### PR TITLE
Fix Texas Hold'em Poly Haven GLTF texture URL mapping

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -576,6 +576,29 @@ function extractAllHttpUrls(apiJson) {
   return Array.from(out);
 }
 
+function buildPolyhavenIncludeUrlMap(filesJson, preferredResolutions = ['2k', '1k']) {
+  if (!filesJson || typeof filesJson !== 'object') return new Map();
+  const resolutions = Array.isArray(preferredResolutions) && preferredResolutions.length
+    ? preferredResolutions
+    : ['2k', '1k'];
+  const map = new Map();
+  resolutions.forEach((resolution) => {
+    const include = filesJson?.gltf?.[resolution]?.gltf?.include;
+    if (!include || typeof include !== 'object') return;
+    Object.entries(include).forEach(([relativePath, entry]) => {
+      const fileUrl = entry?.url;
+      if (!relativePath || typeof relativePath !== 'string' || !fileUrl || typeof fileUrl !== 'string') {
+        return;
+      }
+      const normalized = relativePath.replace(/^\.\//, '');
+      map.set(relativePath, fileUrl);
+      map.set(normalized, fileUrl);
+      map.set(basename(normalized), fileUrl);
+    });
+  });
+  return map;
+}
+
 function pickBestModelUrl(urls) {
   const modelUrls = urls.filter(isModelUrl);
   const glbs = modelUrls.filter((u) => stripQueryHash(u).toLowerCase().endsWith('.glb'));
@@ -1138,16 +1161,21 @@ async function loadPolyhavenModel(assetId, renderer = null) {
       for (const candidateId of assetCandidates) {
         try {
           const filesJson = await fetch(`https://api.polyhaven.com/files/${encodeURIComponent(candidateId)}`).then((r) => r.json());
+          const includeMap = buildPolyhavenIncludeUrlMap(filesJson);
+          includeMap.forEach((url, key) => {
+            if (!fileMap.has(key)) {
+              fileMap.set(key, url);
+            }
+          });
           const allUrls = extractAllHttpUrls(filesJson);
           const apiModelUrl = pickBestModelUrl(allUrls);
           if (apiModelUrl) modelCandidates.add(apiModelUrl);
-          if (!fileMap.size) {
-            fileMap = allUrls.reduce((acc, u) => {
-              const b = basename(stripQueryHash(u));
-              if (!acc.has(b)) acc.set(b, u);
-              return acc;
-            }, new Map());
-          }
+          allUrls.forEach((u) => {
+            const key = basename(stripQueryHash(u));
+            if (!fileMap.has(key)) {
+              fileMap.set(key, u);
+            }
+          });
         } catch (error) {
           console.warn('Poly Haven file lookup failed, falling back to direct URLs', error);
         }
@@ -1169,8 +1197,12 @@ async function loadPolyhavenModel(assetId, renderer = null) {
         loader.manager.setURLModifier((requestedUrl) => {
           if (/^https?:\/\//i.test(requestedUrl)) return requestedUrl;
           const req = stripQueryHash(requestedUrl);
-          const b = basename(req);
-          const mapped = fileMap.get(b);
+          const normalizedReq = req.replace(/^\.\//, '');
+          const mapped =
+            fileMap.get(req) ||
+            fileMap.get(normalizedReq) ||
+            fileMap.get(req.replace(/^.*\//, '')) ||
+            fileMap.get(basename(req));
           if (mapped) return mapped;
           try {
             return new URL(req, baseDir).toString();


### PR DESCRIPTION
### Motivation
- Table and chair GLTFs from Poly Haven sometimes loaded geometry while cloth/chair textures were missing due to nested or relative include paths not matching simple basename remapping. 
- Improve the Three.js GLTF loading pipeline so GLTF auxiliary resources (textures, ktx2, bin, etc.) are resolved reliably from the Poly Haven manifest and visible in the arena.

### Description
- Added `buildPolyhavenIncludeUrlMap(filesJson, preferredResolutions)` to parse `gltf.include` entries from the Poly Haven manifest and produce a map of relative/normalized/basename -> URL entries. 
- Integrated the include-map into `loadPolyhavenModel`, merging include URLs and all manifest HTTP URLs into the `fileMap` used when creating a `THREE.LoadingManager`. 
- Hardened the `loader.manager.setURLModifier` remapping to try multiple lookup keys (`raw`, normalized without `./`, path-stripped, and `basename`) before falling back to `new URL(req, baseDir)`, ensuring texture and auxiliary files resolve in more URI forms. 
- Kept existing fallback behavior that tries direct model URL candidates and `buildPolyhavenModelUrls` when manifest resolution fails.

### Testing
- Ran `npm run build` (TypeScript build via `tsc`) which completed successfully. 
- Ran `npx eslint webapp/src/pages/Games/TexasHoldemArena.jsx` and `npx eslint --no-ignore webapp/src/pages/Games/TexasHoldemArena.jsx`, both produced repository-ignore warnings but no blocking errors. 
- Confirmed the change is limited to `webapp/src/pages/Games/TexasHoldemArena.jsx` and committed the patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf542b4d8483299fe2958a3929dd04)