### PR TITLE
Fix Chess Battle Royal lobby getting stuck at "Connecting to lobby"

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyalLobby.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyalLobby.jsx
@@ -5,6 +5,7 @@ import FlagPickerModal from '../../components/FlagPickerModal.jsx';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 import {
   ensureAccountId,
+  getTpcAccountId,
   getTelegramId,
   getTelegramFirstName,
   getTelegramPhotoUrl,
@@ -13,7 +14,7 @@ import {
 import { getAccountBalance, addTransaction, getOnlineCount } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
 import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
-import { socket } from '../../utils/socket.js';
+import { socket, refreshSocketAuthIdentity } from '../../utils/socket.js';
 import OptionIcon from '../../components/OptionIcon.jsx';
 import { getLobbyIcon } from '../../config/gameAssets.js';
 import GameLobbyHeader from '../../components/GameLobbyHeader.jsx';
@@ -22,6 +23,64 @@ const DEV_ACCOUNT = import.meta.env.VITE_DEV_ACCOUNT_ID;
 const DEV_ACCOUNT_1 = import.meta.env.VITE_DEV_ACCOUNT_ID_1;
 const DEV_ACCOUNT_2 = import.meta.env.VITE_DEV_ACCOUNT_ID_2;
 const AI_FLAG_STORAGE_KEY = 'chessBattleRoyalAiFlag';
+const SOCKET_CONNECT_TIMEOUT_MS = 6000;
+const SOCKET_REGISTER_TIMEOUT_MS = 6000;
+
+async function ensureSocketConnected(timeoutMs = SOCKET_CONNECT_TIMEOUT_MS) {
+  if (socket.connected) return true;
+
+  return new Promise((resolve) => {
+    let settled = false;
+
+    const cleanup = () => {
+      socket.off('connect', handleConnect);
+      socket.off('connect_error', handleError);
+      socket.off('error', handleError);
+    };
+
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      cleanup();
+      resolve(result);
+    };
+
+    const handleConnect = () => finish(true);
+    const handleError = () => finish(false);
+
+    const timer = setTimeout(() => finish(socket.connected), timeoutMs);
+    socket.once('connect', handleConnect);
+    socket.once('connect_error', handleError);
+    socket.once('error', handleError);
+    socket.connect?.();
+  });
+}
+
+async function ensureSocketRegistered(accountId, timeoutMs = SOCKET_REGISTER_TIMEOUT_MS) {
+  if (!accountId) return false;
+  return new Promise((resolve) => {
+    let settled = false;
+
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      resolve(false);
+    }, timeoutMs);
+
+    try {
+      socket.emit('register', { playerId: accountId }, (res) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve(Boolean(res?.success));
+      });
+    } catch {
+      clearTimeout(timer);
+      resolve(false);
+    }
+  });
+}
 
 export default function ChessBattleRoyalLobby() {
   const navigate = useNavigate();
@@ -189,9 +248,33 @@ export default function ChessBattleRoyalLobby() {
     setMatching(true);
     setMatchStatus('Connecting to lobby…');
 
+    if (trackedAccountId) {
+      refreshSocketAuthIdentity(
+        { accountId: String(trackedAccountId) },
+        { reconnect: true }
+      );
+    }
+
+    const socketReady = await ensureSocketConnected();
+    if (!socketReady) {
+      setMatchError('Lobby connection failed. Check your network and try again.');
+      setMatching(false);
+      setMatchStatus('');
+      return;
+    }
+
+    const seatAccountId = getTpcAccountId() || trackedAccountId || accountId;
+    const socketRegistered = await ensureSocketRegistered(seatAccountId);
+    if (!socketRegistered) {
+      setMatchError('Unable to sync your online session. Please retry.');
+      setMatching(false);
+      setMatchStatus('');
+      return;
+    }
+
     const handleLobbyUpdate = ({ tableId: tid, players: list = [] } = {}) => {
       if (!tid || tid !== pendingTableRef.current) return;
-      const others = list.filter((p) => String(p.id) !== String(trackedAccountId || accountId));
+      const others = list.filter((p) => String(p.id) !== String(seatAccountId));
       if (others.length > 0) {
         setMatchStatus('Opponent joined. Locking seats…');
       } else {
@@ -201,10 +284,10 @@ export default function ChessBattleRoyalLobby() {
 
     const handleGameStart = ({ tableId: startedId, players = [] } = {}) => {
       if (!startedId || startedId !== pendingTableRef.current) return;
-      const meIndex = players.findIndex((p) => String(p.id) === String(trackedAccountId || accountId));
-      const opp = players.find((p) => String(p.id) !== String(trackedAccountId || accountId));
+      const meIndex = players.findIndex((p) => String(p.id) === String(seatAccountId));
+      const opp = players.find((p) => String(p.id) !== String(seatAccountId));
       const mySide =
-        players.find((p) => String(p.id) === String(trackedAccountId || accountId))?.side ||
+        players.find((p) => String(p.id) === String(seatAccountId))?.side ||
         (meIndex === 0 ? 'white' : 'black');
       cleanupLobby({ account: trackedAccountId });
       navigateToGame({
@@ -221,16 +304,18 @@ export default function ChessBattleRoyalLobby() {
 
     socket.on('gameStart', handleGameStart);
     socket.on('lobbyUpdate', handleLobbyUpdate);
-    socket.emit('register', { playerId: trackedAccountId });
 
     const friendlyName = getTelegramFirstName() || getTelegramUsername() || 'Player';
     socket.emit(
       'seatTable',
       {
         accountId: trackedAccountId || accountId,
+        tpcAccountId: seatAccountId,
         gameType: 'chess',
         stake: stake.amount ?? 0,
         maxPlayers: 2,
+        mode: 'online',
+        token: stake.token,
         playerName: friendlyName,
         avatar,
         preferredSide
@@ -244,7 +329,8 @@ export default function ChessBattleRoyalLobby() {
         pendingTableRef.current = res.tableId;
         setMatchStatus('Waiting for another player…');
         socket.emit('confirmReady', {
-          accountId: trackedAccountId,
+          accountId: seatAccountId,
+          tpcAccountId: seatAccountId,
           tableId: res.tableId
         });
       }


### PR DESCRIPTION
### Motivation
- Prevent players from stalling on the Chess Battle Royal lobby "Connecting to lobby…" state caused by unreliable Socket.IO connection/registration and identity mismatches.
- Make the chess lobby matchmaking flow consistent with other battle-royal lobbies which already guard socket readiness and registration.

### Description
- Added `ensureSocketConnected` and `ensureSocketRegistered` helpers to explicitly wait for a working socket connection and a successful `register` handshake before attempting to seat the player.
- Synced socket auth prior to matchmaking via `refreshSocketAuthIdentity` to avoid silent identity mismatches between the client and server session.
- Use a unified seating identity `seatAccountId` (from `getTpcAccountId()` / tracked account / local account) when emitting `seatTable` and `confirmReady` and when resolving players on `lobbyUpdate` / `gameStart` callbacks. 
- Included `mode: 'online'` and `token` in the `seatTable` payload to match backend matchmaking metadata expectations and added `tpcAccountId` to payloads for consistent server-side identity resolution. Changes are in `webapp/src/pages/Games/ChessBattleRoyalLobby.jsx`.

### Testing
- Ran policy unit tests with `npx jest test/onlineGamePolicy.test.js --runInBand`, and they passed (all tests green). 
- Ran ESLint on the modified file via `npx eslint webapp/src/pages/Games/ChessBattleRoyalLobby.jsx`; linter reported a repository ignore warning for the file (no blocking errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c17e55a3388329ba58bc7b17c18d27)