### PR TITLE
Fix Pool Royale null player crash and unify seating by TPC account id

### DIFF
--- a/test/poolRoyaleOnlineFlow.test.js
+++ b/test/poolRoyaleOnlineFlow.test.js
@@ -255,6 +255,61 @@ test('runPoolRoyaleOnlineFlow reconnects socket before seating table', async () 
   assert.equal(addCalls[0][2], 'stake');
 });
 
+test('runPoolRoyaleOnlineFlow tolerates null lobby players and accountId-only entries', async () => {
+  const mockSocket = new MockSocket();
+  const refs = createRefs();
+  const state = createState();
+  const started = [];
+
+  const deps = {
+    ensureAccountId: () => Promise.resolve('acct-20'),
+    getAccountBalance: () => Promise.resolve({ balance: 200 }),
+    addTransaction: () => Promise.resolve(),
+    getTelegramId: () => 'tg-20',
+    getTelegramFirstName: () => 'Mira',
+    socket: mockSocket
+  };
+
+  await runPoolRoyaleOnlineFlow({
+    stake: { token: 'TPC', amount: 50 },
+    variant: 'uk',
+    ballSet: 'uk',
+    playType: 'regular',
+    mode: 'online',
+    tableSize: 'medium',
+    avatar: 'me.png',
+    deps,
+    state,
+    refs,
+    timeouts: { seat: 50, matchmaking: 120 },
+    onGameStart: (payload) => started.push(payload)
+  });
+
+  assert.equal(mockSocket.seatRequests.length, 1);
+  mockSocket.seatRequests[0].cb({
+    success: true,
+    tableId: 'tbl-null-safe',
+    players: [null, { accountId: 'acct-30', name: 'Opponent' }],
+    ready: []
+  });
+
+  mockSocket.emit('lobbyUpdate', {
+    tableId: 'tbl-null-safe',
+    players: [null, { accountId: 'acct-30', name: 'Opponent' }]
+  });
+
+  mockSocket.emit('gameStart', {
+    tableId: 'tbl-null-safe',
+    players: [null, { accountId: 'acct-30', name: 'Opponent' }]
+  });
+
+  await delay(0);
+
+  assert.equal(started.length, 1);
+  assert.equal(state.snapshot.matchStatus, '');
+  assert.equal(state.snapshot.matchingError, '');
+});
+
 test('runPoolRoyaleOnlineFlow tolerates transient socket connect errors on mobile', async () => {
   class FlakyConnectSocket extends MockSocket {
     connect() {

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -33,6 +33,17 @@ import {
 const PLAYER_FLAG_STORAGE_KEY = 'poolRoyalePlayerFlag';
 const AI_FLAG_STORAGE_KEY = 'poolRoyaleAiFlag';
 
+function resolveTpcAccountNumber(player) {
+  if (!player || typeof player !== 'object') return '';
+  return String(
+    player.tpcAccountNumber ??
+      player.accountId ??
+      player.playerId ??
+      player.id ??
+      ''
+  ).trim();
+}
+
 export default function PoolRoyaleLobby() {
   const navigate = useNavigate();
   const { search } = useLocation();
@@ -133,10 +144,18 @@ export default function PoolRoyaleLobby() {
     currentTurn
   }) => {
     const selfId = accountId || accountIdRef.current;
-    const selfEntry = roster.find((p) => String(p.id) === String(selfId));
-    const opponentEntry = roster.find((p) => String(p.id) !== String(selfId));
-    const starterId = currentTurn || roster?.[0]?.id || null;
-    const selfIndex = roster.findIndex((p) => String(p.id) === String(selfId));
+    const safeRoster = Array.isArray(roster) ? roster.filter(Boolean) : [];
+    const selfEntry = safeRoster.find(
+      (p) => resolveTpcAccountNumber(p) === String(selfId)
+    );
+    const opponentEntry = safeRoster.find(
+      (p) => resolveTpcAccountNumber(p) !== String(selfId)
+    );
+    const starterId =
+      currentTurn || resolveTpcAccountNumber(safeRoster?.[0]) || null;
+    const selfIndex = safeRoster.findIndex(
+      (p) => resolveTpcAccountNumber(p) === String(selfId)
+    );
     const seat = selfIndex === 1 ? 'B' : 'A';
     const starterSeat =
       starterId && String(starterId) === String(selfId)
@@ -154,7 +173,9 @@ export default function PoolRoyaleLobby() {
       opponentEntry?.name ||
       opponentEntry?.username ||
       opponentEntry?.telegramName ||
-      (opponentEntry?.id ? `TPC ${opponentEntry.id}` : '');
+      (resolveTpcAccountNumber(opponentEntry)
+        ? `TPC ${resolveTpcAccountNumber(opponentEntry)}`
+        : '');
     const opponentAvatar = opponentEntry?.avatar || '';
     cleanupRef.current?.({ account: accountId, skipRefReset: true });
     const params = new URLSearchParams();
@@ -351,13 +372,17 @@ export default function PoolRoyaleLobby() {
 
   const matchingCandidates = useMemo(() => {
     const base = (onlinePlayers || []).map((p) => ({
-      id: p.accountId || p.playerId || p.id,
+      id: resolveTpcAccountNumber(p),
       name:
-        p.username || p.name || p.telegramName || p.telegramId || p.accountId
+        p.username ||
+        p.name ||
+        p.telegramName ||
+        p.telegramId ||
+        resolveTpcAccountNumber(p)
     }));
     const lobbyEntries = (matchPlayers || []).map((p) => ({
-      id: p.id,
-      name: p.name || p.id
+      id: resolveTpcAccountNumber(p),
+      name: p?.name || resolveTpcAccountNumber(p)
     }));
     const merged = [...base, ...lobbyEntries].filter((p) => p.id);
     const seen = new Set();

--- a/webapp/src/pages/Games/poolRoyaleOnlineFlow.js
+++ b/webapp/src/pages/Games/poolRoyaleOnlineFlow.js
@@ -7,6 +7,17 @@ const DEFAULT_MATCH_TIMEOUT_MS = 30000;
 const DEFAULT_SOCKET_CONNECT_TIMEOUT_MS = 15000;
 const DEFAULT_REGISTER_TIMEOUT_MS = 6000;
 
+function resolveTpcAccountNumber(player) {
+  if (!player || typeof player !== 'object') return '';
+  return String(
+    player.tpcAccountNumber ??
+      player.accountId ??
+      player.playerId ??
+      player.id ??
+      ''
+  ).trim();
+}
+
 function logSupportError(message, error, context = {}) {
   // Surface in console for support teams; caller will also show inline errors.
   console.error('[PoolRoyaleLobby]', message, { ...context, error });
@@ -289,7 +300,11 @@ export async function runPoolRoyaleOnlineFlow({
     setMatchPlayers(list);
     matchPlayersRef.current = list;
     setReadyList(ready);
-    const others = list.filter((p) => String(p.id) !== String(accountId));
+    const others = list.filter(
+      (p) =>
+        resolveTpcAccountNumber(p) &&
+        resolveTpcAccountNumber(p) !== String(accountId)
+    );
     setMatchStatus(
       others.length > 0 ? 'Opponent joined. Locking seats…' : 'Waiting for another player…'
     );
@@ -431,7 +446,7 @@ export async function runPoolRoyaleOnlineFlow({
         }
         pendingTableRef.current = res.tableId;
         setMatchStatus('Waiting for another player…');
-        const playersList = res.players || [];
+        const playersList = Array.isArray(res.players) ? res.players.filter(Boolean) : [];
         setMatchPlayers(playersList);
         matchPlayersRef.current = playersList;
         setReadyList(res.ready || []);


### PR DESCRIPTION
### Motivation
- Reproduce and prevent runtime crash caused by reading `.id` on null/malformed lobby player payloads during Pool Royale online matchmaking. 
- Ensure consistent user identity resolution across Telegram and Google by tracking players with a single TPC account identifier. 

### Description
- Added `resolveTpcAccountNumber` helper to resolve player identity in priority order: `tpcAccountNumber`, `accountId`, `playerId`, then `id`, and trimmed to a string. 
- Reworked lobby update and seat handling to use the resolver and made lists null-safe (sanitized seat/players with `filter(Boolean)`) to avoid dereferencing null objects. 
- Updated Pool Royale lobby navigation and matchmaking candidate logic to use the TPC account resolver for both online users and live lobby players, preventing identity mismatches. 
- Added a regression test verifying the online flow tolerates null lobby players and accountId-only entries and still starts a match correctly. 

### Testing
- Ran the Pool Royale online flow unit tests: `npm test -- test/poolRoyaleOnlineFlow.test.js --runInBand`. 
- Result: test suite passed (all tests in that file succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c13a0304208329a3da496618b28c43)