### PR TITLE
Make Pool Royale cue apply shot at impact (defer physics until forward strike)

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -25145,36 +25145,17 @@ const powerRef = useRef(hud.power);
               spinSide = baseSide * SIDE_SPIN_MULTIPLIER * topspinPowerScale;
             }
           }
-          cue.vel.copy(base);
-          if (cue.spin) {
-            cue.spin.set(spinSide, spinTop);
-          }
-          if (cue.omega) {
-            cue.omega.set(0, 0, 0);
-            TMP_VEC3_A.set(shotAimDir.x, 0, shotAimDir.y);
-            if (TMP_VEC3_A.lengthSq() > 1e-8) TMP_VEC3_A.normalize();
-            TMP_VEC3_B.set(-TMP_VEC3_A.z, 0, TMP_VEC3_A.x);
-            if (TMP_VEC3_B.lengthSq() > 1e-8) TMP_VEC3_B.normalize();
-            TMP_VEC3_C.copy(TMP_VEC3_B).multiplyScalar(scaledSpin.x * BALL_R);
-            TMP_VEC3_C.y += scaledSpin.y * BALL_R;
-            const impulseMag = BALL_MASS * base.length();
-            TMP_VEC3_D.copy(TMP_VEC3_A).multiplyScalar(impulseMag);
-            TMP_VEC3_E.copy(TMP_VEC3_C).cross(TMP_VEC3_D);
-            cue.omega.addScaledVector(TMP_VEC3_E, 1 / BALL_INERTIA);
-          }
-          if (cue.pendingSpin) cue.pendingSpin.set(0, 0);
-          cue.spinMode = 'standard';
-          cue.swerveStrength = 0;
-          cue.swervePowerStrength = 0;
-          resetSpinRef.current?.();
-          cueLiftRef.current.lift = 0;
-          cueLiftRef.current.startLift = 0;
-          cue.impacted = false;
-          cue.launchDir = shotAimDir.clone().normalize();
-          maxPowerLiftTriggered = false;
-          cue.lift = 0;
-          cue.liftVel = 0;
-          playCueHit(clampedPower * 0.6);
+          const impactPayload = {
+            base,
+            aimDir: shotAimDir,
+            physicsSpin: {
+              x: spinSide,
+              y: spinTop
+            },
+            clampedPower,
+            liftStrength,
+            applied: false
+          };
 
           if (cameraRef.current && sphRef.current) {
             if (forceImmediateRailOverheadView) {
@@ -25411,9 +25392,11 @@ const powerRef = useRef(hud.power);
               forwardOnly: Boolean(strokeProfile.forwardOnly),
               animationStyle: strokeStyle,
               motionTechnique: strokeProfile.motion ?? strokeStyle,
-              releaseStartsFromCurrentPull: true
+              releaseStartsFromCurrentPull: true,
+              onImpact: () => applyShotAtImpact(impactPayload)
             };
           } else {
+            applyShotAtImpact(impactPayload);
             cueStick.visible = false;
             cueAnimating = false;
             cuePullCurrentRef.current = 0;


### PR DESCRIPTION
### Motivation
- Players observed the cue stick staying pulled after releasing the power slider because the shot physics were applied immediately on release rather than when the cue visually struck the ball.
- The change aligns visual cue animation and physics: pull back → push forward → impact → apply shot.

### Description
- Stop applying the cue-ball velocity/spin immediately on slider release and instead build an `impactPayload` containing `base`, `aimDir`, `physicsSpin`, `clampedPower`, and `liftStrength` (file: `webapp/src/pages/Games/PoolRoyale.jsx`).
- Wire the cue stroke state `onImpact` callback to `applyShotAtImpact(impactPayload)` so the physics are applied exactly when the cue stroke timeline reaches impact during the forward push. 
- Add a safe fallback that immediately calls `applyShotAtImpact(impactPayload)` when cue stroke animation is disabled so behavior remains consistent in non-animated modes.
- Adjust how `physicsSpin` is populated in the payload (pack `spinSide`/`spinTop`) and remove the previous direct mutation path that set `cue.vel`, `cue.spin`, `cue.omega`, etc., at release.

### Testing
- Ran the cue stroke timeline unit tests with `npm test -- test/poolRoyaleCueStrokeTimeline.test.js --runInBand`, which passed.
- Ran the cue impact orchestration tests with `npm test -- test/cueShotImpact.test.js --runInBand`, which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbee2086548329bf3ca42edae935a8)