### PR TITLE
Add Air Hockey live video chat icon & panel to all game cards

### DIFF
--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -1,11 +1,18 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
+import { AiOutlineMessage } from 'react-icons/ai';
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 import LeaderboardCard from '../components/LeaderboardCard.jsx';
 import GameTransactionsCard from '../components/GameTransactionsCard.jsx';
+import LiveVideoChatPanel from '../components/LiveVideoChatPanel.jsx';
 import gamesCatalog from '../config/gamesCatalog.js';
 import { getGameThumbnail } from '../config/gameAssets.js';
-import { getOnlineReadiness, fetchOnlineReadinessMap, ONLINE_READINESS_BY_GAME } from '../config/onlineContract.js';
+import {
+  getOnlineReadiness,
+  fetchOnlineReadinessMap,
+  ONLINE_READINESS_BY_GAME
+} from '../config/onlineContract.js';
+import useLiveVideoChat from '../hooks/useLiveVideoChat.js';
 
 const BADGE_STYLES = {
   'Online Ready': 'bg-emerald-500/20 text-emerald-300 border-emerald-400/40',
@@ -16,6 +23,34 @@ const BADGE_STYLES = {
 export default function Games() {
   useTelegramBackButton();
   const [readinessMap, setReadinessMap] = useState(ONLINE_READINESS_BY_GAME);
+  const [liveMode, setLiveMode] = useState(false);
+  const [showLivePanel, setShowLivePanel] = useState(false);
+  const [liveGameSlug, setLiveGameSlug] = useState('');
+
+  const liveDisplayName = useMemo(() => {
+    if (typeof window === 'undefined') return 'Player';
+    const username = window.localStorage.getItem('telegramUsername');
+    const firstName = window.localStorage.getItem('telegramFirstName');
+    const lastName = window.localStorage.getItem('telegramLastName');
+    return (
+      username || `${firstName || ''} ${lastName || ''}`.trim() || 'Player'
+    );
+  }, []);
+
+  const liveChatRoomId = useMemo(() => {
+    if (!liveGameSlug) return '';
+    const accountId =
+      typeof window !== 'undefined'
+        ? window.localStorage.getItem('accountId') || 'guest'
+        : 'guest';
+    return `game-live-${liveGameSlug}-${accountId}`;
+  }, [liveGameSlug]);
+
+  const liveChat = useLiveVideoChat({
+    roomId: liveChatRoomId,
+    displayName: liveDisplayName,
+    enabled: liveMode
+  });
 
   useEffect(() => {
     let active = true;
@@ -27,6 +62,14 @@ export default function Games() {
     };
   }, []);
 
+  useEffect(() => {
+    if (liveMode) {
+      liveChat.startLiveChat();
+      return;
+    }
+    liveChat.stopLiveChat();
+  }, [liveMode, liveChat.startLiveChat, liveChat.stopLiveChat]);
+
   return (
     <div className="relative space-y-4 text-text">
       <h2 className="text-2xl font-bold text-center mt-4">Games Lobby</h2>
@@ -37,7 +80,8 @@ export default function Games() {
         {gamesCatalog.map((game) => {
           const thumbnail = getGameThumbnail(game.slug);
           const readiness = getOnlineReadiness(game.slug, readinessMap);
-          const badgeTone = BADGE_STYLES[readiness.label] || BADGE_STYLES['Coming Soon'];
+          const badgeTone =
+            BADGE_STYLES[readiness.label] || BADGE_STYLES['Coming Soon'];
           return (
             <Link
               key={game.name}
@@ -54,26 +98,83 @@ export default function Games() {
                     event.currentTarget.src = game.image;
                   }}
                 />
-              <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent" />
-              <span className="absolute bottom-1 left-1 right-1 text-center text-xs font-semibold text-white">
-                {game.name}
-              </span>
-            </div>
-            <div className="flex flex-1 flex-col items-center px-2 py-2 text-center">
-              <p className="text-[10px] text-subtext line-clamp-2">{game.description}</p>
-              <span
-                className={`mt-1 inline-flex items-center rounded-full border px-2 py-0.5 text-[9px] font-semibold uppercase tracking-[0.14em] ${badgeTone}`}
-              >
-                {readiness.label}
-              </span>
-              <span className="mt-2 inline-flex items-center gap-1 rounded-full bg-primary/15 px-2 py-0.5 text-[10px] font-semibold text-primary">
-                Enter Lobby
-              </span>
-            </div>
+                <button
+                  type="button"
+                  aria-label={
+                    liveMode && liveGameSlug === game.slug
+                      ? `Disable live chat for ${game.name}`
+                      : `Enable live chat for ${game.name}`
+                  }
+                  onClick={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    if (liveMode && liveGameSlug === game.slug) {
+                      liveChat.stopLiveChat();
+                      setLiveMode(false);
+                      setShowLivePanel(false);
+                      return;
+                    }
+                    setLiveGameSlug(game.slug);
+                    setLiveMode(true);
+                    setShowLivePanel(true);
+                  }}
+                  className={`absolute left-1 top-1 z-10 flex flex-col items-center rounded px-2 py-1 text-[10px] font-semibold ${
+                    liveMode && liveGameSlug === game.slug
+                      ? 'bg-emerald-500/25 text-emerald-100'
+                      : 'bg-black/35 text-white hover:bg-white/10'
+                  }`}
+                >
+                  <AiOutlineMessage className="text-xl" />
+                  <span>
+                    {liveMode && liveGameSlug === game.slug ? 'Avatar' : 'Live'}
+                  </span>
+                </button>
+                <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent" />
+                <span className="absolute bottom-1 left-1 right-1 text-center text-xs font-semibold text-white">
+                  {game.name}
+                </span>
+              </div>
+              <div className="flex flex-1 flex-col items-center px-2 py-2 text-center">
+                <p className="text-[10px] text-subtext line-clamp-2">
+                  {game.description}
+                </p>
+                <span
+                  className={`mt-1 inline-flex items-center rounded-full border px-2 py-0.5 text-[9px] font-semibold uppercase tracking-[0.14em] ${badgeTone}`}
+                >
+                  {readiness.label}
+                </span>
+                <span className="mt-2 inline-flex items-center gap-1 rounded-full bg-primary/15 px-2 py-0.5 text-[10px] font-semibold text-primary">
+                  Enter Lobby
+                </span>
+              </div>
             </Link>
           );
         })}
       </div>
+      <LiveVideoChatPanel
+        open={showLivePanel && Boolean(liveGameSlug)}
+        onClose={() => {
+          setShowLivePanel(false);
+        }}
+        roomId={liveChatRoomId}
+        localStream={liveChat.localStream}
+        localMediaState={liveChat.mediaState}
+        remotePeers={liveChat.remotePeers}
+        isConnected={liveChat.isConnected}
+        error={liveChat.error}
+        onStart={() => {
+          if (!liveGameSlug) return;
+          setLiveMode(true);
+          liveChat.startLiveChat();
+        }}
+        onStop={() => {
+          liveChat.stopLiveChat();
+          setLiveMode(false);
+          setShowLivePanel(false);
+        }}
+        onToggleMicrophone={liveChat.toggleMicrophone}
+        onToggleCamera={liveChat.toggleCamera}
+      />
       <GameTransactionsCard />
       <LeaderboardCard />
     </div>


### PR DESCRIPTION
### Motivation
- Provide the same live-video entry point that exists in Air Hockey on every game card so players can start a per-game live call directly from the Games lobby.
- Keep behavior and UI identical to Air Hockey: same icon, label state (Live / Avatar) and the same start/stop, mic and camera controls.

### Description
- Added a Live icon button to every game card and wired it to prevent navigation when toggled, matching Air Hockey card behavior by stopping propagation on click; implemented in `webapp/src/pages/Games.jsx`.
- Integrated `useLiveVideoChat` and mounted the existing `LiveVideoChatPanel` on the Games page so the panel can be opened for any game card; the panel exposes start/stop, toggle mic and toggle camera handlers.
- Per-game room IDs are generated as `game-live-<slug>-<accountId>` and a display name is resolved from Telegram/localStorage values so each game session is isolated.
- Kept styling and label logic consistent with Air Hockey (icon + `Live` / `Avatar` text and emerald active state).

### Testing
- Formatted the modified file with Prettier using `npx prettier --write webapp/src/pages/Games.jsx`, which completed successfully.
- Ran a scoped ESLint check; the check surfaced unrelated repository-wide lint errors in generated/dist and other files, so a full repo lint run failed due to pre-existing issues (these are not caused by the changes in this PR).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c00ad4c7508329b202cca538d95a71)