### PR TITLE
Improve AI pocket centering & ball‑in‑hand drag fidelity

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -125,14 +125,7 @@ function pocketNormal (pocket, width, height) {
 
 function pocketEntry (pocket, radius, width, height, target) {
   const normal = pocketNormal(pocket, width, height)
-  let dir = normal
-
-  if (target) {
-    dir = { x: pocket.x - target.x, y: pocket.y - target.y }
-    const len = Math.hypot(dir.x, dir.y) || 1
-    dir = { x: dir.x / len, y: dir.y / len }
-  }
-
+  const dir = normal
   const offset = radius * 1.05
   return {
     x: pocket.x - dir.x * offset,

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -24417,8 +24417,60 @@ const powerRef = useRef(hud.power);
         if (!client) return null;
         const currentProjected = projectFromClient(client.x, client.y);
         if (!currentProjected) return null;
+        const previousScreen = inHandDrag.lastScreen;
+        const previousPos = inHandDrag.lastPos?.clone?.() ?? null;
         inHandDrag.lastScreen = client;
-        return currentProjected;
+        if (!previousScreen || !previousPos) {
+          return currentProjected;
+        }
+        const deltaX = client.x - previousScreen.x;
+        const deltaY = client.y - previousScreen.y;
+        if (Math.abs(deltaX) < 1e-4 && Math.abs(deltaY) < 1e-4) {
+          return previousPos;
+        }
+        const renderCam = cameraRef.current ?? activeRenderCameraRef.current ?? camera;
+        if (!renderCam?.isPerspectiveCamera) {
+          return currentProjected;
+        }
+        const viewport = dom.getBoundingClientRect();
+        if (!(viewport.width > 0 && viewport.height > 0)) {
+          return currentProjected;
+        }
+        const cueWorld = TMP_VEC3_B.set(
+          previousPos.x * worldScaleFactor,
+          TABLE_Y * worldScaleFactor,
+          previousPos.y * worldScaleFactor
+        );
+        const camPos = renderCam.position;
+        const camForward = TMP_VEC3_C.set(0, 0, -1).applyQuaternion(renderCam.quaternion);
+        let depth = cueWorld.clone().sub(camPos).dot(camForward);
+        if (!Number.isFinite(depth) || depth <= 1e-5) {
+          depth = Math.max(
+            renderCam.position.distanceTo(cueWorld),
+            renderCam.near + 1e-3
+          );
+        }
+        const fovRad = THREE.MathUtils.degToRad(renderCam.fov || 50);
+        const worldPerPixelY =
+          (2 * depth * Math.tan(fovRad * 0.5)) / viewport.height;
+        const worldPerPixelX = worldPerPixelY * (renderCam.aspect || viewport.width / viewport.height);
+        const camRight = TMP_VEC3_D.set(1, 0, 0).applyQuaternion(renderCam.quaternion);
+        const camUp = TMP_VEC3_E.set(0, 1, 0).applyQuaternion(renderCam.quaternion);
+        const worldDelta = TMP_VEC3_A
+          .copy(camRight)
+          .multiplyScalar(deltaX * worldPerPixelX)
+          .addScaledVector(camUp, -deltaY * worldPerPixelY);
+        worldDelta.y = 0;
+        const next = previousPos.add(
+          new THREE.Vector2(
+            worldDelta.x / worldScaleFactor,
+            worldDelta.z / worldScaleFactor
+          )
+        );
+        if (!Number.isFinite(next.x) || !Number.isFinite(next.y)) {
+          return currentProjected;
+        }
+        return next;
       };
       const findAiInHandPlacement = () => {
         const radius = Math.max(D_RADIUS - BALL_R * 0.25, BALL_R);


### PR DESCRIPTION
### Motivation
- Make AI aim lines align with the physical center of the pocket entrance so pots are visually centred on the pocket mouth. 
- Make ball‑in‑hand dragging feel 1:1 with the player finger on portrait/mobile by mapping pointer movement to world movement in a camera‑aware way.

### Description
- Use the pocket entrance normal for pocket entry calculation in `pocketEntry` so AI centrelines are computed from the pocket mouth rather than per‑target offsets (`lib/poolAi.js`).
- Replace the previous target‑biased entry vector with the pocket normal in `pocketEntry`, simplifying and stabilising AI aim points. (`lib/poolAi.js`).
- Improve `resolveInHandDragPosition` so it converts screen pointer deltas into world‑space deltas using camera depth, FOV, aspect and camera right/up vectors and applies the delta to the last placed cue position, returning a smoothed, screen‑consistent placement (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Preserve existing fallbacks: small/no movement returns previous placement, and non‑perspective cameras fall back to the original projection behaviour. (`webapp/src/pages/Games/PoolRoyale.jsx`).

### Testing
- Ran the unit tests for AI: `npm test -- --runInBand test/poolAi.test.js` and the suite passed. 
- The run executed 14 tests in `test/poolAi.test.js` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c501f9055083298b152e52ee493a48)