### PR TITLE
Improve Murlan HDRI loading for 120 Hz (8K) — increased timeout and resolution fallback

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -574,7 +574,7 @@ async function resolvePolyHavenHdriUrl(config = {}) {
 
 async function loadPolyHavenHdriEnvironment(renderer, config = {}) {
   if (!renderer) return null;
-  const HDRI_LOAD_TIMEOUT_MS = 15000;
+  const HDRI_LOAD_TIMEOUT_MS = 30000;
   const resolveFallback = async () => {
     try {
       const pmrem = new THREE.PMREMGenerator(renderer);
@@ -655,16 +655,28 @@ async function loadPolyHavenHdriEnvironment(renderer, config = {}) {
       );
     });
 
+  const buildResolutionCandidates = (forcedResolution, resolvedUrl = '') => {
+    const assetId = config?.assetId || 'neon_photostudio';
+    const normalizedResolution = normalizeHdriResolutionId(forcedResolution) || forcedResolution || '2k';
+    const directHdrUrl = `https://dl.polyhaven.org/file/ph-assets/HDRIs/hdr/${normalizedResolution}/${assetId}_${normalizedResolution}.hdr`;
+    const directExrUrl = `https://dl.polyhaven.org/file/ph-assets/HDRIs/exr/${normalizedResolution}/${assetId}_${normalizedResolution}.exr`;
+    return [...new Set([resolvedUrl, directHdrUrl, directExrUrl].filter((entry) => typeof entry === 'string' && entry))];
+  };
+
   for (const forcedResolution of resolutionAttempts) {
-    const url = await resolvePolyHavenHdriUrl({ ...config, forceResolution: forcedResolution });
-    if (!url || attemptedUrls.has(url)) continue;
-    attemptedUrls.add(url);
-    const loaded = await loadFromUrl(url);
-    if (loaded?.envMap) return loaded;
+    const resolvedUrl = await resolvePolyHavenHdriUrl({ ...config, forceResolution: forcedResolution });
+    const candidateUrls = buildResolutionCandidates(forcedResolution, resolvedUrl);
+    let loaded = null;
+    for (const url of candidateUrls) {
+      if (attemptedUrls.has(url)) continue;
+      attemptedUrls.add(url);
+      loaded = await loadFromUrl(url);
+      if (loaded?.envMap) return loaded;
+    }
     console.warn('Failed to load Poly Haven HDRI at requested resolution', {
       assetId: config?.assetId,
       forcedResolution,
-      url
+      urls: candidateUrls
     });
   }
 


### PR DESCRIPTION
### Motivation
- Fix a case where selecting the `120 Hz` / Ultra profile in Murlan Royale left the HDRI environment unloaded so the 8K environment did not appear as it does in other royale games.
- Make HDRI loading more resilient on slower networks or devices when targeting large Poly Haven assets (8K).

### Description
- Increased the HDRI load timeout from `15000` ms to `30000` ms to allow more time for large 8K files to download and decode in `loadPolyHavenHdriEnvironment`.
- Added a per-resolution candidate URL builder that tries the resolved API URL and also constructs direct Poly Haven `.hdr` and `.exr` URLs for the requested resolution before falling back.
- Updated the resolution attempt loop to iterate over each candidate URL (skipping already `attemptedUrls`) and return as soon as a valid `envMap` is loaded, while logging all tried URLs for debugging.
- Preserved the existing preferred-resolution ordering and final fallback generation so the resolution ladder (8k → 4k → 2k → 1k) remains intact.

### Testing
- Ran linting via `npx eslint webapp/src/pages/Games/MurlanRoyaleArena.jsx`, which completed with no blocking errors (file is ignored by repo lint patterns so only a warning was reported).
- Built the webapp with `npm --prefix webapp run build`, and the build completed successfully.
- Verified the modified code path compiles inside the app build and the HDRI loading logic now attempts multiple candidate URLs per resolution.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccf9be30688329a47b6d70f4a7ad57)