### PR TITLE
Fix cue stick staying pulled on shot release (cue tip follows pullback + enforce release forward motion)

### DIFF
--- a/Assets/Scripts/Gameplay/CueController.cs
+++ b/Assets/Scripts/Gameplay/CueController.cs
@@ -150,7 +150,8 @@ namespace Aiming
 
             if (cueTip != null)
             {
-                cueTip.position = cueBall.position - _aimDirection * idleTipGap;
+                float tipDistance = idleTipGap + _currentPullback;
+                cueTip.position = cueBall.position - _aimDirection * tipDistance;
             }
         }
 
@@ -189,7 +190,7 @@ namespace Aiming
             {
                 elapsed += Time.deltaTime;
                 float t = Mathf.Clamp01(elapsed / Mathf.Max(strikeDuration, 0.001f));
-                float eased = strikeEaseIn.Evaluate(t);
+                float eased = Mathf.Max(strikeEaseIn.Evaluate(t), t * 0.2f);
 
                 _currentPullback = Mathf.Lerp(startPullback, 0f, eased);
                 UpdateCuePose();


### PR DESCRIPTION
### Motivation
- Players observed the cue stick visually remaining pulled back when a shot is triggered, so the cue must visibly move forward during the release to match the applied impulse and improve feedback.

### Description
- Update `UpdateCuePose` so the cue tip position follows the live pullback by using `idleTipGap + _currentPullback` for `cueTip.position` instead of a fixed idle gap.
- Adjust `StrikeRoutine` easing to `Mathf.Max(strikeEaseIn.Evaluate(t), t * 0.2f)` to guarantee early forward progress at the start of the release and avoid a stalled visual state before the strike.
- Changes are contained in `Assets/Scripts/Gameplay/CueController.cs` and preserve existing strike/physics paths while improving visual timing.

### Testing
- Attempted to run `dotnet test billiards.Tests/Billiards.Tests.csproj` but the environment lacks the `dotnet` SDK so the test run failed with `dotnet: command not found`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bccc8ce9588329ab69521b5d721a12)