### PR TITLE
Add oak veneer & carbon finishes with inline textures; fix single-frame replay handling

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -296,7 +296,13 @@ const TABLE_FINISH_THUMBNAILS = Object.freeze({
   oakVeneer01: polyHavenThumb('oak_veneer_01'),
   woodTable001: polyHavenThumb('wood_table_001'),
   darkWood: polyHavenThumb('dark_wood'),
-  rosewoodVeneer01: polyHavenThumb('rosewood_veneer_01')
+  rosewoodVeneer01: polyHavenThumb('rosewood_veneer_01'),
+  oakVeneer01Amber: swatchThumbnail(['#9f7148', '#c08a58', '#d6a370']),
+  oakVeneer01Cocoa: swatchThumbnail(['#6d4b33', '#8b6040', '#a67852']),
+  oakVeneer01Walnut: swatchThumbnail(['#543726', '#6f4b34', '#8a6246']),
+  oakVeneer01MahoganyRed: swatchThumbnail(['#7b3f34', '#9a4f40', '#b76655']),
+  oakVeneer01MatteBlack: swatchThumbnail(['#121212', '#242424', '#333333']),
+  carbonFiberChalk: swatchThumbnail(['#0c1018', '#1a1f2a', '#374151'])
 });
 
 const POCKET_LINER_THUMBNAILS = Object.freeze({
@@ -394,7 +400,13 @@ export const POOL_ROYALE_OPTION_LABELS = Object.freeze({
     oakVeneer01: 'Oak Veneer 01',
     woodTable001: 'Wood Table 001',
     darkWood: 'Dark Wood',
-    rosewoodVeneer01: 'Rosewood Veneer 01'
+    rosewoodVeneer01: 'Rosewood Veneer 01',
+    oakVeneer01Amber: 'Amber Glow',
+    oakVeneer01Cocoa: 'Cocoa Drift',
+    oakVeneer01Walnut: 'Walnut Crest',
+    oakVeneer01MahoganyRed: 'Crimson Grain',
+    oakVeneer01MatteBlack: 'Midnight Matte',
+    carbonFiberChalk: 'Carbon Fiber Chalk'
   }),
   chromeColor: Object.freeze({
     chrome: 'Chrome',
@@ -481,6 +493,60 @@ export const POOL_ROYALE_STORE_ITEMS = [
     price: 1020,
     description: 'Rosewood veneer rails with rich, reddish undertones.',
     thumbnail: TABLE_FINISH_THUMBNAILS.rosewoodVeneer01
+  },
+  {
+    id: 'finish-oakVeneer01Amber',
+    type: 'tableFinish',
+    optionId: 'oakVeneer01Amber',
+    name: 'Amber Glow Finish',
+    price: 1060,
+    description: 'Custom amber oak veneer pattern with bright satin grain.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.oakVeneer01Amber
+  },
+  {
+    id: 'finish-oakVeneer01Cocoa',
+    type: 'tableFinish',
+    optionId: 'oakVeneer01Cocoa',
+    name: 'Cocoa Drift Finish',
+    price: 1070,
+    description: 'Custom cocoa oak veneer with warm chocolate undertones.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.oakVeneer01Cocoa
+  },
+  {
+    id: 'finish-oakVeneer01Walnut',
+    type: 'tableFinish',
+    optionId: 'oakVeneer01Walnut',
+    name: 'Walnut Crest Finish',
+    price: 1080,
+    description: 'Custom walnut oak veneer with deeper grain separation.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.oakVeneer01Walnut
+  },
+  {
+    id: 'finish-oakVeneer01MahoganyRed',
+    type: 'tableFinish',
+    optionId: 'oakVeneer01MahoganyRed',
+    name: 'Crimson Grain Finish',
+    price: 1090,
+    description: 'Custom mahogany-red oak veneer for a premium classic look.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.oakVeneer01MahoganyRed
+  },
+  {
+    id: 'finish-oakVeneer01MatteBlack',
+    type: 'tableFinish',
+    optionId: 'oakVeneer01MatteBlack',
+    name: 'Midnight Matte Finish',
+    price: 1100,
+    description: 'Custom matte-black oak veneer with subtle low-gloss grain.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.oakVeneer01MatteBlack
+  },
+  {
+    id: 'finish-carbonFiberChalk',
+    type: 'tableFinish',
+    optionId: 'carbonFiberChalk',
+    name: 'Carbon Fiber Chalk Finish',
+    price: 1160,
+    description: 'Custom carbon weave inspired by the chalk block pattern.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberChalk
   },
   {
     id: 'chrome-chrome',

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2984,6 +2984,60 @@ const TABLE_FINISHES = Object.freeze({
     trim: 0x9b5a44,
     woodTextureId: 'rosewood_veneer_01',
     woodRepeatScale: 1
+  }),
+  oakVeneer01Amber: createStandardWoodFinish({
+    id: 'oakVeneer01Amber',
+    label: 'Amber Glow',
+    rail: 0xc08a58,
+    base: 0x9f7148,
+    trim: 0xd6a370,
+    woodTextureId: 'oak_veneer_01_amber',
+    woodRepeatScale: 1
+  }),
+  oakVeneer01Cocoa: createStandardWoodFinish({
+    id: 'oakVeneer01Cocoa',
+    label: 'Cocoa Drift',
+    rail: 0x8b6040,
+    base: 0x6d4b33,
+    trim: 0xa67852,
+    woodTextureId: 'oak_veneer_01_cocoa',
+    woodRepeatScale: 1
+  }),
+  oakVeneer01Walnut: createStandardWoodFinish({
+    id: 'oakVeneer01Walnut',
+    label: 'Walnut Crest',
+    rail: 0x6f4b34,
+    base: 0x543726,
+    trim: 0x8a6246,
+    woodTextureId: 'oak_veneer_01_walnut',
+    woodRepeatScale: 1
+  }),
+  oakVeneer01MahoganyRed: createStandardWoodFinish({
+    id: 'oakVeneer01MahoganyRed',
+    label: 'Crimson Grain',
+    rail: 0x9a4f40,
+    base: 0x7b3f34,
+    trim: 0xb76655,
+    woodTextureId: 'oak_veneer_01_mahogany_red',
+    woodRepeatScale: 1
+  }),
+  oakVeneer01MatteBlack: createStandardWoodFinish({
+    id: 'oakVeneer01MatteBlack',
+    label: 'Midnight Matte',
+    rail: 0x242424,
+    base: 0x121212,
+    trim: 0x333333,
+    woodTextureId: 'oak_veneer_01_matte_black',
+    woodRepeatScale: 1
+  }),
+  carbonFiberChalk: createStandardWoodFinish({
+    id: 'carbonFiberChalk',
+    label: 'Carbon Fiber Chalk',
+    rail: 0x1a1f2a,
+    base: 0x0c1018,
+    trim: 0x374151,
+    woodTextureId: 'carbon_fiber_chalk',
+    woodRepeatScale: 1
   })
 });
 
@@ -2993,7 +3047,13 @@ const TABLE_FINISH_OPTIONS = Object.freeze(
     TABLE_FINISHES.oakVeneer01,
     TABLE_FINISHES.woodTable001,
     TABLE_FINISHES.darkWood,
-    TABLE_FINISHES.rosewoodVeneer01
+    TABLE_FINISHES.rosewoodVeneer01,
+    TABLE_FINISHES.oakVeneer01Amber,
+    TABLE_FINISHES.oakVeneer01Cocoa,
+    TABLE_FINISHES.oakVeneer01Walnut,
+    TABLE_FINISHES.oakVeneer01MahoganyRed,
+    TABLE_FINISHES.oakVeneer01MatteBlack,
+    TABLE_FINISHES.carbonFiberChalk
   ].filter(Boolean)
 );
 
@@ -28392,6 +28452,9 @@ const powerRef = useRef(hud.power);
         function resolve() {
           const variantId = activeVariantRef.current?.id ?? 'american';
           const shotEvents = [];
+          if (shotRecording && (shotRecording.frames?.length ?? 0) < 2) {
+            recordReplayFrame(performance.now());
+          }
           const firstContactColor = toBallColorId(firstHit);
           const hadObjectPot = potted.some((entry) => entry.id !== 'cue');
           let replayDecision = resolveReplayDecision({
@@ -29127,7 +29190,16 @@ const powerRef = useRef(hud.power);
         if (!shooting && !shotRecording && !replayPlaybackRef.current && pendingRemoteReplayRef.current) {
           const pending = pendingRemoteReplayRef.current;
           pendingRemoteReplayRef.current = null;
-          if (!skipAllReplaysRef.current && pending?.frames?.length > 1) {
+          if (!skipAllReplaysRef.current && pending?.frames?.length > 0) {
+            const normalizedFrames = Array.isArray(pending.frames) ? [...pending.frames] : [];
+            if (normalizedFrames.length === 1) {
+              const firstFrame = normalizedFrames[0];
+              const fallbackFrameTime = Math.max(16, pending.frameTimeMs ?? 1000 / 60);
+              normalizedFrames.push({
+                ...firstFrame,
+                t: Math.max(fallbackFrameTime, firstFrame?.t ?? 0)
+              });
+            }
             const frameTiming = frameTimingRef.current;
             const frameTimeMs =
               Number.isFinite(pending?.frameTimeMs) && pending.frameTimeMs > 0
@@ -29137,6 +29209,7 @@ const powerRef = useRef(hud.power);
                   : 1000 / 60;
             shotRecording = {
               ...pending,
+              frames: normalizedFrames,
               startTime: pending.startTime ?? nowMs,
               startState: pending.startState ?? captureBallSnapshot(),
               zoomOnly: pending.zoomOnly ?? false,

--- a/webapp/src/utils/woodMaterials.js
+++ b/webapp/src/utils/woodMaterials.js
@@ -325,6 +325,103 @@ const polyHavenTextureSet = (assetId) => {
   };
 };
 
+const svgDataUrl = (svg) => `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(svg)}`;
+
+const makeInlineOakVeneerPattern = ({
+  id,
+  base = '#8a623f',
+  grain = '#5e4129',
+  highlight = '#b8885c',
+  pore = '#3f2a1b'
+}) => {
+  const colorMap = svgDataUrl(`
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="${id}-base" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="${base}"/>
+      <stop offset="55%" stop-color="${highlight}"/>
+      <stop offset="100%" stop-color="${base}"/>
+    </linearGradient>
+    <pattern id="${id}-grain" patternUnits="userSpaceOnUse" width="128" height="128">
+      <rect width="128" height="128" fill="none"/>
+      <path d="M-32 16 C 6 2, 44 30, 82 16 S 158 2, 196 16" stroke="${grain}" stroke-width="8" stroke-linecap="round" fill="none" opacity="0.38"/>
+      <path d="M-22 46 C 14 30, 54 62, 90 46 S 166 30, 202 46" stroke="${grain}" stroke-width="6" stroke-linecap="round" fill="none" opacity="0.3"/>
+      <path d="M-28 78 C 8 64, 48 94, 84 78 S 160 64, 196 78" stroke="${grain}" stroke-width="7" stroke-linecap="round" fill="none" opacity="0.32"/>
+      <path d="M-24 110 C 12 94, 52 124, 88 110 S 164 94, 200 110" stroke="${grain}" stroke-width="6" stroke-linecap="round" fill="none" opacity="0.28"/>
+      <circle cx="36" cy="36" r="2.6" fill="${pore}" opacity="0.32"/>
+      <circle cx="94" cy="78" r="2.1" fill="${pore}" opacity="0.28"/>
+      <circle cx="62" cy="106" r="1.8" fill="${pore}" opacity="0.24"/>
+    </pattern>
+  </defs>
+  <rect width="512" height="512" fill="url(#${id}-base)"/>
+  <rect width="512" height="512" fill="url(#${id}-grain)"/>
+</svg>`);
+  const roughnessMap = svgDataUrl(`
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
+  <defs>
+    <pattern id="${id}-rough" patternUnits="userSpaceOnUse" width="128" height="128">
+      <rect width="128" height="128" fill="#6f6f6f"/>
+      <path d="M-32 16 C 6 2, 44 30, 82 16 S 158 2, 196 16" stroke="#9b9b9b" stroke-width="8" stroke-linecap="round" fill="none" opacity="0.66"/>
+      <path d="M-22 46 C 14 30, 54 62, 90 46 S 166 30, 202 46" stroke="#8b8b8b" stroke-width="6" stroke-linecap="round" fill="none" opacity="0.55"/>
+      <path d="M-28 78 C 8 64, 48 94, 84 78 S 160 64, 196 78" stroke="#9a9a9a" stroke-width="7" stroke-linecap="round" fill="none" opacity="0.6"/>
+      <path d="M-24 110 C 12 94, 52 124, 88 110 S 164 94, 200 110" stroke="#858585" stroke-width="6" stroke-linecap="round" fill="none" opacity="0.52"/>
+    </pattern>
+  </defs>
+  <rect width="512" height="512" fill="url(#${id}-rough)"/>
+</svg>`);
+  return { mapUrl: colorMap, roughnessMapUrl: roughnessMap, normalMapUrl: null };
+};
+
+const makeInlineCarbonFiberPattern = ({ id }) => {
+  if (typeof document !== 'undefined') {
+    const canvas = document.createElement('canvas');
+    canvas.width = 128;
+    canvas.height = 128;
+    const ctx = canvas.getContext('2d');
+    if (ctx) {
+      // Match Pool Royale chalk carbon-fiber weave exactly (same geometry and tile size).
+      ctx.fillStyle = '#07090f';
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      ctx.fillStyle = '#0c111a';
+      ctx.fillRect(0, 0, canvas.width / 2, canvas.height / 2);
+      ctx.fillRect(canvas.width / 2, canvas.height / 2, canvas.width / 2, canvas.height / 2);
+      ctx.fillStyle = '#131926';
+      ctx.beginPath();
+      ctx.moveTo(canvas.width / 2, 0);
+      ctx.lineTo(canvas.width, 0);
+      ctx.lineTo(0, canvas.height);
+      ctx.lineTo(0, canvas.height / 2);
+      ctx.closePath();
+      ctx.fill();
+      ctx.beginPath();
+      ctx.moveTo(canvas.width, canvas.height / 2);
+      ctx.lineTo(canvas.width, canvas.height);
+      ctx.lineTo(canvas.width / 2, canvas.height);
+      ctx.closePath();
+      ctx.fill();
+      ctx.strokeStyle = 'rgba(255,255,255,0.04)';
+      ctx.lineWidth = 1;
+      for (let i = -canvas.width; i <= canvas.width; i += canvas.width / 4) {
+        ctx.beginPath();
+        ctx.moveTo(i, 0);
+        ctx.lineTo(i + canvas.width, canvas.height);
+        ctx.stroke();
+      }
+      const mapUrl = canvas.toDataURL('image/png');
+      return { mapUrl, roughnessMapUrl: null, normalMapUrl: null };
+    }
+  }
+  const fallback = svgDataUrl(`
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128">
+  <rect width="128" height="128" fill="#07090f"/>
+  <rect width="64" height="64" fill="#0c111a"/>
+  <rect x="64" y="64" width="64" height="64" fill="#0c111a"/>
+  <path d="M64 0 H128 L0 128 V64 Z" fill="#131926"/>
+  <path d="M128 64 V128 H64 Z" fill="#131926"/>
+</svg>`);
+  return { mapUrl: fallback, roughnessMapUrl: null, normalMapUrl: null };
+};
+
 export const WOOD_GRAIN_OPTIONS = Object.freeze([
   Object.freeze({
     id: 'acg_walnut_quarter',
@@ -473,6 +570,168 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
       rotation: 0,
       textureSize: 2048,
       ...polyHavenTextureSet('japanese_sycamore')
+    }
+  }),
+  Object.freeze({
+    id: 'oak_veneer_01_amber',
+    label: 'Amber Glow',
+    source: 'TonPlaygram custom oak veneer palette',
+    rail: {
+      repeat: { x: 1, y: 1 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineOakVeneerPattern({
+        id: 'oak-amber',
+        base: '#9c734d',
+        grain: '#6b4a2f',
+        highlight: '#c89666',
+        pore: '#4a2f1d'
+      })
+    },
+    frame: {
+      repeat: { x: 1, y: 1 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineOakVeneerPattern({
+        id: 'oak-amber-frame',
+        base: '#8f6844',
+        grain: '#614128',
+        highlight: '#ba885a',
+        pore: '#422817'
+      })
+    }
+  }),
+  Object.freeze({
+    id: 'oak_veneer_01_cocoa',
+    label: 'Cocoa Drift',
+    source: 'TonPlaygram custom oak veneer palette',
+    rail: {
+      repeat: { x: 1, y: 1 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineOakVeneerPattern({
+        id: 'oak-cocoa',
+        base: '#6b4d36',
+        grain: '#4a321f',
+        highlight: '#8b6648',
+        pore: '#2b1a10'
+      })
+    },
+    frame: {
+      repeat: { x: 1, y: 1 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineOakVeneerPattern({
+        id: 'oak-cocoa-frame',
+        base: '#5c422f',
+        grain: '#3f2a1a',
+        highlight: '#79573e',
+        pore: '#24160d'
+      })
+    }
+  }),
+  Object.freeze({
+    id: 'oak_veneer_01_walnut',
+    label: 'Walnut Crest',
+    source: 'TonPlaygram custom oak veneer palette',
+    rail: {
+      repeat: { x: 1, y: 1 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineOakVeneerPattern({
+        id: 'oak-walnut',
+        base: '#5a3e2a',
+        grain: '#3e2818',
+        highlight: '#77513a',
+        pore: '#22140b'
+      })
+    },
+    frame: {
+      repeat: { x: 1, y: 1 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineOakVeneerPattern({
+        id: 'oak-walnut-frame',
+        base: '#4f3625',
+        grain: '#352214',
+        highlight: '#6b4934',
+        pore: '#1e1109'
+      })
+    }
+  }),
+  Object.freeze({
+    id: 'oak_veneer_01_mahogany_red',
+    label: 'Crimson Grain',
+    source: 'TonPlaygram custom oak veneer palette',
+    rail: {
+      repeat: { x: 1, y: 1 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineOakVeneerPattern({
+        id: 'oak-mahogany',
+        base: '#7b3f34',
+        grain: '#58291f',
+        highlight: '#a45a4b',
+        pore: '#31150f'
+      })
+    },
+    frame: {
+      repeat: { x: 1, y: 1 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineOakVeneerPattern({
+        id: 'oak-mahogany-frame',
+        base: '#6d372e',
+        grain: '#4c221b',
+        highlight: '#935245',
+        pore: '#2b130d'
+      })
+    }
+  }),
+  Object.freeze({
+    id: 'oak_veneer_01_matte_black',
+    label: 'Midnight Matte',
+    source: 'TonPlaygram custom oak veneer palette',
+    rail: {
+      repeat: { x: 1, y: 1 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineOakVeneerPattern({
+        id: 'oak-black',
+        base: '#171717',
+        grain: '#0d0d0d',
+        highlight: '#2b2b2b',
+        pore: '#050505'
+      })
+    },
+    frame: {
+      repeat: { x: 1, y: 1 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineOakVeneerPattern({
+        id: 'oak-black-frame',
+        base: '#121212',
+        grain: '#090909',
+        highlight: '#212121',
+        pore: '#040404'
+      })
+    }
+  }),
+  Object.freeze({
+    id: 'carbon_fiber_chalk',
+    label: 'Carbon Fiber Chalk Pattern',
+    source: 'TonPlaygram custom carbon weave',
+    rail: {
+      repeat: { x: 0.8, y: 0.8 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineCarbonFiberPattern({ id: 'carbon-chalk' })
+    },
+    frame: {
+      repeat: { x: 0.8, y: 0.8 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineCarbonFiberPattern({ id: 'carbon-chalk-frame' })
     }
   })
 ]);


### PR DESCRIPTION
### Motivation
- Add several new table finish variants and thumbnails (custom oak veneers and a carbon-fiber chalk pattern) to expand cosmetic options and store offerings.
- Provide inline, self-contained texture/roughness sources so these custom finishes don't rely on external assets.
- Make replay recording/playback more robust for single-frame or very short remote replays so they render correctly.

### Description
- Added new `TABLE_FINISH_THUMBNAILS` entries and updated `POOL_ROYALE_OPTION_LABELS` and `POOL_ROYALE_STORE_ITEMS` to expose `oakVeneer01Amber`, `oakVeneer01Cocoa`, `oakVeneer01Walnut`, `oakVeneer01MahoganyRed`, `oakVeneer01MatteBlack`, and `carbonFiberChalk` options and store entries. 
- Added corresponding finish definitions to `TABLE_FINISHES` and included them in `TABLE_FINISH_OPTIONS` in `PoolRoyale.jsx` using `createStandardWoodFinish` with color/texture ids. 
- Implemented inline texture generation helpers in `woodMaterials.js`: `svgDataUrl`, `makeInlineOakVeneerPattern`, and `makeInlineCarbonFiberPattern`, and added new `WOOD_GRAIN_OPTIONS` entries that use these inline patterns for rail/frame textures. 
- Improved replay handling in the game loop: when resolving a shot, ensure a frame is recorded if `shotRecording` has fewer than 2 frames by calling `recordReplayFrame`; when accepting a pending remote replay allow single-frame payloads and normalize them by duplicating the frame with a fallback `t` to produce a minimal two-frame recording. 

### Testing
- Ran the unit test suite with `yarn test`, and all tests completed successfully. 
- Ran the linter with `yarn lint`, and no new lint errors were reported. 
- Performed a production build with `yarn build`, and the build succeeded without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cade26a980832982839b2942c7ab51)