### PR TITLE
Pool Royale: Add color variants for carbon-fiber table finishes and remove "Chalk" naming

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -400,11 +400,11 @@ export const POOL_ROYALE_OPTION_LABELS = Object.freeze({
     woodTable001: 'Wood Table 001',
     darkWood: 'Dark Wood',
     rosewoodVeneer01: 'Rosewood Veneer 01',
-    carbonFiberChalk: 'Carbon Fiber Chalk',
-    carbonFiberChalkGrey: 'Carbon Fiber Chalk Grey',
-    carbonFiberChalkBeige: 'Carbon Fiber Chalk Beige',
-    carbonFiberChalkDarkBlue: 'Carbon Fiber Chalk Dark Blue',
-    carbonFiberChalkWhite: 'Carbon Fiber Chalk White'
+    carbonFiberChalk: 'Carbon Fiber Black',
+    carbonFiberChalkGrey: 'Carbon Fiber Grey',
+    carbonFiberChalkBeige: 'Carbon Fiber Beige',
+    carbonFiberChalkDarkBlue: 'Carbon Fiber Dark Blue',
+    carbonFiberChalkWhite: 'Carbon Fiber White'
   }),
   chromeColor: Object.freeze({
     chrome: 'Chrome',
@@ -496,45 +496,45 @@ export const POOL_ROYALE_STORE_ITEMS = [
     id: 'finish-carbonFiberChalk',
     type: 'tableFinish',
     optionId: 'carbonFiberChalk',
-    name: 'Carbon Fiber Chalk Finish',
+    name: 'Carbon Fiber Black Finish',
     price: 1160,
-    description: 'Custom carbon weave inspired by the chalk block pattern.',
+    description: 'Custom carbon weave in a deep black palette.',
     thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberChalk
   },
   {
     id: 'finish-carbonFiberChalkGrey',
     type: 'tableFinish',
     optionId: 'carbonFiberChalkGrey',
-    name: 'Carbon Fiber Chalk Grey Finish',
+    name: 'Carbon Fiber Grey Finish',
     price: 1170,
-    description: 'Carbon Fiber Chalk weave in a balanced grey palette.',
+    description: 'Carbon fiber weave in a balanced grey palette.',
     thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberChalkGrey
   },
   {
     id: 'finish-carbonFiberChalkBeige',
     type: 'tableFinish',
     optionId: 'carbonFiberChalkBeige',
-    name: 'Carbon Fiber Chalk Beige Finish',
+    name: 'Carbon Fiber Beige Finish',
     price: 1180,
-    description: 'Carbon Fiber Chalk weave with a warm beige tone.',
+    description: 'Carbon fiber weave with a warm beige tone.',
     thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberChalkBeige
   },
   {
     id: 'finish-carbonFiberChalkDarkBlue',
     type: 'tableFinish',
     optionId: 'carbonFiberChalkDarkBlue',
-    name: 'Carbon Fiber Chalk Dark Blue Finish',
+    name: 'Carbon Fiber Dark Blue Finish',
     price: 1190,
-    description: 'Carbon Fiber Chalk weave recolored with dark blue accents.',
+    description: 'Carbon fiber weave recolored with dark blue accents.',
     thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberChalkDarkBlue
   },
   {
     id: 'finish-carbonFiberChalkWhite',
     type: 'tableFinish',
     optionId: 'carbonFiberChalkWhite',
-    name: 'Carbon Fiber Chalk White Finish',
+    name: 'Carbon Fiber White Finish',
     price: 1200,
-    description: 'Carbon Fiber Chalk weave in a clean white finish.',
+    description: 'Carbon fiber weave in a clean white finish.',
     thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberChalkWhite
   },
   {

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -3025,7 +3025,7 @@ const TABLE_FINISHES = Object.freeze({
   }),
   carbonFiberChalk: createStandardWoodFinish({
     id: 'carbonFiberChalk',
-    label: 'Carbon Fiber Chalk',
+    label: 'Carbon Fiber Black',
     rail: 0x1a1f2a,
     base: 0x0c1018,
     trim: 0x374151,
@@ -3034,38 +3034,38 @@ const TABLE_FINISHES = Object.freeze({
   }),
   carbonFiberChalkGrey: createStandardWoodFinish({
     id: 'carbonFiberChalkGrey',
-    label: 'Carbon Fiber Chalk Grey',
+    label: 'Carbon Fiber Grey',
     rail: 0x4b5563,
     base: 0x2f3540,
     trim: 0x9ca3af,
-    woodTextureId: 'carbon_fiber_chalk',
+    woodTextureId: 'carbon_fiber_grey',
     woodRepeatScale: 1
   }),
   carbonFiberChalkBeige: createStandardWoodFinish({
     id: 'carbonFiberChalkBeige',
-    label: 'Carbon Fiber Chalk Beige',
+    label: 'Carbon Fiber Beige',
     rail: 0xb29b82,
     base: 0x8f7a62,
     trim: 0xe5d3b9,
-    woodTextureId: 'carbon_fiber_chalk',
+    woodTextureId: 'carbon_fiber_beige',
     woodRepeatScale: 1
   }),
   carbonFiberChalkDarkBlue: createStandardWoodFinish({
     id: 'carbonFiberChalkDarkBlue',
-    label: 'Carbon Fiber Chalk Dark Blue',
+    label: 'Carbon Fiber Dark Blue',
     rail: 0x1e2b55,
     base: 0x111a33,
     trim: 0x4b5e91,
-    woodTextureId: 'carbon_fiber_chalk',
+    woodTextureId: 'carbon_fiber_dark_blue',
     woodRepeatScale: 1
   }),
   carbonFiberChalkWhite: createStandardWoodFinish({
     id: 'carbonFiberChalkWhite',
-    label: 'Carbon Fiber Chalk White',
+    label: 'Carbon Fiber White',
     rail: 0xeef2f7,
     base: 0xd8dde5,
     trim: 0xffffff,
-    woodTextureId: 'carbon_fiber_chalk',
+    woodTextureId: 'carbon_fiber_white',
     woodRepeatScale: 1
   })
 });

--- a/webapp/src/utils/woodMaterials.js
+++ b/webapp/src/utils/woodMaterials.js
@@ -372,7 +372,13 @@ const makeInlineOakVeneerPattern = ({
   return { mapUrl: colorMap, roughnessMapUrl: roughnessMap, normalMapUrl: null };
 };
 
-const makeInlineCarbonFiberPattern = ({ id }) => {
+const makeInlineCarbonFiberPattern = ({
+  id,
+  base = '#07090f',
+  tile = '#0c111a',
+  weave = '#131926',
+  lineAlpha = 0.04
+}) => {
   if (typeof document !== 'undefined') {
     const canvas = document.createElement('canvas');
     canvas.width = 128;
@@ -380,12 +386,12 @@ const makeInlineCarbonFiberPattern = ({ id }) => {
     const ctx = canvas.getContext('2d');
     if (ctx) {
       // Match Pool Royale chalk carbon-fiber weave exactly (same geometry and tile size).
-      ctx.fillStyle = '#07090f';
+      ctx.fillStyle = base;
       ctx.fillRect(0, 0, canvas.width, canvas.height);
-      ctx.fillStyle = '#0c111a';
+      ctx.fillStyle = tile;
       ctx.fillRect(0, 0, canvas.width / 2, canvas.height / 2);
       ctx.fillRect(canvas.width / 2, canvas.height / 2, canvas.width / 2, canvas.height / 2);
-      ctx.fillStyle = '#131926';
+      ctx.fillStyle = weave;
       ctx.beginPath();
       ctx.moveTo(canvas.width / 2, 0);
       ctx.lineTo(canvas.width, 0);
@@ -399,7 +405,7 @@ const makeInlineCarbonFiberPattern = ({ id }) => {
       ctx.lineTo(canvas.width / 2, canvas.height);
       ctx.closePath();
       ctx.fill();
-      ctx.strokeStyle = 'rgba(255,255,255,0.04)';
+      ctx.strokeStyle = `rgba(255,255,255,${lineAlpha})`;
       ctx.lineWidth = 1;
       for (let i = -canvas.width; i <= canvas.width; i += canvas.width / 4) {
         ctx.beginPath();
@@ -413,11 +419,11 @@ const makeInlineCarbonFiberPattern = ({ id }) => {
   }
   const fallback = svgDataUrl(`
 <svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128">
-  <rect width="128" height="128" fill="#07090f"/>
-  <rect width="64" height="64" fill="#0c111a"/>
-  <rect x="64" y="64" width="64" height="64" fill="#0c111a"/>
-  <path d="M64 0 H128 L0 128 V64 Z" fill="#131926"/>
-  <path d="M128 64 V128 H64 Z" fill="#131926"/>
+  <rect width="128" height="128" fill="${base}"/>
+  <rect width="64" height="64" fill="${tile}"/>
+  <rect x="64" y="64" width="64" height="64" fill="${tile}"/>
+  <path d="M64 0 H128 L0 128 V64 Z" fill="${weave}"/>
+  <path d="M128 64 V128 H64 Z" fill="${weave}"/>
 </svg>`);
   return { mapUrl: fallback, roughnessMapUrl: null, normalMapUrl: null };
 };
@@ -672,6 +678,116 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
       rotation: 0,
       textureSize: 2048,
       ...makeInlineCarbonFiberPattern({ id: 'carbon-chalk-frame' })
+    }
+  }),
+  Object.freeze({
+    id: 'carbon_fiber_grey',
+    label: 'Carbon Fiber Grey',
+    source: 'TonPlaygram custom carbon weave',
+    rail: {
+      repeat: { x: 7.2, y: 7.2 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineCarbonFiberPattern({
+        id: 'carbon-grey',
+        base: '#222831',
+        tile: '#353d48',
+        weave: '#596675'
+      })
+    },
+    frame: {
+      repeat: { x: 7.2, y: 7.2 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineCarbonFiberPattern({
+        id: 'carbon-grey-frame',
+        base: '#222831',
+        tile: '#353d48',
+        weave: '#596675'
+      })
+    }
+  }),
+  Object.freeze({
+    id: 'carbon_fiber_beige',
+    label: 'Carbon Fiber Beige',
+    source: 'TonPlaygram custom carbon weave',
+    rail: {
+      repeat: { x: 7.2, y: 7.2 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineCarbonFiberPattern({
+        id: 'carbon-beige',
+        base: '#6f5f4f',
+        tile: '#8b7763',
+        weave: '#baa286'
+      })
+    },
+    frame: {
+      repeat: { x: 7.2, y: 7.2 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineCarbonFiberPattern({
+        id: 'carbon-beige-frame',
+        base: '#6f5f4f',
+        tile: '#8b7763',
+        weave: '#baa286'
+      })
+    }
+  }),
+  Object.freeze({
+    id: 'carbon_fiber_dark_blue',
+    label: 'Carbon Fiber Dark Blue',
+    source: 'TonPlaygram custom carbon weave',
+    rail: {
+      repeat: { x: 7.2, y: 7.2 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineCarbonFiberPattern({
+        id: 'carbon-dark-blue',
+        base: '#0f1730',
+        tile: '#1d2a50',
+        weave: '#3f5388'
+      })
+    },
+    frame: {
+      repeat: { x: 7.2, y: 7.2 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineCarbonFiberPattern({
+        id: 'carbon-dark-blue-frame',
+        base: '#0f1730',
+        tile: '#1d2a50',
+        weave: '#3f5388'
+      })
+    }
+  }),
+  Object.freeze({
+    id: 'carbon_fiber_white',
+    label: 'Carbon Fiber White',
+    source: 'TonPlaygram custom carbon weave',
+    rail: {
+      repeat: { x: 7.2, y: 7.2 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineCarbonFiberPattern({
+        id: 'carbon-white',
+        base: '#cad2de',
+        tile: '#dde4ee',
+        weave: '#f7f9ff',
+        lineAlpha: 0.08
+      })
+    },
+    frame: {
+      repeat: { x: 7.2, y: 7.2 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlineCarbonFiberPattern({
+        id: 'carbon-white-frame',
+        base: '#cad2de',
+        tile: '#dde4ee',
+        weave: '#f7f9ff',
+        lineAlpha: 0.08
+      })
     }
   })
 ]);


### PR DESCRIPTION
### Motivation
- Ensure carbon-fiber table finishes keep the same weave geometry / texture mapping while allowing each option to render a distinct color variant. 
- Replace the ambiguous "chalk" naming with straightforward `Carbon Fiber` + color names so each option clearly represents a different color variant.

### Description
- Parameterized the inline carbon-fiber generator by extending `makeInlineCarbonFiberPattern` to accept `base`, `tile`, `weave`, and `lineAlpha` so the same tile/geometry is reused while colors vary (`webapp/src/utils/woodMaterials.js`).
- Added dedicated WOOD_GRAIN entries for grey, beige, dark-blue and white carbon-fiber weaves so those finishes no longer share a single texture id (`webapp/src/utils/woodMaterials.js`).
- Updated Pool Royale table finish definitions to reference the new per-color wood texture IDs and removed the word "Chalk" from visible finish labels (now `Carbon Fiber Black/Grey/Beige/Dark Blue/White`) (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Updated inventory/menu/store option labels, store item names and descriptions to match the new naming and color-focused descriptions (`webapp/src/config/poolRoyaleInventoryConfig.js`).

### Testing
- Ran a production build with `npm --prefix webapp run build` and the build completed successfully; only Vite warnings were emitted and no build errors occurred.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0fec4801c8329b16341d09bb08b34)