### PR TITLE
Restore TON balance under TonConnect button and improve wallet address sync

### DIFF
--- a/webapp/src/hooks/useTokenBalances.js
+++ b/webapp/src/hooks/useTokenBalances.js
@@ -4,6 +4,14 @@ import { getTelegramId } from '../utils/telegram.js';
 import { useTonAddress } from '@tonconnect/ui-react';
 import { loadGoogleProfile } from '../utils/google.js';
 
+const getStoredWalletAddress = () => {
+  try {
+    return localStorage.getItem('walletAddress') || '';
+  } catch {
+    return '';
+  }
+};
+
 export default function useTokenBalances() {
   let telegramId;
   try {
@@ -17,7 +25,35 @@ export default function useTokenBalances() {
   const [tonBalance, setTonBalance] = useState(null);
   const [tpcWalletBalance, setTpcWalletBalance] = useState(null);
 
-  const walletAddress = useTonAddress(true);
+  const tonAddress = useTonAddress(true);
+  const [walletAddress, setWalletAddress] = useState(() => tonAddress || getStoredWalletAddress());
+
+  useEffect(() => {
+    setWalletAddress(tonAddress || getStoredWalletAddress());
+  }, [tonAddress]);
+
+  useEffect(() => {
+    const syncFromStorage = () => {
+      setWalletAddress(tonAddress || getStoredWalletAddress());
+    };
+
+    const handleWalletAddressUpdated = (event) => {
+      const nextAddress = event?.detail?.address || '';
+      setWalletAddress(nextAddress || tonAddress || getStoredWalletAddress());
+    };
+
+    window.addEventListener('storage', syncFromStorage);
+    window.addEventListener('focus', syncFromStorage);
+    window.addEventListener('pageshow', syncFromStorage);
+    window.addEventListener('walletAddressUpdated', handleWalletAddressUpdated);
+
+    return () => {
+      window.removeEventListener('storage', syncFromStorage);
+      window.removeEventListener('focus', syncFromStorage);
+      window.removeEventListener('pageshow', syncFromStorage);
+      window.removeEventListener('walletAddressUpdated', handleWalletAddressUpdated);
+    };
+  }, [tonAddress]);
 
   useEffect(() => {
     async function loadTpc() {

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -166,6 +166,11 @@ export default function Home() {
         )}
 
         <TonConnectButton />
+        {walletAddress && (
+          <div className="mt-2 rounded-lg border border-border bg-background/60 px-3 py-2 text-sm text-white">
+            TON Balance: {formatValue(tonBalance ?? '...', 4)}
+          </div>
+        )}
         <div className="w-full rounded-xl border border-border bg-surface/60 p-3 mb-2 space-y-2">
           <p className="text-xs text-subtext">
             1 TPC account • connect only what is still missing.


### PR DESCRIPTION
### Motivation
- Restore the previous UI behavior where a connected user's TON balance is visible immediately under the main TonConnect button on the Home page. 
- Make balance fetching more resilient to async TonConnect session restores and cross-tab updates by sourcing the wallet address from both TonConnect state and persisted storage. 
- Ensure balances refresh reliably when users return from external wallet apps or when storage/visibility changes occur. 

### Description
- Added `getStoredWalletAddress()` helper and introduced a `walletAddress` state in `useTokenBalances` that initializes from `useTonAddress(true)` or `localStorage`. 
- Added effect hooks in `useTokenBalances` to sync `walletAddress` on changes to TonConnect state and to listen for `storage`, `focus`, `pageshow`, and custom `walletAddressUpdated` events. 
- Kept external balance loading (`getTonBalance` and jetton fetch) tied to the unified `walletAddress` so fetched balances follow the refreshed address. 
- Restored a small UI block in `webapp/src/pages/Home.jsx` that displays `TON Balance: {formatValue(tonBalance)}` directly under the `TonConnectButton`. 

### Testing
- Ran the production build with `cd webapp && npm run build`, which completed successfully (Vite emitted non-blocking chunk-size/dynamic-import warnings but the build passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfc81e28748329917f029d792a45cf)