### PR TITLE
Pool Royale: restore rail-overhead replay camera snapshot

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -21306,20 +21306,23 @@ const powerRef = useRef(hud.power);
         const captureReplayCameraSnapshot = () => {
           const scale = Number.isFinite(worldScaleFactor) ? worldScaleFactor : WORLD_SCALE;
           const minTargetY = Math.max(baseSurfaceWorldY, BALL_CENTER_Y * scale);
-          const activeCamera = activeRenderCameraRef.current ?? camera;
-          const fovSnapshot = Number.isFinite(activeCamera?.fov)
-            ? activeCamera.fov
-            : camera.fov;
           const targetSnapshot = lastCameraTargetRef.current
             ? lastCameraTargetRef.current.clone()
             : broadcastCamerasRef.current?.defaultFocusWorld?.clone?.() ?? null;
+          const railSnapshot = resolveRailOverheadReplayCamera({
+            focusOverride: targetSnapshot,
+            minTargetY,
+            preferredRail: railOverheadSideRef.current
+          });
           const cameraMode =
             pocketCameraStateRef.current && activeShotView?.mode === 'pocket'
               ? `pocket:${activeShotView?.anchorId ?? activeShotView?.pocketId ?? 'active'}`
               : 'broadcast';
-          const resolvedPosition = activeCamera?.position?.clone?.() ?? null;
-          const resolvedTarget = targetSnapshot;
-          const resolvedFov = fovSnapshot;
+          const resolvedPosition = railSnapshot?.position?.clone?.() ?? null;
+          const resolvedTarget = railSnapshot?.target?.clone?.() ?? targetSnapshot;
+          const resolvedFov = Number.isFinite(railSnapshot?.fov)
+            ? railSnapshot.fov
+            : camera.fov;
           if (!resolvedPosition && !resolvedTarget) return null;
           const snapshot = {
             position: resolvedPosition,


### PR DESCRIPTION
### Motivation
- Replays stopped matching the broadcast/rail-overhead framing because replay snapshots began using the active render camera instead of the rail-overhead resolver, so replay recordings no longer matched the broadcast output.

### Description
- Restored the rail-overhead replay snapshot flow in `webapp/src/pages/Games/PoolRoyale.jsx` by calling `resolveRailOverheadReplayCamera(...)` and using the resolved `position`, `target`, and `fov` for replay snapshots.
- Reinstated `minTargetY` handling and the prior camera-mode key generation for replay snapshots and removed the temporary reliance on `activeRenderCameraRef.current` for this capture.
- Change is confined to `webapp/src/pages/Games/PoolRoyale.jsx` and does not touch other systems.

### Testing
- Ran `npm test -- --runInBand test/poolRoyaleCueStrokeTimeline.test.js`, which passed (4/4 tests).
- No additional automated test suites were run for this change; modification is local to the replay camera snapshot logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c90a39270c832995926d93d5c08931)