### PR TITLE
Add mobile-first graphics settings manager, UI and TexasHoldem installer

### DIFF
--- a/Assets/Scripts/Settings.meta
+++ b/Assets/Scripts/Settings.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6a00f56a6f624cc7ae2a4ee02ecf7f4d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Settings/GraphicsPreset.cs
+++ b/Assets/Scripts/Settings/GraphicsPreset.cs
@@ -1,0 +1,14 @@
+namespace TonPlaygram.Settings
+{
+    /// <summary>
+    /// User-facing option selected from the settings menu.
+    /// Auto is persisted as a choice, but can map to any applied quality tier.
+    /// </summary>
+    public enum GraphicsPreset
+    {
+        Auto = 0,
+        Low = 1,
+        Medium = 2,
+        High = 3,
+    }
+}

--- a/Assets/Scripts/Settings/GraphicsPreset.cs.meta
+++ b/Assets/Scripts/Settings/GraphicsPreset.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2a8ccf8b7d1f4c91a2d621625a50436b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Settings/GraphicsQualityTier.cs
+++ b/Assets/Scripts/Settings/GraphicsQualityTier.cs
@@ -1,0 +1,12 @@
+namespace TonPlaygram.Settings
+{
+    /// <summary>
+    /// Internal quality tier that is actually applied to rendering and quality systems.
+    /// </summary>
+    public enum GraphicsQualityTier
+    {
+        Low = 0,
+        Medium = 1,
+        High = 2,
+    }
+}

--- a/Assets/Scripts/Settings/GraphicsQualityTier.cs.meta
+++ b/Assets/Scripts/Settings/GraphicsQualityTier.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8be7e5b8e45a418cbe6ea3a6dfa40d35
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Settings/GraphicsSettingsManager.cs
+++ b/Assets/Scripts/Settings/GraphicsSettingsManager.cs
@@ -1,0 +1,413 @@
+using System;
+using UnityEngine;
+using UnityEngine.Rendering;
+
+namespace TonPlaygram.Settings
+{
+    /// <summary>
+    /// Central mobile-first graphics settings manager.
+    ///
+    /// Responsibilities:
+    /// - Persist and load the user-selected GraphicsPreset.
+    /// - Resolve Auto into an internal tier via hardware heuristics.
+    /// - Apply full-scene quality changes immediately (FPS + render scale + quality knobs).
+    /// - Expose events so UI and gameplay systems can react without tight coupling.
+    ///
+    /// Resolution strategy:
+    /// - URP: set renderScale on the active URP pipeline asset (reflection, no hard package dependency).
+    /// - Non-URP fallback: use ScalableBufferManager.ResizeBuffers(scale, scale) to reduce internal
+    ///   render buffer size while keeping display/UI resolution readable.
+    /// </summary>
+    public sealed class GraphicsSettingsManager : MonoBehaviour
+    {
+        private const string SavedPresetKey = "graphics_preset";
+        private const string SavedAutoResolvedTierKey = "graphics_auto_resolved_tier";
+
+        // Optional singleton convenience for simple projects.
+        public static GraphicsSettingsManager Instance { get; private set; }
+
+        public GraphicsPreset SelectedPreset { get; private set; } = GraphicsPreset.Auto;
+        public GraphicsQualityTier AppliedTier { get; private set; } = GraphicsQualityTier.Medium;
+
+        public event Action<GraphicsPreset, GraphicsQualityTier> OnGraphicsSettingsApplied;
+
+        /// <summary>
+        /// Optional hook for game-specific extras (e.g. post-processing volumes, particle managers)
+        /// that are not globally controllable via QualitySettings alone.
+        /// </summary>
+        public event Action<GraphicsQualityTier> OnCustomQualityTierApplied;
+
+        [Header("Render Scale (clamped at runtime)")]
+        [SerializeField, Range(0.5f, 1.0f)] private float lowRenderScale = 0.70f;
+        [SerializeField, Range(0.7f, 1.1f)] private float mediumRenderScale = 0.90f;
+        [SerializeField, Range(0.9f, 1.4f)] private float highRenderScale = 1.10f;
+
+        [Header("Frame Targets")]
+        [SerializeField] private int lowTargetFps = 60;
+        [SerializeField] private int mediumTargetFps = 90;
+        [SerializeField] private int highTargetFps = 120;
+
+        [Header("Optional UI Messages")]
+        [SerializeField] private bool logFeedbackMessages = true;
+
+        private static readonly string[] PresetDescriptions =
+        {
+            "Recommended. Automatically chooses the best graphics for your phone.",
+            "Best for battery life and lower-end phones.",
+            "Balanced visuals and smooth performance.",
+            "Best visuals for powerful phones.",
+        };
+
+        private void Awake()
+        {
+            if (Instance != null && Instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            Instance = this;
+            DontDestroyOnLoad(gameObject);
+
+            Application.targetFrameRate = -1;
+            QualitySettings.vSyncCount = 0; // Mobile should use explicit frame cap.
+
+            LoadAndApplyOnBoot();
+        }
+
+        public string GetDescription(GraphicsPreset preset)
+        {
+            return PresetDescriptions[(int)preset];
+        }
+
+        public void SetPreset(GraphicsPreset preset, bool showUserMessage = true)
+        {
+            SelectedPreset = preset;
+
+            var resolvedTier = preset == GraphicsPreset.Auto
+                ? ResolveAutoTierAndCache()
+                : PresetToTier(preset);
+
+            ApplyTierInternal(resolvedTier);
+            SaveSelection();
+
+            if (showUserMessage)
+            {
+                EmitUserFeedbackMessage(preset, resolvedTier);
+            }
+
+            OnGraphicsSettingsApplied?.Invoke(SelectedPreset, AppliedTier);
+        }
+
+        public GraphicsQualityTier GetResolvedTierForPreset(GraphicsPreset preset)
+        {
+            return preset == GraphicsPreset.Auto ? ResolveAutoTierNoSideEffects() : PresetToTier(preset);
+        }
+
+        private void LoadAndApplyOnBoot()
+        {
+            if (PlayerPrefs.HasKey(SavedPresetKey))
+            {
+                SelectedPreset = (GraphicsPreset)Mathf.Clamp(PlayerPrefs.GetInt(SavedPresetKey, 0), 0, 3);
+            }
+            else
+            {
+                // First launch: default to Auto for best out-of-box experience.
+                SelectedPreset = GraphicsPreset.Auto;
+                PlayerPrefs.SetInt(SavedPresetKey, (int)SelectedPreset);
+                PlayerPrefs.Save();
+            }
+
+            var tier = SelectedPreset == GraphicsPreset.Auto
+                ? ResolveAutoTierAndCache()
+                : PresetToTier(SelectedPreset);
+
+            ApplyTierInternal(tier);
+            OnGraphicsSettingsApplied?.Invoke(SelectedPreset, AppliedTier);
+        }
+
+        private void SaveSelection()
+        {
+            PlayerPrefs.SetInt(SavedPresetKey, (int)SelectedPreset);
+            PlayerPrefs.SetInt(SavedAutoResolvedTierKey, (int)AppliedTier);
+            PlayerPrefs.Save();
+        }
+
+        private GraphicsQualityTier PresetToTier(GraphicsPreset preset)
+        {
+            switch (preset)
+            {
+                case GraphicsPreset.Low:
+                    return GraphicsQualityTier.Low;
+                case GraphicsPreset.Medium:
+                    return GraphicsQualityTier.Medium;
+                case GraphicsPreset.High:
+                    return GraphicsQualityTier.High;
+                default:
+                    return GraphicsQualityTier.Medium;
+            }
+        }
+
+        private GraphicsQualityTier ResolveAutoTierNoSideEffects()
+        {
+            return ScoreDeviceAndPickTier();
+        }
+
+        private GraphicsQualityTier ResolveAutoTierAndCache()
+        {
+            var tier = ScoreDeviceAndPickTier();
+            PlayerPrefs.SetInt(SavedAutoResolvedTierKey, (int)tier);
+            return tier;
+        }
+
+        private GraphicsQualityTier ScoreDeviceAndPickTier()
+        {
+            // Heuristic scoring. Conservative by design for thermal stability.
+            // Unity does not expose reliable universal thermal APIs across all Android/iOS versions,
+            // so we infer risk via battery state + power-saving hints + hardware headroom.
+
+            var score = 0;
+
+            var refreshRate = GetScreenRefreshRate();
+            if (refreshRate >= 120) score += 25;
+            else if (refreshRate >= 90) score += 15;
+            else if (refreshRate >= 60) score += 8;
+            else score += 2;
+
+            var ramMb = SystemInfo.systemMemorySize;
+            if (ramMb >= 12000) score += 25;
+            else if (ramMb >= 8000) score += 18;
+            else if (ramMb >= 5000) score += 10;
+            else if (ramMb >= 3000) score += 4;
+
+            var cpuCores = SystemInfo.processorCount;
+            if (cpuCores >= 8) score += 18;
+            else if (cpuCores >= 6) score += 12;
+            else if (cpuCores >= 4) score += 6;
+
+            var cpuFreq = SystemInfo.processorFrequency;
+            if (cpuFreq >= 2800) score += 10;
+            else if (cpuFreq >= 2200) score += 6;
+            else if (cpuFreq >= 1600) score += 3;
+
+            score += ScoreGpuLevel();
+            score += ScoreGraphicsApiSupport();
+
+            // Resolution pressure: very high internal pixel count increases GPU cost.
+            var pixelCount = Screen.width * Screen.height;
+            if (pixelCount >= 3000000) score -= 8;      // ~1440p+
+            else if (pixelCount >= 2073600) score -= 4; // ~1080p+
+
+            // Conservative battery sensitivity. If unplugged + low battery, step down.
+            // (No direct universal thermal signal in Unity runtime APIs.)
+            if (SystemInfo.batteryStatus == BatteryStatus.Discharging)
+            {
+                if (SystemInfo.batteryLevel >= 0f && SystemInfo.batteryLevel <= 0.15f)
+                {
+                    score -= 18;
+                }
+                else if (SystemInfo.batteryLevel <= 0.30f)
+                {
+                    score -= 8;
+                }
+            }
+
+            // Safety fallback when key detection data is missing.
+            if (ramMb <= 0 || cpuCores <= 0)
+            {
+                score = Mathf.Min(score, 50);
+            }
+
+            if (score >= 70) return GraphicsQualityTier.High;
+            if (score >= 42) return GraphicsQualityTier.Medium;
+            return GraphicsQualityTier.Low;
+        }
+
+        private int ScoreGpuLevel()
+        {
+            // Practical heuristic based on GPU model strings available in Unity.
+            var gpuName = SystemInfo.graphicsDeviceName;
+            if (string.IsNullOrEmpty(gpuName)) return 0;
+
+            gpuName = gpuName.ToLowerInvariant();
+
+            // High-end families
+            if (gpuName.Contains("adreno 7") || gpuName.Contains("adreno 8") ||
+                gpuName.Contains("mali-g7") || gpuName.Contains("mali-g8") ||
+                gpuName.Contains("apple a17") || gpuName.Contains("apple a18") ||
+                gpuName.Contains("apple m1") || gpuName.Contains("apple m2"))
+            {
+                return 18;
+            }
+
+            // Mid-tier families
+            if (gpuName.Contains("adreno 6") || gpuName.Contains("mali-g5") || gpuName.Contains("mali-g6") ||
+                gpuName.Contains("apple a14") || gpuName.Contains("apple a15") || gpuName.Contains("apple a16"))
+            {
+                return 10;
+            }
+
+            // Entry-level/older
+            if (gpuName.Contains("adreno 5") || gpuName.Contains("mali-t") || gpuName.Contains("powervr"))
+            {
+                return 3;
+            }
+
+            return 6;
+        }
+
+        private int ScoreGraphicsApiSupport()
+        {
+            var api = SystemInfo.graphicsDeviceType;
+            switch (api)
+            {
+                case GraphicsDeviceType.Vulkan:
+                case GraphicsDeviceType.Metal:
+                    return 8;
+                case GraphicsDeviceType.OpenGLES3:
+                    return 4;
+                default:
+                    return 1;
+            }
+        }
+
+        private int GetScreenRefreshRate()
+        {
+#if UNITY_2021_2_OR_NEWER
+            var ratio = Screen.currentResolution.refreshRateRatio;
+            return Mathf.RoundToInt((float)ratio.value);
+#else
+            return Screen.currentResolution.refreshRate;
+#endif
+        }
+
+        private void ApplyTierInternal(GraphicsQualityTier tier)
+        {
+            AppliedTier = tier;
+
+            switch (tier)
+            {
+                case GraphicsQualityTier.Low:
+                    ApplyGlobalQuality(lowTargetFps, lowRenderScale, lodBias: 0.6f, textureLimit: 1,
+                        shadows: ShadowQuality.Disable, shadowDistance: 0f, softParticles: false, anisotropic: AnisotropicFiltering.Disable,
+                        antiAliasing: 0, particleRaycastBudget: 32);
+                    break;
+
+                case GraphicsQualityTier.Medium:
+                    ApplyGlobalQuality(mediumTargetFps, mediumRenderScale, lodBias: 1.0f, textureLimit: 0,
+                        shadows: ShadowQuality.HardOnly, shadowDistance: 22f, softParticles: false, anisotropic: AnisotropicFiltering.Enable,
+                        antiAliasing: 2, particleRaycastBudget: 96);
+                    break;
+
+                case GraphicsQualityTier.High:
+                    var safeHighFps = GetHighestSafeHighRefreshTarget();
+                    ApplyGlobalQuality(safeHighFps, highRenderScale, lodBias: 1.5f, textureLimit: 0,
+                        shadows: ShadowQuality.All, shadowDistance: 40f, softParticles: true, anisotropic: AnisotropicFiltering.ForceEnable,
+                        antiAliasing: 4, particleRaycastBudget: 256);
+                    break;
+            }
+
+            OnCustomQualityTierApplied?.Invoke(tier);
+        }
+
+        private int GetHighestSafeHighRefreshTarget()
+        {
+            var refresh = GetScreenRefreshRate();
+            if (refresh >= 144) return 144;
+            if (refresh >= highTargetFps) return highTargetFps;
+            if (refresh >= 120) return 120;
+            if (refresh >= 90) return 90;
+            return 60;
+        }
+
+        private void ApplyGlobalQuality(
+            int targetFps,
+            float internalRenderScale,
+            float lodBias,
+            int textureLimit,
+            ShadowQuality shadows,
+            float shadowDistance,
+            bool softParticles,
+            AnisotropicFiltering anisotropic,
+            int antiAliasing,
+            int particleRaycastBudget)
+        {
+            Application.targetFrameRate = Mathf.Clamp(targetFps, 30, 144);
+
+            QualitySettings.lodBias = lodBias;
+            QualitySettings.masterTextureLimit = Mathf.Clamp(textureLimit, 0, 3);
+            QualitySettings.shadows = shadows;
+            QualitySettings.shadowDistance = shadowDistance;
+            QualitySettings.softParticles = softParticles;
+            QualitySettings.anisotropicFiltering = anisotropic;
+            QualitySettings.antiAliasing = antiAliasing;
+            QualitySettings.particleRaycastBudget = particleRaycastBudget;
+
+            ApplyInternalResolutionScale(internalRenderScale);
+        }
+
+        private void ApplyInternalResolutionScale(float requestedScale)
+        {
+            // Clamp range for safety and to avoid invalid render targets.
+            var clampedScale = Mathf.Clamp(requestedScale, 0.6f, 1.25f);
+
+            if (TrySetUrpRenderScale(clampedScale))
+            {
+                return;
+            }
+
+            // Non-URP fallback:
+            // Scales render buffers, producing a softer/sharper full-scene image while the display
+            // resolution and UI canvas stay readable. Good default for mobile pipelines.
+            ScalableBufferManager.ResizeBuffers(clampedScale, clampedScale);
+        }
+
+        private bool TrySetUrpRenderScale(float scale)
+        {
+            var pipelineAsset = GraphicsSettings.currentRenderPipeline;
+            if (pipelineAsset == null)
+            {
+                return false;
+            }
+
+            // Reflection keeps this script compilable even when URP package is not installed.
+            var pipelineType = pipelineAsset.GetType();
+            var property = pipelineType.GetProperty("renderScale");
+            if (property == null || !property.CanWrite)
+            {
+                return false;
+            }
+
+            var min = 0.5f;
+            var max = 2.0f;
+            var clamped = Mathf.Clamp(scale, min, max);
+            property.SetValue(pipelineAsset, clamped, null);
+            return true;
+        }
+
+        private void EmitUserFeedbackMessage(GraphicsPreset selectedPreset, GraphicsQualityTier resolvedTier)
+        {
+            if (!logFeedbackMessages)
+            {
+                return;
+            }
+
+            if (selectedPreset == GraphicsPreset.Auto)
+            {
+                Debug.Log($"[Graphics] Auto selected the best settings for your device ({resolvedTier}).");
+                return;
+            }
+
+            Debug.Log("[Graphics] Graphics quality updated.");
+
+            if (selectedPreset == GraphicsPreset.High)
+            {
+                var autoTier = ResolveAutoTierNoSideEffects();
+                if (autoTier != GraphicsQualityTier.High)
+                {
+                    Debug.LogWarning("[Graphics] High graphics may reduce performance on some devices.");
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Settings/GraphicsSettingsManager.cs.meta
+++ b/Assets/Scripts/Settings/GraphicsSettingsManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d5d71ae3c36a4bdab52dd5fbbf65f13f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Settings/GraphicsSettingsUI.cs
+++ b/Assets/Scripts/Settings/GraphicsSettingsUI.cs
@@ -1,0 +1,256 @@
+using System;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace TonPlaygram.Settings
+{
+    /// <summary>
+    /// UI adapter for graphics setting buttons and labels.
+    ///
+    /// Assign button + text references in inspector.
+    /// The script keeps selection highlighting in sync and forwards user taps to manager.
+    /// </summary>
+    public sealed class GraphicsSettingsUI : MonoBehaviour
+    {
+        [Serializable]
+        public sealed class PresetOptionView
+        {
+            public GraphicsPreset preset;
+            public Button button;
+            public Text titleText;
+            public Text descriptionText;
+            public Graphic[] highlightTargets;
+        }
+
+        [Header("Dependencies")]
+        [SerializeField] private GraphicsSettingsManager manager;
+
+        [Header("Preset Options")]
+        [SerializeField] private PresetOptionView[] options;
+
+        [Header("Style")]
+        [SerializeField] private Color selectedColor = new Color(0.15f, 0.7f, 0.3f, 1f);
+        [SerializeField] private Color unselectedColor = new Color(0.2f, 0.2f, 0.2f, 1f);
+        [SerializeField] private Color selectedTextColor = Color.white;
+        [SerializeField] private Color unselectedTextColor = new Color(0.9f, 0.9f, 0.9f, 1f);
+
+        [Header("Optional Feedback")]
+        [SerializeField] private Text feedbackText;
+        [SerializeField] private float feedbackDuration = 2f;
+
+        private float feedbackHideTime;
+
+        private void Awake()
+        {
+            if (manager == null)
+            {
+                manager = GraphicsSettingsManager.Instance;
+            }
+
+            ValidateTexasHoldemPresetLayout();
+            WireButtons();
+            FillDescriptions();
+        }
+
+        private void OnEnable()
+        {
+            if (manager == null)
+            {
+                manager = GraphicsSettingsManager.Instance;
+            }
+
+            if (manager != null)
+            {
+                manager.OnGraphicsSettingsApplied += HandleSettingsApplied;
+                HandleSettingsApplied(manager.SelectedPreset, manager.AppliedTier);
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (manager != null)
+            {
+                manager.OnGraphicsSettingsApplied -= HandleSettingsApplied;
+            }
+        }
+
+        private void Update()
+        {
+            if (feedbackText != null && feedbackText.gameObject.activeSelf && Time.unscaledTime >= feedbackHideTime)
+            {
+                feedbackText.gameObject.SetActive(false);
+            }
+        }
+
+        private void WireButtons()
+        {
+            if (options == null)
+            {
+                return;
+            }
+
+            for (var i = 0; i < options.Length; i++)
+            {
+                var option = options[i];
+                if (option == null || option.button == null)
+                {
+                    continue;
+                }
+
+                var capturedPreset = option.preset;
+                option.button.onClick.RemoveAllListeners();
+                option.button.onClick.AddListener(() => OnPresetClicked(capturedPreset));
+            }
+        }
+
+        private void FillDescriptions()
+        {
+            if (manager == null || options == null)
+            {
+                return;
+            }
+
+            for (var i = 0; i < options.Length; i++)
+            {
+                var option = options[i];
+                if (option == null)
+                {
+                    continue;
+                }
+
+                if (option.titleText != null)
+                {
+                    option.titleText.text = option.preset.ToString();
+                }
+
+                if (option.descriptionText != null)
+                {
+                    option.descriptionText.text = manager.GetDescription(option.preset);
+                }
+            }
+        }
+
+        private void OnPresetClicked(GraphicsPreset preset)
+        {
+            if (manager == null)
+            {
+                Debug.LogWarning("[GraphicsUI] GraphicsSettingsManager not found.");
+                return;
+            }
+
+            var previous = manager.SelectedPreset;
+            manager.SetPreset(preset, showUserMessage: true);
+
+            if (feedbackText == null)
+            {
+                return;
+            }
+
+            if (preset == GraphicsPreset.Auto)
+            {
+                feedbackText.text = "Auto selected the best settings for your device.";
+            }
+            else
+            {
+                feedbackText.text = "Graphics quality updated.";
+                if (preset == GraphicsPreset.High && manager.GetResolvedTierForPreset(GraphicsPreset.Auto) != GraphicsQualityTier.High)
+                {
+                    feedbackText.text = "High graphics may reduce performance on some devices.";
+                }
+            }
+
+            if (previous != preset || preset == GraphicsPreset.Auto)
+            {
+                feedbackText.gameObject.SetActive(true);
+                feedbackHideTime = Time.unscaledTime + Mathf.Max(0.75f, feedbackDuration);
+            }
+        }
+
+        private void HandleSettingsApplied(GraphicsPreset selectedPreset, GraphicsQualityTier resolvedTier)
+        {
+            if (options == null)
+            {
+                return;
+            }
+
+            for (var i = 0; i < options.Length; i++)
+            {
+                var option = options[i];
+                if (option == null)
+                {
+                    continue;
+                }
+
+                var isSelected = option.preset == selectedPreset;
+                var bgColor = isSelected ? selectedColor : unselectedColor;
+                var txtColor = isSelected ? selectedTextColor : unselectedTextColor;
+
+                if (option.highlightTargets != null)
+                {
+                    for (var h = 0; h < option.highlightTargets.Length; h++)
+                    {
+                        var g = option.highlightTargets[h];
+                        if (g != null)
+                        {
+                            g.color = bgColor;
+                        }
+                    }
+                }
+
+                if (option.titleText != null)
+                {
+                    option.titleText.color = txtColor;
+                }
+
+                if (option.descriptionText != null)
+                {
+                    option.descriptionText.color = txtColor;
+
+                    if (selectedPreset == GraphicsPreset.Auto && option.preset == GraphicsPreset.Auto)
+                    {
+                        option.descriptionText.text =
+                            $"{manager.GetDescription(GraphicsPreset.Auto)}\nActive tier: {resolvedTier}.";
+                    }
+                    else
+                    {
+                        option.descriptionText.text = manager.GetDescription(option.preset);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Safety validation for menu migration:
+        /// Texas Hold'em should expose only 4 options: Auto, Low, Medium, High.
+        /// </summary>
+        private void ValidateTexasHoldemPresetLayout()
+        {
+            if (options == null || options.Length != 4)
+            {
+                Debug.LogWarning("[GraphicsUI] Expected exactly 4 preset options (Auto, Low, Medium, High).");
+                return;
+            }
+
+            var mask = 0;
+            for (var i = 0; i < options.Length; i++)
+            {
+                if (options[i] == null)
+                {
+                    continue;
+                }
+
+                mask |= 1 << (int)options[i].preset;
+            }
+
+            const int requiredMask = (1 << (int)GraphicsPreset.Auto)
+                                   | (1 << (int)GraphicsPreset.Low)
+                                   | (1 << (int)GraphicsPreset.Medium)
+                                   | (1 << (int)GraphicsPreset.High);
+
+            if (mask != requiredMask)
+            {
+                Debug.LogWarning("[GraphicsUI] Preset list must include Auto, Low, Medium, and High exactly once.");
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Settings/GraphicsSettingsUI.cs.meta
+++ b/Assets/Scripts/Settings/GraphicsSettingsUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0fe34f4909884842b710cb2760fc10aa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Settings/TexasHoldemGraphicsMenuInstaller.cs
+++ b/Assets/Scripts/Settings/TexasHoldemGraphicsMenuInstaller.cs
@@ -1,0 +1,56 @@
+using UnityEngine;
+
+namespace TonPlaygram.Settings
+{
+    /// <summary>
+    /// Scene-side adapter for the Texas Hold'em settings menu.
+    ///
+    /// Purpose:
+    /// - Disable legacy graphics/HDRI option groups.
+    /// - Ensure only the new 4-option graphics preset UI is visible.
+    ///
+    /// Attach this to your Texas Hold'em menu root and assign references in Inspector.
+    /// This keeps migration from older menu layouts safe and explicit.
+    /// </summary>
+    public sealed class TexasHoldemGraphicsMenuInstaller : MonoBehaviour
+    {
+        [Header("Legacy groups to remove from menu")]
+        [SerializeField] private GameObject[] legacyGraphicsOptionRoots;
+        [SerializeField] private GameObject[] legacyHdriOptionRoots;
+
+        [Header("New graphics preset panel (Auto/Low/Medium/High)")]
+        [SerializeField] private GameObject newGraphicsPresetPanel;
+
+        private void Awake()
+        {
+            DisableLegacyGroups(legacyGraphicsOptionRoots);
+            DisableLegacyGroups(legacyHdriOptionRoots);
+
+            if (newGraphicsPresetPanel != null)
+            {
+                newGraphicsPresetPanel.SetActive(true);
+            }
+            else
+            {
+                Debug.LogWarning("[TexasHoldemGraphicsMenuInstaller] New graphics preset panel is not assigned.");
+            }
+        }
+
+        private static void DisableLegacyGroups(GameObject[] roots)
+        {
+            if (roots == null)
+            {
+                return;
+            }
+
+            for (var i = 0; i < roots.Length; i++)
+            {
+                var root = roots[i];
+                if (root != null)
+                {
+                    root.SetActive(false);
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Settings/TexasHoldemGraphicsMenuInstaller.cs.meta
+++ b/Assets/Scripts/Settings/TexasHoldemGraphicsMenuInstaller.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b2a0ac8f86384a7f87e4dbeeeec926ea
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Motivation
- Introduce a centralized, mobile-first graphics settings system that persists a user-facing `GraphicsPreset`, resolves `Auto` into an internal quality tier via device heuristics, and applies rendering/quality changes at runtime.
- Provide a simple UI adapter to expose the presets to players and display contextual feedback and descriptions.
- Allow migration from older menus by disabling legacy option groups for the Texas Hold'em settings scene.

### Description
- Added `GraphicsPreset` and `GraphicsQualityTier` enums to represent user-facing choices and internal applied tiers respectively.
- Implemented `GraphicsSettingsManager` which scores device characteristics (CPU, RAM, GPU, refresh rate, battery) to pick a tier, persists selections in `PlayerPrefs`, applies quality settings including render scale via URP reflection or `ScalableBufferManager`, and exposes `OnGraphicsSettingsApplied` and `OnCustomQualityTierApplied` events.
- Added `GraphicsSettingsUI` to wire inspector-assigned buttons and texts, keep selection highlighting in sync, show feedback messages, and display active tier when `Auto` is selected.
- Added `TexasHoldemGraphicsMenuInstaller` to disable legacy graphics/HDRI option groups and enable the new 4-option preset panel.
- Added Unity meta files for all new scripts and the `Settings` folder.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb6dac9ab08329bd002909f5935baf)