### PR TITLE
Improve Domino Royal tile texture quality to 4K

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -99,7 +99,7 @@ const FRAME_RATE_TEXTURE_SIZE_MAP = Object.freeze({
 });
 
 const DOMINO_TEXTURE_SIZE_MAP = Object.freeze({
-  hd50: 3072,
+  hd50: 4096,
   fhd60: 4096,
   qhd90: 4096,
   uhd120: 4096,
@@ -6507,7 +6507,7 @@ const getDominoSurfaceTextures = (() => {
     cache = null;
   };
   return () => {
-    const targetSize = 4096;
+    const targetSize = getAdaptiveDominoTextureSize(4096);
     const sizeCap = getRendererTextureSizeCap();
     const preferredSize = Math.max(2048, Math.min(sizeCap, targetSize));
     if (cache && cachedPreferredSize === preferredSize) return cache;
@@ -6578,15 +6578,21 @@ const getDominoSurfaceTextures = (() => {
     porcelainMap.colorSpace = THREE.SRGBColorSpace;
     porcelainMap.anisotropy = Math.min(maxAnisotropy, 16);
     porcelainMap.generateMipmaps = true;
+    porcelainMap.minFilter = THREE.LinearMipmapLinearFilter;
+    porcelainMap.magFilter = THREE.LinearFilter;
 
     const porcelainRoughness = new THREE.CanvasTexture(roughCanvas);
     porcelainRoughness.anisotropy = Math.min(maxAnisotropy, 8);
     porcelainRoughness.generateMipmaps = true;
+    porcelainRoughness.minFilter = THREE.LinearMipmapLinearFilter;
+    porcelainRoughness.magFilter = THREE.LinearFilter;
 
     const pipMap = new THREE.CanvasTexture(pipCanvas);
     pipMap.colorSpace = THREE.SRGBColorSpace;
     pipMap.anisotropy = Math.min(maxAnisotropy, 16);
     pipMap.generateMipmaps = true;
+    pipMap.minFilter = THREE.LinearMipmapLinearFilter;
+    pipMap.magFilter = THREE.LinearFilter;
 
     cache = { porcelainMap, porcelainRoughness, pipMap };
     cachedPreferredSize = preferredSize;

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-03-28-4k-domino-v2';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-03-28-4k-domino-v3';
 
 export default function DominoRoyalArena() {
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- Domino pieces rendered with low effective resolution due to quality preset caps and texture-generation path, producing blurry/low-detail pips and porcelain surfaces.
- Ensure domino tiles use a 4K target where possible and that sampling/filtering is explicit so detail remains crisp at glancing angles and high DPI devices.
- Force clients to fetch the updated runtime so the fix reaches players immediately.

### Description
- Increased the `DOMINO_TEXTURE_SIZE_MAP` so all presets request `4096` for domino textures (file: `webapp/public/domino-royal-game.js`).
- Wired `getDominoSurfaceTextures` to use the adaptive domino texture size resolver via `getAdaptiveDominoTextureSize(4096)` so generated canvases request the high-res path (file: `webapp/public/domino-royal-game.js`).
- Explicitly set mipmap filtering on generated domino textures with `minFilter = THREE.LinearMipmapLinearFilter` and `magFilter = THREE.LinearFilter` for porcelain, roughness and pip maps (file: `webapp/public/domino-royal-game.js`).
- Bumped the Domino Royal script cache/version string to `2026-03-28-4k-domino-v3` so clients will fetch the new script (file: `webapp/src/pages/Games/DominoRoyalArena.jsx`).

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` which completed successfully.
- Ran `npm --prefix webapp run build` which completed successfully (Vite build produced the app; unrelated chunk-size warnings were reported but do not affect this texture fix).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7d0d5a6588329a4dc8e47a7757d7d)