### PR TITLE
Domino Battle Royal: adjust graphics tiers to 60→4K, 90→6K, 120→8K, 144→8K

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -25,39 +25,39 @@ const FRAME_RATE_OPTIONS = Object.freeze([
   },
   {
     id: 'fhd60',
-    label: 'Full HD (60 Hz)',
+    label: '4K (60 Hz)',
     fps: 60,
     renderScale: 1,
     pixelRatioCap: 1,
-    resolution: 'Full HD render • DPR 1.0 cap',
-    description: 'Full HD baseline profile for 60 Hz devices.'
+    resolution: '4K assets • optimized DPR cap',
+    description: '4K profile for 60 Hz displays.'
   },
   {
     id: 'qhd90',
-    label: '2K (90 Hz)',
+    label: '6K (90 Hz)',
     fps: 90,
     renderScale: 1,
     pixelRatioCap: 1.5,
-    resolution: '2K render • DPR 1.5 cap',
-    description: '2K profile for 90 Hz displays.'
+    resolution: '6K assets • optimized DPR cap',
+    description: '6K profile for 90 Hz displays.'
   },
   {
     id: 'uhd120',
-    label: '4K (120 Hz)',
+    label: '8K (120 Hz)',
     fps: 120,
     renderScale: 1,
     pixelRatioCap: 2,
-    resolution: '4K render • DPR 2.0 cap',
-    description: '4K profile for 120 Hz displays and flagship hardware.'
+    resolution: '8K assets • optimized DPR cap',
+    description: '8K profile for 120 Hz displays and flagship hardware.'
   },
   {
     id: 'ultra144',
-    label: 'Ultra 144 (desktop)',
+    label: '8K (144 Hz)',
     fps: 144,
     renderScale: 1,
     pixelRatioCap: 2,
-    resolution: '4K render • DPR 2.0 cap',
-    description: 'Desktop 144 Hz profile with 4K-quality domino rendering.'
+    resolution: '8K assets • optimized DPR cap',
+    description: '8K profile for 144 Hz displays.'
   }
 ]);
 const FRAME_RATE_OPTIONS_BY_ID = Object.freeze(
@@ -92,18 +92,26 @@ const MURLAN_3D_ASSET_RESOLUTION = Object.freeze({
 
 const FRAME_RATE_TEXTURE_SIZE_MAP = Object.freeze({
   hd50: 1024,
-  fhd60: 2048,
-  qhd90: 3072,
-  uhd120: 4096,
-  ultra144: 4096
+  fhd60: 4096,
+  qhd90: 6144,
+  uhd120: 8192,
+  ultra144: 8192
 });
 
 const DOMINO_TEXTURE_SIZE_MAP = Object.freeze({
   hd50: 2048,
-  fhd60: 2048,
-  qhd90: 3072,
-  uhd120: 4096,
-  ultra144: 4096
+  fhd60: 4096,
+  qhd90: 6144,
+  uhd120: 8192,
+  ultra144: 8192
+});
+
+const AVATAR_TEXTURE_SIZE_MAP = Object.freeze({
+  hd50: 512,
+  fhd60: 1024,
+  qhd90: 1536,
+  uhd120: 2048,
+  ultra144: 2048
 });
 
 function getAdaptiveTextureSize(baseSize = 2048) {
@@ -111,7 +119,7 @@ function getAdaptiveTextureSize(baseSize = 2048) {
     FRAME_RATE_TEXTURE_SIZE_MAP[frameRateId] ??
     FRAME_RATE_TEXTURE_SIZE_MAP[DEFAULT_FRAME_RATE_ID] ??
     baseSize;
-  return Math.max(768, Math.min(4096, mappedSize));
+  return Math.max(768, Math.min(8192, mappedSize));
 }
 
 function getAdaptiveDominoTextureSize(baseSize = 4096) {
@@ -127,7 +135,15 @@ function getAdaptiveDominoTextureSize(baseSize = 4096) {
     mappedByFps ??
     DOMINO_TEXTURE_SIZE_MAP[DEFAULT_FRAME_RATE_ID] ??
     baseSize;
-  return Math.max(768, Math.min(4096, mappedSize));
+  return Math.max(768, Math.min(8192, mappedSize));
+}
+
+function getAdaptiveAvatarTextureSize(baseSize = 512) {
+  const mappedSize =
+    AVATAR_TEXTURE_SIZE_MAP[frameRateId] ??
+    AVATAR_TEXTURE_SIZE_MAP[DEFAULT_FRAME_RATE_ID] ??
+    baseSize;
+  return Math.max(256, Math.min(2048, mappedSize));
 }
 
 function resolveTelegramPixelRatioCap(qualityId = DEFAULT_FRAME_RATE_ID) {
@@ -4413,7 +4429,13 @@ function getUnlockedOptions(key, inventory = dominoInventory) {
   );
 }
 
-const HDRI_RESOLUTION_ORDER = Object.freeze(['1k', '2k']);
+const HDRI_RESOLUTION_ORDER = Object.freeze([
+  '1k',
+  '2k',
+  '4k',
+  '8k',
+  '16k'
+]);
 const isTelegramWebView = IS_TELEGRAM_RUNTIME;
 const isMobileDevice = /Android|iPhone|iPad|iPod|Mobile/i.test(
   navigator.userAgent || ''
@@ -4427,9 +4449,22 @@ const isLowProfileDevice =
   isTelegramWebView || isMobileDevice || isLowMemoryDevice || isLowCoreDevice;
 const MAX_HDRI_CACHE_SIZE = prefersUhd ? 4 : isLowProfileDevice ? 1 : 2;
 function resolveHdriResolutionOrder() {
-  if (prefersUhd) return ['2k', '1k'];
-  if (isLowProfileDevice) return ['1k'];
-  return ['2k', '1k'];
+  switch (frameRateId) {
+    case 'ultra144':
+    case 'uhd120':
+      return ['8k', '4k', '2k', '1k'];
+    case 'qhd90':
+      // Poly Haven HDRIs do not provide a native 6k tier, so use 8k with 4k fallback.
+      return ['8k', '4k', '2k', '1k'];
+    case 'fhd60':
+      return ['4k', '2k', '1k'];
+    case 'hd50':
+      return ['2k', '1k'];
+    default:
+      if (prefersUhd) return ['8k', '4k', '2k', '1k'];
+      if (isLowProfileDevice) return ['2k', '1k'];
+      return ['4k', '2k', '1k'];
+  }
 }
 function shouldLoadExternalHdri() {
   // Keep HDRI enabled on mobile/Telegram too (at 1k) so players still see purchased environments.
@@ -5925,7 +5960,7 @@ async function createSeatAvatarTexture(
   source = DEFAULT_AVATAR_EMOJI,
   fallback = DEFAULT_AVATAR_EMOJI
 ) {
-  const size = 512;
+  const size = getAdaptiveAvatarTextureSize(512);
   const canvas = document.createElement('canvas');
   canvas.width = canvas.height = size;
   const ctx = canvas.getContext('2d');


### PR DESCRIPTION
### Motivation
- Align Domino Battle Royal graphics profiles with the requested refresh-rate → asset-resolution mapping so HDRIs, table, chairs, dominos, avatars, and the in-game graphics options present and load higher-resolution assets for higher refresh rates.
- Improve adaptive sizing so avatar and domino textures scale consistently with chosen graphics profiles and platform capabilities.

### Description
- Updated graphics option labels/descriptions in `webapp/public/domino-royal-game.js` so `60Hz` displays are labeled/targeted as `4K`, `90Hz` as `6K`, and both `120Hz` and `144Hz` target `8K` assets (UI strings in `FRAME_RATE_OPTIONS`).
- Increased the adaptive asset-resolution maps `FRAME_RATE_TEXTURE_SIZE_MAP` and `DOMINO_TEXTURE_SIZE_MAP` to map the profiles to 4K/6K/8K-equivalent sizes and raised the `getAdaptiveTextureSize`/`getAdaptiveDominoTextureSize` clamps up to 8K where appropriate.
- Added `AVATAR_TEXTURE_SIZE_MAP` plus `getAdaptiveAvatarTextureSize` and switched `createSeatAvatarTexture` to allocate avatar canvases using the adaptive avatar size so avatar textures follow the graphics profile.
- Expanded `HDRI_RESOLUTION_ORDER` and replaced the HDRI selection logic in `resolveHdriResolutionOrder` so HDRI loading prefers higher tiers per profile (e.g. 60Hz → 4K order, 90Hz uses 8K then 4K fallback since 6K HDRIs are not provided by source, 120/144Hz → 8K first).

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` to verify JavaScript syntax and the modified file parsed successfully (no syntax errors).
- No automated browser or runtime rendering tests were executed in this environment; integration/testing in a browser or device with different refresh rates is recommended to validate memory and performance trade-offs when using larger textures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca10c671a48329bc74d1d31931e795)