### PR TITLE
Raise Murlan Royale self avatar and add scalable avatar frame (2x)

### DIFF
--- a/webapp/src/components/AvatarTimer.jsx
+++ b/webapp/src/components/AvatarTimer.jsx
@@ -18,6 +18,7 @@ export default function AvatarTimer({
   imageScale = 1,
   imageYOffset = 0,
   imageZoom = 1,
+  frameScale = 1,
   scoreStyle = {},
   rollHistoryStyle = {},
   nameCurveRadius = 45,
@@ -46,7 +47,13 @@ export default function AvatarTimer({
         </span>
       )}
       {active && (
-        <div className="avatar-timer-ring" style={{ '--timer-gradient': gradient }} />
+        <div
+          className="avatar-timer-ring"
+          style={{
+            '--timer-gradient': gradient,
+            transform: `scale(${frameScale})`
+          }}
+        />
       )}
       <img
         src={getAvatarUrl(photoUrl)}

--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -4784,7 +4784,7 @@ export default function MurlanRoyaleArena({ search }) {
               ? {
                   position: 'fixed',
                   left: '50%',
-                  bottom: 'calc(11rem + env(safe-area-inset-bottom, 0px))',
+                  bottom: 'calc(12rem + env(safe-area-inset-bottom, 0px))',
                   transform: 'translateX(-50%)',
                   zIndex: 24
                 }
@@ -4815,6 +4815,7 @@ export default function MurlanRoyaleArena({ search }) {
                   name={activePlayer?.name}
                   color={color}
                   size={avatarSize}
+                  frameScale={idx === humanPlayerIndex ? 2 : 1}
                 />
                 <span className="text-[0.65rem] font-semibold uppercase tracking-wide text-white/80 drop-shadow">
                   {handCount} cards


### PR DESCRIPTION
### Motivation
- Improve portrait layout for Murlan Royale by nudging the local (bottom) avatar visually higher on the screen. 
- Provide a simple way to increase the avatar frame/timer ring independently of the avatar image so the frame can be doubled per design request.

### Description
- Added a new `frameScale` prop to `AvatarTimer` with default `1` so the avatar frame/timer ring can be scaled independently (`webapp/src/components/AvatarTimer.jsx`).
- Applied `frameScale={2}` for the human player's avatar in Murlan Royale so the visible frame is twice the avatar size while keeping the avatar image unchanged (`webapp/src/pages/Games/MurlanRoyaleArena.jsx`).
- Raised the fixed bottom offset for the human (self) avatar from `calc(11rem + env(safe-area-inset-bottom, 0px))` to `calc(12rem + env(safe-area-inset-bottom, 0px))` to move the avatar slightly upward on portrait screens (`webapp/src/pages/Games/MurlanRoyaleArena.jsx`).
- The `frameScale` default remains `1` so other games retain current behavior unless explicitly changed.

### Testing
- Ran the production build with `npm --prefix webapp run build` and the build completed successfully (Vite build finished). 
- No additional automated unit tests were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0e0ebb8a083299d2b48dfb7987ac9)