### PR TITLE
Add hosted online multiplayer sync for Checkers Battle Royal

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -65,6 +65,7 @@ validateEnv();
 
 const CHESS_START_FEN = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w - - 0 1';
 const chessGames = new Map();
+const checkersGames = new Map();
 const AUTHENTIC_ACCOUNT_QUERY = {
   isBanned: { $ne: true },
   $or: [
@@ -586,6 +587,31 @@ function updateChessState(tableId, nextState = {}) {
   return merged;
 }
 
+function getCheckersState(tableId) {
+  if (!checkersGames.has(tableId)) {
+    checkersGames.set(tableId, {
+      board: null,
+      turn: 'light',
+      status: '',
+      capturedBySide: { light: [], dark: [] },
+      gameOver: null,
+      updatedAt: Date.now()
+    });
+  }
+  return checkersGames.get(tableId);
+}
+
+function updateCheckersState(tableId, nextState = {}) {
+  const base = getCheckersState(tableId);
+  const merged = {
+    ...base,
+    ...nextState,
+    updatedAt: Date.now()
+  };
+  checkersGames.set(tableId, merged);
+  return merged;
+}
+
 function normalizeSidePreference(pref) {
   return pref === 'white' || pref === 'black' ? pref : 'auto';
 }
@@ -738,6 +764,20 @@ function maybeStartGame(table) {
         if (whitePlayer) table.currentTurn = whitePlayer.id;
         const initial = updateChessState(table.id, { turnWhite: true, lastMove: null });
         io.to(table.id).emit('chessState', { tableId: table.id, ...initial });
+      } else if (table.gameType === 'checkers') {
+        table.players = assignChessSides(table.players);
+        const whitePlayer = table.players.find((p) => p.side === 'white');
+        if (whitePlayer) table.currentTurn = whitePlayer.id;
+        const initial = updateCheckersState(table.id, {
+          turn: 'light',
+          status: 'Match started',
+          capturedBySide: { light: [], dark: [] },
+          gameOver: null
+        });
+        io.to(table.id).emit('checkersState', {
+          tableId: table.id,
+          state: initial
+        });
       }
       io.to(table.id).emit('gameStart', {
         tableId: table.id,
@@ -1536,6 +1576,27 @@ io.on('connection', (socket) => {
     }
   });
 
+  socket.on('joinCheckersRoom', async ({ tableId, accountId }) => {
+    if (!tableId) return;
+    if (accountId && !ensureRegistered(socket, accountId)) return;
+    socket.join(tableId);
+    const state = getCheckersState(tableId);
+    socket.emit('checkersState', { tableId, state });
+    if (accountId) {
+      await registerConnection({
+        userId: String(accountId),
+        roomId: tableId,
+        socketId: socket.id
+      });
+    }
+  });
+
+  socket.on('checkersSyncRequest', ({ tableId }) => {
+    if (!tableId) return;
+    const state = getCheckersState(tableId);
+    socket.emit('checkersState', { tableId, state });
+  });
+
   socket.on('chessSyncRequest', ({ tableId }) => {
     if (!tableId) return;
     const state = getChessState(tableId);
@@ -1700,6 +1761,22 @@ io.on('connection', (socket) => {
       lastMove: move.lastMove || null
     });
     socket.to(tableId).emit('chessMove', { tableId, ...next });
+  });
+
+  socket.on('checkersMove', ({ tableId, accountId, state }) => {
+    if (!tableId || !state) return;
+    const next = updateCheckersState(tableId, {
+      board: Array.isArray(state.board) ? state.board : null,
+      turn: state.turn === 'dark' ? 'dark' : 'light',
+      status: typeof state.status === 'string' ? state.status : '',
+      capturedBySide: state.capturedBySide || { light: [], dark: [] },
+      gameOver: state.gameOver === 'light' || state.gameOver === 'dark' ? state.gameOver : null
+    });
+    socket.to(tableId).emit('checkersMove', {
+      tableId,
+      state: next,
+      hostId: accountId || null
+    });
   });
   socket.on('watchRoom', async ({ roomId }) => {
     if (!roomId) return;

--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -16,8 +16,10 @@ import {
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 import {
   getTelegramFirstName,
-  getTelegramPhotoUrl
+  getTelegramPhotoUrl,
+  getTelegramUsername
 } from '../../utils/telegram.js';
+import { socket } from '../../utils/socket.js';
 import { ARENA_CAMERA_DEFAULTS } from '../../utils/arenaCameraConfig.js';
 import {
   createMurlanStyleTable,
@@ -1071,6 +1073,20 @@ async function loadPolyHavenHdriEnvironment(renderer, variant = {}) {
 export default function CheckersBattleRoyal() {
   useTelegramBackButton();
   const navigate = useNavigate();
+  const searchParams = useMemo(
+    () =>
+      typeof window !== 'undefined'
+        ? new URLSearchParams(window.location.search || '')
+        : new URLSearchParams(),
+    []
+  );
+  const modeParam = searchParams.get('mode') || 'ai';
+  const accountId = searchParams.get('accountId') || '';
+  const initialTableId = searchParams.get('tableId') || '';
+  const initialSideParam = searchParams.get('side') || '';
+  const opponentNameParam = searchParams.get('opponentName') || '';
+  const opponentAvatarParam = searchParams.get('opponentAvatar') || '';
+  const isOnlineMode = modeParam === 'online';
   const mountRef = useRef(null);
 
   const boardRef = useRef(createInitial());
@@ -1097,6 +1113,10 @@ export default function CheckersBattleRoyal() {
 
   const [turn, setTurn] = useState('light');
   const [status, setStatus] = useState(`Loading arena… ${RULE_SUMMARY}`);
+  const [onlineStatus, setOnlineStatus] = useState(
+    isOnlineMode ? 'connecting' : 'offline'
+  );
+  const [tableId, setTableId] = useState(initialTableId);
   const [configOpen, setConfigOpen] = useState(false);
   const [viewMode, setViewMode] = useState('3d');
   const [showGift, setShowGift] = useState(false);
@@ -1107,6 +1127,23 @@ export default function CheckersBattleRoyal() {
     dark: []
   });
   const aiBusyRef = useRef(false);
+  const onlineRef = useRef({
+    enabled: Boolean(isOnlineMode && accountId && initialTableId),
+    tableId: initialTableId || null,
+    side: initialSideParam === 'black' ? 'dark' : 'light',
+    synced: !isOnlineMode,
+    opponent: {
+      name: opponentNameParam || '',
+      avatar: opponentAvatarParam || ''
+    },
+    status: isOnlineMode ? 'connecting' : 'offline'
+  });
+
+  useEffect(() => {
+    if (!isOnlineMode) return;
+    if (accountId && initialTableId) return;
+    navigate('/games/checkersbattleroyal/lobby', { replace: true });
+  }, [accountId, initialTableId, isOnlineMode, navigate]);
   const resolvedAccountId = useMemo(() => chessBattleAccountId(), []);
   const [inventory, setInventory] = useState(() =>
     getChessBattleInventory(resolvedAccountId)
@@ -1319,21 +1356,26 @@ export default function CheckersBattleRoyal() {
     appearance.tableId,
     resolvedAccountId
   ]);
-  const playerName = getTelegramFirstName() || 'Player';
+
+  const playerName =
+    getTelegramFirstName() || getTelegramUsername() || 'Player';
   const playerPhotoUrl = getTelegramPhotoUrl() || '/assets/icons/profile.svg';
+  const myOnlineSide = onlineRef.current.side || 'light';
+  const rivalName = onlineRef.current.opponent?.name || 'Rival';
+  const rivalAvatar = onlineRef.current.opponent?.avatar || '/assets/icons/profile.svg';
 
   const players = [
     {
       index: 0,
-      name: 'Rival',
-      photoUrl: '/assets/icons/profile.svg',
+      name: myOnlineSide === 'light' ? rivalName : playerName,
+      photoUrl: myOnlineSide === 'light' ? rivalAvatar : playerPhotoUrl,
       color: '#f43f5e',
       isTurn: turn === 'dark'
     },
     {
       index: 1,
-      name: playerName,
-      photoUrl: playerPhotoUrl,
+      name: myOnlineSide === 'light' ? playerName : rivalName,
+      photoUrl: myOnlineSide === 'light' ? playerPhotoUrl : rivalAvatar,
       color: '#38bdf8',
       isTurn: turn === 'light'
     }
@@ -1484,6 +1526,120 @@ export default function CheckersBattleRoyal() {
   );
 
   useEffect(() => {
+    onlineRef.current.enabled = Boolean(isOnlineMode && accountId && tableId);
+    onlineRef.current.tableId = tableId || null;
+  }, [accountId, isOnlineMode, tableId]);
+
+  const serializeOnlineState = useMemo(
+    () => () => ({
+      board: copyBoard(boardRef.current),
+      turn,
+      status,
+      capturedBySide,
+      gameOver
+    }),
+    [capturedBySide, gameOver, status, turn]
+  );
+
+  const applyOnlineState = useMemo(
+    () => (payload = {}) => {
+      if (!payload || typeof payload !== 'object') return;
+      if (Array.isArray(payload.board)) {
+        boardRef.current = copyBoard(payload.board);
+        renderPieces();
+      }
+      if (payload.turn === 'light' || payload.turn === 'dark') {
+        setTurn(payload.turn);
+      }
+      if (payload.status) setStatus(payload.status);
+      if (payload.capturedBySide) {
+        setCapturedBySide({
+          light: Array.isArray(payload.capturedBySide.light)
+            ? payload.capturedBySide.light
+            : [],
+          dark: Array.isArray(payload.capturedBySide.dark)
+            ? payload.capturedBySide.dark
+            : []
+        });
+      }
+      if (payload.gameOver === 'light' || payload.gameOver === 'dark') {
+        setGameOver(payload.gameOver);
+      } else if (!payload.gameOver) {
+        setGameOver(null);
+      }
+      selectedRef.current = null;
+      renderHighlights();
+      setCanReplay(false);
+      replayStateRef.current = null;
+    },
+    [renderHighlights, renderPieces]
+  );
+
+  useEffect(() => {
+    if (!onlineRef.current.enabled || !accountId) return undefined;
+    const normalizedInitialSide = initialSideParam === 'black' ? 'dark' : 'light';
+    onlineRef.current.side = normalizedInitialSide;
+    setOnlineStatus('connecting');
+
+    const handleCheckersState = ({ tableId: remoteTableId, state, hostId } = {}) => {
+      if (!remoteTableId || !onlineRef.current.tableId) return;
+      if (remoteTableId !== onlineRef.current.tableId) return;
+      if (hostId && String(hostId) === String(accountId)) return;
+      if (state) applyOnlineState(state);
+      onlineRef.current.synced = true;
+      onlineRef.current.status = 'in-progress';
+      setOnlineStatus('in-game');
+    };
+
+    const handleGameStart = ({ tableId: startedId, players = [] } = {}) => {
+      if (!startedId) return;
+      const me = players.find((p) => String(p.id) === String(accountId));
+      const opp = players.find((p) => String(p.id) !== String(accountId));
+      if (me?.side === 'black' || me?.side === 'white') {
+        onlineRef.current.side = me.side === 'black' ? 'dark' : 'light';
+      }
+      if (opp) onlineRef.current.opponent = { name: opp.name || '', avatar: opp.avatar || '' };
+      onlineRef.current.tableId = startedId;
+      onlineRef.current.status = 'started';
+      setTableId(startedId);
+      setOnlineStatus('in-game');
+      socket.emit('joinCheckersRoom', { tableId: startedId, accountId });
+      socket.emit('checkersSyncRequest', { tableId: startedId });
+      if ((me?.side || '').toLowerCase() === 'white') {
+        window.setTimeout(() => {
+          socket.emit('checkersMove', {
+            tableId: startedId,
+            accountId,
+            state: {
+              board: copyBoard(boardRef.current),
+              turn: 'light',
+              status: `Match started. ${RULE_SUMMARY}`,
+              capturedBySide: { light: [], dark: [] },
+              gameOver: null
+            }
+          });
+        }, 120);
+      }
+    };
+
+    socket.on('gameStart', handleGameStart);
+    socket.on('checkersState', handleCheckersState);
+    socket.on('checkersMove', handleCheckersState);
+    socket.emit('register', { playerId: accountId });
+
+    if (tableId) {
+      socket.emit('joinCheckersRoom', { tableId, accountId });
+      socket.emit('checkersSyncRequest', { tableId });
+    }
+
+    return () => {
+      socket.off('gameStart', handleGameStart);
+      socket.off('checkersState', handleCheckersState);
+      socket.off('checkersMove', handleCheckersState);
+    };
+  }, [accountId, applyOnlineState, initialSideParam, tableId]);
+
+  useEffect(() => {
     const mount = mountRef.current;
     if (!mount) return;
 
@@ -1568,11 +1724,15 @@ export default function CheckersBattleRoyal() {
     const applyMove = (r, c) => {
       const board = boardRef.current;
       const selected = selectedRef.current;
+      const isOnline = onlineRef.current.enabled;
+      const mySide = onlineRef.current.side || HUMAN_SIDE;
+      const canAct = isOnline ? turn === mySide : turn === HUMAN_SIDE;
+      if (!canAct) return;
       const sideMoves = getMovesForSide(board, turn);
       if (!sideMoves.length) {
-        const winnerSide = turn === HUMAN_SIDE ? AI_SIDE : HUMAN_SIDE;
+        const winnerSide = turn === 'light' ? 'dark' : 'light';
         setStatus(
-          `${turn === HUMAN_SIDE ? 'You' : 'AI'} has no legal moves. ${winnerSide === HUMAN_SIDE ? 'You' : 'AI'} win.`
+          `${turn === mySide ? 'You' : 'Opponent'} have no legal moves. ${winnerSide === mySide ? 'You' : 'Opponent'} win.`
         );
         setGameOver(winnerSide);
         return;
@@ -1580,7 +1740,6 @@ export default function CheckersBattleRoyal() {
 
       const piece = board[r][c];
       if (piece && piece.side === turn) {
-        if (turn === AI_SIDE) return;
         const forcedCaptures = sideMoves.filter((move) => move.capture);
         if (
           forcedCaptures.length &&
@@ -1651,7 +1810,7 @@ export default function CheckersBattleRoyal() {
       }
 
       selectedRef.current = null;
-      const nextTurn = turn === HUMAN_SIDE ? AI_SIDE : HUMAN_SIDE;
+      const nextTurn = turn === 'light' ? 'dark' : 'light';
       replayStateRef.current = {
         beforeBoard,
         afterBoard: copyBoard(applied.board),
@@ -1665,15 +1824,24 @@ export default function CheckersBattleRoyal() {
         setGameOver(winnerSide);
         setTurn(nextTurn);
         setStatus(
-          `${nextTurn === HUMAN_SIDE ? 'You' : 'AI'} has no legal moves. ${winnerSide === HUMAN_SIDE ? 'You' : 'AI'} win!`
+          `${nextTurn === mySide ? 'You' : 'Opponent'} have no legal moves. ${winnerSide === mySide ? 'You' : 'Opponent'} win!`
         );
       } else {
         setTurn(nextTurn);
         setStatus(
-          nextTurn === HUMAN_SIDE
+          nextTurn === mySide
             ? 'Your turn. Forced captures are enabled.'
-            : 'AI is thinking…'
+            : isOnline
+              ? 'Opponent turn…'
+              : 'AI is thinking…'
         );
+      }
+      if (isOnline && onlineRef.current.tableId) {
+        socket.emit('checkersMove', {
+          tableId: onlineRef.current.tableId,
+          accountId,
+          state: serializeOnlineState()
+        });
       }
       renderHighlights();
     };
@@ -1989,6 +2157,7 @@ export default function CheckersBattleRoyal() {
   }, []);
 
   useEffect(() => {
+    if (onlineRef.current.enabled) return undefined;
     if (turn !== AI_SIDE || aiBusyRef.current || gameOver) return;
     aiBusyRef.current = true;
     setStatus('AI is thinking…');
@@ -2240,10 +2409,13 @@ export default function CheckersBattleRoyal() {
 
   useEffect(() => {
     if (!gameOver) return;
+    const mySide = onlineRef.current.enabled
+      ? onlineRef.current.side || HUMAN_SIDE
+      : HUMAN_SIDE;
     const winnerAvatar =
-      gameOver === HUMAN_SIDE ? playerPhotoUrl : '/assets/icons/profile.svg';
+      gameOver === mySide ? playerPhotoUrl : rivalAvatar;
     coinConfetti(60, winnerAvatar);
-  }, [gameOver, playerPhotoUrl]);
+  }, [gameOver, playerPhotoUrl, rivalAvatar]);
 
   const replayLastMove = () => {
     if (!replayStateRef.current) return;
@@ -2504,6 +2676,7 @@ export default function CheckersBattleRoyal() {
         <div className="absolute bottom-10 left-1/2 -translate-x-1/2 pointer-events-none">
           <div className="px-5 py-2 rounded-full bg-[rgba(7,10,18,0.65)] border border-[rgba(255,215,0,0.25)] text-sm font-semibold backdrop-blur">
             {status} • Turn: {turn}
+            {onlineStatus !== 'offline' ? ` • Net: ${onlineStatus}` : ''}
           </div>
         </div>
 
@@ -2515,15 +2688,23 @@ export default function CheckersBattleRoyal() {
               </p>
               <img
                 src={
-                  gameOver === HUMAN_SIDE
+                  gameOver ===
+                  (onlineRef.current.enabled
+                    ? onlineRef.current.side || HUMAN_SIDE
+                    : HUMAN_SIDE)
                     ? playerPhotoUrl
-                    : '/assets/icons/profile.svg'
+                    : rivalAvatar
                 }
                 alt="winner avatar"
                 className="mx-auto mt-3 h-20 w-20 rounded-full border-4 border-yellow-300/70 object-cover"
               />
               <p className="mt-2 text-lg font-bold text-white">
-                {gameOver === HUMAN_SIDE ? playerName : 'Rival'}
+                {gameOver ===
+                (onlineRef.current.enabled
+                  ? onlineRef.current.side || HUMAN_SIDE
+                  : HUMAN_SIDE)
+                  ? playerName
+                  : rivalName}
               </p>
               <div className="mt-4 flex gap-2">
                 <button


### PR DESCRIPTION
### Motivation
- Enable Checkers Battle Royal to run as a hosted online match so players matched in the lobby can join a live session and keep game state in sync across clients.
- Reuse existing lobby/`seatTable` flow while providing a lightweight authoritative sync channel for checkers state so matches start cleanly and opponent info appears in-game.

### Description
- Client: wired query params (`mode`, `accountId`, `tableId`, `side`, `opponentName`, `opponentAvatar`) and added online session plumbing to `webapp/src/pages/Games/CheckersBattleRoyal.jsx`, including `onlineRef`, `serializeOnlineState`, `applyOnlineState`, socket handlers for `gameStart`, `checkersState`, `checkersMove`, auto-join/sync and a small host snapshot emit on start. UI now shows online status and opponent identity and the winner panel uses the correct avatar/name in online matches.
- Gameplay: gated input so only the player whose side is active can act in online mode, emit `checkersMove` after local moves, disabled local AI loop while online, and adjusted status/win messages for online play.
- Server: added an in-memory checkers state store and helpers in `bot/server.js` (`checkersGames`, `getCheckersState`, `updateCheckersState`), extended `maybeStartGame` to initialize checkers state and emit `checkersState`, and added socket handlers `joinCheckersRoom`, `checkersSyncRequest`, and `checkersMove` to propagate and persist state and broadcast host updates.
- Files changed: `webapp/src/pages/Games/CheckersBattleRoyal.jsx` (client logic & UI), `bot/server.js` (server state + socket handlers).

### Testing
- Built web client with `npm -C webapp run build` and the build completed successfully (production bundle generated). (success)
- Performed static check on server JS with `node --check bot/server.js` and there were no syntax errors. (success)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf6f9105a4832988f0568ffa7f19b1)