### PR TITLE
Bootstrap backend account before Pool Royale online matchmaking

### DIFF
--- a/test/poolRoyaleOnlineFlow.test.js
+++ b/test/poolRoyaleOnlineFlow.test.js
@@ -101,6 +101,8 @@ test('runPoolRoyaleOnlineFlow debits once and keeps stake for game start', async
 
   const deps = {
     ensureAccountId: () => Promise.resolve('acct-1'),
+    createAccount: () => Promise.resolve({ accountId: 'acct-1' }),
+    loadGoogleProfile: () => null,
     getAccountBalance: () => Promise.resolve({ balance: 200 }),
     addTransaction: (...args) => {
       addCalls.push(args);
@@ -173,6 +175,8 @@ test('runPoolRoyaleOnlineFlow refunds when matchmaking times out', async () => {
 
   const deps = {
     ensureAccountId: () => Promise.resolve('acct-9'),
+    createAccount: () => Promise.resolve({ accountId: 'acct-9' }),
+    loadGoogleProfile: () => null,
     getAccountBalance: () => Promise.resolve({ balance: 200 }),
     addTransaction: (...args) => {
       addCalls.push(args);
@@ -223,6 +227,8 @@ test('runPoolRoyaleOnlineFlow reconnects socket before seating table', async () 
 
   const deps = {
     ensureAccountId: () => Promise.resolve('acct-3'),
+    createAccount: () => Promise.resolve({ accountId: 'acct-3' }),
+    loadGoogleProfile: () => null,
     getAccountBalance: () => Promise.resolve({ balance: 200 }),
     addTransaction: (...args) => {
       addCalls.push(args);
@@ -276,6 +282,8 @@ test('runPoolRoyaleOnlineFlow tolerates transient socket connect errors on mobil
 
   const deps = {
     ensureAccountId: () => Promise.resolve('acct-4'),
+    createAccount: () => Promise.resolve({ accountId: 'acct-4' }),
+    loadGoogleProfile: () => null,
     getAccountBalance: () => Promise.resolve({ balance: 200 }),
     addTransaction: (...args) => {
       addCalls.push(args);
@@ -328,6 +336,8 @@ test('runPoolRoyaleOnlineFlow refunds if register ack fails', async () => {
 
   const deps = {
     ensureAccountId: () => Promise.resolve('acct-12'),
+    createAccount: () => Promise.resolve({ accountId: 'acct-12' }),
+    loadGoogleProfile: () => null,
     getAccountBalance: () => Promise.resolve({ balance: 200 }),
     addTransaction: (...args) => {
       addCalls.push(args);
@@ -357,4 +367,41 @@ test('runPoolRoyaleOnlineFlow refunds if register ack fails', async () => {
   assert.equal(addCalls.length, 2, 'should debit then refund when register ack fails');
   assert.equal(addCalls[1][2], 'stake_refund');
   assert.ok(state.snapshot.matchingError.includes('online session'));
+});
+
+test('runPoolRoyaleOnlineFlow uses backend-resolved account id for lobby seat', async () => {
+  const mockSocket = new MockSocket();
+  const refs = createRefs();
+  const state = createState();
+
+  const deps = {
+    ensureAccountId: () => Promise.resolve('local-acct'),
+    createAccount: () => Promise.resolve({ accountId: 'server-acct' }),
+    loadGoogleProfile: () => ({ id: 'google-1' }),
+    getAccountBalance: () => Promise.resolve({ balance: 300 }),
+    addTransaction: () => Promise.resolve(),
+    getTelegramId: () => null,
+    getTelegramFirstName: () => 'Player',
+    socket: mockSocket
+  };
+
+  await runPoolRoyaleOnlineFlow({
+    stake: { token: 'TPC', amount: 50 },
+    variant: 'uk',
+    ballSet: 'uk',
+    playType: 'regular',
+    mode: 'online',
+    tableSize: '9ft',
+    deps,
+    state,
+    refs,
+    timeouts: { seat: 60, matchmaking: 120 }
+  });
+
+  assert.equal(mockSocket.registerRequests.length, 1);
+  assert.equal(mockSocket.registerRequests[0].playerId, 'server-acct');
+  assert.equal(mockSocket.seatRequests.length, 1);
+  assert.equal(mockSocket.seatRequests[0].payload.accountId, 'server-acct');
+  mockSocket.seatRequests[0].cb({ success: false, message: 'stop' });
+  await delay(0);
 });

--- a/webapp/src/pages/Games/poolRoyaleOnlineFlow.js
+++ b/webapp/src/pages/Games/poolRoyaleOnlineFlow.js
@@ -1,6 +1,7 @@
 import { ensureAccountId, getTelegramFirstName, getTelegramId } from '../../utils/telegram.js';
-import { getAccountBalance, addTransaction } from '../../utils/api.js';
+import { getAccountBalance, addTransaction, createAccount } from '../../utils/api.js';
 import { socket, refreshSocketAuthIdentity } from '../../utils/socket.js';
+import { loadGoogleProfile } from '../../utils/google.js';
 
 const DEFAULT_SEAT_TIMEOUT_MS = 12000;
 const DEFAULT_MATCH_TIMEOUT_MS = 30000;
@@ -129,6 +130,8 @@ export async function runPoolRoyaleOnlineFlow({
 }) {
   const {
     ensureAccountId: ensureAccountIdFn = ensureAccountId,
+    createAccount: createAccountFn = createAccount,
+    loadGoogleProfile: loadGoogleProfileFn = loadGoogleProfile,
     getAccountBalance: getAccountBalanceFn = getAccountBalance,
     addTransaction: addTransactionFn = addTransaction,
     getTelegramId: getTelegramIdFn = getTelegramId,
@@ -199,7 +202,6 @@ export async function runPoolRoyaleOnlineFlow({
   let accountId;
   try {
     accountId = await ensureAccountIdFn();
-    accountIdRef.current = accountId;
   } catch (error) {
     setMatchingError('Unable to verify your TPC account. Please retry.');
     setMatchStatus('');
@@ -208,6 +210,27 @@ export async function runPoolRoyaleOnlineFlow({
     logSupportError('ensureAccountId failed', error);
     return { success: false };
   }
+
+  try {
+    // Ensure an authenticated backend account exists for both Telegram and
+    // Google sign-ins before we check stake balance and reserve funds.
+    const profile = loadGoogleProfileFn?.() || null;
+    const created = await createAccountFn?.(telegramId, profile, accountId);
+    if (created?.error) {
+      throw new Error(created.error);
+    }
+    if (created?.accountId) {
+      accountId = String(created.accountId);
+    }
+  } catch (error) {
+    setMatchingError('Unable to sync your TPC account. Please retry.');
+    setMatchStatus('');
+    setMatching(false);
+    setIsSearching(false);
+    logSupportError('createAccount failed', error, { accountId, telegramId });
+    return { success: false };
+  }
+  accountIdRef.current = accountId;
 
   try {
     const balRes = await getAccountBalanceFn(accountId);


### PR DESCRIPTION
### Motivation
- Mixed identity flows (Telegram vs Google) could use a locally-generated `accountId` that didn't exist on the backend, preventing balance checks and matchmaking seats and blocking players from joining the same lobby.
- Ensure the client uses a backend-resolved account record before reserving stakes and registering with the Socket.IO lobby so mixed-provider players can meet reliably.

### Description
- In `webapp/src/pages/Games/poolRoyaleOnlineFlow.js` import and use `createAccount` and `loadGoogleProfile` and call `createAccount(telegramId, googleProfile, accountId)` after `ensureAccountId()` and before balance/stake logic so the server returns a canonical `accountId` to use for the session.
- Use the backend-resolved `accountId` for `accountIdRef`, socket identity setup, register and `seatTable` payloads so both peers have matching server-side accounts.
- Add dependency injection hooks to the flow (`createAccount` and `loadGoogleProfile`) so tests and runtime can provide appropriate implementations.
- Update `test/poolRoyaleOnlineFlow.test.js` to provide `createAccount`/`loadGoogleProfile` stubs and add a regression test `runPoolRoyaleOnlineFlow uses backend-resolved account id for lobby seat` that asserts the socket `register` and `seatTable` use the server-returned account id.

### Testing
- Ran unit tests for the updated flow with `npm test -- test/poolRoyaleOnlineFlow.test.js --runInBand` and the suite passed (all tests including the new regression test passed).
- Ran related matchmaking meta tests with `npm test -- test/poolRoyaleMatchmakingMeta.test.js --runInBand` and they passed.
- The added test verifies backend-resolved `accountId` is used for socket registration and seating, and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c12ab11adc8329a366aa435bb6326f)