### PR TITLE
Narrow Murlan table and restore stable mobile avatar positions

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -106,7 +106,7 @@ const ENABLE_3D_HUMAN_CHARACTERS = false;
 const ARENA_GROWTH = 1.45; // expanded arena footprint for wider walkways
 const CHAIR_SIZE_SCALE = 1;
 
-const TABLE_RADIUS = 3.22 * MODEL_SCALE;
+const TABLE_RADIUS = 3.05 * MODEL_SCALE;
 const CHAIR_COUNT = 4;
 const CUSTOM_SEAT_ANGLES = [
   THREE.MathUtils.degToRad(90),
@@ -2365,9 +2365,9 @@ const CAMERA_UP_TILT_FORWARD_LERP = 0.14;
 const PLAYER_COLORS = ['#f97316', '#38bdf8', '#a78bfa', '#22c55e'];
 const FALLBACK_SEAT_POSITIONS = [
   { left: '50%', top: '78%' },
-  { left: '80%', top: '50%' },
-  { left: '20%', top: '50%' },
-  { left: '50%', top: '22%' }
+  { left: '84%', top: '49%' },
+  { left: '16%', top: '49%' },
+  { left: '50%', top: '18%' }
 ];
 
 const AI_NAME_TRANSLATIONS = Object.freeze({
@@ -5267,7 +5267,7 @@ export default function MurlanRoyaleArena({ search }) {
                   transform: 'translateX(-50%)',
                   zIndex: 24
                 }
-              : anchor
+              : anchor && !detectCoarsePointer()
                 ? {
                     position: 'absolute',
                     left: `${anchor.x}%`,
@@ -5275,7 +5275,9 @@ export default function MurlanRoyaleArena({ search }) {
                     transform: 'translate(-50%, -50%)'
                   }
                 : { position: 'absolute', left: fallback.left, top: fallback.top, transform: 'translate(-50%, -50%)' };
-            const avatarSize = anchor ? clampValue(1.25 - (anchor.depth - 2.4) * 0.12, 0.85, 1.25) : 1;
+            const avatarSize = anchor && !detectCoarsePointer()
+              ? clampValue(1.25 - (anchor.depth - 2.4) * 0.12, 0.85, 1.25)
+              : 1;
             const color = PLAYER_COLORS[idx % PLAYER_COLORS.length];
             const isTurn = gameState.activePlayer === idx;
             const handCount = activePlayer?.hand?.length ?? 0;


### PR DESCRIPTION
### Motivation
- Reduce the table width on the sides while keeping the table surface height unchanged to better fit portrait/mobile framing. 
- Fix moved player avatars so top/left/right opponent avatars appear in their intended portrait positions on phones and other coarse-pointer devices. 
- Use a deterministic fallback for mobile avatars rather than relying on dynamic 3D anchors which can shift on small screens.

### Description
- Reduced the table radius constant by changing `TABLE_RADIUS` from `3.22 * MODEL_SCALE` to `3.05 * MODEL_SCALE` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` so the table becomes slightly narrower on the sides while height logic is preserved. 
- Updated `FALLBACK_SEAT_POSITIONS` coordinates for the non-human seats to `{ left: '84%', top: '49%' }`, `{ left: '16%', top: '49%' }`, and `{ left: '50%', top: '18%' }` for more consistent portrait layout. 
- Enforced coarse-pointer (mobile/touch) devices to use the fixed fallback positions by switching the runtime check to `detectCoarsePointer()` when choosing between `seatAnchorMap` anchors and fallback positions, and applied the same check to the avatar sizing calculation so mobile avatars use stable sizing.

### Testing
- Ran `npm test -- test/murlan.test.js --runInBand` and the `murlan` unit tests passed (all tests green). 
- Ran `npx eslint webapp/src/pages/Games/MurlanRoyaleArena.jsx` which reported the file is ignored by the current eslint config (no lint errors on this file were enforced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0dc3f1d54832983100fa27e8d169c)