### PR TITLE
Restore Pool Royale replay & broadcast defaults via one-time migration

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1114,6 +1114,7 @@ const CLOTH_COLOR_STORAGE_KEY = 'poolRoyaleClothColor';
 const TABLE_BASE_STORAGE_KEY = 'poolRoyaleTableBase';
 const POCKET_LINER_STORAGE_KEY = 'poolPocketLiner';
 const SKIP_REPLAYS_STORAGE_KEY = 'poolSkipReplays';
+const BROADCAST_REPLAY_METHOD_MIGRATION_KEY = 'poolBroadcastReplayMethodMigrationV20260330';
 const COMMENTARY_PRESET_STORAGE_KEY = 'poolRoyaleCommentaryPreset';
 const COMMENTARY_MUTE_STORAGE_KEY = 'poolRoyaleCommentaryMute';
 const DEFAULT_CUE_STROKE_STYLE = 'featherLine';
@@ -12794,6 +12795,16 @@ function PoolRoyaleGame({
     () => resolveBroadcastSystem(broadcastSystemId),
     [broadcastSystemId]
   );
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const migrationApplied = window.localStorage.getItem(BROADCAST_REPLAY_METHOD_MIGRATION_KEY);
+    if (migrationApplied === '1') return;
+    setSkipAllReplays(false);
+    setBroadcastSystemId(DEFAULT_BROADCAST_SYSTEM_ID);
+    window.localStorage.setItem(SKIP_REPLAYS_STORAGE_KEY, '0');
+    window.localStorage.setItem(BROADCAST_SYSTEM_STORAGE_KEY, DEFAULT_BROADCAST_SYSTEM_ID);
+    window.localStorage.setItem(BROADCAST_REPLAY_METHOD_MIGRATION_KEY, '1');
+  }, []);
   const activeCommentaryPreset = useMemo(
     () =>
       POOL_ROYALE_COMMENTARY_PRESETS.find((preset) => preset.id === commentaryPresetId) ??


### PR DESCRIPTION
### Motivation
- Some clients had local replay/broadcast preferences that diverged from the intended morning baseline, causing replays and broadcast technique to behave differently than expected; a targeted migration is needed to restore the baseline without touching other game systems.

### Description
- Add `BROADCAST_REPLAY_METHOD_MIGRATION_KEY` and a one-time `useEffect` that runs on first client load to clear `skipAllReplays` (set to `false`) and reset `broadcastSystemId` to `DEFAULT_BROADCAST_SYSTEM_ID`, syncing those values to `localStorage` using `SKIP_REPLAYS_STORAGE_KEY` and `BROADCAST_SYSTEM_STORAGE_KEY`.
- Persist the migration marker (`poolBroadcastReplayMethodMigrationV20260330`) so the reset executes only once per client profile.

### Testing
- Ran `npm test -- poolRoyaleCueStrokeTimeline.test.js`, which passed (1 suite, 4 tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca02a68bcc83299098e3e8786f7e8e)