### PR TITLE
Pool Royale: preserve GLTF wood mapping and update carbon fiber finish variants

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -3025,7 +3025,7 @@ const TABLE_FINISHES = Object.freeze({
   }),
   carbonFiberChalk: createStandardWoodFinish({
     id: 'carbonFiberChalk',
-    label: 'Carbon Fiber Chalk',
+    label: 'Carbon Fiber Graphite',
     rail: 0x1a1f2a,
     base: 0x0c1018,
     trim: 0x374151,
@@ -3034,36 +3034,36 @@ const TABLE_FINISHES = Object.freeze({
   }),
   carbonFiberChalkGrey: createStandardWoodFinish({
     id: 'carbonFiberChalkGrey',
-    label: 'Carbon Fiber Chalk Grey',
-    rail: 0x4b5563,
-    base: 0x2f3540,
-    trim: 0x9ca3af,
+    label: 'Carbon Fiber Slate',
+    rail: 0x5f6b7a,
+    base: 0x3d4652,
+    trim: 0xb8c2cf,
     woodTextureId: 'carbon_fiber_chalk',
     woodRepeatScale: 1
   }),
   carbonFiberChalkBeige: createStandardWoodFinish({
     id: 'carbonFiberChalkBeige',
-    label: 'Carbon Fiber Chalk Beige',
-    rail: 0xb29b82,
-    base: 0x8f7a62,
-    trim: 0xe5d3b9,
+    label: 'Carbon Fiber Sand',
+    rail: 0xc3aa88,
+    base: 0x9b8260,
+    trim: 0xf0dfc2,
     woodTextureId: 'carbon_fiber_chalk',
     woodRepeatScale: 1
   }),
   carbonFiberChalkDarkBlue: createStandardWoodFinish({
     id: 'carbonFiberChalkDarkBlue',
-    label: 'Carbon Fiber Chalk Dark Blue',
-    rail: 0x1e2b55,
-    base: 0x111a33,
-    trim: 0x4b5e91,
+    label: 'Carbon Fiber Navy',
+    rail: 0x243b7a,
+    base: 0x15264e,
+    trim: 0x5e79bf,
     woodTextureId: 'carbon_fiber_chalk',
     woodRepeatScale: 1
   }),
   carbonFiberChalkWhite: createStandardWoodFinish({
     id: 'carbonFiberChalkWhite',
-    label: 'Carbon Fiber Chalk White',
-    rail: 0xeef2f7,
-    base: 0xd8dde5,
+    label: 'Carbon Fiber Ice',
+    rail: 0xf3f6fb,
+    base: 0xe2e8f0,
     trim: 0xffffff,
     woodTextureId: 'carbon_fiber_chalk',
     woodRepeatScale: 1
@@ -12141,33 +12141,38 @@ function applyTableFinishToTable(table, finish) {
       (finishInfo.woodTextureId &&
         WOOD_GRAIN_OPTIONS_BY_ID[finishInfo.woodTextureId]) ||
       defaultWoodOption;
-    const nextFrameSurface = resolveWoodSurfaceConfig(
-      resolvedWoodOption?.frame,
-      woodSurfaces.frame ?? woodSurfaces.rail ?? resolvedWoodOption?.rail ?? {
+    const nextRailSurface = resolveWoodSurfaceConfig(
+      resolvedWoodOption?.rail,
+      woodSurfaces.rail ?? resolvedWoodOption?.frame ?? {
         repeat: { x: 1, y: 1 },
         rotation: 0
       }
     );
+    const nextFrameSurface = resolveWoodSurfaceConfig(
+      resolvedWoodOption?.frame,
+      woodSurfaces.frame ?? nextRailSurface
+    );
     const woodRepeatScale = clampWoodRepeatScaleValue(
       resolvedFinish?.woodRepeatScale ?? finishInfo.woodRepeatScale ?? DEFAULT_WOOD_REPEAT_SCALE
     );
-    const highFpsTextureSize = enforceHighFpsTableTextureSize(nextFrameSurface.textureSize);
+    const highFpsRailTextureSize = enforceHighFpsTableTextureSize(nextRailSurface.textureSize);
+    const highFpsFrameTextureSize = enforceHighFpsTableTextureSize(nextFrameSurface.textureSize);
     const synchronizedRailSurface = {
       repeat: new THREE.Vector2(
-        nextFrameSurface.repeat.x,
-        nextFrameSurface.repeat.y
+        nextRailSurface.repeat.x,
+        nextRailSurface.repeat.y
       ),
-      rotation: nextFrameSurface.rotation,
-      textureSize: highFpsTextureSize,
-      mapUrl: nextFrameSurface.mapUrl,
-      roughnessMapUrl: nextFrameSurface.roughnessMapUrl,
-      normalMapUrl: nextFrameSurface.normalMapUrl,
+      rotation: nextRailSurface.rotation,
+      textureSize: highFpsRailTextureSize,
+      mapUrl: nextRailSurface.mapUrl,
+      roughnessMapUrl: nextRailSurface.roughnessMapUrl,
+      normalMapUrl: nextRailSurface.normalMapUrl,
       woodRepeatScale
     };
     const synchronizedFrameSurface = {
       repeat: new THREE.Vector2(nextFrameSurface.repeat.x, nextFrameSurface.repeat.y),
       rotation: nextFrameSurface.rotation,
-      textureSize: highFpsTextureSize,
+      textureSize: highFpsFrameTextureSize,
       mapUrl: nextFrameSurface.mapUrl,
       roughnessMapUrl: nextFrameSurface.roughnessMapUrl,
       normalMapUrl: nextFrameSurface.normalMapUrl,


### PR DESCRIPTION
### Motivation
- Preserve each table finish's original GLTF wood mapping (repeat, rotation, texture sizing) so finishes render with their intended tiling and geometry instead of forcing rail/frame to share the same mapping. 
- Remove the word "Chalk" from carbon fiber finish names and give each carbon option a distinct color identity so the menu and in-game visuals are clearer and differentiated. 

### Description
- Separated rail and frame surface resolution by introducing `nextRailSurface` and `nextFrameSurface` and using `resolvedWoodOption?.rail` for rails and `resolvedWoodOption?.frame` for frames in `applyTableFinishToTable`, preserving each surface's `repeat`, `rotation`, and `textureSize` when applying finishes. 
- Applied separate high-FPS texture sizing for rails and frames with `highFpsRailTextureSize` and `highFpsFrameTextureSize`, and used `nextRailSurface` for `synchronizedRailSurface` and `nextFrameSurface` for `synchronizedFrameSurface` so the GLTF UV mapping is preserved. 
- Renamed carbon fiber finishes to remove "Chalk" and use color-based labels (`Carbon Fiber Graphite`, `Carbon Fiber Slate`, `Carbon Fiber Sand`, `Carbon Fiber Navy`, `Carbon Fiber Ice`) and adjusted their `rail`, `base`, and `trim` color values to make each variant visually distinct. 
- Changed code only in `webapp/src/pages/Games/PoolRoyale.jsx` and kept the underlying `woodTextureId` (`carbon_fiber_chalk`) so the same carbon weave asset is reused while mapping and palette differ per option. 

### Testing
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx`, which completed with no errors but the file is ignored by the repo's ESLint ignore patterns so a warning was reported. 
- Ran `git diff --check` to detect whitespace/errors and it returned no issues. 
- No runtime/visual automated tests were available in this environment; visual verification should be done in-game to confirm GLTF mapping and color differences.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0fec4801c8329b16341d09bb08b34)