### PR TITLE
Restore legacy AI ghost-aiming, improve in‑hand drag smoothing, and match corner pocket layout to middle pockets

### DIFF
--- a/test/poolRoyaleAiAimCompensation.test.js
+++ b/test/poolRoyaleAiAimCompensation.test.js
@@ -16,7 +16,7 @@ describe('Pool Royale AI aim compensation', () => {
     });
     expect(result).toBeTruthy();
     expect(result.aimDir.length()).toBeCloseTo(1, 5);
-    expect(Math.hypot(result.ghost.x - targetPos.x, result.ghost.y - targetPos.y)).toBeCloseTo(0.06024, 4);
+    expect(Math.hypot(result.ghost.x - targetPos.x, result.ghost.y - targetPos.y)).toBeCloseTo(0.06, 5);
   });
 
   it('keeps pre-impact aim unchanged when only side spin changes', () => {
@@ -38,10 +38,18 @@ describe('Pool Royale AI aim compensation', () => {
     });
     expect(withSide).toBeTruthy();
     expect(neutral.aimDir.angleTo(withSide.aimDir)).toBeLessThan(1e-6);
-    expect(withSide.contactDepth).toBeCloseTo(neutral.contactDepth, 8);
+    const neutralDepth = Math.hypot(
+      neutral.ghost.x - targetPos.x,
+      neutral.ghost.y - targetPos.y
+    );
+    const sideDepth = Math.hypot(
+      withSide.ghost.x - targetPos.x,
+      withSide.ghost.y - targetPos.y
+    );
+    expect(sideDepth).toBeCloseTo(neutralDepth, 8);
   });
 
-  it('keeps contact depth close to 2R and adjusts only slightly with spin', () => {
+  it('keeps ghost depth tied to 2R and applies legacy topspin scaling', () => {
     const neutral = resolveAiPotGhostAim({
       cuePos,
       targetPos,
@@ -60,8 +68,16 @@ describe('Pool Royale AI aim compensation', () => {
       power: 1
     });
 
-    expect(neutral.contactDepth).toBeCloseTo(0.06024, 5);
-    expect(topspin.contactDepth).toBeGreaterThan(neutral.contactDepth);
-    expect(topspin.contactDepth - neutral.contactDepth).toBeLessThan(0.0015);
+    const neutralDepth = Math.hypot(
+      neutral.ghost.x - targetPos.x,
+      neutral.ghost.y - targetPos.y
+    );
+    const topspinDepth = Math.hypot(
+      topspin.ghost.x - targetPos.x,
+      topspin.ghost.y - targetPos.y
+    );
+    expect(neutralDepth).toBeCloseTo(0.06, 5);
+    expect(topspinDepth).toBeGreaterThan(neutralDepth);
+    expect(topspinDepth).toBeCloseTo(0.0642, 4);
   });
 });

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1292,7 +1292,7 @@ const POCKET_JAW_CORNER_EDGE_FACTOR = 0.36; // widen the chamfer so the corner j
 const POCKET_JAW_SIDE_EDGE_FACTOR = POCKET_JAW_CORNER_EDGE_FACTOR; // keep the middle pocket chamfer identical to the corners
 const POCKET_JAW_CORNER_MIDDLE_FACTOR = 0.97; // bias toward the new maximum thickness so the jaw crowns through the pocket centre
 const POCKET_JAW_SIDE_MIDDLE_FACTOR = POCKET_JAW_CORNER_MIDDLE_FACTOR; // mirror the fuller centre section across middle pockets for consistency
-const CORNER_POCKET_JAW_LATERAL_EXPANSION = 1.74; // pull both corner-jaw flanks inward a bit more while keeping current jaw height
+const CORNER_POCKET_JAW_LATERAL_EXPANSION = 1.5; // match corner-jaw flank spread to the middle-pocket jaw baseline
 const SIDE_POCKET_JAW_LATERAL_EXPANSION = 1.5; // expand both middle-jaw flanks slightly so all six jaws open up evenly
 const SIDE_POCKET_JAW_RADIUS_EXPANSION = 0.995; // keep middle jaw arcs slightly tighter so side jaws look a bit smaller
 const SIDE_POCKET_JAW_DEPTH_EXPANSION = 1.04; // add a hint of extra depth so the enlarged jaws stay balanced
@@ -1375,6 +1375,7 @@ const SIDE_POCKET_EXTRA_SHIFT = TABLE.THICK * 0.17; // push middle pocket centre
 const SIDE_POCKET_OUTWARD_BIAS = TABLE.THICK * 0.34; // keep chrome plate, wood cut, nets and holder alignment with the farther-out middle pockets
 const SIDE_POCKET_FIELD_PULL = 0; // keep the middle pocket centres perfectly centered to match the chrome cut symmetry
 const SIDE_POCKET_CLOTH_INWARD_PULL = -TABLE.THICK * 0.03; // nudge middle cloth cutouts outward with the shifted side-pocket centreline
+const MATCH_CORNER_LAYOUT_TO_MIDDLE_POCKETS = true; // mirror corner-pocket dimensions and cushion spacing to the middle-pocket baseline
 const CHALK_TOP_COLOR = 0xd9c489;
 const CHALK_SIDE_COLOR = 0x10141b;
 const CHALK_SIDE_ACTIVE_COLOR = 0x1a2430;
@@ -1397,9 +1398,11 @@ const POCKET_SIDE_MOUTH_SCALE =
   POCKET_CORNER_MOUTH_SCALE *
   SIDE_POCKET_MOUTH_REDUCTION_SCALE; // keep the middle pocket mouth width identical to the corner pockets
 const SIDE_POCKET_CUT_SCALE = 1; // keep side pocket cut radius identical to the physical mouth geometry
-const POCKET_CORNER_MOUTH =
-  CORNER_MOUTH_REF * MM_TO_UNITS * POCKET_CORNER_MOUTH_SCALE;
 const POCKET_SIDE_MOUTH = SIDE_MOUTH_REF * MM_TO_UNITS * POCKET_SIDE_MOUTH_SCALE;
+const POCKET_CORNER_MOUTH =
+  MATCH_CORNER_LAYOUT_TO_MIDDLE_POCKETS
+    ? POCKET_SIDE_MOUTH
+    : CORNER_MOUTH_REF * MM_TO_UNITS * POCKET_CORNER_MOUTH_SCALE;
 const BASE_CORNER_POCKET_VIS_R = POCKET_CORNER_MOUTH / 2;
 const CORNER_POCKET_RADIUS_SCALE = 1; // keep corner pocket radius identical to the physical mouth geometry
 const POCKET_VIS_R = BASE_CORNER_POCKET_VIS_R * CORNER_POCKET_RADIUS_SCALE;
@@ -1408,7 +1411,9 @@ const POCKET_R = POCKET_VIS_R * 0.985;
 const POCKET_CENTER_OUTWARD_SHIFT = TABLE.THICK * 0.02; // shift pocket centers outward to keep the pocket stack aligned away from the playfield
 const CORNER_POCKET_CENTER_INSET = Math.max(
   0,
-  POCKET_VIS_R * 0.2 * POCKET_VISUAL_EXPANSION - POCKET_CENTER_OUTWARD_SHIFT
+  MATCH_CORNER_LAYOUT_TO_MIDDLE_POCKETS
+    ? SIDE_POCKET_EXTRA_SHIFT
+    : POCKET_VIS_R * 0.2 * POCKET_VISUAL_EXPANSION - POCKET_CENTER_OUTWARD_SHIFT
 ); // push the corner pocket centres and cuts a bit farther outward toward the rails
 const SIDE_POCKET_RADIUS = POCKET_SIDE_MOUTH / 2;
 const CORNER_CHROME_NOTCH_RADIUS =
@@ -14444,6 +14449,9 @@ function PoolRoyaleGame({
   );
   const inHandPlacementModeRef = useRef(inHandPlacementMode);
   const inHandIconRef = useRef(null);
+  const IN_HAND_DRAG_DEADZONE_WORLD = BALL_R * 0.035;
+  const IN_HAND_DRAG_SMOOTH_MIN_ALPHA = 0.28;
+  const IN_HAND_DRAG_SMOOTH_MAX_ALPHA = 0.84;
   const inHandDragRef = useRef({
     active: false,
     pointerId: null,
@@ -24417,6 +24425,27 @@ const powerRef = useRef(hud.power);
         if (!client) return null;
         const currentProjected = projectFromClient(client.x, client.y);
         if (!currentProjected) return null;
+        const previousProjected =
+          inHandDrag.lastPos?.clone?.() ?? null;
+        if (!previousProjected) {
+          inHandDrag.lastScreen = client;
+          return currentProjected;
+        }
+        const worldDelta = currentProjected.clone().sub(previousProjected);
+        if (worldDelta.lengthSq() <= IN_HAND_DRAG_DEADZONE_WORLD * IN_HAND_DRAG_DEADZONE_WORLD) {
+          inHandDrag.lastScreen = client;
+          return previousProjected;
+        }
+        const prevScreen = inHandDrag.lastScreen;
+        const screenDelta = prevScreen
+          ? Math.hypot(client.x - prevScreen.x, client.y - prevScreen.y)
+          : 0;
+        const adaptiveAlpha = THREE.MathUtils.clamp(
+          IN_HAND_DRAG_SMOOTH_MIN_ALPHA + screenDelta * 0.018,
+          IN_HAND_DRAG_SMOOTH_MIN_ALPHA,
+          IN_HAND_DRAG_SMOOTH_MAX_ALPHA
+        );
+        currentProjected.lerp(previousProjected, 1 - adaptiveAlpha);
         inHandDrag.lastScreen = client;
         return currentProjected;
       };

--- a/webapp/src/pages/Games/poolRoyaleAiAimCompensation.js
+++ b/webapp/src/pages/Games/poolRoyaleAiAimCompensation.js
@@ -1,7 +1,6 @@
 import * as THREE from 'three';
 
 const MIN_VECTOR_EPS = 1e-6;
-const DEFAULT_CONTACT_CALIBRATION = 0.004;
 
 export const resolveAiPotGhostAim = ({
   cuePos,
@@ -9,8 +8,7 @@ export const resolveAiPotGhostAim = ({
   pocketPos,
   ballRadius,
   spin,
-  power,
-  contactCalibration
+  power
 } = {}) => {
   if (!cuePos || !targetPos || !pocketPos) return null;
   const radius = Math.max(0, ballRadius ?? 0);
@@ -21,25 +19,20 @@ export const resolveAiPotGhostAim = ({
   const topBackSpin = THREE.MathUtils.clamp(spin?.y ?? 0, -1, 1);
   const power01 = THREE.MathUtils.clamp(power ?? 0.6, 0, 1);
 
-  // Baseline geometric contact: cue-ball and object-ball centers should be 2R apart at impact.
-  // Keep only a tiny spin/power calibration so aiming stays precise for ball-to-ball touch points.
-  const calibration = THREE.MathUtils.clamp(
-    contactCalibration ?? DEFAULT_CONTACT_CALIBRATION,
-    -0.08,
-    0.08
-  );
-  const contactDepth = radius * 2 * (1 + calibration + topBackSpin * power01 * 0.015);
-
+  // Keep cue-ball approach aligned to the geometric ghost-ball line.
+  // Spin is still used after contact by the runtime physics, but it should not
+  // change the pre-impact aiming direction.
+  // Slightly adjust contact depth with top/back spin to account for post-impact speed changes.
+  const contactDepth = radius * 2 * (1 + topBackSpin * power01 * 0.07);
   const ghost = new THREE.Vector2()
     .copy(targetPos)
-    .sub(toPocketDir.clone().multiplyScalar(contactDepth));
+    .sub(toPocketDir.clone().multiplyScalar(Math.max(radius * 1.5, contactDepth)));
 
   const finalCueVector = new THREE.Vector2().subVectors(ghost, cuePos);
   if (finalCueVector.lengthSq() <= MIN_VECTOR_EPS) return null;
 
   return {
     aimDir: finalCueVector.normalize(),
-    ghost,
-    contactDepth
+    ghost
   };
 };


### PR DESCRIPTION
### Motivation
- Revert recent AI contact-calibration changes so AI aiming and legal-ball suggestion return to the previous, trusted behavior for pot lines. 
- Improve player cue-ball placement (ball‑in‑hand) feel by reducing jitter and making drag movement smoother and more precise while preserving direction. 
- Make corner-pocket geometry and jaws match the middle-pocket sizing/layout so pocket mouths, jaws and cushion distances are consistent across all six pockets. 

### Description
- Restored legacy ghost-ball aiming math in `resolveAiPotGhostAim` by removing the new contact-calibration branch and returning to the previous topspin scaling and 2R baseline; this keeps the AI pre-impact aim unchanged by side spin and aligns legal-target checks to the original behavior. 
- Added an adaptive in‑hand drag filter inside `PoolRoyale.jsx` with a small world-space deadzone and a screen‑delta driven smoothing alpha to make cue‑ball dragging feel smoother and more precise (`IN_HAND_DRAG_DEADZONE_WORLD`, `IN_HAND_DRAG_SMOOTH_MIN_ALPHA`, `IN_HAND_DRAG_SMOOTH_MAX_ALPHA` and updated `resolveInHandDragPosition`). 
- Introduced `MATCH_CORNER_LAYOUT_TO_MIDDLE_POCKETS` toggle and adjusted pocket constants so corner mouth size, center inset and jaw lateral expansion align with the middle-pocket baseline (updated constants and use sites in `PoolRoyale.jsx`). 
- Updated unit test expectations in `test/poolRoyaleAiAimCompensation.test.js` to assert restored legacy ghost-depth values and relative topspin scaling. 

### Testing
- Ran the AI compensation unit test: `npm test -- --runTestsByPath test/poolRoyaleAiAimCompensation.test.js --runInBand`, and the test suite passed (3 tests). 
- Ran `npx eslint webapp/src/pages/Games/poolRoyaleAiAimCompensation.js webapp/src/pages/Games/PoolRoyale.jsx test/poolRoyaleAiAimCompensation.test.js` which returned repository ignore warnings (files matched ignore patterns). 
- Running `npx eslint --no-ignore webapp/src/pages/Games/poolRoyaleAiAimCompensation.js test/poolRoyaleAiAimCompensation.test.js` produced style/lint failures due to repository ESLint expectations (semicolon style and Jest globals) and not functional errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c51308f4cc8329b721d8b4c776594b)