### PR TITLE
Match live avatar video frame to avatar size

### DIFF
--- a/webapp/src/components/GameLiveAvatarOverlay.jsx
+++ b/webapp/src/components/GameLiveAvatarOverlay.jsx
@@ -175,7 +175,7 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
     const applyRect = () => {
       const { rect, node } = findAvatarAnchor();
       if (!rect) return;
-      const FRAME_SCALE = 1.2;
+      const FRAME_SCALE = 1;
       const width = Math.max(Math.round(rect.width * FRAME_SCALE), 32);
       const height = Math.max(Math.round(rect.height * FRAME_SCALE), 32);
       const left = Math.max(


### PR DESCRIPTION
### Motivation
- Ensure the live video bubble exactly matches the detected avatar anchor size by removing the previous inflation so the avatar stays at its real on-screen size.

### Description
- Change `FRAME_SCALE` from `1.2` to `1` in `webapp/src/components/GameLiveAvatarOverlay.jsx`, preserving the existing centering logic and the 32px minimum dimension.

### Testing
- Ran `npm --prefix webapp run build` which completed successfully; Vite produced only non-blocking chunk/dynamic-import warnings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0d5a394fc83299447666bd49ec514)