### PR TITLE
Align side-seat hands and add camera follow for played cards in Murlan Royale

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2953,6 +2953,7 @@ export default function MurlanRoyaleArena({ search }) {
   const cameraOrbitSphericalRef = useRef({ phi: null, phiMin: null, phiMax: null });
   const cameraForwardOffsetScratchRef = useRef(new THREE.Vector3());
   const cameraTurnAnimationRef = useRef(null);
+  const cameraCardFollowAnimationRef = useRef(null);
   const cameraTurnHoldTimeoutRef = useRef(null);
   const cameraTurnSuppressUntilRef = useRef(0);
   const cameraPlayFollowTimeoutRef = useRef(null);
@@ -3052,6 +3053,13 @@ export default function MurlanRoyaleArena({ search }) {
     if (cameraTurnHoldTimeoutRef.current != null) {
       clearTimeout(cameraTurnHoldTimeoutRef.current);
       cameraTurnHoldTimeoutRef.current = null;
+    }
+  }, []);
+
+  const stopCameraCardFollowAnimation = useCallback(() => {
+    if (cameraCardFollowAnimationRef.current != null) {
+      cancelAnimationFrame(cameraCardFollowAnimationRef.current);
+      cameraCardFollowAnimationRef.current = null;
     }
   }, []);
 
@@ -3231,6 +3239,8 @@ export default function MurlanRoyaleArena({ search }) {
 
     const seatConfigs = three.seatConfigs;
     const cardMap = three.cardMap;
+    const humanSeat = seatConfigs.find((seat) => state.players[seat.seatIndex]?.isHuman);
+    const sharedHorizontalAxis = humanSeat?.right?.clone()?.normalize?.() ?? null;
     const humanTurn = state.status === 'PLAYING' && state.players[state.activePlayer]?.isHuman;
     humanTurnRef.current = humanTurn;
 
@@ -3272,7 +3282,7 @@ export default function MurlanRoyaleArena({ search }) {
         const fanYaw = HUMAN_HAND_UNIFORM_YAW_FROM_LEFT
           ? HUMAN_HAND_FAN_MAX_YAW
           : normalizedOffset * (isHumanCard ? HUMAN_HAND_FAN_MAX_YAW : AI_HAND_FAN_MAX_YAW) * fanDirection;
-        const lateralAxis = right;
+        const lateralAxis = !isHumanCard && sharedHorizontalAxis ? sharedHorizontalAxis : right;
         const target = forward.clone().multiplyScalar(radial).addScaledVector(lateralAxis, lateral);
         if (isHumanCard) {
           target.addScaledVector(forward, HUMAN_HAND_CLOSER_OFFSET);
@@ -3312,7 +3322,6 @@ export default function MurlanRoyaleArena({ search }) {
 
     const tableAnchor = three.tableAnchor.clone();
     const tableCount = state.tableCards.length;
-    const humanSeat = seatConfigs.find((seat) => state.players[seat.seatIndex]?.isHuman);
     const bottomCardSpacing = Math.max(humanSeat?.spacing ?? 0, COMMUNITY_CARD_SPACING);
     const bottomCardMaxSpread = Math.max(humanSeat?.maxSpread ?? 0, COMMUNITY_CARD_MAX_SPREAD);
     const tableSpread = tableCount > 1
@@ -4061,6 +4070,7 @@ export default function MurlanRoyaleArena({ search }) {
     if (!threeReady) return;
     const action = gameState?.lastAction;
     if (!action || action.type !== 'PLAY') return;
+    stopCameraCardFollowAnimation();
     clearCameraTurnHoldTimeout();
     clearCameraPlayFollowTimeout();
 
@@ -4074,6 +4084,20 @@ export default function MurlanRoyaleArena({ search }) {
       typeof performance !== 'undefined' && typeof performance.now === 'function'
         ? performance.now()
         : Date.now();
+
+    const followCardFrame = (now) => {
+      if (now - start >= CAMERA_PLAY_FOLLOW_HOLD_MS) {
+        cameraCardFollowAnimationRef.current = null;
+        return;
+      }
+      const liveCardMesh = playedCardId ? store.cardMap.get(playedCardId)?.mesh : null;
+      if (liveCardMesh?.position) {
+        turnCameraTowardTarget(liveCardMesh.position.clone(), { animate: false });
+      }
+      cameraCardFollowAnimationRef.current = requestAnimationFrame(followCardFrame);
+    };
+    cameraCardFollowAnimationRef.current = requestAnimationFrame(followCardFrame);
+
     cameraTurnSuppressUntilRef.current = start + CAMERA_PLAY_FOLLOW_HOLD_MS + CAMERA_PLAY_NEXT_TURN_DELAY_MS;
 
     cameraPlayFollowTimeoutRef.current = setTimeout(() => {
@@ -4096,8 +4120,12 @@ export default function MurlanRoyaleArena({ search }) {
       cameraPlayFollowTimeoutRef.current = null;
     }, CAMERA_PLAY_FOLLOW_HOLD_MS + CAMERA_PLAY_NEXT_TURN_DELAY_MS);
 
-    return () => clearCameraPlayFollowTimeout();
+    return () => {
+      stopCameraCardFollowAnimation();
+      clearCameraPlayFollowTimeout();
+    };
   }, [
+    stopCameraCardFollowAnimation,
     clearCameraPlayFollowTimeout,
     clearCameraTurnHoldTimeout,
     gameState?.lastAction,


### PR DESCRIPTION
### Motivation
- Make the left/right opponent hands visually match the bottom player's one-line horizontal layout so side seats present cards in the same exact arrangement seen at the bottom of the screen. 
- Improve feedback when a player plays a card by having the camera follow the moving card toward the table center and then transition to the next player focus.
- Prevent overlapping camera animations/timeouts so follow and turn transitions do not conflict.

### Description
- Added a `cameraCardFollowAnimationRef` and `stopCameraCardFollowAnimation` to manage a dedicated requestAnimationFrame follow loop for `PLAY` actions and to ensure proper cleanup. 
- Computed a `sharedHorizontalAxis` from the human seat (`seat.right`) and used it as the lateral axis for non-human (left/right) hands so side seats use the same horizontal layout as the bottom hand (`applyStateToScene` changes). 
- On `PLAY` actions, first `turnCameraTowardTarget` the card/table center, then start a short follow loop that repeatedly calls `turnCameraTowardTarget` with `animate:false` to track the live card position until the follow hold window expires. 
- Hooked `stopCameraCardFollowAnimation` into effect teardown and before starting a new follow to avoid overlapping animations, and cleaned up related timeouts (`cameraPlayFollowTimeoutRef` / `cameraTurnHoldTimeoutRef`). 

### Testing
- Ran the production build with `npm --prefix webapp run build`, which completed successfully. 
- Build output included non-blocking Vite chunking warnings about large bundles but no errors, and the new file `webapp/src/pages/Games/MurlanRoyaleArena.jsx` compiled into the bundle.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7b4067154832986f36c2c51240f30)