### PR TITLE
Fix Pool Royale cleanup crash on pocket glow teardown

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -30867,7 +30867,10 @@ const powerRef = useRef(hud.power);
         updatePocketCameraState(false);
         pocketCamerasRef.current.clear();
         pocketDropRef.current.forEach((entry) => {
-          clearPocketGlow(entry);
+          if (entry?.glowMesh) {
+            entry.glowMesh.parent?.remove?.(entry.glowMesh);
+            entry.glowMesh = null;
+          }
         });
         pocketDropRef.current.clear();
         pocketGlowGeometry.dispose?.();


### PR DESCRIPTION
### Motivation
- Prevent a runtime `ReferenceError: clearPocketGlow is not defined` during the Pool Royale teardown where pocket drop entries are iterated while `clearPocketGlow` is out of scope.

### Description
- Replace the out-of-scope `clearPocketGlow(entry)` call in the render teardown with inline safe removal that checks `entry?.glowMesh`, calls `entry.glowMesh.parent?.remove?.(entry.glowMesh)`, and sets `entry.glowMesh = null` before clearing the map.

### Testing
- Ran `npm --prefix webapp run build`, which completed successfully (production build finished without errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc2b13845c832999db2afcea775edf)