### PR TITLE
Fix checkers board mapping and reuse Chess piece palettes

### DIFF
--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -44,7 +44,8 @@ import { getGameVolume } from '../../utils/sound.js';
 import { giftSounds } from '../../utils/giftSounds.js';
 import {
   chessBattleAccountId,
-  getChessBattleInventory
+  getChessBattleInventory,
+  isChessOptionUnlocked
 } from '../../utils/chessBattleInventory.js';
 
 const SIZE = 8;
@@ -59,7 +60,7 @@ const TABLE_HEIGHT = STOOL_HEIGHT + 0.05 * MODEL_SCALE;
 const BOARD_SCALE = 0.064;
 const BOARD_TILE_SIZE = ((SIZE * 4.2 + 3 * 2) * BOARD_SCALE) / SIZE;
 const BOARD_MODEL_OUTER_TO_PLAYABLE_RATIO = 1.14;
-const CHECKERS_PLAYABLE_MAPPING_RATIO = 1.28;
+const CHECKERS_PLAYABLE_MAPPING_RATIO = 1.14;
 const CHAIR_DISTANCE = TABLE_RADIUS + 0.82;
 const SEAT_WIDTH = 0.9 * MODEL_SCALE * STOOL_SCALE;
 const SEAT_DEPTH = 0.95 * MODEL_SCALE * STOOL_SCALE;
@@ -202,22 +203,26 @@ const CHECKERS_HIGHLIGHT_COLORS = Object.freeze({
   capture: '#ff8e6e'
 });
 
-const CHIP_SETS = [
-  { id: 'ruby-cyan', label: 'Ruby/Cyan', light: '#ef4444', dark: '#06b6d4' },
-  {
-    id: 'emerald-violet',
-    label: 'Emerald/Violet',
-    light: '#10b981',
-    dark: '#8b5cf6'
-  },
-  {
-    id: 'amber-slate',
-    label: 'Amber/Slate',
-    light: '#f59e0b',
-    dark: '#334155'
-  },
-  { id: 'rose-ice', label: 'Rose/Ice', light: '#fb7185', dark: '#67e8f9' }
-];
+const CHECKERS_SIDE_COLOR_HEX = Object.freeze({
+  marble: '#ffffff',
+  darkForest: '#ffffff',
+  amberGlow: '#f59e0b',
+  mintVale: '#10b981',
+  royalWave: '#3b82f6',
+  roseMist: '#ef4444',
+  amethyst: '#8b5cf6',
+  cinderBlaze: '#ff6b35',
+  arcticDrift: '#bcd7ff'
+});
+
+const CHECKERS_SIDE_COLOR_OPTIONS = Object.freeze(
+  Object.entries(CHESS_BATTLE_OPTION_LABELS.sideColor).map(([id, label]) => ({
+    id,
+    label,
+    color: CHECKERS_SIDE_COLOR_HEX[id] || '#f8fafc',
+    thumbnail: CHESS_BATTLE_OPTION_THUMBNAILS.sideColor[id]
+  }))
+);
 
 const FALLBACK_SEAT_POSITIONS = [
   { left: '50%', top: '18%' },
@@ -233,10 +238,10 @@ const createInitial = () => {
   const board = Array.from({ length: SIZE }, () => Array(SIZE).fill(null));
   for (let r = 0; r < 3; r += 1)
     for (let c = 0; c < SIZE; c += 1)
-      if ((r + c) % 2 === 1) board[r][c] = { side: 'dark', king: false };
+      if ((r + c) % 2 === 0) board[r][c] = { side: 'dark', king: false };
   for (let r = 5; r < SIZE; r += 1)
     for (let c = 0; c < SIZE; c += 1)
-      if ((r + c) % 2 === 1) board[r][c] = { side: 'light', king: false };
+      if ((r + c) % 2 === 0) board[r][c] = { side: 'light', king: false };
   return board;
 };
 
@@ -485,7 +490,7 @@ function buildFallbackCheckersBoardModel() {
   tileGroup.position.y = boardBaseY + frameHeight + topHeight;
   for (let r = 0; r < SIZE; r += 1) {
     for (let c = 0; c < SIZE; c += 1) {
-      const isDark = (r + c) % 2 === 1;
+      const isDark = (r + c) % 2 === 0;
       const tileMesh = new THREE.Mesh(
         new THREE.BoxGeometry(tileSize, 0.04, tileSize),
         isDark ? darkMat : lightMat
@@ -993,6 +998,13 @@ export default function CheckersBattleRoyal() {
 
   const inv = useMemo(() => {
     const inventory = getChessBattleInventory(chessBattleAccountId());
+    const availableSideColors = CHECKERS_SIDE_COLOR_OPTIONS.filter((option) =>
+      isChessOptionUnlocked('sideColor', option.id, inventory)
+    );
+    const defaultLightSide =
+      inventory.sideColor?.[0] || availableSideColors[0]?.id || 'amberGlow';
+    const defaultDarkSide =
+      inventory.sideColor?.[1] || availableSideColors[1]?.id || 'mintVale';
     return {
       tableId: inventory.tables?.[0] || CHESS_TABLE_OPTIONS[0]?.id,
       chairId: inventory.chairColor?.[0] || CHESS_CHAIR_OPTIONS[0]?.id,
@@ -1000,16 +1012,31 @@ export default function CheckersBattleRoyal() {
       hdriId: inventory.environmentHdri?.[0] || POOL_ROYALE_DEFAULT_HDRI_ID,
       boardTheme:
         inventory.boardTheme?.[0] || CHECKERS_BOARD_THEME_OPTIONS[0]?.id,
-      headStyle: inventory.headStyle?.[0] || 'current'
+      headStyle: inventory.headStyle?.[0] || 'current',
+      lightSideColor: defaultLightSide,
+      darkSideColor: defaultDarkSide
     };
   }, []);
 
   const [appearance, setAppearance] = useState(inv);
-  const [chipSetId, setChipSetId] = useState(CHIP_SETS[0].id);
 
-  const chipSet = CHIP_SETS.find((s) => s.id === chipSetId) || CHIP_SETS[0];
+  const unlockedSideColors = useMemo(() => {
+    const inventory = getChessBattleInventory(chessBattleAccountId());
+    const options = CHECKERS_SIDE_COLOR_OPTIONS.filter((option) =>
+      isChessOptionUnlocked('sideColor', option.id, inventory)
+    );
+    return options.length ? options : CHECKERS_SIDE_COLOR_OPTIONS;
+  }, []);
+
+  const lightChipColor =
+    CHECKERS_SIDE_COLOR_OPTIONS.find((option) => option.id === appearance.lightSideColor)?.color ||
+    CHECKERS_SIDE_COLOR_HEX.amberGlow;
+  const darkChipColor =
+    CHECKERS_SIDE_COLOR_OPTIONS.find((option) => option.id === appearance.darkSideColor)?.color ||
+    CHECKERS_SIDE_COLOR_HEX.mintVale;
+
   const checkerHeadPreset = useMemo(() => {
-    const headId = inv?.headStyle || 'current';
+    const headId = appearance?.headStyle || 'current';
     if (headId === 'headChrome') {
       return { roughness: 0.12, metalness: 0.95, transmission: 0.1, ior: 2.1, thickness: 0.22 };
     }
@@ -1023,7 +1050,7 @@ export default function CheckersBattleRoyal() {
       return { roughness: 0.08, metalness: 0.05, transmission: 0.92, ior: 2.4, thickness: 0.6 };
     }
     return { roughness: 0.05, metalness: 0, transmission: 0.95, ior: 1.5, thickness: 0.5 };
-  }, [inv?.headStyle]);
+  }, [appearance?.headStyle]);
   const playerName = getTelegramFirstName() || 'Player';
   const playerPhotoUrl = getTelegramPhotoUrl() || '/assets/icons/profile.svg';
 
@@ -1063,7 +1090,7 @@ export default function CheckersBattleRoyal() {
               40
             ),
             createCheckerMaterial(
-              piece.side === 'light' ? chipSet.light : chipSet.dark,
+              piece.side === 'light' ? lightChipColor : darkChipColor,
               checkerHeadPreset
             )
           );
@@ -1091,7 +1118,7 @@ export default function CheckersBattleRoyal() {
         }
       }
     },
-    [checkerHeadPreset, chipSet.dark, chipSet.light]
+    [checkerHeadPreset, darkChipColor, lightChipColor]
   );
 
   useEffect(() => {
@@ -1902,15 +1929,52 @@ export default function CheckersBattleRoyal() {
                   ))}
                 </div>
 
-                <div className="mb-2 text-[11px] text-white/70">Chips</div>
-                <div className="flex flex-wrap gap-2">
-                  {CHIP_SETS.map((set) => (
+                <div className="mb-2 text-[11px] text-white/70">Your Pieces</div>
+                <div className="mb-3 grid max-h-28 grid-cols-2 gap-2 overflow-auto">
+                  {unlockedSideColors.map((option) => (
                     <button
-                      key={set.id}
-                      onClick={() => setChipSetId(set.id)}
-                      className={optionButton(chipSetId === set.id)}
+                      key={`light-${option.id}`}
+                      onClick={() =>
+                        setAppearance((prev) => ({
+                          ...prev,
+                          lightSideColor: option.id
+                        }))
+                      }
+                      className={`rounded-xl border px-2 py-2 text-[11px] ${appearance.lightSideColor === option.id ? 'border-cyan-300 bg-cyan-500/20 text-cyan-100' : 'border-white/15 bg-white/5 text-white/70'}`}
                     >
-                      {set.label}
+                      {option.thumbnail ? (
+                        <img
+                          src={option.thumbnail}
+                          alt={`${option.label} piece thumbnail`}
+                          className="mb-1 h-10 w-full rounded object-cover"
+                        />
+                      ) : null}
+                      {option.label}
+                    </button>
+                  ))}
+                </div>
+
+                <div className="mb-2 text-[11px] text-white/70">Rival Pieces</div>
+                <div className="grid max-h-28 grid-cols-2 gap-2 overflow-auto">
+                  {unlockedSideColors.map((option) => (
+                    <button
+                      key={`dark-${option.id}`}
+                      onClick={() =>
+                        setAppearance((prev) => ({
+                          ...prev,
+                          darkSideColor: option.id
+                        }))
+                      }
+                      className={`rounded-xl border px-2 py-2 text-[11px] ${appearance.darkSideColor === option.id ? 'border-cyan-300 bg-cyan-500/20 text-cyan-100' : 'border-white/15 bg-white/5 text-white/70'}`}
+                    >
+                      {option.thumbnail ? (
+                        <img
+                          src={option.thumbnail}
+                          alt={`${option.label} piece thumbnail`}
+                          className="mb-1 h-10 w-full rounded object-cover"
+                        />
+                      ) : null}
+                      {option.label}
                     </button>
                   ))}
                 </div>


### PR DESCRIPTION
### Motivation
- Align Checkers playable squares and piece placement with the board visual so pieces sit on the intended tiles and picks/hits match visuals. 
- Reuse the Chess Battle Royal piece palette and head-style presets so Checkers pieces can use the same textures/colors available in the Chess store.

### Description
- Corrected board-square parity used for initial piece placement and procedural tile drawing by switching the parity tests from `(r + c) % 2 === 1` to `(r + c) % 2 === 0` so pieces map to the visual dark tiles and tile materials follow the same parity.
- Adjusted the GLTF playable-size mapping constant by changing `CHECKERS_PLAYABLE_MAPPING_RATIO` from `1.28` to `1.14` to better align pick tiles / piece positions with external board models.
- Replaced the hardcoded `CHIP_SETS` with `CHECKERS_SIDE_COLOR_OPTIONS` derived from `CHESS_BATTLE_OPTION_LABELS.sideColor` and `CHESS_BATTLE_OPTION_THUMBNAILS`, and added `CHECKERS_SIDE_COLOR_HEX` to map hex values for those options.
- Wired Checkers appearance to use the Chess inventory: added unlocking checks with `isChessOptionUnlocked`, defaulted `lightSideColor`/`darkSideColor` from the Chess inventory, and rendered pieces with `lightChipColor`/`darkChipColor` so all Chess store piece colors are usable in Checkers.
- Exposed two UI pickers in the Checkers config panel for selecting player and rival piece palettes and made the checker material preset respect the selected `appearance.headStyle`.

### Testing
- Ran `npx eslint webapp/src/pages/Games/CheckersBattleRoyal.jsx`; linter reported no actionable errors for this file in the repo configuration (file is ignored by repo eslint patterns in this run).
- Ran `npm run build` which failed due to an unrelated pre-existing TypeScript error in `src/rules/SnookerRoyalRules.ts` (failure is unrelated to this change).
- Launched the webapp dev server and performed an automated browser render validation with Playwright that produced a screenshot of the updated Checkers scene, confirming visual alignment of pieces and the updated palette (screenshot artifact created).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b814564e30832980bd900b29a2ab76)