### PR TITLE
Use official PolyHaven GLTF resource paths for Texas Hold'em models (fix missing textures)

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -546,37 +546,6 @@ function stripQueryHash(u) {
   return u.split('#')[0].split('?')[0];
 }
 
-function basename(p) {
-  const s = p.replace(/\\/g, '/');
-  const parts = s.split('/');
-  return parts[parts.length - 1] || s;
-}
-
-function replaceFileExtension(path, nextExt) {
-  if (!path || !nextExt) return path;
-  const clean = stripQueryHash(path);
-  const dotIdx = clean.lastIndexOf('.');
-  if (dotIdx < 0) return `${clean}${nextExt}`;
-  return `${clean.slice(0, dotIdx)}${nextExt}`;
-}
-
-function resolveTextureFallbackUrl(requestedUrl, fileMap) {
-  if (!fileMap?.size || !requestedUrl) return null;
-  const requestedBase = basename(stripQueryHash(requestedUrl));
-  if (!requestedBase) return null;
-  const lowerBase = requestedBase.toLowerCase();
-  const fallbackExts = ['.jpg', '.jpeg', '.png', '.webp'];
-  if (!lowerBase.endsWith('.ktx2') && !lowerBase.endsWith('.basis')) {
-    return null;
-  }
-  for (const ext of fallbackExts) {
-    const candidate = basename(replaceFileExtension(requestedBase, ext));
-    const mapped = fileMap.get(candidate) || fileMap.get(candidate.toLowerCase());
-    if (mapped) return mapped;
-  }
-  return null;
-}
-
 function isModelUrl(u) {
   const s = stripQueryHash(u).toLowerCase();
   return s.endsWith('.glb') || s.endsWith('.gltf');
@@ -1261,7 +1230,6 @@ async function loadPolyhavenModel(assetId, renderer = null) {
   let cached = POLYHAVEN_MODEL_CACHE.get(cacheKey);
   if (!cached) {
     const promise = (async () => {
-      let fileMap = new Map();
       const modelCandidates = new Set();
       const assetCandidates = Array.from(new Set([assetId, cacheKey]));
 
@@ -1271,15 +1239,6 @@ async function loadPolyhavenModel(assetId, renderer = null) {
           const allUrls = extractAllHttpUrls(filesJson);
           const apiModelUrl = pickBestModelUrl(allUrls);
           if (apiModelUrl) modelCandidates.add(apiModelUrl);
-          if (!fileMap.size) {
-            fileMap = allUrls.reduce((acc, u) => {
-              const b = basename(stripQueryHash(u));
-              if (!acc.has(b)) acc.set(b, u);
-              const lower = b.toLowerCase();
-              if (!acc.has(lower)) acc.set(lower, u);
-              return acc;
-            }, new Map());
-          }
         } catch (error) {
           console.warn('Poly Haven file lookup failed, falling back to direct URLs', error);
         }
@@ -1292,27 +1251,7 @@ async function loadPolyhavenModel(assetId, renderer = null) {
         throw new Error(`No model URL found for ${assetId}`);
       }
 
-      const manager = fileMap.size ? new THREE.LoadingManager() : undefined;
-      const loader = createConfiguredGLTFLoader(renderer, manager);
-
-      if (fileMap.size) {
-        const base = stripQueryHash(modelUrlList[0]);
-        const baseDir = base.substring(0, base.lastIndexOf('/') + 1);
-        loader.manager.setURLModifier((requestedUrl) => {
-          if (/^https?:\/\//i.test(requestedUrl)) return requestedUrl;
-          const textureFallback = resolveTextureFallbackUrl(requestedUrl, fileMap);
-          if (textureFallback) return textureFallback;
-          const req = stripQueryHash(requestedUrl);
-          const b = basename(req);
-          const mapped = fileMap.get(b) || fileMap.get(b.toLowerCase());
-          if (mapped) return mapped;
-          try {
-            return new URL(req, baseDir).toString();
-          } catch {
-            return requestedUrl;
-          }
-        });
-      }
+      const loader = createConfiguredGLTFLoader(renderer);
 
       let gltf = null;
       let lastError = null;


### PR DESCRIPTION
### Motivation
- PolyHaven table and chair GLTF imports were losing their original textures due to custom URL remapping and fallback logic in the Texas Hold'em loader, which caused non-default models to render without proper GLTF textures. 
- Preserve existing procedural/default themes (Octagon/Oval/Diamond tables and Ruby/Slate/Teal/Amber/Violet/Ice/Leather chairs) while restoring correct PolyHaven texture mapping for the remaining themes.

### Description
- Removed the custom `fileMap` + `LoadingManager.setURLModifier` fallback logic from `webapp/src/pages/Games/TexasHoldemArena.jsx` so GLTF loaders use the models' official resource paths. 
- Deleted the local texture fallback helpers that were used only by the removed remapping logic (`basename`, `replaceFileExtension`, and `resolveTextureFallbackUrl`) to avoid conflicting overrides. 
- Kept model preparation and cloning logic (`prepareLoadedModel`, `cloneModelWithLocalMaterials`) intact and still call `prepareLoadedModel(model, { preserveGltfTextureMapping: true })` for PolyHaven assets. 
- Change is localized to `TexasHoldemArena.jsx` and does not modify procedural table/chair generation or the preserved chair/table themes.

### Testing
- Ran the production build with `npm run build` from `webapp/`, which completed successfully. 
- No other automated tests were added or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0b9804b088329a60d2391f2ed0930)