### PR TITLE
Add BCA eight-ball engine and Race-to-61 variant; enhance pocket glow visuals

### DIFF
--- a/lib/bcaEightBall.js
+++ b/lib/bcaEightBall.js
@@ -1,0 +1,159 @@
+function opponent(player) {
+  return player === 'A' ? 'B' : 'A';
+}
+
+function groupForBall(ballId) {
+  if (ballId >= 1 && ballId <= 7) return 'SOLID';
+  if (ballId >= 9 && ballId <= 15) return 'STRIPE';
+  return null;
+}
+
+function remainingGroupBalls(ballsOnTable, group) {
+  if (!group) return 0;
+  let remaining = 0;
+  for (const id of ballsOnTable) {
+    if (groupForBall(id) === group) remaining += 1;
+  }
+  return remaining;
+}
+
+export class BcaEightBall {
+  constructor() {
+    this.state = {
+      ballsOnTable: new Set(Array.from({ length: 15 }, (_, i) => i + 1)),
+      currentPlayer: 'A',
+      assignments: { A: null, B: null },
+      ballInHand: false,
+      frameOver: false,
+      winner: null,
+      breakInProgress: true
+    };
+  }
+
+  shotTaken(shot = {}) {
+    const s = this.state;
+    const contactOrder = Array.isArray(shot.contactOrder) ? shot.contactOrder : [];
+    const pottedList = Array.isArray(shot.potted) ? shot.potted : [];
+    if (s.frameOver) {
+      return {
+        legal: false,
+        foul: true,
+        reason: 'frame over',
+        potted: [],
+        nextPlayer: s.currentPlayer,
+        ballInHandNext: false,
+        frameOver: true,
+        winner: s.winner
+      };
+    }
+
+    const shooter = s.currentPlayer;
+    const other = opponent(shooter);
+    const first = contactOrder[0];
+    const objectPotted = pottedList.filter((id) => id !== 0 && id >= 1 && id <= 15);
+    const cueScratched = pottedList.includes(0) || Boolean(shot.cueOffTable);
+    const shooterGroup = s.assignments[shooter];
+    const shooterGroupRemaining = remainingGroupBalls(s.ballsOnTable, shooterGroup);
+    const eightLegallyOn = Boolean(shooterGroup && shooterGroupRemaining === 0);
+    const firstContactGroup = Number.isFinite(first) ? groupForBall(first) : null;
+
+    let foul = false;
+    let reason = '';
+
+    if (!first) {
+      foul = true;
+      reason = 'no contact';
+    } else if (shooterGroup) {
+      if (eightLegallyOn) {
+        if (first !== 8) {
+          foul = true;
+          reason = 'wrong first contact';
+        }
+      } else if (firstContactGroup !== shooterGroup) {
+        foul = true;
+        reason = 'wrong first contact';
+      }
+    } else if (first === 8) {
+      foul = true;
+      reason = 'wrong first contact';
+    }
+
+    if (!foul && cueScratched) {
+      foul = true;
+      reason = 'scratch';
+    }
+
+    if (!foul && shot.noCushionAfterContact && objectPotted.length === 0) {
+      foul = true;
+      reason = 'no cushion';
+    }
+
+    const pottedEight = objectPotted.includes(8);
+    if (!foul && pottedEight && !eightLegallyOn) {
+      foul = true;
+      reason = 'potted black early';
+    }
+
+    let frameOver = false;
+    let winner = null;
+    let nextPlayer = shooter;
+    let ballInHandNext = false;
+
+    if (foul) {
+      for (const id of objectPotted) {
+        if (id !== 8) s.ballsOnTable.delete(id);
+      }
+      if (pottedEight) {
+        frameOver = true;
+        winner = other;
+      } else {
+        nextPlayer = other;
+        s.currentPlayer = other;
+        ballInHandNext = true;
+      }
+    } else {
+      for (const id of objectPotted) {
+        s.ballsOnTable.delete(id);
+      }
+      if (!shooterGroup) {
+        const groupsPotted = new Set(objectPotted.map((id) => groupForBall(id)).filter(Boolean));
+        if (groupsPotted.size === 1) {
+          const chosen = groupsPotted.has('SOLID') ? 'SOLID' : 'STRIPE';
+          s.assignments[shooter] = chosen;
+          s.assignments[other] = chosen === 'SOLID' ? 'STRIPE' : 'SOLID';
+        }
+      }
+      if (pottedEight) {
+        frameOver = true;
+        winner = shooter;
+      } else {
+        const activeGroup = s.assignments[shooter];
+        const scoredOwnGroup =
+          objectPotted.some((id) => groupForBall(id) === activeGroup) ||
+          (!activeGroup && objectPotted.some((id) => id !== 8));
+        if (!scoredOwnGroup) {
+          nextPlayer = other;
+          s.currentPlayer = other;
+        }
+      }
+    }
+
+    s.ballInHand = ballInHandNext;
+    if (s.breakInProgress) s.breakInProgress = false;
+    s.frameOver = frameOver;
+    s.winner = winner;
+
+    return {
+      legal: !foul,
+      foul,
+      reason: foul ? reason : undefined,
+      potted: pottedList,
+      nextPlayer,
+      ballInHandNext,
+      frameOver,
+      winner
+    };
+  }
+}
+
+export default BcaEightBall;

--- a/src/rules/PoolRoyaleRules.ts
+++ b/src/rules/PoolRoyaleRules.ts
@@ -2,8 +2,9 @@ import { FrameState, Player, ShotContext, ShotEvent } from '../types';
 import { UkPool } from '../../lib/poolUk8Ball.js';
 import { AmericanBilliards } from '../../lib/americanBilliards.js';
 import { NineBall } from '../../lib/nineBall.js';
+import { BcaEightBall } from '../../lib/bcaEightBall.js';
 
-type PoolVariantId = 'american' | 'uk' | '9ball';
+type PoolVariantId = 'american' | 'race61' | 'uk' | '9ball';
 
 type UkColour = 'blue' | 'red' | 'black' | 'cue';
 
@@ -31,6 +32,16 @@ type UkSerializedState = {
 };
 
 type AmericanSerializedState = {
+  ballsOnTable: number[];
+  currentPlayer: 'A' | 'B';
+  assignments: { A: 'SOLID' | 'STRIPE' | null; B: 'SOLID' | 'STRIPE' | null };
+  ballInHand: boolean;
+  frameOver: boolean;
+  winner: 'A' | 'B' | null;
+  breakInProgress: boolean;
+};
+
+type Race61SerializedState = {
   ballsOnTable: number[];
   currentPlayer: 'A' | 'B';
   scores: { A: number; B: number };
@@ -63,6 +74,12 @@ type PoolMeta =
   | {
       variant: 'american';
       state: AmericanSerializedState;
+      hud: HudInfo;
+      breakInProgress?: boolean;
+    }
+  | {
+      variant: 'race61';
+      state: Race61SerializedState;
       hud: HudInfo;
       breakInProgress?: boolean;
     }
@@ -128,7 +145,37 @@ function applyUkState(game: UkPool, snapshot: UkSerializedState) {
   };
 }
 
-function serializeAmericanState(state: AmericanBilliards['state']): AmericanSerializedState {
+function serializeAmericanState(state: BcaEightBall['state']): AmericanSerializedState {
+  return {
+    ballsOnTable: Array.from(state.ballsOnTable.values()),
+    currentPlayer: state.currentPlayer,
+    assignments: {
+      A: state.assignments?.A ?? null,
+      B: state.assignments?.B ?? null
+    },
+    ballInHand: state.ballInHand,
+    frameOver: state.frameOver,
+    winner: state.winner,
+    breakInProgress: state.breakInProgress
+  };
+}
+
+function applyAmericanState(game: BcaEightBall, snapshot: AmericanSerializedState) {
+  game.state = {
+    ballsOnTable: new Set(snapshot.ballsOnTable),
+    currentPlayer: snapshot.currentPlayer,
+    assignments: {
+      A: snapshot.assignments?.A ?? null,
+      B: snapshot.assignments?.B ?? null
+    },
+    ballInHand: snapshot.ballInHand,
+    frameOver: snapshot.frameOver,
+    winner: snapshot.winner,
+    breakInProgress: snapshot.breakInProgress
+  };
+}
+
+function serializeRace61State(state: AmericanBilliards['state']): Race61SerializedState {
   return {
     ballsOnTable: Array.from(state.ballsOnTable.values()),
     currentPlayer: state.currentPlayer,
@@ -146,7 +193,7 @@ function serializeAmericanState(state: AmericanBilliards['state']): AmericanSeri
   };
 }
 
-function applyAmericanState(game: AmericanBilliards, snapshot: AmericanSerializedState) {
+function applyRace61State(game: AmericanBilliards, snapshot: Race61SerializedState) {
   game.state = {
     ballsOnTable: new Set(snapshot.ballsOnTable),
     currentPlayer: snapshot.currentPlayer,
@@ -240,6 +287,12 @@ export class PoolRoyaleRules {
     const normalized = normalizeVariantId(variantKey);
     if (normalized === 'uk' || normalized === '8balluk' || normalized === 'eightballuk' || normalized === 'uk8') {
       this.variant = 'uk';
+    } else if (
+      normalized === 'race61' ||
+      normalized === 'americanbilliards' ||
+      normalized === 'rotation61'
+    ) {
+      this.variant = 'race61';
     } else if (normalized === '9ball' || normalized === 'nineball' || normalized === '9') {
       this.variant = '9ball';
     } else {
@@ -304,12 +357,12 @@ export class PoolRoyaleRules {
         } satisfies PoolMeta;
         return base;
       }
-      default: {
+      case 'race61': {
         const game = new AmericanBilliards();
         game.state.ballInHand = true;
-        const snapshot = serializeAmericanState(game.state);
-        const ballOn = this.computeAmericanBallOn(snapshot);
-        const scores = this.computeAmericanScores(snapshot);
+        const snapshot = serializeRace61State(game.state);
+        const ballOn = this.computeRace61BallOn(snapshot);
+        const scores = this.computeRace61Scores(snapshot);
         const base: FrameState = {
           balls: [],
           activePlayer: 'A',
@@ -324,6 +377,34 @@ export class PoolRoyaleRules {
           next: ballOn.length > 0 ? ballOn.join(' / ').toLowerCase() : 'frame over',
           phase: 'rotation',
           scores
+        };
+        base.meta = {
+          variant: 'race61',
+          state: snapshot,
+          hud,
+          breakInProgress: true
+        } satisfies PoolMeta;
+        return base;
+      }
+      default: {
+        const game = new BcaEightBall();
+        game.state.ballInHand = true;
+        const snapshot = serializeAmericanState(game.state);
+        const ballOn = this.computeAmericanBallOn(snapshot);
+        const base: FrameState = {
+          balls: [],
+          activePlayer: 'A',
+          players: basePlayers(playerA, playerB),
+          currentBreak: 0,
+          phase: 'REDS_AND_COLORS',
+          redsRemaining: 15,
+          ballOn,
+          frameOver: false
+        };
+        const hud: HudInfo = {
+          next: 'open table',
+          phase: 'groups',
+          scores: { A: 0, B: 0 }
         };
         base.meta = {
           variant: 'american',
@@ -342,6 +423,8 @@ export class PoolRoyaleRules {
         return this.applyUkShot(state, events, context);
       case '9ball':
         return this.applyNineBallShot(state, events, context);
+      case 'race61':
+        return this.applyRace61Shot(state, events, context);
       default:
         return this.applyAmericanShot(state, events, context);
     }
@@ -461,7 +544,7 @@ export class PoolRoyaleRules {
   private applyAmericanShot(state: FrameState, events: ShotEvent[], context: ShotContext): FrameState {
     const meta = state.meta as PoolMeta | undefined;
     const previous = meta && meta.variant === 'american' && meta.state ? meta : null;
-    const game = new AmericanBilliards();
+    const game = new BcaEightBall();
     if (previous) {
       applyAmericanState(game, previous.state);
     } else {
@@ -504,7 +587,7 @@ export class PoolRoyaleRules {
       phase:
         frameOver
           ? 'complete'
-          : 'rotation',
+          : 'groups',
       scores
     };
     const breakInProgress = Boolean(snapshot.breakInProgress);
@@ -539,13 +622,118 @@ export class PoolRoyaleRules {
   }
 
   private computeAmericanScores(state: AmericanSerializedState): { A: number; B: number } {
+    const pottedSolids = 7 - state.ballsOnTable.filter((id) => id >= 1 && id <= 7).length;
+    const pottedStripes = 7 - state.ballsOnTable.filter((id) => id >= 9 && id <= 15).length;
+    return {
+      A: state.assignments.A === 'SOLID' ? pottedSolids : state.assignments.A === 'STRIPE' ? pottedStripes : 0,
+      B: state.assignments.B === 'SOLID' ? pottedSolids : state.assignments.B === 'STRIPE' ? pottedStripes : 0
+    };
+  }
+
+  private computeAmericanBallOn(state: AmericanSerializedState): string[] {
+    if (state.frameOver) return [];
+    const seat = state.currentPlayer;
+    const assignment = state.assignments?.[seat] ?? null;
+    if (!assignment) {
+      const hasSolid = state.ballsOnTable.some((id) => id >= 1 && id <= 7);
+      const hasStripe = state.ballsOnTable.some((id) => id >= 9 && id <= 15);
+      if (hasSolid && hasStripe) return ['SOLID', 'STRIPE'];
+      if (hasSolid) return ['SOLID'];
+      if (hasStripe) return ['STRIPE'];
+      return state.ballsOnTable.includes(8) ? ['BLACK'] : [];
+    }
+    if (assignment === 'SOLID') {
+      const hasSolid = state.ballsOnTable.some((id) => id >= 1 && id <= 7);
+      return hasSolid ? ['SOLID'] : state.ballsOnTable.includes(8) ? ['BLACK'] : [];
+    }
+    const hasStripe = state.ballsOnTable.some((id) => id >= 9 && id <= 15);
+    return hasStripe ? ['STRIPE'] : state.ballsOnTable.includes(8) ? ['BLACK'] : [];
+  }
+
+  private applyRace61Shot(state: FrameState, events: ShotEvent[], context: ShotContext): FrameState {
+    const meta = state.meta as PoolMeta | undefined;
+    const previous = meta && meta.variant === 'race61' && meta.state ? meta : null;
+    const game = new AmericanBilliards();
+    if (previous) {
+      applyRace61State(game, previous.state);
+    } else {
+      game.state.ballInHand = true;
+    }
+    const contactOrder: number[] = [];
+    for (const ev of events) {
+      if (ev.type !== 'HIT') continue;
+      const id = parseNumericId(ev.ballId ?? ev.firstContact);
+      if (id != null) contactOrder.push(id);
+    }
+    const potted: number[] = [];
+    for (const ev of events) {
+      if (ev.type !== 'POTTED') continue;
+      if (isCueBallId(ev.ballId ?? ev.ball)) {
+        potted.push(0);
+      } else {
+        const id = parseNumericId(ev.ballId ?? ev.ball);
+        if (id != null) potted.push(id);
+      }
+    }
+    const result = game.shotTaken({
+      contactOrder,
+      potted,
+      cueOffTable: Boolean(context.cueBallPotted),
+      placedFromHand: Boolean(context.placedFromHand),
+      noCushionAfterContact: Boolean(context.noCushionAfterContact)
+    });
+    const pottedCount = potted.filter((id) => id !== 0).length;
+    const snapshot = serializeRace61State(game.state);
+    const ballOn = this.computeRace61BallOn(snapshot);
+    const scores = this.computeRace61Scores(snapshot);
+    const frameOver = snapshot.frameOver;
+    const nextLabel =
+      ballOn.length === 0
+        ? 'frame over'
+        : ballOn.map((entry) => entry.toLowerCase().replace('_', ' ')).join(' / ');
+    const hud: HudInfo = {
+      next: frameOver ? 'frame over' : nextLabel,
+      phase: frameOver ? 'complete' : 'rotation',
+      scores
+    };
+    const breakInProgress = Boolean(snapshot.breakInProgress);
+    return {
+      ...state,
+      activePlayer: game.state.currentPlayer,
+      players: {
+        A: { ...state.players.A, score: scores.A },
+        B: { ...state.players.B, score: scores.B }
+      },
+      currentBreak:
+        !result.foul && game.state.currentPlayer === state.activePlayer && pottedCount > 0
+          ? (state.currentBreak ?? 0) + pottedCount
+          : 0,
+      ballOn: frameOver ? [] : ballOn,
+      frameOver,
+      winner: snapshot.winner ?? undefined,
+      foul: result.foul
+        ? {
+            points: 0,
+            reason: result.reason ?? 'foul'
+          }
+        : undefined,
+      meta: {
+        variant: 'race61',
+        state: snapshot,
+        hud,
+        breakInProgress
+      } satisfies PoolMeta
+    };
+  }
+
+  private computeRace61Scores(state: Race61SerializedState): { A: number; B: number } {
     return {
       A: state.scores?.A ?? 0,
       B: state.scores?.B ?? 0
     };
   }
 
-  private computeAmericanBallOn(state: AmericanSerializedState): string[] {
+  private computeRace61BallOn(state: Race61SerializedState): string[] {
     if (state.frameOver) return [];
     const lowest = lowestBall(state.ballsOnTable);
     if (lowest == null) return [];

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -138,6 +138,7 @@ function clearPocketGlowMesh(entry) {
   if (!entry?.glowMesh) return;
   entry.glowMesh.parent?.remove?.(entry.glowMesh);
   entry.glowMesh = null;
+  entry.glowTone = null;
 }
 
 function loadCareerAttemptsProgress() {
@@ -1684,12 +1685,15 @@ const POCKET_CAM = Object.freeze({
 const POCKET_CAM_EARLY_TRIGGER_DIST = POCKET_CAM.triggerDist * 1.45; // switch to rail overhead broadcast a little earlier on incoming pocket shots
 const POCKET_POPUP_DURATION_MS = 2500;
 const POCKET_POPUP_LIFT = BALL_R * 2.4;
-const POCKET_GLOW_ENABLED = false;
-const POCKET_GLOW_RADIUS = BALL_R * 1.32;
-const POCKET_GLOW_LIFT = BALL_R * 0.78;
-const POCKET_GLOW_OPACITY = 0.62;
+const POCKET_GLOW_ENABLED = true;
+const POCKET_GLOW_RADIUS = BALL_R * 1.46;
+const POCKET_GLOW_LIFT = BALL_R * 0.92;
+const POCKET_GLOW_OPACITY = 0.72;
+const POCKET_GLOW_RAY_OPACITY = 0.38;
+const POCKET_GLOW_SPARK_OPACITY = 0.5;
+const POCKET_GLOW_POINT_LIGHT_INTENSITY = 1.35;
 const POCKET_GLOW_COLORS = Object.freeze({
-  good: 0x2eea73,
+  good: 0x3bc7ff,
   foul: 0xff4b4b
 });
 const POCKET_CHAOS_MOVING_THRESHOLD = 3;
@@ -2054,6 +2058,64 @@ const POOL_VARIANT_COLOR_SETS = Object.freeze({
       'stripe'
     ]
   },
+  race61: {
+    id: 'race61',
+    label: 'American Billiards (Race to 61)',
+    cueColor: 0xffffff,
+    rackLayout: 'triangle',
+    disableSnookerMarkings: true,
+    objectColors: [
+      0xffc52c,
+      0x0a58ff,
+      0xd32232,
+      0x8f32d6,
+      0xff7c1f,
+      0x0faa60,
+      0x651f28,
+      0x111111,
+      0xffc52c,
+      0x0a58ff,
+      0xd32232,
+      0x8f32d6,
+      0xff7c1f,
+      0x0faa60,
+      0x651f28
+    ],
+    objectNumbers: [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+      11,
+      12,
+      13,
+      14,
+      15
+    ],
+    objectPatterns: [
+      'solid',
+      'solid',
+      'solid',
+      'solid',
+      'solid',
+      'solid',
+      'solid',
+      'solid',
+      'stripe',
+      'stripe',
+      'stripe',
+      'stripe',
+      'stripe',
+      'stripe',
+      'stripe'
+    ]
+  },
   '9ball': {
     id: '9ball',
     label: '9-Ball',
@@ -2098,6 +2160,8 @@ function normalizeBallSetKey(value) {
   const normalized = normalizeVariantKey(value);
   if (
     normalized === 'american' ||
+    normalized === 'race61' ||
+    normalized === 'americanbilliards' ||
     normalized === 'solidsstripes' ||
     normalized === 'solidsandstripes' ||
     normalized === 'solids' ||
@@ -2121,6 +2185,12 @@ function resolvePoolVariant(variantId, ballSet = null) {
     normalized === 'uk8'
   ) {
     key = 'uk';
+  } else if (
+    normalized === 'race61' ||
+    normalized === 'americanbilliards' ||
+    normalized === 'rotation61'
+  ) {
+    key = 'race61';
   }
   const base =
     POOL_VARIANT_COLOR_SETS[key] || POOL_VARIANT_COLOR_SETS[DEFAULT_POOL_VARIANT];
@@ -2142,6 +2212,9 @@ function deriveInHandFromFrame(frame) {
   const meta = frame && typeof frame === 'object' ? frame.meta : null;
   if (!meta || typeof meta !== 'object') return false;
   if (meta.variant === 'american' && meta.state) {
+    return Boolean(meta.state.ballInHand);
+  }
+  if (meta.variant === 'race61' && meta.state) {
     return Boolean(meta.state.ballInHand);
   }
   if (meta.variant === '9ball' && meta.state) {
@@ -8386,6 +8459,25 @@ export function Table3D(
   const pocketGlowGeometry = POCKET_GLOW_ENABLED
     ? new THREE.CircleGeometry(POCKET_GLOW_RADIUS, 36)
     : null;
+  const pocketGlowRayGeometry = POCKET_GLOW_ENABLED
+    ? new THREE.CircleGeometry(POCKET_GLOW_RADIUS * 1.42, 24)
+    : null;
+  const pocketGlowSparkGeometry = (() => {
+    if (!POCKET_GLOW_ENABLED) return null;
+    const sparkCount = 18;
+    const positions = new Float32Array(sparkCount * 3);
+    for (let i = 0; i < sparkCount; i += 1) {
+      const radius = POCKET_GLOW_RADIUS * (0.28 + Math.random() * 0.72);
+      const angle = Math.random() * Math.PI * 2;
+      const idx = i * 3;
+      positions[idx] = Math.cos(angle) * radius;
+      positions[idx + 1] = 0;
+      positions[idx + 2] = Math.sin(angle) * radius;
+    }
+    const geometry = new THREE.BufferGeometry();
+    geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+    return geometry;
+  })();
   const pocketGlowMaterials = POCKET_GLOW_ENABLED
     ? {
         good: new THREE.MeshBasicMaterial({
@@ -8393,6 +8485,7 @@ export function Table3D(
           transparent: true,
           opacity: POCKET_GLOW_OPACITY,
           blending: THREE.AdditiveBlending,
+          depthTest: false,
           depthWrite: false,
           side: THREE.DoubleSide
         }),
@@ -8401,26 +8494,108 @@ export function Table3D(
           transparent: true,
           opacity: POCKET_GLOW_OPACITY,
           blending: THREE.AdditiveBlending,
+          depthTest: false,
           depthWrite: false,
           side: THREE.DoubleSide
+        })
+      }
+    : {};
+  const pocketGlowRayMaterials = POCKET_GLOW_ENABLED
+    ? {
+        good: new THREE.MeshBasicMaterial({
+          color: POCKET_GLOW_COLORS.good,
+          transparent: true,
+          opacity: POCKET_GLOW_RAY_OPACITY,
+          blending: THREE.AdditiveBlending,
+          depthTest: false,
+          depthWrite: false,
+          side: THREE.DoubleSide
+        }),
+        foul: new THREE.MeshBasicMaterial({
+          color: POCKET_GLOW_COLORS.foul,
+          transparent: true,
+          opacity: POCKET_GLOW_RAY_OPACITY,
+          blending: THREE.AdditiveBlending,
+          depthTest: false,
+          depthWrite: false,
+          side: THREE.DoubleSide
+        })
+      }
+    : {};
+  const pocketGlowSparkMaterials = POCKET_GLOW_ENABLED
+    ? {
+        good: new THREE.PointsMaterial({
+          color: POCKET_GLOW_COLORS.good,
+          size: BALL_R * 0.24,
+          transparent: true,
+          opacity: POCKET_GLOW_SPARK_OPACITY,
+          blending: THREE.AdditiveBlending,
+          depthTest: false,
+          depthWrite: false
+        }),
+        foul: new THREE.PointsMaterial({
+          color: POCKET_GLOW_COLORS.foul,
+          size: BALL_R * 0.24,
+          transparent: true,
+          opacity: POCKET_GLOW_SPARK_OPACITY,
+          blending: THREE.AdditiveBlending,
+          depthTest: false,
+          depthWrite: false
         })
       }
     : {};
   const createPocketGlowMesh = (tone = 'good') => {
     if (!POCKET_GLOW_ENABLED || !pocketGlowGeometry) return null;
     const material = pocketGlowMaterials[tone] || pocketGlowMaterials.good;
-    if (!material) return null;
-    const glow = new THREE.Mesh(pocketGlowGeometry, material);
-    glow.rotation.x = -Math.PI / 2;
-    glow.renderOrder = 3;
-    glow.castShadow = false;
-    glow.receiveShadow = false;
-    return glow;
+    const rayMaterial = pocketGlowRayMaterials[tone] || pocketGlowRayMaterials.good;
+    const sparkMaterial = pocketGlowSparkMaterials[tone] || pocketGlowSparkMaterials.good;
+    if (!material || !rayMaterial) return null;
+    const glowGroup = new THREE.Group();
+    const aura = new THREE.Mesh(pocketGlowGeometry, material);
+    aura.rotation.x = -Math.PI / 2;
+    aura.renderOrder = 3;
+    aura.castShadow = false;
+    aura.receiveShadow = false;
+    glowGroup.add(aura);
+    if (pocketGlowRayGeometry) {
+      const rays = new THREE.Mesh(pocketGlowRayGeometry, rayMaterial);
+      rays.rotation.x = -Math.PI / 2;
+      rays.renderOrder = 3;
+      rays.castShadow = false;
+      rays.receiveShadow = false;
+      glowGroup.add(rays);
+      glowGroup.userData.rays = rays;
+    }
+    if (pocketGlowSparkGeometry && sparkMaterial) {
+      const sparks = new THREE.Points(pocketGlowSparkGeometry, sparkMaterial);
+      sparks.rotation.x = -Math.PI / 2;
+      sparks.renderOrder = 3;
+      sparks.frustumCulled = false;
+      glowGroup.add(sparks);
+      glowGroup.userData.sparks = sparks;
+    }
+    const glowLight = new THREE.PointLight(POCKET_GLOW_COLORS[tone] ?? POCKET_GLOW_COLORS.good, 0, BALL_R * 8.5, 2);
+    glowLight.castShadow = false;
+    glowGroup.add(glowLight);
+    glowGroup.userData.aura = aura;
+    glowGroup.userData.light = glowLight;
+    glowGroup.userData.tone = tone;
+    return glowGroup;
   };
   const setPocketGlowTone = (entry, tone = 'good') => {
     if (!entry?.glowMesh) return;
     const material = pocketGlowMaterials[tone] || pocketGlowMaterials.good;
-    if (material) entry.glowMesh.material = material;
+    const rayMaterial = pocketGlowRayMaterials[tone] || pocketGlowRayMaterials.good;
+    const sparkMaterial = pocketGlowSparkMaterials[tone] || pocketGlowSparkMaterials.good;
+    const glowColor = POCKET_GLOW_COLORS[tone] ?? POCKET_GLOW_COLORS.good;
+    const aura = entry.glowMesh.userData?.aura;
+    const rays = entry.glowMesh.userData?.rays;
+    const sparks = entry.glowMesh.userData?.sparks;
+    const light = entry.glowMesh.userData?.light;
+    if (material && aura) aura.material = material;
+    if (rayMaterial && rays) rays.material = rayMaterial;
+    if (sparkMaterial && sparks) sparks.material = sparkMaterial;
+    if (light) light.color.setHex(glowColor);
     entry.glowTone = tone;
   };
   const removePocketDropEntry = (ballId) => {
@@ -24920,7 +25095,7 @@ const powerRef = useRef(hud.power);
         let placedFromHand = false;
         const meta = frameSnapshot?.meta;
         if (meta && typeof meta === 'object') {
-          if (meta.variant === 'american' && meta.state) {
+          if ((meta.variant === 'american' || meta.variant === 'race61') && meta.state) {
             placedFromHand = Boolean(meta.state.ballInHand);
           } else if (meta.variant === '9ball' && meta.state) {
             placedFromHand = Boolean(meta.state.ballInHand);
@@ -28309,7 +28484,10 @@ const powerRef = useRef(hud.power);
             if (isTraining) {
               nextInHand = cueBallPotted;
             } else if (nextMeta && typeof nextMeta === 'object') {
-              if (nextMeta.variant === 'american' && nextMeta.state) {
+              if (
+                (nextMeta.variant === 'american' || nextMeta.variant === 'race61') &&
+                nextMeta.state
+              ) {
                 nextInHand = cueBallPotted || Boolean(nextMeta.state.ballInHand);
               } else if (nextMeta.variant === '9ball' && nextMeta.state) {
                 nextInHand = cueBallPotted || Boolean(nextMeta.state.ballInHand);
@@ -30517,6 +30695,14 @@ const powerRef = useRef(hud.power);
                   b.mesh.scale.set(1, 1, 1);
                   b.mesh.position.set(fromX, BALL_CENTER_Y, fromZ);
                 }
+                const pocketGlow = createPocketGlowMesh('good');
+                if (pocketGlow && table) {
+                  pocketGlow.position.set(c.x, BALL_CENTER_Y - BALL_R * 0.42, c.y);
+                  pocketGlow.visible = true;
+                  table.add(pocketGlow);
+                  dropEntry.glowMesh = pocketGlow;
+                  dropEntry.glowTone = 'good';
+                }
                 pocketDropRef.current.set(b.id, dropEntry);
               } else {
                 removePocketDropEntry(b.id);
@@ -30653,6 +30839,7 @@ const powerRef = useRef(hud.power);
                 mesh.visible = true;
                 mesh.position.set(entry.toX ?? runFromX, targetY, entry.toZ ?? runFromZ);
                 mesh.scale.set(1, 1, 1);
+                clearPocketGlowMesh(entry);
                 return;
               }
               entry.velocityY =
@@ -30686,6 +30873,58 @@ const powerRef = useRef(hud.power);
                 }
               }
               mesh.position.set(posX, entry.currentY, posZ);
+              if (entry.glowMesh) {
+                const elapsedMs = Math.max(0, now - (entry.start ?? now));
+                const descentProgress = THREE.MathUtils.clamp(
+                  (fromY - entry.currentY) / fallDistance,
+                  0,
+                  1
+                );
+                const rampIn = THREE.MathUtils.clamp(elapsedMs / 120, 0, 1);
+                const preDropBoost = 1 - THREE.MathUtils.clamp(descentProgress / 0.72, 0, 1) * 0.22;
+                const fadeOut =
+                  descentProgress > 0.72
+                    ? Math.max(0, 1 - (descentProgress - 0.72) / 0.28)
+                    : 1;
+                const speedBoost = THREE.MathUtils.clamp(
+                  (entry.entrySpeed ?? 0) / (BALL_R * 9),
+                  0.8,
+                  1.2
+                );
+                const glowStrength = THREE.MathUtils.clamp(rampIn * preDropBoost * fadeOut * speedBoost, 0, 1);
+                if (glowStrength <= 0.01) {
+                  entry.glowMesh.visible = false;
+                } else {
+                  const glowY = Math.min(
+                    entry.currentY - BALL_R * 0.45,
+                    BALL_CENTER_Y - BALL_R * 0.34
+                  );
+                  entry.glowMesh.visible = true;
+                  entry.glowMesh.position.set(xDrop, glowY, zDrop);
+                  const aura = entry.glowMesh.userData?.aura;
+                  const rays = entry.glowMesh.userData?.rays;
+                  const sparks = entry.glowMesh.userData?.sparks;
+                  const light = entry.glowMesh.userData?.light;
+                  const pulse = 0.92 + Math.sin(now * 0.018 + key.length) * 0.08;
+                  if (aura) {
+                    aura.scale.setScalar((0.82 + glowStrength * 0.78) * pulse);
+                    aura.material.opacity = POCKET_GLOW_OPACITY * glowStrength;
+                  }
+                  if (rays) {
+                    rays.scale.setScalar(0.95 + glowStrength * 1.25);
+                    rays.rotation.z = now * 0.0018;
+                    rays.material.opacity = POCKET_GLOW_RAY_OPACITY * glowStrength;
+                  }
+                  if (sparks) {
+                    sparks.rotation.z = -now * 0.0026;
+                    sparks.position.y = Math.sin(now * 0.01) * BALL_R * 0.08;
+                    sparks.material.opacity = POCKET_GLOW_SPARK_OPACITY * glowStrength;
+                  }
+                  if (light) {
+                    light.intensity = POCKET_GLOW_POINT_LIGHT_INTENSITY * glowStrength;
+                  }
+                }
+              }
             });
           }
           if (pocketPopupRef.current.length > 0) {
@@ -30900,8 +31139,18 @@ const powerRef = useRef(hud.power);
           clearPocketGlowMesh(entry);
         });
         pocketDropRef.current.clear();
-        pocketGlowGeometry.dispose?.();
-        Object.values(pocketGlowMaterials).forEach((material) => material?.dispose?.());
+        if (typeof pocketGlowGeometry !== 'undefined') pocketGlowGeometry?.dispose?.();
+        if (typeof pocketGlowRayGeometry !== 'undefined') pocketGlowRayGeometry?.dispose?.();
+        if (typeof pocketGlowSparkGeometry !== 'undefined') pocketGlowSparkGeometry?.dispose?.();
+        if (typeof pocketGlowMaterials !== 'undefined') {
+          Object.values(pocketGlowMaterials).forEach((material) => material?.dispose?.());
+        }
+        if (typeof pocketGlowRayMaterials !== 'undefined') {
+          Object.values(pocketGlowRayMaterials).forEach((material) => material?.dispose?.());
+        }
+        if (typeof pocketGlowSparkMaterials !== 'undefined') {
+          Object.values(pocketGlowSparkMaterials).forEach((material) => material?.dispose?.());
+        }
         pocketRestIndexRef.current.clear();
         pocketPopupRef.current.forEach((entry) => {
           entry?.mesh?.parent?.remove?.(entry.mesh);


### PR DESCRIPTION
### Motivation
- Support American/BCA eight-ball gameplay and a new Race-to-61 (American Billiards) variant in the rules engine.
- Surface serialized state and UI integration for those variants so the game logic and HUD remain consistent across frames.
- Improve pocket visual feedback by enabling and enriching the pocket glow effect for clearer pocketing cues.

### Description
- Added a new `lib/bcaEightBall.js` implementing `BcaEightBall` with game state and `shotTaken` rule handling for BCA-style 8-ball (assignments, fouls, scratch, black handling, ball-in-hand, break tracking).
- Updated `src/rules/PoolRoyaleRules.ts` to register a `race61` variant, integrate `BcaEightBall` as the american eight-ball engine, add serialization/apply helpers for `american` and `race61` states (`serializeAmericanState`, `applyAmericanState`, `serializeRace61State`, `applyRace61State`), and added `computeAmericanBallOn`, `computeAmericanScores`, `computeRace61BallOn`, and `computeRace61Scores` helper logic.
- Updated `webapp/src/pages/Games/PoolRoyale.jsx` to enable and expand the pocket glow feature and its assets (aura, rays, sparks, point light), add a `race61` color/number/pattern set, derive `ballInHand` for `race61` frames, create/clear pocket glow mesh lifecycle handling, animate glow during pocket drop, and ensure proper disposal of created geometries/materials.
- Minor UI/flow changes to integrate the new variants into `resolvePoolVariant`, `normalizeBallSetKey`, and frame setup paths; also adjusted HUD phase labels for american/groups handling.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb93f734f883298736c9d78b409eae)