### PR TITLE
Fix Checkers lobby identity scoping between Telegram and Google accounts

### DIFF
--- a/test/telegramAccountIsolation.test.js
+++ b/test/telegramAccountIsolation.test.js
@@ -83,4 +83,35 @@ describe('telegram account scoped player ids', () => {
     setTelegramUserId(555);
     expect(getPlayerId()).toBe('legacy-account-id');
   });
+
+  test('uses google scoped ids when running outside Telegram context', () => {
+    setTelegramUserId(null);
+    global.localStorage.setItem('googleId', 'google-user-1');
+
+    const googleOneFirst = getPlayerId();
+    const googleOneSecond = getPlayerId();
+    expect(googleOneFirst).toBeTruthy();
+    expect(googleOneSecond).toBe(googleOneFirst);
+
+    global.localStorage.setItem('googleId', 'google-user-2');
+    const googleTwo = getPlayerId();
+    expect(googleTwo).toBeTruthy();
+    expect(googleTwo).not.toBe(googleOneFirst);
+
+    global.localStorage.setItem('googleId', 'google-user-1');
+    expect(getPlayerId()).toBe(googleOneFirst);
+  });
+
+  test('does not reuse telegram account id for a different google identity in shared storage', () => {
+    setTelegramUserId(101);
+    const telegramScoped = getPlayerId();
+    expect(telegramScoped).toBeTruthy();
+
+    setTelegramUserId(null);
+    global.localStorage.setItem('googleId', 'google-user-99');
+    const googleScoped = getPlayerId();
+
+    expect(googleScoped).toBeTruthy();
+    expect(googleScoped).not.toBe(telegramScoped);
+  });
 });

--- a/webapp/src/utils/telegram.js
+++ b/webapp/src/utils/telegram.js
@@ -22,23 +22,24 @@ function parseTelegramId(value) {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
+function getRuntimeTelegramId() {
+  if (typeof window === 'undefined') return null;
+  const tgId = window?.Telegram?.WebApp?.initDataUnsafe?.user?.id;
+  const telegramId = parseTelegramId(tgId);
+  if (telegramId != null) return telegramId;
+
+  const params = new URLSearchParams(window.location.search);
+  const urlId = params.get('tg') || params.get('telegramId');
+  if (!urlId) return null;
+  return parseTelegramId(urlId);
+}
+
 export function getTelegramId() {
   if (typeof window !== 'undefined') {
-    const tgId = window?.Telegram?.WebApp?.initDataUnsafe?.user?.id;
-    const telegramId = parseTelegramId(tgId);
+    const telegramId = getRuntimeTelegramId();
     if (telegramId != null) {
       localStorage.setItem('telegramId', telegramId);
       return telegramId;
-    }
-    const params = new URLSearchParams(window.location.search);
-    const urlId = params.get('tg') || params.get('telegramId');
-    if (urlId) {
-      const parsed = parseTelegramId(urlId);
-      if (parsed != null) {
-        localStorage.setItem('telegramId', parsed);
-        return parsed;
-      }
-      localStorage.removeItem('telegramId');
     }
     const stored = localStorage.getItem('telegramId');
     if (stored) {
@@ -64,12 +65,32 @@ function accountIdMapStorageKey(telegramId) {
   return `accountId:tg:${telegramId}`;
 }
 
+function accountIdGoogleStorageKey(googleId) {
+  return `accountId:google:${googleId}`;
+}
+
+function getGoogleIdFromStorage(storage) {
+  try {
+    const direct = storage?.getItem('googleId');
+    if (direct) return String(direct);
+    const rawProfile = storage?.getItem('googleProfile');
+    if (!rawProfile) return '';
+    const parsed = JSON.parse(rawProfile);
+    return parsed?.id ? String(parsed.id) : '';
+  } catch {
+    return '';
+  }
+}
+
 function hasAnyScopedAccountIds(storage) {
   try {
     const len = Number(storage?.length) || 0;
     for (let i = 0; i < len; i += 1) {
       const key = storage.key(i);
-      if (typeof key === 'string' && key.startsWith('accountId:tg:')) {
+      if (
+        typeof key === 'string' &&
+        (key.startsWith('accountId:tg:') || key.startsWith('accountId:google:'))
+      ) {
         return true;
       }
     }
@@ -81,8 +102,11 @@ function hasAnyScopedAccountIds(storage) {
 
 export function getPlayerId() {
   if (typeof window === 'undefined') return null;
-  const telegramId = getTelegramId();
   const globalId = localStorage.getItem('accountId');
+  const googleId = getGoogleIdFromStorage(localStorage);
+  const runtimeTelegramId = getRuntimeTelegramId();
+  const cachedTelegramId = parseTelegramId(localStorage.getItem('telegramId'));
+  const telegramId = runtimeTelegramId ?? (isTelegramWebView() ? cachedTelegramId : null);
 
   if (telegramId != null) {
     const perTelegramKey = accountIdMapStorageKey(telegramId);
@@ -104,6 +128,23 @@ export function getPlayerId() {
     if (telegramScopedId) {
       localStorage.setItem('accountId', telegramScopedId);
       return telegramScopedId;
+    }
+  }
+
+  if (googleId) {
+    const perGoogleKey = accountIdGoogleStorageKey(googleId);
+    let googleScopedId = localStorage.getItem(perGoogleKey);
+    if (!googleScopedId && globalId && !hasAnyScopedAccountIds(localStorage)) {
+      googleScopedId = globalId;
+      localStorage.setItem(perGoogleKey, googleScopedId);
+    }
+    if (!googleScopedId) {
+      googleScopedId = generateAccountId();
+      if (googleScopedId) localStorage.setItem(perGoogleKey, googleScopedId);
+    }
+    if (googleScopedId) {
+      localStorage.setItem('accountId', googleScopedId);
+      return googleScopedId;
     }
   }
 


### PR DESCRIPTION
### Motivation
- Users signing in with different providers could be mapped to the same `accountId` in shared browser storage, preventing two distinct players from pairing in the Checkers lobby. 
- The root cause was stale/cached Telegram-scoped IDs being reused for Google sessions outside the Telegram WebView context. 
- The change aims to isolate account identities per provider so online matchmaking sees distinct player identities and allows proper pairing.

### Description
- Added a runtime Telegram ID resolver `getRuntimeTelegramId()` and restricted use of cached Telegram IDs to actual Telegram WebView contexts in `webapp/src/utils/telegram.js`.
- Introduced Google-scoped account keys (`accountId:google:<googleId>`) and helper `getGoogleIdFromStorage()` so Google sessions receive their own scoped `accountId` when appropriate.
- Expanded `hasAnyScopedAccountIds()` to detect both Telegram- and Google-scoped keys and updated `getPlayerId()` to prefer provider-scoped IDs (Telegram when in WebView, otherwise Google then global fallback).
- Added unit tests in `test/telegramAccountIsolation.test.js` to verify Google-scoped IDs outside Telegram and to ensure Telegram-scoped IDs are not reused for different Google identities, while keeping existing readiness tests intact.

### Testing
- Ran provider/isolation unit tests with `npm test -- --runInBand test/telegramAccountIsolation.test.js test/checkersOnlineReadiness.test.js`, and both suites passed.
- Ran online flow smoke tests with `npm test -- --runInBand test/simpleOnlineFlow.test.js`, and the suite passed (note: Jest reported an open-handles notice after completion but tests themselves passed).
- All added and existing assertions relevant to online readiness and account isolation are passing locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c126a70d348329b3b1257465458d51)