### PR TITLE
Fix cue power latching, brighten blue cloths only, and make replay frame fallback more robust

### DIFF
--- a/Assets/Scripts/Gameplay/Broadcast/ReplayBroadcastGate.cs
+++ b/Assets/Scripts/Gameplay/Broadcast/ReplayBroadcastGate.cs
@@ -15,6 +15,7 @@ namespace Aiming.Gameplay.Broadcast
         [SerializeField, Min(0f)] private float replayStartLeadSeconds = 0.08f;
         [Header("Replay frame fallback")]
         [SerializeField] private GameObject replayFrameRoot;
+        [SerializeField] private CanvasGroup replayFrameCanvasGroup;
         [SerializeField, Min(0.05f)] private float replayFrameVisibleSeconds = 1.4f;
 
         public event Action<ReplayBroadcastPayload> ReplayBroadcastRequested;
@@ -46,9 +47,14 @@ namespace Aiming.Gameplay.Broadcast
 
         private void ShowReplayFrame()
         {
-            if (replayFrameRoot == null)
+            if (replayFrameRoot == null && replayFrameCanvasGroup == null)
             {
                 return;
+            }
+
+            if (replayFrameRoot == null && replayFrameCanvasGroup != null)
+            {
+                replayFrameRoot = replayFrameCanvasGroup.gameObject;
             }
 
             if (replayFrameRoutine != null)
@@ -61,9 +67,30 @@ namespace Aiming.Gameplay.Broadcast
 
         private IEnumerator ReplayFrameRoutine()
         {
-            replayFrameRoot.SetActive(true);
+            if (replayFrameRoot != null)
+            {
+                replayFrameRoot.SetActive(true);
+            }
+
+            if (replayFrameCanvasGroup != null)
+            {
+                replayFrameCanvasGroup.alpha = 1f;
+                replayFrameCanvasGroup.interactable = false;
+                replayFrameCanvasGroup.blocksRaycasts = false;
+            }
+
             yield return new WaitForSecondsRealtime(replayFrameVisibleSeconds);
-            replayFrameRoot.SetActive(false);
+
+            if (replayFrameCanvasGroup != null)
+            {
+                replayFrameCanvasGroup.alpha = 0f;
+            }
+
+            if (replayFrameRoot != null)
+            {
+                replayFrameRoot.SetActive(false);
+            }
+
             replayFrameRoutine = null;
         }
     }

--- a/Assets/Scripts/Gameplay/Cue/CueTableClearanceGuard.cs
+++ b/Assets/Scripts/Gameplay/Cue/CueTableClearanceGuard.cs
@@ -21,9 +21,9 @@ namespace Aiming.Gameplay.Cue
         [SerializeField] private Renderer[] clothRenderers;
         [SerializeField] private Material texasHoldemClothMaterial;
         [Header("Cloth color tuning")]
-        [SerializeField] private bool brightenClothColors = true;
-        [SerializeField, Range(0f, 1f)] private float colorBlend = 0.45f;
-        [SerializeField] private Color brighterGreen = new Color(0.16f, 0.56f, 0.26f, 1f);
+        [SerializeField] private bool brightenBlueCloth = true;
+        [SerializeField, Range(0f, 1f)] private float blueColorBlend = 0.35f;
+        [SerializeField] private Color brighterBlue = new Color(0.17f, 0.36f, 0.76f, 1f);
         private readonly MaterialPropertyBlock clothPropertyBlock = new MaterialPropertyBlock();
 
         void LateUpdate()
@@ -118,7 +118,7 @@ namespace Aiming.Gameplay.Cue
 
         private void TuneClothColor()
         {
-            if (!brightenClothColors)
+            if (!brightenBlueCloth)
             {
                 return;
             }
@@ -144,13 +144,12 @@ namespace Aiming.Gameplay.Cue
                 }
 
                 Color sourceColor = hasBaseColor ? shared.GetColor("_BaseColor") : shared.GetColor("_Color");
-                if (!IsGreenCloth(clothRenderer.name, shared.name))
+                if (!IsBlueCloth(clothRenderer.name, shared.name))
                 {
                     continue;
                 }
 
-                Color targetColor = brighterGreen;
-                Color adjusted = Color.Lerp(sourceColor, targetColor, colorBlend);
+                Color adjusted = Color.Lerp(sourceColor, brighterBlue, blueColorBlend);
 
                 clothRenderer.GetPropertyBlock(clothPropertyBlock);
                 if (hasBaseColor)
@@ -167,11 +166,11 @@ namespace Aiming.Gameplay.Cue
             }
         }
 
-        private static bool IsGreenCloth(string rendererName, string materialName)
+        private static bool IsBlueCloth(string rendererName, string materialName)
         {
             string lowerRenderer = string.IsNullOrEmpty(rendererName) ? string.Empty : rendererName.ToLowerInvariant();
             string lowerMaterial = string.IsNullOrEmpty(materialName) ? string.Empty : materialName.ToLowerInvariant();
-            return lowerRenderer.Contains("green") || lowerMaterial.Contains("green");
+            return lowerRenderer.Contains("blue") || lowerMaterial.Contains("blue");
         }
     }
 }

--- a/Assets/Scripts/Gameplay/CueController.cs
+++ b/Assets/Scripts/Gameplay/CueController.cs
@@ -50,6 +50,7 @@ namespace Aiming
         Vector3 _targetDirection = Vector3.forward;
         Vector3 _cueAnchorPosition;
         float _currentCueDepth;
+        float _chargedCueDepth;
         float _power;
         float _latchedShotPower;
         ShotState _shotState = ShotState.Idle;
@@ -91,7 +92,8 @@ namespace Aiming
             if (_shotState == ShotState.Dragging)
             {
                 float pull = pullRange * EaseOutCubic(_power);
-                _currentCueDepth = idleTipGap + pull;
+                _chargedCueDepth = idleTipGap + pull;
+                _currentCueDepth = _chargedCueDepth;
                 UpdateCuePose();
             }
         }
@@ -107,7 +109,8 @@ namespace Aiming
             _shotState = ShotState.Dragging;
             _power = Mathf.Max(_power, RecoverPowerFromCueDepth(_currentCueDepth));
             _latchedShotPower = 0f;
-            _currentCueDepth = idleTipGap + (pullRange * EaseOutCubic(_power));
+            _chargedCueDepth = idleTipGap + (pullRange * EaseOutCubic(_power));
+            _currentCueDepth = _chargedCueDepth;
             gameObject.SetActive(true);
             UpdateCuePose();
         }
@@ -127,6 +130,7 @@ namespace Aiming
             _shotState = ShotState.Idle;
             _power = 0f;
             _latchedShotPower = 0f;
+            _chargedCueDepth = idleTipGap;
             _currentCueDepth = idleTipGap;
             UpdateCuePose();
         }
@@ -138,11 +142,12 @@ namespace Aiming
                 return;
             }
 
-            float recoveredPower = RecoverPowerFromCueDepth(_currentCueDepth);
+            float recoveredPower = RecoverPowerFromCueDepth(_chargedCueDepth);
             _latchedShotPower = Mathf.Clamp01(Mathf.Max(_power, recoveredPower));
             if (_latchedShotPower <= 0.02f)
             {
                 _shotState = ShotState.Idle;
+                _chargedCueDepth = idleTipGap;
                 _currentCueDepth = idleTipGap;
                 UpdateCuePose();
                 return;
@@ -181,7 +186,8 @@ namespace Aiming
             if (_shotState == ShotState.Dragging)
             {
                 float pull = pullRange * EaseOutCubic(_power);
-                _currentCueDepth = idleTipGap + pull;
+                _chargedCueDepth = idleTipGap + pull;
+                _currentCueDepth = _chargedCueDepth;
                 return;
             }
 
@@ -227,7 +233,7 @@ namespace Aiming
             _shotState = ShotState.Striking;
 
             Vector3 strikeDirection = _aimDirection;
-            float pull = pullRange * EaseOutCubic(shotPower);
+            float pull = Mathf.Max(0f, _chargedCueDepth - idleTipGap);
             float visualPull = Mathf.Max(pull, minimumVisualPull);
             float startDepth = idleTipGap + visualPull;
             float hitDepth = idleTipGap;
@@ -279,6 +285,7 @@ namespace Aiming
             _currentCueDepth = idleTipGap;
             _power = 0f;
             _latchedShotPower = 0f;
+            _chargedCueDepth = idleTipGap;
             _shotState = ShotState.Idle;
             UpdateCuePose();
         }


### PR DESCRIPTION
### Motivation
- Fix a bug where shots were triggered but delivered little or no power after changes to the cue animation by decoupling visual cue depth from the captured shot charge state.
- Brighten the blue table cloths only, without altering other cloth colors.
- Ensure the replay frame UI is shown reliably when a ball is potted or a foul occurs, even when toggling the root GameObject is unreliable.

### Description
- `Assets/Scripts/Gameplay/CueController.cs`: introduced a `_chargedCueDepth` field and updated charge/begin/release/strike flows to capture the charged depth separately from the transient animation depth, derive recovered power from the captured charge, and compute strike visual pull from the captured charge so delivered impulse no longer depends on strike animation timing.
- `Assets/Scripts/Gameplay/Cue/CueTableClearanceGuard.cs`: replaced the generic cloth brightening with blue-only tuning (`brightenBlueCloth`, `blueColorBlend`, `brighterBlue`) and a name-based `IsBlueCloth` check so only blue cloth renderers are adjusted via `MaterialPropertyBlock`.
- `Assets/Scripts/Gameplay/Broadcast/ReplayBroadcastGate.cs`: added an optional `CanvasGroup replayFrameCanvasGroup` and updated `ShowReplayFrame` / `ReplayFrameRoutine` to drive canvas alpha as a fallback in addition to activating the `replayFrameRoot` GameObject, improving replay-frame visibility robustness.
- Reset/cleanup: cancel and strike-complete paths reset `_chargedCueDepth` to `idleTipGap` to keep state consistent between shots.

### Testing
- Ran `git diff --check` which passed without reported issues.
- Attempted `dotnet test billiards.Tests/Billiards.Tests.csproj` but it failed due to the environment missing the `dotnet` runtime (`/bin/bash: dotnet: command not found`), so unit/playmode tests were not executed here.
- Source-level smoke validation was performed by reviewing the modified files and ensuring no local compile-time edit errors in the diffs; runtime verification in the Unity editor is recommended (verify shot power across charge levels, blue cloth appearance, and replay-frame visibility on potted/foul events).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0015ed3c483299311cbafc5959386)