### PR TITLE
Fix HDRI fallback & caching for Murlan Royale 120Hz

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -504,7 +504,7 @@ const pickPolyHavenHdriUrl = (apiJson, preferredResolutions = DEFAULT_HDRI_RESOL
 };
 
 async function resolvePolyHavenHdriUrl(config = {}) {
-  const cacheKey = `${config?.assetId ?? 'fallback'}|${(config?.preferredResolutions || []).join(',')}|${config?.fallbackResolution ?? ''}`;
+  const cacheKey = `${config?.assetId ?? 'fallback'}|${(config?.preferredResolutions || []).join(',')}|${config?.fallbackResolution ?? ''}|${config?.forceResolution ?? ''}`;
   if (HDRI_URL_CACHE.has(cacheKey)) {
     return HDRI_URL_CACHE.get(cacheKey);
   }
@@ -586,37 +586,64 @@ async function loadPolyHavenHdriEnvironment(renderer, config = {}) {
       return null;
     }
   };
-  const url = await resolvePolyHavenHdriUrl(config);
-  if (!url) {
-    return resolveFallback();
+  const configuredPreferred = Array.isArray(config?.preferredResolutions)
+    ? config.preferredResolutions
+    : DEFAULT_HDRI_RESOLUTIONS;
+  const attemptedUrls = new Set();
+  const resolutionAttempts = [...new Set(
+    configuredPreferred
+      .map((entry) => normalizeHdriResolutionId(entry))
+      .filter((entry) => Boolean(entry))
+  )];
+  if (!resolutionAttempts.length) {
+    resolutionAttempts.push(...DEFAULT_HDRI_RESOLUTIONS);
   }
-  const lowerUrl = `${url ?? ''}`.toLowerCase();
-  const useExr = lowerUrl.endsWith('.exr');
-  const loader = useExr ? new EXRLoader() : null;
-  const rgbeLoader = new RGBELoader();
-  const activeLoader = useExr && loader ? loader : rgbeLoader;
-  if (!activeLoader) return null;
-  activeLoader.setCrossOrigin?.('anonymous');
-  return new Promise((resolve) => {
-    activeLoader.load(
-      url,
-      (texture) => {
-        const pmrem = new THREE.PMREMGenerator(renderer);
-        pmrem.compileEquirectangularShader();
-        const envMap = pmrem.fromEquirectangular(texture).texture;
-        envMap.name = `${config?.assetId ?? 'polyhaven'}-env`;
-        texture.dispose();
-        pmrem.dispose();
-        resolve({ envMap, url });
-      },
-      undefined,
-      async (error) => {
-        console.warn('Failed to load Poly Haven HDRI', error);
-        const fallbackEnv = await resolveFallback();
-        resolve(fallbackEnv);
-      }
-    );
-  });
+  const loadFromUrl = (url) =>
+    new Promise((resolve) => {
+      const lowerUrl = `${url ?? ''}`.toLowerCase();
+      const useExr = lowerUrl.endsWith('.exr');
+      const loader = useExr ? new EXRLoader() : new RGBELoader();
+      loader.setCrossOrigin?.('anonymous');
+      loader.load(
+        url,
+        (texture) => {
+          const pmrem = new THREE.PMREMGenerator(renderer);
+          pmrem.compileEquirectangularShader();
+          const envMap = pmrem.fromEquirectangular(texture).texture;
+          envMap.name = `${config?.assetId ?? 'polyhaven'}-env`;
+          texture.dispose();
+          pmrem.dispose();
+          resolve({ envMap, url });
+        },
+        undefined,
+        () => resolve(null)
+      );
+    });
+
+  for (const forcedResolution of resolutionAttempts) {
+    const url = await resolvePolyHavenHdriUrl({ ...config, forceResolution: forcedResolution });
+    if (!url || attemptedUrls.has(url)) continue;
+    attemptedUrls.add(url);
+    const loaded = await loadFromUrl(url);
+    if (loaded?.envMap) return loaded;
+    console.warn('Failed to load Poly Haven HDRI at requested resolution', {
+      assetId: config?.assetId,
+      forcedResolution,
+      url
+    });
+  }
+
+  const fallbackUrl = await resolvePolyHavenHdriUrl(config);
+  if (fallbackUrl && !attemptedUrls.has(fallbackUrl)) {
+    const loadedFallback = await loadFromUrl(fallbackUrl);
+    if (loadedFallback?.envMap) return loadedFallback;
+    console.warn('Failed to load Poly Haven HDRI fallback url', {
+      assetId: config?.assetId,
+      url: fallbackUrl
+    });
+  }
+
+  return resolveFallback();
 }
 
 async function loadTexture(textureLoader, url, isColor, maxAnisotropy = 1) {


### PR DESCRIPTION
### Motivation
- Selecting the Ultra (120 Hz) graphics profile sometimes left the Murlan Royale scene without an HDRI because the loader reused a URL or failed to try lower-resolution variants, unlike Pool Royale which falls back automatically. 
- The HDRI URL cache did not consider per-resolution lookups, causing stale URLs to be returned for different forced resolution attempts.

### Description
- Updated `resolvePolyHavenHdriUrl` cache key to include `forceResolution` so per-resolution URL lookups do not collide (`webapp/src/pages/Games/MurlanRoyaleArena.jsx`).
- Reworked `loadPolyHavenHdriEnvironment` to attempt loading the HDRI across the preferred resolution ladder (tries forced `8k`, then `4k`, then `2k`, etc.) using a unified `loadFromUrl` helper and to avoid returning a non-working URL prematurely.
- Added warning logs when loading a specific resolution or the fallback URL fails to aid runtime diagnosis.
- Kept the generated fallback environment when all external HDRI loads fail, preserving a safe default.

### Testing
- Ran the production build with `npm --prefix webapp run build`, which completed successfully and produced the app bundle; Vite emitted only non-blocking chunk-size/dynamic-import warnings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cccddecb4483298fd457478c652ed9)