### PR TITLE
Add graphics preset system with auto-detection (Unity manager + web UI)

### DIFF
--- a/Assets/Scripts/Settings.meta
+++ b/Assets/Scripts/Settings.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6a00f56a6f624cc7ae2a4ee02ecf7f4d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Settings/GraphicsPreset.cs
+++ b/Assets/Scripts/Settings/GraphicsPreset.cs
@@ -1,0 +1,14 @@
+namespace TonPlaygram.Settings
+{
+    /// <summary>
+    /// User-facing option selected from the settings menu.
+    /// Auto is persisted as a choice, but can map to any applied quality tier.
+    /// </summary>
+    public enum GraphicsPreset
+    {
+        Auto = 0,
+        Low = 1,
+        Medium = 2,
+        High = 3,
+    }
+}

--- a/Assets/Scripts/Settings/GraphicsPreset.cs.meta
+++ b/Assets/Scripts/Settings/GraphicsPreset.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2a8ccf8b7d1f4c91a2d621625a50436b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Settings/GraphicsQualityTier.cs
+++ b/Assets/Scripts/Settings/GraphicsQualityTier.cs
@@ -1,0 +1,12 @@
+namespace TonPlaygram.Settings
+{
+    /// <summary>
+    /// Internal quality tier that is actually applied to rendering and quality systems.
+    /// </summary>
+    public enum GraphicsQualityTier
+    {
+        Low = 0,
+        Medium = 1,
+        High = 2,
+    }
+}

--- a/Assets/Scripts/Settings/GraphicsQualityTier.cs.meta
+++ b/Assets/Scripts/Settings/GraphicsQualityTier.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8be7e5b8e45a418cbe6ea3a6dfa40d35
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Settings/GraphicsSettingsManager.cs
+++ b/Assets/Scripts/Settings/GraphicsSettingsManager.cs
@@ -1,0 +1,413 @@
+using System;
+using UnityEngine;
+using UnityEngine.Rendering;
+
+namespace TonPlaygram.Settings
+{
+    /// <summary>
+    /// Central mobile-first graphics settings manager.
+    ///
+    /// Responsibilities:
+    /// - Persist and load the user-selected GraphicsPreset.
+    /// - Resolve Auto into an internal tier via hardware heuristics.
+    /// - Apply full-scene quality changes immediately (FPS + render scale + quality knobs).
+    /// - Expose events so UI and gameplay systems can react without tight coupling.
+    ///
+    /// Resolution strategy:
+    /// - URP: set renderScale on the active URP pipeline asset (reflection, no hard package dependency).
+    /// - Non-URP fallback: use ScalableBufferManager.ResizeBuffers(scale, scale) to reduce internal
+    ///   render buffer size while keeping display/UI resolution readable.
+    /// </summary>
+    public sealed class GraphicsSettingsManager : MonoBehaviour
+    {
+        private const string SavedPresetKey = "graphics_preset";
+        private const string SavedAutoResolvedTierKey = "graphics_auto_resolved_tier";
+
+        // Optional singleton convenience for simple projects.
+        public static GraphicsSettingsManager Instance { get; private set; }
+
+        public GraphicsPreset SelectedPreset { get; private set; } = GraphicsPreset.Auto;
+        public GraphicsQualityTier AppliedTier { get; private set; } = GraphicsQualityTier.Medium;
+
+        public event Action<GraphicsPreset, GraphicsQualityTier> OnGraphicsSettingsApplied;
+
+        /// <summary>
+        /// Optional hook for game-specific extras (e.g. post-processing volumes, particle managers)
+        /// that are not globally controllable via QualitySettings alone.
+        /// </summary>
+        public event Action<GraphicsQualityTier> OnCustomQualityTierApplied;
+
+        [Header("Render Scale (clamped at runtime)")]
+        [SerializeField, Range(0.5f, 1.0f)] private float lowRenderScale = 0.70f;
+        [SerializeField, Range(0.7f, 1.1f)] private float mediumRenderScale = 0.90f;
+        [SerializeField, Range(0.9f, 1.4f)] private float highRenderScale = 1.10f;
+
+        [Header("Frame Targets")]
+        [SerializeField] private int lowTargetFps = 60;
+        [SerializeField] private int mediumTargetFps = 90;
+        [SerializeField] private int highTargetFps = 120;
+
+        [Header("Optional UI Messages")]
+        [SerializeField] private bool logFeedbackMessages = true;
+
+        private static readonly string[] PresetDescriptions =
+        {
+            "Recommended. Automatically chooses the best graphics for your phone.",
+            "Best for battery life and lower-end phones.",
+            "Balanced visuals and smooth performance.",
+            "Best visuals for powerful phones.",
+        };
+
+        private void Awake()
+        {
+            if (Instance != null && Instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            Instance = this;
+            DontDestroyOnLoad(gameObject);
+
+            Application.targetFrameRate = -1;
+            QualitySettings.vSyncCount = 0; // Mobile should use explicit frame cap.
+
+            LoadAndApplyOnBoot();
+        }
+
+        public string GetDescription(GraphicsPreset preset)
+        {
+            return PresetDescriptions[(int)preset];
+        }
+
+        public void SetPreset(GraphicsPreset preset, bool showUserMessage = true)
+        {
+            SelectedPreset = preset;
+
+            var resolvedTier = preset == GraphicsPreset.Auto
+                ? ResolveAutoTierAndCache()
+                : PresetToTier(preset);
+
+            ApplyTierInternal(resolvedTier);
+            SaveSelection();
+
+            if (showUserMessage)
+            {
+                EmitUserFeedbackMessage(preset, resolvedTier);
+            }
+
+            OnGraphicsSettingsApplied?.Invoke(SelectedPreset, AppliedTier);
+        }
+
+        public GraphicsQualityTier GetResolvedTierForPreset(GraphicsPreset preset)
+        {
+            return preset == GraphicsPreset.Auto ? ResolveAutoTierNoSideEffects() : PresetToTier(preset);
+        }
+
+        private void LoadAndApplyOnBoot()
+        {
+            if (PlayerPrefs.HasKey(SavedPresetKey))
+            {
+                SelectedPreset = (GraphicsPreset)Mathf.Clamp(PlayerPrefs.GetInt(SavedPresetKey, 0), 0, 3);
+            }
+            else
+            {
+                // First launch: default to Auto for best out-of-box experience.
+                SelectedPreset = GraphicsPreset.Auto;
+                PlayerPrefs.SetInt(SavedPresetKey, (int)SelectedPreset);
+                PlayerPrefs.Save();
+            }
+
+            var tier = SelectedPreset == GraphicsPreset.Auto
+                ? ResolveAutoTierAndCache()
+                : PresetToTier(SelectedPreset);
+
+            ApplyTierInternal(tier);
+            OnGraphicsSettingsApplied?.Invoke(SelectedPreset, AppliedTier);
+        }
+
+        private void SaveSelection()
+        {
+            PlayerPrefs.SetInt(SavedPresetKey, (int)SelectedPreset);
+            PlayerPrefs.SetInt(SavedAutoResolvedTierKey, (int)AppliedTier);
+            PlayerPrefs.Save();
+        }
+
+        private GraphicsQualityTier PresetToTier(GraphicsPreset preset)
+        {
+            switch (preset)
+            {
+                case GraphicsPreset.Low:
+                    return GraphicsQualityTier.Low;
+                case GraphicsPreset.Medium:
+                    return GraphicsQualityTier.Medium;
+                case GraphicsPreset.High:
+                    return GraphicsQualityTier.High;
+                default:
+                    return GraphicsQualityTier.Medium;
+            }
+        }
+
+        private GraphicsQualityTier ResolveAutoTierNoSideEffects()
+        {
+            return ScoreDeviceAndPickTier();
+        }
+
+        private GraphicsQualityTier ResolveAutoTierAndCache()
+        {
+            var tier = ScoreDeviceAndPickTier();
+            PlayerPrefs.SetInt(SavedAutoResolvedTierKey, (int)tier);
+            return tier;
+        }
+
+        private GraphicsQualityTier ScoreDeviceAndPickTier()
+        {
+            // Heuristic scoring. Conservative by design for thermal stability.
+            // Unity does not expose reliable universal thermal APIs across all Android/iOS versions,
+            // so we infer risk via battery state + power-saving hints + hardware headroom.
+
+            var score = 0;
+
+            var refreshRate = GetScreenRefreshRate();
+            if (refreshRate >= 120) score += 25;
+            else if (refreshRate >= 90) score += 15;
+            else if (refreshRate >= 60) score += 8;
+            else score += 2;
+
+            var ramMb = SystemInfo.systemMemorySize;
+            if (ramMb >= 12000) score += 25;
+            else if (ramMb >= 8000) score += 18;
+            else if (ramMb >= 5000) score += 10;
+            else if (ramMb >= 3000) score += 4;
+
+            var cpuCores = SystemInfo.processorCount;
+            if (cpuCores >= 8) score += 18;
+            else if (cpuCores >= 6) score += 12;
+            else if (cpuCores >= 4) score += 6;
+
+            var cpuFreq = SystemInfo.processorFrequency;
+            if (cpuFreq >= 2800) score += 10;
+            else if (cpuFreq >= 2200) score += 6;
+            else if (cpuFreq >= 1600) score += 3;
+
+            score += ScoreGpuLevel();
+            score += ScoreGraphicsApiSupport();
+
+            // Resolution pressure: very high internal pixel count increases GPU cost.
+            var pixelCount = Screen.width * Screen.height;
+            if (pixelCount >= 3000000) score -= 8;      // ~1440p+
+            else if (pixelCount >= 2073600) score -= 4; // ~1080p+
+
+            // Conservative battery sensitivity. If unplugged + low battery, step down.
+            // (No direct universal thermal signal in Unity runtime APIs.)
+            if (SystemInfo.batteryStatus == BatteryStatus.Discharging)
+            {
+                if (SystemInfo.batteryLevel >= 0f && SystemInfo.batteryLevel <= 0.15f)
+                {
+                    score -= 18;
+                }
+                else if (SystemInfo.batteryLevel <= 0.30f)
+                {
+                    score -= 8;
+                }
+            }
+
+            // Safety fallback when key detection data is missing.
+            if (ramMb <= 0 || cpuCores <= 0)
+            {
+                score = Mathf.Min(score, 50);
+            }
+
+            if (score >= 70) return GraphicsQualityTier.High;
+            if (score >= 42) return GraphicsQualityTier.Medium;
+            return GraphicsQualityTier.Low;
+        }
+
+        private int ScoreGpuLevel()
+        {
+            // Practical heuristic based on GPU model strings available in Unity.
+            var gpuName = SystemInfo.graphicsDeviceName;
+            if (string.IsNullOrEmpty(gpuName)) return 0;
+
+            gpuName = gpuName.ToLowerInvariant();
+
+            // High-end families
+            if (gpuName.Contains("adreno 7") || gpuName.Contains("adreno 8") ||
+                gpuName.Contains("mali-g7") || gpuName.Contains("mali-g8") ||
+                gpuName.Contains("apple a17") || gpuName.Contains("apple a18") ||
+                gpuName.Contains("apple m1") || gpuName.Contains("apple m2"))
+            {
+                return 18;
+            }
+
+            // Mid-tier families
+            if (gpuName.Contains("adreno 6") || gpuName.Contains("mali-g5") || gpuName.Contains("mali-g6") ||
+                gpuName.Contains("apple a14") || gpuName.Contains("apple a15") || gpuName.Contains("apple a16"))
+            {
+                return 10;
+            }
+
+            // Entry-level/older
+            if (gpuName.Contains("adreno 5") || gpuName.Contains("mali-t") || gpuName.Contains("powervr"))
+            {
+                return 3;
+            }
+
+            return 6;
+        }
+
+        private int ScoreGraphicsApiSupport()
+        {
+            var api = SystemInfo.graphicsDeviceType;
+            switch (api)
+            {
+                case GraphicsDeviceType.Vulkan:
+                case GraphicsDeviceType.Metal:
+                    return 8;
+                case GraphicsDeviceType.OpenGLES3:
+                    return 4;
+                default:
+                    return 1;
+            }
+        }
+
+        private int GetScreenRefreshRate()
+        {
+#if UNITY_2021_2_OR_NEWER
+            var ratio = Screen.currentResolution.refreshRateRatio;
+            return Mathf.RoundToInt((float)ratio.value);
+#else
+            return Screen.currentResolution.refreshRate;
+#endif
+        }
+
+        private void ApplyTierInternal(GraphicsQualityTier tier)
+        {
+            AppliedTier = tier;
+
+            switch (tier)
+            {
+                case GraphicsQualityTier.Low:
+                    ApplyGlobalQuality(lowTargetFps, lowRenderScale, lodBias: 0.6f, textureLimit: 1,
+                        shadows: ShadowQuality.Disable, shadowDistance: 0f, softParticles: false, anisotropic: AnisotropicFiltering.Disable,
+                        antiAliasing: 0, particleRaycastBudget: 32);
+                    break;
+
+                case GraphicsQualityTier.Medium:
+                    ApplyGlobalQuality(mediumTargetFps, mediumRenderScale, lodBias: 1.0f, textureLimit: 0,
+                        shadows: ShadowQuality.HardOnly, shadowDistance: 22f, softParticles: false, anisotropic: AnisotropicFiltering.Enable,
+                        antiAliasing: 2, particleRaycastBudget: 96);
+                    break;
+
+                case GraphicsQualityTier.High:
+                    var safeHighFps = GetHighestSafeHighRefreshTarget();
+                    ApplyGlobalQuality(safeHighFps, highRenderScale, lodBias: 1.5f, textureLimit: 0,
+                        shadows: ShadowQuality.All, shadowDistance: 40f, softParticles: true, anisotropic: AnisotropicFiltering.ForceEnable,
+                        antiAliasing: 4, particleRaycastBudget: 256);
+                    break;
+            }
+
+            OnCustomQualityTierApplied?.Invoke(tier);
+        }
+
+        private int GetHighestSafeHighRefreshTarget()
+        {
+            var refresh = GetScreenRefreshRate();
+            if (refresh >= 144) return 144;
+            if (refresh >= highTargetFps) return highTargetFps;
+            if (refresh >= 120) return 120;
+            if (refresh >= 90) return 90;
+            return 60;
+        }
+
+        private void ApplyGlobalQuality(
+            int targetFps,
+            float internalRenderScale,
+            float lodBias,
+            int textureLimit,
+            ShadowQuality shadows,
+            float shadowDistance,
+            bool softParticles,
+            AnisotropicFiltering anisotropic,
+            int antiAliasing,
+            int particleRaycastBudget)
+        {
+            Application.targetFrameRate = Mathf.Clamp(targetFps, 30, 144);
+
+            QualitySettings.lodBias = lodBias;
+            QualitySettings.masterTextureLimit = Mathf.Clamp(textureLimit, 0, 3);
+            QualitySettings.shadows = shadows;
+            QualitySettings.shadowDistance = shadowDistance;
+            QualitySettings.softParticles = softParticles;
+            QualitySettings.anisotropicFiltering = anisotropic;
+            QualitySettings.antiAliasing = antiAliasing;
+            QualitySettings.particleRaycastBudget = particleRaycastBudget;
+
+            ApplyInternalResolutionScale(internalRenderScale);
+        }
+
+        private void ApplyInternalResolutionScale(float requestedScale)
+        {
+            // Clamp range for safety and to avoid invalid render targets.
+            var clampedScale = Mathf.Clamp(requestedScale, 0.6f, 1.25f);
+
+            if (TrySetUrpRenderScale(clampedScale))
+            {
+                return;
+            }
+
+            // Non-URP fallback:
+            // Scales render buffers, producing a softer/sharper full-scene image while the display
+            // resolution and UI canvas stay readable. Good default for mobile pipelines.
+            ScalableBufferManager.ResizeBuffers(clampedScale, clampedScale);
+        }
+
+        private bool TrySetUrpRenderScale(float scale)
+        {
+            var pipelineAsset = GraphicsSettings.currentRenderPipeline;
+            if (pipelineAsset == null)
+            {
+                return false;
+            }
+
+            // Reflection keeps this script compilable even when URP package is not installed.
+            var pipelineType = pipelineAsset.GetType();
+            var property = pipelineType.GetProperty("renderScale");
+            if (property == null || !property.CanWrite)
+            {
+                return false;
+            }
+
+            var min = 0.5f;
+            var max = 2.0f;
+            var clamped = Mathf.Clamp(scale, min, max);
+            property.SetValue(pipelineAsset, clamped, null);
+            return true;
+        }
+
+        private void EmitUserFeedbackMessage(GraphicsPreset selectedPreset, GraphicsQualityTier resolvedTier)
+        {
+            if (!logFeedbackMessages)
+            {
+                return;
+            }
+
+            if (selectedPreset == GraphicsPreset.Auto)
+            {
+                Debug.Log($"[Graphics] Auto selected the best settings for your device ({resolvedTier}).");
+                return;
+            }
+
+            Debug.Log("[Graphics] Graphics quality updated.");
+
+            if (selectedPreset == GraphicsPreset.High)
+            {
+                var autoTier = ResolveAutoTierNoSideEffects();
+                if (autoTier != GraphicsQualityTier.High)
+                {
+                    Debug.LogWarning("[Graphics] High graphics may reduce performance on some devices.");
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Settings/GraphicsSettingsManager.cs.meta
+++ b/Assets/Scripts/Settings/GraphicsSettingsManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d5d71ae3c36a4bdab52dd5fbbf65f13f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Settings/GraphicsSettingsUI.cs
+++ b/Assets/Scripts/Settings/GraphicsSettingsUI.cs
@@ -1,0 +1,221 @@
+using System;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace TonPlaygram.Settings
+{
+    /// <summary>
+    /// UI adapter for graphics setting buttons and labels.
+    ///
+    /// Assign button + text references in inspector.
+    /// The script keeps selection highlighting in sync and forwards user taps to manager.
+    /// </summary>
+    public sealed class GraphicsSettingsUI : MonoBehaviour
+    {
+        [Serializable]
+        public sealed class PresetOptionView
+        {
+            public GraphicsPreset preset;
+            public Button button;
+            public Text titleText;
+            public Text descriptionText;
+            public Graphic[] highlightTargets;
+        }
+
+        [Header("Dependencies")]
+        [SerializeField] private GraphicsSettingsManager manager;
+
+        [Header("Preset Options")]
+        [SerializeField] private PresetOptionView[] options;
+
+        [Header("Style")]
+        [SerializeField] private Color selectedColor = new Color(0.15f, 0.7f, 0.3f, 1f);
+        [SerializeField] private Color unselectedColor = new Color(0.2f, 0.2f, 0.2f, 1f);
+        [SerializeField] private Color selectedTextColor = Color.white;
+        [SerializeField] private Color unselectedTextColor = new Color(0.9f, 0.9f, 0.9f, 1f);
+
+        [Header("Optional Feedback")]
+        [SerializeField] private Text feedbackText;
+        [SerializeField] private float feedbackDuration = 2f;
+
+        private float feedbackHideTime;
+
+        private void Awake()
+        {
+            if (manager == null)
+            {
+                manager = GraphicsSettingsManager.Instance;
+            }
+
+            WireButtons();
+            FillDescriptions();
+        }
+
+        private void OnEnable()
+        {
+            if (manager == null)
+            {
+                manager = GraphicsSettingsManager.Instance;
+            }
+
+            if (manager != null)
+            {
+                manager.OnGraphicsSettingsApplied += HandleSettingsApplied;
+                HandleSettingsApplied(manager.SelectedPreset, manager.AppliedTier);
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (manager != null)
+            {
+                manager.OnGraphicsSettingsApplied -= HandleSettingsApplied;
+            }
+        }
+
+        private void Update()
+        {
+            if (feedbackText != null && feedbackText.gameObject.activeSelf && Time.unscaledTime >= feedbackHideTime)
+            {
+                feedbackText.gameObject.SetActive(false);
+            }
+        }
+
+        private void WireButtons()
+        {
+            if (options == null)
+            {
+                return;
+            }
+
+            for (var i = 0; i < options.Length; i++)
+            {
+                var option = options[i];
+                if (option == null || option.button == null)
+                {
+                    continue;
+                }
+
+                var capturedPreset = option.preset;
+                option.button.onClick.RemoveAllListeners();
+                option.button.onClick.AddListener(() => OnPresetClicked(capturedPreset));
+            }
+        }
+
+        private void FillDescriptions()
+        {
+            if (manager == null || options == null)
+            {
+                return;
+            }
+
+            for (var i = 0; i < options.Length; i++)
+            {
+                var option = options[i];
+                if (option == null)
+                {
+                    continue;
+                }
+
+                if (option.titleText != null)
+                {
+                    option.titleText.text = option.preset.ToString();
+                }
+
+                if (option.descriptionText != null)
+                {
+                    option.descriptionText.text = manager.GetDescription(option.preset);
+                }
+            }
+        }
+
+        private void OnPresetClicked(GraphicsPreset preset)
+        {
+            if (manager == null)
+            {
+                Debug.LogWarning("[GraphicsUI] GraphicsSettingsManager not found.");
+                return;
+            }
+
+            var previous = manager.SelectedPreset;
+            manager.SetPreset(preset, showUserMessage: true);
+
+            if (feedbackText == null)
+            {
+                return;
+            }
+
+            if (preset == GraphicsPreset.Auto)
+            {
+                feedbackText.text = "Auto selected the best settings for your device.";
+            }
+            else
+            {
+                feedbackText.text = "Graphics quality updated.";
+                if (preset == GraphicsPreset.High && manager.GetResolvedTierForPreset(GraphicsPreset.Auto) != GraphicsQualityTier.High)
+                {
+                    feedbackText.text = "High graphics may reduce performance on some devices.";
+                }
+            }
+
+            if (previous != preset || preset == GraphicsPreset.Auto)
+            {
+                feedbackText.gameObject.SetActive(true);
+                feedbackHideTime = Time.unscaledTime + Mathf.Max(0.75f, feedbackDuration);
+            }
+        }
+
+        private void HandleSettingsApplied(GraphicsPreset selectedPreset, GraphicsQualityTier resolvedTier)
+        {
+            if (options == null)
+            {
+                return;
+            }
+
+            for (var i = 0; i < options.Length; i++)
+            {
+                var option = options[i];
+                if (option == null)
+                {
+                    continue;
+                }
+
+                var isSelected = option.preset == selectedPreset;
+                var bgColor = isSelected ? selectedColor : unselectedColor;
+                var txtColor = isSelected ? selectedTextColor : unselectedTextColor;
+
+                if (option.highlightTargets != null)
+                {
+                    for (var h = 0; h < option.highlightTargets.Length; h++)
+                    {
+                        var g = option.highlightTargets[h];
+                        if (g != null)
+                        {
+                            g.color = bgColor;
+                        }
+                    }
+                }
+
+                if (option.titleText != null)
+                {
+                    option.titleText.color = txtColor;
+                }
+
+                if (option.descriptionText != null)
+                {
+                    option.descriptionText.color = txtColor;
+
+                    if (selectedPreset == GraphicsPreset.Auto && option.preset == GraphicsPreset.Auto)
+                    {
+                        option.descriptionText.text =
+                            $"{manager.GetDescription(GraphicsPreset.Auto)}\nActive tier: {resolvedTier}.";
+                    }
+                    else
+                    {
+                        option.descriptionText.text = manager.GetDescription(option.preset);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Settings/GraphicsSettingsUI.cs.meta
+++ b/Assets/Scripts/Settings/GraphicsSettingsUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0fe34f4909884842b710cb2760fc10aa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -170,9 +170,9 @@ function resolveDefaultPixelRatioCap() {
   return window.innerWidth <= 1366 ? 1.5 : 2;
 }
 
-function detectPreferredFrameRateId() {
+function detectAutoGraphicsPreset() {
   if (typeof window === 'undefined' || typeof navigator === 'undefined') {
-    return 'fhd60';
+    return 'medium';
   }
   const coarsePointer = detectCoarsePointer();
   const ua = navigator.userAgent ?? '';
@@ -184,41 +184,49 @@ function detectPreferredFrameRateId() {
   const lowRefresh = detectLowRefreshDisplay();
   const highRefresh = detectHighRefreshDisplay();
   const rendererTier = classifyRendererTier(readGraphicsRendererString());
+  const maxTexture = Number.isFinite(SystemInfoMaxTextureSize()) ? SystemInfoMaxTextureSize() : 4096;
+  let score = 0;
 
   if (lowRefresh) {
-    return 'hd50';
+    score -= 20;
+  }
+  if (highRefresh) score += 16;
+  if (deviceMemory !== null) {
+    if (deviceMemory >= 8) score += 24;
+    else if (deviceMemory >= 6) score += 14;
+    else if (deviceMemory >= 4) score += 6;
+    else score -= 8;
+  }
+  if (hardwareConcurrency >= 8) score += 16;
+  else if (hardwareConcurrency >= 6) score += 9;
+  else if (hardwareConcurrency <= 4) score -= 8;
+
+  if (rendererTier === 'desktopHigh') score += 20;
+  else if (rendererTier === 'desktopMid') score += 8;
+  else if (rendererTier === 'mobile') score += 4;
+
+  if (maxTexture >= 16384) score += 8;
+  else if (maxTexture >= 8192) score += 4;
+
+  if ((isMobileUA || coarsePointer || isTouch || rendererTier === 'mobile') && !highRefresh) {
+    score -= 4;
   }
 
-  if (isMobileUA || coarsePointer || isTouch || rendererTier === 'mobile') {
-    if ((deviceMemory !== null && deviceMemory <= 4) || hardwareConcurrency <= 4) {
-      return 'hd50';
-    }
-    if (highRefresh && hardwareConcurrency >= 8 && (deviceMemory == null || deviceMemory >= 6)) {
-      return 'uhd120';
-    }
-    if (
-      highRefresh ||
-      hardwareConcurrency >= 6 ||
-      (deviceMemory != null && deviceMemory >= 6)
-    ) {
-      return 'qhd90';
-    }
-    return 'fhd60';
-  }
+  if (score >= 52) return 'high';
+  if (score >= 26) return 'medium';
+  return 'low';
+}
 
-  if (rendererTier === 'desktopHigh' && highRefresh) {
-    return 'ultra144';
+function SystemInfoMaxTextureSize() {
+  if (typeof document === 'undefined') return 0;
+  try {
+    const canvas = document.createElement('canvas');
+    const gl = canvas.getContext('webgl2') || canvas.getContext('webgl');
+    if (!gl) return 0;
+    return Number(gl.getParameter(gl.MAX_TEXTURE_SIZE) || 0);
+  } catch (_error) {
+    return 0;
   }
-
-  if (rendererTier === 'desktopHigh' || hardwareConcurrency >= 8) {
-    return 'uhd120';
-  }
-
-  if (rendererTier === 'desktopMid') {
-    return 'qhd90';
-  }
-
-  return 'fhd60';
 }
 
 const MODEL_SCALE = 0.75;
@@ -467,19 +475,6 @@ const CHAIR_MODEL_URLS = [
 
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
 const BASIS_TRANSCODER_PATH = 'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/';
-const HDRI_RESOLUTION_STORAGE_KEY = 'texasHoldemHdriResolution';
-const HDRI_RESOLUTION_OPTIONS = Object.freeze([
-  { id: '8k', label: '8K' },
-  { id: '6k', label: '6K' },
-  { id: '4k', label: '4K' }
-]);
-const HDRI_RESOLUTION_OPTION_MAP = Object.freeze(
-  HDRI_RESOLUTION_OPTIONS.reduce((acc, option) => {
-    acc[option.id] = option;
-    return acc;
-  }, {})
-);
-const HDRI_RESOLUTION_LADDER = Object.freeze(['8k', '6k', '4k', '2k', '1k']);
 const DEFAULT_HDRI_RESOLUTION_ID = '4k';
 const HDRI_ENV_CACHE_LIMIT = 4;
 const DEFAULT_TABLE_THEME_ID = TEXAS_TABLE_THEME_OPTIONS[0]?.id ?? 'murlan-default';
@@ -642,70 +637,50 @@ const AI_ACTION_DELAY_JITTER_MS = 700;
 const CARD_HIGHLIGHT_COLOR = '#facc15';
 const CARD_HIGHLIGHT = new THREE.Color(CARD_HIGHLIGHT_COLOR);
 const CARD_EMISSIVE_OFF = new THREE.Color(0x000000);
-const FRAME_RATE_STORAGE_KEY = 'texasHoldemFrameRate';
-const FRAME_RATE_OPTIONS = Object.freeze([
+const GRAPHICS_PRESET_STORAGE_KEY = 'texasHoldemGraphicsPreset';
+const GRAPHICS_PRESET_OPTIONS = Object.freeze([
   {
-    id: 'hd50',
-    label: 'HD Performance (50 Hz)',
-    fps: 50,
-    renderScale: 1,
-    pixelRatioCap: 1.4,
-    resolution: 'HD render • DPR 1.4 cap',
-    description: 'Minimum HD output for battery saver and 50–60 Hz displays.'
+    id: 'auto',
+    label: 'Auto',
+    description: 'Recommended. Automatically chooses the best graphics for your phone.'
   },
   {
-    id: 'fhd60',
-    label: 'Full HD (60 Hz)',
-    fps: 60,
-    renderScale: 1.1,
-    pixelRatioCap: 1.5,
-    resolution: 'Full HD render • DPR 1.5 cap',
-    description: '1080p-focused profile that mirrors the Snooker frame pacing.'
+    id: 'low',
+    label: 'Low',
+    description: 'Best for battery life and lower-end phones.'
   },
   {
-    id: 'qhd90',
-    label: 'Quad HD (90 Hz)',
-    fps: 90,
-    renderScale: 1.25,
-    pixelRatioCap: 1.7,
-    resolution: 'QHD render • DPR 1.7 cap',
-    description: 'Sharper 1440p render for capable 90 Hz mobile and desktop GPUs.'
+    id: 'medium',
+    label: 'Medium',
+    description: 'Balanced visuals and smooth performance.'
   },
   {
-    id: 'uhd120',
-    label: 'Ultra HD (120 Hz)',
-    fps: 120,
-    renderScale: 1.35,
-    pixelRatioCap: 2,
-    resolution: 'Ultra HD render • DPR 2.0 cap',
-    description: '4K-oriented profile for 120 Hz flagships and desktops.'
-  },
-  {
-    id: 'ultra144',
-    label: 'Ultra HD+ (144 Hz)',
-    fps: 144,
-    renderScale: 1.5,
-    pixelRatioCap: 2.2,
-    resolution: 'Ultra HD+ render • DPR 2.2 cap',
-    description: 'Maximum clarity preset that prioritizes UHD detail at 144 Hz.'
+    id: 'high',
+    label: 'High',
+    description: 'Best visuals for powerful phones.'
   }
 ]);
-const DEFAULT_FRAME_RATE_ID = 'fhd60';
-const FRAME_RATE_TO_HDRI_RESOLUTION_MAP = Object.freeze({
-  hd50: '4k',
-  fhd60: '4k',
-  qhd90: '6k',
-  uhd120: '8k',
-  ultra144: '8k'
-});
-
-function resolveHdriResolutionForGraphics(frameRateOptionId) {
-  const mapped = FRAME_RATE_TO_HDRI_RESOLUTION_MAP[frameRateOptionId];
-  if (mapped && HDRI_RESOLUTION_OPTION_MAP[mapped]) {
-    return mapped;
+const DEFAULT_GRAPHICS_PRESET_ID = 'auto';
+const GRAPHICS_PROFILE_BY_PRESET = Object.freeze({
+  low: {
+    fps: 60,
+    renderScale: 0.7,
+    pixelRatioCap: 1.2,
+    hdriResolutions: ['2k', '1k']
+  },
+  medium: {
+    fps: 90,
+    renderScale: 0.92,
+    pixelRatioCap: 1.5,
+    hdriResolutions: ['4k', '2k', '1k']
+  },
+  high: {
+    fps: 120,
+    renderScale: 1.2,
+    pixelRatioCap: 2,
+    hdriResolutions: ['6k', '4k', '2k', '1k']
   }
-  return DEFAULT_HDRI_RESOLUTION_ID;
-}
+});
 
 const POT_SCATTER_LAYOUT = Object.freeze({
   perRow: 24,
@@ -815,8 +790,7 @@ const CUSTOMIZATION_SECTIONS = [
   { key: 'tableWood', label: 'Table Wood', options: TABLE_WOOD_OPTIONS },
   { key: 'tableCloth', label: 'Table Cloth', options: TABLE_CLOTH_OPTIONS },
   { key: 'tableShape', label: 'Table Shape', options: TABLE_SHAPE_OPTIONS },
-  { key: 'cards', label: 'Cards', options: CARD_THEMES },
-  { key: 'environmentHdri', label: 'HDR Environment', options: TEXAS_HDRI_OPTIONS }
+  { key: 'cards', label: 'Cards', options: CARD_THEMES }
 ];
 
 const NON_DIAMOND_SHAPE_INDEX = (() => {
@@ -3142,44 +3116,42 @@ function TexasHoldemArena({ search }) {
         }),
     [appearance.tableTheme, texasInventory]
   );
-  const [frameRateId, setFrameRateId] = useState(() => {
+  const [graphicsPresetId, setGraphicsPresetId] = useState(() => {
     if (typeof window !== 'undefined') {
-      const stored = window.localStorage?.getItem(FRAME_RATE_STORAGE_KEY);
-      if (stored && FRAME_RATE_OPTIONS.some((opt) => opt.id === stored)) {
+      const stored = window.localStorage?.getItem(GRAPHICS_PRESET_STORAGE_KEY);
+      if (stored && GRAPHICS_PRESET_OPTIONS.some((opt) => opt.id === stored)) {
         return stored;
       }
-      const detected = detectPreferredFrameRateId();
-      if (detected && FRAME_RATE_OPTIONS.some((opt) => opt.id === detected)) {
-        return detected;
-      }
     }
-    return DEFAULT_FRAME_RATE_ID;
+    return DEFAULT_GRAPHICS_PRESET_ID;
   });
-  const activeFrameRateOption = useMemo(
-    () => FRAME_RATE_OPTIONS.find((opt) => opt.id === frameRateId) ?? FRAME_RATE_OPTIONS[0],
-    [frameRateId]
+  const resolvedGraphicsTierId = useMemo(
+    () => (graphicsPresetId === 'auto' ? detectAutoGraphicsPreset() : graphicsPresetId),
+    [graphicsPresetId]
   );
-  const hdriResolutionId = useMemo(
-    () => resolveHdriResolutionForGraphics(frameRateId),
-    [frameRateId]
+  const activeGraphicsProfile = useMemo(
+    () => GRAPHICS_PROFILE_BY_PRESET[resolvedGraphicsTierId] ?? GRAPHICS_PROFILE_BY_PRESET.medium,
+    [resolvedGraphicsTierId]
   );
   const preferredHdriResolutions = useMemo(() => {
-    const normalized = HDRI_RESOLUTION_OPTION_MAP[hdriResolutionId]?.id || DEFAULT_HDRI_RESOLUTION_ID;
-    const startIndex = HDRI_RESOLUTION_LADDER.indexOf(normalized);
-    if (startIndex < 0) return [DEFAULT_HDRI_RESOLUTION_ID, '2k', '1k'];
-    const fallbackResolutions = HDRI_RESOLUTION_LADDER.slice(startIndex).filter(Boolean);
+    const baseResolutions = Array.isArray(activeGraphicsProfile?.hdriResolutions)
+      ? activeGraphicsProfile.hdriResolutions
+      : [DEFAULT_HDRI_RESOLUTION_ID, '2k', '1k'];
+    const fallbackResolutions = baseResolutions.filter(Boolean);
+    if (!fallbackResolutions.includes(DEFAULT_HDRI_RESOLUTION_ID)) fallbackResolutions.push(DEFAULT_HDRI_RESOLUTION_ID);
     if (!fallbackResolutions.includes('2k')) fallbackResolutions.push('2k');
     if (!fallbackResolutions.includes('1k')) fallbackResolutions.push('1k');
     return fallbackResolutions;
-  }, [hdriResolutionId]);
+  }, [activeGraphicsProfile]);
+  const activeHdriResolutionId = preferredHdriResolutions[0] || DEFAULT_HDRI_RESOLUTION_ID;
   const preferredHdriResolutionsRef = useRef(preferredHdriResolutions);
   const loadedHdriResolutionIdRef = useRef(null);
   useEffect(() => {
     preferredHdriResolutionsRef.current = preferredHdriResolutions;
   }, [preferredHdriResolutions]);
   const frameQualityProfile = useMemo(() => {
-    const option = activeFrameRateOption ?? FRAME_RATE_OPTIONS[0];
-    const fallback = FRAME_RATE_OPTIONS[0];
+    const option = activeGraphicsProfile ?? GRAPHICS_PROFILE_BY_PRESET.medium;
+    const fallback = GRAPHICS_PROFILE_BY_PRESET.medium;
     const fps =
       Number.isFinite(option?.fps) && option.fps > 0
         ? option.fps
@@ -3188,27 +3160,27 @@ function TexasHoldemArena({ search }) {
           : 60;
     const renderScale =
       typeof option?.renderScale === 'number' && Number.isFinite(option.renderScale)
-        ? THREE.MathUtils.clamp(option.renderScale, 1, 1.6)
+        ? THREE.MathUtils.clamp(option.renderScale, 0.7, 1.25)
         : 1;
     const pixelRatioCap =
       typeof option?.pixelRatioCap === 'number' && Number.isFinite(option.pixelRatioCap)
         ? Math.max(1, option.pixelRatioCap)
         : resolveDefaultPixelRatioCap();
     return {
-      id: option?.id ?? DEFAULT_FRAME_RATE_ID,
+      id: resolvedGraphicsTierId,
       fps,
       renderScale,
       pixelRatioCap
     };
-  }, [activeFrameRateOption]);
+  }, [activeGraphicsProfile, resolvedGraphicsTierId]);
   const frameQualityRef = useRef(frameQualityProfile);
   useEffect(() => {
     frameQualityRef.current = frameQualityProfile;
   }, [frameQualityProfile]);
   const resolvedFrameTiming = useMemo(() => {
     const fallbackFps =
-      Number.isFinite(FRAME_RATE_OPTIONS[0]?.fps) && FRAME_RATE_OPTIONS[0].fps > 0
-        ? FRAME_RATE_OPTIONS[0].fps
+      Number.isFinite(GRAPHICS_PROFILE_BY_PRESET.medium?.fps) && GRAPHICS_PROFILE_BY_PRESET.medium.fps > 0
+        ? GRAPHICS_PROFILE_BY_PRESET.medium.fps
         : 60;
     const fps =
       Number.isFinite(frameQualityProfile?.fps) && frameQualityProfile.fps > 0
@@ -3216,30 +3188,23 @@ function TexasHoldemArena({ search }) {
         : fallbackFps;
     const targetMs = 1000 / fps;
     return {
-      id: frameQualityProfile?.id ?? FRAME_RATE_OPTIONS[0]?.id ?? DEFAULT_FRAME_RATE_ID,
+      id: graphicsPresetId,
       fps,
       targetMs,
       maxMs: targetMs * FRAME_TIME_CATCH_UP_MULTIPLIER
     };
-  }, [frameQualityProfile]);
+  }, [frameQualityProfile, graphicsPresetId]);
   const frameTimingRef = useRef(resolvedFrameTiming);
   useEffect(() => {
     frameTimingRef.current = resolvedFrameTiming;
   }, [resolvedFrameTiming]);
   useEffect(() => {
     try {
-      window.localStorage?.setItem(FRAME_RATE_STORAGE_KEY, frameRateId);
+      window.localStorage?.setItem(GRAPHICS_PRESET_STORAGE_KEY, graphicsPresetId);
     } catch (error) {
       console.warn("Failed to persist Texas Hold'em graphics", error);
     }
-  }, [frameRateId]);
-  useEffect(() => {
-    try {
-      window.localStorage?.setItem(HDRI_RESOLUTION_STORAGE_KEY, hdriResolutionId);
-    } catch (error) {
-      console.warn("Failed to persist Texas Hold'em HDRI resolution", error);
-    }
-  }, [hdriResolutionId]);
+  }, [graphicsPresetId]);
   const [configOpen, setConfigOpen] = useState(false);
   const timerRef = useRef(null);
   const turnIntervalRef = useRef(null);
@@ -4084,8 +4049,7 @@ function TexasHoldemArena({ search }) {
         applyThemeToMesh(mesh, { rank: 'A', suit: 'S' });
       }
     });
-    const currentHdriResolutionId =
-      HDRI_RESOLUTION_OPTION_MAP[hdriResolutionId]?.id || DEFAULT_HDRI_RESOLUTION_ID;
+    const currentHdriResolutionId = activeHdriResolutionId;
     if (
       environmentOption &&
       (
@@ -4096,7 +4060,7 @@ function TexasHoldemArena({ search }) {
     ) {
       void applyHdriEnvironment(environmentOption);
     }
-  }, [appearance, effectivePlayerCount, hdriResolutionId]);
+  }, [appearance, effectivePlayerCount, activeHdriResolutionId]);
 
   const renderPreview = useCallback((type, option) => {
     switch (type) {
@@ -4294,7 +4258,7 @@ function TexasHoldemArena({ search }) {
     const pixelRatioCap = quality?.pixelRatioCap ?? resolveDefaultPixelRatioCap();
     const renderScale =
       typeof quality?.renderScale === 'number' && Number.isFinite(quality.renderScale)
-        ? THREE.MathUtils.clamp(quality.renderScale, 1, 1.6)
+        ? THREE.MathUtils.clamp(quality.renderScale, 0.7, 1.25)
         : 1;
     renderer.setPixelRatio(Math.min(pixelRatioCap, dpr));
     renderer.setSize(host.clientWidth * renderScale, host.clientHeight * renderScale, false);
@@ -4314,8 +4278,7 @@ function TexasHoldemArena({ search }) {
       if (!activeVariant) return;
       const activeVariantId = activeVariant.id || activeVariant.assetId;
       const currentVariantId = hdriVariantRef.current?.id || hdriVariantRef.current?.assetId;
-      const currentHdriResolutionId =
-        HDRI_RESOLUTION_OPTION_MAP[hdriResolutionId]?.id || DEFAULT_HDRI_RESOLUTION_ID;
+      const currentHdriResolutionId = activeHdriResolutionId;
       if (
         envTextureRef.current &&
         activeVariantId &&
@@ -4380,7 +4343,7 @@ function TexasHoldemArena({ search }) {
       hdriVariantRef.current = activeVariant;
       loadedHdriResolutionIdRef.current = currentHdriResolutionId;
     },
-    [hdriResolutionId]
+    [activeHdriResolutionId]
   );
 
   useEffect(() => {
@@ -6468,43 +6431,21 @@ function TexasHoldemArena({ search }) {
               <div>
                 <p className="text-[10px] uppercase tracking-[0.35em] text-white/70">Graphics</p>
                 <p className="mt-1 text-[0.7rem] text-white/60">
-                  Graphics preset now auto-syncs HDRI resolution so table lighting quality always matches menu quality.
-                </p>
-              </div>
-              <div className="space-y-2">
-                <p className="text-[10px] uppercase tracking-[0.2em] text-white/60">HDRI Resolution</p>
-                <div className="grid grid-cols-3 gap-2">
-                  {HDRI_RESOLUTION_OPTIONS.map((option) => {
-                    const active = option.id === hdriResolutionId;
-                    return (
-                      <button
-                        key={option.id}
-                        type="button"
-                        disabled
-                        aria-pressed={active}
-                        className={`rounded-xl border px-2 py-2 text-center text-[11px] font-semibold uppercase tracking-[0.22em] transition ${
-                          active
-                            ? 'border-sky-300 bg-sky-300/15 text-sky-100 shadow-[0_0_12px_rgba(125,211,252,0.35)]'
-                            : 'border-white/10 bg-white/5 text-white/40'
-                        }`}
-                      >
-                        {option.label}
-                      </button>
-                    );
-                  })}
-                </div>
-                <p className="text-[10px] uppercase tracking-[0.2em] text-white/45">
-                  Auto-selected from your active Graphics profile.
+                  Choose Auto, Low, Medium, or High. Changes apply instantly.
                 </p>
               </div>
               <div className="grid gap-2">
-                {FRAME_RATE_OPTIONS.map((option) => {
-                  const active = option.id === frameRateId;
+                {GRAPHICS_PRESET_OPTIONS.map((option) => {
+                  const active = option.id === graphicsPresetId;
+                  const resolvedTag =
+                    option.id === 'auto'
+                      ? `Active tier: ${(resolvedGraphicsTierId || 'medium').toUpperCase()}`
+                      : '';
                   return (
                     <button
                       key={option.id}
                       type="button"
-                      onClick={() => setFrameRateId(option.id)}
+                      onClick={() => setGraphicsPresetId(option.id)}
                       aria-pressed={active}
                       className={`w-full rounded-2xl border px-3 py-2 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
                         active
@@ -6515,7 +6456,9 @@ function TexasHoldemArena({ search }) {
                       <span className="flex items-center justify-between gap-2">
                         <span className="text-[11px] font-semibold uppercase tracking-[0.26em] text-white">{option.label}</span>
                         <span className="text-[11px] font-semibold tracking-wide text-sky-100">
-                          {option.resolution ? `${option.resolution} • ${option.fps} FPS` : `${option.fps} FPS`}
+                          {option.id === 'auto'
+                            ? `${resolvedGraphicsTierId.toUpperCase()}`
+                            : `${GRAPHICS_PROFILE_BY_PRESET[option.id]?.fps ?? 60} FPS`}
                         </span>
                       </span>
                       {option.description ? (
@@ -6523,10 +6466,22 @@ function TexasHoldemArena({ search }) {
                           {option.description}
                         </span>
                       ) : null}
+                      {resolvedTag ? (
+                        <span className="mt-1 block text-[10px] uppercase tracking-[0.2em] text-emerald-300/90">
+                          {resolvedTag}
+                        </span>
+                      ) : null}
                     </button>
                   );
                 })}
               </div>
+              <p className="text-[10px] uppercase tracking-[0.2em] text-white/55">
+                {graphicsPresetId === 'auto'
+                  ? 'Auto selected the best settings for your device.'
+                  : graphicsPresetId === 'high' && resolvedGraphicsTierId !== 'high'
+                    ? 'High graphics may reduce performance on some devices.'
+                    : 'Graphics quality updated.'}
+              </p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
### Motivation

- Consolidate device-aware graphics selection across Unity and the web client so users can choose `Auto`, `Low`, `Medium`, or `High` presets and get sensible defaults per hardware.
- Provide a mobile-first `GraphicsSettingsManager` in Unity to persist user choice, resolve `Auto` via heuristics, and apply render/quality changes at runtime.
- Replace the previous frame-rate-centric UI on the web with a unified graphics preset flow that maps to FPS, render scale and HDRI resolution selection.

### Description

- Added Unity runtime graphics stack: `GraphicsSettingsManager`, `GraphicsSettingsUI`, `GraphicsPreset` enum, and `GraphicsQualityTier` enum to persist presets (`PlayerPrefs` keys `graphics_preset` and `graphics_auto_resolved_tier`), resolve `Auto` with multi-factor heuristics, and apply quality settings including URP `renderScale` or `ScalableBufferManager` fallback.
- Implemented device scoring functions (`ScoreDeviceAndPickTier`, `ScoreGpuLevel`, `ScoreGraphicsApiSupport`) and safety clamping for render scale, LOD, textures, shadows, AA, particle budgets, and target FPS.
- Added a webapp UI migration in `TexasHoldemArena.jsx` that replaces frame-rate options with preset options (`GRAPHICS_PRESET_OPTIONS`) and storage key `texasHoldemGraphicsPreset`, implements `detectAutoGraphicsPreset()` scoring, includes `SystemInfoMaxTextureSize()` helper, and maps presets to profile values in `GRAPHICS_PROFILE_BY_PRESET` (fps, `renderScale`, `pixelRatioCap`, HDRI candidates).
- Updated renderer application logic to clamp `renderScale` to safer ranges and to choose HDRI resolutions from the active profile; removed the old HDRI selection ladder and frame-rate-only mappings.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb6dac9ab08329bd002909f5935baf)