### PR TITLE
Fix replay broadcast gate rejecting fallback telemetry

### DIFF
--- a/Assets/Scripts/Gameplay/Broadcast/ReplayBroadcastGate.cs
+++ b/Assets/Scripts/Gameplay/Broadcast/ReplayBroadcastGate.cs
@@ -29,21 +29,40 @@ namespace Aiming.Gameplay.Broadcast
 
         public bool TryBroadcastReplay(ReplayBroadcastPayload payload)
         {
-            if (!forceLegacyReplayBroadcast || !payload.IsValid)
+            if (!forceLegacyReplayBroadcast)
             {
                 return false;
             }
 
-            if (!payload.HasCueTelemetry)
+            payload = NormalizePayload(payload);
+
+            if (!payload.IsValid)
             {
-                payload.cueDirection = Vector3.forward;
-                payload.powerNormalized = Mathf.Max(0f, payload.powerNormalized);
+                return false;
             }
 
             payload.BroadcastStartTime = Time.unscaledTime + replayStartLeadSeconds;
             ReplayBroadcastRequested?.Invoke(payload);
             ShowReplayFrame();
             return true;
+        }
+
+        private static ReplayBroadcastPayload NormalizePayload(ReplayBroadcastPayload payload)
+        {
+            if (!payload.HasCueTelemetry && !string.IsNullOrWhiteSpace(payload.shotId))
+            {
+                payload.cueDirection = Vector3.forward;
+                payload.powerNormalized = IsFinite(payload.powerNormalized)
+                    ? Mathf.Max(0f, payload.powerNormalized)
+                    : 0f;
+            }
+
+            return payload;
+        }
+
+        private static bool IsFinite(float value)
+        {
+            return !float.IsNaN(value) && !float.IsInfinity(value);
         }
 
         public void SetLegacyReplayMode(bool enabled)


### PR DESCRIPTION
### Motivation
- Replays were not starting when incoming payloads lacked cue telemetry because validation ran before fallback/backfill was applied, causing legitimate replay requests to be rejected.
- The change ensures legacy replay broadcast still respects `forceLegacyReplayBroadcast` while allowing telemetry fallbacks for recordings that only include a `shotId`.

### Description
- Reordered `TryBroadcastReplay` to normalize the incoming payload first, then validate, and only then invoke `ReplayBroadcastRequested` and the replay frame UI; changes in `Assets/Scripts/Gameplay/Broadcast/ReplayBroadcastGate.cs`.
- Added `NormalizePayload(ReplayBroadcastPayload)` to backfill `cueDirection` and `powerNormalized` when telemetry is missing but `shotId` is present.
- Added `IsFinite(float)` helper and finite-number guarding so `powerNormalized` NaN/Infinity values are clamped to `0f` instead of breaking validation.
- Preserved existing `IsValid` rules (replay-on-potted/foul/shot telemetry) but evaluate them on the normalized payload.

### Testing
- Ran `git diff --check` to ensure no whitespace/merge issues and it succeeded.
- Verified repository status with `git status --short` and staged changes were present.
- Committed the change with `git commit -m "Fix replay broadcast gate rejecting fallback telemetry"` and the commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0cfbf06a48329abe2390932efcb8b)