### PR TITLE
Improve pool shot precision: pocket targeting, deflection compensation and cue motion

### DIFF
--- a/Assets/Scripts/Aiming/AimingConfig.cs
+++ b/Assets/Scripts/Aiming/AimingConfig.cs
@@ -19,6 +19,18 @@ namespace Aiming
         public float tipOffsetMax = 0.85f;
         public float elevationForPower = 4f;
 
+        [Header("AI pocketing")]
+        [Tooltip("How much to bias the object-ball target from pocket center toward the visible mouth opening.")]
+        [Range(0f, 1f)] public float pocketEntranceBias = 1f;
+        [Tooltip("Extra score weight for straighter object→pocket lines.")]
+        [Range(0f, 2f)] public float straightShotPriority = 1.15f;
+        [Tooltip("Extra score weight for open pocket entrance visibility.")]
+        [Range(0f, 2f)] public float clearEntrancePriority = 1.25f;
+
+        [Header("AI deflection compensation")]
+        [Tooltip("How strongly AI compensates cue-ball squirt/deflection at higher power.")]
+        [Range(0f, 2f)] public float powerDeflectionCompensation = 1f;
+
         [Header("Debug")]
         public bool showDebugDefault = true;
         public Color lineColor = new Color(0.1f, 0.9f, 0.9f, 0.9f);

--- a/Assets/Scripts/Aiming/ShotClassifier.cs
+++ b/Assets/Scripts/Aiming/ShotClassifier.cs
@@ -22,8 +22,9 @@ namespace Aiming
             var vOP = (ctx.pocketPos - ctx.objectBallPos).normalized;
             var vOC = (ctx.cueBallPos - ctx.objectBallPos).normalized;
             float dot = Mathf.Clamp(Vector3.Dot(vOP, vOC), -1f, 1f);
-            float angle = Mathf.Acos(dot) * Mathf.Rad2Deg;
-            bool isStraight = angle <= cfg.straightAngleDeg;
+            float objectCutAngle = Mathf.Acos(dot) * Mathf.Rad2Deg;
+            float approachError = Mathf.Abs(180f - objectCutAngle);
+            bool isStraight = approachError <= cfg.straightAngleDeg;
 
             float d = Vector3.Distance(ctx.cueBallPos, ctx.objectBallPos);
             DistBucket bucket =
@@ -38,7 +39,7 @@ namespace Aiming
 
             return new ShotInfo
             {
-                angleDeg = angle,
+                angleDeg = approachError,
                 isStraight = isStraight,
                 isRailShot = rail,
                 losCueToObj = losCO,

--- a/Assets/Scripts/Gameplay/CueController.cs
+++ b/Assets/Scripts/Gameplay/CueController.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using UnityEngine;
+using Aiming.Pockets;
 
 namespace Aiming
 {
@@ -15,6 +16,9 @@ namespace Aiming
         public AdaptiveAimingEngine aiming;
         public Transform cueTip;
         public Transform cueBall, objectBall, pocket;
+        [Header("AI pocket mapping")]
+        public PocketMouth[] pocketMouths;
+        public Transform[] pocketFallbacks;
         public Rigidbody cueBallBody;
         public Bounds tableBounds;
         public float ballRadius = 0.028575f;
@@ -51,12 +55,27 @@ namespace Aiming
         float _power;
         float _latchedShotPower;
         ShotState _shotState = ShotState.Idle;
+        Renderer[] _cueRenderers;
+        bool _cueHiddenUntilBallsStop;
 
         void Update()
         {
             if (aiming == null || cueBall == null || objectBall == null || pocket == null)
             {
                 return;
+            }
+
+            if (_cueHiddenUntilBallsStop)
+            {
+                if (!AreBallsMoving())
+                {
+                    SetCueVisualVisible(true);
+                    _cueHiddenUntilBallsStop = false;
+                }
+                else
+                {
+                    return;
+                }
             }
 
             if (_shotState == ShotState.Striking)
@@ -159,6 +178,10 @@ namespace Aiming
                     bool canAdjustAim = _shotState != ShotState.Dragging || allowAimAdjustWhileCharging;
                     if (canAdjustAim)
                     {
+                        float aimPower = Mathf.Max(_power, sol.recommendedPower01);
+                        float deflectionComp = aiming != null && aiming.config != null ? aiming.config.powerDeflectionCompensation : 1f;
+                        float deflection = strikePhysics.ComputeDeflectionDegrees(spinInput.x, aimPower) * deflectionComp;
+                        desiredDirection = Quaternion.AngleAxis(-deflection, Vector3.up) * desiredDirection;
                         _targetDirection = desiredDirection;
                     }
                 }
@@ -199,11 +222,12 @@ namespace Aiming
 
         ShotSolution BuildAimSolution()
         {
+            Vector3 pocketTarget = ResolveBestPocketTarget();
             ShotContext ctx = new ShotContext
             {
                 cueBallPos = cueBall.position,
                 objectBallPos = objectBall.position,
-                pocketPos = pocket.position,
+                pocketPos = pocketTarget,
                 ballRadius = ballRadius,
                 tableBounds = tableBounds,
                 requiresPower = false,
@@ -211,6 +235,86 @@ namespace Aiming
                 collisionMask = aiming.config ? aiming.config.collisionMask : default
             };
             return aiming.GetAimSolution(ctx);
+        }
+
+        Vector3 ResolveBestPocketTarget()
+        {
+            if (objectBall == null)
+            {
+                return pocket != null ? pocket.position : Vector3.zero;
+            }
+
+            float bestScore = float.NegativeInfinity;
+            Vector3 bestTarget = pocket != null ? pocket.position : objectBall.position;
+            bool hasCandidate = false;
+
+            if (pocketMouths != null)
+            {
+                for (int i = 0; i < pocketMouths.Length; i++)
+                {
+                    PocketMouth mouth = pocketMouths[i];
+                    if (mouth == null || !mouth.IsConfigured)
+                    {
+                        continue;
+                    }
+
+                    Vector3 mouthCenter = mouth.MouthCenterWorld;
+                    Vector3 pocketCenter = mouth.PocketCenterWorld;
+                    float bias = aiming != null && aiming.config != null ? aiming.config.pocketEntranceBias : 1f;
+                    Vector3 target = Vector3.Lerp(pocketCenter, mouthCenter, Mathf.Clamp01(bias));
+                    float score = ScorePocketTarget(target);
+                    if (score > bestScore)
+                    {
+                        hasCandidate = true;
+                        bestScore = score;
+                        bestTarget = target;
+                    }
+                }
+            }
+
+            if (!hasCandidate && pocketFallbacks != null)
+            {
+                for (int i = 0; i < pocketFallbacks.Length; i++)
+                {
+                    Transform candidate = pocketFallbacks[i];
+                    if (candidate == null)
+                    {
+                        continue;
+                    }
+
+                    float score = ScorePocketTarget(candidate.position);
+                    if (score > bestScore)
+                    {
+                        hasCandidate = true;
+                        bestScore = score;
+                        bestTarget = candidate.position;
+                    }
+                }
+            }
+
+            return bestTarget;
+        }
+
+        float ScorePocketTarget(Vector3 target)
+        {
+            Vector3 objToPocket = target - objectBall.position;
+            if (objToPocket.sqrMagnitude < 1e-6f)
+            {
+                return float.NegativeInfinity;
+            }
+
+            Vector3 objToCue = cueBall.position - objectBall.position;
+            Vector3 toPocketDir = objToPocket.normalized;
+            Vector3 toCueDir = objToCue.sqrMagnitude > 1e-6f ? objToCue.normalized : -toPocketDir;
+
+            float approach = Mathf.Clamp01((-Vector3.Dot(toPocketDir, toCueDir) + 1f) * 0.5f);
+            float openness = PhysicsUtil.SphereLineClear(objectBall.position, target, ballRadius * 0.98f,
+                aiming != null && aiming.config != null ? aiming.config.collisionMask : default) ? 1f : 0f;
+
+            float straightWeight = aiming != null && aiming.config != null ? aiming.config.straightShotPriority : 1.15f;
+            float clearWeight = aiming != null && aiming.config != null ? aiming.config.clearEntrancePriority : 1.25f;
+            float distancePenalty = objToPocket.magnitude * 0.15f;
+            return (approach * straightWeight) + (openness * clearWeight) - distancePenalty;
         }
 
         bool AreBallsMoving()
@@ -221,6 +325,7 @@ namespace Aiming
         IEnumerator StrikeRoutine(float shotPower)
         {
             _shotState = ShotState.Striking;
+            SetCueVisualVisible(true);
 
             Vector3 strikeDirection = _aimDirection;
             float pull = pullRange * EaseOutCubic(shotPower);
@@ -257,6 +362,8 @@ namespace Aiming
                 {
                     didStrike = true;
                     ApplyStrikeImpulse(strikeDirection, shotPower);
+                    SetCueVisualVisible(false);
+                    _cueHiddenUntilBallsStop = true;
                 }
 
                 yield return null;
@@ -265,6 +372,8 @@ namespace Aiming
             if (!didStrike)
             {
                 ApplyStrikeImpulse(strikeDirection, shotPower);
+                SetCueVisualVisible(false);
+                _cueHiddenUntilBallsStop = true;
             }
 
             _currentCueDepth = contactDepth;
@@ -294,6 +403,28 @@ namespace Aiming
             t = Mathf.Clamp01(t);
             float inv = 1f - t;
             return 1f - (inv * inv * inv);
+        }
+
+        void Awake()
+        {
+            _cueRenderers = GetComponentsInChildren<Renderer>(true);
+            SetCueVisualVisible(true);
+        }
+
+        void SetCueVisualVisible(bool visible)
+        {
+            if (_cueRenderers == null)
+            {
+                return;
+            }
+
+            for (int i = 0; i < _cueRenderers.Length; i++)
+            {
+                if (_cueRenderers[i] != null)
+                {
+                    _cueRenderers[i].enabled = visible;
+                }
+            }
         }
     }
 }

--- a/Assets/Scripts/Gameplay/CueStrikePhysics.cs
+++ b/Assets/Scripts/Gameplay/CueStrikePhysics.cs
@@ -22,6 +22,17 @@ namespace Aiming
         public float sideSpinTorqueScale = 0.05f;
         [Tooltip("Torque multiplier for top/back spin.")]
         public float verticalSpinTorqueScale = 0.06f;
+        [Tooltip("Maximum cue-ball squirt angle (degrees) at full side spin and full power.")]
+        [Range(0f, 8f)] public float maxPowerDeflectionDeg = 2.2f;
+        [Tooltip("How strongly top spin converts to natural rolling follow after contact.")]
+        [Range(0f, 0.5f)] public float topSpinFollowRollScale = 0.18f;
+
+        public float ComputeDeflectionDegrees(float sideSpin, float normalizedPower)
+        {
+            float clampedSide = Mathf.Clamp(sideSpin, -1f, 1f);
+            float powerFactor = Mathf.Clamp01(normalizedPower);
+            return clampedSide * maxPowerDeflectionDeg * powerFactor;
+        }
 
         public void Apply(Rigidbody cueBallBody, Vector3 strikeDirection, float impulseMagnitude, Vector2 spinInput, float ballRadius)
         {
@@ -45,7 +56,11 @@ namespace Aiming
             Vector3 contactOffset = ((right * clampedSpin.x) + (Vector3.up * clampedSpin.y)) * (ballRadius * contactRadiusFactor);
             Vector3 contactPoint = cueBallBody.worldCenterOfMass + contactOffset;
 
-            cueBallBody.AddForceAtPosition(planarDirection * impulseMagnitude, contactPoint, ForceMode.Impulse);
+            float normalizedPower = Mathf.Clamp01((impulseMagnitude - 1.8f) / Mathf.Max(0.01f, 6.5f - 1.8f));
+            float deflectionDeg = ComputeDeflectionDegrees(clampedSpin.x, normalizedPower);
+            Vector3 compensatedDirection = Quaternion.AngleAxis(deflectionDeg, Vector3.up) * planarDirection;
+
+            cueBallBody.AddForceAtPosition(compensatedDirection * impulseMagnitude, contactPoint, ForceMode.Impulse);
 
             if (Mathf.Abs(clampedSpin.x) > Mathf.Epsilon || Mathf.Abs(clampedSpin.y) > Mathf.Epsilon)
             {
@@ -53,12 +68,22 @@ namespace Aiming
                     right * clampedSpin.y * verticalSpinTorqueScale) * impulseMagnitude;
                 cueBallBody.AddTorque(torque, ForceMode.Impulse);
 
-                float follow = Mathf.Max(0f, clampedSpin.y) * topSpinForwardImpulseScale;
+                float topSpin = Mathf.Max(0f, clampedSpin.y);
+                float follow = topSpin * topSpinForwardImpulseScale;
                 float draw = Mathf.Max(0f, -clampedSpin.y) * backSpinReverseImpulseScale;
                 float spinLinearImpulse = (follow - draw) * impulseMagnitude;
                 if (Mathf.Abs(spinLinearImpulse) > Mathf.Epsilon)
                 {
-                    cueBallBody.AddForce(planarDirection * spinLinearImpulse, ForceMode.Impulse);
+                    cueBallBody.AddForce(compensatedDirection * spinLinearImpulse, ForceMode.Impulse);
+                }
+
+                if (topSpin > 0f)
+                {
+                    float rollAssist = topSpin * normalizedPower * topSpinFollowRollScale * impulseMagnitude;
+                    if (rollAssist > Mathf.Epsilon)
+                    {
+                        cueBallBody.AddForce(compensatedDirection * rollAssist, ForceMode.Impulse);
+                    }
                 }
             }
         }

--- a/Assets/Scripts/Gameplay/Pockets/PocketCollisionResolver.cs
+++ b/Assets/Scripts/Gameplay/Pockets/PocketCollisionResolver.cs
@@ -28,16 +28,16 @@ namespace Aiming.Pockets
             bool any = false;
             any |= ResolveJaw(ball, mouth, mouth.LeftJaw);
             any |= ResolveJaw(ball, mouth, mouth.RightJaw);
-            any |= ResolveTip(ball, mouth, mouth.LeftJaw.StartTip, mouth.LeftJaw.JawRestitution, mouth.LeftJaw.JawFriction);
-            any |= ResolveTip(ball, mouth, mouth.LeftJaw.EndTip, mouth.LeftJaw.JawRestitution, mouth.LeftJaw.JawFriction);
-            any |= ResolveTip(ball, mouth, mouth.RightJaw.StartTip, mouth.RightJaw.JawRestitution, mouth.RightJaw.JawFriction);
-            any |= ResolveTip(ball, mouth, mouth.RightJaw.EndTip, mouth.RightJaw.JawRestitution, mouth.RightJaw.JawFriction);
+            any |= ResolveTip(ball, mouth, mouth.GetEffectiveStartTip(mouth.LeftJaw), mouth.LeftJaw.JawRestitution, mouth.LeftJaw.JawFriction);
+            any |= ResolveTip(ball, mouth, mouth.GetEffectiveEndTip(mouth.LeftJaw), mouth.LeftJaw.JawRestitution, mouth.LeftJaw.JawFriction);
+            any |= ResolveTip(ball, mouth, mouth.GetEffectiveStartTip(mouth.RightJaw), mouth.RightJaw.JawRestitution, mouth.RightJaw.JawFriction);
+            any |= ResolveTip(ball, mouth, mouth.GetEffectiveEndTip(mouth.RightJaw), mouth.RightJaw.JawRestitution, mouth.RightJaw.JawFriction);
             return any;
         }
 
         private bool ResolveJaw(IPoolBallBody ball, PocketMouth mouth, PocketJawDefinition jaw)
         {
-            FiniteJawSegment segment = jaw.Segment;
+            FiniteJawSegment segment = mouth.GetEffectiveJawSegment(jaw);
             if (!PocketGeometry.TryCircleVsCapsule(
                     ball.Position2,
                     ball.Radius,

--- a/Assets/Scripts/Gameplay/Pockets/PocketMouth.cs
+++ b/Assets/Scripts/Gameplay/Pockets/PocketMouth.cs
@@ -16,6 +16,7 @@ namespace Aiming.Pockets
         [SerializeField] private Vector2 pocketCenter = new Vector2(0f, -0.06f);
         [SerializeField] private Vector2 fallDirection = new Vector2(0f, -1f);
         [SerializeField, Range(0f, 1f)] private float cushionRestitution = 0.35f;
+        [SerializeField, Min(0f)] private float cornerSideCushionTrim = 0.006f;
 
         public PocketJawDefinition LeftJaw => leftJaw;
         public PocketJawDefinition RightJaw => rightJaw;
@@ -38,6 +39,70 @@ namespace Aiming.Pockets
 
                 return (leftJaw.Segment.end + rightJaw.Segment.start) * 0.5f;
             }
+        }
+
+        public Vector3 MouthCenterWorld => ToWorld(MouthCenter);
+        public Vector3 PocketCenterWorld => ToWorld(pocketCenter);
+
+        public FiniteJawSegment GetEffectiveJawSegment(PocketJawDefinition jaw)
+        {
+            FiniteJawSegment segment = jaw.Segment;
+            if (!IsCornerPocket || cornerSideCushionTrim <= 1e-6f)
+            {
+                return segment;
+            }
+
+            Vector2 toMouth = MouthCenter - segment.start;
+            if (Vector2.Dot(segment.Direction, toMouth) > 0f)
+            {
+                Vector2 trimmedEnd = MoveToward(segment.end, segment.start, cornerSideCushionTrim);
+                segment.end = trimmedEnd;
+            }
+            else
+            {
+                Vector2 trimmedStart = MoveToward(segment.start, segment.end, cornerSideCushionTrim);
+                segment.start = trimmedStart;
+            }
+
+            return segment;
+        }
+
+        public JawTip GetEffectiveStartTip(PocketJawDefinition jaw)
+        {
+            FiniteJawSegment segment = GetEffectiveJawSegment(jaw);
+            return new JawTip { center = segment.start, radius = jaw.JawRadius };
+        }
+
+        public JawTip GetEffectiveEndTip(PocketJawDefinition jaw)
+        {
+            FiniteJawSegment segment = GetEffectiveJawSegment(jaw);
+            return new JawTip { center = segment.end, radius = jaw.JawRadius };
+        }
+
+        public bool IsCornerPocket
+        {
+            get
+            {
+                Vector2 dir = FallDirection;
+                return Mathf.Abs(dir.x) > 0.2f && Mathf.Abs(dir.y) > 0.2f;
+            }
+        }
+
+        private Vector3 ToWorld(Vector2 local2)
+        {
+            return transform.TransformPoint(new Vector3(local2.x, 0f, local2.y));
+        }
+
+        private static Vector2 MoveToward(Vector2 from, Vector2 to, float distance)
+        {
+            Vector2 delta = to - from;
+            float len = delta.magnitude;
+            if (len < 1e-6f)
+            {
+                return from;
+            }
+
+            return from + delta / len * Mathf.Min(distance, len * 0.45f);
         }
 
         private void OnDrawGizmosSelected()


### PR DESCRIPTION
### Motivation
- Make AI aim to the true pocket entrance center as seen from the object ball, prioritizing clearer and more straight-line pocket entrances for more reliable potting.
- Compensate AI aiming and physics for cue-ball deflection (squirt) caused by side spin and shot power so the AI can select slightly adjusted aim bearings.
- Improve top-spin (follow) behaviour so the cue-ball exhibits a more natural forward-roll follow after contact without changing existing side/back spin handling.
- Make cue-stick motion visually accurate during strike/replay: show pull and forward push, then hide the cue at impact until balls stop moving, and allow a small trim of corner side cushions for visual/physics alignment with the pocket jaws.

### Description
- Fixed straight-shot detection by computing the proper approach error in `ShotClassifier` and using that angle for `isStraight` and `angleDeg` (`Assets/Scripts/Aiming/ShotClassifier.cs`).
- Added tuning parameters in `AimingConfig` for pocket entrance bias, straight/clear shot priorities and AI deflection compensation (`Assets/Scripts/Aiming/AimingConfig.cs`).
- Implemented pocket-mouth-based target selection and scoring in `CueController` so the aiming point is chosen between the pocket center and visible mouth opening and is ranked by straightness and line clarity; AI now pre-compensates aim for expected deflection from side spin/power when updating the aim direction (`Assets/Scripts/Gameplay/CueController.cs`).
- Added cue visual flow changes in `CueController` to show pull/push stroke, hide the cue at impact, and restore visibility when balls stop moving via `SetCueVisualVisible` and `_cueHiddenUntilBallsStop` logic (`Assets/Scripts/Gameplay/CueController.cs`).
- Extended strike physics in `CueStrikePhysics` with `ComputeDeflectionDegrees`, power-scaled side-spin deflection (squirt) applied to the impulse direction, and a `topSpinFollowRollScale` roll-assist to produce more natural forward follow for top spin while leaving side/back spin torque logic intact (`Assets/Scripts/Gameplay/CueStrikePhysics.cs`).
- Added a small corner-pocket cushion trim feature and APIs in `PocketMouth` to compute effective trimmed jaw segments/tips, and switched `PocketCollisionResolver` to use those trimmed segments/tips so only corner pocket jaws are slightly shortened (`Assets/Scripts/Gameplay/Pockets/PocketMouth.cs`, `Assets/Scripts/Gameplay/Pockets/PocketCollisionResolver.cs`).

### Testing
- Ran `git diff --check` on the modified files (`Assets/Scripts/Aiming/AimingConfig.cs`, `Assets/Scripts/Aiming/ShotClassifier.cs`, `Assets/Scripts/Gameplay/CueController.cs`, `Assets/Scripts/Gameplay/CueStrikePhysics.cs`, `Assets/Scripts/Gameplay/Pockets/PocketCollisionResolver.cs`, `Assets/Scripts/Gameplay/Pockets/PocketMouth.cs`) and it reported no whitespace or diff-check issues (success).
- No automated playmode/unit test suite was executed in this rollout; recommend running project compile and existing PlayMode tests such as `Assets/Tests/PlayMode/ShotClassifierTests.cs` and `Assets/Tests/PlayMode/CueStrikePhysicsTests.cs` to validate physics and aiming in-editor.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8bd4fa33c83298a4694b195456fe4)