### PR TITLE
Fix extra-roll CTA and make tile 50 the win podium

### DIFF
--- a/webapp/src/components/SnakeBoard.jsx
+++ b/webapp/src/components/SnakeBoard.jsx
@@ -110,7 +110,7 @@ function buildPyramidLayout() {
 
 const BOARD_LAYOUT = buildPyramidLayout();
 export const BOARD_CELL_COUNT = BOARD_LAYOUT.totalCells;
-export const FINAL_TILE = BOARD_CELL_COUNT + 1;
+export const FINAL_TILE = BOARD_CELL_COUNT;
 const BOARD_WIDTH_UNITS = BOARD_LAYOUT.widthUnits;
 const BOARD_HEIGHT_UNITS = BOARD_LAYOUT.heightUnits;
 const CENTER_COLUMN = BOARD_LAYOUT.centerColumn;
@@ -187,6 +187,7 @@ export default function SnakeBoard({
 
   const tileElements = layoutTiles.map((tile) => {
     const num = tile.cell;
+    const isWinTile = num === FINAL_TILE;
     const rowIndex = Math.floor(tile.row);
     const rowPos = BOARD_HEIGHT_UNITS > 1 ? rowIndex / (BOARD_HEIGHT_UNITS - 1) : 0;
     const scale = 1 + (rowIndex - 3) * SCALE_STEP;
@@ -230,7 +231,15 @@ export default function SnakeBoard({
       transform: `translate(${translateX}px, ${translateY}px) scaleX(${scaleX}) scaleY(${scale}) translateZ(5px)`,
       transformOrigin: "bottom center",
     };
+    if (isWinTile) {
+      style.transform = `translate(${translateX}px, ${translateY}px) scaleX(${scaleX * 1.22}) scaleY(${scale * 1.22}) translateZ(8px)`;
+    }
     if (!highlightClass) style.backgroundColor = "#6db0ad";
+    if (isWinTile) {
+      style.background = 'linear-gradient(145deg, #fbbf24, #f59e0b 58%, #b45309)';
+      style.boxShadow = '0 0 0 2px rgba(255,215,0,0.45), 0 10px 24px rgba(234,179,8,0.35)';
+      style.borderColor = 'rgba(255, 237, 213, 0.9)';
+    }
 
     return (
       <div
@@ -254,7 +263,11 @@ export default function SnakeBoard({
             )}
           </span>
         )}
-        {!cellType && <span className="cell-number">{num}</span>}
+        {!cellType && (
+          isWinTile
+            ? <span className="cell-number" aria-label="Win tile">🏆</span>
+            : <span className="cell-number">{num}</span>
+        )}
         {diceCells && diceCells[num] && (
           <span className="dice-marker">
             <img  src="/assets/icons/file_000000009160620a96f728f463de1c3f.webp" alt="dice" className="dice-icon" />
@@ -331,24 +344,6 @@ export default function SnakeBoard({
   const paddingTop = 0;
   const paddingBottom = '15vh';
 
-  const topLevel = BOARD_LAYOUT.levels[BOARD_LAYOUT.levels.length - 1];
-  const potRowIndex = topLevel.yOffset + topLevel.size - 1;
-  const potCol = topLevel.xOffset + (topLevel.size - 1) / 2;
-  const potRowPos = BOARD_HEIGHT_UNITS > 1 ? potRowIndex / (BOARD_HEIGHT_UNITS - 1) : 0;
-  const potScale = 1 + (potRowIndex - 3) * SCALE_STEP;
-  const potScaleX = potScale * (1 + potRowPos * WIDEN_STEP);
-  const potOffsetX = (potScaleX - 1) * cellWidth;
-  const potTranslateX = (potCol + 0.5 - CENTER_COLUMN) * potOffsetX;
-  const potTranslateY = -rowOffsets[potRowIndex] - cellHeight * 2.8;
-  const potStyle = {
-    gridRowStart: scaledRows - potRowIndex * GRID_SCALE - (GRID_SCALE - 1),
-    gridRowEnd: `span ${GRID_SCALE}`,
-    gridColumnStart: Math.round((potCol - 0.5) * GRID_SCALE) + 1,
-    gridColumnEnd: `span ${GRID_SCALE * 2}`,
-    transform: `translate(${potTranslateX}px, ${potTranslateY}px) scaleX(${potScaleX * 1.1}) scaleY(${potScale}) translateZ(12px)`,
-    transformOrigin: "bottom center",
-  };
-
   return (
     <div className="relative flex justify-center items-center w-screen overflow-visible">
       <img
@@ -390,52 +385,7 @@ export default function SnakeBoard({
             }}
           >
             {tileElements}
-            <div
-              className={`pot-cell ${highlight && highlight.cell === FINAL_TILE ? 'highlight' : ''}`}
-              style={potStyle}
-            >
-              <PlayerToken color="#16a34a" topColor="#ff0000" className="pot-token" />
-              <div className="pot-icon">
-                <img
-                  src={
-                    token === 'TON'
-                      ? '/assets/icons/TON.webp'
-                      : token === 'USDT'
-                        ? '/assets/icons/Usdt.webp'
-                        : '/assets/icons/ezgif-54c96d8a9b9236.webp'
-                  }
-
-                  alt={token}
-                  className="coin-face front"
-                />
-                <img
-                  src={
-                    token === 'TON'
-                      ? '/assets/icons/TON.webp'
-                      : token === 'USDT'
-                        ? '/assets/icons/Usdt.webp'
-                        : '/assets/icons/ezgif-54c96d8a9b9236.webp'
-                  }
-                  alt=""
-                  className="coin-face back"
-                />
-              </div>
-              {players
-                .map((p, i) => ({ ...p, index: i }))
-                .filter((p) => p.position === FINAL_TILE)
-                .map((p) => (
-                  <Fragment key={`win-${p.index}`}>
-                    <PlayerToken
-                      photoUrl={p.photoUrl}
-                      type={p.type || 'normal'}
-                      color={p.color}
-                      photoOnly
-                      className="board-token"
-                    />
-                  </Fragment>
-                ))}
-              {celebrate && <CoinBurst token={token} />}
-            </div>
+            {celebrate && <CoinBurst token={token} />}
           </div>
         </div>
       </div>

--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -185,8 +185,7 @@ const TILE_SIDE_EMISSIVE_SCALE = 0.25;
 const TILE_BOTTOM_EMISSIVE_SCALE = 0.1;
 
 const BENTONITE_EXTRA_SHRINK = [0.85, 0.92];
-const TILE_100_SUPPORT_RADIUS = TILE_SIZE * 0.58;
-const TILE_100_SUPPORT_HEIGHT_EXTRA = TILE_SIZE * 0.25;
+const WIN_TILE_SCALE = 1.22;
 
 const TOKEN_RADIUS_SCALE = 1.19;
 const TOKEN_SCALE_MULTIPLIER = 1;
@@ -245,8 +244,6 @@ const COIN_SPIN_SPEED = Math.PI / 7;
 const TEXTURE_REPEAT_SCALE = 0.85;
 const BOARD_ROTATION_DRAG_SPEED = 0.0065;
 const CAMERA_EXTRA_LIFT = 0.12;
-const COIN_RAISE = TILE_SIZE * 0.24;
-const COIN_LOCAL_LIFT = TILE_SIZE * 0.05;
 
 const AVATAR_ANCHOR_HEIGHT = SEAT_THICKNESS / 2 + BACK_HEIGHT * 0.85;
 
@@ -2935,11 +2932,11 @@ function buildSnakeBoard(
         tilePosition.x *= GROUND_FLOOR_OUTWARD_SCALE;
         tilePosition.z *= GROUND_FLOOR_OUTWARD_SCALE;
       }
-      if (idx === TOTAL_BOARD_TILES) {
-        tilePosition.y += topTileLift;
-      }
       const tile = new THREE.Mesh(tileGeo, materialSet.materials);
       tile.position.copy(tilePosition);
+      if (idx === TOTAL_BOARD_TILES) {
+        tile.scale.setScalar(WIN_TILE_SCALE);
+      }
       tile.castShadow = true;
       tile.receiveShadow = true;
       tile.userData.index = idx;
@@ -2957,7 +2954,7 @@ function buildSnakeBoard(
       }
       indexToPosition.set(idx, topPosition);
 
-      const label = createTileLabel(idx);
+      const label = createTileLabel(idx === TOTAL_BOARD_TILES ? '🏆' : idx);
       let labelY = tileTopY;
       if (idx === TOTAL_BOARD_TILES) {
         labelY += topTileLift;
@@ -3011,33 +3008,6 @@ function buildSnakeBoard(
     );
   });
 
-  const tileHundred = tileMeshes.get(TOTAL_BOARD_TILES);
-  if (tileHundred) {
-    const topLevelPlacement = levelPlacements[levelPlacements.length - 1];
-    const supportBaseY = topLevelPlacement.tileCenterY - tileHeight / 2;
-    const supportTopY = tileHundred.position.y - tileHeight / 2;
-    const supportHeight = Math.max(
-      TILE_100_SUPPORT_HEIGHT_EXTRA,
-      supportTopY - supportBaseY + TILE_100_SUPPORT_HEIGHT_EXTRA
-    );
-    const supportMaterial = new THREE.MeshStandardMaterial({
-      color: PYRAMID_CONCRETE_LIGHT.clone().lerp(PYRAMID_CONCRETE_SHADOW, 0.55),
-      roughness: 0.74,
-      metalness: 0.08,
-      emissive: PYRAMID_CONCRETE_ACCENT.clone().multiplyScalar(0.14),
-      emissiveIntensity: 0.18
-    });
-    const support = new THREE.Mesh(
-      new THREE.CylinderGeometry(TILE_100_SUPPORT_RADIUS * 0.85, TILE_100_SUPPORT_RADIUS, supportHeight, 24),
-      supportMaterial
-    );
-    support.position.set(tileHundred.position.x, supportBaseY + supportHeight / 2, tileHundred.position.z);
-    support.castShadow = true;
-    support.receiveShadow = true;
-    platformGroup.add(support);
-    platformMeshes.push(support);
-  }
-
   const baseHalf = (BASE_LEVEL_TILES * TILE_SIZE) / 2;
   const baseStart = new THREE.Vector3(
     -baseHalf - TILE_SIZE * 0.8,
@@ -3072,24 +3042,8 @@ function buildSnakeBoard(
   boardStaticRoot.add(reserveTokensGroup);
 
   const potGroup = new THREE.Group();
-  const coin = new THREE.Mesh(
-    new THREE.CylinderGeometry(TILE_SIZE * 0.24, TILE_SIZE * 0.24, TILE_SIZE * 0.12, 32),
-    new THREE.MeshStandardMaterial({
-      color: 0xf59e0b,
-      roughness: 0.3,
-      metalness: 0.4,
-      emissive: 0x332200,
-      emissiveIntensity: 0.25
-    })
-  );
-  coin.rotation.x = Math.PI / 2;
-  coin.position.y = COIN_LOCAL_LIFT;
-  coin.castShadow = true;
-  coin.receiveShadow = true;
-  potGroup.add(coin);
-  potGroup.userData.coin = coin;
   const potPos = serpentineIndexToXZ(TOTAL_BOARD_TILES);
-  potGroup.position.set(potPos.x, potPos.y + COIN_RAISE, potPos.z);
+  potGroup.position.set(potPos.x, potPos.y, potPos.z);
   boardRotationRoot.add(potGroup);
 
   const diceGroup = new THREE.Group();

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -2170,6 +2170,7 @@ export default function SnakeAndLadder() {
         if (turnBelongsToMe) {
           // Keep roll CTA visible for immediate extra turns.
           setRollCooldown(0);
+          setMoving(false);
         }
         if (!turnBelongsToMe) setPendingExtraRoll(false);
       }
@@ -4035,6 +4036,8 @@ export default function SnakeAndLadder() {
                   ? vals.some((v) => Number(v) === 6)
                   : Number(vals) === 6;
                 setPendingExtraRoll(rolledSix);
+                if (rolledSix) setTurnMessage('Six! Roll again');
+                setMoving(false);
               }}
             />
           ) : null}


### PR DESCRIPTION
### Motivation
- Players who roll a 6 should be able to immediately roll again and see the roll CTA; the UI was leaving the turn with the human but the local roll button remained hidden due to a stale movement state. 
- The board should have exactly 50 playable tiles and the final playable tile must act as the win podium (bigger/trophy) instead of a separate tower/pot object.

### Description
- Ensure local extra-roll CTA is visible and responsive after a 6 by clearing the local movement lock when a turn is assigned to the local player (`setMoving(false)` on turn update) and restoring the "Six! Roll again" prompt at multiplayer roll end. (changes in `SnakeAndLadder.jsx`).
- Make the final playable tile equal to the board cell count (no extra top tile): set `FINAL_TILE = BOARD_CELL_COUNT` so the last playable tile is tile 50 (`SnakeBoard.jsx`).
- 2D board: remove the separate pot/tower UI and style tile 50 as a podium — increase its scale, add gradient/box-shadow styling and render a trophy emoji on the cell instead of a separate pot element (`SnakeBoard.jsx`).
- 3D board: remove the extra top support/tower and separate coin pot geometry, enlarge the final tile and label it with a trophy, and adjust placement so the final tile itself acts as the win podium (`SnakeBoard3D.jsx`).
- Minor related adjustments to dice/roll flow to ensure `pendingExtraRoll` and `moving` states behave correctly when a six/bonus roll occurs (updates in `SnakeAndLadder.jsx` DiceRoller handlers).

### Testing
- Built the web client: `npm --prefix webapp run build` completed successfully (production build produced without errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca1bfe99ec8329821ee4d99f6478de)