### PR TITLE
Enable click-to-live-avatar for Texas, Domino, Goal Rush, and Four-in-Row

### DIFF
--- a/webapp/src/components/GameLiveAvatarOverlay.jsx
+++ b/webapp/src/components/GameLiveAvatarOverlay.jsx
@@ -3,6 +3,10 @@ import { useLocation } from 'react-router-dom';
 import useLiveVideoChat from '../hooks/useLiveVideoChat.js';
 
 const AVATAR_ANCHOR_SELECTORS = [
+  '#p1AvatarTop',
+  '#dominoLeaderboardCard .leaderboard-row.is-human .leaderboard-avatar',
+  '#dominoLeaderboardCard .leaderboard-row.is-human',
+  '.leaderboard-row.is-human .leaderboard-avatar',
   '[data-self-player="true"] img',
   '[data-self-player="true"] .avatar',
   '[data-self-player="true"]',
@@ -82,54 +86,87 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
 
     let frameId = 0;
     let resizeObserver;
+    let pollingInterval = 0;
+    const iframeListeners = [];
 
-    const scoreAnchor = (element, rect) => {
+    const listSearchDocuments = () => {
+      const docs = [{ doc: document, frameRect: null }];
+      const frames = Array.from(document.querySelectorAll('iframe'));
+      frames.forEach((frame) => {
+        try {
+          if (!frame.contentDocument || !frame.contentWindow) return;
+          docs.push({ doc: frame.contentDocument, frameRect: frame.getBoundingClientRect() });
+        } catch (err) {
+          // ignore cross-origin iframes
+        }
+      });
+      return docs;
+    };
+
+    const toViewportRect = (rect, frameRect) => {
+      if (!frameRect) return rect;
+      return {
+        top: rect.top + frameRect.top,
+        left: rect.left + frameRect.left,
+        width: rect.width,
+        height: rect.height
+      };
+    };
+
+    const scoreAnchor = (element, rect, frameRect = null) => {
+      const viewportRect = toViewportRect(rect, frameRect);
       let score = 0;
       const marker =
         `${element.getAttributeNames().join(' ')} ${element.getAttribute('data-self-player') || ''} ${element.getAttribute('data-is-user') || ''} ${element.getAttribute('data-player-index') || ''} ${element.className || ''} ${element.getAttribute('aria-label') || ''} ${element.getAttribute('alt') || ''}`.toLowerCase();
       if (marker.includes('self')) score += 100;
       if (marker.includes('you')) score += 80;
-      if (rect.top > window.innerHeight * 0.45) score += 25;
-      if (rect.left < window.innerWidth * 0.65) score += 15;
-      score += Math.min(rect.width, rect.height);
+      if (viewportRect.top > window.innerHeight * 0.45) score += 25;
+      if (viewportRect.left < window.innerWidth * 0.65) score += 15;
+      score += Math.min(viewportRect.width, viewportRect.height);
       return score;
     };
 
     const findAvatarAnchor = () => {
       let bestNode = null;
       let bestRect = null;
+      let bestFrameRect = null;
       let bestScore = -Infinity;
-      const seen = new Set();
-      for (const selector of AVATAR_ANCHOR_SELECTORS) {
-        const nodes = document.querySelectorAll(selector);
-        for (const candidate of nodes) {
-          if (seen.has(candidate)) continue;
-          seen.add(candidate);
-          const rect = candidate.getBoundingClientRect();
-          if (rect.width <= 8 || rect.height <= 8) continue;
-          const score = scoreAnchor(candidate, rect);
-          if (score > bestScore) {
-            bestScore = score;
-            bestRect = rect;
-            bestNode = candidate;
+      const docs = listSearchDocuments();
+      for (const { doc, frameRect } of docs) {
+        const seen = new Set();
+        for (const selector of AVATAR_ANCHOR_SELECTORS) {
+          const nodes = doc.querySelectorAll(selector);
+          for (const candidate of nodes) {
+            if (seen.has(candidate)) continue;
+            seen.add(candidate);
+            const rect = candidate.getBoundingClientRect();
+            if (rect.width <= 8 || rect.height <= 8) continue;
+            const score = scoreAnchor(candidate, rect, frameRect);
+            if (score > bestScore) {
+              bestScore = score;
+              bestRect = rect;
+              bestNode = candidate;
+              bestFrameRect = frameRect;
+            }
           }
         }
       }
-      return { rect: bestRect, node: bestNode };
+      return { rect: bestRect, frameRect: bestFrameRect, node: bestNode };
     };
 
     const applyRect = () => {
-      const { rect, node } = findAvatarAnchor();
+      const { rect, frameRect, node } = findAvatarAnchor();
       if (!rect) return;
+      const viewportRect = toViewportRect(rect, frameRect);
       const FRAME_SCALE = 1.2;
-      const width = Math.max(Math.round(rect.width * FRAME_SCALE), 32);
-      const height = Math.max(Math.round(rect.height * FRAME_SCALE), 32);
+      const width = Math.max(Math.round(viewportRect.width * FRAME_SCALE), 32);
+      const height = Math.max(Math.round(viewportRect.height * FRAME_SCALE), 32);
       const left = Math.max(
-        Math.round(rect.left - (width - rect.width) / 2),
+        Math.round(viewportRect.left - (width - viewportRect.width) / 2),
         0
       );
       const top = Math.max(
-        Math.round(rect.top - (height - rect.height) / 2),
+        Math.round(viewportRect.top - (height - viewportRect.height) / 2),
         0
       );
       setAnchorElement(node);
@@ -163,6 +200,12 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
     window.addEventListener('resize', scheduleApply);
     window.addEventListener('orientationchange', scheduleApply);
     window.addEventListener('scroll', scheduleApply, true);
+    pollingInterval = window.setInterval(scheduleApply, 800);
+    const iframes = Array.from(document.querySelectorAll('iframe'));
+    iframes.forEach((frame) => {
+      frame.addEventListener('load', scheduleApply);
+      iframeListeners.push(frame);
+    });
 
     scheduleApply();
 
@@ -173,6 +216,8 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
       window.removeEventListener('resize', scheduleApply);
       window.removeEventListener('orientationchange', scheduleApply);
       window.removeEventListener('scroll', scheduleApply, true);
+      window.clearInterval(pollingInterval);
+      iframeListeners.forEach((frame) => frame.removeEventListener('load', scheduleApply));
     };
   }, [gameSlug, search]);
 

--- a/webapp/src/pages/Games/FourInRowRoyal.jsx
+++ b/webapp/src/pages/Games/FourInRowRoyal.jsx
@@ -1122,7 +1122,9 @@ export default function FourInRowRoyal() {
 
       <div className="pointer-events-none absolute inset-0 z-20">
         <div className="absolute left-1/2 top-[12%] -translate-x-1/2"><AvatarTimer photoUrl="🤖" name="AI Rival" active isTurn={turn === 'ai'} size={1} /></div>
-        <div className="absolute left-1/2 top-[85%] -translate-x-1/2"><AvatarTimer photoUrl={avatar} name={username} active isTurn={turn === 'player'} size={1} /></div>
+        <div className="absolute left-1/2 top-[85%] -translate-x-1/2" data-self-player="true" data-is-user="true">
+          <AvatarTimer photoUrl={avatar} name={username} active isTurn={turn === 'player'} size={1} />
+        </div>
       </div>
 
 

--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -6491,7 +6491,11 @@ function TexasHoldemArena({ search }) {
           />
         ))}
       </div>
-      <div className="absolute bottom-20 left-1/2 z-20 flex -translate-x-1/2 justify-center pointer-events-auto landscape:left-[calc(env(safe-area-inset-left,0px)+5.45rem)] landscape:bottom-[calc(env(safe-area-inset-bottom,0px)+2.45rem)] landscape:translate-x-0">
+      <div
+        className="absolute bottom-20 left-1/2 z-20 flex -translate-x-1/2 justify-center pointer-events-auto landscape:left-[calc(env(safe-area-inset-left,0px)+5.45rem)] landscape:bottom-[calc(env(safe-area-inset-bottom,0px)+2.45rem)] landscape:translate-x-0"
+        data-self-player="true"
+        data-is-user="true"
+      >
         <div className="flex items-center space-x-3 rounded-full bg-white/10 px-4 py-3 text-xs shadow-lg backdrop-blur">
           {humanPlayer?.avatar &&
             (isHumanTurn ? (


### PR DESCRIPTION
### Motivation
- Provide the same click-to-start live camera/mic avatar flow already used in Ludo/Snake/etc. for Texas Hold'em, Domino Royal, Goal Rush (iframe), and Four in Row so players can toggle live avatar by tapping their avatar.
- Reuse the existing `useLiveVideoChat` + `GameLiveAvatarOverlay` logic and make avatar detection robust across different HUDs and iframe-based games.

### Description
- Extended `GameLiveAvatarOverlay` to include new anchor selectors for Goal Rush (`#p1AvatarTop`) and Domino leaderboard human rows and to prefer existing self-player markers like `data-self-player` and `data-is-user`.
- Made the overlay search both the top-level document and same-origin iframe documents, convert iframe-local bounding rects to top-level viewport coordinates, and choose the best anchor by scoring markers and size.
- Added periodic re-evaluation (`setInterval`) and iframe `load` listeners plus observers so moving or dynamically-rendered HUD avatars remain tracked reliably.
- Marked the local player HUD in Texas Hold'em and the Four in Row avatar container with `data-self-player="true"` and `data-is-user="true"` so the overlay can attach to those elements.

### Testing
- Ran `npx eslint --no-ignore` on the modified files which reported only project-ignore warnings and no lint errors for the changes (warnings due to ignore patterns).
- Built the web app with `npm --prefix webapp run build` which completed successfully and produced the production `dist` artifacts.
- No automated browser/visual tests were run in this rollout (build-only verification succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0c5115a408329a2b8d716f093c3cc)