### PR TITLE
Adjust Pool Royale cushion alignment and cloth texture quality

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2368,8 +2368,8 @@ const CLOTH_QUALITY = (() => {
   if (isMobileUA || isTouch || lowMemory || lowRefresh) {
     const highDensity = dpr >= 3;
     return {
-      textureSize: highDensity ? 2560 : 1280,
-      anisotropy: highDensity ? 22 : 18,
+      textureSize: highDensity ? 3072 : 2048,
+      anisotropy: highDensity ? 28 : 24,
       generateMipmaps: true,
       bumpScaleMultiplier: highDensity ? 1.02 : 0.94,
       sheen: 0.78,
@@ -8043,7 +8043,7 @@ export function Table3D(
       ? null
       : resolveClothPatternOverride(clothTextureKey);
   const clothTextureScale =
-    0.032 * 1.35 * 1.56 * 1.12 * clothPatternUpscale; // stretch the weave while keeping the cloth visibly taut
+    0.032 * 1.35 * 1.56 * 1.12 * 1.08 * clothPatternUpscale; // slightly tighten weave tiling so cloth texel density matches cushion detail more closely
   let baseRepeat =
     ((threadsPerBallTarget * ballsAcrossWidth) / CLOTH_THREADS_PER_TILE) *
     clothTextureScale;
@@ -8863,14 +8863,14 @@ export function Table3D(
   });
   finishParts.woodSurfaces.rail = cloneWoodSurfaceConfig(alignedRailSurface);
   const CUSHION_RAIL_FLUSH = -TABLE.THICK * 0.012; // keep cushions closer to center to avoid overlap with rails
-  const CUSHION_SHORT_RAIL_CENTER_NUDGE = TABLE.THICK * 0.038; // ease short-rail cushions slightly outward away from table center
-  const CUSHION_LONG_RAIL_CENTER_NUDGE = TABLE.THICK * 0.07; // ease long-rail cushions slightly outward away from table center
+  const CUSHION_SHORT_RAIL_CENTER_NUDGE = TABLE.THICK * 0.032; // push short-rail cushions a touch farther outward from center for a slightly wider rail stance
+  const CUSHION_LONG_RAIL_CENTER_NUDGE = TABLE.THICK * 0.064; // push long side-rail cushions a tiny bit farther outward toward the rail edge
   const CUSHION_CORNER_CLEARANCE_REDUCTION = TABLE.THICK * 0.32; // shorten the long-rail cushions slightly less so the noses reach farther toward the corners
   const SIDE_CUSHION_POCKET_REACH_REDUCTION = TABLE.THICK * 0.00; // trim the cushion tips near middle pockets so they stop at the rail cut
   const LONG_RAIL_CUSHION_LENGTH_TRIM = BALL_R * 0.72; // shorten short-rail cushions a touch more so the ends don't overhang the pocket cuts
   const SHORT_RAIL_CUSHION_LENGTH_TRIM = BALL_R * 0.08; // trim short-rail cushions slightly more so the ends pull back from the corners
-  const SIDE_CUSHION_RAIL_REACH = TABLE.THICK * 0.056; // push side cushions outward a touch while keeping the rail contact clean
-  const SIDE_CUSHION_CORNER_SHIFT = TABLE.THICK * 0.18; // push side-rail cushions away from the middle pockets toward the corners
+  const SIDE_CUSHION_RAIL_REACH = TABLE.THICK * 0.062; // nudge side cushions a little farther outward so they sit closer to the side rails
+  const SIDE_CUSHION_CORNER_SHIFT = TABLE.THICK * 0.16; // trim a tiny amount from the corner-facing side of long side cushions while keeping middle-pocket-facing ends nearly unchanged
   const SHORT_RAIL_CUSHION_VERTICAL_LIFT = TABLE.THICK * 0.026; // lift all six cushions a touch higher while keeping the same profile
   const LONG_RAIL_CUSHION_VERTICAL_LIFT = SHORT_RAIL_CUSHION_VERTICAL_LIFT; // keep long-rail cushions at the same height as the short rails
   const SHORT_CUSHION_HEIGHT_SCALE = 1; // keep short rail cushions flush with the new trimmed cushion profile


### PR DESCRIPTION
### Motivation

- Improve visual alignment of table cushions so side and short-rail cushions sit slightly farther outward toward the rails to match photographic reference and on-screen framing. 
- Trim the corner-facing side of long side cushions slightly while keeping middle-pocket-facing behaviour unchanged. 
- Make the cloth texture crisper and higher-quality on mobile/touch devices and better match cloth texel density to cushion detail.

### Description

- Updated cushion placement constants in `webapp/src/pages/Games/PoolRoyale.jsx` by tuning `CUSHION_SHORT_RAIL_CENTER_NUDGE`, `CUSHION_LONG_RAIL_CENTER_NUDGE`, `SIDE_CUSHION_RAIL_REACH`, and `SIDE_CUSHION_CORNER_SHIFT` to nudge cushions outward and reduce corner-side extension. 
- Increased mobile/touch cloth texture quality in the runtime texture profile by raising `textureSize` and `anisotropy` for the mobile branch of `CLOTH_QUALITY`. 
- Tightened cloth weave tiling by multiplying `clothTextureScale` by an additional factor (1.08) so cloth texel density better matches cushion detail. 
- All edits are located in `webapp/src/pages/Games/PoolRoyale.jsx` and include inline comment updates explaining the tuning intent.

### Testing

- Ran a production build with `cd webapp && npm run -s build`, which completed successfully. 
- The build produced Vite warnings about large chunks and some dynamic/static import overlaps, but these are non-blocking and unrelated to the visual changes; the build artifacts were generated. 
- No additional automated unit tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf7b16c2dc83298c911b37dfbab45c)