### PR TITLE
Lock Snake camera height, speed dice handoff, rotate board & color-highlight landing tiles

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -236,6 +236,10 @@ const STAIR_OUTWARD_OFFSET = TILE_SIZE * 0.35;
 const COIN_SPIN_SPEED = Math.PI / 7;
 const TEXTURE_REPEAT_SCALE = 0.85;
 const BOARD_ROTATION_DRAG_SPEED = 0.0065;
+const BOARD_AUTO_ROTATE_DURATION = 280;
+const BOARD_AUTO_RESET_DURATION = 420;
+const BOARD_AUTO_RESET_DELAY = 180;
+const BOARD_ROTATION_EPSILON = 0.0005;
 const CAMERA_EXTRA_LIFT = 0.12;
 const COIN_RAISE = TILE_SIZE * 0.24;
 const COIN_LOCAL_LIFT = TILE_SIZE * 0.05;
@@ -1596,37 +1600,6 @@ function createTokenCameraFollowAnimation(camera, controls, followState, restore
     returnTarget: restoreState?.target,
     onComplete
   });
-}
-
-function computeTurnCameraFocusState(board, camera, turnIndex, players = []) {
-  if (!board || !camera) return null;
-  const anchors = Array.isArray(board.seatAnchors) ? board.seatAnchors : [];
-  const player = Array.isArray(players) ? players[turnIndex] : null;
-  const rawSeatIndex = Number.isFinite(player?.seatIndex)
-    ? Number(player.seatIndex)
-    : Number.isInteger(turnIndex)
-    ? turnIndex
-    : Number(turnIndex);
-  const seatIndex = Math.trunc(rawSeatIndex);
-  if (!Number.isFinite(seatIndex) || seatIndex < 0 || seatIndex >= anchors.length) return null;
-  const anchor = anchors[seatIndex];
-  const boardLookTarget = board.boardLookTarget;
-  if (!anchor || !boardLookTarget) return null;
-
-  const seatWorld = new THREE.Vector3();
-  anchor.getWorldPosition(seatWorld);
-  const target = boardLookTarget.clone().lerp(seatWorld, 0.34);
-  target.y = boardLookTarget.y;
-
-  const direction = seatWorld.clone().sub(boardLookTarget).setY(0);
-  if (direction.lengthSq() < 1e-6) return null;
-  direction.normalize();
-
-  // Keep the camera exactly where the player left it (including manual zoom distance)
-  // and only rotate the look target for turn-focus cues.
-  const position = camera.position.clone();
-
-  return { position, target };
 }
 
 function computeDiceCameraFocusState(board, camera) {
@@ -3145,10 +3118,53 @@ function updateTilesHighlight(tileMeshes, highlight, trail, highlightColors = DE
   if (highlight) {
     const tile = tileMeshes.get(highlight.cell);
     if (tile) {
-      const color = colors[highlight.type] ?? colors.normal;
+      const color = highlight.color ? toThreeColor(highlight.color, colors[highlight.type] ?? colors.normal) : (colors[highlight.type] ?? colors.normal);
       applyTileHighlight(tile, color);
     }
   }
+}
+
+function shortestAngleDelta(from, to) {
+  let diff = to - from;
+  while (diff > Math.PI) diff -= Math.PI * 2;
+  while (diff < -Math.PI) diff += Math.PI * 2;
+  return diff;
+}
+
+function computeBoardFacingRotation(board, tileIndex) {
+  if (!board) return null;
+  const numericTile = Number(tileIndex);
+  if (!Number.isFinite(numericTile)) return null;
+  const target = board.indexToPosition.get(numericTile) || board.serpentineIndexToXZ?.(numericTile);
+  if (!target) return null;
+  const angle = Math.atan2(target.x, target.z);
+  return -angle;
+}
+
+function createBoardRotationAnimation(root, toRotationY, duration = BOARD_AUTO_ROTATE_DURATION, onComplete) {
+  if (!root || !Number.isFinite(toRotationY)) return null;
+  const startRotation = root.rotation.y;
+  const delta = shortestAngleDelta(startRotation, toRotationY);
+  if (Math.abs(delta) <= BOARD_ROTATION_EPSILON) {
+    if (typeof onComplete === 'function') onComplete();
+    return null;
+  }
+  const start = performance.now();
+  return {
+    type: 'boardAutoRotate',
+    update: (now) => {
+      const elapsed = now - start;
+      const t = duration > 0 ? Math.min(Math.max(elapsed / duration, 0), 1) : 1;
+      const eased = easeInOut(t);
+      root.rotation.y = startRotation + delta * eased;
+      if (t >= 1) {
+        root.rotation.y = startRotation + delta;
+        if (typeof onComplete === 'function') onComplete();
+        return true;
+      }
+      return false;
+    }
+  };
 }
 
 function updateTokens(
@@ -3836,6 +3852,7 @@ export default function SnakeBoard3D({
   const turnCameraStateRef = useRef(null);
   const cinematicRestoreRef = useRef(null);
   const previousTurnRef = useRef(null);
+  const tokenMoveResetTimeoutRef = useRef(null);
   const lastFrameTimeRef = useRef(0);
   const frameRateRef = useRef(Math.max(30, frameRate || 90));
   const cameraViewModeRef = useRef(cameraViewMode);
@@ -3849,6 +3866,17 @@ export default function SnakeBoard3D({
   const tokenShape = appearanceMemo?.tokenShape;
   const railTheme = appearanceMemo?.rail;
   const snakeTheme = appearanceMemo?.snakeSkin;
+
+  const queueBoardAutoReset = useCallback((board, delay = BOARD_AUTO_RESET_DELAY) => {
+    if (!board?.rotationRoot) return;
+    if (tokenMoveResetTimeoutRef.current) clearTimeout(tokenMoveResetTimeoutRef.current);
+    tokenMoveResetTimeoutRef.current = setTimeout(() => {
+      removeAnimationsByType(animationsRef.current, 'boardAutoRotate');
+      const resetAnim = createBoardRotationAnimation(board.rotationRoot, 0, BOARD_AUTO_RESET_DURATION);
+      if (resetAnim) animationsRef.current.push(resetAnim);
+      tokenMoveResetTimeoutRef.current = null;
+    }, delay);
+  }, []);
 
   useEffect(() => {
     cameraViewModeRef.current = cameraViewMode;
@@ -3873,24 +3901,23 @@ export default function SnakeBoard3D({
     if (previousTurnRef.current === currentTurn) return;
     previousTurnRef.current = currentTurn;
 
-    const focusState = computeTurnCameraFocusState(board, camera, currentTurn, players);
-    if (!focusState) return;
-    turnCameraStateRef.current = {
-      position: focusState.position.clone(),
-      target: focusState.target.clone()
-    };
-
     removeAnimationsByType(animationsRef.current, 'cameraTurnFocus');
     removeAnimationsByType(animationsRef.current, 'cameraDiceZoom');
+    const startState = board.startCameraState || captureCameraState(camera, controls);
+    if (!startState) return;
+    turnCameraStateRef.current = {
+      position: startState.position.clone(),
+      target: startState.target.clone()
+    };
     const turnAnimation = createCameraTransitionAnimation(camera, controls, {
-      toPosition: focusState.position,
-      toTarget: focusState.target,
+      toPosition: startState.position,
+      toTarget: startState.target,
       durationIn: TURN_CAMERA_TURN_IN_DURATION,
       hold: 0,
       durationOut: 0,
       type: 'cameraTurnFocus',
-      returnPosition: focusState.position,
-      returnTarget: focusState.target
+      returnPosition: startState.position,
+      returnTarget: startState.target
     });
     if (turnAnimation) animationsRef.current.push(turnAnimation);
   }, [currentTurn, cameraViewMode]);
@@ -4071,7 +4098,8 @@ export default function SnakeBoard3D({
       const absY = Math.abs(deltaY);
 
       if (absY >= absX && absY >= 0.25 && typeof onCameraTiltChange === 'function') {
-        const nextTilt = clamp01(cameraTiltRef.current + deltaY * 0.0015);
+        const requestedTilt = clamp01(cameraTiltRef.current + deltaY * 0.0015);
+        const nextTilt = Math.min(cameraTiltRef.current, requestedTilt);
         if (Math.abs(nextTilt - cameraTiltRef.current) > 0.0001) {
           cameraTiltRef.current = nextTilt;
           onCameraTiltChange(nextTilt);
@@ -4172,6 +4200,10 @@ export default function SnakeBoard3D({
       arena.controls?.update?.();
       const camera = cameraRef.current;
       if (camera) {
+        const minCameraY = board?.startCameraState?.position?.y;
+        if (Number.isFinite(minCameraY) && camera.position.y < minCameraY) {
+          camera.position.y = minCameraY;
+        }
         if (arena.updateHdriZoom) {
           const target = board?.boardLookTarget ?? arena.boardLookTarget;
           arena.updateHdriZoom(camera, target);
@@ -4245,6 +4277,10 @@ export default function SnakeBoard3D({
       renderer.setAnimationLoop(null);
       handlers.forEach((fn) => fn());
       lastSeatPositionsRef.current = [];
+      if (tokenMoveResetTimeoutRef.current) {
+        clearTimeout(tokenMoveResetTimeoutRef.current);
+        tokenMoveResetTimeoutRef.current = null;
+      }
       seatCallbackRef.current?.([]);
       lastDiceAnchorRef.current = null;
       diceAnchorCallbackRef.current?.(null);
@@ -4344,6 +4380,20 @@ export default function SnakeBoard3D({
         if (followAnimation) animationsRef.current.push(followAnimation);
       }
     }
+
+    if (cameraViewMode !== '2d' && movement && board.rotationRoot) {
+      const faceRotation = computeBoardFacingRotation(board, movement.to);
+      if (Number.isFinite(faceRotation)) {
+        if (tokenMoveResetTimeoutRef.current) {
+          clearTimeout(tokenMoveResetTimeoutRef.current);
+          tokenMoveResetTimeoutRef.current = null;
+        }
+        removeAnimationsByType(animationsRef.current, 'boardAutoRotate');
+        const rotateAnim = createBoardRotationAnimation(board.rotationRoot, faceRotation, BOARD_AUTO_ROTATE_DURATION);
+        if (rotateAnim) animationsRef.current.push(rotateAnim);
+      }
+      queueBoardAutoReset(board);
+    }
   }, [
     players,
     burning,
@@ -4354,7 +4404,8 @@ export default function SnakeBoard3D({
     tokenTheme,
     tokenShape,
     tokenPrototypeVersion,
-    cameraViewMode
+    cameraViewMode,
+    queueBoardAutoReset
   ]);
 
   useEffect(() => {
@@ -4428,6 +4479,18 @@ export default function SnakeBoard3D({
       );
       if (followAnimation) animationsRef.current.push(followAnimation);
     }
+    if (cameraViewMode !== '2d' && board.rotationRoot) {
+      const faceRotation = computeBoardFacingRotation(board, slide.to);
+      if (Number.isFinite(faceRotation)) {
+        if (tokenMoveResetTimeoutRef.current) {
+          clearTimeout(tokenMoveResetTimeoutRef.current);
+          tokenMoveResetTimeoutRef.current = null;
+        }
+        removeAnimationsByType(animationsRef.current, 'boardAutoRotate');
+        const rotateAnim = createBoardRotationAnimation(board.rotationRoot, faceRotation, BOARD_AUTO_ROTATE_DURATION);
+        if (rotateAnim) animationsRef.current.push(rotateAnim);
+      }
+    }
     animationsRef.current.push({
       update: (now) => {
         const t = Math.min((now - startTime) / duration, 1);
@@ -4448,13 +4511,14 @@ export default function SnakeBoard3D({
         if (t >= 1) {
           token.userData.isSliding = false;
           token.position.copy(endBase);
+          queueBoardAutoReset(board, BOARD_AUTO_RESET_DELAY + 120);
           onSlideComplete?.(slide.id, true);
           return true;
         }
         return false;
       }
     });
-  }, [slide, onSlideComplete, cameraViewMode]);
+  }, [slide, onSlideComplete, cameraViewMode, queueBoardAutoReset]);
 
   useEffect(() => {
     if (!diceEvent || !boardRef.current) return;

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -185,6 +185,7 @@ const FINAL_TILE = BOARD_FINAL_TILE;
 const TURN_TIME = 15;
 const AI_ROLL_DELAY_MS = 3400;
 const AI_EXTRA_ROLL_DELAY_MS = 2600;
+const DICE_RESULT_TURN_DELAY_MS = 650;
 const DEFAULT_CAPACITY = 4;
 const COMMENTARY_PRESET_STORAGE_KEY = 'snakeCommentaryPreset';
 const COMMENTARY_MUTE_STORAGE_KEY = 'snakeCommentaryMute';
@@ -2589,8 +2590,8 @@ export default function SnakeAndLadder() {
           setTimeout(() => {
             setCurrentTurn(next);
             setDiceCount(playerDiceCounts[next] ?? 2);
-          }, 2000);
-          setTimeout(() => setMoving(false), 2000);
+          }, DICE_RESULT_TURN_DELAY_MS);
+          setTimeout(() => setMoving(false), DICE_RESULT_TURN_DELAY_MS);
           return;
         }
       } else if (current === 0) {
@@ -2607,8 +2608,8 @@ export default function SnakeAndLadder() {
           setTimeout(() => {
             setCurrentTurn(next);
             setDiceCount(playerDiceCounts[next] ?? 2);
-          }, 2000);
-          setTimeout(() => setMoving(false), 2000);
+          }, DICE_RESULT_TURN_DELAY_MS);
+          setTimeout(() => setMoving(false), DICE_RESULT_TURN_DELAY_MS);
           return;
         }
       } else if (current + value <= FINAL_TILE) {
@@ -2623,8 +2624,8 @@ export default function SnakeAndLadder() {
         setTimeout(() => {
           setCurrentTurn(next);
           setDiceCount(playerDiceCounts[next] ?? 2);
-        }, 2000);
-        setTimeout(() => setMoving(false), 2000);
+        }, DICE_RESULT_TURN_DELAY_MS);
+        setTimeout(() => setMoving(false), DICE_RESULT_TURN_DELAY_MS);
         return;
       }
 
@@ -2674,7 +2675,7 @@ export default function SnakeAndLadder() {
       const finalizeMove = (finalPos, type, effectStart) => {
         const effectOrigin = Number.isFinite(effectStart) ? effectStart : finalPos;
         setPos(finalPos);
-        setHighlight({ cell: finalPos, type });
+        setHighlight({ cell: finalPos, type, color: playerColors[0] || '#ffffff' });
         setTrail([]);
         setTokenType(type);
         setTimeout(() => setHighlight(null), 2300);
@@ -2852,8 +2853,8 @@ export default function SnakeAndLadder() {
         setTimeout(() => {
           setCurrentTurn(next);
           setDiceCount(playerDiceCounts[next] ?? 2);
-        }, 2000);
-        setTimeout(() => setMoving(false), 2000);
+        }, DICE_RESULT_TURN_DELAY_MS);
+        setTimeout(() => setMoving(false), DICE_RESULT_TURN_DELAY_MS);
         return;
       }
     } else if (current === 100 && playerDiceCounts[index] === 1) {
@@ -2866,8 +2867,8 @@ export default function SnakeAndLadder() {
         setTimeout(() => {
           setCurrentTurn(next);
           setDiceCount(playerDiceCounts[next] ?? 2);
-        }, 2000);
-        setTimeout(() => setMoving(false), 2000);
+        }, DICE_RESULT_TURN_DELAY_MS);
+        setTimeout(() => setMoving(false), DICE_RESULT_TURN_DELAY_MS);
         return;
       }
     } else if (current + value <= FINAL_TILE) {
@@ -2922,7 +2923,7 @@ export default function SnakeAndLadder() {
       const effectOrigin = Number.isFinite(effectStart) ? effectStart : finalPos;
       positions[index - 1] = finalPos;
       setAiPositions([...positions]);
-      setHighlight({ cell: finalPos, type });
+      setHighlight({ cell: finalPos, type, color: playerColors[index] || '#ffffff' });
       setTrail([]);
       const victims = capturePieces(finalPos, index);
       if (victims.length) {


### PR DESCRIPTION
### Motivation
- Keep the Snake & Ladder camera fixed at the initial (max) height and avoid allowing the user drag/tilt to lower the view during play. 
- Make dice-result-to-next-turn handoff faster to match the faster turn pacing used in the Ludo Battle Royal flow. 
- During token movement, preserve the start-game camera framing and rotate the board (not the camera) to show the token’s side to the camera; then restore the board rotation after movement. 
- Ensure landed tiles highlight using the token color so the visual feedback matches the moving token.

### Description
- Introduced `DICE_RESULT_TURN_DELAY_MS` and replaced several 2s post-roll/no-move timeouts in both human and AI paths so turns advance faster after dice results (file: `webapp/src/pages/Games/SnakeAndLadder.jsx`).
- Propagated token color into highlight payloads (`setHighlight({ cell, type, color })`) for both player and AI finalize flows and updated tile rendering to honor `highlight.color` while preserving existing type-based fallbacks (files: `webapp/src/pages/Games/SnakeAndLadder.jsx`, `webapp/src/components/SnakeBoard3D.jsx`).
- Implemented board auto-rotation helpers (`computeBoardFacingRotation`, `createBoardRotationAnimation`, `queueBoardAutoReset`) that rotate `board.rotationRoot` toward the active token during movement/slide and automatically reset it to the original orientation after a short delay (file: `webapp/src/components/SnakeBoard3D.jsx`).
- Locked turn-focus camera transitions to the initial start-camera state (so turn-focus preserves the original gameplay framing), prevented drag tilt from lowering the tilt by using `Math.min(current, requested)` for tilt changes, and enforced a minimum camera Y in the render loop based on the start camera height to stop the camera dropping below its original height (file: `webapp/src/components/SnakeBoard3D.jsx`).
- Minor supporting utilities and constants added for board rotation timing and epsilon handling, and removed the previous per-seat turn-focus camera rotation so the camera remains anchored to the start framing (file: `webapp/src/components/SnakeBoard3D.jsx`).

### Testing
- Ran `npx eslint webapp/src/pages/Games/SnakeAndLadder.jsx webapp/src/components/SnakeBoard3D.jsx`, which completed with no errors; the run reported warnings that these paths are ignored by repo ignore settings but no lint failures. 
- Verified repository status locally and committed the changes to the working tree (automated local checks completed normally). 
- No automated visual/UI tests were available in this environment, so visual verification (play / screenshot) was not performed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7aab406dc83298ebdf6098151ac6b)