### PR TITLE
Make Pool Royale cue visibly push forward on shot release

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -25352,7 +25352,15 @@ const powerRef = useRef(hud.power);
           const strikeHoldDuration = strokeProfile.holdDuration ?? LIVE_CUE_IMPACT_HOLD_MS;
           const pullbackDuration = strokeProfile.pullbackDuration ?? 0;
           const startTime = performance.now();
-          const impactPos = idlePos.clone();
+          const strikePushDistance = THREE.MathUtils.lerp(
+            CUE_FOLLOW_THROUGH_MIN,
+            CUE_FOLLOW_THROUGH_MAX,
+            clampedPower
+          );
+          const impactPos = idlePos.clone().addScaledVector(
+            dir,
+            strikePushDistance
+          );
           const followPos = impactPos.clone();
           const followDurationResolved = strikeHoldDuration;
           const recoverDuration = strokeProfile.recoverDuration ?? 0;


### PR DESCRIPTION
### Motivation
- Improve player feedback by ensuring the cue stick advances forward when a shot is triggered instead of visually remaining pulled back, and scale that forward motion with shot power for consistent feel.

### Description
- Compute a `strikePushDistance` by lerping between `CUE_FOLLOW_THROUGH_MIN` and `CUE_FOLLOW_THROUGH_MAX` using `clampedPower`, then set `impactPos = idlePos + dir * strikePushDistance` so the cue pushes forward on impact; change made in `webapp/src/pages/Games/PoolRoyale.jsx`.

### Testing
- Ran `npm test -- --runInBand test/poolRoyaleCueStrokeTimeline.test.js` and it passed.
- Ran `npm test -- --runInBand test/cueShotImpact.test.js` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bccc8ce9588329ab69521b5d721a12)