### PR TITLE
Fix Checkers Battle Royal online sync (server store + client)

### DIFF
--- a/bot/package.json
+++ b/bot/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "start": "node server.js",
-    "receipt:preview": "node scripts/generate-receipt-preview.js"
+    "receipt:preview": "node scripts/generate-receipt-preview.js",
+    "test": "node --test tests/*.test.js"
   },
   "dependencies": {
     "canvas": "^2.11.2",

--- a/bot/server.js
+++ b/bot/server.js
@@ -60,11 +60,13 @@ import {
   listOnline
 } from './services/connectionService.js';
 import { validateSeatTableRequest } from './config/onlineGamePolicy.js';
+import { createCheckersRealtimeStore } from './utils/checkersRealtimeState.js';
 
 validateEnv();
 
 const CHESS_START_FEN = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w - - 0 1';
 const chessGames = new Map();
+const checkersRealtimeStore = createCheckersRealtimeStore();
 const AUTHENTIC_ACCOUNT_QUERY = {
   isBanned: { $ne: true },
   $or: [
@@ -738,6 +740,12 @@ function maybeStartGame(table) {
         if (whitePlayer) table.currentTurn = whitePlayer.id;
         const initial = updateChessState(table.id, { turnWhite: true, lastMove: null });
         io.to(table.id).emit('chessState', { tableId: table.id, ...initial });
+      } else if (table.gameType === 'checkers') {
+        const initial = checkersRealtimeStore.updateState(table.id, {
+          turn: 'light',
+          lastMove: null
+        });
+        io.to(table.id).emit('checkersState', { tableId: table.id, ...initial });
       }
       io.to(table.id).emit('gameStart', {
         tableId: table.id,
@@ -786,6 +794,9 @@ function unseatTableSocket(accountId, tableId, socketId) {
       }
     }
     if (table.players.length === 0) {
+      if (table.gameType === 'checkers') {
+        checkersRealtimeStore.clearState(tableId);
+      }
       tableMap.delete(tableId);
       const key = `${table.gameType}-${table.maxPlayers}`;
       lobbyTables[key] = (lobbyTables[key] || []).filter(
@@ -1536,6 +1547,27 @@ io.on('connection', (socket) => {
     }
   });
 
+  socket.on('joinCheckersRoom', async ({ tableId, accountId }) => {
+    if (!tableId) return;
+    if (accountId && !ensureRegistered(socket, accountId)) return;
+    socket.join(tableId);
+    const state = checkersRealtimeStore.getState(tableId);
+    socket.emit('checkersState', { tableId, ...state });
+    if (accountId) {
+      await registerConnection({
+        userId: String(accountId),
+        roomId: tableId,
+        socketId: socket.id
+      });
+    }
+  });
+
+  socket.on('checkersSyncRequest', ({ tableId }) => {
+    if (!tableId) return;
+    const state = checkersRealtimeStore.getState(tableId);
+    socket.emit('checkersState', { tableId, ...state });
+  });
+
   socket.on('chessSyncRequest', ({ tableId }) => {
     if (!tableId) return;
     const state = getChessState(tableId);
@@ -1700,6 +1732,16 @@ io.on('connection', (socket) => {
       lastMove: move.lastMove || null
     });
     socket.to(tableId).emit('chessMove', { tableId, ...next });
+  });
+
+  socket.on('checkersMove', ({ tableId, move }) => {
+    if (!tableId || !move) return;
+    const next = checkersRealtimeStore.updateState(tableId, {
+      board: move.board,
+      turn: move.turn,
+      lastMove: move.lastMove || null
+    });
+    io.to(tableId).emit('checkersState', { tableId, ...next });
   });
   socket.on('watchRoom', async ({ roomId }) => {
     if (!roomId) return;

--- a/bot/tests/checkersRealtimeState.test.js
+++ b/bot/tests/checkersRealtimeState.test.js
@@ -1,0 +1,51 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  createCheckersRealtimeStore,
+  createInitialCheckersBoard
+} from '../utils/checkersRealtimeState.js';
+
+test('createInitialCheckersBoard creates a standard 12 vs 12 setup', () => {
+  const board = createInitialCheckersBoard();
+  let light = 0;
+  let dark = 0;
+  board.forEach((row) =>
+    row.forEach((cell) => {
+      if (cell?.side === 'light') light += 1;
+      if (cell?.side === 'dark') dark += 1;
+    })
+  );
+  assert.equal(light, 12);
+  assert.equal(dark, 12);
+});
+
+test('store returns default state and accepts valid updates', () => {
+  const store = createCheckersRealtimeStore();
+  const initial = store.getState('table-1');
+  assert.equal(initial.turn, 'light');
+  assert.equal(initial.board.length, 8);
+
+  const nextBoard = createInitialCheckersBoard();
+  nextBoard[5][0] = null;
+  nextBoard[4][1] = { side: 'light', king: false };
+  const next = store.updateState('table-1', {
+    board: nextBoard,
+    turn: 'dark',
+    lastMove: { from: { r: 5, c: 0 }, to: { r: 4, c: 1 } }
+  });
+
+  assert.equal(next.turn, 'dark');
+  assert.equal(next.board[4][1]?.side, 'light');
+  assert.deepEqual(next.lastMove?.to, { r: 4, c: 1 });
+});
+
+test('store ignores malformed board payloads', () => {
+  const store = createCheckersRealtimeStore();
+  const before = store.getState('table-2');
+  const after = store.updateState('table-2', {
+    board: { broken: true },
+    turn: 'oops'
+  });
+  assert.deepEqual(after.board, before.board);
+  assert.equal(after.turn, before.turn);
+});

--- a/bot/utils/checkersRealtimeState.js
+++ b/bot/utils/checkersRealtimeState.js
@@ -1,0 +1,70 @@
+const SIZE = 8;
+
+export function createInitialCheckersBoard() {
+  const board = Array.from({ length: SIZE }, () => Array(SIZE).fill(null));
+  for (let r = 0; r < 3; r += 1) {
+    for (let c = 0; c < SIZE; c += 1) {
+      if ((r + c) % 2 === 1) board[r][c] = { side: 'dark', king: false };
+    }
+  }
+  for (let r = 5; r < SIZE; r += 1) {
+    for (let c = 0; c < SIZE; c += 1) {
+      if ((r + c) % 2 === 1) board[r][c] = { side: 'light', king: false };
+    }
+  }
+  return board;
+}
+
+function normalizeBoard(board) {
+  if (!Array.isArray(board) || board.length !== SIZE) return null;
+  const normalized = board.map((row) => {
+    if (!Array.isArray(row) || row.length !== SIZE) return null;
+    return row.map((cell) => {
+      if (!cell || typeof cell !== 'object') return null;
+      const side = cell.side === 'light' || cell.side === 'dark' ? cell.side : null;
+      if (!side) return null;
+      return { side, king: Boolean(cell.king) };
+    });
+  });
+  if (normalized.some((row) => row == null)) return null;
+  return normalized;
+}
+
+export function createCheckersRealtimeStore() {
+  const stateByTable = new Map();
+
+  const getState = (tableId) => {
+    if (!stateByTable.has(tableId)) {
+      stateByTable.set(tableId, {
+        board: createInitialCheckersBoard(),
+        turn: 'light',
+        lastMove: null,
+        updatedAt: Date.now()
+      });
+    }
+    return stateByTable.get(tableId);
+  };
+
+  const updateState = (tableId, nextState = {}) => {
+    const base = getState(tableId);
+    const merged = {
+      ...base,
+      ...nextState,
+      updatedAt: Date.now()
+    };
+    if (nextState.board) {
+      merged.board = normalizeBoard(nextState.board) || base.board;
+    }
+    if (nextState.turn !== 'light' && nextState.turn !== 'dark') {
+      merged.turn = base.turn;
+    }
+    stateByTable.set(tableId, merged);
+    return merged;
+  };
+
+  const clearState = (tableId) => {
+    stateByTable.delete(tableId);
+  };
+
+  return { getState, updateState, clearState };
+}

--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
@@ -15,8 +15,10 @@ import {
 } from '../../utils/colorSpace.js';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 import {
+  ensureAccountId,
   getTelegramFirstName,
-  getTelegramPhotoUrl
+  getTelegramPhotoUrl,
+  getTelegramUsername
 } from '../../utils/telegram.js';
 import { ARENA_CAMERA_DEFAULTS } from '../../utils/arenaCameraConfig.js';
 import {
@@ -48,6 +50,7 @@ import {
   isChessOptionUnlocked,
   setChessBattleEquippedOption
 } from '../../utils/chessBattleInventory.js';
+import { socket } from '../../utils/socket.js';
 
 const SIZE = 8;
 const MODEL_SCALE = 0.75;
@@ -1071,6 +1074,42 @@ async function loadPolyHavenHdriEnvironment(renderer, variant = {}) {
 export default function CheckersBattleRoyal() {
   useTelegramBackButton();
   const navigate = useNavigate();
+  const { search } = useLocation();
+  const params = useMemo(() => new URLSearchParams(search), [search]);
+  const mode = params.get('mode') || 'ai';
+  const initialTableId = params.get('tableId') || '';
+  const initialAccountId = params.get('accountId') || '';
+  const preferredSideParam = params.get('preferredSide');
+  const initialSideParam = params.get('side');
+  const initialOpponentName = params.get('opponentName') || '';
+  const initialOpponentAvatar = params.get('opponentAvatar') || '';
+  const [accountId, setAccountId] = useState(initialAccountId);
+  const [tableId] = useState(initialTableId);
+  const [onlineStatus, setOnlineStatus] = useState(
+    mode === 'online' ? 'connecting' : 'offline'
+  );
+  const [onlineOpponent, setOnlineOpponent] = useState(
+    initialOpponentName || initialOpponentAvatar
+      ? { name: initialOpponentName || 'Opponent', avatar: initialOpponentAvatar }
+      : null
+  );
+  const [redirecting, setRedirecting] = useState(false);
+  const onlineRef = useRef({
+    enabled: mode === 'online',
+    tableId: initialTableId || null,
+    accountId: initialAccountId || null,
+    side:
+      initialSideParam === 'dark' || initialSideParam === 'black'
+        ? 'dark'
+        : initialSideParam === 'light' || initialSideParam === 'white'
+        ? 'light'
+        : preferredSideParam === 'black'
+        ? 'dark'
+        : 'light',
+    synced: mode !== 'online',
+    status: mode === 'online' ? 'connecting' : 'offline',
+    opponent: null
+  });
   const mountRef = useRef(null);
 
   const boardRef = useRef(createInitial());
@@ -1106,6 +1145,24 @@ export default function CheckersBattleRoyal() {
     light: [],
     dark: []
   });
+  useEffect(() => {
+    if (mode !== 'online') return;
+    if (!initialTableId) {
+      setRedirecting(true);
+      navigate('/games/checkersbattleroyal/lobby', { replace: true });
+      return;
+    }
+    if (!initialAccountId) {
+      ensureAccountId()
+        .then((id) => {
+          if (!id) return;
+          setAccountId(id);
+          onlineRef.current.accountId = id;
+        })
+        .catch(() => {});
+    }
+  }, [initialAccountId, initialTableId, mode, navigate]);
+
   const aiBusyRef = useRef(false);
   const resolvedAccountId = useMemo(() => chessBattleAccountId(), []);
   const [inventory, setInventory] = useState(() =>
@@ -1319,14 +1376,17 @@ export default function CheckersBattleRoyal() {
     appearance.tableId,
     resolvedAccountId
   ]);
-  const playerName = getTelegramFirstName() || 'Player';
+  const playerName =
+    getTelegramFirstName() || getTelegramUsername() || 'Player';
   const playerPhotoUrl = getTelegramPhotoUrl() || '/assets/icons/profile.svg';
+  const rivalName = onlineOpponent?.name || 'Rival';
+  const rivalPhoto = onlineOpponent?.avatar || '/assets/icons/profile.svg';
 
   const players = [
     {
       index: 0,
-      name: 'Rival',
-      photoUrl: '/assets/icons/profile.svg',
+      name: rivalName,
+      photoUrl: rivalPhoto,
       color: '#f43f5e',
       isTurn: turn === 'dark'
     },
@@ -1566,6 +1626,12 @@ export default function CheckersBattleRoyal() {
     const pointer = new THREE.Vector2();
 
     const applyMove = (r, c) => {
+      const isOnlineGame = onlineRef.current.enabled;
+      if (isOnlineGame && !onlineRef.current.synced) return;
+      if (isOnlineGame && turn !== onlineRef.current.side) {
+        setStatus('Waiting for opponent move…');
+        return;
+      }
       const board = boardRef.current;
       const selected = selectedRef.current;
       const sideMoves = getMovesForSide(board, turn);
@@ -1612,6 +1678,21 @@ export default function CheckersBattleRoyal() {
         ...move
       });
       if (!applied) return;
+      const emitOnlineMove = (nextBoard, nextTurn) => {
+        if (!onlineRef.current.enabled || !onlineRef.current.tableId) return;
+        socket.emit('checkersMove', {
+          tableId: onlineRef.current.tableId,
+          move: {
+            board: nextBoard,
+            turn: nextTurn,
+            lastMove: {
+              from: { ...selected },
+              to: { r, c },
+              capture: move.capture || null
+            }
+          }
+        });
+      };
 
       if (Array.isArray(move.capture)) {
         const [captureR, captureC] = move.capture;
@@ -1644,7 +1725,7 @@ export default function CheckersBattleRoyal() {
         setStatus(
           turn === HUMAN_SIDE
             ? 'Chain capture required. Continue capturing.'
-            : 'AI continues a capture chain…'
+            : 'Chain capture required. Continue capturing.'
         );
         renderHighlights();
         return;
@@ -1672,9 +1753,12 @@ export default function CheckersBattleRoyal() {
         setStatus(
           nextTurn === HUMAN_SIDE
             ? 'Your turn. Forced captures are enabled.'
+            : isOnlineGame
+            ? 'Opponent is thinking…'
             : 'AI is thinking…'
         );
       }
+      emitOnlineMove(copyBoard(applied.board), nextTurn);
       renderHighlights();
     };
 
@@ -1989,6 +2073,68 @@ export default function CheckersBattleRoyal() {
   }, []);
 
   useEffect(() => {
+    const isOnlineGame = mode === 'online';
+    onlineRef.current.enabled = isOnlineGame;
+    if (!isOnlineGame) return;
+    if (!tableId || !accountId) return;
+
+    onlineRef.current.tableId = tableId;
+    onlineRef.current.accountId = accountId;
+    onlineRef.current.synced = false;
+    setOnlineStatus('connecting');
+    setStatus('Connecting to online table…');
+
+    const handleGameStart = ({ tableId: startedId, players: remotePlayers = [] } = {}) => {
+      if (!startedId || startedId !== tableId) return;
+      const me = remotePlayers.find((player) => String(player.id) === String(accountId));
+      const opp = remotePlayers.find((player) => String(player.id) !== String(accountId));
+      const mySide =
+        me?.side === 'black' || me?.side === 'dark'
+          ? 'dark'
+          : me?.side === 'white' || me?.side === 'light'
+          ? 'light'
+          : onlineRef.current.side;
+      onlineRef.current.side = mySide;
+      onlineRef.current.opponent = opp || null;
+      setOnlineOpponent(
+        opp ? { name: opp.name || 'Opponent', avatar: opp.avatar || '' } : null
+      );
+      setOnlineStatus('in-game');
+      setStatus(mySide === 'light' ? 'Your turn. Forced captures are enabled.' : 'Waiting for opponent move…');
+    };
+
+    const handleCheckersState = ({ tableId: eventTableId, board, turn: remoteTurn } = {}) => {
+      if (!eventTableId || eventTableId !== tableId) return;
+      if (!Array.isArray(board)) return;
+      boardRef.current = copyBoard(board);
+      selectedRef.current = null;
+      setTurn(remoteTurn === 'dark' ? 'dark' : 'light');
+      setCanReplay(false);
+      setGameOver(null);
+      setCapturedBySide({ light: [], dark: [] });
+      renderPieces();
+      renderHighlights();
+      onlineRef.current.synced = true;
+      setOnlineStatus('in-game');
+      const myTurn = (remoteTurn === 'dark' ? 'dark' : 'light') === onlineRef.current.side;
+      setStatus(myTurn ? 'Your turn. Forced captures are enabled.' : 'Waiting for opponent move…');
+    };
+
+    socket.on('gameStart', handleGameStart);
+    socket.on('checkersState', handleCheckersState);
+    socket.emit('register', { playerId: accountId });
+    socket.emit('joinCheckersRoom', { tableId, accountId });
+    socket.emit('checkersSyncRequest', { tableId });
+
+    return () => {
+      socket.off('gameStart', handleGameStart);
+      socket.off('checkersState', handleCheckersState);
+      socket.emit('leaveLobby', { accountId, tableId });
+    };
+  }, [accountId, mode, renderHighlights, renderPieces, tableId]);
+
+  useEffect(() => {
+    if (onlineRef.current.enabled) return;
     if (turn !== AI_SIDE || aiBusyRef.current || gameOver) return;
     aiBusyRef.current = true;
     setStatus('AI is thinking…');
@@ -2224,6 +2370,10 @@ export default function CheckersBattleRoyal() {
   }, [viewMode]);
 
   const restartGame = () => {
+    if (onlineRef.current.enabled && onlineRef.current.tableId) {
+      socket.emit('checkersSyncRequest', { tableId: onlineRef.current.tableId });
+      return;
+    }
     boardRef.current = createInitial();
     selectedRef.current = null;
     replayStateRef.current = null;
@@ -2260,6 +2410,14 @@ export default function CheckersBattleRoyal() {
 
   const optionButton = (active) =>
     `rounded-lg border px-2 py-1 text-[11px] ${active ? 'border-cyan-300 bg-cyan-500/20 text-cyan-100' : 'border-white/15 bg-white/5 text-white/70'}`;
+
+  if (mode === 'online' && redirecting) {
+    return (
+      <div className="p-4 text-center text-sm text-subtext">
+        Syncing with the lobby…
+      </div>
+    );
+  }
 
   return (
     <div className="fixed inset-0 bg-[#050814] text-white">
@@ -2505,6 +2663,12 @@ export default function CheckersBattleRoyal() {
           <div className="px-5 py-2 rounded-full bg-[rgba(7,10,18,0.65)] border border-[rgba(255,215,0,0.25)] text-sm font-semibold backdrop-blur">
             {status} • Turn: {turn}
           </div>
+          {mode === 'online' && (
+            <div className="mt-2 text-center text-[11px] text-emerald-100/80">
+              Online: {onlineStatus}
+              {tableId ? ` • Table ${tableId.slice(0, 8)}` : ''}
+            </div>
+          )}
         </div>
 
         {gameOver ? (


### PR DESCRIPTION
### Motivation
- Online checkers matches were not sharing authoritative board/turn state between players, preventing reliable multiplayer play. 
- Provide a small, robust realtime state layer and client wiring so two players can join a table, receive the authoritative snapshot, and stay in sync.

### Description
- Added a server-side realtime store `bot/utils/checkersRealtimeState.js` that keeps per-table checkers `board`, `turn`, `lastMove`, and provides `getState`, `updateState`, and `clearState` APIs.
- Integrated the store into socket flows in `bot/server.js` with new events `joinCheckersRoom`, `checkersSyncRequest`, and `checkersMove`, bootstrapped state on match `gameStart`, and cleared state when a table is removed.
- Updated the Checkers client `webapp/src/pages/Games/CheckersBattleRoyal.jsx` to parse lobby query params (`mode`, `tableId`, `accountId`, side/opponent), join the server room, request/sync authoritative state, block local input when it is not the player's turn, emit board snapshots after legal moves, disable the local AI loop during online matches, and show online status/table in the HUD.
- Added unit tests `bot/tests/checkersRealtimeState.test.js` for the realtime store and a `bot` test script in `bot/package.json` to run them.

### Testing
- Ran `npm test` in the `bot` package which executed the new tests and all passed (3 tests, 0 failures).
- Built the web client with `npm run build` in `webapp` which completed successfully (Vite production build).
- No runtime integration test harness was available in CI here; manual QA recommended when deploying sockets behind your production infra and load testing multiplayer scenarios.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf7a1082388329a259f1de55318047)