### PR TITLE
Fix stale TON wallet connection state on Home page

### DIFF
--- a/webapp/src/components/TonConnectSync.jsx
+++ b/webapp/src/components/TonConnectSync.jsx
@@ -14,12 +14,20 @@ export default function TonConnectSync() {
   };
 
   const syncWalletAddress = (address) => {
-    if (address) {
-      localStorage.setItem('walletAddress', address);
+    const normalizedAddress = address || '';
+
+    if (normalizedAddress) {
+      localStorage.setItem('walletAddress', normalizedAddress);
       closeModalIfConnected();
     } else {
       localStorage.removeItem('walletAddress');
     }
+
+    window.dispatchEvent(
+      new CustomEvent('walletAddressUpdated', {
+        detail: { address: normalizedAddress },
+      }),
+    );
   };
 
   useEffect(() => {

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -31,13 +31,22 @@ import useWalletUsdValue from '../hooks/useWalletUsdValue.js';
 import { getTelegramId, getTelegramPhotoUrl } from '../utils/telegram.js';
 import { loadGoogleProfile } from '../utils/google.js';
 
+const getStoredWalletAddress = () => {
+  try {
+    return localStorage.getItem('walletAddress') || '';
+  } catch {
+    return '';
+  }
+};
+
 export default function Home() {
   const [status, setStatus] = useState('checking');
 
   const [photoUrl, setPhotoUrl] = useState(loadAvatar() || '');
   const { tpcBalance, tonBalance, tpcWalletBalance } = useTokenBalances();
   const usdValue = useWalletUsdValue(tonBalance, tpcWalletBalance);
-  const walletAddress = useTonAddress();
+  const tonAddress = useTonAddress();
+  const [walletAddress, setWalletAddress] = useState(() => tonAddress || getStoredWalletAddress());
   const hasGoogle = Boolean(loadGoogleProfile()?.id);
   let telegramId = null;
   try {
@@ -46,6 +55,33 @@ export default function Home() {
     telegramId = null;
   }
   const hasTelegram = Boolean(telegramId);
+
+  useEffect(() => {
+    setWalletAddress(tonAddress || getStoredWalletAddress());
+  }, [tonAddress]);
+
+  useEffect(() => {
+    const syncFromStorage = () => {
+      setWalletAddress(tonAddress || getStoredWalletAddress());
+    };
+
+    const handleWalletAddressUpdated = (event) => {
+      const nextAddress = event?.detail?.address || '';
+      setWalletAddress(nextAddress || tonAddress || getStoredWalletAddress());
+    };
+
+    window.addEventListener('storage', syncFromStorage);
+    window.addEventListener('focus', syncFromStorage);
+    window.addEventListener('pageshow', syncFromStorage);
+    window.addEventListener('walletAddressUpdated', handleWalletAddressUpdated);
+
+    return () => {
+      window.removeEventListener('storage', syncFromStorage);
+      window.removeEventListener('focus', syncFromStorage);
+      window.removeEventListener('pageshow', syncFromStorage);
+      window.removeEventListener('walletAddressUpdated', handleWalletAddressUpdated);
+    };
+  }, [tonAddress]);
 
   const handleOpenTelegramAuth = () => {
     const deepLink = 'tg://resolve?domain=TonPlaygramBot&startapp=account';


### PR DESCRIPTION
### Motivation
- The Home page could continue showing a "searching" or disconnected state after a user completed a TON Connect/RonConnect flow elsewhere because the local Home state wasn't refreshed reliably from TonConnect changes or persisted data.

### Description
- Emit a `walletAddressUpdated` `CustomEvent` and normalize the address in `TonConnectSync` so every TON connection status change also broadcasts the normalized wallet address and still updates `localStorage.walletAddress`.
- Update `Home` to initialize its `walletAddress` from the TonConnect hook or from `localStorage` and to resync when the TonConnect hook (`tonAddress`) changes.
- Add listeners in `Home` for `walletAddressUpdated`, `storage`, `focus`, and `pageshow` so the UI refreshes immediately when returning from external wallet apps or when storage changes.
- Use the synced `walletAddress` state for conditional UI so the connect prompt no longer shows when a wallet has already been connected elsewhere.

### Testing
- Ran the web build with `npm run build` in `webapp`, and the build completed successfully.
- The build produced the same existing Vite chunk-size/dynamic import warnings which are unrelated to this change and did not block the build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf6ac7c7b08329a3729c9d963099e3)