### PR TITLE
Lock rail-overhead replay camera, adjust replay timing, and rename skip-replays key

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1113,7 +1113,7 @@ const TABLE_FINISH_STORAGE_KEY = 'poolRoyaleTableFinish';
 const CLOTH_COLOR_STORAGE_KEY = 'poolRoyaleClothColor';
 const TABLE_BASE_STORAGE_KEY = 'poolRoyaleTableBase';
 const POCKET_LINER_STORAGE_KEY = 'poolPocketLiner';
-const SKIP_REPLAYS_STORAGE_KEY = 'poolSkipReplays';
+const SKIP_REPLAYS_STORAGE_KEY = 'poolRoyaleSkipReplays';
 const COMMENTARY_PRESET_STORAGE_KEY = 'poolRoyaleCommentaryPreset';
 const COMMENTARY_MUTE_STORAGE_KEY = 'poolRoyaleCommentaryMute';
 const DEFAULT_CUE_STROKE_STYLE = 'featherLine';
@@ -1231,9 +1231,9 @@ const TABLE_MAPPING_VISUALS = Object.freeze({
   jaws: false,
   pockets: false
 });
-const LOCK_REPLAY_CAMERA = false;
-const FIXED_RAIL_REPLAY_CAMERA = false;
-const LOCK_RAIL_OVERHEAD_FRAME = false;
+const LOCK_REPLAY_CAMERA = true; // keep replay camera on rail-overhead broadcast framing instead of recorded 2D camera snapshots
+const FIXED_RAIL_REPLAY_CAMERA = true; // force replay playback to use rail-overhead camera path consistently
+const LOCK_RAIL_OVERHEAD_FRAME = true; // keep broadcast top-view locked to rail-overhead framing
 const REPLAY_CUE_STICK_HOLD_MS = 760;
 const REPLAY_CAMERA_START_DELAY_MS = 0;
   const TABLE_BASE_SCALE = 1.2;
@@ -5570,8 +5570,8 @@ const REPLAY_BANNER_VARIANTS = {
 };
 const REPLAY_TRAIL_HEIGHT = BALL_CENTER_Y + BALL_R * 0.3;
 const REPLAY_TRAIL_COLOR = 0xffffff;
-const REPLAY_CUE_RETURN_WINDOW_MS = 480;
-const REPLAY_CUE_START_HOLD_MS = 110;
+const REPLAY_CUE_RETURN_WINDOW_MS = 260;
+const REPLAY_CUE_START_HOLD_MS = 0;
 const RAIL_NEAR_BUFFER = BALL_R * 3.5;
 const SHORT_SHOT_CAMERA_DISTANCE = BALL_R * 12; // keep camera in standing view for close shots
 const SHORT_RAIL_POCKET_TRIGGER =
@@ -5607,14 +5607,14 @@ const PLAYER_CUE_PULLBACK_DURATION_MS = 620;
 const PLAYER_CUE_RELEASE_DURATION_MS = 1320;
 const PLAYER_CUE_IMPACT_HOLD_MS = 540;
 const MIN_PULLBACK_GAP = BALL_R * 0.75;
-const REPLAY_CUE_STROKE_SLOWDOWN = 2.25;
-const REPLAY_CUE_STROKE_LEAD_IN_MS = 240; // begin replay in the charge phase so pullback + strike are both clearly visible
-const REPLAY_CUE_RELEASE_VISIBILITY_MULTIPLIER = 1.42; // stretch the forward push more so cue impact is readable in replay
+const REPLAY_CUE_STROKE_SLOWDOWN = 1.6;
+const REPLAY_CUE_STROKE_LEAD_IN_MS = 0; // match Snooker Royal replay timing window
+const REPLAY_CUE_RELEASE_VISIBILITY_MULTIPLIER = 1; // keep release cadence identical to Snooker Royal replay stroke
 const BREAK_DICE_ROLL_DELAY_MS = 560;
 const BREAK_DICE_RESULT_PAUSE_MS = 720;
 const BREAK_DICE_ROLL_SOUND_URL = '/assets/sounds/u_qpfzpydtro-dice-142528.mp3';
-const REPLAY_CUE_MIN_PULLBACK_MS = 360; // keep replay wind-up visible without consuming the whole replay window
-const REPLAY_CUE_MIN_RELEASE_MS = 620; // keep forward cue strike visible for a clear cue-ball hit
+const REPLAY_CUE_MIN_PULLBACK_MS = 0; // defer to recorded stroke durations like Snooker Royal
+const REPLAY_CUE_MIN_RELEASE_MS = 0; // defer to recorded stroke durations like Snooker Royal
 const CUE_STROKE_POST_HIT_CAMERA_HOLD_MS = 420;
 // Keep the live stroke timing aligned with the reference cue motion:
 // quick push forward and a short hold before snapping back to idle.
@@ -19530,6 +19530,14 @@ const powerRef = useRef(hud.power);
           focusOverride = null,
           minTargetY = null
         } = {}) => {
+          const railCamera = resolveRailOverheadReplayCamera({
+            focusOverride,
+            minTargetY,
+            preferredRail: railOverheadSideRef.current
+          });
+          if (railCamera?.position && railCamera?.target) {
+            return railCamera;
+          }
           const systemVariant =
             broadcastSystemRef.current?.topViewVariant ??
             activeBroadcastSystem?.topViewVariant ??
@@ -21291,21 +21299,23 @@ const powerRef = useRef(hud.power);
         const captureReplayCameraSnapshot = () => {
           const scale = Number.isFinite(worldScaleFactor) ? worldScaleFactor : WORLD_SCALE;
           const minTargetY = Math.max(baseSurfaceWorldY, BALL_CENTER_Y * scale);
-          const activeCamera = activeRenderCameraRef.current ?? camera;
-          const fovSnapshot = Number.isFinite(activeCamera?.fov)
-            ? activeCamera.fov
-            : camera.fov;
           const targetSnapshot = lastCameraTargetRef.current
             ? lastCameraTargetRef.current.clone()
             : broadcastCamerasRef.current?.defaultFocusWorld?.clone?.() ?? null;
+          const railSnapshot = resolveRailOverheadReplayCamera({
+            focusOverride: targetSnapshot,
+            minTargetY,
+            preferredRail: railOverheadSideRef.current
+          });
           const cameraMode =
             pocketCameraStateRef.current && activeShotView?.mode === 'pocket'
               ? `pocket:${activeShotView?.anchorId ?? activeShotView?.pocketId ?? 'active'}`
               : 'broadcast';
-          const resolvedPosition = activeCamera?.position?.clone?.() ?? null;
-          const resolvedTarget = targetSnapshot;
-          const resolvedFov = fovSnapshot;
-          const resolvedMinTargetY = minTargetY;
+          const resolvedPosition = railSnapshot?.position?.clone?.() ?? null;
+          const resolvedTarget = railSnapshot?.target?.clone?.() ?? targetSnapshot;
+          const resolvedFov = Number.isFinite(railSnapshot?.fov)
+            ? railSnapshot.fov
+            : camera.fov;
           if (!resolvedPosition && !resolvedTarget) return null;
           const snapshot = {
             position: resolvedPosition,
@@ -21313,8 +21323,8 @@ const powerRef = useRef(hud.power);
             fov: resolvedFov,
             key: cameraMode
           };
-          if (Number.isFinite(resolvedMinTargetY)) {
-            snapshot.minTargetY = resolvedMinTargetY;
+          if (Number.isFinite(minTargetY)) {
+            snapshot.minTargetY = minTargetY;
           }
           return snapshot;
         };
@@ -28309,7 +28319,7 @@ const powerRef = useRef(hud.power);
           pottedBalls,
           shotContext
         }) => {
-          if (!recording || !hadObjectPot) return null;
+          if (!recording) return null;
           const tags = new Set(recording.replayTags ?? []);
           if (hadObjectPot) tags.add('pot');
           const potCount = pottedBalls.filter((entry) => entry.id !== 'cue').length;
@@ -28319,8 +28329,16 @@ const powerRef = useRef(hud.power);
           const priority = ['multi', 'bank', 'long', 'power', 'spin'];
           const primary = priority.find((tag) => tags.has(tag)) ?? 'default';
           const zoomOnly = recording.zoomOnly && !tags.has('long') && !tags.has('bank');
+          const hadMeaningfulContact = Boolean(shotContext?.contactMade);
+          const hasReplayFrames = (recording?.frames?.length ?? 0) > 1;
+          const hasReplaySignal =
+            hasReplayFrames ||
+            hadObjectPot ||
+            tags.size > 0 ||
+            hadMeaningfulContact ||
+            Boolean(recording?.replayFoul);
           return {
-            shouldReplay: hadObjectPot || tags.size > 0,
+            shouldReplay: hasReplayFrames || hasReplaySignal,
             banner: selectReplayBanner(primary),
             zoomOnly,
             tags: Array.from(tags),
@@ -28342,7 +28360,10 @@ const powerRef = useRef(hud.power);
           });
           let shouldStartReplay =
             !skipAllReplaysRef.current &&
-            Boolean(replayDecision?.shouldReplay) &&
+            Boolean(
+              replayDecision?.shouldReplay ??
+                ((shotRecording?.frames?.length ?? 0) > 1)
+            ) &&
             (shotRecording?.frames?.length ?? 0) > 1;
           let replayBannerText = replayDecision?.banner ?? selectReplayBanner('default');
           let replayAccent = replayDecision?.primaryTag ?? 'default';
@@ -28575,7 +28596,10 @@ const powerRef = useRef(hud.power);
         }
         shouldStartReplay =
           !skipAllReplaysRef.current &&
-          Boolean(replayDecision?.shouldReplay) &&
+          Boolean(
+            replayDecision?.shouldReplay ??
+              ((shotRecording?.frames?.length ?? 0) > 1)
+          ) &&
           (shotRecording?.frames?.length ?? 0) > 1;
         const shooterSeat = currentState?.activePlayer === 'B' ? 'B' : 'A';
         if (potted.length) {
@@ -28836,8 +28860,9 @@ const powerRef = useRef(hud.power);
           pocketSwitchIntentRef.current = null;
           lastPocketBallRef.current = null;
           updatePocketCameraState(false);
-          if (shouldStartReplay && postShotSnapshot) {
+          if (shouldStartReplay) {
             const recordingForReplay = shotRecording;
+            const replayPostState = postShotSnapshot || captureBallSnapshot();
             const launchReplay = () => {
               replayBannerTimeoutRef.current = null;
               setReplayBanner(null);
@@ -28845,7 +28870,7 @@ const powerRef = useRef(hud.power);
               const beginReplay = () => {
                 shotRecording = recordingForReplay;
                 if (recordingForReplay) {
-                  startShotReplay(postShotSnapshot);
+                  startShotReplay(replayPostState);
                 } else {
                   shotReplayRef.current = null;
                 }


### PR DESCRIPTION
### Motivation
- Ensure replays consistently use the rail-overhead broadcast framing and make replay playback timing match the reference (Snooker Royal) for clearer, predictable replays.
- Broaden replay detection so recorded frames, contact events, or fouls trigger replays instead of only potted-object events.
- Avoid a storage key collision / clarify naming for the skip-replays preference.

### Description
- Renamed the skip-replays storage key from `poolSkipReplays` to `poolRoyaleSkipReplays` by updating `SKIP_REPLAYS_STORAGE_KEY`.
- Forced rail-overhead broadcast framing by setting `LOCK_REPLAY_CAMERA`, `FIXED_RAIL_REPLAY_CAMERA`, and `LOCK_RAIL_OVERHEAD_FRAME` to `true`.
- Prioritized the rail-overhead camera in `resolveBroadcastTopViewCamera` and switched `captureReplayCameraSnapshot` to derive replay snapshots from the rail-overhead camera when available.
- Relaxed replay decision logic in `resolveReplayDecision` to consider recorded frames, meaningful contact, and fouls (not just potted-object events), and defaulted to a captured post-shot state when launching replays.
- Tuned multiple replay timing and stroke constants to align with Snooker Royal behavior, including `REPLAY_CUE_RETURN_WINDOW_MS`, `REPLAY_CUE_START_HOLD_MS`, `REPLAY_CUE_STROKE_SLOWDOWN`, `REPLAY_CUE_STROKE_LEAD_IN_MS`, `REPLAY_CUE_RELEASE_VISIBILITY_MULTIPLIER`, `REPLAY_CUE_MIN_PULLBACK_MS`, and `REPLAY_CUE_MIN_RELEASE_MS`.

### Testing
- Ran the JavaScript unit test suite (`yarn test`) and all tests passed.
- Ran linting (`eslint`) and a production build (`yarn build`) and both completed successfully.
- Executed automated replay smoke tests that simulate shot capture and replay flows and observed expected rail-overhead framing and replay playback behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca02a68bcc83299098e3e8786f7e8e)