### PR TITLE
Pool Royale: remove requested and premium HDRIs from inventory/store

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -583,16 +583,35 @@ const RAW_POOL_ROYALE_HDRI_VARIANTS = [
   },
 ];
 
+const POOL_ROYALE_REMOVED_HDRI_IDS = new Set([
+  'churchMeetingRoom',
+  'vestibule',
+  'countryClub',
+  'cycloramaHardLight',
+  'squashCourt',
+  'blockyPhotoStudio',
+  'warmBar',
+  'rostockArches',
+  'vignaioliNight',
+  'stPetersSquareNight',
+  'zwingerNight',
+  'winterEvening',
+  'rathaus',
+  'medievalCafe'
+]);
+
 const HDRI_RESOLUTION_STACK = Object.freeze(['8k', '4k', '2k']);
 
 export const POOL_ROYALE_HDRI_VARIANTS = Object.freeze(
-  RAW_POOL_ROYALE_HDRI_VARIANTS.map((variant) => ({
-    ...variant,
-    preferredResolutions: HDRI_RESOLUTION_STACK,
-    fallbackResolution: HDRI_RESOLUTION_STACK[0],
-    thumbnail: polyHavenThumb(variant.assetId),
-    ...(POOL_ROYALE_HDRI_PLACEMENTS[variant.id] || {})
-  }))
+  RAW_POOL_ROYALE_HDRI_VARIANTS
+    .filter((variant) => variant.price === 0 && !POOL_ROYALE_REMOVED_HDRI_IDS.has(variant.id))
+    .map((variant) => ({
+      ...variant,
+      preferredResolutions: HDRI_RESOLUTION_STACK,
+      fallbackResolution: HDRI_RESOLUTION_STACK[0],
+      thumbnail: polyHavenThumb(variant.assetId),
+      ...(POOL_ROYALE_HDRI_PLACEMENTS[variant.id] || {})
+    }))
 );
 
 const TABLE_FINISH_THUMBNAILS = Object.freeze({


### PR DESCRIPTION
### Motivation
- Remove a set of HDRIs (listed by user) from the Pool Royale inventory and store so they are no longer available to players. 
- Also remove all premium HDRIs from Pool Royale (expose only free HDRIs) to satisfy the request to hide paid/premium environments.

### Description
- Added a `POOL_ROYALE_REMOVED_HDRI_IDS` set containing the requested HDRI ids (e.g. `churchMeetingRoom`, `vestibule`, `countryClub`, `cycloramaHardLight`, `squashCourt`, `blockyPhotoStudio`, `warmBar`, `rostockArches`, `vignaioliNight`, `stPetersSquareNight`, `zwingerNight`, `winterEvening`, `rathaus`, `medievalCafe`) in `webapp/src/config/poolRoyaleInventoryConfig.js`.
- Restricted `POOL_ROYALE_HDRI_VARIANTS` by filtering `RAW_POOL_ROYALE_HDRI_VARIANTS` with `.filter((variant) => variant.price === 0 && !POOL_ROYALE_REMOVED_HDRI_IDS.has(variant.id))` so only non-removed and free HDRIs are included, while preserving placements and thumbnails.
- Because store items are built from `POOL_ROYALE_HDRI_VARIANTS.map(...)` later in the same file, the removed and premium HDRIs are no longer emitted into the store/catalog or environment HDRI store entries.

### Testing
- Ran `npm run lint` under `webapp/` which failed because the project does not define a `lint` script. 
- Ran `npm run build` under `webapp/` and the Vite production build completed successfully (build emitted non-blocking warnings about chunking and one duplicate `case` warning). 
- Build artifacts and metadata were written (e.g. `public/version.json` and app build files) and the production build finished without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d163adfdb08329a9477b998d0cdbeb)