### PR TITLE
Fix missing GLTF textures for Texas Hold'em table/chairs

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -552,6 +552,31 @@ function basename(p) {
   return parts[parts.length - 1] || s;
 }
 
+function replaceFileExtension(path, nextExt) {
+  if (!path || !nextExt) return path;
+  const clean = stripQueryHash(path);
+  const dotIdx = clean.lastIndexOf('.');
+  if (dotIdx < 0) return `${clean}${nextExt}`;
+  return `${clean.slice(0, dotIdx)}${nextExt}`;
+}
+
+function resolveTextureFallbackUrl(requestedUrl, fileMap) {
+  if (!fileMap?.size || !requestedUrl) return null;
+  const requestedBase = basename(stripQueryHash(requestedUrl));
+  if (!requestedBase) return null;
+  const lowerBase = requestedBase.toLowerCase();
+  const fallbackExts = ['.jpg', '.jpeg', '.png', '.webp'];
+  if (!lowerBase.endsWith('.ktx2') && !lowerBase.endsWith('.basis')) {
+    return null;
+  }
+  for (const ext of fallbackExts) {
+    const candidate = basename(replaceFileExtension(requestedBase, ext));
+    const mapped = fileMap.get(candidate);
+    if (mapped) return mapped;
+  }
+  return null;
+}
+
 function isModelUrl(u) {
   const s = stripQueryHash(u).toLowerCase();
   return s.endsWith('.glb') || s.endsWith('.gltf');
@@ -1168,6 +1193,8 @@ async function loadPolyhavenModel(assetId, renderer = null) {
         const baseDir = base.substring(0, base.lastIndexOf('/') + 1);
         loader.manager.setURLModifier((requestedUrl) => {
           if (/^https?:\/\//i.test(requestedUrl)) return requestedUrl;
+          const textureFallback = resolveTextureFallbackUrl(requestedUrl, fileMap);
+          if (textureFallback) return textureFallback;
           const req = stripQueryHash(requestedUrl);
           const b = basename(req);
           const mapped = fileMap.get(b);


### PR DESCRIPTION
### Motivation
- Poly Haven GLTF models sometimes reference compressed texture files (`.ktx2`/`.basis`) which may not be available or transcodable on all WebGL adapters, causing untextured tables/chairs in the Texas Hold'em arena.  
- Provide a robust, backwards-compatible fallback so GLTF loaders can resolve to standard image textures when compressed formats are not present.

### Description
- Added helper functions `replaceFileExtension` and `resolveTextureFallbackUrl` to map requested compressed texture URIs to available image textures (`.jpg`, `.jpeg`, `.png`, `.webp`) using the Poly Haven file manifest.  
- Integrated the fallback into the GLTF `LoadingManager` URL modifier used by `loadPolyhavenModel` so the loader will try the compatibility mapping before the normal basename/baseDir resolution.  
- Changes are localized to `webapp/src/pages/Games/TexasHoldemArena.jsx` and do not modify gameplay logic or other systems.

### Testing
- Ran the production build with `npm --prefix webapp run build`, which completed successfully (Vite finished building; only non-blocking chunk-size warnings were reported).  
- Verified the modified file compiles and the build artifacts were produced without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf542b4d8483299fe2958a3929dd04)