### PR TITLE
Fix cue stick forward strike after power slider release

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -25408,7 +25408,9 @@ const powerRef = useRef(hud.power);
               strikeDip: 0.003,
               wobbleAmount: 0.0018,
               strikeImpactThreshold: strokeProfile.impactThreshold ?? 0.9,
-              forwardOnly: Boolean(strokeProfile.forwardOnly),
+              // Slider release should drive an immediate forward strike from the
+              // currently pulled cue position back to contact.
+              forwardOnly: true,
               animationStyle: strokeStyle,
               motionTechnique: strokeProfile.motion ?? strokeStyle,
               releaseStartsFromCurrentPull: true


### PR DESCRIPTION
### Motivation
- Players reported the cue stick remains pulled after releasing the power slider instead of pushing forward to contact, so the change ensures the visible cue stroke matches the slider-release action and triggers a forward strike animation.

### Description
- Force `forwardOnly: true` when creating the live cue stroke state for slider-release shots in `webapp/src/pages/Games/PoolRoyale.jsx` so the cue visibly pushes from the pulled position back to the impact point and does not remain stuck.

### Testing
- Ran `npm test -- test/poolRoyaleCueStrokeTimeline.test.js --runInBand` and the suite passed (4 tests, all passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbee2086548329bf3ca42edae935a8)