### PR TITLE
Adjust 4-in-a-row board frame alignment and lift

### DIFF
--- a/webapp/src/pages/Games/BadukBattleRoyal.jsx
+++ b/webapp/src/pages/Games/BadukBattleRoyal.jsx
@@ -50,8 +50,9 @@ const BOARD_FRAME_THICKNESS = 0.12;
 const BOARD_FACE_THICKNESS = 0.028;
 const BOARD_SLOT_GAP = 0.15;
 const BOARD_FRAME_DEPTH = BOARD_SLOT_GAP + BOARD_FACE_THICKNESS * 2 + 0.08;
-const BOARD_LIFT_OFFSET = 0.08;
-const BOARD_FRAME_FORWARD_TILT = 0.06;
+const BOARD_LIFT_OFFSET = 0.12;
+const BOARD_FRAME_FORWARD_TILT = 0.082;
+const BOARD_PANEL_FORWARD_PULL = 0.075;
 const CONNECT4_WOOD = '#4b2b1f';
 const CONNECT4_WOOD_DARK = '#2d170f';
 const CONNECT4_PANEL = '#efe9d5';
@@ -473,7 +474,7 @@ export default function BadukBattleRoyal() {
     const panelTiltCos = Math.cos(BOARD_FRAME_FORWARD_TILT);
     const panelTiltSin = Math.sin(BOARD_FRAME_FORWARD_TILT);
     boardPanelGroup.rotation.x = BOARD_FRAME_FORWARD_TILT;
-    boardPanelGroup.position.set(0, boardCenterY * (1 - panelTiltCos), -boardCenterY * panelTiltSin);
+    boardPanelGroup.position.set(0, boardCenterY * (1 - panelTiltCos), -boardCenterY * panelTiltSin + BOARD_PANEL_FORWARD_PULL);
     boardGroup.add(boardPanelGroup);
 
     const selectedBoardTheme = BADUK_BOARD_THEMES.find((item) => item.id === appearance.boardTheme) || BADUK_BOARD_THEMES[0];


### PR DESCRIPTION
### Motivation

- Fix visual alignment of the 4‑in‑a‑row board so the top frame elements align with the side rails and the board reads closer to the player in portrait view by slightly lifting and pulling the panel forward.

### Description

- Increased `BOARD_LIFT_OFFSET` to `0.12` to raise the board/frame slightly higher above the table surface.
- Tuned `BOARD_FRAME_FORWARD_TILT` from `0.06` to `0.082` to increase the forward tilt of the frame panel.
- Added a new `BOARD_PANEL_FORWARD_PULL` (`0.075`) and applied it to `boardPanelGroup.position.set(...)` so the board/frame is pulled visually toward the player.
- Change consolidated in `webapp/src/pages/Games/BadukBattleRoyal.jsx` and affects the board panel transform and placement calculations (`boardCenterY` usage).

### Testing

- Ran `npm run build` from `webapp/` and the production build completed successfully.
- Build output included pre-existing Vite chunk-size/dynamic-import warnings that are unrelated to this change and did not block the build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba9ab6a2e883298998800879253d39)