### PR TITLE
Unify live avatar video frame size across games

### DIFF
--- a/webapp/src/components/GameLiveAvatarOverlay.jsx
+++ b/webapp/src/components/GameLiveAvatarOverlay.jsx
@@ -2,6 +2,8 @@ import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import useLiveVideoChat from '../hooks/useLiveVideoChat.js';
 
+const POOL_ROYALE_FRAME_SIZE = 44;
+
 const AVATAR_ANCHOR_SELECTORS = [
   '[data-self-player="true"] .seat-badge-core',
   '[data-self-player="true"].seat-badge-core',
@@ -175,15 +177,14 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
     const applyRect = () => {
       const { rect, node } = findAvatarAnchor();
       if (!rect) return;
-      const FRAME_SCALE = 1.2;
-      const width = Math.max(Math.round(rect.width * FRAME_SCALE), 32);
-      const height = Math.max(Math.round(rect.height * FRAME_SCALE), 32);
+      const width = POOL_ROYALE_FRAME_SIZE;
+      const height = POOL_ROYALE_FRAME_SIZE;
       const left = Math.max(
-        Math.round(rect.left - (width - rect.width) / 2),
+        Math.round(rect.left + rect.width / 2 - width / 2),
         0
       );
       const top = Math.max(
-        Math.round(rect.top - (height - rect.height) / 2),
+        Math.round(rect.top + rect.height / 2 - height / 2),
         0
       );
       setAnchorElement(node);


### PR DESCRIPTION
### Motivation
- Ensure the live video frame used for in-game avatars matches the Pool Royale frame size and does not resize avatars or alter their underlying layout when the live video is shown.

### Description
- Introduce a shared constant `POOL_ROYALE_FRAME_SIZE = 44` in `webapp/src/components/GameLiveAvatarOverlay.jsx` and use it as the fixed live-video frame size instead of scaling per-avatar.
- Replace the previous `FRAME_SCALE` sizing logic with fixed-size centering math so the overlay is centered on the avatar anchor while preserving each game's avatar sizes and layout.

### Testing
- Ran the production build with `npm --prefix webapp run -s build`, which completed successfully.
- Attempted to run `npm --prefix webapp run -s lint`, but the `webapp/package.json` does not define a `lint` script so that check did not run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0d5a394fc83299447666bd49ec514)