### PR TITLE
Improve live avatar anchor detection across Domino/Goal Rush/Four-in-Row UIs

### DIFF
--- a/webapp/src/components/GameLiveAvatarOverlay.jsx
+++ b/webapp/src/components/GameLiveAvatarOverlay.jsx
@@ -3,6 +3,8 @@ import { useLocation } from 'react-router-dom';
 import useLiveVideoChat from '../hooks/useLiveVideoChat.js';
 
 const AVATAR_ANCHOR_SELECTORS = [
+  '.seat-badge.is-self .seat-badge-core',
+  '.seat-badge.is-self',
   '[data-self-player="true"] .seat-badge-core',
   '[data-self-player="true"] .score-avatar',
   '[data-self-player="true"] .avatar-timer-avatar',
@@ -87,6 +89,7 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
     let frameId = 0;
     const resizeObservers = [];
     const mutationObservers = [];
+    const iframeLoadListeners = [];
 
     const getIframeContexts = (rootDocument = document, offset = { x: 0, y: 0 }) => {
       const contexts = [{ doc: rootDocument, offsetX: offset.x, offsetY: offset.y }];
@@ -189,8 +192,12 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
     const observeContexts = () => {
       mutationObservers.forEach((observer) => observer.disconnect());
       resizeObservers.forEach((observer) => observer.disconnect());
+      iframeLoadListeners.forEach(({ iframe, listener }) => {
+        iframe.removeEventListener('load', listener);
+      });
       mutationObservers.length = 0;
       resizeObservers.length = 0;
+      iframeLoadListeners.length = 0;
 
       const contexts = getIframeContexts();
       contexts.forEach((context) => {
@@ -207,6 +214,15 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
         resizeObserver.observe(context.doc.body);
         resizeObservers.push(resizeObserver);
       });
+
+      document.querySelectorAll('iframe').forEach((iframe) => {
+        const listener = () => {
+          observeContexts();
+          scheduleApply();
+        };
+        iframe.addEventListener('load', listener);
+        iframeLoadListeners.push({ iframe, listener });
+      });
     };
 
     observeContexts();
@@ -214,6 +230,7 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
     window.addEventListener('orientationchange', scheduleApply);
     window.addEventListener('scroll', scheduleApply, true);
     const reobserveTimer = window.setTimeout(observeContexts, 450);
+    const fallbackScanTimer = window.setInterval(scheduleApply, 1200);
 
     scheduleApply();
 
@@ -221,7 +238,11 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
       cancelAnimationFrame(frameId);
       mutationObservers.forEach((observer) => observer.disconnect());
       resizeObservers.forEach((observer) => observer.disconnect());
+      iframeLoadListeners.forEach(({ iframe, listener }) => {
+        iframe.removeEventListener('load', listener);
+      });
       window.clearTimeout(reobserveTimer);
+      window.clearInterval(fallbackScanTimer);
       window.removeEventListener('resize', scheduleApply);
       window.removeEventListener('orientationchange', scheduleApply);
       window.removeEventListener('scroll', scheduleApply, true);


### PR DESCRIPTION
### Motivation
- Make the click-to-enable live camera/microphone overlay behave identically across games (Domino Royal, Goal Rush, Four in a Row) by reliably detecting the user's avatar element. 
- Address cases where game UIs use different DOM patterns (e.g. `.seat-badge.is-self`) or render inside iframes, which prevented the overlay from binding to the avatar. 
- Improve robustness for late/mount-time rendering so live-avatar discovery works even when mutation/resize events are missed.

### Description
- Expanded avatar anchor selector list by adding `'.seat-badge.is-self .seat-badge-core'` and `'.seat-badge.is-self'` to detect Domino-style self-seat avatar elements used in the game UIs in `webapp/src/components/GameLiveAvatarOverlay.jsx`. 
- Added `load` event listeners for `iframe` elements and re-run the observer/anchor discovery when an iframe finishes loading so embedded games (e.g. Goal Rush) are handled correctly. 
- Implemented a lightweight periodic fallback scan (`setInterval`) to re-check anchors periodically to handle delayed rendering scenarios, and ensured listeners/observers are cleaned up on unmount. 
- Changes are contained in `webapp/src/components/GameLiveAvatarOverlay.jsx` and are intended to make the overlay reuse the same live-avatar logic already used by other games.

### Testing
- Built the webapp with `npm --prefix webapp run build`, which completed successfully and produced a production build. 
- The build emitted non-blocking Vite chunking warnings, but no build errors were encountered.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0d04fe1208329b68ac840b53db8fe)