### PR TITLE
Tune topspin physics and AI pot compensation; refine pocket/cushion geometry; add cue recover phase

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5914,9 +5914,9 @@ const DEFAULT_SPIN_LIMITS = Object.freeze({
   maxY: 1
 });
 const MAX_TOPSPIN_INPUT = 0.8; // reduce topspin cap to match Snooker Royal feel
-const TOPSPIN_FOLLOW_TRANSFER_RATE = 0.31; // transfer topspin to forward roll more progressively for a realistic, less abrupt follow phase
-const TOPSPIN_FOLLOW_DECAY_ASSIST = 0.84; // once natural roll forms, bleed residual topspin faster so forward spin settles like a real table
-const TOPSPIN_ROLL_SPEED_FACTOR = 0.84; // cap follow acceleration toward natural rolling speed to avoid endless forward "motor" behavior
+const TOPSPIN_FOLLOW_TRANSFER_RATE = 0.42; // convert topspin into forward roll sooner so natural follow builds progressively instead of feeling delayed
+const TOPSPIN_FOLLOW_DECAY_ASSIST = 0.74; // keep some residual roll-through after impact before spin naturally settles
+const TOPSPIN_ROLL_SPEED_FACTOR = 0.94; // let topspin carry cue-ball speed farther before settling at natural roll
 const TOPSPIN_POWER_SOFT_CAP = 0.9;
 const clampSpinValue = (value) => clamp(value, -1, 1);
 const SPIN_CUSHION_EPS = BALL_R * 0.6;
@@ -6285,19 +6285,20 @@ const resolvePocketEntranceForTarget = (targetPos, pocketIndex) => {
   const mouthHalfWidth = (pocketIndex >= 4 ? POCKET_SIDE_MOUTH : POCKET_CORNER_MOUTH) * 0.5;
   const entranceBase = pocketCenter
     .clone()
-    .add(inward.clone().multiplyScalar(baseRadius * 0.62));
+    .add(inward.clone().multiplyScalar(baseRadius * 0.68));
   if (!targetVec || targetVec.lengthSq() < 1e-6) {
     return entranceBase;
   }
   targetVec.normalize();
   const lateralBias = THREE.MathUtils.clamp(targetVec.dot(lateral), -1, 1);
   const inwardAlignment = THREE.MathUtils.clamp(targetVec.dot(inward), -1, 1);
+  const centeredBias = 1 - Math.abs(lateralBias);
   const sideShift =
     mouthHalfWidth *
-    (pocketIndex >= 4 ? 0.44 : 0.36) *
+    (pocketIndex >= 4 ? 0.26 : 0.22) *
     lateralBias *
-    (0.7 + 0.3 * Math.max(0, inwardAlignment));
-  const depthShift = baseRadius * 0.18 * Math.max(0, inwardAlignment);
+    (0.5 + 0.5 * centeredBias);
+  const depthShift = baseRadius * 0.22 * Math.max(0, inwardAlignment);
   return entranceBase
     .clone()
     .addScaledVector(lateral, sideShift)
@@ -7013,21 +7014,26 @@ function applySpinController(ball, stepScale, airborne = false) {
     if (Math.abs(forwardSpin) > 1e-8) {
       ball.vel.addScaledVector(forward, forwardSpin * rollAccel);
       if (forwardSpin > 0) {
-        const naturalRollSpeed = Math.max(BALL_R * 2.2, speed * TOPSPIN_ROLL_SPEED_FACTOR);
+        const naturalRollSpeed = Math.max(BALL_R * 2.25, speed * TOPSPIN_ROLL_SPEED_FACTOR);
         const settling = THREE.MathUtils.clamp(speed / Math.max(naturalRollSpeed, 1e-6), 0, 1);
+        const rollGap = THREE.MathUtils.clamp(
+          (naturalRollSpeed - speed) / Math.max(naturalRollSpeed, 1e-6),
+          0,
+          1
+        );
         const transfer =
           Math.min(
             forwardSpin,
-            rollAccel * TOPSPIN_FOLLOW_TRANSFER_RATE * (0.28 + settling * 0.72)
+            rollAccel * TOPSPIN_FOLLOW_TRANSFER_RATE * (0.45 + rollGap * 0.55)
           );
         let remainingSpin = Math.max(0, forwardSpin - transfer);
-        // As the cue ball reaches natural rolling speed, any extra topspin
-        // should quickly collapse instead of continuously forcing acceleration.
-        if (speed >= naturalRollSpeed * 0.98) {
-          remainingSpin *= Math.exp(-TOPSPIN_FOLLOW_DECAY_ASSIST * stepScale * 1.25);
+        // Once cue-ball speed reaches natural roll, decay residual topspin faster
+        // so follow looks natural and does not keep "motor-driving" forward.
+        if (speed >= naturalRollSpeed * 0.99) {
+          remainingSpin *= Math.exp(-TOPSPIN_FOLLOW_DECAY_ASSIST * stepScale * 1.15);
         }
         const assistedDecay = Math.exp(
-          -TOPSPIN_FOLLOW_DECAY_ASSIST * stepScale * (0.35 + 0.65 * settling)
+          -TOPSPIN_FOLLOW_DECAY_ASSIST * stepScale * (0.22 + 0.78 * settling)
         );
         ball.spin.y = remainingSpin * assistedDecay;
       }
@@ -8822,7 +8828,7 @@ export function Table3D(
   const CUSHION_CORNER_CLEARANCE_REDUCTION = TABLE.THICK * 0.32; // shorten the long-rail cushions slightly less so the noses reach farther toward the corners
   const SIDE_CUSHION_POCKET_REACH_REDUCTION = TABLE.THICK * 0.00; // trim the cushion tips near middle pockets so they stop at the rail cut
   const LONG_RAIL_CUSHION_LENGTH_TRIM = BALL_R * 0.72; // shorten short-rail cushions a touch more so the ends don't overhang the pocket cuts
-  const SHORT_RAIL_CUSHION_LENGTH_TRIM = BALL_R * 0.08; // trim short-rail cushions slightly more so the ends pull back from the corners
+  const SHORT_RAIL_CUSHION_LENGTH_TRIM = BALL_R * 0.18; // trim side-cushion tips near corner pockets a touch more so both sides stop cleaner at the jaws
   const SIDE_CUSHION_RAIL_REACH = TABLE.THICK * 0.05; // press the side cushions firmly into the rails without creating overlap
   const SIDE_CUSHION_CORNER_SHIFT = TABLE.THICK * 0.18; // push side-rail cushions away from the middle pockets toward the corners
   const SHORT_RAIL_CUSHION_VERTICAL_LIFT = TABLE.THICK * 0.026; // lift all six cushions a touch higher while keeping the same profile
@@ -28233,9 +28239,40 @@ const powerRef = useRef(hud.power);
             setInHandPlacementMode(true);
           }
         };
+        const adjustAiPotPowerForDeflection = (plan, cueBall) => {
+          if (!plan || plan.type !== 'pot' || !cueBall?.pos || !plan.targetBall?.pos || !plan.pocketCenter) {
+            return plan;
+          }
+          const cueToTarget = Math.max(BALL_R, cueBall.pos.distanceTo(plan.targetBall.pos));
+          const targetToPocket = Math.max(BALL_R, plan.targetBall.pos.distanceTo(plan.pocketCenter));
+          const cueVec = plan.targetBall.pos.clone().sub(cueBall.pos).normalize();
+          const potVec = plan.pocketCenter.clone().sub(plan.targetBall.pos).normalize();
+          const alignment = THREE.MathUtils.clamp(cueVec.dot(potVec), -1, 1);
+          const cutSeverity = Math.sqrt(Math.max(0, 1 - alignment * alignment));
+          const travelFactor = THREE.MathUtils.clamp(
+            (cueToTarget + targetToPocket) / Math.max(BALL_R * 54, 1e-6),
+            0,
+            1
+          );
+          const suggestedPower = THREE.MathUtils.clamp(
+            0.44 + travelFactor * 0.34 + cutSeverity * 0.1,
+            0.34,
+            0.9
+          );
+          // Pull power toward a geometry-safe value so object-ball throw/deflection
+          // is predictable and the compensated aim remains valid.
+          plan.power = THREE.MathUtils.lerp(
+            THREE.MathUtils.clamp(plan.power ?? suggestedPower, 0.28, 0.95),
+            suggestedPower,
+            0.7
+          );
+          return plan;
+        };
+
         const refineAiPotAimLine = (plan) => {
           if (!plan?.aimDir || plan.type !== 'pot' || !cue?.active) return plan;
           if (!plan.targetBall?.active || !plan.pocketCenter) return plan;
+          adjustAiPotPowerForDeflection(plan, cue);
           const cuePos = cue.pos?.clone?.();
           if (!cuePos) return plan;
           const compensated = resolveAiPotGhostAim({

--- a/webapp/src/pages/Games/poolRoyaleAiAimCompensation.js
+++ b/webapp/src/pages/Games/poolRoyaleAiAimCompensation.js
@@ -1,9 +1,9 @@
 import * as THREE from 'three';
 
 const MIN_VECTOR_EPS = 1e-6;
-const DEFAULT_CONTACT_CALIBRATION = 0.004;
-const DEFAULT_SIDE_DEFLECTION_SCALE = 0.018;
-const DEFAULT_POWER_DEFLECTION_SCALE = 0.01;
+const DEFAULT_CONTACT_CALIBRATION = 0.0015;
+const DEFAULT_SIDE_DEFLECTION_SCALE = 0.0135;
+const DEFAULT_POWER_DEFLECTION_SCALE = 0.015;
 
 export const resolveAiPotGhostAim = ({
   cuePos,
@@ -18,6 +18,7 @@ export const resolveAiPotGhostAim = ({
   const radius = Math.max(0, ballRadius ?? 0);
   const toPocket = new THREE.Vector2().subVectors(pocketPos, targetPos);
   if (toPocket.lengthSq() <= MIN_VECTOR_EPS) return null;
+  const toPocketDistance = toPocket.length();
 
   const toPocketDir = toPocket.normalize();
   const sideSpin = THREE.MathUtils.clamp(spin?.x ?? 0, -1, 1);
@@ -31,7 +32,7 @@ export const resolveAiPotGhostAim = ({
     -0.08,
     0.08
   );
-  const contactDepth = radius * 2 * (1 + calibration + topBackSpin * power01 * 0.015);
+  const contactDepth = radius * 2 * (1 + calibration);
 
   const cueToTargetDir = new THREE.Vector2().subVectors(targetPos, cuePos);
   if (cueToTargetDir.lengthSq() <= MIN_VECTOR_EPS) return null;
@@ -45,9 +46,14 @@ export const resolveAiPotGhostAim = ({
     (0.45 + cutSeverity * 0.55);
   const powerDeflection =
     topBackSpin *
-    power01 *
+    (0.35 + 0.65 * Math.pow(power01, 1.2)) *
     DEFAULT_POWER_DEFLECTION_SCALE *
-    (0.65 + 0.35 * (1 - cutSeverity));
+    (0.3 + 0.7 * cutSeverity) *
+    THREE.MathUtils.clamp(
+      toPocketDistance / Math.max(radius * 22, MIN_VECTOR_EPS),
+      0.75,
+      1.35
+    );
   const lateralUnit = new THREE.Vector2(-toPocketDir.y, toPocketDir.x);
 
   const ghost = new THREE.Vector2()

--- a/webapp/src/pages/Games/poolRoyaleCueStrokeTimeline.js
+++ b/webapp/src/pages/Games/poolRoyaleCueStrokeTimeline.js
@@ -5,16 +5,19 @@ export const sampleCueStrokeTimeline = ({
   pullbackDuration = 0,
   strikeDuration = 120,
   holdDuration = 50,
+  recoverDuration = 0,
   animationStyle = 'classic'
 } = {}) => {
   const pullback = Math.max(0, pullbackDuration ?? 0)
   const release = Math.max(0, strikeDuration ?? 120)
   const hold = Math.max(0, holdDuration ?? 50)
+  const recover = Math.max(0, recoverDuration ?? 0)
   const safeElapsed = Math.max(0, elapsed)
 
   const pullEnd = pullback
   const releaseEnd = pullEnd + release
   const holdEnd = releaseEnd + hold
+  const recoverEnd = holdEnd + recover
 
   if (safeElapsed <= pullEnd && pullback > 0) {
     return { phase: 'pullback', t: THREE.MathUtils.clamp(safeElapsed / Math.max(pullback, 1e-6), 0, 1), hitArmed: false, done: false }
@@ -51,6 +54,9 @@ export const sampleCueStrokeTimeline = ({
   }
   if (safeElapsed <= holdEnd && hold > 0) {
     return { phase: 'hold', t: THREE.MathUtils.clamp((safeElapsed - releaseEnd) / Math.max(hold, 1e-6), 0, 1), hitArmed: true, done: false }
+  }
+  if (safeElapsed <= recoverEnd && recover > 0) {
+    return { phase: 'recover', t: THREE.MathUtils.clamp((safeElapsed - holdEnd) / Math.max(recover, 1e-6), 0, 1), hitArmed: true, done: false }
   }
   return { phase: 'done', t: 1, hitArmed: true, done: true }
 }


### PR DESCRIPTION
### Motivation
- Improve realism and responsiveness of cue-ball topspin/follow behavior so follow-through feels more natural and less like a perpetual "motor".
- Make AI pot aiming more robust by compensating power/deflection for travel distance and cut severity so suggested power/aim remain reliable.
- Tweak pocket entrance geometry and cushion trimming for cleaner pocket/jaw visuals and more consistent pot trajectories.
- Support a cue `recover` animation phase to enable more accurate cue stroke timing and visual feedback.

### Description
- Adjusted topspin tuning constants and follow behavior in `PoolRoyale.jsx`, including `TOPSPIN_FOLLOW_TRANSFER_RATE`, `TOPSPIN_FOLLOW_DECAY_ASSIST`, and `TOPSPIN_ROLL_SPEED_FACTOR`, and updated the follow transfer/decay math to use a `rollGap` factor and slightly changed natural roll thresholds.
- Modified pocket entrance computation in `PoolRoyale.jsx` by moving the entrance base further out, reducing lateral side-shift multipliers, adding a `centeredBias` influence, and increasing depth shift to improve alignment into mouths.
- Increased `SHORT_RAIL_CUSHION_LENGTH_TRIM` and updated comment to tighten side-cushion tips near corner pockets.
- Added `adjustAiPotPowerForDeflection` helper in `PoolRoyale.jsx` and invoked it from `refineAiPotAimLine` to nudge AI pot power toward geometry-safe values based on cue/target/pocket geometry and cut severity.
- Reworked aim compensation constants and formulas in `poolRoyaleAiAimCompensation.js`: reduced `DEFAULT_CONTACT_CALIBRATION`, adjusted `DEFAULT_SIDE_DEFLECTION_SCALE` and `DEFAULT_POWER_DEFLECTION_SCALE`, removed a small power-based contact depth term and refined `powerDeflection` to account for power curve, cut severity and travel distance.
- Extended `sampleCueStrokeTimeline` in `poolRoyaleCueStrokeTimeline.js` to accept `recoverDuration` and return a new `recover` phase between `hold` and `done` to better model post-strike timing.

### Testing
- Ran the project's automated unit tests with `npm test` and the test suite completed successfully.
- Executed lint checks with `npm run lint` and a development build with `npm run build`, both of which passed without errors.
- Performed a local dev run to sanity-check gameplay scenarios that exercise AI potting, topspin follow and cue animations, and no runtime errors were observed by the automated checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8bd4fa33c83298a4694b195456fe4)