### PR TITLE
Update logos/thumbnails for Table Tennis, Backgammon, Checkers and Baduk

### DIFF
--- a/webapp/src/config/gameAssets.js
+++ b/webapp/src/config/gameAssets.js
@@ -20,11 +20,11 @@ export const gameThumbnails = {
   snake: '/assets/icons/Snake%20and%20ladder%20game%20logo.png',
   murlanroyale: '/assets/icons/Murlan%20Royal%20logo.png',
   chessbattleroyal: '/assets/icons/Chess%20battle%20Royal%20logo.png',
-  checkersbattleroyal: '/assets/icons/Chess%20battle%20Royal%20logo.png',
-  badukbattleroyal: '/assets/icons/Chess%20battle%20Royal%20logo.png',
-  tavullbattleroyal: '/assets/icons/Chess%20battle%20Royal%20logo.png',
+  checkersbattleroyal: '/assets/icons/Checkersbattleroyallogo.png',
+  badukbattleroyal: '/assets/icons/Badukbattleroyallogo.png',
+  tavullbattleroyal: '/assets/icons/Backgammonroyallogo.png',
   ludobattleroyal: '/assets/icons/Ludo%20battle%20Royal%20game%20logo.png',
-  tabletennisroyal: '/assets/icons/table-tennis-royale.svg'
+  tabletennisroyal: '/assets/icons/Tabletennisroyallogo.png'
 };
 
 const buildLobbyIconSet = (keys, icon) =>

--- a/webapp/src/config/gamesCatalog.js
+++ b/webapp/src/config/gamesCatalog.js
@@ -67,7 +67,7 @@ const gamesCatalog = [
     name: 'Checkers Battle Royal',
     route: '/games/checkersbattleroyal/lobby',
     slug: 'checkersbattleroyal',
-    image: '/assets/icons/Chess%20battle%20Royal%20logo.png',
+    image: '/assets/icons/Checkersbattleroyallogo.png',
     description: 'Classic checkers duels with royal 3D presentation.'
   },
 
@@ -75,7 +75,7 @@ const gamesCatalog = [
     name: 'Baduk Battle Royal',
     route: '/games/badukbattleroyal/lobby',
     slug: 'badukbattleroyal',
-    image: '/assets/icons/Chess%20battle%20Royal%20logo.png',
+    image: '/assets/icons/Badukbattleroyallogo.png',
     description: 'Go/Baduk strategy on the shared Battle Royal 3D arena.'
   },
 
@@ -83,14 +83,14 @@ const gamesCatalog = [
     name: 'Backgammon Royal',
     route: '/games/tavullbattleroyal/lobby',
     slug: 'tavullbattleroyal',
-    image: '/assets/icons/Chess%20battle%20Royal%20logo.png',
+    image: '/assets/icons/Backgammonroyallogo.png',
     description: 'Backgammon duels with a royal 3D-inspired board and smart AI.'
   },
   {
     name: 'Table Tennis Royal',
     route: '/games/tabletennisroyal/lobby',
     slug: 'tabletennisroyal',
-    image: '/assets/icons/Pool%20Royal%20game%20logo.png',
+    image: '/assets/icons/Tabletennisroyallogo.png',
     description: 'Fast 3D table-tennis rallies with royal visuals.'
   },
   {


### PR DESCRIPTION
### Motivation
- Replace placeholder/incorrect icons with the newly uploaded official logos so game list cards and thumbnail mappings show the correct artwork for each game.

### Description
- Updated thumbnail mappings in `webapp/src/config/gameAssets.js` to point the following keys to the uploaded assets: `tabletennisroyal` → `Tabletennisroyallogo.png`, `tavullbattleroyal` → `Backgammonroyallogo.png`, `checkersbattleroyal` → `Checkersbattleroyallogo.png`, and `badukbattleroyal` → `Badukbattleroyallogo.png`.
- Updated the Games catalog entries in `webapp/src/config/gamesCatalog.js` so the `/games` listing and cards use the same new image files for those four games.
- No runtime logic changes; this is a configuration/asset mapping update only.

### Testing
- Ran a production build with `npm run build` in `webapp` which completed successfully (Vite warnings about large chunks are unchanged and not related to this change). 
- Started the dev server with `npm run dev` and captured a mobile-viewport screenshot of `/games` using a Playwright script to validate the updated logos render in the games listing, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b792a2b27c8329984bd08083739df2)