### PR TITLE
Narrow Murlan Royale table sides and raise side avatars

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2322,7 +2322,7 @@ const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 0.85;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
 const TABLE_HEIGHT_LIFT = 0.05 * MODEL_SCALE;
 const TABLE_HEIGHT = STOOL_HEIGHT + TABLE_HEIGHT_LIFT;
-const TABLE_SIDE_TRIM_SCALE = 0.9;
+const TABLE_SIDE_TRIM_SCALE = 0.86;
 const TABLE_MODEL_TARGET_DIAMETER = TABLE_RADIUS * 2 * 1.06 * TABLE_SIDE_TRIM_SCALE;
 const TABLE_MODEL_TARGET_HEIGHT = TABLE_HEIGHT;
 const TABLE_HEIGHT_RAISE = TABLE_HEIGHT - BASE_TABLE_HEIGHT;
@@ -5267,7 +5267,7 @@ export default function MurlanRoyaleArena({ search }) {
             const anchor = seatAnchorMap.get(idx);
             const fallback = FALLBACK_SEAT_POSITIONS[idx % FALLBACK_SEAT_POSITIONS.length];
             const isSideSeat = Boolean(anchor) && (anchor.x <= 35 || anchor.x >= 65);
-            const sideSeatTopLift = isSideSeat ? 8 : 0;
+            const sideSeatTopLift = isSideSeat ? 12 : 0;
             const positionStyle = idx === humanPlayerIndex
               ? {
                   position: 'fixed',


### PR DESCRIPTION
### Motivation
- Make the Murlan Royale table slightly narrower on the sides while keeping the existing table height, and lift the left/right side player avatars a bit higher on the portrait layout so they sit closer to the top of the screen.

### Description
- Adjusted `TABLE_SIDE_TRIM_SCALE` from `0.9` to `0.86` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to reduce side width without changing table height.
- Increased the side-seat vertical offset by changing `sideSeatTopLift` from `8` to `12` in the same file so side avatars render higher on the page.

### Testing
- Ran the production build with `cd webapp && npm run -s build` and the build completed successfully; Vite emitted non-blocking warnings about a duplicate `case` and large chunk sizes but the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0e9ed25e48329a0bf04a7840ac28c)