### PR TITLE
Add Backgammon Royal (Tavull) game with 3D board, AI and catalog/lobby updates

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -186,7 +186,7 @@ export default function App() {
             <Route
               path="/games/tavullbattleroyal/lobby"
               element={(
-                <Suspense fallback={<div className="p-4 text-center">Loading Tavull Lobby…</div>}>
+                <Suspense fallback={<div className="p-4 text-center">Loading Backgammon Lobby…</div>}>
                   <TavullBattleRoyalLobby />
                 </Suspense>
               )}
@@ -194,7 +194,7 @@ export default function App() {
             <Route
               path="/games/tavullbattleroyal"
               element={(
-                <Suspense fallback={<div className="p-4 text-center">Loading Tavull Battle Royal…</div>}>
+                <Suspense fallback={<div className="p-4 text-center">Loading Backgammon Royal…</div>}>
                   <TavullBattleRoyal />
                 </Suspense>
               )}

--- a/webapp/src/config/gamesCatalog.js
+++ b/webapp/src/config/gamesCatalog.js
@@ -71,11 +71,11 @@ const gamesCatalog = [
     description: 'Classic checkers duels with royal 3D presentation.'
   },
   {
-    name: 'Tavull Battle Royal',
+    name: 'Backgammon Royal',
     route: '/games/tavullbattleroyal/lobby',
     slug: 'tavullbattleroyal',
     image: '/assets/icons/Chess%20battle%20Royal%20logo.png',
-    description: 'Tavull tables with royal arena visuals and fast matches.'
+    description: 'Backgammon duels with a royal 3D-inspired board and smart AI.'
   },
   {
     name: 'Table Tennis Royal',

--- a/webapp/src/pages/Games/TavullBattleRoyal.jsx
+++ b/webapp/src/pages/Games/TavullBattleRoyal.jsx
@@ -1,5 +1,716 @@
-import CheckersBattleRoyal from './CheckersBattleRoyal.jsx';
+import { useEffect, useMemo, useRef, useState } from 'react'
+import * as THREE from 'three'
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js'
+import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader.js'
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js'
+import { createMurlanStyleTable, applyTableMaterials } from '../../utils/murlanTable.js'
+import { MURLAN_TABLE_FINISHES } from '../../config/murlanTableFinishes.js'
+import { getTelegramFirstName, getTelegramPhotoUrl } from '../../utils/telegram.js'
+import Dice from '../../components/Dice.jsx'
+import BottomLeftIcons from '../../components/BottomLeftIcons.jsx'
+import AvatarTimer from '../../components/AvatarTimer.jsx'
+
+const WHITE = 'white'
+const BLACK = 'black'
+
+const TABLE_RADIUS = 2.55
+const TABLE_HEIGHT = 1.16
+const CHAIR_DISTANCE = TABLE_RADIUS + 0.82
+const BOARD_Y = TABLE_HEIGHT + 0.08
+const POINT_WIDTH = 0.19
+const BOARD_HALF_X = 1.28
+const BOARD_HALF_Z = 0.98
+const POINT_START_X = 0.08
+
+const MODEL_SCALE = 0.75
+const STOOL_SCALE = 1.5 * 1.3
+const SEAT_WIDTH = 0.9 * MODEL_SCALE * STOOL_SCALE
+const SEAT_DEPTH = 0.95 * MODEL_SCALE * STOOL_SCALE
+const SEAT_THICKNESS_SCALED = 0.09 * MODEL_SCALE * STOOL_SCALE
+const BACK_HEIGHT = 0.68 * MODEL_SCALE * STOOL_SCALE
+const BACK_THICKNESS = 0.08 * MODEL_SCALE * STOOL_SCALE
+const ARM_THICKNESS = 0.125 * MODEL_SCALE * STOOL_SCALE
+const ARM_HEIGHT = 0.3 * MODEL_SCALE * STOOL_SCALE
+const ARM_DEPTH = SEAT_DEPTH * 0.75
+const BASE_COLUMN_HEIGHT = 0.5 * MODEL_SCALE * STOOL_SCALE
+const CHAIR_BASE_HEIGHT = TABLE_HEIGHT - SEAT_THICKNESS_SCALED * 0.85
+const FALLBACK_SEAT_POSITIONS = [
+  { left: '50%', top: '18%' },
+  { left: '50%', top: '82%' }
+]
+
+const initialBoard = () => {
+  const points = Array.from({ length: 24 }, () => ({ color: null, count: 0 }))
+  const set = (i, color, count) => {
+    points[i] = { color, count }
+  }
+  set(23, WHITE, 2)
+  set(12, WHITE, 5)
+  set(7, WHITE, 3)
+  set(5, WHITE, 5)
+  set(0, BLACK, 2)
+  set(11, BLACK, 5)
+  set(16, BLACK, 3)
+  set(18, BLACK, 5)
+  return points
+}
+
+const cloneState = (state) => ({
+  points: state.points.map((p) => ({ ...p })),
+  bar: { ...state.bar },
+  off: { ...state.off }
+})
+
+const other = (color) => (color === WHITE ? BLACK : WHITE)
+const dirFor = (color) => (color === WHITE ? -1 : 1)
+const homeRange = (color) => (color === WHITE ? [0, 5] : [18, 23])
+const canLand = (point, color) => !point.color || point.color === color || point.count === 1
+
+const canBearOff = (state, color) => {
+  if (state.bar[color] > 0) return false
+  const [start, end] = homeRange(color)
+  for (let i = 0; i < 24; i += 1) {
+    if (i < start || i > end) {
+      const p = state.points[i]
+      if (p.color === color && p.count > 0) return false
+    }
+  }
+  return true
+}
+
+const hasHigherHomeChecker = (state, color, from) => {
+  if (color === WHITE) {
+    for (let i = from + 1; i <= 5; i += 1) {
+      const p = state.points[i]
+      if (p.color === WHITE && p.count > 0) return true
+    }
+    return false
+  }
+  for (let i = from - 1; i >= 18; i -= 1) {
+    const p = state.points[i]
+    if (p.color === BLACK && p.count > 0) return true
+  }
+  return false
+}
+
+const destinationForBar = (color, die) => (color === WHITE ? 24 - die : die - 1)
+
+const getSingleDieMoves = (state, color, die) => {
+  const moves = []
+  if (state.bar[color] > 0) {
+    const dest = destinationForBar(color, die)
+    if (dest >= 0 && dest < 24 && canLand(state.points[dest], color)) {
+      moves.push({ from: 'bar', to: dest, die })
+    }
+    return moves
+  }
+
+  const direction = dirFor(color)
+  const canOff = canBearOff(state, color)
+
+  for (let i = 0; i < 24; i += 1) {
+    const p = state.points[i]
+    if (p.color !== color || p.count <= 0) continue
+    const dest = i + direction * die
+
+    if (dest >= 0 && dest < 24) {
+      if (canLand(state.points[dest], color)) moves.push({ from: i, to: dest, die })
+      continue
+    }
+
+    if (!canOff) continue
+    if (color === WHITE && dest < 0) {
+      const exact = i - die === -1
+      if (exact || !hasHigherHomeChecker(state, color, i)) moves.push({ from: i, to: 'off', die })
+    }
+    if (color === BLACK && dest > 23) {
+      const exact = i + die === 24
+      if (exact || !hasHigherHomeChecker(state, color, i)) moves.push({ from: i, to: 'off', die })
+    }
+  }
+
+  return moves
+}
+
+const applyMove = (state, color, move) => {
+  const next = cloneState(state)
+  if (move.from === 'bar') {
+    next.bar[color] -= 1
+  } else {
+    const fromPoint = next.points[move.from]
+    fromPoint.count -= 1
+    if (fromPoint.count === 0) fromPoint.color = null
+  }
+
+  if (move.to === 'off') {
+    next.off[color] += 1
+    return next
+  }
+
+  const toPoint = next.points[move.to]
+  if (toPoint.color === other(color) && toPoint.count === 1) {
+    toPoint.color = color
+    toPoint.count = 1
+    next.bar[other(color)] += 1
+    return next
+  }
+
+  if (!toPoint.color) toPoint.color = color
+  toPoint.count += 1
+  return next
+}
+
+const permutationsForDice = (dice) => {
+  if (dice.length !== 2 || dice[0] === dice[1]) return [dice]
+  return [dice, [dice[1], dice[0]]]
+}
+
+const collectTurnSequences = (state, color, dice) => {
+  const sequences = []
+  const recurse = (currentState, diceLeft, line = [], used = []) => {
+    if (!diceLeft.length) {
+      sequences.push({ line, usedDice: used, resultingState: currentState })
+      return
+    }
+    const [die, ...rest] = diceLeft
+    const options = getSingleDieMoves(currentState, color, die)
+    if (!options.length) {
+      sequences.push({ line, usedDice: used, resultingState: currentState })
+      return
+    }
+    options.forEach((mv) => recurse(applyMove(currentState, color, mv), rest, [...line, mv], [...used, die]))
+  }
+
+  permutationsForDice(dice).forEach((order) => recurse(state, order))
+
+  const maxUsed = sequences.reduce((max, s) => Math.max(max, s.usedDice.length), 0)
+  let filtered = sequences.filter((s) => s.usedDice.length === maxUsed)
+
+  if (maxUsed === 1 && dice.length === 2 && dice[0] !== dice[1]) {
+    const higher = Math.max(...dice)
+    if (getSingleDieMoves(state, color, higher).length > 0) {
+      filtered = filtered.filter((s) => s.usedDice[0] === higher)
+    }
+  }
+
+  return filtered
+}
+
+const scorePosition = (state, color) => {
+  const opp = other(color)
+  const pip = (player) => {
+    let total = state.bar[player] * 25
+    for (let i = 0; i < 24; i += 1) {
+      const p = state.points[i]
+      if (p.color !== player) continue
+      const distance = player === WHITE ? i + 1 : 24 - i
+      total += p.count * distance
+    }
+    return total
+  }
+
+  return (pip(opp) - pip(color)) + (state.off[color] - state.off[opp]) * 20 - state.bar[color] * 8 + state.bar[opp] * 8
+}
+
+const pickAiSequence = (state, dice) => {
+  const sequences = collectTurnSequences(state, BLACK, dice)
+  if (!sequences.length) return null
+  return sequences.reduce((best, seq) => (scorePosition(seq.resultingState, BLACK) > scorePosition(best.resultingState, BLACK) ? seq : best), sequences[0])
+}
+
+function createArenaChairFallback(chairColor = '#8b1d2c', legColor = '#111827') {
+  const seatMaterial = new THREE.MeshStandardMaterial({
+    color: chairColor,
+    roughness: 0.42,
+    metalness: 0.18
+  })
+  const legMaterial = new THREE.MeshStandardMaterial({
+    color: legColor,
+    roughness: 0.55,
+    metalness: 0.38
+  })
+  const chair = new THREE.Group()
+  const seatMesh = new THREE.Mesh(
+    new THREE.BoxGeometry(SEAT_WIDTH, SEAT_THICKNESS_SCALED, SEAT_DEPTH),
+    seatMaterial
+  )
+  seatMesh.position.y = SEAT_THICKNESS_SCALED / 2
+  const backMesh = new THREE.Mesh(
+    new THREE.BoxGeometry(SEAT_WIDTH * 0.96, BACK_HEIGHT, BACK_THICKNESS),
+    seatMaterial
+  )
+  backMesh.position.set(
+    0,
+    SEAT_THICKNESS_SCALED / 2 + BACK_HEIGHT / 2,
+    -SEAT_DEPTH / 2 + BACK_THICKNESS / 2
+  )
+  const armGeometry = new THREE.BoxGeometry(ARM_THICKNESS, ARM_HEIGHT, ARM_DEPTH)
+  const armOffsetX = SEAT_WIDTH / 2 - ARM_THICKNESS / 2
+  const armOffsetY = SEAT_THICKNESS_SCALED / 2 + ARM_HEIGHT / 2
+  const armOffsetZ = -ARM_DEPTH / 2 + ARM_THICKNESS * 0.2
+  const leftArm = new THREE.Mesh(armGeometry, seatMaterial)
+  leftArm.position.set(-armOffsetX, armOffsetY, armOffsetZ)
+  const rightArm = new THREE.Mesh(armGeometry, seatMaterial)
+  rightArm.position.set(armOffsetX, armOffsetY, armOffsetZ)
+  const legMesh = new THREE.Mesh(
+    new THREE.CylinderGeometry(0.16 * MODEL_SCALE * STOOL_SCALE, 0.2 * MODEL_SCALE * STOOL_SCALE, BASE_COLUMN_HEIGHT, 18),
+    legMaterial
+  )
+  legMesh.position.y = -SEAT_THICKNESS_SCALED / 2 - BASE_COLUMN_HEIGHT / 2
+  const foot = new THREE.Mesh(
+    new THREE.CylinderGeometry(0.32 * MODEL_SCALE * STOOL_SCALE, 0.32 * MODEL_SCALE * STOOL_SCALE, 0.08 * MODEL_SCALE, 24),
+    legMaterial
+  )
+  foot.position.y = legMesh.position.y - BASE_COLUMN_HEIGHT / 2 - 0.04 * MODEL_SCALE
+  ;[seatMesh, backMesh, leftArm, rightArm, legMesh, foot].forEach((mesh) => {
+    mesh.castShadow = true
+    mesh.receiveShadow = true
+    chair.add(mesh)
+  })
+  return chair
+}
+
+const pointBasePosition = (index) => {
+  if (index <= 11) {
+    const col = index < 6 ? index : index + 1
+    return {
+      x: BOARD_HALF_X - POINT_START_X - col * POINT_WIDTH,
+      z: BOARD_HALF_Z - 0.08,
+      top: false
+    }
+  }
+  const i = 23 - index
+  const col = i < 6 ? i : i + 1
+  return {
+    x: -BOARD_HALF_X + POINT_START_X + col * POINT_WIDTH,
+    z: -BOARD_HALF_Z + 0.08,
+    top: true
+  }
+}
 
 export default function TavullBattleRoyal() {
-  return <CheckersBattleRoyal />;
+  useTelegramBackButton()
+  const canvasHostRef = useRef(null)
+  const sceneBundleRef = useRef(null)
+
+  const [game, setGame] = useState({ points: initialBoard(), bar: { white: 0, black: 0 }, off: { white: 0, black: 0 } })
+  const [dice, setDice] = useState([])
+  const [available, setAvailable] = useState([])
+  const [message, setMessage] = useState('Roll to start. You are White.')
+  const [aiThinking, setAiThinking] = useState(false)
+  const [configOpen, setConfigOpen] = useState(false)
+  const playerName = getTelegramFirstName() || 'Player'
+  const playerAvatar = getTelegramPhotoUrl()
+
+  const winner = game.off.white >= 15 ? WHITE : game.off.black >= 15 ? BLACK : null
+
+  const players = [
+    {
+      index: 0,
+      name: playerName,
+      photoUrl: playerAvatar || '/assets/icons/profile.svg',
+      color: 'white',
+      isTurn: !aiThinking && !winner
+    },
+    {
+      index: 1,
+      name: 'AI Royal',
+      photoUrl: '/assets/icons/profile.svg',
+      color: 'black',
+      isTurn: aiThinking
+    }
+  ]
+
+  const legalStarts = useMemo(() => {
+    const starts = new Set()
+    available.forEach((seq) => {
+      if (seq.line[0]) starts.add(String(seq.line[0].from))
+    })
+    return starts
+  }, [available])
+
+  useEffect(() => {
+    if (!canvasHostRef.current) return undefined
+
+    const host = canvasHostRef.current
+    const scene = new THREE.Scene()
+    scene.background = new THREE.Color('#090f1f')
+
+    const camera = new THREE.PerspectiveCamera(42, host.clientWidth / host.clientHeight, 0.1, 120)
+    camera.position.set(0, 4.9, 5.6)
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: false })
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2))
+    renderer.setSize(host.clientWidth, host.clientHeight)
+    renderer.shadowMap.enabled = true
+    host.appendChild(renderer.domElement)
+
+    const controls = new OrbitControls(camera, renderer.domElement)
+    controls.enablePan = false
+    controls.enableDamping = true
+    controls.maxPolarAngle = Math.PI * 0.48
+    controls.minDistance = 4.4
+    controls.maxDistance = 7.4
+    controls.target.set(0, TABLE_HEIGHT, 0)
+
+    scene.add(new THREE.AmbientLight('#ffffff', 0.5))
+    const key = new THREE.DirectionalLight('#ffffff', 1.15)
+    key.position.set(5, 8, 3)
+    key.castShadow = true
+    scene.add(key)
+
+    const fill = new THREE.PointLight('#6ec4ff', 0.7, 30)
+    fill.position.set(-4, 4.5, -3)
+    scene.add(fill)
+
+    new RGBELoader().load(
+      'https://dl.polyhaven.org/file/ph-assets/HDRIs/hdr/1k/colorful_studio_1k.hdr',
+      (texture) => {
+        texture.mapping = THREE.EquirectangularReflectionMapping
+        scene.environment = texture
+      },
+      undefined,
+      () => {}
+    )
+
+    const table = createMurlanStyleTable({ arena: scene, renderer, tableRadius: TABLE_RADIUS, tableHeight: TABLE_HEIGHT })
+    applyTableMaterials(table.parts, MURLAN_TABLE_FINISHES[0])
+
+    const chairA = createArenaChairFallback('#8b1d2c', '#111827')
+    chairA.position.set(0, CHAIR_BASE_HEIGHT, CHAIR_DISTANCE)
+    chairA.rotation.y = Math.PI
+    scene.add(chairA)
+    const chairB = createArenaChairFallback('#8b1d2c', '#111827')
+    chairB.position.set(0, CHAIR_BASE_HEIGHT, -CHAIR_DISTANCE)
+    scene.add(chairB)
+
+    const boardRoot = new THREE.Group()
+    scene.add(boardRoot)
+
+    const boardBase = new THREE.Mesh(
+      new THREE.BoxGeometry(BOARD_HALF_X * 2, 0.12, BOARD_HALF_Z * 2),
+      new THREE.MeshStandardMaterial({ color: '#744225', roughness: 0.5, metalness: 0.16 })
+    )
+    boardBase.position.y = BOARD_Y
+    boardRoot.add(boardBase)
+
+    const felt = new THREE.Mesh(
+      new THREE.BoxGeometry(BOARD_HALF_X * 1.94, 0.03, BOARD_HALF_Z * 1.92),
+      new THREE.MeshStandardMaterial({ color: '#174a32', roughness: 0.9, metalness: 0.02 })
+    )
+    felt.position.y = BOARD_Y + 0.1
+    boardRoot.add(felt)
+
+    const bar = new THREE.Mesh(
+      new THREE.BoxGeometry(0.14, 0.06, BOARD_HALF_Z * 1.88),
+      new THREE.MeshStandardMaterial({ color: '#5e3018', roughness: 0.6, metalness: 0.08 })
+    )
+    bar.position.y = BOARD_Y + 0.11
+    boardRoot.add(bar)
+
+    const makeTriangle = (x, z, top, dark) => {
+      const shape = new THREE.Shape()
+      if (top) {
+        shape.moveTo(-0.08, 0)
+        shape.lineTo(0.08, 0)
+        shape.lineTo(0, 0.72)
+      } else {
+        shape.moveTo(-0.08, 0)
+        shape.lineTo(0.08, 0)
+        shape.lineTo(0, -0.72)
+      }
+      shape.closePath()
+      const geom = new THREE.ExtrudeGeometry(shape, { depth: 0.02, bevelEnabled: false })
+      geom.rotateX(-Math.PI / 2)
+      const tri = new THREE.Mesh(
+        geom,
+        new THREE.MeshStandardMaterial({ color: dark ? '#7a2f1d' : '#d8b07d', roughness: 0.72, metalness: 0.05 })
+      )
+      tri.position.set(x, BOARD_Y + 0.13, z)
+      boardRoot.add(tri)
+    }
+
+    for (let i = 0; i < 24; i += 1) {
+      const p = pointBasePosition(i)
+      makeTriangle(p.x, p.z, p.top, i % 2 === 0)
+    }
+
+    const chipGroup = new THREE.Group()
+    scene.add(chipGroup)
+
+    const resize = () => {
+      if (!host) return
+      const width = host.clientWidth
+      const height = host.clientHeight
+      camera.aspect = width / height
+      camera.updateProjectionMatrix()
+      renderer.setSize(width, height)
+    }
+    window.addEventListener('resize', resize)
+
+    let raf = 0
+    const tick = () => {
+      controls.update()
+      renderer.render(scene, camera)
+      raf = window.requestAnimationFrame(tick)
+    }
+    tick()
+
+    sceneBundleRef.current = { scene, camera, renderer, controls, chipGroup }
+
+    return () => {
+      window.cancelAnimationFrame(raf)
+      window.removeEventListener('resize', resize)
+      controls.dispose()
+      renderer.dispose()
+      host.removeChild(renderer.domElement)
+      sceneBundleRef.current = null
+    }
+  }, [])
+
+  useEffect(() => {
+    const bundle = sceneBundleRef.current
+    if (!bundle) return
+    const { chipGroup } = bundle
+    chipGroup.clear()
+
+    const createChip = (color) => {
+      const mesh = new THREE.Mesh(
+        new THREE.CylinderGeometry(0.07, 0.07, 0.045, 28),
+        new THREE.MeshStandardMaterial({
+          color: color === WHITE ? '#f2f2f2' : '#191919',
+          roughness: 0.35,
+          metalness: 0.18
+        })
+      )
+      mesh.castShadow = true
+      return mesh
+    }
+
+    for (let i = 0; i < 24; i += 1) {
+      const point = game.points[i]
+      if (!point.color || point.count <= 0) continue
+      const base = pointBasePosition(i)
+      for (let s = 0; s < point.count; s += 1) {
+        const chip = createChip(point.color)
+        const stack = Math.floor(s / 5)
+        const layer = s % 5
+        chip.position.set(
+          base.x,
+          BOARD_Y + 0.16 + layer * 0.07,
+          base.z + (base.top ? 1 : -1) * (0.12 * stack)
+        )
+        chipGroup.add(chip)
+      }
+    }
+
+    const makeBarChips = (count, color, zSign) => {
+      for (let s = 0; s < count; s += 1) {
+        const chip = createChip(color)
+        chip.position.set(0, BOARD_Y + 0.16 + (s % 6) * 0.07, zSign * (0.08 + Math.floor(s / 6) * 0.12))
+        chipGroup.add(chip)
+      }
+    }
+
+    makeBarChips(game.bar.white, WHITE, -1)
+    makeBarChips(game.bar.black, BLACK, 1)
+  }, [game])
+
+  const playAi = (stateAfterPlayer) => {
+    const d1 = 1 + Math.floor(Math.random() * 6)
+    const d2 = 1 + Math.floor(Math.random() * 6)
+    const aiDice = d1 === d2 ? [d1, d1, d1, d1] : [d1, d2]
+    setMessage(`AI rolled ${d1} and ${d2}.`)
+    setAiThinking(true)
+
+    setTimeout(() => {
+      const choice = pickAiSequence(stateAfterPlayer, aiDice)
+      if (!choice || !choice.line.length) {
+        setMessage(`AI rolled ${d1}/${d2} but had no legal move. Your turn.`)
+        setAiThinking(false)
+        setDice([])
+        setAvailable([])
+        return
+      }
+      setGame(choice.resultingState)
+      setMessage(`AI played ${choice.line.length} move(s). Your turn.`)
+      setAiThinking(false)
+      setDice([])
+      setAvailable([])
+    }, 700)
+  }
+
+  const roll = () => {
+    if (aiThinking || winner || available.length > 0) return
+    const d1 = 1 + Math.floor(Math.random() * 6)
+    const d2 = 1 + Math.floor(Math.random() * 6)
+    const useDice = d1 === d2 ? [d1, d1, d1, d1] : [d1, d2]
+    const seq = collectTurnSequences(game, WHITE, useDice)
+    setDice(useDice)
+    setAvailable(seq)
+    if (!seq.length || !seq.some((s) => s.line.length)) {
+      setMessage(`You rolled ${d1}/${d2} but no legal move. AI turn.`)
+      playAi(game)
+      return
+    }
+    setMessage('Tap a highlighted point button below to play your legal turn.')
+  }
+
+  const handlePoint = (index) => {
+    if (!available.length || aiThinking || winner) return
+    const matching = available.find((s) => String(s.line[0]?.from) === String(index))
+    if (!matching) return
+    setGame(matching.resultingState)
+    setAvailable([])
+    setDice([])
+    setMessage('You played. AI is thinking…')
+    playAi(matching.resultingState)
+  }
+
+  return (
+    <div className="fixed inset-0 bg-[#060b16] px-3 py-3 text-white touch-none select-none">
+      <div className="absolute top-20 left-4 z-20 flex flex-col items-start gap-3 pointer-events-none">
+        <button
+          type="button"
+          onClick={() => setConfigOpen((open) => !open)}
+          aria-expanded={configOpen}
+          aria-label={configOpen ? 'Close game menu' : 'Open game menu'}
+          className="pointer-events-auto flex items-center gap-2 rounded-full border border-white/15 bg-black/60 px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-gray-100 shadow-[0_6px_18px_rgba(2,6,23,0.45)] transition hover:border-white/30 hover:text-white"
+        >
+          <span className="text-base leading-none" aria-hidden="true">☰</span>
+          <span className="leading-none">Menu</span>
+        </button>
+      </div>
+
+      <div className="absolute top-20 right-4 z-20 flex flex-col items-end gap-3 pointer-events-none">
+        <div className="pointer-events-auto flex flex-col items-end gap-3">
+          <BottomLeftIcons
+            showInfo={false}
+            showChat={false}
+            showGift={false}
+            className="flex flex-col"
+            buttonClassName="icon-only-button pointer-events-auto flex h-10 w-10 items-center justify-center text-white/90 transition-opacity duration-200 hover:text-white focus:outline-none"
+            iconClassName="text-[1.5rem] leading-none"
+            labelClassName="sr-only"
+            muteIconOn="🔇"
+            muteIconOff="🔊"
+            order={['mute']}
+          />
+        </div>
+      </div>
+
+      {configOpen && (
+        <div className="absolute top-32 right-4 z-30 pointer-events-auto mt-2 w-72 max-w-[80vw] rounded-2xl border border-white/15 bg-black/80 p-4 text-xs text-white shadow-2xl backdrop-blur">
+          <div className="text-[10px] uppercase tracking-[0.4em] text-sky-200/80">Backgammon Settings</div>
+          <div className="mt-2 text-white/70">Roll, select highlighted points, and bear off all 15 checkers to win.</div>
+        </div>
+      )}
+
+      <div className="absolute inset-0 overflow-hidden rounded-2xl border border-white/10 bg-black/30">
+        <div ref={canvasHostRef} className="h-full w-full" />
+      </div>
+
+      <div className="absolute bottom-36 left-1/2 z-20 flex -translate-x-1/2 flex-wrap items-center justify-center gap-2">
+        {dice.length > 0 ? <Dice values={dice} rolling={false} /> : null}
+      </div>
+
+
+      <div className="absolute bottom-20 left-1/2 z-20 grid w-[94vw] max-w-md -translate-x-1/2 grid-cols-6 gap-1">
+        {Array.from({ length: 24 }, (_, i) => (
+          <button
+            key={`point-${i}`}
+            type="button"
+            onClick={() => handlePoint(i)}
+            className={`rounded-lg border px-1 py-1 text-[10px] ${legalStarts.has(String(i)) ? 'border-cyan-300 bg-cyan-500/20' : 'border-white/15 bg-white/5'}`}
+          >
+            P{i + 1}
+          </button>
+        ))}
+      </div>
+
+      <div className="absolute bottom-3 left-1/2 z-20 flex w-[94vw] max-w-sm -translate-x-1/2 gap-2">
+        <button type="button" onClick={roll} disabled={aiThinking || winner || available.length > 0} className="flex-1 rounded-xl bg-cyan-400 px-4 py-2 font-bold text-black disabled:opacity-50">
+          Roll Dice
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            setGame({ points: initialBoard(), bar: { white: 0, black: 0 }, off: { white: 0, black: 0 } })
+            setDice([])
+            setAvailable([])
+            setMessage('New game started. Roll to begin.')
+          }}
+          className="rounded-xl border border-white/30 px-4 py-2"
+        >
+          Reset
+        </button>
+      </div>
+
+      <div className="pointer-events-auto">
+        <BottomLeftIcons
+          onGift={() => {}}
+          showInfo={false}
+          showChat={false}
+          showMute={false}
+          className="fixed right-3 bottom-28 z-50 flex flex-col gap-4"
+          buttonClassName="icon-only-button pointer-events-auto flex h-11 w-11 items-center justify-center text-white/90 transition-opacity duration-200 hover:text-white focus:outline-none"
+          iconClassName="text-[1.65rem] leading-none"
+          labelClassName="sr-only"
+          giftIcon="🎁"
+          order={['gift']}
+        />
+        <BottomLeftIcons
+          onChat={() => {}}
+          showInfo={false}
+          showGift={false}
+          showMute={false}
+          className="fixed left-3 bottom-28 z-50 flex flex-col"
+          buttonClassName="icon-only-button pointer-events-auto flex h-11 w-11 items-center justify-center text-white/90 transition-opacity duration-200 hover:text-white focus:outline-none"
+          iconClassName="text-[1.65rem] leading-none"
+          labelClassName="sr-only"
+          chatIcon="💬"
+          order={['chat']}
+        />
+      </div>
+
+      <div className="absolute inset-0 z-10 pointer-events-none">
+        {players.map((player) => {
+          const fallback = FALLBACK_SEAT_POSITIONS[player.index] || FALLBACK_SEAT_POSITIONS[0]
+          const positionStyle = {
+            position: 'absolute',
+            left: fallback.left,
+            top: fallback.top,
+            transform: 'translate(-50%, -50%)'
+          }
+          return (
+            <div
+              key={`backgammon-seat-${player.index}`}
+              className="absolute pointer-events-auto flex flex-col items-center"
+              style={positionStyle}
+            >
+              <AvatarTimer
+                index={player.index}
+                photoUrl={player.photoUrl}
+                active={player.isTurn}
+                isTurn={player.isTurn}
+                timerPct={1}
+                name={player.name}
+                color={player.color}
+                size={1}
+              />
+              <span className="mt-1 text-[0.65rem] font-semibold text-white drop-shadow-[0_2px_6px_rgba(0,0,0,0.6)]">
+                {player.name}
+              </span>
+            </div>
+          )
+        })}
+      </div>
+
+      <div className="absolute bottom-10 left-1/2 -translate-x-1/2 pointer-events-none">
+        <div className="px-5 py-2 rounded-full bg-[rgba(7,10,18,0.65)] border border-[rgba(255,215,0,0.25)] text-sm font-semibold backdrop-blur">
+          {winner ? `${winner === WHITE ? 'You' : 'AI'} win!` : message}
+        </div>
+      </div>
+    </div>
+  )
 }

--- a/webapp/src/pages/Games/TavullBattleRoyalLobby.jsx
+++ b/webapp/src/pages/Games/TavullBattleRoyalLobby.jsx
@@ -228,7 +228,7 @@ export default function TavullBattleRoyalLobby() {
       'seatTable',
       {
         accountId: trackedAccountId || accountId,
-        gameType: 'checkers',
+        gameType: 'backgammon',
         stake: stake.amount ?? 0,
         maxPlayers: 2,
         playerName: friendlyName,
@@ -257,7 +257,7 @@ export default function TavullBattleRoyalLobby() {
       <div className="relative z-10 space-y-4 p-4 pb-8">
         <GameLobbyHeader
           slug="tavullbattleroyal"
-          title="Tavull Battle Royal Lobby"
+          title="Backgammon Royal Lobby"
           badge={onlineCount != null ? `${onlineCount} online` : 'Syncing…'}
         />
 

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -688,7 +688,7 @@ const storeMeta = {
     accountId: CHESS_STORE_ACCOUNT_ID
   },
   tavullbattleroyal: {
-    name: 'Tavull Battle Royal',
+    name: 'Backgammon Royal',
     items: CHESS_BATTLE_STORE_ITEMS,
     defaults: CHESS_BATTLE_DEFAULT_LOADOUT,
     labels: CHESS_BATTLE_OPTION_LABELS,


### PR DESCRIPTION
### Motivation
- Introduce a playable Backgammon experience (previously called Tavull) with an in-app 3D board and simple AI, and unify naming across the app and store. 
- Provide an interactive single-player flow (roll, move, bear off) for quick matches in the Battle Royal collection. 
- Update lobby and catalog metadata so online matchmaking and UI copy reflect the Backgammon product name.

### Description
- Implemented a full Backgammon game screen in `src/pages/Games/TavullBattleRoyal.jsx` including Three.js scene setup, table/chair rendering, chip stacking, dice UI, move generation, turn sequencing, a heuristic AI (`pickAiSequence`) and basic game controls (`roll`, `handlePoint`, `Reset`).
- Updated routing/UI text fallbacks in `src/App.jsx` from "Tavull" to "Backgammon" for lobby and game suspense fallbacks. 
- Renamed the game entry in `src/config/gamesCatalog.js` to `Backgammon Royal` and improved its description; updated lobby and matchmaking code in `src/pages/Games/TavullBattleRoyalLobby.jsx` to emit `gameType: 'backgammon'` and changed the lobby title to "Backgammon Royal Lobby". 
- Updated store metadata in `src/pages/Store.jsx` to show `name: 'Backgammon Royal'` for the `tavullbattleroyal` key.

### Testing
- Ran the project build with `yarn build` and the test suite with `yarn test`, and both completed successfully. 
- Exercised the new game flow in a local dev run and verified dice rolls, AI turns, and UI controls (no new unit tests were added for the Backgammon logic).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6e8a7f6c883298ca2305f91281a93)