### PR TITLE
Dynamic graphics resolution tiers, texture sizing, frame-rate profiles and UI refinements

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -559,12 +559,12 @@ function detectPreferredFrameRateId() {
   const rendererTier = classifyRendererTier(readGraphicsRendererString());
 
   if (lowRefresh) {
-    return 'hd50';
+    return 'fhd60';
   }
 
   if (isMobileUA || coarsePointer || isTouch || rendererTier === 'mobile') {
     if ((deviceMemory !== null && deviceMemory <= 4) || hardwareConcurrency <= 4) {
-      return 'hd50';
+      return 'fhd60';
     }
     if (highRefresh && hardwareConcurrency >= 8 && (deviceMemory == null || deviceMemory >= 6)) {
       return 'uhd120';
@@ -2725,7 +2725,7 @@ const pocketPlasticTextureCache = new Map();
 const pocketPlasticConsumers = new Set();
 
 const createProceduralPocketPlasticTextures = ({
-  size = 512,
+  size = getRuntimePocketTextureSize(),
   seed = 1337,
   repeat = POCKET_PLASTIC_TEXTURE_REPEAT
 } = {}) => {
@@ -2827,7 +2827,7 @@ const broadcastPocketPlasticTextures = (textures) => {
 
 
 const ensurePocketPlasticTextures = () => {
-  const cacheKey = 'pocket-plastic';
+  const cacheKey = `pocket-plastic-${getRuntimePocketTextureSize()}`;
   if (!pocketPlasticTextureCache.has(cacheKey)) {
     pocketPlasticTextureCache.set(cacheKey, {
       map: null,
@@ -3229,71 +3229,89 @@ const LIGHTING_PRESET_MAP = Object.freeze(
 const FRAME_RATE_STORAGE_KEY = 'snookerFrameRate';
 const FRAME_RATE_OPTIONS = Object.freeze([
   {
-    id: 'hd50',
-    label: 'HD Performance (50 Hz)',
-    fps: 50,
+    id: 'fhd60',
+    label: 'Performance (60 Hz)',
+    fps: 60,
     renderScale: 1,
-    pixelRatioCap: 1.35,
-    resolution: 'HD render • DPR 1.35 cap',
-    description: 'Low-power 50 Hz profile for battery saver and thermal relief.'
+    pixelRatioCap: 1.4,
+    resolution: 'Full HD texture pack • 60 FPS',
+    description: 'Balanced battery profile using Full HD assets.'
   },
   {
     id: 'fhd90',
-    label: 'Full HD (90 Hz)',
+    label: 'Smooth (90 Hz)',
     fps: 90,
     renderScale: 1.12,
     pixelRatioCap: 1.55,
-    resolution: 'Full HD render • DPR 1.55 cap',
-    description: '1080p-focused profile tuned for 90 Hz full-motion play.'
+    resolution: '2K texture pack • 90 FPS',
+    description: 'Sharper 2K assets for fluid 90 FPS play.'
   },
   {
     id: 'qhd90',
-    label: 'Quad HD (105 Hz)',
+    label: 'Pro (105 Hz)',
     fps: 105,
     renderScale: 1.22,
     pixelRatioCap: 1.72,
-    resolution: 'QHD render • DPR 1.72 cap',
-    description: 'Sharper 1440p render for capable 105 Hz mobile and desktop GPUs.'
+    resolution: '4K texture pack • 105 FPS',
+    description: 'High-detail 4K assets for premium devices.'
   },
   {
     id: 'uhd120',
-    label: 'Ultra HD (120 Hz cap)',
+    label: 'Ultra (120 Hz)',
     fps: 120,
     renderScale: 1.28,
     pixelRatioCap: 1.85,
-    resolution: 'Ultra HD render • DPR 1.85 cap',
-    description: '4K-oriented profile tuned for smooth play up to 120 Hz.'
+    resolution: '6K texture pack • 120 FPS',
+    description: 'Maximum 6K assets and 120 FPS target.'
   }
 ]);
 const DEFAULT_FRAME_RATE_ID = 'fhd90';
-const HIGH_FPS_6K_MIN_FPS = 105;
-const HIGH_FPS_6K_TEXTURE_SIZE = 6144;
+const GRAPHICS_RESOLUTION_BY_FPS = Object.freeze([
+  { minFps: 120, key: '6k', textureSize: 6144 },
+  { minFps: 105, key: '4k', textureSize: 4096 },
+  { minFps: 90, key: '2k', textureSize: 2048 },
+  { minFps: 0, key: '1k', textureSize: 1920 }
+]);
+const resolveGraphicsResolutionTier = (fps) => {
+  const safeFps = Number.isFinite(fps) ? fps : 60;
+  return (
+    GRAPHICS_RESOLUTION_BY_FPS.find((tier) => safeFps >= tier.minFps) ??
+    GRAPHICS_RESOLUTION_BY_FPS[GRAPHICS_RESOLUTION_BY_FPS.length - 1]
+  );
+};
 let runtimeTextureProfile = Object.freeze({
-  textureSize: CLOTH_QUALITY.textureSize,
+  textureSize: resolveGraphicsResolutionTier(90).textureSize,
   anisotropy: CLOTH_QUALITY.anisotropy,
   generateMipmaps: CLOTH_QUALITY.generateMipmaps,
-  polyHavenResolution: CLOTH_QUALITY.textureSize >= 4096 ? '8k' : '4k',
-  enforceTableFinishTextureSize: null
+  polyHavenResolution: '2k',
+  hdriResolution: '2k',
+  enforceTableFinishTextureSize: 2048,
+  cueTextureSize: 2048,
+  pocketTextureSize: 1024
 });
 
-const isHighFpsTextureTier = (fps) =>
-  Number.isFinite(fps) && fps >= HIGH_FPS_6K_MIN_FPS;
-
 const updateRuntimeTextureProfile = ({ fps } = {}) => {
-  const highFpsTier = isHighFpsTextureTier(fps);
-  const textureSize = highFpsTier
-    ? Math.max(CLOTH_QUALITY.textureSize, HIGH_FPS_6K_TEXTURE_SIZE)
-    : CLOTH_QUALITY.textureSize;
+  const tier = resolveGraphicsResolutionTier(fps);
+  const textureSize = tier.textureSize;
+  const anisotropyRatio = textureSize / 6144;
+  const anisotropy = Math.max(16, Math.round(CLOTH_QUALITY.anisotropy * anisotropyRatio));
   runtimeTextureProfile = Object.freeze({
     textureSize,
-    anisotropy: CLOTH_QUALITY.anisotropy,
+    anisotropy,
     generateMipmaps: CLOTH_QUALITY.generateMipmaps,
-    polyHavenResolution: textureSize >= 6144 ? '8k' : textureSize >= 4096 ? '8k' : '4k',
-    enforceTableFinishTextureSize: highFpsTier ? HIGH_FPS_6K_TEXTURE_SIZE : null
+    polyHavenResolution: tier.key,
+    hdriResolution: tier.key,
+    enforceTableFinishTextureSize: textureSize,
+    cueTextureSize: textureSize,
+    pocketTextureSize: Math.max(512, Math.min(textureSize, 4096))
   });
 };
 
 const getRuntimeTextureProfile = () => runtimeTextureProfile;
+const getRuntimeCueTextureSize = () =>
+  getRuntimeTextureProfile().cueTextureSize ?? CUE_WOOD_TEXTURE_SIZE;
+const getRuntimePocketTextureSize = () =>
+  getRuntimeTextureProfile().pocketTextureSize ?? 1024;
 
 const enforceHighFpsTableTextureSize = (size) => {
   const minSize = getRuntimeTextureProfile().enforceTableFinishTextureSize;
@@ -4767,7 +4785,8 @@ const HDRI_RESOLUTION_OPTIONS = Object.freeze([
   { id: '8k', label: '8K' },
   { id: '6k', label: '6K' },
   { id: '4k', label: '4K' },
-  { id: '2k', label: '2K' }
+  { id: '2k', label: '2K' },
+  { id: '1k', label: 'Full HD' }
 ]);
 const HDRI_RESOLUTION_OPTION_MAP = Object.freeze(
   HDRI_RESOLUTION_OPTIONS.reduce((acc, option) => {
@@ -7839,7 +7858,7 @@ export function Table3D(
   );
   const synchronizedTextureSize = Math.max(
     initialFrameSurface.textureSize ?? DEFAULT_WOOD_TEXTURE_SIZE,
-    CUE_WOOD_TEXTURE_SIZE
+    getRuntimeCueTextureSize()
   );
   const finalWoodTextureSize = enforceHighFpsTableTextureSize(synchronizedTextureSize);
   const synchronizedRailSurface = {
@@ -12672,6 +12691,10 @@ function PoolRoyaleGame({
       FRAME_RATE_OPTIONS[0],
     [frameRateId]
   );
+  const activeGraphicsResolutionTier = useMemo(
+    () => resolveGraphicsResolutionTier(activeFrameRateOption?.fps),
+    [activeFrameRateOption]
+  );
   const activeHdriResolutionOption = useMemo(
     () =>
       HDRI_RESOLUTION_OPTION_MAP[hdriResolutionId] ??
@@ -12705,7 +12728,13 @@ function PoolRoyaleGame({
   useEffect(() => {
     frameQualityRef.current = frameQualityProfile;
     updateRuntimeTextureProfile({ fps: frameQualityProfile?.fps });
+    ensurePocketPlasticTextures();
   }, [frameQualityProfile]);
+  useEffect(() => {
+    const targetHdriResolution = activeGraphicsResolutionTier?.key;
+    if (!targetHdriResolution || hdriResolutionId === targetHdriResolution) return;
+    setHdriResolutionId(targetHdriResolution);
+  }, [activeGraphicsResolutionTier, hdriResolutionId]);
   const activeBroadcastSystem = useMemo(
     () => resolveBroadcastSystem(broadcastSystemId),
     [broadcastSystemId]
@@ -12803,13 +12832,13 @@ function PoolRoyaleGame({
   );
   const resolvedHdriResolution = useMemo(() => {
     if (hdriResolutionId === 'auto') {
-      return resolveHdriResolutionForTable(responsiveTableSize);
+      return activeGraphicsResolutionTier?.key ?? resolveHdriResolutionForTable(responsiveTableSize);
     }
     if (HDRI_RESOLUTION_OPTION_MAP[hdriResolutionId]) {
       return hdriResolutionId;
     }
-    return resolveHdriResolutionForTable(responsiveTableSize);
-  }, [hdriResolutionId, responsiveTableSize]);
+    return activeGraphicsResolutionTier?.key ?? resolveHdriResolutionForTable(responsiveTableSize);
+  }, [activeGraphicsResolutionTier, hdriResolutionId, responsiveTableSize]);
   const activeEnvironmentHdri = useMemo(
     () => {
       const fromAvailable = availableEnvironmentHdris.find(
@@ -13933,7 +13962,7 @@ function PoolRoyaleGame({
         );
         const cueTextureSize = Math.max(
           cueSurface.textureSize ?? DEFAULT_WOOD_TEXTURE_SIZE,
-          CUE_WOOD_TEXTURE_SIZE
+          getRuntimeCueTextureSize()
         );
         const cueSurfaceConfig = {
           repeat: cueSurface.repeat,
@@ -13990,6 +14019,9 @@ function PoolRoyaleGame({
     }
     applySelectedCueStyle(cueStyleIndex);
   }, [cueStyleIndex, applySelectedCueStyle]);
+  useEffect(() => {
+    applySelectedCueStyle(cueStyleIndexRef.current ?? cueStyleIndex);
+  }, [frameQualityProfile.id, cueStyleIndex, applySelectedCueStyle]);
 
   const highlightChalks = useCallback(
     (activeIndex, suggestedIndex = visibleChalkIndexRef.current) => {
@@ -32510,6 +32542,16 @@ const powerRef = useRef(hud.power);
                 </svg>
               </button>
             </div>
+            {isFreePractice && (
+              <button
+                type="button"
+                onClick={handlePracticeRestart}
+                className="mt-3 flex w-full items-center justify-between rounded-full border border-emerald-300/55 bg-emerald-400/15 px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.24em] text-emerald-100 transition hover:bg-emerald-300/25 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300"
+              >
+                <span>Restart practice</span>
+                <span aria-hidden="true">↻</span>
+              </button>
+            )}
             <div className="mt-4 max-h-72 space-y-4 overflow-y-auto pr-1">
               <div>
                 <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
@@ -33568,26 +33610,14 @@ const powerRef = useRef(hud.power);
           >
             <span aria-hidden="true">☰</span>
           </button>
-          {isFreePractice ? (
-            <button
-              type="button"
-              onClick={handlePracticeRestart}
-              className="pointer-events-auto flex h-[3.15rem] w-[3.15rem] items-center justify-center rounded-[14px] border-none bg-transparent p-0 text-[1.5rem] text-white shadow-none"
-              aria-label="Restart practice"
-              title="Restart practice"
-            >
-              <span aria-hidden="true">↻</span>
-            </button>
-          ) : (
-            <button
-              type="button"
-              onClick={() => setShowChat(true)}
-              className="pointer-events-auto flex h-[3.15rem] w-[3.15rem] items-center justify-center rounded-[14px] border-none bg-transparent p-0 text-[1.5rem] text-white shadow-none"
-              aria-label="Open chat"
-            >
-              <span aria-hidden="true">💬</span>
-            </button>
-          )}
+          <button
+            type="button"
+            onClick={() => setShowChat(true)}
+            className="pointer-events-auto flex h-[3.15rem] w-[3.15rem] items-center justify-center rounded-[14px] border-none bg-transparent p-0 text-[1.5rem] text-white shadow-none"
+            aria-label="Open chat"
+          >
+            <span aria-hidden="true">💬</span>
+          </button>
         </div>
       )}
 


### PR DESCRIPTION
### Motivation

- Provide a consistent mapping from target FPS to appropriate texture/HDRI resolutions and anisotropy so graphics scale with performance targets.  
- Replace the old low-power `hd50` profile with a `fhd60` profile and make frame-rate options more descriptive and aligned with texture packs.  
- Ensure procedural textures (pocket/cue) and table wood textures use runtime-resolved sizes and update when quality changes, and simplify some HUD controls for practice/chat flows.

### Description

- Introduced `GRAPHICS_RESOLUTION_BY_FPS` and `resolveGraphicsResolutionTier` to map an FPS target to a graphics resolution tier and texture size.  
- Reworked runtime texture profile from a fixed shape into `runtimeTextureProfile` seeded by `resolveGraphicsResolutionTier`, and updated `updateRuntimeTextureProfile` to compute `textureSize`, `anisotropy`, `polyHavenResolution`, `hdriResolution`, `enforceTableFinishTextureSize`, `cueTextureSize`, and `pocketTextureSize`.  
- Replaced `hd50` profile with `fhd60` and updated `FRAME_RATE_OPTIONS` entries (ids, labels, `fps`, `pixelRatioCap`, `resolution`, and `description`) and set `DEFAULT_FRAME_RATE_ID` to `fhd90`.  
- Modified `detectPreferredFrameRateId` to return `fhd60` in previously low-power branches.  
- Added `getRuntimeCueTextureSize` and `getRuntimePocketTextureSize` helpers and used them when sizing cue/wood/pocket textures; `createProceduralPocketPlasticTextures` now defaults to `getRuntimePocketTextureSize()`.  
- Made `ensurePocketPlasticTextures` cache keyed by pocket texture size so multiple texture sizes can be cached: ``pocket-plastic-${getRuntimePocketTextureSize()}``.  
- Added `ensurePocketPlasticTextures()` call when `frameQualityProfile` changes and a reactive effect that synchronizes `hdriResolutionId` with the active graphics resolution tier.  
- Resolved HDRI resolution selection to prefer the active graphics tier when `auto` is selected and added a `1k` HDRI option.  
- Re-applies cue style when the frame quality profile changes by invoking `applySelectedCueStyle` in an effect.  
- UI adjustments: moved the practice restart control into the config panel (shown when `isFreePractice`) and simplified the top action buttons to always show chat (removed duplicate restart button).  

### Testing

- Ran a local app build via the project build process (`yarn build`) and the build completed successfully.  
- Ran the test suite (`yarn test`) and unit tests passed.  
- Ran lint/type checks (`yarn lint` / `yarn typecheck`) with no new errors reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c68246e4808329a796aac6bbb495be)