### PR TITLE
Align Pool Royale cue stroke & shot power with reference pull/release behavior

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -25115,17 +25115,16 @@ const powerRef = useRef(hud.power);
 
       const resolveCueStrokeProfile = (_styleId, powerRatio = 0) => {
         const p = THREE.MathUtils.clamp(powerRatio ?? 0, 0, 1);
-        const pullbackDuration = THREE.MathUtils.lerp(90, 170, p);
         return {
-          // Keep a shorter charge-up while preserving a visible pullback/strike cycle.
+          // Match the reference cue stroke: drag defines pullback, release drives a direct strike.
           motion: 'classic',
           pullRatio: easeOutCubic(p),
           pullSmoothing: 1,
-          strikeDuration: Math.max(LIVE_CUE_FORWARD_DURATION_MS, 170),
-          holdDuration: Math.max(LIVE_CUE_IMPACT_HOLD_MS, 80),
-          pullbackDuration,
+          strikeDuration: 120,
+          holdDuration: 50,
+          pullbackDuration: 0,
           recoverDuration: 0,
-          impactThreshold: 0.88,
+          impactThreshold: 0.9,
           forwardOnly: false,
           cameraExtraHoldMs: 240,
           spinScale: 0.22
@@ -25338,7 +25337,7 @@ const powerRef = useRef(hud.power);
         const clampedPower = clampPower(powerInput, 0);
         const strokeStyle = cueStrokeAnimationStyleRef.current ?? DEFAULT_CUE_STROKE_STYLE;
         const strokeProfile = resolveCueStrokeProfile(strokeStyle, clampedPower);
-        const pullRange = 0.24;
+        const pullRange = 0.34;
         const pullTarget = pullRange * strokeProfile.pullRatio;
         const pulledNow = cuePullCurrentRef.current ?? pullTarget;
         const visualCommittedPower = THREE.MathUtils.clamp(
@@ -25427,11 +25426,16 @@ const powerRef = useRef(hud.power);
             replayTags.size > 0 && !replayTags.has('long') && !replayTags.has('bank');
           const frameStateCurrent = frameRef.current ?? null;
           const isBreakShot = (frameStateCurrent?.currentBreak ?? 0) === 0;
-          const powerScale = SHOT_MIN_FACTOR + SHOT_POWER_RANGE * curvedPower;
-          const speedBase = SHOT_BASE_SPEED * (isBreakShot ? SHOT_BREAK_MULTIPLIER : 1);
+          const cueSideDir = new THREE.Vector2(shotAimDir.y, -shotAimDir.x);
+          if (cueSideDir.lengthSq() > 1e-8) cueSideDir.normalize();
+          const shotSpeed =
+            (1.8 + 6.2 * resolvedShotPower) *
+            (isBreakShot ? SHOT_BREAK_MULTIPLIER : 1);
+          const sideSquirt = (scaledSpin.x ?? 0) * resolvedShotPower * 0.22;
           const base = shotAimDir
             .clone()
-            .multiplyScalar(speedBase * powerScale);
+            .multiplyScalar(shotSpeed)
+            .addScaledVector(cueSideDir, sideSquirt);
           const predictedCueSpeed = base.length();
           shotPrediction.speed = predictedCueSpeed;
           if (shouldRecordReplay) {


### PR DESCRIPTION
### Motivation
- Fix the live cue stroke so slider release reliably transfers power to the cue ball and the visual pull/push matches the working reference mechanism. 
- Make the cue stick pullback, forward strike timing and impact trigger identical to the known-good implementation for consistent feel and predictable physics. 

### Description
- Update the live stroke profile in `webapp/src/pages/Games/PoolRoyale.jsx` to use a direct-release style with `strikeDuration: 120`, `holdDuration: 50`, `pullbackDuration: 0`, and `impactThreshold: 0.9`. 
- Increase the slider-to-pull mapping by changing the committed `pullRange` from `0.24` to `0.34` so visible pullback matches the slider drag amount. 
- Replace the previous shot impulse math with the reference-style impulse so the cue ball receives forward velocity computed as `1.8 + 6.2 * power` and preserve side-squirt from spin (normalize cue side vector and add scaled side contribution). 

### Testing
- Ran `npm run -s test -- test/poolRoyaleCueStrokeTimeline.test.js test/cueShotImpact.test.js`. 
- Both test suites passed: `PASS test/cueShotImpact.test.js` and `PASS test/poolRoyaleCueStrokeTimeline.test.js` (7 tests total passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d08ee174988329bbd72527f804bccd)