### PR TITLE
Tune Domino table alignment and Polyhaven resolution fallbacks

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -85,7 +85,7 @@ const DOMINO_TEXTURE_SIZE_MAP = Object.freeze({
   uhd120: 8192
 });
 const FRAME_RATE_MODEL_RESOLUTION_ORDER_MAP = Object.freeze({
-  fhd60: Object.freeze(['2k', '1k']),
+  fhd60: Object.freeze(['2k', '4k', '1k']),
   qhd90: Object.freeze(['4k', '2k']),
   uhd120: Object.freeze(['8k', '4k'])
 });
@@ -6024,16 +6024,22 @@ function disposeObjectResources(object, { disposeTextures = true } = {}) {
   });
 }
 
-const NON_OCTAGON_TABLE_ROTATION = THREE.MathUtils.degToRad(6);
+const NON_OCTAGON_TABLE_ROTATION = THREE.MathUtils.degToRad(3.5);
+const NON_OCTAGON_TABLE_SIDE_SCALE = 0.95;
 
-function fitTableModelToFootprint(model) {
+function fitTableModelToFootprint(model, { keepOctagonProfile = false } = {}) {
   if (!model) return;
   const box = new THREE.Box3().setFromObject(model);
   const size = box.getSize(new THREE.Vector3());
   const targetDiameter = TABLE_RADIUS * 2.1;
   const maxSide = Math.max(size.x, size.z, 0.0001);
-  const scale = targetDiameter / maxSide;
-  model.scale.multiplyScalar(scale);
+  const footprintScale = targetDiameter / maxSide;
+  const sideScale = keepOctagonProfile ? 1 : NON_OCTAGON_TABLE_SIDE_SCALE;
+  model.scale.set(
+    footprintScale * sideScale,
+    footprintScale,
+    footprintScale * sideScale
+  );
 
   const scaled = new THREE.Box3().setFromObject(model);
   const offset = new THREE.Vector3(
@@ -6082,7 +6088,9 @@ async function applyTableTheme(
       disposeObjectResources(model, { disposeTextures: false });
       return;
     }
-    fitTableModelToFootprint(model);
+    fitTableModelToFootprint(model, {
+      keepOctagonProfile: useOctagonRotation
+    });
     tableThemeG.add(model);
     tableThemeG.visible = true;
     setProceduralTableVisible(false);
@@ -6099,7 +6107,9 @@ async function applyTableTheme(
           disposeObjectResources(fallbackModel, { disposeTextures: false });
           return;
         }
-        fitTableModelToFootprint(fallbackModel);
+        fitTableModelToFootprint(fallbackModel, {
+          keepOctagonProfile: true
+        });
         tableThemeG.add(fallbackModel);
         tableThemeG.visible = true;
         setProceduralTableVisible(false);


### PR DESCRIPTION
### Motivation
- Non-octagon table models imported from PolyHaven appeared visually tilted and too wide from the sides in the Domino Battle Royal scene and needed a subtle alignment and size adjustment while preserving the octagon table behavior.
- Model asset selection at different refresh rates needed stronger preferences for higher-resolution PolyHaven models so 60/90/120 Hz users receive appropriate quality with sensible fallbacks.

### Description
- Reduced non-octagon table yaw from 6° to 3.5° by changing `NON_OCTAGON_TABLE_ROTATION` so non-octagon tables render straighter in the gameplay camera.
- Added `NON_OCTAGON_TABLE_SIDE_SCALE = 0.95` and updated `fitTableModelToFootprint` to apply side-only X/Z scaling (while preserving Y scale) for non-octagon tables so they are slightly narrower from the sides but keep the same height.
- Made `fitTableModelToFootprint` accept an option `{ keepOctagonProfile }` and wired callers in `applyTableTheme` and fallback load paths to preserve the octagon table profile (no side scaling) for the default octagon theme and its fallback.
- Updated PolyHaven model resolution order map `FRAME_RATE_MODEL_RESOLUTION_ORDER_MAP` so `fhd60` now prefers `['2k','4k','1k']`, while `qhd90` remains `['4k','2k']` and `uhd120` remains `['8k','4k']`, giving 60 Hz users a 4K fallback option and keeping 120 Hz targeting 8K with 4K fallback.

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` which completed without syntax errors.
- Verified file updates are present by scanning the modified file (search/inspection commands used in the rollout); no automated browser rendering tests were executed in this run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d00e9408388329beecc32675604252)