### PR TITLE
Align Checkers piece mapping to board playable ratio

### DIFF
--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -59,7 +59,10 @@ const TABLE_HEIGHT = STOOL_HEIGHT + 0.05 * MODEL_SCALE;
 const BOARD_SCALE = 0.064;
 const BOARD_TILE_SIZE = ((SIZE * 4.2 + 3 * 2) * BOARD_SCALE) / SIZE;
 const BOARD_MODEL_OUTER_TO_PLAYABLE_RATIO = 1.14;
-const CHECKERS_PLAYABLE_MAPPING_RATIO = 1.28;
+// The imported ABeautifulGame board uses the same playable-to-outer bounds as
+// Chess Battle Royal. Using the same ratio keeps checkers chips centered on the
+// visual squares instead of drifting toward seams/edges.
+const CHECKERS_PLAYABLE_MAPPING_RATIO = BOARD_MODEL_OUTER_TO_PLAYABLE_RATIO;
 const CHAIR_DISTANCE = TABLE_RADIUS + 0.82;
 const SEAT_WIDTH = 0.9 * MODEL_SCALE * STOOL_SCALE;
 const SEAT_DEPTH = 0.95 * MODEL_SCALE * STOOL_SCALE;


### PR DESCRIPTION
### Motivation
- Checker chips were visually drifting off the intended dark squares because the playable-to-outer mapping constant for Checkers did not match the imported board model's mapping used elsewhere, causing misalignment between piece positions and board tiles.

### Description
- Updated `CHECKERS_PLAYABLE_MAPPING_RATIO` in `webapp/src/pages/Games/CheckersBattleRoyal.jsx` to reuse `BOARD_MODEL_OUTER_TO_PLAYABLE_RATIO` and added an inline comment explaining the rationale so pieces stay centered on visual squares without changing board geometry.

### Testing
- Ran `git diff --check` with no issues reported.
- Ran ESLint (`npx eslint`) which produced only an ignore/warning for this file and no blocking errors.
- Attempted automated Playwright page loads and screenshots of the running dev server to visually validate placement, but navigation/timeouts in this environment prevented successful screenshots.
- Attempted a production build (`npm --prefix webapp run build`) but the build could not be fully validated here due to environment/time constraints.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b845c38ac883298aaba01e1ebefba8)