### PR TITLE
Tune Pool Royale shot/spin balance and improve AI pot aiming

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1757,7 +1757,7 @@ const POCKET_VIEW_POST_POT_HOLD_MS =
   POCKET_DROP_RING_HOLD_MS + POCKET_DROP_REST_HOLD_MS;
 const POCKET_VIEW_MAX_HOLD_MS = 2200;
 const POCKET_VIEW_EARLY_HOLD_MS = 320;
-const SPIN_GLOBAL_SCALE = 0.9; // increase overall spin effect by 25% versus the previous 0.72 tuning
+const SPIN_GLOBAL_SCALE = 1.035; // increase overall spin effect by 15%
 // Spin controller adapted from the open-source Billiards solver physics (MIT License).
 const SPIN_TABLE_REFERENCE_WIDTH = 2.627;
 const SPIN_TABLE_REFERENCE_HEIGHT = 1.07707;
@@ -1781,7 +1781,7 @@ const SPIN_AFTER_IMPACT_DEFLECTION_SCALE = 0; // disable preview-only spin defle
 const SHOT_POWER_REDUCTION = 0.425;
 const SHOT_POWER_MULTIPLIER = 2.109375;
 const SHOT_POWER_INCREASE = 1.5; // match Snooker Royale standard shot lift
-const SHOT_POWER_ADJUSTMENT = 0.72; // reduce overall Pool Royale power by an additional 20%
+const SHOT_POWER_ADJUSTMENT = 0.612; // reduce overall Pool Royale shot strength by an additional 15%
 const SHOT_POWER_BOOST = 1.5; // increase overall shot power by 25%
 const SHOT_FORCE_BOOST =
   1.5 *
@@ -28094,7 +28094,9 @@ const powerRef = useRef(hud.power);
           const targetId = String(plan.targetBall.id);
           const toPocketRef = plan.pocketCenter.clone().sub(plan.targetBall.pos);
           const bestRef = { dir: baseDir, score: -Infinity };
-          const scanDegrees = [-2.4, -1.6, -0.9, -0.45, 0, 0.45, 0.9, 1.6, 2.4];
+          const scanDegrees = [
+            -6, -4.5, -3.2, -2.4, -1.6, -1, -0.5, -0.25, 0, 0.25, 0.5, 1, 1.6, 2.4, 3.2, 4.5, 6
+          ];
           scanDegrees.forEach((deg) => {
             const rotated = baseDir
               .clone()
@@ -28103,15 +28105,34 @@ const powerRef = useRef(hud.power);
             rotated.normalize();
             const contact = calcTarget(cue, rotated, ballsRef.current?.length ? ballsRef.current : balls);
             if (!contact?.targetBall || String(contact.targetBall.id) !== targetId) return;
-            const toPocket = plan.pocketCenter.clone().sub(contact.targetBall.pos);
+            if (!isPathClear(contact.targetBall.pos, plan.pocketCenter, new Set([cue?.id, plan.targetBall?.id]))) {
+              return;
+            }
+            const impactPoint =
+              Number.isFinite(contact?.tHit) && contact.tHit > 0
+                ? cuePos.clone().add(rotated.clone().multiplyScalar(contact.tHit))
+                : cuePos.clone();
+            const objectDir = contact.targetBall.pos.clone().sub(impactPoint);
             const pocketAlignment =
-              toPocket.lengthSq() > 1e-6 && toPocketRef.lengthSq() > 1e-6
-                ? toPocket.clone().normalize().dot(toPocketRef.clone().normalize())
+              objectDir.lengthSq() > 1e-6 && toPocketRef.lengthSq() > 1e-6
+                ? objectDir.clone().normalize().dot(toPocketRef.clone().normalize())
                 : 0;
             const depthScore = Number.isFinite(contact?.tHit)
               ? 1 - Math.min(Math.abs(contact.tHit - cuePos.distanceTo(plan.targetBall.pos)) / (BALL_R * 14), 1)
               : 0;
-            const score = pocketAlignment * 0.78 + depthScore * 0.22;
+            const ghost =
+              pocketAlignment > -1
+                ? plan.targetBall.pos
+                    .clone()
+                    .sub(toPocketRef.clone().normalize().multiplyScalar(BALL_R * 2))
+                : null;
+            const cueLaneClear = ghost
+              ? isPathClear(cuePos, ghost, new Set([cue?.id, plan.targetBall?.id]))
+              : true;
+            const score =
+              pocketAlignment * 0.7 +
+              depthScore * 0.2 +
+              (cueLaneClear ? 0.1 : -0.25);
             if (score > bestRef.score) {
               bestRef.dir = rotated;
               bestRef.score = score;


### PR DESCRIPTION
### Motivation
- Reduce Pool Royale shot strength by 15% to soften gameplay pacing and match desired feel. 
- Increase overall cue-ball spin influence by 15% so spin effects are more noticeable. 
- Improve AI potting accuracy so AI aims to pot target balls more reliably. 

### Description
- Raised `SPIN_GLOBAL_SCALE` from `0.9` to `1.035` to increase global spin influence. 
- Lowered `SHOT_POWER_ADJUSTMENT` from `0.72` to `0.612` to reduce shot strength by ~15%. 
- Expanded the AI post-plan angular scan window in `refineAiPotAimLine` to cover a wider candidate set (now ±6°). 
- Made AI pot candidate selection more robust by rejecting object-ball→pocket routes that are blocked, computing impact-based object travel direction for pocket alignment, and adding a `cueLaneClear` term when scoring candidates (all changes in `webapp/src/pages/Games/PoolRoyale.jsx`). 

### Testing
- Ran `npm run build`, which completed successfully. 
- Ran `npx eslint` on the modified file; lint reported the file is ignored by repo lint rules so no direct lint errors were validated in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6986c18288329a68708045a7e3bc5)