### PR TITLE
Add dedicated Backgammon inventory and board material customization

### DIFF
--- a/webapp/src/config/tavullBattleInventoryConfig.js
+++ b/webapp/src/config/tavullBattleInventoryConfig.js
@@ -1,0 +1,209 @@
+import { MURLAN_STOOL_THEMES } from './murlanThemes.js';
+import { MURLAN_TABLE_FINISHES } from './murlanTableFinishes.js';
+import { FOUR_IN_ROW_BOARD_FRAME_FINISH_OPTIONS } from './fourInRowInventoryConfig.js';
+import {
+  POOL_ROYALE_DEFAULT_HDRI_ID,
+  POOL_ROYALE_HDRI_VARIANTS
+} from './poolRoyaleInventoryConfig.js';
+import { swatchThumbnail } from './storeThumbnails.js';
+
+const DEFAULT_HDRI_ID =
+  POOL_ROYALE_DEFAULT_HDRI_ID || POOL_ROYALE_HDRI_VARIANTS[0]?.id;
+
+const BASE_CHAIR_OPTIONS = [
+  {
+    id: 'crimsonVelvet',
+    label: 'Crimson Velvet',
+    primary: '#8b1538',
+    accent: '#5c0f26',
+    highlight: '#d35a7a',
+    legColor: '#1f1f1f'
+  },
+  {
+    id: 'midnightNavy',
+    label: 'Midnight Blue',
+    primary: '#153a8b',
+    accent: '#0c214f',
+    highlight: '#4d74d8',
+    legColor: '#10131c'
+  },
+  {
+    id: 'emeraldWave',
+    label: 'Emerald Wave',
+    primary: '#0f6a2f',
+    accent: '#063d1b',
+    highlight: '#48b26a',
+    legColor: '#142318'
+  },
+  {
+    id: 'onyxShadow',
+    label: 'Onyx Shadow',
+    primary: '#202020',
+    accent: '#101010',
+    highlight: '#6f6f6f',
+    legColor: '#080808'
+  },
+  {
+    id: 'royalPlum',
+    label: 'Royal Chestnut',
+    primary: '#3f1f5b',
+    accent: '#2c1340',
+    highlight: '#7c4ae0',
+    legColor: '#140a24'
+  }
+].map((item) => ({
+  ...item,
+  thumbnail: swatchThumbnail([item.primary, item.accent, item.highlight])
+}));
+
+const mapStoolThemeToChair = (theme) => ({
+  ...theme,
+  primary: theme.seatColor || theme.primary || '#7c3aed',
+  accent: theme.accent || theme.highlight || theme.seatColor,
+  legColor: theme.legColor || theme.baseColor || '#111827',
+  preserveMaterials: theme.preserveMaterials ?? theme.source === 'polyhaven'
+});
+
+export const TAVULL_BATTLE_CHAIR_OPTIONS = Object.freeze([
+  ...MURLAN_STOOL_THEMES.map(mapStoolThemeToChair),
+  ...BASE_CHAIR_OPTIONS
+]);
+
+export const TAVULL_BATTLE_BOARD_FINISH_OPTIONS = Object.freeze([
+  ...MURLAN_TABLE_FINISHES
+]);
+export const TAVULL_BATTLE_FRAME_FINISH_OPTIONS = Object.freeze([
+  ...FOUR_IN_ROW_BOARD_FRAME_FINISH_OPTIONS
+]);
+
+export const TAVULL_BATTLE_TRIANGLE_COLOR_OPTIONS = Object.freeze(
+  [
+    { id: 'amberGlow', label: 'Amber Glow', dark: '#f59e0b', light: '#fef3c7' },
+    { id: 'mintVale', label: 'Mint Vale', dark: '#10b981', light: '#d1fae5' },
+    { id: 'royalWave', label: 'Royal Wave', dark: '#3b82f6', light: '#dbeafe' },
+    { id: 'roseMist', label: 'Rose Mist', dark: '#ef4444', light: '#fee2e2' },
+    { id: 'amethyst', label: 'Amethyst', dark: '#8b5cf6', light: '#ede9fe' },
+    {
+      id: 'cinderBlaze',
+      label: 'Cinder Blaze',
+      dark: '#ff6b35',
+      light: '#ffedd5'
+    },
+    {
+      id: 'arcticDrift',
+      label: 'Arctic Drift',
+      dark: '#93c5fd',
+      light: '#eff6ff'
+    }
+  ].map((option) => ({
+    ...option,
+    thumbnail: swatchThumbnail([option.dark, option.light])
+  }))
+);
+
+export const TAVULL_BATTLE_DEFAULT_UNLOCKS = Object.freeze({
+  chairColor: [TAVULL_BATTLE_CHAIR_OPTIONS[0]?.id],
+  tableFinish: [MURLAN_TABLE_FINISHES[0]?.id],
+  boardFinish: [TAVULL_BATTLE_BOARD_FINISH_OPTIONS[0]?.id],
+  frameFinish: [TAVULL_BATTLE_FRAME_FINISH_OPTIONS[0]?.id],
+  triangleColor: [TAVULL_BATTLE_TRIANGLE_COLOR_OPTIONS[0]?.id],
+  environmentHdri: [DEFAULT_HDRI_ID]
+});
+
+const reduceLabels = (options, labelKey = 'label') =>
+  Object.freeze(
+    options.reduce(
+      (acc, option) => ({ ...acc, [option.id]: option[labelKey] }),
+      {}
+    )
+  );
+
+export const TAVULL_BATTLE_OPTION_LABELS = Object.freeze({
+  chairColor: reduceLabels(TAVULL_BATTLE_CHAIR_OPTIONS),
+  tableFinish: reduceLabels(MURLAN_TABLE_FINISHES),
+  boardFinish: reduceLabels(TAVULL_BATTLE_BOARD_FINISH_OPTIONS),
+  frameFinish: reduceLabels(TAVULL_BATTLE_FRAME_FINISH_OPTIONS),
+  triangleColor: reduceLabels(TAVULL_BATTLE_TRIANGLE_COLOR_OPTIONS),
+  environmentHdri: Object.freeze(
+    POOL_ROYALE_HDRI_VARIANTS.reduce(
+      (acc, variant) => ({ ...acc, [variant.id]: `${variant.name} HDRI` }),
+      {}
+    )
+  )
+});
+
+export const TAVULL_BATTLE_STORE_ITEMS = [
+  ...MURLAN_TABLE_FINISHES.map((finish, idx) => ({
+    id: `tavull-table-finish-${finish.id}`,
+    type: 'tableFinish',
+    optionId: finish.id,
+    name: finish.label,
+    price: finish.price ?? 980 + idx * 40,
+    description: finish.description,
+    swatches: finish.swatches,
+    thumbnail: finish.thumbnail,
+    previewShape: 'table'
+  })),
+  ...TAVULL_BATTLE_CHAIR_OPTIONS.slice(1).map((option, idx) => ({
+    id: `tavull-chair-${option.id}`,
+    type: 'chairColor',
+    optionId: option.id,
+    name: option.label,
+    price: option.price ?? 320 + idx * 20,
+    description:
+      option.description ||
+      `${option.label} seating tuned for Backgammon Royal.`,
+    thumbnail: option.thumbnail,
+    previewShape: 'chair'
+  })),
+  ...TAVULL_BATTLE_BOARD_FINISH_OPTIONS.slice(1).map((finish, idx) => ({
+    id: `tavull-board-finish-${finish.id}`,
+    type: 'boardFinish',
+    optionId: finish.id,
+    name: `${finish.label} Board`,
+    price: 520 + idx * 35,
+    description:
+      'Pool Royale table finish textures for the dice-rolling board lanes and center area.',
+    swatches: finish.swatches,
+    thumbnail: finish.thumbnail,
+    previewShape: 'board'
+  })),
+  ...TAVULL_BATTLE_FRAME_FINISH_OPTIONS.slice(1).map((finish, idx) => ({
+    id: `tavull-frame-finish-${finish.id}`,
+    type: 'frameFinish',
+    optionId: finish.id,
+    name: `${finish.label} Frame`,
+    price: 620 + idx * 35,
+    description:
+      '4 in a Row frame material pack applied to the Backgammon board frame.',
+    swatches: finish.swatches,
+    thumbnail: finish.thumbnail,
+    previewShape: 'board'
+  })),
+  ...TAVULL_BATTLE_TRIANGLE_COLOR_OPTIONS.slice(1).map((option, idx) => ({
+    id: `tavull-triangle-${option.id}`,
+    type: 'triangleColor',
+    optionId: option.id,
+    name: `${option.label} Triangles`,
+    price: 420 + idx * 30,
+    description:
+      'Pool cloth style triangles recolored to match Chess Battle Royal piece palettes.',
+    swatches: [option.dark, option.light],
+    thumbnail: option.thumbnail,
+    previewShape: 'board'
+  })),
+  ...POOL_ROYALE_HDRI_VARIANTS.slice(1).map((variant, idx) => ({
+    id: `tavull-hdri-${variant.id}`,
+    type: 'environmentHdri',
+    optionId: variant.id,
+    name: `${variant.name} HDRI`,
+    price: variant.price ?? 780 + idx * 60,
+    description: `Arena lighting profile based on ${variant.name}.`,
+    thumbnail:
+      variant.thumbnail ||
+      swatchThumbnail(variant.swatches || ['#1f2937', '#0f172a']),
+    previewShape: 'table'
+  }))
+];
+
+export const TAVULL_BATTLE_DEFAULT_LOADOUT = TAVULL_BATTLE_DEFAULT_UNLOCKS;

--- a/webapp/src/pages/Games/TavullBattleRoyal.jsx
+++ b/webapp/src/pages/Games/TavullBattleRoyal.jsx
@@ -1,30 +1,47 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
-import * as THREE from 'three'
-import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js'
-import { RoundedBoxGeometry } from 'three/examples/jsm/geometries/RoundedBoxGeometry.js'
-import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js'
-import { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader.js'
-import { KTX2Loader } from 'three/examples/jsm/loaders/KTX2Loader.js'
-import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.js'
-import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader.js'
-import useTelegramBackButton from '../../hooks/useTelegramBackButton.js'
-import { createMurlanStyleTable, applyTableMaterials } from '../../utils/murlanTable.js'
-import { MURLAN_TABLE_FINISHES } from '../../config/murlanTableFinishes.js'
-import { getTelegramFirstName, getTelegramPhotoUrl } from '../../utils/telegram.js'
-import { applyRendererSRGB, applySRGBColorSpace } from '../../utils/colorSpace.js'
-import BottomLeftIcons from '../../components/BottomLeftIcons.jsx'
-import AvatarTimer from '../../components/AvatarTimer.jsx'
-import { getGameVolume, isGameMuted } from '../../utils/sound.js'
-import QuickMessagePopup from '../../components/QuickMessagePopup.jsx'
-import GiftPopup from '../../components/GiftPopup.jsx'
-import { CHESS_CHAIR_OPTIONS } from '../../config/chessBattleInventoryConfig.js'
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import * as THREE from 'three';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import { RoundedBoxGeometry } from 'three/examples/jsm/geometries/RoundedBoxGeometry.js';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader.js';
+import { KTX2Loader } from 'three/examples/jsm/loaders/KTX2Loader.js';
+import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.js';
+import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader.js';
+import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 import {
-  POOL_ROYALE_DEFAULT_HDRI_ID,
+  createMurlanStyleTable,
+  applyTableMaterials
+} from '../../utils/murlanTable.js';
+import { MURLAN_TABLE_FINISHES } from '../../config/murlanTableFinishes.js';
+import {
+  getTelegramFirstName,
+  getTelegramPhotoUrl
+} from '../../utils/telegram.js';
+import {
+  applyRendererSRGB,
+  applySRGBColorSpace
+} from '../../utils/colorSpace.js';
+import BottomLeftIcons from '../../components/BottomLeftIcons.jsx';
+import AvatarTimer from '../../components/AvatarTimer.jsx';
+import { getGameVolume, isGameMuted } from '../../utils/sound.js';
+import QuickMessagePopup from '../../components/QuickMessagePopup.jsx';
+import GiftPopup from '../../components/GiftPopup.jsx';
+import {
+  TAVULL_BATTLE_BOARD_FINISH_OPTIONS,
+  TAVULL_BATTLE_CHAIR_OPTIONS,
+  TAVULL_BATTLE_FRAME_FINISH_OPTIONS,
+  TAVULL_BATTLE_TRIANGLE_COLOR_OPTIONS
+} from '../../config/tavullBattleInventoryConfig.js';
+import {
   POOL_ROYALE_HDRI_VARIANTS,
   POOL_ROYALE_HDRI_VARIANT_MAP
-} from '../../config/poolRoyaleInventoryConfig.js'
-import { chessBattleAccountId, getChessBattleInventory, isChessOptionUnlocked } from '../../utils/chessBattleInventory.js'
+} from '../../config/poolRoyaleInventoryConfig.js';
+import {
+  getTavullBattleInventory,
+  isTavullOptionUnlocked,
+  tavullBattleAccountId
+} from '../../utils/tavullBattleInventory.js';
 import {
   BLACK,
   WHITE,
@@ -32,97 +49,110 @@ import {
   collectTurnSequences,
   initialBoard,
   pickAiSequence
-} from '../../utils/tavullEngine.js'
+} from '../../utils/tavullEngine.js';
 
-const TABLE_RADIUS = 2.55
-const TABLE_HEIGHT = 1.16
-const CHAIR_DISTANCE = TABLE_RADIUS + 0.82
-const BOARD_Y = TABLE_HEIGHT + 0.08
-const BOARD_HALF_X = 1.28
-const BOARD_HALF_Z = 0.98
-const BOARD_EDGE_MARGIN_X = 0.092
-const BOARD_EDGE_MARGIN_Z = 0.118
-const CENTER_BAR_WIDTH = 0.118
-const POINT_COLUMNS = 6
-const POINT_WIDTH = (BOARD_HALF_X * 2 - CENTER_BAR_WIDTH - BOARD_EDGE_MARGIN_X * 2) / (POINT_COLUMNS * 2)
-const BOARD_BASE_THICKNESS = 0.16
-const FRAME_THICKNESS = 0.112
-const LANE_THICKNESS = 0.04
-const CENTER_BAR_THICKNESS = 0.062
-const POINT_INSET_X = POINT_WIDTH * 0.12
-const POINT_INSET_Z = POINT_WIDTH * 0.16
+const TABLE_RADIUS = 2.55;
+const TABLE_HEIGHT = 1.16;
+const CHAIR_DISTANCE = TABLE_RADIUS + 0.82;
+const BOARD_Y = TABLE_HEIGHT + 0.08;
+const BOARD_HALF_X = 1.28;
+const BOARD_HALF_Z = 0.98;
+const BOARD_EDGE_MARGIN_X = 0.092;
+const BOARD_EDGE_MARGIN_Z = 0.118;
+const CENTER_BAR_WIDTH = 0.118;
+const POINT_COLUMNS = 6;
+const POINT_WIDTH =
+  (BOARD_HALF_X * 2 - CENTER_BAR_WIDTH - BOARD_EDGE_MARGIN_X * 2) /
+  (POINT_COLUMNS * 2);
+const BOARD_BASE_THICKNESS = 0.16;
+const FRAME_THICKNESS = 0.112;
+const LANE_THICKNESS = 0.04;
+const CENTER_BAR_THICKNESS = 0.062;
+const POINT_INSET_X = POINT_WIDTH * 0.12;
+const POINT_INSET_Z = POINT_WIDTH * 0.16;
 
-const TRIANGLE_BASE_Y_OFFSET = 0.127
-const TRIANGLE_HEIGHT = 0.014
-const TRIANGLE_HALF_BASE = POINT_WIDTH * 0.43
-const TRIANGLE_APEX_LENGTH = BOARD_HALF_Z * 0.73
-const CHIP_RADIUS = POINT_WIDTH * 0.36
-const CHIP_HEIGHT = 0.02
-const CHIP_ROW_SPACING = CHIP_RADIUS * 1.88
-const CHIP_COLUMN_SPACING = POINT_WIDTH * 0.34
-const CHIP_POINT_INSET = POINT_WIDTH * 0.18
-const CHIP_BASE_Y_OFFSET = TRIANGLE_BASE_Y_OFFSET + TRIANGLE_HEIGHT + CHIP_HEIGHT * 0.53
-const CHIP_MAX_PER_COLUMN = 5
-const CAPTURE_STRIP_OFFSET_ROWS = 1.15
-const CAPTURE_STRIP_PIECE_GAP = 0.82
+const TRIANGLE_BASE_Y_OFFSET = 0.127;
+const TRIANGLE_HEIGHT = 0.014;
+const TRIANGLE_HALF_BASE = POINT_WIDTH * 0.43;
+const TRIANGLE_APEX_LENGTH = BOARD_HALF_Z * 0.73;
+const CHIP_RADIUS = POINT_WIDTH * 0.36;
+const CHIP_HEIGHT = 0.02;
+const CHIP_ROW_SPACING = CHIP_RADIUS * 1.88;
+const CHIP_COLUMN_SPACING = POINT_WIDTH * 0.34;
+const CHIP_POINT_INSET = POINT_WIDTH * 0.18;
+const CHIP_BASE_Y_OFFSET =
+  TRIANGLE_BASE_Y_OFFSET + TRIANGLE_HEIGHT + CHIP_HEIGHT * 0.53;
+const CHIP_MAX_PER_COLUMN = 5;
+const CAPTURE_STRIP_OFFSET_ROWS = 1.15;
+const CAPTURE_STRIP_PIECE_GAP = 0.82;
 
-const MODEL_SCALE = 0.75
-const STOOL_SCALE = 1.5 * 1.3
-const SEAT_WIDTH = 0.9 * MODEL_SCALE * STOOL_SCALE
-const SEAT_DEPTH = 0.95 * MODEL_SCALE * STOOL_SCALE
-const SEAT_THICKNESS_SCALED = 0.09 * MODEL_SCALE * STOOL_SCALE
-const BACK_HEIGHT = 0.68 * MODEL_SCALE * STOOL_SCALE
-const BACK_THICKNESS = 0.08 * MODEL_SCALE * STOOL_SCALE
-const ARM_THICKNESS = 0.125 * MODEL_SCALE * STOOL_SCALE
-const ARM_HEIGHT = 0.3 * MODEL_SCALE * STOOL_SCALE
-const ARM_DEPTH = SEAT_DEPTH * 0.75
-const BASE_COLUMN_HEIGHT = 0.5 * MODEL_SCALE * STOOL_SCALE
-const CHAIR_BASE_HEIGHT = TABLE_HEIGHT - SEAT_THICKNESS_SCALED * 0.85
-const CAMERA_2D_POSITION = new THREE.Vector3(0, 8.4, 0.01)
-const CAMERA_3D_POSITION = new THREE.Vector3(0, 4.9, 5.6)
-const CAMERA_TARGET = new THREE.Vector3(0, TABLE_HEIGHT, 0)
-const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/'
-const BASIS_TRANSCODER_PATH = 'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/'
+const MODEL_SCALE = 0.75;
+const STOOL_SCALE = 1.5 * 1.3;
+const SEAT_WIDTH = 0.9 * MODEL_SCALE * STOOL_SCALE;
+const SEAT_DEPTH = 0.95 * MODEL_SCALE * STOOL_SCALE;
+const SEAT_THICKNESS_SCALED = 0.09 * MODEL_SCALE * STOOL_SCALE;
+const BACK_HEIGHT = 0.68 * MODEL_SCALE * STOOL_SCALE;
+const BACK_THICKNESS = 0.08 * MODEL_SCALE * STOOL_SCALE;
+const ARM_THICKNESS = 0.125 * MODEL_SCALE * STOOL_SCALE;
+const ARM_HEIGHT = 0.3 * MODEL_SCALE * STOOL_SCALE;
+const ARM_DEPTH = SEAT_DEPTH * 0.75;
+const BASE_COLUMN_HEIGHT = 0.5 * MODEL_SCALE * STOOL_SCALE;
+const CHAIR_BASE_HEIGHT = TABLE_HEIGHT - SEAT_THICKNESS_SCALED * 0.85;
+const CAMERA_2D_POSITION = new THREE.Vector3(0, 8.4, 0.01);
+const CAMERA_3D_POSITION = new THREE.Vector3(0, 4.9, 5.6);
+const CAMERA_TARGET = new THREE.Vector3(0, TABLE_HEIGHT, 0);
+const DRACO_DECODER_PATH =
+  'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
+const BASIS_TRANSCODER_PATH =
+  'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/';
 const DEFAULT_HDRI_ASSET =
-  POOL_ROYALE_HDRI_VARIANT_MAP[POOL_ROYALE_DEFAULT_HDRI_ID] || POOL_ROYALE_HDRI_VARIANTS[0] || null
-let sharedKtx2Loader = null
-let hasDetectedKtx2Support = false
+  POOL_ROYALE_HDRI_VARIANTS[0] ||
+  POOL_ROYALE_HDRI_VARIANT_MAP[POOL_ROYALE_HDRI_VARIANTS[0]?.id] ||
+  null;
+let sharedKtx2Loader = null;
+let hasDetectedKtx2Support = false;
 const CHAIR_MODEL_URLS = Object.freeze([
   'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/SheenChair/glTF-Binary/SheenChair.glb',
   'https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Assets@main/Models/SheenChair/glTF-Binary/SheenChair.glb',
   '/assets/models/chair/chair.glb',
   '/assets/models/chair/chair.gltf'
-])
-const CHAIR_THEMES = Object.freeze([
-  ...CHESS_CHAIR_OPTIONS
-])
+]);
+const CHAIR_THEMES = Object.freeze([...TAVULL_BATTLE_CHAIR_OPTIONS]);
 const QUALITY_OPTIONS = Object.freeze([
   { id: 'performance', label: 'Performance', pixelRatio: 1, shadows: false },
   { id: 'balanced', label: 'Balanced', pixelRatio: 1.5, shadows: true },
   { id: 'ultra', label: 'Ultra', pixelRatio: 2, shadows: true }
-])
-const MOVE_SOUND_URL = 'https://raw.githubusercontent.com/lichess-org/lila/master/public/sound/standard/Move.mp3'
-const WIN_SOUND_URL = 'https://raw.githubusercontent.com/lichess-org/lila/master/public/sound/standard/End.mp3'
-const DICE_ROLL_SOUND_URL = '/assets/sounds/dice-roll.mp3'
+]);
+const MOVE_SOUND_URL =
+  'https://raw.githubusercontent.com/lichess-org/lila/master/public/sound/standard/Move.mp3';
+const WIN_SOUND_URL =
+  'https://raw.githubusercontent.com/lichess-org/lila/master/public/sound/standard/End.mp3';
+const DICE_ROLL_SOUND_URL = '/assets/sounds/dice-roll.mp3';
 const FALLBACK_SEAT_POSITIONS = [
   { left: '50%', top: '73%' },
   { left: '50%', top: '18%' }
-]
-const BACKGAMMON_DIE_SIZE = 0.116
-const BACKGAMMON_DIE_CORNER_RADIUS = BACKGAMMON_DIE_SIZE * 0.18
-const BACKGAMMON_DIE_PIP_RADIUS = BACKGAMMON_DIE_SIZE * 0.093
-const BACKGAMMON_DIE_PIP_DEPTH = BACKGAMMON_DIE_SIZE * 0.018
-const BACKGAMMON_DIE_PIP_RIM_INNER = BACKGAMMON_DIE_PIP_RADIUS * 0.78
-const BACKGAMMON_DIE_PIP_RIM_OUTER = BACKGAMMON_DIE_PIP_RADIUS * 1.08
-const BACKGAMMON_DIE_PIP_RIM_OFFSET = BACKGAMMON_DIE_SIZE * 0.0048
-const BACKGAMMON_DIE_PIP_SPREAD = BACKGAMMON_DIE_SIZE * 0.3
-const BACKGAMMON_DIE_FACE_INSET = BACKGAMMON_DIE_SIZE * 0.064
+];
+const BACKGAMMON_DIE_SIZE = 0.116;
+const BACKGAMMON_DIE_CORNER_RADIUS = BACKGAMMON_DIE_SIZE * 0.18;
+const BACKGAMMON_DIE_PIP_RADIUS = BACKGAMMON_DIE_SIZE * 0.093;
+const BACKGAMMON_DIE_PIP_DEPTH = BACKGAMMON_DIE_SIZE * 0.018;
+const BACKGAMMON_DIE_PIP_RIM_INNER = BACKGAMMON_DIE_PIP_RADIUS * 0.78;
+const BACKGAMMON_DIE_PIP_RIM_OUTER = BACKGAMMON_DIE_PIP_RADIUS * 1.08;
+const BACKGAMMON_DIE_PIP_RIM_OFFSET = BACKGAMMON_DIE_SIZE * 0.0048;
+const BACKGAMMON_DIE_PIP_SPREAD = BACKGAMMON_DIE_SIZE * 0.3;
+const BACKGAMMON_DIE_FACE_INSET = BACKGAMMON_DIE_SIZE * 0.064;
 
-const CHECKERS_CHIP_HEAD_PRESET = Object.freeze({ roughness: 0.18, metalness: 0.35, transmission: 0.18, ior: 1.6, thickness: 0.44 })
+const CHECKERS_CHIP_HEAD_PRESET = Object.freeze({
+  roughness: 0.18,
+  metalness: 0.35,
+  transmission: 0.18,
+  ior: 1.6,
+  thickness: 0.44
+});
 const CHECKERS_CHIP_COLORS = Object.freeze({
   [WHITE]: '#ef4444',
   [BLACK]: '#06b6d4'
-})
+});
 
 function createCheckerMaterial(sideColor, headPreset) {
   return new THREE.MeshPhysicalMaterial({
@@ -135,7 +165,7 @@ function createCheckerMaterial(sideColor, headPreset) {
     clearcoat: 0.22,
     clearcoatRoughness: 0.08,
     specularIntensity: 0.9
-  })
+  });
 }
 
 function getDieOrientationQuaternion(val) {
@@ -146,12 +176,14 @@ function getDieOrientationQuaternion(val) {
     4: new THREE.Euler(0, 0, -Math.PI / 2),
     5: new THREE.Euler(Math.PI / 2, 0, 0),
     6: new THREE.Euler(Math.PI, 0, 0)
-  }
-  return new THREE.Quaternion().setFromEuler(orientations[val] || orientations[1])
+  };
+  return new THREE.Quaternion().setFromEuler(
+    orientations[val] || orientations[1]
+  );
 }
 
 function makeRoyalDie() {
-  const die = new THREE.Group()
+  const die = new THREE.Group();
   const bodyMaterial = new THREE.MeshPhysicalMaterial({
     color: '#ffffff',
     metalness: 0.25,
@@ -160,7 +192,7 @@ function makeRoyalDie() {
     clearcoatRoughness: 0.15,
     reflectivity: 0.75,
     envMapIntensity: 1.4
-  })
+  });
   const pipMaterial = new THREE.MeshPhysicalMaterial({
     color: '#0a0a0a',
     roughness: 0.05,
@@ -170,7 +202,7 @@ function makeRoyalDie() {
     envMapIntensity: 1.1,
     emissive: '#0f172a',
     emissiveIntensity: 0.35
-  })
+  });
   const rimMaterial = new THREE.MeshPhysicalMaterial({
     color: '#ffd700',
     emissive: '#3a2a00',
@@ -183,305 +215,421 @@ function makeRoyalDie() {
     polygonOffset: true,
     polygonOffsetFactor: -1,
     polygonOffsetUnits: -1
-  })
+  });
 
   const body = new THREE.Mesh(
-    new RoundedBoxGeometry(BACKGAMMON_DIE_SIZE, BACKGAMMON_DIE_SIZE, BACKGAMMON_DIE_SIZE, 6, BACKGAMMON_DIE_CORNER_RADIUS),
+    new RoundedBoxGeometry(
+      BACKGAMMON_DIE_SIZE,
+      BACKGAMMON_DIE_SIZE,
+      BACKGAMMON_DIE_SIZE,
+      6,
+      BACKGAMMON_DIE_CORNER_RADIUS
+    ),
     bodyMaterial
-  )
-  body.castShadow = true
-  body.receiveShadow = true
-  die.add(body)
+  );
+  body.castShadow = true;
+  body.receiveShadow = true;
+  die.add(body);
 
-  const pipGeo = new THREE.SphereGeometry(BACKGAMMON_DIE_PIP_RADIUS, 36, 24, 0, Math.PI * 2, 0, Math.PI)
-  pipGeo.rotateX(Math.PI)
-  pipGeo.computeVertexNormals()
-  const pipRimGeo = new THREE.RingGeometry(BACKGAMMON_DIE_PIP_RIM_INNER, BACKGAMMON_DIE_PIP_RIM_OUTER, 64)
-  const faceDepth = BACKGAMMON_DIE_SIZE / 2 - BACKGAMMON_DIE_FACE_INSET * 0.6
-  const spread = BACKGAMMON_DIE_PIP_SPREAD
+  const pipGeo = new THREE.SphereGeometry(
+    BACKGAMMON_DIE_PIP_RADIUS,
+    36,
+    24,
+    0,
+    Math.PI * 2,
+    0,
+    Math.PI
+  );
+  pipGeo.rotateX(Math.PI);
+  pipGeo.computeVertexNormals();
+  const pipRimGeo = new THREE.RingGeometry(
+    BACKGAMMON_DIE_PIP_RIM_INNER,
+    BACKGAMMON_DIE_PIP_RIM_OUTER,
+    64
+  );
+  const faceDepth = BACKGAMMON_DIE_SIZE / 2 - BACKGAMMON_DIE_FACE_INSET * 0.6;
+  const spread = BACKGAMMON_DIE_PIP_SPREAD;
   const faces = [
     { normal: new THREE.Vector3(0, 1, 0), points: [[0, 0]] },
-    { normal: new THREE.Vector3(0, 0, 1), points: [[-spread, -spread], [spread, spread]] },
-    { normal: new THREE.Vector3(1, 0, 0), points: [[-spread, -spread], [0, 0], [spread, spread]] },
-    { normal: new THREE.Vector3(-1, 0, 0), points: [[-spread, -spread], [-spread, spread], [spread, -spread], [spread, spread]] },
-    { normal: new THREE.Vector3(0, 0, -1), points: [[-spread, -spread], [-spread, spread], [0, 0], [spread, -spread], [spread, spread]] },
-    { normal: new THREE.Vector3(0, -1, 0), points: [[-spread, -spread], [-spread, 0], [-spread, spread], [spread, -spread], [spread, 0], [spread, spread]] }
-  ]
+    {
+      normal: new THREE.Vector3(0, 0, 1),
+      points: [
+        [-spread, -spread],
+        [spread, spread]
+      ]
+    },
+    {
+      normal: new THREE.Vector3(1, 0, 0),
+      points: [
+        [-spread, -spread],
+        [0, 0],
+        [spread, spread]
+      ]
+    },
+    {
+      normal: new THREE.Vector3(-1, 0, 0),
+      points: [
+        [-spread, -spread],
+        [-spread, spread],
+        [spread, -spread],
+        [spread, spread]
+      ]
+    },
+    {
+      normal: new THREE.Vector3(0, 0, -1),
+      points: [
+        [-spread, -spread],
+        [-spread, spread],
+        [0, 0],
+        [spread, -spread],
+        [spread, spread]
+      ]
+    },
+    {
+      normal: new THREE.Vector3(0, -1, 0),
+      points: [
+        [-spread, -spread],
+        [-spread, 0],
+        [-spread, spread],
+        [spread, -spread],
+        [spread, 0],
+        [spread, spread]
+      ]
+    }
+  ];
 
   faces.forEach(({ normal, points }) => {
-    const n = normal.clone().normalize()
-    const helper = Math.abs(n.y) > 0.9 ? new THREE.Vector3(0, 0, 1) : new THREE.Vector3(0, 1, 0)
-    const xAxis = new THREE.Vector3().crossVectors(helper, n).normalize()
-    const yAxis = new THREE.Vector3().crossVectors(n, xAxis).normalize()
+    const n = normal.clone().normalize();
+    const helper =
+      Math.abs(n.y) > 0.9
+        ? new THREE.Vector3(0, 0, 1)
+        : new THREE.Vector3(0, 1, 0);
+    const xAxis = new THREE.Vector3().crossVectors(helper, n).normalize();
+    const yAxis = new THREE.Vector3().crossVectors(n, xAxis).normalize();
     points.forEach(([gx, gy]) => {
       const base = new THREE.Vector3()
         .addScaledVector(xAxis, gx)
         .addScaledVector(yAxis, gy)
-        .addScaledVector(n, faceDepth - BACKGAMMON_DIE_PIP_DEPTH * 0.5)
+        .addScaledVector(n, faceDepth - BACKGAMMON_DIE_PIP_DEPTH * 0.5);
 
-      const pip = new THREE.Mesh(pipGeo, pipMaterial)
-      pip.castShadow = true
-      pip.receiveShadow = true
-      pip.position.copy(base).addScaledVector(n, BACKGAMMON_DIE_PIP_DEPTH)
-      pip.quaternion.setFromUnitVectors(new THREE.Vector3(0, 1, 0), n)
-      die.add(pip)
+      const pip = new THREE.Mesh(pipGeo, pipMaterial);
+      pip.castShadow = true;
+      pip.receiveShadow = true;
+      pip.position.copy(base).addScaledVector(n, BACKGAMMON_DIE_PIP_DEPTH);
+      pip.quaternion.setFromUnitVectors(new THREE.Vector3(0, 1, 0), n);
+      die.add(pip);
 
-      const rim = new THREE.Mesh(pipRimGeo, rimMaterial)
-      rim.receiveShadow = true
-      rim.renderOrder = 6
-      rim.position.copy(base).addScaledVector(n, BACKGAMMON_DIE_PIP_RIM_OFFSET)
-      rim.quaternion.setFromUnitVectors(new THREE.Vector3(0, 0, 1), n)
-      die.add(rim)
-    })
-  })
+      const rim = new THREE.Mesh(pipRimGeo, rimMaterial);
+      rim.receiveShadow = true;
+      rim.renderOrder = 6;
+      rim.position.copy(base).addScaledVector(n, BACKGAMMON_DIE_PIP_RIM_OFFSET);
+      rim.quaternion.setFromUnitVectors(new THREE.Vector3(0, 0, 1), n);
+      die.add(rim);
+    });
+  });
 
-  die.visible = false
+  die.visible = false;
   die.userData.setValue = (value) => {
-    die.userData.currentValue = value
-    die.quaternion.copy(getDieOrientationQuaternion(value))
-  }
-  die.userData.setValue(1)
-  return die
+    die.userData.currentValue = value;
+    die.quaternion.copy(getDieOrientationQuaternion(value));
+  };
+  die.userData.setValue(1);
+  return die;
 }
 
 function ensureKtx2SupportDetection(renderer = null) {
-  if (!sharedKtx2Loader || hasDetectedKtx2Support || !renderer) return
+  if (!sharedKtx2Loader || hasDetectedKtx2Support || !renderer) return;
   try {
-    sharedKtx2Loader.detectSupport(renderer)
-    hasDetectedKtx2Support = true
+    sharedKtx2Loader.detectSupport(renderer);
+    hasDetectedKtx2Support = true;
   } catch (error) {
-    console.warn('Failed to detect KTX2 support for Tavull loader', error)
+    console.warn('Failed to detect KTX2 support for Tavull loader', error);
   }
 }
 
 function createConfiguredGLTFLoader(renderer = null) {
-  const loader = new GLTFLoader()
-  loader.setCrossOrigin?.('anonymous')
-  const draco = new DRACOLoader()
-  draco.setDecoderPath(DRACO_DECODER_PATH)
-  loader.setDRACOLoader(draco)
-  loader.setMeshoptDecoder?.(MeshoptDecoder)
+  const loader = new GLTFLoader();
+  loader.setCrossOrigin?.('anonymous');
+  const draco = new DRACOLoader();
+  draco.setDecoderPath(DRACO_DECODER_PATH);
+  loader.setDRACOLoader(draco);
+  loader.setMeshoptDecoder?.(MeshoptDecoder);
 
   if (!sharedKtx2Loader) {
-    sharedKtx2Loader = new KTX2Loader()
-    sharedKtx2Loader.setTranscoderPath(BASIS_TRANSCODER_PATH)
+    sharedKtx2Loader = new KTX2Loader();
+    sharedKtx2Loader.setTranscoderPath(BASIS_TRANSCODER_PATH);
   }
-  ensureKtx2SupportDetection(renderer)
-  loader.setKTX2Loader(sharedKtx2Loader)
-  return loader
+  ensureKtx2SupportDetection(renderer);
+  loader.setKTX2Loader(sharedKtx2Loader);
+  return loader;
 }
 
 function prepareLoadedModel(model) {
   model?.traverse?.((obj) => {
-    if (!obj?.isMesh) return
-    obj.castShadow = true
-    obj.receiveShadow = true
-    const materials = Array.isArray(obj.material) ? obj.material : [obj.material]
+    if (!obj?.isMesh) return;
+    obj.castShadow = true;
+    obj.receiveShadow = true;
+    const materials = Array.isArray(obj.material)
+      ? obj.material
+      : [obj.material];
     materials.forEach((material) => {
-      if (!material) return
-      if (material.map) applySRGBColorSpace(material.map)
-      if (material.emissiveMap) applySRGBColorSpace(material.emissiveMap)
-    })
-  })
+      if (!material) return;
+      if (material.map) applySRGBColorSpace(material.map);
+      if (material.emissiveMap) applySRGBColorSpace(material.emissiveMap);
+    });
+  });
 }
 
 function resolveHdriUrlsByVariantIndex(preferredIndex = 0) {
-  const variant = POOL_ROYALE_HDRI_VARIANTS[preferredIndex] || DEFAULT_HDRI_ASSET
+  const variant =
+    POOL_ROYALE_HDRI_VARIANTS[preferredIndex] || DEFAULT_HDRI_ASSET;
   if (!variant?.assetId) {
-    return ['https://dl.polyhaven.org/file/ph-assets/HDRIs/hdr/2k/colorful_studio_2k.hdr']
+    return [
+      'https://dl.polyhaven.org/file/ph-assets/HDRIs/hdr/2k/colorful_studio_2k.hdr'
+    ];
   }
-  const resolutions = Array.isArray(variant.preferredResolutions) && variant.preferredResolutions.length
-    ? variant.preferredResolutions
-    : ['2k']
-  const ordered = [...resolutions, variant.fallbackResolution, '2k', '1k'].filter(Boolean)
-  const unique = [...new Set(ordered)]
-  return unique.map((resolution) => `https://dl.polyhaven.org/file/ph-assets/HDRIs/hdr/${resolution}/${variant.assetId}_${resolution}.hdr`)
+  const resolutions =
+    Array.isArray(variant.preferredResolutions) &&
+    variant.preferredResolutions.length
+      ? variant.preferredResolutions
+      : ['2k'];
+  const ordered = [
+    ...resolutions,
+    variant.fallbackResolution,
+    '2k',
+    '1k'
+  ].filter(Boolean);
+  const unique = [...new Set(ordered)];
+  return unique.map(
+    (resolution) =>
+      `https://dl.polyhaven.org/file/ph-assets/HDRIs/hdr/${resolution}/${variant.assetId}_${resolution}.hdr`
+  );
 }
 
 function loadHdriEnvironment(scene, preferredIndex = 0) {
-  const rgbe = new RGBELoader()
-  const ordered = resolveHdriUrlsByVariantIndex(preferredIndex)
+  const rgbe = new RGBELoader();
+  const ordered = resolveHdriUrlsByVariantIndex(preferredIndex);
   const tryNext = (index = 0) => {
-    if (index >= ordered.length) return
+    if (index >= ordered.length) return;
     rgbe.load(
       ordered[index],
       (texture) => {
-        texture.mapping = THREE.EquirectangularReflectionMapping
-        scene.environment = texture
+        texture.mapping = THREE.EquirectangularReflectionMapping;
+        scene.environment = texture;
       },
       undefined,
       () => tryNext(index + 1)
-    )
-  }
-  tryNext(0)
+    );
+  };
+  tryNext(0);
 }
 
-function createArenaChairFallback(chairColor = '#8b1d2c', legColor = '#111827') {
+function createArenaChairFallback(
+  chairColor = '#8b1d2c',
+  legColor = '#111827'
+) {
   const seatMaterial = new THREE.MeshStandardMaterial({
     color: chairColor,
     roughness: 0.42,
     metalness: 0.18
-  })
+  });
   const legMaterial = new THREE.MeshStandardMaterial({
     color: legColor,
     roughness: 0.55,
     metalness: 0.38
-  })
-  const chair = new THREE.Group()
+  });
+  const chair = new THREE.Group();
   const seatMesh = new THREE.Mesh(
     new THREE.BoxGeometry(SEAT_WIDTH, SEAT_THICKNESS_SCALED, SEAT_DEPTH),
     seatMaterial
-  )
-  seatMesh.position.y = SEAT_THICKNESS_SCALED / 2
+  );
+  seatMesh.position.y = SEAT_THICKNESS_SCALED / 2;
   const backMesh = new THREE.Mesh(
     new THREE.BoxGeometry(SEAT_WIDTH * 0.96, BACK_HEIGHT, BACK_THICKNESS),
     seatMaterial
-  )
+  );
   backMesh.position.set(
     0,
     SEAT_THICKNESS_SCALED / 2 + BACK_HEIGHT / 2,
     -SEAT_DEPTH / 2 + BACK_THICKNESS / 2
-  )
-  const armGeometry = new THREE.BoxGeometry(ARM_THICKNESS, ARM_HEIGHT, ARM_DEPTH)
-  const armOffsetX = SEAT_WIDTH / 2 - ARM_THICKNESS / 2
-  const armOffsetY = SEAT_THICKNESS_SCALED / 2 + ARM_HEIGHT / 2
-  const armOffsetZ = -ARM_DEPTH / 2 + ARM_THICKNESS * 0.2
-  const leftArm = new THREE.Mesh(armGeometry, seatMaterial)
-  leftArm.position.set(-armOffsetX, armOffsetY, armOffsetZ)
-  const rightArm = new THREE.Mesh(armGeometry, seatMaterial)
-  rightArm.position.set(armOffsetX, armOffsetY, armOffsetZ)
+  );
+  const armGeometry = new THREE.BoxGeometry(
+    ARM_THICKNESS,
+    ARM_HEIGHT,
+    ARM_DEPTH
+  );
+  const armOffsetX = SEAT_WIDTH / 2 - ARM_THICKNESS / 2;
+  const armOffsetY = SEAT_THICKNESS_SCALED / 2 + ARM_HEIGHT / 2;
+  const armOffsetZ = -ARM_DEPTH / 2 + ARM_THICKNESS * 0.2;
+  const leftArm = new THREE.Mesh(armGeometry, seatMaterial);
+  leftArm.position.set(-armOffsetX, armOffsetY, armOffsetZ);
+  const rightArm = new THREE.Mesh(armGeometry, seatMaterial);
+  rightArm.position.set(armOffsetX, armOffsetY, armOffsetZ);
   const legMesh = new THREE.Mesh(
-    new THREE.CylinderGeometry(0.16 * MODEL_SCALE * STOOL_SCALE, 0.2 * MODEL_SCALE * STOOL_SCALE, BASE_COLUMN_HEIGHT, 18),
+    new THREE.CylinderGeometry(
+      0.16 * MODEL_SCALE * STOOL_SCALE,
+      0.2 * MODEL_SCALE * STOOL_SCALE,
+      BASE_COLUMN_HEIGHT,
+      18
+    ),
     legMaterial
-  )
-  legMesh.position.y = -SEAT_THICKNESS_SCALED / 2 - BASE_COLUMN_HEIGHT / 2
+  );
+  legMesh.position.y = -SEAT_THICKNESS_SCALED / 2 - BASE_COLUMN_HEIGHT / 2;
   const foot = new THREE.Mesh(
-    new THREE.CylinderGeometry(0.32 * MODEL_SCALE * STOOL_SCALE, 0.32 * MODEL_SCALE * STOOL_SCALE, 0.08 * MODEL_SCALE, 24),
+    new THREE.CylinderGeometry(
+      0.32 * MODEL_SCALE * STOOL_SCALE,
+      0.32 * MODEL_SCALE * STOOL_SCALE,
+      0.08 * MODEL_SCALE,
+      24
+    ),
     legMaterial
-  )
-  foot.position.y = legMesh.position.y - BASE_COLUMN_HEIGHT / 2 - 0.04 * MODEL_SCALE
-  ;[seatMesh, backMesh, leftArm, rightArm, legMesh, foot].forEach((mesh) => {
-    mesh.castShadow = true
-    mesh.receiveShadow = true
-    chair.add(mesh)
-  })
-  return chair
+  );
+  foot.position.y =
+    legMesh.position.y - BASE_COLUMN_HEIGHT / 2 - 0.04 * MODEL_SCALE;
+  [seatMesh, backMesh, leftArm, rightArm, legMesh, foot].forEach((mesh) => {
+    mesh.castShadow = true;
+    mesh.receiveShadow = true;
+    chair.add(mesh);
+  });
+  return chair;
 }
 
 async function loadMappedChair(renderer, theme) {
-  const loader = createConfiguredGLTFLoader(renderer)
-  let loaded = null
+  const loader = createConfiguredGLTFLoader(renderer);
+  let loaded = null;
   for (const url of CHAIR_MODEL_URLS) {
     try {
-      const gltf = await loader.loadAsync(url)
-      loaded = gltf?.scene || gltf?.scenes?.[0]
-      if (loaded) break
+      const gltf = await loader.loadAsync(url);
+      loaded = gltf?.scene || gltf?.scenes?.[0];
+      if (loaded) break;
     } catch (error) {
-      console.warn('Failed to load Backgammon chair model', url, error)
+      console.warn('Failed to load Backgammon chair model', url, error);
     }
   }
-  if (!loaded) return createArenaChairFallback(theme.primary, theme.leg)
+  if (!loaded) return createArenaChairFallback(theme.primary, theme.leg);
 
-  const model = loaded.clone(true)
-  prepareLoadedModel(model)
-  const tint = new THREE.Color(theme.primary)
-  const legTint = new THREE.Color(theme.leg)
+  const model = loaded.clone(true);
+  prepareLoadedModel(model);
+  const tint = new THREE.Color(theme.primary);
+  const legTint = new THREE.Color(theme.leg);
   model.traverse((node) => {
-    if (!node?.isMesh) return
-    const mats = Array.isArray(node.material) ? node.material : [node.material]
+    if (!node?.isMesh) return;
+    const mats = Array.isArray(node.material) ? node.material : [node.material];
     mats.forEach((mat) => {
-      if (!mat) return
-      const label = `${mat.name || ''} ${node.name || ''}`.toLowerCase()
-      const hasMappedTexture = Boolean(mat.map)
+      if (!mat) return;
+      const label = `${mat.name || ''} ${node.name || ''}`.toLowerCase();
+      const hasMappedTexture = Boolean(mat.map);
       if (!hasMappedTexture) {
-        if (/leg|base|metal|foot/.test(label)) mat.color?.lerp(legTint, 0.7)
-        else mat.color?.lerp(tint, 0.55)
+        if (/leg|base|metal|foot/.test(label)) mat.color?.lerp(legTint, 0.7);
+        else mat.color?.lerp(tint, 0.55);
       }
-      if (mat.map) applySRGBColorSpace(mat.map)
-      if (mat.emissiveMap) applySRGBColorSpace(mat.emissiveMap)
-      mat.needsUpdate = true
-    })
-  })
-  const box = new THREE.Box3().setFromObject(model)
-  const size = box.getSize(new THREE.Vector3())
-  const currentMax = Math.max(size.x, size.y, size.z)
-  const targetMax = Math.max(SEAT_WIDTH, BACK_HEIGHT * 1.2, SEAT_DEPTH)
-  if (currentMax > 0) model.scale.multiplyScalar(targetMax / currentMax)
-  const scaledBox = new THREE.Box3().setFromObject(model)
-  const center = scaledBox.getCenter(new THREE.Vector3())
-  model.position.set(-center.x, -scaledBox.min.y, -center.z)
-  return model
+      if (mat.map) applySRGBColorSpace(mat.map);
+      if (mat.emissiveMap) applySRGBColorSpace(mat.emissiveMap);
+      mat.needsUpdate = true;
+    });
+  });
+  const box = new THREE.Box3().setFromObject(model);
+  const size = box.getSize(new THREE.Vector3());
+  const currentMax = Math.max(size.x, size.y, size.z);
+  const targetMax = Math.max(SEAT_WIDTH, BACK_HEIGHT * 1.2, SEAT_DEPTH);
+  if (currentMax > 0) model.scale.multiplyScalar(targetMax / currentMax);
+  const scaledBox = new THREE.Box3().setFromObject(model);
+  const center = scaledBox.getCenter(new THREE.Vector3());
+  model.position.set(-center.x, -scaledBox.min.y, -center.z);
+  return model;
 }
-
-
 
 const pointColumnFromEdge = (x) => {
-  const laneInnerEdge = BOARD_HALF_X - BOARD_EDGE_MARGIN_X
-  const distanceFromEdge = laneInnerEdge - Math.abs(x)
-  return Math.max(0, Math.min(POINT_COLUMNS - 1, Math.round(distanceFromEdge / POINT_WIDTH)))
-}
+  const laneInnerEdge = BOARD_HALF_X - BOARD_EDGE_MARGIN_X;
+  const distanceFromEdge = laneInnerEdge - Math.abs(x);
+  return Math.max(
+    0,
+    Math.min(POINT_COLUMNS - 1, Math.round(distanceFromEdge / POINT_WIDTH))
+  );
+};
 
 const pointBasePosition = (index) => {
-  const rightLaneOuterX = BOARD_HALF_X - BOARD_EDGE_MARGIN_X - POINT_WIDTH * 0.5 - POINT_INSET_X
-  const rightLaneInnerX = CENTER_BAR_WIDTH * 0.5 + POINT_WIDTH * 0.5 + POINT_INSET_X
-  const leftLaneInnerX = -rightLaneInnerX
-  const leftLaneOuterX = -rightLaneOuterX
+  const rightLaneOuterX =
+    BOARD_HALF_X - BOARD_EDGE_MARGIN_X - POINT_WIDTH * 0.5 - POINT_INSET_X;
+  const rightLaneInnerX =
+    CENTER_BAR_WIDTH * 0.5 + POINT_WIDTH * 0.5 + POINT_INSET_X;
+  const leftLaneInnerX = -rightLaneInnerX;
+  const leftLaneOuterX = -rightLaneOuterX;
 
-  const laneStep = (rightLaneOuterX - rightLaneInnerX) / Math.max(1, POINT_COLUMNS - 1)
+  const laneStep =
+    (rightLaneOuterX - rightLaneInnerX) / Math.max(1, POINT_COLUMNS - 1);
   const bottomLane = [
-    ...Array.from({ length: POINT_COLUMNS }, (_, col) => rightLaneOuterX - col * laneStep),
-    ...Array.from({ length: POINT_COLUMNS }, (_, col) => leftLaneInnerX - col * laneStep)
-  ]
+    ...Array.from(
+      { length: POINT_COLUMNS },
+      (_, col) => rightLaneOuterX - col * laneStep
+    ),
+    ...Array.from(
+      { length: POINT_COLUMNS },
+      (_, col) => leftLaneInnerX - col * laneStep
+    )
+  ];
 
   if (index <= 11) {
     return {
       x: bottomLane[index],
       z: BOARD_HALF_Z - BOARD_EDGE_MARGIN_Z - POINT_INSET_Z,
       top: false
-    }
+    };
   }
-  const i = 23 - index
+  const i = 23 - index;
   return {
     x: bottomLane[i],
     z: -BOARD_HALF_Z + BOARD_EDGE_MARGIN_Z + POINT_INSET_Z,
     top: true
-  }
-}
+  };
+};
 
 export default function TavullBattleRoyal() {
-  const navigate = useNavigate()
-  useTelegramBackButton()
-  const canvasHostRef = useRef(null)
-  const sceneBundleRef = useRef(null)
-  const isMountedRef = useRef(true)
-  const pendingTimeoutsRef = useRef([])
+  const navigate = useNavigate();
+  useTelegramBackButton();
+  const canvasHostRef = useRef(null);
+  const sceneBundleRef = useRef(null);
+  const isMountedRef = useRef(true);
+  const pendingTimeoutsRef = useRef([]);
 
-  const [game, setGame] = useState({ points: initialBoard(), bar: { white: 0, black: 0 }, off: { white: 0, black: 0 } })
-  const [forcedWinner, setForcedWinner] = useState(null)
-  const [dice, setDice] = useState([])
-  const [available, setAvailable] = useState([])
-  const [message, setMessage] = useState('Roll to start. You are White.')
-  const [aiThinking, setAiThinking] = useState(false)
-  const [configOpen, setConfigOpen] = useState(false)
-  const [viewMode, setViewMode] = useState('3d')
-  const [isRollingDice, setIsRollingDice] = useState(false)
-  const [tableFinishIdx, setTableFinishIdx] = useState(0)
-  const [chairThemeIdx, setChairThemeIdx] = useState(0)
-  const [hdriIdx, setHdriIdx] = useState(0)
-  const [qualityIdx, setQualityIdx] = useState(1)
-  const [showChat, setShowChat] = useState(false)
-  const [showGift, setShowGift] = useState(false)
-  const [chatBubbles, setChatBubbles] = useState([])
-  const [soundEnabled, setSoundEnabled] = useState(true)
-  const [inventoryVersion, setInventoryVersion] = useState(0)
-  const [activeMoveHighlight, setActiveMoveHighlight] = useState(null)
-  const [selectedPoint, setSelectedPoint] = useState(null)
-  const accountId = chessBattleAccountId()
-  const chessInventory = useMemo(() => getChessBattleInventory(accountId), [accountId, inventoryVersion])
-  const playerName = getTelegramFirstName() || 'Player'
-  const playerAvatar = getTelegramPhotoUrl()
+  const [game, setGame] = useState({
+    points: initialBoard(),
+    bar: { white: 0, black: 0 },
+    off: { white: 0, black: 0 }
+  });
+  const [forcedWinner, setForcedWinner] = useState(null);
+  const [dice, setDice] = useState([]);
+  const [available, setAvailable] = useState([]);
+  const [message, setMessage] = useState('Roll to start. You are White.');
+  const [aiThinking, setAiThinking] = useState(false);
+  const [configOpen, setConfigOpen] = useState(false);
+  const [viewMode, setViewMode] = useState('3d');
+  const [isRollingDice, setIsRollingDice] = useState(false);
+  const [tableFinishIdx, setTableFinishIdx] = useState(0);
+  const [chairThemeIdx, setChairThemeIdx] = useState(0);
+  const [hdriIdx, setHdriIdx] = useState(0);
+  const [boardFinishIdx, setBoardFinishIdx] = useState(0);
+  const [frameFinishIdx, setFrameFinishIdx] = useState(0);
+  const [triangleColorIdx, setTriangleColorIdx] = useState(0);
+  const [qualityIdx, setQualityIdx] = useState(1);
+  const [showChat, setShowChat] = useState(false);
+  const [showGift, setShowGift] = useState(false);
+  const [chatBubbles, setChatBubbles] = useState([]);
+  const [soundEnabled, setSoundEnabled] = useState(true);
+  const [inventoryVersion, setInventoryVersion] = useState(0);
+  const [activeMoveHighlight, setActiveMoveHighlight] = useState(null);
+  const [selectedPoint, setSelectedPoint] = useState(null);
+  const accountId = tavullBattleAccountId();
+  const tavullInventory = useMemo(
+    () => getTavullBattleInventory(accountId),
+    [accountId, inventoryVersion]
+  );
+  const playerName = getTelegramFirstName() || 'Player';
+  const playerAvatar = getTelegramPhotoUrl();
 
-  const winner = forcedWinner || (game.off.white >= 15 ? WHITE : game.off.black >= 15 ? BLACK : null)
+  const winner =
+    forcedWinner ||
+    (game.off.white >= 15 ? WHITE : game.off.black >= 15 ? BLACK : null);
 
   const players = [
     {
@@ -500,281 +648,442 @@ export default function TavullBattleRoyal() {
       color: 'black',
       isTurn: aiThinking
     }
-  ]
-
+  ];
 
   const ownedChairOptions = useMemo(
-    () => CHAIR_THEMES.filter((option) => isChessOptionUnlocked('chairColor', option.id, chessInventory)),
-    [chessInventory]
-  )
+    () =>
+      CHAIR_THEMES.filter((option) =>
+        isTavullOptionUnlocked('chairColor', option.id, tavullInventory)
+      ),
+    [tavullInventory]
+  );
   const ownedHdriOptions = useMemo(
-    () => POOL_ROYALE_HDRI_VARIANTS.filter((option) => isChessOptionUnlocked('environmentHdri', option.id, chessInventory)),
-    [chessInventory]
-  )
+    () =>
+      POOL_ROYALE_HDRI_VARIANTS.filter((option) =>
+        isTavullOptionUnlocked('environmentHdri', option.id, tavullInventory)
+      ),
+    [tavullInventory]
+  );
   const ownedFinishOptions = useMemo(
-    () => MURLAN_TABLE_FINISHES.filter((option) => isChessOptionUnlocked('tableFinish', option.id, chessInventory)),
-    [chessInventory]
-  )
+    () =>
+      MURLAN_TABLE_FINISHES.filter((option) =>
+        isTavullOptionUnlocked('tableFinish', option.id, tavullInventory)
+      ),
+    [tavullInventory]
+  );
+  const ownedBoardFinishOptions = useMemo(
+    () =>
+      TAVULL_BATTLE_BOARD_FINISH_OPTIONS.filter((option) =>
+        isTavullOptionUnlocked('boardFinish', option.id, tavullInventory)
+      ),
+    [tavullInventory]
+  );
+  const ownedFrameFinishOptions = useMemo(
+    () =>
+      TAVULL_BATTLE_FRAME_FINISH_OPTIONS.filter((option) =>
+        isTavullOptionUnlocked('frameFinish', option.id, tavullInventory)
+      ),
+    [tavullInventory]
+  );
+  const ownedTriangleColorOptions = useMemo(
+    () =>
+      TAVULL_BATTLE_TRIANGLE_COLOR_OPTIONS.filter((option) =>
+        isTavullOptionUnlocked('triangleColor', option.id, tavullInventory)
+      ),
+    [tavullInventory]
+  );
 
   useEffect(() => {
-    const onInventoryUpdate = () => setInventoryVersion((v) => v + 1)
-    window.addEventListener('chessBattleInventoryUpdate', onInventoryUpdate)
-    return () => window.removeEventListener('chessBattleInventoryUpdate', onInventoryUpdate)
-  }, [])
+    const onInventoryUpdate = () => setInventoryVersion((v) => v + 1);
+    window.addEventListener('tavullBattleInventoryUpdate', onInventoryUpdate);
+    return () =>
+      window.removeEventListener(
+        'tavullBattleInventoryUpdate',
+        onInventoryUpdate
+      );
+  }, []);
 
   useEffect(() => {
-    if (!ownedFinishOptions.length) return
-    if (!ownedFinishOptions[tableFinishIdx]) setTableFinishIdx(0)
-  }, [ownedFinishOptions, tableFinishIdx])
+    if (!ownedFinishOptions.length) return;
+    if (!ownedFinishOptions[tableFinishIdx]) setTableFinishIdx(0);
+  }, [ownedFinishOptions, tableFinishIdx]);
 
   useEffect(() => {
-    if (!ownedChairOptions.length) return
-    if (!ownedChairOptions[chairThemeIdx]) setChairThemeIdx(0)
-  }, [ownedChairOptions, chairThemeIdx])
+    if (!ownedChairOptions.length) return;
+    if (!ownedChairOptions[chairThemeIdx]) setChairThemeIdx(0);
+  }, [ownedChairOptions, chairThemeIdx]);
 
   useEffect(() => {
-    if (!ownedHdriOptions.length) return
-    if (!ownedHdriOptions[hdriIdx]) setHdriIdx(0)
-  }, [ownedHdriOptions, hdriIdx])
+    if (!ownedHdriOptions.length) return;
+    if (!ownedHdriOptions[hdriIdx]) setHdriIdx(0);
+  }, [ownedHdriOptions, hdriIdx]);
+  useEffect(() => {
+    if (!ownedBoardFinishOptions.length) return;
+    if (!ownedBoardFinishOptions[boardFinishIdx]) setBoardFinishIdx(0);
+  }, [ownedBoardFinishOptions, boardFinishIdx]);
+  useEffect(() => {
+    if (!ownedFrameFinishOptions.length) return;
+    if (!ownedFrameFinishOptions[frameFinishIdx]) setFrameFinishIdx(0);
+  }, [ownedFrameFinishOptions, frameFinishIdx]);
+  useEffect(() => {
+    if (!ownedTriangleColorOptions.length) return;
+    if (!ownedTriangleColorOptions[triangleColorIdx]) setTriangleColorIdx(0);
+  }, [ownedTriangleColorOptions, triangleColorIdx]);
 
   const playSfx = (url, volumeScale = 1) => {
-    if (isGameMuted() || !soundEnabled) return
+    if (isGameMuted() || !soundEnabled) return;
     try {
-      const audio = new Audio(url)
-      audio.volume = Math.min(1, getGameVolume() * volumeScale)
-      void audio.play().catch(() => {})
+      const audio = new Audio(url);
+      audio.volume = Math.min(1, getGameVolume() * volumeScale);
+      void audio.play().catch(() => {});
     } catch {}
-  }
+  };
 
   useEffect(() => {
-    isMountedRef.current = true
-    if (!canvasHostRef.current) return undefined
+    isMountedRef.current = true;
+    if (!canvasHostRef.current) return undefined;
 
-    const host = canvasHostRef.current
-    const scene = new THREE.Scene()
-    scene.background = new THREE.Color('#090f1f')
+    const host = canvasHostRef.current;
+    const scene = new THREE.Scene();
+    scene.background = new THREE.Color('#090f1f');
 
-    const camera = new THREE.PerspectiveCamera(42, host.clientWidth / host.clientHeight, 0.1, 120)
-    camera.position.copy(CAMERA_3D_POSITION)
+    const camera = new THREE.PerspectiveCamera(
+      42,
+      host.clientWidth / host.clientHeight,
+      0.1,
+      120
+    );
+    camera.position.copy(CAMERA_3D_POSITION);
 
-    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: false, powerPreference: 'high-performance' })
-    applyRendererSRGB(renderer)
-    const initialQuality = QUALITY_OPTIONS[qualityIdx] || QUALITY_OPTIONS[1]
-    renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, initialQuality.pixelRatio))
-    renderer.setSize(host.clientWidth, host.clientHeight)
-    renderer.shadowMap.enabled = Boolean(initialQuality.shadows)
-    host.appendChild(renderer.domElement)
+    const renderer = new THREE.WebGLRenderer({
+      antialias: true,
+      alpha: false,
+      powerPreference: 'high-performance'
+    });
+    applyRendererSRGB(renderer);
+    const initialQuality = QUALITY_OPTIONS[qualityIdx] || QUALITY_OPTIONS[1];
+    renderer.setPixelRatio(
+      Math.min(window.devicePixelRatio || 1, initialQuality.pixelRatio)
+    );
+    renderer.setSize(host.clientWidth, host.clientHeight);
+    renderer.shadowMap.enabled = Boolean(initialQuality.shadows);
+    host.appendChild(renderer.domElement);
 
-    const controls = new OrbitControls(camera, renderer.domElement)
-    controls.enablePan = false
-    controls.enableDamping = true
-    controls.maxPolarAngle = Math.PI * 0.48
-    controls.minDistance = 4.4
-    controls.maxDistance = 8.6
-    controls.target.copy(CAMERA_TARGET)
+    const controls = new OrbitControls(camera, renderer.domElement);
+    controls.enablePan = false;
+    controls.enableDamping = true;
+    controls.maxPolarAngle = Math.PI * 0.48;
+    controls.minDistance = 4.4;
+    controls.maxDistance = 8.6;
+    controls.target.copy(CAMERA_TARGET);
 
     const applyViewMode = (mode) => {
       if (mode === '2d') {
-        camera.position.copy(CAMERA_2D_POSITION)
-        camera.lookAt(CAMERA_TARGET)
-        controls.minPolarAngle = 0.02
-        controls.maxPolarAngle = Math.PI * 0.08
-        controls.enableRotate = false
-        controls.minDistance = 5.8
-        controls.maxDistance = 11.5
+        camera.position.copy(CAMERA_2D_POSITION);
+        camera.lookAt(CAMERA_TARGET);
+        controls.minPolarAngle = 0.02;
+        controls.maxPolarAngle = Math.PI * 0.08;
+        controls.enableRotate = false;
+        controls.minDistance = 5.8;
+        controls.maxDistance = 11.5;
       } else {
-        camera.position.copy(CAMERA_3D_POSITION)
-        camera.lookAt(CAMERA_TARGET)
-        controls.minPolarAngle = 0.4
-        controls.maxPolarAngle = Math.PI * 0.48
-        controls.enableRotate = true
-        controls.minDistance = 4.4
-        controls.maxDistance = 8.6
+        camera.position.copy(CAMERA_3D_POSITION);
+        camera.lookAt(CAMERA_TARGET);
+        controls.minPolarAngle = 0.4;
+        controls.maxPolarAngle = Math.PI * 0.48;
+        controls.enableRotate = true;
+        controls.minDistance = 4.4;
+        controls.maxDistance = 8.6;
       }
-      controls.target.copy(CAMERA_TARGET)
-      controls.update()
-    }
-    applyViewMode(viewMode)
+      controls.target.copy(CAMERA_TARGET);
+      controls.update();
+    };
+    applyViewMode(viewMode);
 
-    scene.add(new THREE.AmbientLight('#ffffff', 0.5))
-    const key = new THREE.DirectionalLight('#ffffff', 1.15)
-    key.position.set(5, 8, 3)
-    key.castShadow = true
-    scene.add(key)
+    scene.add(new THREE.AmbientLight('#ffffff', 0.5));
+    const key = new THREE.DirectionalLight('#ffffff', 1.15);
+    key.position.set(5, 8, 3);
+    key.castShadow = true;
+    scene.add(key);
 
-    const fill = new THREE.PointLight('#6ec4ff', 0.7, 30)
-    fill.position.set(-4, 4.5, -3)
-    scene.add(fill)
+    const fill = new THREE.PointLight('#6ec4ff', 0.7, 30);
+    fill.position.set(-4, 4.5, -3);
+    scene.add(fill);
 
-    const initialHdri = ownedHdriOptions[hdriIdx] || ownedHdriOptions[0]
-    const initialHdriIdx = POOL_ROYALE_HDRI_VARIANTS.findIndex((option) => option.id === initialHdri?.id)
-    loadHdriEnvironment(scene, initialHdriIdx >= 0 ? initialHdriIdx : 0)
+    const initialHdri = ownedHdriOptions[hdriIdx] || ownedHdriOptions[0];
+    const initialHdriIdx = POOL_ROYALE_HDRI_VARIANTS.findIndex(
+      (option) => option.id === initialHdri?.id
+    );
+    loadHdriEnvironment(scene, initialHdriIdx >= 0 ? initialHdriIdx : 0);
 
-    const initialFinish = ownedFinishOptions[tableFinishIdx] || ownedFinishOptions[0]
-    const initialFinishIdx = MURLAN_TABLE_FINISHES.findIndex((option) => option.id === initialFinish?.id)
-    const table = createMurlanStyleTable({ arena: scene, renderer, tableRadius: TABLE_RADIUS, tableHeight: TABLE_HEIGHT })
-    applyTableMaterials(table.parts, MURLAN_TABLE_FINISHES[initialFinishIdx >= 0 ? initialFinishIdx : 0])
+    const initialFinish =
+      ownedFinishOptions[tableFinishIdx] || ownedFinishOptions[0];
+    const initialFinishIdx = MURLAN_TABLE_FINISHES.findIndex(
+      (option) => option.id === initialFinish?.id
+    );
+    const table = createMurlanStyleTable({
+      arena: scene,
+      renderer,
+      tableRadius: TABLE_RADIUS,
+      tableHeight: TABLE_HEIGHT
+    });
+    applyTableMaterials(
+      table.parts,
+      MURLAN_TABLE_FINISHES[initialFinishIdx >= 0 ? initialFinishIdx : 0]
+    );
 
-    const chairRootA = new THREE.Group()
-    chairRootA.position.set(0, CHAIR_BASE_HEIGHT, CHAIR_DISTANCE)
-    chairRootA.rotation.y = Math.PI
-    scene.add(chairRootA)
-    const chairRootB = new THREE.Group()
-    chairRootB.position.set(0, CHAIR_BASE_HEIGHT, -CHAIR_DISTANCE)
-    scene.add(chairRootB)
+    const chairRootA = new THREE.Group();
+    chairRootA.position.set(0, CHAIR_BASE_HEIGHT, CHAIR_DISTANCE);
+    chairRootA.rotation.y = Math.PI;
+    scene.add(chairRootA);
+    const chairRootB = new THREE.Group();
+    chairRootB.position.set(0, CHAIR_BASE_HEIGHT, -CHAIR_DISTANCE);
+    scene.add(chairRootB);
     const setChairs = async (themeIndex) => {
-      const theme = CHAIR_THEMES[themeIndex] || CHAIR_THEMES[0]
-      const a = await loadMappedChair(renderer, theme)
-      const b = a.clone(true)
-      chairRootA.clear()
-      chairRootB.clear()
-      chairRootA.add(a)
-      chairRootB.add(b)
-    }
-    void setChairs(chairThemeIdx)
+      const theme = CHAIR_THEMES[themeIndex] || CHAIR_THEMES[0];
+      const a = await loadMappedChair(renderer, theme);
+      const b = a.clone(true);
+      chairRootA.clear();
+      chairRootB.clear();
+      chairRootA.add(a);
+      chairRootB.add(b);
+    };
+    void setChairs(chairThemeIdx);
 
-    const boardRoot = new THREE.Group()
-    scene.add(boardRoot)
+    const boardRoot = new THREE.Group();
+    scene.add(boardRoot);
 
-    const woodMaterial = new THREE.MeshStandardMaterial({ color: '#7b4127', roughness: 0.52, metalness: 0.14 })
-    const trimMaterial = new THREE.MeshStandardMaterial({ color: '#5d2e1b', roughness: 0.48, metalness: 0.22 })
-    const inlayMaterial = new THREE.MeshStandardMaterial({ color: '#f0dfbf', roughness: 0.74, metalness: 0.02 })
-    const pointDarkMaterial = new THREE.MeshStandardMaterial({ color: '#08080b', roughness: 0.66, metalness: 0.08 })
-    const pointLightMaterial = new THREE.MeshStandardMaterial({ color: '#f4f1e8', roughness: 0.7, metalness: 0.04 })
+    const woodMaterial = new THREE.MeshStandardMaterial({
+      color: '#7b4127',
+      roughness: 0.52,
+      metalness: 0.14
+    });
+    const frameMaterial = new THREE.MeshStandardMaterial({
+      color: '#5d2e1b',
+      roughness: 0.48,
+      metalness: 0.22
+    });
+    const boardSurfaceMaterial = new THREE.MeshStandardMaterial({
+      color: '#f0dfbf',
+      roughness: 0.74,
+      metalness: 0.02
+    });
+    const pointDarkMaterial = new THREE.MeshStandardMaterial({
+      color: '#08080b',
+      roughness: 0.66,
+      metalness: 0.08
+    });
+    const pointLightMaterial = new THREE.MeshStandardMaterial({
+      color: '#f4f1e8',
+      roughness: 0.7,
+      metalness: 0.04
+    });
+    const applyFinishToMaterial = (material, finish, fallback = '#7b4127') => {
+      const [primary] = finish?.swatches || [];
+      material.color.set(primary || fallback);
+      material.needsUpdate = true;
+    };
+    const applyTrianglePalette = (palette) => {
+      pointDarkMaterial.color.set(palette?.dark || '#f59e0b');
+      pointLightMaterial.color.set(palette?.light || '#fef3c7');
+      pointDarkMaterial.needsUpdate = true;
+      pointLightMaterial.needsUpdate = true;
+    };
 
-    const boardBase = new THREE.Mesh(new THREE.BoxGeometry(BOARD_HALF_X * 2, BOARD_BASE_THICKNESS, BOARD_HALF_Z * 2), woodMaterial)
-    boardBase.position.y = BOARD_Y
-    boardRoot.add(boardBase)
+    const boardBase = new THREE.Mesh(
+      new THREE.BoxGeometry(
+        BOARD_HALF_X * 2,
+        BOARD_BASE_THICKNESS,
+        BOARD_HALF_Z * 2
+      ),
+      woodMaterial
+    );
+    boardBase.position.y = BOARD_Y;
+    boardRoot.add(boardBase);
 
     const frameOuter = new THREE.Mesh(
-      new THREE.BoxGeometry(BOARD_HALF_X * 1.98, FRAME_THICKNESS, BOARD_HALF_Z * 1.98),
-      trimMaterial
-    )
-    frameOuter.position.y = BOARD_Y + BOARD_BASE_THICKNESS * 0.52
-    boardRoot.add(frameOuter)
+      new THREE.BoxGeometry(
+        BOARD_HALF_X * 1.98,
+        FRAME_THICKNESS,
+        BOARD_HALF_Z * 1.98
+      ),
+      frameMaterial
+    );
+    frameOuter.position.y = BOARD_Y + BOARD_BASE_THICKNESS * 0.52;
+    boardRoot.add(frameOuter);
 
-    const laneWidth = BOARD_HALF_X - CENTER_BAR_WIDTH * 0.5 - BOARD_EDGE_MARGIN_X
-    const laneDepth = BOARD_HALF_Z * 2 - BOARD_EDGE_MARGIN_Z * 2
-    const laneOffset = CENTER_BAR_WIDTH * 0.5 + laneWidth * 0.5
-    ;[-1, 1].forEach((side) => {
-      const lane = new THREE.Mesh(new THREE.BoxGeometry(laneWidth, LANE_THICKNESS, laneDepth), inlayMaterial)
-      lane.position.set(side * laneOffset, BOARD_Y + BOARD_BASE_THICKNESS * 0.62, 0)
-      boardRoot.add(lane)
-    })
+    const laneWidth =
+      BOARD_HALF_X - CENTER_BAR_WIDTH * 0.5 - BOARD_EDGE_MARGIN_X;
+    const laneDepth = BOARD_HALF_Z * 2 - BOARD_EDGE_MARGIN_Z * 2;
+    const laneOffset = CENTER_BAR_WIDTH * 0.5 + laneWidth * 0.5;
+    [-1, 1].forEach((side) => {
+      const lane = new THREE.Mesh(
+        new THREE.BoxGeometry(laneWidth, LANE_THICKNESS, laneDepth),
+        boardSurfaceMaterial
+      );
+      lane.position.set(
+        side * laneOffset,
+        BOARD_Y + BOARD_BASE_THICKNESS * 0.62,
+        0
+      );
+      boardRoot.add(lane);
+    });
 
-    const centerBar = new THREE.Mesh(new THREE.BoxGeometry(CENTER_BAR_WIDTH, CENTER_BAR_THICKNESS, BOARD_HALF_Z * 2 - BOARD_EDGE_MARGIN_Z * 2), trimMaterial)
-    centerBar.position.y = BOARD_Y + BOARD_BASE_THICKNESS * 0.64
-    boardRoot.add(centerBar)
+    const centerBar = new THREE.Mesh(
+      new THREE.BoxGeometry(
+        CENTER_BAR_WIDTH,
+        CENTER_BAR_THICKNESS,
+        BOARD_HALF_Z * 2 - BOARD_EDGE_MARGIN_Z * 2
+      ),
+      boardSurfaceMaterial
+    );
+    centerBar.position.y = BOARD_Y + BOARD_BASE_THICKNESS * 0.64;
+    boardRoot.add(centerBar);
 
     const hinge = new THREE.Mesh(
       new THREE.BoxGeometry(0.022, 0.09, BOARD_HALF_Z * 0.25),
-      new THREE.MeshStandardMaterial({ color: '#a9b0ba', roughness: 0.3, metalness: 0.92 })
-    )
-    hinge.position.set(0, BOARD_Y + 0.165, 0)
-    boardRoot.add(hinge)
+      new THREE.MeshStandardMaterial({
+        color: '#a9b0ba',
+        roughness: 0.3,
+        metalness: 0.92
+      })
+    );
+    hinge.position.set(0, BOARD_Y + 0.165, 0);
+    boardRoot.add(hinge);
 
     const makeTriangle = (x, top, dark) => {
-      const baseZ = top ? -BOARD_HALF_Z + BOARD_EDGE_MARGIN_Z : BOARD_HALF_Z - BOARD_EDGE_MARGIN_Z
-      const apexZ = top ? baseZ + TRIANGLE_APEX_LENGTH : baseZ - TRIANGLE_APEX_LENGTH
-      const shape = new THREE.Shape()
-      shape.moveTo(-TRIANGLE_HALF_BASE, baseZ)
-      shape.lineTo(TRIANGLE_HALF_BASE, baseZ)
-      shape.lineTo(0, apexZ)
-      shape.closePath()
-      const geom = new THREE.ExtrudeGeometry(shape, { depth: TRIANGLE_HEIGHT, bevelEnabled: false })
-      geom.rotateX(-Math.PI / 2)
-      const tri = new THREE.Mesh(geom, dark ? pointDarkMaterial : pointLightMaterial)
-      tri.position.set(x, BOARD_Y + TRIANGLE_BASE_Y_OFFSET, 0)
-      boardRoot.add(tri)
-    }
+      const baseZ = top
+        ? -BOARD_HALF_Z + BOARD_EDGE_MARGIN_Z
+        : BOARD_HALF_Z - BOARD_EDGE_MARGIN_Z;
+      const apexZ = top
+        ? baseZ + TRIANGLE_APEX_LENGTH
+        : baseZ - TRIANGLE_APEX_LENGTH;
+      const shape = new THREE.Shape();
+      shape.moveTo(-TRIANGLE_HALF_BASE, baseZ);
+      shape.lineTo(TRIANGLE_HALF_BASE, baseZ);
+      shape.lineTo(0, apexZ);
+      shape.closePath();
+      const geom = new THREE.ExtrudeGeometry(shape, {
+        depth: TRIANGLE_HEIGHT,
+        bevelEnabled: false
+      });
+      geom.rotateX(-Math.PI / 2);
+      const tri = new THREE.Mesh(
+        geom,
+        dark ? pointDarkMaterial : pointLightMaterial
+      );
+      tri.position.set(x, BOARD_Y + TRIANGLE_BASE_Y_OFFSET, 0);
+      boardRoot.add(tri);
+    };
 
     for (let i = 0; i < 24; i += 1) {
-      const p = pointBasePosition(i)
-      makeTriangle(p.x, p.top, pointColumnFromEdge(p.x) % 2 === 0)
+      const p = pointBasePosition(i);
+      makeTriangle(p.x, p.top, pointColumnFromEdge(p.x) % 2 === 0);
     }
+    applyFinishToMaterial(
+      boardSurfaceMaterial,
+      ownedBoardFinishOptions[boardFinishIdx] || ownedBoardFinishOptions[0],
+      '#f0dfbf'
+    );
+    applyFinishToMaterial(
+      frameMaterial,
+      ownedFrameFinishOptions[frameFinishIdx] || ownedFrameFinishOptions[0],
+      '#5d2e1b'
+    );
+    applyTrianglePalette(
+      ownedTriangleColorOptions[triangleColorIdx] ||
+        ownedTriangleColorOptions[0]
+    );
 
-    const chipGroup = new THREE.Group()
-    scene.add(chipGroup)
-    const diceGroup = new THREE.Group()
-    scene.add(diceGroup)
-    const diceAnimationState = { entries: [] }
-    const maxDice = 2
+    const chipGroup = new THREE.Group();
+    scene.add(chipGroup);
+    const diceGroup = new THREE.Group();
+    scene.add(diceGroup);
+    const diceAnimationState = { entries: [] };
+    const maxDice = 2;
 
     const diceMeshes = Array.from({ length: maxDice }, () => {
-      const mesh = makeRoyalDie()
-      diceGroup.add(mesh)
-      return mesh
-    })
+      const mesh = makeRoyalDie();
+      diceGroup.add(mesh);
+      return mesh;
+    });
 
-    const raycaster = new THREE.Raycaster()
-    const pointer = new THREE.Vector2()
-    const boardPlane = new THREE.Plane(new THREE.Vector3(0, 1, 0), -(BOARD_Y + 0.16))
-    const hitPoint = new THREE.Vector3()
+    const raycaster = new THREE.Raycaster();
+    const pointer = new THREE.Vector2();
+    const boardPlane = new THREE.Plane(
+      new THREE.Vector3(0, 1, 0),
+      -(BOARD_Y + 0.16)
+    );
+    const hitPoint = new THREE.Vector3();
     const resolveNearestPoint = (x, z) => {
-      let nearest = null
-      let minDist = Infinity
+      let nearest = null;
+      let minDist = Infinity;
       for (let i = 0; i < 24; i += 1) {
-        const base = pointBasePosition(i)
-        const dx = x - base.x
-        const dz = z - base.z
-        const dist = Math.hypot(dx, dz)
+        const base = pointBasePosition(i);
+        const dx = x - base.x;
+        const dz = z - base.z;
+        const dist = Math.hypot(dx, dz);
         if (dist < minDist) {
-          minDist = dist
-          nearest = i
+          minDist = dist;
+          nearest = i;
         }
       }
-      if (minDist > POINT_WIDTH * 0.72) return null
-      return nearest
-    }
+      if (minDist > POINT_WIDTH * 0.72) return null;
+      return nearest;
+    };
     const onBoardTap = (event) => {
-      const rect = renderer.domElement.getBoundingClientRect()
-      pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1
-      pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1
-      raycaster.setFromCamera(pointer, camera)
-      if (!raycaster.ray.intersectPlane(boardPlane, hitPoint)) return
-      const nearest = resolveNearestPoint(hitPoint.x, hitPoint.z)
-      if (nearest == null) return
-      window.dispatchEvent(new CustomEvent('tavullPointTap', { detail: { point: nearest } }))
-    }
-    renderer.domElement.addEventListener('pointerdown', onBoardTap)
+      const rect = renderer.domElement.getBoundingClientRect();
+      pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+      pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+      raycaster.setFromCamera(pointer, camera);
+      if (!raycaster.ray.intersectPlane(boardPlane, hitPoint)) return;
+      const nearest = resolveNearestPoint(hitPoint.x, hitPoint.z);
+      if (nearest == null) return;
+      window.dispatchEvent(
+        new CustomEvent('tavullPointTap', { detail: { point: nearest } })
+      );
+    };
+    renderer.domElement.addEventListener('pointerdown', onBoardTap);
 
     const resize = () => {
-      if (!host) return
-      const width = host.clientWidth
-      const height = host.clientHeight
-      camera.aspect = width / height
-      camera.updateProjectionMatrix()
-      renderer.setSize(width, height)
-    }
-    window.addEventListener('resize', resize)
+      if (!host) return;
+      const width = host.clientWidth;
+      const height = host.clientHeight;
+      camera.aspect = width / height;
+      camera.updateProjectionMatrix();
+      renderer.setSize(width, height);
+    };
+    window.addEventListener('resize', resize);
 
-    let raf = 0
+    let raf = 0;
     const tick = () => {
-      const now = performance.now()
-      diceAnimationState.entries = diceAnimationState.entries.filter((entry) => {
-        if (now < entry.start) return true
-        const elapsed = now - entry.start
-        const t = Math.min(1, elapsed / entry.duration)
-        const eased = 1 - (1 - t) ** 3
-        const arc = Math.sin(Math.PI * t) * 0.18
-        entry.mesh.position.lerpVectors(entry.startPos, entry.endPos, eased)
-        entry.mesh.position.y += arc
-        entry.mesh.rotation.x += 0.42
-        entry.mesh.rotation.y += 0.37
-        entry.mesh.rotation.z += 0.25
-        if (t >= 1) {
-          if (entry.targetQuaternion) {
-            entry.mesh.setRotationFromQuaternion(entry.targetQuaternion)
+      const now = performance.now();
+      diceAnimationState.entries = diceAnimationState.entries.filter(
+        (entry) => {
+          if (now < entry.start) return true;
+          const elapsed = now - entry.start;
+          const t = Math.min(1, elapsed / entry.duration);
+          const eased = 1 - (1 - t) ** 3;
+          const arc = Math.sin(Math.PI * t) * 0.18;
+          entry.mesh.position.lerpVectors(entry.startPos, entry.endPos, eased);
+          entry.mesh.position.y += arc;
+          entry.mesh.rotation.x += 0.42;
+          entry.mesh.rotation.y += 0.37;
+          entry.mesh.rotation.z += 0.25;
+          if (t >= 1) {
+            if (entry.targetQuaternion) {
+              entry.mesh.setRotationFromQuaternion(entry.targetQuaternion);
+            }
+            return false;
           }
-          return false
+          return true;
         }
-        return true
-      })
-      controls.update()
-      renderer.render(scene, camera)
-      raf = window.requestAnimationFrame(tick)
-    }
-    tick()
+      );
+      controls.update();
+      renderer.render(scene, camera);
+      raf = window.requestAnimationFrame(tick);
+    };
+    tick();
 
     sceneBundleRef.current = {
       scene,
@@ -783,23 +1092,27 @@ export default function TavullBattleRoyal() {
       controls,
       chipGroup,
       animateDiceThrow: (values = [], seat = 0) => {
-        const diceValues = (Array.isArray(values) && values.length ? values : [1, 1]).slice(0, maxDice)
-        const startZ = seat === 0 ? BOARD_HALF_Z - 0.05 : -BOARD_HALF_Z + 0.05
-        const endZ = 0
-        const centerXPositions = [-0.34, 0.34]
+        const diceValues = (
+          Array.isArray(values) && values.length ? values : [1, 1]
+        ).slice(0, maxDice);
+        const startZ = seat === 0 ? BOARD_HALF_Z - 0.05 : -BOARD_HALF_Z + 0.05;
+        const endZ = 0;
+        const centerXPositions = [-0.34, 0.34];
         diceMeshes.forEach((mesh, index) => {
           if (index >= diceValues.length) {
-            mesh.visible = false
-            return
+            mesh.visible = false;
+            return;
           }
-          mesh.visible = true
-          const dieValue = Number(diceValues[index]) || 1
-          mesh.userData.setValue?.(dieValue)
-          diceAnimationState.entries = diceAnimationState.entries.filter((entry) => entry.mesh !== mesh)
-          const x = centerXPositions[index] ?? 0
-          const startPos = new THREE.Vector3(x, BOARD_Y + 0.24, startZ)
-          const endPos = new THREE.Vector3(x, BOARD_Y + 0.17, endZ)
-          mesh.position.copy(startPos)
+          mesh.visible = true;
+          const dieValue = Number(diceValues[index]) || 1;
+          mesh.userData.setValue?.(dieValue);
+          diceAnimationState.entries = diceAnimationState.entries.filter(
+            (entry) => entry.mesh !== mesh
+          );
+          const x = centerXPositions[index] ?? 0;
+          const startPos = new THREE.Vector3(x, BOARD_Y + 0.24, startZ);
+          const endPos = new THREE.Vector3(x, BOARD_Y + 0.17, endZ);
+          mesh.position.copy(startPos);
           diceAnimationState.entries.push({
             mesh,
             start: performance.now() + index * 60,
@@ -807,107 +1120,190 @@ export default function TavullBattleRoyal() {
             startPos,
             endPos,
             targetQuaternion: getDieOrientationQuaternion(dieValue)
-          })
-        })
+          });
+        });
       },
       applyViewMode,
-      applyTableFinish: (idx) => applyTableMaterials(table.parts, MURLAN_TABLE_FINISHES[idx] || MURLAN_TABLE_FINISHES[0]),
+      applyTableFinish: (idx) =>
+        applyTableMaterials(
+          table.parts,
+          MURLAN_TABLE_FINISHES[idx] || MURLAN_TABLE_FINISHES[0]
+        ),
       applyHdri: (idx) => loadHdriEnvironment(scene, idx),
+      applyBoardFinish: (idx) =>
+        applyFinishToMaterial(
+          boardSurfaceMaterial,
+          TAVULL_BATTLE_BOARD_FINISH_OPTIONS[idx] ||
+            TAVULL_BATTLE_BOARD_FINISH_OPTIONS[0],
+          '#f0dfbf'
+        ),
+      applyFrameFinish: (idx) =>
+        applyFinishToMaterial(
+          frameMaterial,
+          TAVULL_BATTLE_FRAME_FINISH_OPTIONS[idx] ||
+            TAVULL_BATTLE_FRAME_FINISH_OPTIONS[0],
+          '#5d2e1b'
+        ),
+      applyTriangleColor: (idx) =>
+        applyTrianglePalette(
+          TAVULL_BATTLE_TRIANGLE_COLOR_OPTIONS[idx] ||
+            TAVULL_BATTLE_TRIANGLE_COLOR_OPTIONS[0]
+        ),
       applyQuality: (idx) => {
-        const quality = QUALITY_OPTIONS[idx] || QUALITY_OPTIONS[1]
-        renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, quality.pixelRatio))
-        renderer.shadowMap.enabled = Boolean(quality.shadows)
-        renderer.shadowMap.needsUpdate = true
+        const quality = QUALITY_OPTIONS[idx] || QUALITY_OPTIONS[1];
+        renderer.setPixelRatio(
+          Math.min(window.devicePixelRatio || 1, quality.pixelRatio)
+        );
+        renderer.shadowMap.enabled = Boolean(quality.shadows);
+        renderer.shadowMap.needsUpdate = true;
       },
       applyChairs: setChairs
-    }
+    };
 
     return () => {
-      window.cancelAnimationFrame(raf)
-      window.removeEventListener('resize', resize)
-      controls.dispose()
-      renderer.dispose()
-      renderer.domElement.removeEventListener('pointerdown', onBoardTap)
-      if (host.contains(renderer.domElement)) host.removeChild(renderer.domElement)
-      sceneBundleRef.current = null
-      isMountedRef.current = false
-    }
-  }, [])
+      window.cancelAnimationFrame(raf);
+      window.removeEventListener('resize', resize);
+      controls.dispose();
+      renderer.dispose();
+      renderer.domElement.removeEventListener('pointerdown', onBoardTap);
+      if (host.contains(renderer.domElement))
+        host.removeChild(renderer.domElement);
+      sceneBundleRef.current = null;
+      isMountedRef.current = false;
+    };
+  }, []);
 
-  useEffect(() => () => {
-    pendingTimeoutsRef.current.forEach((id) => window.clearTimeout(id))
-    pendingTimeoutsRef.current = []
-    isMountedRef.current = false
-  }, [])
-
-  useEffect(() => {
-    const bundle = sceneBundleRef.current
-    if (!bundle?.applyViewMode) return
-    bundle.applyViewMode(viewMode)
-  }, [viewMode])
+  useEffect(
+    () => () => {
+      pendingTimeoutsRef.current.forEach((id) => window.clearTimeout(id));
+      pendingTimeoutsRef.current = [];
+      isMountedRef.current = false;
+    },
+    []
+  );
 
   useEffect(() => {
-    const bundle = sceneBundleRef.current
-    if (!bundle?.applyTableFinish) return
-    const selected = ownedFinishOptions[tableFinishIdx] || ownedFinishOptions[0]
-    const globalIdx = MURLAN_TABLE_FINISHES.findIndex((option) => option.id === selected?.id)
-    bundle.applyTableFinish(globalIdx >= 0 ? globalIdx : 0)
-  }, [tableFinishIdx, ownedFinishOptions])
+    const bundle = sceneBundleRef.current;
+    if (!bundle?.applyViewMode) return;
+    bundle.applyViewMode(viewMode);
+  }, [viewMode]);
 
   useEffect(() => {
-    const bundle = sceneBundleRef.current
-    if (!bundle?.applyHdri) return
-    const selected = ownedHdriOptions[hdriIdx] || ownedHdriOptions[0]
-    const globalIdx = POOL_ROYALE_HDRI_VARIANTS.findIndex((option) => option.id === selected?.id)
-    bundle.applyHdri(globalIdx >= 0 ? globalIdx : 0)
-  }, [hdriIdx, ownedHdriOptions])
+    const bundle = sceneBundleRef.current;
+    if (!bundle?.applyTableFinish) return;
+    const selected =
+      ownedFinishOptions[tableFinishIdx] || ownedFinishOptions[0];
+    const globalIdx = MURLAN_TABLE_FINISHES.findIndex(
+      (option) => option.id === selected?.id
+    );
+    bundle.applyTableFinish(globalIdx >= 0 ? globalIdx : 0);
+  }, [tableFinishIdx, ownedFinishOptions]);
 
   useEffect(() => {
-    const bundle = sceneBundleRef.current
-    if (!bundle?.applyQuality) return
-    bundle.applyQuality(qualityIdx)
-  }, [qualityIdx])
+    const bundle = sceneBundleRef.current;
+    if (!bundle?.applyHdri) return;
+    const selected = ownedHdriOptions[hdriIdx] || ownedHdriOptions[0];
+    const globalIdx = POOL_ROYALE_HDRI_VARIANTS.findIndex(
+      (option) => option.id === selected?.id
+    );
+    bundle.applyHdri(globalIdx >= 0 ? globalIdx : 0);
+  }, [hdriIdx, ownedHdriOptions]);
+  useEffect(() => {
+    const bundle = sceneBundleRef.current;
+    if (!bundle?.applyBoardFinish) return;
+    const selected =
+      ownedBoardFinishOptions[boardFinishIdx] || ownedBoardFinishOptions[0];
+    const globalIdx = TAVULL_BATTLE_BOARD_FINISH_OPTIONS.findIndex(
+      (option) => option.id === selected?.id
+    );
+    bundle.applyBoardFinish(globalIdx >= 0 ? globalIdx : 0);
+  }, [boardFinishIdx, ownedBoardFinishOptions]);
+  useEffect(() => {
+    const bundle = sceneBundleRef.current;
+    if (!bundle?.applyFrameFinish) return;
+    const selected =
+      ownedFrameFinishOptions[frameFinishIdx] || ownedFrameFinishOptions[0];
+    const globalIdx = TAVULL_BATTLE_FRAME_FINISH_OPTIONS.findIndex(
+      (option) => option.id === selected?.id
+    );
+    bundle.applyFrameFinish(globalIdx >= 0 ? globalIdx : 0);
+  }, [frameFinishIdx, ownedFrameFinishOptions]);
+  useEffect(() => {
+    const bundle = sceneBundleRef.current;
+    if (!bundle?.applyTriangleColor) return;
+    const selected =
+      ownedTriangleColorOptions[triangleColorIdx] ||
+      ownedTriangleColorOptions[0];
+    const globalIdx = TAVULL_BATTLE_TRIANGLE_COLOR_OPTIONS.findIndex(
+      (option) => option.id === selected?.id
+    );
+    bundle.applyTriangleColor(globalIdx >= 0 ? globalIdx : 0);
+  }, [triangleColorIdx, ownedTriangleColorOptions]);
 
   useEffect(() => {
-    const bundle = sceneBundleRef.current
-    if (!bundle?.applyChairs) return
-    const selected = ownedChairOptions[chairThemeIdx] || ownedChairOptions[0]
-    const globalIdx = CHAIR_THEMES.findIndex((option) => option.id === selected?.id)
-    void bundle.applyChairs(globalIdx >= 0 ? globalIdx : 0)
-  }, [chairThemeIdx, ownedChairOptions])
+    const bundle = sceneBundleRef.current;
+    if (!bundle?.applyQuality) return;
+    bundle.applyQuality(qualityIdx);
+  }, [qualityIdx]);
 
   useEffect(() => {
-    if (!winner) return
-    playSfx(WIN_SOUND_URL, 0.9)
-  }, [winner])
+    const bundle = sceneBundleRef.current;
+    if (!bundle?.applyChairs) return;
+    const selected = ownedChairOptions[chairThemeIdx] || ownedChairOptions[0];
+    const globalIdx = CHAIR_THEMES.findIndex(
+      (option) => option.id === selected?.id
+    );
+    void bundle.applyChairs(globalIdx >= 0 ? globalIdx : 0);
+  }, [chairThemeIdx, ownedChairOptions]);
 
   useEffect(() => {
-    const bundle = sceneBundleRef.current
-    if (!bundle) return
-    const { chipGroup } = bundle
-    chipGroup.clear()
+    if (!winner) return;
+    playSfx(WIN_SOUND_URL, 0.9);
+  }, [winner]);
+
+  useEffect(() => {
+    const bundle = sceneBundleRef.current;
+    if (!bundle) return;
+    const { chipGroup } = bundle;
+    chipGroup.clear();
 
     const createChip = (color) => {
-      const pieceGroup = new THREE.Group()
-      const sideColor = CHECKERS_CHIP_COLORS[color] || CHECKERS_CHIP_COLORS[WHITE]
-      const baseMaterial = createCheckerMaterial(sideColor, CHECKERS_CHIP_HEAD_PRESET)
+      const pieceGroup = new THREE.Group();
+      const sideColor =
+        CHECKERS_CHIP_COLORS[color] || CHECKERS_CHIP_COLORS[WHITE];
+      const baseMaterial = createCheckerMaterial(
+        sideColor,
+        CHECKERS_CHIP_HEAD_PRESET
+      );
 
       const chip = new THREE.Mesh(
-        new THREE.CylinderGeometry(CHIP_RADIUS, CHIP_RADIUS * 0.94, CHIP_HEIGHT, 56, 1, false),
+        new THREE.CylinderGeometry(
+          CHIP_RADIUS,
+          CHIP_RADIUS * 0.94,
+          CHIP_HEIGHT,
+          56,
+          1,
+          false
+        ),
         baseMaterial
-      )
-      chip.castShadow = true
-      chip.receiveShadow = true
-      pieceGroup.add(chip)
+      );
+      chip.castShadow = true;
+      chip.receiveShadow = true;
+      pieceGroup.add(chip);
 
       const topCap = new THREE.Mesh(
-        new THREE.CylinderGeometry(CHIP_RADIUS * 0.74, CHIP_RADIUS * 0.81, CHIP_HEIGHT * 0.42, 48),
+        new THREE.CylinderGeometry(
+          CHIP_RADIUS * 0.74,
+          CHIP_RADIUS * 0.81,
+          CHIP_HEIGHT * 0.42,
+          48
+        ),
         baseMaterial.clone()
-      )
-      topCap.position.y = CHIP_HEIGHT * 0.56
-      topCap.castShadow = true
-      topCap.receiveShadow = true
-      pieceGroup.add(topCap)
+      );
+      topCap.position.y = CHIP_HEIGHT * 0.56;
+      topCap.castShadow = true;
+      topCap.receiveShadow = true;
+      pieceGroup.add(topCap);
 
       const rim = new THREE.Mesh(
         new THREE.TorusGeometry(CHIP_RADIUS * 0.7, CHIP_RADIUS * 0.064, 16, 64),
@@ -918,38 +1314,46 @@ export default function TavullBattleRoyal() {
           transparent: true,
           opacity: 0.85
         })
-      )
-      rim.rotation.x = Math.PI / 2
-      rim.position.y = CHIP_HEIGHT * 0.64
-      pieceGroup.add(rim)
+      );
+      rim.rotation.x = Math.PI / 2;
+      rim.position.y = CHIP_HEIGHT * 0.64;
+      pieceGroup.add(rim);
 
-      return pieceGroup
-    }
+      return pieceGroup;
+    };
 
-    const sourceTargets = new Set()
-    const destinationTargets = new Set()
+    const sourceTargets = new Set();
+    const destinationTargets = new Set();
     available.forEach((sequence) => {
       sequence?.line?.forEach((move) => {
-        if (typeof move?.from !== 'number' || typeof move?.to !== 'number') return
+        if (typeof move?.from !== 'number' || typeof move?.to !== 'number')
+          return;
         if (selectedPoint == null) {
-          sourceTargets.add(move.from)
-          return
+          sourceTargets.add(move.from);
+          return;
         }
         if (move.from === selectedPoint) {
-          sourceTargets.add(move.from)
-          destinationTargets.add(move.to)
+          sourceTargets.add(move.from);
+          destinationTargets.add(move.to);
         }
-      })
-    })
+      });
+    });
 
     if (activeMoveHighlight) {
-      if (typeof activeMoveHighlight.from === 'number') sourceTargets.add(activeMoveHighlight.from)
-      if (typeof activeMoveHighlight.to === 'number') destinationTargets.add(activeMoveHighlight.to)
+      if (typeof activeMoveHighlight.from === 'number')
+        sourceTargets.add(activeMoveHighlight.from);
+      if (typeof activeMoveHighlight.to === 'number')
+        destinationTargets.add(activeMoveHighlight.to);
     }
 
     const createPrecisionMarker = (isSource, emphasized = false) =>
       new THREE.Mesh(
-        new THREE.TorusGeometry(CHIP_RADIUS * (isSource ? 1.08 : 0.92), CHIP_RADIUS * 0.09, 16, 48),
+        new THREE.TorusGeometry(
+          CHIP_RADIUS * (isSource ? 1.08 : 0.92),
+          CHIP_RADIUS * 0.09,
+          16,
+          48
+        ),
         new THREE.MeshStandardMaterial({
           color: emphasized ? '#f59e0b' : isSource ? '#22d3ee' : '#60a5fa',
           emissive: emphasized ? '#7c2d12' : isSource ? '#164e63' : '#1e3a8a',
@@ -959,249 +1363,270 @@ export default function TavullBattleRoyal() {
           transparent: true,
           opacity: emphasized ? 0.98 : isSource ? 0.92 : 0.95
         })
-      )
+      );
 
     const pointMarkerPosition = (pointIndex, forSource) => {
-      const base = pointBasePosition(pointIndex)
-      const point = game.points[pointIndex]
-      const towardCenterSign = base.top ? 1 : -1
-      const count = point?.count || 0
-      const slot = forSource ? Math.max(0, count - 1) : count
-      const row = Math.min(slot % CHIP_MAX_PER_COLUMN, CHIP_MAX_PER_COLUMN - 1)
+      const base = pointBasePosition(pointIndex);
+      const point = game.points[pointIndex];
+      const towardCenterSign = base.top ? 1 : -1;
+      const count = point?.count || 0;
+      const slot = forSource ? Math.max(0, count - 1) : count;
+      const row = Math.min(slot % CHIP_MAX_PER_COLUMN, CHIP_MAX_PER_COLUMN - 1);
       return new THREE.Vector3(
         base.x,
         BOARD_Y + CHIP_BASE_Y_OFFSET + CHIP_HEIGHT * 0.12,
         base.z + towardCenterSign * (CHIP_POINT_INSET + row * CHIP_ROW_SPACING)
-      )
-    }
+      );
+    };
 
     for (let i = 0; i < 24; i += 1) {
-      const point = game.points[i]
-      if (!point.color || point.count <= 0) continue
-      const base = pointBasePosition(i)
-      const totalColumns = Math.ceil(point.count / CHIP_MAX_PER_COLUMN)
-      const columnCenterOffset = (totalColumns - 1) * 0.5
-      const towardCenterSign = base.top ? 1 : -1
+      const point = game.points[i];
+      if (!point.color || point.count <= 0) continue;
+      const base = pointBasePosition(i);
+      const totalColumns = Math.ceil(point.count / CHIP_MAX_PER_COLUMN);
+      const columnCenterOffset = (totalColumns - 1) * 0.5;
+      const towardCenterSign = base.top ? 1 : -1;
       for (let s = 0; s < point.count; s += 1) {
-        const chip = createChip(point.color)
-        const column = Math.floor(s / CHIP_MAX_PER_COLUMN)
-        const row = s % CHIP_MAX_PER_COLUMN
+        const chip = createChip(point.color);
+        const column = Math.floor(s / CHIP_MAX_PER_COLUMN);
+        const row = s % CHIP_MAX_PER_COLUMN;
         chip.position.set(
           base.x + (column - columnCenterOffset) * CHIP_COLUMN_SPACING,
           BOARD_Y + CHIP_BASE_Y_OFFSET,
-          base.z + towardCenterSign * (CHIP_POINT_INSET + row * CHIP_ROW_SPACING)
-        )
-        chipGroup.add(chip)
+          base.z +
+            towardCenterSign * (CHIP_POINT_INSET + row * CHIP_ROW_SPACING)
+        );
+        chipGroup.add(chip);
       }
     }
 
     sourceTargets.forEach((pointIndex) => {
-      if (pointIndex < 0 || pointIndex >= 24) return
-      const marker = createPrecisionMarker(true, typeof selectedPoint === 'number' && pointIndex === selectedPoint)
-      marker.rotation.x = Math.PI / 2
-      marker.position.copy(pointMarkerPosition(pointIndex, true))
-      chipGroup.add(marker)
-    })
+      if (pointIndex < 0 || pointIndex >= 24) return;
+      const marker = createPrecisionMarker(
+        true,
+        typeof selectedPoint === 'number' && pointIndex === selectedPoint
+      );
+      marker.rotation.x = Math.PI / 2;
+      marker.position.copy(pointMarkerPosition(pointIndex, true));
+      chipGroup.add(marker);
+    });
 
     destinationTargets.forEach((pointIndex) => {
-      if (pointIndex < 0 || pointIndex >= 24) return
-      const marker = createPrecisionMarker(false, activeMoveHighlight?.to === pointIndex || selectedPoint != null)
-      if (selectedPoint != null) marker.scale.setScalar(1.12)
-      marker.rotation.x = Math.PI / 2
-      marker.position.copy(pointMarkerPosition(pointIndex, false))
-      chipGroup.add(marker)
-    })
+      if (pointIndex < 0 || pointIndex >= 24) return;
+      const marker = createPrecisionMarker(
+        false,
+        activeMoveHighlight?.to === pointIndex || selectedPoint != null
+      );
+      if (selectedPoint != null) marker.scale.setScalar(1.12);
+      marker.rotation.x = Math.PI / 2;
+      marker.position.copy(pointMarkerPosition(pointIndex, false));
+      chipGroup.add(marker);
+    });
 
     const makeCapturedSideChips = (count, color, edge) => {
-      if (!count) return
-      const maxPerRow = 12
+      if (!count) return;
+      const maxPerRow = 12;
       for (let s = 0; s < count; s += 1) {
-        const chip = createChip(color)
-        const row = Math.floor(s / maxPerRow)
-        const col = s % maxPerRow
-        const rowCount = Math.min(count - row * maxPerRow, maxPerRow)
-        const centered = col - (rowCount - 1) / 2
+        const chip = createChip(color);
+        const row = Math.floor(s / maxPerRow);
+        const col = s % maxPerRow;
+        const rowCount = Math.min(count - row * maxPerRow, maxPerRow);
+        const centered = col - (rowCount - 1) / 2;
         chip.position.set(
           centered * CHIP_COLUMN_SPACING * CAPTURE_STRIP_PIECE_GAP,
           BOARD_Y + CHIP_BASE_Y_OFFSET,
-          edge * (BOARD_HALF_Z + CHIP_POINT_INSET * (CAPTURE_STRIP_OFFSET_ROWS + row * 0.74))
-        )
-        chipGroup.add(chip)
+          edge *
+            (BOARD_HALF_Z +
+              CHIP_POINT_INSET * (CAPTURE_STRIP_OFFSET_ROWS + row * 0.74))
+        );
+        chipGroup.add(chip);
       }
-    }
+    };
 
-    makeCapturedSideChips(game.bar.white, WHITE, 1)
-    makeCapturedSideChips(game.bar.black, BLACK, -1)
-  }, [game, available, activeMoveHighlight, selectedPoint])
+    makeCapturedSideChips(game.bar.white, WHITE, 1);
+    makeCapturedSideChips(game.bar.black, BLACK, -1);
+  }, [game, available, activeMoveHighlight, selectedPoint]);
 
   const animateSequence = (state, color, sequence, onDone) => {
-    const line = sequence?.line || []
+    const line = sequence?.line || [];
     if (!line.length) {
-      onDone?.(state)
-      return
+      onDone?.(state);
+      return;
     }
-    let idx = 0
-    let currentState = state
+    let idx = 0;
+    let currentState = state;
     const runStep = () => {
-      if (!isMountedRef.current) return
-      const move = line[idx]
-      setActiveMoveHighlight({ from: move.from, to: move.to, color })
-      const opponent = color === WHITE ? BLACK : WHITE
-      const previousOpponentBar = currentState.bar[opponent]
-      currentState = applyMove(currentState, color, move)
-      setGame(currentState)
-      const wasCapture = currentState.bar[opponent] > previousOpponentBar
-      playSfx(MOVE_SOUND_URL, wasCapture ? 0.76 : 0.7)
-      idx += 1
+      if (!isMountedRef.current) return;
+      const move = line[idx];
+      setActiveMoveHighlight({ from: move.from, to: move.to, color });
+      const opponent = color === WHITE ? BLACK : WHITE;
+      const previousOpponentBar = currentState.bar[opponent];
+      currentState = applyMove(currentState, color, move);
+      setGame(currentState);
+      const wasCapture = currentState.bar[opponent] > previousOpponentBar;
+      playSfx(MOVE_SOUND_URL, wasCapture ? 0.76 : 0.7);
+      idx += 1;
       if (idx < line.length) {
-        const timeoutId = window.setTimeout(runStep, 460)
-        pendingTimeoutsRef.current.push(timeoutId)
+        const timeoutId = window.setTimeout(runStep, 460);
+        pendingTimeoutsRef.current.push(timeoutId);
       } else {
         const timeoutId = window.setTimeout(() => {
-          setActiveMoveHighlight(null)
-          onDone?.(currentState)
-        }, 320)
-        pendingTimeoutsRef.current.push(timeoutId)
+          setActiveMoveHighlight(null);
+          onDone?.(currentState);
+        }, 320);
+        pendingTimeoutsRef.current.push(timeoutId);
       }
-    }
-    runStep()
-  }
+    };
+    runStep();
+  };
 
   const playAi = (stateAfterPlayer) => {
-    const d1 = 1 + Math.floor(Math.random() * 6)
-    const d2 = 1 + Math.floor(Math.random() * 6)
-    const visibleAiDice = [d1, d2]
-    const aiDice = d1 === d2 ? [d1, d1, d1, d1] : visibleAiDice
-    setMessage(`AI rolled ${d1} and ${d2}.`)
-    setIsRollingDice(true)
-    setAiThinking(true)
-    setSelectedPoint(null)
-    sceneBundleRef.current?.animateDiceThrow?.(visibleAiDice, 1)
-    playSfx(DICE_ROLL_SOUND_URL, 0.75)
+    const d1 = 1 + Math.floor(Math.random() * 6);
+    const d2 = 1 + Math.floor(Math.random() * 6);
+    const visibleAiDice = [d1, d2];
+    const aiDice = d1 === d2 ? [d1, d1, d1, d1] : visibleAiDice;
+    setMessage(`AI rolled ${d1} and ${d2}.`);
+    setIsRollingDice(true);
+    setAiThinking(true);
+    setSelectedPoint(null);
+    sceneBundleRef.current?.animateDiceThrow?.(visibleAiDice, 1);
+    playSfx(DICE_ROLL_SOUND_URL, 0.75);
 
     const timeoutId = window.setTimeout(() => {
-      if (!isMountedRef.current) return
-      setIsRollingDice(false)
-      let choice = null
+      if (!isMountedRef.current) return;
+      setIsRollingDice(false);
+      let choice = null;
       try {
-        choice = pickAiSequence(stateAfterPlayer, aiDice)
+        choice = pickAiSequence(stateAfterPlayer, aiDice);
       } catch (error) {
-        console.error('Backgammon AI turn crashed, skipping turn safely.', error)
+        console.error(
+          'Backgammon AI turn crashed, skipping turn safely.',
+          error
+        );
       }
       if (!choice || !choice.line.length) {
-        setMessage(`AI rolled ${d1}/${d2} but had no legal move. Your turn.`)
-        setAiThinking(false)
-        setDice([])
-        setAvailable([])
-        return
+        setMessage(`AI rolled ${d1}/${d2} but had no legal move. Your turn.`);
+        setAiThinking(false);
+        setDice([]);
+        setAvailable([]);
+        return;
       }
       animateSequence(stateAfterPlayer, BLACK, choice, () => {
-        setMessage(`AI played ${choice.line.length} move(s). Your turn.`)
-        setAiThinking(false)
-        setDice([])
-        setAvailable([])
-      })
-    }, 850)
-    pendingTimeoutsRef.current.push(timeoutId)
-  }
+        setMessage(`AI played ${choice.line.length} move(s). Your turn.`);
+        setAiThinking(false);
+        setDice([]);
+        setAvailable([]);
+      });
+    }, 850);
+    pendingTimeoutsRef.current.push(timeoutId);
+  };
 
   const roll = () => {
-    if (aiThinking || winner || available.length > 0) return
-    setIsRollingDice(true)
-    setSelectedPoint(null)
-    const d1 = 1 + Math.floor(Math.random() * 6)
-    const d2 = 1 + Math.floor(Math.random() * 6)
-    const visibleDice = [d1, d2]
-    const useDice = d1 === d2 ? [d1, d1, d1, d1] : visibleDice
-    sceneBundleRef.current?.animateDiceThrow?.(visibleDice, 0)
-    playSfx(DICE_ROLL_SOUND_URL, 0.75)
+    if (aiThinking || winner || available.length > 0) return;
+    setIsRollingDice(true);
+    setSelectedPoint(null);
+    const d1 = 1 + Math.floor(Math.random() * 6);
+    const d2 = 1 + Math.floor(Math.random() * 6);
+    const visibleDice = [d1, d2];
+    const useDice = d1 === d2 ? [d1, d1, d1, d1] : visibleDice;
+    sceneBundleRef.current?.animateDiceThrow?.(visibleDice, 0);
+    playSfx(DICE_ROLL_SOUND_URL, 0.75);
     const timeoutId = window.setTimeout(() => {
-      if (!isMountedRef.current) return
-      setIsRollingDice(false)
-      playSfx(MOVE_SOUND_URL, 0.45)
-      let seq = []
+      if (!isMountedRef.current) return;
+      setIsRollingDice(false);
+      playSfx(MOVE_SOUND_URL, 0.45);
+      let seq = [];
       try {
-        seq = collectTurnSequences(game, WHITE, useDice)
+        seq = collectTurnSequences(game, WHITE, useDice);
       } catch (error) {
-        console.error('Backgammon player turn evaluation crashed.', error)
+        console.error('Backgammon player turn evaluation crashed.', error);
       }
-      setDice(useDice)
-      setAvailable(seq)
+      setDice(useDice);
+      setAvailable(seq);
       if (!seq.length || !seq.some((s) => s.line.length)) {
-        setMessage(`You rolled ${d1}/${d2} but no legal move. AI turn.`)
-        playAi(game)
-        return
+        setMessage(`You rolled ${d1}/${d2} but no legal move. AI turn.`);
+        playAi(game);
+        return;
       }
-      setMessage('Tap a checker or triangle to select from-point, then tap destination triangle.')
-    }, 820)
-    pendingTimeoutsRef.current.push(timeoutId)
-  }
+      setMessage(
+        'Tap a checker or triangle to select from-point, then tap destination triangle.'
+      );
+    }, 820);
+    pendingTimeoutsRef.current.push(timeoutId);
+  };
 
   const handleSequence = (sequence) => {
-    if (!available.length || aiThinking || winner) return
-    if (!sequence?.line?.length) return
-    setAvailable([])
-    setDice([])
-    setMessage('Moving checkers…')
+    if (!available.length || aiThinking || winner) return;
+    if (!sequence?.line?.length) return;
+    setAvailable([]);
+    setDice([]);
+    setMessage('Moving checkers…');
     animateSequence(game, WHITE, sequence, (stateAfterPlayer) => {
-      setSelectedPoint(null)
-      setMessage('You played. AI is thinking…')
-      playAi(stateAfterPlayer)
-    })
-  }
+      setSelectedPoint(null);
+      setMessage('You played. AI is thinking…');
+      playAi(stateAfterPlayer);
+    });
+  };
 
   useEffect(() => {
     if (!available.length) {
-      setSelectedPoint(null)
-      return
+      setSelectedPoint(null);
+      return;
     }
     const onPointTap = (event) => {
-      const point = event?.detail?.point
-      if (typeof point !== 'number' || aiThinking || winner) return
+      const point = event?.detail?.point;
+      if (typeof point !== 'number' || aiThinking || winner) return;
 
       if (selectedPoint == null) {
-        const startsFromPoint = available.filter((seq) => seq?.line?.[0]?.from === point)
-        if (!startsFromPoint.length) return
-        setSelectedPoint(point)
+        const startsFromPoint = available.filter(
+          (seq) => seq?.line?.[0]?.from === point
+        );
+        if (!startsFromPoint.length) return;
+        setSelectedPoint(point);
         const moveCount = new Set(
           startsFromPoint
             .map((seq) => seq?.line?.[0]?.to)
             .filter((toPoint) => typeof toPoint === 'number')
-        ).size
+        ).size;
         setMessage(
           moveCount > 0
             ? `Piece selected. ${moveCount} legal destination${moveCount > 1 ? 's' : ''} highlighted.`
             : 'Piece selected. Tap destination triangle.'
-        )
-        return
+        );
+        return;
       }
 
-      const narrowed = available.filter((seq) => seq?.line?.[0]?.from === selectedPoint && seq?.line?.[0]?.to === point)
+      const narrowed = available.filter(
+        (seq) =>
+          seq?.line?.[0]?.from === selectedPoint && seq?.line?.[0]?.to === point
+      );
 
       if (narrowed.length >= 1) {
-        handleSequence(narrowed[0])
-        return
+        handleSequence(narrowed[0]);
+        return;
       }
 
-      const restartFromPoint = available.filter((seq) => seq?.line?.[0]?.from === point)
+      const restartFromPoint = available.filter(
+        (seq) => seq?.line?.[0]?.from === point
+      );
       if (restartFromPoint.length) {
-        setSelectedPoint(point)
+        setSelectedPoint(point);
         const moveCount = new Set(
           restartFromPoint
             .map((seq) => seq?.line?.[0]?.to)
             .filter((toPoint) => typeof toPoint === 'number')
-        ).size
+        ).size;
         setMessage(
           moveCount > 0
             ? `Piece changed. ${moveCount} legal destination${moveCount > 1 ? 's' : ''} highlighted.`
             : 'From point changed. Tap destination triangle.'
-        )
+        );
       }
-    }
+    };
 
-    window.addEventListener('tavullPointTap', onPointTap)
-    return () => window.removeEventListener('tavullPointTap', onPointTap)
-  }, [available, aiThinking, winner, selectedPoint])
+    window.addEventListener('tavullPointTap', onPointTap);
+    return () => window.removeEventListener('tavullPointTap', onPointTap);
+  }, [available, aiThinking, winner, selectedPoint]);
 
   return (
     <div className="fixed inset-0 bg-[#060b16] px-3 py-3 text-white touch-none select-none">
@@ -1213,7 +1638,9 @@ export default function TavullBattleRoyal() {
           aria-label={configOpen ? 'Close game menu' : 'Open game menu'}
           className="pointer-events-auto flex items-center gap-2 rounded-full border border-white/15 bg-black/60 px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-gray-100 shadow-[0_6px_18px_rgba(2,6,23,0.45)] transition hover:border-white/30 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
         >
-          <span className="text-base leading-none" aria-hidden="true">☰</span>
+          <span className="text-base leading-none" aria-hidden="true">
+            ☰
+          </span>
           <span className="leading-none">Menu</span>
         </button>
       </div>
@@ -1246,8 +1673,13 @@ export default function TavullBattleRoyal() {
         <div className="absolute top-20 right-4 z-30 pointer-events-auto mt-2 w-72 max-w-[80vw] rounded-2xl border border-white/15 bg-black/80 p-4 text-xs text-white shadow-2xl backdrop-blur max-h-[80vh] overflow-y-auto pr-1">
           <div className="flex items-center justify-between gap-3">
             <div>
-              <p className="text-[10px] uppercase tracking-[0.4em] text-sky-200/80">Backgammon Settings</p>
-              <p className="mt-1 text-[0.7rem] text-white/70">Personalize the chairs and table finish.</p>
+              <p className="text-[10px] uppercase tracking-[0.4em] text-sky-200/80">
+                Backgammon Settings
+              </p>
+              <p className="mt-1 text-[0.7rem] text-white/70">
+                Personalize board finish, frame, triangle colors, chairs, and
+                table finish.
+              </p>
             </div>
             <button
               type="button"
@@ -1255,15 +1687,31 @@ export default function TavullBattleRoyal() {
               className="rounded-full p-1 text-white/70 transition hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300"
               aria-label="Close settings"
             >
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" className="h-4 w-4">
-                <path strokeLinecap="round" strokeLinejoin="round" d="m6 6 12 12M18 6 6 18" />
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.8"
+                className="h-4 w-4"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="m6 6 12 12M18 6 6 18"
+                />
               </svg>
             </button>
           </div>
           <div className="mt-4 space-y-3">
             <label className="flex items-center justify-between text-[0.7rem] text-gray-200">
               <span>Sound effects</span>
-              <input type="checkbox" className="h-4 w-4 rounded border border-emerald-400/40 bg-transparent text-emerald-400 focus:ring-emerald-500" checked={soundEnabled} onChange={(event) => setSoundEnabled(event.target.checked)} />
+              <input
+                type="checkbox"
+                className="h-4 w-4 rounded border border-emerald-400/40 bg-transparent text-emerald-400 focus:ring-emerald-500"
+                checked={soundEnabled}
+                onChange={(event) => setSoundEnabled(event.target.checked)}
+              />
             </label>
             <button
               type="button"
@@ -1275,16 +1723,23 @@ export default function TavullBattleRoyal() {
             <div className="rounded-xl border border-white/10 bg-white/5 p-3">
               <div className="flex items-start justify-between gap-3">
                 <div>
-                  <p className="text-[10px] uppercase tracking-[0.35em] text-white/70">Personalize Arena</p>
-                  <p className="mt-1 text-[0.7rem] text-white/60">Table cloth, chairs, and table details.</p>
+                  <p className="text-[10px] uppercase tracking-[0.35em] text-white/70">
+                    Personalize Arena
+                  </p>
+                  <p className="mt-1 text-[0.7rem] text-white/60">
+                    Table cloth, chairs, and table details.
+                  </p>
                 </div>
                 <button
                   type="button"
                   onClick={() => {
-                    setTableFinishIdx(0)
-                    setChairThemeIdx(0)
-                    setHdriIdx(0)
-                    setQualityIdx(1)
+                    setTableFinishIdx(0);
+                    setChairThemeIdx(0);
+                    setHdriIdx(0);
+                    setBoardFinishIdx(0);
+                    setFrameFinishIdx(0);
+                    setTriangleColorIdx(0);
+                    setQualityIdx(1);
                   }}
                   className="rounded-lg border border-white/15 px-2 py-1 text-[0.65rem] font-semibold text-white/80 transition hover:border-white/30 hover:text-white"
                 >
@@ -1292,16 +1747,100 @@ export default function TavullBattleRoyal() {
                 </button>
               </div>
               <div className="mt-3 grid gap-2">
-                <button type="button" className="rounded-lg border border-white/20 px-3 py-2 text-left" onClick={() => setTableFinishIdx((v) => (v + 1) % Math.max(1, ownedFinishOptions.length))}>
-                  Table Finish: {ownedFinishOptions[tableFinishIdx]?.label || ownedFinishOptions[0]?.label || 'Default'}
+                <button
+                  type="button"
+                  className="rounded-lg border border-white/20 px-3 py-2 text-left"
+                  onClick={() =>
+                    setTableFinishIdx(
+                      (v) => (v + 1) % Math.max(1, ownedFinishOptions.length)
+                    )
+                  }
+                >
+                  Table Finish:{' '}
+                  {ownedFinishOptions[tableFinishIdx]?.label ||
+                    ownedFinishOptions[0]?.label ||
+                    'Default'}
                 </button>
-                <button type="button" className="rounded-lg border border-white/20 px-3 py-2 text-left" onClick={() => setChairThemeIdx((v) => (v + 1) % Math.max(1, ownedChairOptions.length))}>
-                  Chair Theme: {ownedChairOptions[chairThemeIdx]?.label || ownedChairOptions[0]?.label || 'Royal'}
+                <button
+                  type="button"
+                  className="rounded-lg border border-white/20 px-3 py-2 text-left"
+                  onClick={() =>
+                    setChairThemeIdx(
+                      (v) => (v + 1) % Math.max(1, ownedChairOptions.length)
+                    )
+                  }
+                >
+                  Chair Theme:{' '}
+                  {ownedChairOptions[chairThemeIdx]?.label ||
+                    ownedChairOptions[0]?.label ||
+                    'Royal'}
                 </button>
-                <button type="button" className="rounded-lg border border-white/20 px-3 py-2 text-left" onClick={() => setHdriIdx((v) => (v + 1) % Math.max(1, ownedHdriOptions.length))}>
-                  Environment: {ownedHdriOptions[hdriIdx]?.name || ownedHdriOptions[0]?.name || 'Studio'}
+                <button
+                  type="button"
+                  className="rounded-lg border border-white/20 px-3 py-2 text-left"
+                  onClick={() =>
+                    setBoardFinishIdx(
+                      (v) =>
+                        (v + 1) % Math.max(1, ownedBoardFinishOptions.length)
+                    )
+                  }
+                >
+                  Board Finish:{' '}
+                  {ownedBoardFinishOptions[boardFinishIdx]?.label ||
+                    ownedBoardFinishOptions[0]?.label ||
+                    'Classic'}
                 </button>
-                <button type="button" className="rounded-lg border border-white/20 px-3 py-2 text-left" onClick={() => setQualityIdx((v) => (v + 1) % QUALITY_OPTIONS.length)}>
+                <button
+                  type="button"
+                  className="rounded-lg border border-white/20 px-3 py-2 text-left"
+                  onClick={() =>
+                    setFrameFinishIdx(
+                      (v) =>
+                        (v + 1) % Math.max(1, ownedFrameFinishOptions.length)
+                    )
+                  }
+                >
+                  Frame Finish:{' '}
+                  {ownedFrameFinishOptions[frameFinishIdx]?.label ||
+                    ownedFrameFinishOptions[0]?.label ||
+                    'Classic'}
+                </button>
+                <button
+                  type="button"
+                  className="rounded-lg border border-white/20 px-3 py-2 text-left"
+                  onClick={() =>
+                    setTriangleColorIdx(
+                      (v) =>
+                        (v + 1) % Math.max(1, ownedTriangleColorOptions.length)
+                    )
+                  }
+                >
+                  Triangle Colors:{' '}
+                  {ownedTriangleColorOptions[triangleColorIdx]?.label ||
+                    ownedTriangleColorOptions[0]?.label ||
+                    'Amber Glow'}
+                </button>
+                <button
+                  type="button"
+                  className="rounded-lg border border-white/20 px-3 py-2 text-left"
+                  onClick={() =>
+                    setHdriIdx(
+                      (v) => (v + 1) % Math.max(1, ownedHdriOptions.length)
+                    )
+                  }
+                >
+                  Environment:{' '}
+                  {ownedHdriOptions[hdriIdx]?.name ||
+                    ownedHdriOptions[0]?.name ||
+                    'Studio'}
+                </button>
+                <button
+                  type="button"
+                  className="rounded-lg border border-white/20 px-3 py-2 text-left"
+                  onClick={() =>
+                    setQualityIdx((v) => (v + 1) % QUALITY_OPTIONS.length)
+                  }
+                >
                   Graphics: {QUALITY_OPTIONS[qualityIdx]?.label || 'Balanced'}
                 </button>
               </div>
@@ -1312,14 +1851,15 @@ export default function TavullBattleRoyal() {
 
       <div className="absolute inset-0 overflow-hidden rounded-2xl border border-white/10 bg-black/30">
         <div ref={canvasHostRef} className="h-full w-full" />
-
       </div>
 
       <div className="absolute left-1/2 top-[75%] z-20 flex -translate-x-1/2 -translate-y-1/2 flex-col items-center gap-2">
         <button
           type="button"
           onClick={roll}
-          disabled={aiThinking || winner || available.length > 0 || isRollingDice}
+          disabled={
+            aiThinking || winner || available.length > 0 || isRollingDice
+          }
           className="rounded-xl border border-white/30 bg-transparent px-4 py-2 text-sm font-semibold text-white disabled:opacity-50"
         >
           Roll Dice
@@ -1356,7 +1896,11 @@ export default function TavullBattleRoyal() {
       {chatBubbles.map((bubble) => (
         <div key={bubble.id} className="chat-bubble chess-battle-chat-bubble">
           <span>{bubble.text}</span>
-          <img src={bubble.photoUrl} alt="avatar" className="w-5 h-5 rounded-full" />
+          <img
+            src={bubble.photoUrl}
+            alt="avatar"
+            className="w-5 h-5 rounded-full"
+          />
         </div>
       ))}
 
@@ -1365,9 +1909,18 @@ export default function TavullBattleRoyal() {
         onClose={() => setShowChat(false)}
         title="Quick Chat"
         onSend={(text) => {
-          const id = Date.now()
-          setChatBubbles((bubbles) => [...bubbles, { id, text, photoUrl: playerAvatar || '/assets/icons/profile.svg' }])
-          setTimeout(() => setChatBubbles((bubbles) => bubbles.filter((bubble) => bubble.id !== id)), 3000)
+          const id = Date.now();
+          setChatBubbles((bubbles) => [
+            ...bubbles,
+            { id, text, photoUrl: playerAvatar || '/assets/icons/profile.svg' }
+          ]);
+          setTimeout(
+            () =>
+              setChatBubbles((bubbles) =>
+                bubbles.filter((bubble) => bubble.id !== id)
+              ),
+            3000
+          );
         }}
       />
 
@@ -1380,13 +1933,14 @@ export default function TavullBattleRoyal() {
 
       <div className="absolute inset-0 z-10 pointer-events-none">
         {players.map((player) => {
-          const fallback = FALLBACK_SEAT_POSITIONS[player.index] || FALLBACK_SEAT_POSITIONS[0]
+          const fallback =
+            FALLBACK_SEAT_POSITIONS[player.index] || FALLBACK_SEAT_POSITIONS[0];
           const positionStyle = {
             position: 'absolute',
             left: fallback.left,
             top: fallback.top,
             transform: 'translate(-50%, -50%)'
-          }
+          };
           return (
             <div
               key={`backgammon-seat-${player.index}`}
@@ -1407,7 +1961,7 @@ export default function TavullBattleRoyal() {
                 {player.name}
               </span>
             </div>
-          )
+          );
         })}
       </div>
 
@@ -1417,5 +1971,5 @@ export default function TavullBattleRoyal() {
         </div>
       </div>
     </div>
-  )
+  );
 }

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -75,12 +75,24 @@ import {
   LUDO_BATTLE_STORE_ITEMS
 } from '../config/ludoBattleInventoryConfig.js';
 import {
+  TAVULL_BATTLE_DEFAULT_LOADOUT,
+  TAVULL_BATTLE_OPTION_LABELS,
+  TAVULL_BATTLE_STORE_ITEMS
+} from '../config/tavullBattleInventoryConfig.js';
+import {
   addLudoBattleUnlock,
   getLudoBattleInventory,
   isLudoOptionUnlocked,
   listOwnedLudoOptions,
   ludoBattleAccountId
 } from '../utils/ludoBattleInventory.js';
+import {
+  addTavullBattleUnlock,
+  getTavullBattleInventory,
+  isTavullOptionUnlocked,
+  listOwnedTavullOptions,
+  tavullBattleAccountId
+} from '../utils/tavullBattleInventory.js';
 import {
   MURLAN_ROYALE_DEFAULT_LOADOUT,
   MURLAN_ROYALE_OPTION_LABELS,
@@ -131,7 +143,10 @@ import {
 } from '../utils/texasHoldemInventory.js';
 import { buyBundle, getAccountBalance } from '../utils/api.js';
 import { addTrainingAttempts } from '../utils/poolRoyaleTrainingProgress.js';
-import { getLastStorePurchaseSnapshot, recordStorePurchase } from '../utils/storeTransactions.js';
+import {
+  getLastStorePurchaseSnapshot,
+  recordStorePurchase
+} from '../utils/storeTransactions.js';
 import { DEV_INFO } from '../utils/constants.js';
 import { swatchThumbnail } from '../config/storeThumbnails.js';
 
@@ -166,6 +181,14 @@ const CHESS_TYPE_LABELS = {
   sideColor: 'Piece Colors',
   boardTheme: 'Board Themes',
   headStyle: 'Pawn Heads',
+  environmentHdri: 'HDR Environments'
+};
+const TAVULL_TYPE_LABELS = {
+  tableFinish: 'Table Finish',
+  chairColor: 'Chairs',
+  boardFinish: 'Board Finish',
+  frameFinish: 'Board Frame',
+  triangleColor: 'Triangle Colors',
   environmentHdri: 'HDR Environments'
 };
 
@@ -257,24 +280,36 @@ const TON_PRICE_MAX = 5000;
 const THUMBNAIL_SIZE = 256;
 const ZOOM_PREVIEW_SIZE = 1024;
 const POLYHAVEN_THUMBNAIL_BASE = 'https://cdn.polyhaven.com/asset_img/thumbs/';
-const POOL_STORE_ACCOUNT_ID = import.meta.env.VITE_POOL_ROYALE_STORE_ACCOUNT_ID || DEV_INFO.account;
+const POOL_STORE_ACCOUNT_ID =
+  import.meta.env.VITE_POOL_ROYALE_STORE_ACCOUNT_ID || DEV_INFO.account;
 const SNOOKER_STORE_ACCOUNT_ID =
   import.meta.env.VITE_SNOOKER_ROYALE_STORE_ACCOUNT_ID || DEV_INFO.account;
-const AIR_HOCKEY_STORE_ACCOUNT_ID = import.meta.env.VITE_AIR_HOCKEY_STORE_ACCOUNT_ID || DEV_INFO.account;
-const CHESS_STORE_ACCOUNT_ID = import.meta.env.VITE_CHESS_BATTLE_STORE_ACCOUNT_ID || DEV_INFO.account;
-const BLACKJACK_STORE_ACCOUNT_ID = import.meta.env.VITE_BLACKJACK_STORE_ACCOUNT_ID || DEV_INFO.account;
-const LUDO_STORE_ACCOUNT_ID = import.meta.env.VITE_LUDO_BATTLE_STORE_ACCOUNT_ID || DEV_INFO.account;
-const MURLAN_STORE_ACCOUNT_ID = import.meta.env.VITE_MURLAN_ROYALE_STORE_ACCOUNT_ID || DEV_INFO.account;
-const DOMINO_STORE_ACCOUNT_ID = import.meta.env.VITE_DOMINO_ROYALE_STORE_ACCOUNT_ID || DEV_INFO.account;
-const SNAKE_STORE_ACCOUNT_ID = import.meta.env.VITE_SNAKE_STORE_ACCOUNT_ID || DEV_INFO.account;
-const TEXAS_STORE_ACCOUNT_ID = import.meta.env.VITE_TEXAS_HOLDEM_STORE_ACCOUNT_ID || DEV_INFO.account;
+const AIR_HOCKEY_STORE_ACCOUNT_ID =
+  import.meta.env.VITE_AIR_HOCKEY_STORE_ACCOUNT_ID || DEV_INFO.account;
+const CHESS_STORE_ACCOUNT_ID =
+  import.meta.env.VITE_CHESS_BATTLE_STORE_ACCOUNT_ID || DEV_INFO.account;
+const TAVULL_STORE_ACCOUNT_ID =
+  import.meta.env.VITE_TAVULL_BATTLE_STORE_ACCOUNT_ID || DEV_INFO.account;
+const BLACKJACK_STORE_ACCOUNT_ID =
+  import.meta.env.VITE_BLACKJACK_STORE_ACCOUNT_ID || DEV_INFO.account;
+const LUDO_STORE_ACCOUNT_ID =
+  import.meta.env.VITE_LUDO_BATTLE_STORE_ACCOUNT_ID || DEV_INFO.account;
+const MURLAN_STORE_ACCOUNT_ID =
+  import.meta.env.VITE_MURLAN_ROYALE_STORE_ACCOUNT_ID || DEV_INFO.account;
+const DOMINO_STORE_ACCOUNT_ID =
+  import.meta.env.VITE_DOMINO_ROYALE_STORE_ACCOUNT_ID || DEV_INFO.account;
+const SNAKE_STORE_ACCOUNT_ID =
+  import.meta.env.VITE_SNAKE_STORE_ACCOUNT_ID || DEV_INFO.account;
+const TEXAS_STORE_ACCOUNT_ID =
+  import.meta.env.VITE_TEXAS_HOLDEM_STORE_ACCOUNT_ID || DEV_INFO.account;
 
 const createItemKey = (type, optionId) => `${type}:${optionId}`;
 const selectionKey = (item) => `${item.slug}:${item.id}`;
 const formatTpcAmount = (value) => Number(value || 0).toLocaleString();
 
 const resolveSwatches = (type, optionId, fallbackSwatches = []) => {
-  if (OPTION_SWATCH_OVERRIDES[optionId]) return OPTION_SWATCH_OVERRIDES[optionId];
+  if (OPTION_SWATCH_OVERRIDES[optionId])
+    return OPTION_SWATCH_OVERRIDES[optionId];
   if (TYPE_SWATCHES[type]) return TYPE_SWATCHES[type];
   if (fallbackSwatches.length) return fallbackSwatches;
   return TYPE_SWATCHES.default;
@@ -290,7 +325,8 @@ const resolvePreviewShape = (slug, type, preferredShape) => {
 const previewLabel = (shape) => PREVIEW_LABELS[shape] || PREVIEW_LABELS.default;
 
 const normalizePolyHavenImage = (url, size) => {
-  if (typeof url !== 'string' || !url.startsWith(POLYHAVEN_THUMBNAIL_BASE)) return url;
+  if (typeof url !== 'string' || !url.startsWith(POLYHAVEN_THUMBNAIL_BASE))
+    return url;
   try {
     const parsed = new URL(url);
     parsed.searchParams.set('width', size);
@@ -354,12 +390,15 @@ const POOL_CLOTH_SWATCHES = POOL_ROYALE_CLOTH_VARIANTS.reduce((acc, cloth) => {
   return acc;
 }, {});
 
-const SNOOKER_CLOTH_SWATCHES = SNOOKER_ROYALE_CLOTH_VARIANTS.reduce((acc, cloth) => {
-  if (cloth?.swatches?.length) {
-    acc[cloth.id] = cloth.swatches;
-  }
-  return acc;
-}, {});
+const SNOOKER_CLOTH_SWATCHES = SNOOKER_ROYALE_CLOTH_VARIANTS.reduce(
+  (acc, cloth) => {
+    if (cloth?.swatches?.length) {
+      acc[cloth.id] = cloth.swatches;
+    }
+    return acc;
+  },
+  {}
+);
 
 const OPTION_SWATCH_OVERRIDES = {
   ...POOL_CLOTH_SWATCHES,
@@ -477,35 +516,43 @@ const PREVIEW_LABELS = {
 const USAGE_BY_TYPE = {
   tableFinish: {
     title: 'Table finish',
-    description: 'Updates the main table finish visible in every match, replay, and lobby preview.'
+    description:
+      'Updates the main table finish visible in every match, replay, and lobby preview.'
   },
   tableBase: {
     title: 'Table base',
-    description: 'Swaps the base build under the table for all match cameras and result screens.'
+    description:
+      'Swaps the base build under the table for all match cameras and result screens.'
   },
   tableWood: {
     title: 'Table wood',
-    description: 'Replaces the wooden trim around the table for all match broadcasts.'
+    description:
+      'Replaces the wooden trim around the table for all match broadcasts.'
   },
   tableCloth: {
     title: 'Table cloth',
-    description: 'Changes the cloth color and texture players see during every rally.'
+    description:
+      'Changes the cloth color and texture players see during every rally.'
   },
   clothColor: {
     title: 'Cloth color',
-    description: 'Applies a new cloth palette to the table surface in matches and training rooms.'
+    description:
+      'Applies a new cloth palette to the table surface in matches and training rooms.'
   },
   cueStyle: {
     title: 'Cue style',
-    description: 'Replaces the cue model shown in aim view, replays, and win screens.'
+    description:
+      'Replaces the cue model shown in aim view, replays, and win screens.'
   },
   pocketLiner: {
     title: 'Pocket jaws',
-    description: 'Updates the pocket liners that are visible in close-up shots and replays.'
+    description:
+      'Updates the pocket liners that are visible in close-up shots and replays.'
   },
   chromeColor: {
     title: 'Chrome fascia',
-    description: 'Re-tints the table hardware for every broadcast camera and showroom view.'
+    description:
+      'Re-tints the table hardware for every broadcast camera and showroom view.'
   },
   railMarkerColor: {
     title: 'Rail markers',
@@ -513,67 +560,83 @@ const USAGE_BY_TYPE = {
   },
   environmentHdri: {
     title: 'HDR environment',
-    description: 'Replaces the HDR lighting setup used for showroom previews and match lighting.'
+    description:
+      'Replaces the HDR lighting setup used for showroom previews and match lighting.'
   },
   table: {
     title: 'Table finish',
-    description: 'Swaps the main table surface used in matches and lobby previews.'
+    description:
+      'Swaps the main table surface used in matches and lobby previews.'
   },
   field: {
     title: 'Rink surface',
-    description: 'Changes the rink surface and markings used in Air Hockey matches.'
+    description:
+      'Changes the rink surface and markings used in Air Hockey matches.'
   },
   cushionCloth: {
     title: 'Cushion cloth',
-    description: 'Refreshes the padded rail cloth used in gameplay and highlight reels.'
+    description:
+      'Refreshes the padded rail cloth used in gameplay and highlight reels.'
   },
   puck: {
     title: 'Puck finish',
-    description: 'Applies a new puck material in every serve, replay, and highlight view.'
+    description:
+      'Applies a new puck material in every serve, replay, and highlight view.'
   },
   mallet: {
     title: 'Mallet style',
-    description: 'Updates the striker model used by players throughout each match.'
+    description:
+      'Updates the striker model used by players throughout each match.'
   },
   rails: {
     title: 'Rails',
-    description: 'Replaces the rink rails shown in match play and top-down camera shots.'
+    description:
+      'Replaces the rink rails shown in match play and top-down camera shots.'
   },
   goals: {
     title: 'Goals',
-    description: 'Updates the goal framing and net details visible in match shots.'
+    description:
+      'Updates the goal framing and net details visible in match shots.'
   },
   tables: {
     title: 'Table model',
-    description: 'Swaps the full table model used in Chess, Ludo, and Snake arenas.'
+    description:
+      'Swaps the full table model used in Chess, Ludo, and Snake arenas.'
   },
   chairColor: {
     title: 'Chair finish',
-    description: 'Changes the seating upholstery shown in lobby previews and matches.'
+    description:
+      'Changes the seating upholstery shown in lobby previews and matches.'
   },
   stools: {
     title: 'Stools & chairs',
-    description: 'Updates the chair styling around the arena table and podium views.'
+    description:
+      'Updates the chair styling around the arena table and podium views.'
   },
   sideColor: {
     title: 'Piece colors',
-    description: 'Applies a new palette to player pieces in live matches and replays.'
+    description:
+      'Applies a new palette to player pieces in live matches and replays.'
   },
   boardTheme: {
     title: 'Board theme',
-    description: 'Replaces the board texture and accents used in board-based matches.'
+    description:
+      'Replaces the board texture and accents used in board-based matches.'
   },
   boardFinish: {
     title: 'Board finish',
-    description: 'Applies octagon-table finish textures to the 4 in a Row board faces.'
+    description:
+      'Applies octagon-table finish textures to the 4 in a Row board faces.'
   },
   boardFrameFinish: {
     title: 'Board frame',
-    description: 'Updates the 4 in a Row board frame and stand with octagon-table textures.'
+    description:
+      'Updates the 4 in a Row board frame and stand with octagon-table textures.'
   },
   ringFinish: {
     title: 'Ring finish',
-    description: 'Changes the slot ring material (chrome, gold, aluminium, or plastic variants).'
+    description:
+      'Changes the slot ring material (chrome, gold, aluminium, or plastic variants).'
   },
   headStyle: {
     title: 'Pawn heads',
@@ -581,7 +644,8 @@ const USAGE_BY_TYPE = {
   },
   tokenPalette: {
     title: 'Token palette',
-    description: 'Changes the palette for your Ludo tokens across matches and highlights.'
+    description:
+      'Changes the palette for your Ludo tokens across matches and highlights.'
   },
   tokenStyle: {
     title: 'Token style',
@@ -589,23 +653,28 @@ const USAGE_BY_TYPE = {
   },
   tokenPiece: {
     title: 'Token piece',
-    description: 'Replaces the token model shown on the board and victory screens.'
+    description:
+      'Replaces the token model shown on the board and victory screens.'
   },
   outfit: {
     title: 'Outfit',
-    description: 'Applies a new outfit skin to your Murlan avatar across match scenes.'
+    description:
+      'Applies a new outfit skin to your Murlan avatar across match scenes.'
   },
   cards: {
     title: 'Card theme',
-    description: 'Updates the card backs and suits shown during every deal and replay.'
+    description:
+      'Updates the card backs and suits shown during every deal and replay.'
   },
   tableTheme: {
     title: 'Table model',
-    description: 'Swaps the full table model used in Domino or Texas Hold’em arenas.'
+    description:
+      'Swaps the full table model used in Domino or Texas Hold’em arenas.'
   },
   dominoStyle: {
     title: 'Domino style',
-    description: 'Applies a new domino material finish for match play and replays.'
+    description:
+      'Applies a new domino material finish for match play and replays.'
   },
   highlightStyle: {
     title: 'Highlights',
@@ -621,7 +690,8 @@ const USAGE_BY_TYPE = {
   },
   boardPalette: {
     title: 'Board palette',
-    description: 'Updates the Snake board palette used in match and lobby views.'
+    description:
+      'Updates the Snake board palette used in match and lobby views.'
   },
   snakeSkin: {
     title: 'Snake skin',
@@ -732,11 +802,11 @@ const storeMeta = {
   },
   tavullbattleroyal: {
     name: 'Backgammon Royal',
-    items: CHESS_BATTLE_STORE_ITEMS,
-    defaults: CHESS_BATTLE_DEFAULT_LOADOUT,
-    labels: CHESS_BATTLE_OPTION_LABELS,
-    typeLabels: CHESS_TYPE_LABELS,
-    accountId: CHESS_STORE_ACCOUNT_ID
+    items: TAVULL_BATTLE_STORE_ITEMS,
+    defaults: TAVULL_BATTLE_DEFAULT_LOADOUT,
+    labels: TAVULL_BATTLE_OPTION_LABELS,
+    typeLabels: TAVULL_TYPE_LABELS,
+    accountId: TAVULL_STORE_ACCOUNT_ID
   },
   ludobattleroyal: {
     name: 'Ludo Battle Royal',
@@ -785,16 +855,39 @@ export default function Store() {
   const navigate = useNavigate();
   const { gameSlug } = useParams();
   const [accountId, setAccountId] = useState(() => poolRoyalAccountId());
-  const [poolOwned, setPoolOwned] = useState(() => getCachedPoolRoyalInventory(accountId));
-  const [snookerOwned, setSnookerOwned] = useState(() => getCachedSnookerRoyalInventory(accountId));
-  const [airOwned, setAirOwned] = useState(() => getAirHockeyInventory(airHockeyAccountId(accountId)));
-  const [chessOwned, setChessOwned] = useState(() => getChessBattleInventory(chessBattleAccountId(accountId)));
-  const [fourInRowOwned, setFourInRowOwned] = useState(() => getFourInRowInventory(fourInRowAccountId(accountId)));
-  const [ludoOwned, setLudoOwned] = useState(() => getLudoBattleInventory(ludoBattleAccountId(accountId)));
-  const [murlanOwned, setMurlanOwned] = useState(() => getMurlanInventory(murlanAccountId(accountId)));
-  const [dominoOwned, setDominoOwned] = useState(() => getDominoRoyalInventory(dominoRoyalAccountId(accountId)));
-  const [snakeOwned, setSnakeOwned] = useState(() => getSnakeInventory(snakeAccountId(accountId)));
-  const [texasOwned, setTexasOwned] = useState(() => getTexasHoldemInventory(texasHoldemAccountId(accountId)));
+  const [poolOwned, setPoolOwned] = useState(() =>
+    getCachedPoolRoyalInventory(accountId)
+  );
+  const [snookerOwned, setSnookerOwned] = useState(() =>
+    getCachedSnookerRoyalInventory(accountId)
+  );
+  const [airOwned, setAirOwned] = useState(() =>
+    getAirHockeyInventory(airHockeyAccountId(accountId))
+  );
+  const [chessOwned, setChessOwned] = useState(() =>
+    getChessBattleInventory(chessBattleAccountId(accountId))
+  );
+  const [fourInRowOwned, setFourInRowOwned] = useState(() =>
+    getFourInRowInventory(fourInRowAccountId(accountId))
+  );
+  const [ludoOwned, setLudoOwned] = useState(() =>
+    getLudoBattleInventory(ludoBattleAccountId(accountId))
+  );
+  const [tavullOwned, setTavullOwned] = useState(() =>
+    getTavullBattleInventory(tavullBattleAccountId(accountId))
+  );
+  const [murlanOwned, setMurlanOwned] = useState(() =>
+    getMurlanInventory(murlanAccountId(accountId))
+  );
+  const [dominoOwned, setDominoOwned] = useState(() =>
+    getDominoRoyalInventory(dominoRoyalAccountId(accountId))
+  );
+  const [snakeOwned, setSnakeOwned] = useState(() =>
+    getSnakeInventory(snakeAccountId(accountId))
+  );
+  const [texasOwned, setTexasOwned] = useState(() =>
+    getTexasHoldemInventory(texasHoldemAccountId(accountId))
+  );
   const [accountBalance, setAccountBalance] = useState(null);
   const [processing, setProcessing] = useState('');
   const [info, setInfo] = useState('');
@@ -853,7 +946,10 @@ export default function Store() {
     }
     setShowTransactionToast(true);
     if (transactionState === 'processing') return undefined;
-    const timeout = window.setTimeout(() => setShowTransactionToast(false), 7000);
+    const timeout = window.setTimeout(
+      () => setShowTransactionToast(false),
+      7000
+    );
     return () => window.clearTimeout(timeout);
   }, [transactionState, transactionStatus]);
 
@@ -869,8 +965,12 @@ export default function Store() {
       window.localStorage.setItem('accountId', snapshot.accountId);
     }
     setAccountId(snapshot.accountId);
-    const restoredDate = new Date(snapshot.transaction?.date || Date.now()).toLocaleString();
-    setInfo(`Store restored to your last purchase profile from ${restoredDate}.`);
+    const restoredDate = new Date(
+      snapshot.transaction?.date || Date.now()
+    ).toLocaleString();
+    setInfo(
+      `Store restored to your last purchase profile from ${restoredDate}.`
+    );
   }, [accountId]);
 
   useEffect(() => {
@@ -880,6 +980,7 @@ export default function Store() {
     setChessOwned(getChessBattleInventory(chessBattleAccountId(accountId)));
     setFourInRowOwned(getFourInRowInventory(fourInRowAccountId(accountId)));
     setLudoOwned(getLudoBattleInventory(ludoBattleAccountId(accountId)));
+    setTavullOwned(getTavullBattleInventory(tavullBattleAccountId(accountId)));
     setMurlanOwned(getMurlanInventory(murlanAccountId(accountId)));
     setDominoOwned(getDominoRoyalInventory(dominoRoyalAccountId(accountId)));
     setSnakeOwned(getSnakeInventory(snakeAccountId(accountId)));
@@ -889,12 +990,16 @@ export default function Store() {
       .then((inventory) => {
         if (!cancelled && inventory) setPoolOwned(inventory);
       })
-      .catch((err) => console.warn('Failed to sync Pool Royale inventory', err));
+      .catch((err) =>
+        console.warn('Failed to sync Pool Royale inventory', err)
+      );
     getSnookerRoyalInventory(accountId)
       .then((inventory) => {
         if (!cancelled && inventory) setSnookerOwned(inventory);
       })
-      .catch((err) => console.warn('Failed to sync Snooker Royal inventory', err));
+      .catch((err) =>
+        console.warn('Failed to sync Snooker Royal inventory', err)
+      );
     return () => {
       cancelled = true;
     };
@@ -902,37 +1007,57 @@ export default function Store() {
 
   useEffect(() => {
     const handlePoolInventoryUpdate = (event) => {
-      if (event?.detail?.accountId && event.detail.accountId !== accountId) return;
+      if (event?.detail?.accountId && event.detail.accountId !== accountId)
+        return;
       if (event?.detail?.inventory) {
         setPoolOwned(event.detail.inventory);
       } else {
         setPoolOwned(getCachedPoolRoyalInventory(accountId));
         getPoolRoyalInventory(accountId)
           .then((inventory) => setPoolOwned(inventory))
-          .catch((err) => console.warn('Failed to reload Pool Royale inventory', err));
+          .catch((err) =>
+            console.warn('Failed to reload Pool Royale inventory', err)
+          );
       }
     };
     const handleSnookerInventoryUpdate = (event) => {
-      if (event?.detail?.accountId && event.detail.accountId !== accountId) return;
+      if (event?.detail?.accountId && event.detail.accountId !== accountId)
+        return;
       if (event?.detail?.inventory) {
         setSnookerOwned(event.detail.inventory);
       } else {
         setSnookerOwned(getCachedSnookerRoyalInventory(accountId));
         getSnookerRoyalInventory(accountId)
           .then((inventory) => setSnookerOwned(inventory))
-          .catch((err) => console.warn('Failed to reload Snooker Royal inventory', err));
+          .catch((err) =>
+            console.warn('Failed to reload Snooker Royal inventory', err)
+          );
       }
     };
-    window.addEventListener('poolRoyalInventoryUpdate', handlePoolInventoryUpdate);
-    window.addEventListener('snookerRoyalInventoryUpdate', handleSnookerInventoryUpdate);
+    window.addEventListener(
+      'poolRoyalInventoryUpdate',
+      handlePoolInventoryUpdate
+    );
+    window.addEventListener(
+      'snookerRoyalInventoryUpdate',
+      handleSnookerInventoryUpdate
+    );
     return () => {
-      window.removeEventListener('poolRoyalInventoryUpdate', handlePoolInventoryUpdate);
-      window.removeEventListener('snookerRoyalInventoryUpdate', handleSnookerInventoryUpdate);
+      window.removeEventListener(
+        'poolRoyalInventoryUpdate',
+        handlePoolInventoryUpdate
+      );
+      window.removeEventListener(
+        'snookerRoyalInventoryUpdate',
+        handleSnookerInventoryUpdate
+      );
     };
   }, [accountId]);
 
   const loadAccountBalance = useCallback(async () => {
-    const resolvedAccountId = poolRoyalAccountId(accountId === 'guest' ? '' : accountId);
+    const resolvedAccountId = poolRoyalAccountId(
+      accountId === 'guest' ? '' : accountId
+    );
     if (!resolvedAccountId || resolvedAccountId === 'guest') {
       setAccountBalance(null);
       return;
@@ -953,57 +1078,148 @@ export default function Store() {
 
   const storeItemsBySlug = useMemo(
     () => ({
-      poolroyale: POOL_ROYALE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId), slug: 'poolroyale' })),
-      tabletennisroyal: POOL_ROYALE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId), slug: 'tabletennisroyal' })),
-      snookerroyale: SNOOKER_ROYALE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId), slug: 'snookerroyale' })),
-      airhockey: AIR_HOCKEY_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId), slug: 'airhockey' })),
-      chessbattleroyal: CHESS_BATTLE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId), slug: 'chessbattleroyal' })),
-      checkersbattleroyal: CHESS_BATTLE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId), slug: 'checkersbattleroyal' })),
-      fourinrowroyale: FOUR_IN_ROW_BATTLE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId), slug: 'fourinrowroyale' })),
-      tavullbattleroyal: CHESS_BATTLE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId), slug: 'tavullbattleroyal' })),
-      ludobattleroyal: LUDO_BATTLE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId), slug: 'ludobattleroyal' })),
-      murlanroyale: MURLAN_ROYALE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId), slug: 'murlanroyale' })),
-      'domino-royal': DOMINO_ROYAL_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId), slug: 'domino-royal' })),
-      snake: SNAKE_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId), slug: 'snake' })),
-      texasholdem: TEXAS_HOLDEM_STORE_ITEMS.map((item) => ({ ...item, key: createItemKey(item.type, item.optionId), slug: 'texasholdem' }))
+      poolroyale: POOL_ROYALE_STORE_ITEMS.map((item) => ({
+        ...item,
+        key: createItemKey(item.type, item.optionId),
+        slug: 'poolroyale'
+      })),
+      tabletennisroyal: POOL_ROYALE_STORE_ITEMS.map((item) => ({
+        ...item,
+        key: createItemKey(item.type, item.optionId),
+        slug: 'tabletennisroyal'
+      })),
+      snookerroyale: SNOOKER_ROYALE_STORE_ITEMS.map((item) => ({
+        ...item,
+        key: createItemKey(item.type, item.optionId),
+        slug: 'snookerroyale'
+      })),
+      airhockey: AIR_HOCKEY_STORE_ITEMS.map((item) => ({
+        ...item,
+        key: createItemKey(item.type, item.optionId),
+        slug: 'airhockey'
+      })),
+      chessbattleroyal: CHESS_BATTLE_STORE_ITEMS.map((item) => ({
+        ...item,
+        key: createItemKey(item.type, item.optionId),
+        slug: 'chessbattleroyal'
+      })),
+      checkersbattleroyal: CHESS_BATTLE_STORE_ITEMS.map((item) => ({
+        ...item,
+        key: createItemKey(item.type, item.optionId),
+        slug: 'checkersbattleroyal'
+      })),
+      fourinrowroyale: FOUR_IN_ROW_BATTLE_STORE_ITEMS.map((item) => ({
+        ...item,
+        key: createItemKey(item.type, item.optionId),
+        slug: 'fourinrowroyale'
+      })),
+      tavullbattleroyal: TAVULL_BATTLE_STORE_ITEMS.map((item) => ({
+        ...item,
+        key: createItemKey(item.type, item.optionId),
+        slug: 'tavullbattleroyal'
+      })),
+      ludobattleroyal: LUDO_BATTLE_STORE_ITEMS.map((item) => ({
+        ...item,
+        key: createItemKey(item.type, item.optionId),
+        slug: 'ludobattleroyal'
+      })),
+      murlanroyale: MURLAN_ROYALE_STORE_ITEMS.map((item) => ({
+        ...item,
+        key: createItemKey(item.type, item.optionId),
+        slug: 'murlanroyale'
+      })),
+      'domino-royal': DOMINO_ROYAL_STORE_ITEMS.map((item) => ({
+        ...item,
+        key: createItemKey(item.type, item.optionId),
+        slug: 'domino-royal'
+      })),
+      snake: SNAKE_STORE_ITEMS.map((item) => ({
+        ...item,
+        key: createItemKey(item.type, item.optionId),
+        slug: 'snake'
+      })),
+      texasholdem: TEXAS_HOLDEM_STORE_ITEMS.map((item) => ({
+        ...item,
+        key: createItemKey(item.type, item.optionId),
+        slug: 'texasholdem'
+      }))
     }),
     []
   );
 
   const ownedCheckers = useMemo(
     () => ({
-      poolroyale: (type, optionId) => isPoolOptionUnlocked(type, optionId, poolOwned),
-      tabletennisroyal: (type, optionId) => isPoolOptionUnlocked(type, optionId, poolOwned),
-      snookerroyale: (type, optionId) => isSnookerOptionUnlocked(type, optionId, snookerOwned),
-      airhockey: (type, optionId) => isAirHockeyOptionUnlocked(type, optionId, airOwned),
-      chessbattleroyal: (type, optionId) => isChessOptionUnlocked(type, optionId, chessOwned),
-      checkersbattleroyal: (type, optionId) => isChessOptionUnlocked(type, optionId, chessOwned),
-      fourinrowroyale: (type, optionId) => isFourInRowOptionUnlocked(type, optionId, fourInRowOwned),
-      tavullbattleroyal: (type, optionId) => isChessOptionUnlocked(type, optionId, chessOwned),
-      ludobattleroyal: (type, optionId) => isLudoOptionUnlocked(type, optionId, ludoOwned),
-      murlanroyale: (type, optionId) => isMurlanOptionUnlocked(type, optionId, murlanOwned),
-      'domino-royal': (type, optionId) => isDominoOptionUnlocked(type, optionId, dominoOwned),
-      snake: (type, optionId) => isSnakeOptionUnlocked(type, optionId, snakeOwned),
-      texasholdem: (type, optionId) => isTexasOptionUnlocked(type, optionId, texasOwned)
+      poolroyale: (type, optionId) =>
+        isPoolOptionUnlocked(type, optionId, poolOwned),
+      tabletennisroyal: (type, optionId) =>
+        isPoolOptionUnlocked(type, optionId, poolOwned),
+      snookerroyale: (type, optionId) =>
+        isSnookerOptionUnlocked(type, optionId, snookerOwned),
+      airhockey: (type, optionId) =>
+        isAirHockeyOptionUnlocked(type, optionId, airOwned),
+      chessbattleroyal: (type, optionId) =>
+        isChessOptionUnlocked(type, optionId, chessOwned),
+      checkersbattleroyal: (type, optionId) =>
+        isChessOptionUnlocked(type, optionId, chessOwned),
+      fourinrowroyale: (type, optionId) =>
+        isFourInRowOptionUnlocked(type, optionId, fourInRowOwned),
+      tavullbattleroyal: (type, optionId) =>
+        isTavullOptionUnlocked(type, optionId, tavullOwned),
+      ludobattleroyal: (type, optionId) =>
+        isLudoOptionUnlocked(type, optionId, ludoOwned),
+      murlanroyale: (type, optionId) =>
+        isMurlanOptionUnlocked(type, optionId, murlanOwned),
+      'domino-royal': (type, optionId) =>
+        isDominoOptionUnlocked(type, optionId, dominoOwned),
+      snake: (type, optionId) =>
+        isSnakeOptionUnlocked(type, optionId, snakeOwned),
+      texasholdem: (type, optionId) =>
+        isTexasOptionUnlocked(type, optionId, texasOwned)
     }),
-    [airOwned, poolOwned, snookerOwned, chessOwned, fourInRowOwned, ludoOwned, murlanOwned, dominoOwned, snakeOwned, texasOwned]
+    [
+      airOwned,
+      poolOwned,
+      snookerOwned,
+      chessOwned,
+      fourInRowOwned,
+      ludoOwned,
+      tavullOwned,
+      murlanOwned,
+      dominoOwned,
+      snakeOwned,
+      texasOwned
+    ]
   );
 
   const labelResolvers = useMemo(
     () => ({
-      poolroyale: (item) => POOL_ROYALE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
-      tabletennisroyal: (item) => POOL_ROYALE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
-      snookerroyale: (item) => SNOOKER_ROYALE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
-      airhockey: (item) => AIR_HOCKEY_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
-      chessbattleroyal: (item) => CHESS_BATTLE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
-      checkersbattleroyal: (item) => CHESS_BATTLE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
-      fourinrowroyale: (item) => FOUR_IN_ROW_BATTLE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
-      tavullbattleroyal: (item) => CHESS_BATTLE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
-      ludobattleroyal: (item) => LUDO_BATTLE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
-      murlanroyale: (item) => MURLAN_ROYALE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
-      'domino-royal': (item) => DOMINO_ROYAL_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
-      snake: (item) => SNAKE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
-      texasholdem: (item) => TEXAS_HOLDEM_OPTION_LABELS[item.type]?.[item.optionId] || item.name
+      poolroyale: (item) =>
+        POOL_ROYALE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
+      tabletennisroyal: (item) =>
+        POOL_ROYALE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
+      snookerroyale: (item) =>
+        SNOOKER_ROYALE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
+      airhockey: (item) =>
+        AIR_HOCKEY_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
+      chessbattleroyal: (item) =>
+        CHESS_BATTLE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
+      checkersbattleroyal: (item) =>
+        CHESS_BATTLE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
+      fourinrowroyale: (item) =>
+        FOUR_IN_ROW_BATTLE_OPTION_LABELS[item.type]?.[item.optionId] ||
+        item.name,
+      tavullbattleroyal: (item) =>
+        TAVULL_BATTLE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
+      ludobattleroyal: (item) =>
+        LUDO_BATTLE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
+      murlanroyale: (item) =>
+        MURLAN_ROYALE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
+      'domino-royal': (item) =>
+        DOMINO_ROYAL_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
+      snake: (item) =>
+        SNAKE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
+      texasholdem: (item) =>
+        TEXAS_HOLDEM_OPTION_LABELS[item.type]?.[item.optionId] || item.name
     }),
     []
   );
@@ -1016,7 +1232,7 @@ export default function Store() {
       chessbattleroyal: CHESS_TYPE_LABELS,
       checkersbattleroyal: CHESS_TYPE_LABELS,
       fourinrowroyale: FOUR_IN_ROW_TYPE_LABELS,
-      tavullbattleroyal: CHESS_TYPE_LABELS,
+      tavullbattleroyal: TAVULL_TYPE_LABELS,
       ludobattleroyal: LUDO_TYPE_LABELS,
       murlanroyale: MURLAN_TYPE_LABELS,
       'domino-royal': DOMINO_TYPE_LABELS,
@@ -1109,7 +1325,8 @@ export default function Store() {
       const numeric = Number(rawPrice);
       if (!Number.isFinite(numeric)) return TON_PRICE_MIN;
       if (priceRange.max <= priceRange.min) return TON_PRICE_MAX;
-      const ratio = (numeric - priceRange.min) / (priceRange.max - priceRange.min);
+      const ratio =
+        (numeric - priceRange.min) / (priceRange.max - priceRange.min);
       const clamped = Math.min(1, Math.max(0, ratio));
       const value = TON_PRICE_MIN + clamped * (TON_PRICE_MAX - TON_PRICE_MIN);
       return Number(value.toFixed(2));
@@ -1129,7 +1346,10 @@ export default function Store() {
       item.zoomImage
     ];
     return (
-      candidates.find((candidate) => typeof candidate === 'string' && candidate.trim().length > 0) || ''
+      candidates.find(
+        (candidate) =>
+          typeof candidate === 'string' && candidate.trim().length > 0
+      ) || ''
     );
   }, []);
 
@@ -1145,10 +1365,17 @@ export default function Store() {
         item.preview?.thumbnail
       ];
       const resolvedThumbnail =
-        thumbnailCandidates.find((candidate) => typeof candidate === 'string' && candidate.trim().length > 0) || '';
+        thumbnailCandidates.find(
+          (candidate) =>
+            typeof candidate === 'string' && candidate.trim().length > 0
+        ) || '';
       const originalImage = resolveOriginalImage(item);
-      const usesGeneratedSwatch = resolvedThumbnail.startsWith('data:image/svg+xml');
-      const resolved = (resolvedThumbnail && !usesGeneratedSwatch ? resolvedThumbnail : originalImage) || '';
+      const usesGeneratedSwatch =
+        resolvedThumbnail.startsWith('data:image/svg+xml');
+      const resolved =
+        (resolvedThumbnail && !usesGeneratedSwatch
+          ? resolvedThumbnail
+          : originalImage) || '';
       if (resolved) return normalizePolyHavenImage(resolved, THUMBNAIL_SIZE);
       if (item.swatches?.length) {
         return swatchThumbnail(item.swatches);
@@ -1169,9 +1396,15 @@ export default function Store() {
         item.media?.zoom,
         item.media?.image
       ];
-      const zoomFallback = normalizePolyHavenImage(thumbnail, ZOOM_PREVIEW_SIZE);
+      const zoomFallback = normalizePolyHavenImage(
+        thumbnail,
+        ZOOM_PREVIEW_SIZE
+      );
       const zoom =
-        zoomCandidates.find((candidate) => typeof candidate === 'string' && candidate.trim().length > 0) ||
+        zoomCandidates.find(
+          (candidate) =>
+            typeof candidate === 'string' && candidate.trim().length > 0
+        ) ||
         zoomFallback ||
         thumbnail;
       return {
@@ -1188,8 +1421,16 @@ export default function Store() {
       ? normalizeTonPrice(item.price)
       : clampTonPrice(item.price);
     const swatches = resolveSwatches(item.type, item.optionId, item.swatches);
-    const previewShape = resolvePreviewShape(item.slug, item.type, item.previewShape);
-    const nftMeta = buildNftMetadata({ ...item, price: resolvedPrice, swatches });
+    const previewShape = resolvePreviewShape(
+      item.slug,
+      item.type,
+      item.previewShape
+    );
+    const nftMeta = buildNftMetadata({
+      ...item,
+      price: resolvedPrice,
+      swatches
+    });
     return { ...item, price: resolvedPrice, swatches, previewShape, nftMeta };
   };
 
@@ -1204,13 +1445,15 @@ export default function Store() {
         entries.push(
           decorateMarketplaceItem(
             {
-            ...item,
-            slug,
-            displayLabel,
-            typeLabel: typeLabels[item.type] || item.type,
-            gameName: storeMeta[slug]?.name || slug,
-            owned: ownedChecker ? ownedChecker(item.type, item.optionId) : false,
-            seller: 'Official store'
+              ...item,
+              slug,
+              displayLabel,
+              typeLabel: typeLabels[item.type] || item.type,
+              gameName: storeMeta[slug]?.name || slug,
+              owned: ownedChecker
+                ? ownedChecker(item.type, item.optionId)
+                : false,
+              seller: 'Official store'
             },
             { scalePrice: true }
           )
@@ -1228,10 +1471,14 @@ export default function Store() {
   useEffect(() => {
     if (showListModal && ownedMarketplaceItems.length) {
       setListForm((prev) => {
-        const validSelection = ownedMarketplaceItems.find((item) => item.id === prev.itemId);
+        const validSelection = ownedMarketplaceItems.find(
+          (item) => item.id === prev.itemId
+        );
         const nextItem = validSelection || ownedMarketplaceItems[0];
-        const suggestedPrice = prev.price || (nextItem.price ? String(nextItem.price) : '');
-        if (prev.itemId === nextItem.id && prev.price === suggestedPrice) return prev;
+        const suggestedPrice =
+          prev.price || (nextItem.price ? String(nextItem.price) : '');
+        if (prev.itemId === nextItem.id && prev.price === suggestedPrice)
+          return prev;
         return { ...prev, itemId: nextItem.id, price: suggestedPrice };
       });
     }
@@ -1248,7 +1495,8 @@ export default function Store() {
           {
             ...listing,
             slug: listing.slug || listing.game,
-            gameName: storeMeta[listing.slug || listing.game]?.name || 'Player listing',
+            gameName:
+              storeMeta[listing.slug || listing.game]?.name || 'Player listing',
             typeLabel: listing.typeLabel || 'Player NFT',
             displayLabel: listing.displayLabel || listing.name || 'Player NFT',
             owned: true,
@@ -1271,7 +1519,8 @@ export default function Store() {
       return items
         .filter((item) => {
           if (activeGame !== 'all' && item.slug !== activeGame) return false;
-          if (activeType !== 'all' && item.typeLabel !== activeType) return false;
+          if (activeType !== 'all' && item.typeLabel !== activeType)
+            return false;
           if (!term) return true;
           return (
             item.displayLabel.toLowerCase().includes(term) ||
@@ -1283,11 +1532,15 @@ export default function Store() {
         .sort((a, b) => {
           if (sortOption === 'price-low') return a.price - b.price;
           if (sortOption === 'price-high') return b.price - a.price;
-          if (sortOption === 'alpha') return a.displayLabel.localeCompare(b.displayLabel);
+          if (sortOption === 'alpha')
+            return a.displayLabel.localeCompare(b.displayLabel);
           const featuredRank = (item) => {
             const label = item.typeLabel?.toLowerCase() || '';
             const hasThumbnail = Boolean(resolveItemThumbnail(item));
-            const isTableOrChair = label.includes('table') || label.includes('chair') || label.includes('stool');
+            const isTableOrChair =
+              label.includes('table') ||
+              label.includes('chair') ||
+              label.includes('stool');
             if (hasThumbnail && isTableOrChair) return 0;
             if (hasThumbnail) return 1;
             if (isTableOrChair) return 2;
@@ -1303,7 +1556,10 @@ export default function Store() {
     [activeGame, activeType, searchTerm, sortOption]
   );
 
-  const filteredItems = useMemo(() => applyFilters(allMarketplaceItems), [allMarketplaceItems, applyFilters]);
+  const filteredItems = useMemo(
+    () => applyFilters(allMarketplaceItems),
+    [allMarketplaceItems, applyFilters]
+  );
   const filteredUserListings = useMemo(
     () => applyFilters(decoratedUserListings),
     [applyFilters, decoratedUserListings]
@@ -1311,7 +1567,9 @@ export default function Store() {
   const visibleItems = showMyListings ? filteredUserListings : filteredItems;
 
   useEffect(() => {
-    const validKeys = new Set(allMarketplaceItems.map((item) => selectionKey(item)));
+    const validKeys = new Set(
+      allMarketplaceItems.map((item) => selectionKey(item))
+    );
     setSelectedKeys((prev) => prev.filter((key) => validKeys.has(key)));
   }, [allMarketplaceItems]);
 
@@ -1335,10 +1593,12 @@ export default function Store() {
   );
   const hasSelection = selectedKeys.length > 0;
   const hasPurchasableSelection = selectedPurchasable.length > 0;
-  const selectedBalanceAfter = accountBalance === null ? null : accountBalance - selectedTotalPrice;
-  const selectedShortfall = selectedBalanceAfter !== null && selectedBalanceAfter < 0
-    ? Math.abs(selectedBalanceAfter)
-    : 0;
+  const selectedBalanceAfter =
+    accountBalance === null ? null : accountBalance - selectedTotalPrice;
+  const selectedShortfall =
+    selectedBalanceAfter !== null && selectedBalanceAfter < 0
+      ? Math.abs(selectedBalanceAfter)
+      : 0;
 
   useEffect(() => {
     if (!selectedPurchasable.length) {
@@ -1373,7 +1633,9 @@ export default function Store() {
 
   const typeFilters = useMemo(() => {
     const types = new Set();
-    const scopedItems = showMyListings ? decoratedUserListings : allMarketplaceItems;
+    const scopedItems = showMyListings
+      ? decoratedUserListings
+      : allMarketplaceItems;
     scopedItems.forEach((item) => {
       if (item.typeLabel) {
         types.add(item.typeLabel);
@@ -1417,19 +1679,25 @@ export default function Store() {
       if (!groups.has(key)) groups.set(key, []);
       groups.get(key).push(item);
     });
-    return Array.from(groups.entries()).sort((a, b) => a[0].localeCompare(b[0]));
+    return Array.from(groups.entries()).sort((a, b) =>
+      a[0].localeCompare(b[0])
+    );
   }, [activeGame, visibleItems]);
 
   const handleListSubmit = (event) => {
     event?.preventDefault();
-    const selectedItem = ownedMarketplaceItems.find((item) => item.id === listForm.itemId);
+    const selectedItem = ownedMarketplaceItems.find(
+      (item) => item.id === listForm.itemId
+    );
 
     if (!selectedItem) {
       setInfo('Select an owned NFT to list.');
       return;
     }
 
-    const listingPrice = clampTonPrice(listForm.price || selectedItem.price || TON_PRICE_MIN);
+    const listingPrice = clampTonPrice(
+      listForm.price || selectedItem.price || TON_PRICE_MIN
+    );
 
     const newListing = decorateMarketplaceItem({
       id: `user-${Date.now()}`,
@@ -1456,7 +1724,9 @@ export default function Store() {
   };
 
   const handlePurchase = async (items) => {
-    const payload = Array.isArray(items) ? items.filter(Boolean) : [items].filter(Boolean);
+    const payload = Array.isArray(items)
+      ? items.filter(Boolean)
+      : [items].filter(Boolean);
     if (!payload.length) return;
     const fallbackSnapshot = getLastStorePurchaseSnapshot();
     const fallbackAccountId = fallbackSnapshot?.accountId || '';
@@ -1490,7 +1760,10 @@ export default function Store() {
     }
 
     const groupedBySlug = purchasable.reduce((acc, item) => {
-      acc[item.slug] = acc[item.slug] || { items: [], gameName: storeMeta[item.slug]?.name || item.slug };
+      acc[item.slug] = acc[item.slug] || {
+        items: [],
+        gameName: storeMeta[item.slug]?.name || item.slug
+      };
       acc[item.slug].items.push(item);
       return acc;
     }, {});
@@ -1502,7 +1775,9 @@ export default function Store() {
     }
 
     const labelResolver = (slug, item) =>
-      labelResolvers[slug] ? labelResolvers[slug](item) : item.name || item.displayLabel;
+      labelResolvers[slug]
+        ? labelResolvers[slug](item)
+        : item.name || item.displayLabel;
     setProcessing(purchasable.length > 1 ? 'bulk' : purchasable[0].id);
     resetStatus();
     setTransactionState('processing');
@@ -1521,7 +1796,9 @@ export default function Store() {
       if (purchase?.error) {
         setInfo(purchase.error || 'Unable to process TPC payment.');
         setTransactionState('error');
-        setTransactionStatus(purchase.error || 'Payment failed. Please try again.');
+        setTransactionStatus(
+          purchase.error || 'Payment failed. Please try again.'
+        );
         return;
       }
       setTransactionStatus('Payment approved. Unlocking items…');
@@ -1530,12 +1807,14 @@ export default function Store() {
       for (const [slug, group] of Object.entries(groupedBySlug)) {
         if (slug === 'poolroyale' || slug === 'tabletennisroyal') {
           for (const entry of group.items) {
-            const syncTask = addPoolRoyalUnlock(entry.type, entry.optionId, resolvedAccountId).then(
-              (updated) => {
-                setPoolOwned(updated);
-                return updated;
-              }
-            );
+            const syncTask = addPoolRoyalUnlock(
+              entry.type,
+              entry.optionId,
+              resolvedAccountId
+            ).then((updated) => {
+              setPoolOwned(updated);
+              return updated;
+            });
             backgroundSyncTasks.push(syncTask);
           }
           setPoolOwned(getCachedPoolRoyalInventory(resolvedAccountId));
@@ -1543,12 +1822,14 @@ export default function Store() {
         }
         if (slug === 'snookerroyale') {
           for (const entry of group.items) {
-            const syncTask = addSnookerRoyalUnlock(entry.type, entry.optionId, resolvedAccountId).then(
-              (updated) => {
-                setSnookerOwned(updated);
-                return updated;
-              }
-            );
+            const syncTask = addSnookerRoyalUnlock(
+              entry.type,
+              entry.optionId,
+              resolvedAccountId
+            ).then((updated) => {
+              setSnookerOwned(updated);
+              return updated;
+            });
             backgroundSyncTasks.push(syncTask);
           }
           setSnookerOwned(getCachedSnookerRoyalInventory(resolvedAccountId));
@@ -1557,21 +1838,60 @@ export default function Store() {
 
         for (const entry of group.items) {
           if (slug === 'airhockey') {
-            setAirOwned(addAirHockeyUnlock(entry.type, entry.optionId, resolvedAccountId));
-          } else if (slug === 'chessbattleroyal' || slug === 'checkersbattleroyal' || slug === 'tavullbattleroyal') {
-            setChessOwned(addChessBattleUnlock(entry.type, entry.optionId, resolvedAccountId));
+            setAirOwned(
+              addAirHockeyUnlock(entry.type, entry.optionId, resolvedAccountId)
+            );
+          } else if (
+            slug === 'chessbattleroyal' ||
+            slug === 'checkersbattleroyal'
+          ) {
+            setChessOwned(
+              addChessBattleUnlock(
+                entry.type,
+                entry.optionId,
+                resolvedAccountId
+              )
+            );
+          } else if (slug === 'tavullbattleroyal') {
+            setTavullOwned(
+              addTavullBattleUnlock(
+                entry.type,
+                entry.optionId,
+                resolvedAccountId
+              )
+            );
           } else if (slug === 'fourinrowroyale') {
-            setFourInRowOwned(addFourInRowUnlock(entry.type, entry.optionId, resolvedAccountId));
+            setFourInRowOwned(
+              addFourInRowUnlock(entry.type, entry.optionId, resolvedAccountId)
+            );
           } else if (slug === 'ludobattleroyal') {
-            setLudoOwned(addLudoBattleUnlock(entry.type, entry.optionId, resolvedAccountId));
+            setLudoOwned(
+              addLudoBattleUnlock(entry.type, entry.optionId, resolvedAccountId)
+            );
           } else if (slug === 'murlanroyale') {
-            setMurlanOwned(addMurlanUnlock(entry.type, entry.optionId, resolvedAccountId));
+            setMurlanOwned(
+              addMurlanUnlock(entry.type, entry.optionId, resolvedAccountId)
+            );
           } else if (slug === 'domino-royal') {
-            setDominoOwned(addDominoRoyalUnlock(entry.type, entry.optionId, resolvedAccountId));
+            setDominoOwned(
+              addDominoRoyalUnlock(
+                entry.type,
+                entry.optionId,
+                resolvedAccountId
+              )
+            );
           } else if (slug === 'snake') {
-            setSnakeOwned(addSnakeUnlock(entry.type, entry.optionId, resolvedAccountId));
+            setSnakeOwned(
+              addSnakeUnlock(entry.type, entry.optionId, resolvedAccountId)
+            );
           } else if (slug === 'texasholdem') {
-            setTexasOwned(addTexasHoldemUnlock(entry.type, entry.optionId, resolvedAccountId));
+            setTexasOwned(
+              addTexasHoldemUnlock(
+                entry.type,
+                entry.optionId,
+                resolvedAccountId
+              )
+            );
           }
         }
       }
@@ -1580,9 +1900,12 @@ export default function Store() {
       }
 
       const purchasedTrainingAttempts = purchasable.reduce((sum, item) => {
-        if (item.slug !== 'poolroyale' || item.type !== 'poolTrainingAttempt') return sum;
+        if (item.slug !== 'poolroyale' || item.type !== 'poolTrainingAttempt')
+          return sum;
         const attempts = Number(item.optionId);
-        return Number.isFinite(attempts) && attempts > 0 ? sum + Math.floor(attempts) : sum;
+        return Number.isFinite(attempts) && attempts > 0
+          ? sum + Math.floor(attempts)
+          : sum;
       }, 0);
       if (purchasedTrainingAttempts > 0) {
         addTrainingAttempts(purchasedTrainingAttempts);
@@ -1611,7 +1934,9 @@ export default function Store() {
           price: item.price
         }))
       });
-      const purchasedKeys = new Set(purchasable.map((item) => selectionKey(item)));
+      const purchasedKeys = new Set(
+        purchasable.map((item) => selectionKey(item))
+      );
       setSelectedKeys((prev) => prev.filter((key) => !purchasedKeys.has(key)));
       setPurchaseStatus(successLabel);
       setInfo('');
@@ -1631,7 +1956,9 @@ export default function Store() {
   };
 
   const initiateTpcPurchase = async (items) => {
-    const payload = Array.isArray(items) ? items.filter(Boolean) : [items].filter(Boolean);
+    const payload = Array.isArray(items)
+      ? items.filter(Boolean)
+      : [items].filter(Boolean);
     if (!payload.length) return;
     setIsPaying(true);
     resetStatus();
@@ -1644,22 +1971,30 @@ export default function Store() {
 
   const featuredCount = allMarketplaceItems.length;
   const ownedCount = allMarketplaceItems.filter((item) => item.owned).length;
-  const walletLabel = accountId && accountId !== 'guest' ? 'Account linked' : 'Guest mode';
+  const walletLabel =
+    accountId && accountId !== 'guest' ? 'Account linked' : 'Guest mode';
   const mainPaddingClass = hasSelection
     ? 'pb-[calc(10rem+env(safe-area-inset-bottom))]'
     : 'pb-24';
 
   const renderListModal = () => {
     if (!showListModal) return null;
-    const selectedItem = ownedMarketplaceItems.find((item) => item.id === listForm.itemId);
+    const selectedItem = ownedMarketplaceItems.find(
+      (item) => item.id === listForm.itemId
+    );
     return (
       <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 px-4">
         <div className="flex w-full max-w-xl max-h-[90vh] flex-col overflow-hidden rounded-3xl border border-white/10 bg-zinc-950 shadow-2xl">
           <div className="flex items-center justify-between border-b border-white/10 p-4">
             <div>
               <p className="text-xs text-white/60">List an owned NFT</p>
-              <h3 className="text-lg font-semibold text-white">Create marketplace listing</h3>
-              <p className="text-sm text-white/60">Pick an unlocked cosmetic, then set the sale price. We keep the metadata locked to your NFT.</p>
+              <h3 className="text-lg font-semibold text-white">
+                Create marketplace listing
+              </h3>
+              <p className="text-sm text-white/60">
+                Pick an unlocked cosmetic, then set the sale price. We keep the
+                metadata locked to your NFT.
+              </p>
             </div>
             <button
               type="button"
@@ -1670,12 +2005,17 @@ export default function Store() {
             </button>
           </div>
 
-          <form className="grid flex-1 gap-3 overflow-y-auto p-4" onSubmit={handleListSubmit}>
+          <form
+            className="grid flex-1 gap-3 overflow-y-auto p-4"
+            onSubmit={handleListSubmit}
+          >
             <div className="grid gap-3 md:grid-cols-[7fr_5fr] md:items-start">
               <div className="grid gap-2">
                 <div className="flex items-center justify-between text-sm text-white/80">
                   <span>Choose an owned NFT</span>
-                  <span className="text-xs text-white/60">{ownedMarketplaceItems.length} available</span>
+                  <span className="text-xs text-white/60">
+                    {ownedMarketplaceItems.length} available
+                  </span>
                 </div>
                 <div className="grid max-h-72 gap-2 overflow-y-auto pr-1">
                   {ownedMarketplaceItems.length ? (
@@ -1689,7 +2029,9 @@ export default function Store() {
                             setListForm((prev) => ({
                               ...prev,
                               itemId: item.id,
-                              price: prev.price || (item.price ? String(item.price) : '')
+                              price:
+                                prev.price ||
+                                (item.price ? String(item.price) : '')
                             }))
                           }
                           className={`flex items-center justify-between gap-3 rounded-2xl border px-3 py-2 text-left transition ${
@@ -1701,25 +2043,34 @@ export default function Store() {
                           <div className="flex items-center gap-3">
                             {renderPreview3d(item, false)}
                             <div className="grid gap-0.5 text-sm text-white/80">
-                              <div className="font-semibold text-white">{item.displayLabel}</div>
+                              <div className="font-semibold text-white">
+                                {item.displayLabel}
+                              </div>
                               <div className="text-xs text-white/60">
                                 {item.gameName} • {item.typeLabel}
                               </div>
                             </div>
                           </div>
                           <div className="text-right text-sm text-white/80">
-                          <div className="flex items-center justify-end gap-1 font-semibold">
-                            <span>{item.price}</span>
-                            <img src={TON_ICON} alt="TPC" className="h-4 w-4" />
+                            <div className="flex items-center justify-end gap-1 font-semibold">
+                              <span>{item.price}</span>
+                              <img
+                                src={TON_ICON}
+                                alt="TPC"
+                                className="h-4 w-4"
+                              />
+                            </div>
+                            <div className="text-[11px] text-white/50">
+                              Base price
+                            </div>
                           </div>
-                          <div className="text-[11px] text-white/50">Base price</div>
-                        </div>
-                      </button>
-                    );
+                        </button>
+                      );
                     })
                   ) : (
                     <div className="rounded-2xl border border-white/10 bg-black/30 p-3 text-sm text-white/70">
-                      You have no cosmetics unlocked yet. Buy an item from the store before listing it.
+                      You have no cosmetics unlocked yet. Buy an item from the
+                      store before listing it.
                     </div>
                   )}
                 </div>
@@ -1728,9 +2079,13 @@ export default function Store() {
               <div className="grid gap-3 rounded-2xl border border-white/10 bg-black/30 p-3">
                 <div className="flex items-start justify-between gap-2">
                   <div className="space-y-1">
-                    <p className="text-xs uppercase tracking-wide text-white/60">Selected NFT</p>
+                    <p className="text-xs uppercase tracking-wide text-white/60">
+                      Selected NFT
+                    </p>
                     <h4 className="text-base font-semibold text-white">
-                      {selectedItem ? selectedItem.displayLabel : 'No selection'}
+                      {selectedItem
+                        ? selectedItem.displayLabel
+                        : 'No selection'}
                     </h4>
                     <p className="text-xs text-white/60">
                       {selectedItem
@@ -1742,20 +2097,28 @@ export default function Store() {
                 </div>
 
                 <label className="grid gap-1 text-sm text-white/80">
-                  <span className="text-xs uppercase tracking-wide text-white/60">Listing price (TPC)</span>
+                  <span className="text-xs uppercase tracking-wide text-white/60">
+                    Listing price (TPC)
+                  </span>
                   <input
                     type="number"
                     min={TON_PRICE_MIN}
                     max={TON_PRICE_MAX}
                     step="0.01"
                     value={listForm.price}
-                    onChange={(e) => setListForm((prev) => ({ ...prev, price: e.target.value }))}
+                    onChange={(e) =>
+                      setListForm((prev) => ({
+                        ...prev,
+                        price: e.target.value
+                      }))
+                    }
                     placeholder={selectedItem?.price || TON_PRICE_MIN}
                     className="w-full rounded-2xl border border-white/10 bg-black/30 px-3 py-2 text-white outline-none"
                     required
                   />
                   <span className="text-xs text-white/50">
-                    Metadata stays tied to your NFT. Buyers will only see the price you set here.
+                    Metadata stays tied to your NFT. Buyers will only see the
+                    price you set here.
                   </span>
                 </label>
 
@@ -1789,10 +2152,12 @@ export default function Store() {
   const renderConfirmModal = () => {
     if (!confirmItem) return null;
     const gameName = storeMeta[confirmItem.slug]?.name || confirmItem.slug;
-    const confirmBalanceAfter = accountBalance === null ? null : accountBalance - confirmItem.price;
-    const confirmShortfall = confirmBalanceAfter !== null && confirmBalanceAfter < 0
-      ? Math.abs(confirmBalanceAfter)
-      : 0;
+    const confirmBalanceAfter =
+      accountBalance === null ? null : accountBalance - confirmItem.price;
+    const confirmShortfall =
+      confirmBalanceAfter !== null && confirmBalanceAfter < 0
+        ? Math.abs(confirmBalanceAfter)
+        : 0;
     const isInsufficientBalance = confirmShortfall > 0;
     return (
       <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/70 px-4 pb-4 pt-8 sm:pt-12">
@@ -1800,8 +2165,12 @@ export default function Store() {
           <div className="flex items-center justify-between border-b border-white/10 p-4">
             <div>
               <p className="text-xs text-white/60">Confirm purchase</p>
-              <h3 className="text-lg font-semibold text-white">{confirmItem.displayLabel}</h3>
-              <p className="text-sm text-white/60">{gameName} • {confirmItem.typeLabel}</p>
+              <h3 className="text-lg font-semibold text-white">
+                {confirmItem.displayLabel}
+              </h3>
+              <p className="text-sm text-white/60">
+                {gameName} • {confirmItem.typeLabel}
+              </p>
             </div>
             <div className="flex items-center gap-1 rounded-full bg-white/10 px-3 py-1 text-sm font-semibold">
               {confirmItem.price}
@@ -1811,13 +2180,18 @@ export default function Store() {
 
           <div className="space-y-3 p-4 text-sm text-white/70">
             <p>
-              Purchase with your TPC balance. Once approved, we deliver the NFT instantly and log it on your statement.
+              Purchase with your TPC balance. Once approved, we deliver the NFT
+              instantly and log it on your statement.
             </p>
             <div className="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 p-3">
               {renderStoreThumbnail(confirmItem, 'compact')}
               <div className="grid gap-1 text-xs">
-                <div className="text-sm font-semibold text-white">{confirmItem.displayLabel}</div>
-                <div className="text-white/60">{gameName} • {confirmItem.typeLabel}</div>
+                <div className="text-sm font-semibold text-white">
+                  {confirmItem.displayLabel}
+                </div>
+                <div className="text-white/60">
+                  {gameName} • {confirmItem.typeLabel}
+                </div>
               </div>
             </div>
             <div className="grid gap-2 rounded-2xl border border-white/10 bg-white/5 p-3 text-white/80">
@@ -1840,40 +2214,59 @@ export default function Store() {
             <div className="grid gap-2 rounded-2xl border border-white/10 bg-white/5 p-3 text-xs text-white/70">
               <div className="flex flex-wrap items-center justify-between gap-2">
                 <span className="text-white/60">Payment</span>
-                <span className="font-semibold text-white">TPC balance purchase</span>
+                <span className="font-semibold text-white">
+                  TPC balance purchase
+                </span>
               </div>
               <div className="flex flex-wrap items-center justify-between gap-2">
                 <span className="text-white/60">Delivery</span>
-                <span className="font-semibold text-white">NFT sent instantly and logged on your statement</span>
+                <span className="font-semibold text-white">
+                  NFT sent instantly and logged on your statement
+                </span>
               </div>
             </div>
             <div className="grid gap-2 rounded-2xl border border-emerald-300/20 bg-emerald-500/5 p-3 text-xs text-white/80">
               <div className="flex items-center justify-between gap-2">
                 <span className="text-white/60">TPC balance</span>
-                <span className="font-semibold text-white">{accountBalance === null ? '—' : formatTpcAmount(accountBalance)}</span>
+                <span className="font-semibold text-white">
+                  {accountBalance === null
+                    ? '—'
+                    : formatTpcAmount(accountBalance)}
+                </span>
               </div>
               <div className="flex items-center justify-between gap-2">
                 <span className="text-white/60">Item total</span>
-                <span className="font-semibold text-white">{formatTpcAmount(confirmItem.price)}</span>
+                <span className="font-semibold text-white">
+                  {formatTpcAmount(confirmItem.price)}
+                </span>
               </div>
               <div className="flex items-center justify-between gap-2">
                 <span className="text-white/60">After purchase</span>
-                <span className={`font-semibold ${isInsufficientBalance ? 'text-rose-200' : 'text-emerald-200'}`}>
-                  {confirmBalanceAfter === null ? '—' : formatTpcAmount(confirmBalanceAfter)}
+                <span
+                  className={`font-semibold ${isInsufficientBalance ? 'text-rose-200' : 'text-emerald-200'}`}
+                >
+                  {confirmBalanceAfter === null
+                    ? '—'
+                    : formatTpcAmount(confirmBalanceAfter)}
                 </span>
               </div>
               {isInsufficientBalance ? (
-                <p className="text-rose-200">Need {formatTpcAmount(confirmShortfall)} more TPC to complete this purchase.</p>
+                <p className="text-rose-200">
+                  Need {formatTpcAmount(confirmShortfall)} more TPC to complete
+                  this purchase.
+                </p>
               ) : null}
             </div>
             {showTransactionToast ? (
-              <div className={`rounded-2xl border px-3 py-2 text-xs ${
-                transactionState === 'error'
-                  ? 'border-rose-400/50 bg-rose-500/15 text-rose-100'
-                  : transactionState === 'success'
-                    ? 'border-emerald-300/50 bg-emerald-500/10 text-emerald-100'
-                    : 'border-white/20 bg-white/10 text-white/90'
-              }`}>
+              <div
+                className={`rounded-2xl border px-3 py-2 text-xs ${
+                  transactionState === 'error'
+                    ? 'border-rose-400/50 bg-rose-500/15 text-rose-100'
+                    : transactionState === 'success'
+                      ? 'border-emerald-300/50 bg-emerald-500/10 text-emerald-100'
+                      : 'border-white/20 bg-white/10 text-white/90'
+                }`}
+              >
                 <span className="font-semibold">{transactionStatus}</span>
               </div>
             ) : null}
@@ -1889,9 +2282,15 @@ export default function Store() {
                 type="button"
                 onClick={() => initiateTpcPurchase(confirmItem)}
                 className="w-full rounded-2xl bg-emerald-300 px-4 py-2 text-sm font-semibold text-emerald-950 hover:bg-emerald-200 sm:w-auto"
-                disabled={Boolean(processing) || isPaying || isInsufficientBalance}
+                disabled={
+                  Boolean(processing) || isPaying || isInsufficientBalance
+                }
               >
-                {isInsufficientBalance ? 'Insufficient TPC' : isPaying ? 'Purchasing…' : 'Purchase'}
+                {isInsufficientBalance
+                  ? 'Insufficient TPC'
+                  : isPaying
+                    ? 'Purchasing…'
+                    : 'Purchase'}
               </button>
             </div>
           </div>
@@ -1903,10 +2302,12 @@ export default function Store() {
   const renderBulkConfirmModal = () => {
     if (!confirmItems.length) return null;
     const totalPrice = confirmItems.reduce((sum, item) => sum + item.price, 0);
-    const bulkBalanceAfter = accountBalance === null ? null : accountBalance - totalPrice;
-    const bulkShortfall = bulkBalanceAfter !== null && bulkBalanceAfter < 0
-      ? Math.abs(bulkBalanceAfter)
-      : 0;
+    const bulkBalanceAfter =
+      accountBalance === null ? null : accountBalance - totalPrice;
+    const bulkShortfall =
+      bulkBalanceAfter !== null && bulkBalanceAfter < 0
+        ? Math.abs(bulkBalanceAfter)
+        : 0;
     const hasBulkShortfall = bulkShortfall > 0;
     const grouped = confirmItems.reduce((acc, item) => {
       const gameName = storeMeta[item.slug]?.name || item.slug;
@@ -1924,9 +2325,12 @@ export default function Store() {
             <div>
               <p className="text-xs text-white/60">Confirm bulk purchase</p>
               <h3 className="text-lg font-semibold text-white">
-                {confirmItems.length} cosmetics • {groupedLabels || 'Mixed games'}
+                {confirmItems.length} cosmetics •{' '}
+                {groupedLabels || 'Mixed games'}
               </h3>
-              <p className="text-sm text-white/60">Review your cart and pay once to unlock everything.</p>
+              <p className="text-sm text-white/60">
+                Review your cart and pay once to unlock everything.
+              </p>
             </div>
             <div className="flex items-center gap-1 rounded-full bg-white/10 px-3 py-1 text-sm font-semibold">
               {totalPrice.toLocaleString()}
@@ -1944,8 +2348,13 @@ export default function Store() {
                   <div className="flex items-center gap-3">
                     {renderStoreThumbnail(item, 'compact')}
                     <div className="grid gap-0.5">
-                      <span className="text-white font-semibold">{item.displayLabel}</span>
-                      <span className="text-xs text-white/60">{storeMeta[item.slug]?.name || item.slug} • {item.typeLabel}</span>
+                      <span className="text-white font-semibold">
+                        {item.displayLabel}
+                      </span>
+                      <span className="text-xs text-white/60">
+                        {storeMeta[item.slug]?.name || item.slug} •{' '}
+                        {item.typeLabel}
+                      </span>
                     </div>
                   </div>
                   <div className="flex items-center gap-1 text-sm font-semibold">
@@ -1958,45 +2367,67 @@ export default function Store() {
 
             <div className="rounded-2xl border border-white/10 bg-white/5 p-3 text-xs text-white/60">
               <p className="font-semibold text-white">Checkout summary</p>
-              <p className="mt-1">Purchase once with your TPC balance, then we deliver instantly and record it on your statement.</p>
+              <p className="mt-1">
+                Purchase once with your TPC balance, then we deliver instantly
+                and record it on your statement.
+              </p>
             </div>
             <div className="grid gap-2 rounded-2xl border border-white/10 bg-white/5 p-3 text-xs text-white/70">
               <div className="flex flex-wrap items-center justify-between gap-2">
                 <span className="text-white/60">Payment</span>
-                <span className="font-semibold text-white">TPC balance purchase</span>
+                <span className="font-semibold text-white">
+                  TPC balance purchase
+                </span>
               </div>
               <div className="flex flex-wrap items-center justify-between gap-2">
                 <span className="text-white/60">Delivery</span>
-                <span className="font-semibold text-white">NFTs sent instantly and logged on your statement</span>
+                <span className="font-semibold text-white">
+                  NFTs sent instantly and logged on your statement
+                </span>
               </div>
             </div>
             <div className="grid gap-2 rounded-2xl border border-emerald-300/20 bg-emerald-500/5 p-3 text-xs text-white/80">
               <div className="flex items-center justify-between gap-2">
                 <span className="text-white/60">TPC balance</span>
-                <span className="font-semibold text-white">{accountBalance === null ? '—' : formatTpcAmount(accountBalance)}</span>
+                <span className="font-semibold text-white">
+                  {accountBalance === null
+                    ? '—'
+                    : formatTpcAmount(accountBalance)}
+                </span>
               </div>
               <div className="flex items-center justify-between gap-2">
                 <span className="text-white/60">Bundle total</span>
-                <span className="font-semibold text-white">{formatTpcAmount(totalPrice)}</span>
+                <span className="font-semibold text-white">
+                  {formatTpcAmount(totalPrice)}
+                </span>
               </div>
               <div className="flex items-center justify-between gap-2">
                 <span className="text-white/60">After purchase</span>
-                <span className={`font-semibold ${hasBulkShortfall ? 'text-rose-200' : 'text-emerald-200'}`}>
-                  {bulkBalanceAfter === null ? '—' : formatTpcAmount(bulkBalanceAfter)}
+                <span
+                  className={`font-semibold ${hasBulkShortfall ? 'text-rose-200' : 'text-emerald-200'}`}
+                >
+                  {bulkBalanceAfter === null
+                    ? '—'
+                    : formatTpcAmount(bulkBalanceAfter)}
                 </span>
               </div>
               {hasBulkShortfall ? (
-                <p className="text-rose-200">Need {formatTpcAmount(bulkShortfall)} more TPC to checkout this bundle.</p>
+                <p className="text-rose-200">
+                  Need {formatTpcAmount(bulkShortfall)} more TPC to checkout
+                  this bundle.
+                </p>
               ) : null}
             </div>
             {showTransactionToast ? (
-              <div className={`rounded-2xl border px-3 py-2 text-xs ${
-                transactionState === 'error'
-                  ? 'border-rose-400/50 bg-rose-500/15 text-rose-100'
-                  : transactionState === 'success'
-                    ? 'border-emerald-300/50 bg-emerald-500/10 text-emerald-100'
-                    : 'border-white/20 bg-white/10 text-white/90'
-              }`}>
+              <div
+                className={`rounded-2xl border px-3 py-2 text-xs ${
+                  transactionState === 'error'
+                    ? 'border-rose-400/50 bg-rose-500/15 text-rose-100'
+                    : transactionState === 'success'
+                      ? 'border-emerald-300/50 bg-emerald-500/10 text-emerald-100'
+                      : 'border-white/20 bg-white/10 text-white/90'
+                }`}
+              >
                 <span className="font-semibold">{transactionStatus}</span>
               </div>
             ) : null}
@@ -2015,7 +2446,11 @@ export default function Store() {
                 className="w-full rounded-2xl bg-emerald-300 px-4 py-2 text-sm font-semibold text-emerald-950 hover:bg-emerald-200 sm:w-auto"
                 disabled={Boolean(processing) || isPaying || hasBulkShortfall}
               >
-                {hasBulkShortfall ? 'Insufficient TPC' : isPaying ? 'Purchasing…' : 'Purchase'}
+                {hasBulkShortfall
+                  ? 'Insufficient TPC'
+                  : isPaying
+                    ? 'Purchasing…'
+                    : 'Purchase'}
               </button>
             </div>
           </div>
@@ -2035,8 +2470,12 @@ export default function Store() {
         <div className="w-full max-w-4xl max-h-[calc(100vh-2rem)] overflow-y-auto rounded-3xl border border-white/10 bg-zinc-950 shadow-2xl">
           <div className="flex items-start justify-between border-b border-white/10 p-4">
             <div>
-              <p className="text-xs text-white/60">{gameName} • {detailItem.typeLabel}</p>
-              <h3 className="text-lg font-semibold text-white">{detailItem.displayLabel}</h3>
+              <p className="text-xs text-white/60">
+                {gameName} • {detailItem.typeLabel}
+              </p>
+              <h3 className="text-lg font-semibold text-white">
+                {detailItem.displayLabel}
+              </h3>
               <div className="mt-1 flex flex-wrap items-center gap-2 text-xs">
                 <span className="rounded-full border border-white/10 bg-white/5 px-2.5 py-1 text-white/70">
                   {detailItem.slug.replace('-', ' ')}
@@ -2098,10 +2537,15 @@ export default function Store() {
               <div className="space-y-3">
                 <div className="rounded-2xl border border-white/10 bg-white/5 p-3 text-sm text-white/70">
                   <p className="font-semibold text-white">Item overview</p>
-                  <p className="mt-1">{detailItem.description || 'Cosmetic details will appear here.'}</p>
+                  <p className="mt-1">
+                    {detailItem.description ||
+                      'Cosmetic details will appear here.'}
+                  </p>
                 </div>
                 <div className="rounded-2xl border border-white/10 bg-white/5 p-3 text-sm text-white/70 space-y-2">
-                  <p className="font-semibold text-white">{usageDetails.title}</p>
+                  <p className="font-semibold text-white">
+                    {usageDetails.title}
+                  </p>
                   <p className="text-white/70">{usageDetails.description}</p>
                   <div className="flex flex-wrap gap-2 text-xs text-white/60">
                     {usageDetails.placements.map((placement) => (
@@ -2115,44 +2559,64 @@ export default function Store() {
                   </div>
                 </div>
                 <div className="rounded-2xl border border-white/10 bg-white/5 p-3 text-sm text-white/70 space-y-2">
-                  <p className="font-semibold text-white">NFT utility & circulation</p>
+                  <p className="font-semibold text-white">
+                    NFT utility & circulation
+                  </p>
                   <div className="flex items-center justify-between">
                     <span className="text-white/60">Usable in</span>
-                    <span className="font-semibold">{detailItem.nftMeta?.games?.join(', ') || gameName}</span>
+                    <span className="font-semibold">
+                      {detailItem.nftMeta?.games?.join(', ') || gameName}
+                    </span>
                   </div>
                   <div className="flex items-center justify-between">
                     <span className="text-white/60">Circulation</span>
-                    <span className="font-semibold">{detailItem.nftMeta?.circulation?.toLocaleString() || '—'} minted</span>
+                    <span className="font-semibold">
+                      {detailItem.nftMeta?.circulation?.toLocaleString() || '—'}{' '}
+                      minted
+                    </span>
                   </div>
                   <div className="flex items-center justify-between">
                     <span className="text-white/60">Burns</span>
-                    <span className="font-semibold">{detailItem.nftMeta?.burns ?? 0}</span>
+                    <span className="font-semibold">
+                      {detailItem.nftMeta?.burns ?? 0}
+                    </span>
                   </div>
                   <div className="flex items-center justify-between">
                     <span className="text-white/60">Serial</span>
-                    <span className="font-semibold">{detailItem.nftMeta?.serial || 'TPG-XXXXXX'}</span>
+                    <span className="font-semibold">
+                      {detailItem.nftMeta?.serial || 'TPG-XXXXXX'}
+                    </span>
                   </div>
                 </div>
                 <div className="rounded-2xl border border-white/10 bg-white/5 p-3 text-sm text-white/70 space-y-2">
                   <div className="flex items-center justify-between">
                     <span className="text-white/60">Seller</span>
-                    <span className="font-semibold">{detailItem.seller || 'Official store'}</span>
+                    <span className="font-semibold">
+                      {detailItem.seller || 'Official store'}
+                    </span>
                   </div>
                   <div className="flex items-center justify-between">
                     <span className="text-white/60">Status</span>
-                    <span className="font-semibold text-emerald-200">{detailItem.owned ? 'Unlocked' : 'Available'}</span>
+                    <span className="font-semibold text-emerald-200">
+                      {detailItem.owned ? 'Unlocked' : 'Available'}
+                    </span>
                   </div>
                   <div className="flex flex-wrap gap-1">
-                    {(detailItem.swatches || []).slice(0, 6).map((color, index) => (
-                      <span
-                        key={`${detailItem.id}-detail-${color}-${index}`}
-                        className="h-5 w-5 rounded-full border border-white/20 shadow-sm"
-                        style={{ backgroundColor: color }}
-                        title={color}
-                      />
-                    ))}
-                    {(!detailItem.swatches || detailItem.swatches.length === 0) && (
-                      <span className="text-xs text-white/60">Color samples unavailable</span>
+                    {(detailItem.swatches || [])
+                      .slice(0, 6)
+                      .map((color, index) => (
+                        <span
+                          key={`${detailItem.id}-detail-${color}-${index}`}
+                          className="h-5 w-5 rounded-full border border-white/20 shadow-sm"
+                          style={{ backgroundColor: color }}
+                          title={color}
+                        />
+                      ))}
+                    {(!detailItem.swatches ||
+                      detailItem.swatches.length === 0) && (
+                      <span className="text-xs text-white/60">
+                        Color samples unavailable
+                      </span>
                     )}
                   </div>
                 </div>
@@ -2164,13 +2628,19 @@ export default function Store() {
                         key={`${detailItem.id}-history-${index}`}
                         className="flex items-center justify-between rounded-xl border border-white/10 bg-black/20 px-3 py-2 text-xs text-white/70"
                       >
-                        <div className="font-semibold text-white">{event.label}</div>
+                        <div className="font-semibold text-white">
+                          {event.label}
+                        </div>
                         <div className="flex items-center gap-2">
                           {event.date ? <span>{event.date}</span> : null}
                           {event.price ? (
                             <span className="flex items-center gap-1 font-semibold text-white">
                               {event.price}
-                              <img src={TON_ICON} alt="TPC" className="h-3.5 w-3.5" />
+                              <img
+                                src={TON_ICON}
+                                alt="TPC"
+                                className="h-3.5 w-3.5"
+                              />
                             </span>
                           ) : null}
                         </div>
@@ -2202,7 +2672,9 @@ export default function Store() {
               </div>
 
               <div className="space-y-3">
-                <div className="rounded-2xl border border-white/10 bg-white/5 p-3">{renderPreview3d(detailItem, { size: 'md' })}</div>
+                <div className="rounded-2xl border border-white/10 bg-white/5 p-3">
+                  {renderPreview3d(detailItem, { size: 'md' })}
+                </div>
                 <div className="rounded-2xl border border-white/10 bg-white/5 p-3 text-sm text-white/70 space-y-2">
                   <div className="flex items-center justify-between">
                     <p className="font-semibold text-white">Store thumbnail</p>
@@ -2227,12 +2699,17 @@ export default function Store() {
                       <div className="absolute inset-0 bg-gradient-to-br from-black/10 via-transparent to-black/70" />
                     </div>
                   ) : (
-                    <p className="text-xs text-white/50">Store thumbnails are processing for this item.</p>
+                    <p className="text-xs text-white/50">
+                      Store thumbnails are processing for this item.
+                    </p>
                   )}
                 </div>
                 <div className="rounded-2xl border border-white/10 bg-white/5 p-3 text-sm text-white/70">
                   <p className="font-semibold text-white">What you get</p>
-                  <p className="mt-1">After the TPC payment is confirmed, the NFT unlocks immediately on your linked TPC account.</p>
+                  <p className="mt-1">
+                    After the TPC payment is confirmed, the NFT unlocks
+                    immediately on your linked TPC account.
+                  </p>
                 </div>
               </div>
             </div>
@@ -2251,7 +2728,9 @@ export default function Store() {
           <div className="flex items-center justify-between border-b border-white/10 p-4">
             <div>
               <p className="text-xs text-white/60">High-res zoom preview</p>
-              <h3 className="text-sm font-semibold text-white">{zoomPreview.alt}</h3>
+              <h3 className="text-sm font-semibold text-white">
+                {zoomPreview.alt}
+              </h3>
             </div>
             <button
               type="button"
@@ -2268,7 +2747,8 @@ export default function Store() {
               className="h-[60vh] w-full rounded-2xl object-contain"
             />
             <p className="mt-3 text-xs text-white/60">
-              Captured with the same lighting profile as the store thumbnail for consistent finish checks.
+              Captured with the same lighting profile as the store thumbnail for
+              consistent finish checks.
             </p>
           </div>
         </div>
@@ -2277,14 +2757,22 @@ export default function Store() {
   };
 
   const renderPreview3d = (item, options = {}) => {
-    const resolvedOptions = typeof options === 'boolean' ? { showCaption: options } : options;
-    const { showCaption = true, size = 'sm', containerClassName = '' } = resolvedOptions;
+    const resolvedOptions =
+      typeof options === 'boolean' ? { showCaption: options } : options;
+    const {
+      showCaption = true,
+      size = 'sm',
+      containerClassName = ''
+    } = resolvedOptions;
     if (!item) return null;
     const previewShape = item.previewShape || 'default';
     const primary = item.swatches?.[0] || '#0f172a';
     const secondary = item.swatches?.[1] || primary;
     const accent = item.swatches?.[2] || '#f8fafc';
-    const safeId = (item.id || item.optionId || 'preview').replace(/[^a-zA-Z0-9_-]/g, '');
+    const safeId = (item.id || item.optionId || 'preview').replace(
+      /[^a-zA-Z0-9_-]/g,
+      ''
+    );
     const gradientId = `${safeId}-grad`;
     const shineId = `${safeId}-shine`;
     const shadowId = `${safeId}-shadow`;
@@ -2299,10 +2787,34 @@ export default function Store() {
         case 'cue':
           return (
             <g filter={`url(#${shadowId})`}>
-              <rect x="18" y="42" width="106" height="10" rx="5" fill={`url(#${gradientId})`} />
-              <rect x="18" y="40" width="30" height="14" rx="7" fill={accent} opacity="0.25" />
+              <rect
+                x="18"
+                y="42"
+                width="106"
+                height="10"
+                rx="5"
+                fill={`url(#${gradientId})`}
+              />
+              <rect
+                x="18"
+                y="40"
+                width="30"
+                height="14"
+                rx="7"
+                fill={accent}
+                opacity="0.25"
+              />
               <rect x="122" y="44" width="20" height="6" rx="3" fill={accent} />
-              <rect x="18" y="42" width="124" height="10" rx="5" stroke={accent} strokeWidth="1.2" fill="none" />
+              <rect
+                x="18"
+                y="42"
+                width="124"
+                height="10"
+                rx="5"
+                stroke={accent}
+                strokeWidth="1.2"
+                fill="none"
+              />
             </g>
           );
         case 'chess-royals':
@@ -2328,19 +2840,75 @@ export default function Store() {
                 strokeWidth="1.3"
                 opacity="0.9"
               />
-              <ellipse cx="52" cy="76" rx="20" ry="5" fill={secondary} opacity="0.5" />
-              <ellipse cx="98" cy="78" rx="24" ry="6" fill={secondary} opacity="0.6" />
+              <ellipse
+                cx="52"
+                cy="76"
+                rx="20"
+                ry="5"
+                fill={secondary}
+                opacity="0.5"
+              />
+              <ellipse
+                cx="98"
+                cy="78"
+                rx="24"
+                ry="6"
+                fill={secondary}
+                opacity="0.6"
+              />
             </g>
           );
         case 'pawn-head':
           return (
             <g filter={`url(#${shadowId})`}>
-              <ellipse cx="60" cy="36" rx="12" ry="9" fill={accent} opacity="0.85" />
-              <rect x="50" y="42" width="20" height="16" rx="6" fill={`url(#${shineId})`} />
-              <rect x="46" y="56" width="28" height="10" rx="4" fill={`url(#${gradientId})`} />
-              <ellipse cx="104" cy="34" rx="10" ry="10" fill={accent} opacity="0.9" />
-              <rect x="94" y="44" width="20" height="14" rx="5" fill={`url(#${shineId})`} />
-              <rect x="90" y="56" width="28" height="10" rx="4" fill={`url(#${gradientId})`} />
+              <ellipse
+                cx="60"
+                cy="36"
+                rx="12"
+                ry="9"
+                fill={accent}
+                opacity="0.85"
+              />
+              <rect
+                x="50"
+                y="42"
+                width="20"
+                height="16"
+                rx="6"
+                fill={`url(#${shineId})`}
+              />
+              <rect
+                x="46"
+                y="56"
+                width="28"
+                height="10"
+                rx="4"
+                fill={`url(#${gradientId})`}
+              />
+              <ellipse
+                cx="104"
+                cy="34"
+                rx="10"
+                ry="10"
+                fill={accent}
+                opacity="0.9"
+              />
+              <rect
+                x="94"
+                y="44"
+                width="20"
+                height="14"
+                rx="5"
+                fill={`url(#${shineId})`}
+              />
+              <rect
+                x="90"
+                y="56"
+                width="28"
+                height="10"
+                rx="4"
+                fill={`url(#${gradientId})`}
+              />
             </g>
           );
         case 'chrome':
@@ -2350,7 +2918,11 @@ export default function Store() {
                 d="M40 22h86c4 0 6 3 5 6l-10 48c-1 3-4 5-7 5H36c-4 0-6-3-5-7l9-46c1-4 4-6 7-6Z"
                 fill={`url(#${gradientId})`}
               />
-              <path d="M40 28h78l-8 40c-.6 3-3 5-6 5H36Z" fill={`url(#${shineId})`} opacity="0.9" />
+              <path
+                d="M40 28h78l-8 40c-.6 3-3 5-6 5H36Z"
+                fill={`url(#${shineId})`}
+                opacity="0.9"
+              />
               <circle cx="50" cy="34" r="3" fill={accent} opacity="0.7" />
               <circle cx="112" cy="34" r="3" fill={accent} opacity="0.7" />
             </g>
@@ -2358,8 +2930,23 @@ export default function Store() {
         case 'domino':
           return (
             <g filter={`url(#${shadowId})`}>
-              <rect x="26" y="18" width="108" height="64" rx="10" fill={`url(#${gradientId})`} />
-              <line x1="80" y1="22" x2="80" y2="78" stroke={accent} strokeWidth="2" opacity="0.6" />
+              <rect
+                x="26"
+                y="18"
+                width="108"
+                height="64"
+                rx="10"
+                fill={`url(#${gradientId})`}
+              />
+              <line
+                x1="80"
+                y1="22"
+                x2="80"
+                y2="78"
+                stroke={accent}
+                strokeWidth="2"
+                opacity="0.6"
+              />
               <circle cx="60" cy="40" r="6" fill={accent} />
               <circle cx="100" cy="60" r="6" fill={accent} />
               <circle cx="100" cy="40" r="4" fill={accent} opacity="0.6" />
@@ -2368,8 +2955,25 @@ export default function Store() {
         case 'cards':
           return (
             <g filter={`url(#${shadowId})`}>
-              <rect x="32" y="18" width="78" height="58" rx="9" fill={secondary} opacity="0.65" transform="rotate(-6 32 18)" />
-              <rect x="56" y="26" width="78" height="58" rx="9" fill={`url(#${gradientId})`} transform="rotate(6 56 26)" />
+              <rect
+                x="32"
+                y="18"
+                width="78"
+                height="58"
+                rx="9"
+                fill={secondary}
+                opacity="0.65"
+                transform="rotate(-6 32 18)"
+              />
+              <rect
+                x="56"
+                y="26"
+                width="78"
+                height="58"
+                rx="9"
+                fill={`url(#${gradientId})`}
+                transform="rotate(6 56 26)"
+              />
               <rect
                 x="52"
                 y="22"
@@ -2381,41 +2985,136 @@ export default function Store() {
                 fill="none"
                 transform="rotate(3 52 22)"
               />
-              <text x="76" y="56" fill={accent} fontSize="16" fontWeight="700" opacity="0.9">A♠</text>
+              <text
+                x="76"
+                y="56"
+                fill={accent}
+                fontSize="16"
+                fontWeight="700"
+                opacity="0.9"
+              >
+                A♠
+              </text>
             </g>
           );
         case 'table':
           return (
             <g filter={`url(#${shadowId})`}>
-              <rect x="22" y="26" width="116" height="48" rx="12" fill={`url(#${gradientId})`} />
-              <rect x="30" y="34" width="100" height="32" rx="10" fill={`url(#${shineId})`} opacity="0.7" />
-              <rect x="36" y="40" width="88" height="20" rx="8" fill={accent} opacity="0.15" />
+              <rect
+                x="22"
+                y="26"
+                width="116"
+                height="48"
+                rx="12"
+                fill={`url(#${gradientId})`}
+              />
+              <rect
+                x="30"
+                y="34"
+                width="100"
+                height="32"
+                rx="10"
+                fill={`url(#${shineId})`}
+                opacity="0.7"
+              />
+              <rect
+                x="36"
+                y="40"
+                width="88"
+                height="20"
+                rx="8"
+                fill={accent}
+                opacity="0.15"
+              />
             </g>
           );
         case 'puck':
           return (
             <g filter={`url(#${shadowId})`}>
               <circle cx="80" cy="50" r="26" fill={`url(#${gradientId})`} />
-              <circle cx="80" cy="50" r="18" fill={`url(#${shineId})`} opacity="0.8" />
+              <circle
+                cx="80"
+                cy="50"
+                r="18"
+                fill={`url(#${shineId})`}
+                opacity="0.8"
+              />
               <circle cx="80" cy="50" r="10" fill={accent} opacity="0.35" />
             </g>
           );
         case 'token-stack':
           return (
             <g filter={`url(#${shadowId})`}>
-              <ellipse cx="64" cy="42" rx="18" ry="8" fill={`url(#${gradientId})`} />
-              <rect x="46" y="42" width="36" height="12" rx="6" fill={`url(#${shineId})`} opacity="0.8" />
-              <ellipse cx="96" cy="54" rx="18" ry="8" fill={`url(#${shineId})`} opacity="0.9" />
-              <rect x="78" y="54" width="36" height="12" rx="6" fill={`url(#${gradientId})`} />
-              <ellipse cx="78" cy="66" rx="18" ry="8" fill={accent} opacity="0.6" />
-              <rect x="60" y="66" width="36" height="12" rx="6" fill={`url(#${shineId})`} opacity="0.8" />
+              <ellipse
+                cx="64"
+                cy="42"
+                rx="18"
+                ry="8"
+                fill={`url(#${gradientId})`}
+              />
+              <rect
+                x="46"
+                y="42"
+                width="36"
+                height="12"
+                rx="6"
+                fill={`url(#${shineId})`}
+                opacity="0.8"
+              />
+              <ellipse
+                cx="96"
+                cy="54"
+                rx="18"
+                ry="8"
+                fill={`url(#${shineId})`}
+                opacity="0.9"
+              />
+              <rect
+                x="78"
+                y="54"
+                width="36"
+                height="12"
+                rx="6"
+                fill={`url(#${gradientId})`}
+              />
+              <ellipse
+                cx="78"
+                cy="66"
+                rx="18"
+                ry="8"
+                fill={accent}
+                opacity="0.6"
+              />
+              <rect
+                x="60"
+                y="66"
+                width="36"
+                height="12"
+                rx="6"
+                fill={`url(#${shineId})`}
+                opacity="0.8"
+              />
             </g>
           );
         case 'dice':
           return (
             <g filter={`url(#${shadowId})`}>
-              <rect x="42" y="24" width="44" height="44" rx="8" fill={`url(#${shineId})`} />
-              <rect x="76" y="38" width="44" height="44" rx="8" fill={`url(#${gradientId})`} />
+              <rect
+                x="42"
+                y="24"
+                width="44"
+                height="44"
+                rx="8"
+                fill={`url(#${shineId})`}
+              />
+              <rect
+                x="76"
+                y="38"
+                width="44"
+                height="44"
+                rx="8"
+                fill={`url(#${gradientId})`}
+              />
               <circle cx="54" cy="36" r="3" fill={accent} />
               <circle cx="64" cy="46" r="3" fill={accent} />
               <circle cx="54" cy="56" r="3" fill={accent} />
@@ -2429,18 +3128,72 @@ export default function Store() {
         case 'chair':
           return (
             <g filter={`url(#${shadowId})`}>
-              <rect x="54" y="26" width="52" height="36" rx="10" fill={`url(#${gradientId})`} />
-              <rect x="50" y="42" width="60" height="24" rx="8" fill={`url(#${shineId})`} opacity="0.85" />
-              <rect x="58" y="62" width="12" height="20" rx="3" fill={accent} opacity="0.8" />
-              <rect x="100" y="62" width="12" height="20" rx="3" fill={accent} opacity="0.8" />
-              <rect x="70" y="64" width="28" height="8" rx="4" fill={secondary} opacity="0.7" />
+              <rect
+                x="54"
+                y="26"
+                width="52"
+                height="36"
+                rx="10"
+                fill={`url(#${gradientId})`}
+              />
+              <rect
+                x="50"
+                y="42"
+                width="60"
+                height="24"
+                rx="8"
+                fill={`url(#${shineId})`}
+                opacity="0.85"
+              />
+              <rect
+                x="58"
+                y="62"
+                width="12"
+                height="20"
+                rx="3"
+                fill={accent}
+                opacity="0.8"
+              />
+              <rect
+                x="100"
+                y="62"
+                width="12"
+                height="20"
+                rx="3"
+                fill={accent}
+                opacity="0.8"
+              />
+              <rect
+                x="70"
+                y="64"
+                width="28"
+                height="8"
+                rx="4"
+                fill={secondary}
+                opacity="0.7"
+              />
             </g>
           );
         default:
           return (
             <g filter={`url(#${shadowId})`}>
-              <rect x="28" y="26" width="104" height="44" rx="10" fill={`url(#${gradientId})`} />
-              <rect x="38" y="34" width="84" height="28" rx="8" fill={`url(#${shineId})`} opacity="0.8" />
+              <rect
+                x="28"
+                y="26"
+                width="104"
+                height="44"
+                rx="10"
+                fill={`url(#${gradientId})`}
+              />
+              <rect
+                x="38"
+                y="34"
+                width="84"
+                height="28"
+                rx="8"
+                fill={`url(#${shineId})`}
+                opacity="0.8"
+              />
             </g>
           );
       }
@@ -2448,7 +3201,9 @@ export default function Store() {
 
     return (
       <div className={`flex items-center gap-3 ${containerClassName}`}>
-        <div className={`relative overflow-hidden rounded-xl border border-white/10 bg-gradient-to-br from-white/5 to-black/40 shadow-[0_18px_45px_-26px_rgba(0,0,0,0.9)] ${sizeClasses[size] || sizeClasses.sm}`}>
+        <div
+          className={`relative overflow-hidden rounded-xl border border-white/10 bg-gradient-to-br from-white/5 to-black/40 shadow-[0_18px_45px_-26px_rgba(0,0,0,0.9)] ${sizeClasses[size] || sizeClasses.sm}`}
+        >
           <svg viewBox="0 0 160 100" className="h-full w-full">
             <defs>
               <linearGradient id={gradientId} x1="0" y1="0" x2="1" y2="1">
@@ -2459,8 +3214,19 @@ export default function Store() {
                 <stop offset="0%" stopColor={accent} stopOpacity="0.9" />
                 <stop offset="100%" stopColor={secondary} stopOpacity="0.2" />
               </radialGradient>
-              <filter id={shadowId} x="-20%" y="-20%" width="140%" height="140%">
-                <feDropShadow dx="0" dy="10" stdDeviation="8" floodColor="rgba(0,0,0,0.6)" />
+              <filter
+                id={shadowId}
+                x="-20%"
+                y="-20%"
+                width="140%"
+                height="140%"
+              >
+                <feDropShadow
+                  dx="0"
+                  dy="10"
+                  stdDeviation="8"
+                  floodColor="rgba(0,0,0,0.6)"
+                />
               </filter>
             </defs>
             {shapeLayer(previewShape)}
@@ -2469,7 +3235,9 @@ export default function Store() {
         </div>
         {showCaption ? (
           <div className="grid gap-0.5 text-xs text-white/70">
-            <span className="font-semibold text-white">{previewLabel(previewShape)}</span>
+            <span className="font-semibold text-white">
+              {previewLabel(previewShape)}
+            </span>
             <span className="text-white/60">High-fidelity 3D sample</span>
           </div>
         ) : null}
@@ -2486,7 +3254,9 @@ export default function Store() {
     const wrapperClass = isCompact
       ? 'relative h-16 w-20 overflow-hidden rounded-2xl border border-white/10 bg-black/40 shadow-[0_16px_30px_-24px_rgba(0,0,0,0.9)]'
       : 'relative h-32 w-full overflow-hidden rounded-2xl border border-white/10 bg-black/40 shadow-[0_18px_40px_-22px_rgba(0,0,0,0.9)]';
-    const imageClass = isCompact ? 'h-full w-full object-contain p-2' : 'h-full w-full object-contain p-3';
+    const imageClass = isCompact
+      ? 'h-full w-full object-contain p-2'
+      : 'h-full w-full object-contain p-3';
 
     if (resolvedThumbnail) {
       return (
@@ -2498,7 +3268,9 @@ export default function Store() {
             loading="lazy"
           />
           <div className="absolute inset-0 bg-gradient-to-br from-black/10 via-transparent to-black/60" />
-          <div className={`absolute ${isCompact ? 'bottom-1 left-1' : 'bottom-2 left-2'} rounded-full bg-black/70 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wide text-white/80`}>
+          <div
+            className={`absolute ${isCompact ? 'bottom-1 left-1' : 'bottom-2 left-2'} rounded-full bg-black/70 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wide text-white/80`}
+          >
             {label}
           </div>
         </div>
@@ -2507,9 +3279,15 @@ export default function Store() {
 
     return (
       <div className={wrapperClass}>
-        {renderPreview3d(item, { showCaption: false, size: isCompact ? 'sm' : 'lg', containerClassName: 'h-full w-full' })}
+        {renderPreview3d(item, {
+          showCaption: false,
+          size: isCompact ? 'sm' : 'lg',
+          containerClassName: 'h-full w-full'
+        })}
         <div className="absolute inset-0 bg-gradient-to-br from-black/10 via-transparent to-black/60" />
-        <div className={`absolute ${isCompact ? 'bottom-1 left-1' : 'bottom-2 left-2'} rounded-full bg-black/70 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wide text-white/80`}>
+        <div
+          className={`absolute ${isCompact ? 'bottom-1 left-1' : 'bottom-2 left-2'} rounded-full bg-black/70 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wide text-white/80`}
+        >
           {label}
         </div>
       </div>
@@ -2556,9 +3334,15 @@ export default function Store() {
               </span>
             )}
           </div>
-          <div className="text-xs text-white/60">{item.gameName} • {item.typeLabel}</div>
-          <div className="text-[11px] text-white/50">Usage: {usageDetails.title}</div>
-          <div className="text-[11px] text-white/50">Serial {item.nftMeta?.serial}</div>
+          <div className="text-xs text-white/60">
+            {item.gameName} • {item.typeLabel}
+          </div>
+          <div className="text-[11px] text-white/50">
+            Usage: {usageDetails.title}
+          </div>
+          <div className="text-[11px] text-white/50">
+            Serial {item.nftMeta?.serial}
+          </div>
         </div>
 
         <div className="mt-auto flex flex-wrap items-center gap-2">
@@ -2602,7 +3386,9 @@ export default function Store() {
               />
             </div>
             <div className="leading-tight">
-              <div className="text-sm font-semibold tracking-wide">TonPlaygram</div>
+              <div className="text-sm font-semibold tracking-wide">
+                TonPlaygram
+              </div>
               <div className="text-xs text-white/60">NFT Storefront</div>
             </div>
           </div>
@@ -2616,7 +3402,9 @@ export default function Store() {
               </span>
             </div>
             <div className="flex items-center gap-2 rounded-2xl border border-white/10 bg-white/5 px-3 py-2">
-              <div className={`h-2.5 w-2.5 rounded-full ${accountId && accountId !== 'guest' ? 'bg-emerald-400' : 'bg-white/40'}`} />
+              <div
+                className={`h-2.5 w-2.5 rounded-full ${accountId && accountId !== 'guest' ? 'bg-emerald-400' : 'bg-white/40'}`}
+              />
               <div className="text-xs font-semibold">{walletLabel}</div>
             </div>
           </div>
@@ -2654,7 +3442,11 @@ export default function Store() {
           >
             <div className="flex items-start gap-2">
               <span className="mt-0.5 text-base">
-                {transactionState === 'error' ? '⚠️' : transactionState === 'success' ? '✅' : '⏳'}
+                {transactionState === 'error'
+                  ? '⚠️'
+                  : transactionState === 'success'
+                    ? '✅'
+                    : '⏳'}
               </span>
               <span className="font-semibold">{transactionStatus}</span>
             </div>
@@ -2671,7 +3463,9 @@ export default function Store() {
         </div>
       ) : null}
 
-      <main className={`mx-auto w-full max-w-6xl px-4 pt-4 ${mainPaddingClass}`}>
+      <main
+        className={`mx-auto w-full max-w-6xl px-4 pt-4 ${mainPaddingClass}`}
+      >
         <section className="relative overflow-hidden rounded-3xl border border-white/10 bg-gradient-to-br from-white/10 to-white/0 p-5 shadow-sm">
           <div className="absolute -right-8 -top-10 h-40 w-40 rounded-full bg-emerald-400/10 blur-2xl" />
           <div className="absolute -left-10 -bottom-10 h-44 w-44 rounded-full bg-indigo-400/10 blur-2xl" />
@@ -2687,7 +3481,8 @@ export default function Store() {
             </h1>
 
             <p className="max-w-2xl text-sm text-white/70">
-              Mobile-first design inspired by the mock above. Every card shows TPC price, accessory type, and whether you already own it.
+              Mobile-first design inspired by the mock above. Every card shows
+              TPC price, accessory type, and whether you already own it.
             </p>
 
             <div className="mt-3 flex flex-wrap items-center gap-2">
@@ -2705,14 +3500,23 @@ export default function Store() {
           <div className="rounded-3xl border border-white/10 bg-white/5 p-4 shadow-sm">
             <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
               <div>
-                <p className="text-xs uppercase tracking-wide text-white/60">Marketplace</p>
-                <h2 className="text-xl font-semibold leading-tight">Accessories for every TonPlaygram game</h2>
-                <p className="text-sm text-white/60">Quick filters, transparent listings, and a confirmation modal before checkout.</p>
+                <p className="text-xs uppercase tracking-wide text-white/60">
+                  Marketplace
+                </p>
+                <h2 className="text-xl font-semibold leading-tight">
+                  Accessories for every TonPlaygram game
+                </h2>
+                <p className="text-sm text-white/60">
+                  Quick filters, transparent listings, and a confirmation modal
+                  before checkout.
+                </p>
               </div>
               <div className="grid grid-cols-3 items-center gap-3 rounded-2xl border border-white/10 bg-black/20 px-3 py-2 text-sm">
                 <div className="text-left">
                   <p className="text-xs text-white/60">Listings</p>
-                  <p className="font-semibold text-white">{featuredCount.toLocaleString()}</p>
+                  <p className="font-semibold text-white">
+                    {featuredCount.toLocaleString()}
+                  </p>
                 </div>
                 <div className="text-left">
                   <p className="text-xs text-white/60">Owned</p>
@@ -2776,7 +3580,8 @@ export default function Store() {
 
             <div className="mt-3 flex flex-wrap items-center justify-between gap-2 rounded-2xl border border-white/10 bg-black/10 px-3 py-2">
               <div className="text-xs text-white/60">
-                List cosmetics you already own so other players can purchase them securely.
+                List cosmetics you already own so other players can purchase
+                them securely.
               </div>
               <div className="flex flex-wrap items-center gap-2">
                 <button
@@ -2815,7 +3620,9 @@ export default function Store() {
                   </span>
                   {selectedOwnedCount > 0 ? (
                     <span className="text-xs text-amber-200">
-                      {selectedOwnedCount} owned selection{selectedOwnedCount === 1 ? ' is' : 's are'} skipped automatically.
+                      {selectedOwnedCount} owned selection
+                      {selectedOwnedCount === 1 ? ' is' : 's are'} skipped
+                      automatically.
                     </span>
                   ) : null}
                 </div>
@@ -2842,7 +3649,9 @@ export default function Store() {
                 </div>
               </div>
               <div className="flex flex-wrap items-center gap-3 text-xs text-white/60">
-                <span className={`rounded-full border px-2 py-0.5 ${selectedShortfall ? 'border-rose-300/30 bg-rose-400/10 text-rose-100' : 'border-emerald-300/30 bg-emerald-400/10 text-emerald-100'}`}>
+                <span
+                  className={`rounded-full border px-2 py-0.5 ${selectedShortfall ? 'border-rose-300/30 bg-rose-400/10 text-rose-100' : 'border-emerald-300/30 bg-emerald-400/10 text-emerald-100'}`}
+                >
                   {selectedBalanceAfter === null
                     ? 'Balance preview unavailable'
                     : selectedShortfall
@@ -2852,39 +3661,63 @@ export default function Store() {
                 <span className="rounded-full border border-white/10 bg-white/5 px-2 py-0.5">
                   Green + Blue cloth bundles ready for Pool Royale
                 </span>
-                <span>Pick multiple NFTs, confirm once, and unlock them together.</span>
+                <span>
+                  Pick multiple NFTs, confirm once, and unlock them together.
+                </span>
               </div>
             </div>
 
             <div className="mt-3 grid gap-3 rounded-3xl border border-white/10 bg-black/20 p-4 text-sm text-white/80 shadow-sm sm:grid-cols-4">
               <div className="space-y-1">
-                <p className="text-[11px] uppercase tracking-wide text-white/60">Your listings</p>
-                <p className="text-2xl font-semibold text-white">{userListingStats.total}</p>
-                <p className="text-xs text-white/60">Listed items tied to your account</p>
+                <p className="text-[11px] uppercase tracking-wide text-white/60">
+                  Your listings
+                </p>
+                <p className="text-2xl font-semibold text-white">
+                  {userListingStats.total}
+                </p>
+                <p className="text-xs text-white/60">
+                  Listed items tied to your account
+                </p>
               </div>
               <div className="space-y-1">
-                <p className="text-[11px] uppercase tracking-wide text-white/60">Total value</p>
+                <p className="text-[11px] uppercase tracking-wide text-white/60">
+                  Total value
+                </p>
                 <p className="flex items-center gap-1 text-2xl font-semibold text-white">
                   {userListingStats.totalValue.toLocaleString()}
                   <img src={TON_ICON} alt="TPC" className="h-4 w-4" />
                 </p>
-                <p className="text-xs text-white/60">Sum of your active listings</p>
+                <p className="text-xs text-white/60">
+                  Sum of your active listings
+                </p>
               </div>
               <div className="space-y-1">
-                <p className="text-[11px] uppercase tracking-wide text-white/60">Average price</p>
+                <p className="text-[11px] uppercase tracking-wide text-white/60">
+                  Average price
+                </p>
                 <p className="flex items-center gap-1 text-2xl font-semibold text-white">
                   {userListingStats.avgPrice.toLocaleString()}
                   <img src={TON_ICON} alt="TPC" className="h-4 w-4" />
                 </p>
-                <p className="text-xs text-white/60">Per item across your listings</p>
+                <p className="text-xs text-white/60">
+                  Per item across your listings
+                </p>
               </div>
               <div className="space-y-1">
-                <p className="text-[11px] uppercase tracking-wide text-white/60">Floor price</p>
-                <p className="flex items-center gap-1 text-2xl font-semibold text-white">
-                  {userListingStats.total ? userListingStats.floorPrice.toLocaleString() : '—'}
-                  {userListingStats.total ? <img src={TON_ICON} alt="TPC" className="h-4 w-4" /> : null}
+                <p className="text-[11px] uppercase tracking-wide text-white/60">
+                  Floor price
                 </p>
-                <p className="text-xs text-white/60">Lowest priced NFT you listed</p>
+                <p className="flex items-center gap-1 text-2xl font-semibold text-white">
+                  {userListingStats.total
+                    ? userListingStats.floorPrice.toLocaleString()
+                    : '—'}
+                  {userListingStats.total ? (
+                    <img src={TON_ICON} alt="TPC" className="h-4 w-4" />
+                  ) : null}
+                </p>
+                <p className="text-xs text-white/60">
+                  Lowest priced NFT you listed
+                </p>
               </div>
             </div>
 
@@ -2897,7 +3730,7 @@ export default function Store() {
                       activeGame === 'all'
                         ? 'border-white/20 bg-white text-zinc-950'
                         : 'border-white/10 bg-black/20 text-white/75 hover:bg-white/10 hover:text-white'
-                      }`}
+                    }`}
                     onClick={() => handleGameChange('all')}
                   >
                     All
@@ -2919,7 +3752,9 @@ export default function Store() {
               </div>
 
               <div className="grid gap-2">
-                <div className="text-xs font-semibold text-white/70">Accessory types</div>
+                <div className="text-xs font-semibold text-white/70">
+                  Accessory types
+                </div>
                 <div className="flex flex-wrap gap-2">
                   {typeFilters.map((type) => (
                     <button
@@ -2941,8 +3776,13 @@ export default function Store() {
 
           <div className="mt-2 flex items-end justify-between gap-3">
             <div>
-              <div className="text-base font-semibold">{showMyListings ? 'Your listings' : 'Marketplace'}</div>
-              <div className="text-xs text-white/60">{visibleItems.length} listings | pay with TPC | accessories for every game</div>
+              <div className="text-base font-semibold">
+                {showMyListings ? 'Your listings' : 'Marketplace'}
+              </div>
+              <div className="text-xs text-white/60">
+                {visibleItems.length} listings | pay with TPC | accessories for
+                every game
+              </div>
             </div>
             <button className="hidden rounded-2xl border border-white/10 bg-white/5 px-4 py-2 text-sm font-semibold text-white/80 hover:bg-white/10 md:inline">
               View analytics
@@ -2955,8 +3795,13 @@ export default function Store() {
                 <section key={typeLabel} className="space-y-3">
                   <div className="flex items-center justify-between">
                     <div>
-                      <div className="text-sm font-semibold text-white">{typeLabel}</div>
-                      <div className="text-xs text-white/60">{items.length} items • {storeMeta[activeGame]?.name || activeGame}</div>
+                      <div className="text-sm font-semibold text-white">
+                        {typeLabel}
+                      </div>
+                      <div className="text-xs text-white/60">
+                        {items.length} items •{' '}
+                        {storeMeta[activeGame]?.name || activeGame}
+                      </div>
                     </div>
                     <div className="rounded-full border border-white/10 bg-black/20 px-3 py-1 text-xs text-white/60">
                       Category
@@ -2985,15 +3830,29 @@ export default function Store() {
           <div className="rounded-3xl border border-white/10 bg-white/5 p-4 text-sm text-white/70 space-y-2">
             <p className="font-semibold text-white">Quick guidance</p>
             <ul className="list-disc space-y-1 pl-5">
-              <li>Confirmation modal appears before every purchase so you always know the total.</li>
-              <li>The “Owned” badge updates immediately when a purchase succeeds.</li>
-              <li>Mobile-first layout keeps the cards readable on small portrait screens.</li>
+              <li>
+                Confirmation modal appears before every purchase so you always
+                know the total.
+              </li>
+              <li>
+                The “Owned” badge updates immediately when a purchase succeeds.
+              </li>
+              <li>
+                Mobile-first layout keeps the cards readable on small portrait
+                screens.
+              </li>
             </ul>
           </div>
 
-          {info ? <div className="rounded-3xl border border-white/10 bg-white/5 p-4 text-center text-sm font-semibold text-white/80">{info}</div> : null}
+          {info ? (
+            <div className="rounded-3xl border border-white/10 bg-white/5 p-4 text-center text-sm font-semibold text-white/80">
+              {info}
+            </div>
+          ) : null}
           {purchaseStatus ? (
-            <div className="rounded-3xl border border-white/10 bg-white/5 p-4 text-center text-sm font-semibold text-emerald-300">{purchaseStatus}</div>
+            <div className="rounded-3xl border border-white/10 bg-white/5 p-4 text-center text-sm font-semibold text-emerald-300">
+              {purchaseStatus}
+            </div>
           ) : null}
         </div>
       </main>
@@ -3014,7 +3873,9 @@ export default function Store() {
               ) : null}
             </div>
             {hasPurchasableSelection ? (
-              <div className={`text-[11px] ${selectedShortfall ? 'text-rose-200' : 'text-emerald-200'}`}>
+              <div
+                className={`text-[11px] ${selectedShortfall ? 'text-rose-200' : 'text-emerald-200'}`}
+              >
                 {selectedBalanceAfter === null
                   ? 'Balance preview unavailable.'
                   : selectedShortfall

--- a/webapp/src/utils/tavullBattleInventory.js
+++ b/webapp/src/utils/tavullBattleInventory.js
@@ -1,0 +1,103 @@
+import {
+  TAVULL_BATTLE_DEFAULT_UNLOCKS,
+  TAVULL_BATTLE_OPTION_LABELS
+} from '../config/tavullBattleInventoryConfig.js';
+
+const STORAGE_KEY = 'tavullBattleInventoryByAccount';
+
+const readStore = () => {
+  if (typeof window === 'undefined') return {};
+  try {
+    return JSON.parse(window.localStorage.getItem(STORAGE_KEY) || '{}');
+  } catch (err) {
+    console.warn('Failed to read tavull inventory, resetting', err);
+    return {};
+  }
+};
+
+const writeStore = (payload) => {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+  } catch (err) {
+    console.warn('Failed to persist tavull inventory', err);
+  }
+};
+
+const normalizeInventory = (rawInventory) => {
+  const base = Object.fromEntries(
+    Object.entries(TAVULL_BATTLE_DEFAULT_UNLOCKS).map(([key, value]) => [
+      key,
+      [...new Set(value.filter(Boolean))]
+    ])
+  );
+  if (!rawInventory || typeof rawInventory !== 'object') return base;
+  Object.entries(rawInventory).forEach(([key, value]) => {
+    if (!Array.isArray(value) || !base[key]) return;
+    base[key] = [...new Set([...base[key], ...value.filter(Boolean)])];
+  });
+  return base;
+};
+
+const resolveAccountId = (accountId) =>
+  String(accountId || '').trim() || 'guest';
+
+export const getTavullBattleInventory = (accountId) => {
+  const resolvedAccountId = resolveAccountId(accountId);
+  const inventories = readStore();
+  const normalized = normalizeInventory(inventories[resolvedAccountId]);
+  inventories[resolvedAccountId] = normalized;
+  writeStore(inventories);
+  return normalized;
+};
+
+export const isTavullOptionUnlocked = (
+  type,
+  optionId,
+  inventoryOrAccountId
+) => {
+  const inventory =
+    typeof inventoryOrAccountId === 'string' || !inventoryOrAccountId
+      ? getTavullBattleInventory(inventoryOrAccountId)
+      : inventoryOrAccountId;
+  return Array.isArray(inventory?.[type]) && inventory[type].includes(optionId);
+};
+
+export const addTavullBattleUnlock = (type, optionId, accountId) => {
+  const resolvedAccountId = resolveAccountId(accountId);
+  const inventories = readStore();
+  const current = normalizeInventory(inventories[resolvedAccountId]);
+  const nextValues = new Set(current[type] || []);
+  nextValues.add(optionId);
+  const nextInventory = {
+    ...current,
+    [type]: [...nextValues]
+  };
+  const updated = {
+    ...inventories,
+    [resolvedAccountId]: nextInventory
+  };
+  writeStore(updated);
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(
+      new CustomEvent('tavullBattleInventoryUpdate', {
+        detail: { accountId: resolvedAccountId, inventory: nextInventory }
+      })
+    );
+  }
+  return nextInventory;
+};
+
+export const listOwnedTavullOptions = (accountId) => {
+  const inventory = getTavullBattleInventory(accountId);
+  return Object.entries(inventory).flatMap(([type, values]) => {
+    const labels = TAVULL_BATTLE_OPTION_LABELS[type] || {};
+    return values.map((optionId) => ({
+      type,
+      optionId,
+      label: labels[optionId] || optionId
+    }));
+  });
+};
+
+export const tavullBattleAccountId = resolveAccountId;


### PR DESCRIPTION
### Motivation
- Separate Backgammon/Tavull cosmetics and store logic from the Chess inventory so Backgammon has its own unlocks and does not reuse Chess state or events. 
- Reuse existing art/materials where appropriate: Pool Royale table finishes for the board surface, Pool cloth style for triangles (with new color palettes matching Chess piece palettes), and 4-in-a-Row frame finishes for the board frame. 
- Provide in-game controls so players can pick board finish, frame finish, triangle color, chair themes and HDRI lighting specifically for Backgammon.

### Description
- Added a new inventory config `webapp/src/config/tavullBattleInventoryConfig.js` defining `TAVULL_BATTLE_*` option lists, default unlocks and `TAVULL_BATTLE_STORE_ITEMS` that reuse `MURLAN_TABLE_FINISHES`, `POOL_ROYALE_HDRI_VARIANTS` and 4-in-row frame options. 
- Added a new inventory utility `webapp/src/utils/tavullBattleInventory.js` implementing `getTavullBattleInventory`, `isTavullOptionUnlocked`, `addTavullBattleUnlock`, `listOwnedTavullOptions` and dispatching `tavullBattleInventoryUpdate` events so Tavull has isolated local storage and sync. 
- Updated the Backgammon scene `webapp/src/pages/Games/TavullBattleRoyal.jsx` to use the Tavull inventory instead of Chess inventory, added owned-option filtering for `boardFinish`, `frameFinish`, and `triangleColor`, applied board/frame/triangle palettes to the Three.js materials at runtime, and exposed controls in the in-game menu (including `applyBoardFinish`, `applyFrameFinish`, and `applyTriangleColor`). 
- Integrated Backgammon into the global `Store` at `webapp/src/pages/Store.jsx` by wiring `TAVULL_BATTLE_*` items, labels, type labels, a store account env var (`VITE_TAVULL_BATTLE_STORE_ACCOUNT_ID`) and unlocking flow using `addTavullBattleUnlock`; updated ownership checks to use `isTavullOptionUnlocked`. 
- Formatting and minor style updates applied to modified files with `prettier` for consistency.

### Testing
- Ran `npx prettier --write` on modified files and `npx prettier --check` afterwards, and the modified files now pass Prettier formatting. ✅
- Ran `npx eslint` targeted at the new/modified files which completed with workspace ignore-pattern warnings (no new errors introduced in the targeted files). ⚠️
- Ran the workspace linter via `npm run -s lint` which surfaced many pre-existing repo-wide lint issues in unrelated/generated files and therefore did not pass (these are not caused by the Backgammon changes). ⚠️
- Commited the changes and prepared the PR; in-game screenshots could not be captured because the runtime/browser capture tool was not available. ✳️

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb8c3333188329a7038409a95c77eb)