### PR TITLE
Adjust Murlan Royale HDRI/profile selection, reuse Texas card/cloth assets, and widen turn camera

### DIFF
--- a/webapp/src/config/texasHoldemInventoryConfig.js
+++ b/webapp/src/config/texasHoldemInventoryConfig.js
@@ -22,6 +22,7 @@ export const TEXAS_HDRI_OPTIONS = BATTLE_ROYALE_SHARED_HDRI_VARIANTS.map((varian
 export const TEXAS_DEFAULT_HDRI_ID = 'dancingHall';
 
 export const TEXAS_TABLE_FINISH_OPTIONS = BATTLE_ROYALE_SHARED_TABLE_FINISH_OPTIONS;
+export const TEXAS_TABLE_CLOTH_OPTIONS = TABLE_CLOTH_OPTIONS;
 
 export const TEXAS_CHAIR_THEME_OPTIONS = BATTLE_ROYALE_SHARED_CHAIR_THEME_OPTIONS;
 export const TEXAS_TABLE_THEME_OPTIONS = BATTLE_ROYALE_SHARED_TABLE_THEME_OPTIONS;
@@ -31,7 +32,7 @@ const DEFAULT_HDRI_INDEX = Math.max(0, TEXAS_HDRI_OPTIONS.findIndex((variant) =>
 export const TEXAS_HOLDEM_DEFAULT_UNLOCKS = Object.freeze({
   tableFinish: [TEXAS_TABLE_FINISH_OPTIONS[0]?.id],
   tableWood: [TABLE_WOOD_OPTIONS[0]?.id],
-  tableCloth: [TABLE_CLOTH_OPTIONS[0]?.id],
+  tableCloth: [TEXAS_TABLE_CLOTH_OPTIONS[0]?.id],
   tableBase: [TABLE_BASE_OPTIONS[0]?.id],
   chairTheme: [TEXAS_CHAIR_THEME_OPTIONS[0]?.id],
   tableTheme: [TEXAS_TABLE_THEME_OPTIONS[0]?.id],
@@ -43,7 +44,7 @@ export const TEXAS_HOLDEM_DEFAULT_UNLOCKS = Object.freeze({
 export const TEXAS_HOLDEM_OPTION_LABELS = Object.freeze({
   tableFinish: Object.freeze(reduceLabels(TEXAS_TABLE_FINISH_OPTIONS)),
   tableWood: Object.freeze(reduceLabels(TABLE_WOOD_OPTIONS)),
-  tableCloth: Object.freeze(reduceLabels(TABLE_CLOTH_OPTIONS)),
+  tableCloth: Object.freeze(reduceLabels(TEXAS_TABLE_CLOTH_OPTIONS)),
   tableBase: Object.freeze(reduceLabels(TABLE_BASE_OPTIONS)),
   chairTheme: Object.freeze(reduceLabels(TEXAS_CHAIR_THEME_OPTIONS)),
   tableTheme: Object.freeze(reduceLabels(TEXAS_TABLE_THEME_OPTIONS)),
@@ -77,7 +78,7 @@ export const TEXAS_HOLDEM_STORE_ITEMS = [
     description: "Unlock an alternate wood finish for your Hold'em arena table.",
     thumbnail: option.thumbnail
   })),
-  ...TABLE_CLOTH_OPTIONS.slice(1).map((option, idx) => ({
+  ...TEXAS_TABLE_CLOTH_OPTIONS.slice(1).map((option, idx) => ({
     id: `texas-cloth-${option.id}`,
     type: 'tableCloth',
     optionId: option.id,
@@ -150,7 +151,7 @@ export const TEXAS_HOLDEM_DEFAULT_LOADOUT = [
     label: TEXAS_TABLE_FINISH_OPTIONS[0]?.label
   },
   { type: 'tableWood', optionId: TABLE_WOOD_OPTIONS[0]?.id, label: TABLE_WOOD_OPTIONS[0]?.label },
-  { type: 'tableCloth', optionId: TABLE_CLOTH_OPTIONS[0]?.id, label: TABLE_CLOTH_OPTIONS[0]?.label },
+  { type: 'tableCloth', optionId: TEXAS_TABLE_CLOTH_OPTIONS[0]?.id, label: TEXAS_TABLE_CLOTH_OPTIONS[0]?.label },
   { type: 'tableBase', optionId: TABLE_BASE_OPTIONS[0]?.id, label: TABLE_BASE_OPTIONS[0]?.label },
   { type: 'chairTheme', optionId: TEXAS_CHAIR_THEME_OPTIONS[0]?.id, label: TEXAS_CHAIR_THEME_OPTIONS[0]?.label },
   { type: 'tableTheme', optionId: TEXAS_TABLE_THEME_OPTIONS[0]?.id, label: TEXAS_TABLE_THEME_OPTIONS[0]?.label },

--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -46,9 +46,9 @@ import {
   MURLAN_TABLE_THEMES as TABLE_THEMES
 } from '../../config/murlanThemes.js';
 import {
+  TEXAS_TABLE_CLOTH_OPTIONS as MURLAN_TABLE_CLOTHS,
   TEXAS_TABLE_FINISH_OPTIONS as MURLAN_TABLE_FINISHES
 } from '../../config/texasHoldemInventoryConfig.js';
-import { TABLE_CLOTH_OPTIONS as MURLAN_TABLE_CLOTHS } from '../../utils/tableCustomizationOptions.js';
 import { MURLAN_CHARACTER_THEMES } from '../../config/murlanCharacterThemes.js';
 import { giftSounds } from '../../utils/giftSounds.js';
 import { getAvatarUrl } from '../../utils/avatarUtils.js';
@@ -307,6 +307,16 @@ function detectPreferredFrameRateId() {
   }
 
   return DEFAULT_FRAME_RATE_ID;
+}
+
+function detectLikelyMobileDevice() {
+  if (typeof window === 'undefined' || typeof navigator === 'undefined') return false;
+  const ua = navigator.userAgent ?? '';
+  if (/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(ua)) return true;
+  if (detectCoarsePointer()) return true;
+  const maxTouchPoints = navigator.maxTouchPoints ?? 0;
+  if (maxTouchPoints > 1) return true;
+  return classifyRendererTier(readGraphicsRendererString()) === 'mobile';
 }
 
 const CHAIR_MODEL_URLS = [
@@ -2208,8 +2218,8 @@ const CAMERA_PLAY_FOLLOW_HOLD_MS = 420;
 const CAMERA_PLAY_NEXT_TURN_DELAY_MS = 520;
 const CAMERA_PLAY_TURN_DURATION_MS = 300;
 const CAMERA_TARGET_TURN_SNAP_DISTANCE = 0.018 * MODEL_SCALE;
-const CAMERA_PLAYER_TARGET_WEIGHT = 0.45;
-const CAMERA_SIDE_LOOK_EXTRA = 0.22 * MODEL_SCALE;
+const CAMERA_PLAYER_TARGET_WEIGHT = 0.52;
+const CAMERA_SIDE_LOOK_EXTRA = 0.28 * MODEL_SCALE;
 const CAMERA_INWARD_RADIUS_FACTOR = 0.72;
 const CAMERA_UP_TILT_FORWARD_BLEND = 0.34 * MODEL_SCALE;
 const CAMERA_UP_TILT_FORWARD_LERP = 0.14;
@@ -2405,22 +2415,34 @@ const FRAME_RATE_OPTIONS = Object.freeze([
     resolution: '8K texture pack • 120 FPS',
     hdriResolution: '8k',
     preferredTextureSizes: ['8k', '4k', '2k', '1k'],
-    description: 'Poly Haven 8K HDRI target with fallback to 4K.'
+    description: 'Desktop uses 8K→4K HDRI while mobile uses 4K→2K at 120 Hz.'
   }
 ]);
 
 const HDRI_RESOLUTION_POLICY_BY_FPS = Object.freeze([
-  { minFps: 120, preferredResolutions: Object.freeze(['8k', '4k', '2k']), fallbackResolution: '4k' },
+  {
+    minFps: 120,
+    preferredResolutions: Object.freeze(['8k', '4k', '2k']),
+    fallbackResolution: '4k',
+    mobilePreferredResolutions: Object.freeze(['4k', '2k']),
+    mobileFallbackResolution: '2k'
+  },
   { minFps: 90, preferredResolutions: Object.freeze(['4k', '2k']), fallbackResolution: '2k' },
   { minFps: 0, preferredResolutions: Object.freeze(['2k', '1k']), fallbackResolution: '1k' }
 ]);
 
-function resolveHdriPolicyForFps(fps) {
+function resolveHdriPolicyForFps(fps, isMobileDevice = false) {
   const safeFps = Number.isFinite(fps) ? fps : 60;
-  return (
+  const policy = (
     HDRI_RESOLUTION_POLICY_BY_FPS.find((policy) => safeFps >= policy.minFps) ??
     HDRI_RESOLUTION_POLICY_BY_FPS[HDRI_RESOLUTION_POLICY_BY_FPS.length - 1]
   );
+  if (!isMobileDevice) return policy;
+  return {
+    ...policy,
+    preferredResolutions: policy.mobilePreferredResolutions ?? policy.preferredResolutions,
+    fallbackResolution: policy.mobileFallbackResolution ?? policy.fallbackResolution
+  };
 }
 
 function buildHdriResolutionChain(primaryResolution, policy = null) {
@@ -2435,8 +2457,11 @@ function buildHdriResolutionChain(primaryResolution, policy = null) {
 const DEFAULT_FRAME_RATE_OPTION =
   FRAME_RATE_OPTIONS.find((opt) => opt.id === DEFAULT_FRAME_RATE_ID) ?? FRAME_RATE_OPTIONS[0];
 
-function resolveHdriResolutionFromGraphics(frameOption) {
+function resolveHdriResolutionFromGraphics(frameOption, isMobileDevice = false) {
   const targetFromGraphics = frameOption?.hdriResolution;
+  if (isMobileDevice && targetFromGraphics === '8k') {
+    return '4k';
+  }
   if (targetFromGraphics === '2k' || targetFromGraphics === '4k' || targetFromGraphics === '8k') {
     return targetFromGraphics;
   }
@@ -2614,12 +2639,13 @@ export default function MurlanRoyaleArena({ search }) {
       window.removeEventListener('orientationchange', updateOrientation);
     };
   }, []);
+  const isLikelyMobile = useMemo(() => detectLikelyMobileDevice(), []);
   const resolvedHdriResolution = useMemo(() => {
-    return resolveHdriResolutionFromGraphics(activeFrameRateOption);
-  }, [activeFrameRateOption]);
+    return resolveHdriResolutionFromGraphics(activeFrameRateOption, isLikelyMobile);
+  }, [activeFrameRateOption, isLikelyMobile]);
   const activeHdriPolicy = useMemo(
-    () => resolveHdriPolicyForFps(activeFrameRateOption?.fps),
-    [activeFrameRateOption]
+    () => resolveHdriPolicyForFps(activeFrameRateOption?.fps, isLikelyMobile),
+    [activeFrameRateOption, isLikelyMobile]
   );
   const resolvedFrameTiming = useMemo(() => {
     const fallbackFps =
@@ -6098,8 +6124,8 @@ function makeCardFace(rank, suit, theme, w = 768, h = 1080) {
   return tex;
 }
 
-function makeCardBackTexture(theme, w = 512, h = 720) {
-  return makeTonplaygramCardBackTexture(theme, w, h);
+function makeCardBackTexture(theme) {
+  return makeTonplaygramCardBackTexture(theme);
 }
 
 function applyChairThemeMaterials(three, theme) {


### PR DESCRIPTION
### Motivation
- Make Murlan Royale graphics presets follow the requested HDRI resolution mapping per refresh rate and device class to improve visual quality while keeping mobile fallbacks reasonable.
- Ensure Murlan reuses the exact same cloth and card-back assets/logic used by Texas Hold’em so visual assets (cloth textures and logo-on-back cards) are consistent across games.
- Increase camera turn emphasis so the left/right camera motion on player turns is more noticeable.

### Description
- Added `TEXAS_TABLE_CLOTH_OPTIONS` export and switched Texas config defaults to refer to it, so the cloth catalog is a shared source (`webapp/src/config/texasHoldemInventoryConfig.js`).
- Made Murlan arena HDRI selection device-aware by adding `detectLikelyMobileDevice()`, passing `isMobile` into the HDRI resolution resolver, and extending the HDRI policy to include mobile-preferred resolutions for 120 Hz (`webapp/src/pages/Games/MurlanRoyaleArena.jsx`).
- Implemented resolution mapping per request: 60 Hz → 2k (1k fallback), 90 Hz → 4k (2k fallback), 120 Hz → device-aware (mobile: 4k→2k; desktop: 8k→4k) via `HDRI_RESOLUTION_POLICY_BY_FPS`, `resolveHdriPolicyForFps()`, and `resolveHdriResolutionFromGraphics()` changes (`webapp/src/pages/Games/MurlanRoyaleArena.jsx`).
- Aligned card back generation to use the shared Tonplaygram back texture helper without forcing unique sizing so Murlan uses the same back/logo as Texas Hold’em (`makeTonplaygramCardBackTexture` via `makeCardBackTexture` change in `webapp/src/pages/Games/MurlanRoyaleArena.jsx`).
- Increased camera turn constants (`CAMERA_PLAYER_TARGET_WEIGHT` and `CAMERA_SIDE_LOOK_EXTRA`) so turn camera looks a bit further to the side when switching players (`webapp/src/pages/Games/MurlanRoyaleArena.jsx`).

### Testing
- Ran targeted unit tests with `npm test -- --runInBand test/murlan.test.js test/texasHoldemHdriPreload.test.js test/inventoryCrossGameConfig.test.js` and all test suites passed.
- Test summary: `test/inventoryCrossGameConfig.test.js` ✅, `test/murlan.test.js` ✅, `test/texasHoldemHdriPreload.test.js` ✅.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce7471afc48329a50b10c2a031673b)