### PR TITLE
Fix missing GLTF textures on non-default Texas Hold'em tables/chairs

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -552,6 +552,15 @@ function basename(p) {
   return parts[parts.length - 1] || s;
 }
 
+function normalizeAssetFilename(name) {
+  if (!name) return '';
+  try {
+    return decodeURIComponent(String(name)).toLowerCase();
+  } catch {
+    return String(name).toLowerCase();
+  }
+}
+
 function replaceFileExtension(path, nextExt) {
   if (!path || !nextExt) return path;
   const clean = stripQueryHash(path);
@@ -564,13 +573,13 @@ function resolveTextureFallbackUrl(requestedUrl, fileMap) {
   if (!fileMap?.size || !requestedUrl) return null;
   const requestedBase = basename(stripQueryHash(requestedUrl));
   if (!requestedBase) return null;
-  const lowerBase = requestedBase.toLowerCase();
+  const lowerBase = normalizeAssetFilename(requestedBase);
   const fallbackExts = ['.jpg', '.jpeg', '.png', '.webp'];
   if (!lowerBase.endsWith('.ktx2') && !lowerBase.endsWith('.basis')) {
     return null;
   }
   for (const ext of fallbackExts) {
-    const candidate = basename(replaceFileExtension(requestedBase, ext));
+    const candidate = normalizeAssetFilename(basename(replaceFileExtension(requestedBase, ext)));
     const mapped = fileMap.get(candidate);
     if (mapped) return mapped;
   }
@@ -1273,8 +1282,8 @@ async function loadPolyhavenModel(assetId, renderer = null) {
           if (apiModelUrl) modelCandidates.add(apiModelUrl);
           if (!fileMap.size) {
             fileMap = allUrls.reduce((acc, u) => {
-              const b = basename(stripQueryHash(u));
-              if (!acc.has(b)) acc.set(b, u);
+              const b = normalizeAssetFilename(basename(stripQueryHash(u)));
+              if (b && !acc.has(b)) acc.set(b, u);
               return acc;
             }, new Map());
           }
@@ -1301,7 +1310,7 @@ async function loadPolyhavenModel(assetId, renderer = null) {
           const textureFallback = resolveTextureFallbackUrl(requestedUrl, fileMap);
           if (textureFallback) return textureFallback;
           const req = stripQueryHash(requestedUrl);
-          const b = basename(req);
+          const b = normalizeAssetFilename(basename(req));
           const mapped = fileMap.get(b);
           if (mapped) return mapped;
           try {


### PR DESCRIPTION
### Motivation
- Poly Haven glTF models sometimes reference compressed textures (`.ktx2`/`.basis`) whose filenames differ in case or URL encoding from the CDN `files` listing, causing texture lookups to fail for some table and chair assets.
- The change aims to restore original Poly Haven textures for non-default tables/chairs without touching the working procedural/table/seat themes (octagon/oval/diamond and the listed chair themes).

### Description
- Added `normalizeAssetFilename(name)` which URL-decodes and lowercases asset filenames before matching to make lookups case-insensitive and robust to encoding differences.
- Updated `resolveTextureFallbackUrl` to use the normalized filename when mapping `.ktx2`/`.basis` references to fallback `.jpg/.jpeg/.png/.webp` files in the `fileMap`.
- When building `fileMap` from Poly Haven API results, keys are now stored normalized so lookups match consistently, and the GLTF loader `URLModifier` uses the same normalization when mapping requested texture names to CDN URLs.
- Change is limited to `webapp/src/pages/Games/TexasHoldemArena.jsx` and affects texture URL resolution only; procedural/default table and chair logic was not modified.

### Testing
- Ran unit tests with `npm test -- test/texasHoldemHdriPreload.test.js --runInBand` and the suite passed (`1` test suite, `2` tests passed).
- Ran ESLint (`npx eslint webapp/src/pages/Games/TexasHoldemArena.jsx`) which emitted a repository ignore warning for the file but produced no blocking errors.
- Confirmed the modified file compiles and the loader path that performs asset URL normalization is exercised by the existing HDri/model preload tests which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0a7b00e8c8329ac1a2075944f114a)