### PR TITLE
Sync cue stroke to broadcast camera and hold cue view on strike

### DIFF
--- a/Assets/Scripts/Gameplay/CueController.cs
+++ b/Assets/Scripts/Gameplay/CueController.cs
@@ -44,6 +44,9 @@ namespace Aiming
         [Header("Spin input")]
         [Tooltip("Receives normalized spin values from the existing on-screen spin controller.")]
         public Vector2 spinInput;
+        [Header("Camera sync")]
+        [Tooltip("Optional cue camera that should mirror pull/push stroke motion for player, AI, and replay capture.")]
+        public CueCamera cueCamera;
         public CueStrikePhysics strikePhysics = new CueStrikePhysics();
 
         Vector3 _aimDirection = Vector3.forward;
@@ -199,6 +202,30 @@ namespace Aiming
             {
                 cueTip.position = anchor - _aimDirection * _currentCueDepth;
             }
+
+            SyncCueCameraStroke();
+        }
+
+        void SyncCueCameraStroke()
+        {
+            if (cueCamera == null)
+            {
+                return;
+            }
+
+            float delta = _currentCueDepth - idleTipGap;
+            float stroke;
+            if (delta >= 0f)
+            {
+                stroke = pullRange > 0.0001f ? delta / pullRange : 0f;
+            }
+            else
+            {
+                float pushRange = Mathf.Max(0.0001f, idleTipGap - contactTipGap);
+                stroke = delta / pushRange;
+            }
+
+            cueCamera.SetCueStickStroke(Mathf.Clamp(stroke, -1f, 1f));
         }
 
         ShotSolution BuildAimSolution()

--- a/billiards.Unity/CueCamera.cs
+++ b/billiards.Unity/CueCamera.cs
@@ -232,6 +232,10 @@ public class CueCamera : MonoBehaviour
     public float cueStickMaxPush = 0.05f;
     // Visual smoothing for cue stick pull/push.
     public float cueStickStrokeSmooth = 14f;
+    [Header("Shot timing")]
+    // Time to keep the cue camera locked on the strike after trigger before
+    // switching to broadcast follow cameras.
+    public float cueStrikeCameraHoldSeconds = 0.14f;
 
     private float yaw;
     // Blend controlling how far the cue view slides toward the cue ball. 0 keeps
@@ -260,6 +264,8 @@ public class CueCamera : MonoBehaviour
     private float cueStickStrokeVisual;
     private float smoothedCueDistance;
     private bool hasSmoothedCueDistance;
+    private float cueStrikeHoldUntilTime;
+    private bool holdCueAimDuringShot;
     private Vector3 ballInHandTargetPosition;
     [Header("Occlusion settings")]
     // Layers that should be considered when preventing the camera from getting
@@ -324,6 +330,8 @@ public class CueCamera : MonoBehaviour
         shotInProgress = true;
         ballInHandActive = false;
         usingTargetCamera = false;
+        holdCueAimDuringShot = cueStrikeCameraHoldSeconds > 0f;
+        cueStrikeHoldUntilTime = Time.time + Mathf.Max(0f, cueStrikeCameraHoldSeconds);
 
         int aimSide = nextShotIsAi ? -defaultShortRailSign : defaultShortRailSign;
         cueAimSideSign = aimSide;
@@ -392,8 +400,13 @@ public class CueCamera : MonoBehaviour
         {
             UpdateTargetCamera();
         }
+        else if (holdCueAimDuringShot && Time.time < cueStrikeHoldUntilTime)
+        {
+            PositionCueAimCamera(Time.deltaTime, false);
+        }
         else
         {
+            holdCueAimDuringShot = false;
             UpdateBroadcastCamera();
         }
     }
@@ -410,10 +423,13 @@ public class CueCamera : MonoBehaviour
             return;
         }
 
-        int desiredSide = nextShotIsAi ? -defaultShortRailSign : defaultShortRailSign;
-        if (cueAimSideSign != desiredSide)
+        if (!shotInProgress)
         {
-            cueAimSideSign = desiredSide;
+            int desiredSide = nextShotIsAi ? -defaultShortRailSign : defaultShortRailSign;
+            if (cueAimSideSign != desiredSide)
+            {
+                cueAimSideSign = desiredSide;
+            }
         }
 
         Vector3 desiredForward = GetCueAxis();
@@ -1369,6 +1385,7 @@ public class CueCamera : MonoBehaviour
     {
         shotInProgress = false;
         usingTargetCamera = false;
+        holdCueAimDuringShot = false;
         pocketCameraAwaitingDrop = false;
         pocketDropDetected = false;
         pocketCameraStartTime = 0f;


### PR DESCRIPTION
### Motivation
- Improve shot readability by making the cue stick pull/forward push visible to the broadcast/cue camera for both player and AI shots and during replay playback.
- Ensure the camera holds on the cue impact frame briefly before switching to follow/broadcast cameras so the strike is clearly visible.
- Prevent camera side flips while a shot is resolving so the cue framing remains stable during the strike window.

### Description
- Added an optional `CueCamera cueCamera` field to `Assets/Scripts/Gameplay/CueController.cs` and wired a normalized stroke value from cue depth to the camera via `SyncCueCameraStroke()` so pull (+) and push (−) map to `CueCamera.SetCueStickStroke(...)` every pose update.
- Introduced a configurable `cueStrikeCameraHoldSeconds` (default `0.14f`) and internal `holdCueAimDuringShot`/`cueStrikeHoldUntilTime` state in `billiards.Unity/CueCamera.cs` to keep the cue aim camera locked on the strike for the configured window before transitioning to the broadcast follow camera.
- Prevented cue-side re-selection while a shot is in progress by only updating `cueAimSideSign` when `shotInProgress` is false, keeping the framing stable for player and AI shots.
- Reset the strike-hold state when the shot ends so normal camera behavior resumes.

### Testing
- Attempted to run the unit tests with `dotnet test billiards.Tests/Billiards.Tests.csproj`, but the `dotnet` tool was not available in the environment so automated tests could not be executed (failed).
- Verified the patch by inspecting diffs of `Assets/Scripts/Gameplay/CueController.cs` and `billiards.Unity/CueCamera.cs` to confirm the intended changes were applied successfully (inspection succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0057f75a08329ac4ce52ec43d301c)