### PR TITLE
Snake & Ladder: lock camera, rotate board for token movement, and token-colored tile highlights

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import * as THREE from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
@@ -170,6 +170,9 @@ const TURN_CAMERA_TURN_IN_DURATION = 620;
 const DICE_CAMERA_LOOK_IN_DURATION = 360;
 const DICE_CAMERA_LOOK_HOLD_DURATION = 900;
 const DICE_CAMERA_LOOK_OUT_DURATION = 420;
+const BOARD_ROTATE_TO_TOKEN_DURATION = 460;
+const BOARD_ROTATE_RESTORE_DURATION = 520;
+const BOARD_ROTATE_MIN_MOVEMENT_MS = 900;
 
 const BOARD_TILE_HEIGHT = TILE_SIZE * 0.14 * PYRAMID_HEIGHT_MULTIPLIER;
 const TILE_SIDE_COLOR = new THREE.Color(0x8b5e34);
@@ -1518,6 +1521,41 @@ function createCameraTransitionAnimation(
       return true;
     }
   };
+}
+
+function normalizeAngle(angle) {
+  let next = angle;
+  while (next > Math.PI) next -= Math.PI * 2;
+  while (next < -Math.PI) next += Math.PI * 2;
+  return next;
+}
+
+function createBoardRotationAnimation(rotationRoot, toRotationY, duration = 460, type = 'boardRotate') {
+  if (!rotationRoot || !Number.isFinite(toRotationY)) return null;
+  const fromRotation = rotationRoot.rotation.y;
+  const delta = normalizeAngle(toRotationY - fromRotation);
+  const start = performance.now();
+  const target = fromRotation + delta;
+  return {
+    type,
+    update: (now) => {
+      const elapsed = now - start;
+      const t = duration > 0 ? Math.min(Math.max(elapsed / duration, 0), 1) : 1;
+      const eased = easeInOut(t);
+      rotationRoot.rotation.y = fromRotation + delta * eased;
+      if (t >= 1) {
+        rotationRoot.rotation.y = target;
+        return true;
+      }
+      return false;
+    }
+  };
+}
+
+function computeBoardFacingRotationY(position) {
+  if (!position) return 0;
+  const angle = Math.atan2(position.x, position.z);
+  return -angle;
 }
 
 function computeTokenFollowCameraState(board, camera, fromIndex, toIndex) {
@@ -3138,14 +3176,14 @@ function updateTilesHighlight(tileMeshes, highlight, trail, highlightColors = DE
     trail.forEach((segment) => {
       const tile = tileMeshes.get(segment.cell);
       if (!tile) return;
-      const color = colors[segment.type] ?? colors.normal;
+      const color = segment?.color ?? colors[segment.type] ?? colors.normal;
       applyTileHighlight(tile, color, 0.35);
     });
   }
   if (highlight) {
     const tile = tileMeshes.get(highlight.cell);
     if (tile) {
-      const color = colors[highlight.type] ?? colors.normal;
+      const color = highlight?.color ?? colors[highlight.type] ?? colors.normal;
       applyTileHighlight(tile, color);
     }
   }
@@ -3835,6 +3873,8 @@ export default function SnakeBoard3D({
   const cameraRestoreRef = useRef(null);
   const turnCameraStateRef = useRef(null);
   const cinematicRestoreRef = useRef(null);
+  const boardRotationRestoreRef = useRef(0);
+  const boardMovementTimerRef = useRef(null);
   const previousTurnRef = useRef(null);
   const lastFrameTimeRef = useRef(0);
   const frameRateRef = useRef(Math.max(30, frameRate || 90));
@@ -3864,6 +3904,51 @@ export default function SnakeBoard3D({
     lastFrameTimeRef.current = 0;
   }, [frameRate]);
 
+  const resetCameraToStart = useCallback(() => {
+    const board = boardRef.current;
+    const camera = cameraRef.current;
+    const controls = board?.controls;
+    const startCameraState = board?.startCameraState;
+    if (!board || !camera || !controls || !startCameraState) return;
+    camera.position.copy(startCameraState.position);
+    controls.target.copy(startCameraState.target);
+    controls.update();
+  }, []);
+
+  const rotateBoardTowardTile = useCallback((tileIndex) => {
+    const board = boardRef.current;
+    if (!board?.rotationRoot) return;
+    const toPosition = board.indexToPosition.get(tileIndex) || board.serpentineIndexToXZ(tileIndex);
+    if (!toPosition) return;
+    removeAnimationsByType(animationsRef.current, 'boardRotateToToken');
+    const nextRotation = computeBoardFacingRotationY(toPosition);
+    const animation = createBoardRotationAnimation(
+      board.rotationRoot,
+      nextRotation,
+      BOARD_ROTATE_TO_TOKEN_DURATION,
+      'boardRotateToToken'
+    );
+    if (animation) animationsRef.current.push(animation);
+    if (boardMovementTimerRef.current) {
+      clearTimeout(boardMovementTimerRef.current);
+      boardMovementTimerRef.current = null;
+    }
+    boardMovementTimerRef.current = setTimeout(() => {
+      const currentBoard = boardRef.current;
+      if (!currentBoard?.rotationRoot) return;
+      removeAnimationsByType(animationsRef.current, 'boardRotateToToken');
+      removeAnimationsByType(animationsRef.current, 'boardRotateRestore');
+      const restoreAnimation = createBoardRotationAnimation(
+        currentBoard.rotationRoot,
+        boardRotationRestoreRef.current ?? 0,
+        BOARD_ROTATE_RESTORE_DURATION,
+        'boardRotateRestore'
+      );
+      if (restoreAnimation) animationsRef.current.push(restoreAnimation);
+      boardMovementTimerRef.current = null;
+    }, BOARD_ROTATE_MIN_MOVEMENT_MS);
+  }, []);
+
   useEffect(() => {
     const board = boardRef.current;
     const camera = cameraRef.current;
@@ -3872,28 +3957,16 @@ export default function SnakeBoard3D({
     if (!Number.isInteger(currentTurn) || currentTurn < 0) return;
     if (previousTurnRef.current === currentTurn) return;
     previousTurnRef.current = currentTurn;
-
-    const focusState = computeTurnCameraFocusState(board, camera, currentTurn, players);
-    if (!focusState) return;
-    turnCameraStateRef.current = {
-      position: focusState.position.clone(),
-      target: focusState.target.clone()
-    };
-
     removeAnimationsByType(animationsRef.current, 'cameraTurnFocus');
     removeAnimationsByType(animationsRef.current, 'cameraDiceZoom');
-    const turnAnimation = createCameraTransitionAnimation(camera, controls, {
-      toPosition: focusState.position,
-      toTarget: focusState.target,
-      durationIn: TURN_CAMERA_TURN_IN_DURATION,
-      hold: 0,
-      durationOut: 0,
-      type: 'cameraTurnFocus',
-      returnPosition: focusState.position,
-      returnTarget: focusState.target
-    });
-    if (turnAnimation) animationsRef.current.push(turnAnimation);
-  }, [currentTurn, cameraViewMode]);
+    turnCameraStateRef.current = board?.startCameraState
+      ? {
+          position: board.startCameraState.position.clone(),
+          target: board.startCameraState.target.clone()
+        }
+      : null;
+    resetCameraToStart();
+  }, [currentTurn, cameraViewMode, resetCameraToStart]);
 
   useEffect(() => {
     const board = boardRef.current;
@@ -4047,6 +4120,16 @@ export default function SnakeBoard3D({
       seatAnchors: arena.seatAnchors ?? [],
       startCameraState: arena.startCameraState ?? null
     };
+    if (board.rotationRoot) {
+      boardRotationRestoreRef.current = board.rotationRoot.rotation.y;
+    }
+    if (arena.controls && arena.startCameraState?.position && arena.startCameraState?.target) {
+      const startOffset = arena.startCameraState.position.clone().sub(arena.startCameraState.target);
+      const startSpherical = new THREE.Spherical().setFromVector3(startOffset);
+      const lockedPolar = clamp(startSpherical.phi, CAM.phiMin, CAM.phiMax);
+      arena.controls.minPolarAngle = lockedPolar;
+      arena.controls.maxPolarAngle = lockedPolar;
+    }
 
     const boardRotationRoot = board.rotationRoot || board.root;
     const dragState = {
@@ -4172,6 +4255,11 @@ export default function SnakeBoard3D({
       arena.controls?.update?.();
       const camera = cameraRef.current;
       if (camera) {
+        const startCameraY = board?.startCameraState?.position?.y;
+        if (Number.isFinite(startCameraY) && camera.position.y < startCameraY) {
+          camera.position.y = startCameraY;
+          arena.controls?.update?.();
+        }
         if (arena.updateHdriZoom) {
           const target = board?.boardLookTarget ?? arena.boardLookTarget;
           arena.updateHdriZoom(camera, target);
@@ -4249,6 +4337,10 @@ export default function SnakeBoard3D({
       lastDiceAnchorRef.current = null;
       diceAnchorCallbackRef.current?.(null);
       boardRef.current = null;
+      if (boardMovementTimerRef.current) {
+        clearTimeout(boardMovementTimerRef.current);
+        boardMovementTimerRef.current = null;
+      }
       if (renderer.domElement.parentElement === mount) {
         mount.removeChild(renderer.domElement);
       }
@@ -4324,25 +4416,10 @@ export default function SnakeBoard3D({
     prevPlayerPositionsRef.current = sanitizedPositions;
 
     if (cameraViewMode !== '2d' && movement && shouldFollowTileChange(movement.from, movement.to)) {
-      const camera = cameraRef.current;
-      const controls = board.controls;
-      const followState = computeTokenFollowCameraState(board, camera, movement.from, movement.to);
-      if (camera && controls && followState) {
-        removeAnimationsByType(animationsRef.current, 'cameraDiceZoom');
-        removeAnimationsByType(animationsRef.current, 'cameraTokenFollow');
-        const restoreState =
-          turnCameraStateRef.current ||
-          cinematicRestoreRef.current ||
-          captureCameraState(camera, controls);
-        cinematicRestoreRef.current = restoreState;
-        const followAnimation = createTokenCameraFollowAnimation(
-          camera,
-          controls,
-          followState,
-          restoreState
-        );
-        if (followAnimation) animationsRef.current.push(followAnimation);
-      }
+      removeAnimationsByType(animationsRef.current, 'cameraDiceZoom');
+      removeAnimationsByType(animationsRef.current, 'cameraTokenFollow');
+      resetCameraToStart();
+      rotateBoardTowardTile(movement.to);
     }
   }, [
     players,
@@ -4354,7 +4431,9 @@ export default function SnakeBoard3D({
     tokenTheme,
     tokenShape,
     tokenPrototypeVersion,
-    cameraViewMode
+    cameraViewMode,
+    resetCameraToStart,
+    rotateBoardTowardTile
   ]);
 
   useEffect(() => {
@@ -4409,24 +4488,11 @@ export default function SnakeBoard3D({
     const duration = 1100;
     const startTime = performance.now();
     const lift = TOKEN_HEIGHT * 0.6;
-    const camera = cameraRef.current;
-    const controls = board.controls;
-    const followState = computeTokenFollowCameraState(board, camera, slide.from, slide.to);
-    if (cameraViewMode !== '2d' && camera && controls && followState && shouldFollowTileChange(slide.from, slide.to)) {
+    if (cameraViewMode !== '2d' && shouldFollowTileChange(slide.from, slide.to)) {
       removeAnimationsByType(animationsRef.current, 'cameraDiceZoom');
       removeAnimationsByType(animationsRef.current, 'cameraTokenFollow');
-      const restoreState =
-        turnCameraStateRef.current ||
-        cinematicRestoreRef.current ||
-        captureCameraState(camera, controls);
-      cinematicRestoreRef.current = restoreState;
-      const followAnimation = createTokenCameraFollowAnimation(
-        camera,
-        controls,
-        followState,
-        restoreState
-      );
-      if (followAnimation) animationsRef.current.push(followAnimation);
+      resetCameraToStart();
+      rotateBoardTowardTile(slide.to);
     }
     animationsRef.current.push({
       update: (now) => {
@@ -4454,7 +4520,7 @@ export default function SnakeBoard3D({
         return false;
       }
     });
-  }, [slide, onSlideComplete, cameraViewMode]);
+  }, [slide, onSlideComplete, cameraViewMode, resetCameraToStart, rotateBoardTowardTile]);
 
   useEffect(() => {
     if (!diceEvent || !boardRef.current) return;
@@ -4522,24 +4588,7 @@ export default function SnakeBoard3D({
       };
       const active = diceSet.filter((_, idx) => idx < count);
       if (active.length) {
-        const camera = cameraRef.current;
-        const controls = board.controls;
-        const diceCameraState = computeDiceCameraFocusState(board, camera);
-        if (camera && controls && diceCameraState && cameraViewMode !== '2d') {
-          removeAnimationsByType(animationsRef.current, 'cameraTurnFocus');
-          const restoreState = turnCameraStateRef.current || captureCameraState(camera, controls);
-          const diceCameraAnimation = createCameraTransitionAnimation(camera, controls, {
-            toPosition: camera.position.clone(),
-            toTarget: diceCameraState.target,
-            durationIn: DICE_CAMERA_LOOK_IN_DURATION,
-            hold: DICE_CAMERA_LOOK_HOLD_DURATION,
-            durationOut: DICE_CAMERA_LOOK_OUT_DURATION,
-            type: 'cameraDiceZoom',
-            returnPosition: restoreState?.position,
-            returnTarget: restoreState?.target
-          });
-          if (diceCameraAnimation) animationsRef.current.push(diceCameraAnimation);
-        }
+        if (cameraViewMode !== '2d') resetCameraToStart();
 
         const rollAnimation = createDiceRollAnimation(active, {
           basePositions,
@@ -4588,7 +4637,7 @@ export default function SnakeBoard3D({
         lastSeatIndex
       };
     }
-  }, [diceEvent, cameraViewMode]);
+  }, [diceEvent, cameraViewMode, resetCameraToStart]);
 
   useEffect(() => {
     const handle = () => fitRef.current();

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -2091,7 +2091,9 @@ export default function SnakeAndLadder() {
       };
       const finalizeMove = (finalPos, type) => {
         updatePosition(finalPos);
-        setHighlight({ cell: finalPos, type });
+        const playerIndex = playersRef.current.findIndex((pl) => pl.id === playerId);
+        const tokenColor = playerColors[playerIndex >= 0 ? playerIndex : 0] || '#f97316';
+        setHighlight({ cell: finalPos, type, color: tokenColor });
         setTrail([]);
         setTimeout(() => setHighlight(null), 2300);
         setMoving(false);
@@ -2124,7 +2126,9 @@ export default function SnakeAndLadder() {
       };
       const finalizeMove = (finalPos, type) => {
         updatePosition(finalPos);
-        setHighlight({ cell: finalPos, type });
+        const playerIndex = playersRef.current.findIndex((pl) => pl.id === playerId);
+        const tokenColor = playerColors[playerIndex >= 0 ? playerIndex : 0] || '#f97316';
+        setHighlight({ cell: finalPos, type, color: tokenColor });
         setTrail([]);
         setTimeout(() => setHighlight(null), 2300);
         setMoving(false);
@@ -2586,11 +2590,9 @@ export default function SnakeAndLadder() {
           setTurnMessage("");
           setDiceVisible(false);
           const next = getPreviousTurn(currentTurn);
-          setTimeout(() => {
-            setCurrentTurn(next);
-            setDiceCount(playerDiceCounts[next] ?? 2);
-          }, 2000);
-          setTimeout(() => setMoving(false), 2000);
+          setCurrentTurn(next);
+          setDiceCount(playerDiceCounts[next] ?? 2);
+          setMoving(false);
           return;
         }
       } else if (current === 0) {
@@ -2604,11 +2606,9 @@ export default function SnakeAndLadder() {
           setTurnMessage("");
           setDiceVisible(false);
           const next = getPreviousTurn(currentTurn);
-          setTimeout(() => {
-            setCurrentTurn(next);
-            setDiceCount(playerDiceCounts[next] ?? 2);
-          }, 2000);
-          setTimeout(() => setMoving(false), 2000);
+          setCurrentTurn(next);
+          setDiceCount(playerDiceCounts[next] ?? 2);
+          setMoving(false);
           return;
         }
       } else if (current + value <= FINAL_TILE) {
@@ -2620,11 +2620,9 @@ export default function SnakeAndLadder() {
         setTurnMessage("");
         setDiceVisible(false);
         const next = getPreviousTurn(currentTurn);
-        setTimeout(() => {
-          setCurrentTurn(next);
-          setDiceCount(playerDiceCounts[next] ?? 2);
-        }, 2000);
-        setTimeout(() => setMoving(false), 2000);
+        setCurrentTurn(next);
+        setDiceCount(playerDiceCounts[next] ?? 2);
+        setMoving(false);
         return;
       }
 
@@ -2674,7 +2672,7 @@ export default function SnakeAndLadder() {
       const finalizeMove = (finalPos, type, effectStart) => {
         const effectOrigin = Number.isFinite(effectStart) ? effectStart : finalPos;
         setPos(finalPos);
-        setHighlight({ cell: finalPos, type });
+        setHighlight({ cell: finalPos, type, color: playerColors[0] || '#f97316' });
         setTrail([]);
         setTokenType(type);
         setTimeout(() => setHighlight(null), 2300);
@@ -2849,11 +2847,9 @@ export default function SnakeAndLadder() {
         enqueueSnakeCommentaryEvent('needSix', { player: playerLabel });
         setDiceVisible(false);
         const next = getPreviousTurn(currentTurn);
-        setTimeout(() => {
-          setCurrentTurn(next);
-          setDiceCount(playerDiceCounts[next] ?? 2);
-        }, 2000);
-        setTimeout(() => setMoving(false), 2000);
+        setCurrentTurn(next);
+        setDiceCount(playerDiceCounts[next] ?? 2);
+        setMoving(false);
         return;
       }
     } else if (current === 100 && playerDiceCounts[index] === 1) {
@@ -2863,11 +2859,9 @@ export default function SnakeAndLadder() {
         setTurnMessage('');
         setDiceVisible(false);
         const next = getPreviousTurn(currentTurn);
-        setTimeout(() => {
-          setCurrentTurn(next);
-          setDiceCount(playerDiceCounts[next] ?? 2);
-        }, 2000);
-        setTimeout(() => setMoving(false), 2000);
+        setCurrentTurn(next);
+        setDiceCount(playerDiceCounts[next] ?? 2);
+        setMoving(false);
         return;
       }
     } else if (current + value <= FINAL_TILE) {
@@ -2922,7 +2916,7 @@ export default function SnakeAndLadder() {
       const effectOrigin = Number.isFinite(effectStart) ? effectStart : finalPos;
       positions[index - 1] = finalPos;
       setAiPositions([...positions]);
-      setHighlight({ cell: finalPos, type });
+      setHighlight({ cell: finalPos, type, color: playerColors[index] || '#22d3ee' });
       setTrail([]);
       const victims = capturePieces(finalPos, index);
       if (victims.length) {


### PR DESCRIPTION
### Motivation
- Keep the 3D camera locked to the original start framing and height (no downward drift or cinematic camera moves) so the board view stays consistent for the player. 
- When tokens move, present the motion by rotating the board to face the camera (instead of moving the camera) and restore the original board orientation afterwards. 
- Make tile highlights adopt the moving token color and ensure turn progression matches the Ludo Battle Royal flow (advance immediately after dice results when no movement is needed). 

### Description
- Added board rotation helpers and timing constants (`BOARD_ROTATE_*`) and implemented smooth board-rotation animations (`createBoardRotationAnimation`, `computeBoardFacingRotationY`, `normalizeAngle`) in `webapp/src/components/SnakeBoard3D.jsx`.  
- Replaced camera-follow token cinematics with: reset camera to the start view, rotate the board toward the moving token during movement, then restore the board rotation after movement completes; applied to normal moves and slide (snake/ladder) motions. Changes live in `SnakeBoard3D.jsx`.  
- Enforced the start-view vertical camera height and locked polar tilt to the initial start angle so the camera cannot be lowered below the start framing; removed dice/turn cinematic camera zooms and instead reset the camera for dice flow. These constraints are implemented in `SnakeBoard3D.jsx`.  
- Extended tile highlighting to accept explicit colors (`highlight.color` and `trail[].color`) in `updateTilesHighlight`, and updated the Snake & Ladder move finalization (single-player, AI and multiplayer handlers) to pass each player’s token color when landing on a tile in `webapp/src/pages/Games/SnakeAndLadder.jsx`.  
- Adjusted no-move branches (blocked / need exact roll) to immediately advance `currentTurn` and set dice counts rather than relying on delayed timeouts, for both player and AI code paths in `SnakeAndLadder.jsx`.

### Testing
- Built the web app to validate integration and compile-time behavior with `npm --prefix webapp run build`, and the production build completed successfully.  
- No automated unit tests were added or run as part of this change; manual/runtime validation was exercised via the production build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7aab406dc83298ebdf6098151ac6b)