### PR TITLE
Fix Pool Royale online lobby Socket.IO endpoint resolution

### DIFF
--- a/webapp/src/utils/socket.js
+++ b/webapp/src/utils/socket.js
@@ -73,7 +73,13 @@ function deriveSocketPathFromApiBase(rawUrl) {
     const parsed = new URL(rawUrl, fallback);
     const cleanPath = parsed.pathname.replace(/\/+$/, '');
     if (!cleanPath || cleanPath === '/') return '/socket.io';
-    return `${cleanPath}/socket.io`;
+
+    // Most deployments expose REST APIs under `/api` but keep Socket.IO on the
+    // default `/socket.io` endpoint. If we blindly append to `/api`, clients
+    // attempt `/api/socket.io` and fail to connect.
+    const baseWithoutApiSuffix = cleanPath.replace(/\/api(?:\/v\d+)?$/i, '');
+    if (!baseWithoutApiSuffix || baseWithoutApiSuffix === '/') return '/socket.io';
+    return `${baseWithoutApiSuffix}/socket.io`;
   } catch {
     return '/socket.io';
   }


### PR DESCRIPTION
### Motivation
- Connecting to the online Pool Royale lobby failed when the app was built with an API base that included an `/api` suffix, because the client derived `/api/socket.io` (which the server does not expose), leading to “Unable to reach the online arena” errors and automatic stake refunds.

### Description
- Modify `deriveSocketPathFromApiBase()` in `webapp/src/utils/socket.js` to strip trailing `/api` or `/api/vN` from the API pathname before appending `/socket.io`, ensuring the client resolves to `/socket.io` (or `<base>/socket.io`) instead of `/api/socket.io`.
- Preserve explicit socket configuration via `VITE_SOCKET_URL` and `VITE_SOCKET_PATH` and keep existing `io` options/auth behavior unchanged.

### Testing
- Ran `npm run -s build` and the build completed successfully.
- Ran `./node_modules/.bin/eslint --no-warn-ignored webapp/src/utils/socket.js` and there were no reported issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfb96a20f88329bec1a30b66d6fd8a)