### PR TITLE
Tweak cloth/wood visuals, improve replay camera logic, and track rail contacts for shot rules

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -836,7 +836,7 @@ const CHROME_CORNER_POCKET_CUT_SCALE = 1.035; // open only the corner chrome rou
 const CHROME_SIDE_POCKET_CUT_SCALE = 1.02; // open middle-pocket chrome rounded cuts a touch more so the arc reads larger on portrait views
 const CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE = 0.04; // reduce inward pull so middle pocket chrome cuts sit a bit farther out
 const WOOD_RAIL_POCKET_RELIEF_SCALE = 1; // match the wooden rail pocket relief to the jaw outside diameter
-const WOOD_CORNER_RELIEF_INWARD_SCALE = 0.966; // shrink the wooden corner rounded cut a touch more so only the wood corner radius reads slightly tighter
+const WOOD_CORNER_RELIEF_INWARD_SCALE = 0.958; // shrink the wooden corner rounded cut a touch more so only the wood corner radius reads slightly tighter
 const WOOD_CORNER_RAIL_POCKET_RELIEF_SCALE =
   (1 / WOOD_RAIL_POCKET_RELIEF_SCALE) * WOOD_CORNER_RELIEF_INWARD_SCALE; // corner wood arches now sit a hair inside the chrome radius so the rounded cut creeps inward
 const WOOD_CORNER_POCKET_CUT_CENTER_OUTSET_SCALE = -0.018; // push only the wooden corner rounded cut outward a touch without moving side-pocket cuts
@@ -2329,10 +2329,10 @@ const BASE_BALL_COLORS = Object.freeze({
   pink: 0xff7fc3,
   black: 0x111111
 });
-const CLOTH_TEXTURE_INTENSITY = 2.1;
+const CLOTH_TEXTURE_INTENSITY = 2.28;
 const CLOTH_HAIR_INTENSITY = 1.35;
 const CLOTH_BUMP_INTENSITY = 2.1;
-const CLOTH_SOFT_BLEND = 0.4;
+const CLOTH_SOFT_BLEND = 0.34;
 
 const CLOTH_QUALITY = (() => {
   const defaults = {
@@ -3547,7 +3547,7 @@ const ORIGINAL_OUTER_HALF_H =
 const CLOTH_TEXTURE_SIZE = CLOTH_QUALITY.textureSize;
 const CLOTH_THREAD_PITCH = 12 * 1.48; // slightly denser thread spacing for a sharper weave
 const CLOTH_THREADS_PER_TILE = CLOTH_TEXTURE_SIZE / CLOTH_THREAD_PITCH;
-const CLOTH_PATTERN_SCALE = 0.66; // make procedural weave read a touch larger on-screen
+const CLOTH_PATTERN_SCALE = 0.72; // tighten procedural weave slightly so threads read smaller and sharper on mobile
 const CLOTH_TEXTURE_REPEAT_HINT = 1.66;
 const POLYHAVEN_PATTERN_REPEAT_SCALE = 1;
 const POLYHAVEN_ANISOTROPY_BOOST = 9;
@@ -8056,7 +8056,7 @@ export function Table3D(
     patternOverride?.repeatRatioScale && patternOverride.repeatRatioScale > 0
       ? patternOverride.repeatRatioScale
       : 1;
-  const repeatRatio = 3.45 * repeatRatioScale;
+  const repeatRatio = 1 * repeatRatioScale;
   const polyRepeatScale =
     clothMapSource === 'polyhaven' ? POLYHAVEN_PATTERN_REPEAT_SCALE : 1;
   const baseRepeatApplied = baseRepeat * polyRepeatScale;
@@ -14520,6 +14520,7 @@ function PoolRoyaleGame({
     placedFromHand: false,
     contactMade: false,
     cushionAfterContact: false,
+    railContactCountAfterContact: 0,
     attemptsPenaltyApplied: false
   });
   const shotReplayRef = useRef(null);
@@ -19556,39 +19557,21 @@ const powerRef = useRef(hud.power);
             minTargetY,
             preferredRail: railOverheadSideRef.current
           });
-          if (railCamera?.position && railCamera?.target) {
-            return railCamera;
+          if (railCamera?.position) {
+            const fallbackTarget =
+              focusOverride?.clone?.() ??
+              broadcastCamerasRef.current?.defaultFocusWorld?.clone?.() ??
+              lastCameraTargetRef.current?.clone?.() ??
+              new THREE.Vector3(playerOffsetRef.current, ORBIT_FOCUS_BASE_Y, 0);
+            if (Number.isFinite(minTargetY)) {
+              fallbackTarget.y = Math.max(fallbackTarget.y ?? minTargetY, minTargetY);
+            }
+            return {
+              ...railCamera,
+              target: railCamera.target ?? fallbackTarget
+            };
           }
-          const systemVariant =
-            broadcastSystemRef.current?.topViewVariant ??
-            activeBroadcastSystem?.topViewVariant ??
-            'pool';
-          const topViewConfig = resolveBroadcastTopViewVariant(systemVariant);
-          const scale = Number.isFinite(worldScaleFactor) ? worldScaleFactor : WORLD_SCALE;
-          const focusTarget =
-            focusOverride?.clone?.() ??
-            TMP_VEC3_TOP_VIEW
-              .set(
-                playerOffsetRef.current + topViewConfig.screenOffset.x,
-                ORBIT_FOCUS_BASE_Y,
-                topViewConfig.screenOffset.z
-              )
-              .multiplyScalar(scale);
-          if (focusTarget && Number.isFinite(minTargetY)) {
-            focusTarget.y = Math.max(focusTarget.y ?? minTargetY, minTargetY);
-          }
-          const topRadiusBase =
-            fitRadius(camera, topViewConfig.margin) * topViewConfig.radiusScale;
-          const topRadius = clampOrbitRadius(
-            Math.max(topRadiusBase, CAMERA.minR * topViewConfig.minRadiusScale)
-          );
-          const spherical = new THREE.Spherical(
-            topRadius,
-            topViewConfig.phi,
-            Math.PI
-          );
-          const position = new THREE.Vector3().setFromSpherical(spherical).add(focusTarget);
-          return { position, target: focusTarget, fov: STANDING_VIEW_FOV, minTargetY };
+          return null;
         };
 
         const resolveRailOverheadReplayCamera = ({
@@ -22339,8 +22322,6 @@ const powerRef = useRef(hud.power);
           overheadBroadcastVariantRef.current = 'replay';
           storeReplayCameraFrame();
           resetCameraForReplay();
-          enterTopView(true, { variant: 'rail' });
-          setIsRailOverheadView(true);
           const replayCueStroke = trimmed.cueStroke ?? null;
           const replayCueHideFrom = replayCueStroke
             ? Math.max(
@@ -22396,7 +22377,8 @@ const powerRef = useRef(hud.power);
             lastIndex: 0,
             postState: postShotSnapshot,
             pocketDrops: pausedPocketDrops ?? pocketDropRef.current,
-            pocketCameraCutoff: null
+            pocketCameraCutoff: null,
+            forceDualRailOverhead: false
           };
           pausedPocketDrops = pocketDropRef.current;
           pocketDropRef.current = new Map();
@@ -22407,14 +22389,29 @@ const powerRef = useRef(hud.power);
           updateReplayTrail(replayPlayback.cuePath, 0);
           primeReplayCueStick(replayPlayback);
           const path = replayPlayback.cuePath ?? [];
-          if (!LOCK_REPLAY_CAMERA && !FIXED_RAIL_REPLAY_CAMERA) {
-            const initialCamera = trimmed.frames?.[0]?.camera ?? null;
-            if (initialCamera) {
-              replayFrameCameraRef.current = {
-                frameA: initialCamera,
-                frameB: initialCamera,
-                alpha: 0
-              };
+          if (!LOCK_REPLAY_CAMERA && path.length > 0) {
+            const start = path[0]?.pos ?? null;
+            const end = path[path.length - 1]?.pos ?? start;
+            if (start && end) {
+              const focus = new THREE.Vector3(
+                (start.x + end.x) * 0.5,
+                Math.max(
+                  baseSurfaceWorldY,
+                  BALL_CENTER_Y * (Number.isFinite(worldScaleFactor) ? worldScaleFactor : WORLD_SCALE)
+                ),
+                (start.z + end.z) * 0.5
+              );
+              const cinematicReplayCamera = resolveRailOverheadReplayCamera({
+                focusOverride: focus,
+                minTargetY: focus.y
+              });
+              if (cinematicReplayCamera) {
+                replayFrameCameraRef.current = {
+                  frameA: cinematicReplayCamera,
+                  frameB: cinematicReplayCamera,
+                  alpha: 0
+                };
+              }
             }
           }
         };
@@ -22473,8 +22470,6 @@ const powerRef = useRef(hud.power);
           replayCameraRef.current = null;
           replayFrameCameraRef.current = null;
           overheadBroadcastVariantRef.current = 'rail';
-          resetCameraForReplay();
-          setIsRailOverheadView(false);
           replayCueHiddenRef.current = { hideFrom: Infinity, hideUntil: -Infinity };
           setReplayActive(false);
           setReplayFoul(null);
@@ -25329,6 +25324,7 @@ const powerRef = useRef(hud.power);
           placedFromHand,
           contactMade: false,
           cushionAfterContact: false,
+          railContactCountAfterContact: 0,
           attemptsPenaltyApplied: false,
           spin: {
             x: appliedSpinSnapshot.x ?? 0,
@@ -28080,6 +28076,8 @@ const powerRef = useRef(hud.power);
           cueBallPotted,
           contactMade: shotContextRef.current.contactMade,
           cushionAfterContact: shotContextRef.current.cushionAfterContact,
+          railContactCountAfterContact: shotContextRef.current.railContactCountAfterContact ?? 0,
+          doubleBanked: (shotContextRef.current.railContactCountAfterContact ?? 0) >= 2,
           noCushionAfterContact,
           variant: variantId
         };
@@ -28407,6 +28405,7 @@ const powerRef = useRef(hud.power);
           placedFromHand: false,
           contactMade: false,
           cushionAfterContact: false,
+          railContactCountAfterContact: 0,
           attemptsPenaltyApplied: false,
           spin: { x: 0, y: 0 }
         };
@@ -29954,6 +29953,8 @@ const powerRef = useRef(hud.power);
             if (railImpact && b.id === 'cue') b.impacted = true;
             if (railImpact && shotContextRef.current.contactMade) {
               shotContextRef.current.cushionAfterContact = true;
+              shotContextRef.current.railContactCountAfterContact =
+                (shotContextRef.current.railContactCountAfterContact ?? 0) + 1;
             }
             if (railImpact) {
               applyRailImpulse(b, railImpact);


### PR DESCRIPTION
### Motivation

- Tune visual materials and pattern scaling for tighter, sharper cloth rendering and slightly adjusted wood corner relief.  
- Make replay/cinematic camera selection more robust and produce better framed replay views based on the cue path.  
- Track rail contact counts during shots so rules can detect double-banks and other rail-based conditions.

### Description

- Adjusted wood pocket relief by changing `WOOD_CORNER_RELIEF_INWARD_SCALE` from `0.966` to `0.958`.  
- Updated cloth / texture constants: `CLOTH_TEXTURE_INTENSITY` to `2.28`, `CLOTH_SOFT_BLEND` to `0.34`, and `CLOTH_PATTERN_SCALE` to `0.72`, and simplified `repeatRatio` to `1` to tighten weave tiling and appearance.  
- Revised replay/camera logic in `PoolRoyale.jsx` by simplifying `resolveBroadcastTopViewCamera` to prefer an existing rail camera with a reliable fallback target, removed forcing the rail overhead view on replay start/finish, added cinematic replay camera selection in `startShotReplay` based on the cue path, and introduced `forceDualRailOverhead` on replay playback state.  
- Added rail contact tracking to shot context by introducing `railContactCountAfterContact` on `shotContextRef`, incrementing it on rail impacts, resetting it at shot boundaries, and exposing `doubleBanked` when the count is `>= 2` for rules evaluation.

### Testing

- Ran linting with `yarn lint` and static checks which completed successfully.  
- Executed the test suite with `yarn test` and all tests passed on CI.  
- Verified a production build via `yarn build` completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf953ea16c8329a41d326b724913a5)