### PR TITLE
Fix Checkers live avatar anchor to use player seat

### DIFF
--- a/webapp/src/components/GameLiveAvatarOverlay.jsx
+++ b/webapp/src/components/GameLiveAvatarOverlay.jsx
@@ -86,10 +86,9 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
     const scoreAnchor = (element, rect) => {
       let score = 0;
       const marker =
-        `${element.getAttribute('data-self-player') || ''} ${element.getAttribute('data-player-index') || ''} ${element.className || ''} ${element.getAttribute('aria-label') || ''} ${element.getAttribute('alt') || ''}`.toLowerCase();
+        `${element.getAttributeNames().join(' ')} ${element.getAttribute('data-self-player') || ''} ${element.getAttribute('data-is-user') || ''} ${element.getAttribute('data-player-index') || ''} ${element.className || ''} ${element.getAttribute('aria-label') || ''} ${element.getAttribute('alt') || ''}`.toLowerCase();
       if (marker.includes('self')) score += 100;
       if (marker.includes('you')) score += 80;
-      if (marker.includes('player-index') || marker.includes('0')) score += 40;
       if (rect.top > window.innerHeight * 0.45) score += 25;
       if (rect.left < window.innerWidth * 0.65) score += 15;
       score += Math.min(rect.width, rect.height);

--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -2695,6 +2695,9 @@ export default function CheckersBattleRoyal() {
               key={`checkers-seat-${player.index}`}
               className="absolute pointer-events-auto flex flex-col items-center"
               data-player-index={player.index}
+              data-self-player={player.index === 1 ? 'true' : 'false'}
+              data-is-user={player.index === 1 ? 'true' : 'false'}
+              aria-label={player.index === 1 ? 'You' : player.name}
               style={{
                 left: FALLBACK_SEAT_POSITIONS[player.index].left,
                 top: FALLBACK_SEAT_POSITIONS[player.index].top,


### PR DESCRIPTION
### Motivation
- The live camera overlay was binding to the wrong avatar (AI/opponent) in Checkers Battle Royal because the anchor scoring favored a hard-coded player-index bias and did not reliably detect explicit user markers, preventing the expected toggle between avatar and live video like in Ludo.

### Description
- Mark the local player seat container in Checkers with explicit attributes (`data-self-player`, `data-is-user`, and `aria-label="You"`) in `webapp/src/pages/Games/CheckersBattleRoyal.jsx` so the UI element for the bottom/user avatar is identifiable.
- Improve `GameLiveAvatarOverlay` in `webapp/src/components/GameLiveAvatarOverlay.jsx` by including `element.getAttributeNames()` in the marker string and removing the implicit `player-index` bias so attribute-based selectors (e.g., `data-self-player`) are recognized and scored correctly.

### Testing
- Ran the production build with `npm --prefix webapp run build`, and the Vite build completed successfully (there were existing chunk-size warnings but no build failures).
- No automated unit tests were added or changed as part of this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0be0102a08329898a0715813de375)