### PR TITLE
Authoritative checkers engine, realtime session handling, and match settlement

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -61,12 +61,15 @@ import {
 } from './services/connectionService.js';
 import { GAME_ONLINE_POLICY, validateSeatTableRequest } from './config/onlineGamePolicy.js';
 import { createCheckersRealtimeStore } from './utils/checkersRealtimeState.js';
+import { applyAuthoritativeMove, SIDES } from './utils/checkersAuthoritativeEngine.js';
 
 validateEnv();
 
 const CHESS_START_FEN = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w - - 0 1';
 const chessGames = new Map();
 const checkersRealtimeStore = createCheckersRealtimeStore();
+const checkersMatchSessions = new Map();
+const checkersSettlementLedger = new Map();
 const AUTHENTIC_ACCOUNT_QUERY = {
   isBanned: { $ne: true },
   $or: [
@@ -479,6 +482,8 @@ const snookerStates = new Map();
 const lastActionBySocket = new Map();
 const rollRateLimitMs = Number(process.env.SOCKET_ROLL_COOLDOWN_MS) || 800;
 const seatTableRateLimitMs = Number(process.env.SEAT_TABLE_RATE_LIMIT_MS) || 500;
+const checkersMoveRateLimitMs =
+  Number(process.env.CHECKERS_MOVE_RATE_LIMIT_MS) || 120;
 
 const MATCH_META_KEYS = ['mode', 'playType', 'variant', 'tableSize', 'ballSet', 'token'];
 
@@ -759,6 +764,109 @@ function assignChessSides(players = []) {
   }));
 }
 
+function ensureCheckersSession(tableId, table = null) {
+  let session = checkersMatchSessions.get(tableId);
+  if (!session) {
+    session = {
+      tableId,
+      stake: Number(table?.stake || 0),
+      token: table?.meta?.token || 'TPC',
+      playersBySide: {
+        light: table?.players?.find((p) => p.side === 'light')?.id || null,
+        dark: table?.players?.find((p) => p.side === 'dark')?.id || null
+      },
+      processedMoveIds: new Set(),
+      lastMoveAtByPlayer: new Map()
+    };
+    checkersMatchSessions.set(tableId, session);
+  }
+  return session;
+}
+
+async function settleCheckersMatch({
+  tableId,
+  winnerId,
+  loserId,
+  reason = 'match_end',
+  stake = 0,
+  token = 'TPC'
+} = {}) {
+  if (!winnerId || !loserId || !stake) {
+    return {
+      ok: true,
+      status: 'skipped',
+      reason: stake ? 'missing_players' : 'zero_stake'
+    };
+  }
+
+  const round = 1;
+  const settlementKey = `${tableId}:${round}`;
+  if (checkersSettlementLedger.has(settlementKey)) {
+    return {
+      ok: true,
+      status: 'duplicate',
+      settlement: checkersSettlementLedger.get(settlementKey)
+    };
+  }
+
+  const now = new Date();
+  const payoutAmount = Number(stake) * 2;
+  const detail = `checkers:${tableId}:${reason}`;
+  const result = await User.bulkWrite([
+    {
+      updateOne: {
+        filter: { accountId: String(winnerId), isBanned: { $ne: true } },
+        update: {
+          $inc: { balance: payoutAmount },
+          $push: {
+            transactions: {
+              amount: payoutAmount,
+              type: 'game_win',
+              token,
+              game: 'checkersbattle',
+              players: 2,
+              detail,
+              date: now
+            }
+          }
+        }
+      }
+    },
+    {
+      updateOne: {
+        filter: { accountId: String(loserId), isBanned: { $ne: true } },
+        update: {
+          $push: {
+            transactions: {
+              amount: 0,
+              type: 'game_loss',
+              token,
+              game: 'checkersbattle',
+              players: 2,
+              detail,
+              date: now
+            }
+          }
+        }
+      }
+    }
+  ]);
+
+  const settlement = {
+    idempotencyKey: settlementKey,
+    winnerId: String(winnerId),
+    loserId: String(loserId),
+    payoutAmount,
+    token,
+    reason,
+    matched: result.matchedCount || 0,
+    modified: result.modifiedCount || 0,
+    settledAt: now.toISOString()
+  };
+  checkersSettlementLedger.set(settlementKey, settlement);
+  return { ok: true, status: 'settled', settlement };
+}
+
 async function seatTableSocket(
   accountId,
   gameType,
@@ -864,10 +972,15 @@ function maybeStartGame(table) {
         table.players = assignCheckersSides(table.players);
         const lightPlayer = table.players.find((p) => p.side === 'light');
         if (lightPlayer) table.currentTurn = lightPlayer.id;
-        const initial = checkersRealtimeStore.updateState(table.id, {
-          turn: 'light',
-          lastMove: null
+        const initial = checkersRealtimeStore.setState(table.id, {
+          turn: SIDES.LIGHT,
+          lastMove: null,
+          requiredFrom: null,
+          winner: null,
+          reason: null,
+          moveSeq: 0
         });
+        ensureCheckersSession(table.id, table);
         io.to(table.id).emit('checkersState', { tableId: table.id, ...initial });
       }
       io.to(table.id).emit('gameStart', {
@@ -919,6 +1032,7 @@ function unseatTableSocket(accountId, tableId, socketId) {
     if (table.players.length === 0) {
       if (table.gameType === 'checkers') {
         checkersRealtimeStore.clearState(tableId);
+        checkersMatchSessions.delete(tableId);
       }
       tableMap.delete(tableId);
       const key = `${table.gameType}-${table.maxPlayers}`;
@@ -1900,14 +2014,158 @@ io.on('connection', (socket) => {
     socket.to(tableId).emit('chessMove', { tableId, ...next });
   });
 
-  socket.on('checkersMove', ({ tableId, move }) => {
+  socket.on('checkersMove', async ({ tableId, move }) => {
     if (!tableId || !move) return;
-    const next = checkersRealtimeStore.updateState(tableId, {
-      board: move.board,
-      turn: move.turn,
-      lastMove: move.lastMove || null
+
+    const playerId = String(socket.data?.playerId || '');
+    if (!playerId) {
+      socket.emit('checkersMoveRejected', {
+        tableId,
+        error: 'register_required'
+      });
+      return;
+    }
+
+    const table = tableMap.get(tableId);
+    if (!table || table.gameType !== 'checkers') {
+      socket.emit('checkersMoveRejected', { tableId, error: 'table_not_found' });
+      return;
+    }
+
+    const session = ensureCheckersSession(tableId, table);
+    const now = Date.now();
+    const lastActionAt = session.lastMoveAtByPlayer.get(playerId) || 0;
+    if (now - lastActionAt < checkersMoveRateLimitMs) {
+      socket.emit('checkersMoveRejected', {
+        tableId,
+        error: 'move_rate_limited'
+      });
+      return;
+    }
+    session.lastMoveAtByPlayer.set(playerId, now);
+
+    const clientMoveId =
+      typeof move.clientMoveId === 'string' ? move.clientMoveId.slice(0, 120) : '';
+    if (clientMoveId && session.processedMoveIds.has(clientMoveId)) {
+      socket.emit('checkersMoveRejected', {
+        tableId,
+        error: 'duplicate_move'
+      });
+      return;
+    }
+
+    const state = checkersRealtimeStore.getState(tableId);
+    const activeSide = state.turn === SIDES.DARK ? SIDES.DARK : SIDES.LIGHT;
+    const sideForPlayer =
+      String(session.playersBySide.light) === playerId
+        ? SIDES.LIGHT
+        : String(session.playersBySide.dark) === playerId
+          ? SIDES.DARK
+          : null;
+    if (!sideForPlayer) {
+      socket.emit('checkersMoveRejected', {
+        tableId,
+        error: 'seat_required'
+      });
+      return;
+    }
+    if (sideForPlayer !== activeSide) {
+      socket.emit('checkersMoveRejected', {
+        tableId,
+        error: 'not_your_turn'
+      });
+      return;
+    }
+
+    const authoritative = applyAuthoritativeMove(state, move);
+    if (!authoritative.ok) {
+      socket.emit('checkersMoveRejected', {
+        tableId,
+        clientMoveId: clientMoveId || null,
+        error: authoritative.error
+      });
+      return;
+    }
+
+    if (clientMoveId) {
+      session.processedMoveIds.add(clientMoveId);
+      if (session.processedMoveIds.size > 500) {
+        session.processedMoveIds = new Set(
+          Array.from(session.processedMoveIds).slice(-200)
+        );
+      }
+    }
+
+    const nextMoveSeq = Number(state.moveSeq || 0) + 1;
+    const nextState = checkersRealtimeStore.setState(tableId, {
+      board: authoritative.board,
+      turn: authoritative.turn,
+      lastMove: authoritative.lastMove,
+      requiredFrom: authoritative.requiredFrom,
+      winner: authoritative.winner,
+      reason: authoritative.reason,
+      moveSeq: nextMoveSeq
     });
-    io.to(tableId).emit('checkersState', { tableId, ...next });
+
+    table.currentTurn =
+      nextState.turn === SIDES.LIGHT
+        ? session.playersBySide.light
+        : session.playersBySide.dark;
+
+    socket.emit('checkersMoveAccepted', {
+      tableId,
+      clientMoveId: clientMoveId || null,
+      moveSeq: nextMoveSeq,
+      chainCapture: Boolean(authoritative.chainCapture)
+    });
+
+    io.to(tableId).emit('checkersState', { tableId, ...nextState });
+
+    if (!authoritative.winner) return;
+
+    const winnerSide = authoritative.winner;
+    const loserSide = winnerSide === SIDES.LIGHT ? SIDES.DARK : SIDES.LIGHT;
+    const winnerId = session.playersBySide[winnerSide];
+    const loserId = session.playersBySide[loserSide];
+    const matchEndPayload = {
+      tableId,
+      winnerSide,
+      winnerId: winnerId ? String(winnerId) : null,
+      loserId: loserId ? String(loserId) : null,
+      reason: authoritative.reason || 'match_end'
+    };
+    io.to(tableId).emit('matchEnded', matchEndPayload);
+
+    try {
+      const settlementResult = await settleCheckersMatch({
+        tableId,
+        winnerId,
+        loserId,
+        reason: matchEndPayload.reason,
+        stake: Number(session.stake || table.stake || 0),
+        token: session.token || table.meta?.token || 'TPC'
+      });
+      io.to(tableId).emit('settlementConfirmed', {
+        tableId,
+        idempotencyKey: settlementResult.settlement?.idempotencyKey || `${tableId}:1`,
+        winnerId: winnerId ? String(winnerId) : null,
+        loserId: loserId ? String(loserId) : null,
+        payoutAmount: settlementResult.settlement?.payoutAmount || 0,
+        token: settlementResult.settlement?.token || session.token || 'TPC',
+        status: settlementResult.status || 'skipped'
+      });
+    } catch (error) {
+      console.error('checkers settlement failed', error);
+      io.to(tableId).emit('settlementConfirmed', {
+        tableId,
+        idempotencyKey: `${tableId}:1`,
+        winnerId: winnerId ? String(winnerId) : null,
+        loserId: loserId ? String(loserId) : null,
+        payoutAmount: 0,
+        token: session.token || 'TPC',
+        status: 'failed'
+      });
+    }
   });
   socket.on('watchRoom', async ({ roomId }) => {
     if (!roomId) return;

--- a/bot/utils/checkersAuthoritativeEngine.js
+++ b/bot/utils/checkersAuthoritativeEngine.js
@@ -1,0 +1,197 @@
+const SIZE = 8;
+const SIDES = Object.freeze({ LIGHT: 'light', DARK: 'dark' });
+
+export function inBounds(r, c) {
+  return Number.isInteger(r) && Number.isInteger(c) && r >= 0 && r < SIZE && c >= 0 && c < SIZE;
+}
+
+export function cloneBoard(board) {
+  return board.map((row) => row.map((cell) => (cell ? { side: cell.side, king: Boolean(cell.king) } : null)));
+}
+
+export function createInitialBoard() {
+  const board = Array.from({ length: SIZE }, () => Array(SIZE).fill(null));
+  for (let r = 0; r < 3; r += 1) {
+    for (let c = 0; c < SIZE; c += 1) {
+      if ((r + c) % 2 === 1) board[r][c] = { side: SIDES.DARK, king: false };
+    }
+  }
+  for (let r = 5; r < SIZE; r += 1) {
+    for (let c = 0; c < SIZE; c += 1) {
+      if ((r + c) % 2 === 1) board[r][c] = { side: SIDES.LIGHT, king: false };
+    }
+  }
+  return board;
+}
+
+export function normalizeBoard(board) {
+  if (!Array.isArray(board) || board.length !== SIZE) return null;
+  const normalized = board.map((row, r) => {
+    if (!Array.isArray(row) || row.length !== SIZE) return null;
+    return row.map((cell, c) => {
+      if (!cell) return null;
+      if ((r + c) % 2 === 0) return null;
+      const side = cell.side === SIDES.LIGHT || cell.side === SIDES.DARK ? cell.side : null;
+      if (!side) return null;
+      return { side, king: Boolean(cell.king) };
+    });
+  });
+  if (normalized.some((row) => row == null)) return null;
+  return normalized;
+}
+
+function getPieceDirs(piece) {
+  if (piece.king) {
+    return [
+      [1, 1],
+      [1, -1],
+      [-1, 1],
+      [-1, -1]
+    ];
+  }
+  return piece.side === SIDES.LIGHT
+    ? [
+        [-1, 1],
+        [-1, -1]
+      ]
+    : [
+        [1, 1],
+        [1, -1]
+      ];
+}
+
+export function getPieceMoves(board, from) {
+  const piece = board?.[from.r]?.[from.c];
+  if (!piece) return [];
+  const captures = [];
+  const normals = [];
+  for (const [dr, dc] of getPieceDirs(piece)) {
+    const nr = from.r + dr;
+    const nc = from.c + dc;
+    if (!inBounds(nr, nc)) continue;
+    if (!board[nr][nc]) {
+      normals.push({ from, to: { r: nr, c: nc }, capture: null });
+      continue;
+    }
+    if (board[nr][nc].side === piece.side) continue;
+    const jr = nr + dr;
+    const jc = nc + dc;
+    if (inBounds(jr, jc) && !board[jr][jc]) {
+      captures.push({ from, to: { r: jr, c: jc }, capture: { r: nr, c: nc } });
+    }
+  }
+  return captures.length ? captures : normals;
+}
+
+export function getLegalMovesForSide(board, side) {
+  const captures = [];
+  const normals = [];
+  for (let r = 0; r < SIZE; r += 1) {
+    for (let c = 0; c < SIZE; c += 1) {
+      const piece = board?.[r]?.[c];
+      if (!piece || piece.side !== side) continue;
+      const moves = getPieceMoves(board, { r, c });
+      for (const mv of moves) {
+        if (mv.capture) captures.push(mv);
+        else normals.push(mv);
+      }
+    }
+  }
+  return captures.length ? captures : normals;
+}
+
+function crownIfNeeded(piece, row) {
+  if (piece.side === SIDES.LIGHT && row === 0) return { ...piece, king: true };
+  if (piece.side === SIDES.DARK && row === SIZE - 1) return { ...piece, king: true };
+  return { ...piece };
+}
+
+function findWinner(board, turn) {
+  let light = 0;
+  let dark = 0;
+  for (let r = 0; r < SIZE; r += 1) {
+    for (let c = 0; c < SIZE; c += 1) {
+      const piece = board[r][c];
+      if (!piece) continue;
+      if (piece.side === SIDES.LIGHT) light += 1;
+      if (piece.side === SIDES.DARK) dark += 1;
+    }
+  }
+  if (light === 0) return { winner: SIDES.DARK, reason: 'all_light_captured' };
+  if (dark === 0) return { winner: SIDES.LIGHT, reason: 'all_dark_captured' };
+
+  const nextMoves = getLegalMovesForSide(board, turn);
+  if (!nextMoves.length) {
+    return {
+      winner: turn === SIDES.LIGHT ? SIDES.DARK : SIDES.LIGHT,
+      reason: 'no_legal_moves'
+    };
+  }
+  return null;
+}
+
+export function applyAuthoritativeMove(state, payload) {
+  const board = state?.board;
+  const turn = state?.turn === SIDES.DARK ? SIDES.DARK : SIDES.LIGHT;
+  const requiredFrom = state?.requiredFrom && inBounds(state.requiredFrom.r, state.requiredFrom.c)
+    ? state.requiredFrom
+    : null;
+  const from = payload?.from;
+  const to = payload?.to;
+
+  if (!inBounds(from?.r, from?.c) || !inBounds(to?.r, to?.c)) {
+    return { ok: false, error: 'invalid_coordinates' };
+  }
+
+  if (requiredFrom && (requiredFrom.r !== from.r || requiredFrom.c !== from.c)) {
+    return { ok: false, error: 'chain_capture_required_piece' };
+  }
+
+  const piece = board?.[from.r]?.[from.c];
+  if (!piece) return { ok: false, error: 'piece_not_found' };
+  if (piece.side !== turn) return { ok: false, error: 'not_your_turn_piece' };
+
+  const legalMoves = requiredFrom
+    ? getPieceMoves(board, from).filter((mv) => mv.capture)
+    : getLegalMovesForSide(board, turn);
+  const selected = legalMoves.find((mv) => mv.from.r === from.r && mv.from.c === from.c && mv.to.r === to.r && mv.to.c === to.c);
+  if (!selected) return { ok: false, error: 'illegal_move' };
+
+  const nextBoard = cloneBoard(board);
+  nextBoard[from.r][from.c] = null;
+  if (selected.capture) {
+    nextBoard[selected.capture.r][selected.capture.c] = null;
+  }
+  const movedPiece = crownIfNeeded(piece, to.r);
+  nextBoard[to.r][to.c] = movedPiece;
+
+  const followUpCaptures = selected.capture
+    ? getPieceMoves(nextBoard, to).filter((mv) => mv.capture)
+    : [];
+
+  const turnAfter = followUpCaptures.length ? turn : turn === SIDES.LIGHT ? SIDES.DARK : SIDES.LIGHT;
+  const requiredFromAfter = followUpCaptures.length ? { ...to } : null;
+  const winner = followUpCaptures.length ? null : findWinner(nextBoard, turnAfter);
+
+  return {
+    ok: true,
+    board: nextBoard,
+    turn: turnAfter,
+    requiredFrom: requiredFromAfter,
+    chainCapture: followUpCaptures.length > 0,
+    lastMove: {
+      from: { ...from },
+      to: { ...to },
+      capture: selected.capture ? { ...selected.capture } : null,
+      side: piece.side
+    },
+    winner: winner?.winner || null,
+    reason: winner?.reason || null
+  };
+}
+
+export function oppositeSide(side) {
+  return side === SIDES.LIGHT ? SIDES.DARK : SIDES.LIGHT;
+}
+
+export { SIZE, SIDES };

--- a/bot/utils/checkersRealtimeState.js
+++ b/bot/utils/checkersRealtimeState.js
@@ -1,33 +1,7 @@
-const SIZE = 8;
+import { createInitialBoard, normalizeBoard, SIDES } from './checkersAuthoritativeEngine.js';
 
 export function createInitialCheckersBoard() {
-  const board = Array.from({ length: SIZE }, () => Array(SIZE).fill(null));
-  for (let r = 0; r < 3; r += 1) {
-    for (let c = 0; c < SIZE; c += 1) {
-      if ((r + c) % 2 === 1) board[r][c] = { side: 'dark', king: false };
-    }
-  }
-  for (let r = 5; r < SIZE; r += 1) {
-    for (let c = 0; c < SIZE; c += 1) {
-      if ((r + c) % 2 === 1) board[r][c] = { side: 'light', king: false };
-    }
-  }
-  return board;
-}
-
-function normalizeBoard(board) {
-  if (!Array.isArray(board) || board.length !== SIZE) return null;
-  const normalized = board.map((row) => {
-    if (!Array.isArray(row) || row.length !== SIZE) return null;
-    return row.map((cell) => {
-      if (!cell || typeof cell !== 'object') return null;
-      const side = cell.side === 'light' || cell.side === 'dark' ? cell.side : null;
-      if (!side) return null;
-      return { side, king: Boolean(cell.king) };
-    });
-  });
-  if (normalized.some((row) => row == null)) return null;
-  return normalized;
+  return createInitialBoard();
 }
 
 export function createCheckersRealtimeStore() {
@@ -37,15 +11,19 @@ export function createCheckersRealtimeStore() {
     if (!stateByTable.has(tableId)) {
       stateByTable.set(tableId, {
         board: createInitialCheckersBoard(),
-        turn: 'light',
+        turn: SIDES.LIGHT,
         lastMove: null,
+        requiredFrom: null,
+        winner: null,
+        reason: null,
+        moveSeq: 0,
         updatedAt: Date.now()
       });
     }
     return stateByTable.get(tableId);
   };
 
-  const updateState = (tableId, nextState = {}) => {
+  const setState = (tableId, nextState = {}) => {
     const base = getState(tableId);
     const merged = {
       ...base,
@@ -55,16 +33,24 @@ export function createCheckersRealtimeStore() {
     if (nextState.board) {
       merged.board = normalizeBoard(nextState.board) || base.board;
     }
-    if (nextState.turn !== 'light' && nextState.turn !== 'dark') {
+    if (nextState.turn !== SIDES.LIGHT && nextState.turn !== SIDES.DARK) {
       merged.turn = base.turn;
+    }
+    if (
+      nextState.requiredFrom &&
+      (!Number.isInteger(nextState.requiredFrom.r) || !Number.isInteger(nextState.requiredFrom.c))
+    ) {
+      merged.requiredFrom = base.requiredFrom;
     }
     stateByTable.set(tableId, merged);
     return merged;
   };
 
+  const updateState = (tableId, nextState = {}) => setState(tableId, nextState);
+
   const clearState = (tableId) => {
     stateByTable.delete(tableId);
   };
 
-  return { getState, updateState, clearState };
+  return { getState, setState, updateState, clearState };
 }

--- a/test/checkersAuthoritativeEngine.test.js
+++ b/test/checkersAuthoritativeEngine.test.js
@@ -1,0 +1,92 @@
+import { describe, expect, test } from '@jest/globals';
+import {
+  createInitialBoard,
+  getLegalMovesForSide,
+  applyAuthoritativeMove,
+  SIDES
+} from '../bot/utils/checkersAuthoritativeEngine.js';
+
+function emptyBoard() {
+  return Array.from({ length: 8 }, () => Array(8).fill(null));
+}
+
+describe('checkers authoritative engine', () => {
+  test('creates standard opening position', () => {
+    const board = createInitialBoard();
+    let light = 0;
+    let dark = 0;
+    board.forEach((row) =>
+      row.forEach((cell) => {
+        if (cell?.side === SIDES.LIGHT) light += 1;
+        if (cell?.side === SIDES.DARK) dark += 1;
+      })
+    );
+    expect(light).toBe(12);
+    expect(dark).toBe(12);
+  });
+
+  test('enforces forced captures', () => {
+    const board = emptyBoard();
+    board[5][2] = { side: SIDES.LIGHT, king: false };
+    board[4][3] = { side: SIDES.DARK, king: false };
+    board[2][1] = { side: SIDES.LIGHT, king: false };
+
+    const legal = getLegalMovesForSide(board, SIDES.LIGHT);
+    expect(legal.every((m) => m.capture)).toBe(true);
+
+    const rejected = applyAuthoritativeMove(
+      { board, turn: SIDES.LIGHT, requiredFrom: null },
+      { from: { r: 2, c: 1 }, to: { r: 1, c: 0 } }
+    );
+    expect(rejected.ok).toBe(false);
+    expect(rejected.error).toBe('illegal_move');
+
+    const accepted = applyAuthoritativeMove(
+      { board, turn: SIDES.LIGHT, requiredFrom: null },
+      { from: { r: 5, c: 2 }, to: { r: 3, c: 4 } }
+    );
+    expect(accepted.ok).toBe(true);
+    expect(accepted.lastMove.capture).toEqual({ r: 4, c: 3 });
+  });
+
+  test('keeps same turn when chain capture remains', () => {
+    const board = emptyBoard();
+    board[5][0] = { side: SIDES.LIGHT, king: false };
+    board[4][1] = { side: SIDES.DARK, king: false };
+    board[2][3] = { side: SIDES.DARK, king: false };
+
+    const first = applyAuthoritativeMove(
+      { board, turn: SIDES.LIGHT, requiredFrom: null },
+      { from: { r: 5, c: 0 }, to: { r: 3, c: 2 } }
+    );
+    expect(first.ok).toBe(true);
+    expect(first.chainCapture).toBe(true);
+    expect(first.turn).toBe(SIDES.LIGHT);
+    expect(first.requiredFrom).toEqual({ r: 3, c: 2 });
+
+    const wrongPiece = applyAuthoritativeMove(
+      {
+        board: first.board,
+        turn: first.turn,
+        requiredFrom: first.requiredFrom
+      },
+      { from: { r: 3, c: 2 }, to: { r: 4, c: 3 } }
+    );
+    expect(wrongPiece.ok).toBe(false);
+  });
+
+  test('declares winner when opponent has no legal moves', () => {
+    const board = emptyBoard();
+    board[0][1] = { side: SIDES.LIGHT, king: true };
+    board[1][2] = { side: SIDES.DARK, king: false };
+
+    const result = applyAuthoritativeMove(
+      { board, turn: SIDES.LIGHT, requiredFrom: null },
+      { from: { r: 0, c: 1 }, to: { r: 2, c: 3 } }
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.winner).toBe(SIDES.LIGHT);
+    expect(result.reason).toBe('all_dark_captured');
+  });
+});

--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -1157,6 +1157,7 @@ export default function CheckersBattleRoyal() {
   const moveSoundRef = useRef(null);
   const captureSoundRef = useRef(null);
   const pointerDownRef = useRef(null);
+  const pendingMoveRef = useRef(null);
 
   const sceneRef = useRef(null);
   const rendererRef = useRef(null);
@@ -1712,27 +1713,31 @@ export default function CheckersBattleRoyal() {
           );
       const move = legalMoves.find((m) => m.r === r && m.c === c);
       if (!move) return;
+      if (isOnlineGame && onlineRef.current.tableId) {
+        const clientMoveId = `${onlineRef.current.accountId || 'guest'}-${Date.now()}-${Math.random()
+          .toString(36)
+          .slice(2, 8)}`;
+        pendingMoveRef.current = clientMoveId;
+        socket.emit('checkersMove', {
+          tableId: onlineRef.current.tableId,
+          move: {
+            from: { ...selected },
+            to: { r, c },
+            clientMoveId
+          }
+        });
+        selectedRef.current = null;
+        renderHighlights();
+        setStatus('Move submitted…');
+        return;
+      }
+
       const beforeBoard = copyBoard(board);
       const applied = applyMoveToBoard(board, {
         from: { ...selected },
         ...move
       });
       if (!applied) return;
-      const emitOnlineMove = (nextBoard, nextTurn) => {
-        if (!onlineRef.current.enabled || !onlineRef.current.tableId) return;
-        socket.emit('checkersMove', {
-          tableId: onlineRef.current.tableId,
-          move: {
-            board: nextBoard,
-            turn: nextTurn,
-            lastMove: {
-              from: { ...selected },
-              to: { r, c },
-              capture: move.capture || null
-            }
-          }
-        });
-      };
 
       if (Array.isArray(move.capture)) {
         const [captureR, captureC] = move.capture;
@@ -1798,7 +1803,6 @@ export default function CheckersBattleRoyal() {
             : 'AI is thinking…'
         );
       }
-      emitOnlineMove(copyBoard(applied.board), nextTurn);
       renderHighlights();
     };
 
@@ -2159,6 +2163,45 @@ export default function CheckersBattleRoyal() {
       const myTurn = (remoteTurn === 'dark' ? 'dark' : 'light') === onlineRef.current.side;
       setStatus(myTurn ? 'Your turn. Forced captures are enabled.' : 'Waiting for opponent move…');
     };
+    const handleMoveAccepted = ({ tableId: eventTableId, clientMoveId, chainCapture } = {}) => {
+      if (!eventTableId || eventTableId !== tableId) return;
+      if (pendingMoveRef.current && clientMoveId && pendingMoveRef.current !== clientMoveId) return;
+      pendingMoveRef.current = null;
+      if (chainCapture) {
+        setStatus('Chain capture required.');
+      }
+    };
+    const handleMoveRejected = ({ tableId: eventTableId, clientMoveId, error } = {}) => {
+      if (!eventTableId || eventTableId !== tableId) return;
+      if (pendingMoveRef.current && clientMoveId && pendingMoveRef.current !== clientMoveId) return;
+      pendingMoveRef.current = null;
+      const msg =
+        error === 'move_rate_limited'
+          ? 'Too fast. Wait a moment and retry.'
+          : error === 'not_your_turn'
+          ? 'Not your turn.'
+          : error === 'duplicate_move'
+          ? 'Duplicate move ignored.'
+          : error === 'chain_capture_required_piece'
+          ? 'You must continue with the same piece for chain capture.'
+          : 'Move rejected. Syncing board…';
+      setStatus(msg);
+      socket.emit('checkersSyncRequest', { tableId });
+    };
+    const handleMatchEnded = ({ tableId: eventTableId, winnerId } = {}) => {
+      if (!eventTableId || eventTableId !== tableId) return;
+      pendingMoveRef.current = null;
+      const meWon = winnerId && String(winnerId) === String(accountId);
+      setGameOver(meWon ? HUMAN_SIDE : AI_SIDE);
+      setStatus(meWon ? 'You won the match!' : 'You lost the match.');
+    };
+    const handleSettlementConfirmed = ({ tableId: eventTableId, payoutAmount, winnerId, status: settlementStatus } = {}) => {
+      if (!eventTableId || eventTableId !== tableId) return;
+      if (String(winnerId || '') !== String(accountId || '')) return;
+      if (settlementStatus === 'settled' && Number(payoutAmount) > 0) {
+        setStatus(`Match settled. +${Number(payoutAmount)} TPC paid.`);
+      }
+    };
     const handleSocketDisconnect = () => {
       setOnlineStatus('reconnecting');
       setStatus('Connection lost. Reconnecting to table…');
@@ -2172,6 +2215,10 @@ export default function CheckersBattleRoyal() {
     let cancelled = false;
     socket.on('gameStart', handleGameStart);
     socket.on('checkersState', handleCheckersState);
+    socket.on('checkersMoveAccepted', handleMoveAccepted);
+    socket.on('checkersMoveRejected', handleMoveRejected);
+    socket.on('matchEnded', handleMatchEnded);
+    socket.on('settlementConfirmed', handleSettlementConfirmed);
     socket.on('disconnect', handleSocketDisconnect);
     socket.on('reconnect', handleSocketReconnect);
 
@@ -2194,6 +2241,10 @@ export default function CheckersBattleRoyal() {
       cancelled = true;
       socket.off('gameStart', handleGameStart);
       socket.off('checkersState', handleCheckersState);
+      socket.off('checkersMoveAccepted', handleMoveAccepted);
+      socket.off('checkersMoveRejected', handleMoveRejected);
+      socket.off('matchEnded', handleMatchEnded);
+      socket.off('settlementConfirmed', handleSettlementConfirmed);
       socket.off('disconnect', handleSocketDisconnect);
       socket.off('reconnect', handleSocketReconnect);
       socket.emit('leaveLobby', { accountId, tableId });


### PR DESCRIPTION
### Motivation
- Replace fragile client-driven checkers moves with a server-side authoritative engine to prevent desyncs and cheating. 
- Track per-match session state and idempotent settlements so online stake-based matches are settled reliably. 
- Provide client feedback for accepted/rejected moves and settlement results to improve UX during online play.

### Description
- Add a new authoritative engine in `bot/utils/checkersAuthoritativeEngine.js` implementing board creation, move validation, forced-capture rules, chain captures, winner detection, and exported `applyAuthoritativeMove` and `SIDES` constants. 
- Integrate the engine with realtime state by updating `bot/utils/checkersRealtimeState.js` to use the new engine, expose `getState`/`setState`/`updateState`, and extend state with `requiredFrom`, `winner`, `reason`, and `moveSeq`. 
- Update server socket logic in `bot/server.js` to maintain `checkersMatchSessions` and `checkersSettlementLedger`, enforce per-player rate limits, deduplicate client moves via `clientMoveId`, validate and apply moves with `applyAuthoritativeMove`, broadcast `checkersState` and acceptance/rejection events, and perform idempotent on-chain-like settlement via `settleCheckersMatch`. 
- Update the client in `webapp/src/pages/Games/CheckersBattleRoyal.jsx` to emit moves with a `clientMoveId`, track pending moves, and handle new socket events `checkersMoveAccepted`, `checkersMoveRejected`, `matchEnded`, and `settlementConfirmed` to update UI and request syncs when needed. 

### Testing
- Added unit tests `test/checkersAuthoritativeEngine.test.js` that exercise the engine's initial position, forced-capture enforcement, chain-capture behavior, and winner detection. 
- Ran the test suite with `npm test` which executed the new engine tests and they passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1166ec8508329bbe353b45dfe211d)