### PR TITLE
Adjust Murlan octagon table footprint and preserve GLTF chair/cloth materials

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -1480,7 +1480,7 @@ const dimIntensity = (value = 1) => value * LIGHT_INTENSITY_FACTOR;
 const MODEL_SCALE = 0.75;
 const TABLE_SCALE = 0.95;
 const ARENA_GROWTH = 1.45;
-const TABLE_RADIUS = 3.4 * MODEL_SCALE * TABLE_SCALE;
+const TABLE_RADIUS = 3.25 * MODEL_SCALE * TABLE_SCALE;
 const BASE_TABLE_HEIGHT = 1.08 * MODEL_SCALE * TABLE_SCALE;
 const STOOL_SCALE = 1.5 * 1.38;
 const SEAT_WIDTH = 0.9 * MODEL_SCALE * STOOL_SCALE;
@@ -3012,6 +3012,10 @@ function cloneChairWithTheme(chairData, option) {
       if (!mat) return mat;
       if (preserveMaterials) return mat;
       const next = mat.clone();
+      next.userData = {
+        ...(next.userData || {}),
+        dominoCanDispose: true
+      };
       if (upholsterySet.has(mat)) {
         if (next.color)
           next.color.set(option?.seatColor ?? DEFAULT_CHAIR_THEME.seatColor);
@@ -5948,7 +5952,9 @@ function disposeObjectResources(object, { disposeTextures = true } = {}) {
       if (disposeTextures && mat.map && mat.map.dispose) {
         mat.map.dispose();
       }
-      mat.dispose?.();
+      if (disposeTextures || mat.userData?.dominoCanDispose === true) {
+        mat.dispose?.();
+      }
     });
   });
 }
@@ -5957,8 +5963,8 @@ function fitTableModelToFootprint(model) {
   if (!model) return;
   const box = new THREE.Box3().setFromObject(model);
   const size = box.getSize(new THREE.Vector3());
-  const targetDiameter = TABLE_RADIUS * 2.1;
-  const targetHeight = TABLE_HEIGHT * 1.05;
+  const targetDiameter = TABLE_RADIUS * 2;
+  const targetHeight = TABLE_HEIGHT;
   const maxSide = Math.max(size.x, size.z, 0.0001);
   const heightScale = targetHeight / Math.max(size.y, 0.0001);
   const scale = Math.min(targetDiameter / maxSide, heightScale);
@@ -7555,6 +7561,7 @@ function disposeChairResources(root) {
       : [child.material];
     materials.forEach((material) => {
       if (!material) return;
+      if (material.userData?.dominoCanDispose !== true) return;
       CHAIR_TEXTURE_PROPS.forEach((prop) => {
         const texture = material[prop];
         // GLTF material clones share underlying texture instances.


### PR DESCRIPTION
### Motivation
- Make the shared Murlan octagon table appear slightly narrower on mobile while keeping its height unchanged for consistent portrait framing. 
- Ensure all non-procedural table themes (GLTF models) use the same visible footprint as the octagon baseline so table sizes look consistent across Murlan, Domino, Pool Royal and Texas Hold'em variants. 
- Fix missing/blank GLTF textures seen on chairs and table cloth during theme swaps by preserving original GLTF material mappings and avoiding accidental disposal. 
- Scope material disposal only to cloned override materials so Domino-style chair mappings remain identical to the Domino Battle Royal implementation.

### Description
- Reduced the procedural octagon baseline by changing `TABLE_RADIUS` from `3.4 * MODEL_SCALE * TABLE_SCALE` to `3.25 * MODEL_SCALE * TABLE_SCALE` in `webapp/public/domino-royal-game.js` to make the table visually narrower. 
- Normalized external table theme fitting by updating `fitTableModelToFootprint` to use `targetDiameter = TABLE_RADIUS * 2` and `targetHeight = TABLE_HEIGHT` so GLTF themes are sized to the octagon envelope. 
- Prevented disposal of preserved GLTF materials during object teardown by changing `disposeObjectResources` to only call `mat.dispose()` when `disposeTextures` is true or the material is explicitly marked disposable. 
- Marked cloned chair override materials with `userData.dominoCanDispose = true` inside `cloneChairWithTheme`, and changed `disposeChairResources` to only dispose textures/materials that carry that `dominoCanDispose` flag so original GLTF textures remain intact.

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` and it completed without syntax errors. 
- No unit tests were modified for this change and no additional automated tests were run in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce961c1fe483299272b74a83a388c0)