### PR TITLE
Force 4K HDRI on mobile for 90/120/144 Hz Ludo profiles

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -295,6 +295,19 @@ function detectPreferredFrameRateId() {
   return DEFAULT_FRAME_RATE_ID;
 }
 
+function isLikelyMobileDevice() {
+  if (typeof window === 'undefined' || typeof navigator === 'undefined') {
+    return false;
+  }
+  const coarsePointer = detectCoarsePointer();
+  const ua = navigator.userAgent ?? '';
+  const isMobileUA = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(ua);
+  const maxTouchPoints = navigator.maxTouchPoints ?? 0;
+  const isTouch = maxTouchPoints > 1;
+  const rendererTier = classifyRendererTier(readGraphicsRendererString());
+  return isMobileUA || coarsePointer || isTouch || rendererTier === 'mobile';
+}
+
 const ABG_MODEL_URLS = Object.freeze([
   'https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Models@master/2.0/ABeautifulGame/glTF-Binary/ABeautifulGame.glb',
   'https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Models@master/2.0/ABeautifulGame/glTF/ABeautifulGame.gltf'
@@ -2749,6 +2762,15 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
   const textureResolutionKey = useMemo(() => textureResolutionStack.join('|'), [textureResolutionStack]);
   const hdriResolutionProfile = useMemo(() => {
     const option = activeFrameRateOption ?? DEFAULT_FRAME_RATE_OPTION;
+    const mobileHdri4kOptionIds = ['qhd90', 'uhd120', 'uhd144'];
+    const forceMobile4kHdri = isLikelyMobileDevice() && mobileHdri4kOptionIds.includes(option?.id);
+    if (forceMobile4kHdri) {
+      return {
+        preferredResolutions: ['4k', '2k'],
+        fallbackResolution: '2k',
+        key: '4k|2k|mobile'
+      };
+    }
     const preferred = Array.isArray(option?.hdriPreferredResolutions) ? option.hdriPreferredResolutions : [];
     const resolvedPreferred = preferred.length ? preferred : DEFAULT_HDRI_RESOLUTIONS;
     const fallback =


### PR DESCRIPTION
### Motivation
- Ensure mobile devices running high-refresh frame-rate profiles (90 Hz, 120 Hz, 144 Hz) use higher-quality HDRIs (4K with 2K fallback) while preserving existing desktop behavior.
- Avoid globally increasing HDRI sizes on desktop to keep desktop performance and existing user settings unchanged.

### Description
- Added a mobile detection helper `isLikelyMobileDevice()` that reuses existing heuristics (coarse pointer, UA, touch points, renderer tier) in `webapp/src/pages/Games/LudoBattleRoyal.jsx`.
- In the `hdriResolutionProfile` `useMemo` inside `Ludo3D`, added a mobile-only override that forces `preferredResolutions: ['4k','2k']` and `fallbackResolution: '2k'` when the active frame-rate option id is one of `qhd90`, `uhd120`, or `uhd144` and `isLikelyMobileDevice()` returns true.
- Kept all existing desktop HDRI resolution logic and other frame-rate/profile properties unchanged; only mobile HDRI selection is altered.

### Testing
- Ran the production build with `npm --prefix webapp run build` and the build completed successfully (vite build completed, `dist/` produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbc65fa81c8329acd36604a3429749)