### PR TITLE
Add BCA 8‑Ball (BCA) ruleset, integrate into PoolRoyale, and enhance pocket glow visuals

### DIFF
--- a/lib/american8BallBca.js
+++ b/lib/american8BallBca.js
@@ -1,0 +1,143 @@
+const SOLIDS = 'SOLID'
+const STRIPES = 'STRIPE'
+
+export class American8BallBca {
+  constructor () {
+    this.state = {
+      ballsOnTable: new Set(Array.from({ length: 15 }, (_, i) => i + 1)),
+      currentPlayer: 'A',
+      assignments: { A: null, B: null },
+      ballInHand: true,
+      foulStreak: { A: 0, B: 0 },
+      frameOver: false,
+      winner: null,
+      breakInProgress: true
+    }
+  }
+
+  shotTaken (shot = {}) {
+    const s = this.state
+    const current = s.currentPlayer
+    const opp = current === 'A' ? 'B' : 'A'
+    const contactOrder = Array.isArray(shot.contactOrder) ? shot.contactOrder : []
+    const pottedList = Array.isArray(shot.potted) ? shot.potted : []
+    const wasBreakShot = Boolean(s.breakInProgress)
+
+    if (s.frameOver) {
+      return { legal: false, foul: true, reason: 'frame over', winner: s.winner, frameOver: true }
+    }
+
+    const pottedBalls = pottedList.filter((id) => Number.isFinite(id) && id >= 1 && id <= 15)
+    const cueScratch = pottedList.includes(0) || shot.cueOffTable
+    const first = Number.isFinite(contactOrder[0]) ? contactOrder[0] : null
+    const target = this.#legalTargetFor(current)
+    let foul = false
+    let reason = ''
+
+    if (!first && !wasBreakShot) {
+      foul = true
+      reason = 'no contact'
+    } else if (!wasBreakShot && !this.#isLegalFirstContact(first, target)) {
+      foul = true
+      reason = 'wrong first contact'
+    } else if (!wasBreakShot && shot.noCushionAfterContact && pottedBalls.length === 0) {
+      foul = true
+      reason = 'no cushion'
+    } else if (cueScratch) {
+      foul = true
+      reason = 'scratch'
+    }
+
+    for (const id of pottedBalls) s.ballsOnTable.delete(id)
+
+    if (!foul && s.assignments[current] == null && s.assignments[opp] == null) {
+      const solidPotted = pottedBalls.some((id) => id >= 1 && id <= 7)
+      const stripePotted = pottedBalls.some((id) => id >= 9 && id <= 15)
+      if (solidPotted !== stripePotted) {
+        s.assignments[current] = solidPotted ? SOLIDS : STRIPES
+        s.assignments[opp] = solidPotted ? STRIPES : SOLIDS
+      }
+    }
+
+    let frameOver = false
+    let winner = null
+    const pottedEight = pottedBalls.includes(8)
+    const targetIncludesEight = target === 8
+    if (pottedEight) {
+      if (!foul && targetIncludesEight) {
+        frameOver = true
+        winner = current
+      } else {
+        frameOver = true
+        winner = opp
+      }
+    }
+
+    if (frameOver) {
+      s.frameOver = true
+      s.winner = winner
+      s.ballInHand = false
+      s.breakInProgress = false
+      return { legal: !foul, foul, reason: foul ? reason || 'illegal 8-ball' : undefined, frameOver, winner, nextPlayer: current, ballInHandNext: false }
+    }
+
+    let nextPlayer = current
+    if (foul || !this.#keepsTurn(current, pottedBalls)) {
+      nextPlayer = opp
+      s.currentPlayer = opp
+    }
+
+    s.ballInHand = foul
+    s.foulStreak[current] = foul ? (s.foulStreak[current] ?? 0) + 1 : 0
+    s.foulStreak[opp] = foul ? 0 : s.foulStreak[opp] ?? 0
+    s.breakInProgress = false
+
+    return {
+      legal: !foul,
+      foul,
+      reason: foul ? reason : undefined,
+      potted: pottedList,
+      nextPlayer,
+      ballInHandNext: foul,
+      frameOver: false,
+      winner: null
+    }
+  }
+
+  #groupRemaining (group) {
+    if (group === SOLIDS) return Array.from(this.state.ballsOnTable).filter((id) => id >= 1 && id <= 7).length
+    if (group === STRIPES) return Array.from(this.state.ballsOnTable).filter((id) => id >= 9 && id <= 15).length
+    return 0
+  }
+
+  #legalTargetFor (player) {
+    const mine = this.state.assignments[player]
+    if (!mine) return 'OPEN'
+    const mineRemaining = this.#groupRemaining(mine)
+    if (mineRemaining === 0) return 8
+    return mine
+  }
+
+  #isLegalFirstContact (first, target) {
+    if (!Number.isFinite(first)) return false
+    if (target === 'OPEN') return first >= 1 && first <= 15
+    if (target === 8) return first === 8
+    if (target === SOLIDS) return first >= 1 && first <= 7
+    if (target === STRIPES) return first >= 9 && first <= 15
+    return false
+  }
+
+  #keepsTurn (player, pottedBalls) {
+    if (!Array.isArray(pottedBalls) || pottedBalls.length === 0) return false
+    const target = this.#legalTargetFor(player)
+    if (target === 'OPEN') {
+      return pottedBalls.some((id) => id >= 1 && id <= 7) || pottedBalls.some((id) => id >= 9 && id <= 15)
+    }
+    if (target === 8) return pottedBalls.includes(8)
+    if (target === SOLIDS) return pottedBalls.some((id) => id >= 1 && id <= 7)
+    if (target === STRIPES) return pottedBalls.some((id) => id >= 9 && id <= 15)
+    return false
+  }
+}
+
+export default American8BallBca

--- a/src/rules/PoolRoyaleRules.ts
+++ b/src/rules/PoolRoyaleRules.ts
@@ -1,9 +1,10 @@
 import { FrameState, Player, ShotContext, ShotEvent } from '../types';
 import { UkPool } from '../../lib/poolUk8Ball.js';
 import { AmericanBilliards } from '../../lib/americanBilliards.js';
+import { American8BallBca } from '../../lib/american8BallBca.js';
 import { NineBall } from '../../lib/nineBall.js';
 
-type PoolVariantId = 'american' | 'uk' | '9ball';
+type PoolVariantId = 'american' | '8ball' | 'uk' | '9ball';
 
 type UkColour = 'blue' | 'red' | 'black' | 'cue';
 
@@ -43,6 +44,17 @@ type AmericanSerializedState = {
   targetScore: number;
 };
 
+type AmericanEightBallSerializedState = {
+  ballsOnTable: number[];
+  currentPlayer: 'A' | 'B';
+  assignments: { A: 'SOLID' | 'STRIPE' | null; B: 'SOLID' | 'STRIPE' | null };
+  ballInHand: boolean;
+  foulStreak: { A: number; B: number };
+  frameOver: boolean;
+  winner: 'A' | 'B' | null;
+  breakInProgress: boolean;
+};
+
 type NineSerializedState = {
   ballsOnTable: number[];
   currentPlayer: 'A' | 'B';
@@ -59,6 +71,12 @@ type PoolMeta =
       state: UkSerializedState;
       totals: { blue: number; red: number };
       hud: HudInfo;
+    }
+  | {
+      variant: '8ball';
+      state: AmericanEightBallSerializedState;
+      hud: HudInfo;
+      breakInProgress?: boolean;
     }
   | {
       variant: 'american';
@@ -164,6 +182,38 @@ function applyAmericanState(game: AmericanBilliards, snapshot: AmericanSerialize
   };
 }
 
+function serializeAmericanEightBallState(state: American8BallBca['state']): AmericanEightBallSerializedState {
+  return {
+    ballsOnTable: Array.from(state.ballsOnTable.values()),
+    currentPlayer: state.currentPlayer,
+    assignments: {
+      A: state.assignments?.A ?? null,
+      B: state.assignments?.B ?? null
+    },
+    ballInHand: state.ballInHand,
+    foulStreak: { ...state.foulStreak },
+    frameOver: state.frameOver,
+    winner: state.winner,
+    breakInProgress: state.breakInProgress
+  };
+}
+
+function applyAmericanEightBallState(game: American8BallBca, snapshot: AmericanEightBallSerializedState) {
+  game.state = {
+    ballsOnTable: new Set(snapshot.ballsOnTable),
+    currentPlayer: snapshot.currentPlayer,
+    assignments: {
+      A: snapshot.assignments?.A ?? null,
+      B: snapshot.assignments?.B ?? null
+    },
+    ballInHand: snapshot.ballInHand,
+    foulStreak: { ...snapshot.foulStreak },
+    frameOver: snapshot.frameOver,
+    winner: snapshot.winner,
+    breakInProgress: snapshot.breakInProgress
+  };
+}
+
 function serializeNineState(state: NineBall['state']): NineSerializedState {
   return {
     ballsOnTable: Array.from(state.ballsOnTable.values()),
@@ -240,10 +290,20 @@ export class PoolRoyaleRules {
     const normalized = normalizeVariantId(variantKey);
     if (normalized === 'uk' || normalized === '8balluk' || normalized === 'eightballuk' || normalized === 'uk8') {
       this.variant = 'uk';
+    } else if (
+      normalized === '8ball' ||
+      normalized === 'eightball' ||
+      normalized === 'bca' ||
+      normalized === 'bca8ball' ||
+      normalized === 'american'
+    ) {
+      this.variant = '8ball';
     } else if (normalized === '9ball' || normalized === 'nineball' || normalized === '9') {
       this.variant = '9ball';
-    } else {
+    } else if (normalized === 'american61' || normalized === 'americanbilliards' || normalized === 'race61') {
       this.variant = 'american';
+    } else {
+      this.variant = '8ball';
     }
   }
 
@@ -273,6 +333,33 @@ export class PoolRoyaleRules {
           state: snapshot,
           totals: { blue: UK_TOTAL_PER_COLOUR, red: UK_TOTAL_PER_COLOUR },
           hud
+        } satisfies PoolMeta;
+        return base;
+      }
+      case '8ball': {
+        const game = new American8BallBca();
+        const snapshot = serializeAmericanEightBallState(game.state);
+        const ballOn = this.computeAmericanEightBallBallOn(snapshot);
+        const base: FrameState = {
+          balls: [],
+          activePlayer: 'A',
+          players: basePlayers(playerA, playerB),
+          currentBreak: 0,
+          phase: 'REDS_AND_COLORS',
+          redsRemaining: 15,
+          ballOn,
+          frameOver: false
+        };
+        const hud: HudInfo = {
+          next: ballOn.length > 0 ? ballOn.join(' / ').toLowerCase() : 'open table',
+          phase: 'groups',
+          scores: { A: 0, B: 0 }
+        };
+        base.meta = {
+          variant: '8ball',
+          state: snapshot,
+          hud,
+          breakInProgress: true
         } satisfies PoolMeta;
         return base;
       }
@@ -340,11 +427,97 @@ export class PoolRoyaleRules {
     switch (this.variant) {
       case 'uk':
         return this.applyUkShot(state, events, context);
+      case '8ball':
+        return this.applyAmericanEightBallShot(state, events, context);
       case '9ball':
         return this.applyNineBallShot(state, events, context);
       default:
         return this.applyAmericanShot(state, events, context);
     }
+  }
+
+  private applyAmericanEightBallShot(state: FrameState, events: ShotEvent[], context: ShotContext): FrameState {
+    const meta = state.meta as PoolMeta | undefined;
+    const previous = meta && meta.variant === '8ball' && meta.state ? meta : null;
+    const game = new American8BallBca();
+    if (previous) {
+      applyAmericanEightBallState(game, previous.state);
+    }
+    const contactOrder: number[] = [];
+    for (const ev of events) {
+      if (ev.type !== 'HIT') continue;
+      const id = parseNumericId(ev.ballId ?? ev.firstContact);
+      if (id != null) contactOrder.push(id);
+    }
+    const potted: number[] = [];
+    for (const ev of events) {
+      if (ev.type !== 'POTTED') continue;
+      if (isCueBallId(ev.ballId ?? ev.ball)) {
+        potted.push(0);
+      } else {
+        const id = parseNumericId(ev.ballId ?? ev.ball);
+        if (id != null) potted.push(id);
+      }
+    }
+    const result = game.shotTaken({
+      contactOrder,
+      potted,
+      cueOffTable: Boolean(context.cueBallPotted),
+      placedFromHand: Boolean(context.placedFromHand),
+      noCushionAfterContact: Boolean(context.noCushionAfterContact)
+    });
+    const pottedCount = potted.filter((id) => id !== 0).length;
+    const snapshot = serializeAmericanEightBallState(game.state);
+    const ballOn = this.computeAmericanEightBallBallOn(snapshot);
+    const frameOver = snapshot.frameOver;
+    const hud: HudInfo = {
+      next: frameOver ? 'frame over' : ballOn.join(' / ').toLowerCase(),
+      phase: frameOver ? 'complete' : snapshot.assignments.A || snapshot.assignments.B ? 'groups' : 'open',
+      scores: { A: 0, B: 0 }
+    };
+    return {
+      ...state,
+      activePlayer: game.state.currentPlayer,
+      players: {
+        A: { ...state.players.A, score: 0 },
+        B: { ...state.players.B, score: 0 }
+      },
+      currentBreak:
+        !result.foul && game.state.currentPlayer === state.activePlayer && pottedCount > 0
+          ? (state.currentBreak ?? 0) + pottedCount
+          : 0,
+      ballOn: frameOver ? [] : ballOn,
+      frameOver,
+      winner: snapshot.winner ?? undefined,
+      foul: result.foul
+        ? {
+            points: 0,
+            reason: result.reason ?? 'foul'
+          }
+        : undefined,
+      meta: {
+        variant: '8ball',
+        state: snapshot,
+        hud,
+        breakInProgress: Boolean(snapshot.breakInProgress)
+      } satisfies PoolMeta
+    };
+  }
+
+  private computeAmericanEightBallBallOn(state: AmericanEightBallSerializedState): string[] {
+    if (state.frameOver) return [];
+    const current = state.currentPlayer;
+    const assignment = state.assignments?.[current] ?? null;
+    if (!assignment) return ['SOLID', 'STRIPE'];
+    const solidsRemaining = state.ballsOnTable.some((id) => id >= 1 && id <= 7);
+    const stripesRemaining = state.ballsOnTable.some((id) => id >= 9 && id <= 15);
+    if (assignment === 'SOLID') {
+      return solidsRemaining ? ['SOLID'] : ['BLACK'];
+    }
+    if (assignment === 'STRIPE') {
+      return stripesRemaining ? ['STRIPE'] : ['BLACK'];
+    }
+    return ['SOLID', 'STRIPE'];
   }
 
   private applyUkShot(state: FrameState, events: ShotEvent[], context: ShotContext): FrameState {

--- a/webapp/src/config/poolRoyaleTraining.js
+++ b/webapp/src/config/poolRoyaleTraining.js
@@ -117,7 +117,7 @@ const clamp = (value) => Math.max(-0.94, Math.min(0.94, value));
 const DISCIPLINE_TO_VARIANT = {
   '8Ball': 'uk',
   '9-Ball': '9ball',
-  'American Billiards': 'american'
+  'American Billiards': 'american61'
 };
 
 const DIFFICULTY_STEPS = [
@@ -156,7 +156,7 @@ export const TRAINING_SCENARIOS = (() => {
       };
 
       const shotLimit = resolveShotLimit(blueprint, tier);
-      const variant = DISCIPLINE_TO_VARIANT[blueprint.discipline] || 'american';
+      const variant = DISCIPLINE_TO_VARIANT[blueprint.discipline] || 'american61';
       const reward = Math.round(60 + level * 10 + (tier.rewardBonus || 0));
       scenarios.push({
         level,

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -138,6 +138,7 @@ function clearPocketGlowMesh(entry) {
   if (!entry?.glowMesh) return;
   entry.glowMesh.parent?.remove?.(entry.glowMesh);
   entry.glowMesh = null;
+  entry.glowTone = null;
 }
 
 function loadCareerAttemptsProgress() {
@@ -1684,12 +1685,15 @@ const POCKET_CAM = Object.freeze({
 const POCKET_CAM_EARLY_TRIGGER_DIST = POCKET_CAM.triggerDist * 1.45; // switch to rail overhead broadcast a little earlier on incoming pocket shots
 const POCKET_POPUP_DURATION_MS = 2500;
 const POCKET_POPUP_LIFT = BALL_R * 2.4;
-const POCKET_GLOW_ENABLED = false;
-const POCKET_GLOW_RADIUS = BALL_R * 1.32;
-const POCKET_GLOW_LIFT = BALL_R * 0.78;
-const POCKET_GLOW_OPACITY = 0.62;
+const POCKET_GLOW_ENABLED = true;
+const POCKET_GLOW_RADIUS = BALL_R * 1.46;
+const POCKET_GLOW_LIFT = BALL_R * 0.92;
+const POCKET_GLOW_OPACITY = 0.72;
+const POCKET_GLOW_RAY_OPACITY = 0.38;
+const POCKET_GLOW_SPARK_OPACITY = 0.5;
+const POCKET_GLOW_POINT_LIGHT_INTENSITY = 1.35;
 const POCKET_GLOW_COLORS = Object.freeze({
-  good: 0x2eea73,
+  good: 0x3bc7ff,
   foul: 0xff4b4b
 });
 const POCKET_CHAOS_MOVING_THRESHOLD = 3;
@@ -1949,7 +1953,7 @@ const FIXED_WOOD_REPEAT_SCALE = 1; // restore the original per-texture scale wit
 const WOOD_REPEAT_SCALE_MIN = 0.5;
 const WOOD_REPEAT_SCALE_MAX = 2;
 const DEFAULT_WOOD_REPEAT_SCALE = FIXED_WOOD_REPEAT_SCALE;
-const DEFAULT_POOL_VARIANT = 'american';
+const DEFAULT_POOL_VARIANT = '8ball';
 const UK_POOL_RED = 0xd12c2c;
 const UK_POOL_YELLOW = 0xffd700;
 const UK_POOL_BLACK = 0x000000;
@@ -1996,9 +2000,9 @@ const POOL_VARIANT_COLOR_SETS = Object.freeze({
     ],
     objectPatterns: new Array(15).fill('solid')
   },
-  american: {
-    id: 'american',
-    label: 'American 8-Ball',
+  '8ball': {
+    id: '8ball',
+    label: 'BCA 8-Ball',
     cueColor: 0xffffff,
     rackLayout: 'triangle',
     disableSnookerMarkings: true,
@@ -2054,6 +2058,22 @@ const POOL_VARIANT_COLOR_SETS = Object.freeze({
       'stripe'
     ]
   },
+  american: {
+    id: 'american',
+    label: 'American Billiards 61',
+    cueColor: 0xffffff,
+    rackLayout: 'triangle',
+    disableSnookerMarkings: true,
+    objectColors: [
+      0xffc52c, 0x0a58ff, 0xd32232, 0x8f32d6, 0xff7c1f, 0x0faa60, 0x651f28,
+      0x111111, 0xffc52c, 0x0a58ff, 0xd32232, 0x8f32d6, 0xff7c1f, 0x0faa60, 0x651f28
+    ],
+    objectNumbers: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+    objectPatterns: [
+      'solid', 'solid', 'solid', 'solid', 'solid', 'solid', 'solid', 'solid',
+      'stripe', 'stripe', 'stripe', 'stripe', 'stripe', 'stripe', 'stripe'
+    ]
+  },
   '9ball': {
     id: '9ball',
     label: '9-Ball',
@@ -2098,6 +2118,10 @@ function normalizeBallSetKey(value) {
   const normalized = normalizeVariantKey(value);
   if (
     normalized === 'american' ||
+    normalized === '8ball' ||
+    normalized === 'eightball' ||
+    normalized === 'bca' ||
+    normalized === 'bca8ball' ||
     normalized === 'solidsstripes' ||
     normalized === 'solidsandstripes' ||
     normalized === 'solids' ||
@@ -2115,6 +2139,20 @@ function resolvePoolVariant(variantId, ballSet = null) {
   if (normalized === '9' || normalized === 'nineball') {
     key = '9ball';
   } else if (
+    normalized === 'american61' ||
+    normalized === 'americanbilliards' ||
+    normalized === 'race61'
+  ) {
+    key = 'american';
+  } else if (
+    normalized === 'american' ||
+    normalized === '8ball' ||
+    normalized === 'eightball' ||
+    normalized === 'bca' ||
+    normalized === 'bca8ball'
+  ) {
+    key = '8ball';
+  } else if (
     normalized === '8balluk' ||
     normalized === 'eightballuk' ||
     normalized === '8pooluk' ||
@@ -2126,7 +2164,7 @@ function resolvePoolVariant(variantId, ballSet = null) {
     POOL_VARIANT_COLOR_SETS[key] || POOL_VARIANT_COLOR_SETS[DEFAULT_POOL_VARIANT];
   const ballSetKey = normalizeBallSetKey(ballSet);
   if (base.id === 'uk' && ballSetKey === 'american') {
-    const american = POOL_VARIANT_COLOR_SETS.american;
+    const american = POOL_VARIANT_COLOR_SETS['8ball'];
     return {
       ...base,
       ballSet: 'american',
@@ -2141,7 +2179,7 @@ function resolvePoolVariant(variantId, ballSet = null) {
 function deriveInHandFromFrame(frame) {
   const meta = frame && typeof frame === 'object' ? frame.meta : null;
   if (!meta || typeof meta !== 'object') return false;
-  if (meta.variant === 'american' && meta.state) {
+  if ((meta.variant === 'american' || meta.variant === '8ball') && meta.state) {
     return Boolean(meta.state.ballInHand);
   }
   if (meta.variant === '9ball' && meta.state) {
@@ -8386,6 +8424,25 @@ export function Table3D(
   const pocketGlowGeometry = POCKET_GLOW_ENABLED
     ? new THREE.CircleGeometry(POCKET_GLOW_RADIUS, 36)
     : null;
+  const pocketGlowRayGeometry = POCKET_GLOW_ENABLED
+    ? new THREE.CircleGeometry(POCKET_GLOW_RADIUS * 1.42, 24)
+    : null;
+  const pocketGlowSparkGeometry = (() => {
+    if (!POCKET_GLOW_ENABLED) return null;
+    const sparkCount = 18;
+    const positions = new Float32Array(sparkCount * 3);
+    for (let i = 0; i < sparkCount; i += 1) {
+      const radius = POCKET_GLOW_RADIUS * (0.28 + Math.random() * 0.72);
+      const angle = Math.random() * Math.PI * 2;
+      const idx = i * 3;
+      positions[idx] = Math.cos(angle) * radius;
+      positions[idx + 1] = 0;
+      positions[idx + 2] = Math.sin(angle) * radius;
+    }
+    const geometry = new THREE.BufferGeometry();
+    geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+    return geometry;
+  })();
   const pocketGlowMaterials = POCKET_GLOW_ENABLED
     ? {
         good: new THREE.MeshBasicMaterial({
@@ -8393,6 +8450,7 @@ export function Table3D(
           transparent: true,
           opacity: POCKET_GLOW_OPACITY,
           blending: THREE.AdditiveBlending,
+          depthTest: false,
           depthWrite: false,
           side: THREE.DoubleSide
         }),
@@ -8401,26 +8459,108 @@ export function Table3D(
           transparent: true,
           opacity: POCKET_GLOW_OPACITY,
           blending: THREE.AdditiveBlending,
+          depthTest: false,
           depthWrite: false,
           side: THREE.DoubleSide
+        })
+      }
+    : {};
+  const pocketGlowRayMaterials = POCKET_GLOW_ENABLED
+    ? {
+        good: new THREE.MeshBasicMaterial({
+          color: POCKET_GLOW_COLORS.good,
+          transparent: true,
+          opacity: POCKET_GLOW_RAY_OPACITY,
+          blending: THREE.AdditiveBlending,
+          depthTest: false,
+          depthWrite: false,
+          side: THREE.DoubleSide
+        }),
+        foul: new THREE.MeshBasicMaterial({
+          color: POCKET_GLOW_COLORS.foul,
+          transparent: true,
+          opacity: POCKET_GLOW_RAY_OPACITY,
+          blending: THREE.AdditiveBlending,
+          depthTest: false,
+          depthWrite: false,
+          side: THREE.DoubleSide
+        })
+      }
+    : {};
+  const pocketGlowSparkMaterials = POCKET_GLOW_ENABLED
+    ? {
+        good: new THREE.PointsMaterial({
+          color: POCKET_GLOW_COLORS.good,
+          size: BALL_R * 0.24,
+          transparent: true,
+          opacity: POCKET_GLOW_SPARK_OPACITY,
+          blending: THREE.AdditiveBlending,
+          depthTest: false,
+          depthWrite: false
+        }),
+        foul: new THREE.PointsMaterial({
+          color: POCKET_GLOW_COLORS.foul,
+          size: BALL_R * 0.24,
+          transparent: true,
+          opacity: POCKET_GLOW_SPARK_OPACITY,
+          blending: THREE.AdditiveBlending,
+          depthTest: false,
+          depthWrite: false
         })
       }
     : {};
   const createPocketGlowMesh = (tone = 'good') => {
     if (!POCKET_GLOW_ENABLED || !pocketGlowGeometry) return null;
     const material = pocketGlowMaterials[tone] || pocketGlowMaterials.good;
-    if (!material) return null;
-    const glow = new THREE.Mesh(pocketGlowGeometry, material);
-    glow.rotation.x = -Math.PI / 2;
-    glow.renderOrder = 3;
-    glow.castShadow = false;
-    glow.receiveShadow = false;
-    return glow;
+    const rayMaterial = pocketGlowRayMaterials[tone] || pocketGlowRayMaterials.good;
+    const sparkMaterial = pocketGlowSparkMaterials[tone] || pocketGlowSparkMaterials.good;
+    if (!material || !rayMaterial) return null;
+    const glowGroup = new THREE.Group();
+    const aura = new THREE.Mesh(pocketGlowGeometry, material);
+    aura.rotation.x = -Math.PI / 2;
+    aura.renderOrder = 3;
+    aura.castShadow = false;
+    aura.receiveShadow = false;
+    glowGroup.add(aura);
+    if (pocketGlowRayGeometry) {
+      const rays = new THREE.Mesh(pocketGlowRayGeometry, rayMaterial);
+      rays.rotation.x = -Math.PI / 2;
+      rays.renderOrder = 3;
+      rays.castShadow = false;
+      rays.receiveShadow = false;
+      glowGroup.add(rays);
+      glowGroup.userData.rays = rays;
+    }
+    if (pocketGlowSparkGeometry && sparkMaterial) {
+      const sparks = new THREE.Points(pocketGlowSparkGeometry, sparkMaterial);
+      sparks.rotation.x = -Math.PI / 2;
+      sparks.renderOrder = 3;
+      sparks.frustumCulled = false;
+      glowGroup.add(sparks);
+      glowGroup.userData.sparks = sparks;
+    }
+    const glowLight = new THREE.PointLight(POCKET_GLOW_COLORS[tone] ?? POCKET_GLOW_COLORS.good, 0, BALL_R * 8.5, 2);
+    glowLight.castShadow = false;
+    glowGroup.add(glowLight);
+    glowGroup.userData.aura = aura;
+    glowGroup.userData.light = glowLight;
+    glowGroup.userData.tone = tone;
+    return glowGroup;
   };
   const setPocketGlowTone = (entry, tone = 'good') => {
     if (!entry?.glowMesh) return;
     const material = pocketGlowMaterials[tone] || pocketGlowMaterials.good;
-    if (material) entry.glowMesh.material = material;
+    const rayMaterial = pocketGlowRayMaterials[tone] || pocketGlowRayMaterials.good;
+    const sparkMaterial = pocketGlowSparkMaterials[tone] || pocketGlowSparkMaterials.good;
+    const glowColor = POCKET_GLOW_COLORS[tone] ?? POCKET_GLOW_COLORS.good;
+    const aura = entry.glowMesh.userData?.aura;
+    const rays = entry.glowMesh.userData?.rays;
+    const sparks = entry.glowMesh.userData?.sparks;
+    const light = entry.glowMesh.userData?.light;
+    if (material && aura) aura.material = material;
+    if (rayMaterial && rays) rays.material = rayMaterial;
+    if (sparkMaterial && sparks) sparks.material = sparkMaterial;
+    if (light) light.color.setHex(glowColor);
     entry.glowTone = tone;
   };
   const removePocketDropEntry = (ballId) => {
@@ -22766,9 +22906,9 @@ const powerRef = useRef(hud.power);
           addCueStick(-PLAY_W * 0.2, rackStartZ + BALL_R * 4.2, -Math.PI * 0.04);
           addCueStick(PLAY_W * 0.22, baulkZ - BALL_R * 1.2, Math.PI * 0.06);
         } else {
-          const rackColors = POOL_VARIANT_COLOR_SETS.american.objectColors || [];
-          const rackNumbers = POOL_VARIANT_COLOR_SETS.american.objectNumbers || [];
-          const rackPatterns = POOL_VARIANT_COLOR_SETS.american.objectPatterns || [];
+          const rackColors = POOL_VARIANT_COLOR_SETS['8ball'].objectColors || [];
+          const rackNumbers = POOL_VARIANT_COLOR_SETS['8ball'].objectNumbers || [];
+          const rackPatterns = POOL_VARIANT_COLOR_SETS['8ball'].objectPatterns || [];
           const rackStartZ = SPOTS.pink[1] + BALL_R * 2 + RACK_VERTICAL_SCREEN_LIFT;
           const rackPositions = generateRackPositions(
             rackColors.length,
@@ -24920,7 +25060,7 @@ const powerRef = useRef(hud.power);
         let placedFromHand = false;
         const meta = frameSnapshot?.meta;
         if (meta && typeof meta === 'object') {
-          if (meta.variant === 'american' && meta.state) {
+          if ((meta.variant === 'american' || meta.variant === '8ball') && meta.state) {
             placedFromHand = Boolean(meta.state.ballInHand);
           } else if (meta.variant === '9ball' && meta.state) {
             placedFromHand = Boolean(meta.state.ballInHand);
@@ -25619,7 +25759,8 @@ const powerRef = useRef(hud.power);
           const normalized = normalizeTargetId(assignment);
           if (normalized === 'RED') return ['RED'];
           if (normalized === 'BLUE' || normalized === 'YELLOW') {
-            return variantId === 'american' ? ['SOLID'] : ['YELLOW', 'BLUE'];
+            if (variantId === '9ball') return ['YELLOW', 'BLUE'];
+            return ['SOLID'];
           }
           if (normalized === 'BLACK') return ['BLACK', 'BALL_8'];
           if (normalized === 'SOLID' || normalized === 'SOLIDS') return ['SOLID'];
@@ -25751,7 +25892,7 @@ const powerRef = useRef(hud.power);
             hudRef.current?.turn === 1 &&
             aiTurnShotCountRef.current > 0;
           const isRotationVariant =
-            activeVariantId === 'american' || activeVariantId === '9ball';
+            activeVariantId === 'american' || activeVariantId === '8ball' || activeVariantId === '9ball';
           const activeBalls = ballsList.filter((b) => b.active);
           const targetOrder = resolveTargetPriorities(state, activeVariantId, activeBalls);
           const legalTargetsRaw = Array.isArray(state?.ballOn) && state.ballOn.length > 0
@@ -25765,7 +25906,7 @@ const powerRef = useRef(hud.power);
               .filter((entry) => entry && isBallTargetId(entry))
           );
           if (legalTargets.size === 0) {
-            if (activeVariantId === 'american' || activeVariantId === '9ball') {
+            if (activeVariantId === 'american' || activeVariantId === '8ball' || activeVariantId === '9ball') {
               const lowestActive = activeBalls
                 .filter((b) => String(b?.id).toLowerCase() !== 'cue')
                 .reduce(
@@ -26171,7 +26312,12 @@ const powerRef = useRef(hud.power);
               };
             safetyShots.push(safetyPlan);
           });
-          if (!potShots.length && (activeVariantId === 'american' || activeVariantId === '9ball')) {
+          if (
+            !potShots.length &&
+            (activeVariantId === 'american' ||
+              activeVariantId === '8ball' ||
+              activeVariantId === '9ball')
+          ) {
             const targetBall = activeBalls
               .filter((b) => b.id !== cueBall.id)
               .sort((a, b) => a.id - b.id)[0];
@@ -26686,7 +26832,12 @@ const powerRef = useRef(hud.power);
             breakInProgress: Boolean(metaState?.breakInProgress)
           };
           const decision = planShot({
-            game: variantId === 'american' ? 'AMERICAN_BILLIARDS' : 'NINE_BALL',
+            game:
+              variantId === '9ball'
+                ? 'NINE_BALL'
+                : variantId === 'american'
+                  ? 'AMERICAN_BILLIARDS'
+                  : 'EIGHT_BALL',
             state: aiState,
             timeBudgetMs: Math.min(AI_THINKING_BUDGET_MS, 320)
           });
@@ -28309,7 +28460,7 @@ const powerRef = useRef(hud.power);
             if (isTraining) {
               nextInHand = cueBallPotted;
             } else if (nextMeta && typeof nextMeta === 'object') {
-              if (nextMeta.variant === 'american' && nextMeta.state) {
+              if ((nextMeta.variant === 'american' || nextMeta.variant === '8ball') && nextMeta.state) {
                 nextInHand = cueBallPotted || Boolean(nextMeta.state.ballInHand);
               } else if (nextMeta.variant === '9ball' && nextMeta.state) {
                 nextInHand = cueBallPotted || Boolean(nextMeta.state.ballInHand);
@@ -30493,6 +30644,8 @@ const powerRef = useRef(hud.power);
                   fromZ: ringAnchor.z,
                   toX: targetX,
                   toZ: targetZ,
+                  glowX: c.x,
+                  glowZ: c.y,
                   runFromX: railRunStart.x,
                   runFromZ: railRunStart.z,
                   mesh: b.mesh,
@@ -30516,6 +30669,14 @@ const powerRef = useRef(hud.power);
                   b.mesh.visible = true;
                   b.mesh.scale.set(1, 1, 1);
                   b.mesh.position.set(fromX, BALL_CENTER_Y, fromZ);
+                }
+                const pocketGlow = createPocketGlowMesh('good');
+                if (pocketGlow && table) {
+                  pocketGlow.position.set(c.x, BALL_CENTER_Y - POCKET_GLOW_LIFT, c.y);
+                  pocketGlow.visible = false;
+                  table.add(pocketGlow);
+                  dropEntry.glowMesh = pocketGlow;
+                  dropEntry.glowTone = 'good';
                 }
                 pocketDropRef.current.set(b.id, dropEntry);
               } else {
@@ -30653,6 +30814,7 @@ const powerRef = useRef(hud.power);
                 mesh.visible = true;
                 mesh.position.set(entry.toX ?? runFromX, targetY, entry.toZ ?? runFromZ);
                 mesh.scale.set(1, 1, 1);
+                clearPocketGlowMesh(entry);
                 return;
               }
               entry.velocityY =
@@ -30686,6 +30848,61 @@ const powerRef = useRef(hud.power);
                 }
               }
               mesh.position.set(posX, entry.currentY, posZ);
+              if (entry.glowMesh) {
+                const descentProgress = THREE.MathUtils.clamp(
+                  (fromY - entry.currentY) / fallDistance,
+                  0,
+                  1
+                );
+                const elapsed = Math.max(0, now - (entry.start ?? now));
+                const timeBoost = THREE.MathUtils.clamp(elapsed / 140, 0, 1);
+                const riseIntensity = THREE.MathUtils.smoothstep(
+                  descentProgress + timeBoost * 0.34,
+                  0.02,
+                  0.36
+                );
+                const fadeOut = 1 - THREE.MathUtils.smoothstep(descentProgress, 0.58, 1);
+                const speedBoost = THREE.MathUtils.clamp(
+                  (entry.entrySpeed ?? 0) / (BALL_R * 9),
+                  0.55,
+                  1.2
+                );
+                const glowStrength = THREE.MathUtils.clamp(riseIntensity * fadeOut * speedBoost, 0, 1);
+                if (glowStrength <= 0.01) {
+                  entry.glowMesh.visible = false;
+                } else {
+                  const glowY = Math.min(
+                    entry.currentY - BALL_R * 0.72,
+                    BALL_CENTER_Y - BALL_R * 0.08
+                  );
+                  const glowX = entry.glowX ?? xDrop;
+                  const glowZ = entry.glowZ ?? zDrop;
+                  entry.glowMesh.visible = true;
+                  entry.glowMesh.position.set(glowX, glowY, glowZ);
+                  const aura = entry.glowMesh.userData?.aura;
+                  const rays = entry.glowMesh.userData?.rays;
+                  const sparks = entry.glowMesh.userData?.sparks;
+                  const light = entry.glowMesh.userData?.light;
+                  const pulse = 0.92 + Math.sin(now * 0.018 + key.length) * 0.08;
+                  if (aura) {
+                    aura.scale.setScalar((0.88 + glowStrength * 1.22) * pulse);
+                    aura.material.opacity = POCKET_GLOW_OPACITY * glowStrength;
+                  }
+                  if (rays) {
+                    rays.scale.setScalar(1.08 + glowStrength * 1.72);
+                    rays.rotation.z = now * 0.0018;
+                    rays.material.opacity = POCKET_GLOW_RAY_OPACITY * glowStrength;
+                  }
+                  if (sparks) {
+                    sparks.rotation.z = -now * 0.0026;
+                    sparks.position.y = Math.sin(now * 0.01) * BALL_R * 0.08;
+                    sparks.material.opacity = POCKET_GLOW_SPARK_OPACITY * glowStrength;
+                  }
+                  if (light) {
+                    light.intensity = POCKET_GLOW_POINT_LIGHT_INTENSITY * glowStrength;
+                  }
+                }
+              }
             });
           }
           if (pocketPopupRef.current.length > 0) {
@@ -30900,8 +31117,18 @@ const powerRef = useRef(hud.power);
           clearPocketGlowMesh(entry);
         });
         pocketDropRef.current.clear();
-        pocketGlowGeometry.dispose?.();
-        Object.values(pocketGlowMaterials).forEach((material) => material?.dispose?.());
+        if (typeof pocketGlowGeometry !== 'undefined') pocketGlowGeometry?.dispose?.();
+        if (typeof pocketGlowRayGeometry !== 'undefined') pocketGlowRayGeometry?.dispose?.();
+        if (typeof pocketGlowSparkGeometry !== 'undefined') pocketGlowSparkGeometry?.dispose?.();
+        if (typeof pocketGlowMaterials !== 'undefined') {
+          Object.values(pocketGlowMaterials).forEach((material) => material?.dispose?.());
+        }
+        if (typeof pocketGlowRayMaterials !== 'undefined') {
+          Object.values(pocketGlowRayMaterials).forEach((material) => material?.dispose?.());
+        }
+        if (typeof pocketGlowSparkMaterials !== 'undefined') {
+          Object.values(pocketGlowSparkMaterials).forEach((material) => material?.dispose?.());
+        }
         pocketRestIndexRef.current.clear();
         pocketPopupRef.current.forEach((entry) => {
           entry?.mesh?.parent?.remove?.(entry.mesh);
@@ -31484,7 +31711,7 @@ const powerRef = useRef(hud.power);
   }, [showPlayerControls, showSpinController, updateSpinDotPosition]);
 
   const americanBallSwatches = useMemo(() => {
-    const colors = POOL_VARIANT_COLOR_SETS.american.objectColors || [];
+    const colors = POOL_VARIANT_COLOR_SETS['8ball'].objectColors || [];
     return colors.reduce((acc, hex, idx) => {
       acc[idx + 1] = `#${hex.toString(16).padStart(6, '0')}`;
       return acc;

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -709,11 +709,12 @@ export default function PoolRoyaleLobby() {
                   Ruleset
                 </span>
               </div>
-              <div className="grid grid-cols-3 gap-3">
+              <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
                 {[
                   { id: 'uk', label: '8Ball' },
-                  { id: 'american', label: 'American' },
-                  { id: '9ball', label: '9-Ball' }
+                  { id: '8ball', label: 'BCA 8-Ball' },
+                  { id: '9ball', label: '9-Ball' },
+                  { id: 'american61', label: 'Race to 61' }
                 ].map(({ id, label }) => {
                   const active = variant === id;
                   return (


### PR DESCRIPTION
### Motivation

- Introduce a dedicated BCA 8‑Ball rules engine and expose it as an in‑game variant so BCA-style 8‑ball play is supported alongside existing variants. 
- Ensure the UI, training scenarios and game logic correctly select and display the new 8‑ball variant while preserving the existing American Billiards (race to 61) mode. 
- Improve pocket visual feedback with a richer glow, rays and spark effects for better pocket/potting affordance.

### Description

- Added `lib/american8BallBca.js` implementing `American8BallBca` with full shot adjudication, assignment logic, foul handling and serialization-friendly state. 
- Extended `src/rules/PoolRoyaleRules.ts` to recognize an `8ball` variant, added serialization and apply/state restore helpers (`serializeAmericanEightBallState`, `applyAmericanEightBallState`), an `applyAmericanEightBallShot` handler and `computeAmericanEightBallBallOn` to produce `ballOn` and HUD info. 
- Updated training, variant resolution and UI mappings so that BCA 8‑Ball is selectable as `8ball` while preserving `american61`/`american` distinctions for American Billiards (race to 61); adjusted default variant keys and color/ball sets accordingly. 
- Integrated the new variant into multiple UI/game flows (aiming, AI, in‑hand detection, ball-on resolution, lobby variant options and training scenario generation) so gameplay and AI reasoning include `8ball`. 
- Enhanced pocket visuals in `webapp/src/pages/Games/PoolRoyale.jsx` by enabling pocket glow, increasing radius/opacity, adding ray and spark geometries and materials, attaching a point light to glow groups, animating glow during pocket drop, ensuring proper creation/cleanup and exposing `glowTone` state on entries. 
- Minor UI/UX fixes to clear glow state and to use the `8ball` ball swatches and rack layouts where appropriate.

### Testing

- Ran the project's automated test suite including unit tests, linting and a full TypeScript build; all tests and checks completed successfully. 
- Exercised variant selection and basic shot flows manually in the local dev build to confirm the new `8ball` meta is created, serialized and updated during shots without breaking other variants. 
- Verified pocket glow creation, animation and disposal run without console errors in the dev environment across several pot and drop scenarios.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb93f734f883298736c9d78b409eae)