### PR TITLE
Four-in-Row: restore chair anchors and raise board/frame assembly

### DIFF
--- a/webapp/src/pages/Games/FourInRowRoyal.jsx
+++ b/webapp/src/pages/Games/FourInRowRoyal.jsx
@@ -46,7 +46,7 @@ const MODEL_SCALE = 0.75;
 const TABLE_RADIUS = 3.4 * MODEL_SCALE;
 const TABLE_HEIGHT = 1.2;
 const CHAIR_DISTANCE = TABLE_RADIUS + 1.3;
-const BOARD_TABLE_CLEARANCE = 0.12;
+const BOARD_TABLE_CLEARANCE = 0.2;
 const BOARD_BASE_THICKNESS = 0.12;
 const BOARD_FRAME_THICKNESS = 0.12;
 const BOARD_FACE_THICKNESS = 0.028;
@@ -548,14 +548,9 @@ export default function FourInRowRoyal() {
 
     const chairTheme = FOUR_IN_ROW_CHAIR_OPTIONS.find((item) => item.id === appearance.chairId) || FOUR_IN_ROW_CHAIR_OPTIONS[0];
     chairMeshesRef.current = [];
-    const sideChairX = boardWidth / 2 + 1.4;
-    const chairPositions = [
-      [-sideChairX, 0, 0],
-      [sideChairX, 0, 0]
-    ];
-    chairPositions.forEach(([x, y, z]) => {
+    [Math.PI / 2, -Math.PI / 2].forEach((angle) => {
       const chair = new THREE.Group();
-      chair.position.set(x, y, z);
+      chair.position.set(Math.cos(angle) * CHAIR_DISTANCE, 0, Math.sin(angle) * CHAIR_DISTANCE);
       chair.lookAt(0, TABLE_HEIGHT, 0);
       chair.userData = { seatColor: chairTheme.primary, legColor: chairTheme.legColor };
       chairMeshesRef.current.push(chair);


### PR DESCRIPTION
### Motivation

- Ensure the Four-in-Row scene matches the previous layout by restoring chair positions to their earlier side/orbit anchors so chairs appear where they did at the specified prior snapshot. 
- Make the board and its surrounding frame appear visually higher above the table so the whole assembly is lifted on-screen.

### Description

- Increased the board/table clearance by changing `BOARD_TABLE_CLEARANCE` from `0.12` to `0.2` in `webapp/src/pages/Games/FourInRowRoyal.jsx` to lift the board/frame visually. 
- Restored the chair anchoring to use orbit positions (`[Math.PI/2, -Math.PI/2]` and `CHAIR_DISTANCE`) so chairs are placed at the previous side angles instead of the earlier `boardWidth` offset logic. 
- Kept chair instantiation as `THREE.Group` and continued to populate those anchors with the GLTF/procedural chair template via the existing `createChairModel` flow.

### Testing

- Ran the production build with `npm --prefix webapp run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbc2230d008329b83713ece445db0c)