### PR TITLE
Raise human player avatar in Murlan Royale to avoid commentary overlap

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -4784,7 +4784,7 @@ export default function MurlanRoyaleArena({ search }) {
               ? {
                   position: 'fixed',
                   left: '50%',
-                  bottom: 'calc(6.7rem + env(safe-area-inset-bottom, 0px))',
+                  bottom: 'calc(9.8rem + env(safe-area-inset-bottom, 0px))',
                   transform: 'translateX(-50%)',
                   zIndex: 24
                 }


### PR DESCRIPTION
### Motivation
- Prevent the bottom-center human avatar from overlapping the commentary panel and the bottom user/action area on portrait screens so commentary text remains readable and spacing is preserved.

### Description
- Adjusted the fixed bottom offset for the human player avatar in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` from `calc(6.7rem + env(safe-area-inset-bottom, 0px))` to `calc(9.8rem + env(safe-area-inset-bottom, 0px))` to move the avatar higher on-screen.

### Testing
- Ran `npx eslint webapp/src/pages/Games/MurlanRoyaleArena.jsx`, which returned an ESLint ignore warning for the file but no lint errors; no other automated tests were changed or run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0d7ac570c83299dcf56f40bbee5c9)