### PR TITLE
Match Pool Royale lobbies by variant+stake and add regression test

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -540,10 +540,23 @@ function normalizeMatchMeta(rawMeta = {}) {
   return normalized;
 }
 
-function isMatchMetaCompatible(existing = {}, requested = {}) {
+function getMatchmakingPartitionKeys(gameType = '') {
+  const normalizedGameType = normalizeOnlineGameType(gameType);
+  if (normalizedGameType === 'poolroyale') {
+    // Pool Royale variants must pair quickly by stake + variant only.
+    return ['variant'];
+  }
+  return MATCH_META_KEYS;
+}
+
+function isMatchMetaCompatible(existing = {}, requested = {}, gameType = '') {
+  const partitionKeys = getMatchmakingPartitionKeys(gameType);
   const allKeys = new Set([
-    ...Object.keys(existing || {}),
-    ...Object.keys(requested || {})
+    ...partitionKeys.filter(
+      (key) =>
+        key in (existing || {}) ||
+        key in (requested || {})
+    )
   ]);
   for (const key of allKeys) {
     if (key === 'preferredSide') {
@@ -651,7 +664,7 @@ function getAvailableTable(
     (t) =>
       t.stake === stake &&
       t.players.length < t.maxPlayers &&
-      isMatchMetaCompatible(t.meta, normalizedMeta)
+      isMatchMetaCompatible(t.meta, normalizedMeta, gameType)
   );
   if (open) return open;
   const table = {

--- a/test/poolLobbyVariantMatchmaking.test.js
+++ b/test/poolLobbyVariantMatchmaking.test.js
@@ -1,0 +1,107 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import { spawn } from 'child_process';
+import { setTimeout as delay } from 'timers/promises';
+import { io } from 'socket.io-client';
+
+const distDir = new URL('../webapp/dist/', import.meta.url);
+const apiToken = 'test-token';
+
+async function startServer(env) {
+  const server = spawn('node', ['bot/server.js'], { env, stdio: 'pipe' });
+  server.stdout.on('data', (chunk) => process.stdout.write(chunk));
+  server.stderr.on('data', (chunk) => process.stderr.write(chunk));
+  await new Promise((resolve) => {
+    const onData = (chunk) => {
+      if (chunk.toString().includes('Server running on port')) {
+        server.stdout.off('data', onData);
+        resolve();
+      }
+    };
+    server.stdout.on('data', onData);
+  });
+  return server;
+}
+
+test(
+  'pool royale players with same stake + variant match even when other lobby metadata differs',
+  { concurrency: false, timeout: 20000 },
+  async () => {
+    fs.mkdirSync(new URL('assets', distDir), { recursive: true });
+    fs.writeFileSync(new URL('index.html', distDir), '');
+    const env = {
+      ...process.env,
+      PORT: '3212',
+      MONGO_URI: 'memory',
+      BOT_TOKEN: 'dummy',
+      API_AUTH_TOKEN: apiToken,
+      SKIP_WEBAPP_BUILD: '1',
+      SKIP_BOT_LAUNCH: '1'
+    };
+    const server = await startServer(env);
+    const s1 = io('http://localhost:3212', { auth: { token: apiToken } });
+    const s2 = io('http://localhost:3212', { auth: { token: apiToken } });
+
+    try {
+      await Promise.all([
+        new Promise((resolve) => s1.on('connect', resolve)),
+        new Promise((resolve) => s2.on('connect', resolve))
+      ]);
+
+      const register = (socket, playerId) =>
+        new Promise((resolve) => {
+          socket.emit('register', { playerId }, resolve);
+        });
+      await Promise.all([register(s1, 'pool-a'), register(s2, 'pool-b')]);
+
+      const seat = (socket, payload) =>
+        new Promise((resolve) => {
+          socket.emit('seatTable', payload, resolve);
+        });
+
+      const firstSeat = await seat(s1, {
+        accountId: 'pool-a',
+        gameType: 'poolroyale',
+        stake: 250,
+        maxPlayers: 2,
+        mode: 'online',
+        token: 'TPC',
+        variant: '8-ball',
+        tableSize: '8ft',
+        ballSet: 'english'
+      });
+      const secondSeat = await seat(s2, {
+        accountId: 'pool-b',
+        gameType: 'poolroyale',
+        stake: 250,
+        maxPlayers: 2,
+        mode: 'online',
+        token: 'USDT',
+        variant: 'eightball',
+        tableSize: 'pro',
+        ballSet: 'american'
+      });
+
+      assert.equal(firstSeat.success, true);
+      assert.equal(secondSeat.success, true);
+      assert.equal(secondSeat.tableId, firstSeat.tableId);
+
+      s1.emit('confirmReady', { accountId: 'pool-a', tableId: firstSeat.tableId });
+      s2.emit('confirmReady', { accountId: 'pool-b', tableId: firstSeat.tableId });
+
+      const [gameStartA, gameStartB] = await Promise.all([
+        new Promise((resolve) => s1.once('gameStart', resolve)),
+        new Promise((resolve) => s2.once('gameStart', resolve))
+      ]);
+      assert.equal(gameStartA.tableId, firstSeat.tableId);
+      assert.equal(gameStartB.tableId, firstSeat.tableId);
+
+      await delay(50);
+    } finally {
+      s1.disconnect();
+      s2.disconnect();
+      server.kill();
+    }
+  }
+);


### PR DESCRIPTION
### Motivation

- Players in Pool Royale lobbies were failing to match when non-essential metadata (token, tableSize, ballSet) differed despite having the same `variant` and `stake`, so matchmaking should prioritize quick pairing by the minimal keys required for that game.

### Description

- Added `getMatchmakingPartitionKeys(gameType)` which returns a reduced partition key set (`['variant']`) for `poolroyale` and `MATCH_META_KEYS` for other games.
- Updated `isMatchMetaCompatible` to accept a `gameType` parameter and only compare metadata keys returned by the partition function.
- Updated `getAvailableTable` to pass `gameType` into `isMatchMetaCompatible` so Pool Royale-specific partitioning is applied when selecting open tables.
- Added a new regression test `test/poolLobbyVariantMatchmaking.test.js` that asserts two Pool Royale clients with the same stake and equivalent variant values match into the same table even when other metadata differs.

### Testing

- Attempted to run the new test with `node --test test/poolLobbyVariantMatchmaking.test.js`, but the test run could not complete because `bot/server.js` failed to start in this environment due to a missing runtime dependency (`compression`).
- Static checks succeeded with `node --check bot/server.js` and `node --check test/poolLobbyVariantMatchmaking.test.js`.
- The new test file is `test/poolLobbyVariantMatchmaking.test.js` and the runtime failure is an environment dependency issue rather than a logic failure in the matchmaking changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c21a820cac832989216f2a26cc17d4)