### PR TITLE
Persist purchased custom HDRIs into local catalog so they appear in game setup menus

### DIFF
--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -2516,6 +2516,43 @@ export default function Store() {
         Promise.allSettled(backgroundSyncTasks).catch(() => {});
       }
 
+      const purchasedCustomHdriListings = purchasable.filter(
+        (item) =>
+          item?.type === 'environmentHdri' &&
+          typeof item?.optionId === 'string' &&
+          item.optionId.startsWith('custom-hdri:') &&
+          typeof item?.environmentUrl === 'string' &&
+          item.environmentUrl
+      );
+      if (purchasedCustomHdriListings.length) {
+        purchasedCustomHdriListings.forEach((item) => {
+          const slug = String(item.slug || '').toLowerCase();
+          if (!slug) return;
+          const optionIdByGame =
+            item.optionIdByGame && typeof item.optionIdByGame === 'object'
+              ? { ...item.optionIdByGame, [slug]: item.optionId }
+              : { [slug]: item.optionId };
+          saveCustomHdriEntry({
+            id:
+              item.id && String(item.id).startsWith('custom-hdri-')
+                ? item.id
+                : `custom-hdri-${Date.now()}-${slug}`,
+            name: item.name || item.displayLabel || 'Custom HDRI',
+            description: item.description || '',
+            createdAt: Number(item.createdAt || Date.now()),
+            createdBy: resolvedAccountId,
+            visibility: 'private',
+            supportedGames: Array.from(new Set([slug])),
+            optionIdByGame,
+            environmentUrl: item.environmentUrl,
+            thumbnailUrl:
+              item.thumbnailUrl || item.thumbnail || item.environmentUrl,
+            storePrice: Number(item.price || 0)
+          });
+        });
+        setUserListings(getCustomHdriCatalog(resolvedAccountId));
+      }
+
       const purchasedTrainingAttempts = purchasable.reduce((sum, item) => {
         if (item.slug !== 'poolroyale' || item.type !== 'poolTrainingAttempt')
           return sum;


### PR DESCRIPTION
### Motivation
- Players who purchase custom HDRI listings had the asset added to inventory but the in-game table setup builds its HDRI options from the built-in variants plus the local custom HDRI catalog, so purchased HDRIs could be owned yet invisible in the menu. 
- The change ensures storefront purchases for custom HDRIs register into the same catalog the game UIs read from so the selection immediately appears in table setup.

### Description
- Added logic in `webapp/src/pages/Store.jsx` to detect purchased marketplace entries that are custom HDRIs (`item.type === 'environmentHdri'`, `optionId` starts with `custom-hdri:` and a valid `environmentUrl`) and persist them into the local catalog. 
- New code uses `saveCustomHdriEntry` to store the listing metadata (id, name, description, `createdBy`, `visibility: 'private'`, `supportedGames`, `optionIdByGame`, `environmentUrl`, `thumbnailUrl`, and `storePrice`).
- After saving entries the store refreshes `userListings` by calling `getCustomHdriCatalog(resolvedAccountId)` so the newly purchased HDRIs are available during the same session for the game setup menus to display.

### Testing
- Ran the targeted unit test: `npm run -s test -- test/storeDelivery.test.js --runInBand` and it passed (all tests in that file succeeded). 
- Ran lint on the modified file with `npx eslint webapp/src/pages/Store.jsx` and `npx eslint --no-ignore webapp/src/pages/Store.jsx`, which completed but reported the file is ignored by the project ESLint pattern (warning only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c04446d9308329b7d201a994fa7767)