### PR TITLE
Texas Hold'em: remove commentary menu and add HDRI resolution selector

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -40,9 +40,7 @@ import {
   TEXAS_HOLDEM_SPEAKERS
 } from '../../utils/texasHoldemCommentary.js';
 import {
-  getSpeechSupport,
   getSpeechSynthesis,
-  onSpeechSupportChange,
   primeSpeechSynthesis,
   speakCommentaryLines
 } from '../../utils/textToSpeech.js';
@@ -469,7 +467,20 @@ const CHAIR_MODEL_URLS = [
 
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
 const BASIS_TRANSCODER_PATH = 'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/';
-const PREFERRED_HDRI_RESOLUTIONS = Object.freeze(['2k', '1k']);
+const HDRI_RESOLUTION_STORAGE_KEY = 'texasHoldemHdriResolution';
+const HDRI_RESOLUTION_OPTIONS = Object.freeze([
+  { id: '8k', label: '8K' },
+  { id: '6k', label: '6K' },
+  { id: '4k', label: '4K' }
+]);
+const HDRI_RESOLUTION_OPTION_MAP = Object.freeze(
+  HDRI_RESOLUTION_OPTIONS.reduce((acc, option) => {
+    acc[option.id] = option;
+    return acc;
+  }, {})
+);
+const HDRI_RESOLUTION_LADDER = Object.freeze(['8k', '6k', '4k', '2k', '1k']);
+const DEFAULT_HDRI_RESOLUTION_ID = '4k';
 const HDRI_ENV_CACHE_LIMIT = 4;
 const DEFAULT_TABLE_THEME_ID = TEXAS_TABLE_THEME_OPTIONS[0]?.id ?? 'murlan-default';
 const TEXAS_DEFAULT_HDRI_INDEX = Math.max(
@@ -1263,15 +1274,18 @@ async function createFallbackHdriEnvironment(renderer) {
   return { envMap: texture, url: null };
 }
 
-async function loadPolyHavenHdriEnvironment(renderer, config = {}) {
+async function loadPolyHavenHdriEnvironment(renderer, config = {}, preferredResolutions = [DEFAULT_HDRI_RESOLUTION_ID, '2k', '1k']) {
   if (!renderer) return null;
-  const cacheKey = String(config?.id || config?.assetId || config?.fallbackUrl || 'fallback');
+  const preferredKey = Array.isArray(preferredResolutions) && preferredResolutions.length
+    ? preferredResolutions.join(',')
+    : DEFAULT_HDRI_RESOLUTION_ID;
+  const cacheKey = `${String(config?.id || config?.assetId || config?.fallbackUrl || 'fallback')}|${preferredKey}`;
   const cached = HDRI_ENVIRONMENT_CACHE.get(cacheKey);
   if (cached?.envMap) {
     rememberHdriEnvironment(cacheKey, cached);
     return { ...cached, fromCache: true, cacheKey };
   }
-  const url = await resolveTexasHoldemHdriUrl(config, PREFERRED_HDRI_RESOLUTIONS);
+  const url = await resolveTexasHoldemHdriUrl(config, preferredResolutions);
   const resolveFallback = async () => {
     try {
       return await createFallbackHdriEnvironment(renderer);
@@ -2981,7 +2995,7 @@ function TexasHoldemArena({ search }) {
   }, []);
   const [chatBubbles, setChatBubbles] = useState([]);
   const [muted, setMuted] = useState(isGameMuted());
-  const [commentaryPresetId, setCommentaryPresetId] = useState(() => {
+  const [commentaryPresetId] = useState(() => {
     if (typeof window !== 'undefined') {
       const stored = window.localStorage.getItem(COMMENTARY_PRESET_STORAGE_KEY);
       if (stored && TEXAS_HOLDEM_COMMENTARY_PRESETS.some((preset) => preset.id === stored)) {
@@ -2990,7 +3004,7 @@ function TexasHoldemArena({ search }) {
     }
     return DEFAULT_COMMENTARY_PRESET_ID;
   });
-  const [commentaryMuted, setCommentaryMuted] = useState(() => {
+  const [commentaryMuted] = useState(() => {
     if (typeof window !== 'undefined') {
       const stored = window.localStorage.getItem(COMMENTARY_MUTE_STORAGE_KEY);
       if (stored === '1') return true;
@@ -3112,6 +3126,29 @@ function TexasHoldemArena({ search }) {
     () => FRAME_RATE_OPTIONS.find((opt) => opt.id === frameRateId) ?? FRAME_RATE_OPTIONS[0],
     [frameRateId]
   );
+  const [hdriResolutionId, setHdriResolutionId] = useState(() => {
+    if (typeof window !== 'undefined') {
+      const stored = window.localStorage?.getItem(HDRI_RESOLUTION_STORAGE_KEY);
+      if (stored && HDRI_RESOLUTION_OPTION_MAP[stored]) {
+        return stored;
+      }
+    }
+    return DEFAULT_HDRI_RESOLUTION_ID;
+  });
+  const preferredHdriResolutions = useMemo(() => {
+    const normalized = HDRI_RESOLUTION_OPTION_MAP[hdriResolutionId]?.id || DEFAULT_HDRI_RESOLUTION_ID;
+    const startIndex = HDRI_RESOLUTION_LADDER.indexOf(normalized);
+    if (startIndex < 0) return [DEFAULT_HDRI_RESOLUTION_ID, '2k', '1k'];
+    const fallbackResolutions = HDRI_RESOLUTION_LADDER.slice(startIndex).filter(Boolean);
+    if (!fallbackResolutions.includes('2k')) fallbackResolutions.push('2k');
+    if (!fallbackResolutions.includes('1k')) fallbackResolutions.push('1k');
+    return fallbackResolutions;
+  }, [hdriResolutionId]);
+  const preferredHdriResolutionsRef = useRef(preferredHdriResolutions);
+  const loadedHdriResolutionIdRef = useRef(null);
+  useEffect(() => {
+    preferredHdriResolutionsRef.current = preferredHdriResolutions;
+  }, [preferredHdriResolutions]);
   const frameQualityProfile = useMemo(() => {
     const option = activeFrameRateOption ?? FRAME_RATE_OPTIONS[0];
     const fallback = FRAME_RATE_OPTIONS[0];
@@ -3168,6 +3205,13 @@ function TexasHoldemArena({ search }) {
       console.warn("Failed to persist Texas Hold'em graphics", error);
     }
   }, [frameRateId]);
+  useEffect(() => {
+    try {
+      window.localStorage?.setItem(HDRI_RESOLUTION_STORAGE_KEY, hdriResolutionId);
+    } catch (error) {
+      console.warn("Failed to persist Texas Hold'em HDRI resolution", error);
+    }
+  }, [hdriResolutionId]);
   const [configOpen, setConfigOpen] = useState(false);
   const timerRef = useRef(null);
   const turnIntervalRef = useRef(null);
@@ -3208,7 +3252,6 @@ function TexasHoldemArena({ search }) {
       TEXAS_HOLDEM_COMMENTARY_PRESETS[0],
     [commentaryPresetId]
   );
-  const [commentarySupported, setCommentarySupported] = useState(() => getSpeechSupport());
   const commentarySpeakers = useMemo(
     () => [TEXAS_HOLDEM_SPEAKERS.lead, TEXAS_HOLDEM_SPEAKERS.analyst],
     []
@@ -3218,15 +3261,6 @@ function TexasHoldemArena({ search }) {
     commentarySpeakerIndexRef.current = index + 1;
     return commentarySpeakers[index % commentarySpeakers.length] || TEXAS_HOLDEM_SPEAKERS.analyst;
   }, [commentarySpeakers]);
-
-  useEffect(() => {
-    const updateSupport = () => setCommentarySupported(getSpeechSupport());
-    updateSupport();
-    const unsubscribe = onSpeechSupportChange((supported) => setCommentarySupported(Boolean(supported)));
-    return () => {
-      unsubscribe();
-    };
-  }, []);
 
   useEffect(() => {
     commentaryMutedRef.current = commentaryMuted;
@@ -4021,11 +4055,15 @@ function TexasHoldemArena({ search }) {
     });
     if (
       environmentOption &&
-      (!envTextureRef.current || (hdriVariantRef.current?.id || hdriVariantRef.current?.assetId) !== (environmentOption.id || environmentOption.assetId))
+      (
+        !envTextureRef.current ||
+        (hdriVariantRef.current?.id || hdriVariantRef.current?.assetId) !== (environmentOption.id || environmentOption.assetId) ||
+        loadedHdriResolutionIdRef.current !== hdriResolutionId
+      )
     ) {
       void applyHdriEnvironment(environmentOption);
     }
-  }, [appearance, effectivePlayerCount]);
+  }, [appearance, effectivePlayerCount, hdriResolutionId]);
 
   const renderPreview = useCallback((type, option) => {
     switch (type) {
@@ -4243,12 +4281,23 @@ function TexasHoldemArena({ search }) {
       if (!activeVariant) return;
       const activeVariantId = activeVariant.id || activeVariant.assetId;
       const currentVariantId = hdriVariantRef.current?.id || hdriVariantRef.current?.assetId;
-      if (envTextureRef.current && activeVariantId && currentVariantId === activeVariantId) {
+      const currentHdriResolutionId =
+        HDRI_RESOLUTION_OPTION_MAP[hdriResolutionId]?.id || DEFAULT_HDRI_RESOLUTION_ID;
+      if (
+        envTextureRef.current &&
+        activeVariantId &&
+        currentVariantId === activeVariantId &&
+        loadedHdriResolutionIdRef.current === currentHdriResolutionId
+      ) {
         return;
       }
       const requestToken = (hdriApplyRequestRef.current || 0) + 1;
       hdriApplyRequestRef.current = requestToken;
-      const envResult = await loadPolyHavenHdriEnvironment(three.renderer, activeVariant);
+      const envResult = await loadPolyHavenHdriEnvironment(
+        three.renderer,
+        activeVariant,
+        preferredHdriResolutionsRef.current
+      );
       if (!envResult?.envMap) return;
       const usedFallbackEnvironment = !envResult.url;
       if (usedFallbackEnvironment) {
@@ -4296,8 +4345,9 @@ function TexasHoldemArena({ search }) {
         prevDispose();
       }
       hdriVariantRef.current = activeVariant;
+      loadedHdriResolutionIdRef.current = currentHdriResolutionId;
     },
-    []
+    [hdriResolutionId]
   );
 
   useEffect(() => {
@@ -6379,72 +6429,34 @@ function TexasHoldemArena({ search }) {
               </div>
             </div>
             <div className="rounded-xl border border-white/10 bg-white/5 p-3 space-y-2">
-              <p className="text-[10px] uppercase tracking-[0.35em] text-white/70">Commentary</p>
-              <div className="grid gap-2">
-                {TEXAS_HOLDEM_COMMENTARY_PRESETS.map((preset) => {
-                  const active = preset.id === commentaryPresetId;
-                  return (
-                    <button
-                      key={preset.id}
-                      type="button"
-                      onClick={() => setCommentaryPresetId(preset.id)}
-                      aria-pressed={active}
-                      disabled={!commentarySupported}
-                      className={`w-full rounded-2xl border px-3 py-2 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
-                        active
-                          ? 'border-sky-300 bg-sky-300/15 shadow-[0_0_12px_rgba(125,211,252,0.35)]'
-                          : 'border-white/10 bg-white/5 hover:border-white/20 text-white/80'
-                      } ${commentarySupported ? '' : 'cursor-not-allowed opacity-60'}`}
-                    >
-                      <span className="flex items-center justify-between gap-2">
-                        <span className="text-[11px] font-semibold uppercase tracking-[0.26em] text-white">{preset.label}</span>
-                        {active && (
-                          <span className="rounded-full border border-sky-200/70 px-2 py-0.5 text-[9px] tracking-[0.3em] text-sky-100">
-                            Active
-                          </span>
-                        )}
-                      </span>
-                      <span className="mt-1 block text-[10px] uppercase tracking-[0.2em] text-white/60">
-                        {preset.description}
-                      </span>
-                    </button>
-                  );
-                })}
-              </div>
-              <button
-                type="button"
-                onClick={() => setCommentaryMuted((prev) => !prev)}
-                aria-pressed={commentaryMuted}
-                disabled={!commentarySupported}
-                className={`mt-2 flex w-full items-center justify-between gap-3 rounded-full px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.24em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
-                  commentaryMuted
-                    ? 'bg-sky-300 text-black shadow-[0_0_12px_rgba(125,211,252,0.35)]'
-                    : 'bg-white/10 text-white/80 hover:bg-white/20'
-                } ${commentarySupported ? '' : 'cursor-not-allowed opacity-60'}`}
-              >
-                <span>Mute commentary</span>
-                <span
-                  className={`rounded-full border px-2 py-0.5 text-[10px] tracking-[0.3em] ${
-                    commentaryMuted
-                      ? 'border-black/30 text-black/70'
-                      : 'border-white/30 text-white/70'
-                  }`}
-                >
-                  {commentaryMuted ? 'On' : 'Off'}
-                </span>
-              </button>
-              {!commentarySupported && (
-                <p className="text-[0.65rem] text-white/50">
-                  Voice commentary needs Web Speech support.
-                </p>
-              )}
-            </div>
-            <div className="rounded-xl border border-white/10 bg-white/5 p-3 space-y-2">
               <div>
                 <p className="text-[10px] uppercase tracking-[0.35em] text-white/70">Graphics</p>
                 <p className="mt-1 text-[0.7rem] text-white/60">
                   Match the Murlan Royale presets for identical FPS and clarity options.
                 </p>
+              </div>
+              <div className="space-y-2">
+                <p className="text-[10px] uppercase tracking-[0.2em] text-white/60">HDRI Resolution</p>
+                <div className="grid grid-cols-3 gap-2">
+                  {HDRI_RESOLUTION_OPTIONS.map((option) => {
+                    const active = option.id === hdriResolutionId;
+                    return (
+                      <button
+                        key={option.id}
+                        type="button"
+                        onClick={() => setHdriResolutionId(option.id)}
+                        aria-pressed={active}
+                        className={`rounded-xl border px-2 py-2 text-center text-[11px] font-semibold uppercase tracking-[0.22em] transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
+                          active
+                            ? 'border-sky-300 bg-sky-300/15 text-sky-100 shadow-[0_0_12px_rgba(125,211,252,0.35)]'
+                            : 'border-white/10 bg-white/5 text-white/80 hover:border-white/20'
+                        }`}
+                      >
+                        {option.label}
+                      </button>
+                    );
+                  })}
+                </div>
               </div>
               <div className="grid gap-2">
                 {FRAME_RATE_OPTIONS.map((option) => {

--- a/webapp/src/utils/texasHoldemHdriPreload.js
+++ b/webapp/src/utils/texasHoldemHdriPreload.js
@@ -109,7 +109,7 @@ export async function resolveTexasHoldemHdriUrl(config = {}, preferred = DEFAULT
     Array.isArray(config?.preferredResolutions) && config.preferredResolutions.length
       ? config.preferredResolutions
       : preferred;
-  const cacheKey = String(config?.id || config?.assetId || getFallbackHdriUrl(config, preferredResolutions));
+  const cacheKey = `${String(config?.id || config?.assetId || getFallbackHdriUrl(config, preferredResolutions))}|${preferredResolutions.join(',')}`;
   if (hdriUrlCache.has(cacheKey)) {
     return hdriUrlCache.get(cacheKey);
   }


### PR DESCRIPTION
### Motivation
- Remove voice commentary UI from the Texas Hold'em settings menu so commentary text/options no longer appear in the menu flow.
- Expose HDRI resolution choices in the Hold'em graphics menu to match the Pool Royale experience (let players choose 4K/6K/8K HDRI preferences).
- Ensure HDRI environment loading respects the selected resolution and does not reuse cached HDRI URLs for a different resolution preference.

### Description
- Removed the in-menu Commentary controls and related runtime UI hooks so commentary presets and mute toggles are no longer shown (`webapp/src/pages/Games/TexasHoldemArena.jsx`).
- Added HDRI resolution constants, options and storage key (`texasHoldemHdriResolution`) and a resolution ladder with `8k/6k/4k/2k/1k` fallback ordering (`webapp/src/pages/Games/TexasHoldemArena.jsx`).
- Wired the HDRI selector into runtime environment loading so the selected resolution ladder is passed to the HDRI loader and changing resolution triggers environment reloads and reapplication (`webapp/src/pages/Games/TexasHoldemArena.jsx`).
- Updated HDRI URL cache keys to include the preferred resolution order so `resolveTexasHoldemHdriUrl` and `loadPolyHavenHdriEnvironment` will not reuse stale cached URLs from other resolution preferences (`webapp/src/utils/texasHoldemHdriPreload.js`, `webapp/src/pages/Games/TexasHoldemArena.jsx`).

### Testing
- Built the webapp with `npm --prefix webapp run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca35b5afe88329aee4b348b4a94e7e)