### PR TITLE
Ensure socket.auth has accountId before Pool Royale matchmaking

### DIFF
--- a/webapp/src/pages/Games/poolRoyaleOnlineFlow.js
+++ b/webapp/src/pages/Games/poolRoyaleOnlineFlow.js
@@ -62,6 +62,22 @@ async function ensureSocketReady(socketInstance, timeoutMs = DEFAULT_SOCKET_CONN
   });
 }
 
+function setSocketIdentity(socketInstance, accountId) {
+  if (!socketInstance || !accountId) return;
+  try {
+    const existingAuth =
+      socketInstance.auth && typeof socketInstance.auth === 'object'
+        ? socketInstance.auth
+        : {};
+    socketInstance.auth = {
+      ...existingAuth,
+      accountId: String(accountId)
+    };
+  } catch (error) {
+    logSupportError('Socket identity setup failed', error, { accountId });
+  }
+}
+
 async function ensureSocketRegistered(
   socketInstance,
   accountId,
@@ -207,6 +223,10 @@ export async function runPoolRoyaleOnlineFlow({
     logSupportError('getAccountBalance failed', error, { accountId });
     return { success: false };
   }
+
+  // Some mobile sessions can initialize socket auth before accountId is available.
+  // Ensure the current accountId is attached to the next handshake attempt.
+  setSocketIdentity(socketInstance, accountId);
 
   try {
     await addTransactionFn(telegramId, -stake.amount, 'stake', {


### PR DESCRIPTION
### Motivation
- Mobile sessions sometimes initialize the Socket.IO client before the account identity is resolved, which can cause handshake/register failures and unnecessary stake refunds during Pool Royale matchmaking. 
- The change ensures the socket carries the resolved `accountId` before connect/register steps so matchmaking is more reliable and refunds are avoided.

### Description
- Added a `setSocketIdentity` helper that populates `socket.auth.accountId` safely in `webapp/src/pages/Games/poolRoyaleOnlineFlow.js`.
- Called `setSocketIdentity(socketInstance, accountId)` immediately after balance/account validation and before the socket connect/register sequence. 
- Kept existing retry/timeout and refund logic intact so behavior is unchanged except for stronger socket identity handling.

### Testing
- Ran the unit test file `test/poolRoyaleOnlineFlow.test.js` with `npm test -- --runInBand test/poolRoyaleOnlineFlow.test.js`.
- Test results: test suite passed (1 suite, 5 tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfb41f574c8329b59e56026f8031ff)