### PR TITLE
Baduk (4-in-row): raise board, add frame ring finishes, louder SFX & TPC coin burst

### DIFF
--- a/webapp/src/config/badukBattleInventoryConfig.js
+++ b/webapp/src/config/badukBattleInventoryConfig.js
@@ -38,7 +38,6 @@ export const BADUK_BOARD_THEMES = Object.freeze([
 ])
 
 export const BADUK_BOARD_FINISH_OPTIONS = Object.freeze([...MURLAN_TABLE_FINISHES])
-export const BADUK_BOARD_FRAME_FINISH_OPTIONS = Object.freeze([...MURLAN_TABLE_FINISHES])
 
 export const BADUK_RING_FINISH_OPTIONS = Object.freeze([
   {
@@ -81,6 +80,21 @@ export const BADUK_RING_FINISH_OPTIONS = Object.freeze([
     metalness: 0.04,
     roughness: 0.46
   }
+])
+
+const BADUK_FRAME_RING_FINISH_OPTIONS = Object.freeze(
+  BADUK_RING_FINISH_OPTIONS.map((ring) => ({
+    id: `ringFrame-${ring.id}`,
+    label: `${ring.label} Frame`,
+    thumbnail: ring.thumbnail,
+    ringOption: ring,
+    description: `${ring.label} metal/plastic finish for the board frame holder.`
+  }))
+)
+
+export const BADUK_BOARD_FRAME_FINISH_OPTIONS = Object.freeze([
+  ...MURLAN_TABLE_FINISHES,
+  ...BADUK_FRAME_RING_FINISH_OPTIONS
 ])
 
 export const BADUK_STONE_STYLES = Object.freeze([

--- a/webapp/src/pages/Games/BadukBattleRoyal.jsx
+++ b/webapp/src/pages/Games/BadukBattleRoyal.jsx
@@ -38,12 +38,13 @@ import GiftPopup from '../../components/GiftPopup.jsx';
 import QuickMessagePopup from '../../components/QuickMessagePopup.jsx';
 import { badukBattleAccountId, getBadukBattleInventory } from '../../utils/badukBattleInventory.js';
 import { applyRendererSRGB } from '../../utils/colorSpace.js';
+import coinConfetti from '../../utils/coinConfetti';
 
 const MODEL_SCALE = 0.75;
 const TABLE_RADIUS = 3.4 * MODEL_SCALE;
 const TABLE_HEIGHT = 1.2;
 const CHAIR_DISTANCE = TABLE_RADIUS + 1.3;
-const BOARD_TABLE_CLEARANCE = 0.02;
+const BOARD_TABLE_CLEARANCE = 0.12;
 const BOARD_BASE_THICKNESS = 0.12;
 const BOARD_FRAME_THICKNESS = 0.12;
 const BOARD_FACE_THICKNESS = 0.028;
@@ -57,6 +58,7 @@ const CONNECT4_BLUE = '#2d79d8';
 const DROP_PREVIEW_DELAY = 0.09;
 const DROP_BASE_DURATION = 0.2;
 const DROP_ROW_DURATION_STEP = 0.03;
+const WINNER_OVERLAY_DELAY_MS = 900;
 
 const GRAPHICS_PRESETS = Object.freeze([
   { id: 'balanced', label: 'Balanced', pixelRatioScale: 1, shadowMapSize: 1024 },
@@ -297,6 +299,7 @@ export default function BadukBattleRoyal() {
   const [turn, setTurn] = useState('player');
   const [winner, setWinner] = useState(null);
   const [showWinnerActions, setShowWinnerActions] = useState(false);
+  const [showWinnerOverlay, setShowWinnerOverlay] = useState(false);
   const [winningCells, setWinningCells] = useState([]);
   const [hoverCol, setHoverCol] = useState(null);
   const [showChat, setShowChat] = useState(false);
@@ -318,11 +321,21 @@ export default function BadukBattleRoyal() {
   useEffect(() => {
     if (!winner) {
       setShowWinnerActions(false);
+      setShowWinnerOverlay(false);
       return undefined;
     }
+    const overlayTimer = window.setTimeout(() => setShowWinnerOverlay(true), WINNER_OVERLAY_DELAY_MS);
     const timer = window.setTimeout(() => setShowWinnerActions(true), 5000);
-    return () => window.clearTimeout(timer);
+    return () => {
+      window.clearTimeout(overlayTimer);
+      window.clearTimeout(timer);
+    };
   }, [winner]);
+
+  useEffect(() => {
+    if (!showWinnerOverlay || !winner || winner === 'draw') return;
+    coinConfetti(44, '/assets/icons/ezgif-54c96d8a9b9236.webp');
+  }, [showWinnerOverlay, winner]);
 
   useEffect(() => {
     winningCellsRef.current = winningCells;
@@ -334,6 +347,7 @@ export default function BadukBattleRoyal() {
     setTurn('player');
     setWinner(null);
     setWinningCells([]);
+    setShowWinnerOverlay(false);
   };
 
   const worldFromCell = (r, c) => [
@@ -342,7 +356,7 @@ export default function BadukBattleRoyal() {
     0
   ];
 
-  const playTone = (frequency = 430, duration = 0.08, type = 'triangle', gain = 0.02) => {
+  const playTone = (frequency = 430, duration = 0.08, type = 'triangle', gain = 0.026) => {
     const ACtx = window.AudioContext || window.webkitAudioContext;
     if (!ACtx) return;
     if (!audioCtxRef.current) audioCtxRef.current = new ACtx();
@@ -500,8 +514,23 @@ export default function BadukBattleRoyal() {
       });
     };
     applyWoodFinish(boardFaceMat, selectedBoardFinish, 'frame', { x: 0.9, y: 0.9 });
-    applyWoodFinish(railMat, selectedBoardFrameFinish, 'rail', { x: 1, y: 1 });
-    applyWoodFinish(trimMat, selectedBoardFrameFinish, 'frame', { x: 1, y: 1 });
+    const applyFrameFinish = (material, finish, texturePart = 'frame') => {
+      if (finish?.ringOption) {
+        material.map = null;
+        material.normalMap = null;
+        material.aoMap = null;
+        material.roughnessMap = null;
+        material.metalnessMap = null;
+        material.color = new THREE.Color(finish.ringOption.color || '#c7ced9');
+        material.metalness = finish.ringOption.metalness ?? 0.7;
+        material.roughness = finish.ringOption.roughness ?? 0.35;
+        material.needsUpdate = true;
+        return;
+      }
+      applyWoodFinish(material, finish, texturePart, { x: 1, y: 1 });
+    };
+    applyFrameFinish(railMat, selectedBoardFrameFinish, 'rail');
+    applyFrameFinish(trimMat, selectedBoardFrameFinish, 'frame');
 
     const boardThickness = BOARD_FACE_THICKNESS;
     const boardBaseY = boardBottomY - BOARD_BASE_THICKNESS / 2;
@@ -734,25 +763,25 @@ export default function BadukBattleRoyal() {
   const playColumn = (col, token) => {
     const row = getDropRow(board, col);
     if (row < 0) {
-      playTone(180, 0.05, 'sawtooth', 0.012);
+      playTone(180, 0.05, 'sawtooth', 0.016);
       return false;
     }
     const next = cloneBoard(board);
     next[row][col] = token;
     setBoard(next);
-    playTone(token === 'player' ? 520 : 300, 0.09, 'triangle', 0.03);
+    playTone(token === 'player' ? 520 : 300, 0.09, 'triangle', 0.038);
 
     const winning = getWinningCells(next, token);
     if (winning) {
       setWinner(token);
       setWinningCells(winning);
-      playTone(token === 'player' ? 760 : 220, 0.2, 'square', 0.03);
+      playTone(token === 'player' ? 760 : 220, 0.2, 'square', 0.04);
       return true;
     }
     if (isFull(next)) {
       setWinner('draw');
       setWinningCells([]);
-      playTone(200, 0.18, 'triangle', 0.02);
+      playTone(200, 0.18, 'triangle', 0.026);
       return true;
     }
     setTurn(token === 'player' ? 'ai' : 'player');
@@ -949,53 +978,24 @@ export default function BadukBattleRoyal() {
         </button>
       </div>
 
-      {winner && (
+      {winner && showWinnerOverlay && (
         <div className="pointer-events-none absolute inset-0 z-40 flex items-center justify-center">
           <div className="relative w-[min(24rem,90vw)] rounded-3xl border border-yellow-300/30 bg-transparent px-6 pb-6 pt-10 text-center">
-            <div className="pointer-events-none absolute inset-0 overflow-hidden rounded-3xl">
-              {Array.from({ length: 14 }).map((_, i) => {
-                const angle = (Math.PI * 2 * i) / 14;
-                const x = Math.cos(angle) * 120;
-                const y = Math.sin(angle) * 96 - 24;
-                return (
-                  <span
-                    // eslint-disable-next-line react/no-array-index-key
-                    key={`coin-${i}`}
-                    className="absolute left-1/2 top-1/2 text-xl"
-                    style={{
-                      animation: `baduk-coin-burst 900ms ease-out ${i * 35}ms forwards`,
-                      '--x': `${x}px`,
-                      '--y': `${y}px`
-                    }}
-                  >
-                    🪙
-                  </span>
-                );
-              })}
-            </div>
             <div className="mx-auto mb-3 flex h-20 w-20 items-center justify-center overflow-hidden rounded-full border-4 border-yellow-300/60 bg-white/10 text-4xl">
               {winner === 'player' ? <img src={avatar || '/assets/icons/profile.svg'} alt="winner avatar" className="h-full w-full object-cover" /> : '🤖'}
             </div>
             <p className="text-xs uppercase tracking-[0.26em] text-yellow-300">Winner</p>
             <h2 className="mt-2 text-2xl font-bold text-white">{winner === 'draw' ? 'Draw Game' : winner === 'player' ? `${username} Wins!` : 'AI Rival Wins!'}</h2>
-            <p className="mt-2 text-sm text-white/75">{winner === 'draw' ? 'No more moves left.' : '4 pieces connected and highlighted.'}</p>
+            <p className="mt-2 text-sm text-white/75">{winner === 'draw' ? 'No more moves left.' : '4 connected pieces are highlighted first, then the TPC burst appears.'}</p>
             {showWinnerActions && (
               <div className="pointer-events-auto mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2">
-                <button type="button" onClick={resetMatch} className="rounded-xl border border-cyan-300/70 bg-transparent px-4 py-2 text-sm font-semibold text-cyan-100">Play Again</button>
+                <button type="button" onClick={() => { resetMatch(); setShowWinnerOverlay(false); }} className="rounded-xl border border-cyan-300/70 bg-transparent px-4 py-2 text-sm font-semibold text-cyan-100">Play Again</button>
                 <button type="button" onClick={() => navigate('/games/badukbattleroyal/lobby')} className="rounded-xl border border-white/45 bg-transparent px-4 py-2 text-sm font-semibold text-white">Return Lobby</button>
               </div>
             )}
           </div>
         </div>
       )}
-
-      <style>
-        {`@keyframes baduk-coin-burst {
-          0% { opacity: 0; transform: translate(-50%, -50%) scale(0.4); }
-          15% { opacity: 1; }
-          100% { opacity: 0; transform: translate(calc(-50% + var(--x, 0px)), calc(-50% + var(--y, -110px))) scale(1.25); }
-        }`}
-      </style>
 
       <BottomLeftIcons onGift={() => setShowGift(true)} showInfo={false} showChat={false} showMute={false} className="fixed right-3 bottom-28 z-50 flex flex-col gap-4" buttonClassName="icon-only-button pointer-events-auto flex h-11 w-11 items-center justify-center text-white/90" iconClassName="text-[1.65rem] leading-none" labelClassName="sr-only" giftIcon="🎁" order={['gift']} />
       <BottomLeftIcons onChat={() => setShowChat(true)} showInfo={false} showGift={false} showMute={false} className="fixed left-3 bottom-28 z-50 flex flex-col" buttonClassName="icon-only-button pointer-events-auto flex h-11 w-11 items-center justify-center text-white/90" iconClassName="text-[1.65rem] leading-none" labelClassName="sr-only" chatIcon="💬" order={['chat']} />


### PR DESCRIPTION
### Motivation
- Visually align the 4-in-row board so the bottom of the frame holder sits flush with the table and improve polish of the winner feedback.
- Allow the same metal/plastic finish family used for slot rings to be applied to the board frame so users can customize the frame separately.
- Make in-game audio feedback slightly louder and replace the local emoji burst with the shared TPC coin burst used elsewhere.

### Description
- Raised the board assembly by increasing `BOARD_TABLE_CLEARANCE` from `0.02` to `0.12` to make the frame holder visually contact the table surface (`webapp/src/pages/Games/BadukBattleRoyal.jsx`).
- Added ring-derived frame finish options by creating `BADUK_FRAME_RING_FINISH_OPTIONS` and merging them into `BADUK_BOARD_FRAME_FINISH_OPTIONS` so frame finishes can be chosen from wood or ring-style metallic/plastic finishes (`webapp/src/config/badukBattleInventoryConfig.js`).
- Updated frame material application with `applyFrameFinish` to support both wood texture finishes and ring-derived finishes (uses the ring option PBR values when present) (`webapp/src/pages/Games/BadukBattleRoyal.jsx`).
- Increased SFX gain values and per-event gains in `playTone` and calls for invalid/drop/win/draw sounds to make audio feedback louder (`webapp/src/pages/Games/BadukBattleRoyal.jsx`).
- Changed winner flow: highlight the 4 winning cells first, then show a delayed winner overlay controlled by `WINNER_OVERLAY_DELAY_MS` and `showWinnerOverlay`, and trigger the shared `coinConfetti` burst (TPC coin burst) instead of the previous inline emoji burst; removed the old inline keyframe burst markup (`webapp/src/pages/Games/BadukBattleRoyal.jsx`).
- Wired `coinConfetti` import and used the shared confetti utility for the reward burst used in mining/tasks pages (`webapp/src/pages/Games/BadukBattleRoyal.jsx`).

### Testing
- Ran `npx eslint` on the modified files which produced warnings but no blocking errors.
- Built the web app with `npm --prefix webapp run build` and the build completed successfully.
- Manual verification in code that winning cells are still scaled/pulsed before the overlay is shown and that `coinConfetti` is invoked when the overlay appears.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba3e6f1018832995863a4e206dd261)