### PR TITLE
Implement anchored Pool Royal cue shot state flow

### DIFF
--- a/webapp/public/power-slider.js
+++ b/webapp/public/power-slider.js
@@ -8,6 +8,7 @@ export class PowerSlider {
       step = 1,
       cueSrc = '',
       onChange,
+      onStart,
       onCommit,
       theme = 'default',
       labels = false
@@ -19,6 +20,7 @@ export class PowerSlider {
     this.max = max;
     this.step = step;
     this.onChange = onChange;
+    this.onStart = onStart;
     this.onCommit = onCommit;
     this.locked = false;
 
@@ -220,6 +222,7 @@ export class PowerSlider {
     if (this.locked) return;
     e.preventDefault();
     this.dragging = true;
+    if (typeof this.onStart === 'function') this.onStart(this.value);
     this.el.classList.add('ps-no-animate');
     this.el.setPointerCapture(e.pointerId);
     this._updateFromClientY(e.clientY);

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5537,6 +5537,11 @@ const CUE_STROKE_POST_HIT_CAMERA_HOLD_MS = 420;
 // quick push forward and a short hold before snapping back to idle.
 const LIVE_CUE_FORWARD_DURATION_MS = 180;
 const LIVE_CUE_IMPACT_HOLD_MS = 90;
+const CUE_STROKE_IDLE_GAP = 0.01;
+const CUE_STROKE_CONTACT_GAP = 0.001;
+const CUE_STROKE_PULL_RANGE = 0.34;
+const CUE_STROKE_STRIKE_DURATION_MS = 120;
+const CUE_STROKE_HOLD_DURATION_MS = 50;
 const CAMERA_SWITCH_MIN_HOLD_MS = 420;
 const CUEBALL_EARLY_CAMERA_SWITCH_SPEED = BALL_R * 24;
 const CUEBALL_CAMERA_SWITCH_MIN_TRAVEL = BALL_R * 1.15;
@@ -15121,6 +15126,8 @@ const powerRef = useRef(hud.power);
   const aimCurveControlRef = useRef(new THREE.Vector3());
   const cuePullTargetRef = useRef(0);
   const cuePullCurrentRef = useRef(0);
+  const cueShotStateRef = useRef('idle');
+  const latchedShotPowerRef = useRef(Number.NaN);
   const cueStickAnchorRef = useRef(new THREE.Vector3(0, BALL_CENTER_Y, 0));
   const cueLiftRef = useRef({
     active: false,
@@ -21638,6 +21645,7 @@ const powerRef = useRef(hud.power);
             return Boolean(cueAnimating);
           }
           if (!stroke) {
+            cueShotStateRef.current = 'idle';
             if (cueAnimating) {
               const idlePose = lastCueIdlePoseRef.current;
               if (idlePose?.position) {
@@ -21659,6 +21667,7 @@ const powerRef = useRef(hud.power);
             cueAnimating = false;
             cueStrokeStateRef.current = null;
             pendingImpactRef.current = null;
+            cueShotStateRef.current = 'idle';
             syncCueShadow();
             return false;
           }
@@ -21756,6 +21765,7 @@ const powerRef = useRef(hud.power);
             cuePullTargetRef.current = 0;
             cueStrokeStateRef.current = null;
             pendingImpactRef.current = null;
+            cueShotStateRef.current = 'idle';
             if (cameraRef.current && sphRef.current) {
               topViewRef.current = false;
               topViewLockedRef.current = false;
@@ -21842,6 +21852,7 @@ const powerRef = useRef(hud.power);
           cuePullTargetRef.current = 0;
           cueStrokeStateRef.current = null;
           pendingImpactRef.current = null;
+          cueShotStateRef.current = 'idle';
           if (cameraRef.current && sphRef.current) {
             topViewRef.current = false;
             topViewLockedRef.current = false;
@@ -23594,12 +23605,15 @@ const powerRef = useRef(hud.power);
           Boolean(sliderInstanceRef.current?.dragging) ||
           shooting ||
           cueAnimating;
+        const useContactGap =
+          Boolean(options.contact) || cueShotStateRef.current === 'striking';
+        const cueGap = resolveCueStrokeGap(useContactGap);
         const baseX = useAnchor && Number.isFinite(anchor?.x) ? anchor.x : cue.pos.x;
         const baseZ = useAnchor && Number.isFinite(anchor?.z) ? anchor.z : cue.pos.y;
         return TMP_VEC3_CUE_TIP_TARGET.set(
-          baseX - dir.x * (CUE_TIP_GAP + pullAmount) + spinWorld.x,
+          baseX - dir.x * (cueGap + pullAmount) + spinWorld.x,
           CUE_Y + spinWorld.y,
-          baseZ - dir.z * (CUE_TIP_GAP + pullAmount) + spinWorld.z
+          baseZ - dir.z * (cueGap + pullAmount) + spinWorld.z
         );
       };
       const applyCueStickTransform = (tipTarget) => {
@@ -24748,17 +24762,16 @@ const powerRef = useRef(hud.power);
 
       const resolveCueStrokeProfile = (_styleId, powerRatio = 0) => {
         const p = THREE.MathUtils.clamp(powerRatio ?? 0, 0, 1);
-        const pullbackDuration = THREE.MathUtils.lerp(90, 170, p);
         return {
-          // Keep a shorter charge-up while preserving a visible pullback/strike cycle.
+          // Lock rhythm to: idle -> dragging -> striking -> idle.
           motion: 'classic',
           pullRatio: easeOutCubic(p),
           pullSmoothing: 1,
-          strikeDuration: Math.max(LIVE_CUE_FORWARD_DURATION_MS, 170),
-          holdDuration: Math.max(LIVE_CUE_IMPACT_HOLD_MS, 80),
-          pullbackDuration,
+          strikeDuration: CUE_STROKE_STRIKE_DURATION_MS,
+          holdDuration: CUE_STROKE_HOLD_DURATION_MS,
+          pullbackDuration: 0,
           recoverDuration: 0,
-          impactThreshold: 0.88,
+          impactThreshold: 0.9,
           forwardOnly: false,
           cameraExtraHoldMs: 240,
           spinScale: 0.22
@@ -24853,6 +24866,8 @@ const powerRef = useRef(hud.power);
       const easeInOutCubic = (t) =>
         t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
       const easeOutCubic = (t) => 1 - Math.pow(1 - t, 3);
+      const resolveCueStrokeGap = (contact = false) =>
+        (contact ? CUE_STROKE_CONTACT_GAP : CUE_STROKE_IDLE_GAP) + BALL_R;
       const clampCueTipOffset = (vec, limit = BALL_R) => {
         if (!vec) return vec;
         const horiz = Math.hypot(vec.x ?? 0, vec.z ?? 0);
@@ -25009,7 +25024,12 @@ const powerRef = useRef(hud.power);
         } else {
           aimDir.normalize();
         }
-        const clampedPower = clampPower(powerRef.current, 0);
+        const clampedPower = clampPower(
+          currentHud?.turn === 0 && Number.isFinite(latchedShotPowerRef.current)
+            ? latchedShotPowerRef.current
+            : powerRef.current,
+          0
+        );
         const strokeStyle = cueStrokeAnimationStyleRef.current ?? DEFAULT_CUE_STROKE_STYLE;
         const strokeProfile = resolveCueStrokeProfile(strokeStyle, clampedPower);
         const rawSpin = applySpinConstraints(aimDir, true);
@@ -25281,7 +25301,7 @@ const powerRef = useRef(hud.power);
           const dir = new THREE.Vector3(aimDir.x, 0, aimDir.y);
           if (dir.lengthSq() < 1e-8) dir.set(0, 0, 1);
           dir.normalize();
-          if (cue?.pos) {
+          if (cue?.pos && currentHud?.turn === 1) {
             cueStickAnchorRef.current.set(cue.pos.x, CUE_Y, cue.pos.y);
           }
           const backInfo = calcTarget(
@@ -25293,8 +25313,7 @@ const powerRef = useRef(hud.power);
           const maxPull = Number.isFinite(rawMaxPull) ? rawMaxPull : CUE_PULL_BASE;
           // Mirror the reference stroke pullback curve exactly:
           // pull = pullRange * easeOutCubic(power), then push forward on strike.
-          const pullRange = 0.24;
-          const pullTarget = pullRange * strokeProfile.pullRatio;
+          const pullTarget = CUE_STROKE_PULL_RANGE * easeOutCubic(clampedPower);
           const pulledNow = cuePullCurrentRef.current ?? pullTarget;
           const startPull = THREE.MathUtils.clamp(pulledNow, 0, Math.max(maxPull, 0));
           const visualPull = applyVisualPullCompensation(startPull, dir);
@@ -25467,6 +25486,7 @@ const powerRef = useRef(hud.power);
           if (ENABLE_CUE_STROKE_ANIMATION) {
             cueStick.visible = true;
             cueAnimating = true;
+            cueShotStateRef.current = 'striking';
             lastCueIdlePoseRef.current = {
               position: idlePos.clone(),
               rotationX: cueStick.rotation.x,
@@ -29161,8 +29181,11 @@ const powerRef = useRef(hud.power);
           const aiPullReady =
             !isAiTurn ||
             (aiCueViewActive && now >= (aiCuePullReadyAtRef.current ?? 0));
+          const playerDragging = Boolean(sliderInstanceRef.current?.dragging) && isPlayerTurn;
           const desiredPull = aiPullReady
-            ? computePullTargetFromPower(powerRef.current, maxPull)
+            ? playerDragging
+              ? CUE_STROKE_PULL_RANGE * easeOutCubic(clampPower(powerRef.current ?? 0, 0))
+              : computePullTargetFromPower(powerRef.current, maxPull)
             : 0;
           const pull = computeCuePull(desiredPull, maxPull, {
             instant:
@@ -31155,8 +31178,12 @@ const powerRef = useRef(hud.power);
       onChange: (v) => applyPower(v / 100),
       onStart: () => {
         captureCueStickAnchor();
+        cueShotStateRef.current = 'dragging';
       },
-      onCommit: () => {
+      onCommit: (value) => {
+        const normalizedPower = clampPower((value ?? 0) / 100, 0);
+        latchedShotPowerRef.current = normalizedPower;
+        cueShotStateRef.current = normalizedPower > 0.02 ? 'striking' : 'idle';
         fireRef.current?.();
         requestAnimationFrame(() => {
           slider.set(slider.min, { animate: true });
@@ -31180,6 +31207,8 @@ const powerRef = useRef(hud.power);
     applyPower(0);
     cuePullCurrentRef.current = 0;
     cuePullTargetRef.current = 0;
+    cueShotStateRef.current = 'idle';
+    latchedShotPowerRef.current = Number.NaN;
   }, [applyPower, hud.over, hud.turn, shotActive]);
 
   const isPlayerTurn = hud.turn === 0;


### PR DESCRIPTION
### Motivation
- Make the Pool Royale live cue stroke match the requested rhythm and feel: `idle -> dragging -> striking -> idle`, with a tiny idle gap and tight contact, live pullback while dragging, and a fast, heavy strike that does not follow the cue ball after impact. 
- Preserve the existing system and adapt the existing slider/cue stroke code to exactly follow the provided timing and distances without redesigning the mechanic.

### Description
- Added slider `onStart` support and call to capture the cue anchor so the cue is anchored at drag start by calling `captureCueStickAnchor()` on pointer down in `PoolRoyalePowerSlider` (`webapp/public/power-slider.js`).
- Introduced Pool Royale stroke constants and anchored-shot refs: `CUE_STROKE_IDLE_GAP = 0.01`, `CUE_STROKE_CONTACT_GAP = 0.001`, `CUE_STROKE_PULL_RANGE = 0.34`, `CUE_STROKE_STRIKE_DURATION_MS = 120`, and `CUE_STROKE_HOLD_DURATION_MS = 50`, and added `cueShotStateRef` + `latchedShotPowerRef` to `PoolRoyale.jsx` to drive `idle -> dragging -> striking -> idle` flow. (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Live pullback behavior: while dragging, pull amount is computed as `pull = CUE_STROKE_PULL_RANGE * easeOutCubic(power)` and is applied visually; on release the current power is latched and used as the shot power. (`computePullTargetFromPower` / pull usage areas). 
- Latch and fire: on slider `onCommit` we store normalized power into `latchedShotPowerRef` and set `cueShotStateRef` to `striking` so the shot uses the latched value; firing still calls the existing `fireRef.current()` so all shot-side logic is preserved. (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Cue tip gaps and anchoring: replaced generic tip gap usage for the Pool Royale stroke with `resolveCueStrokeGap(contact)` so the tip sits at `idleGap` near the cue ball and switches to `contactGap` during striking; cue tip targets are built from the `cueStickAnchorRef` captured at drag start so the cue does not follow the cue ball after impact (player shots keep the anchor). (`resolveCueTipTarget` and `resolveCueStrokeGap`).
- Strike timing and single-hit: stroke profile uses `strikeDuration = 120ms` and `holdDuration = 50ms`, impact threshold raised to ~`0.9` so hit occurs near 90% progress and the existing `stroke.shotApplied` guard ensures the hit is applied once. 
- Reset paths: ensured `cueShotStateRef` and latched power are reset to idle/`NaN` in stroke termination and HUD reset effect so the cue returns to the close idle pose without a large pullback animation. 

### Testing
- Ran the focused test suite: `npm test -- --runInBand test/poolRoyaleCueStrokeTimeline.test.js`, and it passed (4/4 tests passed).
- Manual visual validation not included (no headful browser in CI here); changes are localized to slider and cue stroke code paths and unit test verifies timeline behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bce49e48208329a24a97e934619b21)