### PR TITLE
Add preferred resolution override for Polyhaven models and prefer 4k/2k for table themes; adjust appearance migration

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -2744,14 +2744,20 @@ function buildPolyhavenModelUrls(assetId, resolutionOrder = ['2k', '1k']) {
 
 async function loadPolyhavenModel(
   assetId,
-  { preserveGltfTextureMapping = true } = {}
+  {
+    preserveGltfTextureMapping = true,
+    preferredResolutionsOverride = null
+  } = {}
 ) {
   if (!assetId) return null;
-  const preferredResolutions = IS_TELEGRAM_RUNTIME
-    ? ['1k']
-    : isLowProfileDevice
-      ? ['1k']
-      : resolveGraphicsModelResolutions(frameRateId);
+  const preferredResolutions =
+    Array.isArray(preferredResolutionsOverride) && preferredResolutionsOverride.length
+      ? preferredResolutionsOverride
+      : IS_TELEGRAM_RUNTIME
+        ? ['1k']
+        : isLowProfileDevice
+          ? ['1k']
+          : resolveGraphicsModelResolutions(frameRateId);
   const cacheKey = `${assetId.toLowerCase()}::${preferredResolutions.join(',')}::${preserveGltfTextureMapping ? 'preserve' : 'normalized'}`;
   if (polyhavenModelCache.has(cacheKey)) {
     const cached = polyhavenModelCache.get(cacheKey);
@@ -4419,12 +4425,6 @@ function normalizeAppearance(raw) {
   });
 
   const selectedTableTheme = TABLE_THEME_OPTIONS[normalized.tableTheme];
-  if (selectedTableTheme?.id === 'CoffeeTable_01') {
-    normalized.tableTheme = findDominoOptionIndex(
-      'tableTheme',
-      LUDO_MATCH_DEFAULT_TABLE_THEME_ID
-    );
-  }
   if (selectedTableTheme?.source === 'procedural' && selectedTableTheme?.id === 'murlan-default') {
     normalized.tableTheme = findDominoOptionIndex(
       'tableTheme',
@@ -4766,11 +4766,6 @@ try {
   const hasMigratedDefaultTable =
     window.localStorage?.getItem(DEFAULT_TABLE_MIGRATION_KEY) === '1';
   if (!hasMigratedDefaultTable) {
-    appearance = sanitizeAppearance(forceMurlanDefaultTableAppearance(appearance));
-    window.localStorage?.setItem(
-      APPEARANCE_STORAGE_KEY,
-      JSON.stringify(appearance)
-    );
     window.localStorage?.setItem(DEFAULT_TABLE_MIGRATION_KEY, '1');
   }
 
@@ -6055,6 +6050,10 @@ function setProceduralTableVisible(flag = true) {
   });
 }
 
+function resolveTableModelResolutions() {
+  return ['4k', '2k'];
+}
+
 async function applyTableTheme(
   option = TABLE_THEME_OPTIONS[appearance.tableTheme] ?? DEFAULT_TABLE_THEME_OPTION
 ) {
@@ -6082,7 +6081,8 @@ async function applyTableTheme(
   setProceduralTableVisible(true);
   try {
     const model = await loadPolyhavenModel(theme.assetId || theme.id, {
-      preserveGltfTextureMapping: theme.preserveMaterials ?? true
+      preserveGltfTextureMapping: theme.preserveMaterials ?? true,
+      preferredResolutionsOverride: resolveTableModelResolutions()
     });
     if (token !== tableThemeToken || !model) {
       disposeObjectResources(model, { disposeTextures: false });
@@ -6105,7 +6105,8 @@ async function applyTableTheme(
         const fallbackModel = await loadPolyhavenModel(
           DEFAULT_TABLE_THEME_OPTION.assetId,
           {
-            preserveGltfTextureMapping: true
+            preserveGltfTextureMapping: true,
+            preferredResolutionsOverride: resolveTableModelResolutions()
           }
         );
         if (token !== tableThemeToken || !fallbackModel) {


### PR DESCRIPTION
### Motivation
- Allow callers to explicitly control which texture/model resolutions are tried when loading Poly Haven assets so high-res table models can be preferred.
- Ensure table themes load higher-resolution assets by default for visual fidelity while keeping caching consistent across resolution sets.
- Avoid force-migrating or remapping stored user appearance values on first run (remove legacy `CoffeeTable_01` remap and stop overwriting appearance during default-table migration).

### Description
- Extend `loadPolyhavenModel` signature with `preferredResolutionsOverride` and use it to select `preferredResolutions`, also include the chosen resolutions in the cache key.
- Add `resolveTableModelResolutions()` which returns `['4k','2k']` and pass it as `preferredResolutionsOverride` when calling `loadPolyhavenModel` from `applyTableTheme` for both primary and fallback loads.
- Remove the special-case remap that forced `tableTheme` when `selectedTableTheme.id === 'CoffeeTable_01'` and stop forcing the `murlan-default` appearance into storage during the default-table migration step.

### Testing
- Ran the frontend build with `yarn build`, which completed successfully.
- Ran the test suite with `npm test`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0a05a43bc8329aedca49583a492f6)