### PR TITLE
Fix Pool Royale replay fallback and replace cloth variants with Caban palette set

### DIFF
--- a/webapp/src/config/poolRoyaleClothPresets.js
+++ b/webapp/src/config/poolRoyaleClothPresets.js
@@ -1,188 +1,127 @@
-import { polyHavenThumb } from './storeThumbnails.js';
+import { polyHavenThumb } from './storeThumbnails.js'
 
 const normalizeHex = (value) => {
-  const asString = typeof value === 'number' ? value.toString(16).padStart(6, '0') : String(value || '').replace('#', '');
-  return `#${asString.slice(0, 6)}`;
-};
+  const asString =
+    typeof value === 'number'
+      ? value.toString(16).padStart(6, '0')
+      : String(value || '').replace('#', '')
+  return `#${asString.slice(0, 6)}`
+}
 
-const clampChannel = (channel) => Math.max(0, Math.min(255, Math.round(channel)));
+const clampChannel = (channel) => Math.max(0, Math.min(255, Math.round(channel)))
 
 const adjustHex = (hex, factor) => {
-  const normalized = normalizeHex(hex).slice(1);
-  const r = parseInt(normalized.slice(0, 2), 16);
-  const g = parseInt(normalized.slice(2, 4), 16);
-  const b = parseInt(normalized.slice(4, 6), 16);
-  const target = factor >= 0 ? 255 : 0;
-  const amount = Math.min(1, Math.max(-1, factor));
-  const delta = Math.abs(amount);
-  const adjust = (channel) => clampChannel(channel + (target - channel) * delta);
-  const next = (adjust(r) << 16) | (adjust(g) << 8) | adjust(b);
-  return `#${next.toString(16).padStart(6, '0')}`;
-};
+  const normalized = normalizeHex(hex).slice(1)
+  const r = parseInt(normalized.slice(0, 2), 16)
+  const g = parseInt(normalized.slice(2, 4), 16)
+  const b = parseInt(normalized.slice(4, 6), 16)
+  const target = factor >= 0 ? 255 : 0
+  const amount = Math.min(1, Math.max(-1, factor))
+  const delta = Math.abs(amount)
+  const adjust = (channel) => clampChannel(channel + (target - channel) * delta)
+  const next = (adjust(r) << 16) | (adjust(g) << 8) | adjust(b)
+  return `#${next.toString(16).padStart(6, '0')}`
+}
 
-const toNumber = (hex) => parseInt(normalizeHex(hex).slice(1), 16);
+const toNumber = (hex) => parseInt(normalizeHex(hex).slice(1), 16)
 
 const buildPalette = (baseHex) => ({
   shadow: toNumber(adjustHex(baseHex, -0.22)),
   base: toNumber(baseHex),
   accent: toNumber(adjustHex(baseHex, 0.12)),
   highlight: toNumber(adjustHex(baseHex, 0.24))
-});
+})
 
 const createSwatches = (baseHex) => [
   normalizeHex(baseHex),
   adjustHex(baseHex, 0.16),
   adjustHex(baseHex, 0.3)
-];
+]
 
-const CABAN_GREEN_SWATCHES = Object.freeze(['#33b46a', '#2ca85f', '#42c47a', '#4fd184', '#238f4a']);
-const CABAN_OCEAN_BLUE_SWATCHES = Object.freeze([
-  '#0b74c6',
-  '#0a6eb8',
-  '#1589e6',
-  '#1fa3ff',
-  '#095fa4'
-]);
+const CABAN_SOURCE_ID = 'caban'
+const CABAN_LABEL = 'Caban Wool'
+const CABAN_BASE_PRICE = 690
+const CABAN_PRICE_STEP = 12
 
-const GREEN_SHADE_NAMES = ['Meadow', 'Spruce', 'Grove', 'Glade', 'Summit'];
-const BLUE_SHADE_NAMES = ['Harbor', 'Fjord', 'Glacier', 'Sapphire', 'Midnight'];
-const NATURE_SHADE_NAMES = ['Fern', 'Grove', 'Canopy', 'Meadow', 'Wildwood'];
-const OCEAN_SHADE_NAMES = ['Crest', 'Current', 'Lagoon', 'Reef', 'Abyss'];
+const CABAN_DETAIL = Object.freeze({
+  bumpMultiplier: 1.22,
+  sheen: 0.58,
+  sheenRoughness: 0.46,
+  emissiveIntensity: 0.24,
+  envMapIntensity: 0.18
+})
 
-const MATERIAL_SERIES = [
+const CABAN_SHADE_GROUPS = Object.freeze([
   {
-    prefix: 'caban',
-    label: 'Caban Wool',
-    sourceId: 'caban',
-    basePrice: 690,
-    priceStep: 10,
-    bluePremium: 20,
+    tone: 'blue',
+    label: 'Blue',
+    shades: [
+      { id: 'bright', name: 'Bright', hex: '#1f8ff5' },
+      { id: 'medium', name: 'Medium', hex: '#166fca' },
+      { id: 'dark', name: 'Dark', hex: '#0f4f95' }
+    ]
+  },
+  {
+    tone: 'green',
+    label: 'Green',
+    shades: [
+      { id: 'bright', name: 'Bright', hex: '#3bbf73' },
+      { id: 'medium', name: 'Medium', hex: '#2a995d' },
+      { id: 'dark', name: 'Dark', hex: '#1d6f43' }
+    ]
+  },
+  {
+    tone: 'beige',
+    label: 'Beige',
+    shades: [
+      { id: 'bright', name: 'Bright', hex: '#d8c197' },
+      { id: 'medium', name: 'Medium', hex: '#b89f73' },
+      { id: 'dark', name: 'Dark', hex: '#927c54' }
+    ]
+  },
+  {
+    tone: 'darkGrey',
+    label: 'Dark Grey',
+    shades: [
+      { id: 'bright', name: 'Bright', hex: '#6f7783' },
+      { id: 'medium', name: 'Medium', hex: '#525962' },
+      { id: 'dark', name: 'Dark', hex: '#353a41' }
+    ]
+  }
+])
+
+const createCabanVariant = ({ tone, label, shade, index, groupIndex }) => {
+  const id = `caban${label.replace(/\s+/g, '')}${shade.name}`
+  const price = CABAN_BASE_PRICE + groupIndex * 12 + index * CABAN_PRICE_STEP
+  return {
+    id,
+    name: `${CABAN_LABEL} — ${label} ${shade.name}`,
+    sourceId: CABAN_SOURCE_ID,
+    tone,
+    baseColor: toNumber(shade.hex),
+    palette: buildPalette(shade.hex),
     sparkle: 1.08,
     stray: 1.06,
-    detail: {
-      bumpMultiplier: 1.22,
-      sheen: 0.58,
-      sheenRoughness: 0.46,
-      emissiveIntensity: 0.24,
-      envMapIntensity: 0.18
-    },
-    greens: CABAN_GREEN_SWATCHES,
-    blues: CABAN_OCEAN_BLUE_SWATCHES
-  },
-  {
-    prefix: 'polarFleece',
-    label: 'Polar Fleece',
-    sourceId: 'polar_fleece',
-    basePrice: 640,
-    priceStep: 10,
-    bluePremium: 20,
-    sparkle: 1.12,
-    stray: 1.1,
-    detail: {
-      bumpMultiplier: 1.12,
-      sheen: 0.7,
-      sheenRoughness: 0.52,
-      emissiveIntensity: 0.34,
-      envMapIntensity: 0.14
-    },
-    greens: CABAN_GREEN_SWATCHES,
-    blues: CABAN_OCEAN_BLUE_SWATCHES
-  },
-  {
-    prefix: 'polarFleecePlush',
-    label: 'Polar Fleece Plush',
-    sourceId: 'polar_fleece',
-    basePrice: 700,
-    priceStep: 10,
-    bluePremium: 20,
-    sparkle: 1.14,
-    stray: 1.12,
-    detail: {
-      bumpMultiplier: 1.14,
-      sheen: 0.72,
-      sheenRoughness: 0.5,
-      emissiveIntensity: 0.36,
-      envMapIntensity: 0.16
-    },
-    greens: CABAN_GREEN_SWATCHES,
-    blues: CABAN_OCEAN_BLUE_SWATCHES
-  },
-  {
-    prefix: 'polarFleeceNatureOcean',
-    label: 'Polar Fleece Nature & Ocean',
-    sourceId: 'polar_fleece',
-    basePrice: 660,
-    priceStep: 10,
-    bluePremium: 20,
-    sparkle: 1.1,
-    stray: 1.08,
-    detail: {
-      bumpMultiplier: 1.16,
-      sheen: 0.68,
-      sheenRoughness: 0.5,
-      emissiveIntensity: 0.34,
-      envMapIntensity: 0.15
-    },
-    greens: CABAN_GREEN_SWATCHES,
-    blues: CABAN_OCEAN_BLUE_SWATCHES,
-    greenShadeNames: NATURE_SHADE_NAMES,
-    blueShadeNames: OCEAN_SHADE_NAMES
-  },
-  {
-    prefix: 'terryCloth',
-    label: 'Polyhaven Terry Cloth',
-    sourceId: 'terry_cloth',
-    basePrice: 740,
-    priceStep: 12,
-    bluePremium: 22,
-    sparkle: 1.05,
-    stray: 1.08,
-    detail: {
-      bumpMultiplier: 1.24,
-      sheen: 0.54,
-      sheenRoughness: 0.58,
-      emissiveIntensity: 0.26,
-      envMapIntensity: 0.17
-    },
-    greens: CABAN_GREEN_SWATCHES,
-    blues: CABAN_OCEAN_BLUE_SWATCHES
+    detail: CABAN_DETAIL,
+    thumbnail: polyHavenThumb(CABAN_SOURCE_ID),
+    price,
+    swatches: createSwatches(shade.hex),
+    description:
+      `${CABAN_LABEL} cloth in ${label.toLowerCase()} (${shade.name.toLowerCase()}) using the original ` +
+      'Poly Haven Caban glTF texture mapping.'
   }
-];
-
-const createVariantsForMaterial = (material) => {
-  const buildTone = (toneKey, palette) =>
-    palette.map((hex, index) => {
-      const shadeNames =
-        toneKey === 'green'
-          ? material.greenShadeNames || GREEN_SHADE_NAMES
-          : material.blueShadeNames || BLUE_SHADE_NAMES;
-      const name = shadeNames[index] || `${toneKey}-${index + 1}`;
-      const toneLabel = toneKey === 'green' ? 'Green' : 'Blue';
-      const id = `${material.prefix}${toneLabel}${name}`;
-      const price = material.basePrice + (toneKey === 'blue' ? material.bluePremium || 0 : 0) + material.priceStep * index;
-      return {
-        id,
-        name: `${material.label} — ${toneLabel} ${name}`,
-        sourceId: material.sourceId,
-        tone: toneKey,
-        baseColor: toNumber(hex),
-        palette: buildPalette(hex),
-        sparkle: material.sparkle,
-        stray: material.stray,
-        detail: material.detail,
-        thumbnail: polyHavenThumb(material.sourceId),
-        price,
-        swatches: createSwatches(hex),
-        description: `${material.label} cloth with a ${toneLabel.toLowerCase()} ${name.toLowerCase()} tint and detailed scan from ${material.sourceId}.`
-      };
-    });
-
-  return [
-    ...buildTone('green', material.greens),
-    ...buildTone('blue', material.blues)
-  ];
-};
+}
 
 export const POOL_ROYALE_CLOTH_VARIANTS = Object.freeze(
-  MATERIAL_SERIES.flatMap((material) => createVariantsForMaterial(material))
-);
+  CABAN_SHADE_GROUPS.flatMap((group, groupIndex) =>
+    group.shades.map((shade, index) =>
+      createCabanVariant({
+        tone: group.tone,
+        label: group.label,
+        shade,
+        index,
+        groupIndex
+      })
+    )
+  )
+)

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -22313,7 +22313,21 @@ const powerRef = useRef(hud.power);
           if (replayPlaybackRef.current) return;
           if (!shotRecording || !shotRecording.frames?.length) return;
           const trimmed = trimReplayRecording(shotRecording);
-          const duration = trimmed.duration;
+          const replayFrames = Array.isArray(trimmed.frames) ? [...trimmed.frames] : [];
+          const fallbackFrameTime = Math.max(16, shotRecording.frameTimeMs ?? 1000 / 60);
+          if (replayFrames.length === 1) {
+            replayFrames.push({
+              ...replayFrames[0],
+              t: Math.max(fallbackFrameTime, replayFrames[0]?.t ?? 0)
+            });
+          }
+          const duration =
+            replayFrames.length > 1
+              ? Math.max(
+                  Number.isFinite(trimmed.duration) ? trimmed.duration : 0,
+                  replayFrames[replayFrames.length - 1]?.t ?? 0
+                )
+              : trimmed.duration;
           if (!Number.isFinite(duration) || duration <= 0) return;
           cueStrokeStateRef.current = null;
           pendingImpactRef.current = null;
@@ -22360,7 +22374,7 @@ const powerRef = useRef(hud.power);
           const slowExtraDuration =
             hasWrongBallSlowImpact && slowSpan > 0 ? slowSpan * (1 / slowFactor - 1) : 0;
           replayPlayback = {
-            frames: trimmed.frames,
+            frames: replayFrames,
             cuePath: trimmed.cuePath,
             cueStroke: replayCueStroke,
             duration,


### PR DESCRIPTION
### Motivation
- Prevent Pool Royale replay startup from aborting when a shot recording contains a single frame and the computed duration is zero. 
- Standardize the Pool Royale cloth inventory to use the original Poly Haven Caban mapping and provide a compact set of required color variants (three brightness levels across four tones). 

### Description
- Add defensive replay normalization in `webapp/src/pages/Games/PoolRoyale.jsx` that synthesizes a second frame when only one frame exists, computes duration from normalized frame timestamps, and uses `replayFrames` for playback so replays no longer exit early. 
- Replace the cloth catalog at `webapp/src/config/poolRoyaleClothPresets.js` with a Caban-only lineup that generates 12 variants (3 blue, 3 green, 3 beige, 3 dark grey) while preserving Poly Haven thumbnail mapping via `polyHavenThumb`. 
- Apply small formatting/lint fixes to the new cloth presets file to match project linting conventions. 

### Testing
- Ran unit tests with `npx jest test/poolRoyaleCueStrokeTimeline.test.js --runInBand` and the suite passed (4 tests, 0 failures). 
- Ran lint/auto-fix with `npx eslint --no-ignore webapp/src/config/poolRoyaleClothPresets.js --fix` and applied fixes to the new presets file. 
- Verified the generated cloth catalog by importing the module with Node and confirming `POOL_ROYALE_CLOTH_VARIANTS.length === 12` and the `sourceId` set to `['caban']`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfb49e8b1c8329a7e42652e38b5ee6)