### PR TITLE
Add doubling cube flow and official doubles handling to Tavull (Backgammon)

### DIFF
--- a/webapp/src/pages/Games/TavullBattleRoyal.jsx
+++ b/webapp/src/pages/Games/TavullBattleRoyal.jsx
@@ -1,30 +1,43 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
-import * as THREE from 'three'
-import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js'
-import { RoundedBoxGeometry } from 'three/examples/jsm/geometries/RoundedBoxGeometry.js'
-import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js'
-import { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader.js'
-import { KTX2Loader } from 'three/examples/jsm/loaders/KTX2Loader.js'
-import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.js'
-import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader.js'
-import useTelegramBackButton from '../../hooks/useTelegramBackButton.js'
-import { createMurlanStyleTable, applyTableMaterials } from '../../utils/murlanTable.js'
-import { MURLAN_TABLE_FINISHES } from '../../config/murlanTableFinishes.js'
-import { getTelegramFirstName, getTelegramPhotoUrl } from '../../utils/telegram.js'
-import { applyRendererSRGB, applySRGBColorSpace } from '../../utils/colorSpace.js'
-import BottomLeftIcons from '../../components/BottomLeftIcons.jsx'
-import AvatarTimer from '../../components/AvatarTimer.jsx'
-import { getGameVolume, isGameMuted } from '../../utils/sound.js'
-import QuickMessagePopup from '../../components/QuickMessagePopup.jsx'
-import GiftPopup from '../../components/GiftPopup.jsx'
-import { CHESS_CHAIR_OPTIONS } from '../../config/chessBattleInventoryConfig.js'
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import * as THREE from 'three';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import { RoundedBoxGeometry } from 'three/examples/jsm/geometries/RoundedBoxGeometry.js';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader.js';
+import { KTX2Loader } from 'three/examples/jsm/loaders/KTX2Loader.js';
+import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.js';
+import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader.js';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
+import {
+  createMurlanStyleTable,
+  applyTableMaterials
+} from '../../utils/murlanTable.js';
+import { MURLAN_TABLE_FINISHES } from '../../config/murlanTableFinishes.js';
+import {
+  getTelegramFirstName,
+  getTelegramPhotoUrl
+} from '../../utils/telegram.js';
+import {
+  applyRendererSRGB,
+  applySRGBColorSpace
+} from '../../utils/colorSpace.js';
+import BottomLeftIcons from '../../components/BottomLeftIcons.jsx';
+import AvatarTimer from '../../components/AvatarTimer.jsx';
+import { getGameVolume, isGameMuted } from '../../utils/sound.js';
+import QuickMessagePopup from '../../components/QuickMessagePopup.jsx';
+import GiftPopup from '../../components/GiftPopup.jsx';
+import { CHESS_CHAIR_OPTIONS } from '../../config/chessBattleInventoryConfig.js';
 import {
   POOL_ROYALE_DEFAULT_HDRI_ID,
   POOL_ROYALE_HDRI_VARIANTS,
   POOL_ROYALE_HDRI_VARIANT_MAP
-} from '../../config/poolRoyaleInventoryConfig.js'
-import { chessBattleAccountId, getChessBattleInventory, isChessOptionUnlocked } from '../../utils/chessBattleInventory.js'
+} from '../../config/poolRoyaleInventoryConfig.js';
+import {
+  chessBattleAccountId,
+  getChessBattleInventory,
+  isChessOptionUnlocked
+} from '../../utils/chessBattleInventory.js';
 import {
   BLACK,
   WHITE,
@@ -32,119 +45,130 @@ import {
   collectTurnSequences,
   formatMove,
   initialBoard,
-  pickAiSequence
-} from '../../utils/tavullEngine.js'
+  pickAiSequence,
+  scorePosition
+} from '../../utils/tavullEngine.js';
 
-const TABLE_RADIUS = 2.55
-const TABLE_HEIGHT = 1.16
-const CHAIR_DISTANCE = TABLE_RADIUS + 0.82
-const BOARD_Y = TABLE_HEIGHT + 0.08
-const POINT_WIDTH = 0.19
-const BOARD_HALF_X = 1.28
-const BOARD_HALF_Z = 0.98
-const POINT_START_X = 0.08
+const TABLE_RADIUS = 2.55;
+const TABLE_HEIGHT = 1.16;
+const CHAIR_DISTANCE = TABLE_RADIUS + 0.82;
+const BOARD_Y = TABLE_HEIGHT + 0.08;
+const POINT_WIDTH = 0.19;
+const BOARD_HALF_X = 1.28;
+const BOARD_HALF_Z = 0.98;
+const POINT_START_X = 0.08;
 
-const MODEL_SCALE = 0.75
-const STOOL_SCALE = 1.5 * 1.3
-const SEAT_WIDTH = 0.9 * MODEL_SCALE * STOOL_SCALE
-const SEAT_DEPTH = 0.95 * MODEL_SCALE * STOOL_SCALE
-const SEAT_THICKNESS_SCALED = 0.09 * MODEL_SCALE * STOOL_SCALE
-const BACK_HEIGHT = 0.68 * MODEL_SCALE * STOOL_SCALE
-const BACK_THICKNESS = 0.08 * MODEL_SCALE * STOOL_SCALE
-const ARM_THICKNESS = 0.125 * MODEL_SCALE * STOOL_SCALE
-const ARM_HEIGHT = 0.3 * MODEL_SCALE * STOOL_SCALE
-const ARM_DEPTH = SEAT_DEPTH * 0.75
-const BASE_COLUMN_HEIGHT = 0.5 * MODEL_SCALE * STOOL_SCALE
-const CHAIR_BASE_HEIGHT = TABLE_HEIGHT - SEAT_THICKNESS_SCALED * 0.85
-const CAMERA_2D_POSITION = new THREE.Vector3(0, 8.4, 0.01)
-const CAMERA_3D_POSITION = new THREE.Vector3(0, 4.9, 5.6)
-const CAMERA_TARGET = new THREE.Vector3(0, TABLE_HEIGHT, 0)
-const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/'
-const BASIS_TRANSCODER_PATH = 'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/'
+const MODEL_SCALE = 0.75;
+const STOOL_SCALE = 1.5 * 1.3;
+const SEAT_WIDTH = 0.9 * MODEL_SCALE * STOOL_SCALE;
+const SEAT_DEPTH = 0.95 * MODEL_SCALE * STOOL_SCALE;
+const SEAT_THICKNESS_SCALED = 0.09 * MODEL_SCALE * STOOL_SCALE;
+const BACK_HEIGHT = 0.68 * MODEL_SCALE * STOOL_SCALE;
+const BACK_THICKNESS = 0.08 * MODEL_SCALE * STOOL_SCALE;
+const ARM_THICKNESS = 0.125 * MODEL_SCALE * STOOL_SCALE;
+const ARM_HEIGHT = 0.3 * MODEL_SCALE * STOOL_SCALE;
+const ARM_DEPTH = SEAT_DEPTH * 0.75;
+const BASE_COLUMN_HEIGHT = 0.5 * MODEL_SCALE * STOOL_SCALE;
+const CHAIR_BASE_HEIGHT = TABLE_HEIGHT - SEAT_THICKNESS_SCALED * 0.85;
+const CAMERA_2D_POSITION = new THREE.Vector3(0, 8.4, 0.01);
+const CAMERA_3D_POSITION = new THREE.Vector3(0, 4.9, 5.6);
+const CAMERA_TARGET = new THREE.Vector3(0, TABLE_HEIGHT, 0);
+const DRACO_DECODER_PATH =
+  'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
+const BASIS_TRANSCODER_PATH =
+  'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/';
 const DEFAULT_HDRI_ASSET =
-  POOL_ROYALE_HDRI_VARIANT_MAP[POOL_ROYALE_DEFAULT_HDRI_ID] || POOL_ROYALE_HDRI_VARIANTS[0] || null
-let sharedKtx2Loader = null
-let hasDetectedKtx2Support = false
+  POOL_ROYALE_HDRI_VARIANT_MAP[POOL_ROYALE_DEFAULT_HDRI_ID] ||
+  POOL_ROYALE_HDRI_VARIANTS[0] ||
+  null;
+let sharedKtx2Loader = null;
+let hasDetectedKtx2Support = false;
 const CHAIR_MODEL_URLS = Object.freeze([
   'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/SheenChair/glTF-Binary/SheenChair.glb',
   'https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Assets@main/Models/SheenChair/glTF-Binary/SheenChair.glb',
   '/assets/models/chair/chair.glb',
   '/assets/models/chair/chair.gltf'
-])
-const CHAIR_THEMES = Object.freeze([
-  ...CHESS_CHAIR_OPTIONS
-])
+]);
+const CHAIR_THEMES = Object.freeze([...CHESS_CHAIR_OPTIONS]);
 const QUALITY_OPTIONS = Object.freeze([
   { id: 'performance', label: 'Performance', pixelRatio: 1, shadows: false },
   { id: 'balanced', label: 'Balanced', pixelRatio: 1.5, shadows: true },
   { id: 'ultra', label: 'Ultra', pixelRatio: 2, shadows: true }
-])
-const MOVE_SOUND_URL = 'https://raw.githubusercontent.com/lichess-org/lila/master/public/sound/standard/Move.mp3'
-const WIN_SOUND_URL = 'https://raw.githubusercontent.com/lichess-org/lila/master/public/sound/standard/End.mp3'
-const DICE_ROLL_SOUND_URL = '/assets/sounds/dice-roll.mp3'
-const DICE_ICON_URL = '/assets/icons/file_000000009160620a96f728f463de1c3f.webp'
+]);
+const MOVE_SOUND_URL =
+  'https://raw.githubusercontent.com/lichess-org/lila/master/public/sound/standard/Move.mp3';
+const WIN_SOUND_URL =
+  'https://raw.githubusercontent.com/lichess-org/lila/master/public/sound/standard/End.mp3';
+const DICE_ROLL_SOUND_URL = '/assets/sounds/dice-roll.mp3';
+const DICE_ICON_URL =
+  '/assets/icons/file_000000009160620a96f728f463de1c3f.webp';
 const FALLBACK_SEAT_POSITIONS = [
   { left: '50%', top: '73%' },
   { left: '50%', top: '18%' }
-]
+];
 const BACKGAMMON_BOARD_MODEL_URLS = Object.freeze([
   '/assets/models/backgammon/backgammon-board.glb',
   '/assets/models/backgammon/backgammon-board.gltf'
-])
-const BACKGAMMON_DIE_SIZE = 0.116
-const BACKGAMMON_DIE_CORNER_RADIUS = BACKGAMMON_DIE_SIZE * 0.18
-const BACKGAMMON_DIE_PIP_RADIUS = BACKGAMMON_DIE_SIZE * 0.093
-const BACKGAMMON_DIE_PIP_DEPTH = BACKGAMMON_DIE_SIZE * 0.018
-const BACKGAMMON_DIE_PIP_RIM_INNER = BACKGAMMON_DIE_PIP_RADIUS * 0.78
-const BACKGAMMON_DIE_PIP_RIM_OUTER = BACKGAMMON_DIE_PIP_RADIUS * 1.08
-const BACKGAMMON_DIE_PIP_RIM_OFFSET = BACKGAMMON_DIE_SIZE * 0.0048
-const BACKGAMMON_DIE_PIP_SPREAD = BACKGAMMON_DIE_SIZE * 0.3
-const BACKGAMMON_DIE_FACE_INSET = BACKGAMMON_DIE_SIZE * 0.064
+]);
+const BACKGAMMON_DIE_SIZE = 0.116;
+const BACKGAMMON_DIE_CORNER_RADIUS = BACKGAMMON_DIE_SIZE * 0.18;
+const BACKGAMMON_DIE_PIP_RADIUS = BACKGAMMON_DIE_SIZE * 0.093;
+const BACKGAMMON_DIE_PIP_DEPTH = BACKGAMMON_DIE_SIZE * 0.018;
+const BACKGAMMON_DIE_PIP_RIM_INNER = BACKGAMMON_DIE_PIP_RADIUS * 0.78;
+const BACKGAMMON_DIE_PIP_RIM_OUTER = BACKGAMMON_DIE_PIP_RADIUS * 1.08;
+const BACKGAMMON_DIE_PIP_RIM_OFFSET = BACKGAMMON_DIE_SIZE * 0.0048;
+const BACKGAMMON_DIE_PIP_SPREAD = BACKGAMMON_DIE_SIZE * 0.3;
+const BACKGAMMON_DIE_FACE_INSET = BACKGAMMON_DIE_SIZE * 0.064;
 
-const BACKGAMMON_DOUBLE_CUBE_SIZE = BACKGAMMON_DIE_SIZE * 1.06
-const BACKGAMMON_DOUBLE_CUBE_VALUES = Object.freeze([2, 4, 8, 16, 32, 64])
+const BACKGAMMON_DOUBLE_CUBE_SIZE = BACKGAMMON_DIE_SIZE * 1.06;
+const BACKGAMMON_DOUBLE_CUBE_VALUES = Object.freeze([2, 4, 8, 16, 32, 64]);
 
 function makeBackgammonDoubleCube(topValue = 64) {
-  const cube = new THREE.Group()
-  const cubeSize = BACKGAMMON_DOUBLE_CUBE_SIZE
-  const faceTone = '#f5efe2'
-  const edgeTone = '#0f172a'
+  const cube = new THREE.Group();
+  const cubeSize = BACKGAMMON_DOUBLE_CUBE_SIZE;
+  const faceTone = '#f5efe2';
+  const edgeTone = '#0f172a';
 
   const makeFaceTexture = (label) => {
-    const canvas = document.createElement('canvas')
-    canvas.width = 256
-    canvas.height = 256
-    const ctx = canvas.getContext('2d')
-    if (!ctx) return null
-    ctx.fillStyle = faceTone
-    ctx.fillRect(0, 0, canvas.width, canvas.height)
-    ctx.strokeStyle = '#d4c4a8'
-    ctx.lineWidth = 16
-    ctx.strokeRect(8, 8, canvas.width - 16, canvas.height - 16)
-    ctx.fillStyle = edgeTone
-    ctx.textAlign = 'center'
-    ctx.textBaseline = 'middle'
-    ctx.font = '700 112px Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif'
-    ctx.fillText(String(label), canvas.width / 2, canvas.height / 2)
-    const texture = new THREE.CanvasTexture(canvas)
-    texture.colorSpace = THREE.SRGBColorSpace
-    texture.needsUpdate = true
-    return texture
-  }
+    const canvas = document.createElement('canvas');
+    canvas.width = 256;
+    canvas.height = 256;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return null;
+    ctx.fillStyle = faceTone;
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    ctx.strokeStyle = '#d4c4a8';
+    ctx.lineWidth = 16;
+    ctx.strokeRect(8, 8, canvas.width - 16, canvas.height - 16);
+    ctx.fillStyle = edgeTone;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.font =
+      '700 112px Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif';
+    ctx.fillText(String(label), canvas.width / 2, canvas.height / 2);
+    const texture = new THREE.CanvasTexture(canvas);
+    texture.colorSpace = THREE.SRGBColorSpace;
+    texture.needsUpdate = true;
+    return texture;
+  };
 
-  const faceMaterials = BACKGAMMON_DOUBLE_CUBE_VALUES.map((value) =>
-    new THREE.MeshStandardMaterial({
-      map: makeFaceTexture(value),
-      roughness: 0.42,
-      metalness: 0.12,
-      color: '#ffffff'
-    })
-  )
+  const faceMaterials = BACKGAMMON_DOUBLE_CUBE_VALUES.map(
+    (value) =>
+      new THREE.MeshStandardMaterial({
+        map: makeFaceTexture(value),
+        roughness: 0.42,
+        metalness: 0.12,
+        color: '#ffffff'
+      })
+  );
 
-  const body = new THREE.Mesh(new THREE.BoxGeometry(cubeSize, cubeSize, cubeSize), faceMaterials)
-  body.castShadow = true
-  body.receiveShadow = true
-  cube.add(body)
+  const body = new THREE.Mesh(
+    new THREE.BoxGeometry(cubeSize, cubeSize, cubeSize),
+    faceMaterials
+  );
+  body.castShadow = true;
+  body.receiveShadow = true;
+  cube.add(body);
 
   const topFaceByValue = {
     2: new THREE.Euler(-Math.PI / 2, 0, 0),
@@ -153,16 +177,16 @@ function makeBackgammonDoubleCube(topValue = 64) {
     16: new THREE.Euler(0, -Math.PI / 2, 0),
     32: new THREE.Euler(Math.PI / 2, 0, 0),
     64: new THREE.Euler(Math.PI, 0, 0)
-  }
+  };
 
   cube.userData.setTopValue = (value) => {
-    cube.userData.topValue = value
-    const euler = topFaceByValue[value] || topFaceByValue[64]
-    cube.quaternion.setFromEuler(euler)
-  }
+    cube.userData.topValue = value;
+    const euler = topFaceByValue[value] || topFaceByValue[64];
+    cube.quaternion.setFromEuler(euler);
+  };
 
-  cube.userData.setTopValue(topValue)
-  return cube
+  cube.userData.setTopValue(topValue);
+  return cube;
 }
 
 function getDieOrientationQuaternion(val) {
@@ -173,12 +197,14 @@ function getDieOrientationQuaternion(val) {
     4: new THREE.Euler(0, 0, -Math.PI / 2),
     5: new THREE.Euler(Math.PI / 2, 0, 0),
     6: new THREE.Euler(Math.PI, 0, 0)
-  }
-  return new THREE.Quaternion().setFromEuler(orientations[val] || orientations[1])
+  };
+  return new THREE.Quaternion().setFromEuler(
+    orientations[val] || orientations[1]
+  );
 }
 
 function makeRoyalDie() {
-  const die = new THREE.Group()
+  const die = new THREE.Group();
   const bodyMaterial = new THREE.MeshPhysicalMaterial({
     color: '#ffffff',
     metalness: 0.25,
@@ -187,7 +213,7 @@ function makeRoyalDie() {
     clearcoatRoughness: 0.15,
     reflectivity: 0.75,
     envMapIntensity: 1.4
-  })
+  });
   const pipMaterial = new THREE.MeshPhysicalMaterial({
     color: '#0a0a0a',
     roughness: 0.05,
@@ -197,7 +223,7 @@ function makeRoyalDie() {
     envMapIntensity: 1.1,
     emissive: '#0f172a',
     emissiveIntensity: 0.35
-  })
+  });
   const rimMaterial = new THREE.MeshPhysicalMaterial({
     color: '#ffd700',
     emissive: '#3a2a00',
@@ -210,288 +236,394 @@ function makeRoyalDie() {
     polygonOffset: true,
     polygonOffsetFactor: -1,
     polygonOffsetUnits: -1
-  })
+  });
 
   const body = new THREE.Mesh(
-    new RoundedBoxGeometry(BACKGAMMON_DIE_SIZE, BACKGAMMON_DIE_SIZE, BACKGAMMON_DIE_SIZE, 6, BACKGAMMON_DIE_CORNER_RADIUS),
+    new RoundedBoxGeometry(
+      BACKGAMMON_DIE_SIZE,
+      BACKGAMMON_DIE_SIZE,
+      BACKGAMMON_DIE_SIZE,
+      6,
+      BACKGAMMON_DIE_CORNER_RADIUS
+    ),
     bodyMaterial
-  )
-  body.castShadow = true
-  body.receiveShadow = true
-  die.add(body)
+  );
+  body.castShadow = true;
+  body.receiveShadow = true;
+  die.add(body);
 
-  const pipGeo = new THREE.SphereGeometry(BACKGAMMON_DIE_PIP_RADIUS, 36, 24, 0, Math.PI * 2, 0, Math.PI)
-  pipGeo.rotateX(Math.PI)
-  pipGeo.computeVertexNormals()
-  const pipRimGeo = new THREE.RingGeometry(BACKGAMMON_DIE_PIP_RIM_INNER, BACKGAMMON_DIE_PIP_RIM_OUTER, 64)
-  const faceDepth = BACKGAMMON_DIE_SIZE / 2 - BACKGAMMON_DIE_FACE_INSET * 0.6
-  const spread = BACKGAMMON_DIE_PIP_SPREAD
+  const pipGeo = new THREE.SphereGeometry(
+    BACKGAMMON_DIE_PIP_RADIUS,
+    36,
+    24,
+    0,
+    Math.PI * 2,
+    0,
+    Math.PI
+  );
+  pipGeo.rotateX(Math.PI);
+  pipGeo.computeVertexNormals();
+  const pipRimGeo = new THREE.RingGeometry(
+    BACKGAMMON_DIE_PIP_RIM_INNER,
+    BACKGAMMON_DIE_PIP_RIM_OUTER,
+    64
+  );
+  const faceDepth = BACKGAMMON_DIE_SIZE / 2 - BACKGAMMON_DIE_FACE_INSET * 0.6;
+  const spread = BACKGAMMON_DIE_PIP_SPREAD;
   const faces = [
     { normal: new THREE.Vector3(0, 1, 0), points: [[0, 0]] },
-    { normal: new THREE.Vector3(0, 0, 1), points: [[-spread, -spread], [spread, spread]] },
-    { normal: new THREE.Vector3(1, 0, 0), points: [[-spread, -spread], [0, 0], [spread, spread]] },
-    { normal: new THREE.Vector3(-1, 0, 0), points: [[-spread, -spread], [-spread, spread], [spread, -spread], [spread, spread]] },
-    { normal: new THREE.Vector3(0, 0, -1), points: [[-spread, -spread], [-spread, spread], [0, 0], [spread, -spread], [spread, spread]] },
-    { normal: new THREE.Vector3(0, -1, 0), points: [[-spread, -spread], [-spread, 0], [-spread, spread], [spread, -spread], [spread, 0], [spread, spread]] }
-  ]
+    {
+      normal: new THREE.Vector3(0, 0, 1),
+      points: [
+        [-spread, -spread],
+        [spread, spread]
+      ]
+    },
+    {
+      normal: new THREE.Vector3(1, 0, 0),
+      points: [
+        [-spread, -spread],
+        [0, 0],
+        [spread, spread]
+      ]
+    },
+    {
+      normal: new THREE.Vector3(-1, 0, 0),
+      points: [
+        [-spread, -spread],
+        [-spread, spread],
+        [spread, -spread],
+        [spread, spread]
+      ]
+    },
+    {
+      normal: new THREE.Vector3(0, 0, -1),
+      points: [
+        [-spread, -spread],
+        [-spread, spread],
+        [0, 0],
+        [spread, -spread],
+        [spread, spread]
+      ]
+    },
+    {
+      normal: new THREE.Vector3(0, -1, 0),
+      points: [
+        [-spread, -spread],
+        [-spread, 0],
+        [-spread, spread],
+        [spread, -spread],
+        [spread, 0],
+        [spread, spread]
+      ]
+    }
+  ];
 
   faces.forEach(({ normal, points }) => {
-    const n = normal.clone().normalize()
-    const helper = Math.abs(n.y) > 0.9 ? new THREE.Vector3(0, 0, 1) : new THREE.Vector3(0, 1, 0)
-    const xAxis = new THREE.Vector3().crossVectors(helper, n).normalize()
-    const yAxis = new THREE.Vector3().crossVectors(n, xAxis).normalize()
+    const n = normal.clone().normalize();
+    const helper =
+      Math.abs(n.y) > 0.9
+        ? new THREE.Vector3(0, 0, 1)
+        : new THREE.Vector3(0, 1, 0);
+    const xAxis = new THREE.Vector3().crossVectors(helper, n).normalize();
+    const yAxis = new THREE.Vector3().crossVectors(n, xAxis).normalize();
     points.forEach(([gx, gy]) => {
       const base = new THREE.Vector3()
         .addScaledVector(xAxis, gx)
         .addScaledVector(yAxis, gy)
-        .addScaledVector(n, faceDepth - BACKGAMMON_DIE_PIP_DEPTH * 0.5)
+        .addScaledVector(n, faceDepth - BACKGAMMON_DIE_PIP_DEPTH * 0.5);
 
-      const pip = new THREE.Mesh(pipGeo, pipMaterial)
-      pip.castShadow = true
-      pip.receiveShadow = true
-      pip.position.copy(base).addScaledVector(n, BACKGAMMON_DIE_PIP_DEPTH)
-      pip.quaternion.setFromUnitVectors(new THREE.Vector3(0, 1, 0), n)
-      die.add(pip)
+      const pip = new THREE.Mesh(pipGeo, pipMaterial);
+      pip.castShadow = true;
+      pip.receiveShadow = true;
+      pip.position.copy(base).addScaledVector(n, BACKGAMMON_DIE_PIP_DEPTH);
+      pip.quaternion.setFromUnitVectors(new THREE.Vector3(0, 1, 0), n);
+      die.add(pip);
 
-      const rim = new THREE.Mesh(pipRimGeo, rimMaterial)
-      rim.receiveShadow = true
-      rim.renderOrder = 6
-      rim.position.copy(base).addScaledVector(n, BACKGAMMON_DIE_PIP_RIM_OFFSET)
-      rim.quaternion.setFromUnitVectors(new THREE.Vector3(0, 0, 1), n)
-      die.add(rim)
-    })
-  })
+      const rim = new THREE.Mesh(pipRimGeo, rimMaterial);
+      rim.receiveShadow = true;
+      rim.renderOrder = 6;
+      rim.position.copy(base).addScaledVector(n, BACKGAMMON_DIE_PIP_RIM_OFFSET);
+      rim.quaternion.setFromUnitVectors(new THREE.Vector3(0, 0, 1), n);
+      die.add(rim);
+    });
+  });
 
-  die.visible = false
+  die.visible = false;
   die.userData.setValue = (value) => {
-    die.userData.currentValue = value
-    die.quaternion.copy(getDieOrientationQuaternion(value))
-  }
-  die.userData.setValue(1)
-  return die
+    die.userData.currentValue = value;
+    die.quaternion.copy(getDieOrientationQuaternion(value));
+  };
+  die.userData.setValue(1);
+  return die;
 }
 
 function ensureKtx2SupportDetection(renderer = null) {
-  if (!sharedKtx2Loader || hasDetectedKtx2Support || !renderer) return
+  if (!sharedKtx2Loader || hasDetectedKtx2Support || !renderer) return;
   try {
-    sharedKtx2Loader.detectSupport(renderer)
-    hasDetectedKtx2Support = true
+    sharedKtx2Loader.detectSupport(renderer);
+    hasDetectedKtx2Support = true;
   } catch (error) {
-    console.warn('Failed to detect KTX2 support for Tavull loader', error)
+    console.warn('Failed to detect KTX2 support for Tavull loader', error);
   }
 }
 
 function createConfiguredGLTFLoader(renderer = null) {
-  const loader = new GLTFLoader()
-  loader.setCrossOrigin?.('anonymous')
-  const draco = new DRACOLoader()
-  draco.setDecoderPath(DRACO_DECODER_PATH)
-  loader.setDRACOLoader(draco)
-  loader.setMeshoptDecoder?.(MeshoptDecoder)
+  const loader = new GLTFLoader();
+  loader.setCrossOrigin?.('anonymous');
+  const draco = new DRACOLoader();
+  draco.setDecoderPath(DRACO_DECODER_PATH);
+  loader.setDRACOLoader(draco);
+  loader.setMeshoptDecoder?.(MeshoptDecoder);
 
   if (!sharedKtx2Loader) {
-    sharedKtx2Loader = new KTX2Loader()
-    sharedKtx2Loader.setTranscoderPath(BASIS_TRANSCODER_PATH)
+    sharedKtx2Loader = new KTX2Loader();
+    sharedKtx2Loader.setTranscoderPath(BASIS_TRANSCODER_PATH);
   }
-  ensureKtx2SupportDetection(renderer)
-  loader.setKTX2Loader(sharedKtx2Loader)
-  return loader
+  ensureKtx2SupportDetection(renderer);
+  loader.setKTX2Loader(sharedKtx2Loader);
+  return loader;
 }
 
 function prepareLoadedModel(model) {
   model?.traverse?.((obj) => {
-    if (!obj?.isMesh) return
-    obj.castShadow = true
-    obj.receiveShadow = true
-    const materials = Array.isArray(obj.material) ? obj.material : [obj.material]
+    if (!obj?.isMesh) return;
+    obj.castShadow = true;
+    obj.receiveShadow = true;
+    const materials = Array.isArray(obj.material)
+      ? obj.material
+      : [obj.material];
     materials.forEach((material) => {
-      if (!material) return
-      if (material.map) applySRGBColorSpace(material.map)
-      if (material.emissiveMap) applySRGBColorSpace(material.emissiveMap)
-    })
-  })
+      if (!material) return;
+      if (material.map) applySRGBColorSpace(material.map);
+      if (material.emissiveMap) applySRGBColorSpace(material.emissiveMap);
+    });
+  });
 }
 
 function resolveHdriUrlsByVariantIndex(preferredIndex = 0) {
-  const variant = POOL_ROYALE_HDRI_VARIANTS[preferredIndex] || DEFAULT_HDRI_ASSET
+  const variant =
+    POOL_ROYALE_HDRI_VARIANTS[preferredIndex] || DEFAULT_HDRI_ASSET;
   if (!variant?.assetId) {
-    return ['https://dl.polyhaven.org/file/ph-assets/HDRIs/hdr/2k/colorful_studio_2k.hdr']
+    return [
+      'https://dl.polyhaven.org/file/ph-assets/HDRIs/hdr/2k/colorful_studio_2k.hdr'
+    ];
   }
-  const resolutions = Array.isArray(variant.preferredResolutions) && variant.preferredResolutions.length
-    ? variant.preferredResolutions
-    : ['2k']
-  const ordered = [...resolutions, variant.fallbackResolution, '2k', '1k'].filter(Boolean)
-  const unique = [...new Set(ordered)]
-  return unique.map((resolution) => `https://dl.polyhaven.org/file/ph-assets/HDRIs/hdr/${resolution}/${variant.assetId}_${resolution}.hdr`)
+  const resolutions =
+    Array.isArray(variant.preferredResolutions) &&
+    variant.preferredResolutions.length
+      ? variant.preferredResolutions
+      : ['2k'];
+  const ordered = [
+    ...resolutions,
+    variant.fallbackResolution,
+    '2k',
+    '1k'
+  ].filter(Boolean);
+  const unique = [...new Set(ordered)];
+  return unique.map(
+    (resolution) =>
+      `https://dl.polyhaven.org/file/ph-assets/HDRIs/hdr/${resolution}/${variant.assetId}_${resolution}.hdr`
+  );
 }
 
 function loadHdriEnvironment(scene, preferredIndex = 0) {
-  const rgbe = new RGBELoader()
-  const ordered = resolveHdriUrlsByVariantIndex(preferredIndex)
+  const rgbe = new RGBELoader();
+  const ordered = resolveHdriUrlsByVariantIndex(preferredIndex);
   const tryNext = (index = 0) => {
-    if (index >= ordered.length) return
+    if (index >= ordered.length) return;
     rgbe.load(
       ordered[index],
       (texture) => {
-        texture.mapping = THREE.EquirectangularReflectionMapping
-        scene.environment = texture
+        texture.mapping = THREE.EquirectangularReflectionMapping;
+        scene.environment = texture;
       },
       undefined,
       () => tryNext(index + 1)
-    )
-  }
-  tryNext(0)
+    );
+  };
+  tryNext(0);
 }
 
-function createArenaChairFallback(chairColor = '#8b1d2c', legColor = '#111827') {
+function createArenaChairFallback(
+  chairColor = '#8b1d2c',
+  legColor = '#111827'
+) {
   const seatMaterial = new THREE.MeshStandardMaterial({
     color: chairColor,
     roughness: 0.42,
     metalness: 0.18
-  })
+  });
   const legMaterial = new THREE.MeshStandardMaterial({
     color: legColor,
     roughness: 0.55,
     metalness: 0.38
-  })
-  const chair = new THREE.Group()
+  });
+  const chair = new THREE.Group();
   const seatMesh = new THREE.Mesh(
     new THREE.BoxGeometry(SEAT_WIDTH, SEAT_THICKNESS_SCALED, SEAT_DEPTH),
     seatMaterial
-  )
-  seatMesh.position.y = SEAT_THICKNESS_SCALED / 2
+  );
+  seatMesh.position.y = SEAT_THICKNESS_SCALED / 2;
   const backMesh = new THREE.Mesh(
     new THREE.BoxGeometry(SEAT_WIDTH * 0.96, BACK_HEIGHT, BACK_THICKNESS),
     seatMaterial
-  )
+  );
   backMesh.position.set(
     0,
     SEAT_THICKNESS_SCALED / 2 + BACK_HEIGHT / 2,
     -SEAT_DEPTH / 2 + BACK_THICKNESS / 2
-  )
-  const armGeometry = new THREE.BoxGeometry(ARM_THICKNESS, ARM_HEIGHT, ARM_DEPTH)
-  const armOffsetX = SEAT_WIDTH / 2 - ARM_THICKNESS / 2
-  const armOffsetY = SEAT_THICKNESS_SCALED / 2 + ARM_HEIGHT / 2
-  const armOffsetZ = -ARM_DEPTH / 2 + ARM_THICKNESS * 0.2
-  const leftArm = new THREE.Mesh(armGeometry, seatMaterial)
-  leftArm.position.set(-armOffsetX, armOffsetY, armOffsetZ)
-  const rightArm = new THREE.Mesh(armGeometry, seatMaterial)
-  rightArm.position.set(armOffsetX, armOffsetY, armOffsetZ)
+  );
+  const armGeometry = new THREE.BoxGeometry(
+    ARM_THICKNESS,
+    ARM_HEIGHT,
+    ARM_DEPTH
+  );
+  const armOffsetX = SEAT_WIDTH / 2 - ARM_THICKNESS / 2;
+  const armOffsetY = SEAT_THICKNESS_SCALED / 2 + ARM_HEIGHT / 2;
+  const armOffsetZ = -ARM_DEPTH / 2 + ARM_THICKNESS * 0.2;
+  const leftArm = new THREE.Mesh(armGeometry, seatMaterial);
+  leftArm.position.set(-armOffsetX, armOffsetY, armOffsetZ);
+  const rightArm = new THREE.Mesh(armGeometry, seatMaterial);
+  rightArm.position.set(armOffsetX, armOffsetY, armOffsetZ);
   const legMesh = new THREE.Mesh(
-    new THREE.CylinderGeometry(0.16 * MODEL_SCALE * STOOL_SCALE, 0.2 * MODEL_SCALE * STOOL_SCALE, BASE_COLUMN_HEIGHT, 18),
+    new THREE.CylinderGeometry(
+      0.16 * MODEL_SCALE * STOOL_SCALE,
+      0.2 * MODEL_SCALE * STOOL_SCALE,
+      BASE_COLUMN_HEIGHT,
+      18
+    ),
     legMaterial
-  )
-  legMesh.position.y = -SEAT_THICKNESS_SCALED / 2 - BASE_COLUMN_HEIGHT / 2
+  );
+  legMesh.position.y = -SEAT_THICKNESS_SCALED / 2 - BASE_COLUMN_HEIGHT / 2;
   const foot = new THREE.Mesh(
-    new THREE.CylinderGeometry(0.32 * MODEL_SCALE * STOOL_SCALE, 0.32 * MODEL_SCALE * STOOL_SCALE, 0.08 * MODEL_SCALE, 24),
+    new THREE.CylinderGeometry(
+      0.32 * MODEL_SCALE * STOOL_SCALE,
+      0.32 * MODEL_SCALE * STOOL_SCALE,
+      0.08 * MODEL_SCALE,
+      24
+    ),
     legMaterial
-  )
-  foot.position.y = legMesh.position.y - BASE_COLUMN_HEIGHT / 2 - 0.04 * MODEL_SCALE
-  ;[seatMesh, backMesh, leftArm, rightArm, legMesh, foot].forEach((mesh) => {
-    mesh.castShadow = true
-    mesh.receiveShadow = true
-    chair.add(mesh)
-  })
-  return chair
+  );
+  foot.position.y =
+    legMesh.position.y - BASE_COLUMN_HEIGHT / 2 - 0.04 * MODEL_SCALE;
+  [seatMesh, backMesh, leftArm, rightArm, legMesh, foot].forEach((mesh) => {
+    mesh.castShadow = true;
+    mesh.receiveShadow = true;
+    chair.add(mesh);
+  });
+  return chair;
 }
 
 async function loadMappedChair(renderer, theme) {
-  const loader = createConfiguredGLTFLoader(renderer)
-  let loaded = null
+  const loader = createConfiguredGLTFLoader(renderer);
+  let loaded = null;
   for (const url of CHAIR_MODEL_URLS) {
     try {
-      const gltf = await loader.loadAsync(url)
-      loaded = gltf?.scene || gltf?.scenes?.[0]
-      if (loaded) break
+      const gltf = await loader.loadAsync(url);
+      loaded = gltf?.scene || gltf?.scenes?.[0];
+      if (loaded) break;
     } catch (error) {
-      console.warn('Failed to load Backgammon chair model', url, error)
+      console.warn('Failed to load Backgammon chair model', url, error);
     }
   }
-  if (!loaded) return createArenaChairFallback(theme.primary, theme.leg)
+  if (!loaded) return createArenaChairFallback(theme.primary, theme.leg);
 
-  const model = loaded.clone(true)
-  prepareLoadedModel(model)
-  const tint = new THREE.Color(theme.primary)
-  const legTint = new THREE.Color(theme.leg)
+  const model = loaded.clone(true);
+  prepareLoadedModel(model);
+  const tint = new THREE.Color(theme.primary);
+  const legTint = new THREE.Color(theme.leg);
   model.traverse((node) => {
-    if (!node?.isMesh) return
-    const mats = Array.isArray(node.material) ? node.material : [node.material]
+    if (!node?.isMesh) return;
+    const mats = Array.isArray(node.material) ? node.material : [node.material];
     mats.forEach((mat) => {
-      if (!mat) return
-      const label = `${mat.name || ''} ${node.name || ''}`.toLowerCase()
-      const hasMappedTexture = Boolean(mat.map)
+      if (!mat) return;
+      const label = `${mat.name || ''} ${node.name || ''}`.toLowerCase();
+      const hasMappedTexture = Boolean(mat.map);
       if (!hasMappedTexture) {
-        if (/leg|base|metal|foot/.test(label)) mat.color?.lerp(legTint, 0.7)
-        else mat.color?.lerp(tint, 0.55)
+        if (/leg|base|metal|foot/.test(label)) mat.color?.lerp(legTint, 0.7);
+        else mat.color?.lerp(tint, 0.55);
       }
-      if (mat.map) applySRGBColorSpace(mat.map)
-      if (mat.emissiveMap) applySRGBColorSpace(mat.emissiveMap)
-      mat.needsUpdate = true
-    })
-  })
-  const box = new THREE.Box3().setFromObject(model)
-  const size = box.getSize(new THREE.Vector3())
-  const currentMax = Math.max(size.x, size.y, size.z)
-  const targetMax = Math.max(SEAT_WIDTH, BACK_HEIGHT * 1.2, SEAT_DEPTH)
-  if (currentMax > 0) model.scale.multiplyScalar(targetMax / currentMax)
-  const scaledBox = new THREE.Box3().setFromObject(model)
-  const center = scaledBox.getCenter(new THREE.Vector3())
-  model.position.set(-center.x, -scaledBox.min.y, -center.z)
-  return model
+      if (mat.map) applySRGBColorSpace(mat.map);
+      if (mat.emissiveMap) applySRGBColorSpace(mat.emissiveMap);
+      mat.needsUpdate = true;
+    });
+  });
+  const box = new THREE.Box3().setFromObject(model);
+  const size = box.getSize(new THREE.Vector3());
+  const currentMax = Math.max(size.x, size.y, size.z);
+  const targetMax = Math.max(SEAT_WIDTH, BACK_HEIGHT * 1.2, SEAT_DEPTH);
+  if (currentMax > 0) model.scale.multiplyScalar(targetMax / currentMax);
+  const scaledBox = new THREE.Box3().setFromObject(model);
+  const center = scaledBox.getCenter(new THREE.Vector3());
+  model.position.set(-center.x, -scaledBox.min.y, -center.z);
+  return model;
 }
-
 
 const pointBasePosition = (index) => {
   if (index <= 11) {
-    const col = index < 6 ? index : index + 1
+    const col = index < 6 ? index : index + 1;
     return {
       x: BOARD_HALF_X - POINT_START_X - col * POINT_WIDTH,
       z: BOARD_HALF_Z - 0.08,
       top: false
-    }
+    };
   }
-  const i = 23 - index
-  const col = i < 6 ? i : i + 1
+  const i = 23 - index;
+  const col = i < 6 ? i : i + 1;
   return {
     x: -BOARD_HALF_X + POINT_START_X + col * POINT_WIDTH,
     z: -BOARD_HALF_Z + 0.08,
     top: true
-  }
-}
+  };
+};
 
 export default function TavullBattleRoyal() {
-  const navigate = useNavigate()
-  useTelegramBackButton()
-  const canvasHostRef = useRef(null)
-  const sceneBundleRef = useRef(null)
-  const isMountedRef = useRef(true)
-  const pendingTimeoutsRef = useRef([])
+  const navigate = useNavigate();
+  useTelegramBackButton();
+  const canvasHostRef = useRef(null);
+  const sceneBundleRef = useRef(null);
+  const isMountedRef = useRef(true);
+  const pendingTimeoutsRef = useRef([]);
 
-  const [game, setGame] = useState({ points: initialBoard(), bar: { white: 0, black: 0 }, off: { white: 0, black: 0 } })
-  const [dice, setDice] = useState([])
-  const [available, setAvailable] = useState([])
-  const [message, setMessage] = useState('Roll to start. You are White.')
-  const [aiThinking, setAiThinking] = useState(false)
-  const [configOpen, setConfigOpen] = useState(false)
-  const [viewMode, setViewMode] = useState('3d')
-  const [isRollingDice, setIsRollingDice] = useState(false)
-  const [tableFinishIdx, setTableFinishIdx] = useState(0)
-  const [chairThemeIdx, setChairThemeIdx] = useState(0)
-  const [hdriIdx, setHdriIdx] = useState(0)
-  const [qualityIdx, setQualityIdx] = useState(1)
-  const [showChat, setShowChat] = useState(false)
-  const [showGift, setShowGift] = useState(false)
-  const [chatBubbles, setChatBubbles] = useState([])
-  const [soundEnabled, setSoundEnabled] = useState(true)
-  const [inventoryVersion, setInventoryVersion] = useState(0)
-  const [activeMoveHighlight, setActiveMoveHighlight] = useState(null)
-  const [selectedPoint, setSelectedPoint] = useState(null)
-  const accountId = chessBattleAccountId()
-  const chessInventory = useMemo(() => getChessBattleInventory(accountId), [accountId, inventoryVersion])
-  const playerName = getTelegramFirstName() || 'Player'
-  const playerAvatar = getTelegramPhotoUrl()
+  const [game, setGame] = useState({
+    points: initialBoard(),
+    bar: { white: 0, black: 0 },
+    off: { white: 0, black: 0 }
+  });
+  const [dice, setDice] = useState([]);
+  const [available, setAvailable] = useState([]);
+  const [message, setMessage] = useState('Roll to start. You are White.');
+  const [aiThinking, setAiThinking] = useState(false);
+  const [configOpen, setConfigOpen] = useState(false);
+  const [viewMode, setViewMode] = useState('3d');
+  const [isRollingDice, setIsRollingDice] = useState(false);
+  const [tableFinishIdx, setTableFinishIdx] = useState(0);
+  const [chairThemeIdx, setChairThemeIdx] = useState(0);
+  const [hdriIdx, setHdriIdx] = useState(0);
+  const [qualityIdx, setQualityIdx] = useState(1);
+  const [showChat, setShowChat] = useState(false);
+  const [showGift, setShowGift] = useState(false);
+  const [chatBubbles, setChatBubbles] = useState([]);
+  const [soundEnabled, setSoundEnabled] = useState(true);
+  const [inventoryVersion, setInventoryVersion] = useState(0);
+  const [activeMoveHighlight, setActiveMoveHighlight] = useState(null);
+  const [selectedPoint, setSelectedPoint] = useState(null);
+  const [cubeValue, setCubeValue] = useState(1);
+  const [cubeOwner, setCubeOwner] = useState(null);
+  const [pendingDoubleOffer, setPendingDoubleOffer] = useState(null);
+  const [forfeitWinner, setForfeitWinner] = useState(null);
+  const accountId = chessBattleAccountId();
+  const chessInventory = useMemo(
+    () => getChessBattleInventory(accountId),
+    [accountId, inventoryVersion]
+  );
+  const playerName = getTelegramFirstName() || 'Player';
+  const playerAvatar = getTelegramPhotoUrl();
 
-  const winner = game.off.white >= 15 ? WHITE : game.off.black >= 15 ? BLACK : null
+  const winner =
+    forfeitWinner ||
+    (game.off.white >= 15 ? WHITE : game.off.black >= 15 ? BLACK : null);
 
   const players = [
     {
@@ -510,291 +642,345 @@ export default function TavullBattleRoyal() {
       color: 'black',
       isTurn: aiThinking
     }
-  ]
-
+  ];
 
   const ownedChairOptions = useMemo(
-    () => CHAIR_THEMES.filter((option) => isChessOptionUnlocked('chairColor', option.id, chessInventory)),
+    () =>
+      CHAIR_THEMES.filter((option) =>
+        isChessOptionUnlocked('chairColor', option.id, chessInventory)
+      ),
     [chessInventory]
-  )
+  );
   const ownedHdriOptions = useMemo(
-    () => POOL_ROYALE_HDRI_VARIANTS.filter((option) => isChessOptionUnlocked('environmentHdri', option.id, chessInventory)),
+    () =>
+      POOL_ROYALE_HDRI_VARIANTS.filter((option) =>
+        isChessOptionUnlocked('environmentHdri', option.id, chessInventory)
+      ),
     [chessInventory]
-  )
+  );
   const ownedFinishOptions = useMemo(
-    () => MURLAN_TABLE_FINISHES.filter((option) => isChessOptionUnlocked('tableFinish', option.id, chessInventory)),
+    () =>
+      MURLAN_TABLE_FINISHES.filter((option) =>
+        isChessOptionUnlocked('tableFinish', option.id, chessInventory)
+      ),
     [chessInventory]
-  )
+  );
 
   useEffect(() => {
-    const onInventoryUpdate = () => setInventoryVersion((v) => v + 1)
-    window.addEventListener('chessBattleInventoryUpdate', onInventoryUpdate)
-    return () => window.removeEventListener('chessBattleInventoryUpdate', onInventoryUpdate)
-  }, [])
+    const onInventoryUpdate = () => setInventoryVersion((v) => v + 1);
+    window.addEventListener('chessBattleInventoryUpdate', onInventoryUpdate);
+    return () =>
+      window.removeEventListener(
+        'chessBattleInventoryUpdate',
+        onInventoryUpdate
+      );
+  }, []);
 
   useEffect(() => {
-    if (!ownedFinishOptions.length) return
-    if (!ownedFinishOptions[tableFinishIdx]) setTableFinishIdx(0)
-  }, [ownedFinishOptions, tableFinishIdx])
+    if (!ownedFinishOptions.length) return;
+    if (!ownedFinishOptions[tableFinishIdx]) setTableFinishIdx(0);
+  }, [ownedFinishOptions, tableFinishIdx]);
 
   useEffect(() => {
-    if (!ownedChairOptions.length) return
-    if (!ownedChairOptions[chairThemeIdx]) setChairThemeIdx(0)
-  }, [ownedChairOptions, chairThemeIdx])
+    if (!ownedChairOptions.length) return;
+    if (!ownedChairOptions[chairThemeIdx]) setChairThemeIdx(0);
+  }, [ownedChairOptions, chairThemeIdx]);
 
   useEffect(() => {
-    if (!ownedHdriOptions.length) return
-    if (!ownedHdriOptions[hdriIdx]) setHdriIdx(0)
-  }, [ownedHdriOptions, hdriIdx])
+    if (!ownedHdriOptions.length) return;
+    if (!ownedHdriOptions[hdriIdx]) setHdriIdx(0);
+  }, [ownedHdriOptions, hdriIdx]);
 
   const playSfx = (url, volumeScale = 1) => {
-    if (isGameMuted() || !soundEnabled) return
+    if (isGameMuted() || !soundEnabled) return;
     try {
-      const audio = new Audio(url)
-      audio.volume = Math.min(1, getGameVolume() * volumeScale)
-      void audio.play().catch(() => {})
+      const audio = new Audio(url);
+      audio.volume = Math.min(1, getGameVolume() * volumeScale);
+      void audio.play().catch(() => {});
     } catch {}
-  }
+  };
 
   useEffect(() => {
-    isMountedRef.current = true
-    if (!canvasHostRef.current) return undefined
+    isMountedRef.current = true;
+    if (!canvasHostRef.current) return undefined;
 
-    const host = canvasHostRef.current
-    const scene = new THREE.Scene()
-    scene.background = new THREE.Color('#090f1f')
+    const host = canvasHostRef.current;
+    const scene = new THREE.Scene();
+    scene.background = new THREE.Color('#090f1f');
 
-    const camera = new THREE.PerspectiveCamera(42, host.clientWidth / host.clientHeight, 0.1, 120)
-    camera.position.copy(CAMERA_3D_POSITION)
+    const camera = new THREE.PerspectiveCamera(
+      42,
+      host.clientWidth / host.clientHeight,
+      0.1,
+      120
+    );
+    camera.position.copy(CAMERA_3D_POSITION);
 
-    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: false, powerPreference: 'high-performance' })
-    applyRendererSRGB(renderer)
-    const initialQuality = QUALITY_OPTIONS[qualityIdx] || QUALITY_OPTIONS[1]
-    renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, initialQuality.pixelRatio))
-    renderer.setSize(host.clientWidth, host.clientHeight)
-    renderer.shadowMap.enabled = Boolean(initialQuality.shadows)
-    host.appendChild(renderer.domElement)
+    const renderer = new THREE.WebGLRenderer({
+      antialias: true,
+      alpha: false,
+      powerPreference: 'high-performance'
+    });
+    applyRendererSRGB(renderer);
+    const initialQuality = QUALITY_OPTIONS[qualityIdx] || QUALITY_OPTIONS[1];
+    renderer.setPixelRatio(
+      Math.min(window.devicePixelRatio || 1, initialQuality.pixelRatio)
+    );
+    renderer.setSize(host.clientWidth, host.clientHeight);
+    renderer.shadowMap.enabled = Boolean(initialQuality.shadows);
+    host.appendChild(renderer.domElement);
 
-    const controls = new OrbitControls(camera, renderer.domElement)
-    controls.enablePan = false
-    controls.enableDamping = true
-    controls.maxPolarAngle = Math.PI * 0.48
-    controls.minDistance = 4.4
-    controls.maxDistance = 8.6
-    controls.target.copy(CAMERA_TARGET)
+    const controls = new OrbitControls(camera, renderer.domElement);
+    controls.enablePan = false;
+    controls.enableDamping = true;
+    controls.maxPolarAngle = Math.PI * 0.48;
+    controls.minDistance = 4.4;
+    controls.maxDistance = 8.6;
+    controls.target.copy(CAMERA_TARGET);
 
     const applyViewMode = (mode) => {
       if (mode === '2d') {
-        camera.position.copy(CAMERA_2D_POSITION)
-        camera.lookAt(CAMERA_TARGET)
-        controls.minPolarAngle = 0.02
-        controls.maxPolarAngle = Math.PI * 0.08
-        controls.enableRotate = false
-        controls.minDistance = 5.8
-        controls.maxDistance = 11.5
+        camera.position.copy(CAMERA_2D_POSITION);
+        camera.lookAt(CAMERA_TARGET);
+        controls.minPolarAngle = 0.02;
+        controls.maxPolarAngle = Math.PI * 0.08;
+        controls.enableRotate = false;
+        controls.minDistance = 5.8;
+        controls.maxDistance = 11.5;
       } else {
-        camera.position.copy(CAMERA_3D_POSITION)
-        camera.lookAt(CAMERA_TARGET)
-        controls.minPolarAngle = 0.4
-        controls.maxPolarAngle = Math.PI * 0.48
-        controls.enableRotate = true
-        controls.minDistance = 4.4
-        controls.maxDistance = 8.6
+        camera.position.copy(CAMERA_3D_POSITION);
+        camera.lookAt(CAMERA_TARGET);
+        controls.minPolarAngle = 0.4;
+        controls.maxPolarAngle = Math.PI * 0.48;
+        controls.enableRotate = true;
+        controls.minDistance = 4.4;
+        controls.maxDistance = 8.6;
       }
-      controls.target.copy(CAMERA_TARGET)
-      controls.update()
-    }
-    applyViewMode(viewMode)
+      controls.target.copy(CAMERA_TARGET);
+      controls.update();
+    };
+    applyViewMode(viewMode);
 
-    scene.add(new THREE.AmbientLight('#ffffff', 0.5))
-    const key = new THREE.DirectionalLight('#ffffff', 1.15)
-    key.position.set(5, 8, 3)
-    key.castShadow = true
-    scene.add(key)
+    scene.add(new THREE.AmbientLight('#ffffff', 0.5));
+    const key = new THREE.DirectionalLight('#ffffff', 1.15);
+    key.position.set(5, 8, 3);
+    key.castShadow = true;
+    scene.add(key);
 
-    const fill = new THREE.PointLight('#6ec4ff', 0.7, 30)
-    fill.position.set(-4, 4.5, -3)
-    scene.add(fill)
+    const fill = new THREE.PointLight('#6ec4ff', 0.7, 30);
+    fill.position.set(-4, 4.5, -3);
+    scene.add(fill);
 
-    loadHdriEnvironment(scene, 0)
+    loadHdriEnvironment(scene, 0);
 
-    const table = createMurlanStyleTable({ arena: scene, renderer, tableRadius: TABLE_RADIUS, tableHeight: TABLE_HEIGHT })
-    applyTableMaterials(table.parts, MURLAN_TABLE_FINISHES[0])
+    const table = createMurlanStyleTable({
+      arena: scene,
+      renderer,
+      tableRadius: TABLE_RADIUS,
+      tableHeight: TABLE_HEIGHT
+    });
+    applyTableMaterials(table.parts, MURLAN_TABLE_FINISHES[0]);
 
-    const chairRootA = new THREE.Group()
-    chairRootA.position.set(0, CHAIR_BASE_HEIGHT, CHAIR_DISTANCE)
-    chairRootA.rotation.y = Math.PI
-    scene.add(chairRootA)
-    const chairRootB = new THREE.Group()
-    chairRootB.position.set(0, CHAIR_BASE_HEIGHT, -CHAIR_DISTANCE)
-    scene.add(chairRootB)
+    const chairRootA = new THREE.Group();
+    chairRootA.position.set(0, CHAIR_BASE_HEIGHT, CHAIR_DISTANCE);
+    chairRootA.rotation.y = Math.PI;
+    scene.add(chairRootA);
+    const chairRootB = new THREE.Group();
+    chairRootB.position.set(0, CHAIR_BASE_HEIGHT, -CHAIR_DISTANCE);
+    scene.add(chairRootB);
     const setChairs = async (themeIndex) => {
-      const theme = CHAIR_THEMES[themeIndex] || CHAIR_THEMES[0]
-      const a = await loadMappedChair(renderer, theme)
-      const b = a.clone(true)
-      chairRootA.clear()
-      chairRootB.clear()
-      chairRootA.add(a)
-      chairRootB.add(b)
-    }
-    void setChairs(chairThemeIdx)
+      const theme = CHAIR_THEMES[themeIndex] || CHAIR_THEMES[0];
+      const a = await loadMappedChair(renderer, theme);
+      const b = a.clone(true);
+      chairRootA.clear();
+      chairRootB.clear();
+      chairRootA.add(a);
+      chairRootB.add(b);
+    };
+    void setChairs(chairThemeIdx);
 
-    const boardRoot = new THREE.Group()
-    scene.add(boardRoot)
+    const boardRoot = new THREE.Group();
+    scene.add(boardRoot);
 
     const loadBackgammonBoardModel = async () => {
-      const loader = createConfiguredGLTFLoader(renderer)
+      const loader = createConfiguredGLTFLoader(renderer);
       for (const url of BACKGAMMON_BOARD_MODEL_URLS) {
         try {
-          const gltf = await loader.loadAsync(url)
-          const model = gltf?.scene || gltf?.scenes?.[0]
-          if (!model) continue
-          prepareLoadedModel(model)
-          model.position.set(0, BOARD_Y + 0.1, 0)
-          model.scale.setScalar(0.85)
-          boardRoot.add(model)
-          return true
+          const gltf = await loader.loadAsync(url);
+          const model = gltf?.scene || gltf?.scenes?.[0];
+          if (!model) continue;
+          prepareLoadedModel(model);
+          model.position.set(0, BOARD_Y + 0.1, 0);
+          model.scale.setScalar(0.85);
+          boardRoot.add(model);
+          return true;
         } catch {
           // Try next URL and fallback to procedural board.
         }
       }
-      return false
-    }
+      return false;
+    };
 
     void loadBackgammonBoardModel().then((loaded) => {
-      if (loaded) return
+      if (loaded) return;
 
       const boardBase = new THREE.Mesh(
         new THREE.BoxGeometry(BOARD_HALF_X * 2, 0.12, BOARD_HALF_Z * 2),
-        new THREE.MeshStandardMaterial({ color: '#744225', roughness: 0.5, metalness: 0.16 })
-      )
-      boardBase.position.y = BOARD_Y
-      boardRoot.add(boardBase)
+        new THREE.MeshStandardMaterial({
+          color: '#744225',
+          roughness: 0.5,
+          metalness: 0.16
+        })
+      );
+      boardBase.position.y = BOARD_Y;
+      boardRoot.add(boardBase);
 
       const felt = new THREE.Mesh(
         new THREE.BoxGeometry(BOARD_HALF_X * 1.94, 0.03, BOARD_HALF_Z * 1.92),
-        new THREE.MeshStandardMaterial({ color: '#174a32', roughness: 0.9, metalness: 0.02 })
-      )
-      felt.position.y = BOARD_Y + 0.1
-      boardRoot.add(felt)
+        new THREE.MeshStandardMaterial({
+          color: '#174a32',
+          roughness: 0.9,
+          metalness: 0.02
+        })
+      );
+      felt.position.y = BOARD_Y + 0.1;
+      boardRoot.add(felt);
 
       const bar = new THREE.Mesh(
         new THREE.BoxGeometry(0.14, 0.06, BOARD_HALF_Z * 1.88),
-        new THREE.MeshStandardMaterial({ color: '#5e3018', roughness: 0.6, metalness: 0.08 })
-      )
-      bar.position.y = BOARD_Y + 0.11
-      boardRoot.add(bar)
+        new THREE.MeshStandardMaterial({
+          color: '#5e3018',
+          roughness: 0.6,
+          metalness: 0.08
+        })
+      );
+      bar.position.y = BOARD_Y + 0.11;
+      boardRoot.add(bar);
 
       const makeTriangle = (x, top, dark) => {
-      const baseZ = top ? -BOARD_HALF_Z + 0.01 : BOARD_HALF_Z - 0.01
-      const apex = top ? -0.56 : 0.56
-      const shape = new THREE.Shape()
-      shape.moveTo(-0.08, 0)
-      shape.lineTo(0.08, 0)
-      shape.lineTo(0, apex)
-      shape.closePath()
-      const geom = new THREE.ExtrudeGeometry(shape, { depth: 0.02, bevelEnabled: false })
-      geom.rotateX(-Math.PI / 2)
-      const tri = new THREE.Mesh(
-        geom,
-        new THREE.MeshStandardMaterial({ color: dark ? '#7a2f1d' : '#d8b07d', roughness: 0.72, metalness: 0.05 })
-      )
-      tri.position.set(x, BOARD_Y + 0.13, baseZ)
-      boardRoot.add(tri)
-      }
+        const baseZ = top ? -BOARD_HALF_Z + 0.01 : BOARD_HALF_Z - 0.01;
+        const apex = top ? -0.56 : 0.56;
+        const shape = new THREE.Shape();
+        shape.moveTo(-0.08, 0);
+        shape.lineTo(0.08, 0);
+        shape.lineTo(0, apex);
+        shape.closePath();
+        const geom = new THREE.ExtrudeGeometry(shape, {
+          depth: 0.02,
+          bevelEnabled: false
+        });
+        geom.rotateX(-Math.PI / 2);
+        const tri = new THREE.Mesh(
+          geom,
+          new THREE.MeshStandardMaterial({
+            color: dark ? '#7a2f1d' : '#d8b07d',
+            roughness: 0.72,
+            metalness: 0.05
+          })
+        );
+        tri.position.set(x, BOARD_Y + 0.13, baseZ);
+        boardRoot.add(tri);
+      };
 
       for (let i = 0; i < 24; i += 1) {
-        const p = pointBasePosition(i)
-        makeTriangle(p.x, p.top, i % 2 === 0)
+        const p = pointBasePosition(i);
+        makeTriangle(p.x, p.top, i % 2 === 0);
       }
-    })
+    });
 
-    const chipGroup = new THREE.Group()
-    scene.add(chipGroup)
-    const diceGroup = new THREE.Group()
-    scene.add(diceGroup)
-    const diceAnimationState = { entries: [] }
-    const maxDice = 2
+    const chipGroup = new THREE.Group();
+    scene.add(chipGroup);
+    const diceGroup = new THREE.Group();
+    scene.add(diceGroup);
+    const diceAnimationState = { entries: [] };
+    const maxDice = 4;
 
     const diceMeshes = Array.from({ length: maxDice }, () => {
-      const mesh = makeRoyalDie()
-      diceGroup.add(mesh)
-      return mesh
-    })
+      const mesh = makeRoyalDie();
+      diceGroup.add(mesh);
+      return mesh;
+    });
 
-    const doubleCube = makeBackgammonDoubleCube(64)
-    doubleCube.position.set(0, BOARD_Y + 0.19, 0)
-    scene.add(doubleCube)
+    const doubleCube = makeBackgammonDoubleCube(64);
+    doubleCube.position.set(0, BOARD_Y + 0.19, 0);
+    scene.add(doubleCube);
 
-    const raycaster = new THREE.Raycaster()
-    const pointer = new THREE.Vector2()
-    const boardPlane = new THREE.Plane(new THREE.Vector3(0, 1, 0), -(BOARD_Y + 0.16))
-    const hitPoint = new THREE.Vector3()
+    const raycaster = new THREE.Raycaster();
+    const pointer = new THREE.Vector2();
+    const boardPlane = new THREE.Plane(
+      new THREE.Vector3(0, 1, 0),
+      -(BOARD_Y + 0.16)
+    );
+    const hitPoint = new THREE.Vector3();
     const resolveNearestPoint = (x, z) => {
-      let nearest = null
-      let minDist = Infinity
+      let nearest = null;
+      let minDist = Infinity;
       for (let i = 0; i < 24; i += 1) {
-        const base = pointBasePosition(i)
-        const dx = x - base.x
-        const dz = z - base.z
-        const dist = Math.hypot(dx, dz)
+        const base = pointBasePosition(i);
+        const dx = x - base.x;
+        const dz = z - base.z;
+        const dist = Math.hypot(dx, dz);
         if (dist < minDist) {
-          minDist = dist
-          nearest = i
+          minDist = dist;
+          nearest = i;
         }
       }
-      if (minDist > 0.22) return null
-      return nearest
-    }
+      if (minDist > 0.22) return null;
+      return nearest;
+    };
     const onBoardTap = (event) => {
-      const rect = renderer.domElement.getBoundingClientRect()
-      pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1
-      pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1
-      raycaster.setFromCamera(pointer, camera)
-      if (!raycaster.ray.intersectPlane(boardPlane, hitPoint)) return
-      const nearest = resolveNearestPoint(hitPoint.x, hitPoint.z)
-      if (nearest == null) return
-      window.dispatchEvent(new CustomEvent('tavullPointTap', { detail: { point: nearest } }))
-    }
-    renderer.domElement.addEventListener('pointerdown', onBoardTap)
+      const rect = renderer.domElement.getBoundingClientRect();
+      pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+      pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+      raycaster.setFromCamera(pointer, camera);
+      if (!raycaster.ray.intersectPlane(boardPlane, hitPoint)) return;
+      const nearest = resolveNearestPoint(hitPoint.x, hitPoint.z);
+      if (nearest == null) return;
+      window.dispatchEvent(
+        new CustomEvent('tavullPointTap', { detail: { point: nearest } })
+      );
+    };
+    renderer.domElement.addEventListener('pointerdown', onBoardTap);
 
     const resize = () => {
-      if (!host) return
-      const width = host.clientWidth
-      const height = host.clientHeight
-      camera.aspect = width / height
-      camera.updateProjectionMatrix()
-      renderer.setSize(width, height)
-    }
-    window.addEventListener('resize', resize)
+      if (!host) return;
+      const width = host.clientWidth;
+      const height = host.clientHeight;
+      camera.aspect = width / height;
+      camera.updateProjectionMatrix();
+      renderer.setSize(width, height);
+    };
+    window.addEventListener('resize', resize);
 
-    let raf = 0
+    let raf = 0;
     const tick = () => {
-      const now = performance.now()
-      diceAnimationState.entries = diceAnimationState.entries.filter((entry) => {
-        if (now < entry.start) return true
-        const elapsed = now - entry.start
-        const t = Math.min(1, elapsed / entry.duration)
-        const eased = 1 - (1 - t) ** 3
-        const arc = Math.sin(Math.PI * t) * 0.18
-        entry.mesh.position.lerpVectors(entry.startPos, entry.endPos, eased)
-        entry.mesh.position.y += arc
-        entry.mesh.rotation.x += 0.42
-        entry.mesh.rotation.y += 0.37
-        entry.mesh.rotation.z += 0.25
-        if (t >= 1) {
-          if (entry.targetQuaternion) {
-            entry.mesh.setRotationFromQuaternion(entry.targetQuaternion)
+      const now = performance.now();
+      diceAnimationState.entries = diceAnimationState.entries.filter(
+        (entry) => {
+          if (now < entry.start) return true;
+          const elapsed = now - entry.start;
+          const t = Math.min(1, elapsed / entry.duration);
+          const eased = 1 - (1 - t) ** 3;
+          const arc = Math.sin(Math.PI * t) * 0.18;
+          entry.mesh.position.lerpVectors(entry.startPos, entry.endPos, eased);
+          entry.mesh.position.y += arc;
+          entry.mesh.rotation.x += 0.42;
+          entry.mesh.rotation.y += 0.37;
+          entry.mesh.rotation.z += 0.25;
+          if (t >= 1) {
+            if (entry.targetQuaternion) {
+              entry.mesh.setRotationFromQuaternion(entry.targetQuaternion);
+            }
+            return false;
           }
-          return false
+          return true;
         }
-        return true
-      })
-      controls.update()
-      renderer.render(scene, camera)
-      raf = window.requestAnimationFrame(tick)
-    }
-    tick()
+      );
+      controls.update();
+      renderer.render(scene, camera);
+      raf = window.requestAnimationFrame(tick);
+    };
+    tick();
 
     sceneBundleRef.current = {
       scene,
@@ -803,24 +989,28 @@ export default function TavullBattleRoyal() {
       controls,
       chipGroup,
       animateDiceThrow: (values = [], seat = 0) => {
-        const diceValues = (Array.isArray(values) && values.length ? values : [1, 1]).slice(0, maxDice)
-        const startZ = seat === 0 ? BOARD_HALF_Z - 0.05 : -BOARD_HALF_Z + 0.05
-        const endZ = seat === 0 ? BOARD_HALF_Z * 0.18 : -BOARD_HALF_Z * 0.18
-        const spacing = 0.16
-        const centerOffset = (diceValues.length - 1) / 2
+        const diceValues = (
+          Array.isArray(values) && values.length ? values : [1, 1]
+        ).slice(0, maxDice);
+        const startZ = seat === 0 ? BOARD_HALF_Z - 0.05 : -BOARD_HALF_Z + 0.05;
+        const endZ = seat === 0 ? BOARD_HALF_Z * 0.18 : -BOARD_HALF_Z * 0.18;
+        const spacing = 0.16;
+        const centerOffset = (diceValues.length - 1) / 2;
         diceMeshes.forEach((mesh, index) => {
           if (index >= diceValues.length) {
-            mesh.visible = false
-            return
+            mesh.visible = false;
+            return;
           }
-          mesh.visible = true
-          const dieValue = Number(diceValues[index]) || 1
-          mesh.userData.setValue?.(dieValue)
-          diceAnimationState.entries = diceAnimationState.entries.filter((entry) => entry.mesh !== mesh)
-          const x = (index - centerOffset) * spacing
-          const startPos = new THREE.Vector3(x, BOARD_Y + 0.24, startZ)
-          const endPos = new THREE.Vector3(x * 0.75, BOARD_Y + 0.17, endZ)
-          mesh.position.copy(startPos)
+          mesh.visible = true;
+          const dieValue = Number(diceValues[index]) || 1;
+          mesh.userData.setValue?.(dieValue);
+          diceAnimationState.entries = diceAnimationState.entries.filter(
+            (entry) => entry.mesh !== mesh
+          );
+          const x = (index - centerOffset) * spacing;
+          const startPos = new THREE.Vector3(x, BOARD_Y + 0.24, startZ);
+          const endPos = new THREE.Vector3(x * 0.75, BOARD_Y + 0.17, endZ);
+          mesh.position.copy(startPos);
           diceAnimationState.entries.push({
             mesh,
             start: performance.now() + index * 60,
@@ -828,85 +1018,117 @@ export default function TavullBattleRoyal() {
             startPos,
             endPos,
             targetQuaternion: getDieOrientationQuaternion(dieValue)
-          })
-        })
+          });
+        });
       },
       applyViewMode,
-      applyTableFinish: (idx) => applyTableMaterials(table.parts, MURLAN_TABLE_FINISHES[idx] || MURLAN_TABLE_FINISHES[0]),
+      applyTableFinish: (idx) =>
+        applyTableMaterials(
+          table.parts,
+          MURLAN_TABLE_FINISHES[idx] || MURLAN_TABLE_FINISHES[0]
+        ),
       applyHdri: (idx) => loadHdriEnvironment(scene, idx),
       applyQuality: (idx) => {
-        const quality = QUALITY_OPTIONS[idx] || QUALITY_OPTIONS[1]
-        renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, quality.pixelRatio))
-        renderer.shadowMap.enabled = Boolean(quality.shadows)
-        renderer.shadowMap.needsUpdate = true
+        const quality = QUALITY_OPTIONS[idx] || QUALITY_OPTIONS[1];
+        renderer.setPixelRatio(
+          Math.min(window.devicePixelRatio || 1, quality.pixelRatio)
+        );
+        renderer.shadowMap.enabled = Boolean(quality.shadows);
+        renderer.shadowMap.needsUpdate = true;
       },
-      applyChairs: setChairs
-    }
+      applyChairs: setChairs,
+      setDoubleCube: (value, owner) => {
+        const renderValue = value === 1 ? 64 : value;
+        doubleCube.userData.setTopValue?.(renderValue);
+        const targetZ =
+          owner === WHITE
+            ? BOARD_HALF_Z * 0.6
+            : owner === BLACK
+              ? -BOARD_HALF_Z * 0.6
+              : 0;
+        doubleCube.position.set(0, BOARD_Y + 0.19, targetZ);
+      }
+    };
 
     return () => {
-      window.cancelAnimationFrame(raf)
-      window.removeEventListener('resize', resize)
-      controls.dispose()
-      renderer.dispose()
-      renderer.domElement.removeEventListener('pointerdown', onBoardTap)
-      if (host.contains(renderer.domElement)) host.removeChild(renderer.domElement)
-      sceneBundleRef.current = null
-      isMountedRef.current = false
-    }
-  }, [])
-
-  useEffect(() => () => {
-    pendingTimeoutsRef.current.forEach((id) => window.clearTimeout(id))
-    pendingTimeoutsRef.current = []
-    isMountedRef.current = false
-  }, [])
+      window.cancelAnimationFrame(raf);
+      window.removeEventListener('resize', resize);
+      controls.dispose();
+      renderer.dispose();
+      renderer.domElement.removeEventListener('pointerdown', onBoardTap);
+      if (host.contains(renderer.domElement))
+        host.removeChild(renderer.domElement);
+      sceneBundleRef.current = null;
+      isMountedRef.current = false;
+    };
+  }, []);
 
   useEffect(() => {
-    const bundle = sceneBundleRef.current
-    if (!bundle?.applyViewMode) return
-    bundle.applyViewMode(viewMode)
-  }, [viewMode])
+    sceneBundleRef.current?.setDoubleCube?.(cubeValue, cubeOwner);
+  }, [cubeValue, cubeOwner]);
+
+  useEffect(
+    () => () => {
+      pendingTimeoutsRef.current.forEach((id) => window.clearTimeout(id));
+      pendingTimeoutsRef.current = [];
+      isMountedRef.current = false;
+    },
+    []
+  );
 
   useEffect(() => {
-    const bundle = sceneBundleRef.current
-    if (!bundle?.applyTableFinish) return
-    const selected = ownedFinishOptions[tableFinishIdx] || ownedFinishOptions[0]
-    const globalIdx = MURLAN_TABLE_FINISHES.findIndex((option) => option.id === selected?.id)
-    bundle.applyTableFinish(globalIdx >= 0 ? globalIdx : 0)
-  }, [tableFinishIdx, ownedFinishOptions])
+    const bundle = sceneBundleRef.current;
+    if (!bundle?.applyViewMode) return;
+    bundle.applyViewMode(viewMode);
+  }, [viewMode]);
 
   useEffect(() => {
-    const bundle = sceneBundleRef.current
-    if (!bundle?.applyHdri) return
-    const selected = ownedHdriOptions[hdriIdx] || ownedHdriOptions[0]
-    const globalIdx = POOL_ROYALE_HDRI_VARIANTS.findIndex((option) => option.id === selected?.id)
-    bundle.applyHdri(globalIdx >= 0 ? globalIdx : 0)
-  }, [hdriIdx, ownedHdriOptions])
+    const bundle = sceneBundleRef.current;
+    if (!bundle?.applyTableFinish) return;
+    const selected =
+      ownedFinishOptions[tableFinishIdx] || ownedFinishOptions[0];
+    const globalIdx = MURLAN_TABLE_FINISHES.findIndex(
+      (option) => option.id === selected?.id
+    );
+    bundle.applyTableFinish(globalIdx >= 0 ? globalIdx : 0);
+  }, [tableFinishIdx, ownedFinishOptions]);
 
   useEffect(() => {
-    const bundle = sceneBundleRef.current
-    if (!bundle?.applyQuality) return
-    bundle.applyQuality(qualityIdx)
-  }, [qualityIdx])
+    const bundle = sceneBundleRef.current;
+    if (!bundle?.applyHdri) return;
+    const selected = ownedHdriOptions[hdriIdx] || ownedHdriOptions[0];
+    const globalIdx = POOL_ROYALE_HDRI_VARIANTS.findIndex(
+      (option) => option.id === selected?.id
+    );
+    bundle.applyHdri(globalIdx >= 0 ? globalIdx : 0);
+  }, [hdriIdx, ownedHdriOptions]);
 
   useEffect(() => {
-    const bundle = sceneBundleRef.current
-    if (!bundle?.applyChairs) return
-    const selected = ownedChairOptions[chairThemeIdx] || ownedChairOptions[0]
-    const globalIdx = CHAIR_THEMES.findIndex((option) => option.id === selected?.id)
-    void bundle.applyChairs(globalIdx >= 0 ? globalIdx : 0)
-  }, [chairThemeIdx, ownedChairOptions])
+    const bundle = sceneBundleRef.current;
+    if (!bundle?.applyQuality) return;
+    bundle.applyQuality(qualityIdx);
+  }, [qualityIdx]);
 
   useEffect(() => {
-    if (!winner) return
-    playSfx(WIN_SOUND_URL, 0.9)
-  }, [winner])
+    const bundle = sceneBundleRef.current;
+    if (!bundle?.applyChairs) return;
+    const selected = ownedChairOptions[chairThemeIdx] || ownedChairOptions[0];
+    const globalIdx = CHAIR_THEMES.findIndex(
+      (option) => option.id === selected?.id
+    );
+    void bundle.applyChairs(globalIdx >= 0 ? globalIdx : 0);
+  }, [chairThemeIdx, ownedChairOptions]);
 
   useEffect(() => {
-    const bundle = sceneBundleRef.current
-    if (!bundle) return
-    const { chipGroup } = bundle
-    chipGroup.clear()
+    if (!winner) return;
+    playSfx(WIN_SOUND_URL, 0.9);
+  }, [winner]);
+
+  useEffect(() => {
+    const bundle = sceneBundleRef.current;
+    if (!bundle) return;
+    const { chipGroup } = bundle;
+    chipGroup.clear();
 
     const createChip = (color) => {
       const mesh = new THREE.Mesh(
@@ -916,37 +1138,39 @@ export default function TavullBattleRoyal() {
           roughness: 0.35,
           metalness: 0.18
         })
-      )
-      mesh.castShadow = true
-      return mesh
-    }
+      );
+      mesh.castShadow = true;
+      return mesh;
+    };
 
-    const highlightTargets = new Set()
+    const highlightTargets = new Set();
     available.forEach((sequence) => {
       sequence?.line?.forEach((move) => {
-        if (typeof move?.from === 'number') highlightTargets.add(move.from)
-        if (typeof move?.to === 'number') highlightTargets.add(move.to)
-      })
-    })
+        if (typeof move?.from === 'number') highlightTargets.add(move.from);
+        if (typeof move?.to === 'number') highlightTargets.add(move.to);
+      });
+    });
     if (activeMoveHighlight) {
-      if (typeof activeMoveHighlight.from === 'number') highlightTargets.add(activeMoveHighlight.from)
-      if (typeof activeMoveHighlight.to === 'number') highlightTargets.add(activeMoveHighlight.to)
+      if (typeof activeMoveHighlight.from === 'number')
+        highlightTargets.add(activeMoveHighlight.from);
+      if (typeof activeMoveHighlight.to === 'number')
+        highlightTargets.add(activeMoveHighlight.to);
     }
 
     for (let i = 0; i < 24; i += 1) {
-      const point = game.points[i]
-      if (!point.color || point.count <= 0) continue
-      const base = pointBasePosition(i)
+      const point = game.points[i];
+      if (!point.color || point.count <= 0) continue;
+      const base = pointBasePosition(i);
       for (let s = 0; s < point.count; s += 1) {
-        const chip = createChip(point.color)
-        const stack = Math.floor(s / 5)
-        const layer = s % 5
+        const chip = createChip(point.color);
+        const stack = Math.floor(s / 5);
+        const layer = s % 5;
         chip.position.set(
           base.x,
           BOARD_Y + 0.16 + layer * 0.07,
           base.z + (base.top ? 1 : -1) * (0.12 * stack)
-        )
-        chipGroup.add(chip)
+        );
+        chipGroup.add(chip);
       }
       if (highlightTargets.has(i)) {
         const ring = new THREE.Mesh(
@@ -958,177 +1182,255 @@ export default function TavullBattleRoyal() {
             roughness: 0.3,
             metalness: 0.2
           })
-        )
-        ring.rotation.x = Math.PI / 2
-        ring.position.set(base.x, BOARD_Y + 0.145, base.z + (base.top ? -0.06 : 0.06))
-        chipGroup.add(ring)
+        );
+        ring.rotation.x = Math.PI / 2;
+        ring.position.set(
+          base.x,
+          BOARD_Y + 0.145,
+          base.z + (base.top ? -0.06 : 0.06)
+        );
+        chipGroup.add(ring);
       }
     }
 
     const makeBarChips = (count, color, zSign) => {
       for (let s = 0; s < count; s += 1) {
-        const chip = createChip(color)
-        chip.position.set(0, BOARD_Y + 0.16 + (s % 6) * 0.07, zSign * (0.08 + Math.floor(s / 6) * 0.12))
-        chipGroup.add(chip)
+        const chip = createChip(color);
+        chip.position.set(
+          0,
+          BOARD_Y + 0.16 + (s % 6) * 0.07,
+          zSign * (0.08 + Math.floor(s / 6) * 0.12)
+        );
+        chipGroup.add(chip);
       }
-    }
+    };
 
-    makeBarChips(game.bar.white, WHITE, -1)
-    makeBarChips(game.bar.black, BLACK, 1)
-  }, [game, available, activeMoveHighlight])
+    makeBarChips(game.bar.white, WHITE, -1);
+    makeBarChips(game.bar.black, BLACK, 1);
+  }, [game, available, activeMoveHighlight]);
 
   const animateSequence = (state, color, sequence, onDone) => {
-    const line = sequence?.line || []
+    const line = sequence?.line || [];
     if (!line.length) {
-      onDone?.(state)
-      return
+      onDone?.(state);
+      return;
     }
-    let idx = 0
-    let currentState = state
+    let idx = 0;
+    let currentState = state;
     const runStep = () => {
-      if (!isMountedRef.current) return
-      const move = line[idx]
-      setActiveMoveHighlight({ from: move.from, to: move.to, color })
-      currentState = applyMove(currentState, color, move)
-      setGame(currentState)
-      playSfx(MOVE_SOUND_URL, 0.65)
-      idx += 1
+      if (!isMountedRef.current) return;
+      const move = line[idx];
+      setActiveMoveHighlight({ from: move.from, to: move.to, color });
+      currentState = applyMove(currentState, color, move);
+      setGame(currentState);
+      playSfx(MOVE_SOUND_URL, 0.65);
+      idx += 1;
       if (idx < line.length) {
-        const timeoutId = window.setTimeout(runStep, 460)
-        pendingTimeoutsRef.current.push(timeoutId)
+        const timeoutId = window.setTimeout(runStep, 460);
+        pendingTimeoutsRef.current.push(timeoutId);
       } else {
         const timeoutId = window.setTimeout(() => {
-          setActiveMoveHighlight(null)
-          onDone?.(currentState)
-        }, 320)
-        pendingTimeoutsRef.current.push(timeoutId)
+          setActiveMoveHighlight(null);
+          onDone?.(currentState);
+        }, 320);
+        pendingTimeoutsRef.current.push(timeoutId);
       }
-    }
-    runStep()
-  }
+    };
+    runStep();
+  };
 
-  const playAi = (stateAfterPlayer) => {
-    const d1 = 1 + Math.floor(Math.random() * 6)
-    const d2 = 1 + Math.floor(Math.random() * 6)
-    const visibleAiDice = [d1, d2]
-    const aiDice = d1 === d2 ? [d1, d1, d1, d1] : visibleAiDice
-    setMessage(`AI rolled ${d1} and ${d2}.`)
-    setIsRollingDice(true)
-    setAiThinking(true)
-    setSelectedPoint(null)
-    sceneBundleRef.current?.animateDiceThrow?.(visibleAiDice, 1)
-    playSfx(DICE_ROLL_SOUND_URL, 0.75)
+  const maybeOfferAiDouble = (stateForAiTurn) => {
+    const aiCanDouble =
+      (cubeOwner == null || cubeOwner === WHITE) && cubeValue < 64;
+    if (!aiCanDouble || pendingDoubleOffer || winner) return false;
+    const aiAdvantage = scorePosition(stateForAiTurn, BLACK);
+    if (aiAdvantage < 22) return false;
+    setPendingDoubleOffer('ai');
+    setAiThinking(false);
+    setMessage(`AI offers Double to ${cubeValue * 2}. Take or Drop?`);
+    return true;
+  };
+
+  const playAi = (stateAfterPlayer, skipDoubleOffer = false) => {
+    if (!skipDoubleOffer && maybeOfferAiDouble(stateAfterPlayer)) return;
+    const d1 = 1 + Math.floor(Math.random() * 6);
+    const d2 = 1 + Math.floor(Math.random() * 6);
+    const aiDice = d1 === d2 ? [d1, d1, d1, d1] : [d1, d2];
+    setMessage(`AI rolled ${d1} and ${d2}.`);
+    setIsRollingDice(true);
+    setAiThinking(true);
+    setSelectedPoint(null);
+    sceneBundleRef.current?.animateDiceThrow?.(aiDice, 1);
+    setDice(aiDice);
+    playSfx(DICE_ROLL_SOUND_URL, 0.75);
 
     const timeoutId = window.setTimeout(() => {
-      if (!isMountedRef.current) return
-      setIsRollingDice(false)
-      let choice = null
+      if (!isMountedRef.current) return;
+      setIsRollingDice(false);
+      let choice = null;
       try {
-        choice = pickAiSequence(stateAfterPlayer, aiDice)
+        choice = pickAiSequence(stateAfterPlayer, aiDice);
       } catch (error) {
-        console.error('Backgammon AI turn crashed, skipping turn safely.', error)
+        console.error(
+          'Backgammon AI turn crashed, skipping turn safely.',
+          error
+        );
       }
       if (!choice || !choice.line.length) {
-        setMessage(`AI rolled ${d1}/${d2} but had no legal move. Your turn.`)
-        setAiThinking(false)
-        setDice([])
-        setAvailable([])
-        return
+        setMessage(`AI rolled ${d1}/${d2} but had no legal move. Your turn.`);
+        setAiThinking(false);
+        setAvailable([]);
+        return;
       }
       animateSequence(stateAfterPlayer, BLACK, choice, () => {
-        setMessage(`AI played ${choice.line.length} move(s). Your turn.`)
-        setAiThinking(false)
-        setDice([])
-        setAvailable([])
-      })
-    }, 850)
-    pendingTimeoutsRef.current.push(timeoutId)
-  }
+        setMessage(`AI played ${choice.line.length} move(s). Your turn.`);
+        setAiThinking(false);
+        setAvailable([]);
+      });
+    }, 850);
+    pendingTimeoutsRef.current.push(timeoutId);
+  };
 
   const roll = () => {
-    if (aiThinking || winner || available.length > 0) return
-    setIsRollingDice(true)
-    setSelectedPoint(null)
-    const d1 = 1 + Math.floor(Math.random() * 6)
-    const d2 = 1 + Math.floor(Math.random() * 6)
-    const visibleDice = [d1, d2]
-    const useDice = d1 === d2 ? [d1, d1, d1, d1] : visibleDice
-    sceneBundleRef.current?.animateDiceThrow?.(visibleDice, 0)
-    playSfx(DICE_ROLL_SOUND_URL, 0.75)
+    if (aiThinking || winner || available.length > 0 || pendingDoubleOffer)
+      return;
+    setIsRollingDice(true);
+    setSelectedPoint(null);
+    const d1 = 1 + Math.floor(Math.random() * 6);
+    const d2 = 1 + Math.floor(Math.random() * 6);
+    const useDice = d1 === d2 ? [d1, d1, d1, d1] : [d1, d2];
+    sceneBundleRef.current?.animateDiceThrow?.(useDice, 0);
+    playSfx(DICE_ROLL_SOUND_URL, 0.75);
     const timeoutId = window.setTimeout(() => {
-      if (!isMountedRef.current) return
-      setIsRollingDice(false)
-      playSfx(MOVE_SOUND_URL, 0.45)
-      let seq = []
+      if (!isMountedRef.current) return;
+      setIsRollingDice(false);
+      playSfx(MOVE_SOUND_URL, 0.45);
+      let seq = [];
       try {
-        seq = collectTurnSequences(game, WHITE, useDice)
+        seq = collectTurnSequences(game, WHITE, useDice);
       } catch (error) {
-        console.error('Backgammon player turn evaluation crashed.', error)
+        console.error('Backgammon player turn evaluation crashed.', error);
       }
-      setDice(visibleDice)
-      setAvailable(seq)
+      setDice(useDice);
+      setAvailable(seq);
       if (!seq.length || !seq.some((s) => s.line.length)) {
-        setMessage(`You rolled ${d1}/${d2} but no legal move. AI turn.`)
-        playAi(game)
-        return
+        setMessage(`You rolled ${d1}/${d2} but no legal move. AI turn.`);
+        playAi(game);
+        return;
       }
-      setMessage('Tap a checker/point to move, or choose a legal turn from the list.')
-    }, 820)
-    pendingTimeoutsRef.current.push(timeoutId)
-  }
+      setMessage(
+        'Tap a checker/point to move, or choose a legal turn from the list.'
+      );
+    }, 820);
+    pendingTimeoutsRef.current.push(timeoutId);
+  };
 
   const handleSequence = (sequence) => {
-    if (!available.length || aiThinking || winner) return
-    if (!sequence?.line?.length) return
-    setAvailable([])
-    setDice([])
-    setMessage('Moving checkers…')
+    if (!available.length || aiThinking || winner) return;
+    if (!sequence?.line?.length) return;
+    setAvailable([]);
+    setDice([]);
+    setMessage('Moving checkers…');
     animateSequence(game, WHITE, sequence, (stateAfterPlayer) => {
-      setSelectedPoint(null)
-      setMessage('You played. AI is thinking…')
-      playAi(stateAfterPlayer)
-    })
-  }
+      setSelectedPoint(null);
+      setMessage('You played. AI is thinking…');
+      playAi(stateAfterPlayer);
+    });
+  };
+
+  const canPlayerOfferDouble =
+    !aiThinking &&
+    !winner &&
+    !pendingDoubleOffer &&
+    !dice.length &&
+    available.length === 0 &&
+    (cubeOwner == null || cubeOwner === BLACK) &&
+    cubeValue < 64;
+
+  const offerDouble = () => {
+    if (!canPlayerOfferDouble) return;
+    const nextCubeValue = Math.min(64, cubeValue * 2);
+    const aiEdge = scorePosition(game, BLACK);
+    const aiAccepts = aiEdge > -22;
+    if (!aiAccepts) {
+      setForfeitWinner(WHITE);
+      setMessage(
+        `AI drops the double. You win ${cubeValue} point${cubeValue > 1 ? 's' : ''}.`
+      );
+      return;
+    }
+    setCubeValue(nextCubeValue);
+    setCubeOwner(WHITE);
+    setMessage(`AI accepts. Cube is ${nextCubeValue}. Roll dice.`);
+  };
+
+  const handleTakeAiDouble = () => {
+    if (pendingDoubleOffer !== 'ai') return;
+    const nextCubeValue = Math.min(64, cubeValue * 2);
+    setPendingDoubleOffer(null);
+    setCubeValue(nextCubeValue);
+    setCubeOwner(BLACK);
+    setAiThinking(true);
+    setMessage(`You take ${nextCubeValue}. AI rolling...`);
+    playAi(game, true);
+  };
+
+  const handleDropAiDouble = () => {
+    if (pendingDoubleOffer !== 'ai') return;
+    setPendingDoubleOffer(null);
+    setForfeitWinner(BLACK);
+    setMessage(
+      `You drop. AI wins ${cubeValue} point${cubeValue > 1 ? 's' : ''}.`
+    );
+  };
 
   useEffect(() => {
     if (!available.length) {
-      setSelectedPoint(null)
-      return
+      setSelectedPoint(null);
+      return;
     }
     const onPointTap = (event) => {
-      const point = event?.detail?.point
-      if (typeof point !== 'number' || aiThinking || winner) return
-      const candidates = available.filter((seq) => seq?.line?.some((move) => move.from === point || move.to === point))
-      if (!candidates.length) return
+      const point = event?.detail?.point;
+      if (typeof point !== 'number' || aiThinking || winner) return;
+      const candidates = available.filter((seq) =>
+        seq?.line?.some((move) => move.from === point || move.to === point)
+      );
+      if (!candidates.length) return;
       if (candidates.length === 1) {
-        handleSequence(candidates[0])
-        return
+        handleSequence(candidates[0]);
+        return;
       }
 
       if (selectedPoint == null || selectedPoint === point) {
-        setSelectedPoint(point)
-        setMessage('Selected point. Tap destination or tap a legal line below.')
-        return
+        setSelectedPoint(point);
+        setMessage(
+          'Selected point. Tap destination or tap a legal line below.'
+        );
+        return;
       }
 
       const narrowed = candidates.filter((seq) =>
-        seq?.line?.some((move) =>
-          (move.from === selectedPoint && move.to === point) || (move.from === point && move.to === selectedPoint)
+        seq?.line?.some(
+          (move) =>
+            (move.from === selectedPoint && move.to === point) ||
+            (move.from === point && move.to === selectedPoint)
         )
-      )
+      );
 
       if (narrowed.length === 1) {
-        handleSequence(narrowed[0])
-        return
+        handleSequence(narrowed[0]);
+        return;
       }
 
-      setSelectedPoint(point)
-      setMessage('Multiple options here. Tap a legal line below to choose the exact move.')
-    }
+      setSelectedPoint(point);
+      setMessage(
+        'Multiple options here. Tap a legal line below to choose the exact move.'
+      );
+    };
 
-    window.addEventListener('tavullPointTap', onPointTap)
-    return () => window.removeEventListener('tavullPointTap', onPointTap)
-  }, [available, aiThinking, winner, selectedPoint])
+    window.addEventListener('tavullPointTap', onPointTap);
+    return () => window.removeEventListener('tavullPointTap', onPointTap);
+  }, [available, aiThinking, winner, selectedPoint]);
 
   return (
     <div className="fixed inset-0 bg-[#060b16] px-3 py-3 text-white touch-none select-none">
@@ -1140,7 +1442,9 @@ export default function TavullBattleRoyal() {
           aria-label={configOpen ? 'Close game menu' : 'Open game menu'}
           className="pointer-events-auto flex items-center gap-2 rounded-full border border-white/15 bg-black/60 px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-gray-100 shadow-[0_6px_18px_rgba(2,6,23,0.45)] transition hover:border-white/30 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
         >
-          <span className="text-base leading-none" aria-hidden="true">☰</span>
+          <span className="text-base leading-none" aria-hidden="true">
+            ☰
+          </span>
           <span className="leading-none">Menu</span>
         </button>
       </div>
@@ -1173,8 +1477,12 @@ export default function TavullBattleRoyal() {
         <div className="absolute top-20 right-4 z-30 pointer-events-auto mt-2 w-72 max-w-[80vw] rounded-2xl border border-white/15 bg-black/80 p-4 text-xs text-white shadow-2xl backdrop-blur max-h-[80vh] overflow-y-auto pr-1">
           <div className="flex items-center justify-between gap-3">
             <div>
-              <p className="text-[10px] uppercase tracking-[0.4em] text-sky-200/80">Backgammon Settings</p>
-              <p className="mt-1 text-[0.7rem] text-white/70">Personalize the chairs and table finish.</p>
+              <p className="text-[10px] uppercase tracking-[0.4em] text-sky-200/80">
+                Backgammon Settings
+              </p>
+              <p className="mt-1 text-[0.7rem] text-white/70">
+                Personalize the chairs and table finish.
+              </p>
             </div>
             <button
               type="button"
@@ -1182,15 +1490,31 @@ export default function TavullBattleRoyal() {
               className="rounded-full p-1 text-white/70 transition hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300"
               aria-label="Close settings"
             >
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" className="h-4 w-4">
-                <path strokeLinecap="round" strokeLinejoin="round" d="m6 6 12 12M18 6 6 18" />
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.8"
+                className="h-4 w-4"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="m6 6 12 12M18 6 6 18"
+                />
               </svg>
             </button>
           </div>
           <div className="mt-4 space-y-3">
             <label className="flex items-center justify-between text-[0.7rem] text-gray-200">
               <span>Sound effects</span>
-              <input type="checkbox" className="h-4 w-4 rounded border border-emerald-400/40 bg-transparent text-emerald-400 focus:ring-emerald-500" checked={soundEnabled} onChange={(event) => setSoundEnabled(event.target.checked)} />
+              <input
+                type="checkbox"
+                className="h-4 w-4 rounded border border-emerald-400/40 bg-transparent text-emerald-400 focus:ring-emerald-500"
+                checked={soundEnabled}
+                onChange={(event) => setSoundEnabled(event.target.checked)}
+              />
             </label>
             <button
               type="button"
@@ -1202,16 +1526,20 @@ export default function TavullBattleRoyal() {
             <div className="rounded-xl border border-white/10 bg-white/5 p-3">
               <div className="flex items-start justify-between gap-3">
                 <div>
-                  <p className="text-[10px] uppercase tracking-[0.35em] text-white/70">Personalize Arena</p>
-                  <p className="mt-1 text-[0.7rem] text-white/60">Table cloth, chairs, and table details.</p>
+                  <p className="text-[10px] uppercase tracking-[0.35em] text-white/70">
+                    Personalize Arena
+                  </p>
+                  <p className="mt-1 text-[0.7rem] text-white/60">
+                    Table cloth, chairs, and table details.
+                  </p>
                 </div>
                 <button
                   type="button"
                   onClick={() => {
-                    setTableFinishIdx(0)
-                    setChairThemeIdx(0)
-                    setHdriIdx(0)
-                    setQualityIdx(1)
+                    setTableFinishIdx(0);
+                    setChairThemeIdx(0);
+                    setHdriIdx(0);
+                    setQualityIdx(1);
                   }}
                   className="rounded-lg border border-white/15 px-2 py-1 text-[0.65rem] font-semibold text-white/80 transition hover:border-white/30 hover:text-white"
                 >
@@ -1219,16 +1547,55 @@ export default function TavullBattleRoyal() {
                 </button>
               </div>
               <div className="mt-3 grid gap-2">
-                <button type="button" className="rounded-lg border border-white/20 px-3 py-2 text-left" onClick={() => setTableFinishIdx((v) => (v + 1) % Math.max(1, ownedFinishOptions.length))}>
-                  Table Finish: {ownedFinishOptions[tableFinishIdx]?.label || ownedFinishOptions[0]?.label || 'Default'}
+                <button
+                  type="button"
+                  className="rounded-lg border border-white/20 px-3 py-2 text-left"
+                  onClick={() =>
+                    setTableFinishIdx(
+                      (v) => (v + 1) % Math.max(1, ownedFinishOptions.length)
+                    )
+                  }
+                >
+                  Table Finish:{' '}
+                  {ownedFinishOptions[tableFinishIdx]?.label ||
+                    ownedFinishOptions[0]?.label ||
+                    'Default'}
                 </button>
-                <button type="button" className="rounded-lg border border-white/20 px-3 py-2 text-left" onClick={() => setChairThemeIdx((v) => (v + 1) % Math.max(1, ownedChairOptions.length))}>
-                  Chair Theme: {ownedChairOptions[chairThemeIdx]?.label || ownedChairOptions[0]?.label || 'Royal'}
+                <button
+                  type="button"
+                  className="rounded-lg border border-white/20 px-3 py-2 text-left"
+                  onClick={() =>
+                    setChairThemeIdx(
+                      (v) => (v + 1) % Math.max(1, ownedChairOptions.length)
+                    )
+                  }
+                >
+                  Chair Theme:{' '}
+                  {ownedChairOptions[chairThemeIdx]?.label ||
+                    ownedChairOptions[0]?.label ||
+                    'Royal'}
                 </button>
-                <button type="button" className="rounded-lg border border-white/20 px-3 py-2 text-left" onClick={() => setHdriIdx((v) => (v + 1) % Math.max(1, ownedHdriOptions.length))}>
-                  Environment: {ownedHdriOptions[hdriIdx]?.name || ownedHdriOptions[0]?.name || 'Studio'}
+                <button
+                  type="button"
+                  className="rounded-lg border border-white/20 px-3 py-2 text-left"
+                  onClick={() =>
+                    setHdriIdx(
+                      (v) => (v + 1) % Math.max(1, ownedHdriOptions.length)
+                    )
+                  }
+                >
+                  Environment:{' '}
+                  {ownedHdriOptions[hdriIdx]?.name ||
+                    ownedHdriOptions[0]?.name ||
+                    'Studio'}
                 </button>
-                <button type="button" className="rounded-lg border border-white/20 px-3 py-2 text-left" onClick={() => setQualityIdx((v) => (v + 1) % QUALITY_OPTIONS.length)}>
+                <button
+                  type="button"
+                  className="rounded-lg border border-white/20 px-3 py-2 text-left"
+                  onClick={() =>
+                    setQualityIdx((v) => (v + 1) % QUALITY_OPTIONS.length)
+                  }
+                >
                   Graphics: {QUALITY_OPTIONS[qualityIdx]?.label || 'Balanced'}
                 </button>
               </div>
@@ -1243,7 +1610,9 @@ export default function TavullBattleRoyal() {
 
       {available.length > 0 && (
         <div className="absolute bottom-32 left-1/2 z-30 w-[94vw] max-w-md -translate-x-1/2 rounded-xl border border-white/15 bg-black/70 p-2 text-[10px] backdrop-blur">
-          <div className="mb-1 text-[10px] uppercase tracking-[0.2em] text-cyan-200">Legal turns</div>
+          <div className="mb-1 text-[10px] uppercase tracking-[0.2em] text-cyan-200">
+            Legal turns
+          </div>
           <div className="max-h-28 space-y-1 overflow-y-auto">
             {available.map((seq, idx) => (
               <button
@@ -1251,7 +1620,11 @@ export default function TavullBattleRoyal() {
                 type="button"
                 onClick={() => handleSequence(seq)}
                 className={`block w-full rounded border px-2 py-1 text-left ${
-                  selectedPoint != null && seq.line.some((move) => move.from === selectedPoint || move.to === selectedPoint)
+                  selectedPoint != null &&
+                  seq.line.some(
+                    (move) =>
+                      move.from === selectedPoint || move.to === selectedPoint
+                  )
                     ? 'border-amber-300/70 bg-amber-500/20'
                     : 'border-cyan-300/40 bg-cyan-500/10'
                 }`}
@@ -1264,12 +1637,24 @@ export default function TavullBattleRoyal() {
       )}
 
       <div className="absolute left-1/2 top-[75%] z-20 flex -translate-x-1/2 -translate-y-1/2 flex-col items-center gap-2">
+        <div className="rounded-full border border-amber-300/35 bg-black/50 px-3 py-1 text-[11px] font-semibold tracking-[0.12em] text-amber-100">
+          Cube x{cubeValue}
+        </div>
         {!!dice.length && (
           <div className="flex items-center gap-2 rounded-full border border-white/20 bg-black/45 px-3 py-1">
             {dice.map((value, index) => (
-              <div key={`dice-ui-${index}`} className="relative h-8 w-8 overflow-hidden rounded-md border border-white/30">
-                <img src={DICE_ICON_URL} alt="dice" className="h-full w-full object-cover" />
-                <span className="absolute inset-0 flex items-center justify-center text-sm font-black text-white drop-shadow-[0_1px_4px_rgba(0,0,0,0.9)]">{value}</span>
+              <div
+                key={`dice-ui-${index}`}
+                className="relative h-8 w-8 overflow-hidden rounded-md border border-white/30"
+              >
+                <img
+                  src={DICE_ICON_URL}
+                  alt="dice"
+                  className="h-full w-full object-cover"
+                />
+                <span className="absolute inset-0 flex items-center justify-center text-sm font-black text-white drop-shadow-[0_1px_4px_rgba(0,0,0,0.9)]">
+                  {value}
+                </span>
               </div>
             ))}
           </div>
@@ -1277,11 +1662,39 @@ export default function TavullBattleRoyal() {
         <button
           type="button"
           onClick={roll}
-          disabled={aiThinking || winner || available.length > 0}
+          disabled={
+            aiThinking || winner || available.length > 0 || pendingDoubleOffer
+          }
           className="rounded-xl border border-white/30 bg-transparent px-4 py-2 text-sm font-semibold text-white disabled:opacity-50"
         >
           Roll Dice
         </button>
+        <button
+          type="button"
+          onClick={offerDouble}
+          disabled={!canPlayerOfferDouble}
+          className="rounded-xl border border-amber-300/45 bg-amber-500/10 px-4 py-2 text-sm font-semibold text-amber-100 disabled:opacity-50"
+        >
+          Double
+        </button>
+        {pendingDoubleOffer === 'ai' && (
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={handleTakeAiDouble}
+              className="rounded-xl border border-emerald-300/55 bg-emerald-500/20 px-4 py-2 text-sm font-semibold text-emerald-100"
+            >
+              Take
+            </button>
+            <button
+              type="button"
+              onClick={handleDropAiDouble}
+              className="rounded-xl border border-rose-300/55 bg-rose-500/20 px-4 py-2 text-sm font-semibold text-rose-100"
+            >
+              Drop
+            </button>
+          </div>
+        )}
       </div>
 
       <div className="pointer-events-auto">
@@ -1314,7 +1727,11 @@ export default function TavullBattleRoyal() {
       {chatBubbles.map((bubble) => (
         <div key={bubble.id} className="chat-bubble chess-battle-chat-bubble">
           <span>{bubble.text}</span>
-          <img src={bubble.photoUrl} alt="avatar" className="w-5 h-5 rounded-full" />
+          <img
+            src={bubble.photoUrl}
+            alt="avatar"
+            className="w-5 h-5 rounded-full"
+          />
         </div>
       ))}
 
@@ -1323,9 +1740,18 @@ export default function TavullBattleRoyal() {
         onClose={() => setShowChat(false)}
         title="Quick Chat"
         onSend={(text) => {
-          const id = Date.now()
-          setChatBubbles((bubbles) => [...bubbles, { id, text, photoUrl: playerAvatar || '/assets/icons/profile.svg' }])
-          setTimeout(() => setChatBubbles((bubbles) => bubbles.filter((bubble) => bubble.id !== id)), 3000)
+          const id = Date.now();
+          setChatBubbles((bubbles) => [
+            ...bubbles,
+            { id, text, photoUrl: playerAvatar || '/assets/icons/profile.svg' }
+          ]);
+          setTimeout(
+            () =>
+              setChatBubbles((bubbles) =>
+                bubbles.filter((bubble) => bubble.id !== id)
+              ),
+            3000
+          );
         }}
       />
 
@@ -1338,13 +1764,14 @@ export default function TavullBattleRoyal() {
 
       <div className="absolute inset-0 z-10 pointer-events-none">
         {players.map((player) => {
-          const fallback = FALLBACK_SEAT_POSITIONS[player.index] || FALLBACK_SEAT_POSITIONS[0]
+          const fallback =
+            FALLBACK_SEAT_POSITIONS[player.index] || FALLBACK_SEAT_POSITIONS[0];
           const positionStyle = {
             position: 'absolute',
             left: fallback.left,
             top: fallback.top,
             transform: 'translate(-50%, -50%)'
-          }
+          };
           return (
             <div
               key={`backgammon-seat-${player.index}`}
@@ -1365,7 +1792,7 @@ export default function TavullBattleRoyal() {
                 {player.name}
               </span>
             </div>
-          )
+          );
         })}
       </div>
 
@@ -1375,5 +1802,5 @@ export default function TavullBattleRoyal() {
         </div>
       </div>
     </div>
-  )
+  );
 }


### PR DESCRIPTION
### Motivation
- Implement Backgammon doubling-cube support and correct doubled-roll behavior so the doubling flow matches official rules and AI can offer/accept/drop doubles.
- Show cube state visually in the 3D scene and give players clear, responsive controls for offering and responding to doubles.

### Description
- Added doubling cube state and flow in `webapp/src/pages/Games/TavullBattleRoyal.jsx` with new state variables `cubeValue`, `cubeOwner`, `pendingDoubleOffer`, and `forfeitWinner`, and updated winner resolution to account for forfeits when a double is dropped.
- Extended dice logic and visuals to support official doubles handling by rendering/animating up to 4 dice when doubles occur and by passing the correct dice array into the turn-evaluation code.
- Wire-up of in-scene 3D doubling cube via `makeBackgammonDoubleCube` and a new `setDoubleCube` hook on the scene bundle so cube face and position reflect current value and owner.
- Implemented doubling UX and AI decisions: player `Double` button (with enable/disable guards), AI double-offer (`maybeOfferAiDouble`) using `scorePosition` heuristics, and player-facing `Take/Drop` responses; integrated take/drop outcomes (apply new cube value or award forfeit win when drop).

### Testing
- Ran unit tests for the backgammon engine with `npm test -- --runInBand test/tavullEngine.test.js`, all tests passed.
- Ran ESLint on the modified file; it produced a repository ignore warning only (`npx eslint ...`), no blocking errors.
- Launched the dev server to validate UI and animation (`npm --prefix webapp run dev -- --host 0.0.0.0 --port 4173`) and captured a screenshot of the updated UI at `browser:/tmp/codex_browser_invocations/f1ba4391fab2e75b/artifacts/artifacts/tavull-double-button.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b80f7e5ec88329a611823ce5b00d43)