### PR TITLE
Pool Royale: only honor URL tableId for invites to avoid stale-table matchmaking

### DIFF
--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -59,6 +59,9 @@ export default function PoolRoyaleLobby() {
   const initialMode = searchParams.get('mode') === 'online' ? 'online' : 'ai';
   const autoStartRequested = searchParams.get('autostart') === '1';
   const requestedOnlineTableId = (searchParams.get('tableId') || '').trim();
+  const useRequestedOnlineTableId =
+    (searchParams.get('invite') === '1' || searchParams.get('joinTable') === '1') &&
+    requestedOnlineTableId;
 
   const [stake, setStake] = useState({ token: 'TPC', amount: 100 });
   const [mode, setMode] = useState(initialMode);
@@ -223,7 +226,7 @@ export default function PoolRoyaleLobby() {
     if (isOnlineMatch) {
       await runPoolRoyaleOnlineFlow({
         stake,
-        tableId: requestedOnlineTableId || undefined,
+        tableId: useRequestedOnlineTableId || undefined,
         variant,
         ballSet: ukBallSet,
         playType,


### PR DESCRIPTION
### Motivation
- Players could be forced into stale/opaque `tableId` values from the URL which acted as a forced table target and isolated them from normal stake+variant matchmaking, preventing automatic pairings.

### Description
- Added a conditional `useRequestedOnlineTableId` in `webapp/src/pages/Games/PoolRoyaleLobby.jsx` that only forwards `tableId` to `runPoolRoyaleOnlineFlow` when the URL includes an explicit invite/join flag (`invite=1` or `joinTable=1`), otherwise passing `undefined` to allow open queue matchmaking.

### Testing
- Ran `npm test -- --runInBand test/poolRoyaleOnlineFlow.test.js test/poolRoyaleMatchmakingMeta.test.js` and both test suites passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c370c988688329b2b6c04cf2c47e5d)