### PR TITLE
Implement Checkers engine, AI, and GLTF board visuals for Checkers Battle Royal

### DIFF
--- a/test/checkersEngine.test.js
+++ b/test/checkersEngine.test.js
@@ -1,0 +1,40 @@
+import {
+  createInitialBoard,
+  getLegalMoves,
+  applyMove,
+  getBestAIMove,
+  getGameState
+} from '../webapp/src/utils/checkersEngine.js';
+
+describe('checkersEngine', () => {
+  test('initial board has legal moves for both sides', () => {
+    const board = createInitialBoard();
+    expect(getLegalMoves(board, 'light').length).toBeGreaterThan(0);
+    expect(getLegalMoves(board, 'dark').length).toBeGreaterThan(0);
+  });
+
+  test('capture is mandatory when available', () => {
+    const board = Array.from({ length: 8 }, () => Array(8).fill(null));
+    board[4][3] = { side: 'light', king: false };
+    board[3][4] = { side: 'dark', king: false };
+    board[5][0] = { side: 'light', king: false };
+
+    const moves = getLegalMoves(board, 'light');
+    expect(moves).toHaveLength(1);
+    expect(moves[0].capture).toEqual([3, 4]);
+  });
+
+  test('ai prefers capture move', () => {
+    const board = Array.from({ length: 8 }, () => Array(8).fill(null));
+    board[2][1] = { side: 'dark', king: false };
+    board[3][2] = { side: 'light', king: false };
+
+    const move = getBestAIMove(board, 'dark');
+    expect(move.capture).toEqual([3, 2]);
+
+    const applied = applyMove(board, move);
+    const state = getGameState(applied.board, 'light');
+    expect(state.finished).toBe(true);
+    expect(state.winner).toBe('dark');
+  });
+});

--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -43,8 +43,17 @@ import {
   chessBattleAccountId,
   getChessBattleInventory
 } from '../../utils/chessBattleInventory.js';
+import {
+  CHECKERS_SIZE,
+  createInitialBoard,
+  copyBoard,
+  getLegalMoves,
+  applyMove,
+  getGameState,
+  getBestAIMove
+} from '../../utils/checkersEngine.js';
 
-const SIZE = 8;
+const SIZE = CHECKERS_SIZE;
 const MODEL_SCALE = 0.75;
 const STOOL_SCALE = 1.5 * 1.3;
 const TABLE_RADIUS = 3.4 * MODEL_SCALE;
@@ -78,11 +87,11 @@ const BASIS_TRANSCODER_PATH =
 
 let sharedKtx2Loader = null;
 let hasDetectedKtx2Support = false;
-const BEAUTIFUL_GAME_URLS = [
-  'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/ABeautifulGame/glTF/ABeautifulGame.gltf',
-  'https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Models@master/2.0/ABeautifulGame/glTF/ABeautifulGame.gltf',
-  'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/ABeautifulGame/glTF/ABeautifulGame.gltf',
-  'https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Assets@main/Models/ABeautifulGame/glTF/ABeautifulGame.gltf'
+const CHECKERS_BOARD_GLTF_URLS = [
+  'https://raw.githubusercontent.com/cx20/gltf-test/master/sampleModels/Chess/glTF-Binary/Chess.glb',
+  'https://cdn.jsdelivr.net/gh/cx20/gltf-test@master/sampleModels/Chess/glTF-Binary/Chess.glb',
+  'https://raw.githubusercontent.com/quaterniusdev/ChessSet/master/Source/GLTF/ChessSet.glb',
+  'https://cdn.jsdelivr.net/gh/quaterniusdev/ChessSet@master/Source/GLTF/ChessSet.glb'
 ];
 
 const CHAIR_MODEL_URLS = [
@@ -127,60 +136,9 @@ const FALLBACK_SEAT_POSITIONS = [
   { left: '50%', top: '82%' }
 ];
 
-const createInitial = () => {
-  const board = Array.from({ length: SIZE }, () => Array(SIZE).fill(null));
-  for (let r = 0; r < 3; r += 1)
-    for (let c = 0; c < SIZE; c += 1)
-      if ((r + c) % 2 === 1) board[r][c] = { side: 'dark', king: false };
-  for (let r = 5; r < SIZE; r += 1)
-    for (let c = 0; c < SIZE; c += 1)
-      if ((r + c) % 2 === 1) board[r][c] = { side: 'light', king: false };
-  return board;
-};
-
-const inBounds = (r, c) => r >= 0 && r < SIZE && c >= 0 && c < SIZE;
-const copyBoard = (board) =>
-  board.map((row) => row.map((cell) => (cell ? { ...cell } : null)));
-
-const getMoves = (board, r, c) => {
-  const piece = board[r][c];
-  if (!piece) return [];
-  const dirs = piece.king
-    ? [
-        [1, 1],
-        [1, -1],
-        [-1, 1],
-        [-1, -1]
-      ]
-    : piece.side === 'light'
-      ? [
-          [-1, 1],
-          [-1, -1]
-        ]
-      : [
-          [1, 1],
-          [1, -1]
-        ];
-  const captures = [];
-  const normals = [];
-  dirs.forEach(([dr, dc]) => {
-    const nr = r + dr;
-    const nc = c + dc;
-    if (!inBounds(nr, nc)) return;
-    if (!board[nr][nc]) normals.push({ r: nr, c: nc });
-    else if (board[nr][nc].side !== piece.side) {
-      const jr = nr + dr;
-      const jc = nc + dc;
-      if (inBounds(jr, jc) && !board[jr][jc])
-        captures.push({ r: jr, c: jc, capture: [nr, nc] });
-    }
-  });
-  return captures.length ? captures : normals;
-};
-
 async function loadBeautifulBoard(loader) {
   let err = null;
-  for (const url of BEAUTIFUL_GAME_URLS) {
+  for (const url of CHECKERS_BOARD_GLTF_URLS) {
     try {
       const gltf = await loader.loadAsync(url);
       if (gltf?.scene) return gltf.scene;
@@ -188,7 +146,7 @@ async function loadBeautifulBoard(loader) {
       err = e;
     }
   }
-  throw err || new Error('ABeautifulGame failed to load');
+  throw err || new Error('Checkers board GLTF failed to load');
 }
 
 function ensureKtx2SupportDetection(renderer = null) {
@@ -378,7 +336,8 @@ export default function CheckersBattleRoyal() {
   const navigate = useNavigate();
   const mountRef = useRef(null);
 
-  const boardRef = useRef(createInitial());
+  const boardRef = useRef(createInitialBoard());
+  const forcedPieceRef = useRef(null);
   const selectedRef = useRef(null);
   const piecesGroupRef = useRef(null);
   const boardOriginRef = useRef({ x: 0, y: 0.75, z: 0, tile: 2.65 });
@@ -394,6 +353,7 @@ export default function CheckersBattleRoyal() {
   const envRef = useRef({ map: null, skybox: null });
 
   const [turn, setTurn] = useState('light');
+  const [thinking, setThinking] = useState(false);
   const [status, setStatus] = useState('Loading arena…');
   const [configOpen, setConfigOpen] = useState(false);
   const [viewMode, setViewMode] = useState('3d');
@@ -521,7 +481,10 @@ export default function CheckersBattleRoyal() {
       );
       selection.position.copy(toPosition(selected.r, selected.c));
       group.add(selection);
-      getMoves(board, selected.r, selected.c).forEach((move) => {
+      const legalMoves = getLegalMoves(board, turn, forcedPieceRef.current);
+      legalMoves
+        .filter((move) => move.from.r === selected.r && move.from.c === selected.c)
+        .forEach((move) => {
         const isCapture = Array.isArray(move.capture);
         const marker = new THREE.Mesh(
           new THREE.CylinderGeometry(
@@ -538,11 +501,11 @@ export default function CheckersBattleRoyal() {
             opacity: 0.9
           })
         );
-        marker.position.copy(toPosition(move.r, move.c));
+        marker.position.copy(toPosition(move.to.r, move.to.c));
         group.add(marker);
-      });
+        });
     },
-    []
+    [turn]
   );
 
   useEffect(() => {
@@ -617,40 +580,71 @@ export default function CheckersBattleRoyal() {
     const raycaster = new THREE.Raycaster();
     const pointer = new THREE.Vector2();
 
-    const applyMove = (r, c) => {
+    const applyPlayerMove = (r, c) => {
       const board = boardRef.current;
+      if (turn !== 'light') return;
+
+      const game = getGameState(board, turn, forcedPieceRef.current);
+      if (game.finished) {
+        setStatus(game.winner === 'light' ? 'You won! Match finished.' : 'Rival won.');
+        return;
+      }
+
       const selected = selectedRef.current;
       const piece = board[r][c];
       if (piece && piece.side === turn) {
+        if (
+          forcedPieceRef.current &&
+          (forcedPieceRef.current.r !== r || forcedPieceRef.current.c !== c)
+        ) {
+          setStatus('Mandatory capture: continue with same checker.');
+          return;
+        }
         selectedRef.current = { r, c };
         renderHighlights();
         return;
       }
+
       if (!selected) return;
-      const moves = getMoves(board, selected.r, selected.c);
-      const move = moves.find((m) => m.r === r && m.c === c);
+      const legalMoves = getLegalMoves(board, turn, forcedPieceRef.current);
+      const move = legalMoves.find(
+        (entry) =>
+          entry.from.r === selected.r &&
+          entry.from.c === selected.c &&
+          entry.to.r === r &&
+          entry.to.c === c
+      );
       if (!move) return;
+
       const beforeBoard = copyBoard(board);
-      const next = board.map((row) => row.slice());
-      const moving = { ...next[selected.r][selected.c] };
-      next[selected.r][selected.c] = null;
-      if (move.capture) next[move.capture[0]][move.capture[1]] = null;
-      if (moving.side === 'light' && r === 0) moving.king = true;
-      if (moving.side === 'dark' && r === SIZE - 1) moving.king = true;
-      next[r][c] = moving;
-      boardRef.current = next;
-      selectedRef.current = null;
+      const beforeForced = forcedPieceRef.current
+        ? { ...forcedPieceRef.current }
+        : null;
+      const applied = applyMove(board, move);
+
+      boardRef.current = applied.board;
+      forcedPieceRef.current = applied.mustContinue ? applied.forcedPiece : null;
+      selectedRef.current = applied.mustContinue ? applied.forcedPiece : null;
       moveSoundRef.current?.play().catch(() => {});
-      const nextTurn = turn === 'light' ? 'dark' : 'light';
+      renderPieces();
+      renderHighlights();
+
+      const nextTurn = applied.mustContinue ? 'light' : 'dark';
       replayStateRef.current = {
         beforeBoard,
-        afterBoard: copyBoard(next),
+        afterBoard: copyBoard(applied.board),
         beforeTurn: turn,
-        afterTurn: nextTurn
+        afterTurn: nextTurn,
+        beforeForced,
+        afterForced: forcedPieceRef.current ? { ...forcedPieceRef.current } : null
       };
       setCanReplay(true);
       setTurn(nextTurn);
-      renderHighlights();
+      setStatus(
+        applied.mustContinue
+          ? 'Combo capture: move the same checker again.'
+          : 'Rival is thinking…'
+      );
     };
 
     const onPointerUp = (event) => {
@@ -660,7 +654,7 @@ export default function CheckersBattleRoyal() {
       raycaster.setFromCamera(pointer, camera);
       const hit = raycaster.intersectObjects(pickTiles, false)[0];
       if (hit?.object?.userData)
-        applyMove(hit.object.userData.r, hit.object.userData.c);
+        applyPlayerMove(hit.object.userData.r, hit.object.userData.c);
     };
 
     const buildSceneAssets = async () => {
@@ -791,8 +785,20 @@ export default function CheckersBattleRoyal() {
         boardVisualGroup.position.y = BOARD_VISUAL_Y_OFFSET;
         boardVisualGroup.add(boardRoot);
         scene.add(boardVisualGroup);
-        boardRoot.scale.setScalar(BOARD_SCALE);
+        boardRoot.scale.setScalar(BOARD_SCALE * 1.15);
         boardRoot.position.set(0, TABLE_HEIGHT, 0);
+        boardRoot.traverse((node) => {
+          if (!node.isMesh) return;
+          node.castShadow = true;
+          node.receiveShadow = true;
+          const mats = Array.isArray(node.material)
+            ? node.material
+            : [node.material];
+          mats.forEach((mat) => {
+            if (mat?.map) applySRGBColorSpace(mat.map);
+            if (mat?.emissiveMap) applySRGBColorSpace(mat.emissiveMap);
+          });
+        });
       } catch {}
 
       boardOriginRef.current = {
@@ -805,7 +811,7 @@ export default function CheckersBattleRoyal() {
       setupPickTiles();
       renderPieces();
       renderHighlights();
-      setStatus('Tap your piece, then a highlighted square to move.');
+      setStatus('Your turn: select a checker and play a legal move.');
     };
 
     void buildSceneAssets();
@@ -920,6 +926,55 @@ export default function CheckersBattleRoyal() {
   }, [appearance]);
 
   useEffect(() => {
+    if (turn !== 'dark') return;
+    const game = getGameState(boardRef.current, 'dark', forcedPieceRef.current);
+    if (game.finished) {
+      setStatus('You won! Rival has no legal moves.');
+      return;
+    }
+
+    setThinking(true);
+    const timer = window.setTimeout(() => {
+      const move = getBestAIMove(
+        boardRef.current,
+        'dark',
+        forcedPieceRef.current,
+        6
+      );
+      if (!move) {
+        setThinking(false);
+        setStatus('You won! Rival has no legal moves.');
+        return;
+      }
+      const applied = applyMove(boardRef.current, move);
+      boardRef.current = applied.board;
+      forcedPieceRef.current = applied.mustContinue ? applied.forcedPiece : null;
+      selectedRef.current = null;
+      renderPieces();
+      renderHighlights();
+      moveSoundRef.current?.play().catch(() => {});
+
+      if (applied.mustContinue) {
+        setThinking(false);
+        setTurn('dark');
+        setStatus('Rival performs a combo capture…');
+        return;
+      }
+
+      setThinking(false);
+      setTurn('light');
+      const nextState = getGameState(boardRef.current, 'light', null);
+      setStatus(
+        nextState.finished
+          ? 'Rival won. You have no legal moves.'
+          : 'Your turn: select a checker and play a legal move.'
+      );
+    }, 420);
+
+    return () => window.clearTimeout(timer);
+  }, [turn, renderPieces, renderHighlights]);
+
+  useEffect(() => {
     const camera = cameraRef.current;
     const controls = controlsRef.current;
     if (!camera || !controls) return;
@@ -950,12 +1005,16 @@ export default function CheckersBattleRoyal() {
     if (!replayStateRef.current) return;
     const replay = replayStateRef.current;
     boardRef.current = copyBoard(replay.beforeBoard);
+    forcedPieceRef.current = replay.beforeForced || null;
     setTurn(replay.beforeTurn);
     renderPieces();
+    renderHighlights();
     setTimeout(() => {
       boardRef.current = copyBoard(replay.afterBoard);
+      forcedPieceRef.current = replay.afterForced || null;
       setTurn(replay.afterTurn);
       renderPieces();
+      renderHighlights();
     }, 700);
   };
 
@@ -1177,7 +1236,7 @@ export default function CheckersBattleRoyal() {
 
         <div className="absolute bottom-10 left-1/2 -translate-x-1/2 pointer-events-none">
           <div className="px-5 py-2 rounded-full bg-[rgba(7,10,18,0.65)] border border-[rgba(255,215,0,0.25)] text-sm font-semibold backdrop-blur">
-            {status} • Turn: {turn}
+            {status} • Turn: {turn}{thinking ? " • AI…" : ""}
           </div>
         </div>
       </div>

--- a/webapp/src/utils/checkersEngine.js
+++ b/webapp/src/utils/checkersEngine.js
@@ -1,0 +1,223 @@
+export const CHECKERS_SIZE = 8;
+
+export function createInitialBoard() {
+  const board = Array.from({ length: CHECKERS_SIZE }, () =>
+    Array(CHECKERS_SIZE).fill(null)
+  );
+  for (let r = 0; r < 3; r += 1) {
+    for (let c = 0; c < CHECKERS_SIZE; c += 1) {
+      if ((r + c) % 2 === 1) board[r][c] = { side: 'dark', king: false };
+    }
+  }
+  for (let r = 5; r < CHECKERS_SIZE; r += 1) {
+    for (let c = 0; c < CHECKERS_SIZE; c += 1) {
+      if ((r + c) % 2 === 1) board[r][c] = { side: 'light', king: false };
+    }
+  }
+  return board;
+}
+
+export function copyBoard(board) {
+  return board.map((row) => row.map((cell) => (cell ? { ...cell } : null)));
+}
+
+export function inBounds(r, c) {
+  return r >= 0 && r < CHECKERS_SIZE && c >= 0 && c < CHECKERS_SIZE;
+}
+
+function moveDirsForPiece(piece) {
+  if (piece.king) {
+    return [
+      [1, 1],
+      [1, -1],
+      [-1, 1],
+      [-1, -1]
+    ];
+  }
+  return piece.side === 'light'
+    ? [
+        [-1, 1],
+        [-1, -1]
+      ]
+    : [
+        [1, 1],
+        [1, -1]
+      ];
+}
+
+export function getPieceMoves(board, r, c, opts = {}) {
+  const piece = board[r]?.[c];
+  if (!piece) return [];
+  const captures = [];
+  const normals = [];
+  moveDirsForPiece(piece).forEach(([dr, dc]) => {
+    const nr = r + dr;
+    const nc = c + dc;
+    if (!inBounds(nr, nc)) return;
+    if (!board[nr][nc] && !opts.captureOnly) {
+      normals.push({ r: nr, c: nc, capture: null });
+      return;
+    }
+    if (board[nr][nc] && board[nr][nc].side !== piece.side) {
+      const jr = nr + dr;
+      const jc = nc + dc;
+      if (inBounds(jr, jc) && !board[jr][jc]) {
+        captures.push({ r: jr, c: jc, capture: [nr, nc] });
+      }
+    }
+  });
+  return captures.length ? captures : normals;
+}
+
+export function getLegalMoves(board, side, forcedPiece = null) {
+  const captures = [];
+  const normals = [];
+  const pieces = [];
+  if (forcedPiece) {
+    pieces.push(forcedPiece);
+  } else {
+    for (let r = 0; r < CHECKERS_SIZE; r += 1) {
+      for (let c = 0; c < CHECKERS_SIZE; c += 1) {
+        if (board[r][c]?.side === side) pieces.push({ r, c });
+      }
+    }
+  }
+
+  pieces.forEach(({ r, c }) => {
+    const pieceMoves = getPieceMoves(board, r, c, {
+      captureOnly: Boolean(forcedPiece)
+    });
+    pieceMoves.forEach((move) => {
+      const decorated = { from: { r, c }, to: { r: move.r, c: move.c }, capture: move.capture };
+      if (move.capture) captures.push(decorated);
+      else normals.push(decorated);
+    });
+  });
+
+  if (captures.length) return captures;
+  if (forcedPiece) return [];
+  return normals;
+}
+
+function crownPiece(piece, row) {
+  if (piece.side === 'light' && row === 0) piece.king = true;
+  if (piece.side === 'dark' && row === CHECKERS_SIZE - 1) piece.king = true;
+}
+
+export function applyMove(board, move) {
+  const next = copyBoard(board);
+  const moving = next[move.from.r][move.from.c];
+  next[move.from.r][move.from.c] = null;
+  if (move.capture) next[move.capture[0]][move.capture[1]] = null;
+  crownPiece(moving, move.to.r);
+  next[move.to.r][move.to.c] = moving;
+
+  const followUps = move.capture
+    ? getPieceMoves(next, move.to.r, move.to.c, { captureOnly: true }).filter(
+        (entry) => entry.capture
+      )
+    : [];
+
+  return {
+    board: next,
+    mustContinue: followUps.length > 0,
+    forcedPiece: followUps.length ? { r: move.to.r, c: move.to.c } : null,
+    wasCapture: Boolean(move.capture)
+  };
+}
+
+function countPieces(board, side) {
+  let count = 0;
+  for (let r = 0; r < CHECKERS_SIZE; r += 1)
+    for (let c = 0; c < CHECKERS_SIZE; c += 1)
+      if (board[r][c]?.side === side) count += 1;
+  return count;
+}
+
+export function getGameState(board, turnSide, forcedPiece = null) {
+  const lightCount = countPieces(board, 'light');
+  const darkCount = countPieces(board, 'dark');
+  if (lightCount === 0) return { finished: true, winner: 'dark' };
+  if (darkCount === 0) return { finished: true, winner: 'light' };
+  const legal = getLegalMoves(board, turnSide, forcedPiece);
+  if (!legal.length) {
+    return { finished: true, winner: turnSide === 'light' ? 'dark' : 'light' };
+  }
+  return { finished: false, winner: null };
+}
+
+function evaluateBoard(board, side) {
+  let score = 0;
+  for (let r = 0; r < CHECKERS_SIZE; r += 1) {
+    for (let c = 0; c < CHECKERS_SIZE; c += 1) {
+      const piece = board[r][c];
+      if (!piece) continue;
+      const val = piece.king ? 5 : 3;
+      const advance = piece.side === 'dark' ? r * 0.08 : (7 - r) * 0.08;
+      const sign = piece.side === side ? 1 : -1;
+      score += sign * (val + advance);
+      if (r > 1 && r < 6 && c > 1 && c < 6) score += sign * 0.15;
+    }
+  }
+  return score;
+}
+
+function opponent(side) {
+  return side === 'light' ? 'dark' : 'light';
+}
+
+function minimax(state, depth, alpha, beta, maximizingFor) {
+  const game = getGameState(state.board, state.turn, state.forcedPiece);
+  if (depth === 0 || game.finished) {
+    if (game.finished) {
+      if (game.winner === maximizingFor) return { score: 1000 + depth };
+      return { score: -1000 - depth };
+    }
+    return { score: evaluateBoard(state.board, maximizingFor) };
+  }
+
+  const moves = getLegalMoves(state.board, state.turn, state.forcedPiece);
+  const isMax = state.turn === maximizingFor;
+  let bestMove = null;
+  let bestScore = isMax ? -Infinity : Infinity;
+
+  for (const move of moves) {
+    const applied = applyMove(state.board, move);
+    const nextState = {
+      board: applied.board,
+      turn: applied.mustContinue ? state.turn : opponent(state.turn),
+      forcedPiece: applied.mustContinue ? applied.forcedPiece : null
+    };
+    const result = minimax(nextState, depth - 1, alpha, beta, maximizingFor);
+
+    if (isMax) {
+      if (result.score > bestScore) {
+        bestScore = result.score;
+        bestMove = move;
+      }
+      alpha = Math.max(alpha, bestScore);
+    } else {
+      if (result.score < bestScore) {
+        bestScore = result.score;
+        bestMove = move;
+      }
+      beta = Math.min(beta, bestScore);
+    }
+    if (beta <= alpha) break;
+  }
+
+  return { score: bestScore, move: bestMove };
+}
+
+export function getBestAIMove(board, side, forcedPiece = null, depth = 5) {
+  const legal = getLegalMoves(board, side, forcedPiece);
+  if (!legal.length) return null;
+  const result = minimax(
+    { board, turn: side, forcedPiece },
+    depth,
+    -Infinity,
+    Infinity,
+    side
+  );
+  return result.move || legal[0];
+}


### PR DESCRIPTION
### Motivation
- Provide a reusable, correct ruleset and a capable AI for Checkers so the Battle Royal variant is fully playable and competitive.
- Match the visual fidelity of the chess Battle Royal by loading GLTF board assets and ensuring textures/materials render correctly.
- Keep gameplay modular and testable by extracting game logic away from rendering/UI.

### Description
- Add a reusable engine `webapp/src/utils/checkersEngine.js` implementing full rules: move generation, forced-capture enforcement, multi-capture chaining, king promotion, game-over detection, board utilities, and a minimax-based AI (`getBestAIMove`).
- Integrate the engine into `CheckersBattleRoyal.jsx` to replace inline move logic with engine calls and to enforce legal/mandatory captures, chained-capture flows, replay state, and turn switching.
- Implement AI automation for the rival (dark) side with thinking state and UI feedback, and wire visual highlights to use legal moves from the engine.
- Swap board GLTF URLs to the chess-battle-royal family and apply color-space + shadow handling for loaded materials to match existing chess visuals; tweak board scale/placement for better fit.
- Add unit tests `test/checkersEngine.test.js` covering initial moves, mandatory capture behavior, and AI capture preference.

### Testing
- Ran unit tests with `npm test -- test/checkersEngine.test.js --runInBand` and all tests passed (3 tests, 1 suite).
- Built the webapp with `npm --prefix webapp run build` which completed successfully and produced the updated bundles.
- Ran linter `npx eslint --no-ignore ...` which reported style/formatting errors (failures) due to repository lint conventions and test-file globals; logic and runtime tests remain green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6bec2939c832986e9e55813ee8c3d)