### PR TITLE
Preserve and normalize Pool Royale `variant` metadata for lobby matchmaking

### DIFF
--- a/bot/config/onlineGamePolicy.js
+++ b/bot/config/onlineGamePolicy.js
@@ -10,7 +10,10 @@ const BASE_SECURITY_CONTROLS = Object.freeze([
 const GAME_ONLINE_POLICY = Object.freeze({
   chess: { maxPlayers: [2], allowMatchMeta: ['preferredSide', 'mode', 'token'] },
   checkers: { maxPlayers: [2], allowMatchMeta: ['preferredSide', 'mode', 'token'] },
-  poolroyale: { maxPlayers: [2], allowMatchMeta: ['mode', 'playType', 'tableSize', 'ballSet', 'token'] },
+  poolroyale: {
+    maxPlayers: [2],
+    allowMatchMeta: ['variant', 'mode', 'playType', 'tableSize', 'ballSet', 'token']
+  },
   snookerroyale: { maxPlayers: [2], allowMatchMeta: ['mode', 'playType', 'tableSize', 'token'] },
   snake: { maxPlayers: [2, 3, 4], allowMatchMeta: ['mode', 'token'] },
   chessbattleroyal: { maxPlayers: [2], allowMatchMeta: ['preferredSide', 'mode', 'token'] },

--- a/bot/server.js
+++ b/bot/server.js
@@ -509,11 +509,22 @@ function normalizeBallSetMeta(value = '') {
   return normalized;
 }
 
+function normalizeVariantMeta(value = '') {
+  const normalized = String(value || '').trim().toLowerCase();
+  if (!normalized) return '';
+  if (normalized === 'us' || normalized === 'usa') return 'american';
+  if (normalized === 'english') return 'uk';
+  if (normalized === 'eightball' || normalized === '8-ball') return '8ball';
+  if (normalized === 'nineball' || normalized === '9-ball') return '9ball';
+  return normalized;
+}
+
 function normalizeMatchMetaValue(key, value) {
   const normalized = String(value || '').trim().toLowerCase();
   if (!normalized) return '';
   if (key === 'tableSize') return normalizeTableSizeMeta(normalized);
   if (key === 'ballSet') return normalizeBallSetMeta(normalized);
+  if (key === 'variant') return normalizeVariantMeta(normalized);
   return normalized;
 }
 

--- a/test/onlineGamePolicy.test.js
+++ b/test/onlineGamePolicy.test.js
@@ -14,6 +14,7 @@ describe('online game policy', () => {
       stake: '25',
       maxPlayers: 2,
       matchMeta: {
+        variant: '8ball',
         mode: 'Ranked',
         tableSize: '9ft',
         token: 'TPC',
@@ -24,7 +25,12 @@ describe('online game policy', () => {
     expect(result.ok).toBe(true);
     expect(result.normalizedStake).toBe(25);
     expect(result.normalizedMaxPlayers).toBe(2);
-    expect(result.safeMatchMeta).toEqual({ mode: 'Ranked', tableSize: '9ft', token: 'TPC' });
+    expect(result.safeMatchMeta).toEqual({
+      variant: '8ball',
+      mode: 'Ranked',
+      tableSize: '9ft',
+      token: 'TPC'
+    });
   });
 
   test('rejects unsupported game and invalid max players', () => {

--- a/test/poolRoyaleMatchmakingMeta.test.js
+++ b/test/poolRoyaleMatchmakingMeta.test.js
@@ -88,6 +88,76 @@ test('pool royale players with partially-filled matching meta share same table',
   }
 });
 
+test('pool royale players using variant aliases still share a table', { concurrency: false, timeout: 20000 }, async () => {
+  fs.mkdirSync(new URL('assets', distDir), { recursive: true });
+  fs.writeFileSync(new URL('index.html', distDir), '');
+
+  const env = {
+    ...process.env,
+    PORT: '3210',
+    MONGO_URI: 'memory',
+    BOT_TOKEN: 'dummy',
+    API_AUTH_TOKEN: apiToken,
+    SKIP_WEBAPP_BUILD: '1',
+    SKIP_BOT_LAUNCH: '1'
+  };
+
+  const server = await startServer(env);
+  const s1 = connectClient(3210);
+  const s2 = connectClient(3210);
+
+  try {
+    await Promise.all([
+      new Promise((resolve) => s1.on('connect', resolve)),
+      new Promise((resolve) => s2.on('connect', resolve))
+    ]);
+
+    s1.emit('register', { playerId: 'acct-variant-1' });
+    s2.emit('register', { playerId: 'acct-variant-2' });
+
+    const firstSeat = await new Promise((resolve) => {
+      s1.emit(
+        'seatTable',
+        {
+          accountId: 'acct-variant-1',
+          gameType: 'poolroyale',
+          stake: 250,
+          maxPlayers: 2,
+          mode: 'online',
+          variant: '8-ball',
+          playerName: 'VariantA'
+        },
+        resolve
+      );
+    });
+
+    const secondSeat = await new Promise((resolve) => {
+      s2.emit(
+        'seatTable',
+        {
+          accountId: 'acct-variant-2',
+          gameType: 'poolroyale',
+          stake: 250,
+          maxPlayers: 2,
+          mode: 'online',
+          variant: 'eightball',
+          playerName: 'VariantB'
+        },
+        resolve
+      );
+    });
+
+    assert.equal(firstSeat.success, true);
+    assert.equal(secondSeat.success, true);
+    assert.equal(secondSeat.tableId, firstSeat.tableId);
+    assert.equal(secondSeat.players.length, 2);
+  } finally {
+    s1.disconnect();
+    s2.disconnect();
+    server.kill();
+  }
+});
+
 test('pool royale disconnect clears stale lobby seat so next player can queue cleanly', { concurrency: false, timeout: 20000 }, async () => {
   fs.mkdirSync(new URL('assets', distDir), { recursive: true });
   fs.writeFileSync(new URL('index.html', distDir), '');


### PR DESCRIPTION
### Motivation
- Players selecting the same stake and game variant could fail to match because `variant` was not preserved by the matchmaking policy and different client alias forms could be treated as different variants. 
- The change ensures lobby matching uses the selected Pool Royale variant and treats common alias forms as equivalent.

### Description
- Added `variant` to Pool Royale `allowMatchMeta` in `bot/config/onlineGamePolicy.js` so seat validation keeps the selected variant.  
- Implemented `normalizeVariantMeta` and wired it into `normalizeMatchMetaValue` in `bot/server.js` to canonicalize common aliases (e.g. `8-ball`/`eightball` → `8ball`, `9-ball`/`nineball` → `9ball`, `english`/`usa`/`us` → `uk`/`american`).
- Updated `test/onlineGamePolicy.test.js` to assert that `variant` is preserved in `safeMatchMeta` for Pool Royale.  
- Added an integration test to `test/poolRoyaleMatchmakingMeta.test.js` verifying two players using equivalent `variant` aliases are matched into the same Pool Royale table.

### Testing
- Ran `npm test -- test/onlineGamePolicy.test.js test/poolRoyaleMatchmakingMeta.test.js` and both suites passed (all tests in those files succeeded).  
- The modified tests (`onlineGamePolicy` and `poolRoyaleMatchmakingMeta`) passed locally with the updated normalization and policy behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1968ed8e483298795f0d0de6f522f)