### PR TITLE
Fix Texas Hold'em HDRI reload behavior for 120Hz mode

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -4343,7 +4343,7 @@ function TexasHoldemArena({ search }) {
       if (!envResult?.envMap) return;
       const usedFallbackEnvironment = !envResult.url;
       if (usedFallbackEnvironment) {
-        if (hdriFallbackRetryCountRef.current < 2) {
+        if (hdriFallbackRetryCountRef.current < 4) {
           hdriFallbackRetryCountRef.current += 1;
           const scheduledToken = requestToken;
           window.setTimeout(() => {
@@ -4387,7 +4387,7 @@ function TexasHoldemArena({ search }) {
         prevDispose();
       }
       hdriVariantRef.current = activeVariant;
-      loadedHdriResolutionIdRef.current = currentHdriResolutionId;
+      loadedHdriResolutionIdRef.current = usedFallbackEnvironment ? null : currentHdriResolutionId;
     },
     [hdriResolutionId]
   );


### PR DESCRIPTION
### Motivation
- The Texas Hold'em arena could get stuck on a procedural fallback HDRI after an initial load failure when `120 Hz`/`8k` was requested, preventing the real HDRI from being retried and loaded.

### Description
- Increased fallback HDRI retry attempts from `2` to `4` in `TexasHoldemArena` to allow more transient recoveries when high-resolution HDRIs fail to load.
- When a procedural fallback environment is used the code now avoids marking that resolution as "loaded" by setting `loadedHdriResolutionIdRef.current` to `null`, allowing subsequent real HDRI attempts to proceed.
- Change applied in `webapp/src/pages/Games/TexasHoldemArena.jsx`.

### Testing
- Ran `npm -C webapp run -s build` and the production build completed successfully. 
- Attempted `npm -C webapp run -s lint` but no `lint` script is defined in `webapp/package.json`, so linting was not run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccf4b79e748329a80476c5849b976e)