### PR TITLE
Adjust Four in Row board frame alignment and board lift

### DIFF
--- a/webapp/src/pages/Games/BadukBattleRoyal.jsx
+++ b/webapp/src/pages/Games/BadukBattleRoyal.jsx
@@ -50,8 +50,10 @@ const BOARD_FRAME_THICKNESS = 0.12;
 const BOARD_FACE_THICKNESS = 0.028;
 const BOARD_SLOT_GAP = 0.15;
 const BOARD_FRAME_DEPTH = BOARD_SLOT_GAP + BOARD_FACE_THICKNESS * 2 + 0.08;
-const BOARD_LIFT_OFFSET = 0.08;
+const BOARD_LIFT_OFFSET = 0.12;
 const BOARD_FRAME_FORWARD_TILT = 0.06;
+const BOARD_FACE_BOTTOM_PULL = 0.026;
+const BOARD_TOP_RAIL_BOTTOM_PULL = 0.026;
 const CONNECT4_WOOD = '#4b2b1f';
 const CONNECT4_WOOD_DARK = '#2d170f';
 const CONNECT4_PANEL = '#efe9d5';
@@ -544,8 +546,8 @@ export default function BadukBattleRoyal() {
     const boardFaceGeo = new THREE.ExtrudeGeometry(boardShape, { depth: boardThickness, bevelEnabled: false, curveSegments: 42 });
     const boardFaceFront = new THREE.Mesh(boardFaceGeo, boardFaceMat);
     const boardFaceBack = boardFaceFront.clone();
-    boardFaceFront.position.set(0, boardCenterY, BOARD_SLOT_GAP / 2 - boardThickness / 2);
-    boardFaceBack.position.set(0, boardCenterY, -BOARD_SLOT_GAP / 2 - boardThickness / 2);
+    boardFaceFront.position.set(0, boardCenterY, BOARD_SLOT_GAP / 2 - boardThickness / 2 + BOARD_FACE_BOTTOM_PULL);
+    boardFaceBack.position.set(0, boardCenterY, -BOARD_SLOT_GAP / 2 - boardThickness / 2 + BOARD_FACE_BOTTOM_PULL);
     boardFaceFront.castShadow = true;
     boardFaceFront.receiveShadow = true;
     boardFaceBack.castShadow = true;
@@ -555,7 +557,11 @@ export default function BadukBattleRoyal() {
     const frameSideWidth = 0.12;
     const topRailDepth = 0.046;
     const topFrontRail = new THREE.Mesh(new THREE.BoxGeometry(boardWidth + frameSideWidth * 2, BOARD_FRAME_THICKNESS, topRailDepth), railMat);
-    topFrontRail.position.set(0, boardCenterY + boardHeight / 2 + BOARD_FRAME_THICKNESS / 2, BOARD_SLOT_GAP / 2 + boardThickness / 2 + topRailDepth / 2);
+    topFrontRail.position.set(
+      0,
+      boardCenterY + boardHeight / 2 + BOARD_FRAME_THICKNESS / 2,
+      BOARD_SLOT_GAP / 2 + boardThickness / 2 + topRailDepth / 2 + BOARD_TOP_RAIL_BOTTOM_PULL
+    );
     const topBackRail = topFrontRail.clone();
     topBackRail.position.z = -topFrontRail.position.z;
     boardPanelGroup.add(topFrontRail, topBackRail);


### PR DESCRIPTION
### Motivation
- Fix visual misalignment observed on portrait screens where the board faces and top rail appeared recessed relative to the side frame; the board should read as pulled slightly toward the player and sit a touch higher above the ground.
- Keep the change minimal and tunable so further small adjustments are easy to make for different layouts or device aspect ratios.

### Description
- Increased `BOARD_LIFT_OFFSET` to raise the entire board assembly slightly (`0.08` → `0.12`) in `webapp/src/pages/Games/BadukBattleRoyal.jsx`.
- Added two tuning constants: `BOARD_FACE_BOTTOM_PULL` and `BOARD_TOP_RAIL_BOTTOM_PULL` and applied them to the front/back board face positions and to the top rail Z position so the front/top parts are pulled visually toward the player.
- Updated positions for `boardFaceFront`, `boardFaceBack`, and `topFrontRail` (and cloned `topBackRail`) to use the new offsets for improved frame edge alignment.

### Testing
- Built the web app with `npm run build` from `webapp/`, and the Vite production build completed successfully (build artifacts produced); the run finished with only existing chunk-size / dynamic-import warnings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bac81b30ec8329aada977fbb024c41)