### PR TITLE
Fix cue power recovery, brighten table cloths, and allow replay on pot/foul

### DIFF
--- a/Assets/Scripts/Gameplay/Broadcast/ReplayBroadcastGate.cs
+++ b/Assets/Scripts/Gameplay/Broadcast/ReplayBroadcastGate.cs
@@ -22,6 +22,12 @@ namespace Aiming.Gameplay.Broadcast
                 return false;
             }
 
+            if (!payload.HasCueTelemetry)
+            {
+                payload.cueDirection = Vector3.forward;
+                payload.powerNormalized = Mathf.Max(0f, payload.powerNormalized);
+            }
+
             payload.BroadcastStartTime = Time.unscaledTime + replayStartLeadSeconds;
             ReplayBroadcastRequested?.Invoke(payload);
             return true;
@@ -40,10 +46,14 @@ namespace Aiming.Gameplay.Broadcast
         public Vector3 cueBallPosition;
         public Vector3 cueDirection;
         public float powerNormalized;
+        public bool replayOnPottedBall;
+        public bool replayOnFoul;
         public float BroadcastStartTime { get; set; }
 
         public bool IsValid =>
-            !string.IsNullOrWhiteSpace(shotId) &&
+            !string.IsNullOrWhiteSpace(shotId) && (HasCueTelemetry || replayOnPottedBall || replayOnFoul);
+
+        public bool HasCueTelemetry =>
             cueDirection.sqrMagnitude > 0.0001f &&
             powerNormalized >= 0f;
     }

--- a/Assets/Scripts/Gameplay/Cue/CueTableClearanceGuard.cs
+++ b/Assets/Scripts/Gameplay/Cue/CueTableClearanceGuard.cs
@@ -20,6 +20,12 @@ namespace Aiming.Gameplay.Cue
         [Header("Cloth material parity")]
         [SerializeField] private Renderer[] clothRenderers;
         [SerializeField] private Material texasHoldemClothMaterial;
+        [Header("Cloth color tuning")]
+        [SerializeField] private bool brightenClothColors = true;
+        [SerializeField, Range(0f, 1f)] private float colorBlend = 0.45f;
+        [SerializeField] private Color brighterGreen = new Color(0.16f, 0.56f, 0.26f, 1f);
+        [SerializeField] private Color brighterBeige = new Color(0.82f, 0.75f, 0.62f, 1f);
+        private readonly MaterialPropertyBlock clothPropertyBlock = new MaterialPropertyBlock();
 
         void LateUpdate()
         {
@@ -27,6 +33,7 @@ namespace Aiming.Gameplay.Cue
             LiftBallsAndHelpers();
             MatchShadowRadius();
             ApplyTexasHoldemCloth();
+            TuneClothColor();
         }
 
         private void KeepCueClear()
@@ -108,6 +115,76 @@ namespace Aiming.Gameplay.Cue
                     clothRenderer.sharedMaterial = texasHoldemClothMaterial;
                 }
             }
+        }
+
+        private void TuneClothColor()
+        {
+            if (!brightenClothColors)
+            {
+                return;
+            }
+
+            foreach (Renderer clothRenderer in clothRenderers)
+            {
+                if (clothRenderer == null)
+                {
+                    continue;
+                }
+
+                Material shared = clothRenderer.sharedMaterial;
+                if (shared == null)
+                {
+                    continue;
+                }
+
+                bool hasBaseColor = shared.HasProperty("_BaseColor");
+                bool hasColor = shared.HasProperty("_Color");
+                if (!hasBaseColor && !hasColor)
+                {
+                    continue;
+                }
+
+                Color sourceColor = hasBaseColor ? shared.GetColor("_BaseColor") : shared.GetColor("_Color");
+                Color targetColor = ResolveTargetClothColor(sourceColor, clothRenderer.name);
+                Color adjusted = Color.Lerp(sourceColor, targetColor, colorBlend);
+
+                clothRenderer.GetPropertyBlock(clothPropertyBlock);
+                if (hasBaseColor)
+                {
+                    clothPropertyBlock.SetColor("_BaseColor", adjusted);
+                }
+
+                if (hasColor)
+                {
+                    clothPropertyBlock.SetColor("_Color", adjusted);
+                }
+
+                clothRenderer.SetPropertyBlock(clothPropertyBlock);
+            }
+        }
+
+        private Color ResolveTargetClothColor(Color sourceColor, string rendererName)
+        {
+            string lowerName = string.IsNullOrEmpty(rendererName) ? string.Empty : rendererName.ToLowerInvariant();
+            if (lowerName.Contains("beige"))
+            {
+                return brighterBeige;
+            }
+
+            if (lowerName.Contains("green"))
+            {
+                return brighterGreen;
+            }
+
+            Color.RGBToHSV(sourceColor, out float hue, out float saturation, out _);
+            bool looksGreen = hue >= 0.22f && hue <= 0.45f && saturation >= 0.2f;
+            bool looksBeige = hue >= 0.08f && hue <= 0.16f && saturation <= 0.35f;
+            if (looksGreen)
+            {
+                return brighterGreen;
+            }
+
+            return looksBeige ? brighterBeige : sourceColor;
         }
     }
 }

--- a/Assets/Scripts/Gameplay/CueController.cs
+++ b/Assets/Scripts/Gameplay/CueController.cs
@@ -103,6 +103,7 @@ namespace Aiming
 
             _cueAnchorPosition = cueBall.position;
             _shotState = ShotState.Dragging;
+            _power = Mathf.Max(_power, RecoverPowerFromCueDepth(_currentCueDepth));
             _latchedShotPower = 0f;
             _currentCueDepth = idleTipGap + (pullRange * EaseOutCubic(_power));
             gameObject.SetActive(true);
@@ -135,7 +136,8 @@ namespace Aiming
                 return;
             }
 
-            _latchedShotPower = Mathf.Clamp01(_power);
+            float recoveredPower = RecoverPowerFromCueDepth(_currentCueDepth);
+            _latchedShotPower = Mathf.Clamp01(Mathf.Max(_power, recoveredPower));
             if (_latchedShotPower <= 0.02f)
             {
                 _shotState = ShotState.Idle;
@@ -294,6 +296,25 @@ namespace Aiming
             t = Mathf.Clamp01(t);
             float inv = 1f - t;
             return 1f - (inv * inv * inv);
+        }
+
+        float RecoverPowerFromCueDepth(float cueDepth)
+        {
+            float pulledDistance = Mathf.Max(0f, cueDepth - idleTipGap);
+            if (pullRange <= 0.0001f)
+            {
+                return 0f;
+            }
+
+            float easedPull = Mathf.Clamp01(pulledDistance / pullRange);
+            return InverseEaseOutCubic(easedPull);
+        }
+
+        static float InverseEaseOutCubic(float easedValue)
+        {
+            easedValue = Mathf.Clamp01(easedValue);
+            float inv = 1f - easedValue;
+            return 1f - Mathf.Pow(inv, 1f / 3f);
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Fix shot triggers that produced little or no power when the cue-stick animation/timing changed by making the fired impulse recover from the cue stick depth so shots use the correct power amount.
- Make table cloth greens and beiges brighter because current variants are too dark for gameplay visibility.
- Ensure the replay frame can be triggered and broadcast when a ball is potted or a foul occurs even if cue telemetry is missing.

### Description
- `CueController`: recover normalized shot power from the current cue animation depth and use the stronger of slider power vs recovered value at release, by adding `RecoverPowerFromCueDepth` and `InverseEaseOutCubic`, setting `_power` in `BeginCharge()`, and clamping the latched power in `ReleaseAndStrike()`.
- `CueTableClearanceGuard`: add cloth color tuning controls (`brightenClothColors`, `colorBlend`, `brighterGreen`, `brighterBeige`) and a runtime `TuneClothColor()` pass that classifies cloth renderers (by name and HSV fallback) and applies blended color adjustments via `MaterialPropertyBlock` to avoid overwriting shared materials.
- `ReplayBroadcastGate`: extend `ReplayBroadcastPayload` with `replayOnPottedBall` and `replayOnFoul`, relax `IsValid` so a payload with either cue telemetry or these flags is acceptable, and inject safe fallback cue telemetry when telemetry is absent to allow legacy broadcast flow.

### Testing
- Performed a code review and inspected diffs with `git diff` and `git status` to validate the intended changes were localized to gameplay scripts and to confirm commit (`git commit`) succeeded.
- No Unity Play Mode or in-engine runtime tests were executed in this headless environment, so runtime/Play Mode validation (shot power feel, replay UI visibility, and visual color checks) remains to be verified inside Unity Editor or CI with playmode tests.
- Static/manual checks: grep/inspection was used to locate related code paths (`CueController`, `CueTableClearanceGuard`, `ReplayBroadcastGate`) to ensure integration points were correctly updated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cff76aa0e08329956ca9c12120b832)