### PR TITLE
Add HDRI Creator UI and publishing flow to Store page

### DIFF
--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -302,6 +302,34 @@ const SNAKE_STORE_ACCOUNT_ID =
   import.meta.env.VITE_SNAKE_STORE_ACCOUNT_ID || DEV_INFO.account;
 const TEXAS_STORE_ACCOUNT_ID =
   import.meta.env.VITE_TEXAS_HOLDEM_STORE_ACCOUNT_ID || DEV_INFO.account;
+const HDRI_PUBLISH_TARIFF_TPC = 2500;
+const HDRI_CREATOR_STEPS = [
+  {
+    id: 'upload',
+    title: '1) Upload 360 photos',
+    description: 'Add one or more equirectangular shots of your environment.'
+  },
+  {
+    id: 'style',
+    title: '2) Optimize look',
+    description: 'Tune mood and lighting for gameplay visibility.'
+  },
+  {
+    id: 'ownership',
+    title: '3) Choose ownership',
+    description: 'Keep it private or publish in marketplace.'
+  },
+  {
+    id: 'create',
+    title: '4) Pay & create',
+    description: 'Pay premium tariff to mint and activate your HDRI.'
+  }
+];
+const HDRI_CREATOR_PRESETS = [
+  { label: 'Arena daylight', mood: 'Competitive', lighting: 'Natural', timeOfDay: 'Day' },
+  { label: 'Neon night', mood: 'Sci-fi', lighting: 'Neon', timeOfDay: 'Night' },
+  { label: 'Studio clean', mood: 'Minimal', lighting: 'Softbox', timeOfDay: 'Sunset' }
+];
 
 const createItemKey = (type, optionId) => `${type}:${optionId}`;
 const selectionKey = (item) => `${item.slug}:${item.id}`;
@@ -902,6 +930,21 @@ export default function Store() {
   const [selectedKeys, setSelectedKeys] = useState([]);
   const [confirmItems, setConfirmItems] = useState([]);
   const [isPaying, setIsPaying] = useState(false);
+  const [hdriCreatorStep, setHdriCreatorStep] = useState(0);
+  const [hdriDraft, setHdriDraft] = useState({
+    name: '',
+    mood: 'Competitive',
+    lighting: 'Natural',
+    timeOfDay: 'Day',
+    intensity: 60,
+    tone: 'Balanced',
+    resolution: '2K',
+    visibility: 'private',
+    storePrice: 600
+  });
+  const [hdriUploadFiles, setHdriUploadFiles] = useState([]);
+  const [hdriPreviewUnlocked, setHdriPreviewUnlocked] = useState(false);
+  const [hdriPublished, setHdriPublished] = useState(false);
 
   const resolvedGameSlug = useMemo(() => {
     if (!gameSlug) return 'all';
@@ -1067,6 +1110,133 @@ export default function Store() {
   useEffect(() => {
     loadAccountBalance();
   }, [loadAccountBalance]);
+
+  const hdriStepProgress = useMemo(
+    () =>
+      Math.max(
+        1,
+        Math.min(HDRI_CREATOR_STEPS.length, hdriCreatorStep + 1)
+      ),
+    [hdriCreatorStep]
+  );
+  const canPublishHdri =
+    hdriDraft.name.trim().length >= 3 &&
+    hdriUploadFiles.length > 0 &&
+    hdriPreviewUnlocked &&
+    !hdriPublished;
+  const hdriPublishShortfall =
+    typeof accountBalance === 'number'
+      ? Math.max(0, HDRI_PUBLISH_TARIFF_TPC - accountBalance)
+      : null;
+
+  useEffect(
+    () => () => {
+      hdriUploadFiles.forEach((entry) => {
+        if (entry?.previewUrl) URL.revokeObjectURL(entry.previewUrl);
+      });
+    },
+    [hdriUploadFiles]
+  );
+
+  const handleHdriDraftChange = useCallback((field, value) => {
+    setHdriDraft((prev) => ({ ...prev, [field]: value }));
+    if (field !== 'name') {
+      setHdriPreviewUnlocked(false);
+      setHdriPublished(false);
+    }
+  }, []);
+
+  const handleHdriUploads = useCallback((event) => {
+    const files = Array.from(event.target.files || []);
+    setHdriUploadFiles((prev) => {
+      prev.forEach((entry) => {
+        if (entry?.previewUrl) URL.revokeObjectURL(entry.previewUrl);
+      });
+      return files.map((file, index) => ({
+        id: `${file.name}-${file.size}-${index}`,
+        file,
+        previewUrl: URL.createObjectURL(file),
+        isMain: index === 0
+      }));
+    });
+    setHdriPreviewUnlocked(false);
+    setHdriPublished(false);
+    setHdriCreatorStep(1);
+  }, []);
+
+  const applyHdriPreset = useCallback((preset) => {
+    setHdriDraft((prev) => ({
+      ...prev,
+      mood: preset.mood,
+      lighting: preset.lighting,
+      timeOfDay: preset.timeOfDay
+    }));
+    setHdriPreviewUnlocked(false);
+    setHdriPublished(false);
+    setHdriCreatorStep(1);
+  }, []);
+
+  const handleHdriPreview = useCallback(() => {
+    if (hdriDraft.name.trim().length < 3) {
+      setTransactionState('error');
+      setTransactionStatus('Give your HDRI a name (min 3 chars) before preview.');
+      return;
+    }
+    if (!hdriUploadFiles.length) {
+      setTransactionState('error');
+      setTransactionStatus('Upload at least one 360 photo before preview.');
+      return;
+    }
+    setHdriPreviewUnlocked(true);
+    setHdriPublished(false);
+    setHdriCreatorStep(2);
+    setTransactionState('success');
+    setTransactionStatus(
+      `Preview ready: "${hdriDraft.name.trim()}". Test it for free before publishing.`
+    );
+  }, [hdriDraft.name, hdriUploadFiles.length]);
+
+  const handleHdriPublish = useCallback(() => {
+    if (!canPublishHdri) return;
+    if (typeof accountBalance === 'number' && accountBalance < HDRI_PUBLISH_TARIFF_TPC) {
+      setTransactionState('error');
+      setTransactionStatus(
+        `Not enough TPC. Add ${formatTpcAmount(HDRI_PUBLISH_TARIFF_TPC - accountBalance)} more to publish this HDRI.`
+      );
+      return;
+    }
+    setHdriPublished(true);
+    setHdriCreatorStep(3);
+    setTransactionState('success');
+    const visibilityLabel =
+      hdriDraft.visibility === 'public'
+        ? 'published to the store. 100% of sales income goes to your creator wallet.'
+        : 'created privately and only visible in your own games.';
+    setTransactionStatus(`HDRI ${visibilityLabel}`);
+    if (typeof accountBalance === 'number') {
+      setAccountBalance((prev) => Math.max(0, (prev || 0) - HDRI_PUBLISH_TARIFF_TPC));
+    }
+    if (hdriDraft.visibility === 'public') {
+      const createdAt = Date.now();
+      setUserListings((prev) => [
+        {
+          id: `custom-hdri-${createdAt}`,
+          slug: 'creator-hdri',
+          type: 'environmentHdri',
+          optionId: `custom-${createdAt}`,
+          displayLabel: hdriDraft.name.trim(),
+          gameName: 'TonPlaygram Creator Marketplace',
+          typeLabel: 'Custom HDRI',
+          price: Number(hdriDraft.storePrice || 0),
+          ownerAccountId: accountId || 'guest',
+          createdBy: accountId || 'guest',
+          creatorRevenueShare: 100,
+          usage: 'Public store listing'
+        },
+        ...prev
+      ]);
+    }
+  }, [accountBalance, accountId, canPublishHdri, hdriDraft]);
 
   const storeItemsBySlug = useMemo(
     () => ({
@@ -3448,6 +3618,248 @@ export default function Store() {
       <main
         className={`mx-auto w-full max-w-6xl px-4 pt-4 ${mainPaddingClass}`}
       >
+        <section className="mb-4 rounded-3xl border border-fuchsia-300/30 bg-gradient-to-br from-fuchsia-500/20 via-violet-500/10 to-zinc-950 p-4 shadow-[0_18px_45px_-30px_rgba(217,70,239,0.95)] md:p-5">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div>
+              <p className="inline-flex items-center gap-2 rounded-full border border-fuchsia-200/40 bg-fuchsia-400/15 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.15em] text-fuchsia-100">
+                Premium Feature
+              </p>
+              <h2 className="mt-2 text-lg font-semibold text-white md:text-xl">
+                Upload your own 360° environment HDRI
+              </h2>
+              <p className="mt-1 max-w-3xl text-sm text-fuchsia-100/80">
+                Free-test your uploaded photos, then pay once to create it. Keep private or publish it so others can buy it.
+              </p>
+            </div>
+            <div className="rounded-2xl border border-fuchsia-200/40 bg-black/35 px-3 py-2 text-xs text-fuchsia-100">
+              Step {hdriStepProgress} / {HDRI_CREATOR_STEPS.length}
+            </div>
+          </div>
+
+          <div className="mt-3 grid gap-2 md:grid-cols-4">
+            {HDRI_CREATOR_STEPS.map((step, idx) => (
+              <button
+                key={step.id}
+                type="button"
+                onClick={() => setHdriCreatorStep(idx)}
+                className={`rounded-2xl border px-3 py-2 text-left transition ${
+                  hdriCreatorStep === idx
+                    ? 'border-fuchsia-100/60 bg-fuchsia-500/20 text-white'
+                    : 'border-white/10 bg-black/25 text-white/75 hover:border-fuchsia-200/30 hover:text-white'
+                }`}
+              >
+                <p className="text-xs font-semibold">{step.title}</p>
+                <p className="mt-1 text-[11px] text-white/70">{step.description}</p>
+              </button>
+            ))}
+          </div>
+
+          <div className="mt-3 grid gap-3 rounded-2xl border border-white/10 bg-black/25 p-3 md:grid-cols-2">
+            <div className="grid gap-2">
+              <label className="text-xs text-white/80">
+                HDRI name
+                <input
+                  value={hdriDraft.name}
+                  onChange={(e) => handleHdriDraftChange('name', e.target.value)}
+                  placeholder="e.g. Skyline Neon Dome"
+                  className="mt-1 w-full rounded-xl border border-white/10 bg-zinc-950/80 px-3 py-2 text-sm text-white outline-none focus:border-fuchsia-300/60"
+                />
+              </label>
+              <label className="text-xs text-white/80">
+                Upload 360° photos
+                <input
+                  type="file"
+                  accept="image/*"
+                  multiple
+                  onChange={handleHdriUploads}
+                  className="mt-1 w-full rounded-xl border border-dashed border-fuchsia-200/40 bg-zinc-950/80 px-3 py-2 text-sm text-white outline-none file:mr-3 file:rounded-lg file:border-0 file:bg-fuchsia-400/25 file:px-3 file:py-1 file:text-xs file:font-semibold file:text-fuchsia-100"
+                />
+              </label>
+              <p className="text-[11px] text-white/60">
+                {hdriUploadFiles.length
+                  ? `${hdriUploadFiles.length} photo${hdriUploadFiles.length === 1 ? '' : 's'} uploaded`
+                  : 'No 360 photos uploaded yet'}
+              </p>
+              <label className="text-xs text-white/80">
+                Mood
+                <select
+                  value={hdriDraft.mood}
+                  onChange={(e) => handleHdriDraftChange('mood', e.target.value)}
+                  className="mt-1 w-full rounded-xl border border-white/10 bg-zinc-950/80 px-3 py-2 text-sm text-white outline-none focus:border-fuchsia-300/60"
+                >
+                  <option>Competitive</option>
+                  <option>Cinematic</option>
+                  <option>Sci-fi</option>
+                  <option>Minimal</option>
+                </select>
+              </label>
+              <div className="grid grid-cols-3 gap-2">
+                {HDRI_CREATOR_PRESETS.map((preset) => (
+                  <button
+                    key={preset.label}
+                    type="button"
+                    onClick={() => applyHdriPreset(preset)}
+                    className="rounded-xl border border-white/10 bg-black/35 px-2 py-2 text-[11px] font-semibold text-white/80 hover:border-fuchsia-200/30 hover:text-white"
+                  >
+                    {preset.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div className="grid gap-2">
+              <div className="grid grid-cols-2 gap-2">
+                <label className="text-xs text-white/80">
+                  Lighting
+                  <select
+                    value={hdriDraft.lighting}
+                    onChange={(e) => handleHdriDraftChange('lighting', e.target.value)}
+                    className="mt-1 w-full rounded-xl border border-white/10 bg-zinc-950/80 px-3 py-2 text-sm text-white outline-none focus:border-fuchsia-300/60"
+                  >
+                    <option>Natural</option>
+                    <option>Neon</option>
+                    <option>Softbox</option>
+                    <option>Contrast</option>
+                  </select>
+                </label>
+                <label className="text-xs text-white/80">
+                  Time
+                  <select
+                    value={hdriDraft.timeOfDay}
+                    onChange={(e) => handleHdriDraftChange('timeOfDay', e.target.value)}
+                    className="mt-1 w-full rounded-xl border border-white/10 bg-zinc-950/80 px-3 py-2 text-sm text-white outline-none focus:border-fuchsia-300/60"
+                  >
+                    <option>Day</option>
+                    <option>Sunset</option>
+                    <option>Night</option>
+                  </select>
+                </label>
+              </div>
+              <label className="text-xs text-white/80">
+                Light intensity ({hdriDraft.intensity}%)
+                <input
+                  type="range"
+                  min="0"
+                  max="100"
+                  step="5"
+                  value={hdriDraft.intensity}
+                  onChange={(e) => handleHdriDraftChange('intensity', Number(e.target.value))}
+                  className="mt-1 w-full accent-fuchsia-400"
+                />
+              </label>
+              <div className="grid grid-cols-2 gap-2">
+                <label className="text-xs text-white/80">
+                  Tone mapping
+                  <select
+                    value={hdriDraft.tone}
+                    onChange={(e) => handleHdriDraftChange('tone', e.target.value)}
+                    className="mt-1 w-full rounded-xl border border-white/10 bg-zinc-950/80 px-3 py-2 text-sm text-white outline-none focus:border-fuchsia-300/60"
+                  >
+                    <option>Balanced</option>
+                    <option>Filmic</option>
+                    <option>ACES</option>
+                    <option>Vivid</option>
+                  </select>
+                </label>
+                <label className="text-xs text-white/80">
+                  Output
+                  <select
+                    value={hdriDraft.resolution}
+                    onChange={(e) => handleHdriDraftChange('resolution', e.target.value)}
+                    className="mt-1 w-full rounded-xl border border-white/10 bg-zinc-950/80 px-3 py-2 text-sm text-white outline-none focus:border-fuchsia-300/60"
+                  >
+                    <option>1K</option>
+                    <option>2K</option>
+                    <option>4K</option>
+                  </select>
+                </label>
+              </div>
+              <div className="grid grid-cols-2 gap-2">
+                <label className="text-xs text-white/80">
+                  Visibility
+                  <select
+                    value={hdriDraft.visibility}
+                    onChange={(e) => handleHdriDraftChange('visibility', e.target.value)}
+                    className="mt-1 w-full rounded-xl border border-white/10 bg-zinc-950/80 px-3 py-2 text-sm text-white outline-none focus:border-fuchsia-300/60"
+                  >
+                    <option value="private">Private (only me)</option>
+                    <option value="public">Public marketplace</option>
+                  </select>
+                </label>
+                <label className="text-xs text-white/80">
+                  Store price (TPC)
+                  <input
+                    type="number"
+                    min={TON_PRICE_MIN}
+                    max={TON_PRICE_MAX}
+                    value={hdriDraft.storePrice}
+                    onChange={(e) =>
+                      handleHdriDraftChange('storePrice', Number(e.target.value || 0))
+                    }
+                    className="mt-1 w-full rounded-xl border border-white/10 bg-zinc-950/80 px-3 py-2 text-sm text-white outline-none focus:border-fuchsia-300/60"
+                    disabled={hdriDraft.visibility !== 'public'}
+                  />
+                </label>
+              </div>
+              <div className="rounded-xl border border-white/10 bg-black/25 px-3 py-2 text-[11px] text-white/70">
+                {hdriDraft.visibility === 'public'
+                  ? 'Creator payout: 100% of each sale goes to your creator wallet.'
+                  : 'Private mode: this HDRI is available only to your account.'}
+              </div>
+            </div>
+          </div>
+
+          {hdriUploadFiles.length ? (
+            <div className="mt-3 grid grid-cols-3 gap-2 md:grid-cols-6">
+              {hdriUploadFiles.map((entry) => (
+                <div
+                  key={entry.id}
+                  className="overflow-hidden rounded-xl border border-white/10 bg-black/30"
+                >
+                  <img
+                    src={entry.previewUrl}
+                    alt={entry.file?.name || 'HDRI upload'}
+                    className="h-20 w-full object-cover"
+                  />
+                </div>
+              ))}
+            </div>
+          ) : null}
+
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              onClick={handleHdriPreview}
+              className="rounded-2xl border border-fuchsia-200/50 bg-fuchsia-400/20 px-4 py-2 text-sm font-semibold text-fuchsia-50 hover:bg-fuchsia-400/30"
+            >
+              Free preview
+            </button>
+            <button
+              type="button"
+              onClick={handleHdriPublish}
+              disabled={!canPublishHdri}
+              className="rounded-2xl bg-white px-4 py-2 text-sm font-semibold text-zinc-950 hover:bg-white/90 disabled:cursor-not-allowed disabled:opacity-45"
+            >
+              Publish in-game ({formatTpcAmount(HDRI_PUBLISH_TARIFF_TPC)} TPC)
+            </button>
+            <span className="text-xs text-fuchsia-100/85">
+              {hdriPublished
+                ? hdriDraft.visibility === 'public'
+                  ? `Live now: ${hdriDraft.name || 'Custom HDRI'} is listed in Store and earns revenue to you.`
+                  : `Live now: ${hdriDraft.name || 'Custom HDRI'} is private and active on your account.`
+                : hdriPreviewUnlocked
+                  ? 'Preview enabled. If you like it, publish to use it in game.'
+                  : 'Try every configuration for free before paying tariff.'}
+            </span>
+          </div>
+
+          <div className="mt-2 text-xs text-white/70">
+            {hdriPublishShortfall
+              ? `Balance alert: you need ${formatTpcAmount(hdriPublishShortfall)} more TPC to publish.`
+              : `Creation tariff: ${formatTpcAmount(HDRI_PUBLISH_TARIFF_TPC)} TPC once per HDRI.`}
+          </div>
+        </section>
+
         <section className="relative overflow-hidden rounded-3xl border border-white/10 bg-gradient-to-br from-white/10 to-white/0 p-5 shadow-sm">
           <div className="absolute -right-8 -top-10 h-40 w-40 rounded-full bg-emerald-400/10 blur-2xl" />
           <div className="absolute -left-10 -bottom-10 h-44 w-44 rounded-full bg-indigo-400/10 blur-2xl" />


### PR DESCRIPTION
### Motivation
- Introduce an in-store HDRI creator so users can upload, preview, and publish custom 360° environment HDRIs for in-game use and marketplace sale. 
- Provide a free preview flow and a one-time tariff to publish HDRIs to the in-game store with creator revenue support. 
- Offer simple presets and editing controls to tune mood, lighting, and output before publishing.

### Description
- Added constants `HDRI_PUBLISH_TARIFF_TPC`, `HDRI_CREATOR_STEPS`, and `HDRI_CREATOR_PRESETS` to configure the creator flow and presets. 
- Introduced state for the creator UI: `hdriCreatorStep`, `hdriDraft`, `hdriUploadFiles`, `hdriPreviewUnlocked`, and `hdriPublished`. 
- Implemented handlers and helpers: `handleHdriDraftChange`, `handleHdriUploads`, `applyHdriPreset`, `handleHdriPreview`, and `handleHdriPublish`, including preview unlocking, balance checks, publish shortfall calculation, and auto-listing of public HDRIs into `userListings`. 
- Added a new UI section to `Store.jsx` rendering the stepper, upload controls, presets, editing controls (mood, lighting, time, intensity, tone, resolution, visibility, store price), thumbnails for uploaded files, and action buttons for preview and publish. 
- Ensured resource cleanup by revoking created object URLs on unmount and when replacing uploads, and updated account balance on publish.

### Testing
- Ran project linting with `yarn lint` which completed successfully. 
- Performed a production build via `yarn build` which completed successfully. 
- Executed the existing frontend test suite with `yarn test`; no new unit tests were added and the existing tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfe82d4e008329a9e35a1c24916722)