### PR TITLE
Domino Royal: fix 3D touch camera after pinch, uplift HUD, and require 2k domino textures

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -119,7 +119,7 @@ function getAdaptiveDominoTextureSize(baseSize = 4096) {
     DOMINO_TEXTURE_SIZE_MAP[frameRateId] ??
     DOMINO_TEXTURE_SIZE_MAP[DEFAULT_FRAME_RATE_ID] ??
     baseSize;
-  return Math.max(768, Math.min(4096, mappedSize));
+  return Math.max(2048, Math.min(4096, mappedSize));
 }
 
 function resolveTelegramPixelRatioCap(qualityId = DEFAULT_FRAME_RATE_ID) {
@@ -9328,6 +9328,14 @@ renderer.domElement.addEventListener('pointermove', (ev) => {
     activePointerPositions.set(ev.pointerId, { x: ev.clientX, y: ev.clientY });
   }
 
+  if (cameraViewMode === VIEW_MODES.threeD && ev.pointerType === 'touch') {
+    if (activePointers.size <= 1 && cameraLookPointerState.pointerId == null) {
+      cameraLookPointerState.pointerId = ev.pointerId;
+      cameraLookPointerState.lastX = ev.clientX;
+      cameraLookPointerState.lastY = ev.clientY;
+    }
+  }
+
   if (cameraViewMode === VIEW_MODES.twoD && ev.pointerType === 'touch') {
     const touchPoints = [];
     for (const pointerId of activePointers) {
@@ -9409,6 +9417,7 @@ renderer.domElement.addEventListener('pointerup', (ev) => {
   }
   if (cameraLookPointerState.pointerId === ev.pointerId) {
     cameraLookPointerState.pointerId = null;
+    cameraLookPointerState.lastX = 0;
     cameraLookPointerState.lastY = 0;
   }
 });
@@ -9421,6 +9430,7 @@ renderer.domElement.addEventListener('pointercancel', (ev) => {
   }
   if (cameraLookPointerState.pointerId === ev.pointerId) {
     cameraLookPointerState.pointerId = null;
+    cameraLookPointerState.lastX = 0;
     cameraLookPointerState.lastY = 0;
   }
 });
@@ -9433,6 +9443,7 @@ renderer.domElement.addEventListener('pointerleave', (ev) => {
   }
   if (cameraLookPointerState.pointerId === ev.pointerId) {
     cameraLookPointerState.pointerId = null;
+    cameraLookPointerState.lastX = 0;
     cameraLookPointerState.lastY = 0;
   }
 });

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -104,7 +104,41 @@ export default function DominoRoyalArena() {
           bottom: auto !important;
         }
         #railControls {
-          bottom: calc(env(safe-area-inset-bottom, 0px) + clamp(1.2rem, 7vh, 2.2rem)) !important;
+          bottom: calc(
+            env(safe-area-inset-bottom, 0px) + clamp(1.2rem, 7vh, 2.2rem) +
+              clamp(2.8rem, 8vh, 3.4rem) + 1.4rem
+          ) !important;
+        }
+        #status {
+          top: calc(4.4rem + env(safe-area-inset-top, 0px)) !important;
+          bottom: auto !important;
+          left: 50% !important;
+          transform: translateX(-50%) !important;
+          z-index: 7 !important;
+          min-width: min(88vw, 22rem);
+          text-align: center;
+          letter-spacing: 0.02em;
+          font-weight: 900 !important;
+          color: #f8fafc !important;
+          border: 1px solid rgba(125, 211, 252, 0.55) !important;
+          background:
+            linear-gradient(120deg, rgba(14, 116, 144, 0.9), rgba(30, 41, 59, 0.92))
+            !important;
+          box-shadow:
+            0 14px 30px rgba(2, 132, 199, 0.28),
+            inset 0 1px 0 rgba(255, 255, 255, 0.22) !important;
+          text-shadow: 0 2px 8px rgba(2, 6, 23, 0.58);
+        }
+        .seat-badge-avatar {
+          width: 2.25rem !important;
+          height: 2.25rem !important;
+        }
+        .seat-badge-core {
+          font-size: 1rem !important;
+        }
+        .seat-badge-name {
+          font-size: 0.72rem !important;
+          padding: 0.16rem 0.46rem !important;
         }
         #quickActions {
           position: static !important;
@@ -213,11 +247,8 @@ export default function DominoRoyalArena() {
             left: 54.9%;
           }
           #status {
-            top: auto !important;
-            bottom: calc(
-              env(safe-area-inset-bottom, 0px) + clamp(1.2rem, 7vh, 2.2rem) +
-                clamp(2.8rem, 8vh, 3.4rem) + 1.4rem
-            ) !important;
+            top: calc(4.45rem + env(safe-area-inset-top, 0px)) !important;
+            bottom: auto !important;
             left: 50% !important;
             transform: translateX(-50%) !important;
             z-index: 7 !important;


### PR DESCRIPTION
### Motivation
- Users reported losing the ability to rotate the camera after performing pinch zooms and wanted commentary/status/controls repositioned for portrait/mobile; domino piece visuals should use higher minimum resolution for sharper pieces.

### Description
- Reworked touch look handling in `webapp/public/domino-royal-game.js` so a single-finger look pointer is re-bound when touch count falls back to one after a pinch, allowing rotation after zoom, and ensured `cameraLookPointerState.lastX/lastY` are reset on `pointerup`/`pointercancel`/`pointerleave` to avoid stale state while touching. 
- Enforced a minimum domino texture size by clamping `getAdaptiveDominoTextureSize` to at least `2048` (2K) in `webapp/public/domino-royal-game.js`. 
- Adjusted mobile HUD/CSS in `webapp/src/pages/Games/DominoRoyalArena.jsx` to move the commentary/status bar upward (one lane above players) and to position the Draw/Pass controls where the commentary used to be; added a stronger, stylish status appearance and tightened seat avatar / name sizing so avatars/video frames are smaller. 

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` and it passed. 
- Ran repository lint via `npm run lint`; lint run reported many pre-existing repository-wide issues unrelated to this change (these warnings/errors are not caused by the small edits in this PR).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c514fda1d88329b76f9d451c796c1a)