### PR TITLE
Show connected TON balance under TonConnect on Home

### DIFF
--- a/webapp/src/hooks/useTokenBalances.js
+++ b/webapp/src/hooks/useTokenBalances.js
@@ -17,7 +17,15 @@ export default function useTokenBalances() {
   const [tonBalance, setTonBalance] = useState(null);
   const [tpcWalletBalance, setTpcWalletBalance] = useState(null);
 
-  const walletAddress = useTonAddress(true);
+  const connectedWalletAddress = useTonAddress(true);
+  const [storedWalletAddress, setStoredWalletAddress] = useState(() => {
+    try {
+      return localStorage.getItem('walletAddress') || '';
+    } catch {
+      return '';
+    }
+  });
+  const walletAddress = connectedWalletAddress || storedWalletAddress;
 
   useEffect(() => {
     async function loadTpc() {
@@ -49,6 +57,28 @@ export default function useTokenBalances() {
       window.removeEventListener('storage', refresh);
     };
   }, [telegramId]);
+
+  useEffect(() => {
+    const syncStoredWallet = () => {
+      try {
+        setStoredWalletAddress(localStorage.getItem('walletAddress') || '');
+      } catch {
+        setStoredWalletAddress('');
+      }
+    };
+
+    window.addEventListener('storage', syncStoredWallet);
+    window.addEventListener('walletAddressUpdated', syncStoredWallet);
+    window.addEventListener('focus', syncStoredWallet);
+    window.addEventListener('pageshow', syncStoredWallet);
+
+    return () => {
+      window.removeEventListener('storage', syncStoredWallet);
+      window.removeEventListener('walletAddressUpdated', syncStoredWallet);
+      window.removeEventListener('focus', syncStoredWallet);
+      window.removeEventListener('pageshow', syncStoredWallet);
+    };
+  }, []);
 
   useEffect(() => {
     async function loadExternal() {

--- a/webapp/src/pages/Home.jsx
+++ b/webapp/src/pages/Home.jsx
@@ -166,6 +166,14 @@ export default function Home() {
         )}
 
         <TonConnectButton />
+        {walletAddress && (
+          <div className="mt-2 text-center">
+            <p className="text-xs text-subtext">Connected TON balance</p>
+            <p className="text-lg font-semibold text-white">
+              {formatValue(tonBalance ?? '...', 4)} TON
+            </p>
+          </div>
+        )}
         <div className="w-full rounded-xl border border-border bg-surface/60 p-3 mb-2 space-y-2">
           <p className="text-xs text-subtext">
             1 TPC account • connect only what is still missing.


### PR DESCRIPTION
### Motivation
- Make the Home page show the connected TON wallet balance near the TonConnect UI so users see their on-chain TON immediately after connecting or when a session is restored.
- Ensure balance fetching works reliably after wallet session restore by reading `walletAddress` from `localStorage` in addition to the active TonConnect address.

### Description
- Display a compact TON balance block under the `TonConnectButton` on the Home page when a wallet address is present by updating `webapp/src/pages/Home.jsx` to render the connected TON value using `formatValue`.
- Improve wallet resolution in `webapp/src/hooks/useTokenBalances.js` to prefer the active TonConnect address from `useTonAddress(true)` but fall back to a `walletAddress` read from `localStorage` via a `storedWalletAddress` state value.
- Add sync listeners (`storage`, `walletAddressUpdated`, `focus`, `pageshow`) inside the hook so `storedWalletAddress` is refreshed when the wallet is updated outside the current render cycle, allowing balance fetches to trigger after session restore.

### Testing
- Ran a production build with `cd webapp && npm run build`, which completed successfully (build finished with warnings but without errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfc81e28748329917f029d792a45cf)