### PR TITLE
Add pocket glow meshes & resource management for pocketed balls

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -15166,6 +15166,92 @@ const powerRef = useRef(hud.power);
   const rollBreakDie3DRef = useRef(async () => 1);
   const pocketDropRef = useRef(new Map());
   const pocketRestIndexRef = useRef(new Map());
+  const pocketGlowResourcesRef = useRef({
+    geometry: null,
+    materials: {},
+    initialized: false
+  });
+  const ensurePocketGlowResources = useCallback(() => {
+    const cache = pocketGlowResourcesRef.current;
+    if (!cache) return { geometry: null, materials: {} };
+    if (cache.initialized) return cache;
+    cache.initialized = true;
+    if (!POCKET_GLOW_ENABLED) {
+      cache.geometry = null;
+      cache.materials = {};
+      return cache;
+    }
+    cache.geometry = new THREE.CircleGeometry(POCKET_GLOW_RADIUS, 36);
+    cache.materials = {
+      good: new THREE.MeshBasicMaterial({
+        color: POCKET_GLOW_COLORS.good,
+        transparent: true,
+        opacity: POCKET_GLOW_OPACITY,
+        blending: THREE.AdditiveBlending,
+        depthWrite: false,
+        side: THREE.DoubleSide
+      }),
+      foul: new THREE.MeshBasicMaterial({
+        color: POCKET_GLOW_COLORS.foul,
+        transparent: true,
+        opacity: POCKET_GLOW_OPACITY,
+        blending: THREE.AdditiveBlending,
+        depthWrite: false,
+        side: THREE.DoubleSide
+      })
+    };
+    return cache;
+  }, []);
+  const createPocketGlowMesh = useCallback(
+    (tone = 'good') => {
+      if (!POCKET_GLOW_ENABLED) return null;
+      const { geometry, materials } = ensurePocketGlowResources();
+      if (!geometry) return null;
+      const material = materials[tone] || materials.good;
+      if (!material) return null;
+      const glow = new THREE.Mesh(geometry, material);
+      glow.rotation.x = -Math.PI / 2;
+      glow.renderOrder = 3;
+      glow.castShadow = false;
+      glow.receiveShadow = false;
+      return glow;
+    },
+    [ensurePocketGlowResources]
+  );
+  const setPocketGlowTone = useCallback(
+    (entry, tone = 'good') => {
+      if (!entry?.glowMesh || !POCKET_GLOW_ENABLED) return;
+      const { materials } = ensurePocketGlowResources();
+      const material = materials[tone] || materials.good;
+      if (material) entry.glowMesh.material = material;
+      entry.glowTone = tone;
+    },
+    [ensurePocketGlowResources]
+  );
+  const clearPocketGlow = useCallback((entry) => {
+    if (!entry?.glowMesh) return;
+    entry.glowMesh.parent?.remove?.(entry.glowMesh);
+    entry.glowMesh = null;
+  }, []);
+  const removePocketDropEntry = useCallback(
+    (ballId) => {
+      const entry = pocketDropRef.current.get(ballId);
+      if (entry) {
+        clearPocketGlow(entry);
+      }
+      pocketDropRef.current.delete(ballId);
+    },
+    [clearPocketGlow]
+  );
+  const disposePocketGlowResources = useCallback(() => {
+    const cache = pocketGlowResourcesRef.current;
+    if (!cache) return;
+    cache.geometry?.dispose?.();
+    Object.values(cache.materials || {}).forEach((material) => material?.dispose?.());
+    cache.geometry = null;
+    cache.materials = {};
+    cache.initialized = false;
+  }, []);
   const pocketPopupRef = useRef([]);
   const pocketPopupPendingRef = useRef([]);
   const captureBallSnapshotRef = useRef(null);
@@ -15215,12 +15301,10 @@ const powerRef = useRef(hud.power);
       applyBallSnapshotRef.current(snapshot);
     }
     pocketDropRef.current.forEach((entry) => {
-      if (entry?.glowMesh) {
-        entry.glowMesh.parent?.remove?.(entry.glowMesh);
-      }
+      clearPocketGlow(entry);
     });
     pocketDropRef.current.clear();
-  }, []);
+  }, [clearPocketGlow]);
   const resetMatchState = useCallback(
     ({ broadcast = false } = {}) => {
       const nextFrame = initialFrame;
@@ -30445,8 +30529,19 @@ const powerRef = useRef(hud.power);
                   rollStartAt: null,
                   rollProgress: 0,
                   pocketId,
-                  resting: false
+                  resting: false,
+                  glowMesh: null,
+                  glowTone: 'good'
                 };
+                if (table) {
+                  const glow = createPocketGlowMesh('good');
+                  if (glow) {
+                    const baseY = pocketTopY + POCKET_GLOW_LIFT;
+                    glow.position.set(c.x, baseY, c.y);
+                    table.add(glow);
+                    dropEntry.glowMesh = glow;
+                  }
+                }
                 if (b.mesh) {
                   b.mesh.visible = true;
                   b.mesh.scale.set(1, 1, 1);
@@ -30873,8 +30968,7 @@ const powerRef = useRef(hud.power);
           }
         });
         pocketDropRef.current.clear();
-        pocketGlowGeometry.dispose?.();
-        Object.values(pocketGlowMaterials).forEach((material) => material?.dispose?.());
+        disposePocketGlowResources();
         pocketRestIndexRef.current.clear();
         pocketPopupRef.current.forEach((entry) => {
           entry?.mesh?.parent?.remove?.(entry.mesh);


### PR DESCRIPTION
### Motivation
- Provide a visual glow under pockets for pocketed balls to improve feedback and make pocket state easier to see while ensuring proper resource lifecycle management.

### Description
- Introduce `pocketGlowResourcesRef` and `ensurePocketGlowResources` to lazily create and cache a shared glow `geometry` and `materials` when `POCKET_GLOW_ENABLED` is active.
- Add `createPocketGlowMesh`, `setPocketGlowTone`, `clearPocketGlow`, `removePocketDropEntry`, and `disposePocketGlowResources` utilities for creating, updating, clearing, and disposing glow meshes and materials.
- Attach `glowMesh` and `glowTone` to pocket drop entries and create a glow mesh when a ball is pocketed and a `table` is available.
- Replace ad-hoc glow removals with `clearPocketGlow` in rematch/reset logic and call `disposePocketGlowResources` during component cleanup to avoid leaks.

### Testing
- Ran `yarn lint` and `yarn build` successfully with no errors.
- Ran the test suite with `yarn test` and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc31679c2083298b80af365f9b82a2)