### PR TITLE
Fix Pool Royale online lobby socket connection for API path prefixes

### DIFF
--- a/webapp/src/utils/socket.js
+++ b/webapp/src/utils/socket.js
@@ -3,7 +3,9 @@ import { API_BASE_URL } from './api.js';
 
 function normalizePath(path) {
   if (!path) return '/socket.io';
-  return path.startsWith('/') ? path : `/${path}`;
+  const trimmed = String(path).trim();
+  if (!trimmed) return '/socket.io';
+  return trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
 }
 
 function normalizeBaseUrl(rawUrl) {
@@ -63,13 +65,29 @@ function buildSocketAuthPayload() {
   };
 }
 
+function deriveSocketPathFromApiBase(rawUrl) {
+  if (!rawUrl) return '/socket.io';
+  const fallback = typeof window !== 'undefined' ? window.location.origin : 'http://localhost';
+
+  try {
+    const parsed = new URL(rawUrl, fallback);
+    const cleanPath = parsed.pathname.replace(/\/+$/, '');
+    if (!cleanPath || cleanPath === '/') return '/socket.io';
+    return `${cleanPath}/socket.io`;
+  } catch {
+    return '/socket.io';
+  }
+}
+
 function resolveSocketConfig() {
   const metaEnv = loadMetaEnv();
   const explicitUrl = metaEnv.VITE_SOCKET_URL;
   const explicitPath = metaEnv.VITE_SOCKET_PATH;
 
   const url = normalizeBaseUrl(explicitUrl || API_BASE_URL);
-  const path = normalizePath(explicitPath);
+  const path = explicitPath
+    ? normalizePath(explicitPath)
+    : normalizePath(deriveSocketPathFromApiBase(API_BASE_URL));
 
   const options = {
     path,


### PR DESCRIPTION
### Motivation
- Fix client failures to reach the online lobby in deployments where the API is served under a path prefix (e.g. `/api`), which caused the client to attempt the wrong Socket.IO endpoint and show "Unable to reach the online arena.".

### Description
- Updated `webapp/src/utils/socket.js` to derive the Socket.IO `path` from `API_BASE_URL` when `VITE_SOCKET_PATH` is not explicitly set, added `deriveSocketPathFromApiBase`, and hardened `normalizePath` to trim and ignore empty/whitespace values while preserving explicit `VITE_SOCKET_PATH` overrides.

### Testing
- Ran `npm test -- test/poolRoyaleOnlineFlow.test.js --runInBand` and the test file passed (5 tests, suite succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfb41f574c8329b59e56026f8031ff)