### PR TITLE
Adjust Snake & Ladder board: larger/outward tiles, bigger 50th tile, remove top coin tower

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -436,12 +436,13 @@ function createPreciseSnakeTiles(scale = 1) {
   const center = 3;
   const spiral = buildSpiralGrid(7).slice(0, 48);
   const colors = ['#e34b4b', '#46d04d', '#4056d8', '#e8b84a'];
+  const outwardSpread = 1.1;
   const preciseTiles = spiral.map((cell, index) => {
     let level = 0;
     let localIndex = index;
     let baseTop = 0.07;
     let riseStep = 0.012;
-    let size = 0.92;
+    let size = 0.98;
     if (index >= 24 && index < 40) {
       level = 1;
       localIndex = index - 24;
@@ -452,12 +453,14 @@ function createPreciseSnakeTiles(scale = 1) {
       localIndex = index - 40;
       baseTop = 1.66;
       riseStep = 0.048;
-      size = 0.9;
+      size = 0.96;
     }
+    const dx = cell.col - center;
+    const dz = cell.row - center;
     return {
       id: index + 1,
-      x: (cell.col - center) * 1.02 * scale,
-      z: (cell.row - center) * 1.02 * scale,
+      x: dx * outwardSpread * scale,
+      z: dz * outwardSpread * scale,
       y: (baseTop + 0.26 / 2 + localIndex * riseStep) * scale,
       size: size * scale,
       color: colors[(index + level) % colors.length]
@@ -465,18 +468,18 @@ function createPreciseSnakeTiles(scale = 1) {
   });
   preciseTiles.push({
     id: 49,
-    x: -1.02 * 0.48 * scale,
+    x: -outwardSpread * 0.54 * scale,
     z: 0,
     y: 2.46 * scale,
-    size: 0.88 * scale,
+    size: 0.94 * scale,
     color: '#3ccfc5'
   });
   preciseTiles.push({
     id: 50,
-    x: 1.02 * 0.24 * scale,
+    x: outwardSpread * 0.34 * scale,
     z: 0,
-    y: 2.78 * scale,
-    size: 0.8 * scale,
+    y: 2.9 * scale,
+    size: 1.08 * scale,
     color: '#51d95a'
   });
   return preciseTiles;
@@ -2935,32 +2938,6 @@ function buildSnakeBoard(
     );
   });
 
-  const tileHundred = tileMeshes.get(TOTAL_BOARD_TILES);
-  if (tileHundred) {
-    const supportBaseY = 1.66 * preciseBoardScale;
-    const supportTopY = tileHundred.position.y - tileHeight / 2;
-    const supportHeight = Math.max(
-      TILE_100_SUPPORT_HEIGHT_EXTRA,
-      supportTopY - supportBaseY + TILE_100_SUPPORT_HEIGHT_EXTRA
-    );
-    const supportMaterial = new THREE.MeshStandardMaterial({
-      color: PYRAMID_CONCRETE_LIGHT.clone().lerp(PYRAMID_CONCRETE_SHADOW, 0.55),
-      roughness: 0.74,
-      metalness: 0.08,
-      emissive: PYRAMID_CONCRETE_ACCENT.clone().multiplyScalar(0.14),
-      emissiveIntensity: 0.18
-    });
-    const support = new THREE.Mesh(
-      new THREE.CylinderGeometry(TILE_100_SUPPORT_RADIUS * 0.85, TILE_100_SUPPORT_RADIUS, supportHeight, 24),
-      supportMaterial
-    );
-    support.position.set(tileHundred.position.x, supportBaseY + supportHeight / 2, tileHundred.position.z);
-    support.castShadow = true;
-    support.receiveShadow = true;
-    platformGroup.add(support);
-    platformMeshes.push(support);
-  }
-
   const baseHalf = Math.max(levelDimensions[0].halfX, levelDimensions[0].halfZ);
   const baseStart = new THREE.Vector3(
     -baseHalf - TILE_SIZE * 0.8,
@@ -2993,27 +2970,6 @@ function buildSnakeBoard(
 
   const reserveTokensGroup = new THREE.Group();
   boardStaticRoot.add(reserveTokensGroup);
-
-  const potGroup = new THREE.Group();
-  const coin = new THREE.Mesh(
-    new THREE.CylinderGeometry(TILE_SIZE * 0.22, TILE_SIZE * 0.25, TILE_SIZE * 0.16, 32),
-    new THREE.MeshStandardMaterial({
-      color: useReferenceSpiral ? 0x2dd4bf : 0xf59e0b,
-      roughness: useReferenceSpiral ? 0.36 : 0.3,
-      metalness: useReferenceSpiral ? 0.16 : 0.4,
-      emissive: useReferenceSpiral ? 0x0f766e : 0x332200,
-      emissiveIntensity: useReferenceSpiral ? 0.18 : 0.25
-    })
-  );
-  coin.rotation.x = Math.PI / 2;
-  coin.position.y = COIN_LOCAL_LIFT;
-  coin.castShadow = true;
-  coin.receiveShadow = true;
-  potGroup.add(coin);
-  potGroup.userData.coin = coin;
-  const potPos = serpentineIndexToXZ(TOTAL_BOARD_TILES);
-  potGroup.position.set(potPos.x, potPos.y + COIN_RAISE, potPos.z);
-  boardRotationRoot.add(potGroup);
 
   const diceGroup = new THREE.Group();
   const baseLevelTop = levelPlacements[0].tileTopY;
@@ -3078,7 +3034,7 @@ function buildSnakeBoard(
     boardTokensGroup,
     reserveTokensGroup,
     serpentineIndexToXZ,
-    potGroup,
+    potGroup: null,
     labelGroup,
     diceGroup,
     diceSet,


### PR DESCRIPTION
### Motivation
- Make the board tiles slightly larger and visually pushed outward from the center so rails/nets align better with the photos and on-screen layout. 
- Make the final tile (tile 50) more prominent by increasing its size and height so it reads as the destination tile. 
- Remove the decorative tower/coin at the top center to simplify the finish presentation.

### Description
- Updated `createPreciseSnakeTiles` in `webapp/src/components/SnakeBoard3D.jsx` to add an `outwardSpread` factor and use it when computing tile `x`/`z` positions so tiles sit farther from the center. 
- Increased base tile sizes for regular and top-level tiles (defaults changed from `0.92` -> `0.98` and `0.9` -> `0.96`) so tiles render slightly bigger. 
- Adjusted special tiles 49/50: moved them outward, raised tile 50's `y` value and increased its `size` so it appears taller/larger than other tiles. 
- Removed the top coin/tower mesh and its pillar/support creation and set `potGroup` to `null` in the returned board object so the coin/tower no longer renders while preserving the rest of the board, rails, nets and ladder logic.

### Testing
- Ran `npx eslint webapp/src/components/SnakeBoard3D.jsx`, which completed and reported a single warning that the file is ignored by the current ESLint ignore config (no lint errors). 
- No unit or integration tests were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0f9276ff483299d5bcb5f284a4c55)