### PR TITLE
Restore Pool Royale AI logic and practice-mode baseline

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1757,7 +1757,7 @@ const POCKET_VIEW_POST_POT_HOLD_MS =
   POCKET_DROP_RING_HOLD_MS + POCKET_DROP_REST_HOLD_MS;
 const POCKET_VIEW_MAX_HOLD_MS = 2200;
 const POCKET_VIEW_EARLY_HOLD_MS = 320;
-const SPIN_GLOBAL_SCALE = 1.035; // increase overall spin effect by 15%
+const SPIN_GLOBAL_SCALE = 0.9; // increase overall spin effect by 25% versus the previous 0.72 tuning
 // Spin controller adapted from the open-source Billiards solver physics (MIT License).
 const SPIN_TABLE_REFERENCE_WIDTH = 2.627;
 const SPIN_TABLE_REFERENCE_HEIGHT = 1.07707;
@@ -1782,7 +1782,7 @@ const SHOT_POWER_REDUCTION = 0.425;
 const SHOT_POWER_MULTIPLIER = 2.109375;
 const SHOT_POWER_INCREASE = 1.5; // match Snooker Royale standard shot lift
 const SHOT_POWER_ADJUSTMENT = 0.72; // reduce overall Pool Royale power by an additional 20%
-const SHOT_POWER_BOOST = 1.275; // reduce overall shot power by 15%
+const SHOT_POWER_BOOST = 1.5; // increase overall shot power by 25%
 const SHOT_FORCE_BOOST =
   1.5 *
   0.75 *
@@ -27192,8 +27192,7 @@ const powerRef = useRef(hud.power);
               pocketPos: plan.pocketCenter,
               ballRadius: BALL_R,
               spin: plan.spin,
-              power: plan.power,
-              contactCalibration: 0
+              power: plan.power
             });
             if (compensatedAim?.aimDir && compensatedAim.aimDir.lengthSq() > 1e-6) {
               corrected = compensatedAim.aimDir.clone();
@@ -27795,8 +27794,7 @@ const powerRef = useRef(hud.power);
                 pocketPos: plan.pocketCenter,
                 ballRadius: BALL_R,
                 spin: plan.spin,
-                power: plan.power,
-                contactCalibration: 0
+                power: plan.power
               });
               if (compensatedAim?.aimDir?.lengthSq?.() > 1e-6) {
                 suggestedDir = compensatedAim.aimDir.clone();
@@ -28096,7 +28094,7 @@ const powerRef = useRef(hud.power);
           const targetId = String(plan.targetBall.id);
           const toPocketRef = plan.pocketCenter.clone().sub(plan.targetBall.pos);
           const bestRef = { dir: baseDir, score: -Infinity };
-          const scanDegrees = [-4, -3, -2.2, -1.4, -0.8, -0.35, 0, 0.35, 0.8, 1.4, 2.2, 3, 4];
+          const scanDegrees = [-2.4, -1.6, -0.9, -0.45, 0, 0.45, 0.9, 1.6, 2.4];
           scanDegrees.forEach((deg) => {
             const rotated = baseDir
               .clone()
@@ -32544,16 +32542,6 @@ const powerRef = useRef(hud.power);
                 </svg>
               </button>
             </div>
-            {isFreePractice && (
-              <button
-                type="button"
-                onClick={handlePracticeRestart}
-                className="mt-3 flex w-full items-center justify-between rounded-full border border-emerald-300/55 bg-emerald-400/15 px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.24em] text-emerald-100 transition hover:bg-emerald-300/25 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300"
-              >
-                <span>Restart practice</span>
-                <span aria-hidden="true">↻</span>
-              </button>
-            )}
             <div className="mt-4 max-h-72 space-y-4 overflow-y-auto pr-1">
               <div>
                 <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
@@ -33612,14 +33600,26 @@ const powerRef = useRef(hud.power);
           >
             <span aria-hidden="true">☰</span>
           </button>
-          <button
-            type="button"
-            onClick={() => setShowChat(true)}
-            className="pointer-events-auto flex h-[3.15rem] w-[3.15rem] items-center justify-center rounded-[14px] border-none bg-transparent p-0 text-[1.5rem] text-white shadow-none"
-            aria-label="Open chat"
-          >
-            <span aria-hidden="true">💬</span>
-          </button>
+          {isFreePractice ? (
+            <button
+              type="button"
+              onClick={handlePracticeRestart}
+              className="pointer-events-auto flex h-[3.15rem] w-[3.15rem] items-center justify-center rounded-[14px] border-none bg-transparent p-0 text-[1.5rem] text-white shadow-none"
+              aria-label="Restart practice"
+              title="Restart practice"
+            >
+              <span aria-hidden="true">↻</span>
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setShowChat(true)}
+              className="pointer-events-auto flex h-[3.15rem] w-[3.15rem] items-center justify-center rounded-[14px] border-none bg-transparent p-0 text-[1.5rem] text-white shadow-none"
+              aria-label="Open chat"
+            >
+              <span aria-hidden="true">💬</span>
+            </button>
+          )}
         </div>
       )}
 

--- a/webapp/src/pages/Games/poolRoyaleAiAimCompensation.js
+++ b/webapp/src/pages/Games/poolRoyaleAiAimCompensation.js
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 
 const MIN_VECTOR_EPS = 1e-6;
-const DEFAULT_CONTACT_CALIBRATION = 0;
+const DEFAULT_CONTACT_CALIBRATION = 0.004;
 
 export const resolveAiPotGhostAim = ({
   cuePos,


### PR DESCRIPTION
### Motivation
- Revert recent tuning that changed AI shot selection, spin/power scaling, and practice-mode placement so AI behaviour and the practice UX match the previous stable baseline from ~10 days ago.

### Description
- Restore AI spin/power constants by setting `SPIN_GLOBAL_SCALE` back to `0.9` and `SHOT_POWER_BOOST` back to `1.5` in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Revert the AI pot-angle search to the previous narrower `scanDegrees` array and remove the per-call `contactCalibration: 0` overrides so the AI uses the module default behaviour.
- Restore the default contact calibration in `webapp/src/pages/Games/poolRoyaleAiAimCompensation.js` by setting `DEFAULT_CONTACT_CALIBRATION` to `0.004`.
- Restore the practice-mode restart UX by removing the restart button from the setup panel and reinstating the dedicated portrait top-bar restart button.
- Changes applied to `webapp/src/pages/Games/PoolRoyale.jsx` and `webapp/src/pages/Games/poolRoyaleAiAimCompensation.js` and committed as `9194723` on branch `work`.

### Testing
- Built the web app with Vite using `cd webapp && npm run build` and the build completed successfully (with non-blocking chunk-size warnings).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6bd7a06148329be9b34c385a96a7a)