### PR TITLE
Fix Checkers Battle Royal piece mapping to board tiles

### DIFF
--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -309,10 +309,10 @@ const createInitial = () => {
   const board = Array.from({ length: SIZE }, () => Array(SIZE).fill(null));
   for (let r = 0; r < 3; r += 1)
     for (let c = 0; c < SIZE; c += 1)
-      if ((r + c) % 2 === 0) board[r][c] = { side: 'dark', king: false };
+      if ((r + c) % 2 === 1) board[r][c] = { side: 'dark', king: false };
   for (let r = 5; r < SIZE; r += 1)
     for (let c = 0; c < SIZE; c += 1)
-      if ((r + c) % 2 === 0) board[r][c] = { side: 'light', king: false };
+      if ((r + c) % 2 === 1) board[r][c] = { side: 'light', king: false };
   return board;
 };
 


### PR DESCRIPTION
### Motivation
- The rendered board marks dark playable tiles when `(r + c) % 2 === 1`, but the initial piece placement used the opposite parity, producing a visible piece-vs-board mismatch.

### Description
- Adjusted initial checkers setup in `webapp/src/pages/Games/CheckersBattleRoyal.jsx` by changing both dark and light side placement checks from `(r + c) % 2 === 0` to `(r + c) % 2 === 1` so pieces spawn on the same playable tile color as the board.

### Testing
- Ran a production build with `npm --prefix webapp run build` which completed successfully.
- Attempted automated visual verification with Playwright (headless Chromium crashed and produced WebGL context creation errors, and a Firefox run produced a debug capture showing the same WebGL limitation), so in-container runtime visual validation is blocked by missing WebGL support in the CI/browser environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b81bc9646c8329ab7d517068315abd)