### PR TITLE
Use Domino placement SFX for Checkers and Backgammon moves

### DIFF
--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -203,8 +203,7 @@ const TARGET_CHAIR_SIZE = new THREE.Vector3(
 );
 const TARGET_CHAIR_MIN_Y = -0.8570624993294478;
 const TARGET_CHAIR_CENTER_Z = -0.1553906416893005;
-const MOVE_SOUND_URL =
-  'https://raw.githubusercontent.com/lichess-org/lila/master/public/sound/standard/Move.mp3';
+const MOVE_SOUND_URL = '/assets/sounds/domino-pieces-1-32112 (mp3cut.net).mp3';
 const TAP_MAX_DISTANCE_PX = 16;
 const TAP_MAX_DURATION_MS = 340;
 const TOUCH_TAP_MAX_DISTANCE_PX = 40;

--- a/webapp/src/pages/Games/TavullBattleRoyal.jsx
+++ b/webapp/src/pages/Games/TavullBattleRoyal.jsx
@@ -122,8 +122,7 @@ const QUALITY_OPTIONS = Object.freeze([
   { id: 'balanced', label: 'Balanced', pixelRatio: 1.5, shadows: true },
   { id: 'ultra', label: 'Ultra', pixelRatio: 2, shadows: true }
 ]);
-const MOVE_SOUND_URL =
-  'https://raw.githubusercontent.com/lichess-org/lila/master/public/sound/standard/Move.mp3';
+const MOVE_SOUND_URL = '/assets/sounds/domino-pieces-1-32112 (mp3cut.net).mp3';
 const WIN_SOUND_URL =
   'https://raw.githubusercontent.com/lichess-org/lila/master/public/sound/standard/End.mp3';
 const DICE_ROLL_SOUND_URL = '/assets/sounds/u_qpfzpydtro-dice-142528.mp3';


### PR DESCRIPTION
### Motivation
- Unify move audio across board games by reusing the Domino Royale tile-placement SFX for piece moves in Checkers Battle Royal and Backgammon (Tavull) Royale to improve consistency and reuse an existing asset.

### Description
- Replaced the `MOVE_SOUND_URL` constant in `webapp/src/pages/Games/CheckersBattleRoyal.jsx` and `webapp/src/pages/Games/TavullBattleRoyal.jsx` to point to the existing asset `/assets/sounds/domino-pieces-1-32112 (mp3cut.net).mp3` without adding any binary files or other assets.

### Testing
- Ran `git diff --check` to validate the patch for whitespace/errors and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc0bb1d37083299bf5ca0e2105da39)