### PR TITLE
Align Murlan Royale inventory, defaults and chair sizing with Domino Battle Royale

### DIFF
--- a/webapp/src/config/murlanInventoryConfig.js
+++ b/webapp/src/config/murlanInventoryConfig.js
@@ -1,14 +1,13 @@
-import { POOL_ROYALE_DEFAULT_HDRI_ID, POOL_ROYALE_HDRI_VARIANTS } from './poolRoyaleInventoryConfig.js';
 import { CARD_THEMES } from '../utils/cards3d.js';
-import {
-  TEXAS_HOLDEM_OPTION_LABELS,
-  TEXAS_TABLE_FINISH_OPTIONS
-} from './texasHoldemInventoryConfig.js';
-import {
-  TABLE_CLOTH_OPTIONS as TEXAS_TABLE_CLOTH_OPTIONS
-} from '../utils/tableCustomizationOptions.js';
 import { MURLAN_CHARACTER_THEMES } from './murlanCharacterThemes.js';
-import { MURLAN_OUTFIT_THEMES, MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from './murlanThemes.js';
+import { MURLAN_OUTFIT_THEMES } from './murlanThemes.js';
+import {
+  BATTLE_ROYALE_SHARED_CHAIR_THEME_OPTIONS as MURLAN_STOOL_THEMES,
+  BATTLE_ROYALE_SHARED_HDRI_VARIANTS as MURLAN_HDRI_OPTIONS,
+  BATTLE_ROYALE_SHARED_TABLE_CLOTH_OPTIONS as MURLAN_TABLE_CLOTH_OPTIONS,
+  BATTLE_ROYALE_SHARED_TABLE_FINISH_OPTIONS as MURLAN_TABLE_FINISH_OPTIONS,
+  BATTLE_ROYALE_SHARED_TABLE_THEME_OPTIONS as MURLAN_TABLE_THEMES
+} from './battleRoyaleSharedInventory.js';
 
 const mapLabels = (options) =>
   Object.freeze(
@@ -18,15 +17,23 @@ const mapLabels = (options) =>
     }, {})
   );
 
+const DEFAULT_MURLAN_SHARED_IDS = Object.freeze({
+  stool: 'dining_chair_02',
+  table: 'murlan-default',
+  tableCloth: 'emerald',
+  tableFinish: 'peelingPaintWeathered',
+  environmentHdri: 'neon_photostudio'
+});
+
 export const MURLAN_ROYALE_DEFAULT_UNLOCKS = Object.freeze({
   outfit: [MURLAN_OUTFIT_THEMES[0].id],
   cards: [CARD_THEMES[0].id],
-  stools: [MURLAN_STOOL_THEMES[0].id],
-  tables: [MURLAN_TABLE_THEMES[0].id],
-  tableCloth: [TEXAS_TABLE_CLOTH_OPTIONS[0].id],
-  tableFinish: [TEXAS_TABLE_FINISH_OPTIONS[0].id],
+  stools: [DEFAULT_MURLAN_SHARED_IDS.stool],
+  tables: [DEFAULT_MURLAN_SHARED_IDS.table],
+  tableCloth: [DEFAULT_MURLAN_SHARED_IDS.tableCloth],
+  tableFinish: [DEFAULT_MURLAN_SHARED_IDS.tableFinish],
   characters: [MURLAN_CHARACTER_THEMES[0].id],
-  environmentHdri: POOL_ROYALE_HDRI_VARIANTS.map((variant) => variant.id)
+  environmentHdri: MURLAN_HDRI_OPTIONS.map((variant) => variant.id)
 });
 
 export const MURLAN_ROYALE_OPTION_LABELS = Object.freeze({
@@ -34,11 +41,11 @@ export const MURLAN_ROYALE_OPTION_LABELS = Object.freeze({
   cards: mapLabels(CARD_THEMES),
   stools: mapLabels(MURLAN_STOOL_THEMES),
   tables: mapLabels(MURLAN_TABLE_THEMES),
-  tableCloth: mapLabels(TEXAS_TABLE_CLOTH_OPTIONS),
-  tableFinish: Object.freeze(TEXAS_HOLDEM_OPTION_LABELS.tableFinish),
+  tableCloth: mapLabels(MURLAN_TABLE_CLOTH_OPTIONS),
+  tableFinish: mapLabels(MURLAN_TABLE_FINISH_OPTIONS),
   characters: mapLabels(MURLAN_CHARACTER_THEMES),
   environmentHdri: mapLabels(
-    POOL_ROYALE_HDRI_VARIANTS.map((variant) => ({
+    MURLAN_HDRI_OPTIONS.map((variant) => ({
       id: variant.id,
       label: `${variant.name} HDRI`
     }))
@@ -46,7 +53,7 @@ export const MURLAN_ROYALE_OPTION_LABELS = Object.freeze({
 });
 
 export const MURLAN_ROYALE_STORE_ITEMS = [
-  ...TEXAS_TABLE_FINISH_OPTIONS.map((finish, idx) => ({
+  ...MURLAN_TABLE_FINISH_OPTIONS.map((finish, idx) => ({
     id: `table-finish-${finish.id}`,
     type: 'tableFinish',
     optionId: finish.id,
@@ -67,7 +74,7 @@ export const MURLAN_ROYALE_STORE_ITEMS = [
     thumbnail: option.thumbnail
   }))
 ].concat(
-  TEXAS_TABLE_CLOTH_OPTIONS.map((cloth, idx) => ({
+  MURLAN_TABLE_CLOTH_OPTIONS.map((cloth, idx) => ({
     id: `cloth-${cloth.id}`,
     type: 'tableCloth',
     optionId: cloth.id,
@@ -105,7 +112,7 @@ export const MURLAN_ROYALE_STORE_ITEMS = [
     description: theme.description,
     thumbnail: theme.thumbnail
   })),
-  POOL_ROYALE_HDRI_VARIANTS.map((variant, idx) => ({
+  MURLAN_HDRI_OPTIONS.map((variant, idx) => ({
     id: `hdri-${variant.id}`,
     type: 'environmentHdri',
     optionId: variant.id,
@@ -121,8 +128,16 @@ export const MURLAN_ROYALE_STORE_ITEMS = [
 export const MURLAN_ROYALE_DEFAULT_LOADOUT = [
   { type: 'outfit', optionId: MURLAN_OUTFIT_THEMES[0].id, label: MURLAN_OUTFIT_THEMES[0].label },
   { type: 'cards', optionId: CARD_THEMES[0].id, label: CARD_THEMES[0].label },
-  { type: 'tables', optionId: MURLAN_TABLE_THEMES[0].id, label: MURLAN_TABLE_THEMES[0].label },
-  { type: 'stools', optionId: MURLAN_STOOL_THEMES[0].id, label: MURLAN_STOOL_THEMES[0].label },
+  {
+    type: 'tables',
+    optionId: MURLAN_TABLE_THEMES.find((option) => option.id === DEFAULT_MURLAN_SHARED_IDS.table)?.id || MURLAN_TABLE_THEMES[0].id,
+    label: (MURLAN_TABLE_THEMES.find((option) => option.id === DEFAULT_MURLAN_SHARED_IDS.table) || MURLAN_TABLE_THEMES[0]).label
+  },
+  {
+    type: 'stools',
+    optionId: MURLAN_STOOL_THEMES.find((option) => option.id === DEFAULT_MURLAN_SHARED_IDS.stool)?.id || MURLAN_STOOL_THEMES[0].id,
+    label: (MURLAN_STOOL_THEMES.find((option) => option.id === DEFAULT_MURLAN_SHARED_IDS.stool) || MURLAN_STOOL_THEMES[0]).label
+  },
   {
     type: 'characters',
     optionId: MURLAN_CHARACTER_THEMES[0].id,
@@ -130,18 +145,18 @@ export const MURLAN_ROYALE_DEFAULT_LOADOUT = [
   },
   {
     type: 'tableCloth',
-    optionId: TEXAS_TABLE_CLOTH_OPTIONS[0].id,
-    label: TEXAS_TABLE_CLOTH_OPTIONS[0].label
+    optionId: MURLAN_TABLE_CLOTH_OPTIONS.find((option) => option.id === DEFAULT_MURLAN_SHARED_IDS.tableCloth)?.id || MURLAN_TABLE_CLOTH_OPTIONS[0].id,
+    label: (MURLAN_TABLE_CLOTH_OPTIONS.find((option) => option.id === DEFAULT_MURLAN_SHARED_IDS.tableCloth) || MURLAN_TABLE_CLOTH_OPTIONS[0]).label
   },
   {
     type: 'tableFinish',
-    optionId: TEXAS_TABLE_FINISH_OPTIONS[0].id,
-    label: TEXAS_TABLE_FINISH_OPTIONS[0].label
+    optionId: MURLAN_TABLE_FINISH_OPTIONS.find((option) => option.id === DEFAULT_MURLAN_SHARED_IDS.tableFinish)?.id || MURLAN_TABLE_FINISH_OPTIONS[0].id,
+    label: (MURLAN_TABLE_FINISH_OPTIONS.find((option) => option.id === DEFAULT_MURLAN_SHARED_IDS.tableFinish) || MURLAN_TABLE_FINISH_OPTIONS[0]).label
   },
   {
     type: 'environmentHdri',
-    optionId: POOL_ROYALE_DEFAULT_HDRI_ID,
+    optionId: DEFAULT_MURLAN_SHARED_IDS.environmentHdri,
     label:
-      MURLAN_ROYALE_OPTION_LABELS.environmentHdri[POOL_ROYALE_DEFAULT_HDRI_ID] || 'HDR Environment'
+      MURLAN_ROYALE_OPTION_LABELS.environmentHdri[DEFAULT_MURLAN_SHARED_IDS.environmentHdri] || 'HDR Environment'
   }
 ];

--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -39,16 +39,14 @@ import BottomLeftIcons from '../../components/BottomLeftIcons.jsx';
 import InfoPopup from '../../components/InfoPopup.jsx';
 import QuickMessagePopup from '../../components/QuickMessagePopup.jsx';
 import GiftPopup from '../../components/GiftPopup.jsx';
-import { POOL_ROYALE_DEFAULT_HDRI_ID, POOL_ROYALE_HDRI_VARIANTS } from '../../config/poolRoyaleInventoryConfig.js';
+import { MURLAN_OUTFIT_THEMES as OUTFIT_THEMES } from '../../config/murlanThemes.js';
 import {
-  MURLAN_OUTFIT_THEMES as OUTFIT_THEMES,
-  MURLAN_STOOL_THEMES as STOOL_THEMES,
-  MURLAN_TABLE_THEMES as TABLE_THEMES
-} from '../../config/murlanThemes.js';
-import {
-  TEXAS_TABLE_FINISH_OPTIONS as MURLAN_TABLE_FINISHES
-} from '../../config/texasHoldemInventoryConfig.js';
-import { TABLE_CLOTH_OPTIONS as MURLAN_TABLE_CLOTHS } from '../../utils/tableCustomizationOptions.js';
+  BATTLE_ROYALE_SHARED_CHAIR_THEME_OPTIONS as STOOL_THEMES,
+  BATTLE_ROYALE_SHARED_HDRI_VARIANTS as MURLAN_HDRI_OPTIONS,
+  BATTLE_ROYALE_SHARED_TABLE_CLOTH_OPTIONS as MURLAN_TABLE_CLOTHS,
+  BATTLE_ROYALE_SHARED_TABLE_FINISH_OPTIONS as MURLAN_TABLE_FINISHES,
+  BATTLE_ROYALE_SHARED_TABLE_THEME_OPTIONS as TABLE_THEMES
+} from '../../config/battleRoyaleSharedInventory.js';
 import { MURLAN_CHARACTER_THEMES } from '../../config/murlanCharacterThemes.js';
 import { giftSounds } from '../../utils/giftSounds.js';
 import { getAvatarUrl } from '../../utils/avatarUtils.js';
@@ -68,13 +66,10 @@ import {
 
 const DEFAULT_HDRI_RESOLUTIONS = Object.freeze(['2k']);
 const HDRI_RESOLUTION_LADDER = Object.freeze(['8k', '4k', '2k', '1k']);
-const MURLAN_HDRI_OPTIONS = POOL_ROYALE_HDRI_VARIANTS.map((variant) => ({
-  ...variant,
-  label: `${variant.name} HDRI`
-}));
+const DEFAULT_HDRI_ID = 'neon_photostudio';
 const DEFAULT_HDRI_INDEX = Math.max(
   0,
-  MURLAN_HDRI_OPTIONS.findIndex((variant) => variant.id === POOL_ROYALE_DEFAULT_HDRI_ID)
+  MURLAN_HDRI_OPTIONS.findIndex((variant) => variant.id === DEFAULT_HDRI_ID)
 );
 const DEFAULT_HDRI_VARIANT = MURLAN_HDRI_OPTIONS[DEFAULT_HDRI_INDEX] ?? MURLAN_HDRI_OPTIONS[0] ?? null;
 const resolveHdriVariant = (index) => {
@@ -83,8 +78,12 @@ const resolveHdriVariant = (index) => {
   return MURLAN_HDRI_OPTIONS[idx] ?? MURLAN_HDRI_OPTIONS[DEFAULT_HDRI_INDEX] ?? MURLAN_HDRI_OPTIONS[0];
 };
 
-const DEFAULT_TABLE_FINISH_INDEX = 0;
-const DEFAULT_TABLE_CLOTH_INDEX = 0;
+const DEFAULT_TABLE_FINISH_ID = 'peelingPaintWeathered';
+const DEFAULT_TABLE_CLOTH_ID = 'emerald';
+const DEFAULT_STOOL_ID = 'dining_chair_02';
+const DEFAULT_TABLE_FINISH_INDEX = Math.max(0, MURLAN_TABLE_FINISHES.findIndex((option) => option.id === DEFAULT_TABLE_FINISH_ID));
+const DEFAULT_TABLE_CLOTH_INDEX = Math.max(0, MURLAN_TABLE_CLOTHS.findIndex((option) => option.id === DEFAULT_TABLE_CLOTH_ID));
+const DEFAULT_STOOL_INDEX = Math.max(0, STOOL_THEMES.findIndex((option) => option.id === DEFAULT_STOOL_ID));
 const resolveTableFinish = (index) => {
   const max = MURLAN_TABLE_FINISHES.length - 1;
   const idx = Number.isFinite(index) ? Math.min(Math.max(Math.round(index), 0), max) : DEFAULT_TABLE_FINISH_INDEX;
@@ -852,16 +851,21 @@ function prepareLoadedModel(model, options = {}) {
     }
   });
 }
-const TARGET_CHAIR_SIZE = new THREE.Vector3(1.3162499970197679, 1.9173749900311232, 1.7001562547683715).multiplyScalar(
-  CHAIR_SIZE_SCALE
+const TARGET_CHAIR_SIZE = new THREE.Vector3(
+  0.9 * MODEL_SCALE * 1.5 * 1.3 * CHAIR_SIZE_SCALE,
+  Math.max(
+    0.68 * MODEL_SCALE * 1.5 * 1.3 * CHAIR_SIZE_SCALE * 1.2,
+    0.9 * MODEL_SCALE * 1.5 * 1.3 * CHAIR_SIZE_SCALE
+  ),
+  0.95 * MODEL_SCALE * 1.5 * 1.3 * CHAIR_SIZE_SCALE
 );
-const TARGET_CHAIR_MIN_Y = -0.8570624993294478 * CHAIR_SIZE_SCALE;
-const TARGET_CHAIR_CENTER_Z = -0.1553906416893005 * CHAIR_SIZE_SCALE;
+const TARGET_CHAIR_MIN_Y = 0;
+const TARGET_CHAIR_CENTER_Z = 0;
 
 const DEFAULT_APPEARANCE = {
   outfit: 0,
   cards: 0,
-  stools: 0,
+  stools: DEFAULT_STOOL_INDEX,
   characters: 0,
   tables: 0,
   tableCloth: DEFAULT_TABLE_CLOTH_INDEX,


### PR DESCRIPTION
### Motivation
- Ensure Murlan Royale uses the same shared Battle Royale asset catalogs (chairs, table themes, cloth, finishes, HDRI variants) as Domino Battle Royale so items, unlocks and runtime selection are consistent across games. 
- Use the same GLTF texture-preserve / fitting logic and chair footprint targets so imported chair/table models display and scale identically to the Domino/Tavull code paths. 
- Provide deterministic default IDs/loadout that match the Domino baseline so new matches show the expected shared visuals out-of-the-box. 

### Description
- Replaced Murlan-specific table/chair/HDri sources with the shared inventory by importing `battleRoyaleSharedInventory.js` and mapping those sets into Murlan option lists in `webapp/src/config/murlanInventoryConfig.js`. 
- Introduced `DEFAULT_MURLAN_SHARED_IDS` and used it to align default unlocks and default loadout (stool/table/tableCloth/tableFinish/environmentHdri) to shared IDs (`dining_chair_02`, `murlan-default`, `emerald`, `peelingPaintWeathered`, `neon_photostudio`) in `webapp/src/config/murlanInventoryConfig.js`. 
- Updated Murlan arena to read the shared Battle Royale sources by changing imports in `webapp/src/pages/Games/MurlanRoyaleArena.jsx`, wired `DEFAULT_*_ID` values to compute default indices, and set the default stool appearance index to the shared chair baseline. 
- Aligned chair fitting targets by replacing the previous hardcoded `TARGET_CHAIR_SIZE` constants with footprint-based calculations (derived from seat/back/seat-depth values) and reset `TARGET_CHAIR_MIN_Y`/`TARGET_CHAIR_CENTER_Z` to zero so GLTF chair models fit the same footprint used by Domino/Tavull loaders in `webapp/src/pages/Games/MurlanRoyaleArena.jsx`. 

### Testing
- Ran the full web build with `npm --prefix webapp run build`, which completed successfully with no compilation errors. 
- Build produced existing Vite warnings about chunk size / dynamic import overlap but no new warnings indicating runtime failures from the changes. 
- No automated unit tests were added or run as part of this change beyond the production build validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf3e4f33a08329b58dda827be7be39)