### PR TITLE
Emit explicit extra-turn events so client can re-show roll control

### DIFF
--- a/bot/gameEngine.js
+++ b/bot/gameEngine.js
@@ -298,7 +298,11 @@ export class GameRoom {
       if (!result) return;
 
       const total = result.dice.reduce((a, b) => a + b, 0);
-      this.io.to(this.id).emit('diceRolled', { playerId: player.playerId, value: total });
+      this.io.to(this.id).emit('diceRolled', {
+        playerId: player.playerId,
+        value: total,
+        extraTurn: result.extraTurn
+      });
       const from = prevPositions[playerIndex];
       const to = result.path.length ? result.path[result.path.length - 1] : from;
 
@@ -337,6 +341,9 @@ export class GameRoom {
         return;
       }
 
+      if (result.extraTurn) {
+        this.io.to(this.id).emit('extraTurnGranted', { playerId: player.playerId });
+      }
       this.currentTurn = this.game.currentTurn;
     } else {
       const result = this.game.rollDice(value);

--- a/bot/server.js
+++ b/bot/server.js
@@ -2446,12 +2446,20 @@ io.on('connection', (socket) => {
       io.to(tableId).emit('diceRolled', {
         accountId,
         dice,
-        newPosition: player.position
+        newPosition: player.position,
+        extraTurn: dice === 6
       });
       const idx = table.players.findIndex((p) => p.id === accountId);
       const nextIndex = (idx + 1) % table.players.length;
-      table.currentTurn = table.players[nextIndex].id;
-      io.to(tableId).emit('turnUpdate', { currentTurn: table.currentTurn });
+      const keepTurn = dice === 6;
+      table.currentTurn = keepTurn ? accountId : table.players[nextIndex].id;
+      io.to(tableId).emit('turnUpdate', {
+        currentTurn: table.currentTurn,
+        extraTurn: keepTurn
+      });
+      if (keepTurn) {
+        io.to(tableId).emit('extraTurnGranted', { accountId });
+      }
       return;
     }
 

--- a/test/snakeGame.test.js
+++ b/test/snakeGame.test.js
@@ -73,6 +73,36 @@ test('rolling multiple sixes grants extra turns but preserves order', () => {
   assert.equal(room.players[0].position, 25);
 });
 
+test('extra turn emits explicit event and keeps turn with same player', () => {
+  const io = new DummyIO();
+  const room = new GameRoom('rExtra', io, 2, {
+    snakes: DEFAULT_SNAKES,
+    ladders: DEFAULT_LADDERS,
+  });
+  room.rollCooldown = 0;
+  const s1 = { id: 's1', join: () => {}, emit: () => {} };
+  const s2 = { id: 's2', join: () => {}, emit: () => {} };
+  room.addPlayer('p1', 'Player1', s1);
+  room.addPlayer('p2', 'Player2', s2);
+  room.startGame();
+
+  io.emitted = [];
+  room.rollDice(s1, [6, 6]);
+
+  assert.equal(room.currentTurn, 0, 'player 1 should keep the turn');
+  const diceRolled = io.emitted.find((e) => e.event === 'diceRolled');
+  assert.ok(diceRolled, 'diceRolled should be emitted');
+  assert.equal(diceRolled.data.extraTurn, true, 'diceRolled should flag extra turn');
+  const extraTurn = io.emitted.find(
+    (e) => e.event === 'extraTurnGranted' && e.data.playerId === 'p1'
+  );
+  assert.ok(extraTurn, 'extraTurnGranted should be emitted for the same player');
+  const turnChanged = io.emitted.find(
+    (e) => e.event === 'turnChanged' && e.data.playerId === 'p1'
+  );
+  assert.ok(turnChanged, 'turnChanged should repeat same player for extra turn');
+});
+
 test('room starts when reaching custom capacity', async () => {
   const io = new DummyIO();
   const room = new GameRoom('r2', io, 2, {
@@ -227,4 +257,3 @@ test('dice cells are shared across players', () => {
     room.turnTimer = null;
   }
 });
-


### PR DESCRIPTION
### Motivation
- Players who earn a reroll (e.g. by rolling a six or landing on a dice cell) reported the roll UI disappeared because the client had no explicit signal that the same player should roll again. 
- The server needs to make extra-turn state explicit in socket events so clients can re-enable the roll icon immediately when the same player retains the turn. 

### Description
- Added `extraTurn` boolean metadata to `diceRolled` payloads for snake games in `bot/gameEngine.js` so clients can detect rerolls (`diceRolled` now includes `extraTurn`).
- Emit a dedicated `extraTurnGranted` socket event from `GameRoom` when `result.extraTurn` is true so clients receive an explicit reroll notification.
- Updated table-mode `rollDice` handling in `bot/server.js` to treat a `6` as keeping the same turn, include `extraTurn` in `turnUpdate`/`diceRolled`, and broadcast `extraTurnGranted` for UI consumption.
- Added a regression test `test('extra turn emits explicit event and keeps turn with same player', ...)` to `test/snakeGame.test.js` that asserts `diceRolled.extraTurn`, the `extraTurnGranted` event, and that `currentTurn` remains the same player.

### Testing
- Added and ran the local test invocation `node --test test/snakeGame.test.js test/snakeApi.test.js`, which attempted to execute the new regression test and existing snake tests.
- Test execution aborted in this environment due to missing dependency resolution for `mongoose` (`ERR_MODULE_NOT_FOUND` for `bot/node_modules/mongoose`), so automated tests did not complete here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c961f7d8d8832991f233deff97a3e4)