### PR TITLE
Fix Pool Royale replay gating and add Oak Veneer + Carbon Fiber table finishes

### DIFF
--- a/test/poolRoyaleStoreTableFinishes.test.js
+++ b/test/poolRoyaleStoreTableFinishes.test.js
@@ -1,0 +1,30 @@
+import { test } from '@jest/globals';
+import assert from 'node:assert/strict';
+import {
+  POOL_ROYALE_OPTION_LABELS,
+  POOL_ROYALE_STORE_ITEMS
+} from '../webapp/src/config/poolRoyaleInventoryConfig.js';
+
+test('Pool Royale store exposes new oak veneer and carbon fiber table finishes', () => {
+  const expectedOptionIds = [
+    'oakVeneer01Honey',
+    'oakVeneer01SmokedWalnut',
+    'oakVeneer01GraphiteBrown',
+    'oakVeneer01RoseTaupe',
+    'oakVeneer01MatteBlack',
+    'carbonFiberMatteDarkGrey'
+  ];
+
+  const tableFinishLabels = POOL_ROYALE_OPTION_LABELS.tableFinish || {};
+  const storeOptionIds = new Set(
+    POOL_ROYALE_STORE_ITEMS
+      .filter((item) => item.type === 'tableFinish')
+      .map((item) => item.optionId)
+  );
+
+  expectedOptionIds.forEach((optionId) => {
+    assert.equal(typeof tableFinishLabels[optionId], 'string');
+    assert.ok(tableFinishLabels[optionId].length > 0);
+    assert.ok(storeOptionIds.has(optionId));
+  });
+});

--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -294,6 +294,12 @@ export const POOL_ROYALE_HDRI_VARIANTS = Object.freeze(
 const TABLE_FINISH_THUMBNAILS = Object.freeze({
   peelingPaintWeathered: polyHavenThumb('wood_peeling_paint_weathered'),
   oakVeneer01: polyHavenThumb('oak_veneer_01'),
+  oakVeneer01Honey: swatchThumbnail(['#c89a64', '#e0bb7a', '#f3d3a2']),
+  oakVeneer01SmokedWalnut: swatchThumbnail(['#855933', '#a8784f', '#c89a64']),
+  oakVeneer01GraphiteBrown: swatchThumbnail(['#4f4037', '#6b584e', '#8a786e']),
+  oakVeneer01RoseTaupe: swatchThumbnail(['#7a5750', '#9a7368', '#c29e8f']),
+  oakVeneer01MatteBlack: swatchThumbnail(['#0f1012', '#1b1c1f', '#2f3136']),
+  carbonFiberMatteDarkGrey: swatchThumbnail(['#1e2229', '#2b3139', '#4b5563']),
   woodTable001: polyHavenThumb('wood_table_001'),
   darkWood: polyHavenThumb('dark_wood'),
   rosewoodVeneer01: polyHavenThumb('rosewood_veneer_01')
@@ -392,6 +398,12 @@ export const POOL_ROYALE_OPTION_LABELS = Object.freeze({
   tableFinish: Object.freeze({
     peelingPaintWeathered: 'Wood Peeling Paint Weathered',
     oakVeneer01: 'Oak Veneer 01',
+    oakVeneer01Honey: 'Oak Veneer 01 Honey Satin',
+    oakVeneer01SmokedWalnut: 'Oak Veneer 01 Smoked Walnut',
+    oakVeneer01GraphiteBrown: 'Oak Veneer 01 Graphite Brown',
+    oakVeneer01RoseTaupe: 'Oak Veneer 01 Rose Taupe',
+    oakVeneer01MatteBlack: 'Oak Veneer 01 Matte Black',
+    carbonFiberMatteDarkGrey: 'Carbon Fiber Matte Dark Grey',
     woodTable001: 'Wood Table 001',
     darkWood: 'Dark Wood',
     rosewoodVeneer01: 'Rosewood Veneer 01',
@@ -466,6 +478,60 @@ export const POOL_ROYALE_STORE_ITEMS = [
     price: 990,
     description: 'Warm oak veneer rails with smooth satin polish.',
     thumbnail: '/store-thumbs/poolRoyale/tableFinish/oakVeneer01.png'
+  },
+  {
+    id: 'finish-oakVeneer01Honey',
+    type: 'tableFinish',
+    optionId: 'oakVeneer01Honey',
+    name: 'Oak Veneer 01 Honey Satin Finish',
+    price: 1000,
+    description: 'Oak Veneer 01 recolored to a bright honey satin tone.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.oakVeneer01Honey
+  },
+  {
+    id: 'finish-oakVeneer01SmokedWalnut',
+    type: 'tableFinish',
+    optionId: 'oakVeneer01SmokedWalnut',
+    name: 'Oak Veneer 01 Smoked Walnut Finish',
+    price: 1010,
+    description: 'Oak Veneer 01 with richer smoked walnut mid-tones.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.oakVeneer01SmokedWalnut
+  },
+  {
+    id: 'finish-oakVeneer01GraphiteBrown',
+    type: 'tableFinish',
+    optionId: 'oakVeneer01GraphiteBrown',
+    name: 'Oak Veneer 01 Graphite Brown Finish',
+    price: 1020,
+    description: 'Oak Veneer 01 shifted into cool graphite-brown tournament rails.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.oakVeneer01GraphiteBrown
+  },
+  {
+    id: 'finish-oakVeneer01RoseTaupe',
+    type: 'tableFinish',
+    optionId: 'oakVeneer01RoseTaupe',
+    name: 'Oak Veneer 01 Rose Taupe Finish',
+    price: 1030,
+    description: 'Oak Veneer 01 tinted with a subtle rose-taupe furniture tone.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.oakVeneer01RoseTaupe
+  },
+  {
+    id: 'finish-oakVeneer01MatteBlack',
+    type: 'tableFinish',
+    optionId: 'oakVeneer01MatteBlack',
+    name: 'Oak Veneer 01 Matte Black Finish',
+    price: 1040,
+    description: 'Oak Veneer 01 recolored into a stealth matte-black finish.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.oakVeneer01MatteBlack
+  },
+  {
+    id: 'finish-carbonFiberMatteDarkGrey',
+    type: 'tableFinish',
+    optionId: 'carbonFiberMatteDarkGrey',
+    name: 'Carbon Fiber Matte Dark Grey Finish',
+    price: 1050,
+    description: 'Matte dark-grey carbon fiber weave for a modern performance look.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberMatteDarkGrey
   },
   {
     id: 'finish-woodTable001',

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2965,6 +2965,39 @@ const createChessPieceWoodTexture = (variantHint = 'pawn_white_base_color.jpg') 
 };
 };
 
+const createCarbonFiberWoodTexture = () => {
+  if (typeof document === 'undefined') {
+    return { mapUrl: null, normalMapUrl: null, roughnessMapUrl: null, repeat: { x: 4, y: 4 } };
+  }
+  const size = 512;
+  const canvas = document.createElement('canvas');
+  canvas.width = size;
+  canvas.height = size;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) {
+    return { mapUrl: null, normalMapUrl: null, roughnessMapUrl: null, repeat: { x: 4, y: 4 } };
+  }
+  const cell = size / 8;
+  ctx.fillStyle = '#1e232b';
+  ctx.fillRect(0, 0, size, size);
+  for (let y = 0; y < 8; y += 1) {
+    for (let x = 0; x < 8; x += 1) {
+      const dark = (x + y) % 2 === 0;
+      ctx.fillStyle = dark ? '#222831' : '#2a313a';
+      ctx.fillRect(x * cell, y * cell, cell, cell);
+      ctx.fillStyle = dark ? 'rgba(255,255,255,0.025)' : 'rgba(0,0,0,0.08)';
+      ctx.fillRect(x * cell, y * cell, cell, cell / 2);
+    }
+  }
+  const gloss = ctx.createLinearGradient(0, 0, size, size);
+  gloss.addColorStop(0, 'rgba(255,255,255,0.05)');
+  gloss.addColorStop(1, 'rgba(0,0,0,0.24)');
+  ctx.fillStyle = gloss;
+  ctx.fillRect(0, 0, size, size);
+  const mapUrl = canvas.toDataURL('image/png');
+  return { mapUrl, normalMapUrl: null, roughnessMapUrl: null, repeat: { x: 4, y: 4 } };
+};
+
 const TABLE_FINISHES = Object.freeze({
   peelingPaintWeathered: createStandardWoodFinish({
     id: 'peelingPaintWeathered',
@@ -2983,6 +3016,59 @@ const TABLE_FINISHES = Object.freeze({
     trim: 0xe0bb7a,
     woodTextureId: 'oak_veneer_01',
     woodRepeatScale: 1
+  }),
+  oakVeneer01Honey: createStandardWoodFinish({
+    id: 'oakVeneer01Honey',
+    label: 'Oak Veneer 01 Honey Satin',
+    rail: 0xd3a56e,
+    base: 0xbf8f58,
+    trim: 0xe8c693,
+    woodTextureId: 'oak_veneer_01',
+    woodRepeatScale: 1
+  }),
+  oakVeneer01SmokedWalnut: createStandardWoodFinish({
+    id: 'oakVeneer01SmokedWalnut',
+    label: 'Oak Veneer 01 Smoked Walnut',
+    rail: 0x8f6039,
+    base: 0x7a4f2f,
+    trim: 0xb08358,
+    woodTextureId: 'oak_veneer_01',
+    woodRepeatScale: 1
+  }),
+  oakVeneer01GraphiteBrown: createStandardWoodFinish({
+    id: 'oakVeneer01GraphiteBrown',
+    label: 'Oak Veneer 01 Graphite Brown',
+    rail: 0x655349,
+    base: 0x54443c,
+    trim: 0x8b7569,
+    woodTextureId: 'oak_veneer_01',
+    woodRepeatScale: 1
+  }),
+  oakVeneer01RoseTaupe: createStandardWoodFinish({
+    id: 'oakVeneer01RoseTaupe',
+    label: 'Oak Veneer 01 Rose Taupe',
+    rail: 0x8b675d,
+    base: 0x755249,
+    trim: 0xb18c7f,
+    woodTextureId: 'oak_veneer_01',
+    woodRepeatScale: 1
+  }),
+  oakVeneer01MatteBlack: createStandardWoodFinish({
+    id: 'oakVeneer01MatteBlack',
+    label: 'Oak Veneer 01 Matte Black',
+    rail: 0x151619,
+    base: 0x101114,
+    trim: 0x2a2c31,
+    woodTextureId: 'oak_veneer_01',
+    woodRepeatScale: 1
+  }),
+  carbonFiberMatteDarkGrey: createStandardWoodFinish({
+    id: 'carbonFiberMatteDarkGrey',
+    label: 'Carbon Fiber Matte Dark Grey',
+    rail: 0x2a3139,
+    base: 0x1f252d,
+    trim: 0x4b5563,
+    woodTexture: createCarbonFiberWoodTexture()
   }),
   woodTable001: createStandardWoodFinish({
     id: 'woodTable001',
@@ -3173,6 +3259,12 @@ const TABLE_FINISH_OPTIONS = Object.freeze(
   [
     TABLE_FINISHES.peelingPaintWeathered,
     TABLE_FINISHES.oakVeneer01,
+    TABLE_FINISHES.oakVeneer01Honey,
+    TABLE_FINISHES.oakVeneer01SmokedWalnut,
+    TABLE_FINISHES.oakVeneer01GraphiteBrown,
+    TABLE_FINISHES.oakVeneer01RoseTaupe,
+    TABLE_FINISHES.oakVeneer01MatteBlack,
+    TABLE_FINISHES.carbonFiberMatteDarkGrey,
     TABLE_FINISHES.woodTable001,
     TABLE_FINISHES.darkWood,
     TABLE_FINISHES.rosewoodVeneer01,
@@ -22384,7 +22476,17 @@ const powerRef = useRef(hud.power);
               )
             : 0;
           const duration = Math.max(frameDuration, strokeDuration);
-          return { frames, cuePath, duration, cueStroke };
+          const normalizedFrames =
+            frames.length === 1 && Number.isFinite(duration) && duration > 0
+              ? [
+                  frames[0],
+                  {
+                    ...frames[0],
+                    t: duration
+                  }
+                ]
+              : frames;
+          return { frames: normalizedFrames, cuePath, duration, cueStroke };
         };
 
         const storeReplayCameraFrame = () => {
@@ -28518,6 +28620,13 @@ const powerRef = useRef(hud.power);
           return REPLAY_TRANSITION_LEAD_MS;
         };
 
+        const hasReplayPayload = (recording) => {
+          if (!recording || typeof recording !== 'object') return false;
+          const frameCount = Array.isArray(recording.frames) ? recording.frames.length : 0;
+          const hasCueStroke = Boolean(recording.cueStroke);
+          return frameCount > 0 || hasCueStroke;
+        };
+
         const resolveReplayDecision = ({
           recording,
           hadObjectPot,
@@ -28558,7 +28667,7 @@ const powerRef = useRef(hud.power);
           let shouldStartReplay =
             !skipAllReplaysRef.current &&
             Boolean(replayDecision?.shouldReplay) &&
-            (shotRecording?.frames?.length ?? 0) > 1;
+            hasReplayPayload(shotRecording);
           let replayBannerText = replayDecision?.banner ?? selectReplayBanner('default');
           let replayAccent = replayDecision?.primaryTag ?? 'default';
           let postShotSnapshot = null;
@@ -28735,7 +28844,7 @@ const powerRef = useRef(hud.power);
             : null;
         }
         const shotWasFoul = Boolean(safeState?.foul);
-        if (shotWasFoul && (shotRecording?.frames?.length ?? 0) > 1) {
+        if (shotWasFoul && hasReplayPayload(shotRecording)) {
           const foulBanner = 'Foul';
           if (replayDecision) {
             const replayTags = new Set(replayDecision.tags ?? []);
@@ -28760,7 +28869,7 @@ const powerRef = useRef(hud.power);
           replayAccent = replayDecision.primaryTag ?? 'foul';
         }
         const isFinalShot =
-          Boolean(safeState?.frameOver) && (shotRecording?.frames?.length ?? 0) > 1;
+          Boolean(safeState?.frameOver) && hasReplayPayload(shotRecording);
         if (isFinalShot) {
           if (replayDecision) {
             const replayTags = new Set(replayDecision.tags ?? []);
@@ -28791,7 +28900,7 @@ const powerRef = useRef(hud.power);
         shouldStartReplay =
           !skipAllReplaysRef.current &&
           Boolean(replayDecision?.shouldReplay) &&
-          (shotRecording?.frames?.length ?? 0) > 1;
+          hasReplayPayload(shotRecording);
         const shooterSeat = currentState?.activePlayer === 'B' ? 'B' : 'A';
         if (potted.length) {
           const newPots = potted.filter(


### PR DESCRIPTION
### Motivation
- Replays for Pool Royale were being silently prevented in cases like potted balls or fouls due to overly strict `frames > 1` checks and missing normalization of single-frame recordings. The intent is to ensure the only user-facing blocker for replays is the menu toggle (skip all replays) and to remove hidden gating logic.  
- Add five new color variants derived from `oakVeneer01` (one matte black) and one matte dark-grey carbon-fiber table finish to the in-game store and runtime finish options so players can purchase and see them in matches/replays.

### Description
- Replay fixes in `webapp/src/pages/Games/PoolRoyale.jsx`: added `trimReplayRecording` normalization to synthesize a second frame when a recording only has one frame but a valid duration exists, and introduced `hasReplayPayload(recording)` to centralize replay payload checks; replaced multiple `frames?.length > 1` checks with `hasReplayPayload` so potted/foul/final shot replays are not blocked by frame-count logic.  
- Replay playback gating changes preserve the `skipAllReplays` menu toggle as the primary runtime blocker and keep existing replay startup flow (`startShotReplay`, banners/slates) intact.  
- Table finishes: added `createCarbonFiberWoodTexture` and six new finishes in `webapp/src/pages/Games/PoolRoyale.jsx` under `TABLE_FINISHES` and `TABLE_FINISH_OPTIONS`: `oakVeneer01Honey`, `oakVeneer01SmokedWalnut`, `oakVeneer01GraphiteBrown`, `oakVeneer01RoseTaupe`, `oakVeneer01MatteBlack`, and `carbonFiberMatteDarkGrey`.  
- Store/config updates in `webapp/src/config/poolRoyaleInventoryConfig.js`: added thumbnails, option labels and store entries for the six new finishes so they appear in inventory and the store UI.  
- Tests: added `test/poolRoyaleStoreTableFinishes.test.js` that verifies the new finish option IDs exist in `POOL_ROYALE_OPTION_LABELS.tableFinish` and in `POOL_ROYALE_STORE_ITEMS`.

### Testing
- Ran the focused test command: `npm test -- --runInBand test/poolRoyaleStoreTableFinishes.test.js test/poolRoyaleCueStrokeTimeline.test.js test/poolRoyalInventoryRoutes.test.js`.  
- All targeted suites passed: `poolRoyalInventoryRoutes`, `poolRoyaleCueStrokeTimeline`, and the new `poolRoyaleStoreTableFinishes` all succeeded (3/3 suites, 6/6 tests passed).  
- The change includes the new unit test file `test/poolRoyaleStoreTableFinishes.test.js` which passed during the run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69caaddc86608329bd568e5b393a8e9b)