### PR TITLE
Pool Royale: sync rail/leg texture density and add LT table finish variants

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -297,11 +297,11 @@ const TABLE_FINISH_THUMBNAILS = Object.freeze({
   woodTable001: polyHavenThumb('wood_table_001'),
   darkWood: polyHavenThumb('dark_wood'),
   rosewoodVeneer01: polyHavenThumb('rosewood_veneer_01'),
-  carbonFiberChalk: swatchThumbnail(['#090b0f', '#111317', '#2a313b']),
-  carbonFiberChalkGrey: swatchThumbnail(['#4b5563', '#6b7280', '#b6becb']),
-  carbonFiberChalkBeige: swatchThumbnail(['#252a31', '#353b45', '#525b68']),
-  carbonFiberChalkDarkBlue: swatchThumbnail(['#4f1220', '#6d1f30', '#8d3248']),
-  carbonFiberChalkWhite: swatchThumbnail(['#ede2d0', '#f6efe2', '#fff8eb'])
+  carbonFiberChalk: swatchThumbnail(['#0c0f14', '#171b22', '#303844']),
+  carbonFiberChalkGrey: swatchThumbnail(['#5f6774', '#7f8794', '#c5cdd9']),
+  carbonFiberChalkBeige: swatchThumbnail(['#2b313a', '#414854', '#646d7a']),
+  carbonFiberChalkDarkBlue: swatchThumbnail(['#5d1a2a', '#7f2a3d', '#a34860']),
+  carbonFiberChalkWhite: swatchThumbnail(['#ebddc9', '#f8efe1', '#fff9ee'])
 });
 
 const POCKET_LINER_THUMBNAILS = Object.freeze({
@@ -400,11 +400,11 @@ export const POOL_ROYALE_OPTION_LABELS = Object.freeze({
     woodTable001: 'Wood Table 001',
     darkWood: 'Dark Wood',
     rosewoodVeneer01: 'Rosewood Veneer 01',
-    carbonFiberChalk: 'Black',
-    carbonFiberChalkGrey: 'Grey',
-    carbonFiberChalkBeige: 'Dark Grey',
-    carbonFiberChalkDarkBlue: 'Burgundy',
-    carbonFiberChalkWhite: 'Milk Cream'
+    carbonFiberChalk: 'LT Black',
+    carbonFiberChalkGrey: 'LT Grey',
+    carbonFiberChalkBeige: 'LT Dark Grey',
+    carbonFiberChalkDarkBlue: 'LT Burgundy',
+    carbonFiberChalkWhite: 'LT Milk Cream'
   }),
   chromeColor: Object.freeze({
     chrome: 'Chrome',
@@ -496,7 +496,7 @@ export const POOL_ROYALE_STORE_ITEMS = [
     id: 'finish-carbonFiberChalk',
     type: 'tableFinish',
     optionId: 'carbonFiberChalk',
-    name: 'Black Finish',
+    name: 'LT Black Finish',
     price: 1160,
     description: 'Solid black molded-plastic finish with no wood grain texture.',
     thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberChalk
@@ -505,7 +505,7 @@ export const POOL_ROYALE_STORE_ITEMS = [
     id: 'finish-carbonFiberChalkGrey',
     type: 'tableFinish',
     optionId: 'carbonFiberChalkGrey',
-    name: 'Grey Finish',
+    name: 'LT Grey Finish',
     price: 1170,
     description: 'Solid grey molded-plastic finish with no wood grain texture.',
     thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberChalkGrey
@@ -514,7 +514,7 @@ export const POOL_ROYALE_STORE_ITEMS = [
     id: 'finish-carbonFiberChalkBeige',
     type: 'tableFinish',
     optionId: 'carbonFiberChalkBeige',
-    name: 'Dark Grey Finish',
+    name: 'LT Dark Grey Finish',
     price: 1180,
     description: 'Solid dark-grey molded-plastic finish with no wood grain texture.',
     thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberChalkBeige
@@ -523,7 +523,7 @@ export const POOL_ROYALE_STORE_ITEMS = [
     id: 'finish-carbonFiberChalkDarkBlue',
     type: 'tableFinish',
     optionId: 'carbonFiberChalkDarkBlue',
-    name: 'Burgundy Finish',
+    name: 'LT Burgundy Finish',
     price: 1190,
     description: 'Solid burgundy molded-plastic finish with no wood grain texture.',
     thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberChalkDarkBlue
@@ -532,7 +532,7 @@ export const POOL_ROYALE_STORE_ITEMS = [
     id: 'finish-carbonFiberChalkWhite',
     type: 'tableFinish',
     optionId: 'carbonFiberChalkWhite',
-    name: 'Milk Cream Finish',
+    name: 'LT Milk Cream Finish',
     price: 1200,
     description: 'Solid milk-cream molded-plastic finish with no wood grain texture.',
     thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberChalkWhite

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -3039,47 +3039,47 @@ const TABLE_FINISHES = Object.freeze({
   }),
   carbonFiberChalk: createStandardWoodFinish({
     id: 'carbonFiberChalk',
-    label: 'Black',
-    rail: 0x111317,
-    base: 0x090b0f,
-    trim: 0x2a313b,
-    woodTextureId: 'plastic_monoblock',
+    label: 'LT Black',
+    rail: 0x171b22,
+    base: 0x0c0f14,
+    trim: 0x303844,
+    woodTextureId: 'plastic_monoblock_lt_black',
     woodRepeatScale: 1
   }),
   carbonFiberChalkGrey: createStandardWoodFinish({
     id: 'carbonFiberChalkGrey',
-    label: 'Grey',
-    rail: 0x6b7280,
-    base: 0x4b5563,
-    trim: 0xb6becb,
-    woodTextureId: 'plastic_monoblock',
+    label: 'LT Grey',
+    rail: 0x7f8794,
+    base: 0x5f6774,
+    trim: 0xc5cdd9,
+    woodTextureId: 'plastic_monoblock_lt_grey',
     woodRepeatScale: 1
   }),
   carbonFiberChalkBeige: createStandardWoodFinish({
     id: 'carbonFiberChalkBeige',
-    label: 'Dark Grey',
-    rail: 0x353b45,
-    base: 0x252a31,
-    trim: 0x525b68,
-    woodTextureId: 'plastic_monoblock',
+    label: 'LT Dark Grey',
+    rail: 0x414854,
+    base: 0x2b313a,
+    trim: 0x646d7a,
+    woodTextureId: 'plastic_monoblock_lt_dark_grey',
     woodRepeatScale: 1
   }),
   carbonFiberChalkDarkBlue: createStandardWoodFinish({
     id: 'carbonFiberChalkDarkBlue',
-    label: 'Burgundy',
-    rail: 0x6d1f30,
-    base: 0x4f1220,
-    trim: 0x8d3248,
-    woodTextureId: 'plastic_monoblock',
+    label: 'LT Burgundy',
+    rail: 0x7f2a3d,
+    base: 0x5d1a2a,
+    trim: 0xa34860,
+    woodTextureId: 'plastic_monoblock_lt_burgundy',
     woodRepeatScale: 1
   }),
   carbonFiberChalkWhite: createStandardWoodFinish({
     id: 'carbonFiberChalkWhite',
-    label: 'Milk Cream',
-    rail: 0xf6efe2,
-    base: 0xede2d0,
-    trim: 0xfff8eb,
-    woodTextureId: 'plastic_monoblock',
+    label: 'LT Milk Cream',
+    rail: 0xf8efe1,
+    base: 0xebddc9,
+    trim: 0xfff9ee,
+    woodTextureId: 'plastic_monoblock_lt_milk_cream',
     woodRepeatScale: 1
   })
 });
@@ -12189,18 +12189,6 @@ function applyTableFinishToTable(table, finish) {
     );
     const highFpsRailTextureSize = enforceHighFpsTableTextureSize(nextRailSurface.textureSize);
     const highFpsFrameTextureSize = enforceHighFpsTableTextureSize(nextFrameSurface.textureSize);
-    const synchronizedRailSurface = {
-      repeat: new THREE.Vector2(
-        nextRailSurface.repeat.x,
-        nextRailSurface.repeat.y
-      ),
-      rotation: nextRailSurface.rotation,
-      textureSize: highFpsRailTextureSize,
-      mapUrl: nextRailSurface.mapUrl,
-      roughnessMapUrl: nextRailSurface.roughnessMapUrl,
-      normalMapUrl: nextRailSurface.normalMapUrl,
-      woodRepeatScale
-    };
     const synchronizedFrameSurface = {
       repeat: new THREE.Vector2(nextFrameSurface.repeat.x, nextFrameSurface.repeat.y),
       rotation: nextFrameSurface.rotation,
@@ -12208,6 +12196,20 @@ function applyTableFinishToTable(table, finish) {
       mapUrl: nextFrameSurface.mapUrl,
       roughnessMapUrl: nextFrameSurface.roughnessMapUrl,
       normalMapUrl: nextFrameSurface.normalMapUrl,
+      woodRepeatScale
+    };
+    // Keep rail texture pattern scale locked to the frame/legs so the full table
+    // shell (rails + skirts + legs) reads as one consistent GLTF texture density.
+    const synchronizedRailSurface = {
+      repeat: new THREE.Vector2(
+        synchronizedFrameSurface.repeat.x,
+        synchronizedFrameSurface.repeat.y
+      ),
+      rotation: synchronizedFrameSurface.rotation,
+      textureSize: highFpsRailTextureSize,
+      mapUrl: synchronizedFrameSurface.mapUrl,
+      roughnessMapUrl: synchronizedFrameSurface.roughnessMapUrl,
+      normalMapUrl: synchronizedFrameSurface.normalMapUrl,
       woodRepeatScale
     };
 

--- a/webapp/src/utils/woodMaterials.js
+++ b/webapp/src/utils/woodMaterials.js
@@ -714,6 +714,131 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
     }
   }),
   Object.freeze({
+    id: 'plastic_monoblock_lt_black',
+    label: 'LT Black',
+    source: 'TonPlaygram molded-plastic satin texture (LT Black)',
+    rail: {
+      repeat: { x: 7.2, y: 7.2 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlinePlasticMonoblockPattern({
+        id: 'plastic-monoblock-lt-black-rail',
+        base: '#0b0d10',
+        sheen: '#1a1f28'
+      })
+    },
+    frame: {
+      repeat: { x: 7.2, y: 7.2 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlinePlasticMonoblockPattern({
+        id: 'plastic-monoblock-lt-black-frame',
+        base: '#0b0d10',
+        sheen: '#1a1f28'
+      })
+    }
+  }),
+  Object.freeze({
+    id: 'plastic_monoblock_lt_grey',
+    label: 'LT Grey',
+    source: 'TonPlaygram molded-plastic satin texture (LT Grey)',
+    rail: {
+      repeat: { x: 7.2, y: 7.2 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlinePlasticMonoblockPattern({
+        id: 'plastic-monoblock-lt-grey-rail',
+        base: '#585f6b',
+        sheen: '#7b8391'
+      })
+    },
+    frame: {
+      repeat: { x: 7.2, y: 7.2 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlinePlasticMonoblockPattern({
+        id: 'plastic-monoblock-lt-grey-frame',
+        base: '#585f6b',
+        sheen: '#7b8391'
+      })
+    }
+  }),
+  Object.freeze({
+    id: 'plastic_monoblock_lt_dark_grey',
+    label: 'LT Dark Grey',
+    source: 'TonPlaygram molded-plastic satin texture (LT Dark Grey)',
+    rail: {
+      repeat: { x: 7.2, y: 7.2 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlinePlasticMonoblockPattern({
+        id: 'plastic-monoblock-lt-dark-grey-rail',
+        base: '#2d323b',
+        sheen: '#434a56'
+      })
+    },
+    frame: {
+      repeat: { x: 7.2, y: 7.2 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlinePlasticMonoblockPattern({
+        id: 'plastic-monoblock-lt-dark-grey-frame',
+        base: '#2d323b',
+        sheen: '#434a56'
+      })
+    }
+  }),
+  Object.freeze({
+    id: 'plastic_monoblock_lt_burgundy',
+    label: 'LT Burgundy',
+    source: 'TonPlaygram molded-plastic satin texture (LT Burgundy)',
+    rail: {
+      repeat: { x: 7.2, y: 7.2 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlinePlasticMonoblockPattern({
+        id: 'plastic-monoblock-lt-burgundy-rail',
+        base: '#5f1d2c',
+        sheen: '#7f2e43'
+      })
+    },
+    frame: {
+      repeat: { x: 7.2, y: 7.2 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlinePlasticMonoblockPattern({
+        id: 'plastic-monoblock-lt-burgundy-frame',
+        base: '#5f1d2c',
+        sheen: '#7f2e43'
+      })
+    }
+  }),
+  Object.freeze({
+    id: 'plastic_monoblock_lt_milk_cream',
+    label: 'LT Milk Cream',
+    source: 'TonPlaygram molded-plastic satin texture (LT Milk Cream)',
+    rail: {
+      repeat: { x: 7.2, y: 7.2 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlinePlasticMonoblockPattern({
+        id: 'plastic-monoblock-lt-milk-cream-rail',
+        base: '#e9dcc9',
+        sheen: '#f8efe1'
+      })
+    },
+    frame: {
+      repeat: { x: 7.2, y: 7.2 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlinePlasticMonoblockPattern({
+        id: 'plastic-monoblock-lt-milk-cream-frame',
+        base: '#e9dcc9',
+        sheen: '#f8efe1'
+      })
+    }
+  }),
+  Object.freeze({
     id: 'carbon_fiber_chalk',
     label: 'Solid Color Finish',
     source: 'TonPlaygram solid-color finish',


### PR DESCRIPTION
### Motivation
- Ensure the wood/plastic pattern scale is visually consistent across rails, skirts/frames and legs so a GLTF table finish reads as a single continuous shell.  
- Replace the five generic plastic finishes (black / grey / dark grey / burgundy / milk cream) with dedicated LT-prefixed variants that match their names and have distinct color/pattern tones.

### Description
- Keep rail pattern density locked to the frame/leg surface by reusing the resolved frame surface parameters for rail textures when applying finishes (`applyTableFinishToTable` change). Files: `webapp/src/pages/Games/PoolRoyale.jsx`.
- Add dedicated molded-plastic presets for the five LT finishes (`plastic_monoblock_lt_black`, `plastic_monoblock_lt_grey`, `plastic_monoblock_lt_dark_grey`, `plastic_monoblock_lt_burgundy`, `plastic_monoblock_lt_milk_cream`) and generate per-variant inline textures with appropriate base/sheen colours. File: `webapp/src/utils/woodMaterials.js`.
- Update Pool Royale finish definitions to use the new LT texture IDs and adjusted rail/base/trim color palettes so visual appearance matches the new names. File: `webapp/src/pages/Games/PoolRoyale.jsx`.
- Update inventory/store metadata and swatch thumbnails to show the `LT` prefix and refreshed swatch colors so UI/shop reflects the new variants. File: `webapp/src/config/poolRoyaleInventoryConfig.js`.

### Testing
- Ran `npm test -- --runInBand test/poolRoyaleRules.test.ts` and it passed (4 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d12f5100348329904e5be7e256fd5d)