### PR TITLE
Fix Pool Royale replay frame camera updates

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -28629,21 +28629,23 @@ const powerRef = useRef(hud.power);
             applyReplayCueStroke(playback, targetTime);
             updateReplayTrail(playback.cuePath, targetTime);
             if (!LOCK_REPLAY_CAMERA) {
-              const nextFrameCamera = frameB?.camera ?? frameA?.camera ?? null;
+              const currentFrameCamera = frameA?.camera ?? null;
+              const nextFrameCamera = frameB?.camera ?? currentFrameCamera;
               const previousFrameCamera =
                 replayFrameCameraRef.current?.frameB ??
                 replayFrameCameraRef.current?.frameA ??
                 null;
-              if (
-                nextFrameCamera &&
-                (!replayFrameCameraRef.current ||
-                  hasReplayCameraChanged(previousFrameCamera, nextFrameCamera))
-              ) {
+              const cameraChanged =
+                hasReplayCameraChanged(previousFrameCamera, currentFrameCamera) ||
+                hasReplayCameraChanged(previousFrameCamera, nextFrameCamera);
+              if ((currentFrameCamera || nextFrameCamera) && (cameraChanged || !replayFrameCameraRef.current)) {
                 replayFrameCameraRef.current = {
-                  frameA: nextFrameCamera,
-                  frameB: nextFrameCamera,
-                  alpha: 0
+                  frameA: currentFrameCamera ?? nextFrameCamera,
+                  frameB: nextFrameCamera ?? currentFrameCamera,
+                  alpha
                 };
+              } else if (replayFrameCameraRef.current) {
+                replayFrameCameraRef.current.alpha = alpha;
               }
             } else {
               replayFrameCameraRef.current = null;


### PR DESCRIPTION
### Motivation
- Replays could show a static or missing camera frame because the playback logic pinned to a single recorded camera snapshot and did not advance/interpolate camera keys correctly.

### Description
- Updated replay camera selection in `webapp/src/pages/Games/PoolRoyale.jsx` to use both the current frame (`frameA.camera`) and the next frame (`frameB.camera`) when resolving replay cameras.
- Compute and propagate interpolation `alpha` into `replayFrameCameraRef.current` so the camera blending progresses smoothly between adjacent replay frames.
- Added a conservative `hasReplayCameraChanged` check to only reset the stored replay frame when camera data actually changes, and otherwise update the stored alpha to continue interpolation.
- Preserved existing behavior when `LOCK_REPLAY_CAMERA` is enabled (no camera frame updates applied).

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully (Vite build succeeded with non-blocking chunk-size/dynamic-import warnings).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0c810dd088329baafb5f8d6ca1b3d)