### PR TITLE
Match Domino pip style to Chess heads and remove Domino commentary

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -557,11 +557,6 @@ function setFeedbackSettings(next, { refreshUi = true } = {}) {
   }
 }
 
-let commentaryGreetingPlayed = true;
-let lastAnnouncedTurn = null;
-
-function announceCommentary() {}
-
 function formatSeatName(index) {
   const names = getSeatUsernames(N);
   if (index === human) {
@@ -3670,12 +3665,12 @@ const DOMINO_DOT_STYLE_OPTIONS = Object.freeze([
     label: 'Ruby',
     icon: '●',
     color: '#9b111e',
-    emissive: '#7f1d1d',
+    emissive: '#000000',
     metalness: 0.05,
-    roughness: 0.2,
-    transmission: 0,
-    ior: 1.5,
-    thickness: 0,
+    roughness: 0.08,
+    transmission: 0.92,
+    ior: 2.4,
+    thickness: 0.6,
     thumbnail: '/assets/game-art/chess-battle-royal/heads/headRuby.svg'
   },
   {
@@ -3683,7 +3678,7 @@ const DOMINO_DOT_STYLE_OPTIONS = Object.freeze([
     label: 'Pearl',
     icon: '●',
     color: '#f5f5f5',
-    emissive: '#cbd5e1',
+    emissive: '#000000',
     metalness: 0.05,
     roughness: 0.25,
     transmission: 0,
@@ -3696,12 +3691,12 @@ const DOMINO_DOT_STYLE_OPTIONS = Object.freeze([
     label: 'Sapphire',
     icon: '●',
     color: '#0f52ba',
-    emissive: '#1d4ed8',
+    emissive: '#000000',
     metalness: 0.05,
-    roughness: 0.2,
-    transmission: 0,
-    ior: 1.5,
-    thickness: 0,
+    roughness: 0.08,
+    transmission: 0.9,
+    ior: 1.8,
+    thickness: 0.7,
     thumbnail: '/assets/game-art/chess-battle-royal/heads/headSapphire.svg'
   },
   {
@@ -3709,12 +3704,12 @@ const DOMINO_DOT_STYLE_OPTIONS = Object.freeze([
     label: 'Emerald',
     icon: '●',
     color: '#046a38',
-    emissive: '#166534',
+    emissive: '#000000',
     metalness: 0.05,
-    roughness: 0.2,
-    transmission: 0,
-    ior: 1.5,
-    thickness: 0,
+    roughness: 0.08,
+    transmission: 0.9,
+    ior: 1.8,
+    thickness: 0.7,
     thumbnail: '/assets/game-art/chess-battle-royal/heads/current.svg'
   },
   {
@@ -3722,12 +3717,12 @@ const DOMINO_DOT_STYLE_OPTIONS = Object.freeze([
     label: 'Chrome',
     icon: '●',
     color: '#d6d8dc',
-    emissive: '#64748b',
+    emissive: '#000000',
     metalness: 0.95,
     roughness: 0.12,
-    transmission: 0,
-    ior: 1.5,
-    thickness: 0,
+    transmission: 0.1,
+    ior: 2.1,
+    thickness: 0.22,
     thumbnail: '/assets/game-art/chess-battle-royal/heads/headChrome.svg'
   },
   {
@@ -3735,12 +3730,12 @@ const DOMINO_DOT_STYLE_OPTIONS = Object.freeze([
     label: 'Gold',
     icon: '●',
     color: '#d4af37',
-    emissive: '#92400e',
+    emissive: '#000000',
     metalness: 0.92,
     roughness: 0.16,
-    transmission: 0,
-    ior: 1.5,
-    thickness: 0,
+    transmission: 0.06,
+    ior: 1.85,
+    thickness: 0.28,
     thumbnail: '/assets/game-art/chess-battle-royal/heads/headGold.svg'
   }
 ]);
@@ -6561,6 +6556,7 @@ function applyDominoStyle(
       ...(style.pip || {}),
       color: pipStyle?.color ?? customDotColor ?? style.pip?.color,
       emissive: pipStyle?.emissive ?? style.pip?.emissive,
+      emissiveIntensity: pipStyle?.emissiveIntensity ?? style.pip?.emissiveIntensity,
       metalness: pipStyle?.metalness ?? style.pip?.metalness,
       roughness: pipStyle?.roughness ?? style.pip?.roughness,
       transmission: pipStyle?.transmission ?? style.pip?.transmission,
@@ -6580,7 +6576,7 @@ function applyDominoStyle(
   const dominoTextures = getDominoSurfaceTextures(pipStyle);
   porcelainMat.map = dominoTextures.porcelainMap;
   porcelainMat.roughnessMap = dominoTextures.porcelainRoughness;
-  pipMat.map = dominoTextures.pipMap;
+  pipMat.map = null;
 
   accentMat = buildDominoMaterial(
     {
@@ -8714,7 +8710,6 @@ function startGame({ resetRace = true } = {}) {
   winnerIndex = null;
   lastHandWinnerIndex = null;
   revealAllHands = false;
-  lastAnnouncedTurn = null;
   clearWinnerHighlight();
   hideWinnerOverlay();
   if (cpuMoveTimeout) {
@@ -8866,16 +8861,6 @@ function startGame({ resetRace = true } = {}) {
   updateInteractivity();
   if (current !== human) {
     scheduleCpuPlay();
-  }
-  if (!commentaryGreetingPlayed) {
-    commentaryGreetingPlayed = true;
-    announceCommentary(
-      'greeting',
-      { player: human },
-      { priority: true, interrupt: true }
-    );
-  } else {
-    announceCommentary('startRound', { player: starter });
   }
 }
 
@@ -9405,7 +9390,6 @@ renderer.domElement.addEventListener('pointerdown', (ev) => {
   if (obj.userData && obj.userData.marker && selectedTile) {
     const side = obj.userData.side;
     const idx = players[human].hand.indexOf(selectedTile);
-    let playedTile = null;
     let playedPlacement = null;
     if (idx >= 0) {
       const [picked] = players[human].hand.splice(idx, 1);
@@ -9418,21 +9402,7 @@ renderer.domElement.addEventListener('pointerdown', (ev) => {
         showMarkersFor(selectedTile);
         return;
       }
-      playedTile = picked;
       playedPlacement = placement;
-    }
-    if (playedTile) {
-      announceCommentary(
-        playedTile.a === playedTile.b ? 'playDouble' : 'playTile',
-        { player: human, tile: playedTile }
-      );
-      if (players[human].hand.length === 1) {
-        announceCommentary(
-          'nearWin',
-          { player: human, tilesLeft: players[human].hand.length },
-          { priority: true }
-        );
-      }
     }
     selectedTile = null;
     clearMarkers();
@@ -9567,9 +9537,6 @@ if (btnDraw) {
   if (drewTile) {
     SFX.drawTile();
   }
-  if (drewTile) {
-    announceCommentary('draw', { player: human });
-  }
   });
 }
 if (btnPass) {
@@ -9578,7 +9545,6 @@ if (btnPass) {
     clearMarkers();
     selectedTile = null;
     SFX.pass();
-    announceCommentary('pass', { player: human });
     schedulePassTurnAdvance(human);
   }
   });
@@ -9704,20 +9670,6 @@ function finishGame({ winner = null, reason = '', revealAll = false } = {}) {
     setStatus('Game over');
   }
 
-  if (reason && reason.toLowerCase().includes('blocked')) {
-    announceCommentary(
-      'blocked',
-      { player: winnerIndex },
-      { priority: true, interrupt: true }
-    );
-  } else if (winnerIndex !== null) {
-    announceCommentary(
-      winnerIndex === human ? 'win' : 'lose',
-      { player: winnerIndex },
-      { priority: true, interrupt: true }
-    );
-  }
-
   if (winnerIndex !== null) {
     SFX.win();
   } else {
@@ -9798,12 +9750,6 @@ function updateInteractivity() {
     return;
   }
   setStatus(`Turn: Player ${current + 1}`);
-  if (lastAnnouncedTurn !== current) {
-    lastAnnouncedTurn = current;
-    announceCommentary(current === human ? 'yourTurn' : 'opponentTurn', {
-      player: current
-    });
-  }
   clearAllPassBubbles();
   renderHands();
   renderChain();
@@ -9856,17 +9802,14 @@ function cpuPlay() {
     if (drew) {
       renderHands();
       SFX.drawTile();
-      announceCommentary('draw', { player: current });
       if (canPlayAny(player.hand)) {
         scheduleCpuPlay();
       } else {
         SFX.pass();
-        announceCommentary('pass', { player: current });
         schedulePassTurnAdvance(current);
       }
     } else {
       SFX.pass();
-      announceCommentary('pass', { player: current });
       schedulePassTurnAdvance(current);
     }
     return;
@@ -9879,17 +9822,6 @@ function cpuPlay() {
     const placement = placeOnBoard(picked, move.side, { animate: true });
     if (placement.success) {
       renderHands();
-      announceCommentary(picked.a === picked.b ? 'playDouble' : 'playTile', {
-        player: current,
-        tile: picked
-      });
-      if (player.hand.length === 1) {
-        announceCommentary(
-          'nearWin',
-          { player: current, tilesLeft: player.hand.length },
-          { priority: true }
-        );
-      }
       if (player.hand.length === 0) {
         concludeHand({
           winner: current,
@@ -9908,17 +9840,14 @@ function cpuPlay() {
   if (drew) {
     renderHands();
     SFX.drawTile();
-    announceCommentary('draw', { player: current });
     if (canPlayAny(player.hand)) {
       scheduleCpuPlay();
     } else {
       SFX.pass();
-      announceCommentary('pass', { player: current });
       schedulePassTurnAdvance(current);
     }
   } else {
     SFX.pass();
-    announceCommentary('pass', { player: current });
     schedulePassTurnAdvance(current);
   }
 }

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-04-04-domino-color-presets-v11';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-04-04-domino-dot-head-match-v12';
 
 export default function DominoRoyalArena() {
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- Make Domino Royal pips visually match the Chess Battle Royal pawn-head materials so pips use the same color/reflectance/IOR/thickness behavior and no longer appear as flat black dots. 
- Remove runtime voice commentary for Domino Royal as it is not needed and was triggering speech hooks in the game flow.

### Description
- Updated `DOMINO_DOT_STYLE_OPTIONS` in `webapp/public/domino-royal-game.js` to align pip material parameters (`roughness`, `transmission`, `ior`, `thickness`) with the Chess head presets and removed the dark emissive tint so dot colors render correctly. 
- Allow pip emissive intensity to be taken from the dot preset by applying `emissiveIntensity` from the style during `applyDominoStyle`. 
- Disabled the generated pip texture map overlay by setting `pipMat.map = null` so pips rely on the material parameters (preserves Chess-style appearance). 
- Removed all Domino-specific voice/commentary hooks and calls (`announceCommentary`, `commentaryGreetingPlayed`, `lastAnnouncedTurn` and all in-game commentary call sites) from the Domino runtime code so no speech is invoked for Domino Royal. 
- Bumped the in-page script version string in `webapp/src/pages/Games/DominoRoyalArena.jsx` (`DOMINO_ROYAL_SCRIPT_VERSION`) to force clients to fetch the updated public script.

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` and it completed successfully. 
- Built the web client with `npm --prefix webapp run -s build` and the build completed (Vite warnings unrelated to these changes were observed but did not fail the build). 
- Verified no remaining Domino commentary references with `rg -n "commentary|announceCommentary|Speech" webapp/public/domino-royal-game.js` which returned no matches.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d12b5c7c8083298dcdc9e4b12a4746)