### PR TITLE
Add manual HDRI resolution controls to Domino Royale graphics menu

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -12,7 +12,9 @@ import './flag-emojis.js';
 const urlParams = new URLSearchParams(window.location.search);
 const FRAME_TIME_CATCH_UP_MULTIPLIER = 3;
 const FRAME_RATE_STORAGE_KEY = 'dominoRoyalFrameRate';
+const HDRI_RESOLUTION_STORAGE_KEY = 'dominoRoyalHdriResolution';
 const DEFAULT_FRAME_RATE_ID = 'fhd60';
+const DEFAULT_HDRI_RESOLUTION_MODE = '4k';
 const FRAME_RATE_OPTIONS = Object.freeze([
   {
     id: 'fhd60',
@@ -53,6 +55,20 @@ const FRAME_RATE_OPTIONS = Object.freeze([
 ]);
 const FRAME_RATE_OPTIONS_BY_ID = Object.freeze(
   FRAME_RATE_OPTIONS.reduce((acc, option) => {
+    acc[option.id] = option;
+    return acc;
+  }, {})
+);
+const HDRI_RESOLUTION_OPTIONS = Object.freeze([
+  { id: 'auto', label: 'Match Graphics' },
+  { id: '8k', label: '8K' },
+  { id: '6k', label: '6K' },
+  { id: '4k', label: '4K' },
+  { id: '2k', label: '2K' },
+  { id: '1k', label: 'Full HD' }
+]);
+const HDRI_RESOLUTION_OPTION_MAP = Object.freeze(
+  HDRI_RESOLUTION_OPTIONS.reduce((acc, option) => {
     acc[option.id] = option;
     return acc;
   }, {})
@@ -441,6 +457,48 @@ function resolveInitialFrameRateId() {
   return DEFAULT_FRAME_RATE_ID;
 }
 
+function resolveGraphicsHdriResolutionId(qualityId = DEFAULT_FRAME_RATE_ID) {
+  switch (qualityId) {
+    case 'ultra144':
+    case 'uhd120':
+      return '8k';
+    case 'qhd90':
+      return '6k';
+    case 'fhd60':
+      return '4k';
+    default:
+      return DEFAULT_HDRI_RESOLUTION_MODE;
+  }
+}
+
+function resolveInitialHdriResolutionId(frameRateOptionId = frameRateId) {
+  const normalizeHdriResolutionId = (rawId) => {
+    if (!rawId) return null;
+    return HDRI_RESOLUTION_OPTION_MAP[rawId] ? rawId : null;
+  };
+  const urlPreset =
+    urlParams.get('hdriResolutionId') || urlParams.get('hdriResolution');
+  const normalizedUrlPreset = normalizeHdriResolutionId(urlPreset);
+  if (normalizedUrlPreset) {
+    return normalizedUrlPreset;
+  }
+  if (typeof window !== 'undefined') {
+    try {
+      const stored = window.localStorage?.getItem(HDRI_RESOLUTION_STORAGE_KEY);
+      const normalizedStored = normalizeHdriResolutionId(stored);
+      if (normalizedStored) {
+        return normalizedStored;
+      }
+    } catch (error) {
+      console.warn(
+        'Failed to read Domino HDRI resolution, falling back',
+        error
+      );
+    }
+  }
+  return resolveGraphicsHdriResolutionId(frameRateOptionId);
+}
+
 function findFallbackFrameRateId(currentId) {
   const idx = FRAME_RATE_OPTIONS.findIndex((opt) => opt.id === currentId);
   if (idx > 0) {
@@ -450,6 +508,7 @@ function findFallbackFrameRateId(currentId) {
 }
 
 let frameRateId = resolveInitialFrameRateId();
+let hdriResolutionId = resolveInitialHdriResolutionId(frameRateId);
 let frameQuality = buildFrameQuality(frameRateId);
 let frameTiming = buildFrameTiming(frameQuality);
 let slowFrameAccumulatorMs = 0;
@@ -462,6 +521,15 @@ function persistFrameRateSelection(id) {
     window.localStorage?.setItem(FRAME_RATE_STORAGE_KEY, id);
   } catch (error) {
     console.warn('Failed to persist Domino graphics option', error);
+  }
+}
+
+function persistHdriResolutionSelection(id) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage?.setItem(HDRI_RESOLUTION_STORAGE_KEY, id);
+  } catch (error) {
+    console.warn('Failed to persist Domino HDRI resolution option', error);
   }
 }
 
@@ -4447,6 +4515,15 @@ const isLowProfileDevice =
   isTelegramWebView || isMobileDevice || isLowMemoryDevice || isLowCoreDevice;
 const MAX_HDRI_CACHE_SIZE = prefersUhd ? 4 : isLowProfileDevice ? 1 : 2;
 function resolveHdriResolutionOrder() {
+  if (
+    hdriResolutionId !== 'auto' &&
+    HDRI_RESOLUTION_OPTION_MAP[hdriResolutionId]
+  ) {
+    const preferredIndex = HDRI_RESOLUTION_ORDER.indexOf(hdriResolutionId);
+    if (preferredIndex >= 0) {
+      return HDRI_RESOLUTION_ORDER.slice(preferredIndex).reverse();
+    }
+  }
   switch (frameRateId) {
     case 'ultra144':
       return ['8k'];
@@ -6937,6 +7014,25 @@ function applyFrameRateSelection(
   }
 }
 
+function applyHdriResolutionSelection(optionId, { refreshUi = true } = {}) {
+  const resolvedId = HDRI_RESOLUTION_OPTION_MAP[optionId]
+    ? optionId
+    : DEFAULT_HDRI_RESOLUTION_MODE;
+  if (hdriResolutionId === resolvedId && refreshUi) {
+    refreshConfigUI();
+    return;
+  }
+  hdriResolutionId = resolvedId;
+  persistHdriResolutionSelection(resolvedId);
+  applyEnvironmentHdri(
+    ENVIRONMENT_HDRI_OPTIONS[appearance.environmentHdri] ??
+      ENVIRONMENT_HDRI_OPTIONS[0]
+  );
+  if (refreshUi) {
+    refreshConfigUI();
+  }
+}
+
 window.addEventListener('dominoRoyalInventoryUpdate', (event) => {
   const targetAccount = resolveDominoAccountId(event?.detail?.accountId);
   const currentAccount = resolveDominoAccountId();
@@ -7293,6 +7389,43 @@ function refreshConfigUI() {
   const graphicsLabel = document.createElement('h4');
   graphicsLabel.textContent = 'Graphics';
   graphicsWrapper.appendChild(graphicsLabel);
+  const activeHdriResolution = resolveHdriResolutionOrder()[0] || '4k';
+  const hdriSummary = document.createElement('p');
+  hdriSummary.textContent = `HDRI resolution: ${String(activeHdriResolution).toUpperCase()}`;
+  hdriSummary.style.margin = '0';
+  hdriSummary.style.fontSize = '0.65rem';
+  hdriSummary.style.lineHeight = '1.4';
+  hdriSummary.style.color = 'rgba(226,232,240,0.72)';
+  graphicsWrapper.appendChild(hdriSummary);
+  const hdriGrid = document.createElement('div');
+  hdriGrid.className = 'config-options';
+  hdriGrid.style.gridTemplateColumns = 'repeat(auto-fit, minmax(126px, 1fr))';
+  HDRI_RESOLUTION_OPTIONS.forEach((option) => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'config-option';
+    const isActive = hdriResolutionId === option.id;
+    if (isActive) {
+      button.classList.add('active');
+    }
+    button.setAttribute('aria-pressed', String(isActive));
+    const label = document.createElement('span');
+    label.textContent = 'HDRI';
+    button.appendChild(label);
+    const line = document.createElement('div');
+    line.textContent = option.label;
+    line.style.fontSize = '0.74rem';
+    line.style.fontWeight = '700';
+    line.style.letterSpacing = '0.04em';
+    button.appendChild(line);
+    button.addEventListener('click', () => {
+      if (hdriResolutionId === option.id) return;
+      applyHdriResolutionSelection(option.id, { refreshUi: false });
+      refreshConfigUI();
+    });
+    hdriGrid.appendChild(button);
+  });
+  graphicsWrapper.appendChild(hdriGrid);
   const graphicsGrid = document.createElement('div');
   graphicsGrid.className = 'config-options';
   graphicsGrid.style.gridTemplateColumns =

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-03-30-graphics-4k-6k-8k-v4';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-03-30-hdri-resolution-menu-v5';
 
 export default function DominoRoyalArena() {
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- Provide players the same per-HDRI resolution controls in Domino Battle Royal as in Pool Royale so HDRI quality can be set independently of FPS/graphics presets. 
- Allow players to explicitly select and persist HDRI texture resolution while preserving the existing automatic behavior that matches graphics presets.

### Description
- Added HDRI resolution constants and mapping (`HDRI_RESOLUTION_OPTIONS`, `HDRI_RESOLUTION_OPTION_MAP`, `HDRI_RESOLUTION_STORAGE_KEY`, `DEFAULT_HDRI_RESOLUTION_MODE`) and initialized a new selection state `hdriResolutionId` in `webapp/public/domino-royal-game.js`.
- Implemented initialization and persistence with URL param support via `resolveInitialHdriResolutionId(...)` and `persistHdriResolutionSelection(...)`, and added `resolveGraphicsHdriResolutionId(...)` to map graphics presets to default HDRI choices.
- Updated HDRI loading selection to honor manual HDRI choice by extending `resolveHdriResolutionOrder()` and added `applyHdriResolutionSelection(...)` to apply the HDRI change immediately without changing frame-rate presets.
- Added UI elements in the Domino config panel to show the active HDRI resolution summary and buttons for `Match Graphics / 8K / 6K / 4K / 2K / Full HD`, and bumped the Domino script version in `webapp/src/pages/Games/DominoRoyalArena.jsx` to force client cache refresh.

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` with no syntax errors reported.
- Ran `npx eslint webapp/public/domino-royal-game.js webapp/src/pages/Games/DominoRoyalArena.jsx` and `npx eslint --no-ignore webapp/src/pages/Games/DominoRoyalArena.jsx`; ESLint reported only ignore/warning messages due to current project ignore patterns and no blocking errors.
- Verified that selecting HDRI resolution triggers `applyEnvironmentHdri(...)` and that `hdriResolutionId` is stored and restored from `localStorage` and via the `hdriResolutionId`/`hdriResolution` URL parameters during startup.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca58eed9e08329958ded75e8d95426)