### PR TITLE
Support matchMeta payload for Pool Royale seatTable matchmaking

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -1746,6 +1746,10 @@ io.on('connection', (socket) => {
       payload = {},
       cb
     ) => {
+      const payloadMatchMeta =
+        payload?.matchMeta && typeof payload.matchMeta === 'object'
+          ? payload.matchMeta
+          : {};
       const {
         gameType,
         stake,
@@ -1761,6 +1765,14 @@ io.on('connection', (socket) => {
         ballSet,
         token
       } = payload;
+      const resolvedVariant = payloadMatchMeta.variant ?? variant;
+      const resolvedMode = payloadMatchMeta.mode ?? mode;
+      const resolvedPlayType = payloadMatchMeta.playType ?? playType;
+      const resolvedTableSize = payloadMatchMeta.tableSize ?? tableSize;
+      const resolvedBallSet = payloadMatchMeta.ballSet ?? ballSet;
+      const resolvedToken = payloadMatchMeta.token ?? token;
+      const resolvedPreferredSide =
+        payloadMatchMeta.preferredSide ?? preferredSide;
       const resolvedAccountId = resolveTpcIdentity(payload);
       if (hasConflictingIdentities(payload)) {
         return cb && cb({ success: false, error: 'identity_mismatch' });
@@ -1785,7 +1797,15 @@ io.on('connection', (socket) => {
         gameType: resolvedGameType,
         stake,
         maxPlayers: resolvedMaxPlayers,
-        matchMeta: { variant, mode, playType, tableSize, ballSet, token, preferredSide }
+        matchMeta: {
+          variant: resolvedVariant,
+          mode: resolvedMode,
+          playType: resolvedPlayType,
+          tableSize: resolvedTableSize,
+          ballSet: resolvedBallSet,
+          token: resolvedToken,
+          preferredSide: resolvedPreferredSide
+        }
       });
       if (!validation.ok) {
         return cb && cb({ success: false, error: validation.error });
@@ -1810,7 +1830,7 @@ io.on('connection', (socket) => {
           playerName,
           socket,
           avatar,
-          preferredSide,
+          resolvedPreferredSide,
           safeMeta,
           tableId
         );
@@ -1823,7 +1843,7 @@ io.on('connection', (socket) => {
           playerName,
           socket,
           avatar,
-          preferredSide,
+          resolvedPreferredSide,
           safeMeta
         );
       }

--- a/test/poolRoyaleMatchmakingMeta.test.js
+++ b/test/poolRoyaleMatchmakingMeta.test.js
@@ -228,6 +228,83 @@ test('pool royale players using spaced variant aliases still share a table', { c
   }
 });
 
+test('pool royale players sending matchMeta payload are matched by stake + variant', { concurrency: false, timeout: 20000 }, async () => {
+  fs.mkdirSync(new URL('assets', distDir), { recursive: true });
+  fs.writeFileSync(new URL('index.html', distDir), '');
+
+  const env = {
+    ...process.env,
+    PORT: '3216',
+    MONGO_URI: 'memory',
+    BOT_TOKEN: 'dummy',
+    API_AUTH_TOKEN: apiToken,
+    SKIP_WEBAPP_BUILD: '1',
+    SKIP_BOT_LAUNCH: '1'
+  };
+
+  const server = await startServer(env);
+  const s1 = connectClient(3216);
+  const s2 = connectClient(3216);
+
+  try {
+    await Promise.all([
+      new Promise((resolve) => s1.on('connect', resolve)),
+      new Promise((resolve) => s2.on('connect', resolve))
+    ]);
+
+    s1.emit('register', { playerId: 'acct-meta-1' });
+    s2.emit('register', { playerId: 'acct-meta-2' });
+
+    const firstSeat = await new Promise((resolve) => {
+      s1.emit(
+        'seatTable',
+        {
+          accountId: 'acct-meta-1',
+          gameType: 'poolroyale',
+          stake: 150,
+          maxPlayers: 2,
+          playerName: 'MetaOne',
+          matchMeta: {
+            variant: '8ball',
+            mode: 'online',
+            playType: 'regular',
+            tableSize: 'pro'
+          }
+        },
+        resolve
+      );
+    });
+
+    const secondSeat = await new Promise((resolve) => {
+      s2.emit(
+        'seatTable',
+        {
+          accountId: 'acct-meta-2',
+          gameType: 'poolroyale',
+          stake: 150,
+          maxPlayers: 2,
+          playerName: 'MetaTwo',
+          matchMeta: {
+            variant: '8-ball',
+            mode: 'online',
+            playType: 'regular'
+          }
+        },
+        resolve
+      );
+    });
+
+    assert.equal(firstSeat.success, true);
+    assert.equal(secondSeat.success, true);
+    assert.equal(secondSeat.tableId, firstSeat.tableId);
+    assert.equal(secondSeat.players.length, 2);
+  } finally {
+    s1.disconnect();
+    s2.disconnect();
+    server.kill();
+  }
+});
+
 test('pool royale quick matchmaking ignores non-variant metadata when stake+variant match', { concurrency: false, timeout: 20000 }, async () => {
   fs.mkdirSync(new URL('assets', distDir), { recursive: true });
   fs.writeFileSync(new URL('index.html', distDir), '');


### PR DESCRIPTION
### Motivation
- Clients sometimes send matchmaking fields under a nested `matchMeta` object instead of top-level keys, and the server previously ignored those nested values which caused Pool Royale online matchmaking to miss compatible players.
- The change ensures consistent handling of matchmaking metadata (variant/stake/etc.) so players with matching stake and variant are seated together even when clients use `matchMeta`.

### Description
- Read and merge `payload.matchMeta` into resolved matchmaking fields (`variant`, `mode`, `playType`, `tableSize`, `ballSet`, `token`, `preferredSide`) before validation in the `seatTable` socket handler in `bot/server.js`.
- Use the resolved metadata for `validateSeatTableRequest` and pass the resolved `preferredSide` to `seatTableSocket` so seating/ready logic is consistent regardless of payload shape.
- Add a regression test in `test/poolRoyaleMatchmakingMeta.test.js` that submits two `seatTable` requests using `matchMeta` and asserts they are matched into the same table, including variant alias normalization (e.g., `8ball` vs `8-ball`).

### Testing
- Ran `npm test -- test/poolRoyaleMatchmakingMeta.test.js --runInBand` which executed the file-level test suite.
- All tests in that file passed: `8 tests, 8 passed` (the new regression test included).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c370c988688329b2b6c04cf2c47e5d)