### PR TITLE
Adjust Domino Royal HUD layout and disable pinch zoom in 3D view

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -5888,7 +5888,7 @@ const seatAvatars = [];
 const seatNameTags = [];
 const seatBadges = [];
 let humanSeatBadgeAnchor = null;
-const HUMAN_SEAT_BADGE_BOTTOM_OFFSET = 106;
+const HUMAN_SEAT_BADGE_BOTTOM_OFFSET = 86;
 const HUMAN_SEAT_BADGE_LEFT_OFFSET = -6;
 const seatOverlay = document.createElement('div');
 seatOverlay.id = 'seatOverlay';
@@ -7703,20 +7703,32 @@ document.body.appendChild(leaderboardCard);
 function updateLeaderboardVisibility() {
   if (!leaderboardCard) return;
   const hideForViewport = isLandscapeViewport();
-  const allowLeaderboard = isPointsRace && !hideForViewport;
+  const allowLeaderboard = !hideForViewport;
   if (leaderboardToggleButton) {
-    leaderboardToggleButton.style.display = isPointsRace && !hideForViewport ? 'grid' : 'none';
+    leaderboardToggleButton.style.display = allowLeaderboard ? 'grid' : 'none';
     leaderboardToggleButton.classList.toggle('is-active', allowLeaderboard && leaderboardExpanded);
     leaderboardToggleButton.setAttribute(
       'aria-pressed',
       allowLeaderboard && leaderboardExpanded ? 'true' : 'false'
     );
+    leaderboardToggleButton.textContent =
+      allowLeaderboard && leaderboardExpanded ? '✕' : '🏆';
+    leaderboardToggleButton.setAttribute(
+      'aria-label',
+      allowLeaderboard && leaderboardExpanded
+        ? 'Hide leaderboard'
+        : 'Show leaderboard'
+    );
+    leaderboardToggleButton.title =
+      allowLeaderboard && leaderboardExpanded
+        ? 'Hide leaderboard'
+        : 'Show leaderboard';
   }
   leaderboardCard.style.display = allowLeaderboard && leaderboardExpanded ? '' : 'none';
 }
 if (leaderboardToggleButton) {
   leaderboardToggleButton.addEventListener('click', () => {
-    if (!isPointsRace || isLandscapeViewport()) return;
+    if (isLandscapeViewport()) return;
     leaderboardExpanded = !leaderboardExpanded;
     updateLeaderboardVisibility();
   });
@@ -9444,34 +9456,8 @@ renderer.domElement.addEventListener('pointermove', (ev) => {
   }
 
   if (cameraViewMode === VIEW_MODES.threeD && ev.pointerType === 'touch') {
-    const touchPoints = [];
-    for (const pointerId of activePointers) {
-      const point = activePointerPositions.get(pointerId);
-      if (point) {
-        touchPoints.push(point);
-      }
-      if (touchPoints.length === 2) {
-        break;
-      }
-    }
-    if (touchPoints.length === 2) {
-      const [first, second] = touchPoints;
-      const currentDistance = Math.hypot(
-        second.x - first.x,
-        second.y - first.y
-      );
-      if (
-        Number.isFinite(pinchZoomState.distance) &&
-        pinchZoomState.mode === VIEW_MODES.threeD
-      ) {
-        applyThreeDZoomFromPinch(currentDistance - pinchZoomState.distance);
-      }
-      pinchZoomState.distance = currentDistance;
-      pinchZoomState.mode = VIEW_MODES.threeD;
-    } else {
-      pinchZoomState.distance = null;
-      pinchZoomState.mode = null;
-    }
+    pinchZoomState.distance = null;
+    pinchZoomState.mode = null;
   }
 
   if (

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -133,8 +133,8 @@ export default function DominoRoyalArena() {
         }
         #dominoLeaderboardCard {
           position: fixed;
-          top: calc(3.9rem + env(safe-area-inset-top, 0px));
-          left: 56.4%;
+          top: calc(2.85rem + env(safe-area-inset-top, 0px));
+          left: 50%;
           transform: translateX(-50%);
           width: min(72vw, 15.5rem);
           z-index: 5;
@@ -149,7 +149,7 @@ export default function DominoRoyalArena() {
         }
         #leaderboardToggle {
           position: fixed;
-          top: calc(0.68rem + env(safe-area-inset-top, 0px));
+          top: calc(0.24rem + env(safe-area-inset-top, 0px));
           left: 50%;
           transform: translateX(-50%);
           width: 2.35rem;
@@ -273,16 +273,16 @@ export default function DominoRoyalArena() {
             left: calc(0.1rem + env(safe-area-inset-left, 0px)) !important;
           }
           #dominoLeaderboardCard {
-            top: calc(3.4rem + env(safe-area-inset-top, 0px));
-            left: 54.9%;
+            top: calc(2.7rem + env(safe-area-inset-top, 0px));
+            left: 50%;
           }
           #leaderboardToggle {
-            top: calc(0.62rem + env(safe-area-inset-top, 0px));
+            top: calc(0.12rem + env(safe-area-inset-top, 0px));
           }
           #railControls {
             bottom: calc(
               env(safe-area-inset-bottom, 0px) + clamp(1.2rem, 7vh, 2.2rem) +
-                clamp(2.8rem, 8vh, 3.4rem) + 1.35rem
+                clamp(2.8rem, 8vh, 3.4rem) + 2rem
             ) !important;
           }
           #status {


### PR DESCRIPTION
### Motivation
- Improve the mobile portrait HUD for Domino Battle Royal by moving the local player avatar lower and nudging draw/pass controls upward for better reachability.  
- Move the leaderboard UI to the true top-center and provide an explicit toggle icon so players can show/hide the leaderboard.  
- Disable pinch-to-zoom in the 3D camera view while leaving 2D pinch zoom behavior intact to avoid accidental 3D zoom gestures.

### Description
- Lowered the bottom player avatar anchor by changing `HUMAN_SEAT_BADGE_BOTTOM_OFFSET` from `106` to `86` in `webapp/public/domino-royal-game.js`.  
- Repositioned the leaderboard card and toggle to the top-center and adjusted portrait offsets for `#dominoLeaderboardCard` and `#leaderboardToggle`, and raised `#railControls` in `webapp/src/pages/Games/DominoRoyalArena.jsx`.  
- Made the leaderboard toggle visible whenever viewport allows (removed the strict `isPointsRace` gating), updated the toggle content to show `🏆` / `✕` and synchronized `aria-label`/`title` state in `webapp/public/domino-royal-game.js`.  
- Disabled 3D pinch zoom by making the threeD pinch branch a no-op (clearing `pinchZoomState.distance`/`mode`) while keeping the existing 2D pinch path which still calls `applyTopDownZoomFromPinch` in `webapp/public/domino-royal-game.js`.

### Testing
- Ran the production build with `npm --prefix webapp run build`, which completed successfully (Vite produced non-blocking chunk-size warnings).  
- No automated unit tests were run as part of this change beyond the successful web build step.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8cce5a3108329bc3ad431b97a78a7)