### PR TITLE
Tune Pool Royale shot power, spin, and AI pot aiming

### DIFF
--- a/test/poolRoyaleAiAimCompensation.test.js
+++ b/test/poolRoyaleAiAimCompensation.test.js
@@ -16,7 +16,7 @@ describe('Pool Royale AI aim compensation', () => {
     });
     expect(result).toBeTruthy();
     expect(result.aimDir.length()).toBeCloseTo(1, 5);
-    expect(Math.hypot(result.ghost.x - targetPos.x, result.ghost.y - targetPos.y)).toBeCloseTo(0.06024, 4);
+    expect(Math.hypot(result.ghost.x - targetPos.x, result.ghost.y - targetPos.y)).toBeCloseTo(0.06, 4);
   });
 
   it('keeps pre-impact aim unchanged when only side spin changes', () => {
@@ -60,7 +60,7 @@ describe('Pool Royale AI aim compensation', () => {
       power: 1
     });
 
-    expect(neutral.contactDepth).toBeCloseTo(0.06024, 5);
+    expect(neutral.contactDepth).toBeCloseTo(0.06, 5);
     expect(topspin.contactDepth).toBeGreaterThan(neutral.contactDepth);
     expect(topspin.contactDepth - neutral.contactDepth).toBeLessThan(0.0015);
   });

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1757,7 +1757,7 @@ const POCKET_VIEW_POST_POT_HOLD_MS =
   POCKET_DROP_RING_HOLD_MS + POCKET_DROP_REST_HOLD_MS;
 const POCKET_VIEW_MAX_HOLD_MS = 2200;
 const POCKET_VIEW_EARLY_HOLD_MS = 320;
-const SPIN_GLOBAL_SCALE = 0.9; // increase overall spin effect by 25% versus the previous 0.72 tuning
+const SPIN_GLOBAL_SCALE = 1.035; // increase overall spin effect by 15%
 // Spin controller adapted from the open-source Billiards solver physics (MIT License).
 const SPIN_TABLE_REFERENCE_WIDTH = 2.627;
 const SPIN_TABLE_REFERENCE_HEIGHT = 1.07707;
@@ -1782,7 +1782,7 @@ const SHOT_POWER_REDUCTION = 0.425;
 const SHOT_POWER_MULTIPLIER = 2.109375;
 const SHOT_POWER_INCREASE = 1.5; // match Snooker Royale standard shot lift
 const SHOT_POWER_ADJUSTMENT = 0.72; // reduce overall Pool Royale power by an additional 20%
-const SHOT_POWER_BOOST = 1.5; // increase overall shot power by 25%
+const SHOT_POWER_BOOST = 1.275; // reduce overall shot power by 15%
 const SHOT_FORCE_BOOST =
   1.5 *
   0.75 *
@@ -27192,7 +27192,8 @@ const powerRef = useRef(hud.power);
               pocketPos: plan.pocketCenter,
               ballRadius: BALL_R,
               spin: plan.spin,
-              power: plan.power
+              power: plan.power,
+              contactCalibration: 0
             });
             if (compensatedAim?.aimDir && compensatedAim.aimDir.lengthSq() > 1e-6) {
               corrected = compensatedAim.aimDir.clone();
@@ -27794,7 +27795,8 @@ const powerRef = useRef(hud.power);
                 pocketPos: plan.pocketCenter,
                 ballRadius: BALL_R,
                 spin: plan.spin,
-                power: plan.power
+                power: plan.power,
+                contactCalibration: 0
               });
               if (compensatedAim?.aimDir?.lengthSq?.() > 1e-6) {
                 suggestedDir = compensatedAim.aimDir.clone();
@@ -28094,7 +28096,7 @@ const powerRef = useRef(hud.power);
           const targetId = String(plan.targetBall.id);
           const toPocketRef = plan.pocketCenter.clone().sub(plan.targetBall.pos);
           const bestRef = { dir: baseDir, score: -Infinity };
-          const scanDegrees = [-2.4, -1.6, -0.9, -0.45, 0, 0.45, 0.9, 1.6, 2.4];
+          const scanDegrees = [-4, -3, -2.2, -1.4, -0.8, -0.35, 0, 0.35, 0.8, 1.4, 2.2, 3, 4];
           scanDegrees.forEach((deg) => {
             const rotated = baseDir
               .clone()

--- a/webapp/src/pages/Games/poolRoyaleAiAimCompensation.js
+++ b/webapp/src/pages/Games/poolRoyaleAiAimCompensation.js
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 
 const MIN_VECTOR_EPS = 1e-6;
-const DEFAULT_CONTACT_CALIBRATION = 0.004;
+const DEFAULT_CONTACT_CALIBRATION = 0;
 
 export const resolveAiPotGhostAim = ({
   cuePos,


### PR DESCRIPTION
### Motivation
- Reduce shot strength so Pool Royale strokes feel ~15% softer and match mobile pacing.  
- Increase spin effectiveness globally so spin play is more responsive by ~15%.  
- Make AI pot aiming more reliable so AI aims to pot targets (clean geometric ghost-ball compensation and a wider micro-scan).

### Description
- Lowered the final shot boost by changing `SHOT_POWER_BOOST` from `1.5` to `1.275` to reduce overall shot force by ~15% (`PoolRoyale.jsx`).
- Raised `SPIN_GLOBAL_SCALE` from `0.9` to `1.035` to increase the effective spin strength by ~15% (`PoolRoyale.jsx`).
- Set the default contact calibration to zero by changing `DEFAULT_CONTACT_CALIBRATION` to `0` in `poolRoyaleAiAimCompensation.js` and passed `contactCalibration: 0` to AI aim compensation calls to force pure geometric ghost-ball aiming (`PoolRoyale.jsx`).
- Widened the AI micro-scan angle window around the ghost aim line (expanded `scanDegrees`) so the AI can find slightly offset potting lines more robustly (`PoolRoyale.jsx`).
- Updated unit expectations in `test/poolRoyaleAiAimCompensation.test.js` to match the zero-calibration baseline.

### Testing
- Ran targeted Jest suites: `test/poolRoyaleAiAimCompensation.test.js` and `test/poolRoyaleSpinController.test.js`, and both suites passed.  
- All changes were validated locally against the modified unit tests (`jest --runInBand`), showing green for the two test files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6986c18288329a68708045a7e3bc5)