### PR TITLE
Use TPC account number as canonical lobby identity for matchmaking

### DIFF
--- a/multiplayer-backend/dist/utils/validation.js
+++ b/multiplayer-backend/dist/utils/validation.js
@@ -2,6 +2,7 @@ import { z } from 'zod';
 export const queueJoinSchema = z.object({
     gameMode: z.string().min(2).max(32),
     region: z.string().min(2).max(16).optional(),
+    tpcAccountNumber: z.string().min(2).max(64).optional(),
 });
 export const roomCreateSchema = z.object({
     isPrivate: z.boolean(),

--- a/multiplayer-backend/dist/ws/socketAuth.js
+++ b/multiplayer-backend/dist/ws/socketAuth.js
@@ -1,11 +1,14 @@
 export function extractSocketUser(socket) {
     const token = socket.handshake.auth.token;
+    const authTPC = socket.handshake.auth.tpcAccountNumber;
     if (!token) {
         return null;
     }
-    const [id, username] = token.split(':');
+    const [id, username, tokenTPC] = token.split(':');
     if (!id || !username) {
         return null;
     }
-    return { id, username };
+    const tpcAccountNumber = authTPC || tokenTPC;
+    const canonicalUserId = tpcAccountNumber || id;
+    return { id, canonicalUserId, username, tpcAccountNumber };
 }

--- a/multiplayer-backend/dist/ws/socketGateway.js
+++ b/multiplayer-backend/dist/ws/socketGateway.js
@@ -37,13 +37,13 @@ export function createRealtimeServer(app) {
     });
     io.on('connection', async (socket) => {
         const user = socket.data.user;
-        sessions.setSocket(user.id, socket.id);
-        await upsertUser(user.id, user.username);
-        await logConnectionEvent({ userId: user.id, socketId: socket.id, event: 'connected' });
-        socket.emit('player:connect', { userId: user.id, socketId: socket.id });
-        const room = roomService.getRoomByUser(user.id);
+        sessions.setSocket(user.canonicalUserId, socket.id);
+        await upsertUser(user.canonicalUserId, user.username);
+        await logConnectionEvent({ userId: user.canonicalUserId, socketId: socket.id, event: 'connected', metadata: user.tpcAccountNumber ? { tpcAccountNumber: user.tpcAccountNumber, providerUserId: user.id } : undefined });
+        socket.emit('player:connect', { userId: user.canonicalUserId, socketId: socket.id });
+        const room = roomService.getRoomByUser(user.canonicalUserId);
         if (room) {
-            socket.emit('player:reconnect', { userId: user.id, matchId: room.matchId });
+            socket.emit('player:reconnect', { userId: user.canonicalUserId, matchId: room.matchId });
         }
         socket.on('player:queue_join', async (payload) => {
             const parsed = queueJoinSchema.safeParse(payload);
@@ -52,14 +52,15 @@ export function createRealtimeServer(app) {
                 return;
             }
             const queueEntry = {
-                userId: user.id,
+                userId: user.canonicalUserId,
                 username: user.username,
                 gameMode: parsed.data.gameMode,
                 region: parsed.data.region,
                 joinedAt: Date.now(),
+                tpcAccountNumber: parsed.data.tpcAccountNumber ?? user.tpcAccountNumber,
             };
             await matchmaking.joinQueue(queueEntry);
-            const pair = await matchmaking.popMatchPair(user.id);
+            const pair = await matchmaking.popMatchPair(user.canonicalUserId);
             if (!pair) {
                 return;
             }
@@ -109,7 +110,7 @@ export function createRealtimeServer(app) {
             });
         });
         socket.on('player:queue_leave', async () => {
-            await matchmaking.leaveQueue(user.id);
+            await matchmaking.leaveQueue(user.canonicalUserId);
         });
         socket.on('room:create', async (payload) => {
             const parsed = roomCreateSchema.safeParse(payload);
@@ -120,10 +121,10 @@ export function createRealtimeServer(app) {
             const dbMatch = await createMatch({
                 roomCode: `PR-${Date.now().toString().slice(-6)}`,
                 isPrivate: parsed.data.isPrivate,
-                createdByUser: user.id,
-                players: [{ userId: user.id, role: 'host' }],
+                createdByUser: user.canonicalUserId,
+                players: [{ userId: user.canonicalUserId, role: 'host' }],
             });
-            const created = roomService.createRoom(user.id, parsed.data.isPrivate, dbMatch.id);
+            const created = roomService.createRoom(user.canonicalUserId, parsed.data.isPrivate, dbMatch.id);
             socket.join(created.roomCode);
             socket.emit('match:found', { matchId: dbMatch.id, roomCode: created.roomCode, opponentUserId: '' });
         });
@@ -133,7 +134,7 @@ export function createRealtimeServer(app) {
                 socket.emit('error', { code: 'ROOM_JOIN_INVALID', message: 'Invalid room:join payload' });
                 return;
             }
-            const joined = roomService.joinRoom(user.id, parsed.data.roomCode);
+            const joined = roomService.joinRoom(user.canonicalUserId, parsed.data.roomCode);
             if (!joined) {
                 socket.emit('error', { code: 'ROOM_JOIN_FAILED', message: 'Room unavailable' });
                 return;
@@ -144,7 +145,7 @@ export function createRealtimeServer(app) {
             io.to(joined.roomCode).emit('match:start', { matchId: joined.matchId, initialState: state });
         });
         socket.on('room:leave', () => {
-            const leftRoom = roomService.leaveRoom(user.id);
+            const leftRoom = roomService.leaveRoom(user.canonicalUserId);
             if (leftRoom) {
                 socket.leave(leftRoom.roomCode);
             }
@@ -156,14 +157,14 @@ export function createRealtimeServer(app) {
                 return;
             }
             const state = stateService.getState(parsed.data.matchId);
-            const result = validator.validateAction(parsed.data, state, user.id);
+            const result = validator.validateAction(parsed.data, state, user.canonicalUserId);
             if (!result.valid) {
                 socket.emit('match:validated_action', { matchId: parsed.data.matchId, tick: parsed.data.tick, accepted: false });
                 return;
             }
             try {
-                const updatedState = stateService.applyValidatedAction(parsed.data, user.id);
-                const room = roomService.getRoomByUser(user.id);
+                const updatedState = stateService.applyValidatedAction(parsed.data, user.canonicalUserId);
+                const room = roomService.getRoomByUser(user.canonicalUserId);
                 if (room) {
                     io.to(room.roomCode).emit('match:state_update', updatedState);
                 }
@@ -179,7 +180,7 @@ export function createRealtimeServer(app) {
                 socket.emit('error', { code: 'MATCH_END_INVALID', message: 'Invalid match result payload' });
                 return;
             }
-            const room = roomService.getRoomByUser(user.id);
+            const room = roomService.getRoomByUser(user.canonicalUserId);
             if (!room || room.matchId !== parsed.data.matchId) {
                 socket.emit('error', { code: 'MATCH_END_SPOOFED', message: 'You are not in this match' });
                 return;
@@ -201,14 +202,14 @@ export function createRealtimeServer(app) {
             socket.emit('match:validated_action', { matchId: 'heartbeat', tick: Date.now(), accepted: true });
         });
         socket.on('disconnect', async () => {
-            sessions.removeSocket(user.id);
-            await matchmaking.leaveQueue(user.id);
-            await logConnectionEvent({ userId: user.id, socketId: socket.id, event: 'disconnected' });
-            const activeRoom = roomService.getRoomByUser(user.id);
+            sessions.removeSocket(user.canonicalUserId);
+            await matchmaking.leaveQueue(user.canonicalUserId);
+            await logConnectionEvent({ userId: user.canonicalUserId, socketId: socket.id, event: 'disconnected' });
+            const activeRoom = roomService.getRoomByUser(user.canonicalUserId);
             if (activeRoom) {
-                socket.to(activeRoom.roomCode).emit('player:disconnect', { userId: user.id });
+                socket.to(activeRoom.roomCode).emit('player:disconnect', { userId: user.canonicalUserId });
             }
-            logger.info({ userId: user.id, socketId: socket.id }, 'Socket disconnected');
+            logger.info({ userId: user.canonicalUserId, socketId: socket.id }, 'Socket disconnected');
         });
     });
     return { io, httpServer };

--- a/multiplayer-backend/docs/socket-event-contracts.md
+++ b/multiplayer-backend/docs/socket-event-contracts.md
@@ -1,10 +1,11 @@
 # Socket Event Contracts
 
-Authentication uses `handshake.auth.token` formatted as `userId:username`.
+Authentication uses `handshake.auth.token` formatted as `userId:username` or `userId:username:tpcAccountNumber`.
+When `tpcAccountNumber` is present (either in token or `handshake.auth.tpcAccountNumber`), it becomes the canonical user identity used for lobby tracking, queueing, and room seating.
 
 ## Client -> Server
 - `player:queue_join`
-  - `{ gameMode: string, region?: string }`
+  - `{ gameMode: string, region?: string, tpcAccountNumber?: string }`
 - `player:queue_leave`
   - `void`
 - `room:create`

--- a/multiplayer-backend/src/services/matchmakingService.ts
+++ b/multiplayer-backend/src/services/matchmakingService.ts
@@ -13,6 +13,7 @@ interface RedisLike {
 export interface QueueEntry {
   userId: string;
   username: string;
+  tpcAccountNumber?: string;
   gameMode: string;
   region?: string;
   joinedAt: number;

--- a/multiplayer-backend/src/types/events.ts
+++ b/multiplayer-backend/src/types/events.ts
@@ -8,6 +8,7 @@ export interface SocketUser {
 export interface JoinQueuePayload {
   gameMode: string;
   region?: string;
+  tpcAccountNumber?: string;
 }
 
 export interface RoomCreatePayload {

--- a/multiplayer-backend/src/utils/validation.ts
+++ b/multiplayer-backend/src/utils/validation.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 export const queueJoinSchema = z.object({
   gameMode: z.string().min(2).max(32),
   region: z.string().min(2).max(16).optional(),
+  tpcAccountNumber: z.string().min(2).max(64).optional(),
 });
 
 export const roomCreateSchema = z.object({

--- a/multiplayer-backend/src/ws/socketAuth.ts
+++ b/multiplayer-backend/src/ws/socketAuth.ts
@@ -2,19 +2,25 @@ import type { Socket } from 'socket.io';
 
 export interface SocketAuthUser {
   id: string;
+  canonicalUserId: string;
   username: string;
+  tpcAccountNumber?: string;
 }
 
 export function extractSocketUser(socket: Socket): SocketAuthUser | null {
   const token = socket.handshake.auth.token as string | undefined;
+  const authTPC = socket.handshake.auth.tpcAccountNumber as string | undefined;
   if (!token) {
     return null;
   }
 
-  const [id, username] = token.split(':');
+  const [id, username, tokenTPC] = token.split(':');
   if (!id || !username) {
     return null;
   }
 
-  return { id, username };
+  const tpcAccountNumber = authTPC || tokenTPC;
+  const canonicalUserId = tpcAccountNumber || id;
+
+  return { id, canonicalUserId, username, tpcAccountNumber };
 }

--- a/multiplayer-backend/src/ws/socketGateway.ts
+++ b/multiplayer-backend/src/ws/socketGateway.ts
@@ -43,15 +43,15 @@ export function createRealtimeServer(app: Express) {
   });
 
   io.on('connection', async (socket) => {
-    const user = socket.data.user as { id: string; username: string };
-    sessions.setSocket(user.id, socket.id);
-    await upsertUser(user.id, user.username);
-    await logConnectionEvent({ userId: user.id, socketId: socket.id, event: 'connected' });
+    const user = socket.data.user as { id: string; canonicalUserId: string; username: string; tpcAccountNumber?: string };
+    sessions.setSocket(user.canonicalUserId, socket.id);
+    await upsertUser(user.canonicalUserId, user.username);
+    await logConnectionEvent({ userId: user.canonicalUserId, socketId: socket.id, event: 'connected', metadata: user.tpcAccountNumber ? { tpcAccountNumber: user.tpcAccountNumber, providerUserId: user.id } : undefined });
 
-    socket.emit('player:connect', { userId: user.id, socketId: socket.id });
-    const room = roomService.getRoomByUser(user.id);
+    socket.emit('player:connect', { userId: user.canonicalUserId, socketId: socket.id });
+    const room = roomService.getRoomByUser(user.canonicalUserId);
     if (room) {
-      socket.emit('player:reconnect', { userId: user.id, matchId: room.matchId });
+      socket.emit('player:reconnect', { userId: user.canonicalUserId, matchId: room.matchId });
     }
 
     socket.on('player:queue_join', async (payload) => {
@@ -62,16 +62,17 @@ export function createRealtimeServer(app: Express) {
       }
 
       const queueEntry = {
-        userId: user.id,
+        userId: user.canonicalUserId,
         username: user.username,
         gameMode: parsed.data.gameMode,
         region: parsed.data.region,
         joinedAt: Date.now(),
+        tpcAccountNumber: parsed.data.tpcAccountNumber ?? user.tpcAccountNumber,
       };
 
       await matchmaking.joinQueue(queueEntry);
 
-      const pair = await matchmaking.popMatchPair(user.id);
+      const pair = await matchmaking.popMatchPair(user.canonicalUserId);
       if (!pair) {
         return;
       }
@@ -127,7 +128,7 @@ export function createRealtimeServer(app: Express) {
     });
 
     socket.on('player:queue_leave', async () => {
-      await matchmaking.leaveQueue(user.id);
+      await matchmaking.leaveQueue(user.canonicalUserId);
     });
 
     socket.on('room:create', async (payload) => {
@@ -140,11 +141,11 @@ export function createRealtimeServer(app: Express) {
       const dbMatch = await createMatch({
         roomCode: `PR-${Date.now().toString().slice(-6)}`,
         isPrivate: parsed.data.isPrivate,
-        createdByUser: user.id,
-        players: [{ userId: user.id, role: 'host' }],
+        createdByUser: user.canonicalUserId,
+        players: [{ userId: user.canonicalUserId, role: 'host' }],
       });
 
-      const created = roomService.createRoom(user.id, parsed.data.isPrivate, dbMatch.id);
+      const created = roomService.createRoom(user.canonicalUserId, parsed.data.isPrivate, dbMatch.id);
       socket.join(created.roomCode);
       socket.emit('match:found', { matchId: dbMatch.id, roomCode: created.roomCode, opponentUserId: '' });
     });
@@ -156,7 +157,7 @@ export function createRealtimeServer(app: Express) {
         return;
       }
 
-      const joined = roomService.joinRoom(user.id, parsed.data.roomCode);
+      const joined = roomService.joinRoom(user.canonicalUserId, parsed.data.roomCode);
       if (!joined) {
         socket.emit('error', { code: 'ROOM_JOIN_FAILED', message: 'Room unavailable' });
         return;
@@ -169,7 +170,7 @@ export function createRealtimeServer(app: Express) {
     });
 
     socket.on('room:leave', () => {
-      const leftRoom = roomService.leaveRoom(user.id);
+      const leftRoom = roomService.leaveRoom(user.canonicalUserId);
       if (leftRoom) {
         socket.leave(leftRoom.roomCode);
       }
@@ -183,15 +184,15 @@ export function createRealtimeServer(app: Express) {
       }
 
       const state = stateService.getState(parsed.data.matchId);
-      const result = validator.validateAction(parsed.data, state, user.id);
+      const result = validator.validateAction(parsed.data, state, user.canonicalUserId);
       if (!result.valid) {
         socket.emit('match:validated_action', { matchId: parsed.data.matchId, tick: parsed.data.tick, accepted: false });
         return;
       }
 
       try {
-        const updatedState = stateService.applyValidatedAction(parsed.data, user.id);
-        const room = roomService.getRoomByUser(user.id);
+        const updatedState = stateService.applyValidatedAction(parsed.data, user.canonicalUserId);
+        const room = roomService.getRoomByUser(user.canonicalUserId);
         if (room) {
           io.to(room.roomCode).emit('match:state_update', updatedState);
         }
@@ -208,7 +209,7 @@ export function createRealtimeServer(app: Express) {
         return;
       }
 
-      const room = roomService.getRoomByUser(user.id);
+      const room = roomService.getRoomByUser(user.canonicalUserId);
       if (!room || room.matchId !== parsed.data.matchId) {
         socket.emit('error', { code: 'MATCH_END_SPOOFED', message: 'You are not in this match' });
         return;
@@ -234,15 +235,15 @@ export function createRealtimeServer(app: Express) {
     });
 
     socket.on('disconnect', async () => {
-      sessions.removeSocket(user.id);
-      await matchmaking.leaveQueue(user.id);
-      await logConnectionEvent({ userId: user.id, socketId: socket.id, event: 'disconnected' });
+      sessions.removeSocket(user.canonicalUserId);
+      await matchmaking.leaveQueue(user.canonicalUserId);
+      await logConnectionEvent({ userId: user.canonicalUserId, socketId: socket.id, event: 'disconnected' });
 
-      const activeRoom = roomService.getRoomByUser(user.id);
+      const activeRoom = roomService.getRoomByUser(user.canonicalUserId);
       if (activeRoom) {
-        socket.to(activeRoom.roomCode).emit('player:disconnect', { userId: user.id });
+        socket.to(activeRoom.roomCode).emit('player:disconnect', { userId: user.canonicalUserId });
       }
-      logger.info({ userId: user.id, socketId: socket.id }, 'Socket disconnected');
+      logger.info({ userId: user.canonicalUserId, socketId: socket.id }, 'Socket disconnected');
     });
   });
 

--- a/multiplayer-backend/tests/socketAuth.test.ts
+++ b/multiplayer-backend/tests/socketAuth.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { extractSocketUser } from '../src/ws/socketAuth.js';
+
+describe('extractSocketUser', () => {
+  it('uses tpc account number from token as canonical identity', () => {
+    const socket = {
+      handshake: {
+        auth: {
+          token: 'telegram-123:alice:TPC-999',
+        },
+      },
+    } as any;
+
+    const user = extractSocketUser(socket);
+    expect(user).toEqual({
+      id: 'telegram-123',
+      canonicalUserId: 'TPC-999',
+      username: 'alice',
+      tpcAccountNumber: 'TPC-999',
+    });
+  });
+
+  it('prefers explicit handshake tpc account number when provided', () => {
+    const socket = {
+      handshake: {
+        auth: {
+          token: 'google-456:bob',
+          tpcAccountNumber: 'TPC-888',
+        },
+      },
+    } as any;
+
+    const user = extractSocketUser(socket);
+    expect(user?.canonicalUserId).toBe('TPC-888');
+  });
+
+  it('falls back to provider identity if tpc account number is absent', () => {
+    const socket = {
+      handshake: {
+        auth: {
+          token: 'google-456:bob',
+        },
+      },
+    } as any;
+
+    const user = extractSocketUser(socket);
+    expect(user?.canonicalUserId).toBe('google-456');
+  });
+});


### PR DESCRIPTION
### Motivation

- Different login providers were creating multiple lobby identities for the same human user, breaking matchmaking and seating when users share a TPC account number. 
- The change makes the backend treat the TPC account number as the canonical identity so Telegram/Google provider IDs map to one lobby identity when the same TPC is present.

### Description

- Added parsing in `extractSocketUser` to accept `userId:username:tpcAccountNumber` (or `handshake.auth.tpcAccountNumber`) and return a `canonicalUserId` that prefers the TPC account number over the provider ID. 
- Switched realtime gateway flows in `socketGateway` to use `canonicalUserId` for session tracking, queue join/leave, matchmaking lookup, room create/join/leave, reconnect/disconnect notifications and action validation. 
- Extended the queue payload and types to accept and store `tpcAccountNumber` (`player:queue_join` validation in `utils/validation.ts` and `types/events.ts`) and added `tpcAccountNumber` to `QueueEntry` metadata in `MatchmakingService`. 
- Updated documentation `docs/socket-event-contracts.md` to record the new token/auth formats and queue contract, and added unit tests for `extractSocketUser` covering token TPC, handshake override, and fallback behavior.

### Testing

- Ran unit tests with `cd multiplayer-backend && npm test` and all tests passed (`3 files, 8 tests, 8 passed`).
- Built the backend with `cd multiplayer-backend && npm run build` and TypeScript compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c17cda3ee8832989505e301b590603)