### PR TITLE
Domino BR: straighten non-octagon tables and apply selective side shrink

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -6042,10 +6042,59 @@ function disposeObjectResources(object, { disposeTextures = true } = {}) {
   });
 }
 
-const NON_OCTAGON_TABLE_ROTATION = THREE.MathUtils.degToRad(4.1);
-const NON_OCTAGON_TABLE_SIDE_SHRINK = 0.94;
+const LEGACY_NON_OCTAGON_TABLE_ROTATION = THREE.MathUtils.degToRad(4.1);
+const NON_OCTAGON_TABLE_ROTATION = 0;
+const NON_OCTAGON_TABLE_SIDE_SHRINK = 0.91;
+const TABLE_ROTATION_EXCLUDED_THEME_IDS = new Set([
+  'murlan-default',
+  'coffee_table_round_01',
+  'round_wooden_table_02'
+]);
+const TABLE_SIDE_SHRINK_EXCLUDED_THEME_IDS = new Set([
+  'murlan-default',
+  'coffee_table_round_01',
+  'round_wooden_table_02',
+  'diamond-edge',
+  'diamond_edge',
+  'diamondEdge'
+]);
 
-function fitTableModelToFootprint(model) {
+function normalizeThemeId(themeId = '') {
+  return String(themeId || '').trim().toLowerCase();
+}
+
+function isOvalTheme(themeId = '') {
+  return normalizeThemeId(themeId).includes('oval');
+}
+
+function isDiamondTheme(themeId = '') {
+  return normalizeThemeId(themeId).includes('diamond');
+}
+
+function shouldKeepLegacyRotation(themeId = '') {
+  const normalized = normalizeThemeId(themeId);
+  if (!normalized) return false;
+  if (normalized === 'murlan-default') return false;
+  if (TABLE_ROTATION_EXCLUDED_THEME_IDS.has(normalized)) return true;
+  return isOvalTheme(normalized) || isDiamondTheme(normalized);
+}
+
+function resolveTableThemeRotation(themeId = '') {
+  const normalized = normalizeThemeId(themeId);
+  if (normalized === 'murlan-default') return TABLE_OCTAGON_ROTATION;
+  return shouldKeepLegacyRotation(normalized)
+    ? LEGACY_NON_OCTAGON_TABLE_ROTATION
+    : NON_OCTAGON_TABLE_ROTATION;
+}
+
+function shouldApplySideShrink(themeId = '') {
+  const normalized = normalizeThemeId(themeId);
+  if (!normalized) return true;
+  if (TABLE_SIDE_SHRINK_EXCLUDED_THEME_IDS.has(normalized)) return false;
+  return !(isOvalTheme(normalized) || isDiamondTheme(normalized));
+}
+
+function fitTableModelToFootprint(model, themeId = '') {
   if (!model) return;
   const box = new THREE.Box3().setFromObject(model);
   const size = box.getSize(new THREE.Vector3());
@@ -6053,8 +6102,10 @@ function fitTableModelToFootprint(model) {
   const maxSide = Math.max(size.x, size.z, 0.0001);
   const scale = targetDiameter / maxSide;
   model.scale.multiplyScalar(scale);
-  model.scale.x *= NON_OCTAGON_TABLE_SIDE_SHRINK;
-  model.scale.z *= NON_OCTAGON_TABLE_SIDE_SHRINK;
+  if (shouldApplySideShrink(themeId)) {
+    model.scale.x *= NON_OCTAGON_TABLE_SIDE_SHRINK;
+    model.scale.z *= NON_OCTAGON_TABLE_SIDE_SHRINK;
+  }
 
   const scaled = new THREE.Box3().setFromObject(model);
   const offset = new THREE.Vector3(
@@ -6078,10 +6129,7 @@ async function applyTableTheme(
   option = TABLE_THEME_OPTIONS[appearance.tableTheme] ?? DEFAULT_TABLE_THEME_OPTION
 ) {
   const theme = option || DEFAULT_TABLE_THEME_OPTION;
-  const useOctagonRotation = theme?.id === 'murlan-default';
-  tableThemeG.rotation.y = useOctagonRotation
-    ? TABLE_OCTAGON_ROTATION
-    : NON_OCTAGON_TABLE_ROTATION;
+  tableThemeG.rotation.y = resolveTableThemeRotation(theme?.id);
   tableThemeG.visible = false;
   while (tableThemeG.children.length) {
     const child = tableThemeG.children.pop();
@@ -6104,7 +6152,7 @@ async function applyTableTheme(
       disposeObjectResources(model, { disposeTextures: false });
       return;
     }
-    fitTableModelToFootprint(model);
+    fitTableModelToFootprint(model, theme?.id);
     tableThemeG.add(model);
     tableThemeG.visible = true;
     setProceduralTableVisible(false);
@@ -6124,7 +6172,7 @@ async function applyTableTheme(
           disposeObjectResources(fallbackModel, { disposeTextures: false });
           return;
         }
-        fitTableModelToFootprint(fallbackModel);
+        fitTableModelToFootprint(fallbackModel, DEFAULT_TABLE_THEME_OPTION?.id);
         tableThemeG.add(fallbackModel);
         tableThemeG.visible = true;
         setProceduralTableVisible(false);


### PR DESCRIPTION
### Motivation
- Ensure domino guide lines on table sides render perfectly horizontal/vertical by removing the small tilt applied to most table themes. 
- Preserve the intended look of special table shapes (octagon, oval, diamond) by excluding them from the straightening and shrink behavior. 
- Make table footprints slightly narrower from the sides while keeping height unchanged so the playable area looks tighter on screen.

### Description
- Replaced the single non-octagon tilt with conditional rotation logic and a rotation resolver (`resolveTableThemeRotation`) that returns either octagon, legacy, or zero rotation depending on theme id. 
- Added helper checks (`normalizeThemeId`, `isOvalTheme`, `isDiamondTheme`) and exclusion sets (`TABLE_ROTATION_EXCLUDED_THEME_IDS`, `TABLE_SIDE_SHRINK_EXCLUDED_THEME_IDS`) to identify themes that should keep legacy behavior. 
- Set the effective non-octagon rotation to `0` and adjusted side shrink factor to `0.91`, while keeping a `LEGACY_NON_OCTAGON_TABLE_ROTATION` available for names that should preserve the previous tilt. 
- Threaded the active theme id into `fitTableModelToFootprint(model, themeId)` and conditionally apply side shrink there; updated `applyTableTheme` and fallback handling to pass the theme id into the fitter.

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` to validate the modified file and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d018d06098832986befecab2155ef4)