### PR TITLE
Add new oak/carbon table finishes with inline veneer textures and fix single-frame replay handling

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -296,7 +296,13 @@ const TABLE_FINISH_THUMBNAILS = Object.freeze({
   oakVeneer01: polyHavenThumb('oak_veneer_01'),
   woodTable001: polyHavenThumb('wood_table_001'),
   darkWood: polyHavenThumb('dark_wood'),
-  rosewoodVeneer01: polyHavenThumb('rosewood_veneer_01')
+  rosewoodVeneer01: polyHavenThumb('rosewood_veneer_01'),
+  oakVeneer01Amber: swatchThumbnail(['#2b3038', '#4a525f', '#6a7382']),
+  oakVeneer01Cocoa: swatchThumbnail(['#101a2b', '#1f2f4a', '#33486b']),
+  oakVeneer01Walnut: swatchThumbnail(['#d7d1c3', '#b7ae9d', '#e7e1d6']),
+  oakVeneer01MahoganyRed: swatchThumbnail(['#4c3627', '#6f5140', '#8b6851']),
+  oakVeneer01MatteBlack: swatchThumbnail(['#d9c29f', '#b99d73', '#e5d2b8']),
+  carbonFiberChalk: swatchThumbnail(['#0c1018', '#1a1f2a', '#374151'])
 });
 
 const POCKET_LINER_THUMBNAILS = Object.freeze({
@@ -394,7 +400,13 @@ export const POOL_ROYALE_OPTION_LABELS = Object.freeze({
     oakVeneer01: 'Oak Veneer 01',
     woodTable001: 'Wood Table 001',
     darkWood: 'Dark Wood',
-    rosewoodVeneer01: 'Rosewood Veneer 01'
+    rosewoodVeneer01: 'Rosewood Veneer 01',
+    oakVeneer01Amber: 'Oak Grey',
+    oakVeneer01Cocoa: 'Oak Dark Blue',
+    oakVeneer01Walnut: 'Oak Magnolia',
+    oakVeneer01MahoganyRed: 'Oak Brown',
+    oakVeneer01MatteBlack: 'Oak Beige',
+    carbonFiberChalk: 'Oak Graphite'
   }),
   chromeColor: Object.freeze({
     chrome: 'Chrome',
@@ -481,6 +493,60 @@ export const POOL_ROYALE_STORE_ITEMS = [
     price: 1020,
     description: 'Rosewood veneer rails with rich, reddish undertones.',
     thumbnail: TABLE_FINISH_THUMBNAILS.rosewoodVeneer01
+  },
+  {
+    id: 'finish-oakVeneer01Amber',
+    type: 'tableFinish',
+    optionId: 'oakVeneer01Amber',
+    name: 'Oak Grey Finish',
+    price: 1060,
+    description: 'Matte oak veneer finish in grey tone.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.oakVeneer01Amber
+  },
+  {
+    id: 'finish-oakVeneer01Cocoa',
+    type: 'tableFinish',
+    optionId: 'oakVeneer01Cocoa',
+    name: 'Oak Dark Blue Finish',
+    price: 1070,
+    description: 'Matte oak veneer finish in dark blue tone.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.oakVeneer01Cocoa
+  },
+  {
+    id: 'finish-oakVeneer01Walnut',
+    type: 'tableFinish',
+    optionId: 'oakVeneer01Walnut',
+    name: 'Oak Magnolia Finish',
+    price: 1080,
+    description: 'Matte oak veneer finish in magnolia tone.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.oakVeneer01Walnut
+  },
+  {
+    id: 'finish-oakVeneer01MahoganyRed',
+    type: 'tableFinish',
+    optionId: 'oakVeneer01MahoganyRed',
+    name: 'Oak Brown Finish',
+    price: 1090,
+    description: 'Matte oak veneer finish in brown tone.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.oakVeneer01MahoganyRed
+  },
+  {
+    id: 'finish-oakVeneer01MatteBlack',
+    type: 'tableFinish',
+    optionId: 'oakVeneer01MatteBlack',
+    name: 'Oak Beige Finish',
+    price: 1100,
+    description: 'Matte oak veneer finish in beige tone.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.oakVeneer01MatteBlack
+  },
+  {
+    id: 'finish-carbonFiberChalk',
+    type: 'tableFinish',
+    optionId: 'carbonFiberChalk',
+    name: 'Oak Graphite Finish',
+    price: 1160,
+    description: 'Matte oak veneer finish in graphite tone.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberChalk
   },
   {
     id: 'chrome-chrome',

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2881,6 +2881,13 @@ const createStandardWoodFinish = ({
   woodTextureId,
   woodRepeatScale,
   createMaterials: () => {
+    const matteOakFinish =
+      id === 'oakVeneer01Amber' ||
+      id === 'oakVeneer01Cocoa' ||
+      id === 'oakVeneer01Walnut' ||
+      id === 'oakVeneer01MahoganyRed' ||
+      id === 'oakVeneer01MatteBlack' ||
+      id === 'carbonFiberChalk';
     const frameColor = new THREE.Color(base);
     const railColor = new THREE.Color(rail);
     const trimColor =
@@ -2889,25 +2896,25 @@ const createStandardWoodFinish = ({
         : railColor.clone().offsetHSL(0.02, 0.08, 0.18);
     const frame = new THREE.MeshPhysicalMaterial({
       color: frameColor,
-      metalness: 0.1,
-      roughness: 0.52,
-      clearcoat: 0.28,
-      clearcoatRoughness: 0.34,
+      metalness: matteOakFinish ? 0.02 : 0.1,
+      roughness: matteOakFinish ? 0.84 : 0.52,
+      clearcoat: matteOakFinish ? 0.03 : 0.28,
+      clearcoatRoughness: matteOakFinish ? 0.92 : 0.34,
       sheen: 0.16,
       sheenRoughness: 0.52,
-      reflectivity: 0.26,
-      envMapIntensity: 0.52
+      reflectivity: matteOakFinish ? 0.04 : 0.26,
+      envMapIntensity: matteOakFinish ? 0.12 : 0.52
     });
     const railMat = new THREE.MeshPhysicalMaterial({
       color: railColor,
-      metalness: 0.12,
-      roughness: 0.48,
-      clearcoat: 0.32,
-      clearcoatRoughness: 0.32,
+      metalness: matteOakFinish ? 0.02 : 0.12,
+      roughness: matteOakFinish ? 0.82 : 0.48,
+      clearcoat: matteOakFinish ? 0.03 : 0.32,
+      clearcoatRoughness: matteOakFinish ? 0.9 : 0.32,
       sheen: 0.2,
       sheenRoughness: 0.52,
-      reflectivity: 0.28,
-      envMapIntensity: 0.56
+      reflectivity: matteOakFinish ? 0.04 : 0.28,
+      envMapIntensity: matteOakFinish ? 0.12 : 0.56
     });
     const trimMat = new THREE.MeshPhysicalMaterial({
       color: trimColor,
@@ -2984,6 +2991,60 @@ const TABLE_FINISHES = Object.freeze({
     trim: 0x9b5a44,
     woodTextureId: 'rosewood_veneer_01',
     woodRepeatScale: 1
+  }),
+  oakVeneer01Amber: createStandardWoodFinish({
+    id: 'oakVeneer01Amber',
+    label: 'Oak Grey',
+    rail: 0x4a525f,
+    base: 0x2b3038,
+    trim: 0x6a7382,
+    woodTextureId: 'oak_veneer_01_amber',
+    woodRepeatScale: 1
+  }),
+  oakVeneer01Cocoa: createStandardWoodFinish({
+    id: 'oakVeneer01Cocoa',
+    label: 'Oak Dark Blue',
+    rail: 0x1f2f4a,
+    base: 0x101a2b,
+    trim: 0x33486b,
+    woodTextureId: 'oak_veneer_01_cocoa',
+    woodRepeatScale: 1
+  }),
+  oakVeneer01Walnut: createStandardWoodFinish({
+    id: 'oakVeneer01Walnut',
+    label: 'Oak Magnolia',
+    rail: 0xb7ae9d,
+    base: 0xd7d1c3,
+    trim: 0xe7e1d6,
+    woodTextureId: 'oak_veneer_01_walnut',
+    woodRepeatScale: 1
+  }),
+  oakVeneer01MahoganyRed: createStandardWoodFinish({
+    id: 'oakVeneer01MahoganyRed',
+    label: 'Oak Brown',
+    rail: 0x6f5140,
+    base: 0x4c3627,
+    trim: 0x8b6851,
+    woodTextureId: 'oak_veneer_01_mahogany_red',
+    woodRepeatScale: 1
+  }),
+  oakVeneer01MatteBlack: createStandardWoodFinish({
+    id: 'oakVeneer01MatteBlack',
+    label: 'Oak Beige',
+    rail: 0xb99d73,
+    base: 0xd9c29f,
+    trim: 0xe5d2b8,
+    woodTextureId: 'oak_veneer_01_matte_black',
+    woodRepeatScale: 1
+  }),
+  carbonFiberChalk: createStandardWoodFinish({
+    id: 'carbonFiberChalk',
+    label: 'Oak Graphite',
+    rail: 0x1a1f2a,
+    base: 0x0c1018,
+    trim: 0x374151,
+    woodTextureId: 'carbon_fiber_chalk',
+    woodRepeatScale: 1
   })
 });
 
@@ -2993,7 +3054,13 @@ const TABLE_FINISH_OPTIONS = Object.freeze(
     TABLE_FINISHES.oakVeneer01,
     TABLE_FINISHES.woodTable001,
     TABLE_FINISHES.darkWood,
-    TABLE_FINISHES.rosewoodVeneer01
+    TABLE_FINISHES.rosewoodVeneer01,
+    TABLE_FINISHES.oakVeneer01Amber,
+    TABLE_FINISHES.oakVeneer01Cocoa,
+    TABLE_FINISHES.oakVeneer01Walnut,
+    TABLE_FINISHES.oakVeneer01MahoganyRed,
+    TABLE_FINISHES.oakVeneer01MatteBlack,
+    TABLE_FINISHES.carbonFiberChalk
   ].filter(Boolean)
 );
 
@@ -28392,6 +28459,9 @@ const powerRef = useRef(hud.power);
         function resolve() {
           const variantId = activeVariantRef.current?.id ?? 'american';
           const shotEvents = [];
+          if (shotRecording && (shotRecording.frames?.length ?? 0) < 2) {
+            recordReplayFrame(performance.now());
+          }
           const firstContactColor = toBallColorId(firstHit);
           const hadObjectPot = potted.some((entry) => entry.id !== 'cue');
           let replayDecision = resolveReplayDecision({
@@ -29127,7 +29197,16 @@ const powerRef = useRef(hud.power);
         if (!shooting && !shotRecording && !replayPlaybackRef.current && pendingRemoteReplayRef.current) {
           const pending = pendingRemoteReplayRef.current;
           pendingRemoteReplayRef.current = null;
-          if (!skipAllReplaysRef.current && pending?.frames?.length > 1) {
+          if (!skipAllReplaysRef.current && pending?.frames?.length > 0) {
+            const normalizedFrames = Array.isArray(pending.frames) ? [...pending.frames] : [];
+            if (normalizedFrames.length === 1) {
+              const firstFrame = normalizedFrames[0];
+              const fallbackFrameTime = Math.max(16, pending.frameTimeMs ?? 1000 / 60);
+              normalizedFrames.push({
+                ...firstFrame,
+                t: Math.max(fallbackFrameTime, firstFrame?.t ?? 0)
+              });
+            }
             const frameTiming = frameTimingRef.current;
             const frameTimeMs =
               Number.isFinite(pending?.frameTimeMs) && pending.frameTimeMs > 0
@@ -29137,6 +29216,7 @@ const powerRef = useRef(hud.power);
                   : 1000 / 60;
             shotRecording = {
               ...pending,
+              frames: normalizedFrames,
               startTime: pending.startTime ?? nowMs,
               startState: pending.startState ?? captureBallSnapshot(),
               zoomOnly: pending.zoomOnly ?? false,

--- a/webapp/src/utils/woodMaterials.js
+++ b/webapp/src/utils/woodMaterials.js
@@ -325,6 +325,38 @@ const polyHavenTextureSet = (assetId) => {
   };
 };
 
+const svgDataUrl = (svg) => `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(svg)}`;
+
+const makeInlineOakVeneerPattern = ({ id }) => {
+  const mapUrl = svgDataUrl(`
+<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256">
+  <defs>
+    <pattern id="${id}-oak" patternUnits="userSpaceOnUse" width="64" height="64">
+      <rect width="64" height="64" fill="#9a9a9a"/>
+      <path d="M-20 12 C 6 2, 28 22, 56 12 S 108 2, 136 12" stroke="#747474" stroke-width="5" fill="none" opacity="0.55"/>
+      <path d="M-18 30 C 10 20, 34 40, 62 30 S 114 20, 142 30" stroke="#7f7f7f" stroke-width="4" fill="none" opacity="0.5"/>
+      <path d="M-22 48 C 6 38, 32 58, 60 48 S 112 38, 140 48" stroke="#6b6b6b" stroke-width="4" fill="none" opacity="0.58"/>
+      <circle cx="20" cy="20" r="2" fill="#626262" opacity="0.35"/>
+      <circle cx="45" cy="44" r="1.5" fill="#585858" opacity="0.35"/>
+    </pattern>
+  </defs>
+  <rect width="256" height="256" fill="url(#${id}-oak)"/>
+</svg>`);
+  const roughnessMapUrl = svgDataUrl(`
+<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256">
+  <defs>
+    <pattern id="${id}-oak-r" patternUnits="userSpaceOnUse" width="64" height="64">
+      <rect width="64" height="64" fill="#b6b6b6"/>
+      <path d="M-20 12 C 6 2, 28 22, 56 12 S 108 2, 136 12" stroke="#d0d0d0" stroke-width="5" fill="none" opacity="0.5"/>
+      <path d="M-18 30 C 10 20, 34 40, 62 30 S 114 20, 142 30" stroke="#c4c4c4" stroke-width="4" fill="none" opacity="0.45"/>
+      <path d="M-22 48 C 6 38, 32 58, 60 48 S 112 38, 140 48" stroke="#dbdbdb" stroke-width="4" fill="none" opacity="0.55"/>
+    </pattern>
+  </defs>
+  <rect width="256" height="256" fill="url(#${id}-oak-r)"/>
+</svg>`);
+  return { mapUrl, roughnessMapUrl, normalMapUrl: null };
+};
+
 export const WOOD_GRAIN_OPTIONS = Object.freeze([
   Object.freeze({
     id: 'acg_walnut_quarter',
@@ -473,6 +505,108 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
       rotation: 0,
       textureSize: 2048,
       ...polyHavenTextureSet('japanese_sycamore')
+    }
+  }),
+  Object.freeze({
+    id: 'oak_veneer_01_amber',
+    label: 'Oak Grey',
+    source: 'TonPlaygram oak veneer palette',
+    rail: {
+      repeat: { x: 6, y: 6 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineOakVeneerPattern({ id: 'oak-grey-rail' })
+    },
+    frame: {
+      repeat: { x: 6, y: 6 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineOakVeneerPattern({ id: 'oak-grey-frame' })
+    }
+  }),
+  Object.freeze({
+    id: 'oak_veneer_01_cocoa',
+    label: 'Oak Dark Blue',
+    source: 'TonPlaygram oak veneer palette',
+    rail: {
+      repeat: { x: 6, y: 6 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineOakVeneerPattern({ id: 'oak-dark-blue-rail' })
+    },
+    frame: {
+      repeat: { x: 6, y: 6 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineOakVeneerPattern({ id: 'oak-dark-blue-frame' })
+    }
+  }),
+  Object.freeze({
+    id: 'oak_veneer_01_walnut',
+    label: 'Oak Magnolia',
+    source: 'TonPlaygram oak veneer palette',
+    rail: {
+      repeat: { x: 6, y: 6 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineOakVeneerPattern({ id: 'oak-magnolia-rail' })
+    },
+    frame: {
+      repeat: { x: 6, y: 6 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineOakVeneerPattern({ id: 'oak-magnolia-frame' })
+    }
+  }),
+  Object.freeze({
+    id: 'oak_veneer_01_mahogany_red',
+    label: 'Oak Brown',
+    source: 'TonPlaygram oak veneer palette',
+    rail: {
+      repeat: { x: 6, y: 6 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineOakVeneerPattern({ id: 'oak-brown-rail' })
+    },
+    frame: {
+      repeat: { x: 6, y: 6 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineOakVeneerPattern({ id: 'oak-brown-frame' })
+    }
+  }),
+  Object.freeze({
+    id: 'oak_veneer_01_matte_black',
+    label: 'Oak Beige',
+    source: 'TonPlaygram oak veneer palette',
+    rail: {
+      repeat: { x: 6, y: 6 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineOakVeneerPattern({ id: 'oak-beige-rail' })
+    },
+    frame: {
+      repeat: { x: 6, y: 6 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineOakVeneerPattern({ id: 'oak-beige-frame' })
+    }
+  }),
+  Object.freeze({
+    id: 'carbon_fiber_chalk',
+    label: 'Oak Graphite',
+    source: 'TonPlaygram oak veneer palette',
+    rail: {
+      repeat: { x: 6, y: 6 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineOakVeneerPattern({ id: 'oak-graphite-rail' })
+    },
+    frame: {
+      repeat: { x: 6, y: 6 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineOakVeneerPattern({ id: 'oak-graphite-frame' })
     }
   })
 ]);


### PR DESCRIPTION
### Motivation

- Expand the Pool Royale catalog with several new oak-veneer and carbon finishes and ensure they render with appropriate matte appearance. 
- Provide inline texture fallbacks for those new veneer variants so wood grains render even if external texture assets are not available. 
- Harden replay handling so single-frame recordings (local or remote) don't get dropped and produce a usable two-frame replay.

### Description

- Added new table finish thumbnails and option labels in `poolRoyaleInventoryConfig.js` for `oakVeneer01Amber`, `oakVeneer01Cocoa`, `oakVeneer01Walnut`, `oakVeneer01MahoganyRed`, `oakVeneer01MatteBlack`, and `carbonFiberChalk`, and exposed them as store items. 
- Added corresponding finish entries to `TABLE_FINISHES` and included them in `TABLE_FINISH_OPTIONS` in `PoolRoyale.jsx`. 
- Modified `createStandardWoodFinish` in `PoolRoyale.jsx` to detect the new matte oak/carbon finishes and lower metalness/increase roughness/adjust clearcoat and env map values to achieve a matte look. 
- Implemented inline SVG-based veneer patterns in `woodMaterials.js` via `makeInlineOakVeneerPattern` and `svgDataUrl`, and added new `WOOD_GRAIN_OPTIONS` entries for the new finishes (`oak_veneer_01_amber`, `oak_veneer_01_cocoa`, `oak_veneer_01_walnut`, `oak_veneer_01_mahogany_red`, `oak_veneer_01_matte_black`, `carbon_fiber_chalk`) that use the inline patterns as texture fallbacks. 
- Hardened replay logic in `PoolRoyale.jsx` so that when finalizing a shot a short single-frame `shotRecording` gets an extra recorded frame (`recordReplayFrame`) to avoid zero-length playbacks, and normalized incoming `pending.frames` for remote replays by duplicating a sole frame and assigning a fallback `t` to produce a two-frame recording; also allow pending remote replays when `pending?.frames?.length > 0` (previously required >1).

### Testing

- Ran unit tests with `yarn test`, and the test suite completed successfully. 
- Ran linter with `yarn lint` and fixed/verified no new lint errors. 
- Built the webapp with `yarn build` to validate bundling and the new inline SVG assets, and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cade26a980832982839b2942c7ab51)