### PR TITLE
Show TON balance below TON Connect button

### DIFF
--- a/frontend/src/wallets/ton/TonLink.tsx
+++ b/frontend/src/wallets/ton/TonLink.tsx
@@ -1,9 +1,45 @@
+import { useEffect, useState } from 'react';
 import { useTonAddress, useTonConnectUI } from '@tonconnect/ui-react';
 import { api } from '../../lib/api';
+import { getWalletBalance } from '../balance/getWalletBalance';
+
+type TonBalanceState = {
+  loading: boolean;
+  value?: string;
+  error?: string;
+};
 
 export function TonLink({ onDone }: { onDone: () => Promise<void> }) {
   const [tonConnectUI] = useTonConnectUI();
   const address = useTonAddress();
+  const [balance, setBalance] = useState<TonBalanceState>({ loading: false });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadBalance = async () => {
+      if (!address) {
+        setBalance({ loading: false });
+        return;
+      }
+
+      setBalance({ loading: true });
+      try {
+        const current = await getWalletBalance({ chain: 'ton', address });
+        if (cancelled) return;
+        setBalance({ loading: false, value: `${current.formatted} ${current.symbol}` });
+      } catch {
+        if (cancelled) return;
+        setBalance({ loading: false, error: 'Balance unavailable' });
+      }
+    };
+
+    void loadBalance();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [address]);
 
   const link = async () => {
     const { nonce, tonProofPayload } = await api<{ nonce: string; tonProofPayload: string }>('/api/wallets/link/nonce?chain=ton');
@@ -37,5 +73,14 @@ export function TonLink({ onDone }: { onDone: () => Promise<void> }) {
     await onDone();
   };
 
-  return <button onClick={() => link().catch((e) => alert(e.message))}>{address ? 'Submit TON proof & Link' : 'Connect TON Wallet'}</button>;
+  return (
+    <div>
+      <button onClick={() => link().catch((e) => alert(e.message))}>{address ? 'Submit TON proof & Link' : 'Connect TON Wallet'}</button>
+      <div style={{ color: '#555', marginTop: 6 }}>
+        {address && balance.loading && 'Balance: loading...'}
+        {address && !balance.loading && balance.value && `Balance: ${balance.value}`}
+        {address && !balance.loading && balance.error && `Balance: ${balance.error}`}
+      </div>
+    </div>
+  );
 }


### PR DESCRIPTION
### Motivation
- Restore the previous UX where the connected TON wallet balance is visible on the TON connect/link view so users see their balance directly under the connect button.

### Description
- Added local state and a `TonBalanceState` type and imported `useEffect`/`useState` in `frontend/src/wallets/ton/TonLink.tsx` to hold loading/value/error for the balance.
- Integrated `getWalletBalance` and added an effect to fetch the TON balance whenever `useTonAddress()` returns an address, handling cancellation and errors.
- Rendered the balance UI under the TON connect/link button with `loading...`, resolved value, and `Balance unavailable` error states.
- No backend/API contract changes were required; the change is UI-only in `TonLink`.

### Testing
- Ran a production frontend build with `npm --prefix frontend run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfc81e28748329917f029d792a45cf)