### PR TITLE
Narrow Murlan octagon table and preserve GLTF chair/table textures

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1256,6 +1256,34 @@ function extractChairMaterials(model) {
   };
 }
 
+const SHARED_GLTF_TEXTURE_PROPS = Object.freeze([
+  'map',
+  'normalMap',
+  'roughnessMap',
+  'metalnessMap',
+  'aoMap',
+  'alphaMap',
+  'emissiveMap',
+  'bumpMap',
+  'displacementMap',
+  'clearcoatMap',
+  'clearcoatRoughnessMap',
+  'clearcoatNormalMap',
+  'specularMap',
+  'sheenColorMap',
+  'sheenRoughnessMap'
+]);
+
+function disposeOwnedMaterialTextures(material) {
+  if (!material) return;
+  SHARED_GLTF_TEXTURE_PROPS.forEach((prop) => {
+    const texture = material[prop];
+    if (texture?.isTexture && texture.userData?.murlanCanDispose === true) {
+      texture.dispose?.();
+    }
+  });
+}
+
 function disposeObjectResources(object) {
   const materials = new Set();
   object.traverse((obj) => {
@@ -1266,8 +1294,7 @@ function disposeObjectResources(object) {
     }
   });
   materials.forEach((mat) => {
-    if (mat?.map) mat.map.dispose?.();
-    if (mat?.emissiveMap) mat.emissiveMap.dispose?.();
+    disposeOwnedMaterialTextures(mat);
     mat?.dispose?.();
   });
 }
@@ -2184,7 +2211,7 @@ const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 0.85;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
 const TABLE_HEIGHT_LIFT = 0.05 * MODEL_SCALE;
 const TABLE_HEIGHT = STOOL_HEIGHT + TABLE_HEIGHT_LIFT;
-const TABLE_MODEL_TARGET_DIAMETER = TABLE_RADIUS * 2;
+const TABLE_MODEL_TARGET_DIAMETER = TABLE_RADIUS * 2 * 1.1;
 const TABLE_MODEL_TARGET_HEIGHT = TABLE_HEIGHT;
 const TABLE_HEIGHT_RAISE = TABLE_HEIGHT - BASE_TABLE_HEIGHT;
 const HUMAN_SELECTION_OFFSET = 0.14 * MODEL_SCALE;
@@ -3727,11 +3754,6 @@ export default function MurlanRoyaleArena({ search }) {
       if (tableBuildTokenRef.current !== token) {
         tableInfo.dispose?.();
         return null;
-      }
-
-      if ((theme?.id || 'murlan-default') === 'murlan-default' && tableInfo?.group) {
-        tableInfo.group.scale.set(1.15, 1, 1.15);
-        tableInfo.radius = (tableInfo.radius || TABLE_RADIUS) * 1.15;
       }
 
       three.tableInfo = tableInfo;

--- a/webapp/src/utils/murlanTable.js
+++ b/webapp/src/utils/murlanTable.js
@@ -308,7 +308,7 @@ export const TABLE_SHAPE_OPTIONS = Object.freeze([
     },
     thumbnail: swatchThumbnail(['#0f172a', '#1f2937', '#38bdf8']),
     createShapes: ({ radius }) => {
-      const octagonSideStretch = 1.16;
+      const octagonSideStretch = 1.1;
       const topShape = scaleShape2D(createRegularPolygonShape(8, radius), octagonSideStretch, 1);
       const feltShape = scaleShape2D(createRegularPolygonShape(8, radius * 0.8), octagonSideStretch, 1);
       const rimInnerShape = scaleShape2D(feltShape, 0.96, 0.96);


### PR DESCRIPTION
### Motivation
- Make the Murlan octagon table slightly less wide while keeping the same height to address visual feedback that the default table is too wide. 
- Ensure other table themes/imported tables fit to the same width/height baseline so all table types appear consistent in the arena. 
- Prevent GLTF chair/table textures from being blanked during rebuilds by avoiding disposal of shared GLTF textures unless explicitly owned. 

### Description
- Reduced the octagon horizontal stretch from `1.16` to `1.1` in `webapp/src/utils/murlanTable.js` to make the default octagon table visually narrower. 
- Unified table fitting by increasing `TABLE_MODEL_TARGET_DIAMETER` (`TABLE_RADIUS * 2 * 1.1`) in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` and removed the ad-hoc 1.15x post-scale for the procedural default table so imported and procedural tables share the same final footprint/height. 
- Added `SHARED_GLTF_TEXTURE_PROPS` and a helper `disposeOwnedMaterialTextures` and updated `disposeObjectResources` to only dispose textures marked with `texture.userData.murlanCanDispose === true`, preventing accidental disposal of shared GLTF texture maps used by chairs/tables. 
- Modified files: `webapp/src/utils/murlanTable.js` and `webapp/src/pages/Games/MurlanRoyaleArena.jsx`.

### Testing
- Ran `npx eslint webapp/src/pages/Games/MurlanRoyaleArena.jsx webapp/src/utils/murlanTable.js`, which reported files ignored by the repo eslint configuration in normal mode. 
- Ran `npx eslint --no-ignore webapp/src/pages/Games/MurlanRoyaleArena.jsx webapp/src/utils/murlanTable.js`, which surfaced many pre-existing style errors in the codebase that are unrelated to these functional changes. 
- Ran whitespace/format checks (repository diff/whitespace validations) which did not report new issues for these edits. 
- No unit or integration tests were added for this UI/asset change in this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce961c1fe483299272b74a83a388c0)