### PR TITLE
Prune chess piece subtrees when loading board for Checkers to keep board only

### DIFF
--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -510,6 +510,24 @@ async function loadCheckersBoardModel(renderer = null) {
   const loader = createConfiguredGLTFLoader(renderer);
   let lastError = null;
 
+  const isChessPieceNode = (node) => {
+    const pieceTypePattern = /(king|queen|rook|bishop|knight|pawn)/i;
+    let current = node;
+    for (let depth = 0; current && depth < 6; depth += 1) {
+      if (pieceTypePattern.test(`${current.name || ''}`)) return true;
+      current = current.parent;
+    }
+    return false;
+  };
+
+  const findPieceRoot = (node) => {
+    let current = node;
+    while (current?.parent && isChessPieceNode(current.parent)) {
+      current = current.parent;
+    }
+    return current;
+  };
+
   for (const url of BEAUTIFUL_GAME_BOARD_URLS) {
     try {
       const resolvedUrl = new URL(url, window.location.href).href;
@@ -531,12 +549,12 @@ async function loadCheckersBoardModel(renderer = null) {
         forceOriginalTextures: true
       };
 
-      const pieceTokens = /\b(pawn|rook|knight|bishop|queen|king)\b/i;
-      const prune = [];
+      const prune = new Set();
       boardModel.traverse((node) => {
         if (!node?.isObject3D) return;
-        const name = `${node.name || ''}`.toLowerCase();
-        if (pieceTokens.test(name)) prune.push(node);
+        if (isChessPieceNode(node)) {
+          prune.add(findPieceRoot(node));
+        }
         if (!node?.isMesh) return;
         node.castShadow = true;
         node.receiveShadow = true;
@@ -549,7 +567,7 @@ async function loadCheckersBoardModel(renderer = null) {
           mat.needsUpdate = true;
         });
       });
-      prune.forEach((node) => node.parent?.remove(node));
+      prune.forEach((node) => node?.parent?.remove(node));
 
       const box = new THREE.Box3().setFromObject(boardModel);
       const size = box.getSize(new THREE.Vector3());


### PR DESCRIPTION
### Motivation
- The Checkers scene reuses the shared Chess GLTF board asset but must remove all chess piece geometry so only the board remains while keeping identical board footprint and sizing as Chess Battle Royal.

### Description
- Added robust piece detection and subtree pruning to `loadCheckersBoardModel` in `webapp/src/pages/Games/CheckersBattleRoyal.jsx` by walking ancestor names for chess keywords (`king|queen|rook|bishop|knight|pawn`) and removing the full piece root node instead of only direct-mesh name matches.
- Replaced simple name-based pruning with a `Set` of root nodes to remove, keeping material/color handling and cast/receive shadow setup unchanged.
- Continued to use the existing normalization/scaling step (`targetSize = BOARD_TILE_SIZE * SIZE`) so Checkers uses the exact same board size mapping as the Chess Battle Royal implementation.

### Testing
- Ran `npx eslint webapp/src/pages/Games/CheckersBattleRoyal.jsx` which reported only the repo ignore warning (no lint errors).
- Started the dev server with `npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173` successfully to validate local app startup (server launched). 
- Attempted a Playwright screenshot to validate runtime rendering but the browser automation timed out in this environment (screenshot step failed due to a timeout).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b800354ddc83299dd307d1ad17aa4c)