### PR TITLE
Add replay-frame fallback, cloth color tuning, and cue pull/power recovery

### DIFF
--- a/Assets/Scripts/Gameplay/Broadcast/ReplayBroadcastGate.cs
+++ b/Assets/Scripts/Gameplay/Broadcast/ReplayBroadcastGate.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using UnityEngine;
 
 namespace Aiming.Gameplay.Broadcast
@@ -12,8 +13,12 @@ namespace Aiming.Gameplay.Broadcast
         [Header("Legacy replay broadcast")]
         [SerializeField] private bool forceLegacyReplayBroadcast = true;
         [SerializeField, Min(0f)] private float replayStartLeadSeconds = 0.08f;
+        [Header("Replay frame fallback")]
+        [SerializeField] private GameObject replayFrameRoot;
+        [SerializeField, Min(0.05f)] private float replayFrameVisibleSeconds = 1.4f;
 
         public event Action<ReplayBroadcastPayload> ReplayBroadcastRequested;
+        private Coroutine replayFrameRoutine;
 
         public bool TryBroadcastReplay(ReplayBroadcastPayload payload)
         {
@@ -22,14 +27,44 @@ namespace Aiming.Gameplay.Broadcast
                 return false;
             }
 
+            if (!payload.HasCueTelemetry)
+            {
+                payload.cueDirection = Vector3.forward;
+                payload.powerNormalized = Mathf.Max(0f, payload.powerNormalized);
+            }
+
             payload.BroadcastStartTime = Time.unscaledTime + replayStartLeadSeconds;
             ReplayBroadcastRequested?.Invoke(payload);
+            ShowReplayFrame();
             return true;
         }
 
         public void SetLegacyReplayMode(bool enabled)
         {
             forceLegacyReplayBroadcast = enabled;
+        }
+
+        private void ShowReplayFrame()
+        {
+            if (replayFrameRoot == null)
+            {
+                return;
+            }
+
+            if (replayFrameRoutine != null)
+            {
+                StopCoroutine(replayFrameRoutine);
+            }
+
+            replayFrameRoutine = StartCoroutine(ReplayFrameRoutine());
+        }
+
+        private IEnumerator ReplayFrameRoutine()
+        {
+            replayFrameRoot.SetActive(true);
+            yield return new WaitForSecondsRealtime(replayFrameVisibleSeconds);
+            replayFrameRoot.SetActive(false);
+            replayFrameRoutine = null;
         }
     }
 
@@ -40,10 +75,16 @@ namespace Aiming.Gameplay.Broadcast
         public Vector3 cueBallPosition;
         public Vector3 cueDirection;
         public float powerNormalized;
+        public bool replayOnPottedBall;
+        public bool replayOnFoul;
         public float BroadcastStartTime { get; set; }
 
         public bool IsValid =>
-            !string.IsNullOrWhiteSpace(shotId) &&
+            replayOnPottedBall ||
+            replayOnFoul ||
+            (!string.IsNullOrWhiteSpace(shotId) && HasCueTelemetry);
+
+        public bool HasCueTelemetry =>
             cueDirection.sqrMagnitude > 0.0001f &&
             powerNormalized >= 0f;
     }

--- a/Assets/Scripts/Gameplay/Cue/CueTableClearanceGuard.cs
+++ b/Assets/Scripts/Gameplay/Cue/CueTableClearanceGuard.cs
@@ -20,6 +20,11 @@ namespace Aiming.Gameplay.Cue
         [Header("Cloth material parity")]
         [SerializeField] private Renderer[] clothRenderers;
         [SerializeField] private Material texasHoldemClothMaterial;
+        [Header("Cloth color tuning")]
+        [SerializeField] private bool brightenClothColors = true;
+        [SerializeField, Range(0f, 1f)] private float colorBlend = 0.45f;
+        [SerializeField] private Color brighterGreen = new Color(0.16f, 0.56f, 0.26f, 1f);
+        private readonly MaterialPropertyBlock clothPropertyBlock = new MaterialPropertyBlock();
 
         void LateUpdate()
         {
@@ -27,6 +32,7 @@ namespace Aiming.Gameplay.Cue
             LiftBallsAndHelpers();
             MatchShadowRadius();
             ApplyTexasHoldemCloth();
+            TuneClothColor();
         }
 
         private void KeepCueClear()
@@ -108,6 +114,64 @@ namespace Aiming.Gameplay.Cue
                     clothRenderer.sharedMaterial = texasHoldemClothMaterial;
                 }
             }
+        }
+
+        private void TuneClothColor()
+        {
+            if (!brightenClothColors)
+            {
+                return;
+            }
+
+            foreach (Renderer clothRenderer in clothRenderers)
+            {
+                if (clothRenderer == null)
+                {
+                    continue;
+                }
+
+                Material shared = clothRenderer.sharedMaterial;
+                if (shared == null)
+                {
+                    continue;
+                }
+
+                bool hasBaseColor = shared.HasProperty("_BaseColor");
+                bool hasColor = shared.HasProperty("_Color");
+                if (!hasBaseColor && !hasColor)
+                {
+                    continue;
+                }
+
+                Color sourceColor = hasBaseColor ? shared.GetColor("_BaseColor") : shared.GetColor("_Color");
+                if (!IsGreenCloth(clothRenderer.name, shared.name))
+                {
+                    continue;
+                }
+
+                Color targetColor = brighterGreen;
+                Color adjusted = Color.Lerp(sourceColor, targetColor, colorBlend);
+
+                clothRenderer.GetPropertyBlock(clothPropertyBlock);
+                if (hasBaseColor)
+                {
+                    clothPropertyBlock.SetColor("_BaseColor", adjusted);
+                }
+
+                if (hasColor)
+                {
+                    clothPropertyBlock.SetColor("_Color", adjusted);
+                }
+
+                clothRenderer.SetPropertyBlock(clothPropertyBlock);
+            }
+        }
+
+        private static bool IsGreenCloth(string rendererName, string materialName)
+        {
+            string lowerRenderer = string.IsNullOrEmpty(rendererName) ? string.Empty : rendererName.ToLowerInvariant();
+            string lowerMaterial = string.IsNullOrEmpty(materialName) ? string.Empty : materialName.ToLowerInvariant();
+            return lowerRenderer.Contains("green") || lowerMaterial.Contains("green");
         }
     }
 }

--- a/Assets/Scripts/Gameplay/CueController.cs
+++ b/Assets/Scripts/Gameplay/CueController.cs
@@ -38,6 +38,8 @@ namespace Aiming
         [Range(0.75f, 0.99f)] public float hitProgress = 0.9f;
         [Tooltip("How much of the strike stays for the final idle->contact micro drive.")]
         [Range(0.02f, 0.25f)] public float contactDrivePortion = 0.1f;
+        [Tooltip("Minimum pull used for strike animation so the cue visibly drives forward every shot.")]
+        [Min(0f)] public float minimumVisualPull = 0.025f;
 
         [Header("Spin input")]
         [Tooltip("Receives normalized spin values from the existing on-screen spin controller.")]
@@ -103,6 +105,7 @@ namespace Aiming
 
             _cueAnchorPosition = cueBall.position;
             _shotState = ShotState.Dragging;
+            _power = Mathf.Max(_power, RecoverPowerFromCueDepth(_currentCueDepth));
             _latchedShotPower = 0f;
             _currentCueDepth = idleTipGap + (pullRange * EaseOutCubic(_power));
             gameObject.SetActive(true);
@@ -135,7 +138,8 @@ namespace Aiming
                 return;
             }
 
-            _latchedShotPower = Mathf.Clamp01(_power);
+            float recoveredPower = RecoverPowerFromCueDepth(_currentCueDepth);
+            _latchedShotPower = Mathf.Clamp01(Mathf.Max(_power, recoveredPower));
             if (_latchedShotPower <= 0.02f)
             {
                 _shotState = ShotState.Idle;
@@ -224,7 +228,8 @@ namespace Aiming
 
             Vector3 strikeDirection = _aimDirection;
             float pull = pullRange * EaseOutCubic(shotPower);
-            float startDepth = idleTipGap + pull;
+            float visualPull = Mathf.Max(pull, minimumVisualPull);
+            float startDepth = idleTipGap + visualPull;
             float hitDepth = idleTipGap;
             float contactDepth = contactTipGap;
             float elapsed = 0f;
@@ -294,6 +299,25 @@ namespace Aiming
             t = Mathf.Clamp01(t);
             float inv = 1f - t;
             return 1f - (inv * inv * inv);
+        }
+
+        float RecoverPowerFromCueDepth(float cueDepth)
+        {
+            float pulledDistance = Mathf.Max(0f, cueDepth - idleTipGap);
+            if (pullRange <= 0.0001f)
+            {
+                return 0f;
+            }
+
+            float easedPull = Mathf.Clamp01(pulledDistance / pullRange);
+            return InverseEaseOutCubic(easedPull);
+        }
+
+        static float InverseEaseOutCubic(float easedValue)
+        {
+            easedValue = Mathf.Clamp01(easedValue);
+            float inv = 1f - easedValue;
+            return 1f - Mathf.Pow(inv, 1f / 3f);
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Ensure legacy replay broadcasts always emit a start and provide a visual fallback when replay telemetry is missing. 
- Improve visual parity and readability of green table cloths by allowing runtime color tuning without changing shared materials. 
- Make cue visuals and shot power more robust by recovering power from cue depth and enforcing a minimum visible pull so strikes appear consistent.

### Description
- `ReplayBroadcastGate`: enforces legacy replay broadcast timing, fills missing cue telemetry defaults, exposes a `replayFrameRoot` with a coroutine to show a visual replay frame for `replayFrameVisibleSeconds`, and updates `ReplayBroadcastPayload` validity to allow replay-on-potted/foul events. 
- `CueTableClearanceGuard`: adds cloth color tuning settings (`brightenClothColors`, `colorBlend`, `brighterGreen`) and applies color adjustments using a `MaterialPropertyBlock` while only affecting renderers/materials identified as green. 
- `CueController`: introduces `minimumVisualPull`, recovers shot power from current cue depth on charge start and release via `RecoverPowerFromCueDepth`, uses recovered power to clamp `_latchedShotPower`, and ensures the strike animation uses `visualPull` so the cue visibly drives forward; includes `InverseEaseOutCubic` helper.

### Testing
- Ran the project's automated tests through the Unity Test Runner including unit and playmode tests, and they all passed. 
- Verified the new replay-frame coroutine and cloth property block logic via editor play sessions (automated playmode tests covered core code paths).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cff76aa0e08329956ca9c12120b832)