### PR TITLE
Align Domino Battle Royale HDRI resolution fallback with graphics tiers

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -4430,6 +4430,7 @@ const HDRI_RESOLUTION_ORDER = Object.freeze([
   '1k',
   '2k',
   '4k',
+  '6k',
   '8k',
   '16k'
 ]);
@@ -4448,21 +4449,22 @@ const MAX_HDRI_CACHE_SIZE = prefersUhd ? 4 : isLowProfileDevice ? 1 : 2;
 function resolveHdriResolutionOrder() {
   switch (frameRateId) {
     case 'ultra144':
+      return ['8k'];
     case 'uhd120':
-      return ['8k', '4k', '2k', '1k'];
+      // Poly Haven may not host every asset in 6k, but we still try 6k first to match graphics profile.
+      return ['8k', '6k'];
     case 'qhd90':
-      // Poly Haven HDRIs do not provide a native 6k tier, so use 8k with 4k fallback.
-      return ['8k', '4k', '2k', '1k'];
+      return ['6k', '4k'];
     case 'fhd60':
-      return ['4k', '2k', '1k'];
+      return ['4k', '2k'];
     default:
-      if (prefersUhd) return ['8k', '4k', '2k', '1k'];
-      if (isLowProfileDevice) return ['2k', '1k'];
-      return ['4k', '2k', '1k'];
+      if (prefersUhd) return ['8k', '6k'];
+      if (isLowProfileDevice) return ['2k'];
+      return ['4k', '2k'];
   }
 }
 function shouldLoadExternalHdri() {
-  // Keep HDRI enabled on mobile/Telegram too (at 1k) so players still see purchased environments.
+  // Keep HDRI enabled on mobile/Telegram so players still see purchased environments.
   return true;
 }
 


### PR DESCRIPTION
### Motivation
- HDRI selection used by the Domino Battle Royale scene did not match the in-game graphics presets, causing mismatched quality and unexpected fallbacks for different refresh-rate profiles.
- The desired mapping is: 60 Hz → `4k` with `2k` fallback, 90 Hz → `6k` with `4k` fallback, 120 Hz → `8k` with `6k` fallback, and 144 Hz → `8k`.

### Description
- Added `6k` to `HDRI_RESOLUTION_ORDER` so the resolution list includes the newly used tier (`webapp/public/domino-royal-game.js`).
- Updated `resolveHdriResolutionOrder()` to return profile-aligned orders: `fhd60` → `['4k','2k']`, `qhd90` → `['6k','4k']`, `uhd120` → `['8k','6k']`, and `ultra144` → `['8k']`, plus matching defaults for `prefersUhd` and low-profile devices (`webapp/public/domino-royal-game.js`).
- Adjusted a nearby comment to remove outdated wording about `1k` mobile behavior so comments reflect the new fallback behavior (`webapp/public/domino-royal-game.js`).

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` which completed without syntax errors.
- Basic smoke validation performed by loading the modified file locally (static check) and ensuring the loader logic still calls the same HDRI loader paths; no runtime tests were included in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca283c54c48329bca62b4b975ab0f1)