### PR TITLE
Fix Pool Royale online matchmaking socket auth fallback

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -174,6 +174,12 @@ io.use((socket, next) => {
   const initData =
     socket.handshake.auth?.initData ||
     socket.handshake.headers?.['x-telegram-init-data'];
+  const accountId =
+    socket.handshake.auth?.accountId ||
+    socket.handshake.headers?.['x-tpc-account-id'];
+  const googleId =
+    socket.handshake.auth?.googleId ||
+    socket.handshake.headers?.['x-google-id'];
 
   if (initData) {
     const data = verifyTelegramInitData(initData);
@@ -187,6 +193,14 @@ io.use((socket, next) => {
 
   if (process.env.API_AUTH_TOKEN && token === process.env.API_AUTH_TOKEN) {
     socket.data.auth = { apiToken: true };
+    return next();
+  }
+
+  if (accountId || googleId) {
+    socket.data.auth = {
+      accountId: accountId ? String(accountId) : undefined,
+      googleId: googleId ? String(googleId) : undefined
+    };
     return next();
   }
 

--- a/webapp/src/utils/socket.js
+++ b/webapp/src/utils/socket.js
@@ -47,12 +47,19 @@ function getStoredAccountId() {
   return window?.localStorage?.getItem('accountId') || '';
 }
 
+function getStoredGoogleId() {
+  if (typeof window === 'undefined') return '';
+  return window?.localStorage?.getItem('googleId') || '';
+}
+
 function buildSocketAuthPayload() {
   const initData = getTelegramInitData();
   const accountId = getStoredAccountId();
+  const googleId = getStoredGoogleId();
   return {
     ...(initData ? { initData } : {}),
-    ...(accountId ? { accountId } : {})
+    ...(accountId ? { accountId } : {}),
+    ...(googleId ? { googleId } : {})
   };
 }
 


### PR DESCRIPTION
### Motivation
- Non-Telegram/native clients could not authenticate over Socket.IO leading to "Unable to reach the online arena" and refunded stakes even though HTTP APIs accept account-based auth. 
- Align socket authentication with existing HTTP auth methods so account-based sessions (accountId/googleId) can join online tables reliably.

### Description
- Update backend Socket.IO auth in `bot/server.js` to accept `accountId` and `googleId` from the handshake `auth` or headers and populate `socket.data.auth` accordingly. 
- Preserve existing Telegram `initData` verification and API token auth paths while returning an `unauthorized` error only when no auth path matches. 
- Add `getStoredGoogleId()` and include `googleId` in the socket auth payload in `webapp/src/utils/socket.js` so native/non-Telegram clients send the same account identifiers during socket handshake. 

### Testing
- Ran `node --check bot/server.js` which completed successfully. 
- Ran `node --check webapp/src/utils/socket.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf8a5c6d108329aaae8bc956588f38)