### PR TITLE
Retry lower HDRI resolutions for Murlan Royale when high-res HDRI fails (fix 120Hz)

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -562,6 +562,31 @@ async function resolvePolyHavenHdriUrl(config = {}) {
 
 async function loadPolyHavenHdriEnvironment(renderer, config = {}) {
   if (!renderer) return null;
+  const buildHdriAttemptQueue = () => {
+    const preferred = Array.isArray(config?.preferredResolutions)
+      ? config.preferredResolutions
+      : DEFAULT_HDRI_RESOLUTIONS;
+    const normalizedPreferred = preferred
+      .map((entry) => normalizeHdriResolutionId(entry))
+      .filter(Boolean);
+    const fallbackResolution = normalizeHdriResolutionId(config?.fallbackResolution);
+    const queue = [...new Set([...normalizedPreferred, fallbackResolution, ...HDRI_RESOLUTION_LADDER])]
+      .filter(Boolean)
+      .map((resolution) => ({
+        resolution,
+        requestConfig: {
+          ...config,
+          forceResolution: resolution
+        }
+      }));
+    if (!queue.length) {
+      queue.push({
+        resolution: null,
+        requestConfig: { ...config }
+      });
+    }
+    return queue;
+  };
   const resolveFallback = async () => {
     try {
       const pmrem = new THREE.PMREMGenerator(renderer);
@@ -586,37 +611,40 @@ async function loadPolyHavenHdriEnvironment(renderer, config = {}) {
       return null;
     }
   };
-  const url = await resolvePolyHavenHdriUrl(config);
-  if (!url) {
-    return resolveFallback();
+  const attempts = buildHdriAttemptQueue();
+  for (const attempt of attempts) {
+    const url = await resolvePolyHavenHdriUrl(attempt.requestConfig);
+    if (!url) continue;
+    const lowerUrl = `${url}`.toLowerCase();
+    const useExr = lowerUrl.endsWith('.exr');
+    const activeLoader = useExr ? new EXRLoader() : new RGBELoader();
+    activeLoader.setCrossOrigin?.('anonymous');
+    const envResult = await new Promise((resolve) => {
+      activeLoader.load(
+        url,
+        (texture) => {
+          const pmrem = new THREE.PMREMGenerator(renderer);
+          pmrem.compileEquirectangularShader();
+          const envMap = pmrem.fromEquirectangular(texture).texture;
+          envMap.name = `${config?.assetId ?? 'polyhaven'}-env`;
+          texture.dispose();
+          pmrem.dispose();
+          resolve({ envMap, url });
+        },
+        undefined,
+        () => resolve(null)
+      );
+    });
+    if (envResult?.envMap) {
+      return envResult;
+    }
+    console.warn('Failed to load Poly Haven HDRI, retrying lower resolution', {
+      assetId: config?.assetId,
+      attemptedResolution: attempt.resolution,
+      url
+    });
   }
-  const lowerUrl = `${url ?? ''}`.toLowerCase();
-  const useExr = lowerUrl.endsWith('.exr');
-  const loader = useExr ? new EXRLoader() : null;
-  const rgbeLoader = new RGBELoader();
-  const activeLoader = useExr && loader ? loader : rgbeLoader;
-  if (!activeLoader) return null;
-  activeLoader.setCrossOrigin?.('anonymous');
-  return new Promise((resolve) => {
-    activeLoader.load(
-      url,
-      (texture) => {
-        const pmrem = new THREE.PMREMGenerator(renderer);
-        pmrem.compileEquirectangularShader();
-        const envMap = pmrem.fromEquirectangular(texture).texture;
-        envMap.name = `${config?.assetId ?? 'polyhaven'}-env`;
-        texture.dispose();
-        pmrem.dispose();
-        resolve({ envMap, url });
-      },
-      undefined,
-      async (error) => {
-        console.warn('Failed to load Poly Haven HDRI', error);
-        const fallbackEnv = await resolveFallback();
-        resolve(fallbackEnv);
-      }
-    );
-  });
+  return resolveFallback();
 }
 
 async function loadTexture(textureLoader, url, isColor, maxAnisotropy = 1) {


### PR DESCRIPTION
### Motivation
- When the Ultra (120 Hz) graphics profile is selected in Murlan Royale, the chosen high-resolution HDRI can fail to load and leave the arena without an environment; the goal is to degrade gracefully like Pool Royale. 
- Improve robustness of HDRI loading by attempting lower resolution variants before falling back to a synthetic environment.

### Description
- Added a deterministic resolution-attempt queue (`buildHdriAttemptQueue`) in `MurlanRoyaleArena` to try preferred resolutions then progressively lower tiers (e.g. `8k` → `4k` → `2k` → `1k`).
- Each attempt calls `resolvePolyHavenHdriUrl` with a `forceResolution` so the URL resolution honors the targeted resolution tier when available.
- For each resolved URL the code now attempts loading with the appropriate loader (`EXRLoader` or `RGBELoader`) and returns the first successful `envMap`; failures are logged and the next resolution is tried.
- The existing synthetic PMREM fallback environment remains as the final safety path when all HDRI attempts fail.

### Testing
- Built the webapp with `cd webapp && npm run -s build` and the build completed successfully; Vite showed non-blocking chunk/dynamic-import warnings but no errors. 
- Verified that the new retry logic compiles and the arena build completes during the production build; no runtime tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cccddecb4483298fd457478c652ed9)