### PR TITLE
Murlan Royale: ground tables & chairs, add Diamond/Oval table shapes, preserve PolyHaven textures, trim table width

### DIFF
--- a/webapp/src/config/murlanThemes.js
+++ b/webapp/src/config/murlanThemes.js
@@ -167,9 +167,28 @@ export const MURLAN_TABLE_THEMES = [
     id: 'murlan-default',
     label: 'Octagon Table',
     source: 'procedural',
+    shapeId: 'classicOctagon',
     price: 0,
     thumbnail: polyHavenThumb('CoffeeTable_01'),
     description: 'Standard Murlan Royale table with a streamlined, pedestal-free setup.'
+  },
+  {
+    id: 'diamondEdge',
+    label: 'Diamond Edge Table',
+    source: 'procedural',
+    shapeId: 'diamondEdge',
+    price: 320,
+    thumbnail: swatchThumbnail(['#1f2937', '#0f172a', '#a855f7']),
+    description: 'Diamond-edge geometry matching the Texas Hold’em table collection.'
+  },
+  {
+    id: 'ovalTable',
+    label: 'Oval Table',
+    source: 'procedural',
+    shapeId: 'grandOval',
+    price: 340,
+    thumbnail: swatchThumbnail(['#0b1220', '#111827', '#f97316']),
+    description: 'Smooth oval table profile matching the Texas Hold’em table collection.'
   },
   ...POLYHAVEN_TABLE_THEMES
 ];

--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -16,7 +16,7 @@ import { clone as cloneSkeleton } from 'three/examples/jsm/utils/SkeletonUtils.j
 import { EXRLoader } from 'three/examples/jsm/loaders/EXRLoader.js';
 import { applyRendererSRGB, applySRGBColorSpace } from '../../utils/colorSpace.js';
 import { ARENA_CAMERA_DEFAULTS, buildArenaCameraConfig } from '../../utils/arenaCameraConfig.js';
-import { applyTableMaterials, createMurlanStyleTable } from '../../utils/murlanTable.js';
+import { applyTableMaterials, createMurlanStyleTable, TABLE_SHAPE_OPTIONS } from '../../utils/murlanTable.js';
 import { CARD_THEMES } from '../../utils/cards3d.js';
 import { makeTonplaygramCardBackTexture } from '../../utils/cards3d.js';
 import { chatBeep, bombSound } from '../../assets/soundData.js';
@@ -103,7 +103,7 @@ const ENABLE_3D_HUMAN_CHARACTERS = false;
 const ARENA_GROWTH = 1.45; // expanded arena footprint for wider walkways
 const CHAIR_SIZE_SCALE = 1;
 
-const TABLE_RADIUS = 3.4 * MODEL_SCALE;
+const TABLE_RADIUS = 3.25 * MODEL_SCALE;
 const CHAIR_COUNT = 4;
 const CUSTOM_SEAT_ANGLES = [
   THREE.MathUtils.degToRad(90),
@@ -1193,6 +1193,15 @@ const CUSTOMIZATION_SECTIONS = [
     ? [{ key: 'characters', label: '3D Players', options: MURLAN_CHARACTER_THEMES }]
     : [])
 ];
+const TABLE_MENU_STYLE_IDS = new Set(['murlan-default', 'diamondEdge', 'ovalTable']);
+const TABLE_SHAPE_BY_ID = new Map(TABLE_SHAPE_OPTIONS.map((option) => [option.id, option]));
+const resolveProceduralShapeForTheme = (tableTheme) => {
+  const shapeId = tableTheme?.shapeId || (tableTheme?.id === 'murlan-default' ? 'classicOctagon' : null);
+  if (!shapeId) {
+    return TABLE_SHAPE_OPTIONS[0];
+  }
+  return TABLE_SHAPE_BY_ID.get(shapeId) || TABLE_SHAPE_OPTIONS[0];
+};
 
 function createRegularPolygonShape(sides = 8, radius = 1) {
   const shape = new THREE.Shape();
@@ -2117,7 +2126,7 @@ async function buildChairTemplate(theme, renderer = null, textureOptions = {}) {
       const polyhavenRoot = await loadPolyhavenModel(theme.assetId, renderer);
       const model = polyhavenRoot.clone(true);
       prepareLoadedModel(model, { preserveGltfTextureMapping: preserveMaterials, maxAnisotropy });
-      if (textureLoader) {
+      if (textureLoader && !preserveMaterials) {
         try {
           const textures = await loadPolyhavenTextureSet(
             theme.assetId,
@@ -2594,8 +2603,8 @@ export default function MurlanRoyaleArena({ search }) {
   }, [seatAnchors]);
 
   const customizationSections = useMemo(() => {
-    const tableTheme = TABLE_THEMES[appearance.tables] ?? TABLE_THEMES[0];
-    const allowTableFinish = tableTheme?.source === 'procedural';
+      const tableTheme = TABLE_THEMES[appearance.tables] ?? TABLE_THEMES[0];
+    const allowTableFinish = TABLE_MENU_STYLE_IDS.has(tableTheme?.id);
     return CUSTOMIZATION_SECTIONS.map((section) => ({
       ...section,
       options: section.options
@@ -3749,7 +3758,8 @@ export default function MurlanRoyaleArena({ search }) {
           renderer: three.renderer,
           tableRadius: TABLE_RADIUS,
           tableHeight: TABLE_HEIGHT,
-          includeBase: false,
+          includeBase: true,
+          shapeOption: resolveProceduralShapeForTheme(theme),
           woodOption: finish?.woodOption || undefined,
           clothOption: cloth || undefined
         });
@@ -4644,7 +4654,7 @@ export default function MurlanRoyaleArena({ search }) {
         const seatRadius = (isHumanSeat ? chairRadius : AI_CHAIR_RADIUS) * CHAIR_SEAT_INWARD_FACTOR;
         const x = Math.cos(angle) * seatRadius;
         const z = Math.sin(angle) * seatRadius;
-        const chairBaseHeight = CHAIR_BASE_HEIGHT - 0.04 * MODEL_SCALE;
+        const chairBaseHeight = 0;
         chair.position.set(x, chairBaseHeight, z);
         chair.lookAt(new THREE.Vector3(0, chairBaseHeight, 0));
         arenaGroup.add(chair);

--- a/webapp/src/utils/murlanTable.js
+++ b/webapp/src/utils/murlanTable.js
@@ -541,7 +541,7 @@ export function createMurlanStyleTable({
   const clothRise = 0.07 * scaleFactor;
   let baseHeight = 0.66 * scaleFactor;
   const tableY = tableHeight - clothRise;
-  const baseLift = 0.03 * scaleFactor;
+  const baseLift = 0;
 
   const minBaseHeight = tableY > 0 ? tableY * 2 : 0;
   if (baseHeight < minBaseHeight) {


### PR DESCRIPTION
### Motivation
- Make Murlan tables/chairs sit flush with the HDRI floor and slightly reduce the table side footprint so the table appears a bit narrower while keeping height/interaction unchanged.
- Ensure chairs and procedural tables use original PolyHaven GLTF materials/textures when those models request preservation so we don't overwrite authentic textures.
- Expose Diamond-edge and Oval procedural table shapes and only show `Table Finish`/`Table Cloth` UI when one of the supported procedural shapes (Octagon/Diamond/Oval) is selected.

### Description
- Added two procedural Murlan table variants and `shapeId` fields in `webapp/src/config/murlanThemes.js` for `diamondEdge` and `ovalTable` and kept the default `murlan-default` octagon mapping.
- Introduced `TABLE_MENU_STYLE_IDS`, `TABLE_SHAPE_BY_ID` and `resolveProceduralShapeForTheme` and imported `TABLE_SHAPE_OPTIONS` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to resolve and apply the correct procedural shape when building the table.
- Trimmed horizontal footprint by changing `TABLE_RADIUS` from `3.4 * MODEL_SCALE` to `3.25 * MODEL_SCALE` and switched procedural table creation to include a grounded base (`includeBase: true`) with shape selection (`shapeOption`).
- Grounded visuals by setting chairs to sit at `y = 0` (replaced previous lifted chair base) and removed the vertical `baseLift` offset in `createMurlanStyleTable` so table bases sit flush with the floor (`webapp/src/pages/Games/MurlanRoyaleArena.jsx`, `webapp/src/utils/murlanTable.js`).
- Preserve original PolyHaven GLTF textures by skipping the texture-set override when `preserveMaterials` is true (only call `loadPolyhavenTextureSet` / `applyTextureSetToModel` when `textureLoader && !preserveMaterials`).

### Testing
- Ran the production web build with `npm --prefix webapp run build`, which completed successfully and produced the site assets; only existing Vite chunk-size/dynamic-import warnings were reported.
- No automated unit tests were modified; the change was validated by a successful `webapp` build and a committed change that updated `webapp/src/config/murlanThemes.js`, `webapp/src/pages/Games/MurlanRoyaleArena.jsx`, and `webapp/src/utils/murlanTable.js`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfd74554488329a6c8189dbdbb58bc)