### PR TITLE
Murlan Royale: HDRI auto-matching and 2K preset support

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2239,7 +2239,9 @@ const FRAME_RATE_OPTIONS = Object.freeze([
     renderScale: 1,
     pixelRatioCap: 1.4,
     resolution: 'HD render • DPR 1.4 cap',
-    description: 'Minimum HD output for battery saver and 50–60 Hz displays.'
+    hdriResolution: '2k',
+    preferredTextureSizes: ['2k', '1k'],
+    description: 'Minimum HD output for battery saver and 50–60 Hz displays with a 2K HDRI target.'
   },
   {
     id: 'fhd60',
@@ -2287,9 +2289,11 @@ const FRAME_RATE_OPTIONS = Object.freeze([
   }
 ]);
 const HDRI_RESOLUTION_OPTIONS = Object.freeze([
+  { id: 'auto', label: 'Auto' },
   { id: '8k', label: '8K' },
   { id: '6k', label: '6K' },
-  { id: '4k', label: '4K' }
+  { id: '4k', label: '4K' },
+  { id: '2k', label: '2K' }
 ]);
 const HDRI_RESOLUTION_OPTION_MAP = Object.freeze(
   HDRI_RESOLUTION_OPTIONS.reduce((acc, option) => {
@@ -2297,7 +2301,7 @@ const HDRI_RESOLUTION_OPTION_MAP = Object.freeze(
     return acc;
   }, {})
 );
-const DEFAULT_HDRI_RESOLUTION_ID = '4k';
+const DEFAULT_HDRI_RESOLUTION_ID = 'auto';
 const DEFAULT_FRAME_RATE_OPTION =
   FRAME_RATE_OPTIONS.find((opt) => opt.id === DEFAULT_FRAME_RATE_ID) ?? FRAME_RATE_OPTIONS[0];
 
@@ -2481,8 +2485,20 @@ export default function MurlanRoyaleArena({ search }) {
       window.removeEventListener('orientationchange', updateOrientation);
     };
   }, []);
-  const resolvedHdriResolution =
-    (HDRI_RESOLUTION_OPTION_MAP[hdriResolutionId] && hdriResolutionId) || DEFAULT_HDRI_RESOLUTION_ID;
+  const resolvedHdriResolution = useMemo(() => {
+    const targetFromGraphics = activeFrameRateOption?.hdriResolution;
+    if (hdriResolutionId === 'auto') {
+      if (typeof targetFromGraphics === 'string' && HDRI_RESOLUTION_OPTION_MAP[targetFromGraphics]) {
+        return targetFromGraphics;
+      }
+      return '4k';
+    }
+    if (HDRI_RESOLUTION_OPTION_MAP[hdriResolutionId]) return hdriResolutionId;
+    if (typeof targetFromGraphics === 'string' && HDRI_RESOLUTION_OPTION_MAP[targetFromGraphics]) {
+      return targetFromGraphics;
+    }
+    return '4k';
+  }, [activeFrameRateOption, hdriResolutionId]);
   const resolvedFrameTiming = useMemo(() => {
     const fallbackFps =
       Number.isFinite(DEFAULT_FRAME_RATE_OPTION?.fps) && DEFAULT_FRAME_RATE_OPTION.fps > 0


### PR DESCRIPTION
### Motivation
- Players reported HDRI quality not matching selected graphics presets in Murlan Royale which leads to visual mismatches for low-end presets.
- The goal is to make HDRI resolution follow the active graphics preset by default while still allowing manual overrides from the options menu.

### Description
- Assigned the `hd50` graphics preset an explicit HDRI target and texture preference by adding `hdriResolution: '2k'` and `preferredTextureSizes: ['2k','1k']` to the preset so low graphics mode uses lighter HDRI assets.
- Extended `HDRI_RESOLUTION_OPTIONS` to include `{ id: 'auto' }` and `2k` so the UI now exposes `Auto` and `2K` choices in addition to `4K/6K/8K`.
- Changed `DEFAULT_HDRI_RESOLUTION_ID` to `'auto'` so HDRI follows the selected graphics preset by default.
- Replaced the previous resolved value with a `useMemo` for `resolvedHdriResolution` that: uses the graphics preset `hdriResolution` when `hdriResolutionId === 'auto'`, respects manual HDRI selection when set, and falls back to `'4k'` if no valid target exists.

### Testing
- Ran the linter with `npx eslint webapp/src/pages/Games/MurlanRoyaleArena.jsx`, which completed; the file is ignored by the current eslint config so no errors were reported and a single ignore warning was emitted.
- No automated runtime/unit tests were executed as part of this change in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb5616d35483299b81bda20c00d195)