### PR TITLE
snake-ladder: retain turn after rolling 6

### DIFF
--- a/examples/snake-ladder/gameLogic.js
+++ b/examples/snake-ladder/gameLogic.js
@@ -75,7 +75,7 @@ export class Game {
     current.position = newPos;
     if (newPos === BOARD_SIZE) {
       this.winner = current.id;
-    } else {
+    } else if (value !== 6) {
       this.currentPlayer = (this.currentPlayer + 1) % this.players.length;
     }
   }


### PR DESCRIPTION
### Motivation
- Ensure a player who rolls a `6` keeps their turn so the Roll Dice button remains available and gameplay follows standard Snake & Ladder rules.

### Description
- Updated `examples/snake-ladder/gameLogic.js` so `rollDice` only advances `currentPlayer` when the rolled `value !== 6`, while preserving the existing position, snake/ladder resolution, and `winner` check.

### Testing
- Ran targeted Node.js checks by mocking `Math.random` to force a `6` and a `1` with `node --input-type=module -e "..."` and verified outputs (`6 0` for a six keeping the same player; `1 1` for a non-six advancing the player), and both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca0394817c8329a0850db74f6c447f)