### PR TITLE
Reduce Pool Royale shot power and strengthen AI accuracy & foul avoidance

### DIFF
--- a/lib/poolUkAdvancedAi.js
+++ b/lib/poolUkAdvancedAi.js
@@ -56,8 +56,10 @@
  * Each entry: { success:number, attempts:number }
  */
 const shotMemory = new Map()
-const MIN_POT_PROBABILITY = 0.36
+const MIN_POT_PROBABILITY = 0.52
 const STRAIGHT_SHOT_THRESHOLD = Math.PI / 12 // ~15 degrees
+const FOUL_REJECTION_THRESHOLD = 0.42
+const SAFETY_ONLY_POT_THRESHOLD = 0.58
 
 function normaliseColourKey (input) {
   const value = typeof input === 'string' ? input : input?.colour
@@ -697,7 +699,26 @@ function simulateCueRollout (state, shot) {
       // cue stops near target
       pos = { x: pos.x, y: pos.y }
   }
-  return { x: pos.x, y: pos.y }
+  const minX = state.ballRadius
+  const maxX = state.width - state.ballRadius
+  const minY = state.ballRadius
+  const maxY = state.height - state.ballRadius
+
+  if (pos.x < minX) {
+    pos.x = minX + (minX - pos.x) * 0.45
+  } else if (pos.x > maxX) {
+    pos.x = maxX - (pos.x - maxX) * 0.45
+  }
+  if (pos.y < minY) {
+    pos.y = minY + (minY - pos.y) * 0.45
+  } else if (pos.y > maxY) {
+    pos.y = maxY - (pos.y - maxY) * 0.45
+  }
+
+  return {
+    x: Math.min(Math.max(pos.x, minX), maxX),
+    y: Math.min(Math.max(pos.y, minY), maxY)
+  }
 }
 
 function generateFastCandidates (state, colour) {
@@ -730,8 +751,17 @@ function foulRisk (shot, state) {
   // apply a stronger penalty when detected.
   const cueAfter = simulateCueRollout(state, shot)
   let risk = 0
-  if (state.pockets.some(p => dist(cueAfter, p) < state.ballRadius * 1.1)) {
-    risk += 0.6
+  if (state.pockets.some(p => dist(cueAfter, p) < state.ballRadius * 1.18)) {
+    risk += 0.8
+  }
+  const cushionMargin = state.ballRadius * 2.1
+  if (
+    cueAfter.x < cushionMargin ||
+    cueAfter.x > state.width - cushionMargin ||
+    cueAfter.y < cushionMargin ||
+    cueAfter.y > state.height - cushionMargin
+  ) {
+    risk += 0.16
   }
   const cue = state.balls.find(b => b.colour === 'cue')
   if (shot.targetBall) {
@@ -740,8 +770,15 @@ function foulRisk (shot, state) {
     )
     const clearance = clearanceMargin(cue, shot.targetBall, oppBalls, [], state.ballRadius, 1.15)
     if (clearance < 1) {
-      risk += (1 - clearance) * 0.55
+      risk += (1 - clearance) * 0.8
     }
+  }
+  if (shot.actionType !== 'pot') {
+    risk = Math.max(0, risk - 0.12)
+  }
+  if (typeof shot.angle === 'number') {
+    const severeCut = Math.max(0, (shot.angle - Math.PI * 0.42) / (Math.PI * 0.28))
+    risk += Math.min(severeCut, 1) * 0.2
   }
   return risk
 }
@@ -770,7 +807,7 @@ function evaluateCandidates (state, colour, candidates) {
       EV = safetyEV(state, colour)
     } else {
       const risk = foulRisk(c, state)
-      if (risk > 0.65) continue
+      if (risk > FOUL_REJECTION_THRESHOLD) continue
       const Ppot = estimatePotProbability(c, state)
       if (Ppot < MIN_POT_PROBABILITY) continue
       const nextState = { ...state, balls: state.balls.map(b => ({ ...b })) }
@@ -789,7 +826,8 @@ function evaluateCandidates (state, colour, candidates) {
       const straightBoost = typeof c.angle === 'number' ? Math.max(0, (Math.PI / 10 - c.angle) / (Math.PI / 10)) * 0.25 : 0
       const positionWeight = 1.4
       const shapeWindow = nextShapeWindow(nextState, colour)
-      EV = Ppot * (baseValue + nextBest * positionWeight + straightBoost + shapeWindow * 0.75) - riskPenalty(risk)
+      const pressureBonus = Ppot >= 0.78 ? 0.12 : 0
+      EV = Ppot * (baseValue + nextBest * positionWeight + straightBoost + shapeWindow * 0.95 + pressureBonus) - riskPenalty(risk) * 1.25
     }
     if (!best || EV > best.EV) {
       best = { c, EV }
@@ -830,7 +868,7 @@ function chooseBestAction (state, colour) {
         : 0
     )
     const maxPot = scored.reduce((m, p) => Math.max(m, p), 0)
-    if (maxPot < 0.35) {
+    if (maxPot < SAFETY_ONLY_POT_THRESHOLD) {
       candidates = candidates.concat(generateSafeties(state, colour))
     }
   }

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1781,7 +1781,7 @@ const SPIN_AFTER_IMPACT_DEFLECTION_SCALE = 0; // disable preview-only spin defle
 const SHOT_POWER_REDUCTION = 0.425;
 const SHOT_POWER_MULTIPLIER = 2.109375;
 const SHOT_POWER_INCREASE = 1.5; // match Snooker Royale standard shot lift
-const SHOT_POWER_ADJUSTMENT = 0.72; // reduce overall Pool Royale power by an additional 20%
+const SHOT_POWER_ADJUSTMENT = 0.576; // reduce current Pool Royale shot power by a further 20%
 const SHOT_POWER_BOOST = 1.5; // increase overall shot power by 25%
 const SHOT_FORCE_BOOST =
   1.5 *
@@ -26614,29 +26614,29 @@ const powerRef = useRef(hud.power);
         const mapSpeedPresetScale = (speed) => {
           switch (speed) {
             case 'soft':
-              return 0.78;
+              return 0.72;
             case 'firm':
-              return 1.18;
+              return 1.05;
             case 'med':
             default:
-              return 1;
+              return 0.9;
           }
         };
 
         const mapSpinPreset = (preset) => {
           switch (preset) {
             case 'followS':
-              return { x: 0, y: -0.18 };
+              return { x: 0, y: -0.15 };
             case 'followL':
-              return { x: 0, y: -0.32 };
+              return { x: 0, y: -0.24 };
             case 'drawS':
-              return { x: 0, y: 0.22 };
+              return { x: 0, y: 0.18 };
             case 'drawL':
-              return { x: 0, y: 0.42 };
+              return { x: 0, y: 0.3 };
             case 'sideL':
-              return { x: -0.35, y: -0.06 };
+              return { x: -0.22, y: -0.04 };
             case 'sideR':
-              return { x: 0.35, y: -0.06 };
+              return { x: 0.22, y: -0.04 };
             default:
               return { x: 0, y: 0 };
           }


### PR DESCRIPTION
### Motivation
- Make Pool Royale shots softer by ~20% so gameplay feels less overpowered and more consistent with Snooker tuning. 
- Improve AI player behavior so it chooses higher-quality pots, avoids fouls/scratches, and positions the cue ball like a professional player. 
- Model post-impact cue-ball position more realistically for better look-ahead and shape planning.

### Description
- Lowered global shot tuning in `webapp/src/pages/Games/PoolRoyale.jsx` by changing `SHOT_POWER_ADJUSTMENT` from `0.72` to `0.576` so final shot force/speed is reduced across the mode. 
- Softened AI execution mapping in `webapp/src/pages/Games/PoolRoyale.jsx` by adjusting `mapSpeedPresetScale` and reducing amplitude of presets in `mapSpinPreset` to produce cleaner, less extreme speed/spin application. 
- Hardened advanced UK AI in `lib/poolUkAdvancedAi.js` by raising `MIN_POT_PROBABILITY`, adding `FOUL_REJECTION_THRESHOLD` and `SAFETY_ONLY_POT_THRESHOLD`, and increasing EV weighting for position/shape so the AI prefers safe/controlled lines when pot confidence is insufficient. 
- Improved positional simulation and foul detection in `lib/poolUkAdvancedAi.js` by adding boundary reflection/clamping in `simulateCueRollout`, increasing penalties in `foulRisk` (scratch proximity, rail-trap, tight clearance, severe cuts), and rejecting high-risk shots earlier in `evaluateCandidates`.

### Testing
- Built the web client with `npm -C webapp run build` and the production build completed successfully (Vite emitted only pre-existing chunk-size/dynamic-import warnings).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c577410d1c8329ae5ce4299dbd39b3)