### PR TITLE
Fix Pool Royale lobby stale seats on socket disconnect

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -1984,6 +1984,22 @@ io.on('connection', (socket) => {
     }
   );
 
+  const clearSocketLobbySeats = () => {
+    const pid = socket.data.playerId;
+    for (const [roomId, seats] of tableSeats.entries()) {
+      const seated = Array.from(seats.values()).some(
+        (seat) => seat?.socketId === socket.id
+      );
+      if (seated) {
+        unseatTableSocket(pid, roomId, socket.id);
+      }
+    }
+  };
+
+  socket.on('disconnecting', () => {
+    clearSocketLobbySeats();
+  });
+
   socket.on('disconnect', async () => {
     await gameManager.handleDisconnect(socket);
     lastActionBySocket.delete(socket.id);
@@ -1999,11 +2015,7 @@ io.on('connection', (socket) => {
         () => {}
       );
     }
-    for (const roomId of socket.rooms) {
-      if (tableSeats.has(roomId)) {
-        unseatTableSocket(pid, roomId, socket.id);
-      }
-    }
+    clearSocketLobbySeats();
     for (const [id, set] of tableWatchers) {
       if (set.delete(socket.id)) {
         const count = set.size;

--- a/test/poolRoyaleMatchmakingMeta.test.js
+++ b/test/poolRoyaleMatchmakingMeta.test.js
@@ -87,3 +87,79 @@ test('pool royale players with partially-filled matching meta share same table',
     server.kill();
   }
 });
+
+test('pool royale disconnect clears stale lobby seat so next player can queue cleanly', { concurrency: false, timeout: 20000 }, async () => {
+  fs.mkdirSync(new URL('assets', distDir), { recursive: true });
+  fs.writeFileSync(new URL('index.html', distDir), '');
+
+  const env = {
+    ...process.env,
+    PORT: '3208',
+    MONGO_URI: 'memory',
+    BOT_TOKEN: 'dummy',
+    API_AUTH_TOKEN: apiToken,
+    SKIP_WEBAPP_BUILD: '1',
+    SKIP_BOT_LAUNCH: '1'
+  };
+
+  const server = await startServer(env);
+  const s1 = connectClient(3208);
+
+  try {
+    await new Promise((resolve) => s1.on('connect', resolve));
+    s1.emit('register', { playerId: 'acct-disconnect-a' });
+
+    const firstSeat = await new Promise((resolve) => {
+      s1.emit(
+        'seatTable',
+        {
+          accountId: 'acct-disconnect-a',
+          gameType: 'poolroyale',
+          stake: 100,
+          maxPlayers: 2,
+          mode: 'online',
+          playType: 'regular',
+          playerName: 'DisconnectA'
+        },
+        resolve
+      );
+    });
+    assert.equal(firstSeat.success, true);
+    assert.equal(firstSeat.players.length, 1);
+
+    s1.disconnect();
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    const s2 = connectClient(3208);
+    try {
+      await new Promise((resolve) => s2.on('connect', resolve));
+      s2.emit('register', { playerId: 'acct-disconnect-b' });
+      const secondSeat = await new Promise((resolve) => {
+        s2.emit(
+          'seatTable',
+          {
+            accountId: 'acct-disconnect-b',
+            gameType: 'poolroyale',
+            stake: 100,
+            maxPlayers: 2,
+            mode: 'online',
+            playType: 'regular',
+            playerName: 'DisconnectB'
+          },
+          resolve
+        );
+      });
+
+      assert.equal(secondSeat.success, true);
+      assert.equal(
+        secondSeat.players.some((player) => player.id === 'acct-disconnect-a'),
+        false
+      );
+      assert.equal(secondSeat.players.length, 1);
+    } finally {
+      s2.disconnect();
+    }
+  } finally {
+    server.kill();
+  }
+});


### PR DESCRIPTION
### Motivation
- Players could be left as ghost seats in Pool Royale lobbies after abrupt disconnects, which blocked fresh 1v1 matchmaking because cleanup relied on `socket.rooms` that may already be cleared at `disconnect` time.

### Description
- Add `clearSocketLobbySeats()` in `bot/server.js` that scans `tableSeats` for entries matching `socket.id` and calls `unseatTableSocket` to remove stale seats. 
- Invoke the helper on `disconnecting` and again as a fallback on `disconnect` so seats are removed reliably even when room membership is no longer present. 
- Add a regression test `pool royale disconnect clears stale lobby seat so next player can queue cleanly` in `test/poolRoyaleMatchmakingMeta.test.js` to reproduce and verify the fix.

### Testing
- Ran `node --test test/poolRoyaleMatchmakingMeta.test.js` which executed both the existing partial-meta matchmaking test and the new disconnect cleanup regression test, and all tests passed. 
- The added test ensures that when player A seats then disconnects, player B can subsequently seat without the stale A entry remaining.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf980e761c8329b70d847245746fc7)