### PR TITLE
Fix Chess Battle Royal lobby pairing and default side selection

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyalLobby.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyalLobby.jsx
@@ -139,7 +139,7 @@ export default function ChessBattleRoyalLobby() {
   const [onlinePlayers, setOnlinePlayers] = useState([]);
   const [matchStatus, setMatchStatus] = useState('');
   const [matchError, setMatchError] = useState('');
-  const [preferredSide, setPreferredSide] = useState('auto');
+  const preferredSide = 'auto';
   const pendingTableRef = useRef('');
   const cleanupRef = useRef(() => {});
   const matchmakingTimeoutRef = useRef(null);
@@ -311,6 +311,7 @@ export default function ChessBattleRoyalLobby() {
       matchmakingTimeoutRef.current = null;
     }
     socket.off('gameStart');
+    socket.off('gameStarted');
     socket.off('lobbyUpdate');
     if (!skipLeave && pendingTableRef.current && (account || accountId)) {
       socket.emit('leaveLobby', {
@@ -402,7 +403,7 @@ export default function ChessBattleRoyalLobby() {
       players: list = [],
       ready = []
     } = {}) => {
-      if (!tid || tid !== pendingTableRef.current) return;
+      if (!tid || String(tid) !== String(pendingTableRef.current)) return;
       setMatchPlayers(Array.isArray(list) ? list : []);
       setReadyList(Array.isArray(ready) ? ready.map((id) => String(id)) : []);
       const others = list.filter(
@@ -416,7 +417,7 @@ export default function ChessBattleRoyalLobby() {
     };
 
     const handleGameStart = ({ tableId: startedId, players = [] } = {}) => {
-      if (!startedId || startedId !== pendingTableRef.current) return;
+      if (!startedId || String(startedId) !== String(pendingTableRef.current)) return;
       const meIndex = players.findIndex(
         (p) => resolveTpcAccountNumber(p) === String(seatAccountId)
       );
@@ -442,6 +443,7 @@ export default function ChessBattleRoyalLobby() {
       cleanupLobby({ account: trackedAccountId, skipRefReset: true });
 
     socket.on('gameStart', handleGameStart);
+    socket.on('gameStarted', handleGameStart);
     socket.on('lobbyUpdate', handleLobbyUpdate);
 
     const matchTimeout = window.setTimeout(() => {
@@ -704,79 +706,6 @@ export default function ChessBattleRoyalLobby() {
             <p className="text-center text-white/60 text-xs">
               Staking uses your TPC account{accountId ? ` #${accountId}` : ''}{' '}
               as escrow for every online round.
-            </p>
-          </div>
-        )}
-
-        {mode === 'online' && (
-          <div className="space-y-2">
-            <div className="flex items-center justify-between">
-              <h3 className="font-semibold text-white">Pick Your Pieces</h3>
-              <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">
-                Sides
-              </span>
-            </div>
-            <div className="grid grid-cols-3 gap-3">
-              {[
-                {
-                  key: 'auto',
-                  label: 'Auto',
-                  desc: 'Random seats, no duplicates',
-                  accent: 'from-slate-400/30 via-slate-500/10 to-transparent',
-                  icon: '🎲'
-                },
-                {
-                  key: 'white',
-                  label: 'White',
-                  desc: 'You start first',
-                  accent: 'from-white/40 via-white/10 to-transparent',
-                  icon: '♔'
-                },
-                {
-                  key: 'black',
-                  label: 'Black',
-                  desc: 'Opponent opens',
-                  accent: 'from-gray-500/30 via-gray-700/10 to-transparent',
-                  icon: '♚'
-                }
-              ].map(({ key, label, desc, accent, icon }) => {
-                const active = preferredSide === key;
-                return (
-                  <button
-                    key={key}
-                    type="button"
-                    onClick={() => setPreferredSide(key)}
-                    className={`flex flex-col gap-3 rounded-2xl border px-4 py-4 text-left shadow transition ${
-                      active
-                        ? 'border-primary bg-primary/10 text-primary'
-                        : 'border-white/10 bg-black/30 text-white/80 hover:border-white/30'
-                    }`}
-                  >
-                    <div
-                      className={`h-12 w-12 rounded-2xl bg-gradient-to-br ${accent} p-[1px]`}
-                    >
-                      <div className="flex h-full w-full items-center justify-center rounded-[18px] bg-[#0b1220] text-xl">
-                        {icon}
-                      </div>
-                    </div>
-                    <div>
-                      <div className="flex items-center justify-between">
-                        <span className="font-semibold">{label}</span>
-                        {active && (
-                          <span className="text-[10px] font-bold uppercase">
-                            Selected
-                          </span>
-                        )}
-                      </div>
-                      <div className="text-xs text-white/60">{desc}</div>
-                    </div>
-                  </button>
-                );
-              })}
-            </div>
-            <p className="text-xs text-white/60 text-center">
-              Auto randomizes colors while ensuring both players get different
-              sides.
             </p>
           </div>
         )}


### PR DESCRIPTION
### Motivation
- Players with identical lobby criteria could fail to pair due to manual side selection and mismatched event variants from the server, so the lobby should enforce a single automatic side policy and be more resilient to server event names and id types. 

### Description
- Force the online side preference to always be `auto` by replacing `const [preferredSide, setPreferredSide] = useState('auto')` with `const preferredSide = 'auto'` in `webapp/src/pages/Games/ChessBattleRoyalLobby.jsx`. 
- Remove the online "Pick Your Pieces" side-selection UI so players do not choose sides in the lobby (the lobby now proceeds directly from stake selection to matchmaking). 
- Harden matchmaking socket handling by subscribing to both `gameStart` and `gameStarted` events and ensuring cleanup removes both listeners. 
- Normalize table ID comparisons in `lobbyUpdate` and `gameStart` handlers to use `String(...)` comparisons to avoid false mismatches when IDs arrive as different primitive types. 

### Testing
- Ran the production build with `npm --prefix webapp run build`, which completed successfully and produced the updated `ChessBattleRoyalLobby` bundle. 
- Verified the modified lobby component compiles into the production bundle and no runtime compile errors appeared during the build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c219e549f4832998d5ba2d5cd0cb60)