### PR TITLE
Add Baduk Battle Royal mode with board assets, inventory, and 3D UI

### DIFF
--- a/webapp/public/assets/game-art/.gitignore
+++ b/webapp/public/assets/game-art/.gitignore
@@ -9,3 +9,5 @@
 !variants/pool-royale/*.svg
 !chess-battle-royal/
 !chess-battle-royal/**
+!baduk-battle-royal/
+!baduk-battle-royal/**

--- a/webapp/public/assets/game-art/baduk-battle-royal/boards/13x13.svg
+++ b/webapp/public/assets/game-art/baduk-battle-royal/boards/13x13.svg
@@ -1,0 +1,82 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1400 1400" role="img" aria-label="Baduk 13x13 board">
+  <defs>
+    <linearGradient id="wood" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#e9c27d"/>
+      <stop offset="55%" stop-color="#d6a35d"/>
+      <stop offset="100%" stop-color="#b57b39"/>
+    </linearGradient>
+    <filter id="grain" x="-20%" y="-20%" width="140%" height="140%">
+      <feTurbulence type="fractalNoise" baseFrequency="0.65" numOctaves="2" seed="13"/>
+      <feColorMatrix type="saturate" values="0.15"/>
+      <feComponentTransfer><feFuncA type="table" tableValues="0 0.08"/></feComponentTransfer>
+    </filter>
+    <style>
+      .grid { stroke:#2f1a08; stroke-width:3.6; stroke-linecap:round; opacity:0.9; }
+      .star { fill:#201205; }
+      .label { fill:#3a1f0c; font-family:Inter,system-ui,sans-serif; font-size:28px; font-weight:600; opacity:0.75; }
+    </style>
+  </defs>
+  <rect x="0" y="0" width="1400" height="1400" rx="48" fill="url(#wood)"/>
+  <rect x="122" y="122" width="1156" height="1156" rx="14" fill="none" stroke="#5b371a" stroke-width="8" opacity="0.5"/>
+  <rect x="140" y="140" width="1120" height="1120" fill="none" stroke="#2f1a08" stroke-width="4" opacity="0.7"/>
+  <rect x="0" y="0" width="1400" height="1400" rx="48" filter="url(#grain)"/>
+  <g>
+    <line x1="140.00" y1="140" x2="140.00" y2="1260" class="grid"/>
+    <line x1="140" y1="140.00" x2="1260" y2="140.00" class="grid"/>
+    <line x1="233.33" y1="140" x2="233.33" y2="1260" class="grid"/>
+    <line x1="140" y1="233.33" x2="1260" y2="233.33" class="grid"/>
+    <line x1="326.67" y1="140" x2="326.67" y2="1260" class="grid"/>
+    <line x1="140" y1="326.67" x2="1260" y2="326.67" class="grid"/>
+    <line x1="420.00" y1="140" x2="420.00" y2="1260" class="grid"/>
+    <line x1="140" y1="420.00" x2="1260" y2="420.00" class="grid"/>
+    <line x1="513.33" y1="140" x2="513.33" y2="1260" class="grid"/>
+    <line x1="140" y1="513.33" x2="1260" y2="513.33" class="grid"/>
+    <line x1="606.67" y1="140" x2="606.67" y2="1260" class="grid"/>
+    <line x1="140" y1="606.67" x2="1260" y2="606.67" class="grid"/>
+    <line x1="700.00" y1="140" x2="700.00" y2="1260" class="grid"/>
+    <line x1="140" y1="700.00" x2="1260" y2="700.00" class="grid"/>
+    <line x1="793.33" y1="140" x2="793.33" y2="1260" class="grid"/>
+    <line x1="140" y1="793.33" x2="1260" y2="793.33" class="grid"/>
+    <line x1="886.67" y1="140" x2="886.67" y2="1260" class="grid"/>
+    <line x1="140" y1="886.67" x2="1260" y2="886.67" class="grid"/>
+    <line x1="980.00" y1="140" x2="980.00" y2="1260" class="grid"/>
+    <line x1="140" y1="980.00" x2="1260" y2="980.00" class="grid"/>
+    <line x1="1073.33" y1="140" x2="1073.33" y2="1260" class="grid"/>
+    <line x1="140" y1="1073.33" x2="1260" y2="1073.33" class="grid"/>
+    <line x1="1166.67" y1="140" x2="1166.67" y2="1260" class="grid"/>
+    <line x1="140" y1="1166.67" x2="1260" y2="1166.67" class="grid"/>
+    <line x1="1260.00" y1="140" x2="1260.00" y2="1260" class="grid"/>
+    <line x1="140" y1="1260.00" x2="1260" y2="1260.00" class="grid"/>
+    <circle cx="420.00" cy="420.00" r="10" class="star"/>
+    <circle cx="980.00" cy="420.00" r="10" class="star"/>
+    <circle cx="420.00" cy="980.00" r="10" class="star"/>
+    <circle cx="980.00" cy="980.00" r="10" class="star"/>
+    <circle cx="700.00" cy="700.00" r="10" class="star"/>
+  </g>
+    <text x="140.00" y="1308" class="label" text-anchor="middle">A</text>
+    <text x="233.33" y="1308" class="label" text-anchor="middle">B</text>
+    <text x="326.67" y="1308" class="label" text-anchor="middle">C</text>
+    <text x="420.00" y="1308" class="label" text-anchor="middle">D</text>
+    <text x="513.33" y="1308" class="label" text-anchor="middle">E</text>
+    <text x="606.67" y="1308" class="label" text-anchor="middle">F</text>
+    <text x="700.00" y="1308" class="label" text-anchor="middle">G</text>
+    <text x="793.33" y="1308" class="label" text-anchor="middle">H</text>
+    <text x="886.67" y="1308" class="label" text-anchor="middle">J</text>
+    <text x="980.00" y="1308" class="label" text-anchor="middle">K</text>
+    <text x="1073.33" y="1308" class="label" text-anchor="middle">L</text>
+    <text x="1166.67" y="1308" class="label" text-anchor="middle">M</text>
+    <text x="1260.00" y="1308" class="label" text-anchor="middle">N</text>
+    <text x="92" y="146.00" class="label" text-anchor="middle">13</text>
+    <text x="92" y="239.33" class="label" text-anchor="middle">12</text>
+    <text x="92" y="332.67" class="label" text-anchor="middle">11</text>
+    <text x="92" y="426.00" class="label" text-anchor="middle">10</text>
+    <text x="92" y="519.33" class="label" text-anchor="middle">9</text>
+    <text x="92" y="612.67" class="label" text-anchor="middle">8</text>
+    <text x="92" y="706.00" class="label" text-anchor="middle">7</text>
+    <text x="92" y="799.33" class="label" text-anchor="middle">6</text>
+    <text x="92" y="892.67" class="label" text-anchor="middle">5</text>
+    <text x="92" y="986.00" class="label" text-anchor="middle">4</text>
+    <text x="92" y="1079.33" class="label" text-anchor="middle">3</text>
+    <text x="92" y="1172.67" class="label" text-anchor="middle">2</text>
+    <text x="92" y="1266.00" class="label" text-anchor="middle">1</text>
+</svg>

--- a/webapp/public/assets/game-art/baduk-battle-royal/boards/16x16.svg
+++ b/webapp/public/assets/game-art/baduk-battle-royal/boards/16x16.svg
@@ -1,0 +1,97 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1400 1400" role="img" aria-label="Baduk 16x16 board">
+  <defs>
+    <linearGradient id="wood" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#e9c27d"/>
+      <stop offset="55%" stop-color="#d6a35d"/>
+      <stop offset="100%" stop-color="#b57b39"/>
+    </linearGradient>
+    <filter id="grain" x="-20%" y="-20%" width="140%" height="140%">
+      <feTurbulence type="fractalNoise" baseFrequency="0.65" numOctaves="2" seed="16"/>
+      <feColorMatrix type="saturate" values="0.15"/>
+      <feComponentTransfer><feFuncA type="table" tableValues="0 0.08"/></feComponentTransfer>
+    </filter>
+    <style>
+      .grid { stroke:#2f1a08; stroke-width:3.6; stroke-linecap:round; opacity:0.9; }
+      .star { fill:#201205; }
+      .label { fill:#3a1f0c; font-family:Inter,system-ui,sans-serif; font-size:28px; font-weight:600; opacity:0.75; }
+    </style>
+  </defs>
+  <rect x="0" y="0" width="1400" height="1400" rx="48" fill="url(#wood)"/>
+  <rect x="122" y="122" width="1156" height="1156" rx="14" fill="none" stroke="#5b371a" stroke-width="8" opacity="0.5"/>
+  <rect x="140" y="140" width="1120" height="1120" fill="none" stroke="#2f1a08" stroke-width="4" opacity="0.7"/>
+  <rect x="0" y="0" width="1400" height="1400" rx="48" filter="url(#grain)"/>
+  <g>
+    <line x1="140.00" y1="140" x2="140.00" y2="1260" class="grid"/>
+    <line x1="140" y1="140.00" x2="1260" y2="140.00" class="grid"/>
+    <line x1="214.67" y1="140" x2="214.67" y2="1260" class="grid"/>
+    <line x1="140" y1="214.67" x2="1260" y2="214.67" class="grid"/>
+    <line x1="289.33" y1="140" x2="289.33" y2="1260" class="grid"/>
+    <line x1="140" y1="289.33" x2="1260" y2="289.33" class="grid"/>
+    <line x1="364.00" y1="140" x2="364.00" y2="1260" class="grid"/>
+    <line x1="140" y1="364.00" x2="1260" y2="364.00" class="grid"/>
+    <line x1="438.67" y1="140" x2="438.67" y2="1260" class="grid"/>
+    <line x1="140" y1="438.67" x2="1260" y2="438.67" class="grid"/>
+    <line x1="513.33" y1="140" x2="513.33" y2="1260" class="grid"/>
+    <line x1="140" y1="513.33" x2="1260" y2="513.33" class="grid"/>
+    <line x1="588.00" y1="140" x2="588.00" y2="1260" class="grid"/>
+    <line x1="140" y1="588.00" x2="1260" y2="588.00" class="grid"/>
+    <line x1="662.67" y1="140" x2="662.67" y2="1260" class="grid"/>
+    <line x1="140" y1="662.67" x2="1260" y2="662.67" class="grid"/>
+    <line x1="737.33" y1="140" x2="737.33" y2="1260" class="grid"/>
+    <line x1="140" y1="737.33" x2="1260" y2="737.33" class="grid"/>
+    <line x1="812.00" y1="140" x2="812.00" y2="1260" class="grid"/>
+    <line x1="140" y1="812.00" x2="1260" y2="812.00" class="grid"/>
+    <line x1="886.67" y1="140" x2="886.67" y2="1260" class="grid"/>
+    <line x1="140" y1="886.67" x2="1260" y2="886.67" class="grid"/>
+    <line x1="961.33" y1="140" x2="961.33" y2="1260" class="grid"/>
+    <line x1="140" y1="961.33" x2="1260" y2="961.33" class="grid"/>
+    <line x1="1036.00" y1="140" x2="1036.00" y2="1260" class="grid"/>
+    <line x1="140" y1="1036.00" x2="1260" y2="1036.00" class="grid"/>
+    <line x1="1110.67" y1="140" x2="1110.67" y2="1260" class="grid"/>
+    <line x1="140" y1="1110.67" x2="1260" y2="1110.67" class="grid"/>
+    <line x1="1185.33" y1="140" x2="1185.33" y2="1260" class="grid"/>
+    <line x1="140" y1="1185.33" x2="1260" y2="1185.33" class="grid"/>
+    <line x1="1260.00" y1="140" x2="1260.00" y2="1260" class="grid"/>
+    <line x1="140" y1="1260.00" x2="1260" y2="1260.00" class="grid"/>
+    <circle cx="364.00" cy="364.00" r="10" class="star"/>
+    <circle cx="1036.00" cy="364.00" r="10" class="star"/>
+    <circle cx="364.00" cy="1036.00" r="10" class="star"/>
+    <circle cx="1036.00" cy="1036.00" r="10" class="star"/>
+    <circle cx="662.67" cy="662.67" r="10" class="star"/>
+    <circle cx="737.33" cy="662.67" r="10" class="star"/>
+    <circle cx="662.67" cy="737.33" r="10" class="star"/>
+    <circle cx="737.33" cy="737.33" r="10" class="star"/>
+  </g>
+    <text x="140.00" y="1308" class="label" text-anchor="middle">A</text>
+    <text x="214.67" y="1308" class="label" text-anchor="middle">B</text>
+    <text x="289.33" y="1308" class="label" text-anchor="middle">C</text>
+    <text x="364.00" y="1308" class="label" text-anchor="middle">D</text>
+    <text x="438.67" y="1308" class="label" text-anchor="middle">E</text>
+    <text x="513.33" y="1308" class="label" text-anchor="middle">F</text>
+    <text x="588.00" y="1308" class="label" text-anchor="middle">G</text>
+    <text x="662.67" y="1308" class="label" text-anchor="middle">H</text>
+    <text x="737.33" y="1308" class="label" text-anchor="middle">J</text>
+    <text x="812.00" y="1308" class="label" text-anchor="middle">K</text>
+    <text x="886.67" y="1308" class="label" text-anchor="middle">L</text>
+    <text x="961.33" y="1308" class="label" text-anchor="middle">M</text>
+    <text x="1036.00" y="1308" class="label" text-anchor="middle">N</text>
+    <text x="1110.67" y="1308" class="label" text-anchor="middle">O</text>
+    <text x="1185.33" y="1308" class="label" text-anchor="middle">P</text>
+    <text x="1260.00" y="1308" class="label" text-anchor="middle">Q</text>
+    <text x="92" y="146.00" class="label" text-anchor="middle">16</text>
+    <text x="92" y="220.67" class="label" text-anchor="middle">15</text>
+    <text x="92" y="295.33" class="label" text-anchor="middle">14</text>
+    <text x="92" y="370.00" class="label" text-anchor="middle">13</text>
+    <text x="92" y="444.67" class="label" text-anchor="middle">12</text>
+    <text x="92" y="519.33" class="label" text-anchor="middle">11</text>
+    <text x="92" y="594.00" class="label" text-anchor="middle">10</text>
+    <text x="92" y="668.67" class="label" text-anchor="middle">9</text>
+    <text x="92" y="743.33" class="label" text-anchor="middle">8</text>
+    <text x="92" y="818.00" class="label" text-anchor="middle">7</text>
+    <text x="92" y="892.67" class="label" text-anchor="middle">6</text>
+    <text x="92" y="967.33" class="label" text-anchor="middle">5</text>
+    <text x="92" y="1042.00" class="label" text-anchor="middle">4</text>
+    <text x="92" y="1116.67" class="label" text-anchor="middle">3</text>
+    <text x="92" y="1191.33" class="label" text-anchor="middle">2</text>
+    <text x="92" y="1266.00" class="label" text-anchor="middle">1</text>
+</svg>

--- a/webapp/public/assets/game-art/baduk-battle-royal/boards/19x19.svg
+++ b/webapp/public/assets/game-art/baduk-battle-royal/boards/19x19.svg
@@ -1,0 +1,110 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1400 1400" role="img" aria-label="Baduk 19x19 board">
+  <defs>
+    <linearGradient id="wood" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#e9c27d"/>
+      <stop offset="55%" stop-color="#d6a35d"/>
+      <stop offset="100%" stop-color="#b57b39"/>
+    </linearGradient>
+    <filter id="grain" x="-20%" y="-20%" width="140%" height="140%">
+      <feTurbulence type="fractalNoise" baseFrequency="0.65" numOctaves="2" seed="19"/>
+      <feColorMatrix type="saturate" values="0.15"/>
+      <feComponentTransfer><feFuncA type="table" tableValues="0 0.08"/></feComponentTransfer>
+    </filter>
+    <style>
+      .grid { stroke:#2f1a08; stroke-width:3.6; stroke-linecap:round; opacity:0.9; }
+      .star { fill:#201205; }
+      .label { fill:#3a1f0c; font-family:Inter,system-ui,sans-serif; font-size:28px; font-weight:600; opacity:0.75; }
+    </style>
+  </defs>
+  <rect x="0" y="0" width="1400" height="1400" rx="48" fill="url(#wood)"/>
+  <rect x="122" y="122" width="1156" height="1156" rx="14" fill="none" stroke="#5b371a" stroke-width="8" opacity="0.5"/>
+  <rect x="140" y="140" width="1120" height="1120" fill="none" stroke="#2f1a08" stroke-width="4" opacity="0.7"/>
+  <rect x="0" y="0" width="1400" height="1400" rx="48" filter="url(#grain)"/>
+  <g>
+    <line x1="140.00" y1="140" x2="140.00" y2="1260" class="grid"/>
+    <line x1="140" y1="140.00" x2="1260" y2="140.00" class="grid"/>
+    <line x1="202.22" y1="140" x2="202.22" y2="1260" class="grid"/>
+    <line x1="140" y1="202.22" x2="1260" y2="202.22" class="grid"/>
+    <line x1="264.44" y1="140" x2="264.44" y2="1260" class="grid"/>
+    <line x1="140" y1="264.44" x2="1260" y2="264.44" class="grid"/>
+    <line x1="326.67" y1="140" x2="326.67" y2="1260" class="grid"/>
+    <line x1="140" y1="326.67" x2="1260" y2="326.67" class="grid"/>
+    <line x1="388.89" y1="140" x2="388.89" y2="1260" class="grid"/>
+    <line x1="140" y1="388.89" x2="1260" y2="388.89" class="grid"/>
+    <line x1="451.11" y1="140" x2="451.11" y2="1260" class="grid"/>
+    <line x1="140" y1="451.11" x2="1260" y2="451.11" class="grid"/>
+    <line x1="513.33" y1="140" x2="513.33" y2="1260" class="grid"/>
+    <line x1="140" y1="513.33" x2="1260" y2="513.33" class="grid"/>
+    <line x1="575.56" y1="140" x2="575.56" y2="1260" class="grid"/>
+    <line x1="140" y1="575.56" x2="1260" y2="575.56" class="grid"/>
+    <line x1="637.78" y1="140" x2="637.78" y2="1260" class="grid"/>
+    <line x1="140" y1="637.78" x2="1260" y2="637.78" class="grid"/>
+    <line x1="700.00" y1="140" x2="700.00" y2="1260" class="grid"/>
+    <line x1="140" y1="700.00" x2="1260" y2="700.00" class="grid"/>
+    <line x1="762.22" y1="140" x2="762.22" y2="1260" class="grid"/>
+    <line x1="140" y1="762.22" x2="1260" y2="762.22" class="grid"/>
+    <line x1="824.44" y1="140" x2="824.44" y2="1260" class="grid"/>
+    <line x1="140" y1="824.44" x2="1260" y2="824.44" class="grid"/>
+    <line x1="886.67" y1="140" x2="886.67" y2="1260" class="grid"/>
+    <line x1="140" y1="886.67" x2="1260" y2="886.67" class="grid"/>
+    <line x1="948.89" y1="140" x2="948.89" y2="1260" class="grid"/>
+    <line x1="140" y1="948.89" x2="1260" y2="948.89" class="grid"/>
+    <line x1="1011.11" y1="140" x2="1011.11" y2="1260" class="grid"/>
+    <line x1="140" y1="1011.11" x2="1260" y2="1011.11" class="grid"/>
+    <line x1="1073.33" y1="140" x2="1073.33" y2="1260" class="grid"/>
+    <line x1="140" y1="1073.33" x2="1260" y2="1073.33" class="grid"/>
+    <line x1="1135.56" y1="140" x2="1135.56" y2="1260" class="grid"/>
+    <line x1="140" y1="1135.56" x2="1260" y2="1135.56" class="grid"/>
+    <line x1="1197.78" y1="140" x2="1197.78" y2="1260" class="grid"/>
+    <line x1="140" y1="1197.78" x2="1260" y2="1197.78" class="grid"/>
+    <line x1="1260.00" y1="140" x2="1260.00" y2="1260" class="grid"/>
+    <line x1="140" y1="1260.00" x2="1260" y2="1260.00" class="grid"/>
+    <circle cx="326.67" cy="326.67" r="10" class="star"/>
+    <circle cx="700.00" cy="326.67" r="10" class="star"/>
+    <circle cx="1073.33" cy="326.67" r="10" class="star"/>
+    <circle cx="326.67" cy="700.00" r="10" class="star"/>
+    <circle cx="700.00" cy="700.00" r="10" class="star"/>
+    <circle cx="1073.33" cy="700.00" r="10" class="star"/>
+    <circle cx="326.67" cy="1073.33" r="10" class="star"/>
+    <circle cx="700.00" cy="1073.33" r="10" class="star"/>
+    <circle cx="1073.33" cy="1073.33" r="10" class="star"/>
+  </g>
+    <text x="140.00" y="1308" class="label" text-anchor="middle">A</text>
+    <text x="202.22" y="1308" class="label" text-anchor="middle">B</text>
+    <text x="264.44" y="1308" class="label" text-anchor="middle">C</text>
+    <text x="326.67" y="1308" class="label" text-anchor="middle">D</text>
+    <text x="388.89" y="1308" class="label" text-anchor="middle">E</text>
+    <text x="451.11" y="1308" class="label" text-anchor="middle">F</text>
+    <text x="513.33" y="1308" class="label" text-anchor="middle">G</text>
+    <text x="575.56" y="1308" class="label" text-anchor="middle">H</text>
+    <text x="637.78" y="1308" class="label" text-anchor="middle">J</text>
+    <text x="700.00" y="1308" class="label" text-anchor="middle">K</text>
+    <text x="762.22" y="1308" class="label" text-anchor="middle">L</text>
+    <text x="824.44" y="1308" class="label" text-anchor="middle">M</text>
+    <text x="886.67" y="1308" class="label" text-anchor="middle">N</text>
+    <text x="948.89" y="1308" class="label" text-anchor="middle">O</text>
+    <text x="1011.11" y="1308" class="label" text-anchor="middle">P</text>
+    <text x="1073.33" y="1308" class="label" text-anchor="middle">Q</text>
+    <text x="1135.56" y="1308" class="label" text-anchor="middle">R</text>
+    <text x="1197.78" y="1308" class="label" text-anchor="middle">S</text>
+    <text x="1260.00" y="1308" class="label" text-anchor="middle">T</text>
+    <text x="92" y="146.00" class="label" text-anchor="middle">19</text>
+    <text x="92" y="208.22" class="label" text-anchor="middle">18</text>
+    <text x="92" y="270.44" class="label" text-anchor="middle">17</text>
+    <text x="92" y="332.67" class="label" text-anchor="middle">16</text>
+    <text x="92" y="394.89" class="label" text-anchor="middle">15</text>
+    <text x="92" y="457.11" class="label" text-anchor="middle">14</text>
+    <text x="92" y="519.33" class="label" text-anchor="middle">13</text>
+    <text x="92" y="581.56" class="label" text-anchor="middle">12</text>
+    <text x="92" y="643.78" class="label" text-anchor="middle">11</text>
+    <text x="92" y="706.00" class="label" text-anchor="middle">10</text>
+    <text x="92" y="768.22" class="label" text-anchor="middle">9</text>
+    <text x="92" y="830.44" class="label" text-anchor="middle">8</text>
+    <text x="92" y="892.67" class="label" text-anchor="middle">7</text>
+    <text x="92" y="954.89" class="label" text-anchor="middle">6</text>
+    <text x="92" y="1017.11" class="label" text-anchor="middle">5</text>
+    <text x="92" y="1079.33" class="label" text-anchor="middle">4</text>
+    <text x="92" y="1141.56" class="label" text-anchor="middle">3</text>
+    <text x="92" y="1203.78" class="label" text-anchor="middle">2</text>
+    <text x="92" y="1266.00" class="label" text-anchor="middle">1</text>
+</svg>

--- a/webapp/public/assets/game-art/baduk-battle-royal/boards/9x9.svg
+++ b/webapp/public/assets/game-art/baduk-battle-royal/boards/9x9.svg
@@ -1,0 +1,66 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1400 1400" role="img" aria-label="Baduk 9x9 board">
+  <defs>
+    <linearGradient id="wood" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#e9c27d"/>
+      <stop offset="55%" stop-color="#d6a35d"/>
+      <stop offset="100%" stop-color="#b57b39"/>
+    </linearGradient>
+    <filter id="grain" x="-20%" y="-20%" width="140%" height="140%">
+      <feTurbulence type="fractalNoise" baseFrequency="0.65" numOctaves="2" seed="9"/>
+      <feColorMatrix type="saturate" values="0.15"/>
+      <feComponentTransfer><feFuncA type="table" tableValues="0 0.08"/></feComponentTransfer>
+    </filter>
+    <style>
+      .grid { stroke:#2f1a08; stroke-width:3.6; stroke-linecap:round; opacity:0.9; }
+      .star { fill:#201205; }
+      .label { fill:#3a1f0c; font-family:Inter,system-ui,sans-serif; font-size:28px; font-weight:600; opacity:0.75; }
+    </style>
+  </defs>
+  <rect x="0" y="0" width="1400" height="1400" rx="48" fill="url(#wood)"/>
+  <rect x="122" y="122" width="1156" height="1156" rx="14" fill="none" stroke="#5b371a" stroke-width="8" opacity="0.5"/>
+  <rect x="140" y="140" width="1120" height="1120" fill="none" stroke="#2f1a08" stroke-width="4" opacity="0.7"/>
+  <rect x="0" y="0" width="1400" height="1400" rx="48" filter="url(#grain)"/>
+  <g>
+    <line x1="140.00" y1="140" x2="140.00" y2="1260" class="grid"/>
+    <line x1="140" y1="140.00" x2="1260" y2="140.00" class="grid"/>
+    <line x1="280.00" y1="140" x2="280.00" y2="1260" class="grid"/>
+    <line x1="140" y1="280.00" x2="1260" y2="280.00" class="grid"/>
+    <line x1="420.00" y1="140" x2="420.00" y2="1260" class="grid"/>
+    <line x1="140" y1="420.00" x2="1260" y2="420.00" class="grid"/>
+    <line x1="560.00" y1="140" x2="560.00" y2="1260" class="grid"/>
+    <line x1="140" y1="560.00" x2="1260" y2="560.00" class="grid"/>
+    <line x1="700.00" y1="140" x2="700.00" y2="1260" class="grid"/>
+    <line x1="140" y1="700.00" x2="1260" y2="700.00" class="grid"/>
+    <line x1="840.00" y1="140" x2="840.00" y2="1260" class="grid"/>
+    <line x1="140" y1="840.00" x2="1260" y2="840.00" class="grid"/>
+    <line x1="980.00" y1="140" x2="980.00" y2="1260" class="grid"/>
+    <line x1="140" y1="980.00" x2="1260" y2="980.00" class="grid"/>
+    <line x1="1120.00" y1="140" x2="1120.00" y2="1260" class="grid"/>
+    <line x1="140" y1="1120.00" x2="1260" y2="1120.00" class="grid"/>
+    <line x1="1260.00" y1="140" x2="1260.00" y2="1260" class="grid"/>
+    <line x1="140" y1="1260.00" x2="1260" y2="1260.00" class="grid"/>
+    <circle cx="420.00" cy="420.00" r="10" class="star"/>
+    <circle cx="980.00" cy="420.00" r="10" class="star"/>
+    <circle cx="420.00" cy="980.00" r="10" class="star"/>
+    <circle cx="980.00" cy="980.00" r="10" class="star"/>
+    <circle cx="700.00" cy="700.00" r="10" class="star"/>
+  </g>
+    <text x="140.00" y="1308" class="label" text-anchor="middle">A</text>
+    <text x="280.00" y="1308" class="label" text-anchor="middle">B</text>
+    <text x="420.00" y="1308" class="label" text-anchor="middle">C</text>
+    <text x="560.00" y="1308" class="label" text-anchor="middle">D</text>
+    <text x="700.00" y="1308" class="label" text-anchor="middle">E</text>
+    <text x="840.00" y="1308" class="label" text-anchor="middle">F</text>
+    <text x="980.00" y="1308" class="label" text-anchor="middle">G</text>
+    <text x="1120.00" y="1308" class="label" text-anchor="middle">H</text>
+    <text x="1260.00" y="1308" class="label" text-anchor="middle">J</text>
+    <text x="92" y="146.00" class="label" text-anchor="middle">9</text>
+    <text x="92" y="286.00" class="label" text-anchor="middle">8</text>
+    <text x="92" y="426.00" class="label" text-anchor="middle">7</text>
+    <text x="92" y="566.00" class="label" text-anchor="middle">6</text>
+    <text x="92" y="706.00" class="label" text-anchor="middle">5</text>
+    <text x="92" y="846.00" class="label" text-anchor="middle">4</text>
+    <text x="92" y="986.00" class="label" text-anchor="middle">3</text>
+    <text x="92" y="1126.00" class="label" text-anchor="middle">2</text>
+    <text x="92" y="1266.00" class="label" text-anchor="middle">1</text>
+</svg>

--- a/webapp/src/config/badukBattleInventoryConfig.js
+++ b/webapp/src/config/badukBattleInventoryConfig.js
@@ -1,0 +1,26 @@
+import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from './murlanThemes.js'
+import { MURLAN_TABLE_FINISHES } from './murlanTableFinishes.js'
+import {
+  POOL_ROYALE_DEFAULT_HDRI_ID,
+  POOL_ROYALE_HDRI_VARIANTS
+} from './poolRoyaleInventoryConfig.js'
+
+const DEFAULT_HDRI_ID = POOL_ROYALE_DEFAULT_HDRI_ID || POOL_ROYALE_HDRI_VARIANTS[0]?.id
+
+const mapStoolThemeToChair = (theme) => ({
+  ...theme,
+  primary: theme.seatColor || theme.primary || '#7c3aed',
+  accent: theme.accent || theme.highlight || theme.seatColor,
+  legColor: theme.legColor || theme.baseColor || '#111827',
+  preserveMaterials: theme.preserveMaterials ?? theme.source === 'polyhaven'
+})
+
+export const BADUK_CHAIR_OPTIONS = Object.freeze([...MURLAN_STOOL_THEMES.map(mapStoolThemeToChair)])
+export const BADUK_TABLE_OPTIONS = Object.freeze([...MURLAN_TABLE_THEMES])
+
+export const BADUK_BATTLE_DEFAULT_LOADOUT = Object.freeze({
+  chairColor: [BADUK_CHAIR_OPTIONS[0]?.id],
+  tables: [BADUK_TABLE_OPTIONS[0]?.id],
+  tableFinish: [MURLAN_TABLE_FINISHES[0]?.id],
+  environmentHdri: [DEFAULT_HDRI_ID]
+})

--- a/webapp/src/pages/Games/BadukBattleRoyal.jsx
+++ b/webapp/src/pages/Games/BadukBattleRoyal.jsx
@@ -5,32 +5,42 @@ import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader.js';
 import { EXRLoader } from 'three/examples/jsm/loaders/EXRLoader.js';
 import { GroundedSkybox } from 'three/examples/jsm/objects/GroundedSkybox.js';
+import { applyRendererSRGB, applySRGBColorSpace } from '../../utils/colorSpace.js';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 import { ARENA_CAMERA_DEFAULTS } from '../../utils/arenaCameraConfig.js';
 import { createMurlanStyleTable, applyTableMaterials } from '../../utils/murlanTable.js';
 import {
-  CHESS_CHAIR_OPTIONS,
-  CHESS_TABLE_OPTIONS,
-  CHESS_BATTLE_DEFAULT_LOADOUT
-} from '../../config/chessBattleInventoryConfig.js';
+  BADUK_CHAIR_OPTIONS,
+  BADUK_TABLE_OPTIONS,
+  BADUK_BATTLE_DEFAULT_LOADOUT
+} from '../../config/badukBattleInventoryConfig.js';
 import {
   POOL_ROYALE_DEFAULT_HDRI_ID,
   POOL_ROYALE_HDRI_VARIANTS
 } from '../../config/poolRoyaleInventoryConfig.js';
 import { MURLAN_TABLE_FINISHES } from '../../config/murlanTableFinishes.js';
-import { chessBattleAccountId, getChessBattleInventory } from '../../utils/chessBattleInventory.js';
+import { getTelegramPhotoUrl, getTelegramUsername } from '../../utils/telegram.js';
+import BottomLeftIcons from '../../components/BottomLeftIcons.jsx';
+import AvatarTimer from '../../components/AvatarTimer.jsx';
+import { badukBattleAccountId, getBadukBattleInventory } from '../../utils/badukBattleInventory.js';
 
 const BOARD_SIZES = [9, 13, 16, 19];
 
 const MODEL_SCALE = 0.75;
 const STOOL_SCALE = 1.5 * 1.3;
+const CARD_SCALE = 0.95;
 const TABLE_RADIUS = 3.4 * MODEL_SCALE;
+const SEAT_WIDTH = 0.9 * MODEL_SCALE * STOOL_SCALE;
+const SEAT_DEPTH = 0.95 * MODEL_SCALE * STOOL_SCALE;
 const BASE_TABLE_HEIGHT = 1.08 * MODEL_SCALE;
 const SEAT_THICKNESS = 0.09 * MODEL_SCALE * STOOL_SCALE;
+const BACK_HEIGHT = 0.68 * MODEL_SCALE * STOOL_SCALE;
+const BACK_THICKNESS = 0.08 * MODEL_SCALE * STOOL_SCALE;
 const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 0.85;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
 const TABLE_HEIGHT = STOOL_HEIGHT + 0.05 * MODEL_SCALE;
-const CHAIR_DISTANCE = TABLE_RADIUS + 0.82;
+const AI_CHAIR_GAP = (0.4 * MODEL_SCALE * CARD_SCALE) * 0.4;
+const CHAIR_DISTANCE = TABLE_RADIUS + AI_CHAIR_GAP + SEAT_DEPTH * 0.52;
 
 const DEFAULT_TARGET_FPS = 120;
 const MIN_TARGET_FPS = 50;
@@ -92,26 +102,26 @@ async function resolveHdriUrl(variant) {
 function createChair(chairColor = '#7f1d1d', legColor = '#111827') {
   const group = new THREE.Group();
   const seat = new THREE.Mesh(
-    new THREE.BoxGeometry(0.68, 0.12, 0.68),
+    new THREE.BoxGeometry(SEAT_WIDTH, SEAT_THICKNESS, SEAT_DEPTH),
     new THREE.MeshStandardMaterial({ color: chairColor, roughness: 0.5 })
   );
-  seat.position.y = STOOL_HEIGHT;
+  seat.position.y = CHAIR_BASE_HEIGHT;
   group.add(seat);
 
   const back = new THREE.Mesh(
-    new THREE.BoxGeometry(0.68, 0.52, 0.1),
+    new THREE.BoxGeometry(SEAT_WIDTH, BACK_HEIGHT, BACK_THICKNESS),
     new THREE.MeshStandardMaterial({ color: chairColor, roughness: 0.55 })
   );
-  back.position.set(0, STOOL_HEIGHT + 0.26, -0.29);
+  back.position.set(0, CHAIR_BASE_HEIGHT + BACK_HEIGHT * 0.5 - SEAT_THICKNESS * 0.15, -SEAT_DEPTH * 0.45);
   group.add(back);
 
   const legGeo = new THREE.CylinderGeometry(0.045, 0.05, STOOL_HEIGHT, 20);
   const legMat = new THREE.MeshStandardMaterial({ color: legColor, metalness: 0.35, roughness: 0.45 });
   [
-    [-0.25, STOOL_HEIGHT / 2, -0.25],
-    [0.25, STOOL_HEIGHT / 2, -0.25],
-    [-0.25, STOOL_HEIGHT / 2, 0.25],
-    [0.25, STOOL_HEIGHT / 2, 0.25]
+    [-SEAT_WIDTH * 0.36, STOOL_HEIGHT / 2, -SEAT_DEPTH * 0.36],
+    [SEAT_WIDTH * 0.36, STOOL_HEIGHT / 2, -SEAT_DEPTH * 0.36],
+    [-SEAT_WIDTH * 0.36, STOOL_HEIGHT / 2, SEAT_DEPTH * 0.36],
+    [SEAT_WIDTH * 0.36, STOOL_HEIGHT / 2, SEAT_DEPTH * 0.36]
   ].forEach(([x, y, z]) => {
     const leg = new THREE.Mesh(legGeo, legMat);
     leg.position.set(x, y, z);
@@ -146,17 +156,19 @@ export default function BadukBattleRoyal() {
   const requestedSize = Number(params.get('boardSize'));
   const boardSize = BOARD_SIZES.includes(requestedSize) ? requestedSize : 19;
   const accountId = params.get('accountId') || '';
+  const avatar = params.get('avatar') || getTelegramPhotoUrl();
+  const username = params.get('username') || getTelegramUsername() || 'Player';
 
   const inventory = useMemo(
-    () => getChessBattleInventory(chessBattleAccountId(accountId || undefined)),
+    () => getBadukBattleInventory(badukBattleAccountId(accountId || undefined)),
     [accountId]
   );
 
   const [appearance, setAppearance] = useState(() => ({
     tableFinish: inventory.tableFinish?.[0] || MURLAN_TABLE_FINISHES[0]?.id,
-    tableId: inventory.tables?.[0] || CHESS_BATTLE_DEFAULT_LOADOUT.tables?.[0] || CHESS_TABLE_OPTIONS[0]?.id,
-    chairId: inventory.chairColor?.[0] || CHESS_BATTLE_DEFAULT_LOADOUT.chairColor?.[0] || CHESS_CHAIR_OPTIONS[0]?.id,
-    hdriId: inventory.environmentHdri?.[0] || CHESS_BATTLE_DEFAULT_LOADOUT.environmentHdri?.[0] || POOL_ROYALE_DEFAULT_HDRI_ID
+    tableId: inventory.tables?.[0] || BADUK_BATTLE_DEFAULT_LOADOUT.tables?.[0] || BADUK_TABLE_OPTIONS[0]?.id,
+    chairId: inventory.chairColor?.[0] || BADUK_BATTLE_DEFAULT_LOADOUT.chairColor?.[0] || BADUK_CHAIR_OPTIONS[0]?.id,
+    hdriId: inventory.environmentHdri?.[0] || BADUK_BATTLE_DEFAULT_LOADOUT.environmentHdri?.[0] || POOL_ROYALE_DEFAULT_HDRI_ID
   }));
 
   const [board, setBoard] = useState(() => createBoard(boardSize));
@@ -180,6 +192,15 @@ export default function BadukBattleRoyal() {
     () => GRAPHICS_OPTIONS.find((opt) => opt.id === graphicsId) || GRAPHICS_OPTIONS[3],
     [graphicsId]
   );
+
+  useEffect(() => {
+    setBoard(createBoard(boardSize));
+    setTurn('black');
+    setCaptures({ black: 0, white: 0 });
+    setPassCount(0);
+    setLastMove(null);
+    setStatus(`Loaded ${boardSize}×${boardSize} board. Black to play.`);
+  }, [boardSize]);
 
   useEffect(() => {
     try {
@@ -251,7 +272,7 @@ export default function BadukBattleRoyal() {
     sceneRef.current = scene;
 
     const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
-    renderer.outputColorSpace = THREE.SRGBColorSpace;
+    applyRendererSRGB(renderer);
     renderer.toneMapping = THREE.ACESFilmicToneMapping;
     renderer.toneMappingExposure = 1.0;
     renderer.setSize(mount.clientWidth, mount.clientHeight);
@@ -293,7 +314,7 @@ export default function BadukBattleRoyal() {
     applyTableMaterials(table.parts, finish);
     tableRef.current = table;
 
-    const chairOption = CHESS_CHAIR_OPTIONS.find((opt) => opt.id === appearance.chairId) || CHESS_CHAIR_OPTIONS[0];
+    const chairOption = BADUK_CHAIR_OPTIONS.find((opt) => opt.id === appearance.chairId) || BADUK_CHAIR_OPTIONS[0];
     const chairs = [Math.PI / 2, -Math.PI / 2].map((angle) => {
       const chair = createChair(chairOption?.primary || chairOption?.seatColor || '#7f1d1d', chairOption?.legColor || '#111827');
       chair.position.set(Math.cos(angle) * CHAIR_DISTANCE, 0, Math.sin(angle) * CHAIR_DISTANCE);
@@ -321,37 +342,11 @@ export default function BadukBattleRoyal() {
     boardGroup.add(boardPlane);
     boardMeshRef.current = boardPlane;
 
-    const lineMat = new THREE.LineBasicMaterial({ color: '#2f1b0c' });
-    const lines = new THREE.Group();
-    const ext = 2.04;
-    for (let i = 0; i < boardSize; i += 1) {
-      const t = (i / (boardSize - 1)) * ext - ext / 2;
-      const geoV = new THREE.BufferGeometry().setFromPoints([
-        new THREE.Vector3(t, TABLE_HEIGHT + 0.048, -ext / 2),
-        new THREE.Vector3(t, TABLE_HEIGHT + 0.048, ext / 2)
-      ]);
-      const geoH = new THREE.BufferGeometry().setFromPoints([
-        new THREE.Vector3(-ext / 2, TABLE_HEIGHT + 0.048, t),
-        new THREE.Vector3(ext / 2, TABLE_HEIGHT + 0.048, t)
-      ]);
-      lines.add(new THREE.Line(geoV, lineMat));
-      lines.add(new THREE.Line(geoH, lineMat));
-    }
-    boardGroup.add(lines);
-
-    const starMat = new THREE.MeshBasicMaterial({ color: '#1f1209' });
-    const starPointsBySize = {
-      9: [[2, 2], [2, 6], [6, 2], [6, 6], [4, 4]],
-      13: [[3, 3], [3, 9], [9, 3], [9, 9], [6, 6]],
-      16: [[3, 3], [3, 12], [12, 3], [12, 12], [7, 7], [7, 8], [8, 7], [8, 8]],
-      19: [[3, 3], [3, 9], [3, 15], [9, 3], [9, 9], [9, 15], [15, 3], [15, 9], [15, 15]]
-    };
-    (starPointsBySize[boardSize] || []).forEach(([r, c]) => {
-      const [x, z] = worldFromCell(r, c);
-      const star = new THREE.Mesh(new THREE.SphereGeometry(0.013, 10, 8), starMat);
-      star.position.set(x, TABLE_HEIGHT + 0.049, z);
-      boardGroup.add(star);
-    });
+    const boardTexture = new THREE.TextureLoader().load(`/assets/game-art/baduk-battle-royal/boards/${boardSize}x${boardSize}.svg`);
+    applySRGBColorSpace(boardTexture);
+    boardTexture.anisotropy = 8;
+    boardPlane.material.map = boardTexture;
+    boardPlane.material.needsUpdate = true;
 
     const stonesGroup = new THREE.Group();
     stonesGroupRef.current = stonesGroup;
@@ -405,7 +400,7 @@ export default function BadukBattleRoyal() {
   }, [appearance.tableFinish]);
 
   useEffect(() => {
-    const next = CHESS_CHAIR_OPTIONS.find((c) => c.id === appearance.chairId) || CHESS_CHAIR_OPTIONS[0];
+    const next = BADUK_CHAIR_OPTIONS.find((c) => c.id === appearance.chairId) || BADUK_CHAIR_OPTIONS[0];
     const chairColor = new THREE.Color(next?.primary || next?.seatColor || '#7f1d1d');
     chairsRef.current.forEach((chair) => {
       chair.traverse((node) => {
@@ -556,6 +551,7 @@ export default function BadukBattleRoyal() {
           </div>
           <p className="mt-2 text-xs text-white/75">Board {boardSize}×{boardSize} • Turn: {turn} • B:{blackStones} W:{whiteStones} • Captures B:{captures.black} W:{captures.white}</p>
           <p className="mt-1 text-xs text-cyan-100/90">{status}</p>
+          <p className="mt-1 text-[11px] text-white/60">Tap an intersection to place a stone. Two passes end the game.</p>
         </div>
       </div>
 
@@ -620,7 +616,7 @@ export default function BadukBattleRoyal() {
 
               <div className="mb-2 text-[11px] uppercase tracking-[0.2em] text-white/70">Tables</div>
               <div className="mb-3 grid max-h-40 grid-cols-2 gap-2 overflow-auto">
-                {CHESS_TABLE_OPTIONS.map((opt) => (
+                {BADUK_TABLE_OPTIONS.map((opt) => (
                   <button
                     key={opt.id}
                     onClick={() => setAppearance((prev) => ({ ...prev, tableId: opt.id }))}
@@ -633,7 +629,7 @@ export default function BadukBattleRoyal() {
 
               <div className="mb-2 text-[11px] uppercase tracking-[0.2em] text-white/70">Chairs</div>
               <div className="mb-3 grid max-h-40 grid-cols-2 gap-2 overflow-auto">
-                {CHESS_CHAIR_OPTIONS.map((opt) => (
+                {BADUK_CHAIR_OPTIONS.map((opt) => (
                   <button
                     key={opt.id}
                     onClick={() => setAppearance((prev) => ({ ...prev, chairId: opt.id }))}
@@ -661,10 +657,46 @@ export default function BadukBattleRoyal() {
                 onClick={() => navigate('/store/badukbattleroyal')}
                 className="mt-3 w-full rounded-xl border border-cyan-300/40 bg-cyan-400/20 px-3 py-2 text-xs font-semibold text-cyan-100"
               >
-                Open Store (shared Chess/Checkers items)
+                Open Store (Baduk items)
               </button>
             </div>
           )}
+        </div>
+      </div>
+
+      <div className="pointer-events-auto">
+        <BottomLeftIcons
+          onGift={() => setStatus('Gift interactions are aligned with Chess Battle Royal UI.')}
+          showInfo={false}
+          showChat={false}
+          showMute={false}
+          className="fixed right-3 bottom-28 z-50 flex flex-col gap-4"
+          buttonClassName="icon-only-button pointer-events-auto flex h-11 w-11 items-center justify-center text-white/90 transition-opacity duration-200 hover:text-white focus:outline-none"
+          iconClassName="text-[1.65rem] leading-none"
+          labelClassName="sr-only"
+          giftIcon="🎁"
+          order={['gift']}
+        />
+        <BottomLeftIcons
+          onChat={() => setStatus('Quick chat coming soon for Baduk multiplayer.')}
+          showInfo={false}
+          showGift={false}
+          showMute={false}
+          className="fixed left-3 bottom-28 z-50 flex flex-col"
+          buttonClassName="icon-only-button pointer-events-auto flex h-11 w-11 items-center justify-center text-white/90 transition-opacity duration-200 hover:text-white focus:outline-none"
+          iconClassName="text-[1.65rem] leading-none"
+          labelClassName="sr-only"
+          chatIcon="💬"
+          order={['chat']}
+        />
+      </div>
+
+      <div className="pointer-events-none absolute inset-0 z-20">
+        <div className="absolute left-1/2 top-[12%] -translate-x-1/2">
+          <AvatarTimer photoUrl="🤖" name="AI Rival" active isTurn={turn === 'white'} size={1} />
+        </div>
+        <div className="absolute left-1/2 top-[85%] -translate-x-1/2">
+          <AvatarTimer photoUrl={avatar} name={username} active isTurn={turn === 'black'} size={1} />
         </div>
       </div>
     </div>

--- a/webapp/src/utils/badukBattleInventory.js
+++ b/webapp/src/utils/badukBattleInventory.js
@@ -1,0 +1,28 @@
+import { BADUK_BATTLE_DEFAULT_LOADOUT } from '../config/badukBattleInventoryConfig.js'
+
+const STORAGE_KEY = 'badukBattleInventoryByAccount'
+const memoryCache = new Map()
+
+export const badukBattleAccountId = (value) => {
+  const normalized = `${value || 'guest'}`.trim()
+  return normalized || 'guest'
+}
+
+const readStore = () => {
+  try {
+    const raw = window.localStorage?.getItem(STORAGE_KEY)
+    if (!raw) return {}
+    return JSON.parse(raw) || {}
+  } catch {
+    return {}
+  }
+}
+
+export const getBadukBattleInventory = (accountId = 'guest') => {
+  const id = badukBattleAccountId(accountId)
+  if (memoryCache.has(id)) return memoryCache.get(id)
+  const db = readStore()
+  const resolved = { ...BADUK_BATTLE_DEFAULT_LOADOUT, ...(db[id] || {}) }
+  memoryCache.set(id, resolved)
+  return resolved
+}


### PR DESCRIPTION
### Motivation
- Introduce a Baduk (Go) variant of the Battle Royal game with proper board artwork and per-account inventory so players can customize tables and chairs. 
- Replace the programmatic board rendering with SVG board textures to support multiple board sizes and visual polish.

### Description
- Add new board SVG assets under `webapp/public/assets/game-art/baduk-battle-royal/boards/` for `9x9`, `13x13`, `16x16`, and `19x19` and update `.gitignore` to include the new folder. 
- Add `badukBattleInventoryConfig.js` exporting chair/table options and default loadout, and add `badukBattleInventory.js` to manage per-account inventory with localStorage and an in-memory cache. 
- Implement the Baduk UI page `BadukBattleRoyal.jsx` that wires inventory, loads SVG board textures, updates chair geometry and layout constants, applies SRGB color-space helpers to the renderer and textures, and swaps previous Chess references to Baduk assets and defaults. 
- Integrate Telegram avatar/username fallbacks and UI components `BottomLeftIcons` and `AvatarTimer` for AI/player avatars and quick status messages, and update in-panel labels and the store button text to reference Baduk items.

### Testing
- Ran a local build with `yarn build` to validate bundling and asset inclusion and the build completed successfully. 
- Ran lint/static checks with `yarn lint` and basic dev server (`yarn start`) to verify the new page renders and SVG textures load, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6fca30fa88329a338f067bb7d7609)