### PR TITLE
Fix Backgammon (Tavull) chair thumbnails to match in-game visuals

### DIFF
--- a/webapp/src/config/tavullBattleInventoryConfig.js
+++ b/webapp/src/config/tavullBattleInventoryConfig.js
@@ -57,13 +57,22 @@ const BASE_CHAIR_OPTIONS = [
   thumbnail: swatchThumbnail([item.primary, item.accent, item.highlight])
 }));
 
-const mapStoolThemeToChair = (theme) => ({
-  ...theme,
-  primary: theme.seatColor || theme.primary || '#7c3aed',
-  accent: theme.accent || theme.highlight || theme.seatColor,
-  legColor: theme.legColor || theme.baseColor || '#111827',
-  preserveMaterials: theme.preserveMaterials ?? theme.source === 'polyhaven'
-});
+const buildChairSwatchThumbnail = (primary, accent, legColor) =>
+  swatchThumbnail([primary, accent || primary, legColor || '#111827']);
+
+const mapStoolThemeToChair = (theme) => {
+  const primary = theme.seatColor || theme.primary || '#7c3aed';
+  const accent = theme.accent || theme.highlight || theme.seatColor || primary;
+  const legColor = theme.legColor || theme.baseColor || '#111827';
+  return {
+    ...theme,
+    primary,
+    accent,
+    legColor,
+    thumbnail: buildChairSwatchThumbnail(primary, accent, legColor),
+    preserveMaterials: theme.preserveMaterials ?? theme.source === 'polyhaven'
+  };
+};
 
 export const TAVULL_BATTLE_CHAIR_OPTIONS = Object.freeze([
   ...MURLAN_STOOL_THEMES.map(mapStoolThemeToChair),


### PR DESCRIPTION
### Motivation
- Store thumbnails for Tavull/Backgammon chair options sometimes showed upstream photo thumbnails that did not reflect the actual in-game seat/accent/leg colors, causing mismatch between item listing and the customization preview.

### Description
- Normalize stool/chair themes in `webapp/src/config/tavullBattleInventoryConfig.js` so each mapped chair now derives `primary`, `accent`, and `legColor` and receives a generated swatch thumbnail via `swatchThumbnail(...)` instead of relying on external thumbnails.
- Added `buildChairSwatchThumbnail` and updated `mapStoolThemeToChair` to populate `thumbnail` and keep `preserveMaterials` behavior intact, while preserving existing ids and unlock logic.

### Testing
- Imported the updated module with Node using `node -e "import('./webapp/src/config/tavullBattleInventoryConfig.js').then(m=>console.log('items',m.TAVULL_BATTLE_STORE_ITEMS.length,'chairs',m.TAVULL_BATTLE_CHAIR_OPTIONS.length)).catch(e=>{console.error(e);process.exit(1);})"` and the script executed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbc2ed20f4832993a654d8eed39f3b)