### PR TITLE
PolyHaven: fallback texture URL resolver for GLTF include paths

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -2710,18 +2710,67 @@ function prepareLoadedModel(model, { preserveGltfTextureMapping = false } = {}) 
   });
 }
 
-function createPolyhavenGltfLoader(includeUrlMap = null) {
+function resolvePolyhavenTextureFormatFromRequest(requestPath = '') {
+  const ext = (requestPath.split('.').pop() || '').toLowerCase();
+  if (!ext) return null;
+  if (ext === 'jpg' || ext === 'jpeg') return 'jpg';
+  if (ext === 'png') return 'png';
+  if (ext === 'webp') return 'webp';
+  if (ext === 'avif') return 'avif';
+  if (ext === 'ktx2') return 'ktx2';
+  return null;
+}
+
+function buildPolyhavenFallbackIncludeUrl(
+  requestUrl = '',
+  { assetId = '', resolution = '2k' } = {}
+) {
+  const cleanUrl = String(requestUrl || '').split('?')[0];
+  if (!cleanUrl) return null;
+  const normalized = cleanUrl.replace(/^\.\//, '');
+  const fileName = normalized.split('/').pop();
+  if (!fileName) return null;
+  const textureFormat = resolvePolyhavenTextureFormatFromRequest(fileName);
+  if (!textureFormat) return null;
+  if (!normalized.includes('/textures/') && !normalized.startsWith('textures/')) {
+    return null;
+  }
+  const resolvedAssetId = String(assetId || '').trim();
+  if (!resolvedAssetId) return null;
+  const resolvedResolution = String(resolution || '2k').toLowerCase();
+  return `https://dl.polyhaven.org/file/ph-assets/Textures/${textureFormat}/${resolvedResolution}/${resolvedAssetId}/${fileName}`;
+}
+
+function createPolyhavenGltfLoader(
+  includeUrlMap = null,
+  { assetId = '', resolution = '2k' } = {}
+) {
   const manager = new THREE.LoadingManager();
   if (includeUrlMap?.size) {
     manager.setURLModifier((requestUrl = '') => {
       const cleanUrl = String(requestUrl || '').split('?')[0];
       const normalized = cleanUrl.replace(/^\.\//, '');
       const fileName = normalized.split('/').pop();
-      return (
+      const mappedUrl =
         includeUrlMap.get(cleanUrl) ||
         includeUrlMap.get(normalized) ||
         includeUrlMap.get(fileName) ||
-        requestUrl
+        null;
+      if (mappedUrl) return mappedUrl;
+      return (
+        buildPolyhavenFallbackIncludeUrl(requestUrl, {
+          assetId,
+          resolution
+        }) || requestUrl
+      );
+    });
+  } else {
+    manager.setURLModifier((requestUrl = '') => {
+      return (
+        buildPolyhavenFallbackIncludeUrl(requestUrl, {
+          assetId,
+          resolution
+        }) || requestUrl
       );
     });
   }
@@ -2788,7 +2837,10 @@ async function loadPolyhavenModel(
           filesManifest,
           candidate?.resolution || preferredResolutions[0] || '2k'
         );
-      const loader = createPolyhavenGltfLoader(includeUrlMap);
+      const loader = createPolyhavenGltfLoader(includeUrlMap, {
+        assetId,
+        resolution: candidate?.resolution || preferredResolutions[0] || '2k'
+      });
       const resolvedUrl = new URL(
         candidateUrl,
         typeof window !== 'undefined' ? window.location?.href : candidateUrl


### PR DESCRIPTION
### Motivation
- Some Poly Haven GLTFs resolve geometry but fail to find their `textures/...` include paths which results in missing table and chair materials in-game. 
- The change provides a deterministic fallback that reconstructs CDN texture URLs for Poly Haven models when the include manifest map is missing or incomplete. 
- Existing procedural and manually-working themes (octagon/oval/diamond tables and the listed chair cloth/finish colors) are not altered by this fix.

### Description
- Added `resolvePolyhavenTextureFormatFromRequest` and `buildPolyhavenFallbackIncludeUrl` to construct Poly Haven texture CDN URLs from requested include paths and the current `assetId`/`resolution`.
- Extended `createPolyhavenGltfLoader` to accept `{ assetId, resolution }` and updated the LoadingManager `setURLModifier` to use the fallback URL when an include map entry is missing or when no include map exists. 
- Updated `loadPolyhavenModel` to pass `assetId` and the candidate `resolution` into the GLTF loader so texture include fallbacks resolve to the correct Poly Haven texture bucket. 
- The fallback only maps texture include paths (checks for `/textures/` and known extensions) and preserves existing include-map behavior where available.

### Testing
- Performed a static JS validity check with `node --check webapp/public/domino-royal-game.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0b5d6a4108329bbbc65000f2bf269)