### PR TITLE
Fix Murlan HDRI resolution selection for 2K/4K/6K/8K

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -430,33 +430,74 @@ function pickBestTextureUrls(apiJson, preferredSizes = PREFERRED_TEXTURE_SIZES) 
 }
 
 const HDRI_URL_CACHE = new Map();
+const HDRI_RESOLUTION_PATTERN = /(?:^|[_/-])((?:1|2|4|6|8|16)k)(?=\.|[_/-]|$)/i;
 
-const pickPolyHavenHdriUrl = (apiJson, preferredResolutions = DEFAULT_HDRI_RESOLUTIONS) => {
-  const urls = [];
-  const walk = (value) => {
+const normalizeHdriResolutionId = (value) => {
+  const lower = String(value || '').toLowerCase();
+  if (HDRI_RESOLUTION_LADDER.includes(lower)) return lower;
+  return null;
+};
+
+const extractResolutionFromHdriUrl = (url) => {
+  if (typeof url !== 'string' || !url.length) return null;
+  const match = url.toLowerCase().match(HDRI_RESOLUTION_PATTERN);
+  if (!match?.[1]) return null;
+  return normalizeHdriResolutionId(match[1]) ?? match[1];
+};
+
+const collectHdriCandidates = (apiJson) => {
+  const out = [];
+  const pushUrl = (url, hintedResolution = null) => {
+    if (typeof url !== 'string' || !url.startsWith('http')) return;
+    const lower = url.toLowerCase();
+    if (!lower.includes('.hdr') && !lower.includes('.exr')) return;
+    out.push({
+      url,
+      resolution: normalizeHdriResolutionId(hintedResolution) ?? extractResolutionFromHdriUrl(url)
+    });
+  };
+  const walk = (value, hintedResolution = null) => {
     if (!value) return;
     if (typeof value === 'string') {
-      const lower = value.toLowerCase();
-      if (value.startsWith('http') && (lower.includes('.hdr') || lower.includes('.exr'))) {
-        urls.push(value);
-      }
+      pushUrl(value, hintedResolution);
       return;
     }
     if (Array.isArray(value)) {
-      value.forEach(walk);
+      value.forEach((entry) => walk(entry, hintedResolution));
       return;
     }
-    if (typeof value === 'object') {
-      Object.values(value).forEach(walk);
-    }
+    if (typeof value !== 'object') return;
+    Object.entries(value).forEach(([key, entry]) => {
+      const nextHint = normalizeHdriResolutionId(key) ?? hintedResolution;
+      walk(entry, nextHint);
+    });
   };
   walk(apiJson);
-  const lower = urls.map((url) => url.toLowerCase());
+  return out;
+};
+
+const pickPolyHavenHdriUrl = (apiJson, preferredResolutions = DEFAULT_HDRI_RESOLUTIONS) => {
+  const candidates = collectHdriCandidates(apiJson);
+  if (!candidates.length) return null;
+
   for (const res of preferredResolutions) {
-    const match = lower.find((url) => url.includes(`_${String(res).toLowerCase()}.`));
-    if (match) return urls[lower.indexOf(match)];
+    const normalized = normalizeHdriResolutionId(res);
+    if (!normalized) continue;
+    const matched = candidates.find((entry) => entry.resolution === normalized);
+    if (matched?.url) return matched.url;
   }
-  return urls[0] ?? null;
+
+  for (const fallbackRes of HDRI_RESOLUTION_LADDER) {
+    const matched = candidates.find((entry) => entry.resolution === fallbackRes);
+    if (matched?.url) return matched.url;
+  }
+
+  for (const candidate of candidates) {
+    if (candidate?.url) {
+      return candidate.url;
+    }
+  }
+  return null;
 };
 
 async function resolvePolyHavenHdriUrl(config = {}) {


### PR DESCRIPTION
### Motivation
- Users could not reliably pick HDRI sizes (2K/4K/6K/8K) because the previous URL matcher only matched a narrow filename pattern and missed valid HDRI URLs.
- HDRI resolution selection must respect the graphics option without breaking environment loading when a perfect match is unavailable.

### Description
- Improved HDRI resolution discovery and selection in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` by adding resolution helpers and a candidate collector.
- Added `HDRI_RESOLUTION_PATTERN`, `normalizeHdriResolutionId`, `extractResolutionFromHdriUrl`, and `collectHdriCandidates` to extract and normalize resolution hints from JSON keys and URLs.
- Reworked `pickPolyHavenHdriUrl` to prefer exact matches for the requested resolution, then fall back along `HDRI_RESOLUTION_LADDER`, and finally return the first valid HDRI candidate.
- Kept safe fallback behavior via existing `resolvePolyHavenHdriUrl` flow so environment loading remains robust when assets are missing.

### Testing
- Ran the production build with `npm -C webapp run build` which completed successfully and produced the Vite build artifacts.
- The build emitted existing Vite warnings about chunk sizes and dynamic-import placements but no errors occurred and the build passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb6986e9188329ab72b9b818a4c184)