### PR TITLE
Fix Checkers Battle Royal lobby player connection reliability

### DIFF
--- a/webapp/src/pages/Games/CheckersBattleRoyalLobby.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyalLobby.jsx
@@ -23,11 +23,13 @@ const DEV_ACCOUNT_1 = import.meta.env.VITE_DEV_ACCOUNT_ID_1;
 const DEV_ACCOUNT_2 = import.meta.env.VITE_DEV_ACCOUNT_ID_2;
 const AI_FLAG_STORAGE_KEY = 'checkersBattleRoyalAiFlag';
 const CHECKERS_HOST_CODE_STORAGE_KEY = 'checkersBattleRoyalHostCode';
+const SOCKET_CONNECT_TIMEOUT_MS = 6000;
 
 function normalizeHostCode(code = '') {
   return String(code || '')
     .trim()
     .replace(/[^a-zA-Z0-9_-]/g, '')
+    .toUpperCase()
     .slice(0, 48);
 }
 
@@ -35,6 +37,37 @@ function buildHostedTableId(code = '') {
   const safeCode = normalizeHostCode(code);
   if (!safeCode) return '';
   return `checkers-2-host-${safeCode}`;
+}
+
+async function ensureSocketConnected(timeoutMs = SOCKET_CONNECT_TIMEOUT_MS) {
+  if (socket.connected) return true;
+
+  return new Promise((resolve) => {
+    let settled = false;
+
+    const cleanup = () => {
+      socket.off('connect', handleConnect);
+      socket.off('connect_error', handleError);
+      socket.off('error', handleError);
+    };
+
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      cleanup();
+      resolve(result);
+    };
+
+    const handleConnect = () => finish(true);
+    const handleError = () => finish(false);
+
+    const timer = setTimeout(() => finish(socket.connected), timeoutMs);
+    socket.once('connect', handleConnect);
+    socket.once('connect_error', handleError);
+    socket.once('error', handleError);
+    socket.connect?.();
+  });
 }
 
 export default function CheckersBattleRoyalLobby() {
@@ -224,6 +257,14 @@ export default function CheckersBattleRoyalLobby() {
     setMatchError('');
     setMatching(true);
     setMatchStatus('Connecting to lobby…');
+
+    const socketReady = await ensureSocketConnected();
+    if (!socketReady) {
+      setMatchError('Lobby connection failed. Check your network and try again.');
+      setMatching(false);
+      setMatchStatus('');
+      return;
+    }
 
     const handleLobbyUpdate = ({ tableId: tid, players: list = [] } = {}) => {
       if (!tid || tid !== pendingTableRef.current) return;


### PR DESCRIPTION
### Motivation
- The lobby flow could emit `register`/`seatTable` while the Socket.IO client was not yet connected, causing players to get stuck and matchmaking to fail. 
- Private host/join codes were case-sensitive which could prevent two players from landing in the same hosted table. 

### Description
- Added a `SOCKET_CONNECT_TIMEOUT_MS` constant and an `ensureSocketConnected` helper that waits for `connect` or fails on `connect_error`/`error` or timeout and calls `socket.connect()` if needed. 
- Integrated `ensureSocketConnected` in the lobby `startGame` flow to wait for the socket to be ready before `register`, `seatTable`, and `confirmReady` are emitted, and surface a user-facing error on failure. 
- Normalized host codes with `normalizeHostCode(...).toUpperCase()` and kept the existing `buildHostedTableId` behavior so private table codes are case-insensitive. 

### Testing
- Ran the production build with `npm --prefix webapp run build` which completed successfully (Vite emitted non-blocking chunking warnings but build artifacts were produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf823f4a988329bd89ead9592b6f96)