### PR TITLE
Fix Checkers Battle Royal online matchmaking identity payloads

### DIFF
--- a/webapp/src/pages/Games/CheckersBattleRoyalLobby.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyalLobby.jsx
@@ -104,6 +104,17 @@ async function ensureSocketRegistered(accountId, timeoutMs = SOCKET_REGISTER_TIM
   });
 }
 
+
+function resolveLobbyPlayerAccount(player = {}) {
+  return String(
+    player?.tpcAccountNumber ||
+      player?.tpcAccountId ||
+      player?.accountId ||
+      player?.id ||
+      ''
+  );
+}
+
 export default function CheckersBattleRoyalLobby() {
   const navigate = useNavigate();
   useTelegramBackButton();
@@ -256,10 +267,12 @@ export default function CheckersBattleRoyalLobby() {
       matchmakingTimeoutRef.current = null;
     }
     socket.off('gameStart');
+    socket.off('gameStarted');
     socket.off('lobbyUpdate');
     if (!skipLeave && pendingTableRef.current && (account || accountId)) {
       socket.emit('leaveLobby', {
         accountId: account || accountId,
+        tpcAccountNumber: account || accountId,
         tpcAccountId: account || accountId,
         tableId: pendingTableRef.current
       });
@@ -374,7 +387,9 @@ export default function CheckersBattleRoyalLobby() {
 
     const handleLobbyUpdate = ({ tableId: tid, players: list = [] } = {}) => {
       if (!tid || tid !== pendingTableRef.current) return;
-      const others = list.filter((p) => String(p.id) !== String(seatAccountId));
+      const others = list.filter(
+        (p) => resolveLobbyPlayerAccount(p) !== String(seatAccountId)
+      );
       if (others.length > 0) {
         setMatchStatus('Opponent joined. Locking seats…');
       } else {
@@ -384,11 +399,15 @@ export default function CheckersBattleRoyalLobby() {
 
     const handleGameStart = ({ tableId: startedId, players = [] } = {}) => {
       if (!startedId || startedId !== pendingTableRef.current) return;
-      const meIndex = players.findIndex((p) => String(p.id) === String(seatAccountId));
-      const opp = players.find((p) => String(p.id) !== String(seatAccountId));
+      const meIndex = players.findIndex(
+        (p) => resolveLobbyPlayerAccount(p) === String(seatAccountId)
+      );
+      const opp = players.find(
+        (p) => resolveLobbyPlayerAccount(p) !== String(seatAccountId)
+      );
       const mySide =
-        players.find((p) => String(p.id) === String(seatAccountId))?.side ||
-        (meIndex === 0 ? 'white' : 'black');
+        players.find((p) => resolveLobbyPlayerAccount(p) === String(seatAccountId))
+          ?.side || (meIndex === 0 ? 'white' : 'black');
       cleanupLobby({ account: trackedAccountId, skipLeave: true });
       navigateToGame({
         tgId,
@@ -410,11 +429,13 @@ export default function CheckersBattleRoyalLobby() {
       setMatching(false);
       setMatchStatus('');
       socket.off('gameStart', handleGameStart);
+      socket.off('gameStarted', handleGameStart);
       socket.off('lobbyUpdate', handleLobbyUpdate);
       return;
     }
 
     socket.on('gameStart', handleGameStart);
+    socket.on('gameStarted', handleGameStart);
     socket.on('lobbyUpdate', handleLobbyUpdate);
 
     const friendlyName = getTelegramFirstName() || getTelegramUsername() || 'Player';
@@ -434,7 +455,8 @@ export default function CheckersBattleRoyalLobby() {
       socket.emit(
         'seatTable',
         {
-          accountId: trackedAccountId || accountId,
+          accountId: seatAccountId,
+          tpcAccountNumber: seatAccountId,
           tpcAccountId: seatAccountId,
           gameType: 'checkers',
           stake: stake.amount ?? 0,


### PR DESCRIPTION
### Motivation
- Online matchmaking sometimes failed to match or seat players because backend events use multiple identity field shapes (`id`, `accountId`, `tpcAccountId`, `tpcAccountNumber`) and the lobby flow only compared one field. 
- The lobby needed to send the full identity payload when seating/leaving so stake-based matching on the server can reliably identify players.

### Description
- Added a helper `resolveLobbyPlayerAccount(player)` in `webapp/src/pages/Games/CheckersBattleRoyalLobby.jsx` to normalize backend player identity from `tpcAccountNumber`, `tpcAccountId`, `accountId`, or `id` into a single comparable string. 
- Switched lobby update and game-start comparisons to use `resolveLobbyPlayerAccount(...)` so opponent detection and side assignment work regardless of which id field the backend emits. 
- Included `tpcAccountNumber`, and used `seatAccountId` as the `accountId` when emitting `seatTable`, and added `tpcAccountNumber`/`tpcAccountId` to the `leaveLobby` payload so the server receives all expected identity fields. 
- Subscribed to both `gameStart` and `gameStarted` socket events and added corresponding `off` cleanup so the client reliably transitions into the match when the server starts a table. 

### Testing
- Ran the production build with `npm --prefix webapp run build` and the build completed successfully. 
- The modified `CheckersBattleRoyalLobby.jsx` was built into the production bundle (see `CheckersBattleRoyalLobby` chunks) without build errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c370ce78ac83299556c71688e74d57)