### PR TITLE
Use TPC account number as primary online lobby identity

### DIFF
--- a/bot/models/User.js
+++ b/bot/models/User.js
@@ -68,6 +68,7 @@ const userSchema = new mongoose.Schema({
 
 
   accountId: { type: String, unique: true },
+  tpcAccountNumber: { type: String, unique: true, sparse: true },
 
   createdAt: { type: Date, default: Date.now },
 
@@ -166,6 +167,12 @@ userSchema.pre('save', function(next) {
   }
   if (!this.accountId) {
     this.accountId = uuidv4();
+  }
+  if (!this.tpcAccountNumber && this.accountId) {
+    this.tpcAccountNumber = String(this.accountId);
+  }
+  if (!this.accountId && this.tpcAccountNumber) {
+    this.accountId = String(this.tpcAccountNumber);
   }
   next();
 });

--- a/bot/routes/online.js
+++ b/bot/routes/online.js
@@ -5,9 +5,9 @@ import { buildReadinessSnapshot } from '../config/onlineGamePolicy.js';
 const router = Router();
 
 router.post('/ping', async (req, res) => {
-  const { playerId, accountId, roomId, status } = req.body || {};
-  const id = playerId || accountId;
-  if (!id) return res.status(400).json({ error: 'playerId required' });
+  const { playerId, accountId, tpcAccountId, tpcAccountNumber, roomId, status } = req.body || {};
+  const id = tpcAccountNumber || tpcAccountId || accountId || playerId;
+  if (!id) return res.status(400).json({ error: 'tpcAccountNumber required' });
   await ping({ userId: String(id), roomId: roomId || null, status: status || 'online' });
   res.json({ success: true });
 });

--- a/bot/routes/profile.js
+++ b/bot/routes/profile.js
@@ -139,8 +139,11 @@ router.post('/get', async (req, res) => {
 
   if (!user.accountId) {
     user.accountId = uuidv4();
-    await user.save();
   }
+  if (!user.tpcAccountNumber) {
+    user.tpcAccountNumber = String(user.accountId);
+  }
+  await user.save();
 
 
   ensureTransactionArray(user);
@@ -162,6 +165,7 @@ router.post('/get', async (req, res) => {
 
   return res.json({
     accountId: user.accountId,
+    tpcAccountNumber: user.tpcAccountNumber || user.accountId,
     nickname: user.nickname,
     firstName: user.firstName,
     lastName: user.lastName,

--- a/bot/server.js
+++ b/bot/server.js
@@ -528,10 +528,33 @@ function isRateLimited(socket, key, cooldownMs) {
   return false;
 }
 
-function ensureRegistered(socket, accountId) {
+function resolveTpcIdentity(payload = {}) {
+  const tpcAccountNumber = String(
+    payload?.tpcAccountNumber ||
+      payload?.tpcAccountId ||
+      payload?.accountId ||
+      payload?.playerId ||
+      ''
+  ).trim();
+  return tpcAccountNumber;
+}
+
+function hasConflictingIdentities(payload = {}) {
+  const ids = [
+    payload?.tpcAccountNumber,
+    payload?.tpcAccountId,
+    payload?.accountId,
+    payload?.playerId
+  ]
+    .map((id) => String(id || '').trim())
+    .filter(Boolean);
+  return new Set(ids).size > 1;
+}
+
+function ensureRegistered(socket, tpcAccountNumber) {
   let registered = socket.data?.playerId;
-  if (!registered && accountId) {
-    registered = String(accountId);
+  if (!registered && tpcAccountNumber) {
+    registered = String(tpcAccountNumber);
     socket.data.playerId = registered;
     let set = userSockets.get(registered);
     if (!set) {
@@ -547,7 +570,7 @@ function ensureRegistered(socket, accountId) {
     socket.emit('errorMessage', 'register_required');
     return false;
   }
-  if (accountId && String(accountId) !== String(registered)) {
+  if (tpcAccountNumber && String(tpcAccountNumber) !== String(registered)) {
     socket.emit('errorMessage', 'identity_mismatch');
     return false;
   }
@@ -1356,8 +1379,8 @@ app.post('/api/admin/accounts/cleanup-fake', authenticate, async (req, res) => {
 });
 
 app.post('/api/snake/table/seat', (req, res) => {
-  const { tableId, playerId, accountId, name, avatar } = req.body || {};
-  const pid = playerId || accountId;
+  const { tableId, name, avatar } = req.body || {};
+  const pid = resolveTpcIdentity(req.body || {});
   if (!tableId || !pid) return res.status(400).json({ error: 'missing data' });
   const [gameType, capStr] = tableId.split('-');
   seatTableSocket(
@@ -1376,8 +1399,8 @@ app.post('/api/snake/table/seat', (req, res) => {
 });
 
 app.post('/api/snake/table/unseat', (req, res) => {
-  const { tableId, playerId, accountId } = req.body || {};
-  const pid = playerId || accountId;
+  const { tableId } = req.body || {};
+  const pid = resolveTpcIdentity(req.body || {});
   unseatTableSocket(pid, tableId);
   res.json({ success: true });
 });
@@ -1624,10 +1647,14 @@ function removeSocketFromLiveChat(socket) {
 }
 
 io.on('connection', (socket) => {
-  socket.on('register', async ({ playerId, accountId, tpcAccountId } = {}, cb) => {
-    const resolvedPlayerId = playerId || tpcAccountId || accountId;
+  socket.on('register', async (payload = {}, cb) => {
+    const resolvedPlayerId = resolveTpcIdentity(payload);
     if (!resolvedPlayerId) {
       cb && cb({ success: false, error: 'missing_player_id' });
+      return;
+    }
+    if (hasConflictingIdentities(payload)) {
+      cb && cb({ success: false, error: 'identity_mismatch' });
       return;
     }
     try {
@@ -1660,9 +1687,10 @@ io.on('connection', (socket) => {
   socket.on(
     'seatTable',
     async (
-      {
-        accountId,
-        tpcAccountId,
+      payload = {},
+      cb
+    ) => {
+      const {
         gameType,
         stake,
         maxPlayers = 4,
@@ -1676,10 +1704,11 @@ io.on('connection', (socket) => {
         tableSize,
         ballSet,
         token
-      },
-      cb
-    ) => {
-      const resolvedAccountId = tpcAccountId || accountId;
+      } = payload;
+      const resolvedAccountId = resolveTpcIdentity(payload);
+      if (hasConflictingIdentities(payload)) {
+        return cb && cb({ success: false, error: 'identity_mismatch' });
+      }
       if (!ensureRegistered(socket, resolvedAccountId)) {
         const error =
           resolvedAccountId &&
@@ -1757,15 +1786,21 @@ io.on('connection', (socket) => {
     }
   );
 
-  socket.on('leaveLobby', ({ accountId, tpcAccountId, tableId }) => {
-    const resolvedAccountId = tpcAccountId || accountId;
+  socket.on('leaveLobby', (payload = {}) => {
+    const { tableId } = payload;
+    const resolvedAccountId = resolveTpcIdentity(payload);
     if (tableId) {
       unseatTableSocket(resolvedAccountId, tableId, socket.id);
     }
   });
 
-  socket.on('confirmReady', ({ accountId, tpcAccountId, tableId }) => {
-    const resolvedAccountId = tpcAccountId || accountId;
+  socket.on('confirmReady', (payload = {}) => {
+    const { tableId } = payload;
+    const resolvedAccountId = resolveTpcIdentity(payload);
+    if (hasConflictingIdentities(payload)) {
+      socket.emit('errorMessage', 'identity_mismatch');
+      return;
+    }
     const table = tableMap.get(tableId);
     if (!table) {
       socket.emit('errorMessage', 'table_not_found');
@@ -1788,8 +1823,13 @@ io.on('connection', (socket) => {
     maybeStartGame(table);
   });
 
-  socket.on('joinRoom', async ({ roomId, playerId, accountId, tpcAccountId, name, avatar }) => {
-    const pid = tpcAccountId || playerId || accountId;
+  socket.on('joinRoom', async (payload = {}) => {
+    const { roomId, name, avatar } = payload;
+    const pid = resolveTpcIdentity(payload);
+    if (hasConflictingIdentities(payload)) {
+      socket.emit('errorMessage', 'identity_mismatch');
+      return;
+    }
     const map = tableSeats.get(roomId);
     const cap = Number(roomId.split('-')[1]) || 4;
     if (!gameManager.rooms.has(roomId) && map && map.size < cap) {

--- a/bot/utils/userUtils.js
+++ b/bot/utils/userUtils.js
@@ -43,6 +43,7 @@ export function sanitizeUser(user) {
   if (!user) return null;
   return {
     accountId: user.accountId,
+    tpcAccountNumber: user.tpcAccountNumber || user.accountId,
     walletAddress: user.walletAddress,
     walletPublicKey: user.walletPublicKey,
     nickname: user.nickname,

--- a/webapp/src/hooks/useOnlineRoomSync.js
+++ b/webapp/src/hooks/useOnlineRoomSync.js
@@ -17,23 +17,22 @@ export default function useOnlineRoomSync(search = '', fallbackName = 'Player') 
         accountId = (await ensureAccountId().catch(() => '')) || '';
       }
       if (cancelled || !accountId) return;
-      socket.emit('register', { playerId: accountId, tpcAccountId: accountId });
+      socket.emit('register', { tpcAccountNumber: accountId });
       socket.emit('joinRoom', {
         roomId: tableId,
-        playerId: accountId,
-        accountId,
+        tpcAccountNumber: accountId,
         tpcAccountId: accountId,
         name: params.get('username') || getTelegramUsername() || fallbackName,
         avatar: params.get('avatar') || '',
       });
-      socket.emit('confirmReady', { accountId, tpcAccountId: accountId, tableId });
+      socket.emit('confirmReady', { tpcAccountNumber: accountId, tpcAccountId: accountId, tableId });
     };
 
     sync().catch(() => {});
 
     return () => {
       cancelled = true;
-      if (accountId) socket.emit('leaveLobby', { accountId, tpcAccountId: accountId, tableId });
+      if (accountId) socket.emit('leaveLobby', { tpcAccountNumber: accountId, tpcAccountId: accountId, tableId });
     };
   }, [search, fallbackName]);
 }

--- a/webapp/src/hooks/useTelegramAuth.js
+++ b/webapp/src/hooks/useTelegramAuth.js
@@ -22,14 +22,14 @@ export default function useTelegramAuth() {
     const acc = localStorage.getItem('accountId');
     if (user?.id) {
       localStorage.setItem('telegramId', user.id);
-      socket.emit('register', { playerId: acc || user.id });
+      socket.emit('register', { tpcAccountNumber: acc || user.id });
       createAccount(user.id).catch(err => {
         console.error('Failed to create account', err);
       });
     } else {
       (async () => {
         const accountId = acc || (await ensureAccountId());
-        socket.emit('register', { playerId: accountId });
+        socket.emit('register', { tpcAccountNumber: accountId });
         try {
           const res = await createAccount(undefined, googleProfile);
           if (res?.accountId) {

--- a/webapp/src/pages/Games/poolRoyaleOnlineFlow.js
+++ b/webapp/src/pages/Games/poolRoyaleOnlineFlow.js
@@ -109,7 +109,7 @@ async function ensureSocketRegistered(
     }, timeoutMs);
 
     try {
-      socketInstance.emit('register', { playerId: accountId, tpcAccountId: accountId }, (res) => {
+      socketInstance.emit('register', { tpcAccountNumber: accountId, tpcAccountId: accountId }, (res) => {
         if (settled) return;
         settled = true;
         clearTimeout(timer);
@@ -322,7 +322,7 @@ export async function runPoolRoyaleOnlineFlow({
     socketInstance.off('gameStart', handleGameStart);
     if (pendingTableRef.current && account) {
       socketInstance.emit('leaveLobby', {
-        accountId: account,
+        tpcAccountNumber: account,
         tpcAccountId: account,
         tableId: pendingTableRef.current
       });
@@ -391,6 +391,7 @@ export async function runPoolRoyaleOnlineFlow({
       'seatTable',
       {
         accountId,
+        tpcAccountNumber: accountId,
         tpcAccountId: accountId,
         stake: stake.amount,
         token: stake.token,
@@ -456,7 +457,7 @@ export async function runPoolRoyaleOnlineFlow({
         matchPlayersRef.current = playersList;
         setReadyList(res.ready || []);
         socketInstance.emit('confirmReady', {
-          accountId,
+          tpcAccountNumber: accountId,
           tpcAccountId: accountId,
           tableId: res.tableId
         });

--- a/webapp/src/utils/api.js
+++ b/webapp/src/utils/api.js
@@ -466,16 +466,16 @@ export function getSnakeResults() {
   return get('/api/snake/results');
 }
 
-export function seatTable(playerId, tableId, name) {
-  return post('/api/snake/table/seat', { playerId, tableId, name });
+export function seatTable(tpcAccountNumber, tableId, name) {
+  return post('/api/snake/table/seat', { tpcAccountNumber, tableId, name });
 }
 
-export function unseatTable(playerId, tableId) {
-  return post('/api/snake/table/unseat', { playerId, tableId });
+export function unseatTable(tpcAccountNumber, tableId) {
+  return post('/api/snake/table/unseat', { tpcAccountNumber, tableId });
 }
 
-export function pingOnline(playerId, status) {
-  return post('/api/online/ping', { playerId, status });
+export function pingOnline(tpcAccountNumber, status) {
+  return post('/api/online/ping', { tpcAccountNumber, status });
 }
 
 export function registerPushToken({ token, platform, accountId, telegramId }) {


### PR DESCRIPTION
### Motivation

- Ensure every player is tracked by a single, stable TPC account number in online lobbies to avoid mixed-identity conflicts and mismatched seats. 
- Provide a consistent client/server contract so lobby/socket flows, REST endpoints and persisted user profiles use the same unique identifier.

### Description

- Added `tpcAccountNumber` to the `User` model and a `pre('save')` sync so `tpcAccountNumber` and `accountId` are populated and kept consistent. 
- Exposed `tpcAccountNumber` in sanitized/profile responses and backfilled it in `/api/profile/get` when missing. 
- Introduced `resolveTpcIdentity` and `hasConflictingIdentities` helpers and updated socket server logic to use TPC-first identity resolution and reject conflicting identity payloads. 
- Updated REST/socket flows (register, seatTable, joinRoom, confirmReady, leaveLobby, ping) and frontend emits/helpers to consistently send `tpcAccountNumber` (Pool Royale online flow, shared hooks and API helpers). 

### Testing

- Performed static runtime checks with `node --check` across modified server and frontend files (`bot/server.js`, `bot/routes/profile.js`, `bot/routes/online.js`, `bot/models/User.js`, `bot/utils/userUtils.js`, `webapp/src/hooks/useOnlineRoomSync.js`, `webapp/src/hooks/useTelegramAuth.js`, `webapp/src/pages/Games/poolRoyaleOnlineFlow.js`, and `webapp/src/utils/api.js`) and they all passed. 
- Verified basic behavior locally by inspecting updated socket emit/handler paths and ensuring no syntax errors during the commit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c180b31b708329803dddfd1e1a524e)