### PR TITLE
Only force Pool Royale online tableId when autostart is present

### DIFF
--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -59,6 +59,8 @@ export default function PoolRoyaleLobby() {
   const initialMode = searchParams.get('mode') === 'online' ? 'online' : 'ai';
   const autoStartRequested = searchParams.get('autostart') === '1';
   const requestedOnlineTableId = (searchParams.get('tableId') || '').trim();
+  const forcedOnlineTableId =
+    autoStartRequested && requestedOnlineTableId ? requestedOnlineTableId : '';
 
   const [stake, setStake] = useState({ token: 'TPC', amount: 100 });
   const [mode, setMode] = useState(initialMode);
@@ -219,7 +221,7 @@ export default function PoolRoyaleLobby() {
     if (isOnlineMatch) {
       await runPoolRoyaleOnlineFlow({
         stake,
-        tableId: requestedOnlineTableId || undefined,
+        tableId: forcedOnlineTableId || undefined,
         variant,
         ballSet: ukBallSet,
         playType,


### PR DESCRIPTION
### Motivation
- Prevent players from being seated into different forced tables due to stale `tableId` query params so normal matchmaking can pair users who selected the same lobby criteria.

### Description
- Compute a `forcedOnlineTableId` and pass it into `runPoolRoyaleOnlineFlow` only when `autostart=1` is present, instead of always passing `searchParams.tableId`, by updating `webapp/src/pages/Games/PoolRoyaleLobby.jsx`.

### Testing
- Ran `npx jest test/poolRoyaleOnlineFlow.test.js --runInBand` and all tests passed.
- Ran `npx eslint webapp/src/pages/Games/PoolRoyaleLobby.jsx` (command completed; file is ignored by repo eslint patterns and produced a warning only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c188cebe6c832982cd55a269315b2f)