### PR TITLE
Improve texture disposal, table/chair layout, and HDRI/mobile policies

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1256,6 +1256,34 @@ function extractChairMaterials(model) {
   };
 }
 
+const SHARED_GLTF_TEXTURE_PROPS = Object.freeze([
+  'map',
+  'normalMap',
+  'roughnessMap',
+  'metalnessMap',
+  'aoMap',
+  'alphaMap',
+  'emissiveMap',
+  'bumpMap',
+  'displacementMap',
+  'clearcoatMap',
+  'clearcoatRoughnessMap',
+  'clearcoatNormalMap',
+  'specularMap',
+  'sheenColorMap',
+  'sheenRoughnessMap'
+]);
+
+function disposeOwnedMaterialTextures(material) {
+  if (!material) return;
+  SHARED_GLTF_TEXTURE_PROPS.forEach((prop) => {
+    const texture = material[prop];
+    if (texture?.isTexture && texture.userData?.murlanCanDispose === true) {
+      texture.dispose?.();
+    }
+  });
+}
+
 function disposeObjectResources(object) {
   const materials = new Set();
   object.traverse((obj) => {
@@ -1266,8 +1294,7 @@ function disposeObjectResources(object) {
     }
   });
   materials.forEach((mat) => {
-    if (mat?.map) mat.map.dispose?.();
-    if (mat?.emissiveMap) mat.emissiveMap.dispose?.();
+    disposeOwnedMaterialTextures(mat);
     mat?.dispose?.();
   });
 }
@@ -2184,7 +2211,7 @@ const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 0.85;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
 const TABLE_HEIGHT_LIFT = 0.05 * MODEL_SCALE;
 const TABLE_HEIGHT = STOOL_HEIGHT + TABLE_HEIGHT_LIFT;
-const TABLE_MODEL_TARGET_DIAMETER = TABLE_RADIUS * 2;
+const TABLE_MODEL_TARGET_DIAMETER = TABLE_RADIUS * 2 * 1.1;
 const TABLE_MODEL_TARGET_HEIGHT = TABLE_HEIGHT;
 const TABLE_HEIGHT_RAISE = TABLE_HEIGHT - BASE_TABLE_HEIGHT;
 const HUMAN_SELECTION_OFFSET = 0.14 * MODEL_SCALE;
@@ -2424,8 +2451,8 @@ const HDRI_RESOLUTION_POLICY_BY_FPS = Object.freeze([
     minFps: 120,
     preferredResolutions: Object.freeze(['8k', '4k', '2k']),
     fallbackResolution: '4k',
-    mobilePreferredResolutions: Object.freeze(['4k', '2k']),
-    mobileFallbackResolution: '2k'
+    mobilePreferredResolutions: Object.freeze(['4k']),
+    mobileFallbackResolution: '4k'
   },
   { minFps: 90, preferredResolutions: Object.freeze(['4k', '2k']), fallbackResolution: '2k' },
   { minFps: 0, preferredResolutions: Object.freeze(['2k', '1k']), fallbackResolution: '1k' }
@@ -3729,11 +3756,6 @@ export default function MurlanRoyaleArena({ search }) {
         return null;
       }
 
-      if ((theme?.id || 'murlan-default') === 'murlan-default' && tableInfo?.group) {
-        tableInfo.group.scale.set(1.15, 1, 1.15);
-        tableInfo.radius = (tableInfo.radius || TABLE_RADIUS) * 1.15;
-      }
-
       three.tableInfo = tableInfo;
       three.tableThemeId = theme?.id || 'murlan-default';
       three.tableClothId = cloth?.id ?? null;
@@ -4612,12 +4634,15 @@ export default function MurlanRoyaleArena({ search }) {
         chair.userData.chairModel = chairModel;
         threeStateRef.current.chairInstances.push(chair);
 
+        const chairBounds = new THREE.Box3().setFromObject(chair);
+        const groundedChairBaseHeight = -chairBounds.min.y;
+
         const angle = CUSTOM_SEAT_ANGLES[i] ?? Math.PI / 2 - (i / CHAIR_COUNT) * Math.PI * 2;
         const isHumanSeat = Boolean(player?.isHuman);
         const seatRadius = (isHumanSeat ? chairRadius : AI_CHAIR_RADIUS) * CHAIR_SEAT_INWARD_FACTOR;
         const x = Math.cos(angle) * seatRadius;
         const z = Math.sin(angle) * seatRadius;
-        const chairBaseHeight = CHAIR_BASE_HEIGHT;
+        const chairBaseHeight = groundedChairBaseHeight;
         chair.position.set(x, chairBaseHeight, z);
         chair.lookAt(new THREE.Vector3(0, chairBaseHeight, 0));
         arenaGroup.add(chair);
@@ -4629,8 +4654,8 @@ export default function MurlanRoyaleArena({ search }) {
           .multiplyScalar(seatRadius - (isHumanSeat ? 1.05 * MODEL_SCALE : 0.65 * MODEL_SCALE));
         focus.y = TABLE_HEIGHT + CARD_H * (isHumanSeat ? 0.72 : 0.55);
         const stoolPosition = forward.clone().multiplyScalar(seatRadius);
-        stoolPosition.y = CHAIR_BASE_HEIGHT + SEAT_THICKNESS / 2;
-        const stoolHeight = STOOL_HEIGHT;
+        stoolPosition.y = chairBaseHeight + SEAT_THICKNESS / 2;
+        const stoolHeight = STOOL_HEIGHT + (chairBaseHeight - CHAIR_BASE_HEIGHT);
         seatConfigs.push({
           seatIndex: i,
           chair,
@@ -4678,8 +4703,9 @@ export default function MurlanRoyaleArena({ search }) {
       spot.target.updateMatrixWorld();
 
       const isPortrait = mount.clientHeight > mount.clientWidth;
+      const hdriScaleFov = isPortrait ? camConfig.fov * 0.9 : camConfig.fov * 0.94;
       camera = new THREE.PerspectiveCamera(
-        camConfig.fov,
+        hdriScaleFov,
         mount.clientWidth / mount.clientHeight,
         camConfig.near,
         camConfig.far

--- a/webapp/src/utils/murlanTable.js
+++ b/webapp/src/utils/murlanTable.js
@@ -308,7 +308,7 @@ export const TABLE_SHAPE_OPTIONS = Object.freeze([
     },
     thumbnail: swatchThumbnail(['#0f172a', '#1f2937', '#38bdf8']),
     createShapes: ({ radius }) => {
-      const octagonSideStretch = 1.16;
+      const octagonSideStretch = 1.06;
       const topShape = scaleShape2D(createRegularPolygonShape(8, radius), octagonSideStretch, 1);
       const feltShape = scaleShape2D(createRegularPolygonShape(8, radius * 0.8), octagonSideStretch, 1);
       const rimInnerShape = scaleShape2D(feltShape, 0.96, 0.96);
@@ -391,6 +391,7 @@ export function makeRoughClothTexture(size, topHex, bottomHex, anisotropy = 8) {
   ctx.fillRect(0, 0, size, size);
 
   const texture = new THREE.CanvasTexture(canvas);
+  texture.userData = { ...(texture.userData || {}), murlanCanDispose: true };
   texture.wrapS = texture.wrapT = THREE.RepeatWrapping;
   const baseRepeat = 12;
   const scaledRepeat = baseRepeat * 30 * 6 * 4;
@@ -447,6 +448,35 @@ function applyWoodSelectionToMaterials(topMat, rimMat, option) {
       sharedKey
     });
   }
+}
+
+
+const TABLE_TEXTURE_PROPS = Object.freeze([
+  'map',
+  'normalMap',
+  'roughnessMap',
+  'metalnessMap',
+  'aoMap',
+  'alphaMap',
+  'emissiveMap',
+  'bumpMap',
+  'displacementMap',
+  'clearcoatMap',
+  'clearcoatRoughnessMap',
+  'clearcoatNormalMap',
+  'specularMap',
+  'sheenColorMap',
+  'sheenRoughnessMap'
+]);
+
+function disposeOwnedTableTextures(material) {
+  if (!material) return;
+  TABLE_TEXTURE_PROPS.forEach((prop) => {
+    const texture = material[prop];
+    if (texture?.isTexture && texture.userData?.murlanCanDispose === true) {
+      texture.dispose?.();
+    }
+  });
 }
 
 export function applyTableMaterials(parts, { woodOption, clothOption, baseOption }, renderer) {
@@ -728,7 +758,7 @@ export function createMurlanStyleTable({
     disposeMaterialWithWood(tableParts.rimWoodMat);
     tableParts.baseMat?.dispose?.();
     tableParts.trimMat?.dispose?.();
-    tableParts.surfaceMat?.map?.dispose?.();
+    disposeOwnedTableTextures(tableParts.surfaceMat);
     tableParts.surfaceMat?.dispose?.();
     if (tableGroup.parent) {
       tableGroup.parent.remove(tableGroup);


### PR DESCRIPTION
### Motivation
- Prevent GPU texture leaks by only disposing textures that the code owns and marking generated textures as disposable.
- Make procedural table sizing and chair placement more robust by grounding chair models and adjusting table target diameter and octagon shape stretch.
- Tweak HDRI resolution policy for mobile and slightly adjust camera FOV when rendering portrait/landscape.

### Description
- Added `SHARED_GLTF_TEXTURE_PROPS` and `disposeOwnedMaterialTextures` and replaced direct `map`/`emissiveMap` disposals in `disposeObjectResources` to only dispose textures with `userData.murlanCanDispose === true`.
- Marked the generated cloth texture in `makeRoughClothTexture` with `texture.userData.murlanCanDispose = true` so it can be safely disposed by the above helper.
- Added `TABLE_TEXTURE_PROPS` and `disposeOwnedTableTextures` and used it when disposing table `surfaceMat` textures to avoid disposing shared textures.
- Increased `TABLE_MODEL_TARGET_DIAMETER` by 10% and removed the special-case scaling that enlarged the procedural default table group.
- Reduced the octagon side stretch from `1.16` to `1.06` in the classic octagon table shape to refine the table silhouette.
- Grounded chair placement by computing `groundedChairBaseHeight` from the cloned chair bounds and using it for `chairBaseHeight`, `stoolPosition.y`, and `stoolHeight` so varied chair models sit correctly on the floor.
- Adjusted camera FOV selection with `hdriScaleFov` (portrait/landscape multipliers) to better fit HDRI framing.
- Tightened the mobile HDRI policy in `HDRI_RESOLUTION_POLICY_BY_FPS` to prefer and fall back to `4k` for the highest-FPS bucket.

### Testing
- Ran the project build with `yarn build` and it completed successfully.
- Executed the test suite with `yarn test` and all automated tests passed.
- Performed a lightweight smoke test of the arena scene in development to verify table/chair layout, texture creation/disposal, and camera framing, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce961c1fe483299272b74a83a388c0)