### PR TITLE
Upgrade graphics profiles to 4K/6K/8K, add adaptive avatar sizes and legacy aliasing

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -15,49 +15,40 @@ const FRAME_RATE_STORAGE_KEY = 'dominoRoyalFrameRate';
 const DEFAULT_FRAME_RATE_ID = 'fhd60';
 const FRAME_RATE_OPTIONS = Object.freeze([
   {
-    id: 'hd50',
-    label: 'HD Performance (50 Hz)',
-    fps: 50,
-    renderScale: 1,
-    pixelRatioCap: 1,
-    resolution: 'Full HD floor render • DPR 1.0 cap',
-    description: '50 Hz fallback with Full HD-quality domino textures.'
-  },
-  {
     id: 'fhd60',
-    label: 'Full HD (60 Hz)',
+    label: '4K (60 Hz)',
     fps: 60,
     renderScale: 1,
     pixelRatioCap: 1,
-    resolution: 'Full HD render • DPR 1.0 cap',
-    description: 'Full HD baseline profile for 60 Hz devices.'
+    resolution: '4K assets • optimized DPR cap',
+    description: '4K profile for 60 Hz displays.'
   },
   {
     id: 'qhd90',
-    label: '2K (90 Hz)',
+    label: '6K (90 Hz)',
     fps: 90,
     renderScale: 1,
     pixelRatioCap: 1.5,
-    resolution: '2K render • DPR 1.5 cap',
-    description: '2K profile for 90 Hz displays.'
+    resolution: '6K assets • optimized DPR cap',
+    description: '6K profile for 90 Hz displays.'
   },
   {
     id: 'uhd120',
-    label: '4K (120 Hz)',
+    label: '8K (120 Hz)',
     fps: 120,
     renderScale: 1,
     pixelRatioCap: 2,
-    resolution: '4K render • DPR 2.0 cap',
-    description: '4K profile for 120 Hz displays and flagship hardware.'
+    resolution: '8K assets • optimized DPR cap',
+    description: '8K profile for 120 Hz displays and flagship hardware.'
   },
   {
     id: 'ultra144',
-    label: 'Ultra 144 (desktop)',
+    label: '8K (144 Hz)',
     fps: 144,
     renderScale: 1,
     pixelRatioCap: 2,
-    resolution: '4K render • DPR 2.0 cap',
-    description: 'Desktop 144 Hz profile with 4K-quality domino rendering.'
+    resolution: '8K assets • optimized DPR cap',
+    description: '8K profile for 144 Hz displays.'
   }
 ]);
 const FRAME_RATE_OPTIONS_BY_ID = Object.freeze(
@@ -91,19 +82,27 @@ const MURLAN_3D_ASSET_RESOLUTION = Object.freeze({
 });
 
 const FRAME_RATE_TEXTURE_SIZE_MAP = Object.freeze({
-  hd50: 1024,
-  fhd60: 2048,
-  qhd90: 3072,
-  uhd120: 4096,
-  ultra144: 4096
+  fhd60: 4096,
+  qhd90: 6144,
+  uhd120: 8192,
+  ultra144: 8192
 });
 
 const DOMINO_TEXTURE_SIZE_MAP = Object.freeze({
-  hd50: 2048,
-  fhd60: 2048,
-  qhd90: 3072,
-  uhd120: 4096,
-  ultra144: 4096
+  fhd60: 4096,
+  qhd90: 6144,
+  uhd120: 8192,
+  ultra144: 8192
+});
+
+const AVATAR_TEXTURE_SIZE_MAP = Object.freeze({
+  fhd60: 1024,
+  qhd90: 1536,
+  uhd120: 2048,
+  ultra144: 2048
+});
+const LEGACY_FRAME_RATE_ALIASES = Object.freeze({
+  hd50: 'fhd60'
 });
 
 function getAdaptiveTextureSize(baseSize = 2048) {
@@ -111,7 +110,7 @@ function getAdaptiveTextureSize(baseSize = 2048) {
     FRAME_RATE_TEXTURE_SIZE_MAP[frameRateId] ??
     FRAME_RATE_TEXTURE_SIZE_MAP[DEFAULT_FRAME_RATE_ID] ??
     baseSize;
-  return Math.max(768, Math.min(4096, mappedSize));
+  return Math.max(768, Math.min(8192, mappedSize));
 }
 
 function getAdaptiveDominoTextureSize(baseSize = 4096) {
@@ -127,13 +126,19 @@ function getAdaptiveDominoTextureSize(baseSize = 4096) {
     mappedByFps ??
     DOMINO_TEXTURE_SIZE_MAP[DEFAULT_FRAME_RATE_ID] ??
     baseSize;
-  return Math.max(768, Math.min(4096, mappedSize));
+  return Math.max(768, Math.min(8192, mappedSize));
+}
+
+function getAdaptiveAvatarTextureSize(baseSize = 512) {
+  const mappedSize =
+    AVATAR_TEXTURE_SIZE_MAP[frameRateId] ??
+    AVATAR_TEXTURE_SIZE_MAP[DEFAULT_FRAME_RATE_ID] ??
+    baseSize;
+  return Math.max(256, Math.min(2048, mappedSize));
 }
 
 function resolveTelegramPixelRatioCap(qualityId = DEFAULT_FRAME_RATE_ID) {
   switch (qualityId) {
-    case 'hd50':
-      return 1;
     case 'fhd60':
       return 1;
     case 'qhd90':
@@ -401,15 +406,23 @@ function buildFrameTiming(quality) {
 }
 
 function resolveInitialFrameRateId() {
+  const normalizeFrameRateId = (rawId) => {
+    if (!rawId) return null;
+    if (FRAME_RATE_OPTIONS_BY_ID[rawId]) return rawId;
+    const legacyId = LEGACY_FRAME_RATE_ALIASES[rawId];
+    return FRAME_RATE_OPTIONS_BY_ID[legacyId] ? legacyId : null;
+  };
   const urlPreset = urlParams.get('frameRateId') || urlParams.get('graphics');
-  if (urlPreset && FRAME_RATE_OPTIONS_BY_ID[urlPreset]) {
-    return urlPreset;
+  const normalizedUrlPreset = normalizeFrameRateId(urlPreset);
+  if (normalizedUrlPreset) {
+    return normalizedUrlPreset;
   }
   if (typeof window !== 'undefined') {
     try {
       const stored = window.localStorage?.getItem(FRAME_RATE_STORAGE_KEY);
-      if (stored && FRAME_RATE_OPTIONS_BY_ID[stored]) {
-        return stored;
+      const normalizedStored = normalizeFrameRateId(stored);
+      if (normalizedStored) {
+        return normalizedStored;
       }
     } catch (error) {
       console.warn(
@@ -4413,7 +4426,13 @@ function getUnlockedOptions(key, inventory = dominoInventory) {
   );
 }
 
-const HDRI_RESOLUTION_ORDER = Object.freeze(['1k', '2k']);
+const HDRI_RESOLUTION_ORDER = Object.freeze([
+  '1k',
+  '2k',
+  '4k',
+  '8k',
+  '16k'
+]);
 const isTelegramWebView = IS_TELEGRAM_RUNTIME;
 const isMobileDevice = /Android|iPhone|iPad|iPod|Mobile/i.test(
   navigator.userAgent || ''
@@ -4427,9 +4446,20 @@ const isLowProfileDevice =
   isTelegramWebView || isMobileDevice || isLowMemoryDevice || isLowCoreDevice;
 const MAX_HDRI_CACHE_SIZE = prefersUhd ? 4 : isLowProfileDevice ? 1 : 2;
 function resolveHdriResolutionOrder() {
-  if (prefersUhd) return ['2k', '1k'];
-  if (isLowProfileDevice) return ['1k'];
-  return ['2k', '1k'];
+  switch (frameRateId) {
+    case 'ultra144':
+    case 'uhd120':
+      return ['8k', '4k', '2k', '1k'];
+    case 'qhd90':
+      // Poly Haven HDRIs do not provide a native 6k tier, so use 8k with 4k fallback.
+      return ['8k', '4k', '2k', '1k'];
+    case 'fhd60':
+      return ['4k', '2k', '1k'];
+    default:
+      if (prefersUhd) return ['8k', '4k', '2k', '1k'];
+      if (isLowProfileDevice) return ['2k', '1k'];
+      return ['4k', '2k', '1k'];
+  }
 }
 function shouldLoadExternalHdri() {
   // Keep HDRI enabled on mobile/Telegram too (at 1k) so players still see purchased environments.
@@ -5925,7 +5955,7 @@ async function createSeatAvatarTexture(
   source = DEFAULT_AVATAR_EMOJI,
   fallback = DEFAULT_AVATAR_EMOJI
 ) {
-  const size = 512;
+  const size = getAdaptiveAvatarTextureSize(512);
   const canvas = document.createElement('canvas');
   canvas.width = canvas.height = size;
   const ctx = canvas.getContext('2d');
@@ -6876,9 +6906,11 @@ function applyFrameRateSelection(
   optionId,
   { refreshUi = true, source = 'system' } = {}
 ) {
-  const resolvedId = FRAME_RATE_OPTIONS_BY_ID[optionId]
-    ? optionId
-    : DEFAULT_FRAME_RATE_ID;
+  const resolvedId =
+    FRAME_RATE_OPTIONS_BY_ID[optionId] ||
+    FRAME_RATE_OPTIONS_BY_ID[LEGACY_FRAME_RATE_ALIASES[optionId]]
+      ? LEGACY_FRAME_RATE_ALIASES[optionId] || optionId
+      : DEFAULT_FRAME_RATE_ID;
   if (source === 'manual') {
     lastManualFrameRateSelectionAt = performance.now();
     slowFrameAccumulatorMs = 0;

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-03-28-4k-domino-v3';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-03-30-graphics-4k-6k-8k-v4';
 
 export default function DominoRoyalArena() {
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- Increase available graphics quality tiers and texture budgets to support higher-resolution displays and richer assets.
- Provide adaptive avatar texture sizing and HDRI resolution selection tuned to selected graphics profiles.
- Maintain backward compatibility with older stored/URL frame-rate identifiers.

### Description
- Update `FRAME_RATE_OPTIONS` labels and descriptions to reflect 4K/6K/8K targets and remove the old `hd50` option. 
- Raise caps in `FRAME_RATE_TEXTURE_SIZE_MAP` and `DOMINO_TEXTURE_SIZE_MAP` to support up to 8192px and expand `getAdaptiveTextureSize`/`getAdaptiveDominoTextureSize` accordingly. 
- Add `AVATAR_TEXTURE_SIZE_MAP` and `getAdaptiveAvatarTextureSize`, and use it in `createSeatAvatarTexture` to produce appropriately sized avatar canvases. 
- Extend HDRI resolution choices (`HDRI_RESOLUTION_ORDER`) and implement `resolveHdriResolutionOrder` switch logic to select higher-res HDRIs for higher-quality profiles. 
- Add `LEGACY_FRAME_RATE_ALIASES` and normalize inputs in `resolveInitialFrameRateId` and `applyFrameRateSelection` so legacy IDs (e.g. `hd50`) fallback to modern profiles. 
- Update script version string in `DominoRoyalArena.jsx`.

### Testing
- Ran the application build with `yarn build` which completed successfully. 
- Executed unit tests with `yarn test` and all tests passed. 
- Performed an automated smoke build/load of the web app (headless) to validate startup and renderer initialization which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca10c671a48329bc74d1d31931e795)