### PR TITLE
Prefer .gltf over .glb for Poly Haven models to restore original textures

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -620,7 +620,10 @@ function pickBestModelUrl(urls) {
   glbs.sort((a, b) => score(b) - score(a));
   gltfs.sort((a, b) => score(b) - score(a));
 
-  return glbs[0] || gltfs[0] || null;
+  // Prefer `.gltf` when available so chairs/tables keep the original Poly Haven texture packs.
+  // This preserves current custom procedural variants (octagon/oval/diamond + ruby/slate/teal/amber/violet/ice/leather),
+  // while fixing missing source textures on the remaining imported themes.
+  return gltfs[0] || glbs[0] || null;
 }
 
 const DEFAULT_STOOL_THEME = Object.freeze({ legColor: '#1f1f1f' });


### PR DESCRIPTION
### Motivation
- Poly Haven imports were sometimes loading `.glb` builds which lose the original GLTF texture pack mapping resulting in missing textures for some table and chair themes. The change aims to restore those source textures while leaving the built-in procedural/custom variants untouched.

### Description
- Change in `pickBestModelUrl` to prefer `.gltf` URLs before `.glb` so Poly Haven models keep their original texture mappings and packs.
- Added inline comment explaining the rationale and noting that procedural/custom sets (octagon/oval/diamond tables and ruby/slate/teal/amber/violet/ice/leather chairs) remain unchanged.
- Modified file: `webapp/src/pages/Games/TexasHoldemArena.jsx` (small selection logic tweak and comment).

### Testing
- Ran `npm test -- test/texasHoldemHdriPreload.test.js` and the suite passed (2 tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0a7b00e8c8329ac1a2075944f114a)