### PR TITLE
Domino: Fix 120Hz HDRI fallback chain and bump game script version

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -4445,9 +4445,9 @@ const MAX_HDRI_CACHE_SIZE = prefersUhd ? 4 : isLowProfileDevice ? 1 : 2;
 function resolveHdriResolutionOrder() {
   switch (frameRateId) {
     case 'uhd120':
-      return ['8k'];
+      return ['8k', '4k', '2k'];
     case 'qhd90':
-      return ['4k'];
+      return ['4k', '2k'];
     case 'fhd60':
     default:
       return ['2k'];
@@ -4527,7 +4527,7 @@ function resolveOfficialHdriOrder(requestedResolution, availableResolutions = []
   const requested = String(requestedResolution || '').toLowerCase();
   if (!requested) return [];
   const aliases = {
-    '8k': ['8k', '4k'],
+    '8k': ['8k', '6k', '4k', '2k', '1k'],
     '4k': ['4k', '2k'],
     '2k': ['2k', '1k']
   };

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-03-30-hdri-resolution-menu-v5';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-04-01-hdri-120hz-fallback-v6';
 
 export default function DominoRoyalArena() {
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- Ensure selecting the 120 Hz graphics profile for Domino Royal reliably loads an HDRI: try `8k` first but gracefully fall back to lower resolutions if the asset or network fails. 
- Match the more robust HDRI resolution fallback behavior used in Pool Royale so purchased environments and high-quality scenes still appear on devices without native 8k files. 

### Description
- Changed `resolveHdriResolutionOrder()` in `webapp/public/domino-royal-game.js` so `uhd120` now returns `['8k','4k','2k']` and `qhd90` returns `['4k','2k']` instead of a single-entry array. 
- Expanded the `8k` alias list in `resolveOfficialHdriOrder()` to `['8k','6k','4k','2k','1k']` so the loader will try intermediate resolutions when an exact 8k file is not available. 
- Bumped the runtime script version constant `DOMINO_ROYAL_SCRIPT_VERSION` in `webapp/src/pages/Games/DominoRoyalArena.jsx` to `2026-04-01-hdri-120hz-fallback-v6` so clients fetch the updated bundle. 

### Testing
- Ran `node --check webapp/public/domino-royal-game.js`, which completed successfully. 
- Ran `node --check webapp/src/pages/Games/DominoRoyalArena.jsx`, which reported a failure because Node `--check` does not support `.jsx` files in this environment (tooling limitation, not a runtime/logic failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccd7c035488329acaad3ca114a4e39)