### PR TITLE
Fix Domino Royal runtime crash by hardening DOM bootstrap guards

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -1497,10 +1497,14 @@ function applyRendererQuality(quality = frameQuality) {
   }
 }
 applyRendererQuality();
-if (!app) {
-  throw new Error('Domino Royal root container #app is missing');
+let appRoot = app;
+if (!appRoot) {
+  console.warn('Domino Royal root container #app is missing; creating fallback root.');
+  appRoot = document.createElement('div');
+  appRoot.id = 'app';
+  document.body.appendChild(appRoot);
 }
-app.appendChild(renderer.domElement);
+appRoot.appendChild(renderer.domElement);
 renderer.domElement.style.touchAction = 'none';
 
 const scene = new THREE.Scene();
@@ -9741,7 +9745,8 @@ renderer.domElement.addEventListener('pointerleave', (ev) => {
   }
 });
 
-btnDraw.addEventListener('click', () => {
+if (btnDraw) {
+  btnDraw.addEventListener('click', () => {
   if (current !== human || gameFinished) return;
   let drewTile = false;
   while (boneyard.length) {
@@ -9764,8 +9769,10 @@ btnDraw.addEventListener('click', () => {
   if (drewTile) {
     announceCommentary('draw', { player: human });
   }
-});
-btnPass.addEventListener('click', () => {
+  });
+}
+if (btnPass) {
+  btnPass.addEventListener('click', () => {
   if (current === human && !gameFinished) {
     clearMarkers();
     selectedTile = null;
@@ -9773,7 +9780,8 @@ btnPass.addEventListener('click', () => {
     announceCommentary('pass', { player: human });
     schedulePassTurnAdvance(human);
   }
-});
+  });
+}
 
 async function bootstrapDominoRoyal() {
   try {


### PR DESCRIPTION
### Motivation
- The Domino Royal game could throw a runtime error when expected DOM nodes (like `#app`, `#draw`, `#pass`) were missing or not yet mounted, causing hard crashes in some mobile/embedded webviews.
- The intent is to make startup resilient to mount-timing mismatches and partial DOM states so the renderer and UI bindings do not crash the whole page.

### Description
- Added a safe bootstrap for the renderer: if `#app` is absent the script now creates a fallback `<div id="app">` and appends the renderer instead of throwing an error (changed `webapp/public/domino-royal-game.js`).
- Guarded gameplay control bindings by checking `btnDraw` and `btnPass` before calling `addEventListener`, preventing `null.addEventListener(...)` exceptions when controls are missing.
- Preserved existing behavior when all expected DOM nodes are present and kept changes localized to the one game script file.

### Testing
- Ran syntax check with `node --check webapp/public/domino-royal-game.js`, which completed successfully.
- Built the front-end with `npm --prefix webapp run build`, which completed successfully (Vite emitted non-blocking chunk warnings only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d09220348c83298bc421f8a3163500)