### PR TITLE
Fix Pool Royale online lobby matchmaking handoff

### DIFF
--- a/test/poolRoyaleOnlineFlow.test.js
+++ b/test/poolRoyaleOnlineFlow.test.js
@@ -154,7 +154,11 @@ test('runPoolRoyaleOnlineFlow debits once and keeps stake for game start', async
     players: [
       { id: 'acct-1', name: 'Alice' },
       { id: 'acct-2', name: 'Bob' }
-    ]
+    ],
+    meta: {
+      tableSize: '9ft',
+      mode: 'online'
+    }
   });
 
   await delay(0);
@@ -164,6 +168,7 @@ test('runPoolRoyaleOnlineFlow debits once and keeps stake for game start', async
   assert.equal(addCalls[0][2], 'stake');
   assert.equal(started.length, 1);
   assert.equal(started[0].tableId, 'tbl-1');
+  assert.equal(started[0].matchMeta?.tableSize, '9ft');
   assert.equal(refs.stakeDebitRef.current, null, 'stake cleared after start');
 });
 

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -72,6 +72,8 @@ export default function PoolRoyaleLobby() {
   const [playType, setPlayType] = useState(initialPlayType);
   const [players, setPlayers] = useState(8);
   const tableSize = resolveTableSize(searchParams.get('tableSize')).id;
+  const defaultTableSize = resolveTableSize().id;
+  const onlineTableSize = defaultTableSize;
   const [onlinePlayers, setOnlinePlayers] = useState([]);
   const [matching, setMatching] = useState(false);
   const [spinningPlayer, setSpinningPlayer] = useState('');
@@ -141,7 +143,8 @@ export default function PoolRoyaleLobby() {
     tableId: startedId,
     roster = [],
     accountId,
-    currentTurn
+    currentTurn,
+    matchMeta = {}
   }) => {
     const selfId = accountId || accountIdRef.current;
     const safeRoster = Array.isArray(roster) ? roster.filter(Boolean) : [];
@@ -193,7 +196,8 @@ export default function PoolRoyaleLobby() {
     if (tgId) params.set('tgId', tgId);
     const resolvedAccountId = accountIdRef.current;
     if (resolvedAccountId) params.set('accountId', resolvedAccountId);
-    if (tableSize) params.set('tableSize', tableSize);
+    const resolvedMatchTableSize = resolveTableSize(matchMeta?.tableSize).id;
+    params.set('tableSize', resolvedMatchTableSize || onlineTableSize);
     params.set('seat', seat);
     params.set('starter', starterSeat);
     const name = (friendlyName || '').trim();
@@ -224,7 +228,7 @@ export default function PoolRoyaleLobby() {
         ballSet: ukBallSet,
         playType,
         mode,
-        tableSize,
+        tableSize: onlineTableSize,
         avatar,
         deps: {
           ensureAccountId,

--- a/webapp/src/pages/Games/poolRoyaleOnlineFlow.js
+++ b/webapp/src/pages/Games/poolRoyaleOnlineFlow.js
@@ -186,6 +186,8 @@ export async function runPoolRoyaleOnlineFlow({
     typeof tableId === 'string' && tableId.trim()
       ? tableId.trim()
       : undefined;
+  const normalizedTableSize =
+    typeof tableSize === 'string' && tableSize.trim() ? tableSize.trim() : undefined;
 
   const telegramId = getTelegramIdFn?.();
 
@@ -351,13 +353,18 @@ export async function runPoolRoyaleOnlineFlow({
     logSupportError(message, null, { reason, ...extra });
   };
 
-  function handleGameStart({ tableId: startedId, players: joined = [], currentTurn } = {}) {
+  function handleGameStart({
+    tableId: startedId,
+    players: joined = [],
+    currentTurn,
+    meta
+  } = {}) {
     if (!startedId || startedId !== pendingTableRef.current) return;
     const roster = Array.isArray(joined) && joined.length > 0 ? joined : matchPlayersRef.current;
     stakeDebitRef.current = null;
     clearTimers();
     cleanupLobby({ account: accountId, skipRefReset: true, keepError: true });
-    onGameStart?.({ tableId: startedId, roster, accountId, currentTurn });
+    onGameStart?.({ tableId: startedId, roster, accountId, currentTurn, matchMeta: meta });
   }
 
   cleanupRef.current = cleanupLobby;
@@ -401,7 +408,7 @@ export async function runPoolRoyaleOnlineFlow({
         mode,
         variant,
         ballSet,
-        tableSize,
+        tableSize: normalizedTableSize,
         playType,
         playerName: getTelegramFirstNameFn?.() || `TPC ${accountId}` || 'Player',
         avatar


### PR DESCRIPTION
### Motivation
- Players were being shown in the Pool Royale lobby but failing to start matches when both sides selected the same visible criteria because hidden `tableSize` differences split matchmaking queues and authoritative server metadata wasn't propagated to the client on game start. 

### Description
- Normalize and forward `tableSize` from the lobby into the online flow by introducing `normalizedTableSize` and sending it to the server in `seatTable` in `poolRoyaleOnlineFlow.js`.
- Include server `meta` from the `gameStart` event in `poolRoyaleOnlineFlow` and forward it to the lobby callback as `matchMeta` so navigation uses authoritative match settings.
- Use a canonical default `onlineTableSize` in `PoolRoyaleLobby.jsx` and pass it into `runPoolRoyaleOnlineFlow` to avoid implicit URL/param mismatches splitting the queue.
- Prefer the server-provided `matchMeta.tableSize` when constructing the post-match navigation URL so both clients load the same table configuration.
- Add an assertion in `test/poolRoyaleOnlineFlow.test.js` to verify `gameStart.meta` is propagated through the `onGameStart` callback.

### Testing
- Ran the unit tests for the online flow with `npm test -- test/poolRoyaleOnlineFlow.test.js` and all tests passed (`7/7`).
- The updated test validates that `matchMeta.tableSize` from server `meta` is present in the `onGameStart` payload.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c188cebe6c832982cd55a269315b2f)