### PR TITLE
Fix Pool Royale online matchmaking failing before socket connects

### DIFF
--- a/test/poolRoyaleOnlineFlow.test.js
+++ b/test/poolRoyaleOnlineFlow.test.js
@@ -10,6 +10,16 @@ class MockSocket extends EventEmitter {
     this.connected = true;
     this.seatRequests = [];
     this.leaveRequests = [];
+    this.connectCalls = 0;
+    this.autoConnect = false;
+  }
+
+  connect() {
+    this.connectCalls += 1;
+    if (this.autoConnect) {
+      this.connected = true;
+      setImmediate(() => this.emit('connect'));
+    }
   }
 
   emit(event, payload, cb) {
@@ -197,4 +207,49 @@ test('runPoolRoyaleOnlineFlow refunds when matchmaking times out', async () => {
   assert.equal(addCalls[1][2], 'stake_refund');
   assert.ok(state.snapshot.matchingError.includes('timed out'));
   assert.equal(refs.pendingTableRef.current, '');
+});
+
+test('runPoolRoyaleOnlineFlow waits for socket connection before failing', async () => {
+  const mockSocket = new MockSocket();
+  mockSocket.connected = false;
+  mockSocket.autoConnect = true;
+  const refs = createRefs();
+  const state = createState();
+  const addCalls = [];
+
+  const deps = {
+    ensureAccountId: () => Promise.resolve('acct-20'),
+    getAccountBalance: () => Promise.resolve({ balance: 300 }),
+    addTransaction: (...args) => {
+      addCalls.push(args);
+      return Promise.resolve();
+    },
+    getTelegramId: () => 'tg-20',
+    getTelegramFirstName: () => 'Jo',
+    socket: mockSocket
+  };
+
+  await runPoolRoyaleOnlineFlow({
+    stake: { token: 'TPC', amount: 50 },
+    tableId: 'room-connect',
+    variant: 'uk',
+    ballSet: 'uk',
+    playType: 'regular',
+    mode: 'online',
+    tableSize: 'medium',
+    avatar: 'me.png',
+    deps,
+    state,
+    refs,
+    timeouts: { seat: 100, matchmaking: 200 }
+  });
+
+  assert.equal(mockSocket.connectCalls, 1);
+  assert.equal(mockSocket.seatRequests.length, 1, 'should proceed to seat after connect');
+  const seatCb = mockSocket.seatRequests[0].cb;
+  seatCb({ success: true, tableId: 'tbl-connect', players: [], ready: [] });
+  mockSocket.emit('gameStart', { tableId: 'tbl-connect', players: [] });
+  await delay(0);
+  assert.equal(addCalls.length, 1, 'should only debit stake before seat result');
+  assert.equal(state.snapshot.matchingError, '');
 });

--- a/webapp/src/pages/Games/poolRoyaleOnlineFlow.js
+++ b/webapp/src/pages/Games/poolRoyaleOnlineFlow.js
@@ -17,6 +17,43 @@ function clearTimeoutSafely(ref) {
   }
 }
 
+function waitForSocketConnection(socketInstance, timeoutMs = 8000) {
+  if (!socketInstance) return Promise.resolve(false);
+  if (socketInstance.connected) return Promise.resolve(true);
+
+  return new Promise((resolve) => {
+    let settled = false;
+    let timeoutId = null;
+
+    const cleanup = () => {
+      if (timeoutId) clearTimeout(timeoutId);
+      socketInstance.off('connect', onConnect);
+      socketInstance.off('connect_error', onConnectError);
+    };
+
+    const settle = (connected) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(connected);
+    };
+
+    const onConnect = () => settle(true);
+    const onConnectError = () => settle(Boolean(socketInstance.connected));
+
+    socketInstance.on('connect', onConnect);
+    socketInstance.on('connect_error', onConnectError);
+
+    timeoutId = setTimeout(() => settle(Boolean(socketInstance.connected)), timeoutMs);
+
+    try {
+      socketInstance.connect?.();
+    } catch {
+      settle(false);
+    }
+  });
+}
+
 export async function runPoolRoyaleOnlineFlow({
   stake,
   tableId,
@@ -145,7 +182,8 @@ export async function runPoolRoyaleOnlineFlow({
     return { success: false };
   }
 
-  if (!socketInstance?.connected) {
+  const isSocketConnected = await waitForSocketConnection(socketInstance);
+  if (!isSocketConnected) {
     setMatchStatus('');
     setMatchingError('Unable to reach the online arena. We refunded your stake.');
     await refundStake('socket_registration_failed', { accountId });


### PR DESCRIPTION
### Motivation
- Prevent the online matchmaking flow from failing immediately when the Socket.IO client is still handshaking on flaky/mobile networks. 
- Avoid incorrectly refunding a player's stake due to a socket connect race. 
- Improve reliability of the Pool Royale online join flow so it proceeds once the socket actually connects. 

### Description
- Added `waitForSocketConnection(socketInstance, timeoutMs)` which calls `socket.connect()` and waits for `connect` / `connect_error` events or a timeout before deciding connectivity. 
- Replaced the immediate `socketInstance?.connected` check with an `await waitForSocketConnection(...)` before treating the arena as unreachable. 
- Added a regression test `runPoolRoyaleOnlineFlow waits for socket connection before failing` and updated `MockSocket` to support `connect()` / `autoConnect` / `connectCalls` for the simulation. 
- Modified files: `webapp/src/pages/Games/poolRoyaleOnlineFlow.js` and `test/poolRoyaleOnlineFlow.test.js`. 

### Testing
- Ran `npm test -- test/poolRoyaleOnlineFlow.test.js --runInBand` and all tests in that file passed. 
- Test summary: 3 tests passed (the existing debit/refund tests plus the new socket-connect regression test).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf706f27f48329bbfc2478e96ed6d4)