### PR TITLE
Add live avatar video overlay to Domino Royale with mic toggle and frameScale

### DIFF
--- a/webapp/src/components/GameLiveAvatarOverlay.jsx
+++ b/webapp/src/components/GameLiveAvatarOverlay.jsx
@@ -25,7 +25,7 @@ const AVATAR_ANCHOR_SELECTORS = [
   '[aria-label="You"]'
 ];
 
-export default function GameLiveAvatarOverlay({ gameSlug, children }) {
+export default function GameLiveAvatarOverlay({ gameSlug, children, frameScale = 1 }) {
   const { search } = useLocation();
   const params = useMemo(() => new URLSearchParams(search), [search]);
   const [liveMode, setLiveMode] = useState(false);
@@ -156,7 +156,10 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
     const applyRect = () => {
       const { rect, node } = findAvatarAnchor();
       if (!rect) return;
-      const FRAME_SCALE = 1.2;
+      const FRAME_SCALE =
+        Number.isFinite(frameScale) && frameScale > 0
+          ? frameScale
+          : 1;
       const width = Math.max(Math.round(rect.width * FRAME_SCALE), 32);
       const height = Math.max(Math.round(rect.height * FRAME_SCALE), 32);
       const left = Math.max(
@@ -252,14 +255,13 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
     };
   }, [anchorElement, liveMode]);
 
+  const micIsOn = liveChat.mediaState?.microphone !== false;
+
   return (
     <>
       {children}
       {liveMode && anchorElement ? (
-        <button
-          type="button"
-          aria-label="Turn off live avatar video"
-          onClick={() => setLiveMode(false)}
+        <div
           className="fixed z-[65] overflow-hidden rounded-full border border-emerald-300 bg-black/30"
           style={{
             top: `${overlayRect.top}px`,
@@ -277,7 +279,29 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
             playsInline
             className="h-full w-full object-cover scale-x-[-1]"
           />
-        </button>
+          <button
+            type="button"
+            aria-label={micIsOn ? 'Mute microphone' : 'Unmute microphone'}
+            onClick={(event) => {
+              event.stopPropagation();
+              liveChat.toggleMicrophone();
+            }}
+            className="absolute -bottom-1 -right-1 h-5 w-5 rounded-full border border-white/70 bg-black/80 text-[10px] text-white shadow-md"
+          >
+            {micIsOn ? '🎙️' : '🔇'}
+          </button>
+          <button
+            type="button"
+            aria-label="Turn off live avatar video"
+            onClick={(event) => {
+              event.stopPropagation();
+              setLiveMode(false);
+            }}
+            className="absolute -top-1 -left-1 h-5 w-5 rounded-full border border-white/70 bg-black/80 text-[10px] font-bold text-white shadow-md"
+          >
+            ×
+          </button>
+        </div>
       ) : null}
     </>
   );

--- a/webapp/src/pages/Games/DominoRoyal.jsx
+++ b/webapp/src/pages/Games/DominoRoyal.jsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 import DominoRoyalArena from './DominoRoyalArena.jsx';
+import GameLiveAvatarOverlay from '../../components/GameLiveAvatarOverlay.jsx';
 import { socket } from '../../utils/socket.js';
 import { ensureAccountId, getTelegramUsername } from '../../utils/telegram.js';
 
@@ -44,7 +45,9 @@ export default function DominoRoyal() {
 
   return (
     <div className="relative w-full h-screen">
-      <DominoRoyalArena />
+      <GameLiveAvatarOverlay gameSlug="domino-royal" frameScale={1}>
+        <DominoRoyalArena />
+      </GameLiveAvatarOverlay>
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Enable Domino Royale players to switch their avatar to live camera (with mic) by tapping their avatar, matching the existing Murlan Royale UX and sizing behavior.
- Make the live-video overlay frame size configurable so different games can match their native avatar frame exactly.

### Description
- Added a `frameScale` prop to `GameLiveAvatarOverlay` and used it to compute the live video overlay geometry instead of a hard-coded scale. (`webapp/src/components/GameLiveAvatarOverlay.jsx`).
- Reworked the live overlay markup to render a positioned video container (instead of a single toggle button) and added in-frame controls: a microphone toggle that calls `liveChat.toggleMicrophone()` and a close button to exit live mode. (`webapp/src/components/GameLiveAvatarOverlay.jsx`).
- Wired Domino Royale to render its arena wrapped in `GameLiveAvatarOverlay` with `frameScale={1}` so the live video frame matches the Domino avatar frame precisely. (`webapp/src/pages/Games/DominoRoyal.jsx`).
- Kept click propagation guarded when using the in-frame buttons and preserve anchor visibility while live mode is active.

### Testing
- Built the web app with `npm --prefix webapp run build`, and the build completed successfully (Vite production build finished). 
- The existing Vite warnings about large chunks and mixed dynamic/static imports remained unchanged and are informational only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0f44582f4832998cc3f51d2af6fca)