### PR TITLE
Align Snooker Royal camera, spin controller, and ball physics with Pool Royale

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -91,7 +91,7 @@ import {
   normalizeSpinInput,
   smoothDamp,
   SPIN_STUN_RADIUS
-} from './poolRoyaleSpinUtils.js';
+} from './snookerRoyalSpinUtils.js';
 
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
 const BASIS_TRANSCODER_PATH =
@@ -1308,13 +1308,17 @@ const POCKET_INTERIOR_CAPTURE_R =
 const SIDE_POCKET_INTERIOR_CAPTURE_R =
   SIDE_POCKET_RADIUS * POCKET_INTERIOR_TOP_SCALE * POCKET_VISUAL_EXPANSION; // keep middle-pocket capture identical to its bowl radius
 const CAPTURE_R =
-  POCKET_INTERIOR_CAPTURE_R + BALL_R * 0.12; // widen the capture bowl so firm/spun shots still drop like Pool Royale
+  POCKET_INTERIOR_CAPTURE_R + BALL_R * 0.22; // mirror Pool Royale corner-pocket capture gain for identical pocket acceptance
 const SIDE_CAPTURE_R =
   SIDE_POCKET_INTERIOR_CAPTURE_R + BALL_R * 0.22; // give middle pockets a touch more capture so shots don't hang in the jaws
-const POCKET_GUARD_RADIUS = Math.max(0, CAPTURE_R - BALL_R * 0.08); // align the rail guard to the playable capture bowl instead of the visual rim
-const POCKET_GUARD_CLEARANCE = Math.max(0, POCKET_GUARD_RADIUS - BALL_R * 0.18); // shrink the safety margin so angled cushion cuts register sooner
+const POCKET_GUARD_RADIUS =
+  CAPTURE_R - BALL_R * 0.12; // mirror Pool Royale guard inset so corner jaw collision acceptance matches
+const POCKET_GUARD_CLEARANCE = Math.max(
+  0,
+  POCKET_GUARD_RADIUS - BALL_R * 0.04
+); // keep corner jaw clearance aligned with the Pool Royale middle-pocket clearance
 const CORNER_POCKET_DEPTH_LIMIT =
-  POCKET_VIS_R * 1.58 * POCKET_VISUAL_EXPANSION; // clamp corner reflections to the actual pocket depth
+  POCKET_VIS_R * 1.6 * POCKET_VISUAL_EXPANSION; // use Pool Royale depth multiplier for matching corner-pocket rebounds
 const SIDE_POCKET_GUARD_RADIUS =
   SIDE_CAPTURE_R - BALL_R * 0.12; // use the middle-pocket bowl to gate reflections with a tighter inset
 const SIDE_POCKET_GUARD_CLEARANCE = Math.max(
@@ -1662,9 +1666,10 @@ const MAX_SPIN_VISUAL_LIFT = MAX_SPIN_VERTICAL; // cap vertical spin offsets so 
 const SPIN_RING_RATIO = 1;
 const SPIN_CLEARANCE_MARGIN = BALL_R * 0.4;
 const SPIN_TIP_MARGIN = CUE_TIP_RADIUS * 1.15;
-const SIDE_SPIN_MULTIPLIER = 1.5;
-const BACKSPIN_MULTIPLIER = 2.6;
-const TOPSPIN_MULTIPLIER = 1.5;
+const SPIN_GLOBAL_BOOST_MULTIPLIER = 1.2;
+const SIDE_SPIN_MULTIPLIER = 1.5 * SPIN_GLOBAL_BOOST_MULTIPLIER;
+const BACKSPIN_MULTIPLIER = 2.6 * SPIN_GLOBAL_BOOST_MULTIPLIER;
+const TOPSPIN_MULTIPLIER = 1.62 * SPIN_GLOBAL_BOOST_MULTIPLIER;
 const CUE_CLEARANCE_PADDING = BALL_R * 0.05;
 const SPIN_CONTROL_DIAMETER_PX = 124;
 const SPIN_DOT_DIAMETER_PX = 16;
@@ -5019,7 +5024,7 @@ function applySnookerScaling({
 }
 
 // Camera: keep a comfortable angle that doesn’t dip below the cloth, but allow a bit more height when it rises
-const STANDING_VIEW_PHI = 0.92; // match Pool Royale standing camera tilt
+const STANDING_VIEW_PHI = 0.96; // lower the standing camera a touch so the table sits slightly lower on screen
 const CUE_SHOT_PHI = Math.PI / 2 - 0.26;
 const STANDING_VIEW_MARGIN = 0.001; // pull the standing frame closer so the table and balls fill more of the view
 const STANDING_VIEW_FOV = 66;
@@ -5035,7 +5040,7 @@ const BROADCAST_DISTANCE_MULTIPLIER = 0.06;
 // Allow portrait/landscape standing camera framing to pull in closer without clipping the table
 const STANDING_VIEW_MARGIN_LANDSCAPE = 0.96;
 const STANDING_VIEW_MARGIN_PORTRAIT = 0.94;
-const STANDING_VIEW_DISTANCE_SCALE = 0.36; // match Pool Royale standing camera distance
+const STANDING_VIEW_DISTANCE_SCALE = 0.33; // pull the standing camera slightly closer to the table for tighter portrait framing
 const BROADCAST_RADIUS_PADDING = TABLE.THICK * 0.02;
 const BROADCAST_PAIR_MARGIN = BALL_R * 5; // keep the cue/target pair safely framed within the broadcast crop
 const BROADCAST_ORBIT_FOCUS_BIAS = 0.6; // prefer the orbit camera's subject framing when updating broadcast heads
@@ -5387,7 +5392,7 @@ const DEFAULT_SPIN_LIMITS = Object.freeze({
 });
 const clampSpinValue = (value) => clamp(value, -1, 1);
 const SPIN_CUSHION_EPS = BALL_R * 0.5;
-const SPIN_VIEW_BLOCK_THRESHOLD = -1; // allow full 360° spin input so every controller side stays responsive
+const SPIN_VIEW_BLOCK_THRESHOLD = 0.12;
 const normalizeCueLift = (liftAngle = 0) => {
   if (!Number.isFinite(liftAngle) || CUE_LIFT_MAX_TILT <= 1e-6) return 0;
   return THREE.MathUtils.clamp(liftAngle / CUE_LIFT_MAX_TILT, 0, 1);
@@ -5418,10 +5423,35 @@ const computeCueViewVector = (cueBall, camera) => {
   return TMP_VEC2_VIEW.clone().normalize();
 };
 
-const clampSpinToVisibleHemisphere = (spinInput, _aimDir, _cueBall, _camera) => {
-  // Keep controller input 1:1 with the user's chosen strike direction on screen.
-  // Do not remap to the camera-facing hemisphere; it made some sides feel unresponsive.
-  return spinInput;
+const clampSpinToVisibleHemisphere = (spinInput, aimDir, cueBall, camera) => {
+  if (!spinInput || !aimDir || !cueBall || !camera) return spinInput;
+  const viewVec = computeCueViewVector(cueBall, camera);
+  if (!viewVec) return spinInput;
+  const axes = prepareSpinAxes(aimDir);
+  TMP_VEC2_SPIN.set(0, 0);
+  TMP_VEC2_SPIN.addScaledVector(axes.perp, spinInput.x ?? 0);
+  TMP_VEC2_SPIN.addScaledVector(axes.axis, spinInput.y ?? 0);
+  if (TMP_VEC2_SPIN.lengthSq() < 1e-8) return spinInput;
+  TMP_VEC2_VIEW.set(viewVec.x, viewVec.y).normalize();
+  const viewDot = TMP_VEC2_SPIN.dot(TMP_VEC2_VIEW);
+  if (viewDot >= 0) return spinInput;
+  const dx = camera.position.x - cueBall.pos.x;
+  const dz = camera.position.z - cueBall.pos.y;
+  const planarDistance = Math.hypot(dx, dz);
+  const elevation = Math.atan2(camera.position.y ?? 0, Math.max(planarDistance, 1e-6));
+  const relax =
+    elevation <= 0
+      ? 0
+      : THREE.MathUtils.clamp(
+          (elevation - 0.35) / (0.75 - 0.35),
+          0,
+          1
+        );
+  TMP_VEC2_SPIN.addScaledVector(TMP_VEC2_VIEW, -viewDot * (1 - relax));
+  return {
+    x: TMP_VEC2_SPIN.dot(axes.perp),
+    y: TMP_VEC2_SPIN.dot(axes.axis)
+  };
 };
 
 const computeShortRailBroadcastDistance = (camera) => {

--- a/webapp/src/pages/Games/snookerRoyalSpinUtils.js
+++ b/webapp/src/pages/Games/snookerRoyalSpinUtils.js
@@ -1,0 +1,241 @@
+const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
+
+export const MAX_SPIN_OFFSET = 0.75;
+export const SPIN_STUN_RADIUS = 0.12;
+export const SPIN_RING1_RADIUS = 0.33;
+export const SPIN_RING2_RADIUS = 0.66;
+export const SPIN_RING3_RADIUS = MAX_SPIN_OFFSET;
+export const SPIN_LEVEL0_MAG = 0;
+export const SPIN_LEVEL1_MAG = SPIN_RING1_RADIUS;
+export const SPIN_LEVEL2_MAG = SPIN_RING2_RADIUS;
+export const SPIN_LEVEL3_MAG = SPIN_RING3_RADIUS;
+export const STRAIGHT_SPIN_DEADZONE = 0.02;
+export const SPIN_RESPONSE_EXPONENT = 1.45;
+export const SPIN_DIRECTIONS = [
+  {
+    id: 'stun',
+    label: 'STUN (no spin)',
+    offset: { x: 0, y: 0 },
+    effect:
+      'Goditje në qendër: cue ball rrëshqet fillimisht dhe kalon në rolling pa topspin/backspin.'
+  },
+  {
+    id: 'topspin',
+    label: 'TOPSPIN (follow)',
+    offset: { x: 0, y: MAX_SPIN_OFFSET },
+    effect:
+      'Goditje sipër qendrës: spin rreth boshtit horizontal në drejtim të lëvizjes, cue ball vazhdon përpara pas kontaktit.'
+  },
+  {
+    id: 'backspin',
+    label: 'BACKSPIN (draw)',
+    offset: { x: 0, y: -MAX_SPIN_OFFSET },
+    effect:
+      'Goditje poshtë qendrës: spin rreth boshtit horizontal në drejtim të kundërt, cue ball ndalon dhe kthehet mbrapsht pas kontaktit.'
+  },
+  {
+    id: 'left-english',
+    label: 'SIDESPIN LEFT',
+    offset: { x: -MAX_SPIN_OFFSET, y: 0 },
+    effect:
+      'Goditje majtas nga qendra: spin rreth boshtit vertikal, ndikon kryesisht në rebound me banda dhe në “throw”.'
+  },
+  {
+    id: 'right-english',
+    label: 'SIDESPIN RIGHT',
+    offset: { x: MAX_SPIN_OFFSET, y: 0 },
+    effect:
+      'Goditje djathtas nga qendra: spin rreth boshtit vertikal në drejtim të kundërt, me të njëjtat efekte anësore.'
+  },
+  {
+    id: 'top-left',
+    label: 'TOPSPIN + LEFT',
+    offset: { x: -SPIN_RING2_RADIUS, y: SPIN_RING2_RADIUS },
+    effect:
+      'Offset diagonal sipër-majtas: follow me efekt në banda dhe cut shots, me spin lateral aktiv.'
+  },
+  {
+    id: 'top-right',
+    label: 'TOPSPIN + RIGHT',
+    offset: { x: SPIN_RING2_RADIUS, y: SPIN_RING2_RADIUS },
+    effect:
+      'Offset diagonal sipër-djathtas: follow me efekt në banda dhe cut shots, me spin lateral aktiv.'
+  },
+  {
+    id: 'back-left',
+    label: 'BACKSPIN + LEFT',
+    offset: { x: -SPIN_RING2_RADIUS, y: -SPIN_RING2_RADIUS },
+    effect:
+      'Offset diagonal poshtë-majtas: draw me kontroll lateral pas kontaktit dhe reagim më agresiv me bandat.'
+  },
+  {
+    id: 'back-right',
+    label: 'BACKSPIN + RIGHT',
+    offset: { x: SPIN_RING2_RADIUS, y: -SPIN_RING2_RADIUS },
+    effect:
+      'Offset diagonal poshtë-djathtas: draw me kontroll lateral pas kontaktit dhe reagim më agresiv me bandat.'
+  }
+];
+
+export const clampToUnitCircle = (x, y) => {
+  const length = Math.hypot(x, y);
+  if (!Number.isFinite(length) || length <= 1) {
+    return { x, y };
+  }
+  const scale = length > 1e-6 ? 1 / length : 0;
+  return { x: x * scale, y: y * scale };
+};
+
+export const clampToMaxOffset = (x, y, maxOffset = MAX_SPIN_OFFSET) => {
+  const length = Math.hypot(x, y);
+  if (!Number.isFinite(length) || length <= maxOffset) {
+    return { x, y };
+  }
+  const scale = length > 1e-6 ? maxOffset / length : 0;
+  return { x: x * scale, y: y * scale };
+};
+
+export const computeQuantizedOffsetScaled = (
+  rawX,
+  rawY,
+  options = {}
+) => {
+  const maxOffset = options.maxOffset ?? MAX_SPIN_OFFSET;
+  const stunRadius = options.stunRadius ?? SPIN_STUN_RADIUS;
+  const ring1Radius = options.ring1Radius ?? SPIN_RING1_RADIUS;
+  const ring2Radius = options.ring2Radius ?? SPIN_RING2_RADIUS;
+  const ring3Radius = options.ring3Radius ?? SPIN_RING3_RADIUS;
+  const level0Mag = options.level0Mag ?? SPIN_LEVEL0_MAG;
+  const level1Mag = options.level1Mag ?? SPIN_LEVEL1_MAG;
+  const level2Mag = options.level2Mag ?? SPIN_LEVEL2_MAG;
+  const level3Mag = options.level3Mag ?? SPIN_LEVEL3_MAG;
+  const angleStep = options.angleStepRad ?? Math.PI / 4;
+
+  const raw = clampToMaxOffset(rawX, rawY, maxOffset);
+  const distance = Math.hypot(raw.x, raw.y);
+  let mag = level3Mag;
+  if (distance <= stunRadius) {
+    mag = level0Mag;
+  } else if (distance <= ring1Radius) {
+    mag = level1Mag;
+  } else if (distance <= ring2Radius) {
+    mag = level2Mag;
+  } else if (distance <= ring3Radius) {
+    mag = level3Mag;
+  }
+  if (mag === 0 || distance <= 1e-6) {
+    return { x: 0, y: 0 };
+  }
+  const angle = Math.atan2(raw.y, raw.x);
+  const snappedAngle = angleStep > 0
+    ? Math.round(angle / angleStep) * angleStep
+    : angle;
+  return {
+    x: Math.cos(snappedAngle) * mag,
+    y: Math.sin(snappedAngle) * mag
+  };
+};
+
+export const normalizeSpinInput = (spin) => {
+  let x = clamp(spin?.x ?? 0, -1, 1);
+  let y = clamp(spin?.y ?? 0, -1, 1);
+
+  // Keep straight high/low and left/right shots easier to select by gently
+  // snapping near-axis drag noise to the principal axis.
+  if (Math.abs(x) <= STRAIGHT_SPIN_DEADZONE) x = 0;
+  if (Math.abs(y) <= STRAIGHT_SPIN_DEADZONE) y = 0;
+
+  const clamped = clampToMaxOffset(x, y, MAX_SPIN_OFFSET);
+  const distance = Math.hypot(clamped.x, clamped.y);
+  const deadzone = Math.max(SPIN_STUN_RADIUS, STRAIGHT_SPIN_DEADZONE);
+  if (distance <= deadzone) {
+    return { x: 0, y: 0 };
+  }
+
+  const activeSpan = Math.max(MAX_SPIN_OFFSET - deadzone, 1e-6);
+  const normalized = clamp((distance - deadzone) / activeSpan, 0, 1);
+  const shaped = normalized ** SPIN_RESPONSE_EXPONENT;
+  const magnitude = deadzone + shaped * activeSpan;
+  const scale = magnitude / Math.max(distance, 1e-6);
+  return {
+    x: clamped.x * scale,
+    y: clamped.y * scale
+  };
+};
+
+export const mapUiOffsetToCueFrame = (
+  uiX,
+  uiY,
+  cameraRight,
+  cameraUp,
+  cueForward
+) => {
+  if (!cameraRight || !cameraUp || !cueForward) {
+    return { x: uiX, y: uiY };
+  }
+  const right = cameraRight;
+  const up = cameraUp;
+  const forward = cueForward;
+  const offsetWorld = {
+    x: right.x * uiX + up.x * uiY,
+    y: right.y * uiX + up.y * uiY,
+    z: right.z * uiX + up.z * uiY
+  };
+  offsetWorld.y = 0;
+  const forwardPlanarLength = Math.hypot(forward.x, forward.z);
+  const forwardPlanar =
+    forwardPlanarLength > 1e-6
+      ? { x: forward.x / forwardPlanarLength, z: forward.z / forwardPlanarLength }
+      : { x: 0, z: 1 };
+  const side = { x: -forwardPlanar.z, z: forwardPlanar.x };
+  return {
+    x: -(offsetWorld.x * side.x + offsetWorld.z * side.z),
+    y: offsetWorld.x * forwardPlanar.x + offsetWorld.z * forwardPlanar.z
+  };
+};
+
+export const mapSpinForPhysics = (spin, options = {}) => {
+  const adjusted = {
+    x: clamp(spin?.x ?? 0, -1, 1),
+    y: clamp(spin?.y ?? 0, -1, 1)
+  };
+  const quantized = normalizeSpinInput(adjusted);
+  const { cameraRight, cameraUp, cueForward } = options;
+  return mapUiOffsetToCueFrame(
+    -quantized.x,
+    quantized.y,
+    cameraRight,
+    cameraUp,
+    cueForward
+  );
+};
+
+// Smooth damp helper adapted from Unity's Mathf.SmoothDamp (MIT licensed).
+export const smoothDamp = (
+  current,
+  target,
+  currentVelocity,
+  smoothTime,
+  maxSpeed,
+  deltaTime
+) => {
+  const clampedSmooth = Math.max(0.0001, smoothTime || 0);
+  const omega = 2 / clampedSmooth;
+  const x = omega * deltaTime;
+  const exp = 1 / (1 + x + 0.48 * x * x + 0.235 * x * x * x);
+  let change = current - target;
+  const originalTarget = target;
+  const maxChange = (maxSpeed ?? Number.POSITIVE_INFINITY) * clampedSmooth;
+  if (Number.isFinite(maxChange)) {
+    change = clamp(change, -maxChange, maxChange);
+  }
+  target = current - change;
+  const temp = (currentVelocity + omega * change) * deltaTime;
+  let velocity = (currentVelocity - omega * temp) * exp;
+  let output = target + (change + temp) * exp;
+  if ((originalTarget - current > 0) === (output > originalTarget)) {
+    output = originalTarget;
+    velocity = (output - originalTarget) / Math.max(deltaTime, 1e-4);
+  }
+  return { value: output, velocity };
+};


### PR DESCRIPTION
### Motivation
- Make the Snooker Royal player standing camera appear closer and slightly lower so portrait framing matches the desired visual feel. 
- Make the on-screen spin controller behavior identical to Pool Royale while keeping each game’s code separate. 
- Match ball speed and collision/ pocket behaviour to Pool Royale so shot pace and rebounds feel the same across both games. 

### Description
- Added a dedicated `webapp/src/pages/Games/snookerRoyalSpinUtils.js` (copied from Pool Royale spin utilities) and switched `SnookerRoyal.jsx` to import `./snookerRoyalSpinUtils.js` so Snooker has independent code with identical spin mapping, quantization, and smoothing logic. 
- Replaced the Snooker no-op hemisphere spin clamp with the camera-aware `clampSpinToVisibleHemisphere` implementation used by Pool Royale, preserving identical controller responsiveness while remaining in Snooker’s code. 
- Tuned standing camera constants in `SnookerRoyal.jsx` (`STANDING_VIEW_PHI` and `STANDING_VIEW_DISTANCE_SCALE`) to bring the player-standing view closer and a touch lower on screen. 
- Aligned multiple physics/pocket and spin constants in `SnookerRoyal.jsx` (example: `CAPTURE_R`, `POCKET_GUARD_RADIUS`, `CORNER_POCKET_DEPTH_LIMIT`, `SPIN_GLOBAL_BOOST_MULTIPLIER`, `SIDE_SPIN_MULTIPLIER`, `BACKSPIN_MULTIPLIER`, `TOPSPIN_MULTIPLIER`, `SPIN_VIEW_BLOCK_THRESHOLD`) to Pool Royale equivalents so ball behaviour and spin effects match. 

### Testing
- Ran lint checks for the modified files with `npx eslint webapp/src/pages/Games/SnookerRoyal.jsx webapp/src/pages/Games/snookerRoyalSpinUtils.js`, which reported the files were ignored by repo ESLint patterns (no runtime errors). 
- Ran a strict lint pass `npx eslint --no-ignore webapp/src/pages/Games/snookerRoyalSpinUtils.js`, which produced style errors (92 `semi` rule violations); these are formatting/style issues and do not indicate runtime/logic failures. 
- No runtime/unit physics tests were executed in this rollout; existing play-mode/unit tests (Unity and JS suites) were not run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb82a7fa0083299b46ce7a3993321b)