### PR TITLE
Pool/Snooker: restore replay fallback and add chess GLTF color table finishes

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -394,7 +394,14 @@ export const POOL_ROYALE_OPTION_LABELS = Object.freeze({
     oakVeneer01: 'Oak Veneer 01',
     woodTable001: 'Wood Table 001',
     darkWood: 'Dark Wood',
-    rosewoodVeneer01: 'Rosewood Veneer 01'
+    rosewoodVeneer01: 'Rosewood Veneer 01',
+    chessAuroraMetalFinish: 'Chess Aurora Metal',
+    chessMonoFinish: 'Chess Mono',
+    chessBlueFinish: 'Chess Blue',
+    chessAmberFinish: 'Chess Amber',
+    chessMintFinish: 'Chess Mint',
+    chessPinkFinish: 'Chess Pink',
+    chessTealFinish: 'Chess Teal'
   }),
   chromeColor: Object.freeze({
     chrome: 'Chrome',
@@ -481,6 +488,69 @@ export const POOL_ROYALE_STORE_ITEMS = [
     price: 1020,
     description: 'Rosewood veneer rails with rich, reddish undertones.',
     thumbnail: TABLE_FINISH_THUMBNAILS.rosewoodVeneer01
+  },
+  {
+    id: 'finish-chessAuroraMetalFinish',
+    type: 'tableFinish',
+    optionId: 'chessAuroraMetalFinish',
+    name: 'Chess Aurora Metal Finish',
+    price: 1080,
+    description: 'ABeautifulGame classic white-metal tone over deep graphite rails.',
+    thumbnail: swatchThumbnail(['#ffffff', '#2b2f36', '#c5d8ff'])
+  },
+  {
+    id: 'finish-chessMonoFinish',
+    type: 'tableFinish',
+    optionId: 'chessMonoFinish',
+    name: 'Chess Mono Finish',
+    price: 1080,
+    description: 'Monochrome chess-piece palette with charcoal depth and light trim.',
+    thumbnail: swatchThumbnail(['#111827', '#0f172a', '#e5e7eb'])
+  },
+  {
+    id: 'finish-chessBlueFinish',
+    type: 'tableFinish',
+    optionId: 'chessBlueFinish',
+    name: 'Chess Blue Finish',
+    price: 1080,
+    description: 'Electric blue piece color paired with slate rails and cool highlights.',
+    thumbnail: swatchThumbnail(['#3b82f6', '#1e293b', '#93c5fd'])
+  },
+  {
+    id: 'finish-chessAmberFinish',
+    type: 'tableFinish',
+    optionId: 'chessAmberFinish',
+    name: 'Chess Amber Finish',
+    price: 1080,
+    description: 'Amber chess-piece tone with midnight base and warm edge trims.',
+    thumbnail: swatchThumbnail(['#f59e0b', '#1f2937', '#fde68a'])
+  },
+  {
+    id: 'finish-chessMintFinish',
+    type: 'tableFinish',
+    optionId: 'chessMintFinish',
+    name: 'Chess Mint Finish',
+    price: 1080,
+    description: 'Mint-themed ABeautifulGame colorway adapted for pool table rails.',
+    thumbnail: swatchThumbnail(['#10b981', '#065f46', '#a7f3d0'])
+  },
+  {
+    id: 'finish-chessPinkFinish',
+    type: 'tableFinish',
+    optionId: 'chessPinkFinish',
+    name: 'Chess Pink Finish',
+    price: 1080,
+    description: 'Crimson-pink chess accent on indigo rails with bright blush trim.',
+    thumbnail: swatchThumbnail(['#ef4444', '#312e81', '#fbcfe8'])
+  },
+  {
+    id: 'finish-chessTealFinish',
+    type: 'tableFinish',
+    optionId: 'chessTealFinish',
+    name: 'Chess Teal Finish',
+    price: 1080,
+    description: 'Violet-teal chess-piece palette with dark studio base contrast.',
+    thumbnail: swatchThumbnail(['#8b5cf6', '#0f172a', '#99f6e4'])
   },
   {
     id: 'chrome-chrome',

--- a/webapp/src/config/snookerRoyalInventoryConfig.js
+++ b/webapp/src/config/snookerRoyalInventoryConfig.js
@@ -393,7 +393,14 @@ export const SNOOKER_ROYALE_OPTION_LABELS = Object.freeze({
     oakVeneer01: 'Oak Veneer 01',
     woodTable001: 'Wood Table 001',
     darkWood: 'Dark Wood',
-    rosewoodVeneer01: 'Rosewood Veneer 01'
+    rosewoodVeneer01: 'Rosewood Veneer 01',
+    chessAuroraMetalFinish: 'Chess Aurora Metal',
+    chessMonoFinish: 'Chess Mono',
+    chessBlueFinish: 'Chess Blue',
+    chessAmberFinish: 'Chess Amber',
+    chessMintFinish: 'Chess Mint',
+    chessPinkFinish: 'Chess Pink',
+    chessTealFinish: 'Chess Teal'
   }),
   chromeColor: Object.freeze({
     chrome: 'Chrome',
@@ -480,6 +487,69 @@ export const SNOOKER_ROYALE_STORE_ITEMS = [
     price: 1020,
     description: 'Rosewood veneer rails with rich, reddish undertones.',
     thumbnail: TABLE_FINISH_THUMBNAILS.rosewoodVeneer01
+  },
+  {
+    id: 'finish-chessAuroraMetalFinish',
+    type: 'tableFinish',
+    optionId: 'chessAuroraMetalFinish',
+    name: 'Chess Aurora Metal Finish',
+    price: 1080,
+    description: 'ABeautifulGame classic white-metal tone over deep graphite rails.',
+    thumbnail: swatchThumbnail(['#ffffff', '#2b2f36', '#c5d8ff'])
+  },
+  {
+    id: 'finish-chessMonoFinish',
+    type: 'tableFinish',
+    optionId: 'chessMonoFinish',
+    name: 'Chess Mono Finish',
+    price: 1080,
+    description: 'Monochrome chess-piece palette with charcoal depth and light trim.',
+    thumbnail: swatchThumbnail(['#111827', '#0f172a', '#e5e7eb'])
+  },
+  {
+    id: 'finish-chessBlueFinish',
+    type: 'tableFinish',
+    optionId: 'chessBlueFinish',
+    name: 'Chess Blue Finish',
+    price: 1080,
+    description: 'Electric blue piece color paired with slate rails and cool highlights.',
+    thumbnail: swatchThumbnail(['#3b82f6', '#1e293b', '#93c5fd'])
+  },
+  {
+    id: 'finish-chessAmberFinish',
+    type: 'tableFinish',
+    optionId: 'chessAmberFinish',
+    name: 'Chess Amber Finish',
+    price: 1080,
+    description: 'Amber chess-piece tone with midnight base and warm edge trims.',
+    thumbnail: swatchThumbnail(['#f59e0b', '#1f2937', '#fde68a'])
+  },
+  {
+    id: 'finish-chessMintFinish',
+    type: 'tableFinish',
+    optionId: 'chessMintFinish',
+    name: 'Chess Mint Finish',
+    price: 1080,
+    description: 'Mint-themed ABeautifulGame colorway adapted for snooker table rails.',
+    thumbnail: swatchThumbnail(['#10b981', '#065f46', '#a7f3d0'])
+  },
+  {
+    id: 'finish-chessPinkFinish',
+    type: 'tableFinish',
+    optionId: 'chessPinkFinish',
+    name: 'Chess Pink Finish',
+    price: 1080,
+    description: 'Crimson-pink chess accent on indigo rails with bright blush trim.',
+    thumbnail: swatchThumbnail(['#ef4444', '#312e81', '#fbcfe8'])
+  },
+  {
+    id: 'finish-chessTealFinish',
+    type: 'tableFinish',
+    optionId: 'chessTealFinish',
+    name: 'Chess Teal Finish',
+    price: 1080,
+    description: 'Violet-teal chess-piece palette with dark studio base contrast.',
+    thumbnail: swatchThumbnail(['#8b5cf6', '#0f172a', '#99f6e4'])
   },
   {
     id: 'chrome-chrome',

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2939,6 +2939,72 @@ const createStandardWoodFinish = ({
   }
 });
 
+const CHESS_GLTF_PIECE_COLOR_FINISHES = Object.freeze([
+  {
+    id: 'chessAuroraMetalFinish',
+    label: 'Chess Aurora Metal',
+    rail: 0xffffff,
+    base: 0x2b2f36,
+    trim: 0xc5d8ff,
+    accent: 0xffffff,
+    woodTextureId: 'oak_veneer_01'
+  },
+  {
+    id: 'chessMonoFinish',
+    label: 'Chess Mono',
+    rail: 0x111827,
+    base: 0x0f172a,
+    trim: 0xe5e7eb,
+    accent: 0x111827,
+    woodTextureId: 'dark_wood'
+  },
+  {
+    id: 'chessBlueFinish',
+    label: 'Chess Blue',
+    rail: 0x3b82f6,
+    base: 0x1e293b,
+    trim: 0x93c5fd,
+    accent: 0x3b82f6,
+    woodTextureId: 'wood_table_001'
+  },
+  {
+    id: 'chessAmberFinish',
+    label: 'Chess Amber',
+    rail: 0xf59e0b,
+    base: 0x1f2937,
+    trim: 0xfde68a,
+    accent: 0xf59e0b,
+    woodTextureId: 'rosewood_veneer_01'
+  },
+  {
+    id: 'chessMintFinish',
+    label: 'Chess Mint',
+    rail: 0x10b981,
+    base: 0x065f46,
+    trim: 0xa7f3d0,
+    accent: 0x10b981,
+    woodTextureId: 'wood_peeling_paint_weathered'
+  },
+  {
+    id: 'chessPinkFinish',
+    label: 'Chess Pink',
+    rail: 0xef4444,
+    base: 0x312e81,
+    trim: 0xfbcfe8,
+    accent: 0xef4444,
+    woodTextureId: 'wood_table_001'
+  },
+  {
+    id: 'chessTealFinish',
+    label: 'Chess Teal',
+    rail: 0x8b5cf6,
+    base: 0x0f172a,
+    trim: 0x99f6e4,
+    accent: 0x8b5cf6,
+    woodTextureId: 'dark_wood'
+  }
+]);
+
 const TABLE_FINISHES = Object.freeze({
   peelingPaintWeathered: createStandardWoodFinish({
     id: 'peelingPaintWeathered',
@@ -2984,7 +3050,16 @@ const TABLE_FINISHES = Object.freeze({
     trim: 0x9b5a44,
     woodTextureId: 'rosewood_veneer_01',
     woodRepeatScale: 1
-  })
+  }),
+  ...Object.fromEntries(
+    CHESS_GLTF_PIECE_COLOR_FINISHES.map((finish) => [
+      finish.id,
+      createStandardWoodFinish({
+        ...finish,
+        woodRepeatScale: 1
+      })
+    ])
+  )
 });
 
 const TABLE_FINISH_OPTIONS = Object.freeze(
@@ -2993,7 +3068,8 @@ const TABLE_FINISH_OPTIONS = Object.freeze(
     TABLE_FINISHES.oakVeneer01,
     TABLE_FINISHES.woodTable001,
     TABLE_FINISHES.darkWood,
-    TABLE_FINISHES.rosewoodVeneer01
+    TABLE_FINISHES.rosewoodVeneer01,
+    ...CHESS_GLTF_PIECE_COLOR_FINISHES.map((finish) => TABLE_FINISHES[finish.id])
   ].filter(Boolean)
 );
 
@@ -28638,6 +28714,25 @@ const powerRef = useRef(hud.power);
         if (replayDecision && shotRecording) {
           shotRecording.replayTags = replayDecision.tags;
           shotRecording.zoomOnly = replayDecision.zoomOnly;
+        }
+        if (
+          !replayDecision &&
+          (shotRecording?.frames?.length ?? 0) > 1 &&
+          Boolean(firstHit)
+        ) {
+          replayDecision = {
+            shouldReplay: true,
+            banner: selectReplayBanner('default'),
+            zoomOnly: false,
+            tags: ['default'],
+            primaryTag: 'default'
+          };
+          replayBannerText = replayDecision.banner;
+          replayAccent = replayDecision.primaryTag;
+          if (shotRecording) {
+            shotRecording.replayTags = replayDecision.tags;
+            shotRecording.zoomOnly = false;
+          }
         }
         shouldStartReplay =
           !skipAllReplaysRef.current &&

--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -2686,6 +2686,72 @@ const createStandardWoodFinish = ({
   }
 });
 
+const CHESS_GLTF_PIECE_COLOR_FINISHES = Object.freeze([
+  {
+    id: 'chessAuroraMetalFinish',
+    label: 'Chess Aurora Metal',
+    rail: 0xffffff,
+    base: 0x2b2f36,
+    trim: 0xc5d8ff,
+    accent: 0xffffff,
+    woodTextureId: 'oak_veneer_01'
+  },
+  {
+    id: 'chessMonoFinish',
+    label: 'Chess Mono',
+    rail: 0x111827,
+    base: 0x0f172a,
+    trim: 0xe5e7eb,
+    accent: 0x111827,
+    woodTextureId: 'dark_wood'
+  },
+  {
+    id: 'chessBlueFinish',
+    label: 'Chess Blue',
+    rail: 0x3b82f6,
+    base: 0x1e293b,
+    trim: 0x93c5fd,
+    accent: 0x3b82f6,
+    woodTextureId: 'wood_table_001'
+  },
+  {
+    id: 'chessAmberFinish',
+    label: 'Chess Amber',
+    rail: 0xf59e0b,
+    base: 0x1f2937,
+    trim: 0xfde68a,
+    accent: 0xf59e0b,
+    woodTextureId: 'rosewood_veneer_01'
+  },
+  {
+    id: 'chessMintFinish',
+    label: 'Chess Mint',
+    rail: 0x10b981,
+    base: 0x065f46,
+    trim: 0xa7f3d0,
+    accent: 0x10b981,
+    woodTextureId: 'wood_peeling_paint_weathered'
+  },
+  {
+    id: 'chessPinkFinish',
+    label: 'Chess Pink',
+    rail: 0xef4444,
+    base: 0x312e81,
+    trim: 0xfbcfe8,
+    accent: 0xef4444,
+    woodTextureId: 'wood_table_001'
+  },
+  {
+    id: 'chessTealFinish',
+    label: 'Chess Teal',
+    rail: 0x8b5cf6,
+    base: 0x0f172a,
+    trim: 0x99f6e4,
+    accent: 0x8b5cf6,
+    woodTextureId: 'dark_wood'
+  }
+]);
+
 const TABLE_FINISHES = Object.freeze({
   peelingPaintWeathered: createStandardWoodFinish({
     id: 'peelingPaintWeathered',
@@ -2731,7 +2797,16 @@ const TABLE_FINISHES = Object.freeze({
     trim: 0x9b5a44,
     woodTextureId: 'rosewood_veneer_01',
     woodRepeatScale: 1
-  })
+  }),
+  ...Object.fromEntries(
+    CHESS_GLTF_PIECE_COLOR_FINISHES.map((finish) => [
+      finish.id,
+      createStandardWoodFinish({
+        ...finish,
+        woodRepeatScale: 1
+      })
+    ])
+  )
 });
 
 const TABLE_FINISH_OPTIONS = Object.freeze(
@@ -2740,7 +2815,8 @@ const TABLE_FINISH_OPTIONS = Object.freeze(
     TABLE_FINISHES.oakVeneer01,
     TABLE_FINISHES.woodTable001,
     TABLE_FINISHES.darkWood,
-    TABLE_FINISHES.rosewoodVeneer01
+    TABLE_FINISHES.rosewoodVeneer01,
+    ...CHESS_GLTF_PIECE_COLOR_FINISHES.map((finish) => TABLE_FINISHES[finish.id])
   ].filter(Boolean)
 );
 


### PR DESCRIPTION
### Motivation
- Replays in Pool Royale were being skipped for some completed shots when no tag-based replay reason was generated despite valid cue contact and captured frames, so a fallback was needed to restore expected replay behavior. 
- Provide players with more purchasable table finishes that match the ABeautifulGame/ABeautifulGame GLTF piece color palettes so pool and snooker tables can use the same visual themes as the chess pieces.

### Description
- Added a replay fallback in `PoolRoyale.jsx` that forces a replay decision when `firstHit` is present and `shotRecording.frames` were captured so replays are no longer silently skipped. 
- Introduced `CHESS_GLTF_PIECE_COLOR_FINISHES` and appended those variants into `TABLE_FINISHES` and `TABLE_FINISH_OPTIONS` in both `PoolRoyale.jsx` and `SnookerRoyal.jsx` to expose seven new finishes (Aurora Metal, Mono, Blue, Amber, Mint, Pink, Teal). 
- Updated inventory/store metadata in `poolRoyaleInventoryConfig.js` and `snookerRoyalInventoryConfig.js` to add labels and `POOL/SNOOKER` store entries for all new finishes so they are purchasable and selectable in-game. 
- Kept changes self-contained to the UI/finish lists and replay-decision logic; no API or engine subsystems were modified.

### Testing
- Ran a production build with `npm --prefix webapp run build`, which completed successfully using Vite and produced no blocking errors. 
- The build reported the existing Vite chunk-size/dynamic-import warnings but no new build-time errors were observed during validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca5a51f04883299807a84e4da492ce)