### PR TITLE
Preserve GLTF-authored cloth textures in Murlan Royale (align with Texas Hold'em)

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1182,40 +1182,11 @@ async function createPolyhavenInstance(
   assetId,
   targetHeight,
   rotationY = 0,
-  renderer = null,
-  textureOptions = {}
+  renderer = null
 ) {
   const root = await loadPolyhavenModel(assetId, renderer);
   const model = root.clone(true);
   prepareLoadedModel(model);
-  const {
-    textureLoader = null,
-    maxAnisotropy = 1,
-    fallbackTexture = null,
-    textureCache = null,
-    textureSet = null,
-    preferredTextureSizes = PREFERRED_TEXTURE_SIZES
-  } = textureOptions || {};
-  if (textureLoader) {
-    try {
-      const textures =
-        textureSet ??
-        (await loadPolyhavenTextureSet(
-          assetId,
-          textureLoader,
-          maxAnisotropy,
-          textureCache,
-          preferredTextureSizes
-        ));
-      if (textures || fallbackTexture) {
-        applyTextureSetToModel(model, textures, fallbackTexture, maxAnisotropy);
-      }
-    } catch (error) {
-      if (fallbackTexture) {
-        applyTextureSetToModel(model, null, fallbackTexture, maxAnisotropy);
-      }
-    }
-  }
   fitModelToHeight(model, targetHeight);
   if (rotationY) model.rotation.y += rotationY;
   return model;
@@ -1904,39 +1875,14 @@ function createProceduralChair(theme) {
   };
 }
 
-async function buildChairTemplate(theme, renderer = null, textureOptions = {}) {
+async function buildChairTemplate(theme, renderer = null) {
   const rotationY = theme?.modelRotation || 0;
   const preserveMaterials = shouldPreserveChairMaterials(theme);
-  const {
-    textureLoader = null,
-    maxAnisotropy = 1,
-    fallbackTexture = null,
-    textureCache = null,
-    preferredTextureSizes = PREFERRED_TEXTURE_SIZES
-  } = textureOptions || {};
   try {
     if (theme?.source === 'polyhaven' && theme?.assetId) {
       const polyhavenRoot = await loadPolyhavenModel(theme.assetId, renderer);
       const model = polyhavenRoot.clone(true);
       prepareLoadedModel(model);
-      if (textureLoader) {
-        try {
-          const textures = await loadPolyhavenTextureSet(
-            theme.assetId,
-            textureLoader,
-            maxAnisotropy,
-            textureCache,
-            preferredTextureSizes
-          );
-          if (textures || fallbackTexture) {
-            applyTextureSetToModel(model, textures, fallbackTexture, maxAnisotropy);
-          }
-        } catch (error) {
-          if (fallbackTexture) {
-            applyTextureSetToModel(model, null, fallbackTexture, maxAnisotropy);
-          }
-        }
-      }
       fitChairModelToFootprint(model);
       if (rotationY) model.rotation.y += rotationY;
       const materials = extractChairMaterials(model);
@@ -3521,14 +3467,7 @@ export default function MurlanRoyaleArena({ search }) {
             theme.assetId,
             TABLE_MODEL_TARGET_HEIGHT,
             theme.rotationY || 0,
-            three.renderer,
-            {
-              textureLoader: three.textureLoader,
-              maxAnisotropy: three.maxAnisotropy,
-              fallbackTexture: three.fallbackTexture,
-              textureCache: three.textureCache,
-              preferredTextureSizes: activeTextureResolutionOrder
-            }
+            three.renderer
           );
           if (tableBuildTokenRef.current === token && model) {
             const tableGroup = new THREE.Group();
@@ -3598,13 +3537,7 @@ export default function MurlanRoyaleArena({ search }) {
       if (!threeReady) return;
       const safe = stoolTheme || STOOL_THEMES[0];
       const store = threeStateRef.current;
-      const chairBuild = await buildChairTemplate(safe, store.renderer, {
-        textureLoader: store.textureLoader,
-        maxAnisotropy: store.maxAnisotropy,
-        fallbackTexture: store.fallbackTexture,
-        textureCache: store.textureCache,
-        preferredTextureSizes: activeTextureResolutionOrder
-      });
+      const chairBuild = await buildChairTemplate(safe, store.renderer);
       const currentAppearance = normalizeAppearance(appearanceRef.current);
       const expectedTheme = STOOL_THEMES[currentAppearance.stools] ?? STOOL_THEMES[0];
       if (expectedTheme.id !== safe.id) return;
@@ -4423,13 +4356,7 @@ export default function MurlanRoyaleArena({ search }) {
       await rebuildTable(tableTheme, tableFinish, tableCloth);
       if (disposed) return;
 
-      const chairBuild = await buildChairTemplate(stoolTheme, renderer, {
-        textureLoader,
-        maxAnisotropy,
-        fallbackTexture,
-        textureCache: threeStateRef.current.textureCache,
-        preferredTextureSizes: activeTextureResolutionOrder
-      });
+      const chairBuild = await buildChairTemplate(stoolTheme, renderer);
       if (disposed) return;
       const chairTemplate = chairBuild.chairTemplate;
       threeStateRef.current.chairTemplate = chairTemplate;


### PR DESCRIPTION
### Motivation
- Murlan Royale was replacing GLTF model materials with fetched Poly Haven texture sets which could break model-authored UVs and make cloth textures disappear, while Texas Hold'em preserves GLTF-authored materials; the goal is to match Texas Hold'em behavior and keep model textures intact.

### Description
- Removed the texture-set override logic from `createPolyhavenInstance` so loaded GLTF materials/maps are preserved in `webapp/src/pages/Games/MurlanRoyaleArena.jsx`.
- Simplified `buildChairTemplate` to stop accepting texture override options and preserve Poly Haven chair GLTF materials instead of replacing them.
- Updated table and chair build call sites to stop passing the now-unused texture-loader/override arguments so Murlan table/chair builds consistently use preserved GLTF textures.

### Testing
- Ran the targeted Jest test `npm run test -- test/poolRoyaleOnlineFlow.test.js --runInBand` and it passed.
- Ran the project lint command (`npm run lint -- webapp/src/pages/Games/MurlanRoyaleArena.jsx`), which surfaced large pre-existing repository lint issues and the target file is ignored by current eslint settings, so no change-specific lint fixes were applied.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cac5c3a2048329864b3a28403cf4f6)