### PR TITLE
Pool Royale: add Snooker-style replay toggle and persisted skip flag

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -12657,7 +12657,14 @@ function PoolRoyaleGame({
     );
   });
   const clothTextureSourceId = DEFAULT_CLOTH_TEXTURE_SOURCE_ID;
-  const [skipAllReplays, setSkipAllReplays] = useState(!POOL_ROYALE_REPLAY_ENABLED);
+  const [skipAllReplays, setSkipAllReplays] = useState(() => {
+    if (typeof window !== 'undefined') {
+      const stored = window.localStorage.getItem(SKIP_REPLAYS_STORAGE_KEY);
+      if (stored === '1') return true;
+      if (stored === '0') return false;
+    }
+    return !POOL_ROYALE_REPLAY_ENABLED;
+  });
   const [commentaryPresetId, setCommentaryPresetId] = useState(DEFAULT_COMMENTARY_PRESET_ID);
   const [commentaryMuted, setCommentaryMuted] = useState(!POOL_ROYALE_VOICE_COMMENTARY_ENABLED);
   const skipReplayRef = useRef(() => {});
@@ -32365,6 +32372,32 @@ const powerRef = useRef(hud.power);
               </button>
             </div>
             <div className="mt-4 max-h-72 space-y-4 overflow-y-auto pr-1">
+              <div className="rounded-xl border border-white/10 bg-white/5 p-3">
+                <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
+                  Replays
+                </h3>
+                <button
+                  type="button"
+                  onClick={() => setSkipAllReplays((prev) => !prev)}
+                  aria-pressed={skipAllReplays}
+                  className={`mt-2 flex w-full items-center justify-between gap-3 rounded-full px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.24em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
+                    skipAllReplays
+                      ? 'bg-emerald-400 text-black shadow-[0_0_18px_rgba(16,185,129,0.65)]'
+                      : 'bg-white/10 text-white/80 hover:bg-white/20'
+                  }`}
+                >
+                  <span>Skip all replays</span>
+                  <span
+                    className={`rounded-full border px-2 py-0.5 text-[10px] tracking-[0.3em] ${
+                      skipAllReplays
+                        ? 'border-black/30 text-black/70'
+                        : 'border-white/30 text-white/70'
+                    }`}
+                  >
+                    {skipAllReplays ? 'On' : 'Off'}
+                  </span>
+                </button>
+              </div>
               <div>
                 <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
                   Table Finish


### PR DESCRIPTION
### Motivation
- Align Pool Royale's replay controls and persistence with the Snooker Royal behavior so players can toggle and persist "skip replays" from the top menu just like Snooker Royal.

### Description
- Initialize `skipAllReplays` from `window.localStorage` using `SKIP_REPLAYS_STORAGE_KEY` (accepting `'1'`/`'0'`) with a fallback to `POOL_ROYALE_REPLAY_ENABLED` in `PoolRoyale.jsx`.
- Add a `Replays` block to the top config/menu panel with a `Skip all replays` On/Off toggle bound to `skipAllReplays`/`setSkipAllReplays` so the preference can be changed from the menu.
- The change complements the existing in-replay skip icon and replay playback logic, without altering the core replay/frame resolution code paths.
- Only file modified: `webapp/src/pages/Games/PoolRoyale.jsx`.

### Testing
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx`, which completed with a repo ignore warning but reported no lint errors for the change.
- Ran `npx eslint --no-ignore webapp/src/pages/Games/PoolRoyale.jsx`, which similarly reported the ignore warning and no errors.
- Verified the code diff and committed the change locally (`git` operations used to validate the patch were successful).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0b8c7401c832987517d80c79b7185)