### PR TITLE
Align Domino HDRI resolutions with graphics refresh-rate profiles

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -4439,16 +4439,17 @@ const MAX_HDRI_CACHE_SIZE = prefersUhd ? 4 : isLowProfileDevice ? 1 : 2;
 function resolveHdriResolutionOrder() {
   switch (frameRateId) {
     case 'ultra144':
+      return ['8k'];
     case 'uhd120':
-      return ['8k', '4k', '2k', '1k'];
+      return ['8k', '6k'];
     case 'qhd90':
-      return ['6k', '4k', '2k', '1k'];
+      return ['6k', '4k'];
     case 'fhd60':
-      return ['4k', '2k', '1k'];
+      return ['4k', '2k'];
     default:
-      if (prefersUhd) return ['8k', '4k', '2k', '1k'];
-      if (isLowProfileDevice) return ['2k', '1k'];
-      return ['4k', '2k', '1k'];
+      if (prefersUhd) return ['8k', '6k'];
+      if (isLowProfileDevice) return ['4k', '2k'];
+      return ['4k', '2k'];
   }
 }
 function shouldLoadExternalHdri() {


### PR DESCRIPTION
### Motivation
- Ensure HDRI asset resolution choices follow the configured graphics profiles so environments match selected refresh-rate options (60/90/120/144 Hz).
- Avoid loading HDRI sizes that are inconsistent with the user's chosen graphics tier to improve visual fidelity and reduce unexpected bandwidth/CPU usage.

### Description
- Updated `resolveHdriResolutionOrder()` in `webapp/public/domino-royal-game.js` to map frame rate IDs to the requested HDRI resolutions: `fhd60` -> `['4k','2k']`, `qhd90` -> `['6k','4k']`, `uhd120` -> `['8k','6k']`, and `ultra144` -> `['8k']`.
- Adjusted the default/fallback branch to prefer `['8k','6k']` when `prefersUhd` is set and to return `['4k','2k']` for low-profile devices, keeping fallback behavior consistent with the new mappings.
- Changes are limited to resolution-selection logic for external HDRI loading and do not alter other asset-loading paths.

### Testing
- Searched and verified updated cases with `rg -n "resolveHdriResolutionOrder|case 'ultra144'|case 'uhd120'|case 'qhd90'|case 'fhd60'" webapp/public/domino-royal-game.js`, which returned the updated function locations and mappings and succeeded. 
- Inspected the modified function block with `nl -ba webapp/public/domino-royal-game.js | sed -n '4434,4468p'` to confirm the new resolution arrays and fallback branches were applied and the check succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca240095208329a740a1ec4b69bf1f)