### PR TITLE
Enable replay slate for all completed Pool Royale shots

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5584,6 +5584,7 @@ const LONG_SHOT_SHORT_RAIL_OFFSET = BALL_R * 18;
 const GOOD_SHOT_REPLAY_DELAY_MS = 900;
 const REPLAY_TRANSITION_LEAD_MS = 420;
 const REPLAY_SLATE_DURATION_MS = 1200;
+const POOL_ROYALE_REPLAY_ALL_SHOTS = true; // keep the replay pipeline visible on every completed shot, not only pots/fouls/finals
 const REPLAY_TIMEOUT_GRACE_MS = 750;
 const REMATCH_DECISION_MS = 15000;
 const POWER_REPLAY_THRESHOLD = 0.78;
@@ -27987,7 +27988,7 @@ const powerRef = useRef(hud.power);
           pottedBalls,
           shotContext
         }) => {
-          if (!recording || !hadObjectPot) return null;
+          if (!recording) return null;
           const tags = new Set(recording.replayTags ?? []);
           if (hadObjectPot) tags.add('pot');
           const potCount = pottedBalls.filter((entry) => entry.id !== 'cue').length;
@@ -27997,9 +27998,10 @@ const powerRef = useRef(hud.power);
           const priority = ['multi', 'bank', 'long', 'power', 'spin'];
           const primary = priority.find((tag) => tags.has(tag)) ?? 'default';
           const zoomOnly = recording.zoomOnly && !tags.has('long') && !tags.has('bank');
+          const shouldReplayByDefault = Boolean(POOL_ROYALE_REPLAY_ALL_SHOTS);
           return {
-            shouldReplay: hadObjectPot || tags.size > 0,
-            banner: selectReplayBanner(primary),
+            shouldReplay: shouldReplayByDefault || hadObjectPot || tags.size > 0,
+            banner: hadObjectPot ? selectReplayBanner(primary) : 'Replay',
             zoomOnly,
             tags: Array.from(tags),
             primaryTag: primary


### PR DESCRIPTION
### Motivation
- Replays were often not shown because the decision logic returned early unless `hadObjectPot` was true, so completed shots that did not pot an object ball (misses, safe plays, etc.) produced no replay slate.
- We want the replay pipeline to be visible for any completed shot when a recording exists so players can review important non-pot events and debug behavior.

### Description
- Added a feature switch `POOL_ROYALE_REPLAY_ALL_SHOTS` and enabled it by default to make the policy explicit and configurable via `webapp/src/pages/Games/PoolRoyale.jsx`.
- Changed `resolveReplayDecision` to require only a valid `recording` and not gate replays solely on `hadObjectPot`, and set `shouldReplay` to `POOL_ROYALE_REPLAY_ALL_SHOTS || hadObjectPot || tags.size > 0`.
- Kept tagging and priority logic (`multi`, `bank`, `long`, `power`, `spin`) intact and use a neutral banner `'Replay'` for non-pot shots so the slate still displays clearly.

### Testing
- Ran the Pool Royale online flow tests with `npm test -- --runInBand test/poolRoyaleOnlineFlow.test.js` and all tests passed.
- Test result: `PASS test/poolRoyaleOnlineFlow.test.js` (8 tests, 8 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0e2f6570c8329811938ffac79d334)