### PR TITLE
Align side opponent card rows with top/bottom layout in Murlan Royale

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -3282,15 +3282,23 @@ export default function MurlanRoyaleArena({ search }) {
           : 0;
         const lateral = humanLineOffset;
         const radial = player.isHuman ? radius : radius + AI_CARD_OUTWARD;
-        const fanArcLift = isHumanCard ? HUMAN_HAND_FAN_ARC_LIFT : AI_HAND_FAN_ARC_LIFT;
+        const fanArcLift = isHumanCard ? HUMAN_HAND_FAN_ARC_LIFT : 0;
         const fanDirection = HUMAN_HAND_FAN_DIRECTION;
-        const fanYaw = HUMAN_HAND_UNIFORM_YAW_FROM_LEFT
-          ? HUMAN_HAND_FAN_MAX_YAW
-          : normalizedOffset * (isHumanCard ? HUMAN_HAND_FAN_MAX_YAW : AI_HAND_FAN_MAX_YAW) * fanDirection;
+        const fanYaw = isHumanCard
+          ? (
+              HUMAN_HAND_UNIFORM_YAW_FROM_LEFT
+                ? HUMAN_HAND_FAN_MAX_YAW
+                : normalizedOffset * HUMAN_HAND_FAN_MAX_YAW * fanDirection
+            )
+          : 0;
         const target = forward.clone().multiplyScalar(radial).addScaledVector(horizontalLayoutAxis, lateral);
         target.addScaledVector(forward, HUMAN_HAND_CLOSER_OFFSET);
         target.addScaledVector(horizontalLayoutAxis, HUMAN_HAND_LEFT_SHIFT);
-        target.y = baseHeight + centerWeight * fanArcLift + HUMAN_HAND_BOTTOM_SHIFT_Y + HUMAN_HAND_UP_SHIFT_Y + leftWeight * HUMAN_HAND_DIRECTIONAL_LIFT;
+        target.y = baseHeight
+          + centerWeight * fanArcLift
+          + HUMAN_HAND_BOTTOM_SHIFT_Y
+          + HUMAN_HAND_UP_SHIFT_Y
+          + (isHumanCard ? leftWeight * HUMAN_HAND_DIRECTIONAL_LIFT : 0);
         if (isHumanCard && selectionSet.has(card.id)) target.y += HUMAN_SELECTION_OFFSET;
         mesh.scale.setScalar(HUMAN_HAND_CARD_SCALE);
         const handLookTarget = focus.clone().addScaledVector(forward, 2.4 * MODEL_SCALE);
@@ -3307,7 +3315,7 @@ export default function MurlanRoyaleArena({ search }) {
           {
             face: isHumanCard ? 'front' : 'back',
             yawY: fanYaw,
-            pitchX: centerWeight * HUMAN_HAND_BOTTOM_INWARD_TILT_X
+            pitchX: isHumanCard ? centerWeight * HUMAN_HAND_BOTTOM_INWARD_TILT_X : 0
           },
           immediate,
           three.animations,


### PR DESCRIPTION
### Motivation
- Side (left/right/top) opponent hands were rendered with extra fan lift/yaw/pitch causing them to appear angled and not match the single horizontal line layout used for top/bottom players.
- The intent is to normalize non-human seat card presentation to match the requested horizontal row appearance while keeping the human player's hand visuals and interaction unchanged.

### Description
- Updated hand placement logic in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to remove AI-only fan arc lift, yaw and pitch so non-human hands render in a straight horizontal row; human-hand math and animation are preserved. 
- Concretely, `fanArcLift` is forced to `0` for non-human cards, AI `fanYaw` is set to `0`, and directional lift/pitch are disabled for AI cards so they align with the top/bottom style.
- Changes adjust the target position `y` and the `pitchX`/`yawY` parameters passed to `setMeshPosition` only for non-human cards.

### Testing
- Ran unit tests with `npm test -- test/murlan.test.js --runInBand`, and the suite passed (`12 tests, 0 failures`).
- Ran `npx eslint webapp/src/pages/Games/MurlanRoyaleArena.jsx` which produced an ignore warning due to repository ESLint ignore settings (no lint errors reported for the change file).
- Attempted an automated Playwright screenshot of `/games/murlanroyale?mode=ai&players=4` after launching the dev server, but Chromium failed to start in this environment due to a missing system library (`libatk-1.0.so.0`), so the screenshot could not be captured here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7dec957e88329b0b22ffda35c7ad3)