### PR TITLE
Align Four in Row seating with Chess Battle Royal assets and share table/chair unlocks

### DIFF
--- a/webapp/src/pages/Games/FourInRowRoyal.jsx
+++ b/webapp/src/pages/Games/FourInRowRoyal.jsx
@@ -62,7 +62,9 @@ const DROP_PREVIEW_DELAY = 0.09;
 const DROP_BASE_DURATION = 0.2;
 const DROP_ROW_DURATION_STEP = 0.03;
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/v1/decoders/';
-const TARGET_CHAIR_SIZE = new THREE.Vector3(1.25, 1.55, 1.25);
+const TARGET_CHAIR_SIZE = new THREE.Vector3(1.3162499970197679, 1.9173749900311232, 1.7001562547683715);
+const TARGET_CHAIR_MIN_Y = -0.8570624993294478;
+const TARGET_CHAIR_CENTER_Z = -0.1553906416893005;
 
 const GRAPHICS_PRESETS = Object.freeze([
   { id: 'balanced', label: 'Balanced', pixelRatioScale: 1, shadowMapSize: 1024 },
@@ -253,10 +255,13 @@ function fitChairModelToFootprint(model) {
     model.scale.multiplyScalar(scale);
   }
   const scaledBox = new THREE.Box3().setFromObject(model);
-  const center = scaledBox.getCenter(new THREE.Vector3());
-  model.position.x += -center.x;
-  model.position.y += -scaledBox.min.y;
-  model.position.z += -center.z;
+  const scaledCenter = scaledBox.getCenter(new THREE.Vector3());
+  const offset = new THREE.Vector3(
+    -scaledCenter.x,
+    TARGET_CHAIR_MIN_Y - scaledBox.min.y,
+    TARGET_CHAIR_CENTER_Z - scaledCenter.z
+  );
+  model.position.add(offset);
 }
 
 function tintChairModel(model, chairTheme) {
@@ -549,8 +554,8 @@ export default function FourInRowRoyal() {
     const chairTheme = FOUR_IN_ROW_CHAIR_OPTIONS.find((item) => item.id === appearance.chairId) || FOUR_IN_ROW_CHAIR_OPTIONS[0];
     chairMeshesRef.current = [];
     const chairPositions = [
-      [Math.cos(Math.PI / 2) * CHAIR_DISTANCE, 0, Math.sin(Math.PI / 2) * CHAIR_DISTANCE],
-      [Math.cos(-Math.PI / 2) * CHAIR_DISTANCE, 0, Math.sin(-Math.PI / 2) * CHAIR_DISTANCE]
+      [-CHAIR_DISTANCE, 0, 0],
+      [CHAIR_DISTANCE, 0, 0]
     ];
     chairPositions.forEach(([x, y, z]) => {
       const chair = new THREE.Group();

--- a/webapp/src/utils/fourInRowInventory.js
+++ b/webapp/src/utils/fourInRowInventory.js
@@ -3,6 +3,7 @@ import {
   FOUR_IN_ROW_BATTLE_DEFAULT_UNLOCKS,
   FOUR_IN_ROW_BATTLE_OPTION_LABELS
 } from '../config/fourInRowInventoryConfig.js'
+import { getChessBattleInventory } from './chessBattleInventory.js'
 
 const STORAGE_KEY = 'fourInRowInventoryByAccount'
 let memoryInventories = {}
@@ -56,6 +57,11 @@ export const getFourInRowInventory = (accountId = 'guest') => {
   const id = fourInRowAccountId(accountId)
   const db = readStore()
   const resolved = normalizeInventory(db[id])
+  const chessInventory = getChessBattleInventory(id)
+  ;['chairColor', 'tables', 'tableFinish'].forEach((sharedKey) => {
+    const merged = new Set([...(resolved[sharedKey] || []), ...(chessInventory?.[sharedKey] || [])])
+    resolved[sharedKey] = Array.from(merged)
+  })
   if (typeof window !== 'undefined') {
     writeStore({ ...db, [id]: resolved })
   }


### PR DESCRIPTION
### Motivation
- Place Four in Row chairs on the left/right sides of the octagon table to match the requested on-screen layout while preserving the existing distance from the table center. 
- Reuse the exact chair/table footprint and calibration from Chess Battle Royal so the same models/textures behave identically across games. 
- Let players use chess-owned table/chair cosmetics in Four in Row so items bought in Chess are available in this arena and can be changed during gameplay.

### Description
- Updated `FourInRowRoyal.jsx` to use the Chess Battle Royal chair calibration values by setting `TARGET_CHAIR_SIZE` and adding `TARGET_CHAIR_MIN_Y` and `TARGET_CHAIR_CENTER_Z`. 
- Reworked `fitChairModelToFootprint` in `FourInRowRoyal.jsx` to apply the same center/vertical/forward offset math used by Chess so loaded chair models align and scale consistently. 
- Moved the two Four in Row chairs to the left/right sides by changing chair spawn positions to `[-CHAIR_DISTANCE, 0, 0]` and `[CHAIR_DISTANCE, 0, 0]` while keeping `CHAIR_DISTANCE` unchanged. 
- Updated `fourInRowInventory.js` to import `getChessBattleInventory` and merge Chess unlocks for `chairColor`, `tables`, and `tableFinish` into the Four in Row resolved inventory so shared cosmetics are usable across games.

### Testing
- Ran `npx eslint webapp/src/pages/Games/FourInRowRoyal.jsx webapp/src/utils/fourInRowInventory.js`; the command completed but both files are covered by repository ignore patterns so only warnings about ignore were reported. 
- Ran `npm run build`; TypeScript build failed due to an unrelated pre-existing declaration error in `src/rules/PoolRoyaleRules.ts` (missing declaration for `../../lib/bcaEightBall.js`), so the repo-wide build could not be completed here. 
- No automated visual/UX tests were run in this environment; changes are focused on 3D placement and inventory merging and should be validated in-app to confirm model alignment and cosmetic availability.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbd2b7565083299703a41983e95aa1)