### PR TITLE
Enhance Pool Royale pocket glow visuals and prevent cleanup crash

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -138,6 +138,7 @@ function clearPocketGlowMesh(entry) {
   if (!entry?.glowMesh) return;
   entry.glowMesh.parent?.remove?.(entry.glowMesh);
   entry.glowMesh = null;
+  entry.glowTone = null;
 }
 
 function loadCareerAttemptsProgress() {
@@ -1684,12 +1685,15 @@ const POCKET_CAM = Object.freeze({
 const POCKET_CAM_EARLY_TRIGGER_DIST = POCKET_CAM.triggerDist * 1.45; // switch to rail overhead broadcast a little earlier on incoming pocket shots
 const POCKET_POPUP_DURATION_MS = 2500;
 const POCKET_POPUP_LIFT = BALL_R * 2.4;
-const POCKET_GLOW_ENABLED = false;
-const POCKET_GLOW_RADIUS = BALL_R * 1.32;
-const POCKET_GLOW_LIFT = BALL_R * 0.78;
-const POCKET_GLOW_OPACITY = 0.62;
+const POCKET_GLOW_ENABLED = true;
+const POCKET_GLOW_RADIUS = BALL_R * 1.46;
+const POCKET_GLOW_LIFT = BALL_R * 0.92;
+const POCKET_GLOW_OPACITY = 0.72;
+const POCKET_GLOW_RAY_OPACITY = 0.38;
+const POCKET_GLOW_SPARK_OPACITY = 0.5;
+const POCKET_GLOW_POINT_LIGHT_INTENSITY = 1.35;
 const POCKET_GLOW_COLORS = Object.freeze({
-  good: 0x2eea73,
+  good: 0x3bc7ff,
   foul: 0xff4b4b
 });
 const POCKET_CHAOS_MOVING_THRESHOLD = 3;
@@ -8386,6 +8390,25 @@ export function Table3D(
   const pocketGlowGeometry = POCKET_GLOW_ENABLED
     ? new THREE.CircleGeometry(POCKET_GLOW_RADIUS, 36)
     : null;
+  const pocketGlowRayGeometry = POCKET_GLOW_ENABLED
+    ? new THREE.CircleGeometry(POCKET_GLOW_RADIUS * 1.42, 24)
+    : null;
+  const pocketGlowSparkGeometry = (() => {
+    if (!POCKET_GLOW_ENABLED) return null;
+    const sparkCount = 18;
+    const positions = new Float32Array(sparkCount * 3);
+    for (let i = 0; i < sparkCount; i += 1) {
+      const radius = POCKET_GLOW_RADIUS * (0.28 + Math.random() * 0.72);
+      const angle = Math.random() * Math.PI * 2;
+      const idx = i * 3;
+      positions[idx] = Math.cos(angle) * radius;
+      positions[idx + 1] = 0;
+      positions[idx + 2] = Math.sin(angle) * radius;
+    }
+    const geometry = new THREE.BufferGeometry();
+    geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+    return geometry;
+  })();
   const pocketGlowMaterials = POCKET_GLOW_ENABLED
     ? {
         good: new THREE.MeshBasicMaterial({
@@ -8406,21 +8429,98 @@ export function Table3D(
         })
       }
     : {};
+  const pocketGlowRayMaterials = POCKET_GLOW_ENABLED
+    ? {
+        good: new THREE.MeshBasicMaterial({
+          color: POCKET_GLOW_COLORS.good,
+          transparent: true,
+          opacity: POCKET_GLOW_RAY_OPACITY,
+          blending: THREE.AdditiveBlending,
+          depthWrite: false,
+          side: THREE.DoubleSide
+        }),
+        foul: new THREE.MeshBasicMaterial({
+          color: POCKET_GLOW_COLORS.foul,
+          transparent: true,
+          opacity: POCKET_GLOW_RAY_OPACITY,
+          blending: THREE.AdditiveBlending,
+          depthWrite: false,
+          side: THREE.DoubleSide
+        })
+      }
+    : {};
+  const pocketGlowSparkMaterials = POCKET_GLOW_ENABLED
+    ? {
+        good: new THREE.PointsMaterial({
+          color: POCKET_GLOW_COLORS.good,
+          size: BALL_R * 0.24,
+          transparent: true,
+          opacity: POCKET_GLOW_SPARK_OPACITY,
+          blending: THREE.AdditiveBlending,
+          depthWrite: false
+        }),
+        foul: new THREE.PointsMaterial({
+          color: POCKET_GLOW_COLORS.foul,
+          size: BALL_R * 0.24,
+          transparent: true,
+          opacity: POCKET_GLOW_SPARK_OPACITY,
+          blending: THREE.AdditiveBlending,
+          depthWrite: false
+        })
+      }
+    : {};
   const createPocketGlowMesh = (tone = 'good') => {
     if (!POCKET_GLOW_ENABLED || !pocketGlowGeometry) return null;
     const material = pocketGlowMaterials[tone] || pocketGlowMaterials.good;
-    if (!material) return null;
-    const glow = new THREE.Mesh(pocketGlowGeometry, material);
-    glow.rotation.x = -Math.PI / 2;
-    glow.renderOrder = 3;
-    glow.castShadow = false;
-    glow.receiveShadow = false;
-    return glow;
+    const rayMaterial = pocketGlowRayMaterials[tone] || pocketGlowRayMaterials.good;
+    const sparkMaterial = pocketGlowSparkMaterials[tone] || pocketGlowSparkMaterials.good;
+    if (!material || !rayMaterial) return null;
+    const glowGroup = new THREE.Group();
+    const aura = new THREE.Mesh(pocketGlowGeometry, material);
+    aura.rotation.x = -Math.PI / 2;
+    aura.renderOrder = 3;
+    aura.castShadow = false;
+    aura.receiveShadow = false;
+    glowGroup.add(aura);
+    if (pocketGlowRayGeometry) {
+      const rays = new THREE.Mesh(pocketGlowRayGeometry, rayMaterial);
+      rays.rotation.x = -Math.PI / 2;
+      rays.renderOrder = 3;
+      rays.castShadow = false;
+      rays.receiveShadow = false;
+      glowGroup.add(rays);
+      glowGroup.userData.rays = rays;
+    }
+    if (pocketGlowSparkGeometry && sparkMaterial) {
+      const sparks = new THREE.Points(pocketGlowSparkGeometry, sparkMaterial);
+      sparks.rotation.x = -Math.PI / 2;
+      sparks.renderOrder = 3;
+      sparks.frustumCulled = false;
+      glowGroup.add(sparks);
+      glowGroup.userData.sparks = sparks;
+    }
+    const glowLight = new THREE.PointLight(POCKET_GLOW_COLORS[tone] ?? POCKET_GLOW_COLORS.good, 0, BALL_R * 8.5, 2);
+    glowLight.castShadow = false;
+    glowGroup.add(glowLight);
+    glowGroup.userData.aura = aura;
+    glowGroup.userData.light = glowLight;
+    glowGroup.userData.tone = tone;
+    return glowGroup;
   };
   const setPocketGlowTone = (entry, tone = 'good') => {
     if (!entry?.glowMesh) return;
     const material = pocketGlowMaterials[tone] || pocketGlowMaterials.good;
-    if (material) entry.glowMesh.material = material;
+    const rayMaterial = pocketGlowRayMaterials[tone] || pocketGlowRayMaterials.good;
+    const sparkMaterial = pocketGlowSparkMaterials[tone] || pocketGlowSparkMaterials.good;
+    const glowColor = POCKET_GLOW_COLORS[tone] ?? POCKET_GLOW_COLORS.good;
+    const aura = entry.glowMesh.userData?.aura;
+    const rays = entry.glowMesh.userData?.rays;
+    const sparks = entry.glowMesh.userData?.sparks;
+    const light = entry.glowMesh.userData?.light;
+    if (material && aura) aura.material = material;
+    if (rayMaterial && rays) rays.material = rayMaterial;
+    if (sparkMaterial && sparks) sparks.material = sparkMaterial;
+    if (light) light.color.setHex(glowColor);
     entry.glowTone = tone;
   };
   const removePocketDropEntry = (ballId) => {
@@ -30517,6 +30617,14 @@ const powerRef = useRef(hud.power);
                   b.mesh.scale.set(1, 1, 1);
                   b.mesh.position.set(fromX, BALL_CENTER_Y, fromZ);
                 }
+                const pocketGlow = createPocketGlowMesh('good');
+                if (pocketGlow && table) {
+                  pocketGlow.position.set(c.x, BALL_CENTER_Y - POCKET_GLOW_LIFT, c.y);
+                  pocketGlow.visible = false;
+                  table.add(pocketGlow);
+                  dropEntry.glowMesh = pocketGlow;
+                  dropEntry.glowTone = 'good';
+                }
                 pocketDropRef.current.set(b.id, dropEntry);
               } else {
                 removePocketDropEntry(b.id);
@@ -30653,6 +30761,7 @@ const powerRef = useRef(hud.power);
                 mesh.visible = true;
                 mesh.position.set(entry.toX ?? runFromX, targetY, entry.toZ ?? runFromZ);
                 mesh.scale.set(1, 1, 1);
+                clearPocketGlowMesh(entry);
                 return;
               }
               entry.velocityY =
@@ -30686,6 +30795,60 @@ const powerRef = useRef(hud.power);
                 }
               }
               mesh.position.set(posX, entry.currentY, posZ);
+              if (entry.glowMesh) {
+                const descentProgress = THREE.MathUtils.clamp(
+                  (fromY - entry.currentY) / fallDistance,
+                  0,
+                  1
+                );
+                const riseWindow = 0.82;
+                const riseIntensity =
+                  descentProgress <= riseWindow
+                    ? Math.sin((descentProgress / riseWindow) * Math.PI * 0.85)
+                    : 0;
+                const fadeOut =
+                  descentProgress > riseWindow
+                    ? Math.max(0, 1 - (descentProgress - riseWindow) / (1 - riseWindow))
+                    : 1;
+                const speedBoost = THREE.MathUtils.clamp(
+                  (entry.entrySpeed ?? 0) / (BALL_R * 9),
+                  0.55,
+                  1.2
+                );
+                const glowStrength = THREE.MathUtils.clamp(riseIntensity * fadeOut * speedBoost, 0, 1);
+                if (glowStrength <= 0.01) {
+                  entry.glowMesh.visible = false;
+                } else {
+                  const glowY = Math.min(
+                    entry.currentY - BALL_R * 0.82,
+                    BALL_CENTER_Y - BALL_R * 0.6
+                  );
+                  entry.glowMesh.visible = true;
+                  entry.glowMesh.position.set(xDrop, glowY, zDrop);
+                  const aura = entry.glowMesh.userData?.aura;
+                  const rays = entry.glowMesh.userData?.rays;
+                  const sparks = entry.glowMesh.userData?.sparks;
+                  const light = entry.glowMesh.userData?.light;
+                  const pulse = 0.92 + Math.sin(now * 0.018 + key.length) * 0.08;
+                  if (aura) {
+                    aura.scale.setScalar((0.82 + glowStrength * 0.78) * pulse);
+                    aura.material.opacity = POCKET_GLOW_OPACITY * glowStrength;
+                  }
+                  if (rays) {
+                    rays.scale.setScalar(0.95 + glowStrength * 1.25);
+                    rays.rotation.z = now * 0.0018;
+                    rays.material.opacity = POCKET_GLOW_RAY_OPACITY * glowStrength;
+                  }
+                  if (sparks) {
+                    sparks.rotation.z = -now * 0.0026;
+                    sparks.position.y = Math.sin(now * 0.01) * BALL_R * 0.08;
+                    sparks.material.opacity = POCKET_GLOW_SPARK_OPACITY * glowStrength;
+                  }
+                  if (light) {
+                    light.intensity = POCKET_GLOW_POINT_LIGHT_INTENSITY * glowStrength;
+                  }
+                }
+              }
             });
           }
           if (pocketPopupRef.current.length > 0) {
@@ -30900,8 +31063,18 @@ const powerRef = useRef(hud.power);
           clearPocketGlowMesh(entry);
         });
         pocketDropRef.current.clear();
-        pocketGlowGeometry.dispose?.();
-        Object.values(pocketGlowMaterials).forEach((material) => material?.dispose?.());
+        if (typeof pocketGlowGeometry !== 'undefined') pocketGlowGeometry?.dispose?.();
+        if (typeof pocketGlowRayGeometry !== 'undefined') pocketGlowRayGeometry?.dispose?.();
+        if (typeof pocketGlowSparkGeometry !== 'undefined') pocketGlowSparkGeometry?.dispose?.();
+        if (typeof pocketGlowMaterials !== 'undefined') {
+          Object.values(pocketGlowMaterials).forEach((material) => material?.dispose?.());
+        }
+        if (typeof pocketGlowRayMaterials !== 'undefined') {
+          Object.values(pocketGlowRayMaterials).forEach((material) => material?.dispose?.());
+        }
+        if (typeof pocketGlowSparkMaterials !== 'undefined') {
+          Object.values(pocketGlowSparkMaterials).forEach((material) => material?.dispose?.());
+        }
         pocketRestIndexRef.current.clear();
         pocketPopupRef.current.forEach((entry) => {
           entry?.mesh?.parent?.remove?.(entry.mesh);


### PR DESCRIPTION
### Motivation
- Add a cinematic neon-blue pocket glow that blooms when a ball reaches the pocket and address a runtime crash where glow geometry/material cleanup could reference undefined variables.

### Description
- Enabled and redesigned the pocket glow: replaced single circle mesh with a layered effect (aura, rotating rays, spark particles, and a dynamic `PointLight`) and tuned neon-blue colors and opacities. 
- Hooked glow creation into the pocket-drop flow so a glow group is created per drop entry and animated by drop progression to ramp up near the pocket mouth and fade as the ball falls. 
- Added dedicated geometries/materials for rays and sparks and updated `setPocketGlowTone` to recolor all sub-elements (aura, rays, sparks, light) for `good`/`foul` tones.
- Hardened teardown and cleanup by clearing `glowTone` in `clearPocketGlowMesh` and guarding disposal with `typeof` checks to avoid `ReferenceError` when disposing geometries/materials during renderer teardown.

### Testing
- Ran the web app production build with `cd webapp && npm run build`, which completed successfully.
- Verified the build process again after changes with `cd /workspace/TonPlaygramWebApp && npm run build`, which also completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb93f734f883298736c9d78b409eae)