### PR TITLE
Enhance AI shot planning and scoring; adjust physics, cameras, and UI for PoolRoyale

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -40,9 +40,9 @@
  * @property {{x:number,y:number}} [suggestedAimPoint]
  */
 
-const LOOKAHEAD_DEPTH = 2
-const LOOKAHEAD_CANDIDATES = 3
-const MONTE_CARLO_BASE_SAMPLES = 28
+const LOOKAHEAD_DEPTH = 4
+const LOOKAHEAD_CANDIDATES = 6
+const MONTE_CARLO_BASE_SAMPLES = 56
 const POWER_SCALE = 0.8
 
 function createRng (seed) {
@@ -356,8 +356,8 @@ function clearShotCandidates (req) {
   const cue = req.state.balls.find(b => b.id === cueBallId)
   const targets = chooseTargets(req)
   const pockets = req.state.pockets
-  const maxCut = req.maxCutAngle ?? Math.PI / 4
-  const minView = req.minViewScore ?? 0.3
+  const maxCut = req.maxCutAngle ?? Math.PI / 3.2
+  const minView = req.minViewScore ?? 0.48
   const candidates = []
 
   for (const target of targets) {

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1480,14 +1480,14 @@ if (BALL_SHADOW_MATERIAL) {
 // Match the snooker build so pace and rebound energy stay consistent between modes.
 // Physics profile tuned to the open-source Billiards solver constants (see /billiards/PhysicsConstants.cs).
 const PHYSICS_PROFILE = Object.freeze({
-  restitution: 1.06,
+  restitution: 1.11,
   mu: 0.421,
   spinDecay: 2.0,
   airSpinDecay: 0.6,
   maxTipOffsetRatio: 0.9
 });
 const PHYSICS_BASE_STEP = 1 / 60;
-const FRICTION = 0.993;
+const FRICTION = 0.9953;
 const DEFAULT_CUSHION_RESTITUTION = PHYSICS_PROFILE.restitution;
 let CUSHION_RESTITUTION = DEFAULT_CUSHION_RESTITUTION;
 const BALL_MASS = 0.17;
@@ -1498,13 +1498,13 @@ const SPIN_KINETIC_FRICTION = 0.22;
 const SPIN_ROLL_DAMPING = 0.1;
 const SPIN_ANGULAR_DAMPING = 0.04;
 const SPIN_GRAVITY = 9.81;
-const ROLLING_RESISTANCE = 0.016;
-const BALL_BALL_FRICTION = 0.18;
+const ROLLING_RESISTANCE = 0.0115;
+const BALL_BALL_FRICTION = 0.11;
 const BALL_CONTACT_EPS = BALL_R * 0.012; // broaden contact tolerance slightly so grazing touches resolve instead of tunneling
 const BALL_COLLISION_SLOP = BALL_R * 0.0015; // keep resting balls stable by ignoring microscopic overlap noise
 const BALL_COLLISION_BAUMGARTE = 0.82; // stronger overlap correction so touching balls map more precisely on every substep
 const RAIL_FRICTION = 0.16;
-const STOP_EPS = 0.012;
+const STOP_EPS = 0.0088;
 const STOP_SOFTENING = 0.96; // ease balls into a stop instead of hard-braking at the speed threshold
 const STOP_FINAL_EPS = STOP_EPS * 0.35;
 const FRAME_TIME_CATCH_UP_MULTIPLIER = 3; // allow up to 3 frames of catch-up when recovering from slow frames
@@ -1679,7 +1679,7 @@ const POCKET_CAM = Object.freeze({
   railFocusLong: BALL_R * 5.6,
   railFocusShort: BALL_R * 6.6
 });
-const POCKET_CAM_EARLY_TRIGGER_DIST = POCKET_CAM.triggerDist * 1.45; // switch to rail overhead broadcast a little earlier on incoming pocket shots
+const POCKET_CAM_EARLY_TRIGGER_DIST = POCKET_CAM.triggerDist * 1.35; // switch to rail overhead broadcast a little earlier on incoming pocket shots
 const POCKET_POPUP_DURATION_MS = 2500;
 const POCKET_POPUP_LIFT = BALL_R * 2.4;
 const POCKET_GLOW_ENABLED = false;
@@ -1752,11 +1752,11 @@ const CAMERA_LATERAL_CLAMP = Object.freeze({
   side: PLAY_H * 0.45
 });
 const POCKET_VIEW_MIN_DURATION_MS = 320;
-const POCKET_VIEW_ACTIVE_EXTENSION_MS = 140;
+const POCKET_VIEW_ACTIVE_EXTENSION_MS = 260;
 const POCKET_VIEW_POST_POT_HOLD_MS =
   POCKET_DROP_RING_HOLD_MS + POCKET_DROP_REST_HOLD_MS;
-const POCKET_VIEW_MAX_HOLD_MS = 900;
-const POCKET_VIEW_EARLY_HOLD_MS = 160;
+const POCKET_VIEW_MAX_HOLD_MS = 1800;
+const POCKET_VIEW_EARLY_HOLD_MS = 220;
 const SPIN_GLOBAL_SCALE = 0.9; // increase overall spin effect by 25% versus the previous 0.72 tuning
 // Spin controller adapted from the open-source Billiards solver physics (MIT License).
 const SPIN_TABLE_REFERENCE_WIDTH = 2.627;
@@ -13594,8 +13594,8 @@ function PoolRoyaleGame({
     return chromeLike && !isTelegram ? 10 : 0;
   }, []);
   const portraitViewport = typeof window === 'undefined' ? true : window.innerHeight >= window.innerWidth;
-  const sharedHudLiftPx = portraitViewport ? 20 : 30;
-  const spinControllerLiftPx = portraitViewport ? 12 : 14;
+  const sharedHudLiftPx = portraitViewport ? 24 : 34;
+  const spinControllerLiftPx = portraitViewport ? 14 : 16;
   const topControlsOffset = 'calc(6.15rem + env(safe-area-inset-top, 0px))';
   const menuButtonTopNudgePx = -14;
   const menuButtonCenterNudgePx = 0;
@@ -13604,7 +13604,7 @@ function PoolRoyaleGame({
   const bottomLeftChatGiftLiftPx = 12;
   const sideActionButtonStepPx = 60;
   const rightHudShiftPx = portraitViewport ? 18 : 8;
-  const bottomHudLeftPx = -30;
+  const bottomHudLeftPx = -36;
   const viewButtonsOffsetPx = 32;
   const viewToggleButtonDropPx = 0;
   const sideControlsBottomPx =
@@ -14584,7 +14584,7 @@ const powerRef = useRef(hud.power);
       setBreakRollMessage(`${seatLabel} rolling from behind the line...`);
       await new Promise((resolve) => window.setTimeout(resolve, BREAK_DICE_ROLL_DELAY_MS));
       playBreakDiceRollSfx();
-      const value = await rollBreakDie3DRef.current(seat);
+      let value = await rollBreakDie3DRef.current(seat);
       setBreakDiceValues((prev) => ({ ...prev, [seat]: value }));
       await new Promise((resolve) => window.setTimeout(resolve, BREAK_DICE_RESULT_PAUSE_MS));
       if (seat === 'user') {
@@ -14604,18 +14604,18 @@ const powerRef = useRef(hud.power);
       }
 
       if (userValue === value) {
-        setBreakRollState('user');
-        setBreakRollMessage(`Tie at ${value}. You reroll first.`);
-        setBreakDiceValues({ ai: null, user: null });
-        breakRollBusyRef.current = false;
-        return;
+        const rerollValue = await rollBreakDie3DRef.current(seat);
+        setBreakDiceValues((prev) => ({ ...prev, [seat]: rerollValue }));
+        await new Promise((resolve) => window.setTimeout(resolve, BREAK_DICE_RESULT_PAUSE_MS));
+        value = rerollValue === userValue ? ((rerollValue % 6) + 1) : rerollValue;
+        setBreakDiceValues((prev) => ({ ...prev, [seat]: value }));
       }
 
       const breakerSeat = userValue > value ? 'A' : 'B';
       const breakerLabel = breakerSeat === 'A' ? 'You' : 'AI';
       breakWinnerSeatRef.current = breakerSeat;
       setBreakRollState('done');
-      setBreakRollMessage(`${breakerLabel} wins (${userValue}-${value}) and breaks.`);
+      setBreakRollMessage(`${breakerLabel} wins (${userValue}-${value}). Highest result breaks.`);
       setHud((prev) => ({ ...prev, turn: breakerSeat === 'A' ? 0 : 1 }));
       setFrameState((prev) => ({ ...prev, activePlayer: breakerSeat }));
       breakRollBusyRef.current = false;
@@ -17404,7 +17404,7 @@ const powerRef = useRef(hud.power);
             if (!shooting) return;
             topViewRef.current = true;
             topViewLockedRef.current = true;
-            enterTopView(true, { variant: 'replay' });
+            enterTopView(true, { variant: 'rail' });
           }, SHOT_CAMERA_HOLD_MS);
         } else if (!preShotTopViewRef.current) {
           exitTopView(true);
@@ -24165,7 +24165,10 @@ const powerRef = useRef(hud.power);
         const cx = (((clientX - r.left) / r.width) * 2 - 1);
         const cy = -(((clientY - r.top) / r.height) * 2 - 1);
         pointer.set(cx, cy);
-        const activeCamera = activeRenderCameraRef.current ?? camera;
+        const inHandActive = Boolean(hudRef.current?.inHand);
+        const activeCamera = inHandActive
+          ? (cameraRef.current ?? camera)
+          : (activeRenderCameraRef.current ?? camera);
         ray.setFromCamera(pointer, activeCamera);
         const pt = new THREE.Vector3();
         ray.ray.intersectPlane(plane, pt);
@@ -24264,7 +24267,7 @@ const powerRef = useRef(hud.power);
         if (breakPlacementRestricted) {
           return false;
         }
-        return variant !== 'uk';
+        return true;
       };
 
       const isSpotFree = (point, clearanceMultiplier = 2.05) => {
@@ -25307,7 +25310,7 @@ const powerRef = useRef(hud.power);
 
           if (cameraRef.current && sphRef.current) {
             if (forceImmediateRailOverheadView) {
-              enterTopView(true, { variant: 'replay' });
+              enterTopView(true, { variant: 'rail' });
               setIsTopDownView(true);
             } else {
               topViewRef.current = false;
@@ -25464,9 +25467,7 @@ const powerRef = useRef(hud.power);
               now + CAMERA_SWITCH_MIN_HOLD_MS + CUE_STROKE_POST_HIT_CAMERA_HOLD_MS
             );
             const strokeReadyAt = Math.max(cameraHoldUntil, now + STROKE_CAMERA_MIN_HOLD_MS);
-            const requiresCueBallMovementTrigger =
-              forceImmediateRailOverheadView ||
-              (!earlyPocketView && !suppressPocketCameras);
+            const requiresCueBallMovementTrigger = false;
             const shouldActivateActionView =
               !requiresCueBallMovementTrigger &&
               (!isLongShot || forceActionActivation) &&
@@ -26839,7 +26840,9 @@ const powerRef = useRef(hud.power);
           const decision = planShot({
             game: variantId === 'american' ? 'AMERICAN_BILLIARDS' : 'NINE_BALL',
             state: aiState,
-            timeBudgetMs: Math.min(AI_THINKING_BUDGET_MS, 320)
+            timeBudgetMs: Math.min(AI_THINKING_BUDGET_MS, 900),
+            maxCutAngle: Math.PI / 3.25,
+            minViewScore: 0.5
           });
           if (!decision?.aimPoint) return null;
           const aimPoint = new THREE.Vector2(
@@ -27081,27 +27084,99 @@ const powerRef = useRef(hud.power);
           if (!plan.targetBall) {
             plan.targetBall = pickLegalTargetBall();
           }
-          if (plan.pocketCenter && plan.targetBall?.pos) {
-            const compensatedAim = resolveAiPotGhostAim({
-              cuePos: cueBall.pos,
-              targetPos: plan.targetBall.pos,
-              pocketPos: plan.pocketCenter,
-              ballRadius: BALL_R,
-              spin: plan.spin,
-              power: plan.power
-            });
-            if (compensatedAim?.aimDir && compensatedAim.aimDir.lengthSq() > 1e-6) {
-              corrected = compensatedAim.aimDir.clone();
-              if (compensatedAim.ghost) {
-                plan.cueToTarget = cueBall.pos.distanceTo(compensatedAim.ghost);
+          const scoreAimDirForTarget = (rawDir, targetBall, pocketCenter = null) => {
+            if (!rawDir || !targetBall || rawDir.lengthSq() <= 1e-6) return null;
+            const dir = rawDir.clone().normalize();
+            const shotContact = calcTarget(cueBall, dir, activeBalls);
+            if (!shotContact?.targetBall) return null;
+            if (String(shotContact.targetBall.id) !== String(targetBall.id)) return null;
+            let score = 2.4;
+            if (shotContact.railNormal) {
+              score -= 0.65;
+            }
+            if (pocketCenter && targetBall?.pos && shotContact?.targetDir) {
+              const targetTravel = shotContact.targetDir.clone().normalize();
+              const toPocket = pocketCenter.clone().sub(targetBall.pos);
+              if (toPocket.lengthSq() > 1e-6) {
+                const pocketDir = toPocket.normalize();
+                const pocketAlign = THREE.MathUtils.clamp(targetTravel.dot(pocketDir), -1, 1);
+                score += pocketAlign * 2.4;
+                if (pocketAlign < 0.2) score -= 1.15;
               }
             }
-          }
-          if (!corrected && plan.targetBall?.pos) {
-            const direct = plan.targetBall.pos.clone().sub(cueBall.pos);
+            if (Number.isFinite(shotContact.tHit)) {
+              const cueDistanceNorm = Math.max(PLAY_W, PLAY_H);
+              const cueDistanceEase = 1 - Math.min(shotContact.tHit / cueDistanceNorm, 1);
+              score += cueDistanceEase * 0.55;
+            }
+            return { dir, score, hitDistance: shotContact?.tHit };
+          };
+          const tunePotAim = (targetBall) => {
+            if (!targetBall?.pos) return null;
+            const candidates = [];
+            const addCandidate = (candidateDir) => {
+              const scored = scoreAimDirForTarget(candidateDir, targetBall, plan.pocketCenter);
+              if (scored) candidates.push(scored);
+            };
+            addCandidate(plan.aimDir);
+            if (corrected) addCandidate(corrected);
+            if (plan.suggestedAimDir?.lengthSq?.() > 1e-6) {
+              addCandidate(plan.suggestedAimDir);
+            }
+            if (plan.pocketCenter) {
+              const compensatedAim = resolveAiPotGhostAim({
+                cuePos: cueBall.pos,
+                targetPos: targetBall.pos,
+                pocketPos: plan.pocketCenter,
+                ballRadius: BALL_R,
+                spin: plan.spin,
+                power: plan.power
+              });
+              if (compensatedAim?.aimDir?.lengthSq?.() > 1e-6) {
+                addCandidate(compensatedAim.aimDir);
+                if (compensatedAim.ghost) {
+                  plan.cueToTarget = cueBall.pos.distanceTo(compensatedAim.ghost);
+                }
+              }
+            }
+            const direct = targetBall.pos.clone().sub(cueBall.pos);
             if (direct.lengthSq() > 1e-6) {
-              corrected = direct.normalize();
-              plan.cueToTarget = cueBall.pos.distanceTo(plan.targetBall.pos);
+              addCandidate(direct);
+            }
+            const refined = candidates
+              .slice(0, 4)
+              .flatMap((entry) => {
+                const seed = entry?.dir;
+                if (!seed || seed.lengthSq() <= 1e-6) return [];
+                const distToTarget = Math.max(
+                  cueBall.pos.distanceTo(targetBall.pos),
+                  BALL_R * 2.2
+                );
+                const baseJitter = Math.min(0.16, Math.max(0.02, BALL_R * 0.6 / distToTarget));
+                const offsets = [0, -baseJitter, baseJitter, -baseJitter * 2, baseJitter * 2];
+                return offsets.map((offset) => {
+                  const cos = Math.cos(offset);
+                  const sin = Math.sin(offset);
+                  const rotated = new THREE.Vector2(
+                    seed.x * cos - seed.y * sin,
+                    seed.x * sin + seed.y * cos
+                  );
+                  return scoreAimDirForTarget(rotated, targetBall, plan.pocketCenter);
+                });
+              })
+              .filter(Boolean);
+            const pool = [...candidates, ...refined].filter(Boolean);
+            if (pool.length === 0) return null;
+            pool.sort((a, b) => b.score - a.score);
+            return pool[0];
+          };
+          if (plan.targetBall?.pos) {
+            const tuned = tunePotAim(plan.targetBall);
+            if (tuned?.dir) {
+              corrected = tuned.dir.clone();
+              if (Number.isFinite(tuned.hitDistance)) {
+                plan.cueToTarget = tuned.hitDistance;
+              }
             }
           }
           if (!corrected && !plan.targetBall) {
@@ -30428,7 +30503,16 @@ const powerRef = useRef(hud.power);
                 } else {
                   // Keep the cue ball on-table in ball-in-hand mode so placement feels immediate.
                   removePocketDropEntry(b.id);
-                  respawnCueBallForInHand({ preferCenter: true });
+                  const suggestedInHandPos = findAiInHandPlacement();
+                  if (suggestedInHandPos) {
+                    cue.active = true;
+                    updateCuePlacement(suggestedInHandPos);
+                    cueBallPlacedFromHandRef.current = false;
+                    pendingInHandResetRef.current = true;
+                    inHandDrag.lastPos = suggestedInHandPos.clone();
+                  } else {
+                    respawnCueBallForInHand({ preferCenter: true });
+                  }
                 }
                 if (isTraining && table) {
                   const scratchPopup = createTrainingScratchPopupMesh();
@@ -30751,11 +30835,29 @@ const powerRef = useRef(hud.power);
             } else {
               const toPocket = pocketView.pocketCenter.clone().sub(focusBall.pos);
               const dist = toPocket.length();
+              const previousDist = Number.isFinite(pocketView.lastDistToPocket)
+                ? pocketView.lastDistToPocket
+                : null;
+              pocketView.lastDistToPocket = dist;
               if (dist > 1e-4) {
                 const approachDir = toPocket.clone().normalize();
                 pocketView.approach.copy(approachDir);
               }
               const speed = focusBall.vel.length() * frameScale;
+              const bouncingAway =
+                previousDist != null &&
+                pocketView.lastRailHitAt != null &&
+                dist > previousDist + BALL_R * 0.35;
+              if (bouncingAway && speed > STOP_EPS) {
+                pocketView.holdUntil = Math.max(
+                  pocketView.holdUntil ?? now,
+                  now + POCKET_VIEW_ACTIVE_EXTENSION_MS * 0.8
+                );
+                if (now >= pocketView.holdUntil) {
+                  resumeAfterPocket(pocketView, now);
+                }
+                return;
+              }
               if (speed > STOP_EPS) {
                 const extendTo = now + POCKET_VIEW_ACTIVE_EXTENSION_MS;
                 pocketView.holdUntil =
@@ -31941,15 +32043,15 @@ const powerRef = useRef(hud.power);
 
       {!isTraining && breakRollState !== 'done' && !hud.over && (
         <div className="pointer-events-none absolute inset-0 z-[95] flex items-center justify-center">
-          <div className="pointer-events-auto w-[min(20rem,88vw)] rounded-2xl border border-cyan-300/45 bg-slate-950/82 p-4 text-center shadow-[0_14px_32px_rgba(0,0,0,0.58)] backdrop-blur">
-            <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-cyan-100">Break dice roll</p>
+          <div className="pointer-events-auto w-[min(18rem,84vw)] text-center">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-cyan-100">Highest result breaks</p>
             <p className="mt-3 text-xs font-semibold text-white/90">{breakRollMessage}</p>
             {breakRollState === 'user' && (
               <button
                 type="button"
                 onClick={() => rollBreakDie('user')}
                 disabled={breakRollBusyRef.current}
-                className="mt-4 rounded-full border border-cyan-200 bg-cyan-200 px-5 py-2 text-xs font-black uppercase tracking-[0.2em] text-slate-950 shadow-[0_0_16px_rgba(34,211,238,0.45)] transition hover:bg-cyan-100 disabled:cursor-not-allowed disabled:opacity-55"
+                className="mt-4 rounded-full border border-cyan-200/75 bg-cyan-200/95 px-4 py-1.5 text-[10px] font-black uppercase tracking-[0.18em] text-slate-950 transition hover:bg-cyan-100 disabled:cursor-not-allowed disabled:opacity-55"
               >
                 Roll your die
               </button>


### PR DESCRIPTION
### Motivation

- Improve AI shot quality and reliability by increasing search depth, candidate count, and Monte Carlo sampling while tightening candidate filters.  
- Bring PoolRoyale physics and camera behavior more in line with the snooker build and solver constants for consistent feel across modes.  
- Fix and improve UX for break dice handling, in-hand placement, and camera transitions during shots.  

### Description

- Increase AI search and sampling (`LOOKAHEAD_DEPTH` 2→4, `LOOKAHEAD_CANDIDATES` 3→6, `MONTE_CARLO_BASE_SAMPLES` 28→56) and raise candidate thresholds (`maxCutAngle`, `minViewScore`) and pass them into `planShot` from the game.  
- Add improved pot-aim scoring and candidate refinement (`scoreAimDirForTarget`, `tunePotAim`) to better choose aim directions, including jittered variants and distance/rail penalties.  
- Change in-hand and AI placement behavior to prefer suggested placements (`findAiInHandPlacement`) and allow full-table in-hand placement broadly.  
- Update physics and tuning constants in `PoolRoyale.jsx` (restitution, `FRICTION`, `ROLLING_RESISTANCE`, `BALL_BALL_FRICTION`, `STOP_EPS`, etc.) and adjust pocket/camera timing values (`POCKET_CAM_EARLY_TRIGGER_DIST`, `POCKET_VIEW_ACTIVE_EXTENSION_MS`, `POCKET_VIEW_MAX_HOLD_MS`, `POCKET_VIEW_EARLY_HOLD_MS`).  
- Modify camera and input logic: prefer `rail` variant for `enterTopView` on shot hold, switch active camera selection when in-hand placements are active, and disable the cue-movement gating for action view activation.  
- Revise break dice logic to reroll ties and clarify messages and UI for the break roll; update break roll button styling and surrounding text.  
- Add pocket view bounce detection to extend pocket viewing when a ball bounces away from a pocket and tweak various HUD layout offsets.  

### Testing

- Ran unit tests with `yarn test` and linters with `yarn lint`, both succeeded without failures.  
- Built the webapp with `yarn build` to validate compile-time and bundling changes and the build completed successfully.  
- Performed automated smoke build checks and basic CI script runs which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4c3b9f6ac832986cb837a70d4f05e)