### PR TITLE
Add multi-game custom HDRI publishing and surface custom HDRIs in game setup

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -101,6 +101,7 @@ import {
 } from '../../utils/poolRoyaleTrainingProgress.js';
 import { markCareerStageCompleted } from '../../utils/poolRoyaleCareerProgress.js';
 import { applyRendererSRGB, applySRGBColorSpace } from '../../utils/colorSpace.js';
+import { listCustomHdrisForGame } from '../../utils/customHdriCatalog.js';
 import {
   clampToUnitCircle,
   computeQuantizedOffsetScaled,
@@ -12679,11 +12680,24 @@ function PoolRoyaleGame({
     [poolInventory]
   );
   const availableEnvironmentHdris = useMemo(
-    () =>
-      POOL_ROYALE_HDRI_VARIANTS.filter((variant) =>
+    () => {
+      const unlockedDefault = POOL_ROYALE_HDRI_VARIANTS.filter((variant) =>
         isPoolOptionUnlocked('environmentHdri', variant.id, poolInventory)
-      ),
-    [poolInventory]
+      );
+      const customVariants = listCustomHdrisForGame({
+        accountId,
+        gameId: 'poolroyale'
+      }).map((entry) => ({
+        id: entry.id,
+        name: entry.name || 'Custom HDRI',
+        thumbnail: entry.thumbnail || '',
+        swatches: entry.swatches || ['#d946ef', '#111827'],
+        preferredResolutions: DEFAULT_HDRI_RESOLUTIONS,
+        fallbackResolution: DEFAULT_HDRI_RESOLUTIONS[0]
+      }));
+      return [...unlockedDefault, ...customVariants];
+    },
+    [accountId, poolInventory]
   );
   const availablePocketLiners = useMemo(
     () =>
@@ -12731,7 +12745,11 @@ function PoolRoyaleGame({
   }, [hdriResolutionId, responsiveTableSize]);
   const activeEnvironmentHdri = useMemo(
     () => {
+      const customVariant = availableEnvironmentHdris.find(
+        (variant) => variant.id === environmentHdriId
+      );
       const variant =
+        customVariant ??
         POOL_ROYALE_HDRI_VARIANT_MAP[environmentHdriId] ??
         POOL_ROYALE_HDRI_VARIANT_MAP[POOL_ROYALE_DEFAULT_HDRI_ID] ??
         POOL_ROYALE_HDRI_VARIANTS[0];
@@ -12752,7 +12770,7 @@ function PoolRoyaleGame({
         fallbackResolution: resolved
       };
     },
-    [environmentHdriId, resolvedHdriResolution]
+    [availableEnvironmentHdris, environmentHdriId, resolvedHdriResolution]
   );
   const dualTablesEnabled = useMemo(() => false, []);
   const activePocketLinerOption = useMemo(

--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -79,6 +79,7 @@ import {
   resolvePlayableTrainingLevel
 } from '../../utils/snookerRoyalTrainingProgress.js';
 import { applyRendererSRGB, applySRGBColorSpace } from '../../utils/colorSpace.js';
+import { listCustomHdrisForGame } from '../../utils/customHdriCatalog.js';
 import BottomLeftIcons from '../../components/BottomLeftIcons.jsx';
 import QuickMessagePopup from '../../components/QuickMessagePopup.jsx';
 import GiftPopup from '../../components/GiftPopup.jsx';
@@ -11676,11 +11677,24 @@ function SnookerRoyalGame({
     [snookerInventory]
   );
   const availableEnvironmentHdris = useMemo(
-    () =>
-      SNOOKER_ROYALE_HDRI_VARIANTS.filter((variant) =>
+    () => {
+      const unlockedDefault = SNOOKER_ROYALE_HDRI_VARIANTS.filter((variant) =>
         isSnookerOptionUnlocked('environmentHdri', variant.id, snookerInventory)
-      ),
-    [snookerInventory]
+      );
+      const customVariants = listCustomHdrisForGame({
+        accountId,
+        gameId: 'snookerroyale'
+      }).map((entry) => ({
+        id: entry.id,
+        name: entry.name || 'Custom HDRI',
+        thumbnail: entry.thumbnail || '',
+        swatches: entry.swatches || ['#d946ef', '#111827'],
+        preferredResolutions: DEFAULT_HDRI_RESOLUTIONS,
+        fallbackResolution: DEFAULT_HDRI_RESOLUTIONS[0]
+      }));
+      return [...unlockedDefault, ...customVariants];
+    },
+    [accountId, snookerInventory]
   );
   const availablePocketLiners = useMemo(
     () =>
@@ -11723,7 +11737,11 @@ function SnookerRoyalGame({
       : activeHdriResolutionOption.id;
   const activeEnvironmentHdri = useMemo(
     () => {
+      const customVariant = availableEnvironmentHdris.find(
+        (variant) => variant.id === environmentHdriId
+      );
       const variant =
+        customVariant ??
         SNOOKER_ROYALE_HDRI_VARIANT_MAP[environmentHdriId] ??
         SNOOKER_ROYALE_HDRI_VARIANT_MAP[SNOOKER_ROYALE_DEFAULT_HDRI_ID] ??
         SNOOKER_ROYALE_HDRI_VARIANTS[0];
@@ -11744,7 +11762,7 @@ function SnookerRoyalGame({
         fallbackResolution: resolved
       };
     },
-    [environmentHdriId, resolvedHdriResolution]
+    [availableEnvironmentHdris, environmentHdriId, resolvedHdriResolution]
   );
   const dualTablesEnabled = useMemo(
     () => environmentHdriId === 'musicHall02',

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -39,6 +39,10 @@ import {
   snookerRoyalAccountId
 } from '../utils/snookerRoyalInventory.js';
 import {
+  CUSTOM_HDRI_GAME_OPTIONS,
+  saveCustomHdri
+} from '../utils/customHdriCatalog.js';
+import {
   addAirHockeyUnlock,
   airHockeyAccountId,
   getAirHockeyInventory,
@@ -334,6 +338,13 @@ const HDRI_CREATOR_PRESETS = [
 const createItemKey = (type, optionId) => `${type}:${optionId}`;
 const selectionKey = (item) => `${item.slug}:${item.id}`;
 const formatTpcAmount = (value) => Number(value || 0).toLocaleString();
+const fileToDataUrl = (file) =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(typeof reader.result === 'string' ? reader.result : '');
+    reader.onerror = () => reject(reader.error || new Error('Failed to read file'));
+    reader.readAsDataURL(file);
+  });
 
 const resolveSwatches = (type, optionId, fallbackSwatches = []) => {
   if (OPTION_SWATCH_OVERRIDES[optionId])
@@ -940,7 +951,8 @@ export default function Store() {
     tone: 'Balanced',
     resolution: '2K',
     visibility: 'private',
-    storePrice: 600
+    storePrice: 600,
+    selectedGames: ['poolroyale']
   });
   const [hdriUploadFiles, setHdriUploadFiles] = useState([]);
   const [hdriPreviewUnlocked, setHdriPreviewUnlocked] = useState(false);
@@ -1122,11 +1134,13 @@ export default function Store() {
   const canPublishHdri =
     hdriDraft.name.trim().length >= 3 &&
     hdriUploadFiles.length > 0 &&
+    hdriDraft.selectedGames.length > 0 &&
     hdriPreviewUnlocked &&
     !hdriPublished;
+  const hdriPublishTariff = HDRI_PUBLISH_TARIFF_TPC * Math.max(1, hdriDraft.selectedGames.length || 0);
   const hdriPublishShortfall =
     typeof accountBalance === 'number'
-      ? Math.max(0, HDRI_PUBLISH_TARIFF_TPC - accountBalance)
+      ? Math.max(0, hdriPublishTariff - accountBalance)
       : null;
 
   useEffect(
@@ -1196,15 +1210,45 @@ export default function Store() {
     );
   }, [hdriDraft.name, hdriUploadFiles.length]);
 
-  const handleHdriPublish = useCallback(() => {
+  const handleHdriPublish = useCallback(async () => {
     if (!canPublishHdri) return;
-    if (typeof accountBalance === 'number' && accountBalance < HDRI_PUBLISH_TARIFF_TPC) {
+    if (typeof accountBalance === 'number' && accountBalance < hdriPublishTariff) {
       setTransactionState('error');
       setTransactionStatus(
-        `Not enough TPC. Add ${formatTpcAmount(HDRI_PUBLISH_TARIFF_TPC - accountBalance)} more to publish this HDRI.`
+        `Not enough TPC. Add ${formatTpcAmount(hdriPublishTariff - accountBalance)} more to publish this HDRI.`
       );
       return;
     }
+    const customId = `custom-hdri-${Date.now()}`;
+    let coverPhotoDataUrl = '';
+    try {
+      if (hdriUploadFiles[0]?.file) {
+        coverPhotoDataUrl = await fileToDataUrl(hdriUploadFiles[0].file);
+      }
+    } catch (error) {
+      console.warn('Failed to build HDRI thumbnail data URL', error);
+    }
+    saveCustomHdri({
+      id: customId,
+      ownerAccountId: accountId || 'guest',
+      name: hdriDraft.name.trim(),
+      thumbnail: coverPhotoDataUrl || hdriUploadFiles[0]?.previewUrl || '',
+      swatches: ['#d946ef', '#111827'],
+      selectedGames: hdriDraft.selectedGames,
+      createdAt: Date.now(),
+      visibility: hdriDraft.visibility
+    });
+    await Promise.all(
+      hdriDraft.selectedGames.map((gameId) => {
+        if (gameId === 'poolroyale') {
+          return addPoolRoyalUnlock('environmentHdri', customId, accountId);
+        }
+        if (gameId === 'snookerroyale') {
+          return addSnookerRoyalUnlock('environmentHdri', customId, accountId);
+        }
+        return Promise.resolve();
+      })
+    );
     setHdriPublished(true);
     setHdriCreatorStep(3);
     setTransactionState('success');
@@ -1214,29 +1258,29 @@ export default function Store() {
         : 'created privately and only visible in your own games.';
     setTransactionStatus(`HDRI ${visibilityLabel}`);
     if (typeof accountBalance === 'number') {
-      setAccountBalance((prev) => Math.max(0, (prev || 0) - HDRI_PUBLISH_TARIFF_TPC));
+      setAccountBalance((prev) => Math.max(0, (prev || 0) - hdriPublishTariff));
     }
     if (hdriDraft.visibility === 'public') {
-      const createdAt = Date.now();
-      setUserListings((prev) => [
-        {
-          id: `custom-hdri-${createdAt}`,
-          slug: 'creator-hdri',
+      setUserListings((prev) => {
+        const createdListings = hdriDraft.selectedGames.map((gameId) => ({
+          id: `${customId}-${gameId}`,
+          slug: gameId,
           type: 'environmentHdri',
-          optionId: `custom-${createdAt}`,
+          optionId: customId,
           displayLabel: hdriDraft.name.trim(),
-          gameName: 'TonPlaygram Creator Marketplace',
+          gameName: storeMeta[gameId]?.name || 'TonPlaygram Creator Marketplace',
           typeLabel: 'Custom HDRI',
           price: Number(hdriDraft.storePrice || 0),
           ownerAccountId: accountId || 'guest',
           createdBy: accountId || 'guest',
           creatorRevenueShare: 100,
-          usage: 'Public store listing'
-        },
-        ...prev
-      ]);
+          usage: `Public store listing • ${storeMeta[gameId]?.name || gameId}`,
+          thumbnail: coverPhotoDataUrl || hdriUploadFiles[0]?.previewUrl || ''
+        }));
+        return [...createdListings, ...prev];
+      });
     }
-  }, [accountBalance, accountId, canPublishHdri, hdriDraft]);
+  }, [accountBalance, accountId, canPublishHdri, hdriDraft, hdriPublishTariff, hdriUploadFiles]);
 
   const storeItemsBySlug = useMemo(
     () => ({
@@ -3680,6 +3724,35 @@ export default function Store() {
                   ? `${hdriUploadFiles.length} photo${hdriUploadFiles.length === 1 ? '' : 's'} uploaded`
                   : 'No 360 photos uploaded yet'}
               </p>
+              <div className="grid gap-1">
+                <p className="text-xs text-white/80">Games (multi-select, tariff per game)</p>
+                <div className="flex flex-wrap gap-2">
+                  {CUSTOM_HDRI_GAME_OPTIONS.map((game) => {
+                    const active = hdriDraft.selectedGames.includes(game.id);
+                    return (
+                      <button
+                        key={game.id}
+                        type="button"
+                        onClick={() =>
+                          handleHdriDraftChange(
+                            'selectedGames',
+                            active
+                              ? hdriDraft.selectedGames.filter((id) => id !== game.id)
+                              : [...hdriDraft.selectedGames, game.id]
+                          )
+                        }
+                        className={`rounded-xl border px-2.5 py-1.5 text-[11px] font-semibold transition ${
+                          active
+                            ? 'border-fuchsia-300/70 bg-fuchsia-500/30 text-white'
+                            : 'border-white/15 bg-black/35 text-white/75 hover:border-fuchsia-200/40 hover:text-white'
+                        }`}
+                      >
+                        {game.label}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
               <label className="text-xs text-white/80">
                 Mood
                 <select
@@ -3840,7 +3913,7 @@ export default function Store() {
               disabled={!canPublishHdri}
               className="rounded-2xl bg-white px-4 py-2 text-sm font-semibold text-zinc-950 hover:bg-white/90 disabled:cursor-not-allowed disabled:opacity-45"
             >
-              Publish in-game ({formatTpcAmount(HDRI_PUBLISH_TARIFF_TPC)} TPC)
+              Publish in-game ({formatTpcAmount(hdriPublishTariff)} TPC)
             </button>
             <span className="text-xs text-fuchsia-100/85">
               {hdriPublished
@@ -3856,7 +3929,7 @@ export default function Store() {
           <div className="mt-2 text-xs text-white/70">
             {hdriPublishShortfall
               ? `Balance alert: you need ${formatTpcAmount(hdriPublishShortfall)} more TPC to publish.`
-              : `Creation tariff: ${formatTpcAmount(HDRI_PUBLISH_TARIFF_TPC)} TPC once per HDRI.`}
+              : `Creation tariff: ${formatTpcAmount(HDRI_PUBLISH_TARIFF_TPC)} TPC × ${Math.max(1, hdriDraft.selectedGames.length || 0)} selected game(s).`}
           </div>
         </section>
 

--- a/webapp/src/utils/customHdriCatalog.js
+++ b/webapp/src/utils/customHdriCatalog.js
@@ -1,0 +1,48 @@
+const STORAGE_KEY = 'tonplaygramCustomHdriCatalogV1';
+
+export const CUSTOM_HDRI_GAME_OPTIONS = Object.freeze([
+  { id: 'poolroyale', label: 'Pool Royale' },
+  { id: 'snookerroyale', label: 'Snooker Royale' }
+]);
+
+const normalizeGames = (games = []) =>
+  Array.from(new Set((Array.isArray(games) ? games : []).filter(Boolean)));
+
+const readAll = () => {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    const parsed = raw ? JSON.parse(raw) : [];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (error) {
+    console.warn('Failed to read custom HDRI catalog', error);
+    return [];
+  }
+};
+
+const writeAll = (items) => {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+};
+
+export const listCustomHdrisForGame = ({ accountId, gameId }) => {
+  if (!accountId || !gameId) return [];
+  return readAll().filter(
+    (entry) =>
+      entry?.ownerAccountId === accountId &&
+      Array.isArray(entry?.selectedGames) &&
+      entry.selectedGames.includes(gameId)
+  );
+};
+
+export const saveCustomHdri = (entry) => {
+  if (!entry?.id || !entry?.ownerAccountId) return null;
+  const normalized = {
+    ...entry,
+    selectedGames: normalizeGames(entry.selectedGames)
+  };
+  const all = readAll().filter((item) => item?.id !== normalized.id);
+  const next = [normalized, ...all].slice(0, 100);
+  writeAll(next);
+  return normalized;
+};


### PR DESCRIPTION
### Motivation
- Allow creators to target their uploaded HDRIs to one or more games, charge the publish tariff per selected game, and surface those HDRIs in each game's table setup with the user-uploaded thumbnail.

### Description
- Add a lightweight local catalog `webapp/src/utils/customHdriCatalog.js` that persists creator HDRIs (owner, selected games, thumbnail, metadata) in `localStorage` under `tonplaygramCustomHdriCatalogV1` and exposes `listCustomHdrisForGame` and `saveCustomHdri`.
- Extend Store HDRI creator (`webapp/src/pages/Store.jsx`) to support multi-game selection in the UI, store `selectedGames` on the draft, compute `hdriPublishTariff = HDRI_PUBLISH_TARIFF_TPC * numberOfSelectedGames`, require at least one selected game to publish, and display the adjusted tariff message.
- Implement thumbnail capture for the uploaded cover photo via `fileToDataUrl`, persist the custom HDRI via `saveCustomHdri`, deduct the aggregated tariff from the creator balance, and unlock the custom HDRI in selected game inventories using `addPoolRoyalUnlock` / `addSnookerRoyalUnlock` while creating per-game public listing entries (including thumbnail) when visibility is `public`.
- Surface creator HDRIs inside game setup menus by importing `listCustomHdrisForGame` and appending account-specific custom variants to `availableEnvironmentHdris` in `PoolRoyale.jsx` and `SnookerRoyal.jsx`, and prefer a matching custom variant when resolving `activeEnvironmentHdri` so thumbnails and names show alongside built-ins.

### Testing
- Built the project bundle successfully with `npm run -s build` (succeeded).
- Ran targeted linting `npx eslint webapp/src/pages/Store.jsx webapp/src/pages/Games/PoolRoyale.jsx webapp/src/pages/Games/SnookerRoyal.jsx webapp/src/utils/customHdriCatalog.js`, which completed with ignore-pattern warnings only (no lint errors reported in the touched logic).
- Verified files were staged and committed (code changes consolidated into a single commit).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bff4b587ec832992ecca9edfb96c51)