### PR TITLE
Display wallet balances and add Solana/BSC balance helper; UI and provider typing tweaks

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,8 @@
     "react-dom": "^18.3.1",
     "viem": "^2.21.45",
     "wagmi": "^2.13.8",
-    "@tanstack/react-query": "^5.59.20"
+    "@tanstack/react-query": "^5.59.20",
+    "@solana/web3.js": "^1.98.4"
   },
   "devDependencies": {
     "@types/react": "^18.3.12",

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import type { ComponentType } from 'react';
 import { App } from './App';
 import { ConnectionProvider, WalletProvider } from '@solana/wallet-adapter-react';
 import { PhantomWalletAdapter } from '@solana/wallet-adapter-wallets';
@@ -11,6 +12,9 @@ import { TonConnectUIProvider } from '@tonconnect/ui-react';
 
 const solanaWallets = [new PhantomWalletAdapter()];
 const queryClient = new QueryClient();
+
+const SolanaConnectionProvider = ConnectionProvider as unknown as ComponentType<any>;
+const SolanaWalletProvider = WalletProvider as unknown as ComponentType<any>;
 
 const wagmiConfig = createConfig({
   chains: [bsc],
@@ -55,16 +59,16 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
       actionsConfiguration={{
         returnStrategy: 'back',
         // Only used in Telegram WebView; harmless elsewhere.
-        twaReturnUrl: window.location.href,
+        twaReturnUrl: window.location.href as `${string}://${string}`,
       }}
     >
       <WagmiProvider config={wagmiConfig}>
         <QueryClientProvider client={queryClient}>
-          <ConnectionProvider endpoint="https://api.mainnet-beta.solana.com">
-            <WalletProvider wallets={solanaWallets} autoConnect>
+          <SolanaConnectionProvider endpoint="https://api.mainnet-beta.solana.com">
+            <SolanaWalletProvider wallets={solanaWallets} autoConnect>
               <App />
-            </WalletProvider>
-          </ConnectionProvider>
+            </SolanaWalletProvider>
+          </SolanaConnectionProvider>
         </QueryClientProvider>
       </WagmiProvider>
     </TonConnectUIProvider>

--- a/frontend/src/wallets/AddWalletModal.tsx
+++ b/frontend/src/wallets/AddWalletModal.tsx
@@ -3,23 +3,48 @@ import { SolanaLink } from './solana/SolanaLink';
 import { EvmLink } from './evm/EvmLink';
 import { TonLink } from './ton/TonLink';
 
+type ChainTab = 'solana' | 'evm' | 'ton';
+
+const TAB_LABEL: Record<ChainTab, string> = {
+  solana: 'Solana',
+  evm: 'BNB',
+  ton: 'TON',
+};
+
 export function AddWalletModal({ onClose, onDone }: { onClose: () => void; onDone: () => Promise<void> }) {
-  const [chain, setChain] = useState<'solana' | 'evm' | 'ton'>('solana');
+  const [chain, setChain] = useState<ChainTab>('solana');
 
   return (
-    <div style={{ border: '1px solid #ccc', padding: 12 }}>
-      <h4>Link wallet</h4>
-      <select value={chain} onChange={(e) => setChain(e.target.value as typeof chain)}>
-        <option value="solana">Solana</option>
-        <option value="evm">EVM</option>
-        <option value="ton">TON</option>
-      </select>
+    <div style={{ border: '1px solid #ccc', padding: 12, borderRadius: 10, background: '#fff' }}>
+      <h4 style={{ marginTop: 0 }}>Link wallet</h4>
+      <p style={{ marginTop: 0, color: '#666' }}>Choose one wallet network to connect.</p>
+
+      <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 12 }}>
+        {(['solana', 'evm', 'ton'] as const).map((tab) => (
+          <button
+            key={tab}
+            type="button"
+            onClick={() => setChain(tab)}
+            style={{
+              padding: '8px 12px',
+              borderRadius: 999,
+              border: '1px solid #ccc',
+              background: chain === tab ? '#111' : '#fff',
+              color: chain === tab ? '#fff' : '#111',
+            }}
+          >
+            {TAB_LABEL[tab]}
+          </button>
+        ))}
+      </div>
 
       {chain === 'solana' && <SolanaLink onDone={onDone} />}
       {chain === 'evm' && <EvmLink onDone={onDone} />}
       {chain === 'ton' && <TonLink onDone={onDone} />}
 
-      <button onClick={onClose}>Close</button>
+      <div style={{ marginTop: 12 }}>
+        <button onClick={onClose}>Close</button>
+      </div>
     </div>
   );
 }

--- a/frontend/src/wallets/WalletsScreen.tsx
+++ b/frontend/src/wallets/WalletsScreen.tsx
@@ -1,9 +1,19 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { SessionState } from '../auth/useSession';
 import { AddWalletModal } from './AddWalletModal';
+import { getWalletBalance } from './balance/getWalletBalance';
+
+type BalanceState = Record<string, { loading: boolean; value?: string; error?: string }>;
+
+function chainLabel(chain: 'solana' | 'evm' | 'ton') {
+  if (chain === 'evm') return 'BNB';
+  if (chain === 'ton') return 'TON';
+  return 'Solana';
+}
 
 export function WalletsScreen({ session }: { session: SessionState }) {
   const [open, setOpen] = useState(false);
+  const [balances, setBalances] = useState<BalanceState>({});
 
   const grouped = useMemo(() => {
     return {
@@ -13,18 +23,58 @@ export function WalletsScreen({ session }: { session: SessionState }) {
     };
   }, [session.wallets]);
 
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadBalances = async () => {
+      const initial: BalanceState = {};
+      for (const wallet of session.wallets) {
+        initial[wallet.id] = { loading: true };
+      }
+      setBalances(initial);
+
+      await Promise.all(
+        session.wallets.map(async (wallet) => {
+          try {
+            const balance = await getWalletBalance({ chain: wallet.chain, address: wallet.address });
+            if (cancelled) return;
+            setBalances((prev) => ({ ...prev, [wallet.id]: { loading: false, value: `${balance.formatted} ${balance.symbol}` } }));
+          } catch {
+            if (cancelled) return;
+            setBalances((prev) => ({ ...prev, [wallet.id]: { loading: false, error: 'Balance unavailable' } }));
+          }
+        }),
+      );
+    };
+
+    void loadBalances();
+    return () => {
+      cancelled = true;
+    };
+  }, [session.wallets]);
+
   return (
     <div>
       <h2>Tpc Account: {session.account?.telegramUserId}</h2>
       <button onClick={() => setOpen(true)}>Add wallet</button>
       {(['solana', 'evm', 'ton'] as const).map((chain) => (
         <section key={chain}>
-          <h3>{chain.toUpperCase()}</h3>
-          {grouped[chain].map((wallet) => (
-            <div key={wallet.id}>
-              {wallet.address} {wallet.isPrimary ? '(primary)' : ''}
-            </div>
-          ))}
+          <h3>{chainLabel(chain)}</h3>
+          {grouped[chain].map((wallet) => {
+            const balance = balances[wallet.id];
+            return (
+              <div key={wallet.id} style={{ marginBottom: 8 }}>
+                <div>
+                  {wallet.address} {wallet.isPrimary ? '(primary)' : ''}
+                </div>
+                <div style={{ color: '#555' }}>
+                  {balance?.loading && 'Balance: loading...'}
+                  {!balance?.loading && balance?.value && `Balance: ${balance.value}`}
+                  {!balance?.loading && balance?.error && `Balance: ${balance.error}`}
+                </div>
+              </div>
+            );
+          })}
           {grouped[chain].length === 0 && <p>No wallets linked.</p>}
         </section>
       ))}

--- a/frontend/src/wallets/balance/getWalletBalance.ts
+++ b/frontend/src/wallets/balance/getWalletBalance.ts
@@ -1,0 +1,74 @@
+import { Connection, PublicKey } from '@solana/web3.js';
+import { createPublicClient, formatEther, http } from 'viem';
+import { bsc } from 'viem/chains';
+
+const solanaConnection = new Connection('https://api.mainnet-beta.solana.com', 'confirmed');
+const bnbClient = createPublicClient({ chain: bsc, transport: http('https://bsc-dataseed.binance.org') });
+
+const CACHE_TTL_MS = 30_000;
+const cache = new Map<string, { expiresAt: number; value: WalletBalance }>();
+
+export type WalletBalance = {
+  symbol: 'TON' | 'SOL' | 'BNB';
+  formatted: string;
+};
+
+function getCacheKey(chain: string, address: string) {
+  return `${chain}:${address}`;
+}
+
+function readCache(chain: string, address: string): WalletBalance | undefined {
+  const key = getCacheKey(chain, address);
+  const hit = cache.get(key);
+  if (!hit) return undefined;
+  if (hit.expiresAt < Date.now()) {
+    cache.delete(key);
+    return undefined;
+  }
+  return hit.value;
+}
+
+function writeCache(chain: string, address: string, value: WalletBalance) {
+  cache.set(getCacheKey(chain, address), { value, expiresAt: Date.now() + CACHE_TTL_MS });
+}
+
+async function getTonBalance(address: string): Promise<WalletBalance> {
+  const cached = readCache('ton', address);
+  if (cached) return cached;
+
+  const response = await fetch(`https://tonapi.io/v2/accounts/${encodeURIComponent(address)}`);
+  if (!response.ok) throw new Error('TON balance unavailable');
+  const data = (await response.json()) as { balance?: number };
+  const ton = Number(data.balance ?? 0) / 1_000_000_000;
+  const value = { symbol: 'TON' as const, formatted: ton.toFixed(4) };
+  writeCache('ton', address, value);
+  return value;
+}
+
+async function getSolBalance(address: string): Promise<WalletBalance> {
+  const cached = readCache('solana', address);
+  if (cached) return cached;
+
+  const lamports = await solanaConnection.getBalance(new PublicKey(address));
+  const sol = lamports / 1_000_000_000;
+  const value = { symbol: 'SOL' as const, formatted: sol.toFixed(4) };
+  writeCache('solana', address, value);
+  return value;
+}
+
+async function getBnbBalance(address: string): Promise<WalletBalance> {
+  const cached = readCache('evm', address);
+  if (cached) return cached;
+
+  const wei = await bnbClient.getBalance({ address: address as `0x${string}` });
+  const bnb = Number(formatEther(wei));
+  const value = { symbol: 'BNB' as const, formatted: bnb.toFixed(4) };
+  writeCache('evm', address, value);
+  return value;
+}
+
+export async function getWalletBalance(input: { chain: 'solana' | 'evm' | 'ton'; address: string }): Promise<WalletBalance> {
+  if (input.chain === 'ton') return getTonBalance(input.address);
+  if (input.chain === 'solana') return getSolBalance(input.address);
+  return getBnbBalance(input.address);
+}

--- a/frontend/src/wallets/evm/EvmLink.tsx
+++ b/frontend/src/wallets/evm/EvmLink.tsx
@@ -13,7 +13,7 @@ export function EvmLink({ onDone }: { onDone: () => Promise<void> }) {
       connect({ connector: wc });
       return;
     }
-    if (!address) throw new Error('No EVM address');
+    if (!address) throw new Error('No BNB address');
 
     const nonceResp = await api<{ nonce: string; message: string }>('/api/wallets/link/nonce?chain=evm');
     const signature = await signMessageAsync({ message: nonceResp.message });
@@ -23,7 +23,7 @@ export function EvmLink({ onDone }: { onDone: () => Promise<void> }) {
       body: JSON.stringify({
         chain: 'evm',
         address,
-        provider: 'walletconnect',
+        provider: 'walletconnect-bnb',
         nonce: nonceResp.nonce,
         message: nonceResp.message,
         signature,
@@ -32,5 +32,5 @@ export function EvmLink({ onDone }: { onDone: () => Promise<void> }) {
     await onDone();
   };
 
-  return <button onClick={() => link().catch((e) => alert(e.message))}>{isConnected ? 'Sign & Link EVM' : 'Connect WalletConnect'}</button>;
+  return <button onClick={() => link().catch((e) => alert(e.message))}>{isConnected ? 'Sign & Link BNB' : 'Connect BNB Wallet'}</button>;
 }


### PR DESCRIPTION
### Motivation

- Surface on-screen balances for linked wallets across Solana, BNB (EVM/BSC) and TON to improve account visibility. 
- Add on-demand balance fetching using native Solana and BSC clients rather than relying on server-side lookups. 
- Clean up wallet linking UX with a tabbed modal and fix provider/typing issues for Solana wallet adapters and TonConnect manifest handling.

### Description

- Added dependency `@solana/web3.js` and updated `frontend/package.json` to support Solana RPC calls. 
- Implemented `getWalletBalance` in `frontend/src/wallets/balance/getWalletBalance.ts` which fetches balances from TON API, a Solana `Connection`, and a `viem` BSC public client, and includes a 30s in-memory cache. 
- Updated `WalletsScreen.tsx` to fetch and display per-wallet balances using `getWalletBalance`, added a `chainLabel` helper, and introduced local balance loading/error states. 
- Improved `AddWalletModal.tsx` visual UI with tab buttons and type-safe tab state, adjusted `main.tsx` to cast Solana providers to `ComponentType<any>` and tightened `twaReturnUrl` typing, and changed EVM link text and provider id to reflect BNB in `EvmLink.tsx` (provider `walletconnect-bnb`).

### Testing

- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf71c9351c8329b2c16bc5e37cd4ff)