### PR TITLE
Pool Royale: ensure replays play after pots/fouls; add new Oak veneer + carbon finishes

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -296,7 +296,13 @@ const TABLE_FINISH_THUMBNAILS = Object.freeze({
   oakVeneer01: polyHavenThumb('oak_veneer_01'),
   woodTable001: polyHavenThumb('wood_table_001'),
   darkWood: polyHavenThumb('dark_wood'),
-  rosewoodVeneer01: polyHavenThumb('rosewood_veneer_01')
+  rosewoodVeneer01: polyHavenThumb('rosewood_veneer_01'),
+  oakVeneer01Amber: swatchThumbnail(['#c0874e', '#d3a06a', '#e5bb84']),
+  oakVeneer01Walnut: swatchThumbnail(['#744528', '#8a5d3a', '#af7a4f']),
+  oakVeneer01Olive: swatchThumbnail(['#57503e', '#6f6650', '#8a7e62']),
+  oakVeneer01Espresso: swatchThumbnail(['#2b1f18', '#3d2e24', '#5b4738']),
+  oakVeneer01MatteBlack: swatchThumbnail(['#101010', '#1a1a1a', '#2b2b2b']),
+  carbonFiberMatteDarkGrey: swatchThumbnail(['#1a1d23', '#24272d', '#353942'])
 });
 
 const POCKET_LINER_THUMBNAILS = Object.freeze({
@@ -394,7 +400,13 @@ export const POOL_ROYALE_OPTION_LABELS = Object.freeze({
     oakVeneer01: 'Oak Veneer 01',
     woodTable001: 'Wood Table 001',
     darkWood: 'Dark Wood',
-    rosewoodVeneer01: 'Rosewood Veneer 01'
+    rosewoodVeneer01: 'Rosewood Veneer 01',
+    oakVeneer01Amber: 'Oak Veneer 01 · Amber',
+    oakVeneer01Walnut: 'Oak Veneer 01 · Walnut',
+    oakVeneer01Olive: 'Oak Veneer 01 · Olive Smoke',
+    oakVeneer01Espresso: 'Oak Veneer 01 · Espresso',
+    oakVeneer01MatteBlack: 'Oak Veneer 01 · Matte Black',
+    carbonFiberMatteDarkGrey: 'Carbon Fiber · Matte Dark Grey'
   }),
   chromeColor: Object.freeze({
     chrome: 'Chrome',
@@ -481,6 +493,60 @@ export const POOL_ROYALE_STORE_ITEMS = [
     price: 1020,
     description: 'Rosewood veneer rails with rich, reddish undertones.',
     thumbnail: TABLE_FINISH_THUMBNAILS.rosewoodVeneer01
+  },
+  {
+    id: 'finish-oakVeneer01Amber',
+    type: 'tableFinish',
+    optionId: 'oakVeneer01Amber',
+    name: 'Oak Veneer 01 · Amber Finish',
+    price: 1030,
+    description: 'Oak veneer pattern retinted to a warm amber tone.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.oakVeneer01Amber
+  },
+  {
+    id: 'finish-oakVeneer01Walnut',
+    type: 'tableFinish',
+    optionId: 'oakVeneer01Walnut',
+    name: 'Oak Veneer 01 · Walnut Finish',
+    price: 1040,
+    description: 'Oak veneer pattern with darker walnut-inspired tones.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.oakVeneer01Walnut
+  },
+  {
+    id: 'finish-oakVeneer01Olive',
+    type: 'tableFinish',
+    optionId: 'oakVeneer01Olive',
+    name: 'Oak Veneer 01 · Olive Smoke Finish',
+    price: 1050,
+    description: 'Smoked olive oak tint for a muted competition look.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.oakVeneer01Olive
+  },
+  {
+    id: 'finish-oakVeneer01Espresso',
+    type: 'tableFinish',
+    optionId: 'oakVeneer01Espresso',
+    name: 'Oak Veneer 01 · Espresso Finish',
+    price: 1060,
+    description: 'Deep espresso oak tone with heavy contrast grain.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.oakVeneer01Espresso
+  },
+  {
+    id: 'finish-oakVeneer01MatteBlack',
+    type: 'tableFinish',
+    optionId: 'oakVeneer01MatteBlack',
+    name: 'Oak Veneer 01 · Matte Black Finish',
+    price: 1080,
+    description: 'Matte black oak veneer with low-reflection finish.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.oakVeneer01MatteBlack
+  },
+  {
+    id: 'finish-carbonFiberMatteDarkGrey',
+    type: 'tableFinish',
+    optionId: 'carbonFiberMatteDarkGrey',
+    name: 'Carbon Fiber · Matte Dark Grey Finish',
+    price: 1120,
+    description: 'Matte dark grey carbon-fiber inspired finish for a modern table shell.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberMatteDarkGrey
   },
   {
     id: 'chrome-chrome',

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2868,7 +2868,9 @@ const createStandardWoodFinish = ({
   trim,
   accent,
   woodTextureId,
-  woodRepeatScale
+  woodRepeatScale,
+  woodPreset,
+  matte = false
 }) => ({
   id,
   label,
@@ -2934,6 +2936,34 @@ const createStandardWoodFinish = ({
         envMapIntensity: 0.72
       });
     }
+    if (woodPreset) {
+      const woodOptions = {
+        hue: woodPreset.hue,
+        sat: woodPreset.sat,
+        light: woodPreset.light,
+        contrast: woodPreset.contrast,
+        repeat: POOL_ROYALE_WOOD_REPEAT,
+        sharedKey: `pool-royale-finish-${id}`,
+        ...POOL_ROYALE_WOOD_SURFACE_PROPS
+      };
+      [materials.frame, materials.rail, materials.leg].forEach((material) => {
+        if (material) {
+          applyWoodTextures(material, woodOptions);
+        }
+      });
+    }
+    if (matte) {
+      [materials.frame, materials.rail, materials.leg, materials.trim]
+        .filter(Boolean)
+        .forEach((material) => {
+          if ('roughness' in material) material.roughness = Math.max(material.roughness ?? 0, 0.86);
+          if ('metalness' in material) material.metalness = Math.min(material.metalness ?? 0, 0.05);
+          if ('clearcoat' in material) material.clearcoat = 0;
+          if ('clearcoatRoughness' in material) material.clearcoatRoughness = 1;
+          if ('sheen' in material) material.sheen = Math.min(material.sheen ?? 0, 0.02);
+          material.needsUpdate = true;
+        });
+    }
     applySnookerStyleWoodPreset(materials, id);
     return { ...materials, ...createPocketMaterials() };
   }
@@ -2984,6 +3014,61 @@ const TABLE_FINISHES = Object.freeze({
     trim: 0x9b5a44,
     woodTextureId: 'rosewood_veneer_01',
     woodRepeatScale: 1
+  }),
+  oakVeneer01Amber: createStandardWoodFinish({
+    id: 'oakVeneer01Amber',
+    label: 'Oak Veneer 01 · Amber',
+    rail: 0xd3a06a,
+    base: 0xc0874e,
+    trim: 0xe5bb84,
+    woodPreset: { hue: 33, sat: 0.4, light: 0.66, contrast: 0.58 }
+  }),
+  oakVeneer01Walnut: createStandardWoodFinish({
+    id: 'oakVeneer01Walnut',
+    label: 'Oak Veneer 01 · Walnut',
+    rail: 0x8a5d3a,
+    base: 0x744528,
+    trim: 0xaf7a4f,
+    woodPreset: { hue: 27, sat: 0.42, light: 0.44, contrast: 0.68 }
+  }),
+  oakVeneer01Olive: createStandardWoodFinish({
+    id: 'oakVeneer01Olive',
+    label: 'Oak Veneer 01 · Olive Smoke',
+    rail: 0x6f6650,
+    base: 0x57503e,
+    trim: 0x8a7e62,
+    woodPreset: { hue: 42, sat: 0.22, light: 0.36, contrast: 0.65 }
+  }),
+  oakVeneer01Espresso: createStandardWoodFinish({
+    id: 'oakVeneer01Espresso',
+    label: 'Oak Veneer 01 · Espresso',
+    rail: 0x3d2e24,
+    base: 0x2b1f18,
+    trim: 0x5b4738,
+    woodPreset: { hue: 20, sat: 0.3, light: 0.24, contrast: 0.76 }
+  }),
+  oakVeneer01MatteBlack: createStandardWoodFinish({
+    id: 'oakVeneer01MatteBlack',
+    label: 'Oak Veneer 01 · Matte Black',
+    rail: 0x1a1a1a,
+    base: 0x101010,
+    trim: 0x2b2b2b,
+    woodPreset: { hue: 24, sat: 0.08, light: 0.16, contrast: 0.74 },
+    matte: true
+  }),
+  carbonFiberMatteDarkGrey: createStandardWoodFinish({
+    id: 'carbonFiberMatteDarkGrey',
+    label: 'Carbon Fiber · Matte Dark Grey',
+    rail: 0x24272d,
+    base: 0x1a1d23,
+    trim: 0x353942,
+    woodPreset: {
+      hue: 220,
+      sat: 0.12,
+      light: 0.2,
+      contrast: 0.82
+    },
+    matte: true
   })
 });
 
@@ -2993,7 +3078,13 @@ const TABLE_FINISH_OPTIONS = Object.freeze(
     TABLE_FINISHES.oakVeneer01,
     TABLE_FINISHES.woodTable001,
     TABLE_FINISHES.darkWood,
-    TABLE_FINISHES.rosewoodVeneer01
+    TABLE_FINISHES.rosewoodVeneer01,
+    TABLE_FINISHES.oakVeneer01Amber,
+    TABLE_FINISHES.oakVeneer01Walnut,
+    TABLE_FINISHES.oakVeneer01Olive,
+    TABLE_FINISHES.oakVeneer01Espresso,
+    TABLE_FINISHES.oakVeneer01MatteBlack,
+    TABLE_FINISHES.carbonFiberMatteDarkGrey
   ].filter(Boolean)
 );
 
@@ -28641,7 +28732,6 @@ const powerRef = useRef(hud.power);
         }
         shouldStartReplay =
           !skipAllReplaysRef.current &&
-          Boolean(replayDecision?.shouldReplay) &&
           (shotRecording?.frames?.length ?? 0) > 1;
         const shooterSeat = currentState?.activePlayer === 'B' ? 'B' : 'A';
         if (potted.length) {


### PR DESCRIPTION
### Motivation
- Replays were being suppressed by extra decision gates after pot/foul shots; replay playback must only be prevented by the user `Skip Replays` option. 
- Add five new colour variants of the existing `Oak Veneer 01` finish (including a matte black variant) plus a matte dark-grey carbon-fiber finish and ensure they render correctly in matches, replays and the store.

### Description
- Unblocked replay playback decision in `webapp/src/pages/Games/PoolRoyale.jsx` so `shouldStartReplay` now depends on the presence of a recorded replay and the `Skip Replays` toggle rather than extra `replayDecision` gates; foul/final tagging and banners are preserved but no longer able to suppress playback. (`startShotReplay`, `shouldStartReplay` logic updated)
- Extended the table finish material builder (`createStandardWoodFinish`) to accept `woodPreset` and `matte` options and to call `applyWoodTextures` when a preset is provided, plus a matte tuning pass that raises roughness and reduces reflectance for low-gloss variants. (material creation code in `PoolRoyale.jsx`)
- Added six new finishes to `TABLE_FINISHES` and `TABLE_FINISH_OPTIONS` in `webapp/src/pages/Games/PoolRoyale.jsx`: `oakVeneer01Amber`, `oakVeneer01Walnut`, `oakVeneer01Olive`, `oakVeneer01Espresso`, `oakVeneer01MatteBlack`, and `carbonFiberMatteDarkGrey`.
- Wired the new finishes into store/inventory configuration in `webapp/src/config/poolRoyaleInventoryConfig.js` by adding thumbnails, labels and `POOL_ROYALE_STORE_ITEMS` entries (ids, prices, descriptions, thumbnails) so they appear in the store and unlock system.

### Testing
- Ran store/inventory tests: `npm test -- test/storeDelivery.test.js test/poolRoyalInventoryRoutes.test.js --runInBand` — both suites passed.
- Ran cue stroke timeline tests: `npm test -- test/poolRoyaleCueStrokeTimeline.test.js --runInBand` — all tests passed.
- Manual visual verification is recommended in a browser/device build for final appearance of the new finishes and to confirm replays play in the real runtime (not covered by headless tests in this PR).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cacc5bbf908329a599807d71f2ee83)