### PR TITLE
Fix HDRI mint failures by shrinking optimized upload payloads

### DIFF
--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -1350,22 +1350,56 @@ export default function Store() {
           const objectUrl = URL.createObjectURL(file);
           image.onload = () => {
             try {
-              const maxWidth = 4096;
-              const maxHeight = 2048;
-              const widthRatio = maxWidth / image.width;
-              const heightRatio = maxHeight / image.height;
-              const scale = Math.min(1, widthRatio, heightRatio);
-              const targetWidth = Math.max(1, Math.round(image.width * scale));
-              const targetHeight = Math.max(1, Math.round(image.height * scale));
-              const canvas = document.createElement('canvas');
-              canvas.width = targetWidth;
-              canvas.height = targetHeight;
-              const context = canvas.getContext('2d');
-              if (!context) {
-                throw new Error('Canvas context unavailable');
+              const createOptimizedDataUrl = ({
+                maxWidth = 2048,
+                maxHeight = 1024,
+                quality = 0.82,
+                maxBytes = 1_200_000,
+                minBytes = 550_000
+              } = {}) => {
+                let targetWidth = image.width;
+                let targetHeight = image.height;
+                const widthRatio = maxWidth / image.width;
+                const heightRatio = maxHeight / image.height;
+                const scale = Math.min(1, widthRatio, heightRatio);
+                targetWidth = Math.max(1, Math.round(image.width * scale));
+                targetHeight = Math.max(1, Math.round(image.height * scale));
+
+                const canvas = document.createElement('canvas');
+                const context = canvas.getContext('2d');
+                if (!context) {
+                  throw new Error('Canvas context unavailable');
+                }
+
+                let attempts = 0;
+                let currentQuality = quality;
+                let output = '';
+                while (attempts < 8) {
+                  attempts += 1;
+                  canvas.width = targetWidth;
+                  canvas.height = targetHeight;
+                  context.clearRect(0, 0, targetWidth, targetHeight);
+                  context.drawImage(image, 0, 0, targetWidth, targetHeight);
+                  output = canvas.toDataURL('image/jpeg', currentQuality);
+                  const approxBytes = Math.ceil((output.length * 3) / 4);
+
+                  if (approxBytes <= maxBytes || (approxBytes <= minBytes && attempts >= 2)) {
+                    return output;
+                  }
+                  if (currentQuality > 0.58) {
+                    currentQuality = Math.max(0.58, currentQuality - 0.08);
+                    continue;
+                  }
+                  targetWidth = Math.max(768, Math.round(targetWidth * 0.82));
+                  targetHeight = Math.max(384, Math.round(targetHeight * 0.82));
+                }
+                return output;
+              };
+
+              const optimizedDataUrl = createOptimizedDataUrl();
+              if (!optimizedDataUrl) {
+                throw new Error('Failed to optimize image');
               }
-              context.drawImage(image, 0, 0, targetWidth, targetHeight);
-              const optimizedDataUrl = canvas.toDataURL('image/jpeg', 0.82);
               resolve({
                 previewUrl: optimizedDataUrl,
                 mintDataUrl: optimizedDataUrl


### PR DESCRIPTION
### Motivation
- Users could preview custom HDRIs but fail to mint them because the optimized data URL payloads were too large for storage/transfer during the publish flow. 
- The change aims to reduce payload size for mobile/large uploads so mint/publish steps succeed without changing UX.

### Description
- Replaced the single-pass export in the HDRI optimizer with an adaptive compression pipeline that reduces JPEG quality and progressively downscales until a byte-budget target is met. 
- Implemented retry logic (up to 8 passes) and byte-size heuristics inside `optimizeHdriImage` to produce `previewUrl` and `mintDataUrl` with smaller payloads. 
- Preserved existing fallback behavior to raw data URLs when optimization or canvas operations fail. 
- Changed file: `webapp/src/pages/Store.jsx` (updated HDRI optimization logic and usage points remain unchanged).

### Testing
- Ran ESLint checks for the modified file; project ignore rules caused the file to be skipped by the repo-wide lint run and `npx eslint --no-ignore webapp/src/pages/Store.jsx` reported only a warning. 
- Performed a full webapp production build with `npm --prefix webapp run build`, and the build completed successfully. 
- No other automated tests were modified or run in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c02f495a748329a2cf7721b90ffd22)