### PR TITLE
Align Murlan HDRI resolutions with Poly Haven mappings

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -279,13 +279,22 @@ const RAW_POOL_ROYALE_HDRI_VARIANTS = [
   },
 ];
 
-const HDRI_RESOLUTION_STACK = Object.freeze(['2k']);
+const POLYHAVEN_OFFICIAL_HDRI_RESOLUTION_STACK = Object.freeze(['16k', '8k', '4k', '2k', '1k']);
+const POLYHAVEN_OFFICIAL_HDRI_FALLBACK_RESOLUTION = '4k';
+const polyHavenHdriUrl = (assetId, resolution) =>
+  `https://dl.polyhaven.org/file/ph-assets/HDRIs/hdr/${resolution}/${assetId}_${resolution}.hdr`;
 
 export const POOL_ROYALE_HDRI_VARIANTS = Object.freeze(
   RAW_POOL_ROYALE_HDRI_VARIANTS.map((variant) => ({
     ...variant,
-    preferredResolutions: HDRI_RESOLUTION_STACK,
-    fallbackResolution: HDRI_RESOLUTION_STACK[0],
+    preferredResolutions: POLYHAVEN_OFFICIAL_HDRI_RESOLUTION_STACK,
+    fallbackResolution: POLYHAVEN_OFFICIAL_HDRI_FALLBACK_RESOLUTION,
+    assetUrls: Object.freeze(
+      POLYHAVEN_OFFICIAL_HDRI_RESOLUTION_STACK.reduce((acc, resolution) => {
+        acc[resolution] = polyHavenHdriUrl(variant.assetId, resolution);
+        return acc;
+      }, {})
+    ),
     thumbnail: polyHavenThumb(variant.assetId),
     ...(POOL_ROYALE_HDRI_PLACEMENTS[variant.id] || {})
   }))

--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -65,7 +65,7 @@ import {
 } from '../../utils/murlanRoyaleCommentary.js';
 
 const DEFAULT_HDRI_RESOLUTIONS = Object.freeze(['4k']);
-const HDRI_RESOLUTION_LADDER = Object.freeze(['8k', '6k', '4k', '2k', '1k']);
+const HDRI_RESOLUTION_LADDER = Object.freeze(['16k', '8k', '4k', '2k', '1k']);
 const MURLAN_HDRI_OPTIONS = POOL_ROYALE_HDRI_VARIANTS.map((variant) => ({
   ...variant,
   label: `${variant.name} HDRI`
@@ -430,7 +430,7 @@ function pickBestTextureUrls(apiJson, preferredSizes = PREFERRED_TEXTURE_SIZES) 
 }
 
 const HDRI_URL_CACHE = new Map();
-const HDRI_RESOLUTION_PATTERN = /(?:^|[_/-])((?:1|2|4|6|8|16)k)(?=\.|[_/-]|$)/i;
+const HDRI_RESOLUTION_PATTERN = /(?:^|[_/-])((?:1|2|4|8|16)k)(?=\.|[_/-]|$)/i;
 
 const normalizeHdriResolutionId = (value) => {
   const lower = String(value || '').toLowerCase();
@@ -2336,16 +2336,16 @@ const FRAME_RATE_OPTIONS = Object.freeze([
     fps: 120,
     renderScale: 1.28,
     pixelRatioCap: 1.85,
-    resolution: '6K texture pack • 120 FPS',
-    hdriResolution: '6k',
-    preferredTextureSizes: ['6k', '4k', '2k', '1k'],
-    description: 'Maximum 6K assets and 120 FPS target.'
+    resolution: '8K texture pack • 120 FPS',
+    hdriResolution: '8k',
+    preferredTextureSizes: ['8k', '4k', '2k', '1k'],
+    description: 'Maximum 8K assets and 120 FPS target.'
   }
 ]);
 const HDRI_RESOLUTION_OPTIONS = Object.freeze([
   { id: 'auto', label: 'Match Graphics' },
+  { id: '16k', label: '16K' },
   { id: '8k', label: '8K' },
-  { id: '6k', label: '6K' },
   { id: '4k', label: '4K' },
   { id: '2k', label: '2K' },
   { id: '1k', label: 'Full HD' }


### PR DESCRIPTION
### Motivation
- Ensure HDRI options match official Poly Haven resolution mappings so UI labels, runtime selection, and downloaded HDR files correspond to real available assets.
- Improve runtime determinism by providing explicit per-resolution Poly Haven URLs for each HDRI variant so the renderer can fetch the exact resolution requested.

### Description
- Updated `webapp/src/config/poolRoyaleInventoryConfig.js` to replace the hardcoded `2k` stack with the official Poly Haven ladder `['16k','8k','4k','2k','1k']`, set the fallback to `4k`, and add an `assetUrls` map with deterministic Poly Haven HDR download URLs per resolution.
- Added a helper `polyHavenHdriUrl` to construct official URLs and wired `thumbnail` generation to remain `polyHavenThumb(variant.assetId)`.
- Updated `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to use the new ladder (`16k`,`8k`,`4k`,`2k`,`1k`), adjusted the resolution-detection regex accordingly, removed the non-official `6k` option, added `16k` to the UI options, and changed the `Ultra (120 Hz)` preset to target `8k` HDRI assets.

### Testing
- Ran the relevant unit/integration suites with `npm test -- --runInBand test/murlan.test.js test/inventoryCrossGameConfig.test.js test/texasHoldemHdriPreload.test.js`, and all tests passed (`3` test suites, `18` tests).
- The changes were validated against the `texasHoldemHdriPreload` logic to ensure resolution selection still prioritizes requested resolutions correctly and the inventory config mappings remained consistent.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb995cdcdc8329891375dca72f9e6d)