### PR TITLE
Add new purchasable Texas Hold'em HDRI environments

### DIFF
--- a/webapp/src/config/texasHoldemInventoryConfig.js
+++ b/webapp/src/config/texasHoldemInventoryConfig.js
@@ -1,6 +1,7 @@
 import { TABLE_BASE_OPTIONS, TABLE_CLOTH_OPTIONS } from '../utils/tableCustomizationOptions.js';
 import { TABLE_SHAPE_OPTIONS } from '../utils/murlanTable.js';
 import { CARD_THEMES } from '../utils/cards3d.js';
+import { polyHavenThumb } from './storeThumbnails.js';
 import {
   BATTLE_ROYALE_SHARED_CHAIR_THEME_OPTIONS,
   BATTLE_ROYALE_SHARED_HDRI_VARIANTS,
@@ -14,7 +15,172 @@ const reduceLabels = (items) =>
     return acc;
   }, {});
 
-export const TEXAS_HDRI_OPTIONS = BATTLE_ROYALE_SHARED_HDRI_VARIANTS.map((variant) => ({
+const TEXAS_EXTRA_HDRI_VARIANTS = Object.freeze([
+  {
+    id: 'churchMeetingRoom',
+    name: 'Church Meeting Room',
+    assetId: 'church_meeting_room',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '8k',
+    price: 2860,
+    exposure: 1.08,
+    environmentIntensity: 1.04,
+    backgroundIntensity: 1,
+    swatches: ['#374151', '#d1d5db'],
+    description: 'Quiet meeting-room ambience with gentle daylight bounce.',
+    cameraHeightM: 1.56,
+    groundRadiusMultiplier: 4.9,
+    groundResolution: 112,
+    arenaScale: 1.24,
+    thumbnail: polyHavenThumb('church_meeting_room')
+  },
+  {
+    id: 'warmBar',
+    name: 'Warm Bar',
+    assetId: 'warm_bar',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '8k',
+    price: 2880,
+    exposure: 1.11,
+    environmentIntensity: 1.08,
+    backgroundIntensity: 1.03,
+    swatches: ['#7c2d12', '#fbbf24'],
+    description: 'Cozy golden bar lighting with rich warm reflections.',
+    cameraHeightM: 1.58,
+    groundRadiusMultiplier: 5.1,
+    groundResolution: 112,
+    arenaScale: 1.27,
+    thumbnail: polyHavenThumb('warm_bar')
+  },
+  {
+    id: 'rostockArches',
+    name: 'Rostock Arches',
+    assetId: 'rostock_arches',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '8k',
+    price: 2920,
+    exposure: 1.07,
+    environmentIntensity: 1.04,
+    backgroundIntensity: 0.99,
+    swatches: ['#6b7280', '#e5e7eb'],
+    description: 'Stone arcade interior with broad natural bounce and depth.',
+    cameraHeightM: 1.6,
+    groundRadiusMultiplier: 5.2,
+    groundResolution: 112,
+    arenaScale: 1.28,
+    thumbnail: polyHavenThumb('rostock_arches')
+  },
+  {
+    id: 'vignaioliNight',
+    name: 'Vignaioli Night',
+    assetId: 'vignaioli_night',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '8k',
+    price: 2940,
+    exposure: 1.06,
+    environmentIntensity: 1.03,
+    backgroundIntensity: 0.98,
+    swatches: ['#1f2937', '#f59e0b'],
+    description: 'Night courtyard mood with subtle practical lights.',
+    cameraHeightM: 1.58,
+    groundRadiusMultiplier: 5.2,
+    groundResolution: 112,
+    arenaScale: 1.27,
+    thumbnail: polyHavenThumb('vignaioli_night')
+  },
+  {
+    id: 'stPetersSquareNight',
+    name: 'St. Peters Square Night',
+    assetId: 'st_peters_square_night',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '8k',
+    price: 2960,
+    exposure: 1.05,
+    environmentIntensity: 1.02,
+    backgroundIntensity: 0.97,
+    swatches: ['#111827', '#cbd5e1'],
+    description: 'Iconic square lit at night with elegant contrast and atmosphere.',
+    cameraHeightM: 1.6,
+    groundRadiusMultiplier: 5.3,
+    groundResolution: 112,
+    arenaScale: 1.29,
+    thumbnail: polyHavenThumb('st_peters_square_night')
+  },
+  {
+    id: 'zwingerNight',
+    name: 'Zwinger Night',
+    assetId: 'zwinger_night',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '8k',
+    price: 2980,
+    exposure: 1.05,
+    environmentIntensity: 1.02,
+    backgroundIntensity: 0.97,
+    swatches: ['#0f172a', '#f8fafc'],
+    description: 'Historic architecture scene with crisp nighttime highlights.',
+    cameraHeightM: 1.6,
+    groundRadiusMultiplier: 5.3,
+    groundResolution: 112,
+    arenaScale: 1.29,
+    thumbnail: polyHavenThumb('zwinger_night')
+  },
+  {
+    id: 'winterEvening',
+    name: 'Winter Evening',
+    assetId: 'winter_evening',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '8k',
+    price: 3000,
+    exposure: 1.04,
+    environmentIntensity: 1.01,
+    backgroundIntensity: 0.96,
+    swatches: ['#0ea5e9', '#e2e8f0'],
+    description: 'Cool seasonal evening light with clean snow-lit reflections.',
+    cameraHeightM: 1.56,
+    groundRadiusMultiplier: 5.1,
+    groundResolution: 112,
+    arenaScale: 1.26,
+    thumbnail: polyHavenThumb('winter_evening')
+  },
+  {
+    id: 'rathaus',
+    name: 'Rathaus',
+    assetId: 'rathaus',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '8k',
+    price: 3020,
+    exposure: 1.06,
+    environmentIntensity: 1.03,
+    backgroundIntensity: 0.98,
+    swatches: ['#334155', '#f1f5f9'],
+    description: 'Grand interior hall with balanced practical and ambient fill.',
+    cameraHeightM: 1.6,
+    groundRadiusMultiplier: 5.2,
+    groundResolution: 112,
+    arenaScale: 1.28,
+    thumbnail: polyHavenThumb('rathaus')
+  },
+  {
+    id: 'medievalCafe',
+    name: 'Medieval Cafe',
+    assetId: 'medieval_cafe',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '8k',
+    price: 3040,
+    exposure: 1.1,
+    environmentIntensity: 1.06,
+    backgroundIntensity: 1.01,
+    swatches: ['#78350f', '#facc15'],
+    description: 'Rustic indoor café with warm lantern ambiance.',
+    cameraHeightM: 1.58,
+    groundRadiusMultiplier: 5,
+    groundResolution: 112,
+    arenaScale: 1.25,
+    thumbnail: polyHavenThumb('medieval_cafe')
+  }
+]);
+
+export const TEXAS_HDRI_OPTIONS = [...BATTLE_ROYALE_SHARED_HDRI_VARIANTS, ...TEXAS_EXTRA_HDRI_VARIANTS].map((variant) => ({
   ...variant,
   label: `${variant.name} HDRI`
 }));


### PR DESCRIPTION
### Motivation
- Add the requested Poly Haven HDRI environments to the Texas Hold'em game so players can purchase and use them from the store and inventory. 
- Ensure new HDRIs match the existing placement/ground sizing so the poker table remains visually grounded. 

### Description
- Imported `polyHavenThumb` and added a new `TEXAS_EXTRA_HDRI_VARIANTS` list in `webapp/src/config/texasHoldemInventoryConfig.js` containing nine HDRI entries. 
- Added the following HDRIs with `assetId`, preferred/fallback resolutions, `price`, `swatches`, `thumbnail`, exposure/intensity values and arena placement tuning: Church Meeting Room, Warm Bar, Rostock Arches, Vignaioli Night, St. Peters Square Night, Zwinger Night, Winter Evening, Rathaus, Medieval Cafe. 
- Merged `TEXAS_EXTRA_HDRI_VARIANTS` with `BATTLE_ROYALE_SHARED_HDRI_VARIANTS` into `TEXAS_HDRI_OPTIONS` so the new HDRIs appear in the Texas store, inventory and customization flows. 

### Testing
- Verified each new Poly Haven `assetId` resolves by calling `https://api.polyhaven.com/files/<asset_id>` and received HTTP 200 responses for the added assets. 
- Ran a production build with `npm run build` and the build completed successfully (Vite reported unrelated pre-existing warnings). 
- Confirmed the modified file `webapp/src/config/texasHoldemInventoryConfig.js` was committed and included in the working tree for deployment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1e19bd01883298ea410e330f8d3ca)