### PR TITLE
Fix Pool Royale cue impact power, replay trigger, and brighten blue cloth presets

### DIFF
--- a/webapp/src/config/poolRoyaleClothPresets.js
+++ b/webapp/src/config/poolRoyaleClothPresets.js
@@ -51,7 +51,7 @@ const CABAN_TONE_GROUPS = Object.freeze([
     idPrefix: 'cabanBlue',
     label: 'Blue',
     tones: ['Sky', 'Royal', 'Navy'],
-    hex: ['#3d9df2', '#1f74cb', '#155196']
+    hex: ['#52afff', '#2b87e6', '#2264b8']
   },
   {
     idPrefix: 'cabanGreen',

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -22091,36 +22091,7 @@ const powerRef = useRef(hud.power);
           cuePullTargetRef.current = 0;
           cueStrokeStateRef.current = null;
           pendingImpactRef.current = null;
-          cue.vel.copy(base);
-          if (cue.spin) {
-            cue.spin.set(spinSide, spinTop);
-          }
-          if (cue.omega) {
-            cue.omega.set(0, 0, 0);
-            TMP_VEC3_A.set(shotAimDir.x, 0, shotAimDir.y);
-            if (TMP_VEC3_A.lengthSq() > 1e-8) TMP_VEC3_A.normalize();
-            TMP_VEC3_B.set(-TMP_VEC3_A.z, 0, TMP_VEC3_A.x);
-            if (TMP_VEC3_B.lengthSq() > 1e-8) TMP_VEC3_B.normalize();
-            TMP_VEC3_C.copy(TMP_VEC3_B).multiplyScalar(scaledSpin.x * BALL_R);
-            TMP_VEC3_C.y += scaledSpin.y * BALL_R;
-            const impulseMag = BALL_MASS * base.length();
-            TMP_VEC3_D.copy(TMP_VEC3_A).multiplyScalar(impulseMag);
-            TMP_VEC3_E.copy(TMP_VEC3_C).cross(TMP_VEC3_D);
-            cue.omega.addScaledVector(TMP_VEC3_E, 1 / BALL_INERTIA);
-          }
-          if (cue.pendingSpin) cue.pendingSpin.set(0, 0);
-          cue.spinMode = 'standard';
-          cue.swerveStrength = 0;
-          cue.swervePowerStrength = 0;
-          resetSpinRef.current?.();
-          cueLiftRef.current.lift = 0;
-          cueLiftRef.current.startLift = 0;
-          cue.impacted = false;
-          cue.launchDir = shotAimDir.clone().normalize();
-          maxPowerLiftTriggered = false;
-          cue.lift = 0;
-          cue.liftVel = 0;
-          playCueHit(clampedPower * 0.6);
+          applyShotImpact();
 
           if (cameraRef.current && sphRef.current) {
             topViewRef.current = false;
@@ -25792,6 +25763,41 @@ const powerRef = useRef(hud.power);
               startOffset: strokeStartOffset
             };
           }
+          let shotImpactApplied = false;
+          const applyShotImpact = () => {
+            if (shotImpactApplied) return;
+            shotImpactApplied = true;
+            cue.vel.copy(base);
+            if (cue.spin) {
+              cue.spin.set(spinSide, spinTop);
+            }
+            if (cue.omega) {
+              cue.omega.set(0, 0, 0);
+              TMP_VEC3_A.set(shotAimDir.x, 0, shotAimDir.y);
+              if (TMP_VEC3_A.lengthSq() > 1e-8) TMP_VEC3_A.normalize();
+              TMP_VEC3_B.set(-TMP_VEC3_A.z, 0, TMP_VEC3_A.x);
+              if (TMP_VEC3_B.lengthSq() > 1e-8) TMP_VEC3_B.normalize();
+              TMP_VEC3_C.copy(TMP_VEC3_B).multiplyScalar(scaledSpin.x * BALL_R);
+              TMP_VEC3_C.y += scaledSpin.y * BALL_R;
+              const impulseMag = BALL_MASS * base.length();
+              TMP_VEC3_D.copy(TMP_VEC3_A).multiplyScalar(impulseMag);
+              TMP_VEC3_E.copy(TMP_VEC3_C).cross(TMP_VEC3_D);
+              cue.omega.addScaledVector(TMP_VEC3_E, 1 / BALL_INERTIA);
+            }
+            if (cue.pendingSpin) cue.pendingSpin.set(0, 0);
+            cue.spinMode = 'standard';
+            cue.swerveStrength = 0;
+            cue.swervePowerStrength = 0;
+            resetSpinRef.current?.();
+            cueLiftRef.current.lift = 0;
+            cueLiftRef.current.startLift = 0;
+            cue.impacted = false;
+            cue.launchDir = shotAimDir.clone().normalize();
+            maxPowerLiftTriggered = false;
+            cue.lift = 0;
+            cue.liftVel = 0;
+            playCueHit(clampedPower * 0.6);
+          };
           if (ENABLE_CUE_STROKE_ANIMATION) {
             cueStick.visible = true;
             cueAnimating = true;
@@ -25820,7 +25826,9 @@ const powerRef = useRef(hud.power);
               forwardOnly: true,
               animationStyle: strokeStyle,
               motionTechnique: strokeProfile.motion ?? strokeStyle,
-              releaseStartsFromCurrentPull: true
+              releaseStartsFromCurrentPull: true,
+              shotApplied: false,
+              onImpact: applyShotImpact
             };
           } else {
             cueStick.visible = false;
@@ -25828,6 +25836,7 @@ const powerRef = useRef(hud.power);
             cuePullCurrentRef.current = 0;
             cuePullTargetRef.current = 0;
             cueStrokeStateRef.current = null;
+            applyShotImpact();
             if (cameraRef.current && sphRef.current) {
               topViewRef.current = false;
               topViewLockedRef.current = false;
@@ -27999,6 +28008,7 @@ const powerRef = useRef(hud.power);
           if (!recording) return null;
           const frameCount = recording.frames?.length ?? 0;
           if (frameCount <= 1) return null;
+          if (!hadObjectPot) return null;
           const tags = new Set(recording.replayTags ?? []);
           if (hadObjectPot) tags.add('pot');
           const potCount = pottedBalls.filter((entry) => entry.id !== 'cue').length;


### PR DESCRIPTION
### Motivation
- Fix a bug where the cue animation could run but the shot physics (power/spin) were not actually applied at impact, causing triggered shots with no power. 
- Ensure replays appear reliably for meaningful events (object-ball pots and fouls) and avoid spurious replay starts for non-pot shots. 
- Improve visual clarity by brightening the blue cloth variants so blue felts read lighter on screen without affecting other cloth tones. 

### Description
- Introduced a shared `applyShotImpact()` function that applies the cue velocity, spin, omega, and related post-impact state, and wired it into both the animated and non-animated stroke code paths to guarantee physics are applied at impact (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Replaced duplicated end-of-stroke physics with calls to the shared `applyShotImpact()` to avoid desync between cue animation and shot force application (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Tightened replay decision logic so automatic standard replays only trigger when an object ball was potted (`hadObjectPot`), while foul replay flow remains handled by the existing foul branch (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Brightened the three blue cloth presets by updating their hex values so only the blue tone group changes (`webapp/src/config/poolRoyaleClothPresets.js`).

### Testing
- Ran `npm run build` in the `webapp/` folder and the production build completed successfully (Vite build succeeded with non-blocking chunk-size warnings). 
- No automated unit tests were present for these gameplay changes; validation was limited to the production build step which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0015ed3c483299311cbafc5959386)