### PR TITLE
Align Four-in-Row chairs to table sides and add live table theme switching

### DIFF
--- a/webapp/src/pages/Games/FourInRowRoyal.jsx
+++ b/webapp/src/pages/Games/FourInRowRoyal.jsx
@@ -348,6 +348,7 @@ export default function FourInRowRoyal() {
   const pointerRef = useRef(new THREE.Vector2());
   const envRef = useRef({ map: null, skybox: null, hdriId: null });
   const tablePartsRef = useRef(null);
+  const tableInfoRef = useRef(null);
   const chairMeshesRef = useRef([]);
   const boardMaterialsRef = useRef({ boardFaceMat: null, railMat: null, trimMat: null, holeRimMat: null });
   const keyLightRef = useRef(null);
@@ -543,14 +544,16 @@ export default function FourInRowRoyal() {
     scene.add(key);
 
     const table = createMurlanStyleTable({ arena: scene, renderer, tableRadius: TABLE_RADIUS, tableHeight: TABLE_HEIGHT, tableThemeId: appearance.tableId });
-    tablePartsRef.current = table.parts;
-    applyTableMaterials(table.parts, MURLAN_TABLE_FINISHES.find((f) => f.id === appearance.tableFinish) || MURLAN_TABLE_FINISHES[0]);
+    table.group.userData.themeId = appearance.tableId;
+    tableInfoRef.current = table;
+    tablePartsRef.current = table.materials;
+    applyTableMaterials(table.materials, MURLAN_TABLE_FINISHES.find((f) => f.id === appearance.tableFinish) || MURLAN_TABLE_FINISHES[0], renderer);
 
     const chairTheme = FOUR_IN_ROW_CHAIR_OPTIONS.find((item) => item.id === appearance.chairId) || FOUR_IN_ROW_CHAIR_OPTIONS[0];
     chairMeshesRef.current = [];
     const chairPositions = [
-      [Math.cos(Math.PI / 2) * CHAIR_DISTANCE, 0, Math.sin(Math.PI / 2) * CHAIR_DISTANCE],
-      [Math.cos(-Math.PI / 2) * CHAIR_DISTANCE, 0, Math.sin(-Math.PI / 2) * CHAIR_DISTANCE]
+      [Math.cos(0) * CHAIR_DISTANCE, 0, Math.sin(0) * CHAIR_DISTANCE],
+      [Math.cos(Math.PI) * CHAIR_DISTANCE, 0, Math.sin(Math.PI) * CHAIR_DISTANCE]
     ];
     chairPositions.forEach(([x, y, z]) => {
       const chair = new THREE.Group();
@@ -807,6 +810,9 @@ export default function FourInRowRoyal() {
     return () => {
       cancelAnimationFrame(raf);
       window.removeEventListener('resize', onResize);
+      tableInfoRef.current?.dispose?.();
+      tableInfoRef.current = null;
+      tablePartsRef.current = null;
       renderer.dispose();
       mount.removeChild(renderer.domElement);
     };
@@ -983,8 +989,30 @@ export default function FourInRowRoyal() {
   useEffect(() => {
     if (!tablePartsRef.current) return;
     const finish = MURLAN_TABLE_FINISHES.find((f) => f.id === appearance.tableFinish) || MURLAN_TABLE_FINISHES[0];
-    applyTableMaterials(tablePartsRef.current, finish);
+    applyTableMaterials(tablePartsRef.current, finish, rendererRef.current);
   }, [appearance.tableFinish]);
+
+  useEffect(() => {
+    const scene = sceneRef.current;
+    const renderer = rendererRef.current;
+    if (!scene || !renderer) return;
+    const current = tableInfoRef.current;
+    if (current?.group?.userData?.themeId === appearance.tableId) return;
+
+    current?.dispose?.();
+    const nextTable = createMurlanStyleTable({
+      arena: scene,
+      renderer,
+      tableRadius: TABLE_RADIUS,
+      tableHeight: TABLE_HEIGHT,
+      tableThemeId: appearance.tableId
+    });
+    nextTable.group.userData.themeId = appearance.tableId;
+    tableInfoRef.current = nextTable;
+    tablePartsRef.current = nextTable.materials;
+    const finish = MURLAN_TABLE_FINISHES.find((f) => f.id === appearance.tableFinish) || MURLAN_TABLE_FINISHES[0];
+    applyTableMaterials(nextTable.materials, finish, renderer);
+  }, [appearance.tableId, appearance.tableFinish]);
 
   useEffect(() => {
     const chairTheme = FOUR_IN_ROW_CHAIR_OPTIONS.find((item) => item.id === appearance.chairId) || FOUR_IN_ROW_CHAIR_OPTIONS[0];
@@ -1040,6 +1068,7 @@ export default function FourInRowRoyal() {
   const aiCount = board.flat().filter((x) => x === 'ai').length;
 
   const optionGroups = [
+    { key: 'tableId', label: 'Tables', options: FOUR_IN_ROW_TABLE_OPTIONS.map((item) => ({ id: item.id, label: item.label, thumbnail: item.thumbnail })) },
     { key: 'chairId', label: 'Chairs', options: FOUR_IN_ROW_CHAIR_OPTIONS.map((item) => ({ id: item.id, label: item.label, thumbnail: item.thumbnail })) },
     { key: 'tableFinish', label: 'Table Cloth', options: MURLAN_TABLE_FINISHES.map((item) => ({ id: item.id, label: item.label, thumbnail: item.thumbnail })) },
     { key: 'boardFinish', label: 'Board Finish', options: FOUR_IN_ROW_BOARD_FINISH_OPTIONS.map((item) => ({ id: item.id, label: item.label, thumbnail: item.thumbnail })) },


### PR DESCRIPTION
### Motivation
- Align Four in a Row seating to the left/right sides of the octagon table while preserving the same distance from the table center so the seating visually matches the Chess Battle Royale setup. 
- Reuse the same Murlan/octagon table return contract and materials/textures so the table visuals and cloths are identical to Chess Battle Royale. 
- Allow players to change the table asset/theme at runtime so the table model and finish can be swapped during a match without leaving the game. 

### Description
- Track the created table instance with a new `tableInfoRef` and use the `createMurlanStyleTable` return contract (`materials`) instead of the old `parts` field, and mark `table.group.userData.themeId` with the theme id. (file: `webapp/src/pages/Games/FourInRowRoyal.jsx`).
- Pass the `renderer` into `applyTableMaterials` and update calls to `applyTableMaterials(..., renderer)` so cloth/texture updates are applied correctly. 
- Add a `useEffect` that recreates/disposes the table when `appearance.tableId` (or `appearance.tableFinish`) changes, reapplying the selected finish immediately so users can swap table models live. 
- Move the two player chairs to the left/right sides by changing `chairPositions` coordinates (use `Math.cos(0)` / `Math.cos(Math.PI)` instead of ±PI/2), and expose a `Tables` customization entry in `optionGroups` so table assets are selectable in-game. 
- Clean up created tables on unmount by calling `tableInfoRef.current?.dispose?.()` and clearing `tableInfoRef`/`tablePartsRef` to avoid stale group/material references. 

### Testing
- Ran the production build with `npm run build` in the `webapp/` directory and the build completed successfully (bundle produced; warnings about large chunks only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbd2b7565083299703a41983e95aa1)