### PR TITLE
Preserve GLTF chair textures during Ludo chair rebuilds

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -910,7 +910,25 @@ function prepareLoadedModel(model) {
   });
 }
 
-function disposeObjectResources(object) {
+const DISPOSABLE_TEXTURE_PROPS = Object.freeze([
+  'map',
+  'normalMap',
+  'roughnessMap',
+  'metalnessMap',
+  'aoMap',
+  'alphaMap',
+  'emissiveMap',
+  'bumpMap',
+  'displacementMap',
+  'clearcoatMap',
+  'clearcoatRoughnessMap',
+  'clearcoatNormalMap',
+  'specularMap',
+  'sheenColorMap',
+  'sheenRoughnessMap'
+]);
+
+function disposeObjectResources(object, { disposeTextures = true } = {}) {
   if (!object) return;
   const materials = new Set();
   object.traverse((obj) => {
@@ -920,8 +938,14 @@ function disposeObjectResources(object) {
     obj.geometry?.dispose?.();
   });
   materials.forEach((mat) => {
-    if (mat?.map) mat.map.dispose?.();
-    if (mat?.emissiveMap) mat.emissiveMap.dispose?.();
+    if (disposeTextures) {
+      DISPOSABLE_TEXTURE_PROPS.forEach((prop) => {
+        const texture = mat?.[prop];
+        if (texture?.isTexture) {
+          texture.dispose?.();
+        }
+      });
+    }
     mat?.dispose?.();
   });
 }
@@ -3469,7 +3493,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       arena.chairs.forEach(({ group }) => {
         const previous = group?.userData?.chairModel;
         if (previous) {
-          disposeObjectResources(previous);
+          disposeObjectResources(previous, { disposeTextures: false });
           group.remove(previous);
         }
       });


### PR DESCRIPTION
### Motivation
- Prevent chair GLTF/PBR textures from being blanked when rebuilding Ludo chairs because shared texture instances were being disposed during clone teardown.
- Match the preservation behavior already used for other Royale models (PolyHaven/Murlan/Holdem) so original PolyHaven textures remain intact when applied.

### Description
- Added a centralized `DISPOSABLE_TEXTURE_PROPS` list covering common PBR texture slots (`map`, `normalMap`, `roughnessMap`, etc.).
- Extended `disposeObjectResources` to accept an options object with `disposeTextures` (default `true`) and to iterate the centralized texture-slot list when disposing textures.
- Updated the chair rebuild path to call `disposeObjectResources(previous, { disposeTextures: false })` when removing old chair clones so shared GLTF texture instances are not disposed during rebuilds.

### Testing
- Ran `npm run -s lint -- src/pages/Games/LudoBattleRoyal.jsx` which exited with code 1 (lint failed in this environment).
- Ran `npm run -s` at the project root which completed (no errors returned in this environment).
- No unit tests were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d120d637208329a1ec400450f861a5)