### PR TITLE
Align Tavull (Backgammon) inventory and board textures with Chess Battle Royal

### DIFF
--- a/test/inventoryCrossGameConfig.test.js
+++ b/test/inventoryCrossGameConfig.test.js
@@ -1,5 +1,6 @@
 import {
   CHESS_BATTLE_DEFAULT_UNLOCKS,
+  CHESS_BATTLE_STORE_ITEMS,
   CHESS_TABLE_OPTIONS
 } from '../webapp/src/config/chessBattleInventoryConfig.js';
 import {
@@ -11,6 +12,10 @@ import {
 } from '../webapp/src/config/ludoBattleInventoryConfig.js';
 import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from '../webapp/src/config/murlanThemes.js';
 import { DOMINO_ROYAL_STORE_ITEMS } from '../webapp/src/config/dominoRoyalInventoryConfig.js';
+import {
+  TAVULL_BATTLE_DEFAULT_UNLOCKS,
+  TAVULL_BATTLE_STORE_ITEMS
+} from '../webapp/src/config/tavullBattleInventoryConfig.js';
 
 describe('cross-game inventory alignment', () => {
   test('domino default table follows chess default murlan table', () => {
@@ -47,5 +52,20 @@ describe('cross-game inventory alignment', () => {
     expect(new Set(DOMINO_ROYAL_DEFAULT_UNLOCKS.chairTheme)).toEqual(
       new Set(MURLAN_STOOL_THEMES.map((theme) => theme.id))
     );
+  });
+
+  test('tavull store keeps chess arena items for tables, chairs, cloth, and hdri', () => {
+    const toOptionSet = (items, type) =>
+      new Set(items.filter((item) => item.type === type).map((item) => item.optionId));
+    const chessTables = toOptionSet(CHESS_BATTLE_STORE_ITEMS, 'tables');
+    const chessChairs = toOptionSet(CHESS_BATTLE_STORE_ITEMS, 'chairColor');
+    const chessTableFinish = toOptionSet(CHESS_BATTLE_STORE_ITEMS, 'tableFinish');
+    const chessHdri = toOptionSet(CHESS_BATTLE_STORE_ITEMS, 'environmentHdri');
+
+    expect(toOptionSet(TAVULL_BATTLE_STORE_ITEMS, 'tables')).toEqual(chessTables);
+    expect(toOptionSet(TAVULL_BATTLE_STORE_ITEMS, 'chairColor')).toEqual(chessChairs);
+    expect(toOptionSet(TAVULL_BATTLE_STORE_ITEMS, 'tableFinish')).toEqual(chessTableFinish);
+    expect(toOptionSet(TAVULL_BATTLE_STORE_ITEMS, 'environmentHdri')).toEqual(chessHdri);
+    expect(TAVULL_BATTLE_DEFAULT_UNLOCKS.tables[0]).toBe(CHESS_BATTLE_DEFAULT_UNLOCKS.tables[0]);
   });
 });

--- a/webapp/src/config/tavullBattleInventoryConfig.js
+++ b/webapp/src/config/tavullBattleInventoryConfig.js
@@ -1,5 +1,6 @@
 import { MURLAN_STOOL_THEMES } from './murlanThemes.js';
 import { MURLAN_TABLE_FINISHES } from './murlanTableFinishes.js';
+import { CHESS_TABLE_OPTIONS } from './chessBattleInventoryConfig.js';
 import { FOUR_IN_ROW_BOARD_FRAME_FINISH_OPTIONS } from './fourInRowInventoryConfig.js';
 import {
   POOL_ROYALE_DEFAULT_HDRI_ID,
@@ -103,6 +104,7 @@ export const TAVULL_BATTLE_TRIANGLE_COLOR_OPTIONS = Object.freeze(
 
 export const TAVULL_BATTLE_DEFAULT_UNLOCKS = Object.freeze({
   chairColor: [TAVULL_BATTLE_CHAIR_OPTIONS[0]?.id],
+  tables: [CHESS_TABLE_OPTIONS[0]?.id],
   tableFinish: [MURLAN_TABLE_FINISHES[0]?.id],
   boardFinish: [TAVULL_BATTLE_BOARD_FINISH_OPTIONS[0]?.id],
   frameFinish: [TAVULL_BATTLE_FRAME_FINISH_OPTIONS[0]?.id],
@@ -120,6 +122,7 @@ const reduceLabels = (options, labelKey = 'label') =>
 
 export const TAVULL_BATTLE_OPTION_LABELS = Object.freeze({
   chairColor: reduceLabels(TAVULL_BATTLE_CHAIR_OPTIONS),
+  tables: reduceLabels(CHESS_TABLE_OPTIONS),
   tableFinish: reduceLabels(MURLAN_TABLE_FINISHES),
   boardFinish: reduceLabels(TAVULL_BATTLE_BOARD_FINISH_OPTIONS),
   frameFinish: reduceLabels(TAVULL_BATTLE_FRAME_FINISH_OPTIONS),
@@ -142,6 +145,18 @@ export const TAVULL_BATTLE_STORE_ITEMS = [
     description: finish.description,
     swatches: finish.swatches,
     thumbnail: finish.thumbnail,
+    previewShape: 'table'
+  })),
+  ...CHESS_TABLE_OPTIONS.slice(1).map((theme, idx) => ({
+    id: `tavull-table-${theme.id}`,
+    type: 'tables',
+    optionId: theme.id,
+    name: theme.label,
+    price: theme.price ?? 980 + idx * 40,
+    description:
+      theme.description ||
+      `${theme.label} table with preserved Poly Haven materials.`,
+    thumbnail: theme.thumbnail,
     previewShape: 'table'
   })),
   ...TAVULL_BATTLE_CHAIR_OPTIONS.slice(1).map((option, idx) => ({
@@ -192,12 +207,12 @@ export const TAVULL_BATTLE_STORE_ITEMS = [
     thumbnail: option.thumbnail,
     previewShape: 'board'
   })),
-  ...POOL_ROYALE_HDRI_VARIANTS.slice(1).map((variant, idx) => ({
+  ...POOL_ROYALE_HDRI_VARIANTS.map((variant, idx) => ({
     id: `tavull-hdri-${variant.id}`,
     type: 'environmentHdri',
     optionId: variant.id,
     name: `${variant.name} HDRI`,
-    price: variant.price ?? 780 + idx * 60,
+    price: variant.price ?? 1400 + idx * 30,
     description: `Arena lighting profile based on ${variant.name}.`,
     thumbnail:
       variant.thumbnail ||

--- a/webapp/src/pages/Games/TavullBattleRoyal.jsx
+++ b/webapp/src/pages/Games/TavullBattleRoyal.jsx
@@ -131,6 +131,8 @@ const FALLBACK_SEAT_POSITIONS = [
   { left: '50%', top: '73%' },
   { left: '50%', top: '18%' }
 ];
+const BOARD_FRAME_TEXTURE_SIZE = 2048;
+const BOARD_FRAME_TEXTURE_REPEAT = [2.2, 2.2];
 const BACKGAMMON_DIE_SIZE = 0.116;
 const BACKGAMMON_DIE_CORNER_RADIUS = BACKGAMMON_DIE_SIZE * 0.18;
 const BACKGAMMON_DIE_PIP_RADIUS = BACKGAMMON_DIE_SIZE * 0.093;
@@ -662,7 +664,9 @@ export default function TavullBattleRoyal() {
   const [inventoryVersion, setInventoryVersion] = useState(0);
   const [activeMoveHighlight, setActiveMoveHighlight] = useState(null);
   const [selectedPoint, setSelectedPoint] = useState(null);
-  const accountId = tavullBattleAccountId();
+  const accountId = tavullBattleAccountId(
+    typeof window !== 'undefined' ? window.localStorage?.getItem('accountId') : ''
+  );
   const tavullInventory = useMemo(
     () => getTavullBattleInventory(accountId),
     [accountId, inventoryVersion]
@@ -993,8 +997,8 @@ export default function TavullBattleRoyal() {
 
     const createCanvasTexture = (drawFn, repeat = [1, 1]) => {
       const canvas = document.createElement('canvas');
-      canvas.width = 512;
-      canvas.height = 512;
+      canvas.width = BOARD_FRAME_TEXTURE_SIZE;
+      canvas.height = BOARD_FRAME_TEXTURE_SIZE;
       const ctx = canvas.getContext('2d');
       if (!ctx) return null;
       drawFn(ctx, canvas.width, canvas.height);
@@ -1022,7 +1026,7 @@ export default function TavullBattleRoyal() {
         ctx.lineTo(width, y);
         ctx.stroke();
       }
-    }, [2.5, 2.5]);
+    }, BOARD_FRAME_TEXTURE_REPEAT);
     const frameTexture = createCanvasTexture((ctx, width, height) => {
       const grad = ctx.createLinearGradient(0, 0, width, height);
       grad.addColorStop(0, '#6e3a22');
@@ -1038,7 +1042,7 @@ export default function TavullBattleRoyal() {
         ctx.lineTo(x - 36, height);
         ctx.stroke();
       }
-    }, [4, 1.5]);
+    }, BOARD_FRAME_TEXTURE_REPEAT);
     const triangleTexture = createCanvasTexture((ctx, width, height) => {
       const grad = ctx.createLinearGradient(0, 0, width, height);
       grad.addColorStop(0, '#ffffff');


### PR DESCRIPTION
### Motivation
- Make the Tavull (Backgammon) Battle Royal game match Chess Battle Royal inventory/layout so purchased items are visible and categories (tables, chairs, table finishes, HDRI) are consistent across games.
- Improve board/frame texture mapping so GLTF board/frame textures have comparable resolution and repeat density to table textures.

### Description
- Added Chess-style `tables` support to Tavull inventory: added `tables` default unlock, labels, and store entries derived from `CHESS_TABLE_OPTIONS` so the Tavull store exposes the same table themes as Chess. (`webapp/src/config/tavullBattleInventoryConfig.js`)
- Aligned HDRI entries in Tavull store with Chess by including all `POOL_ROYALE_HDRI_VARIANTS` and matching fallback pricing so environment options match across games. (`webapp/src/config/tavullBattleInventoryConfig.js`)
- Fixed account resolution in the Tavull game to use the persisted `accountId` from `localStorage` when calling `tavullBattleAccountId`, ensuring per-account inventory (purchased items) shows in the in-game menu. (`webapp/src/pages/Games/TavullBattleRoyal.jsx`)
- Increased canvas-based board/frame texture size and unified repeat values by introducing `BOARD_FRAME_TEXTURE_SIZE` and `BOARD_FRAME_TEXTURE_REPEAT`, and updated the canvas texture generation from 512→2048 and repeat values to improve texture density/consistency with table GLTF textures. (`webapp/src/pages/Games/TavullBattleRoyal.jsx`)
- Added/updated cross-game test `test/inventoryCrossGameConfig.test.js` to assert Tavull store parity with Chess for `tables`, `chairColor`, `tableFinish`, and `environmentHdri`.

### Testing
- Ran the targeted test file with `npm test -- test/inventoryCrossGameConfig.test.js --runInBand` and the suite passed (all new and existing assertions succeeded).
- The change was validated by the updated unit test that verifies Tavull store item sets equal Chess store item sets for the affected categories, and the test run reported success.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bba90fe540832984ab4a897c8de592)