### PR TITLE
Murlan menu: remove commentary controls and add manual HDRI resolution selector

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -665,6 +665,7 @@ const DEFAULT_APPEARANCE = {
 };
 const APPEARANCE_STORAGE_KEY = 'murlanRoyaleAppearance';
 const FRAME_RATE_STORAGE_KEY = 'murlanFrameRate';
+const HDRI_RESOLUTION_STORAGE_KEY = 'murlanHdriResolution';
 const COMMENTARY_PRESET_STORAGE_KEY = 'murlanRoyaleCommentaryPreset';
 const COMMENTARY_MUTE_STORAGE_KEY = 'murlanRoyaleCommentaryMute';
 const COMMENTARY_QUEUE_LIMIT = 4;
@@ -2246,6 +2247,18 @@ const FRAME_RATE_OPTIONS = Object.freeze([
     description: '144 Hz preset that keeps the same 8K quality target as 120 Hz for HDRI and scene assets.'
   }
 ]);
+const HDRI_RESOLUTION_OPTIONS = Object.freeze([
+  { id: '8k', label: '8K' },
+  { id: '6k', label: '6K' },
+  { id: '4k', label: '4K' }
+]);
+const HDRI_RESOLUTION_OPTION_MAP = Object.freeze(
+  HDRI_RESOLUTION_OPTIONS.reduce((acc, option) => {
+    acc[option.id] = option;
+    return acc;
+  }, {})
+);
+const DEFAULT_HDRI_RESOLUTION_ID = '4k';
 const DEFAULT_FRAME_RATE_OPTION =
   FRAME_RATE_OPTIONS.find((opt) => opt.id === DEFAULT_FRAME_RATE_ID) ?? FRAME_RATE_OPTIONS[0];
 
@@ -2368,6 +2381,15 @@ export default function MurlanRoyaleArena({ search }) {
     }
     return DEFAULT_FRAME_RATE_ID || DEFAULT_FRAME_RATE_OPTION.id;
   });
+  const [hdriResolutionId, setHdriResolutionId] = useState(() => {
+    if (typeof window !== 'undefined') {
+      const stored = window.localStorage?.getItem(HDRI_RESOLUTION_STORAGE_KEY);
+      if (stored && HDRI_RESOLUTION_OPTION_MAP[stored]) {
+        return stored;
+      }
+    }
+    return DEFAULT_HDRI_RESOLUTION_ID;
+  });
   const activeFrameRateOption = useMemo(
     () => FRAME_RATE_OPTIONS.find((opt) => opt.id === frameRateId) ?? DEFAULT_FRAME_RATE_OPTION,
     [frameRateId]
@@ -2421,8 +2443,7 @@ export default function MurlanRoyaleArena({ search }) {
     };
   }, []);
   const resolvedHdriResolution =
-    (typeof activeFrameRateOption?.hdriResolution === 'string' && activeFrameRateOption.hdriResolution) ||
-    DEFAULT_HDRI_RESOLUTIONS[0];
+    (HDRI_RESOLUTION_OPTION_MAP[hdriResolutionId] && hdriResolutionId) || DEFAULT_HDRI_RESOLUTION_ID;
   const resolvedFrameTiming = useMemo(() => {
     const fallbackFps =
       Number.isFinite(DEFAULT_FRAME_RATE_OPTION?.fps) && DEFAULT_FRAME_RATE_OPTION.fps > 0
@@ -2524,7 +2545,7 @@ export default function MurlanRoyaleArena({ search }) {
       MURLAN_ROYALE_COMMENTARY_PRESETS[0],
     [commentaryPresetId]
   );
-  const [commentarySupported, setCommentarySupported] = useState(() => getSpeechSupport());
+  const [, setCommentarySupported] = useState(() => getSpeechSupport());
   const commentarySpeakers = useMemo(() => {
     const base = [
       MURLAN_ROYALE_SPEAKERS.lead,
@@ -2711,29 +2732,6 @@ export default function MurlanRoyaleArena({ search }) {
       playNextCommentary();
     }
   }, [playImmediateCommentary, playNextCommentary]);
-
-  const handleToggleCommentary = useCallback(() => {
-    if (commentaryMuted) {
-      unlockCommentary();
-    }
-    setCommentaryMuted((prev) => !prev);
-  }, [commentaryMuted, unlockCommentary]);
-
-  const handleSelectCommentaryPreset = useCallback(
-    (presetId) => {
-      if (!presetId || presetId === commentaryPresetId) return;
-      unlockCommentary();
-      setCommentaryPresetId(presetId);
-      const synth = getSpeechSynthesis();
-      synth?.cancel?.();
-      commentaryQueueRef.current = [];
-      commentarySpeakingRef.current = false;
-      commentaryLastEventAtRef.current = 0;
-      commentarySpeakerIndexRef.current = 0;
-      pendingCommentaryLinesRef.current = null;
-    },
-    [commentaryPresetId, unlockCommentary]
-  );
 
   useEffect(() => {
     syncAudioVolume();
@@ -2929,6 +2927,14 @@ export default function MurlanRoyaleArena({ search }) {
       console.warn('Failed to persist frame rate option', error);
     }
   }, [frameRateId]);
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      window.localStorage?.setItem(HDRI_RESOLUTION_STORAGE_KEY, hdriResolutionId);
+    } catch (error) {
+      console.warn('Failed to persist HDRI resolution option', error);
+    }
+  }, [hdriResolutionId]);
 
   const gameStateRef = useRef(gameState);
   const selectedRef = useRef(selectedIds);
@@ -5052,6 +5058,32 @@ export default function MurlanRoyaleArena({ search }) {
                   </div>
                   <div className="rounded-xl border border-white/10 bg-white/5 p-3 space-y-2">
                     <p className="text-[10px] uppercase tracking-[0.35em] text-white/70">Graphics</p>
+                    <div className="space-y-2">
+                      <p className="text-[10px] uppercase tracking-[0.32em] text-white/65">HDRI Resolution</p>
+                      <p className="text-[10px] uppercase tracking-[0.2em] text-white/50">
+                        Active: {resolvedHdriResolution.toUpperCase()}
+                      </p>
+                      <div className="flex flex-wrap gap-2">
+                        {HDRI_RESOLUTION_OPTIONS.map((option) => {
+                          const active = option.id === hdriResolutionId;
+                          return (
+                            <button
+                              key={option.id}
+                              type="button"
+                              onClick={() => setHdriResolutionId(option.id)}
+                              aria-pressed={active}
+                              className={`flex-1 min-w-[5rem] rounded-full border px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
+                                active
+                                  ? 'border-sky-300 bg-sky-300 text-black shadow-[0_0_12px_rgba(125,211,252,0.45)]'
+                                  : 'border-white/20 bg-white/10 text-white/80 hover:bg-white/20'
+                              }`}
+                            >
+                              {option.label}
+                            </button>
+                          );
+                        })}
+                      </div>
+                    </div>
                     <div className="grid gap-2">
                       {FRAME_RATE_OPTIONS.map((option) => {
                         const active = option.id === frameRateId;
@@ -5082,67 +5114,6 @@ export default function MurlanRoyaleArena({ search }) {
                         );
                       })}
                     </div>
-                  </div>
-                  <div className="rounded-xl border border-white/10 bg-white/5 p-3 space-y-2">
-                    <p className="text-[10px] uppercase tracking-[0.35em] text-white/70">Commentary</p>
-                    <div className="grid gap-2">
-                      {MURLAN_ROYALE_COMMENTARY_PRESETS.map((preset) => {
-                        const active = preset.id === commentaryPresetId;
-                        return (
-                          <button
-                            key={preset.id}
-                            type="button"
-                            onClick={() => handleSelectCommentaryPreset(preset.id)}
-                            aria-pressed={active}
-                            disabled={!commentarySupported}
-                            className={`w-full rounded-2xl border px-3 py-2 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
-                              active
-                                ? 'border-sky-300 bg-sky-300/15 shadow-[0_0_12px_rgba(125,211,252,0.35)]'
-                                : 'border-white/10 bg-white/5 hover:border-white/20 text-white/80'
-                            } ${commentarySupported ? '' : 'cursor-not-allowed opacity-60'}`}
-                          >
-                            <span className="flex items-center justify-between gap-2">
-                              <span className="text-[11px] font-semibold uppercase tracking-[0.26em] text-white">{preset.label}</span>
-                              {active && (
-                                <span className="rounded-full border border-sky-200/70 px-2 py-0.5 text-[9px] tracking-[0.3em] text-sky-100">
-                                  Active
-                                </span>
-                              )}
-                            </span>
-                            <span className="mt-1 block text-[10px] uppercase tracking-[0.2em] text-white/60">
-                              {preset.description}
-                            </span>
-                          </button>
-                        );
-                      })}
-                    </div>
-                    <button
-                      type="button"
-                      onClick={handleToggleCommentary}
-                      aria-pressed={commentaryMuted}
-                      disabled={!commentarySupported}
-                      className={`flex w-full items-center justify-between gap-3 rounded-full px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.24em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
-                        commentaryMuted
-                          ? 'bg-sky-300 text-black shadow-[0_0_12px_rgba(125,211,252,0.45)]'
-                          : 'bg-white/10 text-white/80 hover:bg-white/20'
-                      } ${commentarySupported ? '' : 'cursor-not-allowed opacity-60'}`}
-                    >
-                      <span>Mute commentary</span>
-                      <span
-                        className={`rounded-full border px-2 py-0.5 text-[10px] tracking-[0.3em] ${
-                          commentaryMuted
-                            ? 'border-black/30 text-black/70'
-                            : 'border-white/30 text-white/70'
-                        }`}
-                      >
-                        {commentaryMuted ? 'On' : 'Off'}
-                      </span>
-                    </button>
-                    {!commentarySupported && (
-                      <p className="text-[10px] uppercase tracking-[0.2em] text-white/50">
-                        Voice commentary needs Web Speech support.
-                      </p>
-                    )}
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
### Motivation
- Remove voice commentary controls from the Murlan Royale menu so the menu, inventory and store no longer expose voice commentary toggles. 
- Give players a manual HDRI resolution selector (exact `4k`, `6k`, `8k`) to match Pool Royale behavior. 
- Persist the user HDRI choice and let it drive environment HDRI resolution independently from FPS presets.

### Description
- Removed the in-menu Commentary UI block and its selection/mute handlers from `webapp/src/pages/Games/MurlanRoyaleArena.jsx` so voice commentary is no longer shown in the Murlan menu. 
- Added HDRI resolution support: introduced `HDRI_RESOLUTION_OPTIONS`, `HDRI_RESOLUTION_OPTION_MAP`, `HDRI_RESOLUTION_STORAGE_KEY`, `DEFAULT_HDRI_RESOLUTION_ID`, and `hdriResolutionId` state in `MurlanRoyaleArena.jsx`. 
- Added a new HDRI Resolution picker (buttons for `8K`, `6K`, `4K`) in the Graphics section and persist selection to `localStorage` via `murlanHdriResolution`. 
- Wired `resolvedHdriResolution` to use the manual selection (overrides previous hdri resolution fallback logic derived from frame-rate presets); commentary playback internals remain intact (only the menu controls and related UI handlers were removed).

### Testing
- Ran `npm -C webapp run build`, and the Vite production build completed successfully (build finished; only existing chunk-size/dynamic-import warnings were reported). 
- No unit tests were changed and no automated test failures were observed during the build step.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca340054008329a4ff95a96e047130)