### PR TITLE
Fix checkers piece-to-board mapping and playable-area ratio

### DIFF
--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -59,7 +59,7 @@ const TABLE_HEIGHT = STOOL_HEIGHT + 0.05 * MODEL_SCALE;
 const BOARD_SCALE = 0.064;
 const BOARD_TILE_SIZE = ((SIZE * 4.2 + 3 * 2) * BOARD_SCALE) / SIZE;
 const BOARD_MODEL_OUTER_TO_PLAYABLE_RATIO = 1.14;
-const CHECKERS_PLAYABLE_MAPPING_RATIO = 1.28;
+const CHECKERS_PLAYABLE_MAPPING_RATIO = 1.34;
 const CHAIR_DISTANCE = TABLE_RADIUS + 0.82;
 const SEAT_WIDTH = 0.9 * MODEL_SCALE * STOOL_SCALE;
 const SEAT_DEPTH = 0.95 * MODEL_SCALE * STOOL_SCALE;
@@ -309,10 +309,10 @@ const createInitial = () => {
   const board = Array.from({ length: SIZE }, () => Array(SIZE).fill(null));
   for (let r = 0; r < 3; r += 1)
     for (let c = 0; c < SIZE; c += 1)
-      if ((r + c) % 2 === 0) board[r][c] = { side: 'dark', king: false };
+      if ((r + c) % 2 === 1) board[r][c] = { side: 'dark', king: false };
   for (let r = 5; r < SIZE; r += 1)
     for (let c = 0; c < SIZE; c += 1)
-      if ((r + c) % 2 === 0) board[r][c] = { side: 'light', king: false };
+      if ((r + c) % 2 === 1) board[r][c] = { side: 'light', king: false };
   return board;
 };
 


### PR DESCRIPTION
### Motivation
- Pieces were spawning on the wrong square parity and did not align precisely with the visible playable tiles on the 3D board, so the piece mapping needs to match the board mapping exactly for correct gameplay presentation.

### Description
- Changed playable-square parity for initial placement so pieces spawn on the board's playable squares using `(r + c) % 2 === 1` in `createInitial()` in `webapp/src/pages/Games/CheckersBattleRoyal.jsx`.
- Adjusted GLTF-to-playable-area mapping constant from `CHECKERS_PLAYABLE_MAPPING_RATIO = 1.28` to `1.34` to better scale checker chips to the board model.
- No board geometry or material logic was modified; only piece-placement parity and the playable-area mapping ratio were updated in `webapp/src/pages/Games/CheckersBattleRoyal.jsx`.

### Testing
- Captured a browser screenshot after loading the Checkers scene to visually verify piece alignment (screenshot artifact produced during the run); visual verification succeeded for the run artifact.
- Ran `npx eslint` on the file (the project ignore settings mark the path as ignored so ESLint reported the ignore warning; no syntax errors reported for the edited file during checks).
- Started `npm --prefix webapp run build` to validate the production build, but the build did not complete within the execution window (build was initiated but not finished in this environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b845c38ac883298aaba01e1ebefba8)