### PR TITLE
Fix Pool Royale matchmaking metadata compatibility

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -489,9 +489,19 @@ function normalizeMatchMeta(rawMeta = {}) {
 }
 
 function isMatchMetaCompatible(existing = {}, requested = {}) {
-  const entries = Object.entries(requested);
-  if (!entries.length) return true;
-  return entries.every(([key, value]) => (existing?.[key] || '') === value);
+  const allKeys = new Set([
+    ...Object.keys(existing || {}),
+    ...Object.keys(requested || {})
+  ]);
+  for (const key of allKeys) {
+    const existingValue = existing?.[key];
+    const requestedValue = requested?.[key];
+    // Treat missing keys as wildcards so players can still pair when one client
+    // sends less detailed lobby metadata (for example missing tableSize).
+    if (!existingValue || !requestedValue) continue;
+    if (existingValue !== requestedValue) return false;
+  }
+  return true;
 }
 
 function isRateLimited(socket, key, cooldownMs) {


### PR DESCRIPTION
### Motivation
- Players could appear "online" but fail to pair when one client sent additional lobby metadata (e.g., `tableSize`) and the other did not, causing fragmented queues for `poolroyale`.
- The server-side table matching needed to treat missing metadata as wildcards so clients with partial/superset match meta can still join the same table.

### Description
- Updated `isMatchMetaCompatible` in `bot/server.js` to compute the union of keys and only enforce equality when both `existing` and `requested` provide a value for a key.
- Missing or empty metadata keys are now treated as wildcards so a client with fewer metadata fields can match a client with more fields.
- This preserves strict matching when both sides provide the same key while allowing superset/subset pairings.

### Testing
- Ran the pool-royale focused unit tests with `npm test -- --runInBand test/poolRoyaleMatchmakingMeta.test.js test/poolRoyaleOnlineFlow.test.js` and both test suites passed. 
- Verified `test/poolRoyaleMatchmakingMeta.test.js` confirms partially-filled matching meta results in the same table, and `test/poolRoyaleOnlineFlow.test.js` remains green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf92a955f8832997b37631196173d1)