### PR TITLE
Default to procedural cloth textures in Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -3091,7 +3091,7 @@ const CLOTH_TEXTURE_PRESETS = Object.freeze(
 const DEFAULT_CLOTH_TEXTURE_KEY =
   POOL_ROYALE_DEFAULT_UNLOCKS.clothColor?.[0] ?? CLOTH_LIBRARY[0].id;
 const DEFAULT_CLOTH_COLOR_ID = DEFAULT_CLOTH_TEXTURE_KEY;
-const DEFAULT_CLOTH_TEXTURE_SOURCE_ID = 'polyhaven';
+const DEFAULT_CLOTH_TEXTURE_SOURCE_ID = 'procedural';
 const CLOTH_COLOR_OPTIONS = Object.freeze(
   CLOTH_LIBRARY.map((cloth) => ({
     id: cloth.id,
@@ -4109,24 +4109,20 @@ const createClothTextures = (() => {
       cache.set(cacheKey, entry);
     }
 
-    const normalizedSource =
-      textureSource === 'procedural'
-        ? DEFAULT_CLOTH_TEXTURE_SOURCE_ID
-        : textureSource;
-    ensurePolyHavenTextures(preset, cacheKey);
+    const useProcedural = textureSource === 'procedural';
+    if (!useProcedural) {
+      ensurePolyHavenTextures(preset, cacheKey);
+    }
 
     return {
-      map: cloneTexture(entry.map),
-      bump: cloneTexture(entry.bump),
-      normal: cloneTexture(entry.normal),
-      roughness: cloneTexture(entry.roughness),
+      map: cloneTexture(useProcedural ? entry.proceduralMap ?? entry.map : entry.map),
+      bump: cloneTexture(useProcedural ? entry.proceduralBump ?? entry.bump : entry.bump),
+      normal: cloneTexture(useProcedural ? null : entry.normal),
+      roughness: cloneTexture(useProcedural ? null : entry.roughness),
       presetId: preset.id,
       sourceId: entry.sourceId,
-      mapSource:
-        normalizedSource === DEFAULT_CLOTH_TEXTURE_SOURCE_ID
-          ? entry.mapSource ?? 'procedural'
-          : entry.mapSource ?? 'procedural',
-      ready: Boolean(entry.ready)
+      mapSource: useProcedural ? 'procedural' : entry.mapSource ?? 'procedural',
+      ready: useProcedural ? true : Boolean(entry.ready)
     };
   };
 })();


### PR DESCRIPTION
### Motivation
- Make procedural cloth the default for Pool Royale so the table uses the in-engine generated felt instead of loading GLTF/PolyHaven textures. 
- Reduce external asset loading and ensure consistent, immediate availability of cloth map/bump data for the procedural workflow.

### Description
- Changed the default cloth source from `polyhaven` to `procedural` by updating `DEFAULT_CLOTH_TEXTURE_SOURCE_ID` to `'procedural'` in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Updated the cloth texture factory (`createClothTextures`) to respect an explicit procedural selection and to avoid calling `ensurePolyHavenTextures` when procedural mode is requested.
- When procedural mode is used the returned textures now prefer `proceduralMap`/`proceduralBump`, omit normal/roughness maps, set `mapSource` to `'procedural'`, and mark `ready` immediately.
- Kept the non-procedural path intact so PolyHaven textures are still loaded when explicitly requested.

### Testing
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx` which completed and reported that the file is ignored by the repo lint ignore pattern (no lint errors reported for the change).
- Ran `npx eslint --no-ignore webapp/src/pages/Games/PoolRoyale.jsx` which completed with the same ignore-related warning and no blocking errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c66cbd229c8329bf5ddb42d3d6950b)