### PR TITLE
Respect KTX2 support for Poly Haven textures in TexasHoldem GLTF loader

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -493,6 +493,7 @@ const TEXAS_DEFAULT_HDRI_INDEX = Math.max(
 );
 let sharedKtx2Loader = null;
 let hasDetectedKtx2Support = false;
+let supportsKtx2Transcoding = false;
 const POLYHAVEN_MODEL_CACHE = new Map();
 const HDRI_ENVIRONMENT_CACHE = new Map();
 
@@ -536,8 +537,10 @@ function ensureKtx2SupportDetection(renderer = null) {
   if (!sharedKtx2Loader || hasDetectedKtx2Support || !renderer) return;
   try {
     sharedKtx2Loader.detectSupport(renderer);
+    supportsKtx2Transcoding = true;
     hasDetectedKtx2Support = true;
   } catch (error) {
+    supportsKtx2Transcoding = false;
     console.warn('Texas Hold\'em KTX2 support detection failed', error);
   }
 }
@@ -560,13 +563,16 @@ function replaceFileExtension(path, nextExt) {
   return `${clean.slice(0, dotIdx)}${nextExt}`;
 }
 
-function resolveTextureFallbackUrl(requestedUrl, fileMap) {
+function resolveTextureFallbackUrl(requestedUrl, fileMap, { allowCompressedTextures = false } = {}) {
   if (!fileMap?.size || !requestedUrl) return null;
   const requestedBase = basename(stripQueryHash(requestedUrl));
   if (!requestedBase) return null;
   const lowerBase = requestedBase.toLowerCase();
   const fallbackExts = ['.jpg', '.jpeg', '.png', '.webp'];
   if (!lowerBase.endsWith('.ktx2') && !lowerBase.endsWith('.basis')) {
+    return null;
+  }
+  if (allowCompressedTextures) {
     return null;
   }
   for (const ext of fallbackExts) {
@@ -1055,6 +1061,14 @@ function createConfiguredGLTFLoader(renderer = null, manager = undefined) {
   }
 
   ensureKtx2SupportDetection(renderer);
+  if (!hasDetectedKtx2Support && typeof document !== 'undefined') {
+    const supportRenderer = new THREE.WebGLRenderer({ antialias: false, alpha: true, powerPreference: 'high-performance' });
+    try {
+      ensureKtx2SupportDetection(supportRenderer);
+    } finally {
+      supportRenderer.dispose();
+    }
+  }
 
   loader.setKTX2Loader(sharedKtx2Loader);
   return loader;
@@ -1300,7 +1314,9 @@ async function loadPolyhavenModel(assetId, renderer = null) {
         const baseDir = base.substring(0, base.lastIndexOf('/') + 1);
         loader.manager.setURLModifier((requestedUrl) => {
           if (/^https?:\/\//i.test(requestedUrl)) return requestedUrl;
-          const textureFallback = resolveTextureFallbackUrl(requestedUrl, fileMap);
+          const textureFallback = resolveTextureFallbackUrl(requestedUrl, fileMap, {
+            allowCompressedTextures: supportsKtx2Transcoding
+          });
           if (textureFallback) return textureFallback;
           const req = stripQueryHash(requestedUrl);
           const b = basename(req);


### PR DESCRIPTION
### Motivation
- Poly Haven chair/table GLTFs include compressed texture formats (KTX2/Basis) which should be used when the WebGL adapter can transcode them to preserve authentic texture mapping and PBR material payloads.
- The loader previously fell back to legacy image files unnecessarily when the active renderer was not yet available, causing degraded visuals compared to other arenas that preserve Poly Haven assets.

### Description
- Added a `supportsKtx2Transcoding` flag to track whether KTX2/Basis transcoding is actually supported by the current adapter and set it during KTX2 support detection via `ensureKtx2SupportDetection`.
- Updated `createConfiguredGLTFLoader` to attempt KTX2 detection even when the app renderer is not available by creating a temporary `THREE.WebGLRenderer` and disposing it after probing.
- Changed `resolveTextureFallbackUrl` to accept an `allowCompressedTextures` option and to avoid replacing `.ktx2/.basis` texture requests with `.jpg/.png/.webp` when compressed transcoding is available.
- Wired the `supportsKtx2Transcoding` value into the GLTF `LoadingManager` URL modifier so Poly Haven texture fallbacks only occur on adapters that cannot transcode compressed textures.

### Testing
- Ran `npm test -- --runInBand test/texasHoldemHdriPreload.test.js` and the suite passed (`2 tests, 2 passed`).
- Ran `npx eslint webapp/src/pages/Games/TexasHoldemArena.jsx` which produced a repository ignore warning only and no code errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d08aa821fc832986234339645bda40)