### PR TITLE
Refactor HDRI resolution selection and remove 144Hz/HDri overrides

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -170,7 +170,6 @@ function detectDisplayRefreshTier() {
     return '60';
   }
   const queries = [
-    ['144', '(min-refresh-rate: 144hz)'],
     ['120', '(min-refresh-rate: 120hz)'],
     ['90', '(min-refresh-rate: 90hz)']
   ];
@@ -284,9 +283,6 @@ function detectPreferredFrameRateId() {
     if ((deviceMemory !== null && deviceMemory <= 4) || hardwareConcurrency <= 4) {
       return 'fhd60';
     }
-    if (refreshTier === '144' && hardwareConcurrency >= 8 && (deviceMemory == null || deviceMemory >= 8)) {
-      return 'ultra144';
-    }
     if (refreshTier === '120' && hardwareConcurrency >= 8 && (deviceMemory == null || deviceMemory >= 6)) {
       return 'uhd120';
     }
@@ -298,10 +294,6 @@ function detectPreferredFrameRateId() {
       return 'smooth90';
     }
     return 'fhd60';
-  }
-
-  if (refreshTier === '144' && (rendererTier === 'desktopHigh' || hardwareConcurrency >= 10)) {
-    return 'ultra144';
   }
 
   if (refreshTier === '120' && (rendererTier === 'desktopHigh' || hardwareConcurrency >= 8)) {
@@ -780,7 +772,6 @@ const DEFAULT_APPEARANCE = {
 };
 const APPEARANCE_STORAGE_KEY = 'murlanRoyaleAppearance';
 const FRAME_RATE_STORAGE_KEY = 'murlanFrameRate';
-const HDRI_RESOLUTION_STORAGE_KEY = 'murlanHdriResolution';
 const COMMENTARY_PRESET_STORAGE_KEY = 'murlanRoyaleCommentaryPreset';
 const COMMENTARY_MUTE_STORAGE_KEY = 'murlanRoyaleCommentaryMute';
 const COMMENTARY_QUEUE_LIMIT = 4;
@@ -1096,8 +1087,7 @@ const CUSTOMIZATION_SECTIONS = [
   { key: 'stools', label: 'Stools', options: STOOL_THEMES },
   ...(ENABLE_3D_HUMAN_CHARACTERS
     ? [{ key: 'characters', label: '3D Players', options: MURLAN_CHARACTER_THEMES }]
-    : []),
-  { key: 'environmentHdri', label: 'HDR Environment', options: MURLAN_HDRI_OPTIONS }
+    : [])
 ];
 
 function createRegularPolygonShape(sides = 8, radius = 1) {
@@ -2340,59 +2330,38 @@ const FRAME_RATE_OPTIONS = Object.freeze([
     hdriResolution: '8k',
     preferredTextureSizes: ['8k', '4k', '2k', '1k'],
     description: 'Poly Haven 8K HDRI target with fallback to 4K.'
-  },
-  {
-    id: 'ultra144',
-    label: 'Extreme (144 Hz)',
-    fps: 144,
-    renderScale: 1.28,
-    pixelRatioCap: 1.85,
-    resolution: '8K texture pack • 144 FPS',
-    hdriResolution: '8k',
-    preferredTextureSizes: ['8k', '4k', '2k', '1k'],
-    description: 'Poly Haven 8K HDRI target.'
   }
 ]);
-const HDRI_RESOLUTION_OPTIONS = Object.freeze([
-  { id: 'auto', label: 'Match Graphics' },
-  { id: '8k', label: '8K' },
-  { id: '4k', label: '4K' },
-  { id: '2k', label: '2K' }
+
+const HDRI_RESOLUTION_POLICY_BY_FPS = Object.freeze([
+  { minFps: 120, preferredResolutions: Object.freeze(['8k', '4k', '2k']), fallbackResolution: '4k' },
+  { minFps: 90, preferredResolutions: Object.freeze(['4k', '2k']), fallbackResolution: '2k' },
+  { minFps: 0, preferredResolutions: Object.freeze(['2k', '1k']), fallbackResolution: '1k' }
 ]);
-const HDRI_RESOLUTION_OPTION_MAP = Object.freeze(
-  HDRI_RESOLUTION_OPTIONS.reduce((acc, option) => {
-    acc[option.id] = option;
-    return acc;
-  }, {})
-);
-const DEFAULT_HDRI_RESOLUTION_ID = 'auto';
+
+function resolveHdriPolicyForFps(fps) {
+  const safeFps = Number.isFinite(fps) ? fps : 60;
+  return (
+    HDRI_RESOLUTION_POLICY_BY_FPS.find((policy) => safeFps >= policy.minFps) ??
+    HDRI_RESOLUTION_POLICY_BY_FPS[HDRI_RESOLUTION_POLICY_BY_FPS.length - 1]
+  );
+}
+
+function buildHdriResolutionChain(primaryResolution, policy = null) {
+  const base = Array.isArray(policy?.preferredResolutions) ? policy.preferredResolutions : [];
+  const fallbackLadder = ['8k', '4k', '2k', '1k'];
+  const ordered = [primaryResolution, ...base, ...fallbackLadder].filter(
+    (value) => typeof value === 'string' && value.length
+  );
+  return [...new Set(ordered)];
+}
+
 const DEFAULT_FRAME_RATE_OPTION =
   FRAME_RATE_OPTIONS.find((opt) => opt.id === DEFAULT_FRAME_RATE_ID) ?? FRAME_RATE_OPTIONS[0];
 
-function detectMobileGraphicsDevice() {
-  if (typeof window === 'undefined' || typeof navigator === 'undefined') {
-    return false;
-  }
-  const ua = navigator.userAgent ?? '';
-  const isMobileUA = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(ua);
-  const coarsePointer = detectCoarsePointer();
-  const maxTouchPoints = navigator.maxTouchPoints ?? 0;
-  const isTouch = maxTouchPoints > 1;
-  const rendererTier = classifyRendererTier(readGraphicsRendererString());
-  return Boolean(isMobileUA || coarsePointer || isTouch || rendererTier === 'mobile');
-}
-
-function resolveHdriResolutionFromGraphics(frameOption, isMobileDevice) {
+function resolveHdriResolutionFromGraphics(frameOption) {
   const targetFromGraphics = frameOption?.hdriResolution;
-  if (
-    isMobileDevice &&
-    Number.isFinite(frameOption?.fps) &&
-    frameOption.fps >= 90 &&
-    HDRI_RESOLUTION_OPTION_MAP['4k']
-  ) {
-    return '4k';
-  }
-  if (typeof targetFromGraphics === 'string' && HDRI_RESOLUTION_OPTION_MAP[targetFromGraphics]) {
+  if (targetFromGraphics === '2k' || targetFromGraphics === '4k' || targetFromGraphics === '8k') {
     return targetFromGraphics;
   }
   return '2k';
@@ -2517,15 +2486,6 @@ export default function MurlanRoyaleArena({ search }) {
     }
     return DEFAULT_FRAME_RATE_ID || DEFAULT_FRAME_RATE_OPTION.id;
   });
-  const [hdriResolutionId, setHdriResolutionId] = useState(() => {
-    if (typeof window !== 'undefined') {
-      const stored = window.localStorage?.getItem(HDRI_RESOLUTION_STORAGE_KEY);
-      if (stored && HDRI_RESOLUTION_OPTION_MAP[stored]) {
-        return stored;
-      }
-    }
-    return DEFAULT_HDRI_RESOLUTION_ID;
-  });
   const activeFrameRateOption = useMemo(
     () => FRAME_RATE_OPTIONS.find((opt) => opt.id === frameRateId) ?? DEFAULT_FRAME_RATE_OPTION,
     [frameRateId]
@@ -2578,18 +2538,13 @@ export default function MurlanRoyaleArena({ search }) {
       window.removeEventListener('orientationchange', updateOrientation);
     };
   }, []);
-  const isMobileGraphicsDevice = useMemo(() => detectMobileGraphicsDevice(), []);
   const resolvedHdriResolution = useMemo(() => {
-    const graphicsHdriResolution = resolveHdriResolutionFromGraphics(
-      activeFrameRateOption,
-      isMobileGraphicsDevice
-    );
-    if (hdriResolutionId === 'auto') {
-      return graphicsHdriResolution;
-    }
-    if (HDRI_RESOLUTION_OPTION_MAP[hdriResolutionId]) return hdriResolutionId;
-    return graphicsHdriResolution;
-  }, [activeFrameRateOption, hdriResolutionId, isMobileGraphicsDevice]);
+    return resolveHdriResolutionFromGraphics(activeFrameRateOption);
+  }, [activeFrameRateOption]);
+  const activeHdriPolicy = useMemo(
+    () => resolveHdriPolicyForFps(activeFrameRateOption?.fps),
+    [activeFrameRateOption]
+  );
   const resolvedFrameTiming = useMemo(() => {
     const fallbackFps =
       Number.isFinite(DEFAULT_FRAME_RATE_OPTION?.fps) && DEFAULT_FRAME_RATE_OPTION.fps > 0
@@ -3073,14 +3028,6 @@ export default function MurlanRoyaleArena({ search }) {
       console.warn('Failed to persist frame rate option', error);
     }
   }, [frameRateId]);
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    try {
-      window.localStorage?.setItem(HDRI_RESOLUTION_STORAGE_KEY, hdriResolutionId);
-    } catch (error) {
-      console.warn('Failed to persist HDRI resolution option', error);
-    }
-  }, [hdriResolutionId]);
 
   const gameStateRef = useRef(gameState);
   const selectedRef = useRef(selectedIds);
@@ -3811,15 +3758,11 @@ export default function MurlanRoyaleArena({ search }) {
       const activeVariant = variantConfig || hdriVariantRef.current || DEFAULT_HDRI_VARIANT;
       if (!activeVariant) return;
       const resolution = resolvedHdriResolution || DEFAULT_HDRI_RESOLUTIONS[0];
-      const startIdx = Math.max(0, HDRI_RESOLUTION_LADDER.indexOf(resolution));
-      const preferredResolutions =
-        startIdx >= 0
-          ? HDRI_RESOLUTION_LADDER.slice(startIdx)
-          : [resolution, ...DEFAULT_HDRI_RESOLUTIONS];
+      const preferredResolutions = buildHdriResolutionChain(resolution, activeHdriPolicy);
       const envResult = await loadPolyHavenHdriEnvironment(three.renderer, {
         ...activeVariant,
         preferredResolutions,
-        fallbackResolution: preferredResolutions[preferredResolutions.length - 1] || DEFAULT_HDRI_RESOLUTIONS[0]
+        fallbackResolution: activeHdriPolicy?.fallbackResolution ?? preferredResolutions[1] ?? resolution
       });
       if (!envResult?.envMap || !three.scene) return;
       const prevDispose = disposeEnvironmentRef.current;
@@ -3849,7 +3792,7 @@ export default function MurlanRoyaleArena({ search }) {
         prevDispose();
       }
     },
-    [resolvedHdriResolution]
+    [activeHdriPolicy, resolvedHdriResolution]
   );
 
   useEffect(() => {
@@ -5205,30 +5148,9 @@ export default function MurlanRoyaleArena({ search }) {
                   <div className="rounded-xl border border-white/10 bg-white/5 p-3 space-y-2">
                     <p className="text-[10px] uppercase tracking-[0.35em] text-white/70">Graphics</p>
                     <div className="space-y-2">
-                      <p className="text-[10px] uppercase tracking-[0.32em] text-white/65">HDRI Resolution</p>
                       <p className="text-[10px] uppercase tracking-[0.2em] text-white/50">
                         Active: {resolvedHdriResolution.toUpperCase()}
                       </p>
-                      <div className="flex flex-wrap gap-2">
-                        {HDRI_RESOLUTION_OPTIONS.map((option) => {
-                          const active = option.id === hdriResolutionId;
-                          return (
-                            <button
-                              key={option.id}
-                              type="button"
-                              onClick={() => setHdriResolutionId(option.id)}
-                              aria-pressed={active}
-                              className={`flex-1 min-w-[5rem] rounded-full border px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
-                                active
-                                  ? 'border-sky-300 bg-sky-300 text-black shadow-[0_0_12px_rgba(125,211,252,0.45)]'
-                                  : 'border-white/20 bg-white/10 text-white/80 hover:bg-white/20'
-                              }`}
-                            >
-                              {option.label}
-                            </button>
-                          );
-                        })}
-                      </div>
                     </div>
                     <div className="grid gap-2">
                       {FRAME_RATE_OPTIONS.map((option) => {


### PR DESCRIPTION
### Motivation
- Simplify and centralize HDRI resolution selection by deriving suitable HDRI targets from the active frame-rate profile rather than exposing a separate user-controlled HDRI resolution option.
- Remove support for the rarely-used 144 Hz/`ultra144` graphics tier and related special-casing across detection and selection code.
- Reduce persistence surface by dropping the HDRI resolution storage key and UI for manually selecting HDRI resolution.

### Description
- Introduced `HDRI_RESOLUTION_POLICY_BY_FPS`, `resolveHdriPolicyForFps`, and `buildHdriResolutionChain` to compute preferred HDRI resolution lists and fallbacks based on the active FPS profile.
- Removed the `ultra144` frame-rate option and removed `'(min-refresh-rate: 144hz)'` detection, and eliminated `ultra144` checks from `detectPreferredFrameRateId`.
- Removed the manual HDRI resolution state, storage key (`HDRI_RESOLUTION_STORAGE_KEY`), option list, and UI controls, and replaced logic to resolve HDRI resolution with `resolveHdriResolutionFromGraphics` plus the new policy mechanism.
- Updated `applyHdriEnvironment` to call `buildHdriResolutionChain` and to use policy-derived `fallbackResolution` and `preferredResolutions`, and cleaned up related references and defaults.

### Testing
- Ran the app build and existing unit tests with `yarn test` locally, and the test suite completed successfully.
- Manually exercised graphics settings in the running app to confirm HDRI selection follows the new FPS-based policy and that the HDRI selection UI is removed without runtime errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cca3ca5af483299e61374dca4a6203)