### PR TITLE
Fix Pool Royale cue release power transfer and stroke timing

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -15047,6 +15047,7 @@ const powerRef = useRef(hud.power);
     shootingRef.current = shotActive;
   }, [shotActive]);
   const sliderInstanceRef = useRef(null);
+  const shotPowerSnapshotRef = useRef(0);
   const suggestionAimKeyRef = useRef(null);
   const aiEarlyShotIntentRef = useRef(null);
   const aiShotPreviewRef = useRef(false);
@@ -25113,6 +25114,9 @@ const powerRef = useRef(hud.power);
         );
       };
 
+      const REF_STRIKE_TIME_MS = 120;
+      const REF_HOLD_TIME_MS = 50;
+      const REF_IMPACT_THRESHOLD = 0.9;
       const resolveCueStrokeProfile = (_styleId, powerRatio = 0) => {
         const p = THREE.MathUtils.clamp(powerRatio ?? 0, 0, 1);
         const pullbackDuration = THREE.MathUtils.lerp(90, 170, p);
@@ -25121,11 +25125,12 @@ const powerRef = useRef(hud.power);
           motion: 'classic',
           pullRatio: easeOutCubic(p),
           pullSmoothing: 1,
-          strikeDuration: Math.max(LIVE_CUE_FORWARD_DURATION_MS, 170),
-          holdDuration: Math.max(LIVE_CUE_IMPACT_HOLD_MS, 80),
+          // Mirror the reference mechanism: fixed strike + hold windows.
+          strikeDuration: REF_STRIKE_TIME_MS,
+          holdDuration: REF_HOLD_TIME_MS,
           pullbackDuration,
           recoverDuration: 0,
-          impactThreshold: 0.88,
+          impactThreshold: REF_IMPACT_THRESHOLD,
           forwardOnly: false,
           cameraExtraHoldMs: 240,
           spinScale: 0.22
@@ -25333,8 +25338,11 @@ const powerRef = useRef(hud.power);
         } else {
           aimDir.normalize();
         }
-        const powerInput =
-          Number.isFinite(committedPower) ? committedPower : powerRef.current;
+        const powerInput = Number.isFinite(committedPower)
+          ? committedPower
+          : Number.isFinite(shotPowerSnapshotRef.current)
+            ? shotPowerSnapshotRef.current
+            : powerRef.current;
         const clampedPower = clampPower(powerInput, 0);
         const strokeStyle = cueStrokeAnimationStyleRef.current ?? DEFAULT_CUE_STROKE_STYLE;
         const strokeProfile = resolveCueStrokeProfile(strokeStyle, clampedPower);
@@ -31397,12 +31405,21 @@ const powerRef = useRef(hud.power);
       value: powerRef.current * 100,
       cueSrc: '/assets/snooker/cue.webp',
       labels: true,
-      onChange: (v) => applyPower(v / 100),
+      onChange: (v) => {
+        const normalized = clampPower(v / 100, 0);
+        shotPowerSnapshotRef.current = normalized;
+        applyPower(normalized);
+      },
       onStart: () => {
         captureCueStickAnchor();
+        shotPowerSnapshotRef.current = clampPower(powerRef.current ?? 0, 0);
       },
       onCommit: (value) => {
         const committedPower = Number.isFinite(value) ? value / 100 : null;
+        shotPowerSnapshotRef.current = clampPower(
+          Number.isFinite(committedPower) ? committedPower : powerRef.current,
+          0
+        );
         fireRef.current?.(committedPower);
         requestAnimationFrame(() => {
           slider.set(slider.min, { animate: true });
@@ -31424,6 +31441,7 @@ const powerRef = useRef(hud.power);
       slider.set(slider.min, { animate: true });
     }
     applyPower(0);
+    shotPowerSnapshotRef.current = 0;
     cuePullCurrentRef.current = 0;
     cuePullTargetRef.current = 0;
   }, [applyPower, hud.over, hud.turn, shotActive]);


### PR DESCRIPTION
### Motivation
- The visible cue pull-release animation could fire a shot without reliably transferring the intended slider power to the cue ball, and the cue stroke timing differed from the reference mechanism causing inconsistent impacts.
- Make the slider → shot transfer deterministic and match the reference cue stroke timing so the cue stick performs the same pull/push and the cue ball receives the expected force.

### Description
- Add `shotPowerSnapshotRef` to capture the committed/dragged slider power during `onChange`, `onStart`, and `onCommit`, and use that snapshot when resolving shot power in `fire()` so the released shot uses the intended power even while the UI animates back to zero.
- Modify `resolveCueStrokeProfile` to mirror the reference timing by using fixed strike and hold windows (`REF_STRIKE_TIME_MS = 120`, `REF_HOLD_TIME_MS = 50`) and a deterministic impact threshold (`REF_IMPACT_THRESHOLD = 0.9`) so the cue forward animation/impact timing matches the reference behavior.
- Prefer `shotPowerSnapshotRef` when computing `powerInput` inside `fire()` and keep visual/physics power sync by combining clamped committed power with the visible pull state.
- Reset `shotPowerSnapshotRef` when the slider/cue pull is reset to ensure subsequent shots start from a clean state; changes are localized to `webapp/src/pages/Games/PoolRoyale.jsx`.

### Testing
- Ran unit tests: `npm test -- --runInBand test/cueShotImpact.test.js test/poolRoyaleCueStrokeTimeline.test.js`, and both test suites passed (2 passed, 2 total; 7 tests passed).
- Also ran `npm test -- --runInBand test/poolRoyaleCueStrokeTimeline.test.js` during development, which passed (4 tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d08ee174988329bbd72527f804bccd)