### PR TITLE
Ensure Pool Royale cue-stick transfers slider power on release (failsafe)

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -25333,8 +25333,9 @@ const powerRef = useRef(hud.power);
         } else {
           aimDir.normalize();
         }
-        const powerInput =
-          Number.isFinite(committedPower) ? committedPower : powerRef.current;
+        const powerInput = Number.isFinite(committedPower)
+          ? committedPower
+          : (Number.isFinite(powerRef.current) ? powerRef.current : hudRef.current?.power);
         const clampedPower = clampPower(powerInput, 0);
         const strokeStyle = cueStrokeAnimationStyleRef.current ?? DEFAULT_CUE_STROKE_STYLE;
         const strokeProfile = resolveCueStrokeProfile(strokeStyle, clampedPower);
@@ -25779,9 +25780,14 @@ const powerRef = useRef(hud.power);
             };
           }
           let shotImpactApplied = false;
+          let shotImpactFallbackTimer = null;
           const applyShotImpact = () => {
             if (shotImpactApplied) return;
             shotImpactApplied = true;
+            if (shotImpactFallbackTimer) {
+              clearTimeout(shotImpactFallbackTimer);
+              shotImpactFallbackTimer = null;
+            }
             cue.vel.copy(base);
             if (cue.spin) {
               cue.spin.set(spinSide, spinTop);
@@ -25812,6 +25818,12 @@ const powerRef = useRef(hud.power);
             cue.lift = 0;
             cue.liftVel = 0;
             playCueHit(resolvedShotPower * 0.6);
+          };
+          const queueShotImpactFallback = (delayMs) => {
+            if (shotImpactFallbackTimer || shotImpactApplied) return;
+            shotImpactFallbackTimer = window.setTimeout(() => {
+              applyShotImpact();
+            }, Math.max(16, delayMs));
           };
           if (ENABLE_CUE_STROKE_ANIMATION) {
             cueStick.visible = true;
@@ -25844,12 +25856,20 @@ const powerRef = useRef(hud.power);
               motionTechnique: strokeProfile.motion ?? strokeStyle,
               releaseStartsFromCurrentPull: true
             };
+            // Failsafe: if the cue animation frame loop is interrupted on mobile,
+            // still transfer slider power to cue-ball velocity.
+            queueShotImpactFallback(
+              (strokeProfile.pullbackDuration ?? 0) +
+                (strokeProfile.strikeDuration ?? LIVE_CUE_FORWARD_DURATION_MS) +
+                80
+            );
           } else {
             cueStick.visible = false;
             cueAnimating = false;
             cuePullCurrentRef.current = 0;
             cuePullTargetRef.current = 0;
             cueStrokeStateRef.current = null;
+            queueShotImpactFallback(16);
             if (cameraRef.current && sphRef.current) {
               topViewRef.current = false;
               topViewLockedRef.current = false;


### PR DESCRIPTION
### Motivation
- Fix a bug where the cue-stick forward animation could trigger a shot but the cue ball received no force, resulting in zero-power shots.
- Improve robustness on mobile by ensuring slider-set power is reliably applied even if the cue animation/frame loop is interrupted.

### Description
- Resolve shot power in `fire()` to prefer the committed slider value and fall back to `powerRef.current` or `hudRef.current?.power` when necessary (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Add a failsafe mechanism (`shotImpactFallbackTimer` + `queueShotImpactFallback`) that invokes the same impact logic if the cue animation does not call the impact handler in time.
- Clear the fallback timer inside `applyShotImpact()` to prevent duplicate force application when impact is applied normally.
- Changes are localized to the Pool Royale shot/fire path and the cue-stroke impact handling.

### Testing
- Ran `npm --prefix webapp run build` which completed successfully and produced the production bundles; Vite reported only non-blocking chunk-size/dynamic-import warnings.
- Confirmed the build introduced no errors after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d083248a948329b5e35f297ef22987)