### PR TITLE
Align Murlan HDRI tiers to PolyHaven 2K/4K/8K/16K/20K and map to 60/90/120/144Hz profiles

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -64,8 +64,8 @@ import {
   resolveMurlanLanguageKey
 } from '../../utils/murlanRoyaleCommentary.js';
 
-const DEFAULT_HDRI_RESOLUTIONS = Object.freeze(['4k']);
-const HDRI_RESOLUTION_LADDER = Object.freeze(['8k', '6k', '4k', '2k', '1k']);
+const DEFAULT_HDRI_RESOLUTIONS = Object.freeze(['4k', '2k']);
+const HDRI_RESOLUTION_LADDER = Object.freeze(['20k', '16k', '8k', '4k', '2k']);
 const MURLAN_HDRI_OPTIONS = POOL_ROYALE_HDRI_VARIANTS.map((variant) => ({
   ...variant,
   label: `${variant.name} HDRI`
@@ -165,21 +165,27 @@ function detectLowRefreshDisplay() {
   return false;
 }
 
-function detectHighRefreshDisplay() {
+function detectRefreshRateHint() {
   if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
-    return false;
+    return 60;
   }
-  const queries = ['(min-refresh-rate: 120hz)', '(min-refresh-rate: 90hz)'];
-  for (const query of queries) {
+  const checks = [
+    { query: '(min-refresh-rate: 143hz)', fps: 144 },
+    { query: '(min-refresh-rate: 119hz)', fps: 120 },
+    { query: '(min-refresh-rate: 89hz)', fps: 90 },
+    { query: '(max-refresh-rate: 59hz)', fps: 60 },
+    { query: '(max-refresh-rate: 50hz)', fps: 50 }
+  ];
+  for (const check of checks) {
     try {
-      if (window.matchMedia(query).matches) {
-        return true;
+      if (window.matchMedia(check.query).matches) {
+        return check.fps;
       }
     } catch (err) {
       // ignore unsupported query
     }
   }
-  return false;
+  return 60;
 }
 
 let cachedRendererString = null;
@@ -269,7 +275,7 @@ function detectPreferredFrameRateId() {
   const deviceMemory = typeof navigator.deviceMemory === 'number' ? navigator.deviceMemory : null;
   const hardwareConcurrency = navigator.hardwareConcurrency ?? 4;
   const lowRefresh = detectLowRefreshDisplay();
-  const highRefresh = detectHighRefreshDisplay();
+  const refreshRateHint = detectRefreshRateHint();
   const rendererTier = classifyRendererTier(readGraphicsRendererString());
 
   if (lowRefresh) {
@@ -280,11 +286,14 @@ function detectPreferredFrameRateId() {
     if ((deviceMemory !== null && deviceMemory <= 4) || hardwareConcurrency <= 4) {
       return 'fhd60';
     }
-    if (highRefresh && hardwareConcurrency >= 8 && (deviceMemory == null || deviceMemory >= 6)) {
+    if (refreshRateHint >= 144 && hardwareConcurrency >= 10 && (deviceMemory == null || deviceMemory >= 8)) {
+      return 'ultra144';
+    }
+    if (refreshRateHint >= 120 && hardwareConcurrency >= 8 && (deviceMemory == null || deviceMemory >= 6)) {
       return 'uhd120';
     }
     if (
-      highRefresh ||
+      refreshRateHint >= 90 ||
       hardwareConcurrency >= 6 ||
       (deviceMemory != null && deviceMemory >= 6)
     ) {
@@ -293,7 +302,11 @@ function detectPreferredFrameRateId() {
     return 'fhd60';
   }
 
-  if (rendererTier === 'desktopHigh' || hardwareConcurrency >= 8) {
+  if (rendererTier === 'desktopHigh' && refreshRateHint >= 144 && hardwareConcurrency >= 10) {
+    return 'ultra144';
+  }
+
+  if (refreshRateHint >= 120 && (rendererTier === 'desktopHigh' || hardwareConcurrency >= 8)) {
     return 'uhd120';
   }
 
@@ -309,7 +322,7 @@ const CHAIR_MODEL_URLS = [
   'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/SheenChair/glTF-Binary/SheenChair.glb',
   'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/AntiqueChair/glTF-Binary/AntiqueChair.glb'
 ];
-const PREFERRED_TEXTURE_SIZES = ['4k', '2k', '1k'];
+const PREFERRED_TEXTURE_SIZES = ['8k', '4k', '2k'];
 const POLYHAVEN_MODEL_CACHE = new Map();
 const BASIS_TRANSCODER_PATH = 'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/';
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
@@ -430,7 +443,7 @@ function pickBestTextureUrls(apiJson, preferredSizes = PREFERRED_TEXTURE_SIZES) 
 }
 
 const HDRI_URL_CACHE = new Map();
-const HDRI_RESOLUTION_PATTERN = /(?:^|[_/-])((?:1|2|4|6|8|16)k)(?=\.|[_/-]|$)/i;
+const HDRI_RESOLUTION_PATTERN = /(?:^|[_/-])((?:2|4|8|16|20)k)(?=\.|[_/-]|$)/i;
 
 const normalizeHdriResolutionId = (value) => {
   const lower = String(value || '').toLowerCase();
@@ -2303,10 +2316,11 @@ const FRAME_RATE_OPTIONS = Object.freeze([
     fps: 60,
     renderScale: 1,
     pixelRatioCap: 1.4,
-    resolution: 'Full HD texture pack • 60 FPS',
-    hdriResolution: '1k',
-    preferredTextureSizes: ['2k', '1k'],
-    description: 'Balanced battery profile using Full HD assets.'
+    resolution: '2K texture pack • 60 FPS',
+    hdriResolution: '2k',
+    hdriFallbackResolution: '2k',
+    preferredTextureSizes: ['2k'],
+    description: 'Balanced battery profile with official Poly Haven 2K HDRI + materials.'
   },
   {
     id: 'fhd90',
@@ -2314,41 +2328,56 @@ const FRAME_RATE_OPTIONS = Object.freeze([
     fps: 90,
     renderScale: 1.12,
     pixelRatioCap: 1.55,
-    resolution: '2K texture pack • 90 FPS',
-    hdriResolution: '2k',
-    preferredTextureSizes: ['2k', '1k'],
-    description: 'Sharper 2K assets for fluid 90 FPS play.'
+    resolution: '8K texture pack • 90 FPS',
+    hdriResolution: '8k',
+    hdriFallbackResolution: '4k',
+    preferredTextureSizes: ['8k', '4k', '2k'],
+    description: 'Official Poly Haven 8K target with 4K fallback for consistent 90 Hz rendering.'
   },
   {
     id: 'qhd90',
-    label: 'Pro (105 Hz)',
-    fps: 105,
-    renderScale: 1.22,
+    label: 'Pro (120 Hz)',
+    fps: 120,
+    renderScale: 1.24,
     pixelRatioCap: 1.72,
-    resolution: '4K texture pack • 105 FPS',
-    hdriResolution: '4k',
-    preferredTextureSizes: ['4k', '2k', '1k'],
-    description: 'High-detail 4K assets for premium devices.'
+    resolution: '16K texture pack • 120 FPS',
+    hdriResolution: '16k',
+    hdriFallbackResolution: '8k',
+    preferredTextureSizes: ['16k', '8k', '4k'],
+    description: 'Official Poly Haven 16K target with 8K fallback for 120 Hz devices.'
   },
   {
     id: 'uhd120',
-    label: 'Ultra (120 Hz)',
-    fps: 120,
-    renderScale: 1.28,
-    pixelRatioCap: 1.85,
-    resolution: '6K texture pack • 120 FPS',
-    hdriResolution: '6k',
-    preferredTextureSizes: ['6k', '4k', '2k', '1k'],
-    description: 'Maximum 6K assets and 120 FPS target.'
+    label: 'Ultra (144 Hz)',
+    fps: 144,
+    renderScale: 1.3,
+    pixelRatioCap: 1.9,
+    resolution: '20K texture pack • 144 FPS',
+    hdriResolution: '20k',
+    hdriFallbackResolution: '16k',
+    preferredTextureSizes: ['20k', '16k', '8k'],
+    description: 'Top-tier official Poly Haven 20K target with 16K fallback for 144 Hz displays.'
+  },
+  {
+    id: 'ultra144',
+    label: 'Extreme (144 Hz)',
+    fps: 144,
+    renderScale: 1.34,
+    pixelRatioCap: 2,
+    resolution: '20K texture pack • 144 FPS',
+    hdriResolution: '20k',
+    hdriFallbackResolution: '16k',
+    preferredTextureSizes: ['20k', '16k', '8k'],
+    description: 'Maximum clarity profile for 144 Hz hardware using official Poly Haven 20K assets.'
   }
 ]);
 const HDRI_RESOLUTION_OPTIONS = Object.freeze([
   { id: 'auto', label: 'Match Graphics' },
+  { id: '20k', label: '20K' },
+  { id: '16k', label: '16K' },
   { id: '8k', label: '8K' },
-  { id: '6k', label: '6K' },
   { id: '4k', label: '4K' },
-  { id: '2k', label: '2K' },
-  { id: '1k', label: 'Full HD' }
+  { id: '2k', label: '2K' }
 ]);
 const HDRI_RESOLUTION_OPTION_MAP = Object.freeze(
   HDRI_RESOLUTION_OPTIONS.reduce((acc, option) => {
@@ -2356,7 +2385,7 @@ const HDRI_RESOLUTION_OPTION_MAP = Object.freeze(
     return acc;
   }, {})
 );
-const DEFAULT_HDRI_RESOLUTION_ID = '4k';
+const DEFAULT_HDRI_RESOLUTION_ID = '2k';
 const DEFAULT_FRAME_RATE_OPTION =
   FRAME_RATE_OPTIONS.find((opt) => opt.id === DEFAULT_FRAME_RATE_ID) ?? FRAME_RATE_OPTIONS[0];
 
@@ -2546,14 +2575,21 @@ export default function MurlanRoyaleArena({ search }) {
       if (typeof targetFromGraphics === 'string' && HDRI_RESOLUTION_OPTION_MAP[targetFromGraphics]) {
         return targetFromGraphics;
       }
-      return '4k';
+      return DEFAULT_HDRI_RESOLUTION_ID;
     }
     if (HDRI_RESOLUTION_OPTION_MAP[hdriResolutionId]) return hdriResolutionId;
     if (typeof targetFromGraphics === 'string' && HDRI_RESOLUTION_OPTION_MAP[targetFromGraphics]) {
       return targetFromGraphics;
     }
-    return '4k';
+    return DEFAULT_HDRI_RESOLUTION_ID;
   }, [activeFrameRateOption, hdriResolutionId]);
+  const resolvedHdriFallbackResolution = useMemo(() => {
+    const targetFromGraphics = activeFrameRateOption?.hdriFallbackResolution;
+    if (typeof targetFromGraphics === 'string' && HDRI_RESOLUTION_OPTION_MAP[targetFromGraphics]) {
+      return targetFromGraphics;
+    }
+    return DEFAULT_HDRI_RESOLUTION_ID;
+  }, [activeFrameRateOption]);
   const resolvedFrameTiming = useMemo(() => {
     const fallbackFps =
       Number.isFinite(DEFAULT_FRAME_RATE_OPTION?.fps) && DEFAULT_FRAME_RATE_OPTION.fps > 0
@@ -3783,7 +3819,10 @@ export default function MurlanRoyaleArena({ search }) {
       const envResult = await loadPolyHavenHdriEnvironment(three.renderer, {
         ...activeVariant,
         preferredResolutions,
-        fallbackResolution: preferredResolutions[preferredResolutions.length - 1] || DEFAULT_HDRI_RESOLUTIONS[0]
+        fallbackResolution:
+          resolvedHdriFallbackResolution ||
+          preferredResolutions[preferredResolutions.length - 1] ||
+          DEFAULT_HDRI_RESOLUTIONS[0]
       });
       if (!envResult?.envMap || !three.scene) return;
       const prevDispose = disposeEnvironmentRef.current;
@@ -3813,7 +3852,7 @@ export default function MurlanRoyaleArena({ search }) {
         prevDispose();
       }
     },
-    [resolvedHdriResolution]
+    [resolvedHdriFallbackResolution, resolvedHdriResolution]
   );
 
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- Standardize Murlan Royale HDRI choices to use official Poly Haven resolution tiers and ensure graphics selections match refresh-rate targets (60/90/120/144 Hz). 
- Provide correct runtime selection/fallbacks so the environment HDRI and texture fetches use the intended resolution tiers for table finishes, cloths, cards, UI and chairs.

### Description
- Updated HDRI resolution ladder and defaults to official tiers: `['20k','16k','8k','4k','2k']` and `DEFAULT_HDRI_RESOLUTIONS = ['4k','2k']` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx`.
- Added higher-resolution `HDRI_RESOLUTION_OPTIONS` (`16k`, `20k`), removed unsupported 1k/6k choices for the Murlan UI, and extended the HDRI URL resolution regex to recognize `20k/16k/8k/4k/2k`.
- Reworked frame-rate quality presets (`FRAME_RATE_OPTIONS`) to include explicit `hdriResolution` and `hdriFallbackResolution` and to map graphics profiles to requested targets: 60 Hz → `2k`, 90 Hz → `8k` (fallback `4k`), 120 Hz → `16k` (fallback `8k`), 144 Hz → `20k` (fallback `16k`).
- Improved refresh-rate detection by replacing `detectHighRefreshDisplay()` with `detectRefreshRateHint()` (returns an FPS hint) and using it inside `detectPreferredFrameRateId()` and renderer-tier logic; adjusted preferred texture size ordering to `['8k','4k','2k']` and applied fallback selection when calling `loadPolyHavenHdriEnvironment`.

### Testing
- Ran unit tests: `npm test -- --runInBand test/murlan.test.js` — passed (1 test suite, 12 tests; all passed).
- Ran lint check: `npx eslint webapp/src/pages/Games/MurlanRoyaleArena.jsx` — file is ignored by repo ESLint ignore rules in this environment (warning only), no blocking lint errors reported.

Files changed: `webapp/src/pages/Games/MurlanRoyaleArena.jsx`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cba6b9d6ec832986741849db4aeca3)