### PR TITLE
Fix Texas Hold'em HDRI resolution selection priority

### DIFF
--- a/test/texasHoldemHdriPreload.test.js
+++ b/test/texasHoldemHdriPreload.test.js
@@ -1,0 +1,37 @@
+import { resolveTexasHoldemHdriUrl } from '../webapp/src/utils/texasHoldemHdriPreload.js';
+
+describe('resolveTexasHoldemHdriUrl', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  test('prioritizes requested resolution over config default resolution', async () => {
+    global.fetch = jest.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        hdr: {
+          '8k': {
+            hdr: 'https://cdn.example.com/hdr/studio_8k.hdr'
+          },
+          '2k': {
+            hdr: 'https://cdn.example.com/hdr/studio_2k.hdr'
+          }
+        }
+      })
+    }));
+
+    const url = await resolveTexasHoldemHdriUrl(
+      {
+        id: 'studio',
+        assetId: 'studio',
+        preferredResolutions: ['2k']
+      },
+      ['8k', '6k', '4k', '2k', '1k']
+    );
+
+    expect(url).toBe('https://cdn.example.com/hdr/studio_8k.hdr');
+  });
+});

--- a/webapp/src/utils/texasHoldemHdriPreload.js
+++ b/webapp/src/utils/texasHoldemHdriPreload.js
@@ -125,10 +125,16 @@ async function getPolyHavenFilesJson(assetId) {
 }
 
 export async function resolveTexasHoldemHdriUrl(config = {}, preferred = DEFAULT_RESOLUTIONS) {
-  const preferredResolutions =
-    Array.isArray(config?.preferredResolutions) && config.preferredResolutions.length
-      ? config.preferredResolutions
-      : preferred;
+  const requestedResolutions = Array.isArray(preferred)
+    ? preferred.filter((value) => typeof value === 'string' && value.length)
+    : [];
+  const configResolutions = Array.isArray(config?.preferredResolutions)
+    ? config.preferredResolutions.filter((value) => typeof value === 'string' && value.length)
+    : [];
+  const preferredResolutions = Array.from(new Set([...requestedResolutions, ...configResolutions]));
+  if (!preferredResolutions.length) {
+    preferredResolutions.push(...DEFAULT_RESOLUTIONS);
+  }
   const cacheKey = `${String(config?.id || config?.assetId || getFallbackHdriUrl(config, preferredResolutions))}|${preferredResolutions.join(',')}`;
   if (hdriUrlCache.has(cacheKey)) {
     return hdriUrlCache.get(cacheKey);


### PR DESCRIPTION
### Motivation
- HDRI resolution chosen via the UI was not reliably applied because variant `config.preferredResolutions` could override the player-selected resolution, preventing the HDRI option from changing the loaded asset.
- Ensure the HDRI resolution option actually controls which HDRI asset is loaded so graphics resolution controls work as expected for Texas Hold’em.

### Description
- Update `resolveTexasHoldemHdriUrl` to merge the requested `preferred` resolutions with `config.preferredResolutions`, with de-duplication and the requested resolutions taking precedence when present. (file: `webapp/src/utils/texasHoldemHdriPreload.js`)
- Add a regression unit test that fakes the PolyHaven files JSON and verifies a requested `8k` resolution overrides a variant default of `2k` when available. (file: `test/texasHoldemHdriPreload.test.js`)
- Provide a safe fallback to `DEFAULT_RESOLUTIONS` when no valid preferences are supplied to avoid empty resolution lists.

### Testing
- Ran `npm test -- test/texasHoldemHdriPreload.test.js` and the new test suite passed. (1 test, 1 passed)
- The test validates that `resolveTexasHoldemHdriUrl` returns the `8k` HDRI URL when `['8k', '6k', '4k', '2k', '1k']` is requested and the variant offers `2k` by default.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca6afe3f648329987cdc971ef93e31)