### PR TITLE
Add separate HDRI resolution controls to Domino graphics menu

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -12,7 +12,9 @@ import './flag-emojis.js';
 const urlParams = new URLSearchParams(window.location.search);
 const FRAME_TIME_CATCH_UP_MULTIPLIER = 3;
 const FRAME_RATE_STORAGE_KEY = 'dominoRoyalFrameRate';
+const HDRI_RESOLUTION_STORAGE_KEY = 'dominoRoyalHdriResolution';
 const DEFAULT_FRAME_RATE_ID = 'fhd60';
+const DEFAULT_HDRI_RESOLUTION_MODE = 'auto';
 const FRAME_RATE_OPTIONS = Object.freeze([
   {
     id: 'fhd60',
@@ -53,6 +55,20 @@ const FRAME_RATE_OPTIONS = Object.freeze([
 ]);
 const FRAME_RATE_OPTIONS_BY_ID = Object.freeze(
   FRAME_RATE_OPTIONS.reduce((acc, option) => {
+    acc[option.id] = option;
+    return acc;
+  }, {})
+);
+const HDRI_RESOLUTION_OPTIONS = Object.freeze([
+  { id: 'auto', label: 'Match Graphics' },
+  { id: '8k', label: '8K' },
+  { id: '6k', label: '6K' },
+  { id: '4k', label: '4K' },
+  { id: '2k', label: '2K' },
+  { id: '1k', label: 'Full HD' }
+]);
+const HDRI_RESOLUTION_OPTION_MAP = Object.freeze(
+  HDRI_RESOLUTION_OPTIONS.reduce((acc, option) => {
     acc[option.id] = option;
     return acc;
   }, {})
@@ -441,6 +457,29 @@ function resolveInitialFrameRateId() {
   return DEFAULT_FRAME_RATE_ID;
 }
 
+function normalizeHdriResolutionId(rawId) {
+  if (!rawId) return null;
+  return HDRI_RESOLUTION_OPTION_MAP[rawId] ? rawId : null;
+}
+
+function resolveInitialHdriResolutionId() {
+  if (typeof window !== 'undefined') {
+    try {
+      const stored = window.localStorage?.getItem(HDRI_RESOLUTION_STORAGE_KEY);
+      const normalizedStored = normalizeHdriResolutionId(stored);
+      if (normalizedStored) {
+        return normalizedStored;
+      }
+    } catch (error) {
+      console.warn(
+        'Failed to read Domino HDRI resolution selection, falling back',
+        error
+      );
+    }
+  }
+  return DEFAULT_HDRI_RESOLUTION_MODE;
+}
+
 function findFallbackFrameRateId(currentId) {
   const idx = FRAME_RATE_OPTIONS.findIndex((opt) => opt.id === currentId);
   if (idx > 0) {
@@ -450,6 +489,7 @@ function findFallbackFrameRateId(currentId) {
 }
 
 let frameRateId = resolveInitialFrameRateId();
+let hdriResolutionId = resolveInitialHdriResolutionId();
 let frameQuality = buildFrameQuality(frameRateId);
 let frameTiming = buildFrameTiming(frameQuality);
 let slowFrameAccumulatorMs = 0;
@@ -462,6 +502,15 @@ function persistFrameRateSelection(id) {
     window.localStorage?.setItem(FRAME_RATE_STORAGE_KEY, id);
   } catch (error) {
     console.warn('Failed to persist Domino graphics option', error);
+  }
+}
+
+function persistHdriResolutionSelection(id) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage?.setItem(HDRI_RESOLUTION_STORAGE_KEY, id);
+  } catch (error) {
+    console.warn('Failed to persist Domino HDRI resolution option', error);
   }
 }
 
@@ -4447,6 +4496,14 @@ const isLowProfileDevice =
   isTelegramWebView || isMobileDevice || isLowMemoryDevice || isLowCoreDevice;
 const MAX_HDRI_CACHE_SIZE = prefersUhd ? 4 : isLowProfileDevice ? 1 : 2;
 function resolveHdriResolutionOrder() {
+  const selectedHdriResolution =
+    normalizeHdriResolutionId(hdriResolutionId) ?? DEFAULT_HDRI_RESOLUTION_MODE;
+  if (selectedHdriResolution !== 'auto') {
+    return [
+      selectedHdriResolution,
+      ...HDRI_RESOLUTION_ORDER.filter((res) => res !== selectedHdriResolution)
+    ];
+  }
   switch (frameRateId) {
     case 'ultra144':
       return ['8k'];
@@ -6937,6 +6994,21 @@ function applyFrameRateSelection(
   }
 }
 
+function applyHdriResolutionSelection(optionId, { refreshUi = true } = {}) {
+  const resolvedId =
+    normalizeHdriResolutionId(optionId) ?? DEFAULT_HDRI_RESOLUTION_MODE;
+  if (hdriResolutionId === resolvedId) return;
+  hdriResolutionId = resolvedId;
+  persistHdriResolutionSelection(resolvedId);
+  applyEnvironmentHdri(
+    ENVIRONMENT_HDRI_OPTIONS[appearance.environmentHdri] ??
+      ENVIRONMENT_HDRI_OPTIONS[0]
+  );
+  if (refreshUi) {
+    refreshConfigUI();
+  }
+}
+
 window.addEventListener('dominoRoyalInventoryUpdate', (event) => {
   const targetAccount = resolveDominoAccountId(event?.detail?.accountId);
   const currentAccount = resolveDominoAccountId();
@@ -7297,6 +7369,47 @@ function refreshConfigUI() {
   graphicsGrid.className = 'config-options';
   graphicsGrid.style.gridTemplateColumns =
     'repeat(auto-fit, minmax(200px, 1fr))';
+  const hdriHeader = document.createElement('p');
+  hdriHeader.textContent = 'HDRI Resolution';
+  hdriHeader.style.margin = '0';
+  hdriHeader.style.fontSize = '0.68rem';
+  hdriHeader.style.letterSpacing = '0.08em';
+  hdriHeader.style.textTransform = 'uppercase';
+  hdriHeader.style.fontWeight = '700';
+  hdriHeader.style.color = 'rgba(226,232,240,0.72)';
+  graphicsWrapper.appendChild(hdriHeader);
+  const hdriGrid = document.createElement('div');
+  hdriGrid.className = 'config-options';
+  hdriGrid.style.gridTemplateColumns = 'repeat(auto-fit, minmax(120px, 1fr))';
+  hdriGrid.style.marginTop = '0.45rem';
+  HDRI_RESOLUTION_OPTIONS.forEach((option) => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'config-option';
+    if (hdriResolutionId === option.id) {
+      button.classList.add('active');
+    }
+    button.setAttribute('aria-pressed', String(hdriResolutionId === option.id));
+    const label = document.createElement('span');
+    label.textContent = option.label;
+    button.appendChild(label);
+    button.addEventListener('click', () => {
+      applyHdriResolutionSelection(option.id, { refreshUi: false });
+      refreshConfigUI();
+    });
+    hdriGrid.appendChild(button);
+  });
+  graphicsWrapper.appendChild(hdriGrid);
+  const graphicsHeader = document.createElement('p');
+  graphicsHeader.textContent = 'Render Quality';
+  graphicsHeader.style.margin = '0.65rem 0 0';
+  graphicsHeader.style.fontSize = '0.68rem';
+  graphicsHeader.style.letterSpacing = '0.08em';
+  graphicsHeader.style.textTransform = 'uppercase';
+  graphicsHeader.style.fontWeight = '700';
+  graphicsHeader.style.color = 'rgba(226,232,240,0.72)';
+  graphicsWrapper.appendChild(graphicsHeader);
+  graphicsGrid.style.marginTop = '0.45rem';
   FRAME_RATE_OPTIONS.forEach((option) => {
     const button = document.createElement('button');
     button.type = 'button';


### PR DESCRIPTION
### Motivation
- Provide players the same HDRI resolution control in Domino Battle Royal as exists in Pool Royale so HDRIs can be tuned independently from overall graphics/frame-rate presets.
- Allow manual override of HDRI resolution while keeping an `auto` mode that follows the active graphics profile.

### Description
- Added new HDRI config constants and maps: `HDRI_RESOLUTION_STORAGE_KEY`, `DEFAULT_HDRI_RESOLUTION_MODE`, `HDRI_RESOLUTION_OPTIONS`, and `HDRI_RESOLUTION_OPTION_MAP` in `webapp/public/domino-royal-game.js`.
- Implemented initialization, normalization and persistence helpers: `normalizeHdriResolutionId`, `resolveInitialHdriResolutionId`, and `persistHdriResolutionSelection`, and exposed runtime state `hdriResolutionId`.
- Updated resolution selection logic in `resolveHdriResolutionOrder()` so a manual HDRI choice overrides the automatic frame-rate-driven ordering, and wired `loadHdriEnvironment()` / `applyEnvironmentHdri()` to use that ordering.
- Added `applyHdriResolutionSelection()` and extended the in-game Graphics config UI in `refreshConfigUI()` with a dedicated `HDRI Resolution` section (buttons for `Match Graphics/8K/6K/4K/2K/Full HD`) placed above the Render Quality controls.

### Testing
- Ran `node --check webapp/public/domino-royal-game.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca58eed9e08329958ded75e8d95426)