### PR TITLE
Fix Pool Royale replay visibility and tune rack / topspin behavior

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2249,7 +2249,9 @@ function generateRackPositions(ballCount, layout, ballRadius, startZ) {
   if (ballCount <= 0 || !Number.isFinite(ballRadius) || !Number.isFinite(startZ)) {
     return positions;
   }
-  const contactGap = ballRadius * 0.0022;
+  // Keep a small but visible daylight between touching balls so rack visuals
+  // never look overlapped on portrait/mobile views.
+  const contactGap = ballRadius * 0.014;
   const columnSpacing = ballRadius * 2 + contactGap;
   const rowSpacing = Math.sqrt(3) * ballRadius + contactGap;
   const minCenterDistance = ballRadius * 2 + contactGap;
@@ -5966,10 +5968,10 @@ const DEFAULT_SPIN_LIMITS = Object.freeze({
   minY: -1,
   maxY: 1
 });
-const MAX_TOPSPIN_INPUT = 0.8; // reduce topspin cap to match Snooker Royal feel
-const TOPSPIN_FOLLOW_TRANSFER_RATE = 0.58; // convert topspin into forward roll earlier so straight top spin does not feel stunned
-const TOPSPIN_FOLLOW_DECAY_ASSIST = 0.52; // keep natural roll-through longer before topspin fully settles
-const TOPSPIN_ROLL_SPEED_FACTOR = 1.08; // allow top spin to carry cue-ball speed forward instead of stalling into a stun look
+const MAX_TOPSPIN_INPUT = 0.92; // allow fuller top-spin contact so follow-through matches real-table behavior
+const TOPSPIN_FOLLOW_TRANSFER_RATE = 0.74; // convert topspin into forward roll earlier so straight top spin does not feel stunned
+const TOPSPIN_FOLLOW_DECAY_ASSIST = 0.72; // keep natural roll-through longer before topspin fully settles
+const TOPSPIN_ROLL_SPEED_FACTOR = 1.14; // allow top spin to carry cue-ball speed forward instead of stalling into a stun look
 const TOPSPIN_POWER_SOFT_CAP = 0.9;
 const clampSpinValue = (value) => clamp(value, -1, 1);
 const SPIN_CUSHION_EPS = BALL_R * 0.6;
@@ -12665,14 +12667,7 @@ function PoolRoyaleGame({
     );
   });
   const clothTextureSourceId = DEFAULT_CLOTH_TEXTURE_SOURCE_ID;
-  const [skipAllReplays, setSkipAllReplays] = useState(() => {
-    if (typeof window !== 'undefined') {
-      const stored = window.localStorage.getItem(SKIP_REPLAYS_STORAGE_KEY);
-      if (stored === '1') return true;
-      if (stored === '0') return false;
-    }
-    return false;
-  });
+  const [skipAllReplays, setSkipAllReplays] = useState(false);
   const [commentaryPresetId, setCommentaryPresetId] = useState(() => {
     if (typeof window !== 'undefined') {
       const stored = window.localStorage.getItem(COMMENTARY_PRESET_STORAGE_KEY);


### PR DESCRIPTION
### Motivation
- Replays were not appearing for some users because a persisted setting could silently disable replay playback on load. 
- Rack visuals on portrait/mobile could show balls overlapping due to too-small contact spacing. 
- Topspin follow-through felt weak compared to real-table behavior and needed stronger transfer into forward roll.

### Description
- Force the Pool Royale replay toggle to default to `false` at component init by setting `skipAllReplays` to `false` so stale localStorage values no longer block replay playback (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Increase rack contact spacing by changing the rack contact gap multiplier to `ballRadius * 0.014` and add a clarifying comment to reduce visual overlap in racked balls (`generateRackPositions` in `PoolRoyale.jsx`).
- Tune topspin behavior by raising `MAX_TOPSPIN_INPUT` and increasing `TOPSPIN_FOLLOW_TRANSFER_RATE`, `TOPSPIN_FOLLOW_DECAY_ASSIST`, and `TOPSPIN_ROLL_SPEED_FACTOR` to provide stronger follow-through and more realistic forward roll after topspin shots (`PoolRoyale.jsx`).

### Testing
- Ran unit tests for the affected gameplay areas with `npm test -- --runInBand test/poolRoyaleSpinController.test.js test/cueShotImpact.test.js` and both test suites passed.
- Test results: `PASS test/poolRoyaleSpinController.test.js` and `PASS test/cueShotImpact.test.js` (all tests in those suites succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9615f77e48329bf08ce223b54a4f7)