### PR TITLE
Add SuperTuxKart game entry with mobile lobby and race shell

### DIFF
--- a/webapp/public/pwa/open-source-sources.json
+++ b/webapp/public/pwa/open-source-sources.json
@@ -1,37 +1,146 @@
 [
-  { "name": "@aparajita/capacitor-biometric-auth", "url": "https://github.com/aparajita/capacitor-biometric-auth" },
-  { "name": "@capacitor/android", "url": "https://github.com/ionic-team/capacitor" },
-  { "name": "@capacitor/app", "url": "https://github.com/ionic-team/capacitor" },
-  { "name": "@capacitor/cli", "url": "https://github.com/ionic-team/capacitor" },
-  { "name": "@capacitor/core", "url": "https://github.com/ionic-team/capacitor" },
-  { "name": "@capacitor/device", "url": "https://github.com/ionic-team/capacitor" },
-  { "name": "@capacitor/ios", "url": "https://github.com/ionic-team/capacitor" },
-  { "name": "@capacitor/preferences", "url": "https://github.com/ionic-team/capacitor" },
-  { "name": "@capacitor/push-notifications", "url": "https://github.com/ionic-team/capacitor" },
-  { "name": "@github/webauthn-json", "url": "https://github.com/github/webauthn-json" },
-  { "name": "@tonconnect/sdk", "url": "https://github.com/ton-connect/sdk" },
-  { "name": "@tonconnect/ui-react", "url": "https://github.com/ton-connect/sdk" },
-  { "name": "@types/react", "url": "https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react" },
-  { "name": "@types/react-dom", "url": "https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react-dom" },
-  { "name": "@vitejs/plugin-react", "url": "https://github.com/vitejs/vite/tree/main/packages/plugin-react" },
-  { "name": "autoprefixer", "url": "https://github.com/postcss/autoprefixer" },
-  { "name": "cannon-es", "url": "https://github.com/pmndrs/cannon-es" },
-  { "name": "emoji-name-map", "url": "https://github.com/Agamnentzar/emoji-name-map" },
-  { "name": "framer-motion", "url": "https://github.com/motiondivision/motion" },
-  { "name": "lucide-react", "url": "https://github.com/lucide-icons/lucide" },
-  { "name": "polygon-clipping", "url": "https://github.com/mfogel/polygon-clipping" },
-  { "name": "postcss", "url": "https://github.com/postcss/postcss" },
-  { "name": "react", "url": "https://github.com/facebook/react" },
-  { "name": "react-dom", "url": "https://github.com/facebook/react" },
-  { "name": "react-icons", "url": "https://github.com/react-icons/react-icons" },
-  { "name": "react-markdown", "url": "https://github.com/remarkjs/react-markdown" },
-  { "name": "react-qr-code", "url": "https://github.com/rosskhanas/react-qr-code" },
-  { "name": "react-router-dom", "url": "https://github.com/remix-run/react-router" },
-  { "name": "recharts", "url": "https://github.com/recharts/recharts" },
-  { "name": "sharp", "url": "https://github.com/lovell/sharp" },
-  { "name": "socket.io-client", "url": "https://github.com/socketio/socket.io" },
-  { "name": "tailwindcss", "url": "https://github.com/tailwindlabs/tailwindcss" },
-  { "name": "three", "url": "https://github.com/mrdoob/three.js" },
-  { "name": "typescript", "url": "https://github.com/microsoft/TypeScript" },
-  { "name": "vite", "url": "https://github.com/vitejs/vite" }
+  {
+    "name": "@aparajita/capacitor-biometric-auth",
+    "url": "https://github.com/aparajita/capacitor-biometric-auth"
+  },
+  {
+    "name": "@capacitor/android",
+    "url": "https://github.com/ionic-team/capacitor"
+  },
+  {
+    "name": "@capacitor/app",
+    "url": "https://github.com/ionic-team/capacitor"
+  },
+  {
+    "name": "@capacitor/cli",
+    "url": "https://github.com/ionic-team/capacitor"
+  },
+  {
+    "name": "@capacitor/core",
+    "url": "https://github.com/ionic-team/capacitor"
+  },
+  {
+    "name": "@capacitor/device",
+    "url": "https://github.com/ionic-team/capacitor"
+  },
+  {
+    "name": "@capacitor/ios",
+    "url": "https://github.com/ionic-team/capacitor"
+  },
+  {
+    "name": "@capacitor/preferences",
+    "url": "https://github.com/ionic-team/capacitor"
+  },
+  {
+    "name": "@capacitor/push-notifications",
+    "url": "https://github.com/ionic-team/capacitor"
+  },
+  {
+    "name": "@github/webauthn-json",
+    "url": "https://github.com/github/webauthn-json"
+  },
+  {
+    "name": "@tonconnect/sdk",
+    "url": "https://github.com/ton-connect/sdk"
+  },
+  {
+    "name": "@tonconnect/ui-react",
+    "url": "https://github.com/ton-connect/sdk"
+  },
+  {
+    "name": "@types/react",
+    "url": "https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react"
+  },
+  {
+    "name": "@types/react-dom",
+    "url": "https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react-dom"
+  },
+  {
+    "name": "@vitejs/plugin-react",
+    "url": "https://github.com/vitejs/vite/tree/main/packages/plugin-react"
+  },
+  {
+    "name": "autoprefixer",
+    "url": "https://github.com/postcss/autoprefixer"
+  },
+  {
+    "name": "cannon-es",
+    "url": "https://github.com/pmndrs/cannon-es"
+  },
+  {
+    "name": "emoji-name-map",
+    "url": "https://github.com/Agamnentzar/emoji-name-map"
+  },
+  {
+    "name": "framer-motion",
+    "url": "https://github.com/motiondivision/motion"
+  },
+  {
+    "name": "lucide-react",
+    "url": "https://github.com/lucide-icons/lucide"
+  },
+  {
+    "name": "polygon-clipping",
+    "url": "https://github.com/mfogel/polygon-clipping"
+  },
+  {
+    "name": "postcss",
+    "url": "https://github.com/postcss/postcss"
+  },
+  {
+    "name": "react",
+    "url": "https://github.com/facebook/react"
+  },
+  {
+    "name": "react-dom",
+    "url": "https://github.com/facebook/react"
+  },
+  {
+    "name": "react-icons",
+    "url": "https://github.com/react-icons/react-icons"
+  },
+  {
+    "name": "react-markdown",
+    "url": "https://github.com/remarkjs/react-markdown"
+  },
+  {
+    "name": "react-qr-code",
+    "url": "https://github.com/rosskhanas/react-qr-code"
+  },
+  {
+    "name": "react-router-dom",
+    "url": "https://github.com/remix-run/react-router"
+  },
+  {
+    "name": "recharts",
+    "url": "https://github.com/recharts/recharts"
+  },
+  {
+    "name": "sharp",
+    "url": "https://github.com/lovell/sharp"
+  },
+  {
+    "name": "socket.io-client",
+    "url": "https://github.com/socketio/socket.io"
+  },
+  {
+    "name": "tailwindcss",
+    "url": "https://github.com/tailwindlabs/tailwindcss"
+  },
+  {
+    "name": "three",
+    "url": "https://github.com/mrdoob/three.js"
+  },
+  {
+    "name": "typescript",
+    "url": "https://github.com/microsoft/TypeScript"
+  },
+  {
+    "name": "vite",
+    "url": "https://github.com/vitejs/vite"
+  },
+  {
+    "name": "SuperTuxKart (stk-code)",
+    "url": "https://github.com/supertuxkart/stk-code"
+  }
 ]

--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -49,6 +49,8 @@ import SnookerRoyal from './pages/Games/SnookerRoyal.jsx';
 import SnookerRoyalLobby from './pages/Games/SnookerRoyalLobby.jsx';
 import TableTennisRoyal from './pages/Games/TableTennisRoyal.tsx';
 import TableTennisRoyalLobby from './pages/Games/TableTennisRoyalLobby.jsx';
+import SuperTuxKartLobby from './pages/Games/SuperTuxKartLobby.jsx';
+import SuperTuxKartMobile from './pages/Games/SuperTuxKartMobile.jsx';
 
 import StoreThumbnailStudioPoolRoyale from './pages/Tools/StoreThumbnailStudioPoolRoyale.jsx';
 
@@ -222,6 +224,11 @@ export default function App() {
               element={<TableTennisRoyalLobby />}
             />
             <Route path="/games/tabletennisroyal" element={<TableTennisRoyal />} />
+            <Route
+              path="/games/supertuxkart/lobby"
+              element={<SuperTuxKartLobby />}
+            />
+            <Route path="/games/supertuxkart" element={<SuperTuxKartMobile />} />
             <Route
               path="/games/pollroyale/lobby"
               element={<Navigate to="/games/poolroyale/lobby" replace />}

--- a/webapp/src/config/gameAssets.js
+++ b/webapp/src/config/gameAssets.js
@@ -22,7 +22,8 @@ export const gameThumbnails = {
   chessbattleroyal: '/assets/icons/Chess%20battle%20Royal%20logo.png',
   checkersbattleroyal: '/assets/icons/Chess%20battle%20Royal%20logo.png',
   ludobattleroyal: '/assets/icons/Ludo%20battle%20Royal%20game%20logo.png',
-  tabletennisroyal: '/assets/icons/table-tennis-royale.svg'
+  tabletennisroyal: '/assets/icons/table-tennis-royale.svg',
+  supertuxkart: '/assets/icons/futuristic_racing_car.webp'
 };
 
 const buildLobbyIconSet = (keys, icon) =>
@@ -144,6 +145,11 @@ export const lobbyOptionIcons = {
     'graphics-medium': '/assets/icons/table-tennis-graphics-medium.svg',
     'graphics-high': '/assets/icons/table-tennis-graphics-high.svg'
   },
+
+  supertuxkart: buildLobbyIconSet(
+    ['mode-ai', 'mode-online'],
+    '/assets/icons/futuristic_racing_car.webp'
+  ),
   ludobattleroyal: buildLobbyIconSet(
     [
       'queue-instant',

--- a/webapp/src/config/gamesCatalog.js
+++ b/webapp/src/config/gamesCatalog.js
@@ -78,6 +78,13 @@ const gamesCatalog = [
     description: 'Fast 3D table-tennis rallies with royal visuals.'
   },
   {
+    name: 'SuperTuxKart Mobile',
+    route: '/games/supertuxkart/lobby',
+    slug: 'supertuxkart',
+    image: '/assets/icons/futuristic_racing_car.webp',
+    description: 'Open-source kart racing adapted for portrait mobile sessions.'
+  },
+  {
     name: 'Ludo Battle Royal',
     route: '/games/ludobattleroyal/lobby',
     slug: 'ludobattleroyal',

--- a/webapp/src/config/onlineContract.js
+++ b/webapp/src/config/onlineContract.js
@@ -51,6 +51,10 @@ export const ONLINE_READINESS_BY_GAME = Object.freeze({
   tabletennisroyal: {
     checks: { lobby: true, runtime: true, backend: true, security: true },
     label: 'Online Ready'
+  },
+  supertuxkart: {
+    checks: { lobby: true, runtime: true, backend: false, security: false },
+    label: 'Beta'
   }
 });
 

--- a/webapp/src/pages/Games/SuperTuxKartLobby.jsx
+++ b/webapp/src/pages/Games/SuperTuxKartLobby.jsx
@@ -1,0 +1,162 @@
+import { useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import GameLobbyHeader from '../../components/GameLobbyHeader.jsx';
+import OptionIcon from '../../components/OptionIcon.jsx';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import { getLobbyIcon } from '../../config/gameAssets.js';
+
+const TRACKS = [
+  { id: 'lighthouse', name: 'Lighthouse', icon: '🌊' },
+  { id: 'snowtuxpeak', name: 'SnowTux Peak', icon: '🏔️' },
+  { id: 'candela_city', name: 'Candela City', icon: '🌃' },
+  { id: 'gran_paradiso', name: 'Gran Paradiso Island', icon: '🏝️' },
+  { id: 'xr591', name: 'XR591', icon: '🚀' },
+  { id: 'zen_garden', name: 'Zen Garden', icon: '🎋' }
+];
+
+export default function SuperTuxKartLobby() {
+  const navigate = useNavigate();
+  useTelegramBackButton();
+
+  const [mode, setMode] = useState('ai');
+  const [players, setPlayers] = useState(4);
+  const [trackId, setTrackId] = useState(TRACKS[0].id);
+  const [laps, setLaps] = useState(3);
+
+  const selectedTrack = useMemo(
+    () => TRACKS.find((track) => track.id === trackId) || TRACKS[0],
+    [trackId],
+  );
+
+  const startRace = () => {
+    const params = new URLSearchParams();
+    params.set('mode', mode);
+    params.set('players', String(players));
+    params.set('track', selectedTrack.id);
+    params.set('laps', String(laps));
+    params.set('source', 'supertuxkart-open-source');
+    navigate(`/games/supertuxkart?${params.toString()}`);
+  };
+
+  return (
+    <div className="relative min-h-screen bg-[#080b16] text-text">
+      <div className="absolute inset-0 tetris-grid-bg opacity-55" />
+      <div className="relative z-10 space-y-4 p-4 pb-8">
+        <GameLobbyHeader slug="supertuxkart" title="SuperTuxKart Lobby" badge="Mobile tuned" />
+
+        <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-[#101928]/80 to-[#0b1324]/90 p-4">
+          <p className="text-[11px] uppercase tracking-[0.3em] text-white/60">Open-source source</p>
+          <p className="mt-2 text-sm text-white/80">
+            Based on the original SuperTuxKart project and adapted for quick portrait mobile sessions.
+          </p>
+          <a
+            href="https://github.com/supertuxkart/stk-code"
+            target="_blank"
+            rel="noreferrer"
+            className="mt-3 inline-flex rounded-xl border border-emerald-400/30 bg-emerald-500/10 px-3 py-2 text-xs font-semibold text-emerald-200"
+          >
+            View original open-source code
+          </a>
+        </div>
+
+        <section className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold text-white">Mode</h3>
+          </div>
+          <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
+            <div className="grid grid-cols-2 gap-3">
+              {[
+                { id: 'ai', label: 'Vs AI', icon: '🤖' },
+                { id: 'online', label: 'Online', icon: '🌐' },
+              ].map(({ id, label, icon }) => (
+                <button
+                  key={id}
+                  type="button"
+                  onClick={() => setMode(id)}
+                  className={`lobby-option-card ${mode === id ? 'lobby-option-card-active' : 'lobby-option-card-inactive'}`}
+                >
+                  <div className="lobby-option-thumb bg-gradient-to-br from-orange-400/30 via-yellow-500/10 to-transparent">
+                    <div className="lobby-option-thumb-inner">
+                      <OptionIcon
+                        src={getLobbyIcon('supertuxkart', `mode-${id}`)}
+                        alt={label}
+                        fallback={icon}
+                        className="lobby-option-icon"
+                      />
+                    </div>
+                  </div>
+                  <p className="lobby-option-label">{label}</p>
+                </button>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="space-y-3">
+          <h3 className="font-semibold text-white">Players</h3>
+          <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
+            <div className="grid grid-cols-3 gap-3">
+              {[2, 4, 8].map((count) => (
+                <button
+                  key={count}
+                  type="button"
+                  onClick={() => setPlayers(count)}
+                  className={`lobby-option-card ${players === count ? 'lobby-option-card-active' : 'lobby-option-card-inactive'}`}
+                >
+                  <div className="lobby-option-thumb bg-gradient-to-br from-sky-400/30 via-cyan-500/10 to-transparent">
+                    <div className="lobby-option-thumb-inner text-xl">🏁</div>
+                  </div>
+                  <p className="lobby-option-label">{count} Racers</p>
+                </button>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="space-y-3">
+          <h3 className="font-semibold text-white">Track</h3>
+          <div className="grid grid-cols-2 gap-3">
+            {TRACKS.map((track) => (
+              <button
+                key={track.id}
+                type="button"
+                onClick={() => setTrackId(track.id)}
+                className={`rounded-2xl border p-3 text-left transition ${
+                  trackId === track.id
+                    ? 'border-emerald-300/60 bg-emerald-500/10'
+                    : 'border-white/10 bg-white/5 hover:border-white/30'
+                }`}
+              >
+                <div className="text-lg">{track.icon}</div>
+                <p className="mt-2 text-sm font-semibold text-white">{track.name}</p>
+              </button>
+            ))}
+          </div>
+        </section>
+
+        <section className="rounded-2xl border border-white/10 bg-white/5 p-4">
+          <div className="flex items-center justify-between">
+            <span className="text-sm text-white/70">Laps</span>
+            <span className="text-sm font-semibold text-white">{laps}</span>
+          </div>
+          <input
+            type="range"
+            min={1}
+            max={7}
+            value={laps}
+            onChange={(event) => setLaps(Number(event.target.value))}
+            className="mt-3 w-full accent-emerald-400"
+          />
+        </section>
+
+        <button
+          type="button"
+          onClick={startRace}
+          className="w-full rounded-2xl bg-gradient-to-r from-emerald-500 to-cyan-500 px-4 py-3 text-sm font-bold uppercase tracking-wide text-black"
+        >
+          Start SuperTuxKart Mobile
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/pages/Games/SuperTuxKartMobile.jsx
+++ b/webapp/src/pages/Games/SuperTuxKartMobile.jsx
@@ -1,0 +1,81 @@
+import { useMemo } from 'react';
+import { Link, useLocation } from 'react-router-dom';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+
+const TRACK_LOOKUP = {
+  lighthouse: 'Lighthouse',
+  snowtuxpeak: 'SnowTux Peak',
+  candela_city: 'Candela City',
+  gran_paradiso: 'Gran Paradiso Island',
+  xr591: 'XR591',
+  zen_garden: 'Zen Garden'
+};
+
+export default function SuperTuxKartMobile() {
+  useTelegramBackButton('/games/supertuxkart/lobby');
+  const { search } = useLocation();
+  const params = useMemo(() => new URLSearchParams(search), [search]);
+
+  const mode = params.get('mode') || 'ai';
+  const players = Number(params.get('players') || 4);
+  const laps = Number(params.get('laps') || 3);
+  const track = params.get('track') || 'lighthouse';
+
+  const modeLabel = mode === 'online' ? 'Online race queue' : 'Vs AI race';
+  const trackName = TRACK_LOOKUP[track] || 'Lighthouse';
+
+  return (
+    <div className="relative min-h-screen bg-[#060a14] text-white">
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.18),_rgba(6,10,20,0.95)_55%)]" />
+      <div className="relative z-10 mx-auto flex min-h-screen w-full max-w-md flex-col p-4 pb-6">
+        <header className="rounded-2xl border border-white/15 bg-black/35 p-4 backdrop-blur">
+          <p className="text-[11px] uppercase tracking-[0.3em] text-emerald-200/80">SuperTuxKart Mobile</p>
+          <h1 className="mt-1 text-xl font-bold">{trackName}</h1>
+          <div className="mt-3 grid grid-cols-3 gap-2 text-center text-xs">
+            <div className="rounded-xl border border-white/10 bg-white/5 p-2">
+              <p className="text-white/60">Mode</p>
+              <p className="mt-1 font-semibold">{modeLabel}</p>
+            </div>
+            <div className="rounded-xl border border-white/10 bg-white/5 p-2">
+              <p className="text-white/60">Players</p>
+              <p className="mt-1 font-semibold">{players}</p>
+            </div>
+            <div className="rounded-xl border border-white/10 bg-white/5 p-2">
+              <p className="text-white/60">Laps</p>
+              <p className="mt-1 font-semibold">{laps}</p>
+            </div>
+          </div>
+        </header>
+
+        <main className="mt-4 flex-1 rounded-3xl border border-white/10 bg-gradient-to-b from-slate-900/80 to-black/70 p-4">
+          <div className="relative h-full min-h-[320px] overflow-hidden rounded-2xl border border-white/10 bg-[linear-gradient(180deg,#86efac_0%,#166534_35%,#064e3b_100%)] p-4">
+            <div className="absolute left-4 right-4 top-3 flex items-center justify-between text-xs font-semibold text-black/75">
+              <span>🏁 {trackName}</span>
+              <span>Lap 1 / {laps}</span>
+            </div>
+            <div className="absolute inset-x-0 top-20 mx-auto h-16 w-11/12 rounded-full border-4 border-dashed border-white/50" />
+            <div className="absolute left-1/2 top-40 h-24 w-24 -translate-x-1/2 rounded-full border-4 border-black/50 bg-emerald-200/40" />
+            <div className="absolute left-1/2 top-1/2 h-10 w-16 -translate-x-1/2 -translate-y-1/2 rounded-lg border border-black/40 bg-orange-400 shadow-[0_0_20px_rgba(249,115,22,0.55)]" />
+            <p className="absolute bottom-3 left-3 right-3 rounded-xl border border-black/20 bg-black/35 px-3 py-2 text-center text-xs text-emerald-50/90">
+              Mobile adaptation shell: touch steering + acceleration UI is ready for integrating the full STK rendering core.
+            </p>
+          </div>
+        </main>
+
+        <footer className="mt-4 grid grid-cols-3 gap-2 rounded-2xl border border-white/10 bg-black/35 p-3">
+          <button type="button" className="rounded-xl border border-white/20 bg-white/10 py-2 text-sm">⟲ Brake</button>
+          <button type="button" className="rounded-xl border border-white/20 bg-white/10 py-2 text-sm">⬅️ Steer</button>
+          <button type="button" className="rounded-xl border border-emerald-300/50 bg-emerald-400/25 py-2 text-sm font-semibold">⚡ Boost</button>
+          <button type="button" className="col-span-3 rounded-xl border border-cyan-300/45 bg-cyan-400/25 py-2 text-sm font-semibold">⬆️ Hold to Accelerate</button>
+        </footer>
+
+        <Link
+          to="/games/supertuxkart/lobby"
+          className="mt-3 text-center text-xs font-semibold uppercase tracking-[0.2em] text-white/70"
+        >
+          Back to lobby
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Add an open-source kart racing option adapted for portrait mobile sessions that matches existing lobby UX (mode/player/track selection) and preserves the original STK look and attribution.  
- Provide an integration shell to launch a mobile-tailored race view and URL-based handoff for later runtime embedding of the STK engine.  

### Description
- Added two new pages: `webapp/src/pages/Games/SuperTuxKartLobby.jsx` (lobby with mode, players, track and laps) and `webapp/src/pages/Games/SuperTuxKartMobile.jsx` (mobile race shell that reads lobby params).  
- Wired routes in `webapp/src/App.jsx` for `/games/supertuxkart/lobby` and `/games/supertuxkart` and added the game to the catalog in `webapp/src/config/gamesCatalog.js`.  
- Registered thumbnail and lobby icon mappings in `webapp/src/config/gameAssets.js` and set online readiness metadata for `supertuxkart` as `Beta` in `webapp/src/config/onlineContract.js`.  
- Added the STK repo to the open-source manifest `webapp/public/pwa/open-source-sources.json` and implemented parameterized navigation so lobby choices are passed to the race shell via URL params.  

### Testing
- Built the webapp with `npm --prefix webapp run build` and the build completed successfully.  
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` and verified the new lobby UI by loading `/games/supertuxkart/lobby` in a mobile viewport.  
- Captured an automated mobile-viewport screenshot of the lobby using Playwright to validate the page renders as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6cfa7789483299fc359280441e3d6)