### PR TITLE
Prefer .hdr assets for Murlan Royale 120Hz HDRI selection

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -454,9 +454,11 @@ const collectHdriCandidates = (apiJson) => {
     if (typeof url !== 'string' || !url.startsWith('http')) return;
     const lower = url.toLowerCase();
     if (!lower.includes('.hdr') && !lower.includes('.exr')) return;
+    const format = lower.includes('.hdr') ? 'hdr' : lower.includes('.exr') ? 'exr' : 'unknown';
     out.push({
       url,
-      resolution: normalizeHdriResolutionId(hintedResolution) ?? extractResolutionFromHdriUrl(url)
+      resolution: normalizeHdriResolutionId(hintedResolution) ?? extractResolutionFromHdriUrl(url),
+      format
     });
   };
   const walk = (value, hintedResolution = null) => {
@@ -482,17 +484,27 @@ const collectHdriCandidates = (apiJson) => {
 const pickPolyHavenHdriUrl = (apiJson, preferredResolutions = DEFAULT_HDRI_RESOLUTIONS) => {
   const candidates = collectHdriCandidates(apiJson);
   if (!candidates.length) return null;
+  const pickBestByResolution = (targetResolution) => {
+    const matching = candidates.filter((entry) => entry.resolution === targetResolution);
+    if (!matching.length) return null;
+    return matching.find((entry) => entry.format === 'hdr') ?? matching[0];
+  };
 
   for (const res of preferredResolutions) {
     const normalized = normalizeHdriResolutionId(res);
     if (!normalized) continue;
-    const matched = candidates.find((entry) => entry.resolution === normalized);
+    const matched = pickBestByResolution(normalized);
     if (matched?.url) return matched.url;
   }
 
   for (const fallbackRes of HDRI_RESOLUTION_LADDER) {
-    const matched = candidates.find((entry) => entry.resolution === fallbackRes);
+    const matched = pickBestByResolution(fallbackRes);
     if (matched?.url) return matched.url;
+  }
+
+  const hdrCandidate = candidates.find((candidate) => candidate.format === 'hdr');
+  if (hdrCandidate?.url) {
+    return hdrCandidate.url;
   }
 
   for (const candidate of candidates) {


### PR DESCRIPTION
### Motivation
- Fix Murlan Royale HDRI selection so the 120 Hz / 8K graphics profile reliably loads high-resolution environment maps and behaves like Pool Royale.

### Description
- Updated `collectHdriCandidates` to record a `format` field (`'hdr' | 'exr' | 'unknown'`) for each discovered HDRI URL.
- Modified `pickPolyHavenHdriUrl` to prefer `.hdr` candidates when selecting by resolution and to use a global `.hdr` fallback before any remaining candidate.
- Change scope is limited to `webapp/src/pages/Games/MurlanRoyaleArena.jsx` and does not modify other game code.

### Testing
- Ran `npm test -- --runInBand test/murlan.test.js` and the suite passed (1 test suite, 12 tests all passed).
- No other automated integration or UI tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccf4a753508329b3989b9b91556d43)