### PR TITLE
Fix replay frame fallback visibility in Pool Royal

### DIFF
--- a/Assets/Scripts/Gameplay/Broadcast/ReplayBroadcastGate.cs
+++ b/Assets/Scripts/Gameplay/Broadcast/ReplayBroadcastGate.cs
@@ -21,6 +21,12 @@ namespace Aiming.Gameplay.Broadcast
         public event Action<ReplayBroadcastPayload> ReplayBroadcastRequested;
         private Coroutine replayFrameRoutine;
 
+        private void Awake()
+        {
+            EnsureReplayFrameReferences();
+            SetReplayFrameVisible(false);
+        }
+
         public bool TryBroadcastReplay(ReplayBroadcastPayload payload)
         {
             if (!forceLegacyReplayBroadcast || !payload.IsValid)
@@ -47,14 +53,10 @@ namespace Aiming.Gameplay.Broadcast
 
         private void ShowReplayFrame()
         {
+            EnsureReplayFrameReferences();
             if (replayFrameRoot == null && replayFrameCanvasGroup == null)
             {
                 return;
-            }
-
-            if (replayFrameRoot == null && replayFrameCanvasGroup != null)
-            {
-                replayFrameRoot = replayFrameCanvasGroup.gameObject;
             }
 
             if (replayFrameRoutine != null)
@@ -67,31 +69,52 @@ namespace Aiming.Gameplay.Broadcast
 
         private IEnumerator ReplayFrameRoutine()
         {
-            if (replayFrameRoot != null)
-            {
-                replayFrameRoot.SetActive(true);
-            }
-
-            if (replayFrameCanvasGroup != null)
-            {
-                replayFrameCanvasGroup.alpha = 1f;
-                replayFrameCanvasGroup.interactable = false;
-                replayFrameCanvasGroup.blocksRaycasts = false;
-            }
+            SetReplayFrameVisible(true);
 
             yield return new WaitForSecondsRealtime(replayFrameVisibleSeconds);
 
-            if (replayFrameCanvasGroup != null)
-            {
-                replayFrameCanvasGroup.alpha = 0f;
-            }
-
-            if (replayFrameRoot != null)
-            {
-                replayFrameRoot.SetActive(false);
-            }
+            SetReplayFrameVisible(false);
 
             replayFrameRoutine = null;
+        }
+
+        private void EnsureReplayFrameReferences()
+        {
+            if (replayFrameRoot == null && replayFrameCanvasGroup != null)
+            {
+                replayFrameRoot = replayFrameCanvasGroup.transform.root.gameObject;
+            }
+
+            if (replayFrameCanvasGroup == null && replayFrameRoot != null)
+            {
+                replayFrameCanvasGroup = replayFrameRoot.GetComponentInChildren<CanvasGroup>(true);
+            }
+
+            if (replayFrameRoot == null && replayFrameCanvasGroup == null)
+            {
+                replayFrameCanvasGroup = GetComponentInChildren<CanvasGroup>(true);
+                if (replayFrameCanvasGroup != null)
+                {
+                    replayFrameRoot = replayFrameCanvasGroup.transform.root.gameObject;
+                }
+            }
+        }
+
+        private void SetReplayFrameVisible(bool visible)
+        {
+            if (replayFrameRoot != null)
+            {
+                replayFrameRoot.SetActive(visible);
+            }
+
+            if (replayFrameCanvasGroup == null)
+            {
+                return;
+            }
+
+            replayFrameCanvasGroup.alpha = visible ? 1f : 0f;
+            replayFrameCanvasGroup.interactable = false;
+            replayFrameCanvasGroup.blocksRaycasts = false;
         }
     }
 


### PR DESCRIPTION
### Motivation
- Replays sometimes failed to show the UI "replay frame" when scene inspector references were partially assigned or left null, leaving stale UI visible state or nothing shown during replay triggers.
- The code needed robust runtime fallback wiring and consistent show/hide logic so replay frames appear reliably across different scene configurations.

### Description
- Added `Awake()` to call `EnsureReplayFrameReferences()` and `SetReplayFrameVisible(false)` so frame references are resolved early and hidden at startup.
- Implemented `EnsureReplayFrameReferences()` to auto-resolve `replayFrameRoot` and `replayFrameCanvasGroup` from the hierarchy when inspector fields are missing.
- Centralized show/hide logic into `SetReplayFrameVisible(bool)` and updated `ReplayFrameRoutine()` and `ShowReplayFrame()` to use it so visibility transitions are consistent.
- Hardened `ShowReplayFrame()` to re-run reference resolution before attempting to display the frame, preventing no-op behavior when references are incomplete.

### Testing
- Ran `git diff --check` to validate whitespace/format issues and it completed without reported errors.
- Ran `git status --short` to confirm the change was staged in the working tree and observed the modified file; no automated runtime/unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0c810dd088329baafb5f8d6ca1b3d)