### PR TITLE
Match Pool Royale table wood pattern to cue and tune solid-color finish colors

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1980,7 +1980,7 @@ const CUSHION_FACE_INSET_SHORT = SIDE_RAIL_INNER_THICKNESS * 0.44; // move short
 const CUE_WOOD_REPEAT = new THREE.Vector2(0.08 / 3 * 0.7, 0.44 / 3 * 0.7); // Match cue grain scale to the table finish
 const CUE_WOOD_REPEAT_SCALE = 1 / 9; // enlarge cue wood grain 3× so the pattern reads more clearly at table scale
 const CUE_WOOD_TEXTURE_SIZE = 4096; // 4k cue textures for sharper cue wood finish
-const TABLE_WOOD_REPEAT = new THREE.Vector2(0.08 / 3 * 0.7 * 5, 0.44 / 3 * 0.7 * 5); // tighten finish grain further so rails read crisper on portrait screens
+const TABLE_WOOD_REPEAT = new THREE.Vector2(CUE_WOOD_REPEAT.x, CUE_WOOD_REPEAT.y); // match table GLTF wood pattern scale to cue finish pattern size
 const FIXED_WOOD_REPEAT_SCALE = 1; // restore the original per-texture scale without inflating the grain
 const WOOD_REPEAT_SCALE_MIN = 0.5;
 const WOOD_REPEAT_SCALE_MAX = 2;
@@ -3026,9 +3026,9 @@ const TABLE_FINISHES = Object.freeze({
   carbonFiberChalk: createStandardWoodFinish({
     id: 'carbonFiberChalk',
     label: 'Graphite',
-    rail: 0x1a1f2a,
-    base: 0x0c1018,
-    trim: 0x374151,
+    rail: 0x3a3f46,
+    base: 0x23272e,
+    trim: 0x545b66,
     woodTextureId: 'carbon_fiber_chalk',
     woodRepeatScale: 1,
     disableWoodPattern: true
@@ -3036,9 +3036,9 @@ const TABLE_FINISHES = Object.freeze({
   carbonFiberChalkGrey: createStandardWoodFinish({
     id: 'carbonFiberChalkGrey',
     label: 'Slate',
-    rail: 0x5f6b7a,
-    base: 0x3d4652,
-    trim: 0xb8c2cf,
+    rail: 0x708090,
+    base: 0x556170,
+    trim: 0xadb8c5,
     woodTextureId: 'carbon_fiber_chalk',
     woodRepeatScale: 1,
     disableWoodPattern: true
@@ -3046,9 +3046,9 @@ const TABLE_FINISHES = Object.freeze({
   carbonFiberChalkBeige: createStandardWoodFinish({
     id: 'carbonFiberChalkBeige',
     label: 'Sand',
-    rail: 0xc3aa88,
-    base: 0x9b8260,
-    trim: 0xf0dfc2,
+    rail: 0xd2b48c,
+    base: 0xb89568,
+    trim: 0xf1dec0,
     woodTextureId: 'carbon_fiber_chalk',
     woodRepeatScale: 1,
     disableWoodPattern: true
@@ -3056,9 +3056,9 @@ const TABLE_FINISHES = Object.freeze({
   carbonFiberChalkDarkBlue: createStandardWoodFinish({
     id: 'carbonFiberChalkDarkBlue',
     label: 'Navy',
-    rail: 0x243b7a,
-    base: 0x15264e,
-    trim: 0x5e79bf,
+    rail: 0x1f3a6d,
+    base: 0x16294d,
+    trim: 0x4f6da3,
     woodTextureId: 'carbon_fiber_chalk',
     woodRepeatScale: 1,
     disableWoodPattern: true
@@ -3066,9 +3066,9 @@ const TABLE_FINISHES = Object.freeze({
   carbonFiberChalkWhite: createStandardWoodFinish({
     id: 'carbonFiberChalkWhite',
     label: 'Ice',
-    rail: 0xf3f6fb,
-    base: 0xe2e8f0,
-    trim: 0xffffff,
+    rail: 0xeaf4ff,
+    base: 0xdbe7f5,
+    trim: 0xf8fcff,
     woodTextureId: 'carbon_fiber_chalk',
     woodRepeatScale: 1,
     disableWoodPattern: true


### PR DESCRIPTION
### Motivation
- Ensure GLTF table wood patterns read at the same visible scale as the cue-stick wood grain so table finishes visually match cue finishes in-game.
- Bring solid-color table finishes (Graphite/Slate/Sand/Navy/Ice) into closer agreement with their menu labels by adjusting rail/base/trim tones.

### Description
- Changed the table wood pattern repeat so the table GLTF wood pattern uses the cue wood pattern scale by setting `TABLE_WOOD_REPEAT` to match `CUE_WOOD_REPEAT` in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Tuned the rail/base/trim colors for the solid-color finishes `carbonFiberChalk` (Graphite), `carbonFiberChalkGrey` (Slate), `carbonFiberChalkBeige` (Sand), `carbonFiberChalkDarkBlue` (Navy), and `carbonFiberChalkWhite` (Ice) in `webapp/src/pages/Games/PoolRoyale.jsx` to better match the appearance implied by their names.
- This is a visual-only update to material parameters and texture-repeat behavior; no gameplay logic was changed.

### Testing
- Ran `npm test -- --runInBand test/poolRoyalInventoryRoutes.test.js` and the suite passed (`1 passed`).
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx` which produced a file-ignore warning from the lint configuration and no reported errors for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d10d5ca17483298d430986fe4dbbaf)