### PR TITLE
Fix Pool Royale online lobby table matching

### DIFF
--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -47,6 +47,7 @@ export default function PoolRoyaleLobby() {
   })();
   const initialMode = searchParams.get('mode') === 'online' ? 'online' : 'ai';
   const autoStartRequested = searchParams.get('autostart') === '1';
+  const requestedOnlineTableId = (searchParams.get('tableId') || '').trim();
 
   const [stake, setStake] = useState({ token: 'TPC', amount: 100 });
   const [mode, setMode] = useState(initialMode);
@@ -197,6 +198,7 @@ export default function PoolRoyaleLobby() {
     if (isOnlineMatch) {
       await runPoolRoyaleOnlineFlow({
         stake,
+        tableId: requestedOnlineTableId || undefined,
         variant,
         ballSet: ukBallSet,
         playType,

--- a/webapp/src/pages/Games/poolRoyaleOnlineFlow.js
+++ b/webapp/src/pages/Games/poolRoyaleOnlineFlow.js
@@ -64,7 +64,6 @@ async function ensureSocketReady(socketInstance, timeoutMs = DEFAULT_SOCKET_CONN
 export async function runPoolRoyaleOnlineFlow({
   stake,
   tableId,
-  forceTableJoin = false,
   variant,
   ballSet,
   playType,
@@ -109,7 +108,7 @@ export async function runPoolRoyaleOnlineFlow({
   const matchmakingTimeoutMs = timeouts.matchmaking ?? DEFAULT_MATCH_TIMEOUT_MS;
   const socketConnectTimeoutMs = timeouts.socketConnect ?? DEFAULT_SOCKET_CONNECT_TIMEOUT_MS;
   const requestedTableId =
-    forceTableJoin && typeof tableId === 'string' && tableId.trim()
+    typeof tableId === 'string' && tableId.trim()
       ? tableId.trim()
       : undefined;
 


### PR DESCRIPTION
### Motivation
- Ensure invite/deep-link table targeting is honored so players join the same online table instead of being split into separate queues during Pool Royale matchmaking.

### Description
- Forward a provided `tableId` unconditionally from `PoolRoyaleLobby` into `runPoolRoyaleOnlineFlow` and remove the `forceTableJoin` gating so `poolRoyaleOnlineFlow` will include the requested `tableId` in the socket `seatTable` payload (files changed: `webapp/src/pages/Games/PoolRoyaleLobby.jsx`, `webapp/src/pages/Games/poolRoyaleOnlineFlow.js`).

### Testing
- Ran `npm test -- --runInBand test/poolRoyaleOnlineFlow.test.js` and the suite passed (4 tests). 
- Ran `npm test -- --runInBand test/simpleOnlineFlow.test.js` and the suite passed (2 tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf9b7192e08329be581779af9ba7be)