### PR TITLE
Fix Domino Royal 3D camera drag continuity after pinch zoom

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -9228,6 +9228,23 @@ const cameraLookPointerState = {
   lastX: 0,
   lastY: 0
 };
+function syncCameraLookPointerAfterMultiTouch() {
+  if (cameraViewMode !== VIEW_MODES.threeD) {
+    cameraLookPointerState.pointerId = null;
+    return;
+  }
+  if (activePointers.size !== 1) {
+    return;
+  }
+  const [remainingPointerId] = activePointers;
+  const point = activePointerPositions.get(remainingPointerId);
+  if (!point) {
+    return;
+  }
+  cameraLookPointerState.pointerId = remainingPointerId;
+  cameraLookPointerState.lastX = point.x;
+  cameraLookPointerState.lastY = point.y;
+}
 function findPickRoot(o) {
   let n = o;
   while (n) {
@@ -9388,6 +9405,15 @@ renderer.domElement.addEventListener('pointermove', (ev) => {
   }
 
   if (
+    cameraViewMode === VIEW_MODES.threeD &&
+    ev.pointerType === 'touch' &&
+    activePointers.size === 1 &&
+    cameraLookPointerState.pointerId == null
+  ) {
+    syncCameraLookPointerAfterMultiTouch();
+  }
+
+  if (
     cameraViewMode !== VIEW_MODES.threeD ||
     cameraLookPointerState.pointerId !== ev.pointerId
   ) {
@@ -9409,8 +9435,10 @@ renderer.domElement.addEventListener('pointerup', (ev) => {
   }
   if (cameraLookPointerState.pointerId === ev.pointerId) {
     cameraLookPointerState.pointerId = null;
+    cameraLookPointerState.lastX = 0;
     cameraLookPointerState.lastY = 0;
   }
+  syncCameraLookPointerAfterMultiTouch();
 });
 renderer.domElement.addEventListener('pointercancel', (ev) => {
   activePointers.delete(ev.pointerId);
@@ -9421,8 +9449,10 @@ renderer.domElement.addEventListener('pointercancel', (ev) => {
   }
   if (cameraLookPointerState.pointerId === ev.pointerId) {
     cameraLookPointerState.pointerId = null;
+    cameraLookPointerState.lastX = 0;
     cameraLookPointerState.lastY = 0;
   }
+  syncCameraLookPointerAfterMultiTouch();
 });
 renderer.domElement.addEventListener('pointerleave', (ev) => {
   activePointers.delete(ev.pointerId);
@@ -9433,8 +9463,10 @@ renderer.domElement.addEventListener('pointerleave', (ev) => {
   }
   if (cameraLookPointerState.pointerId === ev.pointerId) {
     cameraLookPointerState.pointerId = null;
+    cameraLookPointerState.lastX = 0;
     cameraLookPointerState.lastY = 0;
   }
+  syncCameraLookPointerAfterMultiTouch();
 });
 
 btnDraw.addEventListener('click', () => {


### PR DESCRIPTION
### Motivation
- Users lost the ability to continue rotating the 3D camera after performing a pinch-zoom gesture, leaving the camera control detached until an additional touch/tap reset occurred. This change aims to preserve a seamless camera-drag experience after multi-touch zoom interactions.

### Description
- Added `syncCameraLookPointerAfterMultiTouch()` in `webapp/public/domino-royal-game.js` to rebind camera-look control to the remaining touch pointer when a two-finger gesture ends. 
- Hooked the rebind helper into `pointermove` so when a two-finger pinch ends and one finger remains the camera-look ownership is recovered automatically. 
- Cleared stale pointer deltas by resetting both `lastX` and `lastY` when the camera-look pointer is released, and invoked the rebind helper from `pointerup`, `pointercancel`, and `pointerleave` for stable touch transitions. 
- Changes are limited to touch/pointer handling for the Domino Royal game script and do not alter rendering, physics, or UI layout.

### Testing
- Performed a syntax check with `node --check webapp/public/domino-royal-game.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4ec464a148329a35d3bd6138251ed)