### PR TITLE
Fix Pool Royale lobby join when using custom table IDs

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -1485,8 +1485,17 @@ io.on('connection', (socket) => {
       if (isRateLimited(socket, 'seatTable', seatTableRateLimitMs)) {
         return cb && cb({ success: false, error: 'rate_limited' });
       }
-      const resolvedGameType = tableId ? String(tableId).split('-')[0] : gameType;
-      const resolvedMaxPlayers = tableId ? Number(String(tableId).split('-')[1]) || 0 : maxPlayers;
+      const rawTableId = tableId ? String(tableId).trim() : '';
+      const parsedTableParts = rawTableId ? rawTableId.split('-') : [];
+      const parsedGameType = parsedTableParts[0];
+      const parsedMaxPlayers = Number(parsedTableParts[1]) || 0;
+      const hasStructuredTableId =
+        Boolean(rawTableId) &&
+        parsedTableParts.length === 2 &&
+        parsedGameType === String(gameType) &&
+        parsedMaxPlayers > 0;
+      const resolvedGameType = hasStructuredTableId ? parsedGameType : gameType;
+      const resolvedMaxPlayers = hasStructuredTableId ? parsedMaxPlayers : maxPlayers;
       const validation = validateSeatTableRequest({
         gameType: resolvedGameType,
         stake,

--- a/test/poolRoyaleCustomTableId.test.js
+++ b/test/poolRoyaleCustomTableId.test.js
@@ -1,0 +1,101 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import { spawn } from 'child_process';
+import { io } from 'socket.io-client';
+
+const distDir = new URL('../webapp/dist/', import.meta.url);
+const apiToken = 'test-token';
+
+async function startServer(env) {
+  const server = spawn('node', ['bot/server.js'], { env, stdio: 'pipe' });
+  await new Promise((resolve) => {
+    const onData = (chunk) => {
+      if (chunk.toString().includes('Server running on port')) {
+        server.stdout.off('data', onData);
+        resolve();
+      }
+    };
+    server.stdout.on('data', onData);
+  });
+  return server;
+}
+
+function connectClient(port) {
+  return io(`http://localhost:${port}`, { auth: { token: apiToken } });
+}
+
+test('pool royale players can match on explicit custom table id', { concurrency: false, timeout: 20000 }, async () => {
+  fs.mkdirSync(new URL('assets', distDir), { recursive: true });
+  fs.writeFileSync(new URL('index.html', distDir), '');
+
+  const env = {
+    ...process.env,
+    PORT: '3208',
+    MONGO_URI: 'memory',
+    BOT_TOKEN: 'dummy',
+    API_AUTH_TOKEN: apiToken,
+    SKIP_WEBAPP_BUILD: '1',
+    SKIP_BOT_LAUNCH: '1'
+  };
+
+  const server = await startServer(env);
+  const s1 = connectClient(3208);
+  const s2 = connectClient(3208);
+
+  try {
+    await Promise.all([
+      new Promise((resolve) => s1.on('connect', resolve)),
+      new Promise((resolve) => s2.on('connect', resolve))
+    ]);
+
+    s1.emit('register', { playerId: 'acct-1' });
+    s2.emit('register', { playerId: 'acct-2' });
+
+    const customTableId = 'b8c0cb30-8d0d-4ef0-8aaa-79de7f2f4521';
+
+    const firstSeat = await new Promise((resolve) => {
+      s1.emit(
+        'seatTable',
+        {
+          accountId: 'acct-1',
+          gameType: 'poolroyale',
+          stake: 100,
+          maxPlayers: 2,
+          mode: 'online',
+          playType: 'regular',
+          tableId: customTableId,
+          playerName: 'P1'
+        },
+        resolve
+      );
+    });
+
+    const secondSeat = await new Promise((resolve) => {
+      s2.emit(
+        'seatTable',
+        {
+          accountId: 'acct-2',
+          gameType: 'poolroyale',
+          stake: 100,
+          maxPlayers: 2,
+          mode: 'online',
+          playType: 'regular',
+          tableId: customTableId,
+          playerName: 'P2'
+        },
+        resolve
+      );
+    });
+
+    assert.equal(firstSeat.success, true);
+    assert.equal(firstSeat.tableId, customTableId);
+    assert.equal(secondSeat.success, true);
+    assert.equal(secondSeat.tableId, customTableId);
+    assert.equal(secondSeat.players.length, 2);
+  } finally {
+    s1.disconnect();
+    s2.disconnect();
+    server.kill();
+  }
+});


### PR DESCRIPTION
### Motivation
- Players could not join the same online Pool Royale table when both used a shared custom/UUID `tableId` because the backend parsed the first UUID segment as `gameType` and rejected the seat request.

### Description
- Update the socket `seatTable` handler to parse `tableId` robustly by trimming and splitting, and only override `gameType`/`maxPlayers` when the ID is clearly the legacy structured form `<gameType>-<maxPlayers>`; otherwise preserve the provided `gameType` and `maxPlayers`.
- The parsing now requires `parsedTableParts.length === 2`, `parsedGameType === String(gameType)` and `parsedMaxPlayers > 0` before applying overrides.
- Add a regression test `test/poolRoyaleCustomTableId.test.js` that starts two clients, registers both, and verifies both can join the same explicit custom table ID and that the table contains 2 players.

### Testing
- Ran `npm test -- --runInBand test/poolRoyaleMatchmakingMeta.test.js test/poolRoyaleCustomTableId.test.js`, and both tests passed.
- The tests that passed are `pool royale players with partially-filled matching meta share same table` and `pool royale players can match on explicit custom table id` (via Jest in the monorepo test runner).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf980e761c8329b70d847245746fc7)