### PR TITLE
Fix Checkers Battle Royal GLTF board tile mapping for piece placement

### DIFF
--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -788,8 +788,11 @@ function resolveCheckersPlayableTileSize(boardModel) {
   const bounds = new THREE.Box3().setFromObject(boardModel);
   const span = Math.max(bounds.max.x - bounds.min.x, bounds.max.z - bounds.min.z);
   if (!Number.isFinite(span) || span <= 0) return BOARD_TILE_SIZE;
+  const isMappedGltfBoard =
+    boardModel?.name === 'ChessBattleRoyalBoard' ||
+    boardModel?.name === 'ABeautifulGameBoard';
   const ratio =
-    boardModel?.name === 'ChessBattleRoyalBoard'
+    isMappedGltfBoard
       ? BOARD_MODEL_OUTER_TO_PLAYABLE_RATIO
       : CHECKERS_PLAYABLE_MAPPING_RATIO;
   return span / ratio / SIZE;


### PR DESCRIPTION
### Motivation
- Ensure checker pieces align precisely with the visual squares when a GLTF board model is loaded by using the correct playable-area mapping instead of the procedural fallback ratio.

### Description
- Adjusted `resolveCheckersPlayableTileSize` in `webapp/src/pages/Games/CheckersBattleRoyal.jsx` to treat mapped GLTF boards (`ChessBattleRoyalBoard` and `ABeautifulGameBoard`) as mapped models and use `BOARD_MODEL_OUTER_TO_PLAYABLE_RATIO` instead of `CHECKERS_PLAYABLE_MAPPING_RATIO`, which aligns piece coordinates with board squares.

### Testing
- Built the webapp with `npm --prefix webapp run build` which completed successfully, and attempted automated browser verification via Playwright where one pre-load screenshot artifact was captured but subsequent Chromium launches crashed (SIGSEGV) in this environment; the build success confirms the change compiles and the automated screenshot run produced an artifact prior to instability.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b81bc9646c8329ab7d517068315abd)