### PR TITLE
Use u_qpfzpydtro-dice-142528.mp3 for dice roll SFX across dice-based games

### DIFF
--- a/webapp/src/components/DiceRoller.jsx
+++ b/webapp/src/components/DiceRoller.jsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { getGameVolume } from '../utils/sound.js';
 import { createDiceRollAudio } from '../utils/diceAudio.js';
 import Dice from './Dice.jsx';
 import { socket } from '../utils/socket.js';
@@ -41,7 +40,7 @@ export default function DiceRoller({
 
   useEffect(() => {
     const handler = () => {
-      if (soundRef.current) soundRef.current.volume = getGameVolume();
+      if (soundRef.current) soundRef.current.volume = 1;
     };
     window.addEventListener('gameVolumeChanged', handler);
     return () => window.removeEventListener('gameVolumeChanged', handler);

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5529,6 +5529,7 @@ const REPLAY_CUE_STROKE_LEAD_IN_MS = 240; // begin replay in the charge phase so
 const REPLAY_CUE_RELEASE_VISIBILITY_MULTIPLIER = 1.42; // stretch the forward push more so cue impact is readable in replay
 const BREAK_DICE_ROLL_DELAY_MS = 560;
 const BREAK_DICE_RESULT_PAUSE_MS = 720;
+const BREAK_DICE_ROLL_SOUND_URL = '/assets/sounds/u_qpfzpydtro-dice-142528.mp3';
 const REPLAY_CUE_MIN_PULLBACK_MS = 360; // keep replay wind-up visible without consuming the whole replay window
 const REPLAY_CUE_MIN_RELEASE_MS = 620; // keep forward cue strike visible for a clear cue-ball hit
 const CUE_STROKE_POST_HIT_CAMERA_HOLD_MS = 420;
@@ -14515,6 +14516,14 @@ const powerRef = useRef(hud.power);
   }, [breakRollState]);
 
   const breakRollPending = breakRollState !== 'done';
+  const playBreakDiceRollSfx = useCallback(() => {
+    if (isGameMuted()) return;
+    try {
+      const audio = new Audio(BREAK_DICE_ROLL_SOUND_URL);
+      audio.volume = 1;
+      void audio.play().catch(() => {});
+    } catch {}
+  }, []);
   const rollBreakDie = useCallback(
     async (seat = 'ai') => {
       if (breakRollBusyRef.current || breakRollState === 'done') return;
@@ -14522,6 +14531,7 @@ const powerRef = useRef(hud.power);
       const seatLabel = seat === 'ai' ? 'AI' : 'You';
       setBreakRollMessage(`${seatLabel} rolling from behind the line...`);
       await new Promise((resolve) => window.setTimeout(resolve, BREAK_DICE_ROLL_DELAY_MS));
+      playBreakDiceRollSfx();
       const value = await rollBreakDie3DRef.current(seat);
       setBreakDiceValues((prev) => ({ ...prev, [seat]: value }));
       await new Promise((resolve) => window.setTimeout(resolve, BREAK_DICE_RESULT_PAUSE_MS));
@@ -14558,7 +14568,7 @@ const powerRef = useRef(hud.power);
       setFrameState((prev) => ({ ...prev, activePlayer: breakerSeat }));
       breakRollBusyRef.current = false;
     },
-    [breakRollState]
+    [breakRollState, playBreakDiceRollSfx]
   );
 
   useEffect(() => {

--- a/webapp/src/pages/Games/TavullBattleRoyal.jsx
+++ b/webapp/src/pages/Games/TavullBattleRoyal.jsx
@@ -126,7 +126,7 @@ const MOVE_SOUND_URL =
   'https://raw.githubusercontent.com/lichess-org/lila/master/public/sound/standard/Move.mp3';
 const WIN_SOUND_URL =
   'https://raw.githubusercontent.com/lichess-org/lila/master/public/sound/standard/End.mp3';
-const DICE_ROLL_SOUND_URL = '/assets/sounds/dice-roll.mp3';
+const DICE_ROLL_SOUND_URL = '/assets/sounds/u_qpfzpydtro-dice-142528.mp3';
 const FALLBACK_SEAT_POSITIONS = [
   { left: '50%', top: '73%' },
   { left: '50%', top: '18%' }
@@ -1702,7 +1702,7 @@ export default function TavullBattleRoyal() {
     setAiThinking(true);
     setSelectedPoint(null);
     sceneBundleRef.current?.animateDiceThrow?.(visibleAiDice, 1);
-    playSfx(DICE_ROLL_SOUND_URL, 0.75);
+    playSfx(DICE_ROLL_SOUND_URL, 1);
 
     const timeoutId = window.setTimeout(() => {
       if (!isMountedRef.current) return;
@@ -1742,7 +1742,7 @@ export default function TavullBattleRoyal() {
     const visibleDice = [d1, d2];
     const useDice = d1 === d2 ? [d1, d1, d1, d1] : visibleDice;
     sceneBundleRef.current?.animateDiceThrow?.(visibleDice, 0);
-    playSfx(DICE_ROLL_SOUND_URL, 0.75);
+    playSfx(DICE_ROLL_SOUND_URL, 1);
     const timeoutId = window.setTimeout(() => {
       if (!isMountedRef.current) return;
       setIsRollingDice(false);

--- a/webapp/src/utils/diceAudio.js
+++ b/webapp/src/utils/diceAudio.js
@@ -1,4 +1,4 @@
-import { getGameVolume } from './sound.js'
+const DICE_ROLL_SOUND_URL = '/assets/sounds/u_qpfzpydtro-dice-142528.mp3'
 
 export const DICE_SFX_PRESETS = Object.freeze([
   { id: 'classic-wood', label: 'Classic Wood' },
@@ -8,97 +8,26 @@ export const DICE_SFX_PRESETS = Object.freeze([
   { id: 'arcade-pop', label: 'Arcade Pop' }
 ])
 
-let sharedCtx = null
-
-function getAudioCtx () {
-  if (typeof window === 'undefined') return null
-  const Ctx = window.AudioContext || window.webkitAudioContext
-  if (!Ctx) return null
-  if (!sharedCtx) sharedCtx = new Ctx()
-  if (sharedCtx.state === 'suspended') {
-    sharedCtx.resume().catch(() => {})
-  }
-  return sharedCtx
-}
-
-function tick (ctx, time, frequency, duration, type = 'square', gain = 0.18) {
-  const osc = ctx.createOscillator()
-  const amp = ctx.createGain()
-  osc.type = type
-  osc.frequency.setValueAtTime(frequency, time)
-  amp.gain.setValueAtTime(0.0001, time)
-  amp.gain.exponentialRampToValueAtTime(Math.max(0.0001, gain), time + 0.004)
-  amp.gain.exponentialRampToValueAtTime(0.0001, time + duration)
-  osc.connect(amp)
-  amp.connect(ctx.destination)
-  osc.start(time)
-  osc.stop(time + duration + 0.01)
-}
-
-function noiseBurst (ctx, time, duration = 0.035, gain = 0.1, highpass = 450) {
-  const buffer = ctx.createBuffer(1, Math.floor(ctx.sampleRate * duration), ctx.sampleRate)
-  const channel = buffer.getChannelData(0)
-  for (let i = 0; i < channel.length; i += 1) channel[i] = (Math.random() * 2 - 1) * (1 - i / channel.length)
-
-  const src = ctx.createBufferSource()
-  src.buffer = buffer
-  const hp = ctx.createBiquadFilter()
-  hp.type = 'highpass'
-  hp.frequency.value = highpass
-  const amp = ctx.createGain()
-  amp.gain.setValueAtTime(gain, time)
-  amp.gain.exponentialRampToValueAtTime(0.0001, time + duration)
-  src.connect(hp)
-  hp.connect(amp)
-  amp.connect(ctx.destination)
-  src.start(time)
-}
-
-function playPreset (ctx, presetId, volume) {
-  const now = ctx.currentTime + 0.01
-  const v = Math.max(0.02, Math.min(1, volume))
-  switch (presetId) {
-    case 'marble-rattle':
-      tick(ctx, now, 680, 0.045, 'triangle', 0.14 * v)
-      tick(ctx, now + 0.035, 740, 0.05, 'triangle', 0.12 * v)
-      noiseBurst(ctx, now + 0.01, 0.03, 0.06 * v, 700)
-      break
-    case 'metallic-clack':
-      tick(ctx, now, 920, 0.035, 'sawtooth', 0.1 * v)
-      tick(ctx, now + 0.022, 480, 0.06, 'square', 0.08 * v)
-      noiseBurst(ctx, now, 0.025, 0.05 * v, 1200)
-      break
-    case 'soft-felt':
-      tick(ctx, now, 320, 0.08, 'sine', 0.12 * v)
-      tick(ctx, now + 0.028, 260, 0.09, 'sine', 0.1 * v)
-      noiseBurst(ctx, now + 0.014, 0.035, 0.03 * v, 300)
-      break
-    case 'arcade-pop':
-      tick(ctx, now, 540, 0.03, 'square', 0.12 * v)
-      tick(ctx, now + 0.04, 820, 0.025, 'triangle', 0.1 * v)
-      tick(ctx, now + 0.07, 620, 0.02, 'square', 0.08 * v)
-      break
-    case 'classic-wood':
-    default:
-      tick(ctx, now, 430, 0.055, 'triangle', 0.14 * v)
-      tick(ctx, now + 0.03, 360, 0.05, 'triangle', 0.1 * v)
-      noiseBurst(ctx, now + 0.008, 0.028, 0.05 * v, 520)
-      break
-  }
-}
-
 export function createDiceRollAudio ({ muted = false, presetId = 'classic-wood' } = {}) {
+  void presetId
+  const audio = typeof Audio !== 'undefined' ? new Audio(DICE_ROLL_SOUND_URL) : null
+  if (audio) {
+    audio.preload = 'auto'
+    audio.volume = 1
+  }
   return {
     muted,
-    volume: getGameVolume(),
+    volume: 1,
     currentTime: 0,
-    pause () {},
+    pause () {
+      audio?.pause()
+    },
     play () {
       if (this.muted) return Promise.resolve()
-      const ctx = getAudioCtx()
-      if (!ctx) return Promise.resolve()
-      playPreset(ctx, presetId, this.volume)
-      return Promise.resolve()
+      if (!audio) return Promise.resolve()
+      audio.volume = Math.max(0, Math.min(1, this.volume))
+      audio.currentTime = 0
+      return audio.play().catch(() => {})
     }
   }
 }

--- a/webapp/src/utils/ludoSfx.js
+++ b/webapp/src/utils/ludoSfx.js
@@ -1,5 +1,6 @@
-// Lightweight procedural SFX inspired by open-source Web Audio patterns (MIT-style oscillator envelopes).
 let sharedCtx = null;
+const LUDO_DICE_ROLL_SOUND_URL = '/assets/sounds/u_qpfzpydtro-dice-142528.mp3';
+let ludoDiceRollAudio = null;
 
 function getAudioContext() {
   if (typeof window === 'undefined') return null;
@@ -31,100 +32,16 @@ function scheduleTone(ctx, { startAt, duration, fromHz, toHz, volume = 0.4, type
   osc.stop(startAt + duration + 0.02);
 }
 
-function scheduleNoiseBurst(ctx, { startAt, duration, volume = 0.2, bandHz = 1800 }) {
-  const sampleCount = Math.max(1, Math.floor(ctx.sampleRate * duration));
-  const buffer = ctx.createBuffer(1, sampleCount, ctx.sampleRate);
-  const data = buffer.getChannelData(0);
-  for (let i = 0; i < sampleCount; i += 1) {
-    const t = i / sampleCount;
-    const contour = 0.45 + 0.55 * Math.sin(Math.PI * t);
-    data[i] = (Math.random() * 2 - 1) * contour;
-  }
-
-  const source = ctx.createBufferSource();
-  source.buffer = buffer;
-
-  const filter = ctx.createBiquadFilter();
-  filter.type = 'bandpass';
-  filter.frequency.setValueAtTime(Math.max(300, bandHz), startAt);
-  filter.Q.setValueAtTime(1.2, startAt);
-
-  const gain = ctx.createGain();
-  gain.gain.setValueAtTime(0.0001, startAt);
-  gain.gain.exponentialRampToValueAtTime(Math.max(0.0001, volume), startAt + Math.min(0.03, duration * 0.4));
-  gain.gain.exponentialRampToValueAtTime(0.0001, startAt + duration);
-
-  source.connect(filter);
-  filter.connect(gain);
-  gain.connect(ctx.destination);
-  source.start(startAt);
-  source.stop(startAt + duration + 0.01);
-}
-
-function scheduleRumble(ctx, { startAt, duration, volume = 0.12, fromHz = 120, toHz = 70 }) {
-  scheduleTone(ctx, {
-    startAt,
-    duration,
-    fromHz,
-    toHz,
-    volume,
-    type: 'sawtooth'
-  });
-}
-
 export function playLudoDiceRollSfx({ volume = 1, muted = false } = {}) {
   if (muted || volume <= 0) return;
-  const ctx = getAudioContext();
-  if (!ctx) return;
-  const now = ctx.currentTime + 0.004;
-  const baseVolume = Math.min(0.58, Math.max(0.2, volume * 0.46));
-
-  // Procedural, source-code-only dice roll SFX (no binary assets), shaped from free Web Audio synthesis patterns.
-  scheduleRumble(ctx, {
-    startAt: now,
-    duration: 0.28,
-    volume: baseVolume * 0.3,
-    fromHz: 132,
-    toHz: 74
-  });
-
-  scheduleNoiseBurst(ctx, {
-    startAt: now,
-    duration: 0.24,
-    volume: baseVolume * 0.85,
-    bandHz: 1580
-  });
-
-  scheduleNoiseBurst(ctx, {
-    startAt: now + 0.085,
-    duration: 0.18,
-    volume: baseVolume * 0.52,
-    bandHz: 1120
-  });
-
-  const impacts = [0.02, 0.055, 0.09, 0.125, 0.165, 0.205, 0.235];
-  impacts.forEach((offset, index) => {
-    const decay = Math.max(0.18, 1 - index * 0.11);
-    const impactVolume = baseVolume * (0.78 + Math.random() * 0.28) * decay;
-    const impactStart = now + offset + (Math.random() - 0.5) * 0.01;
-    scheduleTone(ctx, {
-      startAt: impactStart,
-      duration: 0.038 + Math.random() * 0.026,
-      fromHz: 490 - index * 41 + Math.random() * 24,
-      toHz: 130 + Math.random() * 46,
-      volume: impactVolume,
-      type: index % 2 === 0 ? 'triangle' : 'sine'
-    });
-  });
-
-  scheduleTone(ctx, {
-    startAt: now + 0.22,
-    duration: 0.14,
-    fromHz: 180,
-    toHz: 86,
-    volume: baseVolume * 0.52,
-    type: 'triangle'
-  });
+  if (typeof Audio === 'undefined') return;
+  if (!ludoDiceRollAudio) {
+    ludoDiceRollAudio = new Audio(LUDO_DICE_ROLL_SOUND_URL);
+    ludoDiceRollAudio.preload = 'auto';
+  }
+  ludoDiceRollAudio.volume = 1;
+  ludoDiceRollAudio.currentTime = 0;
+  ludoDiceRollAudio.play().catch(() => {});
 }
 
 export function playLudoTokenStepSfx({ volume = 1, muted = false } = {}) {


### PR DESCRIPTION
### Motivation
- Standardize dice-roll sound across multiple games by using the provided `/assets/sounds/u_qpfzpydtro-dice-142528.mp3` asset so players hear a single, consistent dice effect. 
- Replace procedural or mixed implementations so the same file is used for Lucky Card, Snake & Ladder, Ludo Battle Royal, Pool Royale (break roll), and Backgammon/Tavull Battle Royal. 
- Ensure dice playback is audible at maximum volume (100%) while still honoring mute controls.

### Description
- Switched the shared dice helper to use the asset by default in `webapp/src/utils/diceAudio.js` and force playback volume to `1.0` for the created `Audio` instance. 
- Updated the `DiceRoller` component to keep `createDiceRollAudio` playback volume at `1` so consumers (Lucky Card, Dice popup flows, Snake & Ladder) play the asset at full volume (`webapp/src/components/DiceRoller.jsx`). 
- Replaced Ludo’s procedural dice roll SFX with the same asset and ensured playback at 100% in `webapp/src/utils/ludoSfx.js`. 
- Pointed the Tavull/Backgammon dice constant to the new asset and raised the dice-roll playback scale from `0.75` to `1` for both AI and player rolls in `webapp/src/pages/Games/TavullBattleRoyal.jsx`. 
- Added break-dice roll playback in Pool Royale using the same asset at full volume and wired it into the break-roll flow (`webapp/src/pages/Games/PoolRoyale.jsx`). 
- No binary files were added to the PR; references were changed to the already-present asset under `webapp/public/assets/sounds/`.

### Testing
- Ran `npx eslint` against the modified files (`webapp/src/pages/Games/PoolRoyale.jsx`, `webapp/src/components/DiceRoller.jsx`, `webapp/src/pages/Games/TavullBattleRoyal.jsx`, `webapp/src/utils/diceAudio.js`, `webapp/src/utils/ludoSfx.js`) and the run completed with ignore-pattern warnings only and no lint errors. 
- Verified that the changed code paths create and play an `Audio` instance pointing at `/assets/sounds/u_qpfzpydtro-dice-142528.mp3` and that volume is set to `1` when not muted. 
- No additional automated unit tests were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc05252f8483299503273add862c57)