### PR TITLE
Raise Murlan Royale bottom avatar slightly upward

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -4784,7 +4784,7 @@ export default function MurlanRoyaleArena({ search }) {
               ? {
                   position: 'fixed',
                   left: '50%',
-                  bottom: 'calc(10.4rem + env(safe-area-inset-bottom, 0px))',
+                  bottom: 'calc(11rem + env(safe-area-inset-bottom, 0px))',
                   transform: 'translateX(-50%)',
                   zIndex: 24
                 }


### PR DESCRIPTION
### Motivation
- Improve the visual spacing of the human player's bottom avatar in the Murlan Royale arena on portrait/mobile so it appears slightly higher above the bottom UI/safe-area.

### Description
- Increased the fixed bottom offset for the human player avatar from `calc(10.4rem + env(safe-area-inset-bottom, 0px))` to `calc(11rem + env(safe-area-inset-bottom, 0px))` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx`, preserving existing safe-area handling and other positioning logic.

### Testing
- Ran `npm test -- --runInBand test/murlan.test.js` and all tests passed (Test Suites: 1 passed, Tests: 12 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0de2c3578832999e97a9442dc75e6)