### PR TITLE
Pool Royale: only consume hearts for explicit career training tasks

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -12919,7 +12919,8 @@ function PoolRoyaleGame({
     tableFinishId
   ]);
   const isTraining = playType === 'training';
-  const usesCareerAttempts = isTraining && careerMode;
+  const hasCareerTaskId = Boolean(careerStageId);
+  const usesCareerAttempts = isTraining && careerMode && hasCareerTaskId;
   const isFreePractice = isTraining && !usesCareerAttempts;
   const [trainingAttemptsStoreOpen, setTrainingAttemptsStoreOpen] = useState(false);
   const [selectedTrainingBundleId, setSelectedTrainingBundleId] = useState(TRAINING_ATTEMPT_BUNDLES[0]?.id || '');
@@ -12955,7 +12956,7 @@ function PoolRoyaleGame({
     bonusAwardedStageIds: []
   });
   const [trainingLevel, setTrainingLevel] = useState(() => {
-    if (isTraining && !careerMode) {
+    if (isTraining && !usesCareerAttempts) {
       return PRACTICE_FREEPLAY_LEVEL;
     }
     const requested = Number(initialTrainingLevel);
@@ -13075,11 +13076,11 @@ function PoolRoyaleGame({
   useEffect(() => {
     if (!isTraining) return;
     if (trainingModeState !== 'solo') setTrainingModeState('solo');
-    const shouldEnableRules = careerMode;
+    const shouldEnableRules = usesCareerAttempts;
     if (trainingRulesOn !== shouldEnableRules) {
       setTrainingRulesOn(shouldEnableRules);
     }
-  }, [careerMode, isTraining, trainingModeState, trainingRulesOn]);
+  }, [isTraining, trainingModeState, trainingRulesOn, usesCareerAttempts]);
   const currentTrainingInfo = useMemo(
     () => describeTrainingLevel(trainingLevel),
     [trainingLevel]


### PR DESCRIPTION
### Motivation
- Prevent Practice mode from spending hearts when `career=1` is present in the URL accidentally and ensure hearts are used only for explicit career tasks. 
- Keep free practice behavior (freeplay level selection and rule toggles) active unless a real career stage is started.

### Description
- Add a `hasCareerTaskId` check and require it together with `playType === 'training'` and `careerMode` to set `usesCareerAttempts`, so hearts are gated to actual career tasks only. 
- Treat training sessions that do not use career attempts as free practice by selecting `PRACTICE_FREEPLAY_LEVEL` when appropriate. 
- Sync the training rules toggle to `usesCareerAttempts` and update effect dependencies to avoid applying career constraints in free practice. 
- Modified file: `webapp/src/pages/Games/PoolRoyale.jsx`.

### Testing
- Ran a production build with `cd webapp && npm run build`, which completed successfully (Vite reported only existing chunk-size/dynamic-import warnings).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6dac8b1048329a3333fcb844e5f38)