### PR TITLE
Align Checkers pieces to playable board area

### DIFF
--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -59,7 +59,11 @@ const TABLE_HEIGHT = STOOL_HEIGHT + 0.05 * MODEL_SCALE;
 const BOARD_SCALE = 0.064;
 const BOARD_TILE_SIZE = ((SIZE * 4.2 + 3 * 2) * BOARD_SCALE) / SIZE;
 const BOARD_MODEL_OUTER_TO_PLAYABLE_RATIO = 1.14;
-const CHECKERS_PLAYABLE_MAPPING_RATIO = 1.28;
+const CHECKERS_PLAYABLE_MAPPING_RATIO = 1.36;
+const CHECKERS_PLAYABLE_CENTER_OFFSET_TILES = Object.freeze({
+  x: 0.08,
+  z: 0.2
+});
 const CHAIR_DISTANCE = TABLE_RADIUS + 0.82;
 const SEAT_WIDTH = 0.9 * MODEL_SCALE * STOOL_SCALE;
 const SEAT_DEPTH = 0.95 * MODEL_SCALE * STOOL_SCALE;
@@ -793,6 +797,15 @@ function resolveCheckersPlayableTileSize(boardModel) {
       ? BOARD_MODEL_OUTER_TO_PLAYABLE_RATIO
       : CHECKERS_PLAYABLE_MAPPING_RATIO;
   return span / ratio / SIZE;
+}
+
+function resolveCheckersPlayableCenterOffset(boardModel, tileSize) {
+  if (!boardModel || boardModel?.name === 'ChessBattleRoyalBoard')
+    return { x: 0, z: 0 };
+  return {
+    x: tileSize * CHECKERS_PLAYABLE_CENTER_OFFSET_TILES.x,
+    z: tileSize * CHECKERS_PLAYABLE_CENTER_OFFSET_TILES.z
+  };
 }
 
 function createCheckerMaterial(style, headPreset) {
@@ -1557,11 +1570,18 @@ export default function CheckersBattleRoyal() {
         proceduralBoard.visible = true;
       }
 
+      const activeBoardModel = gltfBoardRef.current || proceduralBoard;
+      const playableTile = resolveCheckersPlayableTileSize(activeBoardModel);
+      const playableOffset = resolveCheckersPlayableCenterOffset(
+        activeBoardModel,
+        playableTile
+      );
+
       boardOriginRef.current = {
-        x: 0,
+        x: playableOffset.x,
         y: TABLE_HEIGHT + 0.08,
-        z: 0,
-        tile: resolveCheckersPlayableTileSize(gltfBoardRef.current || proceduralBoard)
+        z: playableOffset.z,
+        tile: playableTile
       };
 
       setupPickTiles();


### PR DESCRIPTION
### Motivation
- The 3D checkers board model and the playable grid used for piece placement were slightly misaligned, causing pieces/highlights to appear off-center on the rendered board.
- The goal is to adjust only the playable-area mapping (so pieces/highlights align precisely) without modifying the board geometry or assets.

### Description
- Increased `CHECKERS_PLAYABLE_MAPPING_RATIO` from `1.28` to `1.36` to tighten the playable-area mapping against the imported board model.
- Added `CHECKERS_PLAYABLE_CENTER_OFFSET_TILES` and a new `resolveCheckersPlayableCenterOffset(boardModel, tileSize)` helper to compute a small center offset for piece placement when using the imported board.
- Compute `playableTile` and `playableOffset` from the active `gltfBoardRef` (or fallback procedural board) and set `boardOriginRef.current` using the resolved `x`, `z` offsets and `tile` size so piece placement and highlights shift to the correct center.
- Changes are localized to `webapp/src/pages/Games/CheckersBattleRoyal.jsx` and do not modify board assets or visual models.

### Testing
- Ran `npm install` in the `webapp/` folder and the install completed successfully.
- Started the dev server with `npm run dev` and exercised automated browser checks using Playwright to load `http://127.0.0.1:4173/games/checkersbattleroyal` and capture screenshots (`artifacts/checkers-before.png`, `artifacts/checkers-after.png`).
- Built the production bundle with `npm run build` and the build completed successfully (no build failures reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b845c38ac883298aaba01e1ebefba8)