### PR TITLE
Scope accountId per Telegram user to fix Checkers online lobby collisions

### DIFF
--- a/test/telegramAccountIsolation.test.js
+++ b/test/telegramAccountIsolation.test.js
@@ -1,0 +1,86 @@
+import { describe, expect, test, beforeEach } from '@jest/globals';
+import { getPlayerId } from '../webapp/src/utils/telegram.js';
+
+class MemoryStorage {
+  constructor() {
+    this.store = new Map();
+  }
+
+  getItem(key) {
+    return this.store.has(key) ? this.store.get(key) : null;
+  }
+
+  setItem(key, value) {
+    this.store.set(key, String(value));
+  }
+
+  removeItem(key) {
+    this.store.delete(key);
+  }
+
+  clear() {
+    this.store.clear();
+  }
+
+  key(index) {
+    return Array.from(this.store.keys())[index] ?? null;
+  }
+
+  get length() {
+    return this.store.size;
+  }
+}
+
+function setTelegramUserId(id) {
+  const value = id == null ? undefined : id;
+  global.window.Telegram = {
+    WebApp: {
+      initDataUnsafe: {
+        user: value == null ? undefined : { id: value }
+      }
+    }
+  };
+}
+
+describe('telegram account scoped player ids', () => {
+  beforeEach(() => {
+    const storage = new MemoryStorage();
+    global.localStorage = storage;
+    global.window = {
+      localStorage: storage,
+      location: { search: '' },
+      Telegram: { WebApp: { initDataUnsafe: { user: { id: 101 } } } }
+    };
+  });
+
+  test('returns a distinct account id per Telegram user on shared storage', () => {
+    setTelegramUserId(101);
+    const accountOneFirstCall = getPlayerId();
+    const accountOneSecondCall = getPlayerId();
+    expect(accountOneFirstCall).toBeTruthy();
+    expect(accountOneSecondCall).toBe(accountOneFirstCall);
+
+    setTelegramUserId(202);
+    const accountTwo = getPlayerId();
+    expect(accountTwo).toBeTruthy();
+    expect(accountTwo).not.toBe(accountOneFirstCall);
+
+    setTelegramUserId(101);
+    expect(getPlayerId()).toBe(accountOneFirstCall);
+  });
+
+  test('binds legacy global accountId to the first Telegram user for migration', () => {
+    global.localStorage.setItem('accountId', 'legacy-account-id');
+    setTelegramUserId(555);
+
+    expect(getPlayerId()).toBe('legacy-account-id');
+
+    setTelegramUserId(777);
+    const secondAccount = getPlayerId();
+    expect(secondAccount).toBeTruthy();
+    expect(secondAccount).not.toBe('legacy-account-id');
+
+    setTelegramUserId(555);
+    expect(getPlayerId()).toBe('legacy-account-id');
+  });
+});

--- a/webapp/src/utils/telegram.js
+++ b/webapp/src/utils/telegram.js
@@ -60,13 +60,56 @@ function generateAccountId() {
   return `tpc-${timestamp}-${random}`;
 }
 
+function accountIdMapStorageKey(telegramId) {
+  return `accountId:tg:${telegramId}`;
+}
+
+function hasAnyScopedAccountIds(storage) {
+  try {
+    const len = Number(storage?.length) || 0;
+    for (let i = 0; i < len; i += 1) {
+      const key = storage.key(i);
+      if (typeof key === 'string' && key.startsWith('accountId:tg:')) {
+        return true;
+      }
+    }
+  } catch {
+    // ignore storage iteration failures
+  }
+  return false;
+}
+
 export function getPlayerId() {
   if (typeof window === 'undefined') return null;
-  let id = localStorage.getItem('accountId');
-  if (!id) {
-    id = generateAccountId();
-    if (id) localStorage.setItem('accountId', id);
+  const telegramId = getTelegramId();
+  const globalId = localStorage.getItem('accountId');
+
+  if (telegramId != null) {
+    const perTelegramKey = accountIdMapStorageKey(telegramId);
+    let telegramScopedId = localStorage.getItem(perTelegramKey);
+
+    // Backward compatibility:
+    // if this Telegram user already had a single legacy accountId stored, bind it
+    // once to the per-user key instead of generating a new id.
+    if (!telegramScopedId && globalId && !hasAnyScopedAccountIds(localStorage)) {
+      telegramScopedId = globalId;
+      localStorage.setItem(perTelegramKey, telegramScopedId);
+    }
+
+    if (!telegramScopedId) {
+      telegramScopedId = generateAccountId();
+      if (telegramScopedId) localStorage.setItem(perTelegramKey, telegramScopedId);
+    }
+
+    if (telegramScopedId) {
+      localStorage.setItem('accountId', telegramScopedId);
+      return telegramScopedId;
+    }
   }
+
+  if (globalId) return globalId;
+  const id = generateAccountId();
+  if (id) localStorage.setItem('accountId', id);
   return id;
 }
 


### PR DESCRIPTION
### Motivation
- Online matchmaking could fail when multiple Telegram accounts share one device because `accountId` was a single global localStorage key and distinct players resolved to the same identity. 
- The change scopes persisted player identities to Telegram users so two accounts on the same device can occupy separate seats in the same lobby.

### Description
- Updated `getPlayerId()` in `webapp/src/utils/telegram.js` to store a per-user key `accountId:tg:<telegramId>` and return the Telegram-scoped id when a Telegram user is present. 
- Added migration/backward-compatibility logic that binds an existing legacy `accountId` to the first seen Telegram user only when no scoped ids exist, and keeps a mirrored global `accountId` for compatibility. 
- Introduced helper functions `accountIdMapStorageKey()` and `hasAnyScopedAccountIds()` to manage scoped keys. 
- Added `test/telegramAccountIsolation.test.js` to verify per-Telegram isolation and legacy migration behavior.

### Testing
- Ran unit tests with `jest` for the new regression test and an existing readiness test via `npm test -- --runInBand test/telegramAccountIsolation.test.js test/checkersOnlineReadiness.test.js`. 
- Both test suites passed: `2 passed, 2 total` (all tests green).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf93380ed48329a38db23812a89688)