### PR TITLE
Pool Royale: tolerate transient socket connect errors to avoid unnecessary refunds

### DIFF
--- a/test/poolRoyaleOnlineFlow.test.js
+++ b/test/poolRoyaleOnlineFlow.test.js
@@ -246,3 +246,56 @@ test('runPoolRoyaleOnlineFlow reconnects socket before seating table', async () 
   await delay(0);
   assert.equal(addCalls[0][2], 'stake');
 });
+
+test('runPoolRoyaleOnlineFlow tolerates transient socket connect errors on mobile', async () => {
+  class FlakyConnectSocket extends MockSocket {
+    connect() {
+      this.connectCalls += 1;
+      this.connected = false;
+      setTimeout(() => this.emit('connect_error', new Error('temporary network dip')), 5);
+      setTimeout(() => {
+        this.connected = true;
+        this.emit('connect');
+      }, 15);
+    }
+  }
+
+  const mockSocket = new FlakyConnectSocket();
+  mockSocket.connected = false;
+  const refs = createRefs();
+  const state = createState();
+  const addCalls = [];
+
+  const deps = {
+    ensureAccountId: () => Promise.resolve('acct-4'),
+    getAccountBalance: () => Promise.resolve({ balance: 200 }),
+    addTransaction: (...args) => {
+      addCalls.push(args);
+      return Promise.resolve();
+    },
+    getTelegramId: () => 'tg-4',
+    getTelegramFirstName: () => 'Dina',
+    socket: mockSocket
+  };
+
+  await runPoolRoyaleOnlineFlow({
+    stake: { token: 'TPC', amount: 100 },
+    variant: 'uk',
+    ballSet: 'uk',
+    playType: 'regular',
+    mode: 'online',
+    tableSize: 'medium',
+    avatar: 'me.png',
+    deps,
+    state,
+    refs,
+    timeouts: { seat: 50, matchmaking: 100, socketConnect: 60 }
+  });
+
+  assert.equal(mockSocket.connectCalls, 1);
+  assert.equal(mockSocket.seatRequests.length, 1, 'should keep waiting after temporary connect error');
+  mockSocket.seatRequests[0].cb({ success: false, message: 'busy' });
+  await delay(0);
+  assert.equal(state.snapshot.matchingError, 'busy');
+  assert.equal(addCalls[0][2], 'stake');
+});

--- a/webapp/src/pages/Games/poolRoyaleOnlineFlow.js
+++ b/webapp/src/pages/Games/poolRoyaleOnlineFlow.js
@@ -31,6 +31,7 @@ async function ensureSocketReady(socketInstance, timeoutMs = DEFAULT_SOCKET_CONN
   return await new Promise((resolve) => {
     let settled = false;
     let timer;
+    let lastError = null;
 
     const finish = (ok) => {
       if (settled) return;
@@ -39,11 +40,18 @@ async function ensureSocketReady(socketInstance, timeoutMs = DEFAULT_SOCKET_CONN
       socketInstance.off?.('connect', onConnect);
       socketInstance.off?.('connect_error', onConnectError);
       socketInstance.off?.('error', onConnectError);
+      if (!ok && lastError) {
+        logSupportError('Socket connect failed', lastError);
+      }
       resolve(ok);
     };
 
     const onConnect = () => finish(true);
-    const onConnectError = () => finish(false);
+    const onConnectError = (error) => {
+      lastError = error || lastError;
+      // Mobile connections can emit temporary connect errors before succeeding.
+      // Keep waiting until timeout so we avoid false negatives and unnecessary stake refunds.
+    };
 
     timer = setTimeout(() => finish(socketInstance.connected), timeoutMs);
 


### PR DESCRIPTION
### Motivation
- Prevent transient mobile network blips from being treated as fatal socket failures that immediately refund player stakes or block joining the online arena.
- Improve support visibility by logging the final socket error only when the socket actually fails to connect by timeout.
- Add regression coverage for flaky connect behavior to avoid future regressions.

### Description
- Introduced `ensureSocketReady` logic in `webapp/src/pages/Games/poolRoyaleOnlineFlow.js` to attempt `socket.connect()` and wait until either a successful `connect` or the configured timeout before deciding the socket is unavailable.
- Changed connect-error handling to record the last error and avoid immediately finishing the wait on `connect_error`, so transient errors don't trigger early refunds or failures.
- Emit a guarded `logSupportError('Socket connect failed', lastError)` only when the socket still hasn’t connected by the timeout to aid debugging without penalizing transient issues.
- Added a regression test `runPoolRoyaleOnlineFlow tolerates transient socket connect errors on mobile` in `test/poolRoyaleOnlineFlow.test.js` which simulates a `connect_error` followed by `connect` and verifies the flow proceeds to `seatTable` and does not refund prematurely.

### Testing
- Ran `npm test -- test/poolRoyaleOnlineFlow.test.js --runInBand` and all tests passed.
- Test suite run included the new flaky-connect test plus existing matchmaking/start/refund cases, with 4/4 tests passing.
- Test output showed expected support logs for timeout and seat failures but the new behavior correctly tolerated transient `connect_error` events.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf8edfdbac832985ea9445b0a394ac)