### PR TITLE
Restore Pool Royale to 10:00 baseline while preserving on-cloth ball mapping

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -410,8 +410,8 @@ function clearShotCandidates (req) {
   const cue = req.state.balls.find(b => b.id === cueBallId)
   const targets = chooseTargets(req)
   const pockets = req.state.pockets
-  const maxCut = req.maxCutAngle ?? Math.PI / 4.45
-  const minView = req.minViewScore ?? 0.46
+  const maxCut = req.maxCutAngle ?? Math.PI / 4.15
+  const minView = req.minViewScore ?? 0.42
   const candidates = []
 
   for (const target of targets) {
@@ -434,7 +434,7 @@ function clearShotCandidates (req) {
 
       // check paths from cue->ghost and target->pocket are unobstructed
       if (
-        pathBlocked(cue, ghost, req.state.balls, [cueBallId, target.id], r, 1.14) ||
+        pathBlocked(cue, ghost, req.state.balls, [cueBallId, target.id], r, 1.1) ||
         pathBlocked(target, entry, req.state.balls, [cueBallId, target.id], r) ||
         req.state.balls.some(
           b => b.id !== cueBallId && b.id !== target.id && !b.pocketed && dist(b, entry) < r * 1.1
@@ -692,15 +692,15 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
   ) {
     return null
   }
-  const laneClearance = clearanceMargin(cue, target, balls, [cueBallId, target.id], r, 1.4)
-  if (laneClearance < 0.56) {
+  const laneClearance = clearanceMargin(cue, target, balls, [cueBallId, target.id], r, 1.3)
+  if (laneClearance < 0.5) {
     return null
   }
   if (scratchRiskAlongLine(cue, ghost, req.state.pockets || [], r)) {
     return null
   }
   if (
-    pathBlocked(cue, ghost, balls, [cueBallId, target.id], r, 1.14) ||
+    pathBlocked(cue, ghost, balls, [cueBallId, target.id], r, 1.1) ||
     pathBlocked(target, entry, balls, [cueBallId, target.id], r) ||
     balls.some(b => b.id !== cueBallId && b.id !== target.id && !b.pocketed && dist(b, entry) < r * 1.1)
   ) {
@@ -754,7 +754,7 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
     Math.max(0, spin.back || 0) * 0.12 +
     Math.max(0, spin.top || 0) * 0.04
   const clearanceScore = Math.max(0, Math.min((laneClearance - 0.5) / 0.7, 1))
-  if (strict && (centerAlign < 0.56 || pocketOpen < 0.34)) {
+  if (strict && (centerAlign < 0.5 || pocketOpen < 0.3)) {
     return null
   }
   const lookaheadDepth = Number.isFinite(options.lookaheadDepth)
@@ -767,14 +767,14 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
     0,
     Math.min(
       1,
-      0.44 * potChance +
-        0.17 * pocketOpen +
-        0.14 * centerAlign +
-        0.07 * nextScore +
+      0.41 * potChance +
+        0.15 * pocketOpen +
+        0.13 * centerAlign +
+        0.06 * nextScore +
         0.03 * nearHole +
-        0.08 * runoutPotential +
-        0.14 * clearanceScore -
-        0.23 * risk -
+        0.14 * runoutPotential +
+        0.12 * clearanceScore -
+        0.21 * risk -
         (scratchAfterImpact ? 0.2 : 0) -
         spinPenalty -
         difficultyPenalty

--- a/test/poolRoyaleSpinController.test.js
+++ b/test/poolRoyaleSpinController.test.js
@@ -6,11 +6,10 @@ const getSigns = (vec) => ({
 });
 
 describe('Pool Royale spin controller mapping', () => {
-  it('maps the center to a slight default topspin bias', () => {
+  it('maps the center to true stun (no spin)', () => {
     const center = mapSpinForPhysics({ x: 0, y: 0 });
     expect(Math.abs(center.x)).toBe(0);
-    expect(center.y).toBeGreaterThan(0);
-    expect(center.y).toBeLessThan(0.25);
+    expect(Math.abs(center.y)).toBe(0);
   });
 
   it('keeps left/right spin directions aligned with the table axes', () => {

--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -296,7 +296,8 @@ const TABLE_FINISH_THUMBNAILS = Object.freeze({
   oakVeneer01: polyHavenThumb('oak_veneer_01'),
   woodTable001: polyHavenThumb('wood_table_001'),
   darkWood: polyHavenThumb('dark_wood'),
-  rosewoodVeneer01: polyHavenThumb('rosewood_veneer_01')
+  rosewoodVeneer01: polyHavenThumb('rosewood_veneer_01'),
+  chessPieceBlack: swatchThumbnail(['#050505', '#161616', '#3b3b3b'])
 });
 
 const POCKET_LINER_THUMBNAILS = Object.freeze({
@@ -394,7 +395,8 @@ export const POOL_ROYALE_OPTION_LABELS = Object.freeze({
     oakVeneer01: 'Oak Veneer 01',
     woodTable001: 'Wood Table 001',
     darkWood: 'Dark Wood',
-    rosewoodVeneer01: 'Rosewood Veneer 01'
+    rosewoodVeneer01: 'Rosewood Veneer 01',
+    chessPieceBlack: 'Chess Piece Black'
   }),
   chromeColor: Object.freeze({
     chrome: 'Chrome',
@@ -481,6 +483,15 @@ export const POOL_ROYALE_STORE_ITEMS = [
     price: 1020,
     description: 'Rosewood veneer rails with rich, reddish undertones.',
     thumbnail: TABLE_FINISH_THUMBNAILS.rosewoodVeneer01
+  },
+  {
+    id: 'finish-chessPieceBlack',
+    type: 'tableFinish',
+    optionId: 'chessPieceBlack',
+    name: 'Chess Piece Black Finish',
+    price: 1060,
+    description: 'Deep black finish using the same GLTF texture profile as Chess Battle Royale pieces.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.chessPieceBlack
   },
   {
     id: 'chrome-chrome',

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -800,7 +800,7 @@ const CHROME_CORNER_POCKET_CUT_SCALE = 1.035; // open only the corner chrome rou
 const CHROME_SIDE_POCKET_CUT_SCALE = 1.02; // open middle-pocket chrome rounded cuts a touch more so the arc reads larger on portrait views
 const CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE = 0.04; // reduce inward pull so middle pocket chrome cuts sit a bit farther out
 const WOOD_RAIL_POCKET_RELIEF_SCALE = 1; // match the wooden rail pocket relief to the jaw outside diameter
-const WOOD_CORNER_RELIEF_INWARD_SCALE = 0.966; // keep only the wooden corner rounded cut slightly smaller than the jaw outside radius
+const WOOD_CORNER_RELIEF_INWARD_SCALE = 1; // keep the wooden corner rounded cut radius identical to the pocket jaw outside arc
 const WOOD_CORNER_RAIL_POCKET_RELIEF_SCALE =
   (1 / WOOD_RAIL_POCKET_RELIEF_SCALE) * WOOD_CORNER_RELIEF_INWARD_SCALE; // corner wood arches now sit a hair inside the chrome radius so the rounded cut creeps inward
 const WOOD_CORNER_POCKET_CUT_CENTER_OUTSET_SCALE = -0.018; // push only the wooden corner rounded cut outward a touch without moving side-pocket cuts
@@ -1113,7 +1113,7 @@ const TABLE_FINISH_STORAGE_KEY = 'poolRoyaleTableFinish';
 const CLOTH_COLOR_STORAGE_KEY = 'poolRoyaleClothColor';
 const TABLE_BASE_STORAGE_KEY = 'poolRoyaleTableBase';
 const POCKET_LINER_STORAGE_KEY = 'poolPocketLiner';
-const SKIP_REPLAYS_STORAGE_KEY = 'poolRoyaleSkipReplays';
+const SKIP_REPLAYS_STORAGE_KEY = 'poolSkipReplays';
 const COMMENTARY_PRESET_STORAGE_KEY = 'poolRoyaleCommentaryPreset';
 const COMMENTARY_MUTE_STORAGE_KEY = 'poolRoyaleCommentaryMute';
 const DEFAULT_CUE_STROKE_STYLE = 'featherLine';
@@ -1365,7 +1365,7 @@ const ENABLE_BALL_FLOOR_SHADOWS = true;
 const ENABLE_CUE_CLOTH_SHADOW = true;
 const ENABLE_TABLE_FLOOR_SHADOW = false;
 const BALL_SHADOW_RADIUS_MULTIPLIER = 1.08;
-const BALL_SHADOW_OPACITY = 0.25;
+const BALL_SHADOW_OPACITY = 0.3;
 const BALL_SHADOW_LIFT = BALL_R * 0.02;
 const CUE_SHADOW_OPACITY = 0.18;
 const CUE_SHADOW_WIDTH_RATIO = 0.62;
@@ -1463,9 +1463,31 @@ const BALL_SHADOW_GEOMETRY = ENABLE_BALL_FLOOR_SHADOWS
   ? new THREE.CircleGeometry(BALL_R * BALL_SHADOW_RADIUS_MULTIPLIER, 32)
   : null;
 if (BALL_SHADOW_GEOMETRY) BALL_SHADOW_GEOMETRY.rotateX(-Math.PI / 2);
+const BALL_SHADOW_TEXTURE = (() => {
+  if (!ENABLE_BALL_FLOOR_SHADOWS || typeof document === 'undefined') return null;
+  const size = 256;
+  const canvas = document.createElement('canvas');
+  canvas.width = size;
+  canvas.height = size;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return null;
+  const r = size / 2;
+  const g = ctx.createRadialGradient(r, r, r * 0.08, r, r, r);
+  g.addColorStop(0, 'rgba(0,0,0,0.9)');
+  g.addColorStop(0.38, 'rgba(0,0,0,0.58)');
+  g.addColorStop(0.72, 'rgba(0,0,0,0.22)');
+  g.addColorStop(1, 'rgba(0,0,0,0)');
+  ctx.fillStyle = g;
+  ctx.fillRect(0, 0, size, size);
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.colorSpace = THREE.SRGBColorSpace;
+  texture.needsUpdate = true;
+  return texture;
+})();
 const BALL_SHADOW_MATERIAL = ENABLE_BALL_FLOOR_SHADOWS
   ? new THREE.MeshBasicMaterial({
       color: 0x000000,
+      map: BALL_SHADOW_TEXTURE,
       transparent: true,
       opacity: BALL_SHADOW_OPACITY,
       depthWrite: false,
@@ -1935,7 +1957,7 @@ let SIDE_CUSHION_CUT_ANGLE = DEFAULT_SIDE_CUSHION_CUT_ANGLE;
 let SIDE_POCKET_PHYSICS_CUT_ANGLE = DEFAULT_SIDE_POCKET_PHYSICS_CUT_ANGLE;
 const CUSHION_BACK_TRIM = 0.8; // trim 20% off the cushion back that meets the rails
 const CUSHION_FACE_INSET_LONG = SIDE_RAIL_INNER_THICKNESS * 0.58; // pull long-rail cushions farther inward toward the table center
-const CUSHION_FACE_INSET_SHORT = SIDE_RAIL_INNER_THICKNESS * 0.42; // push short-rail cushions a touch outward from table centre
+const CUSHION_FACE_INSET_SHORT = SIDE_RAIL_INNER_THICKNESS * 0.46; // pull short-rail cushions slightly inward to match
 
 // shared UI reduction factor so overlays and controls shrink alongside the table
 
@@ -3037,6 +3059,15 @@ const TABLE_FINISHES = Object.freeze({
     trim: 0x9b5a44,
     woodTextureId: 'rosewood_veneer_01',
     woodRepeatScale: 1
+  }),
+  chessPieceBlack: createStandardWoodFinish({
+    id: 'chessPieceBlack',
+    label: 'Chess Piece Black',
+    rail: 0x0b0b0b,
+    base: 0x050505,
+    trim: 0x2a2a2a,
+    woodTextureId: 'dark_wood',
+    woodRepeatScale: 1
   })
 });
 
@@ -3046,7 +3077,8 @@ const TABLE_FINISH_OPTIONS = Object.freeze(
     TABLE_FINISHES.oakVeneer01,
     TABLE_FINISHES.woodTable001,
     TABLE_FINISHES.darkWood,
-    TABLE_FINISHES.rosewoodVeneer01
+    TABLE_FINISHES.rosewoodVeneer01,
+    TABLE_FINISHES.chessPieceBlack
   ].filter(Boolean)
 );
 
@@ -5623,8 +5655,8 @@ const REPLAY_BANNER_VARIANTS = {
 };
 const REPLAY_TRAIL_HEIGHT = BALL_CENTER_Y + BALL_R * 0.3;
 const REPLAY_TRAIL_COLOR = 0xffffff;
-const REPLAY_CUE_RETURN_WINDOW_MS = 260;
-const REPLAY_CUE_START_HOLD_MS = 0;
+const REPLAY_CUE_RETURN_WINDOW_MS = 480;
+const REPLAY_CUE_START_HOLD_MS = 110;
 const RAIL_NEAR_BUFFER = BALL_R * 3.5;
 const SHORT_SHOT_CAMERA_DISTANCE = BALL_R * 12; // keep camera in standing view for close shots
 const SHORT_RAIL_POCKET_TRIGGER =
@@ -5660,14 +5692,14 @@ const PLAYER_CUE_PULLBACK_DURATION_MS = 620;
 const PLAYER_CUE_RELEASE_DURATION_MS = 1320;
 const PLAYER_CUE_IMPACT_HOLD_MS = 540;
 const MIN_PULLBACK_GAP = BALL_R * 0.75;
-const REPLAY_CUE_STROKE_SLOWDOWN = 1.6;
-const REPLAY_CUE_STROKE_LEAD_IN_MS = 0; // match Snooker Royal replay timing window
-const REPLAY_CUE_RELEASE_VISIBILITY_MULTIPLIER = 1; // keep release cadence identical to Snooker Royal replay stroke
+const REPLAY_CUE_STROKE_SLOWDOWN = 2.25;
+const REPLAY_CUE_STROKE_LEAD_IN_MS = 240; // begin replay in the charge phase so pullback + strike are both clearly visible
+const REPLAY_CUE_RELEASE_VISIBILITY_MULTIPLIER = 1.42; // stretch the forward push more so cue impact is readable in replay
 const BREAK_DICE_ROLL_DELAY_MS = 560;
 const BREAK_DICE_RESULT_PAUSE_MS = 720;
 const BREAK_DICE_ROLL_SOUND_URL = '/assets/sounds/u_qpfzpydtro-dice-142528.mp3';
-const REPLAY_CUE_MIN_PULLBACK_MS = 0; // defer to recorded stroke durations like Snooker Royal
-const REPLAY_CUE_MIN_RELEASE_MS = 0; // defer to recorded stroke durations like Snooker Royal
+const REPLAY_CUE_MIN_PULLBACK_MS = 360; // keep replay wind-up visible without consuming the whole replay window
+const REPLAY_CUE_MIN_RELEASE_MS = 620; // keep forward cue strike visible for a clear cue-ball hit
 const CUE_STROKE_POST_HIT_CAMERA_HOLD_MS = 420;
 // Keep the live stroke timing aligned with the reference cue motion:
 // quick push forward and a short hold before snapping back to idle.
@@ -5967,9 +5999,9 @@ const DEFAULT_SPIN_LIMITS = Object.freeze({
   maxY: 1
 });
 const MAX_TOPSPIN_INPUT = 0.8; // reduce topspin cap to match Snooker Royal feel
-const TOPSPIN_FOLLOW_TRANSFER_RATE = 0.72; // stronger follow transfer so topspin produces a clearer forward roll after contact
-const TOPSPIN_FOLLOW_DECAY_ASSIST = 0.38; // decay topspin a bit slower so cue-ball keeps moving forward like real follow-through
-const TOPSPIN_ROLL_SPEED_FACTOR = 1.2; // raise natural roll target speed so top spin carries the cue-ball farther before settling
+const TOPSPIN_FOLLOW_TRANSFER_RATE = 0.42; // convert topspin into forward roll sooner so natural follow builds progressively instead of feeling delayed
+const TOPSPIN_FOLLOW_DECAY_ASSIST = 0.74; // keep some residual roll-through after impact before spin naturally settles
+const TOPSPIN_ROLL_SPEED_FACTOR = 0.94; // let topspin carry cue-ball speed farther before settling at natural roll
 const TOPSPIN_POWER_SOFT_CAP = 0.9;
 const clampSpinValue = (value) => clamp(value, -1, 1);
 const SPIN_CUSHION_EPS = BALL_R * 0.6;
@@ -19589,14 +19621,6 @@ const powerRef = useRef(hud.power);
           focusOverride = null,
           minTargetY = null
         } = {}) => {
-          const railCamera = resolveRailOverheadReplayCamera({
-            focusOverride,
-            minTargetY,
-            preferredRail: railOverheadSideRef.current
-          });
-          if (railCamera?.position && railCamera?.target) {
-            return railCamera;
-          }
           const systemVariant =
             broadcastSystemRef.current?.topViewVariant ??
             activeBroadcastSystem?.topViewVariant ??
@@ -21358,23 +21382,21 @@ const powerRef = useRef(hud.power);
         const captureReplayCameraSnapshot = () => {
           const scale = Number.isFinite(worldScaleFactor) ? worldScaleFactor : WORLD_SCALE;
           const minTargetY = Math.max(baseSurfaceWorldY, BALL_CENTER_Y * scale);
+          const activeCamera = activeRenderCameraRef.current ?? camera;
+          const fovSnapshot = Number.isFinite(activeCamera?.fov)
+            ? activeCamera.fov
+            : camera.fov;
           const targetSnapshot = lastCameraTargetRef.current
             ? lastCameraTargetRef.current.clone()
             : broadcastCamerasRef.current?.defaultFocusWorld?.clone?.() ?? null;
-          const railSnapshot = resolveRailOverheadReplayCamera({
-            focusOverride: targetSnapshot,
-            minTargetY,
-            preferredRail: railOverheadSideRef.current
-          });
           const cameraMode =
             pocketCameraStateRef.current && activeShotView?.mode === 'pocket'
               ? `pocket:${activeShotView?.anchorId ?? activeShotView?.pocketId ?? 'active'}`
               : 'broadcast';
-          const resolvedPosition = railSnapshot?.position?.clone?.() ?? null;
-          const resolvedTarget = railSnapshot?.target?.clone?.() ?? targetSnapshot;
-          const resolvedFov = Number.isFinite(railSnapshot?.fov)
-            ? railSnapshot.fov
-            : camera.fov;
+          const resolvedPosition = activeCamera?.position?.clone?.() ?? null;
+          const resolvedTarget = targetSnapshot;
+          const resolvedFov = fovSnapshot;
+          const resolvedMinTargetY = minTargetY;
           if (!resolvedPosition && !resolvedTarget) return null;
           const snapshot = {
             position: resolvedPosition,
@@ -21382,8 +21404,8 @@ const powerRef = useRef(hud.power);
             fov: resolvedFov,
             key: cameraMode
           };
-          if (Number.isFinite(minTargetY)) {
-            snapshot.minTargetY = minTargetY;
+          if (Number.isFinite(resolvedMinTargetY)) {
+            snapshot.minTargetY = resolvedMinTargetY;
           }
           return snapshot;
         };
@@ -25459,13 +25481,12 @@ const powerRef = useRef(hud.power);
               : 1;
           const hasCueTargetDirectionSplit = cueVsTargetAlignment < 0.45;
           const forceImmediateRailOverheadView =
-            isBreakShot ||
             Boolean(shotPrediction?.railNormal) ||
             (isMiddlePocketIntent && hasCueTargetDirectionSplit);
           const allowRailOverheadActionView =
-            isBreakShot ||
-            (!isShortShot &&
-              (!isLongShot || predictedCueSpeed <= LONG_SHOT_SPEED_SWITCH_THRESHOLD));
+            !isBreakShot &&
+            !isShortShot &&
+            (!isLongShot || predictedCueSpeed <= LONG_SHOT_SPEED_SWITCH_THRESHOLD);
           const allowLongShotCameraSwitch =
             (forceImmediateRailOverheadView || !suppressOpeningShotViews) &&
             !RAIL_OVERHEAD_AND_POCKET_CAMERA_ONLY &&
@@ -25514,7 +25535,6 @@ const powerRef = useRef(hud.power);
               )
             : null;
           const earlyPocketView =
-            !isBreakShot &&
             !suppressPocketCameras &&
             shotPrediction.ballId &&
             followView
@@ -25587,7 +25607,7 @@ const powerRef = useRef(hud.power);
             const sph = sphRef.current;
             const bounds = cameraBoundsRef.current;
             const standingView = bounds?.standing;
-            if (standingView) {
+            if (standingView && !isBreakShot) {
               sph.radius = clampOrbitRadius(standingView.radius);
               sph.phi = THREE.MathUtils.clamp(
                 standingView.phi,
@@ -28409,7 +28429,7 @@ const powerRef = useRef(hud.power);
           pottedBalls,
           shotContext
         }) => {
-          if (!recording) return null;
+          if (!recording || !hadObjectPot) return null;
           const tags = new Set(recording.replayTags ?? []);
           if (hadObjectPot) tags.add('pot');
           const potCount = pottedBalls.filter((entry) => entry.id !== 'cue').length;
@@ -28419,16 +28439,8 @@ const powerRef = useRef(hud.power);
           const priority = ['multi', 'bank', 'long', 'power', 'spin'];
           const primary = priority.find((tag) => tags.has(tag)) ?? 'default';
           const zoomOnly = recording.zoomOnly && !tags.has('long') && !tags.has('bank');
-          const hadMeaningfulContact = Boolean(shotContext?.contactMade);
-          const hasReplayFrames = (recording?.frames?.length ?? 0) > 1;
-          const hasReplaySignal =
-            hasReplayFrames ||
-            hadObjectPot ||
-            tags.size > 0 ||
-            hadMeaningfulContact ||
-            Boolean(recording?.replayFoul);
           return {
-            shouldReplay: hasReplaySignal,
+            shouldReplay: hadObjectPot || tags.size > 0,
             banner: selectReplayBanner(primary),
             zoomOnly,
             tags: Array.from(tags),
@@ -28944,9 +28956,8 @@ const powerRef = useRef(hud.power);
           pocketSwitchIntentRef.current = null;
           lastPocketBallRef.current = null;
           updatePocketCameraState(false);
-          if (shouldStartReplay) {
+          if (shouldStartReplay && postShotSnapshot) {
             const recordingForReplay = shotRecording;
-            const replayPostState = postShotSnapshot || captureBallSnapshot();
             const launchReplay = () => {
               replayBannerTimeoutRef.current = null;
               setReplayBanner(null);
@@ -28954,7 +28965,7 @@ const powerRef = useRef(hud.power);
               const beginReplay = () => {
                 shotRecording = recordingForReplay;
                 if (recordingForReplay) {
-                  startShotReplay(replayPostState);
+                  startShotReplay(postShotSnapshot);
                 } else {
                   shotReplayRef.current = null;
                 }

--- a/webapp/src/pages/Games/poolRoyaleSpinUtils.js
+++ b/webapp/src/pages/Games/poolRoyaleSpinUtils.js
@@ -11,7 +11,6 @@ export const SPIN_LEVEL2_MAG = SPIN_RING2_RADIUS;
 export const SPIN_LEVEL3_MAG = SPIN_RING3_RADIUS;
 export const STRAIGHT_SPIN_DEADZONE = 0.02;
 export const SPIN_RESPONSE_EXPONENT = 1.45;
-export const SPIN_CENTER_TOPSPIN_BIAS = 0.16;
 export const SPIN_DIRECTIONS = [
   {
     id: 'stun',
@@ -201,9 +200,6 @@ export const mapSpinForPhysics = (spin, options = {}) => {
     y: clamp(spin?.y ?? 0, -1, 1)
   };
   const quantized = normalizeSpinInput(adjusted);
-  if (Math.hypot(quantized.x, quantized.y) <= 1e-6) {
-    return { x: 0, y: SPIN_CENTER_TOPSPIN_BIAS };
-  }
   const { cameraRight, cameraUp, cueForward } = options;
   return mapUiOffsetToCueFrame(
     -quantized.x,


### PR DESCRIPTION
### Motivation
- Bring the Pool Royale gameplay code/configuration back to the earlier (≈10:00) baseline to restore intended replay, rack, and AI behavior while keeping the current visual/physical ball placement on the cloth unchanged.
- Limit scope to Pool Royale subsystems only so unrelated parts of the repo remain untouched.

### Description
- Restored Pool Royale logic and tuning across the gameplay, AI and UI files while preserving the current ball-on-cloth mapping values and rack placement adjustments; affected files include `webapp/src/pages/Games/PoolRoyale.jsx`, `lib/poolAi.js`, `webapp/src/pages/Games/poolRoyaleSpinUtils.js`, `webapp/src/config/poolRoyaleInventoryConfig.js`, and `test/poolRoyaleSpinController.test.js`.
- Kept the on-cloth mapping/tolerance and rack de-overlap logic: `BALL_CENTER_LIFT`, `BALL_CONTACT_EPS`, `BALL_COLLISION_SLOP` and the improved `generateRackPositions` de-overlap/clamping remain as in the current mapping so ball positions on the cloth are preserved.
- Restored tuned AI/shot-evaluation parameters and replay/camera timing to the baseline values in `lib/poolAi.js` and `PoolRoyale.jsx`, and re-aligned spin utilities by removing the center topspin bias from `poolRoyaleSpinUtils.js` so spin mapping matches baseline behavior.
- Reinstated inventory/table-finish baseline options and thumbnails and added the `chessPieceBlack` finish entries in `poolRoyaleInventoryConfig.js` to match the earlier variant list.

### Testing
- Ran the Pool Royale spin controller unit test: `npm test -- --runInBand test/poolRoyaleSpinController.test.js` and it passed.
- Test run result: 1 test suite passed, 7 tests passed (no failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c97c9be3748329826e4190a8a6b271)