### PR TITLE
Restore Pool Royale AI logic and practice mode behavior

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1757,7 +1757,7 @@ const POCKET_VIEW_POST_POT_HOLD_MS =
   POCKET_DROP_RING_HOLD_MS + POCKET_DROP_REST_HOLD_MS;
 const POCKET_VIEW_MAX_HOLD_MS = 2200;
 const POCKET_VIEW_EARLY_HOLD_MS = 320;
-const SPIN_GLOBAL_SCALE = 1.035; // increase overall spin effect by 15%
+const SPIN_GLOBAL_SCALE = 0.9; // increase overall spin effect by 25% versus the previous 0.72 tuning
 // Spin controller adapted from the open-source Billiards solver physics (MIT License).
 const SPIN_TABLE_REFERENCE_WIDTH = 2.627;
 const SPIN_TABLE_REFERENCE_HEIGHT = 1.07707;
@@ -1782,7 +1782,7 @@ const SHOT_POWER_REDUCTION = 0.425;
 const SHOT_POWER_MULTIPLIER = 2.109375;
 const SHOT_POWER_INCREASE = 1.5; // match Snooker Royale standard shot lift
 const SHOT_POWER_ADJUSTMENT = 0.72; // reduce overall Pool Royale power by an additional 20%
-const SHOT_POWER_BOOST = 1.275; // reduce overall shot power by 15%
+const SHOT_POWER_BOOST = 1.5; // increase overall shot power by 25%
 const SHOT_FORCE_BOOST =
   1.5 *
   0.75 *
@@ -27193,7 +27193,7 @@ const powerRef = useRef(hud.power);
               ballRadius: BALL_R,
               spin: plan.spin,
               power: plan.power,
-              contactCalibration: 0
+              contactCalibration: 0.004
             });
             if (compensatedAim?.aimDir && compensatedAim.aimDir.lengthSq() > 1e-6) {
               corrected = compensatedAim.aimDir.clone();
@@ -27796,7 +27796,7 @@ const powerRef = useRef(hud.power);
                 ballRadius: BALL_R,
                 spin: plan.spin,
                 power: plan.power,
-                contactCalibration: 0
+                contactCalibration: 0.004
               });
               if (compensatedAim?.aimDir?.lengthSq?.() > 1e-6) {
                 suggestedDir = compensatedAim.aimDir.clone();
@@ -28096,7 +28096,7 @@ const powerRef = useRef(hud.power);
           const targetId = String(plan.targetBall.id);
           const toPocketRef = plan.pocketCenter.clone().sub(plan.targetBall.pos);
           const bestRef = { dir: baseDir, score: -Infinity };
-          const scanDegrees = [-4, -3, -2.2, -1.4, -0.8, -0.35, 0, 0.35, 0.8, 1.4, 2.2, 3, 4];
+          const scanDegrees = [-2.4, -1.6, -0.9, -0.45, 0, 0.45, 0.9, 1.6, 2.4];
           scanDegrees.forEach((deg) => {
             const rotated = baseDir
               .clone()
@@ -32544,16 +32544,6 @@ const powerRef = useRef(hud.power);
                 </svg>
               </button>
             </div>
-            {isFreePractice && (
-              <button
-                type="button"
-                onClick={handlePracticeRestart}
-                className="mt-3 flex w-full items-center justify-between rounded-full border border-emerald-300/55 bg-emerald-400/15 px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.24em] text-emerald-100 transition hover:bg-emerald-300/25 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300"
-              >
-                <span>Restart practice</span>
-                <span aria-hidden="true">↻</span>
-              </button>
-            )}
             <div className="mt-4 max-h-72 space-y-4 overflow-y-auto pr-1">
               <div>
                 <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
@@ -33612,14 +33602,26 @@ const powerRef = useRef(hud.power);
           >
             <span aria-hidden="true">☰</span>
           </button>
-          <button
-            type="button"
-            onClick={() => setShowChat(true)}
-            className="pointer-events-auto flex h-[3.15rem] w-[3.15rem] items-center justify-center rounded-[14px] border-none bg-transparent p-0 text-[1.5rem] text-white shadow-none"
-            aria-label="Open chat"
-          >
-            <span aria-hidden="true">💬</span>
-          </button>
+          {isFreePractice ? (
+            <button
+              type="button"
+              onClick={handlePracticeRestart}
+              className="pointer-events-auto flex h-[3.15rem] w-[3.15rem] items-center justify-center rounded-[14px] border-none bg-transparent p-0 text-[1.5rem] text-white shadow-none"
+              aria-label="Restart practice"
+              title="Restart practice"
+            >
+              <span aria-hidden="true">↻</span>
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setShowChat(true)}
+              className="pointer-events-auto flex h-[3.15rem] w-[3.15rem] items-center justify-center rounded-[14px] border-none bg-transparent p-0 text-[1.5rem] text-white shadow-none"
+              aria-label="Open chat"
+            >
+              <span aria-hidden="true">💬</span>
+            </button>
+          )}
         </div>
       )}
 

--- a/webapp/src/pages/Games/poolRoyaleAiAimCompensation.js
+++ b/webapp/src/pages/Games/poolRoyaleAiAimCompensation.js
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 
 const MIN_VECTOR_EPS = 1e-6;
-const DEFAULT_CONTACT_CALIBRATION = 0;
+const DEFAULT_CONTACT_CALIBRATION = 0.004;
 
 export const resolveAiPotGhostAim = ({
   cuePos,


### PR DESCRIPTION
### Motivation
- Revert recent tuning that changed AI potting calibration, shot/spin scaling, and practice HUD placement so AI behavior and the free-practice UX match the prior baseline from 10 days ago.

### Description
- Restored AI/physics tuning constants and aiming scan angles in `webapp/src/pages/Games/PoolRoyale.jsx` (reset `SPIN_GLOBAL_SCALE`, `SHOT_POWER_BOOST`, and narrowed `scanDegrees` used for pot-line scanning). 
- Reinstated the AI ghost-aim contact calibration default (`DEFAULT_CONTACT_CALIBRATION = 0.004`) in `webapp/src/pages/Games/poolRoyaleAiAimCompensation.js` and passed that calibration value at AI call sites.
- Restored the free-practice HUD behavior in `PoolRoyale.jsx` so the top action slot shows a Restart button during practice and Chat otherwise, returning the UX to its previous layout.
- Changes were limited to the two files above and do not touch other game modes or unrelated systems.

### Testing
- Ran `git status --short` to confirm only the intended files were modified and the command succeeded. 
- Ran `git diff --check` to ensure there are no whitespace/patch issues and it succeeded. 
- Verified the working tree diff and committed the changes as `3673b05` to confirm the modifications are limited to the targeted files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6bd7a06148329be9b34c385a96a7a)