### PR TITLE
Double live avatar video frame and enforce circular overlay

### DIFF
--- a/webapp/src/components/GameLiveAvatarOverlay.jsx
+++ b/webapp/src/components/GameLiveAvatarOverlay.jsx
@@ -156,9 +156,11 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
     const applyRect = () => {
       const { rect, node } = findAvatarAnchor();
       if (!rect) return;
-      const FRAME_SCALE = 1.2;
-      const width = Math.max(Math.round(rect.width * FRAME_SCALE), 32);
-      const height = Math.max(Math.round(rect.height * FRAME_SCALE), 32);
+      const FRAME_SCALE = 2;
+      const avatarDiameter = Math.max(rect.width, rect.height);
+      const frameDiameter = Math.max(Math.round(avatarDiameter * FRAME_SCALE), 32);
+      const width = frameDiameter;
+      const height = frameDiameter;
       const left = Math.max(
         Math.round(rect.left - (width - rect.width) / 2),
         0


### PR DESCRIPTION
### Motivation
- Ensure the live video frame matches other games (Pool Royale, Murlan Royale) by being visually double the avatar size and always circular so it aligns with avatar shapes.

### Description
- Updated `webapp/src/components/GameLiveAvatarOverlay.jsx` to set `FRAME_SCALE = 2` and compute a single `avatarDiameter = Math.max(rect.width, rect.height)` then use `frameDiameter` for both `width` and `height` so the overlay is perfectly circular and centered over the anchor.

### Testing
- Ran a production build with `npm -C webapp run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0e2e5db708329b3125549db8b13ac)