### PR TITLE
Fix live avatar click toggle for dynamic game avatar nodes

### DIFF
--- a/webapp/src/components/GameLiveAvatarOverlay.jsx
+++ b/webapp/src/components/GameLiveAvatarOverlay.jsx
@@ -89,6 +89,7 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
     let frameId = 0;
     const resizeObservers = [];
     const mutationObservers = [];
+    const clickListeners = [];
 
     const getIframeContexts = (rootDocument = document, offset = { x: 0, y: 0 }) => {
       const contexts = [{ doc: rootDocument, offsetX: offset.x, offsetY: offset.y }];
@@ -109,6 +110,14 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
         }
       });
       return contexts;
+    };
+
+    const isAvatarAnchorTarget = (target, contextDoc) => {
+      if (!(target instanceof Element)) return false;
+      return AVATAR_ANCHOR_SELECTORS.some((selector) => {
+        const nearest = target.closest(selector);
+        return Boolean(nearest && contextDoc.contains(nearest));
+      });
     };
 
     const scoreAnchor = (element, rect) => {
@@ -190,8 +199,12 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
     const observeContexts = () => {
       mutationObservers.forEach((observer) => observer.disconnect());
       resizeObservers.forEach((observer) => observer.disconnect());
+      clickListeners.forEach(({ doc, listener }) => {
+        doc.removeEventListener('click', listener, true);
+      });
       mutationObservers.length = 0;
       resizeObservers.length = 0;
+      clickListeners.length = 0;
 
       const contexts = getIframeContexts();
       contexts.forEach((context) => {
@@ -207,6 +220,15 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
         const resizeObserver = new ResizeObserver(scheduleApply);
         resizeObserver.observe(context.doc.body);
         resizeObservers.push(resizeObserver);
+
+        const delegatedClickListener = (event) => {
+          if (!isAvatarAnchorTarget(event.target, context.doc)) return;
+          event.preventDefault();
+          event.stopPropagation();
+          setLiveMode((prev) => !prev);
+        };
+        context.doc.addEventListener('click', delegatedClickListener, true);
+        clickListeners.push({ doc: context.doc, listener: delegatedClickListener });
       });
     };
 
@@ -222,6 +244,9 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
       cancelAnimationFrame(frameId);
       mutationObservers.forEach((observer) => observer.disconnect());
       resizeObservers.forEach((observer) => observer.disconnect());
+      clickListeners.forEach(({ doc, listener }) => {
+        doc.removeEventListener('click', listener, true);
+      });
       window.clearTimeout(reobserveTimer);
       window.removeEventListener('resize', scheduleApply);
       window.removeEventListener('orientationchange', scheduleApply);
@@ -231,15 +256,10 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
 
   useEffect(() => {
     if (!anchorElement) return undefined;
-    const onToggle = (event) => {
-      event.preventDefault();
-      event.stopPropagation();
-      setLiveMode((prev) => !prev);
-    };
+    const previousCursor = anchorElement.style.cursor;
     anchorElement.style.cursor = 'pointer';
-    anchorElement.addEventListener('click', onToggle);
     return () => {
-      anchorElement.removeEventListener('click', onToggle);
+      anchorElement.style.cursor = previousCursor;
     };
   }, [anchorElement]);
 


### PR DESCRIPTION
### Motivation
- Players reported that tapping their avatar to activate live camera/mic failed in games where avatar DOM nodes are frequently re-rendered (Domino Battle Royal, Goal Rush, Four in Row), while other games (Pool Royale, Ludo) worked reliably. 
- The root cause was a fragile per-element click binding which becomes stale when the game UI replaces avatar elements during updates. 
- The change aims to make avatar-tap behavior consistent across games by using a resilient delegated click strategy that survives DOM mutations and same-origin iframe embedding. 

### Description
- Replaced fragile per-node `click` attachment with delegated click listeners attached to each same-origin document context (main document + same-origin iframes) in `webapp/src/components/GameLiveAvatarOverlay.jsx`. 
- Added `isAvatarAnchorTarget` helper that uses existing `AVATAR_ANCHOR_SELECTORS` with `Element.closest()` to detect avatar clicks and a `clickListeners` list to track and cleanup listeners when contexts are re-observed. 
- Kept visual affordance by setting `cursor: pointer` on the selected anchor element and preserved existing overlay video toggle UI while removing the stale per-element event wiring. 

### Testing
- Ran `npm -C webapp run build` and the production build completed successfully (Vite warnings about chunk sizes were pre-existing and unrelated). 
- Verified the build artifacts were generated without errors and that the modified file `webapp/src/components/GameLiveAvatarOverlay.jsx` compiled as part of the app bundle.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0dbeac02c8329916e81a80e4af6b4)