### PR TITLE
fix(domino-royal): guard required DOM elements to stop runtime crashes

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -7964,9 +7964,37 @@ function makeDomino(
 }
 
 /* ---------- Game State ---------- */
-const statusEl = document.getElementById('status');
-const btnDraw = document.getElementById('draw');
-const btnPass = document.getElementById('pass');
+const resolveRequiredElement = (
+  id,
+  {
+    tagName = 'div',
+    role = null,
+    ariaHidden = true,
+    hide = true
+  } = {}
+) => {
+  const element = document.getElementById(id);
+  if (element) return element;
+  const fallback = document.createElement(tagName);
+  fallback.id = `${id}__fallback`;
+  if (role) {
+    fallback.setAttribute('role', role);
+  }
+  if (ariaHidden) {
+    fallback.setAttribute('aria-hidden', 'true');
+  }
+  if (hide) {
+    fallback.style.display = 'none';
+  }
+  console.warn(
+    `[Domino Royal] Missing required UI node "#${id}". Using fallback to prevent runtime crash.`
+  );
+  return fallback;
+};
+
+const statusEl = resolveRequiredElement('status', { role: 'status' });
+const btnDraw = resolveRequiredElement('draw', { tagName: 'button' });
+const btnPass = resolveRequiredElement('pass', { tagName: 'button' });
 const setControlEnabled = (enabled) => {
   [btnDraw, btnPass].forEach((btn) => {
     if (!btn) return;


### PR DESCRIPTION
### Motivation
- The game could crash during startup when critical DOM nodes (e.g. `#status`, `#draw`, `#pass`) were not present due to mount/unmount or transient DOM state, causing null-reference failures.
- Make initialization resilient so the Domino Royal runtime does not hard-fail when UI nodes are temporarily missing.

### Description
- Added a `resolveRequiredElement` helper in `webapp/public/domino-royal-game.js` that safely resolves an element or returns a hidden fallback element to avoid runtime exceptions.
- Replaced direct lookups for `#status`, `#draw`, and `#pass` with guarded calls to `resolveRequiredElement` and preserved existing behavior for `setControlEnabled`.
- Emit a console warning when a required node is missing so missing-node scenarios are diagnosable without crashing the game.
- Changes are contained to `webapp/public/domino-royal-game.js` and only introduce fallbacks; game logic uses the returned elements unchanged.

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` and the file passed syntax checking successfully.
- Ran `cd webapp && npm run build` and the production build completed successfully (Vite produced non-blocking chunk warnings only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d09220348c83298bc421f8a3163500)