### PR TITLE
Pool Royale: remove legacy wood finishes and add carbon-fiber chalk color variants

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -297,12 +297,11 @@ const TABLE_FINISH_THUMBNAILS = Object.freeze({
   woodTable001: polyHavenThumb('wood_table_001'),
   darkWood: polyHavenThumb('dark_wood'),
   rosewoodVeneer01: polyHavenThumb('rosewood_veneer_01'),
-  oakVeneer01Amber: swatchThumbnail(['#9f7148', '#c08a58', '#d6a370']),
-  oakVeneer01Cocoa: swatchThumbnail(['#6d4b33', '#8b6040', '#a67852']),
-  oakVeneer01Walnut: swatchThumbnail(['#543726', '#6f4b34', '#8a6246']),
-  oakVeneer01MahoganyRed: swatchThumbnail(['#7b3f34', '#9a4f40', '#b76655']),
-  oakVeneer01MatteBlack: swatchThumbnail(['#121212', '#242424', '#333333']),
-  carbonFiberChalk: swatchThumbnail(['#0c1018', '#1a1f2a', '#374151'])
+  carbonFiberChalk: swatchThumbnail(['#0c1018', '#1a1f2a', '#374151']),
+  carbonFiberChalkGrey: swatchThumbnail(['#2f3540', '#4b5563', '#9ca3af']),
+  carbonFiberChalkBeige: swatchThumbnail(['#8f7a62', '#b29b82', '#e5d3b9']),
+  carbonFiberChalkDarkBlue: swatchThumbnail(['#111a33', '#1e2b55', '#4b5e91']),
+  carbonFiberChalkWhite: swatchThumbnail(['#d8dde5', '#eef2f7', '#ffffff'])
 });
 
 const POCKET_LINER_THUMBNAILS = Object.freeze({
@@ -401,12 +400,11 @@ export const POOL_ROYALE_OPTION_LABELS = Object.freeze({
     woodTable001: 'Wood Table 001',
     darkWood: 'Dark Wood',
     rosewoodVeneer01: 'Rosewood Veneer 01',
-    oakVeneer01Amber: 'Amber Glow',
-    oakVeneer01Cocoa: 'Cocoa Drift',
-    oakVeneer01Walnut: 'Walnut Crest',
-    oakVeneer01MahoganyRed: 'Crimson Grain',
-    oakVeneer01MatteBlack: 'Midnight Matte',
-    carbonFiberChalk: 'Carbon Fiber Chalk'
+    carbonFiberChalk: 'Carbon Fiber Chalk',
+    carbonFiberChalkGrey: 'Carbon Fiber Chalk Grey',
+    carbonFiberChalkBeige: 'Carbon Fiber Chalk Beige',
+    carbonFiberChalkDarkBlue: 'Carbon Fiber Chalk Dark Blue',
+    carbonFiberChalkWhite: 'Carbon Fiber Chalk White'
   }),
   chromeColor: Object.freeze({
     chrome: 'Chrome',
@@ -495,51 +493,6 @@ export const POOL_ROYALE_STORE_ITEMS = [
     thumbnail: TABLE_FINISH_THUMBNAILS.rosewoodVeneer01
   },
   {
-    id: 'finish-oakVeneer01Amber',
-    type: 'tableFinish',
-    optionId: 'oakVeneer01Amber',
-    name: 'Amber Glow Finish',
-    price: 1060,
-    description: 'Custom amber oak veneer pattern with bright satin grain.',
-    thumbnail: TABLE_FINISH_THUMBNAILS.oakVeneer01Amber
-  },
-  {
-    id: 'finish-oakVeneer01Cocoa',
-    type: 'tableFinish',
-    optionId: 'oakVeneer01Cocoa',
-    name: 'Cocoa Drift Finish',
-    price: 1070,
-    description: 'Custom cocoa oak veneer with warm chocolate undertones.',
-    thumbnail: TABLE_FINISH_THUMBNAILS.oakVeneer01Cocoa
-  },
-  {
-    id: 'finish-oakVeneer01Walnut',
-    type: 'tableFinish',
-    optionId: 'oakVeneer01Walnut',
-    name: 'Walnut Crest Finish',
-    price: 1080,
-    description: 'Custom walnut oak veneer with deeper grain separation.',
-    thumbnail: TABLE_FINISH_THUMBNAILS.oakVeneer01Walnut
-  },
-  {
-    id: 'finish-oakVeneer01MahoganyRed',
-    type: 'tableFinish',
-    optionId: 'oakVeneer01MahoganyRed',
-    name: 'Crimson Grain Finish',
-    price: 1090,
-    description: 'Custom mahogany-red oak veneer for a premium classic look.',
-    thumbnail: TABLE_FINISH_THUMBNAILS.oakVeneer01MahoganyRed
-  },
-  {
-    id: 'finish-oakVeneer01MatteBlack',
-    type: 'tableFinish',
-    optionId: 'oakVeneer01MatteBlack',
-    name: 'Midnight Matte Finish',
-    price: 1100,
-    description: 'Custom matte-black oak veneer with subtle low-gloss grain.',
-    thumbnail: TABLE_FINISH_THUMBNAILS.oakVeneer01MatteBlack
-  },
-  {
     id: 'finish-carbonFiberChalk',
     type: 'tableFinish',
     optionId: 'carbonFiberChalk',
@@ -547,6 +500,42 @@ export const POOL_ROYALE_STORE_ITEMS = [
     price: 1160,
     description: 'Custom carbon weave inspired by the chalk block pattern.',
     thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberChalk
+  },
+  {
+    id: 'finish-carbonFiberChalkGrey',
+    type: 'tableFinish',
+    optionId: 'carbonFiberChalkGrey',
+    name: 'Carbon Fiber Chalk Grey Finish',
+    price: 1170,
+    description: 'Carbon Fiber Chalk weave in a balanced grey palette.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberChalkGrey
+  },
+  {
+    id: 'finish-carbonFiberChalkBeige',
+    type: 'tableFinish',
+    optionId: 'carbonFiberChalkBeige',
+    name: 'Carbon Fiber Chalk Beige Finish',
+    price: 1180,
+    description: 'Carbon Fiber Chalk weave with a warm beige tone.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberChalkBeige
+  },
+  {
+    id: 'finish-carbonFiberChalkDarkBlue',
+    type: 'tableFinish',
+    optionId: 'carbonFiberChalkDarkBlue',
+    name: 'Carbon Fiber Chalk Dark Blue Finish',
+    price: 1190,
+    description: 'Carbon Fiber Chalk weave recolored with dark blue accents.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberChalkDarkBlue
+  },
+  {
+    id: 'finish-carbonFiberChalkWhite',
+    type: 'tableFinish',
+    optionId: 'carbonFiberChalkWhite',
+    name: 'Carbon Fiber Chalk White Finish',
+    price: 1200,
+    description: 'Carbon Fiber Chalk weave in a clean white finish.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberChalkWhite
   },
   {
     id: 'chrome-chrome',

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2985,57 +2985,48 @@ const TABLE_FINISHES = Object.freeze({
     woodTextureId: 'rosewood_veneer_01',
     woodRepeatScale: 1
   }),
-  oakVeneer01Amber: createStandardWoodFinish({
-    id: 'oakVeneer01Amber',
-    label: 'Amber Glow',
-    rail: 0xc08a58,
-    base: 0x9f7148,
-    trim: 0xd6a370,
-    woodTextureId: 'oak_veneer_01_amber',
-    woodRepeatScale: 1
-  }),
-  oakVeneer01Cocoa: createStandardWoodFinish({
-    id: 'oakVeneer01Cocoa',
-    label: 'Cocoa Drift',
-    rail: 0x8b6040,
-    base: 0x6d4b33,
-    trim: 0xa67852,
-    woodTextureId: 'oak_veneer_01_cocoa',
-    woodRepeatScale: 1
-  }),
-  oakVeneer01Walnut: createStandardWoodFinish({
-    id: 'oakVeneer01Walnut',
-    label: 'Walnut Crest',
-    rail: 0x6f4b34,
-    base: 0x543726,
-    trim: 0x8a6246,
-    woodTextureId: 'oak_veneer_01_walnut',
-    woodRepeatScale: 1
-  }),
-  oakVeneer01MahoganyRed: createStandardWoodFinish({
-    id: 'oakVeneer01MahoganyRed',
-    label: 'Crimson Grain',
-    rail: 0x9a4f40,
-    base: 0x7b3f34,
-    trim: 0xb76655,
-    woodTextureId: 'oak_veneer_01_mahogany_red',
-    woodRepeatScale: 1
-  }),
-  oakVeneer01MatteBlack: createStandardWoodFinish({
-    id: 'oakVeneer01MatteBlack',
-    label: 'Midnight Matte',
-    rail: 0x242424,
-    base: 0x121212,
-    trim: 0x333333,
-    woodTextureId: 'oak_veneer_01_matte_black',
-    woodRepeatScale: 1
-  }),
   carbonFiberChalk: createStandardWoodFinish({
     id: 'carbonFiberChalk',
     label: 'Carbon Fiber Chalk',
     rail: 0x1a1f2a,
     base: 0x0c1018,
     trim: 0x374151,
+    woodTextureId: 'carbon_fiber_chalk',
+    woodRepeatScale: 1
+  }),
+  carbonFiberChalkGrey: createStandardWoodFinish({
+    id: 'carbonFiberChalkGrey',
+    label: 'Carbon Fiber Chalk Grey',
+    rail: 0x4b5563,
+    base: 0x2f3540,
+    trim: 0x9ca3af,
+    woodTextureId: 'carbon_fiber_chalk',
+    woodRepeatScale: 1
+  }),
+  carbonFiberChalkBeige: createStandardWoodFinish({
+    id: 'carbonFiberChalkBeige',
+    label: 'Carbon Fiber Chalk Beige',
+    rail: 0xb29b82,
+    base: 0x8f7a62,
+    trim: 0xe5d3b9,
+    woodTextureId: 'carbon_fiber_chalk',
+    woodRepeatScale: 1
+  }),
+  carbonFiberChalkDarkBlue: createStandardWoodFinish({
+    id: 'carbonFiberChalkDarkBlue',
+    label: 'Carbon Fiber Chalk Dark Blue',
+    rail: 0x1e2b55,
+    base: 0x111a33,
+    trim: 0x4b5e91,
+    woodTextureId: 'carbon_fiber_chalk',
+    woodRepeatScale: 1
+  }),
+  carbonFiberChalkWhite: createStandardWoodFinish({
+    id: 'carbonFiberChalkWhite',
+    label: 'Carbon Fiber Chalk White',
+    rail: 0xeef2f7,
+    base: 0xd8dde5,
+    trim: 0xffffff,
     woodTextureId: 'carbon_fiber_chalk',
     woodRepeatScale: 1
   })
@@ -3048,12 +3039,11 @@ const TABLE_FINISH_OPTIONS = Object.freeze(
     TABLE_FINISHES.woodTable001,
     TABLE_FINISHES.darkWood,
     TABLE_FINISHES.rosewoodVeneer01,
-    TABLE_FINISHES.oakVeneer01Amber,
-    TABLE_FINISHES.oakVeneer01Cocoa,
-    TABLE_FINISHES.oakVeneer01Walnut,
-    TABLE_FINISHES.oakVeneer01MahoganyRed,
-    TABLE_FINISHES.oakVeneer01MatteBlack,
-    TABLE_FINISHES.carbonFiberChalk
+    TABLE_FINISHES.carbonFiberChalk,
+    TABLE_FINISHES.carbonFiberChalkGrey,
+    TABLE_FINISHES.carbonFiberChalkBeige,
+    TABLE_FINISHES.carbonFiberChalkDarkBlue,
+    TABLE_FINISHES.carbonFiberChalkWhite
   ].filter(Boolean)
 );
 


### PR DESCRIPTION
### Motivation
- Remove five legacy oak/wood table finishes from Pool Royale inventory and store exposure to simplify the finish catalog.
- Provide additional color variants that match the existing `carbonFiberChalk` pattern so players get the same weave in multiple colorways.

### Description
- Removed the Amber/Cocoa/Walnut/Crimson/Midnight finishes (IDs: `oakVeneer01Amber`, `oakVeneer01Cocoa`, `oakVeneer01Walnut`, `oakVeneer01MahoganyRed`, `oakVeneer01MatteBlack`) from the Pool Royale inventory/store metadata in `webapp/src/config/poolRoyaleInventoryConfig.js`.
- Added four new carbon-fiber-chalk color variants with thumbnails, labels, prices and store entries: `carbonFiberChalkGrey`, `carbonFiberChalkBeige`, `carbonFiberChalkDarkBlue`, and `carbonFiberChalkWhite` in `webapp/src/config/poolRoyaleInventoryConfig.js`.
- Updated in-game finish definitions so new variants reuse the same `carbon_fiber_chalk` texture but with different color palettes, by editing `TABLE_FINISHES` and `TABLE_FINISH_OPTIONS` in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Updated selectable finish labels and store item entries to reference the new variant IDs and thumbnails.

### Testing
- Ran `npm test -- test/storeDelivery.test.js --runInBand` and it passed (store delivery unit tests succeeded).
- Ran `npm test -- test/storeDelivery.test.js test/poolRoyalInventoryRoutes.test.js --runInBand` and the suite hit an existing integration test timeout in this environment (one test exceeded Jest's default timeout); other tests ran but the combined run timed out in this CI environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb747b7528832997bcf7eed32d8c4d)