### PR TITLE
Align Pool Royale replay pot/foul behavior with Snooker Royal

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -27959,8 +27959,6 @@ const powerRef = useRef(hud.power);
           shotContext
         }) => {
           if (!recording || !hadObjectPot) return null;
-          const frameCount = recording.frames?.length ?? 0;
-          if (frameCount <= 1) return null;
           const tags = new Set(recording.replayTags ?? []);
           if (hadObjectPot) tags.add('pot');
           const potCount = pottedBalls.filter((entry) => entry.id !== 'cue').length;
@@ -27983,9 +27981,6 @@ const powerRef = useRef(hud.power);
         function resolve() {
           const variantId = activeVariantRef.current?.id ?? 'american';
           const shotEvents = [];
-          if (shotRecording && (shotRecording.frames?.length ?? 0) < 2) {
-            recordReplayFrame(performance.now());
-          }
           const firstContactColor = toBallColorId(firstHit);
           const hadObjectPot = potted.some((entry) => entry.id !== 'cue');
           let replayDecision = resolveReplayDecision({
@@ -28243,17 +28238,26 @@ const powerRef = useRef(hud.power);
               ...lastPottedBySeatRef.current,
               [shooterSeat]: newPots[newPots.length - 1] ?? null
             };
-            setPottedBySeat((prev) => ({
-              ...prev,
-              [shooterSeat]: [
-                ...(prev[shooterSeat] || []),
-                ...newPots.map((entry) => ({
-                  id: entry.id ?? String(entry.color ?? 'unknown'),
+            setPottedBySeat((prev) => {
+              const next = {
+                ...prev,
+                [shooterSeat]: [...(prev[shooterSeat] || [])]
+              };
+              const existing = new Set(
+                next[shooterSeat].map((entry) => String(entry.id ?? entry.color))
+              );
+              newPots.forEach((entry) => {
+                const key = String(entry.id ?? entry.color);
+                if (existing.has(key)) return;
+                existing.add(key);
+                next[shooterSeat].push({
+                  id: entry.id ?? key,
                   color: entry.color,
                   pocket: entry.pocket
-                }))
-              ]
-            }));
+                });
+              });
+              return next;
+            });
           } else {
             lastPottedBySeatRef.current = {
               ...lastPottedBySeatRef.current,


### PR DESCRIPTION
### Motivation
- Make Pool Royale replay behavior match Snooker Royal so pot and foul events produce the same replay classification and UI (including the skip button) and use the same recorded frames/lead-in logic.
- Prevent duplicate potted-ball entries in the HUD/replay when the same pot event is reported multiple times.

### Description
- Removed the Pool-only early frame-count gate in `resolveReplayDecision` so pot/foul tagging follows the same evaluation path used by Snooker Royal (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Removed the Pool-only forced pre-resolve frame injection (`recordReplayFrame(...)`) so replay recordings and timing mirror Snooker Royal behavior.
- Reworked potted-ball seat tracking update in `setPottedBySeat` to use the same dedupe-style merge as Snooker Royal and avoid duplicate pot records when a ball is reported more than once.
- Changes are limited to `webapp/src/pages/Games/PoolRoyale.jsx` and keep existing replay UI (skip button, foul banner) intact.

### Testing
- Ran unit tests: `npm test -- --runInBand test/poolRoyaleCueStrokeTimeline.test.js` and all tests passed.
- Ran linter: `npx eslint webapp/src/pages/Games/PoolRoyale.jsx` produced a repository ignore warning only and no code errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0bf6ce7048329affe52430a1acbc4)