### PR TITLE
Tune AI shot evaluation and physics/UX adjustments for PoolRoyale

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -40,9 +40,9 @@
  * @property {{x:number,y:number}} [suggestedAimPoint]
  */
 
-const LOOKAHEAD_DEPTH = 4
-const LOOKAHEAD_CANDIDATES = 6
-const MONTE_CARLO_BASE_SAMPLES = 52
+const LOOKAHEAD_DEPTH = 5
+const LOOKAHEAD_CANDIDATES = 8
+const MONTE_CARLO_BASE_SAMPLES = 72
 const POWER_SCALE = 0.8
 
 function createRng (seed) {
@@ -356,8 +356,8 @@ function clearShotCandidates (req) {
   const cue = req.state.balls.find(b => b.id === cueBallId)
   const targets = chooseTargets(req)
   const pockets = req.state.pockets
-  const maxCut = req.maxCutAngle ?? Math.PI / 4.4
-  const minView = req.minViewScore ?? 0.48
+  const maxCut = req.maxCutAngle ?? Math.PI / 4.35
+  const minView = req.minViewScore ?? 0.5
   const candidates = []
 
   for (const target of targets) {
@@ -400,7 +400,11 @@ function clearShotCandidates (req) {
       const approachStraightness = 1 - Math.min(cut / (Math.PI / 2), 1)
       const cueToTarget = cue ? dist(cue, target) : 0
       const distanceScore = cue ? Math.max(0, 1 - cueToTarget / (r * 60)) : 0
-      const rank = weightedView * 0.5 + approachStraightness * 0.3 + distanceScore * 0.2
+      const rank =
+        weightedView * 0.46 +
+        approachStraightness * 0.25 +
+        distanceScore * 0.12 +
+        Math.max(0, 1 - cut / (Math.PI / 3.4)) * 0.17
 
       // require fairly central hit and open pocket view
       if (cut <= maxCut && weightedView >= minView) {
@@ -500,8 +504,8 @@ function monteCarloPotChance (req, cue, target, entry, ghost, balls, samples = 2
   const distCG = dist(cue, ghost)
   const shotLength = dist(cue, target)
   const distanceFactor = Math.min(shotLength / (r * 20 || 1), 2)
-  const sampleCount = Math.max(samples, Math.round(MONTE_CARLO_BASE_SAMPLES * (1 + distanceFactor)))
-  const jitterScale = 0.015 + 0.025 * distanceFactor
+  const sampleCount = Math.max(samples, Math.round(MONTE_CARLO_BASE_SAMPLES * (1 + distanceFactor * 1.2)))
+  const jitterScale = 0.012 + 0.021 * distanceFactor
   let success = 0
   for (let i = 0; i < sampleCount; i++) {
     const a = baseAngle + (rng() - 0.5) * jitterScale
@@ -634,6 +638,9 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
   }
   const maxD = Math.hypot(req.state.width, req.state.height)
   const potChance = monteCarloPotChance(req, cue, target, entry, ghost, balls, 20, rng)
+  if (strict && potChance < 0.42) {
+    return null
+  }
   const cueAfter = estimateCueAfterShot(cue, target, entry, power, spin, req.state)
   const scratchAfterImpact = scratchRiskAlongLine(target, cueAfter, req.state.pockets || [], r)
   if (strict && scratchAfterImpact) {
@@ -651,7 +658,7 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
       for (const nextPocket of req.state.pockets) {
         nextPocketAlign = Math.max(nextPocketAlign, pocketAlignment(nextPocket, next, req.state.width, req.state.height))
       }
-      const shape = 0.68 * cueDistanceScore + 0.32 * nextPocketAlign
+      const shape = 0.56 * cueDistanceScore + 0.44 * nextPocketAlign
       if (shape > bestShape) bestShape = shape
     }
     nextScore = bestShape
@@ -672,6 +679,10 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
   const cutSeverity = Math.min(cutAngle / (Math.PI / 2), 1)
   const pocketTightness = 1 - pocketOpen
   const difficultyPenalty = 0.25 * (0.5 * cutSeverity + 0.3 * shotLengthFactor + 0.2 * pocketTightness)
+  const spinPenalty =
+    Math.abs(spin.side || 0) * 0.08 +
+    Math.max(0, spin.back || 0) * 0.16 +
+    Math.max(0, spin.top || 0) * 0.05
   const clearanceScore = Math.max(0, Math.min((laneClearance - 0.5) / 0.7, 1))
   if (strict && (centerAlign < 0.5 || pocketOpen < 0.3)) {
     return null
@@ -686,15 +697,16 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
     0,
     Math.min(
       1,
-      0.38 * potChance +
-        0.18 * pocketOpen +
-        0.16 * centerAlign +
-        0.06 * nextScore +
-        0.06 * nearHole +
-        0.08 * runoutPotential +
-        0.08 * clearanceScore -
-        0.18 * risk -
-        (scratchAfterImpact ? 0.18 : 0) -
+      0.34 * potChance +
+        0.17 * pocketOpen +
+        0.13 * centerAlign +
+        0.05 * nextScore +
+        0.04 * nearHole +
+        0.17 * runoutPotential +
+        0.12 * clearanceScore -
+        0.21 * risk -
+        (scratchAfterImpact ? 0.2 : 0) -
+        spinPenalty -
         difficultyPenalty
     )
   )
@@ -889,7 +901,7 @@ export function planShot (req) {
             best = { ...rest, cueBallPosition: req.state.ballInHand ? cuePos : undefined }
           }
           // Only explore additional power/spin if next position is poor and there is a next target
-          if (!hasNext || nextScore >= 0.5) {
+          if (!hasNext || nextScore >= 0.72) {
             continue
           }
         }

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1305,7 +1305,7 @@ const SIDE_POCKET_JAW_EDGE_TRIM_CURVE = POCKET_JAW_EDGE_TAPER_PROFILE_POWER; // 
 const CORNER_POCKET_JAW_EDGE_TRIM_START = SIDE_POCKET_JAW_EDGE_TRIM_START; // keep corner jaw taper start aligned with middle pockets
 const CORNER_POCKET_JAW_EDGE_TRIM_SCALE = SIDE_POCKET_JAW_EDGE_TRIM_SCALE; // match the middle pocket jaw thin/thick profile
 const CORNER_POCKET_JAW_EDGE_TRIM_CURVE = SIDE_POCKET_JAW_EDGE_TRIM_CURVE; // reuse the same taper curve for corner jaws
-const POCKET_JAW_MAPPING_RADIUS_SCALE = 1; // keep jaw collision arcs identical to the rendered jaw geometry
+const POCKET_JAW_MAPPING_RADIUS_SCALE = 1.035; // slightly expand jaw collision arcs so physics cannot slip through visible jaw/chrome edges
 const CORNER_JAW_ARC_DEG = 120; // base corner jaw span; lateral expansion yields 180° (50% circle) coverage
 const SIDE_JAW_ARC_DEG = CORNER_JAW_ARC_DEG; // match the middle pocket jaw span to the corner profile
 const POCKET_RIM_DEPTH_RATIO = 0; // remove the separate pocket rims so the chrome fascias meet the jaws directly
@@ -1480,7 +1480,7 @@ if (BALL_SHADOW_MATERIAL) {
 // Match the snooker build so pace and rebound energy stay consistent between modes.
 // Physics profile tuned to the open-source Billiards solver constants (see /billiards/PhysicsConstants.cs).
 const PHYSICS_PROFILE = Object.freeze({
-  restitution: 1.12,
+  restitution: 1.15,
   mu: 0.421,
   spinDecay: 2.0,
   airSpinDecay: 0.6,
@@ -1498,13 +1498,13 @@ const SPIN_KINETIC_FRICTION = 0.22;
 const SPIN_ROLL_DAMPING = 0.1;
 const SPIN_ANGULAR_DAMPING = 0.04;
 const SPIN_GRAVITY = 9.81;
-const ROLLING_RESISTANCE = 0.0116;
+const ROLLING_RESISTANCE = 0.0102;
 const BALL_BALL_FRICTION = 0.105;
 const BALL_CONTACT_EPS = BALL_R * 0.012; // broaden contact tolerance slightly so grazing touches resolve instead of tunneling
 const BALL_COLLISION_SLOP = BALL_R * 0.0015; // keep resting balls stable by ignoring microscopic overlap noise
 const BALL_COLLISION_BAUMGARTE = 0.82; // stronger overlap correction so touching balls map more precisely on every substep
 const RAIL_FRICTION = 0.16;
-const STOP_EPS = 0.0092;
+const STOP_EPS = 0.0074;
 const STOP_SOFTENING = 0.96; // ease balls into a stop instead of hard-braking at the speed threshold
 const STOP_FINAL_EPS = STOP_EPS * 0.35;
 const FRAME_TIME_CATCH_UP_MULTIPLIER = 3; // allow up to 3 frames of catch-up when recovering from slow frames
@@ -1546,7 +1546,7 @@ const SIDE_POCKET_GUARD_CLEARANCE = Math.max(
   SIDE_POCKET_GUARD_RADIUS - BALL_R * 0.04
 );
 const CUSHION_CUT_RESTITUTION_SCALE = 0.93; // keep a livelier jaw rebound so rails feel less dead
-const CUSHION_CUT_FRICTION_SCALE = 1.12; // trim grab slightly so added bounce is visible without making cuts skid
+const CUSHION_CUT_FRICTION_SCALE = 1.06; // trim grab slightly so added bounce is visible without making cuts skid
 const SIDE_POCKET_DEPTH_LIMIT =
   SIDE_POCKET_RADIUS * 1.6 * POCKET_VISUAL_EXPANSION; // align side-pocket rail limits with the visible mouth depth
 let SIDE_POCKET_SPAN =
@@ -6679,7 +6679,8 @@ function reflectRails(ball) {
     let bestPenetration = 0;
     for (const segment of CUSHION_SEGMENTS) {
       if (!segment?.normal || !segment?.start || !segment?.end) continue;
-      if (nearPocket && segment.type === 'rail') continue;
+      // Keep rail segments active near pockets too; disabling these created
+      // tiny escape corridors where balls could visually cross jaw/cut mapping.
       if (inCaptureZone && inGuardZone && segment.type === 'cut') continue;
       if (segment.type === 'jaw' && segment.center && segment.captureRadius != null) {
         if (ball.pos.distanceTo(segment.center) <= segment.captureRadius) continue;
@@ -6711,7 +6712,12 @@ function reflectRails(ball) {
       if (penetration > bestPenetration) {
         bestPenetration = penetration;
         bestImpact = {
-          type: segment.type === 'cut' ? 'cut' : 'rail',
+          type:
+            segment.type === 'cut'
+              ? 'cut'
+              : segment.type === 'jaw'
+                ? 'jaw'
+                : 'rail',
           normal: TMP_VEC2_LIMIT.clone(),
           tangent: new THREE.Vector2(-TMP_VEC2_LIMIT.y, TMP_VEC2_LIMIT.x)
         };
@@ -7536,7 +7542,7 @@ function updateCushionSegmentsFromTable(table) {
       MICRO_EPS,
       jaw.outerRadius * POCKET_JAW_MAPPING_RADIUS_SCALE
     );
-    const steps = Math.max(10, Math.ceil((jaw.jawAngle / Math.PI) * 24));
+    const steps = Math.max(16, Math.ceil((jaw.jawAngle / Math.PI) * 48));
     const startAngle = jaw.orientationAngle - jaw.jawAngle / 2;
     const endAngle = jaw.orientationAngle + jaw.jawAngle / 2;
     let prev = null;
@@ -13603,8 +13609,8 @@ function PoolRoyaleGame({
   const sideActionButtonsDropPx = 18;
   const bottomLeftChatGiftLiftPx = 12;
   const sideActionButtonStepPx = 60;
-  const rightHudShiftPx = portraitViewport ? 18 : 8;
-  const bottomHudLeftPx = -36;
+  const rightHudShiftPx = portraitViewport ? 24 : 12;
+  const bottomHudLeftPx = -46;
   const viewButtonsOffsetPx = 32;
   const viewToggleButtonDropPx = 0;
   const sideControlsBottomPx =
@@ -19075,7 +19081,7 @@ const powerRef = useRef(hud.power);
           pocketSwitchIntentRef.current = {
             ballId: ball.id,
             forced: true,
-            allowEarly: false,
+            allowEarly: true,
             createdAt: now
           };
         };
@@ -27064,16 +27070,46 @@ const powerRef = useRef(hud.power);
             return plan;
           }
           let corrected = null;
+          const targetId =
+            plan.targetBall?.id != null ? String(plan.targetBall.id) : null;
+          if (plan.pocketCenter && plan.targetBall?.pos) {
+            const compensatedAim = resolveAiPotGhostAim({
+              cuePos: cueBall.pos,
+              targetPos: plan.targetBall.pos,
+              pocketPos: plan.pocketCenter,
+              ballRadius: BALL_R,
+              spin: plan.spin,
+              power: plan.power
+            });
+            if (compensatedAim?.aimDir && compensatedAim.aimDir.lengthSq() > 1e-6) {
+              const normalizedGhostAim = compensatedAim.aimDir.clone().normalize();
+              const ghostContact = calcTarget(cueBall, normalizedGhostAim, activeBalls);
+              if (
+                ghostContact?.targetBall &&
+                targetId != null &&
+                String(ghostContact.targetBall.id) === targetId
+              ) {
+                corrected = normalizedGhostAim;
+                if (compensatedAim.ghost) {
+                  plan.cueToTarget = cueBall.pos.distanceTo(compensatedAim.ghost);
+                }
+              }
+            }
+          }
           if (
+            !corrected &&
             plan.suggestedAimDir &&
             typeof plan.suggestedAimDir.lengthSq === 'function' &&
             plan.suggestedAimDir.lengthSq() > 1e-6
           ) {
-            const suggestedContact = calcTarget(cueBall, plan.suggestedAimDir, activeBalls);
-            if (suggestedContact?.targetBall && isLegalTargetBall(suggestedContact.targetBall)) {
-              corrected = plan.suggestedAimDir.clone().normalize();
-              plan.targetBall = suggestedContact.targetBall;
-              plan.target = toBallColorId(suggestedContact.targetBall.id);
+            const suggestedNorm = plan.suggestedAimDir.clone().normalize();
+            const suggestedContact = calcTarget(cueBall, suggestedNorm, activeBalls);
+            if (
+              suggestedContact?.targetBall &&
+              isLegalTargetBall(suggestedContact.targetBall) &&
+              (targetId == null || String(suggestedContact.targetBall.id) === targetId)
+            ) {
+              corrected = suggestedNorm;
             }
           }
           if (!plan.targetBall && plan.target) {
@@ -27087,27 +27123,18 @@ const powerRef = useRef(hud.power);
           if (!plan.targetBall) {
             plan.targetBall = pickLegalTargetBall();
           }
-          if (plan.pocketCenter && plan.targetBall?.pos) {
-            const compensatedAim = resolveAiPotGhostAim({
-              cuePos: cueBall.pos,
-              targetPos: plan.targetBall.pos,
-              pocketPos: plan.pocketCenter,
-              ballRadius: BALL_R,
-              spin: plan.spin,
-              power: plan.power
-            });
-            if (compensatedAim?.aimDir && compensatedAim.aimDir.lengthSq() > 1e-6) {
-              corrected = compensatedAim.aimDir.clone();
-              if (compensatedAim.ghost) {
-                plan.cueToTarget = cueBall.pos.distanceTo(compensatedAim.ghost);
-              }
-            }
-          }
           if (!corrected && plan.targetBall?.pos) {
             const direct = plan.targetBall.pos.clone().sub(cueBall.pos);
             if (direct.lengthSq() > 1e-6) {
-              corrected = direct.normalize();
-              plan.cueToTarget = cueBall.pos.distanceTo(plan.targetBall.pos);
+              const directNorm = direct.normalize();
+              const directContact = calcTarget(cueBall, directNorm, activeBalls);
+              if (
+                directContact?.targetBall &&
+                String(directContact.targetBall.id) === String(plan.targetBall.id)
+              ) {
+                corrected = directNorm;
+                plan.cueToTarget = cueBall.pos.distanceTo(plan.targetBall.pos);
+              }
             }
           }
           if (!corrected && !plan.targetBall) {
@@ -31011,8 +31038,8 @@ const powerRef = useRef(hud.power);
                 (TMP_VEC3_IN_HAND_ICON.x * 0.5 + 0.5) * rect.width + rect.left;
               const screenY =
                 (-TMP_VEC3_IN_HAND_ICON.y * 0.5 + 0.5) * rect.height + rect.top;
-              const offsetX = 30;
-              const offsetY = -28;
+              const offsetX = 0;
+              const offsetY = 0;
               const clampedX = clamp(
                 screenX + offsetX,
                 rect.left + 16,
@@ -31437,7 +31464,7 @@ const powerRef = useRef(hud.power);
       cueBallPlacedFromHandRef.current = false;
       inHandPlacementModeRef.current = true;
       setInHandPlacementMode(true);
-      inHandPlacementApiRef.current?.begin?.(event, { deferPlacement: true });
+      inHandPlacementApiRef.current?.begin?.(event, { deferPlacement: false });
       if (event.pointerId != null) {
         try {
           event.currentTarget?.setPointerCapture?.(event.pointerId);


### PR DESCRIPTION
### Motivation
- Improve AI shot selection robustness by increasing lookahead, candidate breadth, and Monte Carlo sampling to favor safer, higher-quality runs.
- Reduce small collision/tunneling edge cases around pocket jaws and rails by slightly expanding mapping radii and refining cushion/cut handling.
- Adjust physics/visual constants and several UI/UX behaviors to make simulation and in-hand placement feel more consistent with visible geometry.

### Description
- Increase AI search parameters: `LOOKAHEAD_DEPTH` 4→5, `LOOKAHEAD_CANDIDATES` 6→8, and `MONTE_CARLO_BASE_SAMPLES` 52→72, and raise default `minViewScore` and `maxCut` tweaks.
- Change AI evaluation heuristics: update candidate ranking weights, increase Monte Carlo sampling/jitter scaling, add a strict `potChance` cutoff (`< 0.42`) for strict evaluations, add a `spinPenalty`, adjust difficulty/runout/clearance weightings, and raise the continuation threshold from `nextScore >= 0.5` to `0.72`.
- PoolRoyale physics and pocket geometry adjustments: set `POCKET_JAW_MAPPING_RADIUS_SCALE` 1→1.035, increase `POCKET_JAW` tessellation steps, tweak `PHYSICS_PROFILE.restitution` 1.12→1.15, lower `ROLLING_RESISTANCE`, lower `STOP_EPS`, and reduce `CUSHION_CUT_FRICTION_SCALE` 1.12→1.06.
- Cushion/jaw collision handling and segment generation updates: keep rail segments active near pockets to avoid escape corridors, treat `jaw` segments explicitly when classifying impacts, and increase jaw sampling steps for smoother mapping.
- UI/UX and input updates: adjust HUD offsets (`rightHudShiftPx`, `bottomHudLeftPx`), set `pocketSwitchIntent.allowEarly = true`, remove offsets for the in-hand icon, and make in-hand placement begin with `deferPlacement: false` so placement starts immediately.
- Improve AI aim correction in the client: attempt compensated ghost aim via `resolveAiPotGhostAim` and validate suggested/direct aim contacts against the actual target before accepting corrected aim.

### Testing
- Ran the repository linting and unit test suite; all tests succeeded.
- Performed a production build of the webapp (`npm run build`) and the build completed successfully.
- Ran automated browser-based smoke tests against the PoolRoyale scene (headless run) to exercise pocket/rail interactions and AI planning; no regressions detected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4e924b6d0832983bbb1a8945a1127)