### PR TITLE
Improve 4-in-a-Row board fit, celebration sequence, and frame finish customization

### DIFF
--- a/webapp/src/config/badukBattleInventoryConfig.js
+++ b/webapp/src/config/badukBattleInventoryConfig.js
@@ -38,8 +38,6 @@ export const BADUK_BOARD_THEMES = Object.freeze([
 ])
 
 export const BADUK_BOARD_FINISH_OPTIONS = Object.freeze([...MURLAN_TABLE_FINISHES])
-export const BADUK_BOARD_FRAME_FINISH_OPTIONS = Object.freeze([...MURLAN_TABLE_FINISHES])
-
 export const BADUK_RING_FINISH_OPTIONS = Object.freeze([
   {
     id: 'chrome',
@@ -82,6 +80,20 @@ export const BADUK_RING_FINISH_OPTIONS = Object.freeze([
     roughness: 0.46
   }
 ])
+
+const BADUK_RING_FRAME_FINISH_OPTIONS = Object.freeze(
+  BADUK_RING_FINISH_OPTIONS.map((ring) => ({
+    id: `ringFrame-${ring.id}`,
+    label: `${ring.label} Frame`,
+    thumbnail: ring.thumbnail,
+    color: ring.color,
+    metalness: ring.metalness,
+    roughness: ring.roughness,
+    materialProfile: 'metal-ring'
+  }))
+)
+
+export const BADUK_BOARD_FRAME_FINISH_OPTIONS = Object.freeze([...MURLAN_TABLE_FINISHES, ...BADUK_RING_FRAME_FINISH_OPTIONS])
 
 export const BADUK_STONE_STYLES = Object.freeze([
   { id: 'traditional', label: 'Traditional Shell & Slate', thumbnail: '/assets/game-art/baduk-battle-royal/store/stones/traditional.svg', black: '#0a0a0d', white: '#f8fafc', blackRoughness: 0.28, whiteRoughness: 0.2 },
@@ -151,9 +163,11 @@ export const BADUK_BATTLE_STORE_ITEMS = [
     id: `baduk-board-frame-${finish.id}`,
     type: 'boardFrameFinish',
     optionId: finish.id,
-    name: `${finish.label} Frame`,
+    name: finish.materialProfile === 'metal-ring' ? finish.label : `${finish.label} Frame`,
     price: (finish.price ?? 980) + 120 + idx * 30,
-    description: `Apply ${finish.label} octagon-table textures to the board frame and stand.`,
+    description: finish.materialProfile === 'metal-ring'
+      ? `Apply ${finish.label} style to the board frame and stand.`
+      : `Apply ${finish.label} octagon-table textures to the board frame and stand.`,
     swatches: finish.swatches,
     thumbnail: finish.thumbnail,
     previewShape: 'board'

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1340,7 +1340,7 @@ input:focus {
 
 @keyframes coin-up {
   to {
-    transform: translate(calc(-50% + var(--dx)), 160px);
+    transform: translate(calc(-50% + var(--dx)), var(--dy, 160px));
     opacity: 0;
   }
 }

--- a/webapp/src/pages/Games/BadukBattleRoyal.jsx
+++ b/webapp/src/pages/Games/BadukBattleRoyal.jsx
@@ -43,7 +43,7 @@ const MODEL_SCALE = 0.75;
 const TABLE_RADIUS = 3.4 * MODEL_SCALE;
 const TABLE_HEIGHT = 1.2;
 const CHAIR_DISTANCE = TABLE_RADIUS + 1.3;
-const BOARD_TABLE_CLEARANCE = 0.02;
+const BOARD_TABLE_CLEARANCE = 0.07;
 const BOARD_BASE_THICKNESS = 0.12;
 const BOARD_FRAME_THICKNESS = 0.12;
 const BOARD_FACE_THICKNESS = 0.028;
@@ -57,6 +57,8 @@ const CONNECT4_BLUE = '#2d79d8';
 const DROP_PREVIEW_DELAY = 0.09;
 const DROP_BASE_DURATION = 0.2;
 const DROP_ROW_DURATION_STEP = 0.03;
+const AUDIO_GAIN_MULTIPLIER = 1.22;
+const WIN_CELEBRATION_DELAY_MS = 950;
 
 const GRAPHICS_PRESETS = Object.freeze([
   { id: 'balanced', label: 'Balanced', pixelRatioScale: 1, shadowMapSize: 1024 },
@@ -297,6 +299,7 @@ export default function BadukBattleRoyal() {
   const [turn, setTurn] = useState('player');
   const [winner, setWinner] = useState(null);
   const [showWinnerActions, setShowWinnerActions] = useState(false);
+  const [showWinnerCelebration, setShowWinnerCelebration] = useState(false);
   const [winningCells, setWinningCells] = useState([]);
   const [hoverCol, setHoverCol] = useState(null);
   const [showChat, setShowChat] = useState(false);
@@ -318,10 +321,15 @@ export default function BadukBattleRoyal() {
   useEffect(() => {
     if (!winner) {
       setShowWinnerActions(false);
+      setShowWinnerCelebration(false);
       return undefined;
     }
-    const timer = window.setTimeout(() => setShowWinnerActions(true), 5000);
-    return () => window.clearTimeout(timer);
+    const celebrationTimer = window.setTimeout(() => setShowWinnerCelebration(true), WIN_CELEBRATION_DELAY_MS);
+    const actionsTimer = window.setTimeout(() => setShowWinnerActions(true), WIN_CELEBRATION_DELAY_MS + 4100);
+    return () => {
+      window.clearTimeout(celebrationTimer);
+      window.clearTimeout(actionsTimer);
+    };
   }, [winner]);
 
   useEffect(() => {
@@ -334,6 +342,7 @@ export default function BadukBattleRoyal() {
     setTurn('player');
     setWinner(null);
     setWinningCells([]);
+    setShowWinnerCelebration(false);
   };
 
   const worldFromCell = (r, c) => [
@@ -351,11 +360,11 @@ export default function BadukBattleRoyal() {
     const amp = ctx.createGain();
     osc.frequency.value = frequency;
     osc.type = type;
-    amp.gain.value = gain;
+    amp.gain.value = gain * AUDIO_GAIN_MULTIPLIER;
     osc.connect(amp);
     amp.connect(ctx.destination);
     const now = ctx.currentTime;
-    amp.gain.setValueAtTime(gain, now);
+    amp.gain.setValueAtTime(gain * AUDIO_GAIN_MULTIPLIER, now);
     amp.gain.exponentialRampToValueAtTime(0.0001, now + duration);
     osc.start(now);
     osc.stop(now + duration);
@@ -405,6 +414,7 @@ export default function BadukBattleRoyal() {
     setTurn('player');
     setWinner(null);
     setWinningCells([]);
+    setShowWinnerCelebration(false);
     displayedBoardRef.current = createBoard(rows, cols);
   }, [rows, cols]);
 
@@ -500,8 +510,20 @@ export default function BadukBattleRoyal() {
       });
     };
     applyWoodFinish(boardFaceMat, selectedBoardFinish, 'frame', { x: 0.9, y: 0.9 });
-    applyWoodFinish(railMat, selectedBoardFrameFinish, 'rail', { x: 1, y: 1 });
-    applyWoodFinish(trimMat, selectedBoardFrameFinish, 'frame', { x: 1, y: 1 });
+    if (selectedBoardFrameFinish?.materialProfile === 'metal-ring') {
+      const frameColor = selectedBoardFrameFinish?.color || CONNECT4_WOOD;
+      const frameMetalness = selectedBoardFrameFinish?.metalness ?? 0.45;
+      const frameRoughness = selectedBoardFrameFinish?.roughness ?? 0.3;
+      railMat.color.set(frameColor);
+      railMat.metalness = frameMetalness;
+      railMat.roughness = frameRoughness;
+      trimMat.color.set(new THREE.Color(frameColor).multiplyScalar(0.88));
+      trimMat.metalness = Math.min(1, frameMetalness + 0.08);
+      trimMat.roughness = Math.max(0.16, frameRoughness - 0.08);
+    } else {
+      applyWoodFinish(railMat, selectedBoardFrameFinish, 'rail', { x: 1, y: 1 });
+      applyWoodFinish(trimMat, selectedBoardFrameFinish, 'frame', { x: 1, y: 1 });
+    }
 
     const boardThickness = BOARD_FACE_THICKNESS;
     const boardBaseY = boardBottomY - BOARD_BASE_THICKNESS / 2;
@@ -949,29 +971,34 @@ export default function BadukBattleRoyal() {
         </button>
       </div>
 
-      {winner && (
+      {winner && showWinnerCelebration && (
         <div className="pointer-events-none absolute inset-0 z-40 flex items-center justify-center">
           <div className="relative w-[min(24rem,90vw)] rounded-3xl border border-yellow-300/30 bg-transparent px-6 pb-6 pt-10 text-center">
             <div className="pointer-events-none absolute inset-0 overflow-hidden rounded-3xl">
-              {Array.from({ length: 14 }).map((_, i) => {
-                const angle = (Math.PI * 2 * i) / 14;
-                const x = Math.cos(angle) * 120;
-                const y = Math.sin(angle) * 96 - 24;
-                return (
-                  <span
-                    // eslint-disable-next-line react/no-array-index-key
-                    key={`coin-${i}`}
-                    className="absolute left-1/2 top-1/2 text-xl"
-                    style={{
-                      animation: `baduk-coin-burst 900ms ease-out ${i * 35}ms forwards`,
-                      '--x': `${x}px`,
-                      '--y': `${y}px`
-                    }}
-                  >
-                    🪙
-                  </span>
-                );
-              })}
+              <div className="coin-burst !left-1/2 !bottom-1/2">
+                {Array.from({ length: 28 }).map((_, i) => {
+                  const dx = (Math.random() - 0.5) * 250;
+                  const dy = 120 + Math.random() * 120;
+                  const delay = Math.random() * 0.22;
+                  const dur = 0.72 + Math.random() * 0.34;
+                  return (
+                    <img
+                      // eslint-disable-next-line react/no-array-index-key
+                      key={`coin-${i}`}
+                      src="/assets/icons/ezgif-54c96d8a9b9236.webp"
+                      alt=""
+                      className="coin-img"
+                      style={{
+                        '--dx': `${dx}px`,
+                        '--dy': `${dy}px`,
+                        '--delay': `${delay}s`,
+                        '--dur': `${dur}s`,
+                        animationDelay: `${i * 18}ms`
+                      }}
+                    />
+                  );
+                })}
+              </div>
             </div>
             <div className="mx-auto mb-3 flex h-20 w-20 items-center justify-center overflow-hidden rounded-full border-4 border-yellow-300/60 bg-white/10 text-4xl">
               {winner === 'player' ? <img src={avatar || '/assets/icons/profile.svg'} alt="winner avatar" className="h-full w-full object-cover" /> : '🤖'}
@@ -989,13 +1016,6 @@ export default function BadukBattleRoyal() {
         </div>
       )}
 
-      <style>
-        {`@keyframes baduk-coin-burst {
-          0% { opacity: 0; transform: translate(-50%, -50%) scale(0.4); }
-          15% { opacity: 1; }
-          100% { opacity: 0; transform: translate(calc(-50% + var(--x, 0px)), calc(-50% + var(--y, -110px))) scale(1.25); }
-        }`}
-      </style>
 
       <BottomLeftIcons onGift={() => setShowGift(true)} showInfo={false} showChat={false} showMute={false} className="fixed right-3 bottom-28 z-50 flex flex-col gap-4" buttonClassName="icon-only-button pointer-events-auto flex h-11 w-11 items-center justify-center text-white/90" iconClassName="text-[1.65rem] leading-none" labelClassName="sr-only" giftIcon="🎁" order={['gift']} />
       <BottomLeftIcons onChat={() => setShowChat(true)} showInfo={false} showGift={false} showMute={false} className="fixed left-3 bottom-28 z-50 flex flex-col" buttonClassName="icon-only-button pointer-events-auto flex h-11 w-11 items-center justify-center text-white/90" iconClassName="text-[1.65rem] leading-none" labelClassName="sr-only" chatIcon="💬" order={['chat']} />


### PR DESCRIPTION
### Motivation

- Make the 4-in-a-Row board visually sit higher so the bottom of the frame holder better contacts the table surface.  
- Support using the same TPC coin burst and a clearer celebration sequence when a 4-in-a-row is completed.  
- Expose ring/metal/plastic frame finishes as purchasable store options and apply appropriate material profiles to the board frame.  
- Slightly increase audio feedback loudness for clearer player feedback.

### Description

- Raised the board placement by increasing `BOARD_TABLE_CLEARANCE` and related layout so the frame base visually sits higher in the scene (`webapp/src/pages/Games/BadukBattleRoyal.jsx`).  
- Added `AUDIO_GAIN_MULTIPLIER` and applied it to the local `playTone` calls to modestly increase SFX loudness (`BadukBattleRoyal.jsx`).  
- Reworked the win flow to show a connected-4 highlight first, then trigger a delayed winner celebration overlay and later show action buttons using `showWinnerCelebration` + timed `setTimeout`s (`BadukBattleRoyal.jsx`).  
- Replaced the emoji burst with the app's TPC coin-image burst (reusing `.coin-burst`/`.coin-img` animation) and made the coin vertical travel configurable; updated `webapp/src/index.css` for `--dy` support and swapped the overlay markup to emit coin images on win (`BadukBattleRoyal.jsx`, `index.css`).  
- Added ring-derived frame finish options (`BADUK_RING_FRAME_FINISH_OPTIONS`) and merged them into `BADUK_BOARD_FRAME_FINISH_OPTIONS` so metal/plastic ring styles can be bought/used separately, and updated store item labeling/description logic to handle metal-profile finishes (`webapp/src/config/badukBattleInventoryConfig.js`).  
- Updated frame rendering logic to apply metallic/plastic material properties when a metal-ring profile is selected, and fall back to the existing wood texture pipeline otherwise (`BadukBattleRoyal.jsx`).

### Testing

- Ran linting targeted at the modified config with `npx eslint --no-ignore webapp/src/config/badukBattleInventoryConfig.js`, which completed successfully.  
- Built the web app with `npm --prefix webapp run build`, and the Vite production build completed successfully (build warnings about chunking are pre-existing and informational).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba3e6f1018832995863a4e206dd261)