### PR TITLE
Fix Pool Royale rack spacing and replay trigger reliability

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2252,6 +2252,37 @@ function generateRackPositions(ballCount, layout, ballRadius, startZ) {
   const contactGap = ballRadius * 1e-4;
   const columnSpacing = ballRadius * 2 + contactGap;
   const rowSpacing = Math.sqrt(3) * ballRadius + contactGap;
+  const minCenterDistance = ballRadius * 2;
+  const deOverlapRackPositions = (input) => {
+    if (!Array.isArray(input) || input.length <= 1) return input;
+    const adjusted = input.map((entry) => ({ ...entry }));
+    const settlePasses = Math.max(2, adjusted.length);
+    for (let pass = 0; pass < settlePasses; pass += 1) {
+      let shifted = false;
+      for (let i = 0; i < adjusted.length; i += 1) {
+        for (let j = i + 1; j < adjusted.length; j += 1) {
+          const a = adjusted[i];
+          const b = adjusted[j];
+          const dx = b.x - a.x;
+          const dz = b.z - a.z;
+          const distSq = dx * dx + dz * dz;
+          const minDistSq = minCenterDistance * minCenterDistance;
+          if (distSq >= minDistSq) continue;
+          const dist = Math.sqrt(Math.max(distSq, 1e-12));
+          const overlap = (minCenterDistance - dist) / 2;
+          const nx = dist > 1e-9 ? dx / dist : 1;
+          const nz = dist > 1e-9 ? dz / dist : 0;
+          a.x -= nx * overlap;
+          a.z -= nz * overlap;
+          b.x += nx * overlap;
+          b.z += nz * overlap;
+          shifted = true;
+        }
+      }
+      if (!shifted) break;
+    }
+    return adjusted;
+  };
   if (layout === 'diamond') {
     const rows = [1, 2, 3, 2, 1];
     let index = 0;
@@ -2265,7 +2296,7 @@ function generateRackPositions(ballCount, layout, ballRadius, startZ) {
         index++;
       }
     }
-    return positions;
+    return deOverlapRackPositions(positions);
   }
   let row = 0;
   let placed = 0;
@@ -2280,7 +2311,7 @@ function generateRackPositions(ballCount, layout, ballRadius, startZ) {
     }
     row++;
   }
-  return positions;
+  return deOverlapRackPositions(positions);
 }
 
 // Updated colors for dark cloth (ball colors overridden per variant at runtime)
@@ -28357,7 +28388,7 @@ const powerRef = useRef(hud.power);
           pottedBalls,
           shotContext
         }) => {
-          if (!recording || !hadObjectPot) return null;
+          if (!recording) return null;
           const tags = new Set(recording.replayTags ?? []);
           if (hadObjectPot) tags.add('pot');
           const potCount = pottedBalls.filter((entry) => entry.id !== 'cue').length;
@@ -28367,8 +28398,9 @@ const powerRef = useRef(hud.power);
           const priority = ['multi', 'bank', 'long', 'power', 'spin'];
           const primary = priority.find((tag) => tags.has(tag)) ?? 'default';
           const zoomOnly = recording.zoomOnly && !tags.has('long') && !tags.has('bank');
+          const hasReplaySignal = hadObjectPot || tags.size > 0;
           return {
-            shouldReplay: hadObjectPot || tags.size > 0,
+            shouldReplay: hasReplaySignal,
             banner: selectReplayBanner(primary),
             zoomOnly,
             tags: Array.from(tags),
@@ -28884,8 +28916,9 @@ const powerRef = useRef(hud.power);
           pocketSwitchIntentRef.current = null;
           lastPocketBallRef.current = null;
           updatePocketCameraState(false);
-          if (shouldStartReplay && postShotSnapshot) {
+          if (shouldStartReplay) {
             const recordingForReplay = shotRecording;
+            const replayPostState = postShotSnapshot || captureBallSnapshot();
             const launchReplay = () => {
               replayBannerTimeoutRef.current = null;
               setReplayBanner(null);
@@ -28893,7 +28926,7 @@ const powerRef = useRef(hud.power);
               const beginReplay = () => {
                 shotRecording = recordingForReplay;
                 if (recordingForReplay) {
-                  startShotReplay(postShotSnapshot);
+                  startShotReplay(replayPostState);
                 } else {
                   shotReplayRef.current = null;
                 }


### PR DESCRIPTION
### Motivation
- Balls in the rack could appear to overlap visually on some layouts and device scales, which hurts visual fidelity and UX. 
- Replay playback could be suppressed or blocked when a post-shot snapshot was missing or when replay-worthy tags (foul/final/bank/power/multi) existed but no object ball was potted. 

### Description
- Added an iterative de-overlap pass (`deOverlapRackPositions`) to `generateRackPositions` so generated triangle and diamond rack coordinates are adjusted to enforce a minimum center-to-center spacing (balls touch but do not overlap). 
- Restored replay decision logic so `resolveReplayDecision` returns a replay signal when replay tags exist even if `hadObjectPot` is false by checking `recording.replayTags` and computing `shouldReplay` from tags and pot state. 
- Ensured replay startup always has a usable post-shot state by falling back to `captureBallSnapshot()` when `postShotSnapshot` is not available before calling `startShotReplay`. 
- All changes are contained in `webapp/src/pages/Games/PoolRoyale.jsx` and are limited to rack position generation and replay decision/playback flow. 

### Testing
- Ran the production build with `npm --prefix webapp run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c91777f1188329a2d74fa18f49327c)