### PR TITLE
Fix Pool Royale replay gating and add six new table finishes

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -296,7 +296,13 @@ const TABLE_FINISH_THUMBNAILS = Object.freeze({
   oakVeneer01: polyHavenThumb('oak_veneer_01'),
   woodTable001: polyHavenThumb('wood_table_001'),
   darkWood: polyHavenThumb('dark_wood'),
-  rosewoodVeneer01: polyHavenThumb('rosewood_veneer_01')
+  rosewoodVeneer01: polyHavenThumb('rosewood_veneer_01'),
+  oakVeneer01Amber: swatchThumbnail(['#9f7148', '#c08a58', '#d6a370']),
+  oakVeneer01Cocoa: swatchThumbnail(['#6d4b33', '#8b6040', '#a67852']),
+  oakVeneer01Walnut: swatchThumbnail(['#543726', '#6f4b34', '#8a6246']),
+  oakVeneer01MahoganyRed: swatchThumbnail(['#7b3f34', '#9a4f40', '#b76655']),
+  oakVeneer01MatteBlack: swatchThumbnail(['#121212', '#242424', '#333333']),
+  carbonFiberChalk: swatchThumbnail(['#0c1018', '#1a1f2a', '#374151'])
 });
 
 const POCKET_LINER_THUMBNAILS = Object.freeze({
@@ -394,7 +400,13 @@ export const POOL_ROYALE_OPTION_LABELS = Object.freeze({
     oakVeneer01: 'Oak Veneer 01',
     woodTable001: 'Wood Table 001',
     darkWood: 'Dark Wood',
-    rosewoodVeneer01: 'Rosewood Veneer 01'
+    rosewoodVeneer01: 'Rosewood Veneer 01',
+    oakVeneer01Amber: 'Oak Veneer 01 Amber',
+    oakVeneer01Cocoa: 'Oak Veneer 01 Cocoa',
+    oakVeneer01Walnut: 'Oak Veneer 01 Walnut',
+    oakVeneer01MahoganyRed: 'Oak Veneer 01 Mahogany Red',
+    oakVeneer01MatteBlack: 'Oak Veneer 01 Matte Black',
+    carbonFiberChalk: 'Carbon Fiber Chalk'
   }),
   chromeColor: Object.freeze({
     chrome: 'Chrome',
@@ -481,6 +493,60 @@ export const POOL_ROYALE_STORE_ITEMS = [
     price: 1020,
     description: 'Rosewood veneer rails with rich, reddish undertones.',
     thumbnail: TABLE_FINISH_THUMBNAILS.rosewoodVeneer01
+  },
+  {
+    id: 'finish-oakVeneer01Amber',
+    type: 'tableFinish',
+    optionId: 'oakVeneer01Amber',
+    name: 'Oak Veneer 01 Amber Finish',
+    price: 1060,
+    description: 'Custom amber oak veneer pattern with bright satin grain.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.oakVeneer01Amber
+  },
+  {
+    id: 'finish-oakVeneer01Cocoa',
+    type: 'tableFinish',
+    optionId: 'oakVeneer01Cocoa',
+    name: 'Oak Veneer 01 Cocoa Finish',
+    price: 1070,
+    description: 'Custom cocoa oak veneer with warm chocolate undertones.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.oakVeneer01Cocoa
+  },
+  {
+    id: 'finish-oakVeneer01Walnut',
+    type: 'tableFinish',
+    optionId: 'oakVeneer01Walnut',
+    name: 'Oak Veneer 01 Walnut Finish',
+    price: 1080,
+    description: 'Custom walnut oak veneer with deeper grain separation.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.oakVeneer01Walnut
+  },
+  {
+    id: 'finish-oakVeneer01MahoganyRed',
+    type: 'tableFinish',
+    optionId: 'oakVeneer01MahoganyRed',
+    name: 'Oak Veneer 01 Mahogany Red Finish',
+    price: 1090,
+    description: 'Custom mahogany-red oak veneer for a premium classic look.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.oakVeneer01MahoganyRed
+  },
+  {
+    id: 'finish-oakVeneer01MatteBlack',
+    type: 'tableFinish',
+    optionId: 'oakVeneer01MatteBlack',
+    name: 'Oak Veneer 01 Matte Black Finish',
+    price: 1100,
+    description: 'Custom matte-black oak veneer with subtle low-gloss grain.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.oakVeneer01MatteBlack
+  },
+  {
+    id: 'finish-carbonFiberChalk',
+    type: 'tableFinish',
+    optionId: 'carbonFiberChalk',
+    name: 'Carbon Fiber Chalk Finish',
+    price: 1160,
+    description: 'Custom carbon weave inspired by the chalk block pattern.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberChalk
   },
   {
     id: 'chrome-chrome',

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2984,6 +2984,60 @@ const TABLE_FINISHES = Object.freeze({
     trim: 0x9b5a44,
     woodTextureId: 'rosewood_veneer_01',
     woodRepeatScale: 1
+  }),
+  oakVeneer01Amber: createStandardWoodFinish({
+    id: 'oakVeneer01Amber',
+    label: 'Oak Veneer 01 Amber',
+    rail: 0xc08a58,
+    base: 0x9f7148,
+    trim: 0xd6a370,
+    woodTextureId: 'oak_veneer_01_amber',
+    woodRepeatScale: 1
+  }),
+  oakVeneer01Cocoa: createStandardWoodFinish({
+    id: 'oakVeneer01Cocoa',
+    label: 'Oak Veneer 01 Cocoa',
+    rail: 0x8b6040,
+    base: 0x6d4b33,
+    trim: 0xa67852,
+    woodTextureId: 'oak_veneer_01_cocoa',
+    woodRepeatScale: 1
+  }),
+  oakVeneer01Walnut: createStandardWoodFinish({
+    id: 'oakVeneer01Walnut',
+    label: 'Oak Veneer 01 Walnut',
+    rail: 0x6f4b34,
+    base: 0x543726,
+    trim: 0x8a6246,
+    woodTextureId: 'oak_veneer_01_walnut',
+    woodRepeatScale: 1
+  }),
+  oakVeneer01MahoganyRed: createStandardWoodFinish({
+    id: 'oakVeneer01MahoganyRed',
+    label: 'Oak Veneer 01 Mahogany Red',
+    rail: 0x9a4f40,
+    base: 0x7b3f34,
+    trim: 0xb76655,
+    woodTextureId: 'oak_veneer_01_mahogany_red',
+    woodRepeatScale: 1
+  }),
+  oakVeneer01MatteBlack: createStandardWoodFinish({
+    id: 'oakVeneer01MatteBlack',
+    label: 'Oak Veneer 01 Matte Black',
+    rail: 0x242424,
+    base: 0x121212,
+    trim: 0x333333,
+    woodTextureId: 'oak_veneer_01_matte_black',
+    woodRepeatScale: 1
+  }),
+  carbonFiberChalk: createStandardWoodFinish({
+    id: 'carbonFiberChalk',
+    label: 'Carbon Fiber Chalk',
+    rail: 0x1a1f2a,
+    base: 0x0c1018,
+    trim: 0x374151,
+    woodTextureId: 'carbon_fiber_chalk',
+    woodRepeatScale: 1
   })
 });
 
@@ -2993,7 +3047,13 @@ const TABLE_FINISH_OPTIONS = Object.freeze(
     TABLE_FINISHES.oakVeneer01,
     TABLE_FINISHES.woodTable001,
     TABLE_FINISHES.darkWood,
-    TABLE_FINISHES.rosewoodVeneer01
+    TABLE_FINISHES.rosewoodVeneer01,
+    TABLE_FINISHES.oakVeneer01Amber,
+    TABLE_FINISHES.oakVeneer01Cocoa,
+    TABLE_FINISHES.oakVeneer01Walnut,
+    TABLE_FINISHES.oakVeneer01MahoganyRed,
+    TABLE_FINISHES.oakVeneer01MatteBlack,
+    TABLE_FINISHES.carbonFiberChalk
   ].filter(Boolean)
 );
 
@@ -28392,6 +28452,9 @@ const powerRef = useRef(hud.power);
         function resolve() {
           const variantId = activeVariantRef.current?.id ?? 'american';
           const shotEvents = [];
+          if (shotRecording && (shotRecording.frames?.length ?? 0) < 2) {
+            recordReplayFrame(performance.now());
+          }
           const firstContactColor = toBallColorId(firstHit);
           const hadObjectPot = potted.some((entry) => entry.id !== 'cue');
           let replayDecision = resolveReplayDecision({
@@ -29127,7 +29190,16 @@ const powerRef = useRef(hud.power);
         if (!shooting && !shotRecording && !replayPlaybackRef.current && pendingRemoteReplayRef.current) {
           const pending = pendingRemoteReplayRef.current;
           pendingRemoteReplayRef.current = null;
-          if (!skipAllReplaysRef.current && pending?.frames?.length > 1) {
+          if (!skipAllReplaysRef.current && pending?.frames?.length > 0) {
+            const normalizedFrames = Array.isArray(pending.frames) ? [...pending.frames] : [];
+            if (normalizedFrames.length === 1) {
+              const firstFrame = normalizedFrames[0];
+              const fallbackFrameTime = Math.max(16, pending.frameTimeMs ?? 1000 / 60);
+              normalizedFrames.push({
+                ...firstFrame,
+                t: Math.max(fallbackFrameTime, firstFrame?.t ?? 0)
+              });
+            }
             const frameTiming = frameTimingRef.current;
             const frameTimeMs =
               Number.isFinite(pending?.frameTimeMs) && pending.frameTimeMs > 0
@@ -29137,6 +29209,7 @@ const powerRef = useRef(hud.power);
                   : 1000 / 60;
             shotRecording = {
               ...pending,
+              frames: normalizedFrames,
               startTime: pending.startTime ?? nowMs,
               startState: pending.startState ?? captureBallSnapshot(),
               zoomOnly: pending.zoomOnly ?? false,

--- a/webapp/src/utils/woodMaterials.js
+++ b/webapp/src/utils/woodMaterials.js
@@ -325,6 +325,80 @@ const polyHavenTextureSet = (assetId) => {
   };
 };
 
+const svgDataUrl = (svg) => `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(svg)}`;
+
+const makeInlineOakVeneerPattern = ({
+  id,
+  base = '#8a623f',
+  grain = '#5e4129',
+  highlight = '#b8885c',
+  pore = '#3f2a1b'
+}) => {
+  const colorMap = svgDataUrl(`
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="${id}-base" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="${base}"/>
+      <stop offset="55%" stop-color="${highlight}"/>
+      <stop offset="100%" stop-color="${base}"/>
+    </linearGradient>
+    <pattern id="${id}-grain" patternUnits="userSpaceOnUse" width="128" height="128">
+      <rect width="128" height="128" fill="none"/>
+      <path d="M-32 16 C 6 2, 44 30, 82 16 S 158 2, 196 16" stroke="${grain}" stroke-width="8" stroke-linecap="round" fill="none" opacity="0.38"/>
+      <path d="M-22 46 C 14 30, 54 62, 90 46 S 166 30, 202 46" stroke="${grain}" stroke-width="6" stroke-linecap="round" fill="none" opacity="0.3"/>
+      <path d="M-28 78 C 8 64, 48 94, 84 78 S 160 64, 196 78" stroke="${grain}" stroke-width="7" stroke-linecap="round" fill="none" opacity="0.32"/>
+      <path d="M-24 110 C 12 94, 52 124, 88 110 S 164 94, 200 110" stroke="${grain}" stroke-width="6" stroke-linecap="round" fill="none" opacity="0.28"/>
+      <circle cx="36" cy="36" r="2.6" fill="${pore}" opacity="0.32"/>
+      <circle cx="94" cy="78" r="2.1" fill="${pore}" opacity="0.28"/>
+      <circle cx="62" cy="106" r="1.8" fill="${pore}" opacity="0.24"/>
+    </pattern>
+  </defs>
+  <rect width="512" height="512" fill="url(#${id}-base)"/>
+  <rect width="512" height="512" fill="url(#${id}-grain)"/>
+</svg>`);
+  const roughnessMap = svgDataUrl(`
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
+  <defs>
+    <pattern id="${id}-rough" patternUnits="userSpaceOnUse" width="128" height="128">
+      <rect width="128" height="128" fill="#6f6f6f"/>
+      <path d="M-32 16 C 6 2, 44 30, 82 16 S 158 2, 196 16" stroke="#9b9b9b" stroke-width="8" stroke-linecap="round" fill="none" opacity="0.66"/>
+      <path d="M-22 46 C 14 30, 54 62, 90 46 S 166 30, 202 46" stroke="#8b8b8b" stroke-width="6" stroke-linecap="round" fill="none" opacity="0.55"/>
+      <path d="M-28 78 C 8 64, 48 94, 84 78 S 160 64, 196 78" stroke="#9a9a9a" stroke-width="7" stroke-linecap="round" fill="none" opacity="0.6"/>
+      <path d="M-24 110 C 12 94, 52 124, 88 110 S 164 94, 200 110" stroke="#858585" stroke-width="6" stroke-linecap="round" fill="none" opacity="0.52"/>
+    </pattern>
+  </defs>
+  <rect width="512" height="512" fill="url(#${id}-rough)"/>
+</svg>`);
+  return { mapUrl: colorMap, roughnessMapUrl: roughnessMap, normalMapUrl: null };
+};
+
+const makeInlineCarbonFiberPattern = ({ id, dark = '#0a0d12', light = '#1b2230' }) => {
+  const mapUrl = svgDataUrl(`
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
+  <defs>
+    <pattern id="${id}-carbon" patternUnits="userSpaceOnUse" width="64" height="64">
+      <rect width="64" height="64" fill="${dark}"/>
+      <rect x="0" y="0" width="32" height="32" fill="${light}" opacity="0.42"/>
+      <rect x="32" y="32" width="32" height="32" fill="${light}" opacity="0.42"/>
+      <path d="M0 16 H64 M0 48 H64 M16 0 V64 M48 0 V64" stroke="#f8fafc" stroke-opacity="0.08" stroke-width="1.2"/>
+    </pattern>
+  </defs>
+  <rect width="512" height="512" fill="url(#${id}-carbon)"/>
+</svg>`);
+  const roughnessMapUrl = svgDataUrl(`
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
+  <defs>
+    <pattern id="${id}-rough-carbon" patternUnits="userSpaceOnUse" width="64" height="64">
+      <rect width="64" height="64" fill="#8c8c8c"/>
+      <rect x="0" y="0" width="32" height="32" fill="#6d6d6d"/>
+      <rect x="32" y="32" width="32" height="32" fill="#6d6d6d"/>
+    </pattern>
+  </defs>
+  <rect width="512" height="512" fill="url(#${id}-rough-carbon)"/>
+</svg>`);
+  return { mapUrl, roughnessMapUrl, normalMapUrl: null };
+};
+
 export const WOOD_GRAIN_OPTIONS = Object.freeze([
   Object.freeze({
     id: 'acg_walnut_quarter',
@@ -473,6 +547,168 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
       rotation: 0,
       textureSize: 2048,
       ...polyHavenTextureSet('japanese_sycamore')
+    }
+  }),
+  Object.freeze({
+    id: 'oak_veneer_01_amber',
+    label: 'Oak Veneer 01 · Amber',
+    source: 'TonPlaygram custom oak veneer palette',
+    rail: {
+      repeat: { x: 1, y: 1 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineOakVeneerPattern({
+        id: 'oak-amber',
+        base: '#9c734d',
+        grain: '#6b4a2f',
+        highlight: '#c89666',
+        pore: '#4a2f1d'
+      })
+    },
+    frame: {
+      repeat: { x: 1, y: 1 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineOakVeneerPattern({
+        id: 'oak-amber-frame',
+        base: '#8f6844',
+        grain: '#614128',
+        highlight: '#ba885a',
+        pore: '#422817'
+      })
+    }
+  }),
+  Object.freeze({
+    id: 'oak_veneer_01_cocoa',
+    label: 'Oak Veneer 01 · Cocoa',
+    source: 'TonPlaygram custom oak veneer palette',
+    rail: {
+      repeat: { x: 1, y: 1 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineOakVeneerPattern({
+        id: 'oak-cocoa',
+        base: '#6b4d36',
+        grain: '#4a321f',
+        highlight: '#8b6648',
+        pore: '#2b1a10'
+      })
+    },
+    frame: {
+      repeat: { x: 1, y: 1 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineOakVeneerPattern({
+        id: 'oak-cocoa-frame',
+        base: '#5c422f',
+        grain: '#3f2a1a',
+        highlight: '#79573e',
+        pore: '#24160d'
+      })
+    }
+  }),
+  Object.freeze({
+    id: 'oak_veneer_01_walnut',
+    label: 'Oak Veneer 01 · Walnut',
+    source: 'TonPlaygram custom oak veneer palette',
+    rail: {
+      repeat: { x: 1, y: 1 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineOakVeneerPattern({
+        id: 'oak-walnut',
+        base: '#5a3e2a',
+        grain: '#3e2818',
+        highlight: '#77513a',
+        pore: '#22140b'
+      })
+    },
+    frame: {
+      repeat: { x: 1, y: 1 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineOakVeneerPattern({
+        id: 'oak-walnut-frame',
+        base: '#4f3625',
+        grain: '#352214',
+        highlight: '#6b4934',
+        pore: '#1e1109'
+      })
+    }
+  }),
+  Object.freeze({
+    id: 'oak_veneer_01_mahogany_red',
+    label: 'Oak Veneer 01 · Mahogany Red',
+    source: 'TonPlaygram custom oak veneer palette',
+    rail: {
+      repeat: { x: 1, y: 1 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineOakVeneerPattern({
+        id: 'oak-mahogany',
+        base: '#7b3f34',
+        grain: '#58291f',
+        highlight: '#a45a4b',
+        pore: '#31150f'
+      })
+    },
+    frame: {
+      repeat: { x: 1, y: 1 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineOakVeneerPattern({
+        id: 'oak-mahogany-frame',
+        base: '#6d372e',
+        grain: '#4c221b',
+        highlight: '#935245',
+        pore: '#2b130d'
+      })
+    }
+  }),
+  Object.freeze({
+    id: 'oak_veneer_01_matte_black',
+    label: 'Oak Veneer 01 · Matte Black',
+    source: 'TonPlaygram custom oak veneer palette',
+    rail: {
+      repeat: { x: 1, y: 1 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineOakVeneerPattern({
+        id: 'oak-black',
+        base: '#171717',
+        grain: '#0d0d0d',
+        highlight: '#2b2b2b',
+        pore: '#050505'
+      })
+    },
+    frame: {
+      repeat: { x: 1, y: 1 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineOakVeneerPattern({
+        id: 'oak-black-frame',
+        base: '#121212',
+        grain: '#090909',
+        highlight: '#212121',
+        pore: '#040404'
+      })
+    }
+  }),
+  Object.freeze({
+    id: 'carbon_fiber_chalk',
+    label: 'Carbon Fiber Chalk Pattern',
+    source: 'TonPlaygram custom carbon weave',
+    rail: {
+      repeat: { x: 0.8, y: 0.8 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineCarbonFiberPattern({ id: 'carbon-chalk' })
+    },
+    frame: {
+      repeat: { x: 0.8, y: 0.8 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineCarbonFiberPattern({ id: 'carbon-chalk-frame' })
     }
   })
 ]);


### PR DESCRIPTION
### Motivation
- Replays were being suppressed in Pool Royale when shots recorded too few frames (e.g., on pots or fouls), preventing the replay slate/playback from starting.   
- Remote (networked) shot payloads with a single frame were dropped instead of being normalized into playable replay data.   
- Add five Oak Veneer 01 color variants (including matte black) plus a carbon-fiber pattern finish to the store so players can buy new table finishes.

### Description
- Ensure at least two frames exist before resolving a shot by forcing an extra `recordReplayFrame` when `shotRecording.frames.length < 2` to avoid false-negative replay gating (changes in `webapp/src/pages/Games/PoolRoyale.jsx`).
- Accept remote replay payloads with a single frame by normalizing `pending.frames` into a two-frame sequence (duplicating the single frame with a fallback delta) so remote replays can start (changes in `webapp/src/pages/Games/PoolRoyale.jsx`).
- Add six new table finishes derived from the Oak Veneer 01 pattern plus a carbon-fiber variant, expose them in the game finishes list, and include them in `TABLE_FINISH_OPTIONS` (changes in `webapp/src/pages/Games/PoolRoyale.jsx`).
- Add store thumbnails, labels and purchasable store items for the new finishes (changes in `webapp/src/config/poolRoyaleInventoryConfig.js`).
- Provide inline procedural SVG-based textures and new wood-grain entries used by the new finishes (custom Oak veneer palettes and a carbon-fiber pattern) so the variants have app-defined textures without external asset dependencies (changes in `webapp/src/utils/woodMaterials.js`).

### Testing
- Ran a production build: `cd webapp && npm run build`, which completed successfully (Vite produced non-blocking chunk-size/dynamic-import warnings only).  
- Verified the modified code compiles into the production bundle and the new inventory entries are included in the generated build metadata (build finished without errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cade26a980832982839b2942c7ab51)