### PR TITLE
Enable Checkers Battle Royal online readiness and safer matchmaking

### DIFF
--- a/test/checkersOnlineReadiness.test.js
+++ b/test/checkersOnlineReadiness.test.js
@@ -1,0 +1,20 @@
+import { describe, expect, test } from '@jest/globals';
+import {
+  ONLINE_READINESS_BY_GAME,
+  getOnlineReadiness
+} from '../webapp/src/config/onlineContract.js';
+
+describe('checkers online readiness contract', () => {
+  test('marks checkers battle royal as online ready in local fallback map', () => {
+    expect(ONLINE_READINESS_BY_GAME.checkersbattleroyal).toBeDefined();
+    const readiness = getOnlineReadiness('checkersbattleroyal', ONLINE_READINESS_BY_GAME);
+    expect(readiness.ready).toBe(true);
+    expect(readiness.label).toBe('Online Ready');
+    expect(readiness.checks).toEqual({
+      lobby: true,
+      runtime: true,
+      backend: true,
+      security: true
+    });
+  });
+});

--- a/webapp/src/config/onlineContract.js
+++ b/webapp/src/config/onlineContract.js
@@ -24,6 +24,10 @@ export const ONLINE_READINESS_BY_GAME = Object.freeze({
     checks: { lobby: true, runtime: true, backend: true, security: true },
     label: 'Online Ready'
   },
+  checkersbattleroyal: {
+    checks: { lobby: true, runtime: true, backend: true, security: true },
+    label: 'Online Ready'
+  },
   fourinrowroyale: {
     checks: { lobby: true, runtime: true, backend: true, security: true },
     label: 'Online Ready'

--- a/webapp/src/pages/Games/CheckersBattleRoyalLobby.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyalLobby.jsx
@@ -17,6 +17,7 @@ import { socket } from '../../utils/socket.js';
 import OptionIcon from '../../components/OptionIcon.jsx';
 import { getLobbyIcon } from '../../config/gameAssets.js';
 import GameLobbyHeader from '../../components/GameLobbyHeader.jsx';
+import { getOnlineReadiness } from '../../config/onlineContract.js';
 
 const DEV_ACCOUNT = import.meta.env.VITE_DEV_ACCOUNT_ID;
 const DEV_ACCOUNT_1 = import.meta.env.VITE_DEV_ACCOUNT_ID_1;
@@ -24,6 +25,7 @@ const DEV_ACCOUNT_2 = import.meta.env.VITE_DEV_ACCOUNT_ID_2;
 const AI_FLAG_STORAGE_KEY = 'checkersBattleRoyalAiFlag';
 const CHECKERS_HOST_CODE_STORAGE_KEY = 'checkersBattleRoyalHostCode';
 const SOCKET_CONNECT_TIMEOUT_MS = 6000;
+const MATCHMAKING_TIMEOUT_MS = 45000;
 
 function normalizeHostCode(code = '') {
   return String(code || '')
@@ -91,6 +93,7 @@ export default function CheckersBattleRoyalLobby() {
   const [hostCodeInput, setHostCodeInput] = useState('');
   const pendingTableRef = useRef('');
   const cleanupRef = useRef(() => {});
+  const readiness = getOnlineReadiness('checkersbattleroyal');
 
   const selectedFlag = playerFlagIndex != null ? FLAG_EMOJIS[playerFlagIndex] : '';
   const selectedAiFlag = aiFlagIndex != null ? FLAG_EMOJIS[aiFlagIndex] : '';
@@ -222,8 +225,25 @@ export default function CheckersBattleRoyalLobby() {
   const startGame = async () => {
     const isOnline = mode === 'online';
     if (matching) return;
+    if (isOnline && !readiness.ready) {
+      setMatchError('Online mode is temporarily unavailable for Checkers Battle Royal.');
+      setMatchStatus('');
+      return;
+    }
     let tgId;
     let trackedAccountId;
+    let stakeCharged = false;
+    const refundStakeIfNeeded = async (reason = 'stake_refund') => {
+      if (!isOnline || !stakeCharged || !trackedAccountId || !tgId || !stake.amount) return;
+      stakeCharged = false;
+      try {
+        await addTransaction(tgId, stake.amount, reason, {
+          game: 'checkersbattle',
+          players: 2,
+          accountId: trackedAccountId
+        });
+      } catch {}
+    };
     if (isOnline) {
       try {
         trackedAccountId = await ensureAccountId();
@@ -239,9 +259,11 @@ export default function CheckersBattleRoyalLobby() {
           players: 2,
           accountId: trackedAccountId,
         });
+        stakeCharged = true;
       } catch {}
 
       if (!trackedAccountId) {
+        await refundStakeIfNeeded();
         setMatchError('Unable to resolve your player account. Reopen Telegram and try again.');
         setMatching(false);
         setMatchStatus('');
@@ -260,6 +282,7 @@ export default function CheckersBattleRoyalLobby() {
 
     const socketReady = await ensureSocketConnected();
     if (!socketReady) {
+      await refundStakeIfNeeded();
       setMatchError('Lobby connection failed. Check your network and try again.');
       setMatching(false);
       setMatchStatus('');
@@ -296,19 +319,30 @@ export default function CheckersBattleRoyalLobby() {
 
     cleanupRef.current = () => cleanupLobby({ account: trackedAccountId, skipRefReset: true });
 
+    const hostedTableId =
+      onlineQueueMode === 'quick' ? '' : buildHostedTableId(hostCodeInput);
+    if (onlineQueueMode !== 'quick' && !hostedTableId) {
+      await refundStakeIfNeeded();
+      setMatchError('Enter a host code to create or join a private online table.');
+      setMatching(false);
+      setMatchStatus('');
+      socket.off('gameStart', handleGameStart);
+      socket.off('lobbyUpdate', handleLobbyUpdate);
+      return;
+    }
+
     socket.on('gameStart', handleGameStart);
     socket.on('lobbyUpdate', handleLobbyUpdate);
     socket.emit('register', { playerId: trackedAccountId });
 
     const friendlyName = getTelegramFirstName() || getTelegramUsername() || 'Player';
-    const hostedTableId =
-      onlineQueueMode === 'quick' ? '' : buildHostedTableId(hostCodeInput);
-    if (onlineQueueMode !== 'quick' && !hostedTableId) {
-      setMatchError('Enter a host code to create or join a private online table.');
-      setMatching(false);
+    const matchTimeout = window.setTimeout(async () => {
+      if (!pendingTableRef.current) return;
+      cleanupLobby({ account: trackedAccountId });
+      await refundStakeIfNeeded();
+      setMatchError('No opponent joined in time. Your stake was refunded.');
       setMatchStatus('');
-      return;
-    }
+    }, MATCHMAKING_TIMEOUT_MS);
 
     socket.emit(
       'seatTable',
@@ -320,10 +354,13 @@ export default function CheckersBattleRoyalLobby() {
         playerName: friendlyName,
         avatar,
         preferredSide,
+        token: stake.token,
         ...(hostedTableId ? { tableId: hostedTableId } : {})
       },
-      (res) => {
+      async (res) => {
         if (!res?.success || !res.tableId) {
+          clearTimeout(matchTimeout);
+          await refundStakeIfNeeded();
           setMatchError('Could not join the online lobby. Please try again.');
           cleanupLobby({ account: trackedAccountId });
           return;
@@ -338,6 +375,10 @@ export default function CheckersBattleRoyalLobby() {
           accountId: trackedAccountId,
           tableId: res.tableId
         });
+        cleanupRef.current = () => {
+          clearTimeout(matchTimeout);
+          cleanupLobby({ account: trackedAccountId, skipRefReset: true });
+        };
       }
     );
   };
@@ -424,9 +465,10 @@ export default function CheckersBattleRoyalLobby() {
                   key={key}
                   type="button"
                   onClick={() => setMode(key)}
+                  disabled={key === 'online' && !readiness.ready}
                   className={`lobby-option-card ${
                     active ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
-                  }`}
+                  } ${key === 'online' && !readiness.ready ? 'cursor-not-allowed opacity-60' : ''}`}
                 >
                   <div className={`lobby-option-thumb bg-gradient-to-br ${accent}`}>
                     <div className="lobby-option-thumb-inner">
@@ -449,6 +491,11 @@ export default function CheckersBattleRoyalLobby() {
           <p className="text-xs text-white/60 text-center">
             AI matches stay offline. Online mode uses your TPC stake and pairs you with another player.
           </p>
+          {!readiness.ready && (
+            <p className="text-xs text-amber-200 text-center">
+              Online matchmaking is currently disabled while service checks complete.
+            </p>
+          )}
         </div>
 
         {mode === 'online' && (


### PR DESCRIPTION
### Motivation
- Make Checkers Battle Royal available as an explicit online-ready game and restore a reliable host/queue flow for two-player online matches.
- Prevent user funds from being lost when matchmaking/setup fails and reduce fragile lobby state/listener leaks during host-code flows.
- Keep the webapp readiness contract and lobby UI consistent with other online games.

### Description
- Add `checkersbattleroyal` to the web fallback `ONLINE_READINESS_BY_GAME` map so it reports `Online Ready` via `getOnlineReadiness` (`webapp/src/config/onlineContract.js`).
- Harden the lobby flow in `CheckersBattleRoyalLobby.jsx` by gating online entry on readiness, disabling the Online selector when not ready, and showing a status message to the user.
- Add safer stake handling: track when the stake is charged and call a `refundStakeIfNeeded` helper on socket/connect/host-code/seat errors; include a matchmaking timeout (`MATCHMAKING_TIMEOUT_MS`) that automatically refunds and notifies the player when no opponent joins in time.
- Prevent listener leaks and stale state by removing socket listeners in all early-return host-code validation paths and clearing the matchmaking timeout in cleanup handlers; also include `token` in the `seatTable` payload for consistent metadata across queues (`webapp/src/pages/Games/CheckersBattleRoyalLobby.jsx`).
- Add a regression unit test `test/checkersOnlineReadiness.test.js` that verifies `checkersbattleroyal` is present and `ready` in the fallback readiness map.

### Testing
- Ran `jest` for the new readiness test and online policy tests: `npm test -- --runInBand test/checkersOnlineReadiness.test.js test/onlineGamePolicy.test.js` and both suites passed.
- Also ran the broader online flow suites used in local verification: `test/onlineGamePolicy.test.js`, `test/onlineRoutes.test.js`, and `test/simpleOnlineFlow.test.js`, and all passed in the environment used for these checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf8ac769208329af2d4f51ffcad36f)