### PR TITLE
Preload higher‑res HDRIs for Texas Hold'em (enable 120Hz 8K chain)

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemLobby.jsx
+++ b/webapp/src/pages/Games/TexasHoldemLobby.jsx
@@ -12,6 +12,7 @@ import { getLobbyIcon } from '../../config/gameAssets.js';
 import GameLobbyHeader from '../../components/GameLobbyHeader.jsx';
 import { runSimpleOnlineFlow } from '../../utils/simpleOnlineFlow.js';
 import { socket } from '../../utils/socket.js';
+import { warmTexasHoldemArenaAssetsFromLobby } from '../../utils/texasHoldemHdriPreload.js';
 
 const DEV_ACCOUNT = import.meta.env.VITE_DEV_ACCOUNT_ID;
 const DEV_ACCOUNT_1 = import.meta.env.VITE_DEV_ACCOUNT_ID_1;
@@ -51,6 +52,7 @@ export default function TexasHoldemLobby() {
 
   useEffect(() => {
     import('./TexasHoldem.jsx').catch(() => {});
+    void warmTexasHoldemArenaAssetsFromLobby();
   }, []);
 
   useEffect(() => {

--- a/webapp/src/utils/texasHoldemHdriPreload.js
+++ b/webapp/src/utils/texasHoldemHdriPreload.js
@@ -1,7 +1,7 @@
 import { TEXAS_DEFAULT_HDRI_ID, TEXAS_HDRI_OPTIONS } from '../config/texasHoldemInventoryConfig.js';
 import { TEXAS_CHAIR_THEME_OPTIONS, TEXAS_TABLE_THEME_OPTIONS } from '../config/texasHoldemOptions.js';
 
-const DEFAULT_RESOLUTIONS = Object.freeze(['2k', '1k']);
+const DEFAULT_RESOLUTIONS = Object.freeze(['4k', '2k', '1k']);
 const hdriUrlCache = new Map();
 const hdriJsonPromiseCache = new Map();
 const hdriWarmPromiseCache = new Map();
@@ -183,15 +183,24 @@ export async function resolveTexasHoldemHdriUrl(config = {}, preferred = DEFAULT
   return picked;
 }
 
-export function warmTexasHoldemHdriFromLobby(options = TEXAS_HDRI_OPTIONS) {
+function normalizePreferredResolutions(preferred = DEFAULT_RESOLUTIONS) {
+  const requested = Array.isArray(preferred)
+    ? preferred.filter((value) => typeof value === 'string' && value.length)
+    : [];
+  return requested.length ? Array.from(new Set(requested)) : [...DEFAULT_RESOLUTIONS];
+}
+
+export function warmTexasHoldemHdriFromLobby(options = TEXAS_HDRI_OPTIONS, preferredResolutions = DEFAULT_RESOLUTIONS) {
   if (typeof window === 'undefined' || typeof fetch !== 'function') return Promise.resolve();
   const variants = prioritizeDefaultHdri(options);
+  const normalizedPreferredResolutions = normalizePreferredResolutions(preferredResolutions);
   const jobs = variants.map((variant) => {
-    const key = variant?.id || variant?.assetId || variant?.fallbackUrl;
+    const variantId = variant?.id || variant?.assetId || variant?.fallbackUrl;
+    const key = `${variantId ?? 'unknown'}|${normalizedPreferredResolutions.join(',')}`;
     if (!key) return Promise.resolve();
     if (hdriWarmPromiseCache.has(key)) return hdriWarmPromiseCache.get(key);
 
-    const job = resolveTexasHoldemHdriUrl(variant)
+    const job = resolveTexasHoldemHdriUrl(variant, normalizedPreferredResolutions)
       .then((url) => {
         if (!url) return null;
         return fetch(url, { mode: 'cors', cache: 'force-cache' });
@@ -206,10 +215,17 @@ export function warmTexasHoldemHdriFromLobby(options = TEXAS_HDRI_OPTIONS) {
 
 export function warmTexasHoldemArenaAssetsFromLobby() {
   if (typeof window === 'undefined') return Promise.resolve();
+  const storedFrameRate = window.localStorage?.getItem('texasHoldemFrameRate');
+  const preferredResolutionsByFrameRate = {
+    uhd120: ['8k', '4k', '2k', '1k'],
+    qhd90: ['4k', '2k', '1k'],
+    fhd60: ['2k', '1k']
+  };
+  const preferredResolutions = preferredResolutionsByFrameRate[storedFrameRate] || DEFAULT_RESOLUTIONS;
   const defaultTable = TEXAS_TABLE_THEME_OPTIONS[0];
   const defaultChair = TEXAS_CHAIR_THEME_OPTIONS[0];
   const jobs = [
-    warmTexasHoldemHdriFromLobby(),
+    warmTexasHoldemHdriFromLobby(TEXAS_HDRI_OPTIONS, preferredResolutions),
     warmImageAsset(TEXAS_CARD_BACK_LOGO_SRC)
   ];
 


### PR DESCRIPTION
### Motivation
- Ensure Texas Hold'em warms the same high‑resolution HDRI chain used by Pool Royale when a 120 Hz (uhd120) frame rate is selected so the 8K assets load correctly. 
- Prevent low‑res warm promises from blocking higher‑res warmups by scoping warmup cache keys to the preferred resolution chain.

### Description
- Changed `DEFAULT_RESOLUTIONS` to `['4k','2k','1k']` so preload favors higher‑quality HDRIs by default in `webapp/src/utils/texasHoldemHdriPreload.js`.
- Added `normalizePreferredResolutions(preferred)` and updated `warmTexasHoldemHdriFromLobby` to accept a `preferredResolutions` argument and include the resolution chain in the warmup cache key to avoid reusing mismatched warm promises.
- Made `warmTexasHoldemArenaAssetsFromLobby` pick the preferred chain from the saved frame rate (`texasHoldemFrameRate`) with an explicit mapping that uses `['8k','4k','2k','1k']` for `uhd120` and passes that chain into the HDRI warmup.
- Triggered arena asset warmup on lobby mount by calling `warmTexasHoldemArenaAssetsFromLobby()` from `webapp/src/pages/Games/TexasHoldemLobby.jsx` and added the corresponding import.

### Testing
- Ran the unit tests for HDRI URL resolution with `npm test -- test/texasHoldemHdriPreload.test.js --runInBand` and they passed (2 tests, both succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccf4b79e748329a80476c5849b976e)