### PR TITLE
Add self-avatar live camera/mic panel to Domino, Goal Rush, and Four in Row

### DIFF
--- a/webapp/public/goal-rush.html
+++ b/webapp/public/goal-rush.html
@@ -26,6 +26,7 @@
     .score span{-webkit-text-stroke:0.3px #000;text-shadow:0 0 4px #000;color:#fff}
     .score-player{display:flex;align-items:center;gap:6px;min-width:0;}
     .score-avatar{width:28px;height:28px;border-radius:999px;background:#111;border:1px solid #233050;display:grid;place-items:center;font-size:16px;overflow:hidden;color:#fff;flex-shrink:0;}
+    .score-avatar[data-self-player="true"]{pointer-events:auto;cursor:pointer;}
     .score-avatar.img{background-size:cover;background-position:center;text-indent:-9999px;}
     .badge{padding:2px 6px;border-radius:999px;font-weight:800;color:#fff;-webkit-text-stroke:0.3px #000;text-shadow:0 0 4px #000;white-space:nowrap;font-size:12px;}
     .p1{background:var(--p1)}
@@ -97,6 +98,8 @@
     .chat-bubble{position:fixed;display:flex;align-items:center;gap:.35rem;padding:.35rem .6rem;border-radius:999px;background:rgba(8,13,26,.88);border:1px solid rgba(255,255,255,.12);color:#f8fafc;font-size:.7rem;font-weight:700;box-shadow:0 10px 24px rgba(0,0,0,.45);z-index:7;pointer-events:none;white-space:nowrap;}
     .chat-bubble img,.chat-bubble .avatar{width:1.2rem;height:1.2rem;border-radius:999px;display:grid;place-items:center;background:rgba(255,255,255,.2);font-size:.75rem;}
     .toast{position:fixed;left:50%;bottom:calc(env(safe-area-inset-bottom,0px) + 4.5rem);transform:translateX(-50%);padding:.4rem .75rem;border-radius:999px;background:rgba(15,23,42,.8);border:1px solid rgba(255,255,255,.18);color:#f8fafc;font-size:.72rem;font-weight:700;z-index:7;box-shadow:0 10px 24px rgba(0,0,0,.45);pointer-events:none;}
+    .live-status{font-size:.65rem;color:#86efac;}
+    .live-video{height:8rem;width:100%;border-radius:.65rem;background:#000;object-fit:cover;transform:scaleX(-1);}
     #rules{position:fixed;top:0;left:0;right:0;bottom:0;display:none;align-items:center;justify-content:center;background:rgba(5,8,18,.75);z-index:6;backdrop-filter:blur(2px);}
     #rules .card{max-width:720px;background:#0b1220;color:#e5e7eb;border-radius:16px;box-shadow:0 18px 38px rgba(0,0,0,.45);padding:16px 18px;border:1px solid #233050;}
     #rules h2{margin:0 0 6px 0;font-size:18px;letter-spacing:0.35px;}
@@ -222,6 +225,23 @@
       <p class="gift-note" id="commentarySupportNote" style="display:none;">Voice commentary needs Web Speech support.</p>
     </div>
   </div>
+  <div id="liveModal" class="modal-overlay" aria-hidden="true">
+    <div class="modal-card" role="dialog" aria-modal="true" aria-labelledby="liveTitle">
+      <div class="modal-header">
+        <h3 id="liveTitle">Live Camera & Mic</h3>
+        <button class="modal-close" id="liveClose" type="button" aria-label="Close live camera">✕</button>
+      </div>
+      <div class="gift-note">Tap your avatar to open this panel.</div>
+      <video id="livePreview" class="live-video" autoplay playsinline muted></video>
+      <div id="liveStatus" class="live-status">Ready</div>
+      <div class="quick-messages" style="grid-template-columns:1fr;">
+        <button id="liveStart" type="button">Start camera & mic</button>
+        <button id="liveToggleMic" type="button">Toggle mic</button>
+        <button id="liveToggleCamera" type="button">Toggle camera</button>
+        <button id="liveStop" type="button">Stop</button>
+      </div>
+    </div>
+  </div>
   <div class="hint" id="startHint"></div>
   <div class="landscape-block" style="display:none">Please hold your phone in <b>portrait</b> for the best experience.</div>
 
@@ -259,6 +279,14 @@
   const commentaryMuteButton = document.getElementById('commentaryMute');
   const commentaryMuteState = document.getElementById('commentaryMuteState');
   const commentarySupportNote = document.getElementById('commentarySupportNote');
+  const liveModal = document.getElementById('liveModal');
+  const liveClose = document.getElementById('liveClose');
+  const liveStart = document.getElementById('liveStart');
+  const liveStop = document.getElementById('liveStop');
+  const liveToggleMic = document.getElementById('liveToggleMic');
+  const liveToggleCamera = document.getElementById('liveToggleCamera');
+  const livePreview = document.getElementById('livePreview');
+  const liveStatus = document.getElementById('liveStatus');
   const muteIcon = document.getElementById('muteIcon');
   const muteLabel = document.getElementById('muteLabel');
   const TOP_BAR = 0; // no top offset: HUD moved to bottom so the field can rise up a bit
@@ -340,6 +368,7 @@
   await loadCalibration();
 
   let currentRound = 0;
+  let liveStream = null;
   if(window.tournamentMode){
     try{
       const st = JSON.parse(localStorage.getItem(TOURN_STATE_KEY) || '{}');
@@ -1534,6 +1563,47 @@
     toggleModal(commentaryModal, true);
   }
 
+  function setLiveStatus(text) {
+    if (liveStatus) liveStatus.textContent = text;
+  }
+
+  async function startLivePreview() {
+    if (liveStream) {
+      setLiveStatus('Live preview active');
+      return;
+    }
+    try {
+      liveStream = await navigator.mediaDevices.getUserMedia({
+        audio: true,
+        video: { width: { ideal: 640 }, height: { ideal: 360 }, facingMode: 'user' }
+      });
+      if (livePreview) livePreview.srcObject = liveStream;
+      setLiveStatus('Live preview active');
+    } catch (error) {
+      setLiveStatus(error?.message || 'Unable to access camera and microphone.');
+    }
+  }
+
+  function stopLivePreview() {
+    if (liveStream) {
+      liveStream.getTracks().forEach((track) => track.stop());
+      liveStream = null;
+    }
+    if (livePreview) livePreview.srcObject = null;
+    setLiveStatus('Live preview stopped');
+  }
+
+  function toggleLiveTrack(kind) {
+    if (!liveStream) return;
+    const tracks = kind === 'audio' ? liveStream.getAudioTracks() : liveStream.getVideoTracks();
+    if (!tracks.length) return;
+    const enabled = !tracks.every((track) => track.enabled);
+    tracks.forEach((track) => { track.enabled = enabled; });
+    const micOn = liveStream.getAudioTracks().every((track) => track.enabled);
+    const camOn = liveStream.getVideoTracks().every((track) => track.enabled);
+    setLiveStatus(`Mic ${micOn ? 'On' : 'Off'} · Camera ${camOn ? 'On' : 'Off'}`);
+  }
+
   updateQuickActionMute();
   updateCommentaryMuteState();
   updateCommentarySupport();
@@ -1612,6 +1682,32 @@
       }
     });
   }
+  if (p1AvatarTop) {
+    p1AvatarTop.addEventListener('click', () => {
+      toggleModal(liveModal, true);
+    });
+  }
+  if (liveModal) {
+    liveModal.addEventListener('click', (event) => {
+      if (event.target === liveModal) toggleModal(liveModal, false);
+    });
+  }
+  if (liveClose) {
+    liveClose.addEventListener('click', () => toggleModal(liveModal, false));
+  }
+  if (liveStart) {
+    liveStart.addEventListener('click', () => { startLivePreview(); });
+  }
+  if (liveStop) {
+    liveStop.addEventListener('click', () => { stopLivePreview(); });
+  }
+  if (liveToggleMic) {
+    liveToggleMic.addEventListener('click', () => { toggleLiveTrack('audio'); });
+  }
+  if (liveToggleCamera) {
+    liveToggleCamera.addEventListener('click', () => { toggleLiveTrack('video'); });
+  }
+  window.addEventListener('beforeunload', stopLivePreview);
 
   const keys = new Set();
   const touches = new Map();

--- a/webapp/src/components/LocalMediaPanel.jsx
+++ b/webapp/src/components/LocalMediaPanel.jsx
@@ -1,0 +1,93 @@
+import React from 'react';
+
+export default function LocalMediaPanel({
+  open,
+  onClose,
+  stream,
+  mediaState,
+  isActive,
+  error,
+  onStart,
+  onStop,
+  onToggleMicrophone,
+  onToggleCamera,
+  title = 'Live Camera & Mic'
+}) {
+  const videoRef = React.useRef(null);
+
+  React.useEffect(() => {
+    if (!videoRef.current) return;
+    videoRef.current.srcObject = stream || null;
+  }, [stream]);
+
+  if (!open) return null;
+
+  return (
+    <div className="absolute inset-0 z-[80] flex items-end justify-center bg-black/65 p-3 backdrop-blur-sm pointer-events-auto">
+      <div className="w-full max-w-sm rounded-2xl border border-white/15 bg-slate-950/95 p-3 text-white shadow-2xl">
+        <div className="mb-3 flex items-center justify-between">
+          <h3 className="text-sm font-semibold uppercase tracking-[0.2em]">{title}</h3>
+          <button
+            type="button"
+            className="rounded-md border border-white/20 px-2 py-1 text-xs hover:bg-white/10"
+            onClick={onClose}
+          >
+            Close
+          </button>
+        </div>
+
+        {error ? <p className="mb-2 rounded-md bg-red-500/20 px-2 py-1 text-xs text-red-100">{error}</p> : null}
+
+        <div className="rounded-xl border border-white/15 bg-black/60 p-2">
+          <div className="mb-1 flex items-center justify-between text-[10px] uppercase tracking-[0.2em] text-white/70">
+            <span>You</span>
+            <span>{mediaState?.microphone === false ? '🎙️ Off' : '🎙️ On'} · {mediaState?.camera === false ? '📷 Off' : '📷 On'}</span>
+          </div>
+          <video
+            ref={videoRef}
+            autoPlay
+            playsInline
+            muted
+            className="h-28 w-full rounded-lg bg-black object-cover scale-x-[-1]"
+          />
+        </div>
+
+        <div className="mt-3 flex flex-wrap items-center gap-2">
+          {!isActive ? (
+            <button
+              type="button"
+              onClick={onStart}
+              className="rounded-full bg-emerald-500 px-3 py-1 text-xs font-semibold text-white hover:bg-emerald-400"
+            >
+              Start camera & mic
+            </button>
+          ) : (
+            <>
+              <button
+                type="button"
+                onClick={onToggleMicrophone}
+                className="rounded-full border border-white/25 px-3 py-1 text-xs hover:bg-white/10"
+              >
+                Toggle mic
+              </button>
+              <button
+                type="button"
+                onClick={onToggleCamera}
+                className="rounded-full border border-white/25 px-3 py-1 text-xs hover:bg-white/10"
+              >
+                Toggle camera
+              </button>
+              <button
+                type="button"
+                onClick={onStop}
+                className="rounded-full bg-rose-500 px-3 py-1 text-xs font-semibold text-white hover:bg-rose-400"
+              >
+                Stop
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/hooks/useLocalMediaPreview.js
+++ b/webapp/src/hooks/useLocalMediaPreview.js
@@ -1,0 +1,79 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const DEFAULT_STATE = Object.freeze({ microphone: true, camera: true });
+
+export default function useLocalMediaPreview() {
+  const [stream, setStream] = useState(null);
+  const [isActive, setIsActive] = useState(false);
+  const [mediaState, setMediaState] = useState(DEFAULT_STATE);
+  const [error, setError] = useState('');
+  const streamRef = useRef(null);
+
+  const stop = useCallback(() => {
+    if (streamRef.current) {
+      streamRef.current.getTracks().forEach((track) => track.stop());
+      streamRef.current = null;
+    }
+    setStream(null);
+    setIsActive(false);
+    setMediaState(DEFAULT_STATE);
+  }, []);
+
+  const start = useCallback(async () => {
+    if (streamRef.current) {
+      setIsActive(true);
+      return;
+    }
+    setError('');
+    try {
+      const nextStream = await navigator.mediaDevices.getUserMedia({
+        audio: true,
+        video: {
+          width: { ideal: 640 },
+          height: { ideal: 360 },
+          facingMode: 'user'
+        }
+      });
+      streamRef.current = nextStream;
+      setStream(nextStream);
+      setIsActive(true);
+      setMediaState({
+        microphone: nextStream.getAudioTracks().every((track) => track.enabled),
+        camera: nextStream.getVideoTracks().every((track) => track.enabled)
+      });
+    } catch (mediaError) {
+      const message = mediaError instanceof Error ? mediaError.message : 'Unable to access camera and microphone.';
+      setError(message);
+      setIsActive(false);
+    }
+  }, []);
+
+  const toggleTrack = useCallback((kind) => {
+    const activeStream = streamRef.current;
+    if (!activeStream) return;
+    const tracks = kind === 'audio' ? activeStream.getAudioTracks() : activeStream.getVideoTracks();
+    if (!tracks.length) return;
+    const nextEnabled = !tracks.every((track) => track.enabled);
+    tracks.forEach((track) => {
+      track.enabled = nextEnabled;
+    });
+    setMediaState((prev) => ({
+      ...prev,
+      microphone: kind === 'audio' ? nextEnabled : prev.microphone,
+      camera: kind === 'video' ? nextEnabled : prev.camera
+    }));
+  }, []);
+
+  useEffect(() => () => stop(), [stop]);
+
+  return {
+    stream,
+    isActive,
+    mediaState,
+    error,
+    start,
+    stop,
+    toggleCamera: () => toggleTrack('video'),
+    toggleMicrophone: () => toggleTrack('audio')
+  };
+}

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -1,11 +1,16 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
+import LocalMediaPanel from '../../components/LocalMediaPanel.jsx';
+import useLocalMediaPreview from '../../hooks/useLocalMediaPreview.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
 
 export default function DominoRoyalArena() {
+  const [showLivePanel, setShowLivePanel] = useState(false);
+  const liveMedia = useLocalMediaPreview();
+
   useEffect(() => {
     const statusNode = document.getElementById('status');
     const appRoot = document.getElementById('app');
@@ -48,7 +53,17 @@ export default function DominoRoyalArena() {
     };
     document.body.appendChild(script);
 
+    const handleSelfAvatarClick = (event) => {
+      const target = event.target;
+      if (!(target instanceof Element)) return;
+      if (!target.closest('[data-self-player="true"]')) return;
+      event.preventDefault();
+      setShowLivePanel(true);
+    };
+    document.addEventListener('click', handleSelfAvatarClick, true);
+
     return () => {
+      document.removeEventListener('click', handleSelfAvatarClick, true);
       if (typeof window.__dominoRoyalCleanup === 'function') {
         window.__dominoRoyalCleanup('react-unmount');
       }
@@ -363,6 +378,18 @@ export default function DominoRoyalArena() {
           </div>
         </div>
       </div>
+      <LocalMediaPanel
+        open={showLivePanel}
+        onClose={() => setShowLivePanel(false)}
+        stream={liveMedia.stream}
+        mediaState={liveMedia.mediaState}
+        isActive={liveMedia.isActive}
+        error={liveMedia.error}
+        onStart={liveMedia.start}
+        onStop={liveMedia.stop}
+        onToggleMicrophone={liveMedia.toggleMicrophone}
+        onToggleCamera={liveMedia.toggleCamera}
+      />
     </div>
   );
 }

--- a/webapp/src/pages/Games/FourInRowRoyal.jsx
+++ b/webapp/src/pages/Games/FourInRowRoyal.jsx
@@ -39,6 +39,8 @@ import BottomLeftIcons from '../../components/BottomLeftIcons.jsx';
 import AvatarTimer from '../../components/AvatarTimer.jsx';
 import GiftPopup from '../../components/GiftPopup.jsx';
 import QuickMessagePopup from '../../components/QuickMessagePopup.jsx';
+import LocalMediaPanel from '../../components/LocalMediaPanel.jsx';
+import useLocalMediaPreview from '../../hooks/useLocalMediaPreview.js';
 import { fourInRowAccountId, getFourInRowInventory } from '../../utils/fourInRowInventory.js';
 import { applyRendererSRGB } from '../../utils/colorSpace.js';
 
@@ -404,6 +406,8 @@ export default function FourInRowRoyal() {
   const [showChat, setShowChat] = useState(false);
   const [showGift, setShowGift] = useState(false);
   const [chatBubbles, setChatBubbles] = useState([]);
+  const [showLivePanel, setShowLivePanel] = useState(false);
+  const liveMedia = useLocalMediaPreview();
 
   useEffect(() => {
     hoverColRef.current = hoverCol;
@@ -1133,7 +1137,16 @@ export default function FourInRowRoyal() {
 
       <div className="pointer-events-none absolute inset-0 z-20">
         <div className="absolute left-1/2 top-[12%] -translate-x-1/2"><AvatarTimer photoUrl="🤖" name="AI Rival" active isTurn={turn === 'ai'} size={1} /></div>
-        <div data-self-player="true" className="absolute left-1/2 top-[85%] -translate-x-1/2"><AvatarTimer photoUrl={avatar} name={username} active isTurn={turn === 'player'} size={1} /></div>
+        <div data-self-player="true" className="absolute left-1/2 top-[85%] -translate-x-1/2">
+          <AvatarTimer
+            photoUrl={avatar}
+            name={username}
+            active
+            isTurn={turn === 'player'}
+            size={1}
+            onClick={() => setShowLivePanel(true)}
+          />
+        </div>
       </div>
 
 
@@ -1192,6 +1205,18 @@ export default function FourInRowRoyal() {
       <QuickMessagePopup open={showChat} onClose={() => setShowChat(false)} title="Quick Chat" onSend={(text) => { const id = Date.now(); setChatBubbles((b) => [...b, { id, text, photoUrl: avatar || '/assets/icons/profile.svg' }]); setTimeout(() => setChatBubbles((b) => b.filter((x) => x.id !== id)), 3000); }} />
       {chatBubbles.map((bubble) => <div key={bubble.id} className="chat-bubble chess-battle-chat-bubble"><span>{bubble.text}</span><img src={bubble.photoUrl} alt="avatar" className="w-5 h-5 rounded-full" /></div>)}
       <GiftPopup open={showGift} onClose={() => setShowGift(false)} players={[{ index: 0, id: fourInRowAccountId(accountId || undefined), name: username, photoUrl: avatar || '/assets/icons/profile.svg' }, { index: 1, id: 'ai-rival', name: 'AI Rival', photoUrl: '/assets/icons/bot.webp' }]} senderIndex={0} title="Send Gift" />
+      <LocalMediaPanel
+        open={showLivePanel}
+        onClose={() => setShowLivePanel(false)}
+        stream={liveMedia.stream}
+        mediaState={liveMedia.mediaState}
+        isActive={liveMedia.isActive}
+        error={liveMedia.error}
+        onStart={liveMedia.start}
+        onStop={liveMedia.stop}
+        onToggleMicrophone={liveMedia.toggleMicrophone}
+        onToggleCamera={liveMedia.toggleCamera}
+      />
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Provide the same UX available in other games (tap your avatar to open a live camera + mic preview and controls) for Domino Royal, Goal Rush, and Four in Row so players can quickly change their avatar via camera/mic in-match.
- Reuse a single implementation so the behavior, lifecycle and controls are identical across games and easier to maintain.

### Description
- Added a reusable hook `useLocalMediaPreview` that manages `getUserMedia` lifecycle, exposes `stream`, `isActive`, `mediaState`, `start`, `stop`, `toggleCamera`, and `toggleMicrophone` (file: `webapp/src/hooks/useLocalMediaPreview.js`).
- Added a reusable UI component `LocalMediaPanel` to show the local preview, status and Start/Stop + mic/camera toggles (file: `webapp/src/components/LocalMediaPanel.jsx`).
- Wired Four in Row to open the shared live panel when the local player's avatar is tapped by adding an `onClick` to the `AvatarTimer` and hooking the panel to the `useLocalMediaPreview` API (file: `webapp/src/pages/Games/FourInRowRoyal.jsx`).
- Wired Domino Royal by listening for clicks on DOM nodes annotated `data-self-player="true"` (these are produced by the embedded game script) and opening the same panel bound to the shared hook (file: `webapp/src/pages/Games/DominoRoyalArena.jsx`).
- Updated Goal Rush static game to make the self avatar clickable and added an in-page live modal with preview and controls implementing the same start/stop and toggle logic (file: `webapp/public/goal-rush.html`).

### Testing
- Ran ESLint across the touched paths with `npx eslint webapp/src/pages/Games/FourInRowRoyal.jsx webapp/src/pages/Games/DominoRoyalArena.jsx webapp/src/components/LocalMediaPanel.jsx webapp/src/hooks/useLocalMediaPreview.js webapp/public/goal-rush.html`, which completed with warning-only "file ignored" notices (no lint errors).
- No other automated unit or integration tests were run as part of this change in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0d04fe1208329b68ac840b53db8fe)