### PR TITLE
Restore Pool Royale replay gating to prior behavior

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -27986,7 +27986,7 @@ const powerRef = useRef(hud.power);
           pottedBalls,
           shotContext
         }) => {
-          if (!recording || !hadObjectPot) return null;
+          if (!recording) return null;
           const tags = new Set(recording.replayTags ?? []);
           if (hadObjectPot) tags.add('pot');
           const potCount = pottedBalls.filter((entry) => entry.id !== 'cue').length;
@@ -27996,8 +27996,16 @@ const powerRef = useRef(hud.power);
           const priority = ['multi', 'bank', 'long', 'power', 'spin'];
           const primary = priority.find((tag) => tags.has(tag)) ?? 'default';
           const zoomOnly = recording.zoomOnly && !tags.has('long') && !tags.has('bank');
+          const hadMeaningfulContact = Boolean(shotContext?.contactMade);
+          const hasReplayFrames = (recording?.frames?.length ?? 0) > 1;
+          const hasReplaySignal =
+            hasReplayFrames ||
+            hadObjectPot ||
+            tags.size > 0 ||
+            hadMeaningfulContact ||
+            Boolean(recording?.replayFoul);
           return {
-            shouldReplay: hadObjectPot || tags.size > 0,
+            shouldReplay: hasReplaySignal,
             banner: selectReplayBanner(primary),
             zoomOnly,
             tags: Array.from(tags),


### PR DESCRIPTION
### Motivation
- Replays were being skipped too aggressively because the replay decision required an object-ball pot; the goal is to restore the replay trigger behavior from the previous baseline so valid non-pot replay signals still start playback.

### Description
- Relaxed `resolveReplayDecision` so it no longer returns `null` solely because `hadObjectPot` is false by changing `if (!recording || !hadObjectPot) return null;` to `if (!recording) return null;`.
- Reintroduced the multi-signal replay detection used previously by adding `hadMeaningfulContact`, `hasReplayFrames` and computing `hasReplaySignal` from frames, pots, tags, meaningful contact, or recorded foul, and set `shouldReplay` to that aggregated signal.
- Scoped changes to `webapp/src/pages/Games/PoolRoyale.jsx` only; no other subsystems were modified.

### Testing
- Ran the targeted Jest suite: `npm run -s test -- test/poolRoyaleTrainingProgress.test.js`, and all tests passed (`1` suite, `7` tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf3ee4c844832985b0bc876775065a)