### PR TITLE
fix(pool-royale): restore replay camera change detection

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -19601,6 +19601,35 @@ const powerRef = useRef(hud.power);
           return { position, target, fov: RAIL_OVERHEAD_REPLAY_FOV, minTargetY };
         };
 
+        const hasReplayCameraChanged = (previous, next) => {
+          if (!next) return false;
+          if (!previous) return true;
+          const dist = (a, b) => {
+            if (a && b && typeof a.distanceTo === 'function') return a.distanceTo(b);
+            if (a && b) {
+              const ax = Number.isFinite(a.x) ? a.x : 0;
+              const ay = Number.isFinite(a.y) ? a.y : 0;
+              const az = Number.isFinite(a.z) ? a.z : 0;
+              const bx = Number.isFinite(b.x) ? b.x : 0;
+              const by = Number.isFinite(b.y) ? b.y : 0;
+              const bz = Number.isFinite(b.z) ? b.z : 0;
+              return Math.hypot(ax - bx, ay - by, az - bz);
+            }
+            return Infinity;
+          };
+          const positionShift = dist(previous.position, next.position);
+          const targetShift = dist(previous.target, next.target);
+          const fovShift =
+            Number.isFinite(previous.fov) && Number.isFinite(next.fov)
+              ? Math.abs(previous.fov - next.fov)
+              : 0;
+          return (
+            positionShift > REPLAY_CAMERA_SWITCH_THRESHOLD ||
+            targetShift > REPLAY_CAMERA_SWITCH_THRESHOLD ||
+            fovShift > 1e-3
+          );
+        };
+
         const resolveReplayCameraView = (replayFrameCamera, storedReplayCamera) => {
           const scale = Number.isFinite(worldScaleFactor) ? worldScaleFactor : WORLD_SCALE;
           const minTargetY = Math.max(baseSurfaceWorldY, BALL_CENTER_Y * scale);


### PR DESCRIPTION
### Motivation
- Pool Royale replay playback referenced `hasReplayCameraChanged(...)` but the helper was missing, which could cause replay camera switching to behave incorrectly or skip playback after pots/fouls; the goal is to match Snooker Royale's dynamic broadcast-style framing for post-shot replays.

### Description
- Add `hasReplayCameraChanged(previous, next)` to `webapp/src/pages/Games/PoolRoyale.jsx` which compares camera `position`, `target`, and `fov` deltas (using `REPLAY_CAMERA_SWITCH_THRESHOLD`) to decide when to update/interpolate replay-frame cameras.
- This restores the replay-frame camera switching logic used during replay playback so replay banners/slates and dynamic broadcast framing behave correctly after a ball is potted or a foul is detected.

### Testing
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx` (and with `--no-ignore`) with no lint errors introduced by this change; only an existing ignore-warning from repo config was reported and is unrelated to this patch.
- Confirmed the updated file contains the helper and that the replay playback code path now has the camera-change detection available (static verification).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0d9a546948329b1ec2641049fe7b0)