### PR TITLE
Fix Google-only session auth header fallback for Pool Royale lobby

### DIFF
--- a/test/apiGoogleHeaderFallback.test.js
+++ b/test/apiGoogleHeaderFallback.test.js
@@ -1,0 +1,55 @@
+import { describe, expect, test, beforeEach, afterEach, jest } from '@jest/globals';
+import { post } from '../webapp/src/utils/api.js';
+
+class MemoryStorage {
+  constructor() {
+    this.store = new Map();
+  }
+
+  getItem(key) {
+    return this.store.has(key) ? this.store.get(key) : null;
+  }
+
+  setItem(key, value) {
+    this.store.set(key, String(value));
+  }
+
+  removeItem(key) {
+    this.store.delete(key);
+  }
+}
+
+describe('api auth headers google fallback', () => {
+  const originalWindow = global.window;
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    const storage = new MemoryStorage();
+    global.window = {
+      localStorage: storage,
+      Capacitor: null,
+      Telegram: null
+    };
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => '{}'
+    });
+  });
+
+  afterEach(() => {
+    global.window = originalWindow;
+    global.fetch = originalFetch;
+    jest.clearAllMocks();
+  });
+
+  test('includes X-Google-Id header when only googleProfile is cached', async () => {
+    window.localStorage.setItem('googleProfile', JSON.stringify({ id: 'google-profile-only' }));
+    window.localStorage.removeItem('googleId');
+
+    await post('/api/ping', { ok: true });
+
+    const fetchOptions = global.fetch.mock.calls[0][1];
+    expect(fetchOptions.headers['X-Google-Id']).toBe('google-profile-only');
+  });
+});

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -79,7 +79,18 @@ function buildHeaders(base = {}) {
   if (initData) headers['X-Telegram-Init-Data'] = initData;
   const accountId = window?.localStorage?.getItem('accountId');
   if (accountId) headers['X-Tpc-Account-Id'] = accountId;
-  const googleId = window?.localStorage?.getItem('googleId');
+  const googleId =
+    window?.localStorage?.getItem('googleId') ||
+    (() => {
+      try {
+        const rawProfile = window?.localStorage?.getItem('googleProfile');
+        if (!rawProfile) return '';
+        const parsed = JSON.parse(rawProfile);
+        return parsed?.id ? String(parsed.id) : '';
+      } catch {
+        return '';
+      }
+    })();
   if (googleId) headers['X-Google-Id'] = googleId;
   const bridgeHeaders = getNativeBridgeHeaders();
   Object.entries(bridgeHeaders).forEach(([key, value]) => {


### PR DESCRIPTION
### Motivation
- Pre-seat API calls in the Pool Royale online flow (balance check + stake reservation) run before socket matchmaking, so API auth must match socket auth to let Google-authenticated users proceed to seating. 
- Some sessions store `googleProfile` but not `googleId` in localStorage, which caused API requests to omit `X-Google-Id` and fail authorization before the socket join. 

### Description
- Updated `buildHeaders` in `webapp/src/utils/api.js` to include a fallback that extracts `googleProfile.id` when `localStorage.googleId` is not present so the `X-Google-Id` header is sent for Google-only sessions. 
- Added a regression test `test/apiGoogleHeaderFallback.test.js` to verify `post()` includes `X-Google-Id` when only `googleProfile` is cached. 
- Kept header precedence and existing native/Telegram header behavior intact by adding the fallback without changing other header logic. 

### Testing
- Ran targeted tests with `npm test -- --runInBand test/poolRoyaleOnlineFlow.test.js test/apiGoogleHeaderFallback.test.js`. 
- Both test suites passed: `test/poolRoyaleOnlineFlow.test.js` and `test/apiGoogleHeaderFallback.test.js` (all tests green).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c12ab11adc8329a366aa435bb6326f)