### PR TITLE
Improve Pool Royale AI: better potting, spin realism, and aim-guide accuracy

### DIFF
--- a/webapp/public/lib/poolAi.js
+++ b/webapp/public/lib/poolAi.js
@@ -37,9 +37,9 @@
  * @property {{x:number,y:number}} [aimPoint]
  */
 
-const LOOKAHEAD_DEPTH = 4
-const LOOKAHEAD_CANDIDATES = 6
-const MONTE_CARLO_BASE_SAMPLES = 55
+const LOOKAHEAD_DEPTH = 5
+const LOOKAHEAD_CANDIDATES = 8
+const MONTE_CARLO_BASE_SAMPLES = 72
 
 function createRng (seed) {
   let state = (seed ?? 0) >>> 0
@@ -99,6 +99,27 @@ function clearanceMargin (a, b, balls, ignoreIds, radius, multiplier = 1.35) {
   if (!Number.isFinite(min)) return 1
   const ratio = min / (radius * multiplier)
   return Math.min(Math.max(ratio, 0), 2)
+}
+
+function objectPathClearance (target, pocketEntryPoint, balls, ignoreIds, radius) {
+  let min = Infinity
+  for (const ball of balls) {
+    if (ball.pocketed) continue
+    if (ignoreIds.includes(ball.id)) continue
+    const apx = ball.x - target.x
+    const apy = ball.y - target.y
+    const abx = pocketEntryPoint.x - target.x
+    const aby = pocketEntryPoint.y - target.y
+    const abLenSq = abx * abx + aby * aby
+    if (abLenSq <= 1e-6) continue
+    const t = (apx * abx + apy * aby) / abLenSq
+    if (t <= 0 || t >= 1) continue
+    const closest = { x: target.x + abx * t, y: target.y + aby * t }
+    const d = dist(closest, ball)
+    if (d < min) min = d
+  }
+  if (!Number.isFinite(min)) return 1
+  return Math.min(Math.max(min / (radius * 2.1), 0), 2)
 }
 
 function scratchRiskAlongLine (cue, aimPoint, pockets, radius) {
@@ -367,14 +388,14 @@ function cloneBallsForNextShot (balls, cueAfter, targetId, state) {
 // Rough Monte Carlo estimate of potting probability by jittering the cue
 // aim slightly and checking if paths remain clear. This models human
 // imprecision and rewards shorter, straighter shots.
-function monteCarloPotChance (req, cue, target, entry, ghost, balls, samples = 20, rng = Math.random) {
+function monteCarloPotChance (req, cue, target, entry, ghost, balls, samples = 28, rng = Math.random) {
   const r = req.state.ballRadius
   const baseAngle = Math.atan2(ghost.y - cue.y, ghost.x - cue.x)
   const distCG = dist(cue, ghost)
   const shotLength = dist(cue, target)
   const distanceFactor = Math.min(shotLength / (r * 20 || 1), 2)
   const sampleCount = Math.max(samples, Math.round(MONTE_CARLO_BASE_SAMPLES * (1 + distanceFactor)))
-  const jitterScale = 0.012 + 0.02 * distanceFactor
+  const jitterScale = 0.008 + 0.014 * distanceFactor
   let success = 0
   for (let i = 0; i < sampleCount; i++) {
     const a = baseAngle + (rng() - 0.5) * jitterScale
@@ -457,6 +478,10 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
   if (laneClearance < 0.5) {
     return null
   }
+  const objectLaneClear = objectPathClearance(target, entry, balls, [0, target.id], r)
+  if (objectLaneClear < 0.45) {
+    return null
+  }
   if (scratchRiskAlongLine(cue, ghost, req.state.pockets || [], r)) {
     return null
   }
@@ -505,17 +530,22 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
   const runoutPotential = options.skipLookahead
     ? 0
     : estimateRunoutPotential(req, cueAfterClamped, target.id, balls, lookaheadDepth, rng)
+  const pocketControl = Math.max(
+    0,
+    Math.min((objectLaneClear - 0.45) / 0.9, 1)
+  )
   const quality = Math.max(
     0,
     Math.min(
       1,
-      0.38 * potChance +
-        0.18 * pocketOpen +
+      0.44 * potChance +
+        0.16 * pocketOpen +
         0.16 * centerAlign +
         0.06 * nextScore +
         0.06 * nearHole +
         0.08 * runoutPotential +
-        0.08 * clearanceScore -
+        0.06 * clearanceScore +
+        0.04 * pocketControl -
         0.18 * risk -
         difficultyPenalty
     )
@@ -634,10 +664,12 @@ export function planShot (req) {
 
   const spins = [
     { top: 0, side: 0, back: 0 },
-    { top: 0.2, side: 0, back: -0.2 },
-    { top: -0.2, side: 0, back: 0 },
-    { top: 0, side: 0.18, back: 0 },
-    { top: 0, side: -0.18, back: 0 }
+    { top: 0.15, side: 0, back: -0.15 },
+    { top: -0.18, side: 0, back: 0.22 },
+    { top: 0.1, side: 0.12, back: 0 },
+    { top: 0.1, side: -0.12, back: 0 },
+    { top: 0, side: 0.22, back: 0 },
+    { top: 0, side: -0.22, back: 0 }
   ]
 
   // first, gather candidate target/pocket pairs meeting strict criteria

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1757,7 +1757,7 @@ const POCKET_VIEW_POST_POT_HOLD_MS =
   POCKET_DROP_RING_HOLD_MS + POCKET_DROP_REST_HOLD_MS;
 const POCKET_VIEW_MAX_HOLD_MS = 2200;
 const POCKET_VIEW_EARLY_HOLD_MS = 320;
-const SPIN_GLOBAL_SCALE = 0.9; // increase overall spin effect by 25% versus the previous 0.72 tuning
+const SPIN_GLOBAL_SCALE = 1.02; // raise overall spin response slightly so cue-ball action feels closer to real cloth behavior
 // Spin controller adapted from the open-source Billiards solver physics (MIT License).
 const SPIN_TABLE_REFERENCE_WIDTH = 2.627;
 const SPIN_TABLE_REFERENCE_HEIGHT = 1.07707;
@@ -1770,10 +1770,10 @@ const SPIN_DECAY_RATE = PHYSICS_PROFILE.spinDecay;
 const SPIN_AIR_DECAY_RATE = PHYSICS_PROFILE.airSpinDecay;
 const BACKSPIN_ROLL_BOOST = 1.35;
 const CUE_BACKSPIN_ROLL_BOOST = 3.4;
-const RAIL_SPIN_THROW_SCALE = 0; // keep spin active while preventing spin-based rail deflection from shifting cue-ball target line
+const RAIL_SPIN_THROW_SCALE = 0.22; // re-enable controlled rail throw so side spin changes rebound angle like real tables
 const RAIL_SPIN_THROW_REF_SPEED = BALL_R * 18;
 const RAIL_SPIN_NORMAL_FLIP = 0.65; // align spin inversion with Snooker Royal rebound behavior
-const SPIN_AFTER_IMPACT_DEFLECTION_SCALE = 0; // disable preview-only spin deflection so lines match the true impact geometry
+const SPIN_AFTER_IMPACT_DEFLECTION_SCALE = 0.18; // blend a small spin deflection into the preview so guides match actual shot outcomes
 // Align shot strength to the legacy 2D tuning (3.3 * 0.3 * 1.65) while keeping overall power softer than before.
 // Apply an additional 20% reduction to soften every strike and keep mobile play comfortable.
 // Pool Royale pace now mirrors Snooker Royale to keep ball travel identical between modes.
@@ -29219,8 +29219,6 @@ const powerRef = useRef(hud.power);
           const baseAimDir = new THREE.Vector3(aimDir.x, 0, aimDir.y);
           if (baseAimDir.lengthSq() < 1e-8) baseAimDir.set(0, 0, 1);
           else baseAimDir.normalize();
-          const basePerp = new THREE.Vector3(-baseAimDir.z, 0, baseAimDir.x);
-          if (basePerp.lengthSq() > 1e-8) basePerp.normalize();
           const powerStrength = THREE.MathUtils.clamp(
             powerRef.current ?? 0,
             0,
@@ -29256,21 +29254,31 @@ const powerRef = useRef(hud.power);
             targetPowerStrength = powerStrength * targetTransfer;
             cuePowerStrength = powerStrength * cueTransfer;
           }
+          const guideAimDir3D = new THREE.Vector3(
+            guideAimDir2D.x,
+            0,
+            guideAimDir2D.y
+          );
+          if (guideAimDir3D.lengthSq() < 1e-8) {
+            guideAimDir3D.copy(baseAimDir);
+          } else {
+            guideAimDir3D.normalize();
+          }
+          const guidePerp = new THREE.Vector3(-guideAimDir3D.z, 0, guideAimDir3D.x);
+          if (guidePerp.lengthSq() > 1e-8) guidePerp.normalize();
           const start = new THREE.Vector3(cue.pos.x, BALL_CENTER_Y, cue.pos.y);
           let end = new THREE.Vector3(impact.x, BALL_CENTER_Y, impact.y);
-          const dir = baseAimDir.clone();
+          const dir = guideAimDir3D.clone();
           if (start.distanceTo(end) < 1e-4) {
             end = start.clone().add(dir.clone().multiplyScalar(BALL_R));
           }
-          const perp = new THREE.Vector3(-dir.z, 0, dir.x);
-          if (perp.lengthSq() > 1e-8) perp.normalize();
           const aimPoints = buildSwerveAimLinePoints(
             aimCurvePointsRef.current,
             aimCurveControlRef.current,
             start,
             end,
             dir,
-            perp,
+            guidePerp,
             aimPreviewSpin,
             powerStrength,
             swerveActive,
@@ -29361,8 +29369,8 @@ const powerRef = useRef(hud.power);
           aim.material.color.set(primaryColor);
           aim.material.opacity = 0.55 + 0.35 * powerStrength;
           tickGeom.setFromPoints([
-            end.clone().add(perp.clone().multiplyScalar(AIM_TICK_HALF_LENGTH)),
-            end.clone().add(perp.clone().multiplyScalar(-AIM_TICK_HALF_LENGTH))
+            end.clone().add(guidePerp.clone().multiplyScalar(AIM_TICK_HALF_LENGTH)),
+            end.clone().add(guidePerp.clone().multiplyScalar(-AIM_TICK_HALF_LENGTH))
           ]);
           tick.visible = true;
           if (lookModeRef.current) {
@@ -29378,7 +29386,7 @@ const powerRef = useRef(hud.power);
             : dir.clone();
           const cueFollowPreview = resolveCueFollowPreview({
             cueDir: cueFollowDir,
-            aimDir: dir,
+            aimDir: guideAimDir3D,
             spin: aimPreviewSpin,
             powerStrength,
             cuePowerStrength,
@@ -29432,7 +29440,11 @@ const powerRef = useRef(hud.power);
           });
           const visualPull = applyVisualPullCompensation(pull, dir);
           const { side, vert, hasSpin } = computeSpinOffsets(appliedSpin, ranges);
-          const spinWorld = new THREE.Vector3(perp.x * side, vert, perp.z * side);
+          const spinWorld = new THREE.Vector3(
+            guidePerp.x * side,
+            vert,
+            guidePerp.z * side
+          );
           clampCueTipOffset(spinWorld);
           const obstructionStrength = resolveCueObstruction(
             dir,
@@ -29615,8 +29627,6 @@ const powerRef = useRef(hud.power);
             remoteAimDir.normalize();
           }
           const baseDir = new THREE.Vector3(remoteAimDir.x, 0, remoteAimDir.y);
-          const perp = new THREE.Vector3(-baseDir.z, 0, baseDir.x);
-          if (perp.lengthSq() > 1e-8) perp.normalize();
           const powerStrength = THREE.MathUtils.clamp(remoteAimState?.power ?? 0, 0, 1);
           const remoteSpin = remoteAimState?.spin ?? { x: 0, y: 0 };
           const remoteSpinNormalized = normalizeSpinInput(remoteSpin);
@@ -29634,6 +29644,18 @@ const powerRef = useRef(hud.power);
             guideAimDir2D,
             balls
           );
+          const guideAimDir3D = new THREE.Vector3(
+            guideAimDir2D.x,
+            0,
+            guideAimDir2D.y
+          );
+          if (guideAimDir3D.lengthSq() < 1e-8) {
+            guideAimDir3D.copy(baseDir);
+          } else {
+            guideAimDir3D.normalize();
+          }
+          const guidePerp = new THREE.Vector3(-guideAimDir3D.z, 0, guideAimDir3D.x);
+          if (guidePerp.lengthSq() > 1e-8) guidePerp.normalize();
           const impactDir =
             targetDir && (targetDir.x || targetDir.y)
               ? TMP_VEC3_IMPACT.set(targetDir.x, 0, targetDir.y)
@@ -29653,15 +29675,15 @@ const powerRef = useRef(hud.power);
           const start = new THREE.Vector3(cue.pos.x, BALL_CENTER_Y, cue.pos.y);
           let end = new THREE.Vector3(impact.x, BALL_CENTER_Y, impact.y);
           if (start.distanceTo(end) < 1e-4) {
-            end = start.clone().add(baseDir.clone().multiplyScalar(BALL_R));
+            end = start.clone().add(guideAimDir3D.clone().multiplyScalar(BALL_R));
           }
           const aimPoints = buildSwerveAimLinePoints(
             aimCurvePointsRef.current,
             aimCurveControlRef.current,
             start,
             end,
-            baseDir,
-            perp,
+            guideAimDir3D,
+            guidePerp,
             aimPreviewSpin,
             powerStrength,
             remoteSwerveActive
@@ -29680,8 +29702,8 @@ const powerRef = useRef(hud.power);
             powerStrength
           );
           tickGeom.setFromPoints([
-            end.clone().add(perp.clone().multiplyScalar(AIM_TICK_HALF_LENGTH)),
-            end.clone().add(perp.clone().multiplyScalar(-AIM_TICK_HALF_LENGTH))
+            end.clone().add(guidePerp.clone().multiplyScalar(AIM_TICK_HALF_LENGTH)),
+            end.clone().add(guidePerp.clone().multiplyScalar(-AIM_TICK_HALF_LENGTH))
           ]);
           tick.visible = true;
           const cueFollowDir = cueDir
@@ -29689,7 +29711,7 @@ const powerRef = useRef(hud.power);
             : baseDir.clone();
           const cueFollowPreview = resolveCueFollowPreview({
             cueDir: cueFollowDir,
-            aimDir: baseDir,
+            aimDir: guideAimDir3D,
             spin: aimPreviewSpin,
             powerStrength,
             cuePowerStrength,
@@ -29728,7 +29750,11 @@ const powerRef = useRef(hud.power);
             { x: spinX, y: spinY },
             ranges
           );
-          const spinWorld = new THREE.Vector3(perp.x * side, vert, perp.z * side);
+          const spinWorld = new THREE.Vector3(
+            guidePerp.x * side,
+            vert,
+            guidePerp.z * side
+          );
           clampCueTipOffset(spinWorld);
           const obstructionStrength = resolveCueObstruction(
             baseDir,


### PR DESCRIPTION
### Motivation

- Improve AI potting success and aiming fidelity so the computer opponent behaves like a professional player with more realistic cue-ball control and visible guides that match physics.
- Make spin behavior and aiming previews reflect true post-impact trajectories while preserving existing spin direction conventions.

### Description

- Increase AI search depth/candidate density by tuning `LOOKAHEAD_DEPTH`, `LOOKAHEAD_CANDIDATES`, and `MONTE_CARLO_BASE_SAMPLES` and reduce jitter in the Monte Carlo pot estimator in `webapp/public/lib/poolAi.js` to produce steadier pot probability estimates.
- Add `objectPathClearance` check and require a minimum object-ball→pocket lane clearance before accepting a pot plan, and rebalance shot scoring to weight pot probability and pocket control more heavily (adjusted quality formula) in `webapp/public/lib/poolAi.js`.
- Expand the practical AI spin candidate set so the AI can choose stronger, realistic top/back/side mixes, increasing usable spin strategies in `webapp/public/lib/poolAi.js`.
- Raise global spin response and re-enable controlled rail-throw plus a small post-impact spin deflection preview by adjusting `SPIN_GLOBAL_SCALE`, `RAIL_SPIN_THROW_SCALE` and `SPIN_AFTER_IMPACT_DEFLECTION_SCALE` in `webapp/src/pages/Games/PoolRoyale.jsx` so physics and previews align better.
- Make the aiming guide geometry use the compensated guide direction (`guideAimDir`) for the cue line, tick mark, cue-follow preview and spin-offset vectors for both local and remote aim previews so visuals match the AI/physics aim decisions (`webapp/src/pages/Games/PoolRoyale.jsx`).

### Testing

- Performed a production build with `npm --prefix webapp run build`, and the build completed successfully (Vite build output shows modules transformed and `dist/` generated).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7ac388a74832985960e34ad8c3472)