### PR TITLE
Redesign Snake & Ladder board with classic spiral palette

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -150,6 +150,12 @@ const CAM = {
 
 const TILE_COLOR_A = new THREE.Color(0xe7e2d3);
 const TILE_COLOR_B = new THREE.Color(0x776a5a);
+const CLASSIC_SPIRAL_TILE_COLORS = Object.freeze([
+  new THREE.Color('#ef4444'),
+  new THREE.Color('#4ade80'),
+  new THREE.Color('#3b82f6'),
+  new THREE.Color('#fbbf24')
+]);
 const DEFAULT_HIGHLIGHT_COLORS = Object.freeze({
   normal: new THREE.Color(0xf59e0b),
   snake: new THREE.Color(0xdc2626),
@@ -2235,6 +2241,24 @@ function createTileMaterialSet(baseColor, palette = {}) {
   };
 }
 
+function resolveTileBaseColor(tileIndex, row, col, levelIndex, boardTheme, tileLightBase, tileDarkBase) {
+  const paletteColors = Array.isArray(boardTheme.pathColors)
+    ? boardTheme.pathColors
+        .map((value) => toThreeColor(value, null))
+        .filter(Boolean)
+    : [];
+
+  if (paletteColors.length > 0) {
+    return paletteColors[(tileIndex - 1) % paletteColors.length].clone();
+  }
+
+  if (boardTheme.useClassicSpiralColors) {
+    return CLASSIC_SPIRAL_TILE_COLORS[levelIndex % CLASSIC_SPIRAL_TILE_COLORS.length].clone();
+  }
+
+  return (row + col) % 2 === 0 ? tileLightBase.clone() : tileDarkBase.clone();
+}
+
 function resetTileAppearance(tile) {
   const { topMaterial, sideMaterial, bottomMaterial, baseColor } = tile.userData ?? {};
   if (topMaterial && baseColor) {
@@ -2926,7 +2950,15 @@ function buildSnakeBoard(
     const perimeter = buildPerimeterSequence(size).slice(0, levelTileCount);
     perimeter.forEach(({ row, col }, seqIndex) => {
       const idx = offset + seqIndex + 1;
-      const baseColor = (row + col) % 2 === 0 ? tileLightBase.clone() : tileDarkBase.clone();
+      const baseColor = resolveTileBaseColor(
+        idx,
+        row,
+        col,
+        levelIndex,
+        boardTheme,
+        tileLightBase,
+        tileDarkBase
+      );
       const materialSet = createTileMaterialSet(baseColor, boardTheme);
       const baseX = -half + (col + 0.5) * TILE_SIZE;
       const baseZ = -half + ((size - 1 - row) + 0.5) * TILE_SIZE;

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -426,6 +426,26 @@ const ARENA_THEME_OPTIONS = Object.freeze([
 
 const BOARD_PALETTE_OPTIONS = Object.freeze([
   {
+    id: 'classicSpiralArena',
+    label: 'Classic Spiral Arena',
+    light: '#f8fafc',
+    dark: '#e2e8f0',
+    pathColors: ['#ef4444', '#4ade80', '#3b82f6', '#fbbf24'],
+    side: '#a16207',
+    bottom: '#78350f',
+    topEmissive: '#111827',
+    sideEmissive: '#1f2937',
+    bottomEmissive: '#111827',
+    topRoughness: 0.4,
+    topMetalness: 0.24,
+    topBlend: 0.03,
+    sideBlend: 0.3,
+    bottomBlend: 0.15,
+    highlightNormal: '#f97316',
+    highlightSnake: '#ef4444',
+    highlightLadder: '#22c55e'
+  },
+  {
     id: 'desertMarble',
     label: 'Desert Marble',
     light: '#f3ebe0',


### PR DESCRIPTION
### Motivation
- Make the Snake & Ladder board match the provided reference by introducing a vivid spiral-style color treatment for the path tiles while preserving existing themes and fallbacks.

### Description
- Added a new board palette `Classic Spiral Arena` with an ordered `pathColors` array to `webapp/src/pages/Games/SnakeAndLadder.jsx` so palettes can specify sequential path bands that wrap the board.
- Added `CLASSIC_SPIRAL_TILE_COLORS` constant and a new `resolveTileBaseColor` function in `webapp/src/components/SnakeBoard3D.jsx` to pick tile base colors from `boardTheme.pathColors`, fall back to the new classic spiral colors when `useClassicSpiralColors` is set, or preserve the original checker pattern otherwise.
- Replaced the previous inline checker-color selection with a call to `resolveTileBaseColor` when constructing tile materials so the board supports ordered path palettes without changing other rendering code.

### Testing
- Ran the production build with `npm --prefix webapp run build` and the build completed successfully (Vite reported unrelated chunk-size / dynamic-import warnings but no failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca69f161a48329ad2f2bf7fedb05b8)