### PR TITLE
Add TonPlaygram Arena free HDRI and table placement for Pool Royale

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -2,6 +2,16 @@ import { POOL_ROYALE_CLOTH_VARIANTS } from './poolRoyaleClothPresets.js';
 import { polyHavenThumb, swatchThumbnail } from './storeThumbnails.js';
 
 const POOL_ROYALE_HDRI_PLACEMENTS = Object.freeze({
+  tonplaygramArenaFree: {
+    cameraHeightM: 1.56,
+    groundRadiusMultiplier: 5.4,
+    groundResolution: 112,
+    arenaScale: 1.28,
+    rotationY: Math.PI,
+    tableOffsetX: 0,
+    tableOffsetZ: 0,
+    tableRotationY: Math.PI / 2
+  },
   neonPhotostudio: {
     cameraHeightM: 1.52,
     groundRadiusMultiplier: 3.8,
@@ -95,6 +105,20 @@ const POOL_ROYALE_HDRI_PLACEMENTS = Object.freeze({
 });
 
 const RAW_POOL_ROYALE_HDRI_VARIANTS = [
+  {
+    id: 'tonplaygramArenaFree',
+    name: 'TonPlaygram Arena',
+    assetId: 'tonplaygram_arena_free',
+    assetUrl: '/assets/icons/file_00000000b46071f49c3186dc736411a0.png',
+    preferredResolutions: ['2k'],
+    fallbackResolution: '2k',
+    price: 0,
+    exposure: 1.08,
+    environmentIntensity: 1.06,
+    backgroundIntensity: 1.02,
+    swatches: ['#ef4444', '#0f172a'],
+    description: 'Official TonPlaygram panoramic arena with branded crowd bowl and center marked floor.'
+  },
   {
     id: 'neonPhotostudio',
     name: 'Neon Photo Studio',
@@ -286,7 +310,10 @@ export const POOL_ROYALE_HDRI_VARIANTS = Object.freeze(
     ...variant,
     preferredResolutions: HDRI_RESOLUTION_STACK,
     fallbackResolution: HDRI_RESOLUTION_STACK[0],
-    thumbnail: polyHavenThumb(variant.assetId),
+    thumbnail:
+      variant.thumbnail ||
+      variant.assetUrl ||
+      polyHavenThumb(variant.assetId),
     ...(POOL_ROYALE_HDRI_PLACEMENTS[variant.id] || {})
   }))
 );
@@ -370,6 +397,7 @@ export const POOL_ROYALE_BASE_VARIANTS = Object.freeze([
 })));
 
 export const POOL_ROYALE_DEFAULT_HDRI_ID = 'colorfulStudio';
+export const POOL_ROYALE_DEFAULT_FREE_ARENA_HDRI_ID = 'tonplaygramArenaFree';
 
 export const POOL_ROYALE_DEFAULT_UNLOCKS = Object.freeze({
   tableFinish: ['peelingPaintWeathered'],
@@ -378,7 +406,7 @@ export const POOL_ROYALE_DEFAULT_UNLOCKS = Object.freeze({
   clothColor: [POOL_ROYALE_CLOTH_VARIANTS[0].id],
   cueStyle: ['birch-frost'],
   pocketLiner: ['plastic-black'],
-  environmentHdri: [POOL_ROYALE_DEFAULT_HDRI_ID],
+  environmentHdri: [POOL_ROYALE_DEFAULT_FREE_ARENA_HDRI_ID],
   tableBase: POOL_ROYALE_BASE_VARIANTS.map((variant) => variant.id)
 });
 
@@ -704,7 +732,7 @@ export const POOL_ROYALE_DEFAULT_LOADOUT = [
   },
   {
     type: 'environmentHdri',
-    optionId: POOL_ROYALE_DEFAULT_HDRI_ID,
-    label: POOL_ROYALE_OPTION_LABELS.environmentHdri[POOL_ROYALE_DEFAULT_HDRI_ID]
+    optionId: POOL_ROYALE_DEFAULT_FREE_ARENA_HDRI_ID,
+    label: POOL_ROYALE_OPTION_LABELS.environmentHdri[POOL_ROYALE_DEFAULT_FREE_ARENA_HDRI_ID]
   }
 ];

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -74,6 +74,7 @@ import {
 } from '../../utils/woodMaterials.js';
 import {
   POOL_ROYALE_DEFAULT_HDRI_ID,
+  POOL_ROYALE_DEFAULT_FREE_ARENA_HDRI_ID,
   POOL_ROYALE_DEFAULT_UNLOCKS,
   POOL_ROYALE_HDRI_VARIANTS,
   POOL_ROYALE_HDRI_VARIANT_MAP,
@@ -12581,7 +12582,7 @@ function PoolRoyaleGame({
       'environmentHdri',
       HDRI_STORAGE_KEY,
       (id) => Boolean(POOL_ROYALE_HDRI_VARIANT_MAP[id]),
-      POOL_ROYALE_DEFAULT_HDRI_ID
+      POOL_ROYALE_DEFAULT_FREE_ARENA_HDRI_ID || POOL_ROYALE_DEFAULT_HDRI_ID
     );
   });
   const [hdriResolutionId, setHdriResolutionId] = useState(() => {
@@ -14119,6 +14120,9 @@ function PoolRoyaleGame({
     if (typeof updateEnvironmentRef.current === 'function') {
       updateEnvironmentRef.current(activeEnvironmentVariantRef.current);
     }
+    applyArenaPlacementRef.current?.(activeEnvironmentVariantRef.current);
+    updateDecorTablesRef.current?.(environmentHdriRef.current);
+    updateHospitalityLayoutRef.current?.(environmentHdriRef.current);
   }, [activeEnvironmentHdri, environmentHdriId]);
   useEffect(() => {
     activeTableSlotRef.current = activeTableSlot;
@@ -14285,6 +14289,7 @@ function PoolRoyaleGame({
   const applyBaseRef = useRef(() => {});
   const applyFinishRef = useRef(() => {});
   const applyTableSlotRef = useRef(() => {});
+  const applyArenaPlacementRef = useRef(() => {});
   const updateDecorTablesRef = useRef(() => {});
   const clearDecorTablesRef = useRef(() => {});
   const updateHospitalityLayoutRef = useRef(() => {});
@@ -14299,6 +14304,7 @@ function PoolRoyaleGame({
   const refreshSecondaryTableDecorRef = useRef(() => {});
   const clearSecondaryTableDecorRef = useRef(() => {});
   const secondaryTableDecorRef = useRef({ group: null, dispose: null });
+  const primaryTableRef = useRef(null);
   const secondaryTableRef = useRef(null);
   const secondaryBaseSetterRef = useRef(null);
   const activeTableSlotRef = useRef(initialTableSlot);
@@ -22709,6 +22715,17 @@ const powerRef = useRef(hud.power);
         rendererRef.current
       );
       const SPOTS = spotPositions(baulkZ);
+      primaryTableRef.current = table;
+      const applyArenaPlacement = (variant = activeEnvironmentVariantRef.current) => {
+        const primary = primaryTableRef.current;
+        if (!primary) return;
+        const offsetX = Number.isFinite(variant?.tableOffsetX) ? variant.tableOffsetX : 0;
+        const offsetZ = Number.isFinite(variant?.tableOffsetZ) ? variant.tableOffsetZ : 0;
+        primary.position.set(offsetX, primary.position.y, offsetZ);
+        primary.rotation.y = Number.isFinite(variant?.tableRotationY) ? variant.tableRotationY : 0;
+      };
+      applyArenaPlacementRef.current = applyArenaPlacement;
+      applyArenaPlacement(activeEnvironmentVariantRef.current);
 
       const breakDiceGroup = new THREE.Group();
       table.add(breakDiceGroup);
@@ -31024,6 +31041,7 @@ const powerRef = useRef(hud.power);
         applyBaseRef.current = () => {};
         applyFinishRef.current = () => {};
         applyTableSlotRef.current = () => {};
+        applyArenaPlacementRef.current = () => {};
         clearSecondaryTableDecorRef.current?.();
         refreshSecondaryTableDecorRef.current = () => {};
         clearSecondaryTableDecorRef.current = () => {};
@@ -31041,6 +31059,7 @@ const powerRef = useRef(hud.power);
         chessBoardTextureRef.current = null;
         dartboardTextureRef.current = null;
         applyRailMarkerStyleRef.current = () => {};
+        primaryTableRef.current = null;
         secondaryTableRef.current = null;
         secondaryBaseSetterRef.current = null;
         chalkMeshesRef.current = [];


### PR DESCRIPTION
### Motivation
- Provide a free default Pool Royale arena using the uploaded panoramic asset and make it selectable as the default free HDRI environment. 
- Treat the image as a 360° equirectangular skybox used only for surrounding visuals and lighting, while keeping gameplay objects (table, balls, logic) separate. 
- Ensure the playable table is placed and aligned precisely inside the subtle marked floor area visible in the panorama via per-arena placement metadata. 

### Description
- Added a new HDRI variant `tonplaygramArenaFree` in `webapp/src/config/poolRoyaleInventoryConfig.js` that points to the uploaded panoramic file at `/assets/icons/file_00000000b46071f49c3186dc736411a0.png` and is configured as a free arena with tuned camera/ground/arenaScale and a 2k preferred resolution. 
- Added per-arena placement metadata (`tableOffsetX`, `tableOffsetZ`, `tableRotationY`) in `POOL_ROYALE_HDRI_PLACEMENTS` for the new arena so the gameplay table can be centered and rotated to fit the marked zone. 
- Updated HDRI thumbnail fallback logic so image-based local/custom variants can supply their own `assetUrl` as a thumbnail instead of requiring a PolyHaven thumb. 
- Introduced `POOL_ROYALE_DEFAULT_FREE_ARENA_HDRI_ID` and switched Pool Royale default unlock/loadout to use the new free arena while preserving the existing shared default id for other games. 
- Wired Pool Royale initialization in `webapp/src/pages/Games/PoolRoyale.jsx` to: prefer the new free default when resolving stored selection, create `primaryTableRef` and `applyArenaPlacementRef`, apply the placement metadata to the primary gameplay table at build time and re-apply when the active environment changes, and clear/reset the placement on dispose. 

### Testing
- Ran `npm run -s lint -- webapp/src/config/poolRoyaleInventoryConfig.js webapp/src/pages/Games/PoolRoyale.jsx` which completed but emitted a React-version lint warning. 
- Ran `npx eslint webapp/src/config/poolRoyaleInventoryConfig.js webapp/src/pages/Games/PoolRoyale.jsx` which reported the files are ignored by project ignore settings (informational). 
- Ran `npx eslint --no-ignore webapp/src/config/poolRoyaleInventoryConfig.js webapp/src/pages/Games/PoolRoyale.jsx` which reported existing repository style errors (27 errors); these are pre-existing style issues surfaced when ignore is disabled and were not introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c02a07a3a08329a1112bf8588809e5)