### PR TITLE
Fix Tavull dice face mapping after throw settles

### DIFF
--- a/webapp/src/pages/Games/TavullBattleRoyal.jsx
+++ b/webapp/src/pages/Games/TavullBattleRoyal.jsx
@@ -715,7 +715,9 @@ export default function TavullBattleRoyal() {
         entry.mesh.rotation.y += 0.37
         entry.mesh.rotation.z += 0.25
         if (t >= 1) {
-          entry.mesh.rotation.set((Math.random() - 0.5) * 0.2, Math.random() * Math.PI, (Math.random() - 0.5) * 0.2)
+          if (entry.targetQuaternion) {
+            entry.mesh.setRotationFromQuaternion(entry.targetQuaternion)
+          }
           return false
         }
         return true
@@ -744,7 +746,8 @@ export default function TavullBattleRoyal() {
             return
           }
           mesh.visible = true
-          mesh.userData.setValue?.(Number(diceValues[index]) || 1)
+          const dieValue = Number(diceValues[index]) || 1
+          mesh.userData.setValue?.(dieValue)
           const x = (index - centerOffset) * spacing
           const startPos = new THREE.Vector3(x, BOARD_Y + 0.24, startZ)
           const endPos = new THREE.Vector3(x * 0.75, BOARD_Y + 0.17, endZ)
@@ -754,7 +757,8 @@ export default function TavullBattleRoyal() {
             start: performance.now() + index * 60,
             duration: 980,
             startPos,
-            endPos
+            endPos,
+            targetQuaternion: getDieOrientationQuaternion(dieValue)
           })
         })
       },


### PR DESCRIPTION
### Motivation
- The Tavull/Backgammon dice settled to random rotations after the throw animation which could show faces that did not match the rolled values, so the visual die face must deterministically match the roll like the Snake & Ladder implementation.

### Description
- Store a per-die `targetQuaternion` (from `getDieOrientationQuaternion`) when starting a throw and attach it to the animation entry so the intended face is known ahead of the settle.
- Apply the stored quaternion at the end of each die's animation instead of assigning a random rotation, by calling `entry.mesh.setRotationFromQuaternion(entry.targetQuaternion)` in the tick loop.
- Ensure the die mesh still receives `mesh.userData.setValue(dieValue)` so the die's logical value and rendering are synchronized (change made in `webapp/src/pages/Games/TavullBattleRoyal.jsx`).

### Testing
- Ran unit tests with `npm test -- test/tavullEngine.test.js --runInBand` and the suite passed (4 tests passed). 
- Ran `npx eslint webapp/src/pages/Games/TavullBattleRoyal.jsx` which produced a repo ignore warning for that path (no errors).
- Started the webapp dev server and captured a portrait viewport screenshot of the updated scene via Playwright to validate the visual change (`artifacts/tavull-dice-fix.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7fff037d083299c1f306b79e3474a)