### PR TITLE
One-tap gift sending in games (GiftPopup)

### DIFF
--- a/webapp/src/components/GiftPopup.jsx
+++ b/webapp/src/components/GiftPopup.jsx
@@ -1,14 +1,12 @@
 import { useState, useEffect } from 'react';
 import { createPortal } from 'react-dom';
-import { getPlayerId, ensureAccountId } from '../utils/telegram.js';
+import { ensureAccountId } from '../utils/telegram.js';
 import { sendGift } from '../utils/api.js';
 import { NFT_GIFTS } from '../utils/nftGifts.js';
 import GiftIcon from './GiftIcon.jsx';
 import { giftSounds } from '../utils/giftSounds.js';
 import { getGameVolume } from '../utils/sound.js';
-import ConfirmPopup from './ConfirmPopup.jsx';
 import InfoPopup from './InfoPopup.jsx';
-
 
 export default function GiftPopup({
   open,
@@ -29,16 +27,10 @@ export default function GiftPopup({
   playerButtonClassName = 'w-full flex items-center space-x-2 border border-border rounded px-1 py-0.5 text-sm',
   playerButtonActiveClassName = 'bg-accent',
   tierTitleClassName = 'text-sm font-bold',
-  giftButtonClassName = 'border border-border rounded px-1 py-0.5 text-sm flex items-center justify-center space-x-1',
-  giftButtonActiveClassName = 'bg-accent',
-  costClassName = 'text-xs text-center mt-2 flex items-center justify-center space-x-1',
-  sendButtonClassName = 'w-full px-3 py-1 bg-primary hover:bg-primary-hover rounded text-black',
-  noteClassName = 'text-xs text-center mt-1'
+  giftButtonClassName = 'border border-border rounded px-1 py-0.5 text-sm flex items-center justify-center space-x-1'
 }) {
   const validPlayers = players.filter((p) => p.id);
-  const [selected, setSelected] = useState(NFT_GIFTS[0]);
   const [target, setTarget] = useState(validPlayers[0]?.index || 0);
-  const [confirmOpen, setConfirmOpen] = useState(false);
   const [infoMsg, setInfoMsg] = useState('');
   const [pendingGift, setPendingGift] = useState(null);
   const resolvedTitle = title ?? 'Send Gift';
@@ -50,69 +42,70 @@ export default function GiftPopup({
       setPendingGift(null);
     }
   };
+
   useEffect(() => {
     if (validPlayers.length > 0 && !validPlayers.some((p) => p.index === target)) {
       setTarget(validPlayers[0].index);
     }
-  }, [validPlayers]);
+  }, [validPlayers, target]);
+
   if (!open && !infoMsg) return null;
   const recipient = validPlayers.find((p) => p.index === target);
 
-  const handleSend = async () => {
+  const handleSend = async (gift) => {
     if (!recipient) return;
-    setConfirmOpen(false);
+
     try {
       const fromId = await ensureAccountId();
-      const res = await sendGift(fromId, recipient.id, selected.id);
+      const res = await sendGift(fromId, recipient.id, gift.id);
       if (res?.error) {
         setInfoMsg(res.error);
         onClose();
         return;
       }
-      const sound = giftSounds[selected.id];
+
+      const sound = giftSounds[gift.id];
       if (sound) {
-        const a = new Audio(sound);
-        a.volume = getGameVolume();
-        if (selected.id === 'bullseye') {
+        const audio = new Audio(sound);
+        audio.volume = getGameVolume();
+        if (gift.id === 'bullseye') {
           setTimeout(() => {
-            a.play().catch(() => {});
+            audio.play().catch(() => {});
           }, 2500);
         } else {
-          a.play().catch(() => {});
+          audio.play().catch(() => {});
         }
-        if (selected.id === 'magic_trick') {
+
+        if (gift.id === 'magic_trick') {
           setTimeout(() => {
-            a.pause();
+            audio.pause();
           }, 4000);
-        } else if (selected.id === 'fireworks') {
+        } else if (gift.id === 'fireworks') {
           setTimeout(() => {
-            a.pause();
+            audio.pause();
           }, 6000);
-        } else if (selected.id === 'surprise_box') {
+        } else if (gift.id === 'surprise_box') {
           setTimeout(() => {
-            a.pause();
+            audio.pause();
           }, 5000);
         }
       }
-      setInfoMsg(`Sent ${selected.name} to ${recipient.name}`);
-      setPendingGift({ from: senderIndex, to: target, gift: selected });
+
+      setInfoMsg(`Sent ${gift.name} to ${recipient.name}`);
+      setPendingGift({ from: senderIndex, to: target, gift });
     } catch {
       setInfoMsg('Failed to send gift');
     }
+
     onClose();
   };
 
   const tiers = [1, 2, 3];
+
   return createPortal(
     <>
-      <div
-        className={overlayClassName}
-        onClick={onClose}
-      >
-        <div
-          className={panelClassName}
-          onClick={(e) => e.stopPropagation()}
-        >
+      <div className={overlayClassName} onClick={onClose}>
+        <div className={panelClassName} onClick={(e) => e.stopPropagation()}>
           {showCloseButton || title ? (
             <div className={headerClassName}>
               <p className={titleClassName}>{resolvedTitle}</p>
@@ -125,35 +118,33 @@ export default function GiftPopup({
           ) : (
             <p className={titleClassName}>{resolvedTitle}</p>
           )}
+
           <div className={playerListClassName}>
             {validPlayers.map((p) => (
               <button
                 key={p.index}
                 onClick={() => setTarget(p.index)}
-                className={`${playerButtonClassName} ${
-                  target === p.index ? playerButtonActiveClassName : ''
-                }`}
+                className={`${playerButtonClassName} ${target === p.index ? playerButtonActiveClassName : ''}`}
               >
                 <img src={p.photoUrl} alt={`${p.name}'s avatar`} className="w-5 h-5 rounded-full" />
                 <span>{p.name}</span>
               </button>
             ))}
           </div>
+
           {tiers.map((tier) => (
             <div key={tier} className={tierGroupClassName}>
               <p className={tierTitleClassName}>Tier {tier}</p>
               <div className={giftGridClassName}>
-                {NFT_GIFTS.filter((g) => g.tier === tier).map((g) => (
+                {NFT_GIFTS.filter((g) => g.tier === tier).map((gift) => (
                   <button
-                    key={g.id}
-                    onClick={() => setSelected(g)}
-                    className={`${giftButtonClassName} ${
-                      selected.id === g.id ? giftButtonActiveClassName : ''
-                    }`}
+                    key={gift.id}
+                    onClick={() => handleSend(gift)}
+                    className={giftButtonClassName}
                   >
-                  <GiftIcon icon={g.icon} className="w-4 h-4" />
+                    <GiftIcon icon={gift.icon} className="w-4 h-4" />
                     <span className="flex items-center space-x-0.5">
-                      <span>{g.price}</span>
+                      <span>{gift.price}</span>
                       <img src="/assets/icons/ezgif-54c96d8a9b9236.webp" alt="TPC" className="w-3 h-3" />
                     </span>
                   </button>
@@ -161,28 +152,8 @@ export default function GiftPopup({
               </div>
             </div>
           ))}
-          <div className={costClassName}>
-            <span>Cost:</span>
-            <span>{selected.price}</span>
-            <img src="/assets/icons/ezgif-54c96d8a9b9236.webp" alt="TPC" className="w-3 h-3" />
-          </div>
-          <button
-            className={sendButtonClassName}
-            onClick={() => setConfirmOpen(true)}
-          >
-            Send <GiftIcon icon={selected.icon} className="w-4 h-4 inline" /> {selected.name}
-          </button>
-          <p className={noteClassName}>
-            10% charge and the amount of the gift will be deducted from your balance.
-          </p>
         </div>
       </div>
-      <ConfirmPopup
-        open={confirmOpen}
-        message="10% charge and the amount of the gift will be deducted from your balance. Continue?"
-        onConfirm={handleSend}
-        onCancel={() => setConfirmOpen(false)}
-      />
       <InfoPopup
         open={Boolean(infoMsg)}
         onClose={handleInfoClose}


### PR DESCRIPTION
### Motivation
- Make in-game gift sending faster by removing the multi-step selection/confirm flow so users can send a gift with a single tap like quick chat messages.
- Centralize the behavior change in the shared component so all games on the Games page inherit the faster flow automatically.
- Keep existing recipient selection, sound, and animation hooks intact so gameplay feedback remains consistent.

### Description
- Reworked `webapp/src/components/GiftPopup.jsx` to send gifts immediately when a gift tile is tapped by changing gift tiles to `onClick={() => handleSend(gift)}` and making `handleSend` accept a `gift` parameter.
- Removed intermediate selection state and the confirm flow by deleting the `selected` state, `ConfirmPopup` import/usage, and the cost/send/note UI block.
- Preserved API call flow and side effects by still calling `sendGift(...)`, playing `giftSounds[...]`, showing the `InfoPopup`, and emitting `onGiftSent` with `{ from, to, gift }` for existing in-game animations.
- Minor cleanup of imports and variables (use `ensureAccountId` only) so the component is simpler and all pages that render `GiftPopup` (e.g. `PoolRoyale`, `SnookerRoyal`, `TexasHoldemArena`, `AirHockey3D`, and other game pages) get one-tap behavior.

### Testing
- Ran `npm --prefix webapp run build` to validate the webapp compiles; build succeeded (Vite produced chunk-size warnings but no build errors).
- Ran `npx eslint --no-ignore webapp/src/components/GiftPopup.jsx` which showed no errors (only an ignore-pattern warning when run without `--no-ignore`).
- Manually inspected pages that mount `GiftPopup` to verify the component usage sites will inherit the one-tap behavior (no automated UI tests were executed for the visual flow in this PR).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf7b1aa9fc83298e85715d8cc3a77d)