### PR TITLE
Enhance pocket-entry scoring, aim/physics robustness, and replay cue behavior

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -148,6 +148,31 @@ function pocketAlignment (pocket, target, width, height) {
   return Math.max(0, (approach.x / len) * normal.x + (approach.y / len) * normal.y)
 }
 
+function pocketEntranceOpenness (target, pocket, req) {
+  if (!target || !pocket || !req?.state) return 0
+  const r = req.state.ballRadius
+  const entry = pocketEntry(pocket, r, req.state.width, req.state.height, target)
+  const laneLen = Math.max(dist(target, entry), r * 2)
+  const laneDir = { x: (entry.x - target.x) / laneLen, y: (entry.y - target.y) / laneLen }
+  let minEdge = Infinity
+  for (const b of req.state.balls || []) {
+    if (!b || b.pocketed || b.id === target.id) continue
+    const relX = b.x - target.x
+    const relY = b.y - target.y
+    const along = relX * laneDir.x + relY * laneDir.y
+    if (along <= 0 || along >= laneLen + r * 1.8) continue
+    const lateral = Math.abs(relX * laneDir.y - relY * laneDir.x)
+    const edgeGap = lateral - r * 2
+    if (edgeGap < minEdge) minEdge = edgeGap
+  }
+  const clearance = Number.isFinite(minEdge)
+    ? Math.max(0, Math.min((minEdge + r * 0.9) / (r * 2.2), 1))
+    : 1
+  const alignment = pocketAlignment(pocket, target, req.state.width, req.state.height)
+  const straightness = Math.max(0, Math.min((alignment - 0.2) / 0.8, 1))
+  return Math.min(1, clearance * 0.65 + straightness * 0.35)
+}
+
 function ghostPointForTargetPocket (target, pocket, req) {
   const r = req.state.ballRadius
   const entry = pocketEntry(pocket, r, req.state.width, req.state.height, target)
@@ -298,7 +323,12 @@ function chooseTargets (req) {
       if (eight) return [eight]
       return []
     }
-    return balls.filter(b => b.id !== 8)
+    const openTargets = balls.filter(b => b.id !== 8)
+    if (openTargets.length === 0) {
+      const eight = balls.find(b => b.id === 8)
+      return eight ? [eight] : []
+    }
+    return openTargets
   }
   return balls
 }
@@ -361,7 +391,12 @@ function nextTargetsAfter (targetId, req) {
       if (eight) return [eight]
       return []
     }
-    return cloned.filter(b => b.id !== 8)
+    const openTargets = cloned.filter(b => b.id !== 8)
+    if (openTargets.length === 0) {
+      const eight = cloned.find(b => b.id === 8)
+      return eight ? [eight] : []
+    }
+    return openTargets
   }
   return cloned
 }
@@ -416,18 +451,20 @@ function clearShotCandidates (req) {
       const viewScore = Math.min(viewAngle / (Math.PI / 2), 1)
       const entryAlignment = pocketAlignment(pocket, target, req.state.width, req.state.height)
       const weightedView = viewScore * (0.7 + 0.3 * entryAlignment)
+      const entranceOpenness = pocketEntranceOpenness(target, pocket, req)
+      const pocketView = weightedView * (0.68 + 0.32 * entranceOpenness)
       const approachStraightness = 1 - Math.min(cut / (Math.PI / 2), 1)
       const cueToTarget = cue ? dist(cue, target) : 0
       const distanceScore = cue ? Math.max(0, 1 - cueToTarget / (r * 60)) : 0
       const rank =
-        weightedView * 0.46 +
-        approachStraightness * 0.25 +
-        distanceScore * 0.12 +
-        Math.max(0, 1 - cut / (Math.PI / 3.4)) * 0.17
+        pocketView * 0.5 +
+        approachStraightness * 0.3 +
+        distanceScore * 0.08 +
+        entranceOpenness * 0.12
 
       // require fairly central hit and open pocket view
-      if (cut <= maxCut && weightedView >= minView) {
-        candidates.push({ target, pocket, cut, view: weightedView, rank })
+      if (cut <= maxCut && pocketView >= minView) {
+        candidates.push({ target, pocket, cut, view: pocketView, rank })
       }
     }
   }
@@ -472,7 +509,8 @@ export function estimateCueAfterShot (cue, target, pocket, power, spin, table) {
 
   const cutDot = Math.max(-1, Math.min(1, shotDir.x * objectDir.x + shotDir.y * objectDir.y))
   const cutSeverity = Math.sqrt(Math.max(0, 1 - cutDot * cutDot))
-  const baseTravel = Math.max(table.ballRadius * 3, power * table.ballRadius * (18 - 3.6 * cutSeverity))
+  const tableRadius = Number.isFinite(table?.ballRadius) ? table.ballRadius : 10
+  const baseTravel = Math.max(tableRadius * 3, power * tableRadius * (18 - 3.6 * cutSeverity))
 
   // Stun component (natural tangent line), then follow/draw layered on top.
   const followAmount = Math.max(0, spin.top || 0)
@@ -850,7 +888,7 @@ export function planShot (req) {
 
   const powers = req.state?.breakInProgress
     ? [1 * POWER_SCALE]
-    : [0.48 * POWER_SCALE, 0.66 * POWER_SCALE, 0.82 * POWER_SCALE, 0.94 * POWER_SCALE]
+    : [0.5 * POWER_SCALE, 0.66 * POWER_SCALE, 0.82 * POWER_SCALE, 0.94 * POWER_SCALE]
   const defaultSpins = [
     { top: 0, side: 0, back: 0 },
     { top: 0.3, side: 0, back: 0 },

--- a/test/poolAi.test.js
+++ b/test/poolAi.test.js
@@ -382,3 +382,57 @@ test('uses hidden helper numbers/colours when ids are missing', () => {
   const decision = planShot(req)
   assert.equal(decision.targetBallId, 3)
 })
+
+test('prioritises clearer pocket entrance when one lane is cluttered', () => {
+  const decision = planShot({
+    game: 'AMERICAN_BILLIARDS',
+    state: {
+      balls: [
+        { id: 0, x: 260, y: 250, vx: 0, vy: 0, pocketed: false },
+        { id: 1, x: 500, y: 250, vx: 0, vy: 0, pocketed: false },
+        // blocker near the top pocket entrance lane
+        { id: 12, x: 500, y: 74, vx: 0, vy: 0, pocketed: false }
+      ],
+      pockets: [
+        { x: 500, y: 0 },
+        { x: 500, y: 500 }
+      ],
+      width: 1000,
+      height: 500,
+      ballRadius: 10,
+      friction: 0.01,
+      legalBallIds: [1]
+    },
+    timeBudgetMs: 120,
+    rngSeed: 11
+  });
+
+  assert.equal(decision.targetBallId, 1);
+  assert(decision.targetPocket);
+  assert(decision.targetPocket.y > 300, 'should prefer the clearer bottom-pocket lane');
+});
+
+
+test('eight-pool targets black when only 8 remains and group metadata is missing', () => {
+  const decision = planShot({
+    game: 'EIGHT_POOL_UK',
+    state: {
+      balls: [
+        { id: 0, x: 140, y: 240, vx: 0, vy: 0, pocketed: false },
+        { id: 8, x: 520, y: 240, vx: 0, vy: 0, pocketed: false }
+      ],
+      pockets: [
+        { x: 0, y: 0 }, { x: 500, y: 0 }, { x: 1000, y: 0 },
+        { x: 0, y: 500 }, { x: 500, y: 500 }, { x: 1000, y: 500 }
+      ],
+      width: 1000,
+      height: 500,
+      ballRadius: 10,
+      friction: 0.01
+    },
+    rngSeed: 13,
+    timeBudgetMs: 100
+  });
+
+  assert.equal(decision.targetBallId, 8);
+});

--- a/test/poolRoyaleAiAimCompensation.test.js
+++ b/test/poolRoyaleAiAimCompensation.test.js
@@ -16,10 +16,10 @@ describe('Pool Royale AI aim compensation', () => {
     });
     expect(result).toBeTruthy();
     expect(result.aimDir.length()).toBeCloseTo(1, 5);
-    expect(Math.hypot(result.ghost.x - targetPos.x, result.ghost.y - targetPos.y)).toBeCloseTo(0.06, 4);
+    expect(Math.hypot(result.ghost.x - targetPos.x, result.ghost.y - targetPos.y)).toBeCloseTo(0.06024, 4);
   });
 
-  it('keeps pre-impact aim unchanged when only side spin changes', () => {
+  it('adjusts pre-impact aim when side spin/power deflection is present', () => {
     const neutral = resolveAiPotGhostAim({
       cuePos,
       targetPos,
@@ -37,7 +37,7 @@ describe('Pool Royale AI aim compensation', () => {
       power: 0.8
     });
     expect(withSide).toBeTruthy();
-    expect(neutral.aimDir.angleTo(withSide.aimDir)).toBeLessThan(1e-6);
+    expect(neutral.aimDir.angleTo(withSide.aimDir)).toBeGreaterThan(1e-4);
     expect(withSide.contactDepth).toBeCloseTo(neutral.contactDepth, 8);
   });
 
@@ -60,7 +60,7 @@ describe('Pool Royale AI aim compensation', () => {
       power: 1
     });
 
-    expect(neutral.contactDepth).toBeCloseTo(0.06, 5);
+    expect(neutral.contactDepth).toBeCloseTo(0.06024, 5);
     expect(topspin.contactDepth).toBeGreaterThan(neutral.contactDepth);
     expect(topspin.contactDepth - neutral.contactDepth).toBeLessThan(0.0015);
   });

--- a/webapp/public/lib/poolAi.js
+++ b/webapp/public/lib/poolAi.js
@@ -148,6 +148,31 @@ function pocketAlignment (pocket, target, width, height) {
   return Math.max(0, (approach.x / len) * normal.x + (approach.y / len) * normal.y)
 }
 
+function pocketEntranceOpenness (target, pocket, req) {
+  if (!target || !pocket || !req?.state) return 0
+  const r = req.state.ballRadius
+  const entry = pocketEntry(pocket, r, req.state.width, req.state.height, target)
+  const laneLen = Math.max(dist(target, entry), r * 2)
+  const laneDir = { x: (entry.x - target.x) / laneLen, y: (entry.y - target.y) / laneLen }
+  let minEdge = Infinity
+  for (const b of req.state.balls || []) {
+    if (!b || b.pocketed || b.id === target.id) continue
+    const relX = b.x - target.x
+    const relY = b.y - target.y
+    const along = relX * laneDir.x + relY * laneDir.y
+    if (along <= 0 || along >= laneLen + r * 1.8) continue
+    const lateral = Math.abs(relX * laneDir.y - relY * laneDir.x)
+    const edgeGap = lateral - r * 2
+    if (edgeGap < minEdge) minEdge = edgeGap
+  }
+  const clearance = Number.isFinite(minEdge)
+    ? Math.max(0, Math.min((minEdge + r * 0.9) / (r * 2.2), 1))
+    : 1
+  const alignment = pocketAlignment(pocket, target, req.state.width, req.state.height)
+  const straightness = Math.max(0, Math.min((alignment - 0.2) / 0.8, 1))
+  return Math.min(1, clearance * 0.65 + straightness * 0.35)
+}
+
 function ghostPointForTargetPocket (target, pocket, req) {
   const r = req.state.ballRadius
   const entry = pocketEntry(pocket, r, req.state.width, req.state.height, target)
@@ -298,7 +323,12 @@ function chooseTargets (req) {
       if (eight) return [eight]
       return []
     }
-    return balls.filter(b => b.id !== 8)
+    const openTargets = balls.filter(b => b.id !== 8)
+    if (openTargets.length === 0) {
+      const eight = balls.find(b => b.id === 8)
+      return eight ? [eight] : []
+    }
+    return openTargets
   }
   return balls
 }
@@ -361,7 +391,12 @@ function nextTargetsAfter (targetId, req) {
       if (eight) return [eight]
       return []
     }
-    return cloned.filter(b => b.id !== 8)
+    const openTargets = cloned.filter(b => b.id !== 8)
+    if (openTargets.length === 0) {
+      const eight = cloned.find(b => b.id === 8)
+      return eight ? [eight] : []
+    }
+    return openTargets
   }
   return cloned
 }
@@ -416,18 +451,20 @@ function clearShotCandidates (req) {
       const viewScore = Math.min(viewAngle / (Math.PI / 2), 1)
       const entryAlignment = pocketAlignment(pocket, target, req.state.width, req.state.height)
       const weightedView = viewScore * (0.7 + 0.3 * entryAlignment)
+      const entranceOpenness = pocketEntranceOpenness(target, pocket, req)
+      const pocketView = weightedView * (0.68 + 0.32 * entranceOpenness)
       const approachStraightness = 1 - Math.min(cut / (Math.PI / 2), 1)
       const cueToTarget = cue ? dist(cue, target) : 0
       const distanceScore = cue ? Math.max(0, 1 - cueToTarget / (r * 60)) : 0
       const rank =
-        weightedView * 0.46 +
-        approachStraightness * 0.25 +
-        distanceScore * 0.12 +
-        Math.max(0, 1 - cut / (Math.PI / 3.4)) * 0.17
+        pocketView * 0.5 +
+        approachStraightness * 0.3 +
+        distanceScore * 0.08 +
+        entranceOpenness * 0.12
 
       // require fairly central hit and open pocket view
-      if (cut <= maxCut && weightedView >= minView) {
-        candidates.push({ target, pocket, cut, view: weightedView, rank })
+      if (cut <= maxCut && pocketView >= minView) {
+        candidates.push({ target, pocket, cut, view: pocketView, rank })
       }
     }
   }
@@ -472,7 +509,8 @@ export function estimateCueAfterShot (cue, target, pocket, power, spin, table) {
 
   const cutDot = Math.max(-1, Math.min(1, shotDir.x * objectDir.x + shotDir.y * objectDir.y))
   const cutSeverity = Math.sqrt(Math.max(0, 1 - cutDot * cutDot))
-  const baseTravel = Math.max(table.ballRadius * 3, power * table.ballRadius * (18 - 3.6 * cutSeverity))
+  const tableRadius = Number.isFinite(table?.ballRadius) ? table.ballRadius : 10
+  const baseTravel = Math.max(tableRadius * 3, power * tableRadius * (18 - 3.6 * cutSeverity))
 
   // Stun component (natural tangent line), then follow/draw layered on top.
   const followAmount = Math.max(0, spin.top || 0)
@@ -850,7 +888,7 @@ export function planShot (req) {
 
   const powers = req.state?.breakInProgress
     ? [1 * POWER_SCALE]
-    : [0.48 * POWER_SCALE, 0.66 * POWER_SCALE, 0.82 * POWER_SCALE, 0.94 * POWER_SCALE]
+    : [0.5 * POWER_SCALE, 0.66 * POWER_SCALE, 0.82 * POWER_SCALE, 0.94 * POWER_SCALE]
   const defaultSpins = [
     { top: 0, side: 0, back: 0 },
     { top: 0.3, side: 0, back: 0 },

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1233,7 +1233,7 @@ const TABLE_MAPPING_VISUALS = Object.freeze({
 });
 const LOCK_REPLAY_CAMERA = false;
 const FIXED_RAIL_REPLAY_CAMERA = false;
-const LOCK_RAIL_OVERHEAD_FRAME = true;
+const LOCK_RAIL_OVERHEAD_FRAME = false;
 const REPLAY_CUE_STICK_HOLD_MS = 760;
 const REPLAY_CAMERA_START_DELAY_MS = 0;
   const TABLE_BASE_SCALE = 1.2;
@@ -5914,6 +5914,8 @@ const DEFAULT_SPIN_LIMITS = Object.freeze({
   maxY: 1
 });
 const MAX_TOPSPIN_INPUT = 0.8; // reduce topspin cap to match Snooker Royal feel
+const TOPSPIN_FOLLOW_TRANSFER_RATE = 0.38; // transfer a portion of top spin into forward roll each physics step for natural follow-through fade
+const TOPSPIN_FOLLOW_DECAY_ASSIST = 0.54; // accelerate only top-spin decay once forward roll is established so follow naturally settles
 const TOPSPIN_POWER_SOFT_CAP = 0.9;
 const clampSpinValue = (value) => clamp(value, -1, 1);
 const SPIN_CUSHION_EPS = BALL_R * 0.6;
@@ -6976,6 +6978,20 @@ function applySpinController(ball, stepScale, airborne = false) {
     }
     if (Math.abs(forwardSpin) > 1e-8) {
       ball.vel.addScaledVector(forward, forwardSpin * rollAccel);
+      if (forwardSpin > 0) {
+        const naturalRollSpeed = Math.max(BALL_R * 2.2, speed * 0.78);
+        const settling = THREE.MathUtils.clamp(speed / Math.max(naturalRollSpeed, 1e-6), 0, 1);
+        const transfer =
+          Math.min(
+            forwardSpin,
+            rollAccel * TOPSPIN_FOLLOW_TRANSFER_RATE * (0.35 + settling * 0.65)
+          );
+        ball.spin.y = Math.max(0, forwardSpin - transfer);
+        const assistedDecay = Math.exp(
+          -TOPSPIN_FOLLOW_DECAY_ASSIST * stepScale * (0.3 + 0.7 * settling)
+        );
+        ball.spin.y *= assistedDecay;
+      }
     }
   }
   return decaySpin(ball, stepScale, airborne);
@@ -15265,6 +15281,7 @@ const powerRef = useRef(hud.power);
   const lastCameraTargetRef = useRef(new THREE.Vector3(0, ORBIT_FOCUS_BASE_Y, 0));
   const replayCameraRef = useRef(null);
   const replayFrameCameraRef = useRef(null);
+  const replayCueHiddenRef = useRef({ hideFrom: Infinity, hideUntil: -Infinity });
   const updateSpinDotPosition = useCallback((value, blocked) => {
     if (!value) value = { x: 0, y: 0 };
     const dot = spinDotElRef.current;
@@ -19463,10 +19480,10 @@ const powerRef = useRef(hud.power);
           focusOverride = null,
           minTargetY = null
         } = {}) => {
-          // Keep replay 2D framing locked to the active broadcast top-view profile.
-          return resolveBroadcastTopViewCamera({
+          return resolveRailOverheadReplayCamera({
             focusOverride,
-            minTargetY
+            minTargetY,
+            preferredRail: railOverheadSideRef.current
           });
         };
 
@@ -20391,7 +20408,7 @@ const powerRef = useRef(hud.power);
           const scale = Number.isFinite(worldScaleFactor) ? worldScaleFactor : WORLD_SCALE;
           const minTargetY = Math.max(baseSurfaceWorldY, BALL_CENTER_Y * scale);
           let overheadApplied = false;
-          if (overheadVariant === 'replay' || overheadVariant === 'rail') {
+          if (overheadVariant === 'rail') {
             const overheadCamera = resolveRailOverheadReplayCamera({
               focusOverride: topFocusTarget,
               minTargetY,
@@ -21411,6 +21428,16 @@ const powerRef = useRef(hud.power);
               if (meshB.visible != null) {
                 ball.mesh.visible = meshB.visible;
               }
+              if (ball.id === 'cue' && replayPlaybackRef.current) {
+                const hidden = replayCueHiddenRef.current;
+                if (
+                  hidden &&
+                  targetTime >= (hidden.hideFrom ?? Infinity) &&
+                  targetTime < (hidden.hideUntil ?? -Infinity)
+                ) {
+                  ball.mesh.visible = false;
+                }
+              }
             }
             if (ball.shadow) {
               ball.shadow.visible = ball.mesh?.visible ?? ball.shadow.visible;
@@ -21961,7 +21988,8 @@ const powerRef = useRef(hud.power);
             return true;
           }
           if (sample.phase === 'recover') {
-            cueStick.position.copy(followPos ?? impactPos);
+            const eased = easeInOutCubic(sample.t);
+            cueStick.position.lerpVectors(followPos ?? impactPos, idlePos ?? impactPos, eased);
             cueStick.rotation.x = baseRotationX ?? cueStick.rotation.x;
             cueStick.rotation.y = baseRotationY ?? cueStick.rotation.y;
             syncCueShadow();
@@ -22197,13 +22225,22 @@ const powerRef = useRef(hud.power);
           pendingImpactRef.current = null;
           setReplayActive(true);
           setReplayFoul(shotRecording?.replayFoul ?? null);
-          overheadBroadcastVariantRef.current = 'replay';
+          overheadBroadcastVariantRef.current = 'rail';
           storeReplayCameraFrame();
           resetCameraForReplay();
+          const replayCueStroke = trimmed.cueStroke ?? null;
+          const replayCueHideFrom = replayCueStroke
+            ? Math.max(
+                120,
+                (replayCueStroke.pullback ?? replayCueStroke.pullbackDuration ?? 0) +
+                  (replayCueStroke.release ?? replayCueStroke.releaseDuration ?? 0) * 0.72
+              )
+            : 180;
+          replayCueHiddenRef.current = { hideFrom: replayCueHideFrom, hideUntil: duration };
           replayPlayback = {
             frames: trimmed.frames,
             cuePath: trimmed.cuePath,
-            cueStroke: trimmed.cueStroke ?? null,
+            cueStroke: replayCueStroke,
             duration,
             startedAt: performance.now(),
             lastIndex: 0,
@@ -22286,6 +22323,7 @@ const powerRef = useRef(hud.power);
           replayCameraRef.current = null;
           replayFrameCameraRef.current = null;
           overheadBroadcastVariantRef.current = 'rail';
+          replayCueHiddenRef.current = { hideFrom: Infinity, hideUntil: -Infinity };
           setReplayActive(false);
           setReplayFoul(null);
         };

--- a/webapp/src/pages/Games/poolRoyaleAiAimCompensation.js
+++ b/webapp/src/pages/Games/poolRoyaleAiAimCompensation.js
@@ -2,6 +2,8 @@ import * as THREE from 'three';
 
 const MIN_VECTOR_EPS = 1e-6;
 const DEFAULT_CONTACT_CALIBRATION = 0.004;
+const DEFAULT_SIDE_DEFLECTION_SCALE = 0.018;
+const DEFAULT_POWER_DEFLECTION_SCALE = 0.01;
 
 export const resolveAiPotGhostAim = ({
   cuePos,
@@ -18,6 +20,7 @@ export const resolveAiPotGhostAim = ({
   if (toPocket.lengthSq() <= MIN_VECTOR_EPS) return null;
 
   const toPocketDir = toPocket.normalize();
+  const sideSpin = THREE.MathUtils.clamp(spin?.x ?? 0, -1, 1);
   const topBackSpin = THREE.MathUtils.clamp(spin?.y ?? 0, -1, 1);
   const power01 = THREE.MathUtils.clamp(power ?? 0.6, 0, 1);
 
@@ -30,9 +33,28 @@ export const resolveAiPotGhostAim = ({
   );
   const contactDepth = radius * 2 * (1 + calibration + topBackSpin * power01 * 0.015);
 
+  const cueToTargetDir = new THREE.Vector2().subVectors(targetPos, cuePos);
+  if (cueToTargetDir.lengthSq() <= MIN_VECTOR_EPS) return null;
+  cueToTargetDir.normalize();
+  const cutAlignment = THREE.MathUtils.clamp(cueToTargetDir.dot(toPocketDir), -1, 1);
+  const cutSeverity = Math.sqrt(Math.max(0, 1 - cutAlignment * cutAlignment));
+  const sideDeflection =
+    sideSpin *
+    power01 *
+    DEFAULT_SIDE_DEFLECTION_SCALE *
+    (0.45 + cutSeverity * 0.55);
+  const powerDeflection =
+    topBackSpin *
+    power01 *
+    DEFAULT_POWER_DEFLECTION_SCALE *
+    (0.65 + 0.35 * (1 - cutSeverity));
+  const lateralUnit = new THREE.Vector2(-toPocketDir.y, toPocketDir.x);
+
   const ghost = new THREE.Vector2()
     .copy(targetPos)
-    .sub(toPocketDir.clone().multiplyScalar(contactDepth));
+    .sub(toPocketDir.clone().multiplyScalar(contactDepth))
+    .addScaledVector(lateralUnit, sideDeflection)
+    .addScaledVector(toPocketDir, powerDeflection);
 
   const finalCueVector = new THREE.Vector2().subVectors(ghost, cuePos);
   if (finalCueVector.lengthSq() <= MIN_VECTOR_EPS) return null;


### PR DESCRIPTION
### Motivation
- Improve shot selection by measuring how open a pocket entrance lane is (to prefer clearer lanes when nearby balls clutter an approach). 
- Make target selection robust for `EIGHT_POOL_UK` when group metadata is missing so the 8 ball is targeted when it is the only remaining object. 
- Harden aim/physics computations against missing table metadata and better model spin/power deflection and topspin transfer to rolling. 

### Description
- Add a new helper `pocketEntranceOpenness` and incorporate it into `clearShotCandidates` to compute a `pocketView` and factor `entranceOpenness` into candidate ranking and filtering. 
- Adjust `chooseTargets` and `nextTargetsAfter` for `EIGHT_POOL_UK` to return the 8 ball when no other open targets remain. 
- Make `estimateCueAfterShot` tolerate missing `table.ballRadius` by falling back to a safe default and use that value for travel computations. 
- Tweak the initial candidate `powers` list used by `planShot` to use a slightly higher lowest power (`0.5 * POWER_SCALE`). 
- Refine aim compensation in `resolveAiPotGhostAim` by adding side/power deflection scaling and a small calibration that nudges the ghost aim for side/top/back spin and power. 
- Introduce `TOPSPIN_FOLLOW_TRANSFER_RATE` and `TOPSPIN_FOLLOW_DECAY_ASSIST` and apply logic in `applySpinController` to transfer some topspin into forward roll and accelerate topspin decay once forward roll is established. 
- Add replay cue-hide support via `replayCueHiddenRef` and hide the cue mesh during the part of the replay where the cue should be out of view, and switch several replay defaults/overhead variant choices and a minor cue-stick recovery easing tweak. 
- Update public/browser build copies of `poolAi.js` to mirror the library changes. 

### Testing
- Ran the unit test suite including the updated `test/poolAi.test.js` additions, and the modified `test/poolRoyaleAiAimCompensation.test.js` expectations, and all tests passed. 
- Verified the new pocket-entrance scenario test `prioritises clearer pocket entrance when one lane is cluttered` passes under the AI planner. 
- Verified the eight-pool fallback test `eight-pool targets black when only 8 remains and group metadata is missing` passes. 
- Verified aim compensation test adjustments in `poolRoyaleAiAimCompensation.test.js` pass with the new deflection/contact constants.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7dc0233ec8329b764e780f67337af)