### PR TITLE
Harden chess lobby matchmaking: seat retry/backoff + stake-safe forced-table joins

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -645,7 +645,15 @@ function getAvailableTable(
   if (!lobbyTables[key]) lobbyTables[key] = [];
   if (forcedTableId) {
     const existing = tableMap.get(forcedTableId);
-    if (existing) return existing;
+    if (existing) {
+      const normalizedStake = Number(stake) || 0;
+      const canJoinForced =
+        existing.gameType === gameType &&
+        Number(existing.stake || 0) === normalizedStake &&
+        existing.players.length < existing.maxPlayers &&
+        isMatchMetaCompatible(existing.meta, normalizedMeta, gameType);
+      if (canJoinForced) return existing;
+    }
     // Ignore stale/non-existent forced ids so quick matchmaking can still pair
     // users by game type + stake instead of trapping them in a private table.
   }

--- a/test/chessLobbyStaleTableIdMatchmaking.test.js
+++ b/test/chessLobbyStaleTableIdMatchmaking.test.js
@@ -88,3 +88,89 @@ test(
     }
   }
 );
+
+test(
+  'chess quick matchmaking ignores forced table ids when stake mismatches',
+  { concurrency: false, timeout: 20000 },
+  async () => {
+    fs.mkdirSync(new URL('assets', distDir), { recursive: true });
+    fs.writeFileSync(new URL('index.html', distDir), '');
+    const env = {
+      ...process.env,
+      PORT: '3213',
+      MONGO_URI: 'memory',
+      BOT_TOKEN: 'dummy',
+      API_AUTH_TOKEN: apiToken,
+      SKIP_WEBAPP_BUILD: '1',
+      SKIP_BOT_LAUNCH: '1'
+    };
+    const server = await startServer(env);
+    const s1 = io('http://localhost:3213', { auth: { token: apiToken } });
+    const s2 = io('http://localhost:3213', { auth: { token: apiToken } });
+    const s3 = io('http://localhost:3213', { auth: { token: apiToken } });
+
+    try {
+      await Promise.all([
+        new Promise((resolve) => s1.on('connect', resolve)),
+        new Promise((resolve) => s2.on('connect', resolve)),
+        new Promise((resolve) => s3.on('connect', resolve))
+      ]);
+
+      const register = (socket, playerId) =>
+        new Promise((resolve) => {
+          socket.emit('register', { playerId }, resolve);
+        });
+
+      await Promise.all([
+        register(s1, 'chess-stake-a'),
+        register(s2, 'chess-stake-b'),
+        register(s3, 'chess-stake-c')
+      ]);
+
+      const seat = (socket, payload) =>
+        new Promise((resolve) => {
+          socket.emit('seatTable', payload, resolve);
+        });
+
+      const firstSeat = await seat(s1, {
+        accountId: 'chess-stake-a',
+        gameType: 'chess',
+        stake: 100,
+        maxPlayers: 2,
+        mode: 'online',
+        token: 'TPC'
+      });
+
+      const mismatchedStakeSeat = await seat(s2, {
+        accountId: 'chess-stake-b',
+        gameType: 'chess',
+        stake: 500,
+        maxPlayers: 2,
+        mode: 'online',
+        token: 'TPC',
+        tableId: firstSeat.tableId
+      });
+
+      const matchingStakeSeat = await seat(s3, {
+        accountId: 'chess-stake-c',
+        gameType: 'chess',
+        stake: 100,
+        maxPlayers: 2,
+        mode: 'online',
+        token: 'TPC',
+        tableId: firstSeat.tableId
+      });
+
+      assert.equal(firstSeat.success, true);
+      assert.equal(mismatchedStakeSeat.success, true);
+      assert.notEqual(mismatchedStakeSeat.tableId, firstSeat.tableId);
+      assert.equal(matchingStakeSeat.success, true);
+      assert.equal(matchingStakeSeat.tableId, firstSeat.tableId);
+    } finally {
+      s1.disconnect();
+      s2.disconnect();
+      s3.disconnect();
+      server.kill();
+    }
+  }
+);

--- a/webapp/src/pages/Games/ChessBattleRoyalLobby.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyalLobby.jsx
@@ -32,6 +32,7 @@ const AI_FLAG_STORAGE_KEY = 'chessBattleRoyalAiFlag';
 const SOCKET_CONNECT_TIMEOUT_MS = 6000;
 const SOCKET_REGISTER_TIMEOUT_MS = 6000;
 const MATCHMAKING_TIMEOUT_MS = 45000;
+const SEAT_RETRY_BASE_DELAY_MS = 700;
 const MATCHMAKING_RECOVERABLE_ERRORS = new Set([
   'register_required',
   'rate_limited',
@@ -457,7 +458,7 @@ export default function ChessBattleRoyalLobby() {
     const friendlyName =
       getTelegramFirstName() || getTelegramUsername() || 'Player';
     let seatAttempts = 0;
-    const maxSeatAttempts = 2;
+    const maxSeatAttempts = 4;
     const seatPlayer = () => {
       seatAttempts += 1;
       socket.emit(
@@ -482,7 +483,11 @@ export default function ChessBattleRoyalLobby() {
               MATCHMAKING_RECOVERABLE_ERRORS.has(res?.error) &&
               seatAttempts < maxSeatAttempts;
             if (shouldRetry) {
-              setMatchStatus('Retrying online seat…');
+              const retryDelay = Math.min(
+                SEAT_RETRY_BASE_DELAY_MS * 2 ** (seatAttempts - 1),
+                3000
+              );
+              setMatchStatus('Retrying matchmaking request…');
               if (res?.error === 'identity_mismatch' && seatAccountId) {
                 refreshSocketAuthIdentity(
                   { accountId: String(seatAccountId) },
@@ -512,7 +517,7 @@ export default function ChessBattleRoyalLobby() {
                   }
                 }
                 seatPlayer();
-              }, 400);
+              }, retryDelay);
               return;
             }
             setMatchError('Could not join the online lobby. Please try again.');


### PR DESCRIPTION
### Motivation
- Matchmaking would stop too quickly in the lobby (short seat attempts / rate-limit windows) and could place players into forced tables with mismatched stakes, breaking stake-based pairing expectations.
- Improve reliability and UX so matchmaking stays active on transient errors and only joins forced tables when game type, capacity and stake/metadata match.

### Description
- Tighten forced-table logic in `bot/server.js` `getAvailableTable` so an existing forced table is only reused when `gameType`, `stake`, `maxPlayers` and `matchMeta` are compatible instead of unconditionally returning the forced table.
- Harden client seat flow in `webapp/src/pages/Games/ChessBattleRoyalLobby.jsx` by increasing `maxSeatAttempts` from `2` to `4`, adding `SEAT_RETRY_BASE_DELAY_MS`, and using exponential backoff (capped) with a clearer retry status message during transient failures.
- Add a regression test in `test/chessLobbyStaleTableIdMatchmaking.test.js` that verifies forced table IDs are ignored when stake mismatches while same-stake players still match into the same table.

### Testing
- Ran the lobby matchmaking tests with `node --test test/chessLobbyStaleTableIdMatchmaking.test.js test/chessLobbyPreferredSideMatchmaking.test.js` and all tests passed (3/3).
- The new stake-mismatch forced-table test confirms tables are not mixed across different stake values and the existing stale-table behavior remains supported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4b09ec764832991b29033aa0bfbe3)