### PR TITLE
Align Domino dot styles with Chess head materials (remove glass option)

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -4220,18 +4220,6 @@ const DOMINO_STYLE_OPTIONS = Object.freeze([
 
 const DOMINO_DOT_STYLE_OPTIONS = Object.freeze([
   {
-    id: 'headGlass',
-    label: 'Glass',
-    icon: '●',
-    color: '#ffffff',
-    metalness: 0,
-    roughness: 0.05,
-    transmission: 0.95,
-    ior: 1.5,
-    thickness: 0.5,
-    thumbnail: '/assets/game-art/chess-battle-royal/heads/current.svg'
-  },
-  {
     id: 'headRuby',
     label: 'Ruby',
     icon: '●',
@@ -4244,6 +4232,18 @@ const DOMINO_DOT_STYLE_OPTIONS = Object.freeze([
     thumbnail: '/assets/game-art/chess-battle-royal/heads/headRuby.svg'
   },
   {
+    id: 'headPearl',
+    label: 'Pearl',
+    icon: '●',
+    color: '#f5f5f5',
+    metalness: 0.05,
+    roughness: 0.25,
+    transmission: 0,
+    ior: 1.3,
+    thickness: 0.2,
+    thumbnail: '/assets/game-art/chess-battle-royal/heads/current.svg'
+  },
+  {
     id: 'headSapphire',
     label: 'Sapphire',
     icon: '●',
@@ -4254,6 +4254,30 @@ const DOMINO_DOT_STYLE_OPTIONS = Object.freeze([
     ior: 1.8,
     thickness: 0.7,
     thumbnail: '/assets/game-art/chess-battle-royal/heads/headSapphire.svg'
+  },
+  {
+    id: 'headEmerald',
+    label: 'Emerald',
+    icon: '●',
+    color: '#046a38',
+    metalness: 0.05,
+    roughness: 0.08,
+    transmission: 0.9,
+    ior: 1.8,
+    thickness: 0.7,
+    thumbnail: '/assets/game-art/chess-battle-royal/heads/current.svg'
+  },
+  {
+    id: 'headDiamond',
+    label: 'Diamond',
+    icon: '●',
+    color: '#ffffff',
+    metalness: 0,
+    roughness: 0.03,
+    transmission: 0.98,
+    ior: 2.4,
+    thickness: 0.8,
+    thumbnail: '/assets/game-art/chess-battle-royal/heads/current.svg'
   },
   {
     id: 'headChrome',

--- a/webapp/src/config/dominoRoyalInventoryConfig.js
+++ b/webapp/src/config/dominoRoyalInventoryConfig.js
@@ -46,12 +46,13 @@ export const DOMINO_ROYAL_OPTION_SETS = Object.freeze({
     { id: 'sunsetAmber', label: 'Sunset Amber' }
   ],
   dominoDotStyle: [
-    { id: 'pawnClassic', label: 'Pawn Classic' },
-    { id: 'pawnRuby', label: 'Pawn Ruby' },
-    { id: 'pawnSapphire', label: 'Pawn Sapphire' },
-    { id: 'pawnChrome', label: 'Pawn Chrome' },
-    { id: 'pawnGold', label: 'Pawn Gold' },
-    { id: 'pawnEmerald', label: 'Pawn Emerald' }
+    { id: 'headRuby', label: 'Ruby' },
+    { id: 'headPearl', label: 'Pearl' },
+    { id: 'headSapphire', label: 'Sapphire' },
+    { id: 'headEmerald', label: 'Emerald' },
+    { id: 'headDiamond', label: 'Diamond' },
+    { id: 'headChrome', label: 'Chrome' },
+    { id: 'headGold', label: 'Gold' }
   ],
   dominoFrameStyle: [
     { id: 'goldImperial', label: 'Gold Imperial' },
@@ -96,12 +97,13 @@ const DOMINO_STYLE_THUMBNAILS = Object.freeze({
 
 
 const DOMINO_DOT_STYLE_THUMBNAILS = Object.freeze({
-  pawnClassic: '/assets/game-art/chess-battle-royal/heads/current.svg',
-  pawnRuby: '/assets/game-art/chess-battle-royal/heads/headRuby.svg',
-  pawnSapphire: '/assets/game-art/chess-battle-royal/heads/headSapphire.svg',
-  pawnChrome: '/assets/game-art/chess-battle-royal/heads/headChrome.svg',
-  pawnGold: '/assets/game-art/chess-battle-royal/heads/headGold.svg',
-  pawnEmerald: swatchThumbnail(['#065f46', '#10b981', '#d1fae5'])
+  headRuby: '/assets/game-art/chess-battle-royal/heads/headRuby.svg',
+  headPearl: '/assets/game-art/chess-battle-royal/heads/current.svg',
+  headSapphire: '/assets/game-art/chess-battle-royal/heads/headSapphire.svg',
+  headEmerald: swatchThumbnail(['#065f46', '#10b981', '#d1fae5']),
+  headDiamond: swatchThumbnail(['#f8fafc', '#dbeafe', '#bfdbfe']),
+  headChrome: '/assets/game-art/chess-battle-royal/heads/headChrome.svg',
+  headGold: '/assets/game-art/chess-battle-royal/heads/headGold.svg'
 });
 
 const DOMINO_FRAME_STYLE_THUMBNAILS = Object.freeze({
@@ -214,7 +216,7 @@ export const DOMINO_ROYAL_STORE_ITEMS = [
     optionId: option.id,
     name: option.label,
     price: 640 + idx * 35,
-    description: 'Chess Battle Royal pawn-head inspired dot set for domino pips.',
+    description: 'Chess Battle Royal head-material inspired dot set for domino pips (no glass option).',
     thumbnail: DOMINO_DOT_STYLE_THUMBNAILS[option.id]
   })),
   ...DOMINO_ROYAL_OPTION_SETS.dominoFrameStyle.slice(1).map((option, idx) => ({


### PR DESCRIPTION
### Motivation
- Make Domino Battle Royal dot options use the same head-material presets as Chess Battle Royal while excluding the glass variant, per design request to share visual materials between games.
- Ensure the menu/store data and runtime choices are consistent so players can pick the same high-quality head-style materials for domino pips.

### Description
- Replaced the Domino runtime dot options in `webapp/public/domino-royal-game.js` by removing the `headGlass` option and adding Chess head-material entries: `headRuby`, `headPearl`, `headSapphire`, `headEmerald`, `headDiamond`, `headChrome`, and `headGold` (updated `DOMINO_DOT_STYLE_OPTIONS`).
- Updated the inventory configuration in `webapp/src/config/dominoRoyalInventoryConfig.js` to use the Chess head-style IDs/labels and thumbnails for `dominoDotStyle` and `DOMINO_DOT_STYLE_THUMBNAILS` so UI/store lists match runtime options.
- Adjusted store item generation copy for domino dot styles to explicitly note the head-material lineup and that glass is excluded (updated description text used when mapping `DOMINO_ROYAL_STORE_ITEMS`).

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` and the file passed syntax checks (success).
- Ran `node --check webapp/src/config/dominoRoyalInventoryConfig.js` and the file passed syntax checks (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0f73488ac8329bca370ac726c620d)