### PR TITLE
Make avatar clickable to toggle live video and improve live-avatar overlay framing

### DIFF
--- a/webapp/src/components/AirHockey3D.jsx
+++ b/webapp/src/components/AirHockey3D.jsx
@@ -10,7 +10,6 @@ import { bombSound, chatBeep } from '../assets/soundData.js';
 import GiftPopup from './GiftPopup.jsx';
 import QuickMessagePopup from './QuickMessagePopup.jsx';
 import { giftSounds } from '../utils/giftSounds.js';
-import { AiOutlineMessage } from 'react-icons/ai';
 import LiveVideoChatPanel from './LiveVideoChatPanel.jsx';
 import useLiveVideoChat from '../hooks/useLiveVideoChat.js';
 import { getGameVolume, isGameMuted, toggleGameMuted } from '../utils/sound.js';
@@ -2566,6 +2565,14 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
     );
   };
 
+  const toggleLiveAvatar = () => {
+    setLiveMode((prev) => {
+      const next = !prev;
+      setShowLivePanel(next);
+      return next;
+    });
+  };
+
   return (
     <div
       ref={hostRef}
@@ -2582,21 +2589,28 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
           className="flex items-center gap-2 rounded bg-white/10 px-2 py-1 text-xs"
           data-player-index="0"
         >
-          {liveMode ? (
-            <video
-              ref={topLiveVideoRef}
-              autoPlay
-              playsInline
-              muted
-              className="h-10 w-10 rounded-full border border-emerald-300/70 object-cover bg-black scale-x-[-1]"
-            />
-          ) : (
-            <img
-              src={getAvatarUrl(player.avatar)}
-              alt=""
-              className="h-5 w-5 rounded-full object-cover"
-            />
-          )}
+          <button
+            type="button"
+            onClick={toggleLiveAvatar}
+            className="rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300/80"
+            aria-label={liveMode ? 'Turn off live avatar video' : 'Turn on live avatar video'}
+          >
+            {liveMode ? (
+              <video
+                ref={topLiveVideoRef}
+                autoPlay
+                playsInline
+                muted
+                className="h-10 w-10 rounded-full border border-emerald-300/70 object-cover bg-black scale-x-[-1]"
+              />
+            ) : (
+              <img
+                src={getAvatarUrl(player.avatar)}
+                alt=""
+                className="h-5 w-5 rounded-full object-cover"
+              />
+            )}
+          </button>
           <span className="truncate">
             {player.name}: {ui.left}
             {liveMode ? <span className="ml-1 text-emerald-200">• Live</span> : null}
@@ -2662,19 +2676,6 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
             : 'bottom-2 left-2 items-start'
         }`}
       >
-        <button
-          type="button"
-          onClick={() => {
-            setLiveMode((prev) => !prev);
-            setShowLivePanel((prev) => (!liveMode ? true : prev));
-          }}
-          className={`flex flex-col items-center rounded px-2 py-1 text-[10px] font-semibold ${
-            liveMode ? 'bg-emerald-500/25 text-emerald-100' : 'bg-transparent text-white hover:bg-white/10'
-          }`}
-        >
-          <AiOutlineMessage className="text-xl" />
-          <span>{liveMode ? 'Avatar' : 'Live'}</span>
-        </button>
         <button
           type="button"
           onClick={() => setShowChat(true)}

--- a/webapp/src/components/GameLiveAvatarOverlay.jsx
+++ b/webapp/src/components/GameLiveAvatarOverlay.jsx
@@ -24,6 +24,7 @@ const AVATAR_ANCHOR_SELECTORS = [
   'img[alt="You"]',
   '[aria-label="You"]'
 ];
+const FRAME_SCALE = 2;
 
 export default function GameLiveAvatarOverlay({ gameSlug, children }) {
   const { search } = useLocation();
@@ -156,9 +157,10 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
     const applyRect = () => {
       const { rect, node } = findAvatarAnchor();
       if (!rect) return;
-      const FRAME_SCALE = 1.2;
-      const width = Math.max(Math.round(rect.width * FRAME_SCALE), 32);
-      const height = Math.max(Math.round(rect.height * FRAME_SCALE), 32);
+      const avatarDiameter = Math.max(rect.width, rect.height);
+      const frameDiameter = Math.max(Math.round(avatarDiameter * FRAME_SCALE), 32);
+      const width = frameDiameter;
+      const height = frameDiameter;
       const left = Math.max(
         Math.round(rect.left - (width - rect.width) / 2),
         0


### PR DESCRIPTION
### Motivation
- Improve the UX for enabling/disabling live avatar video by making the avatar itself a toggle and remove a duplicated HUD control, and make the live-avatar overlay frame better fit circular avatars.

### Description
- Add a `toggleLiveAvatar` handler and wrap the top-left avatar in a focusable button that toggles `liveMode` and `showLivePanel`, including an `aria-label` for accessibility.
- Remove the previous HUD live toggle button and the unused `AiOutlineMessage` import from `AirHockey3D.jsx` to avoid duplicate controls.
- Introduce `FRAME_SCALE = 2` in `GameLiveAvatarOverlay.jsx` and compute the overlay frame from the avatar diameter so the frame is square, centered, and scales consistently.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0e2e5db708329b3125549db8b13ac)