### PR TITLE
Match Snooker Royal camera, spin controller and shot pace to Pool Royale

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -91,7 +91,7 @@ import {
   normalizeSpinInput,
   smoothDamp,
   SPIN_STUN_RADIUS
-} from './poolRoyaleSpinUtils.js';
+} from './snookerRoyalSpinUtils.js';
 
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
 const BASIS_TRANSCODER_PATH =
@@ -1542,6 +1542,8 @@ const SPIN_AFTER_IMPACT_DEFLECTION_SCALE = 0; // keep the cue follow line aligne
 const SHOT_POWER_REDUCTION = 0.425; // reduce shot power by 50% to match the requested pacing
 const SHOT_POWER_MULTIPLIER = 2.109375;
 const SHOT_POWER_INCREASE = 1.5; // boost overall shot strength by 50%
+const SHOT_POWER_ADJUSTMENT = 0.72; // keep baseline ball pace identical to Pool Royale
+const SHOT_POWER_BOOST = 1.5; // keep baseline ball pace identical to Pool Royale
 const SHOT_FORCE_BOOST =
   1.5 *
   0.75 *
@@ -1551,7 +1553,9 @@ const SHOT_FORCE_BOOST =
   0.85 *
   SHOT_POWER_REDUCTION *
   SHOT_POWER_MULTIPLIER *
-  SHOT_POWER_INCREASE;
+  SHOT_POWER_INCREASE *
+  SHOT_POWER_ADJUSTMENT *
+  SHOT_POWER_BOOST;
 const SHOT_BREAK_MULTIPLIER = 1.5;
 const SHOT_BASE_SPEED = 3.3 * 0.3 * 1.65 * SHOT_FORCE_BOOST;
 const SHOT_MIN_FACTOR = 0.25;
@@ -5019,7 +5023,7 @@ function applySnookerScaling({
 }
 
 // Camera: keep a comfortable angle that doesn’t dip below the cloth, but allow a bit more height when it rises
-const STANDING_VIEW_PHI = 0.92; // match Pool Royale standing camera tilt
+const STANDING_VIEW_PHI = 0.96; // lower the standing camera angle slightly so players see more rail-level framing
 const CUE_SHOT_PHI = Math.PI / 2 - 0.26;
 const STANDING_VIEW_MARGIN = 0.001; // pull the standing frame closer so the table and balls fill more of the view
 const STANDING_VIEW_FOV = 66;
@@ -5028,14 +5032,14 @@ const CAMERA_LOWEST_PHI = CUE_SHOT_PHI - 0.1; // match Pool Royale standing-view
 const CAMERA_MIN_PHI = Math.max(CAMERA_ABS_MIN_PHI, STANDING_VIEW_PHI - 0.54);
 const CAMERA_MAX_PHI = CAMERA_LOWEST_PHI; // halt the downward sweep right above the cue while still enabling the lower AI cue height for players
 // Bring the cue camera in closer so the player view sits right against the rail on portrait screens.
-const PLAYER_CAMERA_DISTANCE_FACTOR = 0.0154; // match Pool Royale standing/cue camera distance
+const PLAYER_CAMERA_DISTANCE_FACTOR = 0.0148; // move the player standing camera a bit closer to the table
 const BROADCAST_RADIUS_LIMIT_MULTIPLIER = 1.14;
 // Bring the standing/broadcast framing closer to the cloth so the table feels less distant while matching the rail proximity of the pocket cams
 const BROADCAST_DISTANCE_MULTIPLIER = 0.06;
 // Allow portrait/landscape standing camera framing to pull in closer without clipping the table
 const STANDING_VIEW_MARGIN_LANDSCAPE = 0.96;
 const STANDING_VIEW_MARGIN_PORTRAIT = 0.94;
-const STANDING_VIEW_DISTANCE_SCALE = 0.36; // match Pool Royale standing camera distance
+const STANDING_VIEW_DISTANCE_SCALE = 0.33; // pull the standing camera closer for tighter on-table framing
 const BROADCAST_RADIUS_PADDING = TABLE.THICK * 0.02;
 const BROADCAST_PAIR_MARGIN = BALL_R * 5; // keep the cue/target pair safely framed within the broadcast crop
 const BROADCAST_ORBIT_FOCUS_BIAS = 0.6; // prefer the orbit camera's subject framing when updating broadcast heads
@@ -5167,7 +5171,7 @@ const CAMERA_TILT_ZOOM = BALL_R * 1.5;
 const CAMERA_SURFACE_STOP_MARGIN = BALL_R * 1.3;
 const IN_HAND_CAMERA_RADIUS_MULTIPLIER = 1.32; // restore the 9pm in-hand orbit framing for cue-ball placement
 // When pushing the camera below the cue height, translate forward instead of dipping beneath the cue.
-const CUE_VIEW_FORWARD_SLIDE_MAX = CAMERA.minR * 0.32; // nudge forward slightly at the floor of the cue view, then stop
+const CUE_VIEW_FORWARD_SLIDE_MAX = CAMERA.minR * 0.36; // keep cue-view forward slide behavior identical to Pool Royale
 const CUE_VIEW_FORWARD_SLIDE_BLEND_FADE = 0.32;
 const CUE_VIEW_FORWARD_SLIDE_RESET_BLEND = 0.45;
 const CUE_VIEW_SPIN_ZOOM = 0;

--- a/webapp/src/pages/Games/snookerRoyalSpinUtils.js
+++ b/webapp/src/pages/Games/snookerRoyalSpinUtils.js
@@ -1,0 +1,241 @@
+const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
+
+export const MAX_SPIN_OFFSET = 0.75;
+export const SPIN_STUN_RADIUS = 0.12;
+export const SPIN_RING1_RADIUS = 0.33;
+export const SPIN_RING2_RADIUS = 0.66;
+export const SPIN_RING3_RADIUS = MAX_SPIN_OFFSET;
+export const SPIN_LEVEL0_MAG = 0;
+export const SPIN_LEVEL1_MAG = SPIN_RING1_RADIUS;
+export const SPIN_LEVEL2_MAG = SPIN_RING2_RADIUS;
+export const SPIN_LEVEL3_MAG = SPIN_RING3_RADIUS;
+export const STRAIGHT_SPIN_DEADZONE = 0.02;
+export const SPIN_RESPONSE_EXPONENT = 1.45;
+export const SPIN_DIRECTIONS = [
+  {
+    id: 'stun',
+    label: 'STUN (no spin)',
+    offset: { x: 0, y: 0 },
+    effect:
+      'Goditje në qendër: cue ball rrëshqet fillimisht dhe kalon në rolling pa topspin/backspin.'
+  },
+  {
+    id: 'topspin',
+    label: 'TOPSPIN (follow)',
+    offset: { x: 0, y: MAX_SPIN_OFFSET },
+    effect:
+      'Goditje sipër qendrës: spin rreth boshtit horizontal në drejtim të lëvizjes, cue ball vazhdon përpara pas kontaktit.'
+  },
+  {
+    id: 'backspin',
+    label: 'BACKSPIN (draw)',
+    offset: { x: 0, y: -MAX_SPIN_OFFSET },
+    effect:
+      'Goditje poshtë qendrës: spin rreth boshtit horizontal në drejtim të kundërt, cue ball ndalon dhe kthehet mbrapsht pas kontaktit.'
+  },
+  {
+    id: 'left-english',
+    label: 'SIDESPIN LEFT',
+    offset: { x: -MAX_SPIN_OFFSET, y: 0 },
+    effect:
+      'Goditje majtas nga qendra: spin rreth boshtit vertikal, ndikon kryesisht në rebound me banda dhe në “throw”.'
+  },
+  {
+    id: 'right-english',
+    label: 'SIDESPIN RIGHT',
+    offset: { x: MAX_SPIN_OFFSET, y: 0 },
+    effect:
+      'Goditje djathtas nga qendra: spin rreth boshtit vertikal në drejtim të kundërt, me të njëjtat efekte anësore.'
+  },
+  {
+    id: 'top-left',
+    label: 'TOPSPIN + LEFT',
+    offset: { x: -SPIN_RING2_RADIUS, y: SPIN_RING2_RADIUS },
+    effect:
+      'Offset diagonal sipër-majtas: follow me efekt në banda dhe cut shots, me spin lateral aktiv.'
+  },
+  {
+    id: 'top-right',
+    label: 'TOPSPIN + RIGHT',
+    offset: { x: SPIN_RING2_RADIUS, y: SPIN_RING2_RADIUS },
+    effect:
+      'Offset diagonal sipër-djathtas: follow me efekt në banda dhe cut shots, me spin lateral aktiv.'
+  },
+  {
+    id: 'back-left',
+    label: 'BACKSPIN + LEFT',
+    offset: { x: -SPIN_RING2_RADIUS, y: -SPIN_RING2_RADIUS },
+    effect:
+      'Offset diagonal poshtë-majtas: draw me kontroll lateral pas kontaktit dhe reagim më agresiv me bandat.'
+  },
+  {
+    id: 'back-right',
+    label: 'BACKSPIN + RIGHT',
+    offset: { x: SPIN_RING2_RADIUS, y: -SPIN_RING2_RADIUS },
+    effect:
+      'Offset diagonal poshtë-djathtas: draw me kontroll lateral pas kontaktit dhe reagim më agresiv me bandat.'
+  }
+];
+
+export const clampToUnitCircle = (x, y) => {
+  const length = Math.hypot(x, y);
+  if (!Number.isFinite(length) || length <= 1) {
+    return { x, y };
+  }
+  const scale = length > 1e-6 ? 1 / length : 0;
+  return { x: x * scale, y: y * scale };
+};
+
+export const clampToMaxOffset = (x, y, maxOffset = MAX_SPIN_OFFSET) => {
+  const length = Math.hypot(x, y);
+  if (!Number.isFinite(length) || length <= maxOffset) {
+    return { x, y };
+  }
+  const scale = length > 1e-6 ? maxOffset / length : 0;
+  return { x: x * scale, y: y * scale };
+};
+
+export const computeQuantizedOffsetScaled = (
+  rawX,
+  rawY,
+  options = {}
+) => {
+  const maxOffset = options.maxOffset ?? MAX_SPIN_OFFSET;
+  const stunRadius = options.stunRadius ?? SPIN_STUN_RADIUS;
+  const ring1Radius = options.ring1Radius ?? SPIN_RING1_RADIUS;
+  const ring2Radius = options.ring2Radius ?? SPIN_RING2_RADIUS;
+  const ring3Radius = options.ring3Radius ?? SPIN_RING3_RADIUS;
+  const level0Mag = options.level0Mag ?? SPIN_LEVEL0_MAG;
+  const level1Mag = options.level1Mag ?? SPIN_LEVEL1_MAG;
+  const level2Mag = options.level2Mag ?? SPIN_LEVEL2_MAG;
+  const level3Mag = options.level3Mag ?? SPIN_LEVEL3_MAG;
+  const angleStep = options.angleStepRad ?? Math.PI / 4;
+
+  const raw = clampToMaxOffset(rawX, rawY, maxOffset);
+  const distance = Math.hypot(raw.x, raw.y);
+  let mag = level3Mag;
+  if (distance <= stunRadius) {
+    mag = level0Mag;
+  } else if (distance <= ring1Radius) {
+    mag = level1Mag;
+  } else if (distance <= ring2Radius) {
+    mag = level2Mag;
+  } else if (distance <= ring3Radius) {
+    mag = level3Mag;
+  }
+  if (mag === 0 || distance <= 1e-6) {
+    return { x: 0, y: 0 };
+  }
+  const angle = Math.atan2(raw.y, raw.x);
+  const snappedAngle = angleStep > 0
+    ? Math.round(angle / angleStep) * angleStep
+    : angle;
+  return {
+    x: Math.cos(snappedAngle) * mag,
+    y: Math.sin(snappedAngle) * mag
+  };
+};
+
+export const normalizeSpinInput = (spin) => {
+  let x = clamp(spin?.x ?? 0, -1, 1);
+  let y = clamp(spin?.y ?? 0, -1, 1);
+
+  // Keep straight high/low and left/right shots easier to select by gently
+  // snapping near-axis drag noise to the principal axis.
+  if (Math.abs(x) <= STRAIGHT_SPIN_DEADZONE) x = 0;
+  if (Math.abs(y) <= STRAIGHT_SPIN_DEADZONE) y = 0;
+
+  const clamped = clampToMaxOffset(x, y, MAX_SPIN_OFFSET);
+  const distance = Math.hypot(clamped.x, clamped.y);
+  const deadzone = Math.max(SPIN_STUN_RADIUS, STRAIGHT_SPIN_DEADZONE);
+  if (distance <= deadzone) {
+    return { x: 0, y: 0 };
+  }
+
+  const activeSpan = Math.max(MAX_SPIN_OFFSET - deadzone, 1e-6);
+  const normalized = clamp((distance - deadzone) / activeSpan, 0, 1);
+  const shaped = normalized ** SPIN_RESPONSE_EXPONENT;
+  const magnitude = deadzone + shaped * activeSpan;
+  const scale = magnitude / Math.max(distance, 1e-6);
+  return {
+    x: clamped.x * scale,
+    y: clamped.y * scale
+  };
+};
+
+export const mapUiOffsetToCueFrame = (
+  uiX,
+  uiY,
+  cameraRight,
+  cameraUp,
+  cueForward
+) => {
+  if (!cameraRight || !cameraUp || !cueForward) {
+    return { x: uiX, y: uiY };
+  }
+  const right = cameraRight;
+  const up = cameraUp;
+  const forward = cueForward;
+  const offsetWorld = {
+    x: right.x * uiX + up.x * uiY,
+    y: right.y * uiX + up.y * uiY,
+    z: right.z * uiX + up.z * uiY
+  };
+  offsetWorld.y = 0;
+  const forwardPlanarLength = Math.hypot(forward.x, forward.z);
+  const forwardPlanar =
+    forwardPlanarLength > 1e-6
+      ? { x: forward.x / forwardPlanarLength, z: forward.z / forwardPlanarLength }
+      : { x: 0, z: 1 };
+  const side = { x: -forwardPlanar.z, z: forwardPlanar.x };
+  return {
+    x: -(offsetWorld.x * side.x + offsetWorld.z * side.z),
+    y: offsetWorld.x * forwardPlanar.x + offsetWorld.z * forwardPlanar.z
+  };
+};
+
+export const mapSpinForPhysics = (spin, options = {}) => {
+  const adjusted = {
+    x: clamp(spin?.x ?? 0, -1, 1),
+    y: clamp(spin?.y ?? 0, -1, 1)
+  };
+  const quantized = normalizeSpinInput(adjusted);
+  const { cameraRight, cameraUp, cueForward } = options;
+  return mapUiOffsetToCueFrame(
+    -quantized.x,
+    quantized.y,
+    cameraRight,
+    cameraUp,
+    cueForward
+  );
+};
+
+// Smooth damp helper adapted from Unity's Mathf.SmoothDamp (MIT licensed).
+export const smoothDamp = (
+  current,
+  target,
+  currentVelocity,
+  smoothTime,
+  maxSpeed,
+  deltaTime
+) => {
+  const clampedSmooth = Math.max(0.0001, smoothTime || 0);
+  const omega = 2 / clampedSmooth;
+  const x = omega * deltaTime;
+  const exp = 1 / (1 + x + 0.48 * x * x + 0.235 * x * x * x);
+  let change = current - target;
+  const originalTarget = target;
+  const maxChange = (maxSpeed ?? Number.POSITIVE_INFINITY) * clampedSmooth;
+  if (Number.isFinite(maxChange)) {
+    change = clamp(change, -maxChange, maxChange);
+  }
+  target = current - change;
+  const temp = (currentVelocity + omega * change) * deltaTime;
+  let velocity = (currentVelocity - omega * temp) * exp;
+  let output = target + (change + temp) * exp;
+  if ((originalTarget - current > 0) === (output > originalTarget)) {
+    output = originalTarget;
+    velocity = (output - originalTarget) / Math.max(deltaTime, 1e-4);
+  }
+  return { value: output, velocity };
+};


### PR DESCRIPTION
### Motivation
- Make the Snooker Royal player standing camera closer and slightly lower on-screen, make the spin control logic identical to Pool Royale while keeping separate code, and ensure ball speed/physics match Pool Royale for consistent gameplay feel.

### Description
- Extracted a dedicated spin utils module `snookerRoyalSpinUtils.js` (copied from Pool Royale) and switched `SnookerRoyal.jsx` to import spin helpers from that file so behavior is identical but code stays separate.
- Aligned shot launch composition by adding `SHOT_POWER_ADJUSTMENT` and `SHOT_POWER_BOOST` into the `SHOT_FORCE_BOOST` calculation so `SHOT_BASE_SPEED` and spin reference scales match Pool Royale.
- Tuned standing/playing camera values by changing `STANDING_VIEW_PHI`, `PLAYER_CAMERA_DISTANCE_FACTOR`, and `STANDING_VIEW_DISTANCE_SCALE` to bring the player camera closer and slightly lower, and set `CUE_VIEW_FORWARD_SLIDE_MAX` to match Pool Royale.

### Testing
- Ran the production build with `npm --prefix webapp run build`, and the build completed successfully (warnings about large chunks were present but did not fail the build).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb82a7fa0083299b46ce7a3993321b)