### PR TITLE
Share Murlan Royale inventory with Texas/Pool assets

### DIFF
--- a/test/inventoryCrossGameConfig.test.js
+++ b/test/inventoryCrossGameConfig.test.js
@@ -13,6 +13,17 @@ import {
 import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from '../webapp/src/config/murlanThemes.js';
 import { DOMINO_ROYAL_STORE_ITEMS } from '../webapp/src/config/dominoRoyalInventoryConfig.js';
 import {
+  MURLAN_ROYALE_DEFAULT_UNLOCKS,
+  MURLAN_ROYALE_STORE_ITEMS
+} from '../webapp/src/config/murlanInventoryConfig.js';
+import {
+  TEXAS_HOLDEM_DEFAULT_UNLOCKS,
+  TEXAS_HOLDEM_STORE_ITEMS,
+  TEXAS_TABLE_FINISH_OPTIONS
+} from '../webapp/src/config/texasHoldemInventoryConfig.js';
+import { TABLE_CLOTH_OPTIONS } from '../webapp/src/utils/tableCustomizationOptions.js';
+import { CARD_THEMES } from '../webapp/src/utils/cards3d.js';
+import {
   TAVULL_BATTLE_DEFAULT_UNLOCKS,
   TAVULL_BATTLE_CHAIR_OPTIONS,
   TAVULL_BATTLE_BOARD_FINISH_OPTIONS,
@@ -73,6 +84,32 @@ describe('cross-game inventory alignment', () => {
     expect(toOptionSet(TAVULL_BATTLE_STORE_ITEMS, 'tableFinish')).toEqual(chessTableFinish);
     expect(toOptionSet(TAVULL_BATTLE_STORE_ITEMS, 'environmentHdri')).toEqual(chessHdri);
     expect(TAVULL_BATTLE_DEFAULT_UNLOCKS.tables[0]).toBe(CHESS_BATTLE_DEFAULT_UNLOCKS.tables[0]);
+  });
+
+  test('murlan shares texas hold’em inventories for poker arena assets', () => {
+    const toOptionSet = (items, type) =>
+      new Set(items.filter((item) => item.type === type).map((item) => item.optionId));
+
+    expect(toOptionSet(MURLAN_ROYALE_STORE_ITEMS, 'tables')).toEqual(
+      toOptionSet(TEXAS_HOLDEM_STORE_ITEMS, 'tableTheme')
+    );
+    expect(toOptionSet(MURLAN_ROYALE_STORE_ITEMS, 'stools')).toEqual(
+      toOptionSet(TEXAS_HOLDEM_STORE_ITEMS, 'chairTheme')
+    );
+    expect(toOptionSet(MURLAN_ROYALE_STORE_ITEMS, 'tableFinish')).toEqual(
+      new Set(TEXAS_TABLE_FINISH_OPTIONS.map((option) => option.id))
+    );
+    expect(toOptionSet(MURLAN_ROYALE_STORE_ITEMS, 'tableCloth')).toEqual(
+      new Set(TABLE_CLOTH_OPTIONS.map((option) => option.id))
+    );
+    expect(toOptionSet(MURLAN_ROYALE_STORE_ITEMS, 'cards')).toEqual(
+      toOptionSet(TEXAS_HOLDEM_STORE_ITEMS, 'cards')
+    );
+    expect(MURLAN_ROYALE_DEFAULT_UNLOCKS.tables[0]).toBe(TEXAS_HOLDEM_DEFAULT_UNLOCKS.tableTheme[0]);
+    expect(MURLAN_ROYALE_DEFAULT_UNLOCKS.stools[0]).toBe(TEXAS_HOLDEM_DEFAULT_UNLOCKS.chairTheme[0]);
+    expect(MURLAN_ROYALE_DEFAULT_UNLOCKS.tableFinish[0]).toBe(TEXAS_HOLDEM_DEFAULT_UNLOCKS.tableFinish[0]);
+    expect(MURLAN_ROYALE_DEFAULT_UNLOCKS.tableCloth[0]).toBe(TEXAS_HOLDEM_DEFAULT_UNLOCKS.tableCloth[0]);
+    expect(MURLAN_ROYALE_DEFAULT_UNLOCKS.cards[0]).toBe(CARD_THEMES[0]?.id);
   });
 
   test('tavull store thumbnails match each source option thumbnail', () => {

--- a/webapp/src/config/murlanInventoryConfig.js
+++ b/webapp/src/config/murlanInventoryConfig.js
@@ -1,7 +1,12 @@
-import { CARD_THEMES } from '../utils/cardThemes.js';
 import { POOL_ROYALE_DEFAULT_HDRI_ID, POOL_ROYALE_HDRI_VARIANTS } from './poolRoyaleInventoryConfig.js';
-import { MURLAN_TABLE_CLOTHS } from './murlanTableCloths.js';
-import { MURLAN_TABLE_FINISHES } from './murlanTableFinishes.js';
+import { CARD_THEMES } from '../utils/cards3d.js';
+import {
+  TEXAS_HOLDEM_OPTION_LABELS,
+  TEXAS_TABLE_FINISH_OPTIONS
+} from './texasHoldemInventoryConfig.js';
+import {
+  TABLE_CLOTH_OPTIONS as TEXAS_TABLE_CLOTH_OPTIONS
+} from '../utils/tableCustomizationOptions.js';
 import { MURLAN_CHARACTER_THEMES } from './murlanCharacterThemes.js';
 import { MURLAN_OUTFIT_THEMES, MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from './murlanThemes.js';
 
@@ -18,8 +23,8 @@ export const MURLAN_ROYALE_DEFAULT_UNLOCKS = Object.freeze({
   cards: [CARD_THEMES[0].id],
   stools: [MURLAN_STOOL_THEMES[0].id],
   tables: [MURLAN_TABLE_THEMES[0].id],
-  tableCloth: [MURLAN_TABLE_CLOTHS[0].id],
-  tableFinish: [MURLAN_TABLE_FINISHES[0].id],
+  tableCloth: [TEXAS_TABLE_CLOTH_OPTIONS[0].id],
+  tableFinish: [TEXAS_TABLE_FINISH_OPTIONS[0].id],
   characters: [MURLAN_CHARACTER_THEMES[0].id],
   environmentHdri: POOL_ROYALE_HDRI_VARIANTS.map((variant) => variant.id)
 });
@@ -29,8 +34,8 @@ export const MURLAN_ROYALE_OPTION_LABELS = Object.freeze({
   cards: mapLabels(CARD_THEMES),
   stools: mapLabels(MURLAN_STOOL_THEMES),
   tables: mapLabels(MURLAN_TABLE_THEMES),
-  tableCloth: mapLabels(MURLAN_TABLE_CLOTHS),
-  tableFinish: mapLabels(MURLAN_TABLE_FINISHES),
+  tableCloth: mapLabels(TEXAS_TABLE_CLOTH_OPTIONS),
+  tableFinish: Object.freeze(TEXAS_HOLDEM_OPTION_LABELS.tableFinish),
   characters: mapLabels(MURLAN_CHARACTER_THEMES),
   environmentHdri: mapLabels(
     POOL_ROYALE_HDRI_VARIANTS.map((variant) => ({
@@ -41,7 +46,7 @@ export const MURLAN_ROYALE_OPTION_LABELS = Object.freeze({
 });
 
 export const MURLAN_ROYALE_STORE_ITEMS = [
-  ...MURLAN_TABLE_FINISHES.map((finish, idx) => ({
+  ...TEXAS_TABLE_FINISH_OPTIONS.map((finish, idx) => ({
     id: `table-finish-${finish.id}`,
     type: 'tableFinish',
     optionId: finish.id,
@@ -62,7 +67,7 @@ export const MURLAN_ROYALE_STORE_ITEMS = [
     thumbnail: option.thumbnail
   }))
 ].concat(
-  MURLAN_TABLE_CLOTHS.map((cloth, idx) => ({
+  TEXAS_TABLE_CLOTH_OPTIONS.map((cloth, idx) => ({
     id: `cloth-${cloth.id}`,
     type: 'tableCloth',
     optionId: cloth.id,
@@ -125,13 +130,13 @@ export const MURLAN_ROYALE_DEFAULT_LOADOUT = [
   },
   {
     type: 'tableCloth',
-    optionId: MURLAN_TABLE_CLOTHS[0].id,
-    label: MURLAN_TABLE_CLOTHS[0].label
+    optionId: TEXAS_TABLE_CLOTH_OPTIONS[0].id,
+    label: TEXAS_TABLE_CLOTH_OPTIONS[0].label
   },
   {
     type: 'tableFinish',
-    optionId: MURLAN_TABLE_FINISHES[0].id,
-    label: MURLAN_TABLE_FINISHES[0].label
+    optionId: TEXAS_TABLE_FINISH_OPTIONS[0].id,
+    label: TEXAS_TABLE_FINISH_OPTIONS[0].label
   },
   {
     type: 'environmentHdri',

--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -17,7 +17,7 @@ import { EXRLoader } from 'three/examples/jsm/loaders/EXRLoader.js';
 import { applyRendererSRGB, applySRGBColorSpace } from '../../utils/colorSpace.js';
 import { ARENA_CAMERA_DEFAULTS, buildArenaCameraConfig } from '../../utils/arenaCameraConfig.js';
 import { applyTableMaterials, createMurlanStyleTable } from '../../utils/murlanTable.js';
-import { CARD_THEMES } from '../../utils/cardThemes.js';
+import { CARD_THEMES } from '../../utils/cards3d.js';
 import { makeTonplaygramCardBackTexture } from '../../utils/cards3d.js';
 import { chatBeep, bombSound } from '../../assets/soundData.js';
 import {
@@ -45,8 +45,10 @@ import {
   MURLAN_STOOL_THEMES as STOOL_THEMES,
   MURLAN_TABLE_THEMES as TABLE_THEMES
 } from '../../config/murlanThemes.js';
-import { MURLAN_TABLE_CLOTHS } from '../../config/murlanTableCloths.js';
-import { MURLAN_TABLE_FINISHES } from '../../config/murlanTableFinishes.js';
+import {
+  TEXAS_TABLE_FINISH_OPTIONS as MURLAN_TABLE_FINISHES
+} from '../../config/texasHoldemInventoryConfig.js';
+import { TABLE_CLOTH_OPTIONS as MURLAN_TABLE_CLOTHS } from '../../utils/tableCustomizationOptions.js';
 import { MURLAN_CHARACTER_THEMES } from '../../config/murlanCharacterThemes.js';
 import { giftSounds } from '../../utils/giftSounds.js';
 import { getAvatarUrl } from '../../utils/avatarUtils.js';


### PR DESCRIPTION
### Motivation
- Avoid duplicate downloads and asset duplication by reusing existing poker HDRI and poker arena asset definitions across games. 
- Keep Store SKUs distinct while sharing the underlying option sources so users don’t have to download identical HDRIs, cloths, finishes or card themes multiple times. 
- Ensure inventories and defaults remain aligned across Murlan Royale and Texas Hold’em to prevent mismatches at runtime.

### Description
- Reworked `webapp/src/config/murlanInventoryConfig.js` to import and reuse `TEXAS_TABLE_FINISH_OPTIONS`, `TABLE_CLOTH_OPTIONS` (as `TEXAS_TABLE_CLOTH_OPTIONS`) and the shared card themes from `cards3d`, and to continue sourcing HDRI variants from `poolRoyaleInventoryConfig.js`.
- Updated Murlan default unlocks and option labels to reference the Texas/Pool option sets for `tableCloth`, `tableFinish`, and `cards` so the same option ids/metadata are used programmatically.
- Adjusted `webapp/src/pages/Games/MurlanRoyaleArena.jsx` imports so the live Murlan arena uses the shared Texas finish/cloth and card theme sources at runtime.
- Added a regression test `test/inventoryCrossGameConfig.test.js` that verifies Murlan and Texas inventories are aligned for tables, chairs, table finishes, cloths, cards and default unlocks.

### Testing
- Ran the added test file with `npm test -- test/inventoryCrossGameConfig.test.js --runInBand`, and it passed (test suite `test/inventoryCrossGameConfig.test.js` — 6 tests passed).
- No other automated tests were impacted by these changes in the run performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdf7a07f248329ae9bc6e19ee5ff05)