### PR TITLE
Fix premium custom HDRIs missing from game menu

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -12708,7 +12708,11 @@ function PoolRoyaleGame({
   );
   const availableEnvironmentHdris = useMemo(
     () => {
-      const customVariants = getCustomHdriVariantsForGame('poolroyale', accountId);
+      const customVariants = getCustomHdriVariantsForGame(
+        'poolroyale',
+        accountId,
+        poolInventory?.environmentHdri
+      );
       const merged = [...POOL_ROYALE_HDRI_VARIANTS, ...customVariants];
       return merged.filter((variant) =>
         isPoolOptionUnlocked('environmentHdri', variant.id, poolInventory)

--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -11705,7 +11705,11 @@ function SnookerRoyalGame({
   );
   const availableEnvironmentHdris = useMemo(
     () => {
-      const customVariants = getCustomHdriVariantsForGame('snookerroyale', accountId);
+      const customVariants = getCustomHdriVariantsForGame(
+        'snookerroyale',
+        accountId,
+        snookerInventory?.environmentHdri
+      );
       const merged = [...SNOOKER_ROYALE_HDRI_VARIANTS, ...customVariants];
       return merged.filter((variant) =>
         isSnookerOptionUnlocked('environmentHdri', variant.id, snookerInventory)

--- a/webapp/src/utils/customHdriCatalog.js
+++ b/webapp/src/utils/customHdriCatalog.js
@@ -50,25 +50,69 @@ export const saveCustomHdriEntry = (entry) => {
   return nextEntry;
 };
 
-export const getCustomHdriVariantsForGame = (slug, viewerAccountId = null) =>
-  getCustomHdriCatalog(viewerAccountId)
+const toVariant = (entry, slug, optionIdOverride = null) => {
+  const optionId = optionIdOverride || entry?.optionIdByGame?.[slug];
+  if (typeof optionId !== 'string' || !optionId) return null;
+  const name =
+    typeof entry?.name === 'string' && entry.name.trim()
+      ? entry.name.trim()
+      : 'Premium HDRI';
+  const environmentUrl =
+    typeof entry?.environmentUrl === 'string' ? entry.environmentUrl : '';
+  const thumbnailUrl =
+    typeof entry?.thumbnailUrl === 'string' ? entry.thumbnailUrl : '';
+  return {
+    id: optionId,
+    name,
+    assetUrl: environmentUrl,
+    thumbnail: thumbnailUrl || environmentUrl || '',
+    preferredResolutions: ['2k'],
+    fallbackResolution: '2k',
+    exposure: 1.02,
+    environmentIntensity: 1.04,
+    backgroundIntensity: 0.98,
+    swatches: ['#d946ef', '#7c3aed'],
+    description: `Creator HDRI · ${name}`,
+    isCustomUpload: true
+  };
+};
+
+export const getCustomHdriVariantsForGame = (
+  slug,
+  viewerAccountId = null,
+  ownedOptionIds = []
+) => {
+  const catalogVariants = getCustomHdriCatalog(viewerAccountId)
     .filter(
       (entry) =>
         Array.isArray(entry.supportedGames) &&
         entry.supportedGames.includes(slug) &&
         typeof entry.optionIdByGame?.[slug] === 'string'
     )
-    .map((entry) => ({
-      id: entry.optionIdByGame[slug],
-      name: entry.name,
-      assetUrl: entry.environmentUrl,
-      thumbnail: entry.thumbnailUrl || entry.environmentUrl || '',
-      preferredResolutions: ['2k'],
-      fallbackResolution: '2k',
-      exposure: 1.02,
-      environmentIntensity: 1.04,
-      backgroundIntensity: 0.98,
-      swatches: ['#d946ef', '#7c3aed'],
-      description: `Creator HDRI · ${entry.name}`,
-      isCustomUpload: true
-    }));
+    .map((entry) => toVariant(entry, slug))
+    .filter(Boolean);
+
+  const seenIds = new Set(catalogVariants.map((variant) => variant.id));
+  const fallbackOwnedVariants = Array.isArray(ownedOptionIds)
+    ? ownedOptionIds
+        .filter(
+          (optionId) =>
+            typeof optionId === 'string' &&
+            optionId.startsWith('custom-hdri:') &&
+            !seenIds.has(optionId)
+        )
+        .map((optionId) =>
+          toVariant(
+            {
+              name: 'Premium HDRI',
+              optionIdByGame: { [slug]: optionId }
+            },
+            slug,
+            optionId
+          )
+        )
+        .filter(Boolean)
+    : [];
+
+  return [...catalogVariants, ...fallbackOwnedVariants];
+};


### PR DESCRIPTION
### Motivation
- Owned user-created HDRIs (premium `custom-hdri:` entries) were not appearing in game HDRI menus when the local custom catalog metadata was absent or missing for that entry.
- The store publishes HDRIs into inventory using `custom-hdri:` option IDs, so the game menu needs to consider purchased IDs even if the full catalog entry is not present locally.
- Make HDRI resolution resilient so purchased custom HDRIs always show in games when present in the player's inventory.

### Description
- Added a resilient variant builder `toVariant` and extended `getCustomHdriVariantsForGame` in `webapp/src/utils/customHdriCatalog.js` to accept an `ownedOptionIds` array and synthesize fallback variants for `custom-hdri:` IDs when catalog metadata is missing.
- The fallback logic filters out already-known catalog variants and constructs minimal but usable HDRI variant objects for owned `custom-hdri:` IDs so they can be shown in menus.
- Updated `PoolRoyale` and `SnookerRoyal` pages to pass their `environmentHdri` inventory (`poolInventory?.environmentHdri` and `snookerInventory?.environmentHdri`) into `getCustomHdriVariantsForGame` so purchased custom HDRIs are included in the merged HDRI list.
- Changes touch `webapp/src/utils/customHdriCatalog.js`, `webapp/src/pages/Games/PoolRoyale.jsx`, and `webapp/src/pages/Games/SnookerRoyal.jsx`.

### Testing
- Ran a production build with `npm --prefix webapp run build`, which completed successfully (Vite build finished without errors).
- Verified the new `getCustomHdriVariantsForGame` path is invoked from `PoolRoyale` and `SnookerRoyal` by running the build and confirming files compiled.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0feead61483299e1907ef3bbc91ec)