### PR TITLE
Fix Domino Royal camera controls, HUD layout, avatar frame size and domino texture resolution

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -99,7 +99,7 @@ const FRAME_RATE_TEXTURE_SIZE_MAP = Object.freeze({
 });
 
 const DOMINO_TEXTURE_SIZE_MAP = Object.freeze({
-  hd50: 3072,
+  hd50: 2048,
   fhd60: 4096,
   qhd90: 4096,
   uhd120: 4096,
@@ -119,7 +119,7 @@ function getAdaptiveDominoTextureSize(baseSize = 4096) {
     DOMINO_TEXTURE_SIZE_MAP[frameRateId] ??
     DOMINO_TEXTURE_SIZE_MAP[DEFAULT_FRAME_RATE_ID] ??
     baseSize;
-  return Math.max(768, Math.min(4096, mappedSize));
+  return Math.max(2048, Math.min(4096, mappedSize));
 }
 
 function resolveTelegramPixelRatioCap(qualityId = DEFAULT_FRAME_RATE_ID) {
@@ -9328,6 +9328,17 @@ renderer.domElement.addEventListener('pointermove', (ev) => {
     activePointerPositions.set(ev.pointerId, { x: ev.clientX, y: ev.clientY });
   }
 
+  if (
+    cameraViewMode === VIEW_MODES.threeD &&
+    ev.pointerType === 'touch' &&
+    activePointers.size === 1 &&
+    cameraLookPointerState.pointerId == null
+  ) {
+    cameraLookPointerState.pointerId = ev.pointerId;
+    cameraLookPointerState.lastX = ev.clientX;
+    cameraLookPointerState.lastY = ev.clientY;
+  }
+
   if (cameraViewMode === VIEW_MODES.twoD && ev.pointerType === 'touch') {
     const touchPoints = [];
     for (const pointerId of activePointers) {
@@ -9410,6 +9421,19 @@ renderer.domElement.addEventListener('pointerup', (ev) => {
   if (cameraLookPointerState.pointerId === ev.pointerId) {
     cameraLookPointerState.pointerId = null;
     cameraLookPointerState.lastY = 0;
+  }
+  if (
+    cameraViewMode === VIEW_MODES.threeD &&
+    activePointers.size === 1 &&
+    cameraLookPointerState.pointerId == null
+  ) {
+    const [remainingPointerId] = activePointers;
+    const remainingPoint = activePointerPositions.get(remainingPointerId);
+    if (Number.isFinite(remainingPoint?.x) && Number.isFinite(remainingPoint?.y)) {
+      cameraLookPointerState.pointerId = remainingPointerId;
+      cameraLookPointerState.lastX = remainingPoint.x;
+      cameraLookPointerState.lastY = remainingPoint.y;
+    }
   }
 });
 renderer.domElement.addEventListener('pointercancel', (ev) => {

--- a/webapp/src/components/GameLiveAvatarOverlay.jsx
+++ b/webapp/src/components/GameLiveAvatarOverlay.jsx
@@ -25,7 +25,8 @@ const AVATAR_ANCHOR_SELECTORS = [
   '[aria-label="You"]'
 ];
 
-const FRAME_SCALE = 2;
+const DEFAULT_FRAME_SCALE = 2;
+const DOMINO_FRAME_SCALE = 1.1;
 const ACTIVATION_TOUCH_PADDING = 8;
 const AVATAR_FRAME_STYLES = Object.freeze({
   borderRadius: '999px',
@@ -166,8 +167,10 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
     const applyRect = () => {
       const { rect, node } = findAvatarAnchor();
       if (!rect) return;
+      const frameScale =
+        gameSlug === 'domino-royal' ? DOMINO_FRAME_SCALE : DEFAULT_FRAME_SCALE;
       const avatarDiameter = Math.min(rect.width, rect.height);
-      const frameDiameter = Math.max(Math.round(avatarDiameter * FRAME_SCALE), 32);
+      const frameDiameter = Math.max(Math.round(avatarDiameter * frameScale), 32);
       const width = frameDiameter;
       const height = frameDiameter;
       const left = Math.max(

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -106,6 +106,24 @@ export default function DominoRoyalArena() {
         #railControls {
           bottom: calc(env(safe-area-inset-bottom, 0px) + clamp(1.2rem, 7vh, 2.2rem)) !important;
         }
+        #status {
+          border-radius: 16px !important;
+          border: 1px solid rgba(103, 232, 249, 0.55) !important;
+          background: linear-gradient(
+            135deg,
+            rgba(10, 18, 36, 0.95),
+            rgba(8, 47, 73, 0.9)
+          ) !important;
+          box-shadow:
+            0 14px 28px rgba(2, 6, 23, 0.55),
+            0 0 0 1px rgba(56, 189, 248, 0.28) !important;
+          color: #f8fafc !important;
+          font-weight: 900 !important;
+          letter-spacing: 0.04em !important;
+          text-transform: uppercase !important;
+          text-shadow: 0 1px 8px rgba(15, 23, 42, 0.6) !important;
+          padding: 0.52rem 1rem !important;
+        }
         #quickActions {
           position: static !important;
         }
@@ -216,11 +234,17 @@ export default function DominoRoyalArena() {
             top: auto !important;
             bottom: calc(
               env(safe-area-inset-bottom, 0px) + clamp(1.2rem, 7vh, 2.2rem) +
-                clamp(2.8rem, 8vh, 3.4rem) + 1.4rem
+                clamp(2.8rem, 8vh, 3.4rem) + clamp(6.1rem, 15vh, 8.2rem)
             ) !important;
             left: 50% !important;
             transform: translateX(-50%) !important;
             z-index: 7 !important;
+          }
+          #railControls {
+            bottom: calc(
+              env(safe-area-inset-bottom, 0px) + clamp(1.2rem, 7vh, 2.2rem) +
+                clamp(2.8rem, 8vh, 3.4rem) + 1.4rem
+            ) !important;
           }
         }
         #winnerOverlay {


### PR DESCRIPTION
### Motivation
- Users could no longer continue rotating/looking around after pinch zooming on mobile in Domino Royal, breaking the expected camera interaction flow.  
- Commentary and action controls needed repositioning and improved styling in portrait so commentary sits above player tiles and the Draw/Pass buttons occupy the previous commentary lane.  
- The live avatar video frame for Domino looked oversized and domino piece textures needed a guaranteed minimum 2K resolution for visual fidelity.

### Description
- Rebound single-touch look control when recovering from pinch: added logic in `webapp/public/domino-royal-game.js` to reassign `cameraLookPointerState.pointerId` on `pointermove`/`pointerup` so a remaining touch resumes camera look/rotation in 3D view.  
- Ensure high-res domino textures: changed `DOMINO_TEXTURE_SIZE_MAP` (`hd50` -> `2048`) and forced `getAdaptiveDominoTextureSize` to clamp to a minimum of `2048` in `webapp/public/domino-royal-game.js`.  
- Portrait HUD/CSS adjustments: updated inline CSS in `webapp/src/pages/Games/DominoRoyalArena.jsx` to style `#status` (commentary) with a higher placement and stronger visual treatment and moved `#railControls` (Draw/Pass) upward in portrait layout.  
- Reduce live avatar frame for Domino: added `DOMINO_FRAME_SCALE` and use a smaller frame scale for `gameSlug === 'domino-royal'` in `webapp/src/components/GameLiveAvatarOverlay.jsx` so the video frame is no longer oversized.

### Testing
- Ran a production build with `npm --prefix webapp run build` and the build completed successfully (Vite produced only existing chunk-size warnings); build passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c51fffb1608329b5b86cff74546a7f)