### PR TITLE
Fix Texas Hold'em HDRI resolution switching

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -507,6 +507,24 @@ function rememberHdriEnvironment(cacheKey, payload) {
   }
 }
 
+function withHdriResolutionPreferences(variant, preferredResolutions = []) {
+  if (!variant) return null;
+  const basePreferred =
+    Array.isArray(variant.preferredResolutions) && variant.preferredResolutions.length
+      ? variant.preferredResolutions
+      : [DEFAULT_HDRI_RESOLUTION_ID];
+  const requested = Array.isArray(preferredResolutions)
+    ? preferredResolutions.filter((res) => typeof res === 'string' && res.length)
+    : [];
+  const mergedPreferred = Array.from(new Set([...requested, ...basePreferred]));
+  const fallbackResolution = mergedPreferred[0] || basePreferred[0] || DEFAULT_HDRI_RESOLUTION_ID;
+  return {
+    ...variant,
+    preferredResolutions: mergedPreferred,
+    fallbackResolution
+  };
+}
+
 function ensureKtx2SupportDetection(renderer = null) {
   if (!sharedKtx2Loader || hasDetectedKtx2Support || !renderer) return;
   try {
@@ -3883,9 +3901,12 @@ function TexasHoldemArena({ search }) {
     const baseOption = TABLE_BASE_OPTIONS[safe.tableBase] ?? TABLE_BASE_OPTIONS[0];
     const chairOption = TEXAS_CHAIR_THEME_OPTIONS[safe.chairTheme] ?? TEXAS_CHAIR_THEME_OPTIONS[0];
     const environmentOption =
-      TEXAS_HDRI_OPTIONS[safe.environmentHdri] ??
-      TEXAS_HDRI_OPTIONS[TEXAS_DEFAULT_HDRI_INDEX] ??
-      TEXAS_HDRI_OPTIONS[0];
+      withHdriResolutionPreferences(
+        TEXAS_HDRI_OPTIONS[safe.environmentHdri] ??
+          TEXAS_HDRI_OPTIONS[TEXAS_DEFAULT_HDRI_INDEX] ??
+          TEXAS_HDRI_OPTIONS[0],
+        preferredHdriResolutionsRef.current
+      );
     const { option: shapeOption, rotationY } = getEffectiveShapeConfig(
       safe.tableShape,
       effectivePlayerCount
@@ -4053,12 +4074,14 @@ function TexasHoldemArena({ search }) {
         applyThemeToMesh(mesh, { rank: 'A', suit: 'S' });
       }
     });
+    const currentHdriResolutionId =
+      HDRI_RESOLUTION_OPTION_MAP[hdriResolutionId]?.id || DEFAULT_HDRI_RESOLUTION_ID;
     if (
       environmentOption &&
       (
         !envTextureRef.current ||
         (hdriVariantRef.current?.id || hdriVariantRef.current?.assetId) !== (environmentOption.id || environmentOption.assetId) ||
-        loadedHdriResolutionIdRef.current !== hdriResolutionId
+        loadedHdriResolutionIdRef.current !== currentHdriResolutionId
       )
     ) {
       void applyHdriEnvironment(environmentOption);
@@ -4387,9 +4410,12 @@ function TexasHoldemArena({ search }) {
     const initialAppearanceRaw = normalizeAppearance(appearanceRef.current);
     const initialAppearance = enforceShapeForPlayers(initialAppearanceRaw, effectivePlayerCount);
     const initialEnvironment =
-      TEXAS_HDRI_OPTIONS[initialAppearance.environmentHdri] ??
-      TEXAS_HDRI_OPTIONS[TEXAS_DEFAULT_HDRI_INDEX] ??
-      TEXAS_HDRI_OPTIONS[0];
+      withHdriResolutionPreferences(
+        TEXAS_HDRI_OPTIONS[initialAppearance.environmentHdri] ??
+          TEXAS_HDRI_OPTIONS[TEXAS_DEFAULT_HDRI_INDEX] ??
+          TEXAS_HDRI_OPTIONS[0],
+        preferredHdriResolutionsRef.current
+      );
 
     const arenaGroup = new THREE.Group();
     scene.add(arenaGroup);


### PR DESCRIPTION
### Motivation
- The Texas Hold'em arena was not respecting user-selected HDRI resolution changes and could stick to a previously loaded lower-quality environment due to missing resolution preferences on the variant object.
- The Pool Royale implementation already normalizes HDRI variant resolution preferences before applying environments, so applying the same technique should ensure resolution switching behaves correctly.

### Description
- Added a helper `withHdriResolutionPreferences(variant, preferredResolutions)` that merges the currently requested resolution ladder with a variant's base `preferredResolutions` and sets a `fallbackResolution`.
- Replaced raw HDRI variant usage in Texas Hold'em with the normalized variant from `withHdriResolutionPreferences` during both initial boot and runtime appearance updates so environment loads request the correct resolution tier.
- Aligned the environment-reload guard to compare the normalized resolution id (`currentHdriResolutionId`) so changing `hdriResolutionId` triggers re-application when necessary.
- Changes made in `webapp/src/pages/Games/TexasHoldemArena.jsx`.

### Testing
- Ran `npx eslint --no-ignore --no-warn-ignored webapp/src/pages/Games/TexasHoldemArena.jsx`, which completed without errors (only repository-level warnings), indicating the modified file passes lint checks.
- No other automated tests were run in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca5848e1e48329956725f211fd0312)