### PR TITLE
Align Domino Royal arena asset quality with graphics presets

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -84,6 +84,16 @@ const DOMINO_TEXTURE_SIZE_MAP = Object.freeze({
   qhd90: 4096,
   uhd120: 8192
 });
+const FRAME_RATE_MODEL_RESOLUTION_ORDER_MAP = Object.freeze({
+  fhd60: Object.freeze(['2k', '1k']),
+  qhd90: Object.freeze(['4k', '2k', '1k']),
+  uhd120: Object.freeze(['8k', '4k', '2k', '1k'])
+});
+const FRAME_RATE_WOOD_TEXTURE_RESOLUTION_MAP = Object.freeze({
+  fhd60: '2k',
+  qhd90: '4k',
+  uhd120: '8k'
+});
 
 const AVATAR_TEXTURE_SIZE_MAP = Object.freeze({
   fhd60: 2048,
@@ -124,6 +134,22 @@ function getAdaptiveAvatarTextureSize(baseSize = 512) {
     AVATAR_TEXTURE_SIZE_MAP[DEFAULT_FRAME_RATE_ID] ??
     baseSize;
   return Math.max(256, Math.min(8192, mappedSize));
+}
+
+function resolveGraphicsModelResolutions(qualityId = DEFAULT_FRAME_RATE_ID) {
+  return (
+    FRAME_RATE_MODEL_RESOLUTION_ORDER_MAP[qualityId] ??
+    FRAME_RATE_MODEL_RESOLUTION_ORDER_MAP[DEFAULT_FRAME_RATE_ID] ??
+    ['2k', '1k']
+  );
+}
+
+function resolveGraphicsWoodTextureResolution(qualityId = DEFAULT_FRAME_RATE_ID) {
+  return (
+    FRAME_RATE_WOOD_TEXTURE_RESOLUTION_MAP[qualityId] ??
+    FRAME_RATE_WOOD_TEXTURE_RESOLUTION_MAP[DEFAULT_FRAME_RATE_ID] ??
+    '2k'
+  );
 }
 
 function resolveTelegramPixelRatioCap(qualityId = DEFAULT_FRAME_RATE_ID) {
@@ -2724,17 +2750,16 @@ async function loadPolyhavenModel(
   { preserveGltfTextureMapping = true } = {}
 ) {
   if (!assetId) return null;
-  const cacheKey = `${assetId.toLowerCase()}::${preserveGltfTextureMapping ? 'preserve' : 'normalized'}`;
-  if (polyhavenModelCache.has(cacheKey)) {
-    const cached = polyhavenModelCache.get(cacheKey);
-    return cached.clone(true);
-  }
-
   const preferredResolutions = IS_TELEGRAM_RUNTIME
     ? ['1k']
     : isLowProfileDevice
       ? ['1k']
-      : ['2k', '1k'];
+      : resolveGraphicsModelResolutions(frameRateId);
+  const cacheKey = `${assetId.toLowerCase()}::${preferredResolutions.join(',')}::${preserveGltfTextureMapping ? 'preserve' : 'normalized'}`;
+  if (polyhavenModelCache.has(cacheKey)) {
+    const cached = polyhavenModelCache.get(cacheKey);
+    return cached.clone(true);
+  }
   const filesManifest = await getPolyhavenFilesManifest(assetId);
   const manifestCandidates = buildPolyhavenManifestCandidates(
     filesManifest,
@@ -2743,7 +2768,7 @@ async function loadPolyhavenModel(
   const fallbackCandidates = buildPolyhavenModelUrls(assetId, preferredResolutions).map(
     (url) => ({
       url,
-      resolution: url.match(/\/(1k|2k)\//i)?.[1]?.toLowerCase?.() || '2k',
+      resolution: url.match(/\/(1k|2k|4k|8k)\//i)?.[1]?.toLowerCase?.() || '2k',
       includeUrlMap: null
     })
   );
@@ -3135,13 +3160,13 @@ const POLYHAVEN_ASSET_ALIASES = Object.freeze({
   rosewood_veneer_01: 'rosewood_veneer1'
 });
 
-const polyHavenTextureSet = (assetId) => {
+const polyHavenTextureSet = (assetId, resolution = '2k') => {
   const resolvedId = POLYHAVEN_ASSET_ALIASES[assetId] ?? assetId;
-  const base = `https://dl.polyhaven.org/file/ph-assets/Textures/jpg/2k/${resolvedId}/${resolvedId}`;
+  const base = `https://dl.polyhaven.org/file/ph-assets/Textures/jpg/${resolution}/${resolvedId}/${resolvedId}`;
   return {
-    mapUrl: `${base}_diff_2k.jpg`,
-    roughnessMapUrl: `${base}_rough_2k.jpg`,
-    normalMapUrl: `${base}_nor_gl_2k.jpg`
+    mapUrl: `${base}_diff_${resolution}.jpg`,
+    roughnessMapUrl: `${base}_rough_${resolution}.jpg`,
+    normalMapUrl: `${base}_nor_gl_${resolution}.jpg`
   };
 };
 
@@ -5896,6 +5921,19 @@ function updateTableMaterials() {
     TABLE_WOOD_OPTIONS[appearance.tableWood] ?? TABLE_WOOD_OPTIONS[0];
   const { preset, grain } = resolveWoodComponents(wood);
   const sharedKey = `domino-wood-${wood?.id ?? preset.id ?? 'default'}`;
+  const woodTextureResolution = resolveGraphicsWoodTextureResolution(frameRateId);
+  const retargetPolyhavenWoodTexture = (url) =>
+    typeof url === 'string' && url.includes('dl.polyhaven.org/file/ph-assets/Textures/jpg/')
+      ? url
+          .replace(/\/(1k|2k|4k|8k)\//i, `/${woodTextureResolution}/`)
+          .replace(/_(diff|rough|nor_gl)_(1k|2k|4k|8k)\.jpg$/i, `_$1_${woodTextureResolution}.jpg`)
+      : url;
+  const adaptiveFrameTextureSize = getAdaptiveTextureSize(
+    grain?.frame?.textureSize ?? DEFAULT_WOOD_TEXTURE_SIZE
+  );
+  const adaptiveRailTextureSize = getAdaptiveTextureSize(
+    grain?.rail?.textureSize ?? DEFAULT_WOOD_TEXTURE_SIZE
+  );
   applyWoodTextures(tableMaterials.top, {
     hue: preset.hue,
     sat: preset.sat,
@@ -5903,14 +5941,18 @@ function updateTableMaterials() {
     contrast: preset.contrast,
     repeat: grain?.frame?.repeat ?? grain?.rail?.repeat ?? { x: 0.24, y: 0.38 },
     rotation: grain?.frame?.rotation ?? 0,
-    textureSize: grain?.frame?.textureSize ?? DEFAULT_WOOD_TEXTURE_SIZE,
+    textureSize: adaptiveFrameTextureSize,
     roughnessBase: 0.16,
     roughnessVariance: 0.28,
     sharedKey,
-    mapUrl: grain?.frame?.mapUrl ?? grain?.rail?.mapUrl,
+    mapUrl: retargetPolyhavenWoodTexture(grain?.frame?.mapUrl ?? grain?.rail?.mapUrl),
     roughnessMapUrl:
-      grain?.frame?.roughnessMapUrl ?? grain?.rail?.roughnessMapUrl,
-    normalMapUrl: grain?.frame?.normalMapUrl ?? grain?.rail?.normalMapUrl
+      retargetPolyhavenWoodTexture(
+        grain?.frame?.roughnessMapUrl ?? grain?.rail?.roughnessMapUrl
+      ),
+    normalMapUrl: retargetPolyhavenWoodTexture(
+      grain?.frame?.normalMapUrl ?? grain?.rail?.normalMapUrl
+    )
   });
   applyWoodTextures(tableMaterials.rim, {
     hue: preset.hue,
@@ -5919,14 +5961,18 @@ function updateTableMaterials() {
     contrast: preset.contrast,
     repeat: grain?.rail?.repeat ?? grain?.frame?.repeat ?? { x: 0.12, y: 0.62 },
     rotation: grain?.rail?.rotation ?? 0,
-    textureSize: grain?.rail?.textureSize ?? DEFAULT_WOOD_TEXTURE_SIZE,
+    textureSize: adaptiveRailTextureSize,
     roughnessBase: 0.18,
     roughnessVariance: 0.32,
     sharedKey,
-    mapUrl: grain?.rail?.mapUrl ?? grain?.frame?.mapUrl,
+    mapUrl: retargetPolyhavenWoodTexture(grain?.rail?.mapUrl ?? grain?.frame?.mapUrl),
     roughnessMapUrl:
-      grain?.rail?.roughnessMapUrl ?? grain?.frame?.roughnessMapUrl,
-    normalMapUrl: grain?.rail?.normalMapUrl ?? grain?.frame?.normalMapUrl
+      retargetPolyhavenWoodTexture(
+        grain?.rail?.roughnessMapUrl ?? grain?.frame?.roughnessMapUrl
+      ),
+    normalMapUrl: retargetPolyhavenWoodTexture(
+      grain?.rail?.normalMapUrl ?? grain?.frame?.normalMapUrl
+    )
   });
   if (!tableMaterials.top.map) {
     tableMaterials.top.color.set(wood.baseHex);


### PR DESCRIPTION
### Motivation
- Ensure table, chair and table-cloth visuals use the same graphics-quality tier as the in-game Graphics option so arena objects appear consistent across presets.
- Allow higher-resolution PolyHaven models/textures to be selected when the player chooses 4K/8K profiles rather than always falling back to 2K.

### Description
- Added `FRAME_RATE_MODEL_RESOLUTION_ORDER_MAP` and `FRAME_RATE_WOOD_TEXTURE_RESOLUTION_MAP` and helpers `resolveGraphicsModelResolutions` and `resolveGraphicsWoodTextureResolution` to map graphics presets to model/texture resolution choices.
- Extended `polyHavenTextureSet` to accept a `resolution` parameter and produce resolution-specific texture URLs instead of hardcoding 2K.
- Updated `loadPolyhavenModel` to select model resolution order based on the active graphics profile and include the chosen resolution list in the model cache key so cached variants respect quality changes.
- Retargeted table wood texture URLs and made generated wood texture sizes adaptive in `updateTableMaterials` so table top/rim textures follow the active graphics tier and use the adaptive texture size helper.

### Testing
- Run `node --check webapp/public/domino-royal-game.js` which completed successfully.
- No additional automated browser/runtime tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cff9235c94832995c479bf8c7a72b7)