### PR TITLE
Adjust Domino Battle Royal mobile HUD layout and disable 3D pinch zoom

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -5888,7 +5888,7 @@ const seatAvatars = [];
 const seatNameTags = [];
 const seatBadges = [];
 let humanSeatBadgeAnchor = null;
-const HUMAN_SEAT_BADGE_BOTTOM_OFFSET = 106;
+const HUMAN_SEAT_BADGE_BOTTOM_OFFSET = 74;
 const HUMAN_SEAT_BADGE_LEFT_OFFSET = -6;
 const seatOverlay = document.createElement('div');
 seatOverlay.id = 'seatOverlay';
@@ -7703,9 +7703,9 @@ document.body.appendChild(leaderboardCard);
 function updateLeaderboardVisibility() {
   if (!leaderboardCard) return;
   const hideForViewport = isLandscapeViewport();
-  const allowLeaderboard = isPointsRace && !hideForViewport;
+  const allowLeaderboard = !hideForViewport;
   if (leaderboardToggleButton) {
-    leaderboardToggleButton.style.display = isPointsRace && !hideForViewport ? 'grid' : 'none';
+    leaderboardToggleButton.style.display = !hideForViewport ? 'grid' : 'none';
     leaderboardToggleButton.classList.toggle('is-active', allowLeaderboard && leaderboardExpanded);
     leaderboardToggleButton.setAttribute(
       'aria-pressed',
@@ -7716,7 +7716,7 @@ function updateLeaderboardVisibility() {
 }
 if (leaderboardToggleButton) {
   leaderboardToggleButton.addEventListener('click', () => {
-    if (!isPointsRace || isLandscapeViewport()) return;
+    if (isLandscapeViewport()) return;
     leaderboardExpanded = !leaderboardExpanded;
     updateLeaderboardVisibility();
   });
@@ -7732,7 +7732,6 @@ function computePipTotal(hand = []) {
 
 function updateLeaderboardCard() {
   if (!leaderboardCard) return;
-  if (!isPointsRace && leaderboardExpanded) leaderboardExpanded = false;
   updateLeaderboardVisibility();
   const titleEl = leaderboardCard.querySelector('.leaderboard-title');
   const rowsHost = leaderboardCard.querySelector('.leaderboard-rows');
@@ -9444,34 +9443,8 @@ renderer.domElement.addEventListener('pointermove', (ev) => {
   }
 
   if (cameraViewMode === VIEW_MODES.threeD && ev.pointerType === 'touch') {
-    const touchPoints = [];
-    for (const pointerId of activePointers) {
-      const point = activePointerPositions.get(pointerId);
-      if (point) {
-        touchPoints.push(point);
-      }
-      if (touchPoints.length === 2) {
-        break;
-      }
-    }
-    if (touchPoints.length === 2) {
-      const [first, second] = touchPoints;
-      const currentDistance = Math.hypot(
-        second.x - first.x,
-        second.y - first.y
-      );
-      if (
-        Number.isFinite(pinchZoomState.distance) &&
-        pinchZoomState.mode === VIEW_MODES.threeD
-      ) {
-        applyThreeDZoomFromPinch(currentDistance - pinchZoomState.distance);
-      }
-      pinchZoomState.distance = currentDistance;
-      pinchZoomState.mode = VIEW_MODES.threeD;
-    } else {
-      pinchZoomState.distance = null;
-      pinchZoomState.mode = null;
-    }
+    pinchZoomState.distance = null;
+    pinchZoomState.mode = null;
   }
 
   if (

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -105,7 +105,7 @@ export default function DominoRoyalArena() {
           bottom: auto !important;
         }
         #railControls {
-          bottom: calc(env(safe-area-inset-bottom, 0px) + clamp(3.1rem, 8.5vh, 4.1rem)) !important;
+          bottom: calc(env(safe-area-inset-bottom, 0px) + clamp(3.65rem, 9.1vh, 4.65rem)) !important;
           background: transparent !important;
           border: 0 !important;
           box-shadow: none !important;
@@ -133,8 +133,8 @@ export default function DominoRoyalArena() {
         }
         #dominoLeaderboardCard {
           position: fixed;
-          top: calc(3.9rem + env(safe-area-inset-top, 0px));
-          left: 56.4%;
+          top: calc(2.95rem + env(safe-area-inset-top, 0px));
+          left: 50%;
           transform: translateX(-50%);
           width: min(72vw, 15.5rem);
           z-index: 5;
@@ -149,7 +149,7 @@ export default function DominoRoyalArena() {
         }
         #leaderboardToggle {
           position: fixed;
-          top: calc(0.68rem + env(safe-area-inset-top, 0px));
+          top: calc(0.08rem + env(safe-area-inset-top, 0px));
           left: 50%;
           transform: translateX(-50%);
           width: 2.35rem;
@@ -163,6 +163,20 @@ export default function DominoRoyalArena() {
           z-index: 8;
           padding: 0;
           font-size: 1.05rem;
+          font-weight: 900;
+          line-height: 1;
+        }
+        #leaderboardToggle .leaderboard-icon {
+          display: inline-flex;
+          width: 1.22rem;
+          height: 1.22rem;
+          align-items: center;
+          justify-content: center;
+        }
+        #leaderboardToggle .leaderboard-icon svg {
+          width: 100%;
+          height: 100%;
+          display: block;
         }
         #leaderboardToggle.is-active {
           border-color: rgba(56, 189, 248, 0.9);
@@ -273,16 +287,16 @@ export default function DominoRoyalArena() {
             left: calc(0.1rem + env(safe-area-inset-left, 0px)) !important;
           }
           #dominoLeaderboardCard {
-            top: calc(3.4rem + env(safe-area-inset-top, 0px));
-            left: 54.9%;
+            top: calc(2.9rem + env(safe-area-inset-top, 0px));
+            left: 50%;
           }
           #leaderboardToggle {
-            top: calc(0.62rem + env(safe-area-inset-top, 0px));
+            top: calc(0.06rem + env(safe-area-inset-top, 0px));
           }
           #railControls {
             bottom: calc(
               env(safe-area-inset-bottom, 0px) + clamp(1.2rem, 7vh, 2.2rem) +
-                clamp(2.8rem, 8vh, 3.4rem) + 1.35rem
+                clamp(2.8rem, 8vh, 3.4rem) + 1.85rem
             ) !important;
           }
           #status {
@@ -365,7 +379,16 @@ export default function DominoRoyalArena() {
           <span id="muteLabel" className="visually-hidden">Mute</span>
         </button>
       </div>
-      <button id="leaderboardToggle" type="button" aria-label="Toggle leaderboard" title="Toggle leaderboard">🏆</button>
+      <button id="leaderboardToggle" type="button" aria-label="Toggle leaderboard" title="Toggle leaderboard">
+        <span className="leaderboard-icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none">
+            <path d="M4.5 18.5h15" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+            <rect x="5.3" y="10.6" width="3.1" height="5.6" rx="0.9" fill="currentColor" />
+            <rect x="10.45" y="7.25" width="3.1" height="8.95" rx="0.9" fill="currentColor" />
+            <rect x="15.6" y="4.7" width="3.1" height="11.5" rx="0.9" fill="currentColor" />
+          </svg>
+        </span>
+      </button>
       <div id="railControls" aria-label="Game controls">
         <button id="draw" type="button">Draw</button>
         <button id="pass" type="button">Pass</button>


### PR DESCRIPTION
### Motivation
- Improve mobile portrait UX by moving the local player avatar lower and nudging the Draw/Pass controls upward so they no longer sit too close to the bottom edge. 
- Make the leaderboard toggle more visible and consistent by placing a dedicated icon at the very top-center and allowing toggling in non-landscape view. 
- Prevent accidental pinch-to-zoom interactions in the 3D view while keeping pinch-to-zoom behavior intact for the 2D/top-down view.

### Description
- Adjusted human avatar badge anchoring in `webapp/public/domino-royal-game.js` by changing `HUMAN_SEAT_BADGE_BOTTOM_OFFSET` from `106` to `74` so the avatar appears lower on the screen. 
- Raised the Draw/Pass control rail by updating bottom offsets in `webapp/src/pages/Games/DominoRoyalArena.jsx` (changed `#railControls` base and portrait bottom clamps to sit higher). 
- Repositioned leaderboard UI to the top center in CSS and replaced the toggle glyph with an inline SVG icon in `DominoRoyalArena.jsx`, and added small styling for the icon (`.leaderboard-icon`). 
- Made leaderboard toggle available whenever not in landscape by relaxing logic in `webapp/public/domino-royal-game.js` (`updateLeaderboardVisibility` now uses `!isLandscapeViewport()` instead of requiring `isPointsRace`), and simplified the click handler accordingly so users can show/hide the leaderboard at the top-center. 
- Disabled pinch-to-zoom in 3D view by clearing `pinchZoomState.distance` and `pinchZoomState.mode` in the `pointermove` handler when `cameraViewMode === VIEW_MODES.threeD`, while preserving existing pinch-to-zoom handling for the 2D view. 
- Minor layout tweaks to quick-action spacing to keep controls visually consistent with the new offsets.

Files changed: `webapp/src/pages/Games/DominoRoyalArena.jsx`, `webapp/public/domino-royal-game.js`.

### Testing
- Ran `npx eslint webapp/src/pages/Games/DominoRoyalArena.jsx webapp/public/domino-royal-game.js`; linter run completed but both files are ignored by the repo lint configuration so only warnings were reported and no blocking lint errors occurred. 
- Verified changes were committed locally (`git commit`) and PR metadata was prepared; no automated unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8cce5a3108329bc3ad431b97a78a7)