### PR TITLE
Air Hockey: one‑tap Live mode switch and circular double‑size avatar fallback in live chat

### DIFF
--- a/webapp/src/components/AirHockey3D.jsx
+++ b/webapp/src/components/AirHockey3D.jsx
@@ -572,6 +572,7 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
   const [chatBubbles, setChatBubbles] = useState([]);
   const [showChatOptions, setShowChatOptions] = useState(false);
   const [showLiveChat, setShowLiveChat] = useState(false);
+  const [showLiveOptions, setShowLiveOptions] = useState(false);
 
   useEffect(() => {
     if (!showChatOptions) return undefined;
@@ -579,6 +580,12 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
     window.addEventListener('click', close);
     return () => window.removeEventListener('click', close);
   }, [showChatOptions]);
+  useEffect(() => {
+    if (!showLiveOptions) return undefined;
+    const close = () => setShowLiveOptions(false);
+    window.addEventListener('click', close);
+    return () => window.removeEventListener('click', close);
+  }, [showLiveOptions]);
   const [muted, setMuted] = useState(isGameMuted());
   const [commentaryPresetId, setCommentaryPresetId] = useState(() => {
     if (typeof window !== 'undefined') {
@@ -697,6 +704,17 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
     displayName: player?.name || 'Player',
     enabled: showLiveChat
   });
+  useEffect(() => {
+    if (!showLiveChat || liveChat.isConnected) return;
+    liveChat.startLiveChat();
+  }, [showLiveChat, liveChat.isConnected, liveChat.startLiveChat]);
+  const remoteAvatarLookup = useMemo(() => {
+    const opponentAvatar = getAvatarUrl(ai.avatar);
+    return liveChat.remotePeers.reduce((acc, peer) => {
+      acc[peer.socketId] = opponentAvatar;
+      return acc;
+    }, {});
+  }, [ai.avatar, liveChat.remotePeers]);
   const giftPlayers = useMemo(() => {
     const playerAvatar = getAvatarUrl(player.avatar);
     const aiAvatar = getAvatarUrl(ai.avatar);
@@ -2672,10 +2690,11 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
                 onClick={() => {
                   setShowChatOptions(false);
                   setShowLiveChat(true);
+                  setShowLiveOptions(false);
                 }}
                 className="rounded px-2 py-1 text-left hover:bg-white/10"
               >
-                Live chat (video + mic)
+                Live (face + voice)
               </button>
             </div>
           )}
@@ -2693,14 +2712,41 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
             >
               <span className="text-xl">{muted ? '🔇' : '🔊'}</span>
             </button>
-            <button
-              type="button"
-              onClick={() => setShowGift(true)}
-              className="flex flex-col items-center rounded bg-transparent px-2 py-1 text-[10px] font-semibold text-white hover:bg-white/10"
-            >
-              <span className="text-xl">🎁</span>
-              <span>Gift</span>
-            </button>
+            <div className="relative" onClick={(event) => event.stopPropagation()}>
+              <button
+                type="button"
+                onClick={() => setShowLiveOptions((prev) => !prev)}
+                className="flex flex-col items-center rounded bg-transparent px-2 py-1 text-[10px] font-semibold text-white hover:bg-white/10"
+              >
+                <span className="text-xl">🎥</span>
+                <span>Live</span>
+              </button>
+              {showLiveOptions ? (
+                <div className="absolute left-10 top-0 z-50 flex min-w-[9rem] flex-col gap-1 rounded-lg border border-white/20 bg-black/85 p-2 text-xs">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setShowLiveOptions(false);
+                      liveChat.stopLiveChat();
+                      setShowLiveChat(false);
+                    }}
+                    className="rounded px-2 py-1 text-left hover:bg-white/10"
+                  >
+                    Avatar
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setShowLiveOptions(false);
+                      setShowLiveChat(true);
+                    }}
+                    className="rounded px-2 py-1 text-left hover:bg-white/10"
+                  >
+                    Live (face + voice)
+                  </button>
+                </div>
+              ) : null}
+            </div>
           </>
         ) : null}
       </div>
@@ -2769,14 +2815,41 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
       )}
       <div className="absolute bottom-2 right-2 flex flex-col items-end space-y-2 z-20">
         {!isTopDownView && (
-          <button
-            type="button"
-            onClick={() => setShowGift(true)}
-            className="flex flex-col items-center rounded bg-transparent px-2 py-1 text-[10px] font-semibold text-white hover:bg-white/10"
-          >
-            <span className="text-xl">🎁</span>
-            <span>Gift</span>
-          </button>
+          <div className="relative" onClick={(event) => event.stopPropagation()}>
+            <button
+              type="button"
+              onClick={() => setShowLiveOptions((prev) => !prev)}
+              className="flex flex-col items-center rounded bg-transparent px-2 py-1 text-[10px] font-semibold text-white hover:bg-white/10"
+            >
+              <span className="text-xl">🎥</span>
+              <span>Live</span>
+            </button>
+            {showLiveOptions ? (
+              <div className="absolute bottom-11 right-0 z-50 flex min-w-[9rem] flex-col gap-1 rounded-lg border border-white/20 bg-black/85 p-2 text-xs">
+                <button
+                  type="button"
+                  onClick={() => {
+                    setShowLiveOptions(false);
+                    liveChat.stopLiveChat();
+                    setShowLiveChat(false);
+                  }}
+                  className="rounded px-2 py-1 text-left hover:bg-white/10"
+                >
+                  Avatar
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setShowLiveOptions(false);
+                    setShowLiveChat(true);
+                  }}
+                  className="rounded px-2 py-1 text-left hover:bg-white/10"
+                >
+                  Live (face + voice)
+                </button>
+              </div>
+            ) : null}
+          </div>
         )}
         {isTopDownView && (
           <button
@@ -2963,6 +3036,8 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
         onStop={liveChat.stopLiveChat}
         onToggleMicrophone={liveChat.toggleMicrophone}
         onToggleCamera={liveChat.toggleCamera}
+        localAvatarUrl={chatAvatar}
+        remoteAvatarLookup={remoteAvatarLookup}
       />
       <div className="pointer-events-auto">
         <GiftPopup

--- a/webapp/src/components/LiveVideoChatPanel.jsx
+++ b/webapp/src/components/LiveVideoChatPanel.jsx
@@ -1,7 +1,27 @@
 import React from 'react';
 
-function VideoTile({ title, stream, muted = false, mediaState, mirror = false }) {
+function AvatarFallback({ avatarUrl, label, doubleSize = false }) {
+  const sizeClass = doubleSize ? 'h-20 w-20 text-2xl' : 'h-10 w-10 text-sm';
+  if (avatarUrl) {
+    return (
+      <img
+        src={avatarUrl}
+        alt={`${label} avatar`}
+        className={`${sizeClass} rounded-full border border-white/30 object-cover shadow-[0_8px_20px_rgba(0,0,0,0.45)]`}
+      />
+    );
+  }
+  const fallbackInitial = (label || '?').slice(0, 1).toUpperCase();
+  return (
+    <div className={`${sizeClass} flex items-center justify-center rounded-full border border-white/30 bg-slate-800/80 font-semibold text-white shadow-[0_8px_20px_rgba(0,0,0,0.45)]`}>
+      {fallbackInitial}
+    </div>
+  );
+}
+
+function VideoTile({ title, stream, muted = false, mediaState, mirror = false, avatarUrl }) {
   const videoRef = React.useRef(null);
+  const showAvatar = !stream || mediaState?.camera === false;
 
   React.useEffect(() => {
     if (!videoRef.current) return;
@@ -14,13 +34,19 @@ function VideoTile({ title, stream, muted = false, mediaState, mirror = false })
         <span className="truncate">{title}</span>
         <span>{mediaState?.microphone === false ? '🎙️ Off' : '🎙️ On'} · {mediaState?.camera === false ? '📷 Off' : '📷 On'}</span>
       </div>
-      <video
-        ref={videoRef}
-        autoPlay
-        playsInline
-        muted={muted}
-        className={`h-24 w-full rounded-lg bg-black object-cover ${mirror ? 'scale-x-[-1]' : ''}`}
-      />
+      {showAvatar ? (
+        <div className="flex h-24 w-full items-center justify-center rounded-lg bg-black/80">
+          <AvatarFallback avatarUrl={avatarUrl} label={title} doubleSize />
+        </div>
+      ) : (
+        <video
+          ref={videoRef}
+          autoPlay
+          playsInline
+          muted={muted}
+          className={`h-24 w-full rounded-lg bg-black object-cover ${mirror ? 'scale-x-[-1]' : ''}`}
+        />
+      )}
     </div>
   );
 }
@@ -37,7 +63,9 @@ export default function LiveVideoChatPanel({
   onStart,
   onStop,
   onToggleMicrophone,
-  onToggleCamera
+  onToggleCamera,
+  localAvatarUrl,
+  remoteAvatarLookup = {}
 }) {
   if (!open) return null;
 
@@ -66,13 +94,19 @@ export default function LiveVideoChatPanel({
               <span>You</span>
               <span>{localMediaState?.microphone === false ? '🎙️ Off' : '🎙️ On'} · {localMediaState?.camera === false ? '📷 Off' : '📷 On'}</span>
             </div>
-            <video
-              ref={localVideoRef}
-              autoPlay
-              playsInline
-              muted
-              className="h-24 w-full rounded-lg bg-black object-cover scale-x-[-1]"
-            />
+            {localMediaState?.camera === false ? (
+              <div className="flex h-24 w-full items-center justify-center rounded-lg bg-black/80">
+                <AvatarFallback avatarUrl={localAvatarUrl} label="You" doubleSize />
+              </div>
+            ) : (
+              <video
+                ref={localVideoRef}
+                autoPlay
+                playsInline
+                muted
+                className="h-24 w-full rounded-lg bg-black object-cover scale-x-[-1]"
+              />
+            )}
           </div>
           {remotePeers.length > 0 ? (
             remotePeers.map((peer) => (
@@ -81,6 +115,7 @@ export default function LiveVideoChatPanel({
                 title={peer.displayName || 'Player'}
                 stream={peer.stream}
                 mediaState={peer.mediaState}
+                avatarUrl={remoteAvatarLookup[peer.socketId]}
               />
             ))
           ) : (

--- a/webapp/src/hooks/useLiveVideoChat.js
+++ b/webapp/src/hooks/useLiveVideoChat.js
@@ -131,7 +131,7 @@ export default function useLiveVideoChat({ roomId, displayName, enabled }) {
   }, [safeRoomId]);
 
   const startLiveChat = useCallback(async () => {
-    if (!enabled || !safeRoomId || isConnected) return;
+    if (!safeRoomId || isConnected) return;
     setError('');
     try {
       const stream = await navigator.mediaDevices.getUserMedia({
@@ -166,7 +166,7 @@ export default function useLiveVideoChat({ roomId, displayName, enabled }) {
       setError(message);
       console.error('live chat media init failed', mediaError);
     }
-  }, [displayName, enabled, isConnected, safeRoomId]);
+  }, [displayName, isConnected, safeRoomId]);
 
   const toggleTrack = useCallback((kind) => {
     const stream = localStreamRef.current;


### PR DESCRIPTION
### Motivation
- Improve the Air Hockey HUD to let players switch quickly between avatar-only and live (face + voice) modes with a single tap. 
- Provide a consistent, polished call-frame when video is off by showing a circular avatar fallback that is visually larger than the normal avatar. 
- Ensure live sessions can be started programmatically from the HUD flow while preserving manual mic/camera toggles.

### Description
- Replaced the previous quick Gift HUD entry with a compact `Live` selector in `webapp/src/components/AirHockey3D.jsx` that shows an inline popup to choose `Avatar` or `Live (face + voice)`. 
- Added an automatic start flow so selecting Live will call `startLiveChat()` and wired `localAvatarUrl` and `remoteAvatarLookup` into the live panel to keep fallback visuals consistent. 
- Implemented `AvatarFallback` in `webapp/src/components/LiveVideoChatPanel.jsx` and updated `VideoTile` to render a circular avatar (double-size for the video/call frame) when `stream` is missing or camera is off. 
- Relaxed the `startLiveChat` guard in `webapp/src/hooks/useLiveVideoChat.js` (removed the `enabled` dependency) so the new one-tap HUD flow can initiate the live session programmatically.

### Testing
- Built the project with `npm run -s build`, which completed successfully. 
- Ran linting with `npm run -s lint -- webapp/src/components/AirHockey3D.jsx webapp/src/components/LiveVideoChatPanel.jsx webapp/src/hooks/useLiveVideoChat.js`, which surfaced many pre-existing workspace lint problems and ignored-file warnings, so the repo-wide lint output is noisy but the changes compile. 
- Verified the new UI props are passed to `LiveVideoChatPanel` and that `startLiveChat()` is invoked when Live is selected during a local dev build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfefb155908329a98a4ec369f5aacd)