### PR TITLE
Fix Snake & Ladder roll button visibility for multiplayer extra rolls

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1268,6 +1268,7 @@ export default function SnakeAndLadder() {
   const [rollingIndex, setRollingIndex] = useState(null);
   const [playerRollTrigger, setPlayerRollTrigger] = useState(0);
   const [playerAutoRolling, setPlayerAutoRolling] = useState(false);
+  const [pendingExtraRoll, setPendingExtraRoll] = useState(false);
   const [timeLeft, setTimeLeft] = useState(TURN_TIME);
   const [aiAvatars, setAiAvatars] = useState([]);
   const [burning, setBurning] = useState([]); // indices of tokens burning
@@ -2166,6 +2167,9 @@ export default function SnakeAndLadder() {
       if (idx >= 0) {
         setCurrentTurn(idx);
         setDiceCount(playerDiceCounts[idx] ?? 1);
+        if (playersRef.current[idx]?.id !== myAccountId) {
+          setPendingExtraRoll(false);
+        }
         if (playersRef.current[idx]?.id === myAccountId) {
           // Keep roll CTA visible for immediate extra turns.
           setRollCooldown(0);
@@ -3153,7 +3157,7 @@ export default function SnakeAndLadder() {
   const myPlayerIndex = computedIndex >= 0 ? computedIndex : null;
   const canRoll =
     myPlayerIndex !== null &&
-    currentTurn === myPlayerIndex &&
+    (currentTurn === myPlayerIndex || (isMultiplayer && pendingExtraRoll)) &&
     !moving &&
     rollCooldown === 0 &&
     !gameOver &&
@@ -4000,7 +4004,7 @@ export default function SnakeAndLadder() {
       )}
       {isMultiplayer && myPlayerIndex !== null && (
         <div className="sr-only" aria-hidden="true">
-          {currentTurn === myPlayerIndex && !moving ? (
+          {(currentTurn === myPlayerIndex || pendingExtraRoll) && !moving ? (
             <DiceRoller
               clickable
               showButton={false}
@@ -4009,6 +4013,7 @@ export default function SnakeAndLadder() {
               emitRollEvent
               divRef={diceRollerDivRef}
               onRollStart={() => {
+                setPendingExtraRoll(false);
                 diceRollIdRef.current += 1;
                 startDiceBoardAnimation({
                   id: diceRollIdRef.current,
@@ -4018,6 +4023,10 @@ export default function SnakeAndLadder() {
                 });
               }}
               onRollEnd={(vals) => {
+                const rolledSix = Array.isArray(vals)
+                  ? vals.some((v) => Number(v) === 6)
+                  : Number(vals) === 6;
+                setPendingExtraRoll(rolledSix);
                 startDiceBoardAnimation({
                   id: diceRollIdRef.current,
                   phase: 'end',


### PR DESCRIPTION
### Motivation
- Players who roll a 6 (entering the board) lost the ability to immediately take the extra roll because the roll CTA could disappear when server turn sync lagged, breaking expected game flow.

### Description
- Add a `pendingExtraRoll` state flag to track that the local player has an outstanding bonus roll after a six.
- Allow the local player to `canRoll` when `pendingExtraRoll` is true by updating the roll eligibility check.
- Clear `pendingExtraRoll` when the active turn moves away from the local player so the CTA does not remain visible incorrectly. 
- Wire `DiceRoller` multiplayer callbacks to clear the flag on `onRollStart` and set it on `onRollEnd` when a six was rolled.

### Testing
- Ran `npm run build` which invokes `tsc -p tsconfig.build.json` and completed successfully. 
- Ran `npx eslint webapp/src/pages/Games/SnakeAndLadder.jsx` and `npx eslint --no-ignore webapp/src/pages/Games/SnakeAndLadder.jsx` which reported an ESLint ignore warning for the file in this environment but no code errors.
- Verified the app build step completed and no TypeScript errors were produced during the build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca0394817c8329a0850db74f6c447f)