### PR TITLE
Enable 8K HDRI selection for Texas Hold'em 120Hz profile

### DIFF
--- a/webapp/src/config/texasHoldemInventoryConfig.js
+++ b/webapp/src/config/texasHoldemInventoryConfig.js
@@ -14,10 +14,17 @@ const reduceLabels = (items) =>
     return acc;
   }, {});
 
-export const TEXAS_HDRI_OPTIONS = POOL_ROYALE_HDRI_VARIANTS.map((variant) => ({
-  ...variant,
-  label: `${variant.name} HDRI`
-}));
+export const TEXAS_HDRI_OPTIONS = POOL_ROYALE_HDRI_VARIANTS.map((variant) => {
+  const baseResolutions = Array.isArray(variant?.preferredResolutions)
+    ? variant.preferredResolutions.filter((res) => typeof res === 'string' && res.length)
+    : [];
+  const preferredResolutions = Array.from(new Set(['8k', ...baseResolutions, '4k', '2k', '1k']));
+  return {
+    ...variant,
+    preferredResolutions,
+    label: `${variant.name} HDRI`
+  };
+});
 
 export const TEXAS_DEFAULT_HDRI_ID = 'dancingHall';
 

--- a/webapp/src/utils/texasHoldemHdriPreload.js
+++ b/webapp/src/utils/texasHoldemHdriPreload.js
@@ -1,7 +1,7 @@
 import { TEXAS_DEFAULT_HDRI_ID, TEXAS_HDRI_OPTIONS } from '../config/texasHoldemInventoryConfig.js';
 import { TEXAS_CHAIR_THEME_OPTIONS, TEXAS_TABLE_THEME_OPTIONS } from '../config/texasHoldemOptions.js';
 
-const DEFAULT_RESOLUTIONS = Object.freeze(['2k', '1k']);
+const DEFAULT_RESOLUTIONS = Object.freeze(['8k', '4k', '2k', '1k']);
 const hdriUrlCache = new Map();
 const hdriJsonPromiseCache = new Map();
 const hdriWarmPromiseCache = new Map();


### PR DESCRIPTION
### Motivation
- Selecting the 120 Hz graphics preset in Texas Hold'em did not reliably request the high-resolution HDRI path (8K) used by other games, causing lower-quality HDRI to load at high-refresh rates.

### Description
- Normalize TEXAS HDRI variants so each gets a preferred resolution stack with `8k` first and fallbacks `4k`, `2k`, `1k` by updating `webapp/src/config/texasHoldemInventoryConfig.js`.
- Change the HDRI preload default ordering to `['8k','4k','2k','1k']` in `webapp/src/utils/texasHoldemHdriPreload.js` so lobby warm-up and runtime resolution resolution attempts match the 120Hz expectation.
- The change ensures the same high-end HDRI resolution path is available to Texas Hold'em when the user selects the Ultra/120Hz graphics profile.

### Testing
- Executed `cd webapp && npm run -s build` and the production build completed successfully (Vite build finished; only non-blocking chunk-size/dynamic-import warnings reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccf980a9d483298141731c13dc8cfe)