### PR TITLE
Use TPC account IDs for Checkers Battle Royal online seating

### DIFF
--- a/test/ensureAccountIdTpcResolution.test.js
+++ b/test/ensureAccountIdTpcResolution.test.js
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, test } from '@jest/globals';
+import { ensureAccountId } from '../webapp/src/utils/telegram.js';
+
+class MemoryStorage {
+  constructor() {
+    this.store = new Map();
+  }
+
+  getItem(key) {
+    return this.store.has(key) ? this.store.get(key) : null;
+  }
+
+  setItem(key, value) {
+    this.store.set(key, String(value));
+  }
+
+  removeItem(key) {
+    this.store.delete(key);
+  }
+
+  key(index) {
+    return Array.from(this.store.keys())[index] ?? null;
+  }
+
+  get length() {
+    return this.store.size;
+  }
+}
+
+describe('ensureAccountId', () => {
+  beforeEach(() => {
+    const storage = new MemoryStorage();
+    global.localStorage = storage;
+    global.window = {
+      localStorage: storage,
+      location: { origin: 'http://localhost', search: '' },
+      Telegram: undefined
+    };
+  });
+
+  test('resolves to server TPC account id for google identity', async () => {
+    global.localStorage.setItem(
+      'googleProfile',
+      JSON.stringify({ id: 'google-user-11', firstName: 'Gigi' })
+    );
+
+    let requestBody = null;
+    global.fetch = async (_url, options = {}) => {
+      requestBody = JSON.parse(options.body);
+      return {
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ accountId: 'tpc-server-11' })
+      };
+    };
+
+    const resolved = await ensureAccountId();
+    expect(resolved).toBe('tpc-server-11');
+    expect(requestBody?.googleId).toBe('google-user-11');
+    expect(requestBody?.accountId).toBeTruthy();
+  });
+
+  test('falls back to local scoped id when account create request fails', async () => {
+    global.localStorage.setItem('googleId', 'google-user-fallback');
+
+    global.fetch = async () => {
+      throw new Error('network down');
+    };
+
+    const resolved = await ensureAccountId();
+    expect(resolved).toBeTruthy();
+    expect(typeof resolved).toBe('string');
+    expect(resolved).toBe(global.localStorage.getItem('accountId'));
+  });
+});

--- a/webapp/src/pages/Games/CheckersBattleRoyalLobby.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyalLobby.jsx
@@ -294,10 +294,10 @@ export default function CheckersBattleRoyalLobby() {
     let trackedAccountId;
     let stakeCharged = false;
     const refundStakeIfNeeded = async (reason = 'stake_refund') => {
-      if (!isOnline || !stakeCharged || !trackedAccountId || !tgId || !stake.amount) return;
+      if (!isOnline || !stakeCharged || !trackedAccountId || !stake.amount) return;
       stakeCharged = false;
       try {
-        await addTransaction(tgId, stake.amount, reason, {
+        await addTransaction(tgId ?? undefined, stake.amount, reason, {
           game: 'checkersbattle',
           players: 2,
           accountId: trackedAccountId
@@ -312,7 +312,7 @@ export default function CheckersBattleRoyalLobby() {
 
       if (!trackedAccountId) {
         await refundStakeIfNeeded();
-        setMatchError('Unable to resolve your player account. Reopen Telegram and try again.');
+        setMatchError('Unable to resolve your TPC account number. Reopen app and try again.');
         setMatching(false);
         setMatchStatus('');
         return;
@@ -333,7 +333,7 @@ export default function CheckersBattleRoyalLobby() {
 
       try {
         tgId = getTelegramId();
-        await addTransaction(tgId, -stake.amount, 'stake', {
+        await addTransaction(tgId ?? undefined, -stake.amount, 'stake', {
           game: 'checkersbattle',
           players: 2,
           accountId: trackedAccountId,

--- a/webapp/src/utils/telegram.js
+++ b/webapp/src/utils/telegram.js
@@ -1,4 +1,4 @@
-import { fetchTelegramInfo } from "./api.js";
+import { createAccount, fetchTelegramInfo } from "./api.js";
 
 export function isTelegramWebView() {
   if (typeof window === 'undefined') return false;
@@ -160,9 +160,52 @@ export function getPlayerId() {
   return id;
 }
 
+let ensureAccountIdInFlight = null;
+
+function loadGoogleProfileFromStorage() {
+  if (typeof window === 'undefined') return null;
+  try {
+    const rawProfile = window.localStorage?.getItem('googleProfile');
+    if (!rawProfile) return null;
+    const parsed = JSON.parse(rawProfile);
+    if (!parsed?.id) return null;
+    return {
+      id: String(parsed.id),
+      email: parsed.email || undefined,
+      firstName: parsed.firstName || undefined,
+      lastName: parsed.lastName || undefined,
+      photo: parsed.photo || undefined
+    };
+  } catch {
+    return null;
+  }
+}
+
 export async function ensureAccountId() {
   if (typeof window === 'undefined') return null;
-  return getPlayerId();
+  if (ensureAccountIdInFlight) return ensureAccountIdInFlight;
+
+  const localScopedId = getPlayerId();
+  const telegramId = getTelegramId();
+  const googleProfile = telegramId ? null : loadGoogleProfileFromStorage();
+
+  ensureAccountIdInFlight = createAccount(
+    telegramId,
+    googleProfile,
+    localScopedId || undefined
+  )
+    .then((response) => {
+      if (response?.accountId && typeof response.accountId === 'string') {
+        return response.accountId;
+      }
+      return localScopedId || null;
+    })
+    .catch(() => localScopedId || null)
+    .finally(() => {
+      ensureAccountIdInFlight = null;
+    });
+
+  return ensureAccountIdInFlight;
 }
 
 export function getTelegramUsername() {


### PR DESCRIPTION
### Motivation
- Online seating/matchmaking was failing for users when Telegram and Google identities produced different local IDs, so the app needs a canonical TPC account number to unify players across providers.
- The change ensures the game uses the server-side TPC account id as the canonical player identity for seating, transactions and socket registration.

### Description
- Updated `ensureAccountId` in `webapp/src/utils/telegram.js` to call `createAccount` and return the server-provided `accountId` while falling back to the existing scoped local id if the request fails.
- Added in-flight deduplication via `ensureAccountIdInFlight` and a helper `loadGoogleProfileFromStorage` to avoid concurrent resolution races.
- Imported `createAccount` and preserved existing local-scoped id behavior for backward compatibility when the server call fails.
- Adjusted `CheckersBattleRoyalLobby.jsx` to handle account-id-only flows (Google-only users) by passing `undefined` for missing Telegram ids to `addTransaction` and clarified the user-facing error copy to reference TPC account number resolution.
- Added `test/ensureAccountIdTpcResolution.test.js` to verify server account resolution for Google identities and fallback behavior when network/account creation fails.

### Testing
- Ran `npm test -- --runInBand test/ensureAccountIdTpcResolution.test.js test/telegramAccountIsolation.test.js` and both test suites passed.
- New tests in `test/ensureAccountIdTpcResolution.test.js` passed and existing `test/telegramAccountIsolation.test.js` still passes, confirming compatibility with previous account-scoping logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c13a4a186883299463bdfab124e7fe)