### PR TITLE
Fix Checkers Battle Royal board scaling and theme switching

### DIFF
--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -57,7 +57,8 @@ const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 0.85;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
 const TABLE_HEIGHT = STOOL_HEIGHT + 0.05 * MODEL_SCALE;
 const BOARD_SCALE = 0.0576;
-const BOARD_TILE_SIZE = ((SIZE * 4.2 + 3 * 2) * BOARD_SCALE) / SIZE;
+const BOARD_TILE_SIZE = 4.2 * BOARD_SCALE;
+const BOARD_DISPLAY_SIZE = (SIZE * 4.2 + 3 * 2) * BOARD_SCALE;
 const CHAIR_DISTANCE = TABLE_RADIUS + 0.82;
 const SEAT_WIDTH = 0.9 * MODEL_SCALE * STOOL_SCALE;
 const SEAT_DEPTH = 0.95 * MODEL_SCALE * STOOL_SCALE;
@@ -421,7 +422,7 @@ const searchBestMove = (
 };
 
 function buildFallbackCheckersBoardModel() {
-  const targetBoardSize = BOARD_TILE_SIZE * SIZE;
+  const targetBoardSize = BOARD_DISPLAY_SIZE;
   const boardModel = new THREE.Group();
   boardModel.name = 'ChessBattleRoyalBoard';
   const boardBaseY = TABLE_HEIGHT - 0.2;
@@ -429,7 +430,7 @@ function buildFallbackCheckersBoardModel() {
   const frameSize = targetBoardSize * 1.14;
   const frameHeight = 0.14;
   const topHeight = 0.04;
-  const tileSize = targetBoardSize / SIZE;
+  const tileSize = BOARD_TILE_SIZE;
 
   const frameDarkMat = new THREE.MeshStandardMaterial({
     color: '#3a2d23',
@@ -526,10 +527,6 @@ async function loadCheckersBoardModel(renderer = null) {
 
       const boardModel = source.clone(true);
       boardModel.name = 'ABeautifulGameBoard';
-      boardModel.userData = {
-        ...(boardModel.userData || {}),
-        forceOriginalTextures: true
-      };
 
       const pieceTokens = /\b(pawn|rook|knight|bishop|queen|king)\b/i;
       const prune = [];
@@ -554,7 +551,7 @@ async function loadCheckersBoardModel(renderer = null) {
       const box = new THREE.Box3().setFromObject(boardModel);
       const size = box.getSize(new THREE.Vector3());
       const largest = Math.max(size.x, size.z, 0.001);
-      const targetSize = BOARD_TILE_SIZE * SIZE;
+      const targetSize = BOARD_DISPLAY_SIZE;
       const scale = targetSize / largest;
       boardModel.scale.multiplyScalar(scale);
 
@@ -615,7 +612,6 @@ function applyCheckersBoardTheme(
   snapshotBoardMaterials(boardModel);
   restoreBoardMaterials(boardModel);
 
-  if (boardModel?.userData?.forceOriginalTextures) return;
 
   const frameLight = new THREE.Color(option?.frameLight || '#d2b48c');
   const frameDark = new THREE.Color(option?.frameDark || '#3a2d23');


### PR DESCRIPTION
### Motivation
- The Checkers arena used a different per-tile sizing and total footprint than Chess Battle Royal, causing visual/interaction mismatch when swapping boards. 
- Imported chess GLTF boards were kept with their original textures, preventing runtime board theme/color swaps from applying to Checkers.

### Description
- Aligned board metrics with the chess implementation by introducing `BOARD_DISPLAY_SIZE` and changing `BOARD_TILE_SIZE` to `4.2 * BOARD_SCALE` so per-tile and full-board sizes match Chess Battle Royal. (`webapp/src/pages/Games/CheckersBattleRoyal.jsx`)
- Updated the fallback board builder to use `BOARD_DISPLAY_SIZE` for the framed board footprint while using the unified `BOARD_TILE_SIZE` for playable tiles. (`buildFallbackCheckersBoardModel`) 
- When loading the BeautifulGame GLTF, stopped forcing original textures so `applyCheckersBoardTheme` can recolor imported board geometry at runtime, enabling board color/theme switches to take effect. (`loadCheckersBoardModel` / `applyCheckersBoardTheme`)
- Preserved pruning of chess piece nodes from the imported GLTF so only the board is reused while Checkers pieces remain the app's own meshes. (`loadCheckersBoardModel`) 

### Testing
- Ran the linter: `npx eslint --no-ignore webapp/src/pages/Games/CheckersBattleRoyal.jsx` which produced only a non-blocking file-ignore warning. (warning only)
- Performed a production build: `npm --prefix webapp run build` and the Vite build completed successfully (warnings about large chunks were non-blocking). (pass)
- Launched the dev server and captured a mobile-portrait verification screenshot using Playwright (navigated to `/games/checkersbattleroyal` and saved `artifacts/checkers-board-update.png`). (screenshot captured)
- No automated unit tests were modified; existing test suite was not re-run beyond the build validation above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7e3fa6c848329b98d9049f8026f9f)