### PR TITLE
Include Telegram initData in Socket.IO auth for Pool Royale online matchmaking

### DIFF
--- a/webapp/src/utils/socket.js
+++ b/webapp/src/utils/socket.js
@@ -37,6 +37,25 @@ function loadMetaEnv() {
   return {};
 }
 
+function getTelegramInitData() {
+  if (typeof window === 'undefined') return '';
+  return window?.Telegram?.WebApp?.initData || '';
+}
+
+function getStoredAccountId() {
+  if (typeof window === 'undefined') return '';
+  return window?.localStorage?.getItem('accountId') || '';
+}
+
+function buildSocketAuthPayload() {
+  const initData = getTelegramInitData();
+  const accountId = getStoredAccountId();
+  return {
+    ...(initData ? { initData } : {}),
+    ...(accountId ? { accountId } : {})
+  };
+}
+
 function resolveSocketConfig() {
   const metaEnv = loadMetaEnv();
   const explicitUrl = metaEnv.VITE_SOCKET_URL;
@@ -48,6 +67,7 @@ function resolveSocketConfig() {
   const options = {
     path,
     transports: ['websocket', 'polling'],
+    auth: (cb) => cb(buildSocketAuthPayload()),
     reconnectionAttempts: 8,
     reconnectionDelay: 500,
     reconnectionDelayMax: 5000,


### PR DESCRIPTION
### Motivation
- Online Pool Royale matchmaking could fail because the client did not send Telegram WebApp init data (or stored account id) during the Socket.IO handshake, causing the server to reject the connection and trigger immediate refund/timeout flows.

### Description
- Added helpers `getTelegramInitData`, `getStoredAccountId`, and `buildSocketAuthPayload` to `webapp/src/utils/socket.js` to safely read `window.Telegram.WebApp.initData` and `localStorage` account id.
- Configured the Socket.IO client options to include an `auth` callback that sends `{ initData, accountId }` when present so the server socket middleware can authenticate the handshake.
- Kept existing base URL and `path` resolution unchanged and preserved reconnection/transport settings.
- Changed file: `webapp/src/utils/socket.js`.

### Testing
- Ran `npm test -- test/poolRoyaleOnlineFlow.test.js --runInBand`, which executed the Pool Royale online flow unit tests and completed successfully (2 tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf706f27f48329bbfc2478e96ed6d4)