### PR TITLE
Preserve PolyHaven chair GLTF texture mapping in Ludo Battle Royal

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -894,7 +894,24 @@ function createConfiguredGLTFLoader(renderer = null) {
   return loader;
 }
 
-function prepareLoadedModel(model) {
+function normalizeMaterialTextures(material, maxAnisotropy = 1) {
+  if (!material) return;
+  if (material.map) {
+    applySRGBColorSpace(material.map);
+    normalizePbrTexture(material.map, maxAnisotropy);
+  }
+  if (material.emissiveMap) {
+    applySRGBColorSpace(material.emissiveMap);
+    normalizePbrTexture(material.emissiveMap, maxAnisotropy);
+  }
+  normalizePbrTexture(material.normalMap, maxAnisotropy);
+  normalizePbrTexture(material.roughnessMap, maxAnisotropy);
+  normalizePbrTexture(material.metalnessMap, maxAnisotropy);
+  normalizePbrTexture(material.aoMap, maxAnisotropy);
+}
+
+function prepareLoadedModel(model, options = {}) {
+  const { preserveGltfTextureMapping = false, maxAnisotropy = 1 } = options;
   if (!model) return;
   model.traverse((obj) => {
     if (obj.isMesh) {
@@ -903,8 +920,13 @@ function prepareLoadedModel(model) {
       const mats = Array.isArray(obj.material) ? obj.material : [obj.material];
       mats.forEach((mat) => {
         if (!mat) return;
-        if (mat.map) applySRGBColorSpace(mat.map);
-        if (mat.emissiveMap) applySRGBColorSpace(mat.emissiveMap);
+        if (preserveGltfTextureMapping) {
+          normalizeMaterialTextures(mat, maxAnisotropy);
+        } else {
+          if (mat.map) applySRGBColorSpace(mat.map);
+          if (mat.emissiveMap) applySRGBColorSpace(mat.emissiveMap);
+        }
+        mat.needsUpdate = true;
       });
     }
   });
@@ -1236,16 +1258,17 @@ async function createPolyhavenInstance(
 ) {
   const root = await loadPolyhavenModel(assetId, renderer);
   const model = root.clone ? root.clone(true) : root;
-  prepareLoadedModel(model);
   const {
     textureLoader = null,
     maxAnisotropy = 1,
     fallbackTexture = null,
     textureCache = null,
     textureSet = null,
-    preferredTextureSizes = PREFERRED_TEXTURE_SIZES
+    preferredTextureSizes = PREFERRED_TEXTURE_SIZES,
+    preserveGltfTextureMapping = false
   } = textureOptions || {};
-  if (textureLoader) {
+  prepareLoadedModel(model, { preserveGltfTextureMapping, maxAnisotropy });
+  if (textureLoader && !preserveGltfTextureMapping) {
     try {
       const textures =
         textureSet ??
@@ -1468,7 +1491,7 @@ async function buildChairTemplate(theme, renderer = null, textureOptions = {}) {
         TARGET_CHAIR_SIZE.y - TARGET_CHAIR_MIN_Y,
         theme.modelRotation || 0,
         renderer,
-        textureOptions
+        { ...textureOptions, preserveGltfTextureMapping: preserve }
       );
       fitChairModelToFootprint(model);
       return {


### PR DESCRIPTION
### Motivation
- PolyHaven-sourced chair models were having their original GLTF texture mapping overwritten when the app applied fallback or replacement texture sets, causing visible mapping/UV regressions compared to prior fixes for Murlan/Texas arenas. 
- Ensure PolyHaven chair themes keep their original materials/UV mapping while still normalizing textures (color space, anisotropy) for consistent rendering.

### Description
- Added `normalizeMaterialTextures(material, maxAnisotropy)` to normalize existing material maps (base/emissive/normal/roughness/metalness/ao) without replacing the original mapping.
- Extended `prepareLoadedModel` to accept `preserveGltfTextureMapping` and `maxAnisotropy`, and to call `normalizeMaterialTextures` when preservation is requested.
- Updated `createPolyhavenInstance` to accept `preserveGltfTextureMapping` and to skip applying PolyHaven texture-set overrides when preservation is true, while still preparing/normalizing maps.
- Wired `buildChairTemplate` to pass the chair theme's preservation intent into `createPolyhavenInstance` so PolyHaven chair themes retain original mapping consistently.

### Testing
- Ran ESLint checks with `npx eslint webapp/src/pages/Games/LudoBattleRoyal.jsx --no-ignore`, which reported only the repository-level ignore warning for this file and produced no lint errors from the change.  (No other automated tests were modified or required for this change.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d120d637208329a1ec400450f861a5)