### PR TITLE
Match Pool Royale cue release/power to reference stroke (pull, timing, launch speed)

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1835,6 +1835,13 @@ const SHOT_BREAK_MULTIPLIER = 1.5;
 const SHOT_BASE_SPEED = 3.3 * 0.3 * 1.65 * SHOT_FORCE_BOOST;
 const SHOT_MIN_FACTOR = 0.25;
 const SHOT_POWER_RANGE = 0.75;
+// Reference stroke model (matches the validated PoolPreview mechanism):
+// - pull amount scales with eased slider power
+// - fixed strike/hold timeline
+// - cue-ball launch speed uses 1.8 + 6.2 * power
+const REFERENCE_PULL_RANGE = 0.34;
+const REFERENCE_STRIKE_TIME_MS = 120;
+const REFERENCE_HOLD_TIME_MS = 50;
 const SPIN_POWER_REFERENCE_SPEED = SHOT_BASE_SPEED * 1.25;
 const SPIN_POWER_MIN_SCALE = 0.35;
 const SPIN_POWER_MAX_SCALE = 1.25;
@@ -25338,7 +25345,7 @@ const powerRef = useRef(hud.power);
         const clampedPower = clampPower(powerInput, 0);
         const strokeStyle = cueStrokeAnimationStyleRef.current ?? DEFAULT_CUE_STROKE_STYLE;
         const strokeProfile = resolveCueStrokeProfile(strokeStyle, clampedPower);
-        const pullRange = 0.24;
+        const pullRange = REFERENCE_PULL_RANGE;
         const pullTarget = pullRange * strokeProfile.pullRatio;
         const pulledNow = cuePullCurrentRef.current ?? pullTarget;
         const visualCommittedPower = THREE.MathUtils.clamp(
@@ -25429,9 +25436,10 @@ const powerRef = useRef(hud.power);
           const isBreakShot = (frameStateCurrent?.currentBreak ?? 0) === 0;
           const powerScale = SHOT_MIN_FACTOR + SHOT_POWER_RANGE * curvedPower;
           const speedBase = SHOT_BASE_SPEED * (isBreakShot ? SHOT_BREAK_MULTIPLIER : 1);
+          const legacyReferenceSpeed = 1.8 + 6.2 * resolvedShotPower;
           const base = shotAimDir
             .clone()
-            .multiplyScalar(speedBase * powerScale);
+            .multiplyScalar(Math.max(speedBase * powerScale, legacyReferenceSpeed));
           const predictedCueSpeed = base.length();
           shotPrediction.speed = predictedCueSpeed;
           if (shouldRecordReplay) {
@@ -25651,9 +25659,9 @@ const powerRef = useRef(hud.power);
           if (shotRecording) {
             recordReplayFrame(performance.now());
           }
-          const strikeDuration = strokeProfile.strikeDuration ?? LIVE_CUE_FORWARD_DURATION_MS;
-          const strikeHoldDuration = strokeProfile.holdDuration ?? LIVE_CUE_IMPACT_HOLD_MS;
-          const pullbackDuration = strokeProfile.pullbackDuration ?? 0;
+          const strikeDuration = REFERENCE_STRIKE_TIME_MS;
+          const strikeHoldDuration = REFERENCE_HOLD_TIME_MS;
+          const pullbackDuration = 0;
           const startTime = performance.now();
           const shotStrength = THREE.MathUtils.clamp(resolvedShotPower, 0, 1);
           const impactForwardDistance = THREE.MathUtils.lerp(
@@ -25835,7 +25843,7 @@ const powerRef = useRef(hud.power);
               baseRotationY: cueStick.rotation.y,
               strikeDip: 0.003,
               wobbleAmount: 0.0018,
-              strikeImpactThreshold: strokeProfile.impactThreshold ?? 0.9,
+              strikeImpactThreshold: 0.9,
               // Slider release should drive an immediate forward strike from the
               // currently pulled cue position back to contact.
               forwardOnly: true,


### PR DESCRIPTION
### Motivation
- Fix inconsistent cue release where releasing the power slider sometimes produced no effective impulse on the cue ball by aligning Pool Royale stroke mechanics to the validated reference implementation.
- Ensure the visible pull/push cue animation and the physics impulse use the same mapping so the slider always transfers expected force to the cue ball.

### Description
- Introduced explicit reference stroke constants `REFERENCE_PULL_RANGE`, `REFERENCE_STRIKE_TIME_MS`, and `REFERENCE_HOLD_TIME_MS` and used them to compute visual pull and strike timing in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Switched the shot pull calculation to use `REFERENCE_PULL_RANGE` so visible pullback maps directly to `resolvedShotPower` (visible pull is considered when committing the shot).
- Ensured cue-ball launch speed always uses at least the legacy reference formula `1.8 + 6.2 * power` when building the shot impulse so release never results in zero/weak transfer.
- Locked the cue-strike impact trigger threshold to `0.9` and set fixed strike/hold durations to match the reference stroke timeline used by the cue stroke animation subsystem.

### Testing
- Ran timeline unit tests with `npm test -- test/poolRoyaleCueStrokeTimeline.test.js --runInBand` and all tests passed (4 tests, 1 suite). 
- Ran shot-impact orchestration tests with `npm test -- test/cueShotImpact.test.js --runInBand` and all tests passed (3 tests, 1 suite).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d08ee174988329bbd72527f804bccd)