### PR TITLE
Treat `preferredSide` as a seat preference so chess players with opposite side choices can match

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -546,6 +546,11 @@ function isMatchMetaCompatible(existing = {}, requested = {}) {
     ...Object.keys(requested || {})
   ]);
   for (const key of allKeys) {
+    if (key === 'preferredSide') {
+      // Side is a seat preference, not a matchmaking partition. Keep players
+      // in the same queue even when they pick opposite colors.
+      continue;
+    }
     const existingValue = existing?.[key];
     const requestedValue = requested?.[key];
     // Treat missing keys as wildcards so players can still pair when one client

--- a/test/chessLobbyPreferredSideMatchmaking.test.js
+++ b/test/chessLobbyPreferredSideMatchmaking.test.js
@@ -1,0 +1,103 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import { spawn } from 'child_process';
+import { setTimeout as delay } from 'timers/promises';
+import { io } from 'socket.io-client';
+
+const distDir = new URL('../webapp/dist/', import.meta.url);
+const apiToken = 'test-token';
+
+async function startServer(env) {
+  const server = spawn('node', ['bot/server.js'], { env, stdio: 'pipe' });
+  server.stdout.on('data', (chunk) => process.stdout.write(chunk));
+  server.stderr.on('data', (chunk) => process.stderr.write(chunk));
+  await new Promise((resolve) => {
+    const onData = (chunk) => {
+      if (chunk.toString().includes('Server running on port')) {
+        server.stdout.off('data', onData);
+        resolve();
+      }
+    };
+    server.stdout.on('data', onData);
+  });
+  return server;
+}
+
+test(
+  'chess players with opposite preferred sides are matched into the same lobby',
+  { concurrency: false, timeout: 20000 },
+  async () => {
+    fs.mkdirSync(new URL('assets', distDir), { recursive: true });
+    fs.writeFileSync(new URL('index.html', distDir), '');
+    const env = {
+      ...process.env,
+      PORT: '3211',
+      MONGO_URI: 'memory',
+      BOT_TOKEN: 'dummy',
+      API_AUTH_TOKEN: apiToken,
+      SKIP_WEBAPP_BUILD: '1',
+      SKIP_BOT_LAUNCH: '1'
+    };
+    const server = await startServer(env);
+    const s1 = io('http://localhost:3211', { auth: { token: apiToken } });
+    const s2 = io('http://localhost:3211', { auth: { token: apiToken } });
+
+    try {
+      await Promise.all([
+        new Promise((resolve) => s1.on('connect', resolve)),
+        new Promise((resolve) => s2.on('connect', resolve))
+      ]);
+
+      const register = (socket, playerId) =>
+        new Promise((resolve) => {
+          socket.emit('register', { playerId }, resolve);
+        });
+      await Promise.all([register(s1, 'chess-a'), register(s2, 'chess-b')]);
+
+      const seat = (socket, payload) =>
+        new Promise((resolve) => {
+          socket.emit('seatTable', payload, resolve);
+        });
+
+      const firstSeat = await seat(s1, {
+        accountId: 'chess-a',
+        gameType: 'chess',
+        stake: 100,
+        maxPlayers: 2,
+        mode: 'online',
+        token: 'TPC',
+        preferredSide: 'white'
+      });
+      const secondSeat = await seat(s2, {
+        accountId: 'chess-b',
+        gameType: 'chessbattleroyal',
+        stake: 100,
+        maxPlayers: 2,
+        mode: 'online',
+        token: 'TPC',
+        preferredSide: 'black'
+      });
+
+      assert.equal(firstSeat.success, true);
+      assert.equal(secondSeat.success, true);
+      assert.equal(secondSeat.tableId, firstSeat.tableId);
+
+      s1.emit('confirmReady', { accountId: 'chess-a', tableId: firstSeat.tableId });
+      s2.emit('confirmReady', { accountId: 'chess-b', tableId: firstSeat.tableId });
+
+      const [gameStartA, gameStartB] = await Promise.all([
+        new Promise((resolve) => s1.once('gameStart', resolve)),
+        new Promise((resolve) => s2.once('gameStart', resolve))
+      ]);
+      assert.equal(gameStartA.tableId, firstSeat.tableId);
+      assert.equal(gameStartB.tableId, firstSeat.tableId);
+
+      await delay(50);
+    } finally {
+      s1.disconnect();
+      s2.disconnect();
+      server.kill();
+    }
+  }
+);


### PR DESCRIPTION
### Motivation
- Players using the Chess Battle Royal lobby with identical matchmaking criteria but opposite `preferredSide` (white/black) were being split into different queues, preventing them from being paired.

### Description
- Updated `isMatchMetaCompatible` in `bot/server.js` to ignore the `preferredSide` key so side preference is treated as a seat preference rather than a matchmaking partition.
- Added an integration test `test/chessLobbyPreferredSideMatchmaking.test.js` that starts the server, registers two sockets, seats one as `chess` and the other as `chessbattleroyal` with opposite `preferredSide` values, and verifies they join the same table and receive `gameStart`.

### Testing
- Ran the new integration test with `node --test test/chessLobbyPreferredSideMatchmaking.test.js`, which started the server against an in-memory MongoDB and passed (1 test, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c20da260fc832994c6da1ddb6c2a57)