### PR TITLE
Fix Pool Royale online identity handling for Google + Telegram players

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -181,26 +181,30 @@ io.use((socket, next) => {
     socket.handshake.auth?.googleId ||
     socket.handshake.headers?.['x-google-id'];
 
+  const resolvedAuth = {};
   if (initData) {
     const data = verifyTelegramInitData(initData);
     if (data) {
-      socket.data.auth = {
-        telegramId: data.user ? Number(JSON.parse(data.user).id) : undefined
-      };
-      return next();
+      resolvedAuth.telegramId = data.user ? Number(JSON.parse(data.user).id) : undefined;
     }
   }
 
   if (process.env.API_AUTH_TOKEN && token === process.env.API_AUTH_TOKEN) {
-    socket.data.auth = { apiToken: true };
+    socket.data.auth = { ...resolvedAuth, apiToken: true };
     return next();
   }
 
   if (accountId || googleId) {
     socket.data.auth = {
+      ...resolvedAuth,
       accountId: accountId ? String(accountId) : undefined,
       googleId: googleId ? String(googleId) : undefined
     };
+    return next();
+  }
+
+  if (Object.keys(resolvedAuth).length > 0) {
+    socket.data.auth = resolvedAuth;
     return next();
   }
 

--- a/webapp/src/pages/Games/poolRoyaleOnlineFlow.js
+++ b/webapp/src/pages/Games/poolRoyaleOnlineFlow.js
@@ -1,6 +1,6 @@
 import { ensureAccountId, getTelegramFirstName, getTelegramId } from '../../utils/telegram.js';
 import { getAccountBalance, addTransaction } from '../../utils/api.js';
-import { socket } from '../../utils/socket.js';
+import { socket, refreshSocketAuthIdentity } from '../../utils/socket.js';
 
 const DEFAULT_SEAT_TIMEOUT_MS = 12000;
 const DEFAULT_MATCH_TIMEOUT_MS = 30000;
@@ -65,6 +65,10 @@ async function ensureSocketReady(socketInstance, timeoutMs = DEFAULT_SOCKET_CONN
 function setSocketIdentity(socketInstance, accountId) {
   if (!socketInstance || !accountId) return;
   try {
+    if (socketInstance === socket) {
+      refreshSocketAuthIdentity({ accountId: String(accountId) });
+      return;
+    }
     const existingAuth =
       socketInstance.auth && typeof socketInstance.auth === 'object'
         ? socketInstance.auth

--- a/webapp/src/utils/socket.js
+++ b/webapp/src/utils/socket.js
@@ -51,7 +51,16 @@ function getStoredAccountId() {
 
 function getStoredGoogleId() {
   if (typeof window === 'undefined') return '';
-  return window?.localStorage?.getItem('googleId') || '';
+  const direct = window?.localStorage?.getItem('googleId') || '';
+  if (direct) return direct;
+  try {
+    const rawProfile = window?.localStorage?.getItem('googleProfile');
+    if (!rawProfile) return '';
+    const parsed = JSON.parse(rawProfile);
+    return parsed?.id ? String(parsed.id) : '';
+  } catch {
+    return '';
+  }
 }
 
 function buildSocketAuthPayload() {
@@ -63,6 +72,20 @@ function buildSocketAuthPayload() {
     ...(accountId ? { accountId } : {}),
     ...(googleId ? { googleId } : {})
   };
+}
+
+function isSameIdentity(currentAuth, nextAuth) {
+  const currentAccountId = String(currentAuth?.accountId || '');
+  const nextAccountId = String(nextAuth?.accountId || '');
+  const currentGoogleId = String(currentAuth?.googleId || '');
+  const nextGoogleId = String(nextAuth?.googleId || '');
+  const currentInit = String(currentAuth?.initData || '');
+  const nextInit = String(nextAuth?.initData || '');
+  return (
+    currentAccountId === nextAccountId &&
+    currentGoogleId === nextGoogleId &&
+    currentInit === nextInit
+  );
 }
 
 function deriveSocketPathFromApiBase(rawUrl) {
@@ -111,3 +134,19 @@ function resolveSocketConfig() {
 const { url, options } = resolveSocketConfig();
 
 export const socket = io(url, options);
+
+export function refreshSocketAuthIdentity(patch = {}, { reconnect = false } = {}) {
+  const base = buildSocketAuthPayload();
+  const nextAuth = {
+    ...base,
+    ...patch
+  };
+  if (!isSameIdentity(socket.auth, nextAuth)) {
+    socket.auth = nextAuth;
+    if (reconnect && socket.connected) {
+      socket.disconnect();
+      socket.connect();
+    }
+  }
+  return nextAuth;
+}


### PR DESCRIPTION
### Motivation
- Users signed in via Google (cached `googleProfile`) and Telegram initData could end up with mismatched/partial socket identity, causing failures to join/seat the same online table. The change aims to keep provider/account identity in sync across the web socket lifecycle so players (Google and Telegram) connect reliably.

### Description
- Make `getStoredGoogleId()` resilient to setups where only a cached `googleProfile` exists by parsing it as a fallback and returning `id` when present. (`webapp/src/utils/socket.js`)
- Add `refreshSocketAuthIdentity()` and `isSameIdentity()` to centralize socket auth payload construction and allow safe in-place refresh (optionally reconnect). (`webapp/src/utils/socket.js`)
- Update Pool Royale online flow to use `refreshSocketAuthIdentity()` when setting the main client socket identity, avoiding stale auth before `register`/`seatTable`. (`webapp/src/pages/Games/poolRoyaleOnlineFlow.js`) 
- Harden server socket auth middleware to merge Telegram initData-derived auth with account/google identities (instead of returning early), allowing cross-provider identities (Telegram + Google/accountId) to coexist for the same socket connection. (`bot/server.js`)

### Testing
- Ran the targeted unit tests with `npm test -- test/poolRoyaleOnlineFlow.test.js --runInBand` and all tests passed: 5 tests, 1 suite (`PASS`).
- Ran `npx eslint` on the changed files which produced only project ignore warnings and no lint errors for the modified logic. (files are ignored by project ESLint patterns so only warnings were emitted).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfc897a56c832998e8ada9e642d750)