### PR TITLE
Add WebGL renderer fallbacks and conditional KTX2 handling to MurlanRoyaleArena

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -188,6 +188,17 @@ function detectDisplayRefreshTier() {
 
 let cachedRendererString = null;
 let rendererLookupAttempted = false;
+const RENDERER_CONTEXT_CANDIDATES = Object.freeze([
+  { label: 'webgl2-high', contextName: 'webgl2', attrs: { antialias: true, alpha: false, powerPreference: 'high-performance' } },
+  { label: 'webgl2-safe', contextName: 'webgl2', attrs: { antialias: false, alpha: false, powerPreference: 'default' } },
+  { label: 'webgl-high', contextName: 'webgl', attrs: { antialias: true, alpha: false, powerPreference: 'high-performance' } },
+  { label: 'webgl-safe', contextName: 'webgl', attrs: { antialias: false, alpha: false, powerPreference: 'default' } },
+  {
+    label: 'experimental-webgl-safe',
+    contextName: 'experimental-webgl',
+    attrs: { antialias: false, alpha: false, powerPreference: 'default' }
+  }
+]);
 
 function readGraphicsRendererString() {
   if (rendererLookupAttempted) {
@@ -220,6 +231,35 @@ function readGraphicsRendererString() {
   } catch (err) {
     return null;
   }
+}
+
+function createWebGLRendererWithFallback() {
+  const errors = [];
+
+  for (const candidate of RENDERER_CONTEXT_CANDIDATES) {
+    const canvas = document.createElement('canvas');
+    const context = canvas.getContext(candidate.contextName, candidate.attrs);
+    if (!context) {
+      errors.push(`${candidate.label}: context unavailable`);
+      continue;
+    }
+
+    try {
+      const renderer = new THREE.WebGLRenderer({
+        canvas,
+        context,
+        antialias: Boolean(candidate.attrs.antialias),
+        alpha: false,
+        powerPreference: candidate.attrs.powerPreference ?? 'default'
+      });
+      renderer.userData.webglAdapter = candidate.label;
+      return renderer;
+    } catch (error) {
+      errors.push(`${candidate.label}: ${error?.message || String(error)}`);
+    }
+  }
+
+  throw new Error(`Unable to initialize WebGL renderer (${errors.join(' | ')})`);
 }
 
 function classifyRendererTier(rendererString) {
@@ -1443,15 +1483,19 @@ function createConfiguredGLTFLoader(renderer = null, manager = undefined) {
     sharedKtx2Loader.setTranscoderPath(BASIS_TRANSCODER_PATH);
   }
 
+  let ktx2Ready = false;
   if (renderer) {
     try {
       sharedKtx2Loader.detectSupport(renderer);
+      ktx2Ready = true;
     } catch (error) {
       console.warn('Murlan KTX2 support detection failed', error);
     }
   }
 
-  loader.setKTX2Loader(sharedKtx2Loader);
+  if (ktx2Ready) {
+    loader.setKTX2Loader(sharedKtx2Loader);
+  }
   return loader;
 }
 
@@ -4473,7 +4517,7 @@ export default function MurlanRoyaleArena({ search }) {
     let lastRenderTime = performance.now();
 
     const setup = async () => {
-      renderer = new THREE.WebGLRenderer({ antialias: true, alpha: false, powerPreference: 'high-performance' });
+      renderer = createWebGLRendererWithFallback();
       applyRendererSRGB(renderer);
       renderer.toneMapping = THREE.ACESFilmicToneMapping;
       renderer.toneMappingExposure = 1.85;
@@ -4484,6 +4528,7 @@ export default function MurlanRoyaleArena({ search }) {
       renderer.domElement.style.display = 'block';
       mount.appendChild(renderer.domElement);
       dom = renderer.domElement;
+      console.info('Murlan WebGL adapter selected', renderer.userData?.webglAdapter || 'unknown');
       threeStateRef.current.renderer = renderer;
       const textureLoader = new THREE.TextureLoader();
       textureLoader.setCrossOrigin?.('anonymous');


### PR DESCRIPTION
### Motivation
- Some devices/browsers were failing the initial WebGL setup or KTX2 capability detection which caused GLTF materials (table/cloth/chair textures) to render blank or invisible.
- The goal is to make GLTF texture loading more resilient by trying multiple WebGL context configurations and avoiding attaching unsupported compressed-texture decoders.

### Description
- Added a renderer fallback chain via `RENDERER_CONTEXT_CANDIDATES` and `createWebGLRendererWithFallback()` that tries `webgl2`, `webgl`, and `experimental-webgl` with high/safe attribute presets and returns a usable `THREE.WebGLRenderer` or throws a diagnostic error.
- Switched scene initialization to use `createWebGLRendererWithFallback()` so the Murlan/Texas 3D setup will pick a compatible adapter at runtime (file: `webapp/src/pages/Games/MurlanRoyaleArena.jsx`).
- Made KTX2 setup defensive by calling `sharedKtx2Loader.detectSupport(renderer)` and only calling `loader.setKTX2Loader(sharedKtx2Loader)` when detection succeeds to avoid enabling unsupported KTX2 decoding paths.
- Added a small informational log `Murlan WebGL adapter selected` that records which adapter preset was chosen to aid device-specific debugging.

### Testing
- Built the web app with `npm --prefix webapp run build` and the build completed successfully (vite production build).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf542b4d8483299fe2958a3929dd04)