### PR TITLE
Pool Royale: bind HDRI resolution to graphics presets and remove 144 Hz option

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -349,7 +349,6 @@ function detectDisplayRefreshRateBucket() {
     return 60;
   }
   const checks = [
-    { query: '(min-refresh-rate: 143hz)', fps: 144 },
     { query: '(min-refresh-rate: 119hz)', fps: 120 },
     { query: '(min-refresh-rate: 89hz)', fps: 90 }
   ];
@@ -589,13 +588,10 @@ function detectPreferredFrameRateId() {
       return 'fhd60';
     }
     if (
-      refreshBucket >= 144 &&
+      (refreshBucket >= 120 || highRefresh) &&
       hardwareConcurrency >= 8 &&
-      (deviceMemory == null || deviceMemory >= 8)
+      (deviceMemory == null || deviceMemory >= 6)
     ) {
-      return 'uhd144';
-    }
-    if (highRefresh && hardwareConcurrency >= 8 && (deviceMemory == null || deviceMemory >= 6)) {
       return 'uhd120';
     }
     if (
@@ -608,34 +604,16 @@ function detectPreferredFrameRateId() {
     return 'fhd60';
   }
 
-  if (
-    refreshBucket >= 144 &&
-    (rendererTier === 'desktopHigh' || hardwareConcurrency >= 8)
-  ) {
-    return 'uhd144';
-  }
-  if (rendererTier === 'desktopHigh' || hardwareConcurrency >= 8) {
+  if (refreshBucket >= 120 && (rendererTier === 'desktopHigh' || hardwareConcurrency >= 8)) {
     return 'uhd120';
   }
+  if (rendererTier === 'desktopHigh' || hardwareConcurrency >= 8) return 'uhd120';
 
   if (rendererTier === 'desktopMid') {
     return 'qhd90';
   }
 
   return DEFAULT_FRAME_RATE_ID;
-}
-
-function isMobileGraphicsDevice() {
-  if (typeof window === 'undefined' || typeof navigator === 'undefined') {
-    return false;
-  }
-  const coarsePointer = detectCoarsePointer();
-  const ua = navigator.userAgent ?? '';
-  const isMobileUA = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(ua);
-  const maxTouchPoints = navigator.maxTouchPoints ?? 0;
-  const isTouch = maxTouchPoints > 1;
-  const rendererTier = classifyRendererTier(readGraphicsRendererString());
-  return isMobileUA || coarsePointer || isTouch || rendererTier === 'mobile';
 }
 
 function resolveDefaultPixelRatioCap() {
@@ -3342,7 +3320,7 @@ const FRAME_RATE_OPTIONS = Object.freeze([
     renderScale: 1.12,
     pixelRatioCap: 1.55,
     resolution: '4K texture pack • 90 FPS',
-    description: 'Sharper Poly Haven 4K assets with automatic 2K fallback.'
+    description: 'Sharper Poly Haven 4K assets at a 90 FPS target.'
   },
   {
     id: 'uhd120',
@@ -3351,16 +3329,7 @@ const FRAME_RATE_OPTIONS = Object.freeze([
     renderScale: 1.3,
     pixelRatioCap: 1.85,
     resolution: '8K texture pack • 120 FPS',
-    description: 'Poly Haven 8K assets with 4K fallback for stable loading.'
-  },
-  {
-    id: 'uhd144',
-    label: 'Elite (144 Hz)',
-    fps: 144,
-    renderScale: 1.36,
-    pixelRatioCap: 2,
-    resolution: '8K texture pack • 144 FPS',
-    description: 'Maximum Poly Haven 8K assets with 144 FPS target.'
+    description: 'Poly Haven 8K assets at a 120 FPS target.'
   }
 ]);
 const DEFAULT_FRAME_RATE_ID = 'qhd90';
@@ -4875,20 +4844,6 @@ function softenOuterExtrudeEdges(geometry, depth, radiusRatio = 0.25, options = 
 
 const HDRI_STORAGE_KEY = 'poolHdriEnvironment';
 const DEFAULT_HDRI_RESOLUTIONS = Object.freeze(['4k']);
-const HDRI_RESOLUTION_STORAGE_KEY = 'poolHdriResolution';
-const DEFAULT_HDRI_RESOLUTION_MODE = '4k';
-const HDRI_RESOLUTION_OPTIONS = Object.freeze([
-  { id: 'auto', label: 'Match Table' },
-  { id: '8k', label: '8K' },
-  { id: '4k', label: '4K' },
-  { id: '2k', label: '2K' }
-]);
-const HDRI_RESOLUTION_OPTION_MAP = Object.freeze(
-  HDRI_RESOLUTION_OPTIONS.reduce((acc, option) => {
-    acc[option.id] = option;
-    return acc;
-  }, {})
-);
 const DEFAULT_HDRI_CAMERA_HEIGHT_M = 1.5;
 const MIN_HDRI_CAMERA_HEIGHT_M = 0.8;
 const DEFAULT_HDRI_RADIUS_MULTIPLIER = 6;
@@ -4900,20 +4855,12 @@ const HDRI_CAMERA_SCALE_LERP = 0.18;
 const HDRI_URL_CACHE = new Map();
 const HDRI_PREFETCH_CACHE = new Map();
 const HDRI_RESOLUTION_POLICY_BY_FPS = Object.freeze([
-  { minFps: 144, preferredResolutions: Object.freeze(['8k']), fallbackResolution: '8k' },
-  { minFps: 120, preferredResolutions: Object.freeze(['8k', '4k']), fallbackResolution: '4k' },
-  { minFps: 90, preferredResolutions: Object.freeze(['4k', '2k']), fallbackResolution: '2k' },
+  { minFps: 120, preferredResolutions: Object.freeze(['8k']), fallbackResolution: '8k' },
+  { minFps: 90, preferredResolutions: Object.freeze(['4k']), fallbackResolution: '4k' },
   { minFps: 0, preferredResolutions: Object.freeze(['2k']), fallbackResolution: '2k' }
 ]);
 
-function resolveHdriPolicyForFps(fps, { isMobileDevice = false } = {}) {
-  if (isMobileDevice && Number.isFinite(fps) && fps >= 90) {
-    return {
-      minFps: 90,
-      preferredResolutions: Object.freeze(['4k']),
-      fallbackResolution: '4k'
-    };
-  }
+function resolveHdriPolicyForFps(fps) {
   const safeFps = Number.isFinite(fps) ? fps : 60;
   return (
     HDRI_RESOLUTION_POLICY_BY_FPS.find((policy) => safeFps >= policy.minFps) ??
@@ -4921,11 +4868,7 @@ function resolveHdriPolicyForFps(fps, { isMobileDevice = false } = {}) {
   );
 }
 
-function resolveHdriResolutionForTable(tableSizeMeta) {
-  const widthMm = tableSizeMeta?.playfield?.widthMm;
-  if (Number.isFinite(widthMm) && widthMm >= 2540) {
-    return '8k';
-  }
+function resolveHdriResolutionForTable() {
   return '4k';
 }
 
@@ -12821,15 +12764,6 @@ function PoolRoyaleGame({
       POOL_ROYALE_DEFAULT_HDRI_ID
     );
   });
-  const [hdriResolutionId, setHdriResolutionId] = useState(() => {
-    if (typeof window !== 'undefined') {
-      const stored = window.localStorage.getItem(HDRI_RESOLUTION_STORAGE_KEY);
-      if (stored && HDRI_RESOLUTION_OPTION_MAP[stored]) {
-        return stored;
-      }
-    }
-    return DEFAULT_HDRI_RESOLUTION_MODE;
-  });
   const [lightingId, setLightingId] = useState(() => DEFAULT_LIGHTING_ID);
   const [chromeColorId, setChromeColorId] = useState(() => {
     return resolveStoredSelection(
@@ -12868,22 +12802,9 @@ function PoolRoyaleGame({
     () => resolveGraphicsResolutionTier(activeFrameRateOption?.fps),
     [activeFrameRateOption]
   );
-  const mobileGraphicsDevice = useMemo(() => isMobileGraphicsDevice(), []);
   const autoHdriResolutionFromGraphics = useMemo(() => {
-    const graphicsResolution =
-      activeGraphicsResolutionTier?.key ?? resolveHdriResolutionForTable(responsiveTableSize);
-    const fps = activeFrameRateOption?.fps;
-    if (mobileGraphicsDevice && Number.isFinite(fps) && fps >= 90) {
-      return '4k';
-    }
-    return graphicsResolution;
-  }, [activeFrameRateOption, activeGraphicsResolutionTier, mobileGraphicsDevice, responsiveTableSize]);
-  const activeHdriResolutionOption = useMemo(
-    () =>
-      HDRI_RESOLUTION_OPTION_MAP[hdriResolutionId] ??
-      HDRI_RESOLUTION_OPTIONS[0],
-    [hdriResolutionId]
-  );
+    return activeGraphicsResolutionTier?.key ?? resolveHdriResolutionForTable(responsiveTableSize);
+  }, [activeGraphicsResolutionTier, responsiveTableSize]);
   const frameQualityProfile = useMemo(() => {
     const option = activeFrameRateOption ?? FRAME_RATE_OPTIONS[0];
     const fallback = FRAME_RATE_OPTIONS[0];
@@ -12913,11 +12834,6 @@ function PoolRoyaleGame({
     updateRuntimeTextureProfile({ fps: frameQualityProfile?.fps });
     ensurePocketPlasticTextures();
   }, [frameQualityProfile]);
-  useEffect(() => {
-    const targetHdriResolution = autoHdriResolutionFromGraphics;
-    if (!targetHdriResolution || hdriResolutionId === targetHdriResolution) return;
-    setHdriResolutionId(targetHdriResolution);
-  }, [autoHdriResolutionFromGraphics, hdriResolutionId]);
   const activeBroadcastSystem = useMemo(
     () => resolveBroadcastSystem(broadcastSystemId),
     [broadcastSystemId]
@@ -13014,20 +12930,11 @@ function PoolRoyaleGame({
     [availableTableBases, tableBaseId]
   );
   const resolvedHdriResolution = useMemo(() => {
-    if (hdriResolutionId === 'auto') {
-      return autoHdriResolutionFromGraphics;
-    }
-    if (HDRI_RESOLUTION_OPTION_MAP[hdriResolutionId]) {
-      return hdriResolutionId;
-    }
     return autoHdriResolutionFromGraphics;
-  }, [autoHdriResolutionFromGraphics, hdriResolutionId]);
+  }, [autoHdriResolutionFromGraphics]);
   const activeHdriPolicy = useMemo(
-    () =>
-      resolveHdriPolicyForFps(activeFrameRateOption?.fps, {
-        isMobileDevice: mobileGraphicsDevice
-      }),
-    [activeFrameRateOption, mobileGraphicsDevice]
+    () => resolveHdriPolicyForFps(activeFrameRateOption?.fps),
+    [activeFrameRateOption]
   );
   const activeEnvironmentHdri = useMemo(
     () => {
@@ -13041,21 +12948,13 @@ function PoolRoyaleGame({
         availableEnvironmentHdris[0] ??
         POOL_ROYALE_HDRI_VARIANTS[0];
       if (!variant) return null;
-      const basePreferred =
-        Array.isArray(variant.preferredResolutions) && variant.preferredResolutions.length
-          ? variant.preferredResolutions
-          : DEFAULT_HDRI_RESOLUTIONS;
       const policyPreferred = activeHdriPolicy?.preferredResolutions ?? [];
-      const resolved = resolvedHdriResolution ?? policyPreferred[0] ?? basePreferred[0];
+      const resolved = resolvedHdriResolution ?? policyPreferred[0] ?? DEFAULT_HDRI_RESOLUTIONS[0];
       if (!resolved) return variant;
-      const preferredResolutions =
-        policyPreferred.length > 0
-          ? [resolved, ...policyPreferred.filter((res) => res !== resolved)]
-          : [resolved, ...basePreferred.filter((res) => res !== resolved)];
       return {
         ...variant,
-        preferredResolutions,
-        fallbackResolution: activeHdriPolicy?.fallbackResolution ?? resolved
+        preferredResolutions: [resolved],
+        fallbackResolution: resolved
       };
     },
     [activeHdriPolicy, availableEnvironmentHdris, environmentHdriId, resolvedHdriResolution]
@@ -14353,8 +14252,8 @@ function PoolRoyaleGame({
   }, [environmentHdriId]);
   useEffect(() => {
     if (typeof window === 'undefined') return;
-    window.localStorage.setItem(HDRI_RESOLUTION_STORAGE_KEY, hdriResolutionId);
-  }, [hdriResolutionId]);
+    window.localStorage.removeItem('poolHdriResolution');
+  }, []);
   useEffect(() => {
     if (typeof window === 'undefined') return;
     window.localStorage.setItem(LIGHTING_STORAGE_KEY, lightingId);
@@ -14371,17 +14270,10 @@ function PoolRoyaleGame({
       .filter((variant) => variant.id !== environmentHdriId)
       .slice(0, 2)
       .map((variant) => {
-        const basePreferred =
-          Array.isArray(variant.preferredResolutions) && variant.preferredResolutions.length
-            ? variant.preferredResolutions
-            : DEFAULT_HDRI_RESOLUTIONS;
-        const resolved = resolvedHdriResolution ?? basePreferred[0];
-        const preferredResolutions = resolved
-          ? [resolved, ...basePreferred.filter((res) => res !== resolved)]
-          : basePreferred;
+        const resolved = resolvedHdriResolution ?? DEFAULT_HDRI_RESOLUTIONS[0];
         return {
           ...variant,
-          preferredResolutions,
+          preferredResolutions: resolved ? [resolved] : DEFAULT_HDRI_RESOLUTIONS,
           fallbackResolution: resolved
         };
       });
@@ -33327,34 +33219,9 @@ const powerRef = useRef(hud.power);
                 <p className="mt-1 text-[0.7rem] text-white/70">
                   Match the Murlan Royale quality presets for identical FPS and clarity choices.
                 </p>
-                <div className="mt-3">
-                  <h4 className="text-[10px] uppercase tracking-[0.32em] text-emerald-100/70">
-                    HDRI Resolution
-                  </h4>
-                  <p className="mt-1 text-[0.7rem] text-white/60">
-                    Active: {resolvedHdriResolution?.toUpperCase() || activeHdriResolutionOption.label}
-                  </p>
-                  <div className="mt-2 flex flex-wrap gap-2">
-                    {HDRI_RESOLUTION_OPTIONS.map((option) => {
-                      const active = option.id === hdriResolutionId;
-                      return (
-                        <button
-                          key={option.id}
-                          type="button"
-                          onClick={() => setHdriResolutionId(option.id)}
-                          aria-pressed={active}
-                          className={`flex-1 min-w-[7.5rem] rounded-full border px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
-                            active
-                              ? 'border-emerald-300 bg-emerald-300 text-black shadow-[0_0_16px_rgba(16,185,129,0.55)]'
-                              : 'border-white/20 bg-white/10 text-white/80 hover:bg-white/20'
-                          }`}
-                        >
-                          {option.label}
-                        </button>
-                      );
-                    })}
-                  </div>
-                </div>
+                <p className="mt-1 text-[0.7rem] text-white/60">
+                  HDRI resolution follows Graphics preset only: 60 Hz → 2K, 90 Hz → 4K, 120 Hz → 8K.
+                </p>
                 <div className="mt-2 grid gap-2">
                   {FRAME_RATE_OPTIONS.map((option) => {
                     const active = option.id === frameRateId;


### PR DESCRIPTION
### Motivation
- Ensure HDRI resolution is deterministic and driven only by the chosen graphics/refresh-rate preset for consistent mobile and desktop behavior.
- Simplify UX by removing a separate HDRI resolution selector and preventing unsupported 144 Hz preset paths.

### Description
- Removed the user-facing HDRI resolution selector and storage (`poolHdriResolution`) so HDRI is no longer directly adjustable in the Graphics panel and users control it via the graphics preset only.
- Bound HDRI resolution to the selected refresh-rate preset (graphics preset) with the mapping: 60 Hz → 2K, 90 Hz → 4K, 120 Hz → 8K, and removed 144 Hz as a preset/target.
- Updated refresh-rate detection and preferred-preset selection logic to stop targeting 144 Hz and to cap the top path at 120 Hz for mobile and desktop heuristics.
- Simplified HDRI policy and preload behavior to use a single enforced resolution per FPS tier (no multi-resolution fallback chains); prefetch now requests only the resolved resolution.
- Changes are implemented in `webapp/src/pages/Games/PoolRoyale.jsx` (adjusted detection, frame options, HDRI policy, UI text and storage handling).

### Testing
- Ran a production build: `cd webapp && npm run -s build`; the build completed successfully.
- Build produced the usual Vite warnings about large chunks/dynamic imports but no errors relevant to these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbfb7d8fb483298ca6e0363c86d1bd)