### PR TITLE
Improve replay cameras, rail-contact tracking, and cloth/rail visuals

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -836,7 +836,7 @@ const CHROME_CORNER_POCKET_CUT_SCALE = 1.035; // open only the corner chrome rou
 const CHROME_SIDE_POCKET_CUT_SCALE = 1.02; // open middle-pocket chrome rounded cuts a touch more so the arc reads larger on portrait views
 const CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE = 0.04; // reduce inward pull so middle pocket chrome cuts sit a bit farther out
 const WOOD_RAIL_POCKET_RELIEF_SCALE = 1; // match the wooden rail pocket relief to the jaw outside diameter
-const WOOD_CORNER_RELIEF_INWARD_SCALE = 0.966; // shrink the wooden corner rounded cut a touch more so only the wood corner radius reads slightly tighter
+const WOOD_CORNER_RELIEF_INWARD_SCALE = 0.958; // shrink the wooden corner rounded cut a touch more so only the wood corner radius reads slightly tighter
 const WOOD_CORNER_RAIL_POCKET_RELIEF_SCALE =
   (1 / WOOD_RAIL_POCKET_RELIEF_SCALE) * WOOD_CORNER_RELIEF_INWARD_SCALE; // corner wood arches now sit a hair inside the chrome radius so the rounded cut creeps inward
 const WOOD_CORNER_POCKET_CUT_CENTER_OUTSET_SCALE = -0.018; // push only the wooden corner rounded cut outward a touch without moving side-pocket cuts
@@ -2329,10 +2329,10 @@ const BASE_BALL_COLORS = Object.freeze({
   pink: 0xff7fc3,
   black: 0x111111
 });
-const CLOTH_TEXTURE_INTENSITY = 2.1;
+const CLOTH_TEXTURE_INTENSITY = 2.28;
 const CLOTH_HAIR_INTENSITY = 1.35;
 const CLOTH_BUMP_INTENSITY = 2.1;
-const CLOTH_SOFT_BLEND = 0.4;
+const CLOTH_SOFT_BLEND = 0.34;
 
 const CLOTH_QUALITY = (() => {
   const defaults = {
@@ -3547,7 +3547,7 @@ const ORIGINAL_OUTER_HALF_H =
 const CLOTH_TEXTURE_SIZE = CLOTH_QUALITY.textureSize;
 const CLOTH_THREAD_PITCH = 12 * 1.48; // slightly denser thread spacing for a sharper weave
 const CLOTH_THREADS_PER_TILE = CLOTH_TEXTURE_SIZE / CLOTH_THREAD_PITCH;
-const CLOTH_PATTERN_SCALE = 0.66; // make procedural weave read a touch larger on-screen
+const CLOTH_PATTERN_SCALE = 0.72; // tighten procedural weave slightly so threads read smaller and sharper on mobile
 const CLOTH_TEXTURE_REPEAT_HINT = 1.66;
 const POLYHAVEN_PATTERN_REPEAT_SCALE = 1;
 const POLYHAVEN_ANISOTROPY_BOOST = 9;
@@ -14520,6 +14520,7 @@ function PoolRoyaleGame({
     placedFromHand: false,
     contactMade: false,
     cushionAfterContact: false,
+    railContactCountAfterContact: 0,
     attemptsPenaltyApplied: false
   });
   const shotReplayRef = useRef(null);
@@ -19559,32 +19560,27 @@ const powerRef = useRef(hud.power);
           if (railCamera?.position && railCamera?.target) {
             return railCamera;
           }
-          const systemVariant =
-            broadcastSystemRef.current?.topViewVariant ??
-            activeBroadcastSystem?.topViewVariant ??
-            'pool';
-          const topViewConfig = resolveBroadcastTopViewVariant(systemVariant);
           const scale = Number.isFinite(worldScaleFactor) ? worldScaleFactor : WORLD_SCALE;
           const focusTarget =
             focusOverride?.clone?.() ??
             TMP_VEC3_TOP_VIEW
               .set(
-                playerOffsetRef.current + topViewConfig.screenOffset.x,
+                playerOffsetRef.current + RAIL_OVERHEAD_SCREEN_OFFSET.x,
                 ORBIT_FOCUS_BASE_Y,
-                topViewConfig.screenOffset.z
+                RAIL_OVERHEAD_SCREEN_OFFSET.z
               )
               .multiplyScalar(scale);
           if (focusTarget && Number.isFinite(minTargetY)) {
             focusTarget.y = Math.max(focusTarget.y ?? minTargetY, minTargetY);
           }
           const topRadiusBase =
-            fitRadius(camera, topViewConfig.margin) * topViewConfig.radiusScale;
+            fitRadius(camera, TOP_VIEW_MARGIN) * RAIL_OVERHEAD_TOP_VIEW_RADIUS_SCALE;
           const topRadius = clampOrbitRadius(
-            Math.max(topRadiusBase, CAMERA.minR * topViewConfig.minRadiusScale)
+            Math.max(topRadiusBase, CAMERA.minR * RAIL_OVERHEAD_TOP_VIEW_MIN_RADIUS_SCALE)
           );
           const spherical = new THREE.Spherical(
             topRadius,
-            topViewConfig.phi,
+            RAIL_OVERHEAD_PHI,
             Math.PI
           );
           const position = new THREE.Vector3().setFromSpherical(spherical).add(focusTarget);
@@ -20735,6 +20731,27 @@ const powerRef = useRef(hud.power);
               clothMat.bumpScale !== clothMat.userData.bumpScale
             ) {
               clothMat.bumpScale = clothMat.userData.bumpScale;
+            }
+            if (cushionMat && !cushionMat.userData?.preserveOriginalUvMapping) {
+              const syncTextureRepeat = (texture) => {
+                if (
+                  texture &&
+                  (texture.repeat.x !== targetRepeat || texture.repeat.y !== targetRepeatY)
+                ) {
+                  texture.repeat.set(targetRepeat, targetRepeatY);
+                  texture.needsUpdate = true;
+                }
+              };
+              syncTextureRepeat(cushionMat.map);
+              syncTextureRepeat(cushionMat.normalMap);
+              syncTextureRepeat(cushionMat.bumpMap);
+              syncTextureRepeat(cushionMat.roughnessMap);
+              if (
+                Number.isFinite(clothMat.userData?.bumpScale) &&
+                cushionMat.bumpScale !== clothMat.userData.bumpScale
+              ) {
+                cushionMat.bumpScale = clothMat.userData.bumpScale;
+              }
             }
           }
           updateHdriScale(renderCamera, lookTarget);
@@ -22339,8 +22356,6 @@ const powerRef = useRef(hud.power);
           overheadBroadcastVariantRef.current = 'replay';
           storeReplayCameraFrame();
           resetCameraForReplay();
-          enterTopView(true, { variant: 'rail' });
-          setIsRailOverheadView(true);
           const replayCueStroke = trimmed.cueStroke ?? null;
           const replayCueHideFrom = replayCueStroke
             ? Math.max(
@@ -22407,14 +22422,29 @@ const powerRef = useRef(hud.power);
           updateReplayTrail(replayPlayback.cuePath, 0);
           primeReplayCueStick(replayPlayback);
           const path = replayPlayback.cuePath ?? [];
-          if (!LOCK_REPLAY_CAMERA && !FIXED_RAIL_REPLAY_CAMERA) {
-            const initialCamera = trimmed.frames?.[0]?.camera ?? null;
-            if (initialCamera) {
-              replayFrameCameraRef.current = {
-                frameA: initialCamera,
-                frameB: initialCamera,
-                alpha: 0
-              };
+          if (!LOCK_REPLAY_CAMERA && path.length > 0) {
+            const start = path[0]?.pos ?? null;
+            const end = path[path.length - 1]?.pos ?? start;
+            if (start && end) {
+              const focus = new THREE.Vector3(
+                (start.x + end.x) * 0.5,
+                Math.max(
+                  baseSurfaceWorldY,
+                  BALL_CENTER_Y * (Number.isFinite(worldScaleFactor) ? worldScaleFactor : WORLD_SCALE)
+                ),
+                (start.z + end.z) * 0.5
+              );
+              const cinematicReplayCamera = resolveRailOverheadReplayCamera({
+                focusOverride: focus,
+                minTargetY: focus.y
+              });
+              if (cinematicReplayCamera) {
+                replayFrameCameraRef.current = {
+                  frameA: cinematicReplayCamera,
+                  frameB: cinematicReplayCamera,
+                  alpha: 0
+                };
+              }
             }
           }
         };
@@ -22473,8 +22503,6 @@ const powerRef = useRef(hud.power);
           replayCameraRef.current = null;
           replayFrameCameraRef.current = null;
           overheadBroadcastVariantRef.current = 'rail';
-          resetCameraForReplay();
-          setIsRailOverheadView(false);
           replayCueHiddenRef.current = { hideFrom: Infinity, hideUntil: -Infinity };
           setReplayActive(false);
           setReplayFoul(null);
@@ -25329,6 +25357,7 @@ const powerRef = useRef(hud.power);
           placedFromHand,
           contactMade: false,
           cushionAfterContact: false,
+          railContactCountAfterContact: 0,
           attemptsPenaltyApplied: false,
           spin: {
             x: appliedSpinSnapshot.x ?? 0,
@@ -28080,6 +28109,8 @@ const powerRef = useRef(hud.power);
           cueBallPotted,
           contactMade: shotContextRef.current.contactMade,
           cushionAfterContact: shotContextRef.current.cushionAfterContact,
+          railContactCountAfterContact: shotContextRef.current.railContactCountAfterContact ?? 0,
+          doubleBanked: (shotContextRef.current.railContactCountAfterContact ?? 0) >= 2,
           noCushionAfterContact,
           variant: variantId
         };
@@ -28283,6 +28314,13 @@ const powerRef = useRef(hud.power);
           shotRecording.replayTags = replayDecision.tags;
           shotRecording.zoomOnly = replayDecision.zoomOnly;
         }
+        if (shotRecording) {
+          const pottedSidePocket = potted.some(
+            (entry) => entry?.id !== 'cue' && (entry?.pocket === 'TM' || entry?.pocket === 'BM')
+          );
+          shotRecording.forceDualRailOverhead =
+            pottedSidePocket || (shotContextRef.current.railContactCountAfterContact ?? 0) >= 2;
+        }
         shouldStartReplay =
           !skipAllReplaysRef.current &&
           Boolean(replayDecision?.shouldReplay) &&
@@ -28407,6 +28445,7 @@ const powerRef = useRef(hud.power);
           placedFromHand: false,
           contactMade: false,
           cushionAfterContact: false,
+          railContactCountAfterContact: 0,
           attemptsPenaltyApplied: false,
           spin: { x: 0, y: 0 }
         };
@@ -28712,7 +28751,7 @@ const powerRef = useRef(hud.power);
             applyReplayFrame(frameA, frameB, alpha);
             applyReplayCueStroke(playback, targetTime);
             updateReplayTrail(playback.cuePath, targetTime);
-            if (!LOCK_REPLAY_CAMERA && !FIXED_RAIL_REPLAY_CAMERA) {
+            if (!LOCK_REPLAY_CAMERA) {
               const frameCameraA = frameA?.camera ?? null;
               const frameCameraB = frameB?.camera ?? frameCameraA;
               if (frameCameraA || frameCameraB) {
@@ -29954,6 +29993,8 @@ const powerRef = useRef(hud.power);
             if (railImpact && b.id === 'cue') b.impacted = true;
             if (railImpact && shotContextRef.current.contactMade) {
               shotContextRef.current.cushionAfterContact = true;
+              shotContextRef.current.railContactCountAfterContact =
+                (shotContextRef.current.railContactCountAfterContact ?? 0) + 1;
             }
             if (railImpact) {
               applyRailImpulse(b, railImpact);


### PR DESCRIPTION
### Motivation
- Tighten table and chrome/wood pocket geometry and cloth appearance to improve visual fidelity across devices.
- Track rail contacts after the first cue contact so shot resolution and replay selection can detect double-bank/dual-rail shots.
- Make replay camera selection more cinematic and prevent forced rail overhead camera mode during replays while keeping UVs synced for cushions.

### Description
- Adjusted several visual constants: `WOOD_CORNER_RELIEF_INWARD_SCALE` from `0.966` to `0.958`, `CLOTH_TEXTURE_INTENSITY` from `2.1` to `2.28`, `CLOTH_SOFT_BLEND` from `0.4` to `0.34`, and `CLOTH_PATTERN_SCALE` from `0.66` to `0.72` to tighten weave and cloth rendering.
- Added `railContactCountAfterContact` to `shotContextRef` and reset it at shot boundaries, incrementing it on rail impacts to enable `doubleBanked` detection and related rule logic.
- Set `shotRecording.forceDualRailOverhead` based on detected side-pocket pots or when `railContactCountAfterContact >= 2` so replays can pick dual-rail overheads.
- Improved replay camera handling by computing a cinematic focus from the cue path start/end and calling `resolveRailOverheadReplayCamera` instead of forcing top/rail view, and replaced legacy top-view config usage with `RAIL_OVERHEAD_*` constants and `TOP_VIEW_MARGIN` where appropriate.
- Sync cushion material UV repeats with cloth repeats unless `preserveOriginalUvMapping` is set, and ensure `bumpScale` is aligned between cloth and cushion when appropriate.

### Testing
- Ran unit tests with `yarn test`, and all unit tests passed.
- Ran linter with `yarn lint`, and the lint check passed with no new warnings.
- Built the webapp with `yarn build` to verify bundling and runtime consistency, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf953ea16c8329a41d326b724913a5)