### PR TITLE
Fix Checkers Battle Royal lobby reconnect for mixed account identities

### DIFF
--- a/webapp/src/pages/Games/CheckersBattleRoyalLobby.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyalLobby.jsx
@@ -27,6 +27,11 @@ const CHECKERS_HOST_CODE_STORAGE_KEY = 'checkersBattleRoyalHostCode';
 const SOCKET_CONNECT_TIMEOUT_MS = 6000;
 const SOCKET_REGISTER_TIMEOUT_MS = 6000;
 const MATCHMAKING_TIMEOUT_MS = 45000;
+const MATCHMAKING_RECOVERABLE_ERRORS = new Set([
+  'register_required',
+  'rate_limited',
+  'identity_mismatch'
+]);
 
 function normalizeHostCode(code = '') {
   return String(code || '')
@@ -339,7 +344,10 @@ export default function CheckersBattleRoyalLobby() {
     setMatchStatus('Connecting to lobby…');
 
     if (trackedAccountId) {
-      refreshSocketAuthIdentity({ accountId: String(trackedAccountId) });
+      refreshSocketAuthIdentity(
+        { accountId: String(trackedAccountId) },
+        { reconnect: true }
+      );
     }
 
     const socketReady = await ensureSocketConnected();
@@ -436,17 +444,49 @@ export default function CheckersBattleRoyalLobby() {
         async (res) => {
           if (!res?.success || !res.tableId) {
             const shouldRetry =
-              (res?.error === 'register_required' || res?.error === 'rate_limited') &&
+              MATCHMAKING_RECOVERABLE_ERRORS.has(res?.error) &&
               seatAttempts < maxSeatAttempts;
             if (shouldRetry) {
               setMatchStatus('Retrying online seat…');
-              setTimeout(() => seatPlayer(), 400);
+              if (res?.error === 'identity_mismatch' && trackedAccountId) {
+                refreshSocketAuthIdentity(
+                  { accountId: String(trackedAccountId) },
+                  { reconnect: true }
+                );
+              }
+              setTimeout(async () => {
+                const restored = await ensureSocketConnected();
+                if (!restored) {
+                  clearTimeout(matchTimeout);
+                  matchmakingTimeoutRef.current = null;
+                  await refundStakeIfNeeded();
+                  setMatchError('Lobby connection dropped while retrying. Your stake was refunded.');
+                  cleanupLobby({ account: trackedAccountId });
+                  return;
+                }
+                if (res?.error === 'identity_mismatch' && trackedAccountId) {
+                  const reRegistered = await ensureSocketRegistered(trackedAccountId);
+                  if (!reRegistered) {
+                    clearTimeout(matchTimeout);
+                    matchmakingTimeoutRef.current = null;
+                    await refundStakeIfNeeded();
+                    setMatchError('Could not restore your online identity. Your stake was refunded.');
+                    cleanupLobby({ account: trackedAccountId });
+                    return;
+                  }
+                }
+                seatPlayer();
+              }, 400);
               return;
             }
             clearTimeout(matchTimeout);
             matchmakingTimeoutRef.current = null;
             await refundStakeIfNeeded();
-            setMatchError('Could not join the online lobby. Please try again.');
+            const serverMessage =
+              typeof res?.error === 'string' && res.error.trim()
+                ? ` (${res.error.replace(/_/g, ' ')})`
+                : '';
+            setMatchError(`Could not join the online lobby. Please try again${serverMessage}.`);
             cleanupLobby({ account: trackedAccountId });
             return;
           }


### PR DESCRIPTION
### Motivation
- Users signing in with different identity contexts (Telegram vs Google) could hit stale socket auth and fail to join the Checkers Battle Royal lobby. 
- The lobby code updated socket auth without forcing a reconnect or repairing server-side registration, causing backend `identity_mismatch` or `register_required` errors to block seating.
- The change aims to recover from transient identity/connection errors so two different accounts can be paired and start the same game.

### Description
- Added `MATCHMAKING_RECOVERABLE_ERRORS` set including `register_required`, `rate_limited`, and `identity_mismatch` to classify retryable seat failures.
- When binding a tracked `accountId` before matchmaking, call `refreshSocketAuthIdentity(..., { reconnect: true })` to force the socket to re-authenticate with the backend.
- For recoverable seat failures, implement a retry flow that waits, ensures the socket reconnects, and on `identity_mismatch` explicitly re-registers the socket before retrying `seatTable`.
- Improve the user-facing seat-failure message to append a normalized server error suffix (e.g., `(identity mismatch)`) for clearer diagnostics.

### Testing
- Ran bot unit tests with `npm --prefix bot test` and they passed (3 tests passed). 
- Built the web app with `npm --prefix webapp run build` and the production build completed successfully. 
- Ran lint checks `npx eslint webapp/src/pages/Games/CheckersBattleRoyalLobby.jsx` and `npx eslint --no-ignore webapp/src/pages/Games/CheckersBattleRoyalLobby.jsx`, which produced repo-ignore warnings but no blocking errors. 
- Verified the lobby code path by building the webapp and confirming the `CheckersBattleRoyalLobby` bundle was emitted during the build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c12b7e2524832985e7fc21eb766117)