### PR TITLE
Tavull (Backgammon) UI: move commentary to top, lower Roll Dice, and simplify avatar caption

### DIFF
--- a/webapp/src/pages/Games/TavullBattleRoyal.jsx
+++ b/webapp/src/pages/Games/TavullBattleRoyal.jsx
@@ -1841,6 +1841,14 @@ export default function TavullBattleRoyal() {
 
   return (
     <div className="fixed inset-0 bg-[#060b16] px-3 py-3 text-white touch-none select-none">
+      {message ? (
+        <div className="pointer-events-none absolute left-1/2 top-4 z-30 -translate-x-1/2 px-4">
+          <div className="max-w-[80vw] rounded-full border border-white/15 bg-black/55 px-4 py-2 text-center text-xs font-semibold text-white/90 shadow-[0_10px_30px_rgba(0,0,0,0.45)] backdrop-blur">
+            {message}
+          </div>
+        </div>
+      ) : null}
+
       <div className="absolute top-20 left-4 z-20 flex flex-col items-start gap-3 pointer-events-none">
         <button
           type="button"
@@ -2019,7 +2027,7 @@ export default function TavullBattleRoyal() {
         <div ref={canvasHostRef} className="h-full w-full" />
       </div>
 
-      <div className="absolute left-1/2 top-[79%] z-20 flex -translate-x-1/2 -translate-y-1/2 flex-col items-center gap-2">
+      <div className="absolute left-1/2 top-[81%] z-20 flex -translate-x-1/2 -translate-y-1/2 flex-col items-center gap-2">
         <button
           type="button"
           onClick={roll}
@@ -2126,7 +2134,7 @@ export default function TavullBattleRoyal() {
               <span className="mt-1 text-[0.65rem] font-semibold text-white drop-shadow-[0_2px_6px_rgba(0,0,0,0.6)]">
                 {player.name}
               </span>
-              {player.index === 1 && (
+              {player.index === 1 && winner && (
                 <span
                   className="mt-0.5 max-w-[120px] text-center text-[0.52rem] font-semibold leading-[1.2] text-white/90 drop-shadow-[0_2px_6px_rgba(0,0,0,0.75)]"
                   style={{
@@ -2136,7 +2144,7 @@ export default function TavullBattleRoyal() {
                     overflow: 'hidden'
                   }}
                 >
-                  {winner ? `${winner === WHITE ? 'You' : 'AI'} win!` : message}
+                  {winner === WHITE ? 'You win!' : 'AI wins!'}
                 </span>
               )}
             </div>


### PR DESCRIPTION
### Motivation
- Align the Backgammon Royal HUD with the Ludo Battle Royal layout by placing the live commentary/status text at the very top of the screen for better visibility. 
- Move the dice control slightly downward so it no longer overlaps or feels cramped under the user avatar area on portrait screens. 
- Avoid duplicate/status text showing both in the top commentary and under the AI avatar by keeping the avatar caption reserved for final winner text only.

### Description
- Added a top-centered floating commentary capsule that displays the current `message` when present, styled to match existing HUD patterns (`webapp/src/pages/Games/TavullBattleRoyal.jsx`).
- Nudged the `Roll Dice` control down by changing its anchor from `top-[79%]` to `top-[81%]` so it sits lower under the avatar area (`webapp/src/pages/Games/TavullBattleRoyal.jsx`).
- Changed the avatar-side caption logic so the small caption under the AI/player avatar only renders for final winner text (now gated by `winner`) and shows a concise `You win!` / `AI wins!` message instead of repeating `message` (`webapp/src/pages/Games/TavullBattleRoyal.jsx`).

### Testing
- Ran the production build with `npm --prefix webapp run build`, which completed successfully and produced the app bundles. 
- The build reported non-blocking Vite warnings about chunk sizes and some dynamic/static import patterns, but no errors occurred and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0c56057448329ab9a92345d657a1e)