### PR TITLE
Remove live icon controls from Games cards

### DIFF
--- a/webapp/src/pages/Games.jsx
+++ b/webapp/src/pages/Games.jsx
@@ -1,10 +1,8 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { AiOutlineMessage } from 'react-icons/ai';
 import useTelegramBackButton from '../hooks/useTelegramBackButton.js';
 import LeaderboardCard from '../components/LeaderboardCard.jsx';
 import GameTransactionsCard from '../components/GameTransactionsCard.jsx';
-import LiveVideoChatPanel from '../components/LiveVideoChatPanel.jsx';
 import gamesCatalog from '../config/gamesCatalog.js';
 import { getGameThumbnail } from '../config/gameAssets.js';
 import {
@@ -12,7 +10,6 @@ import {
   fetchOnlineReadinessMap,
   ONLINE_READINESS_BY_GAME
 } from '../config/onlineContract.js';
-import useLiveVideoChat from '../hooks/useLiveVideoChat.js';
 
 const BADGE_STYLES = {
   'Online Ready': 'bg-emerald-500/20 text-emerald-300 border-emerald-400/40',
@@ -23,34 +20,6 @@ const BADGE_STYLES = {
 export default function Games() {
   useTelegramBackButton();
   const [readinessMap, setReadinessMap] = useState(ONLINE_READINESS_BY_GAME);
-  const [liveMode, setLiveMode] = useState(false);
-  const [showLivePanel, setShowLivePanel] = useState(false);
-  const [liveGameSlug, setLiveGameSlug] = useState('');
-
-  const liveDisplayName = useMemo(() => {
-    if (typeof window === 'undefined') return 'Player';
-    const username = window.localStorage.getItem('telegramUsername');
-    const firstName = window.localStorage.getItem('telegramFirstName');
-    const lastName = window.localStorage.getItem('telegramLastName');
-    return (
-      username || `${firstName || ''} ${lastName || ''}`.trim() || 'Player'
-    );
-  }, []);
-
-  const liveChatRoomId = useMemo(() => {
-    if (!liveGameSlug) return '';
-    const accountId =
-      typeof window !== 'undefined'
-        ? window.localStorage.getItem('accountId') || 'guest'
-        : 'guest';
-    return `game-live-${liveGameSlug}-${accountId}`;
-  }, [liveGameSlug]);
-
-  const liveChat = useLiveVideoChat({
-    roomId: liveChatRoomId,
-    displayName: liveDisplayName,
-    enabled: liveMode
-  });
 
   useEffect(() => {
     let active = true;
@@ -61,14 +30,6 @@ export default function Games() {
       active = false;
     };
   }, []);
-
-  useEffect(() => {
-    if (liveMode) {
-      liveChat.startLiveChat();
-      return;
-    }
-    liveChat.stopLiveChat();
-  }, [liveMode, liveChat.startLiveChat, liveChat.stopLiveChat]);
 
   return (
     <div className="relative space-y-4 text-text">
@@ -98,37 +59,6 @@ export default function Games() {
                     event.currentTarget.src = game.image;
                   }}
                 />
-                <button
-                  type="button"
-                  aria-label={
-                    liveMode && liveGameSlug === game.slug
-                      ? `Disable live chat for ${game.name}`
-                      : `Enable live chat for ${game.name}`
-                  }
-                  onClick={(event) => {
-                    event.preventDefault();
-                    event.stopPropagation();
-                    if (liveMode && liveGameSlug === game.slug) {
-                      liveChat.stopLiveChat();
-                      setLiveMode(false);
-                      setShowLivePanel(false);
-                      return;
-                    }
-                    setLiveGameSlug(game.slug);
-                    setLiveMode(true);
-                    setShowLivePanel(true);
-                  }}
-                  className={`absolute left-1 top-1 z-10 flex flex-col items-center rounded px-2 py-1 text-[10px] font-semibold ${
-                    liveMode && liveGameSlug === game.slug
-                      ? 'bg-emerald-500/25 text-emerald-100'
-                      : 'bg-black/35 text-white hover:bg-white/10'
-                  }`}
-                >
-                  <AiOutlineMessage className="text-xl" />
-                  <span>
-                    {liveMode && liveGameSlug === game.slug ? 'Avatar' : 'Live'}
-                  </span>
-                </button>
                 <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent" />
                 <span className="absolute bottom-1 left-1 right-1 text-center text-xs font-semibold text-white">
                   {game.name}
@@ -151,30 +81,6 @@ export default function Games() {
           );
         })}
       </div>
-      <LiveVideoChatPanel
-        open={showLivePanel && Boolean(liveGameSlug)}
-        onClose={() => {
-          setShowLivePanel(false);
-        }}
-        roomId={liveChatRoomId}
-        localStream={liveChat.localStream}
-        localMediaState={liveChat.mediaState}
-        remotePeers={liveChat.remotePeers}
-        isConnected={liveChat.isConnected}
-        error={liveChat.error}
-        onStart={() => {
-          if (!liveGameSlug) return;
-          setLiveMode(true);
-          liveChat.startLiveChat();
-        }}
-        onStop={() => {
-          liveChat.stopLiveChat();
-          setLiveMode(false);
-          setShowLivePanel(false);
-        }}
-        onToggleMicrophone={liveChat.toggleMicrophone}
-        onToggleCamera={liveChat.toggleCamera}
-      />
       <GameTransactionsCard />
       <LeaderboardCard />
     </div>


### PR DESCRIPTION
### Motivation
- Remove the live/chat overlay from each game card to match the requested UI change and declutter the Games lobby. 
- Remove associated live-chat wiring from the page since the overlay and its controls are no longer needed.

### Description
- Deleted the live control button and icon overlay from `webapp/src/pages/Games.jsx` so game cards no longer show the live/Avatar control. 
- Removed unused imports: `AiOutlineMessage`, `LiveVideoChatPanel` and `useLiveVideoChat` from `Games.jsx`.
- Removed live-related state and helpers including `liveMode`, `showLivePanel`, `liveGameSlug`, the `liveDisplayName` and `liveChatRoomId` memos, and the `useEffect` that started/stopped the live chat. 
- Left game card layout, readiness badge and the "Enter Lobby" CTA intact.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully with Vite warnings about chunk sizes but no build errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0bea49fe48329bfe3c2af1072dde6)