### PR TITLE
Snake: remove floor/wall textures and rebuild 50‑tile spiral board

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -409,6 +409,65 @@ function rotateSequenceToClosestPoint(sequence, scorePoint) {
   return sequence.slice(bestIndex).concat(sequence.slice(0, bestIndex));
 }
 
+function buildSpiralGrid(size) {
+  const cells = [];
+  let left = 0;
+  let right = size - 1;
+  let top = 0;
+  let bottom = size - 1;
+  while (left <= right && top <= bottom) {
+    for (let col = left; col <= right; col += 1) cells.push({ row: bottom, col });
+    bottom -= 1;
+    for (let row = bottom; row >= top; row -= 1) cells.push({ row, col: right });
+    right -= 1;
+    if (top <= bottom) {
+      for (let col = right; col >= left; col -= 1) cells.push({ row: top, col });
+      top += 1;
+    }
+    if (left <= right) {
+      for (let row = top; row <= bottom; row += 1) cells.push({ row, col: left });
+      left += 1;
+    }
+  }
+  return cells;
+}
+
+function createPreciseSnakeTiles() {
+  const center = 3;
+  const spiral = buildSpiralGrid(7).slice(0, 48);
+  const colors = ['#e34b4b', '#46d04d', '#4056d8', '#e8b84a'];
+  const preciseTiles = spiral.map((cell, index) => {
+    let level = 0;
+    let localIndex = index;
+    let baseTop = 0.07;
+    let riseStep = 0.012;
+    let size = 0.92;
+    if (index >= 24 && index < 40) {
+      level = 1;
+      localIndex = index - 24;
+      baseTop = 0.88;
+      riseStep = 0.022;
+    } else if (index >= 40) {
+      level = 2;
+      localIndex = index - 40;
+      baseTop = 1.66;
+      riseStep = 0.048;
+      size = 0.9;
+    }
+    return {
+      id: index + 1,
+      x: (cell.col - center) * 1.02,
+      z: (cell.row - center) * 1.02,
+      y: baseTop + 0.26 / 2 + localIndex * riseStep,
+      size,
+      color: colors[(index + level) % colors.length]
+    };
+  });
+  preciseTiles.push({ id: 49, x: -1.02 * 0.48, z: 0, y: 2.46, size: 0.88, color: '#3ccfc5' });
+  preciseTiles.push({ id: 50, x: 1.02 * 0.24, z: 0, y: 2.78, size: 0.8, color: '#51d95a' });
+  return preciseTiles;
+}
+
 function addPavementLayer(parent, size, thickness, bottomY, meshes, material = null) {
   const pavementMaterial =
     material ||
@@ -2706,246 +2765,73 @@ function buildSnakeBoard(
   const railTheme = appearanceOptions.rail ?? {};
   const snakeTheme = appearanceOptions.snakeSkin ?? {};
   const diceTheme = appearanceOptions.dice ?? {};
-  const floorTexture = appearanceOptions.floorTexture ?? null;
-  const wallTexture = appearanceOptions.wallTexture ?? null;
   const highlightColors = createHighlightColors(boardTheme);
   const useReferenceSpiral = boardTheme.spiralReference === true;
-  const tileLightBase = toThreeColor(boardTheme.light, TILE_COLOR_A);
-  const tileDarkBase = toThreeColor(boardTheme.dark, TILE_COLOR_B);
 
   const tileMeshes = new Map();
   const indexToPosition = new Map();
-  const tileHeight = BOARD_TILE_HEIGHT;
-  const tileGeo = new THREE.BoxGeometry(
-    TILE_SIZE - TILE_GAP,
-    tileHeight,
-    TILE_SIZE - TILE_GAP
-  );
+  const tileHeight = 0.26;
 
   const labelGroup = new THREE.Group();
   boardRotationRoot.add(labelGroup);
 
-  const platformThickness = PYRAMID_PLATFORM_THICKNESS;
-  const levelGap = PYRAMID_LEVEL_GAP;
   const platformMeshes = [];
-  const wallMaterials = [];
-  const topMaterials = [];
   const railingInfos = [];
-  const levelPlacements = [];
-  const topTileLift = (platformThickness + tileHeight + levelGap) * TOP_TILE_EXTRA_LEVELS;
-  const pavementMaterial = new THREE.MeshStandardMaterial({
-    color: new THREE.Color('#6b7280'),
-    roughness: 0.88,
-    metalness: 0.35,
-    envMapIntensity: 0.6
+  const addLayer = (sizeX, sizeY, sizeZ, y, color) => {
+    const mesh = new THREE.Mesh(
+      new THREE.BoxGeometry(sizeX, sizeY, sizeZ),
+      new THREE.MeshStandardMaterial({ color, roughness: 0.94, metalness: 0.04 })
+    );
+    mesh.position.y = y;
+    mesh.castShadow = true;
+    mesh.receiveShadow = true;
+    platformGroup.add(mesh);
+    platformMeshes.push(mesh);
+    return mesh;
+  };
+
+  addLayer(10.2, 0.42, 10.2, -0.36, '#5a5a5a');
+  addLayer(8.1, 0.24, 8.1, -0.05, '#444f5d');
+  addLayer(5.88, 0.24, 5.88, 0.76, '#555555');
+  addLayer(3.68, 0.24, 3.68, 1.54, '#666666');
+  addLayer(2.22, 0.24, 1.16, 2.22, '#7b7b7b');
+
+  const preciseTiles = createPreciseSnakeTiles();
+  preciseTiles.forEach((tileSpec) => {
+    const baseColor = useReferenceSpiral
+      ? SPIRAL_REFERENCE_COLORS[(tileSpec.id - 1) % SPIRAL_REFERENCE_COLORS.length]
+      : new THREE.Color(tileSpec.color);
+    const materialSet = createTileMaterialSet(baseColor, boardTheme);
+    const tileGeo = new THREE.BoxGeometry(tileSpec.size, tileHeight, tileSpec.size);
+    const tile = new THREE.Mesh(tileGeo, materialSet.materials);
+    tile.position.set(tileSpec.x, tileSpec.y, tileSpec.z);
+    tile.castShadow = true;
+    tile.receiveShadow = true;
+    tile.userData.index = tileSpec.id;
+    tile.userData.topMaterial = materialSet.topMaterial;
+    tile.userData.sideMaterial = materialSet.sideMaterial;
+    tile.userData.bottomMaterial = materialSet.bottomMaterial;
+    tile.userData.baseColor = materialSet.topMaterial.color.clone();
+    tileGroup.add(tile);
+    tileMeshes.set(tileSpec.id, tile);
+    const topPosition = new THREE.Vector3(tileSpec.x, tileSpec.y + tileHeight / 2, tileSpec.z);
+    indexToPosition.set(tileSpec.id, topPosition);
+
+    const label = createTileLabel(tileSpec.id);
+    label.position.set(tileSpec.x, topPosition.y + TILE_LABEL_OFFSET, tileSpec.z);
+    labelGroup.add(label);
   });
 
-  let currentLevelBottom = 0;
-  PYRAMID_LEVELS.forEach((size, levelIndex) => {
-    const dimension = size * TILE_SIZE;
-    const t = levelIndex / Math.max(1, PYRAMID_LEVELS.length - 1);
-    const referenceLevelColor = SPIRAL_REFERENCE_COLORS[levelIndex % SPIRAL_REFERENCE_COLORS.length];
-    const wallColor = useReferenceSpiral
-      ? referenceLevelColor.clone().lerp(new THREE.Color('#101010'), 0.2)
-      : PYRAMID_WALL_LIGHT.clone().lerp(PYRAMID_WALL_DARK, t * 0.85);
-    const wallGlowBase = useReferenceSpiral
-      ? referenceLevelColor.clone().lerp(new THREE.Color('#ffffff'), 0.22)
-      : PYRAMID_WALL_ACCENT.clone().lerp(PYRAMID_WALL_DARK, t * 0.35);
-    const rimTone = useReferenceSpiral
-      ? referenceLevelColor.clone().lerp(new THREE.Color('#ffffff'), 0.35)
-      : PYRAMID_CONCRETE_ACCENT.clone().lerp(PYRAMID_CONCRETE_LIGHT, t * 0.65);
-    const topTone = useReferenceSpiral
-      ? referenceLevelColor.clone().lerp(new THREE.Color('#0f172a'), 0.25)
-      : PYRAMID_CONCRETE_ACCENT.clone().lerp(PYRAMID_CONCRETE_LIGHT, t * 0.1);
-    const wallMaterial = new THREE.MeshStandardMaterial({
-      color: wallColor,
-      roughness: useReferenceSpiral ? 0.56 : 0.76,
-      metalness: useReferenceSpiral ? 0.05 : 0.08,
-      emissive: wallGlowBase.clone().multiplyScalar(useReferenceSpiral ? 0.09 : 0.18),
-      emissiveIntensity: useReferenceSpiral ? 0.2 : 0.14
-    });
-    wallMaterials.push(wallMaterial);
-    const topMaterial = new THREE.MeshStandardMaterial({
-      color: topTone,
-      roughness: useReferenceSpiral ? 0.5 : 0.68,
-      metalness: useReferenceSpiral ? 0.08 : 0.12,
-      emissive: rimTone.clone().multiplyScalar(useReferenceSpiral ? 0.08 : 0.12),
-      emissiveIntensity: useReferenceSpiral ? 0.16 : 0.12
-    });
-    topMaterials.push(topMaterial);
-    const bottomMaterial = new THREE.MeshStandardMaterial({
-      color: PYRAMID_CONCRETE_BASE,
-      roughness: 0.84,
-      metalness: 0.1,
-      emissive: PYRAMID_CONCRETE_BASE.clone().multiplyScalar(0.06),
-      emissiveIntensity: 0.12
-    });
-    const baseExtraRatio = 1 - levelIndex / (PYRAMID_LEVELS.length + 1);
-    let extra =
-      BOARD_BASE_EXTRA *
-      (levelIndex === 0 ? baseExtraRatio * BASE_PLATFORM_EXTRA_MULTIPLIER : baseExtraRatio);
-    if (levelIndex === 0) {
-      extra += FIRST_LEVEL_PLATFORM_EXTRA;
-    }
-    const shrinkFactor = BENTONITE_EXTRA_SHRINK[levelIndex] ?? 1;
-    const platformSize = dimension + extra * shrinkFactor;
-    const roundedCornerRatio = levelIndex === 0 ? 0.08 : 0.045;
-    const maxCornerRadius = Math.max(0, platformThickness / 2 - 0.0001);
-    const desiredCornerRadius = platformSize * roundedCornerRatio;
-    const cornerRadius = Math.min(desiredCornerRadius, maxCornerRadius);
-    const platformGeometry =
-      cornerRadius > 0
-        ? new RoundedBoxGeometry(platformSize, platformThickness, platformSize, 8, cornerRadius)
-        : new THREE.BoxGeometry(platformSize, platformThickness, platformSize);
-    const platformMaterials = [
-      wallMaterial,
-      wallMaterial,
-      topMaterial,
-      bottomMaterial,
-      wallMaterial,
-      wallMaterial
-    ];
-    const platform = new THREE.Mesh(platformGeometry, platformMaterials);
-    platform.position.y = currentLevelBottom + platformThickness / 2;
-    platformGroup.add(platform);
-    platformMeshes.push(platform);
-
-    const platformTopY = currentLevelBottom + platformThickness;
-    const walkwayEstimate = -dimension / 2 + TILE_SIZE / 2;
-    railingInfos.push({
-      halfSize: platformSize / 2,
-      topY: platformTopY,
-      gapWidth: RAIL_GAP_WIDTH,
-      walkwayCenter: walkwayEstimate,
-      levelIndex
-    });
-
-    if (levelIndex === 0 && SHOW_PAVEMENT_LAYER) {
-      const pavementSize = platformSize * PAVEMENT_EXTRA_SCALE;
-      addPavementLayer(
-        platformGroup,
-        pavementSize,
-        PAVEMENT_THICKNESS,
-        currentLevelBottom,
-        platformMeshes,
-        pavementMaterial
-      );
-    }
-
-    const tileCenterY = currentLevelBottom + platformThickness + tileHeight / 2;
-    const tileTopY = tileCenterY + tileHeight / 2;
-    levelPlacements.push({
-      size,
-      half: dimension / 2,
-      tileCenterY,
-      tileTopY
-    });
-
-    currentLevelBottom += platformThickness + tileHeight + levelGap;
-  });
-
-  if (floorTexture?.assetId && renderer) {
-    loadPolyhavenTextureSet(floorTexture.assetId, renderer)
-      .then((textureSet) => {
-        if (!textureSet) return;
-        const repeat = (floorTexture.repeat ?? 2) * TEXTURE_REPEAT_SCALE * 3;
-        applyTextureSetToMaterial(pavementMaterial, textureSet, repeat);
-        topMaterials.forEach((material) => {
-          applyTextureSetToMaterial(material, textureSet, repeat);
-        });
-      })
-      .catch(() => {});
-  }
-
-  if (wallTexture?.assetId && renderer) {
-    loadPolyhavenTextureSet(wallTexture.assetId, renderer)
-      .then((textureSet) => {
-        if (!textureSet) return;
-        wallMaterials.forEach((material) => {
-          const repeatX = (wallTexture.repeat ?? 1.6) * TEXTURE_REPEAT_SCALE * 1.15;
-          const repeatY = repeatX / 1.5;
-          applyTextureSetToMaterial(material, textureSet, { x: repeatX, y: repeatY });
-        });
-      })
-      .catch(() => {});
-  }
-
-  const levelOffsets = [];
-  let accumulated = 0;
-  PYRAMID_LEVELS.forEach((size, idx) => {
-    levelOffsets[idx] = accumulated;
-    accumulated += LEVEL_TILE_COUNTS[idx];
-  });
-
-  let previousLevelEndPoint = null;
-  PYRAMID_LEVELS.forEach((size, levelIndex) => {
-    const offset = levelOffsets[levelIndex];
-    const levelTileCount = LEVEL_TILE_COUNTS[levelIndex] ?? 0;
-    if (levelTileCount <= 0) return;
-    const { half, tileCenterY, tileTopY } = levelPlacements[levelIndex];
-    const floorScale = levelIndex === 0 ? GROUND_FLOOR_OUTWARD_SCALE : 1;
-    const toFloorPoint = ({ row, col }) => {
-      const x = (-half + (col + 0.5) * TILE_SIZE) * floorScale;
-      const z = (-half + ((size - 1 - row) + 0.5) * TILE_SIZE) * floorScale;
-      return { x, z };
-    };
-    const perimeter = rotateSequenceToClosestPoint(buildPerimeterSequence(size), (cell) => {
-      if (!previousLevelEndPoint) return 0;
-      const next = toFloorPoint(cell);
-      const dx = next.x - previousLevelEndPoint.x;
-      const dz = next.z - previousLevelEndPoint.z;
-      return dx * dx + dz * dz;
-    }).slice(0, levelTileCount);
-    perimeter.forEach(({ row, col }, seqIndex) => {
-      const idx = offset + seqIndex + 1;
-      const baseColor = useReferenceSpiral
-        ? SPIRAL_REFERENCE_COLORS[(seqIndex + levelIndex) % SPIRAL_REFERENCE_COLORS.length].clone()
-        : (row + col) % 2 === 0
-        ? tileLightBase.clone()
-        : tileDarkBase.clone();
-      const materialSet = createTileMaterialSet(baseColor, boardTheme);
-      const baseX = -half + (col + 0.5) * TILE_SIZE;
-      const baseZ = -half + ((size - 1 - row) + 0.5) * TILE_SIZE;
-      const tilePosition = new THREE.Vector3(baseX, tileCenterY, baseZ);
-      if (levelIndex === 0) {
-        tilePosition.x *= GROUND_FLOOR_OUTWARD_SCALE;
-        tilePosition.z *= GROUND_FLOOR_OUTWARD_SCALE;
-      }
-      if (idx === TOTAL_BOARD_TILES) {
-        tilePosition.y += topTileLift;
-      }
-      const tile = new THREE.Mesh(tileGeo, materialSet.materials);
-      tile.position.copy(tilePosition);
-      tile.castShadow = true;
-      tile.receiveShadow = true;
-      tile.userData.index = idx;
-      tile.userData.topMaterial = materialSet.topMaterial;
-      tile.userData.sideMaterial = materialSet.sideMaterial;
-      tile.userData.bottomMaterial = materialSet.bottomMaterial;
-      tile.userData.baseColor = materialSet.topMaterial.color.clone();
-      tileGroup.add(tile);
-      tileMeshes.set(idx, tile);
-
-      const topPosition = tilePosition.clone();
-      topPosition.y = tileTopY;
-      if (idx === TOTAL_BOARD_TILES) {
-        topPosition.y += topTileLift;
-      }
-      indexToPosition.set(idx, topPosition);
-
-      const label = createTileLabel(idx);
-      let labelY = tileTopY;
-      if (idx === TOTAL_BOARD_TILES) {
-        labelY += topTileLift;
-      }
-      label.position.set(tilePosition.x, labelY + TILE_LABEL_OFFSET, tilePosition.z);
-      labelGroup.add(label);
-
-      if (seqIndex === perimeter.length - 1) {
-        previousLevelEndPoint = { x: tilePosition.x, z: tilePosition.z };
-      }
-    });
-  });
+  const levelPlacements = [
+    { tileTopY: 0.07 + tileHeight },
+    { tileTopY: 0.88 + tileHeight },
+    { tileTopY: 1.66 + tileHeight }
+  ];
+  railingInfos.push(
+    { halfSize: 10.2 / 2, topY: -0.15, gapWidth: RAIL_GAP_WIDTH, walkwayCenter: 0, levelIndex: 0 },
+    { halfSize: 8.1 / 2, topY: 0.07, gapWidth: RAIL_GAP_WIDTH, walkwayCenter: 0, levelIndex: 1 },
+    { halfSize: 5.88 / 2, topY: 0.88, gapWidth: RAIL_GAP_WIDTH, walkwayCenter: 0, levelIndex: 2 }
+  );
 
   railingInfos.forEach(({ halfSize, topY, gapWidth, walkwayCenter, levelIndex }) => {
     const startIndex = LEVEL_START_INDICES[levelIndex] ?? 1;
@@ -2977,8 +2863,7 @@ function buildSnakeBoard(
 
   const tileHundred = tileMeshes.get(TOTAL_BOARD_TILES);
   if (tileHundred) {
-    const topLevelPlacement = levelPlacements[levelPlacements.length - 1];
-    const supportBaseY = topLevelPlacement.tileCenterY - tileHeight / 2;
+    const supportBaseY = 1.66;
     const supportTopY = tileHundred.position.y - tileHeight / 2;
     const supportHeight = Math.max(
       TILE_100_SUPPORT_HEIGHT_EXTRA,
@@ -3002,7 +2887,7 @@ function buildSnakeBoard(
     platformMeshes.push(support);
   }
 
-  const baseHalf = (BASE_LEVEL_TILES * TILE_SIZE) / 2;
+  const baseHalf = 10.2 / 2;
   const baseStart = new THREE.Vector3(
     -baseHalf - TILE_SIZE * 0.8,
     levelPlacements[0].tileTopY,

--- a/webapp/src/config/snakeInventoryConfig.js
+++ b/webapp/src/config/snakeInventoryConfig.js
@@ -18,32 +18,6 @@ const SNAKE_TABLE_FINISH_OPTIONS = Object.freeze([
   { id: 'rosewoodVeneer01', label: 'Rosewood Veneer 01' }
 ]);
 
-const SNAKE_FLOOR_TEXTURE_OPTIONS = Object.freeze([
-  { id: 'paving_stones_02', label: 'Paving Stones 02' },
-  { id: 'paving_stones_07', label: 'Paving Stones 07' },
-  { id: 'paving_stones_08', label: 'Paving Stones 08' },
-  { id: 'paving_stones_12', label: 'Paving Stones 12' },
-  { id: 'cobblestone_floor_03', label: 'Cobblestone Floor 03' },
-  { id: 'cobblestone_floor_05', label: 'Cobblestone Floor 05' },
-  { id: 'concrete_pavers_01', label: 'Concrete Pavers 01' },
-  { id: 'concrete_pavers_02', label: 'Concrete Pavers 02' },
-  { id: 'stone_floor_05', label: 'Stone Floor 05' },
-  { id: 'stone_floor_06', label: 'Stone Floor 06' }
-]);
-
-const SNAKE_WALL_TEXTURE_OPTIONS = Object.freeze([
-  { id: 'brick_wall_02', label: 'Brick Wall 02' },
-  { id: 'brick_wall_03', label: 'Brick Wall 03' },
-  { id: 'castle_wall_01', label: 'Castle Wall 01' },
-  { id: 'concrete_wall_002', label: 'Concrete Wall 002' },
-  { id: 'concrete_wall_004', label: 'Concrete Wall 004' },
-  { id: 'painted_wall_01', label: 'Painted Wall 01' },
-  { id: 'plaster_wall_01', label: 'Plaster Wall 01' },
-  { id: 'stone_wall_02', label: 'Stone Wall 02' },
-  { id: 'stone_wall_03', label: 'Stone Wall 03' },
-  { id: 'tiles_wall_01', label: 'Tiles Wall 01' }
-]);
-
 const SNAKE_TOKEN_SHAPE_OPTIONS = Object.freeze([
   { id: 'pawn', label: 'Pawn Token' },
   { id: 'knight', label: 'Knight Token' },
@@ -79,32 +53,6 @@ const SNAKE_TABLE_FINISH_THUMBNAILS = Object.freeze({
   woodTable001: polyHavenThumb('wood_table_001'),
   darkWood: polyHavenThumb('dark_wood'),
   rosewoodVeneer01: polyHavenThumb('rosewood_veneer_01')
-});
-
-const SNAKE_FLOOR_TEXTURE_THUMBNAILS = Object.freeze({
-  paving_stones_02: polyHavenThumb('paving_stones_02'),
-  paving_stones_07: polyHavenThumb('paving_stones_07'),
-  paving_stones_08: polyHavenThumb('paving_stones_08'),
-  paving_stones_12: polyHavenThumb('paving_stones_12'),
-  cobblestone_floor_03: polyHavenThumb('cobblestone_floor_03'),
-  cobblestone_floor_05: polyHavenThumb('cobblestone_floor_05'),
-  concrete_pavers_01: polyHavenThumb('concrete_pavers_01'),
-  concrete_pavers_02: polyHavenThumb('concrete_pavers_02'),
-  stone_floor_05: polyHavenThumb('stone_floor_05'),
-  stone_floor_06: polyHavenThumb('stone_floor_06')
-});
-
-const SNAKE_WALL_TEXTURE_THUMBNAILS = Object.freeze({
-  brick_wall_02: polyHavenThumb('brick_wall_02'),
-  brick_wall_03: polyHavenThumb('brick_wall_03'),
-  castle_wall_01: polyHavenThumb('castle_wall_01'),
-  concrete_wall_002: polyHavenThumb('concrete_wall_002'),
-  concrete_wall_004: polyHavenThumb('concrete_wall_004'),
-  painted_wall_01: polyHavenThumb('painted_wall_01'),
-  plaster_wall_01: polyHavenThumb('plaster_wall_01'),
-  stone_wall_02: polyHavenThumb('stone_wall_02'),
-  stone_wall_03: polyHavenThumb('stone_wall_03'),
-  tiles_wall_01: polyHavenThumb('tiles_wall_01')
 });
 
 const SNAKE_THEME_THUMBNAILS = Object.freeze({
@@ -157,8 +105,6 @@ export const SNAKE_DEFAULT_UNLOCKS = Object.freeze({
   tokenFinish: ['ceramicSheen'],
   tokenColor: ['amberGlow', 'mintVale', 'royalWave', 'roseMist'],
   tableFinish: [SNAKE_TABLE_FINISH_OPTIONS[0].id],
-  floorTexture: [SNAKE_FLOOR_TEXTURE_OPTIONS[0].id],
-  wallTexture: [SNAKE_WALL_TEXTURE_OPTIONS[0].id],
   headStyle: [SNAKE_PAWN_HEAD_OPTIONS[0].id],
   tokenShape: [SNAKE_TOKEN_SHAPE_OPTIONS[0].id],
   tables: [MURLAN_TABLE_THEMES[0].id],
@@ -200,8 +146,6 @@ export const SNAKE_OPTION_LABELS = Object.freeze({
   tokenColor: mapLabels(SNAKE_TOKEN_COLOR_OPTIONS),
   headStyle: mapLabels(SNAKE_PAWN_HEAD_OPTIONS),
   tableFinish: mapLabels(SNAKE_TABLE_FINISH_OPTIONS),
-  floorTexture: mapLabels(SNAKE_FLOOR_TEXTURE_OPTIONS),
-  wallTexture: mapLabels(SNAKE_WALL_TEXTURE_OPTIONS),
   tokenShape: mapLabels(SNAKE_TOKEN_SHAPE_OPTIONS),
   tables: mapLabels(MURLAN_TABLE_THEMES),
   stools: mapLabels(MURLAN_STOOL_THEMES),
@@ -377,24 +321,6 @@ export const SNAKE_STORE_ITEMS = [
     description: `${finish.label} finish imported from Pool Royale.`,
     thumbnail: SNAKE_TABLE_FINISH_THUMBNAILS[finish.id]
   })),
-  ...SNAKE_FLOOR_TEXTURE_OPTIONS.map((option, idx) => ({
-    id: `snake-floor-${option.id}`,
-    type: 'floorTexture',
-    optionId: option.id,
-    name: option.label,
-    price: 640 + idx * 18,
-    description: `Poly Haven pavement texture: ${option.label}.`,
-    thumbnail: SNAKE_FLOOR_TEXTURE_THUMBNAILS[option.id]
-  })),
-  ...SNAKE_WALL_TEXTURE_OPTIONS.map((option, idx) => ({
-    id: `snake-wall-${option.id}`,
-    type: 'wallTexture',
-    optionId: option.id,
-    name: option.label,
-    price: 620 + idx * 16,
-    description: `Poly Haven wall texture: ${option.label}.`,
-    thumbnail: SNAKE_WALL_TEXTURE_THUMBNAILS[option.id]
-  })),
   ...SNAKE_TOKEN_SHAPE_OPTIONS.map((option, idx) => ({
     id: `snake-token-${option.id}`,
     type: 'tokenShape',
@@ -449,16 +375,6 @@ export const SNAKE_DEFAULT_LOADOUT = [
     type: 'tableFinish',
     optionId: SNAKE_TABLE_FINISH_OPTIONS[0].id,
     label: SNAKE_TABLE_FINISH_OPTIONS[0].label
-  },
-  {
-    type: 'floorTexture',
-    optionId: SNAKE_FLOOR_TEXTURE_OPTIONS[0].id,
-    label: SNAKE_FLOOR_TEXTURE_OPTIONS[0].label
-  },
-  {
-    type: 'wallTexture',
-    optionId: SNAKE_WALL_TEXTURE_OPTIONS[0].id,
-    label: SNAKE_WALL_TEXTURE_OPTIONS[0].label
   },
   {
     type: 'tokenShape',

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -894,8 +894,6 @@ const SNAKE_CUSTOMIZATION_SECTIONS = [
   { key: 'tableFinish', label: 'Table Finish', options: TABLE_FINISH_OPTIONS },
   { key: 'tables', label: 'Table Models', options: TABLE_THEME_OPTIONS },
   { key: 'stools', label: 'Chairs', options: STOOL_THEME_OPTIONS },
-  { key: 'floorTexture', label: 'Floor Texture', options: FLOOR_TEXTURE_OPTIONS },
-  { key: 'wallTexture', label: 'Wall Texture', options: WALL_TEXTURE_OPTIONS },
   { key: 'environmentHdri', label: 'HDR Environments', options: HDRI_OPTIONS }
 ];
 
@@ -964,8 +962,6 @@ const DEFAULT_APPEARANCE = Object.freeze({
   tableFinish: 0,
   tables: 0,
   stools: 0,
-  floorTexture: 0,
-  wallTexture: 0,
   environmentHdri: DEFAULT_HDRI_INDEX
 });
 
@@ -984,8 +980,6 @@ function normalizeAppearance(value = {}) {
     ['tableFinish', TABLE_FINISH_OPTIONS.length],
     ['tables', TABLE_THEME_OPTIONS.length],
     ['stools', STOOL_THEME_OPTIONS.length],
-    ['floorTexture', FLOOR_TEXTURE_OPTIONS.length],
-    ['wallTexture', WALL_TEXTURE_OPTIONS.length],
     ['environmentHdri', HDRI_OPTIONS.length]
   ];
   entries.forEach(([key, max]) => {
@@ -1013,8 +1007,6 @@ function resolveAppearance(appearance) {
   const snakeSkin = SNAKE_SKIN_OPTIONS[0];
   const tableTheme = TABLE_THEME_OPTIONS[normalized.tables] ?? TABLE_THEME_OPTIONS[0];
   const stoolTheme = STOOL_THEME_OPTIONS[normalized.stools] ?? STOOL_THEME_OPTIONS[0];
-  const floorTexture = FLOOR_TEXTURE_OPTIONS[normalized.floorTexture] ?? FLOOR_TEXTURE_OPTIONS[0];
-  const wallTexture = WALL_TEXTURE_OPTIONS[normalized.wallTexture] ?? WALL_TEXTURE_OPTIONS[0];
   const environmentHdri =
     HDRI_OPTIONS[normalized.environmentHdri] ??
     HDRI_OPTIONS[DEFAULT_HDRI_INDEX] ??
@@ -1036,8 +1028,6 @@ function resolveAppearance(appearance) {
     snakeSkin: { ...snakeSkin },
     tableTheme,
     stoolTheme,
-    floorTexture,
-    wallTexture,
     environmentHdri
   };
 }
@@ -3409,8 +3399,7 @@ export default function SnakeAndLadder() {
           </div>
         );
       }
-      case 'floorTexture':
-      case 'wallTexture': {
+      case 'tableFinish': {
         const swatches = option.swatches || ['#94a3b8', '#1f2937'];
         return (
           <div

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -259,8 +259,6 @@ const SNAKE_TYPE_LABELS = {
   tableFinish: 'Table Finish',
   tables: 'Table Models',
   stools: 'Chairs',
-  floorTexture: 'Floor Textures',
-  wallTexture: 'Wall Textures',
   environmentHdri: 'HDR Environments'
 };
 
@@ -931,14 +929,6 @@ const USAGE_BY_TYPE = {
     title: 'Token shape',
     description: 'Changes the 3D token shape shown in matches and previews.'
   },
-  floorTexture: {
-    title: 'Floor texture',
-    description: 'Swaps the floor surface texture used in the arena scene.'
-  },
-  wallTexture: {
-    title: 'Wall texture',
-    description: 'Replaces the arena wall panels visible behind the board.'
-  }
 };
 
 const hashString = (value) => {


### PR DESCRIPTION
### Motivation
- Remove floor and wall texture options from Snake inventory/store and UI to simplify customization and prevent external texture selection for the arena. 
- Replace the previous procedural pyramid board code with an exact 50‑tile spiral pyramid layout to match the provided reference implementation.

### Description
- Removed floor/wall texture options, thumbnails, default unlocks and loadout entries, and store items for Snake floor and wall textures in `webapp/src/config/snakeInventoryConfig.js`.
- Removed floor/wall customization controls, appearance normalization/resolution, and store/type labels/descriptions so floor/wall textures no longer appear in the Snake customization UI or store (`webapp/src/pages/Games/SnakeAndLadder.jsx`, `webapp/src/pages/Store.jsx`).
- Rebuilt the 3D Snake board in `webapp/src/components/SnakeBoard3D.jsx` by adding `buildSpiralGrid` and `createPreciseSnakeTiles`, replacing the previous multi‑level procedural platform/tile generation with explicit layered base blocks and precisely placed 50 tiles (sizes, heights, colors and labels) and simplified platform layers to match the provided reference board code.
- Cleaned up related tile/label placement and index mapping so tokens, dice and camera code use the new precise `indexToPosition` mapping (board tokens, pot and dice logic left intact but now reference the new placements).

### Testing
- Ran a production build with `npm run -s build` which completed successfully. 
- No unit/integration tests were modified or executed as part of this change; visual verification is recommended in a running dev build to confirm board appearance and that the floor/wall texture controls are no longer present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0c8b30e2883298778c4ec8e461110)