### PR TITLE
Fix Pool Royale lobby auto-registration fallback

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -491,7 +491,20 @@ function isRateLimited(socket, key, cooldownMs) {
 }
 
 function ensureRegistered(socket, accountId) {
-  const registered = socket.data?.playerId;
+  let registered = socket.data?.playerId;
+  if (!registered && accountId) {
+    registered = String(accountId);
+    socket.data.playerId = registered;
+    let set = userSockets.get(registered);
+    if (!set) {
+      set = new Set();
+      userSockets.set(registered, set);
+    }
+    set.add(socket.id);
+    registerConnection({ userId: registered, socketId: socket.id }).catch((err) => {
+      console.error('registerConnection fallback failed', err);
+    });
+  }
   if (!registered) {
     socket.emit('errorMessage', 'register_required');
     return false;


### PR DESCRIPTION
### Motivation
- Players sometimes could not join the Pool Royal online lobby because the client called `seatTable` before an explicit `register` handshake, causing `ensureRegistered` to emit `register_required` and blocking matchmaking.

### Description
- Update `ensureRegistered` to bind `socket.data.playerId` from the provided `accountId` when the socket has no registered player, enabling a safe fallback registration at the time of lobby actions.
- Persist the fallback into the in-memory `userSockets` map and call `registerConnection({ userId, socketId })` so presence and `ActiveConnection` tracking are updated for matchmaking and lobby visibility.
- Keep the existing identity validation and still reject requests when `accountId` does not match the registered identity, and log any `registerConnection` errors without failing the request path.

### Testing
- Ran `node --check bot/server.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf82775394832990dfca514ff4f48c)