### PR TITLE
Adjust Snake & Ladder board spacing, remove top tower, and emphasize tile 50

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -436,6 +436,8 @@ function createPreciseSnakeTiles(scale = 1) {
   const center = 3;
   const spiral = buildSpiralGrid(7).slice(0, 48);
   const colors = ['#e34b4b', '#46d04d', '#4056d8', '#e8b84a'];
+  const tileOutwardSpread = 1.07;
+  const tileSizeBoost = 1.08;
   const preciseTiles = spiral.map((cell, index) => {
     let level = 0;
     let localIndex = index;
@@ -459,27 +461,31 @@ function createPreciseSnakeTiles(scale = 1) {
       x: (cell.col - center) * 1.02 * scale,
       z: (cell.row - center) * 1.02 * scale,
       y: (baseTop + 0.26 / 2 + localIndex * riseStep) * scale,
-      size: size * scale,
+      size: size * tileSizeBoost * scale,
       color: colors[(index + level) % colors.length]
     };
   });
   preciseTiles.push({
     id: 49,
-    x: -1.02 * 0.48 * scale,
+    x: -1.02 * 0.48 * tileOutwardSpread * scale,
     z: 0,
     y: 2.46 * scale,
-    size: 0.88 * scale,
+    size: 0.88 * tileSizeBoost * scale,
     color: '#3ccfc5'
   });
   preciseTiles.push({
     id: 50,
-    x: 1.02 * 0.24 * scale,
+    x: 1.02 * 0.24 * tileOutwardSpread * scale,
     z: 0,
-    y: 2.78 * scale,
-    size: 0.8 * scale,
+    y: 2.86 * scale,
+    size: 1.08 * tileSizeBoost * scale,
     color: '#51d95a'
   });
-  return preciseTiles;
+  return preciseTiles.map((tileSpec) => ({
+    ...tileSpec,
+    x: tileSpec.x * tileOutwardSpread,
+    z: tileSpec.z * tileOutwardSpread
+  }));
 }
 
 function getTileLevelById(tileId) {
@@ -2858,9 +2864,12 @@ function buildSnakeBoard(
       ? SPIRAL_REFERENCE_COLORS[(tileSpec.id - 1) % SPIRAL_REFERENCE_COLORS.length]
       : new THREE.Color(tileSpec.color);
     const materialSet = createTileMaterialSet(baseColor, boardTheme);
-    const tileGeo = new THREE.BoxGeometry(tileSpec.size, tileHeight, tileSpec.size);
+    const isFinalTile = tileSpec.id === 50;
+    const tileBoxHeight = isFinalTile ? tileHeight * 1.5 : tileHeight;
+    const tileGeo = new THREE.BoxGeometry(tileSpec.size, tileBoxHeight, tileSpec.size);
     const tile = new THREE.Mesh(tileGeo, materialSet.materials);
-    tile.position.set(tileSpec.x, tileSpec.y, tileSpec.z);
+    const tileCenterY = isFinalTile ? tileSpec.y + (tileBoxHeight - tileHeight) / 2 : tileSpec.y;
+    tile.position.set(tileSpec.x, tileCenterY, tileSpec.z);
     tile.castShadow = true;
     tile.receiveShadow = true;
     tile.userData.index = tileSpec.id;
@@ -2870,7 +2879,7 @@ function buildSnakeBoard(
     tile.userData.baseColor = materialSet.topMaterial.color.clone();
     tileGroup.add(tile);
     tileMeshes.set(tileSpec.id, tile);
-    const topPosition = new THREE.Vector3(tileSpec.x, tileSpec.y + tileHeight / 2, tileSpec.z);
+    const topPosition = new THREE.Vector3(tileSpec.x, tileCenterY + tileBoxHeight / 2, tileSpec.z);
     indexToPosition.set(tileSpec.id, topPosition);
 
     const label = createTileLabel(tileSpec.id);
@@ -2935,32 +2944,6 @@ function buildSnakeBoard(
     );
   });
 
-  const tileHundred = tileMeshes.get(TOTAL_BOARD_TILES);
-  if (tileHundred) {
-    const supportBaseY = 1.66 * preciseBoardScale;
-    const supportTopY = tileHundred.position.y - tileHeight / 2;
-    const supportHeight = Math.max(
-      TILE_100_SUPPORT_HEIGHT_EXTRA,
-      supportTopY - supportBaseY + TILE_100_SUPPORT_HEIGHT_EXTRA
-    );
-    const supportMaterial = new THREE.MeshStandardMaterial({
-      color: PYRAMID_CONCRETE_LIGHT.clone().lerp(PYRAMID_CONCRETE_SHADOW, 0.55),
-      roughness: 0.74,
-      metalness: 0.08,
-      emissive: PYRAMID_CONCRETE_ACCENT.clone().multiplyScalar(0.14),
-      emissiveIntensity: 0.18
-    });
-    const support = new THREE.Mesh(
-      new THREE.CylinderGeometry(TILE_100_SUPPORT_RADIUS * 0.85, TILE_100_SUPPORT_RADIUS, supportHeight, 24),
-      supportMaterial
-    );
-    support.position.set(tileHundred.position.x, supportBaseY + supportHeight / 2, tileHundred.position.z);
-    support.castShadow = true;
-    support.receiveShadow = true;
-    platformGroup.add(support);
-    platformMeshes.push(support);
-  }
-
   const baseHalf = Math.max(levelDimensions[0].halfX, levelDimensions[0].halfZ);
   const baseStart = new THREE.Vector3(
     -baseHalf - TILE_SIZE * 0.8,
@@ -2993,27 +2976,6 @@ function buildSnakeBoard(
 
   const reserveTokensGroup = new THREE.Group();
   boardStaticRoot.add(reserveTokensGroup);
-
-  const potGroup = new THREE.Group();
-  const coin = new THREE.Mesh(
-    new THREE.CylinderGeometry(TILE_SIZE * 0.22, TILE_SIZE * 0.25, TILE_SIZE * 0.16, 32),
-    new THREE.MeshStandardMaterial({
-      color: useReferenceSpiral ? 0x2dd4bf : 0xf59e0b,
-      roughness: useReferenceSpiral ? 0.36 : 0.3,
-      metalness: useReferenceSpiral ? 0.16 : 0.4,
-      emissive: useReferenceSpiral ? 0x0f766e : 0x332200,
-      emissiveIntensity: useReferenceSpiral ? 0.18 : 0.25
-    })
-  );
-  coin.rotation.x = Math.PI / 2;
-  coin.position.y = COIN_LOCAL_LIFT;
-  coin.castShadow = true;
-  coin.receiveShadow = true;
-  potGroup.add(coin);
-  potGroup.userData.coin = coin;
-  const potPos = serpentineIndexToXZ(TOTAL_BOARD_TILES);
-  potGroup.position.set(potPos.x, potPos.y + COIN_RAISE, potPos.z);
-  boardRotationRoot.add(potGroup);
 
   const diceGroup = new THREE.Group();
   const baseLevelTop = levelPlacements[0].tileTopY;


### PR DESCRIPTION
### Motivation
- Improve the visual composition so tiles sit slightly larger and farther from the board center to better align with rails and nets. 
- Make the final tile more prominent so the finish is visually clear on portrait mobile screens. 
- Remove the decorative tower/coin at the top that conflicts with the desired cleaner final-tile presentation.

### Description
- Increased per-tile scale and outward spread by adding `tileSizeBoost` and `tileOutwardSpread` and applying them in `createPreciseSnakeTiles` so tiles are larger and pushed outward from center. 
- Adjusted special placements for tile 49 and tile 50 by updating their `x`, `y`, and `size` values so they read larger and sit correctly in the layout. 
- Made tile 50 taller by using an increased box geometry height when `tileSpec.id === 50` and offset its Y position so the visual top aligns with other tiles. 
- Removed the top-end support/coin/pot visual by deleting the support column and pot/coin mesh creation and placement so the board finish is driven by tiles only.

### Testing
- Ran a production build with `npm -C webapp run build` which completed successfully and produced the application `dist` output. 
- Verified only `webapp/src/components/SnakeBoard3D.jsx` was modified for these changes during the update and build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0f9276ff483299d5bcb5f284a4c55)