### PR TITLE
Improve Domino Royal tile fidelity with 4K textures and higher mesh detail

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -89,6 +89,8 @@ const MURLAN_3D_ASSET_RESOLUTION = Object.freeze({
   chairClothTextureSize: 2048,
   dominoTextureSize: 4096
 });
+const DOMINO_PIECE_TEXTURE_TARGET_SIZE = 4096;
+const DOMINO_PIECE_TEXTURE_MIN_SIZE = 2048;
 
 const FRAME_RATE_TEXTURE_SIZE_MAP = Object.freeze({
   hd50: 1024,
@@ -6380,7 +6382,7 @@ function getChainSpacing(
 
 /* ---------- Materials ---------- */
 const SHARED_DOMINO_MATERIALS = new Set();
-const DOMINO_BODY_SEGMENTS = 12;
+const DOMINO_BODY_SEGMENTS = 24;
 const DOMINO_PIP_SEGMENTS = 48;
 const DOMINO_PIP_RING_SEGMENTS = 96;
 const SHARED_DOMINO_PIP_GEOMETRY = new THREE.SphereGeometry(
@@ -6507,9 +6509,12 @@ const getDominoSurfaceTextures = (() => {
     cache = null;
   };
   return () => {
-    const targetSize = 4096;
+    const targetSize = DOMINO_PIECE_TEXTURE_TARGET_SIZE;
     const sizeCap = getRendererTextureSizeCap();
-    const preferredSize = Math.max(2048, Math.min(sizeCap, targetSize));
+    const preferredSize = Math.max(
+      DOMINO_PIECE_TEXTURE_MIN_SIZE,
+      Math.min(sizeCap, targetSize)
+    );
     if (cache && cachedPreferredSize === preferredSize) return cache;
     if (typeof document === 'undefined') {
       cache = { porcelainMap: null, porcelainRoughness: null, pipMap: null };
@@ -6519,12 +6524,18 @@ const getDominoSurfaceTextures = (() => {
     let size = preferredSize;
     let porcelainCanvas = document.createElement('canvas');
     porcelainCanvas.width = porcelainCanvas.height = size;
-    let pctx = porcelainCanvas.getContext('2d', { willReadFrequently: true });
-    while (!pctx && size > 1024) {
-      size = Math.max(1024, Math.floor(size / 2));
+    let pctx = porcelainCanvas.getContext('2d');
+    if (!pctx) {
+      pctx = porcelainCanvas.getContext('2d', { willReadFrequently: true });
+    }
+    while (!pctx && size > DOMINO_PIECE_TEXTURE_MIN_SIZE) {
+      size = Math.max(DOMINO_PIECE_TEXTURE_MIN_SIZE, Math.floor(size / 2));
       porcelainCanvas = document.createElement('canvas');
       porcelainCanvas.width = porcelainCanvas.height = size;
-      pctx = porcelainCanvas.getContext('2d', { willReadFrequently: true });
+      pctx = porcelainCanvas.getContext('2d');
+      if (!pctx) {
+        pctx = porcelainCanvas.getContext('2d', { willReadFrequently: true });
+      }
     }
     if (!pctx) {
       cache = { porcelainMap: null, porcelainRoughness: null, pipMap: null };


### PR DESCRIPTION
### Motivation
- Domino pieces appeared low-resolution due to both coarse mesh tessellation and runtime texture fallbacks that could downscale generated canvases too aggressively. 
- The change aims to keep procedural domino textures at a 4K target when supported, with a safer 2K floor to avoid blurry tiles on capable devices. 
- Canvas context acquisition was fragile in some runtimes, causing unexpected downscaling; improving context handling reduces those fallbacks.

### Description
- Added `DOMINO_PIECE_TEXTURE_TARGET_SIZE` (4096) and `DOMINO_PIECE_TEXTURE_MIN_SIZE` (2048) constants and switched the domino surface texture generator to use them instead of an unconstrained value (file: `webapp/public/domino-royal-game.js`).
- Raised rounded domino body tessellation by changing `DOMINO_BODY_SEGMENTS` from `12` to `24` to reduce visible faceting on close-up pieces.
- Updated `getDominoSurfaceTextures()` to compute `preferredSize` using the new constants and the renderer texture cap so textures prefer 4K but will not drop below 2K when possible.
- Improved 2D canvas context acquisition by trying a plain `getContext('2d')` first, then falling back to `getContext('2d', { willReadFrequently: true })`, and only halving the canvas size down to the defined minimum instead of 1024.

### Testing
- Ran a syntax/parse check with `node --check webapp/public/domino-royal-game.js`, which completed successfully. 
- No automated rendering/visual regression tests were available in this environment, so visual verification should be performed in a browser/device test pass to confirm improved piece fidelity.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7d0d5a6588329a4dc8e47a7757d7d)