### PR TITLE
Pool Royale: fix cue power fallback and align replay feedback with Snooker logic

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -14654,11 +14654,14 @@ const [ruleToast, setRuleToast] = useState(null);
 const ruleToastTimeoutRef = useRef(null);
 const [replayActive, setReplayActive] = useState(false);
 const [replayFoul, setReplayFoul] = useState(null);
+const [replayPottedLabel, setReplayPottedLabel] = useState(null);
 const handleSkipReplayClick = useCallback(() => {
   if (skipReplayRef.current) {
     skipReplayRef.current();
   } else {
     setReplayActive(false);
+    setReplayFoul(null);
+    setReplayPottedLabel(null);
   }
 }, []);
   const [hudInsets, setHudInsets] = useState({ left: '0px', right: '0px' });
@@ -14679,6 +14682,7 @@ const showRuleToast = useCallback((message) => {
   }, 3000);
 }, []);
 const powerRef = useRef(hud.power);
+const lastSliderPowerRef = useRef(0);
   const clampPower = useCallback((value, fallback = 0) => {
     if (!Number.isFinite(value)) return fallback;
     return THREE.MathUtils.clamp(value, 0, 1);
@@ -22340,6 +22344,7 @@ const powerRef = useRef(hud.power);
           pendingImpactRef.current = null;
           setReplayActive(true);
           setReplayFoul(shotRecording?.replayFoul ?? null);
+          setReplayPottedLabel(shotRecording?.replayPottedLabel ?? null);
           overheadBroadcastVariantRef.current = 'replay';
           storeReplayCameraFrame();
           resetCameraForReplay();
@@ -22494,6 +22499,7 @@ const powerRef = useRef(hud.power);
           replayCueHiddenRef.current = { hideFrom: Infinity, hideUntil: -Infinity };
           setReplayActive(false);
           setReplayFoul(null);
+          setReplayPottedLabel(null);
         };
         const skipReplay = () => {
           if (replayBannerTimeoutRef.current) {
@@ -25328,7 +25334,11 @@ const powerRef = useRef(hud.power);
         }
         const powerInput =
           Number.isFinite(committedPower) ? committedPower : powerRef.current;
-        const clampedPower = clampPower(powerInput, 0);
+        const sliderFallbackPower = clampPower(lastSliderPowerRef.current, 0);
+        const clampedPower = clampPower(
+          powerInput > 0 ? powerInput : sliderFallbackPower,
+          0
+        );
         const strokeStyle = cueStrokeAnimationStyleRef.current ?? DEFAULT_CUE_STROKE_STYLE;
         const strokeProfile = resolveCueStrokeProfile(strokeStyle, clampedPower);
         const rawSpin = applySpinConstraints(aimDir, true);
@@ -28003,7 +28013,7 @@ const powerRef = useRef(hud.power);
           pottedBalls,
           shotContext
         }) => {
-          if (!recording) return null;
+          if (!recording || !hadObjectPot) return null;
           const frameCount = recording.frames?.length ?? 0;
           if (frameCount <= 1) return null;
           const tags = new Set(recording.replayTags ?? []);
@@ -28015,10 +28025,9 @@ const powerRef = useRef(hud.power);
           const priority = ['multi', 'bank', 'long', 'power', 'spin'];
           const primary = priority.find((tag) => tags.has(tag)) ?? 'default';
           const zoomOnly = recording.zoomOnly && !tags.has('long') && !tags.has('bank');
-          const replayLabel = hadObjectPot ? selectReplayBanner(primary) : 'Replay';
           return {
-            shouldReplay: true,
-            banner: replayLabel,
+            shouldReplay: hadObjectPot || tags.size > 0,
+            banner: selectReplayBanner(primary),
             zoomOnly,
             tags: Array.from(tags),
             primaryTag: primary
@@ -28217,6 +28226,18 @@ const powerRef = useRef(hud.power);
           };
         }
         if (shotRecording) {
+          const pottedObjects = potted.filter(
+            (entry) => entry && String(entry.id || '').toLowerCase() !== 'cue'
+          );
+          const firstPottedColor = pottedObjects[0]?.color
+            ? String(pottedObjects[0].color).toUpperCase()
+            : null;
+          shotRecording.replayPottedLabel =
+            pottedObjects.length > 1
+              ? `${pottedObjects.length} Balls Potted`
+              : firstPottedColor
+                ? `Potted: ${firstPottedColor}`
+                : null;
           shotRecording.replayFoul = safeState?.foul
             ? { ...safeState.foul }
             : null;
@@ -31379,14 +31400,25 @@ const powerRef = useRef(hud.power);
       value: powerRef.current * 100,
       cueSrc: '/assets/snooker/cue.webp',
       labels: true,
-      onChange: (v) => applyPower(v / 100),
+      onChange: (v) => {
+        const nextPower = clampPower(v / 100, 0);
+        if (nextPower > 0) {
+          lastSliderPowerRef.current = nextPower;
+        }
+        applyPower(nextPower);
+      },
       onStart: () => {
         captureCueStickAnchor();
       },
       onCommit: (value) => {
-        const committedPower = Number.isFinite(value) ? value / 100 : null;
+        const committedPowerRaw = Number.isFinite(value) ? value / 100 : null;
+        const committedPower = clampPower(
+          committedPowerRaw > 0 ? committedPowerRaw : lastSliderPowerRef.current,
+          0
+        );
         fireRef.current?.(committedPower);
         requestAnimationFrame(() => {
+          lastSliderPowerRef.current = 0;
           slider.set(slider.min, { animate: true });
           applyPower(0);
         });
@@ -31405,6 +31437,7 @@ const powerRef = useRef(hud.power);
     if (slider) {
       slider.set(slider.min, { animate: true });
     }
+    lastSliderPowerRef.current = 0;
     applyPower(0);
     cuePullCurrentRef.current = 0;
     cuePullTargetRef.current = 0;
@@ -32388,6 +32421,11 @@ const powerRef = useRef(hud.power);
             {replayFoul && (
               <div className="mt-2 rounded-full border border-red-300/70 bg-red-500/30 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.28em] text-red-100 shadow-[0_10px_28px_rgba(0,0,0,0.45)]">
                 Foul{replayFoul.reason ? `: ${replayFoul.reason}` : ''}
+              </div>
+            )}
+            {!replayFoul && replayPottedLabel && (
+              <div className="mt-2 rounded-full border border-emerald-300/70 bg-emerald-500/25 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.22em] text-emerald-100 shadow-[0_10px_28px_rgba(0,0,0,0.45)]">
+                {replayPottedLabel}
               </div>
             )}
           </div>


### PR DESCRIPTION
### Motivation
- Prevent the user-visible cue animation from firing without applying power to the cueball when the slider commit payload is empty or zero. 
- Make Pool Royale replay decisions and UI feedback behave the same way as Snooker Royal (replay gated by object-ball pots and clearly show fouls or potted outcomes). 

### Description
- Use a `lastSliderPowerRef` fallback so `fire()` will use the latest non-zero dragged slider value when the committed power is missing or zero, avoiding shots with no applied impulse. 
- Require `hadObjectPot` when forming the base replay decision (match Snooker Royal gating) and preserve existing tag/prioritization logic. 
- Record a `replayPottedLabel` into `shotRecording` (single-color label or count) and expose it via a new `replayPottedLabel` state so the replay frame shows either a foul or a potted summary. 
- Clear and set `replayPottedLabel` together with `replayFoul` on replay start, finish and skip to keep replay UI lifecycle consistent. 

### Testing
- Ran a full webapp production build with `npm --prefix webapp run build` and the build completed successfully (Vite emitted non-blocking chunk/dynamic-import warnings only). 
- Verified the Pool Royale page compiles and the runtime code paths for `fire()` and replay start/finish/skip were updated; no new build errors were introduced. 
- Note: no repository `lint` script was available to run a lint target, so only the build was used for automated validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d00ba489bc8329bee5bfa1706eac24)