### PR TITLE
Fix Pool Royale replay preference migration after forced disable

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1152,6 +1152,7 @@ const POCKET_LINER_STORAGE_KEY = 'poolPocketLiner';
 const POOL_ROYALE_REPLAY_ENABLED = true;
 const POOL_ROYALE_VOICE_COMMENTARY_ENABLED = false;
 const SKIP_REPLAYS_STORAGE_KEY = 'poolRoyaleSkipReplays';
+const REPLAY_PREF_MIGRATION_KEY = 'poolRoyaleReplayPrefMigrationV1';
 const COMMENTARY_PRESET_STORAGE_KEY = 'poolRoyaleCommentaryPreset';
 const COMMENTARY_MUTE_STORAGE_KEY = 'poolRoyaleCommentaryMute';
 const DEFAULT_CUE_STROKE_STYLE = 'featherLine';
@@ -12659,7 +12660,20 @@ function PoolRoyaleGame({
   const clothTextureSourceId = DEFAULT_CLOTH_TEXTURE_SOURCE_ID;
   const [skipAllReplays, setSkipAllReplays] = useState(() => {
     if (typeof window !== 'undefined') {
+      const migratedReplayPref = window.localStorage.getItem(REPLAY_PREF_MIGRATION_KEY) === '1';
       const stored = window.localStorage.getItem(SKIP_REPLAYS_STORAGE_KEY);
+      if (
+        POOL_ROYALE_REPLAY_ENABLED &&
+        !migratedReplayPref &&
+        stored === '1'
+      ) {
+        window.localStorage.setItem(REPLAY_PREF_MIGRATION_KEY, '1');
+        window.localStorage.setItem(SKIP_REPLAYS_STORAGE_KEY, '0');
+        return false;
+      }
+      if (!migratedReplayPref) {
+        window.localStorage.setItem(REPLAY_PREF_MIGRATION_KEY, '1');
+      }
       if (stored === '1') return true;
       if (stored === '0') return false;
     }


### PR DESCRIPTION
### Motivation
- Replays appeared disabled for users even after re-enabling the feature because clients had previously persisted `poolRoyaleSkipReplays=1` while the feature was force-disabled. 
- Add a one-time migration to correct stale local storage so replay playback/broadcast flow resumes for affected users.

### Description
- Added `REPLAY_PREF_MIGRATION_KEY` and migration logic in `webapp/src/pages/Games/PoolRoyale.jsx` to mark when migration has run. 
- On component initialization (`skipAllReplays` state), if `POOL_ROYALE_REPLAY_ENABLED` is `true` and an old `SKIP_REPLAYS_STORAGE_KEY` value of `'1'` is present and migration hasn't run, the code resets `poolRoyaleSkipReplays` to `'0'` and marks migration complete. 
- This preserves any explicit user choice made after migration while restoring replays for clients who were forced to skip them by the previous rollout.

### Testing
- Ran the unit test suite for cue stroke timeline with `npm test -- --runInBand test/poolRoyaleCueStrokeTimeline.test.js` and it passed (4 tests). 
- Ran `npx eslint` for the modified file; lint reported the file is ignored by repo patterns in this environment (no lint errors emitted for the change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0cfbf06a48329abe2390932efcb8b)