### PR TITLE
Ensure Roll CTA remains visible on immediate extra turns in Snake & Ladder

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -2166,6 +2166,10 @@ export default function SnakeAndLadder() {
       if (idx >= 0) {
         setCurrentTurn(idx);
         setDiceCount(playerDiceCounts[idx] ?? 1);
+        if (playersRef.current[idx]?.id === myAccountId) {
+          // Keep roll CTA visible for immediate extra turns.
+          setRollCooldown(0);
+        }
       }
     };
     const onStarted = () => {
@@ -2738,6 +2742,10 @@ export default function SnakeAndLadder() {
           const next = extraTurn ? currentTurn : getPreviousTurn(currentTurn);
           setCurrentTurn(next);
           setDiceCount(playerDiceCounts[next] ?? 1);
+          if (extraTurn && next === 0) {
+            // Do not delay the local extra roll button after a six/bonus.
+            setRollCooldown(0);
+          }
         }
       };
 


### PR DESCRIPTION
### Motivation
- Players who earn an immediate extra roll (for example after rolling a 6 or landing on a bonus dice cell) could see the Roll CTA disappear and be unable to trigger the follow-up roll promptly.

### Description
- Clear the local roll cooldown when the server emits a turn update back to the local player by setting `setRollCooldown(0)` in `onTurn` so the Roll CTA can appear immediately.
- When finalizing a move that grants an extra turn (six / bonus dice) in the single-player flow, clear the cooldown if the next turn remains the local player by calling `setRollCooldown(0)` so chained rolls are immediately available.
- Change applied in `webapp/src/pages/Games/SnakeAndLadder.jsx`.

### Testing
- Ran `npx eslint webapp/src/pages/Games/SnakeAndLadder.jsx` (command completed; file is ignored by project eslint config) — completed.
- Ran unit tests `npm test -- --runInBand --forceExit test/snakeGame.test.js` — test suite passed (10 tests, 1 suite).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c961f7d8d8832991f233deff97a3e4)