### PR TITLE
Add Baduk store cosmetics and improve board/stone rendering

### DIFF
--- a/webapp/public/assets/game-art/baduk-battle-royal/store/ATTRIBUTION.md
+++ b/webapp/public/assets/game-art/baduk-battle-royal/store/ATTRIBUTION.md
@@ -1,0 +1,5 @@
+# Baduk store art attribution
+
+Board and stone preview icons in this folder are original lightweight SVG thumbnails created for storefront previews.
+
+The in-game board textures remain based on the Apache-2.0 open-source `online-go/goban` board art listed in `../boards/ATTRIBUTION.md`.

--- a/webapp/public/assets/game-art/baduk-battle-royal/store/boards/classicKaya.svg
+++ b/webapp/public/assets/game-art/baduk-battle-royal/store/boards/classicKaya.svg
@@ -1,0 +1,1 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 256 256'><rect width='256' height='256' fill='#e2ae68'/><g stroke='#2a1709' stroke-width='4' opacity='.9'> <path d='M48 48v160M88 48v160M128 48v160M168 48v160M208 48v160'/><path d='M48 48h160M48 88h160M48 128h160M48 168h160M48 208h160'/></g></svg>

--- a/webapp/public/assets/game-art/baduk-battle-royal/store/boards/midnightBamboo.svg
+++ b/webapp/public/assets/game-art/baduk-battle-royal/store/boards/midnightBamboo.svg
@@ -1,0 +1,1 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 256 256'><rect width='256' height='256' fill='#a4773f'/><rect width='256' height='256' fill='#2d1f12' opacity='.18'/><g stroke='#201309' stroke-width='4' opacity='.92'> <path d='M48 48v160M88 48v160M128 48v160M168 48v160M208 48v160'/><path d='M48 48h160M48 88h160M48 128h160M48 168h160M48 208h160'/></g></svg>

--- a/webapp/public/assets/game-art/baduk-battle-royal/store/boards/sakuraDawn.svg
+++ b/webapp/public/assets/game-art/baduk-battle-royal/store/boards/sakuraDawn.svg
@@ -1,0 +1,1 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 256 256'><rect width='256' height='256' fill='#d2a084'/><rect width='256' height='256' fill='#f9d5d8' opacity='.12'/><g stroke='#4d2f2d' stroke-width='4' opacity='.92'> <path d='M48 48v160M88 48v160M128 48v160M168 48v160M208 48v160'/><path d='M48 48h160M48 88h160M48 128h160M48 168h160M48 208h160'/></g></svg>

--- a/webapp/public/assets/game-art/baduk-battle-royal/store/boards/stoneTemple.svg
+++ b/webapp/public/assets/game-art/baduk-battle-royal/store/boards/stoneTemple.svg
@@ -1,0 +1,1 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 256 256'><rect width='256' height='256' fill='#c6b391'/><g stroke='#2c2c2c' stroke-width='4' opacity='.9'> <path d='M48 48v160M88 48v160M128 48v160M168 48v160M208 48v160'/><path d='M48 48h160M48 88h160M48 128h160M48 168h160M48 208h160'/></g></svg>

--- a/webapp/public/assets/game-art/baduk-battle-royal/store/boards/volcanicAsh.svg
+++ b/webapp/public/assets/game-art/baduk-battle-royal/store/boards/volcanicAsh.svg
@@ -1,0 +1,1 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 256 256'><rect width='256' height='256' fill='#8e765f'/><rect width='256' height='256' fill='#231f1b' opacity='.2'/><g stroke='#1a1715' stroke-width='4' opacity='.95'> <path d='M48 48v160M88 48v160M128 48v160M168 48v160M208 48v160'/><path d='M48 48h160M48 88h160M48 128h160M48 168h160M48 208h160'/></g></svg>

--- a/webapp/public/assets/game-art/baduk-battle-royal/store/stones/coralSky.svg
+++ b/webapp/public/assets/game-art/baduk-battle-royal/store/stones/coralSky.svg
@@ -1,0 +1,1 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 256 256'><rect width='256' height='256' fill='#132338'/><ellipse cx='86' cy='128' rx='54' ry='36' fill='#2463ad'/><ellipse cx='170' cy='128' rx='54' ry='36' fill='#ff8a6b'/></svg>

--- a/webapp/public/assets/game-art/baduk-battle-royal/store/stones/jadeIvory.svg
+++ b/webapp/public/assets/game-art/baduk-battle-royal/store/stones/jadeIvory.svg
@@ -1,0 +1,1 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 256 256'><rect width='256' height='256' fill='#12211c'/><ellipse cx='86' cy='128' rx='54' ry='36' fill='#0f3b2e'/><ellipse cx='170' cy='128' rx='54' ry='36' fill='#f8f3d8'/></svg>

--- a/webapp/public/assets/game-art/baduk-battle-royal/store/stones/monoInk.svg
+++ b/webapp/public/assets/game-art/baduk-battle-royal/store/stones/monoInk.svg
@@ -1,0 +1,1 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 256 256'><rect width='256' height='256' fill='#232323'/><ellipse cx='86' cy='128' rx='54' ry='36' fill='#151515'/><ellipse cx='170' cy='128' rx='54' ry='36' fill='#dbdbdb'/></svg>

--- a/webapp/public/assets/game-art/baduk-battle-royal/store/stones/obsidianGold.svg
+++ b/webapp/public/assets/game-art/baduk-battle-royal/store/stones/obsidianGold.svg
@@ -1,0 +1,1 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 256 256'><rect width='256' height='256' fill='#1b1408'/><ellipse cx='86' cy='128' rx='54' ry='36' fill='#050506'/><ellipse cx='170' cy='128' rx='54' ry='36' fill='#f7c24b'/></svg>

--- a/webapp/public/assets/game-art/baduk-battle-royal/store/stones/traditional.svg
+++ b/webapp/public/assets/game-art/baduk-battle-royal/store/stones/traditional.svg
@@ -1,0 +1,1 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 256 256'><rect width='256' height='256' fill='#121212'/><ellipse cx='86' cy='128' rx='54' ry='36' fill='#0a0a0d'/><ellipse cx='170' cy='128' rx='54' ry='36' fill='#f8fafc'/></svg>

--- a/webapp/src/config/badukBattleInventoryConfig.js
+++ b/webapp/src/config/badukBattleInventoryConfig.js
@@ -4,6 +4,7 @@ import {
   POOL_ROYALE_DEFAULT_HDRI_ID,
   POOL_ROYALE_HDRI_VARIANTS
 } from './poolRoyaleInventoryConfig.js'
+import { swatchThumbnail } from './storeThumbnails.js'
 
 const DEFAULT_HDRI_ID = POOL_ROYALE_DEFAULT_HDRI_ID || POOL_ROYALE_HDRI_VARIANTS[0]?.id
 
@@ -18,9 +19,103 @@ const mapStoolThemeToChair = (theme) => ({
 export const BADUK_CHAIR_OPTIONS = Object.freeze([...MURLAN_STOOL_THEMES.map(mapStoolThemeToChair)])
 export const BADUK_TABLE_OPTIONS = Object.freeze([...MURLAN_TABLE_THEMES])
 
-export const BADUK_BATTLE_DEFAULT_LOADOUT = Object.freeze({
+export const BADUK_BOARD_THEMES = Object.freeze([
+  { id: 'classicKaya', label: 'Classic Kaya', thumbnail: '/assets/game-art/baduk-battle-royal/store/boards/classicKaya.svg', tint: '#e2ae68', grid: '#2a1709' },
+  { id: 'midnightBamboo', label: 'Midnight Bamboo', thumbnail: '/assets/game-art/baduk-battle-royal/store/boards/midnightBamboo.svg', tint: '#a4773f', grid: '#201309' },
+  { id: 'stoneTemple', label: 'Stone Temple', thumbnail: '/assets/game-art/baduk-battle-royal/store/boards/stoneTemple.svg', tint: '#c6b391', grid: '#2c2c2c' },
+  { id: 'sakuraDawn', label: 'Sakura Dawn', thumbnail: '/assets/game-art/baduk-battle-royal/store/boards/sakuraDawn.svg', tint: '#d2a084', grid: '#4d2f2d' },
+  { id: 'volcanicAsh', label: 'Volcanic Ash', thumbnail: '/assets/game-art/baduk-battle-royal/store/boards/volcanicAsh.svg', tint: '#8e765f', grid: '#1a1715' }
+])
+
+export const BADUK_STONE_STYLES = Object.freeze([
+  { id: 'traditional', label: 'Traditional Shell & Slate', thumbnail: '/assets/game-art/baduk-battle-royal/store/stones/traditional.svg', black: '#0a0a0d', white: '#f8fafc', blackRoughness: 0.28, whiteRoughness: 0.2 },
+  { id: 'jadeIvory', label: 'Jade & Ivory', thumbnail: '/assets/game-art/baduk-battle-royal/store/stones/jadeIvory.svg', black: '#0f3b2e', white: '#f8f3d8', blackRoughness: 0.22, whiteRoughness: 0.26 },
+  { id: 'obsidianGold', label: 'Obsidian & Gold', thumbnail: '/assets/game-art/baduk-battle-royal/store/stones/obsidianGold.svg', black: '#050506', white: '#f7c24b', blackRoughness: 0.16, whiteRoughness: 0.24 },
+  { id: 'coralSky', label: 'Coral & Sky', thumbnail: '/assets/game-art/baduk-battle-royal/store/stones/coralSky.svg', black: '#2463ad', white: '#ff8a6b', blackRoughness: 0.2, whiteRoughness: 0.28 },
+  { id: 'monoInk', label: 'Mono Ink', thumbnail: '/assets/game-art/baduk-battle-royal/store/stones/monoInk.svg', black: '#151515', white: '#dbdbdb', blackRoughness: 0.24, whiteRoughness: 0.24 }
+])
+
+export const BADUK_BATTLE_DEFAULT_UNLOCKS = Object.freeze({
   chairColor: [BADUK_CHAIR_OPTIONS[0]?.id],
   tables: [BADUK_TABLE_OPTIONS[0]?.id],
   tableFinish: [MURLAN_TABLE_FINISHES[0]?.id],
+  boardTheme: [BADUK_BOARD_THEMES[0]?.id],
+  stoneStyle: [BADUK_STONE_STYLES[0]?.id],
   environmentHdri: [DEFAULT_HDRI_ID]
 })
+
+export const BADUK_BATTLE_OPTION_LABELS = Object.freeze({
+  chairColor: Object.freeze(BADUK_CHAIR_OPTIONS.reduce((acc, option) => ({ ...acc, [option.id]: option.label }), {})),
+  tables: Object.freeze(BADUK_TABLE_OPTIONS.reduce((acc, option) => ({ ...acc, [option.id]: option.label }), {})),
+  tableFinish: Object.freeze(MURLAN_TABLE_FINISHES.reduce((acc, option) => ({ ...acc, [option.id]: option.label }), {})),
+  boardTheme: Object.freeze(BADUK_BOARD_THEMES.reduce((acc, option) => ({ ...acc, [option.id]: option.label }), {})),
+  stoneStyle: Object.freeze(BADUK_STONE_STYLES.reduce((acc, option) => ({ ...acc, [option.id]: option.label }), {})),
+  environmentHdri: Object.freeze(POOL_ROYALE_HDRI_VARIANTS.reduce((acc, variant) => ({ ...acc, [variant.id]: `${variant.name} HDRI` }), {}))
+})
+
+export const BADUK_BATTLE_DEFAULT_LOADOUT = BADUK_BATTLE_DEFAULT_UNLOCKS
+
+export const BADUK_BATTLE_STORE_ITEMS = [
+  ...MURLAN_TABLE_FINISHES.map((finish, idx) => ({
+    id: `baduk-table-finish-${finish.id}`,
+    type: 'tableFinish',
+    optionId: finish.id,
+    name: finish.label,
+    price: finish.price ?? 960 + idx * 40,
+    description: finish.description,
+    swatches: finish.swatches,
+    thumbnail: finish.thumbnail,
+    previewShape: 'table'
+  })),
+  ...BADUK_TABLE_OPTIONS.slice(1).map((theme, idx) => ({
+    id: `baduk-table-${theme.id}`,
+    type: 'tables',
+    optionId: theme.id,
+    name: theme.label,
+    price: theme.price ?? 960 + idx * 40,
+    description: theme.description || `${theme.label} table with preserved Poly Haven materials.`,
+    thumbnail: theme.thumbnail,
+    previewShape: 'table'
+  })),
+  ...BADUK_CHAIR_OPTIONS.slice(1).map((option, idx) => ({
+    id: `baduk-chair-${option.id}`,
+    type: 'chairColor',
+    optionId: option.id,
+    name: option.label,
+    price: option.price ?? 320 + idx * 20,
+    description: option.description || `${option.label} seating tuned for Baduk Battle Royal.`,
+    thumbnail: option.thumbnail,
+    previewShape: 'chair'
+  })),
+  ...BADUK_BOARD_THEMES.slice(1).map((theme, idx) => ({
+    id: `baduk-board-${theme.id}`,
+    type: 'boardTheme',
+    optionId: theme.id,
+    name: theme.label,
+    price: 450 + idx * 30,
+    description: 'Open-source goban texture variant with high-contrast line work.',
+    thumbnail: theme.thumbnail,
+    swatches: [theme.tint, theme.grid],
+    previewShape: 'board'
+  })),
+  ...BADUK_STONE_STYLES.slice(1).map((style, idx) => ({
+    id: `baduk-stones-${style.id}`,
+    type: 'stoneStyle',
+    optionId: style.id,
+    name: style.label,
+    price: 420 + idx * 35,
+    description: 'Stone set inspired by free/open-source goban palettes.',
+    thumbnail: style.thumbnail,
+    swatches: [style.black, style.white],
+    previewShape: 'piece'
+  })),
+  ...POOL_ROYALE_HDRI_VARIANTS.slice(1).map((variant, idx) => ({
+    id: `baduk-hdri-${variant.id}`,
+    type: 'environmentHdri',
+    optionId: variant.id,
+    name: `${variant.name} HDRI`,
+    price: 780 + idx * 60,
+    description: `Arena lighting profile based on ${variant.name}.`,
+    thumbnail: variant.thumbnail || swatchThumbnail(variant.swatches || ['#1f2937', '#0f172a'])
+  }))
+]

--- a/webapp/src/pages/Games/BadukBattleRoyal.jsx
+++ b/webapp/src/pages/Games/BadukBattleRoyal.jsx
@@ -10,6 +10,8 @@ import { ARENA_CAMERA_DEFAULTS } from '../../utils/arenaCameraConfig.js';
 import { createMurlanStyleTable, applyTableMaterials } from '../../utils/murlanTable.js';
 import {
   BADUK_CHAIR_OPTIONS,
+  BADUK_BOARD_THEMES,
+  BADUK_STONE_STYLES,
   BADUK_TABLE_OPTIONS,
   BADUK_BATTLE_DEFAULT_LOADOUT
 } from '../../config/badukBattleInventoryConfig.js';
@@ -27,7 +29,7 @@ import { badukBattleAccountId, getBadukBattleInventory } from '../../utils/baduk
 import { applyRendererSRGB, applySRGBColorSpace } from '../../utils/colorSpace.js';
 
 const BOARD_SIZES = [9, 13, 16, 19];
-const BOARD_TEXTURE_SIZE = 1024;
+const BOARD_TEXTURE_SIZE = 2048;
 const BOARD_GRID_MIN = 86;
 const BOARD_GRID_MAX = 938;
 const BOARD_GRID_RANGE_RATIO = (BOARD_GRID_MAX - BOARD_GRID_MIN) / BOARD_TEXTURE_SIZE;
@@ -173,6 +175,8 @@ export default function BadukBattleRoyal() {
     tableFinish: inventory.tableFinish?.[0] || MURLAN_TABLE_FINISHES[0]?.id,
     tableId: inventory.tables?.[0] || BADUK_BATTLE_DEFAULT_LOADOUT.tables?.[0] || BADUK_TABLE_OPTIONS[0]?.id,
     chairId: inventory.chairColor?.[0] || BADUK_BATTLE_DEFAULT_LOADOUT.chairColor?.[0] || BADUK_CHAIR_OPTIONS[0]?.id,
+    boardTheme: inventory.boardTheme?.[0] || BADUK_BATTLE_DEFAULT_LOADOUT.boardTheme?.[0] || BADUK_BOARD_THEMES[0]?.id,
+    stoneStyle: inventory.stoneStyle?.[0] || BADUK_BATTLE_DEFAULT_LOADOUT.stoneStyle?.[0] || BADUK_STONE_STYLES[0]?.id,
     hdriId: inventory.environmentHdri?.[0] || BADUK_BATTLE_DEFAULT_LOADOUT.environmentHdri?.[0] || POOL_ROYALE_DEFAULT_HDRI_ID
   }));
 
@@ -244,9 +248,18 @@ export default function BadukBattleRoyal() {
     if (!group) return;
     group.clear();
 
+    const stoneStyle = BADUK_STONE_STYLES.find((style) => style.id === appearance.stoneStyle) || BADUK_STONE_STYLES[0];
     const stoneGeo = new THREE.SphereGeometry(0.045, 22, 16);
-    const blackMat = new THREE.MeshStandardMaterial({ color: '#0b0b0d', roughness: 0.28, metalness: 0.06 });
-    const whiteMat = new THREE.MeshStandardMaterial({ color: '#f8fafc', roughness: 0.2, metalness: 0.03 });
+    const blackMat = new THREE.MeshStandardMaterial({
+      color: stoneStyle?.black || '#0b0b0d',
+      roughness: stoneStyle?.blackRoughness ?? 0.28,
+      metalness: 0.06
+    });
+    const whiteMat = new THREE.MeshStandardMaterial({
+      color: stoneStyle?.white || '#f8fafc',
+      roughness: stoneStyle?.whiteRoughness ?? 0.2,
+      metalness: 0.03
+    });
     const markerGeo = new THREE.SphereGeometry(0.014, 14, 10);
     const markerMat = new THREE.MeshBasicMaterial({ color: '#34d399' });
 
@@ -272,7 +285,7 @@ export default function BadukBattleRoyal() {
 
   useEffect(() => {
     renderStones(board, lastMove);
-  }, [board, lastMove]);
+  }, [appearance.stoneStyle, board, lastMove]);
 
   useEffect(() => {
     const mount = mountRef.current;
@@ -354,8 +367,12 @@ export default function BadukBattleRoyal() {
 
     const boardTexture = new THREE.TextureLoader().load(`/assets/game-art/baduk-battle-royal/boards/${boardSize}x${boardSize}.svg`);
     applySRGBColorSpace(boardTexture);
-    boardTexture.anisotropy = 8;
+    boardTexture.anisotropy = 16;
+    boardTexture.minFilter = THREE.LinearMipmapLinearFilter;
+    boardTexture.magFilter = THREE.LinearFilter;
     boardPlane.material.map = boardTexture;
+    const boardTheme = BADUK_BOARD_THEMES.find((theme) => theme.id === appearance.boardTheme) || BADUK_BOARD_THEMES[0];
+    boardPlane.material.color = new THREE.Color(boardTheme?.tint || '#d7a359');
     boardPlane.material.needsUpdate = true;
 
     const stonesGroup = new THREE.Group();
@@ -402,7 +419,7 @@ export default function BadukBattleRoyal() {
         }
       });
     };
-  }, [boardSize, appearance.chairId, graphicsOption.fps, graphicsOption.pixelRatioCap, graphicsOption.renderScale]);
+  }, [boardSize, appearance.boardTheme, appearance.chairId, graphicsOption.fps, graphicsOption.pixelRatioCap, graphicsOption.renderScale]);
 
   useEffect(() => {
     const finish = MURLAN_TABLE_FINISHES.find((f) => f.id === appearance.tableFinish) || MURLAN_TABLE_FINISHES[0];
@@ -647,6 +664,32 @@ export default function BadukBattleRoyal() {
                     key={opt.id}
                     onClick={() => setAppearance((prev) => ({ ...prev, chairId: opt.id }))}
                     className={optionButton(appearance.chairId === opt.id)}
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
+
+              <div className="mb-2 text-[11px] uppercase tracking-[0.2em] text-white/70">Baduk Boards</div>
+              <div className="mb-3 grid max-h-40 grid-cols-2 gap-2 overflow-auto">
+                {BADUK_BOARD_THEMES.map((opt) => (
+                  <button
+                    key={opt.id}
+                    onClick={() => setAppearance((prev) => ({ ...prev, boardTheme: opt.id }))}
+                    className={optionButton(appearance.boardTheme === opt.id)}
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
+
+              <div className="mb-2 text-[11px] uppercase tracking-[0.2em] text-white/70">Stone Sets</div>
+              <div className="mb-3 grid max-h-40 grid-cols-2 gap-2 overflow-auto">
+                {BADUK_STONE_STYLES.map((opt) => (
+                  <button
+                    key={opt.id}
+                    onClick={() => setAppearance((prev) => ({ ...prev, stoneStyle: opt.id }))}
+                    className={optionButton(appearance.stoneStyle === opt.id)}
                   >
                     {opt.label}
                   </button>

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -51,12 +51,24 @@ import {
   CHESS_BATTLE_STORE_ITEMS
 } from '../config/chessBattleInventoryConfig.js';
 import {
+  BADUK_BATTLE_DEFAULT_LOADOUT,
+  BADUK_BATTLE_OPTION_LABELS,
+  BADUK_BATTLE_STORE_ITEMS
+} from '../config/badukBattleInventoryConfig.js';
+import {
   addChessBattleUnlock,
   getChessBattleInventory,
   isChessOptionUnlocked,
   chessBattleAccountId,
   listOwnedChessOptions
 } from '../utils/chessBattleInventory.js';
+import {
+  addBadukBattleUnlock,
+  getBadukBattleInventory,
+  isBadukOptionUnlocked,
+  listOwnedBadukOptions,
+  badukBattleAccountId
+} from '../utils/badukBattleInventory.js';
 import {
   LUDO_BATTLE_DEFAULT_LOADOUT,
   LUDO_BATTLE_OPTION_LABELS,
@@ -154,6 +166,15 @@ const CHESS_TYPE_LABELS = {
   sideColor: 'Piece Colors',
   boardTheme: 'Board Themes',
   headStyle: 'Pawn Heads',
+  environmentHdri: 'HDR Environments'
+};
+
+const BADUK_TYPE_LABELS = {
+  tables: 'Table Models',
+  tableFinish: 'Table Finish',
+  chairColor: 'Chairs',
+  boardTheme: 'Baduk Boards',
+  stoneStyle: 'Stone Sets',
   environmentHdri: 'HDR Environments'
 };
 
@@ -690,10 +711,10 @@ const storeMeta = {
   },
   badukbattleroyal: {
     name: 'Baduk Battle Royal',
-    items: CHESS_BATTLE_STORE_ITEMS,
-    defaults: CHESS_BATTLE_DEFAULT_LOADOUT,
-    labels: CHESS_BATTLE_OPTION_LABELS,
-    typeLabels: CHESS_TYPE_LABELS,
+    items: BADUK_BATTLE_STORE_ITEMS,
+    defaults: BADUK_BATTLE_DEFAULT_LOADOUT,
+    labels: BADUK_BATTLE_OPTION_LABELS,
+    typeLabels: BADUK_TYPE_LABELS,
     accountId: CHESS_STORE_ACCOUNT_ID
   },
   tavullbattleroyal: {
@@ -755,6 +776,7 @@ export default function Store() {
   const [snookerOwned, setSnookerOwned] = useState(() => getCachedSnookerRoyalInventory(accountId));
   const [airOwned, setAirOwned] = useState(() => getAirHockeyInventory(airHockeyAccountId(accountId)));
   const [chessOwned, setChessOwned] = useState(() => getChessBattleInventory(chessBattleAccountId(accountId)));
+  const [badukOwned, setBadukOwned] = useState(() => getBadukBattleInventory(badukBattleAccountId(accountId)));
   const [ludoOwned, setLudoOwned] = useState(() => getLudoBattleInventory(ludoBattleAccountId(accountId)));
   const [murlanOwned, setMurlanOwned] = useState(() => getMurlanInventory(murlanAccountId(accountId)));
   const [dominoOwned, setDominoOwned] = useState(() => getDominoRoyalInventory(dominoRoyalAccountId(accountId)));
@@ -843,6 +865,7 @@ export default function Store() {
     setSnookerOwned(getCachedSnookerRoyalInventory(accountId));
     setAirOwned(getAirHockeyInventory(airHockeyAccountId(accountId)));
     setChessOwned(getChessBattleInventory(chessBattleAccountId(accountId)));
+    setBadukOwned(getBadukBattleInventory(badukBattleAccountId(accountId)));
     setLudoOwned(getLudoBattleInventory(ludoBattleAccountId(accountId)));
     setMurlanOwned(getMurlanInventory(murlanAccountId(accountId)));
     setDominoOwned(getDominoRoyalInventory(dominoRoyalAccountId(accountId)));
@@ -923,7 +946,7 @@ export default function Store() {
       airhockey: AIR_HOCKEY_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId), slug: 'airhockey' })),
       chessbattleroyal: CHESS_BATTLE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId), slug: 'chessbattleroyal' })),
       checkersbattleroyal: CHESS_BATTLE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId), slug: 'checkersbattleroyal' })),
-      badukbattleroyal: CHESS_BATTLE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId), slug: 'badukbattleroyal' })),
+      badukbattleroyal: BADUK_BATTLE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId), slug: 'badukbattleroyal' })),
       tavullbattleroyal: CHESS_BATTLE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId), slug: 'tavullbattleroyal' })),
       ludobattleroyal: LUDO_BATTLE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId), slug: 'ludobattleroyal' })),
       murlanroyale: MURLAN_ROYALE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId), slug: 'murlanroyale' })),
@@ -942,7 +965,7 @@ export default function Store() {
       airhockey: (type, optionId) => isAirHockeyOptionUnlocked(type, optionId, airOwned),
       chessbattleroyal: (type, optionId) => isChessOptionUnlocked(type, optionId, chessOwned),
       checkersbattleroyal: (type, optionId) => isChessOptionUnlocked(type, optionId, chessOwned),
-      badukbattleroyal: (type, optionId) => isChessOptionUnlocked(type, optionId, chessOwned),
+      badukbattleroyal: (type, optionId) => isBadukOptionUnlocked(type, optionId, badukOwned),
       tavullbattleroyal: (type, optionId) => isChessOptionUnlocked(type, optionId, chessOwned),
       ludobattleroyal: (type, optionId) => isLudoOptionUnlocked(type, optionId, ludoOwned),
       murlanroyale: (type, optionId) => isMurlanOptionUnlocked(type, optionId, murlanOwned),
@@ -950,7 +973,7 @@ export default function Store() {
       snake: (type, optionId) => isSnakeOptionUnlocked(type, optionId, snakeOwned),
       texasholdem: (type, optionId) => isTexasOptionUnlocked(type, optionId, texasOwned)
     }),
-    [airOwned, poolOwned, snookerOwned, chessOwned, ludoOwned, murlanOwned, dominoOwned, snakeOwned, texasOwned]
+    [airOwned, poolOwned, snookerOwned, chessOwned, badukOwned, ludoOwned, murlanOwned, dominoOwned, snakeOwned, texasOwned]
   );
 
   const labelResolvers = useMemo(
@@ -961,7 +984,7 @@ export default function Store() {
       airhockey: (item) => AIR_HOCKEY_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
       chessbattleroyal: (item) => CHESS_BATTLE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
       checkersbattleroyal: (item) => CHESS_BATTLE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
-      badukbattleroyal: (item) => CHESS_BATTLE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
+      badukbattleroyal: (item) => BADUK_BATTLE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
       tavullbattleroyal: (item) => CHESS_BATTLE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
       ludobattleroyal: (item) => LUDO_BATTLE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
       murlanroyale: (item) => MURLAN_ROYALE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
@@ -979,7 +1002,7 @@ export default function Store() {
       airhockey: AIR_HOCKEY_TYPE_LABELS,
       chessbattleroyal: CHESS_TYPE_LABELS,
       checkersbattleroyal: CHESS_TYPE_LABELS,
-      badukbattleroyal: CHESS_TYPE_LABELS,
+      badukbattleroyal: BADUK_TYPE_LABELS,
       tavullbattleroyal: CHESS_TYPE_LABELS,
       ludobattleroyal: LUDO_TYPE_LABELS,
       murlanroyale: MURLAN_TYPE_LABELS,
@@ -1522,8 +1545,10 @@ export default function Store() {
         for (const entry of group.items) {
           if (slug === 'airhockey') {
             setAirOwned(addAirHockeyUnlock(entry.type, entry.optionId, resolvedAccountId));
-          } else if (slug === 'chessbattleroyal' || slug === 'checkersbattleroyal' || slug === 'badukbattleroyal' || slug === 'tavullbattleroyal') {
+          } else if (slug === 'chessbattleroyal' || slug === 'checkersbattleroyal' || slug === 'tavullbattleroyal') {
             setChessOwned(addChessBattleUnlock(entry.type, entry.optionId, resolvedAccountId));
+          } else if (slug === 'badukbattleroyal') {
+            setBadukOwned(addBadukBattleUnlock(entry.type, entry.optionId, resolvedAccountId));
           } else if (slug === 'ludobattleroyal') {
             setLudoOwned(addLudoBattleUnlock(entry.type, entry.optionId, resolvedAccountId));
           } else if (slug === 'murlanroyale') {

--- a/webapp/src/utils/badukBattleInventory.js
+++ b/webapp/src/utils/badukBattleInventory.js
@@ -1,7 +1,18 @@
-import { BADUK_BATTLE_DEFAULT_LOADOUT } from '../config/badukBattleInventoryConfig.js'
+import {
+  BADUK_BATTLE_DEFAULT_LOADOUT,
+  BADUK_BATTLE_DEFAULT_UNLOCKS,
+  BADUK_BATTLE_OPTION_LABELS
+} from '../config/badukBattleInventoryConfig.js'
 
 const STORAGE_KEY = 'badukBattleInventoryByAccount'
-const memoryCache = new Map()
+let memoryInventories = {}
+let storageHealthy = true
+
+const copyDefaults = () =>
+  Object.entries(BADUK_BATTLE_DEFAULT_UNLOCKS).reduce((acc, [key, values]) => {
+    acc[key] = Array.isArray(values) ? [...values].filter(Boolean) : []
+    return acc
+  }, {})
 
 export const badukBattleAccountId = (value) => {
   const normalized = `${value || 'guest'}`.trim()
@@ -9,20 +20,78 @@ export const badukBattleAccountId = (value) => {
 }
 
 const readStore = () => {
+  if (typeof window === 'undefined' || !storageHealthy) return memoryInventories
   try {
     const raw = window.localStorage?.getItem(STORAGE_KEY)
-    if (!raw) return {}
-    return JSON.parse(raw) || {}
+    memoryInventories = raw ? JSON.parse(raw) : {}
+    storageHealthy = true
   } catch {
-    return {}
+    storageHealthy = false
   }
+  return memoryInventories
+}
+
+const writeStore = (payload) => {
+  memoryInventories = payload || {}
+  if (typeof window === 'undefined' || !storageHealthy) return
+  try {
+    window.localStorage?.setItem(STORAGE_KEY, JSON.stringify(memoryInventories))
+  } catch {
+    storageHealthy = false
+  }
+}
+
+const normalizeInventory = (rawInventory) => {
+  const base = copyDefaults()
+  if (!rawInventory || typeof rawInventory !== 'object') return base
+  const merged = { ...base }
+  Object.entries(rawInventory).forEach(([key, value]) => {
+    if (!Array.isArray(value)) return
+    merged[key] = Array.from(new Set([...(merged[key] || []), ...value]))
+  })
+  return merged
 }
 
 export const getBadukBattleInventory = (accountId = 'guest') => {
   const id = badukBattleAccountId(accountId)
-  if (memoryCache.has(id)) return memoryCache.get(id)
   const db = readStore()
-  const resolved = { ...BADUK_BATTLE_DEFAULT_LOADOUT, ...(db[id] || {}) }
-  memoryCache.set(id, resolved)
+  const resolved = normalizeInventory(db[id])
+  if (typeof window !== 'undefined') {
+    writeStore({ ...db, [id]: resolved })
+  }
   return resolved
 }
+
+export const isBadukOptionUnlocked = (type, optionId, inventoryOrAccountId) => {
+  if (!type || !optionId) return false
+  const inventory =
+    typeof inventoryOrAccountId === 'string' || !inventoryOrAccountId
+      ? getBadukBattleInventory(inventoryOrAccountId)
+      : inventoryOrAccountId
+  return Array.isArray(inventory?.[type]) && inventory[type].includes(optionId)
+}
+
+export const addBadukBattleUnlock = (type, optionId, accountId = 'guest') => {
+  const id = badukBattleAccountId(accountId)
+  const db = readStore()
+  const current = normalizeInventory(db[id])
+  const nextValues = new Set(current[type] || [])
+  nextValues.add(optionId)
+  const nextInventory = { ...current, [type]: Array.from(nextValues) }
+  writeStore({ ...db, [id]: nextInventory })
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent('badukBattleInventoryUpdate', { detail: { accountId: id, inventory: nextInventory } }))
+  }
+  return nextInventory
+}
+
+export const listOwnedBadukOptions = (accountId) => {
+  const inventory = getBadukBattleInventory(accountId)
+  return Object.entries(inventory).flatMap(([type, values]) => {
+    if (!Array.isArray(values)) return []
+    const labels = BADUK_BATTLE_OPTION_LABELS[type] || {}
+    return values.map((optionId) => ({ type, optionId, label: labels[optionId] || optionId }))
+  })
+}
+
+export const getDefaultBadukBattleLoadout = () => ({ ...BADUK_BATTLE_DEFAULT_LOADOUT })


### PR DESCRIPTION
### Motivation
- Increase visual fidelity of Baduk Battle Royal boards and expose multiple purchasable board/stone styles for player customization.  
- Decouple Baduk cosmetics from the shared chess inventory so Baduk can have its own store/catalog and persistent unlocks.  
- Provide small lightweight storefront previews and respect upstream open-source goban art attribution for in-game textures.

### Description
- Added a Baduk-specific inventory/config: `BADUK_BOARD_THEMES`, `BADUK_STONE_STYLES`, defaults and `BADUK_BATTLE_STORE_ITEMS` in `webapp/src/config/badukBattleInventoryConfig.js`.  
- Implemented local inventory utilities for Baduk (`get`, `isUnlocked`, `addUnlock`, `listOwned`, event dispatch) in `webapp/src/utils/badukBattleInventory.js` so purchases persist and broadcast updates.  
- Wired the store to use Baduk-specific items and labels by updating `webapp/src/pages/Store.jsx` to serve `badukbattleroyal` from the new Baduk catalog and apply unlocks when purchased.  
- Improved in-game rendering in `webapp/src/pages/Games/BadukBattleRoyal.jsx` by increasing `BOARD_TEXTURE_SIZE` to `2048`, raising texture `anisotropy` to `16`, enabling mipmapping/filters, adding board-theme tinting and selectable stone-style materials, and adding UI selectors for board and stone sets.  
- Added lightweight SVG storefront thumbnails and attribution files under `webapp/public/assets/game-art/baduk-battle-royal/store/` for 5 board themes and 5 stone styles and included an attribution note referencing the Apache-2.0 online-go/goban base assets.

### Testing
- Ran inventory consistency test with `npm test -- test/inventoryCrossGameConfig.test.js --runInBand` which passed.  
- Attempted combined store tests with `npm test -- test/storeDelivery.test.js test/inventoryCrossGameConfig.test.js --runInBand`, where inventory cross-game test passed but `test/storeDelivery.test.js` failed due to a missing environment dependency (`uuid` module) unrelated to these changes.  
- Ran `npx eslint` on the edited files which returned warnings that the files are ignored by repo ignore settings (no code errors reported).  
- Launched the webdev server and attempted an automated Playwright screenshot of `/store/badukbattleroyal`, but the headless browser capture timed out in this environment (dev server did start successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b788a337008329883b5c704a0e714c)