### PR TITLE
Domino Royale: adjust mobile HUD, add top-center leaderboard toggle, and disable 3D pinch zoom

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -5888,7 +5888,7 @@ const seatAvatars = [];
 const seatNameTags = [];
 const seatBadges = [];
 let humanSeatBadgeAnchor = null;
-const HUMAN_SEAT_BADGE_BOTTOM_OFFSET = 106;
+const HUMAN_SEAT_BADGE_BOTTOM_OFFSET = 84;
 const HUMAN_SEAT_BADGE_LEFT_OFFSET = -6;
 const seatOverlay = document.createElement('div');
 seatOverlay.id = 'seatOverlay';
@@ -7703,9 +7703,9 @@ document.body.appendChild(leaderboardCard);
 function updateLeaderboardVisibility() {
   if (!leaderboardCard) return;
   const hideForViewport = isLandscapeViewport();
-  const allowLeaderboard = isPointsRace && !hideForViewport;
+  const allowLeaderboard = !hideForViewport;
   if (leaderboardToggleButton) {
-    leaderboardToggleButton.style.display = isPointsRace && !hideForViewport ? 'grid' : 'none';
+    leaderboardToggleButton.style.display = !hideForViewport ? 'grid' : 'none';
     leaderboardToggleButton.classList.toggle('is-active', allowLeaderboard && leaderboardExpanded);
     leaderboardToggleButton.setAttribute(
       'aria-pressed',
@@ -7716,7 +7716,7 @@ function updateLeaderboardVisibility() {
 }
 if (leaderboardToggleButton) {
   leaderboardToggleButton.addEventListener('click', () => {
-    if (!isPointsRace || isLandscapeViewport()) return;
+    if (isLandscapeViewport()) return;
     leaderboardExpanded = !leaderboardExpanded;
     updateLeaderboardVisibility();
   });
@@ -9460,12 +9460,6 @@ renderer.domElement.addEventListener('pointermove', (ev) => {
         second.x - first.x,
         second.y - first.y
       );
-      if (
-        Number.isFinite(pinchZoomState.distance) &&
-        pinchZoomState.mode === VIEW_MODES.threeD
-      ) {
-        applyThreeDZoomFromPinch(currentDistance - pinchZoomState.distance);
-      }
       pinchZoomState.distance = currentDistance;
       pinchZoomState.mode = VIEW_MODES.threeD;
     } else {

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -105,7 +105,7 @@ export default function DominoRoyalArena() {
           bottom: auto !important;
         }
         #railControls {
-          bottom: calc(env(safe-area-inset-bottom, 0px) + clamp(3.1rem, 8.5vh, 4.1rem)) !important;
+          bottom: calc(env(safe-area-inset-bottom, 0px) + clamp(3.95rem, 10.2vh, 4.95rem)) !important;
           background: transparent !important;
           border: 0 !important;
           box-shadow: none !important;
@@ -149,7 +149,7 @@ export default function DominoRoyalArena() {
         }
         #leaderboardToggle {
           position: fixed;
-          top: calc(0.68rem + env(safe-area-inset-top, 0px));
+          top: calc(0.14rem + env(safe-area-inset-top, 0px));
           left: 50%;
           transform: translateX(-50%);
           width: 2.35rem;
@@ -277,7 +277,7 @@ export default function DominoRoyalArena() {
             left: 54.9%;
           }
           #leaderboardToggle {
-            top: calc(0.62rem + env(safe-area-inset-top, 0px));
+            top: calc(0.08rem + env(safe-area-inset-top, 0px));
           }
           #railControls {
             bottom: calc(


### PR DESCRIPTION
### Motivation
- Improve mobile portrait UX by moving the player avatar closer to the bottom and the Draw/Pass controls slightly higher to avoid overlap with system UI.
- Make the leaderboard toggle visible at the very top-center so players can show/hide the leaderboard quickly in portrait.
- Prevent unintended pinch zoom interactions in the 3D camera view while preserving pinch zoom on the 2D view.

### Description
- Lowered the self-player badge anchor by changing `HUMAN_SEAT_BADGE_BOTTOM_OFFSET` from `106` to `84` in `webapp/public/domino-royal-game.js` to move the avatar visually closer to the bottom of the screen.
- Raised the Draw/Pass control rail by adjusting `#railControls` bottom offset in `webapp/src/pages/Games/DominoRoyalArena.jsx` so the buttons sit a bit higher above the bottom area.
- Repositioned the leaderboard toggle icon to the top-center by updating `#leaderboardToggle` `top` values in `webapp/src/pages/Games/DominoRoyalArena.jsx` and updated the toggle logic in `webapp/public/domino-royal-game.js` so the button is shown in portrait and controls leaderboard visibility regardless of race mode (still hidden in landscape).
- Disabled three-dimensional pinch-zoom by removing the call to `applyThreeDZoomFromPinch(...)` in the touch `pointermove` handler while leaving 2D pinch handling (`applyTopDownZoomFromPinch`) intact in `webapp/public/domino-royal-game.js`.

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` and it succeeded.
- Built the web app with `npm -C webapp run -s build` and the production build completed successfully.
- Attempted `node --check` against the React `.jsx` file (`webapp/src/pages/Games/DominoRoyalArena.jsx`), which failed because the runtime `node --check` invocation in this environment does not accept `.jsx` file extensions; this is an environment limitation and not a runtime error in the change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8cce5a3108329bc3ad431b97a78a7)