### PR TITLE
Fix Tavull (Backgammon) GLTF texture mapping and normalization

### DIFF
--- a/webapp/src/pages/Games/TavullBattleRoyal.jsx
+++ b/webapp/src/pages/Games/TavullBattleRoyal.jsx
@@ -369,13 +369,35 @@ function prepareLoadedModel(model) {
     if (!obj?.isMesh) return;
     obj.castShadow = true;
     obj.receiveShadow = true;
+    if (obj.geometry?.attributes?.uv && !obj.geometry.attributes.uv2) {
+      obj.geometry.setAttribute('uv2', obj.geometry.attributes.uv);
+    }
     const materials = Array.isArray(obj.material)
       ? obj.material
       : [obj.material];
     materials.forEach((material) => {
       if (!material) return;
-      if (material.map) applySRGBColorSpace(material.map);
-      if (material.emissiveMap) applySRGBColorSpace(material.emissiveMap);
+      const colorMaps = [material.map, material.emissiveMap];
+      const linearMaps = [
+        material.normalMap,
+        material.roughnessMap,
+        material.metalnessMap,
+        material.aoMap,
+        material.displacementMap,
+        material.alphaMap,
+        material.bumpMap
+      ];
+
+      colorMaps.filter(Boolean).forEach((texture) => {
+        applySRGBColorSpace(texture);
+        texture.flipY = false;
+        texture.needsUpdate = true;
+      });
+      linearMaps.filter(Boolean).forEach((texture) => {
+        if ('colorSpace' in texture) texture.colorSpace = THREE.NoColorSpace;
+        texture.flipY = false;
+        texture.needsUpdate = true;
+      });
     });
   });
 }
@@ -523,8 +545,28 @@ async function loadMappedChair(renderer, theme) {
         if (/leg|base|metal|foot/.test(label)) mat.color?.lerp(legTint, 0.7);
         else mat.color?.lerp(tint, 0.55);
       }
-      if (mat.map) applySRGBColorSpace(mat.map);
-      if (mat.emissiveMap) applySRGBColorSpace(mat.emissiveMap);
+      if (mat.map) {
+        applySRGBColorSpace(mat.map);
+        mat.map.flipY = false;
+      }
+      if (mat.emissiveMap) {
+        applySRGBColorSpace(mat.emissiveMap);
+        mat.emissiveMap.flipY = false;
+      }
+      [
+        mat.normalMap,
+        mat.roughnessMap,
+        mat.metalnessMap,
+        mat.aoMap,
+        mat.displacementMap,
+        mat.alphaMap,
+        mat.bumpMap
+      ]
+        .filter(Boolean)
+        .forEach((texture) => {
+          if ('colorSpace' in texture) texture.colorSpace = THREE.NoColorSpace;
+          texture.flipY = false;
+        });
       mat.needsUpdate = true;
     });
   });


### PR DESCRIPTION
### Motivation
- Imported GLTF chair models for Tavull (Backgammon Royal) were rendering incorrectly because AO/lightmap and other texture channels were not consistently mapped or using the right color spaces after load.
- The change aims to ensure glTF textures and UV channels are normalized so DRACO/Meshopt/KTX2-loaded models display correctly across devices and renderers.

### Description
- Auto-populate `uv2` from `uv` for meshes that have UVs but are missing `uv2` to preserve AO/lightmap-style channels after import.
- Normalize color textures (`map`, `emissiveMap`) by forcing sRGB color space, setting `flipY = false`, and marking them with `needsUpdate` after load.
- Normalize data textures (`normalMap`, `roughnessMap`, `metalnessMap`, `aoMap`, `displacementMap`, `alphaMap`, `bumpMap`) by forcing no-color/linear color space (`THREE.NoColorSpace` when available) and setting `flipY = false`.
- Applied the above normalization in `prepareLoadedModel` and in the chair model setup path so materials are consistently updated after cloning and tinting.

### Testing
- Ran the Tavull engine unit tests with `npm test -- test/tavullEngine.test.js --runInBand` and all tests passed.
- Ran lint on the modified file with `npx eslint webapp/src/pages/Games/TavullBattleRoyal.jsx`, which reported the file is ignored by repo lint patterns and produced no rule failures for the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb9536cb70832997207f1f4a9c4f71)