### PR TITLE
Tune Pool Royale shot power and upgrade AI foul-safe planning

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -42,8 +42,10 @@
 
 const LOOKAHEAD_DEPTH = 5
 const LOOKAHEAD_CANDIDATES = 8
-const MONTE_CARLO_BASE_SAMPLES = 72
+const MONTE_CARLO_BASE_SAMPLES = 120
 const POWER_SCALE = 0.8
+const PRO_ACCURACY_JITTER_SCALE = 0.72
+const FOUL_PROXIMITY_MARGIN = 1.55
 
 function createRng (seed) {
   let state = (seed ?? 0) >>> 0
@@ -505,7 +507,7 @@ function monteCarloPotChance (req, cue, target, entry, ghost, balls, samples = 2
   const shotLength = dist(cue, target)
   const distanceFactor = Math.min(shotLength / (r * 20 || 1), 2)
   const sampleCount = Math.max(samples, Math.round(MONTE_CARLO_BASE_SAMPLES * (1 + distanceFactor * 1.2)))
-  const jitterScale = 0.012 + 0.021 * distanceFactor
+  const jitterScale = (0.012 + 0.021 * distanceFactor) * PRO_ACCURACY_JITTER_SCALE
   let success = 0
   for (let i = 0; i < sampleCount; i++) {
     const a = baseAngle + (rng() - 0.5) * jitterScale
@@ -640,7 +642,7 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
   const potChance = monteCarloPotChance(req, cue, target, entry, ghost, balls, 20, rng)
   const cueAfter = estimateCueAfterShot(cue, target, entry, power, spin, req.state)
   const scratchAfterImpact = scratchRiskAlongLine(target, cueAfter, req.state.pockets || [], r)
-  if (strict && scratchAfterImpact) {
+  if (scratchAfterImpact) {
     return null
   }
   const nextTargets = nextTargetsAfter(target.id, { ...req, state: { ...req.state, balls } })
@@ -660,7 +662,7 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
     }
     nextScore = bestShape
   }
-  const risk = req.state.pockets.some(p => dist(cueAfter, p) < r * 1.2) ? 1 : 0
+  const risk = req.state.pockets.some(p => dist(cueAfter, p) < r * FOUL_PROXIMITY_MARGIN) ? 1 : 0
   const shotVec = { x: target.x - cue.x, y: target.y - cue.y }
   const potVec = { x: entry.x - target.x, y: entry.y - target.y }
   let cutAngle = Math.abs(Math.atan2(potVec.y, potVec.x) - Math.atan2(shotVec.y, shotVec.x))
@@ -701,8 +703,7 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
         0.04 * nearHole +
         0.17 * runoutPotential +
         0.12 * clearanceScore -
-        0.21 * risk -
-        (scratchAfterImpact ? 0.2 : 0) -
+        0.24 * risk -
         spinPenalty -
         difficultyPenalty
     )
@@ -739,6 +740,30 @@ function safetyShot (req) {
     spin: { top: 0, side: 0, back: 0 },
     quality: 0,
     rationale: 'safety'
+  }
+}
+
+function suggestionSafetyShot (req) {
+  const cueBallId = resolveCueBallId(req.state)
+  const cue = req.state.balls.find(b => b.id === cueBallId)
+  if (!cue) return null
+  const suggestion = findSuggestedTarget(req, null)
+  if (!suggestion) return null
+  const target = req.state.balls.find(b => b.id === suggestion.suggestedTargetBallId)
+  if (!target || target.pocketed) return null
+  const aim = suggestion.suggestedAimPoint
+  if (!aim) return null
+  if (pathBlocked(cue, aim, req.state.balls, [cueBallId, target.id], req.state.ballRadius, 1.1)) return null
+  if (scratchRiskAlongLine(cue, aim, req.state.pockets || [], req.state.ballRadius)) return null
+  const angle = Math.atan2(aim.y - cue.y, aim.x - cue.x)
+  return {
+    angleRad: angle,
+    power: 0.45 * POWER_SCALE,
+    spin: { top: 0, side: 0, back: 0.06 },
+    targetBallId: target.id,
+    aimPoint: aim,
+    quality: 0.02,
+    rationale: 'suggested-legal-safety'
   }
 }
 
@@ -893,14 +918,11 @@ export function planShot (req) {
         )
         if (baseCand) {
           hasViableShot = true
-          const { nextScore, hasNext, ...rest } = baseCand
+          const { ...rest } = baseCand
           if (!best || rest.quality > best.quality) {
             best = { ...rest, cueBallPosition: req.state.ballInHand ? cuePos : undefined }
           }
-          // Only explore additional power/spin if next position is poor and there is a next target
-          if (!hasNext || nextScore >= 0.72) {
-            continue
-          }
+          // Always explore additional power/spin to maximise cue-ball control.
         }
 
         const spins = buildSpinCandidates(cuePos, target, pocket, req)
@@ -908,7 +930,9 @@ export function planShot (req) {
           for (const spin of spins.concat(defaultSpins)) {
             if (power === powers[0] && spin === spins[0]) continue
             if (Date.now() > deadline) {
-              return best && best.quality >= 0.1 ? best : fallbackAimAtTarget(req) || safetyShot(req)
+              return best && best.quality >= 0.1
+                ? best
+                : fallbackAimAtTarget(req) || suggestionSafetyShot(req) || safetyShot(req)
             }
             const cand = evaluate(
               req,
@@ -944,10 +968,10 @@ export function planShot (req) {
     if (best.quality >= 0.1) return best
     if (hasViableShot) return best
   }
-  if (!hasViableShot) return safetyShot(req)
+  if (!hasViableShot) return suggestionSafetyShot(req) || safetyShot(req)
   fallback = fallbackAimAtTarget(req)
   if (fallback) return fallback
-  return safetyShot(req)
+  return suggestionSafetyShot(req) || safetyShot(req)
 }
 
 export default planShot

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1778,11 +1778,13 @@ const SPIN_AFTER_IMPACT_DEFLECTION_SCALE = 0; // disable preview-only spin defle
 // Apply an additional 20% reduction to soften every strike and keep mobile play comfortable.
 // Pool Royale pace now mirrors Snooker Royale to keep ball travel identical between modes.
 // Apply an extra 15% reduction to keep Pool Royale strokes slightly softer than Snooker Royal.
+// Requested balance pass: trim an additional 20% from the current strike power.
 const SHOT_POWER_REDUCTION = 0.425;
 const SHOT_POWER_MULTIPLIER = 2.109375;
 const SHOT_POWER_INCREASE = 1.5; // match Snooker Royale standard shot lift
 const SHOT_POWER_ADJUSTMENT = 0.72; // reduce overall Pool Royale power by an additional 20%
 const SHOT_POWER_BOOST = 1.5; // increase overall shot power by 25%
+const SHOT_POWER_BALANCE_SCALE = 0.8; // global 20% reduction from the previous live tuning
 const SHOT_FORCE_BOOST =
   1.5 *
   0.75 *
@@ -1794,7 +1796,8 @@ const SHOT_FORCE_BOOST =
   SHOT_POWER_MULTIPLIER *
   SHOT_POWER_INCREASE *
   SHOT_POWER_ADJUSTMENT *
-  SHOT_POWER_BOOST;
+  SHOT_POWER_BOOST *
+  SHOT_POWER_BALANCE_SCALE;
 const SHOT_BREAK_MULTIPLIER = 1.5;
 const SHOT_BASE_SPEED = 3.3 * 0.3 * 1.65 * SHOT_FORCE_BOOST;
 const SHOT_MIN_FACTOR = 0.25;


### PR DESCRIPTION
### Motivation
- Reduce player shot strength by 20% for Pool Royale to match requested balance changes and mobile pacing.
- Improve AI accuracy and make the AI avoid fouls more reliably while producing stronger position play.

### Description
- Reduced global Pool Royale strike force by introducing `SHOT_POWER_BALANCE_SCALE = 0.8` and applying it into the final shot force chain in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Increased Monte Carlo sampling and tightened aim jitter for AI pot estimation by changing `MONTE_CARLO_BASE_SAMPLES` from `72` to `120` and multiplying the jitter by a new `PRO_ACCURACY_JITTER_SCALE` in `lib/poolAi.js`.
- Hardened foul avoidance by rejecting post-impact scratch paths unconditionally (no longer only in strict mode) and increasing pocket-proximity detection via `FOUL_PROXIMITY_MARGIN`, which increases risk weighting in the `evaluate` scoring.
- Always explore additional `power`/`spin` branches for better cue-ball control instead of skipping some branches, and added a `suggestionSafetyShot` fallback that uses `findSuggestedTarget` / suggested legal aim to pick a low-risk legal safety when no good pot is found.

### Testing
- Ran `npm test -- --runInBand test/poolAi.test.js test/poolRoyaleAiAimCompensation.test.js` and both test suites passed (`PASS test/poolAi.test.js`, `PASS test/poolRoyaleAiAimCompensation.test.js`).
- Changes applied to `lib/poolAi.js` and `webapp/src/pages/Games/PoolRoyale.jsx` and validated by the above unit tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c577410d1c8329ae5ce4299dbd39b3)