### PR TITLE
Fix Checkers Battle Royal online lobby timeout cleanup and reconnect handling

### DIFF
--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -2151,10 +2151,21 @@ export default function CheckersBattleRoyal() {
       const myTurn = (remoteTurn === 'dark' ? 'dark' : 'light') === onlineRef.current.side;
       setStatus(myTurn ? 'Your turn. Forced captures are enabled.' : 'Waiting for opponent move…');
     };
+    const handleSocketDisconnect = () => {
+      setOnlineStatus('reconnecting');
+      setStatus('Connection lost. Reconnecting to table…');
+    };
+    const handleSocketReconnect = () => {
+      socket.emit('register', { playerId: accountId });
+      socket.emit('joinCheckersRoom', { tableId, accountId });
+      socket.emit('checkersSyncRequest', { tableId });
+    };
 
     let cancelled = false;
     socket.on('gameStart', handleGameStart);
     socket.on('checkersState', handleCheckersState);
+    socket.on('disconnect', handleSocketDisconnect);
+    socket.on('reconnect', handleSocketReconnect);
 
     const joinOnlineTable = async () => {
       const connected = await ensureOnlineSocketConnected();
@@ -2175,6 +2186,8 @@ export default function CheckersBattleRoyal() {
       cancelled = true;
       socket.off('gameStart', handleGameStart);
       socket.off('checkersState', handleCheckersState);
+      socket.off('disconnect', handleSocketDisconnect);
+      socket.off('reconnect', handleSocketReconnect);
       socket.emit('leaveLobby', { accountId, tableId });
     };
   }, [accountId, mode, renderHighlights, renderPieces, tableId]);

--- a/webapp/src/pages/Games/CheckersBattleRoyalLobby.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyalLobby.jsx
@@ -92,6 +92,7 @@ export default function CheckersBattleRoyalLobby() {
   const [onlineQueueMode, setOnlineQueueMode] = useState('quick');
   const [hostCodeInput, setHostCodeInput] = useState('');
   const pendingTableRef = useRef('');
+  const matchmakingTimeoutRef = useRef(null);
   const cleanupRef = useRef(() => {});
   const readiness = getOnlineReadiness('checkersbattleroyal');
 
@@ -158,6 +159,16 @@ export default function CheckersBattleRoyalLobby() {
 
   useEffect(() => () => cleanupRef.current?.(), []);
 
+  useEffect(
+    () => () => {
+      if (matchmakingTimeoutRef.current) {
+        clearTimeout(matchmakingTimeoutRef.current);
+        matchmakingTimeoutRef.current = null;
+      }
+    },
+    []
+  );
+
   useEffect(() => {
     try {
       const stored = window.localStorage?.getItem(CHECKERS_HOST_CODE_STORAGE_KEY) || '';
@@ -208,6 +219,10 @@ export default function CheckersBattleRoyalLobby() {
   };
 
   const cleanupLobby = ({ account, skipRefReset, skipLeave } = {}) => {
+    if (matchmakingTimeoutRef.current) {
+      clearTimeout(matchmakingTimeoutRef.current);
+      matchmakingTimeoutRef.current = null;
+    }
     socket.off('gameStart');
     socket.off('lobbyUpdate');
     if (!skipLeave && pendingTableRef.current && (account || accountId)) {
@@ -343,6 +358,7 @@ export default function CheckersBattleRoyalLobby() {
       setMatchError('No opponent joined in time. Your stake was refunded.');
       setMatchStatus('');
     }, MATCHMAKING_TIMEOUT_MS);
+    matchmakingTimeoutRef.current = matchTimeout;
 
     socket.emit(
       'seatTable',
@@ -361,6 +377,7 @@ export default function CheckersBattleRoyalLobby() {
       async (res) => {
         if (!res?.success || !res.tableId) {
           clearTimeout(matchTimeout);
+          matchmakingTimeoutRef.current = null;
           await refundStakeIfNeeded();
           setMatchError('Could not join the online lobby. Please try again.');
           cleanupLobby({ account: trackedAccountId });
@@ -378,6 +395,7 @@ export default function CheckersBattleRoyalLobby() {
         });
         cleanupRef.current = () => {
           clearTimeout(matchTimeout);
+          matchmakingTimeoutRef.current = null;
           cleanupLobby({ account: trackedAccountId, skipRefReset: true });
         };
       }


### PR DESCRIPTION
### Motivation
- Prevent stale matchmaking timers and incorrect refund/error UI when a lobby flow completes or is cancelled by ensuring the lobby timeout is tracked and cancelled. 
- Improve runtime resilience for online checkers games so transient network disconnects do not leave the client desynced from the server.

### Description
- Added a dedicated `matchmakingTimeoutRef` in `CheckersBattleRoyalLobby.jsx` and clear it on unmount, on explicit cleanup, and on all matchmaking failure/success paths to avoid late timeout side effects. 
- Updated `cleanupLobby` to clear the matchmaking timeout and reset the ref so cancelled or finished flows cannot trigger refunds/errors after navigation. 
- In `CheckersBattleRoyal.jsx` added `disconnect` and `reconnect` socket handlers that update `onlineStatus`/`status` on disconnect and, on reconnect, re-register the player, re-join the checkers room and request a full `checkersSyncRequest` to restore board state. 
- Ensured event listeners for the new handlers are removed on effect cleanup to avoid leaks.

### Testing
- Ran `npm test -- --runInBand test/checkersOnlineReadiness.test.js test/onlineGamePolicy.test.js test/simpleOnlineFlow.test.js` and all test suites passed (3 suites, 7 tests total). 
- Also ran `npm test -- --runInBand test/checkersOnlineReadiness.test.js test/onlineGamePolicy.test.js` earlier and those suites passed (2 suites, 5 tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf9761d3588329968527fb28e9c3ff)