### PR TITLE
Pool Royale: remove voice commentary UI/store, refine replays & AI aim, nudge short-rail cushions

### DIFF
--- a/bot/utils/voiceCommentaryCatalog.js
+++ b/bot/utils/voiceCommentaryCatalog.js
@@ -161,23 +161,6 @@ export function normalizeVoiceInventory(rawInventory) {
   };
 }
 
-export function buildVoiceStoreItems(catalog) {
-  const languageMap = new Map();
-  for (const voice of catalog.voices) {
-    const key = `${voice.language}|${voice.locale.split('-')[0]}`;
-    if (!languageMap.has(key)) {
-      languageMap.set(key, {
-        id: `voice-${voice.locale.toLowerCase()}`,
-        type: 'voiceLanguage',
-        optionId: voice.locale,
-        name: `${voice.language} Commentary Pack`,
-        description: `${voice.language} commentary voices for all games`,
-        price: voice.locale.toLowerCase().startsWith('en-') ? 0 : 2200,
-        voiceIds: []
-      });
-    }
-    languageMap.get(key).voiceIds.push(voice.id);
-  }
-
-  return Array.from(languageMap.values()).sort((a, b) => a.name.localeCompare(b.name));
+export function buildVoiceStoreItems(_catalog) {
+  return [];
 }

--- a/test/voiceCommentaryUnlocks.test.js
+++ b/test/voiceCommentaryUnlocks.test.js
@@ -35,18 +35,14 @@ test('voice unlock grants locale voices for all games', () => {
   assert.ok(normalized.ownedLocales.includes('it-IT'));
 });
 
-test('store item builder keeps English free and paid multilingual packs', () => {
+test('store item builder omits voice commentary packs', () => {
   const items = buildVoiceStoreItems({
     voices: [
       { id: 'nova_en_us_f', locale: 'en-US', language: 'English' },
-      { id: 'atlas_en_us_m', locale: 'en-US', language: 'English' },
       { id: 'sofia_it_it_f', locale: 'it-IT', language: 'Italian' }
     ]
   });
-  const en = items.find((item) => item.optionId === 'en-US');
-  const it = items.find((item) => item.optionId === 'it-IT');
-  assert.equal(en.price, 0);
-  assert.ok(it.price > 0);
+  assert.deepEqual(items, []);
 });
 
 

--- a/webapp/src/config/voiceCommentaryInventoryConfig.js
+++ b/webapp/src/config/voiceCommentaryInventoryConfig.js
@@ -16,21 +16,7 @@ const VOICE_LANGUAGE_PACKS = [
 ];
 
 export const VOICE_COMMENTARY_OPTION_LABELS = {
-  voiceLanguage: VOICE_LANGUAGE_PACKS.reduce((acc, pack) => {
-    acc[pack.locale] = `${pack.language} (${pack.locale})`;
-    return acc;
-  }, {})
+  voiceLanguage: {}
 };
 
-export const VOICE_COMMENTARY_STORE_ITEMS = VOICE_LANGUAGE_PACKS.map((pack) => ({
-  id: `voice-${pack.locale.toLowerCase()}`,
-  type: 'voiceLanguage',
-  optionId: pack.locale,
-  name: `${pack.language} Commentary Pack`,
-  description:
-    pack.price === 0
-      ? 'Default free English commentary for all games.'
-      : `${pack.language} commentary voice unlock for all games.`,
-  price: pack.price,
-  rarity: pack.price === 0 ? 'free' : 'premium'
-}));
+export const VOICE_COMMENTARY_STORE_ITEMS = [];

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1935,7 +1935,7 @@ let SIDE_CUSHION_CUT_ANGLE = DEFAULT_SIDE_CUSHION_CUT_ANGLE;
 let SIDE_POCKET_PHYSICS_CUT_ANGLE = DEFAULT_SIDE_POCKET_PHYSICS_CUT_ANGLE;
 const CUSHION_BACK_TRIM = 0.8; // trim 20% off the cushion back that meets the rails
 const CUSHION_FACE_INSET_LONG = SIDE_RAIL_INNER_THICKNESS * 0.58; // pull long-rail cushions farther inward toward the table center
-const CUSHION_FACE_INSET_SHORT = SIDE_RAIL_INNER_THICKNESS * 0.46; // pull short-rail cushions slightly inward to match
+const CUSHION_FACE_INSET_SHORT = SIDE_RAIL_INNER_THICKNESS * 0.42; // move short-rail cushions a touch outward to match the early-morning table profile
 
 // shared UI reduction factor so overlays and controls shrink alongside the table
 
@@ -5615,6 +5615,8 @@ const BREAK_DICE_RESULT_PAUSE_MS = 720;
 const BREAK_DICE_ROLL_SOUND_URL = '/assets/sounds/u_qpfzpydtro-dice-142528.mp3';
 const REPLAY_CUE_MIN_PULLBACK_MS = 360; // keep replay wind-up visible without consuming the whole replay window
 const REPLAY_CUE_MIN_RELEASE_MS = 0; // defer to recorded stroke durations like Snooker Royal
+const REPLAY_FOUL_IMPACT_SLOW_SCALE = 0.32;
+const REPLAY_FOUL_IMPACT_WINDOW_MS = 220;
 const CUE_STROKE_POST_HIT_CAMERA_HOLD_MS = 420;
 // Keep the live stroke timing aligned with the reference cue motion:
 // quick push forward and a short hold before snapping back to idle.
@@ -22319,11 +22321,23 @@ const powerRef = useRef(hud.power);
               )
             : 180;
           replayCueHiddenRef.current = { hideFrom: replayCueHideFrom, hideUntil: duration };
+          const replaySlowZones = Array.isArray(shotRecording?.replaySlowZones)
+            ? shotRecording.replaySlowZones
+            : [];
+          const replaySlowdownExtraMs = replaySlowZones.reduce((total, zone) => {
+            if (!Number.isFinite(zone?.start) || !Number.isFinite(zone?.end)) return total;
+            const len = Math.max(0, zone.end - zone.start);
+            if (len <= 0) return total;
+            const scale = THREE.MathUtils.clamp(zone.scale ?? 1, 0.05, 1);
+            return total + Math.max(0, len / scale - len);
+          }, 0);
           replayPlayback = {
             frames: trimmed.frames,
             cuePath: trimmed.cuePath,
             cueStroke: replayCueStroke,
-            duration,
+            sourceDuration: duration,
+            slowZones: replaySlowZones,
+            duration: duration + replaySlowdownExtraMs,
             startedAt: performance.now(),
             lastIndex: 0,
             postState: postShotSnapshot,
@@ -22349,6 +22363,39 @@ const powerRef = useRef(hud.power);
               };
             }
           }
+        };
+
+        const mapReplayElapsedToSourceTime = (elapsed, sourceDuration, slowZones = []) => {
+          if (!Array.isArray(slowZones) || slowZones.length === 0) {
+            return Math.min(Math.max(elapsed, 0), sourceDuration);
+          }
+          const sorted = slowZones
+            .filter((zone) => Number.isFinite(zone?.start) && Number.isFinite(zone?.end) && zone.end > zone.start)
+            .map((zone) => ({
+              start: Math.max(0, Math.min(sourceDuration, zone.start)),
+              end: Math.max(0, Math.min(sourceDuration, zone.end)),
+              scale: THREE.MathUtils.clamp(zone.scale ?? 1, 0.05, 1)
+            }))
+            .filter((zone) => zone.end > zone.start)
+            .sort((a, b) => a.start - b.start);
+          if (!sorted.length) return Math.min(Math.max(elapsed, 0), sourceDuration);
+          let added = 0;
+          const clampedElapsed = Math.max(0, elapsed);
+          for (const zone of sorted) {
+            const zoneLen = zone.end - zone.start;
+            const slowedLen = zoneLen / zone.scale;
+            const zoneStartOnTimeline = zone.start + added;
+            const zoneEndOnTimeline = zoneStartOnTimeline + slowedLen;
+            if (clampedElapsed < zoneStartOnTimeline) {
+              return Math.min(sourceDuration, clampedElapsed - added);
+            }
+            if (clampedElapsed <= zoneEndOnTimeline) {
+              const zoneElapsed = clampedElapsed - zoneStartOnTimeline;
+              return Math.min(sourceDuration, zone.start + zoneElapsed * zone.scale);
+            }
+            added += slowedLen - zoneLen;
+          }
+          return Math.min(sourceDuration, clampedElapsed - added);
         };
 
         const waitMs = (ms = 0) =>
@@ -24964,6 +25011,7 @@ const powerRef = useRef(hud.power);
       let potted = [];
       const pottedIds = new Set();
       let firstHit = null;
+      let firstHitReplayTime = null;
 
       const alignStandingCameraToAim = (
         cueBall,
@@ -25276,6 +25324,7 @@ const powerRef = useRef(hud.power);
         potted = [];
         pottedIds.clear();
         firstHit = null;
+        firstHitReplayTime = null;
         clearInterval(timerRef.current);
         const aimDir = aimDirRef.current.clone();
         if (aimDir.lengthSq() < 1e-6) {
@@ -28266,7 +28315,7 @@ const powerRef = useRef(hud.power);
             ballRadius: BALL_R,
             spin: plan.spin,
             power: plan.power,
-            contactCalibration: 0
+            contactCalibration: 0.02
           });
           const baseDir =
             compensated?.aimDir?.lengthSq?.() > 1e-6
@@ -28276,7 +28325,7 @@ const powerRef = useRef(hud.power);
           const targetId = String(plan.targetBall.id);
           const toPocketRef = plan.pocketCenter.clone().sub(plan.targetBall.pos);
           const bestRef = { dir: baseDir, score: -Infinity };
-          const scanDegrees = [-2.4, -1.6, -0.9, -0.45, 0, 0.45, 0.9, 1.6, 2.4];
+          const scanDegrees = [-3, -2.2, -1.6, -1.05, -0.6, -0.3, 0, 0.3, 0.6, 1.05, 1.6, 2.2, 3];
           scanDegrees.forEach((deg) => {
             const rotated = baseDir
               .clone()
@@ -28330,9 +28379,10 @@ const powerRef = useRef(hud.power);
           pottedBalls,
           shotContext
         }) => {
-          if (!recording || !hadObjectPot) return null;
+          const hadAnyPot = Array.isArray(pottedBalls) && pottedBalls.length > 0;
+          if (!recording || !hadAnyPot) return null;
           const tags = new Set(recording.replayTags ?? []);
-          if (hadObjectPot) tags.add('pot');
+          if (hadObjectPot || hadAnyPot) tags.add('pot');
           const potCount = pottedBalls.filter((entry) => entry.id !== 'cue').length;
           if (potCount > 1) tags.add('multi');
           if (shotContext?.cushionAfterContact) tags.add('bank');
@@ -28539,6 +28589,20 @@ const powerRef = useRef(hud.power);
           shotRecording.replayFoul = safeState?.foul
             ? { ...safeState.foul }
             : null;
+          const foulReason = String(safeState?.foul?.reason || '').toLowerCase();
+          const wrongBallFoul = /wrong|illegal|not\s*on|first\s*contact/.test(foulReason);
+          if (wrongBallFoul && Number.isFinite(firstHitReplayTime)) {
+            const impactStart = Math.max(0, firstHitReplayTime - REPLAY_FOUL_IMPACT_WINDOW_MS * 0.35);
+            shotRecording.replaySlowZones = [
+              {
+                start: impactStart,
+                end: impactStart + REPLAY_FOUL_IMPACT_WINDOW_MS,
+                scale: REPLAY_FOUL_IMPACT_SLOW_SCALE
+              }
+            ];
+          } else {
+            shotRecording.replaySlowZones = [];
+          }
         }
         const shotWasFoul = Boolean(safeState?.foul);
         if (shotWasFoul && (shotRecording?.frames?.length ?? 0) > 1) {
@@ -28936,6 +29000,7 @@ const powerRef = useRef(hud.power);
           potted = [];
           pottedIds.clear();
           firstHit = null;
+          firstHitReplayTime = null;
       lastShotPower = 0;
     }
   }
@@ -28975,7 +29040,12 @@ const powerRef = useRef(hud.power);
             return;
           }
           try {
-            const targetTime = Math.min(elapsed, duration);
+            const sourceDuration = Number.isFinite(playback.sourceDuration) ? playback.sourceDuration : duration;
+            const targetTime = mapReplayElapsedToSourceTime(
+              Math.min(elapsed, duration),
+              sourceDuration,
+              playback.slowZones
+            );
             let frameIndex = playback.lastIndex ?? 0;
             while (frameIndex < frames.length - 1 && frames[frameIndex + 1].t <= targetTime) {
               frameIndex += 1;
@@ -30383,6 +30453,9 @@ const powerRef = useRef(hud.power);
                 if (!firstHit) {
                   if (a.id === 'cue' && b.id !== 'cue') firstHit = b.id;
                   else if (b.id === 'cue' && a.id !== 'cue') firstHit = a.id;
+                  if (shotRecording?.startTime != null) {
+                    firstHitReplayTime = Math.max(0, performance.now() - shotRecording.startTime);
+                  }
                 }
                 if (
                   !shotContextRef.current.contactMade &&
@@ -32753,69 +32826,6 @@ const powerRef = useRef(hud.power);
                     {skipAllReplays ? 'On' : 'Off'}
                   </span>
                 </button>
-              </div>
-              <div>
-                <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
-                  Commentary
-                </h3>
-                <div className="mt-2 grid gap-2">
-                  {POOL_ROYALE_COMMENTARY_PRESETS.map((preset) => {
-                    const active = preset.id === commentaryPresetId;
-                    return (
-                      <button
-                        key={preset.id}
-                        type="button"
-                        onClick={() => setCommentaryPresetId(preset.id)}
-                        aria-pressed={active}
-                        disabled={!commentarySupported}
-                        className={`w-full rounded-2xl border px-3 py-2 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
-                          active
-                            ? 'border-emerald-300 bg-emerald-300/15 shadow-[0_0_12px_rgba(16,185,129,0.35)]'
-                            : 'border-white/10 bg-white/5 hover:border-white/20 text-white/80'
-                        } ${commentarySupported ? '' : 'cursor-not-allowed opacity-60'}`}
-                      >
-                        <span className="flex items-center justify-between gap-2">
-                          <span className="text-[11px] font-semibold uppercase tracking-[0.26em] text-white">{preset.label}</span>
-                          {active && (
-                            <span className="rounded-full border border-emerald-200/70 px-2 py-0.5 text-[9px] tracking-[0.3em] text-emerald-100">
-                              Active
-                            </span>
-                          )}
-                        </span>
-                        <span className="mt-1 block text-[10px] uppercase tracking-[0.2em] text-white/60">
-                          {preset.description}
-                        </span>
-                      </button>
-                    );
-                  })}
-                </div>
-                <button
-                  type="button"
-                  onClick={() => setCommentaryMuted((prev) => !prev)}
-                  aria-pressed={commentaryMuted}
-                  disabled={!commentarySupported}
-                  className={`mt-2 flex w-full items-center justify-between gap-3 rounded-full px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.24em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
-                    commentaryMuted
-                      ? 'bg-emerald-400 text-black shadow-[0_0_18px_rgba(16,185,129,0.65)]'
-                      : 'bg-white/10 text-white/80 hover:bg-white/20'
-                  } ${commentarySupported ? '' : 'cursor-not-allowed opacity-60'}`}
-                >
-                  <span>Mute commentary</span>
-                  <span
-                    className={`rounded-full border px-2 py-0.5 text-[10px] tracking-[0.3em] ${
-                      commentaryMuted
-                        ? 'border-black/30 text-black/70'
-                        : 'border-white/30 text-white/70'
-                    }`}
-                  >
-                    {commentaryMuted ? 'On' : 'Off'}
-                  </span>
-                </button>
-                {!commentarySupported && (
-                  <p className="mt-2 text-[0.65rem] text-white/60">
-                    Voice commentary requires Web Speech support.
-                  </p>
-                )}
               </div>
               <div>
                 <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">


### PR DESCRIPTION
### Motivation
- Remove in-game voice commentary controls and purchasable voice packs from menu/store to stop commentary being presented or sold in Pool Royale and related surfaces.
- Restore and tighten replay behaviour so replays trigger reliably on potted-ball events and on fouls, while slowing only the impact moment for wrong-ball/illegal-first-contact fouls.
- Improve AI pot aiming so AI shots are more accurate by refining contact compensation and sampling resolution.
- Adjust short-rail cushion geometry to match the requested early-morning table profile.

### Description
- Removed the in-game Commentary UI block from the Pool Royale settings menu so commentary presets and the mute toggle are no longer exposed in that panel (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Disabled voice commentary store items by making the store builder return an empty list and clearing the web config store array (`bot/utils/voiceCommentaryCatalog.js` and `webapp/src/config/voiceCommentaryInventoryConfig.js`).
- Changed replay decision logic to consider any potted-ball events for triggering replays and to keep foul replays forced where appropriate, and updated the decision path accordingly (`resolveReplayDecision` adjustments in `PoolRoyale.jsx`).
- Added targeted replay slow zones and mapping logic so the replay timeline can slow only a short window around the recorded first-contact impact for wrong/illegal-first-contact fouls, using `REPLAY_FOUL_IMPACT_SLOW_SCALE`, `REPLAY_FOUL_IMPACT_WINDOW_MS`, `replaySlowZones`, and `mapReplayElapsedToSourceTime` (`PoolRoyale.jsx`).
- Captured a replay-anchored first-hit timestamp (`firstHitReplayTime`) when the cue first hits another ball and used it to anchor foul-impact slow zones (`PoolRoyale.jsx`).
- Improved AI pot aim refinement by increasing `contactCalibration` slightly and widening the angular `scanDegrees` sampling to better find robust pot lines (`PoolRoyale.jsx`).
- Nudged short-rail cushions outward by changing `CUSHION_FACE_INSET_SHORT` from `* 0.46` to `* 0.42` to match the requested table profile (`PoolRoyale.jsx`).
- Updated the voice commentary unit test to expect the voice store builder now returns an empty array (`test/voiceCommentaryUnlocks.test.js`).

### Testing
- Ran unit tests: `npm test -- --runInBand test/voiceCommentaryUnlocks.test.js test/poolRoyaleAimSuggestion.test.js` and both test suites passed (2/2 suites, 8/8 tests passed).
- Ran lint check: `npx eslint webapp/src/pages/Games/PoolRoyale.jsx bot/utils/voiceCommentaryCatalog.js webapp/src/config/voiceCommentaryInventoryConfig.js test/voiceCommentaryUnlocks.test.js` which completed but reported repository ignore warnings only (no blocking errors).
- No runtime / manual playtests were performed as part of these automated checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca33617a288329a073ac5ade339195)