### PR TITLE
Texas Hold'em: tie HDRI to graphics preset and remove HDRI menu controls

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -476,7 +476,6 @@ const CHAIR_MODEL_URLS = [
 
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
 const BASIS_TRANSCODER_PATH = 'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/';
-const HDRI_RESOLUTION_STORAGE_KEY = 'texasHoldemHdriResolution';
 const HDRI_RESOLUTION_OPTIONS = Object.freeze([
   { id: '2k', label: '2K' },
   { id: '4k', label: '4K' },
@@ -853,8 +852,7 @@ const CUSTOMIZATION_SECTIONS = [
   { key: 'tableWood', label: 'Table Wood', options: TABLE_WOOD_OPTIONS },
   { key: 'tableCloth', label: 'Table Cloth', options: TABLE_CLOTH_OPTIONS },
   { key: 'tableShape', label: 'Table Shape', options: TABLE_SHAPE_OPTIONS },
-  { key: 'cards', label: 'Cards', options: CARD_THEMES },
-  { key: 'environmentHdri', label: 'HDR Environment', options: TEXAS_HDRI_OPTIONS }
+  { key: 'cards', label: 'Cards', options: CARD_THEMES }
 ];
 
 const NON_DIAMOND_SHAPE_INDEX = (() => {
@@ -3281,13 +3279,6 @@ function TexasHoldemArena({ search }) {
       console.warn("Failed to persist Texas Hold'em graphics", error);
     }
   }, [frameRateId]);
-  useEffect(() => {
-    try {
-      window.localStorage?.setItem(HDRI_RESOLUTION_STORAGE_KEY, hdriResolutionId);
-    } catch (error) {
-      console.warn("Failed to persist Texas Hold'em HDRI resolution", error);
-    }
-  }, [hdriResolutionId]);
   const [configOpen, setConfigOpen] = useState(false);
   const timerRef = useRef(null);
   const turnIntervalRef = useRef(null);
@@ -6516,33 +6507,7 @@ function TexasHoldemArena({ search }) {
               <div>
                 <p className="text-[10px] uppercase tracking-[0.35em] text-white/70">Graphics</p>
                 <p className="mt-1 text-[0.7rem] text-white/60">
-                  Graphics preset auto-syncs HDRI using official Poly Haven tiers (2K/4K/8K/16K/20K) and defined fallback ladders.
-                </p>
-              </div>
-              <div className="space-y-2">
-                <p className="text-[10px] uppercase tracking-[0.2em] text-white/60">HDRI Resolution</p>
-                <div className="grid grid-cols-5 gap-2">
-                  {HDRI_RESOLUTION_OPTIONS.map((option) => {
-                    const active = option.id === hdriResolutionId;
-                    return (
-                      <button
-                        key={option.id}
-                        type="button"
-                        disabled
-                        aria-pressed={active}
-                        className={`rounded-xl border px-2 py-2 text-center text-[11px] font-semibold uppercase tracking-[0.22em] transition ${
-                          active
-                            ? 'border-sky-300 bg-sky-300/15 text-sky-100 shadow-[0_0_12px_rgba(125,211,252,0.35)]'
-                            : 'border-white/10 bg-white/5 text-white/40'
-                        }`}
-                      >
-                        {option.label}
-                      </button>
-                    );
-                  })}
-                </div>
-                <p className="text-[10px] uppercase tracking-[0.2em] text-white/45">
-                  Auto-selected from your active Graphics profile.
+                  Graphics preset now drives one shared quality ladder for table, chairs, and HDRI so arena fidelity stays matched.
                 </p>
               </div>
               <div className="grid gap-2">


### PR DESCRIPTION
### Motivation
- Prevent HDRI quality from drifting relative to table and chairs by making HDRI resolution follow the active graphics preset instead of a separate menu control.
- Simplify the in-game customization UI by removing redundant HDRI controls and ensuring a single source of truth for rendering fidelity.

### Description
- Removed the HDR Environment selector from the Texas Hold'em customization sections so `environmentHdri` is no longer exposed in the menu UI. 
- Eliminated separate HDRI resolution persistence by removing the `texasHoldemHdriResolution` storage key and the effect that saved it to `localStorage`.
- Removed the standalone HDRI resolution block from the Graphics panel and updated the helper copy to indicate that table, chairs, and HDRI share a single quality ladder driven by the graphics preset.
- All changes made in `webapp/src/pages/Games/TexasHoldemArena.jsx` to keep HDRI resolution in sync with the existing graphics/frame-rate/profile logic.

### Testing
- Ran the unit test `test/texasHoldemHdriPreload.test.js` with `npm test -- --runInBand test/texasHoldemHdriPreload.test.js` and it passed. 
- Ran ESLint via `npx eslint` which produced a repo-ignore warning for the file but no lint errors were introduced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbd32a3e188329a9343ce1e776e8ba)