### PR TITLE
Avoid reusing cached Telegram ID outside Telegram WebApp (fix lobby auth bleed)

### DIFF
--- a/test/telegramAccountIsolation.test.js
+++ b/test/telegramAccountIsolation.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, test, beforeEach } from '@jest/globals';
-import { getPlayerId } from '../webapp/src/utils/telegram.js';
+import { getPlayerId, getTelegramId } from '../webapp/src/utils/telegram.js';
 
 class MemoryStorage {
   constructor() {
@@ -113,5 +113,23 @@ describe('telegram account scoped player ids', () => {
 
     expect(googleScoped).toBeTruthy();
     expect(googleScoped).not.toBe(telegramScoped);
+  });
+
+  test('does not return cached telegramId outside Telegram webview', () => {
+    setTelegramUserId(null);
+    global.window.Telegram = undefined;
+    global.localStorage.setItem('telegramId', '5555');
+
+    expect(getTelegramId()).toBeNull();
+  });
+
+  test('returns cached telegramId only while Telegram webview is present', () => {
+    setTelegramUserId(1234);
+    expect(getTelegramId()).toBe(1234);
+
+    // Runtime Telegram id disappears but Telegram WebApp context still exists.
+    global.window.Telegram = { WebApp: { initDataUnsafe: {}, platform: 'ios' } };
+
+    expect(getTelegramId()).toBe(1234);
   });
 });

--- a/webapp/src/utils/telegram.js
+++ b/webapp/src/utils/telegram.js
@@ -41,11 +41,17 @@ export function getTelegramId() {
       localStorage.setItem('telegramId', telegramId);
       return telegramId;
     }
-    const stored = localStorage.getItem('telegramId');
-    if (stored) {
-      const parsed = parseTelegramId(stored);
-      if (parsed != null) return parsed;
-      localStorage.removeItem('telegramId');
+    // Important identity isolation:
+    // when running outside Telegram (for example Google login in a browser),
+    // we must not reuse stale telegramId values from previous sessions.
+    const canUseStoredTelegramId = isTelegramWebView();
+    if (canUseStoredTelegramId) {
+      const stored = localStorage.getItem('telegramId');
+      if (stored) {
+        const parsed = parseTelegramId(stored);
+        if (parsed != null) return parsed;
+        localStorage.removeItem('telegramId');
+      }
     }
   }
   return null;


### PR DESCRIPTION
### Motivation
- Users in browser/Google sessions were intermittently blocked from joining Pool Royale lobbies because a stale `telegramId` cached in localStorage could be reused outside the Telegram WebApp context and cause auth/transaction calls to attribute actions to the wrong identity.

### Description
- Restrict `getTelegramId()` to only return a stored `telegramId` when the app is actually running inside the Telegram WebApp by checking `isTelegramWebView()` before reusing localStorage values (file changed: `webapp/src/utils/telegram.js`).
- Add targeted tests that assert cached `telegramId` is ignored outside Telegram and still available when Telegram WebApp context exists (file changed: `test/telegramAccountIsolation.test.js`).
- This prevents stale Telegram identity leakage into Google/browser sessions and avoids cross-account auth failures during stake reservation and lobby entry.

### Testing
- Ran `jest test/telegramAccountIsolation.test.js` and `jest test/poolRoyaleOnlineFlow.test.js`, both passed (11 tests total across suites).
- Re-ran `jest test/poolRoyaleMatchmakingMeta.test.js`, which passed (3 tests).
- All automated tests referenced above passed locally after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c12ab11adc8329a366aa435bb6326f)