### PR TITLE
Domino: Fix HDRI loading for 120Hz (8K-first fallback + manifest URLs)

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -4445,12 +4445,12 @@ const MAX_HDRI_CACHE_SIZE = prefersUhd ? 4 : isLowProfileDevice ? 1 : 2;
 function resolveHdriResolutionOrder() {
   switch (frameRateId) {
     case 'uhd120':
-      return ['8k', '4k', '2k'];
+      return ['8k', '6k', '4k', '2k', '1k'];
     case 'qhd90':
-      return ['4k', '2k'];
+      return ['4k', '2k', '1k'];
     case 'fhd60':
     default:
-      return ['2k'];
+      return ['2k', '1k'];
   }
 }
 function shouldLoadExternalHdri() {
@@ -4540,6 +4540,33 @@ function resolveOfficialHdriOrder(requestedResolution, availableResolutions = []
   return normalizeHdriResolutionsByPreference(availableResolutions, requested).slice(0, 4);
 }
 
+function pickPolyHavenHdriUrl(apiJson, preferredResolutions = []) {
+  const urls = [];
+  const walk = (value) => {
+    if (!value) return;
+    if (typeof value === 'string') {
+      if (value.startsWith('http') && value.toLowerCase().includes('.hdr')) {
+        urls.push(value);
+      }
+      return;
+    }
+    if (Array.isArray(value)) {
+      value.forEach(walk);
+      return;
+    }
+    if (typeof value === 'object') {
+      Object.values(value).forEach(walk);
+    }
+  };
+  walk(apiJson);
+  const lower = urls.map((u) => u.toLowerCase());
+  for (const res of preferredResolutions) {
+    const match = lower.find((u) => u.includes(`_${res}.`));
+    if (match) return urls[lower.indexOf(match)];
+  }
+  return urls[0] ?? null;
+}
+
 async function loadHdriEnvironment(variant) {
   if (!variant?.assetId) return null;
   if (!shouldLoadExternalHdri()) return null;
@@ -4551,8 +4578,10 @@ async function loadHdriEnvironment(variant) {
     : [];
   const order = preferred.length ? preferred : allowedResolutions;
   let availableHdriResolutions = [];
+  let hdriManifestJson = null;
   try {
     const manifest = await fetchPolyhavenHdriManifest(variant.assetId);
+    hdriManifestJson = manifest;
     availableHdriResolutions = Object.keys(manifest?.hdri || {});
   } catch (error) {
     console.warn('Failed fetching Poly Haven HDRI manifest, using static resolution order', error);
@@ -4569,7 +4598,20 @@ async function loadHdriEnvironment(variant) {
       if (hdriTextureCache.has(cacheKey)) {
         return hdriTextureCache.get(cacheKey);
       }
+      const manifestPreferred = resolveOfficialHdriOrder(
+        res,
+        availableHdriResolutions
+      );
+      const manifestUrl = pickPolyHavenHdriUrl(
+        hdriManifestJson,
+        manifestPreferred.length ? manifestPreferred : [res]
+      );
       const urls = [
+        ...(
+          manifestUrl
+            ? [manifestUrl]
+            : []
+        ),
         `https://dl.polyhaven.org/file/ph-assets/HDRIs/hdr/${res}/${variant.assetId}_${res}.hdr`,
         `https://dl.polyhaven.org/file/ph-assets/HDRIs/exr/${res}/${variant.assetId}_${res}.exr`
       ];


### PR DESCRIPTION
### Motivation

- Selecting the `120 Hz`/Ultra graphics profile in Domino sometimes failed to load HDRI environments, causing no background/environment lighting to appear. 
- Pool Royale already resolves PolyHaven manifests and falls back gracefully; Domino needs the same 8K-first reliability approach so `uhd120` actually gets 8K assets when available.

### Description

- Extended the HDRI resolution chain in `resolveHdriResolutionOrder` so `uhd120` tries `['8k','6k','4k','2k','1k']` and lower profiles include `1k` fallbacks. 
- Added `pickPolyHavenHdriUrl(apiJson, preferredResolutions)` helper to pick official `.hdr` links from Poly Haven manifest JSON before using generated URLs. 
- Updated `loadHdriEnvironment` to fetch and retain the manifest JSON, prefer manifest-picked URLs per resolution, and then fall back to the constructed `.hdr`/`.exr` URLs across the ordered resolution ladder. 
- All changes are contained in `webapp/public/domino-royal-game.js` and align Domino HDRI loading with the Pool Royale model.

### Testing

- Ran a syntax check with `node --check webapp/public/domino-royal-game.js`, which completed successfully. 
- Verified the modified file loads without syntax errors in the repository environment (no other automated tests were executed for this change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccf49a6e508329b110a08ac6ef9b0a)