### PR TITLE
Adjust 4-in-a-row board frame alignment and lift

### DIFF
--- a/webapp/src/pages/Games/BadukBattleRoyal.jsx
+++ b/webapp/src/pages/Games/BadukBattleRoyal.jsx
@@ -50,8 +50,10 @@ const BOARD_FRAME_THICKNESS = 0.12;
 const BOARD_FACE_THICKNESS = 0.028;
 const BOARD_SLOT_GAP = 0.15;
 const BOARD_FRAME_DEPTH = BOARD_SLOT_GAP + BOARD_FACE_THICKNESS * 2 + 0.08;
-const BOARD_LIFT_OFFSET = 0.08;
+const BOARD_LIFT_OFFSET = 0.13;
 const BOARD_FRAME_FORWARD_TILT = 0.06;
+const BOARD_FACE_FORWARD_PULL = 0.045;
+const BOARD_TOP_RAIL_FORWARD_PULL = 0.07;
 const CONNECT4_WOOD = '#4b2b1f';
 const CONNECT4_WOOD_DARK = '#2d170f';
 const CONNECT4_PANEL = '#efe9d5';
@@ -544,8 +546,8 @@ export default function BadukBattleRoyal() {
     const boardFaceGeo = new THREE.ExtrudeGeometry(boardShape, { depth: boardThickness, bevelEnabled: false, curveSegments: 42 });
     const boardFaceFront = new THREE.Mesh(boardFaceGeo, boardFaceMat);
     const boardFaceBack = boardFaceFront.clone();
-    boardFaceFront.position.set(0, boardCenterY, BOARD_SLOT_GAP / 2 - boardThickness / 2);
-    boardFaceBack.position.set(0, boardCenterY, -BOARD_SLOT_GAP / 2 - boardThickness / 2);
+    boardFaceFront.position.set(0, boardCenterY, BOARD_SLOT_GAP / 2 - boardThickness / 2 + BOARD_FACE_FORWARD_PULL);
+    boardFaceBack.position.set(0, boardCenterY, -BOARD_SLOT_GAP / 2 - boardThickness / 2 + BOARD_FACE_FORWARD_PULL);
     boardFaceFront.castShadow = true;
     boardFaceFront.receiveShadow = true;
     boardFaceBack.castShadow = true;
@@ -555,9 +557,14 @@ export default function BadukBattleRoyal() {
     const frameSideWidth = 0.12;
     const topRailDepth = 0.046;
     const topFrontRail = new THREE.Mesh(new THREE.BoxGeometry(boardWidth + frameSideWidth * 2, BOARD_FRAME_THICKNESS, topRailDepth), railMat);
-    topFrontRail.position.set(0, boardCenterY + boardHeight / 2 + BOARD_FRAME_THICKNESS / 2, BOARD_SLOT_GAP / 2 + boardThickness / 2 + topRailDepth / 2);
+    const topRailBaseZ = BOARD_SLOT_GAP / 2 + boardThickness / 2 + topRailDepth / 2;
+    topFrontRail.position.set(
+      0,
+      boardCenterY + boardHeight / 2 + BOARD_FRAME_THICKNESS / 2,
+      topRailBaseZ + BOARD_TOP_RAIL_FORWARD_PULL
+    );
     const topBackRail = topFrontRail.clone();
-    topBackRail.position.z = -topFrontRail.position.z;
+    topBackRail.position.z = -topRailBaseZ + BOARD_TOP_RAIL_FORWARD_PULL;
     boardPanelGroup.add(topFrontRail, topBackRail);
 
     const bottomRail = new THREE.Mesh(new THREE.BoxGeometry(boardWidth + frameSideWidth * 2, BOARD_FRAME_THICKNESS, BOARD_FRAME_DEPTH), railMat);


### PR DESCRIPTION
### Motivation
- Fix visual misalignment where the top parts of the frame and the two board faces appear too low and not flush with the side rails in portrait view, and lift the board slightly off the ground for better separation.
- Make the board faces and top rails appear closer to the player (pulled forward) so the frame edges align visually with the side rails on mobile portrait screens.

### Description
- Updated `webapp/src/pages/Games/BadukBattleRoyal.jsx` to increase vertical clearance by changing `BOARD_LIFT_OFFSET` from `0.08` to `0.13` so the board/frame sits higher above the table. 
- Added `BOARD_FACE_FORWARD_PULL = 0.045` and applied it to the Z placement of `boardFaceFront` and `boardFaceBack` so both faces are pulled slightly toward the player. 
- Added `BOARD_TOP_RAIL_FORWARD_PULL = 0.07`, introduced `topRailBaseZ` and adjusted `topFrontRail`/`topBackRail` Z positions to pull the top rails forward while keeping explicit front/back placement for consistent alignment. 
- Small refactor of rail placement to compute `topRailBaseZ` and apply the forward pull consistently for front and back rails.

### Testing
- Ran `cd webapp && npx eslint src/pages/Games/BadukBattleRoyal.jsx` which completed but reported the file is ignored by current ESLint ignore settings (warning, no errors). 
- Ran `cd webapp && npx eslint --no-ignore src/pages/Games/BadukBattleRoyal.jsx` which produced the same ignore warning under the current configuration (warning, no errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba9ab6a2e883298998800879253d39)