### PR TITLE
Resolve PolyHaven GLTF texture URL case mismatches for Texas Hold'em table/chair themes

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -560,6 +560,17 @@ function replaceFileExtension(path, nextExt) {
   return `${clean.slice(0, dotIdx)}${nextExt}`;
 }
 
+function resolveFileMapUrl(fileMap, requestedName) {
+  if (!fileMap?.size || !requestedName) return null;
+  const direct = fileMap.get(requestedName);
+  if (direct) return direct;
+  const lower = requestedName.toLowerCase();
+  for (const [key, value] of fileMap.entries()) {
+    if (key.toLowerCase() === lower) return value;
+  }
+  return null;
+}
+
 function resolveTextureFallbackUrl(requestedUrl, fileMap) {
   if (!fileMap?.size || !requestedUrl) return null;
   const requestedBase = basename(stripQueryHash(requestedUrl));
@@ -571,7 +582,7 @@ function resolveTextureFallbackUrl(requestedUrl, fileMap) {
   }
   for (const ext of fallbackExts) {
     const candidate = basename(replaceFileExtension(requestedBase, ext));
-    const mapped = fileMap.get(candidate);
+    const mapped = resolveFileMapUrl(fileMap, candidate);
     if (mapped) return mapped;
   }
   return null;
@@ -1302,7 +1313,7 @@ async function loadPolyhavenModel(assetId, renderer = null) {
           if (textureFallback) return textureFallback;
           const req = stripQueryHash(requestedUrl);
           const b = basename(req);
-          const mapped = fileMap.get(b);
+          const mapped = resolveFileMapUrl(fileMap, b);
           if (mapped) return mapped;
           try {
             return new URL(req, baseDir).toString();


### PR DESCRIPTION
### Motivation
- Fix cases where PolyHaven-sourced GLTF models (tables/chairs) failed to load their original textures due to filename/casing differences between requested URLs and the PolyHaven API file map while leaving existing procedural/default table and chair themes unchanged.

### Description
- Add `resolveFileMapUrl(fileMap, requestedName)` helper that performs exact and case-insensitive filename lookups against PolyHaven file maps.
- Use the new resolver in `resolveTextureFallbackUrl` (KTX2/Basis → JPG/PNG/WebP fallback) so fallback textures are found reliably.
- Use the new resolver inside the GLTF `LoadingManager` URL modifier so regular texture requests map to the correct PolyHaven URLs even when case differs.

### Testing
- Ran `npx eslint webapp/src/pages/Games/TexasHoldemArena.jsx` and `npx eslint --no-ignore webapp/src/pages/Games/TexasHoldemArena.jsx`, which completed with a file-ignore warning and reported no lint errors for the modified file.
- No unit or integration tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0a7b00e8c8329ac1a2075944f114a)