### PR TITLE
Latch cue power during charge so UI slider resets don't zero-out strikes

### DIFF
--- a/Assets/Scripts/Gameplay/CueController.cs
+++ b/Assets/Scripts/Gameplay/CueController.cs
@@ -55,6 +55,7 @@ namespace Aiming
         float _currentCueDepth;
         float _chargedCueDepth;
         float _power;
+        float _maxPowerDuringCharge;
         float _latchedShotPower;
         ShotState _shotState = ShotState.Idle;
 
@@ -94,7 +95,9 @@ namespace Aiming
 
             if (_shotState == ShotState.Dragging)
             {
-                float pull = pullRange * EaseOutCubic(_power);
+                _maxPowerDuringCharge = Mathf.Max(_maxPowerDuringCharge, _power);
+                float effectivePower = Mathf.Max(_power, _maxPowerDuringCharge);
+                float pull = pullRange * EaseOutCubic(effectivePower);
                 _chargedCueDepth = idleTipGap + pull;
                 _currentCueDepth = _chargedCueDepth;
                 UpdateCuePose();
@@ -111,6 +114,7 @@ namespace Aiming
             _cueAnchorPosition = cueBall.position;
             _shotState = ShotState.Dragging;
             _power = Mathf.Max(_power, RecoverPowerFromCueDepth(_currentCueDepth));
+            _maxPowerDuringCharge = _power;
             _latchedShotPower = 0f;
             _chargedCueDepth = idleTipGap + (pullRange * EaseOutCubic(_power));
             _currentCueDepth = _chargedCueDepth;
@@ -132,6 +136,7 @@ namespace Aiming
 
             _shotState = ShotState.Idle;
             _power = 0f;
+            _maxPowerDuringCharge = 0f;
             _latchedShotPower = 0f;
             _chargedCueDepth = idleTipGap;
             _currentCueDepth = idleTipGap;
@@ -146,10 +151,11 @@ namespace Aiming
             }
 
             float recoveredPower = RecoverPowerFromCueDepth(_chargedCueDepth);
-            _latchedShotPower = Mathf.Clamp01(Mathf.Max(_power, recoveredPower));
+            _latchedShotPower = Mathf.Clamp01(Mathf.Max(Mathf.Max(_power, recoveredPower), _maxPowerDuringCharge));
             if (_latchedShotPower <= 0.02f)
             {
                 _shotState = ShotState.Idle;
+                _maxPowerDuringCharge = 0f;
                 _chargedCueDepth = idleTipGap;
                 _currentCueDepth = idleTipGap;
                 UpdateCuePose();
@@ -188,7 +194,8 @@ namespace Aiming
         {
             if (_shotState == ShotState.Dragging)
             {
-                float pull = pullRange * EaseOutCubic(_power);
+                float effectivePower = Mathf.Max(_power, _maxPowerDuringCharge);
+                float pull = pullRange * EaseOutCubic(effectivePower);
                 _chargedCueDepth = idleTipGap + pull;
                 _currentCueDepth = _chargedCueDepth;
                 return;
@@ -311,6 +318,7 @@ namespace Aiming
 
             _currentCueDepth = idleTipGap;
             _power = 0f;
+            _maxPowerDuringCharge = 0f;
             _latchedShotPower = 0f;
             _chargedCueDepth = idleTipGap;
             _shotState = ShotState.Idle;


### PR DESCRIPTION
### Motivation
- The cue animation could play while the cue ball received little or no impulse because a transient `0` from the power slider right before release would clear the intended shot power. 
- We need the visual cue pull and the physics impulse to consistently reflect the highest power reached during the charge cycle so shots feel reliable.

### Description
- Added a `_maxPowerDuringCharge` field to `Assets/Scripts/Gameplay/CueController.cs` to remember the highest normalized power observed during a charge. 
- Updated `SetChargePower` and `UpdateCueDepth` to use the effective (latched) power for cue pull visualization so the cue animation reflects the highest charge. 
- Initialized `_maxPowerDuringCharge` in `BeginCharge` and included it when computing `_latchedShotPower` in `ReleaseAndStrike` so the strike uses the strongest available power source (`_power`, recovered depth, or `_maxPowerDuringCharge`). 
- Reset `_maxPowerDuringCharge` on `CancelCharge`, after zero-power early-exit in `ReleaseAndStrike`, and after the strike completes to avoid stale values.

### Testing
- No automated runtime or PlayMode tests were executed in this CLI environment; please run Unity Editor PlayMode tests to validate behavior (recommended: verify slider edge cases where UI sends `0` during release).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d01703cc6c83298d839c44d718ccd9)