### PR TITLE
Add Baduk board and stone cosmetics to store and improve board rendering

### DIFF
--- a/webapp/public/assets/game-art/baduk-battle-royal/boards/ATTRIBUTION.md
+++ b/webapp/public/assets/game-art/baduk-battle-royal/boards/ATTRIBUTION.md
@@ -4,4 +4,8 @@
 - Source: https://github.com/online-go/goban/blob/main/assets/img/anime_board.svg
 - License: Apache-2.0
 
-The board overlays (`9x9.svg`, `13x13.svg`, `16x16.svg`, `19x19.svg`) in this folder use that base board texture and add static grid/star-point layers for Baduk board sizes.
+The board overlays in this folder are derived from that Apache-2.0 base artwork:
+- Size overlays: `9x9.svg`, `13x13.svg`, `16x16.svg`, `19x19.svg`
+- Store theme variants: `classic-*.svg`, `walnut-*.svg`, `slate-*.svg`, `jade-*.svg`, `midnight-*.svg`
+
+Stone thumbnails in `../stones/*.svg` are original simple vector previews created for in-app store cards.

--- a/webapp/public/assets/game-art/baduk-battle-royal/boards/classic-13x13.svg
+++ b/webapp/public/assets/game-art/baduk-battle-royal/boards/classic-13x13.svg
@@ -1,0 +1,50 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024">
+  <defs>
+    <linearGradient id="woodTint" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#efc987" stop-opacity="0.26"/>
+      <stop offset="100%" stop-color="#9a642e" stop-opacity="0.22"/>
+    </linearGradient>
+    <pattern id="grain" width="24" height="24" patternUnits="userSpaceOnUse">
+      <path d="M0 12h24" stroke="#4f2f15" stroke-opacity="0.06" stroke-width="1"/>
+      <path d="M0 6h24" stroke="#fff" stroke-opacity="0.04" stroke-width="0.8"/>
+    </pattern>
+    <style>
+      .g { stroke:#2a1507; stroke-linecap:round; stroke-opacity:.9; }
+      .s { fill:#241105; opacity:.96; }
+    </style>
+  </defs>
+  <image href="/assets/game-art/baduk-battle-royal/boards/ogs-anime-board.svg" x="0" y="0" width="1024" height="1024" preserveAspectRatio="none"/>
+  <rect x="86" y="86" width="852" height="852" fill="url(#woodTint)"/>
+  <rect x="86" y="86" width="852" height="852" fill="url(#grain)"/>
+  <line x1="86.0000" y1="86" x2="86.0000" y2="938" class="g" stroke-width="3.2"/>
+  <line x1="86" y1="86.0000" x2="938" y2="86.0000" class="g" stroke-width="3.2"/>
+  <line x1="157.0000" y1="86" x2="157.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="157.0000" x2="938" y2="157.0000" class="g" stroke-width="2.2"/>
+  <line x1="228.0000" y1="86" x2="228.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="228.0000" x2="938" y2="228.0000" class="g" stroke-width="2.2"/>
+  <line x1="299.0000" y1="86" x2="299.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="299.0000" x2="938" y2="299.0000" class="g" stroke-width="2.2"/>
+  <line x1="370.0000" y1="86" x2="370.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="370.0000" x2="938" y2="370.0000" class="g" stroke-width="2.2"/>
+  <line x1="441.0000" y1="86" x2="441.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="441.0000" x2="938" y2="441.0000" class="g" stroke-width="2.2"/>
+  <line x1="512.0000" y1="86" x2="512.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="512.0000" x2="938" y2="512.0000" class="g" stroke-width="2.2"/>
+  <line x1="583.0000" y1="86" x2="583.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="583.0000" x2="938" y2="583.0000" class="g" stroke-width="2.2"/>
+  <line x1="654.0000" y1="86" x2="654.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="654.0000" x2="938" y2="654.0000" class="g" stroke-width="2.2"/>
+  <line x1="725.0000" y1="86" x2="725.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="725.0000" x2="938" y2="725.0000" class="g" stroke-width="2.2"/>
+  <line x1="796.0000" y1="86" x2="796.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="796.0000" x2="938" y2="796.0000" class="g" stroke-width="2.2"/>
+  <line x1="867.0000" y1="86" x2="867.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="867.0000" x2="938" y2="867.0000" class="g" stroke-width="2.2"/>
+  <line x1="938.0000" y1="86" x2="938.0000" y2="938" class="g" stroke-width="3.2"/>
+  <line x1="86" y1="938.0000" x2="938" y2="938.0000" class="g" stroke-width="3.2"/>
+  <circle cx="299.0000" cy="299.0000" r="6.6" class="s"/>
+  <circle cx="725.0000" cy="299.0000" r="6.6" class="s"/>
+  <circle cx="299.0000" cy="725.0000" r="6.6" class="s"/>
+  <circle cx="725.0000" cy="725.0000" r="6.6" class="s"/>
+  <circle cx="512.0000" cy="512.0000" r="6.6" class="s"/>
+</svg>

--- a/webapp/public/assets/game-art/baduk-battle-royal/boards/classic-16x16.svg
+++ b/webapp/public/assets/game-art/baduk-battle-royal/boards/classic-16x16.svg
@@ -1,0 +1,59 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024">
+  <defs>
+    <linearGradient id="woodTint" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#efc987" stop-opacity="0.26"/>
+      <stop offset="100%" stop-color="#9a642e" stop-opacity="0.22"/>
+    </linearGradient>
+    <pattern id="grain" width="24" height="24" patternUnits="userSpaceOnUse">
+      <path d="M0 12h24" stroke="#4f2f15" stroke-opacity="0.06" stroke-width="1"/>
+      <path d="M0 6h24" stroke="#fff" stroke-opacity="0.04" stroke-width="0.8"/>
+    </pattern>
+    <style>
+      .g { stroke:#2a1507; stroke-linecap:round; stroke-opacity:.9; }
+      .s { fill:#241105; opacity:.96; }
+    </style>
+  </defs>
+  <image href="/assets/game-art/baduk-battle-royal/boards/ogs-anime-board.svg" x="0" y="0" width="1024" height="1024" preserveAspectRatio="none"/>
+  <rect x="86" y="86" width="852" height="852" fill="url(#woodTint)"/>
+  <rect x="86" y="86" width="852" height="852" fill="url(#grain)"/>
+  <line x1="86.0000" y1="86" x2="86.0000" y2="938" class="g" stroke-width="3.2"/>
+  <line x1="86" y1="86.0000" x2="938" y2="86.0000" class="g" stroke-width="3.2"/>
+  <line x1="142.8000" y1="86" x2="142.8000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="142.8000" x2="938" y2="142.8000" class="g" stroke-width="2.2"/>
+  <line x1="199.6000" y1="86" x2="199.6000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="199.6000" x2="938" y2="199.6000" class="g" stroke-width="2.2"/>
+  <line x1="256.4000" y1="86" x2="256.4000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="256.4000" x2="938" y2="256.4000" class="g" stroke-width="2.2"/>
+  <line x1="313.2000" y1="86" x2="313.2000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="313.2000" x2="938" y2="313.2000" class="g" stroke-width="2.2"/>
+  <line x1="370.0000" y1="86" x2="370.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="370.0000" x2="938" y2="370.0000" class="g" stroke-width="2.2"/>
+  <line x1="426.8000" y1="86" x2="426.8000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="426.8000" x2="938" y2="426.8000" class="g" stroke-width="2.2"/>
+  <line x1="483.6000" y1="86" x2="483.6000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="483.6000" x2="938" y2="483.6000" class="g" stroke-width="2.2"/>
+  <line x1="540.4000" y1="86" x2="540.4000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="540.4000" x2="938" y2="540.4000" class="g" stroke-width="2.2"/>
+  <line x1="597.2000" y1="86" x2="597.2000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="597.2000" x2="938" y2="597.2000" class="g" stroke-width="2.2"/>
+  <line x1="654.0000" y1="86" x2="654.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="654.0000" x2="938" y2="654.0000" class="g" stroke-width="2.2"/>
+  <line x1="710.8000" y1="86" x2="710.8000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="710.8000" x2="938" y2="710.8000" class="g" stroke-width="2.2"/>
+  <line x1="767.6000" y1="86" x2="767.6000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="767.6000" x2="938" y2="767.6000" class="g" stroke-width="2.2"/>
+  <line x1="824.4000" y1="86" x2="824.4000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="824.4000" x2="938" y2="824.4000" class="g" stroke-width="2.2"/>
+  <line x1="881.2000" y1="86" x2="881.2000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="881.2000" x2="938" y2="881.2000" class="g" stroke-width="2.2"/>
+  <line x1="938.0000" y1="86" x2="938.0000" y2="938" class="g" stroke-width="3.2"/>
+  <line x1="86" y1="938.0000" x2="938" y2="938.0000" class="g" stroke-width="3.2"/>
+  <circle cx="256.4000" cy="256.4000" r="6.6" class="s"/>
+  <circle cx="767.6000" cy="256.4000" r="6.6" class="s"/>
+  <circle cx="256.4000" cy="767.6000" r="6.6" class="s"/>
+  <circle cx="767.6000" cy="767.6000" r="6.6" class="s"/>
+  <circle cx="483.6000" cy="483.6000" r="6.6" class="s"/>
+  <circle cx="540.4000" cy="483.6000" r="6.6" class="s"/>
+  <circle cx="483.6000" cy="540.4000" r="6.6" class="s"/>
+  <circle cx="540.4000" cy="540.4000" r="6.6" class="s"/>
+</svg>

--- a/webapp/public/assets/game-art/baduk-battle-royal/boards/classic-19x19.svg
+++ b/webapp/public/assets/game-art/baduk-battle-royal/boards/classic-19x19.svg
@@ -1,0 +1,66 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024">
+  <defs>
+    <linearGradient id="woodTint" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#efc987" stop-opacity="0.26"/>
+      <stop offset="100%" stop-color="#9a642e" stop-opacity="0.22"/>
+    </linearGradient>
+    <pattern id="grain" width="24" height="24" patternUnits="userSpaceOnUse">
+      <path d="M0 12h24" stroke="#4f2f15" stroke-opacity="0.06" stroke-width="1"/>
+      <path d="M0 6h24" stroke="#fff" stroke-opacity="0.04" stroke-width="0.8"/>
+    </pattern>
+    <style>
+      .g { stroke:#2a1507; stroke-linecap:round; stroke-opacity:.9; }
+      .s { fill:#241105; opacity:.96; }
+    </style>
+  </defs>
+  <image href="/assets/game-art/baduk-battle-royal/boards/ogs-anime-board.svg" x="0" y="0" width="1024" height="1024" preserveAspectRatio="none"/>
+  <rect x="86" y="86" width="852" height="852" fill="url(#woodTint)"/>
+  <rect x="86" y="86" width="852" height="852" fill="url(#grain)"/>
+  <line x1="86.0000" y1="86" x2="86.0000" y2="938" class="g" stroke-width="3.2"/>
+  <line x1="86" y1="86.0000" x2="938" y2="86.0000" class="g" stroke-width="3.2"/>
+  <line x1="133.3333" y1="86" x2="133.3333" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="133.3333" x2="938" y2="133.3333" class="g" stroke-width="2.2"/>
+  <line x1="180.6667" y1="86" x2="180.6667" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="180.6667" x2="938" y2="180.6667" class="g" stroke-width="2.2"/>
+  <line x1="228.0000" y1="86" x2="228.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="228.0000" x2="938" y2="228.0000" class="g" stroke-width="2.2"/>
+  <line x1="275.3333" y1="86" x2="275.3333" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="275.3333" x2="938" y2="275.3333" class="g" stroke-width="2.2"/>
+  <line x1="322.6667" y1="86" x2="322.6667" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="322.6667" x2="938" y2="322.6667" class="g" stroke-width="2.2"/>
+  <line x1="370.0000" y1="86" x2="370.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="370.0000" x2="938" y2="370.0000" class="g" stroke-width="2.2"/>
+  <line x1="417.3333" y1="86" x2="417.3333" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="417.3333" x2="938" y2="417.3333" class="g" stroke-width="2.2"/>
+  <line x1="464.6667" y1="86" x2="464.6667" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="464.6667" x2="938" y2="464.6667" class="g" stroke-width="2.2"/>
+  <line x1="512.0000" y1="86" x2="512.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="512.0000" x2="938" y2="512.0000" class="g" stroke-width="2.2"/>
+  <line x1="559.3333" y1="86" x2="559.3333" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="559.3333" x2="938" y2="559.3333" class="g" stroke-width="2.2"/>
+  <line x1="606.6667" y1="86" x2="606.6667" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="606.6667" x2="938" y2="606.6667" class="g" stroke-width="2.2"/>
+  <line x1="654.0000" y1="86" x2="654.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="654.0000" x2="938" y2="654.0000" class="g" stroke-width="2.2"/>
+  <line x1="701.3333" y1="86" x2="701.3333" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="701.3333" x2="938" y2="701.3333" class="g" stroke-width="2.2"/>
+  <line x1="748.6667" y1="86" x2="748.6667" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="748.6667" x2="938" y2="748.6667" class="g" stroke-width="2.2"/>
+  <line x1="796.0000" y1="86" x2="796.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="796.0000" x2="938" y2="796.0000" class="g" stroke-width="2.2"/>
+  <line x1="843.3333" y1="86" x2="843.3333" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="843.3333" x2="938" y2="843.3333" class="g" stroke-width="2.2"/>
+  <line x1="890.6667" y1="86" x2="890.6667" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="890.6667" x2="938" y2="890.6667" class="g" stroke-width="2.2"/>
+  <line x1="938.0000" y1="86" x2="938.0000" y2="938" class="g" stroke-width="3.2"/>
+  <line x1="86" y1="938.0000" x2="938" y2="938.0000" class="g" stroke-width="3.2"/>
+  <circle cx="228.0000" cy="228.0000" r="6.6" class="s"/>
+  <circle cx="512.0000" cy="228.0000" r="6.6" class="s"/>
+  <circle cx="796.0000" cy="228.0000" r="6.6" class="s"/>
+  <circle cx="228.0000" cy="512.0000" r="6.6" class="s"/>
+  <circle cx="512.0000" cy="512.0000" r="6.6" class="s"/>
+  <circle cx="796.0000" cy="512.0000" r="6.6" class="s"/>
+  <circle cx="228.0000" cy="796.0000" r="6.6" class="s"/>
+  <circle cx="512.0000" cy="796.0000" r="6.6" class="s"/>
+  <circle cx="796.0000" cy="796.0000" r="6.6" class="s"/>
+</svg>

--- a/webapp/public/assets/game-art/baduk-battle-royal/boards/classic-9x9.svg
+++ b/webapp/public/assets/game-art/baduk-battle-royal/boards/classic-9x9.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024">
+  <defs>
+    <linearGradient id="woodTint" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#efc987" stop-opacity="0.26"/>
+      <stop offset="100%" stop-color="#9a642e" stop-opacity="0.22"/>
+    </linearGradient>
+    <pattern id="grain" width="24" height="24" patternUnits="userSpaceOnUse">
+      <path d="M0 12h24" stroke="#4f2f15" stroke-opacity="0.06" stroke-width="1"/>
+      <path d="M0 6h24" stroke="#fff" stroke-opacity="0.04" stroke-width="0.8"/>
+    </pattern>
+    <style>
+      .g { stroke:#2a1507; stroke-linecap:round; stroke-opacity:.9; }
+      .s { fill:#241105; opacity:.96; }
+    </style>
+  </defs>
+  <image href="/assets/game-art/baduk-battle-royal/boards/ogs-anime-board.svg" x="0" y="0" width="1024" height="1024" preserveAspectRatio="none"/>
+  <rect x="86" y="86" width="852" height="852" fill="url(#woodTint)"/>
+  <rect x="86" y="86" width="852" height="852" fill="url(#grain)"/>
+  <line x1="86.0000" y1="86" x2="86.0000" y2="938" class="g" stroke-width="3.2"/>
+  <line x1="86" y1="86.0000" x2="938" y2="86.0000" class="g" stroke-width="3.2"/>
+  <line x1="192.5000" y1="86" x2="192.5000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="192.5000" x2="938" y2="192.5000" class="g" stroke-width="2.2"/>
+  <line x1="299.0000" y1="86" x2="299.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="299.0000" x2="938" y2="299.0000" class="g" stroke-width="2.2"/>
+  <line x1="405.5000" y1="86" x2="405.5000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="405.5000" x2="938" y2="405.5000" class="g" stroke-width="2.2"/>
+  <line x1="512.0000" y1="86" x2="512.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="512.0000" x2="938" y2="512.0000" class="g" stroke-width="2.2"/>
+  <line x1="618.5000" y1="86" x2="618.5000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="618.5000" x2="938" y2="618.5000" class="g" stroke-width="2.2"/>
+  <line x1="725.0000" y1="86" x2="725.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="725.0000" x2="938" y2="725.0000" class="g" stroke-width="2.2"/>
+  <line x1="831.5000" y1="86" x2="831.5000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="831.5000" x2="938" y2="831.5000" class="g" stroke-width="2.2"/>
+  <line x1="938.0000" y1="86" x2="938.0000" y2="938" class="g" stroke-width="3.2"/>
+  <line x1="86" y1="938.0000" x2="938" y2="938.0000" class="g" stroke-width="3.2"/>
+  <circle cx="299.0000" cy="299.0000" r="6.6" class="s"/>
+  <circle cx="725.0000" cy="299.0000" r="6.6" class="s"/>
+  <circle cx="299.0000" cy="725.0000" r="6.6" class="s"/>
+  <circle cx="725.0000" cy="725.0000" r="6.6" class="s"/>
+  <circle cx="512.0000" cy="512.0000" r="6.6" class="s"/>
+</svg>

--- a/webapp/public/assets/game-art/baduk-battle-royal/boards/jade-13x13.svg
+++ b/webapp/public/assets/game-art/baduk-battle-royal/boards/jade-13x13.svg
@@ -1,0 +1,50 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024">
+  <defs>
+    <linearGradient id="woodTint" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#c9f2d4" stop-opacity="0.26"/>
+      <stop offset="100%" stop-color="#2f7f64" stop-opacity="0.22"/>
+    </linearGradient>
+    <pattern id="grain" width="24" height="24" patternUnits="userSpaceOnUse">
+      <path d="M0 12h24" stroke="#0d3d2f" stroke-opacity="0.06" stroke-width="1"/>
+      <path d="M0 6h24" stroke="#ecfeff" stroke-opacity="0.04" stroke-width="0.8"/>
+    </pattern>
+    <style>
+      .g { stroke:#114233; stroke-linecap:round; stroke-opacity:.9; }
+      .s { fill:#0c2e24; opacity:.96; }
+    </style>
+  </defs>
+  <image href="/assets/game-art/baduk-battle-royal/boards/ogs-anime-board.svg" x="0" y="0" width="1024" height="1024" preserveAspectRatio="none"/>
+  <rect x="86" y="86" width="852" height="852" fill="url(#woodTint)"/>
+  <rect x="86" y="86" width="852" height="852" fill="url(#grain)"/>
+  <line x1="86.0000" y1="86" x2="86.0000" y2="938" class="g" stroke-width="3.2"/>
+  <line x1="86" y1="86.0000" x2="938" y2="86.0000" class="g" stroke-width="3.2"/>
+  <line x1="157.0000" y1="86" x2="157.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="157.0000" x2="938" y2="157.0000" class="g" stroke-width="2.2"/>
+  <line x1="228.0000" y1="86" x2="228.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="228.0000" x2="938" y2="228.0000" class="g" stroke-width="2.2"/>
+  <line x1="299.0000" y1="86" x2="299.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="299.0000" x2="938" y2="299.0000" class="g" stroke-width="2.2"/>
+  <line x1="370.0000" y1="86" x2="370.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="370.0000" x2="938" y2="370.0000" class="g" stroke-width="2.2"/>
+  <line x1="441.0000" y1="86" x2="441.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="441.0000" x2="938" y2="441.0000" class="g" stroke-width="2.2"/>
+  <line x1="512.0000" y1="86" x2="512.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="512.0000" x2="938" y2="512.0000" class="g" stroke-width="2.2"/>
+  <line x1="583.0000" y1="86" x2="583.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="583.0000" x2="938" y2="583.0000" class="g" stroke-width="2.2"/>
+  <line x1="654.0000" y1="86" x2="654.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="654.0000" x2="938" y2="654.0000" class="g" stroke-width="2.2"/>
+  <line x1="725.0000" y1="86" x2="725.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="725.0000" x2="938" y2="725.0000" class="g" stroke-width="2.2"/>
+  <line x1="796.0000" y1="86" x2="796.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="796.0000" x2="938" y2="796.0000" class="g" stroke-width="2.2"/>
+  <line x1="867.0000" y1="86" x2="867.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="867.0000" x2="938" y2="867.0000" class="g" stroke-width="2.2"/>
+  <line x1="938.0000" y1="86" x2="938.0000" y2="938" class="g" stroke-width="3.2"/>
+  <line x1="86" y1="938.0000" x2="938" y2="938.0000" class="g" stroke-width="3.2"/>
+  <circle cx="299.0000" cy="299.0000" r="6.6" class="s"/>
+  <circle cx="725.0000" cy="299.0000" r="6.6" class="s"/>
+  <circle cx="299.0000" cy="725.0000" r="6.6" class="s"/>
+  <circle cx="725.0000" cy="725.0000" r="6.6" class="s"/>
+  <circle cx="512.0000" cy="512.0000" r="6.6" class="s"/>
+</svg>

--- a/webapp/public/assets/game-art/baduk-battle-royal/boards/jade-16x16.svg
+++ b/webapp/public/assets/game-art/baduk-battle-royal/boards/jade-16x16.svg
@@ -1,0 +1,59 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024">
+  <defs>
+    <linearGradient id="woodTint" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#c9f2d4" stop-opacity="0.26"/>
+      <stop offset="100%" stop-color="#2f7f64" stop-opacity="0.22"/>
+    </linearGradient>
+    <pattern id="grain" width="24" height="24" patternUnits="userSpaceOnUse">
+      <path d="M0 12h24" stroke="#0d3d2f" stroke-opacity="0.06" stroke-width="1"/>
+      <path d="M0 6h24" stroke="#ecfeff" stroke-opacity="0.04" stroke-width="0.8"/>
+    </pattern>
+    <style>
+      .g { stroke:#114233; stroke-linecap:round; stroke-opacity:.9; }
+      .s { fill:#0c2e24; opacity:.96; }
+    </style>
+  </defs>
+  <image href="/assets/game-art/baduk-battle-royal/boards/ogs-anime-board.svg" x="0" y="0" width="1024" height="1024" preserveAspectRatio="none"/>
+  <rect x="86" y="86" width="852" height="852" fill="url(#woodTint)"/>
+  <rect x="86" y="86" width="852" height="852" fill="url(#grain)"/>
+  <line x1="86.0000" y1="86" x2="86.0000" y2="938" class="g" stroke-width="3.2"/>
+  <line x1="86" y1="86.0000" x2="938" y2="86.0000" class="g" stroke-width="3.2"/>
+  <line x1="142.8000" y1="86" x2="142.8000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="142.8000" x2="938" y2="142.8000" class="g" stroke-width="2.2"/>
+  <line x1="199.6000" y1="86" x2="199.6000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="199.6000" x2="938" y2="199.6000" class="g" stroke-width="2.2"/>
+  <line x1="256.4000" y1="86" x2="256.4000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="256.4000" x2="938" y2="256.4000" class="g" stroke-width="2.2"/>
+  <line x1="313.2000" y1="86" x2="313.2000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="313.2000" x2="938" y2="313.2000" class="g" stroke-width="2.2"/>
+  <line x1="370.0000" y1="86" x2="370.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="370.0000" x2="938" y2="370.0000" class="g" stroke-width="2.2"/>
+  <line x1="426.8000" y1="86" x2="426.8000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="426.8000" x2="938" y2="426.8000" class="g" stroke-width="2.2"/>
+  <line x1="483.6000" y1="86" x2="483.6000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="483.6000" x2="938" y2="483.6000" class="g" stroke-width="2.2"/>
+  <line x1="540.4000" y1="86" x2="540.4000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="540.4000" x2="938" y2="540.4000" class="g" stroke-width="2.2"/>
+  <line x1="597.2000" y1="86" x2="597.2000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="597.2000" x2="938" y2="597.2000" class="g" stroke-width="2.2"/>
+  <line x1="654.0000" y1="86" x2="654.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="654.0000" x2="938" y2="654.0000" class="g" stroke-width="2.2"/>
+  <line x1="710.8000" y1="86" x2="710.8000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="710.8000" x2="938" y2="710.8000" class="g" stroke-width="2.2"/>
+  <line x1="767.6000" y1="86" x2="767.6000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="767.6000" x2="938" y2="767.6000" class="g" stroke-width="2.2"/>
+  <line x1="824.4000" y1="86" x2="824.4000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="824.4000" x2="938" y2="824.4000" class="g" stroke-width="2.2"/>
+  <line x1="881.2000" y1="86" x2="881.2000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="881.2000" x2="938" y2="881.2000" class="g" stroke-width="2.2"/>
+  <line x1="938.0000" y1="86" x2="938.0000" y2="938" class="g" stroke-width="3.2"/>
+  <line x1="86" y1="938.0000" x2="938" y2="938.0000" class="g" stroke-width="3.2"/>
+  <circle cx="256.4000" cy="256.4000" r="6.6" class="s"/>
+  <circle cx="767.6000" cy="256.4000" r="6.6" class="s"/>
+  <circle cx="256.4000" cy="767.6000" r="6.6" class="s"/>
+  <circle cx="767.6000" cy="767.6000" r="6.6" class="s"/>
+  <circle cx="483.6000" cy="483.6000" r="6.6" class="s"/>
+  <circle cx="540.4000" cy="483.6000" r="6.6" class="s"/>
+  <circle cx="483.6000" cy="540.4000" r="6.6" class="s"/>
+  <circle cx="540.4000" cy="540.4000" r="6.6" class="s"/>
+</svg>

--- a/webapp/public/assets/game-art/baduk-battle-royal/boards/jade-19x19.svg
+++ b/webapp/public/assets/game-art/baduk-battle-royal/boards/jade-19x19.svg
@@ -1,0 +1,66 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024">
+  <defs>
+    <linearGradient id="woodTint" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#c9f2d4" stop-opacity="0.26"/>
+      <stop offset="100%" stop-color="#2f7f64" stop-opacity="0.22"/>
+    </linearGradient>
+    <pattern id="grain" width="24" height="24" patternUnits="userSpaceOnUse">
+      <path d="M0 12h24" stroke="#0d3d2f" stroke-opacity="0.06" stroke-width="1"/>
+      <path d="M0 6h24" stroke="#ecfeff" stroke-opacity="0.04" stroke-width="0.8"/>
+    </pattern>
+    <style>
+      .g { stroke:#114233; stroke-linecap:round; stroke-opacity:.9; }
+      .s { fill:#0c2e24; opacity:.96; }
+    </style>
+  </defs>
+  <image href="/assets/game-art/baduk-battle-royal/boards/ogs-anime-board.svg" x="0" y="0" width="1024" height="1024" preserveAspectRatio="none"/>
+  <rect x="86" y="86" width="852" height="852" fill="url(#woodTint)"/>
+  <rect x="86" y="86" width="852" height="852" fill="url(#grain)"/>
+  <line x1="86.0000" y1="86" x2="86.0000" y2="938" class="g" stroke-width="3.2"/>
+  <line x1="86" y1="86.0000" x2="938" y2="86.0000" class="g" stroke-width="3.2"/>
+  <line x1="133.3333" y1="86" x2="133.3333" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="133.3333" x2="938" y2="133.3333" class="g" stroke-width="2.2"/>
+  <line x1="180.6667" y1="86" x2="180.6667" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="180.6667" x2="938" y2="180.6667" class="g" stroke-width="2.2"/>
+  <line x1="228.0000" y1="86" x2="228.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="228.0000" x2="938" y2="228.0000" class="g" stroke-width="2.2"/>
+  <line x1="275.3333" y1="86" x2="275.3333" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="275.3333" x2="938" y2="275.3333" class="g" stroke-width="2.2"/>
+  <line x1="322.6667" y1="86" x2="322.6667" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="322.6667" x2="938" y2="322.6667" class="g" stroke-width="2.2"/>
+  <line x1="370.0000" y1="86" x2="370.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="370.0000" x2="938" y2="370.0000" class="g" stroke-width="2.2"/>
+  <line x1="417.3333" y1="86" x2="417.3333" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="417.3333" x2="938" y2="417.3333" class="g" stroke-width="2.2"/>
+  <line x1="464.6667" y1="86" x2="464.6667" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="464.6667" x2="938" y2="464.6667" class="g" stroke-width="2.2"/>
+  <line x1="512.0000" y1="86" x2="512.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="512.0000" x2="938" y2="512.0000" class="g" stroke-width="2.2"/>
+  <line x1="559.3333" y1="86" x2="559.3333" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="559.3333" x2="938" y2="559.3333" class="g" stroke-width="2.2"/>
+  <line x1="606.6667" y1="86" x2="606.6667" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="606.6667" x2="938" y2="606.6667" class="g" stroke-width="2.2"/>
+  <line x1="654.0000" y1="86" x2="654.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="654.0000" x2="938" y2="654.0000" class="g" stroke-width="2.2"/>
+  <line x1="701.3333" y1="86" x2="701.3333" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="701.3333" x2="938" y2="701.3333" class="g" stroke-width="2.2"/>
+  <line x1="748.6667" y1="86" x2="748.6667" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="748.6667" x2="938" y2="748.6667" class="g" stroke-width="2.2"/>
+  <line x1="796.0000" y1="86" x2="796.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="796.0000" x2="938" y2="796.0000" class="g" stroke-width="2.2"/>
+  <line x1="843.3333" y1="86" x2="843.3333" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="843.3333" x2="938" y2="843.3333" class="g" stroke-width="2.2"/>
+  <line x1="890.6667" y1="86" x2="890.6667" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="890.6667" x2="938" y2="890.6667" class="g" stroke-width="2.2"/>
+  <line x1="938.0000" y1="86" x2="938.0000" y2="938" class="g" stroke-width="3.2"/>
+  <line x1="86" y1="938.0000" x2="938" y2="938.0000" class="g" stroke-width="3.2"/>
+  <circle cx="228.0000" cy="228.0000" r="6.6" class="s"/>
+  <circle cx="512.0000" cy="228.0000" r="6.6" class="s"/>
+  <circle cx="796.0000" cy="228.0000" r="6.6" class="s"/>
+  <circle cx="228.0000" cy="512.0000" r="6.6" class="s"/>
+  <circle cx="512.0000" cy="512.0000" r="6.6" class="s"/>
+  <circle cx="796.0000" cy="512.0000" r="6.6" class="s"/>
+  <circle cx="228.0000" cy="796.0000" r="6.6" class="s"/>
+  <circle cx="512.0000" cy="796.0000" r="6.6" class="s"/>
+  <circle cx="796.0000" cy="796.0000" r="6.6" class="s"/>
+</svg>

--- a/webapp/public/assets/game-art/baduk-battle-royal/boards/jade-9x9.svg
+++ b/webapp/public/assets/game-art/baduk-battle-royal/boards/jade-9x9.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024">
+  <defs>
+    <linearGradient id="woodTint" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#c9f2d4" stop-opacity="0.26"/>
+      <stop offset="100%" stop-color="#2f7f64" stop-opacity="0.22"/>
+    </linearGradient>
+    <pattern id="grain" width="24" height="24" patternUnits="userSpaceOnUse">
+      <path d="M0 12h24" stroke="#0d3d2f" stroke-opacity="0.06" stroke-width="1"/>
+      <path d="M0 6h24" stroke="#ecfeff" stroke-opacity="0.04" stroke-width="0.8"/>
+    </pattern>
+    <style>
+      .g { stroke:#114233; stroke-linecap:round; stroke-opacity:.9; }
+      .s { fill:#0c2e24; opacity:.96; }
+    </style>
+  </defs>
+  <image href="/assets/game-art/baduk-battle-royal/boards/ogs-anime-board.svg" x="0" y="0" width="1024" height="1024" preserveAspectRatio="none"/>
+  <rect x="86" y="86" width="852" height="852" fill="url(#woodTint)"/>
+  <rect x="86" y="86" width="852" height="852" fill="url(#grain)"/>
+  <line x1="86.0000" y1="86" x2="86.0000" y2="938" class="g" stroke-width="3.2"/>
+  <line x1="86" y1="86.0000" x2="938" y2="86.0000" class="g" stroke-width="3.2"/>
+  <line x1="192.5000" y1="86" x2="192.5000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="192.5000" x2="938" y2="192.5000" class="g" stroke-width="2.2"/>
+  <line x1="299.0000" y1="86" x2="299.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="299.0000" x2="938" y2="299.0000" class="g" stroke-width="2.2"/>
+  <line x1="405.5000" y1="86" x2="405.5000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="405.5000" x2="938" y2="405.5000" class="g" stroke-width="2.2"/>
+  <line x1="512.0000" y1="86" x2="512.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="512.0000" x2="938" y2="512.0000" class="g" stroke-width="2.2"/>
+  <line x1="618.5000" y1="86" x2="618.5000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="618.5000" x2="938" y2="618.5000" class="g" stroke-width="2.2"/>
+  <line x1="725.0000" y1="86" x2="725.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="725.0000" x2="938" y2="725.0000" class="g" stroke-width="2.2"/>
+  <line x1="831.5000" y1="86" x2="831.5000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="831.5000" x2="938" y2="831.5000" class="g" stroke-width="2.2"/>
+  <line x1="938.0000" y1="86" x2="938.0000" y2="938" class="g" stroke-width="3.2"/>
+  <line x1="86" y1="938.0000" x2="938" y2="938.0000" class="g" stroke-width="3.2"/>
+  <circle cx="299.0000" cy="299.0000" r="6.6" class="s"/>
+  <circle cx="725.0000" cy="299.0000" r="6.6" class="s"/>
+  <circle cx="299.0000" cy="725.0000" r="6.6" class="s"/>
+  <circle cx="725.0000" cy="725.0000" r="6.6" class="s"/>
+  <circle cx="512.0000" cy="512.0000" r="6.6" class="s"/>
+</svg>

--- a/webapp/public/assets/game-art/baduk-battle-royal/boards/midnight-13x13.svg
+++ b/webapp/public/assets/game-art/baduk-battle-royal/boards/midnight-13x13.svg
@@ -1,0 +1,50 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024">
+  <defs>
+    <linearGradient id="woodTint" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#6b7280" stop-opacity="0.26"/>
+      <stop offset="100%" stop-color="#111827" stop-opacity="0.22"/>
+    </linearGradient>
+    <pattern id="grain" width="24" height="24" patternUnits="userSpaceOnUse">
+      <path d="M0 12h24" stroke="#1f2937" stroke-opacity="0.06" stroke-width="1"/>
+      <path d="M0 6h24" stroke="#ffffff" stroke-opacity="0.04" stroke-width="0.8"/>
+    </pattern>
+    <style>
+      .g { stroke:#f3f4f6; stroke-linecap:round; stroke-opacity:.9; }
+      .s { fill:#d1d5db; opacity:.96; }
+    </style>
+  </defs>
+  <image href="/assets/game-art/baduk-battle-royal/boards/ogs-anime-board.svg" x="0" y="0" width="1024" height="1024" preserveAspectRatio="none"/>
+  <rect x="86" y="86" width="852" height="852" fill="url(#woodTint)"/>
+  <rect x="86" y="86" width="852" height="852" fill="url(#grain)"/>
+  <line x1="86.0000" y1="86" x2="86.0000" y2="938" class="g" stroke-width="3.2"/>
+  <line x1="86" y1="86.0000" x2="938" y2="86.0000" class="g" stroke-width="3.2"/>
+  <line x1="157.0000" y1="86" x2="157.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="157.0000" x2="938" y2="157.0000" class="g" stroke-width="2.2"/>
+  <line x1="228.0000" y1="86" x2="228.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="228.0000" x2="938" y2="228.0000" class="g" stroke-width="2.2"/>
+  <line x1="299.0000" y1="86" x2="299.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="299.0000" x2="938" y2="299.0000" class="g" stroke-width="2.2"/>
+  <line x1="370.0000" y1="86" x2="370.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="370.0000" x2="938" y2="370.0000" class="g" stroke-width="2.2"/>
+  <line x1="441.0000" y1="86" x2="441.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="441.0000" x2="938" y2="441.0000" class="g" stroke-width="2.2"/>
+  <line x1="512.0000" y1="86" x2="512.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="512.0000" x2="938" y2="512.0000" class="g" stroke-width="2.2"/>
+  <line x1="583.0000" y1="86" x2="583.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="583.0000" x2="938" y2="583.0000" class="g" stroke-width="2.2"/>
+  <line x1="654.0000" y1="86" x2="654.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="654.0000" x2="938" y2="654.0000" class="g" stroke-width="2.2"/>
+  <line x1="725.0000" y1="86" x2="725.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="725.0000" x2="938" y2="725.0000" class="g" stroke-width="2.2"/>
+  <line x1="796.0000" y1="86" x2="796.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="796.0000" x2="938" y2="796.0000" class="g" stroke-width="2.2"/>
+  <line x1="867.0000" y1="86" x2="867.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="867.0000" x2="938" y2="867.0000" class="g" stroke-width="2.2"/>
+  <line x1="938.0000" y1="86" x2="938.0000" y2="938" class="g" stroke-width="3.2"/>
+  <line x1="86" y1="938.0000" x2="938" y2="938.0000" class="g" stroke-width="3.2"/>
+  <circle cx="299.0000" cy="299.0000" r="6.6" class="s"/>
+  <circle cx="725.0000" cy="299.0000" r="6.6" class="s"/>
+  <circle cx="299.0000" cy="725.0000" r="6.6" class="s"/>
+  <circle cx="725.0000" cy="725.0000" r="6.6" class="s"/>
+  <circle cx="512.0000" cy="512.0000" r="6.6" class="s"/>
+</svg>

--- a/webapp/public/assets/game-art/baduk-battle-royal/boards/midnight-16x16.svg
+++ b/webapp/public/assets/game-art/baduk-battle-royal/boards/midnight-16x16.svg
@@ -1,0 +1,59 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024">
+  <defs>
+    <linearGradient id="woodTint" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#6b7280" stop-opacity="0.26"/>
+      <stop offset="100%" stop-color="#111827" stop-opacity="0.22"/>
+    </linearGradient>
+    <pattern id="grain" width="24" height="24" patternUnits="userSpaceOnUse">
+      <path d="M0 12h24" stroke="#1f2937" stroke-opacity="0.06" stroke-width="1"/>
+      <path d="M0 6h24" stroke="#ffffff" stroke-opacity="0.04" stroke-width="0.8"/>
+    </pattern>
+    <style>
+      .g { stroke:#f3f4f6; stroke-linecap:round; stroke-opacity:.9; }
+      .s { fill:#d1d5db; opacity:.96; }
+    </style>
+  </defs>
+  <image href="/assets/game-art/baduk-battle-royal/boards/ogs-anime-board.svg" x="0" y="0" width="1024" height="1024" preserveAspectRatio="none"/>
+  <rect x="86" y="86" width="852" height="852" fill="url(#woodTint)"/>
+  <rect x="86" y="86" width="852" height="852" fill="url(#grain)"/>
+  <line x1="86.0000" y1="86" x2="86.0000" y2="938" class="g" stroke-width="3.2"/>
+  <line x1="86" y1="86.0000" x2="938" y2="86.0000" class="g" stroke-width="3.2"/>
+  <line x1="142.8000" y1="86" x2="142.8000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="142.8000" x2="938" y2="142.8000" class="g" stroke-width="2.2"/>
+  <line x1="199.6000" y1="86" x2="199.6000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="199.6000" x2="938" y2="199.6000" class="g" stroke-width="2.2"/>
+  <line x1="256.4000" y1="86" x2="256.4000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="256.4000" x2="938" y2="256.4000" class="g" stroke-width="2.2"/>
+  <line x1="313.2000" y1="86" x2="313.2000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="313.2000" x2="938" y2="313.2000" class="g" stroke-width="2.2"/>
+  <line x1="370.0000" y1="86" x2="370.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="370.0000" x2="938" y2="370.0000" class="g" stroke-width="2.2"/>
+  <line x1="426.8000" y1="86" x2="426.8000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="426.8000" x2="938" y2="426.8000" class="g" stroke-width="2.2"/>
+  <line x1="483.6000" y1="86" x2="483.6000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="483.6000" x2="938" y2="483.6000" class="g" stroke-width="2.2"/>
+  <line x1="540.4000" y1="86" x2="540.4000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="540.4000" x2="938" y2="540.4000" class="g" stroke-width="2.2"/>
+  <line x1="597.2000" y1="86" x2="597.2000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="597.2000" x2="938" y2="597.2000" class="g" stroke-width="2.2"/>
+  <line x1="654.0000" y1="86" x2="654.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="654.0000" x2="938" y2="654.0000" class="g" stroke-width="2.2"/>
+  <line x1="710.8000" y1="86" x2="710.8000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="710.8000" x2="938" y2="710.8000" class="g" stroke-width="2.2"/>
+  <line x1="767.6000" y1="86" x2="767.6000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="767.6000" x2="938" y2="767.6000" class="g" stroke-width="2.2"/>
+  <line x1="824.4000" y1="86" x2="824.4000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="824.4000" x2="938" y2="824.4000" class="g" stroke-width="2.2"/>
+  <line x1="881.2000" y1="86" x2="881.2000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="881.2000" x2="938" y2="881.2000" class="g" stroke-width="2.2"/>
+  <line x1="938.0000" y1="86" x2="938.0000" y2="938" class="g" stroke-width="3.2"/>
+  <line x1="86" y1="938.0000" x2="938" y2="938.0000" class="g" stroke-width="3.2"/>
+  <circle cx="256.4000" cy="256.4000" r="6.6" class="s"/>
+  <circle cx="767.6000" cy="256.4000" r="6.6" class="s"/>
+  <circle cx="256.4000" cy="767.6000" r="6.6" class="s"/>
+  <circle cx="767.6000" cy="767.6000" r="6.6" class="s"/>
+  <circle cx="483.6000" cy="483.6000" r="6.6" class="s"/>
+  <circle cx="540.4000" cy="483.6000" r="6.6" class="s"/>
+  <circle cx="483.6000" cy="540.4000" r="6.6" class="s"/>
+  <circle cx="540.4000" cy="540.4000" r="6.6" class="s"/>
+</svg>

--- a/webapp/public/assets/game-art/baduk-battle-royal/boards/midnight-19x19.svg
+++ b/webapp/public/assets/game-art/baduk-battle-royal/boards/midnight-19x19.svg
@@ -1,0 +1,66 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024">
+  <defs>
+    <linearGradient id="woodTint" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#6b7280" stop-opacity="0.26"/>
+      <stop offset="100%" stop-color="#111827" stop-opacity="0.22"/>
+    </linearGradient>
+    <pattern id="grain" width="24" height="24" patternUnits="userSpaceOnUse">
+      <path d="M0 12h24" stroke="#1f2937" stroke-opacity="0.06" stroke-width="1"/>
+      <path d="M0 6h24" stroke="#ffffff" stroke-opacity="0.04" stroke-width="0.8"/>
+    </pattern>
+    <style>
+      .g { stroke:#f3f4f6; stroke-linecap:round; stroke-opacity:.9; }
+      .s { fill:#d1d5db; opacity:.96; }
+    </style>
+  </defs>
+  <image href="/assets/game-art/baduk-battle-royal/boards/ogs-anime-board.svg" x="0" y="0" width="1024" height="1024" preserveAspectRatio="none"/>
+  <rect x="86" y="86" width="852" height="852" fill="url(#woodTint)"/>
+  <rect x="86" y="86" width="852" height="852" fill="url(#grain)"/>
+  <line x1="86.0000" y1="86" x2="86.0000" y2="938" class="g" stroke-width="3.2"/>
+  <line x1="86" y1="86.0000" x2="938" y2="86.0000" class="g" stroke-width="3.2"/>
+  <line x1="133.3333" y1="86" x2="133.3333" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="133.3333" x2="938" y2="133.3333" class="g" stroke-width="2.2"/>
+  <line x1="180.6667" y1="86" x2="180.6667" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="180.6667" x2="938" y2="180.6667" class="g" stroke-width="2.2"/>
+  <line x1="228.0000" y1="86" x2="228.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="228.0000" x2="938" y2="228.0000" class="g" stroke-width="2.2"/>
+  <line x1="275.3333" y1="86" x2="275.3333" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="275.3333" x2="938" y2="275.3333" class="g" stroke-width="2.2"/>
+  <line x1="322.6667" y1="86" x2="322.6667" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="322.6667" x2="938" y2="322.6667" class="g" stroke-width="2.2"/>
+  <line x1="370.0000" y1="86" x2="370.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="370.0000" x2="938" y2="370.0000" class="g" stroke-width="2.2"/>
+  <line x1="417.3333" y1="86" x2="417.3333" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="417.3333" x2="938" y2="417.3333" class="g" stroke-width="2.2"/>
+  <line x1="464.6667" y1="86" x2="464.6667" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="464.6667" x2="938" y2="464.6667" class="g" stroke-width="2.2"/>
+  <line x1="512.0000" y1="86" x2="512.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="512.0000" x2="938" y2="512.0000" class="g" stroke-width="2.2"/>
+  <line x1="559.3333" y1="86" x2="559.3333" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="559.3333" x2="938" y2="559.3333" class="g" stroke-width="2.2"/>
+  <line x1="606.6667" y1="86" x2="606.6667" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="606.6667" x2="938" y2="606.6667" class="g" stroke-width="2.2"/>
+  <line x1="654.0000" y1="86" x2="654.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="654.0000" x2="938" y2="654.0000" class="g" stroke-width="2.2"/>
+  <line x1="701.3333" y1="86" x2="701.3333" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="701.3333" x2="938" y2="701.3333" class="g" stroke-width="2.2"/>
+  <line x1="748.6667" y1="86" x2="748.6667" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="748.6667" x2="938" y2="748.6667" class="g" stroke-width="2.2"/>
+  <line x1="796.0000" y1="86" x2="796.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="796.0000" x2="938" y2="796.0000" class="g" stroke-width="2.2"/>
+  <line x1="843.3333" y1="86" x2="843.3333" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="843.3333" x2="938" y2="843.3333" class="g" stroke-width="2.2"/>
+  <line x1="890.6667" y1="86" x2="890.6667" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="890.6667" x2="938" y2="890.6667" class="g" stroke-width="2.2"/>
+  <line x1="938.0000" y1="86" x2="938.0000" y2="938" class="g" stroke-width="3.2"/>
+  <line x1="86" y1="938.0000" x2="938" y2="938.0000" class="g" stroke-width="3.2"/>
+  <circle cx="228.0000" cy="228.0000" r="6.6" class="s"/>
+  <circle cx="512.0000" cy="228.0000" r="6.6" class="s"/>
+  <circle cx="796.0000" cy="228.0000" r="6.6" class="s"/>
+  <circle cx="228.0000" cy="512.0000" r="6.6" class="s"/>
+  <circle cx="512.0000" cy="512.0000" r="6.6" class="s"/>
+  <circle cx="796.0000" cy="512.0000" r="6.6" class="s"/>
+  <circle cx="228.0000" cy="796.0000" r="6.6" class="s"/>
+  <circle cx="512.0000" cy="796.0000" r="6.6" class="s"/>
+  <circle cx="796.0000" cy="796.0000" r="6.6" class="s"/>
+</svg>

--- a/webapp/public/assets/game-art/baduk-battle-royal/boards/midnight-9x9.svg
+++ b/webapp/public/assets/game-art/baduk-battle-royal/boards/midnight-9x9.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024">
+  <defs>
+    <linearGradient id="woodTint" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#6b7280" stop-opacity="0.26"/>
+      <stop offset="100%" stop-color="#111827" stop-opacity="0.22"/>
+    </linearGradient>
+    <pattern id="grain" width="24" height="24" patternUnits="userSpaceOnUse">
+      <path d="M0 12h24" stroke="#1f2937" stroke-opacity="0.06" stroke-width="1"/>
+      <path d="M0 6h24" stroke="#ffffff" stroke-opacity="0.04" stroke-width="0.8"/>
+    </pattern>
+    <style>
+      .g { stroke:#f3f4f6; stroke-linecap:round; stroke-opacity:.9; }
+      .s { fill:#d1d5db; opacity:.96; }
+    </style>
+  </defs>
+  <image href="/assets/game-art/baduk-battle-royal/boards/ogs-anime-board.svg" x="0" y="0" width="1024" height="1024" preserveAspectRatio="none"/>
+  <rect x="86" y="86" width="852" height="852" fill="url(#woodTint)"/>
+  <rect x="86" y="86" width="852" height="852" fill="url(#grain)"/>
+  <line x1="86.0000" y1="86" x2="86.0000" y2="938" class="g" stroke-width="3.2"/>
+  <line x1="86" y1="86.0000" x2="938" y2="86.0000" class="g" stroke-width="3.2"/>
+  <line x1="192.5000" y1="86" x2="192.5000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="192.5000" x2="938" y2="192.5000" class="g" stroke-width="2.2"/>
+  <line x1="299.0000" y1="86" x2="299.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="299.0000" x2="938" y2="299.0000" class="g" stroke-width="2.2"/>
+  <line x1="405.5000" y1="86" x2="405.5000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="405.5000" x2="938" y2="405.5000" class="g" stroke-width="2.2"/>
+  <line x1="512.0000" y1="86" x2="512.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="512.0000" x2="938" y2="512.0000" class="g" stroke-width="2.2"/>
+  <line x1="618.5000" y1="86" x2="618.5000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="618.5000" x2="938" y2="618.5000" class="g" stroke-width="2.2"/>
+  <line x1="725.0000" y1="86" x2="725.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="725.0000" x2="938" y2="725.0000" class="g" stroke-width="2.2"/>
+  <line x1="831.5000" y1="86" x2="831.5000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="831.5000" x2="938" y2="831.5000" class="g" stroke-width="2.2"/>
+  <line x1="938.0000" y1="86" x2="938.0000" y2="938" class="g" stroke-width="3.2"/>
+  <line x1="86" y1="938.0000" x2="938" y2="938.0000" class="g" stroke-width="3.2"/>
+  <circle cx="299.0000" cy="299.0000" r="6.6" class="s"/>
+  <circle cx="725.0000" cy="299.0000" r="6.6" class="s"/>
+  <circle cx="299.0000" cy="725.0000" r="6.6" class="s"/>
+  <circle cx="725.0000" cy="725.0000" r="6.6" class="s"/>
+  <circle cx="512.0000" cy="512.0000" r="6.6" class="s"/>
+</svg>

--- a/webapp/public/assets/game-art/baduk-battle-royal/boards/slate-13x13.svg
+++ b/webapp/public/assets/game-art/baduk-battle-royal/boards/slate-13x13.svg
@@ -1,0 +1,50 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024">
+  <defs>
+    <linearGradient id="woodTint" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#b9c2d0" stop-opacity="0.26"/>
+      <stop offset="100%" stop-color="#4b5563" stop-opacity="0.22"/>
+    </linearGradient>
+    <pattern id="grain" width="24" height="24" patternUnits="userSpaceOnUse">
+      <path d="M0 12h24" stroke="#334155" stroke-opacity="0.06" stroke-width="1"/>
+      <path d="M0 6h24" stroke="#f8fafc" stroke-opacity="0.04" stroke-width="0.8"/>
+    </pattern>
+    <style>
+      .g { stroke:#0f172a; stroke-linecap:round; stroke-opacity:.9; }
+      .s { fill:#0b1120; opacity:.96; }
+    </style>
+  </defs>
+  <image href="/assets/game-art/baduk-battle-royal/boards/ogs-anime-board.svg" x="0" y="0" width="1024" height="1024" preserveAspectRatio="none"/>
+  <rect x="86" y="86" width="852" height="852" fill="url(#woodTint)"/>
+  <rect x="86" y="86" width="852" height="852" fill="url(#grain)"/>
+  <line x1="86.0000" y1="86" x2="86.0000" y2="938" class="g" stroke-width="3.2"/>
+  <line x1="86" y1="86.0000" x2="938" y2="86.0000" class="g" stroke-width="3.2"/>
+  <line x1="157.0000" y1="86" x2="157.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="157.0000" x2="938" y2="157.0000" class="g" stroke-width="2.2"/>
+  <line x1="228.0000" y1="86" x2="228.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="228.0000" x2="938" y2="228.0000" class="g" stroke-width="2.2"/>
+  <line x1="299.0000" y1="86" x2="299.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="299.0000" x2="938" y2="299.0000" class="g" stroke-width="2.2"/>
+  <line x1="370.0000" y1="86" x2="370.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="370.0000" x2="938" y2="370.0000" class="g" stroke-width="2.2"/>
+  <line x1="441.0000" y1="86" x2="441.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="441.0000" x2="938" y2="441.0000" class="g" stroke-width="2.2"/>
+  <line x1="512.0000" y1="86" x2="512.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="512.0000" x2="938" y2="512.0000" class="g" stroke-width="2.2"/>
+  <line x1="583.0000" y1="86" x2="583.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="583.0000" x2="938" y2="583.0000" class="g" stroke-width="2.2"/>
+  <line x1="654.0000" y1="86" x2="654.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="654.0000" x2="938" y2="654.0000" class="g" stroke-width="2.2"/>
+  <line x1="725.0000" y1="86" x2="725.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="725.0000" x2="938" y2="725.0000" class="g" stroke-width="2.2"/>
+  <line x1="796.0000" y1="86" x2="796.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="796.0000" x2="938" y2="796.0000" class="g" stroke-width="2.2"/>
+  <line x1="867.0000" y1="86" x2="867.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="867.0000" x2="938" y2="867.0000" class="g" stroke-width="2.2"/>
+  <line x1="938.0000" y1="86" x2="938.0000" y2="938" class="g" stroke-width="3.2"/>
+  <line x1="86" y1="938.0000" x2="938" y2="938.0000" class="g" stroke-width="3.2"/>
+  <circle cx="299.0000" cy="299.0000" r="6.6" class="s"/>
+  <circle cx="725.0000" cy="299.0000" r="6.6" class="s"/>
+  <circle cx="299.0000" cy="725.0000" r="6.6" class="s"/>
+  <circle cx="725.0000" cy="725.0000" r="6.6" class="s"/>
+  <circle cx="512.0000" cy="512.0000" r="6.6" class="s"/>
+</svg>

--- a/webapp/public/assets/game-art/baduk-battle-royal/boards/slate-16x16.svg
+++ b/webapp/public/assets/game-art/baduk-battle-royal/boards/slate-16x16.svg
@@ -1,0 +1,59 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024">
+  <defs>
+    <linearGradient id="woodTint" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#b9c2d0" stop-opacity="0.26"/>
+      <stop offset="100%" stop-color="#4b5563" stop-opacity="0.22"/>
+    </linearGradient>
+    <pattern id="grain" width="24" height="24" patternUnits="userSpaceOnUse">
+      <path d="M0 12h24" stroke="#334155" stroke-opacity="0.06" stroke-width="1"/>
+      <path d="M0 6h24" stroke="#f8fafc" stroke-opacity="0.04" stroke-width="0.8"/>
+    </pattern>
+    <style>
+      .g { stroke:#0f172a; stroke-linecap:round; stroke-opacity:.9; }
+      .s { fill:#0b1120; opacity:.96; }
+    </style>
+  </defs>
+  <image href="/assets/game-art/baduk-battle-royal/boards/ogs-anime-board.svg" x="0" y="0" width="1024" height="1024" preserveAspectRatio="none"/>
+  <rect x="86" y="86" width="852" height="852" fill="url(#woodTint)"/>
+  <rect x="86" y="86" width="852" height="852" fill="url(#grain)"/>
+  <line x1="86.0000" y1="86" x2="86.0000" y2="938" class="g" stroke-width="3.2"/>
+  <line x1="86" y1="86.0000" x2="938" y2="86.0000" class="g" stroke-width="3.2"/>
+  <line x1="142.8000" y1="86" x2="142.8000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="142.8000" x2="938" y2="142.8000" class="g" stroke-width="2.2"/>
+  <line x1="199.6000" y1="86" x2="199.6000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="199.6000" x2="938" y2="199.6000" class="g" stroke-width="2.2"/>
+  <line x1="256.4000" y1="86" x2="256.4000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="256.4000" x2="938" y2="256.4000" class="g" stroke-width="2.2"/>
+  <line x1="313.2000" y1="86" x2="313.2000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="313.2000" x2="938" y2="313.2000" class="g" stroke-width="2.2"/>
+  <line x1="370.0000" y1="86" x2="370.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="370.0000" x2="938" y2="370.0000" class="g" stroke-width="2.2"/>
+  <line x1="426.8000" y1="86" x2="426.8000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="426.8000" x2="938" y2="426.8000" class="g" stroke-width="2.2"/>
+  <line x1="483.6000" y1="86" x2="483.6000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="483.6000" x2="938" y2="483.6000" class="g" stroke-width="2.2"/>
+  <line x1="540.4000" y1="86" x2="540.4000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="540.4000" x2="938" y2="540.4000" class="g" stroke-width="2.2"/>
+  <line x1="597.2000" y1="86" x2="597.2000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="597.2000" x2="938" y2="597.2000" class="g" stroke-width="2.2"/>
+  <line x1="654.0000" y1="86" x2="654.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="654.0000" x2="938" y2="654.0000" class="g" stroke-width="2.2"/>
+  <line x1="710.8000" y1="86" x2="710.8000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="710.8000" x2="938" y2="710.8000" class="g" stroke-width="2.2"/>
+  <line x1="767.6000" y1="86" x2="767.6000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="767.6000" x2="938" y2="767.6000" class="g" stroke-width="2.2"/>
+  <line x1="824.4000" y1="86" x2="824.4000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="824.4000" x2="938" y2="824.4000" class="g" stroke-width="2.2"/>
+  <line x1="881.2000" y1="86" x2="881.2000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="881.2000" x2="938" y2="881.2000" class="g" stroke-width="2.2"/>
+  <line x1="938.0000" y1="86" x2="938.0000" y2="938" class="g" stroke-width="3.2"/>
+  <line x1="86" y1="938.0000" x2="938" y2="938.0000" class="g" stroke-width="3.2"/>
+  <circle cx="256.4000" cy="256.4000" r="6.6" class="s"/>
+  <circle cx="767.6000" cy="256.4000" r="6.6" class="s"/>
+  <circle cx="256.4000" cy="767.6000" r="6.6" class="s"/>
+  <circle cx="767.6000" cy="767.6000" r="6.6" class="s"/>
+  <circle cx="483.6000" cy="483.6000" r="6.6" class="s"/>
+  <circle cx="540.4000" cy="483.6000" r="6.6" class="s"/>
+  <circle cx="483.6000" cy="540.4000" r="6.6" class="s"/>
+  <circle cx="540.4000" cy="540.4000" r="6.6" class="s"/>
+</svg>

--- a/webapp/public/assets/game-art/baduk-battle-royal/boards/slate-19x19.svg
+++ b/webapp/public/assets/game-art/baduk-battle-royal/boards/slate-19x19.svg
@@ -1,0 +1,66 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024">
+  <defs>
+    <linearGradient id="woodTint" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#b9c2d0" stop-opacity="0.26"/>
+      <stop offset="100%" stop-color="#4b5563" stop-opacity="0.22"/>
+    </linearGradient>
+    <pattern id="grain" width="24" height="24" patternUnits="userSpaceOnUse">
+      <path d="M0 12h24" stroke="#334155" stroke-opacity="0.06" stroke-width="1"/>
+      <path d="M0 6h24" stroke="#f8fafc" stroke-opacity="0.04" stroke-width="0.8"/>
+    </pattern>
+    <style>
+      .g { stroke:#0f172a; stroke-linecap:round; stroke-opacity:.9; }
+      .s { fill:#0b1120; opacity:.96; }
+    </style>
+  </defs>
+  <image href="/assets/game-art/baduk-battle-royal/boards/ogs-anime-board.svg" x="0" y="0" width="1024" height="1024" preserveAspectRatio="none"/>
+  <rect x="86" y="86" width="852" height="852" fill="url(#woodTint)"/>
+  <rect x="86" y="86" width="852" height="852" fill="url(#grain)"/>
+  <line x1="86.0000" y1="86" x2="86.0000" y2="938" class="g" stroke-width="3.2"/>
+  <line x1="86" y1="86.0000" x2="938" y2="86.0000" class="g" stroke-width="3.2"/>
+  <line x1="133.3333" y1="86" x2="133.3333" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="133.3333" x2="938" y2="133.3333" class="g" stroke-width="2.2"/>
+  <line x1="180.6667" y1="86" x2="180.6667" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="180.6667" x2="938" y2="180.6667" class="g" stroke-width="2.2"/>
+  <line x1="228.0000" y1="86" x2="228.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="228.0000" x2="938" y2="228.0000" class="g" stroke-width="2.2"/>
+  <line x1="275.3333" y1="86" x2="275.3333" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="275.3333" x2="938" y2="275.3333" class="g" stroke-width="2.2"/>
+  <line x1="322.6667" y1="86" x2="322.6667" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="322.6667" x2="938" y2="322.6667" class="g" stroke-width="2.2"/>
+  <line x1="370.0000" y1="86" x2="370.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="370.0000" x2="938" y2="370.0000" class="g" stroke-width="2.2"/>
+  <line x1="417.3333" y1="86" x2="417.3333" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="417.3333" x2="938" y2="417.3333" class="g" stroke-width="2.2"/>
+  <line x1="464.6667" y1="86" x2="464.6667" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="464.6667" x2="938" y2="464.6667" class="g" stroke-width="2.2"/>
+  <line x1="512.0000" y1="86" x2="512.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="512.0000" x2="938" y2="512.0000" class="g" stroke-width="2.2"/>
+  <line x1="559.3333" y1="86" x2="559.3333" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="559.3333" x2="938" y2="559.3333" class="g" stroke-width="2.2"/>
+  <line x1="606.6667" y1="86" x2="606.6667" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="606.6667" x2="938" y2="606.6667" class="g" stroke-width="2.2"/>
+  <line x1="654.0000" y1="86" x2="654.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="654.0000" x2="938" y2="654.0000" class="g" stroke-width="2.2"/>
+  <line x1="701.3333" y1="86" x2="701.3333" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="701.3333" x2="938" y2="701.3333" class="g" stroke-width="2.2"/>
+  <line x1="748.6667" y1="86" x2="748.6667" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="748.6667" x2="938" y2="748.6667" class="g" stroke-width="2.2"/>
+  <line x1="796.0000" y1="86" x2="796.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="796.0000" x2="938" y2="796.0000" class="g" stroke-width="2.2"/>
+  <line x1="843.3333" y1="86" x2="843.3333" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="843.3333" x2="938" y2="843.3333" class="g" stroke-width="2.2"/>
+  <line x1="890.6667" y1="86" x2="890.6667" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="890.6667" x2="938" y2="890.6667" class="g" stroke-width="2.2"/>
+  <line x1="938.0000" y1="86" x2="938.0000" y2="938" class="g" stroke-width="3.2"/>
+  <line x1="86" y1="938.0000" x2="938" y2="938.0000" class="g" stroke-width="3.2"/>
+  <circle cx="228.0000" cy="228.0000" r="6.6" class="s"/>
+  <circle cx="512.0000" cy="228.0000" r="6.6" class="s"/>
+  <circle cx="796.0000" cy="228.0000" r="6.6" class="s"/>
+  <circle cx="228.0000" cy="512.0000" r="6.6" class="s"/>
+  <circle cx="512.0000" cy="512.0000" r="6.6" class="s"/>
+  <circle cx="796.0000" cy="512.0000" r="6.6" class="s"/>
+  <circle cx="228.0000" cy="796.0000" r="6.6" class="s"/>
+  <circle cx="512.0000" cy="796.0000" r="6.6" class="s"/>
+  <circle cx="796.0000" cy="796.0000" r="6.6" class="s"/>
+</svg>

--- a/webapp/public/assets/game-art/baduk-battle-royal/boards/slate-9x9.svg
+++ b/webapp/public/assets/game-art/baduk-battle-royal/boards/slate-9x9.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024">
+  <defs>
+    <linearGradient id="woodTint" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#b9c2d0" stop-opacity="0.26"/>
+      <stop offset="100%" stop-color="#4b5563" stop-opacity="0.22"/>
+    </linearGradient>
+    <pattern id="grain" width="24" height="24" patternUnits="userSpaceOnUse">
+      <path d="M0 12h24" stroke="#334155" stroke-opacity="0.06" stroke-width="1"/>
+      <path d="M0 6h24" stroke="#f8fafc" stroke-opacity="0.04" stroke-width="0.8"/>
+    </pattern>
+    <style>
+      .g { stroke:#0f172a; stroke-linecap:round; stroke-opacity:.9; }
+      .s { fill:#0b1120; opacity:.96; }
+    </style>
+  </defs>
+  <image href="/assets/game-art/baduk-battle-royal/boards/ogs-anime-board.svg" x="0" y="0" width="1024" height="1024" preserveAspectRatio="none"/>
+  <rect x="86" y="86" width="852" height="852" fill="url(#woodTint)"/>
+  <rect x="86" y="86" width="852" height="852" fill="url(#grain)"/>
+  <line x1="86.0000" y1="86" x2="86.0000" y2="938" class="g" stroke-width="3.2"/>
+  <line x1="86" y1="86.0000" x2="938" y2="86.0000" class="g" stroke-width="3.2"/>
+  <line x1="192.5000" y1="86" x2="192.5000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="192.5000" x2="938" y2="192.5000" class="g" stroke-width="2.2"/>
+  <line x1="299.0000" y1="86" x2="299.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="299.0000" x2="938" y2="299.0000" class="g" stroke-width="2.2"/>
+  <line x1="405.5000" y1="86" x2="405.5000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="405.5000" x2="938" y2="405.5000" class="g" stroke-width="2.2"/>
+  <line x1="512.0000" y1="86" x2="512.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="512.0000" x2="938" y2="512.0000" class="g" stroke-width="2.2"/>
+  <line x1="618.5000" y1="86" x2="618.5000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="618.5000" x2="938" y2="618.5000" class="g" stroke-width="2.2"/>
+  <line x1="725.0000" y1="86" x2="725.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="725.0000" x2="938" y2="725.0000" class="g" stroke-width="2.2"/>
+  <line x1="831.5000" y1="86" x2="831.5000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="831.5000" x2="938" y2="831.5000" class="g" stroke-width="2.2"/>
+  <line x1="938.0000" y1="86" x2="938.0000" y2="938" class="g" stroke-width="3.2"/>
+  <line x1="86" y1="938.0000" x2="938" y2="938.0000" class="g" stroke-width="3.2"/>
+  <circle cx="299.0000" cy="299.0000" r="6.6" class="s"/>
+  <circle cx="725.0000" cy="299.0000" r="6.6" class="s"/>
+  <circle cx="299.0000" cy="725.0000" r="6.6" class="s"/>
+  <circle cx="725.0000" cy="725.0000" r="6.6" class="s"/>
+  <circle cx="512.0000" cy="512.0000" r="6.6" class="s"/>
+</svg>

--- a/webapp/public/assets/game-art/baduk-battle-royal/boards/walnut-13x13.svg
+++ b/webapp/public/assets/game-art/baduk-battle-royal/boards/walnut-13x13.svg
@@ -1,0 +1,50 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024">
+  <defs>
+    <linearGradient id="woodTint" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#c99662" stop-opacity="0.26"/>
+      <stop offset="100%" stop-color="#5c3418" stop-opacity="0.22"/>
+    </linearGradient>
+    <pattern id="grain" width="24" height="24" patternUnits="userSpaceOnUse">
+      <path d="M0 12h24" stroke="#5b371f" stroke-opacity="0.06" stroke-width="1"/>
+      <path d="M0 6h24" stroke="#f9f3e8" stroke-opacity="0.04" stroke-width="0.8"/>
+    </pattern>
+    <style>
+      .g { stroke:#2b180d; stroke-linecap:round; stroke-opacity:.9; }
+      .s { fill:#2a1103; opacity:.96; }
+    </style>
+  </defs>
+  <image href="/assets/game-art/baduk-battle-royal/boards/ogs-anime-board.svg" x="0" y="0" width="1024" height="1024" preserveAspectRatio="none"/>
+  <rect x="86" y="86" width="852" height="852" fill="url(#woodTint)"/>
+  <rect x="86" y="86" width="852" height="852" fill="url(#grain)"/>
+  <line x1="86.0000" y1="86" x2="86.0000" y2="938" class="g" stroke-width="3.2"/>
+  <line x1="86" y1="86.0000" x2="938" y2="86.0000" class="g" stroke-width="3.2"/>
+  <line x1="157.0000" y1="86" x2="157.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="157.0000" x2="938" y2="157.0000" class="g" stroke-width="2.2"/>
+  <line x1="228.0000" y1="86" x2="228.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="228.0000" x2="938" y2="228.0000" class="g" stroke-width="2.2"/>
+  <line x1="299.0000" y1="86" x2="299.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="299.0000" x2="938" y2="299.0000" class="g" stroke-width="2.2"/>
+  <line x1="370.0000" y1="86" x2="370.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="370.0000" x2="938" y2="370.0000" class="g" stroke-width="2.2"/>
+  <line x1="441.0000" y1="86" x2="441.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="441.0000" x2="938" y2="441.0000" class="g" stroke-width="2.2"/>
+  <line x1="512.0000" y1="86" x2="512.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="512.0000" x2="938" y2="512.0000" class="g" stroke-width="2.2"/>
+  <line x1="583.0000" y1="86" x2="583.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="583.0000" x2="938" y2="583.0000" class="g" stroke-width="2.2"/>
+  <line x1="654.0000" y1="86" x2="654.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="654.0000" x2="938" y2="654.0000" class="g" stroke-width="2.2"/>
+  <line x1="725.0000" y1="86" x2="725.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="725.0000" x2="938" y2="725.0000" class="g" stroke-width="2.2"/>
+  <line x1="796.0000" y1="86" x2="796.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="796.0000" x2="938" y2="796.0000" class="g" stroke-width="2.2"/>
+  <line x1="867.0000" y1="86" x2="867.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="867.0000" x2="938" y2="867.0000" class="g" stroke-width="2.2"/>
+  <line x1="938.0000" y1="86" x2="938.0000" y2="938" class="g" stroke-width="3.2"/>
+  <line x1="86" y1="938.0000" x2="938" y2="938.0000" class="g" stroke-width="3.2"/>
+  <circle cx="299.0000" cy="299.0000" r="6.6" class="s"/>
+  <circle cx="725.0000" cy="299.0000" r="6.6" class="s"/>
+  <circle cx="299.0000" cy="725.0000" r="6.6" class="s"/>
+  <circle cx="725.0000" cy="725.0000" r="6.6" class="s"/>
+  <circle cx="512.0000" cy="512.0000" r="6.6" class="s"/>
+</svg>

--- a/webapp/public/assets/game-art/baduk-battle-royal/boards/walnut-16x16.svg
+++ b/webapp/public/assets/game-art/baduk-battle-royal/boards/walnut-16x16.svg
@@ -1,0 +1,59 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024">
+  <defs>
+    <linearGradient id="woodTint" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#c99662" stop-opacity="0.26"/>
+      <stop offset="100%" stop-color="#5c3418" stop-opacity="0.22"/>
+    </linearGradient>
+    <pattern id="grain" width="24" height="24" patternUnits="userSpaceOnUse">
+      <path d="M0 12h24" stroke="#5b371f" stroke-opacity="0.06" stroke-width="1"/>
+      <path d="M0 6h24" stroke="#f9f3e8" stroke-opacity="0.04" stroke-width="0.8"/>
+    </pattern>
+    <style>
+      .g { stroke:#2b180d; stroke-linecap:round; stroke-opacity:.9; }
+      .s { fill:#2a1103; opacity:.96; }
+    </style>
+  </defs>
+  <image href="/assets/game-art/baduk-battle-royal/boards/ogs-anime-board.svg" x="0" y="0" width="1024" height="1024" preserveAspectRatio="none"/>
+  <rect x="86" y="86" width="852" height="852" fill="url(#woodTint)"/>
+  <rect x="86" y="86" width="852" height="852" fill="url(#grain)"/>
+  <line x1="86.0000" y1="86" x2="86.0000" y2="938" class="g" stroke-width="3.2"/>
+  <line x1="86" y1="86.0000" x2="938" y2="86.0000" class="g" stroke-width="3.2"/>
+  <line x1="142.8000" y1="86" x2="142.8000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="142.8000" x2="938" y2="142.8000" class="g" stroke-width="2.2"/>
+  <line x1="199.6000" y1="86" x2="199.6000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="199.6000" x2="938" y2="199.6000" class="g" stroke-width="2.2"/>
+  <line x1="256.4000" y1="86" x2="256.4000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="256.4000" x2="938" y2="256.4000" class="g" stroke-width="2.2"/>
+  <line x1="313.2000" y1="86" x2="313.2000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="313.2000" x2="938" y2="313.2000" class="g" stroke-width="2.2"/>
+  <line x1="370.0000" y1="86" x2="370.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="370.0000" x2="938" y2="370.0000" class="g" stroke-width="2.2"/>
+  <line x1="426.8000" y1="86" x2="426.8000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="426.8000" x2="938" y2="426.8000" class="g" stroke-width="2.2"/>
+  <line x1="483.6000" y1="86" x2="483.6000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="483.6000" x2="938" y2="483.6000" class="g" stroke-width="2.2"/>
+  <line x1="540.4000" y1="86" x2="540.4000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="540.4000" x2="938" y2="540.4000" class="g" stroke-width="2.2"/>
+  <line x1="597.2000" y1="86" x2="597.2000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="597.2000" x2="938" y2="597.2000" class="g" stroke-width="2.2"/>
+  <line x1="654.0000" y1="86" x2="654.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="654.0000" x2="938" y2="654.0000" class="g" stroke-width="2.2"/>
+  <line x1="710.8000" y1="86" x2="710.8000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="710.8000" x2="938" y2="710.8000" class="g" stroke-width="2.2"/>
+  <line x1="767.6000" y1="86" x2="767.6000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="767.6000" x2="938" y2="767.6000" class="g" stroke-width="2.2"/>
+  <line x1="824.4000" y1="86" x2="824.4000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="824.4000" x2="938" y2="824.4000" class="g" stroke-width="2.2"/>
+  <line x1="881.2000" y1="86" x2="881.2000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="881.2000" x2="938" y2="881.2000" class="g" stroke-width="2.2"/>
+  <line x1="938.0000" y1="86" x2="938.0000" y2="938" class="g" stroke-width="3.2"/>
+  <line x1="86" y1="938.0000" x2="938" y2="938.0000" class="g" stroke-width="3.2"/>
+  <circle cx="256.4000" cy="256.4000" r="6.6" class="s"/>
+  <circle cx="767.6000" cy="256.4000" r="6.6" class="s"/>
+  <circle cx="256.4000" cy="767.6000" r="6.6" class="s"/>
+  <circle cx="767.6000" cy="767.6000" r="6.6" class="s"/>
+  <circle cx="483.6000" cy="483.6000" r="6.6" class="s"/>
+  <circle cx="540.4000" cy="483.6000" r="6.6" class="s"/>
+  <circle cx="483.6000" cy="540.4000" r="6.6" class="s"/>
+  <circle cx="540.4000" cy="540.4000" r="6.6" class="s"/>
+</svg>

--- a/webapp/public/assets/game-art/baduk-battle-royal/boards/walnut-19x19.svg
+++ b/webapp/public/assets/game-art/baduk-battle-royal/boards/walnut-19x19.svg
@@ -1,0 +1,66 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024">
+  <defs>
+    <linearGradient id="woodTint" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#c99662" stop-opacity="0.26"/>
+      <stop offset="100%" stop-color="#5c3418" stop-opacity="0.22"/>
+    </linearGradient>
+    <pattern id="grain" width="24" height="24" patternUnits="userSpaceOnUse">
+      <path d="M0 12h24" stroke="#5b371f" stroke-opacity="0.06" stroke-width="1"/>
+      <path d="M0 6h24" stroke="#f9f3e8" stroke-opacity="0.04" stroke-width="0.8"/>
+    </pattern>
+    <style>
+      .g { stroke:#2b180d; stroke-linecap:round; stroke-opacity:.9; }
+      .s { fill:#2a1103; opacity:.96; }
+    </style>
+  </defs>
+  <image href="/assets/game-art/baduk-battle-royal/boards/ogs-anime-board.svg" x="0" y="0" width="1024" height="1024" preserveAspectRatio="none"/>
+  <rect x="86" y="86" width="852" height="852" fill="url(#woodTint)"/>
+  <rect x="86" y="86" width="852" height="852" fill="url(#grain)"/>
+  <line x1="86.0000" y1="86" x2="86.0000" y2="938" class="g" stroke-width="3.2"/>
+  <line x1="86" y1="86.0000" x2="938" y2="86.0000" class="g" stroke-width="3.2"/>
+  <line x1="133.3333" y1="86" x2="133.3333" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="133.3333" x2="938" y2="133.3333" class="g" stroke-width="2.2"/>
+  <line x1="180.6667" y1="86" x2="180.6667" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="180.6667" x2="938" y2="180.6667" class="g" stroke-width="2.2"/>
+  <line x1="228.0000" y1="86" x2="228.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="228.0000" x2="938" y2="228.0000" class="g" stroke-width="2.2"/>
+  <line x1="275.3333" y1="86" x2="275.3333" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="275.3333" x2="938" y2="275.3333" class="g" stroke-width="2.2"/>
+  <line x1="322.6667" y1="86" x2="322.6667" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="322.6667" x2="938" y2="322.6667" class="g" stroke-width="2.2"/>
+  <line x1="370.0000" y1="86" x2="370.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="370.0000" x2="938" y2="370.0000" class="g" stroke-width="2.2"/>
+  <line x1="417.3333" y1="86" x2="417.3333" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="417.3333" x2="938" y2="417.3333" class="g" stroke-width="2.2"/>
+  <line x1="464.6667" y1="86" x2="464.6667" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="464.6667" x2="938" y2="464.6667" class="g" stroke-width="2.2"/>
+  <line x1="512.0000" y1="86" x2="512.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="512.0000" x2="938" y2="512.0000" class="g" stroke-width="2.2"/>
+  <line x1="559.3333" y1="86" x2="559.3333" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="559.3333" x2="938" y2="559.3333" class="g" stroke-width="2.2"/>
+  <line x1="606.6667" y1="86" x2="606.6667" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="606.6667" x2="938" y2="606.6667" class="g" stroke-width="2.2"/>
+  <line x1="654.0000" y1="86" x2="654.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="654.0000" x2="938" y2="654.0000" class="g" stroke-width="2.2"/>
+  <line x1="701.3333" y1="86" x2="701.3333" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="701.3333" x2="938" y2="701.3333" class="g" stroke-width="2.2"/>
+  <line x1="748.6667" y1="86" x2="748.6667" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="748.6667" x2="938" y2="748.6667" class="g" stroke-width="2.2"/>
+  <line x1="796.0000" y1="86" x2="796.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="796.0000" x2="938" y2="796.0000" class="g" stroke-width="2.2"/>
+  <line x1="843.3333" y1="86" x2="843.3333" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="843.3333" x2="938" y2="843.3333" class="g" stroke-width="2.2"/>
+  <line x1="890.6667" y1="86" x2="890.6667" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="890.6667" x2="938" y2="890.6667" class="g" stroke-width="2.2"/>
+  <line x1="938.0000" y1="86" x2="938.0000" y2="938" class="g" stroke-width="3.2"/>
+  <line x1="86" y1="938.0000" x2="938" y2="938.0000" class="g" stroke-width="3.2"/>
+  <circle cx="228.0000" cy="228.0000" r="6.6" class="s"/>
+  <circle cx="512.0000" cy="228.0000" r="6.6" class="s"/>
+  <circle cx="796.0000" cy="228.0000" r="6.6" class="s"/>
+  <circle cx="228.0000" cy="512.0000" r="6.6" class="s"/>
+  <circle cx="512.0000" cy="512.0000" r="6.6" class="s"/>
+  <circle cx="796.0000" cy="512.0000" r="6.6" class="s"/>
+  <circle cx="228.0000" cy="796.0000" r="6.6" class="s"/>
+  <circle cx="512.0000" cy="796.0000" r="6.6" class="s"/>
+  <circle cx="796.0000" cy="796.0000" r="6.6" class="s"/>
+</svg>

--- a/webapp/public/assets/game-art/baduk-battle-royal/boards/walnut-9x9.svg
+++ b/webapp/public/assets/game-art/baduk-battle-royal/boards/walnut-9x9.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024">
+  <defs>
+    <linearGradient id="woodTint" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#c99662" stop-opacity="0.26"/>
+      <stop offset="100%" stop-color="#5c3418" stop-opacity="0.22"/>
+    </linearGradient>
+    <pattern id="grain" width="24" height="24" patternUnits="userSpaceOnUse">
+      <path d="M0 12h24" stroke="#5b371f" stroke-opacity="0.06" stroke-width="1"/>
+      <path d="M0 6h24" stroke="#f9f3e8" stroke-opacity="0.04" stroke-width="0.8"/>
+    </pattern>
+    <style>
+      .g { stroke:#2b180d; stroke-linecap:round; stroke-opacity:.9; }
+      .s { fill:#2a1103; opacity:.96; }
+    </style>
+  </defs>
+  <image href="/assets/game-art/baduk-battle-royal/boards/ogs-anime-board.svg" x="0" y="0" width="1024" height="1024" preserveAspectRatio="none"/>
+  <rect x="86" y="86" width="852" height="852" fill="url(#woodTint)"/>
+  <rect x="86" y="86" width="852" height="852" fill="url(#grain)"/>
+  <line x1="86.0000" y1="86" x2="86.0000" y2="938" class="g" stroke-width="3.2"/>
+  <line x1="86" y1="86.0000" x2="938" y2="86.0000" class="g" stroke-width="3.2"/>
+  <line x1="192.5000" y1="86" x2="192.5000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="192.5000" x2="938" y2="192.5000" class="g" stroke-width="2.2"/>
+  <line x1="299.0000" y1="86" x2="299.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="299.0000" x2="938" y2="299.0000" class="g" stroke-width="2.2"/>
+  <line x1="405.5000" y1="86" x2="405.5000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="405.5000" x2="938" y2="405.5000" class="g" stroke-width="2.2"/>
+  <line x1="512.0000" y1="86" x2="512.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="512.0000" x2="938" y2="512.0000" class="g" stroke-width="2.2"/>
+  <line x1="618.5000" y1="86" x2="618.5000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="618.5000" x2="938" y2="618.5000" class="g" stroke-width="2.2"/>
+  <line x1="725.0000" y1="86" x2="725.0000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="725.0000" x2="938" y2="725.0000" class="g" stroke-width="2.2"/>
+  <line x1="831.5000" y1="86" x2="831.5000" y2="938" class="g" stroke-width="2.2"/>
+  <line x1="86" y1="831.5000" x2="938" y2="831.5000" class="g" stroke-width="2.2"/>
+  <line x1="938.0000" y1="86" x2="938.0000" y2="938" class="g" stroke-width="3.2"/>
+  <line x1="86" y1="938.0000" x2="938" y2="938.0000" class="g" stroke-width="3.2"/>
+  <circle cx="299.0000" cy="299.0000" r="6.6" class="s"/>
+  <circle cx="725.0000" cy="299.0000" r="6.6" class="s"/>
+  <circle cx="299.0000" cy="725.0000" r="6.6" class="s"/>
+  <circle cx="725.0000" cy="725.0000" r="6.6" class="s"/>
+  <circle cx="512.0000" cy="512.0000" r="6.6" class="s"/>
+</svg>

--- a/webapp/public/assets/game-art/baduk-battle-royal/stones/cobaltIvory.svg
+++ b/webapp/public/assets/game-art/baduk-battle-royal/stones/cobaltIvory.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 128"><rect width="256" height="128" rx="24" fill="#0f172a"/><circle cx="80" cy="64" r="42" fill="#0f254a"/><circle cx="80" cy="52" r="18" fill="#60a5fa" opacity="0.22"/><circle cx="176" cy="64" r="42" fill="#e5e7eb"/><circle cx="176" cy="52" r="18" fill="#fff" opacity="0.4"/></svg>

--- a/webapp/public/assets/game-art/baduk-battle-royal/stones/forestBone.svg
+++ b/webapp/public/assets/game-art/baduk-battle-royal/stones/forestBone.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 128"><rect width="256" height="128" rx="24" fill="#14532d"/><circle cx="80" cy="64" r="42" fill="#1f3c2f"/><circle cx="80" cy="52" r="18" fill="#84cc16" opacity="0.2"/><circle cx="176" cy="64" r="42" fill="#fff7ed"/><circle cx="176" cy="52" r="18" fill="#fff" opacity="0.45"/></svg>

--- a/webapp/public/assets/game-art/baduk-battle-royal/stones/neonArc.svg
+++ b/webapp/public/assets/game-art/baduk-battle-royal/stones/neonArc.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 128"><rect width="256" height="128" rx="24" fill="#312e81"/><circle cx="80" cy="64" r="42" fill="#312e81"/><circle cx="80" cy="52" r="18" fill="#f472b6" opacity="0.3"/><circle cx="176" cy="64" r="42" fill="#f5f3ff"/><circle cx="176" cy="52" r="18" fill="#22d3ee" opacity="0.3"/></svg>

--- a/webapp/public/assets/game-art/baduk-battle-royal/stones/obsidianPearl.svg
+++ b/webapp/public/assets/game-art/baduk-battle-royal/stones/obsidianPearl.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 128"><rect width="256" height="128" rx="24" fill="#292524"/><circle cx="80" cy="64" r="42" fill="#151515"/><circle cx="80" cy="52" r="18" fill="#fde68a" opacity="0.2"/><circle cx="176" cy="64" r="42" fill="#fef3c7"/><circle cx="176" cy="52" r="18" fill="#fff" opacity="0.4"/></svg>

--- a/webapp/public/assets/game-art/baduk-battle-royal/stones/shellSlate.svg
+++ b/webapp/public/assets/game-art/baduk-battle-royal/stones/shellSlate.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 128">
+  <rect width="256" height="128" rx="24" fill="#1f2937"/>
+  <circle cx="80" cy="64" r="42" fill="#0b0b0d"/>
+  <circle cx="80" cy="52" r="18" fill="#ffffff" opacity="0.15"/>
+  <circle cx="176" cy="64" r="42" fill="#f8fafc"/>
+  <circle cx="176" cy="52" r="18" fill="#ffffff" opacity="0.35"/>
+</svg>

--- a/webapp/src/config/badukBattleInventoryConfig.js
+++ b/webapp/src/config/badukBattleInventoryConfig.js
@@ -18,9 +18,145 @@ const mapStoolThemeToChair = (theme) => ({
 export const BADUK_CHAIR_OPTIONS = Object.freeze([...MURLAN_STOOL_THEMES.map(mapStoolThemeToChair)])
 export const BADUK_TABLE_OPTIONS = Object.freeze([...MURLAN_TABLE_THEMES])
 
+export const BADUK_BOARD_THEMES = Object.freeze([
+  { id: 'classic', label: 'Classic Hinoki', price: 360, thumbnail: '/assets/game-art/baduk-battle-royal/boards/classic-19x19.svg' },
+  { id: 'walnut', label: 'Walnut Pro Grid', price: 420, thumbnail: '/assets/game-art/baduk-battle-royal/boards/walnut-19x19.svg' },
+  { id: 'slate', label: 'Slate Arena', price: 460, thumbnail: '/assets/game-art/baduk-battle-royal/boards/slate-19x19.svg' },
+  { id: 'jade', label: 'Jade Masters', price: 500, thumbnail: '/assets/game-art/baduk-battle-royal/boards/jade-19x19.svg' },
+  { id: 'midnight', label: 'Midnight Carbon', price: 540, thumbnail: '/assets/game-art/baduk-battle-royal/boards/midnight-19x19.svg' }
+])
+
+export const BADUK_STONE_STYLES = Object.freeze([
+  {
+    id: 'shellSlate',
+    label: 'Shell & Slate',
+    price: 380,
+    blackColor: '#0b0b0d',
+    whiteColor: '#f8fafc',
+    blackRoughness: 0.3,
+    whiteRoughness: 0.18,
+    markerColor: '#34d399',
+    thumbnail: '/assets/game-art/baduk-battle-royal/stones/shellSlate.svg'
+  },
+  {
+    id: 'obsidianPearl',
+    label: 'Obsidian Pearl',
+    price: 430,
+    blackColor: '#151515',
+    whiteColor: '#fef3c7',
+    blackRoughness: 0.22,
+    whiteRoughness: 0.14,
+    markerColor: '#f59e0b',
+    thumbnail: '/assets/game-art/baduk-battle-royal/stones/obsidianPearl.svg'
+  },
+  {
+    id: 'cobaltIvory',
+    label: 'Cobalt Ivory',
+    price: 470,
+    blackColor: '#0f254a',
+    whiteColor: '#e5e7eb',
+    blackRoughness: 0.24,
+    whiteRoughness: 0.2,
+    markerColor: '#38bdf8',
+    thumbnail: '/assets/game-art/baduk-battle-royal/stones/cobaltIvory.svg'
+  },
+  {
+    id: 'forestBone',
+    label: 'Forest Bone',
+    price: 510,
+    blackColor: '#1f3c2f',
+    whiteColor: '#fff7ed',
+    blackRoughness: 0.28,
+    whiteRoughness: 0.18,
+    markerColor: '#84cc16',
+    thumbnail: '/assets/game-art/baduk-battle-royal/stones/forestBone.svg'
+  },
+  {
+    id: 'neonArc',
+    label: 'Neon Arc',
+    price: 560,
+    blackColor: '#312e81',
+    whiteColor: '#f5f3ff',
+    blackRoughness: 0.18,
+    whiteRoughness: 0.12,
+    markerColor: '#f472b6',
+    thumbnail: '/assets/game-art/baduk-battle-royal/stones/neonArc.svg'
+  }
+])
+
 export const BADUK_BATTLE_DEFAULT_LOADOUT = Object.freeze({
   chairColor: [BADUK_CHAIR_OPTIONS[0]?.id],
   tables: [BADUK_TABLE_OPTIONS[0]?.id],
   tableFinish: [MURLAN_TABLE_FINISHES[0]?.id],
+  boardTheme: [BADUK_BOARD_THEMES[0]?.id],
+  stoneStyle: [BADUK_STONE_STYLES[0]?.id],
   environmentHdri: [DEFAULT_HDRI_ID]
 })
+
+export const BADUK_BATTLE_OPTION_LABELS = Object.freeze({
+  chairColor: Object.freeze(BADUK_CHAIR_OPTIONS.reduce((acc, option) => ({ ...acc, [option.id]: option.label }), {})),
+  tables: Object.freeze(BADUK_TABLE_OPTIONS.reduce((acc, option) => ({ ...acc, [option.id]: option.label }), {})),
+  tableFinish: Object.freeze(MURLAN_TABLE_FINISHES.reduce((acc, option) => ({ ...acc, [option.id]: option.label }), {})),
+  boardTheme: Object.freeze(BADUK_BOARD_THEMES.reduce((acc, option) => ({ ...acc, [option.id]: option.label }), {})),
+  stoneStyle: Object.freeze(BADUK_STONE_STYLES.reduce((acc, option) => ({ ...acc, [option.id]: option.label }), {})),
+  environmentHdri: Object.freeze(
+    POOL_ROYALE_HDRI_VARIANTS.reduce((acc, variant) => {
+      acc[variant.id] = `${variant.name} HDRI`
+      return acc
+    }, {})
+  )
+})
+
+export const BADUK_BATTLE_STORE_ITEMS = Object.freeze([
+  ...MURLAN_TABLE_FINISHES.map((finish, idx) => ({
+    id: `baduk-table-finish-${finish.id}`,
+    type: 'tableFinish',
+    optionId: finish.id,
+    name: finish.label,
+    price: finish.price ?? 980 + idx * 40,
+    description: finish.description,
+    swatches: finish.swatches,
+    thumbnail: finish.thumbnail,
+    previewShape: 'table'
+  })),
+  ...BADUK_TABLE_OPTIONS.slice(1).map((theme, idx) => ({
+    id: `baduk-table-${theme.id}`,
+    type: 'tables',
+    optionId: theme.id,
+    name: theme.label,
+    price: theme.price ?? 920 + idx * 35,
+    description: theme.description || `${theme.label} table tuned for Baduk Battle Royal.`,
+    thumbnail: theme.thumbnail,
+    previewShape: 'table'
+  })),
+  ...BADUK_CHAIR_OPTIONS.slice(1).map((option, idx) => ({
+    id: `baduk-chair-${option.id}`,
+    type: 'chairColor',
+    optionId: option.id,
+    name: option.label,
+    price: option.price ?? 320 + idx * 20,
+    description: option.description || `${option.label} seating for the Baduk arena.`,
+    thumbnail: option.thumbnail,
+    previewShape: 'chair'
+  })),
+  ...BADUK_BOARD_THEMES.slice(1).map((theme) => ({
+    id: `baduk-board-${theme.id}`,
+    type: 'boardTheme',
+    optionId: theme.id,
+    name: theme.label,
+    price: theme.price,
+    description: `${theme.label} board skin based on open-source goban artwork.`,
+    thumbnail: theme.thumbnail,
+    previewShape: 'board'
+  })),
+  ...BADUK_STONE_STYLES.slice(1).map((style) => ({
+    id: `baduk-stone-${style.id}`,
+    type: 'stoneStyle',
+    optionId: style.id,
+    name: style.label,
+    price: style.price,
+    description: `${style.label} stone material palette for matches and replays.`,
+    thumbnail: style.thumbnail,
+    previewShape: 'board'
+  }))
+])

--- a/webapp/src/pages/Games/BadukBattleRoyal.jsx
+++ b/webapp/src/pages/Games/BadukBattleRoyal.jsx
@@ -10,6 +10,8 @@ import { ARENA_CAMERA_DEFAULTS } from '../../utils/arenaCameraConfig.js';
 import { createMurlanStyleTable, applyTableMaterials } from '../../utils/murlanTable.js';
 import {
   BADUK_CHAIR_OPTIONS,
+  BADUK_BOARD_THEMES,
+  BADUK_STONE_STYLES,
   BADUK_TABLE_OPTIONS,
   BADUK_BATTLE_DEFAULT_LOADOUT
 } from '../../config/badukBattleInventoryConfig.js';
@@ -27,9 +29,9 @@ import { badukBattleAccountId, getBadukBattleInventory } from '../../utils/baduk
 import { applyRendererSRGB, applySRGBColorSpace } from '../../utils/colorSpace.js';
 
 const BOARD_SIZES = [9, 13, 16, 19];
-const BOARD_TEXTURE_SIZE = 1024;
-const BOARD_GRID_MIN = 86;
-const BOARD_GRID_MAX = 938;
+const BOARD_TEXTURE_SIZE = 2048;
+const BOARD_GRID_MIN = 172;
+const BOARD_GRID_MAX = 1876;
 const BOARD_GRID_RANGE_RATIO = (BOARD_GRID_MAX - BOARD_GRID_MIN) / BOARD_TEXTURE_SIZE;
 
 const MODEL_SCALE = 0.75;
@@ -142,6 +144,9 @@ const optionButton = (active) =>
     active ? 'border-cyan-300 bg-cyan-500/20 text-cyan-100' : 'border-white/15 bg-white/5 text-white/70'
   }`;
 
+const getBoardTexturePath = (themeId, size) =>
+  `/assets/game-art/baduk-battle-royal/boards/${themeId || 'classic'}-${size}x${size}.svg`;
+
 export default function BadukBattleRoyal() {
   useTelegramBackButton();
   const mountRef = useRef(null);
@@ -173,6 +178,8 @@ export default function BadukBattleRoyal() {
     tableFinish: inventory.tableFinish?.[0] || MURLAN_TABLE_FINISHES[0]?.id,
     tableId: inventory.tables?.[0] || BADUK_BATTLE_DEFAULT_LOADOUT.tables?.[0] || BADUK_TABLE_OPTIONS[0]?.id,
     chairId: inventory.chairColor?.[0] || BADUK_BATTLE_DEFAULT_LOADOUT.chairColor?.[0] || BADUK_CHAIR_OPTIONS[0]?.id,
+    boardTheme: inventory.boardTheme?.[0] || BADUK_BATTLE_DEFAULT_LOADOUT.boardTheme?.[0] || BADUK_BOARD_THEMES[0]?.id,
+    stoneStyle: inventory.stoneStyle?.[0] || BADUK_BATTLE_DEFAULT_LOADOUT.stoneStyle?.[0] || BADUK_STONE_STYLES[0]?.id,
     hdriId: inventory.environmentHdri?.[0] || BADUK_BATTLE_DEFAULT_LOADOUT.environmentHdri?.[0] || POOL_ROYALE_DEFAULT_HDRI_ID
   }));
 
@@ -245,10 +252,11 @@ export default function BadukBattleRoyal() {
     group.clear();
 
     const stoneGeo = new THREE.SphereGeometry(0.045, 22, 16);
-    const blackMat = new THREE.MeshStandardMaterial({ color: '#0b0b0d', roughness: 0.28, metalness: 0.06 });
-    const whiteMat = new THREE.MeshStandardMaterial({ color: '#f8fafc', roughness: 0.2, metalness: 0.03 });
+    const stoneStyle = BADUK_STONE_STYLES.find((entry) => entry.id === appearance.stoneStyle) || BADUK_STONE_STYLES[0];
+    const blackMat = new THREE.MeshStandardMaterial({ color: stoneStyle.blackColor, roughness: stoneStyle.blackRoughness ?? 0.28, metalness: 0.06 });
+    const whiteMat = new THREE.MeshStandardMaterial({ color: stoneStyle.whiteColor, roughness: stoneStyle.whiteRoughness ?? 0.2, metalness: 0.03 });
     const markerGeo = new THREE.SphereGeometry(0.014, 14, 10);
-    const markerMat = new THREE.MeshBasicMaterial({ color: '#34d399' });
+    const markerMat = new THREE.MeshBasicMaterial({ color: stoneStyle.markerColor || '#34d399' });
 
     for (let r = 0; r < boardSize; r += 1) {
       for (let c = 0; c < boardSize; c += 1) {
@@ -272,7 +280,7 @@ export default function BadukBattleRoyal() {
 
   useEffect(() => {
     renderStones(board, lastMove);
-  }, [board, lastMove]);
+  }, [board, lastMove, appearance.stoneStyle]);
 
   useEffect(() => {
     const mount = mountRef.current;
@@ -352,9 +360,12 @@ export default function BadukBattleRoyal() {
     boardGroup.add(boardPlane);
     boardMeshRef.current = boardPlane;
 
-    const boardTexture = new THREE.TextureLoader().load(`/assets/game-art/baduk-battle-royal/boards/${boardSize}x${boardSize}.svg`);
+    const boardTexture = new THREE.TextureLoader().load(getBoardTexturePath(appearance.boardTheme, boardSize));
     applySRGBColorSpace(boardTexture);
-    boardTexture.anisotropy = 8;
+    boardTexture.anisotropy = Math.min(renderer.capabilities.getMaxAnisotropy(), 16);
+    boardTexture.generateMipmaps = true;
+    boardTexture.minFilter = THREE.LinearMipmapLinearFilter;
+    boardTexture.magFilter = THREE.LinearFilter;
     boardPlane.material.map = boardTexture;
     boardPlane.material.needsUpdate = true;
 
@@ -402,7 +413,7 @@ export default function BadukBattleRoyal() {
         }
       });
     };
-  }, [boardSize, appearance.chairId, graphicsOption.fps, graphicsOption.pixelRatioCap, graphicsOption.renderScale]);
+  }, [boardSize, appearance.boardTheme, appearance.chairId, graphicsOption.fps, graphicsOption.pixelRatioCap, graphicsOption.renderScale]);
 
   useEffect(() => {
     const finish = MURLAN_TABLE_FINISHES.find((f) => f.id === appearance.tableFinish) || MURLAN_TABLE_FINISHES[0];
@@ -662,6 +673,32 @@ export default function BadukBattleRoyal() {
                     className={optionButton(appearance.hdriId === opt.id)}
                   >
                     {opt.name}
+                  </button>
+                ))}
+              </div>
+
+              <div className="mb-2 mt-3 text-[11px] uppercase tracking-[0.2em] text-white/70">Board Skin</div>
+              <div className="mb-3 grid max-h-40 grid-cols-2 gap-2 overflow-auto">
+                {BADUK_BOARD_THEMES.map((opt) => (
+                  <button
+                    key={opt.id}
+                    onClick={() => setAppearance((prev) => ({ ...prev, boardTheme: opt.id }))}
+                    className={optionButton(appearance.boardTheme === opt.id)}
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
+
+              <div className="mb-2 text-[11px] uppercase tracking-[0.2em] text-white/70">Stone Style</div>
+              <div className="flex max-h-40 flex-wrap gap-2 overflow-auto">
+                {BADUK_STONE_STYLES.map((opt) => (
+                  <button
+                    key={opt.id}
+                    onClick={() => setAppearance((prev) => ({ ...prev, stoneStyle: opt.id }))}
+                    className={optionButton(appearance.stoneStyle === opt.id)}
+                  >
+                    {opt.label}
                   </button>
                 ))}
               </div>

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -51,12 +51,24 @@ import {
   CHESS_BATTLE_STORE_ITEMS
 } from '../config/chessBattleInventoryConfig.js';
 import {
+  BADUK_BATTLE_DEFAULT_LOADOUT,
+  BADUK_BATTLE_OPTION_LABELS,
+  BADUK_BATTLE_STORE_ITEMS
+} from '../config/badukBattleInventoryConfig.js';
+import {
   addChessBattleUnlock,
   getChessBattleInventory,
   isChessOptionUnlocked,
   chessBattleAccountId,
   listOwnedChessOptions
 } from '../utils/chessBattleInventory.js';
+import {
+  addBadukBattleUnlock,
+  getBadukBattleInventory,
+  isBadukOptionUnlocked,
+  listOwnedBadukOptions,
+  badukBattleAccountId
+} from '../utils/badukBattleInventory.js';
 import {
   LUDO_BATTLE_DEFAULT_LOADOUT,
   LUDO_BATTLE_OPTION_LABELS,
@@ -157,6 +169,15 @@ const CHESS_TYPE_LABELS = {
   environmentHdri: 'HDR Environments'
 };
 
+const BADUK_TYPE_LABELS = {
+  tables: 'Table Models',
+  tableFinish: 'Table Finish',
+  chairColor: 'Chairs',
+  boardTheme: 'Board Themes',
+  stoneStyle: 'Stone Styles',
+  environmentHdri: 'HDR Environments'
+};
+
 const BLACKJACK_TYPE_LABELS = {
   tableWood: 'Table Wood',
   tableCloth: 'Table Cloth',
@@ -240,6 +261,7 @@ const SNOOKER_STORE_ACCOUNT_ID =
   import.meta.env.VITE_SNOOKER_ROYALE_STORE_ACCOUNT_ID || DEV_INFO.account;
 const AIR_HOCKEY_STORE_ACCOUNT_ID = import.meta.env.VITE_AIR_HOCKEY_STORE_ACCOUNT_ID || DEV_INFO.account;
 const CHESS_STORE_ACCOUNT_ID = import.meta.env.VITE_CHESS_BATTLE_STORE_ACCOUNT_ID || DEV_INFO.account;
+const BADUK_STORE_ACCOUNT_ID = import.meta.env.VITE_BADUK_BATTLE_STORE_ACCOUNT_ID || DEV_INFO.account;
 const BLACKJACK_STORE_ACCOUNT_ID = import.meta.env.VITE_BLACKJACK_STORE_ACCOUNT_ID || DEV_INFO.account;
 const LUDO_STORE_ACCOUNT_ID = import.meta.env.VITE_LUDO_BATTLE_STORE_ACCOUNT_ID || DEV_INFO.account;
 const MURLAN_STORE_ACCOUNT_ID = import.meta.env.VITE_MURLAN_ROYALE_STORE_ACCOUNT_ID || DEV_INFO.account;
@@ -308,6 +330,7 @@ const TYPE_SWATCHES = {
   tableShape: ['#334155', '#64748b'],
   sideColor: ['#f8fafc', '#1f2937'],
   boardTheme: ['#f59e0b', '#14b8a6'],
+  stoneStyle: ['#111827', '#f8fafc'],
   headStyle: ['#0f172a', '#facc15'],
   cards: ['#f8fafc', '#e5e7eb'],
   dominoStyle: ['#f8fafc', '#d1d5db'],
@@ -405,6 +428,7 @@ const PREVIEW_BY_TYPE = {
   chairColor: 'chair',
   stools: 'chair',
   boardTheme: 'chess-royals',
+  stoneStyle: 'chess-royals',
   sideColor: 'chess-royals',
   headStyle: 'pawn-head',
   chromeColor: 'chrome',
@@ -540,6 +564,10 @@ const USAGE_BY_TYPE = {
   boardTheme: {
     title: 'Board theme',
     description: 'Replaces the board texture and accents used in Chess matches.'
+  },
+  stoneStyle: {
+    title: 'Stone style',
+    description: 'Applies a new Baduk stone material set in live matches and replays.'
   },
   headStyle: {
     title: 'Pawn heads',
@@ -690,11 +718,11 @@ const storeMeta = {
   },
   badukbattleroyal: {
     name: 'Baduk Battle Royal',
-    items: CHESS_BATTLE_STORE_ITEMS,
-    defaults: CHESS_BATTLE_DEFAULT_LOADOUT,
-    labels: CHESS_BATTLE_OPTION_LABELS,
-    typeLabels: CHESS_TYPE_LABELS,
-    accountId: CHESS_STORE_ACCOUNT_ID
+    items: BADUK_BATTLE_STORE_ITEMS,
+    defaults: BADUK_BATTLE_DEFAULT_LOADOUT,
+    labels: BADUK_BATTLE_OPTION_LABELS,
+    typeLabels: BADUK_TYPE_LABELS,
+    accountId: BADUK_STORE_ACCOUNT_ID
   },
   tavullbattleroyal: {
     name: 'Backgammon Royal',
@@ -755,6 +783,7 @@ export default function Store() {
   const [snookerOwned, setSnookerOwned] = useState(() => getCachedSnookerRoyalInventory(accountId));
   const [airOwned, setAirOwned] = useState(() => getAirHockeyInventory(airHockeyAccountId(accountId)));
   const [chessOwned, setChessOwned] = useState(() => getChessBattleInventory(chessBattleAccountId(accountId)));
+  const [badukOwned, setBadukOwned] = useState(() => getBadukBattleInventory(badukBattleAccountId(accountId)));
   const [ludoOwned, setLudoOwned] = useState(() => getLudoBattleInventory(ludoBattleAccountId(accountId)));
   const [murlanOwned, setMurlanOwned] = useState(() => getMurlanInventory(murlanAccountId(accountId)));
   const [dominoOwned, setDominoOwned] = useState(() => getDominoRoyalInventory(dominoRoyalAccountId(accountId)));
@@ -843,6 +872,7 @@ export default function Store() {
     setSnookerOwned(getCachedSnookerRoyalInventory(accountId));
     setAirOwned(getAirHockeyInventory(airHockeyAccountId(accountId)));
     setChessOwned(getChessBattleInventory(chessBattleAccountId(accountId)));
+    setBadukOwned(getBadukBattleInventory(badukBattleAccountId(accountId)));
     setLudoOwned(getLudoBattleInventory(ludoBattleAccountId(accountId)));
     setMurlanOwned(getMurlanInventory(murlanAccountId(accountId)));
     setDominoOwned(getDominoRoyalInventory(dominoRoyalAccountId(accountId)));
@@ -923,7 +953,7 @@ export default function Store() {
       airhockey: AIR_HOCKEY_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId), slug: 'airhockey' })),
       chessbattleroyal: CHESS_BATTLE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId), slug: 'chessbattleroyal' })),
       checkersbattleroyal: CHESS_BATTLE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId), slug: 'checkersbattleroyal' })),
-      badukbattleroyal: CHESS_BATTLE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId), slug: 'badukbattleroyal' })),
+      badukbattleroyal: BADUK_BATTLE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId), slug: 'badukbattleroyal' })),
       tavullbattleroyal: CHESS_BATTLE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId), slug: 'tavullbattleroyal' })),
       ludobattleroyal: LUDO_BATTLE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId), slug: 'ludobattleroyal' })),
       murlanroyale: MURLAN_ROYALE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId), slug: 'murlanroyale' })),
@@ -942,7 +972,7 @@ export default function Store() {
       airhockey: (type, optionId) => isAirHockeyOptionUnlocked(type, optionId, airOwned),
       chessbattleroyal: (type, optionId) => isChessOptionUnlocked(type, optionId, chessOwned),
       checkersbattleroyal: (type, optionId) => isChessOptionUnlocked(type, optionId, chessOwned),
-      badukbattleroyal: (type, optionId) => isChessOptionUnlocked(type, optionId, chessOwned),
+      badukbattleroyal: (type, optionId) => isBadukOptionUnlocked(type, optionId, badukOwned),
       tavullbattleroyal: (type, optionId) => isChessOptionUnlocked(type, optionId, chessOwned),
       ludobattleroyal: (type, optionId) => isLudoOptionUnlocked(type, optionId, ludoOwned),
       murlanroyale: (type, optionId) => isMurlanOptionUnlocked(type, optionId, murlanOwned),
@@ -950,7 +980,7 @@ export default function Store() {
       snake: (type, optionId) => isSnakeOptionUnlocked(type, optionId, snakeOwned),
       texasholdem: (type, optionId) => isTexasOptionUnlocked(type, optionId, texasOwned)
     }),
-    [airOwned, poolOwned, snookerOwned, chessOwned, ludoOwned, murlanOwned, dominoOwned, snakeOwned, texasOwned]
+    [airOwned, poolOwned, snookerOwned, chessOwned, badukOwned, ludoOwned, murlanOwned, dominoOwned, snakeOwned, texasOwned]
   );
 
   const labelResolvers = useMemo(
@@ -961,7 +991,7 @@ export default function Store() {
       airhockey: (item) => AIR_HOCKEY_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
       chessbattleroyal: (item) => CHESS_BATTLE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
       checkersbattleroyal: (item) => CHESS_BATTLE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
-      badukbattleroyal: (item) => CHESS_BATTLE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
+      badukbattleroyal: (item) => BADUK_BATTLE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
       tavullbattleroyal: (item) => CHESS_BATTLE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
       ludobattleroyal: (item) => LUDO_BATTLE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
       murlanroyale: (item) => MURLAN_ROYALE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
@@ -979,7 +1009,7 @@ export default function Store() {
       airhockey: AIR_HOCKEY_TYPE_LABELS,
       chessbattleroyal: CHESS_TYPE_LABELS,
       checkersbattleroyal: CHESS_TYPE_LABELS,
-      badukbattleroyal: CHESS_TYPE_LABELS,
+      badukbattleroyal: BADUK_TYPE_LABELS,
       tavullbattleroyal: CHESS_TYPE_LABELS,
       ludobattleroyal: LUDO_TYPE_LABELS,
       murlanroyale: MURLAN_TYPE_LABELS,
@@ -1522,8 +1552,10 @@ export default function Store() {
         for (const entry of group.items) {
           if (slug === 'airhockey') {
             setAirOwned(addAirHockeyUnlock(entry.type, entry.optionId, resolvedAccountId));
-          } else if (slug === 'chessbattleroyal' || slug === 'checkersbattleroyal' || slug === 'badukbattleroyal' || slug === 'tavullbattleroyal') {
+          } else if (slug === 'chessbattleroyal' || slug === 'checkersbattleroyal' || slug === 'tavullbattleroyal') {
             setChessOwned(addChessBattleUnlock(entry.type, entry.optionId, resolvedAccountId));
+          } else if (slug === 'badukbattleroyal') {
+            setBadukOwned(addBadukBattleUnlock(entry.type, entry.optionId, resolvedAccountId));
           } else if (slug === 'ludobattleroyal') {
             setLudoOwned(addLudoBattleUnlock(entry.type, entry.optionId, resolvedAccountId));
           } else if (slug === 'murlanroyale') {

--- a/webapp/src/utils/badukBattleInventory.js
+++ b/webapp/src/utils/badukBattleInventory.js
@@ -1,4 +1,7 @@
-import { BADUK_BATTLE_DEFAULT_LOADOUT } from '../config/badukBattleInventoryConfig.js'
+import {
+  BADUK_BATTLE_DEFAULT_LOADOUT,
+  BADUK_BATTLE_OPTION_LABELS
+} from '../config/badukBattleInventoryConfig.js'
 
 const STORAGE_KEY = 'badukBattleInventoryByAccount'
 const memoryCache = new Map()
@@ -7,6 +10,12 @@ export const badukBattleAccountId = (value) => {
   const normalized = `${value || 'guest'}`.trim()
   return normalized || 'guest'
 }
+
+const copyDefaults = () =>
+  Object.entries(BADUK_BATTLE_DEFAULT_LOADOUT).reduce((acc, [key, values]) => {
+    acc[key] = Array.isArray(values) ? [...values].filter(Boolean) : []
+    return acc
+  }, {})
 
 const readStore = () => {
   try {
@@ -18,11 +27,73 @@ const readStore = () => {
   }
 }
 
+const writeStore = (payload) => {
+  try {
+    window.localStorage?.setItem(STORAGE_KEY, JSON.stringify(payload || {}))
+  } catch {
+    // ignore localStorage write issues
+  }
+}
+
+const normalizeInventory = (rawInventory) => {
+  const base = copyDefaults()
+  if (!rawInventory || typeof rawInventory !== 'object') return base
+  const merged = { ...base }
+  Object.entries(rawInventory).forEach(([key, value]) => {
+    if (!Array.isArray(value)) return
+    merged[key] = Array.from(new Set([...(merged[key] || []), ...value]))
+  })
+  return merged
+}
+
 export const getBadukBattleInventory = (accountId = 'guest') => {
   const id = badukBattleAccountId(accountId)
   if (memoryCache.has(id)) return memoryCache.get(id)
   const db = readStore()
-  const resolved = { ...BADUK_BATTLE_DEFAULT_LOADOUT, ...(db[id] || {}) }
+  const resolved = normalizeInventory(db[id])
   memoryCache.set(id, resolved)
   return resolved
+}
+
+export const isBadukOptionUnlocked = (type, optionId, inventoryOrAccountId) => {
+  if (!type || !optionId) return false
+  const inventory =
+    typeof inventoryOrAccountId === 'string' || !inventoryOrAccountId
+      ? getBadukBattleInventory(inventoryOrAccountId)
+      : inventoryOrAccountId
+  return Array.isArray(inventory?.[type]) && inventory[type].includes(optionId)
+}
+
+export const addBadukBattleUnlock = (type, optionId, accountId = 'guest') => {
+  const id = badukBattleAccountId(accountId)
+  const db = readStore()
+  const current = normalizeInventory(db[id])
+  const nextInventory = {
+    ...current,
+    [type]: Array.from(new Set([...(current[type] || []), optionId]))
+  }
+  const nextDb = { ...db, [id]: nextInventory }
+  writeStore(nextDb)
+  memoryCache.set(id, nextInventory)
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(
+      new CustomEvent('badukBattleInventoryUpdate', {
+        detail: { accountId: id, inventory: nextInventory }
+      })
+    )
+  }
+  return nextInventory
+}
+
+export const listOwnedBadukOptions = (accountId) => {
+  const inventory = getBadukBattleInventory(accountId)
+  return Object.entries(inventory).flatMap(([type, values]) => {
+    if (!Array.isArray(values)) return []
+    const labels = BADUK_BATTLE_OPTION_LABELS[type] || {}
+    return values.map((optionId) => ({
+      type,
+      optionId,
+      label: labels[optionId] || optionId
+    }))
+  })
 }


### PR DESCRIPTION
### Motivation
- Provide higher-fidelity Baduk visuals and monetize customizations by adding purchasable board skins and stone styles to the Baduk Battle Royal game.
- Keep Baduk assets/config separate from Chess so store ownership, labels, and unlock logic are correct for Baduk players.

### Description
- Added a dedicated Baduk inventory/config (`webapp/src/config/badukBattleInventoryConfig.js`) introducing 5 board themes and 5 stone styles plus default loadout, labels and `BADUK_BATTLE_STORE_ITEMS` store entries.
- Implemented persistence and helper functions for Baduk inventory in `webapp/src/utils/badukBattleInventory.js` (`getBadukBattleInventory`, `isBadukOptionUnlocked`, `addBadukBattleUnlock`, `listOwnedBadukOptions`).
- Wired Store integration to use Baduk-specific data and ownership checks by updating `webapp/src/pages/Store.jsx` (metadata, type labels, ownership resolvers, and purchase sync logic for `badukbattleroyal`).
- Upgraded the Baduk renderer and settings UI (`webapp/src/pages/Games/BadukBattleRoyal.jsx`) to use higher board texture-space constants, load theme-based board textures with mipmaps/anisotropy, and apply selected stone material/marker colors; added in-game selectors for `Board Skin` and `Stone Style`.
- Added themed board SVG variants and stone thumbnail SVG assets under `webapp/public/assets/game-art/baduk-battle-royal/` and updated attribution to document derivation from the `online-go/goban` Apache-2.0 board base.

### Testing
- Ran the production build with `npm run build` in `webapp/` which completed successfully (Vite emitted non-blocking chunk-size warnings not caused by these changes). ✅
- Launched the dev server and captured a mobile-viewport screenshot of `/store/badukbattleroyal` to validate the store UI and new options were visible. ✅

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b788a337008329883b5c704a0e714c)