### PR TITLE
Improve Pool Royale AI targeting, replay camera dynamics, and cue/topspin realism

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -148,6 +148,31 @@ function pocketAlignment (pocket, target, width, height) {
   return Math.max(0, (approach.x / len) * normal.x + (approach.y / len) * normal.y)
 }
 
+function pocketEntranceOpenness (target, pocket, req) {
+  if (!target || !pocket || !req?.state) return 0
+  const r = req.state.ballRadius
+  const entry = pocketEntry(pocket, r, req.state.width, req.state.height, target)
+  const laneLen = Math.max(dist(target, entry), r * 2)
+  const laneDir = { x: (entry.x - target.x) / laneLen, y: (entry.y - target.y) / laneLen }
+  let minEdge = Infinity
+  for (const b of req.state.balls || []) {
+    if (!b || b.pocketed || b.id === target.id) continue
+    const relX = b.x - target.x
+    const relY = b.y - target.y
+    const along = relX * laneDir.x + relY * laneDir.y
+    if (along <= 0 || along >= laneLen + r * 1.8) continue
+    const lateral = Math.abs(relX * laneDir.y - relY * laneDir.x)
+    const edgeGap = lateral - r * 2
+    if (edgeGap < minEdge) minEdge = edgeGap
+  }
+  const clearance = Number.isFinite(minEdge)
+    ? Math.max(0, Math.min((minEdge + r * 0.9) / (r * 2.2), 1))
+    : 1
+  const alignment = pocketAlignment(pocket, target, req.state.width, req.state.height)
+  const straightness = Math.max(0, Math.min((alignment - 0.2) / 0.8, 1))
+  return Math.min(1, clearance * 0.65 + straightness * 0.35)
+}
+
 function ghostPointForTargetPocket (target, pocket, req) {
   const r = req.state.ballRadius
   const entry = pocketEntry(pocket, r, req.state.width, req.state.height, target)
@@ -416,18 +441,20 @@ function clearShotCandidates (req) {
       const viewScore = Math.min(viewAngle / (Math.PI / 2), 1)
       const entryAlignment = pocketAlignment(pocket, target, req.state.width, req.state.height)
       const weightedView = viewScore * (0.7 + 0.3 * entryAlignment)
+      const entranceOpenness = pocketEntranceOpenness(target, pocket, req)
+      const pocketView = weightedView * (0.68 + 0.32 * entranceOpenness)
       const approachStraightness = 1 - Math.min(cut / (Math.PI / 2), 1)
       const cueToTarget = cue ? dist(cue, target) : 0
       const distanceScore = cue ? Math.max(0, 1 - cueToTarget / (r * 60)) : 0
       const rank =
-        weightedView * 0.46 +
-        approachStraightness * 0.25 +
-        distanceScore * 0.12 +
-        Math.max(0, 1 - cut / (Math.PI / 3.4)) * 0.17
+        pocketView * 0.5 +
+        approachStraightness * 0.3 +
+        distanceScore * 0.08 +
+        entranceOpenness * 0.12
 
       // require fairly central hit and open pocket view
-      if (cut <= maxCut && weightedView >= minView) {
-        candidates.push({ target, pocket, cut, view: weightedView, rank })
+      if (cut <= maxCut && pocketView >= minView) {
+        candidates.push({ target, pocket, cut, view: pocketView, rank })
       }
     }
   }
@@ -472,7 +499,8 @@ export function estimateCueAfterShot (cue, target, pocket, power, spin, table) {
 
   const cutDot = Math.max(-1, Math.min(1, shotDir.x * objectDir.x + shotDir.y * objectDir.y))
   const cutSeverity = Math.sqrt(Math.max(0, 1 - cutDot * cutDot))
-  const baseTravel = Math.max(table.ballRadius * 3, power * table.ballRadius * (18 - 3.6 * cutSeverity))
+  const tableRadius = Number.isFinite(table?.ballRadius) ? table.ballRadius : 10
+  const baseTravel = Math.max(tableRadius * 3, power * tableRadius * (18 - 3.6 * cutSeverity))
 
   // Stun component (natural tangent line), then follow/draw layered on top.
   const followAmount = Math.max(0, spin.top || 0)
@@ -850,7 +878,7 @@ export function planShot (req) {
 
   const powers = req.state?.breakInProgress
     ? [1 * POWER_SCALE]
-    : [0.48 * POWER_SCALE, 0.66 * POWER_SCALE, 0.82 * POWER_SCALE, 0.94 * POWER_SCALE]
+    : [0.5 * POWER_SCALE, 0.66 * POWER_SCALE, 0.82 * POWER_SCALE, 0.94 * POWER_SCALE]
   const defaultSpins = [
     { top: 0, side: 0, back: 0 },
     { top: 0.3, side: 0, back: 0 },

--- a/test/poolAi.test.js
+++ b/test/poolAi.test.js
@@ -382,3 +382,32 @@ test('uses hidden helper numbers/colours when ids are missing', () => {
   const decision = planShot(req)
   assert.equal(decision.targetBallId, 3)
 })
+
+test('prioritises clearer pocket entrance when one lane is cluttered', () => {
+  const decision = planShot({
+    game: 'AMERICAN_BILLIARDS',
+    state: {
+      balls: [
+        { id: 0, x: 260, y: 250, vx: 0, vy: 0, pocketed: false },
+        { id: 1, x: 500, y: 250, vx: 0, vy: 0, pocketed: false },
+        // blocker near the top pocket entrance lane
+        { id: 12, x: 500, y: 74, vx: 0, vy: 0, pocketed: false }
+      ],
+      pockets: [
+        { x: 500, y: 0 },
+        { x: 500, y: 500 }
+      ],
+      width: 1000,
+      height: 500,
+      ballRadius: 10,
+      friction: 0.01,
+      legalBallIds: [1]
+    },
+    timeBudgetMs: 120,
+    rngSeed: 11
+  });
+
+  assert.equal(decision.targetBallId, 1);
+  assert(decision.targetPocket);
+  assert(decision.targetPocket.y > 300, 'should prefer the clearer bottom-pocket lane');
+});

--- a/webapp/public/lib/poolAi.js
+++ b/webapp/public/lib/poolAi.js
@@ -148,6 +148,31 @@ function pocketAlignment (pocket, target, width, height) {
   return Math.max(0, (approach.x / len) * normal.x + (approach.y / len) * normal.y)
 }
 
+function pocketEntranceOpenness (target, pocket, req) {
+  if (!target || !pocket || !req?.state) return 0
+  const r = req.state.ballRadius
+  const entry = pocketEntry(pocket, r, req.state.width, req.state.height, target)
+  const laneLen = Math.max(dist(target, entry), r * 2)
+  const laneDir = { x: (entry.x - target.x) / laneLen, y: (entry.y - target.y) / laneLen }
+  let minEdge = Infinity
+  for (const b of req.state.balls || []) {
+    if (!b || b.pocketed || b.id === target.id) continue
+    const relX = b.x - target.x
+    const relY = b.y - target.y
+    const along = relX * laneDir.x + relY * laneDir.y
+    if (along <= 0 || along >= laneLen + r * 1.8) continue
+    const lateral = Math.abs(relX * laneDir.y - relY * laneDir.x)
+    const edgeGap = lateral - r * 2
+    if (edgeGap < minEdge) minEdge = edgeGap
+  }
+  const clearance = Number.isFinite(minEdge)
+    ? Math.max(0, Math.min((minEdge + r * 0.9) / (r * 2.2), 1))
+    : 1
+  const alignment = pocketAlignment(pocket, target, req.state.width, req.state.height)
+  const straightness = Math.max(0, Math.min((alignment - 0.2) / 0.8, 1))
+  return Math.min(1, clearance * 0.65 + straightness * 0.35)
+}
+
 function ghostPointForTargetPocket (target, pocket, req) {
   const r = req.state.ballRadius
   const entry = pocketEntry(pocket, r, req.state.width, req.state.height, target)
@@ -416,18 +441,20 @@ function clearShotCandidates (req) {
       const viewScore = Math.min(viewAngle / (Math.PI / 2), 1)
       const entryAlignment = pocketAlignment(pocket, target, req.state.width, req.state.height)
       const weightedView = viewScore * (0.7 + 0.3 * entryAlignment)
+      const entranceOpenness = pocketEntranceOpenness(target, pocket, req)
+      const pocketView = weightedView * (0.68 + 0.32 * entranceOpenness)
       const approachStraightness = 1 - Math.min(cut / (Math.PI / 2), 1)
       const cueToTarget = cue ? dist(cue, target) : 0
       const distanceScore = cue ? Math.max(0, 1 - cueToTarget / (r * 60)) : 0
       const rank =
-        weightedView * 0.46 +
-        approachStraightness * 0.25 +
-        distanceScore * 0.12 +
-        Math.max(0, 1 - cut / (Math.PI / 3.4)) * 0.17
+        pocketView * 0.5 +
+        approachStraightness * 0.3 +
+        distanceScore * 0.08 +
+        entranceOpenness * 0.12
 
       // require fairly central hit and open pocket view
-      if (cut <= maxCut && weightedView >= minView) {
-        candidates.push({ target, pocket, cut, view: weightedView, rank })
+      if (cut <= maxCut && pocketView >= minView) {
+        candidates.push({ target, pocket, cut, view: pocketView, rank })
       }
     }
   }
@@ -472,7 +499,8 @@ export function estimateCueAfterShot (cue, target, pocket, power, spin, table) {
 
   const cutDot = Math.max(-1, Math.min(1, shotDir.x * objectDir.x + shotDir.y * objectDir.y))
   const cutSeverity = Math.sqrt(Math.max(0, 1 - cutDot * cutDot))
-  const baseTravel = Math.max(table.ballRadius * 3, power * table.ballRadius * (18 - 3.6 * cutSeverity))
+  const tableRadius = Number.isFinite(table?.ballRadius) ? table.ballRadius : 10
+  const baseTravel = Math.max(tableRadius * 3, power * tableRadius * (18 - 3.6 * cutSeverity))
 
   // Stun component (natural tangent line), then follow/draw layered on top.
   const followAmount = Math.max(0, spin.top || 0)
@@ -850,7 +878,7 @@ export function planShot (req) {
 
   const powers = req.state?.breakInProgress
     ? [1 * POWER_SCALE]
-    : [0.48 * POWER_SCALE, 0.66 * POWER_SCALE, 0.82 * POWER_SCALE, 0.94 * POWER_SCALE]
+    : [0.5 * POWER_SCALE, 0.66 * POWER_SCALE, 0.82 * POWER_SCALE, 0.94 * POWER_SCALE]
   const defaultSpins = [
     { top: 0, side: 0, back: 0 },
     { top: 0.3, side: 0, back: 0 },

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1233,7 +1233,7 @@ const TABLE_MAPPING_VISUALS = Object.freeze({
 });
 const LOCK_REPLAY_CAMERA = false;
 const FIXED_RAIL_REPLAY_CAMERA = false;
-const LOCK_RAIL_OVERHEAD_FRAME = true;
+const LOCK_RAIL_OVERHEAD_FRAME = false;
 const REPLAY_CUE_STICK_HOLD_MS = 760;
 const REPLAY_CAMERA_START_DELAY_MS = 0;
   const TABLE_BASE_SCALE = 1.2;
@@ -5914,6 +5914,8 @@ const DEFAULT_SPIN_LIMITS = Object.freeze({
   maxY: 1
 });
 const MAX_TOPSPIN_INPUT = 0.8; // reduce topspin cap to match Snooker Royal feel
+const TOPSPIN_FOLLOW_TRANSFER_RATE = 0.38; // transfer a portion of top spin into forward roll each physics step for natural follow-through fade
+const TOPSPIN_FOLLOW_DECAY_ASSIST = 0.54; // accelerate only top-spin decay once forward roll is established so follow naturally settles
 const TOPSPIN_POWER_SOFT_CAP = 0.9;
 const clampSpinValue = (value) => clamp(value, -1, 1);
 const SPIN_CUSHION_EPS = BALL_R * 0.6;
@@ -6976,6 +6978,20 @@ function applySpinController(ball, stepScale, airborne = false) {
     }
     if (Math.abs(forwardSpin) > 1e-8) {
       ball.vel.addScaledVector(forward, forwardSpin * rollAccel);
+      if (forwardSpin > 0) {
+        const naturalRollSpeed = Math.max(BALL_R * 2.2, speed * 0.78);
+        const settling = THREE.MathUtils.clamp(speed / Math.max(naturalRollSpeed, 1e-6), 0, 1);
+        const transfer =
+          Math.min(
+            forwardSpin,
+            rollAccel * TOPSPIN_FOLLOW_TRANSFER_RATE * (0.35 + settling * 0.65)
+          );
+        ball.spin.y = Math.max(0, forwardSpin - transfer);
+        const assistedDecay = Math.exp(
+          -TOPSPIN_FOLLOW_DECAY_ASSIST * stepScale * (0.3 + 0.7 * settling)
+        );
+        ball.spin.y *= assistedDecay;
+      }
     }
   }
   return decaySpin(ball, stepScale, airborne);
@@ -15265,6 +15281,7 @@ const powerRef = useRef(hud.power);
   const lastCameraTargetRef = useRef(new THREE.Vector3(0, ORBIT_FOCUS_BASE_Y, 0));
   const replayCameraRef = useRef(null);
   const replayFrameCameraRef = useRef(null);
+  const replayCueHiddenRef = useRef({ hideFrom: Infinity, hideUntil: -Infinity });
   const updateSpinDotPosition = useCallback((value, blocked) => {
     if (!value) value = { x: 0, y: 0 };
     const dot = spinDotElRef.current;
@@ -21411,6 +21428,16 @@ const powerRef = useRef(hud.power);
               if (meshB.visible != null) {
                 ball.mesh.visible = meshB.visible;
               }
+              if (ball.id === 'cue' && replayPlaybackRef.current) {
+                const hidden = replayCueHiddenRef.current;
+                if (
+                  hidden &&
+                  targetTime >= (hidden.hideFrom ?? Infinity) &&
+                  targetTime < (hidden.hideUntil ?? -Infinity)
+                ) {
+                  ball.mesh.visible = false;
+                }
+              }
             }
             if (ball.shadow) {
               ball.shadow.visible = ball.mesh?.visible ?? ball.shadow.visible;
@@ -21961,7 +21988,8 @@ const powerRef = useRef(hud.power);
             return true;
           }
           if (sample.phase === 'recover') {
-            cueStick.position.copy(followPos ?? impactPos);
+            const eased = easeInOutCubic(sample.t);
+            cueStick.position.lerpVectors(followPos ?? impactPos, idlePos ?? impactPos, eased);
             cueStick.rotation.x = baseRotationX ?? cueStick.rotation.x;
             cueStick.rotation.y = baseRotationY ?? cueStick.rotation.y;
             syncCueShadow();
@@ -22200,10 +22228,19 @@ const powerRef = useRef(hud.power);
           overheadBroadcastVariantRef.current = 'replay';
           storeReplayCameraFrame();
           resetCameraForReplay();
+          const replayCueStroke = trimmed.cueStroke ?? null;
+          const replayCueHideFrom = replayCueStroke
+            ? Math.max(
+                120,
+                (replayCueStroke.pullback ?? replayCueStroke.pullbackDuration ?? 0) +
+                  (replayCueStroke.release ?? replayCueStroke.releaseDuration ?? 0) * 0.72
+              )
+            : 180;
+          replayCueHiddenRef.current = { hideFrom: replayCueHideFrom, hideUntil: duration };
           replayPlayback = {
             frames: trimmed.frames,
             cuePath: trimmed.cuePath,
-            cueStroke: trimmed.cueStroke ?? null,
+            cueStroke: replayCueStroke,
             duration,
             startedAt: performance.now(),
             lastIndex: 0,
@@ -22286,6 +22323,7 @@ const powerRef = useRef(hud.power);
           replayCameraRef.current = null;
           replayFrameCameraRef.current = null;
           overheadBroadcastVariantRef.current = 'rail';
+          replayCueHiddenRef.current = { hideFrom: Infinity, hideUntil: -Infinity };
           setReplayActive(false);
           setReplayFoul(null);
         };


### PR DESCRIPTION
### Motivation
- Make AI pick shots that aim the target at the center of the pocket entrance and prefer lanes that are clearer and straighter so suggested shots read more like a real player.
- Make broadcast/replay camera views (rail overhead & top-view) behave dynamically instead of being hard-locked so replay/broadcast framing matches the chosen broadcast rig.
- Improve topspin/follow physics and cue-stick replay motion to feel natural: transfer forward/topspin into rolling follow and show a complete pull→strike→push→recover motion in replays.

### Description
- Added `pocketEntranceOpenness` scorer and integrated it into shot candidate ranking so candidates favor clearer pocket-entry lanes and central entrance alignment (updates in `lib/poolAi.js` and mirrored in `webapp/public/lib/poolAi.js`).
- Hardened `estimateCueAfterShot` by using a safe fallback `table.ballRadius` when table data is missing and slightly adjusted the default power ladder to stabilize natural-shot choices (in `lib/poolAi.js` and public copy).
- Enabled dynamic rail-overhead broadcast framing by turning off the hard lock (`LOCK_RAIL_OVERHEAD_FRAME = false`) so broadcast/replay uses the active camera rig for framing (in `webapp/src/pages/Games/PoolRoyale.jsx`).
- Implemented topspin follow improvements that transfer a portion of positive forward/topspin into forward roll and accelerate topspin decay once rolling is established, preserving side/backspin behavior (in `webapp/src/pages/Games/PoolRoyale.jsx`).
- Refined cue-stick replay logic: added a replay cue hide window after impact (hide cue ball during the main replay window) and restored it near replay end, and made the recover phase lerp the cue back to idle for a clear pull/push/recover animation (in `webapp/src/pages/Games/PoolRoyale.jsx`).
- Added an automated test to validate prioritisation of clearer pocket lanes and updated tests to reflect AI changes (`test/poolAi.test.js`).

### Testing
- Ran the AI unit tests with `node --test test/poolAi.test.js` and all tests passed after the changes (final run: 15 tests, 0 failures).
- Verified the JS runtime that the public bundled AI (`webapp/public/lib/poolAi.js`) was updated to match `lib/poolAi.js` and tests remained green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7dc0233ec8329b764e780f67337af)