### PR TITLE
Preserve GLTF chair texture mapping in Ludo Battle Royal

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -894,7 +894,50 @@ function createConfiguredGLTFLoader(renderer = null) {
   return loader;
 }
 
-function prepareLoadedModel(model) {
+function normalizePbrTexture(texture, maxAnisotropy = 1, { preserveWrapping = false } = {}) {
+  if (!texture) return;
+  texture.flipY = false;
+  if (!preserveWrapping) {
+    texture.wrapS = texture.wrapS ?? THREE.RepeatWrapping;
+    texture.wrapT = texture.wrapT ?? THREE.RepeatWrapping;
+  }
+  texture.anisotropy = Math.max(texture.anisotropy ?? 1, maxAnisotropy);
+  texture.needsUpdate = true;
+}
+
+function normalizeMaterialTextures(
+  material,
+  maxAnisotropy = 8,
+  { preserveGltfTextureMapping = false } = {}
+) {
+  if (!material) return;
+  if (material.map) {
+    applySRGBColorSpace(material.map);
+    normalizePbrTexture(material.map, maxAnisotropy, {
+      preserveWrapping: preserveGltfTextureMapping
+    });
+  }
+  if (material.emissiveMap) {
+    applySRGBColorSpace(material.emissiveMap);
+    normalizePbrTexture(material.emissiveMap, maxAnisotropy, {
+      preserveWrapping: preserveGltfTextureMapping
+    });
+  }
+  normalizePbrTexture(material.normalMap, maxAnisotropy, {
+    preserveWrapping: preserveGltfTextureMapping
+  });
+  normalizePbrTexture(material.roughnessMap, maxAnisotropy, {
+    preserveWrapping: preserveGltfTextureMapping
+  });
+  normalizePbrTexture(material.metalnessMap, maxAnisotropy, {
+    preserveWrapping: preserveGltfTextureMapping
+  });
+  normalizePbrTexture(material.aoMap, maxAnisotropy, {
+    preserveWrapping: preserveGltfTextureMapping
+  });
+}
+
+function prepareLoadedModel(model, { preserveGltfTextureMapping = false } = {}) {
   if (!model) return;
   model.traverse((obj) => {
     if (obj.isMesh) {
@@ -902,9 +945,10 @@ function prepareLoadedModel(model) {
       obj.receiveShadow = true;
       const mats = Array.isArray(obj.material) ? obj.material : [obj.material];
       mats.forEach((mat) => {
-        if (!mat) return;
-        if (mat.map) applySRGBColorSpace(mat.map);
-        if (mat.emissiveMap) applySRGBColorSpace(mat.emissiveMap);
+        normalizeMaterialTextures(mat, 8, { preserveGltfTextureMapping });
+        if (mat) {
+          mat.needsUpdate = true;
+        }
       });
     }
   });
@@ -1013,7 +1057,7 @@ async function loadPolyhavenModel(assetId, renderer = null) {
         const gltf = await loader.loadAsync(resolvedUrl);
         const root = gltf.scene || gltf.scenes?.[0] || gltf;
         if (root) {
-          prepareLoadedModel(root);
+          prepareLoadedModel(root, { preserveGltfTextureMapping: true });
           return root;
         }
       } catch (error) {
@@ -1045,15 +1089,6 @@ async function loadTexture(textureLoader, url, isColor, maxAnisotropy = 1) {
       () => reject(new Error('texture load failed'))
     );
   });
-}
-
-function normalizePbrTexture(texture, maxAnisotropy = 1) {
-  if (!texture) return;
-  texture.flipY = false;
-  texture.wrapS = texture.wrapS ?? THREE.RepeatWrapping;
-  texture.wrapT = texture.wrapT ?? THREE.RepeatWrapping;
-  texture.anisotropy = Math.max(texture.anisotropy ?? 1, maxAnisotropy);
-  texture.needsUpdate = true;
 }
 
 async function loadPolyhavenTextureSet(
@@ -1236,7 +1271,7 @@ async function createPolyhavenInstance(
 ) {
   const root = await loadPolyhavenModel(assetId, renderer);
   const model = root.clone ? root.clone(true) : root;
-  prepareLoadedModel(model);
+  prepareLoadedModel(model, { preserveGltfTextureMapping: true });
   const {
     textureLoader = null,
     maxAnisotropy = 1,


### PR DESCRIPTION
### Motivation
- Chair models from Poly Haven were having their original GLTF texture mapping/wrapping overridden, producing incorrect appearances in the Ludo Battle Royal arena. 
- The goal is to reuse the same texture-preservation approach used for other arenas (e.g. Texas Hold'em) so Poly Haven chair assets keep their original UV/wraps and scans.

### Description
- Added `normalizePbrTexture(...)` with a `preserveWrapping` option and a `normalizeMaterialTextures(...)` helper to centralize PBR texture normalization. 
- Reworked `prepareLoadedModel` to accept `{ preserveGltfTextureMapping }` and to call `normalizeMaterialTextures` for base/emissive/normal/roughness/metalness/ao maps and set `mat.needsUpdate`.
- Ensured Poly Haven model loading and cloned instancing call `prepareLoadedModel(..., { preserveGltfTextureMapping: true })` by updating `loadPolyhavenModel` and `createPolyhavenInstance` so chair GLTFs retain original mapping.
- Changes made to `webapp/src/pages/Games/LudoBattleRoyal.jsx` to align behavior with other arenas and to avoid forcing `RepeatWrapping` when the GLTF intends a specific wrap/UV layout.

### Testing
- Ran `npm run lint -- webapp/src/pages/Games/LudoBattleRoyal.jsx` which completed with no lint errors (project produced an ignored-file warning but no errors). 
- Ran `npx eslint webapp/src/pages/Games/LudoBattleRoyal.jsx` and `npx eslint --no-ignore webapp/src/pages/Games/LudoBattleRoyal.jsx`, both completed with the same ignored-file warning and no errors.
- No automated runtime rendering tests were available in CI for this change; only static lint checks were executed and passed (warnings only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d120d637208329a1ec400450f861a5)