### PR TITLE
Trim Murlan table sides and align top avatars with chairs

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2322,7 +2322,8 @@ const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 0.85;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
 const TABLE_HEIGHT_LIFT = 0.05 * MODEL_SCALE;
 const TABLE_HEIGHT = STOOL_HEIGHT + TABLE_HEIGHT_LIFT;
-const TABLE_MODEL_TARGET_DIAMETER = TABLE_RADIUS * 2 * 1.06;
+const TABLE_SIDE_TRIM_SCALE = 0.96;
+const TABLE_MODEL_TARGET_DIAMETER = TABLE_RADIUS * 2 * 1.06 * TABLE_SIDE_TRIM_SCALE;
 const TABLE_MODEL_TARGET_HEIGHT = TABLE_HEIGHT;
 const TABLE_HEIGHT_RAISE = TABLE_HEIGHT - BASE_TABLE_HEIGHT;
 const HUMAN_SELECTION_OFFSET = 0.14 * MODEL_SCALE;
@@ -3403,14 +3404,20 @@ export default function MurlanRoyaleArena({ search }) {
 
     const anchors = seatConfigs.map((seat, index) => {
       const anchorPoint = new THREE.Vector3();
-      const headBone = seat?.characterRig?.bones?.head;
-      if (headBone) {
-        headBone.getWorldPosition(anchorPoint);
-        anchorPoint.y += 0.08 * MODEL_SCALE;
+      const shouldUseChairAnchor = !gameStateRef.current?.players?.[index]?.isHuman;
+      if (shouldUseChairAnchor && seat?.chair) {
+        seat.chair.getWorldPosition(anchorPoint);
+        anchorPoint.y += 0.32 * MODEL_SCALE;
       } else {
-        const stool = seat.stoolPosition ? seat.stoolPosition.clone() : new THREE.Vector3();
-        stool.y = seat.stoolHeight ?? CHAIR_BASE_HEIGHT;
-        anchorPoint.copy(stool);
+        const headBone = seat?.characterRig?.bones?.head;
+        if (headBone) {
+          headBone.getWorldPosition(anchorPoint);
+          anchorPoint.y += 0.08 * MODEL_SCALE;
+        } else {
+          const stool = seat.stoolPosition ? seat.stoolPosition.clone() : new THREE.Vector3();
+          stool.y = seat.stoolHeight ?? CHAIR_BASE_HEIGHT;
+          anchorPoint.copy(stool);
+        }
       }
       const projected = anchorPoint.clone().project(camera);
       const x = clampValue(((projected.x + 1) / 2) * 100, -10, 110);
@@ -3849,7 +3856,7 @@ export default function MurlanRoyaleArena({ search }) {
         const procedural = createMurlanStyleTable({
           arena: three.arena,
           renderer: three.renderer,
-          tableRadius: TABLE_RADIUS,
+          tableRadius: TABLE_RADIUS * TABLE_SIDE_TRIM_SCALE,
           tableHeight: TABLE_HEIGHT,
           includeBase: true,
           shapeOption,


### PR DESCRIPTION
### Motivation
- Reduce the visual width of Murlan tables on the sides while keeping the table surface height unchanged to better fit portrait screens. 
- Reposition top/side avatar chips so AI and non-human avatars align with their chairs (restoring the previous visual relation between chairs and avatars).

### Description
- Introduced `TABLE_SIDE_TRIM_SCALE` and applied it to `TABLE_MODEL_TARGET_DIAMETER` to slightly trim table side width without changing `TABLE_MODEL_TARGET_HEIGHT` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx`.
- Applied `TABLE_SIDE_TRIM_SCALE` to procedural table generation by multiplying `tableRadius` passed to `createMurlanStyleTable`, keeping imported and procedural tables consistent.
- Updated `updateSeatAnchors` so non-human seats use the chair world position via `seat.chair.getWorldPosition(anchorPoint)` (with a vertical offset) and kept existing `headBone`/`stoolPosition` fallbacks for other cases.
- Minor cleanup to ensure stool fallback assignment indentation is consistent.

### Testing
- Ran `cd webapp && npm run build` which completed successfully and produced the production build artifacts.
- The build emitted non-blocking Vite warnings (duplicate `case` clause and chunk-size/dynamic-import suggestions) that are unrelated to this change and did not block the build.
- No additional automated unit/integration tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0e25804b48329806d13fd61cd4075)