### PR TITLE
Fix Texas Hold'em HDRI loading fallback for 120Hz profile

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -1308,7 +1308,7 @@ async function loadPolyHavenHdriEnvironment(renderer, config = {}, preferredReso
     rememberHdriEnvironment(cacheKey, cached);
     return { ...cached, fromCache: true, cacheKey };
   }
-  const url = await resolveTexasHoldemHdriUrl(config, preferredResolutions);
+
   const resolveFallback = async () => {
     try {
       return await createFallbackHdriEnvironment(renderer);
@@ -1317,15 +1317,36 @@ async function loadPolyHavenHdriEnvironment(renderer, config = {}, preferredReso
       return null;
     }
   };
-  const lowerUrl = `${url ?? ''}`.toLowerCase();
-  const useExr = lowerUrl.endsWith('.exr');
-  const loader = useExr ? new EXRLoader() : null;
-  const rgbeLoader = new RGBELoader();
-  const activeLoader = useExr && loader ? loader : rgbeLoader;
-  if (!activeLoader) return null;
-  activeLoader.setCrossOrigin?.('anonymous');
+
+  const orderedResolutions = Array.isArray(preferredResolutions) && preferredResolutions.length
+    ? preferredResolutions
+    : [DEFAULT_HDRI_RESOLUTION_ID, '2k', '1k'];
+  const candidateUrls = [];
+  const seenUrls = new Set();
+
+  for (let i = 0; i < orderedResolutions.length; i += 1) {
+    const attemptResolutions = orderedResolutions.slice(i);
+    const candidateUrl = await resolveTexasHoldemHdriUrl(config, attemptResolutions);
+    if (typeof candidateUrl !== 'string' || !candidateUrl) continue;
+    if (seenUrls.has(candidateUrl)) continue;
+    seenUrls.add(candidateUrl);
+    candidateUrls.push(candidateUrl);
+  }
+
+  if (!candidateUrls.length) {
+    const directUrl = await resolveTexasHoldemHdriUrl(config, orderedResolutions);
+    if (typeof directUrl === 'string' && directUrl && !seenUrls.has(directUrl)) {
+      candidateUrls.push(directUrl);
+      seenUrls.add(directUrl);
+    }
+  }
+
   const loadTextureWithRetry = (resourceUrl, attempt = 0) =>
     new Promise((resolve) => {
+      const lowerUrl = `${resourceUrl ?? ''}`.toLowerCase();
+      const useExr = lowerUrl.endsWith('.exr');
+      const activeLoader = useExr ? new EXRLoader() : new RGBELoader();
+      activeLoader.setCrossOrigin?.('anonymous');
       activeLoader.load(
         resourceUrl,
         (texture) => resolve({ texture, error: null }),
@@ -1343,30 +1364,24 @@ async function loadPolyHavenHdriEnvironment(renderer, config = {}, preferredReso
       );
     });
 
-  return new Promise((resolve) => {
-    if (!url) {
-      resolveFallback().then(resolve);
-      return;
+  for (const url of candidateUrls) {
+    const { texture, error } = await loadTextureWithRetry(url);
+    if (!texture) {
+      console.warn('Failed to load Poly Haven HDRI candidate', { url, error });
+      continue;
     }
-    loadTextureWithRetry(url)
-      .then(async ({ texture, error }) => {
-        if (!texture) {
-          console.warn('Failed to load Poly Haven HDRI', error);
-          const fallbackEnv = await resolveFallback();
-          resolve(fallbackEnv);
-          return;
-        }
-        const pmrem = new THREE.PMREMGenerator(renderer);
-        pmrem.compileEquirectangularShader();
-        const envMap = pmrem.fromEquirectangular(texture).texture;
-        envMap.name = `${config?.assetId ?? 'polyhaven'}-env`;
-        texture.dispose();
-        pmrem.dispose();
-        const result = { envMap, url, fromCache: false, cacheKey };
-        rememberHdriEnvironment(cacheKey, result);
-        resolve(result);
-      });
-  });
+    const pmrem = new THREE.PMREMGenerator(renderer);
+    pmrem.compileEquirectangularShader();
+    const envMap = pmrem.fromEquirectangular(texture).texture;
+    envMap.name = `${config?.assetId ?? 'polyhaven'}-env`;
+    texture.dispose();
+    pmrem.dispose();
+    const result = { envMap, url, fromCache: false, cacheKey };
+    rememberHdriEnvironment(cacheKey, result);
+    return result;
+  }
+
+  return resolveFallback();
 }
 
 function adjustHexColor(hex, amount) {


### PR DESCRIPTION
### Motivation
- The 120 Hz graphics profile could fail to load an HDRI when the highest-resolution URL was unavailable, causing no HDR environment to be applied; Pool Royale uses graceful downgrade to lower-res HDRIs and we want the same behavior for Texas Hold'em. 
- Improve robustness of HDRI fetching so transient failures at higher resolutions do not block scene lighting and background.

### Description
- Updated HDRI loader in `webapp/src/pages/Games/TexasHoldemArena.jsx` to build an ordered candidate list of HDRI URLs derived from the preferred resolutions (e.g., 8k → 4k → 2k) and try them sequentially until one succeeds. 
- Added per-candidate retry logic and automatic loader selection (EXR vs RGBE) so each candidate gets multiple attempts before falling back to the next candidate. 
- Preserved the existing `HDRI_ENVIRONMENT_CACHE` semantics so the first successfully loaded candidate is cached under the active profile cache key. 
- If all candidates fail, the code falls back to the existing synthetic PMREM fallback environment to guarantee a usable lighting/background.

### Testing
- Ran the production build with `npm --prefix webapp run build` and the build completed successfully (Vite warnings about large chunks were unchanged and non-blocking).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccce0150508329a4811c80e583f945)