### PR TITLE
Fix Pool Royale replay visibility, rack spacing, and topspin follow

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1113,7 +1113,7 @@ const TABLE_FINISH_STORAGE_KEY = 'poolRoyaleTableFinish';
 const CLOTH_COLOR_STORAGE_KEY = 'poolRoyaleClothColor';
 const TABLE_BASE_STORAGE_KEY = 'poolRoyaleTableBase';
 const POCKET_LINER_STORAGE_KEY = 'poolPocketLiner';
-const SKIP_REPLAYS_STORAGE_KEY = 'poolSkipReplays';
+const SKIP_REPLAYS_STORAGE_KEY = 'poolRoyaleSkipReplays';
 const COMMENTARY_PRESET_STORAGE_KEY = 'poolRoyaleCommentaryPreset';
 const COMMENTARY_MUTE_STORAGE_KEY = 'poolRoyaleCommentaryMute';
 const DEFAULT_CUE_STROKE_STYLE = 'featherLine';
@@ -2249,7 +2249,7 @@ function generateRackPositions(ballCount, layout, ballRadius, startZ) {
   if (ballCount <= 0 || !Number.isFinite(ballRadius) || !Number.isFinite(startZ)) {
     return positions;
   }
-  const contactGap = ballRadius * 0.0022;
+  const contactGap = ballRadius * 0.018;
   const columnSpacing = ballRadius * 2 + contactGap;
   const rowSpacing = Math.sqrt(3) * ballRadius + contactGap;
   const minCenterDistance = ballRadius * 2 + contactGap;
@@ -5967,9 +5967,9 @@ const DEFAULT_SPIN_LIMITS = Object.freeze({
   maxY: 1
 });
 const MAX_TOPSPIN_INPUT = 0.8; // reduce topspin cap to match Snooker Royal feel
-const TOPSPIN_FOLLOW_TRANSFER_RATE = 0.58; // convert topspin into forward roll earlier so straight top spin does not feel stunned
-const TOPSPIN_FOLLOW_DECAY_ASSIST = 0.52; // keep natural roll-through longer before topspin fully settles
-const TOPSPIN_ROLL_SPEED_FACTOR = 1.08; // allow top spin to carry cue-ball speed forward instead of stalling into a stun look
+const TOPSPIN_FOLLOW_TRANSFER_RATE = 0.72; // stronger follow transfer so topspin produces a clearer forward roll after contact
+const TOPSPIN_FOLLOW_DECAY_ASSIST = 0.38; // decay topspin a bit slower so cue-ball keeps moving forward like real follow-through
+const TOPSPIN_ROLL_SPEED_FACTOR = 1.2; // raise natural roll target speed so top spin carries the cue-ball farther before settling
 const TOPSPIN_POWER_SOFT_CAP = 0.9;
 const clampSpinValue = (value) => clamp(value, -1, 1);
 const SPIN_CUSHION_EPS = BALL_R * 0.6;
@@ -28420,7 +28420,9 @@ const powerRef = useRef(hud.power);
           const primary = priority.find((tag) => tags.has(tag)) ?? 'default';
           const zoomOnly = recording.zoomOnly && !tags.has('long') && !tags.has('bank');
           const hadMeaningfulContact = Boolean(shotContext?.contactMade);
+          const hasReplayFrames = (recording?.frames?.length ?? 0) > 1;
           const hasReplaySignal =
+            hasReplayFrames ||
             hadObjectPot ||
             tags.size > 0 ||
             hadMeaningfulContact ||


### PR DESCRIPTION
### Motivation
- Replays for Pool Royale were being suppressed by a global/stale replay flag and replay gating could miss valid recorded shots, so replay playback needed to be restored.
- Racked balls were visually overlapping on the rack screen, so spacing needed to be increased to avoid overlaps.
- Topspin felt underpowered and the cue ball didn’t carry forward realistically, so topspin follow tuning was required.

### Description
- Use a game-scoped storage key by renaming `SKIP_REPLAYS_STORAGE_KEY` to `poolRoyaleSkipReplays` so Pool Royale replay preference is isolated to this game and not affected by a global flag (change in `webapp/src/pages/Games/PoolRoyale.jsx`).
- Relax replay eligibility by treating any recorded shot that has valid replay frames as a replay signal (`hasReplayFrames`) so playback can occur even when other tags/contacts are missing (change in `resolveReplayDecision` in `PoolRoyale.jsx`).
- Increase rack contact gap in `generateRackPositions` by changing `contactGap` from `ballRadius * 0.0022` to `ballRadius * 0.018` to remove visual overlap between racked balls (change in `PoolRoyale.jsx`).
- Tune topspin/follow constants to produce stronger and longer follow-through by updating `TOPSPIN_FOLLOW_TRANSFER_RATE`, `TOPSPIN_FOLLOW_DECAY_ASSIST`, and `TOPSPIN_ROLL_SPEED_FACTOR` in `PoolRoyale.jsx`.

### Testing
- Ran a production build with `npm --prefix webapp run build`, which completed successfully; Vite produced only non-blocking chunk/import warnings and the build artifacts were generated.
- No automated unit/test-suite runs were executed as part of this change in this session.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9615f77e48329bf08ce223b54a4f7)