### PR TITLE
Enable live-avatar click-to-camera for Texas Hold'em, Domino, Goal Rush and Four in a Row

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -6082,9 +6082,13 @@ function applyBadgeAvatar(target, source = DEFAULT_AVATAR_EMOJI) {
   }
 }
 
-function createSeatBadge({ avatar = '🎯', name = '' } = {}) {
+function createSeatBadge({ avatar = '🎯', name = '', isSelf = false } = {}) {
   const wrap = document.createElement('div');
   wrap.className = 'seat-badge';
+  if (isSelf) {
+    wrap.dataset.selfPlayer = 'true';
+    wrap.classList.add('is-self');
+  }
 
   const avatarWrap = document.createElement('div');
   avatarWrap.className = 'seat-badge-avatar';
@@ -6117,7 +6121,11 @@ function refreshSeatBadges(avatars = [], names = []) {
   const avatarSources = avatars.length ? avatars : buildSeatAvatarSources(N);
   const nameSources = names.length ? names : buildSeatNames(N);
   avatarSources.forEach((avatar, idx) => {
-    const badge = createSeatBadge({ avatar, name: nameSources[idx] ?? '' });
+    const badge = createSeatBadge({
+      avatar,
+      name: nameSources[idx] ?? '',
+      isSelf: idx === human
+    });
     badge.style.setProperty('--timer-gradient', gradient);
     seatBadges.push(badge);
   });
@@ -7700,7 +7708,7 @@ function updateLeaderboardCard() {
       return (
         `<div class="leaderboard-row ${entry.idx === human ? 'is-human' : ''}">` +
         `<span class="leaderboard-rank">${rank + 1}</span>` +
-        `<span class="${avatarClass}"${avatarStyle}>${avatarLabel}</span>` +
+        `<span class="${avatarClass}"${avatarStyle}${entry.idx === human ? ' data-self-player="true"' : ''}>${avatarLabel}</span>` +
         `<span class="leaderboard-name">${entry.name}</span>` +
         `${scoreColumn}` +
         `<span class="leaderboard-stat">${entry.piecesLeft} left</span>` +

--- a/webapp/public/goal-rush.html
+++ b/webapp/public/goal-rush.html
@@ -123,7 +123,7 @@
     <div class="scoreboard">
       <div class="score" aria-live="polite">
         <div class="score-player">
-          <span id="p1AvatarTop" class="score-avatar" aria-hidden="true"></span>
+          <span id="p1AvatarTop" class="score-avatar" data-self-player="true" aria-hidden="true"></span>
           <span id="p1Name" class="badge p1">P1</span>
         </div>
         <span id="s1">0</span>

--- a/webapp/src/components/GameLiveAvatarOverlay.jsx
+++ b/webapp/src/components/GameLiveAvatarOverlay.jsx
@@ -3,6 +3,9 @@ import { useLocation } from 'react-router-dom';
 import useLiveVideoChat from '../hooks/useLiveVideoChat.js';
 
 const AVATAR_ANCHOR_SELECTORS = [
+  '[data-self-player="true"] .seat-badge-core',
+  '[data-self-player="true"] .score-avatar',
+  '[data-self-player="true"] .avatar-timer-avatar',
   '[data-self-player="true"] img',
   '[data-self-player="true"] .avatar',
   '[data-self-player="true"]',
@@ -13,6 +16,7 @@ const AVATAR_ANCHOR_SELECTORS = [
   '[data-player-index="0"] img',
   '[data-player-index="0"] .avatar',
   '[data-player-index="0"]',
+  '#p1AvatarTop',
   '.player-avatar.you img',
   '.player-avatar.you',
   '.hud-player-you img',
@@ -81,7 +85,29 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
     if (typeof window === 'undefined') return undefined;
 
     let frameId = 0;
-    let resizeObserver;
+    const resizeObservers = [];
+    const mutationObservers = [];
+
+    const getIframeContexts = (rootDocument = document, offset = { x: 0, y: 0 }) => {
+      const contexts = [{ doc: rootDocument, offsetX: offset.x, offsetY: offset.y }];
+      const iframes = rootDocument.querySelectorAll('iframe');
+      iframes.forEach((iframe) => {
+        try {
+          const childDoc = iframe.contentDocument;
+          if (!childDoc?.body) return;
+          const rect = iframe.getBoundingClientRect();
+          contexts.push(
+            ...getIframeContexts(childDoc, {
+              x: offset.x + rect.left,
+              y: offset.y + rect.top
+            })
+          );
+        } catch {
+          // Cross-origin iframe; ignore.
+        }
+      });
+      return contexts;
+    };
 
     const scoreAnchor = (element, rect) => {
       let score = 0;
@@ -100,18 +126,27 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
       let bestRect = null;
       let bestScore = -Infinity;
       const seen = new Set();
-      for (const selector of AVATAR_ANCHOR_SELECTORS) {
-        const nodes = document.querySelectorAll(selector);
-        for (const candidate of nodes) {
-          if (seen.has(candidate)) continue;
-          seen.add(candidate);
-          const rect = candidate.getBoundingClientRect();
-          if (rect.width <= 8 || rect.height <= 8) continue;
-          const score = scoreAnchor(candidate, rect);
-          if (score > bestScore) {
-            bestScore = score;
-            bestRect = rect;
-            bestNode = candidate;
+      const contexts = getIframeContexts();
+      for (const context of contexts) {
+        for (const selector of AVATAR_ANCHOR_SELECTORS) {
+          const nodes = context.doc.querySelectorAll(selector);
+          for (const candidate of nodes) {
+            if (seen.has(candidate)) continue;
+            seen.add(candidate);
+            const localRect = candidate.getBoundingClientRect();
+            if (localRect.width <= 8 || localRect.height <= 8) continue;
+            const rect = {
+              top: localRect.top + context.offsetY,
+              left: localRect.left + context.offsetX,
+              width: localRect.width,
+              height: localRect.height
+            };
+            const score = scoreAnchor(candidate, rect);
+            if (score > bestScore) {
+              bestScore = score;
+              bestRect = rect;
+              bestNode = candidate;
+            }
           }
         }
       }
@@ -151,25 +186,42 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
       frameId = requestAnimationFrame(applyRect);
     };
 
-    const mutationObserver = new MutationObserver(scheduleApply);
-    mutationObserver.observe(document.body, {
-      childList: true,
-      subtree: true,
-      attributes: true
-    });
+    const observeContexts = () => {
+      mutationObservers.forEach((observer) => observer.disconnect());
+      resizeObservers.forEach((observer) => observer.disconnect());
+      mutationObservers.length = 0;
+      resizeObservers.length = 0;
 
-    resizeObserver = new ResizeObserver(scheduleApply);
-    resizeObserver.observe(document.body);
+      const contexts = getIframeContexts();
+      contexts.forEach((context) => {
+        if (!context.doc?.body) return;
+        const mutationObserver = new MutationObserver(scheduleApply);
+        mutationObserver.observe(context.doc.body, {
+          childList: true,
+          subtree: true,
+          attributes: true
+        });
+        mutationObservers.push(mutationObserver);
+
+        const resizeObserver = new ResizeObserver(scheduleApply);
+        resizeObserver.observe(context.doc.body);
+        resizeObservers.push(resizeObserver);
+      });
+    };
+
+    observeContexts();
     window.addEventListener('resize', scheduleApply);
     window.addEventListener('orientationchange', scheduleApply);
     window.addEventListener('scroll', scheduleApply, true);
+    const reobserveTimer = window.setTimeout(observeContexts, 450);
 
     scheduleApply();
 
     return () => {
       cancelAnimationFrame(frameId);
-      mutationObserver.disconnect();
-      resizeObserver?.disconnect();
+      mutationObservers.forEach((observer) => observer.disconnect());
+      resizeObservers.forEach((observer) => observer.disconnect());
+      window.clearTimeout(reobserveTimer);
       window.removeEventListener('resize', scheduleApply);
       window.removeEventListener('orientationchange', scheduleApply);
       window.removeEventListener('scroll', scheduleApply, true);

--- a/webapp/src/pages/Games/FourInRowRoyal.jsx
+++ b/webapp/src/pages/Games/FourInRowRoyal.jsx
@@ -1122,7 +1122,7 @@ export default function FourInRowRoyal() {
 
       <div className="pointer-events-none absolute inset-0 z-20">
         <div className="absolute left-1/2 top-[12%] -translate-x-1/2"><AvatarTimer photoUrl="🤖" name="AI Rival" active isTurn={turn === 'ai'} size={1} /></div>
-        <div className="absolute left-1/2 top-[85%] -translate-x-1/2"><AvatarTimer photoUrl={avatar} name={username} active isTurn={turn === 'player'} size={1} /></div>
+        <div data-self-player="true" className="absolute left-1/2 top-[85%] -translate-x-1/2"><AvatarTimer photoUrl={avatar} name={username} active isTurn={turn === 'player'} size={1} /></div>
       </div>
 
 

--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -6491,7 +6491,10 @@ function TexasHoldemArena({ search }) {
           />
         ))}
       </div>
-      <div className="absolute bottom-20 left-1/2 z-20 flex -translate-x-1/2 justify-center pointer-events-auto landscape:left-[calc(env(safe-area-inset-left,0px)+5.45rem)] landscape:bottom-[calc(env(safe-area-inset-bottom,0px)+2.45rem)] landscape:translate-x-0">
+      <div
+        data-self-player="true"
+        className="absolute bottom-20 left-1/2 z-20 flex -translate-x-1/2 justify-center pointer-events-auto landscape:left-[calc(env(safe-area-inset-left,0px)+5.45rem)] landscape:bottom-[calc(env(safe-area-inset-bottom,0px)+2.45rem)] landscape:translate-x-0"
+      >
         <div className="flex items-center space-x-3 rounded-full bg-white/10 px-4 py-3 text-xs shadow-lg backdrop-blur">
           {humanPlayer?.avatar &&
             (isHumanTurn ? (


### PR DESCRIPTION
### Motivation
- Make the existing “tap your avatar to open live camera/mic” UX available and consistent across additional games by ensuring the shared overlay can reliably find the player’s avatar element in each game's UI. 

### Description
- Extended `GameLiveAvatarOverlay.jsx` to search for avatar anchors across the main document and same-origin iframes, and to observe DOM + resize changes in those contexts so the overlay stays aligned while UI updates occur.  
- Added additional avatar anchor selectors (seat badges, score avatars, avatar-timer avatars, Goal Rush top avatar) so the overlay can match more game layouts.  
- Marked the human/self avatar nodes in UIs so detection is deterministic by adding `data-self-player=

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0c5115a408329a2b8d716f093c3cc)