### PR TITLE
Domino: use Chess pawn-head materials for dots, add thumbnails, and conditionally show table cloth/finish

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -4219,12 +4219,66 @@ const DOMINO_STYLE_OPTIONS = Object.freeze([
 ]);
 
 const DOMINO_DOT_STYLE_OPTIONS = Object.freeze([
-  { id: 'pawnClassic', label: 'Pawn Classic', icon: '♟', color: '#121314', emissive: '#080808', metalness: 0.55, roughness: 0.22 },
-  { id: 'pawnRuby', label: 'Pawn Ruby', icon: '♟', color: '#ffe4e6', emissive: '#881337', metalness: 0.62, roughness: 0.2 },
-  { id: 'pawnSapphire', label: 'Pawn Sapphire', icon: '♟', color: '#e0f2fe', emissive: '#1d4ed8', metalness: 0.62, roughness: 0.2 },
-  { id: 'pawnChrome', label: 'Pawn Chrome', icon: '♟', color: '#e5e7eb', emissive: '#6b7280', metalness: 0.9, roughness: 0.16 },
-  { id: 'pawnGold', label: 'Pawn Gold', icon: '♟', color: '#fef3c7', emissive: '#a16207', metalness: 0.88, roughness: 0.18 },
-  { id: 'pawnEmerald', label: 'Pawn Emerald', icon: '♟', color: '#d1fae5', emissive: '#047857', metalness: 0.7, roughness: 0.18 }
+  {
+    id: 'headGlass',
+    label: 'Glass',
+    icon: '●',
+    color: '#ffffff',
+    metalness: 0,
+    roughness: 0.05,
+    transmission: 0.95,
+    ior: 1.5,
+    thickness: 0.5,
+    thumbnail: '/assets/game-art/chess-battle-royal/heads/current.svg'
+  },
+  {
+    id: 'headRuby',
+    label: 'Ruby',
+    icon: '●',
+    color: '#9b111e',
+    metalness: 0.05,
+    roughness: 0.08,
+    transmission: 0.92,
+    ior: 2.4,
+    thickness: 0.6,
+    thumbnail: '/assets/game-art/chess-battle-royal/heads/headRuby.svg'
+  },
+  {
+    id: 'headSapphire',
+    label: 'Sapphire',
+    icon: '●',
+    color: '#0f52ba',
+    metalness: 0.05,
+    roughness: 0.08,
+    transmission: 0.9,
+    ior: 1.8,
+    thickness: 0.7,
+    thumbnail: '/assets/game-art/chess-battle-royal/heads/headSapphire.svg'
+  },
+  {
+    id: 'headChrome',
+    label: 'Chrome',
+    icon: '●',
+    color: '#d6d8dc',
+    metalness: 0.95,
+    roughness: 0.12,
+    transmission: 0.1,
+    ior: 2.1,
+    thickness: 0.22,
+    thumbnail: '/assets/game-art/chess-battle-royal/heads/headChrome.svg'
+  },
+  {
+    id: 'headGold',
+    label: 'Gold',
+    icon: '●',
+    color: '#d4af37',
+    metalness: 0.92,
+    roughness: 0.16,
+    transmission: 0.06,
+    ior: 1.85,
+    thickness: 0.28,
+    thumbnail: '/assets/game-art/chess-battle-royal/heads/headGold.svg'
+  }
 ]);
 
 const DOMINO_FRAME_STYLE_OPTIONS = Object.freeze([
@@ -4258,25 +4312,34 @@ const TABLE_SETUP_SECTIONS = [
 
 const TABLE_FINISH_THEMES = new Set([
   'murlan-default',
+  'octagon-table',
   'diamond-edge',
   'diamond_edge',
-  'diamondEdge'
+  'diamondedge',
+  'oval-table'
 ]);
 
 function isTableFinishTheme(themeId = '') {
-  const normalized = String(themeId || '').trim();
+  const normalized = String(themeId || '').trim().toLowerCase();
   if (!normalized) return false;
   if (TABLE_FINISH_THEMES.has(normalized)) return true;
-  return normalized.toLowerCase().includes('diamond');
+  return (
+    normalized.includes('diamond') ||
+    normalized.includes('octagon') ||
+    normalized.includes('oval')
+  );
 }
 
 function getVisibleTableSetupSections() {
   const selectedTheme =
     TABLE_THEME_OPTIONS[appearance.tableTheme] ?? DEFAULT_TABLE_THEME_OPTION;
-  const showTableFinish = isTableFinishTheme(selectedTheme?.id);
-  return TABLE_SETUP_SECTIONS.filter((section) =>
-    section.key === 'tableWood' ? showTableFinish : true
-  );
+  const showFinishAndCloth = isTableFinishTheme(selectedTheme?.id);
+  return TABLE_SETUP_SECTIONS.filter((section) => {
+    if (section.key === 'tableWood' || section.key === 'tableCloth') {
+      return showFinishAndCloth;
+    }
+    return true;
+  });
 }
 
 const DOMINO_OPTIONS_BY_KEY = Object.freeze({
@@ -6940,7 +7003,10 @@ function applyDominoStyle(
       color: customDotColor ?? pipStyle?.color ?? style.pip?.color,
       emissive: pipStyle?.emissive ?? style.pip?.emissive,
       metalness: pipStyle?.metalness ?? style.pip?.metalness,
-      roughness: pipStyle?.roughness ?? style.pip?.roughness
+      roughness: pipStyle?.roughness ?? style.pip?.roughness,
+      transmission: pipStyle?.transmission ?? style.pip?.transmission,
+      ior: pipStyle?.ior ?? style.pip?.ior,
+      thickness: pipStyle?.thickness ?? style.pip?.thickness
     },
     {
       color: '#0a0a0a',

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-04-04-domino-color-presets-v10';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-04-04-domino-color-presets-v11';
 
 export default function DominoRoyalArena() {
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- Unify Domino visuals with the Chess Battle Royale assets by reusing the pawn-head material presets for domino dots and provide matching thumbnails for the menu.
- Remove the “Pawn …” phrasing from domino dot menu entries so options show only dot style names.
- Keep the config menu behavior where selecting an option does not auto-close the menu while still applying the change.
- Show `Table Finish` and `Table Cloth` options only for table themes that support finishes (octagon/diamond/oval) to reduce UI noise.

### Description
- Replaced `DOMINO_DOT_STYLE_OPTIONS` with material presets derived from the chess pawn-head presets (Glass, Ruby, Sapphire, Chrome, Gold) and added `thumbnail` references to chess head SVG assets (`webapp/public/domino-royal-game.js`).
- Wired additional material properties for dot materials by passing `transmission`, `ior`, and `thickness` into the pip material creation so dot visuals match the pawn-head appearance (`pipMat` construction in `applyDominoStyle`).
- Extended `TABLE_FINISH_THEMES` and updated `isTableFinishTheme` to detect octagon/diamond/oval themes (ID and substring matches) and changed `getVisibleTableSetupSections` to show `tableWood` and `tableCloth` only when the selected theme is a finish-capable theme (`webapp/public/domino-royal-game.js`).
- Bumped the runtime script version string constant to force clients to load the updated Domino runtime (`DOMINO_ROYAL_SCRIPT_VERSION` in `webapp/src/pages/Games/DominoRoyalArena.jsx`).

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` and it completed successfully.
- Ran `npx eslint webapp/public/domino-royal-game.js --no-warn-ignored` and it completed without errors.
- Ran `npx eslint webapp/src/pages/Games/DominoRoyalArena.jsx` which reported a warning that the file is ignored by the repository eslint pattern (no errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0e9ac26ac8329a8f21c68eb588a23)