### PR TITLE
Fix Pool Royale online seating for explicit table IDs

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -59,7 +59,7 @@ import {
   countOnline,
   listOnline
 } from './services/connectionService.js';
-import { validateSeatTableRequest } from './config/onlineGamePolicy.js';
+import { GAME_ONLINE_POLICY, validateSeatTableRequest } from './config/onlineGamePolicy.js';
 import { createCheckersRealtimeStore } from './utils/checkersRealtimeState.js';
 
 validateEnv();
@@ -595,6 +595,37 @@ function getAvailableTable(
     `Created new table: ${table.id} (${gameType}, cap ${maxPlayers}, stake: ${stake})`
   );
   return table;
+}
+
+function resolveSeatIdentityFromTableId(tableId, fallbackGameType, fallbackMaxPlayers) {
+  if (!tableId) {
+    return {
+      gameType: fallbackGameType,
+      maxPlayers: fallbackMaxPlayers
+    };
+  }
+
+  const [prefix, capStr] = String(tableId).split('-');
+  const parsedCap = Number(capStr);
+
+  // Some joins use invite/table ids that are opaque (UUID-like) and not in
+  // "<game>-<capacity>-..." form. In those cases, keep the explicit payload
+  // gameType/maxPlayers instead of inferring invalid values from the table id.
+  if (
+    !GAME_ONLINE_POLICY[prefix] ||
+    !Number.isFinite(parsedCap) ||
+    parsedCap <= 0
+  ) {
+    return {
+      gameType: fallbackGameType,
+      maxPlayers: fallbackMaxPlayers
+    };
+  }
+
+  return {
+    gameType: prefix,
+    maxPlayers: parsedCap
+  };
 }
 
 function cleanupSeats() {
@@ -1531,8 +1562,10 @@ io.on('connection', (socket) => {
       if (isRateLimited(socket, 'seatTable', seatTableRateLimitMs)) {
         return cb && cb({ success: false, error: 'rate_limited' });
       }
-      const resolvedGameType = tableId ? String(tableId).split('-')[0] : gameType;
-      const resolvedMaxPlayers = tableId ? Number(String(tableId).split('-')[1]) || 0 : maxPlayers;
+      const {
+        gameType: resolvedGameType,
+        maxPlayers: resolvedMaxPlayers
+      } = resolveSeatIdentityFromTableId(tableId, gameType, maxPlayers);
       const validation = validateSeatTableRequest({
         gameType: resolvedGameType,
         stake,

--- a/test/poolRoyaleMatchmakingMeta.test.js
+++ b/test/poolRoyaleMatchmakingMeta.test.js
@@ -163,3 +163,77 @@ test('pool royale disconnect clears stale lobby seat so next player can queue cl
     server.kill();
   }
 });
+
+test('pool royale allows joining the same explicit tableId when id is not game-prefixed', { concurrency: false, timeout: 20000 }, async () => {
+  fs.mkdirSync(new URL('assets', distDir), { recursive: true });
+  fs.writeFileSync(new URL('index.html', distDir), '');
+
+  const env = {
+    ...process.env,
+    PORT: '3209',
+    MONGO_URI: 'memory',
+    BOT_TOKEN: 'dummy',
+    API_AUTH_TOKEN: apiToken,
+    SKIP_WEBAPP_BUILD: '1',
+    SKIP_BOT_LAUNCH: '1'
+  };
+
+  const server = await startServer(env);
+  const s1 = connectClient(3209);
+  const s2 = connectClient(3209);
+  const sharedTableId = 'room-77';
+
+  try {
+    await Promise.all([
+      new Promise((resolve) => s1.on('connect', resolve)),
+      new Promise((resolve) => s2.on('connect', resolve))
+    ]);
+
+    s1.emit('register', { playerId: 'acct-room-a' });
+    s2.emit('register', { playerId: 'acct-room-b' });
+
+    const firstSeat = await new Promise((resolve) => {
+      s1.emit(
+        'seatTable',
+        {
+          accountId: 'acct-room-a',
+          gameType: 'poolroyale',
+          stake: 100,
+          maxPlayers: 2,
+          mode: 'online',
+          playType: 'regular',
+          tableId: sharedTableId,
+          playerName: 'RoomA'
+        },
+        resolve
+      );
+    });
+
+    const secondSeat = await new Promise((resolve) => {
+      s2.emit(
+        'seatTable',
+        {
+          accountId: 'acct-room-b',
+          gameType: 'poolroyale',
+          stake: 100,
+          maxPlayers: 2,
+          mode: 'online',
+          playType: 'regular',
+          tableId: sharedTableId,
+          playerName: 'RoomB'
+        },
+        resolve
+      );
+    });
+
+    assert.equal(firstSeat.success, true);
+    assert.equal(firstSeat.tableId, sharedTableId);
+    assert.equal(secondSeat.success, true);
+    assert.equal(secondSeat.tableId, sharedTableId);
+    assert.equal(secondSeat.players.length, 2);
+  } finally {
+    s1.disconnect();
+    s2.disconnect();
+    server.kill();
+  }
+});


### PR DESCRIPTION
### Motivation

- Joining via invite/URL can pass an explicit `tableId` like `room-77` which was being parsed as `<game>-<capacity>-...` causing validation to fail and preventing players from seating together.

### Description

- Add `resolveSeatIdentityFromTableId` helper in `bot/server.js` that parses `tableId` only when it matches a valid game prefix and numeric capacity, otherwise it falls back to the provided `gameType`/`maxPlayers` payload.
- Import `GAME_ONLINE_POLICY` and use it in the resolver to validate parsed prefixes against known online games.
- Use the new helper when handling the `seatTable` socket event so validation uses the correct `gameType`/`maxPlayers` values.
- Add a regression integration test `pool royale allows joining the same explicit tableId when id is not game-prefixed` in `test/poolRoyaleMatchmakingMeta.test.js` to cover opaque invite-style `tableId`s (e.g. `room-77`).

### Testing

- Ran `npm test -- test/poolRoyaleMatchmakingMeta.test.js` and the suite passed with 3 tests succeeding (including the new regression test).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c00c63cc04832997087f149f3a1e29)