### PR TITLE
Match Pool Royale table finish pattern to cue stick and adjust solid finish colors

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -298,9 +298,9 @@ const TABLE_FINISH_THUMBNAILS = Object.freeze({
   darkWood: polyHavenThumb('dark_wood'),
   rosewoodVeneer01: polyHavenThumb('rosewood_veneer_01'),
   carbonFiberChalk: swatchThumbnail(['#0c1018', '#1a1f2a', '#374151']),
-  carbonFiberChalkGrey: swatchThumbnail(['#2f3540', '#4b5563', '#9ca3af']),
+  carbonFiberChalkGrey: swatchThumbnail(['#454c56', '#606975', '#a9b1bc']),
   carbonFiberChalkBeige: swatchThumbnail(['#8f7a62', '#b29b82', '#e5d3b9']),
-  carbonFiberChalkDarkBlue: swatchThumbnail(['#111a33', '#1e2b55', '#4b5e91']),
+  carbonFiberChalkDarkBlue: swatchThumbnail(['#13264d', '#1f3a70', '#4b67a3']),
   carbonFiberChalkWhite: swatchThumbnail(['#d8dde5', '#eef2f7', '#ffffff'])
 });
 

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1980,7 +1980,7 @@ const CUSHION_FACE_INSET_SHORT = SIDE_RAIL_INNER_THICKNESS * 0.44; // move short
 const CUE_WOOD_REPEAT = new THREE.Vector2(0.08 / 3 * 0.7, 0.44 / 3 * 0.7); // Match cue grain scale to the table finish
 const CUE_WOOD_REPEAT_SCALE = 1 / 9; // enlarge cue wood grain 3× so the pattern reads more clearly at table scale
 const CUE_WOOD_TEXTURE_SIZE = 4096; // 4k cue textures for sharper cue wood finish
-const TABLE_WOOD_REPEAT = new THREE.Vector2(0.08 / 3 * 0.7 * 5, 0.44 / 3 * 0.7 * 5); // tighten finish grain further so rails read crisper on portrait screens
+const TABLE_WOOD_REPEAT = CUE_WOOD_REPEAT.clone(); // keep table wood pattern density equal to cue-finish pattern density
 const FIXED_WOOD_REPEAT_SCALE = 1; // restore the original per-texture scale without inflating the grain
 const WOOD_REPEAT_SCALE_MIN = 0.5;
 const WOOD_REPEAT_SCALE_MAX = 2;
@@ -3036,9 +3036,9 @@ const TABLE_FINISHES = Object.freeze({
   carbonFiberChalkGrey: createStandardWoodFinish({
     id: 'carbonFiberChalkGrey',
     label: 'Slate',
-    rail: 0x5f6b7a,
-    base: 0x3d4652,
-    trim: 0xb8c2cf,
+    rail: 0x606975,
+    base: 0x454c56,
+    trim: 0xa9b1bc,
     woodTextureId: 'carbon_fiber_chalk',
     woodRepeatScale: 1,
     disableWoodPattern: true
@@ -3056,9 +3056,9 @@ const TABLE_FINISHES = Object.freeze({
   carbonFiberChalkDarkBlue: createStandardWoodFinish({
     id: 'carbonFiberChalkDarkBlue',
     label: 'Navy',
-    rail: 0x243b7a,
-    base: 0x15264e,
-    trim: 0x5e79bf,
+    rail: 0x1f3a70,
+    base: 0x13264d,
+    trim: 0x4b67a3,
     woodTextureId: 'carbon_fiber_chalk',
     woodRepeatScale: 1,
     disableWoodPattern: true


### PR DESCRIPTION
### Motivation
- Ensure the GLTF table finish pattern density matches the cue-stick finish so wood grain reads consistently between cue view and table rails. 
- Make single-color (solid) table finishes visually match their menu/swatch names so thumbnails and in-game rail/base/trim colors are consistent.

### Description
- Use the cue wood repeat vector for table finishes by setting `TABLE_WOOD_REPEAT = CUE_WOOD_REPEAT.clone()` in `webapp/src/pages/Games/PoolRoyale.jsx` so table pattern density equals cue-finish density. 
- Tweak the `rail`, `base`, and `trim` hex values for the `Slate` (`carbonFiberChalkGrey`) and `Navy` (`carbonFiberChalkDarkBlue`) solid finishes in `webapp/src/pages/Games/PoolRoyale.jsx` so their in-game appearance better matches their names. 
- Update the corresponding store/menu swatch thumbnails in `webapp/src/config/poolRoyaleInventoryConfig.js` for `carbonFiberChalkGrey` and `carbonFiberChalkDarkBlue` so thumbnails reflect the adjusted colors.

### Testing
- Ran lint on the modified files with `npx eslint webapp/src/pages/Games/PoolRoyale.jsx webapp/src/config/poolRoyaleInventoryConfig.js`, which completed with exit code `0` and produced warnings that the files are ignored by repo lint-ignore patterns and a React-version detection warning; no lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d10d5ca17483298d430986fe4dbbaf)