### PR TITLE
Fix chess battle royal lobby pairing and remove side picker

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -706,11 +706,47 @@ function resolveSeatIdentityFromTableId(tableId, fallbackGameType, fallbackMaxPl
 
 function cleanupSeats() {
   const now = Date.now();
-  for (const [tableId, players] of tableSeats) {
-    for (const [pid, info] of players) {
-      if (now - info.ts > 60_000) players.delete(pid);
+  for (const [tableId, seats] of tableSeats) {
+    const stalePlayerIds = [];
+    for (const [pid, info] of seats) {
+      if (now - info.ts > 60_000) stalePlayerIds.push(String(pid));
     }
-    if (players.size === 0) tableSeats.delete(tableId);
+    if (stalePlayerIds.length === 0) continue;
+
+    stalePlayerIds.forEach((pid) => seats.delete(pid));
+
+    const table = tableMap.get(tableId);
+    if (table) {
+      table.players = (table.players || []).filter(
+        (player) => !stalePlayerIds.includes(String(player.id))
+      );
+      if (table.ready) {
+        stalePlayerIds.forEach((pid) => table.ready.delete(pid));
+      }
+      if (
+        table.currentTurn &&
+        stalePlayerIds.includes(String(table.currentTurn))
+      ) {
+        table.currentTurn = table.players[0]?.id || null;
+      }
+      io.to(tableId).emit('lobbyUpdate', {
+        tableId,
+        players: table.players,
+        currentTurn: table.currentTurn,
+        ready: Array.from(table.ready || []),
+        meta: table.meta
+      });
+    }
+
+    if (seats.size === 0) tableSeats.delete(tableId);
+
+    if (table && table.players.length === 0) {
+      tableMap.delete(tableId);
+      const key = `${table.gameType}-${table.maxPlayers}`;
+      lobbyTables[key] = (lobbyTables[key] || []).filter(
+        (entry) => entry.id !== tableId
+      );
+    }
   }
 }
 

--- a/webapp/src/pages/Games/ChessBattleRoyalLobby.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyalLobby.jsx
@@ -139,7 +139,7 @@ export default function ChessBattleRoyalLobby() {
   const [onlinePlayers, setOnlinePlayers] = useState([]);
   const [matchStatus, setMatchStatus] = useState('');
   const [matchError, setMatchError] = useState('');
-  const [preferredSide, setPreferredSide] = useState('auto');
+  const preferredSide = 'auto';
   const pendingTableRef = useRef('');
   const cleanupRef = useRef(() => {});
   const matchmakingTimeoutRef = useRef(null);
@@ -704,79 +704,6 @@ export default function ChessBattleRoyalLobby() {
             <p className="text-center text-white/60 text-xs">
               Staking uses your TPC account{accountId ? ` #${accountId}` : ''}{' '}
               as escrow for every online round.
-            </p>
-          </div>
-        )}
-
-        {mode === 'online' && (
-          <div className="space-y-2">
-            <div className="flex items-center justify-between">
-              <h3 className="font-semibold text-white">Pick Your Pieces</h3>
-              <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">
-                Sides
-              </span>
-            </div>
-            <div className="grid grid-cols-3 gap-3">
-              {[
-                {
-                  key: 'auto',
-                  label: 'Auto',
-                  desc: 'Random seats, no duplicates',
-                  accent: 'from-slate-400/30 via-slate-500/10 to-transparent',
-                  icon: '🎲'
-                },
-                {
-                  key: 'white',
-                  label: 'White',
-                  desc: 'You start first',
-                  accent: 'from-white/40 via-white/10 to-transparent',
-                  icon: '♔'
-                },
-                {
-                  key: 'black',
-                  label: 'Black',
-                  desc: 'Opponent opens',
-                  accent: 'from-gray-500/30 via-gray-700/10 to-transparent',
-                  icon: '♚'
-                }
-              ].map(({ key, label, desc, accent, icon }) => {
-                const active = preferredSide === key;
-                return (
-                  <button
-                    key={key}
-                    type="button"
-                    onClick={() => setPreferredSide(key)}
-                    className={`flex flex-col gap-3 rounded-2xl border px-4 py-4 text-left shadow transition ${
-                      active
-                        ? 'border-primary bg-primary/10 text-primary'
-                        : 'border-white/10 bg-black/30 text-white/80 hover:border-white/30'
-                    }`}
-                  >
-                    <div
-                      className={`h-12 w-12 rounded-2xl bg-gradient-to-br ${accent} p-[1px]`}
-                    >
-                      <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-xl">
-                        {icon}
-                      </div>
-                    </div>
-                    <div>
-                      <div className="flex items-center justify-between">
-                        <span className="font-semibold">{label}</span>
-                        {active && (
-                          <span className="text-[10px] font-bold uppercase">
-                            Selected
-                          </span>
-                        )}
-                      </div>
-                      <div className="text-xs text-white/60">{desc}</div>
-                    </div>
-                  </button>
-                );
-              })}
-            </div>
-            <p className="text-xs text-white/60 text-center">
-              Auto randomizes colors while ensuring both players get different
-              sides.
             </p>
           </div>
         )}


### PR DESCRIPTION
### Motivation
- Players in the Chess Battle Royal lobby could become stuck due to stale/ghost seats in the in-memory seat map, which prevented two real users with the same matchmaking criteria from being paired.  
- The lobby needs to reliably remove expired seats and reflect that state to connected clients so matchmaking and game start logic work correctly.  
- The UI side-picker caused unnecessary client-side divergence; the lobby should default to automatic side assignment for online matches.

### Description
- Updated `cleanupSeats` in `bot/server.js` to collect stale seat ids, remove them from the `tableSeats` map, and also remove matching entries from the table's `players` list.  
- After cleaning stale seats the server now updates `table.ready`, recalculates `currentTurn` if needed, emits an updated `lobbyUpdate` for the table, and removes empty tables from `tableMap` and `lobbyTables`.  
- Removed the “Pick Your Pieces” UI from `webapp/src/pages/Games/ChessBattleRoyalLobby.jsx` and locked the client-side `preferredSide` to `'auto'` so side assignment is handled automatically by the server.

### Testing
- Ran the focused unit test with `npm test -- test/chessLobbyPreferredSideMatchmaking.test.js --runInBand`, which passed.  
- Ran `npx eslint bot/server.js webapp/src/pages/Games/ChessBattleRoyalLobby.jsx` (repo eslint ignore rules applied) which completed with warnings.  
- Ran `npx eslint --no-ignore bot/server.js webapp/src/pages/Games/ChessBattleRoyalLobby.jsx` to surface style issues and observed pre-existing legacy lint errors in the large filebase (these are unrelated to the functional changes in this PR).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c219e549f4832998d5ba2d5cd0cb60)