### PR TITLE
Domino Royal: target 4K domino textures for all quality tiers

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -99,7 +99,7 @@ const FRAME_RATE_TEXTURE_SIZE_MAP = Object.freeze({
 });
 
 const DOMINO_TEXTURE_SIZE_MAP = Object.freeze({
-  hd50: 3072,
+  hd50: 4096,
   fhd60: 4096,
   qhd90: 4096,
   uhd120: 4096,
@@ -6492,7 +6492,9 @@ const getDominoSurfaceTextures = (() => {
     const lowMemoryDevice =
       isLowProfileDevice ||
       (typeof navigator !== 'undefined' && typeof navigator.deviceMemory === 'number' && navigator.deviceMemory <= 4);
-    let size = lowMemoryDevice ? Math.max(2048, Math.min(preferredSize, 3072)) : preferredSize;
+    let size = lowMemoryDevice
+      ? Math.max(2048, Math.min(preferredSize, 4096))
+      : preferredSize;
     let porcelainCanvas = document.createElement('canvas');
     porcelainCanvas.width = porcelainCanvas.height = size;
     let pctx = porcelainCanvas.getContext('2d', { willReadFrequently: true });


### PR DESCRIPTION
### Motivation
- Align Domino Royal domino tile surface fidelity with the high-resolution dice used by Ludo Battle Royal so tiles can render at 4K even on the lower quality profile.

### Description
- Updated `webapp/public/domino-royal-game.js` to set `DOMINO_TEXTURE_SIZE_MAP.hd50` to `4096` and raised the low-memory canvas cap in `getDominoSurfaceTextures` from `3072` to allow up to `4096` so generated domino canvases can reach 4K where renderer/device limits permit.

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` and the file passed syntax checking successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c79dffa4e08329b99473c2cb427ed6)