### PR TITLE
Anchor live camera to user avatar in Checkers Battle Royal

### DIFF
--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -2695,6 +2695,8 @@ export default function CheckersBattleRoyal() {
               key={`checkers-seat-${player.index}`}
               className="absolute pointer-events-auto flex flex-col items-center"
               data-player-index={player.index}
+              data-self-player={player.index === 1 ? 'true' : undefined}
+              data-is-user={player.index === 1 ? 'true' : undefined}
               style={{
                 left: FALLBACK_SEAT_POSITIONS[player.index].left,
                 top: FALLBACK_SEAT_POSITIONS[player.index].top,


### PR DESCRIPTION
### Motivation
- The live-camera toggle was attaching to the wrong avatar in the Checkers Battle Royal scene, so the overlay must be guided to the local user avatar so clicking toggles the user’s live video instead of the opponent’s.

### Description
- Add `data-self-player="true"` and `data-is-user="true"` to the local player seat element in `webapp/src/pages/Games/CheckersBattleRoyal.jsx` (player index `1`) so `GameLiveAvatarOverlay` prioritizes the correct DOM node as the live-video anchor.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully; Vite emitted only non-blocking chunk/dynamic-import warnings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0be0102a08329898a0715813de375)