### PR TITLE
Stabilize human seat badge position and ensure visibility

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -5879,6 +5879,7 @@ let seatLabelShouldDisplay = shouldShowSeatLabel;
 const seatAvatars = [];
 const seatNameTags = [];
 const seatBadges = [];
+let humanSeatBadgeAnchor = null;
 const seatOverlay = document.createElement('div');
 seatOverlay.id = 'seatOverlay';
 document.body.appendChild(seatOverlay);
@@ -6013,11 +6014,21 @@ function updateSeatBadgePositions() {
     world.y +=
       CHAIR_DIMENSIONS.seatThickness + CHAIR_DIMENSIONS.backHeight * 0.62;
     world.project(camera);
-    const x = (world.x * 0.5 + 0.5) * rect.width + rect.left;
-    const y = (1 - (world.y * 0.5 + 0.5)) * rect.height + rect.top;
+    const projectedX = (world.x * 0.5 + 0.5) * rect.width + rect.left;
+    const projectedY = (1 - (world.y * 0.5 + 0.5)) * rect.height + rect.top;
+    let x = projectedX;
+    let y = projectedY;
+    if (idx === human) {
+      if (!humanSeatBadgeAnchor) {
+        humanSeatBadgeAnchor = { x: projectedX, y: projectedY };
+      }
+      x = humanSeatBadgeAnchor.x;
+      y = humanSeatBadgeAnchor.y;
+    }
     badge.style.left = `${x}px`;
     badge.style.top = `${y}px`;
-    badge.style.opacity = world.z > 1 || world.z < -1 ? '0' : '1';
+    badge.style.opacity =
+      idx === human ? '1' : world.z > 1 || world.z < -1 ? '0' : '1';
   });
 }
 
@@ -6048,6 +6059,7 @@ function disposeSeatNameTags() {
 }
 
 function disposeSeatBadges() {
+  humanSeatBadgeAnchor = null;
   while (seatBadges.length) {
     const badge = seatBadges.pop();
     badge?.remove?.();


### PR DESCRIPTION
### Motivation

- Prevent the local (human) player's seat badge from jittering or drifting as the camera or chairs move by anchoring its screen position once projected.  
- Ensure the human badge remains visible even when its 3D projection would otherwise be considered off-screen or occluded.  
- Clear anchor state when badges are disposed to avoid stale positions on re-render.

### Description

- Added `humanSeatBadgeAnchor` to store a fixed screen position for the human player's badge.  
- Compute `projectedX`/`projectedY` and use those values to initialize the anchor and then reuse the anchor for subsequent frames when `idx === human`.  
- Keep the human badge opacity forced to visible (`'1'`) regardless of `world.z` and only hide other badges when out of view.  
- Reset `humanSeatBadgeAnchor` to `null` in `disposeSeatBadges()` and renamed local position variables for clarity.

### Testing

- Ran the web build (`npm run build`) to verify the client bundle compiles successfully and the change does not break the build. Tests passed.  
- Executed lint checks (`npm run lint`) to ensure code style is maintained and the checks passed.  
- Performed the automated test suite (`npm test`) which completed successfully and showed no regressions in badge or seat-related tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0c6196e908329bb8c6fd52bb21b53)