### PR TITLE
Fix 4-in-row customization updates without full scene reload

### DIFF
--- a/webapp/src/config/badukBattleInventoryConfig.js
+++ b/webapp/src/config/badukBattleInventoryConfig.js
@@ -1,5 +1,6 @@
-import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from './murlanThemes.js'
+import { MURLAN_TABLE_THEMES } from './murlanThemes.js'
 import { MURLAN_TABLE_FINISHES } from './murlanTableFinishes.js'
+import { CHESS_CHAIR_OPTIONS } from './chessBattleInventoryConfig.js'
 import {
   POOL_ROYALE_DEFAULT_HDRI_ID,
   POOL_ROYALE_HDRI_VARIANTS
@@ -16,7 +17,9 @@ const mapStoolThemeToChair = (theme) => ({
   preserveMaterials: theme.preserveMaterials ?? theme.source === 'polyhaven'
 })
 
-export const BADUK_CHAIR_OPTIONS = Object.freeze([...MURLAN_STOOL_THEMES.map(mapStoolThemeToChair)])
+export const BADUK_CHAIR_OPTIONS = Object.freeze([
+  ...CHESS_CHAIR_OPTIONS.map(mapStoolThemeToChair)
+])
 export const BADUK_TABLE_OPTIONS = Object.freeze([...MURLAN_TABLE_THEMES])
 
 export const BADUK_BOARD_LAYOUTS = Object.freeze([
@@ -25,11 +28,6 @@ export const BADUK_BOARD_LAYOUTS = Object.freeze([
 ])
 
 export const BADUK_BOARD_THEMES = Object.freeze([
-  { id: 'classicKaya', label: 'Classic Kaya', thumbnail: '/assets/game-art/baduk-battle-royal/store/boards/classicKaya.svg', tint: '#e2ae68', grid: '#2a1709' },
-  { id: 'midnightBamboo', label: 'Midnight Bamboo', thumbnail: '/assets/game-art/baduk-battle-royal/store/boards/midnightBamboo.svg', tint: '#a4773f', grid: '#201309' },
-  { id: 'stoneTemple', label: 'Stone Temple', thumbnail: '/assets/game-art/baduk-battle-royal/store/boards/stoneTemple.svg', tint: '#c6b391', grid: '#2c2c2c' },
-  { id: 'sakuraDawn', label: 'Sakura Dawn', thumbnail: '/assets/game-art/baduk-battle-royal/store/boards/sakuraDawn.svg', tint: '#d2a084', grid: '#4d2f2d' },
-  { id: 'volcanicAsh', label: 'Volcanic Ash', thumbnail: '/assets/game-art/baduk-battle-royal/store/boards/volcanicAsh.svg', tint: '#8e765f', grid: '#1a1715' },
   { id: 'auroraMint', label: 'Aurora Mint', thumbnail: swatchThumbnail(['#4ade80', '#14532d']), tint: '#4ade80', grid: '#14532d' },
   { id: 'royalSapphire', label: 'Royal Sapphire', thumbnail: swatchThumbnail(['#3b82f6', '#0f172a']), tint: '#3b82f6', grid: '#0f172a' },
   { id: 'desertCopper', label: 'Desert Copper', thumbnail: swatchThumbnail(['#f59e0b', '#78350f']), tint: '#f59e0b', grid: '#78350f' },

--- a/webapp/src/pages/Games/BadukBattleRoyal.jsx
+++ b/webapp/src/pages/Games/BadukBattleRoyal.jsx
@@ -22,7 +22,8 @@ import {
 } from '../../config/badukBattleInventoryConfig.js';
 import {
   POOL_ROYALE_DEFAULT_HDRI_ID,
-  POOL_ROYALE_HDRI_VARIANTS
+  POOL_ROYALE_HDRI_VARIANTS,
+  POOL_ROYALE_HDRI_VARIANT_MAP
 } from '../../config/poolRoyaleInventoryConfig.js';
 import { MURLAN_TABLE_FINISHES } from '../../config/murlanTableFinishes.js';
 import {
@@ -44,7 +45,7 @@ const MODEL_SCALE = 0.75;
 const TABLE_RADIUS = 3.4 * MODEL_SCALE;
 const TABLE_HEIGHT = 1.2;
 const CHAIR_DISTANCE = TABLE_RADIUS + 1.3;
-const BOARD_TABLE_CLEARANCE = 0.12;
+const BOARD_TABLE_CLEARANCE = 0.2;
 const BOARD_BASE_THICKNESS = 0.12;
 const BOARD_FRAME_THICKNESS = 0.12;
 const BOARD_FACE_THICKNESS = 0.028;
@@ -215,6 +216,12 @@ async function resolveHdriUrl(variant) {
   }
 }
 
+const resolveHdriVariant = (value) =>
+  POOL_ROYALE_HDRI_VARIANT_MAP[value] ||
+  POOL_ROYALE_HDRI_VARIANTS.find((variant) => variant.id === value) ||
+  POOL_ROYALE_HDRI_VARIANTS.find((variant) => variant.id === POOL_ROYALE_DEFAULT_HDRI_ID) ||
+  POOL_ROYALE_HDRI_VARIANTS[0];
+
 function createChair(chairColor = '#7f1d1d', legColor = '#111827') {
   const group = new THREE.Group();
   const seat = new THREE.Mesh(new THREE.BoxGeometry(0.85, 0.09, 0.92), new THREE.MeshStandardMaterial({ color: chairColor, roughness: 0.5 }));
@@ -257,6 +264,16 @@ export default function BadukBattleRoyal() {
   const rayRef = useRef(new THREE.Raycaster());
   const pointerRef = useRef(new THREE.Vector2());
   const envRef = useRef({ map: null, skybox: null, hdriId: null });
+  const tableRef = useRef(null);
+  const chairsRef = useRef([]);
+  const boardMaterialsRef = useRef({
+    face: null,
+    rail: null,
+    trim: null,
+    holeRim: null
+  });
+  const keyLightRef = useRef(null);
+  const tableThemeIdRef = useRef(null);
   const audioCtxRef = useRef(null);
   const [params] = useSearchParams();
   const navigate = useNavigate();
@@ -458,16 +475,20 @@ export default function BadukBattleRoyal() {
     key.position.set(2.2, 4.5, 1.6);
     key.castShadow = true;
     scene.add(key);
+    keyLightRef.current = key;
 
     const table = createMurlanStyleTable({ arena: scene, renderer, tableRadius: TABLE_RADIUS, tableHeight: TABLE_HEIGHT, tableThemeId: appearance.tableId });
-    applyTableMaterials(table.parts, MURLAN_TABLE_FINISHES.find((f) => f.id === appearance.tableFinish) || MURLAN_TABLE_FINISHES[0]);
+    tableRef.current = table;
+    tableThemeIdRef.current = appearance.tableId;
+    applyTableMaterials(table.parts || table.materials, MURLAN_TABLE_FINISHES.find((f) => f.id === appearance.tableFinish) || MURLAN_TABLE_FINISHES[0]);
 
     const chairTheme = BADUK_CHAIR_OPTIONS.find((item) => item.id === appearance.chairId) || BADUK_CHAIR_OPTIONS[0];
-    [Math.PI / 2, -Math.PI / 2].forEach((angle) => {
+    chairsRef.current = [Math.PI / 2, -Math.PI / 2].map((angle) => {
       const chair = createChair(chairTheme.primary, chairTheme.legColor);
       chair.position.set(Math.cos(angle) * CHAIR_DISTANCE, 0, Math.sin(angle) * CHAIR_DISTANCE);
       chair.lookAt(0, TABLE_HEIGHT, 0);
       scene.add(chair);
+      return chair;
     });
 
     const boardGroup = new THREE.Group();
@@ -488,6 +509,7 @@ export default function BadukBattleRoyal() {
       roughness: selectedRingFinish?.roughness ?? 0.52,
       metalness: selectedRingFinish?.metalness ?? 0.04
     });
+    boardMaterialsRef.current = { face: boardFaceMat, rail: railMat, trim: trimMat, holeRim: holeRimMat };
 
     const resolveWoodOption = (finish) => {
       const preset = WOOD_FINISH_PRESETS.find((entry) => entry.id === finish?.woodOption?.presetId) || WOOD_FINISH_PRESETS[1] || WOOD_FINISH_PRESETS[0];
@@ -721,17 +743,21 @@ export default function BadukBattleRoyal() {
     return () => {
       cancelAnimationFrame(raf);
       window.removeEventListener('resize', onResize);
+      tableRef.current = null;
+      chairsRef.current = [];
+      boardMaterialsRef.current = { face: null, rail: null, trim: null, holeRim: null };
+      keyLightRef.current = null;
       renderer.dispose();
       mount.removeChild(renderer.domElement);
     };
-  }, [rows, cols, appearance.boardTheme, appearance.boardFinish, appearance.boardFrameFinish, appearance.ringFinish, appearance.tableId, appearance.tableFinish, appearance.chairId, appearance.graphics, boardWidth, boardHeight, boardCenterY, slotRadius, xStep, yStep]);
+  }, [rows, cols, boardWidth, boardHeight, boardCenterY, slotRadius, xStep, yStep]);
 
   useEffect(() => {
     const scene = sceneRef.current;
     if (!scene || envRef.current.hdriId === appearance.hdriId) return;
     let cancelled = false;
     const apply = async () => {
-      const variant = POOL_ROYALE_HDRI_VARIANTS.find((h) => h.id === appearance.hdriId) || POOL_ROYALE_HDRI_VARIANTS[0];
+      const variant = resolveHdriVariant(appearance.hdriId);
       const url = await resolveHdriUrl(variant);
       const loader = url.toLowerCase().endsWith('.exr') ? new EXRLoader() : new RGBELoader();
       const envMap = await loader.loadAsync(url);
@@ -747,6 +773,96 @@ export default function BadukBattleRoyal() {
     void apply();
     return () => { cancelled = true; };
   }, [appearance.hdriId]);
+
+  useEffect(() => {
+    const scene = sceneRef.current;
+    const renderer = rendererRef.current;
+    if (!scene || !renderer || !appearance.tableId || appearance.tableId === tableThemeIdRef.current) return;
+    const existing = tableRef.current;
+    existing?.dispose?.();
+    const nextTable = createMurlanStyleTable({
+      arena: scene,
+      renderer,
+      tableRadius: TABLE_RADIUS,
+      tableHeight: TABLE_HEIGHT,
+      tableThemeId: appearance.tableId
+    });
+    tableRef.current = nextTable;
+    tableThemeIdRef.current = appearance.tableId;
+    const finish = MURLAN_TABLE_FINISHES.find((entry) => entry.id === appearance.tableFinish) || MURLAN_TABLE_FINISHES[0];
+    applyTableMaterials(nextTable.parts || nextTable.materials, finish);
+  }, [appearance.tableId, appearance.tableFinish]);
+
+  useEffect(() => {
+    const table = tableRef.current;
+    if (table?.parts || table?.materials) {
+      const finish = MURLAN_TABLE_FINISHES.find((entry) => entry.id === appearance.tableFinish) || MURLAN_TABLE_FINISHES[0];
+      applyTableMaterials(table.parts || table.materials, finish);
+    }
+
+    const chairTheme = BADUK_CHAIR_OPTIONS.find((item) => item.id === appearance.chairId) || BADUK_CHAIR_OPTIONS[0];
+    const seatColor = new THREE.Color(chairTheme.primary || '#7f1d1d');
+    const legColor = new THREE.Color(chairTheme.legColor || '#111827');
+    chairsRef.current.forEach((chair) => {
+      chair?.traverse?.((obj) => {
+        if (!obj?.isMesh) return;
+        const material = Array.isArray(obj.material) ? obj.material[0] : obj.material;
+        if (!material?.color) return;
+        const lowerName = (obj.name || '').toLowerCase();
+        const useLegColor = lowerName.includes('leg');
+        material.color.copy(useLegColor ? legColor : seatColor);
+        material.needsUpdate = true;
+      });
+    });
+  }, [appearance.tableFinish, appearance.chairId]);
+
+  useEffect(() => {
+    const boardTheme = BADUK_BOARD_THEMES.find((item) => item.id === appearance.boardTheme) || BADUK_BOARD_THEMES[0];
+    const boardFinish = BADUK_BOARD_FINISH_OPTIONS.find((item) => item.id === appearance.boardFinish) || BADUK_BOARD_FINISH_OPTIONS[0];
+    const frameFinish = BADUK_BOARD_FRAME_FINISH_OPTIONS.find((item) => item.id === appearance.boardFrameFinish) || BADUK_BOARD_FRAME_FINISH_OPTIONS[0];
+    const ringFinish = BADUK_RING_FINISH_OPTIONS.find((item) => item.id === appearance.ringFinish) || BADUK_RING_FINISH_OPTIONS[0];
+    const mats = boardMaterialsRef.current;
+    if (!mats.face || !mats.rail || !mats.trim || !mats.holeRim) return;
+
+    mats.face.color.set(boardTheme?.tint || boardFinish?.swatches?.[0] || CONNECT4_PANEL);
+    if (frameFinish?.ringOption) {
+      [mats.rail, mats.trim].forEach((mat) => {
+        mat.map = null;
+        mat.normalMap = null;
+        mat.aoMap = null;
+        mat.roughnessMap = null;
+        mat.metalnessMap = null;
+        mat.color = new THREE.Color(frameFinish.ringOption.color || '#c7ced9');
+        mat.metalness = frameFinish.ringOption.metalness ?? 0.7;
+        mat.roughness = frameFinish.ringOption.roughness ?? 0.35;
+        mat.needsUpdate = true;
+      });
+    } else {
+      mats.rail.color.set(frameFinish?.swatches?.[0] || CONNECT4_WOOD);
+      mats.trim.color.set(frameFinish?.swatches?.[1] || CONNECT4_WOOD_DARK);
+      mats.rail.metalness = 0.08;
+      mats.rail.roughness = 0.52;
+      mats.trim.metalness = 0.1;
+      mats.trim.roughness = 0.48;
+      mats.rail.needsUpdate = true;
+      mats.trim.needsUpdate = true;
+    }
+    mats.holeRim.color.set(ringFinish?.color || '#9a856e');
+    mats.holeRim.metalness = ringFinish?.metalness ?? 0.04;
+    mats.holeRim.roughness = ringFinish?.roughness ?? 0.52;
+    mats.holeRim.needsUpdate = true;
+  }, [appearance.boardTheme, appearance.boardFinish, appearance.boardFrameFinish, appearance.ringFinish]);
+
+  useEffect(() => {
+    const renderer = rendererRef.current;
+    const key = keyLightRef.current;
+    const mount = mountRef.current;
+    if (!renderer || !key || !mount) return;
+    const preset = GRAPHICS_PRESETS.find((g) => g.id === appearance.graphics) || GRAPHICS_PRESETS[0];
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio * preset.pixelRatioScale, 2));
+    renderer.setSize(mount.clientWidth, mount.clientHeight);
+    key.shadow.mapSize.setScalar(preset.shadowMapSize);
+  }, [appearance.graphics]);
 
   useEffect(() => {
     if (!winningCells.length) return;
@@ -965,17 +1081,6 @@ export default function BadukBattleRoyal() {
       <div className="pointer-events-none absolute inset-0 z-20">
         <div className="absolute left-1/2 top-[12%] -translate-x-1/2"><AvatarTimer photoUrl="🤖" name="AI Rival" active isTurn={turn === 'ai'} size={1} /></div>
         <div className="absolute left-1/2 top-[85%] -translate-x-1/2"><AvatarTimer photoUrl={avatar} name={username} active isTurn={turn === 'player'} size={1} /></div>
-      </div>
-
-      <div className="pointer-events-auto fixed bottom-4 right-3 z-50 flex gap-2">
-        <button type="button" onClick={() => navigate('/store/badukbattleroyal')} className="rounded-xl border border-white/20 bg-black/60 px-3 py-2 text-xs">Store</button>
-        <button
-          type="button"
-          onClick={resetMatch}
-          className="rounded-xl border border-cyan-300/40 bg-cyan-400/30 px-3 py-2 text-xs font-semibold"
-        >
-          Restart
-        </button>
       </div>
 
       {winner && showWinnerOverlay && (


### PR DESCRIPTION
### Motivation
- Prevent full Three.js scene re-creation when a player changes a customization option so the running game and its state (pieces, turn, animations) are preserved.
- Raise the connect‑4 board slightly on screen and remove unnecessary bottom UI controls to match desired mobile portrait UX.
- Replace legacy chair/HDRI loading behavior with the same mapping used by Chess Battle Royal to fix chair/HDRI loading issues and keep inventories consistent.
- Remove legacy baduk board themes from the store/options so only Connect‑4 style boards remain.

### Description
- Reworked the Baduk (4 in a Row) page to apply live updates instead of rebuilding the scene by adding `tableRef`, `chairsRef`, `boardMaterialsRef`, `keyLightRef`, and `tableThemeIdRef` and introducing targeted `useEffect` handlers to update table theme/finish, chairs, board materials/frame/ring, graphics presets, and HDRI at runtime (`webapp/src/pages/Games/BadukBattleRoyal.jsx`).
- Switched HDRI resolution lookup to use the same variant map approach as Chess (`POOL_ROYALE_HDRI_VARIANT_MAP`) via a new `resolveHdriVariant` helper and used it when loading environment maps so HDRIs resolve consistently with other games.
- Increased vertical offset so the board/frame sits higher by changing `BOARD_TABLE_CLEARANCE` from `0.12` to `0.2` to match the requested upward visual shift.
- Removed the bottom Store and Restart buttons from the game UI so they no longer appear on the gameplay screen.
- Aligned chair inventory mapping to the Chess chair source by importing `CHESS_CHAIR_OPTIONS` and mapping it into `BADUK_CHAIR_OPTIONS`, and removed several legacy baduk board themes from the `BADUK_BOARD_THEMES` list so only the Connect‑4 style themes remain (`webapp/src/config/badukBattleInventoryConfig.js`).
- Improved material application/cleanup: use `applyTableMaterials` defensively for tables returned from `createMurlanStyleTable` and dispose/replace table when `tableId` changes to avoid full scene reloads.

### Testing
- Ran lint on the updated inventory config with `npx eslint --no-ignore webapp/src/config/badukBattleInventoryConfig.js`, which completed successfully (no errors).
- Ran a broader eslint check `npx eslint webapp/src/pages/Games/BadukBattleRoyal.jsx webapp/src/config/badukBattleInventoryConfig.js` which produced warnings due to repository ignore rules for the page file but reported no blocking errors for the config file.
- All automated checks above completed and any reported issues were warnings only; no unit/functional tests were modified or added in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba4608fd608329bf4b09a1808114b4)