### PR TITLE
Fix Texas Holdem settings menu anchor position

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -6543,7 +6543,7 @@ function TexasHoldemArena({ search }) {
   return (
     <div className="relative w-full h-full">
       <div ref={mountRef} className="absolute inset-0" />
-      <div className="fixed z-20 flex items-start left-[calc(0.2rem+env(safe-area-inset-left,0px))] bottom-[calc(env(safe-area-inset-bottom,0px)+8.9rem)] landscape:left-[calc(0.2rem+env(safe-area-inset-left,0px))] landscape:bottom-[calc(env(safe-area-inset-bottom,0px)+8.9rem)]">
+      <div className="fixed z-20 left-[calc(0.2rem+env(safe-area-inset-left,0px))] bottom-[calc(env(safe-area-inset-bottom,0px)+8.9rem)] landscape:left-[calc(0.2rem+env(safe-area-inset-left,0px))] landscape:bottom-[calc(env(safe-area-inset-bottom,0px)+8.9rem)]">
         <div className="flex items-center gap-2">
           <button
             type="button"
@@ -6559,7 +6559,7 @@ function TexasHoldemArena({ search }) {
           </button>
         </div>
       {configOpen && (
-        <div className="pointer-events-auto mt-2 w-72 max-w-[80vw] max-h-[80vh] overflow-y-auto rounded-2xl border border-white/15 bg-black/80 p-4 text-xs text-white shadow-2xl backdrop-blur pr-1">
+        <div className="pointer-events-auto absolute left-0 bottom-[calc(100%+0.5rem)] w-72 max-w-[80vw] max-h-[80vh] overflow-y-auto rounded-2xl border border-white/15 bg-black/80 p-4 text-xs text-white shadow-2xl backdrop-blur pr-1">
           <div className="flex items-center justify-between gap-3">
             <div>
               <p className="text-[10px] uppercase tracking-[0.4em] text-sky-200/80">Table Setup</p>


### PR DESCRIPTION
### Motivation
- The settings/menu panel opening would shift the menu button from its fixed screen spot, causing a jarring UI on portrait/mobile layouts.
- The intent is to keep the menu trigger visually locked in place and render the panel as a popover that does not affect layout.

### Description
- Adjusted the fixed wrapper in `webapp/src/pages/Games/TexasHoldemArena.jsx` to remove the flow-based flex positioning so the trigger remains anchored (`fixed` wrapper no longer includes `flex items-start`).
- Render the settings panel as an absolutely positioned popover (`absolute left-0 bottom-[calc(100%+0.5rem)]`) so it appears above the trigger and opening the panel does not reflow or move the button.
- Change is minimal (2 insertions, 2 deletions) and scoped to `TexasHoldemArena.jsx`.

### Testing
- Ran the production build with `npm --prefix /workspace/TonPlaygramWebApp/webapp run build` which completed successfully and produced the optimized `dist` artifacts.
- Attempted `npm --prefix /workspace/TonPlaygramWebApp/webapp run lint` which failed because this repository does not define a `lint` script (no lint step run).
- No unit tests were run as part of this change; manual visual verification was the target for the UI adjustment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0ea52e2b48329897c6fac6d7ccd95)