### PR TITLE
Adjust Domino Royal portrait HUD, leaderboard toggle, and disable 3D pinch zoom

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -5888,7 +5888,7 @@ const seatAvatars = [];
 const seatNameTags = [];
 const seatBadges = [];
 let humanSeatBadgeAnchor = null;
-const HUMAN_SEAT_BADGE_BOTTOM_OFFSET = 106;
+const HUMAN_SEAT_BADGE_BOTTOM_OFFSET = 82;
 const HUMAN_SEAT_BADGE_LEFT_OFFSET = -6;
 const seatOverlay = document.createElement('div');
 seatOverlay.id = 'seatOverlay';
@@ -7703,9 +7703,9 @@ document.body.appendChild(leaderboardCard);
 function updateLeaderboardVisibility() {
   if (!leaderboardCard) return;
   const hideForViewport = isLandscapeViewport();
-  const allowLeaderboard = isPointsRace && !hideForViewport;
+  const allowLeaderboard = !hideForViewport;
   if (leaderboardToggleButton) {
-    leaderboardToggleButton.style.display = isPointsRace && !hideForViewport ? 'grid' : 'none';
+    leaderboardToggleButton.style.display = !hideForViewport ? 'grid' : 'none';
     leaderboardToggleButton.classList.toggle('is-active', allowLeaderboard && leaderboardExpanded);
     leaderboardToggleButton.setAttribute(
       'aria-pressed',
@@ -7716,7 +7716,7 @@ function updateLeaderboardVisibility() {
 }
 if (leaderboardToggleButton) {
   leaderboardToggleButton.addEventListener('click', () => {
-    if (!isPointsRace || isLandscapeViewport()) return;
+    if (isLandscapeViewport()) return;
     leaderboardExpanded = !leaderboardExpanded;
     updateLeaderboardVisibility();
   });
@@ -9460,12 +9460,6 @@ renderer.domElement.addEventListener('pointermove', (ev) => {
         second.x - first.x,
         second.y - first.y
       );
-      if (
-        Number.isFinite(pinchZoomState.distance) &&
-        pinchZoomState.mode === VIEW_MODES.threeD
-      ) {
-        applyThreeDZoomFromPinch(currentDistance - pinchZoomState.distance);
-      }
       pinchZoomState.distance = currentDistance;
       pinchZoomState.mode = VIEW_MODES.threeD;
     } else {

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -149,7 +149,7 @@ export default function DominoRoyalArena() {
         }
         #leaderboardToggle {
           position: fixed;
-          top: calc(0.68rem + env(safe-area-inset-top, 0px));
+          top: calc(0.1rem + env(safe-area-inset-top, 0px));
           left: 50%;
           transform: translateX(-50%);
           width: 2.35rem;
@@ -277,12 +277,12 @@ export default function DominoRoyalArena() {
             left: 54.9%;
           }
           #leaderboardToggle {
-            top: calc(0.62rem + env(safe-area-inset-top, 0px));
+            top: calc(0.06rem + env(safe-area-inset-top, 0px));
           }
           #railControls {
             bottom: calc(
               env(safe-area-inset-bottom, 0px) + clamp(1.2rem, 7vh, 2.2rem) +
-                clamp(2.8rem, 8vh, 3.4rem) + 1.35rem
+                clamp(2.8rem, 8vh, 3.4rem) + 2.15rem
             ) !important;
           }
           #status {


### PR DESCRIPTION
### Motivation
- Improve portrait HUD layout so the local player's avatar sits closer to the bottom and Draw/Pass controls do not overlap other bottom UI.
- Make the leaderboard toggle visible at the very top center and allow it to show/hide the leaderboard (except on landscape where space is limited).
- Prevent two-finger pinch from changing zoom in the 3D camera view while preserving pinch-to-zoom in the 2D (top-down) view.

### Description
- Lowered the human seat badge anchor by updating `HUMAN_SEAT_BADGE_BOTTOM_OFFSET` from `106` to `82` to move the self avatar visually closer to the bottom (`webapp/public/domino-royal-game.js`).
- Raised the bottom HUD by increasing the portrait `#railControls` offset (added to the calc) so `Draw`/`Pass` sit slightly higher (`webapp/src/pages/Games/DominoRoyalArena.jsx`).
- Moved the leaderboard toggle icon toward the very top center via CSS tweaks to `#leaderboardToggle` and portrait overrides (`webapp/src/pages/Games/DominoRoyalArena.jsx`).
- Changed leaderboard visibility logic so the toggle is available when viewport is not landscape and the toggle now controls showing/hiding the leaderboard (removed the previous `isPointsRace` gating) (`webapp/public/domino-royal-game.js`).
- Disabled the call that applied pinch zoom in 3D during pointer moves by removing the `applyThreeDZoomFromPinch` invocation while preserving pinch state tracking (pinch still tracked but has no effect in `3d`), keeping 2D pinch behavior intact (`webapp/public/domino-royal-game.js`).

### Testing
- Ran linting with `npx eslint webapp/src/pages/Games/DominoRoyalArena.jsx webapp/public/domino-royal-game.js` which completed successfully and reported only ignore-pattern warnings (no errors).
- No unit tests were changed or executed for this UI/interaction patch.
- Manual visual verification is recommended on a device in portrait orientation to confirm avatar position, `Draw/Pass` placement, leaderboard toggle behavior, and that pinch does nothing in 3D but still zooms in 2D.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8cce5a3108329bc3ad431b97a78a7)