### PR TITLE
Fix rack overlap in Pool Royale and make replay trigger reliable

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2252,6 +2252,37 @@ function generateRackPositions(ballCount, layout, ballRadius, startZ) {
   const contactGap = ballRadius * 1e-4;
   const columnSpacing = ballRadius * 2 + contactGap;
   const rowSpacing = Math.sqrt(3) * ballRadius + contactGap;
+  const minCenterDistance = ballRadius * 2;
+  const deOverlapRackPositions = (input) => {
+    if (!Array.isArray(input) || input.length <= 1) return input;
+    const adjusted = input.map((entry) => ({ ...entry }));
+    const settlePasses = Math.max(2, adjusted.length);
+    for (let pass = 0; pass < settlePasses; pass += 1) {
+      let shifted = false;
+      for (let i = 0; i < adjusted.length; i += 1) {
+        for (let j = i + 1; j < adjusted.length; j += 1) {
+          const a = adjusted[i];
+          const b = adjusted[j];
+          const dx = b.x - a.x;
+          const dz = b.z - a.z;
+          const distSq = dx * dx + dz * dz;
+          const minDistSq = minCenterDistance * minCenterDistance;
+          if (distSq >= minDistSq) continue;
+          const dist = Math.sqrt(Math.max(distSq, 1e-12));
+          const overlap = (minCenterDistance - dist) / 2;
+          const nx = dist > 1e-9 ? dx / dist : 1;
+          const nz = dist > 1e-9 ? dz / dist : 0;
+          a.x -= nx * overlap;
+          a.z -= nz * overlap;
+          b.x += nx * overlap;
+          b.z += nz * overlap;
+          shifted = true;
+        }
+      }
+      if (!shifted) break;
+    }
+    return adjusted;
+  };
   if (layout === 'diamond') {
     const rows = [1, 2, 3, 2, 1];
     let index = 0;
@@ -2265,7 +2296,7 @@ function generateRackPositions(ballCount, layout, ballRadius, startZ) {
         index++;
       }
     }
-    return positions;
+    return deOverlapRackPositions(positions);
   }
   let row = 0;
   let placed = 0;
@@ -2280,7 +2311,7 @@ function generateRackPositions(ballCount, layout, ballRadius, startZ) {
     }
     row++;
   }
-  return positions;
+  return deOverlapRackPositions(positions);
 }
 
 // Updated colors for dark cloth (ball colors overridden per variant at runtime)
@@ -28357,7 +28388,7 @@ const powerRef = useRef(hud.power);
           pottedBalls,
           shotContext
         }) => {
-          if (!recording || !hadObjectPot) return null;
+          if (!recording) return null;
           const tags = new Set(recording.replayTags ?? []);
           if (hadObjectPot) tags.add('pot');
           const potCount = pottedBalls.filter((entry) => entry.id !== 'cue').length;
@@ -28367,8 +28398,9 @@ const powerRef = useRef(hud.power);
           const priority = ['multi', 'bank', 'long', 'power', 'spin'];
           const primary = priority.find((tag) => tags.has(tag)) ?? 'default';
           const zoomOnly = recording.zoomOnly && !tags.has('long') && !tags.has('bank');
+          const hasReplaySignal = hadObjectPot || tags.size > 0;
           return {
-            shouldReplay: hadObjectPot || tags.size > 0,
+            shouldReplay: hasReplaySignal,
             banner: selectReplayBanner(primary),
             zoomOnly,
             tags: Array.from(tags),
@@ -28884,8 +28916,9 @@ const powerRef = useRef(hud.power);
           pocketSwitchIntentRef.current = null;
           lastPocketBallRef.current = null;
           updatePocketCameraState(false);
-          if (shouldStartReplay && postShotSnapshot) {
+          if (shouldStartReplay) {
             const recordingForReplay = shotRecording;
+            const replayPostState = postShotSnapshot || captureBallSnapshot();
             const launchReplay = () => {
               replayBannerTimeoutRef.current = null;
               setReplayBanner(null);
@@ -28893,7 +28926,7 @@ const powerRef = useRef(hud.power);
               const beginReplay = () => {
                 shotRecording = recordingForReplay;
                 if (recordingForReplay) {
-                  startShotReplay(postShotSnapshot);
+                  startShotReplay(replayPostState);
                 } else {
                   shotReplayRef.current = null;
                 }


### PR DESCRIPTION
### Motivation
- Balls placed in the rack were occasionally overlapping visually and needed a deterministic pass to ensure they touch but do not overlap. 
- The replay flow could be blocked when a pre-captured post-shot snapshot was missing or when replay gating required an object pot, so replay should follow the same unblocked logic used earlier today.

### Description
- Added a de-overlap settling pass inside `generateRackPositions` that nudges positions so center-to-center distances are at least one full diameter, and applied it to both triangle and diamond layouts in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Relaxed replay gating in `resolveReplayDecision` to allow replay when recorded replay tags/signals exist rather than requiring `hadObjectPot` to be true in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Added a replay start fallback that uses the captured `postShotSnapshot` or calls `captureBallSnapshot()` when starting the replay so playback is not blocked if the snapshot wasn’t pre-captured.

### Testing
- Ran the focused test command `npm test -- --runInBand test/poolRoyaleCueStrokeTimeline.test.js test/poolRoyaleTrainingProgress.test.js` and both suites passed.
- Test summary: `2` test suites passed, `11` tests passed (no failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c90f6b1e4c8329b850f47d4c62109d)