### PR TITLE
Remove Clips/Highlights card and snake background from Achievements & Roadmap

### DIFF
--- a/webapp/src/components/HomeSocialHub.jsx
+++ b/webapp/src/components/HomeSocialHub.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { FaUserFriends, FaGamepad, FaComments, FaVideo } from 'react-icons/fa';
+import { FaUserFriends, FaGamepad, FaComments } from 'react-icons/fa';
 import LoginOptions from './LoginOptions.jsx';
 import { socket } from '../utils/socket.js';
 import { getTelegramId } from '../utils/telegram.js';
@@ -314,27 +314,6 @@ export default function HomeSocialHub() {
         </div>
       </div>
 
-      <div className="rounded-lg border border-border bg-background/40 p-3 space-y-2">
-        <div className="flex items-center justify-between">
-          <p className="text-sm font-semibold text-white flex items-center gap-2">
-            <FaVideo className="text-primary" /> Clips & Highlights
-          </p>
-          <span className="text-xs text-subtext">Share</span>
-        </div>
-        <p className="text-xs text-subtext">
-          Upload short clips, add a caption, and share to the wall or direct messages.
-        </p>
-        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-          <input
-            type="file"
-            accept="video/*"
-            className="text-xs text-subtext file:mr-3 file:rounded-full file:border-0 file:bg-primary file:px-3 file:py-1 file:text-[11px] file:font-semibold file:text-background"
-          />
-          <button className="rounded-full bg-primary px-4 py-2 text-xs font-semibold text-background">
-            Upload Clip
-          </button>
-        </div>
-      </div>
     </div>
   );
 }

--- a/webapp/src/components/ProjectAchievementsCard.jsx
+++ b/webapp/src/components/ProjectAchievementsCard.jsx
@@ -341,12 +341,6 @@ export default function ProjectAchievementsCard() {
 
   return (
     <div className="relative rounded-2xl border border-border/70 bg-gradient-to-br from-surface/95 via-surface/90 to-surface/80 p-5 shadow-xl shadow-black/5 space-y-6 overflow-hidden wide-card">
-      <img
-        src="/assets/icons/snakes_and_ladders.webp"
-        className="background-behind-board object-cover opacity-30"
-        alt=""
-        onError={(e) => { e.currentTarget.style.display = 'none'; }}
-      />
       <div className="space-y-2 text-center">
         <p className="text-[10px] uppercase tracking-[0.4em] text-muted">Playgram</p>
         <h3 className="text-xl font-semibold">Achievements & Roadmap</h3>


### PR DESCRIPTION
### Motivation
- Remove the Home page "Clips & Highlights" card and the snakes/laser background image from the Achievements & Roadmap card to match the requested UI cleanup and remove the related unused icon import.

### Description
- Deleted the Clips & Highlights UI block from `webapp/src/components/HomeSocialHub.jsx` and removed the now-unused `FaVideo` import.
- Removed the background `<img>` overlay from `webapp/src/components/ProjectAchievementsCard.jsx` to eliminate the snake/laser image behind the card content.
- Minor cleanup limited to the two component files listed above with no behavioral logic changes.

### Testing
- Ran the production build with `npm --prefix webapp run build`, which completed successfully.
- The build produced unrelated Vite warnings about chunk sizes and mixed static/dynamic imports but no errors related to these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0bdc7ba608329975b1e69ac32494d)