### PR TITLE
Align Backgammon (Tavull) inventory/menu with Chess Battle Royal catalog

### DIFF
--- a/test/inventoryCrossGameConfig.test.js
+++ b/test/inventoryCrossGameConfig.test.js
@@ -9,6 +9,10 @@ import {
 import {
   LUDO_BATTLE_STORE_ITEMS
 } from '../webapp/src/config/ludoBattleInventoryConfig.js';
+import {
+  TAVULL_BATTLE_DEFAULT_UNLOCKS,
+  TAVULL_BATTLE_STORE_ITEMS
+} from '../webapp/src/config/tavullBattleInventoryConfig.js';
 import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from '../webapp/src/config/murlanThemes.js';
 import { DOMINO_ROYAL_STORE_ITEMS } from '../webapp/src/config/dominoRoyalInventoryConfig.js';
 
@@ -47,5 +51,15 @@ describe('cross-game inventory alignment', () => {
     expect(new Set(DOMINO_ROYAL_DEFAULT_UNLOCKS.chairTheme)).toEqual(
       new Set(MURLAN_STOOL_THEMES.map((theme) => theme.id))
     );
+  });
+
+  test('backgammon store and defaults include murlan table themes', () => {
+    const tavullTableStoreIds = new Set(
+      TAVULL_BATTLE_STORE_ITEMS.filter((item) => item.type === 'tables').map((item) => item.optionId)
+    );
+    const expectedTableIds = new Set(MURLAN_TABLE_THEMES.map((theme) => theme.id));
+
+    expect(TAVULL_BATTLE_DEFAULT_UNLOCKS.tables[0]).toBe(MURLAN_TABLE_THEMES[0]?.id);
+    expect(tavullTableStoreIds).toEqual(new Set([...expectedTableIds].filter((id) => id !== MURLAN_TABLE_THEMES[0]?.id)));
   });
 });

--- a/webapp/src/config/tavullBattleInventoryConfig.js
+++ b/webapp/src/config/tavullBattleInventoryConfig.js
@@ -1,4 +1,5 @@
 import { MURLAN_STOOL_THEMES } from './murlanThemes.js';
+import { MURLAN_TABLE_THEMES } from './murlanThemes.js';
 import { MURLAN_TABLE_FINISHES } from './murlanTableFinishes.js';
 import { FOUR_IN_ROW_BOARD_FRAME_FINISH_OPTIONS } from './fourInRowInventoryConfig.js';
 import {
@@ -103,6 +104,7 @@ export const TAVULL_BATTLE_TRIANGLE_COLOR_OPTIONS = Object.freeze(
 
 export const TAVULL_BATTLE_DEFAULT_UNLOCKS = Object.freeze({
   chairColor: [TAVULL_BATTLE_CHAIR_OPTIONS[0]?.id],
+  tables: [MURLAN_TABLE_THEMES[0]?.id],
   tableFinish: [MURLAN_TABLE_FINISHES[0]?.id],
   boardFinish: [TAVULL_BATTLE_BOARD_FINISH_OPTIONS[0]?.id],
   frameFinish: [TAVULL_BATTLE_FRAME_FINISH_OPTIONS[0]?.id],
@@ -120,6 +122,7 @@ const reduceLabels = (options, labelKey = 'label') =>
 
 export const TAVULL_BATTLE_OPTION_LABELS = Object.freeze({
   chairColor: reduceLabels(TAVULL_BATTLE_CHAIR_OPTIONS),
+  tables: reduceLabels(MURLAN_TABLE_THEMES),
   tableFinish: reduceLabels(MURLAN_TABLE_FINISHES),
   boardFinish: reduceLabels(TAVULL_BATTLE_BOARD_FINISH_OPTIONS),
   frameFinish: reduceLabels(TAVULL_BATTLE_FRAME_FINISH_OPTIONS),
@@ -142,6 +145,18 @@ export const TAVULL_BATTLE_STORE_ITEMS = [
     description: finish.description,
     swatches: finish.swatches,
     thumbnail: finish.thumbnail,
+    previewShape: 'table'
+  })),
+  ...MURLAN_TABLE_THEMES.slice(1).map((theme, idx) => ({
+    id: `tavull-table-${theme.id}`,
+    type: 'tables',
+    optionId: theme.id,
+    name: theme.label,
+    price: theme.price ?? 980 + idx * 40,
+    description:
+      theme.description ||
+      `${theme.label} table with preserved Poly Haven materials.`,
+    thumbnail: theme.thumbnail,
     previewShape: 'table'
   })),
   ...TAVULL_BATTLE_CHAIR_OPTIONS.slice(1).map((option, idx) => ({

--- a/webapp/src/pages/Games/TavullBattleRoyal.jsx
+++ b/webapp/src/pages/Games/TavullBattleRoyal.jsx
@@ -32,6 +32,7 @@ import {
   TAVULL_BATTLE_FRAME_FINISH_OPTIONS,
   TAVULL_BATTLE_TRIANGLE_COLOR_OPTIONS
 } from '../../config/tavullBattleInventoryConfig.js';
+import { MURLAN_TABLE_THEMES } from '../../config/murlanThemes.js';
 import {
   POOL_ROYALE_HDRI_VARIANTS,
   POOL_ROYALE_HDRI_VARIANT_MAP
@@ -117,6 +118,7 @@ const CHAIR_MODEL_URLS = Object.freeze([
   '/assets/models/chair/chair.gltf'
 ]);
 const CHAIR_THEMES = Object.freeze([...TAVULL_BATTLE_CHAIR_OPTIONS]);
+const TABLE_THEMES = Object.freeze([...MURLAN_TABLE_THEMES]);
 const QUALITY_OPTIONS = Object.freeze([
   { id: 'performance', label: 'Performance', pixelRatio: 1, shadows: false },
   { id: 'balanced', label: 'Balanced', pixelRatio: 1.5, shadows: true },
@@ -646,6 +648,7 @@ export default function TavullBattleRoyal() {
   const [viewMode, setViewMode] = useState('3d');
   const [isRollingDice, setIsRollingDice] = useState(false);
   const [tableFinishIdx, setTableFinishIdx] = useState(0);
+  const [tableThemeIdx, setTableThemeIdx] = useState(0);
   const [chairThemeIdx, setChairThemeIdx] = useState(0);
   const [hdriIdx, setHdriIdx] = useState(0);
   const [boardFinishIdx, setBoardFinishIdx] = useState(0);
@@ -662,7 +665,11 @@ export default function TavullBattleRoyal() {
   const [inventoryVersion, setInventoryVersion] = useState(0);
   const [activeMoveHighlight, setActiveMoveHighlight] = useState(null);
   const [selectedPoint, setSelectedPoint] = useState(null);
-  const accountId = tavullBattleAccountId();
+  const accountId = useMemo(() => {
+    if (typeof window === 'undefined') return tavullBattleAccountId();
+    const params = new URLSearchParams(window.location.search);
+    return tavullBattleAccountId(params.get('accountId'));
+  }, []);
   const tavullInventory = useMemo(
     () => getTavullBattleInventory(accountId),
     [accountId, inventoryVersion]
@@ -693,6 +700,13 @@ export default function TavullBattleRoyal() {
     }
   ];
 
+  const ownedTableOptions = useMemo(
+    () =>
+      TABLE_THEMES.filter((option) =>
+        isTavullOptionUnlocked('tables', option.id, tavullInventory)
+      ),
+    [tavullInventory]
+  );
   const ownedChairOptions = useMemo(
     () =>
       CHAIR_THEMES.filter((option) =>
@@ -739,6 +753,13 @@ export default function TavullBattleRoyal() {
   const customizationSections = useMemo(
     () => [
       {
+        key: 'tables',
+        label: 'Tables',
+        options: ownedTableOptions,
+        selectedIdx: tableThemeIdx,
+        setSelectedIdx: setTableThemeIdx
+      },
+      {
         key: 'tableFinish',
         label: 'Table Finish',
         options: ownedFinishOptions,
@@ -782,6 +803,8 @@ export default function TavullBattleRoyal() {
       }
     ],
     [
+      ownedTableOptions,
+      tableThemeIdx,
       ownedFinishOptions,
       tableFinishIdx,
       ownedChairOptions,
@@ -832,14 +855,23 @@ export default function TavullBattleRoyal() {
   }, []);
 
   useEffect(() => {
-    const onInventoryUpdate = () => setInventoryVersion((v) => v + 1);
+    const onInventoryUpdate = (event) => {
+      if (!event?.detail?.accountId || event.detail.accountId === accountId) {
+        setInventoryVersion((v) => v + 1);
+      }
+    };
     window.addEventListener('tavullBattleInventoryUpdate', onInventoryUpdate);
     return () =>
       window.removeEventListener(
         'tavullBattleInventoryUpdate',
         onInventoryUpdate
       );
-  }, []);
+  }, [accountId]);
+
+  useEffect(() => {
+    if (!ownedTableOptions.length) return;
+    if (!ownedTableOptions[tableThemeIdx]) setTableThemeIdx(0);
+  }, [ownedTableOptions, tableThemeIdx]);
 
   useEffect(() => {
     if (!ownedFinishOptions.length) return;
@@ -1022,7 +1054,7 @@ export default function TavullBattleRoyal() {
         ctx.lineTo(width, y);
         ctx.stroke();
       }
-    }, [2.5, 2.5]);
+    }, [2.2, 2.2]);
     const frameTexture = createCanvasTexture((ctx, width, height) => {
       const grad = ctx.createLinearGradient(0, 0, width, height);
       grad.addColorStop(0, '#6e3a22');
@@ -1038,7 +1070,7 @@ export default function TavullBattleRoyal() {
         ctx.lineTo(x - 36, height);
         ctx.stroke();
       }
-    }, [4, 1.5]);
+    }, [2.2, 2.2]);
     const triangleTexture = createCanvasTexture((ctx, width, height) => {
       const grad = ctx.createLinearGradient(0, 0, width, height);
       grad.addColorStop(0, '#ffffff');
@@ -1934,6 +1966,7 @@ export default function TavullBattleRoyal() {
                 <button
                   type="button"
                   onClick={() => {
+                    setTableThemeIdx(0);
                     setTableFinishIdx(0);
                     setChairThemeIdx(0);
                     setHdriIdx(0);

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -184,6 +184,7 @@ const CHESS_TYPE_LABELS = {
   environmentHdri: 'HDR Environments'
 };
 const TAVULL_TYPE_LABELS = {
+  tables: 'Table Models',
   tableFinish: 'Table Finish',
   chairColor: 'Chairs',
   boardFinish: 'Board Finish',


### PR DESCRIPTION
### Motivation
- Make purchased Backgammon (Tavull) cosmetics show up in the game menu by fixing how the account inventory is resolved and when inventory updates are applied. 
- Expose the same core cosmetic categories (tables, table finishes/cloth, chairs, HDRI) in Backgammon as in Chess so store and in-game customization match across games. 
- Ensure board/frame texture tiling matches table texture scale so GLTF/mapped textures appear consistent visually.

### Description
- Added `tables` support to the Tavull inventory and store by importing `MURLAN_TABLE_THEMES` and updating `webapp/src/config/tavullBattleInventoryConfig.js` to include `tables` in `TAVULL_BATTLE_DEFAULT_UNLOCKS`, `TAVULL_BATTLE_OPTION_LABELS`, and `TAVULL_BATTLE_STORE_ITEMS`.
- Exposed the `tables` category in the in-game customization UI by adding `tableThemeIdx`, `TABLE_THEMES`, `ownedTableOptions`, and a `Tables` customization section in `webapp/src/pages/Games/TavullBattleRoyal.jsx`, and wired the reset button to reset the new selection.
- Fix inventory/account resolution and scoped inventory events by reading `accountId` from URL query params in `TavullBattleRoyal.jsx` and filtering `tavullBattleInventoryUpdate` events by `event.detail.accountId` so purchases for the active account are applied.
- Normalized canvas texture repeat values for board and frame textures (changed to matching repeat `[2.2, 2.2]`) in `webapp/src/pages/Games/TavullBattleRoyal.jsx` to make tile scale consistent with table GLTF textures.
- Added `tables` label to `TAVULL_TYPE_LABELS` in `webapp/src/pages/Store.jsx` so the store UI shows `Table Models` for Backgammon.
- Added/updated the cross-game inventory test in `test/inventoryCrossGameConfig.test.js` to assert Tavull store/defaults include Murlan table themes.

### Testing
- Ran `npm test -- test/inventoryCrossGameConfig.test.js --runInBand` and the suite passed (4 tests, all green).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bba90fe540832984ab4a897c8de592)