### PR TITLE
Align Domino Royal bottom avatar to center-bottom and lower commentary position

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -5880,6 +5880,8 @@ const seatAvatars = [];
 const seatNameTags = [];
 const seatBadges = [];
 let humanSeatBadgeAnchor = null;
+const HUMAN_SEAT_BADGE_BOTTOM_OFFSET = 118;
+const HUMAN_SEAT_BADGE_LEFT_OFFSET = -6;
 const seatOverlay = document.createElement('div');
 seatOverlay.id = 'seatOverlay';
 document.body.appendChild(seatOverlay);
@@ -6019,9 +6021,12 @@ function updateSeatBadgePositions() {
     let x = projectedX;
     let y = projectedY;
     if (idx === human) {
-      if (!humanSeatBadgeAnchor) {
-        humanSeatBadgeAnchor = { x: projectedX, y: projectedY };
-      }
+      const anchorX =
+        rect.left + rect.width * 0.5 + HUMAN_SEAT_BADGE_LEFT_OFFSET;
+      const anchorY = rect.top + rect.height - HUMAN_SEAT_BADGE_BOTTOM_OFFSET;
+      if (!humanSeatBadgeAnchor) humanSeatBadgeAnchor = { x: anchorX, y: anchorY };
+      humanSeatBadgeAnchor.x = anchorX;
+      humanSeatBadgeAnchor.y = anchorY;
       x = humanSeatBadgeAnchor.x;
       y = humanSeatBadgeAnchor.y;
     }

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -227,6 +227,10 @@ export default function DominoRoyalArena() {
           height: 1.95rem !important;
           font-size: 0.86rem !important;
         }
+        .seat-badge.is-self .seat-badge-avatar,
+        .seat-badge.is-self .seat-badge-core {
+          transform: none !important;
+        }
         .seat-badge-name {
           font-size: 0.69rem !important;
         }
@@ -247,7 +251,7 @@ export default function DominoRoyalArena() {
           #status {
             top: auto !important;
             bottom: calc(
-              env(safe-area-inset-bottom, 0px) + clamp(8rem, 18vh, 10.4rem)
+              env(safe-area-inset-bottom, 0px) + clamp(6.9rem, 15vh, 8.8rem)
             ) !important;
             left: 50% !important;
             transform: translateX(-50%) !important;


### PR DESCRIPTION
### Motivation
- Keep the bottom (player) avatar visually centered on portrait phones and stable while keeping the video/frame size unchanged, and move commentary/status text lower so it doesn't overlap the bottom UI.

### Description
- Added constants `HUMAN_SEAT_BADGE_BOTTOM_OFFSET` and `HUMAN_SEAT_BADGE_LEFT_OFFSET` and changed `updateSeatBadgePositions()` to anchor the human seat badge to a fixed center-bottom screen position instead of following the 3D projection (`webapp/public/domino-royal-game.js`).
- Prevented extra transform/scale drift for the self avatar by forcing no transform on the self badge via CSS selector `.seat-badge.is-self .seat-badge-avatar` / `.seat-badge.is-self .seat-badge-core` (`webapp/src/pages/Games/DominoRoyalArena.jsx`).
- Lowered the portrait bottom offset for the status/commentary block by reducing the `#status` bottom clamp so commentary appears further down on portrait screens (`webapp/src/pages/Games/DominoRoyalArena.jsx`).

### Testing
- Ran `npx eslint webapp/src/pages/Games/DominoRoyalArena.jsx webapp/public/domino-royal-game.js` which completed but reported the files are ignored by project ESLint ignore rules (warnings). 
- Ran `npx eslint --no-ignore webapp/public/domino-royal-game.js webapp/src/pages/Games/DominoRoyalArena.jsx` which produced existing lint errors across the large generated bundle (automated lint run reported failures unrelated to these small edits).
- Ran `node --check webapp/public/domino-royal-game.js` which reported no syntax errors and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c52976c2088329bc91cc7fa3040804)