### PR TITLE
Pool AI: improved cue physics, target/legal-ball handling, and tuning

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -17,7 +17,7 @@
 /**
  * @typedef {Object} AimRequest
  * @property {GameType} game
- * @property {{balls:Ball[],pockets:Pocket[],width:number,height:number,ballRadius:number,friction:number,myGroup?:'SOLIDS'|'STRIPES'|'UNASSIGNED',ballOn?:'blue'|'red'|null,ballInHand?:boolean,mustPlayFromBaulk?:boolean,baulkLineY?:number,breakInProgress?:boolean,breakPlacementRestricted?:boolean}} state
+ * @property {{balls:Ball[],pockets:Pocket[],width:number,height:number,ballRadius:number,friction:number,myGroup?:'SOLIDS'|'STRIPES'|'UNASSIGNED',ballOn?:'blue'|'red'|null,ballInHand?:boolean,mustPlayFromBaulk?:boolean,baulkLineY?:number,breakInProgress?:boolean,breakPlacementRestricted?:boolean,preferredTargetBallId?:number,legalBallIds?:number[]}} state
  * @property {number} [state.cueBallId]
  * @property {number} [timeBudgetMs]
  * @property {number} [rngSeed]
@@ -41,8 +41,8 @@
  */
 
 const LOOKAHEAD_DEPTH = 6
-const LOOKAHEAD_CANDIDATES = 12
-const MONTE_CARLO_BASE_SAMPLES = 96
+const LOOKAHEAD_CANDIDATES = 14
+const MONTE_CARLO_BASE_SAMPLES = 128
 const POWER_SCALE = 0.8
 
 function createRng (seed) {
@@ -253,8 +253,24 @@ function normaliseAimRequest (req) {
 function chooseTargets (req) {
   const cueBallId = resolveCueBallId(req.state)
   const balls = req.state.balls.filter(b => !b.pocketed && b.id !== cueBallId)
+  const legalIds = Array.isArray(req.state.legalBallIds)
+    ? req.state.legalBallIds.filter(id => Number.isFinite(id))
+    : []
+  const legalSet = legalIds.length > 0 ? new Set(legalIds) : null
+  const preferredTargetBallId = Number.isFinite(req.state.preferredTargetBallId)
+    ? Number(req.state.preferredTargetBallId)
+    : null
+  const restrictToLegal = candidateBalls => {
+    if (!legalSet) return candidateBalls
+    return candidateBalls.filter(ball => legalSet.has(ball.id))
+  }
   if (req.game === 'NINE_BALL') {
-    const lowest = balls.reduce((m, b) => (b.id < m.id ? b : m), balls[0])
+    const playable = restrictToLegal(balls)
+    if (preferredTargetBallId != null) {
+      const preferred = playable.find(ball => ball.id === preferredTargetBallId)
+      if (preferred) return [preferred]
+    }
+    const lowest = playable.reduce((m, b) => (b.id < m.id ? b : m), playable[0])
     return lowest ? [lowest] : []
   }
   if (req.game === 'AMERICAN_BILLIARDS') {
@@ -263,16 +279,16 @@ function chooseTargets (req) {
     const eight = balls.find(b => b.id === 8)
     const group = currentGroup(req.state)
     if (group === 'SOLIDS') {
-      if (solids.length > 0) return solids
-      if (eight) return [eight]
+      if (solids.length > 0) return restrictToLegal(solids)
+      if (eight) return restrictToLegal([eight])
       return []
     }
     if (group === 'STRIPES') {
-      if (stripes.length > 0) return stripes
-      if (eight) return [eight]
+      if (stripes.length > 0) return restrictToLegal(stripes)
+      if (eight) return restrictToLegal([eight])
       return []
     }
-    return balls
+    return restrictToLegal(balls)
   }
   if (req.game === 'EIGHT_POOL_UK') {
     const solids = balls.filter(b => b.id >= 1 && b.id <= 7)
@@ -280,18 +296,18 @@ function chooseTargets (req) {
     const eight = balls.find(b => b.id === 8)
     const group = currentGroup(req.state)
     if (group === 'SOLIDS') {
-      if (solids.length > 0) return solids
-      if (eight) return [eight]
+      if (solids.length > 0) return restrictToLegal(solids)
+      if (eight) return restrictToLegal([eight])
       return []
     }
     if (group === 'STRIPES') {
-      if (stripes.length > 0) return stripes
-      if (eight) return [eight]
+      if (stripes.length > 0) return restrictToLegal(stripes)
+      if (eight) return restrictToLegal([eight])
       return []
     }
-    return balls.filter(b => b.id !== 8)
+    return restrictToLegal(balls.filter(b => b.id !== 8))
   }
-  return balls
+  return restrictToLegal(balls)
 }
 
 function nextTargetsAfter (targetId, req) {
@@ -443,28 +459,41 @@ function findSuggestedTarget (req, primaryTargetId = null) {
 export function estimateCueAfterShot (cue, target, pocket, power, spin, table) {
   const toTarget = { x: target.x - cue.x, y: target.y - cue.y }
   const toPocket = { x: pocket.x - target.x, y: pocket.y - target.y }
-  const dir = { x: toTarget.x - toPocket.x, y: toTarget.y - toPocket.y }
-  const len = Math.hypot(dir.x, dir.y) || 1
+  const shotLen = Math.hypot(toTarget.x, toTarget.y) || 1
+  const objectLen = Math.hypot(toPocket.x, toPocket.y) || 1
+  const shotDir = { x: toTarget.x / shotLen, y: toTarget.y / shotLen }
+  const objectDir = { x: toPocket.x / objectLen, y: toPocket.y / objectLen }
+  const stunDirRaw = { x: shotDir.x - objectDir.x, y: shotDir.y - objectDir.y }
+  const stunLen = Math.hypot(stunDirRaw.x, stunDirRaw.y) || 1
+  const stunDir = { x: stunDirRaw.x / stunLen, y: stunDirRaw.y / stunLen }
 
-  // Base travel of the cue ball after striking the target – this is the
-  // straight path with no spin influence. Power only affects distance.
-  const baseDist = (power * 120) / len
+  const cutDot = Math.max(-1, Math.min(1, shotDir.x * objectDir.x + shotDir.y * objectDir.y))
+  const cutSeverity = Math.sqrt(Math.max(0, 1 - cutDot * cutDot))
+  const baseTravel = Math.max(table.ballRadius * 3, power * table.ballRadius * (18 - 3.6 * cutSeverity))
+
+  // Stun component (natural tangent line), then follow/draw layered on top.
+  const followAmount = Math.max(0, spin.top || 0)
+  const drawAmount = Math.max(0, spin.back || 0)
+  const travelScale = 1 + followAmount * 0.62 - drawAmount * (0.55 + cutSeverity * 0.25)
   const result = {
-    x: target.x + dir.x * baseDist,
-    y: target.y + dir.y * baseDist
+    x: target.x + stunDir.x * baseTravel * travelScale,
+    y: target.y + stunDir.y * baseTravel * travelScale
   }
-  // Apply spin after the straight path has been established. Top/back spin
-  // extend or reduce travel along the shot line while side spin adds a
-  // perpendicular offset after impact.
-  const distScale = 1 + spin.top - spin.back
-  result.x += dir.x * baseDist * (distScale - 1)
-  result.y += dir.y * baseDist * (distScale - 1)
 
-  const tableScale = Math.max(table.width, table.height) * 0.04
-  const sideOffset = spin.side * power * tableScale
-  const perp = { x: -dir.y / len, y: dir.x / len }
-  result.x += perp.x * sideOffset
-  result.y += perp.y * sideOffset
+  if (drawAmount > 1e-4) {
+    const drawTravel = baseTravel * drawAmount * (0.42 + 0.48 * (1 - cutSeverity))
+    result.x -= shotDir.x * drawTravel
+    result.y -= shotDir.y * drawTravel
+  }
+
+  // Side spin keeps existing sign convention while scaling with power and cut.
+  const sideUnit = { x: -stunDir.y, y: stunDir.x }
+  const tableScale = Math.max(table.width, table.height) * 0.045
+  const sideFactor = (1 - cutSeverity) * 0.3 + 0.7
+  const sideOffset = (spin.side || 0) * power * tableScale * sideFactor
+  result.x += sideUnit.x * sideOffset
+  result.y += sideUnit.y * sideOffset
+
   return result
 }
 
@@ -505,7 +534,7 @@ function monteCarloPotChance (req, cue, target, entry, ghost, balls, samples = 2
   const shotLength = dist(cue, target)
   const distanceFactor = Math.min(shotLength / (r * 20 || 1), 2)
   const sampleCount = Math.max(samples, Math.round(MONTE_CARLO_BASE_SAMPLES * (1 + distanceFactor * 1.2)))
-  const jitterScale = 0.012 + 0.021 * distanceFactor
+  const jitterScale = 0.008 + 0.015 * distanceFactor
   let success = 0
   for (let i = 0; i < sampleCount; i++) {
     const a = baseAngle + (rng() - 0.5) * jitterScale
@@ -519,7 +548,7 @@ function monteCarloPotChance (req, cue, target, entry, ghost, balls, samples = 2
     if (pathBlocked(cue, g, balls, [cueBallId, target.id], r, 1.1)) continue
     if (pathBlocked(target, entry, balls, [cueBallId, target.id], r)) continue
     // if jitter deviates too far from ideal contact, treat as miss
-    if (dist(g, ghost) > r * 0.5) continue
+    if (dist(g, ghost) > r * 0.42) continue
     success++
   }
   return success / sampleCount
@@ -571,10 +600,10 @@ function estimateRunoutPotential (req, cueAfter, targetId, balls, depth = 1, rng
 function buildSpinCandidates (cue, target, pocket, req) {
   const base = [
     { top: 0, side: 0, back: 0 },
-    { top: 0.22, side: 0, back: 0 },
-    { top: 0, side: 0, back: 0.22 },
-    { top: 0.18, side: 0.15, back: 0 },
-    { top: 0.18, side: -0.15, back: 0 }
+    { top: 0.28, side: 0, back: 0 },
+    { top: 0, side: 0, back: 0.28 },
+    { top: 0.22, side: 0.2, back: 0 },
+    { top: 0.22, side: -0.2, back: 0 }
   ]
   const nextTargets = nextTargetsAfter(target.id, req)
   if (!nextTargets.length) return base
@@ -680,9 +709,9 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
   const pocketTightness = 1 - pocketOpen
   const difficultyPenalty = 0.25 * (0.5 * cutSeverity + 0.3 * shotLengthFactor + 0.2 * pocketTightness)
   const spinPenalty =
-    Math.abs(spin.side || 0) * 0.08 +
-    Math.max(0, spin.back || 0) * 0.16 +
-    Math.max(0, spin.top || 0) * 0.05
+    Math.abs(spin.side || 0) * 0.06 +
+    Math.max(0, spin.back || 0) * 0.12 +
+    Math.max(0, spin.top || 0) * 0.04
   const clearanceScore = Math.max(0, Math.min((laneClearance - 0.5) / 0.7, 1))
   if (strict && (centerAlign < 0.5 || pocketOpen < 0.3)) {
     return null
@@ -697,12 +726,12 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
     0,
     Math.min(
       1,
-      0.34 * potChance +
-        0.17 * pocketOpen +
+      0.41 * potChance +
+        0.15 * pocketOpen +
         0.13 * centerAlign +
-        0.05 * nextScore +
-        0.04 * nearHole +
-        0.17 * runoutPotential +
+        0.06 * nextScore +
+        0.03 * nearHole +
+        0.14 * runoutPotential +
         0.12 * clearanceScore -
         0.21 * risk -
         (scratchAfterImpact ? 0.2 : 0) -
@@ -818,13 +847,13 @@ export function planShot (req) {
 
   const powers = req.state?.breakInProgress
     ? [1 * POWER_SCALE]
-    : [0.5 * POWER_SCALE, 0.7 * POWER_SCALE, 0.85 * POWER_SCALE]
+    : [0.48 * POWER_SCALE, 0.66 * POWER_SCALE, 0.82 * POWER_SCALE, 0.94 * POWER_SCALE]
   const defaultSpins = [
     { top: 0, side: 0, back: 0 },
-    { top: 0.25, side: 0, back: 0 },
-    { top: 0, side: 0, back: 0.25 },
-    { top: 0.15, side: 0.25, back: 0 },
-    { top: 0.15, side: -0.25, back: 0 }
+    { top: 0.3, side: 0, back: 0 },
+    { top: 0, side: 0, back: 0.3 },
+    { top: 0.2, side: 0.3, back: 0 },
+    { top: 0.2, side: -0.3, back: 0 }
   ]
 
   // first, gather candidate target/pocket pairs meeting strict criteria

--- a/webapp/public/lib/poolAi.js
+++ b/webapp/public/lib/poolAi.js
@@ -17,7 +17,8 @@
 /**
  * @typedef {Object} AimRequest
  * @property {GameType} game
- * @property {{balls:Ball[],pockets:Pocket[],width:number,height:number,ballRadius:number,friction:number,myGroup?:'SOLIDS'|'STRIPES'|'UNASSIGNED',ballOn?:'blue'|'red'|null,ballInHand?:boolean,mustPlayFromBaulk?:boolean,baulkLineY?:number,breakInProgress?:boolean,breakPlacementRestricted?:boolean}} state
+ * @property {{balls:Ball[],pockets:Pocket[],width:number,height:number,ballRadius:number,friction:number,myGroup?:'SOLIDS'|'STRIPES'|'UNASSIGNED',ballOn?:'blue'|'red'|null,ballInHand?:boolean,mustPlayFromBaulk?:boolean,baulkLineY?:number,breakInProgress?:boolean,breakPlacementRestricted?:boolean,preferredTargetBallId?:number,legalBallIds?:number[]}} state
+ * @property {number} [state.cueBallId]
  * @property {number} [timeBudgetMs]
  * @property {number} [rngSeed]
  * @property {number} [maxCutAngle] maximum allowed cut angle in radians for a shot candidate
@@ -35,11 +36,14 @@
  * @property {string} rationale
  * @property {{x:number,y:number}} [cueBallPosition]
  * @property {{x:number,y:number}} [aimPoint]
+ * @property {number} [suggestedTargetBallId]
+ * @property {{x:number,y:number}} [suggestedAimPoint]
  */
 
-const LOOKAHEAD_DEPTH = 4
-const LOOKAHEAD_CANDIDATES = 6
-const MONTE_CARLO_BASE_SAMPLES = 55
+const LOOKAHEAD_DEPTH = 6
+const LOOKAHEAD_CANDIDATES = 14
+const MONTE_CARLO_BASE_SAMPLES = 128
+const POWER_SCALE = 0.8
 
 function createRng (seed) {
   let state = (seed ?? 0) >>> 0
@@ -55,10 +59,6 @@ function dist (a, b) {
   const dx = a.x - b.x
   const dy = a.y - b.y
   return Math.hypot(dx, dy)
-}
-
-function clamp (value, min, max) {
-  return Math.min(Math.max(value, min), max)
 }
 
 function lineIntersectsBall (a, b, ball, radius) {
@@ -148,6 +148,26 @@ function pocketAlignment (pocket, target, width, height) {
   return Math.max(0, (approach.x / len) * normal.x + (approach.y / len) * normal.y)
 }
 
+function ghostPointForTargetPocket (target, pocket, req) {
+  const r = req.state.ballRadius
+  const entry = pocketEntry(pocket, r, req.state.width, req.state.height, target)
+  const dt = dist(target, entry)
+  if (dt <= 1e-6) return null
+  const ghost = {
+    x: target.x - (entry.x - target.x) * (r * 2 / dt),
+    y: target.y - (entry.y - target.y) * (r * 2 / dt)
+  }
+  if (
+    ghost.x < r ||
+    ghost.x > req.state.width - r ||
+    ghost.y < r ||
+    ghost.y > req.state.height - r
+  ) {
+    return null
+  }
+  return ghost
+}
+
 function currentGroup (state) {
   let g = state.myGroup
   if (!g || g === 'UNASSIGNED') {
@@ -159,41 +179,154 @@ function currentGroup (state) {
   // Map the textual colour assignment to the corresponding group.
   if (norm === 'RED') return 'SOLIDS'
   if (norm === 'BLUE') return 'STRIPES'
-  if (norm === 'YELLOW') return 'SOLIDS'
   if (norm === 'SOLIDS' || norm === 'STRIPES') return norm
   return undefined
 }
 
-function parseBallOnIds (state) {
-  const raw = state?.ballOn
-  const entries = Array.isArray(raw) ? raw : raw ? [raw] : []
-  const ids = entries
-    .map(value => {
-      if (typeof value === 'number') return value
-      if (typeof value !== 'string') return null
+function resolveCueBallId (state) {
+  if (Number.isFinite(state?.cueBallId)) return state.cueBallId
+  const cue = state?.balls?.find(b => b?.isCue === true)
+  if (cue && Number.isFinite(cue.id)) return cue.id
+  return 0
+}
+
+function inferIdFromColour (ball, indexByColour) {
+  const colour = (ball?.colour || ball?.color || '').toString().toLowerCase()
+  if (colour.startsWith('black')) return 8
+  if (colour.startsWith('red') || colour.startsWith('solid')) {
+    const next = (indexByColour.red = (indexByColour.red || 0) + 1)
+    return Math.min(7, Math.max(1, next))
+  }
+  if (colour.startsWith('yellow') || colour.startsWith('blue') || colour.startsWith('stripe')) {
+    const next = (indexByColour.yellow = (indexByColour.yellow || 0) + 1)
+    return Math.min(15, Math.max(9, 8 + next))
+  }
+  return null
+}
+
+function resolveBallId (ball, fallback, indexByColour) {
+  const candidates = [
+    ball?.id,
+    ball?.number,
+    ball?.ballNumber,
+    ball?.markerNumber,
+    ball?.helperNumber,
+    ball?.aiHelperNumber,
+    ball?.hiddenNumber
+  ]
+
+  for (const value of candidates) {
+    if (Number.isFinite(value)) return Number(value)
+    if (typeof value === 'string') {
       const match = value.match(/(\d+)/)
-      return match ? Number(match[1]) : null
-    })
-    .filter(id => Number.isFinite(id))
-  return Array.from(new Set(ids))
+      if (match) return Number.parseInt(match[1], 10)
+    }
+  }
+
+  const inferred = inferIdFromColour(ball, indexByColour)
+  if (Number.isFinite(inferred)) return inferred
+  return fallback
+}
+
+function normaliseAimRequest (req) {
+  const state = req?.state || {}
+  const indexByColour = { red: 0, yellow: 0 }
+  let fallbackId = 20
+  const balls = (state.balls || []).map(ball => {
+    const id = resolveBallId(ball, fallbackId++, indexByColour)
+    return { ...ball, id }
+  })
+
+  const cueBall = balls.find(b => b?.isCue === true || b?.colour === 'cue' || b?.color === 'cue' || b?.id === 0)
+  const cueBallId = cueBall ? cueBall.id : resolveCueBallId({ ...state, balls })
+
+  return {
+    ...req,
+    state: {
+      ...state,
+      balls,
+      cueBallId
+    }
+  }
 }
 
 function chooseTargets (req) {
-  const balls = req.state.balls.filter(b => !b.pocketed && b.id !== 0)
-  const ballOnIds = parseBallOnIds(req.state)
-  if (req.game === 'NINE_BALL' || req.game === 'AMERICAN_BILLIARDS') {
-    if (ballOnIds.length > 0) {
-      const restricted = balls.filter(b => ballOnIds.includes(b.id))
-      if (restricted.length > 0) return restricted
+  const cueBallId = resolveCueBallId(req.state)
+  const balls = req.state.balls.filter(b => !b.pocketed && b.id !== cueBallId)
+  const legalIds = Array.isArray(req.state.legalBallIds)
+    ? req.state.legalBallIds.filter(id => Number.isFinite(id))
+    : []
+  const legalSet = legalIds.length > 0 ? new Set(legalIds) : null
+  const preferredTargetBallId = Number.isFinite(req.state.preferredTargetBallId)
+    ? Number(req.state.preferredTargetBallId)
+    : null
+  const restrictToLegal = candidateBalls => {
+    if (!legalSet) return candidateBalls
+    return candidateBalls.filter(ball => legalSet.has(ball.id))
+  }
+  if (req.game === 'NINE_BALL') {
+    const playable = restrictToLegal(balls)
+    if (preferredTargetBallId != null) {
+      const preferred = playable.find(ball => ball.id === preferredTargetBallId)
+      if (preferred) return [preferred]
     }
-    const lowest = balls.reduce((m, b) => (b.id < m.id ? b : m), balls[0])
+    const lowest = playable.reduce((m, b) => (b.id < m.id ? b : m), playable[0])
     return lowest ? [lowest] : []
+  }
+  if (req.game === 'AMERICAN_BILLIARDS') {
+    const solids = balls.filter(b => b.id >= 1 && b.id <= 7)
+    const stripes = balls.filter(b => b.id >= 9 && b.id <= 15)
+    const eight = balls.find(b => b.id === 8)
+    const group = currentGroup(req.state)
+    if (group === 'SOLIDS') {
+      if (solids.length > 0) return restrictToLegal(solids)
+      if (eight) return restrictToLegal([eight])
+      return []
+    }
+    if (group === 'STRIPES') {
+      if (stripes.length > 0) return restrictToLegal(stripes)
+      if (eight) return restrictToLegal([eight])
+      return []
+    }
+    return restrictToLegal(balls)
   }
   if (req.game === 'EIGHT_POOL_UK') {
     const solids = balls.filter(b => b.id >= 1 && b.id <= 7)
     const stripes = balls.filter(b => b.id >= 9 && b.id <= 15)
     const eight = balls.find(b => b.id === 8)
     const group = currentGroup(req.state)
+    if (group === 'SOLIDS') {
+      if (solids.length > 0) return restrictToLegal(solids)
+      if (eight) return restrictToLegal([eight])
+      return []
+    }
+    if (group === 'STRIPES') {
+      if (stripes.length > 0) return restrictToLegal(stripes)
+      if (eight) return restrictToLegal([eight])
+      return []
+    }
+    return restrictToLegal(balls.filter(b => b.id !== 8))
+  }
+  return restrictToLegal(balls)
+}
+
+function nextTargetsAfter (targetId, req) {
+  const cueBallId = resolveCueBallId(req.state)
+  const cloned = req.state.balls.filter(b => !b.pocketed && b.id !== targetId && b.id !== cueBallId)
+  if (req.game === 'NINE_BALL') {
+    if (cloned.length === 0) return []
+    const lowest = cloned.reduce((m, b) => (b.id < m.id ? b : m), cloned[0])
+    return lowest ? [lowest] : []
+  }
+  if (req.game === 'AMERICAN_BILLIARDS') {
+    const solids = cloned.filter(b => b.id >= 1 && b.id <= 7)
+    const stripes = cloned.filter(b => b.id >= 9 && b.id <= 15)
+    const eight = cloned.find(b => b.id === 8)
+    let group = currentGroup(req.state)
+    if (!group || group === 'UNASSIGNED') {
+      if (targetId >= 1 && targetId <= 7) group = 'SOLIDS'
+      else if (targetId >= 9 && targetId <= 15) group = 'STRIPES'
+    }
     if (group === 'SOLIDS') {
       if (solids.length > 0) return solids
       if (eight) return [eight]
@@ -204,17 +337,7 @@ function chooseTargets (req) {
       if (eight) return [eight]
       return []
     }
-    return balls.filter(b => b.id !== 8)
-  }
-  return balls
-}
-
-function nextTargetsAfter (targetId, req) {
-  const cloned = req.state.balls.filter(b => !b.pocketed && b.id !== targetId && b.id !== 0)
-  if (req.game === 'NINE_BALL' || req.game === 'AMERICAN_BILLIARDS') {
-    if (cloned.length === 0) return []
-    const lowest = cloned.reduce((m, b) => (b.id < m.id ? b : m), cloned[0])
-    return lowest ? [lowest] : []
+    return cloned
   }
   if (req.game === 'EIGHT_POOL_UK') {
     const solids = cloned.filter(b => b.id >= 1 && b.id <= 7)
@@ -245,11 +368,12 @@ function nextTargetsAfter (targetId, req) {
 // preferring smaller cut angles and wider pocket views.
 function clearShotCandidates (req) {
   const r = req.state.ballRadius
-  const cue = req.state.balls.find(b => b.id === 0)
+  const cueBallId = resolveCueBallId(req.state)
+  const cue = req.state.balls.find(b => b.id === cueBallId)
   const targets = chooseTargets(req)
   const pockets = req.state.pockets
-  const maxCut = req.maxCutAngle ?? Math.PI / 4
-  const minView = req.minViewScore ?? 0.3
+  const maxCut = req.maxCutAngle ?? Math.PI / 4.15
+  const minView = req.minViewScore ?? 0.42
   const candidates = []
 
   for (const target of targets) {
@@ -272,10 +396,10 @@ function clearShotCandidates (req) {
 
       // check paths from cue->ghost and target->pocket are unobstructed
       if (
-        pathBlocked(cue, ghost, req.state.balls, [0, target.id], r, 1.1) ||
-        pathBlocked(target, entry, req.state.balls, [0, target.id], r) ||
+        pathBlocked(cue, ghost, req.state.balls, [cueBallId, target.id], r, 1.1) ||
+        pathBlocked(target, entry, req.state.balls, [cueBallId, target.id], r) ||
         req.state.balls.some(
-          b => b.id !== 0 && b.id !== target.id && !b.pocketed && dist(b, entry) < r * 1.1
+          b => b.id !== cueBallId && b.id !== target.id && !b.pocketed && dist(b, entry) < r * 1.1
         )
       ) {
         continue
@@ -290,18 +414,16 @@ function clearShotCandidates (req) {
       const entryAlignment = pocketAlignment(pocket, target, req.state.width, req.state.height)
       const weightedView = viewScore * (0.7 + 0.3 * entryAlignment)
       const approachStraightness = 1 - Math.min(cut / (Math.PI / 2), 1)
-      const laneClearance = clearanceMargin(cue, target, req.state.balls, [0, target.id], r, 1.35)
       const cueToTarget = cue ? dist(cue, target) : 0
       const distanceScore = cue ? Math.max(0, 1 - cueToTarget / (r * 60)) : 0
-      const clearanceScore = Math.max(0, Math.min((laneClearance - 0.4) / 0.8, 1))
       const rank =
-        weightedView * 0.45 +
+        weightedView * 0.46 +
         approachStraightness * 0.25 +
-        distanceScore * 0.2 +
-        clearanceScore * 0.1
+        distanceScore * 0.12 +
+        Math.max(0, 1 - cut / (Math.PI / 3.4)) * 0.17
 
       // require fairly central hit and open pocket view
-      if (cut <= maxCut && weightedView >= minView && laneClearance >= 0.4) {
+      if (cut <= maxCut && weightedView >= minView) {
         candidates.push({ target, pocket, cut, view: weightedView, rank })
       }
     }
@@ -311,31 +433,67 @@ function clearShotCandidates (req) {
   return candidates
 }
 
+function findSuggestedTarget (req, primaryTargetId = null) {
+  const cueBallId = resolveCueBallId(req.state)
+  const cue = req.state.balls.find(b => b.id === cueBallId)
+  if (!cue) return null
+  const ranked = clearShotCandidates(req)
+  const fallbackPool = ranked.length > 0
+    ? ranked
+    : chooseTargets(req).flatMap(target => req.state.pockets.map(pocket => ({ target, pocket, rank: 0 })))
+  for (const candidate of fallbackPool) {
+    const targetId = candidate?.target?.id
+    if (!Number.isFinite(targetId)) continue
+    if (primaryTargetId != null && targetId === primaryTargetId) continue
+    const ghost = ghostPointForTargetPocket(candidate.target, candidate.pocket, req)
+    if (!ghost) continue
+    if (pathBlocked(cue, ghost, req.state.balls, [cueBallId, targetId], req.state.ballRadius, 1.1)) continue
+    return {
+      suggestedTargetBallId: targetId,
+      suggestedAimPoint: ghost
+    }
+  }
+  return null
+}
+
 export function estimateCueAfterShot (cue, target, pocket, power, spin, table) {
   const toTarget = { x: target.x - cue.x, y: target.y - cue.y }
   const toPocket = { x: pocket.x - target.x, y: pocket.y - target.y }
-  const dir = { x: toTarget.x - toPocket.x, y: toTarget.y - toPocket.y }
-  const len = Math.hypot(dir.x, dir.y) || 1
+  const shotLen = Math.hypot(toTarget.x, toTarget.y) || 1
+  const objectLen = Math.hypot(toPocket.x, toPocket.y) || 1
+  const shotDir = { x: toTarget.x / shotLen, y: toTarget.y / shotLen }
+  const objectDir = { x: toPocket.x / objectLen, y: toPocket.y / objectLen }
+  const stunDirRaw = { x: shotDir.x - objectDir.x, y: shotDir.y - objectDir.y }
+  const stunLen = Math.hypot(stunDirRaw.x, stunDirRaw.y) || 1
+  const stunDir = { x: stunDirRaw.x / stunLen, y: stunDirRaw.y / stunLen }
 
-  // Base travel of the cue ball after striking the target – this is the
-  // straight path with no spin influence. Power only affects distance.
-  const baseDist = (power * 120) / len
+  const cutDot = Math.max(-1, Math.min(1, shotDir.x * objectDir.x + shotDir.y * objectDir.y))
+  const cutSeverity = Math.sqrt(Math.max(0, 1 - cutDot * cutDot))
+  const baseTravel = Math.max(table.ballRadius * 3, power * table.ballRadius * (18 - 3.6 * cutSeverity))
+
+  // Stun component (natural tangent line), then follow/draw layered on top.
+  const followAmount = Math.max(0, spin.top || 0)
+  const drawAmount = Math.max(0, spin.back || 0)
+  const travelScale = 1 + followAmount * 0.62 - drawAmount * (0.55 + cutSeverity * 0.25)
   const result = {
-    x: target.x + dir.x * baseDist,
-    y: target.y + dir.y * baseDist
+    x: target.x + stunDir.x * baseTravel * travelScale,
+    y: target.y + stunDir.y * baseTravel * travelScale
   }
-  // Apply spin after the straight path has been established. Top/back spin
-  // extend or reduce travel along the shot line while side spin adds a
-  // perpendicular offset after impact.
-  const distScale = 1 + spin.top - spin.back
-  result.x += dir.x * baseDist * (distScale - 1)
-  result.y += dir.y * baseDist * (distScale - 1)
 
-  const tableScale = Math.max(table.width, table.height) * 0.04
-  const sideOffset = spin.side * power * tableScale
-  const perp = { x: -dir.y / len, y: dir.x / len }
-  result.x += perp.x * sideOffset
-  result.y += perp.y * sideOffset
+  if (drawAmount > 1e-4) {
+    const drawTravel = baseTravel * drawAmount * (0.42 + 0.48 * (1 - cutSeverity))
+    result.x -= shotDir.x * drawTravel
+    result.y -= shotDir.y * drawTravel
+  }
+
+  // Side spin keeps existing sign convention while scaling with power and cut.
+  const sideUnit = { x: -stunDir.y, y: stunDir.x }
+  const tableScale = Math.max(table.width, table.height) * 0.045
+  const sideFactor = (1 - cutSeverity) * 0.3 + 0.7
+  const sideOffset = (spin.side || 0) * power * tableScale * sideFactor
+  result.x += sideUnit.x * sideOffset
+  result.y += sideUnit.y * sideOffset
+
   return result
 }
 
@@ -348,13 +506,14 @@ function clampPointToTable (point, table, margin = 1) {
 }
 
 function cloneBallsForNextShot (balls, cueAfter, targetId, state) {
+  const cueBallId = resolveCueBallId(state)
   const clamped = clampPointToTable(cueAfter, state, 1.1)
   return balls.map(ball => {
     const next = { ...ball }
     if (next.id === targetId) {
       next.pocketed = true
     }
-    if (next.id === 0) {
+    if (next.id === cueBallId) {
       next.x = clamped.x
       next.y = clamped.y
       next.vx = 0
@@ -369,12 +528,13 @@ function cloneBallsForNextShot (balls, cueAfter, targetId, state) {
 // imprecision and rewards shorter, straighter shots.
 function monteCarloPotChance (req, cue, target, entry, ghost, balls, samples = 20, rng = Math.random) {
   const r = req.state.ballRadius
+  const cueBallId = resolveCueBallId(req.state)
   const baseAngle = Math.atan2(ghost.y - cue.y, ghost.x - cue.x)
   const distCG = dist(cue, ghost)
   const shotLength = dist(cue, target)
   const distanceFactor = Math.min(shotLength / (r * 20 || 1), 2)
-  const sampleCount = Math.max(samples, Math.round(MONTE_CARLO_BASE_SAMPLES * (1 + distanceFactor)))
-  const jitterScale = 0.012 + 0.02 * distanceFactor
+  const sampleCount = Math.max(samples, Math.round(MONTE_CARLO_BASE_SAMPLES * (1 + distanceFactor * 1.2)))
+  const jitterScale = 0.008 + 0.015 * distanceFactor
   let success = 0
   for (let i = 0; i < sampleCount; i++) {
     const a = baseAngle + (rng() - 0.5) * jitterScale
@@ -385,10 +545,10 @@ function monteCarloPotChance (req, cue, target, entry, ghost, balls, samples = 2
       g.y < r ||
       g.y > req.state.height - r
     ) continue
-    if (pathBlocked(cue, g, balls, [0, target.id], r, 1.1)) continue
-    if (pathBlocked(target, entry, balls, [0, target.id], r)) continue
+    if (pathBlocked(cue, g, balls, [cueBallId, target.id], r, 1.1)) continue
+    if (pathBlocked(target, entry, balls, [cueBallId, target.id], r)) continue
     // if jitter deviates too far from ideal contact, treat as miss
-    if (dist(g, ghost) > r * 0.5) continue
+    if (dist(g, ghost) > r * 0.42) continue
     success++
   }
   return success / sampleCount
@@ -396,9 +556,10 @@ function monteCarloPotChance (req, cue, target, entry, ghost, balls, samples = 2
 
 function estimateRunoutPotential (req, cueAfter, targetId, balls, depth = 1, rng = Math.random) {
   if (!req?.state || depth <= 0) return 0
+  const cueBallId = resolveCueBallId(req.state)
   const nextBalls = cloneBallsForNextShot(balls, cueAfter, targetId, req.state)
   const nextReq = { ...req, state: { ...req.state, balls: nextBalls, ballInHand: false } }
-  const cue = nextBalls.find(b => b.id === 0)
+  const cue = nextBalls.find(b => b.id === cueBallId)
   if (!cue) return 0
   const candidates = clearShotCandidates(nextReq)
   if (!candidates.length) return 0
@@ -435,8 +596,45 @@ function estimateRunoutPotential (req, cueAfter, targetId, balls, depth = 1, rng
   return best
 }
 
+
+function buildSpinCandidates (cue, target, pocket, req) {
+  const base = [
+    { top: 0, side: 0, back: 0 },
+    { top: 0.28, side: 0, back: 0 },
+    { top: 0, side: 0, back: 0.28 },
+    { top: 0.22, side: 0.2, back: 0 },
+    { top: 0.22, side: -0.2, back: 0 }
+  ]
+  const nextTargets = nextTargetsAfter(target.id, req)
+  if (!nextTargets.length) return base
+
+  const entry = pocketEntry(pocket, req.state.ballRadius, req.state.width, req.state.height, target)
+  const naturalCueAfter = estimateCueAfterShot(cue, target, entry, 0.7, { top: 0, side: 0, back: 0 }, req.state)
+  const next = nextTargets
+    .slice()
+    .sort((a, b) => dist(a, naturalCueAfter) - dist(b, naturalCueAfter))[0]
+  if (!next) return base
+
+  const toNext = { x: next.x - naturalCueAfter.x, y: next.y - naturalCueAfter.y }
+  const shotDir = { x: entry.x - target.x, y: entry.y - target.y }
+  const shotLen = Math.hypot(shotDir.x, shotDir.y) || 1
+  const sideUnit = { x: -shotDir.y / shotLen, y: shotDir.x / shotLen }
+  const sideProjection = (toNext.x * sideUnit.x + toNext.y * sideUnit.y) / Math.max(req.state.ballRadius * 20, 1)
+  const forwardProjection = (toNext.x * shotDir.x + toNext.y * shotDir.y) / Math.max(shotLen * req.state.ballRadius * 12, 1)
+
+  const adaptive = {
+    top: Math.max(-0.35, Math.min(0.35, forwardProjection > 0 ? 0.1 + forwardProjection : 0.05)),
+    back: Math.max(0, Math.min(0.35, forwardProjection < -0.04 ? -forwardProjection : 0)),
+    side: Math.max(-0.35, Math.min(0.35, sideProjection))
+  }
+  adaptive.top = Math.max(0, adaptive.top - adaptive.back)
+
+  return [adaptive, ...base]
+}
+
 function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict = false, options = {}) {
   const r = req.state.ballRadius
+  const cueBallId = resolveCueBallId(req.state)
   const rng = options.rng ?? Math.random
   const balls = ballsOverride || req.state.balls
   const entry = pocketEntry(pocket, r, req.state.width, req.state.height, target)
@@ -453,7 +651,7 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
   ) {
     return null
   }
-  const laneClearance = clearanceMargin(cue, target, balls, [0, target.id], r, 1.3)
+  const laneClearance = clearanceMargin(cue, target, balls, [cueBallId, target.id], r, 1.3)
   if (laneClearance < 0.5) {
     return null
   }
@@ -461,25 +659,40 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
     return null
   }
   if (
-    pathBlocked(cue, ghost, balls, [0, target.id], r, 1.1) ||
-    pathBlocked(target, entry, balls, [0, target.id], r) ||
-    balls.some(b => b.id !== 0 && b.id !== target.id && !b.pocketed && dist(b, entry) < r * 1.1)
+    pathBlocked(cue, ghost, balls, [cueBallId, target.id], r, 1.1) ||
+    pathBlocked(target, entry, balls, [cueBallId, target.id], r) ||
+    balls.some(b => b.id !== cueBallId && b.id !== target.id && !b.pocketed && dist(b, entry) < r * 1.1)
   ) {
     return null
   }
   const maxD = Math.hypot(req.state.width, req.state.height)
-  const potChance = monteCarloPotChance(req, cue, target, entry, ghost, balls, 20, rng)
+  const mcSamples = Number.isFinite(options.mcSamples)
+    ? Math.max(24, Math.round(options.mcSamples))
+    : 20
+  const potChance = monteCarloPotChance(req, cue, target, entry, ghost, balls, mcSamples, rng)
   const cueAfter = estimateCueAfterShot(cue, target, entry, power, spin, req.state)
-  const cueAfterClamped = clampPointToTable(cueAfter, req.state, 1.1)
+  const scratchAfterImpact = scratchRiskAlongLine(target, cueAfter, req.state.pockets || [], r)
+  if (strict && scratchAfterImpact) {
+    return null
+  }
   const nextTargets = nextTargetsAfter(target.id, { ...req, state: { ...req.state, balls } })
   let nextScore = 0
   let hasNext = false
   if (nextTargets.length > 0) {
     hasNext = true
-    const next = nextTargets[0]
-    nextScore = 1 - Math.min(dist(cueAfterClamped, next) / maxD, 1)
+    let bestShape = 0
+    for (const next of nextTargets.slice(0, 4)) {
+      const cueDistanceScore = 1 - Math.min(dist(cueAfter, next) / maxD, 1)
+      let nextPocketAlign = 0
+      for (const nextPocket of req.state.pockets) {
+        nextPocketAlign = Math.max(nextPocketAlign, pocketAlignment(nextPocket, next, req.state.width, req.state.height))
+      }
+      const shape = 0.56 * cueDistanceScore + 0.44 * nextPocketAlign
+      if (shape > bestShape) bestShape = shape
+    }
+    nextScore = bestShape
   }
-  const risk = req.state.pockets.some(p => dist(cueAfterClamped, p) < r * 1.4) ? 1 : 0
+  const risk = req.state.pockets.some(p => dist(cueAfter, p) < r * 1.2) ? 1 : 0
   const shotVec = { x: target.x - cue.x, y: target.y - cue.y }
   const potVec = { x: entry.x - target.x, y: entry.y - target.y }
   let cutAngle = Math.abs(Math.atan2(potVec.y, potVec.x) - Math.atan2(shotVec.y, shotVec.x))
@@ -495,6 +708,10 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
   const cutSeverity = Math.min(cutAngle / (Math.PI / 2), 1)
   const pocketTightness = 1 - pocketOpen
   const difficultyPenalty = 0.25 * (0.5 * cutSeverity + 0.3 * shotLengthFactor + 0.2 * pocketTightness)
+  const spinPenalty =
+    Math.abs(spin.side || 0) * 0.06 +
+    Math.max(0, spin.back || 0) * 0.12 +
+    Math.max(0, spin.top || 0) * 0.04
   const clearanceScore = Math.max(0, Math.min((laneClearance - 0.5) / 0.7, 1))
   if (strict && (centerAlign < 0.5 || pocketOpen < 0.3)) {
     return null
@@ -504,19 +721,21 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
     : LOOKAHEAD_DEPTH
   const runoutPotential = options.skipLookahead
     ? 0
-    : estimateRunoutPotential(req, cueAfterClamped, target.id, balls, lookaheadDepth, rng)
+    : estimateRunoutPotential(req, cueAfter, target.id, balls, lookaheadDepth, rng)
   const quality = Math.max(
     0,
     Math.min(
       1,
-      0.38 * potChance +
-        0.18 * pocketOpen +
-        0.16 * centerAlign +
+      0.41 * potChance +
+        0.15 * pocketOpen +
+        0.13 * centerAlign +
         0.06 * nextScore +
-        0.06 * nearHole +
-        0.08 * runoutPotential +
-        0.08 * clearanceScore -
-        0.18 * risk -
+        0.03 * nearHole +
+        0.14 * runoutPotential +
+        0.12 * clearanceScore -
+        0.21 * risk -
+        (scratchAfterImpact ? 0.2 : 0) -
+        spinPenalty -
         difficultyPenalty
     )
   )
@@ -536,7 +755,8 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
 }
 
 function safetyShot (req) {
-  const cue = req.state.balls.find(b => b.id === 0)
+  const cueBallId = resolveCueBallId(req.state)
+  const cue = req.state.balls.find(b => b.id === cueBallId)
   const corners = [
     { x: 0, y: 0 },
     { x: req.state.width, y: 0 },
@@ -547,7 +767,7 @@ function safetyShot (req) {
   const angle = Math.atan2(target.y - cue.y, target.x - cue.x)
   return {
     angleRad: angle,
-    power: 0.5,
+    power: 0.5 * POWER_SCALE,
     spin: { top: 0, side: 0, back: 0 },
     quality: 0,
     rationale: 'safety'
@@ -555,7 +775,8 @@ function safetyShot (req) {
 }
 
 function fallbackAimAtTarget (req) {
-  const cue = req.state.balls.find(b => b.id === 0)
+  const cueBallId = resolveCueBallId(req.state)
+  const cue = req.state.balls.find(b => b.id === cueBallId)
   const targets = chooseTargets(req)
   if (!cue || targets.length === 0) return null
 
@@ -587,7 +808,7 @@ function fallbackAimAtTarget (req) {
     const angle = Math.atan2(ghost.y - cue.y, ghost.x - cue.x)
     const candidate = {
       angleRad: angle,
-      power: 0.65,
+      power: 0.65 * POWER_SCALE,
       spin: { top: 0, side: 0, back: 0 },
       targetBallId: target.id,
       targetPocket: bestPocket,
@@ -605,39 +826,34 @@ function fallbackAimAtTarget (req) {
   return rest
 }
 
-function buildPowerOptions (req, cuePos, target) {
-  const r = req.state.ballRadius
-  const shotDist = dist(cuePos, target)
-  const base = clamp(shotDist / (r * 32), 0.4, 0.92)
-  const candidates = [
-    base - 0.14,
-    base - 0.06,
-    base,
-    base + 0.08,
-    base + 0.18
-  ].map(value => clamp(value, 0.35, 0.98))
-  return Array.from(new Set(candidates.map(v => Number(v.toFixed(3)))))
-}
-
 /**
  * @param {AimRequest} req
  * @returns {ShotDecision}
  */
 export function planShot (req) {
+  req = normaliseAimRequest(req)
   const r = req.state.ballRadius
+  const cueBallId = resolveCueBallId(req.state)
   const start = Date.now()
   const deadline = req.timeBudgetMs ? start + req.timeBudgetMs : Infinity
+  const thinkingBudget = Number.isFinite(req.timeBudgetMs) ? Math.max(120, req.timeBudgetMs) : 700
+  const budgetScale = Math.min(2.4, Math.max(0.7, thinkingBudget / 700))
+  const lookaheadDepth = Math.max(4, Math.min(8, Math.round(LOOKAHEAD_DEPTH * budgetScale)))
+  const mcSamples = Math.max(48, Math.min(220, Math.round(MONTE_CARLO_BASE_SAMPLES * budgetScale)))
   const rng = Number.isFinite(req.rngSeed) ? createRng(req.rngSeed) : Math.random
   let best = null
   let fallback = null
   let hasViableShot = false
 
-  const spins = [
+  const powers = req.state?.breakInProgress
+    ? [1 * POWER_SCALE]
+    : [0.48 * POWER_SCALE, 0.66 * POWER_SCALE, 0.82 * POWER_SCALE, 0.94 * POWER_SCALE]
+  const defaultSpins = [
     { top: 0, side: 0, back: 0 },
-    { top: 0.2, side: 0, back: -0.2 },
-    { top: -0.2, side: 0, back: 0 },
-    { top: 0, side: 0.18, back: 0 },
-    { top: 0, side: -0.18, back: 0 }
+    { top: 0.3, side: 0, back: 0 },
+    { top: 0, side: 0, back: 0.3 },
+    { top: 0.2, side: 0.3, back: 0 },
+    { top: 0.2, side: -0.3, back: 0 }
   ]
 
   // first, gather candidate target/pocket pairs meeting strict criteria
@@ -685,33 +901,31 @@ export function planShot (req) {
             continue
           }
           const overlap = req.state.balls.some(
-            b => b.id !== 0 && !b.pocketed && dist(cand, b) < r * 2
+            b => b.id !== cueBallId && !b.pocketed && dist(cand, b) < r * 2
           )
           if (overlap) continue
           placements.push(cand)
         }
       } else {
-        const cue = req.state.balls.find(b => b.id === 0)
+        const cue = req.state.balls.find(b => b.id === cueBallId)
         placements.push({ x: cue.x, y: cue.y })
       }
 
       for (const cuePos of placements) {
         const balls = req.state.balls.map(b =>
-          b.id === 0 ? { ...b, x: cuePos.x, y: cuePos.y } : b
+          b.id === cueBallId ? { ...b, x: cuePos.x, y: cuePos.y } : b
         )
 
-        const powers = buildPowerOptions(req, cuePos, target)
-        const basePower = powers[Math.floor(powers.length / 2)] ?? powers[0]
         const baseCand = evaluate(
           req,
           cuePos,
           target,
           pocket,
-          basePower,
-          spins[0],
+          powers[0],
+          defaultSpins[0],
           balls,
           strict,
-          { lookaheadDepth: LOOKAHEAD_DEPTH, rng }
+          { lookaheadDepth, mcSamples, rng }
         )
         if (baseCand) {
           hasViableShot = true
@@ -720,14 +934,15 @@ export function planShot (req) {
             best = { ...rest, cueBallPosition: req.state.ballInHand ? cuePos : undefined }
           }
           // Only explore additional power/spin if next position is poor and there is a next target
-          if (!hasNext || nextScore >= 0.5) {
+          if (!hasNext || nextScore >= 0.72) {
             continue
           }
         }
 
+        const spins = buildSpinCandidates(cuePos, target, pocket, req)
         for (const power of powers) {
-          for (const spin of spins) {
-            if (power === basePower && spin === spins[0]) continue
+          for (const spin of spins.concat(defaultSpins)) {
+            if (power === powers[0] && spin === spins[0]) continue
             if (Date.now() > deadline) {
               return best && best.quality >= 0.1 ? best : fallbackAimAtTarget(req) || safetyShot(req)
             }
@@ -740,7 +955,7 @@ export function planShot (req) {
               spin,
               balls,
               strict,
-              { lookaheadDepth: LOOKAHEAD_DEPTH, rng }
+              { lookaheadDepth, mcSamples, rng }
             )
             if (cand) {
               hasViableShot = true
@@ -757,6 +972,11 @@ export function planShot (req) {
   }
 
   if (best) {
+    const suggestion = findSuggestedTarget(req, best.targetBallId)
+    if (suggestion) {
+      best.suggestedTargetBallId = suggestion.suggestedTargetBallId
+      best.suggestedAimPoint = suggestion.suggestedAimPoint
+    }
     if (best.quality >= 0.1) return best
     if (hasViableShot) return best
   }

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1757,7 +1757,7 @@ const POCKET_VIEW_POST_POT_HOLD_MS =
   POCKET_DROP_RING_HOLD_MS + POCKET_DROP_REST_HOLD_MS;
 const POCKET_VIEW_MAX_HOLD_MS = 2200;
 const POCKET_VIEW_EARLY_HOLD_MS = 320;
-const SPIN_GLOBAL_SCALE = 0.9; // increase overall spin effect by 25% versus the previous 0.72 tuning
+const SPIN_GLOBAL_SCALE = 0.98; // slightly stronger global spin so english/follow/draw feel closer to real-table response
 // Spin controller adapted from the open-source Billiards solver physics (MIT License).
 const SPIN_TABLE_REFERENCE_WIDTH = 2.627;
 const SPIN_TABLE_REFERENCE_HEIGHT = 1.07707;
@@ -1914,10 +1914,10 @@ const MAX_SPIN_VISUAL_LIFT = MAX_SPIN_VERTICAL; // cap vertical spin offsets so 
 const SPIN_RING_RATIO = 1;
 const SPIN_CLEARANCE_MARGIN = BALL_R * 0.4;
 const SPIN_TIP_MARGIN = CUE_TIP_RADIUS * 1.35;
-const SPIN_GLOBAL_BOOST_MULTIPLIER = 1.2;
-const SIDE_SPIN_MULTIPLIER = 1.5 * SPIN_GLOBAL_BOOST_MULTIPLIER;
-const BACKSPIN_MULTIPLIER = 2.6 * SPIN_GLOBAL_BOOST_MULTIPLIER;
-const TOPSPIN_MULTIPLIER = 1.62 * SPIN_GLOBAL_BOOST_MULTIPLIER;
+const SPIN_GLOBAL_BOOST_MULTIPLIER = 1.28;
+const SIDE_SPIN_MULTIPLIER = 1.56 * SPIN_GLOBAL_BOOST_MULTIPLIER;
+const BACKSPIN_MULTIPLIER = 2.72 * SPIN_GLOBAL_BOOST_MULTIPLIER;
+const TOPSPIN_MULTIPLIER = 1.74 * SPIN_GLOBAL_BOOST_MULTIPLIER;
 const CUE_CLEARANCE_PADDING = BALL_R * 0.05;
 const SPIN_CONTROL_DIAMETER_PX = 124;
 const SPIN_DOT_DIAMETER_PX = 16;
@@ -26923,6 +26923,33 @@ const powerRef = useRef(hud.power);
             ? frameSnapshot.ballOn[0]
             : frameSnapshot?.ballOn ?? null;
           const normalizedBallOn = normalizeAiGroup(rawBallOn);
+          const rawBallOnList = Array.isArray(frameSnapshot?.ballOn)
+            ? frameSnapshot.ballOn
+            : rawBallOn != null
+              ? [rawBallOn]
+              : [];
+          const parseBallIdFromToken = (value) => {
+            if (typeof value === 'number' && Number.isFinite(value)) {
+              return Number(value);
+            }
+            if (typeof value !== 'string') return null;
+            const normalized = value.trim().toUpperCase();
+            const direct = /^BALL_(\d+)$/.exec(normalized);
+            if (direct) return Number.parseInt(direct[1], 10);
+            const plain = /^(\d+)$/.exec(normalized);
+            if (plain) return Number.parseInt(plain[1], 10);
+            if (normalized === 'BLACK') return 8;
+            return null;
+          };
+          const legalBallIds = Array.from(
+            new Set(
+              rawBallOnList
+                .map((entry) => parseBallIdFromToken(entry))
+                .filter((id) => Number.isFinite(id))
+            )
+          );
+          const preferredTargetBallId =
+            legalBallIds.length === 1 ? legalBallIds[0] : null;
           const aiState = {
             balls: aiBalls,
             pockets,
@@ -26934,6 +26961,8 @@ const powerRef = useRef(hud.power);
             ballInHand: Boolean(metaState?.ballInHand),
             myGroup: normalizedAssignment,
             ballOn: normalizedBallOn ?? null,
+            preferredTargetBallId,
+            legalBallIds,
             breakInProgress: Boolean(metaState?.breakInProgress)
           };
           const decision = planShot({
@@ -29258,7 +29287,8 @@ const powerRef = useRef(hud.power);
           }
           const start = new THREE.Vector3(cue.pos.x, BALL_CENTER_Y, cue.pos.y);
           let end = new THREE.Vector3(impact.x, BALL_CENTER_Y, impact.y);
-          const dir = baseAimDir.clone();
+          const guideDir3 = new THREE.Vector3(guideAimDir2D.x, 0, guideAimDir2D.y);
+          const dir = guideDir3.lengthSq() > 1e-8 ? guideDir3.normalize() : baseAimDir.clone();
           if (start.distanceTo(end) < 1e-4) {
             end = start.clone().add(dir.clone().multiplyScalar(BALL_R));
           }
@@ -29615,8 +29645,6 @@ const powerRef = useRef(hud.power);
             remoteAimDir.normalize();
           }
           const baseDir = new THREE.Vector3(remoteAimDir.x, 0, remoteAimDir.y);
-          const perp = new THREE.Vector3(-baseDir.z, 0, baseDir.x);
-          if (perp.lengthSq() > 1e-8) perp.normalize();
           const powerStrength = THREE.MathUtils.clamp(remoteAimState?.power ?? 0, 0, 1);
           const remoteSpin = remoteAimState?.spin ?? { x: 0, y: 0 };
           const remoteSpinNormalized = normalizeSpinInput(remoteSpin);
@@ -29652,15 +29680,19 @@ const powerRef = useRef(hud.power);
           }
           const start = new THREE.Vector3(cue.pos.x, BALL_CENTER_Y, cue.pos.y);
           let end = new THREE.Vector3(impact.x, BALL_CENTER_Y, impact.y);
+          const remoteGuideDir3 = new THREE.Vector3(guideAimDir2D.x, 0, guideAimDir2D.y);
+          const remoteGuideDir = remoteGuideDir3.lengthSq() > 1e-8 ? remoteGuideDir3.normalize() : baseDir.clone();
+          const perp = new THREE.Vector3(-remoteGuideDir.z, 0, remoteGuideDir.x);
+          if (perp.lengthSq() > 1e-8) perp.normalize();
           if (start.distanceTo(end) < 1e-4) {
-            end = start.clone().add(baseDir.clone().multiplyScalar(BALL_R));
+            end = start.clone().add(remoteGuideDir.clone().multiplyScalar(BALL_R));
           }
           const aimPoints = buildSwerveAimLinePoints(
             aimCurvePointsRef.current,
             aimCurveControlRef.current,
             start,
             end,
-            baseDir,
+            remoteGuideDir,
             perp,
             aimPreviewSpin,
             powerStrength,
@@ -29689,7 +29721,7 @@ const powerRef = useRef(hud.power);
             : baseDir.clone();
           const cueFollowPreview = resolveCueFollowPreview({
             cueDir: cueFollowDir,
-            aimDir: baseDir,
+            aimDir: remoteGuideDir,
             spin: aimPreviewSpin,
             powerStrength,
             cuePowerStrength,
@@ -29721,7 +29753,7 @@ const powerRef = useRef(hud.power);
               powerStrength
             ).pullSmoothing
           });
-          const visualPull = applyVisualPullCompensation(pull, baseDir);
+          const visualPull = applyVisualPullCompensation(pull, remoteGuideDir);
           const spinX = THREE.MathUtils.clamp(remoteAimState?.spin?.x ?? 0, -1, 1);
           const spinY = THREE.MathUtils.clamp(remoteAimState?.spin?.y ?? 0, -1, 1);
           const { side, vert, hasSpin } = computeSpinOffsets(
@@ -29731,7 +29763,7 @@ const powerRef = useRef(hud.power);
           const spinWorld = new THREE.Vector3(perp.x * side, vert, perp.z * side);
           clampCueTipOffset(spinWorld);
           const obstructionStrength = resolveCueObstruction(
-            baseDir,
+            remoteGuideDir,
             pull,
             activeRenderCameraRef.current ?? cameraRef.current ?? camera,
             spinWorld
@@ -29740,7 +29772,7 @@ const powerRef = useRef(hud.power);
             resolveCueObstructionTilt(obstructionStrength);
           const tiltAmount = hasSpin ? Math.abs(spinY) : 0;
           const extraTilt = MAX_BACKSPIN_TILT * Math.min(tiltAmount, 1);
-          cueStick.rotation.y = Math.atan2(baseDir.x, baseDir.z) + Math.PI;
+          cueStick.rotation.y = Math.atan2(remoteGuideDir.x, remoteGuideDir.z) + Math.PI;
           applyCueButtTilt(
             cueStick,
             extraTilt + obstructionTilt + obstructionTiltFromLift
@@ -29748,7 +29780,7 @@ const powerRef = useRef(hud.power);
           if (tipGroupRef.current) {
             tipGroupRef.current.position.set(0, 0, -cueLen / 2);
           }
-          const tipTarget = resolveCueTipTarget(baseDir, visualPull, spinWorld);
+          const tipTarget = resolveCueTipTarget(remoteGuideDir, visualPull, spinWorld);
           applyCueObstructionLift(tipTarget, obstructionLift);
           applyCueStickTransform(tipTarget);
           clampCueButtAboveCushion(tipTarget);


### PR DESCRIPTION
### Motivation
- Improve realism and robustness of the billiards AI by refining cue-ball aftermath physics, pot-probability estimation, and spin/power tuning.
- Allow rule-driven target restriction and UI suggestions via explicit legal/preferred target IDs so the AI respects game state and can propose alternate shots.
- Reduce false positives from hard-coded id==0 assumptions and normalize ball identification from varied input formats.

### Description
- Add request normalization and id resolution (`resolveBallId`, `inferIdFromColour`, `resolveCueBallId`, `normaliseAimRequest`) and replace hard-coded cue-ball `id === 0` checks with the resolved `cueBallId` across AI logic.
- Introduce `legalBallIds` and `preferredTargetBallId` in `AimRequest.state` and enforce them in `chooseTargets`, `nextTargetsAfter`, and candidate generation to support rule-restricted play and UI preferences.
- Replace simple post-impact estimate with a more realistic `estimateCueAfterShot` model (stun, follow/draw layers, side-spin offset, cut severity) and tune spin/power scales via `POWER_SCALE` and updated spin multipliers.
- Increase lookahead and Monte Carlo fidelity (`LOOKAHEAD_CANDIDATES`, `MONTE_CARLO_BASE_SAMPLES`) and reduce jitter to tighten pot-chance estimation; add adaptive MC sampling (`mcSamples`) and jitter scaling changes in `monteCarloPotChance`.
- Add helper functions `ghostPointForTargetPocket` and `findSuggestedTarget` to produce optional suggested follow-up target and aim point in the decision; return `suggestedTargetBallId`/`suggestedAimPoint` in shot decisions when applicable.
- Rework shot candidate scoring and thresholds (`clearShotCandidates`, `evaluate`) including adjustments to view/cut thresholds, spin/difficulty penalties, runout weighting, scratch handling, lane clearance and risk scoring.
- Add `buildSpinCandidates` to generate adaptive spin candidates for position play and broaden power/spin candidate sets used by `planShot` while honoring `ballInHand` placements.
- Mirror AI changes into the public web bundle and update `PoolRoyale.jsx` to parse `ballOn` tokens into `legalBallIds`/`preferredTargetBallId`, pass `cueBallId`, and fix several aim/guide vector usages and visual aim calculations; also adjust pool-specific spin/power tuning constants.

### Testing
- Ran the project's automated unit test suite via `yarn test`, which completed successfully. 
- Built the web frontend with `yarn build`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7ac388a74832985960e34ad8c3472)