### PR TITLE
Fix Pool Royale variant alias matchmaking in lobby

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -512,10 +512,11 @@ function normalizeBallSetMeta(value = '') {
 function normalizeVariantMeta(value = '') {
   const normalized = String(value || '').trim().toLowerCase();
   if (!normalized) return '';
+  const compact = normalized.replace(/[\s_-]+/g, '');
   if (normalized === 'us' || normalized === 'usa') return 'american';
   if (normalized === 'english') return 'uk';
-  if (normalized === 'eightball' || normalized === '8-ball') return '8ball';
-  if (normalized === 'nineball' || normalized === '9-ball') return '9ball';
+  if (compact === 'eightball' || compact === '8ball') return '8ball';
+  if (compact === 'nineball' || compact === '9ball') return '9ball';
   return normalized;
 }
 

--- a/test/poolRoyaleMatchmakingMeta.test.js
+++ b/test/poolRoyaleMatchmakingMeta.test.js
@@ -158,6 +158,76 @@ test('pool royale players using variant aliases still share a table', { concurre
   }
 });
 
+test('pool royale players using spaced variant aliases still share a table', { concurrency: false, timeout: 20000 }, async () => {
+  fs.mkdirSync(new URL('assets', distDir), { recursive: true });
+  fs.writeFileSync(new URL('index.html', distDir), '');
+
+  const env = {
+    ...process.env,
+    PORT: '3217',
+    MONGO_URI: 'memory',
+    BOT_TOKEN: 'dummy',
+    API_AUTH_TOKEN: apiToken,
+    SKIP_WEBAPP_BUILD: '1',
+    SKIP_BOT_LAUNCH: '1'
+  };
+
+  const server = await startServer(env);
+  const s1 = connectClient(3217);
+  const s2 = connectClient(3217);
+
+  try {
+    await Promise.all([
+      new Promise((resolve) => s1.on('connect', resolve)),
+      new Promise((resolve) => s2.on('connect', resolve))
+    ]);
+
+    s1.emit('register', { playerId: 'acct-variant-space-1' });
+    s2.emit('register', { playerId: 'acct-variant-space-2' });
+
+    const firstSeat = await new Promise((resolve) => {
+      s1.emit(
+        'seatTable',
+        {
+          accountId: 'acct-variant-space-1',
+          gameType: 'poolroyale',
+          stake: 250,
+          maxPlayers: 2,
+          mode: 'online',
+          variant: '8 ball',
+          playerName: 'VariantSpaceA'
+        },
+        resolve
+      );
+    });
+
+    const secondSeat = await new Promise((resolve) => {
+      s2.emit(
+        'seatTable',
+        {
+          accountId: 'acct-variant-space-2',
+          gameType: 'poolroyale',
+          stake: 250,
+          maxPlayers: 2,
+          mode: 'online',
+          variant: '8_ball',
+          playerName: 'VariantSpaceB'
+        },
+        resolve
+      );
+    });
+
+    assert.equal(firstSeat.success, true);
+    assert.equal(secondSeat.success, true);
+    assert.equal(secondSeat.tableId, firstSeat.tableId);
+    assert.equal(secondSeat.players.length, 2);
+  } finally {
+    s1.disconnect();
+    s2.disconnect();
+    server.kill();
+  }
+});
+
 test('pool royale quick matchmaking ignores non-variant metadata when stake+variant match', { concurrency: false, timeout: 20000 }, async () => {
   fs.mkdirSync(new URL('assets', distDir), { recursive: true });
   fs.writeFileSync(new URL('index.html', distDir), '');


### PR DESCRIPTION
### Motivation
- Players using equivalent but differently formatted Pool Royale variant strings (e.g. `8 ball`, `8_ball`, `8-ball`) were treated as distinct matchmaking buckets and could not be paired despite matching stake and game type.
- Normalize variant metadata more robustly so matchmaking groups by canonical variant values rather than raw client string formatting.

### Description
- Update `normalizeVariantMeta` in `bot/server.js` to remove spaces, underscores and dashes (`/[\s_-]+/g`) before matching, and map compacted values to canonical `8ball`/`9ball` names while preserving existing mappings for `american`/`uk`.
- Ensure `normalizeMatchMetaValue` continues to call the improved variant normalizer so lobby matching sees canonical values.
- Add an integration regression test in `test/poolRoyaleMatchmakingMeta.test.js` that seats two accounts using spaced/underscored variant aliases and verifies they join the same table.

### Testing
- Ran `npm test -- test/poolRoyaleMatchmakingMeta.test.js`; the suite passed with the new test included (7 tests passed).
- Verified the new test case `pool royale players using spaced variant aliases still share a table` passes alongside the existing Pool Royale matchmaking tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2cb23c1ec8329a9d6bf3016e9d335)