### PR TITLE
Ignore stale tableId during quick matchmaking to restore stake-based matching

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -646,19 +646,8 @@ function getAvailableTable(
   if (forcedTableId) {
     const existing = tableMap.get(forcedTableId);
     if (existing) return existing;
-    const table = {
-      id: forcedTableId,
-      gameType,
-      stake,
-      maxPlayers,
-      players: [],
-      currentTurn: null,
-      ready: new Set(),
-      meta: normalizedMeta
-    };
-    lobbyTables[key].push(table);
-    tableMap.set(table.id, table);
-    return table;
+    // Ignore stale/non-existent forced ids so quick matchmaking can still pair
+    // users by game type + stake instead of trapping them in a private table.
   }
   const open = lobbyTables[key].find(
     (t) =>

--- a/test/chessLobbyStaleTableIdMatchmaking.test.js
+++ b/test/chessLobbyStaleTableIdMatchmaking.test.js
@@ -1,0 +1,90 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import { spawn } from 'child_process';
+import { io } from 'socket.io-client';
+
+const distDir = new URL('../webapp/dist/', import.meta.url);
+const apiToken = 'test-token';
+
+async function startServer(env) {
+  const server = spawn('node', ['bot/server.js'], { env, stdio: 'pipe' });
+  server.stdout.on('data', (chunk) => process.stdout.write(chunk));
+  server.stderr.on('data', (chunk) => process.stderr.write(chunk));
+  await new Promise((resolve) => {
+    const onData = (chunk) => {
+      if (chunk.toString().includes('Server running on port')) {
+        server.stdout.off('data', onData);
+        resolve();
+      }
+    };
+    server.stdout.on('data', onData);
+  });
+  return server;
+}
+
+test(
+  'chess quick matchmaking ignores stale table ids and still matches same-stake players',
+  { concurrency: false, timeout: 20000 },
+  async () => {
+    fs.mkdirSync(new URL('assets', distDir), { recursive: true });
+    fs.writeFileSync(new URL('index.html', distDir), '');
+    const env = {
+      ...process.env,
+      PORT: '3212',
+      MONGO_URI: 'memory',
+      BOT_TOKEN: 'dummy',
+      API_AUTH_TOKEN: apiToken,
+      SKIP_WEBAPP_BUILD: '1',
+      SKIP_BOT_LAUNCH: '1'
+    };
+    const server = await startServer(env);
+    const s1 = io('http://localhost:3212', { auth: { token: apiToken } });
+    const s2 = io('http://localhost:3212', { auth: { token: apiToken } });
+
+    try {
+      await Promise.all([
+        new Promise((resolve) => s1.on('connect', resolve)),
+        new Promise((resolve) => s2.on('connect', resolve))
+      ]);
+
+      const register = (socket, playerId) =>
+        new Promise((resolve) => {
+          socket.emit('register', { playerId }, resolve);
+        });
+      await Promise.all([register(s1, 'chess-stale-a'), register(s2, 'chess-stale-b')]);
+
+      const seat = (socket, payload) =>
+        new Promise((resolve) => {
+          socket.emit('seatTable', payload, resolve);
+        });
+
+      const firstSeat = await seat(s1, {
+        accountId: 'chess-stale-a',
+        gameType: 'chess',
+        stake: 500,
+        maxPlayers: 2,
+        mode: 'online',
+        token: 'TPC',
+        tableId: 'stale-table-a'
+      });
+      const secondSeat = await seat(s2, {
+        accountId: 'chess-stale-b',
+        gameType: 'chess',
+        stake: 500,
+        maxPlayers: 2,
+        mode: 'online',
+        token: 'TPC',
+        tableId: 'stale-table-b'
+      });
+
+      assert.equal(firstSeat.success, true);
+      assert.equal(secondSeat.success, true);
+      assert.equal(secondSeat.tableId, firstSeat.tableId);
+    } finally {
+      s1.disconnect();
+      s2.disconnect();
+      server.kill();
+    }
+  }
+);


### PR DESCRIPTION
### Motivation
- Players carrying stale or opaque `tableId` values could be forced into new private tables, preventing quick matchmaking by stake and making the lobby search appear broken. 
- The goal is to allow normal matchmaking when a provided `tableId` does not refer to an existing table so same-stake players can be paired.

### Description
- Stop creating a new table for a non-existent `forcedTableId` in `getAvailableTable` inside `bot/server.js`, so the server falls back to open-table matchmaking by `gameType`, `stake`, and compatible meta.
- Keep the existing behavior where an existing `forcedTableId` still returns that table when present. 
- Add regression test `test/chessLobbyStaleTableIdMatchmaking.test.js` which verifies two chess players with matching stake but different stale `tableId` values are seated into the same table.

### Testing
- Ran `npm test -- --runInBand test/chessLobbyPreferredSideMatchmaking.test.js test/chessLobbyStaleTableIdMatchmaking.test.js` and both test suites passed. 
- The new regression test `test/chessLobbyStaleTableIdMatchmaking.test.js` passed and confirms stale `tableId` values no longer block stake-based matching.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c36fe82bd48329ac6ff29a022f2dfb)