### PR TITLE
Remove Texas Hold'em 'Table Wood' customization and derive wood from table finish

### DIFF
--- a/webapp/src/config/texasHoldemInventoryConfig.js
+++ b/webapp/src/config/texasHoldemInventoryConfig.js
@@ -1,4 +1,4 @@
-import { TABLE_BASE_OPTIONS, TABLE_CLOTH_OPTIONS, TABLE_WOOD_OPTIONS } from '../utils/tableCustomizationOptions.js';
+import { TABLE_BASE_OPTIONS, TABLE_CLOTH_OPTIONS } from '../utils/tableCustomizationOptions.js';
 import { TABLE_SHAPE_OPTIONS } from '../utils/murlanTable.js';
 import { CARD_THEMES } from '../utils/cards3d.js';
 import {
@@ -30,7 +30,6 @@ const DEFAULT_HDRI_INDEX = Math.max(0, TEXAS_HDRI_OPTIONS.findIndex((variant) =>
 
 export const TEXAS_HOLDEM_DEFAULT_UNLOCKS = Object.freeze({
   tableFinish: [TEXAS_TABLE_FINISH_OPTIONS[0]?.id],
-  tableWood: [TABLE_WOOD_OPTIONS[0]?.id],
   tableCloth: [TABLE_CLOTH_OPTIONS[0]?.id],
   tableBase: [TABLE_BASE_OPTIONS[0]?.id],
   chairTheme: [TEXAS_CHAIR_THEME_OPTIONS[0]?.id],
@@ -46,7 +45,6 @@ export const TEXAS_HOLDEM_DEFAULT_UNLOCKS = Object.freeze({
 
 export const TEXAS_HOLDEM_OPTION_LABELS = Object.freeze({
   tableFinish: Object.freeze(reduceLabels(TEXAS_TABLE_FINISH_OPTIONS)),
-  tableWood: Object.freeze(reduceLabels(TABLE_WOOD_OPTIONS)),
   tableCloth: Object.freeze(reduceLabels(TABLE_CLOTH_OPTIONS)),
   tableBase: Object.freeze(reduceLabels(TABLE_BASE_OPTIONS)),
   chairTheme: Object.freeze(reduceLabels(TEXAS_CHAIR_THEME_OPTIONS)),
@@ -70,15 +68,6 @@ export const TEXAS_HOLDEM_STORE_ITEMS = [
     price: option.price,
     description: option.description,
     swatches: option.swatches,
-    thumbnail: option.thumbnail
-  })),
-  ...TABLE_WOOD_OPTIONS.slice(1).map((option, idx) => ({
-    id: `texas-wood-${option.id}`,
-    type: 'tableWood',
-    optionId: option.id,
-    name: option.label,
-    price: 540 + idx * 40,
-    description: "Unlock an alternate wood finish for your Hold'em arena table.",
     thumbnail: option.thumbnail
   })),
   ...TABLE_CLOTH_OPTIONS.slice(1).map((option, idx) => ({
@@ -153,7 +142,6 @@ export const TEXAS_HOLDEM_DEFAULT_LOADOUT = [
     optionId: TEXAS_TABLE_FINISH_OPTIONS[0]?.id,
     label: TEXAS_TABLE_FINISH_OPTIONS[0]?.label
   },
-  { type: 'tableWood', optionId: TABLE_WOOD_OPTIONS[0]?.id, label: TABLE_WOOD_OPTIONS[0]?.label },
   { type: 'tableCloth', optionId: TABLE_CLOTH_OPTIONS[0]?.id, label: TABLE_CLOTH_OPTIONS[0]?.label },
   { type: 'tableBase', optionId: TABLE_BASE_OPTIONS[0]?.id, label: TABLE_BASE_OPTIONS[0]?.label },
   { type: 'chairTheme', optionId: TEXAS_CHAIR_THEME_OPTIONS[0]?.id, label: TEXAS_CHAIR_THEME_OPTIONS[0]?.label },

--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -834,7 +834,6 @@ const CUSTOMIZATION_SECTIONS = [
   { key: 'tableTheme', label: 'Table Model', options: TEXAS_TABLE_THEME_OPTIONS },
   { key: 'tableFinish', label: 'Table Finish', options: TEXAS_TABLE_FINISH_OPTIONS },
   { key: 'chairTheme', label: 'Chairs', options: TEXAS_CHAIR_THEME_OPTIONS },
-  { key: 'tableWood', label: 'Table Wood', options: TABLE_WOOD_OPTIONS },
   { key: 'tableCloth', label: 'Table Cloth', options: TABLE_CLOTH_OPTIONS },
   { key: 'tableShape', label: 'Table Shape', options: TABLE_SHAPE_OPTIONS },
   { key: 'cards', label: 'Cards', options: CARD_THEMES }
@@ -870,8 +869,8 @@ const REGION_NAMES = typeof Intl !== 'undefined' ? new Intl.DisplayNames(['en'],
 const resolveDefaultTableFinish = (index) =>
   TEXAS_TABLE_FINISH_OPTIONS[index] ?? TEXAS_TABLE_FINISH_OPTIONS[0] ?? null;
 
-const resolveEffectiveWoodOption = ({ tableTheme, tableFinish, tableWood }) => {
-  const baseWoodOption = TABLE_WOOD_OPTIONS[tableWood] ?? TABLE_WOOD_OPTIONS[0];
+const resolveEffectiveWoodOption = ({ tableTheme, tableFinish }) => {
+  const baseWoodOption = TABLE_WOOD_OPTIONS[0];
   if (tableTheme?.id !== DEFAULT_TABLE_THEME_ID) {
     return baseWoodOption;
   }
@@ -1005,7 +1004,6 @@ function normalizeAppearance(value = {}) {
   const normalized = { ...DEFAULT_APPEARANCE };
   const entries = [
     ['tableFinish', TEXAS_TABLE_FINISH_OPTIONS.length],
-    ['tableWood', TABLE_WOOD_OPTIONS.length],
     ['tableCloth', TABLE_CLOTH_OPTIONS.length],
     ['tableBase', TABLE_BASE_OPTIONS.length],
     ['chairTheme', TEXAS_CHAIR_THEME_OPTIONS.length],
@@ -3233,7 +3231,6 @@ function TexasHoldemArena({ search }) {
       const normalized = normalizeAppearance(value);
       const map = {
         tableFinish: TEXAS_TABLE_FINISH_OPTIONS,
-        tableWood: TABLE_WOOD_OPTIONS,
         tableCloth: TABLE_CLOTH_OPTIONS,
         tableBase: TABLE_BASE_OPTIONS,
         chairTheme: TEXAS_CHAIR_THEME_OPTIONS,
@@ -4053,8 +4050,7 @@ function TexasHoldemArena({ search }) {
     const tableTheme = TEXAS_TABLE_THEME_OPTIONS[safe.tableTheme] ?? TEXAS_TABLE_THEME_OPTIONS[0];
     const woodOption = resolveEffectiveWoodOption({
       tableTheme,
-      tableFinish: safe.tableFinish,
-      tableWood: safe.tableWood
+      tableFinish: safe.tableFinish
     });
     const clothOption = TABLE_CLOTH_OPTIONS[safe.tableCloth] ?? TABLE_CLOTH_OPTIONS[0];
     const baseOption = TABLE_BASE_OPTIONS[safe.tableBase] ?? TABLE_BASE_OPTIONS[0];


### PR DESCRIPTION
### Motivation
- Simplify Texas Hold'em customization by removing the redundant `tableWood` option because table finishes already cover the desired wood appearance.
- Prevent UI confusion by hiding an unused menu option and centralizing wood/material resolution to table finishes for consistency.

### Description
- Removed `tableWood` exports/usages from the Texas inventory configuration by deleting the default unlock, option labels, store entries, and default loadout item in `webapp/src/config/texasHoldemInventoryConfig.js`.
- Removed the `Table Wood` customization section from the in-game menu in `webapp/src/pages/Games/TexasHoldemArena.jsx` so it no longer appears in the UI.
- Updated appearance normalization and unlock handling to drop `tableWood` from validation maps and indices in `TexasHoldemArena.jsx`.
- Simplified `resolveEffectiveWoodOption` to derive the wood/material from the selected table finish (or default) instead of a separate `tableWood` slot.

### Testing
- Ran the targeted unit test `jest --runInBand test/texasHoldemHdriPreload.test.js`, which passed (2 tests, 2 passed).
- No other automated tests were modified; full test suite not executed in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d09b0d0bc08329a432ea7c7cd55702)