### PR TITLE
Straighten non-octagon Domino table orientations

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -2531,10 +2531,15 @@ const MURLAN_TABLE_THEMES = Object.freeze(
     { id: 'small_wooden_table_01', label: 'Small Wooden Table 01' }
   ].map((option, index) => {
     const source = option.source || 'polyhaven';
+    const rotationY =
+      source === 'polyhaven'
+        ? (option.rotationY ?? -Math.PI / 12)
+        : (option.rotationY ?? 0);
     return {
       ...option,
       assetId: source === 'polyhaven' ? option.assetId || option.id : null,
       source,
+      rotationY,
       thumbnail: option.thumbnail || POLYHAVEN_THUMB(option.id),
       price: option.price ?? 980 + index * 40,
       preserveMaterials: option.preserveMaterials ?? source === 'polyhaven',

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-04-03-domino-table-alignment-v8';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-04-04-domino-table-straight-lines-v9';
 
 export default function DominoRoyalArena() {
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- Players reported non-octagon Domino Battle Royal tables render slightly rotated and need to appear in straight lines while keeping the octagon (`murlan-default`) table untouched.

### Description
- Apply a default Y-axis rotation correction for Poly Haven (non-procedural) table themes by adding `rotationY = option.rotationY ?? -Math.PI/12` to the theme mapping in `webapp/public/domino-royal-game.js` so those tables render straighter on screen. 
- Preserve procedural/octagon table behavior by leaving `murlan-default` (procedural) rotation at `0` unless explicitly configured. 
- Expose the computed `rotationY` on each table theme object so downstream loaders apply it. 
- Bump the domino script version string in `webapp/src/pages/Games/DominoRoyalArena.jsx` to `2026-04-04-domino-table-straight-lines-v9` to force clients to fetch the updated logic.

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` to validate the generated game script syntax, and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d089a2c8a883298ad4638950dd684e)