### PR TITLE
Align Checkers board size and theming with Chess Battle Royal

### DIFF
--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -56,8 +56,11 @@ const SEAT_THICKNESS = 0.09 * MODEL_SCALE * STOOL_SCALE;
 const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 0.85;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
 const TABLE_HEIGHT = STOOL_HEIGHT + 0.05 * MODEL_SCALE;
+const BOARD = { N: 8, tile: 4.2, rim: 3 };
 const BOARD_SCALE = 0.0576;
-const BOARD_TILE_SIZE = ((SIZE * 4.2 + 3 * 2) * BOARD_SCALE) / SIZE;
+const RAW_BOARD_SIZE = BOARD.N * BOARD.tile + BOARD.rim * 2;
+const BOARD_DISPLAY_SIZE = RAW_BOARD_SIZE * BOARD_SCALE;
+const BOARD_TILE_SIZE = BOARD_DISPLAY_SIZE / SIZE;
 const CHAIR_DISTANCE = TABLE_RADIUS + 0.82;
 const SEAT_WIDTH = 0.9 * MODEL_SCALE * STOOL_SCALE;
 const SEAT_DEPTH = 0.95 * MODEL_SCALE * STOOL_SCALE;
@@ -113,60 +116,91 @@ const resolveHdriVariant = (value) => {
 const CHECKERS_BOARD_THEMES = Object.freeze([
   {
     id: 'classic',
-    preserveOriginalMaterials: true,
-    light: '#e7e2d3',
-    dark: '#776a5a',
-    frameLight: '#d2b48c',
-    frameDark: '#3a2d23'
+    light: '#eee8d5',
+    dark: '#2b2f36',
+    frameLight: '#c5d8ff',
+    frameDark: '#141b2f',
+    surfaceRoughness: 0.62,
+    surfaceMetalness: 0.12,
+    frameRoughness: 0.74,
+    frameMetalness: 0.14
   },
   {
     id: 'ivorySlate',
-    light: '#ece5d6',
-    dark: '#4b5563',
-    frameLight: '#d6c8a9',
-    frameDark: '#111827'
+    light: '#e5e7eb',
+    dark: '#111827',
+    frameLight: '#c5d8ff',
+    frameDark: '#141b2f',
+    surfaceRoughness: 0.62,
+    surfaceMetalness: 0.12,
+    frameRoughness: 0.74,
+    frameMetalness: 0.14
   },
   {
     id: 'forest',
-    light: '#e7f6dc',
-    dark: '#1f4d36',
-    frameLight: '#9fbe8e',
-    frameDark: '#163525'
+    light: '#a7f3d0',
+    dark: '#065f46',
+    frameLight: '#c5d8ff',
+    frameDark: '#141b2f',
+    surfaceRoughness: 0.62,
+    surfaceMetalness: 0.12,
+    frameRoughness: 0.74,
+    frameMetalness: 0.14
   },
   {
     id: 'sand',
-    light: '#f7dfbe',
-    dark: '#8a5a3c',
-    frameLight: '#d5a779',
-    frameDark: '#422313'
+    light: '#ddd0b8',
+    dark: '#6b4f3a',
+    frameLight: '#c5d8ff',
+    frameDark: '#141b2f',
+    surfaceRoughness: 0.62,
+    surfaceMetalness: 0.12,
+    frameRoughness: 0.74,
+    frameMetalness: 0.14
   },
   {
     id: 'ocean',
-    light: '#dceef6',
-    dark: '#1e3a8a',
-    frameLight: '#a6c8db',
-    frameDark: '#172554'
+    light: '#a4c8e1',
+    dark: '#1e3a5f',
+    frameLight: '#c5d8ff',
+    frameDark: '#141b2f',
+    surfaceRoughness: 0.62,
+    surfaceMetalness: 0.12,
+    frameRoughness: 0.74,
+    frameMetalness: 0.14
   },
   {
     id: 'violet',
-    light: '#efe8ff',
-    dark: '#5b3a82',
-    frameLight: '#c3a7ea',
-    frameDark: '#312040'
+    light: '#ddd6fe',
+    dark: '#3b2a6e',
+    frameLight: '#c5d8ff',
+    frameDark: '#141b2f',
+    surfaceRoughness: 0.62,
+    surfaceMetalness: 0.12,
+    frameRoughness: 0.74,
+    frameMetalness: 0.14
   },
   {
     id: 'chrome',
-    light: '#ecf2f8',
-    dark: '#334155',
-    frameLight: '#d1dae5',
-    frameDark: '#0f172a'
+    light: '#b0b0b0',
+    dark: '#6e6e6e',
+    frameLight: '#c5d8ff',
+    frameDark: '#141b2f',
+    surfaceRoughness: 0.62,
+    surfaceMetalness: 0.12,
+    frameRoughness: 0.74,
+    frameMetalness: 0.14
   },
   {
     id: 'nebulaGlass',
-    light: '#dbeafe',
-    dark: '#1e1b4b',
-    frameLight: '#a5b4fc',
-    frameDark: '#111827'
+    light: '#e0f2fe',
+    dark: '#0b1024',
+    frameLight: '#c5d8ff',
+    frameDark: '#141b2f',
+    surfaceRoughness: 0.62,
+    surfaceMetalness: 0.12,
+    frameRoughness: 0.74,
+    frameMetalness: 0.14
   }
 ]);
 
@@ -526,12 +560,7 @@ async function loadCheckersBoardModel(renderer = null) {
 
       const boardModel = source.clone(true);
       boardModel.name = 'ABeautifulGameBoard';
-      boardModel.userData = {
-        ...(boardModel.userData || {}),
-        forceOriginalTextures: true
-      };
-
-      const pieceTokens = /\b(pawn|rook|knight|bishop|queen|king)\b/i;
+      const pieceTokens = /\b(pawn|rook|knight|bishop|queen|king|piece|whitepiece|blackpiece)\b/i;
       const prune = [];
       boardModel.traverse((node) => {
         if (!node?.isObject3D) return;
@@ -615,8 +644,6 @@ function applyCheckersBoardTheme(
   snapshotBoardMaterials(boardModel);
   restoreBoardMaterials(boardModel);
 
-  if (boardModel?.userData?.forceOriginalTextures) return;
-
   const frameLight = new THREE.Color(option?.frameLight || '#d2b48c');
   const frameDark = new THREE.Color(option?.frameDark || '#3a2d23');
   const light = new THREE.Color(option?.light || '#e7e2d3');
@@ -646,9 +673,13 @@ function applyCheckersBoardTheme(
         if (mat?.map) mat.map = null;
         if (mat?.color?.copy) mat.color.copy(taggedColor);
         if ('roughness' in mat)
-          mat.roughness = /frame/.test(taggedPart) ? 0.78 : 0.4;
+          mat.roughness = /frame/.test(taggedPart)
+            ? option?.frameRoughness ?? 0.74
+            : option?.surfaceRoughness ?? 0.62;
         if ('metalness' in mat)
-          mat.metalness = /frame/.test(taggedPart) ? 0.18 : 0.2;
+          mat.metalness = /frame/.test(taggedPart)
+            ? option?.frameMetalness ?? 0.14
+            : option?.surfaceMetalness ?? 0.12;
         mat.needsUpdate = true;
       });
       node.castShadow = true;
@@ -678,8 +709,14 @@ function applyCheckersBoardTheme(
       if (!mat) return;
       if (mat?.map) mat.map = null;
       if (mat?.color?.copy) mat.color.copy(targetColor);
-      if ('roughness' in mat) mat.roughness = isFrame ? 0.8 : 0.62;
-      if ('metalness' in mat) mat.metalness = isFrame ? 0.2 : 0.08;
+      if ('roughness' in mat)
+        mat.roughness = isFrame
+          ? option?.frameRoughness ?? 0.74
+          : option?.surfaceRoughness ?? 0.62;
+      if ('metalness' in mat)
+        mat.metalness = isFrame
+          ? option?.frameMetalness ?? 0.14
+          : option?.surfaceMetalness ?? 0.12;
       mat.needsUpdate = true;
     });
     node.castShadow = true;


### PR DESCRIPTION
### Motivation
- Make the Checkers Battle Royal board use the exact physical footprint and mapping used by Chess Battle Royal so pieces align identically across games.
- Ensure board color/theme changes in Checkers use the same palette/filters/material response as Chess Battle Royal so store board items match visually.
- Remove chess piece geometry when loading the shared ABeautifulGame model so only the board remains in the Checkers view.

### Description
- Introduced shared board sizing constants (`BOARD`, `RAW_BOARD_SIZE`, `BOARD_DISPLAY_SIZE`) and compute `BOARD_TILE_SIZE` so checkers tile math matches the chess board footprint (file: `webapp/src/pages/Games/CheckersBattleRoyal.jsx`).
- Updated `CHECKERS_BOARD_THEMES` to use the Chess Battle Royale palette values and added material parameters (`surfaceRoughness`, `surfaceMetalness`, `frameRoughness`, `frameMetalness`) for consistent visual response.
- Broadened piece-pruning when importing the `ABeautifulGame` GLTF to also remove generic `piece`/`whitepiece`/`blackpiece` nodes and stopped forcing original textures so the board can be recolored.
- Made `applyCheckersBoardTheme` use theme-provided roughness/metalness/frame values when recoloring meshes so runtime theme swaps match the chess implementation.

### Testing
- Ran `npm --prefix webapp run build` and the Vite production build completed successfully (warnings about chunk sizes/dynamic imports are pre-existing and unrelated to this change).
- Ran `npx eslint` on the modified file which reported a repository ignore warning in this environment (no lint errors emitted for the change itself).
- Attempted a Playwright screenshot to visually validate the board, but Chromium crashed with a SIGSEGV in this container so no image was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7ed9829248329a606ccc56e777ff0)