### PR TITLE
Add Pool-style HDRI resolution controls to Murlan Royale graphics menu

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2287,9 +2287,12 @@ const FRAME_RATE_OPTIONS = Object.freeze([
   }
 ]);
 const HDRI_RESOLUTION_OPTIONS = Object.freeze([
+  { id: 'auto', label: 'Match Table' },
   { id: '8k', label: '8K' },
   { id: '6k', label: '6K' },
-  { id: '4k', label: '4K' }
+  { id: '4k', label: '4K' },
+  { id: '2k', label: '2K' },
+  { id: '1k', label: 'Full HD' }
 ]);
 const HDRI_RESOLUTION_OPTION_MAP = Object.freeze(
   HDRI_RESOLUTION_OPTIONS.reduce((acc, option) => {
@@ -2297,7 +2300,7 @@ const HDRI_RESOLUTION_OPTION_MAP = Object.freeze(
     return acc;
   }, {})
 );
-const DEFAULT_HDRI_RESOLUTION_ID = '4k';
+const DEFAULT_HDRI_RESOLUTION_ID = 'auto';
 const DEFAULT_FRAME_RATE_OPTION =
   FRAME_RATE_OPTIONS.find((opt) => opt.id === DEFAULT_FRAME_RATE_ID) ?? FRAME_RATE_OPTIONS[0];
 
@@ -2481,8 +2484,19 @@ export default function MurlanRoyaleArena({ search }) {
       window.removeEventListener('orientationchange', updateOrientation);
     };
   }, []);
-  const resolvedHdriResolution =
-    (HDRI_RESOLUTION_OPTION_MAP[hdriResolutionId] && hdriResolutionId) || DEFAULT_HDRI_RESOLUTION_ID;
+  const resolvedHdriResolution = useMemo(() => {
+    if (hdriResolutionId === 'auto') {
+      return activeFrameRateOption?.hdriResolution || DEFAULT_HDRI_RESOLUTIONS[0];
+    }
+    if (HDRI_RESOLUTION_OPTION_MAP[hdriResolutionId]) {
+      return hdriResolutionId;
+    }
+    return activeFrameRateOption?.hdriResolution || DEFAULT_HDRI_RESOLUTIONS[0];
+  }, [activeFrameRateOption, hdriResolutionId]);
+  const activeHdriResolutionOption = useMemo(
+    () => HDRI_RESOLUTION_OPTION_MAP[hdriResolutionId] ?? HDRI_RESOLUTION_OPTION_MAP[DEFAULT_HDRI_RESOLUTION_ID],
+    [hdriResolutionId]
+  );
   const resolvedFrameTiming = useMemo(() => {
     const fallbackFps =
       Number.isFinite(DEFAULT_FRAME_RATE_OPTION?.fps) && DEFAULT_FRAME_RATE_OPTION.fps > 0
@@ -5100,7 +5114,10 @@ export default function MurlanRoyaleArena({ search }) {
                     <div className="space-y-2">
                       <p className="text-[10px] uppercase tracking-[0.32em] text-white/65">HDRI Resolution</p>
                       <p className="text-[10px] uppercase tracking-[0.2em] text-white/50">
-                        Active: {resolvedHdriResolution.toUpperCase()}
+                        Active:{' '}
+                        {hdriResolutionId === 'auto'
+                          ? `${resolvedHdriResolution.toUpperCase()} (${activeHdriResolutionOption?.label || 'Match Table'})`
+                          : activeHdriResolutionOption?.label || resolvedHdriResolution.toUpperCase()}
                       </p>
                       <div className="flex flex-wrap gap-2">
                         {HDRI_RESOLUTION_OPTIONS.map((option) => {


### PR DESCRIPTION
### Motivation
- Align Murlan Royale HDRI controls with Pool Royale so players can pick HDRI resolution independently from the global graphics preset. 
- Provide an `auto`/"Match Table" mode that follows the selected graphics/frame-rate preset while still allowing manual overrides. 

### Description
- Expanded `HDRI_RESOLUTION_OPTIONS` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to: `auto` (Match Table), `8k`, `6k`, `4k`, `2k`, and `1k`.
- Changed the default HDRI mode to `auto` by setting `DEFAULT_HDRI_RESOLUTION_ID = 'auto'` and made the resolved HDRI logic map `auto` to the active frame-rate option's `hdriResolution` via a `useMemo` `resolvedHdriResolution`.
- Added `activeHdriResolutionOption` `useMemo` and updated the graphics UI label to show the resolved resolution and auto-mode context (e.g. `8K (Match Table)`).
- All edits are contained to `webapp/src/pages/Games/MurlanRoyaleArena.jsx` and keep manual HDRI selection independent from `FRAME_RATE_OPTIONS` while preserving an auto-sync behavior.

### Testing
- Ran `npx eslint webapp/src/pages/Games/MurlanRoyaleArena.jsx`, which produced only an ignore-pattern warning from the repo lint config and reported no lint errors for the change.
- No unit or integration tests were executed for this PR; no automated test failures were observed during the edit and lint run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca6b9fe29c8329b2f22114fd3caf37)