### PR TITLE
Increase Domino Royal tile texture resolution to 4K

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -6474,13 +6474,7 @@ const getDominoSurfaceTextures = (() => {
     cache = null;
   };
   return () => {
-    const targetSize = Math.max(
-      2048,
-      Math.min(
-        4096,
-        getAdaptiveDominoTextureSize(MURLAN_3D_ASSET_RESOLUTION.dominoTextureSize)
-      )
-    );
+    const targetSize = 4096;
     if (cache && cachedSize === targetSize) return cache;
     disposeCachedTextures();
     if (typeof document === 'undefined') {
@@ -6489,10 +6483,7 @@ const getDominoSurfaceTextures = (() => {
     }
     const sizeCap = getRendererTextureSizeCap();
     const preferredSize = Math.max(2048, Math.min(sizeCap, targetSize));
-    const lowMemoryDevice =
-      isLowProfileDevice ||
-      (typeof navigator !== 'undefined' && typeof navigator.deviceMemory === 'number' && navigator.deviceMemory <= 4);
-    let size = lowMemoryDevice ? Math.max(2048, Math.min(preferredSize, 3072)) : preferredSize;
+    let size = preferredSize;
     let porcelainCanvas = document.createElement('canvas');
     porcelainCanvas.width = porcelainCanvas.height = size;
     let pctx = porcelainCanvas.getContext('2d', { willReadFrequently: true });


### PR DESCRIPTION
### Motivation
- Raise Domino Battle Royal tile surface texture fidelity so domino materials match the 4K dice quality used in Ludo Battle Royal for visual parity and higher-detail rendering.

### Description
- Force the domino texture generation target to `4096` by setting `targetSize = 4096` inside `getDominoSurfaceTextures` in `webapp/public/domino-royal-game.js`.
- Remove the low-memory downscale branch that previously forced a `3072` cap, and instead use the computed `preferredSize` (still clamped by renderer/GPU caps via `getRendererTextureSizeCap`).
- Change is limited to the domino surface texture generation path and preserves renderer/device caps logic elsewhere.

### Testing
- Ran `npm run test -- test/inventoryCrossGameConfig.test.js --runInBand` and the test suite passed (5 tests, all passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c79dffa4e08329b99473c2cb427ed6)