### PR TITLE
Pool Royale: strict replay frames, cloth texture fallbacks, and ball/cloth tuning

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1485,7 +1485,7 @@ const CLOTH_REFLECTION_LIMITS = Object.freeze({
 const CLOTH_REFLECTIONS_DISABLED = true;
 const POCKET_HOLE_R =
   POCKET_VIS_R * POCKET_CUT_EXPANSION * POCKET_VISUAL_EXPANSION; // cloth cutout radius now matches the interior pocket rim
-const BALL_CENTER_LIFT = BALL_R * 0.035; // lift balls slightly higher so they visually ride on top of the cloth surface
+const BALL_CENTER_LIFT = BALL_R * 0.05; // lift balls a touch more so they sit clearly above the cloth surface on portrait screens
 const BALL_CENTER_Y =
   CLOTH_TOP_LOCAL + CLOTH_LIFT + BALL_R - CLOTH_DROP + BALL_CENTER_LIFT; // rest balls directly on the lowered cloth plane
 const BALL_SHADOW_Y = BALL_CENTER_Y - BALL_R + BALL_SHADOW_LIFT + MICRO_EPS;
@@ -3321,7 +3321,7 @@ const FRAME_RATE_OPTIONS = Object.freeze([
     renderScale: 1,
     pixelRatioCap: 1.4,
     resolution: '2K texture pack • 60 FPS',
-    description: 'Balanced battery profile using Poly Haven 2K assets.'
+    description: 'Balanced battery profile using Poly Haven 2K textures with 1K fallback.'
   },
   {
     id: 'qhd90',
@@ -3330,7 +3330,7 @@ const FRAME_RATE_OPTIONS = Object.freeze([
     renderScale: 1.12,
     pixelRatioCap: 1.55,
     resolution: '4K texture pack • 90 FPS',
-    description: 'Sharper Poly Haven 4K assets at a 90 FPS target.'
+    description: 'Sharper Poly Haven 4K textures with 2K fallback at a 90 FPS target.'
   },
   {
     id: 'uhd120',
@@ -3364,11 +3364,20 @@ const resolveGraphicsUiScaleFactor = (fps) => {
   if (safeFps >= 90) return 1.04;
   return 1;
 };
+const resolvePolyHavenFallbackResolutions = (fps) => {
+  const safeFps = Number.isFinite(fps) ? fps : 60;
+  if (safeFps >= 120) {
+    return isLikelyMobileDevice() ? ['4k', '2k'] : ['8k', '4k'];
+  }
+  if (safeFps >= 90) return ['4k', '2k'];
+  return ['2k', '1k'];
+};
 let runtimeTextureProfile = Object.freeze({
   textureSize: resolveGraphicsResolutionTier(90).textureSize,
   anisotropy: CLOTH_QUALITY.anisotropy,
   generateMipmaps: CLOTH_QUALITY.generateMipmaps,
   polyHavenResolution: '4k',
+  polyHavenFallbackResolutions: ['4k', '2k'],
   hdriResolution: '4k',
   enforceTableFinishTextureSize: 4096,
   cueTextureSize: 4096,
@@ -3387,6 +3396,7 @@ const updateRuntimeTextureProfile = ({ fps } = {}) => {
     anisotropy,
     generateMipmaps: CLOTH_QUALITY.generateMipmaps,
     polyHavenResolution: tier.key,
+    polyHavenFallbackResolutions: resolvePolyHavenFallbackResolutions(fps),
     hdriResolution: tier.key,
     enforceTableFinishTextureSize: textureSize,
     cueTextureSize: textureSize,
@@ -3718,6 +3728,14 @@ const upgradePolyHavenTextureUrlTo4k = (url) => {
   if (!url.includes('/2k/') && !url.includes('_2k')) return url;
   return url.replace('/2k/', '/4k/').replace(/_2k(\.\w+)$/, '_4k$1');
 };
+const remapPolyHavenTextureUrlResolution = (url, targetResolution) => {
+  if (typeof url !== 'string' || !url.length) return url;
+  const target = String(targetResolution || '').toLowerCase();
+  if (!target) return url;
+  return url
+    .replace(/\/(1k|2k|4k|8k)\//i, `/${target}/`)
+    .replace(/_(1k|2k|4k|8k)(\.\w+)$/i, `_${target}$2`);
+};
 
 const createClothTextures = (() => {
   const cache = new Map();
@@ -4042,45 +4060,35 @@ const createClothTextures = (() => {
           urls = {};
         }
 
-        const fallback4k = buildPolyHavenTextureUrls(preset.sourceId, '4k');
-        const fallback2k = buildPolyHavenTextureUrls(preset.sourceId, '2k');
-        const fallback1k = buildPolyHavenTextureUrls(preset.sourceId, '1k');
-        const legacy4k = buildPolyHavenLegacyTextureUrls(preset.sourceId, '4k');
-        const legacy2k = buildPolyHavenLegacyTextureUrls(preset.sourceId, '2k');
-        const legacy1k = buildPolyHavenLegacyTextureUrls(preset.sourceId, '1k');
+        const runtimeProfile = getRuntimeTextureProfile();
+        const preferredResolutions =
+          Array.isArray(runtimeProfile?.polyHavenFallbackResolutions) &&
+          runtimeProfile.polyHavenFallbackResolutions.length
+            ? runtimeProfile.polyHavenFallbackResolutions
+            : [runtimeProfile?.polyHavenResolution || '2k', '1k'];
         const loader = new THREE.TextureLoader();
         loader.setCrossOrigin('anonymous');
+        const buildCandidatesForType = (type) => {
+          const apiUrl = urls?.[type] ?? null;
+          const candidates = [];
+          preferredResolutions.forEach((resolution) => {
+            if (apiUrl) {
+              candidates.push(remapPolyHavenTextureUrlResolution(apiUrl, resolution));
+            }
+            const modern = buildPolyHavenTextureUrls(preset.sourceId, resolution);
+            const legacy = buildPolyHavenLegacyTextureUrls(preset.sourceId, resolution);
+            if (modern?.[type]) candidates.push(modern[type]);
+            if (type === 'normal' && modern?.normal) {
+              candidates.push(modern.normal.replace('_nor_gl_', '_nor_dx_'));
+            }
+            if (legacy?.[type]) candidates.push(legacy[type]);
+          });
+          return [...new Set(candidates.filter(Boolean))];
+        };
 
-        const diffuseCandidates = [
-          upgradePolyHavenTextureUrlTo4k(urls.diffuse),
-          fallback4k?.diffuse,
-          legacy4k?.diffuse,
-          fallback2k?.diffuse,
-          legacy2k?.diffuse,
-          fallback1k?.diffuse,
-          legacy1k?.diffuse
-        ].filter(Boolean);
-        const normalCandidates = [
-          upgradePolyHavenTextureUrlTo4k(urls.normal),
-          fallback4k?.normal,
-          fallback4k?.normal?.replace('_nor_gl_', '_nor_dx_'),
-          legacy4k?.normal,
-          fallback2k?.normal,
-          fallback2k?.normal?.replace('_nor_gl_', '_nor_dx_'),
-          legacy2k?.normal,
-          fallback1k?.normal,
-          fallback1k?.normal?.replace('_nor_gl_', '_nor_dx_'),
-          legacy1k?.normal
-        ].filter(Boolean);
-        const roughnessCandidates = [
-          upgradePolyHavenTextureUrlTo4k(urls.roughness),
-          fallback4k?.roughness,
-          legacy4k?.roughness,
-          fallback2k?.roughness,
-          legacy2k?.roughness,
-          fallback1k?.roughness,
-          legacy1k?.roughness
-        ].filter(Boolean);
+        const diffuseCandidates = buildCandidatesForType('diffuse');
+        const normalCandidates = buildCandidatesForType('normal');
+        const roughnessCandidates = buildCandidatesForType('roughness');
 
         let map = null;
         let normal = null;
@@ -4210,6 +4218,18 @@ function updateClothTexturesForFinish (
   textureSource = DEFAULT_CLOTH_TEXTURE_SOURCE_ID
 ) {
   if (!finishInfo?.clothMat) return;
+  const enforceProceduralClothResponse = (material, roughnessValue) => {
+    if (!material) return;
+    material.roughness = Math.max(Number(roughnessValue) || 0, 0.86);
+    material.metalness = 0;
+    material.clearcoat = 0;
+    material.clearcoatRoughness = 1;
+    material.sheen = 0;
+    material.sheenRoughness = 1;
+    material.envMapIntensity = 0;
+    if ('reflectivity' in material) material.reflectivity = 0;
+    material.needsUpdate = true;
+  };
   registerClothTextureConsumer(textureKey, finishInfo);
   const textures = createClothTextures(textureKey, textureSource);
   const textureScale = textures.mapSource === 'polyhaven' ? POLYHAVEN_PATTERN_REPEAT_SCALE : 1;
@@ -4265,6 +4285,7 @@ function updateClothTexturesForFinish (
   } else {
     finishInfo.clothMat.roughness = roughnessBase;
   }
+  enforceProceduralClothResponse(finishInfo.clothMat, finishInfo.clothMat.roughness);
   if (Number.isFinite(finishInfo.clothBase?.baseBumpScale)) {
     finishInfo.clothMat.bumpScale = finishInfo.clothBase.baseBumpScale;
   }
@@ -4310,6 +4331,7 @@ function updateClothTexturesForFinish (
     } else {
       finishInfo.cushionMat.roughness = roughnessBase;
     }
+    enforceProceduralClothResponse(finishInfo.cushionMat, finishInfo.cushionMat.roughness);
     if (Number.isFinite(finishInfo.clothBase?.baseBumpScale)) {
       finishInfo.cushionMat.bumpScale = finishInfo.clothBase.baseBumpScale;
     }
@@ -5568,6 +5590,7 @@ const GOOD_SHOT_REPLAY_DELAY_MS = 900;
 const REPLAY_TRANSITION_LEAD_MS = 420;
 const REPLAY_SLATE_DURATION_MS = 1200;
 const REPLAY_TIMEOUT_GRACE_MS = 750;
+const REPLAY_USE_STRICT_CAPTURED_FRAMES = true; // replay only recorded frames (no interpolation) to preserve exact captured motion
 const REMATCH_DECISION_MS = 15000;
 const POWER_REPLAY_THRESHOLD = 0.78;
 const SPIN_REPLAY_THRESHOLD = 0.32;
@@ -28680,11 +28703,15 @@ const powerRef = useRef(hud.power);
             }
             playback.lastIndex = frameIndex;
             const frameA = frames[frameIndex];
-            const frameB = frames[Math.min(frameIndex + 1, frames.length - 1)] ?? null;
+            const frameB = REPLAY_USE_STRICT_CAPTURED_FRAMES
+              ? frameA
+              : frames[Math.min(frameIndex + 1, frames.length - 1)] ?? null;
             const span = frameB ? Math.max(frameB.t - frameA.t, 1e-6) : 1;
-            const alpha = frameB
-              ? THREE.MathUtils.clamp((targetTime - frameA.t) / span, 0, 1)
-              : 0;
+            const alpha = REPLAY_USE_STRICT_CAPTURED_FRAMES
+              ? 0
+              : frameB
+                ? THREE.MathUtils.clamp((targetTime - frameA.t) / span, 0, 1)
+                : 0;
             applyReplayFrame(frameA, frameB, alpha);
             applyReplayCueStroke(playback, targetTime);
             updateReplayTrail(playback.cuePath, targetTime);


### PR DESCRIPTION
### Motivation

- Ensure replays play back exactly as recorded (no in-between interpolation) so captured frames from earlier sessions are reproduced verbatim.
- Nudge balls visually upward so they clearly ride on top of the cloth surface in portrait/mobile framing.
- Make GLTF cloth textures match procedural cloth appearance by reducing specular/clearcoat/env response and unifying roughness behavior.
- Use explicit texture resolution fallbacks per refresh-rate tier (60/90/120 Hz) so cloth assets load the intended resolution with sensible fallbacks.

### Description

- Added `REPLAY_USE_STRICT_CAPTURED_FRAMES` and updated replay playback selection so playback uses captured frames (no interpolation) when enabled, and adjusted the alpha calculation accordingly (file: `webapp/src/pages/Games/PoolRoyale.jsx`).
- Increased resting ball lift by changing `BALL_CENTER_LIFT` from `BALL_R * 0.035` to `BALL_R * 0.05` so balls sit higher above the cloth plane (file: `webapp/src/pages/Games/PoolRoyale.jsx`).
- Introduced runtime PolyHaven fallback resolution logic with `resolvePolyHavenFallbackResolutions`, added `polyHavenFallbackResolutions` to `runtimeTextureProfile`, a `remapPolyHavenTextureUrlResolution` helper, and rebuilt PolyHaven candidate URL lists to respect the preferred resolution ladder per FPS tier (60Hz→2K/1K, 90Hz→4K/2K, 120Hz→desktop 8K/4K or mobile 4K/2K) (file: `webapp/src/pages/Games/PoolRoyale.jsx`).
- Enforced a matte/procedural-like response for cloth materials after applying texture updates by clamping `roughness` and zeroing `metalness`, `clearcoat`, `envMapIntensity`, and `reflectivity` where appropriate so GLTF cloth looks consistent with procedural cloths (file: `webapp/src/pages/Games/PoolRoyale.jsx`).
- Updated frame-rate UI descriptions to reflect the new texture/fallback policy and wired the runtime profile into texture loaders (file: `webapp/src/pages/Games/PoolRoyale.jsx`).

### Testing

- Ran the unit tests for pool rules with `npm run -s test -- poolRoyaleRules.test.ts` and they passed (`4 tests, 0 failures`).
- Attempted linting for the edited file with `npm run -s lint -- webapp/src/pages/Games/PoolRoyale.jsx`, but repository-wide lint runs surfaced many pre-existing/generated errors unrelated to this change; no lint fixes were applied for unrelated files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf5162f17883298f459c2e941950c4)