### PR TITLE
Normalize Pool Royale lobby match metadata (tableSize/ballSet) and add regression test

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -491,12 +491,39 @@ const checkersMoveRateLimitMs =
 
 const MATCH_META_KEYS = ['mode', 'playType', 'variant', 'tableSize', 'ballSet', 'token'];
 
+function normalizeTableSizeMeta(value = '') {
+  const normalized = String(value || '').trim().toLowerCase();
+  if (!normalized) return '';
+  if (normalized === 'pro') return '9ft';
+  if (normalized.includes('9') && normalized.includes('ft')) return '9ft';
+  if (normalized.includes('8') && normalized.includes('ft')) return '8ft';
+  if (normalized.includes('tournament')) return '9ft';
+  return normalized;
+}
+
+function normalizeBallSetMeta(value = '') {
+  const normalized = String(value || '').trim().toLowerCase();
+  if (!normalized) return '';
+  if (normalized === 'us' || normalized === 'usa') return 'american';
+  if (normalized === 'english') return 'uk';
+  return normalized;
+}
+
+function normalizeMatchMetaValue(key, value) {
+  const normalized = String(value || '').trim().toLowerCase();
+  if (!normalized) return '';
+  if (key === 'tableSize') return normalizeTableSizeMeta(normalized);
+  if (key === 'ballSet') return normalizeBallSetMeta(normalized);
+  return normalized;
+}
+
 function normalizeMatchMeta(rawMeta = {}) {
   const normalized = {};
   MATCH_META_KEYS.forEach((key) => {
     const value = rawMeta[key];
     if (typeof value === 'string' && value.trim()) {
-      normalized[key] = value.trim().toLowerCase();
+      const normalizedValue = normalizeMatchMetaValue(key, value);
+      if (normalizedValue) normalized[key] = normalizedValue;
     }
   });
   return normalized;

--- a/test/poolRoyaleMatchmakingMeta.test.js
+++ b/test/poolRoyaleMatchmakingMeta.test.js
@@ -237,3 +237,75 @@ test('pool royale allows joining the same explicit tableId when id is not game-p
     server.kill();
   }
 });
+
+test('pool royale canonicalizes table size aliases so equivalent criteria can still match', { concurrency: false, timeout: 20000 }, async () => {
+  fs.mkdirSync(new URL('assets', distDir), { recursive: true });
+  fs.writeFileSync(new URL('index.html', distDir), '');
+
+  const env = {
+    ...process.env,
+    PORT: '3210',
+    MONGO_URI: 'memory',
+    BOT_TOKEN: 'dummy',
+    API_AUTH_TOKEN: apiToken,
+    SKIP_WEBAPP_BUILD: '1',
+    SKIP_BOT_LAUNCH: '1'
+  };
+
+  const server = await startServer(env);
+  const s1 = connectClient(3210);
+  const s2 = connectClient(3210);
+
+  try {
+    await Promise.all([
+      new Promise((resolve) => s1.on('connect', resolve)),
+      new Promise((resolve) => s2.on('connect', resolve))
+    ]);
+
+    s1.emit('register', { playerId: 'acct-size-a' });
+    s2.emit('register', { playerId: 'acct-size-b' });
+
+    const firstSeat = await new Promise((resolve) => {
+      s1.emit(
+        'seatTable',
+        {
+          accountId: 'acct-size-a',
+          gameType: 'poolroyale',
+          stake: 100,
+          maxPlayers: 2,
+          mode: 'online',
+          playType: 'regular',
+          tableSize: '9 ft (Tournament)',
+          playerName: 'SizeA'
+        },
+        resolve
+      );
+    });
+
+    const secondSeat = await new Promise((resolve) => {
+      s2.emit(
+        'seatTable',
+        {
+          accountId: 'acct-size-b',
+          gameType: 'poolroyale',
+          stake: 100,
+          maxPlayers: 2,
+          mode: 'online',
+          playType: 'regular',
+          tableSize: 'pro',
+          playerName: 'SizeB'
+        },
+        resolve
+      );
+    });
+
+    assert.equal(firstSeat.success, true);
+    assert.equal(secondSeat.success, true);
+    assert.equal(secondSeat.tableId, firstSeat.tableId);
+    assert.equal(secondSeat.players.length, 2);
+  } finally {
+    s1.disconnect();
+    s2.disconnect();
+    server.kill();
+  }
+});


### PR DESCRIPTION
### Motivation
- Players selecting equivalent lobby criteria with different labels (e.g. `pro` vs `9 ft (Tournament)`) were being treated as incompatible, causing visible online counts but failing to pair.  
- The matchmaking logic compares normalized match metadata; some legacy/variant labels for `tableSize` and `ballSet` needed canonicalization to avoid split lobbies.  
- Add a test that reproduces the alias mismatch and protects against regressions.  

### Description
- Added canonicalization helpers in `bot/server.js`: `normalizeTableSizeMeta`, `normalizeBallSetMeta`, and `normalizeMatchMetaValue`, and applied them inside `normalizeMatchMeta` so `tableSize` and `ballSet` values are normalized before compatibility checks.  
- `tableSize` alias handling maps values like `pro`, `9 ft (Tournament)`, and `tournament` to canonical ids (`9ft` / `8ft` when appropriate).  
- `ballSet` alias handling maps `us`/`usa` → `american` and `english` → `uk`.  
- Added an integration/regression test `test/poolRoyaleMatchmakingMeta.test.js` that seats two players using different `tableSize` labels and asserts they land in the same table.  

### Testing
- Added an automated integration test (`test/poolRoyaleMatchmakingMeta.test.js`) that reproduces the alias pairing scenario and asserts both seats join the same table.  
- Attempted to run the test with `npm test -- test/poolRoyaleMatchmakingMeta.test.js`, which failed in this environment because `jest` is not available in PATH.  
- Attempted `node --test test/poolRoyaleMatchmakingMeta.test.js`, which failed in this environment because `socket.io-client` is not installed in `node_modules`; the test should run successfully in CI or a developer environment with project dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c188cebe6c832982cd55a269315b2f)