### PR TITLE
Adjust Murlan Royale table side width and side-seat avatar vertical offset

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2322,7 +2322,7 @@ const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 0.85;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
 const TABLE_HEIGHT_LIFT = 0.05 * MODEL_SCALE;
 const TABLE_HEIGHT = STOOL_HEIGHT + TABLE_HEIGHT_LIFT;
-const TABLE_SIDE_TRIM_SCALE = 0.92;
+const TABLE_SIDE_TRIM_SCALE = 0.9;
 const TABLE_MODEL_TARGET_DIAMETER = TABLE_RADIUS * 2 * 1.06 * TABLE_SIDE_TRIM_SCALE;
 const TABLE_MODEL_TARGET_HEIGHT = TABLE_HEIGHT;
 const TABLE_HEIGHT_RAISE = TABLE_HEIGHT - BASE_TABLE_HEIGHT;
@@ -5267,7 +5267,7 @@ export default function MurlanRoyaleArena({ search }) {
             const anchor = seatAnchorMap.get(idx);
             const fallback = FALLBACK_SEAT_POSITIONS[idx % FALLBACK_SEAT_POSITIONS.length];
             const isSideSeat = Boolean(anchor) && (anchor.x <= 35 || anchor.x >= 65);
-            const sideSeatTopLift = isSideSeat ? 6 : 0;
+            const sideSeatTopLift = isSideSeat ? 8 : 0;
             const positionStyle = idx === humanPlayerIndex
               ? {
                   position: 'fixed',


### PR DESCRIPTION
### Motivation
- Make the Murlan Royale table slightly narrower on the sides while keeping the same table height and raise the left/right (side) avatars a bit higher on the screen to better match the requested visual layout.

### Description
- In `webapp/src/pages/Games/MurlanRoyaleArena.jsx` reduced `TABLE_SIDE_TRIM_SCALE` from `0.92` to `0.9` to trim the table width and increased the side-seat vertical lift (`sideSeatTopLift`) from `6` to `8` so side avatars render higher on the portrait viewport.

### Testing
- Ran the production build with `npm --prefix webapp run build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0e70a97e083299a3a4aa5527ee369)