### PR TITLE
Fix PolyHaven GLTF texture persistence for Texas Hold’em chairs/tables

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -1135,6 +1135,68 @@ function disposeObjectResources(object) {
   });
 }
 
+function cloneModelWithLocalMaterials(source) {
+  if (!source) return source;
+  const clonedRoot = source.clone(true);
+  const textureCache = new Map();
+  const materialCache = new Map();
+
+  const cloneTexture = (texture) => {
+    if (!texture?.isTexture) return texture ?? null;
+    if (textureCache.has(texture)) return textureCache.get(texture);
+    const cloned = texture.clone();
+    cloned.needsUpdate = true;
+    textureCache.set(texture, cloned);
+    return cloned;
+  };
+
+  const cloneMaterial = (material) => {
+    if (!material) return material;
+    if (materialCache.has(material)) return materialCache.get(material);
+    const cloned = material.clone();
+    const mapSlots = [
+      'map',
+      'alphaMap',
+      'aoMap',
+      'bumpMap',
+      'displacementMap',
+      'emissiveMap',
+      'lightMap',
+      'metalnessMap',
+      'normalMap',
+      'roughnessMap',
+      'specularMap',
+      'clearcoatMap',
+      'clearcoatNormalMap',
+      'clearcoatRoughnessMap',
+      'iridescenceMap',
+      'iridescenceThicknessMap',
+      'sheenColorMap',
+      'sheenRoughnessMap',
+      'thicknessMap',
+      'transmissionMap'
+    ];
+    mapSlots.forEach((slot) => {
+      if (cloned[slot]) {
+        cloned[slot] = cloneTexture(cloned[slot]);
+      }
+    });
+    materialCache.set(material, cloned);
+    return cloned;
+  };
+
+  clonedRoot.traverse((node) => {
+    if (!node?.isMesh) return;
+    if (Array.isArray(node.material)) {
+      node.material = node.material.map((mat) => cloneMaterial(mat));
+    } else {
+      node.material = cloneMaterial(node.material);
+    }
+  });
+
+  return clonedRoot;
+}
+
 function buildPolyhavenModelUrls(assetId) {
   if (!assetId) return [];
   return [
@@ -1282,7 +1344,7 @@ async function loadPolyhavenModel(assetId, renderer = null) {
     cached = promise;
   }
   const baseModel = await cached;
-  return baseModel.clone(true);
+  return cloneModelWithLocalMaterials(baseModel);
 }
 
 const shouldPreserveChairMaterials = (theme) => Boolean(theme?.preserveMaterials || theme?.source === 'polyhaven');


### PR DESCRIPTION
### Motivation
- PolyHaven GLTF models were being reused via `clone(true)` which kept shared material/texture references so disposing one arena instance could break textures/UVs on later instances. 
- The change aims to ensure chairs and tables loaded from PolyHaven keep their original GLTF mapping and do not lose textures after other instances are cleaned up, matching the approach used for the table cloth pipeline.

### Description
- Added `cloneModelWithLocalMaterials()` to `webapp/src/pages/Games/TexasHoldemArena.jsx` which deep-clones materials and relevant texture map slots for an instance. 
- The material clone duplicates common map slots (`map`, `normalMap`, `roughnessMap`, `metalnessMap`, etc.) and caches cloned textures/materials to avoid redundant copies. 
- Updated `loadPolyhavenModel()` to return `cloneModelWithLocalMaterials(baseModel)` instead of `baseModel.clone(true)` so each arena instance receives independent material/texture objects. 
- The change is scoped to PolyHaven model loading for Texas Hold’em chairs/tables and does not alter the table-cloth customization flow.

### Testing
- Ran the production build with `npm -C webapp run build` and the build completed successfully. 
- Vite reported the same pre-existing chunking/dynamic-import warnings, which are unrelated to this fix and did not block the build. 
- No automated unit tests were added or changed for this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfeb58eb5883299de585b43aee7ad2)