### PR TITLE
Remove Domino Royale leaderboard and adjust Draw/Pass button placement

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -7692,108 +7692,18 @@ const winnerPlayAgainButton = document.getElementById('winnerPlayAgain');
 const winnerReturnLobbyButton = document.getElementById('winnerReturnLobby');
 const winnerCoinBurst = document.getElementById('winnerCoinBurst');
 const leaderboardToggleButton = document.getElementById('leaderboardToggle');
-let leaderboardExpanded = false;
-const leaderboardCard = document.createElement('div');
-leaderboardCard.id = 'dominoLeaderboardCard';
-leaderboardCard.setAttribute('aria-live', 'polite');
-leaderboardCard.innerHTML =
-  '<div class="leaderboard-title">Leaderboard</div><div class="leaderboard-rows"></div>';
-document.body.appendChild(leaderboardCard);
+const leaderboardCard = null;
 
 function updateLeaderboardVisibility() {
-  if (!leaderboardCard) return;
-  const hideForViewport = isLandscapeViewport();
-  const allowLeaderboard = !hideForViewport;
-  if (leaderboardToggleButton) {
-    leaderboardToggleButton.style.display = !hideForViewport ? 'grid' : 'none';
-    leaderboardToggleButton.classList.toggle('is-active', allowLeaderboard && leaderboardExpanded);
-    leaderboardToggleButton.setAttribute(
-      'aria-pressed',
-      allowLeaderboard && leaderboardExpanded ? 'true' : 'false'
-    );
-  }
-  leaderboardCard.style.display = allowLeaderboard && leaderboardExpanded ? '' : 'none';
-}
-if (leaderboardToggleButton) {
-  leaderboardToggleButton.addEventListener('click', () => {
-    if (isLandscapeViewport()) return;
-    leaderboardExpanded = !leaderboardExpanded;
-    updateLeaderboardVisibility();
-  });
+  if (!leaderboardToggleButton) return;
+  leaderboardToggleButton.style.display = 'none';
+  leaderboardToggleButton.setAttribute('aria-hidden', 'true');
 }
 updateLeaderboardVisibility();
 
-function computePipTotal(hand = []) {
-  return hand.reduce(
-    (sum, tile) => sum + Number(tile?.a || 0) + Number(tile?.b || 0),
-    0
-  );
-}
 
 function updateLeaderboardCard() {
-  if (!leaderboardCard) return;
-  if (!isPointsRace && leaderboardExpanded) leaderboardExpanded = false;
-  updateLeaderboardVisibility();
-  const titleEl = leaderboardCard.querySelector('.leaderboard-title');
-  const rowsHost = leaderboardCard.querySelector('.leaderboard-rows');
-  if (!rowsHost) return;
-  if (titleEl) {
-    titleEl.textContent = isPointsRace
-      ? `Leaderboard • Race to ${raceTargetPoints}`
-      : 'Leaderboard • Single Game';
-  }
-  leaderboardCard.classList.toggle('is-points-race', Boolean(isPointsRace));
-  leaderboardCard.classList.toggle('is-single-game', !isPointsRace);
-  const names = getSeatUsernames(N);
-  const avatars = buildSeatAvatarSources(N);
-  const rows = players
-    .map((player, idx) => ({
-      idx,
-      name: names[idx] || `Player ${idx + 1}`,
-      avatar: avatars[idx] || DEFAULT_AVATAR_EMOJI,
-      piecesLeft: player?.hand?.length ?? 0,
-      pointsLeft: computePipTotal(player?.hand || []),
-      raceTotal: Number.isFinite(racePenaltyTotals[idx]) ? racePenaltyTotals[idx] : 0,
-      disqualified: Boolean(raceDisqualifiedPlayers[idx])
-    }))
-    .sort((a, b) => {
-      if (isPointsRace) {
-        if (gameFinished && Number.isInteger(lastHandWinnerIndex)) {
-          if (a.idx === lastHandWinnerIndex && b.idx !== lastHandWinnerIndex) return -1;
-          if (b.idx === lastHandWinnerIndex && a.idx !== lastHandWinnerIndex) return 1;
-        }
-        if (a.disqualified !== b.disqualified) {
-          return a.disqualified ? 1 : -1;
-        }
-        return a.raceTotal - b.raceTotal || a.pointsLeft - b.pointsLeft || a.piecesLeft - b.piecesLeft;
-      }
-      return a.piecesLeft - b.piecesLeft || a.pointsLeft - b.pointsLeft;
-    });
-  rowsHost.innerHTML = rows
-    .map((entry, rank) => {
-      const avatarClass = isAvatarUrl(entry.avatar)
-        ? 'leaderboard-avatar has-photo'
-        : 'leaderboard-avatar';
-      const avatarStyle = isAvatarUrl(entry.avatar)
-        ? ` style="background-image:url('${entry.avatar}')"`
-        : '';
-      const scoreColumn = isPointsRace
-        ? `<span class="leaderboard-stat">${entry.raceTotal} pts${entry.disqualified ? ' • DQ' : ''}</span>`
-        : '';
-      const avatarLabel = isAvatarUrl(entry.avatar)
-        ? ''
-        : entry.avatar || DEFAULT_AVATAR_EMOJI;
-      return (
-        `<div class="leaderboard-row ${entry.idx === human ? 'is-human' : ''}">` +
-        `<span class="leaderboard-rank">${rank + 1}</span>` +
-        `<span class="${avatarClass}"${avatarStyle}${entry.idx === human ? ' data-self-player="true"' : ''}>${avatarLabel}</span>` +
-        `<span class="leaderboard-name">${entry.name}</span>` +
-        `${scoreColumn}` +
-        `<span class="leaderboard-stat">${entry.piecesLeft} left</span>` +
-        '</div>'
-      );
-    })
-    .join('');
+  return;
 }
 
 function hideWinnerOverlay() {

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -105,7 +105,13 @@ export default function DominoRoyalArena() {
           bottom: auto !important;
         }
         #railControls {
-          bottom: calc(env(safe-area-inset-bottom, 0px) + clamp(3.1rem, 8.5vh, 4.1rem)) !important;
+          left: calc(0.75rem + env(safe-area-inset-left, 0px)) !important;
+          right: calc(0.75rem + env(safe-area-inset-right, 0px)) !important;
+          width: auto !important;
+          transform: none !important;
+          justify-content: space-between !important;
+          gap: 0.5rem !important;
+          bottom: calc(env(safe-area-inset-bottom, 0px) + clamp(4.1rem, 10vh, 5rem)) !important;
           background: transparent !important;
           border: 0 !important;
           box-shadow: none !important;
@@ -113,6 +119,7 @@ export default function DominoRoyalArena() {
           backdrop-filter: none !important;
         }
         #railControls button {
+          min-width: clamp(5.5rem, 26vw, 7.2rem) !important;
           background: transparent !important;
           border: 1px solid rgba(226, 232, 240, 0.92) !important;
           color: #f8fafc !important;
@@ -130,112 +137,6 @@ export default function DominoRoyalArena() {
         }
         #quickActions .quick-action[data-action="chat"] {
           left: calc(0.75rem + env(safe-area-inset-left, 0px)) !important;
-        }
-        #dominoLeaderboardCard {
-          position: fixed;
-          top: calc(3.9rem + env(safe-area-inset-top, 0px));
-          left: 56.4%;
-          transform: translateX(-50%);
-          width: min(72vw, 15.5rem);
-          z-index: 5;
-          border-radius: 12px;
-          border: 1px solid rgba(148, 163, 184, 0.34);
-          background: linear-gradient(180deg, rgba(15, 23, 42, 0.96), rgba(15, 23, 42, 0.86));
-          box-shadow: 0 10px 20px rgba(2, 6, 23, 0.4);
-          backdrop-filter: blur(8px);
-          color: #f8fafc;
-          padding: 0.44rem 0.48rem;
-          pointer-events: none;
-        }
-        #leaderboardToggle {
-          position: fixed;
-          top: calc(0.1rem + env(safe-area-inset-top, 0px));
-          left: 50%;
-          transform: translateX(-50%);
-          width: 2.35rem;
-          height: 2.35rem;
-          border-radius: 999px;
-          border: 1px solid rgba(148, 163, 184, 0.5);
-          background: rgba(15, 23, 42, 0.92);
-          color: #f8fafc;
-          display: none;
-          place-items: center;
-          z-index: 8;
-          padding: 0;
-          font-size: 1.05rem;
-        }
-        #leaderboardToggle.is-active {
-          border-color: rgba(56, 189, 248, 0.9);
-          box-shadow: 0 0 0 2px rgba(14, 165, 233, 0.3);
-        }
-        #dominoLeaderboardCard .leaderboard-title {
-          font-size: 0.58rem;
-          letter-spacing: 0.14em;
-          text-transform: uppercase;
-          color: rgba(186, 230, 253, 0.92);
-          margin-bottom: 0.3rem;
-          text-align: center;
-          font-weight: 800;
-        }
-        #dominoLeaderboardCard .leaderboard-rows {
-          display: grid;
-          gap: 0.2rem;
-        }
-        #dominoLeaderboardCard .leaderboard-row {
-          display: grid;
-          grid-template-columns: 1.1rem 1.1rem minmax(0, 1fr) auto auto;
-          align-items: center;
-          column-gap: 0.33rem;
-          border-radius: 8px;
-          border: 1px solid rgba(148, 163, 184, 0.2);
-          background: rgba(15, 23, 42, 0.62);
-          padding: 0.2rem 0.34rem;
-          font-size: 0.64rem;
-        }
-        #dominoLeaderboardCard.is-single-game .leaderboard-row {
-          grid-template-columns: 1.1rem 1.1rem minmax(0, 1fr) auto;
-        }
-        #dominoLeaderboardCard .leaderboard-row.is-human {
-          border-color: rgba(56, 189, 248, 0.58);
-          background: rgba(14, 116, 144, 0.27);
-        }
-        #dominoLeaderboardCard .leaderboard-rank {
-          font-weight: 800;
-          text-align: center;
-          color: #fde68a;
-          font-size: 0.62rem;
-        }
-        #dominoLeaderboardCard .leaderboard-avatar {
-          width: 1.1rem;
-          height: 1.1rem;
-          border-radius: 999px;
-          border: 1px solid rgba(255, 255, 255, 0.5);
-          display: grid;
-          place-items: center;
-          overflow: hidden;
-          font-size: 0.63rem;
-          line-height: 1;
-          background: rgba(30, 41, 59, 0.95);
-          background-size: cover;
-          background-position: center;
-        }
-        #dominoLeaderboardCard .leaderboard-avatar.has-photo {
-          color: transparent;
-          text-indent: -9999px;
-        }
-        #dominoLeaderboardCard .leaderboard-name {
-          overflow: hidden;
-          text-overflow: ellipsis;
-          white-space: nowrap;
-          font-weight: 700;
-          font-size: 0.63rem;
-        }
-        #dominoLeaderboardCard .leaderboard-stat {
-          font-weight: 700;
-          color: rgba(226, 232, 240, 0.92);
-          white-space: nowrap;
-          font-size: 0.61rem;
-          letter-spacing: 0.01em;
         }
         #status {
           display: none !important;
@@ -272,17 +173,10 @@ export default function DominoRoyalArena() {
           #configButton {
             left: calc(0.1rem + env(safe-area-inset-left, 0px)) !important;
           }
-          #dominoLeaderboardCard {
-            top: calc(3.4rem + env(safe-area-inset-top, 0px));
-            left: 54.9%;
-          }
-          #leaderboardToggle {
-            top: calc(0.06rem + env(safe-area-inset-top, 0px));
-          }
           #railControls {
             bottom: calc(
               env(safe-area-inset-bottom, 0px) + clamp(1.2rem, 7vh, 2.2rem) +
-                clamp(2.8rem, 8vh, 3.4rem) + 2.15rem
+                clamp(2.8rem, 8vh, 3.4rem) + 3.1rem
             ) !important;
           }
           #status {
@@ -365,7 +259,6 @@ export default function DominoRoyalArena() {
           <span id="muteLabel" className="visually-hidden">Mute</span>
         </button>
       </div>
-      <button id="leaderboardToggle" type="button" aria-label="Toggle leaderboard" title="Toggle leaderboard">🏆</button>
       <div id="railControls" aria-label="Game controls">
         <button id="draw" type="button">Draw</button>
         <button id="pass" type="button">Pass</button>


### PR DESCRIPTION
### Motivation
- The in-game leaderboard (‘biscuit’ at top) is unnecessary for the Domino Royale arena and should be removed to declutter the top of the screen. 
- The `Draw` and `Pass` controls need to sit slightly higher and move toward the left/right edges on portrait phones to match the provided mock.

### Description
- Removed leaderboard UI elements and styles from the arena React page by deleting the leaderboard toggle markup and associated inline CSS in `webapp/src/pages/Games/DominoRoyalArena.jsx`. 
- Disabled leaderboard runtime behavior in the shipped game script by hiding the toggle and making leaderboard update/render functions no-ops in `webapp/public/domino-royal-game.js`. 
- Repositioned the rail control container and buttons for portrait layout by changing `#railControls` rules to span left/right, use `justify-content: space-between`, increase bottom offset in portrait, and set a larger `min-width` for control buttons so `Draw` and `Pass` move up and toward the sides. 
- Minor cleanup: removed the in-script `computePipTotal` usage (leaderboard-related) and related rendering code paths that are no longer needed.

### Testing
- Ran the production build with `npm run build --prefix webapp`, which completed successfully; Vite emitted non-blocking chunk/dynamic-import warnings but the build finished without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8dd5809948329bafaf8bf4f5fc8c4)