### PR TITLE
Preserve GLTF chair materials to fix Murlan cloth textures

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1230,7 +1230,7 @@ function buildPolyhavenModelUrls(assetId) {
 }
 
 function shouldPreserveChairMaterials(theme) {
-  return Boolean(theme?.preserveMaterials || theme?.source === 'polyhaven');
+  return Boolean(theme?.preserveMaterials || theme?.source === 'polyhaven' || theme?.source === 'gltf');
 }
 
 function createConfiguredGLTFLoader(renderer = null, manager = undefined) {


### PR DESCRIPTION
### Motivation
- GLTF-authored chair models had their embedded cloth textures overridden by runtime recoloring, causing GLTF cloth textures to not appear as intended; preserve original model materials the same way as other authored assets.

### Description
- Update in `webapp/src/pages/Games/MurlanRoyaleArena.jsx`: `shouldPreserveChairMaterials(theme)` now returns `true` when `theme.source === 'gltf'`, so GLTF models keep their authored materials and textures.

### Testing
- Ran the targeted unit test: `npm test -- test/murlan.test.js --runInBand` and it passed. (Test suite: `test/murlan.test.js` — PASS)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cac5c3a2048329864b3a28403cf4f6)