### PR TITLE
Fix Pool Royale lobby recovery when socket identity is stale

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -1677,7 +1677,15 @@ io.on('connection', (socket) => {
       },
       cb
     ) => {
-      if (!ensureRegistered(socket, accountId)) return cb && cb({ success: false, error: 'register_required' });
+      if (!ensureRegistered(socket, accountId)) {
+        const error =
+          accountId &&
+          socket.data?.playerId &&
+          String(accountId) !== String(socket.data.playerId)
+            ? 'identity_mismatch'
+            : 'register_required';
+        return cb && cb({ success: false, error });
+      }
       if (isRateLimited(socket, 'seatTable', seatTableRateLimitMs)) {
         return cb && cb({ success: false, error: 'rate_limited' });
       }

--- a/test/poolRoyaleOnlineFlow.test.js
+++ b/test/poolRoyaleOnlineFlow.test.js
@@ -358,3 +358,68 @@ test('runPoolRoyaleOnlineFlow refunds if register ack fails', async () => {
   assert.equal(addCalls[1][2], 'stake_refund');
   assert.ok(state.snapshot.matchingError.includes('online session'));
 });
+
+test('runPoolRoyaleOnlineFlow retries seat after identity mismatch and starts match', async () => {
+  const mockSocket = new MockSocket();
+  const refs = createRefs();
+  const state = createState();
+  const addCalls = [];
+  const started = [];
+
+  const deps = {
+    ensureAccountId: () => Promise.resolve('acct-22'),
+    getAccountBalance: () => Promise.resolve({ balance: 200 }),
+    addTransaction: (...args) => {
+      addCalls.push(args);
+      return Promise.resolve();
+    },
+    getTelegramId: () => null,
+    getTelegramFirstName: () => '',
+    socket: mockSocket
+  };
+
+  await runPoolRoyaleOnlineFlow({
+    stake: { token: 'TPC', amount: 100 },
+    variant: 'uk',
+    ballSet: 'uk',
+    playType: 'regular',
+    mode: 'online',
+    tableSize: '9ft',
+    avatar: 'me.png',
+    deps,
+    state,
+    refs,
+    timeouts: { seat: 50, matchmaking: 200, register: 60 },
+    onGameStart: (payload) => started.push(payload)
+  });
+
+  assert.equal(mockSocket.seatRequests.length, 1);
+  mockSocket.seatRequests[0].cb({ success: false, error: 'identity_mismatch' });
+  await delay(450);
+
+  assert.equal(mockSocket.registerRequests.length, 2, 'identity mismatch should trigger register retry');
+  assert.equal(mockSocket.seatRequests.length, 2, 'identity mismatch should trigger seat retry');
+
+  mockSocket.seatRequests[1].cb({
+    success: true,
+    tableId: 'tbl-identity',
+    players: [
+      { id: 'acct-22', name: 'TPC acct-22' },
+      { id: 'acct-23', name: 'TPC acct-23' }
+    ],
+    ready: ['acct-22']
+  });
+  mockSocket.emit('gameStart', {
+    tableId: 'tbl-identity',
+    players: [
+      { id: 'acct-22', name: 'TPC acct-22' },
+      { id: 'acct-23', name: 'TPC acct-23' }
+    ],
+    currentTurn: 'acct-22'
+  });
+  await delay(0);
+
+  assert.equal(started.length, 1);
+  assert.equal(addCalls.length, 1, 'stake should remain debited when match starts');
+  assert.equal(state.snapshot.matchingError, '');
+});

--- a/webapp/src/pages/Games/poolRoyaleOnlineFlow.js
+++ b/webapp/src/pages/Games/poolRoyaleOnlineFlow.js
@@ -112,6 +112,18 @@ async function ensureSocketRegistered(
   });
 }
 
+async function recoverSocketIdentity({
+  socketInstance,
+  accountId,
+  socketConnectTimeoutMs,
+  registerTimeoutMs
+}) {
+  setSocketIdentity(socketInstance, accountId);
+  const ready = await ensureSocketReady(socketInstance, socketConnectTimeoutMs);
+  if (!ready) return false;
+  return ensureSocketRegistered(socketInstance, accountId, registerTimeoutMs);
+}
+
 export async function runPoolRoyaleOnlineFlow({
   stake,
   tableId,
@@ -377,12 +389,37 @@ export async function runPoolRoyaleOnlineFlow({
         clearTimeoutSafely(seatTimeoutRef);
         setIsSearching(false);
         if (!res?.success || !res.tableId) {
-          const shouldRetry = (res?.error === 'register_required' || res?.error === 'rate_limited') && seatAttempts < maxSeatAttempts;
+          const isRegistrationError =
+            res?.error === 'register_required' || res?.error === 'identity_mismatch';
+          const shouldRetry =
+            (isRegistrationError || res?.error === 'rate_limited') &&
+            seatAttempts < maxSeatAttempts;
           if (shouldRetry) {
-            setMatchStatus('Retrying online seat…');
-            seatTimeoutRef.current = setTimeout(() => {
-              seatPlayer();
-            }, 400);
+            const retrySeat = async () => {
+              if (isRegistrationError) {
+                setMatchStatus('Resyncing your online session…');
+                const recovered = await recoverSocketIdentity({
+                  socketInstance,
+                  accountId,
+                  socketConnectTimeoutMs,
+                  registerTimeoutMs
+                });
+                if (!recovered) {
+                  triggerTimeoutRefund(
+                    'socket_registration_failed',
+                    'Unable to sync your online session. We refunded your stake.',
+                    { response: res, accountId, seatAttempts }
+                  );
+                  return;
+                }
+              } else {
+                setMatchStatus('Retrying online seat…');
+              }
+              seatTimeoutRef.current = setTimeout(() => {
+                seatPlayer();
+              }, 400);
+            };
+            retrySeat();
             return;
           }
           triggerTimeoutRefund(


### PR DESCRIPTION
### Motivation
- Joining Pool Royale lobbies could fail when a client socket held a stale registration (for example after switching between Telegram and Google identities), leaving players unable to seat or join the same game. 
- The client had no targeted recovery for `register_required`/identity mismatch responses and would often refund stake or abort matchmaking instead of resyncing the socket identity.

### Description
- Added a recovery path `recoverSocketIdentity` in `webapp/src/pages/Games/poolRoyaleOnlineFlow.js` that refreshes the socket auth payload, reconnects (if needed) and re-registers before retrying seating. 
- Updated the seat retry logic in `webapp/src/pages/Games/poolRoyaleOnlineFlow.js` to detect `identity_mismatch` and `register_required` and to attempt the identity recovery flow before retrying. 
- Modified server-side `seatTable` handling in `bot/server.js` to return a distinct `identity_mismatch` error when the requested `accountId` differs from the socket's registered `playerId`, enabling the client to choose the correct recovery strategy. 
- Added a focused regression test in `test/poolRoyaleOnlineFlow.test.js` that simulates an `identity_mismatch` on first seat, verifies the client re-registers and retries seating, and confirms the match proceeds to `gameStart` without refunding the stake.

### Testing
- Ran the focused test suite with `npx jest test/poolRoyaleOnlineFlow.test.js --runInBand`, and the suite passed with all tests green (6 tests passed). 
- The new identity-mismatch regression test validates that the client issues a register retry and a second seat attempt and that the stake remains debited when the match starts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c12ab11adc8329a366aa435bb6326f)