### PR TITLE
Improve live avatar click targeting for Domino Royal, Goal Rush, and Four In Row

### DIFF
--- a/webapp/src/components/GameLiveAvatarOverlay.jsx
+++ b/webapp/src/components/GameLiveAvatarOverlay.jsx
@@ -4,8 +4,13 @@ import useLiveVideoChat from '../hooks/useLiveVideoChat.js';
 
 const AVATAR_ANCHOR_SELECTORS = [
   '[data-self-player="true"] .seat-badge-core',
+  '[data-self-player="true"].seat-badge-core',
+  '.seat-badge.is-self .seat-badge-core',
+  '.seat-badge.is-self',
   '[data-self-player="true"] .score-avatar',
+  '[data-self-player="true"].score-avatar',
   '[data-self-player="true"] .avatar-timer-avatar',
+  '[data-self-player="true"].avatar-timer-avatar',
   '[data-self-player="true"] img',
   '[data-self-player="true"] .avatar',
   '[data-self-player="true"]',
@@ -17,6 +22,7 @@ const AVATAR_ANCHOR_SELECTORS = [
   '[data-player-index="0"] .avatar',
   '[data-player-index="0"]',
   '#p1AvatarTop',
+  '#p1Avatar',
   '.player-avatar.you img',
   '.player-avatar.you',
   '.hud-player-you img',
@@ -81,6 +87,19 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
     localVideoRef.current.srcObject = liveChat.localStream || null;
   }, [liveChat.localStream]);
 
+  const prioritizedSelectors = useMemo(() => {
+    if (gameSlug === 'goalrush') {
+      return ['#p1AvatarTop', '#p1Avatar', '[data-self-player="true"]', ...AVATAR_ANCHOR_SELECTORS];
+    }
+    if (gameSlug === 'domino-royal') {
+      return ['.seat-badge.is-self .seat-badge-core', '.seat-badge.is-self', ...AVATAR_ANCHOR_SELECTORS];
+    }
+    if (gameSlug === 'fourinrowroyale') {
+      return ['[data-self-player="true"] .avatar-timer-avatar', '[data-self-player="true"]', ...AVATAR_ANCHOR_SELECTORS];
+    }
+    return AVATAR_ANCHOR_SELECTORS;
+  }, [gameSlug]);
+
   useLayoutEffect(() => {
     if (typeof window === 'undefined') return undefined;
 
@@ -128,7 +147,7 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
       const seen = new Set();
       const contexts = getIframeContexts();
       for (const context of contexts) {
-        for (const selector of AVATAR_ANCHOR_SELECTORS) {
+        for (const selector of prioritizedSelectors) {
           const nodes = context.doc.querySelectorAll(selector);
           for (const candidate of nodes) {
             if (seen.has(candidate)) continue;
@@ -226,7 +245,7 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
       window.removeEventListener('orientationchange', scheduleApply);
       window.removeEventListener('scroll', scheduleApply, true);
     };
-  }, [gameSlug, search]);
+  }, [gameSlug, prioritizedSelectors, search]);
 
   useEffect(() => {
     if (!anchorElement) return undefined;


### PR DESCRIPTION
### Motivation
- Make the live camera/mic toggle attach to the same self-avatar element users already click in Domino Royal, Goal Rush and Four In Row so the existing live-avatar flow (camera+mic) works consistently across these games.

### Description
- Expanded the generic avatar detection list by adding selectors such as `#p1Avatar`, `.seat-badge.is-self`, direct `.score-avatar`, and direct `.avatar-timer-avatar` in `webapp/src/components/GameLiveAvatarOverlay.jsx`.
- Added a `prioritizedSelectors` `useMemo` that returns game-specific ordered selector lists for `goalrush`, `domino-royal`, and `fourinrowroyale` so preferred anchors are checked first.
- Replaced the avatar discovery loop to iterate over `prioritizedSelectors` and added `prioritizedSelectors` to the `useLayoutEffect` dependency list so anchor detection updates correctly per game context.
- Change is limited to selection/attachment logic and preserves the existing `useLiveVideoChat` flow and UI overlay behavior.

### Testing
- Ran a production build with `npm run build` in `webapp/` and it completed successfully.
- No automated unit tests were modified or run beyond the build step (build succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0d04fe1208329b68ac840b53db8fe)