### PR TITLE
Fix extra-roll UX; make tile 50 the final podium and remove top tower

### DIFF
--- a/webapp/src/components/SnakeBoard.jsx
+++ b/webapp/src/components/SnakeBoard.jsx
@@ -110,7 +110,7 @@ function buildPyramidLayout() {
 
 const BOARD_LAYOUT = buildPyramidLayout();
 export const BOARD_CELL_COUNT = BOARD_LAYOUT.totalCells;
-export const FINAL_TILE = BOARD_CELL_COUNT + 1;
+export const FINAL_TILE = BOARD_CELL_COUNT;
 const BOARD_WIDTH_UNITS = BOARD_LAYOUT.widthUnits;
 const BOARD_HEIGHT_UNITS = BOARD_LAYOUT.heightUnits;
 const CENTER_COLUMN = BOARD_LAYOUT.centerColumn;
@@ -222,12 +222,13 @@ export default function SnakeBoard({
         : cellType === "snake"
         ? snakeOffsets[num]
         : null;
+    const isFinalTile = num === FINAL_TILE;
     const style = {
       gridRowStart: scaledRows - tile.row * GRID_SCALE - (GRID_SCALE - 1),
       gridRowEnd: `span ${GRID_SCALE}`,
       gridColumnStart: Math.round(tile.col * GRID_SCALE) + 1,
       gridColumnEnd: `span ${GRID_SCALE}`,
-      transform: `translate(${translateX}px, ${translateY}px) scaleX(${scaleX}) scaleY(${scale}) translateZ(5px)`,
+      transform: `translate(${translateX}px, ${translateY}px) scaleX(${scaleX * (isFinalTile ? 1.2 : 1)}) scaleY(${scale * (isFinalTile ? 1.2 : 1)}) translateZ(5px)`,
       transformOrigin: "bottom center",
     };
     if (!highlightClass) style.backgroundColor = "#6db0ad";
@@ -254,7 +255,7 @@ export default function SnakeBoard({
             )}
           </span>
         )}
-        {!cellType && <span className="cell-number">{num}</span>}
+        {!cellType && <span className="cell-number">{isFinalTile ? '🏆' : num}</span>}
         {diceCells && diceCells[num] && (
           <span className="dice-marker">
             <img  src="/assets/icons/file_000000009160620a96f728f463de1c3f.webp" alt="dice" className="dice-icon" />
@@ -331,24 +332,6 @@ export default function SnakeBoard({
   const paddingTop = 0;
   const paddingBottom = '15vh';
 
-  const topLevel = BOARD_LAYOUT.levels[BOARD_LAYOUT.levels.length - 1];
-  const potRowIndex = topLevel.yOffset + topLevel.size - 1;
-  const potCol = topLevel.xOffset + (topLevel.size - 1) / 2;
-  const potRowPos = BOARD_HEIGHT_UNITS > 1 ? potRowIndex / (BOARD_HEIGHT_UNITS - 1) : 0;
-  const potScale = 1 + (potRowIndex - 3) * SCALE_STEP;
-  const potScaleX = potScale * (1 + potRowPos * WIDEN_STEP);
-  const potOffsetX = (potScaleX - 1) * cellWidth;
-  const potTranslateX = (potCol + 0.5 - CENTER_COLUMN) * potOffsetX;
-  const potTranslateY = -rowOffsets[potRowIndex] - cellHeight * 2.8;
-  const potStyle = {
-    gridRowStart: scaledRows - potRowIndex * GRID_SCALE - (GRID_SCALE - 1),
-    gridRowEnd: `span ${GRID_SCALE}`,
-    gridColumnStart: Math.round((potCol - 0.5) * GRID_SCALE) + 1,
-    gridColumnEnd: `span ${GRID_SCALE * 2}`,
-    transform: `translate(${potTranslateX}px, ${potTranslateY}px) scaleX(${potScaleX * 1.1}) scaleY(${potScale}) translateZ(12px)`,
-    transformOrigin: "bottom center",
-  };
-
   return (
     <div className="relative flex justify-center items-center w-screen overflow-visible">
       <img
@@ -390,52 +373,6 @@ export default function SnakeBoard({
             }}
           >
             {tileElements}
-            <div
-              className={`pot-cell ${highlight && highlight.cell === FINAL_TILE ? 'highlight' : ''}`}
-              style={potStyle}
-            >
-              <PlayerToken color="#16a34a" topColor="#ff0000" className="pot-token" />
-              <div className="pot-icon">
-                <img
-                  src={
-                    token === 'TON'
-                      ? '/assets/icons/TON.webp'
-                      : token === 'USDT'
-                        ? '/assets/icons/Usdt.webp'
-                        : '/assets/icons/ezgif-54c96d8a9b9236.webp'
-                  }
-
-                  alt={token}
-                  className="coin-face front"
-                />
-                <img
-                  src={
-                    token === 'TON'
-                      ? '/assets/icons/TON.webp'
-                      : token === 'USDT'
-                        ? '/assets/icons/Usdt.webp'
-                        : '/assets/icons/ezgif-54c96d8a9b9236.webp'
-                  }
-                  alt=""
-                  className="coin-face back"
-                />
-              </div>
-              {players
-                .map((p, i) => ({ ...p, index: i }))
-                .filter((p) => p.position === FINAL_TILE)
-                .map((p) => (
-                  <Fragment key={`win-${p.index}`}>
-                    <PlayerToken
-                      photoUrl={p.photoUrl}
-                      type={p.type || 'normal'}
-                      color={p.color}
-                      photoOnly
-                      className="board-token"
-                    />
-                  </Fragment>
-                ))}
-              {celebrate && <CoinBurst token={token} />}
-            </div>
           </div>
         </div>
       </div>

--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -185,8 +185,6 @@ const TILE_SIDE_EMISSIVE_SCALE = 0.25;
 const TILE_BOTTOM_EMISSIVE_SCALE = 0.1;
 
 const BENTONITE_EXTRA_SHRINK = [0.85, 0.92];
-const TILE_100_SUPPORT_RADIUS = TILE_SIZE * 0.58;
-const TILE_100_SUPPORT_HEIGHT_EXTRA = TILE_SIZE * 0.25;
 
 const TOKEN_RADIUS_SCALE = 1.19;
 const TOKEN_SCALE_MULTIPLIER = 1;
@@ -202,7 +200,7 @@ const BASE_PLATFORM_EXTRA_MULTIPLIER = 1.72;
 const FIRST_LEVEL_PLATFORM_EXTRA = TILE_SIZE * 0.9;
 const TOKEN_MULTI_OCCUPANT_RADIUS = TILE_SIZE * 0.24 * TOKEN_RADIUS_SCALE * TOKEN_SCALE_MULTIPLIER;
 const DICE_PLAYER_EXTRA_OFFSET = TILE_SIZE * 1.8;
-const TOP_TILE_EXTRA_LEVELS = 1;
+const TOP_TILE_EXTRA_LEVELS = 0;
 const TOKEN_REST_RAIL_INSET_BY_SEAT = Object.freeze([
   TILE_SIZE * 1.55,
   TILE_SIZE * 1.18,
@@ -241,12 +239,9 @@ const STAIR_COLOR = 0x111111;
 const STAIR_WIDTH = TILE_SIZE * 0.72;
 const STAIR_DEPTH_MIN = TILE_SIZE * 0.22;
 const STAIR_OUTWARD_OFFSET = TILE_SIZE * 0.35;
-const COIN_SPIN_SPEED = Math.PI / 7;
 const TEXTURE_REPEAT_SCALE = 0.85;
 const BOARD_ROTATION_DRAG_SPEED = 0.0065;
 const CAMERA_EXTRA_LIFT = 0.12;
-const COIN_RAISE = TILE_SIZE * 0.24;
-const COIN_LOCAL_LIFT = TILE_SIZE * 0.05;
 
 const AVATAR_ANCHOR_HEIGHT = SEAT_THICKNESS / 2 + BACK_HEIGHT * 0.85;
 
@@ -2148,7 +2143,7 @@ function createDiceSettleAnimation(diceArray, { basePositions, baseY, startState
   };
 }
 
-function createTileLabel(number) {
+function createTileLabel(number, textOverride = null) {
   const size = 256;
   const canvas = document.createElement('canvas');
   canvas.width = size;
@@ -2156,13 +2151,18 @@ function createTileLabel(number) {
   const ctx = canvas.getContext('2d');
   ctx.clearRect(0, 0, size, size);
 
-  const text = String(number);
+  const text = textOverride ?? String(number);
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
-  ctx.font = `700 ${size * 0.55}px 'Inter', 'Segoe UI', sans-serif`;
-  ctx.lineWidth = size * 0.08;
-  ctx.strokeStyle = 'rgba(15,23,42,0.85)';
-  ctx.strokeText(text, size / 2, size / 2);
+  const isEmojiLabel = textOverride != null;
+  ctx.font = isEmojiLabel
+    ? `${size * 0.52}px 'Apple Color Emoji', 'Segoe UI Emoji', 'Noto Color Emoji', 'Inter', sans-serif`
+    : `700 ${size * 0.55}px 'Inter', 'Segoe UI', sans-serif`;
+  if (!isEmojiLabel) {
+    ctx.lineWidth = size * 0.08;
+    ctx.strokeStyle = 'rgba(15,23,42,0.85)';
+    ctx.strokeText(text, size / 2, size / 2);
+  }
   ctx.fillStyle = '#f8fafc';
   ctx.fillText(text, size / 2, size / 2);
 
@@ -2940,6 +2940,9 @@ function buildSnakeBoard(
       }
       const tile = new THREE.Mesh(tileGeo, materialSet.materials);
       tile.position.copy(tilePosition);
+      if (idx === TOTAL_BOARD_TILES) {
+        tile.scale.set(1.18, 1.05, 1.18);
+      }
       tile.castShadow = true;
       tile.receiveShadow = true;
       tile.userData.index = idx;
@@ -2957,7 +2960,7 @@ function buildSnakeBoard(
       }
       indexToPosition.set(idx, topPosition);
 
-      const label = createTileLabel(idx);
+      const label = createTileLabel(idx, idx === TOTAL_BOARD_TILES ? '🏆' : null);
       let labelY = tileTopY;
       if (idx === TOTAL_BOARD_TILES) {
         labelY += topTileLift;
@@ -3011,33 +3014,6 @@ function buildSnakeBoard(
     );
   });
 
-  const tileHundred = tileMeshes.get(TOTAL_BOARD_TILES);
-  if (tileHundred) {
-    const topLevelPlacement = levelPlacements[levelPlacements.length - 1];
-    const supportBaseY = topLevelPlacement.tileCenterY - tileHeight / 2;
-    const supportTopY = tileHundred.position.y - tileHeight / 2;
-    const supportHeight = Math.max(
-      TILE_100_SUPPORT_HEIGHT_EXTRA,
-      supportTopY - supportBaseY + TILE_100_SUPPORT_HEIGHT_EXTRA
-    );
-    const supportMaterial = new THREE.MeshStandardMaterial({
-      color: PYRAMID_CONCRETE_LIGHT.clone().lerp(PYRAMID_CONCRETE_SHADOW, 0.55),
-      roughness: 0.74,
-      metalness: 0.08,
-      emissive: PYRAMID_CONCRETE_ACCENT.clone().multiplyScalar(0.14),
-      emissiveIntensity: 0.18
-    });
-    const support = new THREE.Mesh(
-      new THREE.CylinderGeometry(TILE_100_SUPPORT_RADIUS * 0.85, TILE_100_SUPPORT_RADIUS, supportHeight, 24),
-      supportMaterial
-    );
-    support.position.set(tileHundred.position.x, supportBaseY + supportHeight / 2, tileHundred.position.z);
-    support.castShadow = true;
-    support.receiveShadow = true;
-    platformGroup.add(support);
-    platformMeshes.push(support);
-  }
-
   const baseHalf = (BASE_LEVEL_TILES * TILE_SIZE) / 2;
   const baseStart = new THREE.Vector3(
     -baseHalf - TILE_SIZE * 0.8,
@@ -3070,27 +3046,6 @@ function buildSnakeBoard(
 
   const reserveTokensGroup = new THREE.Group();
   boardStaticRoot.add(reserveTokensGroup);
-
-  const potGroup = new THREE.Group();
-  const coin = new THREE.Mesh(
-    new THREE.CylinderGeometry(TILE_SIZE * 0.24, TILE_SIZE * 0.24, TILE_SIZE * 0.12, 32),
-    new THREE.MeshStandardMaterial({
-      color: 0xf59e0b,
-      roughness: 0.3,
-      metalness: 0.4,
-      emissive: 0x332200,
-      emissiveIntensity: 0.25
-    })
-  );
-  coin.rotation.x = Math.PI / 2;
-  coin.position.y = COIN_LOCAL_LIFT;
-  coin.castShadow = true;
-  coin.receiveShadow = true;
-  potGroup.add(coin);
-  potGroup.userData.coin = coin;
-  const potPos = serpentineIndexToXZ(TOTAL_BOARD_TILES);
-  potGroup.position.set(potPos.x, potPos.y + COIN_RAISE, potPos.z);
-  boardRotationRoot.add(potGroup);
 
   const diceGroup = new THREE.Group();
   const baseLevelTop = levelPlacements[0].tileTopY;
@@ -3155,7 +3110,6 @@ function buildSnakeBoard(
     boardTokensGroup,
     reserveTokensGroup,
     serpentineIndexToXZ,
-    potGroup,
     labelGroup,
     diceGroup,
     diceSet,
@@ -4226,9 +4180,6 @@ export default function SnakeBoard3D({
         if (arena.updateHdriZoom) {
           const target = board?.boardLookTarget ?? arena.boardLookTarget;
           arena.updateHdriZoom(camera, target);
-        }
-        if (board?.potGroup) {
-          board.potGroup.rotation.y += deltaSeconds * COIN_SPIN_SPEED;
         }
         if (board?.seatAnchors?.length && seatCallbackRef.current) {
           const positions = board.seatAnchors.map((anchor, index) => {

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -4023,6 +4023,7 @@ export default function SnakeAndLadder() {
                   seatIndex: currentTurn
                 });
                 setPendingExtraRoll(false);
+                setPlayerAutoRolling(false);
               }}
               onRollEnd={(vals) => {
                 startDiceBoardAnimation({
@@ -4035,6 +4036,7 @@ export default function SnakeAndLadder() {
                   ? vals.some((v) => Number(v) === 6)
                   : Number(vals) === 6;
                 setPendingExtraRoll(rolledSix);
+                setPlayerAutoRolling(false);
               }}
             />
           ) : null}
@@ -4075,7 +4077,7 @@ export default function SnakeAndLadder() {
             open={showInfo}
             onClose={() => setShowInfo(false)}
             title="Snake & Ladder"
-            info="Roll one die each turn. A 6 enters your token onto the board and also grants an extra roll. Ladders lift you up and snakes bring you down. You must land exactly on the pot tile to win."
+            info="Roll one die each turn. A 6 enters your token onto the board and also grants an extra roll. Ladders lift you up and snakes bring you down. Land exactly on tile 50 (🏆) to win."
           />
         </div>
       )}
@@ -4084,7 +4086,7 @@ export default function SnakeAndLadder() {
           <HintPopup
             open={showExactHelp}
             onClose={() => setShowExactHelp(false)}
-            message="You must roll the exact number to land on the pot."
+            message="You must roll the exact number to land on tile 50 (🏆)."
           />
         </div>
       )}


### PR DESCRIPTION
### Motivation
- Players who roll a six should be able to manually roll again immediately and see the `ROLL` button; the UI currently hides or blocks that in some flows. 
- The board visual should use a single final tile as a podium rather than an elevated tower/pot, and the game must have exactly 50 playable tiles with tile 50 being the win tile.

### Description
- Allow immediate manual extra-rolls by resetting `playerAutoRolling` when a human roll begins and ends in `SnakeAndLadder` (added `setPlayerAutoRolling(false)` in `onRollStart`/`onRollEnd`).
- Make the board finish be tile 50 by setting `FINAL_TILE` to the layout cell count (`FINAL_TILE = BOARD_CELL_COUNT`) so the board uses exactly 50 playable tiles (changed in `SnakeBoard.jsx`).
- Remove the separate top/tower/pot presentation and instead highlight the final tile: enlarged final-tile scale and show a `🏆` label on the final tile in both 2D and 3D boards (changes in `SnakeBoard.jsx` and `SnakeBoard3D.jsx`).
- Remove the support/tower and coin pot objects from the 3D board and stop rotating/using them; add emoji-capable tile labels and scale tweaks for the podium tile (changes in `SnakeBoard3D.jsx`).
- Update help/hint text to explicitly reference landing on `tile 50 (🏆)` as the finish condition (change in `SnakeAndLadder.jsx`).

Files changed (key): `webapp/src/pages/Games/SnakeAndLadder.jsx`, `webapp/src/components/SnakeBoard.jsx`, `webapp/src/components/SnakeBoard3D.jsx`.

### Testing
- Built the web client with `npm --prefix webapp run build` and the build completed successfully.
- Ran the Snake unit/api tests with `npm test -- --runInBand test/snakeGame.test.js test/snakeApi.test.js`, both suites passed (tests passed but the repo test harness reports existing teardown open-handle warnings unrelated to these changes).
- Ran ESLint checks on the modified files (no new errors introduced; only repository ignore warnings observed during lint runs).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca1bfe99ec8329821ee4d99f6478de)