### PR TITLE
Unify live avatar video frame size across games

### DIFF
--- a/webapp/src/components/GameLiveAvatarOverlay.jsx
+++ b/webapp/src/components/GameLiveAvatarOverlay.jsx
@@ -2,6 +2,8 @@ import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import useLiveVideoChat from '../hooks/useLiveVideoChat.js';
 
+const POOL_ROYALE_VIDEO_FRAME_SIZE = 44;
+
 const AVATAR_ANCHOR_SELECTORS = [
   '[data-self-player="true"] .seat-badge-core',
   '[data-self-player="true"].seat-badge-core',
@@ -175,9 +177,8 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
     const applyRect = () => {
       const { rect, node } = findAvatarAnchor();
       if (!rect) return;
-      const FRAME_SCALE = 1.2;
-      const width = Math.max(Math.round(rect.width * FRAME_SCALE), 32);
-      const height = Math.max(Math.round(rect.height * FRAME_SCALE), 32);
+      const width = Math.max(POOL_ROYALE_VIDEO_FRAME_SIZE, 32);
+      const height = Math.max(POOL_ROYALE_VIDEO_FRAME_SIZE, 32);
       const left = Math.max(
         Math.round(rect.left - (width - rect.width) / 2),
         0


### PR DESCRIPTION
### Motivation
- Ensure the live avatar video overlay uses the same fixed frame size as the Pool Royale UI while keeping the detected avatar element itself unchanged so the avatar visual size is not altered.

### Description
- Add a shared constant `POOL_ROYALE_VIDEO_FRAME_SIZE = 44` in `GameLiveAvatarOverlay` and use it to compute overlay dimensions instead of scaling by each anchor's size. 
- Remove the previous `FRAME_SCALE` per-avatar scaling logic and apply a fixed width/height (with a lower bound of `32`) while preserving the overlay centering calculation and anchor detection. 
- Keep existing iframe/context observation, mutation/resize observers, and click/toggle behavior intact so anchoring and live-mode behavior remain unchanged.

### Testing
- Ran `npm run build` from `webapp/` and the production build completed successfully. 
- The build emitted existing Vite warnings about chunk sizes/dynamic imports but these are non-blocking and do not prevent the build from completing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0d5a394fc83299447666bd49ec514)