### PR TITLE
Air Hockey: one-tap Live/Avatar toggle + top HUD circular live video

### DIFF
--- a/webapp/src/components/AirHockey3D.jsx
+++ b/webapp/src/components/AirHockey3D.jsx
@@ -570,15 +570,8 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
   const [showGift, setShowGift] = useState(false);
   const [cameraLiftUi, setCameraLiftUi] = useState(DEFAULT_CAMERA_LIFT);
   const [chatBubbles, setChatBubbles] = useState([]);
-  const [showChatOptions, setShowChatOptions] = useState(false);
-  const [showLiveChat, setShowLiveChat] = useState(false);
-
-  useEffect(() => {
-    if (!showChatOptions) return undefined;
-    const close = () => setShowChatOptions(false);
-    window.addEventListener('click', close);
-    return () => window.removeEventListener('click', close);
-  }, [showChatOptions]);
+  const [liveMode, setLiveMode] = useState(false);
+  const [showLivePanel, setShowLivePanel] = useState(false);
   const [muted, setMuted] = useState(isGameMuted());
   const [commentaryPresetId, setCommentaryPresetId] = useState(() => {
     if (typeof window !== 'undefined') {
@@ -646,6 +639,7 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
   const restartTimeoutRef = useRef(null);
   const redirectTimeoutRef = useRef(null);
   const lastTouchRef = useRef(null);
+  const topLiveVideoRef = useRef(null);
   const materialsRef = useRef({
     tableSurface: null,
     cushion: null,
@@ -695,8 +689,15 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
   const liveChat = useLiveVideoChat({
     roomId: liveChatRoomId,
     displayName: player?.name || 'Player',
-    enabled: showLiveChat
+    enabled: liveMode
   });
+  useEffect(() => {
+    if (liveMode) {
+      liveChat.startLiveChat();
+      return;
+    }
+    liveChat.stopLiveChat();
+  }, [liveMode, liveChat.startLiveChat, liveChat.stopLiveChat]);
   const giftPlayers = useMemo(() => {
     const playerAvatar = getAvatarUrl(player.avatar);
     const aiAvatar = getAvatarUrl(ai.avatar);
@@ -718,6 +719,10 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
       }
     ];
   }, [ai, accountId, player, resolvedAccountId]);
+  useEffect(() => {
+    if (!topLiveVideoRef.current) return;
+    topLiveVideoRef.current.srcObject = liveChat.localStream || null;
+  }, [liveChat.localStream]);
   const updateRendererSettings = useCallback(() => {
     const renderer = rendererRef.current;
     const host = hostRef.current;
@@ -2577,13 +2582,24 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
           className="flex items-center gap-2 rounded bg-white/10 px-2 py-1 text-xs"
           data-player-index="0"
         >
-          <img
-            src={getAvatarUrl(player.avatar)}
-            alt=""
-            className="h-5 w-5 rounded-full object-cover"
-          />
+          {liveMode ? (
+            <video
+              ref={topLiveVideoRef}
+              autoPlay
+              playsInline
+              muted
+              className="h-10 w-10 rounded-full border border-emerald-300/70 object-cover bg-black scale-x-[-1]"
+            />
+          ) : (
+            <img
+              src={getAvatarUrl(player.avatar)}
+              alt=""
+              className="h-5 w-5 rounded-full object-cover"
+            />
+          )}
           <span className="truncate">
             {player.name}: {ui.left}
+            {liveMode ? <span className="ml-1 text-emerald-200">• Live</span> : null}
           </span>
         </div>
         <div
@@ -2646,40 +2662,27 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
             : 'bottom-2 left-2 items-start'
         }`}
       >
-        <div className="relative" onClick={(event) => event.stopPropagation()}>
-          <button
-            type="button"
-            onClick={() => setShowChatOptions((prev) => !prev)}
-            className="flex flex-col items-center rounded bg-transparent px-2 py-1 text-[10px] font-semibold text-white hover:bg-white/10"
-          >
-            <AiOutlineMessage className="text-xl" />
-            <span>Chat</span>
-          </button>
-          {showChatOptions && (
-            <div className="absolute left-10 top-0 z-50 flex min-w-[9rem] flex-col gap-1 rounded-lg border border-white/20 bg-black/85 p-2 text-xs">
-              <button
-                type="button"
-                onClick={() => {
-                  setShowChatOptions(false);
-                  setShowChat(true);
-                }}
-                className="rounded px-2 py-1 text-left hover:bg-white/10"
-              >
-                Quick chat
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  setShowChatOptions(false);
-                  setShowLiveChat(true);
-                }}
-                className="rounded px-2 py-1 text-left hover:bg-white/10"
-              >
-                Live chat (video + mic)
-              </button>
-            </div>
-          )}
-        </div>
+        <button
+          type="button"
+          onClick={() => {
+            setLiveMode((prev) => !prev);
+            setShowLivePanel((prev) => (!liveMode ? true : prev));
+          }}
+          className={`flex flex-col items-center rounded px-2 py-1 text-[10px] font-semibold ${
+            liveMode ? 'bg-emerald-500/25 text-emerald-100' : 'bg-transparent text-white hover:bg-white/10'
+          }`}
+        >
+          <AiOutlineMessage className="text-xl" />
+          <span>{liveMode ? 'Avatar' : 'Live'}</span>
+        </button>
+        <button
+          type="button"
+          onClick={() => setShowChat(true)}
+          className="flex flex-col items-center rounded bg-transparent px-2 py-1 text-[10px] font-semibold text-white hover:bg-white/10"
+        >
+          <span className="text-xl">💬</span>
+          <span>Chat</span>
+        </button>
         {isTopDownView ? (
           <>
             <button
@@ -2947,20 +2950,25 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
         />
       </div>
       <LiveVideoChatPanel
-        open={showLiveChat}
+        open={showLivePanel && liveMode}
         onClose={() => {
-          liveChat.stopLiveChat();
-          setShowLiveChat(false);
-          setShowChatOptions(false);
+          setShowLivePanel(false);
         }}
         roomId={liveChatRoomId}
-        localVideoRef={liveChat.localVideoRef}
+        localStream={liveChat.localStream}
         localMediaState={liveChat.mediaState}
         remotePeers={liveChat.remotePeers}
         isConnected={liveChat.isConnected}
         error={liveChat.error}
-        onStart={liveChat.startLiveChat}
-        onStop={liveChat.stopLiveChat}
+        onStart={() => {
+          setLiveMode(true);
+          liveChat.startLiveChat();
+        }}
+        onStop={() => {
+          liveChat.stopLiveChat();
+          setLiveMode(false);
+          setShowLivePanel(false);
+        }}
         onToggleMicrophone={liveChat.toggleMicrophone}
         onToggleCamera={liveChat.toggleCamera}
       />

--- a/webapp/src/components/LiveVideoChatPanel.jsx
+++ b/webapp/src/components/LiveVideoChatPanel.jsx
@@ -29,7 +29,7 @@ export default function LiveVideoChatPanel({
   open,
   onClose,
   roomId,
-  localVideoRef,
+  localStream,
   localMediaState,
   remotePeers,
   isConnected,
@@ -61,19 +61,13 @@ export default function LiveVideoChatPanel({
         {error ? <p className="mb-2 rounded-md bg-red-500/20 px-2 py-1 text-xs text-red-100">{error}</p> : null}
 
         <div className="space-y-2">
-          <div className="rounded-xl border border-white/15 bg-black/60 p-2">
-            <div className="mb-1 flex items-center justify-between text-[10px] uppercase tracking-[0.2em] text-white/70">
-              <span>You</span>
-              <span>{localMediaState?.microphone === false ? '🎙️ Off' : '🎙️ On'} · {localMediaState?.camera === false ? '📷 Off' : '📷 On'}</span>
-            </div>
-            <video
-              ref={localVideoRef}
-              autoPlay
-              playsInline
-              muted
-              className="h-24 w-full rounded-lg bg-black object-cover scale-x-[-1]"
-            />
-          </div>
+          <VideoTile
+            title="You"
+            stream={localStream}
+            muted
+            mediaState={localMediaState}
+            mirror
+          />
           {remotePeers.length > 0 ? (
             remotePeers.map((peer) => (
               <VideoTile

--- a/webapp/src/hooks/useLiveVideoChat.js
+++ b/webapp/src/hooks/useLiveVideoChat.js
@@ -15,7 +15,7 @@ export default function useLiveVideoChat({ roomId, displayName, enabled }) {
   const [remotePeers, setRemotePeers] = useState([]);
   const [mediaState, setMediaState] = useState(EMPTY_MEDIA_STATE);
   const [error, setError] = useState('');
-  const localVideoRef = useRef(null);
+  const [localStream, setLocalStream] = useState(null);
   const localStreamRef = useRef(null);
   const peersRef = useRef(new Map());
 
@@ -117,10 +117,7 @@ export default function useLiveVideoChat({ roomId, displayName, enabled }) {
     if (localStreamRef.current) {
       localStreamRef.current.getTracks().forEach((track) => track.stop());
       localStreamRef.current = null;
-    }
-
-    if (localVideoRef.current) {
-      localVideoRef.current.srcObject = null;
+      setLocalStream(null);
     }
 
     if (safeRoomId) {
@@ -144,10 +141,7 @@ export default function useLiveVideoChat({ roomId, displayName, enabled }) {
       });
 
       localStreamRef.current = stream;
-      if (localVideoRef.current) {
-        localVideoRef.current.srcObject = stream;
-      }
-
+      setLocalStream(stream);
       setMediaState({
         microphone: stream.getAudioTracks().every((track) => track.enabled),
         camera: stream.getVideoTracks().every((track) => track.enabled)
@@ -263,7 +257,7 @@ export default function useLiveVideoChat({ roomId, displayName, enabled }) {
   return {
     error,
     isConnected,
-    localVideoRef,
+    localStream,
     mediaState,
     remotePeers,
     startLiveChat,


### PR DESCRIPTION
### Motivation
- Make switching between avatar and live face/voice in Air Hockey faster and more discoverable by replacing a two-step chat options popover with a single Live/Avatar toggle and a persistent live preview in the top HUD. 
- Visually highlight when a user is broadcasting by replacing the small avatar with a larger circular live camera frame and a clear “Live” indicator.

### Description
- Introduced a `liveMode` state and `showLivePanel` in `AirHockey3D.jsx` and replaced the previous chat-options popover with a dedicated Live/Avatar toggle plus a separate quick `Chat` button for one-tap quick messages. 
- When `liveMode` is active the top-left HUD avatar is replaced by a mirrored circular `<video>` element sized `h-10 w-10` (vs `h-5 w-5` avatar) and a `• Live` label, and the live preview is synced to the local media stream. 
- Exposed the active local media stream from the hook by adding `localStream` to `useLiveVideoChat` and updated start/stop logic to set/clear it. 
- Updated `LiveVideoChatPanel.jsx` to accept `localStream` and render the local preview using the existing `VideoTile` component, and wired panel `onStart`/`onStop` callbacks to coordinate `liveMode` and panel visibility.

### Testing
- Ran `npx eslint webapp/src/components/AirHockey3D.jsx webapp/src/components/LiveVideoChatPanel.jsx webapp/src/hooks/useLiveVideoChat.js` which completed with file-ignore warnings under the repository ESLint config. (warnings) 
- Ran `npx eslint --no-ignore` on the same files which surfaced lint issues in the modified hook file (reported multiple lint errors); these are ESLint findings and not functional test failures. (errors reported)
- Verified `git diff --check HEAD~1..HEAD` produced no whitespace/diff-check issues. (clean)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c005319f4c8329aa534df82ed03ca1)