### PR TITLE
Fix Pool Royale pocket glow cleanup reference error

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -134,6 +134,12 @@ const TRAINING_ATTEMPT_BUNDLES = Object.freeze([
 
 const CAREER_ATTEMPTS_KEY = 'poolRoyaleCareerAttempts';
 
+function clearPocketGlowMesh(entry) {
+  if (!entry?.glowMesh) return;
+  entry.glowMesh.parent?.remove?.(entry.glowMesh);
+  entry.glowMesh = null;
+}
+
 function loadCareerAttemptsProgress() {
   if (typeof window === 'undefined') {
     return { carryShots: 0, attemptsAwardedStageIds: [], bonusAwardedStageIds: [] };
@@ -8417,15 +8423,10 @@ export function Table3D(
     if (material) entry.glowMesh.material = material;
     entry.glowTone = tone;
   };
-  const clearPocketGlow = (entry) => {
-    if (!entry?.glowMesh) return;
-    entry.glowMesh.parent?.remove?.(entry.glowMesh);
-    entry.glowMesh = null;
-  };
   const removePocketDropEntry = (ballId) => {
     const entry = pocketDropRef.current.get(ballId);
     if (entry) {
-      clearPocketGlow(entry);
+      clearPocketGlowMesh(entry);
     }
     pocketDropRef.current.delete(ballId);
   };
@@ -30896,7 +30897,7 @@ const powerRef = useRef(hud.power);
         updatePocketCameraState(false);
         pocketCamerasRef.current.clear();
         pocketDropRef.current.forEach((entry) => {
-          clearPocketGlow(entry);
+          clearPocketGlowMesh(entry);
         });
         pocketDropRef.current.clear();
         pocketGlowGeometry.dispose?.();


### PR DESCRIPTION
### Motivation
- Prevent a runtime crash where cleanup paths called `clearPocketGlow` and triggered `ReferenceError: clearPocketGlow is not defined` during game teardown or pocket-drop removal. 

### Description
- Added a module-level helper `clearPocketGlowMesh(entry)` that safely removes and nulls a pocket glow mesh. 
- Replaced local calls to the previously-missing `clearPocketGlow` with `clearPocketGlowMesh` in the pocket-drop removal logic. 
- Reused `clearPocketGlowMesh` during scene/renderer teardown to consistently clear active pocket drops and avoid the crash. 
- Change is confined to `webapp/src/pages/Games/PoolRoyale.jsx` and preserves existing disposal of geometry and materials.

### Testing
- Ran `npm test -- poolRoyaleOnlineFlow.test.js --runInBand` and the test suite passed. 
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx` which completed but the file is ignored by project ESLint config so no lint violations were reported for this file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb8f2ba58483299a4387bb0f5527e5)