### PR TITLE
Pool Royale matchmaking: match by stake + variant only

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -540,7 +540,19 @@ function normalizeMatchMeta(rawMeta = {}) {
   return normalized;
 }
 
-function isMatchMetaCompatible(existing = {}, requested = {}) {
+function isMatchMetaCompatible(existing = {}, requested = {}, gameType = '') {
+  const normalizedGameType = String(gameType || '').trim().toLowerCase();
+
+  if (normalizedGameType === 'poolroyale') {
+    const existingVariant = existing?.variant || '';
+    const requestedVariant = requested?.variant || '';
+    // Pool Royale quick matchmaking now only partitions by stake + variant.
+    // Stake is checked outside this helper (see getAvailableTable).
+    // Keep missing variants as wildcards for backward compatibility.
+    if (!existingVariant || !requestedVariant) return true;
+    return existingVariant === requestedVariant;
+  }
+
   const allKeys = new Set([
     ...Object.keys(existing || {}),
     ...Object.keys(requested || {})
@@ -651,7 +663,7 @@ function getAvailableTable(
     (t) =>
       t.stake === stake &&
       t.players.length < t.maxPlayers &&
-      isMatchMetaCompatible(t.meta, normalizedMeta)
+      isMatchMetaCompatible(t.meta, normalizedMeta, gameType)
   );
   if (open) return open;
   const table = {

--- a/test/poolRoyaleMatchmakingMeta.test.js
+++ b/test/poolRoyaleMatchmakingMeta.test.js
@@ -158,6 +158,82 @@ test('pool royale players using variant aliases still share a table', { concurre
   }
 });
 
+test('pool royale quick matchmaking ignores non-variant metadata when stake+variant match', { concurrency: false, timeout: 20000 }, async () => {
+  fs.mkdirSync(new URL('assets', distDir), { recursive: true });
+  fs.writeFileSync(new URL('index.html', distDir), '');
+
+  const env = {
+    ...process.env,
+    PORT: '3211',
+    MONGO_URI: 'memory',
+    BOT_TOKEN: 'dummy',
+    API_AUTH_TOKEN: apiToken,
+    SKIP_WEBAPP_BUILD: '1',
+    SKIP_BOT_LAUNCH: '1'
+  };
+
+  const server = await startServer(env);
+  const s1 = connectClient(3211);
+  const s2 = connectClient(3211);
+
+  try {
+    await Promise.all([
+      new Promise((resolve) => s1.on('connect', resolve)),
+      new Promise((resolve) => s2.on('connect', resolve))
+    ]);
+
+    s1.emit('register', { playerId: 'acct-meta-1' });
+    s2.emit('register', { playerId: 'acct-meta-2' });
+
+    const firstSeat = await new Promise((resolve) => {
+      s1.emit(
+        'seatTable',
+        {
+          accountId: 'acct-meta-1',
+          gameType: 'poolroyale',
+          stake: 500,
+          maxPlayers: 2,
+          mode: 'ranked',
+          playType: 'duel',
+          tableSize: '9ft',
+          ballSet: 'american',
+          variant: '8ball',
+          playerName: 'MetaA'
+        },
+        resolve
+      );
+    });
+
+    const secondSeat = await new Promise((resolve) => {
+      s2.emit(
+        'seatTable',
+        {
+          accountId: 'acct-meta-2',
+          gameType: 'poolroyale',
+          stake: 500,
+          maxPlayers: 2,
+          mode: 'casual',
+          playType: 'quick',
+          tableSize: 'pro',
+          ballSet: 'uk',
+          variant: 'eightball',
+          playerName: 'MetaB'
+        },
+        resolve
+      );
+    });
+
+    assert.equal(firstSeat.success, true);
+    assert.equal(secondSeat.success, true);
+    assert.equal(secondSeat.tableId, firstSeat.tableId);
+    assert.equal(secondSeat.players.length, 2);
+  } finally {
+    s1.disconnect();
+    s2.disconnect();
+    server.kill();
+  }
+});
+
 test('pool royale disconnect clears stale lobby seat so next player can queue cleanly', { concurrency: false, timeout: 20000 }, async () => {
   fs.mkdirSync(new URL('assets', distDir), { recursive: true });
   fs.writeFileSync(new URL('index.html', distDir), '');


### PR DESCRIPTION
### Motivation
- Players in the Pool Royale lobby could both appear online but fail to match because optional lobby metadata fragmented queues beyond `stake` and `variant`.
- The intent is to simplify quick matchmaking for Pool Royale so players with the same `stake` and equivalent `variant` (including alias normalization) are matched reliably.

### Description
- Added a `gameType` aware branch to `isMatchMetaCompatible` that, for `poolroyale`, treats matching as compatible when `variant` values match (and treats missing variants as wildcards). (`bot/server.js`)
- Passed `gameType` into the matchmaking check in `getAvailableTable` so the Pool Royale-specific rule is applied when searching for open tables. (`bot/server.js`)
- Added a regression test `pool royale quick matchmaking ignores non-variant metadata when stake+variant match` to `test/poolRoyaleMatchmakingMeta.test.js` that verifies players match even when `mode`, `playType`, `tableSize`, and `ballSet` differ as long as `stake` and `variant` align.

### Testing
- Ran `node --test test/poolRoyaleMatchmakingMeta.test.js` which executed the existing matchmaking tests plus the new regression test and all tests passed. 
- The test run covered matching by stake/variant aliases and the new scenario where non-variant metadata differs, with zero failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c21a820cac832989216f2a26cc17d4)