### PR TITLE
Align live avatar overlay frame size with avatar dimensions

### DIFF
--- a/webapp/src/components/GameLiveAvatarOverlay.jsx
+++ b/webapp/src/components/GameLiveAvatarOverlay.jsx
@@ -175,17 +175,10 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
     const applyRect = () => {
       const { rect, node } = findAvatarAnchor();
       if (!rect) return;
-      const FRAME_SCALE = 1.2;
-      const width = Math.max(Math.round(rect.width * FRAME_SCALE), 32);
-      const height = Math.max(Math.round(rect.height * FRAME_SCALE), 32);
-      const left = Math.max(
-        Math.round(rect.left - (width - rect.width) / 2),
-        0
-      );
-      const top = Math.max(
-        Math.round(rect.top - (height - rect.height) / 2),
-        0
-      );
+      const width = Math.max(Math.round(rect.width), 32);
+      const height = Math.max(Math.round(rect.height), 32);
+      const left = Math.max(Math.round(rect.left), 0);
+      const top = Math.max(Math.round(rect.top), 0);
       setAnchorElement(node);
       setOverlayRect((prev) => {
         if (


### PR DESCRIPTION
### Motivation
- Make the live video overlay match the detected avatar bounds exactly so the avatar's displayed size remains unchanged (consistent with Pool Royale behavior).

### Description
- Update `webapp/src/components/GameLiveAvatarOverlay.jsx` to stop applying the 1.2x frame scale and centering offsets, using the detected `rect.width`/`rect.height` (with the existing 32px minimum) and the detected `rect.left`/`rect.top` directly for overlay positioning.

### Testing
- Ran a production build in `webapp/` with `npm run build`, which completed successfully; only existing Vite chunking warnings were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0d5a394fc83299447666bd49ec514)