### PR TITLE
Improve Pool Royale AI pocket targeting, topspin follow realism, and cue/replay stroke

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -123,20 +123,55 @@ function pocketNormal (pocket, width, height) {
   return { x: dir.x / len, y: dir.y / len }
 }
 
+function classifyPocket (pocket, width, height, radius) {
+  const edgeTol = Math.max(radius * 2.25, Math.min(width, height) * 0.1)
+  const nearLeft = pocket.x <= edgeTol
+  const nearRight = pocket.x >= width - edgeTol
+  const nearTop = pocket.y <= edgeTol
+  const nearBottom = pocket.y >= height - edgeTol
+  if ((nearLeft || nearRight) && (nearTop || nearBottom)) return 'corner'
+  return 'side'
+}
+
+function pocketMouthHalfWidth (pocket, radius, width, height) {
+  const type = classifyPocket(pocket, width, height, radius)
+  return type === 'corner' ? radius * 2.55 : radius * 2.9
+}
+
+function pocketMouthTangent (pocket, width, height, radius) {
+  const type = classifyPocket(pocket, width, height, radius)
+  if (type === 'corner') {
+    const normal = pocketNormal(pocket, width, height)
+    const tangent = { x: -normal.y, y: normal.x }
+    const len = Math.hypot(tangent.x, tangent.y) || 1
+    return { x: tangent.x / len, y: tangent.y / len }
+  }
+  const dx = Math.abs(pocket.x - width / 2)
+  const dy = Math.abs(pocket.y - height / 2)
+  return dx >= dy ? { x: 0, y: 1 } : { x: 1, y: 0 }
+}
+
 function pocketEntry (pocket, radius, width, height, target) {
   const normal = pocketNormal(pocket, width, height)
-  let dir = normal
-
-  if (target) {
-    dir = { x: pocket.x - target.x, y: pocket.y - target.y }
-    const len = Math.hypot(dir.x, dir.y) || 1
-    dir = { x: dir.x / len, y: dir.y / len }
+  const mouthHalf = pocketMouthHalfWidth(pocket, radius, width, height)
+  const tangent = pocketMouthTangent(pocket, width, height, radius)
+  const offset = radius * 1.34
+  const entranceCenter = {
+    x: pocket.x + normal.x * offset,
+    y: pocket.y + normal.y * offset
   }
-
-  const offset = radius * 1.05
+  if (!target) return entranceCenter
+  const approach = {
+    x: entranceCenter.x - target.x,
+    y: entranceCenter.y - target.y
+  }
+  const approachLen = Math.hypot(approach.x, approach.y) || 1
+  const approachNorm = { x: approach.x / approachLen, y: approach.y / approachLen }
+  const lateral = approachNorm.x * tangent.x + approachNorm.y * tangent.y
+  const lateralShift = Math.max(-mouthHalf * 0.82, Math.min(mouthHalf * 0.82, lateral * mouthHalf * 0.5))
   return {
-    x: pocket.x - dir.x * offset,
-    y: pocket.y - dir.y * offset
+    x: entranceCenter.x + tangent.x * lateralShift,
+    y: entranceCenter.y + tangent.y * lateralShift
   }
 }
 
@@ -457,10 +492,10 @@ function clearShotCandidates (req) {
       const cueToTarget = cue ? dist(cue, target) : 0
       const distanceScore = cue ? Math.max(0, 1 - cueToTarget / (r * 60)) : 0
       const rank =
-        pocketView * 0.5 +
-        approachStraightness * 0.3 +
-        distanceScore * 0.08 +
-        entranceOpenness * 0.12
+        pocketView * 0.42 +
+        approachStraightness * 0.38 +
+        distanceScore * 0.06 +
+        entranceOpenness * 0.14
 
       // require fairly central hit and open pocket view
       if (cut <= maxCut && pocketView >= minView) {
@@ -636,7 +671,6 @@ function estimateRunoutPotential (req, cueAfter, targetId, balls, depth = 1, rng
   }
   return best
 }
-
 
 function buildSpinCandidates (cue, target, pocket, req) {
   const base = [

--- a/webapp/public/lib/poolAi.js
+++ b/webapp/public/lib/poolAi.js
@@ -123,20 +123,55 @@ function pocketNormal (pocket, width, height) {
   return { x: dir.x / len, y: dir.y / len }
 }
 
+function classifyPocket (pocket, width, height, radius) {
+  const edgeTol = Math.max(radius * 2.25, Math.min(width, height) * 0.1)
+  const nearLeft = pocket.x <= edgeTol
+  const nearRight = pocket.x >= width - edgeTol
+  const nearTop = pocket.y <= edgeTol
+  const nearBottom = pocket.y >= height - edgeTol
+  if ((nearLeft || nearRight) && (nearTop || nearBottom)) return 'corner'
+  return 'side'
+}
+
+function pocketMouthHalfWidth (pocket, radius, width, height) {
+  const type = classifyPocket(pocket, width, height, radius)
+  return type === 'corner' ? radius * 2.55 : radius * 2.9
+}
+
+function pocketMouthTangent (pocket, width, height, radius) {
+  const type = classifyPocket(pocket, width, height, radius)
+  if (type === 'corner') {
+    const normal = pocketNormal(pocket, width, height)
+    const tangent = { x: -normal.y, y: normal.x }
+    const len = Math.hypot(tangent.x, tangent.y) || 1
+    return { x: tangent.x / len, y: tangent.y / len }
+  }
+  const dx = Math.abs(pocket.x - width / 2)
+  const dy = Math.abs(pocket.y - height / 2)
+  return dx >= dy ? { x: 0, y: 1 } : { x: 1, y: 0 }
+}
+
 function pocketEntry (pocket, radius, width, height, target) {
   const normal = pocketNormal(pocket, width, height)
-  let dir = normal
-
-  if (target) {
-    dir = { x: pocket.x - target.x, y: pocket.y - target.y }
-    const len = Math.hypot(dir.x, dir.y) || 1
-    dir = { x: dir.x / len, y: dir.y / len }
+  const mouthHalf = pocketMouthHalfWidth(pocket, radius, width, height)
+  const tangent = pocketMouthTangent(pocket, width, height, radius)
+  const offset = radius * 1.34
+  const entranceCenter = {
+    x: pocket.x + normal.x * offset,
+    y: pocket.y + normal.y * offset
   }
-
-  const offset = radius * 1.05
+  if (!target) return entranceCenter
+  const approach = {
+    x: entranceCenter.x - target.x,
+    y: entranceCenter.y - target.y
+  }
+  const approachLen = Math.hypot(approach.x, approach.y) || 1
+  const approachNorm = { x: approach.x / approachLen, y: approach.y / approachLen }
+  const lateral = approachNorm.x * tangent.x + approachNorm.y * tangent.y
+  const lateralShift = Math.max(-mouthHalf * 0.82, Math.min(mouthHalf * 0.82, lateral * mouthHalf * 0.5))
   return {
-    x: pocket.x - dir.x * offset,
-    y: pocket.y - dir.y * offset
+    x: entranceCenter.x + tangent.x * lateralShift,
+    y: entranceCenter.y + tangent.y * lateralShift
   }
 }
 
@@ -457,10 +492,10 @@ function clearShotCandidates (req) {
       const cueToTarget = cue ? dist(cue, target) : 0
       const distanceScore = cue ? Math.max(0, 1 - cueToTarget / (r * 60)) : 0
       const rank =
-        pocketView * 0.5 +
-        approachStraightness * 0.3 +
-        distanceScore * 0.08 +
-        entranceOpenness * 0.12
+        pocketView * 0.42 +
+        approachStraightness * 0.38 +
+        distanceScore * 0.06 +
+        entranceOpenness * 0.14
 
       // require fairly central hit and open pocket view
       if (cut <= maxCut && pocketView >= minView) {
@@ -636,7 +671,6 @@ function estimateRunoutPotential (req, cueAfter, targetId, balls, depth = 1, rng
   }
   return best
 }
-
 
 function buildSpinCandidates (cue, target, pocket, req) {
   const base = [

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5916,6 +5916,8 @@ const DEFAULT_SPIN_LIMITS = Object.freeze({
 const MAX_TOPSPIN_INPUT = 0.8; // reduce topspin cap to match Snooker Royal feel
 const TOPSPIN_FOLLOW_TRANSFER_RATE = 0.38; // transfer a portion of top spin into forward roll each physics step for natural follow-through fade
 const TOPSPIN_FOLLOW_DECAY_ASSIST = 0.54; // accelerate only top-spin decay once forward roll is established so follow naturally settles
+const TOPSPIN_NATURAL_ROLL_RATIO = 0.86; // expected forward spin magnitude once the cue ball settles into natural roll
+const TOPSPIN_EXTRA_PUSH_SLIP_RATIO = 0.68; // use only the slip component above natural roll to keep follow realistic
 const TOPSPIN_POWER_SOFT_CAP = 0.9;
 const clampSpinValue = (value) => clamp(value, -1, 1);
 const SPIN_CUSHION_EPS = BALL_R * 0.6;
@@ -6977,8 +6979,12 @@ function applySpinController(ball, stepScale, airborne = false) {
       rollAccel *= backspinBoost;
     }
     if (Math.abs(forwardSpin) > 1e-8) {
-      ball.vel.addScaledVector(forward, forwardSpin * rollAccel);
       if (forwardSpin > 0) {
+        const naturalRollSpin = speed * TOPSPIN_NATURAL_ROLL_RATIO;
+        const topSlip = Math.max(0, forwardSpin - naturalRollSpin);
+        const effectiveTopPush =
+          naturalRollSpin + topSlip * TOPSPIN_EXTRA_PUSH_SLIP_RATIO;
+        ball.vel.addScaledVector(forward, effectiveTopPush * rollAccel);
         const naturalRollSpeed = Math.max(BALL_R * 2.2, speed * 0.78);
         const settling = THREE.MathUtils.clamp(speed / Math.max(naturalRollSpeed, 1e-6), 0, 1);
         const transfer =
@@ -6991,6 +6997,8 @@ function applySpinController(ball, stepScale, airborne = false) {
           -TOPSPIN_FOLLOW_DECAY_ASSIST * stepScale * (0.3 + 0.7 * settling)
         );
         ball.spin.y *= assistedDecay;
+      } else {
+        ball.vel.addScaledVector(forward, forwardSpin * rollAccel);
       }
     }
   }
@@ -21845,6 +21853,7 @@ const powerRef = useRef(hud.power);
           if (forwardOnly) {
             const safeStrikeDuration = Math.max(1, strikeDuration ?? 120);
             const safeHoldDuration = Math.max(0, holdDuration ?? 50);
+            const safeRecoverDuration = Math.max(120, recoverDuration ?? 180);
             const impactThreshold = THREE.MathUtils.clamp(
               strikeImpactThreshold ?? 0.9,
               0,
@@ -21903,7 +21912,35 @@ const powerRef = useRef(hud.power);
               stroke.shotApplied = true;
               stroke.onImpact?.();
             }
+            const totalForwardWindow = safeStrikeDuration + safeHoldDuration + safeRecoverDuration;
+            if (elapsed < safeStrikeDuration) {
+              cueAnimating = true;
+              syncCueShadow();
+              return true;
+            }
             if (elapsed < safeStrikeDuration + safeHoldDuration) {
+              const holdT = THREE.MathUtils.clamp(
+                (elapsed - safeStrikeDuration) / Math.max(safeHoldDuration, 1e-6),
+                0,
+                1
+              );
+              cueStick.position.lerpVectors(impactPos, followPos ?? impactPos, easeOutCubic(holdT));
+              cueAnimating = true;
+              syncCueShadow();
+              return true;
+            }
+            if (elapsed < totalForwardWindow) {
+              const recoverT = THREE.MathUtils.clamp(
+                (elapsed - safeStrikeDuration - safeHoldDuration) /
+                  Math.max(safeRecoverDuration, 1e-6),
+                0,
+                1
+              );
+              cueStick.position.lerpVectors(
+                followPos ?? impactPos,
+                idlePos ?? impactPos,
+                easeInOutCubic(recoverT)
+              );
               cueAnimating = true;
               syncCueShadow();
               return true;
@@ -22221,6 +22258,44 @@ const powerRef = useRef(hud.power);
           const trimmed = trimReplayRecording(shotRecording);
           const duration = trimmed.duration;
           if (!Number.isFinite(duration) || duration <= 0) return;
+          const resolveReplayCueStopTime = (frames, maxDuration) => {
+            if (!Array.isArray(frames) || frames.length < 2) return maxDuration;
+            const minStableWindow = 180;
+            const stopSpeedSq = Math.pow(BALL_R * 0.55, 2);
+            const extractCuePos = (frame) => {
+              const cueBall = frame?.balls?.find?.((entry) => String(entry?.id) === 'cue');
+              const pos = cueBall?.mesh?.position ?? cueBall?.pos;
+              if (!pos || !Number.isFinite(pos.x)) return null;
+              const z = Number.isFinite(pos.z) ? pos.z : pos.y;
+              if (!Number.isFinite(z)) return null;
+              return { x: pos.x, z };
+            };
+            let stableFrom = null;
+            let candidate = maxDuration;
+            for (let i = 1; i < frames.length; i += 1) {
+              const prev = frames[i - 1];
+              const curr = frames[i];
+              const p0 = extractCuePos(prev);
+              const p1 = extractCuePos(curr);
+              if (!p0 || !p1) continue;
+              const dtMs = Math.max(1, (curr.t ?? 0) - (prev.t ?? 0));
+              const invDt = 1000 / dtMs;
+              const vx = (p1.x - p0.x) * invDt;
+              const vz = (p1.z - p0.z) * invDt;
+              const speedSq = vx * vx + vz * vz;
+              if (speedSq <= stopSpeedSq) {
+                stableFrom = stableFrom ?? (curr.t ?? 0);
+                const stableElapsed = (curr.t ?? 0) - stableFrom;
+                if (stableElapsed >= minStableWindow) {
+                  candidate = curr.t ?? candidate;
+                  break;
+                }
+              } else {
+                stableFrom = null;
+              }
+            }
+            return THREE.MathUtils.clamp(candidate, 0, maxDuration);
+          };
           cueStrokeStateRef.current = null;
           pendingImpactRef.current = null;
           setReplayActive(true);
@@ -22236,7 +22311,11 @@ const powerRef = useRef(hud.power);
                   (replayCueStroke.release ?? replayCueStroke.releaseDuration ?? 0) * 0.72
               )
             : 180;
-          replayCueHiddenRef.current = { hideFrom: replayCueHideFrom, hideUntil: duration };
+          const replayCueShowAt = resolveReplayCueStopTime(trimmed.frames, duration);
+          replayCueHiddenRef.current = {
+            hideFrom: replayCueHideFrom,
+            hideUntil: Math.max(replayCueHideFrom + 80, replayCueShowAt)
+          };
           replayPlayback = {
             frames: trimmed.frames,
             cuePath: trimmed.cuePath,
@@ -25545,7 +25624,10 @@ const powerRef = useRef(hud.power);
           const pullbackDuration = strokeProfile.pullbackDuration ?? 0;
           const startTime = performance.now();
           const impactPos = idlePos.clone();
-          const followPos = impactPos.clone();
+          const followTravel = Math.max(BALL_R * 0.55, CUE_FOLLOW_THROUGH_MAX * 0.18);
+          const followPos = impactPos
+            .clone()
+            .addScaledVector(dir, followTravel);
           const followDurationResolved = strikeHoldDuration;
           const recoverDuration = strokeProfile.recoverDuration ?? 0;
           const forwardPreviewHold =


### PR DESCRIPTION
### Motivation
- AI was aiming too close to pocket jaws and not toward the effective center of the pocket opening, causing imprecise pots. 
- Top-spin follow behaved unnaturally compared to real-life cue-ball follow (over-driven or not settling into forward roll). 
- Cue-stick replay and live stroke presentation lacked a visible professional follow-through and timely cue-ball visibility in replays.

### Description
- Added pocket classification and entrance modeling (`classifyPocket`, `pocketMouthHalfWidth`, `pocketMouthTangent`) and replaced the old pocket entry computation with a mouth-centered entrance point that shifts laterally based on approach angle (`pocketEntry`). (files: `lib/poolAi.js`, `webapp/public/lib/poolAi.js`).
- Rebalanced AI shot ranking weights to prefer straighter, clearer pocket approaches by increasing straightness/entrance influence and slightly lowering raw pocket-view weight. (file: `lib/poolAi.js`).
- Refined topspin-to-roll logic so topspin pushes the cue ball using a natural-roll + slip model and only uses the slip portion for extra push, then decays follow naturally; kept backspin behavior unchanged. (file: `webapp/src/pages/Games/PoolRoyale.jsx`).
- Improved cue stroke visuals by adding an explicit forward follow-through and a recover-to-idle phase for live forward strikes, and by computing a replay cue visibility window that reveals the cue ball once recorded motion stabilizes (hide after impact, reveal when cue motion is settled). (file: `webapp/src/pages/Games/PoolRoyale.jsx`).

### Testing
- Ran syntax checks: `node --check lib/poolAi.js` and `node --check webapp/public/lib/poolAi.js` and both succeeded. 
- Ran linting: `npx eslint lib/poolAi.js` and it passed (note: the main `PoolRoyale.jsx` source is ignored by repo ESLint config during this run). 
- Smoke-verified that the updated runtime AI bundle was copied to `webapp/public/lib/poolAi.js` and that no runtime syntax errors were introduced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8b0f6a1388329af078fb2b1320875)