### PR TITLE
Add Domino dot and frame style options; update domino color themes and UI previews

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -4007,68 +4007,68 @@ const DOMINO_STYLE_OPTIONS = Object.freeze([
     }
   },
   {
-    id: 'obsidianPlatinum',
-    label: 'Obsidian Platinum',
-    preview: ['#090909', '#c5ccd9'],
+    id: 'royalCrimson',
+    label: 'Royal Crimson',
+    preview: ['#991b1b', '#7f1d1d'],
     body: {
-      color: '#0b0c10',
-      roughness: 0.24,
-      metalness: 0.32,
+      color: '#991b1b',
+      roughness: 0.22,
+      metalness: 0.3,
       clearcoat: 1.0,
       clearcoatRoughness: 0.04,
-      reflectivity: 0.6,
-      sheen: 0.25,
-      sheenColor: '#1f2937'
+      reflectivity: 0.64,
+      sheen: 0.28,
+      sheenColor: '#fecaca'
     },
     pip: {
-      color: '#dce6ff',
-      metalness: 0.74,
-      roughness: 0.18,
+      color: '#fef2f2',
+      metalness: 0.62,
+      roughness: 0.2,
       clearcoat: 0.55,
       clearcoatRoughness: 0.03,
-      emissive: '#6b87ff',
+      emissive: '#7f1d1d',
       emissiveIntensity: dimIntensity(0.08),
       sheen: 0.18
     },
     accent: {
-      color: '#d7dce3',
-      emissive: '#5b636f',
-      emissiveIntensity: dimIntensity(0.38),
+      color: '#fecaca',
+      emissive: '#7f1d1d',
+      emissiveIntensity: dimIntensity(0.4),
       metalness: 1.0,
-      roughness: 0.14,
+      roughness: 0.16,
       reflectivity: 1.0,
       ringInner: 0.106,
       ringOuter: 0.124
     }
   },
   {
-    id: 'midnightRose',
-    label: 'Midnight Rose',
-    preview: ['#0d1533', '#c27c6a'],
+    id: 'azureRegal',
+    label: 'Azure Regal',
+    preview: ['#1d4ed8', '#1e3a8a'],
     body: {
-      color: '#101b38',
+      color: '#1d4ed8',
       roughness: 0.2,
-      metalness: 0.26,
+      metalness: 0.28,
       clearcoat: 1.0,
       clearcoatRoughness: 0.04,
       reflectivity: 0.66,
-      sheen: 0.42,
-      sheenColor: '#27446d'
+      sheen: 0.3,
+      sheenColor: '#bfdbfe'
     },
     pip: {
-      color: '#f1f2f8',
-      metalness: 0.35,
-      roughness: 0.14,
+      color: '#e0f2fe',
+      metalness: 0.5,
+      roughness: 0.16,
       clearcoat: 0.5,
       clearcoatRoughness: 0.05,
-      emissive: '#2a3f63',
-      emissiveIntensity: dimIntensity(0.1),
+      emissive: '#1e3a8a',
+      emissiveIntensity: dimIntensity(0.08),
       sheen: 0.2
     },
     accent: {
-      color: '#c27c6a',
-      emissive: '#5b3126',
-      emissiveIntensity: dimIntensity(0.46),
+      color: '#bfdbfe',
+      emissive: '#1e40af',
+      emissiveIntensity: dimIntensity(0.44),
       metalness: 1.0,
       roughness: 0.18,
       reflectivity: 1.0,
@@ -4077,32 +4077,32 @@ const DOMINO_STYLE_OPTIONS = Object.freeze([
     }
   },
   {
-    id: 'auroraJade',
-    label: 'Aurora Jade',
-    preview: ['#0e3b2c', '#d0b58f'],
+    id: 'emeraldCrown',
+    label: 'Emerald Crown',
+    preview: ['#047857', '#065f46'],
     body: {
-      color: '#0e3b2c',
+      color: '#047857',
       roughness: 0.22,
       metalness: 0.28,
       clearcoat: 1.0,
       clearcoatRoughness: 0.05,
       reflectivity: 0.68,
       sheen: 0.36,
-      sheenColor: '#1c6d53'
+      sheenColor: '#a7f3d0'
     },
     pip: {
-      color: '#f1f5f2',
+      color: '#ecfdf5',
       metalness: 0.42,
       roughness: 0.16,
       clearcoat: 0.55,
       clearcoatRoughness: 0.04,
-      emissive: '#215544',
+      emissive: '#065f46',
       emissiveIntensity: dimIntensity(0.08),
       sheen: 0.16
     },
     accent: {
-      color: '#d0b58f',
-      emissive: '#7a5b36',
+      color: '#a7f3d0',
+      emissive: '#047857',
       emissiveIntensity: dimIntensity(0.44),
       metalness: 0.92,
       roughness: 0.19,
@@ -4112,32 +4112,32 @@ const DOMINO_STYLE_OPTIONS = Object.freeze([
     }
   },
   {
-    id: 'frostedOpal',
-    label: 'Frosted Opal',
-    preview: ['#e8eef4', '#7a93d2'],
+    id: 'violetEmpire',
+    label: 'Violet Empire',
+    preview: ['#6d28d9', '#581c87'],
     body: {
-      color: '#e8eef4',
-      roughness: 0.18,
-      metalness: 0.22,
+      color: '#6d28d9',
+      roughness: 0.2,
+      metalness: 0.24,
       clearcoat: 1.0,
       clearcoatRoughness: 0.05,
       reflectivity: 0.7,
-      sheen: 0.4,
-      sheenColor: '#ffffff'
+      sheen: 0.36,
+      sheenColor: '#ddd6fe'
     },
     pip: {
-      color: '#182235',
-      metalness: 0.58,
-      roughness: 0.2,
+      color: '#f5f3ff',
+      metalness: 0.54,
+      roughness: 0.18,
       clearcoat: 0.55,
       clearcoatRoughness: 0.04,
-      emissive: '#1c3a6b',
+      emissive: '#4c1d95',
       emissiveIntensity: dimIntensity(0.09),
       sheen: 0.18
     },
     accent: {
-      color: '#7a93d2',
-      emissive: '#31497a',
+      color: '#ddd6fe',
+      emissive: '#6d28d9',
       emissiveIntensity: dimIntensity(0.42),
       metalness: 0.95,
       roughness: 0.17,
@@ -4147,33 +4147,33 @@ const DOMINO_STYLE_OPTIONS = Object.freeze([
     }
   },
   {
-    id: 'carbonVolt',
-    label: 'Carbon Volt',
-    preview: ['#0b1020', '#22d3ee'],
+    id: 'obsidianNight',
+    label: 'Obsidian Night',
+    preview: ['#111827', '#0f172a'],
     body: {
-      color: '#0c1428',
+      color: '#111827',
       roughness: 0.28,
       metalness: 0.48,
       clearcoat: 0.95,
       clearcoatRoughness: 0.06,
       reflectivity: 0.62,
       sheen: 0.24,
-      sheenColor: '#1f2a44'
+      sheenColor: '#9ca3af'
     },
     pip: {
-      color: '#e0f2fe',
-      metalness: 0.68,
+      color: '#f8fafc',
+      metalness: 0.6,
       roughness: 0.18,
       clearcoat: 0.62,
       clearcoatRoughness: 0.04,
-      emissive: '#22d3ee',
-      emissiveIntensity: dimIntensity(0.2),
+      emissive: '#1f2937',
+      emissiveIntensity: dimIntensity(0.12),
       sheen: 0.18
     },
     accent: {
-      color: '#22d3ee',
-      emissive: '#0ea5e9',
-      emissiveIntensity: dimIntensity(0.54),
+      color: '#9ca3af',
+      emissive: '#4b5563',
+      emissiveIntensity: dimIntensity(0.42),
       metalness: 0.98,
       roughness: 0.18,
       reflectivity: 1,
@@ -4182,32 +4182,32 @@ const DOMINO_STYLE_OPTIONS = Object.freeze([
     }
   },
   {
-    id: 'sandstoneAurora',
-    label: 'Sandstone Aurora',
-    preview: ['#f1d8b0', '#f97316'],
+    id: 'sunsetAmber',
+    label: 'Sunset Amber',
+    preview: ['#b45309', '#78350f'],
     body: {
-      color: '#f1d8b0',
-      roughness: 0.34,
-      metalness: 0.22,
-      clearcoat: 0.82,
-      clearcoatRoughness: 0.08,
-      reflectivity: 0.58,
-      sheen: 0.26,
-      sheenColor: '#fff1db'
+      color: '#b45309',
+      roughness: 0.3,
+      metalness: 0.24,
+      clearcoat: 0.9,
+      clearcoatRoughness: 0.06,
+      reflectivity: 0.6,
+      sheen: 0.28,
+      sheenColor: '#fde68a'
     },
     pip: {
-      color: '#422006',
+      color: '#fffbeb',
       metalness: 0.44,
-      roughness: 0.26,
+      roughness: 0.2,
       clearcoat: 0.6,
       clearcoatRoughness: 0.06,
-      emissive: '#6b2f0d',
-      emissiveIntensity: dimIntensity(0.14),
+      emissive: '#78350f',
+      emissiveIntensity: dimIntensity(0.1),
       sheen: 0.16
     },
     accent: {
-      color: '#f97316',
-      emissive: '#c2410c',
+      color: '#fde68a',
+      emissive: '#b45309',
       emissiveIntensity: dimIntensity(0.46),
       metalness: 0.93,
       roughness: 0.2,
@@ -4216,6 +4216,24 @@ const DOMINO_STYLE_OPTIONS = Object.freeze([
       ringOuter: 0.122
     }
   }
+]);
+
+const DOMINO_DOT_STYLE_OPTIONS = Object.freeze([
+  { id: 'pawnClassic', label: 'Pawn Classic', icon: '♟', color: '#121314', emissive: '#080808', metalness: 0.55, roughness: 0.22 },
+  { id: 'pawnRuby', label: 'Pawn Ruby', icon: '♟', color: '#ffe4e6', emissive: '#881337', metalness: 0.62, roughness: 0.2 },
+  { id: 'pawnSapphire', label: 'Pawn Sapphire', icon: '♟', color: '#e0f2fe', emissive: '#1d4ed8', metalness: 0.62, roughness: 0.2 },
+  { id: 'pawnChrome', label: 'Pawn Chrome', icon: '♟', color: '#e5e7eb', emissive: '#6b7280', metalness: 0.9, roughness: 0.16 },
+  { id: 'pawnGold', label: 'Pawn Gold', icon: '♟', color: '#fef3c7', emissive: '#a16207', metalness: 0.88, roughness: 0.18 },
+  { id: 'pawnEmerald', label: 'Pawn Emerald', icon: '♟', color: '#d1fae5', emissive: '#047857', metalness: 0.7, roughness: 0.18 }
+]);
+
+const DOMINO_FRAME_STYLE_OPTIONS = Object.freeze([
+  { id: 'goldImperial', label: 'Gold Imperial', color: '#d8af37', emissive: '#7a5300', metalness: 1.0, roughness: 0.2 },
+  { id: 'chromeEdge', label: 'Chrome Edge', color: '#d1d5db', emissive: '#6b7280', metalness: 1.0, roughness: 0.14 },
+  { id: 'aluminumMatte', label: 'Aluminium Matte', color: '#9ca3af', emissive: '#475569', metalness: 0.92, roughness: 0.18 },
+  { id: 'bronzeForge', label: 'Bronze Forge', color: '#b45309', emissive: '#7c2d12', metalness: 0.9, roughness: 0.2 },
+  { id: 'obsidianTrim', label: 'Obsidian Trim', color: '#374151', emissive: '#111827', metalness: 0.82, roughness: 0.2 },
+  { id: 'roseCopper', label: 'Rose Copper', color: '#f59e0b', emissive: '#b45309', metalness: 0.9, roughness: 0.18 }
 ]);
 
 const TABLE_SETUP_SECTIONS = [
@@ -4227,7 +4245,9 @@ const TABLE_SETUP_SECTIONS = [
   { key: 'tableTheme', label: 'Table Theme', options: TABLE_THEME_OPTIONS },
   { key: 'tableWood', label: 'Table Finish', options: TABLE_WOOD_OPTIONS },
   { key: 'tableCloth', label: 'Table Cloth', options: TABLE_CLOTH_OPTIONS },
-  { key: 'dominoStyle', label: 'Domino', options: DOMINO_STYLE_OPTIONS },
+  { key: 'dominoStyle', label: 'Domino Colors', options: DOMINO_STYLE_OPTIONS },
+  { key: 'dominoDotStyle', label: 'Domino Dots', options: DOMINO_DOT_STYLE_OPTIONS },
+  { key: 'dominoFrameStyle', label: 'Domino Frames', options: DOMINO_FRAME_STYLE_OPTIONS },
   {
     key: 'highlightStyle',
     label: 'Highlights',
@@ -4265,6 +4285,8 @@ const DOMINO_OPTIONS_BY_KEY = Object.freeze({
   tableWood: TABLE_WOOD_OPTIONS,
   tableCloth: TABLE_CLOTH_OPTIONS,
   dominoStyle: DOMINO_STYLE_OPTIONS,
+  dominoDotStyle: DOMINO_DOT_STYLE_OPTIONS,
+  dominoFrameStyle: DOMINO_FRAME_STYLE_OPTIONS,
   highlightStyle: HIGHLIGHT_STYLE_OPTIONS,
   chairTheme: CHAIR_THEME_OPTIONS
 });
@@ -4411,6 +4433,8 @@ function normalizeAppearance(raw) {
     ['tableWood', TABLE_WOOD_OPTIONS.length],
     ['tableCloth', TABLE_CLOTH_OPTIONS.length],
     ['dominoStyle', DOMINO_STYLE_OPTIONS.length],
+    ['dominoDotStyle', DOMINO_DOT_STYLE_OPTIONS.length],
+    ['dominoFrameStyle', DOMINO_FRAME_STYLE_OPTIONS.length],
     ['highlightStyle', HIGHLIGHT_STYLE_OPTIONS.length],
     ['chairTheme', CHAIR_THEME_OPTIONS.length]
   ];
@@ -6680,6 +6704,12 @@ let accentMat = null;
 let currentDominoStyleOption =
   DOMINO_STYLE_OPTIONS[DEFAULT_APPEARANCE.dominoStyle] ??
   DOMINO_STYLE_OPTIONS[0];
+let currentDominoDotStyleOption =
+  DOMINO_DOT_STYLE_OPTIONS[DEFAULT_APPEARANCE.dominoDotStyle] ??
+  DOMINO_DOT_STYLE_OPTIONS[0];
+let currentDominoFrameStyleOption =
+  DOMINO_FRAME_STYLE_OPTIONS[DEFAULT_APPEARANCE.dominoFrameStyle] ??
+  DOMINO_FRAME_STYLE_OPTIONS[0];
 let dominoStyleProfile = {
   ringInner: currentDominoStyleOption?.accent?.ringInner ?? 0.107,
   ringOuter: currentDominoStyleOption?.accent?.ringOuter ?? 0.12,
@@ -6861,9 +6891,17 @@ const getDominoSurfaceTextures = (() => {
   };
 })();
 
-function applyDominoStyle(option = DOMINO_STYLE_OPTIONS[0]) {
+function applyDominoStyle(
+  option = DOMINO_STYLE_OPTIONS[0],
+  dotOption = currentDominoDotStyleOption,
+  frameOption = currentDominoFrameStyleOption
+) {
   const style = option ?? DOMINO_STYLE_OPTIONS[0];
+  const pipStyle = dotOption ?? DOMINO_DOT_STYLE_OPTIONS[0];
+  const frameStyle = frameOption ?? DOMINO_FRAME_STYLE_OPTIONS[0];
   currentDominoStyleOption = style;
+  currentDominoDotStyleOption = pipStyle;
+  currentDominoFrameStyleOption = frameStyle;
   disposeDominoBaseMaterials();
   porcelainMat = buildDominoMaterial(style.body, {
     color: '#f8f8fb',
@@ -6876,30 +6914,48 @@ function applyDominoStyle(option = DOMINO_STYLE_OPTIONS[0]) {
     sheenColor: '#fefaf2',
     envMapIntensity: 1.18
   });
-  pipMat = buildDominoMaterial(style.pip, {
-    color: '#0a0a0a',
-    roughness: 0.05,
-    metalness: 0.6,
-    clearcoat: 0.9,
-    clearcoatRoughness: 0.04,
-    sheen: 0.12,
-    envMapIntensity: 0.85
-  });
+  pipMat = buildDominoMaterial(
+    {
+      ...(style.pip || {}),
+      color: pipStyle?.color ?? style.pip?.color,
+      emissive: pipStyle?.emissive ?? style.pip?.emissive,
+      metalness: pipStyle?.metalness ?? style.pip?.metalness,
+      roughness: pipStyle?.roughness ?? style.pip?.roughness
+    },
+    {
+      color: '#0a0a0a',
+      roughness: 0.05,
+      metalness: 0.6,
+      clearcoat: 0.9,
+      clearcoatRoughness: 0.04,
+      sheen: 0.12,
+      envMapIntensity: 0.85
+    }
+  );
   const dominoTextures = getDominoSurfaceTextures();
   porcelainMat.map = dominoTextures.porcelainMap;
   porcelainMat.roughnessMap = dominoTextures.porcelainRoughness;
   pipMat.map = dominoTextures.pipMap;
 
-  accentMat = buildDominoMaterial(style.accent, {
-    color: '#d7b03b',
-    emissive: '#593d00',
-    emissiveIntensity: dimIntensity(0.55),
-    metalness: 1.0,
-    roughness: 0.18,
-    reflectivity: 1.0,
-    envMapIntensity: 1.42,
-    side: THREE.DoubleSide
-  });
+  accentMat = buildDominoMaterial(
+    {
+      ...(style.accent || {}),
+      color: frameStyle?.color ?? style.accent?.color,
+      emissive: frameStyle?.emissive ?? style.accent?.emissive,
+      metalness: frameStyle?.metalness ?? style.accent?.metalness,
+      roughness: frameStyle?.roughness ?? style.accent?.roughness
+    },
+    {
+      color: '#d7b03b',
+      emissive: '#593d00',
+      emissiveIntensity: dimIntensity(0.55),
+      metalness: 1.0,
+      roughness: 0.18,
+      reflectivity: 1.0,
+      envMapIntensity: 1.42,
+      side: THREE.DoubleSide
+    }
+  );
   accentMat.polygonOffset = true;
   accentMat.polygonOffsetFactor = -1;
   accentMat.polygonOffsetUnits = -1;
@@ -7095,7 +7151,11 @@ function applyAppearanceChange({ refresh = true } = {}) {
   clearExistingDominoMeshes();
   updateTableMaterials();
   applyDominoStyle(
-    DOMINO_STYLE_OPTIONS[appearance.dominoStyle] ?? DOMINO_STYLE_OPTIONS[0]
+    DOMINO_STYLE_OPTIONS[appearance.dominoStyle] ?? DOMINO_STYLE_OPTIONS[0],
+    DOMINO_DOT_STYLE_OPTIONS[appearance.dominoDotStyle] ??
+      DOMINO_DOT_STYLE_OPTIONS[0],
+    DOMINO_FRAME_STYLE_OPTIONS[appearance.dominoFrameStyle] ??
+      DOMINO_FRAME_STYLE_OPTIONS[0]
   );
   applyHighlightStyle(
     HIGHLIGHT_STYLE_OPTIONS[appearance.highlightStyle] ??
@@ -7147,7 +7207,11 @@ function applyFrameRateSelection(
     ENVIRONMENT_HDRI_OPTIONS[appearance.environmentHdri] ??
       ENVIRONMENT_HDRI_OPTIONS[0]
   );
-  applyDominoStyle(currentDominoStyleOption);
+  applyDominoStyle(
+    currentDominoStyleOption,
+    currentDominoDotStyleOption,
+    currentDominoFrameStyleOption
+  );
   buildChairs(
     CHAIR_THEME_OPTIONS[appearance.chairTheme] ?? DEFAULT_CHAIR_THEME
   );
@@ -7313,6 +7377,42 @@ function createOptionPreview(key, option) {
         swatch.appendChild(inset);
       }
       break;
+    case 'dominoDotStyle': {
+      swatch.style.position = 'relative';
+      swatch.style.overflow = 'hidden';
+      swatch.style.background = 'linear-gradient(135deg, #111827, #0f172a)';
+      const dot = document.createElement('div');
+      dot.style.position = 'absolute';
+      dot.style.left = '50%';
+      dot.style.top = '50%';
+      dot.style.transform = 'translate(-50%, -50%)';
+      dot.style.width = '0.95rem';
+      dot.style.height = '0.95rem';
+      dot.style.borderRadius = '999px';
+      dot.style.background = option.color ?? '#121314';
+      dot.style.boxShadow = `0 0 0 2px ${option.emissive ?? '#d8af37'}`;
+      dot.style.display = 'grid';
+      dot.style.placeItems = 'center';
+      dot.style.fontSize = '0.62rem';
+      dot.style.fontWeight = '800';
+      dot.style.color = '#111827';
+      dot.textContent = option.icon ?? '♟';
+      swatch.appendChild(dot);
+      break;
+    }
+    case 'dominoFrameStyle': {
+      swatch.style.position = 'relative';
+      swatch.style.overflow = 'hidden';
+      swatch.style.background = 'linear-gradient(135deg, #f8fafc, #e2e8f0)';
+      const frame = document.createElement('div');
+      frame.style.position = 'absolute';
+      frame.style.inset = '0.25rem';
+      frame.style.borderRadius = '0.5rem';
+      frame.style.border = `3px solid ${option.color ?? '#d8af37'}`;
+      frame.style.boxShadow = `0 0 0 1px rgba(15,23,42,0.3), inset 0 0 0 1px ${option.emissive ?? '#7a5300'}`;
+      swatch.appendChild(frame);
+      break;
+    }
     case 'highlightStyle': {
       swatch.style.position = 'relative';
       swatch.style.overflow = 'hidden';

--- a/webapp/src/config/dominoRoyalInventoryConfig.js
+++ b/webapp/src/config/dominoRoyalInventoryConfig.js
@@ -38,12 +38,28 @@ export const DOMINO_ROYAL_OPTION_SETS = Object.freeze({
   environmentHdri: BATTLE_ROYALE_SHARED_HDRI_VARIANTS.map(({ id, name }) => ({ id, label: `${name} HDRI` })),
   dominoStyle: [
     { id: 'imperialIvory', label: 'Imperial Ivory' },
-    { id: 'obsidianPlatinum', label: 'Obsidian Platinum' },
-    { id: 'midnightRose', label: 'Midnight Rose' },
-    { id: 'auroraJade', label: 'Aurora Jade' },
-    { id: 'frostedOpal', label: 'Frosted Opal' },
-    { id: 'carbonVolt', label: 'Carbon Volt' },
-    { id: 'sandstoneAurora', label: 'Sandstone Aurora' }
+    { id: 'royalCrimson', label: 'Royal Crimson' },
+    { id: 'azureRegal', label: 'Azure Regal' },
+    { id: 'emeraldCrown', label: 'Emerald Crown' },
+    { id: 'violetEmpire', label: 'Violet Empire' },
+    { id: 'obsidianNight', label: 'Obsidian Night' },
+    { id: 'sunsetAmber', label: 'Sunset Amber' }
+  ],
+  dominoDotStyle: [
+    { id: 'pawnClassic', label: 'Pawn Classic' },
+    { id: 'pawnRuby', label: 'Pawn Ruby' },
+    { id: 'pawnSapphire', label: 'Pawn Sapphire' },
+    { id: 'pawnChrome', label: 'Pawn Chrome' },
+    { id: 'pawnGold', label: 'Pawn Gold' },
+    { id: 'pawnEmerald', label: 'Pawn Emerald' }
+  ],
+  dominoFrameStyle: [
+    { id: 'goldImperial', label: 'Gold Imperial' },
+    { id: 'chromeEdge', label: 'Chrome Edge' },
+    { id: 'aluminumMatte', label: 'Aluminium Matte' },
+    { id: 'bronzeForge', label: 'Bronze Forge' },
+    { id: 'obsidianTrim', label: 'Obsidian Trim' },
+    { id: 'roseCopper', label: 'Rose Copper' }
   ],
   highlightStyle: [
     { id: 'marksmanAmber', label: 'Marksman Amber' },
@@ -70,12 +86,31 @@ const DOMINO_TABLE_CLOTH_THUMBNAILS = Object.freeze({
 
 const DOMINO_STYLE_THUMBNAILS = Object.freeze({
   imperialIvory: swatchThumbnail(['#f8fafc', '#cbd5f5', '#e2e8f0']),
-  obsidianPlatinum: swatchThumbnail(['#1f2937', '#6b7280', '#e5e7eb']),
-  midnightRose: swatchThumbnail(['#881337', '#1f2937', '#fecdd3']),
-  auroraJade: swatchThumbnail(['#047857', '#0f172a', '#86efac']),
-  frostedOpal: swatchThumbnail(['#f8fafc', '#c7d2fe', '#e2e8f0']),
-  carbonVolt: swatchThumbnail(['#0f172a', '#111827', '#fde047']),
-  sandstoneAurora: swatchThumbnail(['#d6c7a1', '#7c2d12', '#fcd34d'])
+  royalCrimson: swatchThumbnail(['#991b1b', '#7f1d1d', '#fecaca']),
+  azureRegal: swatchThumbnail(['#1d4ed8', '#1e3a8a', '#bfdbfe']),
+  emeraldCrown: swatchThumbnail(['#047857', '#065f46', '#a7f3d0']),
+  violetEmpire: swatchThumbnail(['#6d28d9', '#581c87', '#ddd6fe']),
+  obsidianNight: swatchThumbnail(['#111827', '#0f172a', '#9ca3af']),
+  sunsetAmber: swatchThumbnail(['#b45309', '#78350f', '#fde68a'])
+});
+
+
+const DOMINO_DOT_STYLE_THUMBNAILS = Object.freeze({
+  pawnClassic: '/assets/game-art/chess-battle-royal/heads/current.svg',
+  pawnRuby: '/assets/game-art/chess-battle-royal/heads/headRuby.svg',
+  pawnSapphire: '/assets/game-art/chess-battle-royal/heads/headSapphire.svg',
+  pawnChrome: '/assets/game-art/chess-battle-royal/heads/headChrome.svg',
+  pawnGold: '/assets/game-art/chess-battle-royal/heads/headGold.svg',
+  pawnEmerald: swatchThumbnail(['#065f46', '#10b981', '#d1fae5'])
+});
+
+const DOMINO_FRAME_STYLE_THUMBNAILS = Object.freeze({
+  goldImperial: swatchThumbnail(['#f59e0b', '#fbbf24', '#78350f']),
+  chromeEdge: swatchThumbnail(['#f5f5f5', '#a1a1aa', '#1f2937']),
+  aluminumMatte: swatchThumbnail(['#d1d5db', '#9ca3af', '#334155']),
+  bronzeForge: swatchThumbnail(['#b45309', '#92400e', '#451a03']),
+  obsidianTrim: swatchThumbnail(['#111827', '#374151', '#9ca3af']),
+  roseCopper: swatchThumbnail(['#b45309', '#f59e0b', '#fbcfe8'])
 });
 
 const DOMINO_HIGHLIGHT_THUMBNAILS = Object.freeze({
@@ -108,6 +143,8 @@ export const DOMINO_ROYAL_DEFAULT_UNLOCKS = Object.freeze({
   tableTheme: DOMINO_ROYAL_OPTION_SETS.tableTheme.map((option) => option.id),
   environmentHdri: BATTLE_ROYALE_SHARED_HDRI_VARIANTS.map((variant) => variant.id),
   dominoStyle: [getDominoDefaultOptionId('dominoStyle')].filter(Boolean),
+  dominoDotStyle: [getDominoDefaultOptionId('dominoDotStyle')].filter(Boolean),
+  dominoFrameStyle: [getDominoDefaultOptionId('dominoFrameStyle')].filter(Boolean),
   highlightStyle: [getDominoDefaultOptionId('highlightStyle')].filter(Boolean),
   chairTheme: DOMINO_ROYAL_OPTION_SETS.chairTheme.map((option) => option.id)
 });
@@ -170,6 +207,25 @@ export const DOMINO_ROYAL_STORE_ITEMS = [
     description: 'Premium domino material set for tiles and pips.',
     thumbnail: DOMINO_STYLE_THUMBNAILS[option.id]
   })),
+
+  ...DOMINO_ROYAL_OPTION_SETS.dominoDotStyle.slice(1).map((option, idx) => ({
+    id: `domino-dot-style-${option.id}`,
+    type: 'dominoDotStyle',
+    optionId: option.id,
+    name: option.label,
+    price: 640 + idx * 35,
+    description: 'Chess Battle Royal pawn-head inspired dot set for domino pips.',
+    thumbnail: DOMINO_DOT_STYLE_THUMBNAILS[option.id]
+  })),
+  ...DOMINO_ROYAL_OPTION_SETS.dominoFrameStyle.slice(1).map((option, idx) => ({
+    id: `domino-frame-style-${option.id}`,
+    type: 'dominoFrameStyle',
+    optionId: option.id,
+    name: option.label,
+    price: 700 + idx * 40,
+    description: 'Domino frame finish pack inspired by luxury metallic trims.',
+    thumbnail: DOMINO_FRAME_STYLE_THUMBNAILS[option.id]
+  })),
   ...DOMINO_ROYAL_OPTION_SETS.highlightStyle.slice(1).map((option, idx) => ({
     id: `domino-highlight-${option.id}`,
     type: 'highlightStyle',
@@ -220,6 +276,16 @@ export const DOMINO_ROYAL_DEFAULT_LOADOUT = [
     type: 'dominoStyle',
     optionId: getDominoDefaultOptionId('dominoStyle'),
     label: getLabelForOption('dominoStyle', getDominoDefaultOptionId('dominoStyle'))
+  },
+  {
+    type: 'dominoDotStyle',
+    optionId: getDominoDefaultOptionId('dominoDotStyle'),
+    label: getLabelForOption('dominoDotStyle', getDominoDefaultOptionId('dominoDotStyle'))
+  },
+  {
+    type: 'dominoFrameStyle',
+    optionId: getDominoDefaultOptionId('dominoFrameStyle'),
+    label: getLabelForOption('dominoFrameStyle', getDominoDefaultOptionId('dominoFrameStyle'))
   },
   {
     type: 'highlightStyle',

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -241,7 +241,9 @@ const DOMINO_TYPE_LABELS = {
   tableBase: 'Table Base',
   tableTheme: 'Table Models',
   environmentHdri: 'HDR Environments',
-  dominoStyle: 'Domino Styles',
+  dominoStyle: 'Domino Colors',
+  dominoDotStyle: 'Domino Dots',
+  dominoFrameStyle: 'Domino Frames',
   highlightStyle: 'Highlights',
   chairTheme: 'Chairs'
 };
@@ -583,6 +585,8 @@ const TYPE_SWATCHES = {
   headStyle: ['#0f172a', '#facc15'],
   cards: ['#f8fafc', '#e5e7eb'],
   dominoStyle: ['#f8fafc', '#d1d5db'],
+  dominoDotStyle: ['#111827', '#eab308'],
+  dominoFrameStyle: ['#f59e0b', '#a1a1aa'],
   highlightStyle: ['#22d3ee', '#818cf8'],
   tokenPalette: ['#ef4444', '#22c55e', '#3b82f6'],
   tokenStyle: ['#eab308', '#6366f1'],
@@ -686,6 +690,8 @@ const PREVIEW_BY_TYPE = {
   environmentHdri: 'table',
   cards: 'cards',
   dominoStyle: 'domino',
+  dominoDotStyle: 'pawn-head',
+  dominoFrameStyle: 'domino',
   tokenPalette: 'token-stack',
   tokenStyle: 'token-stack',
   tokenPiece: 'token-stack',
@@ -886,9 +892,19 @@ const USAGE_BY_TYPE = {
       'Swaps the full table model used in Domino or Texas Hold’em arenas.'
   },
   dominoStyle: {
-    title: 'Domino style',
+    title: 'Domino colors',
     description:
-      'Applies a new domino material finish for match play and replays.'
+      'Applies one of six store colors while Imperial Ivory remains the default.'
+  },
+  dominoDotStyle: {
+    title: 'Domino dots',
+    description:
+      'Swaps domino pips with Chess Battle Royal pawn-head inspired dot sets.'
+  },
+  dominoFrameStyle: {
+    title: 'Domino frames',
+    description:
+      'Changes the domino frame trim to metallic finishes like gold, chrome, aluminium, and bronze.'
   },
   highlightStyle: {
     title: 'Highlights',


### PR DESCRIPTION
### Motivation

- Introduce more granular domino customization by splitting pips (dots) and frame trims into separate selectable style sets.
- Refresh the existing domino color/style palette with new themed variants and updated material properties for a richer visual set.
- Surface the new options in the store, thumbnails, previews and appearance persistence so players can buy and select dot/frame styles independently.

### Description

- Added `DOMINO_DOT_STYLE_OPTIONS` and `DOMINO_FRAME_STYLE_OPTIONS` with default sets and integrated them into `TABLE_SETUP_SECTIONS`, `DOMINO_OPTIONS_BY_KEY`, and appearance normalization/limits. 
- Replaced several existing domino style entries with renamed themed color variants (e.g. `royalCrimson`, `azureRegal`, `emeraldCrown`, `violetEmpire`, `obsidianNight`, `sunsetAmber`) and adjusted material parameters for those styles. 
- Extended `applyDominoStyle` to accept `dotOption` and `frameOption`, merged dot attributes into the pip material and frame attributes into the accent material, and added new current selection variables (`currentDominoDotStyleOption`, `currentDominoFrameStyleOption`). 
- Added thumbnail mappings, store item entries (`dominoDotStyle`, `dominoFrameStyle`), preview type labels, swatch colors, and `createOptionPreview` UI handling for the new option types; updated labels from "Domino Styles" to "Domino Colors" where appropriate. 

### Testing

- Ran the project's automated unit test suite with `yarn test` and static linting with `yarn lint`, both completed successfully. 
- Performed a development build with `yarn build` to ensure the updated asset references and UI components compile successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0d393475083299e9c900586cf2090)