### PR TITLE
Refactor SnakeBoard layout: ring-based floors, elevations, and visual adjustments

### DIFF
--- a/webapp/src/components/SnakeBoard.jsx
+++ b/webapp/src/components/SnakeBoard.jsx
@@ -1,109 +1,98 @@
 import { useState, useEffect, useRef, Fragment, useMemo } from "react";
 import PlayerToken from "./PlayerToken.jsx";
 
-const LEVEL_SPECS = [
-  { size: 8, gapAfter: 2 },
-  { size: 5, gapAfter: 2 },
-  { size: 3, gapAfter: 0 },
-];
 const PLAYABLE_TILE_COUNT = 50;
 const GRID_SCALE = 2;
 const EXTRA_COLUMN_FRACTION = 0.6;
 const CELL_HEIGHT_RATIO = 1.9;
 const BOARD_SCALE = 1.12;
-const FINAL_SCALE_TARGET = 1.65;
+const FLOOR_COUNT = 3;
+const FLOOR_RISE = 1.05;
+const FLOOR_RAMP = 0.34;
 
 function buildPyramidLayout() {
-  const baseSize = LEVEL_SPECS[0].size;
-  let cell = 1;
-  let yCursor = 0;
-  const tiles = [];
-  const levels = [];
-  let minX = Infinity;
-  let maxX = -Infinity;
-  let maxY = -Infinity;
+  const gridSize = 8;
+  const ringSpecs = [
+    { size: 8, offset: 0 },
+    { size: 5, offset: 1.5 },
+    { size: 3, offset: 2.5 },
+  ];
 
-  LEVEL_SPECS.forEach(({ size, gapAfter }, levelIndex) => {
-    const xOffset = (baseSize - size) / 2;
-    const yOffset = yCursor;
-    const levelTiles = [];
+  const ringPath = ({ size, offset }) => {
+    const points = [];
+    const left = offset;
+    const right = offset + size - 1;
+    const top = offset;
+    const bottom = offset + size - 1;
+    for (let c = left; c <= right; c++) points.push({ col: c, row: top });
+    for (let r = top + 1; r <= bottom; r++) points.push({ col: right, row: r });
+    for (let c = right - 1; c >= left; c--) points.push({ col: c, row: bottom });
+    for (let r = bottom - 1; r > top; r--) points.push({ col: left, row: r });
+    return points;
+  };
 
-    const pushTile = (col, row) => {
-      const tile = {
-        cell,
-        col,
-        row,
-        levelIndex,
-        levelSize: size,
-      };
-      tiles.push(tile);
-      levelTiles.push(tile);
-      cell += 1;
-      minX = Math.min(minX, col);
-      maxX = Math.max(maxX, col + 1);
-      maxY = Math.max(maxY, row + 1);
-    };
-
-    for (let i = 0; i < size; i++) pushTile(xOffset + i, yOffset);
-    for (let i = 1; i < size; i++) pushTile(xOffset + size - 1, yOffset + i);
-    for (let i = size - 2; i >= 0; i--) pushTile(xOffset + i, yOffset + size - 1);
-    for (let i = size - 2; i >= 1; i--) pushTile(xOffset, yOffset + i);
-
-    levels.push({
-      levelIndex,
-      startCell: levelTiles[0]?.cell ?? cell,
-      endCell: levelTiles[levelTiles.length - 1]?.cell ?? cell,
-      size,
-      xOffset,
-      yOffset,
-    });
-
-    yCursor += size + (gapAfter ?? 0);
+  const allPoints = [];
+  ringSpecs.forEach((ring, ringIndex) => {
+    const ringPoints = ringPath(ring);
+    const startIndex = ringIndex === 0 ? 0 : Math.floor(ringPoints.length * 0.14);
+    const orderedRingPoints = [...ringPoints.slice(startIndex), ...ringPoints.slice(0, startIndex)];
+    if (allPoints.length) {
+      const prev = allPoints[allPoints.length - 1];
+      const next = orderedRingPoints[0];
+      allPoints.push({
+        col: prev.col + (next.col - prev.col) * 0.35,
+        row: prev.row + (next.row - prev.row) * 0.35,
+        floorBlend: ringIndex - 0.65,
+      });
+      allPoints.push({
+        col: prev.col + (next.col - prev.col) * 0.7,
+        row: prev.row + (next.row - prev.row) * 0.7,
+        floorBlend: ringIndex - 0.25,
+      });
+    }
+    orderedRingPoints.forEach((point) => allPoints.push({ ...point, floorBlend: ringIndex }));
   });
 
-  const totalCells = Math.min(PLAYABLE_TILE_COUNT, cell - 1);
-  const widthUnits = maxX - minX;
-  const heightUnits = maxY;
-
-  const mirrorColumn = (col) => minX + widthUnits - (col + 1);
-
-  const mirroredTiles = tiles
-    .filter((tile) => tile.cell <= totalCells)
-    .map((tile) => ({
-    ...tile,
-    col: mirrorColumn(tile.col),
+  const tiles = allPoints.slice(0, PLAYABLE_TILE_COUNT).map((point, index) => ({
+    cell: index + 1,
+    ...point,
   }));
+  const totalCells = tiles.length;
 
-  const mirroredLevels = levels
-    .map((level) => {
-      const tilesInLevel = mirroredTiles.filter((tile) => tile.levelIndex === level.levelIndex);
-      if (!tilesInLevel.length) return null;
-      return {
-        ...level,
-        startCell: tilesInLevel[0].cell,
-        endCell: tilesInLevel[tilesInLevel.length - 1].cell,
-        xOffset: mirrorColumn(level.xOffset + level.size - 1),
-      };
-    })
-    .filter(Boolean);
-
-  let mirroredMinX = Infinity;
-  let mirroredMaxX = -Infinity;
-  mirroredTiles.forEach((tile) => {
-    mirroredMinX = Math.min(mirroredMinX, tile.col);
-    mirroredMaxX = Math.max(mirroredMaxX, tile.col + 1);
+  const withElevation = tiles.map((tile) => {
+    const floorBase = Math.max(0, tile.floorBlend ?? tile.levelIndex ?? 0);
+    const floorIndex = Math.min(FLOOR_COUNT - 1, Math.floor(floorBase));
+    const floorProgress = Math.max(0, floorBase - floorIndex);
+    return {
+      ...tile,
+      levelIndex: floorIndex,
+      elevation: floorIndex * FLOOR_RISE + floorProgress * FLOOR_RAMP,
+    };
   });
 
-  const centerColumn = mirroredMinX + (mirroredMaxX - mirroredMinX) / 2;
+  const widthUnits = gridSize;
+  const heightUnits = gridSize;
+  const centerColumn = gridSize / 2;
+  const levels = Array.from({ length: FLOOR_COUNT }, (_, levelIndex) => {
+    const levelTiles = withElevation.filter((tile) => tile.levelIndex === levelIndex);
+    return {
+      levelIndex,
+      startCell: levelTiles[0]?.cell ?? 1,
+      endCell: levelTiles[levelTiles.length - 1]?.cell ?? totalCells,
+      size: ringSpecs[levelIndex]?.size ?? 3,
+      xOffset: ringSpecs[levelIndex]?.offset ?? levelIndex,
+      yOffset: ringSpecs[levelIndex]?.offset ?? levelIndex,
+    };
+  });
 
   return {
-    tiles: mirroredTiles,
-    levels: mirroredLevels,
+    tiles: withElevation,
+    levels,
     totalCells,
-    widthUnits: mirroredMaxX - mirroredMinX,
+    widthUnits,
     heightUnits,
-    minX: mirroredMinX,
-    maxX: mirroredMaxX,
+    minX: 0,
+    maxX: gridSize,
     centerColumn,
   };
 }
@@ -114,9 +103,7 @@ export const FINAL_TILE = BOARD_CELL_COUNT + 1;
 const BOARD_WIDTH_UNITS = BOARD_LAYOUT.widthUnits;
 const BOARD_HEIGHT_UNITS = BOARD_LAYOUT.heightUnits;
 const CENTER_COLUMN = BOARD_LAYOUT.centerColumn;
-const SCALE_STEP = (FINAL_SCALE_TARGET - 1) / Math.max(1, BOARD_HEIGHT_UNITS - 3);
-const FINAL_SCALE = 1 + (BOARD_HEIGHT_UNITS - 3) * SCALE_STEP;
-const WIDEN_STEP = 0.07;
+const FINAL_SCALE = 1.45;
 
 function CoinBurst({ token }) {
   const coins = Array.from({ length: 30 }, () => ({
@@ -174,26 +161,19 @@ export default function SnakeBoard({
   const scaledCols = BOARD_WIDTH_UNITS * GRID_SCALE;
   const scaledRows = BOARD_HEIGHT_UNITS * GRID_SCALE;
 
-  const rowOffsets = useMemo(() => {
-    const offsets = [0];
-    for (let r = 1; r < BOARD_HEIGHT_UNITS; r++) {
-      const prevScale = 1 + (r - 3) * SCALE_STEP;
-      offsets[r] = offsets[r - 1] + (prevScale - 1) * cellHeight;
-    }
-    return offsets;
-  }, [cellHeight]);
-
-  const offsetYMax = rowOffsets[BOARD_HEIGHT_UNITS - 1] ?? 0;
+  const maxElevation = useMemo(
+    () => layoutTiles.reduce((best, tile) => Math.max(best, tile.elevation ?? 0), 0),
+    [layoutTiles],
+  );
+  const offsetYMax = maxElevation * cellHeight;
 
   const tileElements = layoutTiles.map((tile) => {
     const num = tile.cell;
-    const rowIndex = Math.floor(tile.row);
-    const rowPos = BOARD_HEIGHT_UNITS > 1 ? rowIndex / (BOARD_HEIGHT_UNITS - 1) : 0;
-    const scale = 1 + (rowIndex - 3) * SCALE_STEP;
-    const scaleX = scale * (1 + rowPos * WIDEN_STEP);
-    const offsetX = (scaleX - 1) * cellWidth;
+    const scale = 1 + (tile.elevation ?? 0) * 0.2;
+    const scaleX = scale;
+    const offsetX = (scaleX - 1) * cellWidth * 0.9;
     const translateX = (tile.col + 0.5 - CENTER_COLUMN) * offsetX;
-    const translateY = -rowOffsets[rowIndex];
+    const translateY = -(tile.elevation ?? 0) * cellHeight;
     const isHighlight = highlight && highlight.cell === num;
     const trailHighlight = trail?.find((t) => t.cell === num);
     const highlightClass = isHighlight
@@ -311,10 +291,10 @@ export default function SnakeBoard({
   }, []);
 
 
-  const angle = 58;
-  const boardXOffset = 20; // pixels - align board slightly right
-  const boardYOffset = 60;
-  const boardZOffset = -50;
+  const angle = 63;
+  const boardXOffset = 8;
+  const boardYOffset = 48;
+  const boardZOffset = -64;
   const CAMERA_OFFSET_ROWS = 0;
 
   useEffect(() => {
@@ -331,15 +311,14 @@ export default function SnakeBoard({
   const paddingTop = 0;
   const paddingBottom = '15vh';
 
-  const topLevel = BOARD_LAYOUT.levels[BOARD_LAYOUT.levels.length - 1];
-  const potRowIndex = topLevel.yOffset + topLevel.size - 1;
-  const potCol = topLevel.xOffset + (topLevel.size - 1) / 2;
-  const potRowPos = BOARD_HEIGHT_UNITS > 1 ? potRowIndex / (BOARD_HEIGHT_UNITS - 1) : 0;
-  const potScale = 1 + (potRowIndex - 3) * SCALE_STEP;
-  const potScaleX = potScale * (1 + potRowPos * WIDEN_STEP);
+  const finalTile = layoutTiles[layoutTiles.length - 1];
+  const potRowIndex = finalTile?.row ?? 0;
+  const potCol = finalTile?.col ?? CENTER_COLUMN;
+  const potScale = 1 + (finalTile?.elevation ?? 0) * 0.2;
+  const potScaleX = potScale;
   const potOffsetX = (potScaleX - 1) * cellWidth;
   const potTranslateX = (potCol + 0.5 - CENTER_COLUMN) * potOffsetX;
-  const potTranslateY = -rowOffsets[potRowIndex] - cellHeight * 2.8;
+  const potTranslateY = -((finalTile?.elevation ?? 0) * cellHeight) - cellHeight * 1.65;
   const potStyle = {
     gridRowStart: scaledRows - potRowIndex * GRID_SCALE - (GRID_SCALE - 1),
     gridRowEnd: `span ${GRID_SCALE}`,
@@ -373,7 +352,7 @@ export default function SnakeBoard({
         <div className="snake-board-tilt">
           <div
             ref={gridRef}
-            className="snake-board-grid grid gap-x-1 gap-y-2 relative mx-auto"
+            className="snake-board-grid grid gap-x-0.5 gap-y-0.5 relative mx-auto"
             style={{
               width: `${cellWidth * BOARD_WIDTH_UNITS}px`,
               height: `${cellHeight * BOARD_HEIGHT_UNITS + offsetYMax}px`,


### PR DESCRIPTION
### Motivation
- Replace the previous stacked-level pyramid algorithm with a more flexible ring-based layout that supports multiple floors and per-tile elevation for improved 3D visual staging.
- Introduce explicit floor/elevation parameters to allow smoother visual scaling and easier tuning of board perspective and pot placement.

### Description
- Rewrote `buildPyramidLayout` to generate tiles from `ringSpecs` and a ring path, producing `tiles` with `floorBlend`, `levelIndex`, and computed `elevation`, and removed the old `LEVEL_SPECS` and mirror logic.  
- Added constants `FLOOR_COUNT`, `FLOOR_RISE`, and `FLOOR_RAMP` and computed elevation-based transforms used for tile `scale` and `translateY`, and constructed `levels` from computed floors.  
- Removed `SCALE_STEP`/`WIDEN_STEP` logic and replaced final scaling with a fixed `FINAL_SCALE`, adjusted `BOARD_LAYOUT` fields (width/height/center) and updated pot placement to use the final tile's column/elevation.  
- Tweaked layout/rendering parameters including grid gaps, board `angle`, `boardXOffset`, `boardYOffset`, and `boardZOffset`, and made the board height account for maximum elevation (`offsetYMax`).

### Testing
- Ran the test suite via `yarn test` which completed successfully.  
- Performed a production build with `yarn build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0a72c151c8329a5385d30da6e3acf)