### PR TITLE
Adjust 4-in-row board frame alignment and lift

### DIFF
--- a/webapp/src/pages/Games/BadukBattleRoyal.jsx
+++ b/webapp/src/pages/Games/BadukBattleRoyal.jsx
@@ -50,8 +50,10 @@ const BOARD_FRAME_THICKNESS = 0.12;
 const BOARD_FACE_THICKNESS = 0.028;
 const BOARD_SLOT_GAP = 0.15;
 const BOARD_FRAME_DEPTH = BOARD_SLOT_GAP + BOARD_FACE_THICKNESS * 2 + 0.08;
-const BOARD_LIFT_OFFSET = 0.08;
-const BOARD_FRAME_FORWARD_TILT = 0.06;
+const BOARD_LIFT_OFFSET = 0.14;
+const BOARD_FRAME_FORWARD_TILT = 0.09;
+const BOARD_FACE_FORWARD_PULL = 0.022;
+const BOARD_TOP_FRAME_FORWARD_PULL = 0.032;
 const CONNECT4_WOOD = '#4b2b1f';
 const CONNECT4_WOOD_DARK = '#2d170f';
 const CONNECT4_PANEL = '#efe9d5';
@@ -544,8 +546,8 @@ export default function BadukBattleRoyal() {
     const boardFaceGeo = new THREE.ExtrudeGeometry(boardShape, { depth: boardThickness, bevelEnabled: false, curveSegments: 42 });
     const boardFaceFront = new THREE.Mesh(boardFaceGeo, boardFaceMat);
     const boardFaceBack = boardFaceFront.clone();
-    boardFaceFront.position.set(0, boardCenterY, BOARD_SLOT_GAP / 2 - boardThickness / 2);
-    boardFaceBack.position.set(0, boardCenterY, -BOARD_SLOT_GAP / 2 - boardThickness / 2);
+    boardFaceFront.position.set(0, boardCenterY, BOARD_SLOT_GAP / 2 - boardThickness / 2 + BOARD_FACE_FORWARD_PULL);
+    boardFaceBack.position.set(0, boardCenterY, -BOARD_SLOT_GAP / 2 - boardThickness / 2 + BOARD_FACE_FORWARD_PULL);
     boardFaceFront.castShadow = true;
     boardFaceFront.receiveShadow = true;
     boardFaceBack.castShadow = true;
@@ -555,9 +557,13 @@ export default function BadukBattleRoyal() {
     const frameSideWidth = 0.12;
     const topRailDepth = 0.046;
     const topFrontRail = new THREE.Mesh(new THREE.BoxGeometry(boardWidth + frameSideWidth * 2, BOARD_FRAME_THICKNESS, topRailDepth), railMat);
-    topFrontRail.position.set(0, boardCenterY + boardHeight / 2 + BOARD_FRAME_THICKNESS / 2, BOARD_SLOT_GAP / 2 + boardThickness / 2 + topRailDepth / 2);
+    topFrontRail.position.set(
+      0,
+      boardCenterY + boardHeight / 2 + BOARD_FRAME_THICKNESS / 2,
+      BOARD_SLOT_GAP / 2 + boardThickness / 2 + topRailDepth / 2 + BOARD_TOP_FRAME_FORWARD_PULL
+    );
     const topBackRail = topFrontRail.clone();
-    topBackRail.position.z = -topFrontRail.position.z;
+    topBackRail.position.z = -topFrontRail.position.z + BOARD_TOP_FRAME_FORWARD_PULL * 2;
     boardPanelGroup.add(topFrontRail, topBackRail);
 
     const bottomRail = new THREE.Mesh(new THREE.BoxGeometry(boardWidth + frameSideWidth * 2, BOARD_FRAME_THICKNESS, BOARD_FRAME_DEPTH), railMat);


### PR DESCRIPTION
### Motivation
- Improve on-screen perspective of the 4-in-row (Baduk) board so the top parts of the frame and the two board faces read closer to the user in portrait view and align with the side rails.
- Lift the board slightly away from the table/ground to match the referenced photo and visual expectation.

### Description
- Increased `BOARD_LIFT_OFFSET` and `BOARD_FRAME_FORWARD_TILT`, and added `BOARD_FACE_FORWARD_PULL` and `BOARD_TOP_FRAME_FORWARD_PULL` constants in `webapp/src/pages/Games/BadukBattleRoyal.jsx` to control lift, tilt and targeted forward pull.
- Applied `BOARD_FACE_FORWARD_PULL` to `boardFaceFront` and `boardFaceBack` z positions so both board planes are pulled toward the user.
- Applied `BOARD_TOP_FRAME_FORWARD_PULL` to the `topFrontRail`/`topBackRail` z positions so the upper frame rails are visually closer and better aligned with side rails.

### Testing
- Ran `npx eslint webapp/src/pages/Games/BadukBattleRoyal.jsx`, which completed with a file-ignore warning but no errors.
- Ran `npx eslint --no-ignore webapp/src/pages/Games/BadukBattleRoyal.jsx`, which completed with the same warning and no errors.
- Started `npm run lint` (repo-wide) but the full repo lint pass did not complete within the interactive run window; no blocking errors were observed in local file lint checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bac81b30ec8329aada977fbb024c41)