### PR TITLE
Fix 3D camera drag after pinch, enforce 2K domino textures, and rebalance mobile HUD

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -6469,9 +6469,12 @@ const getDominoSurfaceTextures = (() => {
     cache = null;
   };
   return () => {
-    const targetSize = Math.min(
-      4096,
-      getAdaptiveDominoTextureSize(MURLAN_3D_ASSET_RESOLUTION.dominoTextureSize)
+    const targetSize = Math.max(
+      2048,
+      Math.min(
+        4096,
+        getAdaptiveDominoTextureSize(MURLAN_3D_ASSET_RESOLUTION.dominoTextureSize)
+      )
     );
     if (cache && cachedSize === targetSize) return cache;
     disposeCachedTextures();
@@ -6480,16 +6483,16 @@ const getDominoSurfaceTextures = (() => {
       return cache;
     }
     const sizeCap = getRendererTextureSizeCap();
-    const preferredSize = Math.max(512, Math.min(sizeCap, targetSize));
+    const preferredSize = Math.max(2048, Math.min(sizeCap, targetSize));
     const lowMemoryDevice =
       isLowProfileDevice ||
       (typeof navigator !== 'undefined' && typeof navigator.deviceMemory === 'number' && navigator.deviceMemory <= 4);
-    let size = lowMemoryDevice ? Math.min(preferredSize, 3072) : preferredSize;
+    let size = lowMemoryDevice ? Math.max(2048, Math.min(preferredSize, 3072)) : preferredSize;
     let porcelainCanvas = document.createElement('canvas');
     porcelainCanvas.width = porcelainCanvas.height = size;
     let pctx = porcelainCanvas.getContext('2d', { willReadFrequently: true });
-    while (!pctx && size > 512) {
-      size = Math.max(512, Math.floor(size / 2));
+    while (!pctx && size > 1024) {
+      size = Math.max(1024, Math.floor(size / 2));
       porcelainCanvas = document.createElement('canvas');
       porcelainCanvas.width = porcelainCanvas.height = size;
       pctx = porcelainCanvas.getContext('2d', { willReadFrequently: true });
@@ -9228,6 +9231,27 @@ const cameraLookPointerState = {
   lastX: 0,
   lastY: 0
 };
+function assignCameraLookPointerFromActivePointers(excludedPointerId = null) {
+  if (cameraViewMode !== VIEW_MODES.threeD) {
+    return;
+  }
+  for (const pointerId of activePointers) {
+    if (pointerId === excludedPointerId) {
+      continue;
+    }
+    const point = activePointerPositions.get(pointerId);
+    if (!point) {
+      continue;
+    }
+    cameraLookPointerState.pointerId = pointerId;
+    cameraLookPointerState.lastX = point.x;
+    cameraLookPointerState.lastY = point.y;
+    return;
+  }
+  cameraLookPointerState.pointerId = null;
+  cameraLookPointerState.lastX = 0;
+  cameraLookPointerState.lastY = 0;
+}
 function findPickRoot(o) {
   let n = o;
   while (n) {
@@ -9408,8 +9432,7 @@ renderer.domElement.addEventListener('pointerup', (ev) => {
     pinchZoomState.mode = null;
   }
   if (cameraLookPointerState.pointerId === ev.pointerId) {
-    cameraLookPointerState.pointerId = null;
-    cameraLookPointerState.lastY = 0;
+    assignCameraLookPointerFromActivePointers(ev.pointerId);
   }
 });
 renderer.domElement.addEventListener('pointercancel', (ev) => {
@@ -9420,8 +9443,7 @@ renderer.domElement.addEventListener('pointercancel', (ev) => {
     pinchZoomState.mode = null;
   }
   if (cameraLookPointerState.pointerId === ev.pointerId) {
-    cameraLookPointerState.pointerId = null;
-    cameraLookPointerState.lastY = 0;
+    assignCameraLookPointerFromActivePointers(ev.pointerId);
   }
 });
 renderer.domElement.addEventListener('pointerleave', (ev) => {
@@ -9432,8 +9454,7 @@ renderer.domElement.addEventListener('pointerleave', (ev) => {
     pinchZoomState.mode = null;
   }
   if (cameraLookPointerState.pointerId === ev.pointerId) {
-    cameraLookPointerState.pointerId = null;
-    cameraLookPointerState.lastY = 0;
+    assignCameraLookPointerFromActivePointers(ev.pointerId);
   }
 });
 

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -204,6 +204,32 @@ export default function DominoRoyalArena() {
           font-size: 0.61rem;
           letter-spacing: 0.01em;
         }
+        #status {
+          background: linear-gradient(
+            145deg,
+            rgba(8, 18, 40, 0.96),
+            rgba(15, 23, 42, 0.88)
+          ) !important;
+          border: 1px solid rgba(56, 189, 248, 0.52) !important;
+          box-shadow:
+            0 12px 28px rgba(2, 6, 23, 0.55),
+            inset 0 0 0 1px rgba(148, 163, 184, 0.22) !important;
+          font-size: clamp(0.82rem, 2.6vw, 1rem) !important;
+          letter-spacing: 0.03em !important;
+          text-transform: uppercase;
+        }
+        .seat-badge-avatar {
+          width: 2.3rem !important;
+          height: 2.3rem !important;
+        }
+        .seat-badge-core {
+          width: 1.95rem !important;
+          height: 1.95rem !important;
+          font-size: 0.86rem !important;
+        }
+        .seat-badge-name {
+          font-size: 0.69rem !important;
+        }
         @media (orientation: portrait) {
           #configButton {
             left: calc(0.1rem + env(safe-area-inset-left, 0px)) !important;
@@ -212,11 +238,16 @@ export default function DominoRoyalArena() {
             top: calc(0.62rem + env(safe-area-inset-top, 0px));
             left: 54.9%;
           }
+          #railControls {
+            bottom: calc(
+              env(safe-area-inset-bottom, 0px) + clamp(1.2rem, 7vh, 2.2rem) +
+                clamp(2.8rem, 8vh, 3.4rem) + 1.35rem
+            ) !important;
+          }
           #status {
             top: auto !important;
             bottom: calc(
-              env(safe-area-inset-bottom, 0px) + clamp(1.2rem, 7vh, 2.2rem) +
-                clamp(2.8rem, 8vh, 3.4rem) + 1.4rem
+              env(safe-area-inset-bottom, 0px) + clamp(8rem, 18vh, 10.4rem)
             ) !important;
             left: 50% !important;
             transform: translateX(-50%) !important;


### PR DESCRIPTION
### Motivation
- Preserve 3D camera look/turn control after pinch-zoom so users can rotate the view with one remaining touch instead of losing control. 
- Move commentary/status UI up and place Draw/Pass controls where commentary was to match the requested mobile portrait layout and improve readability. 
- Reduce avatar/video frame footprint on the table so the player video/avatars appear visually smaller. 
- Ensure domino surface textures are at least 2K to improve tile visual fidelity on capable devices.

### Description
- Added `assignCameraLookPointerFromActivePointers` and wired it into `pointerup`/`pointercancel`/`pointerleave` so the active look pointer is reassigned to any remaining touch instead of being cleared, restoring camera-look after pinch gestures (`webapp/public/domino-royal-game.js`).
- Increased the domino texture generation floor to target a minimum of 2048px and adjusted preferred/canvas sizing and fallback loops so the generated porcelain/pip/roughness canvases favor >=2K where possible (`getDominoSurfaceTextures` changes in `webapp/public/domino-royal-game.js`).
- Rebalanced the in-game HUD for portrait mobile: restyled the `#status` commentary pill, moved `#railControls` (Draw/Pass) up in portrait, and reduced `.seat-badge-avatar` / `.seat-badge-core` sizes to shrink avatar/video-frame area (`webapp/src/pages/Games/DominoRoyalArena.jsx`).
- Minor robustness tweaks to canvas context fallback thresholds to prefer larger canvases while still falling back safely on constrained contexts (`webapp/public/domino-royal-game.js`).

### Testing
- Ran syntax checks with `node --check webapp/public/domino-royal-game.js` which succeeded. 
- Ran syntax checks with `node --check webapp/src/pages/Games/dominoRoyalTemplate.js` which succeeded. 
- Ran `npm run -s lint -- webapp/src/pages/Games/DominoRoyalArena.jsx`, which was attempted but the lint process did not complete within the session window and therefore did not report a finished result.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c51fffb1608329b5b86cff74546a7f)