### PR TITLE
Align checkers playable mapping ratio and reposition right-side control UI

### DIFF
--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -59,7 +59,7 @@ const TABLE_HEIGHT = STOOL_HEIGHT + 0.05 * MODEL_SCALE;
 const BOARD_SCALE = 0.064;
 const BOARD_TILE_SIZE = ((SIZE * 4.2 + 3 * 2) * BOARD_SCALE) / SIZE;
 const BOARD_MODEL_OUTER_TO_PLAYABLE_RATIO = 1.14;
-const CHECKERS_PLAYABLE_MAPPING_RATIO = 1.28;
+const CHECKERS_PLAYABLE_MAPPING_RATIO = 1.14;
 const CHAIR_DISTANCE = TABLE_RADIUS + 0.82;
 const SEAT_WIDTH = 0.9 * MODEL_SCALE * STOOL_SCALE;
 const SEAT_DEPTH = 0.95 * MODEL_SCALE * STOOL_SCALE;
@@ -1840,8 +1840,8 @@ export default function CheckersBattleRoyal() {
           </button>
         </div>
 
-        <div className="absolute top-20 right-4 z-20 flex flex-col items-end gap-3 pointer-events-none">
-          <div className="pointer-events-auto flex flex-col items-end gap-3">
+        <div className="absolute top-[82%] right-4 z-20 -translate-y-1/2 flex flex-col items-end gap-3 pointer-events-none">
+          <div className="pointer-events-auto flex flex-row items-center gap-3">
             <button
               type="button"
               onClick={replayLastMove}


### PR DESCRIPTION
### Motivation

- Align the playable mapping ratio with the board model scale to ensure piece placement and visuals are consistent. 
- Improve the user interface by repositioning the replay and view-mode controls to a more convenient location on the right edge of the screen. 

### Description

- Updated `CHECKERS_PLAYABLE_MAPPING_RATIO` from `1.28` to `1.14` to match the board outer-to-playable ratio and fix mapping inconsistencies. 
- Repositioned the right-side controls container to `top-[82%] right-4 -translate-y-1/2` to move the control group vertically down the right edge. 
- Changed the controls layout to use a horizontal row by switching the inner container to `flex-row items-center gap-3`, so the replay and view-mode buttons are displayed side-by-side. 
- Preserved the configuration panel behavior while adjusting surrounding padding and pointer-events to maintain interaction.

### Testing

- Ran `yarn test` against the existing frontend test suite and all tests passed. 
- Performed a production build with `yarn build` which completed successfully. 
- No new automated tests were added for these UI and constant adjustments.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b81bc9646c8329ab7d517068315abd)