### PR TITLE
Fix live avatar reactivation on avatar re-tap

### DIFF
--- a/webapp/src/components/GameLiveAvatarOverlay.jsx
+++ b/webapp/src/components/GameLiveAvatarOverlay.jsx
@@ -157,7 +157,10 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
 
     const applyRect = () => {
       const { rect, node } = findAvatarAnchor();
-      if (!rect) return;
+      if (!rect || !node) {
+        setAnchorElement(null);
+        return;
+      }
       const width = Math.max(POOL_ROYALE_VIDEO_FRAME_SIZE, 32);
       const height = Math.max(POOL_ROYALE_VIDEO_FRAME_SIZE, 32);
       const left = Math.max(
@@ -214,6 +217,7 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
     window.addEventListener('resize', scheduleApply);
     window.addEventListener('orientationchange', scheduleApply);
     window.addEventListener('scroll', scheduleApply, true);
+    const recheckTimer = window.setInterval(scheduleApply, 800);
     const reobserveTimer = window.setTimeout(observeContexts, 450);
 
     scheduleApply();
@@ -222,6 +226,7 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
       cancelAnimationFrame(frameId);
       mutationObservers.forEach((observer) => observer.disconnect());
       resizeObservers.forEach((observer) => observer.disconnect());
+      window.clearInterval(recheckTimer);
       window.clearTimeout(reobserveTimer);
       window.removeEventListener('resize', scheduleApply);
       window.removeEventListener('orientationchange', scheduleApply);
@@ -230,25 +235,45 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
   }, [gameSlug, search]);
 
   useEffect(() => {
-    if (!anchorElement) return undefined;
-    const onToggle = (event) => {
+    if (typeof window === 'undefined') return undefined;
+
+    const onToggleFromAvatar = (event) => {
+      const target = event.target;
+      if (!(target instanceof Element)) return;
+      if (!anchorElement || !anchorElement.isConnected) return;
+      if (!anchorElement.contains(target) && target !== anchorElement) return;
       event.preventDefault();
       event.stopPropagation();
       setLiveMode((prev) => !prev);
     };
-    anchorElement.style.cursor = 'pointer';
-    anchorElement.addEventListener('click', onToggle);
+
+    const onPointerDownFromAvatar = (event) => {
+      const target = event.target;
+      if (!(target instanceof Element)) return;
+      if (!anchorElement || !anchorElement.isConnected) return;
+      if (!anchorElement.contains(target) && target !== anchorElement) return;
+      event.preventDefault();
+      event.stopPropagation();
+    };
+
+    document.addEventListener('click', onToggleFromAvatar, true);
+    document.addEventListener('pointerdown', onPointerDownFromAvatar, true);
+
     return () => {
-      anchorElement.removeEventListener('click', onToggle);
+      document.removeEventListener('click', onToggleFromAvatar, true);
+      document.removeEventListener('pointerdown', onPointerDownFromAvatar, true);
     };
   }, [anchorElement]);
 
   useEffect(() => {
     if (!anchorElement) return undefined;
+    const previousCursor = anchorElement.style.cursor;
     const previousVisibility = anchorElement.style.visibility;
+    anchorElement.style.cursor = 'pointer';
     if (liveMode) anchorElement.style.visibility = 'hidden';
     else anchorElement.style.visibility = previousVisibility || '';
     return () => {
+      anchorElement.style.cursor = previousCursor || '';
       anchorElement.style.visibility = previousVisibility || '';
     };
   }, [anchorElement, liveMode]);


### PR DESCRIPTION
### Motivation
- Some games (Domino Battle Royal, Goal Rush, 4 in a Row) replace avatar DOM nodes during runtime which broke re-activating live camera/mic by clicking the avatar. 
- The overlay previously stayed bound to stale nodes and attached click handlers directly to a node that could be swapped out, causing lost toggles. 
- The goal is to make avatar tap behavior match other games (Pool Royale, Ludo Battle Royal) so tapping the avatar reliably toggles live camera/mic.

### Description
- Update `GameLiveAvatarOverlay.jsx` to clear stale anchors when `findAvatarAnchor()` returns no node by calling `setAnchorElement(null)` so the overlay doesn't remain bound to removed elements. 
- Add a periodic recheck (`setInterval(scheduleApply, 800)`) in addition to `MutationObserver`/`ResizeObserver` to reacquire avatar anchors in UIs where updates may be missed or delayed. 
- Replace per-node `click` binding with delegated capture listeners on `document` (`click` + `pointerdown`) that validate the current anchor at event time so taps still work after avatar DOM replacements. 
- Preserve cursor and visibility UX by setting/restoring `anchorElement.style.cursor` and `visibility` when the anchor changes or live mode toggles.

### Testing
- Built the web app: `npm --prefix webapp run build` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0dbeac02c8329916e81a80e4af6b4)