### PR TITLE
Add live video avatar overlay and in-lobby live chat panel for games

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -38,14 +38,30 @@ import TexasHoldemLobby from './pages/Games/TexasHoldemLobby.jsx';
 import DominoRoyal from './pages/Games/DominoRoyal.jsx';
 import DominoRoyalLobby from './pages/Games/DominoRoyalLobby.jsx';
 
-const ChessBattleRoyal = React.lazy(() => import('./pages/Games/ChessBattleRoyal.jsx'));
-const ChessBattleRoyalLobby = React.lazy(() => import('./pages/Games/ChessBattleRoyalLobby.jsx'));
-const CheckersBattleRoyal = React.lazy(() => import('./pages/Games/CheckersBattleRoyal.jsx'));
-const CheckersBattleRoyalLobby = React.lazy(() => import('./pages/Games/CheckersBattleRoyalLobby.jsx'));
-const FourInRowRoyal = React.lazy(() => import('./pages/Games/FourInRowRoyal.jsx'));
-const FourInRowRoyalLobby = React.lazy(() => import('./pages/Games/FourInRowRoyalLobby.jsx'));
-const TavullBattleRoyal = React.lazy(() => import('./pages/Games/TavullBattleRoyal.jsx'));
-const TavullBattleRoyalLobby = React.lazy(() => import('./pages/Games/TavullBattleRoyalLobby.jsx'));
+const ChessBattleRoyal = React.lazy(
+  () => import('./pages/Games/ChessBattleRoyal.jsx')
+);
+const ChessBattleRoyalLobby = React.lazy(
+  () => import('./pages/Games/ChessBattleRoyalLobby.jsx')
+);
+const CheckersBattleRoyal = React.lazy(
+  () => import('./pages/Games/CheckersBattleRoyal.jsx')
+);
+const CheckersBattleRoyalLobby = React.lazy(
+  () => import('./pages/Games/CheckersBattleRoyalLobby.jsx')
+);
+const FourInRowRoyal = React.lazy(
+  () => import('./pages/Games/FourInRowRoyal.jsx')
+);
+const FourInRowRoyalLobby = React.lazy(
+  () => import('./pages/Games/FourInRowRoyalLobby.jsx')
+);
+const TavullBattleRoyal = React.lazy(
+  () => import('./pages/Games/TavullBattleRoyal.jsx')
+);
+const TavullBattleRoyalLobby = React.lazy(
+  () => import('./pages/Games/TavullBattleRoyalLobby.jsx')
+);
 import PoolRoyale from './pages/Games/PoolRoyale.jsx';
 import PoolRoyaleLobby from './pages/Games/PoolRoyaleLobby.jsx';
 import PoolRoyaleCareer from './pages/Games/PoolRoyaleCareer.jsx';
@@ -56,6 +72,7 @@ import StoreThumbnailStudioPoolRoyale from './pages/Tools/StoreThumbnailStudioPo
 
 import Layout from './components/Layout.jsx';
 import TonConnectSync from './components/TonConnectSync.jsx';
+import GameLiveAvatarOverlay from './components/GameLiveAvatarOverlay.jsx';
 import useTelegramAuth from './hooks/useTelegramAuth.js';
 import useTelegramFullscreen from './hooks/useTelegramFullscreen.js';
 import useMobileFullscreen from './hooks/useMobileFullscreen.js';
@@ -69,10 +86,14 @@ export default function App() {
   // TonConnect can hang if the manifest URL/origin mismatch.
   // Keep this as early as possible.
   if (typeof window !== 'undefined') {
-    const canonical = import.meta.env.VITE_PUBLIC_APP_URL || 'https://tonplaygram-bot.onrender.com';
+    const canonical =
+      import.meta.env.VITE_PUBLIC_APP_URL ||
+      'https://tonplaygram-bot.onrender.com';
     try {
       const canonicalUrl = new URL(canonical);
-      const isLocalhost = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
+      const isLocalhost =
+        window.location.hostname === 'localhost' ||
+        window.location.hostname === '127.0.0.1';
       if (!isLocalhost && canonicalUrl.origin !== window.location.origin) {
         const next = new URL(window.location.href);
         next.protocol = canonicalUrl.protocol;
@@ -92,8 +113,10 @@ export default function App() {
   useNativePushNotifications();
 
   const canonicalOrigin = useMemo(
-    () => import.meta.env.VITE_PUBLIC_APP_URL || 'https://tonplaygram-bot.onrender.com',
-    [],
+    () =>
+      import.meta.env.VITE_PUBLIC_APP_URL ||
+      'https://tonplaygram-bot.onrender.com',
+    []
   );
 
   // Always load the TonConnect manifest from the canonical origin.
@@ -119,9 +142,9 @@ export default function App() {
       // "back" works across regular browsers + Telegram webview.
       returnStrategy: 'back',
       // Where TonConnect should return the user after approving in-wallet.
-      twaReturnUrl: isTelegramWebView() ? telegramReturnUrl : returnUrl,
+      twaReturnUrl: isTelegramWebView() ? telegramReturnUrl : returnUrl
     }),
-    [returnUrl, telegramReturnUrl],
+    [returnUrl, telegramReturnUrl]
   );
 
   return (
@@ -142,79 +165,145 @@ export default function App() {
             <Route path="/games" element={<Games />} />
             <Route path="/games/transactions" element={<GameTransactions />} />
             <Route path="/games/:game/lobby" element={<Lobby />} />
-            <Route path="/games/snake" element={<SnakeAndLadder />} />
+            <Route
+              path="/games/snake"
+              element={
+                <GameLiveAvatarOverlay gameSlug="snake">
+                  <SnakeAndLadder />
+                </GameLiveAvatarOverlay>
+              }
+            />
             <Route path="/games/snake/mp" element={<SnakeMultiplayer />} />
             <Route path="/games/snake/results" element={<SnakeResults />} />
             <Route path="/games/goalrush/lobby" element={<GoalRushLobby />} />
-            <Route path="/games/goalrush" element={<GoalRush />} />
+            <Route
+              path="/games/goalrush"
+              element={
+                <GameLiveAvatarOverlay gameSlug="goalrush">
+                  <GoalRush />
+                </GameLiveAvatarOverlay>
+              }
+            />
             <Route path="/games/airhockey/lobby" element={<AirHockeyLobby />} />
             <Route path="/games/airhockey" element={<AirHockey />} />
             <Route
               path="/games/chessbattleroyal/lobby"
-              element={(
-                <Suspense fallback={<div className="p-4 text-center">Loading Chess Lobby…</div>}>
+              element={
+                <Suspense
+                  fallback={
+                    <div className="p-4 text-center">Loading Chess Lobby…</div>
+                  }
+                >
                   <ChessBattleRoyalLobby />
                 </Suspense>
-              )}
+              }
             />
             <Route
               path="/games/chessbattleroyal"
-              element={(
-                <Suspense fallback={<div className="p-4 text-center">Loading Chess Battle Royal…</div>}>
-                  <ChessBattleRoyal />
+              element={
+                <Suspense
+                  fallback={
+                    <div className="p-4 text-center">
+                      Loading Chess Battle Royal…
+                    </div>
+                  }
+                >
+                  <GameLiveAvatarOverlay gameSlug="chessbattleroyal">
+                    <ChessBattleRoyal />
+                  </GameLiveAvatarOverlay>
                 </Suspense>
-              )}
+              }
             />
 
             <Route
               path="/games/checkersbattleroyal/lobby"
-              element={(
-                <Suspense fallback={<div className="p-4 text-center">Loading Checkers Lobby…</div>}>
+              element={
+                <Suspense
+                  fallback={
+                    <div className="p-4 text-center">
+                      Loading Checkers Lobby…
+                    </div>
+                  }
+                >
                   <CheckersBattleRoyalLobby />
                 </Suspense>
-              )}
+              }
             />
             <Route
               path="/games/checkersbattleroyal"
-              element={(
-                <Suspense fallback={<div className="p-4 text-center">Loading Checkers Battle Royal…</div>}>
-                  <CheckersBattleRoyal />
+              element={
+                <Suspense
+                  fallback={
+                    <div className="p-4 text-center">
+                      Loading Checkers Battle Royal…
+                    </div>
+                  }
+                >
+                  <GameLiveAvatarOverlay gameSlug="checkersbattleroyal">
+                    <CheckersBattleRoyal />
+                  </GameLiveAvatarOverlay>
                 </Suspense>
-              )}
+              }
             />
 
             <Route
               path="/games/fourinrowroyale/lobby"
-              element={(
-                <Suspense fallback={<div className="p-4 text-center">Loading 4 in a Row Lobby…</div>}>
+              element={
+                <Suspense
+                  fallback={
+                    <div className="p-4 text-center">
+                      Loading 4 in a Row Lobby…
+                    </div>
+                  }
+                >
                   <FourInRowRoyalLobby />
                 </Suspense>
-              )}
+              }
             />
             <Route
               path="/games/fourinrowroyale"
-              element={(
-                <Suspense fallback={<div className="p-4 text-center">Loading 4 in a Row…</div>}>
-                  <FourInRowRoyal />
+              element={
+                <Suspense
+                  fallback={
+                    <div className="p-4 text-center">Loading 4 in a Row…</div>
+                  }
+                >
+                  <GameLiveAvatarOverlay gameSlug="fourinrowroyale">
+                    <FourInRowRoyal />
+                  </GameLiveAvatarOverlay>
                 </Suspense>
-              )}
+              }
             />
 
             <Route
               path="/games/tavullbattleroyal/lobby"
-              element={(
-                <Suspense fallback={<div className="p-4 text-center">Loading Backgammon Lobby…</div>}>
+              element={
+                <Suspense
+                  fallback={
+                    <div className="p-4 text-center">
+                      Loading Backgammon Lobby…
+                    </div>
+                  }
+                >
                   <TavullBattleRoyalLobby />
                 </Suspense>
-              )}
+              }
             />
             <Route
               path="/games/tavullbattleroyal"
-              element={(
-                <Suspense fallback={<div className="p-4 text-center">Loading Backgammon Royal…</div>}>
-                  <TavullBattleRoyal />
+              element={
+                <Suspense
+                  fallback={
+                    <div className="p-4 text-center">
+                      Loading Backgammon Royal…
+                    </div>
+                  }
+                >
+                  <GameLiveAvatarOverlay gameSlug="tavullbattleroyal">
+                    <TavullBattleRoyal />
+                  </GameLiveAvatarOverlay>
                 </Suspense>
-              )}
+              }
             />
             <Route
               path="/games/ludobattleroyal/lobby"
@@ -222,23 +311,48 @@ export default function App() {
             />
             <Route
               path="/games/ludobattleroyal"
-              element={<LudoBattleRoyal />}
+              element={
+                <GameLiveAvatarOverlay gameSlug="ludobattleroyal">
+                  <LudoBattleRoyal />
+                </GameLiveAvatarOverlay>
+              }
             />
             <Route
               path="/games/texasholdem/lobby"
               element={<TexasHoldemLobby />}
             />
-            <Route path="/games/texasholdem" element={<TexasHoldem />} />
+            <Route
+              path="/games/texasholdem"
+              element={
+                <GameLiveAvatarOverlay gameSlug="texasholdem">
+                  <TexasHoldem />
+                </GameLiveAvatarOverlay>
+              }
+            />
             <Route
               path="/games/domino-royal/lobby"
               element={<DominoRoyalLobby />}
             />
-            <Route path="/games/domino-royal" element={<DominoRoyal />} />
+            <Route
+              path="/games/domino-royal"
+              element={
+                <GameLiveAvatarOverlay gameSlug="domino-royal">
+                  <DominoRoyal />
+                </GameLiveAvatarOverlay>
+              }
+            />
             <Route
               path="/games/murlanroyale/lobby"
               element={<MurlanRoyaleLobby />}
             />
-            <Route path="/games/murlanroyale" element={<MurlanRoyale />} />
+            <Route
+              path="/games/murlanroyale"
+              element={
+                <GameLiveAvatarOverlay gameSlug="murlanroyale">
+                  <MurlanRoyale />
+                </GameLiveAvatarOverlay>
+              }
+            />
             <Route
               path="/games/poolroyale/lobby"
               element={<PoolRoyaleLobby />}
@@ -247,12 +361,26 @@ export default function App() {
               path="/games/poolroyale/career"
               element={<PoolRoyaleCareer />}
             />
-            <Route path="/games/poolroyale" element={<PoolRoyale />} />
+            <Route
+              path="/games/poolroyale"
+              element={
+                <GameLiveAvatarOverlay gameSlug="poolroyale">
+                  <PoolRoyale />
+                </GameLiveAvatarOverlay>
+              }
+            />
             <Route
               path="/games/snookerroyale/lobby"
               element={<SnookerRoyalLobby />}
             />
-            <Route path="/games/snookerroyale" element={<SnookerRoyal />} />
+            <Route
+              path="/games/snookerroyale"
+              element={
+                <GameLiveAvatarOverlay gameSlug="snookerroyale">
+                  <SnookerRoyal />
+                </GameLiveAvatarOverlay>
+              }
+            />
             <Route
               path="/games/pollroyale/lobby"
               element={<Navigate to="/games/poolroyale/lobby" replace />}
@@ -264,7 +392,10 @@ export default function App() {
             <Route path="/spin" element={<SpinPage />} />
             <Route path="/admin/influencer" element={<InfluencerAdmin />} />
             <Route path="/tasks" element={<Tasks />} />
-            <Route path="/store" element={<Navigate to="/store/all" replace />} />
+            <Route
+              path="/store"
+              element={<Navigate to="/store/all" replace />}
+            />
             <Route path="/store/:gameSlug" element={<Store />} />
             <Route path="/referral" element={<Referral />} />
             <Route path="/wallet" element={<Wallet />} />

--- a/webapp/src/components/GameLiveAvatarOverlay.jsx
+++ b/webapp/src/components/GameLiveAvatarOverlay.jsx
@@ -1,0 +1,96 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import { AiOutlineMessage } from 'react-icons/ai';
+import LiveVideoChatPanel from './LiveVideoChatPanel.jsx';
+import useLiveVideoChat from '../hooks/useLiveVideoChat.js';
+
+export default function GameLiveAvatarOverlay({ gameSlug, children }) {
+  const { search } = useLocation();
+  const params = useMemo(() => new URLSearchParams(search), [search]);
+  const [liveMode, setLiveMode] = useState(false);
+  const [showLivePanel, setShowLivePanel] = useState(false);
+
+  const displayName = useMemo(() => {
+    if (typeof window === 'undefined') return 'Player';
+    const username = window.localStorage.getItem('telegramUsername');
+    const firstName = window.localStorage.getItem('telegramFirstName');
+    const lastName = window.localStorage.getItem('telegramLastName');
+    return (
+      username || `${firstName || ''} ${lastName || ''}`.trim() || 'Player'
+    );
+  }, []);
+
+  const roomId = useMemo(() => {
+    const accountId =
+      typeof window !== 'undefined'
+        ? window.localStorage.getItem('accountId') || 'guest'
+        : 'guest';
+    const sessionId =
+      params.get('table') ||
+      params.get('tableId') ||
+      params.get('room') ||
+      params.get('roomId') ||
+      'default';
+    return `live-${gameSlug}-${sessionId}-${accountId}`;
+  }, [gameSlug, params]);
+
+  const liveChat = useLiveVideoChat({
+    roomId,
+    displayName,
+    enabled: liveMode
+  });
+
+  useEffect(() => {
+    if (liveMode) {
+      liveChat.startLiveChat();
+      return;
+    }
+    liveChat.stopLiveChat();
+  }, [liveMode, liveChat.startLiveChat, liveChat.stopLiveChat]);
+
+  return (
+    <>
+      {children}
+      <div className="fixed bottom-24 left-2 z-[65] pointer-events-auto flex flex-col gap-3 items-start">
+        <button
+          type="button"
+          onClick={() => {
+            setLiveMode((prev) => !prev);
+            setShowLivePanel((prev) => (!liveMode ? true : prev));
+          }}
+          className={`flex flex-col items-center rounded px-2 py-1 text-[10px] font-semibold ${
+            liveMode
+              ? 'bg-emerald-500/25 text-emerald-100'
+              : 'bg-transparent text-white hover:bg-white/10'
+          }`}
+        >
+          <AiOutlineMessage className="text-xl" />
+          <span>{liveMode ? 'Avatar' : 'Live'}</span>
+        </button>
+      </div>
+      <LiveVideoChatPanel
+        open={showLivePanel && liveMode}
+        onClose={() => {
+          setShowLivePanel(false);
+        }}
+        roomId={roomId}
+        localStream={liveChat.localStream}
+        localMediaState={liveChat.mediaState}
+        remotePeers={liveChat.remotePeers}
+        isConnected={liveChat.isConnected}
+        error={liveChat.error}
+        onStart={() => {
+          setLiveMode(true);
+          liveChat.startLiveChat();
+        }}
+        onStop={() => {
+          liveChat.stopLiveChat();
+          setLiveMode(false);
+          setShowLivePanel(false);
+        }}
+        onToggleMicrophone={liveChat.toggleMicrophone}
+        onToggleCamera={liveChat.toggleCamera}
+      />
+    </>
+  );
+}

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -1,11 +1,18 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
+import { AiOutlineMessage } from 'react-icons/ai';
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 import LeaderboardCard from '../components/LeaderboardCard.jsx';
 import GameTransactionsCard from '../components/GameTransactionsCard.jsx';
+import LiveVideoChatPanel from '../components/LiveVideoChatPanel.jsx';
 import gamesCatalog from '../config/gamesCatalog.js';
 import { getGameThumbnail } from '../config/gameAssets.js';
-import { getOnlineReadiness, fetchOnlineReadinessMap, ONLINE_READINESS_BY_GAME } from '../config/onlineContract.js';
+import {
+  getOnlineReadiness,
+  fetchOnlineReadinessMap,
+  ONLINE_READINESS_BY_GAME
+} from '../config/onlineContract.js';
+import useLiveVideoChat from '../hooks/useLiveVideoChat.js';
 
 const BADGE_STYLES = {
   'Online Ready': 'bg-emerald-500/20 text-emerald-300 border-emerald-400/40',
@@ -16,6 +23,34 @@ const BADGE_STYLES = {
 export default function Games() {
   useTelegramBackButton();
   const [readinessMap, setReadinessMap] = useState(ONLINE_READINESS_BY_GAME);
+  const [liveMode, setLiveMode] = useState(false);
+  const [showLivePanel, setShowLivePanel] = useState(false);
+  const [liveGameSlug, setLiveGameSlug] = useState('');
+
+  const liveDisplayName = useMemo(() => {
+    if (typeof window === 'undefined') return 'Player';
+    const username = window.localStorage.getItem('telegramUsername');
+    const firstName = window.localStorage.getItem('telegramFirstName');
+    const lastName = window.localStorage.getItem('telegramLastName');
+    return (
+      username || `${firstName || ''} ${lastName || ''}`.trim() || 'Player'
+    );
+  }, []);
+
+  const liveChatRoomId = useMemo(() => {
+    if (!liveGameSlug) return '';
+    const accountId =
+      typeof window !== 'undefined'
+        ? window.localStorage.getItem('accountId') || 'guest'
+        : 'guest';
+    return `game-live-${liveGameSlug}-${accountId}`;
+  }, [liveGameSlug]);
+
+  const liveChat = useLiveVideoChat({
+    roomId: liveChatRoomId,
+    displayName: liveDisplayName,
+    enabled: liveMode
+  });
 
   useEffect(() => {
     let active = true;
@@ -27,6 +62,14 @@ export default function Games() {
     };
   }, []);
 
+  useEffect(() => {
+    if (liveMode) {
+      liveChat.startLiveChat();
+      return;
+    }
+    liveChat.stopLiveChat();
+  }, [liveMode, liveChat.startLiveChat, liveChat.stopLiveChat]);
+
   return (
     <div className="relative space-y-4 text-text">
       <h2 className="text-2xl font-bold text-center mt-4">Games Lobby</h2>
@@ -37,7 +80,8 @@ export default function Games() {
         {gamesCatalog.map((game) => {
           const thumbnail = getGameThumbnail(game.slug);
           const readiness = getOnlineReadiness(game.slug, readinessMap);
-          const badgeTone = BADGE_STYLES[readiness.label] || BADGE_STYLES['Coming Soon'];
+          const badgeTone =
+            BADGE_STYLES[readiness.label] || BADGE_STYLES['Coming Soon'];
           return (
             <Link
               key={game.name}
@@ -54,26 +98,83 @@ export default function Games() {
                     event.currentTarget.src = game.image;
                   }}
                 />
-              <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent" />
-              <span className="absolute bottom-1 left-1 right-1 text-center text-xs font-semibold text-white">
-                {game.name}
-              </span>
-            </div>
-            <div className="flex flex-1 flex-col items-center px-2 py-2 text-center">
-              <p className="text-[10px] text-subtext line-clamp-2">{game.description}</p>
-              <span
-                className={`mt-1 inline-flex items-center rounded-full border px-2 py-0.5 text-[9px] font-semibold uppercase tracking-[0.14em] ${badgeTone}`}
-              >
-                {readiness.label}
-              </span>
-              <span className="mt-2 inline-flex items-center gap-1 rounded-full bg-primary/15 px-2 py-0.5 text-[10px] font-semibold text-primary">
-                Enter Lobby
-              </span>
-            </div>
+                <button
+                  type="button"
+                  aria-label={
+                    liveMode && liveGameSlug === game.slug
+                      ? `Disable live chat for ${game.name}`
+                      : `Enable live chat for ${game.name}`
+                  }
+                  onClick={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    if (liveMode && liveGameSlug === game.slug) {
+                      liveChat.stopLiveChat();
+                      setLiveMode(false);
+                      setShowLivePanel(false);
+                      return;
+                    }
+                    setLiveGameSlug(game.slug);
+                    setLiveMode(true);
+                    setShowLivePanel(true);
+                  }}
+                  className={`absolute left-1 top-1 z-10 flex flex-col items-center rounded px-2 py-1 text-[10px] font-semibold ${
+                    liveMode && liveGameSlug === game.slug
+                      ? 'bg-emerald-500/25 text-emerald-100'
+                      : 'bg-black/35 text-white hover:bg-white/10'
+                  }`}
+                >
+                  <AiOutlineMessage className="text-xl" />
+                  <span>
+                    {liveMode && liveGameSlug === game.slug ? 'Avatar' : 'Live'}
+                  </span>
+                </button>
+                <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent" />
+                <span className="absolute bottom-1 left-1 right-1 text-center text-xs font-semibold text-white">
+                  {game.name}
+                </span>
+              </div>
+              <div className="flex flex-1 flex-col items-center px-2 py-2 text-center">
+                <p className="text-[10px] text-subtext line-clamp-2">
+                  {game.description}
+                </p>
+                <span
+                  className={`mt-1 inline-flex items-center rounded-full border px-2 py-0.5 text-[9px] font-semibold uppercase tracking-[0.14em] ${badgeTone}`}
+                >
+                  {readiness.label}
+                </span>
+                <span className="mt-2 inline-flex items-center gap-1 rounded-full bg-primary/15 px-2 py-0.5 text-[10px] font-semibold text-primary">
+                  Enter Lobby
+                </span>
+              </div>
             </Link>
           );
         })}
       </div>
+      <LiveVideoChatPanel
+        open={showLivePanel && Boolean(liveGameSlug)}
+        onClose={() => {
+          setShowLivePanel(false);
+        }}
+        roomId={liveChatRoomId}
+        localStream={liveChat.localStream}
+        localMediaState={liveChat.mediaState}
+        remotePeers={liveChat.remotePeers}
+        isConnected={liveChat.isConnected}
+        error={liveChat.error}
+        onStart={() => {
+          if (!liveGameSlug) return;
+          setLiveMode(true);
+          liveChat.startLiveChat();
+        }}
+        onStop={() => {
+          liveChat.stopLiveChat();
+          setLiveMode(false);
+          setShowLivePanel(false);
+        }}
+        onToggleMicrophone={liveChat.toggleMicrophone}
+        onToggleCamera={liveChat.toggleCamera}
+      />
       <GameTransactionsCard />
       <LeaderboardCard />
     </div>


### PR DESCRIPTION
### Motivation

- Enable live video/avatar chat for players in game lobbies and individual game pages to improve social interaction. 
- Provide a lightweight overlay UI so live chat can be toggled without leaving a game. 
- Surface live chat controls both from the Games catalog and when entering specific game routes.

### Description

- Add new component `GameLiveAvatarOverlay.jsx` which manages room id, display name, and toggling of the live video/avatar panel using the existing `useLiveVideoChat` hook and `LiveVideoChatPanel` component. 
- Wrap multiple game routes in `App.jsx` with `GameLiveAvatarOverlay` so the overlay is available on those game pages, and refactor several `Suspense` usages formatting. 
- Update `Games.jsx` to add a per-game live button in the games grid, manage live chat state (`liveMode`, `liveGameSlug`, etc.), and render `LiveVideoChatPanel` for the selected game using `useLiveVideoChat`. 
- Minor formatting/whitespace tweaks and imports added (`GameLiveAvatarOverlay`, `AiOutlineMessage`, and live chat hook usage). 

### Testing

- Ran linting with `npm run lint` and the linter passed. 
- Ran unit tests with `npm test` and the test suite passed. 
- Built the web app with `npm run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c00ad4c7508329b202cca538d95a71)