### PR TITLE
Prevent null ball entries causing runtime crash in Snooker rules

### DIFF
--- a/src/rules/SnookerRoyalRules.ts
+++ b/src/rules/SnookerRoyalRules.ts
@@ -126,6 +126,12 @@ function calculateFoulPoints(ballOn: BallColor[], involved: BallColor[]): number
   return Math.min(7, Math.max(4, ballOnValue, involvedValue));
 }
 
+function isBallState(value: unknown): value is Ball {
+  if (!value || typeof value !== 'object') return false;
+  const candidate = value as Partial<Ball>;
+  return typeof candidate.id === 'string' && typeof candidate.color === 'string';
+}
+
 export class SnookerRoyalRules {
   constructor(_variant?: string | null) {}
 
@@ -160,9 +166,11 @@ export class SnookerRoyalRules {
     const colorsRemaining = Array.isArray(meta?.colorsRemaining)
       ? [...meta.colorsRemaining]
       : [...COLOR_ORDER];
-    const ballsState = Array.isArray(state.balls) && state.balls.length
-      ? state.balls.map((ball) => ({ ...ball }))
-      : buildInitialBalls();
+    const restoredBalls =
+      Array.isArray(state.balls) && state.balls.length
+        ? state.balls.filter(isBallState).map((ball) => ({ ...ball }))
+        : [];
+    const ballsState = restoredBalls.length > 0 ? restoredBalls : buildInitialBalls();
     const ballSnapshot = new Map(
       ballsState.map((ball) => [ball.id, { onTable: ball.onTable, potted: ball.potted }])
     );
@@ -459,14 +467,15 @@ export class SnookerRoyalRules {
       respotColor(nominatedFreeBall);
     }
     if (foulReason && pottedColors.length) {
-      const removed = new Set(
+      const removed = new Set<Exclude<BallColor, 'RED'>>(
         pottedColors
           .map((entry) => entry.color)
-          .filter((color) => color && color !== 'RED')
+          .filter((color): color is Exclude<BallColor, 'RED'> => color !== 'RED')
       );
       if (removed.size) {
         for (let index = colorsRemaining.length - 1; index >= 0; index -= 1) {
-          if (removed.has(colorsRemaining[index])) {
+          const color = colorsRemaining[index];
+          if (color !== 'RED' && removed.has(color)) {
             colorsRemaining.splice(index, 1);
           }
         }


### PR DESCRIPTION
### Motivation
- A runtime error occurred when processing shots where persisted `state.balls` contained null/malformed entries and code attempted to read `.id`, crashing gameplay.

### Description
- Added a defensive type guard `isBallState` in `src/rules/SnookerRoyalRules.ts` to validate persisted ball objects before use.
- Sanitized the `applyShot` restoration path to `filter` and restore only valid ball objects and to fall back to `buildInitialBalls()` when no valid entries remain.
- Tightened the color-removal logic for `colorsRemaining` to preserve TypeScript narrowing and avoid unsafe set membership checks.

### Testing
- Ran `npm run build` to type-check and compile the code; the changes to `SnookerRoyalRules` were applied but the build failed due to an existing unrelated TypeScript error `TS7016: Could not find a declaration file for module '../../lib/bcaEightBall.js'` in `src/rules/PoolRoyaleRules.ts`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbd08d83cc83298722793b24b44816)