### PR TITLE
Improve Pool Royale matchmaking reliability: register handshake, seat retry, timeout tuning

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -1437,16 +1437,25 @@ mongoose.connection.once('open', async () => {
 });
 
 io.on('connection', (socket) => {
-  socket.on('register', async ({ playerId }) => {
-    if (!playerId) return;
-    let set = userSockets.get(String(playerId));
-    if (!set) {
-      set = new Set();
-      userSockets.set(String(playerId), set);
+  socket.on('register', async ({ playerId } = {}, cb) => {
+    if (!playerId) {
+      cb && cb({ success: false, error: 'missing_player_id' });
+      return;
     }
-    set.add(socket.id);
-    socket.data.playerId = String(playerId);
-    await registerConnection({ userId: String(playerId), socketId: socket.id });
+    try {
+      let set = userSockets.get(String(playerId));
+      if (!set) {
+        set = new Set();
+        userSockets.set(String(playerId), set);
+      }
+      set.add(socket.id);
+      socket.data.playerId = String(playerId);
+      await registerConnection({ userId: String(playerId), socketId: socket.id });
+      cb && cb({ success: true });
+    } catch (error) {
+      console.error('register socket failed', error);
+      cb && cb({ success: false, error: 'register_failed' });
+    }
   });
 
   socket.on('createLobby', ({ roomId }, cb) => {

--- a/test/poolRoyaleOnlineFlow.test.js
+++ b/test/poolRoyaleOnlineFlow.test.js
@@ -10,6 +10,7 @@ class MockSocket extends EventEmitter {
     this.connected = true;
     this.seatRequests = [];
     this.leaveRequests = [];
+    this.registerRequests = [];
     this.connectCalls = 0;
   }
 
@@ -20,6 +21,11 @@ class MockSocket extends EventEmitter {
   }
 
   emit(event, payload, cb) {
+    if (event === 'register') {
+      this.registerRequests.push(payload);
+      if (typeof cb === 'function') cb({ success: true });
+      return true;
+    }
     if (event === 'seatTable') {
       this.seatRequests.push({ payload, cb });
       return true;
@@ -122,6 +128,7 @@ test('runPoolRoyaleOnlineFlow debits once and keeps stake for game start', async
   });
 
   assert.equal(mockSocket.seatRequests.length, 1);
+  assert.equal(mockSocket.registerRequests.length, 1);
   const seatPayload = mockSocket.seatRequests[0].payload;
   assert.equal(seatPayload.ballSet, 'american');
   assert.equal(seatPayload.variant, 'uk');
@@ -241,6 +248,7 @@ test('runPoolRoyaleOnlineFlow reconnects socket before seating table', async () 
   });
 
   assert.equal(mockSocket.connectCalls, 1);
+  assert.equal(mockSocket.registerRequests.length, 1);
   assert.equal(mockSocket.seatRequests.length, 1, 'should proceed after reconnecting');
   mockSocket.seatRequests[0].cb({ success: false, message: 'busy' });
   await delay(0);
@@ -293,9 +301,60 @@ test('runPoolRoyaleOnlineFlow tolerates transient socket connect errors on mobil
   });
 
   assert.equal(mockSocket.connectCalls, 1);
+  assert.equal(mockSocket.registerRequests.length, 1);
   assert.equal(mockSocket.seatRequests.length, 1, 'should keep waiting after temporary connect error');
   mockSocket.seatRequests[0].cb({ success: false, message: 'busy' });
   await delay(0);
   assert.equal(state.snapshot.matchingError, 'busy');
   assert.equal(addCalls[0][2], 'stake');
+});
+
+test('runPoolRoyaleOnlineFlow refunds if register ack fails', async () => {
+  class RejectRegisterSocket extends MockSocket {
+    emit(event, payload, cb) {
+      if (event === 'register') {
+        this.registerRequests.push(payload);
+        if (typeof cb === 'function') cb({ success: false, error: 'register_failed' });
+        return true;
+      }
+      return super.emit(event, payload, cb);
+    }
+  }
+
+  const mockSocket = new RejectRegisterSocket();
+  const refs = createRefs();
+  const state = createState();
+  const addCalls = [];
+
+  const deps = {
+    ensureAccountId: () => Promise.resolve('acct-12'),
+    getAccountBalance: () => Promise.resolve({ balance: 200 }),
+    addTransaction: (...args) => {
+      addCalls.push(args);
+      return Promise.resolve();
+    },
+    getTelegramId: () => 'tg-12',
+    getTelegramFirstName: () => 'Elena',
+    socket: mockSocket
+  };
+
+  await runPoolRoyaleOnlineFlow({
+    stake: { token: 'TPC', amount: 100 },
+    variant: 'uk',
+    ballSet: 'uk',
+    playType: 'regular',
+    mode: 'online',
+    tableSize: 'medium',
+    avatar: 'me.png',
+    deps,
+    state,
+    refs,
+    timeouts: { seat: 50, matchmaking: 100, register: 40 }
+  });
+
+  assert.equal(mockSocket.registerRequests.length, 1);
+  assert.equal(mockSocket.seatRequests.length, 0);
+  assert.equal(addCalls.length, 2, 'should debit then refund when register ack fails');
+  assert.equal(addCalls[1][2], 'stake_refund');
+  assert.ok(state.snapshot.matchingError.includes('online session'));
 });

--- a/webapp/src/pages/Games/poolRoyaleOnlineFlow.js
+++ b/webapp/src/pages/Games/poolRoyaleOnlineFlow.js
@@ -4,7 +4,8 @@ import { socket } from '../../utils/socket.js';
 
 const DEFAULT_SEAT_TIMEOUT_MS = 12000;
 const DEFAULT_MATCH_TIMEOUT_MS = 30000;
-const DEFAULT_SOCKET_CONNECT_TIMEOUT_MS = 8000;
+const DEFAULT_SOCKET_CONNECT_TIMEOUT_MS = 15000;
+const DEFAULT_REGISTER_TIMEOUT_MS = 6000;
 
 function logSupportError(message, error, context = {}) {
   // Surface in console for support teams; caller will also show inline errors.
@@ -61,6 +62,36 @@ async function ensureSocketReady(socketInstance, timeoutMs = DEFAULT_SOCKET_CONN
   });
 }
 
+async function ensureSocketRegistered(
+  socketInstance,
+  accountId,
+  timeoutMs = DEFAULT_REGISTER_TIMEOUT_MS
+) {
+  if (!socketInstance || !accountId) return false;
+
+  return await new Promise((resolve) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      resolve(false);
+    }, timeoutMs);
+
+    try {
+      socketInstance.emit('register', { playerId: accountId }, (res) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve(!!res?.success);
+      });
+    } catch (error) {
+      clearTimeout(timer);
+      logSupportError('Socket register emit failed', error, { accountId });
+      resolve(false);
+    }
+  });
+}
+
 export async function runPoolRoyaleOnlineFlow({
   stake,
   tableId,
@@ -107,6 +138,7 @@ export async function runPoolRoyaleOnlineFlow({
   const seatTimeoutMs = timeouts.seat ?? DEFAULT_SEAT_TIMEOUT_MS;
   const matchmakingTimeoutMs = timeouts.matchmaking ?? DEFAULT_MATCH_TIMEOUT_MS;
   const socketConnectTimeoutMs = timeouts.socketConnect ?? DEFAULT_SOCKET_CONNECT_TIMEOUT_MS;
+  const registerTimeoutMs = timeouts.register ?? DEFAULT_REGISTER_TIMEOUT_MS;
   const requestedTableId =
     typeof tableId === 'string' && tableId.trim()
       ? tableId.trim()
@@ -202,6 +234,20 @@ export async function runPoolRoyaleOnlineFlow({
     return { success: false };
   }
 
+  const socketRegistered = await ensureSocketRegistered(
+    socketInstance,
+    accountId,
+    registerTimeoutMs
+  );
+  if (!socketRegistered) {
+    setMatchStatus('');
+    setMatchingError('Unable to sync your online session. We refunded your stake.');
+    await refundStake('socket_register_ack_failed', { accountId });
+    setMatching(false);
+    setIsSearching(false);
+    return { success: false };
+  }
+
   function handleLobbyUpdate({ tableId: tid, players: list = [], ready = [] } = {}) {
     if (!tid || tid !== pendingTableRef.current) return;
     setMatchPlayers(list);
@@ -271,7 +317,6 @@ export async function runPoolRoyaleOnlineFlow({
 
   socketInstance.on('lobbyUpdate', handleLobbyUpdate);
   socketInstance.on('gameStart', handleGameStart);
-  socketInstance.emit('register', { playerId: accountId });
 
   function startMatchTimeout(tableId) {
     clearTimeoutSafely(matchTimeoutRef);
@@ -283,47 +328,62 @@ export async function runPoolRoyaleOnlineFlow({
     }, matchmakingTimeoutMs);
   }
 
-  socketInstance.emit(
-    'seatTable',
-    {
-      accountId,
-      stake: stake.amount,
-      token: stake.token,
-      gameType: 'poolroyale',
-      maxPlayers: 2,
-      tableId: requestedTableId,
-      mode,
-      variant,
-      ballSet,
-      tableSize,
-      playType,
-      playerName: getTelegramFirstNameFn?.() || `TPC ${accountId}` || 'Player',
-      avatar
-    },
-    (res) => {
-      clearTimeoutSafely(seatTimeoutRef);
-      setIsSearching(false);
-      if (!res?.success || !res.tableId) {
-        triggerTimeoutRefund(
-          'seat_table_failed',
-          res?.message || 'Failed to join the online arena. Please retry.',
-          { response: res, accountId }
-        );
-        return;
-      }
-      pendingTableRef.current = res.tableId;
-      setMatchStatus('Waiting for another player…');
-      const playersList = res.players || [];
-      setMatchPlayers(playersList);
-      matchPlayersRef.current = playersList;
-      setReadyList(res.ready || []);
-      socketInstance.emit('confirmReady', {
+  let seatAttempts = 0;
+  const maxSeatAttempts = 2;
+  const seatPlayer = () => {
+    seatAttempts += 1;
+    socketInstance.emit(
+      'seatTable',
+      {
         accountId,
-        tableId: res.tableId
-      });
-      startMatchTimeout(res.tableId);
-    }
-  );
+        stake: stake.amount,
+        token: stake.token,
+        gameType: 'poolroyale',
+        maxPlayers: 2,
+        tableId: requestedTableId,
+        mode,
+        variant,
+        ballSet,
+        tableSize,
+        playType,
+        playerName: getTelegramFirstNameFn?.() || `TPC ${accountId}` || 'Player',
+        avatar
+      },
+      (res) => {
+        clearTimeoutSafely(seatTimeoutRef);
+        setIsSearching(false);
+        if (!res?.success || !res.tableId) {
+          const shouldRetry = (res?.error === 'register_required' || res?.error === 'rate_limited') && seatAttempts < maxSeatAttempts;
+          if (shouldRetry) {
+            setMatchStatus('Retrying online seat…');
+            seatTimeoutRef.current = setTimeout(() => {
+              seatPlayer();
+            }, 400);
+            return;
+          }
+          triggerTimeoutRefund(
+            'seat_table_failed',
+            res?.message || 'Failed to join the online arena. Please retry.',
+            { response: res, accountId, seatAttempts }
+          );
+          return;
+        }
+        pendingTableRef.current = res.tableId;
+        setMatchStatus('Waiting for another player…');
+        const playersList = res.players || [];
+        setMatchPlayers(playersList);
+        matchPlayersRef.current = playersList;
+        setReadyList(res.ready || []);
+        socketInstance.emit('confirmReady', {
+          accountId,
+          tableId: res.tableId
+        });
+        startMatchTimeout(res.tableId);
+      }
+    );
+  };
+
+  seatPlayer();
 
   return { success: true };
 }


### PR DESCRIPTION
### Motivation
- Fix race/timeout cases where clients assumed socket registration succeeded and received "Unable to reach the online arena" despite being online, especially on mobile networks. 
- Prevent unnecessary stake loss by ensuring the socket registration step is acknowledged before attempting to occupy a table. 
- Make short-lived backend errors (e.g. transient rate-limit or register-required) retryable to avoid immediate matchmaking failures.

### Description
- Added a callback-style register acknowledgement on the server `register` socket handler so clients receive `{ success: true }` or `{ success: false, error }` responses (file: `bot/server.js`).
- Introduced `ensureSocketRegistered` in `poolRoyaleOnlineFlow.js` and call it after `ensureSocketReady`, with a dedicated `register` timeout (`DEFAULT_REGISTER_TIMEOUT_MS`) and a clear refund path when registration ack fails.
- Increased the socket connect wait window from `8000ms` to `15000ms` to tolerate mobile network jitter and added a targeted seat retry (one retry) for transient errors (`register_required` / `rate_limited`) before failing matchmaking.
- Implemented a short backoff/retry loop for `seatTable` emits and removed the previous blind `register` emit (client now performs explicit register+ack step); updated related state/cleanup/refund flows in `webapp/src/pages/Games/poolRoyaleOnlineFlow.js`.
- Added/updated unit tests in `test/poolRoyaleOnlineFlow.test.js` to assert `register` tracking and to cover the register-ack failure refund scenario.

### Testing
- Ran the modified Pool Royale online flow tests with `npm test -- test/poolRoyaleOnlineFlow.test.js --runInBand` and all tests passed.
- Test summary: 1 test suite executed, 5 tests passed (including new `register ack failure` refund test).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfa14cc9d4832993b43fa180d37b18)