### PR TITLE
Align Murlan Royale assets & inventory with Domino Battle Royale

### DIFF
--- a/test/inventoryCrossGameConfig.test.js
+++ b/test/inventoryCrossGameConfig.test.js
@@ -5,23 +5,20 @@ import {
 } from '../webapp/src/config/chessBattleInventoryConfig.js';
 import {
   DOMINO_ROYAL_DEFAULT_UNLOCKS,
-  DOMINO_ROYAL_OPTION_SETS
+  DOMINO_ROYAL_OPTION_SETS,
+  DOMINO_ROYAL_STORE_ITEMS
 } from '../webapp/src/config/dominoRoyalInventoryConfig.js';
 import {
   LUDO_BATTLE_STORE_ITEMS
 } from '../webapp/src/config/ludoBattleInventoryConfig.js';
 import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from '../webapp/src/config/murlanThemes.js';
-import { DOMINO_ROYAL_STORE_ITEMS } from '../webapp/src/config/dominoRoyalInventoryConfig.js';
 import {
   MURLAN_ROYALE_DEFAULT_UNLOCKS,
   MURLAN_ROYALE_STORE_ITEMS
 } from '../webapp/src/config/murlanInventoryConfig.js';
 import {
-  TEXAS_HOLDEM_DEFAULT_UNLOCKS,
-  TEXAS_HOLDEM_STORE_ITEMS,
   TEXAS_TABLE_FINISH_OPTIONS
 } from '../webapp/src/config/texasHoldemInventoryConfig.js';
-import { TABLE_CLOTH_OPTIONS } from '../webapp/src/utils/tableCustomizationOptions.js';
 import { CARD_THEMES } from '../webapp/src/utils/cards3d.js';
 import {
   TAVULL_BATTLE_DEFAULT_UNLOCKS,
@@ -86,29 +83,40 @@ describe('cross-game inventory alignment', () => {
     expect(TAVULL_BATTLE_DEFAULT_UNLOCKS.tables[0]).toBe(CHESS_BATTLE_DEFAULT_UNLOCKS.tables[0]);
   });
 
-  test('murlan shares texas hold’em inventories for poker arena assets', () => {
+  test('murlan matches domino inventory for tables, chairs, cloth, and hdri', () => {
     const toOptionSet = (items, type) =>
       new Set(items.filter((item) => item.type === type).map((item) => item.optionId));
 
     expect(toOptionSet(MURLAN_ROYALE_STORE_ITEMS, 'tables')).toEqual(
-      toOptionSet(TEXAS_HOLDEM_STORE_ITEMS, 'tableTheme')
+      new Set(DOMINO_ROYAL_OPTION_SETS.tableTheme.map((option) => option.id))
     );
     expect(toOptionSet(MURLAN_ROYALE_STORE_ITEMS, 'stools')).toEqual(
-      toOptionSet(TEXAS_HOLDEM_STORE_ITEMS, 'chairTheme')
+      new Set(DOMINO_ROYAL_OPTION_SETS.chairTheme.map((option) => option.id))
+    );
+    expect(toOptionSet(MURLAN_ROYALE_STORE_ITEMS, 'tableCloth')).toEqual(
+      new Set(DOMINO_ROYAL_OPTION_SETS.tableCloth.map((option) => option.id))
+    );
+    expect(toOptionSet(MURLAN_ROYALE_STORE_ITEMS, 'environmentHdri')).toEqual(
+      new Set(DOMINO_ROYAL_OPTION_SETS.environmentHdri.map((option) => option.id))
+    );
+    expect(new Set(MURLAN_ROYALE_DEFAULT_UNLOCKS.tables)).toEqual(
+      new Set(DOMINO_ROYAL_OPTION_SETS.tableTheme.map((option) => option.id))
+    );
+    expect(new Set(MURLAN_ROYALE_DEFAULT_UNLOCKS.stools)).toEqual(
+      new Set(DOMINO_ROYAL_OPTION_SETS.chairTheme.map((option) => option.id))
+    );
+    expect(new Set(MURLAN_ROYALE_DEFAULT_UNLOCKS.tableCloth)).toEqual(
+      new Set(DOMINO_ROYAL_OPTION_SETS.tableCloth.map((option) => option.id))
+    );
+    expect(new Set(MURLAN_ROYALE_DEFAULT_UNLOCKS.environmentHdri)).toEqual(
+      new Set(DOMINO_ROYAL_OPTION_SETS.environmentHdri.map((option) => option.id))
     );
     expect(toOptionSet(MURLAN_ROYALE_STORE_ITEMS, 'tableFinish')).toEqual(
       new Set(TEXAS_TABLE_FINISH_OPTIONS.map((option) => option.id))
     );
-    expect(toOptionSet(MURLAN_ROYALE_STORE_ITEMS, 'tableCloth')).toEqual(
-      new Set(TABLE_CLOTH_OPTIONS.map((option) => option.id))
+    expect(new Set(MURLAN_ROYALE_DEFAULT_UNLOCKS.tableFinish)).toEqual(
+      new Set([TEXAS_TABLE_FINISH_OPTIONS[0]?.id])
     );
-    expect(toOptionSet(MURLAN_ROYALE_STORE_ITEMS, 'cards')).toEqual(
-      toOptionSet(TEXAS_HOLDEM_STORE_ITEMS, 'cards')
-    );
-    expect(MURLAN_ROYALE_DEFAULT_UNLOCKS.tables[0]).toBe(TEXAS_HOLDEM_DEFAULT_UNLOCKS.tableTheme[0]);
-    expect(MURLAN_ROYALE_DEFAULT_UNLOCKS.stools[0]).toBe(TEXAS_HOLDEM_DEFAULT_UNLOCKS.chairTheme[0]);
-    expect(MURLAN_ROYALE_DEFAULT_UNLOCKS.tableFinish[0]).toBe(TEXAS_HOLDEM_DEFAULT_UNLOCKS.tableFinish[0]);
-    expect(MURLAN_ROYALE_DEFAULT_UNLOCKS.tableCloth[0]).toBe(TEXAS_HOLDEM_DEFAULT_UNLOCKS.tableCloth[0]);
     expect(MURLAN_ROYALE_DEFAULT_UNLOCKS.cards[0]).toBe(CARD_THEMES[0]?.id);
   });
 

--- a/webapp/src/config/murlanInventoryConfig.js
+++ b/webapp/src/config/murlanInventoryConfig.js
@@ -1,14 +1,17 @@
-import { POOL_ROYALE_DEFAULT_HDRI_ID, POOL_ROYALE_HDRI_VARIANTS } from './poolRoyaleInventoryConfig.js';
+import { POOL_ROYALE_DEFAULT_HDRI_ID } from './poolRoyaleInventoryConfig.js';
 import { CARD_THEMES } from '../utils/cards3d.js';
 import {
   TEXAS_HOLDEM_OPTION_LABELS,
   TEXAS_TABLE_FINISH_OPTIONS
 } from './texasHoldemInventoryConfig.js';
-import {
-  TABLE_CLOTH_OPTIONS as TEXAS_TABLE_CLOTH_OPTIONS
-} from '../utils/tableCustomizationOptions.js';
 import { MURLAN_CHARACTER_THEMES } from './murlanCharacterThemes.js';
 import { MURLAN_OUTFIT_THEMES, MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from './murlanThemes.js';
+import {
+  BATTLE_ROYALE_SHARED_CHAIR_THEME_OPTIONS,
+  BATTLE_ROYALE_SHARED_HDRI_VARIANTS,
+  BATTLE_ROYALE_SHARED_TABLE_CLOTH_OPTIONS,
+  BATTLE_ROYALE_SHARED_TABLE_THEME_OPTIONS
+} from './battleRoyaleSharedInventory.js';
 
 const mapLabels = (options) =>
   Object.freeze(
@@ -21,24 +24,24 @@ const mapLabels = (options) =>
 export const MURLAN_ROYALE_DEFAULT_UNLOCKS = Object.freeze({
   outfit: [MURLAN_OUTFIT_THEMES[0].id],
   cards: [CARD_THEMES[0].id],
-  stools: [MURLAN_STOOL_THEMES[0].id],
-  tables: [MURLAN_TABLE_THEMES[0].id],
-  tableCloth: [TEXAS_TABLE_CLOTH_OPTIONS[0].id],
+  stools: BATTLE_ROYALE_SHARED_CHAIR_THEME_OPTIONS.map((theme) => theme.id),
+  tables: BATTLE_ROYALE_SHARED_TABLE_THEME_OPTIONS.map((theme) => theme.id),
+  tableCloth: BATTLE_ROYALE_SHARED_TABLE_CLOTH_OPTIONS.map((cloth) => cloth.id),
   tableFinish: [TEXAS_TABLE_FINISH_OPTIONS[0].id],
   characters: [MURLAN_CHARACTER_THEMES[0].id],
-  environmentHdri: POOL_ROYALE_HDRI_VARIANTS.map((variant) => variant.id)
+  environmentHdri: BATTLE_ROYALE_SHARED_HDRI_VARIANTS.map((variant) => variant.id)
 });
 
 export const MURLAN_ROYALE_OPTION_LABELS = Object.freeze({
   outfit: mapLabels(MURLAN_OUTFIT_THEMES),
   cards: mapLabels(CARD_THEMES),
-  stools: mapLabels(MURLAN_STOOL_THEMES),
-  tables: mapLabels(MURLAN_TABLE_THEMES),
-  tableCloth: mapLabels(TEXAS_TABLE_CLOTH_OPTIONS),
+  stools: mapLabels(BATTLE_ROYALE_SHARED_CHAIR_THEME_OPTIONS),
+  tables: mapLabels(BATTLE_ROYALE_SHARED_TABLE_THEME_OPTIONS),
+  tableCloth: mapLabels(BATTLE_ROYALE_SHARED_TABLE_CLOTH_OPTIONS),
   tableFinish: Object.freeze(TEXAS_HOLDEM_OPTION_LABELS.tableFinish),
   characters: mapLabels(MURLAN_CHARACTER_THEMES),
   environmentHdri: mapLabels(
-    POOL_ROYALE_HDRI_VARIANTS.map((variant) => ({
+    BATTLE_ROYALE_SHARED_HDRI_VARIANTS.map((variant) => ({
       id: variant.id,
       label: `${variant.name} HDRI`
     }))
@@ -67,7 +70,7 @@ export const MURLAN_ROYALE_STORE_ITEMS = [
     thumbnail: option.thumbnail
   }))
 ].concat(
-  TEXAS_TABLE_CLOTH_OPTIONS.map((cloth, idx) => ({
+  BATTLE_ROYALE_SHARED_TABLE_CLOTH_OPTIONS.map((cloth, idx) => ({
     id: `cloth-${cloth.id}`,
     type: 'tableCloth',
     optionId: cloth.id,
@@ -78,7 +81,7 @@ export const MURLAN_ROYALE_STORE_ITEMS = [
     thumbnail: cloth.thumbnail,
     previewShape: 'table'
   })),
-  MURLAN_TABLE_THEMES.filter((theme, idx) => idx > 0).map((theme, idx) => ({
+  BATTLE_ROYALE_SHARED_TABLE_THEME_OPTIONS.map((theme, idx) => ({
     id: `table-${theme.id}`,
     type: 'tables',
     optionId: theme.id,
@@ -87,7 +90,7 @@ export const MURLAN_ROYALE_STORE_ITEMS = [
     description: theme.description || `${theme.label} table with preserved Poly Haven materials.`,
     thumbnail: theme.thumbnail
   })),
-  MURLAN_STOOL_THEMES.filter((theme, idx) => idx > 0).map((theme, idx) => ({
+  BATTLE_ROYALE_SHARED_CHAIR_THEME_OPTIONS.map((theme, idx) => ({
     id: `stool-${theme.id}`,
     type: 'stools',
     optionId: theme.id,
@@ -105,7 +108,7 @@ export const MURLAN_ROYALE_STORE_ITEMS = [
     description: theme.description,
     thumbnail: theme.thumbnail
   })),
-  POOL_ROYALE_HDRI_VARIANTS.map((variant, idx) => ({
+  BATTLE_ROYALE_SHARED_HDRI_VARIANTS.map((variant, idx) => ({
     id: `hdri-${variant.id}`,
     type: 'environmentHdri',
     optionId: variant.id,
@@ -130,8 +133,8 @@ export const MURLAN_ROYALE_DEFAULT_LOADOUT = [
   },
   {
     type: 'tableCloth',
-    optionId: TEXAS_TABLE_CLOTH_OPTIONS[0].id,
-    label: TEXAS_TABLE_CLOTH_OPTIONS[0].label
+    optionId: BATTLE_ROYALE_SHARED_TABLE_CLOTH_OPTIONS[0].id,
+    label: BATTLE_ROYALE_SHARED_TABLE_CLOTH_OPTIONS[0].label
   },
   {
     type: 'tableFinish',

--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -99,12 +99,13 @@ const resolveTableCloth = (index) => {
 const DEFAULT_FRAME_RATE_ID = 'fhd60';
 
 const MODEL_SCALE = 0.75;
+const TABLE_SCALE = 0.95;
 const CHARACTER_PROPORTION_SCALE = 2.0;
 const ENABLE_3D_HUMAN_CHARACTERS = false;
 const ARENA_GROWTH = 1.45; // expanded arena footprint for wider walkways
 const CHAIR_SIZE_SCALE = 1;
 
-const TABLE_RADIUS = 3.4 * MODEL_SCALE;
+const TABLE_RADIUS = 3.4 * MODEL_SCALE * TABLE_SCALE;
 const CHAIR_COUNT = 4;
 const CUSTOM_SEAT_ANGLES = [
   THREE.MathUtils.degToRad(90),
@@ -320,6 +321,7 @@ const BASIS_TRANSCODER_PATH = 'https://cdn.jsdelivr.net/npm/three@0.164.0/exampl
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
 
 let sharedKtx2Loader = null;
+let hasDetectedKtx2Support = false;
 
 function stripQueryHash(u) {
   return u.split('#')[0].split('?')[0];
@@ -1425,6 +1427,16 @@ function shouldPreserveChairMaterials(theme) {
   return Boolean(theme?.preserveMaterials || theme?.source === 'polyhaven' || theme?.source === 'gltf');
 }
 
+function ensureMurlanKtx2SupportDetection(renderer = null) {
+  if (!sharedKtx2Loader || hasDetectedKtx2Support || !renderer) return;
+  try {
+    sharedKtx2Loader.detectSupport(renderer);
+    hasDetectedKtx2Support = true;
+  } catch (error) {
+    console.warn('Murlan KTX2 support detection failed', error);
+  }
+}
+
 function createConfiguredGLTFLoader(renderer = null, manager = undefined) {
   const loader = new GLTFLoader(manager);
   loader.setCrossOrigin?.('anonymous');
@@ -1439,13 +1451,7 @@ function createConfiguredGLTFLoader(renderer = null, manager = undefined) {
     sharedKtx2Loader.setTranscoderPath(BASIS_TRANSCODER_PATH);
   }
 
-  if (renderer) {
-    try {
-      sharedKtx2Loader.detectSupport(renderer);
-    } catch (error) {
-      console.warn('Murlan KTX2 support detection failed', error);
-    }
-  }
+  ensureMurlanKtx2SupportDetection(renderer);
 
   loader.setKTX2Loader(sharedKtx2Loader);
   return loader;
@@ -2157,7 +2163,7 @@ async function buildChairTemplate(theme, renderer = null, textureOptions = {}) {
   return createProceduralChair(theme);
 }
 
-const STOOL_SCALE = 1.5 * 1.3 * CHAIR_SIZE_SCALE;
+const STOOL_SCALE = 1.5 * 1.38 * CHAIR_SIZE_SCALE;
 const CARD_SCALE = 1;
 const CARD_W = 0.4 * MODEL_SCALE * CARD_SCALE;
 const CARD_H = 0.56 * MODEL_SCALE * CARD_SCALE;
@@ -2177,7 +2183,7 @@ const ARM_THICKNESS = 0.125 * MODEL_SCALE * STOOL_SCALE;
 const ARM_HEIGHT = 0.3 * MODEL_SCALE * STOOL_SCALE;
 const ARM_DEPTH = SEAT_DEPTH * 0.75;
 const BASE_COLUMN_HEIGHT = 0.5 * MODEL_SCALE * STOOL_SCALE;
-const BASE_TABLE_HEIGHT = 1.08 * MODEL_SCALE;
+const BASE_TABLE_HEIGHT = 1.08 * MODEL_SCALE * TABLE_SCALE;
 const BASE_HUMAN_CHAIR_RADIUS = 5.6 * MODEL_SCALE * ARENA_GROWTH * 0.85;
 const HUMAN_CHAIR_PULLBACK = 0.08 * MODEL_SCALE;
 const CHAIR_INWARD_OFFSET = 0.18 * MODEL_SCALE;
@@ -2224,7 +2230,7 @@ const TABLE_CARD_AREA_FORWARD_SHIFT = 0.72 * MODEL_SCALE;
 const DEAL_CARD_STEP_DELAY_MS = 60;
 const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 0.85;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
-const TABLE_HEIGHT_LIFT = 0.05 * MODEL_SCALE;
+const TABLE_HEIGHT_LIFT = 0.05 * MODEL_SCALE * TABLE_SCALE;
 const TABLE_HEIGHT = STOOL_HEIGHT + TABLE_HEIGHT_LIFT;
 const TABLE_MODEL_TARGET_DIAMETER = TABLE_RADIUS * 2 * 1.06;
 const TABLE_MODEL_TARGET_HEIGHT = TABLE_HEIGHT;


### PR DESCRIPTION
### Motivation
- Ensure Murlan Royale uses the same table/chair/cloth/HDRI asset sets and proportions as Domino Battle Royal so visuals and inventory are consistent across Battle Royale games.
- Prevent duplicated asset definitions and mismatched sizing/texture conversion behavior between arenas.

### Description
- Replaced Murlan-specific table, stool, table cloth and HDRI sources with the shared Battle Royale inventory by importing `BATTLE_ROYALE_SHARED_*` sets and wiring them into `MURLAN_ROYALE_*` exports in `webapp/src/config/murlanInventoryConfig.js` so store items and defaults match Domino.
- Updated Murlan arena sizing/scaling constants in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` (added `TABLE_SCALE`, adjusted `TABLE_RADIUS`, propagated `TABLE_SCALE` into `BASE_TABLE_HEIGHT`, `TABLE_HEIGHT_LIFT`, and `STOOL_SCALE` math) to match Domino proportions and footprint.
- Standardized GLTF loader/KTX2 handling in `MurlanRoyaleArena.jsx` by reusing a Domino-style one-time KTX2 support detection flow (`ensureMurlanKtx2SupportDetection`) and shared `KTX2Loader` setup for consistent texture/transcoder behavior.
- Updated `test/inventoryCrossGameConfig.test.js` to assert parity between Murlan and Domino inventories for tables, stools, table cloths and HDRIs and adjusted imports accordingly.

### Testing
- Ran the focused Jest suite `npm test -- test/inventoryCrossGameConfig.test.js --runInBand`, which passed (Test Suites: 1 passed, Tests: 6 passed). 
- Ran targeted linting with `npx eslint` during development; an initial targeted lint invocation showed ignored files/warnings due to repo ignore rules and earlier strict runs surfaced fixable issues which were addressed while iterating (final automated validation was the passing Jest test above).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf3e4f33a08329b58dda827be7be39)