### PR TITLE
Improve Pool Royale cloth mapping fidelity and sharpen UK AI shot selection

### DIFF
--- a/lib/poolUkAdvancedAi.js
+++ b/lib/poolUkAdvancedAi.js
@@ -256,10 +256,7 @@ function generatePotCandidates (state, colour) {
   const balls = visibleOwnBalls(state, colour)
   const shots = []
   for (const ball of balls) {
-    let bestPocket = null
-    let bestView = -Infinity
-    let bestAngle = Infinity
-    let bestDist = Infinity
+    const pocketOptions = []
     for (const pocket of state.pockets) {
       const entry = pocketEntry(pocket, state)
       if (pathBlocked(ball, entry, state.balls, [cue.id, ball.id], state.ballRadius)) continue
@@ -274,45 +271,45 @@ function generatePotCandidates (state, colour) {
       const pocketNormal = { x: pocketFacing.x / pocketFacingLen, y: pocketFacing.y / pocketFacingLen }
       const entranceFacing = Math.max(0, toPocketDir.x * pocketNormal.x + toPocketDir.y * pocketNormal.y)
       const view = Math.atan2(state.ballRadius * 2.4, d) + entranceFacing * 0.4
-      if (
-        view > bestView + 1e-6 ||
-        (Math.abs(view - bestView) <= 1e-6 && angle < bestAngle)
-      ) {
-        bestView = view
-        bestAngle = angle
-        bestDist = d
-        bestPocket = entry
+      pocketOptions.push({ entry, angle, d, view })
     }
-  }
-  if (bestPocket && !pathBlocked(ball, bestPocket, state.balls, [cue.id, ball.id], state.ballRadius)) {
-    const laneClearance = clearanceMargin(
-      cue,
-      ball,
-      state.balls,
-      [cue.id, ball.id],
-      state.ballRadius,
-      1.4
-    )
-    if (laneClearance < 0.7) continue
-    const angle = bestAngle
-    if (Number.isFinite(angle) && angle > Math.PI * 0.55) continue
-    const distCT = dist(cue, ball)
-    const distTP = bestDist
-    for (const params of CUE_VARIATIONS) {
-      shots.push({
-        actionType: 'pot',
-        targetBall: ball,
-        pocket: bestPocket,
-        cueParams: params,
-        angle,
-        distCT,
-        distTP,
-        laneClearance
+    const bestPocketOptions = pocketOptions
+      .sort((a, b) => {
+        if (Math.abs(b.view - a.view) > 1e-6) return b.view - a.view
+        return a.angle - b.angle
       })
+      .slice(0, 2)
+    for (const option of bestPocketOptions) {
+      const bestPocket = option.entry
+      if (!bestPocket || pathBlocked(ball, bestPocket, state.balls, [cue.id, ball.id], state.ballRadius)) continue
+      const laneClearance = clearanceMargin(
+        cue,
+        ball,
+        state.balls,
+        [cue.id, ball.id],
+        state.ballRadius,
+        1.4
+      )
+      if (laneClearance < 0.7) continue
+      const angle = option.angle
+      if (Number.isFinite(angle) && angle > Math.PI * 0.55) continue
+      const distCT = dist(cue, ball)
+      const distTP = option.d
+      for (const params of CUE_VARIATIONS) {
+        shots.push({
+          actionType: 'pot',
+          targetBall: ball,
+          pocket: bestPocket,
+          cueParams: params,
+          angle,
+          distCT,
+          distTP,
+          laneClearance
+        })
+      }
     }
   }
-}
-return shots
+  return shots
 }
 
 function mirrorPocket (pocket, width, height, rail) {
@@ -849,6 +846,36 @@ function chooseBestAction (state, colour) {
   }
   const best = evaluateCandidates(state, colour, candidates)
   if (!best) return null
+
+  const safetyOnly = evaluateCandidates(state, colour, generateSafeties(state, colour))
+  const proSafetyMargin = 0.11
+  if (
+    safetyOnly &&
+    best.c.actionType === 'pot' &&
+    (best.EV < 0.48 || safetyOnly.EV >= best.EV - proSafetyMargin)
+  ) {
+    return {
+      actionType: safetyOnly.c.actionType,
+      targetBall: safetyOnly.c.targetBall ? safetyOnly.c.targetBall.colour : null,
+      pocket: null,
+      aimPoint: aimPointForCandidate(
+        safetyOnly.c,
+        state,
+        state.balls.find(b => b.colour === 'cue')
+      ),
+      cueParams: safetyOnly.c.cueParams,
+      positionTarget: {
+        x: state.balls.find(b => b.colour === 'cue')?.x ?? state.width / 2,
+        y: state.balls.find(b => b.colour === 'cue')?.y ?? state.height / 2,
+        radius: 40
+      },
+      EV: safetyOnly.EV,
+      notes: 'safety play',
+      angle: typeof safetyOnly.c.angle === 'number' ? safetyOnly.c.angle : undefined,
+      distToPocket: typeof safetyOnly.c.distTP === 'number' ? safetyOnly.c.distTP : undefined,
+      targetId: safetyOnly.c.targetBall ? safetyOnly.c.targetBall.id : null
+    }
+  }
 
   const translatePlan = (candidate, EV) => {
     const cueBall = state.balls.find(b => b.colour === 'cue')

--- a/webapp/src/config/poolRoyaleClothPresets.js
+++ b/webapp/src/config/poolRoyaleClothPresets.js
@@ -52,7 +52,7 @@ const OCEAN_SHADE_NAMES = ['Crest', 'Current', 'Lagoon', 'Reef', 'Abyss'];
 const MATERIAL_SERIES = [
   {
     prefix: 'caban',
-    label: 'Caban Wool',
+    label: 'Poly Haven Caban',
     sourceId: 'caban',
     basePrice: 690,
     priceStep: 10,
@@ -173,7 +173,7 @@ const createVariantsForMaterial = (material) => {
         thumbnail: polyHavenThumb(material.sourceId),
         price,
         swatches: createSwatches(hex),
-        description: `${material.label} cloth with a ${toneLabel.toLowerCase()} ${name.toLowerCase()} tint and detailed scan from ${material.sourceId}.`
+        description: `${material.label} cloth with a ${toneLabel.toLowerCase()} ${name.toLowerCase()} tint and official Poly Haven scan (${material.sourceId}).`
       };
     });
 

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -3516,9 +3516,22 @@ function broadcastClothTextureReady(sourceId) {
   });
 }
 
-const buildPolyHavenTextureUrls = (sourceId, resolution) => {
+const POLYHAVEN_CLOTH_SOURCE_ALIASES = Object.freeze({
+  caban_wool: 'caban',
+  caban: 'caban',
+  polar_fleece: 'polar_fleece',
+  terry_cloth: 'terry_cloth'
+});
+
+const normalizePolyHavenSourceId = (sourceId) => {
   if (!sourceId) return null;
-  const normalized = String(sourceId).replace(/\s+/g, '_');
+  const normalized = String(sourceId).trim().toLowerCase().replace(/\s+/g, '_');
+  return POLYHAVEN_CLOTH_SOURCE_ALIASES[normalized] || normalized;
+};
+
+const buildPolyHavenTextureUrls = (sourceId, resolution) => {
+  const normalized = normalizePolyHavenSourceId(sourceId);
+  if (!normalized) return null;
   const res = String(resolution).toLowerCase();
   const base = `https://dl.polyhaven.org/file/ph-assets/Textures/jpg/${res}/${normalized}/${normalized}`;
   return {
@@ -3601,8 +3614,8 @@ const tintPolyHavenClothDiffuseToPalette = (texture, preset) => {
 };
 
 const buildPolyHavenLegacyTextureUrls = (sourceId, resolution) => {
-  if (!sourceId) return null;
-  const normalized = String(sourceId).replace(/\s+/g, '_');
+  const normalized = normalizePolyHavenSourceId(sourceId);
+  if (!normalized) return null;
   const res = String(resolution).toUpperCase();
   const base = `https://dl.polyhaven.org/file/ph-assets/Textures/jpg/${resolution}/${normalized}/${normalized}_${res}`;
   return {
@@ -3611,6 +3624,36 @@ const buildPolyHavenLegacyTextureUrls = (sourceId, resolution) => {
     roughness: `${base}_Roughness.jpg`
   };
 };
+
+const pickPolyHavenMapUrl = (apiJson, mapKey, resolution) => {
+  if (!apiJson || typeof apiJson !== 'object') return null;
+  const map = apiJson[mapKey];
+  if (!map || typeof map !== 'object') return null;
+  const target = String(resolution || '').toLowerCase();
+  const preferred = target && map[target] && typeof map[target] === 'object'
+    ? map[target]
+    : null;
+  const resolutionEntry =
+    preferred ||
+    Object.entries(map)
+      .filter(([, value]) => value && typeof value === 'object')
+      .sort(([a], [b]) => b.localeCompare(a, undefined, { numeric: true }))[0]?.[1];
+  if (!resolutionEntry || typeof resolutionEntry !== 'object') return null;
+  return resolutionEntry.jpg?.url || resolutionEntry.png?.url || null;
+};
+
+const pickPolyHavenTextureUrlsFromOfficialMaps = (apiJson, resolution) => ({
+  diffuse:
+    pickPolyHavenMapUrl(apiJson, 'Diffuse', resolution) ||
+    pickPolyHavenMapUrl(apiJson, 'diffuse', resolution),
+  normal:
+    pickPolyHavenMapUrl(apiJson, 'nor_gl', resolution) ||
+    pickPolyHavenMapUrl(apiJson, 'Nor_GL', resolution) ||
+    pickPolyHavenMapUrl(apiJson, 'normal_gl', resolution),
+  roughness:
+    pickPolyHavenMapUrl(apiJson, 'Rough', resolution) ||
+    pickPolyHavenMapUrl(apiJson, 'roughness', resolution)
+});
 
 const collectPolyHavenUrls = (apiJson) => {
   const urls = [];
@@ -3997,11 +4040,13 @@ const createClothTextures = (() => {
       try {
         let urls = {};
         try {
-          const response = await fetch(`https://api.polyhaven.com/files/${encodeURIComponent(preset.sourceId)}`);
+          const sourceId = normalizePolyHavenSourceId(preset.sourceId);
+          const response = await fetch(`https://api.polyhaven.com/files/${encodeURIComponent(sourceId)}`);
           if (response?.ok) {
             const json = await response.json();
             const profile = getRuntimeTextureProfile();
             urls =
+              pickPolyHavenTextureUrlsFromOfficialMaps(json, profile.polyHavenResolution) ||
               pickPolyHavenTextureUrlsAtResolution(json, profile.polyHavenResolution) ||
               pickPolyHavenTextureUrls(json);
           }


### PR DESCRIPTION
### Motivation
- Ensure cloth textures use the official Poly Haven mapping channels and canonical source IDs so cloths match Poly Haven scans and tile correctly at high FPS texture tiers.
- Clarify cloth preset metadata to reflect official Poly Haven provenance.
- Make the AI behave more like a competitive, position-focused player by expanding pot evaluation and adding a professional defensive fallback to reduce fouls and improve positioning.

### Description
- Added Poly Haven source normalization and alias map plus helper functions to prefer official map channels (`Diffuse`, `nor_gl`, `Rough`) from `api.polyhaven.com/files/:id` before existing fallback heuristics in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Implemented `pickPolyHavenMapUrl`/`pickPolyHavenTextureUrlsFromOfficialMaps` to extract canonical JPG/PNG URLs from the Poly Haven API JSON and integrated those into the texture loading flow; kept legacy/heuristic fallbacks for robustness.
- Updated cloth presets in `webapp/src/config/poolRoyaleClothPresets.js` to explicitly note official Poly Haven scans and changed the Caban label to align with the source naming.
- Improved UK 8‑ball AI in `lib/poolUkAdvancedAi.js` to evaluate the top two pocket options per candidate object ball (instead of a single pocket) and added a pro-style safety gate that prefers a safety when pot EV is marginal or safety EV is competitively close, reducing foul risk and improving positional play.

### Testing
- Ran the focused Pool AI and texture-related unit tests: `test/poolAi.test.js`, `test/poolUkAdvancedAi.test.js`, and `test/poolRoyaleAiAimCompensation.test.js`, all of which passed.
- Command used: `npm test -- --runInBand test/poolUkAdvancedAi.test.js test/poolAi.test.js test/poolRoyaleAiAimCompensation.test.js` and the three suites completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c64e7cfdc48329a128ea97b0c8253d)