### PR TITLE
Ensure Pool Royale cue-stick forwards slider power to cue ball and add fallback impact

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -114,6 +114,7 @@ import {
   shouldApplyPoolSuggestion
 } from './poolRoyaleAimSuggestion.js';
 import { sampleCueStrokeTimeline } from './poolRoyaleCueStrokeTimeline.js';
+import { applyShotImpact as applyShotImpactPayload, createShotImpactFallback, createShotImpactPayload } from './cueShotImpact.js';
 import { polyHavenThumb } from '../../config/storeThumbnails.js';
 
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/v1/decoders/';
@@ -25778,10 +25779,7 @@ const powerRef = useRef(hud.power);
               startOffset: strokeStartOffset
             };
           }
-          let shotImpactApplied = false;
-          const applyShotImpact = () => {
-            if (shotImpactApplied) return;
-            shotImpactApplied = true;
+          const shotImpactPayload = createShotImpactPayload(() => {
             cue.vel.copy(base);
             if (cue.spin) {
               cue.spin.set(spinSide, spinTop);
@@ -25812,7 +25810,8 @@ const powerRef = useRef(hud.power);
             cue.lift = 0;
             cue.liftVel = 0;
             playCueHit(resolvedShotPower * 0.6);
-          };
+          });
+          const applyShotImpact = () => applyShotImpactPayload(shotImpactPayload);
           if (ENABLE_CUE_STROKE_ANIMATION) {
             cueStick.visible = true;
             cueAnimating = true;
@@ -25844,7 +25843,12 @@ const powerRef = useRef(hud.power);
               motionTechnique: strokeProfile.motion ?? strokeStyle,
               releaseStartsFromCurrentPull: true
             };
+            const safeImpactAt =
+              startTime + Math.max(1, strikeDuration) * THREE.MathUtils.clamp(strokeProfile.impactThreshold ?? 0.9, 0, 1);
+            pendingImpactRef.current = createShotImpactFallback(shotImpactPayload, safeImpactAt);
           } else {
+            pendingImpactRef.current = null;
+            applyShotImpact();
             cueStick.visible = false;
             cueAnimating = false;
             cuePullCurrentRef.current = 0;


### PR DESCRIPTION
### Motivation
- Players observed the cue-stick forward animation could play but the cue ball sometimes received no or insufficient power, indicating the slider power wasn't reliably transferred at impact. 
- The change aims to make the shot launch idempotent and resilient to animation timing edge-cases so the committed slider power always reaches the cue ball.

### Description
- Wired the Pool Royale shot launch to use the shared impact payload helpers by importing `createShotImpactPayload`, `createShotImpactFallback` and the payload `apply` helper and packaging the velocity/spin application into a `shotImpactPayload` in `PoolRoyale.jsx`.
- Replaced the local ad-hoc impact callback with a payload-based `applyShotImpact` wrapper so the cue-ball velocity/spin are applied exactly once via the existing idempotent helper.
- Added a timed fallback (`pendingImpactRef.current = createShotImpactFallback(...)`) when the cue-stroke animation path is used so the impact will still execute if animation timing is skipped, and ensured the non-animated path applies the impact immediately.
- Small safety: clear `pendingImpactRef` when applying immediately so there is no duplicate application.

### Testing
- Ran the unit tests `test/cueShotImpact.test.js` and `test/poolRoyaleCueStrokeTimeline.test.js` with `npm test -- test/cueShotImpact.test.js test/poolRoyaleCueStrokeTimeline.test.js --runInBand`, and both test suites passed. 
- All relevant assertions in those tests succeeded (2 test suites, 7 tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d083248a948329b5e35f297ef22987)