### PR TITLE
Wait for socket reconnection before matchmaking in Pool/Snooker lobbies

### DIFF
--- a/test/poolRoyaleOnlineFlow.test.js
+++ b/test/poolRoyaleOnlineFlow.test.js
@@ -10,6 +10,13 @@ class MockSocket extends EventEmitter {
     this.connected = true;
     this.seatRequests = [];
     this.leaveRequests = [];
+    this.connectCalls = 0;
+  }
+
+  connect() {
+    this.connectCalls += 1;
+    this.connected = true;
+    this.emit('connect');
   }
 
   emit(event, payload, cb) {
@@ -197,4 +204,44 @@ test('runPoolRoyaleOnlineFlow refunds when matchmaking times out', async () => {
   assert.equal(addCalls[1][2], 'stake_refund');
   assert.ok(state.snapshot.matchingError.includes('timed out'));
   assert.equal(refs.pendingTableRef.current, '');
+});
+
+test('runPoolRoyaleOnlineFlow reconnects socket before seating table', async () => {
+  const mockSocket = new MockSocket();
+  mockSocket.connected = false;
+  const refs = createRefs();
+  const state = createState();
+  const addCalls = [];
+
+  const deps = {
+    ensureAccountId: () => Promise.resolve('acct-3'),
+    getAccountBalance: () => Promise.resolve({ balance: 200 }),
+    addTransaction: (...args) => {
+      addCalls.push(args);
+      return Promise.resolve();
+    },
+    getTelegramId: () => 'tg-3',
+    getTelegramFirstName: () => 'Chris',
+    socket: mockSocket
+  };
+
+  await runPoolRoyaleOnlineFlow({
+    stake: { token: 'TPC', amount: 100 },
+    variant: 'uk',
+    ballSet: 'uk',
+    playType: 'regular',
+    mode: 'online',
+    tableSize: 'medium',
+    avatar: 'me.png',
+    deps,
+    state,
+    refs,
+    timeouts: { seat: 50, matchmaking: 100, socketConnect: 50 }
+  });
+
+  assert.equal(mockSocket.connectCalls, 1);
+  assert.equal(mockSocket.seatRequests.length, 1, 'should proceed after reconnecting');
+  mockSocket.seatRequests[0].cb({ success: false, message: 'busy' });
+  await delay(0);
+  assert.equal(addCalls[0][2], 'stake');
 });

--- a/webapp/src/pages/Games/poolRoyaleOnlineFlow.js
+++ b/webapp/src/pages/Games/poolRoyaleOnlineFlow.js
@@ -4,6 +4,7 @@ import { socket } from '../../utils/socket.js';
 
 const DEFAULT_SEAT_TIMEOUT_MS = 12000;
 const DEFAULT_MATCH_TIMEOUT_MS = 30000;
+const DEFAULT_SOCKET_CONNECT_TIMEOUT_MS = 8000;
 
 function logSupportError(message, error, context = {}) {
   // Surface in console for support teams; caller will also show inline errors.
@@ -15,6 +16,41 @@ function clearTimeoutSafely(ref) {
     clearTimeout(ref.current);
     ref.current = null;
   }
+}
+
+async function ensureSocketReady(socketInstance, timeoutMs = DEFAULT_SOCKET_CONNECT_TIMEOUT_MS) {
+  if (!socketInstance) return false;
+  if (socketInstance.connected) return true;
+
+  try {
+    socketInstance.connect?.();
+  } catch {
+    return false;
+  }
+
+  return await new Promise((resolve) => {
+    let settled = false;
+    let timer;
+
+    const finish = (ok) => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      socketInstance.off?.('connect', onConnect);
+      socketInstance.off?.('connect_error', onConnectError);
+      socketInstance.off?.('error', onConnectError);
+      resolve(ok);
+    };
+
+    const onConnect = () => finish(true);
+    const onConnectError = () => finish(false);
+
+    timer = setTimeout(() => finish(socketInstance.connected), timeoutMs);
+
+    socketInstance.once?.('connect', onConnect);
+    socketInstance.once?.('connect_error', onConnectError);
+    socketInstance.once?.('error', onConnectError);
+  });
 }
 
 export async function runPoolRoyaleOnlineFlow({
@@ -62,6 +98,7 @@ export async function runPoolRoyaleOnlineFlow({
 
   const seatTimeoutMs = timeouts.seat ?? DEFAULT_SEAT_TIMEOUT_MS;
   const matchmakingTimeoutMs = timeouts.matchmaking ?? DEFAULT_MATCH_TIMEOUT_MS;
+  const socketConnectTimeoutMs = timeouts.socketConnect ?? DEFAULT_SOCKET_CONNECT_TIMEOUT_MS;
   const requestedTableId =
     typeof tableId === 'string' && tableId.trim() ? tableId.trim() : undefined;
 
@@ -145,7 +182,8 @@ export async function runPoolRoyaleOnlineFlow({
     return { success: false };
   }
 
-  if (!socketInstance?.connected) {
+  const socketReady = await ensureSocketReady(socketInstance, socketConnectTimeoutMs);
+  if (!socketReady) {
     setMatchStatus('');
     setMatchingError('Unable to reach the online arena. We refunded your stake.');
     await refundStake('socket_registration_failed', { accountId });

--- a/webapp/src/pages/Games/snookerRoyalOnlineFlow.js
+++ b/webapp/src/pages/Games/snookerRoyalOnlineFlow.js
@@ -4,6 +4,7 @@ import { socket } from '../../utils/socket.js';
 
 const DEFAULT_SEAT_TIMEOUT_MS = 12000;
 const DEFAULT_MATCH_TIMEOUT_MS = 30000;
+const DEFAULT_SOCKET_CONNECT_TIMEOUT_MS = 8000;
 
 function logSupportError(message, error, context = {}) {
   // Surface in console for support teams; caller will also show inline errors.
@@ -15,6 +16,41 @@ function clearTimeoutSafely(ref) {
     clearTimeout(ref.current);
     ref.current = null;
   }
+}
+
+async function ensureSocketReady(socketInstance, timeoutMs = DEFAULT_SOCKET_CONNECT_TIMEOUT_MS) {
+  if (!socketInstance) return false;
+  if (socketInstance.connected) return true;
+
+  try {
+    socketInstance.connect?.();
+  } catch {
+    return false;
+  }
+
+  return await new Promise((resolve) => {
+    let settled = false;
+    let timer;
+
+    const finish = (ok) => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      socketInstance.off?.('connect', onConnect);
+      socketInstance.off?.('connect_error', onConnectError);
+      socketInstance.off?.('error', onConnectError);
+      resolve(ok);
+    };
+
+    const onConnect = () => finish(true);
+    const onConnectError = () => finish(false);
+
+    timer = setTimeout(() => finish(socketInstance.connected), timeoutMs);
+
+    socketInstance.once?.('connect', onConnect);
+    socketInstance.once?.('connect_error', onConnectError);
+    socketInstance.once?.('error', onConnectError);
+  });
 }
 
 export async function runSnookerRoyalOnlineFlow({
@@ -61,6 +97,7 @@ export async function runSnookerRoyalOnlineFlow({
 
   const seatTimeoutMs = timeouts.seat ?? DEFAULT_SEAT_TIMEOUT_MS;
   const matchmakingTimeoutMs = timeouts.matchmaking ?? DEFAULT_MATCH_TIMEOUT_MS;
+  const socketConnectTimeoutMs = timeouts.socketConnect ?? DEFAULT_SOCKET_CONNECT_TIMEOUT_MS;
 
   const telegramId = getTelegramIdFn?.();
 
@@ -142,7 +179,8 @@ export async function runSnookerRoyalOnlineFlow({
     return { success: false };
   }
 
-  if (!socketInstance?.connected) {
+  const socketReady = await ensureSocketReady(socketInstance, socketConnectTimeoutMs);
+  if (!socketReady) {
     setMatchStatus('');
     setMatchingError('Unable to reach the online arena. We refunded your stake.');
     await refundStake('socket_registration_failed', { accountId });


### PR DESCRIPTION
### Motivation
- Players were being refunded immediately with "Unable to reach the online arena" when the client socket was briefly disconnected. 
- The previous logic checked `socket.connected` once and aborted, which caused premature stake refunds on transient network drops. 

### Description
- Add an in-file `ensureSocketReady` helper to `poolRoyaleOnlineFlow.js` and `snookerRoyalOnlineFlow.js` that calls `socket.connect()` and waits for `connect`/`connect_error` or a timeout. 
- Use a configurable `timeouts.socketConnect` (default `8000ms`) and wait before deciding to refund the stake. 
- Preserve existing stake reserve/refund behavior when reconnection cannot be established. 
- Add a regression test in `test/poolRoyaleOnlineFlow.test.js` that simulates a disconnected socket, verifies `connect()` is called, and ensures seating proceeds after reconnect. 

### Testing
- Ran `npm test -- test/poolRoyaleOnlineFlow.test.js --runInBand` and all tests passed (3 tests, including the new reconnect scenario). 
- The new test `runPoolRoyaleOnlineFlow reconnects socket before seating table` verifies reconnect attempt and continued seating and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf706f27f48329bbfc2478e96ed6d4)