### PR TITLE
Improve Checkers Battle Royal lobby socket recovery and registration retry

### DIFF
--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -255,6 +255,8 @@ async function ensureOnlineSocketConnected(timeoutMs = ONLINE_SOCKET_CONNECT_TIM
 
   return new Promise((resolve) => {
     let settled = false;
+    let timer = null;
+    let lastError = null;
 
     const cleanup = () => {
       socket.off('connect', handleConnect);
@@ -265,18 +267,24 @@ async function ensureOnlineSocketConnected(timeoutMs = ONLINE_SOCKET_CONNECT_TIM
     const finish = (ok) => {
       if (settled) return;
       settled = true;
-      clearTimeout(timer);
+      if (timer) clearTimeout(timer);
       cleanup();
+      if (!ok && lastError) {
+        console.warn('[CheckersBattleRoyal] online socket connect failed', lastError);
+      }
       resolve(ok);
     };
 
     const handleConnect = () => finish(true);
-    const handleError = () => finish(false);
+    const handleError = (error) => {
+      // Keep waiting through temporary network blips and only fail on timeout.
+      lastError = error || lastError;
+    };
 
-    const timer = window.setTimeout(() => finish(Boolean(socket.connected)), timeoutMs);
+    timer = window.setTimeout(() => finish(Boolean(socket.connected)), timeoutMs);
     socket.once('connect', handleConnect);
-    socket.once('connect_error', handleError);
-    socket.once('error', handleError);
+    socket.on('connect_error', handleError);
+    socket.on('error', handleError);
     socket.connect?.();
   });
 }

--- a/webapp/src/pages/Games/CheckersBattleRoyalLobby.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyalLobby.jsx
@@ -32,6 +32,10 @@ const MATCHMAKING_RECOVERABLE_ERRORS = new Set([
   'rate_limited',
   'identity_mismatch'
 ]);
+const MATCHMAKING_REQUIRES_REGISTER_REFRESH = new Set([
+  'register_required',
+  'identity_mismatch'
+]);
 
 function normalizeHostCode(code = '') {
   return String(code || '')
@@ -52,6 +56,8 @@ async function ensureSocketConnected(timeoutMs = SOCKET_CONNECT_TIMEOUT_MS) {
 
   return new Promise((resolve) => {
     let settled = false;
+    let timer = null;
+    let lastError = null;
 
     const cleanup = () => {
       socket.off('connect', handleConnect);
@@ -62,18 +68,26 @@ async function ensureSocketConnected(timeoutMs = SOCKET_CONNECT_TIMEOUT_MS) {
     const finish = (result) => {
       if (settled) return;
       settled = true;
-      clearTimeout(timer);
+      if (timer) clearTimeout(timer);
       cleanup();
+      if (!result && lastError) {
+        // Keep a support signal in devtools without exposing low-level errors in UI.
+        console.warn('[CheckersLobby] socket connect failed', lastError);
+      }
       resolve(result);
     };
 
     const handleConnect = () => finish(true);
-    const handleError = () => finish(false);
+    const handleError = (error) => {
+      // Some mobile networks emit a temporary connect_error before a successful
+      // connect event. Keep listening until timeout to avoid false negatives.
+      lastError = error || lastError;
+    };
 
-    const timer = setTimeout(() => finish(socket.connected), timeoutMs);
+    timer = setTimeout(() => finish(socket.connected), timeoutMs);
     socket.once('connect', handleConnect);
-    socket.once('connect_error', handleError);
-    socket.once('error', handleError);
+    socket.on('connect_error', handleError);
+    socket.on('error', handleError);
     socket.connect?.();
   });
 }
@@ -448,7 +462,10 @@ export default function CheckersBattleRoyalLobby() {
               seatAttempts < maxSeatAttempts;
             if (shouldRetry) {
               setMatchStatus('Retrying online seat…');
-              if (res?.error === 'identity_mismatch' && trackedAccountId) {
+              if (
+                MATCHMAKING_REQUIRES_REGISTER_REFRESH.has(res?.error) &&
+                trackedAccountId
+              ) {
                 refreshSocketAuthIdentity(
                   { accountId: String(trackedAccountId) },
                   { reconnect: true }
@@ -464,7 +481,10 @@ export default function CheckersBattleRoyalLobby() {
                   cleanupLobby({ account: trackedAccountId });
                   return;
                 }
-                if (res?.error === 'identity_mismatch' && trackedAccountId) {
+                if (
+                  MATCHMAKING_REQUIRES_REGISTER_REFRESH.has(res?.error) &&
+                  trackedAccountId
+                ) {
                   const reRegistered = await ensureSocketRegistered(trackedAccountId);
                   if (!reRegistered) {
                     clearTimeout(matchTimeout);


### PR DESCRIPTION
### Motivation
- Players using different identity providers (Telegram vs Google) could get stuck when joining the online lobby because the retry path did not fully refresh registration for some recoverable errors. 
- Transient mobile/network `connect_error` events were treated as immediate failures which caused false-negative lobby connections during matchmaking.

### Description
- Add `MATCHMAKING_REQUIRES_REGISTER_REFRESH` and update retry logic so `register_required` (in addition to `identity_mismatch`) triggers a socket auth refresh and re-registration attempt before giving up (`webapp/src/pages/Games/CheckersBattleRoyalLobby.jsx`).
- Harden socket connect logic to tolerate transient `connect_error`/`error` events and wait until a configurable timeout before failing, keeping a devtool-visible warning for diagnostics (`ensureSocketConnected` in Checkers lobby and `ensureOnlineSocketConnected` in the Checkers runtime). 
- Apply the same transient-connect tolerance to the Checkers runtime join flow so handoff from lobby to game is more resilient (`webapp/src/pages/Games/CheckersBattleRoyal.jsx`).

### Testing
- Ran the webapp production build via `npm run build` in `webapp/` and it completed successfully (Vite built chunks and output reported a successful build despite chunk-size warnings). 
- No automated unit/integration tests were present for this matchmaking flow in the repository, so none were executed.
- End-to-end two-client matchmaking (Telegram+Google) could not be executed in this headless CI environment and should be validated manually with two real clients to confirm both users enter the same table.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1347a23708329b2d788b7c62e960e)