### PR TITLE
Tavull: select-to-highlight legal moves and move commentary above board

### DIFF
--- a/webapp/src/pages/Games/TavullBattleRoyal.jsx
+++ b/webapp/src/pages/Games/TavullBattleRoyal.jsx
@@ -1161,12 +1161,13 @@ export default function TavullBattleRoyal() {
       if (selectedPoint == null) {
         const startsFromPoint = available.filter((seq) => seq?.line?.[0]?.from === point)
         if (!startsFromPoint.length) return
-        if (startsFromPoint.length === 1) {
-          handleSequence(startsFromPoint[0])
-          return
-        }
         setSelectedPoint(point)
-        setMessage('From point selected. Tap destination triangle.')
+        const destinationCount = new Set(startsFromPoint.map((seq) => seq?.line?.[0]?.to).filter((to) => typeof to === 'number')).size
+        setMessage(
+          destinationCount > 1
+            ? `Checker selected. ${destinationCount} legal moves highlighted. Tap a destination triangle.`
+            : 'Checker selected. Legal move highlighted. Tap destination triangle.'
+        )
         return
       }
 
@@ -1174,6 +1175,12 @@ export default function TavullBattleRoyal() {
 
       if (narrowed.length >= 1) {
         handleSequence(narrowed[0])
+        return
+      }
+
+      if (point === selectedPoint) {
+        setSelectedPoint(null)
+        setMessage('Selection cleared. Tap a checker or triangle to choose a move.')
         return
       }
 
@@ -1396,7 +1403,7 @@ export default function TavullBattleRoyal() {
         })}
       </div>
 
-      <div className="absolute top-[61%] left-1/2 -translate-x-1/2 pointer-events-none">
+      <div className="absolute top-[33%] left-1/2 -translate-x-1/2 pointer-events-none">
         <div className="px-5 py-2 rounded-full bg-[rgba(7,10,18,0.65)] border border-[rgba(255,215,0,0.25)] text-sm font-semibold backdrop-blur">
           {winner ? `${winner === WHITE ? 'You' : 'AI'} win!` : message}
         </div>


### PR DESCRIPTION
### Motivation
- Improve UX for Backgammon Royal by making piece selection explicit and visually clear so players see legal destinations before committing a move. 
- Place the commentary/status bubble between the top avatar area and the board on portrait layouts so messages are visually closer to gameplay area.

### Description
- Updated point tap handling in `webapp/src/pages/Games/TavullBattleRoyal.jsx` so tapping a checker always selects it first and highlights legal destination triangles instead of auto-playing when only one sequence exists. 
- Compute `destinationCount` for the selected point and show a contextual message that indicates how many legal moves are available. 
- Allow clearing the selection by tapping the selected point again and provide a clear status message when selection is cleared. 
- Moved the in-game commentary/status bubble CSS from `top-[61%]` to `top-[33%]` so it renders between the top avatar and the board in portrait layouts.

### Testing
- Ran `npm test -- --runInBand test/tavullEngine.test.js` and the suite passed: 1 test suite, 4 tests all passing. 
- No other automated tests were modified or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba2a8a45048329a1b3291b9da8bea4)