### PR TITLE
GameLiveAvatarOverlay: per-game frame scale and circular frame sizing

### DIFF
--- a/webapp/src/components/GameLiveAvatarOverlay.jsx
+++ b/webapp/src/components/GameLiveAvatarOverlay.jsx
@@ -25,6 +25,15 @@ const AVATAR_ANCHOR_SELECTORS = [
   '[aria-label="You"]'
 ];
 
+const GAMES_WITH_EXISTING_DOUBLE_FRAME = new Set([
+  'texasholdem',
+  'poolroyale',
+  'snookerroyale',
+  'murlanroyale'
+]);
+const DEFAULT_FRAME_SCALE = 2;
+const LEGACY_FRAME_SCALE = 1.2;
+
 export default function GameLiveAvatarOverlay({ gameSlug, children }) {
   const { search } = useLocation();
   const params = useMemo(() => new URLSearchParams(search), [search]);
@@ -61,6 +70,14 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
       'default';
     return `live-${gameSlug}-${sessionId}-${accountId}`;
   }, [gameSlug, params]);
+
+  const frameScale = useMemo(
+    () =>
+      GAMES_WITH_EXISTING_DOUBLE_FRAME.has((gameSlug || '').toLowerCase())
+        ? LEGACY_FRAME_SCALE
+        : DEFAULT_FRAME_SCALE,
+    [gameSlug]
+  );
 
   const liveChat = useLiveVideoChat({
     roomId,
@@ -156,9 +173,11 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
     const applyRect = () => {
       const { rect, node } = findAvatarAnchor();
       if (!rect) return;
-      const FRAME_SCALE = 1.2;
-      const width = Math.max(Math.round(rect.width * FRAME_SCALE), 32);
-      const height = Math.max(Math.round(rect.height * FRAME_SCALE), 32);
+      const FRAME_SCALE = frameScale;
+      const avatarDiameter = Math.max(rect.width, rect.height);
+      const frameDiameter = Math.max(Math.round(avatarDiameter * FRAME_SCALE), 32);
+      const width = frameDiameter;
+      const height = frameDiameter;
       const left = Math.max(
         Math.round(rect.left - (width - rect.width) / 2),
         0
@@ -226,7 +245,7 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
       window.removeEventListener('orientationchange', scheduleApply);
       window.removeEventListener('scroll', scheduleApply, true);
     };
-  }, [gameSlug, search]);
+  }, [frameScale, gameSlug, search]);
 
   useEffect(() => {
     if (!anchorElement) return undefined;


### PR DESCRIPTION
### Motivation
- Some games include their own double-width avatar frames which caused our overlay to appear oversized, so we need per-game scaling to preserve legacy visuals.
- The overlay should use a consistent circular frame sized from the larger avatar dimension to avoid non-square artifacts when avatars are not perfectly square.

### Description
- Added `GAMES_WITH_EXISTING_DOUBLE_FRAME`, `DEFAULT_FRAME_SCALE`, and `LEGACY_FRAME_SCALE` constants and compute `frameScale` from `gameSlug` using `useMemo`.
- Replaced the hardcoded `FRAME_SCALE = 1.2` with the computed `frameScale` and changed sizing to compute a circular `frameDiameter` from the max of `rect.width` and `rect.height` before centering the overlay.
- Adjusted `useLayoutEffect` dependency list to include `frameScale` so the overlay recalculates when scale rules change.
- Kept anchor detection and event handling logic intact but updated sizing math to set `width` and `height` to the same computed diameter.

### Testing
- Ran the frontend unit test suite with `yarn test` and unit tests passed. 
- Performed a production build with `yarn build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0e2e5db708329b3125549db8b13ac)