### PR TITLE
Device-aware HDRI resolution mapping for Texas Hold'em (60/90/120Hz)

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -675,13 +675,13 @@ const FRAME_RATE_OPTIONS = Object.freeze([
     fps: 120,
     renderScale: 1.3,
     pixelRatioCap: 1.85,
-    resolution: '8K texture pack • 120 FPS',
-    description: 'Poly Haven 8K assets at a 120 FPS target.'
+    resolution: 'Adaptive HDRI pack • 120 FPS',
+    description: 'Desktop targets 8K→4K while mobile targets 4K→2K at 120 FPS.'
   }
 ]);
 const DEFAULT_FRAME_RATE_ID = 'qhd90';
 const HDRI_RESOLUTION_POLICY_BY_FPS = Object.freeze([
-  Object.freeze({ minFps: 120, preferredResolutions: Object.freeze(['8k', '4k', '2k']), fallbackResolution: '4k' }),
+  Object.freeze({ minFps: 120, preferredResolutions: Object.freeze(['8k', '4k']), fallbackResolution: '4k' }),
   Object.freeze({ minFps: 90, preferredResolutions: Object.freeze(['4k', '2k']), fallbackResolution: '2k' }),
   Object.freeze({ minFps: 0, preferredResolutions: Object.freeze(['2k', '1k']), fallbackResolution: '1k' })
 ]);
@@ -694,13 +694,27 @@ function resolveHdriResolutionProfileForGraphics(frameRateOptionId) {
     HDRI_RESOLUTION_POLICY_BY_FPS[HDRI_RESOLUTION_POLICY_BY_FPS.length - 1];
   const primary = policy?.preferredResolutions?.[0];
   const normalizedPrimary = HDRI_RESOLUTION_OPTION_MAP[primary]?.id || DEFAULT_HDRI_RESOLUTION_ID;
-  const fallback = (policy?.preferredResolutions || []).filter(
-    (value) => value && value !== normalizedPrimary
-  );
+  let fallback = (policy?.preferredResolutions || []).filter((value) => value && value !== normalizedPrimary);
+  let fallbackResolution = policy?.fallbackResolution || fallback[0] || normalizedPrimary;
+
+  if (fps >= 120) {
+    const mobileDevice = isMobileGraphicsDevice();
+    if (mobileDevice) {
+      fallback = ['2k'];
+      return {
+        primary: '4k',
+        fallback,
+        fallbackResolution: '2k'
+      };
+    }
+    fallback = ['4k'];
+    fallbackResolution = '4k';
+  }
+
   return {
     primary: normalizedPrimary,
     fallback,
-    fallbackResolution: policy?.fallbackResolution || fallback[0] || normalizedPrimary
+    fallbackResolution
   };
 }
 


### PR DESCRIPTION
### Motivation
- Make HDRI selection deterministic by refresh rate and device class so low-refresh devices use smaller HDRIs while high-refresh desktops can use very high-res assets without forcing mobile downloads.
- Map requested targets: 60 Hz → 2K (fallback 1K), 90 Hz → 4K (fallback 2K), 120 Hz → mobile 4K→2K and desktop 8K→4K.

### Description
- Updated the 120 Hz menu text in `FRAME_RATE_OPTIONS.uhd120` to reflect adaptive HDRI behavior (`Adaptive HDRI pack • 120 FPS`) in `webapp/src/pages/Games/TexasHoldemArena.jsx`.
- Reduced the 120 Hz entry in `HDRI_RESOLUTION_POLICY_BY_FPS` to `['8k','4k']` so desktop primary remains 8K with 4K fallback while removing the redundant 2K entry.
- Implemented a device-aware override in `resolveHdriResolutionProfileForGraphics` that uses `isMobileGraphicsDevice()` to return a mobile 120 Hz profile (`primary: '4k', fallback: ['2k'], fallbackResolution: '2k'`) and otherwise preserves the desktop 8K→4K policy.
- Cleaned up fallback-resolution handling so `primary`, `fallback`, and `fallbackResolution` are computed consistently and returned from the resolver.

### Testing
- Ran `npm run -s lint -- webapp/src/pages/Games/TexasHoldemArena.jsx`, which reported that the target file is ignored by the repo eslint settings and surfaced many pre-existing lint errors in generated/dist files that are unrelated to this change.
- No unit tests or CI runs were executed as part of this change; the modification is limited to `webapp/src/pages/Games/TexasHoldemArena.jsx` and is ready for integration testing in the normal pipeline.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce748f5f888329a6f0b658a025d972)