### PR TITLE
Restore Pool Royale online lobby identity sync using TPC account number

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -1788,8 +1788,8 @@ io.on('connection', (socket) => {
     maybeStartGame(table);
   });
 
-  socket.on('joinRoom', async ({ roomId, playerId, accountId, name, avatar }) => {
-    const pid = playerId || accountId;
+  socket.on('joinRoom', async ({ roomId, playerId, accountId, tpcAccountId, name, avatar }) => {
+    const pid = tpcAccountId || playerId || accountId;
     const map = tableSeats.get(roomId);
     const cap = Number(roomId.split('-')[1]) || 4;
     if (!gameManager.rooms.has(roomId) && map && map.size < cap) {

--- a/test/poolRoyaleOnlineFlow.test.js
+++ b/test/poolRoyaleOnlineFlow.test.js
@@ -129,7 +129,9 @@ test('runPoolRoyaleOnlineFlow debits once and keeps stake for game start', async
 
   assert.equal(mockSocket.seatRequests.length, 1);
   assert.equal(mockSocket.registerRequests.length, 1);
+  assert.equal(mockSocket.registerRequests[0].tpcAccountId, 'acct-1');
   const seatPayload = mockSocket.seatRequests[0].payload;
+  assert.equal(seatPayload.tpcAccountId, 'acct-1');
   assert.equal(seatPayload.ballSet, 'american');
   assert.equal(seatPayload.variant, 'uk');
   assert.equal(seatPayload.mode, 'online');
@@ -249,6 +251,7 @@ test('runPoolRoyaleOnlineFlow reconnects socket before seating table', async () 
 
   assert.equal(mockSocket.connectCalls, 1);
   assert.equal(mockSocket.registerRequests.length, 1);
+  assert.equal(mockSocket.registerRequests[0].tpcAccountId, 'acct-3');
   assert.equal(mockSocket.seatRequests.length, 1, 'should proceed after reconnecting');
   mockSocket.seatRequests[0].cb({ success: false, message: 'busy' });
   await delay(0);
@@ -302,11 +305,67 @@ test('runPoolRoyaleOnlineFlow tolerates transient socket connect errors on mobil
 
   assert.equal(mockSocket.connectCalls, 1);
   assert.equal(mockSocket.registerRequests.length, 1);
+  assert.equal(mockSocket.registerRequests[0].tpcAccountId, 'acct-4');
   assert.equal(mockSocket.seatRequests.length, 1, 'should keep waiting after temporary connect error');
   mockSocket.seatRequests[0].cb({ success: false, message: 'busy' });
   await delay(0);
   assert.equal(state.snapshot.matchingError, 'busy');
   assert.equal(addCalls[0][2], 'stake');
+});
+
+test('runPoolRoyaleOnlineFlow tolerates null lobby players and accountId-only entries', async () => {
+  const mockSocket = new MockSocket();
+  const refs = createRefs();
+  const state = createState();
+  const started = [];
+
+  const deps = {
+    ensureAccountId: () => Promise.resolve('acct-20'),
+    getAccountBalance: () => Promise.resolve({ balance: 200 }),
+    addTransaction: () => Promise.resolve(),
+    getTelegramId: () => 'tg-20',
+    getTelegramFirstName: () => 'Mira',
+    socket: mockSocket
+  };
+
+  await runPoolRoyaleOnlineFlow({
+    stake: { token: 'TPC', amount: 50 },
+    variant: 'uk',
+    ballSet: 'uk',
+    playType: 'regular',
+    mode: 'online',
+    tableSize: 'medium',
+    avatar: 'me.png',
+    deps,
+    state,
+    refs,
+    timeouts: { seat: 50, matchmaking: 120 },
+    onGameStart: (payload) => started.push(payload)
+  });
+
+  assert.equal(mockSocket.seatRequests.length, 1);
+  mockSocket.seatRequests[0].cb({
+    success: true,
+    tableId: 'tbl-null-safe',
+    players: [null, { accountId: 'acct-30', name: 'Opponent' }],
+    ready: []
+  });
+
+  mockSocket.emit('lobbyUpdate', {
+    tableId: 'tbl-null-safe',
+    players: [null, { accountId: 'acct-30', name: 'Opponent' }]
+  });
+
+  mockSocket.emit('gameStart', {
+    tableId: 'tbl-null-safe',
+    players: [null, { accountId: 'acct-30', name: 'Opponent' }]
+  });
+
+  await delay(0);
+
+  assert.equal(started.length, 1);
+  assert.equal(state.snapshot.matchStatus, '');
+  assert.equal(state.snapshot.matchingError, '');
 });
 
 test('runPoolRoyaleOnlineFlow refunds if register ack fails', async () => {

--- a/webapp/src/hooks/useOnlineRoomSync.js
+++ b/webapp/src/hooks/useOnlineRoomSync.js
@@ -17,21 +17,23 @@ export default function useOnlineRoomSync(search = '', fallbackName = 'Player') 
         accountId = (await ensureAccountId().catch(() => '')) || '';
       }
       if (cancelled || !accountId) return;
-      socket.emit('register', { playerId: accountId });
+      socket.emit('register', { playerId: accountId, tpcAccountId: accountId });
       socket.emit('joinRoom', {
         roomId: tableId,
+        playerId: accountId,
         accountId,
+        tpcAccountId: accountId,
         name: params.get('username') || getTelegramUsername() || fallbackName,
         avatar: params.get('avatar') || '',
       });
-      socket.emit('confirmReady', { accountId, tableId });
+      socket.emit('confirmReady', { accountId, tpcAccountId: accountId, tableId });
     };
 
     sync().catch(() => {});
 
     return () => {
       cancelled = true;
-      if (accountId) socket.emit('leaveLobby', { accountId, tableId });
+      if (accountId) socket.emit('leaveLobby', { accountId, tpcAccountId: accountId, tableId });
     };
   }, [search, fallbackName]);
 }

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -33,6 +33,17 @@ import {
 const PLAYER_FLAG_STORAGE_KEY = 'poolRoyalePlayerFlag';
 const AI_FLAG_STORAGE_KEY = 'poolRoyaleAiFlag';
 
+function resolveTpcAccountNumber(player) {
+  if (!player || typeof player !== 'object') return '';
+  return String(
+    player.tpcAccountNumber ??
+      player.accountId ??
+      player.playerId ??
+      player.id ??
+      ''
+  ).trim();
+}
+
 export default function PoolRoyaleLobby() {
   const navigate = useNavigate();
   const { search } = useLocation();
@@ -133,10 +144,18 @@ export default function PoolRoyaleLobby() {
     currentTurn
   }) => {
     const selfId = accountId || accountIdRef.current;
-    const selfEntry = roster.find((p) => String(p.id) === String(selfId));
-    const opponentEntry = roster.find((p) => String(p.id) !== String(selfId));
-    const starterId = currentTurn || roster?.[0]?.id || null;
-    const selfIndex = roster.findIndex((p) => String(p.id) === String(selfId));
+    const safeRoster = Array.isArray(roster) ? roster.filter(Boolean) : [];
+    const selfEntry = safeRoster.find(
+      (p) => resolveTpcAccountNumber(p) === String(selfId)
+    );
+    const opponentEntry = safeRoster.find(
+      (p) => resolveTpcAccountNumber(p) !== String(selfId)
+    );
+    const starterId =
+      currentTurn || resolveTpcAccountNumber(safeRoster?.[0]) || null;
+    const selfIndex = safeRoster.findIndex(
+      (p) => resolveTpcAccountNumber(p) === String(selfId)
+    );
     const seat = selfIndex === 1 ? 'B' : 'A';
     const starterSeat =
       starterId && String(starterId) === String(selfId)
@@ -154,7 +173,9 @@ export default function PoolRoyaleLobby() {
       opponentEntry?.name ||
       opponentEntry?.username ||
       opponentEntry?.telegramName ||
-      (opponentEntry?.id ? `TPC ${opponentEntry.id}` : '');
+      (resolveTpcAccountNumber(opponentEntry)
+        ? `TPC ${resolveTpcAccountNumber(opponentEntry)}`
+        : '');
     const opponentAvatar = opponentEntry?.avatar || '';
     cleanupRef.current?.({ account: accountId, skipRefReset: true });
     const params = new URLSearchParams();
@@ -351,13 +372,17 @@ export default function PoolRoyaleLobby() {
 
   const matchingCandidates = useMemo(() => {
     const base = (onlinePlayers || []).map((p) => ({
-      id: p.accountId || p.playerId || p.id,
+      id: resolveTpcAccountNumber(p),
       name:
-        p.username || p.name || p.telegramName || p.telegramId || p.accountId
+        p.username ||
+        p.name ||
+        p.telegramName ||
+        p.telegramId ||
+        resolveTpcAccountNumber(p)
     }));
     const lobbyEntries = (matchPlayers || []).map((p) => ({
-      id: p.id,
-      name: p.name || p.id
+      id: resolveTpcAccountNumber(p),
+      name: p?.name || resolveTpcAccountNumber(p)
     }));
     const merged = [...base, ...lobbyEntries].filter((p) => p.id);
     const seen = new Set();

--- a/webapp/src/pages/Games/poolRoyaleOnlineFlow.js
+++ b/webapp/src/pages/Games/poolRoyaleOnlineFlow.js
@@ -7,6 +7,17 @@ const DEFAULT_MATCH_TIMEOUT_MS = 30000;
 const DEFAULT_SOCKET_CONNECT_TIMEOUT_MS = 15000;
 const DEFAULT_REGISTER_TIMEOUT_MS = 6000;
 
+function resolveTpcAccountNumber(player) {
+  if (!player || typeof player !== 'object') return '';
+  return String(
+    player.tpcAccountNumber ??
+      player.accountId ??
+      player.playerId ??
+      player.id ??
+      ''
+  ).trim();
+}
+
 function logSupportError(message, error, context = {}) {
   // Surface in console for support teams; caller will also show inline errors.
   console.error('[PoolRoyaleLobby]', message, { ...context, error });
@@ -98,7 +109,7 @@ async function ensureSocketRegistered(
     }, timeoutMs);
 
     try {
-      socketInstance.emit('register', { playerId: accountId }, (res) => {
+      socketInstance.emit('register', { playerId: accountId, tpcAccountId: accountId }, (res) => {
         if (settled) return;
         settled = true;
         clearTimeout(timer);
@@ -289,7 +300,11 @@ export async function runPoolRoyaleOnlineFlow({
     setMatchPlayers(list);
     matchPlayersRef.current = list;
     setReadyList(ready);
-    const others = list.filter((p) => String(p.id) !== String(accountId));
+    const others = list.filter(
+      (p) =>
+        resolveTpcAccountNumber(p) &&
+        resolveTpcAccountNumber(p) !== String(accountId)
+    );
     setMatchStatus(
       others.length > 0 ? 'Opponent joined. Locking seats…' : 'Waiting for another player…'
     );
@@ -306,7 +321,11 @@ export async function runPoolRoyaleOnlineFlow({
     socketInstance.off('lobbyUpdate', handleLobbyUpdate);
     socketInstance.off('gameStart', handleGameStart);
     if (pendingTableRef.current && account) {
-      socketInstance.emit('leaveLobby', { accountId: account, tableId: pendingTableRef.current });
+      socketInstance.emit('leaveLobby', {
+        accountId: account,
+        tpcAccountId: account,
+        tableId: pendingTableRef.current
+      });
     }
     pendingTableRef.current = '';
     clearSpinInterval();
@@ -372,6 +391,7 @@ export async function runPoolRoyaleOnlineFlow({
       'seatTable',
       {
         accountId,
+        tpcAccountId: accountId,
         stake: stake.amount,
         token: stake.token,
         gameType: 'poolroyale',
@@ -431,12 +451,13 @@ export async function runPoolRoyaleOnlineFlow({
         }
         pendingTableRef.current = res.tableId;
         setMatchStatus('Waiting for another player…');
-        const playersList = res.players || [];
+        const playersList = Array.isArray(res.players) ? res.players.filter(Boolean) : [];
         setMatchPlayers(playersList);
         matchPlayersRef.current = playersList;
         setReadyList(res.ready || []);
         socketInstance.emit('confirmReady', {
           accountId,
+          tpcAccountId: accountId,
           tableId: res.tableId
         });
         startMatchTimeout(res.tableId);


### PR DESCRIPTION
### Motivation

- Restore the Pool Royale online flow to the behavior from two months ago where the TPC account number is used as the canonical online identity across providers and sockets.
- Fix connection & seating failures caused by mixed identity payloads (Telegram initData, Google id, plain accountId) and null/malformed lobby entries that broke opponent detection.

### Description

- Use a small `resolveTpcAccountNumber` helper in `poolRoyaleOnlineFlow.js` and `PoolRoyaleLobby.jsx` to normalise player identity from `tpcAccountNumber`, `accountId`, `playerId`, or `id`, and make lobby roster handling null-safe.
- Include `tpcAccountId` in socket payloads for `register`, `seatTable`, `joinRoom`, `confirmReady`, and `leaveLobby` in the client hooks/flows (`webapp/src/pages/Games/poolRoyaleOnlineFlow.js`, `webapp/src/hooks/useOnlineRoomSync.js`), and pass it along when emitting those events.
- Update server-side join logic to prefer `tpcAccountId` when resolving a joining player in `bot/server.js` so backend room joins match lobby seating keys.
- Harden matchmaking/lobby handling to filter out null players and to match/announce opponents by the resolved TPC account number, and add/adjust unit tests in `test/poolRoyaleOnlineFlow.test.js` to assert `tpcAccountId` usage and null-safe roster behavior.

### Testing

- Ran the Pool Royale online flow unit tests with `npm test -- --runInBand test/poolRoyaleOnlineFlow.test.js`. 
- All tests in that file passed: 7 tests, 7 passed, test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c17bde72248329aefadb274cc140b7)