### PR TITLE
Use canonical TPC account ID for Checkers Battle Royal online matchmaking

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -1624,20 +1624,21 @@ function removeSocketFromLiveChat(socket) {
 }
 
 io.on('connection', (socket) => {
-  socket.on('register', async ({ playerId } = {}, cb) => {
-    if (!playerId) {
+  socket.on('register', async ({ playerId, accountId, tpcAccountId } = {}, cb) => {
+    const resolvedPlayerId = playerId || tpcAccountId || accountId;
+    if (!resolvedPlayerId) {
       cb && cb({ success: false, error: 'missing_player_id' });
       return;
     }
     try {
-      let set = userSockets.get(String(playerId));
+      let set = userSockets.get(String(resolvedPlayerId));
       if (!set) {
         set = new Set();
-        userSockets.set(String(playerId), set);
+        userSockets.set(String(resolvedPlayerId), set);
       }
       set.add(socket.id);
-      socket.data.playerId = String(playerId);
-      await registerConnection({ userId: String(playerId), socketId: socket.id });
+      socket.data.playerId = String(resolvedPlayerId);
+      await registerConnection({ userId: String(resolvedPlayerId), socketId: socket.id });
       cb && cb({ success: true });
     } catch (error) {
       console.error('register socket failed', error);
@@ -1661,6 +1662,7 @@ io.on('connection', (socket) => {
     async (
       {
         accountId,
+        tpcAccountId,
         gameType,
         stake,
         maxPlayers = 4,
@@ -1677,11 +1679,12 @@ io.on('connection', (socket) => {
       },
       cb
     ) => {
-      if (!ensureRegistered(socket, accountId)) {
+      const resolvedAccountId = tpcAccountId || accountId;
+      if (!ensureRegistered(socket, resolvedAccountId)) {
         const error =
-          accountId &&
+          resolvedAccountId &&
           socket.data?.playerId &&
-          String(accountId) !== String(socket.data.playerId)
+          String(resolvedAccountId) !== String(socket.data.playerId)
             ? 'identity_mismatch'
             : 'register_required';
         return cb && cb({ success: false, error });
@@ -1715,7 +1718,7 @@ io.on('connection', (socket) => {
       let table;
       if (tableId) {
         table = await seatTableSocket(
-          accountId,
+          resolvedAccountId,
           validation.normalizedGameType,
           validation.normalizedStake,
           validation.normalizedMaxPlayers,
@@ -1728,7 +1731,7 @@ io.on('connection', (socket) => {
         );
       } else {
         table = await seatTableSocket(
-          accountId,
+          resolvedAccountId,
           validation.normalizedGameType,
           validation.normalizedStake,
           validation.normalizedMaxPlayers,
@@ -1754,26 +1757,28 @@ io.on('connection', (socket) => {
     }
   );
 
-  socket.on('leaveLobby', ({ accountId, tableId }) => {
+  socket.on('leaveLobby', ({ accountId, tpcAccountId, tableId }) => {
+    const resolvedAccountId = tpcAccountId || accountId;
     if (tableId) {
-      unseatTableSocket(accountId, tableId, socket.id);
+      unseatTableSocket(resolvedAccountId, tableId, socket.id);
     }
   });
 
-  socket.on('confirmReady', ({ accountId, tableId }) => {
+  socket.on('confirmReady', ({ accountId, tpcAccountId, tableId }) => {
+    const resolvedAccountId = tpcAccountId || accountId;
     const table = tableMap.get(tableId);
     if (!table) {
       socket.emit('errorMessage', 'table_not_found');
       return;
     }
-    if (!ensureRegistered(socket, accountId)) return;
-    const seated = table.players.some((player) => String(player.id) === String(accountId));
+    if (!ensureRegistered(socket, resolvedAccountId)) return;
+    const seated = table.players.some((player) => String(player.id) === String(resolvedAccountId));
     if (!seated) {
       socket.emit('errorMessage', 'seat_required');
       return;
     }
     if (!table.ready) table.ready = new Set();
-    table.ready.add(String(accountId));
+    table.ready.add(String(resolvedAccountId));
     io.to(tableId).emit('lobbyUpdate', {
       tableId,
       players: table.players,

--- a/webapp/src/pages/Games/CheckersBattleRoyalLobby.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyalLobby.jsx
@@ -5,6 +5,7 @@ import FlagPickerModal from '../../components/FlagPickerModal.jsx';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 import {
   ensureAccountId,
+  getTpcAccountId,
   getTelegramId,
   getTelegramFirstName,
   getTelegramPhotoUrl,
@@ -162,7 +163,7 @@ export default function CheckersBattleRoyalLobby() {
     ensureAccountId()
       .then((id) => {
         if (cancelled) return;
-        setAccountId(id || '');
+        setAccountId(getTpcAccountId() || id || '');
       })
       .catch(() => {});
     return () => {
@@ -259,6 +260,7 @@ export default function CheckersBattleRoyalLobby() {
     if (!skipLeave && pendingTableRef.current && (account || accountId)) {
       socket.emit('leaveLobby', {
         accountId: account || accountId,
+        tpcAccountId: account || accountId,
         tableId: pendingTableRef.current
       });
     }
@@ -293,6 +295,7 @@ export default function CheckersBattleRoyalLobby() {
     if (isOnline) {
       try {
         trackedAccountId = await ensureAccountId();
+        trackedAccountId = getTpcAccountId() || trackedAccountId;
         if (trackedAccountId) setAccountId((prev) => prev || trackedAccountId);
       } catch {}
 
@@ -359,7 +362,8 @@ export default function CheckersBattleRoyalLobby() {
       return;
     }
 
-    const socketRegistered = await ensureSocketRegistered(trackedAccountId || accountId);
+    const seatAccountId = getTpcAccountId() || trackedAccountId || accountId;
+    const socketRegistered = await ensureSocketRegistered(seatAccountId);
     if (!socketRegistered) {
       await refundStakeIfNeeded();
       setMatchError('Unable to sync your online session. Please retry.');
@@ -370,7 +374,7 @@ export default function CheckersBattleRoyalLobby() {
 
     const handleLobbyUpdate = ({ tableId: tid, players: list = [] } = {}) => {
       if (!tid || tid !== pendingTableRef.current) return;
-      const others = list.filter((p) => String(p.id) !== String(trackedAccountId || accountId));
+      const others = list.filter((p) => String(p.id) !== String(seatAccountId));
       if (others.length > 0) {
         setMatchStatus('Opponent joined. Locking seats…');
       } else {
@@ -380,10 +384,10 @@ export default function CheckersBattleRoyalLobby() {
 
     const handleGameStart = ({ tableId: startedId, players = [] } = {}) => {
       if (!startedId || startedId !== pendingTableRef.current) return;
-      const meIndex = players.findIndex((p) => String(p.id) === String(trackedAccountId || accountId));
-      const opp = players.find((p) => String(p.id) !== String(trackedAccountId || accountId));
+      const meIndex = players.findIndex((p) => String(p.id) === String(seatAccountId));
+      const opp = players.find((p) => String(p.id) !== String(seatAccountId));
       const mySide =
-        players.find((p) => String(p.id) === String(trackedAccountId || accountId))?.side ||
+        players.find((p) => String(p.id) === String(seatAccountId))?.side ||
         (meIndex === 0 ? 'white' : 'black');
       cleanupLobby({ account: trackedAccountId, skipLeave: true });
       navigateToGame({
@@ -431,6 +435,7 @@ export default function CheckersBattleRoyalLobby() {
         'seatTable',
         {
           accountId: trackedAccountId || accountId,
+          tpcAccountId: seatAccountId,
           gameType: 'checkers',
           stake: stake.amount ?? 0,
           maxPlayers: 2,
@@ -497,7 +502,8 @@ export default function CheckersBattleRoyalLobby() {
               : 'Waiting for another player…'
           );
           socket.emit('confirmReady', {
-            accountId: trackedAccountId,
+            accountId: seatAccountId,
+            tpcAccountId: seatAccountId,
             tableId: res.tableId
           });
           cleanupRef.current = () => {

--- a/webapp/src/utils/telegram.js
+++ b/webapp/src/utils/telegram.js
@@ -118,6 +118,11 @@ export function getPlayerId() {
     const perTelegramKey = accountIdMapStorageKey(telegramId);
     let telegramScopedId = localStorage.getItem(perTelegramKey);
 
+    if (globalId && (!telegramScopedId || telegramScopedId !== globalId)) {
+      telegramScopedId = globalId;
+      localStorage.setItem(perTelegramKey, telegramScopedId);
+    }
+
     // Backward compatibility:
     // if this Telegram user already had a single legacy accountId stored, bind it
     // once to the per-user key instead of generating a new id.
@@ -140,6 +145,10 @@ export function getPlayerId() {
   if (googleId) {
     const perGoogleKey = accountIdGoogleStorageKey(googleId);
     let googleScopedId = localStorage.getItem(perGoogleKey);
+    if (globalId && (!googleScopedId || googleScopedId !== globalId)) {
+      googleScopedId = globalId;
+      localStorage.setItem(perGoogleKey, googleScopedId);
+    }
     if (!googleScopedId && globalId && !hasAnyScopedAccountIds(localStorage)) {
       googleScopedId = globalId;
       localStorage.setItem(perGoogleKey, googleScopedId);
@@ -163,6 +172,11 @@ export function getPlayerId() {
 export async function ensureAccountId() {
   if (typeof window === 'undefined') return null;
   return getPlayerId();
+}
+
+export function getTpcAccountId() {
+  if (typeof window === 'undefined') return null;
+  return localStorage.getItem('accountId') || getPlayerId();
 }
 
 export function getTelegramUsername() {


### PR DESCRIPTION
### Motivation

- Ensure the TPC account number stored in `localStorage.accountId` is used as the canonical player identity for online matchmaking so Telegram and Google logins don't produce mismatched identities. 
- Prevent players from being unable to join/see each other in the lobby when they selected the same criteria due to identity drift between providers.

### Description

- Prefer and expose the canonical TPC id via a new helper `getTpcAccountId()` and sync Telegram/Google scoped ids with the global `accountId` in `webapp/src/utils/telegram.js`.
- Resolve and use the TPC id in the Checkers lobby flow by calling `getTpcAccountId()` in `webapp/src/pages/Games/CheckersBattleRoyalLobby.jsx` and by sending `tpcAccountId` in socket payloads for `seatTable`, `confirmReady`, and `leaveLobby`.
- Update server socket handlers in `bot/server.js` (`register`, `seatTable`, `leaveLobby`, `confirmReady`) to accept `tpcAccountId` and treat it as the authoritative identity when seating/unseating and when marking players `ready`.
- Use the resolved TPC id when comparing players for lobby updates and game start decisions so seat assignment and match start are consistent across auth contexts.

### Testing

- Ran unit tests for the online flow with `npm test -- --runInBand test/simpleOnlineFlow.test.js`, and the suite passed.
- Attempted a scoped lint run; lint reported large pre-existing repository errors unrelated to this patch and ignore-pattern warnings, so no new lint failures were introduced by the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1793f40f48329942ab0c763a4b757)