### PR TITLE
Add live-avatar click support for Texas Hold'em, Domino Royal, Goal Rush and Four In Row

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -6082,9 +6082,15 @@ function applyBadgeAvatar(target, source = DEFAULT_AVATAR_EMOJI) {
   }
 }
 
-function createSeatBadge({ avatar = '🎯', name = '' } = {}) {
+function createSeatBadge({ avatar = '🎯', name = '', index = -1, isSelf = false } = {}) {
   const wrap = document.createElement('div');
   wrap.className = 'seat-badge';
+  wrap.dataset.playerIndex = String(index);
+  if (isSelf) {
+    wrap.dataset.selfPlayer = 'true';
+    wrap.dataset.you = 'true';
+    wrap.dataset.playerRole = 'self';
+  }
 
   const avatarWrap = document.createElement('div');
   avatarWrap.className = 'seat-badge-avatar';
@@ -6095,6 +6101,12 @@ function createSeatBadge({ avatar = '🎯', name = '' } = {}) {
 
   const core = document.createElement('div');
   core.className = 'seat-badge-core';
+  core.dataset.playerIndex = String(index);
+  if (isSelf) {
+    core.dataset.selfPlayer = 'true';
+    core.dataset.you = 'true';
+    core.dataset.playerRole = 'self';
+  }
   applyBadgeAvatar(core, avatar);
   avatarWrap.appendChild(core);
 
@@ -6117,7 +6129,12 @@ function refreshSeatBadges(avatars = [], names = []) {
   const avatarSources = avatars.length ? avatars : buildSeatAvatarSources(N);
   const nameSources = names.length ? names : buildSeatNames(N);
   avatarSources.forEach((avatar, idx) => {
-    const badge = createSeatBadge({ avatar, name: nameSources[idx] ?? '' });
+    const badge = createSeatBadge({
+      avatar,
+      name: nameSources[idx] ?? '',
+      index: idx,
+      isSelf: idx === human
+    });
     badge.style.setProperty('--timer-gradient', gradient);
     seatBadges.push(badge);
   });

--- a/webapp/public/goal-rush.html
+++ b/webapp/public/goal-rush.html
@@ -123,7 +123,7 @@
     <div class="scoreboard">
       <div class="score" aria-live="polite">
         <div class="score-player">
-          <span id="p1AvatarTop" class="score-avatar" aria-hidden="true"></span>
+          <span id="p1AvatarTop" class="score-avatar" aria-hidden="true" data-self-player="true" data-player-role="self" data-player-index="0"></span>
           <span id="p1Name" class="badge p1">P1</span>
         </div>
         <span id="s1">0</span>

--- a/webapp/src/components/GameLiveAvatarOverlay.jsx
+++ b/webapp/src/components/GameLiveAvatarOverlay.jsx
@@ -18,7 +18,9 @@ const AVATAR_ANCHOR_SELECTORS = [
   '.hud-player-you img',
   '.hud-player-you',
   'img[alt="You"]',
-  '[aria-label="You"]'
+  '[aria-label="You"]',
+  '#p1AvatarTop',
+  '[data-player-role="self"]'
 ];
 
 export default function GameLiveAvatarOverlay({ gameSlug, children }) {
@@ -95,23 +97,53 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
       return score;
     };
 
+    const getSearchContexts = () => {
+      const contexts = [{ root: document, offsetLeft: 0, offsetTop: 0 }];
+      const iframes = Array.from(document.querySelectorAll('iframe'));
+      iframes.forEach((frame) => {
+        let frameDoc = null;
+        try {
+          frameDoc = frame.contentDocument || frame.contentWindow?.document || null;
+        } catch (error) {
+          frameDoc = null;
+        }
+        if (!frameDoc?.body) return;
+        const frameRect = frame.getBoundingClientRect();
+        contexts.push({
+          root: frameDoc,
+          offsetLeft: frameRect.left,
+          offsetTop: frameRect.top
+        });
+      });
+      return contexts;
+    };
+
     const findAvatarAnchor = () => {
       let bestNode = null;
       let bestRect = null;
       let bestScore = -Infinity;
-      const seen = new Set();
-      for (const selector of AVATAR_ANCHOR_SELECTORS) {
-        const nodes = document.querySelectorAll(selector);
-        for (const candidate of nodes) {
-          if (seen.has(candidate)) continue;
-          seen.add(candidate);
-          const rect = candidate.getBoundingClientRect();
-          if (rect.width <= 8 || rect.height <= 8) continue;
-          const score = scoreAnchor(candidate, rect);
-          if (score > bestScore) {
-            bestScore = score;
-            bestRect = rect;
-            bestNode = candidate;
+      const contexts = getSearchContexts();
+      for (const context of contexts) {
+        const seen = new Set();
+        for (const selector of AVATAR_ANCHOR_SELECTORS) {
+          const nodes = context.root.querySelectorAll(selector);
+          for (const candidate of nodes) {
+            if (seen.has(candidate)) continue;
+            seen.add(candidate);
+            const localRect = candidate.getBoundingClientRect();
+            if (localRect.width <= 8 || localRect.height <= 8) continue;
+            const rect = {
+              top: localRect.top + context.offsetTop,
+              left: localRect.left + context.offsetLeft,
+              width: localRect.width,
+              height: localRect.height
+            };
+            const score = scoreAnchor(candidate, rect);
+            if (score > bestScore) {
+              bestScore = score;
+              bestRect = rect;
+              bestNode = candidate;
+            }
           }
         }
       }
@@ -163,6 +195,7 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
     window.addEventListener('resize', scheduleApply);
     window.addEventListener('orientationchange', scheduleApply);
     window.addEventListener('scroll', scheduleApply, true);
+    const pollTimer = window.setInterval(scheduleApply, 1200);
 
     scheduleApply();
 
@@ -170,6 +203,7 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
       cancelAnimationFrame(frameId);
       mutationObserver.disconnect();
       resizeObserver?.disconnect();
+      window.clearInterval(pollTimer);
       window.removeEventListener('resize', scheduleApply);
       window.removeEventListener('orientationchange', scheduleApply);
       window.removeEventListener('scroll', scheduleApply, true);

--- a/webapp/src/pages/Games/FourInRowRoyal.jsx
+++ b/webapp/src/pages/Games/FourInRowRoyal.jsx
@@ -1122,7 +1122,7 @@ export default function FourInRowRoyal() {
 
       <div className="pointer-events-none absolute inset-0 z-20">
         <div className="absolute left-1/2 top-[12%] -translate-x-1/2"><AvatarTimer photoUrl="🤖" name="AI Rival" active isTurn={turn === 'ai'} size={1} /></div>
-        <div className="absolute left-1/2 top-[85%] -translate-x-1/2"><AvatarTimer photoUrl={avatar} name={username} active isTurn={turn === 'player'} size={1} /></div>
+        <div className="absolute left-1/2 top-[85%] -translate-x-1/2" data-self-player="true"><AvatarTimer photoUrl={avatar} name={username} active isTurn={turn === 'player'} size={1} index={0} /></div>
       </div>
 
 

--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -6492,7 +6492,7 @@ function TexasHoldemArena({ search }) {
         ))}
       </div>
       <div className="absolute bottom-20 left-1/2 z-20 flex -translate-x-1/2 justify-center pointer-events-auto landscape:left-[calc(env(safe-area-inset-left,0px)+5.45rem)] landscape:bottom-[calc(env(safe-area-inset-bottom,0px)+2.45rem)] landscape:translate-x-0">
-        <div className="flex items-center space-x-3 rounded-full bg-white/10 px-4 py-3 text-xs shadow-lg backdrop-blur">
+        <div className="player-avatar you flex items-center space-x-3 rounded-full bg-white/10 px-4 py-3 text-xs shadow-lg backdrop-blur" data-self-player="true" data-you="true">
           {humanPlayer?.avatar &&
             (isHumanTurn ? (
               renderAvatarTimer(humanPlayer.avatar, 44)


### PR DESCRIPTION
### Motivation
- Make the user-avatar click behavior consistent across multiple arenas so players can toggle live camera/microphone by clicking their own avatar the same way as in existing games (Ludo, Battle Royale, Snake, etc.).
- Ensure the shared overlay can detect self-avatar anchors even when the game UI is embedded in same-origin iframes.

### Description
- Extended `GameLiveAvatarOverlay.jsx` to search for avatar anchors inside same-origin iframes, added fallback selectors (`#p1AvatarTop`, `[data-player-role="self"]`) and a periodic poll to improve discovery reliability. 
- Marked the Texas Hold'em HUD avatar container as the self avatar by adding `data-self-player="true"` / `data-you="true"` and the `player-avatar you` wrapper so the overlay can attach to it. 
- Marked the Four In Row local avatar element with `data-self-player="true"` and passed `index={0}` to `AvatarTimer` so it is discoverable by the overlay. 
- Updated `webapp/public/goal-rush.html` to annotate the `#p1AvatarTop` scoreboard avatar with `data-self-player="true" data-player-role="self" data-player-index="0"` for iframe recognition. 
- Updated Domino Royal seat badge generation in `webapp/public/domino-royal-game.js` to emit `data-player-index` and self markers (`data-self-player`, `data-you`, `data-player-role`) on the badge/core for the human seat so the overlay can locate the user avatar in the game canvas/DOM.

### Testing
- Ran `npm --prefix webapp run build`, which completed successfully and produced the production build. 
- The build emitted existing non-blocking Vite warnings about mixed static/dynamic imports and large chunk sizes, but no errors occurred and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0c5115a408329a2b8d716f093c3cc)