### PR TITLE
Redesign snake-ladder client with precise pyramid board UI

### DIFF
--- a/examples/snake-ladder/ReactClient.jsx
+++ b/examples/snake-ladder/ReactClient.jsx
@@ -1,5 +1,35 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { io } from 'socket.io-client';
+
+const PYRAMID_ROW_LENGTHS = [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 15];
+const BOARD_SIZE = 100;
+
+function buildPyramidRows() {
+  const rows = [];
+  let value = 1;
+
+  for (let row = PYRAMID_ROW_LENGTHS.length - 1; row >= 0; row -= 1) {
+    const rowSize = PYRAMID_ROW_LENGTHS[row];
+    const values = [];
+
+    for (let col = 0; col < rowSize; col += 1) {
+      if (value <= BOARD_SIZE) values.push(value);
+      value += 1;
+    }
+
+    if (row % 2 === 1) values.reverse();
+    rows.unshift(values);
+  }
+
+  return rows;
+}
+
+function getCellAccent(value) {
+  if (value === BOARD_SIZE) return '#17b26a';
+  if (value <= 10) return '#3b82f6';
+  if (value % 10 === 0) return '#f59e0b';
+  return '#7c3aed';
+}
 
 export default function ReactClient({
   roomId = 'room1',
@@ -8,6 +38,17 @@ export default function ReactClient({
 }) {
   const [state, setState] = useState(null);
   const [socket] = useState(() => io(serverUrl));
+
+  const rows = useMemo(() => buildPyramidRows(), []);
+  const playersByTile = useMemo(() => {
+    if (!state) return {};
+
+    return state.players.reduce((acc, player) => {
+      if (!acc[player.position]) acc[player.position] = [];
+      acc[player.position].push(player);
+      return acc;
+    }, {});
+  }, [state]);
 
   useEffect(() => {
     socket.emit('joinRoom', { roomId, name: playerName });
@@ -19,26 +60,165 @@ export default function ReactClient({
 
   const rollDice = () => socket.emit('rollDice', { roomId });
 
-  if (!state) return <div>Loading...</div>;
+  if (!state) return <div style={{ color: '#fff' }}>Loading...</div>;
 
   const current = state.players[state.currentPlayer]?.id;
 
   return (
-    <div>
-      <h3>Room: {state.roomId}</h3>
-      <p>Current Player: {current}</p>
-      <p>Last Dice Roll: {state.diceRoll}</p>
-      <ul>
-        {state.players.map((p) => (
-          <li key={p.id}>
-            {p.name}: {p.position}
-          </li>
+    <div
+      style={{
+        minHeight: '100vh',
+        padding: '16px 12px 24px',
+        background: 'radial-gradient(circle at top, #1e293b 0%, #020617 70%)',
+        color: '#e2e8f0',
+        fontFamily: 'Inter, system-ui, sans-serif'
+      }}
+    >
+      <div
+        style={{
+          margin: '0 auto 16px',
+          maxWidth: 900,
+          background:
+            'linear-gradient(145deg, rgba(30,41,59,0.92), rgba(15,23,42,0.96))',
+          border: '1px solid rgba(148,163,184,0.35)',
+          borderRadius: 16,
+          padding: 14,
+          boxShadow: '0 18px 30px rgba(2,6,23,0.45)'
+        }}
+      >
+        <h3 style={{ margin: '0 0 8px', letterSpacing: 0.4 }}>
+          Room: {state.roomId}
+        </h3>
+        <p style={{ margin: '4px 0' }}>Current Player: {current}</p>
+        <p style={{ margin: '4px 0 12px' }}>Last Dice Roll: {state.diceRoll}</p>
+        <button
+          onClick={rollDice}
+          disabled={socket.id !== current || state.winner}
+          style={{
+            border: 'none',
+            borderRadius: 999,
+            padding: '10px 16px',
+            fontWeight: 700,
+            background: 'linear-gradient(90deg, #22c55e, #14b8a6)',
+            color: '#082f49',
+            cursor:
+              socket.id !== current || state.winner ? 'not-allowed' : 'pointer',
+            opacity: socket.id !== current || state.winner ? 0.45 : 1
+          }}
+        >
+          Roll Dice
+        </button>
+        {state.winner && (
+          <p style={{ margin: '12px 0 0' }}>Winner: {state.winner}</p>
+        )}
+      </div>
+
+      <div style={{ margin: '0 auto', maxWidth: 900 }}>
+        {rows.map((row, rowIndex) => (
+          <div
+            key={`row-${rowIndex}`}
+            style={{
+              display: 'grid',
+              gap: 6,
+              gridTemplateColumns: `repeat(${row.length}, minmax(18px, 1fr))`,
+              marginBottom: 6,
+              width: `${(row.length / PYRAMID_ROW_LENGTHS[PYRAMID_ROW_LENGTHS.length - 1]) * 100}%`,
+              marginInline: 'auto'
+            }}
+          >
+            {row.map((tile) => {
+              const snakeTo = state.snakes[tile];
+              const ladderTo = state.ladders[tile];
+              const players = playersByTile[tile] || [];
+
+              return (
+                <div
+                  key={tile}
+                  style={{
+                    position: 'relative',
+                    minHeight: 42,
+                    borderRadius: 10,
+                    border: `1px solid ${getCellAccent(tile)}99`,
+                    background:
+                      'linear-gradient(180deg, rgba(15,23,42,0.95), rgba(30,41,59,0.92))',
+                    boxShadow: `inset 0 0 0 1px ${getCellAccent(tile)}33`
+                  }}
+                >
+                  <span
+                    style={{
+                      position: 'absolute',
+                      top: 5,
+                      left: 6,
+                      fontSize: 11,
+                      opacity: 0.95
+                    }}
+                  >
+                    {tile}
+                  </span>
+                  {snakeTo && (
+                    <span
+                      style={{
+                        position: 'absolute',
+                        top: 4,
+                        right: 6,
+                        fontSize: 12
+                      }}
+                      title={`Snake to ${snakeTo}`}
+                    >
+                      🐍
+                    </span>
+                  )}
+                  {ladderTo && (
+                    <span
+                      style={{
+                        position: 'absolute',
+                        top: 4,
+                        right: 6,
+                        fontSize: 12
+                      }}
+                      title={`Ladder to ${ladderTo}`}
+                    >
+                      🪜
+                    </span>
+                  )}
+                  <div
+                    style={{
+                      position: 'absolute',
+                      left: 4,
+                      right: 4,
+                      bottom: 4,
+                      display: 'flex',
+                      gap: 4,
+                      flexWrap: 'wrap'
+                    }}
+                  >
+                    {players.map((player, idx) => (
+                      <span
+                        key={player.id}
+                        title={player.name}
+                        style={{
+                          width: 16,
+                          height: 16,
+                          borderRadius: '50%',
+                          display: 'inline-flex',
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                          fontSize: 9,
+                          fontWeight: 700,
+                          color: '#020617',
+                          background: idx % 2 === 0 ? '#fbbf24' : '#22d3ee'
+                        }}
+                      >
+                        {player.name.slice(0, 1).toUpperCase()}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
         ))}
-      </ul>
-      <button onClick={rollDice} disabled={socket.id !== current || state.winner}>
-        Roll Dice
-      </button>
-      {state.winner && <p>Winner: {state.winner}</p>}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Replace the minimal list-based client with a precise, stylish pyramid-shaped board that starts at tile 1 and presents tiles deterministically for clearer gameplay and visual fidelity.
- Improve per-tile feedback and readable player state so the board communicates snakes, ladders and player tokens at a glance.
- Keep the existing multiplayer socket contract intact while optimizing UI rendering and state derivation.

### Description
- Implemented a deterministic pyramid layout using `PYRAMID_ROW_LENGTHS`, `BOARD_SIZE`, and `buildPyramidRows()` to generate rows for a 100-tile board in `examples/snake-ladder/ReactClient.jsx`.
- Added `getCellAccent()` plus memoized `rows` and `playersByTile` to drive compact, high-fidelity tile rendering with accent colors and stacked player badges.
- Reworked the UI into a styled game surface with a framed HUD, updated `Roll Dice` button styling, and inline tile render logic that shows snake/ladder indicators and tile numbers.
- Preserved socket usage and game events (`joinRoom`, `gameStateUpdate`, `rollDice`) so multiplayer logic remains unchanged.

### Testing
- Ran `npx prettier --write examples/snake-ladder/ReactClient.jsx` which completed successfully.
- Ran `npx prettier --check examples/snake-ladder/ReactClient.jsx` which passed after formatting.
- Ran `npx eslint examples/snake-ladder/ReactClient.jsx` which reported a repository ignore warning but no lint errors.
- Ran `node --check examples/snake-ladder/ReactClient.jsx` which failed due to Node not recognizing the `.jsx` extension (expected for this example file and not a build-time failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca36bc66dc832997fb38e951139ec1)