### PR TITLE
Adjust 4-in-a-row board tilt and lift to improve portrait alignment

### DIFF
--- a/webapp/src/pages/Games/BadukBattleRoyal.jsx
+++ b/webapp/src/pages/Games/BadukBattleRoyal.jsx
@@ -50,8 +50,9 @@ const BOARD_FRAME_THICKNESS = 0.12;
 const BOARD_FACE_THICKNESS = 0.028;
 const BOARD_SLOT_GAP = 0.15;
 const BOARD_FRAME_DEPTH = BOARD_SLOT_GAP + BOARD_FACE_THICKNESS * 2 + 0.08;
-const BOARD_LIFT_OFFSET = 0.08;
-const BOARD_FRAME_FORWARD_TILT = 0.06;
+const BOARD_LIFT_OFFSET = 0.11;
+const BOARD_FRAME_FORWARD_TILT = 0.085;
+const BOARD_PANEL_FORWARD_OFFSET = 0.045;
 const CONNECT4_WOOD = '#4b2b1f';
 const CONNECT4_WOOD_DARK = '#2d170f';
 const CONNECT4_PANEL = '#efe9d5';
@@ -473,7 +474,7 @@ export default function BadukBattleRoyal() {
     const panelTiltCos = Math.cos(BOARD_FRAME_FORWARD_TILT);
     const panelTiltSin = Math.sin(BOARD_FRAME_FORWARD_TILT);
     boardPanelGroup.rotation.x = BOARD_FRAME_FORWARD_TILT;
-    boardPanelGroup.position.set(0, boardCenterY * (1 - panelTiltCos), -boardCenterY * panelTiltSin);
+    boardPanelGroup.position.set(0, boardCenterY * (1 - panelTiltCos), -boardCenterY * panelTiltSin + BOARD_PANEL_FORWARD_OFFSET);
     boardGroup.add(boardPanelGroup);
 
     const selectedBoardTheme = BADUK_BOARD_THEMES.find((item) => item.id === appearance.boardTheme) || BADUK_BOARD_THEMES[0];


### PR DESCRIPTION
### Motivation
- Fix visual alignment in the 4-in-a-Row scene so the top rails and dual board faces appear pulled toward the player in portrait view and better align with the side rails. 
- Raise the board/frame assembly slightly so the frame sits a bit higher above the table surface and is not too close to the ground.

### Description
- Increased `BOARD_LIFT_OFFSET` from `0.08` to `0.11` to lift the board/frame assembly higher above the table. 
- Increased `BOARD_FRAME_FORWARD_TILT` from `0.06` to `0.085` to pitch the panel forward for better perceived alignment. 
- Added `BOARD_PANEL_FORWARD_OFFSET = 0.045` and applied it to the tilted `boardPanelGroup` position so the top rails and both board faces are translated forward (toward the user on screen). 
- Change made in `webapp/src/pages/Games/BadukBattleRoyal.jsx` (updated constants and `boardPanelGroup.position`).

### Testing
- Ran `npx eslint webapp/src/pages/Games/BadukBattleRoyal.jsx`, which reports the file is ignored by the repo lint configuration and thus produced a lint-warning only, with no syntax errors emitted for the modified file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba9ab6a2e883298998800879253d39)