### PR TITLE
Add GameLiveAvatarOverlay and per-game live chat UI

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -38,14 +38,30 @@ import TexasHoldemLobby from './pages/Games/TexasHoldemLobby.jsx';
 import DominoRoyal from './pages/Games/DominoRoyal.jsx';
 import DominoRoyalLobby from './pages/Games/DominoRoyalLobby.jsx';
 
-const ChessBattleRoyal = React.lazy(() => import('./pages/Games/ChessBattleRoyal.jsx'));
-const ChessBattleRoyalLobby = React.lazy(() => import('./pages/Games/ChessBattleRoyalLobby.jsx'));
-const CheckersBattleRoyal = React.lazy(() => import('./pages/Games/CheckersBattleRoyal.jsx'));
-const CheckersBattleRoyalLobby = React.lazy(() => import('./pages/Games/CheckersBattleRoyalLobby.jsx'));
-const FourInRowRoyal = React.lazy(() => import('./pages/Games/FourInRowRoyal.jsx'));
-const FourInRowRoyalLobby = React.lazy(() => import('./pages/Games/FourInRowRoyalLobby.jsx'));
-const TavullBattleRoyal = React.lazy(() => import('./pages/Games/TavullBattleRoyal.jsx'));
-const TavullBattleRoyalLobby = React.lazy(() => import('./pages/Games/TavullBattleRoyalLobby.jsx'));
+const ChessBattleRoyal = React.lazy(
+  () => import('./pages/Games/ChessBattleRoyal.jsx')
+);
+const ChessBattleRoyalLobby = React.lazy(
+  () => import('./pages/Games/ChessBattleRoyalLobby.jsx')
+);
+const CheckersBattleRoyal = React.lazy(
+  () => import('./pages/Games/CheckersBattleRoyal.jsx')
+);
+const CheckersBattleRoyalLobby = React.lazy(
+  () => import('./pages/Games/CheckersBattleRoyalLobby.jsx')
+);
+const FourInRowRoyal = React.lazy(
+  () => import('./pages/Games/FourInRowRoyal.jsx')
+);
+const FourInRowRoyalLobby = React.lazy(
+  () => import('./pages/Games/FourInRowRoyalLobby.jsx')
+);
+const TavullBattleRoyal = React.lazy(
+  () => import('./pages/Games/TavullBattleRoyal.jsx')
+);
+const TavullBattleRoyalLobby = React.lazy(
+  () => import('./pages/Games/TavullBattleRoyalLobby.jsx')
+);
 import PoolRoyale from './pages/Games/PoolRoyale.jsx';
 import PoolRoyaleLobby from './pages/Games/PoolRoyaleLobby.jsx';
 import PoolRoyaleCareer from './pages/Games/PoolRoyaleCareer.jsx';
@@ -56,6 +72,7 @@ import StoreThumbnailStudioPoolRoyale from './pages/Tools/StoreThumbnailStudioPo
 
 import Layout from './components/Layout.jsx';
 import TonConnectSync from './components/TonConnectSync.jsx';
+import GameLiveAvatarOverlay from './components/GameLiveAvatarOverlay.jsx';
 import useTelegramAuth from './hooks/useTelegramAuth.js';
 import useTelegramFullscreen from './hooks/useTelegramFullscreen.js';
 import useMobileFullscreen from './hooks/useMobileFullscreen.js';
@@ -69,10 +86,14 @@ export default function App() {
   // TonConnect can hang if the manifest URL/origin mismatch.
   // Keep this as early as possible.
   if (typeof window !== 'undefined') {
-    const canonical = import.meta.env.VITE_PUBLIC_APP_URL || 'https://tonplaygram-bot.onrender.com';
+    const canonical =
+      import.meta.env.VITE_PUBLIC_APP_URL ||
+      'https://tonplaygram-bot.onrender.com';
     try {
       const canonicalUrl = new URL(canonical);
-      const isLocalhost = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
+      const isLocalhost =
+        window.location.hostname === 'localhost' ||
+        window.location.hostname === '127.0.0.1';
       if (!isLocalhost && canonicalUrl.origin !== window.location.origin) {
         const next = new URL(window.location.href);
         next.protocol = canonicalUrl.protocol;
@@ -92,8 +113,10 @@ export default function App() {
   useNativePushNotifications();
 
   const canonicalOrigin = useMemo(
-    () => import.meta.env.VITE_PUBLIC_APP_URL || 'https://tonplaygram-bot.onrender.com',
-    [],
+    () =>
+      import.meta.env.VITE_PUBLIC_APP_URL ||
+      'https://tonplaygram-bot.onrender.com',
+    []
   );
 
   // Always load the TonConnect manifest from the canonical origin.
@@ -119,9 +142,9 @@ export default function App() {
       // "back" works across regular browsers + Telegram webview.
       returnStrategy: 'back',
       // Where TonConnect should return the user after approving in-wallet.
-      twaReturnUrl: isTelegramWebView() ? telegramReturnUrl : returnUrl,
+      twaReturnUrl: isTelegramWebView() ? telegramReturnUrl : returnUrl
     }),
-    [returnUrl, telegramReturnUrl],
+    [returnUrl, telegramReturnUrl]
   );
 
   return (
@@ -142,79 +165,145 @@ export default function App() {
             <Route path="/games" element={<Games />} />
             <Route path="/games/transactions" element={<GameTransactions />} />
             <Route path="/games/:game/lobby" element={<Lobby />} />
-            <Route path="/games/snake" element={<SnakeAndLadder />} />
+            <Route
+              path="/games/snake"
+              element={
+                <GameLiveAvatarOverlay gameSlug="snake">
+                  <SnakeAndLadder />
+                </GameLiveAvatarOverlay>
+              }
+            />
             <Route path="/games/snake/mp" element={<SnakeMultiplayer />} />
             <Route path="/games/snake/results" element={<SnakeResults />} />
             <Route path="/games/goalrush/lobby" element={<GoalRushLobby />} />
-            <Route path="/games/goalrush" element={<GoalRush />} />
+            <Route
+              path="/games/goalrush"
+              element={
+                <GameLiveAvatarOverlay gameSlug="goalrush">
+                  <GoalRush />
+                </GameLiveAvatarOverlay>
+              }
+            />
             <Route path="/games/airhockey/lobby" element={<AirHockeyLobby />} />
             <Route path="/games/airhockey" element={<AirHockey />} />
             <Route
               path="/games/chessbattleroyal/lobby"
-              element={(
-                <Suspense fallback={<div className="p-4 text-center">Loading Chess Lobby…</div>}>
+              element={
+                <Suspense
+                  fallback={
+                    <div className="p-4 text-center">Loading Chess Lobby…</div>
+                  }
+                >
                   <ChessBattleRoyalLobby />
                 </Suspense>
-              )}
+              }
             />
             <Route
               path="/games/chessbattleroyal"
-              element={(
-                <Suspense fallback={<div className="p-4 text-center">Loading Chess Battle Royal…</div>}>
-                  <ChessBattleRoyal />
+              element={
+                <Suspense
+                  fallback={
+                    <div className="p-4 text-center">
+                      Loading Chess Battle Royal…
+                    </div>
+                  }
+                >
+                  <GameLiveAvatarOverlay gameSlug="chessbattleroyal">
+                    <ChessBattleRoyal />
+                  </GameLiveAvatarOverlay>
                 </Suspense>
-              )}
+              }
             />
 
             <Route
               path="/games/checkersbattleroyal/lobby"
-              element={(
-                <Suspense fallback={<div className="p-4 text-center">Loading Checkers Lobby…</div>}>
+              element={
+                <Suspense
+                  fallback={
+                    <div className="p-4 text-center">
+                      Loading Checkers Lobby…
+                    </div>
+                  }
+                >
                   <CheckersBattleRoyalLobby />
                 </Suspense>
-              )}
+              }
             />
             <Route
               path="/games/checkersbattleroyal"
-              element={(
-                <Suspense fallback={<div className="p-4 text-center">Loading Checkers Battle Royal…</div>}>
-                  <CheckersBattleRoyal />
+              element={
+                <Suspense
+                  fallback={
+                    <div className="p-4 text-center">
+                      Loading Checkers Battle Royal…
+                    </div>
+                  }
+                >
+                  <GameLiveAvatarOverlay gameSlug="checkersbattleroyal">
+                    <CheckersBattleRoyal />
+                  </GameLiveAvatarOverlay>
                 </Suspense>
-              )}
+              }
             />
 
             <Route
               path="/games/fourinrowroyale/lobby"
-              element={(
-                <Suspense fallback={<div className="p-4 text-center">Loading 4 in a Row Lobby…</div>}>
+              element={
+                <Suspense
+                  fallback={
+                    <div className="p-4 text-center">
+                      Loading 4 in a Row Lobby…
+                    </div>
+                  }
+                >
                   <FourInRowRoyalLobby />
                 </Suspense>
-              )}
+              }
             />
             <Route
               path="/games/fourinrowroyale"
-              element={(
-                <Suspense fallback={<div className="p-4 text-center">Loading 4 in a Row…</div>}>
-                  <FourInRowRoyal />
+              element={
+                <Suspense
+                  fallback={
+                    <div className="p-4 text-center">Loading 4 in a Row…</div>
+                  }
+                >
+                  <GameLiveAvatarOverlay gameSlug="fourinrowroyale">
+                    <FourInRowRoyal />
+                  </GameLiveAvatarOverlay>
                 </Suspense>
-              )}
+              }
             />
 
             <Route
               path="/games/tavullbattleroyal/lobby"
-              element={(
-                <Suspense fallback={<div className="p-4 text-center">Loading Backgammon Lobby…</div>}>
+              element={
+                <Suspense
+                  fallback={
+                    <div className="p-4 text-center">
+                      Loading Backgammon Lobby…
+                    </div>
+                  }
+                >
                   <TavullBattleRoyalLobby />
                 </Suspense>
-              )}
+              }
             />
             <Route
               path="/games/tavullbattleroyal"
-              element={(
-                <Suspense fallback={<div className="p-4 text-center">Loading Backgammon Royal…</div>}>
-                  <TavullBattleRoyal />
+              element={
+                <Suspense
+                  fallback={
+                    <div className="p-4 text-center">
+                      Loading Backgammon Royal…
+                    </div>
+                  }
+                >
+                  <GameLiveAvatarOverlay gameSlug="tavullbattleroyal">
+                    <TavullBattleRoyal />
+                  </GameLiveAvatarOverlay>
                 </Suspense>
-              )}
+              }
             />
             <Route
               path="/games/ludobattleroyal/lobby"
@@ -222,23 +311,48 @@ export default function App() {
             />
             <Route
               path="/games/ludobattleroyal"
-              element={<LudoBattleRoyal />}
+              element={
+                <GameLiveAvatarOverlay gameSlug="ludobattleroyal">
+                  <LudoBattleRoyal />
+                </GameLiveAvatarOverlay>
+              }
             />
             <Route
               path="/games/texasholdem/lobby"
               element={<TexasHoldemLobby />}
             />
-            <Route path="/games/texasholdem" element={<TexasHoldem />} />
+            <Route
+              path="/games/texasholdem"
+              element={
+                <GameLiveAvatarOverlay gameSlug="texasholdem">
+                  <TexasHoldem />
+                </GameLiveAvatarOverlay>
+              }
+            />
             <Route
               path="/games/domino-royal/lobby"
               element={<DominoRoyalLobby />}
             />
-            <Route path="/games/domino-royal" element={<DominoRoyal />} />
+            <Route
+              path="/games/domino-royal"
+              element={
+                <GameLiveAvatarOverlay gameSlug="domino-royal">
+                  <DominoRoyal />
+                </GameLiveAvatarOverlay>
+              }
+            />
             <Route
               path="/games/murlanroyale/lobby"
               element={<MurlanRoyaleLobby />}
             />
-            <Route path="/games/murlanroyale" element={<MurlanRoyale />} />
+            <Route
+              path="/games/murlanroyale"
+              element={
+                <GameLiveAvatarOverlay gameSlug="murlanroyale">
+                  <MurlanRoyale />
+                </GameLiveAvatarOverlay>
+              }
+            />
             <Route
               path="/games/poolroyale/lobby"
               element={<PoolRoyaleLobby />}
@@ -247,12 +361,26 @@ export default function App() {
               path="/games/poolroyale/career"
               element={<PoolRoyaleCareer />}
             />
-            <Route path="/games/poolroyale" element={<PoolRoyale />} />
+            <Route
+              path="/games/poolroyale"
+              element={
+                <GameLiveAvatarOverlay gameSlug="poolroyale">
+                  <PoolRoyale />
+                </GameLiveAvatarOverlay>
+              }
+            />
             <Route
               path="/games/snookerroyale/lobby"
               element={<SnookerRoyalLobby />}
             />
-            <Route path="/games/snookerroyale" element={<SnookerRoyal />} />
+            <Route
+              path="/games/snookerroyale"
+              element={
+                <GameLiveAvatarOverlay gameSlug="snookerroyale">
+                  <SnookerRoyal />
+                </GameLiveAvatarOverlay>
+              }
+            />
             <Route
               path="/games/pollroyale/lobby"
               element={<Navigate to="/games/poolroyale/lobby" replace />}
@@ -264,7 +392,10 @@ export default function App() {
             <Route path="/spin" element={<SpinPage />} />
             <Route path="/admin/influencer" element={<InfluencerAdmin />} />
             <Route path="/tasks" element={<Tasks />} />
-            <Route path="/store" element={<Navigate to="/store/all" replace />} />
+            <Route
+              path="/store"
+              element={<Navigate to="/store/all" replace />}
+            />
             <Route path="/store/:gameSlug" element={<Store />} />
             <Route path="/referral" element={<Referral />} />
             <Route path="/wallet" element={<Wallet />} />

--- a/webapp/src/components/GameLiveAvatarOverlay.jsx
+++ b/webapp/src/components/GameLiveAvatarOverlay.jsx
@@ -1,0 +1,233 @@
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import useLiveVideoChat from '../hooks/useLiveVideoChat.js';
+
+const AVATAR_ANCHOR_SELECTORS = [
+  '[data-self-player="true"] img',
+  '[data-self-player="true"] .avatar',
+  '[data-self-player="true"]',
+  '[data-is-user="true"] img',
+  '[data-is-user="true"]',
+  '[data-you="true"] img',
+  '[data-you="true"]',
+  '[data-player-index="0"] img',
+  '[data-player-index="0"] .avatar',
+  '[data-player-index="0"]',
+  '.player-avatar.you img',
+  '.player-avatar.you',
+  '.hud-player-you img',
+  '.hud-player-you',
+  'img[alt="You"]',
+  '[aria-label="You"]'
+];
+
+export default function GameLiveAvatarOverlay({ gameSlug, children }) {
+  const { search } = useLocation();
+  const params = useMemo(() => new URLSearchParams(search), [search]);
+  const [liveMode, setLiveMode] = useState(false);
+  const [anchorElement, setAnchorElement] = useState(null);
+  const localVideoRef = useRef(null);
+  const [overlayRect, setOverlayRect] = useState({
+    top: 96,
+    left: 12,
+    width: 44,
+    height: 44
+  });
+
+  const displayName = useMemo(() => {
+    if (typeof window === 'undefined') return 'Player';
+    const username = window.localStorage.getItem('telegramUsername');
+    const firstName = window.localStorage.getItem('telegramFirstName');
+    const lastName = window.localStorage.getItem('telegramLastName');
+    return (
+      username || `${firstName || ''} ${lastName || ''}`.trim() || 'Player'
+    );
+  }, []);
+
+  const roomId = useMemo(() => {
+    const accountId =
+      typeof window !== 'undefined'
+        ? window.localStorage.getItem('accountId') || 'guest'
+        : 'guest';
+    const sessionId =
+      params.get('table') ||
+      params.get('tableId') ||
+      params.get('room') ||
+      params.get('roomId') ||
+      'default';
+    return `live-${gameSlug}-${sessionId}-${accountId}`;
+  }, [gameSlug, params]);
+
+  const liveChat = useLiveVideoChat({
+    roomId,
+    displayName,
+    enabled: liveMode
+  });
+
+  useEffect(() => {
+    if (liveMode) {
+      liveChat.startLiveChat();
+      return;
+    }
+    liveChat.stopLiveChat();
+  }, [liveMode, liveChat.startLiveChat, liveChat.stopLiveChat]);
+
+  useEffect(() => {
+    if (!localVideoRef.current) return;
+    localVideoRef.current.srcObject = liveChat.localStream || null;
+  }, [liveChat.localStream]);
+
+  useLayoutEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+
+    let frameId = 0;
+    let resizeObserver;
+
+    const scoreAnchor = (element, rect) => {
+      let score = 0;
+      const marker =
+        `${element.getAttribute('data-self-player') || ''} ${element.getAttribute('data-player-index') || ''} ${element.className || ''} ${element.getAttribute('aria-label') || ''} ${element.getAttribute('alt') || ''}`.toLowerCase();
+      if (marker.includes('self')) score += 100;
+      if (marker.includes('you')) score += 80;
+      if (marker.includes('player-index') || marker.includes('0')) score += 40;
+      if (rect.top > window.innerHeight * 0.45) score += 25;
+      if (rect.left < window.innerWidth * 0.65) score += 15;
+      score += Math.min(rect.width, rect.height);
+      return score;
+    };
+
+    const findAvatarAnchor = () => {
+      let bestNode = null;
+      let bestRect = null;
+      let bestScore = -Infinity;
+      const seen = new Set();
+      for (const selector of AVATAR_ANCHOR_SELECTORS) {
+        const nodes = document.querySelectorAll(selector);
+        for (const candidate of nodes) {
+          if (seen.has(candidate)) continue;
+          seen.add(candidate);
+          const rect = candidate.getBoundingClientRect();
+          if (rect.width <= 8 || rect.height <= 8) continue;
+          const score = scoreAnchor(candidate, rect);
+          if (score > bestScore) {
+            bestScore = score;
+            bestRect = rect;
+            bestNode = candidate;
+          }
+        }
+      }
+      return { rect: bestRect, node: bestNode };
+    };
+
+    const applyRect = () => {
+      const { rect, node } = findAvatarAnchor();
+      if (!rect) return;
+      const FRAME_SCALE = 1.2;
+      const width = Math.max(Math.round(rect.width * FRAME_SCALE), 32);
+      const height = Math.max(Math.round(rect.height * FRAME_SCALE), 32);
+      const left = Math.max(
+        Math.round(rect.left - (width - rect.width) / 2),
+        0
+      );
+      const top = Math.max(
+        Math.round(rect.top - (height - rect.height) / 2),
+        0
+      );
+      setAnchorElement(node);
+      setOverlayRect((prev) => {
+        if (
+          Math.abs(prev.top - top) <= 1 &&
+          Math.abs(prev.left - left) <= 1 &&
+          Math.abs(prev.width - width) <= 1 &&
+          Math.abs(prev.height - height) <= 1
+        ) {
+          return prev;
+        }
+        return { top, left, width, height };
+      });
+    };
+
+    const scheduleApply = () => {
+      cancelAnimationFrame(frameId);
+      frameId = requestAnimationFrame(applyRect);
+    };
+
+    const mutationObserver = new MutationObserver(scheduleApply);
+    mutationObserver.observe(document.body, {
+      childList: true,
+      subtree: true,
+      attributes: true
+    });
+
+    resizeObserver = new ResizeObserver(scheduleApply);
+    resizeObserver.observe(document.body);
+    window.addEventListener('resize', scheduleApply);
+    window.addEventListener('orientationchange', scheduleApply);
+    window.addEventListener('scroll', scheduleApply, true);
+
+    scheduleApply();
+
+    return () => {
+      cancelAnimationFrame(frameId);
+      mutationObserver.disconnect();
+      resizeObserver?.disconnect();
+      window.removeEventListener('resize', scheduleApply);
+      window.removeEventListener('orientationchange', scheduleApply);
+      window.removeEventListener('scroll', scheduleApply, true);
+    };
+  }, [gameSlug, search]);
+
+  useEffect(() => {
+    if (!anchorElement) return undefined;
+    const onToggle = (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      setLiveMode((prev) => !prev);
+    };
+    anchorElement.style.cursor = 'pointer';
+    anchorElement.addEventListener('click', onToggle);
+    return () => {
+      anchorElement.removeEventListener('click', onToggle);
+    };
+  }, [anchorElement]);
+
+  useEffect(() => {
+    if (!anchorElement) return undefined;
+    const previousVisibility = anchorElement.style.visibility;
+    if (liveMode) anchorElement.style.visibility = 'hidden';
+    else anchorElement.style.visibility = previousVisibility || '';
+    return () => {
+      anchorElement.style.visibility = previousVisibility || '';
+    };
+  }, [anchorElement, liveMode]);
+
+  return (
+    <>
+      {children}
+      {liveMode && anchorElement ? (
+        <button
+          type="button"
+          aria-label="Turn off live avatar video"
+          onClick={() => setLiveMode(false)}
+          className="fixed z-[65] overflow-hidden rounded-full border border-emerald-300 bg-black/30"
+          style={{
+            top: `${overlayRect.top}px`,
+            left: `${overlayRect.left}px`,
+            width: `${overlayRect.width}px`,
+            height: `${overlayRect.height}px`
+          }}
+        >
+          <video
+            ref={(node) => {
+              localVideoRef.current = node;
+            }}
+            autoPlay
+            muted
+            playsInline
+            className="h-full w-full object-cover scale-x-[-1]"
+          />
+        </button>
+      ) : null}
+    </>
+  );
+}

--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -1,11 +1,18 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
+import { AiOutlineMessage } from 'react-icons/ai';
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 import LeaderboardCard from '../components/LeaderboardCard.jsx';
 import GameTransactionsCard from '../components/GameTransactionsCard.jsx';
+import LiveVideoChatPanel from '../components/LiveVideoChatPanel.jsx';
 import gamesCatalog from '../config/gamesCatalog.js';
 import { getGameThumbnail } from '../config/gameAssets.js';
-import { getOnlineReadiness, fetchOnlineReadinessMap, ONLINE_READINESS_BY_GAME } from '../config/onlineContract.js';
+import {
+  getOnlineReadiness,
+  fetchOnlineReadinessMap,
+  ONLINE_READINESS_BY_GAME
+} from '../config/onlineContract.js';
+import useLiveVideoChat from '../hooks/useLiveVideoChat.js';
 
 const BADGE_STYLES = {
   'Online Ready': 'bg-emerald-500/20 text-emerald-300 border-emerald-400/40',
@@ -16,6 +23,34 @@ const BADGE_STYLES = {
 export default function Games() {
   useTelegramBackButton();
   const [readinessMap, setReadinessMap] = useState(ONLINE_READINESS_BY_GAME);
+  const [liveMode, setLiveMode] = useState(false);
+  const [showLivePanel, setShowLivePanel] = useState(false);
+  const [liveGameSlug, setLiveGameSlug] = useState('');
+
+  const liveDisplayName = useMemo(() => {
+    if (typeof window === 'undefined') return 'Player';
+    const username = window.localStorage.getItem('telegramUsername');
+    const firstName = window.localStorage.getItem('telegramFirstName');
+    const lastName = window.localStorage.getItem('telegramLastName');
+    return (
+      username || `${firstName || ''} ${lastName || ''}`.trim() || 'Player'
+    );
+  }, []);
+
+  const liveChatRoomId = useMemo(() => {
+    if (!liveGameSlug) return '';
+    const accountId =
+      typeof window !== 'undefined'
+        ? window.localStorage.getItem('accountId') || 'guest'
+        : 'guest';
+    return `game-live-${liveGameSlug}-${accountId}`;
+  }, [liveGameSlug]);
+
+  const liveChat = useLiveVideoChat({
+    roomId: liveChatRoomId,
+    displayName: liveDisplayName,
+    enabled: liveMode
+  });
 
   useEffect(() => {
     let active = true;
@@ -27,6 +62,14 @@ export default function Games() {
     };
   }, []);
 
+  useEffect(() => {
+    if (liveMode) {
+      liveChat.startLiveChat();
+      return;
+    }
+    liveChat.stopLiveChat();
+  }, [liveMode, liveChat.startLiveChat, liveChat.stopLiveChat]);
+
   return (
     <div className="relative space-y-4 text-text">
       <h2 className="text-2xl font-bold text-center mt-4">Games Lobby</h2>
@@ -37,7 +80,8 @@ export default function Games() {
         {gamesCatalog.map((game) => {
           const thumbnail = getGameThumbnail(game.slug);
           const readiness = getOnlineReadiness(game.slug, readinessMap);
-          const badgeTone = BADGE_STYLES[readiness.label] || BADGE_STYLES['Coming Soon'];
+          const badgeTone =
+            BADGE_STYLES[readiness.label] || BADGE_STYLES['Coming Soon'];
           return (
             <Link
               key={game.name}
@@ -54,26 +98,83 @@ export default function Games() {
                     event.currentTarget.src = game.image;
                   }}
                 />
-              <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent" />
-              <span className="absolute bottom-1 left-1 right-1 text-center text-xs font-semibold text-white">
-                {game.name}
-              </span>
-            </div>
-            <div className="flex flex-1 flex-col items-center px-2 py-2 text-center">
-              <p className="text-[10px] text-subtext line-clamp-2">{game.description}</p>
-              <span
-                className={`mt-1 inline-flex items-center rounded-full border px-2 py-0.5 text-[9px] font-semibold uppercase tracking-[0.14em] ${badgeTone}`}
-              >
-                {readiness.label}
-              </span>
-              <span className="mt-2 inline-flex items-center gap-1 rounded-full bg-primary/15 px-2 py-0.5 text-[10px] font-semibold text-primary">
-                Enter Lobby
-              </span>
-            </div>
+                <button
+                  type="button"
+                  aria-label={
+                    liveMode && liveGameSlug === game.slug
+                      ? `Disable live chat for ${game.name}`
+                      : `Enable live chat for ${game.name}`
+                  }
+                  onClick={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    if (liveMode && liveGameSlug === game.slug) {
+                      liveChat.stopLiveChat();
+                      setLiveMode(false);
+                      setShowLivePanel(false);
+                      return;
+                    }
+                    setLiveGameSlug(game.slug);
+                    setLiveMode(true);
+                    setShowLivePanel(true);
+                  }}
+                  className={`absolute left-1 top-1 z-10 flex flex-col items-center rounded px-2 py-1 text-[10px] font-semibold ${
+                    liveMode && liveGameSlug === game.slug
+                      ? 'bg-emerald-500/25 text-emerald-100'
+                      : 'bg-black/35 text-white hover:bg-white/10'
+                  }`}
+                >
+                  <AiOutlineMessage className="text-xl" />
+                  <span>
+                    {liveMode && liveGameSlug === game.slug ? 'Avatar' : 'Live'}
+                  </span>
+                </button>
+                <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent" />
+                <span className="absolute bottom-1 left-1 right-1 text-center text-xs font-semibold text-white">
+                  {game.name}
+                </span>
+              </div>
+              <div className="flex flex-1 flex-col items-center px-2 py-2 text-center">
+                <p className="text-[10px] text-subtext line-clamp-2">
+                  {game.description}
+                </p>
+                <span
+                  className={`mt-1 inline-flex items-center rounded-full border px-2 py-0.5 text-[9px] font-semibold uppercase tracking-[0.14em] ${badgeTone}`}
+                >
+                  {readiness.label}
+                </span>
+                <span className="mt-2 inline-flex items-center gap-1 rounded-full bg-primary/15 px-2 py-0.5 text-[10px] font-semibold text-primary">
+                  Enter Lobby
+                </span>
+              </div>
             </Link>
           );
         })}
       </div>
+      <LiveVideoChatPanel
+        open={showLivePanel && Boolean(liveGameSlug)}
+        onClose={() => {
+          setShowLivePanel(false);
+        }}
+        roomId={liveChatRoomId}
+        localStream={liveChat.localStream}
+        localMediaState={liveChat.mediaState}
+        remotePeers={liveChat.remotePeers}
+        isConnected={liveChat.isConnected}
+        error={liveChat.error}
+        onStart={() => {
+          if (!liveGameSlug) return;
+          setLiveMode(true);
+          liveChat.startLiveChat();
+        }}
+        onStop={() => {
+          liveChat.stopLiveChat();
+          setLiveMode(false);
+          setShowLivePanel(false);
+        }}
+        onToggleMicrophone={liveChat.toggleMicrophone}
+        onToggleCamera={liveChat.toggleCamera}
+      />
       <GameTransactionsCard />
       <LeaderboardCard />
     </div>


### PR DESCRIPTION
### Motivation

- Provide a live avatar video overlay that can be anchored to the player's avatar inside game UIs to enable quick live video previews while playing. 
- Expose per-game live chat controls from the Games lobby so users can start/stop live video for a specific game session. 
- Integrate live-video features with the existing `useLiveVideoChat` hook and ensure lazy-loaded game routes still work with the overlay.

### Description

- Added new component `GameLiveAvatarOverlay.jsx` that detects a best-match avatar DOM node in a game view, anchors/resizes an overlay, and renders the local video stream with toggle behavior. 
- Wrapped many game route elements in `App.jsx` with `<GameLiveAvatarOverlay gameSlug="...">` so the overlay can attach to in-game avatar nodes for those games, and cleaned up some `Suspense` and formatting around lazy routes. 
- Extended `Games.jsx` to add in-lobby live controls: a per-game Live button, a `LiveVideoChatPanel` import and panel usage, and logic to start/stop `useLiveVideoChat` for the selected game and room. 
- Minor imports/formatting adjustments across files and use of the existing `useLiveVideoChat` hook to drive the UI and media state.

### Testing

- Ran a local development build with `npm run build` which completed successfully. 
- Executed the test suite with `npm test` and the automated tests passed. 
- Ran `npm run lint` and addressed formatting so linting completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c00ad4c7508329b202cca538d95a71)