### PR TITLE
Fix TON wallet balance retrieval (use TonAPI account balance)

### DIFF
--- a/webapp/src/hooks/useTokenBalances.js
+++ b/webapp/src/hooks/useTokenBalances.js
@@ -88,16 +88,27 @@ export default function useTokenBalances() {
         return;
       }
       try {
-        const ton = await getTonBalance(walletAddress);
-        if (ton?.error) throw new Error(ton.error);
-        setTonBalance(ton.balance ?? 0);
+        const tonapiRes = await fetch(
+          `https://tonapi.io/v2/accounts/${encodeURIComponent(walletAddress)}`
+        );
+        if (!tonapiRes.ok) throw new Error(`tonapi account request failed (${tonapiRes.status})`);
+        const tonapiData = await tonapiRes.json();
+        const nanoTonBalance = Number(tonapiData?.balance ?? 0);
+        setTonBalance(Number.isFinite(nanoTonBalance) ? nanoTonBalance / 1e9 : 0);
       } catch (err) {
-        console.error('Failed to load TON balance:', err);
-        setTonBalance(0);
+        console.error('Failed to load TON balance from tonapi:', err);
+        try {
+          const ton = await getTonBalance(walletAddress);
+          if (ton?.error) throw new Error(ton.error);
+          setTonBalance(ton.balance ?? 0);
+        } catch (fallbackErr) {
+          console.error('Failed to load TON balance from backend fallback:', fallbackErr);
+          setTonBalance(0);
+        }
       }
       try {
         const res = await fetch(
-          `https://tonapi.io/v2/accounts/${walletAddress}/jettons/EQDY3qbfGN6IMI5d4MsEoprhuMTz09OkqjyhPKX6DVtzbi6X`
+          `https://tonapi.io/v2/accounts/${encodeURIComponent(walletAddress)}/jettons/EQDY3qbfGN6IMI5d4MsEoprhuMTz09OkqjyhPKX6DVtzbi6X`
         );
         if (!res.ok) throw new Error('request failed');
         const data = await res.json();


### PR DESCRIPTION
### Motivation
- The UI showed `$0.00` for connected TON wallets because the hook relied on a path that could return zero for some address formats, so the on-screen USD/TON values were incorrect. 
- The goal is to read the true on-chain TON balance for the connected wallet and avoid malformed requests when addresses contain reserved characters.

### Description
- Updated `webapp/src/hooks/useTokenBalances.js` to fetch account data from TonAPI's account endpoint (`https://tonapi.io/v2/accounts/{address}`) and convert the returned nanoTON balance to TON before setting `tonBalance`.
- Applied `encodeURIComponent` to the wallet address when calling TonAPI for both the account and jetton endpoints to prevent URL-breaking address formats. 
- Added a safe fallback to call the existing backend `getTonBalance` if the TonAPI request fails, preserving the previous behavior as a secondary option.

### Testing
- Ran `cd webapp && npm run build` and the build completed successfully. 
- Vite produced existing, non-blocking warnings about chunk size and mixed static/dynamic imports which are unrelated to the balance fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2cc000aa48329bbb5ebc1d08b2fb4)