### PR TITLE
Fix Pool Royale cue stick power transfer on strike

### DIFF
--- a/Assets/Scripts/Gameplay/CueController.cs
+++ b/Assets/Scripts/Gameplay/CueController.cs
@@ -40,6 +40,10 @@ namespace Aiming
         [Range(0.02f, 0.25f)] public float contactDrivePortion = 0.1f;
         [Tooltip("Minimum pull used for strike animation so the cue visibly drives forward every shot.")]
         [Min(0f)] public float minimumVisualPull = 0.025f;
+        [Tooltip("Minimum normalized shot power that is still treated as a real strike.")]
+        [Range(0f, 1f)] public float minimumStrikePower = 0.02f;
+        [Tooltip("How much the cue-stick forward travel contributes to final shot power (0 = slider only, 1 = full blend).")]
+        [Range(0f, 1f)] public float strokeTravelPowerWeight = 0.65f;
 
         [Header("Spin input")]
         [Tooltip("Receives normalized spin values from the existing on-screen spin controller.")]
@@ -146,8 +150,9 @@ namespace Aiming
             }
 
             float recoveredPower = RecoverPowerFromCueDepth(_chargedCueDepth);
-            _latchedShotPower = Mathf.Clamp01(Mathf.Max(_power, recoveredPower));
-            if (_latchedShotPower <= 0.02f)
+            float currentDepthPower = RecoverPowerFromCueDepth(_currentCueDepth);
+            _latchedShotPower = Mathf.Clamp01(Mathf.Max(_power, recoveredPower, currentDepthPower));
+            if (_latchedShotPower <= minimumStrikePower)
             {
                 _shotState = ShotState.Idle;
                 _chargedCueDepth = idleTipGap;
@@ -294,7 +299,8 @@ namespace Aiming
                 if (!didStrike && t >= hitT)
                 {
                     didStrike = true;
-                    ApplyStrikeImpulse(strikeDirection, shotPower);
+                    float transmittedPower = ComputeTransmittedPower(shotPower, visualPull);
+                    ApplyStrikeImpulse(strikeDirection, transmittedPower);
                 }
 
                 yield return null;
@@ -302,7 +308,8 @@ namespace Aiming
 
             if (!didStrike)
             {
-                ApplyStrikeImpulse(strikeDirection, shotPower);
+                float transmittedPower = ComputeTransmittedPower(shotPower, visualPull);
+                ApplyStrikeImpulse(strikeDirection, transmittedPower);
             }
 
             _currentCueDepth = contactDepth;
@@ -325,7 +332,15 @@ namespace Aiming
             }
 
             float impulseMagnitude = Mathf.Lerp(baseStrikeImpulse, maxStrikeImpulse, Mathf.Clamp01(shotPower));
+            cueBallBody.WakeUp();
             strikePhysics.Apply(cueBallBody, strikeDirection, impulseMagnitude, spinInput, ballRadius);
+        }
+
+        float ComputeTransmittedPower(float sliderPower, float visualPull)
+        {
+            float pullPower = pullRange > 0.0001f ? Mathf.Clamp01(visualPull / pullRange) : 0f;
+            float blendedPower = Mathf.Lerp(sliderPower, Mathf.Max(sliderPower, pullPower), strokeTravelPowerWeight);
+            return Mathf.Clamp01(Mathf.Max(sliderPower, blendedPower));
         }
 
         static float EaseOutCubic(float t)

--- a/Assets/Tests/PlayMode/CueStrikePhysicsTests.cs
+++ b/Assets/Tests/PlayMode/CueStrikePhysicsTests.cs
@@ -36,5 +36,26 @@ namespace Aiming.Tests
 
             Object.DestroyImmediate(go);
         }
+
+        [Test]
+        public void Apply_HigherImpulse_ProducesHigherLinearVelocity()
+        {
+            var lowGo = new GameObject("CueBallLow");
+            var lowRb = lowGo.AddComponent<Rigidbody>();
+            lowRb.useGravity = false;
+
+            var highGo = new GameObject("CueBallHigh");
+            var highRb = highGo.AddComponent<Rigidbody>();
+            highRb.useGravity = false;
+
+            var physics = new CueStrikePhysics();
+            physics.Apply(lowRb, Vector3.forward, 1.5f, Vector2.zero, 0.028575f);
+            physics.Apply(highRb, Vector3.forward, 5f, Vector2.zero, 0.028575f);
+
+            Assert.Greater(highRb.velocity.z, lowRb.velocity.z);
+
+            Object.DestroyImmediate(lowGo);
+            Object.DestroyImmediate(highGo);
+        }
     }
 }


### PR DESCRIPTION
### Motivation
- The cue-stick forward animation could play a strike without transferring power to the cue ball, producing weak or zero shots; the strike needs to reliably use slider power and the actual pulled cue travel.

### Description
- Latched strike power now considers the slider value, recovered power from `_chargedCueDepth`, and the current visual cue depth by updating `ReleaseAndStrike` to compute `_latchedShotPower` from all sources in `Assets/Scripts/Gameplay/CueController.cs`.
- Added `minimumStrikePower` and `strokeTravelPowerWeight` parameters and implemented `ComputeTransmittedPower` to blend slider power with cue-stick travel, and used the blended value when applying the strike during the `StrikeRoutine`.
- Ensured the cue ball Rigidbody is `WakeUp()`-ed before applying the impulse so the force always takes effect at hit time.
- Added a PlayMode test `Apply_HigherImpulse_ProducesHigherLinearVelocity` in `Assets/Tests/PlayMode/CueStrikePhysicsTests.cs` to validate higher impulse yields higher forward velocity.

### Testing
- A new Unity PlayMode test `Apply_HigherImpulse_ProducesHigherLinearVelocity` was added but Unity tests were not executed in this environment (no test runner available).
- No automated PlayMode or EditMode tests were run here; changes were committed locally to the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d01703cc6c83298d839c44d718ccd9)