### PR TITLE
Improve Pool Royale online matchmaking resilience for transient socket issues

### DIFF
--- a/test/poolRoyaleOnlineFlow.test.js
+++ b/test/poolRoyaleOnlineFlow.test.js
@@ -416,11 +416,55 @@ test('runPoolRoyaleOnlineFlow refunds if register ack fails', async () => {
     timeouts: { seat: 50, matchmaking: 100, register: 40 }
   });
 
-  assert.equal(mockSocket.registerRequests.length, 1);
+  assert.equal(mockSocket.registerRequests.length, 3);
   assert.equal(mockSocket.seatRequests.length, 0);
   assert.equal(addCalls.length, 2, 'should debit then refund when register ack fails');
   assert.equal(addCalls[1][2], 'stake_refund');
   assert.ok(state.snapshot.matchingError.includes('online session'));
+});
+
+test('runPoolRoyaleOnlineFlow retries register after transient ack failure', async () => {
+  class FlakyRegisterSocket extends MockSocket {
+    emit(event, payload, cb) {
+      if (event === 'register') {
+        this.registerRequests.push(payload);
+        const attempt = this.registerRequests.length;
+        if (typeof cb === 'function') {
+          cb(attempt === 1 ? { success: false, error: 'temporary_failure' } : { success: true });
+        }
+        return true;
+      }
+      return super.emit(event, payload, cb);
+    }
+  }
+
+  const mockSocket = new FlakyRegisterSocket();
+  const refs = createRefs();
+  const state = createState();
+
+  await runPoolRoyaleOnlineFlow({
+    stake: { token: 'TPC', amount: 100 },
+    variant: 'uk',
+    ballSet: 'uk',
+    playType: 'regular',
+    mode: 'online',
+    tableSize: 'medium',
+    avatar: 'me.png',
+    deps: {
+      ensureAccountId: () => Promise.resolve('acct-17'),
+      getAccountBalance: () => Promise.resolve({ balance: 200 }),
+      addTransaction: () => Promise.resolve(),
+      getTelegramId: () => 'tg-17',
+      getTelegramFirstName: () => 'Nora',
+      socket: mockSocket
+    },
+    state,
+    refs,
+    timeouts: { seat: 50, matchmaking: 100, register: 40 }
+  });
+
+  assert.equal(mockSocket.registerRequests.length, 2, 'should retry register once after transient failure');
+  assert.equal(mockSocket.seatRequests.length, 1, 'should continue to seat after register retry succeeds');
 });
 
 test('runPoolRoyaleOnlineFlow retries seat after identity mismatch and starts match', async () => {

--- a/webapp/src/pages/Games/poolRoyaleOnlineFlow.js
+++ b/webapp/src/pages/Games/poolRoyaleOnlineFlow.js
@@ -6,6 +6,8 @@ const DEFAULT_SEAT_TIMEOUT_MS = 12000;
 const DEFAULT_MATCH_TIMEOUT_MS = 30000;
 const DEFAULT_SOCKET_CONNECT_TIMEOUT_MS = 15000;
 const DEFAULT_REGISTER_TIMEOUT_MS = 6000;
+const DEFAULT_SOCKET_READY_ATTEMPTS = 3;
+const DEFAULT_REGISTER_ATTEMPTS = 3;
 
 function resolveTpcAccountNumber(player) {
   if (!player || typeof player !== 'object') return '';
@@ -121,6 +123,37 @@ async function ensureSocketRegistered(
       resolve(false);
     }
   });
+}
+
+async function ensureSocketReadyWithRetry(
+  socketInstance,
+  timeoutMs = DEFAULT_SOCKET_CONNECT_TIMEOUT_MS,
+  maxAttempts = DEFAULT_SOCKET_READY_ATTEMPTS
+) {
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const ready = await ensureSocketReady(socketInstance, timeoutMs);
+    if (ready) return true;
+    if (attempt < maxAttempts) {
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+  }
+  return false;
+}
+
+async function ensureSocketRegisteredWithRetry(
+  socketInstance,
+  accountId,
+  timeoutMs = DEFAULT_REGISTER_TIMEOUT_MS,
+  maxAttempts = DEFAULT_REGISTER_ATTEMPTS
+) {
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const registered = await ensureSocketRegistered(socketInstance, accountId, timeoutMs);
+    if (registered) return true;
+    if (attempt < maxAttempts) {
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+  }
+  return false;
 }
 
 async function recoverSocketIdentity({
@@ -273,7 +306,10 @@ export async function runPoolRoyaleOnlineFlow({
     return { success: false };
   }
 
-  const socketReady = await ensureSocketReady(socketInstance, socketConnectTimeoutMs);
+  const socketReady = await ensureSocketReadyWithRetry(
+    socketInstance,
+    socketConnectTimeoutMs
+  );
   if (!socketReady) {
     setMatchStatus('');
     setMatchingError('Unable to reach the online arena. We refunded your stake.');
@@ -283,7 +319,7 @@ export async function runPoolRoyaleOnlineFlow({
     return { success: false };
   }
 
-  const socketRegistered = await ensureSocketRegistered(
+  const socketRegistered = await ensureSocketRegisteredWithRetry(
     socketInstance,
     accountId,
     registerTimeoutMs


### PR DESCRIPTION
### Motivation
- Reduce false matchmaking failures when mobile/socket connections briefly glitch and users get refunded before a peer can join. 
- Make the client-side Pool Royale setup tolerate transient register/connect hiccups so two players in the same lobby can actually match.

### Description
- Added retry configuration constants `DEFAULT_SOCKET_READY_ATTEMPTS` and `DEFAULT_REGISTER_ATTEMPTS` and implemented `ensureSocketReadyWithRetry` and `ensureSocketRegisteredWithRetry` in `poolRoyaleOnlineFlow`. 
- Replaced single-shot socket readiness and register checks with the new retry wrappers in `runPoolRoyaleOnlineFlow` so the flow waits and retries before refunding stake. 
- Added a new test that simulates a transient `register` ack failure and updated the failing-register test to assert the new retry behavior in `test/poolRoyaleOnlineFlow.test.js`.

### Testing
- Ran the Pool Royale online flow tests with `npm test -- test/poolRoyaleOnlineFlow.test.js`, and all tests passed. 
- Result: `PASS test/poolRoyaleOnlineFlow.test.js` with `8 passed, 8 total`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c387390a108329ba6b329319b2006c)