### PR TITLE
Add table shape customization, grounding, and GLTF texture-preservation tweaks

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -16,7 +16,7 @@ import { clone as cloneSkeleton } from 'three/examples/jsm/utils/SkeletonUtils.j
 import { EXRLoader } from 'three/examples/jsm/loaders/EXRLoader.js';
 import { applyRendererSRGB, applySRGBColorSpace } from '../../utils/colorSpace.js';
 import { ARENA_CAMERA_DEFAULTS, buildArenaCameraConfig } from '../../utils/arenaCameraConfig.js';
-import { applyTableMaterials, createMurlanStyleTable } from '../../utils/murlanTable.js';
+import { applyTableMaterials, createMurlanStyleTable, TABLE_SHAPE_OPTIONS } from '../../utils/murlanTable.js';
 import { CARD_THEMES } from '../../utils/cards3d.js';
 import { makeTonplaygramCardBackTexture } from '../../utils/cards3d.js';
 import { chatBeep, bombSound } from '../../assets/soundData.js';
@@ -81,9 +81,12 @@ const resolveHdriVariant = (index) => {
 const DEFAULT_TABLE_FINISH_ID = 'peelingPaintWeathered';
 const DEFAULT_TABLE_CLOTH_ID = 'emerald';
 const DEFAULT_STOOL_ID = 'dining_chair_02';
+const DEFAULT_TABLE_SHAPE_ID = 'classicOctagon';
 const DEFAULT_TABLE_FINISH_INDEX = Math.max(0, MURLAN_TABLE_FINISHES.findIndex((option) => option.id === DEFAULT_TABLE_FINISH_ID));
 const DEFAULT_TABLE_CLOTH_INDEX = Math.max(0, MURLAN_TABLE_CLOTHS.findIndex((option) => option.id === DEFAULT_TABLE_CLOTH_ID));
 const DEFAULT_STOOL_INDEX = Math.max(0, STOOL_THEMES.findIndex((option) => option.id === DEFAULT_STOOL_ID));
+const DEFAULT_TABLE_SHAPE_INDEX = Math.max(0, TABLE_SHAPE_OPTIONS.findIndex((option) => option.id === DEFAULT_TABLE_SHAPE_ID));
+const TABLE_SHAPES_WITH_SURFACE_CUSTOMIZATION = new Set(['classicOctagon', 'diamondEdge', 'grandOval']);
 const resolveTableFinish = (index) => {
   const max = MURLAN_TABLE_FINISHES.length - 1;
   const idx = Number.isFinite(index) ? Math.min(Math.max(Math.round(index), 0), max) : DEFAULT_TABLE_FINISH_INDEX;
@@ -103,7 +106,7 @@ const ENABLE_3D_HUMAN_CHARACTERS = false;
 const ARENA_GROWTH = 1.45; // expanded arena footprint for wider walkways
 const CHAIR_SIZE_SCALE = 1;
 
-const TABLE_RADIUS = 3.4 * MODEL_SCALE;
+const TABLE_RADIUS = 3.22 * MODEL_SCALE;
 const CHAIR_COUNT = 4;
 const CUSTOM_SEAT_ANGLES = [
   THREE.MathUtils.degToRad(90),
@@ -870,6 +873,7 @@ const DEFAULT_APPEARANCE = {
   stools: DEFAULT_STOOL_INDEX,
   characters: 0,
   tables: 0,
+  tableShape: DEFAULT_TABLE_SHAPE_INDEX,
   tableCloth: DEFAULT_TABLE_CLOTH_INDEX,
   tableFinish: DEFAULT_TABLE_FINISH_INDEX,
   environmentHdri: DEFAULT_HDRI_INDEX
@@ -1185,6 +1189,7 @@ const COMMENTARY_PRIMARY_SPEAKERS = Object.freeze({
 });
 const CUSTOMIZATION_SECTIONS = [
   { key: 'tables', label: 'Table Model', options: TABLE_THEMES },
+  { key: 'tableShape', label: 'Table Shape', options: TABLE_SHAPE_OPTIONS },
   { key: 'tableCloth', label: 'Table Cloth', options: MURLAN_TABLE_CLOTHS },
   { key: 'tableFinish', label: 'Table Finish', options: MURLAN_TABLE_FINISHES },
   { key: 'cards', label: 'Cards', options: CARD_THEMES },
@@ -1215,6 +1220,7 @@ function normalizeAppearance(value = {}) {
     ['stools', STOOL_THEMES.length],
     ['characters', MURLAN_CHARACTER_THEMES.length],
     ['tables', TABLE_THEMES.length],
+    ['tableShape', TABLE_SHAPE_OPTIONS.length],
     ['tableCloth', MURLAN_TABLE_CLOTHS.length],
     ['tableFinish', MURLAN_TABLE_FINISHES.length],
     ['environmentHdri', MURLAN_HDRI_OPTIONS.length]
@@ -1320,6 +1326,17 @@ function disposeObjectResources(object) {
 function liftModelToGround(model, targetMinY = 0) {
   const box = new THREE.Box3().setFromObject(model);
   model.position.y += targetMinY - box.min.y;
+}
+
+function groundObjectToY(object, targetY = 0) {
+  if (!object) return 0;
+  const box = new THREE.Box3().setFromObject(object);
+  if (!Number.isFinite(box.min.y)) return 0;
+  const delta = targetY - box.min.y;
+  if (delta !== 0) {
+    object.position.y += delta;
+  }
+  return delta;
 }
 
 function fitModelToHeight(model, targetHeight) {
@@ -1479,7 +1496,7 @@ async function loadGltfChair(urls = CHAIR_MODEL_URLS, rotationY = 0, renderer = 
     throw new Error('Chair model missing scene');
   }
 
-  prepareLoadedModel(model);
+  prepareLoadedModel(model, { preserveGltfTextureMapping: true });
 
   fitChairModelToFootprint(model);
   if (rotationY) {
@@ -2028,7 +2045,7 @@ async function loadPolyhavenModel(assetId, renderer = null) {
     if (!root) {
       throw new Error(`Missing scene for ${assetId}`);
     }
-    prepareLoadedModel(root);
+    prepareLoadedModel(root, { preserveGltfTextureMapping: true });
     return root;
   })();
 
@@ -2117,7 +2134,7 @@ async function buildChairTemplate(theme, renderer = null, textureOptions = {}) {
       const polyhavenRoot = await loadPolyhavenModel(theme.assetId, renderer);
       const model = polyhavenRoot.clone(true);
       prepareLoadedModel(model, { preserveGltfTextureMapping: preserveMaterials, maxAnisotropy });
-      if (textureLoader) {
+      if (textureLoader && !preserveMaterials) {
         try {
           const textures = await loadPolyhavenTextureSet(
             theme.assetId,
@@ -2595,18 +2612,23 @@ export default function MurlanRoyaleArena({ search }) {
 
   const customizationSections = useMemo(() => {
     const tableTheme = TABLE_THEMES[appearance.tables] ?? TABLE_THEMES[0];
-    const allowTableFinish = tableTheme?.source === 'procedural';
+    const tableShape = TABLE_SHAPE_OPTIONS[appearance.tableShape] ?? TABLE_SHAPE_OPTIONS[DEFAULT_TABLE_SHAPE_INDEX];
+    const allowTableSurfaceControls =
+      tableTheme?.source === 'procedural' &&
+      TABLE_SHAPES_WITH_SURFACE_CUSTOMIZATION.has(tableShape?.id);
     return CUSTOMIZATION_SECTIONS.map((section) => ({
       ...section,
       options: section.options
         .map((option, idx) => ({ ...option, idx }))
-        .filter(({ id }) => isMurlanOptionUnlocked(section.key, id, murlanInventory))
+        .filter(({ id }) =>
+          section.key === 'tableShape' ? true : isMurlanOptionUnlocked(section.key, id, murlanInventory)
+        )
     }))
       .filter((section) => section.options.length > 0)
       .filter((section) =>
-        section.key === 'tableFinish' || section.key === 'tableCloth' ? allowTableFinish : true
+        section.key === 'tableFinish' || section.key === 'tableCloth' ? allowTableSurfaceControls : true
       );
-  }, [appearance.tables, murlanInventory]);
+  }, [appearance.tables, appearance.tableShape, murlanInventory]);
   const [frameRateId, setFrameRateId] = useState(() => {
     if (typeof window !== 'undefined') {
       const stored = window.localStorage?.getItem(FRAME_RATE_STORAGE_KEY);
@@ -2713,6 +2735,7 @@ export default function MurlanRoyaleArena({ search }) {
         stools: STOOL_THEMES,
         characters: MURLAN_CHARACTER_THEMES,
         tables: TABLE_THEMES,
+        tableShape: TABLE_SHAPE_OPTIONS,
         tableCloth: MURLAN_TABLE_CLOTHS,
         tableFinish: MURLAN_TABLE_FINISHES,
         environmentHdri: MURLAN_HDRI_OPTIONS
@@ -2722,8 +2745,11 @@ export default function MurlanRoyaleArena({ search }) {
       Object.entries(map).forEach(([key, options]) => {
         const idx = Number.isFinite(next[key]) ? next[key] : 0;
         const option = options[idx];
-        if (!option || !isMurlanOptionUnlocked(key, option.id, murlanInventory)) {
-          const fallbackIdx = options.findIndex((opt) => isMurlanOptionUnlocked(key, opt.id, murlanInventory));
+        const isUnlocked = key === 'tableShape' ? true : isMurlanOptionUnlocked(key, option?.id, murlanInventory);
+        if (!option || !isUnlocked) {
+          const fallbackIdx = options.findIndex((opt) =>
+            key === 'tableShape' ? true : isMurlanOptionUnlocked(key, opt.id, murlanInventory)
+          );
           const safeIdx = fallbackIdx >= 0 ? fallbackIdx : 0;
           if (safeIdx !== idx) {
             next[key] = safeIdx;
@@ -3194,6 +3220,7 @@ export default function MurlanRoyaleArena({ search }) {
     scoreboard: null,
     tableInfo: null,
     tableThemeId: null,
+    tableShapeId: null,
     tableClothId: null,
     tableFinishId: null,
     chairMaterials: null,
@@ -3689,7 +3716,7 @@ export default function MurlanRoyaleArena({ search }) {
   }, []);
 
   const rebuildTable = useCallback(
-    async (tableTheme, tableFinish, tableCloth) => {
+    async (tableTheme, tableFinish, tableCloth, tableShapeOption) => {
       const three = threeStateRef.current;
       if (!three?.arena || !three.renderer) return null;
       const token = ++tableBuildTokenRef.current;
@@ -3701,6 +3728,7 @@ export default function MurlanRoyaleArena({ search }) {
       const theme = tableTheme || TABLE_THEMES[0];
       const finish = tableFinish || MURLAN_TABLE_FINISHES[DEFAULT_TABLE_FINISH_INDEX] || null;
       const cloth = tableCloth || MURLAN_TABLE_CLOTHS[DEFAULT_TABLE_CLOTH_INDEX] || null;
+      const shapeOption = tableShapeOption || TABLE_SHAPE_OPTIONS[DEFAULT_TABLE_SHAPE_INDEX];
       let tableInfo = null;
 
       if (theme?.source === 'polyhaven' && theme?.assetId) {
@@ -3716,17 +3744,19 @@ export default function MurlanRoyaleArena({ search }) {
               fallbackTexture: three.fallbackTexture,
               textureCache: three.textureCache,
               preferredTextureSizes: activeTextureResolutionOrder
-            }
+            },
+            true
           );
           if (tableBuildTokenRef.current === token && model) {
             const tableGroup = new THREE.Group();
             tableGroup.add(model);
             const { surfaceY, radius } = fitTableModelToArena(tableGroup);
+            const groundedDelta = groundObjectToY(tableGroup, 0);
             three.arena.add(tableGroup);
             tableInfo = {
               group: tableGroup,
-              surfaceY,
-              tableHeight: surfaceY,
+              surfaceY: surfaceY + groundedDelta,
+              tableHeight: surfaceY + groundedDelta,
               radius,
               dispose: () => {
                 disposeObjectResources(tableGroup);
@@ -3750,9 +3780,12 @@ export default function MurlanRoyaleArena({ search }) {
           tableRadius: TABLE_RADIUS,
           tableHeight: TABLE_HEIGHT,
           includeBase: false,
+          shapeOption,
           woodOption: finish?.woodOption || undefined,
           clothOption: cloth || undefined
         });
+        const groundedDelta = groundObjectToY(procedural.group, 0);
+        procedural.surfaceY += groundedDelta;
         tableInfo = { ...procedural, themeId: theme?.id || 'murlan-default' };
       }
 
@@ -3763,6 +3796,7 @@ export default function MurlanRoyaleArena({ search }) {
 
       three.tableInfo = tableInfo;
       three.tableThemeId = theme?.id || 'murlan-default';
+      three.tableShapeId = shapeOption?.id ?? TABLE_SHAPE_OPTIONS[DEFAULT_TABLE_SHAPE_INDEX]?.id ?? null;
       three.tableClothId = cloth?.id ?? null;
       three.tableFinishId = finish?.id ?? null;
       three.tableAnchor = new THREE.Vector3(0, tableInfo.surfaceY + CARD_SURFACE_OFFSET, TABLE_CARD_AREA_FORWARD_SHIFT);
@@ -3940,6 +3974,7 @@ export default function MurlanRoyaleArena({ search }) {
       ? MURLAN_CHARACTER_THEMES[safe.characters] ?? MURLAN_CHARACTER_THEMES[0]
       : null;
       const tableTheme = TABLE_THEMES[safe.tables] ?? TABLE_THEMES[0];
+      const tableShape = TABLE_SHAPE_OPTIONS[safe.tableShape] ?? TABLE_SHAPE_OPTIONS[DEFAULT_TABLE_SHAPE_INDEX];
       const tableFinish = resolveTableFinish(safe.tableFinish);
       const tableFinishId =
         tableFinish?.id ?? MURLAN_TABLE_FINISHES[DEFAULT_TABLE_FINISH_INDEX]?.id ?? null;
@@ -3954,10 +3989,11 @@ export default function MurlanRoyaleArena({ search }) {
         if (!three.scene) return;
         const tableChanged =
           three.tableThemeId !== tableTheme.id ||
+          (tableTheme?.source === 'procedural' && three.tableShapeId !== tableShape?.id) ||
           !three.tableInfo ||
           (tableTheme?.source === 'procedural' && three.tableFinishId !== tableFinishId);
         if (tableChanged) {
-          await rebuildTable(tableTheme, tableFinish, tableCloth);
+          await rebuildTable(tableTheme, tableFinish, tableCloth, tableShape);
         } else if (
           tableTheme?.source === 'procedural' &&
           three.tableInfo?.materials &&
@@ -4541,6 +4577,7 @@ export default function MurlanRoyaleArena({ search }) {
       : null;
       const cardTheme = CARD_THEMES[currentAppearance.cards] ?? CARD_THEMES[0];
       const tableTheme = TABLE_THEMES[currentAppearance.tables] ?? TABLE_THEMES[0];
+      const tableShape = TABLE_SHAPE_OPTIONS[currentAppearance.tableShape] ?? TABLE_SHAPE_OPTIONS[DEFAULT_TABLE_SHAPE_INDEX];
       const tableFinish = resolveTableFinish(currentAppearance.tableFinish);
       const tableCloth = resolveTableCloth(currentAppearance.tableCloth);
       const outfitTheme = OUTFIT_THEMES[currentAppearance.outfit] ?? OUTFIT_THEMES[0];
@@ -4599,7 +4636,7 @@ export default function MurlanRoyaleArena({ search }) {
 
       updateScoreboardDisplay(computeUiState(gameStateRef.current).scoreboard);
 
-      await rebuildTable(tableTheme, tableFinish, tableCloth);
+      await rebuildTable(tableTheme, tableFinish, tableCloth, tableShape);
       if (disposed) return;
 
       const chairBuild = await buildChairTemplate(stoolTheme, renderer, {
@@ -4646,7 +4683,8 @@ export default function MurlanRoyaleArena({ search }) {
         const z = Math.sin(angle) * seatRadius;
         const chairBaseHeight = CHAIR_BASE_HEIGHT - 0.04 * MODEL_SCALE;
         chair.position.set(x, chairBaseHeight, z);
-        chair.lookAt(new THREE.Vector3(0, chairBaseHeight, 0));
+        groundObjectToY(chair, 0);
+        chair.lookAt(new THREE.Vector3(0, chair.position.y, 0));
         arenaGroup.add(chair);
 
         const forward = new THREE.Vector3(Math.cos(angle), 0, Math.sin(angle));
@@ -4656,8 +4694,8 @@ export default function MurlanRoyaleArena({ search }) {
           .multiplyScalar(seatRadius - (isHumanSeat ? 1.05 * MODEL_SCALE : 0.65 * MODEL_SCALE));
         focus.y = TABLE_HEIGHT + CARD_H * (isHumanSeat ? 0.72 : 0.55);
         const stoolPosition = forward.clone().multiplyScalar(seatRadius);
-        stoolPosition.y = CHAIR_BASE_HEIGHT + SEAT_THICKNESS / 2;
-        const stoolHeight = STOOL_HEIGHT;
+        stoolPosition.y = chair.position.y + SEAT_THICKNESS / 2;
+        const stoolHeight = stoolPosition.y + SEAT_THICKNESS / 2;
         seatConfigs.push({
           seatIndex: i,
           chair,
@@ -5036,6 +5074,9 @@ export default function MurlanRoyaleArena({ search }) {
         scoreboard: null,
         tableInfo: null,
         tableThemeId: null,
+        tableShapeId: null,
+        tableClothId: null,
+        tableFinishId: null,
         chairMaterials: null,
         chairTemplate: null,
         chairThemePreserve: false,

--- a/webapp/src/utils/murlanTable.js
+++ b/webapp/src/utils/murlanTable.js
@@ -323,10 +323,10 @@ export const TABLE_SHAPE_OPTIONS = Object.freeze([
     },
     thumbnail: swatchThumbnail(['#0b1220', '#111827', '#f97316']),
     createShapes: ({ radius }) => {
-      const width = radius * 2.1;
-      const height = radius * 1.45;
+      const width = radius * 2.12;
+      const height = radius * 2;
       const topShape = createOvalShape(width, height, 64);
-      const feltShape = createOvalShape(width * 0.82, height * 0.82, 64);
+      const feltShape = createOvalShape(width * 0.8, height * 0.8, 64);
       const rimInnerShape = scaleShape2D(feltShape, 0.97, 0.97);
       return { topShape, feltShape, rimInnerShape };
     }
@@ -338,15 +338,17 @@ export const TABLE_SHAPE_OPTIONS = Object.freeze([
       borderRadius: '18%'
     },
     thumbnail: swatchThumbnail(['#1f2937', '#0f172a', '#a855f7']),
-    createShapes: ({ radius, scaleFactor }) => {
-      const factor = Number.isFinite(scaleFactor) && scaleFactor > 0 ? scaleFactor : radius / 0.9 || 1;
-      const outerHalf = 0.95 * factor;
-      const clothHalf = 0.7 * factor;
-      const innerHalf = 0.76 * factor;
-      const topShape = createRoundedRectangleShape(outerHalf * 2, outerHalf * 2, 0.12 * factor);
-      const feltShape = createRoundedRectangleShape(clothHalf * 2, clothHalf * 2, 0.08 * factor);
-      const rimInnerShape = createRoundedRectangleShape(innerHalf * 2, innerHalf * 2, 0.1 * factor);
-      return { topShape, feltShape, rimInnerShape, feltRadius: clothHalf };
+    createShapes: ({ radius }) => {
+      const width = radius * 2.12;
+      const height = radius * 2;
+      const topCorner = Math.min(width, height) * 0.16;
+      const feltWidth = width * 0.8;
+      const feltHeight = height * 0.8;
+      const feltCorner = Math.min(feltWidth, feltHeight) * 0.14;
+      const topShape = createRoundedRectangleShape(width, height, topCorner);
+      const feltShape = createRoundedRectangleShape(feltWidth, feltHeight, feltCorner);
+      const rimInnerShape = scaleShape2D(feltShape, 0.97, 0.97);
+      return { topShape, feltShape, rimInnerShape };
     }
   }
 ]);


### PR DESCRIPTION
### Motivation
- Add configurable table shapes to the arena so users can select different top geometries for tables.
- Ensure loaded table and chair models sit correctly on the arena floor by grounding procedurally- and asset-created geometry.
- Preserve GLTF texture mapping in some model loads and adjust table/chair sizing to improve visual fit.

### Description
- Introduce `TABLE_SHAPE_OPTIONS` and wire a new `tableShape` appearance slot with defaults and normalization handling. 
- Add `tableShape` to the customization UI and make it always visible/unlocked while keeping other options gated by inventory checks.
- Extend `rebuildTable` to accept a `tableShapeOption` and pass it into `createMurlanStyleTable`, and store `three.tableShapeId` on scene state.
- Add `groundObjectToY` helper and use it to adjust surface Y for loaded/procedural tables and to ground chairs, then update `surfaceY`/anchors accordingly; also adjust `TABLE_RADIUS`, some shape geometry math, and stool/chair placement logic.
- Pass `preserveGltfTextureMapping: true` into select `prepareLoadedModel` calls so GLTF texture mapping is preserved for certain model loads.

### Testing
- Ran unit tests locally with `yarn test`, which passed.
- Built the webapp bundle with `yarn build`, which completed successfully.
- Ran lint checks with `yarn lint`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfd74554488329a6c8189dbdbb58bc)