### PR TITLE
Fix Pool Royale rules for 9-ball/race61 and 8-ball black-ball foul detection

### DIFF
--- a/lib/americanBilliards.js
+++ b/lib/americanBilliards.js
@@ -2,10 +2,9 @@ export class AmericanBilliards {
   constructor (options = {}) {
     const targetScore = Number.isFinite(options.targetScore) ? options.targetScore : 61
     this.state = {
-      ballsOnTable: new Set(Array.from({ length: 15 }, (_, i) => i + 1)),
+      ballsOnTable: new Set(Array.from({ length: 9 }, (_, i) => i + 1)),
       currentPlayer: 'A',
       scores: { A: 0, B: 0 },
-      assignments: { A: null, B: null },
       ballInHand: false,
       foulStreak: { A: 0, B: 0 },
       frameOver: false,
@@ -43,12 +42,12 @@ export class AmericanBilliards {
     const first = contactOrder[0]
     const lowest = lowestBall(s.ballsOnTable)
 
-    if (!wasBreakShot && !foul && !first) {
+    if (!foul && !first) {
       foul = true
       reason = 'no contact'
     }
 
-    if (!wasBreakShot && !foul && !isLegalFirstContact(first, { lowest })) {
+    if (!foul && !isLegalFirstContact(first, { lowest })) {
       foul = true
       reason = 'wrong first contact'
     }
@@ -59,7 +58,7 @@ export class AmericanBilliards {
     }
 
     const pottedBalls = pottedList.filter(id => id !== 0)
-    if (!wasBreakShot && !foul && shot.noCushionAfterContact && pottedBalls.length === 0) {
+    if (!foul && shot.noCushionAfterContact && pottedBalls.length === 0) {
       foul = true
       reason = 'no cushion'
     }
@@ -75,9 +74,9 @@ export class AmericanBilliards {
       ballInHandNext = true
       s.foulStreak[current] = (s.foulStreak[current] ?? 0) + 1
       s.foulStreak[opp] = 0
-      // Rotation convention in this implementation: potted object balls stay down on a foul.
       for (const id of pottedBalls) {
-        if (id >= 1 && id <= 15) s.ballsOnTable.delete(id)
+        if (id === 9) s.ballsOnTable.add(id)
+        else if (id >= 1 && id <= 9) s.ballsOnTable.delete(id)
       }
     } else {
       s.foulStreak[current] = 0
@@ -94,17 +93,12 @@ export class AmericanBilliards {
     if (!frameOver && s.scores[current] >= target) {
       frameOver = true
       winner = current
-    } else if (!frameOver && s.ballsOnTable.size === 0) {
-      frameOver = true
-      if (s.scores.A > s.scores.B) winner = 'A'
-      else if (s.scores.B > s.scores.A) winner = 'B'
-      else winner = 'TIE'
     }
 
     if (!frameOver) {
       if (foul) {
         nextPlayer = opp
-      } else if (pottedBalls.some((id) => id >= 1 && id <= 15)) {
+      } else if (pottedBalls.some((id) => id >= 1 && id <= 9)) {
         nextPlayer = current
       } else {
         nextPlayer = opp

--- a/lib/bcaEightBall.js
+++ b/lib/bcaEightBall.js
@@ -49,8 +49,8 @@ export class BcaEightBall {
 
     const shooter = s.currentPlayer;
     const other = opponent(shooter);
-    const first = contactOrder[0];
     const objectPotted = pottedList.filter((id) => id !== 0 && id >= 1 && id <= 15);
+    const first = Number.isFinite(contactOrder[0]) ? contactOrder[0] : (objectPotted[0] ?? null);
     const cueScratched = pottedList.includes(0) || Boolean(shot.cueOffTable);
     const shooterGroup = s.assignments[shooter];
     const shooterGroupRemaining = remainingGroupBalls(s.ballsOnTable, shooterGroup);

--- a/test/americanBilliards.test.js
+++ b/test/americanBilliards.test.js
@@ -2,11 +2,10 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 import { AmericanBilliards } from '../lib/americanBilliards.js'
 
-test('open table: first contact cannot be the 8-ball', () => {
+test('first contact must be lowest ball (including break shot)', () => {
   const game = new AmericanBilliards()
-  game.state.breakInProgress = false
   const res = game.shotTaken({
-    contactOrder: [2],
+    contactOrder: [3],
     potted: [],
     cueOffTable: false
   })
@@ -30,6 +29,23 @@ test('legal break pots score by ball value and keep shooter at table', () => {
   assert.equal(game.state.breakInProgress, false)
   assert.equal(game.state.scores.A, 3)
   assert.equal(breakShot.nextPlayer, 'A')
+})
+
+test('potting 9-ball legally scores points but does not auto-win before 61', () => {
+  const game = new AmericanBilliards()
+  game.state.breakInProgress = false
+  game.state.ballsOnTable = new Set([1, 9])
+
+  const res = game.shotTaken({
+    contactOrder: [1],
+    potted: [9],
+    cueOffTable: false
+  })
+
+  assert.equal(res.foul, false)
+  assert.equal(res.frameOver, false)
+  assert.equal(res.winner, null)
+  assert.equal(res.scores.A, 9)
 })
 
 
@@ -99,20 +115,18 @@ test('reaching 61 points wins the frame immediately', () => {
   assert.equal(res.scores.A, 61)
 })
 
-test('if all balls are gone before 61, higher score wins', () => {
+test('on foul, potted 9 is spotted back up', () => {
   const game = new AmericanBilliards()
   game.state.breakInProgress = false
-  game.state.currentPlayer = 'B'
-  game.state.scores = { A: 40, B: 50 }
-  game.state.ballsOnTable = new Set([15])
+  game.state.ballsOnTable = new Set([1, 9])
 
   const res = game.shotTaken({
-    contactOrder: [15],
-    potted: [15],
+    contactOrder: [1],
+    potted: [9, 0],
     cueOffTable: false
   })
 
-  assert.equal(res.foul, false)
-  assert.equal(res.frameOver, true)
-  assert.equal(res.winner, 'B')
+  assert.equal(res.foul, true)
+  assert.equal(res.reason, 'scratch')
+  assert.equal(game.state.ballsOnTable.has(9), true)
 })

--- a/test/bcaEightBall.test.js
+++ b/test/bcaEightBall.test.js
@@ -1,0 +1,20 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { BcaEightBall } from '../lib/bcaEightBall.js';
+
+test('legal black pot is not marked foul when hit event is missing but pot is present', () => {
+  const game = new BcaEightBall();
+  game.state.breakInProgress = false;
+  game.state.assignments = { A: 'SOLID', B: 'STRIPE' };
+  game.state.ballsOnTable = new Set([8]);
+
+  const res = game.shotTaken({
+    contactOrder: [],
+    potted: [8],
+    cueOffTable: false
+  });
+
+  assert.equal(res.foul, false);
+  assert.equal(res.frameOver, true);
+  assert.equal(res.winner, 'A');
+});


### PR DESCRIPTION
### Motivation
- Ensure each Pool Royale variant (9-ball, American/race61, 8-ball UK/BCA) uses its own rule-set and that race61 behaves like rotation/9-ball but with a race-to-61 scoring rule.
- Prevent valid BCA 8-ball black-ball finishes from being misclassified as fouls when HIT telemetry is missing.

### Description
- Updated `lib/americanBilliards.js` to implement 9-ball-style rotation behavior with race-to-61 scoring by: using a 1–9 rack, enforcing lowest-ball-first contact on all shots (including break), normalizing scratch/no-cushion handling, scoring potted balls by value, spotting the 9 back onto the table on a foul, and ensuring a legal pot of 9 only adds points (does not auto-win unless target score reached). (`lib/americanBilliards.js`)
- Changed `lib/bcaEightBall.js` to infer `first` contact from potted object balls when the `HIT` event is missing, so a legal black pot without an explicit hit event is not incorrectly judged a foul. (`lib/bcaEightBall.js`)
- Updated tests: adjusted `test/americanBilliards.test.js` to reflect the race61/9-ball-style behavior and added `test/bcaEightBall.test.js` to cover the black-pot-without-hit telemetry case. (`test/americanBilliards.test.js`, `test/bcaEightBall.test.js`)

### Testing
- Ran targeted unit suites with `npm test -- --runInBand test/nineBall.test.js test/americanBilliards.test.js test/bcaEightBall.test.js`.
- Result: all targeted suites passed: `PASS test/bcaEightBall.test.js`, `PASS test/americanBilliards.test.js`, `PASS test/nineBall.test.js` (3/3 test suites passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc13643550832981e3e98c33cc1a18)