### PR TITLE
Introduce shot state machine and cue-depth based pullback; refine strike timing and easing

### DIFF
--- a/Assets/Scripts/Gameplay/CueController.cs
+++ b/Assets/Scripts/Gameplay/CueController.cs
@@ -5,6 +5,13 @@ namespace Aiming
 {
     public class CueController : MonoBehaviour
     {
+        enum ShotState
+        {
+            Idle,
+            Dragging,
+            Striking
+        }
+
         public AdaptiveAimingEngine aiming;
         public Transform cueTip;
         public Transform cueBall, objectBall, pocket;
@@ -13,25 +20,22 @@ namespace Aiming
         public float ballRadius = 0.028575f;
 
         [Header("Cue placement")]
-        public float idleTipGap = 0.012f;
+        public float idleTipGap = 0.010f;
+        public float contactTipGap = 0.001f;
         public float baseCueOffset = 0.12f;
-        public float maxPullbackDistance = 0.16f;
+        public float pullRange = 0.34f;
 
         [Header("Aiming feel")]
         [Range(1f, 30f)] public float rotationDamping = 14f;
-        [Range(1f, 30f)] public float translationDamping = 18f;
         public bool allowAimAdjustWhileCharging = false;
 
         [Header("Strike feel")]
-        public float strikeDuration = 0.055f;
-        public float recoilDistance = 0.015f;
-        public float recoilDuration = 0.04f;
+        public float strikeDuration = 0.12f;
+        public float strikeHoldDuration = 0.05f;
         public float baseStrikeImpulse = 1.8f;
         public float maxStrikeImpulse = 6.5f;
-        [Tooltip("How close to idle pullback the cue must be before applying the strike impulse.")]
-        public float strikeContactPullbackThreshold = 0.001f;
-        public AnimationCurve pullbackEasing = AnimationCurve.EaseInOut(0f, 0f, 1f, 1f);
-        public AnimationCurve strikeEaseIn = AnimationCurve.EaseInOut(0f, 0f, 1f, 1f);
+        [Tooltip("Normalized strike progress where the hit is fired once.")]
+        [Range(0.75f, 0.99f)] public float hitProgress = 0.9f;
 
         [Header("Spin input")]
         [Tooltip("Receives normalized spin values from the existing on-screen spin controller.")]
@@ -40,13 +44,11 @@ namespace Aiming
 
         Vector3 _aimDirection = Vector3.forward;
         Vector3 _targetDirection = Vector3.forward;
-        float _currentPullback;
-        float _targetPullback;
-        float _pullbackVelocity;
+        Vector3 _cueAnchorPosition;
+        float _currentCueDepth;
         float _power;
-        float _lastRequestedPower;
-        bool _charging;
-        bool _striking;
+        float _latchedShotPower;
+        ShotState _shotState = ShotState.Idle;
 
         void Update()
         {
@@ -55,34 +57,54 @@ namespace Aiming
                 return;
             }
 
-            if (_striking)
+            if (_shotState == ShotState.Striking)
             {
                 return;
             }
 
             bool ballsMoving = AreBallsMoving();
-            if (ballsMoving && !_charging)
+            if (ballsMoving && _shotState == ShotState.Idle)
             {
                 gameObject.SetActive(false);
                 return;
             }
 
             gameObject.SetActive(true);
+            if (_shotState == ShotState.Idle)
+            {
+                _cueAnchorPosition = cueBall.position;
+            }
+
             UpdateAimDirection();
-            UpdatePullback();
+            UpdateCueDepth();
             UpdateCuePose();
         }
 
         public void SetChargePower(float normalizedPower)
         {
             _power = Mathf.Clamp01(normalizedPower);
-            _lastRequestedPower = _power;
-            _targetPullback = pullbackEasing.Evaluate(_power) * maxPullbackDistance;
+
+            if (_shotState == ShotState.Dragging)
+            {
+                float pull = pullRange * EaseOutCubic(_power);
+                _currentCueDepth = idleTipGap + pull;
+                UpdateCuePose();
+            }
         }
 
         public void BeginCharge()
         {
-            _charging = true;
+            if (_shotState == ShotState.Striking)
+            {
+                return;
+            }
+
+            _cueAnchorPosition = cueBall.position;
+            _shotState = ShotState.Dragging;
+            _latchedShotPower = 0f;
+            _currentCueDepth = idleTipGap + (pullRange * EaseOutCubic(_power));
+            gameObject.SetActive(true);
+            UpdateCuePose();
         }
 
         public void SetSpinInput(Vector2 normalizedSpin)
@@ -92,16 +114,35 @@ namespace Aiming
 
         public void CancelCharge()
         {
-            _charging = false;
-            SetChargePower(0f);
+            if (_shotState == ShotState.Striking)
+            {
+                return;
+            }
+
+            _shotState = ShotState.Idle;
+            _power = 0f;
+            _latchedShotPower = 0f;
+            _currentCueDepth = idleTipGap;
+            UpdateCuePose();
         }
 
         public void ReleaseAndStrike()
         {
-            if (_striking) return;
+            if (_shotState != ShotState.Dragging)
+            {
+                return;
+            }
 
-            float shotPower = Mathf.Clamp01(Mathf.Max(_power, _lastRequestedPower));
-            StartCoroutine(StrikeRoutine(shotPower));
+            _latchedShotPower = Mathf.Clamp01(_power);
+            if (_latchedShotPower <= 0.02f)
+            {
+                _shotState = ShotState.Idle;
+                _currentCueDepth = idleTipGap;
+                UpdateCuePose();
+                return;
+            }
+
+            StartCoroutine(StrikeRoutine(_latchedShotPower));
         }
 
         void UpdateAimDirection()
@@ -113,7 +154,8 @@ namespace Aiming
                 if (desiredDirection.sqrMagnitude > 1e-6f)
                 {
                     desiredDirection.Normalize();
-                    if (!_charging || allowAimAdjustWhileCharging)
+                    bool canAdjustAim = _shotState != ShotState.Dragging || allowAimAdjustWhileCharging;
+                    if (canAdjustAim)
                     {
                         _targetDirection = desiredDirection;
                     }
@@ -128,30 +170,28 @@ namespace Aiming
             }
         }
 
-        void UpdatePullback()
+        void UpdateCueDepth()
         {
-            if (!_charging)
+            if (_shotState == ShotState.Dragging)
             {
-                _targetPullback = 0f;
+                float pull = pullRange * EaseOutCubic(_power);
+                _currentCueDepth = idleTipGap + pull;
+                return;
             }
 
-            _currentPullback = Mathf.SmoothDamp(
-                _currentPullback,
-                _targetPullback,
-                ref _pullbackVelocity,
-                1f / Mathf.Max(translationDamping, 0.01f));
+            _currentCueDepth = idleTipGap;
         }
 
         void UpdateCuePose()
         {
-            float cueDistance = baseCueOffset + idleTipGap + _currentPullback;
-            transform.position = cueBall.position - _aimDirection * cueDistance;
+            Vector3 anchor = _cueAnchorPosition;
+            float cueDistance = baseCueOffset + _currentCueDepth;
+            transform.position = anchor - _aimDirection * cueDistance;
             transform.rotation = Quaternion.LookRotation(_aimDirection, Vector3.up);
 
             if (cueTip != null)
             {
-                float tipDistance = idleTipGap + _currentPullback;
-                cueTip.position = cueBall.position - _aimDirection * tipDistance;
+                cueTip.position = anchor - _aimDirection * _currentCueDepth;
             }
         }
 
@@ -178,24 +218,28 @@ namespace Aiming
 
         IEnumerator StrikeRoutine(float shotPower)
         {
-            _striking = true;
-            _charging = false;
+            _shotState = ShotState.Striking;
 
             Vector3 strikeDirection = _aimDirection;
-            float startPullback = _currentPullback;
+            float startDepth = Mathf.Max(_currentCueDepth, idleTipGap);
+            float contactDepth = contactTipGap;
             float elapsed = 0f;
             bool didStrike = false;
+            float hitTAtIdleDepth = Mathf.Clamp01((idleTipGap - startDepth) / Mathf.Min(contactDepth - startDepth, -0.0001f));
+            float resolvedHitProgress = Mathf.Max(hitProgress, hitTAtIdleDepth);
+            _currentCueDepth = startDepth;
+            UpdateCuePose();
 
             while (elapsed < strikeDuration)
             {
                 elapsed += Time.deltaTime;
                 float t = Mathf.Clamp01(elapsed / Mathf.Max(strikeDuration, 0.001f));
-                float eased = Mathf.Max(strikeEaseIn.Evaluate(t), t * 0.2f);
+                float eased = EaseOutCubic(t);
 
-                _currentPullback = Mathf.Lerp(startPullback, 0f, eased);
+                _currentCueDepth = Mathf.Lerp(startDepth, contactDepth, eased);
                 UpdateCuePose();
 
-                if (!didStrike && _currentPullback <= strikeContactPullbackThreshold)
+                if (!didStrike && t >= resolvedHitProgress)
                 {
                     didStrike = true;
                     ApplyStrikeImpulse(strikeDirection, shotPower);
@@ -209,16 +253,15 @@ namespace Aiming
                 ApplyStrikeImpulse(strikeDirection, shotPower);
             }
 
-            _currentPullback = recoilDistance;
+            _currentCueDepth = contactDepth;
             UpdateCuePose();
-            yield return new WaitForSeconds(recoilDuration);
+            yield return new WaitForSeconds(strikeHoldDuration);
 
-            _currentPullback = 0f;
-            _targetPullback = 0f;
+            _currentCueDepth = idleTipGap;
             _power = 0f;
-            _lastRequestedPower = 0f;
-            _striking = false;
-            gameObject.SetActive(false);
+            _latchedShotPower = 0f;
+            _shotState = ShotState.Idle;
+            UpdateCuePose();
         }
 
         void ApplyStrikeImpulse(Vector3 strikeDirection, float shotPower)
@@ -230,6 +273,13 @@ namespace Aiming
 
             float impulseMagnitude = Mathf.Lerp(baseStrikeImpulse, maxStrikeImpulse, Mathf.Clamp01(shotPower));
             strikePhysics.Apply(cueBallBody, strikeDirection, impulseMagnitude, spinInput, ballRadius);
+        }
+
+        static float EaseOutCubic(float t)
+        {
+            t = Mathf.Clamp01(t);
+            float inv = 1f - t;
+            return 1f - (inv * inv * inv);
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Replace the previous pullback/charging flags with an explicit shot state machine to make charge, release and strike logic clearer and more robust.
- Move from a smoothed pullback value to an explicit cue depth anchored to the cue ball to simplify pose updates and make strike timing and feel more consistent.
- Simplify easing logic and expose a clear `hitProgress` point to control when the strike impulse is applied.

### Description
- Add `ShotState` enum (`Idle`, `Dragging`, `Striking`) and replace `_charging`/`_striking` with `_shotState` to centralize shot lifecycle management.
- Replace pullback variables with an anchor-based depth system using `_cueAnchorPosition`, `_currentCueDepth`, `idleTipGap`, `contactTipGap`, and `pullRange`, and update pose with `UpdateCuePose` anchored to the cue ball.
- Update public fields and timing: reduce `idleTipGap`, add `contactTipGap`, rename `maxPullbackDistance` to `pullRange`, increase `strikeDuration`, add `strikeHoldDuration`, and expose `hitProgress` for normalized hit timing; remove `translationDamping` and curve-driven pullback/strike easing.
- Change charge/strike methods to the new flow: `SetChargePower` updates depth while dragging, `BeginCharge` latches anchor and enters `Dragging`, `CancelCharge` reverts to `Idle`, `ReleaseAndStrike` latches power and starts `StrikeRoutine`, and `StrikeRoutine` uses `EaseOutCubic` and `hitProgress` to determine when to call `ApplyStrikeImpulse`.

### Testing
- Ran the project's automated unit and PlayMode test suites that exercise cue behavior and physics interactions and observed all tests pass.
- Executed a lightweight playmode smoke check for cue charge/release flows and observed expected state transitions and impulse application.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bce49e48208329a24a97e934619b21)