### PR TITLE
CueController: depth-based shot state machine and refined strike timing

### DIFF
--- a/Assets/Scripts/Gameplay/CueController.cs
+++ b/Assets/Scripts/Gameplay/CueController.cs
@@ -5,6 +5,13 @@ namespace Aiming
 {
     public class CueController : MonoBehaviour
     {
+        enum ShotState
+        {
+            Idle,
+            Dragging,
+            Striking
+        }
+
         public AdaptiveAimingEngine aiming;
         public Transform cueTip;
         public Transform cueBall, objectBall, pocket;
@@ -13,25 +20,24 @@ namespace Aiming
         public float ballRadius = 0.028575f;
 
         [Header("Cue placement")]
-        public float idleTipGap = 0.012f;
+        public float idleTipGap = 0.010f;
+        public float contactTipGap = 0.001f;
         public float baseCueOffset = 0.12f;
-        public float maxPullbackDistance = 0.16f;
+        public float pullRange = 0.34f;
 
         [Header("Aiming feel")]
         [Range(1f, 30f)] public float rotationDamping = 14f;
-        [Range(1f, 30f)] public float translationDamping = 18f;
         public bool allowAimAdjustWhileCharging = false;
 
         [Header("Strike feel")]
-        public float strikeDuration = 0.055f;
-        public float recoilDistance = 0.015f;
-        public float recoilDuration = 0.04f;
+        public float strikeDuration = 0.12f;
+        public float strikeHoldDuration = 0.05f;
         public float baseStrikeImpulse = 1.8f;
         public float maxStrikeImpulse = 6.5f;
-        [Tooltip("How close to idle pullback the cue must be before applying the strike impulse.")]
-        public float strikeContactPullbackThreshold = 0.001f;
-        public AnimationCurve pullbackEasing = AnimationCurve.EaseInOut(0f, 0f, 1f, 1f);
-        public AnimationCurve strikeEaseIn = AnimationCurve.EaseInOut(0f, 0f, 1f, 1f);
+        [Tooltip("Normalized strike progress where the hit is fired once.")]
+        [Range(0.75f, 0.99f)] public float hitProgress = 0.9f;
+        [Tooltip("How much of the strike stays for the final idle->contact micro drive.")]
+        [Range(0.02f, 0.25f)] public float contactDrivePortion = 0.1f;
 
         [Header("Spin input")]
         [Tooltip("Receives normalized spin values from the existing on-screen spin controller.")]
@@ -40,13 +46,11 @@ namespace Aiming
 
         Vector3 _aimDirection = Vector3.forward;
         Vector3 _targetDirection = Vector3.forward;
-        float _currentPullback;
-        float _targetPullback;
-        float _pullbackVelocity;
+        Vector3 _cueAnchorPosition;
+        float _currentCueDepth;
         float _power;
-        float _lastRequestedPower;
-        bool _charging;
-        bool _striking;
+        float _latchedShotPower;
+        ShotState _shotState = ShotState.Idle;
 
         void Update()
         {
@@ -55,34 +59,54 @@ namespace Aiming
                 return;
             }
 
-            if (_striking)
+            if (_shotState == ShotState.Striking)
             {
                 return;
             }
 
             bool ballsMoving = AreBallsMoving();
-            if (ballsMoving && !_charging)
+            if (ballsMoving && _shotState == ShotState.Idle)
             {
                 gameObject.SetActive(false);
                 return;
             }
 
             gameObject.SetActive(true);
+            if (_shotState == ShotState.Idle)
+            {
+                _cueAnchorPosition = cueBall.position;
+            }
+
             UpdateAimDirection();
-            UpdatePullback();
+            UpdateCueDepth();
             UpdateCuePose();
         }
 
         public void SetChargePower(float normalizedPower)
         {
             _power = Mathf.Clamp01(normalizedPower);
-            _lastRequestedPower = _power;
-            _targetPullback = pullbackEasing.Evaluate(_power) * maxPullbackDistance;
+
+            if (_shotState == ShotState.Dragging)
+            {
+                float pull = pullRange * EaseOutCubic(_power);
+                _currentCueDepth = idleTipGap + pull;
+                UpdateCuePose();
+            }
         }
 
         public void BeginCharge()
         {
-            _charging = true;
+            if (_shotState == ShotState.Striking)
+            {
+                return;
+            }
+
+            _cueAnchorPosition = cueBall.position;
+            _shotState = ShotState.Dragging;
+            _latchedShotPower = 0f;
+            _currentCueDepth = idleTipGap + (pullRange * EaseOutCubic(_power));
+            gameObject.SetActive(true);
+            UpdateCuePose();
         }
 
         public void SetSpinInput(Vector2 normalizedSpin)
@@ -92,16 +116,35 @@ namespace Aiming
 
         public void CancelCharge()
         {
-            _charging = false;
-            SetChargePower(0f);
+            if (_shotState == ShotState.Striking)
+            {
+                return;
+            }
+
+            _shotState = ShotState.Idle;
+            _power = 0f;
+            _latchedShotPower = 0f;
+            _currentCueDepth = idleTipGap;
+            UpdateCuePose();
         }
 
         public void ReleaseAndStrike()
         {
-            if (_striking) return;
+            if (_shotState != ShotState.Dragging)
+            {
+                return;
+            }
 
-            float shotPower = Mathf.Clamp01(Mathf.Max(_power, _lastRequestedPower));
-            StartCoroutine(StrikeRoutine(shotPower));
+            _latchedShotPower = Mathf.Clamp01(_power);
+            if (_latchedShotPower <= 0.02f)
+            {
+                _shotState = ShotState.Idle;
+                _currentCueDepth = idleTipGap;
+                UpdateCuePose();
+                return;
+            }
+
+            StartCoroutine(StrikeRoutine(_latchedShotPower));
         }
 
         void UpdateAimDirection()
@@ -113,7 +156,8 @@ namespace Aiming
                 if (desiredDirection.sqrMagnitude > 1e-6f)
                 {
                     desiredDirection.Normalize();
-                    if (!_charging || allowAimAdjustWhileCharging)
+                    bool canAdjustAim = _shotState != ShotState.Dragging || allowAimAdjustWhileCharging;
+                    if (canAdjustAim)
                     {
                         _targetDirection = desiredDirection;
                     }
@@ -128,30 +172,28 @@ namespace Aiming
             }
         }
 
-        void UpdatePullback()
+        void UpdateCueDepth()
         {
-            if (!_charging)
+            if (_shotState == ShotState.Dragging)
             {
-                _targetPullback = 0f;
+                float pull = pullRange * EaseOutCubic(_power);
+                _currentCueDepth = idleTipGap + pull;
+                return;
             }
 
-            _currentPullback = Mathf.SmoothDamp(
-                _currentPullback,
-                _targetPullback,
-                ref _pullbackVelocity,
-                1f / Mathf.Max(translationDamping, 0.01f));
+            _currentCueDepth = idleTipGap;
         }
 
         void UpdateCuePose()
         {
-            float cueDistance = baseCueOffset + idleTipGap + _currentPullback;
-            transform.position = cueBall.position - _aimDirection * cueDistance;
+            Vector3 anchor = _cueAnchorPosition;
+            float cueDistance = baseCueOffset + _currentCueDepth;
+            transform.position = anchor - _aimDirection * cueDistance;
             transform.rotation = Quaternion.LookRotation(_aimDirection, Vector3.up);
 
             if (cueTip != null)
             {
-                float tipDistance = idleTipGap + _currentPullback;
-                cueTip.position = cueBall.position - _aimDirection * tipDistance;
+                cueTip.position = anchor - _aimDirection * _currentCueDepth;
             }
         }
 
@@ -178,24 +220,40 @@ namespace Aiming
 
         IEnumerator StrikeRoutine(float shotPower)
         {
-            _striking = true;
-            _charging = false;
+            _shotState = ShotState.Striking;
 
             Vector3 strikeDirection = _aimDirection;
-            float startPullback = _currentPullback;
+            float pull = pullRange * EaseOutCubic(shotPower);
+            float startDepth = idleTipGap + pull;
+            float hitDepth = idleTipGap;
+            float contactDepth = contactTipGap;
             float elapsed = 0f;
             bool didStrike = false;
+            float contactStartT = Mathf.Clamp01(1f - contactDrivePortion);
+            float hitT = Mathf.Clamp01(Mathf.Max(hitProgress, contactStartT));
+            _currentCueDepth = startDepth;
+            UpdateCuePose();
 
             while (elapsed < strikeDuration)
             {
                 elapsed += Time.deltaTime;
                 float t = Mathf.Clamp01(elapsed / Mathf.Max(strikeDuration, 0.001f));
-                float eased = Mathf.Max(strikeEaseIn.Evaluate(t), t * 0.2f);
+                float cueDepth;
+                if (t < contactStartT)
+                {
+                    float phaseT = contactStartT > 0f ? t / contactStartT : 1f;
+                    cueDepth = Mathf.Lerp(startDepth, hitDepth, EaseOutCubic(phaseT));
+                }
+                else
+                {
+                    float phaseT = contactStartT < 1f ? (t - contactStartT) / (1f - contactStartT) : 1f;
+                    cueDepth = Mathf.Lerp(hitDepth, contactDepth, EaseOutCubic(phaseT));
+                }
 
-                _currentPullback = Mathf.Lerp(startPullback, 0f, eased);
+                _currentCueDepth = cueDepth;
                 UpdateCuePose();
 
-                if (!didStrike && _currentPullback <= strikeContactPullbackThreshold)
+                if (!didStrike && t >= hitT)
                 {
                     didStrike = true;
                     ApplyStrikeImpulse(strikeDirection, shotPower);
@@ -209,16 +267,15 @@ namespace Aiming
                 ApplyStrikeImpulse(strikeDirection, shotPower);
             }
 
-            _currentPullback = recoilDistance;
+            _currentCueDepth = contactDepth;
             UpdateCuePose();
-            yield return new WaitForSeconds(recoilDuration);
+            yield return new WaitForSeconds(strikeHoldDuration);
 
-            _currentPullback = 0f;
-            _targetPullback = 0f;
+            _currentCueDepth = idleTipGap;
             _power = 0f;
-            _lastRequestedPower = 0f;
-            _striking = false;
-            gameObject.SetActive(false);
+            _latchedShotPower = 0f;
+            _shotState = ShotState.Idle;
+            UpdateCuePose();
         }
 
         void ApplyStrikeImpulse(Vector3 strikeDirection, float shotPower)
@@ -230,6 +287,13 @@ namespace Aiming
 
             float impulseMagnitude = Mathf.Lerp(baseStrikeImpulse, maxStrikeImpulse, Mathf.Clamp01(shotPower));
             strikePhysics.Apply(cueBallBody, strikeDirection, impulseMagnitude, spinInput, ballRadius);
+        }
+
+        static float EaseOutCubic(float t)
+        {
+            t = Mathf.Clamp01(t);
+            float inv = 1f - t;
+            return 1f - (inv * inv * inv);
         }
     }
 }


### PR DESCRIPTION
### Motivation

- Replace the previous pullback-only charging model with an explicit shot state machine to better manage dragging, striking, and idle behaviors.
- Improve strike timing and feel by splitting the strike into staged motion (hit and micro-contact) and providing configurable hold and contact parameters.
- Ensure cue pose is consistently anchored to the cue ball during drag/strike and allow controlled aim adjustment while charging.

### Description

- Introduced `ShotState` enum and `_shotState` to track `Idle`, `Dragging`, and `Striking` states and updated logic across `Update`, `BeginCharge`, `CancelCharge`, and `ReleaseAndStrike` to use it.
- Replaced `_currentPullback`/`_targetPullback` with a depth-driven approach using `_currentCueDepth`, added `pullRange` and `contactTipGap`, and adjusted `idleTipGap` and other tuning parameters.
- Reworked charge flow so `SetChargePower` and `BeginCharge` update pose during dragging and `ReleaseAndStrike` latches power and starts a new `StrikeRoutine` that fires the hit based on `hitProgress` and moves into a contact micro-drive based on `contactDrivePortion`.
- Reimplemented `StrikeRoutine` with staged easing using a new `EaseOutCubic` helper, added `strikeHoldDuration`, and moved cue anchoring to `_cueAnchorPosition` used by `UpdateCuePose`.

### Testing

- Project compiles in the Unity Editor after the changes without script errors.
- Ran the repository's automated test suite (unit and playmode tests) and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bce49e48208329a24a97e934619b21)