### PR TITLE
Improve Pool Royale pocket jaw physics and ball-contact aiming precision

### DIFF
--- a/Assets/Scripts/Gameplay/Pockets/PocketCollisionResolver.cs
+++ b/Assets/Scripts/Gameplay/Pockets/PocketCollisionResolver.cs
@@ -4,12 +4,19 @@ namespace Aiming.Pockets
 {
     /// <summary>
     /// Resolves jaw-face + rounded-tip contacts using explicit billiards response.
+    /// Tuned for realistic corner-pocket jaw rattle and glancing slides.
     /// </summary>
     [System.Serializable]
     public class PocketCollisionResolver
     {
         [SerializeField, Min(0f)] private float positionalSlop = 0.0002f;
         [SerializeField, Min(0f)] private float maxPushOut = 0.02f;
+
+        [Header("Jaw realism")]
+        [SerializeField, Range(0f, 1f)] private float glancingRestitutionScale = 0.4f;
+        [SerializeField, Range(0f, 1f)] private float glancingFrictionScale = 0.5f;
+        [SerializeField, Min(0f)] private float minTangentialCarry = 0.03f;
+        [SerializeField, Range(0f, 1f)] private float pocketGuidance = 0.22f;
 
         public bool Resolve(IPoolBallBody ball, PocketMouth mouth)
         {
@@ -19,16 +26,16 @@ namespace Aiming.Pockets
             }
 
             bool any = false;
-            any |= ResolveJaw(ball, mouth.LeftJaw);
-            any |= ResolveJaw(ball, mouth.RightJaw);
-            any |= ResolveTip(ball, mouth.LeftJaw.StartTip, mouth.LeftJaw.JawRestitution, mouth.LeftJaw.JawFriction);
-            any |= ResolveTip(ball, mouth.LeftJaw.EndTip, mouth.LeftJaw.JawRestitution, mouth.LeftJaw.JawFriction);
-            any |= ResolveTip(ball, mouth.RightJaw.StartTip, mouth.RightJaw.JawRestitution, mouth.RightJaw.JawFriction);
-            any |= ResolveTip(ball, mouth.RightJaw.EndTip, mouth.RightJaw.JawRestitution, mouth.RightJaw.JawFriction);
+            any |= ResolveJaw(ball, mouth, mouth.LeftJaw);
+            any |= ResolveJaw(ball, mouth, mouth.RightJaw);
+            any |= ResolveTip(ball, mouth, mouth.LeftJaw.StartTip, mouth.LeftJaw.JawRestitution, mouth.LeftJaw.JawFriction);
+            any |= ResolveTip(ball, mouth, mouth.LeftJaw.EndTip, mouth.LeftJaw.JawRestitution, mouth.LeftJaw.JawFriction);
+            any |= ResolveTip(ball, mouth, mouth.RightJaw.StartTip, mouth.RightJaw.JawRestitution, mouth.RightJaw.JawFriction);
+            any |= ResolveTip(ball, mouth, mouth.RightJaw.EndTip, mouth.RightJaw.JawRestitution, mouth.RightJaw.JawFriction);
             return any;
         }
 
-        private bool ResolveJaw(IPoolBallBody ball, PocketJawDefinition jaw)
+        private bool ResolveJaw(IPoolBallBody ball, PocketMouth mouth, PocketJawDefinition jaw)
         {
             FiniteJawSegment segment = jaw.Segment;
             if (!PocketGeometry.TryCircleVsCapsule(
@@ -38,27 +45,39 @@ namespace Aiming.Pockets
                     jaw.JawRadius,
                     out Vector2 normal,
                     out float penetration,
-                    out _))
+                    out Vector2 closest))
             {
                 return false;
             }
 
-            ApplyCollisionResponse(ball, normal, penetration, jaw.JawRestitution, jaw.JawFriction);
+            Vector2 tangent = segment.Direction.sqrMagnitude > 1e-8f
+                ? segment.Direction.normalized
+                : new Vector2(-normal.y, normal.x);
+            ApplyCollisionResponse(ball, mouth, normal, tangent, closest, penetration, jaw.JawRestitution, jaw.JawFriction);
             return true;
         }
 
-        private bool ResolveTip(IPoolBallBody ball, JawTip tip, float restitution, float friction)
+        private bool ResolveTip(IPoolBallBody ball, PocketMouth mouth, JawTip tip, float restitution, float friction)
         {
             if (!PocketGeometry.TryCircleVsTip(ball.Position2, ball.Radius, tip, out Vector2 normal, out float penetration))
             {
                 return false;
             }
 
-            ApplyCollisionResponse(ball, normal, penetration, restitution, friction);
+            Vector2 tangent = new Vector2(-normal.y, normal.x);
+            ApplyCollisionResponse(ball, mouth, normal, tangent, tip.center, penetration, restitution, friction);
             return true;
         }
 
-        private void ApplyCollisionResponse(IPoolBallBody ball, Vector2 normal, float penetration, float restitution, float friction)
+        private void ApplyCollisionResponse(
+            IPoolBallBody ball,
+            PocketMouth mouth,
+            Vector2 normal,
+            Vector2 tangent,
+            Vector2 contactPoint,
+            float penetration,
+            float restitution,
+            float friction)
         {
             float push = Mathf.Min(Mathf.Max(0f, penetration + positionalSlop), maxPushOut);
             ball.Position2 += normal * push;
@@ -67,14 +86,54 @@ namespace Aiming.Pockets
             float vn = Vector2.Dot(vel, normal);
 
             // Only reflect when moving into the jaw.
-            if (vn < 0f)
+            if (vn >= 0f)
             {
-                Vector2 vN = normal * vn;
-                Vector2 vT = vel - vN;
-                Vector2 reflectedN = -vN * Mathf.Clamp01(restitution);
-                Vector2 dampedT = vT * Mathf.Clamp01(1f - friction);
-                ball.Velocity2 = reflectedN + dampedT;
+                return;
             }
+
+            if (tangent.sqrMagnitude < 1e-8f)
+            {
+                tangent = new Vector2(-normal.y, normal.x);
+            }
+            tangent.Normalize();
+
+            float tangentSpeedSigned = Vector2.Dot(vel, tangent);
+            float tangentSpeed = Mathf.Abs(tangentSpeedSigned);
+            float normalSpeed = -vn;
+            float impactRatio = normalSpeed / Mathf.Max(1e-5f, normalSpeed + tangentSpeed);
+
+            float effectiveRestitution = Mathf.Lerp(
+                Mathf.Clamp01(restitution) * Mathf.Clamp01(glancingRestitutionScale),
+                Mathf.Clamp01(restitution),
+                impactRatio);
+
+            float effectiveFriction = Mathf.Lerp(
+                Mathf.Clamp01(friction) * Mathf.Clamp01(glancingFrictionScale),
+                Mathf.Clamp01(friction),
+                impactRatio);
+
+            float reflectedNormalSpeed = normalSpeed * effectiveRestitution;
+            float outTangentSpeed = tangentSpeedSigned * (1f - effectiveFriction);
+
+            // Keep a small tangential carry on glancing contacts so balls rattle/slide naturally
+            // on jaw angles instead of unnaturally sticking or kicking straight out.
+            float minCarry = minTangentialCarry * (normalSpeed + tangentSpeed);
+            if (Mathf.Abs(outTangentSpeed) < minCarry)
+            {
+                float sign = Mathf.Abs(tangentSpeedSigned) > 1e-5f ? Mathf.Sign(tangentSpeedSigned) : 1f;
+                outTangentSpeed = sign * minCarry;
+            }
+
+            // Bias glancing contacts toward the pocket opening direction.
+            Vector2 toPocket = mouth.PocketCenter - contactPoint;
+            if (toPocket.sqrMagnitude > 1e-8f)
+            {
+                Vector2 toPocketDir = toPocket.normalized;
+                float tangentTowardPocket = Vector2.Dot(tangent, toPocketDir);
+                outTangentSpeed += tangentTowardPocket * normalSpeed * pocketGuidance;
+            }
+
+            ball.Velocity2 = normal * reflectedNormalSpeed + tangent * outTangentSpeed;
         }
     }
 }

--- a/test/poolRoyaleAiAimCompensation.test.js
+++ b/test/poolRoyaleAiAimCompensation.test.js
@@ -16,7 +16,7 @@ describe('Pool Royale AI aim compensation', () => {
     });
     expect(result).toBeTruthy();
     expect(result.aimDir.length()).toBeCloseTo(1, 5);
-    expect(Math.hypot(result.ghost.x - targetPos.x, result.ghost.y - targetPos.y)).toBeGreaterThan(0.04);
+    expect(Math.hypot(result.ghost.x - targetPos.x, result.ghost.y - targetPos.y)).toBeCloseTo(0.06024, 4);
   });
 
   it('keeps pre-impact aim unchanged when only side spin changes', () => {
@@ -38,5 +38,30 @@ describe('Pool Royale AI aim compensation', () => {
     });
     expect(withSide).toBeTruthy();
     expect(neutral.aimDir.angleTo(withSide.aimDir)).toBeLessThan(1e-6);
+    expect(withSide.contactDepth).toBeCloseTo(neutral.contactDepth, 8);
+  });
+
+  it('keeps contact depth close to 2R and adjusts only slightly with spin', () => {
+    const neutral = resolveAiPotGhostAim({
+      cuePos,
+      targetPos,
+      pocketPos,
+      ballRadius: 0.03,
+      spin: { x: 0, y: 0 },
+      power: 1
+    });
+
+    const topspin = resolveAiPotGhostAim({
+      cuePos,
+      targetPos,
+      pocketPos,
+      ballRadius: 0.03,
+      spin: { x: 0, y: 1 },
+      power: 1
+    });
+
+    expect(neutral.contactDepth).toBeCloseTo(0.06024, 5);
+    expect(topspin.contactDepth).toBeGreaterThan(neutral.contactDepth);
+    expect(topspin.contactDepth - neutral.contactDepth).toBeLessThan(0.0015);
   });
 });

--- a/webapp/src/pages/Games/poolRoyaleAiAimCompensation.js
+++ b/webapp/src/pages/Games/poolRoyaleAiAimCompensation.js
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 
 const MIN_VECTOR_EPS = 1e-6;
+const DEFAULT_CONTACT_CALIBRATION = 0.004;
 
 export const resolveAiPotGhostAim = ({
   cuePos,
@@ -8,7 +9,8 @@ export const resolveAiPotGhostAim = ({
   pocketPos,
   ballRadius,
   spin,
-  power
+  power,
+  contactCalibration
 } = {}) => {
   if (!cuePos || !targetPos || !pocketPos) return null;
   const radius = Math.max(0, ballRadius ?? 0);
@@ -19,20 +21,25 @@ export const resolveAiPotGhostAim = ({
   const topBackSpin = THREE.MathUtils.clamp(spin?.y ?? 0, -1, 1);
   const power01 = THREE.MathUtils.clamp(power ?? 0.6, 0, 1);
 
-  // Keep cue-ball approach aligned to the geometric ghost-ball line.
-  // Spin is still used after contact by the runtime physics, but it should not
-  // change the pre-impact aiming direction.
-  // Slightly adjust contact depth with top/back spin to account for post-impact speed changes.
-  const contactDepth = radius * 2 * (1 + topBackSpin * power01 * 0.07);
+  // Baseline geometric contact: cue-ball and object-ball centers should be 2R apart at impact.
+  // Keep only a tiny spin/power calibration so aiming stays precise for ball-to-ball touch points.
+  const calibration = THREE.MathUtils.clamp(
+    contactCalibration ?? DEFAULT_CONTACT_CALIBRATION,
+    -0.08,
+    0.08
+  );
+  const contactDepth = radius * 2 * (1 + calibration + topBackSpin * power01 * 0.015);
+
   const ghost = new THREE.Vector2()
     .copy(targetPos)
-    .sub(toPocketDir.clone().multiplyScalar(Math.max(radius * 1.5, contactDepth)));
+    .sub(toPocketDir.clone().multiplyScalar(contactDepth));
 
   const finalCueVector = new THREE.Vector2().subVectors(ghost, cuePos);
   if (finalCueVector.lengthSq() <= MIN_VECTOR_EPS) return null;
 
   return {
     aimDir: finalCueVector.normalize(),
-    ghost
+    ghost,
+    contactDepth
   };
 };


### PR DESCRIPTION
### Motivation
- Make corner-pocket interactions feel more realistic by preventing unnatural pops on jaw/corner contacts and encouraging natural rattle/slide toward the pocket opening. 
- Increase precision of ghost-ball aiming so cue/object ball contact maps extremely close to the true `2R` geometry when balls touch.

### Description
- Reworked `PocketCollisionResolver` to add glancing-impact tuning: new inspector fields `glancingRestitutionScale`, `glancingFrictionScale`, `minTangentialCarry`, and `pocketGuidance`, and updated jaw/tip resolution to compute tangents and contact points so glancing collisions preserve tangential carry and bias deflections toward the pocket (`Assets/Scripts/Gameplay/Pockets/PocketCollisionResolver.cs`).
- Adjusted resolver signatures and response logic to use the jaw tangent and contact point, compute `impactRatio`, blend effective restitution/friction based on impact angle, and enforce a minimum tangential carry for natural rattling behavior.
- Tightened AI ghost-ball contact calibration in `resolveAiPotGhostAim` by adding `DEFAULT_CONTACT_CALIBRATION`, a `contactCalibration` parameter, smaller spin-based adjustments, and returning `contactDepth` for diagnostics (`webapp/src/pages/Games/poolRoyaleAiAimCompensation.js`).
- Updated unit tests to assert precise ghost displacement and contact-depth invariants and to ensure side-spin does not change the pre-impact aim (`test/poolRoyaleAiAimCompensation.test.js`).

### Testing
- Ran the JavaScript unit suite for the AI compensation changes with `npm test -- test/poolRoyaleAiAimCompensation.test.js`, and all tests passed (3 tests, 1 suite).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c119d221e083299b375533c8302bde)