### PR TITLE
Fix: keep human avatar fixed between commentary and hand in Murlan Royale

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -4780,14 +4780,22 @@ export default function MurlanRoyaleArena({ search }) {
             const activePlayer = gameState.players?.[idx] ?? player;
             const anchor = seatAnchorMap.get(idx);
             const fallback = FALLBACK_SEAT_POSITIONS[idx % FALLBACK_SEAT_POSITIONS.length];
-            const positionStyle = anchor
+            const positionStyle = idx === humanPlayerIndex
               ? {
-                  position: 'absolute',
-                  left: `${anchor.x}%`,
-                  top: `${anchor.y + (idx === humanPlayerIndex ? -2.2 : 0)}%`,
-                  transform: 'translate(-50%, -50%)'
+                  position: 'fixed',
+                  left: '50%',
+                  bottom: 'calc(6.7rem + env(safe-area-inset-bottom, 0px))',
+                  transform: 'translateX(-50%)',
+                  zIndex: 24
                 }
-              : { position: 'absolute', left: fallback.left, top: idx === humanPlayerIndex ? '76.8%' : fallback.top, transform: 'translate(-50%, -50%)' };
+              : anchor
+                ? {
+                    position: 'absolute',
+                    left: `${anchor.x}%`,
+                    top: `${anchor.y}%`,
+                    transform: 'translate(-50%, -50%)'
+                  }
+                : { position: 'absolute', left: fallback.left, top: fallback.top, transform: 'translate(-50%, -50%)' };
             const avatarSize = anchor ? clampValue(1.25 - (anchor.depth - 2.4) * 0.12, 0.85, 1.25) : 1;
             const color = PLAYER_COLORS[idx % PLAYER_COLORS.length];
             const isTurn = gameState.activePlayer === idx;


### PR DESCRIPTION
### Motivation
- The human player's avatar/timer could move with seat anchoring and become obscured by other UI elements in portrait play, reducing visibility during the full match. 
- The avatar should remain visible in the lane between commentary text and the bottom action/hand area on mobile portrait screens.

### Description
- Move the human player avatar/timer stack to a bottom-center persistent HUD by setting `position: fixed`, `left: '50%'`, `bottom: 'calc(6.7rem + env(safe-area-inset-bottom, 0px))'`, `transform: 'translateX(-50%)'`, and `zIndex: 24` in `MurlanRoyaleArena`.
- Keep non-human players (AI/opponents) using their existing anchored positioning so only the bottom user avatar is persistent.
- Modified file: `webapp/src/pages/Games/MurlanRoyaleArena.jsx` (updated `positionStyle` logic for `humanPlayerIndex`).

### Testing
- Ran the production build with `npm --prefix webapp run build` and it completed successfully (build completed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0d015ac188329bdfb1a888728ac34)