### PR TITLE
Domino Royale: mobile HUD tweaks — leaderboard toggle, avatar & control layout

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -5888,7 +5888,7 @@ const seatAvatars = [];
 const seatNameTags = [];
 const seatBadges = [];
 let humanSeatBadgeAnchor = null;
-const HUMAN_SEAT_BADGE_BOTTOM_OFFSET = 118;
+const HUMAN_SEAT_BADGE_BOTTOM_OFFSET = 106;
 const HUMAN_SEAT_BADGE_LEFT_OFFSET = -6;
 const seatOverlay = document.createElement('div');
 seatOverlay.id = 'seatOverlay';
@@ -7691,6 +7691,8 @@ const winnerOverlayReason = document.getElementById('winnerReason');
 const winnerPlayAgainButton = document.getElementById('winnerPlayAgain');
 const winnerReturnLobbyButton = document.getElementById('winnerReturnLobby');
 const winnerCoinBurst = document.getElementById('winnerCoinBurst');
+const leaderboardToggleButton = document.getElementById('leaderboardToggle');
+let leaderboardExpanded = false;
 const leaderboardCard = document.createElement('div');
 leaderboardCard.id = 'dominoLeaderboardCard';
 leaderboardCard.setAttribute('aria-live', 'polite');
@@ -7700,7 +7702,24 @@ document.body.appendChild(leaderboardCard);
 
 function updateLeaderboardVisibility() {
   if (!leaderboardCard) return;
-  leaderboardCard.style.display = isLandscapeViewport() ? 'none' : '';
+  const hideForViewport = isLandscapeViewport();
+  const allowLeaderboard = isPointsRace && !hideForViewport;
+  if (leaderboardToggleButton) {
+    leaderboardToggleButton.style.display = isPointsRace && !hideForViewport ? 'grid' : 'none';
+    leaderboardToggleButton.classList.toggle('is-active', allowLeaderboard && leaderboardExpanded);
+    leaderboardToggleButton.setAttribute(
+      'aria-pressed',
+      allowLeaderboard && leaderboardExpanded ? 'true' : 'false'
+    );
+  }
+  leaderboardCard.style.display = allowLeaderboard && leaderboardExpanded ? '' : 'none';
+}
+if (leaderboardToggleButton) {
+  leaderboardToggleButton.addEventListener('click', () => {
+    if (!isPointsRace || isLandscapeViewport()) return;
+    leaderboardExpanded = !leaderboardExpanded;
+    updateLeaderboardVisibility();
+  });
 }
 updateLeaderboardVisibility();
 
@@ -7713,6 +7732,7 @@ function computePipTotal(hand = []) {
 
 function updateLeaderboardCard() {
   if (!leaderboardCard) return;
+  if (!isPointsRace && leaderboardExpanded) leaderboardExpanded = false;
   updateLeaderboardVisibility();
   const titleEl = leaderboardCard.querySelector('.leaderboard-title');
   const rowsHost = leaderboardCard.querySelector('.leaderboard-rows');

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -105,7 +105,18 @@ export default function DominoRoyalArena() {
           bottom: auto !important;
         }
         #railControls {
-          bottom: calc(env(safe-area-inset-bottom, 0px) + clamp(1.2rem, 7vh, 2.2rem)) !important;
+          bottom: calc(env(safe-area-inset-bottom, 0px) + clamp(3.1rem, 8.5vh, 4.1rem)) !important;
+          background: transparent !important;
+          border: 0 !important;
+          box-shadow: none !important;
+          padding: 0 !important;
+          backdrop-filter: none !important;
+        }
+        #railControls button {
+          background: transparent !important;
+          border: 1px solid rgba(226, 232, 240, 0.92) !important;
+          color: #f8fafc !important;
+          box-shadow: none !important;
         }
         #quickActions {
           position: static !important;
@@ -122,7 +133,7 @@ export default function DominoRoyalArena() {
         }
         #dominoLeaderboardCard {
           position: fixed;
-          top: calc(3.55rem + env(safe-area-inset-top, 0px));
+          top: calc(3.9rem + env(safe-area-inset-top, 0px));
           left: 56.4%;
           transform: translateX(-50%);
           width: min(72vw, 15.5rem);
@@ -135,6 +146,27 @@ export default function DominoRoyalArena() {
           color: #f8fafc;
           padding: 0.44rem 0.48rem;
           pointer-events: none;
+        }
+        #leaderboardToggle {
+          position: fixed;
+          top: calc(0.68rem + env(safe-area-inset-top, 0px));
+          left: 50%;
+          transform: translateX(-50%);
+          width: 2.35rem;
+          height: 2.35rem;
+          border-radius: 999px;
+          border: 1px solid rgba(148, 163, 184, 0.5);
+          background: rgba(15, 23, 42, 0.92);
+          color: #f8fafc;
+          display: none;
+          place-items: center;
+          z-index: 8;
+          padding: 0;
+          font-size: 1.05rem;
+        }
+        #leaderboardToggle.is-active {
+          border-color: rgba(56, 189, 248, 0.9);
+          box-shadow: 0 0 0 2px rgba(14, 165, 233, 0.3);
         }
         #dominoLeaderboardCard .leaderboard-title {
           font-size: 0.58rem;
@@ -206,6 +238,7 @@ export default function DominoRoyalArena() {
           letter-spacing: 0.01em;
         }
         #status {
+          display: none !important;
           background: linear-gradient(
             145deg,
             rgba(8, 18, 40, 0.96),
@@ -240,8 +273,11 @@ export default function DominoRoyalArena() {
             left: calc(0.1rem + env(safe-area-inset-left, 0px)) !important;
           }
           #dominoLeaderboardCard {
-            top: calc(0.62rem + env(safe-area-inset-top, 0px));
+            top: calc(3.4rem + env(safe-area-inset-top, 0px));
             left: 54.9%;
+          }
+          #leaderboardToggle {
+            top: calc(0.62rem + env(safe-area-inset-top, 0px));
           }
           #railControls {
             bottom: calc(
@@ -329,6 +365,7 @@ export default function DominoRoyalArena() {
           <span id="muteLabel" className="visually-hidden">Mute</span>
         </button>
       </div>
+      <button id="leaderboardToggle" type="button" aria-label="Toggle leaderboard" title="Toggle leaderboard">🏆</button>
       <div id="railControls" aria-label="Game controls">
         <button id="draw" type="button">Draw</button>
         <button id="pass" type="button">Pass</button>


### PR DESCRIPTION
### Motivation
- Improve mobile portrait UX by preventing the leaderboard from showing during single-game sessions while allowing players in points/race mode to open it via a centered trophy icon.
- Shift the local player avatar slightly lower and simplify the draw/pass controls so they appear as two minimal buttons placed higher on screen.
- Remove the on-screen commentary/status overlay to reduce visual clutter during play.

### Description
- Add a centered `#leaderboardToggle` button and wiring in `webapp/src/pages/Games/DominoRoyalArena.jsx` and `webapp/public/domino-royal-game.js`, plus CSS to position and style the trophy toggle and its active state.
- Change leaderboard visibility logic (`updateLeaderboardVisibility`) so the card never appears for single games and only appears for points/race matches when the toggle is visible and activated, and ensure `leaderboardExpanded` is reset when switching modes (in `domino-royal-game.js`).
- Lower the human seat badge by updating `HUMAN_SEAT_BADGE_BOTTOM_OFFSET` from `118` to `106` in `webapp/public/domino-royal-game.js` to move the avatar a bit further down.
- Move `#railControls` upward and remove background/border/shadow (buttons made visually transparent with outlined style) and hide the `#status` overlay by setting `display: none !important` in `webapp/src/pages/Games/DominoRoyalArena.jsx`.

### Testing
- Built the web app assets with `cd webapp && npm run -s build`, which completed successfully (production build produced assets and warnings only about chunk sizes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8c4f407508329bd34e5ad37ed9993)