### PR TITLE
Align Pool Royale cue stroke to reference pull/push; fix slider release power mapping

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -25338,9 +25338,9 @@ const powerRef = useRef(hud.power);
         const clampedPower = clampPower(powerInput, 0);
         const strokeStyle = cueStrokeAnimationStyleRef.current ?? DEFAULT_CUE_STROKE_STYLE;
         const strokeProfile = resolveCueStrokeProfile(strokeStyle, clampedPower);
-        const pullRange = 0.24;
-        const pullTarget = pullRange * strokeProfile.pullRatio;
-        const pulledNow = cuePullCurrentRef.current ?? pullTarget;
+        const pullRange = 0.34;
+        const pullTarget = pullRange * easeOutCubic(clampedPower);
+        const pulledNow = Math.max(cuePullCurrentRef.current ?? 0, pullTarget);
         const visualCommittedPower = THREE.MathUtils.clamp(
           pulledNow / Math.max(pullRange, 1e-6),
           0,
@@ -25641,9 +25641,8 @@ const powerRef = useRef(hud.power);
               .sub(TMP_VEC3_CUE_TIP_OFFSET);
           };
           const idlePos = buildCuePosition(0);
-          // Start the release from the *currently visible* pulled cue position
-          // so slider release always pushes forward from what the player sees.
-          const releaseStartPos = cueStick.position.clone();
+          // Start release from the same computed pulled pose that feeds power.
+          const releaseStartPos = buildCuePosition(visualPull);
           cueStick.position.copy(releaseStartPos);
           TMP_VEC3_BUTT.copy(cueStick.position).add(TMP_VEC3_CUE_BUTT_OFFSET);
           cueAnimating = true;
@@ -25651,8 +25650,8 @@ const powerRef = useRef(hud.power);
           if (shotRecording) {
             recordReplayFrame(performance.now());
           }
-          const strikeDuration = strokeProfile.strikeDuration ?? LIVE_CUE_FORWARD_DURATION_MS;
-          const strikeHoldDuration = strokeProfile.holdDuration ?? LIVE_CUE_IMPACT_HOLD_MS;
+          const strikeDuration = 120;
+          const strikeHoldDuration = 50;
           const pullbackDuration = strokeProfile.pullbackDuration ?? 0;
           const startTime = performance.now();
           const shotStrength = THREE.MathUtils.clamp(resolvedShotPower, 0, 1);
@@ -25835,7 +25834,7 @@ const powerRef = useRef(hud.power);
               baseRotationY: cueStick.rotation.y,
               strikeDip: 0.003,
               wobbleAmount: 0.0018,
-              strikeImpactThreshold: strokeProfile.impactThreshold ?? 0.9,
+              strikeImpactThreshold: 0.9,
               // Slider release should drive an immediate forward strike from the
               // currently pulled cue position back to contact.
               forwardOnly: true,


### PR DESCRIPTION
### Motivation
- Players reported that releasing the power slider sometimes produced no or near-zero impulse on the cue ball, so the visible pull/push animation must match the physics power exactly. 
- The goal is to mirror the known-good reference mechanism: use the same pull math and make the strike start from the computed pulled pose so power always transfers to the cue ball.

### Description
- Updated pull math to use a `pullRange` of `0.34` and compute the committed pull as `pullRange * easeOutCubic(clampedPower)` so slider power maps into pull exactly. 
- Ensure the release uses the larger of current visual pull and the computed pull via `pulledNow = Math.max(cuePullCurrentRef.current ?? 0, pullTarget)` to keep visual and physics in sync. 
- Make the strike start from the computed pulled pose by setting the release start pose to `buildCuePosition(visualPull)` instead of sampling the transient `cueStick.position`. 
- Hardened strike timing to reference-like values (`120ms` strike, `50ms` hold) and fixed the impact arming threshold to `0.9` for deterministic impact timing; changes are in `webapp/src/pages/Games/PoolRoyale.jsx`.

### Testing
- Built the web app with `npm -C webapp run build` and the production build completed successfully. 
- The build produced the same pre-existing Vite warnings about chunking/dynamic imports; no new warnings or build errors were introduced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d08ee174988329bbd72527f804bccd)