### PR TITLE
Restore Pool Royale online seating by requested table ID

### DIFF
--- a/test/poolRoyaleOnlineFlow.test.js
+++ b/test/poolRoyaleOnlineFlow.test.js
@@ -100,6 +100,7 @@ test('runPoolRoyaleOnlineFlow debits once and keeps stake for game start', async
 
   await runPoolRoyaleOnlineFlow({
     stake: { token: 'TPC', amount: 100 },
+    tableId: 'room-77',
     variant: 'uk',
     ballSet: 'american',
     playType: 'regular',
@@ -120,6 +121,7 @@ test('runPoolRoyaleOnlineFlow debits once and keeps stake for game start', async
   assert.equal(seatPayload.mode, 'online');
   assert.equal(seatPayload.tableSize, 'medium');
   assert.equal(seatPayload.playType, 'regular');
+  assert.equal(seatPayload.tableId, 'room-77');
   const seatCb = mockSocket.seatRequests[0].cb;
   seatCb({
     success: true,
@@ -169,6 +171,7 @@ test('runPoolRoyaleOnlineFlow refunds when matchmaking times out', async () => {
 
   await runPoolRoyaleOnlineFlow({
     stake: { token: 'TPC', amount: 75 },
+    tableId: 'room-timeout',
     variant: 'uk',
     ballSet: 'uk',
     playType: 'regular',
@@ -183,6 +186,7 @@ test('runPoolRoyaleOnlineFlow refunds when matchmaking times out', async () => {
 
   assert.equal(mockSocket.seatRequests.length, 1);
   const seatCb = mockSocket.seatRequests[0].cb;
+  assert.equal(mockSocket.seatRequests[0].payload.tableId, 'room-timeout');
   seatCb({ success: true, tableId: 'tbl-timeout', players: [], ready: [] });
 
   await delay(120);

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -60,6 +60,7 @@ export default function PoolRoyaleLobby() {
   const [playType, setPlayType] = useState(initialPlayType);
   const [players, setPlayers] = useState(8);
   const tableSize = resolveTableSize(searchParams.get('tableSize')).id;
+  const requestedTableId = (searchParams.get('tableId') || searchParams.get('tableNr') || '').trim();
   const [onlinePlayers, setOnlinePlayers] = useState([]);
   const [matching, setMatching] = useState(false);
   const [spinningPlayer, setSpinningPlayer] = useState('');
@@ -197,6 +198,7 @@ export default function PoolRoyaleLobby() {
     if (isOnlineMatch) {
       await runPoolRoyaleOnlineFlow({
         stake,
+        tableId: requestedTableId,
         variant,
         ballSet: ukBallSet,
         playType,

--- a/webapp/src/pages/Games/poolRoyaleOnlineFlow.js
+++ b/webapp/src/pages/Games/poolRoyaleOnlineFlow.js
@@ -19,6 +19,7 @@ function clearTimeoutSafely(ref) {
 
 export async function runPoolRoyaleOnlineFlow({
   stake,
+  tableId,
   variant,
   ballSet,
   playType,
@@ -61,6 +62,8 @@ export async function runPoolRoyaleOnlineFlow({
 
   const seatTimeoutMs = timeouts.seat ?? DEFAULT_SEAT_TIMEOUT_MS;
   const matchmakingTimeoutMs = timeouts.matchmaking ?? DEFAULT_MATCH_TIMEOUT_MS;
+  const requestedTableId =
+    typeof tableId === 'string' && tableId.trim() ? tableId.trim() : undefined;
 
   const telegramId = getTelegramIdFn?.();
 
@@ -240,6 +243,7 @@ export async function runPoolRoyaleOnlineFlow({
       token: stake.token,
       gameType: 'poolroyale',
       maxPlayers: 2,
+      tableId: requestedTableId,
       mode,
       variant,
       ballSet,


### PR DESCRIPTION
### Motivation
- Players need to be able to join a specific online Pool Royale table by its ID/number so both opponents land in the same table when starting an online match.

### Description
- Added an optional `tableId` parameter to `runPoolRoyaleOnlineFlow` and normalize it to `requestedTableId` before use.
- Forward the normalized `tableId` in the `seatTable` payload so matchmaking can target the requested table (`tableId: requestedTableId`).
- Read `tableId` (and legacy `tableNr`) from the Pool Royale lobby URL and pass it into the online flow when starting matchmaking.
- Updated tests in `test/poolRoyaleOnlineFlow.test.js` to provide and assert the requested `tableId` is included in seat requests.

### Testing
- Ran `npm test -- poolRoyaleOnlineFlow.test.js` and the suite passed (2 tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf6b23a0a48329a6f0ea74ef2e5537)