### PR TITLE
Exclude per-user `token` from lobby matchmaking keys and add regression test

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -489,7 +489,9 @@ const seatTableRateLimitMs = Number(process.env.SEAT_TABLE_RATE_LIMIT_MS) || 500
 const checkersMoveRateLimitMs =
   Number(process.env.CHECKERS_MOVE_RATE_LIMIT_MS) || 120;
 
-const MATCH_META_KEYS = ['mode', 'playType', 'variant', 'tableSize', 'ballSet', 'token'];
+// `token` is accepted for validation/telemetry, but it must not partition
+// public matchmaking queues because clients can send user-specific values.
+const MATCH_META_KEYS = ['mode', 'playType', 'variant', 'tableSize', 'ballSet'];
 
 function normalizeTableSizeMeta(value = '') {
   const normalized = String(value || '').trim().toLowerCase();

--- a/test/checkersLobbyAliasMatchmaking.test.js
+++ b/test/checkersLobbyAliasMatchmaking.test.js
@@ -99,3 +99,68 @@ test(
     }
   }
 );
+
+test(
+  'checkers alias matchmaking ignores per-user token metadata',
+  { concurrency: false, timeout: 20000 },
+  async () => {
+    fs.mkdirSync(new URL('assets', distDir), { recursive: true });
+    fs.writeFileSync(new URL('index.html', distDir), '');
+    const env = {
+      ...process.env,
+      PORT: '3211',
+      MONGO_URI: 'memory',
+      BOT_TOKEN: 'dummy',
+      API_AUTH_TOKEN: apiToken,
+      SKIP_WEBAPP_BUILD: '1',
+      SKIP_BOT_LAUNCH: '1'
+    };
+    const server = await startServer(env);
+    const s1 = io('http://localhost:3211', { auth: { token: apiToken } });
+    const s2 = io('http://localhost:3211', { auth: { token: apiToken } });
+
+    try {
+      await Promise.all([
+        new Promise((resolve) => s1.on('connect', resolve)),
+        new Promise((resolve) => s2.on('connect', resolve))
+      ]);
+
+      const register = (socket, playerId) =>
+        new Promise((resolve) => {
+          socket.emit('register', { playerId }, resolve);
+        });
+      await Promise.all([register(s1, 'checkers-token-a'), register(s2, 'checkers-token-b')]);
+
+      const seat = (socket, payload) =>
+        new Promise((resolve) => {
+          socket.emit('seatTable', payload, resolve);
+        });
+
+      const firstSeat = await seat(s1, {
+        accountId: 'checkers-token-a',
+        gameType: 'checkers',
+        stake: 100,
+        maxPlayers: 2,
+        mode: 'online',
+        token: 'user-token-a'
+      });
+      const secondSeat = await seat(s2, {
+        accountId: 'checkers-token-b',
+        gameType: 'checkersbattleroyal',
+        stake: 100,
+        maxPlayers: 2,
+        mode: 'online',
+        token: 'user-token-b'
+      });
+
+      assert.equal(firstSeat.success, true);
+      assert.equal(secondSeat.success, true);
+      assert.equal(secondSeat.tableId, firstSeat.tableId);
+      assert.equal(secondSeat.players.length, 2);
+    } finally {
+      s1.disconnect();
+      s2.disconnect();
+      server.kill();
+    }
+  }
+);


### PR DESCRIPTION
### Motivation
- Players with identical queue criteria were not being matched when clients supplied different per-user `token` metadata, because `token` was used to partition public matchmaking queues.

### Description
- Remove `token` from the server matchmaking keys by updating `MATCH_META_KEYS` in `bot/server.js` so `token` is validated but not used to split public lobbies. 
- Add a regression integration test `checkers alias matchmaking ignores per-user token metadata` in `test/checkersLobbyAliasMatchmaking.test.js` that seats two players with different `token` values and asserts they share the same table.

### Testing
- Attempted to run the new integration test with `npm test -- test/checkersLobbyAliasMatchmaking.test.js`, but the test run could not start the server due to a missing runtime dependency (`compression`), so the automated test run failed to execute in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c20da260fc832994c6da1ddb6c2a57)