### PR TITLE
Align Checkers Battle Royal arena and menu with Chess Battle Royal; ensure board visibility

### DIFF
--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -9,19 +9,27 @@ import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader.js';
 import { EXRLoader } from 'three/examples/jsm/loaders/EXRLoader.js';
 import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.js';
 import { GroundedSkybox } from 'three/examples/jsm/objects/GroundedSkybox.js';
-import { applyRendererSRGB, applySRGBColorSpace } from '../../utils/colorSpace.js';
+import {
+  applyRendererSRGB,
+  applySRGBColorSpace
+} from '../../utils/colorSpace.js';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
-import { getTelegramFirstName, getTelegramPhotoUrl } from '../../utils/telegram.js';
+import {
+  getTelegramFirstName,
+  getTelegramPhotoUrl
+} from '../../utils/telegram.js';
 import { ARENA_CAMERA_DEFAULTS } from '../../utils/arenaCameraConfig.js';
-import { createMurlanStyleTable, applyTableMaterials } from '../../utils/murlanTable.js';
+import {
+  createMurlanStyleTable,
+  applyTableMaterials
+} from '../../utils/murlanTable.js';
 import AvatarTimer from '../../components/AvatarTimer.jsx';
 import BottomLeftIcons from '../../components/BottomLeftIcons.jsx';
 import GiftPopup from '../../components/GiftPopup.jsx';
 import QuickMessagePopup from '../../components/QuickMessagePopup.jsx';
 import {
   CHESS_CHAIR_OPTIONS,
-  CHESS_TABLE_OPTIONS,
-  CHESS_BATTLE_OPTION_LABELS
+  CHESS_TABLE_OPTIONS
 } from '../../config/chessBattleInventoryConfig.js';
 import {
   POOL_ROYALE_DEFAULT_HDRI_ID,
@@ -31,7 +39,10 @@ import { MURLAN_TABLE_FINISHES } from '../../config/murlanTableFinishes.js';
 import { chatBeep } from '../../assets/soundData.js';
 import { getGameVolume } from '../../utils/sound.js';
 import { giftSounds } from '../../utils/giftSounds.js';
-import { chessBattleAccountId, getChessBattleInventory } from '../../utils/chessBattleInventory.js';
+import {
+  chessBattleAccountId,
+  getChessBattleInventory
+} from '../../utils/chessBattleInventory.js';
 
 const SIZE = 8;
 const MODEL_SCALE = 0.75;
@@ -44,6 +55,7 @@ const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
 const TABLE_HEIGHT = STOOL_HEIGHT + 0.05 * MODEL_SCALE;
 const BOARD_SCALE = 0.0576;
 const BOARD_VISUAL_Y_OFFSET = -0.08;
+const BOARD_TILE_SIZE = ((SIZE * 4.2 + 3 * 2) * BOARD_SCALE) / SIZE;
 const CHAIR_DISTANCE = TABLE_RADIUS + 0.82;
 const SEAT_WIDTH = 0.9 * MODEL_SCALE * STOOL_SCALE;
 const SEAT_DEPTH = 0.95 * MODEL_SCALE * STOOL_SCALE;
@@ -59,8 +71,10 @@ const MIN_HDRI_CAMERA_HEIGHT_M = 0.4;
 const MIN_HDRI_RADIUS = 28;
 const DEFAULT_HDRI_RADIUS_MULTIPLIER = 4;
 const DEFAULT_HDRI_GROUNDED_RESOLUTION = 112;
-const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
-const BASIS_TRANSCODER_PATH = 'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/';
+const DRACO_DECODER_PATH =
+  'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
+const BASIS_TRANSCODER_PATH =
+  'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/';
 
 let sharedKtx2Loader = null;
 let hasDetectedKtx2Support = false;
@@ -76,10 +90,15 @@ const CHAIR_MODEL_URLS = [
   'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/SheenChair/glTF-Binary/SheenChair.glb',
   'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/AntiqueChair/glTF-Binary/AntiqueChair.glb'
 ];
-const TARGET_CHAIR_SIZE = new THREE.Vector3(1.3162499970197679, 1.9173749900311232, 1.7001562547683715);
+const TARGET_CHAIR_SIZE = new THREE.Vector3(
+  1.3162499970197679,
+  1.9173749900311232,
+  1.7001562547683715
+);
 const TARGET_CHAIR_MIN_Y = -0.8570624993294478;
 const TARGET_CHAIR_CENTER_Z = -0.1553906416893005;
-const MOVE_SOUND_URL = 'https://raw.githubusercontent.com/lichess-org/lila/master/public/sound/standard/Move.mp3';
+const MOVE_SOUND_URL =
+  'https://raw.githubusercontent.com/lichess-org/lila/master/public/sound/standard/Move.mp3';
 const CHECKERS_HIGHLIGHT_COLORS = Object.freeze({
   selection: '#ff8e6e',
   move: '#7ef9a1',
@@ -88,8 +107,18 @@ const CHECKERS_HIGHLIGHT_COLORS = Object.freeze({
 
 const CHIP_SETS = [
   { id: 'ruby-cyan', label: 'Ruby/Cyan', light: '#ef4444', dark: '#06b6d4' },
-  { id: 'emerald-violet', label: 'Emerald/Violet', light: '#10b981', dark: '#8b5cf6' },
-  { id: 'amber-slate', label: 'Amber/Slate', light: '#f59e0b', dark: '#334155' },
+  {
+    id: 'emerald-violet',
+    label: 'Emerald/Violet',
+    light: '#10b981',
+    dark: '#8b5cf6'
+  },
+  {
+    id: 'amber-slate',
+    label: 'Amber/Slate',
+    light: '#f59e0b',
+    dark: '#334155'
+  },
   { id: 'rose-ice', label: 'Rose/Ice', light: '#fb7185', dark: '#67e8f9' }
 ];
 
@@ -100,22 +129,38 @@ const FALLBACK_SEAT_POSITIONS = [
 
 const createInitial = () => {
   const board = Array.from({ length: SIZE }, () => Array(SIZE).fill(null));
-  for (let r = 0; r < 3; r += 1) for (let c = 0; c < SIZE; c += 1) if ((r + c) % 2 === 1) board[r][c] = { side: 'dark', king: false };
-  for (let r = 5; r < SIZE; r += 1) for (let c = 0; c < SIZE; c += 1) if ((r + c) % 2 === 1) board[r][c] = { side: 'light', king: false };
+  for (let r = 0; r < 3; r += 1)
+    for (let c = 0; c < SIZE; c += 1)
+      if ((r + c) % 2 === 1) board[r][c] = { side: 'dark', king: false };
+  for (let r = 5; r < SIZE; r += 1)
+    for (let c = 0; c < SIZE; c += 1)
+      if ((r + c) % 2 === 1) board[r][c] = { side: 'light', king: false };
   return board;
 };
 
 const inBounds = (r, c) => r >= 0 && r < SIZE && c >= 0 && c < SIZE;
-const copyBoard = (board) => board.map((row) => row.map((cell) => (cell ? { ...cell } : null)));
+const copyBoard = (board) =>
+  board.map((row) => row.map((cell) => (cell ? { ...cell } : null)));
 
 const getMoves = (board, r, c) => {
   const piece = board[r][c];
   if (!piece) return [];
   const dirs = piece.king
-    ? [[1, 1], [1, -1], [-1, 1], [-1, -1]]
+    ? [
+        [1, 1],
+        [1, -1],
+        [-1, 1],
+        [-1, -1]
+      ]
     : piece.side === 'light'
-      ? [[-1, 1], [-1, -1]]
-      : [[1, 1], [1, -1]];
+      ? [
+          [-1, 1],
+          [-1, -1]
+        ]
+      : [
+          [1, 1],
+          [1, -1]
+        ];
   const captures = [];
   const normals = [];
   dirs.forEach(([dr, dc]) => {
@@ -126,7 +171,8 @@ const getMoves = (board, r, c) => {
     else if (board[nr][nc].side !== piece.side) {
       const jr = nr + dr;
       const jc = nc + dc;
-      if (inBounds(jr, jc) && !board[jr][jc]) captures.push({ r: jr, c: jc, capture: [nr, nc] });
+      if (inBounds(jr, jc) && !board[jr][jc])
+        captures.push({ r: jr, c: jc, capture: [nr, nc] });
     }
   });
   return captures.length ? captures : normals;
@@ -176,7 +222,11 @@ function createConfiguredGLTFLoader(renderer = null) {
 function fitChairModelToFootprint(model) {
   const box = new THREE.Box3().setFromObject(model);
   const size = box.getSize(new THREE.Vector3());
-  const targetMax = Math.max(TARGET_CHAIR_SIZE.x, TARGET_CHAIR_SIZE.y, TARGET_CHAIR_SIZE.z);
+  const targetMax = Math.max(
+    TARGET_CHAIR_SIZE.x,
+    TARGET_CHAIR_SIZE.y,
+    TARGET_CHAIR_SIZE.z
+  );
   const currentMax = Math.max(size.x, size.y, size.z);
   if (currentMax > 0) {
     model.scale.multiplyScalar(targetMax / currentMax);
@@ -225,14 +275,36 @@ async function buildChessMappedChairTemplate() {
 }
 
 function createProceduralChairFallback(chairColor, legColor) {
-  const seatMaterial = new THREE.MeshStandardMaterial({ color: chairColor, roughness: 0.42, metalness: 0.18 });
-  const legMaterial = new THREE.MeshStandardMaterial({ color: legColor, roughness: 0.55, metalness: 0.38 });
+  const seatMaterial = new THREE.MeshStandardMaterial({
+    color: chairColor,
+    roughness: 0.42,
+    metalness: 0.18
+  });
+  const legMaterial = new THREE.MeshStandardMaterial({
+    color: legColor,
+    roughness: 0.55,
+    metalness: 0.38
+  });
   const chair = new THREE.Group();
-  const seatMesh = new THREE.Mesh(new THREE.BoxGeometry(SEAT_WIDTH, SEAT_THICKNESS_SCALED, SEAT_DEPTH), seatMaterial);
+  const seatMesh = new THREE.Mesh(
+    new THREE.BoxGeometry(SEAT_WIDTH, SEAT_THICKNESS_SCALED, SEAT_DEPTH),
+    seatMaterial
+  );
   seatMesh.position.y = SEAT_THICKNESS_SCALED / 2;
-  const backMesh = new THREE.Mesh(new THREE.BoxGeometry(SEAT_WIDTH * 0.96, BACK_HEIGHT, BACK_THICKNESS), seatMaterial);
-  backMesh.position.set(0, SEAT_THICKNESS_SCALED / 2 + BACK_HEIGHT / 2, -SEAT_DEPTH / 2 + BACK_THICKNESS / 2);
-  const armGeometry = new THREE.BoxGeometry(ARM_THICKNESS, ARM_HEIGHT, ARM_DEPTH);
+  const backMesh = new THREE.Mesh(
+    new THREE.BoxGeometry(SEAT_WIDTH * 0.96, BACK_HEIGHT, BACK_THICKNESS),
+    seatMaterial
+  );
+  backMesh.position.set(
+    0,
+    SEAT_THICKNESS_SCALED / 2 + BACK_HEIGHT / 2,
+    -SEAT_DEPTH / 2 + BACK_THICKNESS / 2
+  );
+  const armGeometry = new THREE.BoxGeometry(
+    ARM_THICKNESS,
+    ARM_HEIGHT,
+    ARM_DEPTH
+  );
   const armOffsetX = SEAT_WIDTH / 2 - ARM_THICKNESS / 2;
   const armOffsetY = SEAT_THICKNESS_SCALED / 2 + ARM_HEIGHT / 2;
   const armOffsetZ = -ARM_DEPTH / 2 + ARM_THICKNESS * 0.2;
@@ -240,10 +312,27 @@ function createProceduralChairFallback(chairColor, legColor) {
   leftArm.position.set(-armOffsetX, armOffsetY, armOffsetZ);
   const rightArm = new THREE.Mesh(armGeometry, seatMaterial);
   rightArm.position.set(armOffsetX, armOffsetY, armOffsetZ);
-  const legMesh = new THREE.Mesh(new THREE.CylinderGeometry(0.16 * MODEL_SCALE * STOOL_SCALE, 0.2 * MODEL_SCALE * STOOL_SCALE, BASE_COLUMN_HEIGHT, 18), legMaterial);
+  const legMesh = new THREE.Mesh(
+    new THREE.CylinderGeometry(
+      0.16 * MODEL_SCALE * STOOL_SCALE,
+      0.2 * MODEL_SCALE * STOOL_SCALE,
+      BASE_COLUMN_HEIGHT,
+      18
+    ),
+    legMaterial
+  );
   legMesh.position.y = -SEAT_THICKNESS_SCALED / 2 - BASE_COLUMN_HEIGHT / 2;
-  const foot = new THREE.Mesh(new THREE.CylinderGeometry(0.32 * MODEL_SCALE * STOOL_SCALE, 0.32 * MODEL_SCALE * STOOL_SCALE, 0.08 * MODEL_SCALE, 24), legMaterial);
-  foot.position.y = legMesh.position.y - BASE_COLUMN_HEIGHT / 2 - 0.04 * MODEL_SCALE;
+  const foot = new THREE.Mesh(
+    new THREE.CylinderGeometry(
+      0.32 * MODEL_SCALE * STOOL_SCALE,
+      0.32 * MODEL_SCALE * STOOL_SCALE,
+      0.08 * MODEL_SCALE,
+      24
+    ),
+    legMaterial
+  );
+  foot.position.y =
+    legMesh.position.y - BASE_COLUMN_HEIGHT / 2 - 0.04 * MODEL_SCALE;
   [seatMesh, backMesh, leftArm, rightArm, legMesh, foot].forEach((mesh) => {
     mesh.castShadow = true;
     mesh.receiveShadow = true;
@@ -257,7 +346,9 @@ async function resolveHdriUrl(variant) {
   const fallback = `https://dl.polyhaven.org/file/ph-assets/HDRIs/hdr/${fallbackRes}/${variant?.assetId || 'colorful_studio'}_${fallbackRes}.hdr`;
   if (!variant?.assetId) return fallback;
   try {
-    const res = await fetch(`https://api.polyhaven.com/files/${encodeURIComponent(variant.assetId)}`);
+    const res = await fetch(
+      `https://api.polyhaven.com/files/${encodeURIComponent(variant.assetId)}`
+    );
     if (!res.ok) return fallback;
     const data = await res.json();
     const urls = [];
@@ -265,12 +356,18 @@ async function resolveHdriUrl(variant) {
       if (!value) return;
       if (typeof value === 'string') {
         const low = value.toLowerCase();
-        if (value.startsWith('http') && (low.endsWith('.hdr') || low.endsWith('.exr'))) urls.push(value);
+        if (
+          value.startsWith('http') &&
+          (low.endsWith('.hdr') || low.endsWith('.exr'))
+        )
+          urls.push(value);
       } else if (Array.isArray(value)) value.forEach(walk);
       else if (typeof value === 'object') Object.values(value).forEach(walk);
     };
     walk(data);
-    return urls.find((u) => u.includes(`/${fallbackRes}/`)) || urls[0] || fallback;
+    return (
+      urls.find((u) => u.includes(`/${fallbackRes}/`)) || urls[0] || fallback
+    );
   } catch {
     return fallback;
   }
@@ -298,7 +395,6 @@ export default function CheckersBattleRoyal() {
 
   const [turn, setTurn] = useState('light');
   const [status, setStatus] = useState('Loading arena…');
-  const [showAppearance, setShowAppearance] = useState(false);
   const [configOpen, setConfigOpen] = useState(false);
   const [viewMode, setViewMode] = useState('3d');
   const [showGift, setShowGift] = useState(false);
@@ -324,8 +420,20 @@ export default function CheckersBattleRoyal() {
   const playerPhotoUrl = getTelegramPhotoUrl() || '/assets/icons/profile.svg';
 
   const players = [
-    { index: 0, name: 'Rival', photoUrl: '/assets/icons/profile.svg', color: '#f43f5e', isTurn: turn === 'dark' },
-    { index: 1, name: playerName, photoUrl: playerPhotoUrl, color: '#38bdf8', isTurn: turn === 'light' }
+    {
+      index: 0,
+      name: 'Rival',
+      photoUrl: '/assets/icons/profile.svg',
+      color: '#f43f5e',
+      isTurn: turn === 'dark'
+    },
+    {
+      index: 1,
+      name: playerName,
+      photoUrl: playerPhotoUrl,
+      color: '#38bdf8',
+      isTurn: turn === 'light'
+    }
   ];
 
   const renderPieces = useMemo(
@@ -340,7 +448,12 @@ export default function CheckersBattleRoyal() {
           const piece = board[r][c];
           if (!piece) continue;
           const chip = new THREE.Mesh(
-            new THREE.CylinderGeometry(tile * 0.28, tile * 0.28, tile * 0.13, 40),
+            new THREE.CylinderGeometry(
+              tile * 0.28,
+              tile * 0.28,
+              tile * 0.13,
+              40
+            ),
             new THREE.MeshStandardMaterial({
               color: piece.side === 'light' ? chipSet.light : chipSet.dark,
               roughness: 0.25,
@@ -348,12 +461,20 @@ export default function CheckersBattleRoyal() {
             })
           );
           chip.castShadow = true;
-          chip.position.set(x + (c - 3.5) * tile, y + tile * 0.075, z + (r - 3.5) * tile);
+          chip.position.set(
+            x + (c - 3.5) * tile,
+            y + tile * 0.075,
+            z + (r - 3.5) * tile
+          );
           chip.userData = { r, c, side: piece.side };
           if (piece.king) {
             const ring = new THREE.Mesh(
               new THREE.TorusGeometry(tile * 0.17, tile * 0.04, 12, 30),
-              new THREE.MeshStandardMaterial({ color: '#f8fafc', metalness: 0.92, roughness: 0.18 })
+              new THREE.MeshStandardMaterial({
+                color: '#f8fafc',
+                metalness: 0.92,
+                roughness: 0.18
+              })
             );
             ring.rotation.x = Math.PI / 2;
             ring.position.y = tile * 0.09;
@@ -379,19 +500,40 @@ export default function CheckersBattleRoyal() {
       if (!selected) return;
       const board = boardRef.current;
       const { x, y, z, tile } = boardOriginRef.current;
-      const toPosition = (r, c) => new THREE.Vector3(x + (c - 3.5) * tile, y + tile * 0.02, z + (r - 3.5) * tile);
+      const toPosition = (r, c) =>
+        new THREE.Vector3(
+          x + (c - 3.5) * tile,
+          y + tile * 0.02,
+          z + (r - 3.5) * tile
+        );
       const selection = new THREE.Mesh(
-        new THREE.CylinderGeometry(tile * 0.3, tile * 0.3, Math.max(0.07, tile * 0.03), 20),
-        new THREE.MeshBasicMaterial({ color: CHECKERS_HIGHLIGHT_COLORS.selection, transparent: true, opacity: 0.9 })
+        new THREE.CylinderGeometry(
+          tile * 0.3,
+          tile * 0.3,
+          Math.max(0.07, tile * 0.03),
+          20
+        ),
+        new THREE.MeshBasicMaterial({
+          color: CHECKERS_HIGHLIGHT_COLORS.selection,
+          transparent: true,
+          opacity: 0.9
+        })
       );
       selection.position.copy(toPosition(selected.r, selected.c));
       group.add(selection);
       getMoves(board, selected.r, selected.c).forEach((move) => {
         const isCapture = Array.isArray(move.capture);
         const marker = new THREE.Mesh(
-          new THREE.CylinderGeometry(tile * 0.26, tile * 0.26, Math.max(0.06, tile * 0.03), 20),
+          new THREE.CylinderGeometry(
+            tile * 0.26,
+            tile * 0.26,
+            Math.max(0.06, tile * 0.03),
+            20
+          ),
           new THREE.MeshBasicMaterial({
-            color: isCapture ? CHECKERS_HIGHLIGHT_COLORS.capture : CHECKERS_HIGHLIGHT_COLORS.move,
+            color: isCapture
+              ? CHECKERS_HIGHLIGHT_COLORS.capture
+              : CHECKERS_HIGHLIGHT_COLORS.move,
             transparent: true,
             opacity: 0.9
           })
@@ -411,7 +553,10 @@ export default function CheckersBattleRoyal() {
     scene.background = new THREE.Color('#0b1220');
     sceneRef.current = scene;
 
-    const renderer = new THREE.WebGLRenderer({ antialias: true, powerPreference: 'high-performance' });
+    const renderer = new THREE.WebGLRenderer({
+      antialias: true,
+      powerPreference: 'high-performance'
+    });
     renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
     renderer.setSize(mount.clientWidth, mount.clientHeight);
     renderer.toneMapping = THREE.ACESFilmicToneMapping;
@@ -432,7 +577,8 @@ export default function CheckersBattleRoyal() {
     const cameraBackOffset = (isPortrait ? 2.55 : 1.78) + 0.35;
     const cameraForwardOffset = isPortrait ? 0.08 : 0.2;
     const cameraHeightOffset = isPortrait ? 1.72 : 1.34;
-    const cameraRadius = CHAIR_DISTANCE + cameraBackOffset - cameraForwardOffset;
+    const cameraRadius =
+      CHAIR_DISTANCE + cameraBackOffset - cameraForwardOffset;
     camera.position.set(
       Math.cos(cameraSeatAngle) * cameraRadius,
       TABLE_HEIGHT + cameraHeightOffset,
@@ -496,7 +642,12 @@ export default function CheckersBattleRoyal() {
       selectedRef.current = null;
       moveSoundRef.current?.play().catch(() => {});
       const nextTurn = turn === 'light' ? 'dark' : 'light';
-      replayStateRef.current = { beforeBoard, afterBoard: copyBoard(next), beforeTurn: turn, afterTurn: nextTurn };
+      replayStateRef.current = {
+        beforeBoard,
+        afterBoard: copyBoard(next),
+        beforeTurn: turn,
+        afterTurn: nextTurn
+      };
       setCanReplay(true);
       setTurn(nextTurn);
       renderHighlights();
@@ -508,7 +659,8 @@ export default function CheckersBattleRoyal() {
       pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
       raycaster.setFromCamera(pointer, camera);
       const hit = raycaster.intersectObjects(pickTiles, false)[0];
-      if (hit?.object?.userData) applyMove(hit.object.userData.r, hit.object.userData.c);
+      if (hit?.object?.userData)
+        applyMove(hit.object.userData.r, hit.object.userData.c);
     };
 
     const buildSceneAssets = async () => {
@@ -518,8 +670,15 @@ export default function CheckersBattleRoyal() {
         if (pickTiles.length) return;
         for (let r = 0; r < SIZE; r += 1) {
           for (let c = 0; c < SIZE; c += 1) {
-            const pick = new THREE.Mesh(new THREE.BoxGeometry(tile * 0.94, 0.25, tile * 0.94), pickMaterial);
-            pick.position.set(x + (c - 3.5) * tile, y + 0.16, z + (r - 3.5) * tile);
+            const pick = new THREE.Mesh(
+              new THREE.BoxGeometry(tile * 0.94, 0.25, tile * 0.94),
+              pickMaterial
+            );
+            pick.position.set(
+              x + (c - 3.5) * tile,
+              y + 0.16,
+              z + (r - 3.5) * tile
+            );
             pick.userData = { r, c };
             pickTiles.push(pick);
             scene.add(pick);
@@ -528,8 +687,15 @@ export default function CheckersBattleRoyal() {
       };
 
       try {
-        const table = createMurlanStyleTable({ arena: scene, renderer, tableRadius: TABLE_RADIUS, tableHeight: TABLE_HEIGHT });
-        const finish = MURLAN_TABLE_FINISHES.find((f) => f.id === appearance.tableFinish) || MURLAN_TABLE_FINISHES[0];
+        const table = createMurlanStyleTable({
+          arena: scene,
+          renderer,
+          tableRadius: TABLE_RADIUS,
+          tableHeight: TABLE_HEIGHT
+        });
+        const finish =
+          MURLAN_TABLE_FINISHES.find((f) => f.id === appearance.tableFinish) ||
+          MURLAN_TABLE_FINISHES[0];
         applyTableMaterials(table.parts, finish);
         tableRef.current = table;
       } catch (error) {
@@ -537,14 +703,19 @@ export default function CheckersBattleRoyal() {
       }
 
       try {
-        const chairOption = CHESS_CHAIR_OPTIONS.find((c) => c.id === appearance.chairId) || CHESS_CHAIR_OPTIONS[0];
-        const chairColor = chairOption?.primary || chairOption?.seatColor || '#8b0000';
+        const chairOption =
+          CHESS_CHAIR_OPTIONS.find((c) => c.id === appearance.chairId) ||
+          CHESS_CHAIR_OPTIONS[0];
+        const chairColor =
+          chairOption?.primary || chairOption?.seatColor || '#8b0000';
         const chairTemplate = await buildChessMappedChairTemplate();
         const makeChair = (z, ry) => {
           const g = chairTemplate.clone(true);
           g.traverse((obj) => {
             if (!obj.isMesh) return;
-            const mats = Array.isArray(obj.material) ? obj.material : [obj.material];
+            const mats = Array.isArray(obj.material)
+              ? obj.material
+              : [obj.material];
             mats.forEach((mat) => {
               if (mat?.color) mat.color.set(chairColor);
               mat.needsUpdate = true;
@@ -555,11 +726,17 @@ export default function CheckersBattleRoyal() {
           scene.add(g);
           return g;
         };
-        chairsRef.current = [makeChair(CHAIR_DISTANCE, Math.PI), makeChair(-CHAIR_DISTANCE, 0)];
+        chairsRef.current = [
+          makeChair(CHAIR_DISTANCE, Math.PI),
+          makeChair(-CHAIR_DISTANCE, 0)
+        ];
       } catch (error) {
         console.error('Checkers chairs load failed, using fallback:', error);
-        const chairOption = CHESS_CHAIR_OPTIONS.find((c) => c.id === appearance.chairId) || CHESS_CHAIR_OPTIONS[0];
-        const chairColor = chairOption?.primary || chairOption?.seatColor || '#8b0000';
+        const chairOption =
+          CHESS_CHAIR_OPTIONS.find((c) => c.id === appearance.chairId) ||
+          CHESS_CHAIR_OPTIONS[0];
+        const chairColor =
+          chairOption?.primary || chairOption?.seatColor || '#8b0000';
         const legColor = chairOption?.legColor || '#111827';
         const makeFallback = (z, ry) => {
           const g = createProceduralChairFallback(chairColor, legColor);
@@ -568,36 +745,62 @@ export default function CheckersBattleRoyal() {
           scene.add(g);
           return g;
         };
-        chairsRef.current = [makeFallback(CHAIR_DISTANCE, Math.PI), makeFallback(-CHAIR_DISTANCE, 0)];
+        chairsRef.current = [
+          makeFallback(CHAIR_DISTANCE, Math.PI),
+          makeFallback(-CHAIR_DISTANCE, 0)
+        ];
       }
 
+      const addVisibleBoardBase = () => {
+        const boardBase = new THREE.Group();
+        const lightMat = new THREE.MeshStandardMaterial({
+          color: '#d1d5db',
+          roughness: 0.34,
+          metalness: 0.22
+        });
+        const darkMat = new THREE.MeshStandardMaterial({
+          color: '#1f2937',
+          roughness: 0.4,
+          metalness: 0.28
+        });
+        for (let r = 0; r < SIZE; r += 1) {
+          for (let c = 0; c < SIZE; c += 1) {
+            const sq = new THREE.Mesh(
+              new THREE.BoxGeometry(BOARD_TILE_SIZE, 0.06, BOARD_TILE_SIZE),
+              (r + c) % 2 ? darkMat : lightMat
+            );
+            sq.position.set(
+              (c - 3.5) * BOARD_TILE_SIZE,
+              TABLE_HEIGHT + 0.02,
+              (r - 3.5) * BOARD_TILE_SIZE
+            );
+            sq.receiveShadow = true;
+            boardBase.add(sq);
+          }
+        }
+        scene.add(boardBase);
+      };
+
+      addVisibleBoardBase();
+
       try {
-        const boardRoot = await loadBeautifulBoard(createConfiguredGLTFLoader(renderer));
+        const boardRoot = await loadBeautifulBoard(
+          createConfiguredGLTFLoader(renderer)
+        );
         const boardVisualGroup = new THREE.Group();
         boardVisualGroup.position.y = BOARD_VISUAL_Y_OFFSET;
         boardVisualGroup.add(boardRoot);
         scene.add(boardVisualGroup);
         boardRoot.scale.setScalar(BOARD_SCALE);
         boardRoot.position.set(0, TABLE_HEIGHT, 0);
+      } catch {}
 
-        const bbox = new THREE.Box3().setFromObject(boardRoot);
-        const center = bbox.getCenter(new THREE.Vector3());
-        const span = Math.max(bbox.max.x - bbox.min.x, bbox.max.z - bbox.min.z);
-        const tile = Number.isFinite(span) && span > 0 ? span / SIZE : 2.65;
-        boardOriginRef.current = { x: center.x, y: bbox.max.y + tile * 0.05, z: center.z, tile };
-      } catch {
-        const tile = 2.65;
-        const lightMat = new THREE.MeshStandardMaterial({ color: '#d1d5db', roughness: 0.4, metalness: 0.2 });
-        const darkMat = new THREE.MeshStandardMaterial({ color: '#1f2937', roughness: 0.45, metalness: 0.35 });
-        for (let r = 0; r < SIZE; r += 1) {
-          for (let c = 0; c < SIZE; c += 1) {
-            const sq = new THREE.Mesh(new THREE.BoxGeometry(tile, 0.24, tile), (r + c) % 2 ? darkMat : lightMat);
-            sq.position.set((c - 3.5) * tile, TABLE_HEIGHT, (r - 3.5) * tile);
-            scene.add(sq);
-          }
-        }
-        boardOriginRef.current = { x: 0, y: TABLE_HEIGHT + tile * 0.08, z: 0, tile };
-      }
+      boardOriginRef.current = {
+        x: 0,
+        y: TABLE_HEIGHT + 0.08,
+        z: 0,
+        tile: BOARD_TILE_SIZE
+      };
 
       setupPickTiles();
       renderPieces();
@@ -632,7 +835,8 @@ export default function CheckersBattleRoyal() {
       renderer.dispose();
       moveSoundRef.current?.pause();
       moveSoundRef.current = null;
-      if (mount.contains(renderer.domElement)) mount.removeChild(renderer.domElement);
+      if (mount.contains(renderer.domElement))
+        mount.removeChild(renderer.domElement);
       cameraRef.current = null;
       controlsRef.current = null;
     };
@@ -642,11 +846,18 @@ export default function CheckersBattleRoyal() {
     const scene = sceneRef.current;
     if (!scene) return;
 
-    const finish = MURLAN_TABLE_FINISHES.find((f) => f.id === appearance.tableFinish) || MURLAN_TABLE_FINISHES[0];
-    if (tableRef.current?.parts) applyTableMaterials(tableRef.current.parts, finish);
+    const finish =
+      MURLAN_TABLE_FINISHES.find((f) => f.id === appearance.tableFinish) ||
+      MURLAN_TABLE_FINISHES[0];
+    if (tableRef.current?.parts)
+      applyTableMaterials(tableRef.current.parts, finish);
 
-    const chairOption = CHESS_CHAIR_OPTIONS.find((c) => c.id === appearance.chairId) || CHESS_CHAIR_OPTIONS[0];
-    const nextChairColor = new THREE.Color(chairOption?.primary || chairOption?.seatColor || '#8b0000');
+    const chairOption =
+      CHESS_CHAIR_OPTIONS.find((c) => c.id === appearance.chairId) ||
+      CHESS_CHAIR_OPTIONS[0];
+    const nextChairColor = new THREE.Color(
+      chairOption?.primary || chairOption?.seatColor || '#8b0000'
+    );
     chairsRef.current.forEach((chairGroup) => {
       chairGroup?.traverse?.((child) => {
         if (child?.isMesh && child.material?.color) {
@@ -660,21 +871,44 @@ export default function CheckersBattleRoyal() {
 
     const applyHdri = async () => {
       try {
-        const variant = POOL_ROYALE_HDRI_VARIANTS.find((h) => h.id === appearance.hdriId) || POOL_ROYALE_HDRI_VARIANTS[0];
+        const variant =
+          POOL_ROYALE_HDRI_VARIANTS.find((h) => h.id === appearance.hdriId) ||
+          POOL_ROYALE_HDRI_VARIANTS[0];
         const url = await resolveHdriUrl(variant);
-        const loaderEnv = url.toLowerCase().endsWith('.exr') ? new EXRLoader() : new RGBELoader();
+        const loaderEnv = url.toLowerCase().endsWith('.exr')
+          ? new EXRLoader()
+          : new RGBELoader();
         const envMap = await loaderEnv.loadAsync(url);
         envMap.mapping = THREE.EquirectangularReflectionMapping;
         scene.environment = envMap;
         scene.background = envMap;
         if (envRef.current?.skybox) scene.remove(envRef.current.skybox);
-        const cameraHeight = Math.max(variant?.cameraHeightM ?? 1.5, MIN_HDRI_CAMERA_HEIGHT_M) * HDRI_UNITS_PER_METER;
-        const radiusMultiplier = typeof variant?.groundRadiusMultiplier === 'number' ? variant.groundRadiusMultiplier : DEFAULT_HDRI_RADIUS_MULTIPLIER;
-        const groundRadius = Math.max(TABLE_RADIUS * HDRI_UNITS_PER_METER * radiusMultiplier, MIN_HDRI_RADIUS);
-        const skyboxResolution = Math.max(16, Math.floor(variant?.groundResolution ?? DEFAULT_HDRI_GROUNDED_RESOLUTION));
-        const skybox = new GroundedSkybox(envMap, cameraHeight, groundRadius, skyboxResolution);
+        const cameraHeight =
+          Math.max(variant?.cameraHeightM ?? 1.5, MIN_HDRI_CAMERA_HEIGHT_M) *
+          HDRI_UNITS_PER_METER;
+        const radiusMultiplier =
+          typeof variant?.groundRadiusMultiplier === 'number'
+            ? variant.groundRadiusMultiplier
+            : DEFAULT_HDRI_RADIUS_MULTIPLIER;
+        const groundRadius = Math.max(
+          TABLE_RADIUS * HDRI_UNITS_PER_METER * radiusMultiplier,
+          MIN_HDRI_RADIUS
+        );
+        const skyboxResolution = Math.max(
+          16,
+          Math.floor(
+            variant?.groundResolution ?? DEFAULT_HDRI_GROUNDED_RESOLUTION
+          )
+        );
+        const skybox = new GroundedSkybox(
+          envMap,
+          cameraHeight,
+          groundRadius,
+          skyboxResolution
+        );
         skybox.position.y = cameraHeight;
-        if (typeof variant?.rotationY === 'number') skybox.rotation.y = variant.rotationY;
+        if (typeof variant?.rotationY === 'number')
+          skybox.rotation.y = variant.rotationY;
         scene.add(skybox);
         envRef.current = { map: envMap, skybox, hdriId: appearance.hdriId };
       } catch (error) {
@@ -699,7 +933,11 @@ export default function CheckersBattleRoyal() {
     } else {
       const cameraSeatAngle = Math.PI / 2;
       const cameraRadius = CHAIR_DISTANCE + 2.7;
-      camera.position.set(Math.cos(cameraSeatAngle) * cameraRadius, TABLE_HEIGHT + 1.72, Math.sin(cameraSeatAngle) * cameraRadius);
+      camera.position.set(
+        Math.cos(cameraSeatAngle) * cameraRadius,
+        TABLE_HEIGHT + 1.72,
+        Math.sin(cameraSeatAngle) * cameraRadius
+      );
       controls.enableRotate = true;
       controls.minPolarAngle = THREE.MathUtils.degToRad(28);
       controls.maxPolarAngle = ARENA_CAMERA_DEFAULTS.phiMax;
@@ -721,7 +959,8 @@ export default function CheckersBattleRoyal() {
     }, 700);
   };
 
-  const optionButton = (active) => `rounded-lg border px-2 py-1 text-[11px] ${active ? 'border-cyan-300 bg-cyan-500/20 text-cyan-100' : 'border-white/15 bg-white/5 text-white/70'}`;
+  const optionButton = (active) =>
+    `rounded-lg border px-2 py-1 text-[11px] ${active ? 'border-cyan-300 bg-cyan-500/20 text-cyan-100' : 'border-white/15 bg-white/5 text-white/70'}`;
 
   return (
     <div className="fixed inset-0 bg-[#050814] text-white">
@@ -740,14 +979,142 @@ export default function CheckersBattleRoyal() {
 
         <div className="absolute top-20 right-4 z-20 flex flex-col items-end gap-3 pointer-events-none">
           <div className="pointer-events-auto flex flex-col items-end gap-3">
-            <button type="button" onClick={replayLastMove} disabled={!canReplay} className={`icon-only-button flex h-10 w-10 items-center justify-center text-[1.4rem] ${canReplay ? 'text-white/90' : 'text-white/40'}`}>↺</button>
-            <button type="button" onClick={() => setViewMode((mode) => (mode === '3d' ? '2d' : '3d'))} className="icon-only-button flex h-10 w-10 items-center justify-center text-[0.75rem] font-semibold uppercase tracking-[0.08em] text-white/90">{viewMode === '3d' ? '2D' : '3D'}</button>
+            <button
+              type="button"
+              onClick={replayLastMove}
+              disabled={!canReplay}
+              className={`icon-only-button flex h-10 w-10 items-center justify-center text-[1.4rem] ${canReplay ? 'text-white/90' : 'text-white/40'}`}
+            >
+              ↺
+            </button>
+            <button
+              type="button"
+              onClick={() =>
+                setViewMode((mode) => (mode === '3d' ? '2d' : '3d'))
+              }
+              className="icon-only-button flex h-10 w-10 items-center justify-center text-[0.75rem] font-semibold uppercase tracking-[0.08em] text-white/90"
+            >
+              {viewMode === '3d' ? '2D' : '3D'}
+            </button>
           </div>
           {configOpen && (
-            <div className="pointer-events-auto mt-2 w-72 max-w-[80vw] rounded-2xl border border-white/15 bg-black/80 p-4 text-xs text-white shadow-2xl">
-              <div className="mb-2 text-xs font-semibold uppercase tracking-[0.22em] text-white/80">Checkers Battle Royal</div>
-              <button type="button" onClick={() => setShowAppearance((v) => !v)} className="mb-2 w-full rounded-2xl border border-white/15 bg-white/10 px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.2em] text-white/90">Appearance</button>
-              <button type="button" onClick={() => setViewMode((mode) => (mode === '3d' ? '2d' : '3d'))} className="w-full rounded-2xl border border-white/15 bg-white/10 px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.2em] text-white/90">{viewMode === '3d' ? '2D View' : '3D View'}</button>
+            <div className="pointer-events-auto mt-2 w-72 max-w-[80vw] rounded-2xl border border-white/15 bg-black/80 p-4 text-xs text-white shadow-2xl backdrop-blur max-h-[80vh] overflow-y-auto pr-1">
+              <div className="mb-2 text-xs font-semibold uppercase tracking-[0.22em] text-white/80">
+                Checkers Battle Royal
+              </div>
+              <button
+                type="button"
+                onClick={() =>
+                  setViewMode((mode) => (mode === '3d' ? '2d' : '3d'))
+                }
+                className="w-full rounded-2xl border border-white/15 bg-white/10 px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.2em] text-white/90"
+              >
+                {viewMode === '3d' ? '2D View' : '3D View'}
+              </button>
+              <div className="mt-3 rounded-xl border border-white/10 bg-white/5 p-3">
+                <div className="mb-2 text-[11px] uppercase tracking-[0.2em] text-white/70">
+                  Table Finish
+                </div>
+                <div className="mb-3 grid max-h-40 grid-cols-2 gap-2 overflow-auto">
+                  {MURLAN_TABLE_FINISHES.map((opt) => (
+                    <button
+                      key={opt.id}
+                      onClick={() =>
+                        setAppearance((prev) => ({
+                          ...prev,
+                          tableFinish: opt.id
+                        }))
+                      }
+                      className={`rounded-xl border px-2 py-2 text-[11px] ${appearance.tableFinish === opt.id ? 'border-cyan-300 bg-cyan-500/20 text-cyan-100' : 'border-white/15 bg-white/5 text-white/70'}`}
+                    >
+                      {opt.thumbnail ? (
+                        <img
+                          src={opt.thumbnail}
+                          alt={`${opt.label} thumbnail`}
+                          className="mb-1 h-10 w-full rounded object-cover"
+                        />
+                      ) : null}
+                      {opt.label}
+                    </button>
+                  ))}
+                </div>
+
+                <div className="mb-2 text-[11px] uppercase tracking-[0.2em] text-white/70">
+                  Tables
+                </div>
+                <div className="mb-3 grid max-h-40 grid-cols-2 gap-2 overflow-auto">
+                  {CHESS_TABLE_OPTIONS.map((opt) => (
+                    <button
+                      key={opt.id}
+                      onClick={() =>
+                        setAppearance((prev) => ({ ...prev, tableId: opt.id }))
+                      }
+                      className={`rounded-xl border px-2 py-2 text-[11px] ${appearance.tableId === opt.id ? 'border-cyan-300 bg-cyan-500/20 text-cyan-100' : 'border-white/15 bg-white/5 text-white/70'}`}
+                    >
+                      {opt.thumbnail ? (
+                        <img
+                          src={opt.thumbnail}
+                          alt={`${opt.label} thumbnail`}
+                          className="mb-1 h-10 w-full rounded object-cover"
+                        />
+                      ) : null}
+                      {opt.label}
+                    </button>
+                  ))}
+                </div>
+
+                <div className="mb-2 text-[11px] uppercase tracking-[0.2em] text-white/70">
+                  Chairs
+                </div>
+                <div className="mb-3 grid max-h-40 grid-cols-2 gap-2 overflow-auto">
+                  {CHESS_CHAIR_OPTIONS.map((opt) => (
+                    <button
+                      key={opt.id}
+                      onClick={() =>
+                        setAppearance((prev) => ({ ...prev, chairId: opt.id }))
+                      }
+                      className={`rounded-xl border px-2 py-2 text-[11px] ${appearance.chairId === opt.id ? 'border-cyan-300 bg-cyan-500/20 text-cyan-100' : 'border-white/15 bg-white/5 text-white/70'}`}
+                    >
+                      {opt.thumbnail ? (
+                        <img
+                          src={opt.thumbnail}
+                          alt={`${opt.label} thumbnail`}
+                          className="mb-1 h-10 w-full rounded object-cover"
+                        />
+                      ) : null}
+                      {opt.label}
+                    </button>
+                  ))}
+                </div>
+
+                <div className="mb-2 text-[11px] text-white/70">HDRI</div>
+                <div className="mb-3 flex max-h-24 flex-wrap gap-2 overflow-auto">
+                  {POOL_ROYALE_HDRI_VARIANTS.map((opt) => (
+                    <button
+                      key={opt.id}
+                      onClick={() =>
+                        setAppearance((prev) => ({ ...prev, hdriId: opt.id }))
+                      }
+                      className={optionButton(appearance.hdriId === opt.id)}
+                    >
+                      {opt.name}
+                    </button>
+                  ))}
+                </div>
+
+                <div className="mb-2 text-[11px] text-white/70">Chips</div>
+                <div className="flex flex-wrap gap-2">
+                  {CHIP_SETS.map((set) => (
+                    <button
+                      key={set.id}
+                      onClick={() => setChipSetId(set.id)}
+                      className={optionButton(chipSetId === set.id)}
+                    >
+                      {set.label}
+                    </button>
+                  ))}
+                </div>
+              </div>
             </div>
           )}
         </div>
@@ -781,7 +1148,16 @@ export default function CheckersBattleRoyal() {
 
         <div className="absolute inset-0 z-10 pointer-events-none">
           {players.map((player) => (
-            <div key={`checkers-seat-${player.index}`} className="absolute pointer-events-auto flex flex-col items-center" data-player-index={player.index} style={{ left: FALLBACK_SEAT_POSITIONS[player.index].left, top: FALLBACK_SEAT_POSITIONS[player.index].top, transform: 'translate(-50%, -50%)' }}>
+            <div
+              key={`checkers-seat-${player.index}`}
+              className="absolute pointer-events-auto flex flex-col items-center"
+              data-player-index={player.index}
+              style={{
+                left: FALLBACK_SEAT_POSITIONS[player.index].left,
+                top: FALLBACK_SEAT_POSITIONS[player.index].top,
+                transform: 'translate(-50%, -50%)'
+              }}
+            >
               <AvatarTimer
                 index={player.index}
                 photoUrl={player.photoUrl}
@@ -792,7 +1168,9 @@ export default function CheckersBattleRoyal() {
                 color={player.color}
                 size={1}
               />
-              <span className="mt-1 text-[0.65rem] font-semibold text-white">{player.name}</span>
+              <span className="mt-1 text-[0.65rem] font-semibold text-white">
+                {player.name}
+              </span>
             </div>
           ))}
         </div>
@@ -807,60 +1185,13 @@ export default function CheckersBattleRoyal() {
       {chatBubbles.map((bubble) => (
         <div key={bubble.id} className="chat-bubble chess-battle-chat-bubble">
           <span>{bubble.text}</span>
-          <img src={bubble.photoUrl} alt="avatar" className="w-5 h-5 rounded-full" />
+          <img
+            src={bubble.photoUrl}
+            alt="avatar"
+            className="w-5 h-5 rounded-full"
+          />
         </div>
       ))}
-
-      {showAppearance && (
-        <div className="absolute left-3 right-3 bottom-20 rounded-2xl border border-white/15 bg-[#0b1324]/95 p-3 max-h-[46vh] overflow-y-auto">
-          <div className="mb-2 text-xs font-semibold">Checkers Arena Setup (Chess Battle Royal style)</div>
-          <div className="mb-2 text-[11px] text-white/60">Board: ABeautifulGame • Table: {appearance.tableId} • Chair: {appearance.chairId} • HDRI: {CHESS_BATTLE_OPTION_LABELS.environmentHdri?.[appearance.hdriId] || appearance.hdriId}</div>
-
-          <div className="mb-2 text-[11px] text-white/70">Chips</div>
-          <div className="mb-3 flex flex-wrap gap-2">
-            {CHIP_SETS.map((set) => (
-              <button key={set.id} onClick={() => setChipSetId(set.id)} className={optionButton(chipSetId === set.id)}>{set.label}</button>
-            ))}
-          </div>
-
-          <div className="mb-2 text-[11px] uppercase tracking-[0.2em] text-white/70">Tables</div>
-          <div className="mb-3 grid max-h-40 grid-cols-2 gap-2 overflow-auto">
-            {CHESS_TABLE_OPTIONS.map((opt) => (
-              <button key={opt.id} onClick={() => setAppearance((prev) => ({ ...prev, tableId: opt.id }))} className={`rounded-xl border px-2 py-2 text-[11px] ${appearance.tableId === opt.id ? 'border-cyan-300 bg-cyan-500/20 text-cyan-100' : 'border-white/15 bg-white/5 text-white/70'}`}>
-                {opt.thumbnail ? <img src={opt.thumbnail} alt={`${opt.label} thumbnail`} className="mb-1 h-10 w-full rounded object-cover" /> : null}
-                {opt.label}
-              </button>
-            ))}
-          </div>
-
-          <div className="mb-2 text-[11px] uppercase tracking-[0.2em] text-white/70">Chairs</div>
-          <div className="mb-3 grid max-h-40 grid-cols-2 gap-2 overflow-auto">
-            {CHESS_CHAIR_OPTIONS.map((opt) => (
-              <button key={opt.id} onClick={() => setAppearance((prev) => ({ ...prev, chairId: opt.id }))} className={`rounded-xl border px-2 py-2 text-[11px] ${appearance.chairId === opt.id ? 'border-cyan-300 bg-cyan-500/20 text-cyan-100' : 'border-white/15 bg-white/5 text-white/70'}`}>
-                {opt.thumbnail ? <img src={opt.thumbnail} alt={`${opt.label} thumbnail`} className="mb-1 h-10 w-full rounded object-cover" /> : null}
-                {opt.label}
-              </button>
-            ))}
-          </div>
-
-          <div className="mb-2 text-[11px] uppercase tracking-[0.2em] text-white/70">Table Finish</div>
-          <div className="mb-3 grid max-h-40 grid-cols-2 gap-2 overflow-auto">
-            {MURLAN_TABLE_FINISHES.map((opt) => (
-              <button key={opt.id} onClick={() => setAppearance((prev) => ({ ...prev, tableFinish: opt.id }))} className={`rounded-xl border px-2 py-2 text-[11px] ${appearance.tableFinish === opt.id ? 'border-cyan-300 bg-cyan-500/20 text-cyan-100' : 'border-white/15 bg-white/5 text-white/70'}`}>
-                {opt.thumbnail ? <img src={opt.thumbnail} alt={`${opt.label} thumbnail`} className="mb-1 h-10 w-full rounded object-cover" /> : null}
-                {opt.label}
-              </button>
-            ))}
-          </div>
-
-          <div className="mb-2 text-[11px] text-white/70">HDRI</div>
-          <div className="flex max-h-24 flex-wrap gap-2 overflow-auto">
-            {POOL_ROYALE_HDRI_VARIANTS.map((opt) => (
-              <button key={opt.id} onClick={() => setAppearance((prev) => ({ ...prev, hdriId: opt.id }))} className={optionButton(appearance.hdriId === opt.id)}>{opt.name}</button>
-            ))}
-          </div>
-        </div>
-      )}
 
       <div className="pointer-events-auto">
         <QuickMessagePopup
@@ -869,11 +1200,20 @@ export default function CheckersBattleRoyal() {
           title="Quick Chat"
           onSend={(text) => {
             const id = Date.now();
-            setChatBubbles((bubbles) => [...bubbles, { id, text, photoUrl: playerPhotoUrl }]);
+            setChatBubbles((bubbles) => [
+              ...bubbles,
+              { id, text, photoUrl: playerPhotoUrl }
+            ]);
             const audio = new Audio(chatBeep);
             audio.volume = getGameVolume();
             audio.play().catch(() => {});
-            setTimeout(() => setChatBubbles((bubbles) => bubbles.filter((bubble) => bubble.id !== id)), 1800);
+            setTimeout(
+              () =>
+                setChatBubbles((bubbles) =>
+                  bubbles.filter((bubble) => bubble.id !== id)
+                ),
+              1800
+            );
           }}
         />
       </div>


### PR DESCRIPTION
### Motivation
- Make the Checkers Battle Royal arena match the Chess Battle Royal visual scale and seat/table layout so pieces, table and chairs appear the same size and positions. 
- Guarantee the board is visible even when the imported GLTF model's bounds are unreliable. 
- Unify the in-game menu appearance and ordering to follow the Chess Battle Royal panel with thumbnail-based customization instead of a separate Appearance popup.

### Description
- Added a `BOARD_TILE_SIZE` constant and locked the board origin to the table center so tile sizing/positions use the same chess-derived scale. 
- Always render a visible checkerboard base on the table (`addVisibleBoardBase`) and then layer the imported board model on top so the board is visible if the GLTF bounding box is unreliable. 
- Integrated the customization groups (Table Finish, Tables, Chairs, HDRI, Chips) directly into the config menu and removed the separate `showAppearance` panel, using thumbnails where available to match Chess Battle Royal layout. 
- Miscellaneous formatting and robustness tweaks in `webapp/src/pages/Games/CheckersBattleRoyal.jsx` (loader/scene setup, safer defaults for board origin and pick tiles). 

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully. 
- Started the dev server and captured a full-page automated screenshot of the loaded Checkers page via Playwright; the final run succeeded and produced the artifact at `artifacts/checkers-battle-royal-loaded.png`. 
- An initial Playwright run timed out in this environment but a follow-up run completed successfully and produced the screenshot artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6b7aa7afc8329815662bea4e486dd)