### PR TITLE
Raise human avatar overlay in Murlan Royale arena

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -4784,7 +4784,7 @@ export default function MurlanRoyaleArena({ search }) {
               ? {
                   position: 'fixed',
                   left: '50%',
-                  bottom: 'calc(9.8rem + env(safe-area-inset-bottom, 0px))',
+                  bottom: 'calc(10.4rem + env(safe-area-inset-bottom, 0px))',
                   transform: 'translateX(-50%)',
                   zIndex: 24
                 }


### PR DESCRIPTION
### Motivation
- Improve the visual positioning of the human player's avatar on portrait/mobile screens by moving it slightly higher on the page.

### Description
- Updated `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to increase the human player's fixed bottom offset from `calc(9.8rem + env(safe-area-inset-bottom, 0px))` to `calc(10.4rem + env(safe-area-inset-bottom, 0px))`, preserving safe-area inset handling.

### Testing
- Verified the change by inspecting the updated file and confirming the offset now reads `10.4rem`, and no automated unit tests were required for this visual adjustment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0da66e9c48329ac441b980b31a503)