### PR TITLE
Pool Royale: preserve PolyHaven finishes, make carbon finishes solid, equalize topspin, and harden replay startup

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -400,11 +400,11 @@ export const POOL_ROYALE_OPTION_LABELS = Object.freeze({
     woodTable001: 'Wood Table 001',
     darkWood: 'Dark Wood',
     rosewoodVeneer01: 'Rosewood Veneer 01',
-    carbonFiberChalk: 'Carbon Fiber Chalk',
-    carbonFiberChalkGrey: 'Carbon Fiber Chalk Grey',
-    carbonFiberChalkBeige: 'Carbon Fiber Chalk Beige',
-    carbonFiberChalkDarkBlue: 'Carbon Fiber Chalk Dark Blue',
-    carbonFiberChalkWhite: 'Carbon Fiber Chalk White'
+    carbonFiberChalk: 'Graphite',
+    carbonFiberChalkGrey: 'Slate',
+    carbonFiberChalkBeige: 'Sand',
+    carbonFiberChalkDarkBlue: 'Navy',
+    carbonFiberChalkWhite: 'Ice'
   }),
   chromeColor: Object.freeze({
     chrome: 'Chrome',
@@ -496,45 +496,45 @@ export const POOL_ROYALE_STORE_ITEMS = [
     id: 'finish-carbonFiberChalk',
     type: 'tableFinish',
     optionId: 'carbonFiberChalk',
-    name: 'Carbon Fiber Chalk Finish',
+    name: 'Graphite Finish',
     price: 1160,
-    description: 'Custom carbon weave inspired by the chalk block pattern.',
+    description: 'Solid graphite finish with the same material roughness response.',
     thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberChalk
   },
   {
     id: 'finish-carbonFiberChalkGrey',
     type: 'tableFinish',
     optionId: 'carbonFiberChalkGrey',
-    name: 'Carbon Fiber Chalk Grey Finish',
+    name: 'Slate Finish',
     price: 1170,
-    description: 'Carbon Fiber Chalk weave in a balanced grey palette.',
+    description: 'Solid slate finish with the same material roughness response.',
     thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberChalkGrey
   },
   {
     id: 'finish-carbonFiberChalkBeige',
     type: 'tableFinish',
     optionId: 'carbonFiberChalkBeige',
-    name: 'Carbon Fiber Chalk Beige Finish',
+    name: 'Sand Finish',
     price: 1180,
-    description: 'Carbon Fiber Chalk weave with a warm beige tone.',
+    description: 'Solid sand finish with the same material roughness response.',
     thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberChalkBeige
   },
   {
     id: 'finish-carbonFiberChalkDarkBlue',
     type: 'tableFinish',
     optionId: 'carbonFiberChalkDarkBlue',
-    name: 'Carbon Fiber Chalk Dark Blue Finish',
+    name: 'Navy Finish',
     price: 1190,
-    description: 'Carbon Fiber Chalk weave recolored with dark blue accents.',
+    description: 'Solid navy finish with the same material roughness response.',
     thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberChalkDarkBlue
   },
   {
     id: 'finish-carbonFiberChalkWhite',
     type: 'tableFinish',
     optionId: 'carbonFiberChalkWhite',
-    name: 'Carbon Fiber Chalk White Finish',
+    name: 'Ice Finish',
     price: 1200,
-    description: 'Carbon Fiber Chalk weave in a clean white finish.',
+    description: 'Solid ice finish with the same material roughness response.',
     thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberChalkWhite
   },
   {

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1955,7 +1955,7 @@ const SPIN_TIP_MARGIN = CUE_TIP_RADIUS * 1.35;
 const SPIN_GLOBAL_BOOST_MULTIPLIER = 1.28;
 const SIDE_SPIN_MULTIPLIER = 1.78 * SPIN_GLOBAL_BOOST_MULTIPLIER;
 const BACKSPIN_MULTIPLIER = 2.72 * SPIN_GLOBAL_BOOST_MULTIPLIER;
-const TOPSPIN_MULTIPLIER = 1.74 * SPIN_GLOBAL_BOOST_MULTIPLIER;
+const TOPSPIN_MULTIPLIER = BACKSPIN_MULTIPLIER;
 const CUE_CLEARANCE_PADDING = BALL_R * 0.05;
 const SPIN_CONTROL_DIAMETER_PX = 124;
 const SPIN_DOT_DIAMETER_PX = 16;
@@ -3025,48 +3025,53 @@ const TABLE_FINISHES = Object.freeze({
   }),
   carbonFiberChalk: createStandardWoodFinish({
     id: 'carbonFiberChalk',
-    label: 'Carbon Fiber Graphite',
+    label: 'Graphite',
     rail: 0x1a1f2a,
     base: 0x0c1018,
     trim: 0x374151,
     woodTextureId: 'carbon_fiber_chalk',
-    woodRepeatScale: 1
+    woodRepeatScale: 1,
+    disableWoodPattern: true
   }),
   carbonFiberChalkGrey: createStandardWoodFinish({
     id: 'carbonFiberChalkGrey',
-    label: 'Carbon Fiber Slate',
+    label: 'Slate',
     rail: 0x5f6b7a,
     base: 0x3d4652,
     trim: 0xb8c2cf,
     woodTextureId: 'carbon_fiber_chalk',
-    woodRepeatScale: 1
+    woodRepeatScale: 1,
+    disableWoodPattern: true
   }),
   carbonFiberChalkBeige: createStandardWoodFinish({
     id: 'carbonFiberChalkBeige',
-    label: 'Carbon Fiber Sand',
+    label: 'Sand',
     rail: 0xc3aa88,
     base: 0x9b8260,
     trim: 0xf0dfc2,
     woodTextureId: 'carbon_fiber_chalk',
-    woodRepeatScale: 1
+    woodRepeatScale: 1,
+    disableWoodPattern: true
   }),
   carbonFiberChalkDarkBlue: createStandardWoodFinish({
     id: 'carbonFiberChalkDarkBlue',
-    label: 'Carbon Fiber Navy',
+    label: 'Navy',
     rail: 0x243b7a,
     base: 0x15264e,
     trim: 0x5e79bf,
     woodTextureId: 'carbon_fiber_chalk',
-    woodRepeatScale: 1
+    woodRepeatScale: 1,
+    disableWoodPattern: true
   }),
   carbonFiberChalkWhite: createStandardWoodFinish({
     id: 'carbonFiberChalkWhite',
-    label: 'Carbon Fiber Ice',
+    label: 'Ice',
     rail: 0xf3f6fb,
     base: 0xe2e8f0,
     trim: 0xffffff,
     woodTextureId: 'carbon_fiber_chalk',
-    woodRepeatScale: 1
+    woodRepeatScale: 1,
+    disableWoodPattern: true
   })
 });
 
@@ -6021,18 +6026,18 @@ const DEFAULT_SPIN_LIMITS = Object.freeze({
   minY: -1,
   maxY: 1
 });
-const MAX_TOPSPIN_INPUT = 0.92; // increase topspin cap so follow-through carries farther after contact
+const MAX_TOPSPIN_INPUT = 1; // allow full topspin input so forward spin can match draw strength
 const TOPSPIN_FOLLOW_TRANSFER_RATE = 0.52; // stronger transfer keeps forward roll alive longer for clearer follow-through
 const TOPSPIN_FOLLOW_DECAY_ASSIST = 0.84; // once natural roll forms, bleed residual topspin faster so forward spin settles like a real table
 const TOPSPIN_ROLL_SPEED_FACTOR = 0.84; // cap follow acceleration toward natural rolling speed to avoid endless forward "motor" behavior
-const TOPSPIN_POWER_SOFT_CAP = 0.9;
+const TOPSPIN_POWER_SOFT_CAP = 1;
 const clampSpinValue = (value) => clamp(value, -1, 1);
 const SPIN_CUSHION_EPS = BALL_R * 0.6;
 const SPIN_VIEW_BLOCK_THRESHOLD = 0.12;
 
 const resolveTopspinPowerScale = (power) => {
   if (!Number.isFinite(power)) return 0.55 + TOPSPIN_POWER_SOFT_CAP * 0.45;
-  const cappedPower = Math.min(power, TOPSPIN_POWER_SOFT_CAP);
+  const cappedPower = THREE.MathUtils.clamp(power, 0, TOPSPIN_POWER_SOFT_CAP);
   return 0.55 + cappedPower * 0.45;
 };
 
@@ -8022,11 +8027,18 @@ export function Table3D(
     resolvedWoodOption?.frame,
     resolvedWoodOption?.rail ?? defaultWoodOption.frame ?? defaultWoodOption.rail
   );
-  const synchronizedTextureSize = Math.max(
-    initialFrameSurface.textureSize ?? DEFAULT_WOOD_TEXTURE_SIZE,
-    getRuntimeCueTextureSize()
-  );
-  const finalWoodTextureSize = enforceHighFpsTableTextureSize(synchronizedTextureSize);
+  const usesPolyHavenWoodMaps =
+    typeof initialFrameSurface.mapUrl === 'string' &&
+    initialFrameSurface.mapUrl.includes('polyhaven.org');
+  const synchronizedTextureSize = usesPolyHavenWoodMaps
+    ? (initialFrameSurface.textureSize ?? DEFAULT_WOOD_TEXTURE_SIZE)
+    : Math.max(
+        initialFrameSurface.textureSize ?? DEFAULT_WOOD_TEXTURE_SIZE,
+        getRuntimeCueTextureSize()
+      );
+  const finalWoodTextureSize = usesPolyHavenWoodMaps
+    ? synchronizedTextureSize
+    : enforceHighFpsTableTextureSize(synchronizedTextureSize);
   const synchronizedRailSurface = {
     repeat: new THREE.Vector2(
       initialFrameSurface.repeat.x,
@@ -8052,12 +8064,22 @@ export function Table3D(
     woodRepeatScale
   };
 
-  applyWoodTextureToMaterial(railMat, synchronizedRailSurface);
-  applyWoodTextureToMaterial(frameMat, synchronizedFrameSurface);
-  if (legMat !== frameMat) {
-    applyWoodTextureToMaterial(legMat, {
-      ...synchronizedFrameSurface
+  if (resolvedFinish?.disableWoodPattern) {
+    [railMat, frameMat, legMat].forEach((mat) => {
+      if (!mat) return;
+      mat.map = null;
+      mat.normalMap = null;
+      mat.roughnessMap = null;
+      mat.needsUpdate = true;
     });
+  } else {
+    applyWoodTextureToMaterial(railMat, synchronizedRailSurface);
+    applyWoodTextureToMaterial(frameMat, synchronizedFrameSurface);
+    if (legMat !== frameMat) {
+      applyWoodTextureToMaterial(legMat, {
+        ...synchronizedFrameSurface
+      });
+    }
   }
   [railMat, frameMat, legMat].forEach((mat) => {
     applyTableFinishDulling(mat);
@@ -21535,8 +21557,10 @@ const powerRef = useRef(hud.power);
 
         const applyReplayFrame = (frameA, frameB, alpha) => {
           if (!frameA) return false;
-          const aMap = new Map(frameA.balls.map((entry) => [entry.id, entry]));
-          const bMap = frameB ? new Map(frameB.balls.map((entry) => [entry.id, entry])) : null;
+          const frameABalls = Array.isArray(frameA.balls) ? frameA.balls : [];
+          const frameBBalls = Array.isArray(frameB?.balls) ? frameB.balls : frameABalls;
+          const aMap = new Map(frameABalls.map((entry) => [entry.id, entry]));
+          const bMap = new Map(frameBBalls.map((entry) => [entry.id, entry]));
           balls.forEach((ball) => {
             const aState = aMap.get(ball.id);
             if (!aState) return;
@@ -22425,7 +22449,15 @@ const powerRef = useRef(hud.power);
 
         const startShotReplay = (postShotSnapshot) => {
           if (replayPlaybackRef.current) return;
-          if (!shotRecording || !shotRecording.frames?.length) return;
+          if (!shotRecording) return;
+          if (!Array.isArray(shotRecording.frames) || shotRecording.frames.length === 0) {
+            const startState = Array.isArray(shotRecording.startState) ? shotRecording.startState : captureBallSnapshot();
+            const endState = Array.isArray(postShotSnapshot) ? postShotSnapshot : captureBallSnapshot();
+            shotRecording.frames = [
+              { t: 0, balls: startState },
+              { t: Math.max(16, shotRecording.frameTimeMs ?? 1000 / 60), balls: endState }
+            ];
+          }
           const trimmed = trimReplayRecording(shotRecording);
           const duration = trimmed.duration;
           if (!Number.isFinite(duration) || duration <= 0) return;

--- a/webapp/src/utils/woodMaterials.js
+++ b/webapp/src/utils/woodMaterials.js
@@ -526,13 +526,13 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
     label: 'Rosewood Veneer 01',
     source: 'Poly Haven — Rosewood Veneer 01 (CC0)',
     rail: {
-      repeat: { x: 0.7, y: 0.7 }, // enlarge the veneer grain for the rails
+      repeat: { x: 1, y: 1 },
       rotation: 0,
       textureSize: 2048,
       ...polyHavenTextureSet('rosewood_veneer_01')
     },
     frame: {
-      repeat: { x: 0.72, y: 0.72 }, // slightly finer than rails to balance the border scale
+      repeat: { x: 1, y: 1 },
       rotation: 0,
       textureSize: 2048,
       ...polyHavenTextureSet('rosewood_veneer_01')
@@ -659,19 +659,17 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
   }),
   Object.freeze({
     id: 'carbon_fiber_chalk',
-    label: 'Carbon Fiber Chalk Pattern',
-    source: 'TonPlaygram custom carbon weave',
+    label: 'Solid Color Finish',
+    source: 'TonPlaygram solid-color finish',
     rail: {
-      repeat: { x: 7.2, y: 7.2 },
+      repeat: { x: 1, y: 1 },
       rotation: 0,
-      textureSize: 2048,
-      ...makeInlineCarbonFiberPattern({ id: 'carbon-chalk' })
+      textureSize: 2048
     },
     frame: {
-      repeat: { x: 7.2, y: 7.2 },
+      repeat: { x: 1, y: 1 },
       rotation: 0,
-      textureSize: 2048,
-      ...makeInlineCarbonFiberPattern({ id: 'carbon-chalk-frame' })
+      textureSize: 2048
     }
   })
 ]);


### PR DESCRIPTION
### Motivation
- Align table finish rendering with original PolyHaven assets and in-game graphics options by preserving original texture resolution and UV mapping for PolyHaven glTF textures. 
- Provide single-colour carbon finishes (no visible weave/pattern) while preserving material roughness to match menu swatches and naming. 
- Make forward topspin (follow) produce the same effective forward rolling power as backspin (draw). 
- Ensure replay playback reliably starts instead of only showing banners when recording frames are missing or malformed.

### Description
- Preserved PolyHaven texture mapping/resolution by skipping runtime upscaling for PolyHaven wood maps in `Table3D` and related texture sync logic (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Added a `disableWoodPattern` finish flag and conditional branch in `Table3D` to remove `map`/`normalMap`/`roughnessMap` when a finish requests a solid colour, while keeping roughness and other material properties intact (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Renamed the five carbon variants and updated inventory/store labels and descriptions to remove the "Carbon Fiber" prefix and reflect single-colour finishes (`webapp/src/config/poolRoyaleInventoryConfig.js`).
- Converted the inline carbon pattern entry to a solid-color wood option and set repeat to `1x1` for these picks in the wood catalogue (`webapp/src/utils/woodMaterials.js`).
- Equalized topspin behaviour by allowing full topspin input (`MAX_TOPSPIN_INPUT = 1`), removing the earlier soft cap, and setting `TOPSPIN_MULTIPLIER` to match `BACKSPIN_MULTIPLIER`, plus clamping logic adjustments in `resolveTopspinPowerScale` (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Hardened replay startup and playback: added guards so `applyReplayFrame` handles missing/invalid `balls` arrays safely and `startShotReplay` builds a minimal fallback `frames` sequence when `shotRecording.frames` is empty, preventing silent failures when attempting to start a replay (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Normalized repeat mapping for `rosewood_veneer_01` to `1x1` to keep PolyHaven-based finishes consistent with their original mapping (`webapp/src/utils/woodMaterials.js`).

### Testing
- Ran the targeted unit tests: `npm test -- --runInBand test/poolRoyaleSpinController.test.js test/poolRoyaleTrainingProgress.test.js`, and both suites passed. (2 test suites, 14 tests passed.)
- No additional automated rendering or end-to-end visual tests were available in this environment; the change includes defensive fallbacks to improve runtime reliability for replay and texture loading.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1080d1d3c8329b81cf2fbef75d88a)