### PR TITLE
Update HDRI selection rules for 60/90/120Hz on mobile and desktop

### DIFF
--- a/Assets/Scripts/Gameplay/Rendering/HdriQualityGuard.cs
+++ b/Assets/Scripts/Gameplay/Rendering/HdriQualityGuard.cs
@@ -3,15 +3,24 @@ using UnityEngine;
 namespace Aiming.Gameplay.Rendering
 {
     /// <summary>
-    /// Locks HDRI loading to high quality when 120hz is enabled so 8k environments
-    /// keep loading consistently.
+    /// Applies HDRI resolution profiles based on the selected refresh rate and device type.
     /// </summary>
     public class HdriQualityGuard : MonoBehaviour
     {
         [SerializeField] private bool lockLegacyHdriProfile = true;
-        [SerializeField] private int highRefreshRate = 120;
-        [SerializeField] private int hdriResolution = 8192;
-        [SerializeField] private Cubemap activeHdri;
+        [SerializeField] private int refreshRate60Hz = 60;
+        [SerializeField] private int refreshRate90Hz = 90;
+        [SerializeField] private int refreshRate120Hz = 120;
+
+        [Header("Desktop HDRI Maps")]
+        [SerializeField] private Cubemap desktopHdri2K;
+        [SerializeField] private Cubemap desktopHdri4K;
+        [SerializeField] private Cubemap desktopHdri8K;
+
+        [Header("Mobile HDRI Maps")]
+        [SerializeField] private Cubemap mobileHdri2K;
+        [SerializeField] private Cubemap mobileHdri4K;
+
         [SerializeField] private Material[] skyboxTargets;
 
         public void ApplyHdriProfile(int targetRefreshRate)
@@ -21,14 +30,9 @@ namespace Aiming.Gameplay.Rendering
                 return;
             }
 
-            bool shouldForce8k = targetRefreshRate >= highRefreshRate;
-            QualitySettings.globalTextureMipmapLimit = shouldForce8k ? 0 : 1;
-            QualitySettings.masterTextureLimit = shouldForce8k ? 0 : 1;
-
-            if (activeHdri == null || !shouldForce8k)
-            {
-                return;
-            }
+            bool isMobileDevice = SystemInfo.deviceType == DeviceType.Handheld;
+            HdriProfile profile = ResolveProfile(targetRefreshRate, isMobileDevice);
+            ApplyTextureQuality(profile.primaryResolution, profile.fallbackResolution);
 
             for (int i = 0; i < skyboxTargets.Length; i++)
             {
@@ -38,8 +42,74 @@ namespace Aiming.Gameplay.Rendering
                     continue;
                 }
 
-                target.SetTexture("_Tex", activeHdri);
-                target.SetInt("_HdriResolution", hdriResolution);
+                Cubemap selectedHdri = profile.primaryHdri != null ? profile.primaryHdri : profile.fallbackHdri;
+                if (selectedHdri != null)
+                {
+                    target.SetTexture("_Tex", selectedHdri);
+                }
+
+                target.SetInt("_HdriResolution", profile.primaryResolution);
+                target.SetInt("_HdriFallbackResolution", profile.fallbackResolution);
+            }
+        }
+
+        private HdriProfile ResolveProfile(int targetRefreshRate, bool isMobileDevice)
+        {
+            if (targetRefreshRate >= refreshRate120Hz)
+            {
+                if (isMobileDevice)
+                {
+                    return new HdriProfile(mobileHdri4K, mobileHdri2K, 4096, 2048);
+                }
+
+                return new HdriProfile(desktopHdri8K, desktopHdri4K, 8192, 4096);
+            }
+
+            if (targetRefreshRate >= refreshRate90Hz)
+            {
+                Cubemap primaryHdri = isMobileDevice ? mobileHdri4K : desktopHdri4K;
+                Cubemap fallbackHdri = isMobileDevice ? mobileHdri2K : desktopHdri2K;
+                return new HdriProfile(primaryHdri, fallbackHdri, 4096, 2048);
+            }
+
+            Cubemap lowRefreshPrimary = isMobileDevice ? mobileHdri2K : desktopHdri2K;
+            return new HdriProfile(lowRefreshPrimary, null, 2048, 1024);
+        }
+
+        private static void ApplyTextureQuality(int primaryResolution, int fallbackResolution)
+        {
+            int maxResolution = Mathf.Max(primaryResolution, fallbackResolution);
+            if (maxResolution >= 8192)
+            {
+                QualitySettings.globalTextureMipmapLimit = 0;
+                QualitySettings.masterTextureLimit = 0;
+                return;
+            }
+
+            if (maxResolution >= 4096)
+            {
+                QualitySettings.globalTextureMipmapLimit = 1;
+                QualitySettings.masterTextureLimit = 1;
+                return;
+            }
+
+            QualitySettings.globalTextureMipmapLimit = 2;
+            QualitySettings.masterTextureLimit = 2;
+        }
+
+        private readonly struct HdriProfile
+        {
+            public readonly Cubemap primaryHdri;
+            public readonly Cubemap fallbackHdri;
+            public readonly int primaryResolution;
+            public readonly int fallbackResolution;
+
+            public HdriProfile(Cubemap primaryHdri, Cubemap fallbackHdri, int primaryResolution, int fallbackResolution)
+            {
+                this.primaryHdri = primaryHdri;
+                this.fallbackHdri = fallbackHdri;
+                this.primaryResolution = primaryResolution;
+                this.fallbackResolution = fallbackResolution;
             }
         }
     }


### PR DESCRIPTION
### Motivation
- Implement explicit HDRI selection rules so graphics options map refresh-rate tiers to the requested primary/fallback HDRI resolutions for mobile and desktop.
- Ensure the game uses appropriate texture quality settings when high-resolution HDRIs (4K/8K) are selected so environments load consistently.

### Description
- Rewrote `Assets/Scripts/Gameplay/Rendering/HdriQualityGuard.cs` to add serialized desktop/mobile Cubemap slots and refresh-rate fields so assets can be assigned in the Unity Inspector.
- Added `ResolveProfile(...)` to map refresh rates to profiles exactly as requested: 60Hz -> 2K with 1K fallback, 90Hz -> 4K with 2K fallback, 120Hz mobile -> 4K/2K, 120Hz desktop -> 8K/4K.
- Replaced the legacy single-HDRI logic with profile application that sets the skybox texture to primary (or fallback) and writes `_HdriResolution` and `_HdriFallbackResolution` to the material.
- Added `ApplyTextureQuality(...)` to adjust `QualitySettings.globalTextureMipmapLimit` and `QualitySettings.masterTextureLimit` based on selected profile resolutions, and introduced a small `HdriProfile` struct to carry profile data.

### Testing
- Attempted to run unit tests with `dotnet test billiards.Tests/Billiards.Tests.csproj`, but the command failed in this environment due to missing .NET SDK (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce74a5706c8329901b907a091d9429)