### PR TITLE
Fix Poly Haven GLTF texture remapping for Murlan table/chair themes

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -710,11 +710,13 @@ async function loadTexture(textureLoader, url, isColor, maxAnisotropy = 1) {
   });
 }
 
-function normalizePbrTexture(texture, maxAnisotropy = 1) {
+function normalizePbrTexture(texture, maxAnisotropy = 1, { preserveWrapping = false } = {}) {
   if (!texture) return;
   texture.flipY = false;
-  texture.wrapS = texture.wrapS ?? THREE.RepeatWrapping;
-  texture.wrapT = texture.wrapT ?? THREE.RepeatWrapping;
+  if (!preserveWrapping) {
+    texture.wrapS = texture.wrapS ?? THREE.RepeatWrapping;
+    texture.wrapT = texture.wrapT ?? THREE.RepeatWrapping;
+  }
   texture.anisotropy = Math.max(texture.anisotropy ?? 1, maxAnisotropy);
   texture.needsUpdate = true;
 }
@@ -816,16 +818,16 @@ function normalizeMaterialTextures(material, maxAnisotropy = 1) {
   if (!material) return;
   if (material.map) {
     applySRGBColorSpace(material.map);
-    normalizePbrTexture(material.map, maxAnisotropy);
+    normalizePbrTexture(material.map, maxAnisotropy, { preserveWrapping: true });
   }
   if (material.emissiveMap) {
     applySRGBColorSpace(material.emissiveMap);
-    normalizePbrTexture(material.emissiveMap, maxAnisotropy);
+    normalizePbrTexture(material.emissiveMap, maxAnisotropy, { preserveWrapping: true });
   }
-  normalizePbrTexture(material.normalMap, maxAnisotropy);
-  normalizePbrTexture(material.roughnessMap, maxAnisotropy);
-  normalizePbrTexture(material.metalnessMap, maxAnisotropy);
-  normalizePbrTexture(material.aoMap, maxAnisotropy);
+  normalizePbrTexture(material.normalMap, maxAnisotropy, { preserveWrapping: true });
+  normalizePbrTexture(material.roughnessMap, maxAnisotropy, { preserveWrapping: true });
+  normalizePbrTexture(material.metalnessMap, maxAnisotropy, { preserveWrapping: true });
+  normalizePbrTexture(material.aoMap, maxAnisotropy, { preserveWrapping: true });
 }
 
 function prepareLoadedModel(model, options = {}) {
@@ -1475,6 +1477,56 @@ function buildPolyhavenModelUrls(assetId) {
   ];
 }
 
+function extractPolyhavenIncludeUrlMap(manifest, resolution = '2k') {
+  const include = manifest?.gltf?.[resolution]?.gltf?.include;
+  if (!include || typeof include !== 'object') return null;
+  const map = new Map();
+  Object.entries(include).forEach(([relativePath, entry]) => {
+    if (!relativePath || typeof relativePath !== 'string') return;
+    const fileUrl = entry?.url;
+    if (!fileUrl || typeof fileUrl !== 'string') return;
+    map.set(relativePath, fileUrl);
+    map.set(relativePath.replace(/^\.\//, ''), fileUrl);
+    map.set(relativePath.split('/').pop() || relativePath, fileUrl);
+  });
+  return map;
+}
+
+function buildPolyhavenManifestCandidates(manifest, resolutionOrder = ['2k', '1k']) {
+  if (!manifest?.gltf || typeof manifest.gltf !== 'object') return [];
+  const availableResolutions = Object.keys(manifest.gltf);
+  const orderedResolutions = Array.from(new Set([...resolutionOrder, ...availableResolutions]));
+  return orderedResolutions
+    .map((resolution) => {
+      const url = manifest?.gltf?.[resolution]?.gltf?.url;
+      if (!url || typeof url !== 'string') return null;
+      return {
+        url,
+        resolution: String(resolution).toLowerCase(),
+        includeUrlMap: extractPolyhavenIncludeUrlMap(manifest, resolution)
+      };
+    })
+    .filter(Boolean);
+}
+
+function createPolyhavenGltfLoader(renderer = null, includeUrlMap = null) {
+  const manager = new THREE.LoadingManager();
+  if (includeUrlMap?.size) {
+    manager.setURLModifier((requestUrl = '') => {
+      const cleanUrl = String(requestUrl || '').split('?')[0];
+      const normalized = cleanUrl.replace(/^\.\//, '');
+      const fileName = normalized.split('/').pop();
+      return (
+        includeUrlMap.get(cleanUrl) ||
+        includeUrlMap.get(normalized) ||
+        includeUrlMap.get(fileName) ||
+        requestUrl
+      );
+    });
+  }
+  return createConfiguredGLTFLoader(renderer, manager);
+}
+
 function shouldPreserveChairMaterials(theme) {
   return Boolean(theme?.preserveMaterials || theme?.source === 'polyhaven' || theme?.source === 'gltf');
 }
@@ -2004,33 +2056,48 @@ async function loadPolyhavenModel(assetId, renderer = null) {
   }
 
   const promise = (async () => {
-    const modelCandidates = new Set();
+    const modelCandidates = [];
     const assetCandidates = Array.from(new Set([assetId, normalizedId]));
+    const seenUrls = new Set();
 
     for (const candidateId of assetCandidates) {
       try {
         const filesJson = await fetch(`https://api.polyhaven.com/files/${encodeURIComponent(candidateId)}`).then((r) => r.json());
+        const manifestCandidates = buildPolyhavenManifestCandidates(filesJson);
+        manifestCandidates.forEach((candidate) => {
+          if (!candidate?.url || seenUrls.has(candidate.url)) return;
+          seenUrls.add(candidate.url);
+          modelCandidates.push(candidate);
+        });
         const allUrls = extractAllHttpUrls(filesJson);
         const apiModelUrl = pickBestModelUrl(allUrls);
-        if (apiModelUrl) modelCandidates.add(apiModelUrl);
+        if (apiModelUrl && !seenUrls.has(apiModelUrl)) {
+          seenUrls.add(apiModelUrl);
+          modelCandidates.push({ url: apiModelUrl, includeUrlMap: null, resolution: null });
+        }
       } catch (error) {
         console.warn('Poly Haven file lookup failed, falling back to direct URLs', error);
       }
 
-      buildPolyhavenModelUrls(candidateId).forEach((u) => modelCandidates.add(u));
+      buildPolyhavenModelUrls(candidateId).forEach((u) => {
+        if (seenUrls.has(u)) return;
+        seenUrls.add(u);
+        modelCandidates.push({ url: u, includeUrlMap: null, resolution: null });
+      });
     }
 
-    const modelUrlList = Array.from(modelCandidates);
-    if (!modelUrlList.length) {
+    if (!modelCandidates.length) {
       throw new Error(`No model URL found for ${assetId}`);
     }
 
-    const loader = createConfiguredGLTFLoader(renderer);
-
     let gltf = null;
     let lastError = null;
-    for (const modelUrl of modelUrlList) {
+    for (const candidate of modelCandidates) {
       try {
+        const includeUrlMap = candidate?.includeUrlMap;
+        const modelUrl = candidate?.url;
+        if (!modelUrl) continue;
+        const loader = createPolyhavenGltfLoader(renderer, includeUrlMap);
         const resolvedUrl = new URL(modelUrl, typeof window !== 'undefined' ? window.location?.href : modelUrl).href;
         const resourcePath = resolvedUrl.substring(0, resolvedUrl.lastIndexOf('/') + 1);
         loader.setResourcePath?.(resourcePath);


### PR DESCRIPTION
### Motivation
- Poly Haven models used by Murlan Royale sometimes referenced external files via manifest `include` entries and their GLTF texture mapping/wrapping needed to be preserved so original textures load correctly for non-procedural tables and chairs.
- Keep already-correct procedural/table-cloth/finish and base chair theme behavior unchanged while making Poly Haven-backed assets resolve their referenced textures reliably.

### Description
- Preserve GLTF texture wrapping when desired by adding an optional `preserveWrapping` flag to `normalizePbrTexture` and using it for `prepareLoadedModel`/`normalizeMaterialTextures` so original mapping semantics are retained for preserved materials.
- Add Poly Haven manifest helpers: `extractPolyhavenIncludeUrlMap`, `buildPolyhavenManifestCandidates`, and `createPolyhavenGltfLoader` to support manifest `include` URL remapping via a `LoadingManager` URL modifier.
- Update `loadPolyhavenModel` to build an ordered list of model candidates from API manifest entries, `pickBestModelUrl` results and fallback direct URLs, deduplicate with `seenUrls`, and use the manifest-aware GLTF loader so GLTF-referenced textures resolve correctly.
- Keep procedural table generation and explicitly mentioned stool/table/cloth/finish themes unchanged (the octagon/oval/diamond edge table + specified cloth/finish and ruby/slate/teal/amber/violet/ice/leather chair themes are not modified).

### Testing
- Ran `npm test -- --runInBand test/murlan.test.js`, which passed (12 tests passed). 
- Ran `npm test -- --runInBand test/murlan.test.js test/inventoryCrossGameConfig.test.js`, which failed due to a pre-existing `inventoryCrossGameConfig.test.js` default-unlock expectation mismatch unrelated to the texture-loading changes. 
- Attempted an automated page screenshot with Playwright to verify textures visually, but headless Chromium failed to run in this container due to a missing system shared library (`libatk-1.0.so.0`), so no screenshot artifact could be produced here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0d6380844832980de8e288c0dd47b)