### PR TITLE
Pool Royale: restore legacy AI targeting and smooth in‑hand cue drag

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -40,9 +40,9 @@
  * @property {{x:number,y:number}} [suggestedAimPoint]
  */
 
-const LOOKAHEAD_DEPTH = 5
-const LOOKAHEAD_CANDIDATES = 8
-const MONTE_CARLO_BASE_SAMPLES = 72
+const LOOKAHEAD_DEPTH = 2
+const LOOKAHEAD_CANDIDATES = 3
+const MONTE_CARLO_BASE_SAMPLES = 28
 const POWER_SCALE = 0.8
 
 function createRng (seed) {
@@ -356,8 +356,8 @@ function clearShotCandidates (req) {
   const cue = req.state.balls.find(b => b.id === cueBallId)
   const targets = chooseTargets(req)
   const pockets = req.state.pockets
-  const maxCut = req.maxCutAngle ?? Math.PI / 4.35
-  const minView = req.minViewScore ?? 0.5
+  const maxCut = req.maxCutAngle ?? Math.PI / 4
+  const minView = req.minViewScore ?? 0.3
   const candidates = []
 
   for (const target of targets) {
@@ -400,11 +400,7 @@ function clearShotCandidates (req) {
       const approachStraightness = 1 - Math.min(cut / (Math.PI / 2), 1)
       const cueToTarget = cue ? dist(cue, target) : 0
       const distanceScore = cue ? Math.max(0, 1 - cueToTarget / (r * 60)) : 0
-      const rank =
-        weightedView * 0.46 +
-        approachStraightness * 0.25 +
-        distanceScore * 0.12 +
-        Math.max(0, 1 - cut / (Math.PI / 3.4)) * 0.17
+      const rank = weightedView * 0.5 + approachStraightness * 0.3 + distanceScore * 0.2
 
       // require fairly central hit and open pocket view
       if (cut <= maxCut && weightedView >= minView) {
@@ -504,8 +500,8 @@ function monteCarloPotChance (req, cue, target, entry, ghost, balls, samples = 2
   const distCG = dist(cue, ghost)
   const shotLength = dist(cue, target)
   const distanceFactor = Math.min(shotLength / (r * 20 || 1), 2)
-  const sampleCount = Math.max(samples, Math.round(MONTE_CARLO_BASE_SAMPLES * (1 + distanceFactor * 1.2)))
-  const jitterScale = 0.012 + 0.021 * distanceFactor
+  const sampleCount = Math.max(samples, Math.round(MONTE_CARLO_BASE_SAMPLES * (1 + distanceFactor)))
+  const jitterScale = 0.015 + 0.025 * distanceFactor
   let success = 0
   for (let i = 0; i < sampleCount; i++) {
     const a = baseAngle + (rng() - 0.5) * jitterScale
@@ -638,9 +634,6 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
   }
   const maxD = Math.hypot(req.state.width, req.state.height)
   const potChance = monteCarloPotChance(req, cue, target, entry, ghost, balls, 20, rng)
-  if (strict && potChance < 0.42) {
-    return null
-  }
   const cueAfter = estimateCueAfterShot(cue, target, entry, power, spin, req.state)
   const scratchAfterImpact = scratchRiskAlongLine(target, cueAfter, req.state.pockets || [], r)
   if (strict && scratchAfterImpact) {
@@ -658,7 +651,7 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
       for (const nextPocket of req.state.pockets) {
         nextPocketAlign = Math.max(nextPocketAlign, pocketAlignment(nextPocket, next, req.state.width, req.state.height))
       }
-      const shape = 0.56 * cueDistanceScore + 0.44 * nextPocketAlign
+      const shape = 0.68 * cueDistanceScore + 0.32 * nextPocketAlign
       if (shape > bestShape) bestShape = shape
     }
     nextScore = bestShape
@@ -679,10 +672,6 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
   const cutSeverity = Math.min(cutAngle / (Math.PI / 2), 1)
   const pocketTightness = 1 - pocketOpen
   const difficultyPenalty = 0.25 * (0.5 * cutSeverity + 0.3 * shotLengthFactor + 0.2 * pocketTightness)
-  const spinPenalty =
-    Math.abs(spin.side || 0) * 0.08 +
-    Math.max(0, spin.back || 0) * 0.16 +
-    Math.max(0, spin.top || 0) * 0.05
   const clearanceScore = Math.max(0, Math.min((laneClearance - 0.5) / 0.7, 1))
   if (strict && (centerAlign < 0.5 || pocketOpen < 0.3)) {
     return null
@@ -697,16 +686,15 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
     0,
     Math.min(
       1,
-      0.34 * potChance +
-        0.17 * pocketOpen +
-        0.13 * centerAlign +
-        0.05 * nextScore +
-        0.04 * nearHole +
-        0.17 * runoutPotential +
-        0.12 * clearanceScore -
-        0.21 * risk -
-        (scratchAfterImpact ? 0.2 : 0) -
-        spinPenalty -
+      0.38 * potChance +
+        0.18 * pocketOpen +
+        0.16 * centerAlign +
+        0.06 * nextScore +
+        0.06 * nearHole +
+        0.08 * runoutPotential +
+        0.08 * clearanceScore -
+        0.18 * risk -
+        (scratchAfterImpact ? 0.18 : 0) -
         difficultyPenalty
     )
   )
@@ -901,7 +889,7 @@ export function planShot (req) {
             best = { ...rest, cueBallPosition: req.state.ballInHand ? cuePos : undefined }
           }
           // Only explore additional power/spin if next position is poor and there is a next target
-          if (!hasNext || nextScore >= 0.72) {
+          if (!hasNext || nextScore >= 0.5) {
             continue
           }
         }

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -14448,6 +14448,7 @@ function PoolRoyaleGame({
     active: false,
     pointerId: null,
     lastPos: null,
+    smoothedPos: null,
     lastScreen: null,
     deferred: false,
     source: null
@@ -24406,8 +24407,12 @@ const powerRef = useRef(hud.power);
         cue.active = true;
         updateCuePlacement(next);
         inHandDrag.lastPos = next;
+        if (!commit) {
+          inHandDrag.smoothedPos = next.clone();
+        }
         if (commit) {
           inHandDrag.lastPos = null;
+          inHandDrag.smoothedPos = null;
           cueBallPlacedFromHandRef.current = true;
         }
         return true;
@@ -24418,7 +24423,17 @@ const powerRef = useRef(hud.power);
         const currentProjected = projectFromClient(client.x, client.y);
         if (!currentProjected) return null;
         inHandDrag.lastScreen = client;
-        return currentProjected;
+        const anchor = inHandDrag.smoothedPos ?? inHandDrag.lastPos;
+        if (!anchor) return currentProjected;
+        const step = TMP_VEC2_B.copy(currentProjected).sub(anchor);
+        const stepLen = step.length();
+        if (stepLen <= 1e-4) return anchor.clone();
+        const maxStep = BALL_R * 0.82;
+        if (stepLen > maxStep) {
+          step.multiplyScalar(maxStep / stepLen);
+        }
+        const alpha = stepLen > BALL_R * 0.95 ? 0.92 : 0.65;
+        return anchor.clone().add(step.multiplyScalar(alpha));
       };
       const findAiInHandPlacement = () => {
         const radius = Math.max(D_RADIUS - BALL_R * 0.25, BALL_R);
@@ -24658,6 +24673,7 @@ const powerRef = useRef(hud.power);
         inHandDrag.deferred = false;
         inHandDrag.source = null;
         inHandDrag.lastScreen = null;
+        inHandDrag.smoothedPos = null;
         const pos = inHandDrag.lastPos;
         if (pos) {
           tryUpdatePlacement(pos, true);
@@ -24681,6 +24697,7 @@ const powerRef = useRef(hud.power);
           inHandDrag.deferred = deferredPlacement;
           inHandDrag.source = 'icon';
           inHandDrag.lastScreen = getPointerClient(e);
+          inHandDrag.smoothedPos = null;
           if (deferredPlacement) {
             inHandDrag.lastPos = p;
           }
@@ -24719,6 +24736,7 @@ const powerRef = useRef(hud.power);
           inHandDrag.deferred = false;
           inHandDrag.source = null;
           inHandDrag.lastScreen = null;
+          inHandDrag.smoothedPos = null;
           const pos = inHandDrag.lastPos;
           if (pos) {
             tryUpdatePlacement(pos, true);


### PR DESCRIPTION
### Motivation
- Restore the Pool Royale AI aiming/target suggestion behavior to the legacy baseline so AI chooses legal targets and aim points as before the recent tuning churn. 
- Improve the cue‑ball "ball in hand" dragging feel to be smoother and more precise while keeping the existing directional mapping on mobile portrait.

### Description
- Reverted/tuned the AI planner in `lib/poolAi.js` (lookahead/candidate parameters, evaluation weights, Monte‑Carlo jitter and candidate selection flow) to restore the previous targeting baseline and ensure `suggestedTargetBallId` / `suggestedAimPoint` behavior is produced again. 
- Added bounded smoothing state (`smoothedPos`) and step‑limited, direction‑preserving interpolation to in‑hand drag projection in `webapp/src/pages/Games/PoolRoyale.jsx`, with smoothing applied during moves and cleared on commit/end. 
- Kept changes scoped to AI decision logic and the in‑hand cue placement flow only (`lib/poolAi.js` and `webapp/src/pages/Games/PoolRoyale.jsx`).

### Testing
- Ran `node --check lib/poolAi.js` and it completed successfully. 
- Ran `node --check webapp/public/lib/poolAi.js` and it completed successfully. 
- Ran `npm --prefix webapp run lint` which failed because the `webapp` package does not define a `lint` script in this repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c529a5cb988329968c426683f40699)