### PR TITLE
Murlan Royale: keep player avatar visible with fixed bottom-center HUD

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -4777,6 +4777,7 @@ export default function MurlanRoyaleArena({ search }) {
         ) : null}
         <div className="absolute inset-0 pointer-events-none">
           {players.map((player, idx) => {
+            if (idx === humanPlayerIndex) return null;
             const activePlayer = gameState.players?.[idx] ?? player;
             const anchor = seatAnchorMap.get(idx);
             const fallback = FALLBACK_SEAT_POSITIONS[idx % FALLBACK_SEAT_POSITIONS.length];
@@ -4784,10 +4785,10 @@ export default function MurlanRoyaleArena({ search }) {
               ? {
                   position: 'absolute',
                   left: `${anchor.x}%`,
-                  top: `${anchor.y + (idx === humanPlayerIndex ? -2.2 : 0)}%`,
+                  top: `${anchor.y}%`,
                   transform: 'translate(-50%, -50%)'
                 }
-              : { position: 'absolute', left: fallback.left, top: idx === humanPlayerIndex ? '76.8%' : fallback.top, transform: 'translate(-50%, -50%)' };
+              : { position: 'absolute', left: fallback.left, top: fallback.top, transform: 'translate(-50%, -50%)' };
             const avatarSize = anchor ? clampValue(1.25 - (anchor.depth - 2.4) * 0.12, 0.85, 1.25) : 1;
             const color = PLAYER_COLORS[idx % PLAYER_COLORS.length];
             const isTurn = gameState.activePlayer === idx;
@@ -5034,6 +5035,26 @@ export default function MurlanRoyaleArena({ search }) {
                 <p className="mt-1 text-xs font-medium tracking-wide text-sky-100 drop-shadow-[0_2px_6px_rgba(0,0,0,0.8)]">{uiState.tableSummary}</p>
               )}
               {actionError && <p className="mt-1.5 text-[11px] font-semibold text-red-300 drop-shadow-[0_2px_6px_rgba(0,0,0,0.8)]">{actionError}</p>}
+            </div>
+          </div>
+        )}
+
+        {humanPlayer && (
+          <div className="pointer-events-none fixed bottom-[6.65rem] left-1/2 z-30 -translate-x-1/2">
+            <div className="flex flex-col items-center gap-1 rounded-2xl border border-white/20 bg-black/35 px-3 py-1.5 shadow-[0_8px_24px_rgba(2,6,23,0.5)] backdrop-blur-[2px]">
+              <AvatarTimer
+                index={humanPlayerIndex}
+                photoUrl={humanPlayer?.avatar}
+                active={gameState.activePlayer === humanPlayerIndex}
+                isTurn={gameState.activePlayer === humanPlayerIndex}
+                timerPct={1}
+                name={humanPlayer?.name}
+                color={PLAYER_COLORS[humanPlayerIndex % PLAYER_COLORS.length]}
+                size={1.08}
+              />
+              <span className="text-[0.65rem] font-semibold uppercase tracking-wide text-white/90 drop-shadow">
+                {humanPlayer?.hand?.length ?? 0} cards
+              </span>
             </div>
           </div>
         )}


### PR DESCRIPTION
### Motivation
- Ensure the human player's avatar remains visible on-screen in portrait mode by separating it from the in-world seat overlays which can be occluded by cards or UI. 
- Align the avatar visually between commentary text and the action/card controls to match the requested portrait layout. 
- No external skills were required to make these UI layout changes.

### Description
- Updated `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to skip rendering the human player's floating seat badge in the seat-overlay loop so the in-world anchor no longer controls the local avatar placement. 
- Added a dedicated fixed bottom-center HUD block that renders the human player's `AvatarTimer` and live hand-count; it is positioned at `bottom-[6.65rem]` and a higher z-index so it sits between the commentary block (`bottom-[8.6rem]`) and the action buttons (`bottom-[4.8rem]`). 
- Adjusted fallback/top positioning for other players' seat badges so non-human players continue to render at their anchors or fallback positions. 
- This change is purely UI/layout; no gameplay or networking logic was altered.

### Testing
- Ran the app build with `npm --prefix webapp run build`, which completed successfully. 
- Ran linter `npx eslint webapp/src/pages/Games/MurlanRoyaleArena.jsx` which produced the repo-specific ignore warning but no blocking errors. 
- No automated unit tests were modified; existing tests were not affected by this layout-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0d015ac188329bdfb1a888728ac34)