### PR TITLE
Fix Poly Haven texture URL resolution in Texas Hold'em arena

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -571,7 +571,7 @@ function resolveTextureFallbackUrl(requestedUrl, fileMap) {
   }
   for (const ext of fallbackExts) {
     const candidate = basename(replaceFileExtension(requestedBase, ext));
-    const mapped = fileMap.get(candidate);
+    const mapped = fileMap.get(candidate) || fileMap.get(candidate.toLowerCase());
     if (mapped) return mapped;
   }
   return null;
@@ -1275,6 +1275,8 @@ async function loadPolyhavenModel(assetId, renderer = null) {
             fileMap = allUrls.reduce((acc, u) => {
               const b = basename(stripQueryHash(u));
               if (!acc.has(b)) acc.set(b, u);
+              const lower = b.toLowerCase();
+              if (!acc.has(lower)) acc.set(lower, u);
               return acc;
             }, new Map());
           }
@@ -1302,7 +1304,7 @@ async function loadPolyhavenModel(assetId, renderer = null) {
           if (textureFallback) return textureFallback;
           const req = stripQueryHash(requestedUrl);
           const b = basename(req);
-          const mapped = fileMap.get(b);
+          const mapped = fileMap.get(b) || fileMap.get(b.toLowerCase());
           if (mapped) return mapped;
           try {
             return new URL(req, baseDir).toString();


### PR DESCRIPTION
### Motivation
- Improve reliability of GLTF material texture resolution for Poly Haven table and chair models where filename casing mismatches cause missing textures. 
- Preserve existing procedural/table cloth and chair themes (octagon/oval/diamond + ruby/slate/teal/amber/violet/ice/leather) while fixing the other Poly Haven assets.

### Description
- Make fallback texture remapping case-insensitive by checking lowercase keys when resolving `.ktx2`/`.basis` → image fallbacks in `resolveTextureFallbackUrl`.
- When building the Poly Haven `fileMap` from API results, add lowercase aliases for each basename to support case-insensitive lookups.
- Update the GLTF loader `URLModifier` lookup to try both the original basename and a lowercase variant when remapping requested texture URLs.
- Changes are limited to `webapp/src/pages/Games/TexasHoldemArena.jsx` and only affect Poly Haven model/texture resolution logic.

### Testing
- Ran linter check with `npx eslint webapp/src/pages/Games/TexasHoldemArena.jsx`, which completed and reported the file is ignored by project lint rules (no errors introduced by the change).
- No new unit tests were added and existing automated test suites were not run as part of this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0b5d6a4108329bbbc65000f2bf269)