### PR TITLE
Adjust Four in Row chair placement and raise board/frame

### DIFF
--- a/webapp/src/pages/Games/FourInRowRoyal.jsx
+++ b/webapp/src/pages/Games/FourInRowRoyal.jsx
@@ -46,7 +46,7 @@ const MODEL_SCALE = 0.75;
 const TABLE_RADIUS = 3.4 * MODEL_SCALE;
 const TABLE_HEIGHT = 1.2;
 const CHAIR_DISTANCE = TABLE_RADIUS + 1.3;
-const BOARD_TABLE_CLEARANCE = 0.12;
+const BOARD_TABLE_CLEARANCE = 0.2;
 const BOARD_BASE_THICKNESS = 0.12;
 const BOARD_FRAME_THICKNESS = 0.12;
 const BOARD_FACE_THICKNESS = 0.028;
@@ -548,10 +548,9 @@ export default function FourInRowRoyal() {
 
     const chairTheme = FOUR_IN_ROW_CHAIR_OPTIONS.find((item) => item.id === appearance.chairId) || FOUR_IN_ROW_CHAIR_OPTIONS[0];
     chairMeshesRef.current = [];
-    const sideChairX = boardWidth / 2 + 1.4;
     const chairPositions = [
-      [-sideChairX, 0, 0],
-      [sideChairX, 0, 0]
+      [Math.cos(Math.PI / 2) * CHAIR_DISTANCE, 0, Math.sin(Math.PI / 2) * CHAIR_DISTANCE],
+      [Math.cos(-Math.PI / 2) * CHAIR_DISTANCE, 0, Math.sin(-Math.PI / 2) * CHAIR_DISTANCE]
     ];
     chairPositions.forEach(([x, y, z]) => {
       const chair = new THREE.Group();


### PR DESCRIPTION
### Motivation
- Restore the Four in Row scene layout so chairs return to the previous front/back placement and move the board/frame visually higher to match the intended portrait view and user direction expectations.

### Description
- Increased `BOARD_TABLE_CLEARANCE` from `0.12` to `0.2` in `webapp/src/pages/Games/FourInRowRoyal.jsx` to raise the board/frame assembly.
- Replaced the side-offset chair placement with coordinates computed from `CHAIR_DISTANCE` (front/back along ±Z) so chairs match the prior orientation and sit at `CHAIR_DISTANCE` from the table center.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully (Vite reported only existing chunk-size/dynamic-import warnings).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbc2230d008329b83713ece445db0c)