### PR TITLE
Add 4-in-a-Row board, frame and ring finish cosmetics to store

### DIFF
--- a/webapp/src/config/badukBattleInventoryConfig.js
+++ b/webapp/src/config/badukBattleInventoryConfig.js
@@ -24,7 +24,6 @@ export const BADUK_BOARD_LAYOUTS = Object.freeze([
   { id: 'arena8x7', label: 'Arena 8×7', rows: 7, cols: 8 }
 ])
 
-
 export const BADUK_BOARD_THEMES = Object.freeze([
   { id: 'classicKaya', label: 'Classic Kaya', thumbnail: '/assets/game-art/baduk-battle-royal/store/boards/classicKaya.svg', tint: '#e2ae68', grid: '#2a1709' },
   { id: 'midnightBamboo', label: 'Midnight Bamboo', thumbnail: '/assets/game-art/baduk-battle-royal/store/boards/midnightBamboo.svg', tint: '#a4773f', grid: '#201309' },
@@ -36,6 +35,52 @@ export const BADUK_BOARD_THEMES = Object.freeze([
   { id: 'desertCopper', label: 'Desert Copper', thumbnail: swatchThumbnail(['#f59e0b', '#78350f']), tint: '#f59e0b', grid: '#78350f' },
   { id: 'violetNebula', label: 'Violet Nebula', thumbnail: swatchThumbnail(['#a855f7', '#312e81']), tint: '#a855f7', grid: '#312e81' },
   { id: 'iceSilver', label: 'Ice Silver', thumbnail: swatchThumbnail(['#cbd5e1', '#334155']), tint: '#cbd5e1', grid: '#334155' }
+])
+
+export const BADUK_BOARD_FINISH_OPTIONS = Object.freeze([...MURLAN_TABLE_FINISHES])
+export const BADUK_BOARD_FRAME_FINISH_OPTIONS = Object.freeze([...MURLAN_TABLE_FINISHES])
+
+export const BADUK_RING_FINISH_OPTIONS = Object.freeze([
+  {
+    id: 'chrome',
+    label: 'Chrome',
+    thumbnail: swatchThumbnail(['#dbe2ea', '#617185']),
+    color: '#e2e8f0',
+    metalness: 1,
+    roughness: 0.16
+  },
+  {
+    id: 'gold',
+    label: 'Gold',
+    thumbnail: swatchThumbnail(['#facc15', '#92400e']),
+    color: '#f6c453',
+    metalness: 0.98,
+    roughness: 0.24
+  },
+  {
+    id: 'aluminium',
+    label: 'Aluminium',
+    thumbnail: swatchThumbnail(['#cbd5e1', '#64748b']),
+    color: '#c7ced9',
+    metalness: 0.84,
+    roughness: 0.28
+  },
+  {
+    id: 'plasticBlack',
+    label: 'Plastic Black',
+    thumbnail: swatchThumbnail(['#0f172a', '#334155']),
+    color: '#1f2937',
+    metalness: 0.06,
+    roughness: 0.52
+  },
+  {
+    id: 'plasticWhite',
+    label: 'Plastic White',
+    thumbnail: swatchThumbnail(['#f8fafc', '#cbd5e1']),
+    color: '#f1f5f9',
+    metalness: 0.04,
+    roughness: 0.46
+  }
 ])
 
 export const BADUK_STONE_STYLES = Object.freeze([
@@ -55,6 +100,9 @@ export const BADUK_BATTLE_DEFAULT_UNLOCKS = Object.freeze({
   chairColor: [BADUK_CHAIR_OPTIONS[0]?.id],
   tables: [BADUK_TABLE_OPTIONS[0]?.id],
   tableFinish: [MURLAN_TABLE_FINISHES[0]?.id],
+  boardFinish: [BADUK_BOARD_FINISH_OPTIONS[0]?.id],
+  boardFrameFinish: [BADUK_BOARD_FRAME_FINISH_OPTIONS[0]?.id],
+  ringFinish: [BADUK_RING_FINISH_OPTIONS[0]?.id],
   boardTheme: [BADUK_BOARD_THEMES[0]?.id],
   boardLayout: [BADUK_BOARD_LAYOUTS[0]?.id],
   stoneStyle: [BADUK_STONE_STYLES[0]?.id],
@@ -65,6 +113,9 @@ export const BADUK_BATTLE_OPTION_LABELS = Object.freeze({
   chairColor: Object.freeze(BADUK_CHAIR_OPTIONS.reduce((acc, option) => ({ ...acc, [option.id]: option.label }), {})),
   tables: Object.freeze(BADUK_TABLE_OPTIONS.reduce((acc, option) => ({ ...acc, [option.id]: option.label }), {})),
   tableFinish: Object.freeze(MURLAN_TABLE_FINISHES.reduce((acc, option) => ({ ...acc, [option.id]: option.label }), {})),
+  boardFinish: Object.freeze(BADUK_BOARD_FINISH_OPTIONS.reduce((acc, option) => ({ ...acc, [option.id]: option.label }), {})),
+  boardFrameFinish: Object.freeze(BADUK_BOARD_FRAME_FINISH_OPTIONS.reduce((acc, option) => ({ ...acc, [option.id]: option.label }), {})),
+  ringFinish: Object.freeze(BADUK_RING_FINISH_OPTIONS.reduce((acc, option) => ({ ...acc, [option.id]: option.label }), {})),
   boardTheme: Object.freeze(BADUK_BOARD_THEMES.reduce((acc, option) => ({ ...acc, [option.id]: option.label }), {})),
   boardLayout: Object.freeze(BADUK_BOARD_LAYOUTS.reduce((acc, option) => ({ ...acc, [option.id]: option.label }), {})),
   stoneStyle: Object.freeze(BADUK_STONE_STYLES.reduce((acc, option) => ({ ...acc, [option.id]: option.label }), {})),
@@ -84,6 +135,39 @@ export const BADUK_BATTLE_STORE_ITEMS = [
     swatches: finish.swatches,
     thumbnail: finish.thumbnail,
     previewShape: 'table'
+  })),
+  ...BADUK_BOARD_FINISH_OPTIONS.slice(1).map((finish, idx) => ({
+    id: `baduk-board-finish-${finish.id}`,
+    type: 'boardFinish',
+    optionId: finish.id,
+    name: `${finish.label} Board`,
+    price: finish.price ?? 540 + idx * 35,
+    description: `${finish.label} octagon-table finish for the 4 in a Row board faces.`,
+    swatches: finish.swatches,
+    thumbnail: finish.thumbnail,
+    previewShape: 'board'
+  })),
+  ...BADUK_BOARD_FRAME_FINISH_OPTIONS.slice(1).map((finish, idx) => ({
+    id: `baduk-board-frame-${finish.id}`,
+    type: 'boardFrameFinish',
+    optionId: finish.id,
+    name: `${finish.label} Frame`,
+    price: (finish.price ?? 980) + 120 + idx * 30,
+    description: `Apply ${finish.label} octagon-table textures to the board frame and stand.`,
+    swatches: finish.swatches,
+    thumbnail: finish.thumbnail,
+    previewShape: 'board'
+  })),
+  ...BADUK_RING_FINISH_OPTIONS.slice(1).map((ring, idx) => ({
+    id: `baduk-ring-${ring.id}`,
+    type: 'ringFinish',
+    optionId: ring.id,
+    name: `${ring.label} Rings`,
+    price: 420 + idx * 40,
+    description: `${ring.label} ring trim around every board slot.`,
+    swatches: ring.id.includes('plastic') ? [ring.color] : [ring.color, '#111827'],
+    thumbnail: ring.thumbnail,
+    previewShape: 'piece'
   })),
   ...BADUK_TABLE_OPTIONS.slice(1).map((theme, idx) => ({
     id: `baduk-table-${theme.id}`,

--- a/webapp/src/pages/Games/BadukBattleRoyal.jsx
+++ b/webapp/src/pages/Games/BadukBattleRoyal.jsx
@@ -11,6 +11,9 @@ import { createMurlanStyleTable, applyTableMaterials } from '../../utils/murlanT
 import {
   BADUK_CHAIR_OPTIONS,
   BADUK_BOARD_THEMES,
+  BADUK_BOARD_FINISH_OPTIONS,
+  BADUK_BOARD_FRAME_FINISH_OPTIONS,
+  BADUK_RING_FINISH_OPTIONS,
   BADUK_STONE_STYLES,
   BADUK_TABLE_OPTIONS,
   BADUK_BATTLE_DEFAULT_LOADOUT,
@@ -22,6 +25,12 @@ import {
   POOL_ROYALE_HDRI_VARIANTS
 } from '../../config/poolRoyaleInventoryConfig.js';
 import { MURLAN_TABLE_FINISHES } from '../../config/murlanTableFinishes.js';
+import {
+  applyWoodTextures,
+  DEFAULT_WOOD_GRAIN_ID,
+  WOOD_FINISH_PRESETS,
+  WOOD_GRAIN_OPTIONS_BY_ID
+} from '../../utils/woodMaterials.js';
 import { getTelegramPhotoUrl, getTelegramUsername } from '../../utils/telegram.js';
 import BottomLeftIcons from '../../components/BottomLeftIcons.jsx';
 import AvatarTimer from '../../components/AvatarTimer.jsx';
@@ -275,6 +284,9 @@ export default function BadukBattleRoyal() {
     tableFinish: inventory.tableFinish?.[0] || MURLAN_TABLE_FINISHES[0]?.id,
     tableId: inventory.tables?.[0] || BADUK_BATTLE_DEFAULT_LOADOUT.tables?.[0] || BADUK_TABLE_OPTIONS[0]?.id,
     chairId: inventory.chairColor?.[0] || BADUK_BATTLE_DEFAULT_LOADOUT.chairColor?.[0] || BADUK_CHAIR_OPTIONS[0]?.id,
+    boardFinish: inventory.boardFinish?.[0] || BADUK_BATTLE_DEFAULT_LOADOUT.boardFinish?.[0] || BADUK_BOARD_FINISH_OPTIONS[0]?.id,
+    boardFrameFinish: inventory.boardFrameFinish?.[0] || BADUK_BATTLE_DEFAULT_LOADOUT.boardFrameFinish?.[0] || BADUK_BOARD_FRAME_FINISH_OPTIONS[0]?.id,
+    ringFinish: inventory.ringFinish?.[0] || BADUK_BATTLE_DEFAULT_LOADOUT.ringFinish?.[0] || BADUK_RING_FINISH_OPTIONS[0]?.id,
     boardTheme: inventory.boardTheme?.[0] || BADUK_BATTLE_DEFAULT_LOADOUT.boardTheme?.[0] || BADUK_BOARD_THEMES[0]?.id,
     stoneStyle: inventory.stoneStyle?.[0] || BADUK_BATTLE_DEFAULT_LOADOUT.stoneStyle?.[0] || BADUK_STONE_STYLES[0]?.id,
     hdriId: inventory.environmentHdri?.[0] || BADUK_BATTLE_DEFAULT_LOADOUT.environmentHdri?.[0] || POOL_ROYALE_DEFAULT_HDRI_ID,
@@ -446,8 +458,50 @@ export default function BadukBattleRoyal() {
 
     const boardGroup = new THREE.Group();
 
+    const selectedBoardTheme = BADUK_BOARD_THEMES.find((item) => item.id === appearance.boardTheme) || BADUK_BOARD_THEMES[0];
+    const selectedBoardFinish =
+      BADUK_BOARD_FINISH_OPTIONS.find((item) => item.id === appearance.boardFinish) || BADUK_BOARD_FINISH_OPTIONS[0];
+    const selectedBoardFrameFinish =
+      BADUK_BOARD_FRAME_FINISH_OPTIONS.find((item) => item.id === appearance.boardFrameFinish) || BADUK_BOARD_FRAME_FINISH_OPTIONS[0];
+    const selectedRingFinish =
+      BADUK_RING_FINISH_OPTIONS.find((item) => item.id === appearance.ringFinish) || BADUK_RING_FINISH_OPTIONS[0];
+
+    const boardFaceMat = new THREE.MeshStandardMaterial({ color: selectedBoardTheme?.tint || CONNECT4_PANEL, roughness: 0.74, metalness: 0.02, side: THREE.DoubleSide });
     const railMat = new THREE.MeshStandardMaterial({ color: CONNECT4_WOOD, roughness: 0.52, metalness: 0.08 });
     const trimMat = new THREE.MeshStandardMaterial({ color: CONNECT4_WOOD_DARK, roughness: 0.48, metalness: 0.1 });
+    const holeRimMat = new THREE.MeshStandardMaterial({
+      color: selectedRingFinish?.color || '#9a856e',
+      roughness: selectedRingFinish?.roughness ?? 0.52,
+      metalness: selectedRingFinish?.metalness ?? 0.04
+    });
+
+    const resolveWoodOption = (finish) => {
+      const preset = WOOD_FINISH_PRESETS.find((entry) => entry.id === finish?.woodOption?.presetId) || WOOD_FINISH_PRESETS[1] || WOOD_FINISH_PRESETS[0];
+      const grainId = finish?.woodOption?.grainId || DEFAULT_WOOD_GRAIN_ID;
+      const grain = WOOD_GRAIN_OPTIONS_BY_ID[grainId] || WOOD_GRAIN_OPTIONS_BY_ID[DEFAULT_WOOD_GRAIN_ID] || {};
+      return { preset, grain };
+    };
+    const applyWoodFinish = (material, finish, texturePart = 'rail', fallbackRepeat = { x: 1, y: 1 }) => {
+      if (!material) return;
+      const { preset, grain } = resolveWoodOption(finish);
+      const texture = grain?.[texturePart] || {};
+      applyWoodTextures(material, {
+        hue: preset?.hue ?? 32,
+        sat: preset?.sat ?? 0.34,
+        light: preset?.light ?? 0.7,
+        contrast: preset?.contrast ?? 0.52,
+        repeat: texture?.repeat ?? fallbackRepeat,
+        rotation: texture?.rotation ?? 0,
+        textureSize: texture?.textureSize,
+        mapUrl: texture?.mapUrl,
+        roughnessMapUrl: texture?.roughnessMapUrl,
+        normalMapUrl: texture?.normalMapUrl,
+        sharedKey: `baduk-${finish?.id || 'default'}-${texturePart}`
+      });
+    };
+    applyWoodFinish(boardFaceMat, selectedBoardFinish, 'frame', { x: 0.9, y: 0.9 });
+    applyWoodFinish(railMat, selectedBoardFrameFinish, 'rail', { x: 1, y: 1 });
+    applyWoodFinish(trimMat, selectedBoardFrameFinish, 'frame', { x: 1, y: 1 });
 
     const boardThickness = BOARD_FACE_THICKNESS;
     const boardBaseY = boardBottomY - BOARD_BASE_THICKNESS / 2;
@@ -469,7 +523,6 @@ export default function BadukBattleRoyal() {
     }
 
     const boardFaceGeo = new THREE.ExtrudeGeometry(boardShape, { depth: boardThickness, bevelEnabled: false, curveSegments: 42 });
-    const boardFaceMat = new THREE.MeshStandardMaterial({ color: CONNECT4_PANEL, roughness: 0.74, metalness: 0.02, side: THREE.DoubleSide });
     const boardFaceFront = new THREE.Mesh(boardFaceGeo, boardFaceMat);
     const boardFaceBack = boardFaceFront.clone();
     boardFaceFront.position.set(0, boardCenterY, BOARD_SLOT_GAP / 2 - boardThickness / 2);
@@ -516,7 +569,6 @@ export default function BadukBattleRoyal() {
     boardGroup.add(leftFoot, rightFoot);
 
     const holeRimGeo = new THREE.TorusGeometry(slotRadius * 0.97, 0.018, 16, 42);
-    const holeRimMat = new THREE.MeshStandardMaterial({ color: '#9a856e', roughness: 0.52, metalness: 0.04 });
     for (let r = 0; r < rows; r += 1) {
       for (let c = 0; c < cols; c += 1) {
         const [x, y] = worldFromCell(r, c);
@@ -643,7 +695,7 @@ export default function BadukBattleRoyal() {
       renderer.dispose();
       mount.removeChild(renderer.domElement);
     };
-  }, [rows, cols, appearance.boardTheme, appearance.tableId, appearance.tableFinish, appearance.chairId, appearance.graphics, boardWidth, boardHeight, boardCenterY, slotRadius, xStep, yStep]);
+  }, [rows, cols, appearance.boardTheme, appearance.boardFinish, appearance.boardFrameFinish, appearance.ringFinish, appearance.tableId, appearance.tableFinish, appearance.chairId, appearance.graphics, boardWidth, boardHeight, boardCenterY, slotRadius, xStep, yStep]);
 
   useEffect(() => {
     const scene = sceneRef.current;
@@ -808,6 +860,9 @@ export default function BadukBattleRoyal() {
     { key: 'tableId', label: 'Tables', options: BADUK_TABLE_OPTIONS.map((item) => ({ id: item.id, label: item.label, thumbnail: item.thumbnail })) },
     { key: 'chairId', label: 'Chairs', options: BADUK_CHAIR_OPTIONS.map((item) => ({ id: item.id, label: item.label, thumbnail: item.thumbnail })) },
     { key: 'tableFinish', label: 'Table Cloth', options: MURLAN_TABLE_FINISHES.map((item) => ({ id: item.id, label: item.label, thumbnail: item.thumbnail })) },
+    { key: 'boardFinish', label: 'Board Finish', options: BADUK_BOARD_FINISH_OPTIONS.map((item) => ({ id: item.id, label: item.label, thumbnail: item.thumbnail })) },
+    { key: 'boardFrameFinish', label: 'Board Frame', options: BADUK_BOARD_FRAME_FINISH_OPTIONS.map((item) => ({ id: item.id, label: item.label, thumbnail: item.thumbnail })) },
+    { key: 'ringFinish', label: 'Ring Finish', options: BADUK_RING_FINISH_OPTIONS.map((item) => ({ id: item.id, label: item.label, thumbnail: item.thumbnail })) },
     { key: 'hdriId', label: 'HDRI', options: POOL_ROYALE_HDRI_VARIANTS.map((item) => ({ id: item.id, label: item.name, thumbnail: item.thumbnail })) },
     { key: 'boardTheme', label: 'Board', options: BADUK_BOARD_THEMES.map((item) => ({ id: item.id, label: item.label, thumbnail: item.thumbnail })) },
     { key: 'stoneStyle', label: 'Pieces', options: BADUK_STONE_STYLES.map((item) => ({ id: item.id, label: item.label, thumbnail: item.thumbnail })) },

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -561,7 +561,19 @@ const USAGE_BY_TYPE = {
   },
   boardTheme: {
     title: 'Board theme',
-    description: 'Replaces the board texture and accents used in Chess matches.'
+    description: 'Replaces the board texture and accents used in board-based matches.'
+  },
+  boardFinish: {
+    title: 'Board finish',
+    description: 'Applies octagon-table finish textures to the 4 in a Row board faces.'
+  },
+  boardFrameFinish: {
+    title: 'Board frame',
+    description: 'Updates the 4 in a Row board frame and stand with octagon-table textures.'
+  },
+  ringFinish: {
+    title: 'Ring finish',
+    description: 'Changes the slot ring material (chrome, gold, aluminium, or plastic variants).'
   },
   headStyle: {
     title: 'Pawn heads',


### PR DESCRIPTION
### Motivation
- Provide players with purchasable octagon-table finishes for the 4-in-a-Row board so the board face, frame/stand and slot rings can be themed consistently with Pool/Octagon table assets.
- Expose metal/plastic ring variants (chrome, gold, aluminium, plastic black, plastic white) so users can personalise slot trim independently from the board finish.

### Description
- Added new config exports and option sets: `BADUK_BOARD_FINISH_OPTIONS`, `BADUK_BOARD_FRAME_FINISH_OPTIONS`, and `BADUK_RING_FINISH_OPTIONS` in `webapp/src/config/badukBattleInventoryConfig.js` and wired them into `BADUK_BATTLE_STORE_ITEMS`, default unlocks and `BADUK_BATTLE_OPTION_LABELS`.
- Created store item entries for board finishes, board frame finishes and ring finishes so they appear in the store feed and can be purchased by users (`baduk-board-finish-*`, `baduk-board-frame-*`, `baduk-ring-*`).
- Updated the 4-in-a-Row game renderer and customization UI (`webapp/src/pages/Games/BadukBattleRoyal.jsx`) to: add new `appearance` state fields (`boardFinish`, `boardFrameFinish`, `ringFinish`), resolve selected finishes, apply octagon table wood textures via `applyWoodTextures` for faces and frames, and set ring rim materials using the new ring variant properties.
- Updated store metadata labels/descriptions in `webapp/src/pages/Store.jsx` to include the new `boardFinish`, `boardFrameFinish` and `ringFinish` types for clear storefront copy.

### Testing
- Ran `npx eslint --no-ignore --no-warn-ignored webapp/src/config/badukBattleInventoryConfig.js` which passed after the fixups described in the change set. (Succeeded.)
- Ran a production build with `npm --prefix webapp run build` to validate bundling and asset generation; Vite build completed successfully and produced the application bundles. (Succeeded.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba2bddb7a4832984627e68687b26fa)