### PR TITLE
Adjust Checkers HDRI span to match Chess Battle Royal proportions

### DIFF
--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -90,7 +90,7 @@ const MIN_HDRI_CAMERA_HEIGHT_M = 0.9;
 const MIN_HDRI_RADIUS = 28;
 const DEFAULT_HDRI_RADIUS_MULTIPLIER = 6;
 const DEFAULT_HDRI_GROUNDED_RESOLUTION = 256;
-const CHECKERS_ROOM_HALF_SPAN = 11.8;
+const CHECKERS_ROOM_HALF_SPAN = CHAIR_DISTANCE + SEAT_DEPTH;
 const CHECKERS_GRAPHICS_PROFILE_STORAGE_KEY =
   'checkersBattleRoyalGraphicsProfile';
 const CHECKERS_DEFAULT_GRAPHICS_PROFILE_ID = 'hz90_2k';
@@ -2561,10 +2561,7 @@ export default function CheckersBattleRoyal() {
           typeof variant?.groundRadiusMultiplier === 'number'
             ? variant.groundRadiusMultiplier
             : DEFAULT_HDRI_RADIUS_MULTIPLIER;
-        const sceneSpan = Math.max(
-          CHECKERS_ROOM_HALF_SPAN,
-          CHAIR_DISTANCE + TABLE_RADIUS
-        );
+        const sceneSpan = CHECKERS_ROOM_HALF_SPAN;
         const groundRadius = Math.max(
           sceneSpan * radiusMultiplier * HDRI_UNITS_PER_METER,
           MIN_HDRI_RADIUS


### PR DESCRIPTION
### Motivation
- Make the HDRI appear larger in Checkers Battle Royal so the visual proportion between the table/chairs and the grounded HDRI matches the Chess Battle Royal layout by deriving the HDRI span from the actual table/chair envelope instead of a fixed oversized value.

### Description
- Replaced the hardcoded `CHECKERS_ROOM_HALF_SPAN = 11.8` with `CHECKERS_ROOM_HALF_SPAN = CHAIR_DISTANCE + SEAT_DEPTH` and simplified the HDRI `sceneSpan` calculation to use `CHECKERS_ROOM_HALF_SPAN` directly in `webapp/src/pages/Games/CheckersBattleRoyal.jsx` so the grounded skybox radius is computed from the game furniture footprint.

### Testing
- Ran `npx eslint webapp/src/pages/Games/CheckersBattleRoyal.jsx` (and with `--no-ignore`) and observed no lint errors (only an ignore warning from the project lint config).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdf37e636c83299bafcfbf9ef45a37)