### PR TITLE
Texas Hold'em: remove table wood customization and fix Poly Haven GLTF texture lookup

### DIFF
--- a/webapp/src/config/texasHoldemInventoryConfig.js
+++ b/webapp/src/config/texasHoldemInventoryConfig.js
@@ -1,4 +1,4 @@
-import { TABLE_BASE_OPTIONS, TABLE_CLOTH_OPTIONS, TABLE_WOOD_OPTIONS } from '../utils/tableCustomizationOptions.js';
+import { TABLE_BASE_OPTIONS, TABLE_CLOTH_OPTIONS } from '../utils/tableCustomizationOptions.js';
 import { TABLE_SHAPE_OPTIONS } from '../utils/murlanTable.js';
 import { CARD_THEMES } from '../utils/cards3d.js';
 import {
@@ -30,7 +30,6 @@ const DEFAULT_HDRI_INDEX = Math.max(0, TEXAS_HDRI_OPTIONS.findIndex((variant) =>
 
 export const TEXAS_HOLDEM_DEFAULT_UNLOCKS = Object.freeze({
   tableFinish: [TEXAS_TABLE_FINISH_OPTIONS[0]?.id],
-  tableWood: [TABLE_WOOD_OPTIONS[0]?.id],
   tableCloth: [TABLE_CLOTH_OPTIONS[0]?.id],
   tableBase: [TABLE_BASE_OPTIONS[0]?.id],
   chairTheme: [TEXAS_CHAIR_THEME_OPTIONS[0]?.id],
@@ -46,7 +45,6 @@ export const TEXAS_HOLDEM_DEFAULT_UNLOCKS = Object.freeze({
 
 export const TEXAS_HOLDEM_OPTION_LABELS = Object.freeze({
   tableFinish: Object.freeze(reduceLabels(TEXAS_TABLE_FINISH_OPTIONS)),
-  tableWood: Object.freeze(reduceLabels(TABLE_WOOD_OPTIONS)),
   tableCloth: Object.freeze(reduceLabels(TABLE_CLOTH_OPTIONS)),
   tableBase: Object.freeze(reduceLabels(TABLE_BASE_OPTIONS)),
   chairTheme: Object.freeze(reduceLabels(TEXAS_CHAIR_THEME_OPTIONS)),
@@ -70,15 +68,6 @@ export const TEXAS_HOLDEM_STORE_ITEMS = [
     price: option.price,
     description: option.description,
     swatches: option.swatches,
-    thumbnail: option.thumbnail
-  })),
-  ...TABLE_WOOD_OPTIONS.slice(1).map((option, idx) => ({
-    id: `texas-wood-${option.id}`,
-    type: 'tableWood',
-    optionId: option.id,
-    name: option.label,
-    price: 540 + idx * 40,
-    description: "Unlock an alternate wood finish for your Hold'em arena table.",
     thumbnail: option.thumbnail
   })),
   ...TABLE_CLOTH_OPTIONS.slice(1).map((option, idx) => ({
@@ -153,7 +142,6 @@ export const TEXAS_HOLDEM_DEFAULT_LOADOUT = [
     optionId: TEXAS_TABLE_FINISH_OPTIONS[0]?.id,
     label: TEXAS_TABLE_FINISH_OPTIONS[0]?.label
   },
-  { type: 'tableWood', optionId: TABLE_WOOD_OPTIONS[0]?.id, label: TABLE_WOOD_OPTIONS[0]?.label },
   { type: 'tableCloth', optionId: TABLE_CLOTH_OPTIONS[0]?.id, label: TABLE_CLOTH_OPTIONS[0]?.label },
   { type: 'tableBase', optionId: TABLE_BASE_OPTIONS[0]?.id, label: TABLE_BASE_OPTIONS[0]?.label },
   { type: 'chairTheme', optionId: TEXAS_CHAIR_THEME_OPTIONS[0]?.id, label: TEXAS_CHAIR_THEME_OPTIONS[0]?.label },

--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -552,6 +552,16 @@ function basename(p) {
   return parts[parts.length - 1] || s;
 }
 
+function normalizePathBasename(value) {
+  if (!value) return '';
+  const base = basename(stripQueryHash(String(value)));
+  try {
+    return decodeURIComponent(base).toLowerCase();
+  } catch {
+    return base.toLowerCase();
+  }
+}
+
 function replaceFileExtension(path, nextExt) {
   if (!path || !nextExt) return path;
   const clean = stripQueryHash(path);
@@ -571,7 +581,7 @@ function resolveTextureFallbackUrl(requestedUrl, fileMap) {
   }
   for (const ext of fallbackExts) {
     const candidate = basename(replaceFileExtension(requestedBase, ext));
-    const mapped = fileMap.get(candidate);
+    const mapped = fileMap.get(normalizePathBasename(candidate));
     if (mapped) return mapped;
   }
   return null;
@@ -834,7 +844,6 @@ const CUSTOMIZATION_SECTIONS = [
   { key: 'tableTheme', label: 'Table Model', options: TEXAS_TABLE_THEME_OPTIONS },
   { key: 'tableFinish', label: 'Table Finish', options: TEXAS_TABLE_FINISH_OPTIONS },
   { key: 'chairTheme', label: 'Chairs', options: TEXAS_CHAIR_THEME_OPTIONS },
-  { key: 'tableWood', label: 'Table Wood', options: TABLE_WOOD_OPTIONS },
   { key: 'tableCloth', label: 'Table Cloth', options: TABLE_CLOTH_OPTIONS },
   { key: 'tableShape', label: 'Table Shape', options: TABLE_SHAPE_OPTIONS },
   { key: 'cards', label: 'Cards', options: CARD_THEMES }
@@ -1005,7 +1014,6 @@ function normalizeAppearance(value = {}) {
   const normalized = { ...DEFAULT_APPEARANCE };
   const entries = [
     ['tableFinish', TEXAS_TABLE_FINISH_OPTIONS.length],
-    ['tableWood', TABLE_WOOD_OPTIONS.length],
     ['tableCloth', TABLE_CLOTH_OPTIONS.length],
     ['tableBase', TABLE_BASE_OPTIONS.length],
     ['chairTheme', TEXAS_CHAIR_THEME_OPTIONS.length],
@@ -1275,7 +1283,7 @@ async function loadPolyhavenModel(assetId, renderer = null) {
           if (apiModelUrl) modelCandidates.add(apiModelUrl);
           if (!fileMap.size) {
             fileMap = allUrls.reduce((acc, u) => {
-              const b = basename(stripQueryHash(u));
+              const b = normalizePathBasename(u);
               if (!acc.has(b)) acc.set(b, u);
               return acc;
             }, new Map());
@@ -1303,7 +1311,7 @@ async function loadPolyhavenModel(assetId, renderer = null) {
           const textureFallback = resolveTextureFallbackUrl(requestedUrl, fileMap);
           if (textureFallback) return textureFallback;
           const req = stripQueryHash(requestedUrl);
-          const b = basename(req);
+          const b = normalizePathBasename(req);
           const mapped = fileMap.get(b);
           if (mapped) return mapped;
           try {
@@ -3233,7 +3241,6 @@ function TexasHoldemArena({ search }) {
       const normalized = normalizeAppearance(value);
       const map = {
         tableFinish: TEXAS_TABLE_FINISH_OPTIONS,
-        tableWood: TABLE_WOOD_OPTIONS,
         tableCloth: TABLE_CLOTH_OPTIONS,
         tableBase: TABLE_BASE_OPTIONS,
         chairTheme: TEXAS_CHAIR_THEME_OPTIONS,


### PR DESCRIPTION
### Motivation
- Product/UX: remove `tableWood` from Hold'em because table finish already provides the intended visual customization and the separate wood option is redundant. 
- Bug fix: Poly Haven GLTF models (tables/chairs) sometimes loaded without their original textures due to filename/encoding mismatches; texture lookup must be hardened to restore original GLTF textures.

### Description
- Removed `tableWood` usage from the Texas Hold'em inventory/store model by updating `webapp/src/config/texasHoldemInventoryConfig.js` to drop imports, default unlocks, option labels, store items and default loadout entries for `tableWood`.
- Removed the `Table Wood` customization section and related appearance normalization/validation for Hold'em in `webapp/src/pages/Games/TexasHoldemArena.jsx` so the option no longer appears in the UI or runtime checks.
- Added a helper `normalizePathBasename` to `webapp/src/pages/Games/TexasHoldemArena.jsx` and used it to normalize/decode basenames when building the Poly Haven `fileMap` and when resolving texture fallbacks in the GLTF URL modifier, improving matching for encoded/non-standard filenames.
- Kept all explicitly listed fine models (octagon/oval/diamond tables and specified chair themes) unchanged; the texture matching changes only improve resolution for other Poly Haven assets.

### Testing
- Built the webapp production bundle with `npm --prefix webapp run build`, and the build completed successfully with only the existing Vite chunk-size/dynamic-import warnings and no new errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d09b0d0bc08329a432ea7c7cd55702)