### PR TITLE
Fix Pool Royale lobby matchmaking for partial metadata

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -475,9 +475,26 @@ function normalizeMatchMeta(rawMeta = {}) {
 }
 
 function isMatchMetaCompatible(existing = {}, requested = {}) {
-  const entries = Object.entries(requested);
-  if (!entries.length) return true;
-  return entries.every(([key, value]) => (existing?.[key] || '') === value);
+  const keys = new Set([
+    ...Object.keys(existing || {}),
+    ...Object.keys(requested || {})
+  ]);
+  if (!keys.size) return true;
+
+  for (const key of keys) {
+    const existingValue = existing?.[key];
+    const requestedValue = requested?.[key];
+    if (!existingValue || !requestedValue) {
+      // Missing metadata acts like a wildcard so legacy/new clients
+      // can still meet in the same lobby when they agree on shared keys.
+      continue;
+    }
+    if (existingValue !== requestedValue) {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 function isRateLimited(socket, key, cooldownMs) {


### PR DESCRIPTION
### Motivation
- Players were being split into separate lobbies when one client sent only partial matchmaking metadata, preventing Pool Royale online connections; matching should allow missing keys to act like wildcards so mixed/legacy clients can be paired.

### Description
- Relaxed the `isMatchMetaCompatible` check in `bot/server.js` so missing metadata keys no longer block matching while still rejecting explicit conflicting key values.

### Testing
- Ran `npm test -- test/poolRoyaleMatchmakingMeta.test.js test/poolRoyaleOnlineFlow.test.js --runInBand`, and both tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf82775394832990dfca514ff4f48c)