### PR TITLE
Align Checkers board mapping and compute board origin for precise piece placement

### DIFF
--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -59,7 +59,7 @@ const TABLE_HEIGHT = STOOL_HEIGHT + 0.05 * MODEL_SCALE;
 const BOARD_SCALE = 0.064;
 const BOARD_TILE_SIZE = ((SIZE * 4.2 + 3 * 2) * BOARD_SCALE) / SIZE;
 const BOARD_MODEL_OUTER_TO_PLAYABLE_RATIO = 1.14;
-const CHECKERS_PLAYABLE_MAPPING_RATIO = 1.28;
+const CHECKERS_PLAYABLE_MAPPING_RATIO = BOARD_MODEL_OUTER_TO_PLAYABLE_RATIO;
 const CHAIR_DISTANCE = TABLE_RADIUS + 0.82;
 const SEAT_WIDTH = 0.9 * MODEL_SCALE * STOOL_SCALE;
 const SEAT_DEPTH = 0.95 * MODEL_SCALE * STOOL_SCALE;
@@ -793,6 +793,34 @@ function resolveCheckersPlayableTileSize(boardModel) {
       ? BOARD_MODEL_OUTER_TO_PLAYABLE_RATIO
       : CHECKERS_PLAYABLE_MAPPING_RATIO;
   return span / ratio / SIZE;
+}
+
+function resolveCheckersBoardOrigin(boardModel) {
+  const tile = resolveCheckersPlayableTileSize(boardModel);
+  if (!boardModel) {
+    return {
+      x: 0,
+      y: TABLE_HEIGHT + 0.08,
+      z: 0,
+      tile
+    };
+  }
+  const bounds = new THREE.Box3().setFromObject(boardModel);
+  if (bounds.isEmpty()) {
+    return {
+      x: 0,
+      y: TABLE_HEIGHT + 0.08,
+      z: 0,
+      tile
+    };
+  }
+  const center = bounds.getCenter(new THREE.Vector3());
+  return {
+    x: center.x,
+    y: bounds.max.y + Math.max(0.09, tile * 0.35),
+    z: center.z,
+    tile
+  };
 }
 
 function createCheckerMaterial(style, headPreset) {
@@ -1557,12 +1585,9 @@ export default function CheckersBattleRoyal() {
         proceduralBoard.visible = true;
       }
 
-      boardOriginRef.current = {
-        x: 0,
-        y: TABLE_HEIGHT + 0.08,
-        z: 0,
-        tile: resolveCheckersPlayableTileSize(gltfBoardRef.current || proceduralBoard)
-      };
+      boardOriginRef.current = resolveCheckersBoardOrigin(
+        gltfBoardRef.current || proceduralBoard
+      );
 
       setupPickTiles();
       renderPieces();


### PR DESCRIPTION
### Motivation
- Pieces were not reliably aligning with the visual 3D board model because the playable-tile mapping and origin were using fixed values instead of measured model bounds.
- The change aims to place checkers exactly on squares for any loaded board GLTF by deriving the playable tile size and origin from the actual board geometry.

### Description
- Use the board model outer-to-playable ratio for playable mapping by changing `CHECKERS_PLAYABLE_MAPPING_RATIO` to `BOARD_MODEL_OUTER_TO_PLAYABLE_RATIO` in `webapp/src/pages/Games/CheckersBattleRoyal.jsx` so tile scaling matches the loaded model.
- Add `resolveCheckersBoardOrigin(boardModel)` to compute the board origin (`x,y,z`) and tile size from the model bounds (center and top surface), including a conservative Y offset above the board top to avoid z-fighting.
- Initialize `boardOriginRef.current` using the new `resolveCheckersBoardOrigin(...)` when assets finish loading, replacing the previous fixed origin object so piece placement uses measured board geometry.
- Minor safety checks added when the board model is missing or its bounds are empty to fall back to the previous default origin and tile size.

### Testing
- Ran a production build with `npm --prefix webapp run build` which completed successfully.
- Ran an automated Playwright script that opened `/games/checkersbattleroyal` in a portrait viewport, waited for the scene to load, and captured screenshots (`artifacts/checkers-before.png`, `artifacts/checkers-final.png`), and the screenshots were produced and reviewed successfully.
- Verified in the running development server that pieces render at the resolved positions and highlights/picking still function after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b81bc9646c8329ab7d517068315abd)