### PR TITLE
Pool Royale: fix cloth color labels, ball lift, cue strike timing and replay triggers

### DIFF
--- a/webapp/src/config/poolRoyaleClothPresets.js
+++ b/webapp/src/config/poolRoyaleClothPresets.js
@@ -57,19 +57,19 @@ const CABAN_TONE_GROUPS = Object.freeze([
     idPrefix: 'cabanGreen',
     label: 'Green',
     tones: ['Mint', 'Classic', 'Forest'],
-    hex: ['#3fbf72', '#2f955a', '#206843']
+    hex: ['#6fbe71', '#3f7f45', '#1f4f2b']
   },
   {
     idPrefix: 'cabanBeige',
     label: 'Beige',
     tones: ['Sand', 'Natural', 'Khaki'],
-    hex: ['#d9c4a0', '#b89c74', '#8f7656']
+    hex: ['#d9c3a2', '#b79d78', '#937450']
   },
   {
     idPrefix: 'cabanDarkGrey',
     label: 'Dark Grey',
     tones: ['Slate', 'Graphite', 'Charcoal'],
-    hex: ['#65717f', '#505b67', '#373f49']
+    hex: ['#6b6f74', '#4b5057', '#2f343b']
   }
 ])
 
@@ -80,7 +80,7 @@ export const POOL_ROYALE_CLOTH_VARIANTS = Object.freeze(
   CABAN_TONE_GROUPS.flatMap((group) =>
     group.hex.map((hex, index) => ({
       id: `${group.idPrefix}${group.tones[index]}`,
-      name: `Caban Wool — ${group.label} ${group.tones[index]}`,
+      name: `${group.label} ${group.tones[index]}`,
       sourceId: 'caban',
       tone: group.label.toLowerCase(),
       baseColor: toNumber(hex),

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1485,7 +1485,7 @@ const CLOTH_REFLECTION_LIMITS = Object.freeze({
 const CLOTH_REFLECTIONS_DISABLED = true;
 const POCKET_HOLE_R =
   POCKET_VIS_R * POCKET_CUT_EXPANSION * POCKET_VISUAL_EXPANSION; // cloth cutout radius now matches the interior pocket rim
-const BALL_CENTER_LIFT = BALL_R * 0.035; // lift balls slightly higher so they visually ride on top of the cloth surface
+const BALL_CENTER_LIFT = BALL_R * 0.042; // micro-lift so balls sit precisely on top of the cloth without dipping under
 const BALL_CENTER_Y =
   CLOTH_TOP_LOCAL + CLOTH_LIFT + BALL_R - CLOTH_DROP + BALL_CENTER_LIFT; // rest balls directly on the lowered cloth plane
 const BALL_SHADOW_Y = BALL_CENTER_Y - BALL_R + BALL_SHADOW_LIFT + MICRO_EPS;
@@ -1904,8 +1904,8 @@ const CUE_PULL_STANDING_CAMERA_BONUS = 0.2; // add extra draw for higher orbit a
 const CUE_PULL_MAX_VISUAL_BONUS = 0.38; // cap the compensation so the cue never overextends past the intended stroke
 const CUE_PULL_GLOBAL_VISIBILITY_BOOST = 0.86; // trim global pullback so charge-up stays readable without over-drawing the cue
 const CUE_PULL_RETURN_PUSH = 0.97; // push the cue forward to contact more decisively after pullback
-const CUE_FOLLOW_THROUGH_MIN = BALL_R * 3.9; // keep low-power shots visibly pushing through the cue ball
-const CUE_FOLLOW_THROUGH_MAX = BALL_R * 8.4; // extend top-end follow-through so powerful shots visibly punch forward
+const CUE_FOLLOW_THROUGH_MIN = BALL_R * 4.5; // keep low-power strokes visibly pushing through contact
+const CUE_FOLLOW_THROUGH_MAX = BALL_R * 9.3; // extend top-end follow-through so powerful shots visibly punch forward
 const CUE_POWER_GAMMA = 1.85; // ease-in curve to keep low-power strokes controllable
 const CUE_STRIKE_DURATION_MS = 260;
 const PLAYER_CUE_STRIKE_MIN_MS = 120;
@@ -25581,36 +25581,14 @@ const powerRef = useRef(hud.power);
               spinSide = baseSide * SIDE_SPIN_MULTIPLIER * topspinPowerScale;
             }
           }
-          cue.vel.copy(base);
-          if (cue.spin) {
-            cue.spin.set(spinSide, spinTop);
-          }
-          if (cue.omega) {
-            cue.omega.set(0, 0, 0);
-            TMP_VEC3_A.set(shotAimDir.x, 0, shotAimDir.y);
-            if (TMP_VEC3_A.lengthSq() > 1e-8) TMP_VEC3_A.normalize();
-            TMP_VEC3_B.set(-TMP_VEC3_A.z, 0, TMP_VEC3_A.x);
-            if (TMP_VEC3_B.lengthSq() > 1e-8) TMP_VEC3_B.normalize();
-            TMP_VEC3_C.copy(TMP_VEC3_B).multiplyScalar(scaledSpin.x * BALL_R);
-            TMP_VEC3_C.y += scaledSpin.y * BALL_R;
-            const impulseMag = BALL_MASS * base.length();
-            TMP_VEC3_D.copy(TMP_VEC3_A).multiplyScalar(impulseMag);
-            TMP_VEC3_E.copy(TMP_VEC3_C).cross(TMP_VEC3_D);
-            cue.omega.addScaledVector(TMP_VEC3_E, 1 / BALL_INERTIA);
-          }
-          if (cue.pendingSpin) cue.pendingSpin.set(0, 0);
-          cue.spinMode = 'standard';
-          cue.swerveStrength = 0;
-          cue.swervePowerStrength = 0;
-          resetSpinRef.current?.();
-          cueLiftRef.current.lift = 0;
-          cueLiftRef.current.startLift = 0;
-          cue.impacted = false;
-          cue.launchDir = shotAimDir.clone().normalize();
-          maxPowerLiftTriggered = false;
-          cue.lift = 0;
-          cue.liftVel = 0;
-          playCueHit(clampedPower * 0.6);
+          const shotImpactPayload = {
+            base: base.clone(),
+            aimDir: shotAimDir.clone(),
+            physicsSpin: { x: spinSide, y: spinTop },
+            clampedPower,
+            liftStrength,
+            applied: false
+          };
 
           if (cameraRef.current && sphRef.current) {
             if (forceImmediateRailOverheadView) {
@@ -25712,8 +25690,23 @@ const powerRef = useRef(hud.power);
           const pullbackDuration = strokeProfile.pullbackDuration ?? 0;
           const startTime = performance.now();
           const impactPos = idlePos.clone();
-          const followPos = impactPos.clone();
-          const followDurationResolved = strikeHoldDuration;
+          const followThroughDistance = THREE.MathUtils.lerp(
+            CUE_FOLLOW_THROUGH_MIN,
+            CUE_FOLLOW_THROUGH_MAX,
+            clampedPower
+          );
+          const followPos = impactPos
+            .clone()
+            .addScaledVector(dir, followThroughDistance);
+          const followSpeed = THREE.MathUtils.lerp(
+            CUE_FOLLOW_SPEED_MIN,
+            CUE_FOLLOW_SPEED_MAX,
+            clampedPower
+          );
+          const followDurationResolved = Math.max(
+            strikeHoldDuration,
+            (followThroughDistance / Math.max(followSpeed, 1e-6)) * 1000
+          );
           const recoverDuration = strokeProfile.recoverDuration ?? 0;
           const forwardPreviewHold =
             startTime +
@@ -25851,7 +25844,11 @@ const powerRef = useRef(hud.power);
               motionTechnique: strokeProfile.motion ?? strokeStyle,
               releaseStartsFromCurrentPull: true
             };
+            cueStrokeStateRef.current.onImpact = () => {
+              applyShotAtImpact(shotImpactPayload);
+            };
           } else {
+            applyShotAtImpact(shotImpactPayload);
             cueStick.visible = false;
             cueAnimating = false;
             cuePullCurrentRef.current = 0;
@@ -28025,7 +28022,7 @@ const powerRef = useRef(hud.power);
           pottedBalls,
           shotContext
         }) => {
-          if (!recording || !hadObjectPot) return null;
+          if (!recording) return null;
           const tags = new Set(recording.replayTags ?? []);
           if (hadObjectPot) tags.add('pot');
           const potCount = pottedBalls.filter((entry) => entry.id !== 'cue').length;
@@ -28035,8 +28032,9 @@ const powerRef = useRef(hud.power);
           const priority = ['multi', 'bank', 'long', 'power', 'spin'];
           const primary = priority.find((tag) => tags.has(tag)) ?? 'default';
           const zoomOnly = recording.zoomOnly && !tags.has('long') && !tags.has('bank');
+          const hasTaggedHighlight = tags.size > 0;
           return {
-            shouldReplay: hadObjectPot || tags.size > 0,
+            shouldReplay: hadObjectPot || hasTaggedHighlight,
             banner: selectReplayBanner(primary),
             zoomOnly,
             tags: Array.from(tags),


### PR DESCRIPTION
### Motivation
- Cloth presets were visually biased toward blue and menu labels included the redundant source prefix, so players saw mismatched color names and a confusing label; balls also visually dipped under the cloth in some views.  
- Cue animation applied the physics impulse before the visible impact which produced a stuck/unsynchronized strike animation and inconsistent replay visuals.  
- Replays were sometimes suppressed when a shot was visually interesting (power/long/spin/bank) but no object ball was potted, causing players to miss replays they expected.

### Description
- Changed cloth tone hex values for the green, beige and dark grey `CABAN_TONE_GROUPS` entries to less-blue tints and removed the `Caban Wool —` prefix from generated `POOL_ROYALE_CLOTH_VARIANTS` names so UI shows only color names (`webapp/src/config/poolRoyaleClothPresets.js`).  
- Raised resting ball height by increasing `BALL_CENTER_LIFT` to `BALL_R * 0.042` so balls sit precisely on top of the cloth (`webapp/src/pages/Games/PoolRoyale.jsx`).  
- Increased cue follow-through extents (`CUE_FOLLOW_THROUGH_MIN`/`MAX`) and computed a follow-through distance and duration based on shot power and `CUE_FOLLOW_SPEED_*` to produce a clearer forward strike.  
- Synchronized physics impulse with the visible cue impact by creating a `shotImpactPayload` and applying it on impact via the cue stroke state (`applyShotAtImpact`) and hooking `cueStrokeStateRef.current.onImpact` so velocity/spin/omega are set at the visual contact moment instead of before it (`webapp/src/pages/Games/PoolRoyale.jsx`).  
- Relaxed replay gating in `resolveReplayDecision` so recordings with highlight tags (power/long/spin/bank) can trigger a replay even if no object ball was potted (previous logic required `hadObjectPot`), improving replay availability (`webapp/src/pages/Games/PoolRoyale.jsx`).

### Testing
- Ran `npm --prefix webapp run build` to validate compilation and bundling; the build completed successfully (Vite produced standard chunk-size warnings but no errors).  
- Confirmed only the following source files were modified: `webapp/src/config/poolRoyaleClothPresets.js` and `webapp/src/pages/Games/PoolRoyale.jsx`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfe41da2e08329a3de49949373cc84)