### PR TITLE
Fix Texas Hold'em 120Hz HDRI resolution selection

### DIFF
--- a/test/texasHoldemHdriPreload.test.js
+++ b/test/texasHoldemHdriPreload.test.js
@@ -34,4 +34,32 @@ describe('resolveTexasHoldemHdriUrl', () => {
 
     expect(url).toBe('https://cdn.example.com/hdr/studio_8k.hdr');
   });
+
+  test('prefers hdr over exr for the same requested resolution', async () => {
+    global.fetch = jest.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        exr: {
+          '8k': {
+            exr: 'https://cdn.example.com/exr/studio_8k.exr'
+          }
+        },
+        hdr: {
+          '8k': {
+            hdr: 'https://cdn.example.com/hdr/studio_8k.hdr'
+          }
+        }
+      })
+    }));
+
+    const url = await resolveTexasHoldemHdriUrl(
+      {
+        id: 'studio',
+        assetId: 'studio'
+      },
+      ['8k', '4k', '2k']
+    );
+
+    expect(url).toBe('https://cdn.example.com/hdr/studio_8k.hdr');
+  });
 });

--- a/webapp/src/utils/texasHoldemHdriPreload.js
+++ b/webapp/src/utils/texasHoldemHdriPreload.js
@@ -92,12 +92,29 @@ function pickPolyHavenHdriUrl(fileMap, preferredResolutions = DEFAULT_RESOLUTION
 
   if (!urls.length) return null;
   const lowerUrls = urls.map((url) => url.toLowerCase());
+  const chooseByResolution = (resolution) => {
+    const withUnderscore = lowerUrls
+      .map((url, index) => ({ url, index }))
+      .filter(({ url }) => url.includes(`_${resolution}.`));
+    if (withUnderscore.length) {
+      const hdrMatch = withUnderscore.find(({ url }) => url.includes('.hdr'));
+      return urls[(hdrMatch || withUnderscore[0]).index];
+    }
+    const withPathSegment = lowerUrls
+      .map((url, index) => ({ url, index }))
+      .filter(({ url }) => url.includes(`/${resolution}/`));
+    if (withPathSegment.length) {
+      const hdrMatch = withPathSegment.find(({ url }) => url.includes('.hdr'));
+      return urls[(hdrMatch || withPathSegment[0]).index];
+    }
+    return null;
+  };
   for (const resolution of preferredResolutions) {
-    const withUnderscore = lowerUrls.find((url) => url.includes(`_${resolution}.`));
-    if (withUnderscore) return urls[lowerUrls.indexOf(withUnderscore)];
-    const withPathSegment = lowerUrls.find((url) => url.includes(`/${resolution}/`));
-    if (withPathSegment) return urls[lowerUrls.indexOf(withPathSegment)];
+    const resolved = chooseByResolution(resolution);
+    if (resolved) return resolved;
   }
+  const firstHdr = lowerUrls.findIndex((url) => url.includes('.hdr'));
+  if (firstHdr >= 0) return urls[firstHdr];
   return urls[0] || null;
 }
 


### PR DESCRIPTION
### Motivation
- Players reported that selecting the 120Hz graphics preset sometimes failed to load the expected 8K HDRI because the preloader chose non-HDR candidates first. 
- Make HDRI selection deterministic and align Texas Hold'em behavior with Pool Royale so `uhd120` picks the high-quality `.hdr` asset when available.

### Description
- Improved `pickPolyHavenHdriUrl` in `webapp/src/utils/texasHoldemHdriPreload.js` to perform resolution-aware matching and prefer `.hdr` URLs when multiple formats exist for the same resolution. 
- Added a final HDR-first fallback so the function returns the first `.hdr` seen before falling back to any available URL. 
- Added a unit test `test/texasHoldemHdriPreload.test.js` to assert that `resolveTexasHoldemHdriUrl` prefers an `8k` `.hdr` over an `8k` `.exr` candidate.

### Testing
- Ran `npm test -- test/texasHoldemHdriPreload.test.js`; both tests in the suite passed. 
- Test results: `PASS test/texasHoldemHdriPreload.test.js` (2 tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccd789c6908329b5072094378f7e01)