### PR TITLE
Reduce renderer effect dependencies in CheckersBattleRoyal

### DIFF
--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -523,7 +523,6 @@ async function loadCheckersBoardModel(loader) {
 }
 
 
-
 function snapshotBoardMaterials(boardModel) {
   if (!boardModel || BOARD_MATERIAL_CACHE.has(boardModel)) return;
   const cache = new Map();
@@ -1366,7 +1365,7 @@ export default function CheckersBattleRoyal() {
       cameraRef.current = null;
       controlsRef.current = null;
     };
-  }, [renderPieces, appearance.chairId, appearance.tableFinish, appearance.boardTheme]);
+  }, [renderPieces]);
 
   useEffect(() => {
     if (turn !== AI_SIDE || aiBusyRef.current) return;


### PR DESCRIPTION
### Motivation
- Prevent the renderer initialization effect from re-running when unrelated appearance properties change to avoid unnecessary re-initialization and potential visual glitches.

### Description
- Simplified the renderer `useEffect` dependency array in `CheckersBattleRoyal.jsx` from `[renderPieces, appearance.chairId, appearance.tableFinish, appearance.boardTheme]` to just `[renderPieces]` so appearance changes no longer force a full renderer teardown/recreate.
- No other logic changes were made to rendering or board handling in this file.

### Testing
- Ran unit tests with `yarn test`, which succeeded.
- Ran linting with `yarn lint`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b79bdf46f08329a1ed36181ebda964)