### PR TITLE
Domino Royale: keep camera look active after pinch-zoom on mobile

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -9228,6 +9228,33 @@ const cameraLookPointerState = {
   lastX: 0,
   lastY: 0
 };
+function syncCameraLookPointerToActiveTouch() {
+  if (cameraViewMode !== VIEW_MODES.threeD) {
+    cameraLookPointerState.pointerId = null;
+    cameraLookPointerState.lastX = 0;
+    cameraLookPointerState.lastY = 0;
+    return;
+  }
+  if (activePointers.size !== 1) {
+    cameraLookPointerState.pointerId = null;
+    cameraLookPointerState.lastX = 0;
+    cameraLookPointerState.lastY = 0;
+    return;
+  }
+  for (const pointerId of activePointers) {
+    const point = activePointerPositions.get(pointerId);
+    if (!point) {
+      continue;
+    }
+    cameraLookPointerState.pointerId = pointerId;
+    cameraLookPointerState.lastX = point.x;
+    cameraLookPointerState.lastY = point.y;
+    return;
+  }
+  cameraLookPointerState.pointerId = null;
+  cameraLookPointerState.lastX = 0;
+  cameraLookPointerState.lastY = 0;
+}
 function findPickRoot(o) {
   let n = o;
   while (n) {
@@ -9408,8 +9435,7 @@ renderer.domElement.addEventListener('pointerup', (ev) => {
     pinchZoomState.mode = null;
   }
   if (cameraLookPointerState.pointerId === ev.pointerId) {
-    cameraLookPointerState.pointerId = null;
-    cameraLookPointerState.lastY = 0;
+    syncCameraLookPointerToActiveTouch();
   }
 });
 renderer.domElement.addEventListener('pointercancel', (ev) => {
@@ -9420,8 +9446,7 @@ renderer.domElement.addEventListener('pointercancel', (ev) => {
     pinchZoomState.mode = null;
   }
   if (cameraLookPointerState.pointerId === ev.pointerId) {
-    cameraLookPointerState.pointerId = null;
-    cameraLookPointerState.lastY = 0;
+    syncCameraLookPointerToActiveTouch();
   }
 });
 renderer.domElement.addEventListener('pointerleave', (ev) => {
@@ -9432,8 +9457,7 @@ renderer.domElement.addEventListener('pointerleave', (ev) => {
     pinchZoomState.mode = null;
   }
   if (cameraLookPointerState.pointerId === ev.pointerId) {
-    cameraLookPointerState.pointerId = null;
-    cameraLookPointerState.lastY = 0;
+    syncCameraLookPointerToActiveTouch();
   }
 });
 


### PR DESCRIPTION
### Motivation
- When pinch-zooming in Domino Royale 3D on touch devices, lifting one finger could leave the camera look control detached so the player could not turn the camera until they touched again.

### Description
- Added `syncCameraLookPointerToActiveTouch()` to rebind `cameraLookPointerState` to the remaining active touch when in 3D mode.
- Replaced direct clearing of the look pointer in `pointerup`, `pointercancel`, and `pointerleave` handlers with calls to the new sync function so camera rotation continues immediately after a pinch.

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4ec464a148329a35d3bd6138251ed)