### PR TITLE
Add BCA eight-ball rules and Race-to-61 variant; enable pocket glow visuals and update UI

### DIFF
--- a/lib/bcaEightBall.js
+++ b/lib/bcaEightBall.js
@@ -1,0 +1,177 @@
+const SOLIDS = new Set([1, 2, 3, 4, 5, 6, 7])
+const STRIPES = new Set([9, 10, 11, 12, 13, 14, 15])
+
+function inferGroup (ballId) {
+  if (SOLIDS.has(ballId)) return 'SOLID'
+  if (STRIPES.has(ballId)) return 'STRIPE'
+  return null
+}
+
+function hasGroupBallsLeft (ballsOnTable, group) {
+  if (!group) return false
+  if (group === 'SOLID') {
+    for (const id of SOLIDS) {
+      if (ballsOnTable.has(id)) return true
+    }
+    return false
+  }
+  for (const id of STRIPES) {
+    if (ballsOnTable.has(id)) return true
+  }
+  return false
+}
+
+export class BcaEightBall {
+  constructor () {
+    this.state = {
+      ballsOnTable: new Set(Array.from({ length: 15 }, (_, i) => i + 1)),
+      currentPlayer: 'A',
+      assignments: { A: null, B: null },
+      ballInHand: false,
+      foulStreak: { A: 0, B: 0 },
+      frameOver: false,
+      winner: null,
+      breakInProgress: true
+    }
+  }
+
+  shotTaken (shot = {}) {
+    const s = this.state
+    const contactOrder = Array.isArray(shot.contactOrder) ? shot.contactOrder : []
+    const pottedList = Array.isArray(shot.potted) ? shot.potted : []
+
+    if (s.frameOver) {
+      return {
+        legal: false,
+        foul: true,
+        reason: 'frame over',
+        potted: [],
+        nextPlayer: s.currentPlayer,
+        ballInHandNext: false,
+        frameOver: true,
+        winner: s.winner
+      }
+    }
+
+    const shooter = s.currentPlayer
+    const opponent = shooter === 'A' ? 'B' : 'A'
+    const shooterGroup = s.assignments[shooter]
+    const opponentGroup = s.assignments[opponent]
+    const wasBreak = Boolean(s.breakInProgress)
+    const first = Number.isFinite(contactOrder[0]) ? contactOrder[0] : null
+    const pottedBalls = pottedList.filter((id) => Number.isFinite(id) && id > 0)
+
+    let foul = false
+    let reason = ''
+    let frameOver = false
+    let winner = null
+    let nextPlayer = shooter
+    let ballInHandNext = false
+
+    const shooterCleared = shooterGroup ? !hasGroupBallsLeft(s.ballsOnTable, shooterGroup) : false
+    const legalFirstTargets = (() => {
+      if (!shooterGroup) return new Set([...SOLIDS, ...STRIPES])
+      if (shooterCleared) return new Set([8])
+      return shooterGroup === 'SOLID' ? new Set(SOLIDS) : new Set(STRIPES)
+    })()
+
+    if (!wasBreak && !first) {
+      foul = true
+      reason = 'no contact'
+    }
+
+    if (!wasBreak && !foul && !legalFirstTargets.has(first)) {
+      foul = true
+      reason = 'wrong first contact'
+    }
+
+    if (!foul && (pottedList.includes(0) || shot.cueOffTable)) {
+      foul = true
+      reason = 'scratch'
+    }
+
+    if (!wasBreak && !foul && shot.noCushionAfterContact && pottedBalls.length === 0) {
+      foul = true
+      reason = 'no cushion'
+    }
+
+    const eightPotted = pottedBalls.includes(8)
+    if (eightPotted) {
+      const legalEight = !foul && shooterGroup && shooterCleared && first === 8
+      frameOver = true
+      winner = legalEight ? shooter : opponent
+      s.frameOver = true
+      s.winner = winner
+      s.ballInHand = false
+      s.breakInProgress = false
+      return {
+        legal: legalEight,
+        foul: !legalEight || foul,
+        reason: legalEight ? undefined : reason || 'illegal 8-ball pot',
+        potted: pottedList,
+        nextPlayer: shooter,
+        ballInHandNext: false,
+        frameOver: true,
+        winner
+      }
+    }
+
+    // Keep all legally potted object balls down.
+    for (const id of pottedBalls) {
+      if (id >= 1 && id <= 15) s.ballsOnTable.delete(id)
+    }
+
+    const nonEightPotted = pottedBalls.filter((id) => id !== 8)
+    const ownGroupPotted = shooterGroup
+      ? nonEightPotted.some((id) => inferGroup(id) === shooterGroup)
+      : false
+    const groupPotOnOpenTable = !shooterGroup
+      ? nonEightPotted.map((id) => inferGroup(id)).find(Boolean) ?? null
+      : null
+
+    if (!foul && !wasBreak && !shooterGroup && groupPotOnOpenTable) {
+      s.assignments[shooter] = groupPotOnOpenTable
+      s.assignments[opponent] = groupPotOnOpenTable === 'SOLID' ? 'STRIPE' : 'SOLID'
+    } else if (!foul && wasBreak && !shooterGroup) {
+      // BCA: table stays open after break even if balls are potted.
+      s.assignments[shooter] = null
+      s.assignments[opponent] = opponentGroup ?? null
+    }
+
+    if (foul) {
+      nextPlayer = opponent
+      ballInHandNext = true
+      s.currentPlayer = opponent
+      s.foulStreak[shooter] = (s.foulStreak[shooter] ?? 0) + 1
+      s.foulStreak[opponent] = 0
+    } else {
+      s.foulStreak[shooter] = 0
+      s.foulStreak[opponent] = 0
+      const continuesTurn = ownGroupPotted || (!shooterGroup && Boolean(groupPotOnOpenTable))
+      if (!continuesTurn) {
+        nextPlayer = opponent
+        s.currentPlayer = opponent
+      }
+    }
+
+    s.ballInHand = ballInHandNext
+    if (wasBreak || !foul || nonEightPotted.length > 0 || shot.breakComplete) {
+      s.breakInProgress = false
+    }
+    s.frameOver = frameOver
+    s.winner = winner
+
+    return {
+      legal: !foul,
+      foul,
+      reason: foul ? reason : undefined,
+      potted: pottedList,
+      nextPlayer,
+      ballInHandNext,
+      frameOver,
+      winner
+    }
+  }
+}
+
+export default BcaEightBall

--- a/src/rules/PoolRoyaleRules.ts
+++ b/src/rules/PoolRoyaleRules.ts
@@ -2,8 +2,9 @@ import { FrameState, Player, ShotContext, ShotEvent } from '../types';
 import { UkPool } from '../../lib/poolUk8Ball.js';
 import { AmericanBilliards } from '../../lib/americanBilliards.js';
 import { NineBall } from '../../lib/nineBall.js';
+import { BcaEightBall } from '../../lib/bcaEightBall.js';
 
-type PoolVariantId = 'american' | 'uk' | '9ball';
+type PoolVariantId = 'american' | 'uk' | '9ball' | 'race61';
 
 type UkColour = 'blue' | 'red' | 'black' | 'cue';
 
@@ -53,6 +54,17 @@ type NineSerializedState = {
   breakInProgress: boolean;
 };
 
+type EightBallSerializedState = {
+  ballsOnTable: number[];
+  currentPlayer: 'A' | 'B';
+  assignments: { A: 'SOLID' | 'STRIPE' | null; B: 'SOLID' | 'STRIPE' | null };
+  ballInHand: boolean;
+  foulStreak: { A: number; B: number };
+  frameOver: boolean;
+  winner: 'A' | 'B' | null;
+  breakInProgress: boolean;
+};
+
 type PoolMeta =
   | {
       variant: 'uk';
@@ -62,13 +74,19 @@ type PoolMeta =
     }
   | {
       variant: 'american';
-      state: AmericanSerializedState;
+      state: EightBallSerializedState;
       hud: HudInfo;
       breakInProgress?: boolean;
     }
   | {
       variant: '9ball';
       state: NineSerializedState;
+      hud: HudInfo;
+      breakInProgress?: boolean;
+    }
+  | {
+      variant: 'race61';
+      state: AmericanSerializedState;
       hud: HudInfo;
       breakInProgress?: boolean;
     };
@@ -188,6 +206,38 @@ function applyNineState(game: NineBall, snapshot: NineSerializedState) {
   };
 }
 
+function serializeEightBallState(state: BcaEightBall['state']): EightBallSerializedState {
+  return {
+    ballsOnTable: Array.from(state.ballsOnTable.values()),
+    currentPlayer: state.currentPlayer,
+    assignments: {
+      A: state.assignments?.A ?? null,
+      B: state.assignments?.B ?? null
+    },
+    ballInHand: state.ballInHand,
+    foulStreak: { ...state.foulStreak },
+    frameOver: state.frameOver,
+    winner: state.winner,
+    breakInProgress: state.breakInProgress
+  };
+}
+
+function applyEightBallState(game: BcaEightBall, snapshot: EightBallSerializedState) {
+  game.state = {
+    ballsOnTable: new Set(snapshot.ballsOnTable),
+    currentPlayer: snapshot.currentPlayer,
+    assignments: {
+      A: snapshot.assignments?.A ?? null,
+      B: snapshot.assignments?.B ?? null
+    },
+    ballInHand: snapshot.ballInHand,
+    foulStreak: { ...snapshot.foulStreak },
+    frameOver: snapshot.frameOver,
+    winner: snapshot.winner,
+    breakInProgress: snapshot.breakInProgress
+  };
+}
+
 function parseUkColour(value: unknown): UkColour | null {
   if (typeof value === 'number') {
     if (value === 8) return 'black';
@@ -242,6 +292,13 @@ export class PoolRoyaleRules {
       this.variant = 'uk';
     } else if (normalized === '9ball' || normalized === 'nineball' || normalized === '9') {
       this.variant = '9ball';
+    } else if (
+      normalized === 'americanbilliards' ||
+      normalized === 'race61' ||
+      normalized === 'rotation61' ||
+      normalized === '61'
+    ) {
+      this.variant = 'race61';
     } else {
       this.variant = 'american';
     }
@@ -304,8 +361,8 @@ export class PoolRoyaleRules {
         } satisfies PoolMeta;
         return base;
       }
-      default: {
-        const game = new AmericanBilliards();
+      case 'race61': {
+        const game = new AmericanBilliards({ targetScore: 61 });
         game.state.ballInHand = true;
         const snapshot = serializeAmericanState(game.state);
         const ballOn = this.computeAmericanBallOn(snapshot);
@@ -326,6 +383,34 @@ export class PoolRoyaleRules {
           scores
         };
         base.meta = {
+          variant: 'race61',
+          state: snapshot,
+          hud,
+          breakInProgress: true
+        } satisfies PoolMeta;
+        return base;
+      }
+      default: {
+        const game = new BcaEightBall();
+        game.state.ballInHand = true;
+        const snapshot = serializeEightBallState(game.state);
+        const ballOn = this.computeEightBallBallOn(snapshot);
+        const base: FrameState = {
+          balls: [],
+          activePlayer: 'A',
+          players: basePlayers(playerA, playerB),
+          currentBreak: 0,
+          phase: 'REDS_AND_COLORS',
+          redsRemaining: 15,
+          ballOn,
+          frameOver: false
+        };
+        const hud: HudInfo = {
+          next: ballOn.length > 0 ? ballOn.map((entry) => entry.toLowerCase()).join(' / ') : 'frame over',
+          phase: 'open',
+          scores: { A: 0, B: 0 }
+        };
+        base.meta = {
           variant: 'american',
           state: snapshot,
           hud,
@@ -342,8 +427,10 @@ export class PoolRoyaleRules {
         return this.applyUkShot(state, events, context);
       case '9ball':
         return this.applyNineBallShot(state, events, context);
+      case 'race61':
+        return this.applyAmericanRaceShot(state, events, context);
       default:
-        return this.applyAmericanShot(state, events, context);
+        return this.applyEightBallShot(state, events, context);
     }
   }
 
@@ -458,9 +545,9 @@ export class PoolRoyaleRules {
     return [];
   }
 
-  private applyAmericanShot(state: FrameState, events: ShotEvent[], context: ShotContext): FrameState {
+  private applyAmericanRaceShot(state: FrameState, events: ShotEvent[], context: ShotContext): FrameState {
     const meta = state.meta as PoolMeta | undefined;
-    const previous = meta && meta.variant === 'american' && meta.state ? meta : null;
+    const previous = meta && meta.variant === 'race61' && meta.state ? meta : null;
     const game = new AmericanBilliards();
     if (previous) {
       applyAmericanState(game, previous.state);
@@ -529,13 +616,119 @@ export class PoolRoyaleRules {
           }
         : undefined,
       meta: {
-        variant: 'american',
+        variant: 'race61',
         state: snapshot,
         hud,
         breakInProgress
       } satisfies PoolMeta
     };
     return nextState;
+  }
+
+  private applyEightBallShot(state: FrameState, events: ShotEvent[], context: ShotContext): FrameState {
+    const meta = state.meta as PoolMeta | undefined;
+    const previous = meta && meta.variant === 'american' && meta.state ? meta : null;
+    const game = new BcaEightBall();
+    if (previous) {
+      applyEightBallState(game, previous.state as EightBallSerializedState);
+    } else {
+      game.state.ballInHand = true;
+    }
+    const contactOrder: number[] = [];
+    for (const ev of events) {
+      if (ev.type !== 'HIT') continue;
+      const id = parseNumericId(ev.ballId ?? ev.firstContact);
+      if (id != null) contactOrder.push(id);
+    }
+    const potted: number[] = [];
+    for (const ev of events) {
+      if (ev.type !== 'POTTED') continue;
+      if (isCueBallId(ev.ballId ?? ev.ball)) {
+        potted.push(0);
+      } else {
+        const id = parseNumericId(ev.ballId ?? ev.ball);
+        if (id != null) potted.push(id);
+      }
+    }
+    const result = game.shotTaken({
+      contactOrder,
+      potted,
+      cueOffTable: Boolean(context.cueBallPotted),
+      placedFromHand: Boolean(context.placedFromHand),
+      noCushionAfterContact: Boolean(context.noCushionAfterContact)
+    });
+    const pottedCount = potted.filter((id) => id !== 0).length;
+    const snapshot = serializeEightBallState(game.state);
+    const ballOn = this.computeEightBallBallOn(snapshot);
+    const nextState: FrameState = {
+      ...state,
+      activePlayer: game.state.currentPlayer,
+      players: {
+        A: { ...state.players.A, score: this.computeEightBallScore(snapshot, 'A') },
+        B: { ...state.players.B, score: this.computeEightBallScore(snapshot, 'B') }
+      },
+      currentBreak:
+        !result.foul && game.state.currentPlayer === state.activePlayer && pottedCount > 0
+          ? (state.currentBreak ?? 0) + pottedCount
+          : 0,
+      ballOn: snapshot.frameOver ? [] : ballOn,
+      frameOver: snapshot.frameOver,
+      winner: snapshot.winner ?? undefined,
+      foul: result.foul
+        ? {
+            points: 0,
+            reason: result.reason ?? 'foul'
+          }
+        : undefined,
+      meta: {
+        variant: 'american',
+        state: snapshot,
+        hud: {
+          next: snapshot.frameOver
+            ? 'frame over'
+            : ballOn.length > 0
+              ? ballOn.map((entry) => entry.toLowerCase()).join(' / ')
+              : 'open table',
+          phase: snapshot.assignments.A || snapshot.assignments.B ? 'groups' : 'open',
+          scores: {
+            A: this.computeEightBallScore(snapshot, 'A'),
+            B: this.computeEightBallScore(snapshot, 'B')
+          }
+        },
+        breakInProgress: Boolean(snapshot.breakInProgress)
+      } satisfies PoolMeta
+    };
+    return nextState;
+  }
+
+  private computeEightBallScore(state: EightBallSerializedState, seat: 'A' | 'B'): number {
+    const group = state.assignments?.[seat];
+    if (!group) return 0;
+    const tableSet = new Set(state.ballsOnTable);
+    const targetIds = group === 'SOLID' ? [1, 2, 3, 4, 5, 6, 7] : [9, 10, 11, 12, 13, 14, 15];
+    const made = targetIds.filter((id) => !tableSet.has(id)).length;
+    return made;
+  }
+
+  private computeEightBallBallOn(state: EightBallSerializedState): string[] {
+    if (state.frameOver) return [];
+    const tableSet = new Set(state.ballsOnTable);
+    const current = state.currentPlayer;
+    const assignment = state.assignments?.[current];
+    if (!assignment) {
+      const targets: string[] = [];
+      if ([1, 2, 3, 4, 5, 6, 7].some((id) => tableSet.has(id))) targets.push('SOLID');
+      if ([9, 10, 11, 12, 13, 14, 15].some((id) => tableSet.has(id))) targets.push('STRIPE');
+      if (targets.length === 0 && tableSet.has(8)) targets.push('BLACK');
+      return targets;
+    }
+    const ownRemaining =
+      assignment === 'SOLID'
+        ? [1, 2, 3, 4, 5, 6, 7].some((id) => tableSet.has(id))
+        : [9, 10, 11, 12, 13, 14, 15].some((id) => tableSet.has(id));
+    if (ownRemaining) return [assignment];
+    if (tableSet.has(8)) return ['BLACK'];
+    return [];
   }
 
   private computeAmericanScores(state: AmericanSerializedState): { A: number; B: number } {

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -138,6 +138,7 @@ function clearPocketGlowMesh(entry) {
   if (!entry?.glowMesh) return;
   entry.glowMesh.parent?.remove?.(entry.glowMesh);
   entry.glowMesh = null;
+  entry.glowTone = null;
 }
 
 function loadCareerAttemptsProgress() {
@@ -1684,12 +1685,15 @@ const POCKET_CAM = Object.freeze({
 const POCKET_CAM_EARLY_TRIGGER_DIST = POCKET_CAM.triggerDist * 1.45; // switch to rail overhead broadcast a little earlier on incoming pocket shots
 const POCKET_POPUP_DURATION_MS = 2500;
 const POCKET_POPUP_LIFT = BALL_R * 2.4;
-const POCKET_GLOW_ENABLED = false;
-const POCKET_GLOW_RADIUS = BALL_R * 1.32;
-const POCKET_GLOW_LIFT = BALL_R * 0.78;
-const POCKET_GLOW_OPACITY = 0.62;
+const POCKET_GLOW_ENABLED = true;
+const POCKET_GLOW_RADIUS = BALL_R * 1.46;
+const POCKET_GLOW_LIFT = BALL_R * 0.92;
+const POCKET_GLOW_OPACITY = 0.72;
+const POCKET_GLOW_RAY_OPACITY = 0.38;
+const POCKET_GLOW_SPARK_OPACITY = 0.5;
+const POCKET_GLOW_POINT_LIGHT_INTENSITY = 1.35;
 const POCKET_GLOW_COLORS = Object.freeze({
-  good: 0x2eea73,
+  good: 0x3bc7ff,
   foul: 0xff4b4b
 });
 const POCKET_CHAOS_MOVING_THRESHOLD = 3;
@@ -1998,7 +2002,7 @@ const POOL_VARIANT_COLOR_SETS = Object.freeze({
   },
   american: {
     id: 'american',
-    label: 'American 8-Ball',
+    label: 'American 8-Ball (BCA)',
     cueColor: 0xffffff,
     rackLayout: 'triangle',
     disableSnookerMarkings: true,
@@ -2083,6 +2087,48 @@ const POOL_VARIANT_COLOR_SETS = Object.freeze({
       'solid',
       'stripe'
     ]
+  },
+  race61: {
+    id: 'race61',
+    label: 'American Billiards (Race to 61)',
+    cueColor: 0xffffff,
+    rackLayout: 'triangle',
+    disableSnookerMarkings: true,
+    objectColors: [
+      0xffc52c,
+      0x0a58ff,
+      0xd32232,
+      0x8f32d6,
+      0xff7c1f,
+      0x0faa60,
+      0x651f28,
+      0x111111,
+      0xffc52c,
+      0x0a58ff,
+      0xd32232,
+      0x8f32d6,
+      0xff7c1f,
+      0x0faa60,
+      0x651f28
+    ],
+    objectNumbers: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+    objectPatterns: [
+      'solid',
+      'solid',
+      'solid',
+      'solid',
+      'solid',
+      'solid',
+      'solid',
+      'solid',
+      'stripe',
+      'stripe',
+      'stripe',
+      'stripe',
+      'stripe',
+      'stripe',
+      'stripe'
+    ]
   }
 });
 
@@ -2106,6 +2152,13 @@ function normalizeBallSetKey(value) {
     return 'american';
   }
   if (normalized === 'uk' || normalized === 'redyellow') return 'uk';
+  if (
+    normalized === 'race61' ||
+    normalized === 'americanbilliards' ||
+    normalized === 'rotation61'
+  ) {
+    return 'race61';
+  }
   return normalized;
 }
 
@@ -2121,6 +2174,13 @@ function resolvePoolVariant(variantId, ballSet = null) {
     normalized === 'uk8'
   ) {
     key = 'uk';
+  } else if (
+    normalized === 'race61' ||
+    normalized === 'americanbilliards' ||
+    normalized === 'rotation61' ||
+    normalized === '61'
+  ) {
+    key = 'race61';
   }
   const base =
     POOL_VARIANT_COLOR_SETS[key] || POOL_VARIANT_COLOR_SETS[DEFAULT_POOL_VARIANT];
@@ -2142,6 +2202,9 @@ function deriveInHandFromFrame(frame) {
   const meta = frame && typeof frame === 'object' ? frame.meta : null;
   if (!meta || typeof meta !== 'object') return false;
   if (meta.variant === 'american' && meta.state) {
+    return Boolean(meta.state.ballInHand);
+  }
+  if (meta.variant === 'race61' && meta.state) {
     return Boolean(meta.state.ballInHand);
   }
   if (meta.variant === '9ball' && meta.state) {
@@ -8386,6 +8449,25 @@ export function Table3D(
   const pocketGlowGeometry = POCKET_GLOW_ENABLED
     ? new THREE.CircleGeometry(POCKET_GLOW_RADIUS, 36)
     : null;
+  const pocketGlowRayGeometry = POCKET_GLOW_ENABLED
+    ? new THREE.CircleGeometry(POCKET_GLOW_RADIUS * 1.42, 24)
+    : null;
+  const pocketGlowSparkGeometry = (() => {
+    if (!POCKET_GLOW_ENABLED) return null;
+    const sparkCount = 18;
+    const positions = new Float32Array(sparkCount * 3);
+    for (let i = 0; i < sparkCount; i += 1) {
+      const radius = POCKET_GLOW_RADIUS * (0.28 + Math.random() * 0.72);
+      const angle = Math.random() * Math.PI * 2;
+      const idx = i * 3;
+      positions[idx] = Math.cos(angle) * radius;
+      positions[idx + 1] = 0;
+      positions[idx + 2] = Math.sin(angle) * radius;
+    }
+    const geometry = new THREE.BufferGeometry();
+    geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+    return geometry;
+  })();
   const pocketGlowMaterials = POCKET_GLOW_ENABLED
     ? {
         good: new THREE.MeshBasicMaterial({
@@ -8393,6 +8475,7 @@ export function Table3D(
           transparent: true,
           opacity: POCKET_GLOW_OPACITY,
           blending: THREE.AdditiveBlending,
+          depthTest: false,
           depthWrite: false,
           side: THREE.DoubleSide
         }),
@@ -8401,26 +8484,108 @@ export function Table3D(
           transparent: true,
           opacity: POCKET_GLOW_OPACITY,
           blending: THREE.AdditiveBlending,
+          depthTest: false,
           depthWrite: false,
           side: THREE.DoubleSide
+        })
+      }
+    : {};
+  const pocketGlowRayMaterials = POCKET_GLOW_ENABLED
+    ? {
+        good: new THREE.MeshBasicMaterial({
+          color: POCKET_GLOW_COLORS.good,
+          transparent: true,
+          opacity: POCKET_GLOW_RAY_OPACITY,
+          blending: THREE.AdditiveBlending,
+          depthTest: false,
+          depthWrite: false,
+          side: THREE.DoubleSide
+        }),
+        foul: new THREE.MeshBasicMaterial({
+          color: POCKET_GLOW_COLORS.foul,
+          transparent: true,
+          opacity: POCKET_GLOW_RAY_OPACITY,
+          blending: THREE.AdditiveBlending,
+          depthTest: false,
+          depthWrite: false,
+          side: THREE.DoubleSide
+        })
+      }
+    : {};
+  const pocketGlowSparkMaterials = POCKET_GLOW_ENABLED
+    ? {
+        good: new THREE.PointsMaterial({
+          color: POCKET_GLOW_COLORS.good,
+          size: BALL_R * 0.24,
+          transparent: true,
+          opacity: POCKET_GLOW_SPARK_OPACITY,
+          blending: THREE.AdditiveBlending,
+          depthTest: false,
+          depthWrite: false
+        }),
+        foul: new THREE.PointsMaterial({
+          color: POCKET_GLOW_COLORS.foul,
+          size: BALL_R * 0.24,
+          transparent: true,
+          opacity: POCKET_GLOW_SPARK_OPACITY,
+          blending: THREE.AdditiveBlending,
+          depthTest: false,
+          depthWrite: false
         })
       }
     : {};
   const createPocketGlowMesh = (tone = 'good') => {
     if (!POCKET_GLOW_ENABLED || !pocketGlowGeometry) return null;
     const material = pocketGlowMaterials[tone] || pocketGlowMaterials.good;
-    if (!material) return null;
-    const glow = new THREE.Mesh(pocketGlowGeometry, material);
-    glow.rotation.x = -Math.PI / 2;
-    glow.renderOrder = 3;
-    glow.castShadow = false;
-    glow.receiveShadow = false;
-    return glow;
+    const rayMaterial = pocketGlowRayMaterials[tone] || pocketGlowRayMaterials.good;
+    const sparkMaterial = pocketGlowSparkMaterials[tone] || pocketGlowSparkMaterials.good;
+    if (!material || !rayMaterial) return null;
+    const glowGroup = new THREE.Group();
+    const aura = new THREE.Mesh(pocketGlowGeometry, material);
+    aura.rotation.x = -Math.PI / 2;
+    aura.renderOrder = 3;
+    aura.castShadow = false;
+    aura.receiveShadow = false;
+    glowGroup.add(aura);
+    if (pocketGlowRayGeometry) {
+      const rays = new THREE.Mesh(pocketGlowRayGeometry, rayMaterial);
+      rays.rotation.x = -Math.PI / 2;
+      rays.renderOrder = 3;
+      rays.castShadow = false;
+      rays.receiveShadow = false;
+      glowGroup.add(rays);
+      glowGroup.userData.rays = rays;
+    }
+    if (pocketGlowSparkGeometry && sparkMaterial) {
+      const sparks = new THREE.Points(pocketGlowSparkGeometry, sparkMaterial);
+      sparks.rotation.x = -Math.PI / 2;
+      sparks.renderOrder = 3;
+      sparks.frustumCulled = false;
+      glowGroup.add(sparks);
+      glowGroup.userData.sparks = sparks;
+    }
+    const glowLight = new THREE.PointLight(POCKET_GLOW_COLORS[tone] ?? POCKET_GLOW_COLORS.good, 0, BALL_R * 8.5, 2);
+    glowLight.castShadow = false;
+    glowGroup.add(glowLight);
+    glowGroup.userData.aura = aura;
+    glowGroup.userData.light = glowLight;
+    glowGroup.userData.tone = tone;
+    return glowGroup;
   };
   const setPocketGlowTone = (entry, tone = 'good') => {
     if (!entry?.glowMesh) return;
     const material = pocketGlowMaterials[tone] || pocketGlowMaterials.good;
-    if (material) entry.glowMesh.material = material;
+    const rayMaterial = pocketGlowRayMaterials[tone] || pocketGlowRayMaterials.good;
+    const sparkMaterial = pocketGlowSparkMaterials[tone] || pocketGlowSparkMaterials.good;
+    const glowColor = POCKET_GLOW_COLORS[tone] ?? POCKET_GLOW_COLORS.good;
+    const aura = entry.glowMesh.userData?.aura;
+    const rays = entry.glowMesh.userData?.rays;
+    const sparks = entry.glowMesh.userData?.sparks;
+    const light = entry.glowMesh.userData?.light;
+    if (material && aura) aura.material = material;
+    if (rayMaterial && rays) rays.material = rayMaterial;
+    if (sparkMaterial && sparks) sparks.material = sparkMaterial;
+    if (light) light.color.setHex(glowColor);
     entry.glowTone = tone;
   };
   const removePocketDropEntry = (ballId) => {
@@ -24920,7 +25085,7 @@ const powerRef = useRef(hud.power);
         let placedFromHand = false;
         const meta = frameSnapshot?.meta;
         if (meta && typeof meta === 'object') {
-          if (meta.variant === 'american' && meta.state) {
+          if ((meta.variant === 'american' || meta.variant === 'race61') && meta.state) {
             placedFromHand = Boolean(meta.state.ballInHand);
           } else if (meta.variant === '9ball' && meta.state) {
             placedFromHand = Boolean(meta.state.ballInHand);
@@ -25751,7 +25916,7 @@ const powerRef = useRef(hud.power);
             hudRef.current?.turn === 1 &&
             aiTurnShotCountRef.current > 0;
           const isRotationVariant =
-            activeVariantId === 'american' || activeVariantId === '9ball';
+            activeVariantId === 'race61' || activeVariantId === '9ball';
           const activeBalls = ballsList.filter((b) => b.active);
           const targetOrder = resolveTargetPriorities(state, activeVariantId, activeBalls);
           const legalTargetsRaw = Array.isArray(state?.ballOn) && state.ballOn.length > 0
@@ -25765,7 +25930,7 @@ const powerRef = useRef(hud.power);
               .filter((entry) => entry && isBallTargetId(entry))
           );
           if (legalTargets.size === 0) {
-            if (activeVariantId === 'american' || activeVariantId === '9ball') {
+            if (activeVariantId === 'race61' || activeVariantId === '9ball') {
               const lowestActive = activeBalls
                 .filter((b) => String(b?.id).toLowerCase() !== 'cue')
                 .reduce(
@@ -26171,7 +26336,7 @@ const powerRef = useRef(hud.power);
               };
             safetyShots.push(safetyPlan);
           });
-          if (!potShots.length && (activeVariantId === 'american' || activeVariantId === '9ball')) {
+          if (!potShots.length && (activeVariantId === 'race61' || activeVariantId === '9ball')) {
             const targetBall = activeBalls
               .filter((b) => b.id !== cueBall.id)
               .sort((a, b) => a.id - b.id)[0];
@@ -28309,7 +28474,7 @@ const powerRef = useRef(hud.power);
             if (isTraining) {
               nextInHand = cueBallPotted;
             } else if (nextMeta && typeof nextMeta === 'object') {
-              if (nextMeta.variant === 'american' && nextMeta.state) {
+              if ((nextMeta.variant === 'american' || nextMeta.variant === 'race61') && nextMeta.state) {
                 nextInHand = cueBallPotted || Boolean(nextMeta.state.ballInHand);
               } else if (nextMeta.variant === '9ball' && nextMeta.state) {
                 nextInHand = cueBallPotted || Boolean(nextMeta.state.ballInHand);
@@ -30517,6 +30682,14 @@ const powerRef = useRef(hud.power);
                   b.mesh.scale.set(1, 1, 1);
                   b.mesh.position.set(fromX, BALL_CENTER_Y, fromZ);
                 }
+                const pocketGlow = createPocketGlowMesh('good');
+                if (pocketGlow && table) {
+                  pocketGlow.position.set(c.x, BALL_CENTER_Y - POCKET_GLOW_LIFT, c.y);
+                  pocketGlow.visible = false;
+                  table.add(pocketGlow);
+                  dropEntry.glowMesh = pocketGlow;
+                  dropEntry.glowTone = 'good';
+                }
                 pocketDropRef.current.set(b.id, dropEntry);
               } else {
                 removePocketDropEntry(b.id);
@@ -30653,6 +30826,7 @@ const powerRef = useRef(hud.power);
                 mesh.visible = true;
                 mesh.position.set(entry.toX ?? runFromX, targetY, entry.toZ ?? runFromZ);
                 mesh.scale.set(1, 1, 1);
+                clearPocketGlowMesh(entry);
                 return;
               }
               entry.velocityY =
@@ -30686,6 +30860,60 @@ const powerRef = useRef(hud.power);
                 }
               }
               mesh.position.set(posX, entry.currentY, posZ);
+              if (entry.glowMesh) {
+                const descentProgress = THREE.MathUtils.clamp(
+                  (fromY - entry.currentY) / fallDistance,
+                  0,
+                  1
+                );
+                const riseWindow = 0.82;
+                const riseIntensity =
+                  descentProgress <= riseWindow
+                    ? Math.sin((descentProgress / riseWindow) * Math.PI * 0.85)
+                    : 0;
+                const fadeOut =
+                  descentProgress > riseWindow
+                    ? Math.max(0, 1 - (descentProgress - riseWindow) / (1 - riseWindow))
+                    : 1;
+                const speedBoost = THREE.MathUtils.clamp(
+                  (entry.entrySpeed ?? 0) / (BALL_R * 9),
+                  0.55,
+                  1.2
+                );
+                const glowStrength = THREE.MathUtils.clamp(riseIntensity * fadeOut * speedBoost, 0, 1);
+                if (glowStrength <= 0.01) {
+                  entry.glowMesh.visible = false;
+                } else {
+                  const glowY = Math.min(
+                    entry.currentY - BALL_R * 0.28,
+                    BALL_CENTER_Y - BALL_R * 0.12
+                  );
+                  entry.glowMesh.visible = true;
+                  entry.glowMesh.position.set(xDrop, glowY, zDrop);
+                  const aura = entry.glowMesh.userData?.aura;
+                  const rays = entry.glowMesh.userData?.rays;
+                  const sparks = entry.glowMesh.userData?.sparks;
+                  const light = entry.glowMesh.userData?.light;
+                  const pulse = 0.92 + Math.sin(now * 0.018 + key.length) * 0.08;
+                  if (aura) {
+                    aura.scale.setScalar((0.82 + glowStrength * 0.78) * pulse);
+                    aura.material.opacity = POCKET_GLOW_OPACITY * glowStrength;
+                  }
+                  if (rays) {
+                    rays.scale.setScalar(0.95 + glowStrength * 1.25);
+                    rays.rotation.z = now * 0.0018;
+                    rays.material.opacity = POCKET_GLOW_RAY_OPACITY * glowStrength;
+                  }
+                  if (sparks) {
+                    sparks.rotation.z = -now * 0.0026;
+                    sparks.position.y = Math.sin(now * 0.01) * BALL_R * 0.08;
+                    sparks.material.opacity = POCKET_GLOW_SPARK_OPACITY * glowStrength;
+                  }
+                  if (light) {
+                    light.intensity = POCKET_GLOW_POINT_LIGHT_INTENSITY * glowStrength;
+                  }
+                }
+              }
             });
           }
           if (pocketPopupRef.current.length > 0) {
@@ -30900,8 +31128,18 @@ const powerRef = useRef(hud.power);
           clearPocketGlowMesh(entry);
         });
         pocketDropRef.current.clear();
-        pocketGlowGeometry.dispose?.();
-        Object.values(pocketGlowMaterials).forEach((material) => material?.dispose?.());
+        if (typeof pocketGlowGeometry !== 'undefined') pocketGlowGeometry?.dispose?.();
+        if (typeof pocketGlowRayGeometry !== 'undefined') pocketGlowRayGeometry?.dispose?.();
+        if (typeof pocketGlowSparkGeometry !== 'undefined') pocketGlowSparkGeometry?.dispose?.();
+        if (typeof pocketGlowMaterials !== 'undefined') {
+          Object.values(pocketGlowMaterials).forEach((material) => material?.dispose?.());
+        }
+        if (typeof pocketGlowRayMaterials !== 'undefined') {
+          Object.values(pocketGlowRayMaterials).forEach((material) => material?.dispose?.());
+        }
+        if (typeof pocketGlowSparkMaterials !== 'undefined') {
+          Object.values(pocketGlowSparkMaterials).forEach((material) => material?.dispose?.());
+        }
         pocketRestIndexRef.current.clear();
         pocketPopupRef.current.forEach((entry) => {
           entry?.mesh?.parent?.remove?.(entry.mesh);

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -712,8 +712,9 @@ export default function PoolRoyaleLobby() {
               <div className="grid grid-cols-3 gap-3">
                 {[
                   { id: 'uk', label: '8Ball' },
-                  { id: 'american', label: 'American' },
-                  { id: '9ball', label: '9-Ball' }
+                  { id: 'american', label: '8-Ball (BCA)' },
+                  { id: '9ball', label: '9-Ball' },
+                  { id: 'race61', label: 'Race to 61' }
                 ].map(({ id, label }) => {
                   const active = variant === id;
                   return (


### PR DESCRIPTION
### Motivation
- Implement BCA (American 8-ball) rule support and a new Race-to-61 variant so the game can run BCA eight-ball and rotation-style match types.
- Improve pocket visual feedback with configurable glow, rays, sparks and lighting to make potted-ball feedback more readable and attractive.
- Ensure game state serialization and UI variants reflect the new rule engines and in-hand logic.

### Description
- Added a new rule engine `lib/bcaEightBall.js` implementing BCA eight-ball shot adjudication, state model and `shotTaken` semantics.
- Integrated eight-ball support into `PoolRoyaleRules.ts` by introducing `EightBallSerializedState`, serialization/apply helpers (`serializeEightBallState` / `applyEightBallState`), `applyEightBallShot`, `computeEightBallScore`, and `computeEightBallBallOn`, and added a `race61` variant that instantiates `AmericanBilliards({ targetScore: 61 })` for race scoring.
- Switched the default American 8-ball flow to use the BCA engine for frame initialization and shot application, added variant parsing for `race61`, and adjusted in-hand/AI logic to include the new variant.
- Enhanced pocket visuals in `PoolRoyale.jsx` by enabling pocket glow, adding new glow parameters (ray/spark/light), creating composite glow meshes (aura, rays, sparks, point light), animating glow on pocket drop, and ensuring proper disposal and state clearing; also updated color sets and variant labels to include `race61` and relabeled the American variant to "8-Ball (BCA)".
- Minor UI and state plumbing changes such as `clearPocketGlowMesh` and `deriveInHandFromFrame` updates to handle the new variants and glow tone tracking.

### Testing
- Built the project and type-checked TypeScript with `yarn build` which completed successfully.
- Ran the project's automated test suite with `yarn test` and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb93f734f883298736c9d78b409eae)