### PR TITLE
Domino: improve live-avatar framing and increase tile texture resolution

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -99,8 +99,8 @@ const FRAME_RATE_TEXTURE_SIZE_MAP = Object.freeze({
 });
 
 const DOMINO_TEXTURE_SIZE_MAP = Object.freeze({
-  hd50: 2048,
-  fhd60: 3328,
+  hd50: 3072,
+  fhd60: 4096,
   qhd90: 4096,
   uhd120: 4096,
   ultra144: 4096
@@ -6484,7 +6484,7 @@ const getDominoSurfaceTextures = (() => {
     const lowMemoryDevice =
       isLowProfileDevice ||
       (typeof navigator !== 'undefined' && typeof navigator.deviceMemory === 'number' && navigator.deviceMemory <= 4);
-    let size = lowMemoryDevice ? Math.min(preferredSize, 2048) : preferredSize;
+    let size = lowMemoryDevice ? Math.min(preferredSize, 3072) : preferredSize;
     let porcelainCanvas = document.createElement('canvas');
     porcelainCanvas.width = porcelainCanvas.height = size;
     let pctx = porcelainCanvas.getContext('2d', { willReadFrequently: true });

--- a/webapp/src/components/GameLiveAvatarOverlay.jsx
+++ b/webapp/src/components/GameLiveAvatarOverlay.jsx
@@ -27,6 +27,13 @@ const AVATAR_ANCHOR_SELECTORS = [
 
 const FRAME_SCALE = 2;
 const ACTIVATION_TOUCH_PADDING = 8;
+const AVATAR_FRAME_STYLES = Object.freeze({
+  borderRadius: '999px',
+  border: '2px solid rgba(255,255,255,.32)',
+  boxShadow: '0 8px 18px rgba(0,0,0,.35),0 0 0 2px rgba(6,12,24,.45)',
+  background:
+    'radial-gradient(circle at 30% 30%,rgba(255,255,255,.2),rgba(0,0,0,.12)),linear-gradient(135deg,#0ea5e9,#22c55e)'
+});
 
 export default function GameLiveAvatarOverlay({ gameSlug, children }) {
   const { search } = useLocation();
@@ -272,12 +279,20 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
           type="button"
           aria-label="Turn off live avatar video"
           onClick={() => setLiveMode(false)}
-          className="fixed z-[65] overflow-hidden rounded-full border border-emerald-300 bg-black/30 touch-manipulation"
+          className="fixed z-[65] overflow-hidden touch-manipulation"
           style={{
             top: `${overlayRect.top}px`,
             left: `${overlayRect.left}px`,
             width: `${overlayRect.width}px`,
-            height: `${overlayRect.height}px`
+            height: `${overlayRect.height}px`,
+            ...(gameSlug === 'domino-royal' ? AVATAR_FRAME_STYLES : {}),
+            ...(gameSlug !== 'domino-royal'
+              ? {
+                  borderRadius: '999px',
+                  border: '1px solid rgb(110 231 183 / 1)',
+                  background: 'rgb(0 0 0 / 0.3)'
+                }
+              : {})
           }}
         >
           <video


### PR DESCRIPTION
### Motivation
- Make the user's live video overlay visually match the avatar frame and preserve a 2× footprint over the avatar anchor for the Domino Battle Royal UI. 
- Raise domino piece texture density so tile surfaces match the table resolution and look sharp on HD/FHD devices.

### Description
- Updated `webapp/src/components/GameLiveAvatarOverlay.jsx` to apply a shared circular avatar frame style (border, shadow, gradient) for the live-video bubble when `gameSlug === 'domino-royal'` while keeping the overlay sizing logic (2× avatar scale) unchanged. 
- Adjusted `webapp/public/domino-royal-game.js` `DOMINO_TEXTURE_SIZE_MAP` to increase `hd50` -> `3072` and `fhd60` -> `4096`. 
- Raised the low-memory ceiling used for creating domino surface canvases from `2048` to `3072` so low-profile devices still produce higher-quality domino maps.

### Testing
- Ran lint check with `npx eslint webapp/src/components/GameLiveAvatarOverlay.jsx webapp/public/domino-royal-game.js` which produced warnings about ignore rules but no lint errors. 
- Built the repo with `npm run build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4b1a8a0708329a28ed8f9c439e656)