### PR TITLE
Pool Royale: restore replay camera snapshot behavior

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -21306,23 +21306,20 @@ const powerRef = useRef(hud.power);
         const captureReplayCameraSnapshot = () => {
           const scale = Number.isFinite(worldScaleFactor) ? worldScaleFactor : WORLD_SCALE;
           const minTargetY = Math.max(baseSurfaceWorldY, BALL_CENTER_Y * scale);
+          const activeCamera = activeRenderCameraRef.current ?? camera;
+          const fovSnapshot = Number.isFinite(activeCamera?.fov)
+            ? activeCamera.fov
+            : camera.fov;
           const targetSnapshot = lastCameraTargetRef.current
             ? lastCameraTargetRef.current.clone()
             : broadcastCamerasRef.current?.defaultFocusWorld?.clone?.() ?? null;
-          const railSnapshot = resolveRailOverheadReplayCamera({
-            focusOverride: targetSnapshot,
-            minTargetY,
-            preferredRail: railOverheadSideRef.current
-          });
           const cameraMode =
             pocketCameraStateRef.current && activeShotView?.mode === 'pocket'
               ? `pocket:${activeShotView?.anchorId ?? activeShotView?.pocketId ?? 'active'}`
               : 'broadcast';
-          const resolvedPosition = railSnapshot?.position?.clone?.() ?? null;
-          const resolvedTarget = railSnapshot?.target?.clone?.() ?? targetSnapshot;
-          const resolvedFov = Number.isFinite(railSnapshot?.fov)
-            ? railSnapshot.fov
-            : camera.fov;
+          const resolvedPosition = activeCamera?.position?.clone?.() ?? null;
+          const resolvedTarget = targetSnapshot;
+          const resolvedFov = fovSnapshot;
           if (!resolvedPosition && !resolvedTarget) return null;
           const snapshot = {
             position: resolvedPosition,


### PR DESCRIPTION
### Motivation
- Replays in Pool Royale were captured with a forced rail-overhead snapshot path which produced incorrect/undesired viewpoints during playback.
- The change returns snapshot capture to use the active render camera so replays appear as they were before the regression.

### Description
- Updated `captureReplayCameraSnapshot` in `webapp/src/pages/Games/PoolRoyale.jsx` to use the active render camera position and FOV (`activeRenderCameraRef.current ?? camera`) instead of forcing `resolveRailOverheadReplayCamera` for the snapshot.
- Kept `minTargetY` and `targetSnapshot` handling intact while restoring the snapshot `position`, `target`, and `fov` sources to the active camera.
- No other gameplay, camera, or replay playback logic was modified.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c90162e7c8832992ce95cd88ce0052)