### PR TITLE
Improve Pool Royale live avatar activation touch area

### DIFF
--- a/webapp/src/components/GameLiveAvatarOverlay.jsx
+++ b/webapp/src/components/GameLiveAvatarOverlay.jsx
@@ -26,6 +26,7 @@ const AVATAR_ANCHOR_SELECTORS = [
 ];
 
 const FRAME_SCALE = 2;
+const ACTIVATION_TOUCH_PADDING = 8;
 
 export default function GameLiveAvatarOverlay({ gameSlug, children }) {
   const { search } = useLocation();
@@ -231,19 +232,13 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
     };
   }, [gameSlug, search]);
 
-  useEffect(() => {
-    if (!anchorElement) return undefined;
-    const onToggle = (event) => {
-      event.preventDefault();
-      event.stopPropagation();
-      setLiveMode((prev) => !prev);
-    };
-    anchorElement.style.cursor = 'pointer';
-    anchorElement.addEventListener('click', onToggle);
-    return () => {
-      anchorElement.removeEventListener('click', onToggle);
-    };
-  }, [anchorElement]);
+  const activationRect = useMemo(() => {
+    const width = overlayRect.width + ACTIVATION_TOUCH_PADDING * 2;
+    const height = overlayRect.height + ACTIVATION_TOUCH_PADDING * 2;
+    const left = Math.max(overlayRect.left - ACTIVATION_TOUCH_PADDING, 0);
+    const top = Math.max(overlayRect.top - ACTIVATION_TOUCH_PADDING, 0);
+    return { top, left, width, height };
+  }, [overlayRect]);
 
   useEffect(() => {
     if (!anchorElement) return undefined;
@@ -258,12 +253,26 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
   return (
     <>
       {children}
+      {!liveMode && anchorElement ? (
+        <button
+          type="button"
+          aria-label="Turn on live avatar video"
+          onClick={() => setLiveMode(true)}
+          className="fixed z-[64] rounded-full bg-transparent touch-manipulation"
+          style={{
+            top: `${activationRect.top}px`,
+            left: `${activationRect.left}px`,
+            width: `${activationRect.width}px`,
+            height: `${activationRect.height}px`
+          }}
+        />
+      ) : null}
       {liveMode && anchorElement ? (
         <button
           type="button"
           aria-label="Turn off live avatar video"
           onClick={() => setLiveMode(false)}
-          className="fixed z-[65] overflow-hidden rounded-full border border-emerald-300 bg-black/30"
+          className="fixed z-[65] overflow-hidden rounded-full border border-emerald-300 bg-black/30 touch-manipulation"
           style={{
             top: `${overlayRect.top}px`,
             left: `${overlayRect.left}px`,


### PR DESCRIPTION
### Motivation
- Players on mobile portrait screens reported the avatar was hard to tap to activate the live camera; the hit area needed to be increased for reliable activation. 
- Change should be minimally invasive and keep the visible live video overlay behavior unchanged while improving touch responsiveness.

### Description
- Added a new `ACTIVATION_TOUCH_PADDING` constant and computed an expanded `activationRect` around the detected avatar overlay using `useMemo` to increase the tappable area. 
- Replaced the previous direct click-binding on the avatar DOM node with a fixed transparent activation `button` that sits over the expanded activation bounds and calls `setLiveMode(true)`. 
- Kept the existing live video overlay element and anchor-hide logic intact, and added the `touch-manipulation` class to activation/deactivation buttons to improve mobile tap responsiveness. 
- Removed the anchor element click listener in favor of the explicit activation button to reduce missed taps and cross-frame interaction edge cases.

### Testing
- Built the web app with `npm --prefix webapp run build`, which completed successfully (Vite production build). 
- No other automated tests were changed or run as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c10e08df488329a57bf5f37b81ddbd)