### PR TITLE
Fix GLTF table/chair texture handling for Texas & Murlan arenas

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1419,10 +1419,16 @@ async function createPolyhavenInstance(
 
 function buildPolyhavenModelUrls(assetId) {
   if (!assetId) return [];
-  return [
-    `https://dl.polyhaven.org/file/ph-assets/Models/gltf/2k/${assetId}/${assetId}_2k.gltf`,
-    `https://dl.polyhaven.org/file/ph-assets/Models/gltf/1k/${assetId}/${assetId}_1k.gltf`
-  ];
+  const ids = Array.from(new Set([assetId, assetId?.toLowerCase?.()]));
+  const urls = [];
+  ids.forEach((id) => {
+    if (!id) return;
+    urls.push(
+      `https://dl.polyhaven.org/file/ph-assets/Models/gltf/2k/${id}/${id}_2k.gltf`,
+      `https://dl.polyhaven.org/file/ph-assets/Models/gltf/1k/${id}/${id}_1k.gltf`
+    );
+  });
+  return urls;
 }
 
 function shouldPreserveChairMaterials(theme) {

--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -1059,7 +1059,33 @@ function createConfiguredGLTFLoader(renderer = null, manager = undefined) {
   return loader;
 }
 
-function prepareLoadedModel(model) {
+function normalizePbrTexture(texture, maxAnisotropy = 1) {
+  if (!texture) return;
+  texture.flipY = false;
+  texture.wrapS = texture.wrapS ?? THREE.RepeatWrapping;
+  texture.wrapT = texture.wrapT ?? THREE.RepeatWrapping;
+  texture.anisotropy = Math.max(texture.anisotropy ?? 1, maxAnisotropy);
+  texture.needsUpdate = true;
+}
+
+function normalizeMaterialTextures(material, maxAnisotropy = 1) {
+  if (!material) return;
+  if (material.map) {
+    applySRGBColorSpace(material.map);
+    normalizePbrTexture(material.map, maxAnisotropy);
+  }
+  if (material.emissiveMap) {
+    applySRGBColorSpace(material.emissiveMap);
+    normalizePbrTexture(material.emissiveMap, maxAnisotropy);
+  }
+  normalizePbrTexture(material.normalMap, maxAnisotropy);
+  normalizePbrTexture(material.roughnessMap, maxAnisotropy);
+  normalizePbrTexture(material.metalnessMap, maxAnisotropy);
+  normalizePbrTexture(material.aoMap, maxAnisotropy);
+}
+
+function prepareLoadedModel(model, options = {}) {
+  const { preserveGltfTextureMapping = false, maxAnisotropy = 8 } = options;
   model.traverse((obj) => {
     if (obj.isMesh) {
       obj.castShadow = true;
@@ -1067,8 +1093,13 @@ function prepareLoadedModel(model) {
       const mats = Array.isArray(obj.material) ? obj.material : [obj.material];
       mats.forEach((mat) => {
         if (!mat) return;
-        if (mat.map) applySRGBColorSpace(mat.map);
-        if (mat.emissiveMap) applySRGBColorSpace(mat.emissiveMap);
+        if (preserveGltfTextureMapping) {
+          normalizeMaterialTextures(mat, maxAnisotropy);
+        } else {
+          if (mat.map) applySRGBColorSpace(mat.map);
+          if (mat.emissiveMap) applySRGBColorSpace(mat.emissiveMap);
+        }
+        mat.needsUpdate = true;
       });
     }
   });
@@ -1228,7 +1259,7 @@ async function loadPolyhavenModel(assetId, renderer = null) {
 
       const model = gltf.scene || gltf.scenes?.[0] || gltf;
       if (!model) throw new Error(`Poly Haven model missing scene for ${assetId}`);
-      prepareLoadedModel(model);
+      prepareLoadedModel(model, { preserveGltfTextureMapping: true });
       return model;
     })();
 
@@ -1240,7 +1271,8 @@ async function loadPolyhavenModel(assetId, renderer = null) {
   return baseModel.clone(true);
 }
 
-const shouldPreserveChairMaterials = (theme) => Boolean(theme?.preserveMaterials || theme?.source === 'polyhaven');
+const shouldPreserveChairMaterials = (theme) =>
+  Boolean(theme?.preserveMaterials || theme?.source === 'polyhaven' || theme?.source === 'gltf');
 
 async function buildTableForTheme({
   arena,
@@ -1648,8 +1680,7 @@ function extractChairMaterials(model) {
       const mats = Array.isArray(obj.material) ? obj.material : [obj.material];
       mats.forEach((mat) => {
         if (!mat) return;
-        if (mat.map) applySRGBColorSpace(mat.map);
-        if (mat.emissiveMap) applySRGBColorSpace(mat.emissiveMap);
+        normalizeMaterialTextures(mat);
         const bucket = (mat.metalness ?? 0) > 0.35 ? metal : upholstery;
         bucket.add(mat);
       });
@@ -1687,17 +1718,7 @@ async function loadGltfChair(renderer = null) {
     throw new Error('Chair model missing scene');
   }
 
-  model.traverse((obj) => {
-    if (obj.isMesh) {
-      obj.castShadow = true;
-      obj.receiveShadow = true;
-      const mats = Array.isArray(obj.material) ? obj.material : [obj.material];
-      mats.forEach((mat) => {
-        if (mat?.map) applySRGBColorSpace(mat.map);
-        if (mat?.emissiveMap) applySRGBColorSpace(mat.emissiveMap);
-      });
-    }
-  });
+  prepareLoadedModel(model, { preserveGltfTextureMapping: true });
 
   fitChairModelToFootprint(model);
 


### PR DESCRIPTION
### Motivation
- Imported GLTF/PolyHaven table and chair assets sometimes had incorrect texture settings (color space, `flipY`, wrapping, anisotropy) causing visual issues; the Ludo Battle Royal flow already handled this correctly and needs to be reused for Texas Hold'em and Murlan arenas.

### Description
- Added `normalizePbrTexture` and `normalizeMaterialTextures` helpers and extended `prepareLoadedModel` with a `preserveGltfTextureMapping` option to centralize texture normalization for GLTF imports in `TexasHoldemArena`.
- Updated chair/table loading paths in `webapp/src/pages/Games/TexasHoldemArena.jsx` to call `prepareLoadedModel(..., { preserveGltfTextureMapping: true })` when preserving original materials and to normalize chair materials before bucketing.
- Broadened the “preserve original materials” detection to include `source === 'gltf'` so GLTF-sourced themes preserve material behavior like PolyHaven assets.
- Improved PolyHaven model URL generation in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to try both original and lowercase asset IDs (resilient candidates), which helps avoid failures due to casing differences when loading table/chair models.

### Testing
- Ran the project build with `npm run -s build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfcc554de08329962883fca7f24a17)