### PR TITLE
Lower local player avatar in Ludo Battle Royal UI

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -351,6 +351,7 @@ const FALLBACK_SEAT_POSITIONS = [
   { left: '52%', top: '24%' },
   { left: '20%', top: '56%' }
 ];
+const SELF_AVATAR_BOTTOM_OFFSET_PERCENT = 2;
 
 const colorNumberToHex = (value) => `#${value.toString(16).padStart(6, '0')}`;
 
@@ -6034,17 +6035,18 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             const fallback =
               FALLBACK_SEAT_POSITIONS[player.index] ||
               FALLBACK_SEAT_POSITIONS[FALLBACK_SEAT_POSITIONS.length - 1];
+            const selfBottomOffset = player.index === 0 ? SELF_AVATAR_BOTTOM_OFFSET_PERCENT : 0;
             const positionStyle = anchor
               ? {
                   position: 'absolute',
                   left: `${anchor.x}%`,
-                  top: `${anchor.y}%`,
+                  top: `${anchor.y + selfBottomOffset}%`,
                   transform: 'translate(-50%, -50%)'
                 }
               : {
                   position: 'absolute',
                   left: fallback.left,
-                  top: fallback.top,
+                  top: `calc(${fallback.top} + ${selfBottomOffset}%)`,
                   transform: 'translate(-50%, -50%)'
                 };
             const depth = anchor?.depth ?? 3;


### PR DESCRIPTION
### Motivation
- Move the bottom (local) Ludo player avatar slightly further down so it appears a bit lower on portrait screens for improved visual alignment and UX.

### Description
- Add `SELF_AVATAR_BOTTOM_OFFSET_PERCENT = 2` in `webapp/src/pages/Games/LudoBattleRoyal.jsx` and apply the offset only when `player.index === 0`, updating both anchor-based and fallback avatar positioning so the local avatar is rendered lower on screen.

### Testing
- Built the web app with `npm --prefix webapp run -s build` and the build completed successfully (Vite emitted non-blocking chunk-size warnings unrelated to this change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4b1134308832999d70bbfa1319f38)