### PR TITLE
Fix Ludo Battle Royal 120Hz HDRI profile to load 8K assets

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -2762,7 +2762,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
   const textureResolutionKey = useMemo(() => textureResolutionStack.join('|'), [textureResolutionStack]);
   const hdriResolutionProfile = useMemo(() => {
     const option = activeFrameRateOption ?? DEFAULT_FRAME_RATE_OPTION;
-    const mobileHdri4kOptionIds = ['qhd90', 'uhd120', 'uhd144'];
+    const mobileHdri4kOptionIds = ['qhd90'];
     const forceMobile4kHdri = isLikelyMobileDevice() && mobileHdri4kOptionIds.includes(option?.id);
     if (forceMobile4kHdri) {
       return {


### PR DESCRIPTION
### Motivation
- The Ludo Battle Royal 120 Hz profile was being forced to a mobile-only 4K HDRI path, preventing the intended `8k -> 4k` HDRI selection used by other Battle Royal games.

### Description
- Adjusted `webapp/src/pages/Games/LudoBattleRoyal.jsx` to change `mobileHdri4kOptionIds` from `['qhd90', 'uhd120', 'uhd144']` to `['qhd90']` so the mobile 4K-only override applies to 90 Hz only and `uhd120`/`uhd144` retain their 8K-first preference.

### Testing
- Ran the production build with `npm --prefix webapp run build` and the build completed successfully with only existing Vite chunk-size/dynamic-import warnings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccf9d96fc48329ade7adab186f9954)