### PR TITLE
Fix Checkers Battle Royal board sizing and theme application to match Chess

### DIFF
--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -526,10 +526,6 @@ async function loadCheckersBoardModel(renderer = null) {
 
       const boardModel = source.clone(true);
       boardModel.name = 'ABeautifulGameBoard';
-      boardModel.userData = {
-        ...(boardModel.userData || {}),
-        forceOriginalTextures: true
-      };
 
       const pieceTokens = /\b(pawn|rook|knight|bishop|queen|king)\b/i;
       const prune = [];
@@ -555,6 +551,17 @@ async function loadCheckersBoardModel(renderer = null) {
       const size = box.getSize(new THREE.Vector3());
       const largest = Math.max(size.x, size.z, 0.001);
       const targetSize = BOARD_TILE_SIZE * SIZE;
+
+      // Keep Checkers board footprint aligned with Chess Battle Royal.
+      // If the imported GLTF includes extra scenery (field/stadium),
+      // prefer procedural board fallback for stable gameplay sizing.
+      if (largest > targetSize * 3) {
+        console.warn(
+          'Checkers Battle Royal: imported board model includes extra geometry; using fallback board for consistent sizing.'
+        );
+        continue;
+      }
+
       const scale = targetSize / largest;
       boardModel.scale.multiplyScalar(scale);
 
@@ -614,8 +621,6 @@ function applyCheckersBoardTheme(
   if (!boardModel) return;
   snapshotBoardMaterials(boardModel);
   restoreBoardMaterials(boardModel);
-
-  if (boardModel?.userData?.forceOriginalTextures) return;
 
   const frameLight = new THREE.Color(option?.frameLight || '#d2b48c');
   const frameDark = new THREE.Color(option?.frameDark || '#3a2d23');


### PR DESCRIPTION
### Motivation
- Ensure Checkers Battle Royal uses the same playable board footprint and theme behavior as Chess Battle Royal so players can swap board art and colors reliably.
- Prevent imported GLTF boards that include extra scenery or preserved original textures from breaking sizing, theme colors, or showing chess pieces in the Checkers scene.

### Description
- Removed the forced-preserve-original-texture behavior so theme color changes apply to loaded board models by allowing material recoloring in `applyCheckersBoardTheme` (`webapp/src/pages/Games/CheckersBattleRoyal.jsx`).
- Added a geometry sanity check when loading external board GLTFs to skip oversized models (likely containing stadium/field) and fall back to the procedural board to keep the playable footprint aligned with Chess (`loadCheckersBoardModel`).
- Continued to prune chess piece meshes from imported board assets so only the board geometry is used in Checkers mode (`loadCheckersBoardModel` traversal/prune logic).
- Kept material snapshot/restore to avoid mutating shared materials while applying new theme colors to the board model.

### Testing
- Built the web app successfully with `npm --prefix webapp run build` (build completed without errors).
- Launched the dev server and captured a mobile-portrait screenshot of the Checkers page via Playwright to visually validate the board (screenshot captured during validation).
- Ran `npx eslint webapp/src/pages/Games/CheckersBattleRoyal.jsx` which reported a file-ignore warning only and no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7e3fa6c848329b98d9049f8026f9f)