### PR TITLE
Fix Pool Royale slider release power mapping

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -25339,7 +25339,9 @@ const powerRef = useRef(hud.power);
         const strokeStyle = cueStrokeAnimationStyleRef.current ?? DEFAULT_CUE_STROKE_STYLE;
         const strokeProfile = resolveCueStrokeProfile(strokeStyle, clampedPower);
         const pullRange = 0.24;
-        const pullTarget = pullRange * strokeProfile.pullRatio;
+        // Keep Pool Royale release power behavior aligned with the reference
+        // cue mechanic: pull = PULL_RANGE * easeOut(power), then strike on release.
+        const pullTarget = pullRange * easeOutCubic(clampedPower);
         const pulledNow = cuePullCurrentRef.current ?? pullTarget;
         const visualCommittedPower = THREE.MathUtils.clamp(
           pulledNow / Math.max(pullRange, 1e-6),
@@ -31402,7 +31404,13 @@ const powerRef = useRef(hud.power);
         captureCueStickAnchor();
       },
       onCommit: (value) => {
-        const committedPower = Number.isFinite(value) ? value / 100 : null;
+        const sliderValue =
+          Number.isFinite(value)
+            ? value
+            : Number.isFinite(slider.get?.())
+              ? slider.get()
+              : slider.min;
+        const committedPower = Number.isFinite(sliderValue) ? sliderValue / 100 : null;
         fireRef.current?.(committedPower);
         requestAnimationFrame(() => {
           slider.set(slider.min, { animate: true });


### PR DESCRIPTION
### Motivation
- Players reported that releasing the pull slider sometimes produced no/near-zero cue-ball movement because the visible cue pullback and the physics power were out of sync.
- Make the live pullback and the physics impulse use the same reference mechanic so visible cue motion always transfers energy on release.

### Description
- Compute the visual pull target from slider power using the reference ease-out curve by replacing `pullTarget = pullRange * strokeProfile.pullRatio` with `pullTarget = pullRange * easeOutCubic(clampedPower)` in `webapp/src/pages/Games/PoolRoyale.jsx` so visible pullback matches the original cue mechanic.
- Harden slider commit handling in the power slider `onCommit` by reading a safe fallback value from the slider instance (`slider.get()`) when the committed `value` is not finite before passing `committedPower` into `fire()` in `webapp/src/pages/Games/PoolRoyale.jsx`.

### Testing
- Built the web app with `npm --prefix webapp run build` and the build completed successfully.
- Build emitted existing Vite warnings about large chunks/dynamic imports but these are unrelated to the change and did not block the build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d088f731908329ab95a38df2e1460d)