### PR TITLE
Unify Checkers pieces with Backgammon Royale materials

### DIFF
--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -33,6 +33,7 @@ import {
   CHESS_CHAIR_OPTIONS,
   CHESS_TABLE_OPTIONS
 } from '../../config/chessBattleInventoryConfig.js';
+import { BACKGAMMON_PIECE_STYLE_MAP } from '../../config/backgammonRoyalInventoryConfig.js';
 import {
   POOL_ROYALE_DEFAULT_HDRI_ID,
   POOL_ROYALE_HDRI_VARIANTS,
@@ -218,47 +219,26 @@ const CHECKERS_HIGHLIGHT_COLORS = Object.freeze({
 });
 
 const CHECKERS_CHIP_SET_BY_ID = Object.freeze({
-  marble: { id: 'marble', light: '#f5f5f5', dark: '#6b7280', textureProfile: 'marbleWhite' },
-  darkForest: { id: 'darkForest', light: '#4ade80', dark: '#14532d', textureProfile: 'walnutWood' },
-  amberGlow: { id: 'amberGlow', light: '#f59e0b', dark: '#78350f', textureProfile: 'mapleWood' },
-  mintVale: { id: 'mintVale', light: '#2dd4bf', dark: '#0f766e', textureProfile: 'mapleWood' },
-  royalWave: { id: 'royalWave', light: '#60a5fa', dark: '#1d4ed8', textureProfile: 'marbleWhite' },
-  roseMist: { id: 'roseMist', light: '#f472b6', dark: '#9d174d', textureProfile: 'walnutWood' },
-  amethyst: { id: 'amethyst', light: '#a78bfa', dark: '#581c87', textureProfile: 'walnutWood' },
-  cinderBlaze: { id: 'cinderBlaze', light: '#fb923c', dark: '#7c2d12', textureProfile: 'walnutWood' },
-  arcticDrift: { id: 'arcticDrift', light: '#e2e8f0', dark: '#0f172a', textureProfile: 'marbleWhite' },
-  obsidianGold: { id: 'obsidianGold', light: '#facc15', dark: '#111827', textureProfile: 'ebonyPolish' },
-  coralBloom: { id: 'coralBloom', light: '#fb7185', dark: '#0ea5e9', textureProfile: 'marbleWhite' },
-  neonPulse: { id: 'neonPulse', light: '#a3e635', dark: '#4c1d95', textureProfile: 'ebonyPolish' }
+  marble: { id: 'marble' },
+  darkForest: { id: 'darkForest' },
+  amberGlow: { id: 'amberGlow' },
+  mintVale: { id: 'mintVale' },
+  royalWave: { id: 'royalWave' },
+  roseMist: { id: 'roseMist' },
+  amethyst: { id: 'amethyst' },
+  cinderBlaze: { id: 'cinderBlaze' },
+  arcticDrift: { id: 'arcticDrift' },
+  obsidianGold: { id: 'obsidianGold' },
+  coralBloom: { id: 'coralBloom' },
+  neonPulse: { id: 'neonPulse' }
 });
-
-const CHECKERS_PIECE_TEXTURES = Object.freeze({
-  mapleWood: Object.freeze({
-    colorMap: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/2k/Wood067/Wood067_2K_Color.jpg',
-    roughnessMap: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/2k/Wood067/Wood067_2K_Roughness.jpg',
-    normalMap: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/2k/Wood067/Wood067_2K_NormalGL.jpg',
-    repeat: 2.2
-  }),
-  walnutWood: Object.freeze({
-    colorMap: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/2k/Wood049/Wood049_2K_Color.jpg',
-    roughnessMap: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/2k/Wood049/Wood049_2K_Roughness.jpg',
-    normalMap: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/2k/Wood049/Wood049_2K_NormalGL.jpg',
-    repeat: 2
-  }),
-  marbleWhite: Object.freeze({
-    colorMap: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/2k/Marble020/Marble020_2K_Color.jpg',
-    roughnessMap: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/2k/Marble020/Marble020_2K_Roughness.jpg',
-    normalMap: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/2k/Marble020/Marble020_2K_NormalGL.jpg',
-    repeat: 1.4
-  }),
-  ebonyPolish: Object.freeze({
-    colorMap: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/2k/Wood059/Wood059_2K_Color.jpg',
-    roughnessMap: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/2k/Wood059/Wood059_2K_Roughness.jpg',
-    normalMap: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/2k/Wood059/Wood059_2K_NormalGL.jpg',
-    repeat: 1.8
-  })
+const BACKGAMMON_CHECKER_HEAD_PRESET = Object.freeze({
+  roughness: 0.18,
+  metalness: 0.35,
+  transmission: 0.18,
+  ior: 1.6,
+  thickness: 0.44
 });
-const CHECKERS_TEXTURE_CACHE = new Map();
 
 const FALLBACK_SEAT_POSITIONS = [
   { left: '50%', top: '18%' },
@@ -277,14 +257,12 @@ const createCheckerMesh = ({
   side,
   king,
   chipSet,
-  checkerHeadPreset,
-  textureSet
+  checkerHeadPreset
 }) => {
   const pieceGroup = new THREE.Group();
   const baseMaterial = createCheckerMaterial(
     side === 'light' ? chipSet.light : chipSet.dark,
-    checkerHeadPreset,
-    textureSet
+    checkerHeadPreset
   );
   const chip = new THREE.Mesh(
     new THREE.CylinderGeometry(
@@ -849,25 +827,7 @@ function resolveCheckersPlayableTileSize(boardModel) {
   return span / ratio / SIZE;
 }
 
-function applyCheckerTextureSet(material, textureSet) {
-  if (!material || !textureSet) return;
-  const repeat = Number.isFinite(textureSet.repeat) ? textureSet.repeat : 1.8;
-  const assignTexture = (key, texture, colorSpace = false) => {
-    if (!texture) return;
-    const cloned = texture.clone();
-    cloned.wrapS = THREE.RepeatWrapping;
-    cloned.wrapT = THREE.RepeatWrapping;
-    cloned.repeat.set(repeat, repeat);
-    if (colorSpace) applySRGBColorSpace(cloned);
-    cloned.needsUpdate = true;
-    material[key] = cloned;
-  };
-  assignTexture('map', textureSet.colorMap, true);
-  assignTexture('roughnessMap', textureSet.roughnessMap);
-  assignTexture('normalMap', textureSet.normalMap);
-}
-
-function createCheckerMaterial(sideColor, headPreset, textureSet = null) {
+function createCheckerMaterial(sideColor, headPreset) {
   const material = new THREE.MeshPhysicalMaterial({
     color: new THREE.Color(sideColor),
     roughness: headPreset?.roughness ?? 0.08,
@@ -879,11 +839,6 @@ function createCheckerMaterial(sideColor, headPreset, textureSet = null) {
     clearcoatRoughness: 0.08,
     specularIntensity: 0.9
   });
-  if (textureSet) {
-    applyCheckerTextureSet(material, textureSet);
-    material.transmission = Math.min(material.transmission, 0.16);
-    material.thickness = Math.min(material.thickness, 0.24);
-  }
   return material;
 }
 function ensureKtx2SupportDetection(renderer = null) {
@@ -922,37 +877,6 @@ function createConfiguredGLTFLoader(renderer = null) {
   ensureKtx2SupportDetection(renderer);
   loader.setKTX2Loader(sharedKtx2Loader);
   return loader;
-}
-
-async function loadCheckerTextureSet(profileId) {
-  const profile = CHECKERS_PIECE_TEXTURES[profileId];
-  if (!profile) return null;
-  if (CHECKERS_TEXTURE_CACHE.has(profileId)) {
-    return CHECKERS_TEXTURE_CACHE.get(profileId);
-  }
-  const loader = new THREE.TextureLoader();
-  loader.setCrossOrigin('anonymous');
-  const loadTexture = (url) =>
-    new Promise((resolve, reject) => {
-      loader.load(url, resolve, undefined, reject);
-    });
-  const request = Promise.all([
-    loadTexture(profile.colorMap),
-    loadTexture(profile.roughnessMap),
-    loadTexture(profile.normalMap)
-  ])
-    .then(([colorMap, roughnessMap, normalMap]) => ({
-      colorMap,
-      roughnessMap,
-      normalMap,
-      repeat: profile.repeat
-    }))
-    .catch((error) => {
-      console.warn('Checkers piece texture load failed:', error);
-      return null;
-    });
-  CHECKERS_TEXTURE_CACHE.set(profileId, request);
-  return request;
 }
 
 function fitChairModelToFootprint(model) {
@@ -1228,7 +1152,6 @@ export default function CheckersBattleRoyal() {
   const chairsRef = useRef([]);
   const chairMaterialSetsRef = useRef([]);
   const envRef = useRef({ map: null, skybox: null });
-  const pieceTextureSetRef = useRef({ light: null, dark: null });
   const boardThemeRef = useRef(CHECKERS_BOARD_THEME_OPTIONS[0]);
   const gltfBoardRef = useRef(null);
   const proceduralBoardRef = useRef({ lightMat: null, darkMat: null });
@@ -1281,9 +1204,17 @@ export default function CheckersBattleRoyal() {
       CHECKERS_CHIP_SET_BY_ID[p2PieceStyleId] ||
       CHECKERS_CHIP_SET_BY_ID[defaultP2PieceStyleId] ||
       CHECKERS_CHIP_SET_BY_ID.mintVale;
+    const lightBackgammonStyle =
+      BACKGAMMON_PIECE_STYLE_MAP[lightPieceStyle.id] ||
+      BACKGAMMON_PIECE_STYLE_MAP[defaultP1PieceStyleId] ||
+      BACKGAMMON_PIECE_STYLE_MAP.amberGlow;
+    const darkBackgammonStyle =
+      BACKGAMMON_PIECE_STYLE_MAP[darkPieceStyle.id] ||
+      BACKGAMMON_PIECE_STYLE_MAP[defaultP2PieceStyleId] ||
+      BACKGAMMON_PIECE_STYLE_MAP.mintVale;
     return {
-      light: lightPieceStyle.light,
-      dark: darkPieceStyle.dark,
+      light: lightBackgammonStyle?.color || '#f59e0b',
+      dark: darkBackgammonStyle?.color || '#10b981',
       lightStyleId: lightPieceStyle.id,
       darkStyleId: darkPieceStyle.id
     };
@@ -1300,52 +1231,7 @@ export default function CheckersBattleRoyal() {
         .filter(Boolean),
     [unlockedPieceStyleIds]
   );
-  const checkerHeadPreset = useMemo(() => {
-    const headId = inv?.headStyle || 'current';
-    if (headId === 'headChrome') {
-      return {
-        roughness: 0.12,
-        metalness: 0.95,
-        transmission: 0.1,
-        ior: 2.1,
-        thickness: 0.22
-      };
-    }
-    if (headId === 'headGold') {
-      return {
-        roughness: 0.16,
-        metalness: 0.92,
-        transmission: 0.06,
-        ior: 1.85,
-        thickness: 0.28
-      };
-    }
-    if (headId === 'headSapphire') {
-      return {
-        roughness: 0.08,
-        metalness: 0.05,
-        transmission: 0.9,
-        ior: 1.8,
-        thickness: 0.7
-      };
-    }
-    if (headId === 'headRuby') {
-      return {
-        roughness: 0.08,
-        metalness: 0.05,
-        transmission: 0.92,
-        ior: 2.4,
-        thickness: 0.6
-      };
-    }
-    return {
-      roughness: 0.18,
-      metalness: 0.35,
-      transmission: 0.18,
-      ior: 1.6,
-      thickness: 0.44
-    };
-  }, [inv?.headStyle]);
+  const checkerHeadPreset = BACKGAMMON_CHECKER_HEAD_PRESET;
   const playerName = getTelegramFirstName() || 'Player';
   const playerPhotoUrl = getTelegramPhotoUrl() || '/assets/icons/profile.svg';
 
@@ -1383,11 +1269,7 @@ export default function CheckersBattleRoyal() {
             side: piece.side,
             king: piece.king,
             chipSet: piecePalette,
-            checkerHeadPreset,
-            textureSet:
-              piece.side === 'light'
-                ? pieceTextureSetRef.current.light
-                : pieceTextureSetRef.current.dark
+            checkerHeadPreset
           });
 
           pieceGroup.position.set(
@@ -1425,11 +1307,7 @@ export default function CheckersBattleRoyal() {
             side: piece.side,
             king: piece.king,
             chipSet: piecePalette,
-            checkerHeadPreset,
-            textureSet:
-              piece.side === 'light'
-                ? pieceTextureSetRef.current.light
-                : pieceTextureSetRef.current.dark
+            checkerHeadPreset
           });
           checker.position.set(
             x + centered * tile * CAPTURE_STRIP_PIECE_GAP,
@@ -1449,33 +1327,6 @@ export default function CheckersBattleRoyal() {
   useEffect(() => {
     renderPieces();
   }, [renderPieces, turn]);
-
-  useEffect(() => {
-    let cancelled = false;
-    const loadTextures = async () => {
-      const lightProfile =
-        CHECKERS_CHIP_SET_BY_ID[piecePalette.lightStyleId]?.textureProfile;
-      const darkProfile =
-        CHECKERS_CHIP_SET_BY_ID[piecePalette.darkStyleId]?.textureProfile;
-      const [light, dark] = await Promise.all([
-        loadCheckerTextureSet(lightProfile),
-        loadCheckerTextureSet(darkProfile)
-      ]);
-      if (cancelled) return;
-      pieceTextureSetRef.current = { light, dark };
-      renderPieces();
-      renderCapturedPieces();
-    };
-    void loadTextures();
-    return () => {
-      cancelled = true;
-    };
-  }, [
-    piecePalette.darkStyleId,
-    piecePalette.lightStyleId,
-    renderCapturedPieces,
-    renderPieces
-  ]);
 
   useEffect(() => {
     renderCapturedPieces();


### PR DESCRIPTION
### Motivation
- Make Checkers Battle Royal pieces use the same visual finish and color mapping as Backgammon (Tavull) so pieces share identical look and feel across games. 
- Remove the previous per-piece texture-profile pipeline which diverged visuals from the Backgammon asset set. 
- Simplify runtime piece material creation by reusing the Backgammon material model and presets for predictable rendering on mobile and desktop.

### Description
- Import `BACKGAMMON_PIECE_STYLE_MAP` and map Checkers style IDs to Backgammon colors so piece colors come from the same style catalog. 
- Replace per-style `CHECKERS_CHIP_SET_BY_ID` entries that included texture profiles with ID-only definitions and derive actual piece colors from `BACKGAMMON_PIECE_STYLE_MAP`. 
- Add `BACKGAMMON_CHECKER_HEAD_PRESET` and switch `createCheckerMaterial`/`createCheckerMesh` to use the shared MeshPhysical material preset instead of applying per-piece texture sets. 
- Remove the texture-loading and application code paths (texture cache, `applyCheckerTextureSet`, `loadCheckerTextureSet`, `pieceTextureSetRef` and the related effect) so chips render with the unified Backgammon-style material only.

### Testing
- Ran `npx eslint webapp/src/pages/Games/CheckersBattleRoyal.jsx` which reported the file is ignored by the repo ESLint ignore settings (no lint errors surfaced for the file). 
- Ran `npm test -- --runInBand test/tavullEngine.test.js` and the suite passed (`4 passed, 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba9a578c7c83299aebd7488d2809c6)