### PR TITLE
Add new Pool Royale table finishes (oak variants & carbon), inline carbon-fiber pattern, and single-frame replay handling

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -296,7 +296,13 @@ const TABLE_FINISH_THUMBNAILS = Object.freeze({
   oakVeneer01: polyHavenThumb('oak_veneer_01'),
   woodTable001: polyHavenThumb('wood_table_001'),
   darkWood: polyHavenThumb('dark_wood'),
-  rosewoodVeneer01: polyHavenThumb('rosewood_veneer_01')
+  rosewoodVeneer01: polyHavenThumb('rosewood_veneer_01'),
+  oakVeneer01Amber: swatchThumbnail(['#9f7148', '#c08a58', '#d6a370']),
+  oakVeneer01Cocoa: swatchThumbnail(['#6d4b33', '#8b6040', '#a67852']),
+  oakVeneer01Walnut: swatchThumbnail(['#543726', '#6f4b34', '#8a6246']),
+  oakVeneer01MahoganyRed: swatchThumbnail(['#7b3f34', '#9a4f40', '#b76655']),
+  oakVeneer01MatteBlack: swatchThumbnail(['#353a42', '#4a4f57', '#5e646d']),
+  carbonFiberChalk: swatchThumbnail(['#0c1018', '#1a1f2a', '#374151'])
 });
 
 const POCKET_LINER_THUMBNAILS = Object.freeze({
@@ -394,7 +400,13 @@ export const POOL_ROYALE_OPTION_LABELS = Object.freeze({
     oakVeneer01: 'Oak Veneer 01',
     woodTable001: 'Wood Table 001',
     darkWood: 'Dark Wood',
-    rosewoodVeneer01: 'Rosewood Veneer 01'
+    rosewoodVeneer01: 'Rosewood Veneer 01',
+    oakVeneer01Amber: 'Amber Glow',
+    oakVeneer01Cocoa: 'Cocoa Drift',
+    oakVeneer01Walnut: 'Walnut Crest',
+    oakVeneer01MahoganyRed: 'Crimson Grain',
+    oakVeneer01MatteBlack: 'Midnight Matte',
+    carbonFiberChalk: 'Carbon Fiber Chalk'
   }),
   chromeColor: Object.freeze({
     chrome: 'Chrome',
@@ -481,6 +493,60 @@ export const POOL_ROYALE_STORE_ITEMS = [
     price: 1020,
     description: 'Rosewood veneer rails with rich, reddish undertones.',
     thumbnail: TABLE_FINISH_THUMBNAILS.rosewoodVeneer01
+  },
+  {
+    id: 'finish-oakVeneer01Amber',
+    type: 'tableFinish',
+    optionId: 'oakVeneer01Amber',
+    name: 'Amber Glow Finish',
+    price: 1060,
+    description: 'Custom amber oak veneer pattern with bright satin grain.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.oakVeneer01Amber
+  },
+  {
+    id: 'finish-oakVeneer01Cocoa',
+    type: 'tableFinish',
+    optionId: 'oakVeneer01Cocoa',
+    name: 'Cocoa Drift Finish',
+    price: 1070,
+    description: 'Custom cocoa oak veneer with warm chocolate undertones.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.oakVeneer01Cocoa
+  },
+  {
+    id: 'finish-oakVeneer01Walnut',
+    type: 'tableFinish',
+    optionId: 'oakVeneer01Walnut',
+    name: 'Walnut Crest Finish',
+    price: 1080,
+    description: 'Custom walnut oak veneer with deeper grain separation.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.oakVeneer01Walnut
+  },
+  {
+    id: 'finish-oakVeneer01MahoganyRed',
+    type: 'tableFinish',
+    optionId: 'oakVeneer01MahoganyRed',
+    name: 'Crimson Grain Finish',
+    price: 1090,
+    description: 'Custom mahogany-red oak veneer for a premium classic look.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.oakVeneer01MahoganyRed
+  },
+  {
+    id: 'finish-oakVeneer01MatteBlack',
+    type: 'tableFinish',
+    optionId: 'oakVeneer01MatteBlack',
+    name: 'Midnight Matte Finish',
+    price: 1100,
+    description: 'Custom matte-black oak veneer with subtle low-gloss grain.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.oakVeneer01MatteBlack
+  },
+  {
+    id: 'finish-carbonFiberChalk',
+    type: 'tableFinish',
+    optionId: 'carbonFiberChalk',
+    name: 'Carbon Fiber Chalk Finish',
+    price: 1160,
+    description: 'Custom carbon weave inspired by the chalk block pattern.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberChalk
   },
   {
     id: 'chrome-chrome',

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2984,6 +2984,60 @@ const TABLE_FINISHES = Object.freeze({
     trim: 0x9b5a44,
     woodTextureId: 'rosewood_veneer_01',
     woodRepeatScale: 1
+  }),
+  oakVeneer01Amber: createStandardWoodFinish({
+    id: 'oakVeneer01Amber',
+    label: 'Amber Glow',
+    rail: 0xc08a58,
+    base: 0x9f7148,
+    trim: 0xd6a370,
+    woodTextureId: 'oak_veneer_01_amber',
+    woodRepeatScale: 1
+  }),
+  oakVeneer01Cocoa: createStandardWoodFinish({
+    id: 'oakVeneer01Cocoa',
+    label: 'Cocoa Drift',
+    rail: 0x8b6040,
+    base: 0x6d4b33,
+    trim: 0xa67852,
+    woodTextureId: 'oak_veneer_01_cocoa',
+    woodRepeatScale: 1
+  }),
+  oakVeneer01Walnut: createStandardWoodFinish({
+    id: 'oakVeneer01Walnut',
+    label: 'Walnut Crest',
+    rail: 0x6f4b34,
+    base: 0x543726,
+    trim: 0x8a6246,
+    woodTextureId: 'oak_veneer_01_walnut',
+    woodRepeatScale: 1
+  }),
+  oakVeneer01MahoganyRed: createStandardWoodFinish({
+    id: 'oakVeneer01MahoganyRed',
+    label: 'Crimson Grain',
+    rail: 0x9a4f40,
+    base: 0x7b3f34,
+    trim: 0xb76655,
+    woodTextureId: 'oak_veneer_01_mahogany_red',
+    woodRepeatScale: 1
+  }),
+  oakVeneer01MatteBlack: createStandardWoodFinish({
+    id: 'oakVeneer01MatteBlack',
+    label: 'Midnight Matte',
+    rail: 0x4a4f57,
+    base: 0x353a42,
+    trim: 0x5e646d,
+    woodTextureId: 'oak_veneer_01_matte_black',
+    woodRepeatScale: 1
+  }),
+  carbonFiberChalk: createStandardWoodFinish({
+    id: 'carbonFiberChalk',
+    label: 'Carbon Fiber Chalk',
+    rail: 0x1a1f2a,
+    base: 0x0c1018,
+    trim: 0x374151,
+    woodTextureId: 'carbon_fiber_chalk',
+    woodRepeatScale: 1
   })
 });
 
@@ -2993,7 +3047,13 @@ const TABLE_FINISH_OPTIONS = Object.freeze(
     TABLE_FINISHES.oakVeneer01,
     TABLE_FINISHES.woodTable001,
     TABLE_FINISHES.darkWood,
-    TABLE_FINISHES.rosewoodVeneer01
+    TABLE_FINISHES.rosewoodVeneer01,
+    TABLE_FINISHES.oakVeneer01Amber,
+    TABLE_FINISHES.oakVeneer01Cocoa,
+    TABLE_FINISHES.oakVeneer01Walnut,
+    TABLE_FINISHES.oakVeneer01MahoganyRed,
+    TABLE_FINISHES.oakVeneer01MatteBlack,
+    TABLE_FINISHES.carbonFiberChalk
   ].filter(Boolean)
 );
 
@@ -28392,6 +28452,9 @@ const powerRef = useRef(hud.power);
         function resolve() {
           const variantId = activeVariantRef.current?.id ?? 'american';
           const shotEvents = [];
+          if (shotRecording && (shotRecording.frames?.length ?? 0) < 2) {
+            recordReplayFrame(performance.now());
+          }
           const firstContactColor = toBallColorId(firstHit);
           const hadObjectPot = potted.some((entry) => entry.id !== 'cue');
           let replayDecision = resolveReplayDecision({
@@ -29127,7 +29190,16 @@ const powerRef = useRef(hud.power);
         if (!shooting && !shotRecording && !replayPlaybackRef.current && pendingRemoteReplayRef.current) {
           const pending = pendingRemoteReplayRef.current;
           pendingRemoteReplayRef.current = null;
-          if (!skipAllReplaysRef.current && pending?.frames?.length > 1) {
+          if (!skipAllReplaysRef.current && pending?.frames?.length > 0) {
+            const normalizedFrames = Array.isArray(pending.frames) ? [...pending.frames] : [];
+            if (normalizedFrames.length === 1) {
+              const firstFrame = normalizedFrames[0];
+              const fallbackFrameTime = Math.max(16, pending.frameTimeMs ?? 1000 / 60);
+              normalizedFrames.push({
+                ...firstFrame,
+                t: Math.max(fallbackFrameTime, firstFrame?.t ?? 0)
+              });
+            }
             const frameTiming = frameTimingRef.current;
             const frameTimeMs =
               Number.isFinite(pending?.frameTimeMs) && pending.frameTimeMs > 0
@@ -29137,6 +29209,7 @@ const powerRef = useRef(hud.power);
                   : 1000 / 60;
             shotRecording = {
               ...pending,
+              frames: normalizedFrames,
               startTime: pending.startTime ?? nowMs,
               startState: pending.startState ?? captureBallSnapshot(),
               zoomOnly: pending.zoomOnly ?? false,

--- a/webapp/src/utils/woodMaterials.js
+++ b/webapp/src/utils/woodMaterials.js
@@ -325,6 +325,58 @@ const polyHavenTextureSet = (assetId) => {
   };
 };
 
+const svgDataUrl = (svg) => `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(svg)}`;
+
+const makeInlineCarbonFiberPattern = ({ id }) => {
+  if (typeof document !== 'undefined') {
+    const canvas = document.createElement('canvas');
+    canvas.width = 128;
+    canvas.height = 128;
+    const ctx = canvas.getContext('2d');
+    if (ctx) {
+      // Match Pool Royale chalk carbon-fiber weave exactly (same geometry and tile size).
+      ctx.fillStyle = '#07090f';
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      ctx.fillStyle = '#0c111a';
+      ctx.fillRect(0, 0, canvas.width / 2, canvas.height / 2);
+      ctx.fillRect(canvas.width / 2, canvas.height / 2, canvas.width / 2, canvas.height / 2);
+      ctx.fillStyle = '#131926';
+      ctx.beginPath();
+      ctx.moveTo(canvas.width / 2, 0);
+      ctx.lineTo(canvas.width, 0);
+      ctx.lineTo(0, canvas.height);
+      ctx.lineTo(0, canvas.height / 2);
+      ctx.closePath();
+      ctx.fill();
+      ctx.beginPath();
+      ctx.moveTo(canvas.width, canvas.height / 2);
+      ctx.lineTo(canvas.width, canvas.height);
+      ctx.lineTo(canvas.width / 2, canvas.height);
+      ctx.closePath();
+      ctx.fill();
+      ctx.strokeStyle = 'rgba(255,255,255,0.04)';
+      ctx.lineWidth = 1;
+      for (let i = -canvas.width; i <= canvas.width; i += canvas.width / 4) {
+        ctx.beginPath();
+        ctx.moveTo(i, 0);
+        ctx.lineTo(i + canvas.width, canvas.height);
+        ctx.stroke();
+      }
+      const mapUrl = canvas.toDataURL('image/png');
+      return { mapUrl, roughnessMapUrl: null, normalMapUrl: null };
+    }
+  }
+  const fallback = svgDataUrl(`
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128">
+  <rect width="128" height="128" fill="#07090f"/>
+  <rect width="64" height="64" fill="#0c111a"/>
+  <rect x="64" y="64" width="64" height="64" fill="#0c111a"/>
+  <path d="M64 0 H128 L0 128 V64 Z" fill="#131926"/>
+  <path d="M128 64 V128 H64 Z" fill="#131926"/>
+</svg>`);
+  return { mapUrl: fallback, roughnessMapUrl: null, normalMapUrl: null };
+};
+
 export const WOOD_GRAIN_OPTIONS = Object.freeze([
   Object.freeze({
     id: 'acg_walnut_quarter',
@@ -473,6 +525,108 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
       rotation: 0,
       textureSize: 2048,
       ...polyHavenTextureSet('japanese_sycamore')
+    }
+  }),
+  Object.freeze({
+    id: 'oak_veneer_01_amber',
+    label: 'Amber Glow',
+    source: 'TonPlaygram custom oak veneer palette',
+    rail: {
+      repeat: { x: 6, y: 6 },
+      rotation: 0,
+      textureSize: 2048,
+      ...polyHavenTextureSet('oak_veneer_01')
+    },
+    frame: {
+      repeat: { x: 6, y: 6 },
+      rotation: 0,
+      textureSize: 2048,
+      ...polyHavenTextureSet('oak_veneer_01')
+    }
+  }),
+  Object.freeze({
+    id: 'oak_veneer_01_cocoa',
+    label: 'Cocoa Drift',
+    source: 'TonPlaygram custom oak veneer palette',
+    rail: {
+      repeat: { x: 6, y: 6 },
+      rotation: 0,
+      textureSize: 2048,
+      ...polyHavenTextureSet('oak_veneer_01')
+    },
+    frame: {
+      repeat: { x: 6, y: 6 },
+      rotation: 0,
+      textureSize: 2048,
+      ...polyHavenTextureSet('oak_veneer_01')
+    }
+  }),
+  Object.freeze({
+    id: 'oak_veneer_01_walnut',
+    label: 'Walnut Crest',
+    source: 'TonPlaygram custom oak veneer palette',
+    rail: {
+      repeat: { x: 6, y: 6 },
+      rotation: 0,
+      textureSize: 2048,
+      ...polyHavenTextureSet('oak_veneer_01')
+    },
+    frame: {
+      repeat: { x: 6, y: 6 },
+      rotation: 0,
+      textureSize: 2048,
+      ...polyHavenTextureSet('oak_veneer_01')
+    }
+  }),
+  Object.freeze({
+    id: 'oak_veneer_01_mahogany_red',
+    label: 'Crimson Grain',
+    source: 'TonPlaygram custom oak veneer palette',
+    rail: {
+      repeat: { x: 6, y: 6 },
+      rotation: 0,
+      textureSize: 2048,
+      ...polyHavenTextureSet('oak_veneer_01')
+    },
+    frame: {
+      repeat: { x: 6, y: 6 },
+      rotation: 0,
+      textureSize: 2048,
+      ...polyHavenTextureSet('oak_veneer_01')
+    }
+  }),
+  Object.freeze({
+    id: 'oak_veneer_01_matte_black',
+    label: 'Midnight Matte',
+    source: 'TonPlaygram custom oak veneer palette',
+    rail: {
+      repeat: { x: 10, y: 10 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineCarbonFiberPattern({ id: 'carbon-matte-dark-grey-rail' })
+    },
+    frame: {
+      repeat: { x: 10, y: 10 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineCarbonFiberPattern({ id: 'carbon-matte-dark-grey-frame' })
+    }
+  }),
+  Object.freeze({
+    id: 'carbon_fiber_chalk',
+    label: 'Carbon Fiber Chalk Pattern',
+    source: 'TonPlaygram custom carbon weave',
+    rail: {
+      repeat: { x: 10, y: 10 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineCarbonFiberPattern({ id: 'carbon-chalk' })
+    },
+    frame: {
+      repeat: { x: 10, y: 10 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineCarbonFiberPattern({ id: 'carbon-chalk-frame' })
     }
   })
 ]);


### PR DESCRIPTION
### Motivation

- Expand Pool Royale customization with additional oak veneer finishes and a carbon-fiber chalk option to provide more visual choices for tables and cues.
- Provide a robust fallback for single-frame shot recordings and remote replays so very-short recordings don't get ignored or crash replay playback.

### Description

- Added new thumbnail entries and option labels in `poolRoyaleInventoryConfig.js` for `oakVeneer01Amber`, `oakVeneer01Cocoa`, `oakVeneer01Walnut`, `oakVeneer01MahoganyRed`, `oakVeneer01MatteBlack`, and `carbonFiberChalk`, and added corresponding store items.
- Extended `PoolRoyale.jsx` `TABLE_FINISHES` and `TABLE_FINISH_OPTIONS` to include the new oak and carbon finishes and exposed their color/texture metadata via `createStandardWoodFinish` entries.
- Hardened replay handling in `PoolRoyale.jsx` by: recording an extra frame when a shot recording has fewer than 2 frames before resolving; normalizing incoming `pending.frames` arrays for remote replays; and duplicating a single remote frame with a fallback `t` timestamp so single-frame replays play back correctly.
- Added `svgDataUrl` and `makeInlineCarbonFiberPattern` helpers in `woodMaterials.js` and extended `WOOD_GRAIN_OPTIONS` with new `oak_veneer_01_*` presets and a `carbon_fiber_chalk` option that uses an inline canvas-generated texture (with an SVG fallback) for environments where a generated bitmap is not available.

### Testing

- Ran unit tests with `yarn test` and all tests passed.
- Ran linter with `yarn lint` and no lint errors were reported.
- Built a production bundle with `yarn build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cade26a980832982839b2942c7ab51)