### PR TITLE
Guard pocket glow cleanup to prevent ReferenceError in Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -30873,8 +30873,12 @@ const powerRef = useRef(hud.power);
           }
         });
         pocketDropRef.current.clear();
-        pocketGlowGeometry.dispose?.();
-        Object.values(pocketGlowMaterials).forEach((material) => material?.dispose?.());
+        if (typeof pocketGlowGeometry !== 'undefined') {
+          pocketGlowGeometry.dispose?.();
+        }
+        if (typeof pocketGlowMaterials !== 'undefined') {
+          Object.values(pocketGlowMaterials).forEach((material) => material?.dispose?.());
+        }
         pocketRestIndexRef.current.clear();
         pocketPopupRef.current.forEach((entry) => {
           entry?.mesh?.parent?.remove?.(entry.mesh);


### PR DESCRIPTION
### Motivation
- A runtime `ReferenceError: pocketGlowGeometry is not defined` appeared during teardown paths for the American billiards variant when pocket glow resources were not present in scope. 
- The change prevents crashes during unmount/re-init by avoiding direct references to potentially undefined pocket glow identifiers.

### Description
- Added `typeof` guards around `pocketGlowGeometry.dispose?.()` and the `Object.values(pocketGlowMaterials).forEach(...)` call in the Pool Royale teardown to ensure disposal only runs when those identifiers exist. 
- The fix is localized to the effect cleanup in `webapp/src/pages/Games/PoolRoyale.jsx` to avoid changing rendering behavior when glow is enabled. 

### Testing
- Ran `npm test -- --runInBand test/americanBilliards.test.js` and the test suite passed. 
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx`, which completed with a note that the file is ignored by the current ESLint config (no lint errors reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc31679c2083298b80af365f9b82a2)