### PR TITLE
Add authoritative online Checkers rooms and server-side move sync

### DIFF
--- a/bot/config/onlineGamePolicy.js
+++ b/bot/config/onlineGamePolicy.js
@@ -13,6 +13,7 @@ const GAME_ONLINE_POLICY = Object.freeze({
   snake: { maxPlayers: [2, 3, 4], allowMatchMeta: ['mode', 'token'] },
   chessbattleroyal: { maxPlayers: [2], allowMatchMeta: ['preferredSide', 'mode', 'token'] },
   checkersbattleroyal: { maxPlayers: [2], allowMatchMeta: ['mode', 'token'] },
+  checkers: { maxPlayers: [2], allowMatchMeta: ['mode', 'token'] },
   'domino-royal': { maxPlayers: [2, 4], allowMatchMeta: ['variant', 'mode', 'token'] },
   ludobattleroyal: { maxPlayers: [2, 4], allowMatchMeta: ['variant', 'mode', 'token'] },
   texasholdem: { maxPlayers: [2, 6], allowMatchMeta: ['mode', 'token'] },

--- a/bot/gameEngine.js
+++ b/bot/gameEngine.js
@@ -231,6 +231,7 @@ export class GameRoom {
     const current = this.players[this.currentTurn];
     if (current) {
       this.io.to(this.id).emit('turnChanged', { playerId: current.playerId });
+      if (this.gameType !== 'snake') return;
       if (this.turnTimer) clearTimeout(this.turnTimer);
       this.turnTimer = setTimeout(() => {
         if (
@@ -520,10 +521,11 @@ export class GameRoomManager {
     return room;
   }
 
-  async joinRoom(roomId, playerId, name, socket, avatar = '') {
+  async joinRoom(roomId, playerId, name, socket, avatar = '', options = {}) {
     const match = /-(\d+)$/.exec(roomId);
-    const cap = match ? Number(match[1]) : 4;
-    const room = await this.getRoom(roomId, cap);
+    const fallbackCap = match ? Number(match[1]) : 4;
+    const cap = Number(options.capacity) || fallbackCap;
+    const room = await this.getRoom(roomId, cap, undefined, options.gameType);
     const result = room.addPlayer(playerId, name, socket, avatar);
     if (!result.error) await this.saveRoom(room);
     return result;

--- a/bot/logic/checkersGame.js
+++ b/bot/logic/checkersGame.js
@@ -33,20 +33,105 @@ export class CheckersGame {
     return this.board[row][col];
   }
 
-  movePiece(playerIdx, from, to) {
-    const piece = this.pieceAt(from);
-    if (!piece || piece.player !== playerIdx) return false;
-    if (this.pieceAt(to)) return false;
-    const dr = to.row - from.row;
-    const dc = Math.abs(to.col - from.col);
-    if (Math.abs(dr) !== 1 || dc !== 1) return false;
-    if (!piece.king && dr !== (playerIdx === 0 ? 1 : -1)) return false;
-    this.board[to.row][to.col] = piece;
-    this.board[from.row][from.col] = null;
-    if ((playerIdx === 0 && to.row === 7) || (playerIdx === 1 && to.row === 0)) {
-      piece.king = true;
+  #countPieces(playerIdx) {
+    let count = 0;
+    for (let row = 0; row < 8; row++) {
+      for (let col = 0; col < 8; col++) {
+        const piece = this.board[row][col];
+        if (piece?.player === playerIdx) count += 1;
+      }
     }
-    this.currentTurn = (this.currentTurn + 1) % this.players.length;
-    return true;
+    return count;
+  }
+
+  #normalizeCell(cell) {
+    if (!cell || !Number.isInteger(cell.row) || !Number.isInteger(cell.col)) {
+      return null;
+    }
+    if (cell.row < 0 || cell.row > 7 || cell.col < 0 || cell.col > 7) {
+      return null;
+    }
+    return { row: cell.row, col: cell.col };
+  }
+
+  #isForwardMove(piece, playerIdx, dr) {
+    if (piece.king) return true;
+    return dr === (playerIdx === 0 ? 1 : -1);
+  }
+
+  movePiece(playerIdx, from, to) {
+    if (this.finished) return { ok: false, error: 'game_finished' };
+    if (this.currentTurn !== playerIdx) return { ok: false, error: 'not_your_turn' };
+    const fromCell = this.#normalizeCell(from);
+    const toCell = this.#normalizeCell(to);
+    if (!fromCell || !toCell) return { ok: false, error: 'invalid_cell' };
+
+    const piece = this.pieceAt(fromCell);
+    if (!piece || piece.player !== playerIdx) return { ok: false, error: 'invalid_piece' };
+    if (this.pieceAt(toCell)) return { ok: false, error: 'target_occupied' };
+
+    const dr = toCell.row - fromCell.row;
+    const dc = toCell.col - fromCell.col;
+    const absDr = Math.abs(dr);
+    const absDc = Math.abs(dc);
+    if (absDr !== absDc || (absDr !== 1 && absDr !== 2)) {
+      return { ok: false, error: 'invalid_move_shape' };
+    }
+
+    let captured = null;
+    if (absDr === 1) {
+      if (!this.#isForwardMove(piece, playerIdx, dr)) {
+        return { ok: false, error: 'invalid_direction' };
+      }
+    } else if (absDr === 2) {
+      if (!piece.king && !this.#isForwardMove(piece, playerIdx, dr / 2)) {
+        return { ok: false, error: 'invalid_direction' };
+      }
+      const mid = {
+        row: fromCell.row + dr / 2,
+        col: fromCell.col + dc / 2
+      };
+      const jumped = this.pieceAt(mid);
+      if (!jumped || jumped.player === playerIdx) {
+        return { ok: false, error: 'no_enemy_to_capture' };
+      }
+      captured = { ...mid, player: jumped.player };
+      this.board[mid.row][mid.col] = null;
+    }
+
+    this.board[toCell.row][toCell.col] = piece;
+    this.board[fromCell.row][fromCell.col] = null;
+    let crowned = false;
+    if ((playerIdx === 0 && toCell.row === 7) || (playerIdx === 1 && toCell.row === 0)) {
+      if (!piece.king) {
+        piece.king = true;
+        crowned = true;
+      }
+    }
+
+    const opponentIdx = playerIdx === 0 ? 1 : 0;
+    const opponentPieces = this.#countPieces(opponentIdx);
+    if (opponentPieces === 0) {
+      this.finished = true;
+    }
+
+    this.currentTurn = this.players.length > 0 ? (this.currentTurn + 1) % this.players.length : 0;
+    return {
+      ok: true,
+      from: fromCell,
+      to: toCell,
+      captured,
+      crowned,
+      nextTurn: this.currentTurn,
+      winner: this.finished ? playerIdx : null
+    };
+  }
+
+  getState() {
+    return {
+      board: this.board,
+      currentTurn: this.currentTurn,
+      finished: this.finished
+    };
   }
 }

--- a/bot/server.js
+++ b/bot/server.js
@@ -1482,7 +1482,11 @@ io.on('connection', (socket) => {
   socket.on('joinRoom', async ({ roomId, playerId, accountId, name, avatar }) => {
     const pid = playerId || accountId;
     const map = tableSeats.get(roomId);
-    const cap = Number(roomId.split('-')[1]) || 4;
+    const tableEntry = tableMap.get(roomId);
+    const cap =
+      Number(tableEntry?.maxPlayers) ||
+      Number(roomId.split('-')[1]) ||
+      4;
     if (!gameManager.rooms.has(roomId) && map && map.size < cap) {
       socket.emit('waitingForPlayers', { roomId, current: map.size, capacity: cap });
       return;
@@ -1513,7 +1517,13 @@ io.on('connection', (socket) => {
         () => {}
       );
     }
-    const result = await gameManager.joinRoom(roomId, pid, name, socket, avatar);
+    const inferredGameType =
+      tableEntry?.gameType ||
+      (roomId.startsWith('checkers') ? 'checkers' : 'snake');
+    const result = await gameManager.joinRoom(roomId, pid, name, socket, avatar, {
+      capacity: cap,
+      gameType: inferredGameType
+    });
     if (result.error) {
       socket.emit('error', result.error);
     } else if (result.board) {
@@ -1701,6 +1711,62 @@ io.on('connection', (socket) => {
     });
     socket.to(tableId).emit('chessMove', { tableId, ...next });
   });
+
+  socket.on('checkersMove', async ({ roomId, from, to }) => {
+    if (!roomId) return;
+    const room = await gameManager.getRoom(roomId).catch(() => null);
+    if (!room || room.gameType !== 'checkers') {
+      socket.emit('errorMessage', 'checkers_room_not_found');
+      return;
+    }
+    if (room.status !== 'playing') {
+      socket.emit('errorMessage', 'game_not_started');
+      return;
+    }
+    const playerIndex = room.players.findIndex((p) => p.socketId === socket.id);
+    if (playerIndex === -1) {
+      socket.emit('errorMessage', 'player_not_in_room');
+      return;
+    }
+    const result = room.game.movePiece(playerIndex, from, to);
+    if (!result?.ok) {
+      socket.emit('errorMessage', result?.error || 'invalid_move');
+      return;
+    }
+    room.currentTurn = room.game.currentTurn;
+    io.to(room.id).emit('checkersMove', {
+      roomId: room.id,
+      playerId: room.players[playerIndex]?.playerId,
+      from: result.from,
+      to: result.to,
+      captured: result.captured,
+      crowned: result.crowned,
+      board: room.game.board,
+      currentTurn: room.players[room.currentTurn]?.playerId || null
+    });
+    if (result.winner != null) {
+      room.status = 'finished';
+      io.to(room.id).emit('gameWon', {
+        roomId: room.id,
+        playerId: room.players[result.winner]?.playerId || null
+      });
+    } else {
+      room.emitNextTurn();
+    }
+    await gameManager.saveRoom(room);
+  });
+
+  socket.on('checkersSyncRequest', async ({ roomId }) => {
+    if (!roomId) return;
+    const room = await gameManager.getRoom(roomId).catch(() => null);
+    if (!room || room.gameType !== 'checkers') return;
+    socket.emit('checkersState', {
+      roomId,
+      board: room.game.board,
+      currentTurn: room.players[room.currentTurn]?.playerId || null,
+      status: room.status
+    });
+  });
   socket.on('watchRoom', async ({ roomId }) => {
     if (!roomId) return;
     let set = tableWatchers.get(roomId);
@@ -1764,6 +1830,9 @@ io.on('connection', (socket) => {
 
     const room = gameManager.findRoomBySocket(socket.id);
     if (!room) return;
+    if (room.gameType !== 'snake') {
+      return socket.emit('errorMessage', 'unsupported_action_for_game');
+    }
     if (isRateLimited(socket, 'rollDice', rollRateLimitMs)) {
       return socket.emit('errorMessage', 'roll_rate_limited');
     }


### PR DESCRIPTION
### Motivation
- Enable hosting full online Checkers matches with authoritative server logic so remote players can join, play, and stay in sync reliably.
- Ensure lobby validation and hosted-room inference accept and initialize Checkers rooms correctly and prevent cross-game timer/actions from running in non-Snake rooms.

### Description
- Added `checkers` to the online game policy so seat/lobby validation accepts hosted Checkers table IDs and metadata (`bot/config/onlineGamePolicy.js`).
- Reworked `CheckersGame` to perform normalized move validation and return structured results including captures, crowning, winner detection, and error codes; added helper routines and a `getState()` method (`bot/logic/checkersGame.js`).
- Implemented server-side socket handlers `checkersMove` and `checkersSyncRequest` to validate moves authoritatively, broadcast updated board and turn state, and emit `gameWon` when applicable (`bot/server.js`).
- Improved room join flow and inference so hosted tables created with arbitrary IDs still initialize with the correct `gameType` and `capacity` and pass those options to the game manager (`bot/server.js`, `bot/gameEngine.js`).
- Prevented Snake-specific auto-turn/roll timer from executing for non-Snake rooms and blocked `rollDice` actions when the socket room is not a Snake game to keep game behaviors isolated per game type (`bot/gameEngine.js`, `bot/server.js`).

### Testing
- Ran static runtime checks: `node --check bot/logic/checkersGame.js` (success).
- Ran static runtime checks: `node --check bot/gameEngine.js` (success).
- Ran static runtime checks: `node --check bot/server.js` (success).
- Ran static runtime checks: `node --check bot/config/onlineGamePolicy.js` (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf6f9105a4832988f0568ffa7f19b1)