### PR TITLE
Add 16 Poly Haven HDRI environments to Domino store

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -3370,6 +3370,166 @@ const POOL_ROYALE_HDRI_VARIANTS = Object.freeze([
     exposure: 1.1,
     environmentIntensity: 1.06,
     backgroundIntensity: 1.02
+  },
+  {
+    id: 'churchMeetingRoom',
+    name: 'Church Meeting Room',
+    assetId: 'church_meeting_room',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '2k',
+    exposure: 1.08,
+    environmentIntensity: 1.05,
+    backgroundIntensity: 1.0
+  },
+  {
+    id: 'polyHavenStudio',
+    name: 'Poly Haven Studio',
+    assetId: 'poly_haven_studio',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '2k',
+    exposure: 1.16,
+    environmentIntensity: 1.1,
+    backgroundIntensity: 1.06
+  },
+  {
+    id: 'cinemaLobby',
+    name: 'Cinema Lobby',
+    assetId: 'cinema_lobby',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '2k',
+    exposure: 1.1,
+    environmentIntensity: 1.08,
+    backgroundIntensity: 1.03
+  },
+  {
+    id: 'warmBar',
+    name: 'Warm Bar',
+    assetId: 'warm_bar',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '2k',
+    exposure: 1.06,
+    environmentIntensity: 1.03,
+    backgroundIntensity: 0.99
+  },
+  {
+    id: 'pineAttic',
+    name: 'Pine Attic',
+    assetId: 'pine_attic',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '2k',
+    exposure: 1.05,
+    environmentIntensity: 1.02,
+    backgroundIntensity: 0.98
+  },
+  {
+    id: 'rostockArches',
+    name: 'Rostock Arches',
+    assetId: 'rostock_arches',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '2k',
+    exposure: 1.08,
+    environmentIntensity: 1.04,
+    backgroundIntensity: 1.0
+  },
+  {
+    id: 'vignaioliNight',
+    name: 'Vignaioli Night',
+    assetId: 'vignaioli_night',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '2k',
+    exposure: 1.03,
+    environmentIntensity: 1.01,
+    backgroundIntensity: 0.97
+  },
+  {
+    id: 'stPetersSquareNight',
+    name: 'St. Peters Square Night',
+    assetId: 'st_peters_square_night',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '2k',
+    exposure: 1.02,
+    environmentIntensity: 1.0,
+    backgroundIntensity: 0.96
+  },
+  {
+    id: 'zwingerNight',
+    name: 'Zwinger Night',
+    assetId: 'zwinger_night',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '2k',
+    exposure: 1.03,
+    environmentIntensity: 1.01,
+    backgroundIntensity: 0.97
+  },
+  {
+    id: 'winterEvening',
+    name: 'Winter Evening',
+    assetId: 'winter_evening',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '2k',
+    exposure: 1.0,
+    environmentIntensity: 0.99,
+    backgroundIntensity: 0.95
+  },
+  {
+    id: 'rathaus',
+    name: 'Rathaus',
+    assetId: 'rathaus',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '2k',
+    exposure: 1.07,
+    environmentIntensity: 1.04,
+    backgroundIntensity: 1.0
+  },
+  {
+    id: 'newmanLobby',
+    name: 'Newman Lobby',
+    assetId: 'newman_lobby',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '2k',
+    exposure: 1.09,
+    environmentIntensity: 1.06,
+    backgroundIntensity: 1.02
+  },
+  {
+    id: 'lapa',
+    name: 'Lapa',
+    assetId: 'lapa',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '2k',
+    exposure: 1.08,
+    environmentIntensity: 1.05,
+    backgroundIntensity: 1.01
+  },
+  {
+    id: 'medievalCafe',
+    name: 'Medieval Cafe',
+    assetId: 'medieval_cafe',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '2k',
+    exposure: 1.07,
+    environmentIntensity: 1.04,
+    backgroundIntensity: 1.0
+  },
+  {
+    id: 'crossfitGym',
+    name: 'Crossfit Gym',
+    assetId: 'crossfit_gym',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '2k',
+    exposure: 1.1,
+    environmentIntensity: 1.07,
+    backgroundIntensity: 1.03
+  },
+  {
+    id: 'voortrekkerInterior',
+    name: 'Voortrekker Interior',
+    assetId: 'voortrekker_interior',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '2k',
+    exposure: 1.09,
+    environmentIntensity: 1.06,
+    backgroundIntensity: 1.02
   }
 ]);
 


### PR DESCRIPTION
### Motivation
- Provide the requested Poly Haven HDRI environments so players can purchase and use them in-game with the same grounding/scale behavior as existing HDRIs. 
- Keep HDRI sizing and resolution policy consistent with current entries so the table remains visually grounded and behaves predictably across devices.

### Description
- Added 16 new variants to `POOL_ROYALE_HDRI_VARIANTS` in `webapp/public/domino-royal-game.js` with `assetId`, `preferredResolutions`, `fallbackResolution`, `exposure`, `environmentIntensity`, and `backgroundIntensity` for each (Church Meeting Room, Poly Haven Studio, Cinema Lobby, Warm Bar, Pine Attic, Rostock Arches, Vignaioli Night, St. Peters Square Night, Zwinger Night, Winter Evening, Rathaus, Newman Lobby, Lapa, Medieval Cafe, Crossfit Gym, Voortrekker Interior). 
- Those variants automatically flow into `ENVIRONMENT_HDRI_OPTIONS` (uses `POLYHAVEN_THUMB(variant.assetId)` for thumbnails) so they appear in the store/UI without additional wiring. 
- Kept the same resolution policy (`preferredResolutions: ['8k','4k','2k']`, `fallbackResolution: '2k'`) to match existing environment handling and grounded table presentation.

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` to validate JavaScript syntax, which completed successfully. 
- Verified each new `assetId` returns HTTP 200 from `https://api.polyhaven.com/files/<assetId>` using a `curl` loop, and all assets responded with `200`. 
- Confirmed the new entries are included in `ENVIRONMENT_HDRI_OPTIONS` by inspecting the updated `domino-royal-game.js` mapping, and no runtime-facing code changes were required for listing or selection.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d151a3344483298bef35020da50e87)