### PR TITLE
Domino: add diamond/oval procedural tables, tighten table sides, adaptive textures, and fix avatar video anchoring

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -1479,8 +1479,9 @@ const dimIntensity = (value = 1) => value * LIGHT_INTENSITY_FACTOR;
 
 const MODEL_SCALE = 0.75;
 const TABLE_SCALE = 0.95;
+const TABLE_SIDE_SHRINK = 0.93;
 const ARENA_GROWTH = 1.45;
-const TABLE_RADIUS = 3.4 * MODEL_SCALE * TABLE_SCALE;
+const TABLE_RADIUS = 3.4 * MODEL_SCALE * TABLE_SCALE * TABLE_SIDE_SHRINK;
 const BASE_TABLE_HEIGHT = 1.08 * MODEL_SCALE * TABLE_SCALE;
 const STOOL_SCALE = 1.5 * 1.38;
 const SEAT_WIDTH = 0.9 * MODEL_SCALE * STOOL_SCALE;
@@ -2503,6 +2504,12 @@ const MURLAN_TABLE_THEMES = Object.freeze(
   })
 );
 
+const PROCEDURAL_TABLE_SHAPES = Object.freeze({
+  octagon: 'octagon',
+  diamondEdge: 'diamond-edge',
+  oval: 'oval'
+});
+
 const CHAIR_THEME_OPTIONS = Object.freeze(
   MURLAN_STOOL_THEMES.map((theme, idx) => ({
     ...theme,
@@ -3496,6 +3503,8 @@ function applyWoodTextures(
 ) {
   if (!material) return null;
   disposeWoodTextures(material);
+  const effectiveTextureSize = getAdaptiveTextureSize(textureSize);
+  const effectiveRoughnessSize = getAdaptiveTextureSize(roughnessSize);
   const repeatVec = new THREE.Vector2(repeat?.x ?? 1, repeat?.y ?? 1);
   let map = null;
   let roughnessMap = null;
@@ -3506,24 +3515,24 @@ function applyWoodTextures(
           sat,
           light,
           contrast,
-          textureSize,
-          roughnessSize,
+          textureSize: effectiveTextureSize,
+          roughnessSize: effectiveRoughnessSize,
           roughnessBase,
           roughnessVariance,
           sharedKey
         })
       : {
           map: makeNaturalWoodTexture(
-            textureSize,
-            textureSize,
+            effectiveTextureSize,
+            effectiveTextureSize,
             hue,
             sat,
             light,
             contrast
           ),
           roughnessMap: makeRoughnessMap(
-            roughnessSize,
-            roughnessSize,
+            effectiveRoughnessSize,
+            effectiveRoughnessSize,
             roughnessBase,
             roughnessVariance
           )
@@ -3904,10 +3913,30 @@ const POOL_ROYALE_HDRI_VARIANTS = Object.freeze([
   }
 ]);
 
-const TABLE_THEME_OPTIONS = MURLAN_TABLE_THEMES.map((theme) => ({
-  ...theme,
-  label: theme.label || theme.name || theme.id
-}));
+const TABLE_THEME_OPTIONS = Object.freeze([
+  ...MURLAN_TABLE_THEMES.map((theme) => ({
+    ...theme,
+    label: theme.label || theme.name || theme.id
+  })),
+  {
+    id: PROCEDURAL_TABLE_SHAPES.diamondEdge,
+    label: 'Diamond Edge Table',
+    source: 'procedural',
+    assetId: null,
+    price: 0,
+    thumbnail: POLYHAVEN_THUMB('CoffeeTable_01'),
+    description: 'Procedural diamond-edge table shape shared with Texas Holdem.'
+  },
+  {
+    id: PROCEDURAL_TABLE_SHAPES.oval,
+    label: 'Oval Table',
+    source: 'procedural',
+    assetId: null,
+    price: 0,
+    thumbnail: POLYHAVEN_THUMB('coffee_table_round_01'),
+    description: 'Procedural oval table shape shared with Texas Holdem.'
+  }
+]);
 const DEFAULT_TABLE_THEME_OPTION = TABLE_THEME_OPTIONS[0] || null;
 const ENVIRONMENT_HDRI_OPTIONS = POOL_ROYALE_HDRI_VARIANTS.map((variant) => ({
   ...variant,
@@ -4210,9 +4239,13 @@ const TABLE_SETUP_SECTIONS = [
 
 const TABLE_FINISH_THEMES = new Set([
   'murlan-default',
+  'octagon',
   'diamond-edge',
   'diamond_edge',
-  'diamondEdge'
+  'diamondEdge',
+  'oval',
+  'oval-table',
+  'ovalTable'
 ]);
 
 function isTableFinishTheme(themeId = '') {
@@ -4227,7 +4260,9 @@ function getVisibleTableSetupSections() {
     TABLE_THEME_OPTIONS[appearance.tableTheme] ?? DEFAULT_TABLE_THEME_OPTION;
   const showTableFinish = isTableFinishTheme(selectedTheme?.id);
   return TABLE_SETUP_SECTIONS.filter((section) =>
-    section.key === 'tableWood' ? showTableFinish : true
+    section.key === 'tableWood' || section.key === 'tableCloth'
+      ? showTableFinish
+      : true
   );
 }
 
@@ -4274,6 +4309,15 @@ function resolveDefaultOptionId(key, options = []) {
 const DOMINO_DEFAULT_UNLOCKS = Object.freeze(
   Object.entries(DOMINO_OPTIONS_BY_KEY).reduce((acc, [key, options]) => {
     const defaultId = resolveDefaultOptionId(key, options);
+    if (key === 'tableTheme') {
+      const defaults = [
+        defaultId,
+        PROCEDURAL_TABLE_SHAPES.diamondEdge,
+        PROCEDURAL_TABLE_SHAPES.oval
+      ].filter(Boolean);
+      acc[key] = Array.from(new Set(defaults));
+      return acc;
+    }
     acc[key] = defaultId ? [defaultId] : [];
     return acc;
   }, {})
@@ -5809,7 +5853,9 @@ function makeClothTexture({
   bottom = '#0b3a1d',
   border = '#041f10'
 } = {}) {
-  const size = 1024;
+  const size = getAdaptiveTextureSize(
+    MURLAN_3D_ASSET_RESOLUTION.tableClothTextureSize
+  );
   const canvas = document.createElement('canvas');
   canvas.width = canvas.height = size;
   const ctx = canvas.getContext('2d');
@@ -6016,8 +6062,18 @@ async function applyTableTheme(
   option = TABLE_THEME_OPTIONS[appearance.tableTheme] ?? DEFAULT_TABLE_THEME_OPTION
 ) {
   const theme = option || DEFAULT_TABLE_THEME_OPTION;
-  const useOctagonRotation = theme?.id === 'murlan-default';
+  const themeId = String(theme?.id || '').toLowerCase();
+  const isProceduralTheme = !theme?.assetId;
+  const proceduralShapeId = themeId.includes('diamond')
+    ? PROCEDURAL_TABLE_SHAPES.diamondEdge
+    : themeId.includes('oval')
+      ? PROCEDURAL_TABLE_SHAPES.oval
+      : PROCEDURAL_TABLE_SHAPES.octagon;
+  const useOctagonRotation = proceduralShapeId === PROCEDURAL_TABLE_SHAPES.octagon;
   tableThemeG.rotation.y = useOctagonRotation
+    ? TABLE_OCTAGON_ROTATION
+    : NON_OCTAGON_TABLE_ROTATION;
+  proceduralTableG.rotation.y = useOctagonRotation
     ? TABLE_OCTAGON_ROTATION
     : NON_OCTAGON_TABLE_ROTATION;
   tableThemeG.visible = false;
@@ -6027,8 +6083,9 @@ async function applyTableTheme(
     child?.removeFromParent?.();
   }
   const token = ++tableThemeToken;
-  if (!theme?.assetId) {
+  if (isProceduralTheme) {
     activeTableThemeId = null;
+    buildProceduralTable(proceduralShapeId);
     setProceduralTableVisible(true);
     return;
   }
@@ -6458,11 +6515,52 @@ const TABLE_BASE_Y = TABLE_HEIGHT - TABLE_TOP_DEPTH;
 const CLOTH_TOP = TABLE_HEIGHT;
 const RAIL_TOP = CLOTH_TOP + 0.04 * MODEL_SCALE;
 
-(function buildTable() {
-  const sides = 8;
-  const topShape = createRegularPolygonShape(sides, TABLE_OUTER_RADIUS);
-  const feltShape = createRegularPolygonShape(sides, CLOTH_RADIUS);
-  const rimInnerShape = createRegularPolygonShape(sides, TABLE_INNER_RADIUS);
+function clearProceduralTableMeshes() {
+  proceduralTableParts.forEach((mesh) => {
+    if (!mesh) return;
+    proceduralTableG.remove(mesh);
+    mesh.geometry?.dispose?.();
+  });
+  proceduralTableParts.length = 0;
+}
+
+function createOvalShape(radiusX, radiusY) {
+  const shape = new THREE.Shape();
+  shape.absellipse(0, 0, radiusX, radiusY, 0, Math.PI * 2, false, 0);
+  shape.closePath();
+  return shape;
+}
+
+function createProceduralTableShapes(shapeId = PROCEDURAL_TABLE_SHAPES.octagon) {
+  const normalized = String(shapeId || '').toLowerCase();
+  if (normalized.includes('diamond')) {
+    return {
+      topShape: createRegularPolygonShape(4, TABLE_OUTER_RADIUS),
+      feltShape: createRegularPolygonShape(4, CLOTH_RADIUS),
+      rimInnerShape: createRegularPolygonShape(4, TABLE_INNER_RADIUS)
+    };
+  }
+  if (normalized.includes('oval')) {
+    return {
+      topShape: createOvalShape(TABLE_OUTER_RADIUS * 1.12, TABLE_OUTER_RADIUS * 0.8),
+      feltShape: createOvalShape(CLOTH_RADIUS * 1.12, CLOTH_RADIUS * 0.8),
+      rimInnerShape: createOvalShape(TABLE_INNER_RADIUS * 1.12, TABLE_INNER_RADIUS * 0.8)
+    };
+  }
+  return {
+    topShape: createRegularPolygonShape(8, TABLE_OUTER_RADIUS),
+    feltShape: createRegularPolygonShape(8, CLOTH_RADIUS),
+    rimInnerShape: createRegularPolygonShape(8, TABLE_INNER_RADIUS)
+  };
+}
+
+function buildProceduralTable(
+  shapeId = PROCEDURAL_TABLE_SHAPES.octagon
+) {
+  clearProceduralTableMeshes();
+  const { topShape, feltShape, rimInnerShape } = createProceduralTableShapes(
+    shapeId
+  );
 
   const topShapeWithHole = topShape.clone();
   topShapeWithHole.holes.push(feltShape);
@@ -6543,7 +6641,9 @@ const RAIL_TOP = CLOTH_TOP + 0.04 * MODEL_SCALE;
   proceduralTableParts.push(column);
 
   // Base and trim intentionally omitted to remove the oversized pedestal.
-})();
+}
+
+buildProceduralTable(PROCEDURAL_TABLE_SHAPES.octagon);
 
 const SCALE = MODEL_SCALE * 0.92;
 const DOMINO_SCALE = 1.5 * 1.22; // upscale tiles for stronger readability
@@ -7087,6 +7187,7 @@ function applyFrameRateSelection(
     ENVIRONMENT_HDRI_OPTIONS[appearance.environmentHdri] ??
       ENVIRONMENT_HDRI_OPTIONS[0]
   );
+  updateTableMaterials();
   applyDominoStyle(currentDominoStyleOption);
   buildChairs(
     CHAIR_THEME_OPTIONS[appearance.chairTheme] ?? DEFAULT_CHAIR_THEME

--- a/webapp/src/components/GameLiveAvatarOverlay.jsx
+++ b/webapp/src/components/GameLiveAvatarOverlay.jsx
@@ -3,6 +3,9 @@ import { useLocation } from 'react-router-dom';
 import useLiveVideoChat from '../hooks/useLiveVideoChat.js';
 
 const AVATAR_ANCHOR_SELECTORS = [
+  '.seat-badge.is-self .seat-badge-core',
+  '.seat-badge.is-self .seat-badge-avatar',
+  '.seat-badge.is-self',
   '[data-self-player="true"] .seat-badge-core',
   '[data-self-player="true"] .score-avatar',
   '[data-self-player="true"] .avatar-timer-avatar',
@@ -127,6 +130,13 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
       if (marker.includes('you')) score += 80;
       if (rect.top > window.innerHeight * 0.45) score += 25;
       if (rect.left < window.innerWidth * 0.65) score += 15;
+      if (gameSlug === 'domino-royal') {
+        // Keep local avatar frame anchored to the player's bottom seat,
+        // never to incidental top-left UI nodes.
+        if (rect.top > window.innerHeight * 0.52) score += 140;
+        if (rect.top < window.innerHeight * 0.35) score -= 220;
+        if (rect.left < window.innerWidth * 0.2) score -= 35;
+      }
       score += Math.min(rect.width, rect.height);
       return score;
     };
@@ -166,6 +176,9 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
     const applyRect = () => {
       const { rect, node } = findAvatarAnchor();
       if (!rect) return;
+      if (gameSlug === 'domino-royal' && rect.top < window.innerHeight * 0.35) {
+        return;
+      }
       const avatarDiameter = Math.min(rect.width, rect.height);
       const frameDiameter = Math.max(Math.round(avatarDiameter * FRAME_SCALE), 32);
       const width = frameDiameter;

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-04-03-domino-table-alignment-v8';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-04-03-domino-table-shapes-v9';
 
 export default function DominoRoyalArena() {
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- Narrow the Domino table horizontally (preserve height) to better fit portrait screens and player hands. 
- Prevent the local live-avatar video frame from snapping to incidental UI nodes (top-left) and ensure it stays anchored to the player's bottom seat. 
- Expose Diamond Edge and Oval procedural table shapes and only show table finish/cloth options when the selected table shape supports them, while matching table cloth/wood quality to graphics settings.

### Description
- Introduced `TABLE_SIDE_SHRINK` and applied it to `TABLE_RADIUS` to reduce side footprint without changing vertical dimensions in `webapp/public/domino-royal-game.js`.
- Added `PROCEDURAL_TABLE_SHAPES`, appended `diamond-edge` and `oval` procedural themes to `TABLE_THEME_OPTIONS`, included them in default unlocks, and implemented `createOvalShape`, `createProceduralTableShapes`, `buildProceduralTable`, and `clearProceduralTableMeshes` so procedural geometry rebuilds per selected shape.
- Made cloth and wood texture generation graphics-aware by using `getAdaptiveTextureSize` in `makeClothTexture` and `applyWoodTextures`, and ensured `updateTableMaterials()` is invoked when graphics/profile changes (frame-rate selection) to refresh materials.
- Restricted config menu visibility so `tableWood` and `tableCloth` sections appear only for table themes considered finish-capable (octagon/diamond/oval) via `getVisibleTableSetupSections` and `TABLE_FINISH_THEMES` updates.
- Fixed live avatar overlay anchoring in `webapp/src/components/GameLiveAvatarOverlay.jsx` by adding `.seat-badge.is-self` selectors and Domino-specific scoring/guard logic so the video frame prefers the bottom self seat and rejects anchors that are too high or in the top-left.
- Bumped `DOMINO_ROYAL_SCRIPT_VERSION` in `webapp/src/pages/Games/DominoRoyalArena.jsx` to ensure clients load the updated runtime.

### Testing
- Built the web app with `npm --prefix webapp run build` and the production build completed successfully (Vite emitted non-blocking chunk-size/dynamic-import warnings only). 
- Ran ESLint on the changed files via `npx eslint webapp/src/components/GameLiveAvatarOverlay.jsx webapp/public/domino-royal-game.js` which produced warnings only (files are ignored by repo patterns) and no errors. 
- Verified that the updated Domino script file and the `DOMINO_ROYAL_SCRIPT_VERSION` change were included in the generated build artifacts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfd8b9bb448329bd465007631a3812)