### PR TITLE
Adjust 4-in-a-row board alignment and elevation

### DIFF
--- a/webapp/src/pages/Games/BadukBattleRoyal.jsx
+++ b/webapp/src/pages/Games/BadukBattleRoyal.jsx
@@ -50,8 +50,10 @@ const BOARD_FRAME_THICKNESS = 0.12;
 const BOARD_FACE_THICKNESS = 0.028;
 const BOARD_SLOT_GAP = 0.15;
 const BOARD_FRAME_DEPTH = BOARD_SLOT_GAP + BOARD_FACE_THICKNESS * 2 + 0.08;
-const BOARD_LIFT_OFFSET = 0.08;
-const BOARD_FRAME_FORWARD_TILT = 0.06;
+const BOARD_LIFT_OFFSET = 0.14;
+const BOARD_FRAME_FORWARD_TILT = 0.095;
+const BOARD_FRONT_PULL = 0.055;
+const BOARD_TOP_RAIL_FRONT_PULL = 0.035;
 const CONNECT4_WOOD = '#4b2b1f';
 const CONNECT4_WOOD_DARK = '#2d170f';
 const CONNECT4_PANEL = '#efe9d5';
@@ -544,8 +546,8 @@ export default function BadukBattleRoyal() {
     const boardFaceGeo = new THREE.ExtrudeGeometry(boardShape, { depth: boardThickness, bevelEnabled: false, curveSegments: 42 });
     const boardFaceFront = new THREE.Mesh(boardFaceGeo, boardFaceMat);
     const boardFaceBack = boardFaceFront.clone();
-    boardFaceFront.position.set(0, boardCenterY, BOARD_SLOT_GAP / 2 - boardThickness / 2);
-    boardFaceBack.position.set(0, boardCenterY, -BOARD_SLOT_GAP / 2 - boardThickness / 2);
+    boardFaceFront.position.set(0, boardCenterY, BOARD_SLOT_GAP / 2 - boardThickness / 2 + BOARD_FRONT_PULL);
+    boardFaceBack.position.set(0, boardCenterY, -BOARD_SLOT_GAP / 2 - boardThickness / 2 + BOARD_FRONT_PULL);
     boardFaceFront.castShadow = true;
     boardFaceFront.receiveShadow = true;
     boardFaceBack.castShadow = true;
@@ -555,9 +557,14 @@ export default function BadukBattleRoyal() {
     const frameSideWidth = 0.12;
     const topRailDepth = 0.046;
     const topFrontRail = new THREE.Mesh(new THREE.BoxGeometry(boardWidth + frameSideWidth * 2, BOARD_FRAME_THICKNESS, topRailDepth), railMat);
-    topFrontRail.position.set(0, boardCenterY + boardHeight / 2 + BOARD_FRAME_THICKNESS / 2, BOARD_SLOT_GAP / 2 + boardThickness / 2 + topRailDepth / 2);
+    const topRailBaseZ = BOARD_SLOT_GAP / 2 + boardThickness / 2 + topRailDepth / 2;
+    topFrontRail.position.set(
+      0,
+      boardCenterY + boardHeight / 2 + BOARD_FRAME_THICKNESS / 2,
+      topRailBaseZ + BOARD_TOP_RAIL_FRONT_PULL
+    );
     const topBackRail = topFrontRail.clone();
-    topBackRail.position.z = -topFrontRail.position.z;
+    topBackRail.position.z = -topRailBaseZ + BOARD_TOP_RAIL_FRONT_PULL;
     boardPanelGroup.add(topFrontRail, topBackRail);
 
     const bottomRail = new THREE.Mesh(new THREE.BoxGeometry(boardWidth + frameSideWidth * 2, BOARD_FRAME_THICKNESS, BOARD_FRAME_DEPTH), railMat);


### PR DESCRIPTION
### Motivation
- Fix visual misalignment where the top parts of the board/frame appeared too far from the player and not aligned with side rails when viewed in portrait/mobile; the board should be slightly lifted and pulled toward the user for a better camera-facing fit. 
- Make a small, focused visual adjustment without changing gameplay logic so the frame visually matches the sides and sits a bit higher above the table.

### Description
- Increased the board lift and forward tilt by updating `BOARD_LIFT_OFFSET` and `BOARD_FRAME_FORWARD_TILT` to raise and tilt the board more toward the player. 
- Introduced `BOARD_FRONT_PULL` to nudge both `boardFaceFront` and `boardFaceBack` forward so both faces appear pulled toward the user. 
- Added `BOARD_TOP_RAIL_FRONT_PULL` and a shared `topRailBaseZ` so the front and back top rails apply the same forward pull while keeping their mirror relationship. 
- All changes are confined to `webapp/src/pages/Games/BadukBattleRoyal.jsx` and adjust only mesh positioning/placement (no gameplay/AI changes).

### Testing
- Ran the production build with `npm --prefix webapp run build` and the build completed successfully (Vite produced the app bundle with standard warnings about large chunks).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bac81b30ec8329aada977fbb024c41)