### PR TITLE
Improve GLTF texture handling, disposal, and model sizing adjustments

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -826,7 +826,24 @@ function applyTextureSetToModel(model, textureSet, fallbackTexture, maxAnisotrop
   });
 }
 
-function prepareLoadedModel(model) {
+function normalizeMaterialTextures(material, maxAnisotropy = 1) {
+  if (!material) return;
+  if (material.map) {
+    applySRGBColorSpace(material.map);
+    normalizePbrTexture(material.map, maxAnisotropy);
+  }
+  if (material.emissiveMap) {
+    applySRGBColorSpace(material.emissiveMap);
+    normalizePbrTexture(material.emissiveMap, maxAnisotropy);
+  }
+  normalizePbrTexture(material.normalMap, maxAnisotropy);
+  normalizePbrTexture(material.roughnessMap, maxAnisotropy);
+  normalizePbrTexture(material.metalnessMap, maxAnisotropy);
+  normalizePbrTexture(material.aoMap, maxAnisotropy);
+}
+
+function prepareLoadedModel(model, options = {}) {
+  const { preserveGltfTextureMapping = false, maxAnisotropy = 8 } = options;
   model.traverse((obj) => {
     if (obj.isMesh) {
       obj.castShadow = true;
@@ -834,8 +851,13 @@ function prepareLoadedModel(model) {
       const mats = Array.isArray(obj.material) ? obj.material : [obj.material];
       mats.forEach((mat) => {
         if (!mat) return;
-        if (mat.map) applySRGBColorSpace(mat.map);
-        if (mat.emissiveMap) applySRGBColorSpace(mat.emissiveMap);
+        if (preserveGltfTextureMapping) {
+          normalizeMaterialTextures(mat, maxAnisotropy);
+        } else {
+          if (mat.map) applySRGBColorSpace(mat.map);
+          if (mat.emissiveMap) applySRGBColorSpace(mat.emissiveMap);
+        }
+        mat.needsUpdate = true;
       });
     }
   });
@@ -1256,6 +1278,34 @@ function extractChairMaterials(model) {
   };
 }
 
+const SHARED_GLTF_TEXTURE_PROPS = Object.freeze([
+  'map',
+  'normalMap',
+  'roughnessMap',
+  'metalnessMap',
+  'aoMap',
+  'alphaMap',
+  'emissiveMap',
+  'bumpMap',
+  'displacementMap',
+  'clearcoatMap',
+  'clearcoatRoughnessMap',
+  'clearcoatNormalMap',
+  'specularMap',
+  'sheenColorMap',
+  'sheenRoughnessMap'
+]);
+
+function disposeOwnedMaterialTextures(material) {
+  if (!material) return;
+  SHARED_GLTF_TEXTURE_PROPS.forEach((prop) => {
+    const texture = material[prop];
+    if (texture?.isTexture && texture.userData?.murlanCanDispose === true) {
+      texture.dispose?.();
+    }
+  });
+}
+
 function disposeObjectResources(object) {
   const materials = new Set();
   object.traverse((obj) => {
@@ -1266,8 +1316,7 @@ function disposeObjectResources(object) {
     }
   });
   materials.forEach((mat) => {
-    if (mat?.map) mat.map.dispose?.();
-    if (mat?.emissiveMap) mat.emissiveMap.dispose?.();
+    disposeOwnedMaterialTextures(mat);
     mat?.dispose?.();
   });
 }
@@ -1335,11 +1384,12 @@ async function createPolyhavenInstance(
   targetHeight,
   rotationY = 0,
   renderer = null,
-  textureOptions = {}
+  textureOptions = {},
+  preserveGltfTextureMapping = true
 ) {
   const root = await loadPolyhavenModel(assetId, renderer);
   const model = root.clone(true);
-  prepareLoadedModel(model);
+  prepareLoadedModel(model, { preserveGltfTextureMapping });
   const {
     textureLoader = null,
     maxAnisotropy = 1,
@@ -1348,7 +1398,7 @@ async function createPolyhavenInstance(
     textureSet = null,
     preferredTextureSizes = PREFERRED_TEXTURE_SIZES
   } = textureOptions || {};
-  if (textureLoader) {
+  if (textureLoader && !preserveGltfTextureMapping) {
     try {
       const textures =
         textureSet ??
@@ -2070,7 +2120,7 @@ async function buildChairTemplate(theme, renderer = null, textureOptions = {}) {
     if (theme?.source === 'polyhaven' && theme?.assetId) {
       const polyhavenRoot = await loadPolyhavenModel(theme.assetId, renderer);
       const model = polyhavenRoot.clone(true);
-      prepareLoadedModel(model);
+      prepareLoadedModel(model, { preserveGltfTextureMapping: preserveMaterials, maxAnisotropy });
       if (textureLoader) {
         try {
           const textures = await loadPolyhavenTextureSet(
@@ -2099,12 +2149,14 @@ async function buildChairTemplate(theme, renderer = null, textureOptions = {}) {
     }
     if (theme?.source === 'gltf' && Array.isArray(theme.urls) && theme.urls.length) {
       const gltfChair = await loadGltfChair(theme.urls, rotationY, renderer);
+      prepareLoadedModel(gltfChair.chairTemplate, { preserveGltfTextureMapping: preserveMaterials, maxAnisotropy });
       if (!preserveMaterials) {
         applyChairThemeMaterials({ chairMaterials: gltfChair.materials }, theme);
       }
       return { ...gltfChair, preserveOriginal: preserveMaterials };
     }
     const gltfChair = await loadGltfChair(CHAIR_MODEL_URLS, rotationY, renderer);
+    prepareLoadedModel(gltfChair.chairTemplate, { preserveGltfTextureMapping: preserveMaterials, maxAnisotropy });
     if (!preserveMaterials) {
       applyChairThemeMaterials({ chairMaterials: gltfChair.materials }, theme);
     }
@@ -2184,7 +2236,7 @@ const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 0.85;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
 const TABLE_HEIGHT_LIFT = 0.05 * MODEL_SCALE;
 const TABLE_HEIGHT = STOOL_HEIGHT + TABLE_HEIGHT_LIFT;
-const TABLE_MODEL_TARGET_DIAMETER = TABLE_RADIUS * 2;
+const TABLE_MODEL_TARGET_DIAMETER = TABLE_RADIUS * 2 * 1.06;
 const TABLE_MODEL_TARGET_HEIGHT = TABLE_HEIGHT;
 const TABLE_HEIGHT_RAISE = TABLE_HEIGHT - BASE_TABLE_HEIGHT;
 const HUMAN_SELECTION_OFFSET = 0.14 * MODEL_SCALE;
@@ -3729,11 +3781,6 @@ export default function MurlanRoyaleArena({ search }) {
         return null;
       }
 
-      if ((theme?.id || 'murlan-default') === 'murlan-default' && tableInfo?.group) {
-        tableInfo.group.scale.set(1.15, 1, 1.15);
-        tableInfo.radius = (tableInfo.radius || TABLE_RADIUS) * 1.15;
-      }
-
       three.tableInfo = tableInfo;
       three.tableThemeId = theme?.id || 'murlan-default';
       three.tableClothId = cloth?.id ?? null;
@@ -4520,7 +4567,7 @@ export default function MurlanRoyaleArena({ search }) {
       const environmentVariant = resolveHdriVariant(currentAppearance.environmentHdri);
       hdriVariantRef.current = environmentVariant;
 
-      const arenaScale = 1.3 * ARENA_GROWTH;
+      const arenaScale = 1.18 * ARENA_GROWTH;
       const boardSize = (TABLE_RADIUS * 2 + 1.2 * MODEL_SCALE) * arenaScale;
       const camConfig = buildArenaCameraConfig(boardSize);
       const interiorWidth = Math.max(TABLE_RADIUS * ARENA_GROWTH * 3.4, CHAIR_RADIUS * 2 + 4 * MODEL_SCALE);
@@ -4617,7 +4664,7 @@ export default function MurlanRoyaleArena({ search }) {
         const seatRadius = (isHumanSeat ? chairRadius : AI_CHAIR_RADIUS) * CHAIR_SEAT_INWARD_FACTOR;
         const x = Math.cos(angle) * seatRadius;
         const z = Math.sin(angle) * seatRadius;
-        const chairBaseHeight = CHAIR_BASE_HEIGHT;
+        const chairBaseHeight = CHAIR_BASE_HEIGHT - 0.04 * MODEL_SCALE;
         chair.position.set(x, chairBaseHeight, z);
         chair.lookAt(new THREE.Vector3(0, chairBaseHeight, 0));
         arenaGroup.add(chair);

--- a/webapp/src/utils/murlanTable.js
+++ b/webapp/src/utils/murlanTable.js
@@ -308,7 +308,7 @@ export const TABLE_SHAPE_OPTIONS = Object.freeze([
     },
     thumbnail: swatchThumbnail(['#0f172a', '#1f2937', '#38bdf8']),
     createShapes: ({ radius }) => {
-      const octagonSideStretch = 1.16;
+      const octagonSideStretch = 1.06;
       const topShape = scaleShape2D(createRegularPolygonShape(8, radius), octagonSideStretch, 1);
       const feltShape = scaleShape2D(createRegularPolygonShape(8, radius * 0.8), octagonSideStretch, 1);
       const rimInnerShape = scaleShape2D(feltShape, 0.96, 0.96);


### PR DESCRIPTION
### Motivation

- Ensure GLTF materials keep correct color space and texture parameter normalization while preserving original GLTF texture mappings when requested.
- Avoid disposing shared textures accidentally by only disposing textures explicitly owned by this codepath.
- Tune model/table/chair sizing and arena scale to better match visual targets.

### Description

- Add `normalizeMaterialTextures` and extend `prepareLoadedModel` with `preserveGltfTextureMapping` and `maxAnisotropy` options to centralize sRGB application and PBR texture normalization, and set `mat.needsUpdate` after processing materials. 
- Stop forcing external Polyhaven texture application when preserving GLTF texture mapping by threading `preserveGltfTextureMapping` through `createPolyhavenInstance` and `buildChairTemplate`. 
- Introduce `SHARED_GLTF_TEXTURE_PROPS` and `disposeOwnedMaterialTextures` and use it in `disposeObjectResources` so only textures with `userData.murlanCanDispose === true` are disposed. 
- Adjust several layout/size constants and placements: reduce `arenaScale`, tweak `CHAIR_BASE_HEIGHT`, increase `TABLE_MODEL_TARGET_DIAMETER` by 6%, and reduce octagon side stretch for table shapes.

### Testing

- Ran the project's test suite via `yarn test` and the tests completed successfully. 
- Ran linting with `yarn lint` and a production build with `yarn build`, both completing without errors. 
- Manual smoke-tested model loading and chair/table generation in the local dev environment to verify texture preservation and sizing adjustments.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce961c1fe483299272b74a83a388c0)