### PR TITLE
Improve Pool Royale cloth texture mapping and AI shot quality

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -643,7 +643,7 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
   const potChance = monteCarloPotChance(req, cue, target, entry, ghost, balls, mcSamples, rng)
   const cueAfter = estimateCueAfterShot(cue, target, entry, power, spin, req.state)
   const scratchAfterImpact = scratchRiskAlongLine(target, cueAfter, req.state.pockets || [], r)
-  if (strict && scratchAfterImpact) {
+  if (scratchAfterImpact) {
     return null
   }
   const nextTargets = nextTargetsAfter(target.id, { ...req, state: { ...req.state, balls } })
@@ -728,19 +728,34 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
 function safetyShot (req) {
   const cueBallId = resolveCueBallId(req.state)
   const cue = req.state.balls.find(b => b.id === cueBallId)
-  const corners = [
-    { x: 0, y: 0 },
-    { x: req.state.width, y: 0 },
-    { x: 0, y: req.state.height },
-    { x: req.state.width, y: req.state.height }
+  const legalTargets = chooseTargets(req).filter(ball => !ball?.pocketed)
+  const pockets = req.state.pockets || []
+  const safeAnchors = [
+    { x: req.state.width * 0.12, y: req.state.height * 0.12 },
+    { x: req.state.width * 0.88, y: req.state.height * 0.12 },
+    { x: req.state.width * 0.12, y: req.state.height * 0.88 },
+    { x: req.state.width * 0.88, y: req.state.height * 0.88 },
+    { x: req.state.width * 0.5, y: req.state.height * 0.16 },
+    { x: req.state.width * 0.5, y: req.state.height * 0.84 }
   ]
-  const target = corners.reduce((best, c) => (dist(cue, c) > dist(cue, best) ? c : best), corners[0])
+  const scoreAnchor = (anchor) => {
+    const minTargetDist = legalTargets.length
+      ? legalTargets.reduce((best, ball) => Math.min(best, dist(anchor, ball)), Infinity)
+      : dist(anchor, cue)
+    const nearestPocketDist = pockets.length
+      ? pockets.reduce((best, p) => Math.min(best, dist(anchor, p)), Infinity)
+      : req.state.ballRadius * 10
+    const travelDist = dist(cue, anchor)
+    const scratchPadding = Math.min(1, nearestPocketDist / Math.max(req.state.ballRadius * 8, 1e-6))
+    return minTargetDist * 0.62 + nearestPocketDist * 0.28 + travelDist * 0.1 * scratchPadding
+  }
+  const target = safeAnchors.reduce((best, c) => (scoreAnchor(c) > scoreAnchor(best) ? c : best), safeAnchors[0])
   const angle = Math.atan2(target.y - cue.y, target.x - cue.x)
   return {
     angleRad: angle,
-    power: 0.5 * POWER_SCALE,
+    power: 0.56 * POWER_SCALE,
     spin: { top: 0, side: 0, back: 0 },
-    quality: 0,
+    quality: 0.08,
     rationale: 'safety'
   }
 }
@@ -948,12 +963,13 @@ export function planShot (req) {
       best.suggestedTargetBallId = suggestion.suggestedTargetBallId
       best.suggestedAimPoint = suggestion.suggestedAimPoint
     }
-    if (best.quality >= 0.1) return best
+    if (best.quality >= 0.18) return best
     if (hasViableShot) return best
   }
-  if (!hasViableShot) return safetyShot(req)
+  if (!hasViableShot || (best && best.quality < 0.14)) return safetyShot(req)
   fallback = fallbackAimAtTarget(req)
-  if (fallback) return fallback
+  if (fallback && (!best || best.quality < 0.1)) return fallback
+  if (best) return best
   return safetyShot(req)
 }
 

--- a/webapp/src/config/poolRoyaleClothPresets.js
+++ b/webapp/src/config/poolRoyaleClothPresets.js
@@ -52,7 +52,7 @@ const OCEAN_SHADE_NAMES = ['Crest', 'Current', 'Lagoon', 'Reef', 'Abyss'];
 const MATERIAL_SERIES = [
   {
     prefix: 'caban',
-    label: 'Caban Wool',
+    label: 'Caban',
     sourceId: 'caban',
     basePrice: 690,
     priceStep: 10,
@@ -90,7 +90,7 @@ const MATERIAL_SERIES = [
   },
   {
     prefix: 'polarFleecePlush',
-    label: 'Polar Fleece Plush',
+    label: 'Polar Fleece',
     sourceId: 'polar_fleece',
     basePrice: 700,
     priceStep: 10,
@@ -109,7 +109,7 @@ const MATERIAL_SERIES = [
   },
   {
     prefix: 'polarFleeceNatureOcean',
-    label: 'Polar Fleece Nature & Ocean',
+    label: 'Polar Fleece',
     sourceId: 'polar_fleece',
     basePrice: 660,
     priceStep: 10,
@@ -130,7 +130,7 @@ const MATERIAL_SERIES = [
   },
   {
     prefix: 'terryCloth',
-    label: 'Polyhaven Terry Cloth',
+    label: 'Terry Cloth',
     sourceId: 'terry_cloth',
     basePrice: 740,
     priceStep: 12,

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -3445,6 +3445,11 @@ const CLOTH_THREADS_PER_TILE = CLOTH_TEXTURE_SIZE / CLOTH_THREAD_PITCH;
 const CLOTH_PATTERN_SCALE = 0.66; // make procedural weave read a touch larger on-screen
 const CLOTH_TEXTURE_REPEAT_HINT = 1.66;
 const POLYHAVEN_PATTERN_REPEAT_SCALE = 1.08;
+const POLYHAVEN_REFERENCE_TABLE_INCHES = Object.freeze({
+  width: 100,
+  height: 50
+});
+const CM_TO_INCH = 0.3937007874;
 const POLYHAVEN_ANISOTROPY_BOOST = 9;
 const POLYHAVEN_TEXTURE_RESOLUTION =
   CLOTH_QUALITY.textureSize >= 4096 ? '8k' : '4k';
@@ -3466,6 +3471,8 @@ const CLOTH_TEXTURE_KEYS_BY_SOURCE = CLOTH_LIBRARY.reduce((acc, cloth) => {
 
 const CLOTH_TEXTURE_CONSUMERS = new Map();
 const CLOTH_CONSUMER_KEYS = new Map();
+const POLYHAVEN_INFO_CACHE = new Map();
+const POLYHAVEN_INFO_PENDING = new Map();
 
 const resolveClothPatternOverride = (textureKey) => {
   const preset =
@@ -3610,6 +3617,52 @@ const buildPolyHavenLegacyTextureUrls = (sourceId, resolution) => {
     normal: `${base}_NormalGL.jpg`,
     roughness: `${base}_Roughness.jpg`
   };
+};
+
+const fetchPolyHavenInfo = async (sourceId) => {
+  if (!sourceId) return null;
+  if (POLYHAVEN_INFO_CACHE.has(sourceId)) {
+    return POLYHAVEN_INFO_CACHE.get(sourceId);
+  }
+  if (POLYHAVEN_INFO_PENDING.has(sourceId)) {
+    return POLYHAVEN_INFO_PENDING.get(sourceId);
+  }
+  if (typeof fetch !== 'function') return null;
+  const pending = (async () => {
+    try {
+      const response = await fetch(`https://api.polyhaven.com/info/${encodeURIComponent(sourceId)}`);
+      if (!response?.ok) {
+        POLYHAVEN_INFO_CACHE.set(sourceId, null);
+        return null;
+      }
+      const info = await response.json();
+      POLYHAVEN_INFO_CACHE.set(sourceId, info);
+      return info;
+    } catch (error) {
+      POLYHAVEN_INFO_CACHE.set(sourceId, null);
+      return null;
+    } finally {
+      POLYHAVEN_INFO_PENDING.delete(sourceId);
+    }
+  })();
+  POLYHAVEN_INFO_PENDING.set(sourceId, pending);
+  return pending;
+};
+
+const resolvePolyHavenRepeatScaleFromInfo = (info) => {
+  const dimensionsCm = Array.isArray(info?.dimensions) ? info.dimensions : null;
+  if (!dimensionsCm || dimensionsCm.length < 2) return POLYHAVEN_PATTERN_REPEAT_SCALE;
+  const [widthCm, heightCm] = dimensionsCm;
+  if (!Number.isFinite(widthCm) || !Number.isFinite(heightCm) || widthCm <= 0 || heightCm <= 0) {
+    return POLYHAVEN_PATTERN_REPEAT_SCALE;
+  }
+  const texWidthInches = widthCm * CM_TO_INCH;
+  const texHeightInches = heightCm * CM_TO_INCH;
+  if (texWidthInches <= 0 || texHeightInches <= 0) return POLYHAVEN_PATTERN_REPEAT_SCALE;
+  const repeatX = POLYHAVEN_REFERENCE_TABLE_INCHES.width / texWidthInches;
+  const repeatY = POLYHAVEN_REFERENCE_TABLE_INCHES.height / texHeightInches;
+  const averageRepeat = (repeatX + repeatY) * 0.5;
+  return THREE.MathUtils.clamp(averageRepeat, 0.35, 2.2);
 };
 
 const collectPolyHavenUrls = (apiJson) => {
@@ -3996,6 +4049,7 @@ const createClothTextures = (() => {
     const promise = (async () => {
       try {
         let urls = {};
+        let sourceInfo = null;
         try {
           const response = await fetch(`https://api.polyhaven.com/files/${encodeURIComponent(preset.sourceId)}`);
           if (response?.ok) {
@@ -4008,6 +4062,7 @@ const createClothTextures = (() => {
         } catch (error) {
           urls = {};
         }
+        sourceInfo = await fetchPolyHavenInfo(preset.sourceId);
 
         const fallback4k = buildPolyHavenTextureUrls(preset.sourceId, '4k');
         const fallback2k = buildPolyHavenTextureUrls(preset.sourceId, '2k');
@@ -4065,6 +4120,7 @@ const createClothTextures = (() => {
         );
 
         const existing = cache.get(cacheKey) || {};
+        const realWorldRepeatScale = resolvePolyHavenRepeatScaleFromInfo(sourceInfo);
         cache.set(cacheKey, {
           ...existing,
           map: map ?? existing.map ?? null,
@@ -4073,6 +4129,14 @@ const createClothTextures = (() => {
           roughness: roughness ?? existing.roughness ?? null,
           presetId: preset.id,
           sourceId: preset.sourceId,
+          sourceName:
+            typeof sourceInfo?.name === 'string' && sourceInfo.name.trim()
+              ? sourceInfo.name.trim()
+              : null,
+          sourceDimensionsCm: Array.isArray(sourceInfo?.dimensions)
+            ? sourceInfo.dimensions.slice(0, 2)
+            : null,
+          realWorldRepeatScale,
           mapSource: map ? 'polyhaven' : existing.mapSource ?? 'procedural',
           ready: Boolean(map || normal || roughness)
         });
@@ -4122,6 +4186,14 @@ const createClothTextures = (() => {
       roughness: cloneTexture(entry.roughness),
       presetId: preset.id,
       sourceId: entry.sourceId,
+      sourceName: entry.sourceName ?? null,
+      sourceDimensionsCm: Array.isArray(entry.sourceDimensionsCm)
+        ? entry.sourceDimensionsCm.slice(0, 2)
+        : null,
+      realWorldRepeatScale:
+        Number.isFinite(entry.realWorldRepeatScale)
+          ? entry.realWorldRepeatScale
+          : POLYHAVEN_PATTERN_REPEAT_SCALE,
       mapSource:
         normalizedSource === DEFAULT_CLOTH_TEXTURE_SOURCE_ID
           ? entry.mapSource ?? 'procedural'
@@ -4185,7 +4257,12 @@ function updateClothTexturesForFinish (
   if (!finishInfo?.clothMat) return;
   registerClothTextureConsumer(textureKey, finishInfo);
   const textures = createClothTextures(textureKey, textureSource);
-  const textureScale = textures.mapSource === 'polyhaven' ? POLYHAVEN_PATTERN_REPEAT_SCALE : 1;
+  const textureScale =
+    textures.mapSource === 'polyhaven'
+      ? Number.isFinite(textures.realWorldRepeatScale)
+        ? textures.realWorldRepeatScale
+        : POLYHAVEN_PATTERN_REPEAT_SCALE
+      : 1;
   const targetNormalScale =
     finishInfo.clothBase?.isPolyHavenCloth && textures.normal
       ? POLYHAVEN_NORMAL_SCALE
@@ -4243,6 +4320,12 @@ function updateClothTexturesForFinish (
   }
   if (finishInfo.clothMat.userData) {
     finishInfo.clothMat.userData.polyRepeatScale = textureScale;
+    finishInfo.clothMat.userData.polySourceName = textures.sourceName ?? null;
+    finishInfo.clothMat.userData.polySourceDimensionsCm = Array.isArray(
+      textures.sourceDimensionsCm
+    )
+      ? textures.sourceDimensionsCm.slice(0, 2)
+      : null;
     finishInfo.clothMat.userData.baseRepeat = baseRepeatValue;
     finishInfo.clothMat.userData.baseRepeatRaw = baseRepeatRaw;
     finishInfo.clothMat.userData.nearRepeat = baseRepeatValue * 1.12;


### PR DESCRIPTION
### Motivation
- Align cloth visuals with Poly Haven originals so cloth textures use official mapping, names and real-world repeat scale for higher-fidelity, high-FPS rendering.
- Make the AI behave more like a disciplined professional player by avoiding scratches, preferring true safety choices and reducing weak pot attempts.

### Description
- Add Poly Haven metadata fetch and caching (`fetchPolyHavenInfo`, `POLYHAVEN_INFO_CACHE`, `POLYHAVEN_INFO_PENDING`) and compute a real-world repeat scale from official `dimensions` to drive texture tiling; constants `POLYHAVEN_REFERENCE_TABLE_INCHES` and `CM_TO_INCH` are introduced and used. (`webapp/src/pages/Games/PoolRoyale.jsx`) 
- Wire `sourceName`, `sourceDimensionsCm` and `realWorldRepeatScale` through the cloth pipeline (`ensurePolyHavenTextures`, `createClothTextures`) and apply the computed repeat when binding maps in `updateClothTexturesForFinish` (userData keys: `polyRepeatScale`, `polySourceName`, `polySourceDimensionsCm`). (`webapp/src/pages/Games/PoolRoyale.jsx`) 
- Normalize cloth preset labels to match Poly Haven naming (`Caban`, `Polar Fleece`, `Terry Cloth`) so UI selections match official assets. (`webapp/src/config/poolRoyaleClothPresets.js`) 
- Harden AI shot logic in `lib/poolAi.js` by rejecting shots with post-impact scratch risk, replacing corner-safety with scored safe anchor placement, slightly boosting safety power/quality, and tightening acceptance thresholds so low-quality pots fall back to safety. (`lib/poolAi.js`) 

### Testing
- Ran `node --check lib/poolAi.js` and it succeeded. 
- Ran `node --check webapp/src/config/poolRoyaleClothPresets.js` and it succeeded. 
- Ran `node -e "import('./lib/poolAi.js').then(()=>console.log('poolAi ok'))"` and it printed success. 
- Bundled `webapp/src/pages/Games/PoolRoyale.jsx` with `npx --yes esbuild ...` and the bundle completed successfully. 
- Project lint (`npm --prefix webapp run -s lint`) was executed and returned a non-zero exit (lint step failed in this environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c64e7cfdc48329a128ea97b0c8253d)