### PR TITLE
Fix Pool Royale online matchmaking pairing reliability

### DIFF
--- a/multiplayer-backend/dist/services/matchmakingService.js
+++ b/multiplayer-backend/dist/services/matchmakingService.js
@@ -7,6 +7,7 @@ export class MatchmakingService {
         this.redisClient = redisClient;
     }
     async joinQueue(entry) {
+        await this.redisClient.lrem(this.queueKey, 0, entry.userId);
         await this.redisClient.hset(`${this.queueKey}:meta`, entry.userId, JSON.stringify(entry));
         await this.redisClient.rpush(this.queueKey, entry.userId);
     }
@@ -14,21 +15,67 @@ export class MatchmakingService {
         await this.redisClient.lrem(this.queueKey, 0, userId);
         await this.redisClient.hdel(`${this.queueKey}:meta`, userId);
     }
-    async popMatchPair() {
-        const firstId = await this.redisClient.lpop(this.queueKey);
-        if (!firstId) {
+    async popMatchPair(requesterId) {
+        const allQueuedIds = await this.redisClient.lrange(this.queueKey, 0, -1);
+        if (allQueuedIds.length < 2) {
             return null;
         }
-        const secondId = await this.redisClient.lpop(this.queueKey);
-        if (!secondId) {
-            await this.redisClient.lpush(this.queueKey, firstId);
+        const [requester, opponent] = requesterId
+            ? await this.pickCompatibleWithRequester(requesterId, allQueuedIds)
+            : await this.pickFirstCompatiblePair(allQueuedIds);
+        if (!requester || !opponent) {
             return null;
         }
-        const [firstRaw, secondRaw] = await this.redisClient.hmget(`${this.queueKey}:meta`, firstId, secondId);
-        await this.redisClient.hdel(`${this.queueKey}:meta`, firstId, secondId);
-        if (!firstRaw || !secondRaw) {
-            return null;
+        await this.redisClient.lrem(this.queueKey, 0, requester.userId);
+        await this.redisClient.lrem(this.queueKey, 0, opponent.userId);
+        await this.redisClient.hdel(`${this.queueKey}:meta`, requester.userId, opponent.userId);
+        return [requester, opponent];
+    }
+    async pickCompatibleWithRequester(requesterId, queuedIds) {
+        const requesterRaw = (await this.redisClient.hmget(`${this.queueKey}:meta`, requesterId))[0];
+        if (!requesterRaw) {
+            return [null, null];
         }
-        return [JSON.parse(firstRaw), JSON.parse(secondRaw)];
+        const requester = JSON.parse(requesterRaw);
+        const opponentIds = queuedIds.filter((queuedId) => queuedId !== requesterId);
+        if (opponentIds.length === 0) {
+            return [null, null];
+        }
+        const opponentsRaw = await this.redisClient.hmget(`${this.queueKey}:meta`, ...opponentIds);
+        for (let i = 0; i < opponentsRaw.length; i += 1) {
+            const raw = opponentsRaw[i];
+            if (!raw) {
+                continue;
+            }
+            const candidate = JSON.parse(raw);
+            if (this.canMatchTogether(requester, candidate)) {
+                return [requester, candidate];
+            }
+        }
+        return [null, null];
+    }
+    async pickFirstCompatiblePair(queuedIds) {
+        const entriesRaw = await this.redisClient.hmget(`${this.queueKey}:meta`, ...queuedIds);
+        const entries = entriesRaw
+            .map((raw) => (raw ? JSON.parse(raw) : null))
+            .filter((entry) => Boolean(entry));
+        for (let firstIndex = 0; firstIndex < entries.length; firstIndex += 1) {
+            for (let secondIndex = firstIndex + 1; secondIndex < entries.length; secondIndex += 1) {
+                const first = entries[firstIndex];
+                const second = entries[secondIndex];
+                if (this.canMatchTogether(first, second)) {
+                    return [first, second];
+                }
+            }
+        }
+        return [null, null];
+    }
+    canMatchTogether(first, second) {
+        if (first.userId === second.userId) {
+            return false;
+        }
+        const firstRegion = first.region?.toLowerCase() ?? 'global';
+        const secondRegion = second.region?.toLowerCase() ?? 'global';
+        return first.gameMode === second.gameMode && firstRegion === secondRegion;
     }
 }

--- a/multiplayer-backend/dist/ws/socketGateway.js
+++ b/multiplayer-backend/dist/ws/socketGateway.js
@@ -51,17 +51,38 @@ export function createRealtimeServer(app) {
                 socket.emit('error', { code: 'QUEUE_INVALID_PAYLOAD', message: 'Invalid queue payload', details: parsed.error.flatten() });
                 return;
             }
-            await matchmaking.joinQueue({
+            const queueEntry = {
                 userId: user.id,
                 username: user.username,
                 gameMode: parsed.data.gameMode,
+                region: parsed.data.region,
                 joinedAt: Date.now(),
-            });
-            const pair = await matchmaking.popMatchPair();
+            };
+            await matchmaking.joinQueue(queueEntry);
+            const pair = await matchmaking.popMatchPair(user.id);
             if (!pair) {
                 return;
             }
             const [playerA, playerB] = pair;
+            const playerASocketId = sessions.getSocket(playerA.userId);
+            const playerBSocketId = sessions.getSocket(playerB.userId);
+            if (!playerASocketId || !playerBSocketId) {
+                if (playerASocketId) {
+                    await matchmaking.joinQueue(playerA);
+                    io.to(playerASocketId).emit('error', {
+                        code: 'QUEUE_RETRYING',
+                        message: 'Opponent disconnected while matching. Searching again.',
+                    });
+                }
+                if (playerBSocketId) {
+                    await matchmaking.joinQueue(playerB);
+                    io.to(playerBSocketId).emit('error', {
+                        code: 'QUEUE_RETRYING',
+                        message: 'Opponent disconnected while matching. Searching again.',
+                    });
+                }
+                return;
+            }
             const dbMatch = await createMatch({
                 roomCode: `MM-${Date.now().toString().slice(-6)}`,
                 isPrivate: false,
@@ -75,11 +96,10 @@ export function createRealtimeServer(app) {
             roomService.joinRoom(playerB.userId, generatedRoom.roomCode);
             const initialState = stateService.createInitialState(dbMatch.id, playerA.userId, playerB.userId);
             await startMatch(dbMatch.id, initialState);
-            [playerA.userId, playerB.userId].forEach((playerId) => {
-                const socketId = sessions.getSocket(playerId);
-                if (!socketId) {
-                    return;
-                }
+            [
+                { playerId: playerA.userId, socketId: playerASocketId },
+                { playerId: playerB.userId, socketId: playerBSocketId },
+            ].forEach(({ playerId, socketId }) => {
                 io.to(socketId).emit('match:found', {
                     matchId: dbMatch.id,
                     roomCode: generatedRoom.roomCode,

--- a/multiplayer-backend/src/services/matchmakingService.ts
+++ b/multiplayer-backend/src/services/matchmakingService.ts
@@ -6,15 +6,15 @@ interface RedisLike {
   rpush(key: string, value: string): Promise<unknown>;
   lrem(key: string, count: number, value: string): Promise<unknown>;
   hdel(key: string, ...fields: string[]): Promise<unknown>;
-  lpop(key: string): Promise<string | null>;
-  lpush(key: string, value: string): Promise<unknown>;
   hmget(key: string, ...fields: string[]): Promise<Array<string | null>>;
+  lrange(key: string, start: number, stop: number): Promise<string[]>;
 }
 
 export interface QueueEntry {
   userId: string;
   username: string;
   gameMode: string;
+  region?: string;
   joinedAt: number;
 }
 
@@ -24,6 +24,7 @@ export class MatchmakingService {
   constructor(private readonly redisClient: RedisLike = redis) {}
 
   async joinQueue(entry: QueueEntry): Promise<void> {
+    await this.redisClient.lrem(this.queueKey, 0, entry.userId);
     await this.redisClient.hset(`${this.queueKey}:meta`, entry.userId, JSON.stringify(entry));
     await this.redisClient.rpush(this.queueKey, entry.userId);
   }
@@ -33,24 +34,84 @@ export class MatchmakingService {
     await this.redisClient.hdel(`${this.queueKey}:meta`, userId);
   }
 
-  async popMatchPair(): Promise<[QueueEntry, QueueEntry] | null> {
-    const firstId = await this.redisClient.lpop(this.queueKey);
-    if (!firstId) {
-      return null;
-    }
-    const secondId = await this.redisClient.lpop(this.queueKey);
-    if (!secondId) {
-      await this.redisClient.lpush(this.queueKey, firstId);
+  async popMatchPair(requesterId?: string): Promise<[QueueEntry, QueueEntry] | null> {
+    const allQueuedIds = await this.redisClient.lrange(this.queueKey, 0, -1);
+    if (allQueuedIds.length < 2) {
       return null;
     }
 
-    const [firstRaw, secondRaw] = await this.redisClient.hmget(`${this.queueKey}:meta`, firstId, secondId);
-    await this.redisClient.hdel(`${this.queueKey}:meta`, firstId, secondId);
+    const [requester, opponent] = requesterId
+      ? await this.pickCompatibleWithRequester(requesterId, allQueuedIds)
+      : await this.pickFirstCompatiblePair(allQueuedIds);
 
-    if (!firstRaw || !secondRaw) {
+    if (!requester || !opponent) {
       return null;
     }
 
-    return [JSON.parse(firstRaw) as QueueEntry, JSON.parse(secondRaw) as QueueEntry];
+    await this.redisClient.lrem(this.queueKey, 0, requester.userId);
+    await this.redisClient.lrem(this.queueKey, 0, opponent.userId);
+    await this.redisClient.hdel(`${this.queueKey}:meta`, requester.userId, opponent.userId);
+
+    return [requester, opponent];
+  }
+
+  private async pickCompatibleWithRequester(
+    requesterId: string,
+    queuedIds: string[],
+  ): Promise<[QueueEntry | null, QueueEntry | null]> {
+    const requesterRaw = (await this.redisClient.hmget(`${this.queueKey}:meta`, requesterId))[0];
+    if (!requesterRaw) {
+      return [null, null];
+    }
+    const requester = JSON.parse(requesterRaw) as QueueEntry;
+
+    const opponentIds = queuedIds.filter((queuedId) => queuedId !== requesterId);
+    if (opponentIds.length === 0) {
+      return [null, null];
+    }
+
+    const opponentsRaw = await this.redisClient.hmget(`${this.queueKey}:meta`, ...opponentIds);
+    for (let i = 0; i < opponentsRaw.length; i += 1) {
+      const raw = opponentsRaw[i];
+      if (!raw) {
+        continue;
+      }
+      const candidate = JSON.parse(raw) as QueueEntry;
+      if (this.canMatchTogether(requester, candidate)) {
+        return [requester, candidate];
+      }
+    }
+
+    return [null, null];
+  }
+
+  private async pickFirstCompatiblePair(queuedIds: string[]): Promise<[QueueEntry | null, QueueEntry | null]> {
+    const entriesRaw = await this.redisClient.hmget(`${this.queueKey}:meta`, ...queuedIds);
+    const entries = entriesRaw
+      .map((raw) => (raw ? (JSON.parse(raw) as QueueEntry) : null))
+      .filter((entry): entry is QueueEntry => Boolean(entry));
+
+    for (let firstIndex = 0; firstIndex < entries.length; firstIndex += 1) {
+      for (let secondIndex = firstIndex + 1; secondIndex < entries.length; secondIndex += 1) {
+        const first = entries[firstIndex];
+        const second = entries[secondIndex];
+        if (this.canMatchTogether(first, second)) {
+          return [first, second];
+        }
+      }
+    }
+
+    return [null, null];
+  }
+
+  private canMatchTogether(first: QueueEntry, second: QueueEntry): boolean {
+    if (first.userId === second.userId) {
+      return false;
+    }
+
+    const firstRegion = first.region?.toLowerCase() ?? 'global';
+    const secondRegion = second.region?.toLowerCase() ?? 'global';
+
+    return first.gameMode === second.gameMode && firstRegion === secondRegion;
   }
 }

--- a/multiplayer-backend/src/ws/socketGateway.ts
+++ b/multiplayer-backend/src/ws/socketGateway.ts
@@ -61,19 +61,43 @@ export function createRealtimeServer(app: Express) {
         return;
       }
 
-      await matchmaking.joinQueue({
+      const queueEntry = {
         userId: user.id,
         username: user.username,
         gameMode: parsed.data.gameMode,
+        region: parsed.data.region,
         joinedAt: Date.now(),
-      });
+      };
 
-      const pair = await matchmaking.popMatchPair();
+      await matchmaking.joinQueue(queueEntry);
+
+      const pair = await matchmaking.popMatchPair(user.id);
       if (!pair) {
         return;
       }
 
       const [playerA, playerB] = pair;
+      const playerASocketId = sessions.getSocket(playerA.userId);
+      const playerBSocketId = sessions.getSocket(playerB.userId);
+
+      if (!playerASocketId || !playerBSocketId) {
+        if (playerASocketId) {
+          await matchmaking.joinQueue(playerA);
+          io.to(playerASocketId).emit('error', {
+            code: 'QUEUE_RETRYING',
+            message: 'Opponent disconnected while matching. Searching again.',
+          });
+        }
+        if (playerBSocketId) {
+          await matchmaking.joinQueue(playerB);
+          io.to(playerBSocketId).emit('error', {
+            code: 'QUEUE_RETRYING',
+            message: 'Opponent disconnected while matching. Searching again.',
+          });
+        }
+        return;
+      }
+
       const dbMatch = await createMatch({
         roomCode: `MM-${Date.now().toString().slice(-6)}`,
         isPrivate: false,
@@ -89,11 +113,10 @@ export function createRealtimeServer(app: Express) {
       const initialState = stateService.createInitialState(dbMatch.id, playerA.userId, playerB.userId);
       await startMatch(dbMatch.id, initialState as unknown as Prisma.JsonObject);
 
-      [playerA.userId, playerB.userId].forEach((playerId) => {
-        const socketId = sessions.getSocket(playerId);
-        if (!socketId) {
-          return;
-        }
+      [
+        { playerId: playerA.userId, socketId: playerASocketId },
+        { playerId: playerB.userId, socketId: playerBSocketId },
+      ].forEach(({ playerId, socketId }) => {
         io.to(socketId).emit('match:found', {
           matchId: dbMatch.id,
           roomCode: generatedRoom.roomCode,

--- a/multiplayer-backend/tests/matchmakingService.test.ts
+++ b/multiplayer-backend/tests/matchmakingService.test.ts
@@ -34,54 +34,67 @@ class InMemoryRedis {
     return 1;
   }
 
-  async lpop(key: string) {
-    const list = this.lists.get(key) ?? [];
-    const item = list.shift() ?? null;
-    this.lists.set(key, list);
-    return item;
-  }
-
-  async lpush(key: string, value: string) {
-    const list = this.lists.get(key) ?? [];
-    list.unshift(value);
-    this.lists.set(key, list);
-    return list.length;
-  }
-
   async hmget(key: string, ...fields: string[]) {
     const hash = this.hashes.get(key) ?? new Map<string, string>();
     return fields.map((field) => hash.get(field) ?? null);
   }
+
+  async lrange(key: string, start: number, stop: number) {
+    const list = this.lists.get(key) ?? [];
+    const safeStop = stop < 0 ? list.length + stop + 1 : stop + 1;
+    return list.slice(start, safeStop);
+  }
 }
 
-const makeEntry = (userId: string): QueueEntry => ({
+const makeEntry = (userId: string, overrides: Partial<QueueEntry> = {}): QueueEntry => ({
   userId,
   username: `player-${userId}`,
   gameMode: 'ranked',
+  region: 'eu',
   joinedAt: Date.now(),
+  ...overrides,
 });
 
 describe('MatchmakingService', () => {
-  it('pairs two queued players', async () => {
+  it('pairs requester with compatible queued player', async () => {
     const redis = new InMemoryRedis();
     const service = new MatchmakingService(redis);
 
     await service.joinQueue(makeEntry('u1'));
     await service.joinQueue(makeEntry('u2'));
 
-    const pair = await service.popMatchPair();
+    const pair = await service.popMatchPair('u2');
     expect(pair).not.toBeNull();
-    expect(pair?.[0].userId).toBe('u1');
-    expect(pair?.[1].userId).toBe('u2');
+    expect(pair?.[0].userId).toBe('u2');
+    expect(pair?.[1].userId).toBe('u1');
   });
 
-  it('returns null when queue has less than two players', async () => {
+  it('does not pair players from different game modes or regions', async () => {
     const redis = new InMemoryRedis();
     const service = new MatchmakingService(redis);
 
-    await service.joinQueue(makeEntry('solo'));
-    const pair = await service.popMatchPair();
+    await service.joinQueue(makeEntry('u1', { gameMode: 'ranked', region: 'eu' }));
+    await service.joinQueue(makeEntry('u2', { gameMode: 'casual', region: 'eu' }));
+    await service.joinQueue(makeEntry('u3', { gameMode: 'ranked', region: 'na' }));
 
+    const pair = await service.popMatchPair('u1');
     expect(pair).toBeNull();
+  });
+
+  it('deduplicates queue joins for the same user', async () => {
+    const redis = new InMemoryRedis();
+    const service = new MatchmakingService(redis);
+
+    await service.joinQueue(makeEntry('u1'));
+    await service.joinQueue(makeEntry('u1'));
+    await service.joinQueue(makeEntry('u2'));
+
+    const pair = await service.popMatchPair('u2');
+    expect(pair).not.toBeNull();
+    expect(pair?.[0].userId).toBe('u2');
+    expect(pair?.[1].userId).toBe('u1');
+
+    const secondTry = await service.popMatchPair('u1');
+    expect(secondTry).toBeNull();
   });
 });


### PR DESCRIPTION
### Motivation
- Players were affected by failed or incorrect pairings in the online lobby (e.g., "unable" to start matches) because the queue allowed duplicate joins, ignored region/gameMode compatibility, and could start matches when a player's socket had disconnected. 
- The change aims to make matchmaking deterministic around the requester, only match compatible opponents, and avoid half-started matches when sockets are gone.

### Description
- Harden `MatchmakingService` by deduplicating joins (`lrem` before `rpush`), adding optional `region` metadata to `QueueEntry`, and replacing the naive `lpop` pairing with a requester-centered `popMatchPair(requesterId?)` plus `pickCompatibleWithRequester` and `pickFirstCompatiblePair` helper flows. 
- Add strict compatibility checks in `canMatchTogether` to require matching `gameMode` and `region` (never self-match). 
- Update the realtime gateway (`socketGateway`) to enqueue a normalized `queueEntry` (including `region`), call `popMatchPair(user.id)`, and perform defensive socket presence checks before creating a DB match, re-queueing and emitting `QUEUE_RETRYING` if an opponent disconnected during matching. 
- Expand unit tests in `multiplayer-backend/tests/matchmakingService.test.ts` to cover requester-centric pairing, compatibility filtering, and duplicate-join protection, and update the built artifacts in `multiplayer-backend/dist/`.

### Testing
- Ran unit tests with `npm --prefix multiplayer-backend test`, and all tests passed (2 test files, 5 tests total). 
- Built the backend with `npm --prefix multiplayer-backend run build`, which completed successfully and regenerated the `dist` artifacts. 
- The new tests exercise `MatchmakingService` pairing logic and the added compatibility/dedup behavior and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf9b7192e08329be581779af9ba7be)