### PR TITLE
Pool Royale: fix cloth colors/labels, raise balls, cue strike and replay behavior

### DIFF
--- a/webapp/src/config/poolRoyaleClothPresets.js
+++ b/webapp/src/config/poolRoyaleClothPresets.js
@@ -57,19 +57,19 @@ const CABAN_TONE_GROUPS = Object.freeze([
     idPrefix: 'cabanGreen',
     label: 'Green',
     tones: ['Mint', 'Classic', 'Forest'],
-    hex: ['#3fbf72', '#2f955a', '#206843']
+    hex: ['#5aa86b', '#3d7f4d', '#2b5a37']
   },
   {
     idPrefix: 'cabanBeige',
     label: 'Beige',
     tones: ['Sand', 'Natural', 'Khaki'],
-    hex: ['#d9c4a0', '#b89c74', '#8f7656']
+    hex: ['#d6bd94', '#b69369', '#8f6f49']
   },
   {
     idPrefix: 'cabanDarkGrey',
     label: 'Dark Grey',
     tones: ['Slate', 'Graphite', 'Charcoal'],
-    hex: ['#65717f', '#505b67', '#373f49']
+    hex: ['#6e6860', '#54504a', '#3a3733']
   }
 ])
 
@@ -80,7 +80,7 @@ export const POOL_ROYALE_CLOTH_VARIANTS = Object.freeze(
   CABAN_TONE_GROUPS.flatMap((group) =>
     group.hex.map((hex, index) => ({
       id: `${group.idPrefix}${group.tones[index]}`,
-      name: `Caban Wool — ${group.label} ${group.tones[index]}`,
+      name: `${group.label} ${group.tones[index]}`,
       sourceId: 'caban',
       tone: group.label.toLowerCase(),
       baseColor: toNumber(hex),

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1485,7 +1485,7 @@ const CLOTH_REFLECTION_LIMITS = Object.freeze({
 const CLOTH_REFLECTIONS_DISABLED = true;
 const POCKET_HOLE_R =
   POCKET_VIS_R * POCKET_CUT_EXPANSION * POCKET_VISUAL_EXPANSION; // cloth cutout radius now matches the interior pocket rim
-const BALL_CENTER_LIFT = BALL_R * 0.035; // lift balls slightly higher so they visually ride on top of the cloth surface
+const BALL_CENTER_LIFT = BALL_R * 0.045; // lift balls a touch more so they sit exactly on top of the cloth surface
 const BALL_CENTER_Y =
   CLOTH_TOP_LOCAL + CLOTH_LIFT + BALL_R - CLOTH_DROP + BALL_CENTER_LIFT; // rest balls directly on the lowered cloth plane
 const BALL_SHADOW_Y = BALL_CENTER_Y - BALL_R + BALL_SHADOW_LIFT + MICRO_EPS;
@@ -25711,8 +25711,21 @@ const powerRef = useRef(hud.power);
           const strikeHoldDuration = strokeProfile.holdDuration ?? LIVE_CUE_IMPACT_HOLD_MS;
           const pullbackDuration = strokeProfile.pullbackDuration ?? 0;
           const startTime = performance.now();
-          const impactPos = idlePos.clone();
-          const followPos = impactPos.clone();
+          const shotStrength = THREE.MathUtils.clamp(clampedPower, 0, 1);
+          const impactForwardDistance = THREE.MathUtils.lerp(
+            BALL_R * 0.08,
+            BALL_R * 0.18,
+            shotStrength
+          );
+          const followThroughDistance = THREE.MathUtils.lerp(
+            CUE_FOLLOW_THROUGH_MIN,
+            CUE_FOLLOW_THROUGH_MAX,
+            Math.pow(shotStrength, CUE_POWER_GAMMA)
+          );
+          const impactPos = idlePos.clone().addScaledVector(dir, impactForwardDistance);
+          const followPos = impactPos
+            .clone()
+            .addScaledVector(dir, Math.max(BALL_R * 0.55, followThroughDistance));
           const followDurationResolved = strikeHoldDuration;
           const recoverDuration = strokeProfile.recoverDuration ?? 0;
           const forwardPreviewHold =
@@ -28025,7 +28038,9 @@ const powerRef = useRef(hud.power);
           pottedBalls,
           shotContext
         }) => {
-          if (!recording || !hadObjectPot) return null;
+          if (!recording) return null;
+          const frameCount = recording.frames?.length ?? 0;
+          if (frameCount <= 1) return null;
           const tags = new Set(recording.replayTags ?? []);
           if (hadObjectPot) tags.add('pot');
           const potCount = pottedBalls.filter((entry) => entry.id !== 'cue').length;
@@ -28035,9 +28050,10 @@ const powerRef = useRef(hud.power);
           const priority = ['multi', 'bank', 'long', 'power', 'spin'];
           const primary = priority.find((tag) => tags.has(tag)) ?? 'default';
           const zoomOnly = recording.zoomOnly && !tags.has('long') && !tags.has('bank');
+          const replayLabel = hadObjectPot ? selectReplayBanner(primary) : 'Replay';
           return {
-            shouldReplay: hadObjectPot || tags.size > 0,
-            banner: selectReplayBanner(primary),
+            shouldReplay: true,
+            banner: replayLabel,
             zoomOnly,
             tags: Array.from(tags),
             primaryTag: primary


### PR DESCRIPTION
### Motivation
- Cloth presets for Pool Royale were visually blue-shifted and the UI names included an unnecessary vendor prefix, causing mismatch between name and appearance.
- Balls were visually sinking slightly below the felt surface instead of resting cleanly on top.
- The cue stick felt like it stopped at contact and sometimes produced a stuck/weak strike animation rather than pushing through the cue ball.
- Replay playback was selectively gated (only for certain pot outcomes) which prevented valid recorded shots from showing their replay.

### Description
- Retuned cloth palette hex values for Green / Beige / Dark Grey tone groups and removed the `Caban Wool —` prefix from cloth menu labels in `webapp/src/config/poolRoyaleClothPresets.js` so labels show only the color names.
- Raised the ball resting center by updating `BALL_CENTER_LIFT` in `webapp/src/pages/Games/PoolRoyale.jsx` so balls sit on top of the cloth plane instead of appearing to sink.
- Updated cue strike motion in `webapp/src/pages/Games/PoolRoyale.jsx` to compute a forward impact position and follow-through distance scaled by shot power, so the cue visibly pushes through contact and follow-through matches shot strength.
- Relaxed replay gating in `webapp/src/pages/Games/PoolRoyale.jsx` by requiring a valid recording with more than one frame and returning `shouldReplay: true` with a neutral `Replay` banner for non-pot shots so recorded shots consistently trigger playback.

### Testing
- Ran the production build with `npm --prefix webapp run build` and it completed successfully with Vite producing the `dist/` output.
- Build reported non-blocking chunk-size warnings but no errors, and modified files compiled into the production bundle.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfe41da2e08329a3de49949373cc84)