### PR TITLE
Fix Domino Royal avatar video placement, config panel behavior, and domino pip styling

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -6805,6 +6805,7 @@ function getDominoPipGeometry(radius) {
 let porcelainMat = null;
 let pipMat = null;
 let accentMat = null;
+let dominoPipStyleTexture = null;
 let currentDominoStyleOption =
   DOMINO_STYLE_OPTIONS[DEFAULT_APPEARANCE.dominoStyle] ??
   DOMINO_STYLE_OPTIONS[0];
@@ -6840,6 +6841,10 @@ function disposeDominoBaseMaterials() {
     SHARED_DOMINO_MATERIALS.delete(pipMat);
     pipMat.dispose?.();
     pipMat = null;
+  }
+  if (dominoPipStyleTexture) {
+    dominoPipStyleTexture.dispose?.();
+    dominoPipStyleTexture = null;
   }
 }
 
@@ -6995,6 +7000,76 @@ const getDominoSurfaceTextures = (() => {
   };
 })();
 
+function createDominoPipStyleTexture(dotStyle = null) {
+  if (typeof document === 'undefined') return null;
+  const canvas = document.createElement('canvas');
+  const size = 512;
+  canvas.width = size;
+  canvas.height = size;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return null;
+  const styleId = String(dotStyle?.id || '').toLowerCase();
+  const base = dotStyle?.color || '#121314';
+  const bright = adjustHexColor(base, 0.36);
+  const dark = adjustHexColor(base, -0.42);
+  const gradient = ctx.createRadialGradient(
+    size * 0.32,
+    size * 0.3,
+    size * 0.06,
+    size * 0.62,
+    size * 0.66,
+    size * 0.75
+  );
+  gradient.addColorStop(0, bright);
+  gradient.addColorStop(0.58, base);
+  gradient.addColorStop(1, dark);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, size, size);
+
+  if (styleId.includes('ruby') || styleId.includes('sapphire') || styleId.includes('emerald')) {
+    ctx.globalAlpha = 0.24;
+    ctx.strokeStyle = adjustHexColor(base, 0.5);
+    ctx.lineWidth = size * 0.045;
+    for (let i = -size; i < size * 2; i += size * 0.22) {
+      ctx.beginPath();
+      ctx.moveTo(i, 0);
+      ctx.lineTo(i + size, size);
+      ctx.stroke();
+    }
+    ctx.globalAlpha = 1;
+  } else if (styleId.includes('chrome')) {
+    const chromeBand = ctx.createLinearGradient(0, 0, size, size);
+    chromeBand.addColorStop(0, '#eef2f7');
+    chromeBand.addColorStop(0.24, '#7b8490');
+    chromeBand.addColorStop(0.5, '#f4f7fb');
+    chromeBand.addColorStop(0.78, '#6b7280');
+    chromeBand.addColorStop(1, '#e2e8f0');
+    ctx.globalAlpha = 0.55;
+    ctx.fillStyle = chromeBand;
+    ctx.fillRect(0, 0, size, size);
+    ctx.globalAlpha = 1;
+  } else if (styleId.includes('gold')) {
+    const shimmer = ctx.createLinearGradient(0, 0, size, size);
+    shimmer.addColorStop(0, '#fff5bf');
+    shimmer.addColorStop(0.34, '#d4af37');
+    shimmer.addColorStop(0.62, '#f2cf69');
+    shimmer.addColorStop(1, '#8a6a11');
+    ctx.globalAlpha = 0.5;
+    ctx.fillStyle = shimmer;
+    ctx.fillRect(0, 0, size, size);
+    ctx.globalAlpha = 1;
+  }
+
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.colorSpace = THREE.SRGBColorSpace;
+  texture.anisotropy = Math.min(getRendererAnisotropyCap(), 8);
+  texture.generateMipmaps = true;
+  texture.minFilter = THREE.LinearMipmapLinearFilter;
+  texture.magFilter = THREE.LinearFilter;
+  texture.needsUpdate = true;
+  return texture;
+}
+
 function applyDominoStyle(
   option = DOMINO_STYLE_OPTIONS[0],
   dotOption = currentDominoDotStyleOption,
@@ -7045,7 +7120,12 @@ function applyDominoStyle(
   const dominoTextures = getDominoSurfaceTextures();
   porcelainMat.map = dominoTextures.porcelainMap;
   porcelainMat.roughnessMap = dominoTextures.porcelainRoughness;
-  pipMat.map = dominoTextures.pipMap;
+  if (dominoPipStyleTexture) {
+    dominoPipStyleTexture.dispose?.();
+    dominoPipStyleTexture = null;
+  }
+  dominoPipStyleTexture = createDominoPipStyleTexture(pipStyle);
+  pipMat.map = dominoPipStyleTexture ?? dominoTextures.pipMap;
 
   accentMat = buildDominoMaterial(
     {
@@ -7693,6 +7773,9 @@ function refreshConfigUI() {
       button.addEventListener('click', () => {
         if (appearance[section.key] === idx) return;
         appearance[section.key] = idx;
+        if (section.key === 'dominoStyle') appearance.dominoBodyColor = null;
+        if (section.key === 'dominoDotStyle') appearance.dominoDotColor = null;
+        if (section.key === 'dominoFrameStyle') appearance.dominoFrameColor = null;
         applyAppearanceChange({ refresh: false });
         refreshConfigUI();
       });
@@ -7988,11 +8071,11 @@ configButtonEl?.addEventListener('click', () => {
 configCloseEl?.addEventListener('click', () => closeConfigPanel());
 document.addEventListener('click', (event) => {
   if (!configPanelEl?.classList.contains('active')) return;
-  if (
-    configPanelEl.contains(event.target) ||
-    configButtonEl?.contains(event.target)
-  )
-    return;
+  const eventPath =
+    typeof event.composedPath === 'function' ? event.composedPath() : [];
+  const clickedInsidePanel = eventPath.includes(configPanelEl);
+  const clickedConfigButton = eventPath.includes(configButtonEl);
+  if (clickedInsidePanel || clickedConfigButton) return;
   closeConfigPanel();
 });
 document.addEventListener('keydown', (event) => {

--- a/webapp/src/components/GameLiveAvatarOverlay.jsx
+++ b/webapp/src/components/GameLiveAvatarOverlay.jsx
@@ -3,6 +3,8 @@ import { useLocation } from 'react-router-dom';
 import useLiveVideoChat from '../hooks/useLiveVideoChat.js';
 
 const AVATAR_ANCHOR_SELECTORS = [
+  '#seatOverlay .seat-badge.is-self .seat-badge-core',
+  '#seatOverlay .seat-badge.is-self',
   '[data-self-player="true"] .seat-badge-core',
   '[data-self-player="true"] .score-avatar',
   '[data-self-player="true"] .avatar-timer-avatar',
@@ -125,6 +127,8 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
         `${element.getAttributeNames().join(' ')} ${element.getAttribute('data-self-player') || ''} ${element.getAttribute('data-is-user') || ''} ${element.getAttribute('data-player-index') || ''} ${element.className || ''} ${element.getAttribute('aria-label') || ''} ${element.getAttribute('alt') || ''}`.toLowerCase();
       if (marker.includes('self')) score += 100;
       if (marker.includes('you')) score += 80;
+      if (marker.includes('seat-badge')) score += 90;
+      if (marker.includes('is-self')) score += 80;
       if (rect.top > window.innerHeight * 0.45) score += 25;
       if (rect.left < window.innerWidth * 0.65) score += 15;
       score += Math.min(rect.width, rect.height);
@@ -165,7 +169,19 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
 
     const applyRect = () => {
       const { rect, node } = findAvatarAnchor();
-      if (!rect) return;
+      if (!rect || !node?.isConnected) {
+        setAnchorElement(null);
+        if (gameSlug === 'domino-royal') {
+          const size = 58;
+          setOverlayRect({
+            top: Math.max(window.innerHeight - size - 110, 0),
+            left: Math.max(Math.round(window.innerWidth * 0.5 - size * 0.5), 0),
+            width: size,
+            height: size
+          });
+        }
+        return;
+      }
       const avatarDiameter = Math.min(rect.width, rect.height);
       const frameDiameter = Math.max(Math.round(avatarDiameter * FRAME_SCALE), 32);
       const width = frameDiameter;
@@ -246,6 +262,7 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
     const top = Math.max(overlayRect.top - ACTIVATION_TOUCH_PADDING, 0);
     return { top, left, width, height };
   }, [overlayRect]);
+  const hasRenderableAnchor = Boolean(anchorElement) || gameSlug === 'domino-royal';
 
   useEffect(() => {
     if (!anchorElement) return undefined;
@@ -260,7 +277,7 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
   return (
     <>
       {children}
-      {!liveMode && anchorElement ? (
+      {!liveMode && hasRenderableAnchor ? (
         <button
           type="button"
           aria-label="Turn on live avatar video"
@@ -274,7 +291,7 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
           }}
         />
       ) : null}
-      {liveMode && anchorElement ? (
+      {liveMode && hasRenderableAnchor ? (
         <button
           type="button"
           aria-label="Turn off live avatar video"


### PR DESCRIPTION
### Motivation
- Prevent the local live-video overlay from jumping to the top-left/menu area by making the overlay anchor reliably track the player's bottom seat badge. 
- Stop the table setup menu from closing immediately when selecting options that rerender its contents. 
- Ensure selecting a domino head/dot/style visibly updates pip color/texture and does not get overridden by stale custom color overrides.

### Description
- Prefer `.seat-badge.is-self` anchors and boost seat-badge scoring in `GameLiveAvatarOverlay` to reliably target the local player, and add a Domino-specific bottom-center fallback rectangle while the badge node is not yet available (`webapp/src/components/GameLiveAvatarOverlay.jsx`).
- Allow the overlay activation/video controls to render using the fallback anchor so the user video does not appear at the top-left before the seat badge is discovered (`GameLiveAvatarOverlay.jsx`).
- Replace panel outside-click logic to use `event.composedPath()` so clicks that re-render the panel (or originate from shadow/iframe contexts) do not inadvertently close it (`webapp/public/domino-royal-game.js`).
- Add `createDominoPipStyleTexture` to generate per-head pip textures (ruby/sapphire/emerald/chrome/gold variants) and apply that texture to the domino pip material in `applyDominoStyle`, disposing previous textures to avoid leaks (`webapp/public/domino-royal-game.js`).
- Clear conflicting custom color overrides when a user selects a new `dominoStyle`, `dominoDotStyle`, or `dominoFrameStyle` so the selected head/style becomes visible immediately (`webapp/public/domino-royal-game.js`).

### Testing
- Built the web app with `npm -C webapp run build` and the build completed successfully (Vite emitted non-blocking chunk/import warnings).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0fbcfd6b48329919839bce9ac0f03)