### PR TITLE
Prevent accidental private queue joins in Pool Royale online matchmaking

### DIFF
--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -60,7 +60,6 @@ export default function PoolRoyaleLobby() {
   const [playType, setPlayType] = useState(initialPlayType);
   const [players, setPlayers] = useState(8);
   const tableSize = resolveTableSize(searchParams.get('tableSize')).id;
-  const requestedTableId = (searchParams.get('tableId') || searchParams.get('tableNr') || '').trim();
   const [onlinePlayers, setOnlinePlayers] = useState([]);
   const [matching, setMatching] = useState(false);
   const [spinningPlayer, setSpinningPlayer] = useState('');
@@ -198,7 +197,6 @@ export default function PoolRoyaleLobby() {
     if (isOnlineMatch) {
       await runPoolRoyaleOnlineFlow({
         stake,
-        tableId: requestedTableId,
         variant,
         ballSet: ukBallSet,
         playType,

--- a/webapp/src/pages/Games/poolRoyaleOnlineFlow.js
+++ b/webapp/src/pages/Games/poolRoyaleOnlineFlow.js
@@ -64,6 +64,7 @@ async function ensureSocketReady(socketInstance, timeoutMs = DEFAULT_SOCKET_CONN
 export async function runPoolRoyaleOnlineFlow({
   stake,
   tableId,
+  forceTableJoin = false,
   variant,
   ballSet,
   playType,
@@ -108,7 +109,9 @@ export async function runPoolRoyaleOnlineFlow({
   const matchmakingTimeoutMs = timeouts.matchmaking ?? DEFAULT_MATCH_TIMEOUT_MS;
   const socketConnectTimeoutMs = timeouts.socketConnect ?? DEFAULT_SOCKET_CONNECT_TIMEOUT_MS;
   const requestedTableId =
-    typeof tableId === 'string' && tableId.trim() ? tableId.trim() : undefined;
+    forceTableJoin && typeof tableId === 'string' && tableId.trim()
+      ? tableId.trim()
+      : undefined;
 
   const telegramId = getTelegramIdFn?.();
 


### PR DESCRIPTION
### Motivation
- Players could be forced into a stale/private lobby because `tableId`/`tableNr` in the URL was reused when starting regular online matchmaking, causing the UI to show online players but never match them together.  
- Make forced table joins explicit so normal matchmaking uses the shared queue unless a forced join is intentionally requested.

### Description
- Stop reusing the URL `tableId`/`tableNr` when launching regular online matchmaking by removing the implicit `requestedTableId` usage in `webapp/src/pages/Games/PoolRoyaleLobby.jsx`.  
- Add a `forceTableJoin` flag to `runPoolRoyaleOnlineFlow` in `webapp/src/pages/Games/poolRoyaleOnlineFlow.js` and only honor `tableId` when `forceTableJoin === true`.  
- Update the `PoolRoyaleLobby` call to `runPoolRoyaleOnlineFlow` to no longer pass the URL table id for normal queueing, ensuring players enter the shared matchmaking pool by default.

### Testing
- Ran `npx eslint webapp/src/pages/Games/PoolRoyaleLobby.jsx webapp/src/pages/Games/poolRoyaleOnlineFlow.js`, which completed and reported the files are ignored by the repo lint ignore settings.  
- Ran `npx eslint --no-ignore webapp/src/pages/Games/PoolRoyaleLobby.jsx webapp/src/pages/Games/poolRoyaleOnlineFlow.js`, which surfaced many existing project style errors in these files; the reported issues are pre-existing and not introduced by this change.  
- Confirmed the modified code paths and socket join flow locations were inspected to ensure the change only affects forced-table behavior and not general matchmaking logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf92a955f8832997b37631196173d1)