### PR TITLE
Toggle live avatar from HUD avatar and normalize live overlay frame sizing

### DIFF
--- a/webapp/src/components/AirHockey3D.jsx
+++ b/webapp/src/components/AirHockey3D.jsx
@@ -10,7 +10,6 @@ import { bombSound, chatBeep } from '../assets/soundData.js';
 import GiftPopup from './GiftPopup.jsx';
 import QuickMessagePopup from './QuickMessagePopup.jsx';
 import { giftSounds } from '../utils/giftSounds.js';
-import { AiOutlineMessage } from 'react-icons/ai';
 import LiveVideoChatPanel from './LiveVideoChatPanel.jsx';
 import useLiveVideoChat from '../hooks/useLiveVideoChat.js';
 import { getGameVolume, isGameMuted, toggleGameMuted } from '../utils/sound.js';
@@ -723,6 +722,13 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
     if (!topLiveVideoRef.current) return;
     topLiveVideoRef.current.srcObject = liveChat.localStream || null;
   }, [liveChat.localStream]);
+  const toggleLiveFromAvatar = useCallback(() => {
+    setLiveMode((prev) => {
+      const nextLiveMode = !prev;
+      setShowLivePanel((panelOpen) => (nextLiveMode ? true : panelOpen));
+      return nextLiveMode;
+    });
+  }, []);
   const updateRendererSettings = useCallback(() => {
     const renderer = rendererRef.current;
     const host = hostRef.current;
@@ -2579,8 +2585,19 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
         style={isTopDownView ? undefined : { top: `${2.35 + HUD_VERTICAL_SHIFT_REM - HUD_TOP_ROW_LIFT_REM}rem` }}
       >
         <div
-          className="flex items-center gap-2 rounded bg-white/10 px-2 py-1 text-xs"
+          className="flex items-center gap-2 rounded bg-white/10 px-2 py-1 text-xs cursor-pointer"
           data-player-index="0"
+          data-self-player="true"
+          role="button"
+          tabIndex={0}
+          aria-label={liveMode ? 'Turn off live avatar video' : 'Turn on live avatar video'}
+          onClick={toggleLiveFromAvatar}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault();
+              toggleLiveFromAvatar();
+            }
+          }}
         >
           {liveMode ? (
             <video
@@ -2662,19 +2679,6 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
             : 'bottom-2 left-2 items-start'
         }`}
       >
-        <button
-          type="button"
-          onClick={() => {
-            setLiveMode((prev) => !prev);
-            setShowLivePanel((prev) => (!liveMode ? true : prev));
-          }}
-          className={`flex flex-col items-center rounded px-2 py-1 text-[10px] font-semibold ${
-            liveMode ? 'bg-emerald-500/25 text-emerald-100' : 'bg-transparent text-white hover:bg-white/10'
-          }`}
-        >
-          <AiOutlineMessage className="text-xl" />
-          <span>{liveMode ? 'Avatar' : 'Live'}</span>
-        </button>
         <button
           type="button"
           onClick={() => setShowChat(true)}

--- a/webapp/src/components/GameLiveAvatarOverlay.jsx
+++ b/webapp/src/components/GameLiveAvatarOverlay.jsx
@@ -25,6 +25,8 @@ const AVATAR_ANCHOR_SELECTORS = [
   '[aria-label="You"]'
 ];
 
+const FRAME_SCALE = 2;
+
 export default function GameLiveAvatarOverlay({ gameSlug, children }) {
   const { search } = useLocation();
   const params = useMemo(() => new URLSearchParams(search), [search]);
@@ -156,9 +158,10 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
     const applyRect = () => {
       const { rect, node } = findAvatarAnchor();
       if (!rect) return;
-      const FRAME_SCALE = 1.2;
-      const width = Math.max(Math.round(rect.width * FRAME_SCALE), 32);
-      const height = Math.max(Math.round(rect.height * FRAME_SCALE), 32);
+      const avatarDiameter = Math.max(rect.width, rect.height);
+      const frameDiameter = Math.max(Math.round(avatarDiameter * FRAME_SCALE), 32);
+      const width = frameDiameter;
+      const height = frameDiameter;
       const left = Math.max(
         Math.round(rect.left - (width - rect.width) / 2),
         0


### PR DESCRIPTION
### Motivation

- Make it easier and more accessible to start/stop avatar live video by enabling the avatar HUD element as the toggle target instead of a separate menu button.
- Remove redundant menu control and ensure the live video panel opens when appropriate for improved UX.
- Normalize the live avatar overlay frame sizing to produce a consistent circular frame regardless of anchor element aspect ratio.

### Description

- Removed the `AiOutlineMessage` import and deleted the separate live/menu `button` that toggled avatar live mode from the HUD menu.
- Added `toggleLiveFromAvatar` handler and wired it to the HUD avatar container with `role="button"`, `tabIndex={0}`, `aria-label`, `onClick`, and keyboard `onKeyDown` support so the avatar element can toggle live mode and open the live panel when enabling live video.
- Added `data-self-player="true"` to the avatar HUD element to improve anchor selection for the overlay and ensured the top live `video` element is populated from `liveChat.localStream`.
- In `GameLiveAvatarOverlay` introduced a module-level `FRAME_SCALE` constant and changed the overlay sizing logic to compute a consistent `avatarDiameter` and `frameDiameter`, replacing the previous local scale to produce square frames sized from the larger avatar dimension.

### Testing

- Ran the frontend build with `yarn build` and the build completed successfully.
- Executed the test suite with `yarn test` and all automated tests passed.
- Ran linting with `yarn lint` and no new lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0e2e5db708329b3125549db8b13ac)