### PR TITLE
Improve pocket entrance scoring, aim compensation, topspin behavior and replay cue handling

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -148,6 +148,31 @@ function pocketAlignment (pocket, target, width, height) {
   return Math.max(0, (approach.x / len) * normal.x + (approach.y / len) * normal.y)
 }
 
+function pocketEntranceOpenness (target, pocket, req) {
+  if (!target || !pocket || !req?.state) return 0
+  const r = req.state.ballRadius
+  const entry = pocketEntry(pocket, r, req.state.width, req.state.height, target)
+  const laneLen = Math.max(dist(target, entry), r * 2)
+  const laneDir = { x: (entry.x - target.x) / laneLen, y: (entry.y - target.y) / laneLen }
+  let minEdge = Infinity
+  for (const b of req.state.balls || []) {
+    if (!b || b.pocketed || b.id === target.id) continue
+    const relX = b.x - target.x
+    const relY = b.y - target.y
+    const along = relX * laneDir.x + relY * laneDir.y
+    if (along <= 0 || along >= laneLen + r * 1.8) continue
+    const lateral = Math.abs(relX * laneDir.y - relY * laneDir.x)
+    const edgeGap = lateral - r * 2
+    if (edgeGap < minEdge) minEdge = edgeGap
+  }
+  const clearance = Number.isFinite(minEdge)
+    ? Math.max(0, Math.min((minEdge + r * 0.9) / (r * 2.2), 1))
+    : 1
+  const alignment = pocketAlignment(pocket, target, req.state.width, req.state.height)
+  const straightness = Math.max(0, Math.min((alignment - 0.2) / 0.8, 1))
+  return Math.min(1, clearance * 0.65 + straightness * 0.35)
+}
+
 function ghostPointForTargetPocket (target, pocket, req) {
   const r = req.state.ballRadius
   const entry = pocketEntry(pocket, r, req.state.width, req.state.height, target)
@@ -416,18 +441,20 @@ function clearShotCandidates (req) {
       const viewScore = Math.min(viewAngle / (Math.PI / 2), 1)
       const entryAlignment = pocketAlignment(pocket, target, req.state.width, req.state.height)
       const weightedView = viewScore * (0.7 + 0.3 * entryAlignment)
+      const entranceOpenness = pocketEntranceOpenness(target, pocket, req)
+      const pocketView = weightedView * (0.68 + 0.32 * entranceOpenness)
       const approachStraightness = 1 - Math.min(cut / (Math.PI / 2), 1)
       const cueToTarget = cue ? dist(cue, target) : 0
       const distanceScore = cue ? Math.max(0, 1 - cueToTarget / (r * 60)) : 0
       const rank =
-        weightedView * 0.46 +
-        approachStraightness * 0.25 +
-        distanceScore * 0.12 +
-        Math.max(0, 1 - cut / (Math.PI / 3.4)) * 0.17
+        pocketView * 0.5 +
+        approachStraightness * 0.3 +
+        distanceScore * 0.08 +
+        entranceOpenness * 0.12
 
       // require fairly central hit and open pocket view
-      if (cut <= maxCut && weightedView >= minView) {
-        candidates.push({ target, pocket, cut, view: weightedView, rank })
+      if (cut <= maxCut && pocketView >= minView) {
+        candidates.push({ target, pocket, cut, view: pocketView, rank })
       }
     }
   }
@@ -472,7 +499,8 @@ export function estimateCueAfterShot (cue, target, pocket, power, spin, table) {
 
   const cutDot = Math.max(-1, Math.min(1, shotDir.x * objectDir.x + shotDir.y * objectDir.y))
   const cutSeverity = Math.sqrt(Math.max(0, 1 - cutDot * cutDot))
-  const baseTravel = Math.max(table.ballRadius * 3, power * table.ballRadius * (18 - 3.6 * cutSeverity))
+  const tableRadius = Number.isFinite(table?.ballRadius) ? table.ballRadius : 10
+  const baseTravel = Math.max(tableRadius * 3, power * tableRadius * (18 - 3.6 * cutSeverity))
 
   // Stun component (natural tangent line), then follow/draw layered on top.
   const followAmount = Math.max(0, spin.top || 0)
@@ -850,7 +878,7 @@ export function planShot (req) {
 
   const powers = req.state?.breakInProgress
     ? [1 * POWER_SCALE]
-    : [0.48 * POWER_SCALE, 0.66 * POWER_SCALE, 0.82 * POWER_SCALE, 0.94 * POWER_SCALE]
+    : [0.5 * POWER_SCALE, 0.66 * POWER_SCALE, 0.82 * POWER_SCALE, 0.94 * POWER_SCALE]
   const defaultSpins = [
     { top: 0, side: 0, back: 0 },
     { top: 0.3, side: 0, back: 0 },

--- a/test/poolAi.test.js
+++ b/test/poolAi.test.js
@@ -382,3 +382,32 @@ test('uses hidden helper numbers/colours when ids are missing', () => {
   const decision = planShot(req)
   assert.equal(decision.targetBallId, 3)
 })
+
+test('prioritises clearer pocket entrance when one lane is cluttered', () => {
+  const decision = planShot({
+    game: 'AMERICAN_BILLIARDS',
+    state: {
+      balls: [
+        { id: 0, x: 260, y: 250, vx: 0, vy: 0, pocketed: false },
+        { id: 1, x: 500, y: 250, vx: 0, vy: 0, pocketed: false },
+        // blocker near the top pocket entrance lane
+        { id: 12, x: 500, y: 74, vx: 0, vy: 0, pocketed: false }
+      ],
+      pockets: [
+        { x: 500, y: 0 },
+        { x: 500, y: 500 }
+      ],
+      width: 1000,
+      height: 500,
+      ballRadius: 10,
+      friction: 0.01,
+      legalBallIds: [1]
+    },
+    timeBudgetMs: 120,
+    rngSeed: 11
+  });
+
+  assert.equal(decision.targetBallId, 1);
+  assert(decision.targetPocket);
+  assert(decision.targetPocket.y > 300, 'should prefer the clearer bottom-pocket lane');
+});

--- a/test/poolRoyaleAiAimCompensation.test.js
+++ b/test/poolRoyaleAiAimCompensation.test.js
@@ -19,7 +19,7 @@ describe('Pool Royale AI aim compensation', () => {
     expect(Math.hypot(result.ghost.x - targetPos.x, result.ghost.y - targetPos.y)).toBeCloseTo(0.06, 4);
   });
 
-  it('keeps pre-impact aim unchanged when only side spin changes', () => {
+  it('applies side-spin compensation to pre-impact aim', () => {
     const neutral = resolveAiPotGhostAim({
       cuePos,
       targetPos,
@@ -37,8 +37,9 @@ describe('Pool Royale AI aim compensation', () => {
       power: 0.8
     });
     expect(withSide).toBeTruthy();
-    expect(neutral.aimDir.angleTo(withSide.aimDir)).toBeLessThan(1e-6);
+    expect(neutral.aimDir.angleTo(withSide.aimDir)).toBeGreaterThan(1e-4);
     expect(withSide.contactDepth).toBeCloseTo(neutral.contactDepth, 8);
+    expect(Math.abs(withSide.compensation?.sideDeflection ?? 0)).toBeGreaterThan(0);
   });
 
   it('keeps contact depth close to 2R and adjusts only slightly with spin', () => {
@@ -63,5 +64,28 @@ describe('Pool Royale AI aim compensation', () => {
     expect(neutral.contactDepth).toBeCloseTo(0.06, 5);
     expect(topspin.contactDepth).toBeGreaterThan(neutral.contactDepth);
     expect(topspin.contactDepth - neutral.contactDepth).toBeLessThan(0.0015);
+  });
+
+  it('increases compensation with higher shot power', () => {
+    const lowPower = resolveAiPotGhostAim({
+      cuePos,
+      targetPos,
+      pocketPos,
+      ballRadius: 0.03,
+      spin: { x: 0.65, y: 0.2 },
+      power: 0.35
+    });
+    const highPower = resolveAiPotGhostAim({
+      cuePos,
+      targetPos,
+      pocketPos,
+      ballRadius: 0.03,
+      spin: { x: 0.65, y: 0.2 },
+      power: 1
+    });
+    expect(lowPower).toBeTruthy();
+    expect(highPower).toBeTruthy();
+    expect(Math.abs(highPower.compensation?.sideDeflection ?? 0))
+      .toBeGreaterThan(Math.abs(lowPower.compensation?.sideDeflection ?? 0));
   });
 });

--- a/webapp/public/lib/poolAi.js
+++ b/webapp/public/lib/poolAi.js
@@ -148,6 +148,31 @@ function pocketAlignment (pocket, target, width, height) {
   return Math.max(0, (approach.x / len) * normal.x + (approach.y / len) * normal.y)
 }
 
+function pocketEntranceOpenness (target, pocket, req) {
+  if (!target || !pocket || !req?.state) return 0
+  const r = req.state.ballRadius
+  const entry = pocketEntry(pocket, r, req.state.width, req.state.height, target)
+  const laneLen = Math.max(dist(target, entry), r * 2)
+  const laneDir = { x: (entry.x - target.x) / laneLen, y: (entry.y - target.y) / laneLen }
+  let minEdge = Infinity
+  for (const b of req.state.balls || []) {
+    if (!b || b.pocketed || b.id === target.id) continue
+    const relX = b.x - target.x
+    const relY = b.y - target.y
+    const along = relX * laneDir.x + relY * laneDir.y
+    if (along <= 0 || along >= laneLen + r * 1.8) continue
+    const lateral = Math.abs(relX * laneDir.y - relY * laneDir.x)
+    const edgeGap = lateral - r * 2
+    if (edgeGap < minEdge) minEdge = edgeGap
+  }
+  const clearance = Number.isFinite(minEdge)
+    ? Math.max(0, Math.min((minEdge + r * 0.9) / (r * 2.2), 1))
+    : 1
+  const alignment = pocketAlignment(pocket, target, req.state.width, req.state.height)
+  const straightness = Math.max(0, Math.min((alignment - 0.2) / 0.8, 1))
+  return Math.min(1, clearance * 0.65 + straightness * 0.35)
+}
+
 function ghostPointForTargetPocket (target, pocket, req) {
   const r = req.state.ballRadius
   const entry = pocketEntry(pocket, r, req.state.width, req.state.height, target)
@@ -416,18 +441,20 @@ function clearShotCandidates (req) {
       const viewScore = Math.min(viewAngle / (Math.PI / 2), 1)
       const entryAlignment = pocketAlignment(pocket, target, req.state.width, req.state.height)
       const weightedView = viewScore * (0.7 + 0.3 * entryAlignment)
+      const entranceOpenness = pocketEntranceOpenness(target, pocket, req)
+      const pocketView = weightedView * (0.68 + 0.32 * entranceOpenness)
       const approachStraightness = 1 - Math.min(cut / (Math.PI / 2), 1)
       const cueToTarget = cue ? dist(cue, target) : 0
       const distanceScore = cue ? Math.max(0, 1 - cueToTarget / (r * 60)) : 0
       const rank =
-        weightedView * 0.46 +
-        approachStraightness * 0.25 +
-        distanceScore * 0.12 +
-        Math.max(0, 1 - cut / (Math.PI / 3.4)) * 0.17
+        pocketView * 0.5 +
+        approachStraightness * 0.3 +
+        distanceScore * 0.08 +
+        entranceOpenness * 0.12
 
       // require fairly central hit and open pocket view
-      if (cut <= maxCut && weightedView >= minView) {
-        candidates.push({ target, pocket, cut, view: weightedView, rank })
+      if (cut <= maxCut && pocketView >= minView) {
+        candidates.push({ target, pocket, cut, view: pocketView, rank })
       }
     }
   }
@@ -472,7 +499,8 @@ export function estimateCueAfterShot (cue, target, pocket, power, spin, table) {
 
   const cutDot = Math.max(-1, Math.min(1, shotDir.x * objectDir.x + shotDir.y * objectDir.y))
   const cutSeverity = Math.sqrt(Math.max(0, 1 - cutDot * cutDot))
-  const baseTravel = Math.max(table.ballRadius * 3, power * table.ballRadius * (18 - 3.6 * cutSeverity))
+  const tableRadius = Number.isFinite(table?.ballRadius) ? table.ballRadius : 10
+  const baseTravel = Math.max(tableRadius * 3, power * tableRadius * (18 - 3.6 * cutSeverity))
 
   // Stun component (natural tangent line), then follow/draw layered on top.
   const followAmount = Math.max(0, spin.top || 0)
@@ -850,7 +878,7 @@ export function planShot (req) {
 
   const powers = req.state?.breakInProgress
     ? [1 * POWER_SCALE]
-    : [0.48 * POWER_SCALE, 0.66 * POWER_SCALE, 0.82 * POWER_SCALE, 0.94 * POWER_SCALE]
+    : [0.5 * POWER_SCALE, 0.66 * POWER_SCALE, 0.82 * POWER_SCALE, 0.94 * POWER_SCALE]
   const defaultSpins = [
     { top: 0, side: 0, back: 0 },
     { top: 0.3, side: 0, back: 0 },

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1233,7 +1233,7 @@ const TABLE_MAPPING_VISUALS = Object.freeze({
 });
 const LOCK_REPLAY_CAMERA = false;
 const FIXED_RAIL_REPLAY_CAMERA = false;
-const LOCK_RAIL_OVERHEAD_FRAME = true;
+const LOCK_RAIL_OVERHEAD_FRAME = false;
 const REPLAY_CUE_STICK_HOLD_MS = 760;
 const REPLAY_CAMERA_START_DELAY_MS = 0;
   const TABLE_BASE_SCALE = 1.2;
@@ -5914,6 +5914,8 @@ const DEFAULT_SPIN_LIMITS = Object.freeze({
   maxY: 1
 });
 const MAX_TOPSPIN_INPUT = 0.8; // reduce topspin cap to match Snooker Royal feel
+const TOPSPIN_FOLLOW_TRANSFER_RATE = 0.38; // transfer a portion of top spin into forward roll each physics step for natural follow-through fade
+const TOPSPIN_FOLLOW_DECAY_ASSIST = 0.54; // accelerate only top-spin decay once forward roll is established so follow naturally settles
 const TOPSPIN_POWER_SOFT_CAP = 0.9;
 const clampSpinValue = (value) => clamp(value, -1, 1);
 const SPIN_CUSHION_EPS = BALL_R * 0.6;
@@ -6976,6 +6978,20 @@ function applySpinController(ball, stepScale, airborne = false) {
     }
     if (Math.abs(forwardSpin) > 1e-8) {
       ball.vel.addScaledVector(forward, forwardSpin * rollAccel);
+      if (forwardSpin > 0) {
+        const naturalRollSpeed = Math.max(BALL_R * 2.2, speed * 0.78);
+        const settling = THREE.MathUtils.clamp(speed / Math.max(naturalRollSpeed, 1e-6), 0, 1);
+        const transfer =
+          Math.min(
+            forwardSpin,
+            rollAccel * TOPSPIN_FOLLOW_TRANSFER_RATE * (0.35 + settling * 0.65)
+          );
+        ball.spin.y = Math.max(0, forwardSpin - transfer);
+        const assistedDecay = Math.exp(
+          -TOPSPIN_FOLLOW_DECAY_ASSIST * stepScale * (0.3 + 0.7 * settling)
+        );
+        ball.spin.y *= assistedDecay;
+      }
     }
   }
   return decaySpin(ball, stepScale, airborne);
@@ -15265,6 +15281,7 @@ const powerRef = useRef(hud.power);
   const lastCameraTargetRef = useRef(new THREE.Vector3(0, ORBIT_FOCUS_BASE_Y, 0));
   const replayCameraRef = useRef(null);
   const replayFrameCameraRef = useRef(null);
+  const replayCueHiddenRef = useRef({ hideFrom: Infinity, hideUntil: -Infinity });
   const updateSpinDotPosition = useCallback((value, blocked) => {
     if (!value) value = { x: 0, y: 0 };
     const dot = spinDotElRef.current;
@@ -19631,47 +19648,37 @@ const powerRef = useRef(hud.power);
             !cueAnimating;
           const galleryState = cueGalleryStateRef.current;
           if (replayPlaybackActive) {
-            const storedReplayCamera = replayCameraRef.current;
             const scale = Number.isFinite(worldScaleFactor) ? worldScaleFactor : WORLD_SCALE;
-            const resolvedReplayCamera = resolveReplayCameraView(
-              replayFrameCameraRef.current,
-              storedReplayCamera
-            );
-            const minTargetY = Math.max(
-              baseSurfaceWorldY,
-              Number.isFinite(resolvedReplayCamera?.minTargetY)
-                ? resolvedReplayCamera.minTargetY
-                : BALL_CENTER_Y * scale
-            );
-            const focusTarget =
-              resolvedReplayCamera?.target?.clone?.() ??
-              storedReplayCamera?.target?.clone?.() ??
-              lastCameraTargetRef.current?.clone?.() ??
-              new THREE.Vector3(playerOffsetRef.current * scale, minTargetY, 0);
-            focusTarget.y = Math.max(focusTarget.y ?? 0, minTargetY);
-            const safePosition =
-              resolvedReplayCamera?.position?.clone?.() ??
-              storedReplayCamera?.position?.clone?.() ??
-              camera.position.clone();
-            if (safePosition.y < minTargetY + CAMERA_CUE_SURFACE_MARGIN * scale) {
-              safePosition.y = minTargetY + CAMERA_CUE_SURFACE_MARGIN * scale;
-            }
-            const replayFov = Number.isFinite(resolvedReplayCamera?.fov)
-              ? resolvedReplayCamera.fov
-              : Number.isFinite(storedReplayCamera?.fov)
-                ? storedReplayCamera.fov
-                : camera.fov;
+            const minTargetY = Math.max(baseSurfaceWorldY, BALL_CENTER_Y * scale);
+            const cueBallReplay = (ballsRef.current?.length ? ballsRef.current : balls)
+              .find((ball) => ball?.id === 'cue' && ball?.active && ball?.pos);
+            const focusTarget = cueBallReplay?.pos
+              ? new THREE.Vector3(cueBallReplay.pos.x, minTargetY, cueBallReplay.pos.y)
+              : lastCameraTargetRef.current?.clone?.() ??
+                new THREE.Vector3(playerOffsetRef.current * scale, minTargetY, 0);
+            const railReplayCamera = resolveRailOverheadReplayCamera({
+              focusOverride: focusTarget,
+              minTargetY,
+              preferredRail: railOverheadSideRef.current
+            });
+            const replayPosition = railReplayCamera?.position?.clone?.() ?? camera.position.clone();
+            const replayTarget = railReplayCamera?.target?.clone?.() ?? focusTarget;
+            const replayFov = Number.isFinite(railReplayCamera?.fov)
+              ? railReplayCamera.fov
+              : RAIL_OVERHEAD_REPLAY_FOV;
             if (Number.isFinite(replayFov) && camera.fov !== replayFov) {
               camera.fov = replayFov;
               camera.updateProjectionMatrix();
             }
-            camera.position.copy(safePosition);
-            camera.lookAt(focusTarget);
+            camera.position.copy(replayPosition);
+            camera.lookAt(replayTarget);
             renderCamera = camera;
-            lookTarget = focusTarget;
-            broadcastArgs.focusWorld = focusTarget.clone();
-            broadcastArgs.targetWorld = focusTarget.clone();
-            broadcastArgs.lerp = 0;
+            lookTarget = replayTarget;
+            broadcastArgs.focusWorld = replayTarget.clone();
+            broadcastArgs.targetWorld = replayTarget.clone();
+            broadcastArgs.orbitWorld = replayPosition.clone();
+            broadcastArgs.preferredRail = railOverheadSideRef.current;
+            broadcastArgs.lerp = 0.08;
           } else if (galleryState?.active) {
             const basePosition =
               galleryState.basePosition ?? galleryState.position ?? null;
@@ -21411,6 +21418,16 @@ const powerRef = useRef(hud.power);
               if (meshB.visible != null) {
                 ball.mesh.visible = meshB.visible;
               }
+              if (ball.id === 'cue' && replayPlaybackRef.current) {
+                const hidden = replayCueHiddenRef.current;
+                if (
+                  hidden &&
+                  targetTime >= (hidden.hideFrom ?? Infinity) &&
+                  targetTime < (hidden.hideUntil ?? -Infinity)
+                ) {
+                  ball.mesh.visible = false;
+                }
+              }
             }
             if (ball.shadow) {
               ball.shadow.visible = ball.mesh?.visible ?? ball.shadow.visible;
@@ -21961,7 +21978,8 @@ const powerRef = useRef(hud.power);
             return true;
           }
           if (sample.phase === 'recover') {
-            cueStick.position.copy(followPos ?? impactPos);
+            const eased = easeInOutCubic(sample.t);
+            cueStick.position.lerpVectors(followPos ?? impactPos, idlePos ?? impactPos, eased);
             cueStick.rotation.x = baseRotationX ?? cueStick.rotation.x;
             cueStick.rotation.y = baseRotationY ?? cueStick.rotation.y;
             syncCueShadow();
@@ -22200,10 +22218,19 @@ const powerRef = useRef(hud.power);
           overheadBroadcastVariantRef.current = 'replay';
           storeReplayCameraFrame();
           resetCameraForReplay();
+          const replayCueStroke = trimmed.cueStroke ?? null;
+          const replayCueHideFrom = replayCueStroke
+            ? Math.max(
+                120,
+                (replayCueStroke.pullback ?? replayCueStroke.pullbackDuration ?? 0) +
+                  (replayCueStroke.release ?? replayCueStroke.releaseDuration ?? 0) * 0.72
+              )
+            : 180;
+          replayCueHiddenRef.current = { hideFrom: replayCueHideFrom, hideUntil: duration };
           replayPlayback = {
             frames: trimmed.frames,
             cuePath: trimmed.cuePath,
-            cueStroke: trimmed.cueStroke ?? null,
+            cueStroke: replayCueStroke,
             duration,
             startedAt: performance.now(),
             lastIndex: 0,
@@ -22286,6 +22313,7 @@ const powerRef = useRef(hud.power);
           replayCameraRef.current = null;
           replayFrameCameraRef.current = null;
           overheadBroadcastVariantRef.current = 'rail';
+          replayCueHiddenRef.current = { hideFrom: Infinity, hideUntil: -Infinity };
           setReplayActive(false);
           setReplayFoul(null);
         };
@@ -26938,7 +26966,7 @@ const powerRef = useRef(hud.power);
                 })
                 .filter((id) => Number.isFinite(id))
             : [];
-          const legalIdsFromGroup = normalizedAssignment
+          const assignedLiveIds = normalizedAssignment
             ? aiBalls
                 .filter((ball) => {
                   if (ball.pocketed || ball.id === cueBallId) return false;
@@ -26948,6 +26976,11 @@ const powerRef = useRef(hud.power);
                 })
                 .map((ball) => ball.id)
             : [];
+          const blackBallLive = aiBalls.some((ball) => ball.id === 8 && !ball.pocketed);
+          const legalIdsFromGroup =
+            normalizedAssignment && assignedLiveIds.length === 0 && blackBallLive
+              ? [8]
+              : assignedLiveIds;
           const legalBallIds =
             legalIdsFromBallOn.length > 0
               ? legalIdsFromBallOn

--- a/webapp/src/pages/Games/poolRoyaleAiAimCompensation.js
+++ b/webapp/src/pages/Games/poolRoyaleAiAimCompensation.js
@@ -2,6 +2,8 @@ import * as THREE from 'three';
 
 const MIN_VECTOR_EPS = 1e-6;
 const DEFAULT_CONTACT_CALIBRATION = 0.004;
+const SIDE_SPIN_COMPENSATION_SCALE = 0.28;
+const POWER_DEFLECTION_SCALE = 0.32;
 
 export const resolveAiPotGhostAim = ({
   cuePos,
@@ -18,11 +20,11 @@ export const resolveAiPotGhostAim = ({
   if (toPocket.lengthSq() <= MIN_VECTOR_EPS) return null;
 
   const toPocketDir = toPocket.normalize();
+  const sideSpin = THREE.MathUtils.clamp(spin?.x ?? 0, -1, 1);
   const topBackSpin = THREE.MathUtils.clamp(spin?.y ?? 0, -1, 1);
   const power01 = THREE.MathUtils.clamp(power ?? 0.6, 0, 1);
 
   // Baseline geometric contact: cue-ball and object-ball centers should be 2R apart at impact.
-  // Keep only a tiny spin/power calibration so aiming stays precise for ball-to-ball touch points.
   const calibration = THREE.MathUtils.clamp(
     contactCalibration ?? DEFAULT_CONTACT_CALIBRATION,
     -0.08,
@@ -30,9 +32,38 @@ export const resolveAiPotGhostAim = ({
   );
   const contactDepth = radius * 2 * (1 + calibration + topBackSpin * power01 * 0.015);
 
-  const ghost = new THREE.Vector2()
+  const baseGhost = new THREE.Vector2()
     .copy(targetPos)
     .sub(toPocketDir.clone().multiplyScalar(contactDepth));
+
+  const cueToTarget = new THREE.Vector2().subVectors(targetPos, cuePos);
+  const cueToTargetLen = cueToTarget.length();
+  if (cueToTargetLen <= MIN_VECTOR_EPS) return null;
+  cueToTarget.normalize();
+
+  const cutCos = THREE.MathUtils.clamp(cueToTarget.dot(toPocketDir), -1, 1);
+  const cutSeverity = Math.sqrt(Math.max(0, 1 - cutCos * cutCos));
+  const sidePerp = new THREE.Vector2(-cueToTarget.y, cueToTarget.x);
+
+  // Compensate for power + spin induced deflection/throw before object-ball impact.
+  const sideDeflection =
+    radius *
+    sideSpin *
+    (0.38 + cutSeverity * 0.62) *
+    (0.45 + power01 * 0.55) *
+    SIDE_SPIN_COMPENSATION_SCALE;
+
+  const topBackDeflection =
+    radius *
+    topBackSpin *
+    power01 *
+    (0.18 + cutSeverity * 0.22) *
+    POWER_DEFLECTION_SCALE;
+
+  const ghost = baseGhost
+    .clone()
+    .sub(sidePerp.multiplyScalar(sideDeflection))
+    .sub(cueToTarget.clone().multiplyScalar(topBackDeflection));
 
   const finalCueVector = new THREE.Vector2().subVectors(ghost, cuePos);
   if (finalCueVector.lengthSq() <= MIN_VECTOR_EPS) return null;
@@ -40,6 +71,11 @@ export const resolveAiPotGhostAim = ({
   return {
     aimDir: finalCueVector.normalize(),
     ghost,
-    contactDepth
+    contactDepth,
+    compensation: {
+      sideDeflection,
+      topBackDeflection,
+      cutSeverity
+    }
   };
 };


### PR DESCRIPTION
### Motivation

- Improve shot ranking by evaluating how open a pocket entrance lane is so the AI prefers clearer lanes over visually similar but cluttered ones.
- Compensate for side and top/back spin (and shot power) when resolving the pre-impact ghost aim so AI aim accounts for deflection and throw. 
- Make topspin transfer into forward roll for more natural follow-through behavior and hide the cue during replay sections to avoid visual distraction, while also hardening some defaults.

### Description

- Added `pocketEntranceOpenness` and integrated it into `clearShotCandidates` to compute a `pocketView` and an updated ranking formula, and switched candidate visibility checks to use `pocketView` instead of the previous weighted view.
- Enhanced aim compensation in `resolveAiPotGhostAim` to compute side and top/back deflections scaled by cut severity and power, returning a `compensation` object with `sideDeflection`, `topBackDeflection`, and `cutSeverity` for debugging and tests. 
- Tolerantly guarded `estimateCueAfterShot` by defaulting to a numeric `table.ballRadius` when missing, and nudged the initial non-break `powers` sample from `0.48` to `0.5`.
- Introduced topspin follow transfer and assisted decay constants and logic in `applySpinController` to move a portion of forward spin into ball velocity and accelerate decay once roll is established.
- Improved replay behaviour in `PoolRoyale.jsx` by adding `replayCueHiddenRef` and hiding the cue mesh for a computed window during replay, refining rail-overhead replay camera resolution and broadcast args, easing cue-stick recover motion, and providing a fallback that treats the black ball as legal when assignment yields no live ids but black remains.
- Added and updated unit tests to assert clearer pocket entrance prioritization and side-spin/ power compensation behavior in `test/poolAi.test.js` and `test/poolRoyaleAiAimCompensation.test.js` respectively.

### Testing

- Ran the unit test suite via `npm test` and verified the updated and new tests in `test/poolAi.test.js` and `test/poolRoyaleAiAimCompensation.test.js` executed. 
- The new pocket entrance prioritization test asserting the AI prefers the clearer lane passed. 
- The aim compensation tests asserting side-spin affects aim and that compensation increases with power passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7dc0233ec8329b764e780f67337af)