### PR TITLE
Normalize battle-royal game slugs so checkers/chess clients share the same online lobby

### DIFF
--- a/bot/config/onlineGamePolicy.js
+++ b/bot/config/onlineGamePolicy.js
@@ -23,6 +23,17 @@ const GAME_ONLINE_POLICY = Object.freeze({
   murlanroyale: { maxPlayers: [2, 4], allowMatchMeta: ['variant', 'mode', 'token'] }
 });
 
+const GAME_TYPE_ALIASES = Object.freeze({
+  chessbattleroyal: 'chess',
+  checkersbattleroyal: 'checkers'
+});
+
+export function normalizeOnlineGameType(gameType) {
+  const normalized = String(gameType || '').trim().toLowerCase();
+  if (!normalized) return '';
+  return GAME_TYPE_ALIASES[normalized] || normalized;
+}
+
 function sanitizeMetaValue(value) {
   if (value == null) return undefined;
   if (typeof value === 'string') return value.slice(0, 48);
@@ -35,7 +46,8 @@ export function validateSeatTableRequest({
   maxPlayers,
   matchMeta = {}
 } = {}) {
-  const policy = GAME_ONLINE_POLICY[gameType];
+  const normalizedGameType = normalizeOnlineGameType(gameType);
+  const policy = GAME_ONLINE_POLICY[normalizedGameType];
   if (!policy) {
     return { ok: false, error: 'unsupported_game_type' };
   }
@@ -60,6 +72,7 @@ export function validateSeatTableRequest({
 
   return {
     ok: true,
+    normalizedGameType,
     normalizedStake,
     normalizedMaxPlayers,
     safeMatchMeta,
@@ -84,4 +97,4 @@ export function buildReadinessSnapshot() {
   }, {});
 }
 
-export { GAME_ONLINE_POLICY, BASE_SECURITY_CONTROLS };
+export { GAME_ONLINE_POLICY, BASE_SECURITY_CONTROLS, GAME_TYPE_ALIASES };

--- a/bot/server.js
+++ b/bot/server.js
@@ -59,7 +59,11 @@ import {
   countOnline,
   listOnline
 } from './services/connectionService.js';
-import { GAME_ONLINE_POLICY, validateSeatTableRequest } from './config/onlineGamePolicy.js';
+import {
+  GAME_ONLINE_POLICY,
+  validateSeatTableRequest,
+  normalizeOnlineGameType
+} from './config/onlineGamePolicy.js';
 import { createCheckersRealtimeStore } from './utils/checkersRealtimeState.js';
 import { applyAuthoritativeMove, SIDES } from './utils/checkersAuthoritativeEngine.js';
 
@@ -603,9 +607,10 @@ function getAvailableTable(
 }
 
 function resolveSeatIdentityFromTableId(tableId, fallbackGameType, fallbackMaxPlayers) {
+  const normalizedFallbackGameType = normalizeOnlineGameType(fallbackGameType);
   if (!tableId) {
     return {
-      gameType: fallbackGameType,
+      gameType: normalizedFallbackGameType,
       maxPlayers: fallbackMaxPlayers
     };
   }
@@ -622,13 +627,13 @@ function resolveSeatIdentityFromTableId(tableId, fallbackGameType, fallbackMaxPl
     parsedCap <= 0
   ) {
     return {
-      gameType: fallbackGameType,
+      gameType: normalizedFallbackGameType,
       maxPlayers: fallbackMaxPlayers
     };
   }
 
   return {
-    gameType: prefix,
+    gameType: normalizeOnlineGameType(prefix),
     maxPlayers: parsedCap
   };
 }
@@ -1703,7 +1708,7 @@ io.on('connection', (socket) => {
       if (tableId) {
         table = await seatTableSocket(
           accountId,
-          resolvedGameType,
+          validation.normalizedGameType,
           validation.normalizedStake,
           validation.normalizedMaxPlayers,
           playerName,
@@ -1716,7 +1721,7 @@ io.on('connection', (socket) => {
       } else {
         table = await seatTableSocket(
           accountId,
-          resolvedGameType,
+          validation.normalizedGameType,
           validation.normalizedStake,
           validation.normalizedMaxPlayers,
           playerName,

--- a/test/checkersLobbyAliasMatchmaking.test.js
+++ b/test/checkersLobbyAliasMatchmaking.test.js
@@ -1,0 +1,101 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import { spawn } from 'child_process';
+import { setTimeout as delay } from 'timers/promises';
+import { io } from 'socket.io-client';
+
+const distDir = new URL('../webapp/dist/', import.meta.url);
+const apiToken = 'test-token';
+
+async function startServer(env) {
+  const server = spawn('node', ['bot/server.js'], { env, stdio: 'pipe' });
+  server.stdout.on('data', (chunk) => process.stdout.write(chunk));
+  server.stderr.on('data', (chunk) => process.stderr.write(chunk));
+  await new Promise((resolve) => {
+    const onData = (chunk) => {
+      if (chunk.toString().includes('Server running on port')) {
+        server.stdout.off('data', onData);
+        resolve();
+      }
+    };
+    server.stdout.on('data', onData);
+  });
+  return server;
+}
+
+test(
+  'checkers aliases seat into the same online lobby and start the same game',
+  { concurrency: false, timeout: 20000 },
+  async () => {
+    fs.mkdirSync(new URL('assets', distDir), { recursive: true });
+    fs.writeFileSync(new URL('index.html', distDir), '');
+    const env = {
+      ...process.env,
+      PORT: '3210',
+      MONGO_URI: 'memory',
+      BOT_TOKEN: 'dummy',
+      API_AUTH_TOKEN: apiToken,
+      SKIP_WEBAPP_BUILD: '1',
+      SKIP_BOT_LAUNCH: '1'
+    };
+    const server = await startServer(env);
+    const s1 = io('http://localhost:3210', { auth: { token: apiToken } });
+    const s2 = io('http://localhost:3210', { auth: { token: apiToken } });
+
+    try {
+      await Promise.all([
+        new Promise((resolve) => s1.on('connect', resolve)),
+        new Promise((resolve) => s2.on('connect', resolve))
+      ]);
+
+      const register = (socket, playerId) =>
+        new Promise((resolve) => {
+          socket.emit('register', { playerId }, resolve);
+        });
+      await Promise.all([register(s1, 'checkers-a'), register(s2, 'checkers-b')]);
+
+      const seat = (socket, payload) =>
+        new Promise((resolve) => {
+          socket.emit('seatTable', payload, resolve);
+        });
+
+      const firstSeat = await seat(s1, {
+        accountId: 'checkers-a',
+        gameType: 'checkers',
+        stake: 100,
+        maxPlayers: 2,
+        mode: 'online',
+        token: 'TPC'
+      });
+      const secondSeat = await seat(s2, {
+        accountId: 'checkers-b',
+        gameType: 'checkersbattleroyal',
+        stake: 100,
+        maxPlayers: 2,
+        mode: 'online',
+        token: 'TPC'
+      });
+
+      assert.equal(firstSeat.success, true);
+      assert.equal(secondSeat.success, true);
+      assert.equal(secondSeat.tableId, firstSeat.tableId);
+
+      s1.emit('confirmReady', { accountId: 'checkers-a', tableId: firstSeat.tableId });
+      s2.emit('confirmReady', { accountId: 'checkers-b', tableId: firstSeat.tableId });
+
+      const [gameStartA, gameStartB] = await Promise.all([
+        new Promise((resolve) => s1.once('gameStart', resolve)),
+        new Promise((resolve) => s2.once('gameStart', resolve))
+      ]);
+      assert.equal(gameStartA.tableId, firstSeat.tableId);
+      assert.equal(gameStartB.tableId, firstSeat.tableId);
+
+      await delay(50);
+    } finally {
+      s1.disconnect();
+      s2.disconnect();
+      server.kill();
+    }
+  }
+);

--- a/test/onlineGamePolicy.test.js
+++ b/test/onlineGamePolicy.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, test } from '@jest/globals';
 import {
   GAME_ONLINE_POLICY,
+  normalizeOnlineGameType,
   validateSeatTableRequest,
   buildReadinessSnapshot,
   BASE_SECURITY_CONTROLS
@@ -48,9 +49,17 @@ describe('online game policy', () => {
     });
 
     expect(chess.ok).toBe(true);
+    expect(chess.normalizedGameType).toBe('chess');
     expect(chess.safeMatchMeta).toEqual({ preferredSide: 'white', mode: 'online' });
     expect(checkers.ok).toBe(true);
+    expect(checkers.normalizedGameType).toBe('checkers');
     expect(checkers.safeMatchMeta).toEqual({ preferredSide: 'black', mode: 'online' });
+  });
+
+  test('normalizes battle royal aliases to shared lobby game types', () => {
+    expect(normalizeOnlineGameType('chessbattleroyal')).toBe('chess');
+    expect(normalizeOnlineGameType('checkersbattleroyal')).toBe('checkers');
+    expect(normalizeOnlineGameType('poolroyale')).toBe('poolroyale');
   });
 
   test('buildReadinessSnapshot returns all policy games with security checks', () => {


### PR DESCRIPTION
### Motivation
- Different clients were using different game slugs (e.g. `checkers` vs `checkersbattleroyal`) which allowed users to be seated into separate matchmaking queues and prevented them from meeting in the same lobby/game.

### Description
- Added `GAME_TYPE_ALIASES` and `normalizeOnlineGameType(gameType)` in `bot/config/onlineGamePolicy.js` and used it to canonicalize incoming game types before policy lookup and seating.
- Updated `validateSeatTableRequest` to use and return `normalizedGameType`, and exported the alias map for visibility.
- Wired normalization into the socket matchmaking flow in `bot/server.js` by importing `normalizeOnlineGameType`, normalizing fallback/table-derived identities, and always seating using `validation.normalizedGameType` rather than the raw client slug.
- Added an integration test `test/checkersLobbyAliasMatchmaking.test.js` that simulates one client using `gameType: 'checkers'` and another using `gameType: 'checkersbattleroyal'` and asserts they receive the same `tableId` and `gameStart`; updated `test/onlineGamePolicy.test.js` to assert normalization behavior and the new `normalizedGameType` output.

### Testing
- Ran the new socket integration scenario with `node --test test/checkersLobbyAliasMatchmaking.test.js` which completed and passed (TAP output OK). 
- Ran unit tests with `npx jest test/onlineGamePolicy.test.js --runInBand` which passed all assertions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c126a70d348329b3b1257465458d51)