### PR TITLE
Align Domino Battle Royale table orientation and exclude octagon/oval/diamond from side-scaling

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -6042,10 +6042,26 @@ function disposeObjectResources(object, { disposeTextures = true } = {}) {
   });
 }
 
-const NON_OCTAGON_TABLE_ROTATION = THREE.MathUtils.degToRad(4.1);
-const NON_OCTAGON_TABLE_SIDE_SHRINK = 0.94;
+const LEGACY_NON_OCTAGON_TABLE_ROTATION = THREE.MathUtils.degToRad(4.1);
+const STRAIGHT_TABLE_ROTATION = 0;
+const NON_OCTAGON_TABLE_SIDE_SHRINK = 0.9;
+const LEGACY_NON_OCTAGON_TABLE_SIDE_SHRINK = 0.94;
 
-function fitTableModelToFootprint(model) {
+function shouldKeepOriginalTableTransform(themeId = '') {
+  const normalized = String(themeId || '').trim().toLowerCase();
+  if (!normalized) return false;
+  return (
+    normalized === 'murlan-default' ||
+    normalized.includes('octagon') ||
+    normalized.includes('oval') ||
+    normalized.includes('diamond')
+  );
+}
+
+function fitTableModelToFootprint(
+  model,
+  { shrinkSides = true, sideShrinkScale = NON_OCTAGON_TABLE_SIDE_SHRINK } = {}
+) {
   if (!model) return;
   const box = new THREE.Box3().setFromObject(model);
   const size = box.getSize(new THREE.Vector3());
@@ -6053,8 +6069,10 @@ function fitTableModelToFootprint(model) {
   const maxSide = Math.max(size.x, size.z, 0.0001);
   const scale = targetDiameter / maxSide;
   model.scale.multiplyScalar(scale);
-  model.scale.x *= NON_OCTAGON_TABLE_SIDE_SHRINK;
-  model.scale.z *= NON_OCTAGON_TABLE_SIDE_SHRINK;
+  if (shrinkSides) {
+    model.scale.x *= sideShrinkScale;
+    model.scale.z *= sideShrinkScale;
+  }
 
   const scaled = new THREE.Box3().setFromObject(model);
   const offset = new THREE.Vector3(
@@ -6078,10 +6096,14 @@ async function applyTableTheme(
   option = TABLE_THEME_OPTIONS[appearance.tableTheme] ?? DEFAULT_TABLE_THEME_OPTION
 ) {
   const theme = option || DEFAULT_TABLE_THEME_OPTION;
-  const useOctagonRotation = theme?.id === 'murlan-default';
-  tableThemeG.rotation.y = useOctagonRotation
+  const keepOriginalTransform = shouldKeepOriginalTableTransform(theme?.id);
+  const themeId = String(theme?.id || '').trim().toLowerCase();
+  const isOctagonTheme = themeId === 'murlan-default' || themeId.includes('octagon');
+  tableThemeG.rotation.y = isOctagonTheme
     ? TABLE_OCTAGON_ROTATION
-    : NON_OCTAGON_TABLE_ROTATION;
+    : keepOriginalTransform
+      ? LEGACY_NON_OCTAGON_TABLE_ROTATION
+      : STRAIGHT_TABLE_ROTATION;
   tableThemeG.visible = false;
   while (tableThemeG.children.length) {
     const child = tableThemeG.children.pop();
@@ -6104,7 +6126,12 @@ async function applyTableTheme(
       disposeObjectResources(model, { disposeTextures: false });
       return;
     }
-    fitTableModelToFootprint(model);
+    fitTableModelToFootprint(model, {
+      shrinkSides: true,
+      sideShrinkScale: keepOriginalTransform
+        ? LEGACY_NON_OCTAGON_TABLE_SIDE_SHRINK
+        : NON_OCTAGON_TABLE_SIDE_SHRINK
+    });
     tableThemeG.add(model);
     tableThemeG.visible = true;
     setProceduralTableVisible(false);
@@ -6124,7 +6151,12 @@ async function applyTableTheme(
           disposeObjectResources(fallbackModel, { disposeTextures: false });
           return;
         }
-        fitTableModelToFootprint(fallbackModel);
+        fitTableModelToFootprint(fallbackModel, {
+          shrinkSides: true,
+          sideShrinkScale: keepOriginalTransform
+            ? LEGACY_NON_OCTAGON_TABLE_SIDE_SHRINK
+            : NON_OCTAGON_TABLE_SIDE_SHRINK
+        });
         tableThemeG.add(fallbackModel);
         tableThemeG.visible = true;
         setProceduralTableVisible(false);


### PR DESCRIPTION
### Motivation
- Make Domino Battle Royale table models render with straight orientation so domino lanes and table sides align perfectly to screen horizontal/vertical axes. 
- Preserve existing visual behavior for the octagon table and other shapes that should not be modified (oval and diamond). 
- Reduce side footprint for non-protected table models so they fit the arena better while keeping table height unchanged.

### Description
- Added `shouldKeepOriginalTableTransform(themeId)` to detect protected theme IDs (octagon, oval, diamond, and the procedural `murlan-default`).
- Introduced new constants `STRAIGHT_TABLE_ROTATION`, `LEGACY_NON_OCTAGON_TABLE_ROTATION`, and `LEGACY_NON_OCTAGON_TABLE_SIDE_SHRINK` and tightened `NON_OCTAGON_TABLE_SIDE_SHRINK` to change side-shrink behavior.
- Extended `fitTableModelToFootprint` signature to accept `{ shrinkSides, sideShrinkScale }` and apply configurable side scaling instead of hardcoded shrink factors.
- Updated `applyTableTheme` to choose rotation (straight, legacy tilt, or octagon rotation) and pass the appropriate `sideShrinkScale` when fitting both primary and fallback models so protected themes keep legacy transforms.
- Changes applied to `webapp/public/domino-royal-game.js`.

### Testing
- Ran a JavaScript syntax check with `node --check webapp/public/domino-royal-game.js`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d018d06098832986befecab2155ef4)