### PR TITLE
Preserve PolyHaven GLTF texture mapping; show Table Finish/Cloth only for Octagon/Diamond/Oval

### DIFF
--- a/webapp/src/config/texasHoldemInventoryConfig.js
+++ b/webapp/src/config/texasHoldemInventoryConfig.js
@@ -34,7 +34,11 @@ export const TEXAS_HOLDEM_DEFAULT_UNLOCKS = Object.freeze({
   tableCloth: [TABLE_CLOTH_OPTIONS[0]?.id],
   tableBase: [TABLE_BASE_OPTIONS[0]?.id],
   chairTheme: [TEXAS_CHAIR_THEME_OPTIONS[0]?.id],
-  tableTheme: [TEXAS_TABLE_THEME_OPTIONS[0]?.id],
+  tableTheme: [
+    TEXAS_TABLE_THEME_OPTIONS[0]?.id,
+    TEXAS_TABLE_THEME_OPTIONS.find((option) => option.id === 'diamondEdge')?.id,
+    TEXAS_TABLE_THEME_OPTIONS.find((option) => option.id === 'ovalTable')?.id
+  ].filter(Boolean),
   tableShape: [TABLE_SHAPE_OPTIONS[0]?.id],
   cards: [CARD_THEMES[0]?.id],
   environmentHdri: [TEXAS_DEFAULT_HDRI_ID]

--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -839,6 +839,7 @@ const CUSTOMIZATION_SECTIONS = [
   { key: 'tableShape', label: 'Table Shape', options: TABLE_SHAPE_OPTIONS },
   { key: 'cards', label: 'Cards', options: CARD_THEMES }
 ];
+const TABLE_STYLE_MENU_THEME_IDS = new Set(['murlan-default', 'diamondEdge', 'ovalTable']);
 
 const NON_DIAMOND_SHAPE_INDEX = (() => {
   const index = TABLE_SHAPE_OPTIONS.findIndex((option) => option.id !== DIAMOND_SHAPE_ID);
@@ -1059,39 +1060,57 @@ function createConfiguredGLTFLoader(renderer = null, manager = undefined) {
   return loader;
 }
 
-function normalizePbrTexture(texture, maxAnisotropy = 1) {
+function normalizePbrTexture(texture, maxAnisotropy = 1, { preserveWrapping = false } = {}) {
   if (!texture) return;
   texture.flipY = false;
-  texture.wrapS = texture.wrapS ?? THREE.RepeatWrapping;
-  texture.wrapT = texture.wrapT ?? THREE.RepeatWrapping;
+  if (!preserveWrapping) {
+    texture.wrapS = texture.wrapS ?? THREE.RepeatWrapping;
+    texture.wrapT = texture.wrapT ?? THREE.RepeatWrapping;
+  }
   texture.anisotropy = Math.max(texture.anisotropy ?? 1, maxAnisotropy);
   texture.needsUpdate = true;
 }
 
-function normalizeMaterialTextures(material, maxAnisotropy = 8) {
+function normalizeMaterialTextures(
+  material,
+  maxAnisotropy = 8,
+  { preserveGltfTextureMapping = false } = {}
+) {
   if (!material) return;
   if (material.map) {
     applySRGBColorSpace(material.map);
-    normalizePbrTexture(material.map, maxAnisotropy);
+    normalizePbrTexture(material.map, maxAnisotropy, {
+      preserveWrapping: preserveGltfTextureMapping
+    });
   }
   if (material.emissiveMap) {
     applySRGBColorSpace(material.emissiveMap);
-    normalizePbrTexture(material.emissiveMap, maxAnisotropy);
+    normalizePbrTexture(material.emissiveMap, maxAnisotropy, {
+      preserveWrapping: preserveGltfTextureMapping
+    });
   }
-  normalizePbrTexture(material.normalMap, maxAnisotropy);
-  normalizePbrTexture(material.roughnessMap, maxAnisotropy);
-  normalizePbrTexture(material.metalnessMap, maxAnisotropy);
-  normalizePbrTexture(material.aoMap, maxAnisotropy);
+  normalizePbrTexture(material.normalMap, maxAnisotropy, {
+    preserveWrapping: preserveGltfTextureMapping
+  });
+  normalizePbrTexture(material.roughnessMap, maxAnisotropy, {
+    preserveWrapping: preserveGltfTextureMapping
+  });
+  normalizePbrTexture(material.metalnessMap, maxAnisotropy, {
+    preserveWrapping: preserveGltfTextureMapping
+  });
+  normalizePbrTexture(material.aoMap, maxAnisotropy, {
+    preserveWrapping: preserveGltfTextureMapping
+  });
 }
 
-function prepareLoadedModel(model) {
+function prepareLoadedModel(model, { preserveGltfTextureMapping = false } = {}) {
   model.traverse((obj) => {
     if (obj.isMesh) {
       obj.castShadow = true;
       obj.receiveShadow = true;
       const mats = Array.isArray(obj.material) ? obj.material : [obj.material];
       mats.forEach((mat) => {
-        normalizeMaterialTextures(mat);
+        normalizeMaterialTextures(mat, 8, { preserveGltfTextureMapping });
         if (mat) {
           mat.needsUpdate = true;
         }
@@ -1254,7 +1273,7 @@ async function loadPolyhavenModel(assetId, renderer = null) {
 
       const model = gltf.scene || gltf.scenes?.[0] || gltf;
       if (!model) throw new Error(`Poly Haven model missing scene for ${assetId}`);
-      prepareLoadedModel(model);
+      prepareLoadedModel(model, { preserveGltfTextureMapping: true });
       return model;
     })();
 
@@ -3206,9 +3225,9 @@ function TexasHoldemArena({ search }) {
       }))
         .filter((section) => section.options.length > 0)
         .filter((section) => {
-          if (section.key !== 'tableFinish') return true;
+          if (section.key !== 'tableFinish' && section.key !== 'tableCloth') return true;
           const tableTheme = TEXAS_TABLE_THEME_OPTIONS[appearance.tableTheme] ?? TEXAS_TABLE_THEME_OPTIONS[0];
-          return tableTheme?.id === DEFAULT_TABLE_THEME_ID;
+          return TABLE_STYLE_MENU_THEME_IDS.has(tableTheme?.id);
         }),
     [appearance.tableTheme, texasInventory]
   );


### PR DESCRIPTION
### Motivation
- Preserve original GLTF UV/wrapping for PolyHaven table and chair models so their exported textures display correctly in Texas Hold’em scenes.
- Only surface customizations (Table Finish / Table Cloth) should be editable in the menu when the selected table model uses the Murlan-style shapes that support those options.
- Make Diamond Edge and Oval table styles available by default in the Texas Hold’em customization unlocks so they are selectable in the UI.

### Description
- Add `preserveWrapping` to `normalizePbrTexture` and a `preserveGltfTextureMapping` option to `normalizeMaterialTextures` and `prepareLoadedModel` so GLTF-imported textures can keep their original wrapping while still applying color-space and anisotropy normalization in `webapp/src/pages/Games/TexasHoldemArena.jsx`.
- Call `prepareLoadedModel(model, { preserveGltfTextureMapping: true })` when loading PolyHaven GLTF assets so their original mapping is preserved.
- Introduce `TABLE_STYLE_MENU_THEME_IDS = new Set(['murlan-default','diamondEdge','ovalTable'])` and update customization filtering so `tableFinish` and `tableCloth` sections are shown only when the selected table theme id is in that allowlist in `webapp/src/pages/Games/TexasHoldemArena.jsx`.
- Add `diamondEdge` and `ovalTable` to the Texas default unlocked `tableTheme` list so those styles appear in the customization menu by default in `webapp/src/config/texasHoldemInventoryConfig.js`.
- Files changed: `webapp/src/pages/Games/TexasHoldemArena.jsx`, `webapp/src/config/texasHoldemInventoryConfig.js`.

### Testing
- Ran `npx eslint webapp/src/pages/Games/TexasHoldemArena.jsx webapp/src/config/texasHoldemInventoryConfig.js`, which completed and reported the repository ignore/warning state for these files.
- Ran `npx eslint --no-ignore webapp/src/pages/Games/TexasHoldemArena.jsx webapp/src/config/texasHoldemInventoryConfig.js`, which reported existing repository style-rule failures (semicolon/quote conventions) but did not surface parser/runtime errors related to the changes.
- Verified the code paths that load PolyHaven models now call the updated preparation function with `preserveGltfTextureMapping: true` and the customization menu filtering logic is applied (no automated visual tests available in this environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfde67f6508329bb9e53dc8a585247)