### PR TITLE
Fix: pin human seat badge screen position after cards appear and keep it visible

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -5879,6 +5879,7 @@ let seatLabelShouldDisplay = shouldShowSeatLabel;
 const seatAvatars = [];
 const seatNameTags = [];
 const seatBadges = [];
+let fixedHumanBadgeAnchor = null;
 const seatOverlay = document.createElement('div');
 seatOverlay.id = 'seatOverlay';
 document.body.appendChild(seatOverlay);
@@ -6013,11 +6014,24 @@ function updateSeatBadgePositions() {
     world.y +=
       CHAIR_DIMENSIONS.seatThickness + CHAIR_DIMENSIONS.backHeight * 0.62;
     world.project(camera);
-    const x = (world.x * 0.5 + 0.5) * rect.width + rect.left;
-    const y = (1 - (world.y * 0.5 + 0.5)) * rect.height + rect.top;
+    let x = (world.x * 0.5 + 0.5) * rect.width + rect.left;
+    let y = (1 - (world.y * 0.5 + 0.5)) * rect.height + rect.top;
+    if (idx === human) {
+      const hasHumanCards = (players?.[human]?.hand?.length || 0) > 0;
+      if (!fixedHumanBadgeAnchor && hasHumanCards) {
+        fixedHumanBadgeAnchor = {
+          xRatio: rect.width > 0 ? (x - rect.left) / rect.width : 0.5,
+          yRatio: rect.height > 0 ? (y - rect.top) / rect.height : 0.5
+        };
+      }
+      if (fixedHumanBadgeAnchor) {
+        x = rect.left + fixedHumanBadgeAnchor.xRatio * rect.width;
+        y = rect.top + fixedHumanBadgeAnchor.yRatio * rect.height;
+      }
+    }
     badge.style.left = `${x}px`;
     badge.style.top = `${y}px`;
-    badge.style.opacity = world.z > 1 || world.z < -1 ? '0' : '1';
+    badge.style.opacity = idx === human ? '1' : world.z > 1 || world.z < -1 ? '0' : '1';
   });
 }
 
@@ -6048,6 +6062,7 @@ function disposeSeatNameTags() {
 }
 
 function disposeSeatBadges() {
+  fixedHumanBadgeAnchor = null;
   while (seatBadges.length) {
     const badge = seatBadges.pop();
     badge?.remove?.();


### PR DESCRIPTION
### Motivation
- Prevent the human player's badge from jumping around as the 3D scene or camera updates once the player's hand is dealt, and ensure the human badge remains visible even when projection Z fluctuates.

### Description
- Add a `fixedHumanBadgeAnchor` to store a screen-relative anchor (`xRatio`/`yRatio`) for the human seat badge when the human first receives cards, and use it to stabilize the badge position across frames and resizes.
- Compute the anchor only when the human has cards and when `rect.width`/`rect.height` are valid to avoid division issues, then apply the anchored coordinates on subsequent updates.
- Ensure the human badge always has `opacity: 1` while other badges keep the projection-based visibility test (`world.z` bounds).
- Reset `fixedHumanBadgeAnchor` in `disposeSeatBadges()` so the anchor is cleared when badges are rebuilt.

### Testing
- Ran `npm run lint` and `npm test` against the existing frontend test suite; both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0c6196e908329bb8c6fd52bb21b53)