### PR TITLE
Fix Checkers Battle Royal online matchmaking and lobby routing

### DIFF
--- a/bot/config/onlineGamePolicy.js
+++ b/bot/config/onlineGamePolicy.js
@@ -14,7 +14,7 @@ const GAME_ONLINE_POLICY = Object.freeze({
   snookerroyale: { maxPlayers: [2], allowMatchMeta: ['mode', 'playType', 'tableSize', 'token'] },
   snake: { maxPlayers: [2, 3, 4], allowMatchMeta: ['mode', 'token'] },
   chessbattleroyal: { maxPlayers: [2], allowMatchMeta: ['preferredSide', 'mode', 'token'] },
-  checkersbattleroyal: { maxPlayers: [2], allowMatchMeta: ['mode', 'token'] },
+  checkersbattleroyal: { maxPlayers: [2], allowMatchMeta: ['preferredSide', 'mode', 'token'] },
   'domino-royal': { maxPlayers: [2, 4], allowMatchMeta: ['variant', 'mode', 'token'] },
   ludobattleroyal: { maxPlayers: [2, 4], allowMatchMeta: ['variant', 'mode', 'token'] },
   texasholdem: { maxPlayers: [2, 6], allowMatchMeta: ['mode', 'token'] },

--- a/bot/server.js
+++ b/bot/server.js
@@ -476,6 +476,7 @@ const rollRateLimitMs = Number(process.env.SOCKET_ROLL_COOLDOWN_MS) || 800;
 const seatTableRateLimitMs = Number(process.env.SEAT_TABLE_RATE_LIMIT_MS) || 500;
 
 const MATCH_META_KEYS = ['mode', 'playType', 'variant', 'tableSize', 'ballSet', 'token'];
+const CHECKERS_REALTIME_GAME_TYPES = new Set(['checkers', 'checkersbattleroyal']);
 
 function normalizeMatchMeta(rawMeta = {}) {
   const normalized = {};
@@ -486,6 +487,21 @@ function normalizeMatchMeta(rawMeta = {}) {
     }
   });
   return normalized;
+}
+
+function isCheckersRealtimeGame(gameType = '') {
+  return CHECKERS_REALTIME_GAME_TYPES.has(String(gameType || '').toLowerCase());
+}
+
+function parseTableIdDescriptor(tableId = '') {
+  const raw = String(tableId || '').trim();
+  if (!raw) return { gameType: '', maxPlayers: 0 };
+  const match = raw.match(/^(.*)-(\d+)(?:-.+)?$/);
+  if (!match) return { gameType: raw, maxPlayers: 0 };
+  return {
+    gameType: match[1],
+    maxPlayers: Number(match[2]) || 0
+  };
 }
 
 function isMatchMetaCompatible(existing = {}, requested = {}) {
@@ -824,7 +840,7 @@ function maybeStartGame(table) {
         if (whitePlayer) table.currentTurn = whitePlayer.id;
         const initial = updateChessState(table.id, { turnWhite: true, lastMove: null });
         io.to(table.id).emit('chessState', { tableId: table.id, ...initial });
-      } else if (table.gameType === 'checkers') {
+      } else if (isCheckersRealtimeGame(table.gameType)) {
         table.players = assignCheckersSides(table.players);
         const lightPlayer = table.players.find((p) => p.side === 'light');
         if (lightPlayer) table.currentTurn = lightPlayer.id;
@@ -881,7 +897,7 @@ function unseatTableSocket(accountId, tableId, socketId) {
       }
     }
     if (table.players.length === 0) {
-      if (table.gameType === 'checkers') {
+      if (isCheckersRealtimeGame(table.gameType)) {
         checkersRealtimeStore.clearState(tableId);
       }
       tableMap.delete(tableId);
@@ -1485,8 +1501,9 @@ io.on('connection', (socket) => {
       if (isRateLimited(socket, 'seatTable', seatTableRateLimitMs)) {
         return cb && cb({ success: false, error: 'rate_limited' });
       }
-      const resolvedGameType = tableId ? String(tableId).split('-')[0] : gameType;
-      const resolvedMaxPlayers = tableId ? Number(String(tableId).split('-')[1]) || 0 : maxPlayers;
+      const descriptor = tableId ? parseTableIdDescriptor(tableId) : null;
+      const resolvedGameType = descriptor?.gameType || gameType;
+      const resolvedMaxPlayers = descriptor?.maxPlayers || maxPlayers;
       const validation = validateSeatTableRequest({
         gameType: resolvedGameType,
         stake,
@@ -1844,7 +1861,7 @@ io.on('connection', (socket) => {
       const board =
         room.gameType === 'snake'
           ? { snakes: room.snakes, ladders: room.ladders, diceCells: room.diceCells }
-          : room.gameType === 'checkers'
+          : isCheckersRealtimeGame(room.gameType)
           ? { board: room.game.board }
           : null;
       if (board) socket.emit('boardData', board);

--- a/test/onlineGamePolicy.test.js
+++ b/test/onlineGamePolicy.test.js
@@ -33,7 +33,7 @@ describe('online game policy', () => {
     });
   });
 
-  test('accepts chess and checkers lobby aliases used by seatTable clients', () => {
+  test('accepts chess/checkers aliases and checkers battle royal metadata used by seatTable clients', () => {
     const chess = validateSeatTableRequest({
       gameType: 'chess',
       stake: 100,
@@ -46,11 +46,22 @@ describe('online game policy', () => {
       maxPlayers: 2,
       matchMeta: { preferredSide: 'black', mode: 'online' }
     });
+    const checkersBattleRoyal = validateSeatTableRequest({
+      gameType: 'checkersbattleroyal',
+      stake: 100,
+      maxPlayers: 2,
+      matchMeta: { preferredSide: 'black', mode: 'online' }
+    });
 
     expect(chess.ok).toBe(true);
     expect(chess.safeMatchMeta).toEqual({ preferredSide: 'white', mode: 'online' });
     expect(checkers.ok).toBe(true);
     expect(checkers.safeMatchMeta).toEqual({ preferredSide: 'black', mode: 'online' });
+    expect(checkersBattleRoyal.ok).toBe(true);
+    expect(checkersBattleRoyal.safeMatchMeta).toEqual({
+      preferredSide: 'black',
+      mode: 'online'
+    });
   });
 
   test('buildReadinessSnapshot returns all policy games with security checks', () => {

--- a/webapp/src/pages/Games/CheckersBattleRoyalLobby.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyalLobby.jsx
@@ -38,7 +38,7 @@ function normalizeHostCode(code = '') {
 function buildHostedTableId(code = '') {
   const safeCode = normalizeHostCode(code);
   if (!safeCode) return '';
-  return `checkers-2-host-${safeCode}`;
+  return `checkersbattleroyal-2-host-${safeCode}`;
 }
 
 async function ensureSocketConnected(timeoutMs = SOCKET_CONNECT_TIMEOUT_MS) {
@@ -348,7 +348,7 @@ export default function CheckersBattleRoyalLobby() {
       'seatTable',
       {
         accountId: trackedAccountId || accountId,
-        gameType: 'checkers',
+        gameType: 'checkersbattleroyal',
         stake: stake.amount ?? 0,
         maxPlayers: 2,
         mode: 'online',


### PR DESCRIPTION
### Motivation
- Users joining Checkers Battle Royal were routed into the generic `checkers` online flow which caused lobby, matchmaking and realtime state to be inconsistent for Battle Royal tables. 
- Private hosted table IDs and metadata for the Battle Royal mode needed to resolve to the correct online pool and preserve `preferredSide` semantics.

### Description
- Change the lobby client to emit `gameType: 'checkersbattleroyal'` and to generate private hosted table IDs with the `checkersbattleroyal-2-host-...` prefix by updating `webapp/src/pages/Games/CheckersBattleRoyalLobby.jsx` and the hosted table builder. 
- Treat both `checkers` and `checkersbattleroyal` as realtime checkers games in the backend by adding `CHECKERS_REALTIME_GAME_TYPES` and `isCheckersRealtimeGame` and using them for game start, cleanup and spectator board sync in `bot/server.js`. 
- Add robust parsing of forced `tableId` values with `parseTableIdDescriptor` so `seatTable` resolves `gameType` and `maxPlayers` correctly from host-table IDs and uses the parsed values during validation. 
- Allow `preferredSide` metadata for `checkersbattleroyal` in `bot/config/onlineGamePolicy.js` and expand tests in `test/onlineGamePolicy.test.js` to validate the new contract. 

### Testing
- Ran unit tests with `npm test -- --runInBand test/onlineGamePolicy.test.js test/checkersOnlineReadiness.test.js`. 
- All targeted tests passed: `PASS test/onlineGamePolicy.test.js` and `PASS test/checkersOnlineReadiness.test.js`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf9761d3588329968527fb28e9c3ff)