### PR TITLE
Fix Pool Royale shot release power and ignore tiny accidental pulls

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -25340,15 +25340,22 @@ const powerRef = useRef(hud.power);
         const strokeProfile = resolveCueStrokeProfile(strokeStyle, clampedPower);
         const pullRange = 0.24;
         const pullTarget = pullRange * strokeProfile.pullRatio;
-        const pulledNow = cuePullCurrentRef.current ?? pullTarget;
-        const visualCommittedPower = THREE.MathUtils.clamp(
+        const pulledNowRaw = cuePullCurrentRef.current;
+        const pulledNow = Number.isFinite(pulledNowRaw) ? pulledNowRaw : pullTarget;
+        const visualCommittedPowerRaw = THREE.MathUtils.clamp(
           pulledNow / Math.max(pullRange, 1e-6),
           0,
           1
         );
+        const visualCommittedPower = Number.isFinite(visualCommittedPowerRaw)
+          ? visualCommittedPowerRaw
+          : 0;
         // Keep physics power in sync with the visible cue pullback so a forward
         // cue release always transfers slider energy to the cue ball.
-        const resolvedShotPower = Math.max(clampedPower, visualCommittedPower);
+        const resolvedShotPower = clampPower(
+          Math.max(clampedPower, visualCommittedPower),
+          clampedPower
+        );
         const rawSpin = applySpinConstraints(aimDir, true);
         const spinScale = THREE.MathUtils.clamp(strokeProfile.spinScale ?? 0.4, 0.12, 1);
         const appliedSpin = {
@@ -31403,7 +31410,9 @@ const powerRef = useRef(hud.power);
       },
       onCommit: (value) => {
         const committedPower = Number.isFinite(value) ? value / 100 : null;
-        fireRef.current?.(committedPower);
+        if ((committedPower ?? 0) > 0.02) {
+          fireRef.current?.(committedPower);
+        }
         requestAnimationFrame(() => {
           slider.set(slider.min, { animate: true });
           applyPower(0);


### PR DESCRIPTION
### Motivation
- Players reported the cue ball not moving on slider release because the resolved shot power could be invalid when the visible cue-pull state was unstable.
- The goal is to ensure the shot uses a stable, clamped power value captured at release and to match the reference pull→release mechanism.

### Description
- Added finite-value guards when reading `cuePullCurrentRef.current` and when computing the visual committed power so the code never derives `NaN` from an undefined pull value. (`webapp/src/pages/Games/PoolRoyale.jsx`)
- Passed the final `resolvedShotPower` through the existing `clampPower` helper so physics always receives a valid 0..1 power input. (`resolvedShotPower = clampPower(...)`)
- Prevent slider `onCommit` from firing a shot for tiny accidental pulls by only calling `fire` when `committedPower > 0.02`.

### Testing
- Built the webapp with `npm --prefix webapp run build` and the build completed successfully (Vite warnings about chunking only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d088f731908329ab95a38df2e1460d)