### PR TITLE
Fix Pool Royale auto-aim crash from undefined lane-check helper

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -25828,7 +25828,12 @@ const powerRef = useRef(hud.power);
           const cueEase = Math.max(0, 1 - cueDist / Math.max(PLAY_W, PLAY_H));
           return pocketEase * 0.65 + cueEase * 0.35;
         };
-        const pickPreferredBall = (targets, candidateBalls, cuePos) => {
+        const pickPreferredBall = (
+          targets,
+          candidateBalls,
+          cuePos,
+          laneOpenEvaluator = () => false
+        ) => {
           for (const targetId of targets) {
             const matches = candidateBalls.filter((ball) => matchesTargetId(ball, targetId));
             if (matches.length > 0) {
@@ -25836,10 +25841,10 @@ const powerRef = useRef(hud.power);
                 if (!best) return ball;
                 const bestScore =
                   scoreBallForAim(best, cuePos) *
-                  (isDirectLaneOpen(best) ? 1 : 0.35);
+                  (laneOpenEvaluator(best) ? 1 : 0.35);
                 const score =
                   scoreBallForAim(ball, cuePos) *
-                  (isDirectLaneOpen(ball) ? 1 : 0.35);
+                  (laneOpenEvaluator(ball) ? 1 : 0.35);
                 return score > bestScore ? ball : best;
               }, null);
             }
@@ -27375,7 +27380,7 @@ const powerRef = useRef(hud.power);
           if (!targetBall && combinedTargets.length > 0) {
             targetBall =
               pickDirectPreferredBall(combinedTargets) ||
-              pickPreferredBall(combinedTargets, candidateBalls, cuePos);
+              pickPreferredBall(combinedTargets, candidateBalls, cuePos, isDirectLaneOpen);
           }
 
           if (!targetBall && activeVariantId === 'uk') {
@@ -27391,12 +27396,17 @@ const powerRef = useRef(hud.power);
             if (preferredColours.length > 0) {
               targetBall =
                 pickDirectPreferredBall(preferredColours) ||
-                pickPreferredBall(preferredColours, candidateBalls, cuePos);
+                pickPreferredBall(preferredColours, candidateBalls, cuePos, isDirectLaneOpen);
             }
           }
 
           if (!targetBall) {
-            targetBall = pickPreferredBall(['BLACK'], candidateBalls, cuePos);
+            targetBall = pickPreferredBall(
+              ['BLACK'],
+              candidateBalls,
+              cuePos,
+              isDirectLaneOpen
+            );
           }
 
           if (!targetBall) {
@@ -27405,7 +27415,8 @@ const powerRef = useRef(hud.power);
                 .map((ball) => toBallColorId(ball.id))
                 .filter((entry) => entry && isBallTargetId(entry)),
               candidateBalls,
-              cuePos
+              cuePos,
+              isDirectLaneOpen
             );
           }
 
@@ -27416,7 +27427,12 @@ const powerRef = useRef(hud.power);
           if (targetBall && !isDirectFirstContact(targetBall)) {
             const rerouted =
               pickDirectPreferredBall(combinedTargets) ||
-              pickPreferredBall(combinedTargets, candidateBalls, cuePos) ||
+              pickPreferredBall(
+                combinedTargets,
+                candidateBalls,
+                cuePos,
+                isDirectLaneOpen
+              ) ||
               pickFallbackBall();
             if (rerouted) targetBall = rerouted;
           }


### PR DESCRIPTION
### Motivation
- A runtime `ReferenceError` occurred in Pool Royale because `pickPreferredBall` referenced `isDirectLaneOpen` which was not in scope when auto-aim logic executed. 
- The change makes the lane-open check explicit and local to the auto-aim evaluation to prevent the crash and make ranking behavior deterministic.

### Description
- Changed `pickPreferredBall` to accept an optional `laneOpenEvaluator` callback (`(targets, candidateBalls, cuePos, laneOpenEvaluator = () => false)`) and use it for lane-open scoring instead of calling `isDirectLaneOpen` directly. 
- Updated all `pickPreferredBall(...)` call sites inside `resolveAutoAimDirection` to pass the locally scoped `isDirectLaneOpen` function so the evaluator runs in the correct scope. 
- Kept existing fallback logic unchanged and preserved default behavior when no evaluator is supplied. 
- The change is contained to `webapp/src/pages/Games/PoolRoyale.jsx`.

### Testing
- Ran a production build with `npm -C webapp run build` which completed successfully (Vite emitted non-fatal chunk-size/dynamic-import warnings). 
- Verified the build output files were produced and the modified file compiles without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4bb669d4483299389fbcc49558df1)