### PR TITLE
Fix live avatar overlay sizing to use smaller anchor dimension

### DIFF
--- a/webapp/src/components/GameLiveAvatarOverlay.jsx
+++ b/webapp/src/components/GameLiveAvatarOverlay.jsx
@@ -158,7 +158,7 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
     const applyRect = () => {
       const { rect, node } = findAvatarAnchor();
       if (!rect) return;
-      const avatarDiameter = Math.max(rect.width, rect.height);
+      const avatarDiameter = Math.min(rect.width, rect.height);
       const frameDiameter = Math.max(Math.round(avatarDiameter * FRAME_SCALE), 32);
       const width = frameDiameter;
       const height = frameDiameter;


### PR DESCRIPTION
### Motivation
- Prevent the live video overlay from becoming oversized when the detected avatar anchor is rectangular and make the video frame better match the visible avatar on portrait mobile screens.

### Description
- In `webapp/src/components/GameLiveAvatarOverlay.jsx` compute `avatarDiameter` using `Math.min(rect.width, rect.height)` instead of `Math.max`, preserving the existing `FRAME_SCALE` multiplier and centering logic so the overlay remains positioned correctly.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully (Vite reported existing non-blocking chunk-size warnings).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c10d5f94308329b84f0b316b0230ee)