### PR TITLE
Pool Royale: fix replay trigger, prevent rack overlaps, and improve topspin behavior

### DIFF
--- a/test/poolRoyaleSpinController.test.js
+++ b/test/poolRoyaleSpinController.test.js
@@ -6,10 +6,11 @@ const getSigns = (vec) => ({
 });
 
 describe('Pool Royale spin controller mapping', () => {
-  it('maps the center to true stun (no spin)', () => {
+  it('maps the center to a slight default topspin bias', () => {
     const center = mapSpinForPhysics({ x: 0, y: 0 });
     expect(Math.abs(center.x)).toBe(0);
-    expect(Math.abs(center.y)).toBe(0);
+    expect(center.y).toBeGreaterThan(0);
+    expect(center.y).toBeLessThan(0.25);
   });
 
   it('keeps left/right spin directions aligned with the table axes', () => {

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2253,10 +2253,17 @@ function generateRackPositions(ballCount, layout, ballRadius, startZ) {
   const columnSpacing = ballRadius * 2 + contactGap;
   const rowSpacing = Math.sqrt(3) * ballRadius + contactGap;
   const minCenterDistance = ballRadius * 2;
+  const rackCushionClearance = ballRadius * 0.08;
+  const rackLimitX = Math.max(0, RAIL_LIMIT_X - ballRadius - rackCushionClearance);
+  const rackLimitZ = Math.max(0, RAIL_LIMIT_Y - ballRadius - rackCushionClearance);
+  const clampRackPosition = (entry) => ({
+    x: clamp(entry.x, -rackLimitX, rackLimitX),
+    z: clamp(entry.z, -rackLimitZ, rackLimitZ)
+  });
   const deOverlapRackPositions = (input) => {
     if (!Array.isArray(input) || input.length <= 1) return input;
-    const adjusted = input.map((entry) => ({ ...entry }));
-    const settlePasses = Math.max(2, adjusted.length);
+    const adjusted = input.map((entry) => clampRackPosition(entry));
+    const settlePasses = Math.max(4, adjusted.length * 2);
     for (let pass = 0; pass < settlePasses; pass += 1) {
       let shifted = false;
       for (let i = 0; i < adjusted.length; i += 1) {
@@ -2276,6 +2283,20 @@ function generateRackPositions(ballCount, layout, ballRadius, startZ) {
           a.z -= nz * overlap;
           b.x += nx * overlap;
           b.z += nz * overlap;
+          const clampedA = clampRackPosition(a);
+          const clampedB = clampRackPosition(b);
+          a.x = clampedA.x;
+          a.z = clampedA.z;
+          b.x = clampedB.x;
+          b.z = clampedB.z;
+          shifted = true;
+        }
+      }
+      for (let i = 0; i < adjusted.length; i += 1) {
+        const clamped = clampRackPosition(adjusted[i]);
+        if (Math.abs(clamped.x - adjusted[i].x) > 1e-9 || Math.abs(clamped.z - adjusted[i].z) > 1e-9) {
+          adjusted[i].x = clamped.x;
+          adjusted[i].z = clamped.z;
           shifted = true;
         }
       }
@@ -5946,9 +5967,9 @@ const DEFAULT_SPIN_LIMITS = Object.freeze({
   maxY: 1
 });
 const MAX_TOPSPIN_INPUT = 0.8; // reduce topspin cap to match Snooker Royal feel
-const TOPSPIN_FOLLOW_TRANSFER_RATE = 0.42; // convert topspin into forward roll sooner so natural follow builds progressively instead of feeling delayed
-const TOPSPIN_FOLLOW_DECAY_ASSIST = 0.74; // keep some residual roll-through after impact before spin naturally settles
-const TOPSPIN_ROLL_SPEED_FACTOR = 0.94; // let topspin carry cue-ball speed farther before settling at natural roll
+const TOPSPIN_FOLLOW_TRANSFER_RATE = 0.58; // convert topspin into forward roll earlier so straight top spin does not feel stunned
+const TOPSPIN_FOLLOW_DECAY_ASSIST = 0.52; // keep natural roll-through longer before topspin fully settles
+const TOPSPIN_ROLL_SPEED_FACTOR = 1.08; // allow top spin to carry cue-ball speed forward instead of stalling into a stun look
 const TOPSPIN_POWER_SOFT_CAP = 0.9;
 const clampSpinValue = (value) => clamp(value, -1, 1);
 const SPIN_CUSHION_EPS = BALL_R * 0.6;
@@ -28398,7 +28419,12 @@ const powerRef = useRef(hud.power);
           const priority = ['multi', 'bank', 'long', 'power', 'spin'];
           const primary = priority.find((tag) => tags.has(tag)) ?? 'default';
           const zoomOnly = recording.zoomOnly && !tags.has('long') && !tags.has('bank');
-          const hasReplaySignal = hadObjectPot || tags.size > 0;
+          const hadMeaningfulContact = Boolean(shotContext?.contactMade);
+          const hasReplaySignal =
+            hadObjectPot ||
+            tags.size > 0 ||
+            hadMeaningfulContact ||
+            Boolean(recording?.replayFoul);
           return {
             shouldReplay: hasReplaySignal,
             banner: selectReplayBanner(primary),

--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -11,6 +11,7 @@ export const SPIN_LEVEL2_MAG = SPIN_RING2_RADIUS;
 export const SPIN_LEVEL3_MAG = SPIN_RING3_RADIUS;
 export const STRAIGHT_SPIN_DEADZONE = 0.02;
 export const SPIN_RESPONSE_EXPONENT = 1.45;
+export const SPIN_CENTER_TOPSPIN_BIAS = 0.16;
 export const SPIN_DIRECTIONS = [
   {
     id: 'stun',
@@ -200,6 +201,9 @@ export const mapSpinForPhysics = (spin, options = {}) => {
     y: clamp(spin?.y ?? 0, -1, 1)
   };
   const quantized = normalizeSpinInput(adjusted);
+  if (Math.hypot(quantized.x, quantized.y) <= 1e-6) {
+    return { x: 0, y: SPIN_CENTER_TOPSPIN_BIAS };
+  }
   const { cameraRight, cameraUp, cueForward } = options;
   return mapUiOffsetToCueFrame(
     -quantized.x,


### PR DESCRIPTION
### Motivation
- Replays were sometimes not shown even when the shot had visible contact or a foul, so replay gating needed to be more inclusive.
- Balls placed at the rack could overlap or clip into the rails/cushions, producing visual artifacts and inconsistent collisions.
- Straight/top-spin shots (and centered spin dot) produced a stun-like effect instead of a natural follow-through and forward roll.

### Description
- Replay decision logic was extended to treat meaningful shot contact and recorded fouls as replay signals so replays still trigger when appropriate by default (`resolveReplayDecision` in `PoolRoyale.jsx`).
- Rack generation was hardened by clamping generated positions inside cushion-safe limits and running stronger iterative de-overlap passes with clamp re-application to avoid overlapping racked balls and rail/cushion clipping (`generateRackPositions` in `PoolRoyale.jsx`).
- Topspin behavior was tuned by adjusting `TOPSPIN_FOLLOW_TRANSFER_RATE`, `TOPSPIN_FOLLOW_DECAY_ASSIST`, and `TOPSPIN_ROLL_SPEED_FACTOR` to convert topspin into forward roll earlier and preserve natural roll-through (`PoolRoyale.jsx`).
- Added a small default topspin bias when the spin controller is centered (`SPIN_CENTER_TOPSPIN_BIAS`) and return that bias from `mapSpinForPhysics` so the red-dot center no longer produces a pure stun (`poolRoyaleSpinUtils.js`).
- Updated spin-controller unit test expectations to reflect the new default center topspin bias (`test/poolRoyaleSpinController.test.js`).

### Testing
- Ran `jest --runTestsByPath test/poolRoyaleSpinController.test.js` and the suite passed: 1 test file, 7 tests all successful.
- No other automated test suites were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9216cf32883299bfd79a16ee3c127)