### PR TITLE
fix(pool-royale): preserve polyhaven table finish mapping and solid finishes

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2906,7 +2906,8 @@ const createStandardWoodFinish = ({
   trim,
   accent,
   woodTextureId,
-  woodRepeatScale
+  woodRepeatScale,
+  disableWoodPattern = false
 }) => ({
   id,
   label,
@@ -2918,6 +2919,7 @@ const createStandardWoodFinish = ({
   }),
   woodTextureId,
   woodRepeatScale,
+  disableWoodPattern,
   createMaterials: () => {
     const frameColor = new THREE.Color(base);
     const railColor = new THREE.Color(rail);
@@ -7957,9 +7959,8 @@ export function Table3D(
       : (typeof finish === 'string' && TABLE_FINISHES[finish]) ||
         (finish?.id && TABLE_FINISHES[finish.id]) ||
         TABLE_FINISHES[DEFAULT_TABLE_FINISH_ID];
-  const cueRepeatScale = resolvedFinish?.id === 'peelingPaintWeathered' ? 1 : CUE_WOOD_REPEAT_SCALE;
   const woodRepeatScale = clampWoodRepeatScaleValue(
-    (resolvedFinish?.woodRepeatScale ?? DEFAULT_WOOD_REPEAT_SCALE) * cueRepeatScale
+    resolvedFinish?.woodRepeatScale ?? DEFAULT_WOOD_REPEAT_SCALE
   );
   const clothTextureKey =
     resolvedFinish?.clothTextureKey ?? DEFAULT_CLOTH_TEXTURE_KEY;


### PR DESCRIPTION
### Motivation
- Poly Haven wood finishes should retain their original UV / texture mapping density so table finishes look authentic. 
- Solid-color / carbon-fiber finishes must be able to disable the wood pattern so they render as a single color matching their names.

### Description
- Preserve the `disableWoodPattern` flag on finishes created with `createStandardWoodFinish` so solid-color finishes render without wood/carbon pattern textures (changed in `webapp/src/pages/Games/PoolRoyale.jsx`).
- Stop applying the cue-only repeat scaling when computing table `woodRepeatScale` in `Table3D`, so Poly Haven table finishes keep their original mapping density instead of being rescaled (changed in `webapp/src/pages/Games/PoolRoyale.jsx`).
- The change is limited to `webapp/src/pages/Games/PoolRoyale.jsx` and keeps existing default behavior for finishes that don't provide overrides.

### Testing
- Ran the production build with `npm -C webapp run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d12037b860832983398112b0d3a22f)