### PR TITLE
Align Murlan HDRI resolutions with Poly Haven official mappings

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -279,16 +279,39 @@ const RAW_POOL_ROYALE_HDRI_VARIANTS = [
   },
 ];
 
-const HDRI_RESOLUTION_STACK = Object.freeze(['2k']);
+const POOL_ROYALE_OFFICIAL_HDRI_RESOLUTIONS = Object.freeze({
+  neon_photostudio: Object.freeze(['16k', '8k', '4k', '2k', '1k']),
+  colorful_studio: Object.freeze(['16k', '8k', '4k', '2k', '1k']),
+  dancing_hall: Object.freeze(['16k', '8k', '4k', '2k', '1k']),
+  abandoned_hall_01: Object.freeze(['16k', '8k', '4k', '2k', '1k']),
+  mirrored_hall: Object.freeze(['29k', '24k', '16k', '8k', '4k', '2k', '1k']),
+  music_hall_02: Object.freeze(['16k', '8k', '4k', '2k', '1k']),
+  old_hall: Object.freeze(['16k', '8k', '4k', '2k', '1k']),
+  blocky_photo_studio: Object.freeze(['16k', '8k', '4k', '2k', '1k']),
+  cyclorama_hard_light: Object.freeze(['16k', '8k', '4k', '2k', '1k']),
+  abandoned_garage: Object.freeze(['29k', '24k', '16k', '8k', '4k', '2k', '1k']),
+  vestibule: Object.freeze(['16k', '8k', '4k', '2k', '1k']),
+  country_club: Object.freeze(['16k', '8k', '4k', '2k', '1k']),
+  sepulchral_chapel_rotunda: Object.freeze(['19k', '16k', '8k', '4k', '2k', '1k']),
+  squash_court: Object.freeze(['24k', '16k', '8k', '4k', '2k', '1k'])
+});
+
+const DEFAULT_HDRI_RESOLUTION_STACK = Object.freeze(['8k', '4k', '2k', '1k']);
+
+const resolveOfficialHdriResolutions = (assetId) =>
+  POOL_ROYALE_OFFICIAL_HDRI_RESOLUTIONS[assetId] || DEFAULT_HDRI_RESOLUTION_STACK;
 
 export const POOL_ROYALE_HDRI_VARIANTS = Object.freeze(
-  RAW_POOL_ROYALE_HDRI_VARIANTS.map((variant) => ({
-    ...variant,
-    preferredResolutions: HDRI_RESOLUTION_STACK,
-    fallbackResolution: HDRI_RESOLUTION_STACK[0],
-    thumbnail: polyHavenThumb(variant.assetId),
-    ...(POOL_ROYALE_HDRI_PLACEMENTS[variant.id] || {})
-  }))
+  RAW_POOL_ROYALE_HDRI_VARIANTS.map((variant) => {
+    const preferredResolutions = resolveOfficialHdriResolutions(variant.assetId);
+    return {
+      ...variant,
+      preferredResolutions,
+      fallbackResolution: preferredResolutions[preferredResolutions.length - 1] || DEFAULT_HDRI_RESOLUTION_STACK[DEFAULT_HDRI_RESOLUTION_STACK.length - 1],
+      thumbnail: polyHavenThumb(variant.assetId),
+      ...(POOL_ROYALE_HDRI_PLACEMENTS[variant.id] || {})
+    };
+  })
 );
 
 const TABLE_FINISH_THUMBNAILS = Object.freeze({

--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -64,8 +64,8 @@ import {
   resolveMurlanLanguageKey
 } from '../../utils/murlanRoyaleCommentary.js';
 
-const DEFAULT_HDRI_RESOLUTIONS = Object.freeze(['4k']);
-const HDRI_RESOLUTION_LADDER = Object.freeze(['8k', '6k', '4k', '2k', '1k']);
+const DEFAULT_HDRI_RESOLUTIONS = Object.freeze(['8k', '4k', '2k', '1k']);
+const HDRI_RESOLUTION_LADDER = Object.freeze(['29k', '24k', '19k', '16k', '8k', '4k', '2k', '1k']);
 const MURLAN_HDRI_OPTIONS = POOL_ROYALE_HDRI_VARIANTS.map((variant) => ({
   ...variant,
   label: `${variant.name} HDRI`
@@ -430,7 +430,7 @@ function pickBestTextureUrls(apiJson, preferredSizes = PREFERRED_TEXTURE_SIZES) 
 }
 
 const HDRI_URL_CACHE = new Map();
-const HDRI_RESOLUTION_PATTERN = /(?:^|[_/-])((?:1|2|4|6|8|16)k)(?=\.|[_/-]|$)/i;
+const HDRI_RESOLUTION_PATTERN = /(?:^|[_/-])((?:1|2|4|8|16|19|24|29)k)(?=\.|[_/-]|$)/i;
 
 const normalizeHdriResolutionId = (value) => {
   const lower = String(value || '').toLowerCase();
@@ -2336,16 +2336,16 @@ const FRAME_RATE_OPTIONS = Object.freeze([
     fps: 120,
     renderScale: 1.28,
     pixelRatioCap: 1.85,
-    resolution: '6K texture pack • 120 FPS',
-    hdriResolution: '6k',
-    preferredTextureSizes: ['6k', '4k', '2k', '1k'],
-    description: 'Maximum 6K assets and 120 FPS target.'
+    resolution: '8K texture pack • 120 FPS',
+    hdriResolution: '8k',
+    preferredTextureSizes: ['8k', '4k', '2k', '1k'],
+    description: 'Maximum 8K HDRI and 120 FPS target.'
   }
 ]);
 const HDRI_RESOLUTION_OPTIONS = Object.freeze([
   { id: 'auto', label: 'Match Graphics' },
+  { id: '16k', label: '16K' },
   { id: '8k', label: '8K' },
-  { id: '6k', label: '6K' },
   { id: '4k', label: '4K' },
   { id: '2k', label: '2K' },
   { id: '1k', label: 'Full HD' }


### PR DESCRIPTION
### Motivation
- Ensure HDRI resolution options and runtime selection match the actual resolution variants published by Poly Haven so the app loads the correct `.hdr/.exr` files for each environment. 
- Remove the prior forced `2k` override and unsupported `6k` selection so UI labels, presets and loader logic reflect available asset resolutions. 
- Improve quality preset consistency by aligning the Ultra preset HDRI target with an official high-res variant.

### Description
- Added `POOL_ROYALE_OFFICIAL_HDRI_RESOLUTIONS` and `resolveOfficialHdriResolutions(assetId)` in `webapp/src/config/poolRoyaleInventoryConfig.js` and replaced the hardcoded `2k` stack so each `POOL_ROYALE_HDRI_VARIANTS` entry now exposes the official per-asset `preferredResolutions` and `fallbackResolution` (including 19k/24k/29k where present). 
- Updated `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to use `DEFAULT_HDRI_RESOLUTIONS = ['8k','4k','2k','1k']`, extended `HDRI_RESOLUTION_LADDER` to include `29k/24k/19k/16k`, and expanded the resolution regex `HDRI_RESOLUTION_PATTERN` to recognize those IDs. 
- Adjusted graphics preset and UI resolution options: replaced the unsupported `6k` target with official `8k` for the Ultra preset, added `16k` to `HDRI_RESOLUTION_OPTIONS`, and updated `hdriResolution`/`preferredTextureSizes` accordingly. 
- The Poly Haven URL picking/loading logic remains the same but now receives correct `preferredResolutions` per asset so the loader will pick official high-res files when available.

### Testing
- Ran `npm test -- test/murlan.test.js --runInBand`, which passed (all tests green). 
- Ran `npm test -- test/texasHoldemHdriPreload.test.js --runInBand`, which passed (test passed validating resolution prioritization).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb995cdcdc8329891375dca72f9e6d)