### PR TITLE
Include custom/premium HDRIs in game HDRI menus (Checkers & Tavull)

### DIFF
--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -50,6 +50,7 @@ import {
   isChessOptionUnlocked,
   setChessBattleEquippedOption
 } from '../../utils/chessBattleInventory.js';
+import { getCustomHdriVariantsForGame } from '../../utils/customHdriCatalog.js';
 import { socket } from '../../utils/socket.js';
 
 const SIZE = 8;
@@ -103,26 +104,28 @@ const BEAUTIFUL_GAME_BOARD_URLS = Object.freeze([
 let sharedKtx2Loader = null;
 let hasDetectedKtx2Support = false;
 const resolveHdriVariant = (value) => {
+  const customVariants = getCustomHdriVariantsForGame('checkersbattleroyal');
+  const allVariants = [...POOL_ROYALE_HDRI_VARIANTS, ...customVariants];
   if (typeof value === 'string') {
     return (
       POOL_ROYALE_HDRI_VARIANT_MAP[value] ||
-      POOL_ROYALE_HDRI_VARIANTS.find((variant) => variant.id === value) ||
-      POOL_ROYALE_HDRI_VARIANTS.find(
+      allVariants.find((variant) => variant.id === value) ||
+      allVariants.find(
         (variant) => variant.id === POOL_ROYALE_DEFAULT_HDRI_ID
       ) ||
-      POOL_ROYALE_HDRI_VARIANTS[0]
+      allVariants[0]
     );
   }
-  const max = POOL_ROYALE_HDRI_VARIANTS.length - 1;
+  const max = allVariants.length - 1;
   const idx = Number.isFinite(value)
     ? Math.max(0, Math.min(max, Math.round(value)))
     : Math.max(
         0,
-        POOL_ROYALE_HDRI_VARIANTS.findIndex(
+        allVariants.findIndex(
           (variant) => variant.id === POOL_ROYALE_DEFAULT_HDRI_ID
         )
       );
-  return POOL_ROYALE_HDRI_VARIANTS[idx] || POOL_ROYALE_HDRI_VARIANTS[0];
+  return allVariants[idx] || allVariants[0];
 };
 const CHECKERS_BOARD_THEMES = Object.freeze([
   {
@@ -1241,11 +1244,16 @@ export default function CheckersBattleRoyal() {
     [inventory]
   );
   const unlockedHdriOptions = useMemo(
-    () =>
-      POOL_ROYALE_HDRI_VARIANTS.filter((opt) =>
+    () => {
+      const customVariants = getCustomHdriVariantsForGame(
+        'checkersbattleroyal',
+        resolvedAccountId
+      );
+      return [...POOL_ROYALE_HDRI_VARIANTS, ...customVariants].filter((opt) =>
         isChessOptionUnlocked('environmentHdri', opt.id, inventory)
-      ),
-    [inventory]
+      );
+    },
+    [inventory, resolvedAccountId]
   );
 
   const inv = useMemo(

--- a/webapp/src/pages/Games/TavullBattleRoyal.jsx
+++ b/webapp/src/pages/Games/TavullBattleRoyal.jsx
@@ -41,6 +41,7 @@ import {
   isTavullOptionUnlocked,
   tavullBattleAccountId
 } from '../../utils/tavullBattleInventory.js';
+import { getCustomHdriVariantsForGame } from '../../utils/customHdriCatalog.js';
 import {
   BLACK,
   WHITE,
@@ -704,11 +705,16 @@ export default function TavullBattleRoyal() {
     [tavullInventory]
   );
   const ownedHdriOptions = useMemo(
-    () =>
-      POOL_ROYALE_HDRI_VARIANTS.filter((option) =>
+    () => {
+      const customVariants = getCustomHdriVariantsForGame(
+        'tavullbattleroyal',
+        accountId
+      );
+      return [...POOL_ROYALE_HDRI_VARIANTS, ...customVariants].filter((option) =>
         isTavullOptionUnlocked('environmentHdri', option.id, tavullInventory)
-      ),
-    [tavullInventory]
+      );
+    },
+    [accountId, tavullInventory]
   );
   const ownedFinishOptions = useMemo(
     () =>


### PR DESCRIPTION
### Motivation
- Fix the bug where user-created/premium HDRIs (creator uploads or purchases) do not appear in the in-game HDRI selection when the user owns them.
- Ensure games that allow environment HDRI customization include both built-in and custom HDRIs when computing available/unlocked options.

### Description
- Imported `getCustomHdriVariantsForGame` and merged custom catalog variants with `POOL_ROYALE_HDRI_VARIANTS` so creator HDRIs are considered alongside built-in variants in `CheckersBattleRoyal` and `TavullBattleRoyal`.
- Updated `resolveHdriVariant` in `CheckersBattleRoyal.jsx` to resolve custom HDRI IDs by searching the merged variant list instead of only built-in presets.
- Replaced direct filters over `POOL_ROYALE_HDRI_VARIANTS` with merged lists when computing unlocked/owned HDRI options and added `accountId` / `resolvedAccountId` to relevant `useMemo` dependency lists.
- Small dependency / memo adjustments to ensure inventory/account changes refresh the HDRI option lists.

### Testing
- Ran unit tests with `npm test -- --runInBand test/inventoryCrossGameConfig.test.js` and the suite passed (5 tests, 1 suite).
- Ran linter (`npx eslint`) which executed but reported the two modified files as ignored by repository ignore patterns (warnings only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0feead61483299e1907ef3bbc91ec)