### PR TITLE
Normalize GLTF/PBR textures for tables and chairs in TexasHoldem and Murlan arenas

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -845,6 +845,8 @@ function prepareLoadedModel(model, options = {}) {
         } else {
           if (mat.map) applySRGBColorSpace(mat.map);
           if (mat.emissiveMap) applySRGBColorSpace(mat.emissiveMap);
+          normalizePbrTexture(mat.map, maxAnisotropy);
+          normalizePbrTexture(mat.emissiveMap, maxAnisotropy);
         }
         mat.needsUpdate = true;
       });

--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -1059,6 +1059,31 @@ function createConfiguredGLTFLoader(renderer = null, manager = undefined) {
   return loader;
 }
 
+function normalizePbrTexture(texture, maxAnisotropy = 1) {
+  if (!texture) return;
+  texture.flipY = false;
+  texture.wrapS = texture.wrapS ?? THREE.RepeatWrapping;
+  texture.wrapT = texture.wrapT ?? THREE.RepeatWrapping;
+  texture.anisotropy = Math.max(texture.anisotropy ?? 1, maxAnisotropy);
+  texture.needsUpdate = true;
+}
+
+function normalizeMaterialTextures(material, maxAnisotropy = 8) {
+  if (!material) return;
+  if (material.map) {
+    applySRGBColorSpace(material.map);
+    normalizePbrTexture(material.map, maxAnisotropy);
+  }
+  if (material.emissiveMap) {
+    applySRGBColorSpace(material.emissiveMap);
+    normalizePbrTexture(material.emissiveMap, maxAnisotropy);
+  }
+  normalizePbrTexture(material.normalMap, maxAnisotropy);
+  normalizePbrTexture(material.roughnessMap, maxAnisotropy);
+  normalizePbrTexture(material.metalnessMap, maxAnisotropy);
+  normalizePbrTexture(material.aoMap, maxAnisotropy);
+}
+
 function prepareLoadedModel(model) {
   model.traverse((obj) => {
     if (obj.isMesh) {
@@ -1066,9 +1091,10 @@ function prepareLoadedModel(model) {
       obj.receiveShadow = true;
       const mats = Array.isArray(obj.material) ? obj.material : [obj.material];
       mats.forEach((mat) => {
-        if (!mat) return;
-        if (mat.map) applySRGBColorSpace(mat.map);
-        if (mat.emissiveMap) applySRGBColorSpace(mat.emissiveMap);
+        normalizeMaterialTextures(mat);
+        if (mat) {
+          mat.needsUpdate = true;
+        }
       });
     }
   });


### PR DESCRIPTION
### Motivation
- GLTF-loaded table and chair materials could have inconsistent orientation, wrapping, anisotropy and color-space handling which produced incorrect visuals for tables/chairs across arenas. 
- The Battle Royale flow already normalizes GLTF/PBR textures; the Texas Hold’em and Murlan arenas needed the same normalization to match visual behavior.

### Description
- Added `normalizePbrTexture` and `normalizeMaterialTextures` helpers and wired them into `prepareLoadedModel` in `webapp/src/pages/Games/TexasHoldemArena.jsx` so every material map/emissive/PBR map gets consistent `flipY`, wrapping, `anisotropy` and sRGB handling.
- Updated `prepareLoadedModel` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to normalize `map` and `emissiveMap` with `normalizePbrTexture` even when `preserveGltfTextureMapping` is false, ensuring consistent sampling/orientation for PolyHaven/gltf table and chair assets.
- Changes touch the GLTF load/prepare pipeline used when building tables and `chairTemplate` so procedural fallbacks and cloned models receive the same normalization.

### Testing
- Ran lint on the touched files with `npx eslint webapp/src/pages/Games/TexasHoldemArena.jsx webapp/src/pages/Games/MurlanRoyaleArena.jsx`, which completed but reported the files are ignored by project ESLint rules (warnings only).
- Ran targeted unit tests with `npm test -- test/murlan.test.js test/texasHoldemGame.test.js --runInBand` and both test suites passed (all tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfcc554de08329962883fca7f24a17)