### PR TITLE
Fix Backgammon Royal (Tavull) store preview thumbnail mapping

### DIFF
--- a/bot/routes/account.js
+++ b/bot/routes/account.js
@@ -22,6 +22,7 @@ import { fetchTelegramInfo } from '../utils/telegram.js';
 import { applyStoreItemDelivery } from './store.js';
 import { POOL_ROYALE_STORE_ITEMS } from '../../webapp/src/config/poolRoyaleInventoryConfig.js';
 import { SNOOKER_ROYALE_STORE_ITEMS } from '../../webapp/src/config/snookerRoyalInventoryConfig.js';
+import { TAVULL_BATTLE_STORE_ITEMS } from '../../webapp/src/config/tavullBattleInventoryConfig.js';
 import { applyVoiceCommentaryUnlocks } from './voiceCommentary.js';
 import { getVoiceCatalog } from '../utils/voiceCommentaryCatalog.js';
 import {
@@ -35,13 +36,17 @@ import {
 const router = Router();
 
 const STORE_ITEMS_INDEX = new Map(
-  [...POOL_ROYALE_STORE_ITEMS, ...SNOOKER_ROYALE_STORE_ITEMS].map((item) => [
+  [
+    ...POOL_ROYALE_STORE_ITEMS,
+    ...SNOOKER_ROYALE_STORE_ITEMS,
+    ...TAVULL_BATTLE_STORE_ITEMS
+  ].map((item) => [
     `${item.type}:${item.optionId}`,
     item
   ])
 );
 
-function resolveStoreItemPreview(items = []) {
+export function resolveStoreItemPreview(items = []) {
   for (const item of items) {
     const key = `${item.type}:${item.optionId}`;
     const found = STORE_ITEMS_INDEX.get(key);

--- a/test/inventoryCrossGameConfig.test.js
+++ b/test/inventoryCrossGameConfig.test.js
@@ -14,8 +14,14 @@ import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from '../webapp/src/config/m
 import { DOMINO_ROYAL_STORE_ITEMS } from '../webapp/src/config/dominoRoyalInventoryConfig.js';
 import {
   TAVULL_BATTLE_DEFAULT_UNLOCKS,
+  TAVULL_BATTLE_CHAIR_OPTIONS,
+  TAVULL_BATTLE_BOARD_FINISH_OPTIONS,
+  TAVULL_BATTLE_FRAME_FINISH_OPTIONS,
+  TAVULL_BATTLE_TRIANGLE_COLOR_OPTIONS,
   TAVULL_BATTLE_STORE_ITEMS
 } from '../webapp/src/config/tavullBattleInventoryConfig.js';
+import { MURLAN_TABLE_FINISHES } from '../webapp/src/config/murlanTableFinishes.js';
+import { POOL_ROYALE_HDRI_VARIANTS } from '../webapp/src/config/poolRoyaleInventoryConfig.js';
 
 describe('cross-game inventory alignment', () => {
   test('domino default table follows chess default murlan table', () => {
@@ -67,5 +73,23 @@ describe('cross-game inventory alignment', () => {
     expect(toOptionSet(TAVULL_BATTLE_STORE_ITEMS, 'tableFinish')).toEqual(chessTableFinish);
     expect(toOptionSet(TAVULL_BATTLE_STORE_ITEMS, 'environmentHdri')).toEqual(chessHdri);
     expect(TAVULL_BATTLE_DEFAULT_UNLOCKS.tables[0]).toBe(CHESS_BATTLE_DEFAULT_UNLOCKS.tables[0]);
+  });
+
+  test('tavull store thumbnails match each source option thumbnail', () => {
+    const optionByType = {
+      tableFinish: new Map(MURLAN_TABLE_FINISHES.map((option) => [option.id, option])),
+      tables: new Map(CHESS_TABLE_OPTIONS.map((option) => [option.id, option])),
+      chairColor: new Map(TAVULL_BATTLE_CHAIR_OPTIONS.map((option) => [option.id, option])),
+      boardFinish: new Map(TAVULL_BATTLE_BOARD_FINISH_OPTIONS.map((option) => [option.id, option])),
+      frameFinish: new Map(TAVULL_BATTLE_FRAME_FINISH_OPTIONS.map((option) => [option.id, option])),
+      triangleColor: new Map(TAVULL_BATTLE_TRIANGLE_COLOR_OPTIONS.map((option) => [option.id, option])),
+      environmentHdri: new Map(POOL_ROYALE_HDRI_VARIANTS.map((option) => [option.id, option]))
+    };
+
+    TAVULL_BATTLE_STORE_ITEMS.forEach((item) => {
+      const source = optionByType[item.type]?.get(item.optionId);
+      expect(source).toBeTruthy();
+      expect(item.thumbnail).toBe(source.thumbnail);
+    });
   });
 });


### PR DESCRIPTION
### Motivation
- Purchase receipts and backend preview flows must show the correct thumbnail/label for Backgammon Royal items by `type:optionId`, but Tavull items were missing from the backend lookup causing mismatches.

### Description
- Added `TAVULL_BATTLE_STORE_ITEMS` to the `STORE_ITEMS_INDEX` in `bot/routes/account.js` so lookups by `type:optionId` resolve Tavull items correctly.
- Made `resolveStoreItemPreview` exported from `bot/routes/account.js` to allow test access and reuse.
- Added a regression test in `test/inventoryCrossGameConfig.test.js` that verifies every Tavull store item thumbnail matches its corresponding source option thumbnail for `tableFinish`, `tables`, `chairColor`, `boardFinish`, `frameFinish`, `triangleColor`, and `environmentHdri`.

### Testing
- Ran `npm test -- --runInBand test/inventoryCrossGameConfig.test.js`, which executed the updated cross-game inventory tests and the new thumbnail consistency check; result: PASS (all tests in that suite passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbc2ed20f4832993a654d8eed39f3b)