### PR TITLE
Share Pool HDRIs and Domino chairs with Texas Hold'em via shared catalog

### DIFF
--- a/test/inventoryCrossGameConfig.test.js
+++ b/test/inventoryCrossGameConfig.test.js
@@ -26,8 +26,12 @@ import { MURLAN_TABLE_CLOTHS } from '../webapp/src/config/murlanTableCloths.js';
 import { TABLE_CLOTH_OPTIONS } from '../webapp/src/utils/tableCustomizationOptions.js';
 import { CARD_THEMES as TEXAS_CARD_THEMES } from '../webapp/src/utils/cards3d.js';
 import { TEXAS_CHAIR_THEME_OPTIONS, TEXAS_TABLE_THEME_OPTIONS } from '../webapp/src/config/texasHoldemOptions.js';
-import { TEXAS_TABLE_FINISH_OPTIONS } from '../webapp/src/config/texasHoldemInventoryConfig.js';
-import { POOL_ROYALE_HDRI_VARIANTS } from '../webapp/src/config/poolRoyaleInventoryConfig.js';
+import {
+  TEXAS_DEFAULT_HDRI_ID,
+  TEXAS_HDRI_OPTIONS,
+  TEXAS_TABLE_FINISH_OPTIONS
+} from '../webapp/src/config/texasHoldemInventoryConfig.js';
+import { POOL_ROYALE_DEFAULT_HDRI_ID, POOL_ROYALE_HDRI_VARIANTS } from '../webapp/src/config/poolRoyaleInventoryConfig.js';
 
 describe('cross-game inventory alignment', () => {
   test('domino default table follows chess default murlan table', () => {
@@ -64,6 +68,12 @@ describe('cross-game inventory alignment', () => {
     expect(new Set(DOMINO_ROYAL_DEFAULT_UNLOCKS.chairTheme)).toEqual(
       new Set(MURLAN_STOOL_THEMES.map((theme) => theme.id))
     );
+  });
+
+  test('texas holdem reuses pool hdris and domino chair catalog while keeping separate store ids', () => {
+    expect(TEXAS_HDRI_OPTIONS).toBe(POOL_ROYALE_HDRI_VARIANTS);
+    expect(TEXAS_DEFAULT_HDRI_ID).toBe(POOL_ROYALE_DEFAULT_HDRI_ID);
+    expect(TEXAS_CHAIR_THEME_OPTIONS).toBe(DOMINO_ROYAL_OPTION_SETS.chairTheme);
   });
 
 

--- a/webapp/src/config/dominoRoyalInventoryConfig.js
+++ b/webapp/src/config/dominoRoyalInventoryConfig.js
@@ -2,6 +2,7 @@ import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from './murlanThemes.js';
 import { TABLE_CLOTH_OPTIONS } from '../utils/tableCustomizationOptions.js';
 import { TEXAS_TABLE_FINISH_OPTIONS } from './texasHoldemInventoryConfig.js';
 import { POOL_ROYALE_DEFAULT_HDRI_ID, POOL_ROYALE_HDRI_VARIANTS } from './poolRoyaleInventoryConfig.js';
+import { DOMINO_BATTLE_ROYAL_CHAIR_THEME_OPTIONS } from './sharedInventoryCatalogs.js';
 import { swatchThumbnail } from './storeThumbnails.js';
 
 export const DOMINO_ROYAL_OPTION_SETS = Object.freeze({
@@ -45,12 +46,7 @@ export const DOMINO_ROYAL_OPTION_SETS = Object.freeze({
     { id: 'iceTracer', label: 'Ice Tracer' },
     { id: 'violetPulse', label: 'Violet Pulse' }
   ],
-  chairTheme: MURLAN_STOOL_THEMES.map(({ id, label, price = 0, description }) => ({
-    id,
-    label,
-    price,
-    description: description || `${label} seating set from Murlan Royale`
-  }))
+  chairTheme: DOMINO_BATTLE_ROYAL_CHAIR_THEME_OPTIONS
 });
 
 

--- a/webapp/src/config/sharedInventoryCatalogs.js
+++ b/webapp/src/config/sharedInventoryCatalogs.js
@@ -1,0 +1,12 @@
+import { MURLAN_STOOL_THEMES } from './murlanThemes.js';
+import { POOL_ROYALE_DEFAULT_HDRI_ID, POOL_ROYALE_HDRI_VARIANTS } from './poolRoyaleInventoryConfig.js';
+
+export const DOMINO_BATTLE_ROYAL_CHAIR_THEME_OPTIONS = Object.freeze(
+  MURLAN_STOOL_THEMES.map((theme) => ({
+    ...theme,
+    description: theme.description || `${theme.label} seating set from Murlan Royale`
+  }))
+);
+
+export const TEXAS_HOLDEM_SHARED_HDRI_OPTIONS = POOL_ROYALE_HDRI_VARIANTS;
+export const TEXAS_HOLDEM_SHARED_DEFAULT_HDRI_ID = POOL_ROYALE_DEFAULT_HDRI_ID;

--- a/webapp/src/config/texasHoldemInventoryConfig.js
+++ b/webapp/src/config/texasHoldemInventoryConfig.js
@@ -3,10 +3,8 @@ import { TABLE_SHAPE_OPTIONS } from '../utils/murlanTable.js';
 import { CARD_THEMES } from '../utils/cards3d.js';
 import { TEXAS_CHAIR_THEME_OPTIONS, TEXAS_TABLE_THEME_OPTIONS } from './texasHoldemOptions.js';
 import { polyHavenThumb } from './storeThumbnails.js';
-import {
-  POOL_ROYALE_HDRI_VARIANTS,
-  POOL_ROYALE_OPTION_LABELS
-} from './poolRoyaleInventoryConfig.js';
+import { POOL_ROYALE_OPTION_LABELS } from './poolRoyaleInventoryConfig.js';
+import { TEXAS_HOLDEM_SHARED_DEFAULT_HDRI_ID, TEXAS_HOLDEM_SHARED_HDRI_OPTIONS } from './sharedInventoryCatalogs.js';
 
 const reduceLabels = (items) =>
   items.reduce((acc, option) => {
@@ -14,19 +12,8 @@ const reduceLabels = (items) =>
     return acc;
   }, {});
 
-export const TEXAS_HDRI_OPTIONS = POOL_ROYALE_HDRI_VARIANTS.map((variant) => {
-  const baseResolutions = Array.isArray(variant?.preferredResolutions)
-    ? variant.preferredResolutions.filter((res) => typeof res === 'string' && res.length)
-    : [];
-  const preferredResolutions = Array.from(new Set(['8k', ...baseResolutions, '4k', '2k', '1k']));
-  return {
-    ...variant,
-    preferredResolutions,
-    label: `${variant.name} HDRI`
-  };
-});
-
-export const TEXAS_DEFAULT_HDRI_ID = 'dancingHall';
+export const TEXAS_HDRI_OPTIONS = TEXAS_HOLDEM_SHARED_HDRI_OPTIONS;
+export const TEXAS_DEFAULT_HDRI_ID = TEXAS_HOLDEM_SHARED_DEFAULT_HDRI_ID;
 
 export const TEXAS_TABLE_FINISH_OPTIONS = Object.freeze([
   {
@@ -126,7 +113,7 @@ export const TEXAS_HOLDEM_OPTION_LABELS = Object.freeze({
   cards: Object.freeze(reduceLabels(CARD_THEMES)),
   environmentHdri: Object.freeze(
     TEXAS_HDRI_OPTIONS.reduce((acc, option) => {
-      acc[option.id] = option.label;
+      acc[option.id] = `${option.name} HDRI`;
       return acc;
     }, {})
   )
@@ -192,7 +179,7 @@ export const TEXAS_HOLDEM_STORE_ITEMS = [
     id: `texas-hdri-${variant.id}`,
     type: 'environmentHdri',
     optionId: variant.id,
-    name: variant.label,
+    name: `${variant.name} HDRI`,
     price: variant.price ?? 1400 + idx * 25,
     description: variant.description || 'Poly Haven HDRI environment used in Murlan Royale.',
     swatches: variant.swatches,
@@ -234,6 +221,8 @@ export const TEXAS_HOLDEM_DEFAULT_LOADOUT = [
   {
     type: 'environmentHdri',
     optionId: TEXAS_DEFAULT_HDRI_ID,
-    label: TEXAS_HOLDEM_OPTION_LABELS.environmentHdri?.[TEXAS_DEFAULT_HDRI_ID] || TEXAS_HDRI_OPTIONS[DEFAULT_HDRI_INDEX]?.label
+    label:
+      TEXAS_HOLDEM_OPTION_LABELS.environmentHdri?.[TEXAS_DEFAULT_HDRI_ID] ||
+      (TEXAS_HDRI_OPTIONS[DEFAULT_HDRI_INDEX] ? `${TEXAS_HDRI_OPTIONS[DEFAULT_HDRI_INDEX].name} HDRI` : undefined)
   }
 ];

--- a/webapp/src/config/texasHoldemOptions.js
+++ b/webapp/src/config/texasHoldemOptions.js
@@ -1,5 +1,6 @@
-import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from './murlanThemes.js';
+import { MURLAN_TABLE_THEMES } from './murlanThemes.js';
+import { DOMINO_BATTLE_ROYAL_CHAIR_THEME_OPTIONS } from './sharedInventoryCatalogs.js';
 
-export const TEXAS_CHAIR_THEME_OPTIONS = Object.freeze(MURLAN_STOOL_THEMES);
+export const TEXAS_CHAIR_THEME_OPTIONS = DOMINO_BATTLE_ROYAL_CHAIR_THEME_OPTIONS;
 export const TEXAS_TABLE_THEME_OPTIONS = Object.freeze(MURLAN_TABLE_THEMES);
 export const TEXAS_CHAIR_COLOR_OPTIONS = TEXAS_CHAIR_THEME_OPTIONS;


### PR DESCRIPTION
### Motivation
- Make Texas Hold'em use the exact same Pool Royale HDRI variants and default ID and reuse the Domino Battle Royal chair catalog so the games share the same in-code inventory (avoids duplicating HDRI definitions and chair option objects). 
- Preserve existing store SKU separation and store-item IDs so store listings remain independent while the underlying catalogs are shared.

### Description
- Added `webapp/src/config/sharedInventoryCatalogs.js` to centralize `POOL_ROYALE_HDRI_VARIANTS`/default and the Domino chair theme export used across games. 
- Updated `webapp/src/config/texasHoldemOptions.js` to reuse the shared Domino chair catalog for `TEXAS_CHAIR_THEME_OPTIONS`. 
- Updated `webapp/src/config/texasHoldemInventoryConfig.js` to consume the shared Pool HDRI variants/default (`TEXAS_HDRI_OPTIONS` and `TEXAS_DEFAULT_HDRI_ID`) while keeping Texas-specific store item IDs and labels. 
- Updated `webapp/src/config/dominoRoyalInventoryConfig.js` to consume the shared chair catalog; updated `test/inventoryCrossGameConfig.test.js` to assert the new sharing behavior.

### Testing
- Ran the focused test suite with `npm test -- test/inventoryCrossGameConfig.test.js --runInBand`. 
- All tests passed: `1` test suite, `7` tests (all passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdface29848329ad39389252eba6fc)