### PR TITLE
Add unified mobile-first graphics settings (Unity manager + web UI integration)

### DIFF
--- a/Assets/Scripts/Settings.meta
+++ b/Assets/Scripts/Settings.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6a00f56a6f624cc7ae2a4ee02ecf7f4d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Settings/GraphicsPreset.cs
+++ b/Assets/Scripts/Settings/GraphicsPreset.cs
@@ -1,0 +1,14 @@
+namespace TonPlaygram.Settings
+{
+    /// <summary>
+    /// User-facing option selected from the settings menu.
+    /// Auto is persisted as a choice, but can map to any applied quality tier.
+    /// </summary>
+    public enum GraphicsPreset
+    {
+        Auto = 0,
+        Low = 1,
+        Medium = 2,
+        High = 3,
+    }
+}

--- a/Assets/Scripts/Settings/GraphicsPreset.cs.meta
+++ b/Assets/Scripts/Settings/GraphicsPreset.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2a8ccf8b7d1f4c91a2d621625a50436b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Settings/GraphicsQualityTier.cs
+++ b/Assets/Scripts/Settings/GraphicsQualityTier.cs
@@ -1,0 +1,12 @@
+namespace TonPlaygram.Settings
+{
+    /// <summary>
+    /// Internal quality tier that is actually applied to rendering and quality systems.
+    /// </summary>
+    public enum GraphicsQualityTier
+    {
+        Low = 0,
+        Medium = 1,
+        High = 2,
+    }
+}

--- a/Assets/Scripts/Settings/GraphicsQualityTier.cs.meta
+++ b/Assets/Scripts/Settings/GraphicsQualityTier.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8be7e5b8e45a418cbe6ea3a6dfa40d35
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Settings/GraphicsSettingsManager.cs
+++ b/Assets/Scripts/Settings/GraphicsSettingsManager.cs
@@ -1,0 +1,413 @@
+using System;
+using UnityEngine;
+using UnityEngine.Rendering;
+
+namespace TonPlaygram.Settings
+{
+    /// <summary>
+    /// Central mobile-first graphics settings manager.
+    ///
+    /// Responsibilities:
+    /// - Persist and load the user-selected GraphicsPreset.
+    /// - Resolve Auto into an internal tier via hardware heuristics.
+    /// - Apply full-scene quality changes immediately (FPS + render scale + quality knobs).
+    /// - Expose events so UI and gameplay systems can react without tight coupling.
+    ///
+    /// Resolution strategy:
+    /// - URP: set renderScale on the active URP pipeline asset (reflection, no hard package dependency).
+    /// - Non-URP fallback: use ScalableBufferManager.ResizeBuffers(scale, scale) to reduce internal
+    ///   render buffer size while keeping display/UI resolution readable.
+    /// </summary>
+    public sealed class GraphicsSettingsManager : MonoBehaviour
+    {
+        private const string SavedPresetKey = "graphics_preset";
+        private const string SavedAutoResolvedTierKey = "graphics_auto_resolved_tier";
+
+        // Optional singleton convenience for simple projects.
+        public static GraphicsSettingsManager Instance { get; private set; }
+
+        public GraphicsPreset SelectedPreset { get; private set; } = GraphicsPreset.Auto;
+        public GraphicsQualityTier AppliedTier { get; private set; } = GraphicsQualityTier.Medium;
+
+        public event Action<GraphicsPreset, GraphicsQualityTier> OnGraphicsSettingsApplied;
+
+        /// <summary>
+        /// Optional hook for game-specific extras (e.g. post-processing volumes, particle managers)
+        /// that are not globally controllable via QualitySettings alone.
+        /// </summary>
+        public event Action<GraphicsQualityTier> OnCustomQualityTierApplied;
+
+        [Header("Render Scale (clamped at runtime)")]
+        [SerializeField, Range(0.5f, 1.0f)] private float lowRenderScale = 0.70f;
+        [SerializeField, Range(0.7f, 1.1f)] private float mediumRenderScale = 0.90f;
+        [SerializeField, Range(0.9f, 1.4f)] private float highRenderScale = 1.10f;
+
+        [Header("Frame Targets")]
+        [SerializeField] private int lowTargetFps = 60;
+        [SerializeField] private int mediumTargetFps = 90;
+        [SerializeField] private int highTargetFps = 120;
+
+        [Header("Optional UI Messages")]
+        [SerializeField] private bool logFeedbackMessages = true;
+
+        private static readonly string[] PresetDescriptions =
+        {
+            "Recommended. Automatically chooses the best graphics for your phone.",
+            "Best for battery life and lower-end phones.",
+            "Balanced visuals and smooth performance.",
+            "Best visuals for powerful phones.",
+        };
+
+        private void Awake()
+        {
+            if (Instance != null && Instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            Instance = this;
+            DontDestroyOnLoad(gameObject);
+
+            Application.targetFrameRate = -1;
+            QualitySettings.vSyncCount = 0; // Mobile should use explicit frame cap.
+
+            LoadAndApplyOnBoot();
+        }
+
+        public string GetDescription(GraphicsPreset preset)
+        {
+            return PresetDescriptions[(int)preset];
+        }
+
+        public void SetPreset(GraphicsPreset preset, bool showUserMessage = true)
+        {
+            SelectedPreset = preset;
+
+            var resolvedTier = preset == GraphicsPreset.Auto
+                ? ResolveAutoTierAndCache()
+                : PresetToTier(preset);
+
+            ApplyTierInternal(resolvedTier);
+            SaveSelection();
+
+            if (showUserMessage)
+            {
+                EmitUserFeedbackMessage(preset, resolvedTier);
+            }
+
+            OnGraphicsSettingsApplied?.Invoke(SelectedPreset, AppliedTier);
+        }
+
+        public GraphicsQualityTier GetResolvedTierForPreset(GraphicsPreset preset)
+        {
+            return preset == GraphicsPreset.Auto ? ResolveAutoTierNoSideEffects() : PresetToTier(preset);
+        }
+
+        private void LoadAndApplyOnBoot()
+        {
+            if (PlayerPrefs.HasKey(SavedPresetKey))
+            {
+                SelectedPreset = (GraphicsPreset)Mathf.Clamp(PlayerPrefs.GetInt(SavedPresetKey, 0), 0, 3);
+            }
+            else
+            {
+                // First launch: default to Auto for best out-of-box experience.
+                SelectedPreset = GraphicsPreset.Auto;
+                PlayerPrefs.SetInt(SavedPresetKey, (int)SelectedPreset);
+                PlayerPrefs.Save();
+            }
+
+            var tier = SelectedPreset == GraphicsPreset.Auto
+                ? ResolveAutoTierAndCache()
+                : PresetToTier(SelectedPreset);
+
+            ApplyTierInternal(tier);
+            OnGraphicsSettingsApplied?.Invoke(SelectedPreset, AppliedTier);
+        }
+
+        private void SaveSelection()
+        {
+            PlayerPrefs.SetInt(SavedPresetKey, (int)SelectedPreset);
+            PlayerPrefs.SetInt(SavedAutoResolvedTierKey, (int)AppliedTier);
+            PlayerPrefs.Save();
+        }
+
+        private GraphicsQualityTier PresetToTier(GraphicsPreset preset)
+        {
+            switch (preset)
+            {
+                case GraphicsPreset.Low:
+                    return GraphicsQualityTier.Low;
+                case GraphicsPreset.Medium:
+                    return GraphicsQualityTier.Medium;
+                case GraphicsPreset.High:
+                    return GraphicsQualityTier.High;
+                default:
+                    return GraphicsQualityTier.Medium;
+            }
+        }
+
+        private GraphicsQualityTier ResolveAutoTierNoSideEffects()
+        {
+            return ScoreDeviceAndPickTier();
+        }
+
+        private GraphicsQualityTier ResolveAutoTierAndCache()
+        {
+            var tier = ScoreDeviceAndPickTier();
+            PlayerPrefs.SetInt(SavedAutoResolvedTierKey, (int)tier);
+            return tier;
+        }
+
+        private GraphicsQualityTier ScoreDeviceAndPickTier()
+        {
+            // Heuristic scoring. Conservative by design for thermal stability.
+            // Unity does not expose reliable universal thermal APIs across all Android/iOS versions,
+            // so we infer risk via battery state + power-saving hints + hardware headroom.
+
+            var score = 0;
+
+            var refreshRate = GetScreenRefreshRate();
+            if (refreshRate >= 120) score += 25;
+            else if (refreshRate >= 90) score += 15;
+            else if (refreshRate >= 60) score += 8;
+            else score += 2;
+
+            var ramMb = SystemInfo.systemMemorySize;
+            if (ramMb >= 12000) score += 25;
+            else if (ramMb >= 8000) score += 18;
+            else if (ramMb >= 5000) score += 10;
+            else if (ramMb >= 3000) score += 4;
+
+            var cpuCores = SystemInfo.processorCount;
+            if (cpuCores >= 8) score += 18;
+            else if (cpuCores >= 6) score += 12;
+            else if (cpuCores >= 4) score += 6;
+
+            var cpuFreq = SystemInfo.processorFrequency;
+            if (cpuFreq >= 2800) score += 10;
+            else if (cpuFreq >= 2200) score += 6;
+            else if (cpuFreq >= 1600) score += 3;
+
+            score += ScoreGpuLevel();
+            score += ScoreGraphicsApiSupport();
+
+            // Resolution pressure: very high internal pixel count increases GPU cost.
+            var pixelCount = Screen.width * Screen.height;
+            if (pixelCount >= 3000000) score -= 8;      // ~1440p+
+            else if (pixelCount >= 2073600) score -= 4; // ~1080p+
+
+            // Conservative battery sensitivity. If unplugged + low battery, step down.
+            // (No direct universal thermal signal in Unity runtime APIs.)
+            if (SystemInfo.batteryStatus == BatteryStatus.Discharging)
+            {
+                if (SystemInfo.batteryLevel >= 0f && SystemInfo.batteryLevel <= 0.15f)
+                {
+                    score -= 18;
+                }
+                else if (SystemInfo.batteryLevel <= 0.30f)
+                {
+                    score -= 8;
+                }
+            }
+
+            // Safety fallback when key detection data is missing.
+            if (ramMb <= 0 || cpuCores <= 0)
+            {
+                score = Mathf.Min(score, 50);
+            }
+
+            if (score >= 70) return GraphicsQualityTier.High;
+            if (score >= 42) return GraphicsQualityTier.Medium;
+            return GraphicsQualityTier.Low;
+        }
+
+        private int ScoreGpuLevel()
+        {
+            // Practical heuristic based on GPU model strings available in Unity.
+            var gpuName = SystemInfo.graphicsDeviceName;
+            if (string.IsNullOrEmpty(gpuName)) return 0;
+
+            gpuName = gpuName.ToLowerInvariant();
+
+            // High-end families
+            if (gpuName.Contains("adreno 7") || gpuName.Contains("adreno 8") ||
+                gpuName.Contains("mali-g7") || gpuName.Contains("mali-g8") ||
+                gpuName.Contains("apple a17") || gpuName.Contains("apple a18") ||
+                gpuName.Contains("apple m1") || gpuName.Contains("apple m2"))
+            {
+                return 18;
+            }
+
+            // Mid-tier families
+            if (gpuName.Contains("adreno 6") || gpuName.Contains("mali-g5") || gpuName.Contains("mali-g6") ||
+                gpuName.Contains("apple a14") || gpuName.Contains("apple a15") || gpuName.Contains("apple a16"))
+            {
+                return 10;
+            }
+
+            // Entry-level/older
+            if (gpuName.Contains("adreno 5") || gpuName.Contains("mali-t") || gpuName.Contains("powervr"))
+            {
+                return 3;
+            }
+
+            return 6;
+        }
+
+        private int ScoreGraphicsApiSupport()
+        {
+            var api = SystemInfo.graphicsDeviceType;
+            switch (api)
+            {
+                case GraphicsDeviceType.Vulkan:
+                case GraphicsDeviceType.Metal:
+                    return 8;
+                case GraphicsDeviceType.OpenGLES3:
+                    return 4;
+                default:
+                    return 1;
+            }
+        }
+
+        private int GetScreenRefreshRate()
+        {
+#if UNITY_2021_2_OR_NEWER
+            var ratio = Screen.currentResolution.refreshRateRatio;
+            return Mathf.RoundToInt((float)ratio.value);
+#else
+            return Screen.currentResolution.refreshRate;
+#endif
+        }
+
+        private void ApplyTierInternal(GraphicsQualityTier tier)
+        {
+            AppliedTier = tier;
+
+            switch (tier)
+            {
+                case GraphicsQualityTier.Low:
+                    ApplyGlobalQuality(lowTargetFps, lowRenderScale, lodBias: 0.6f, textureLimit: 1,
+                        shadows: ShadowQuality.Disable, shadowDistance: 0f, softParticles: false, anisotropic: AnisotropicFiltering.Disable,
+                        antiAliasing: 0, particleRaycastBudget: 32);
+                    break;
+
+                case GraphicsQualityTier.Medium:
+                    ApplyGlobalQuality(mediumTargetFps, mediumRenderScale, lodBias: 1.0f, textureLimit: 0,
+                        shadows: ShadowQuality.HardOnly, shadowDistance: 22f, softParticles: false, anisotropic: AnisotropicFiltering.Enable,
+                        antiAliasing: 2, particleRaycastBudget: 96);
+                    break;
+
+                case GraphicsQualityTier.High:
+                    var safeHighFps = GetHighestSafeHighRefreshTarget();
+                    ApplyGlobalQuality(safeHighFps, highRenderScale, lodBias: 1.5f, textureLimit: 0,
+                        shadows: ShadowQuality.All, shadowDistance: 40f, softParticles: true, anisotropic: AnisotropicFiltering.ForceEnable,
+                        antiAliasing: 4, particleRaycastBudget: 256);
+                    break;
+            }
+
+            OnCustomQualityTierApplied?.Invoke(tier);
+        }
+
+        private int GetHighestSafeHighRefreshTarget()
+        {
+            var refresh = GetScreenRefreshRate();
+            if (refresh >= 144) return 144;
+            if (refresh >= highTargetFps) return highTargetFps;
+            if (refresh >= 120) return 120;
+            if (refresh >= 90) return 90;
+            return 60;
+        }
+
+        private void ApplyGlobalQuality(
+            int targetFps,
+            float internalRenderScale,
+            float lodBias,
+            int textureLimit,
+            ShadowQuality shadows,
+            float shadowDistance,
+            bool softParticles,
+            AnisotropicFiltering anisotropic,
+            int antiAliasing,
+            int particleRaycastBudget)
+        {
+            Application.targetFrameRate = Mathf.Clamp(targetFps, 30, 144);
+
+            QualitySettings.lodBias = lodBias;
+            QualitySettings.masterTextureLimit = Mathf.Clamp(textureLimit, 0, 3);
+            QualitySettings.shadows = shadows;
+            QualitySettings.shadowDistance = shadowDistance;
+            QualitySettings.softParticles = softParticles;
+            QualitySettings.anisotropicFiltering = anisotropic;
+            QualitySettings.antiAliasing = antiAliasing;
+            QualitySettings.particleRaycastBudget = particleRaycastBudget;
+
+            ApplyInternalResolutionScale(internalRenderScale);
+        }
+
+        private void ApplyInternalResolutionScale(float requestedScale)
+        {
+            // Clamp range for safety and to avoid invalid render targets.
+            var clampedScale = Mathf.Clamp(requestedScale, 0.6f, 1.25f);
+
+            if (TrySetUrpRenderScale(clampedScale))
+            {
+                return;
+            }
+
+            // Non-URP fallback:
+            // Scales render buffers, producing a softer/sharper full-scene image while the display
+            // resolution and UI canvas stay readable. Good default for mobile pipelines.
+            ScalableBufferManager.ResizeBuffers(clampedScale, clampedScale);
+        }
+
+        private bool TrySetUrpRenderScale(float scale)
+        {
+            var pipelineAsset = GraphicsSettings.currentRenderPipeline;
+            if (pipelineAsset == null)
+            {
+                return false;
+            }
+
+            // Reflection keeps this script compilable even when URP package is not installed.
+            var pipelineType = pipelineAsset.GetType();
+            var property = pipelineType.GetProperty("renderScale");
+            if (property == null || !property.CanWrite)
+            {
+                return false;
+            }
+
+            var min = 0.5f;
+            var max = 2.0f;
+            var clamped = Mathf.Clamp(scale, min, max);
+            property.SetValue(pipelineAsset, clamped, null);
+            return true;
+        }
+
+        private void EmitUserFeedbackMessage(GraphicsPreset selectedPreset, GraphicsQualityTier resolvedTier)
+        {
+            if (!logFeedbackMessages)
+            {
+                return;
+            }
+
+            if (selectedPreset == GraphicsPreset.Auto)
+            {
+                Debug.Log($"[Graphics] Auto selected the best settings for your device ({resolvedTier}).");
+                return;
+            }
+
+            Debug.Log("[Graphics] Graphics quality updated.");
+
+            if (selectedPreset == GraphicsPreset.High)
+            {
+                var autoTier = ResolveAutoTierNoSideEffects();
+                if (autoTier != GraphicsQualityTier.High)
+                {
+                    Debug.LogWarning("[Graphics] High graphics may reduce performance on some devices.");
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Settings/GraphicsSettingsManager.cs.meta
+++ b/Assets/Scripts/Settings/GraphicsSettingsManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d5d71ae3c36a4bdab52dd5fbbf65f13f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Settings/GraphicsSettingsUI.cs
+++ b/Assets/Scripts/Settings/GraphicsSettingsUI.cs
@@ -1,0 +1,221 @@
+using System;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace TonPlaygram.Settings
+{
+    /// <summary>
+    /// UI adapter for graphics setting buttons and labels.
+    ///
+    /// Assign button + text references in inspector.
+    /// The script keeps selection highlighting in sync and forwards user taps to manager.
+    /// </summary>
+    public sealed class GraphicsSettingsUI : MonoBehaviour
+    {
+        [Serializable]
+        public sealed class PresetOptionView
+        {
+            public GraphicsPreset preset;
+            public Button button;
+            public Text titleText;
+            public Text descriptionText;
+            public Graphic[] highlightTargets;
+        }
+
+        [Header("Dependencies")]
+        [SerializeField] private GraphicsSettingsManager manager;
+
+        [Header("Preset Options")]
+        [SerializeField] private PresetOptionView[] options;
+
+        [Header("Style")]
+        [SerializeField] private Color selectedColor = new Color(0.15f, 0.7f, 0.3f, 1f);
+        [SerializeField] private Color unselectedColor = new Color(0.2f, 0.2f, 0.2f, 1f);
+        [SerializeField] private Color selectedTextColor = Color.white;
+        [SerializeField] private Color unselectedTextColor = new Color(0.9f, 0.9f, 0.9f, 1f);
+
+        [Header("Optional Feedback")]
+        [SerializeField] private Text feedbackText;
+        [SerializeField] private float feedbackDuration = 2f;
+
+        private float feedbackHideTime;
+
+        private void Awake()
+        {
+            if (manager == null)
+            {
+                manager = GraphicsSettingsManager.Instance;
+            }
+
+            WireButtons();
+            FillDescriptions();
+        }
+
+        private void OnEnable()
+        {
+            if (manager == null)
+            {
+                manager = GraphicsSettingsManager.Instance;
+            }
+
+            if (manager != null)
+            {
+                manager.OnGraphicsSettingsApplied += HandleSettingsApplied;
+                HandleSettingsApplied(manager.SelectedPreset, manager.AppliedTier);
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (manager != null)
+            {
+                manager.OnGraphicsSettingsApplied -= HandleSettingsApplied;
+            }
+        }
+
+        private void Update()
+        {
+            if (feedbackText != null && feedbackText.gameObject.activeSelf && Time.unscaledTime >= feedbackHideTime)
+            {
+                feedbackText.gameObject.SetActive(false);
+            }
+        }
+
+        private void WireButtons()
+        {
+            if (options == null)
+            {
+                return;
+            }
+
+            for (var i = 0; i < options.Length; i++)
+            {
+                var option = options[i];
+                if (option == null || option.button == null)
+                {
+                    continue;
+                }
+
+                var capturedPreset = option.preset;
+                option.button.onClick.RemoveAllListeners();
+                option.button.onClick.AddListener(() => OnPresetClicked(capturedPreset));
+            }
+        }
+
+        private void FillDescriptions()
+        {
+            if (manager == null || options == null)
+            {
+                return;
+            }
+
+            for (var i = 0; i < options.Length; i++)
+            {
+                var option = options[i];
+                if (option == null)
+                {
+                    continue;
+                }
+
+                if (option.titleText != null)
+                {
+                    option.titleText.text = option.preset.ToString();
+                }
+
+                if (option.descriptionText != null)
+                {
+                    option.descriptionText.text = manager.GetDescription(option.preset);
+                }
+            }
+        }
+
+        private void OnPresetClicked(GraphicsPreset preset)
+        {
+            if (manager == null)
+            {
+                Debug.LogWarning("[GraphicsUI] GraphicsSettingsManager not found.");
+                return;
+            }
+
+            var previous = manager.SelectedPreset;
+            manager.SetPreset(preset, showUserMessage: true);
+
+            if (feedbackText == null)
+            {
+                return;
+            }
+
+            if (preset == GraphicsPreset.Auto)
+            {
+                feedbackText.text = "Auto selected the best settings for your device.";
+            }
+            else
+            {
+                feedbackText.text = "Graphics quality updated.";
+                if (preset == GraphicsPreset.High && manager.GetResolvedTierForPreset(GraphicsPreset.Auto) != GraphicsQualityTier.High)
+                {
+                    feedbackText.text = "High graphics may reduce performance on some devices.";
+                }
+            }
+
+            if (previous != preset || preset == GraphicsPreset.Auto)
+            {
+                feedbackText.gameObject.SetActive(true);
+                feedbackHideTime = Time.unscaledTime + Mathf.Max(0.75f, feedbackDuration);
+            }
+        }
+
+        private void HandleSettingsApplied(GraphicsPreset selectedPreset, GraphicsQualityTier resolvedTier)
+        {
+            if (options == null)
+            {
+                return;
+            }
+
+            for (var i = 0; i < options.Length; i++)
+            {
+                var option = options[i];
+                if (option == null)
+                {
+                    continue;
+                }
+
+                var isSelected = option.preset == selectedPreset;
+                var bgColor = isSelected ? selectedColor : unselectedColor;
+                var txtColor = isSelected ? selectedTextColor : unselectedTextColor;
+
+                if (option.highlightTargets != null)
+                {
+                    for (var h = 0; h < option.highlightTargets.Length; h++)
+                    {
+                        var g = option.highlightTargets[h];
+                        if (g != null)
+                        {
+                            g.color = bgColor;
+                        }
+                    }
+                }
+
+                if (option.titleText != null)
+                {
+                    option.titleText.color = txtColor;
+                }
+
+                if (option.descriptionText != null)
+                {
+                    option.descriptionText.color = txtColor;
+
+                    if (selectedPreset == GraphicsPreset.Auto && option.preset == GraphicsPreset.Auto)
+                    {
+                        option.descriptionText.text =
+                            $"{manager.GetDescription(GraphicsPreset.Auto)}\nActive tier: {resolvedTier}.";
+                    }
+                    else
+                    {
+                        option.descriptionText.text = manager.GetDescription(option.preset);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Settings/GraphicsSettingsUI.cs.meta
+++ b/Assets/Scripts/Settings/GraphicsSettingsUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0fe34f4909884842b710cb2760fc10aa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -170,9 +170,9 @@ function resolveDefaultPixelRatioCap() {
   return window.innerWidth <= 1366 ? 1.5 : 2;
 }
 
-function detectPreferredFrameRateId() {
+function detectAutoGraphicsTierId() {
   if (typeof window === 'undefined' || typeof navigator === 'undefined') {
-    return 'fhd60';
+    return 'medium';
   }
   const coarsePointer = detectCoarsePointer();
   const ua = navigator.userAgent ?? '';
@@ -185,40 +185,42 @@ function detectPreferredFrameRateId() {
   const highRefresh = detectHighRefreshDisplay();
   const rendererTier = classifyRendererTier(readGraphicsRendererString());
 
-  if (lowRefresh) {
-    return 'hd50';
-  }
+  let score = 0;
+  if (lowRefresh) score -= 12;
+  if (highRefresh) score += 16;
 
   if (isMobileUA || coarsePointer || isTouch || rendererTier === 'mobile') {
-    if ((deviceMemory !== null && deviceMemory <= 4) || hardwareConcurrency <= 4) {
-      return 'hd50';
+    if (deviceMemory != null) {
+      if (deviceMemory >= 8) score += 16;
+      else if (deviceMemory >= 6) score += 10;
+      else if (deviceMemory >= 4) score += 4;
+      else score -= 10;
     }
-    if (highRefresh && hardwareConcurrency >= 8 && (deviceMemory == null || deviceMemory >= 6)) {
-      return 'uhd120';
-    }
-    if (
-      highRefresh ||
-      hardwareConcurrency >= 6 ||
-      (deviceMemory != null && deviceMemory >= 6)
-    ) {
-      return 'qhd90';
-    }
-    return 'fhd60';
+    if (hardwareConcurrency >= 8) score += 14;
+    else if (hardwareConcurrency >= 6) score += 8;
+    else if (hardwareConcurrency <= 4) score -= 8;
+  } else {
+    // Desktop fallback for web builds.
+    if (rendererTier === 'desktopHigh') score += 18;
+    else if (rendererTier === 'desktopMid') score += 8;
+    if (hardwareConcurrency >= 8) score += 10;
   }
 
-  if (rendererTier === 'desktopHigh' && highRefresh) {
-    return 'ultra144';
+  if (typeof window !== 'undefined') {
+    const pixelCount = Math.max(1, window.screen?.width || 1) * Math.max(1, window.screen?.height || 1);
+    if (pixelCount >= 3000000) score -= 7;
+    else if (pixelCount >= 2073600) score -= 4;
   }
 
-  if (rendererTier === 'desktopHigh' || hardwareConcurrency >= 8) {
-    return 'uhd120';
-  }
+  if (score >= 22) return 'high';
+  if (score >= 8) return 'medium';
+  return 'low';
+}
 
-  if (rendererTier === 'desktopMid') {
-    return 'qhd90';
-  }
-
-  return 'fhd60';
+function resolveSafeHighFpsTarget() {
+  if (detectHighRefreshDisplay()) return 120;
+  if (!detectLowRefreshDisplay()) return 90;
+  return 60;
 }
 
 const MODEL_SCALE = 0.75;
@@ -467,7 +469,6 @@ const CHAIR_MODEL_URLS = [
 
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
 const BASIS_TRANSCODER_PATH = 'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/';
-const HDRI_RESOLUTION_STORAGE_KEY = 'texasHoldemHdriResolution';
 const HDRI_RESOLUTION_OPTIONS = Object.freeze([
   { id: '8k', label: '8K' },
   { id: '6k', label: '6K' },
@@ -642,65 +643,50 @@ const AI_ACTION_DELAY_JITTER_MS = 700;
 const CARD_HIGHLIGHT_COLOR = '#facc15';
 const CARD_HIGHLIGHT = new THREE.Color(CARD_HIGHLIGHT_COLOR);
 const CARD_EMISSIVE_OFF = new THREE.Color(0x000000);
-const FRAME_RATE_STORAGE_KEY = 'texasHoldemFrameRate';
-const FRAME_RATE_OPTIONS = Object.freeze([
+const GRAPHICS_PRESET_STORAGE_KEY = 'texasHoldemGraphicsPreset';
+const GRAPHICS_PRESET_OPTIONS = Object.freeze([
   {
-    id: 'hd50',
-    label: 'HD Performance (50 Hz)',
-    fps: 50,
-    renderScale: 1,
-    pixelRatioCap: 1.4,
-    resolution: 'HD render • DPR 1.4 cap',
-    description: 'Minimum HD output for battery saver and 50–60 Hz displays.'
-  },
-  {
-    id: 'fhd60',
-    label: 'Full HD (60 Hz)',
-    fps: 60,
-    renderScale: 1.1,
-    pixelRatioCap: 1.5,
-    resolution: 'Full HD render • DPR 1.5 cap',
-    description: '1080p-focused profile that mirrors the Snooker frame pacing.'
-  },
-  {
-    id: 'qhd90',
-    label: 'Quad HD (90 Hz)',
+    id: 'auto',
+    label: 'Auto',
     fps: 90,
-    renderScale: 1.25,
-    pixelRatioCap: 1.7,
-    resolution: 'QHD render • DPR 1.7 cap',
-    description: 'Sharper 1440p render for capable 90 Hz mobile and desktop GPUs.'
+    renderScale: 0.95,
+    pixelRatioCap: 1.5,
+    description: 'Recommended. Automatically chooses the best graphics for your phone.'
   },
   {
-    id: 'uhd120',
-    label: 'Ultra HD (120 Hz)',
+    id: 'low',
+    label: 'Low',
+    fps: 60,
+    renderScale: 0.7,
+    pixelRatioCap: 1.1,
+    description: 'Best for battery life and lower-end phones.'
+  },
+  {
+    id: 'medium',
+    label: 'Medium',
+    fps: 90,
+    renderScale: 0.9,
+    pixelRatioCap: 1.45,
+    description: 'Balanced visuals and smooth performance.'
+  },
+  {
+    id: 'high',
+    label: 'High',
     fps: 120,
-    renderScale: 1.35,
+    renderScale: 1.15,
     pixelRatioCap: 2,
-    resolution: 'Ultra HD render • DPR 2.0 cap',
-    description: '4K-oriented profile for 120 Hz flagships and desktops.'
-  },
-  {
-    id: 'ultra144',
-    label: 'Ultra HD+ (144 Hz)',
-    fps: 144,
-    renderScale: 1.5,
-    pixelRatioCap: 2.2,
-    resolution: 'Ultra HD+ render • DPR 2.2 cap',
-    description: 'Maximum clarity preset that prioritizes UHD detail at 144 Hz.'
+    description: 'Best visuals for powerful phones.'
   }
 ]);
-const DEFAULT_FRAME_RATE_ID = 'fhd60';
-const FRAME_RATE_TO_HDRI_RESOLUTION_MAP = Object.freeze({
-  hd50: '4k',
-  fhd60: '4k',
-  qhd90: '6k',
-  uhd120: '8k',
-  ultra144: '8k'
+const DEFAULT_GRAPHICS_PRESET_ID = 'auto';
+const GRAPHICS_TO_HDRI_RESOLUTION_MAP = Object.freeze({
+  low: '2k',
+  medium: '4k',
+  high: '6k'
 });
 
-function resolveHdriResolutionForGraphics(frameRateOptionId) {
-  const mapped = FRAME_RATE_TO_HDRI_RESOLUTION_MAP[frameRateOptionId];
+function resolveHdriResolutionForGraphics(graphicsTierId) {
+  const mapped = GRAPHICS_TO_HDRI_RESOLUTION_MAP[graphicsTierId];
   if (mapped && HDRI_RESOLUTION_OPTION_MAP[mapped]) {
     return mapped;
   }
@@ -3142,26 +3128,34 @@ function TexasHoldemArena({ search }) {
         }),
     [appearance.tableTheme, texasInventory]
   );
-  const [frameRateId, setFrameRateId] = useState(() => {
+  const [graphicsPresetId, setGraphicsPresetId] = useState(() => {
     if (typeof window !== 'undefined') {
-      const stored = window.localStorage?.getItem(FRAME_RATE_STORAGE_KEY);
-      if (stored && FRAME_RATE_OPTIONS.some((opt) => opt.id === stored)) {
+      const stored = window.localStorage?.getItem(GRAPHICS_PRESET_STORAGE_KEY);
+      if (stored && GRAPHICS_PRESET_OPTIONS.some((opt) => opt.id === stored)) {
         return stored;
       }
-      const detected = detectPreferredFrameRateId();
-      if (detected && FRAME_RATE_OPTIONS.some((opt) => opt.id === detected)) {
-        return detected;
+      const detected = detectAutoGraphicsTierId();
+      if (detected && GRAPHICS_PRESET_OPTIONS.some((opt) => opt.id === detected)) {
+        return 'auto';
       }
     }
-    return DEFAULT_FRAME_RATE_ID;
+    return DEFAULT_GRAPHICS_PRESET_ID;
   });
-  const activeFrameRateOption = useMemo(
-    () => FRAME_RATE_OPTIONS.find((opt) => opt.id === frameRateId) ?? FRAME_RATE_OPTIONS[0],
-    [frameRateId]
+  const autoDetectedGraphicsTier = useMemo(
+    () => detectAutoGraphicsTierId(),
+    []
+  );
+  const resolvedGraphicsTierId = useMemo(
+    () => (graphicsPresetId === 'auto' ? autoDetectedGraphicsTier : graphicsPresetId),
+    [autoDetectedGraphicsTier, graphicsPresetId]
+  );
+  const activeGraphicsOption = useMemo(
+    () => GRAPHICS_PRESET_OPTIONS.find((opt) => opt.id === resolvedGraphicsTierId) ?? GRAPHICS_PRESET_OPTIONS[2],
+    [resolvedGraphicsTierId]
   );
   const hdriResolutionId = useMemo(
-    () => resolveHdriResolutionForGraphics(frameRateId),
-    [frameRateId]
+    () => resolveHdriResolutionForGraphics(resolvedGraphicsTierId),
+    [resolvedGraphicsTierId]
   );
   const preferredHdriResolutions = useMemo(() => {
     const normalized = HDRI_RESOLUTION_OPTION_MAP[hdriResolutionId]?.id || DEFAULT_HDRI_RESOLUTION_ID;
@@ -3178,37 +3172,39 @@ function TexasHoldemArena({ search }) {
     preferredHdriResolutionsRef.current = preferredHdriResolutions;
   }, [preferredHdriResolutions]);
   const frameQualityProfile = useMemo(() => {
-    const option = activeFrameRateOption ?? FRAME_RATE_OPTIONS[0];
-    const fallback = FRAME_RATE_OPTIONS[0];
+    const option = activeGraphicsOption ?? GRAPHICS_PRESET_OPTIONS[2];
+    const fallback = GRAPHICS_PRESET_OPTIONS[2];
     const fps =
       Number.isFinite(option?.fps) && option.fps > 0
-        ? option.fps
+        ? option?.id === 'high'
+          ? Math.min(option.fps, resolveSafeHighFpsTarget())
+          : option.fps
         : Number.isFinite(fallback?.fps) && fallback.fps > 0
           ? fallback.fps
           : 60;
     const renderScale =
       typeof option?.renderScale === 'number' && Number.isFinite(option.renderScale)
-        ? THREE.MathUtils.clamp(option.renderScale, 1, 1.6)
+        ? THREE.MathUtils.clamp(option.renderScale, 0.65, 1.25)
         : 1;
     const pixelRatioCap =
       typeof option?.pixelRatioCap === 'number' && Number.isFinite(option.pixelRatioCap)
         ? Math.max(1, option.pixelRatioCap)
         : resolveDefaultPixelRatioCap();
     return {
-      id: option?.id ?? DEFAULT_FRAME_RATE_ID,
+      id: option?.id ?? DEFAULT_GRAPHICS_PRESET_ID,
       fps,
       renderScale,
       pixelRatioCap
     };
-  }, [activeFrameRateOption]);
+  }, [activeGraphicsOption]);
   const frameQualityRef = useRef(frameQualityProfile);
   useEffect(() => {
     frameQualityRef.current = frameQualityProfile;
   }, [frameQualityProfile]);
   const resolvedFrameTiming = useMemo(() => {
     const fallbackFps =
-      Number.isFinite(FRAME_RATE_OPTIONS[0]?.fps) && FRAME_RATE_OPTIONS[0].fps > 0
-        ? FRAME_RATE_OPTIONS[0].fps
+      Number.isFinite(GRAPHICS_PRESET_OPTIONS[2]?.fps) && GRAPHICS_PRESET_OPTIONS[2].fps > 0
+        ? GRAPHICS_PRESET_OPTIONS[2].fps
         : 60;
     const fps =
       Number.isFinite(frameQualityProfile?.fps) && frameQualityProfile.fps > 0
@@ -3216,7 +3212,7 @@ function TexasHoldemArena({ search }) {
         : fallbackFps;
     const targetMs = 1000 / fps;
     return {
-      id: frameQualityProfile?.id ?? FRAME_RATE_OPTIONS[0]?.id ?? DEFAULT_FRAME_RATE_ID,
+      id: frameQualityProfile?.id ?? GRAPHICS_PRESET_OPTIONS[2]?.id ?? DEFAULT_GRAPHICS_PRESET_ID,
       fps,
       targetMs,
       maxMs: targetMs * FRAME_TIME_CATCH_UP_MULTIPLIER
@@ -3228,19 +3224,13 @@ function TexasHoldemArena({ search }) {
   }, [resolvedFrameTiming]);
   useEffect(() => {
     try {
-      window.localStorage?.setItem(FRAME_RATE_STORAGE_KEY, frameRateId);
+      window.localStorage?.setItem(GRAPHICS_PRESET_STORAGE_KEY, graphicsPresetId);
     } catch (error) {
       console.warn("Failed to persist Texas Hold'em graphics", error);
     }
-  }, [frameRateId]);
-  useEffect(() => {
-    try {
-      window.localStorage?.setItem(HDRI_RESOLUTION_STORAGE_KEY, hdriResolutionId);
-    } catch (error) {
-      console.warn("Failed to persist Texas Hold'em HDRI resolution", error);
-    }
-  }, [hdriResolutionId]);
+  }, [graphicsPresetId]);
   const [configOpen, setConfigOpen] = useState(false);
+  const [graphicsNotice, setGraphicsNotice] = useState('');
   const timerRef = useRef(null);
   const turnIntervalRef = useRef(null);
   const soundsRef = useRef({});
@@ -3257,6 +3247,24 @@ function TexasHoldemArena({ search }) {
   useEffect(() => {
     gameStateRef.current = gameState;
   }, [gameState]);
+  const handleGraphicsPresetChange = useCallback((nextPresetId) => {
+    setGraphicsPresetId((current) => {
+      if (current === nextPresetId) return current;
+      if (nextPresetId === 'auto') {
+        setGraphicsNotice('Auto selected the best settings for your device.');
+      } else if (nextPresetId === 'high' && autoDetectedGraphicsTier !== 'high') {
+        setGraphicsNotice('High graphics may reduce performance on some devices.');
+      } else {
+        setGraphicsNotice('Graphics quality updated.');
+      }
+      return nextPresetId;
+    });
+  }, [autoDetectedGraphicsTier]);
+  useEffect(() => {
+    if (!graphicsNotice) return undefined;
+    const timeout = window.setTimeout(() => setGraphicsNotice(''), 2000);
+    return () => window.clearTimeout(timeout);
+  }, [graphicsNotice]);
 
   useEffect(() => {
     const handler = (event) => {
@@ -4294,7 +4302,7 @@ function TexasHoldemArena({ search }) {
     const pixelRatioCap = quality?.pixelRatioCap ?? resolveDefaultPixelRatioCap();
     const renderScale =
       typeof quality?.renderScale === 'number' && Number.isFinite(quality.renderScale)
-        ? THREE.MathUtils.clamp(quality.renderScale, 1, 1.6)
+        ? THREE.MathUtils.clamp(quality.renderScale, 0.65, 1.25)
         : 1;
     renderer.setPixelRatio(Math.min(pixelRatioCap, dpr));
     renderer.setSize(host.clientWidth * renderScale, host.clientHeight * renderScale, false);
@@ -6468,43 +6476,17 @@ function TexasHoldemArena({ search }) {
               <div>
                 <p className="text-[10px] uppercase tracking-[0.35em] text-white/70">Graphics</p>
                 <p className="mt-1 text-[0.7rem] text-white/60">
-                  Graphics preset now auto-syncs HDRI resolution so table lighting quality always matches menu quality.
-                </p>
-              </div>
-              <div className="space-y-2">
-                <p className="text-[10px] uppercase tracking-[0.2em] text-white/60">HDRI Resolution</p>
-                <div className="grid grid-cols-3 gap-2">
-                  {HDRI_RESOLUTION_OPTIONS.map((option) => {
-                    const active = option.id === hdriResolutionId;
-                    return (
-                      <button
-                        key={option.id}
-                        type="button"
-                        disabled
-                        aria-pressed={active}
-                        className={`rounded-xl border px-2 py-2 text-center text-[11px] font-semibold uppercase tracking-[0.22em] transition ${
-                          active
-                            ? 'border-sky-300 bg-sky-300/15 text-sky-100 shadow-[0_0_12px_rgba(125,211,252,0.35)]'
-                            : 'border-white/10 bg-white/5 text-white/40'
-                        }`}
-                      >
-                        {option.label}
-                      </button>
-                    );
-                  })}
-                </div>
-                <p className="text-[10px] uppercase tracking-[0.2em] text-white/45">
-                  Auto-selected from your active Graphics profile.
+                  Choose Auto, Low, Medium, or High. Changes apply instantly.
                 </p>
               </div>
               <div className="grid gap-2">
-                {FRAME_RATE_OPTIONS.map((option) => {
-                  const active = option.id === frameRateId;
+                {GRAPHICS_PRESET_OPTIONS.map((option) => {
+                  const active = option.id === graphicsPresetId;
                   return (
                     <button
                       key={option.id}
                       type="button"
-                      onClick={() => setFrameRateId(option.id)}
+                      onClick={() => handleGraphicsPresetChange(option.id)}
                       aria-pressed={active}
                       className={`w-full rounded-2xl border px-3 py-2 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
                         active
@@ -6515,7 +6497,7 @@ function TexasHoldemArena({ search }) {
                       <span className="flex items-center justify-between gap-2">
                         <span className="text-[11px] font-semibold uppercase tracking-[0.26em] text-white">{option.label}</span>
                         <span className="text-[11px] font-semibold tracking-wide text-sky-100">
-                          {option.resolution ? `${option.resolution} • ${option.fps} FPS` : `${option.fps} FPS`}
+                          {option.id === 'auto' ? `Active: ${resolvedGraphicsTierId}` : `${option.fps} FPS`}
                         </span>
                       </span>
                       {option.description ? (
@@ -6527,6 +6509,14 @@ function TexasHoldemArena({ search }) {
                   );
                 })}
               </div>
+              <p className="text-[10px] uppercase tracking-[0.2em] text-white/45">
+                HDRI resolution is now managed automatically by the selected graphics tier.
+              </p>
+              {graphicsNotice ? (
+                <p className="rounded-lg border border-sky-300/25 bg-sky-400/10 px-2 py-1 text-[10px] uppercase tracking-[0.16em] text-sky-100">
+                  {graphicsNotice}
+                </p>
+              ) : null}
             </div>
           </div>
         </div>


### PR DESCRIPTION
### Motivation

- Provide a unified, mobile-first graphics settings system across the Unity client and web game UI so users can choose Auto/Low/Medium/High tiers and the app can resolve and apply safe quality settings automatically.
- Replace the previous frame-rate-focused presets with a more flexible graphics-tier model that better maps HDRI, render scale and pixel ratio for varied devices.

### Description

- Adds a new Unity settings module under `Assets/Scripts/Settings` including `GraphicsPreset`, `GraphicsQualityTier`, `GraphicsSettingsManager` (device heuristics, URP reflection, ScalableBufferManager fallback, persistence, events) and `GraphicsSettingsUI` (inspector-bound preset UI adapter). 
- Implements device scoring heuristics (CPU, RAM, GPU string, refresh rate, battery) to resolve `Auto` into an internal `GraphicsQualityTier` and applies quality knobs (frame target, LOD bias, texture limits, shadows, anti-aliasing, render scale) immediately.
- Updates the web frontend (`webapp/src/pages/Games/TexasHoldemArena.jsx`) to replace frame-rate presets with `GRAPHICS_PRESET_OPTIONS`, introduce `detectAutoGraphicsTierId()` scoring, persist `texasHoldemGraphicsPreset` in `localStorage`, map graphics tiers to HDRI resolution via `GRAPHICS_TO_HDRI_RESOLUTION_MAP`, and update UI/feedback messages for Auto/Low/Medium/High.
- Removes manual HDRI resolution selection and adapts renderer application code to use clamped render scales and safe high-FPS targets for high-tier selections.

### Testing

- Performed a web build/lint pass on the frontend and verified the modified `TexasHoldemArena.jsx` compiles and the new presets are selectable in development; `npm build`/`npm lint` completed without errors. 
- Opened the Unity project in Editor to allow script compilation and confirmed the new `GraphicsSettingsManager` and `GraphicsSettingsUI` scripts compile without errors in the Editor (no runtime assertions added). 
- No automated unit tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb6dac9ab08329bd002909f5935baf)