### PR TITLE
Adjust Murlan table footprint and preserve GLTF texture mapping

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -727,10 +727,27 @@ async function loadTexture(textureLoader, url, isColor, maxAnisotropy = 1) {
 function normalizePbrTexture(texture, maxAnisotropy = 1) {
   if (!texture) return;
   texture.flipY = false;
-  texture.wrapS = texture.wrapS ?? THREE.RepeatWrapping;
-  texture.wrapT = texture.wrapT ?? THREE.RepeatWrapping;
   texture.anisotropy = Math.max(texture.anisotropy ?? 1, maxAnisotropy);
+  texture.generateMipmaps = true;
+  texture.minFilter = THREE.LinearMipmapLinearFilter;
+  texture.magFilter = THREE.LinearFilter;
   texture.needsUpdate = true;
+}
+
+function normalizeMaterialTextures(material, maxAnisotropy = 1) {
+  if (!material) return;
+  if (material.map) {
+    applySRGBColorSpace(material.map);
+    normalizePbrTexture(material.map, maxAnisotropy);
+  }
+  if (material.emissiveMap) {
+    applySRGBColorSpace(material.emissiveMap);
+    normalizePbrTexture(material.emissiveMap, maxAnisotropy);
+  }
+  normalizePbrTexture(material.normalMap, maxAnisotropy);
+  normalizePbrTexture(material.roughnessMap, maxAnisotropy);
+  normalizePbrTexture(material.metalnessMap, maxAnisotropy);
+  normalizePbrTexture(material.aoMap, maxAnisotropy);
 }
 
 async function loadPolyhavenTextureSet(
@@ -826,7 +843,7 @@ function applyTextureSetToModel(model, textureSet, fallbackTexture, maxAnisotrop
   });
 }
 
-function prepareLoadedModel(model) {
+function prepareLoadedModel(model, { preserveGltfTextureMapping = false, maxAnisotropy = 8 } = {}) {
   model.traverse((obj) => {
     if (obj.isMesh) {
       obj.castShadow = true;
@@ -834,8 +851,10 @@ function prepareLoadedModel(model) {
       const mats = Array.isArray(obj.material) ? obj.material : [obj.material];
       mats.forEach((mat) => {
         if (!mat) return;
-        if (mat.map) applySRGBColorSpace(mat.map);
-        if (mat.emissiveMap) applySRGBColorSpace(mat.emissiveMap);
+        normalizeMaterialTextures(mat, maxAnisotropy);
+        if (preserveGltfTextureMapping) {
+          mat.needsUpdate = true;
+        }
       });
     }
   });
@@ -1433,7 +1452,10 @@ async function loadGltfChair(urls = CHAIR_MODEL_URLS, rotationY = 0, renderer = 
     throw new Error('Chair model missing scene');
   }
 
-  prepareLoadedModel(model);
+  prepareLoadedModel(model, {
+    preserveGltfTextureMapping: true,
+    maxAnisotropy: renderer?.capabilities?.getMaxAnisotropy?.() ?? 8
+  });
 
   fitChairModelToFootprint(model);
   if (rotationY) {
@@ -1982,7 +2004,10 @@ async function loadPolyhavenModel(assetId, renderer = null) {
     if (!root) {
       throw new Error(`Missing scene for ${assetId}`);
     }
-    prepareLoadedModel(root);
+    prepareLoadedModel(root, {
+      preserveGltfTextureMapping: true,
+      maxAnisotropy: renderer?.capabilities?.getMaxAnisotropy?.() ?? 8
+    });
     return root;
   })();
 
@@ -2187,6 +2212,7 @@ const TABLE_HEIGHT = STOOL_HEIGHT + TABLE_HEIGHT_LIFT;
 const TABLE_MODEL_TARGET_DIAMETER = TABLE_RADIUS * 2;
 const TABLE_MODEL_TARGET_HEIGHT = TABLE_HEIGHT;
 const TABLE_HEIGHT_RAISE = TABLE_HEIGHT - BASE_TABLE_HEIGHT;
+const TABLE_FOOTPRINT_SCALE = 1.08;
 const HUMAN_SELECTION_OFFSET = 0.14 * MODEL_SCALE;
 const AI_CARD_LIFT = 0.05 * MODEL_SCALE;
 const AI_CARD_OUTWARD = 0;
@@ -3729,9 +3755,9 @@ export default function MurlanRoyaleArena({ search }) {
         return null;
       }
 
-      if ((theme?.id || 'murlan-default') === 'murlan-default' && tableInfo?.group) {
-        tableInfo.group.scale.set(1.15, 1, 1.15);
-        tableInfo.radius = (tableInfo.radius || TABLE_RADIUS) * 1.15;
+      if (tableInfo?.group) {
+        tableInfo.group.scale.set(TABLE_FOOTPRINT_SCALE, 1, TABLE_FOOTPRINT_SCALE);
+        tableInfo.radius = (tableInfo.radius || TABLE_RADIUS) * TABLE_FOOTPRINT_SCALE;
       }
 
       three.tableInfo = tableInfo;

--- a/webapp/src/utils/murlanTable.js
+++ b/webapp/src/utils/murlanTable.js
@@ -162,10 +162,12 @@ async function applyPolyhavenClothTexture(parts, clothOption, renderer) {
   if (clothMat.userData?.polyhavenRequestId !== requestId) return;
 
   const repeat = Number.isFinite(clothOption.repeat) ? clothOption.repeat : 2.2;
+  const repeatRatio = Number.isFinite(clothOption.repeatRatio) ? clothOption.repeatRatio : 1;
+  const repeatY = repeat * repeatRatio;
   const applyRepeat = (tex) => {
     if (!tex) return;
     tex.wrapS = tex.wrapT = THREE.RepeatWrapping;
-    tex.repeat.set(repeat, repeat);
+    tex.repeat.set(repeat, repeatY);
     tex.needsUpdate = true;
   };
 
@@ -187,6 +189,11 @@ async function applyPolyhavenClothTexture(parts, clothOption, renderer) {
   } else if (clothMat.color) {
     clothMat.color.set('#ffffff');
   }
+  clothMat.userData = {
+    ...(clothMat.userData || {}),
+    repeat,
+    repeatRatio
+  };
   clothMat.needsUpdate = true;
 }
 
@@ -308,7 +315,7 @@ export const TABLE_SHAPE_OPTIONS = Object.freeze([
     },
     thumbnail: swatchThumbnail(['#0f172a', '#1f2937', '#38bdf8']),
     createShapes: ({ radius }) => {
-      const octagonSideStretch = 1.16;
+      const octagonSideStretch = 1.08;
       const topShape = scaleShape2D(createRegularPolygonShape(8, radius), octagonSideStretch, 1);
       const feltShape = scaleShape2D(createRegularPolygonShape(8, radius * 0.8), octagonSideStretch, 1);
       const rimInnerShape = scaleShape2D(feltShape, 0.96, 0.96);
@@ -323,8 +330,8 @@ export const TABLE_SHAPE_OPTIONS = Object.freeze([
     },
     thumbnail: swatchThumbnail(['#0b1220', '#111827', '#f97316']),
     createShapes: ({ radius }) => {
-      const width = radius * 2.1;
-      const height = radius * 1.45;
+      const width = radius * 2 * 1.08;
+      const height = radius * 2;
       const topShape = createOvalShape(width, height, 64);
       const feltShape = createOvalShape(width * 0.82, height * 0.82, 64);
       const rimInnerShape = scaleShape2D(feltShape, 0.97, 0.97);
@@ -339,14 +346,17 @@ export const TABLE_SHAPE_OPTIONS = Object.freeze([
     },
     thumbnail: swatchThumbnail(['#1f2937', '#0f172a', '#a855f7']),
     createShapes: ({ radius, scaleFactor }) => {
-      const factor = Number.isFinite(scaleFactor) && scaleFactor > 0 ? scaleFactor : radius / 0.9 || 1;
-      const outerHalf = 0.95 * factor;
-      const clothHalf = 0.7 * factor;
-      const innerHalf = 0.76 * factor;
-      const topShape = createRoundedRectangleShape(outerHalf * 2, outerHalf * 2, 0.12 * factor);
-      const feltShape = createRoundedRectangleShape(clothHalf * 2, clothHalf * 2, 0.08 * factor);
-      const rimInnerShape = createRoundedRectangleShape(innerHalf * 2, innerHalf * 2, 0.1 * factor);
-      return { topShape, feltShape, rimInnerShape, feltRadius: clothHalf };
+      const factor = Number.isFinite(scaleFactor) && scaleFactor > 0 ? scaleFactor : 1;
+      const width = radius * 2 * 1.08;
+      const height = radius * 2;
+      const feltWidth = width * 0.74;
+      const feltHeight = height * 0.74;
+      const innerWidth = width * 0.8;
+      const innerHeight = height * 0.8;
+      const topShape = createRoundedRectangleShape(width, height, 0.12 * factor);
+      const feltShape = createRoundedRectangleShape(feltWidth, feltHeight, 0.08 * factor);
+      const rimInnerShape = createRoundedRectangleShape(innerWidth, innerHeight, 0.1 * factor);
+      return { topShape, feltShape, rimInnerShape, feltRadius: Math.min(feltWidth, feltHeight) / 2 };
     }
   }
 ]);


### PR DESCRIPTION
### Motivation
- Make the Murlan octagon table slightly narrower while keeping its height and make other procedural table shapes share the same visible footprint so all tables match visually.
- Ensure GLTF-imported chair and table materials keep their original texture mapping and render with correct PBR texture settings (mipmaps, filters, anisotropy) so chair cloth and table cloth textures appear correctly and match other games (Domino, Pool Royale, Texas Hold’em).
- Allow cloth textures to express non-square UV tiling by honoring both a `repeat` and a `repeatRatio` so cloth mapping can match existing Pool/Texas behavior.

### Description
- Reduced octagon side stretch from `1.16` to `1.08` and unified oval/diamond procedural shapes to use the same XZ footprint baseline in `webapp/src/utils/murlanTable.js` (`TABLE_SHAPE_OPTIONS` changes).
- Added `repeatRatio` handling and applied separate X/Y repeat to cloth textures in `applyPolyhavenClothTexture` so cloth UV tiling uses `repeat` and `repeatRatio`, and store these values on `clothMat.userData`.
- Introduced `normalizePbrTexture` improvements and a new `normalizeMaterialTextures` helper to set mipmaps/filters/anisotropy and apply sRGB for color maps, and updated `prepareLoadedModel` to normalize textures (with options) in `webapp/src/pages/Games/MurlanRoyaleArena.jsx`.
- When loading GLTF/polyhaven chair and table models, call `prepareLoadedModel(..., { preserveGltfTextureMapping: true, maxAnisotropy })` so GLTF original mapping is preserved while textures are normalized.
- Added `TABLE_FOOTPRINT_SCALE` and apply a shared XZ scale when placing table models so all table themes use the same visible footprint while preserving vertical profile.

### Testing
- Ran `npx eslint webapp/src/pages/Games/MurlanRoyaleArena.jsx webapp/src/utils/murlanTable.js`, which returned repo ignore warnings but no lint errors relevant to the changes.
- Built the webapp with `npm --prefix webapp run build`, which completed successfully (Vite production build finished).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce961c1fe483299272b74a83a388c0)