### PR TITLE
Tune Domino table alignment and enforce 4K/8K graphics fallbacks

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -21,8 +21,8 @@ const FRAME_RATE_OPTIONS = Object.freeze([
     fps: 60,
     renderScale: 1,
     pixelRatioCap: 1,
-    resolution: '2K assets • 1K fallback',
-    description: '2K profile for 60 Hz displays with 1K fallback.'
+    resolution: '2K assets • 4K fallback',
+    description: '2K profile for 60 Hz displays with 4K fallback.'
   },
   {
     id: 'qhd90',
@@ -30,8 +30,8 @@ const FRAME_RATE_OPTIONS = Object.freeze([
     fps: 90,
     renderScale: 1,
     pixelRatioCap: 1.5,
-    resolution: '4K assets • 2K fallback',
-    description: '4K profile for 90 Hz displays with 2K fallback.'
+    resolution: '4K assets • 4K fallback',
+    description: '4K profile for 90 Hz displays with 4K fallback.'
   },
   {
     id: 'uhd120',
@@ -89,6 +89,11 @@ const FRAME_RATE_MODEL_RESOLUTION_ORDER_MAP = Object.freeze({
   qhd90: Object.freeze(['4k', '2k']),
   uhd120: Object.freeze(['8k', '4k'])
 });
+const FRAME_RATE_TABLE_MODEL_RESOLUTION_ORDER_MAP = Object.freeze({
+  fhd60: Object.freeze(['2k', '4k']),
+  qhd90: Object.freeze(['4k']),
+  uhd120: Object.freeze(['8k', '4k'])
+});
 const FRAME_RATE_WOOD_TEXTURE_RESOLUTION_MAP = Object.freeze({
   fhd60: '2k',
   qhd90: '4k',
@@ -141,6 +146,16 @@ function resolveGraphicsModelResolutions(qualityId = DEFAULT_FRAME_RATE_ID) {
     FRAME_RATE_MODEL_RESOLUTION_ORDER_MAP[qualityId] ??
     FRAME_RATE_MODEL_RESOLUTION_ORDER_MAP[DEFAULT_FRAME_RATE_ID] ??
     ['2k', '1k']
+  );
+}
+
+function resolveGraphicsTableModelResolutions(
+  qualityId = DEFAULT_FRAME_RATE_ID
+) {
+  return (
+    FRAME_RATE_TABLE_MODEL_RESOLUTION_ORDER_MAP[qualityId] ??
+    FRAME_RATE_TABLE_MODEL_RESOLUTION_ORDER_MAP[DEFAULT_FRAME_RATE_ID] ??
+    ['2k', '4k']
   );
 }
 
@@ -2748,10 +2763,13 @@ function buildPolyhavenModelUrls(assetId, resolutionOrder = ['2k', '1k']) {
 
 async function loadPolyhavenModel(
   assetId,
-  { preserveGltfTextureMapping = true } = {}
+  { preserveGltfTextureMapping = true, resolutionOrder = null } = {}
 ) {
   if (!assetId) return null;
-  const preferredResolutions = resolveGraphicsModelResolutions(frameRateId);
+  const preferredResolutions =
+    Array.isArray(resolutionOrder) && resolutionOrder.length
+      ? resolutionOrder
+      : resolveGraphicsModelResolutions(frameRateId);
   const cacheKey = `${assetId.toLowerCase()}::${preferredResolutions.join(',')}::${preserveGltfTextureMapping ? 'preserve' : 'normalized'}`;
   if (polyhavenModelCache.has(cacheKey)) {
     const cached = polyhavenModelCache.get(cacheKey);
@@ -4486,9 +4504,9 @@ function resolveHdriPolicyForFrameRate(qualityId = DEFAULT_FRAME_RATE_ID, fps = 
     return Object.freeze({ preferredResolutions: Object.freeze(['4k']) });
   }
   if (qualityId === 'qhd90' || fps >= 90) {
-    return Object.freeze({ preferredResolutions: Object.freeze(['2k']) });
+    return Object.freeze({ preferredResolutions: Object.freeze(['4k']) });
   }
-  return Object.freeze({ preferredResolutions: Object.freeze(['1k']) });
+  return Object.freeze({ preferredResolutions: Object.freeze(['4k']) });
 }
 const isTelegramWebView = IS_TELEGRAM_RUNTIME;
 const isMobileDevice = /Android|iPhone|iPad|iPod|Mobile/i.test(
@@ -4597,8 +4615,8 @@ function resolveOfficialHdriOrder(requestedResolution, availableResolutions = []
   if (!requested) return [];
   const aliases = {
     '8k': ['8k', '4k'],
-    '4k': ['4k', '2k'],
-    '2k': ['2k', '1k']
+    '4k': ['4k'],
+    '2k': ['2k', '4k']
   };
   const requestedOrder = aliases[requested] || [requested];
   const availableSet = new Set(
@@ -6024,7 +6042,8 @@ function disposeObjectResources(object, { disposeTextures = true } = {}) {
   });
 }
 
-const NON_OCTAGON_TABLE_ROTATION = THREE.MathUtils.degToRad(6);
+const NON_OCTAGON_TABLE_ROTATION = THREE.MathUtils.degToRad(3.25);
+const NON_OCTAGON_TABLE_SIDE_SHRINK = 0.94;
 
 function fitTableModelToFootprint(model) {
   if (!model) return;
@@ -6034,6 +6053,8 @@ function fitTableModelToFootprint(model) {
   const maxSide = Math.max(size.x, size.z, 0.0001);
   const scale = targetDiameter / maxSide;
   model.scale.multiplyScalar(scale);
+  model.scale.x *= NON_OCTAGON_TABLE_SIDE_SHRINK;
+  model.scale.z *= NON_OCTAGON_TABLE_SIDE_SHRINK;
 
   const scaled = new THREE.Box3().setFromObject(model);
   const offset = new THREE.Vector3(
@@ -6076,7 +6097,8 @@ async function applyTableTheme(
   setProceduralTableVisible(true);
   try {
     const model = await loadPolyhavenModel(theme.assetId || theme.id, {
-      preserveGltfTextureMapping: theme.preserveMaterials ?? true
+      preserveGltfTextureMapping: theme.preserveMaterials ?? true,
+      resolutionOrder: resolveGraphicsTableModelResolutions(frameRateId)
     });
     if (token !== tableThemeToken || !model) {
       disposeObjectResources(model, { disposeTextures: false });
@@ -6093,7 +6115,10 @@ async function applyTableTheme(
       try {
         const fallbackModel = await loadPolyhavenModel(
           DEFAULT_TABLE_THEME_OPTION.assetId,
-          { preserveGltfTextureMapping: true }
+          {
+            preserveGltfTextureMapping: true,
+            resolutionOrder: resolveGraphicsTableModelResolutions(frameRateId)
+          }
         );
         if (token !== tableThemeToken || !fallbackModel) {
           disposeObjectResources(fallbackModel, { disposeTextures: false });


### PR DESCRIPTION
### Motivation
- Make non-octagon Domino tables visually straighter and slightly narrower from the sides while leaving the octagon table behavior untouched. 
- Ensure PolyHaven model and HDRI selection follow the requested quality tiers so displays at 60/90/120 Hz pick appropriate model textures and HDRIs with a reliable 4K fallback for high-refresh cases.

### Description
- Added a table-specific resolution policy `FRAME_RATE_TABLE_MODEL_RESOLUTION_ORDER_MAP` and helper `resolveGraphicsTableModelResolutions(qualityId)` to prefer table model resolutions per frame-rate profile. 
- Extended `loadPolyhavenModel` to accept an optional `resolutionOrder` parameter so callers can request table-specific resolution chains. 
- Wired table theme loading to call `loadPolyhavenModel(..., { resolutionOrder: resolveGraphicsTableModelResolutions(frameRateId) })` so PolyHaven table models respect the new table policy. 
- Reduced non-octagon table yaw from `6°` to `3.25°` (`NON_OCTAGON_TABLE_ROTATION`) and applied a side-only shrink factor `NON_OCTAGON_TABLE_SIDE_SHRINK = 0.94` to `model.scale.x` and `model.scale.z` in `fitTableModelToFootprint` to make non-octagon tables appear straighter and slightly narrower while preserving height alignment. 
- Updated `FRAME_RATE_OPTIONS` labels/descriptions to reflect new fallback behavior (60 Hz -> 2K with 4K fallback, 90 Hz -> 4K, 120 Hz -> 8K with 4K fallback). 
- Adjusted HDRI resolution policy via `resolveHdriPolicyForFrameRate` and `resolveOfficialHdriOrder` so 120 Hz prioritizes `8k` with `4k` as the defined fallback, and `2k` selection can fall back to `4k` when appropriate. 

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` to verify syntax and the modified module parses cleanly; the check succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d00e9408388329beecc32675604252)