### PR TITLE
Texas Hold'em: remove commentary from menu and add HDRI 4K/6K/8K selector

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -469,7 +469,6 @@ const CHAIR_MODEL_URLS = [
 
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
 const BASIS_TRANSCODER_PATH = 'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/';
-const PREFERRED_HDRI_RESOLUTIONS = Object.freeze(['2k', '1k']);
 const HDRI_ENV_CACHE_LIMIT = 4;
 const DEFAULT_TABLE_THEME_ID = TEXAS_TABLE_THEME_OPTIONS[0]?.id ?? 'murlan-default';
 const TEXAS_DEFAULT_HDRI_INDEX = Math.max(
@@ -614,6 +613,25 @@ const CARD_HIGHLIGHT_COLOR = '#facc15';
 const CARD_HIGHLIGHT = new THREE.Color(CARD_HIGHLIGHT_COLOR);
 const CARD_EMISSIVE_OFF = new THREE.Color(0x000000);
 const FRAME_RATE_STORAGE_KEY = 'texasHoldemFrameRate';
+const HDRI_RESOLUTION_STORAGE_KEY = 'texasHoldemHdriResolution';
+const HDRI_RESOLUTION_OPTIONS = Object.freeze([
+  {
+    id: '8k',
+    label: '8K HDRI',
+    preferredResolutions: Object.freeze(['8k', '6k', '4k', '2k', '1k'])
+  },
+  {
+    id: '6k',
+    label: '6K HDRI',
+    preferredResolutions: Object.freeze(['6k', '4k', '2k', '1k'])
+  },
+  {
+    id: '4k',
+    label: '4K HDRI',
+    preferredResolutions: Object.freeze(['4k', '2k', '1k'])
+  }
+]);
+const DEFAULT_HDRI_RESOLUTION_ID = '4k';
 const FRAME_RATE_OPTIONS = Object.freeze([
   {
     id: 'hd50',
@@ -1263,15 +1281,16 @@ async function createFallbackHdriEnvironment(renderer) {
   return { envMap: texture, url: null };
 }
 
-async function loadPolyHavenHdriEnvironment(renderer, config = {}) {
+async function loadPolyHavenHdriEnvironment(renderer, config = {}, preferredResolutions = null) {
   if (!renderer) return null;
-  const cacheKey = String(config?.id || config?.assetId || config?.fallbackUrl || 'fallback');
+  const preferredKey = Array.isArray(preferredResolutions) ? preferredResolutions.join('|') : '';
+  const cacheKey = `${String(config?.id || config?.assetId || config?.fallbackUrl || 'fallback')}::${preferredKey || 'auto'}`;
   const cached = HDRI_ENVIRONMENT_CACHE.get(cacheKey);
   if (cached?.envMap) {
     rememberHdriEnvironment(cacheKey, cached);
     return { ...cached, fromCache: true, cacheKey };
   }
-  const url = await resolveTexasHoldemHdriUrl(config, PREFERRED_HDRI_RESOLUTIONS);
+  const url = await resolveTexasHoldemHdriUrl(config, preferredResolutions || undefined);
   const resolveFallback = async () => {
     try {
       return await createFallbackHdriEnvironment(renderer);
@@ -3030,6 +3049,7 @@ function TexasHoldemArena({ search }) {
   const envTextureRef = useRef(null);
   const hdriApplyRequestRef = useRef(0);
   const hdriFallbackRetryCountRef = useRef(0);
+  const hdriResolutionModeRef = useRef(DEFAULT_HDRI_RESOLUTION_ID);
   const ensureAppearanceUnlocked = useCallback(
     (value = DEFAULT_APPEARANCE) => {
       const normalized = normalizeAppearance(value);
@@ -3112,6 +3132,32 @@ function TexasHoldemArena({ search }) {
     () => FRAME_RATE_OPTIONS.find((opt) => opt.id === frameRateId) ?? FRAME_RATE_OPTIONS[0],
     [frameRateId]
   );
+  const [hdriResolutionId, setHdriResolutionId] = useState(() => {
+    if (typeof window !== 'undefined') {
+      const stored = window.localStorage?.getItem(HDRI_RESOLUTION_STORAGE_KEY);
+      if (stored && HDRI_RESOLUTION_OPTIONS.some((opt) => opt.id === stored)) {
+        return stored;
+      }
+    }
+    return DEFAULT_HDRI_RESOLUTION_ID;
+  });
+  const activeHdriResolutionOption = useMemo(
+    () =>
+      HDRI_RESOLUTION_OPTIONS.find((opt) => opt.id === hdriResolutionId) ??
+      HDRI_RESOLUTION_OPTIONS[HDRI_RESOLUTION_OPTIONS.length - 1],
+    [hdriResolutionId]
+  );
+  const hdriPreferredResolutions = useMemo(
+    () => activeHdriResolutionOption?.preferredResolutions || HDRI_RESOLUTION_OPTIONS[2].preferredResolutions,
+    [activeHdriResolutionOption]
+  );
+  const hdriPreferredResolutionsRef = useRef(hdriPreferredResolutions);
+  useEffect(() => {
+    hdriPreferredResolutionsRef.current = hdriPreferredResolutions;
+  }, [hdriPreferredResolutions]);
+  useEffect(() => {
+    hdriResolutionModeRef.current = hdriResolutionId;
+  }, [hdriResolutionId]);
   const frameQualityProfile = useMemo(() => {
     const option = activeFrameRateOption ?? FRAME_RATE_OPTIONS[0];
     const fallback = FRAME_RATE_OPTIONS[0];
@@ -3168,6 +3214,13 @@ function TexasHoldemArena({ search }) {
       console.warn("Failed to persist Texas Hold'em graphics", error);
     }
   }, [frameRateId]);
+  useEffect(() => {
+    try {
+      window.localStorage?.setItem(HDRI_RESOLUTION_STORAGE_KEY, hdriResolutionId);
+    } catch (error) {
+      console.warn("Failed to persist Texas Hold'em HDRI resolution", error);
+    }
+  }, [hdriResolutionId]);
   const [configOpen, setConfigOpen] = useState(false);
   const timerRef = useRef(null);
   const turnIntervalRef = useRef(null);
@@ -4243,12 +4296,23 @@ function TexasHoldemArena({ search }) {
       if (!activeVariant) return;
       const activeVariantId = activeVariant.id || activeVariant.assetId;
       const currentVariantId = hdriVariantRef.current?.id || hdriVariantRef.current?.assetId;
-      if (envTextureRef.current && activeVariantId && currentVariantId === activeVariantId) {
+      const activeResolutionMode = hdriResolutionModeRef.current || DEFAULT_HDRI_RESOLUTION_ID;
+      const currentResolutionMode = envTextureRef.current?.userData?.hdriResolutionMode;
+      if (
+        envTextureRef.current &&
+        activeVariantId &&
+        currentVariantId === activeVariantId &&
+        currentResolutionMode === activeResolutionMode
+      ) {
         return;
       }
       const requestToken = (hdriApplyRequestRef.current || 0) + 1;
       hdriApplyRequestRef.current = requestToken;
-      const envResult = await loadPolyHavenHdriEnvironment(three.renderer, activeVariant);
+      const envResult = await loadPolyHavenHdriEnvironment(
+        three.renderer,
+        activeVariant,
+        hdriPreferredResolutionsRef.current
+      );
       if (!envResult?.envMap) return;
       const usedFallbackEnvironment = !envResult.url;
       if (usedFallbackEnvironment) {
@@ -4278,6 +4342,10 @@ function TexasHoldemArena({ search }) {
         three.scene.environmentIntensity = activeVariant.environmentIntensity;
       }
       three.renderer.toneMappingExposure = activeVariant?.exposure ?? three.renderer.toneMappingExposure;
+      envResult.envMap.userData = {
+        ...(envResult.envMap.userData || {}),
+        hdriResolutionMode: activeResolutionMode
+      };
       envTextureRef.current = envResult.envMap;
       disposeEnvironmentRef.current = () => {
         if (three.scene) {
@@ -4299,6 +4367,17 @@ function TexasHoldemArena({ search }) {
     },
     []
   );
+
+  useEffect(() => {
+    if (!threeRef.current?.renderer) return;
+    const currentVariant =
+      hdriVariantRef.current ||
+      TEXAS_HDRI_OPTIONS[appearance.environmentHdri] ||
+      TEXAS_HDRI_OPTIONS[TEXAS_DEFAULT_HDRI_INDEX] ||
+      TEXAS_HDRI_OPTIONS[0];
+    if (!currentVariant) return;
+    void applyHdriEnvironment(currentVariant);
+  }, [applyHdriEnvironment, appearance.environmentHdri, hdriResolutionId]);
 
   useEffect(() => {
     const mount = mountRef.current;
@@ -6379,72 +6458,34 @@ function TexasHoldemArena({ search }) {
               </div>
             </div>
             <div className="rounded-xl border border-white/10 bg-white/5 p-3 space-y-2">
-              <p className="text-[10px] uppercase tracking-[0.35em] text-white/70">Commentary</p>
-              <div className="grid gap-2">
-                {TEXAS_HOLDEM_COMMENTARY_PRESETS.map((preset) => {
-                  const active = preset.id === commentaryPresetId;
-                  return (
-                    <button
-                      key={preset.id}
-                      type="button"
-                      onClick={() => setCommentaryPresetId(preset.id)}
-                      aria-pressed={active}
-                      disabled={!commentarySupported}
-                      className={`w-full rounded-2xl border px-3 py-2 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
-                        active
-                          ? 'border-sky-300 bg-sky-300/15 shadow-[0_0_12px_rgba(125,211,252,0.35)]'
-                          : 'border-white/10 bg-white/5 hover:border-white/20 text-white/80'
-                      } ${commentarySupported ? '' : 'cursor-not-allowed opacity-60'}`}
-                    >
-                      <span className="flex items-center justify-between gap-2">
-                        <span className="text-[11px] font-semibold uppercase tracking-[0.26em] text-white">{preset.label}</span>
-                        {active && (
-                          <span className="rounded-full border border-sky-200/70 px-2 py-0.5 text-[9px] tracking-[0.3em] text-sky-100">
-                            Active
-                          </span>
-                        )}
-                      </span>
-                      <span className="mt-1 block text-[10px] uppercase tracking-[0.2em] text-white/60">
-                        {preset.description}
-                      </span>
-                    </button>
-                  );
-                })}
-              </div>
-              <button
-                type="button"
-                onClick={() => setCommentaryMuted((prev) => !prev)}
-                aria-pressed={commentaryMuted}
-                disabled={!commentarySupported}
-                className={`mt-2 flex w-full items-center justify-between gap-3 rounded-full px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.24em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
-                  commentaryMuted
-                    ? 'bg-sky-300 text-black shadow-[0_0_12px_rgba(125,211,252,0.35)]'
-                    : 'bg-white/10 text-white/80 hover:bg-white/20'
-                } ${commentarySupported ? '' : 'cursor-not-allowed opacity-60'}`}
-              >
-                <span>Mute commentary</span>
-                <span
-                  className={`rounded-full border px-2 py-0.5 text-[10px] tracking-[0.3em] ${
-                    commentaryMuted
-                      ? 'border-black/30 text-black/70'
-                      : 'border-white/30 text-white/70'
-                  }`}
-                >
-                  {commentaryMuted ? 'On' : 'Off'}
-                </span>
-              </button>
-              {!commentarySupported && (
-                <p className="text-[0.65rem] text-white/50">
-                  Voice commentary needs Web Speech support.
-                </p>
-              )}
-            </div>
-            <div className="rounded-xl border border-white/10 bg-white/5 p-3 space-y-2">
               <div>
                 <p className="text-[10px] uppercase tracking-[0.35em] text-white/70">Graphics</p>
                 <p className="mt-1 text-[0.7rem] text-white/60">
                   Match the Murlan Royale presets for identical FPS and clarity options.
                 </p>
+              </div>
+              <div className="grid gap-2">
+                {HDRI_RESOLUTION_OPTIONS.map((option) => {
+                  const active = option.id === hdriResolutionId;
+                  return (
+                    <button
+                      key={option.id}
+                      type="button"
+                      onClick={() => setHdriResolutionId(option.id)}
+                      aria-pressed={active}
+                      className={`w-full rounded-2xl border px-3 py-2 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
+                        active
+                          ? 'border-sky-300 bg-sky-300/15 shadow-[0_0_12px_rgba(125,211,252,0.35)]'
+                          : 'border-white/10 bg-white/5 hover:border-white/20 text-white/80'
+                      }`}
+                    >
+                      <span className="flex items-center justify-between gap-2">
+                        <span className="text-[11px] font-semibold uppercase tracking-[0.26em] text-white">{option.label}</span>
+                        {active && <span className="text-[11px] font-semibold tracking-wide text-sky-100">Active</span>}
+                      </span>
+                    </button>
+                  );
+                })}
               </div>
               <div className="grid gap-2">
                 {FRAME_RATE_OPTIONS.map((option) => {


### PR DESCRIPTION
### Motivation
- Remove in-menu voice commentary controls and text so the Texas Hold'em settings menu no longer exposes commentary UI elements.
- Provide a user-facing HDRI quality control (4K / 6K / 8K) to match the Pool Royale experience and let players choose HDRI resolution preference for better graphics control on capable devices.

### Description
- Removed the entire `Commentary` block from the in-game settings panel in `webapp/src/pages/Games/TexasHoldemArena.jsx` so voice commentary options and mute controls are no longer shown in the menu.
- Added HDRI resolution configuration constants and UI: introduced `HDRI_RESOLUTION_OPTIONS`, `HDRI_RESOLUTION_STORAGE_KEY`, and `DEFAULT_HDRI_RESOLUTION_ID`, plus a menu selector that exposes `8k`, `6k`, and `4k` choices and stores the selection in `localStorage` under `texasHoldemHdriResolution`.
- Wired HDRI loading to respect the chosen resolution: `loadPolyHavenHdriEnvironment` now accepts a `preferredResolutions` parameter, cache keys include the resolution mode, and `applyHdriEnvironment` passes the selected preference to HDRI resolution resolution and keys the cached environment by resolution mode (`envMap.userData.hdriResolutionMode`).
- Ensured HDRI is re-applied when the user changes the HDRI resolution option by re-running the environment apply logic when the resolution state changes.

### Testing
- Built the web app with `npm --prefix webapp run build`, and the build completed successfully (no runtime build errors reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca35b5afe88329aee4b348b4a94e7e)