### PR TITLE
Show roll CTA for extra turns and convert final tile to 50-tile trophy podium

### DIFF
--- a/webapp/src/components/SnakeBoard.jsx
+++ b/webapp/src/components/SnakeBoard.jsx
@@ -110,7 +110,7 @@ function buildPyramidLayout() {
 
 const BOARD_LAYOUT = buildPyramidLayout();
 export const BOARD_CELL_COUNT = BOARD_LAYOUT.totalCells;
-export const FINAL_TILE = BOARD_CELL_COUNT + 1;
+export const FINAL_TILE = BOARD_CELL_COUNT;
 const BOARD_WIDTH_UNITS = BOARD_LAYOUT.widthUnits;
 const BOARD_HEIGHT_UNITS = BOARD_LAYOUT.heightUnits;
 const CENTER_COLUMN = BOARD_LAYOUT.centerColumn;

--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -185,8 +185,6 @@ const TILE_SIDE_EMISSIVE_SCALE = 0.25;
 const TILE_BOTTOM_EMISSIVE_SCALE = 0.1;
 
 const BENTONITE_EXTRA_SHRINK = [0.85, 0.92];
-const TILE_100_SUPPORT_RADIUS = TILE_SIZE * 0.58;
-const TILE_100_SUPPORT_HEIGHT_EXTRA = TILE_SIZE * 0.25;
 
 const TOKEN_RADIUS_SCALE = 1.19;
 const TOKEN_SCALE_MULTIPLIER = 1;
@@ -202,7 +200,9 @@ const BASE_PLATFORM_EXTRA_MULTIPLIER = 1.72;
 const FIRST_LEVEL_PLATFORM_EXTRA = TILE_SIZE * 0.9;
 const TOKEN_MULTI_OCCUPANT_RADIUS = TILE_SIZE * 0.24 * TOKEN_RADIUS_SCALE * TOKEN_SCALE_MULTIPLIER;
 const DICE_PLAYER_EXTRA_OFFSET = TILE_SIZE * 1.8;
-const TOP_TILE_EXTRA_LEVELS = 1;
+const TOP_TILE_EXTRA_LEVELS = 0;
+const WIN_PODIUM_SCALE_XZ = 1.32;
+const WIN_PODIUM_SCALE_Y = 1.55;
 const TOKEN_REST_RAIL_INSET_BY_SEAT = Object.freeze([
   TILE_SIZE * 1.55,
   TILE_SIZE * 1.18,
@@ -2156,14 +2156,19 @@ function createTileLabel(number) {
   const ctx = canvas.getContext('2d');
   ctx.clearRect(0, 0, size, size);
 
-  const text = String(number);
+  const isWinTile = number === TOTAL_BOARD_TILES;
+  const text = isWinTile ? '🏆' : String(number);
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
-  ctx.font = `700 ${size * 0.55}px 'Inter', 'Segoe UI', sans-serif`;
+  ctx.font = isWinTile
+    ? `${size * 0.56}px 'Apple Color Emoji', 'Segoe UI Emoji', 'Noto Color Emoji', sans-serif`
+    : `700 ${size * 0.55}px 'Inter', 'Segoe UI', sans-serif`;
   ctx.lineWidth = size * 0.08;
   ctx.strokeStyle = 'rgba(15,23,42,0.85)';
-  ctx.strokeText(text, size / 2, size / 2);
-  ctx.fillStyle = '#f8fafc';
+  if (!isWinTile) {
+    ctx.strokeText(text, size / 2, size / 2);
+  }
+  ctx.fillStyle = isWinTile ? '#fbbf24' : '#f8fafc';
   ctx.fillText(text, size / 2, size / 2);
 
   const texture = new THREE.CanvasTexture(canvas);
@@ -2935,11 +2940,16 @@ function buildSnakeBoard(
         tilePosition.x *= GROUND_FLOOR_OUTWARD_SCALE;
         tilePosition.z *= GROUND_FLOOR_OUTWARD_SCALE;
       }
-      if (idx === TOTAL_BOARD_TILES) {
-        tilePosition.y += topTileLift;
+      const isWinTile = idx === TOTAL_BOARD_TILES;
+      const winTileHeight = isWinTile ? tileHeight * WIN_PODIUM_SCALE_Y : tileHeight;
+      if (isWinTile) {
+        tilePosition.y += topTileLift + (winTileHeight - tileHeight) * 0.5;
       }
       const tile = new THREE.Mesh(tileGeo, materialSet.materials);
       tile.position.copy(tilePosition);
+      if (isWinTile) {
+        tile.scale.set(WIN_PODIUM_SCALE_XZ, WIN_PODIUM_SCALE_Y, WIN_PODIUM_SCALE_XZ);
+      }
       tile.castShadow = true;
       tile.receiveShadow = true;
       tile.userData.index = idx;
@@ -2951,17 +2961,11 @@ function buildSnakeBoard(
       tileMeshes.set(idx, tile);
 
       const topPosition = tilePosition.clone();
-      topPosition.y = tileTopY;
-      if (idx === TOTAL_BOARD_TILES) {
-        topPosition.y += topTileLift;
-      }
+      topPosition.y = tilePosition.y + winTileHeight / 2;
       indexToPosition.set(idx, topPosition);
 
       const label = createTileLabel(idx);
-      let labelY = tileTopY;
-      if (idx === TOTAL_BOARD_TILES) {
-        labelY += topTileLift;
-      }
+      const labelY = topPosition.y;
       label.position.set(tilePosition.x, labelY + TILE_LABEL_OFFSET, tilePosition.z);
       labelGroup.add(label);
     });
@@ -3010,33 +3014,6 @@ function buildSnakeBoard(
       platformMeshes
     );
   });
-
-  const tileHundred = tileMeshes.get(TOTAL_BOARD_TILES);
-  if (tileHundred) {
-    const topLevelPlacement = levelPlacements[levelPlacements.length - 1];
-    const supportBaseY = topLevelPlacement.tileCenterY - tileHeight / 2;
-    const supportTopY = tileHundred.position.y - tileHeight / 2;
-    const supportHeight = Math.max(
-      TILE_100_SUPPORT_HEIGHT_EXTRA,
-      supportTopY - supportBaseY + TILE_100_SUPPORT_HEIGHT_EXTRA
-    );
-    const supportMaterial = new THREE.MeshStandardMaterial({
-      color: PYRAMID_CONCRETE_LIGHT.clone().lerp(PYRAMID_CONCRETE_SHADOW, 0.55),
-      roughness: 0.74,
-      metalness: 0.08,
-      emissive: PYRAMID_CONCRETE_ACCENT.clone().multiplyScalar(0.14),
-      emissiveIntensity: 0.18
-    });
-    const support = new THREE.Mesh(
-      new THREE.CylinderGeometry(TILE_100_SUPPORT_RADIUS * 0.85, TILE_100_SUPPORT_RADIUS, supportHeight, 24),
-      supportMaterial
-    );
-    support.position.set(tileHundred.position.x, supportBaseY + supportHeight / 2, tileHundred.position.z);
-    support.castShadow = true;
-    support.receiveShadow = true;
-    platformGroup.add(support);
-    platformMeshes.push(support);
-  }
 
   const baseHalf = (BASE_LEVEL_TILES * TILE_SIZE) / 2;
   const baseStart = new THREE.Vector3(

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -3154,13 +3154,13 @@ export default function SnakeAndLadder() {
     ? mpPlayers.findIndex((p) => p.id === accountId)
     : 0;
   const myPlayerIndex = computedIndex >= 0 ? computedIndex : null;
-  const hasLocalExtraRoll = isMultiplayer && pendingExtraRoll;
+  const hasLocalExtraRoll = pendingExtraRoll;
   const isMyTurnForRoll =
     myPlayerIndex !== null && (currentTurn === myPlayerIndex || hasLocalExtraRoll);
   const canRoll =
     isMyTurnForRoll &&
     !moving &&
-    rollCooldown === 0 &&
+    (rollCooldown === 0 || pendingExtraRoll) &&
     !gameOver &&
     !waitingForPlayers &&
     !playerAutoRolling &&


### PR DESCRIPTION
### Motivation
- Players who roll a 6 (or otherwise earn an extra roll) should immediately see the ROLL CTA so the local human can continue without waiting for cooldown gating.  
- The board must use exactly 50 playable tiles and present the last tile as a clear win podium (no top tower/support), visually emphasising victory with a trophy marker.

### Description
- Allow local extra-rolls to show the roll CTA by treating `pendingExtraRoll` as the local extra-turn flag and letting it bypass `rollCooldown` when computing `canRoll` in `SnakeAndLadder.jsx`.  
- Make the final tile equal to the board playable cell count by exporting `FINAL_TILE = BOARD_CELL_COUNT` in `SnakeBoard.jsx`, ensuring the board target is exactly 50 tiles.  
- Replace the previous top support/tower and transform the final tile into a podium: set `TOP_TILE_EXTRA_LEVELS = 0`, add `WIN_PODIUM_SCALE_XZ`/`WIN_PODIUM_SCALE_Y`, scale and lift the final tile, and remove the old support geometry in `SnakeBoard3D.jsx`.  
- Render a trophy emoji on the win tile label by using a specialised canvas label for the final tile (uses 🏆 and a gold fill color) in `SnakeBoard3D.jsx`.

### Testing
- Ran ESLint on the changed files (`npx eslint ...`) which returned only ignore/warning messages (no code errors reported).  
- Built the webapp production bundle (`npm --prefix webapp run build`) and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca1bfe99ec8329821ee4d99f6478de)