### PR TITLE
Accept legacy 'checkers'/'chess' lobby aliases in matchmaking policy

### DIFF
--- a/bot/config/onlineGamePolicy.js
+++ b/bot/config/onlineGamePolicy.js
@@ -8,6 +8,8 @@ const BASE_SECURITY_CONTROLS = Object.freeze([
 ]);
 
 const GAME_ONLINE_POLICY = Object.freeze({
+  chess: { maxPlayers: [2], allowMatchMeta: ['preferredSide', 'mode', 'token'] },
+  checkers: { maxPlayers: [2], allowMatchMeta: ['preferredSide', 'mode', 'token'] },
   poolroyale: { maxPlayers: [2], allowMatchMeta: ['mode', 'playType', 'tableSize', 'ballSet', 'token'] },
   snookerroyale: { maxPlayers: [2], allowMatchMeta: ['mode', 'playType', 'tableSize', 'token'] },
   snake: { maxPlayers: [2, 3, 4], allowMatchMeta: ['mode', 'token'] },

--- a/test/onlineGamePolicy.test.js
+++ b/test/onlineGamePolicy.test.js
@@ -33,6 +33,26 @@ describe('online game policy', () => {
     });
   });
 
+  test('accepts chess and checkers lobby aliases used by seatTable clients', () => {
+    const chess = validateSeatTableRequest({
+      gameType: 'chess',
+      stake: 100,
+      maxPlayers: 2,
+      matchMeta: { preferredSide: 'white', mode: 'online' }
+    });
+    const checkers = validateSeatTableRequest({
+      gameType: 'checkers',
+      stake: 100,
+      maxPlayers: 2,
+      matchMeta: { preferredSide: 'black', mode: 'online' }
+    });
+
+    expect(chess.ok).toBe(true);
+    expect(chess.safeMatchMeta).toEqual({ preferredSide: 'white', mode: 'online' });
+    expect(checkers.ok).toBe(true);
+    expect(checkers.safeMatchMeta).toEqual({ preferredSide: 'black', mode: 'online' });
+  });
+
   test('buildReadinessSnapshot returns all policy games with security checks', () => {
     const snapshot = buildReadinessSnapshot();
     expect(Object.keys(snapshot).sort()).toEqual(Object.keys(GAME_ONLINE_POLICY).sort());


### PR DESCRIPTION
### Motivation
- Lobby clients were sending `seatTable` with `gameType: 'checkers'` or `'chess'`, but policy validation only allowed `checkersbattleroyal`/`chessbattleroyal`, causing `unsupported_game_type` and preventing players from connecting.  

### Description
- Added `chess` and `checkers` entries to `GAME_ONLINE_POLICY` in `bot/config/onlineGamePolicy.js` to accept legacy lobby aliases.  
- Allowed `preferredSide` in the `allowMatchMeta` for those aliases so side-preference payloads from the lobby are preserved and sanitized.  
- Added a regression test in `test/onlineGamePolicy.test.js` to validate both `chess` and `checkers` aliases and ensure metadata sanitization.  

### Testing
- Ran `npm test -- --runInBand test/onlineGamePolicy.test.js`.  
- Test suite passed: all tests in `test/onlineGamePolicy.test.js` succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf823f4a988329bd89ead9592b6f96)