### PR TITLE
Align side-seat opponent hands to horizontal card row in Murlan Royale

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -3248,6 +3248,9 @@ export default function MurlanRoyaleArena({ search }) {
     } else {
       horizontalLayoutAxis.set(1, 0, 0);
     }
+    const sharedOpponentLookTarget = humanSeatConfig?.focus?.clone?.()
+      ?.addScaledVector(humanSeatConfig?.forward ?? new THREE.Vector3(0, 0, 1), 2.4 * MODEL_SCALE)
+      ?? three.tableAnchor.clone().setY(TABLE_HEIGHT + 0.26 * MODEL_SCALE);
 
     state.players.forEach((player, idx) => {
       const seat = seatConfigs[idx];
@@ -3282,7 +3285,7 @@ export default function MurlanRoyaleArena({ search }) {
           : 0;
         const lateral = humanLineOffset;
         const radial = player.isHuman ? radius : radius + AI_CARD_OUTWARD;
-        const fanArcLift = isHumanCard ? HUMAN_HAND_FAN_ARC_LIFT : AI_HAND_FAN_ARC_LIFT;
+        const fanArcLift = isHumanCard ? HUMAN_HAND_FAN_ARC_LIFT : 0;
         const fanDirection = HUMAN_HAND_FAN_DIRECTION;
         const fanYaw = HUMAN_HAND_UNIFORM_YAW_FROM_LEFT
           ? HUMAN_HAND_FAN_MAX_YAW
@@ -3293,7 +3296,9 @@ export default function MurlanRoyaleArena({ search }) {
         target.y = baseHeight + centerWeight * fanArcLift + HUMAN_HAND_BOTTOM_SHIFT_Y + HUMAN_HAND_UP_SHIFT_Y + leftWeight * HUMAN_HAND_DIRECTIONAL_LIFT;
         if (isHumanCard && selectionSet.has(card.id)) target.y += HUMAN_SELECTION_OFFSET;
         mesh.scale.setScalar(HUMAN_HAND_CARD_SCALE);
-        const handLookTarget = focus.clone().addScaledVector(forward, 2.4 * MODEL_SCALE);
+        const handLookTarget = isHumanCard
+          ? focus.clone().addScaledVector(forward, 2.4 * MODEL_SCALE)
+          : sharedOpponentLookTarget;
         setCommunityCardLegibility(mesh, false);
         const previousPlayer = previous?.players?.[idx];
         const isNewHandCard = Boolean(card && !previousPlayer?.hand?.some((prevCard) => prevCard.id === card.id));
@@ -3307,7 +3312,7 @@ export default function MurlanRoyaleArena({ search }) {
           {
             face: isHumanCard ? 'front' : 'back',
             yawY: fanYaw,
-            pitchX: centerWeight * HUMAN_HAND_BOTTOM_INWARD_TILT_X
+            pitchX: isHumanCard ? centerWeight * HUMAN_HAND_BOTTOM_INWARD_TILT_X : 0
           },
           immediate,
           three.animations,


### PR DESCRIPTION
### Motivation
- Side players' hands (left/right) should appear as a single horizontal row like the top/bottom players to match the provided visual layout requirement.
- Reduce vertical arc/tilt on non-human hands so their cards present in a cleaner, consistent horizontal line.

### Description
- Compute a `sharedOpponentLookTarget` (from the human seat focus + forward vector or a table-anchor fallback) and reuse it for non-human hand look targets so side seats share the same visual facing as horizontal rows.
- Disable vertical fan lift for non-human hands by setting opponent `fanArcLift` to `0` instead of the AI lift constant so those cards stay level.
- Remove inward pitch for opponent cards by setting `pitchX` to `0` for non-human hands while preserving human-hand pitch and animation.
- Modified file: `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to implement the above behavior.

### Testing
- Built the webapp with `npm --prefix webapp run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7dec957e88329b0b22ffda35c7ad3)