### PR TITLE
Narrow Murlan table sides and raise side avatars

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2322,7 +2322,7 @@ const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 0.85;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
 const TABLE_HEIGHT_LIFT = 0.05 * MODEL_SCALE;
 const TABLE_HEIGHT = STOOL_HEIGHT + TABLE_HEIGHT_LIFT;
-const TABLE_SIDE_TRIM_SCALE = 0.96;
+const TABLE_SIDE_TRIM_SCALE = 0.92;
 const TABLE_MODEL_TARGET_DIAMETER = TABLE_RADIUS * 2 * 1.06 * TABLE_SIDE_TRIM_SCALE;
 const TABLE_MODEL_TARGET_HEIGHT = TABLE_HEIGHT;
 const TABLE_HEIGHT_RAISE = TABLE_HEIGHT - BASE_TABLE_HEIGHT;
@@ -5266,6 +5266,8 @@ export default function MurlanRoyaleArena({ search }) {
             const activePlayer = gameState.players?.[idx] ?? player;
             const anchor = seatAnchorMap.get(idx);
             const fallback = FALLBACK_SEAT_POSITIONS[idx % FALLBACK_SEAT_POSITIONS.length];
+            const isSideSeat = Boolean(anchor) && (anchor.x <= 35 || anchor.x >= 65);
+            const sideSeatTopLift = isSideSeat ? 6 : 0;
             const positionStyle = idx === humanPlayerIndex
               ? {
                   position: 'fixed',
@@ -5278,10 +5280,15 @@ export default function MurlanRoyaleArena({ search }) {
                 ? {
                     position: 'absolute',
                     left: `${anchor.x}%`,
-                    top: `${anchor.y}%`,
+                    top: `${clampValue(anchor.y - sideSeatTopLift, -10, 110)}%`,
                     transform: 'translate(-50%, -50%)'
                   }
-                : { position: 'absolute', left: fallback.left, top: fallback.top, transform: 'translate(-50%, -50%)' };
+                : {
+                    position: 'absolute',
+                    left: fallback.left,
+                    top: fallback.top,
+                    transform: 'translate(-50%, -50%)'
+                  };
             const avatarSize = anchor ? clampValue(1.25 - (anchor.depth - 2.4) * 0.12, 0.85, 1.25) : 1;
             const color = PLAYER_COLORS[idx % PLAYER_COLORS.length];
             const isTurn = gameState.activePlayer === idx;


### PR DESCRIPTION
### Motivation
- Make the Murlan Royale table a bit narrower on the left/right sides while preserving current table height and overall look.
- Move player avatar overlays that sit on the left/right of the screen a bit upward so they appear closer to the top on portrait/mobile layouts.

### Description
- Reduced the procedural table side trim by changing `TABLE_SIDE_TRIM_SCALE` from `0.96` to `0.92` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` so the table is slightly slimmer on the sides while keeping the same height math.
- Added side-seat detection and a small vertical lift for side opponents by computing `isSideSeat` from the seat anchor `x` and applying a `sideSeatTopLift` to the avatar overlay `top` position (clamped via `clampValue`) in `webapp/src/pages/Games/MurlanRoyaleArena.jsx`.

### Testing
- Ran `npm --prefix webapp run -s build` and the build completed successfully.
- Build produced existing non-blocking Vite warnings about a duplicate `case` branch and large chunk sizes, but the production build output was generated without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0e50d53c48329b269ef78a5103338)