### PR TITLE
Guard pocket glow cleanup to avoid ReferenceError in Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -30873,8 +30873,12 @@ const powerRef = useRef(hud.power);
           }
         });
         pocketDropRef.current.clear();
-        pocketGlowGeometry.dispose?.();
-        Object.values(pocketGlowMaterials).forEach((material) => material?.dispose?.());
+        if (typeof pocketGlowGeometry !== 'undefined' && pocketGlowGeometry) {
+          pocketGlowGeometry.dispose?.();
+        }
+        if (typeof pocketGlowMaterials !== 'undefined' && pocketGlowMaterials) {
+          Object.values(pocketGlowMaterials).forEach((material) => material?.dispose?.());
+        }
         pocketRestIndexRef.current.clear();
         pocketPopupRef.current.forEach((entry) => {
           entry?.mesh?.parent?.remove?.(entry.mesh);


### PR DESCRIPTION
### Motivation
- A runtime `ReferenceError: pocketGlowGeometry is not defined` occurred during Pool Royale teardown in some variants (notably the American variant) when pocket glow resources were not present, causing a crash.

### Description
- Added defensive `typeof` checks before disposing `pocketGlowGeometry` and iterating `pocketGlowMaterials` in the cleanup/teardown path of `webapp/src/pages/Games/PoolRoyale.jsx` to avoid referencing unbound variables.

### Testing
- Ran a production build with `npm --prefix webapp run build` which completed successfully (Vite emitted only non-blocking chunking warnings).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc31679c2083298b80af365f9b82a2)