### PR TITLE
Start Ludo Battle Royal camera near max zoom-out on match start

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1519,6 +1519,7 @@ const BOARD_ROTATION_Y = -Math.PI / 2;
 const CAMERA_BASE_RADIUS = Math.max(TABLE_RADIUS, BOARD_RADIUS);
 const CAMERA_EXTRA_ZOOM_IN = 0.9;
 const CAMERA_EXTRA_ZOOM_OUT = 1.1;
+const INITIAL_CAMERA_DISTANCE_FACTOR = 0.96;
 const CAM = {
   fov: CAMERA_FOV,
   near: CAMERA_NEAR,
@@ -4385,6 +4386,9 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     const targetLift = isPortrait ? PORTRAIT_CAMERA_TUNING.targetLift : CAMERA_TARGET_LIFT;
     const boardLookTarget = new THREE.Vector3(0, tableInfo.surfaceY + targetLift + 0.12 * MODEL_SCALE, 0);
     boardLookTargetRef.current = boardLookTarget;
+    const initialCameraDirection = camera.position.clone().sub(boardLookTarget).normalize();
+    const desiredInitialCameraRadius = clamp(CAM.maxR * INITIAL_CAMERA_DISTANCE_FACTOR, CAM.minR, CAM.maxR);
+    camera.position.copy(boardLookTarget).add(initialCameraDirection.multiplyScalar(desiredInitialCameraRadius));
     camera.lookAt(boardLookTarget);
 
     controls = new OrbitControls(camera, renderer.domElement);


### PR DESCRIPTION
### Motivation
- The Ludo Battle Royal scene previously initialized the camera too close to the board which makes the opening view overly zoomed-in, so the initial view should start near the maximum allowed orbit to show the whole table.

### Description
- Added `INITIAL_CAMERA_DISTANCE_FACTOR = 0.96` and updated the camera initialization in `webapp/src/pages/Games/LudoBattleRoyal.jsx` to compute the view direction from the board target, clamp a near-max radius using existing `CAM.minR`/`CAM.maxR` and reposition the camera before the first `lookAt` so the opening frame is zoomed out.

### Testing
- Ran `npm --prefix webapp run -s build` and the build completed successfully; Vite emitted non-blocking chunking/dynamic-import warnings that are unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0be856d1c832988ec3ae037b48194)