### PR TITLE
Add carbon-fiber table finishes with inline weave textures and make replay handling robust for single-frame recordings

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -296,7 +296,13 @@ const TABLE_FINISH_THUMBNAILS = Object.freeze({
   oakVeneer01: polyHavenThumb('oak_veneer_01'),
   woodTable001: polyHavenThumb('wood_table_001'),
   darkWood: polyHavenThumb('dark_wood'),
-  rosewoodVeneer01: polyHavenThumb('rosewood_veneer_01')
+  rosewoodVeneer01: polyHavenThumb('rosewood_veneer_01'),
+  oakVeneer01Amber: swatchThumbnail(['#2b3038', '#4a525f', '#6a7382']),
+  oakVeneer01Cocoa: swatchThumbnail(['#101a2b', '#1f2f4a', '#33486b']),
+  oakVeneer01Walnut: swatchThumbnail(['#d7d1c3', '#b7ae9d', '#e7e1d6']),
+  oakVeneer01MahoganyRed: swatchThumbnail(['#4c3627', '#6f5140', '#8b6851']),
+  oakVeneer01MatteBlack: swatchThumbnail(['#d9c29f', '#b99d73', '#e5d2b8']),
+  carbonFiberChalk: swatchThumbnail(['#0c1018', '#1a1f2a', '#374151'])
 });
 
 const POCKET_LINER_THUMBNAILS = Object.freeze({
@@ -394,7 +400,13 @@ export const POOL_ROYALE_OPTION_LABELS = Object.freeze({
     oakVeneer01: 'Oak Veneer 01',
     woodTable001: 'Wood Table 001',
     darkWood: 'Dark Wood',
-    rosewoodVeneer01: 'Rosewood Veneer 01'
+    rosewoodVeneer01: 'Rosewood Veneer 01',
+    oakVeneer01Amber: 'Carbon Grey',
+    oakVeneer01Cocoa: 'Carbon Dark Blue',
+    oakVeneer01Walnut: 'Carbon Magnolia',
+    oakVeneer01MahoganyRed: 'Carbon Brown',
+    oakVeneer01MatteBlack: 'Carbon Beige',
+    carbonFiberChalk: 'Carbon Graphite'
   }),
   chromeColor: Object.freeze({
     chrome: 'Chrome',
@@ -481,6 +493,60 @@ export const POOL_ROYALE_STORE_ITEMS = [
     price: 1020,
     description: 'Rosewood veneer rails with rich, reddish undertones.',
     thumbnail: TABLE_FINISH_THUMBNAILS.rosewoodVeneer01
+  },
+  {
+    id: 'finish-oakVeneer01Amber',
+    type: 'tableFinish',
+    optionId: 'oakVeneer01Amber',
+    name: 'Carbon Grey Finish',
+    price: 1060,
+    description: 'Carbon weave finish in grey tone.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.oakVeneer01Amber
+  },
+  {
+    id: 'finish-oakVeneer01Cocoa',
+    type: 'tableFinish',
+    optionId: 'oakVeneer01Cocoa',
+    name: 'Carbon Dark Blue Finish',
+    price: 1070,
+    description: 'Carbon weave finish in dark blue tone.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.oakVeneer01Cocoa
+  },
+  {
+    id: 'finish-oakVeneer01Walnut',
+    type: 'tableFinish',
+    optionId: 'oakVeneer01Walnut',
+    name: 'Carbon Magnolia Finish',
+    price: 1080,
+    description: 'Carbon weave finish in magnolia tone.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.oakVeneer01Walnut
+  },
+  {
+    id: 'finish-oakVeneer01MahoganyRed',
+    type: 'tableFinish',
+    optionId: 'oakVeneer01MahoganyRed',
+    name: 'Carbon Brown Finish',
+    price: 1090,
+    description: 'Carbon weave finish in brown tone.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.oakVeneer01MahoganyRed
+  },
+  {
+    id: 'finish-oakVeneer01MatteBlack',
+    type: 'tableFinish',
+    optionId: 'oakVeneer01MatteBlack',
+    name: 'Carbon Beige Finish',
+    price: 1100,
+    description: 'Carbon weave finish in beige tone.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.oakVeneer01MatteBlack
+  },
+  {
+    id: 'finish-carbonFiberChalk',
+    type: 'tableFinish',
+    optionId: 'carbonFiberChalk',
+    name: 'Carbon Graphite Finish',
+    price: 1160,
+    description: 'Custom carbon weave inspired by the chalk block pattern.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberChalk
   },
   {
     id: 'chrome-chrome',

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2984,6 +2984,60 @@ const TABLE_FINISHES = Object.freeze({
     trim: 0x9b5a44,
     woodTextureId: 'rosewood_veneer_01',
     woodRepeatScale: 1
+  }),
+  oakVeneer01Amber: createStandardWoodFinish({
+    id: 'oakVeneer01Amber',
+    label: 'Carbon Grey',
+    rail: 0x4a525f,
+    base: 0x2b3038,
+    trim: 0x6a7382,
+    woodTextureId: 'oak_veneer_01_amber',
+    woodRepeatScale: 1
+  }),
+  oakVeneer01Cocoa: createStandardWoodFinish({
+    id: 'oakVeneer01Cocoa',
+    label: 'Carbon Dark Blue',
+    rail: 0x1f2f4a,
+    base: 0x101a2b,
+    trim: 0x33486b,
+    woodTextureId: 'oak_veneer_01_cocoa',
+    woodRepeatScale: 1
+  }),
+  oakVeneer01Walnut: createStandardWoodFinish({
+    id: 'oakVeneer01Walnut',
+    label: 'Carbon Magnolia',
+    rail: 0xb7ae9d,
+    base: 0xd7d1c3,
+    trim: 0xe7e1d6,
+    woodTextureId: 'oak_veneer_01_walnut',
+    woodRepeatScale: 1
+  }),
+  oakVeneer01MahoganyRed: createStandardWoodFinish({
+    id: 'oakVeneer01MahoganyRed',
+    label: 'Carbon Brown',
+    rail: 0x6f5140,
+    base: 0x4c3627,
+    trim: 0x8b6851,
+    woodTextureId: 'oak_veneer_01_mahogany_red',
+    woodRepeatScale: 1
+  }),
+  oakVeneer01MatteBlack: createStandardWoodFinish({
+    id: 'oakVeneer01MatteBlack',
+    label: 'Carbon Beige',
+    rail: 0xb99d73,
+    base: 0xd9c29f,
+    trim: 0xe5d2b8,
+    woodTextureId: 'oak_veneer_01_matte_black',
+    woodRepeatScale: 1
+  }),
+  carbonFiberChalk: createStandardWoodFinish({
+    id: 'carbonFiberChalk',
+    label: 'Carbon Graphite',
+    rail: 0x1a1f2a,
+    base: 0x0c1018,
+    trim: 0x374151,
+    woodTextureId: 'carbon_fiber_chalk',
+    woodRepeatScale: 1
   })
 });
 
@@ -2993,7 +3047,13 @@ const TABLE_FINISH_OPTIONS = Object.freeze(
     TABLE_FINISHES.oakVeneer01,
     TABLE_FINISHES.woodTable001,
     TABLE_FINISHES.darkWood,
-    TABLE_FINISHES.rosewoodVeneer01
+    TABLE_FINISHES.rosewoodVeneer01,
+    TABLE_FINISHES.oakVeneer01Amber,
+    TABLE_FINISHES.oakVeneer01Cocoa,
+    TABLE_FINISHES.oakVeneer01Walnut,
+    TABLE_FINISHES.oakVeneer01MahoganyRed,
+    TABLE_FINISHES.oakVeneer01MatteBlack,
+    TABLE_FINISHES.carbonFiberChalk
   ].filter(Boolean)
 );
 
@@ -28392,6 +28452,9 @@ const powerRef = useRef(hud.power);
         function resolve() {
           const variantId = activeVariantRef.current?.id ?? 'american';
           const shotEvents = [];
+          if (shotRecording && (shotRecording.frames?.length ?? 0) < 2) {
+            recordReplayFrame(performance.now());
+          }
           const firstContactColor = toBallColorId(firstHit);
           const hadObjectPot = potted.some((entry) => entry.id !== 'cue');
           let replayDecision = resolveReplayDecision({
@@ -29127,7 +29190,16 @@ const powerRef = useRef(hud.power);
         if (!shooting && !shotRecording && !replayPlaybackRef.current && pendingRemoteReplayRef.current) {
           const pending = pendingRemoteReplayRef.current;
           pendingRemoteReplayRef.current = null;
-          if (!skipAllReplaysRef.current && pending?.frames?.length > 1) {
+          if (!skipAllReplaysRef.current && pending?.frames?.length > 0) {
+            const normalizedFrames = Array.isArray(pending.frames) ? [...pending.frames] : [];
+            if (normalizedFrames.length === 1) {
+              const firstFrame = normalizedFrames[0];
+              const fallbackFrameTime = Math.max(16, pending.frameTimeMs ?? 1000 / 60);
+              normalizedFrames.push({
+                ...firstFrame,
+                t: Math.max(fallbackFrameTime, firstFrame?.t ?? 0)
+              });
+            }
             const frameTiming = frameTimingRef.current;
             const frameTimeMs =
               Number.isFinite(pending?.frameTimeMs) && pending.frameTimeMs > 0
@@ -29137,6 +29209,7 @@ const powerRef = useRef(hud.power);
                   : 1000 / 60;
             shotRecording = {
               ...pending,
+              frames: normalizedFrames,
               startTime: pending.startTime ?? nowMs,
               startState: pending.startState ?? captureBallSnapshot(),
               zoomOnly: pending.zoomOnly ?? false,

--- a/webapp/src/utils/woodMaterials.js
+++ b/webapp/src/utils/woodMaterials.js
@@ -325,6 +325,64 @@ const polyHavenTextureSet = (assetId) => {
   };
 };
 
+const svgDataUrl = (svg) => `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(svg)}`;
+
+const makeInlineCarbonFiberPattern = ({
+  id,
+  base = '#07090f',
+  checker = '#0c111a',
+  weave = '#131926',
+  stroke = 'rgba(255,255,255,0.04)'
+}) => {
+  if (typeof document !== 'undefined') {
+    const canvas = document.createElement('canvas');
+    canvas.width = 128;
+    canvas.height = 128;
+    const ctx = canvas.getContext('2d');
+    if (ctx) {
+      // Match Pool Royale chalk carbon-fiber weave exactly (same geometry and tile size).
+      ctx.fillStyle = base;
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      ctx.fillStyle = checker;
+      ctx.fillRect(0, 0, canvas.width / 2, canvas.height / 2);
+      ctx.fillRect(canvas.width / 2, canvas.height / 2, canvas.width / 2, canvas.height / 2);
+      ctx.fillStyle = weave;
+      ctx.beginPath();
+      ctx.moveTo(canvas.width / 2, 0);
+      ctx.lineTo(canvas.width, 0);
+      ctx.lineTo(0, canvas.height);
+      ctx.lineTo(0, canvas.height / 2);
+      ctx.closePath();
+      ctx.fill();
+      ctx.beginPath();
+      ctx.moveTo(canvas.width, canvas.height / 2);
+      ctx.lineTo(canvas.width, canvas.height);
+      ctx.lineTo(canvas.width / 2, canvas.height);
+      ctx.closePath();
+      ctx.fill();
+      ctx.strokeStyle = stroke;
+      ctx.lineWidth = 1;
+      for (let i = -canvas.width; i <= canvas.width; i += canvas.width / 4) {
+        ctx.beginPath();
+        ctx.moveTo(i, 0);
+        ctx.lineTo(i + canvas.width, canvas.height);
+        ctx.stroke();
+      }
+      const mapUrl = canvas.toDataURL('image/png');
+      return { mapUrl, roughnessMapUrl: null, normalMapUrl: null };
+    }
+  }
+  const fallback = svgDataUrl(`
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128">
+  <rect width="128" height="128" fill="${base}"/>
+  <rect width="64" height="64" fill="${checker}"/>
+  <rect x="64" y="64" width="64" height="64" fill="${checker}"/>
+  <path d="M64 0 H128 L0 128 V64 Z" fill="${weave}"/>
+  <path d="M128 64 V128 H64 Z" fill="${weave}"/>
+</svg>`);
+  return { mapUrl: fallback, roughnessMapUrl: null, normalMapUrl: null };
+};
+
 export const WOOD_GRAIN_OPTIONS = Object.freeze([
   Object.freeze({
     id: 'acg_walnut_quarter',
@@ -473,6 +531,162 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
       rotation: 0,
       textureSize: 2048,
       ...polyHavenTextureSet('japanese_sycamore')
+    }
+  }),
+  Object.freeze({
+    id: 'oak_veneer_01_amber',
+    label: 'Carbon Grey',
+    source: 'TonPlaygram custom carbon weave palette',
+    rail: {
+      repeat: { x: 10, y: 10 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineCarbonFiberPattern({
+        id: 'carbon-grey-rail',
+        base: '#2b3038',
+        checker: '#3a404a',
+        weave: '#4a525f'
+      })
+    },
+    frame: {
+      repeat: { x: 10, y: 10 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineCarbonFiberPattern({
+        id: 'carbon-grey-frame',
+        base: '#252a32',
+        checker: '#343a43',
+        weave: '#444c58'
+      })
+    }
+  }),
+  Object.freeze({
+    id: 'oak_veneer_01_cocoa',
+    label: 'Carbon Dark Blue',
+    source: 'TonPlaygram custom carbon weave palette',
+    rail: {
+      repeat: { x: 10, y: 10 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineCarbonFiberPattern({
+        id: 'carbon-dark-blue-rail',
+        base: '#101a2b',
+        checker: '#15233a',
+        weave: '#1f2f4a'
+      })
+    },
+    frame: {
+      repeat: { x: 10, y: 10 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineCarbonFiberPattern({
+        id: 'carbon-dark-blue-frame',
+        base: '#0c1627',
+        checker: '#122035',
+        weave: '#1b2a42'
+      })
+    }
+  }),
+  Object.freeze({
+    id: 'oak_veneer_01_walnut',
+    label: 'Carbon Magnolia',
+    source: 'TonPlaygram custom carbon weave palette',
+    rail: {
+      repeat: { x: 10, y: 10 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineCarbonFiberPattern({
+        id: 'carbon-magnolia-rail',
+        base: '#d7d1c3',
+        checker: '#c7c0b0',
+        weave: '#b7ae9d',
+        stroke: 'rgba(20,24,34,0.12)'
+      })
+    },
+    frame: {
+      repeat: { x: 10, y: 10 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineCarbonFiberPattern({
+        id: 'carbon-magnolia-frame',
+        base: '#d1cab9',
+        checker: '#c2baa7',
+        weave: '#b1a894',
+        stroke: 'rgba(20,24,34,0.12)'
+      })
+    }
+  }),
+  Object.freeze({
+    id: 'oak_veneer_01_mahogany_red',
+    label: 'Carbon Brown',
+    source: 'TonPlaygram custom carbon weave palette',
+    rail: {
+      repeat: { x: 10, y: 10 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineCarbonFiberPattern({
+        id: 'carbon-brown-rail',
+        base: '#4c3627',
+        checker: '#5c4331',
+        weave: '#6f5140'
+      })
+    },
+    frame: {
+      repeat: { x: 10, y: 10 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineCarbonFiberPattern({
+        id: 'carbon-brown-frame',
+        base: '#422f22',
+        checker: '#513b2d',
+        weave: '#624938'
+      })
+    }
+  }),
+  Object.freeze({
+    id: 'oak_veneer_01_matte_black',
+    label: 'Carbon Beige',
+    source: 'TonPlaygram custom carbon weave palette',
+    rail: {
+      repeat: { x: 10, y: 10 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineCarbonFiberPattern({
+        id: 'carbon-beige-rail',
+        base: '#d9c29f',
+        checker: '#c9af89',
+        weave: '#b99d73',
+        stroke: 'rgba(20,24,34,0.1)'
+      })
+    },
+    frame: {
+      repeat: { x: 10, y: 10 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineCarbonFiberPattern({
+        id: 'carbon-beige-frame',
+        base: '#d0b690',
+        checker: '#c1a680',
+        weave: '#b3956a',
+        stroke: 'rgba(20,24,34,0.1)'
+      })
+    }
+  }),
+  Object.freeze({
+    id: 'carbon_fiber_chalk',
+    label: 'Carbon Graphite',
+    source: 'TonPlaygram custom carbon weave',
+    rail: {
+      repeat: { x: 10, y: 10 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineCarbonFiberPattern({ id: 'carbon-chalk' })
+    },
+    frame: {
+      repeat: { x: 10, y: 10 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineCarbonFiberPattern({ id: 'carbon-chalk-frame' })
     }
   })
 ]);


### PR DESCRIPTION
### Motivation
- Introduce a set of new carbon-fiber style table finishes and thumbnails so players can purchase/apply carbon weave variants in Pool Royale.
- Provide inline (canvas/SVG) carbon-weave textures to avoid depending on external assets for these new finishes.
- Handle edge cases where replay recordings contain only a single frame (remote or local) so replays still play back and don't get dropped.

### Description
- Added multiple new table finish thumbnails and option labels in `poolRoyaleInventoryConfig.js` and registered new store items for each finish (e.g. `oakVeneer01Amber`, `oakVeneer01Cocoa`, `carbonFiberChalk`, etc.).
- Extended `TABLE_FINISHES` and `TABLE_FINISH_OPTIONS` in `PoolRoyale.jsx` to include the new finishes and their color/texture metadata, and added them to the cue finish palette.
- Implemented `makeInlineCarbonFiberPattern` (with a `canvas` renderer and an SVG fallback via `svgDataUrl`) in `woodMaterials.js` and added a number of `WOOD_GRAIN_OPTIONS` entries that use the inline carbon-weave textures for rail/frame maps.
- Hardened replay logic in `PoolRoyale.jsx` by ensuring local recordings get a second frame when resolving (`recordReplayFrame` if frames < 2) and by accepting pending remote recordings with a single frame by normalizing frames and synthesizing a second timing frame so playback can start.

### Testing
- Ran unit tests with `yarn test` and the suite completed successfully.
- Ran static checks with `yarn lint` and no lint errors were reported.
- Performed a production build with `yarn build` which completed without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cade26a980832982839b2942c7ab51)