### PR TITLE
Fix Checkers online lobby stake flow for Telegram/Google mixed accounts

### DIFF
--- a/bot/routes/profile.js
+++ b/bot/routes/profile.js
@@ -29,6 +29,32 @@ export function parseTwitterHandle(input) {
 
 const router = Router();
 
+export function canManageUserTransactions(reqAuth = {}, user = null, requestedTelegramId = null) {
+  if (!user) return false;
+  if (reqAuth?.apiToken) return true;
+
+  const authTelegramId = reqAuth?.telegramId;
+  if (authTelegramId != null) {
+    if (requestedTelegramId != null && Number(requestedTelegramId) !== Number(authTelegramId)) {
+      return false;
+    }
+    if (user.telegramId != null) {
+      return Number(user.telegramId) === Number(authTelegramId);
+    }
+    return requestedTelegramId != null;
+  }
+
+  if (reqAuth?.accountId && user.accountId) {
+    return String(reqAuth.accountId) === String(user.accountId);
+  }
+
+  if (reqAuth?.googleId && user.googleId) {
+    return String(reqAuth.googleId) === String(user.googleId);
+  }
+
+  return false;
+}
+
 router.post('/register-wallet', async (req, res) => {
   const { walletAddress } = req.body;
   if (!walletAddress) {
@@ -200,34 +226,31 @@ router.post('/addTransaction', authenticate, async (req, res) => {
       .status(400)
       .json({ error: 'telegramId or accountId, amount and type required' });
   }
-  if (!req.auth?.telegramId) {
-    return res.status(403).json({ error: 'forbidden' });
-  }
+
   let user = null;
-  if (telegramId != null) {
-    if (req.auth.telegramId !== telegramId) {
-      return res.status(403).json({ error: 'forbidden' });
-    }
-    user = await User.findOne({ telegramId });
-  }
+  if (telegramId != null) user = await User.findOne({ telegramId });
   if (!user && accountId) user = await User.findOne({ accountId });
+
   if (!user) {
     const data = {
-      accountId,
+      accountId: accountId || uuidv4(),
       referralCode: String(telegramId || accountId)
     };
     if (telegramId != null) data.telegramId = telegramId;
+    if (req.auth?.googleId) data.googleId = req.auth.googleId;
     user = new User(data);
   }
+
+  if (!canManageUserTransactions(req.auth, user, telegramId)) {
+    return res.status(403).json({ error: 'forbidden' });
+  }
+
   ensureTransactionArray(user);
   const tx = { amount, type, date: new Date() };
   if (game) tx.game = game;
   if (players) tx.players = players;
   user.transactions.push(tx);
   await user.save();
-  if (!user.telegramId || user.telegramId !== req.auth.telegramId) {
-    return res.status(403).json({ error: 'forbidden' });
-  }
   res.json({ transactions: user.transactions });
 });
 

--- a/test/profileTransactionAuth.test.js
+++ b/test/profileTransactionAuth.test.js
@@ -1,0 +1,39 @@
+import { canManageUserTransactions } from '../bot/routes/profile.js';
+
+describe('canManageUserTransactions', () => {
+  test('allows telegram-owned account with matching telegram id', () => {
+    const allowed = canManageUserTransactions(
+      { telegramId: 123 },
+      { telegramId: 123, accountId: 'acc-1' },
+      123
+    );
+    expect(allowed).toBe(true);
+  });
+
+  test('blocks telegram auth when telegram id mismatches payload', () => {
+    const allowed = canManageUserTransactions(
+      { telegramId: 123 },
+      { telegramId: 123, accountId: 'acc-1' },
+      456
+    );
+    expect(allowed).toBe(false);
+  });
+
+  test('allows account-id owned user for non-telegram auth', () => {
+    const allowed = canManageUserTransactions(
+      { accountId: 'acc-google' },
+      { accountId: 'acc-google' },
+      null
+    );
+    expect(allowed).toBe(true);
+  });
+
+  test('allows google-owned user for google auth', () => {
+    const allowed = canManageUserTransactions(
+      { googleId: 'gid-9' },
+      { accountId: 'acc-2', googleId: 'gid-9' },
+      null
+    );
+    expect(allowed).toBe(true);
+  });
+});


### PR DESCRIPTION
### Motivation
- The online lobby flow could fail to reserve or refund stakes when players used different identity providers (Telegram vs Google/account) because the `POST /api/profile/addTransaction` handler implicitly required Telegram auth.
- That caused account-based users to be rejected before matchmaking even though the client supplies `accountId`, blocking mixed-provider matches.
- The change targets transaction authorization so the socket/lobby matchmaking code can proceed once stake operations succeed.

### Description
- Added a helper `canManageUserTransactions(reqAuth, user, requestedTelegramId)` to centralize ownership checks across Telegram, accountId, Google, and admin API-token paths. 
- Updated `router.post('/addTransaction', ...)` to locate or create the `User` (including binding `googleId` from `req.auth` when present) and to authorize via `canManageUserTransactions` instead of hard-requiring Telegram auth. 
- Removed the previous Telegram-only post-save check and preserved identity-mismatch protections for Telegram payloads. 
- Added unit tests `test/profileTransactionAuth.test.js` to cover Telegram, accountId, and Google ownership authorization cases.

### Testing
- Ran `npm test -- --runInBand test/profileTransactionAuth.test.js test/checkersOnlineReadiness.test.js test/poolRoyaleOnlineFlow.test.js`. 
- All targeted suites passed successfully. 
- The changes were validated to allow stake reservation/refund for account-based (non-Telegram) users, enabling mixed Telegram/Google players to reach the same lobby and start a game.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c126a70d348329b3b1257465458d51)