### PR TITLE
Fix HDRI mint failures caused by oversized local storage payloads

### DIFF
--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -1350,8 +1350,8 @@ export default function Store() {
           const objectUrl = URL.createObjectURL(file);
           image.onload = () => {
             try {
-              const maxWidth = 4096;
-              const maxHeight = 2048;
+              const maxWidth = 2048;
+              const maxHeight = 1024;
               const widthRatio = maxWidth / image.width;
               const heightRatio = maxHeight / image.height;
               const scale = Math.min(1, widthRatio, heightRatio);
@@ -1365,7 +1365,7 @@ export default function Store() {
                 throw new Error('Canvas context unavailable');
               }
               context.drawImage(image, 0, 0, targetWidth, targetHeight);
-              const optimizedDataUrl = canvas.toDataURL('image/jpeg', 0.82);
+              const optimizedDataUrl = canvas.toDataURL('image/jpeg', 0.72);
               resolve({
                 previewUrl: optimizedDataUrl,
                 mintDataUrl: optimizedDataUrl
@@ -1524,18 +1524,34 @@ export default function Store() {
         acc[slug] = `custom-hdri:${createdAt}:${slug}`;
         return acc;
       }, {});
-      const entry = saveCustomHdriEntry({
-        id: `custom-hdri-${createdAt}`,
-        name: hdriDraft.name.trim(),
-        type: 'environmentHdri',
-        price: Number(hdriDraft.storePrice || 0),
-        createdBy: accountId || 'guest',
-        visibility: hdriDraft.visibility,
-        supportedGames: hdriSelectedGames,
-        optionIdByGame,
-        thumbnailUrl: uploadedImageDataUrl,
-        environmentUrl: uploadedImageDataUrl
-      });
+      let entry = null;
+      try {
+        entry = saveCustomHdriEntry({
+          id: `custom-hdri-${createdAt}`,
+          name: hdriDraft.name.trim(),
+          type: 'environmentHdri',
+          price: Number(hdriDraft.storePrice || 0),
+          createdBy: accountId || 'guest',
+          visibility: hdriDraft.visibility,
+          supportedGames: hdriSelectedGames,
+          optionIdByGame,
+          thumbnailUrl: uploadedImageDataUrl,
+          environmentUrl: uploadedImageDataUrl
+        });
+      } catch (error) {
+        if (
+          typeof error?.name === 'string' &&
+          (error.name === 'QuotaExceededError' || error.name === 'NS_ERROR_DOM_QUOTA_REACHED')
+        ) {
+          setTransactionState('error');
+          setTransactionStatus(
+            'Could not save HDRI on this device (storage full). Remove old uploads or clear app cache, then try again.'
+          );
+          setHdriPublishing(false);
+          return;
+        }
+        throw error;
+      }
       await Promise.all(
         hdriSelectedGames.map((slug) => {
           const optionId = optionIdByGame[slug];
@@ -1582,9 +1598,12 @@ export default function Store() {
     } catch (error) {
       console.warn('HDRI publish failed', error);
       setTransactionState('error');
-      setTransactionStatus(
-        'Could not mint this HDRI right now. Please re-check your upload and try again.'
-      );
+      const message =
+        typeof error?.message === 'string' &&
+        error.message.toLowerCase().includes('quota')
+          ? 'Could not save HDRI on this device (storage full). Remove old uploads or clear app cache, then try again.'
+          : 'Could not mint this HDRI right now. Please try again in a few seconds.';
+      setTransactionStatus(message);
     } finally {
       setHdriPublishing(false);
     }


### PR DESCRIPTION
### Motivation
- Users could preview HDRI uploads but fail to mint because large optimized images exceeded browser/device localStorage quota and produced a generic "Could not mint" error.
- The change aims to reduce persisted payload size and surface clear, actionable errors when device storage is full.

### Description
- Reduced client-side HDRI optimization target from `4096x2048` to `2048x1024` and lowered JPEG quality from `0.82` to `0.72` to produce much smaller data URLs before persistence and minting (`optimizeHdriImage` in `webapp/src/pages/Store.jsx`).
- Wrapped the call to `saveCustomHdriEntry(...)` in a `try/catch` to detect quota failures (`QuotaExceededError` and `NS_ERROR_DOM_QUOTA_REACHED`) and return a clear storage-full error state instead of proceeding to a misleading mint failure.
- Added an explicit quota-aware publish error message that reports "Could not save HDRI on this device (storage full)..." for quota-related exceptions and falls back to a generic retry message for other errors.

### Testing
- Ran the production build with `npm --prefix webapp run build` and the build completed successfully (warnings about large chunks were reported but build succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c02f495a748329a2cf7721b90ffd22)