### PR TITLE
Normalize TPC (accountId) identity for lobby seating and matchmaking

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -66,6 +66,7 @@ import {
 } from './config/onlineGamePolicy.js';
 import { createCheckersRealtimeStore } from './utils/checkersRealtimeState.js';
 import { applyAuthoritativeMove, SIDES } from './utils/checkersAuthoritativeEngine.js';
+import { findMemoryUser } from './utils/memoryUserStore.js';
 
 validateEnv();
 
@@ -526,6 +527,78 @@ function isRateLimited(socket, key, cooldownMs) {
   map[key] = now;
   lastActionBySocket.set(socket.id, map);
   return false;
+}
+
+async function resolveTpcAccountId(
+  socket,
+  { accountId, tpcAccountId, playerId } = {}
+) {
+  const normalizedTpc = tpcAccountId ? String(tpcAccountId) : '';
+  if (normalizedTpc) {
+    socket.data.tpcAccountId = normalizedTpc;
+    return normalizedTpc;
+  }
+
+  const authAccountId = socket.data?.auth?.accountId
+    ? String(socket.data.auth.accountId)
+    : '';
+  if (authAccountId) {
+    socket.data.tpcAccountId = authAccountId;
+    return authAccountId;
+  }
+
+  if (socket.data?.tpcAccountId) {
+    return String(socket.data.tpcAccountId);
+  }
+
+  const normalizedAccountId = accountId ? String(accountId) : '';
+  const normalizedPlayerId = playerId ? String(playerId) : '';
+  const identityValue = normalizedAccountId || normalizedPlayerId;
+  const authGoogleId = socket.data?.auth?.googleId
+    ? String(socket.data.auth.googleId)
+    : '';
+  const authTelegramId = Number(socket.data?.auth?.telegramId);
+
+  const queryCandidates = [];
+  if (normalizedAccountId) {
+    queryCandidates.push({ accountId: normalizedAccountId });
+  }
+  if (normalizedPlayerId && normalizedPlayerId !== normalizedAccountId) {
+    queryCandidates.push({ accountId: normalizedPlayerId });
+  }
+  if (authGoogleId) {
+    queryCandidates.push({ googleId: authGoogleId });
+  }
+  if (Number.isFinite(authTelegramId) && authTelegramId > 0) {
+    queryCandidates.push({ telegramId: authTelegramId });
+  }
+  if (identityValue) {
+    const asNumber = Number(identityValue);
+    if (Number.isFinite(asNumber) && asNumber > 0) {
+      queryCandidates.push({ telegramId: asNumber });
+    }
+    queryCandidates.push({ googleId: identityValue });
+  }
+
+  for (const query of queryCandidates) {
+    try {
+      const user = await User.findOne(query, { accountId: 1 }).lean();
+      if (user?.accountId) {
+        socket.data.tpcAccountId = String(user.accountId);
+        return String(user.accountId);
+      }
+    } catch (error) {
+      console.error('resolveTpcAccountId query failed', query, error?.message || error);
+    }
+    const memoryUser = findMemoryUser(query);
+    if (memoryUser?.accountId) {
+      socket.data.tpcAccountId = String(memoryUser.accountId);
+      return String(memoryUser.accountId);
+    }
+  }
+
+  if (identityValue) return identityValue;
+  return '';
 }
 
 function ensureRegistered(socket, accountId) {
@@ -1625,7 +1698,11 @@ function removeSocketFromLiveChat(socket) {
 
 io.on('connection', (socket) => {
   socket.on('register', async ({ playerId, accountId, tpcAccountId } = {}, cb) => {
-    const resolvedPlayerId = playerId || tpcAccountId || accountId;
+    const resolvedPlayerId = await resolveTpcAccountId(socket, {
+      playerId,
+      accountId,
+      tpcAccountId
+    });
     if (!resolvedPlayerId) {
       cb && cb({ success: false, error: 'missing_player_id' });
       return;
@@ -1638,6 +1715,7 @@ io.on('connection', (socket) => {
       }
       set.add(socket.id);
       socket.data.playerId = String(resolvedPlayerId);
+      socket.data.tpcAccountId = String(resolvedPlayerId);
       await registerConnection({ userId: String(resolvedPlayerId), socketId: socket.id });
       cb && cb({ success: true });
     } catch (error) {
@@ -1679,7 +1757,10 @@ io.on('connection', (socket) => {
       },
       cb
     ) => {
-      const resolvedAccountId = tpcAccountId || accountId;
+      const resolvedAccountId = await resolveTpcAccountId(socket, {
+        accountId,
+        tpcAccountId
+      });
       if (!ensureRegistered(socket, resolvedAccountId)) {
         const error =
           resolvedAccountId &&
@@ -1758,14 +1839,22 @@ io.on('connection', (socket) => {
   );
 
   socket.on('leaveLobby', ({ accountId, tpcAccountId, tableId }) => {
-    const resolvedAccountId = tpcAccountId || accountId;
-    if (tableId) {
-      unseatTableSocket(resolvedAccountId, tableId, socket.id);
-    }
+    resolveTpcAccountId(socket, { accountId, tpcAccountId })
+      .then((resolvedAccountId) => {
+        if (tableId) {
+          unseatTableSocket(resolvedAccountId, tableId, socket.id);
+        }
+      })
+      .catch(() => {
+        if (tableId) unseatTableSocket(accountId, tableId, socket.id);
+      });
   });
 
-  socket.on('confirmReady', ({ accountId, tpcAccountId, tableId }) => {
-    const resolvedAccountId = tpcAccountId || accountId;
+  socket.on('confirmReady', async ({ accountId, tpcAccountId, tableId }) => {
+    const resolvedAccountId = await resolveTpcAccountId(socket, {
+      accountId,
+      tpcAccountId
+    });
     const table = tableMap.get(tableId);
     if (!table) {
       socket.emit('errorMessage', 'table_not_found');
@@ -1789,7 +1878,7 @@ io.on('connection', (socket) => {
   });
 
   socket.on('joinRoom', async ({ roomId, playerId, accountId, name, avatar }) => {
-    const pid = playerId || accountId;
+    const pid = await resolveTpcAccountId(socket, { playerId, accountId });
     const map = tableSeats.get(roomId);
     const cap = Number(roomId.split('-')[1]) || 4;
     if (!gameManager.rooms.has(roomId) && map && map.size < cap) {

--- a/test/checkersLobbyTpcIdentityMatchmaking.test.js
+++ b/test/checkersLobbyTpcIdentityMatchmaking.test.js
@@ -1,0 +1,112 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import { spawn } from 'child_process';
+import { io } from 'socket.io-client';
+
+const distDir = new URL('../webapp/dist/', import.meta.url);
+const apiToken = 'test-token';
+
+async function startServer(env) {
+  const server = spawn('node', ['bot/server.js'], { env, stdio: 'pipe' });
+  server.stdout.on('data', (chunk) => process.stdout.write(chunk));
+  server.stderr.on('data', (chunk) => process.stderr.write(chunk));
+  await new Promise((resolve) => {
+    const onData = (chunk) => {
+      if (chunk.toString().includes('Server running on port')) {
+        server.stdout.off('data', onData);
+        resolve();
+      }
+    };
+    server.stdout.on('data', onData);
+  });
+  return server;
+}
+
+test(
+  'checkers lobby resolves Google identity to TPC account id for seat + ready',
+  { concurrency: false, timeout: 20000 },
+  async () => {
+    fs.mkdirSync(new URL('assets', distDir), { recursive: true });
+    fs.writeFileSync(new URL('index.html', distDir), '');
+    const env = {
+      ...process.env,
+      PORT: '3211',
+      MONGO_URI: 'memory',
+      BOT_TOKEN: 'dummy',
+      API_AUTH_TOKEN: apiToken,
+      SKIP_WEBAPP_BUILD: '1',
+      SKIP_BOT_LAUNCH: '1'
+    };
+    const server = await startServer(env);
+
+    const createAccount = async ({ accountId, googleId, firstName }) => {
+      const res = await fetch('http://localhost:3211/api/account/create', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${apiToken}`
+        },
+        body: JSON.stringify({ accountId, googleId, firstName })
+      });
+      assert.equal(res.status, 200);
+    };
+
+    await createAccount({ accountId: 'tpc-google-a', googleId: 'google-a', firstName: 'A' });
+    await createAccount({ accountId: 'tpc-google-b', googleId: 'google-b', firstName: 'B' });
+
+    const s1 = io('http://localhost:3211', { auth: { googleId: 'google-a' } });
+    const s2 = io('http://localhost:3211', { auth: { googleId: 'google-b' } });
+
+    try {
+      await Promise.all([
+        new Promise((resolve) => s1.on('connect', resolve)),
+        new Promise((resolve) => s2.on('connect', resolve))
+      ]);
+
+      const register = (socket, accountId) =>
+        new Promise((resolve) => socket.emit('register', { accountId }, resolve));
+      await Promise.all([register(s1, 'google-a'), register(s2, 'google-b')]);
+
+      const seat = (socket, accountId) =>
+        new Promise((resolve) => {
+          socket.emit(
+            'seatTable',
+            {
+              accountId,
+              gameType: 'checkersbattleroyal',
+              stake: 50,
+              maxPlayers: 2,
+              mode: 'online',
+              token: 'TPC'
+            },
+            resolve
+          );
+        });
+
+      const firstSeat = await seat(s1, 'google-a');
+      const secondSeat = await seat(s2, 'google-b');
+      assert.equal(firstSeat.success, true);
+      assert.equal(secondSeat.success, true);
+      assert.equal(secondSeat.tableId, firstSeat.tableId);
+      assert.ok(firstSeat.players.some((p) => p.id === 'tpc-google-a'));
+      assert.ok(secondSeat.players.some((p) => p.id === 'tpc-google-b'));
+
+      s1.emit('confirmReady', { accountId: 'google-a', tableId: firstSeat.tableId });
+      s2.emit('confirmReady', { accountId: 'google-b', tableId: firstSeat.tableId });
+
+      const [gameStartA, gameStartB] = await Promise.all([
+        new Promise((resolve) => s1.once('gameStart', resolve)),
+        new Promise((resolve) => s2.once('gameStart', resolve))
+      ]);
+      assert.equal(gameStartA.tableId, firstSeat.tableId);
+      assert.equal(gameStartB.tableId, firstSeat.tableId);
+      assert.ok(gameStartA.players.some((p) => p.id === 'tpc-google-a'));
+      assert.ok(gameStartB.players.some((p) => p.id === 'tpc-google-b'));
+    } finally {
+      s1.disconnect();
+      s2.disconnect();
+      server.kill();
+    }
+  }
+);


### PR DESCRIPTION
### Motivation
- Clients sometimes send provider-specific IDs (Telegram/Google) instead of the canonical TPC `accountId`, causing identity_mismatch and seating issues in the online lobby. 
- The lobby seating/ready flow must reliably map any incoming identity to the same server-side TPC account so matched players seat and start games together.

### Description
- Added an async resolver `resolveTpcAccountId(socket, { accountId, tpcAccountId, playerId })` that returns a canonical TPC `accountId` by checking explicit `tpcAccountId`, socket auth hints, cached socket data, DB lookups, and a memory-user fallback. (`bot/server.js`) 
- Updated socket handlers to use resolved TPC identity in `register`, `seatTable`, `leaveLobby`, `confirmReady`, and `joinRoom` flows so seating and readiness checks use the canonical id. (`bot/server.js`) 
- Added `findMemoryUser` fallback usage in the resolver for `MONGO_URI=memory` test/runtime cases. (`bot/server.js`) 
- Added integration test `test/checkersLobbyTpcIdentityMatchmaking.test.js` that creates Google-linked users with known TPC accountIds and verifies register -> seat -> confirmReady -> gameStart flows use TPC ids.

### Testing
- Ran `node --test test/checkersLobbyAliasMatchmaking.test.js test/checkersLobbyTpcIdentityMatchmaking.test.js`; initial run revealed a failing test during development, the resolver was extended to include memory-store fallback and the failing case was fixed. 
- Final run of `node --test test/checkersLobbyAliasMatchmaking.test.js test/checkersLobbyTpcIdentityMatchmaking.test.js` completed with both tests passing (2/2 passing).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c17cda3ee8832989505e301b590603)