### PR TITLE
Domino Royale: remove color presets/custom colors and rename/move chair section

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -3756,6 +3756,7 @@ const TABLE_SETUP_SECTIONS = [
     options: ENVIRONMENT_HDRI_OPTIONS
   },
   { key: 'tableTheme', label: 'Table Theme', options: TABLE_THEME_OPTIONS },
+  { key: 'chairTheme', label: 'Chairs', options: CHAIR_THEME_OPTIONS },
   { key: 'tableWood', label: 'Table Finish', options: TABLE_WOOD_OPTIONS },
   { key: 'tableCloth', label: 'Table Cloth', options: TABLE_CLOTH_OPTIONS },
   { key: 'dominoStyle', label: 'Domino Colors', options: DOMINO_STYLE_OPTIONS },
@@ -3765,8 +3766,7 @@ const TABLE_SETUP_SECTIONS = [
     key: 'highlightStyle',
     label: 'Highlights',
     options: HIGHLIGHT_STYLE_OPTIONS
-  },
-  { key: 'chairTheme', label: 'Stolat', options: CHAIR_THEME_OPTIONS }
+  }
 ];
 
 const TABLE_FINISH_THEMES = new Set([
@@ -7105,43 +7105,6 @@ function createOptionPreview(key, option) {
   return swatch;
 }
 
-
-const DOMINO_COLOR_PRESETS = Object.freeze([
-  {
-    id: 'classic-royal',
-    label: 'Classic Royal',
-    dominoBodyColor: '#f8f8fb',
-    dominoDotColor: '#121314',
-    dominoFrameColor: '#d8af37'
-  },
-  {
-    id: 'deep-ocean',
-    label: 'Deep Ocean',
-    dominoBodyColor: '#dbeafe',
-    dominoDotColor: '#0b3b8f',
-    dominoFrameColor: '#38bdf8'
-  },
-  {
-    id: 'ember-glow',
-    label: 'Ember Glow',
-    dominoBodyColor: '#fff1f2',
-    dominoDotColor: '#9f1239',
-    dominoFrameColor: '#fb7185'
-  }
-]);
-
-function matchesDominoColorPreset(preset, currentAppearance) {
-  if (!preset || !currentAppearance) return false;
-  return (
-    (currentAppearance.dominoBodyColor || '').toLowerCase() ===
-      preset.dominoBodyColor.toLowerCase() &&
-    (currentAppearance.dominoDotColor || '').toLowerCase() ===
-      preset.dominoDotColor.toLowerCase() &&
-    (currentAppearance.dominoFrameColor || '').toLowerCase() ===
-      preset.dominoFrameColor.toLowerCase()
-  );
-}
-
 function refreshConfigUI() {
   if (!configSectionsEl) return;
   configSectionsEl.replaceChildren();
@@ -7179,140 +7142,6 @@ function refreshConfigUI() {
     wrapper.appendChild(optionsGrid);
     configSectionsEl.appendChild(wrapper);
   });
-
-  const dominoPresetWrapper = document.createElement('div');
-  dominoPresetWrapper.className = 'config-section';
-  const dominoPresetLabel = document.createElement('h4');
-  dominoPresetLabel.textContent = 'Domino quick color presets';
-  dominoPresetWrapper.appendChild(dominoPresetLabel);
-  const dominoPresetGrid = document.createElement('div');
-  dominoPresetGrid.className = 'config-options';
-  dominoPresetGrid.style.gridTemplateColumns = 'repeat(auto-fit, minmax(120px, 1fr))';
-  DOMINO_COLOR_PRESETS.forEach((preset) => {
-    const presetButton = document.createElement('button');
-    presetButton.type = 'button';
-    presetButton.className = 'config-option';
-    presetButton.style.alignItems = 'stretch';
-    if (matchesDominoColorPreset(preset, appearance)) {
-      presetButton.classList.add('active');
-    }
-    const previewRow = document.createElement('div');
-    previewRow.style.display = 'grid';
-    previewRow.style.gridTemplateColumns = 'repeat(3, minmax(0, 1fr))';
-    previewRow.style.gap = '0.2rem';
-    [preset.dominoBodyColor, preset.dominoDotColor, preset.dominoFrameColor].forEach(
-      (color) => {
-        const swatch = document.createElement('div');
-        swatch.style.height = '1rem';
-        swatch.style.borderRadius = '0.45rem';
-        swatch.style.border = '1px solid rgba(255,255,255,0.18)';
-        swatch.style.background = color;
-        previewRow.appendChild(swatch);
-      }
-    );
-    presetButton.appendChild(previewRow);
-    const presetName = document.createElement('span');
-    presetName.textContent = preset.label;
-    presetButton.appendChild(presetName);
-    presetButton.addEventListener('click', () => {
-      appearance.dominoBodyColor = preset.dominoBodyColor;
-      appearance.dominoDotColor = preset.dominoDotColor;
-      appearance.dominoFrameColor = preset.dominoFrameColor;
-      applyAppearanceChange({ refresh: true });
-    });
-    dominoPresetGrid.appendChild(presetButton);
-  });
-  dominoPresetWrapper.appendChild(dominoPresetGrid);
-  const dominoPresetHint = document.createElement('p');
-  dominoPresetHint.textContent =
-    'Pick 1 of 3 ready combinations for body, dots, and inner frame colors.';
-  dominoPresetHint.style.margin = '0';
-  dominoPresetHint.style.fontSize = '0.65rem';
-  dominoPresetHint.style.color = 'rgba(226,232,240,0.7)';
-  dominoPresetHint.style.lineHeight = '1.4';
-  dominoPresetWrapper.appendChild(dominoPresetHint);
-  configSectionsEl.appendChild(dominoPresetWrapper);
-
-  const customDominoColorWrapper = document.createElement('div');
-  customDominoColorWrapper.className = 'config-section';
-  const customColorLabel = document.createElement('h4');
-  customColorLabel.textContent = 'Custom domino colors';
-  customDominoColorWrapper.appendChild(customColorLabel);
-  const customColorGrid = document.createElement('div');
-  customColorGrid.className = 'config-options';
-  customColorGrid.style.gridTemplateColumns =
-    'repeat(auto-fit, minmax(140px, 1fr))';
-  [
-    {
-      key: 'dominoBodyColor',
-      label: 'Tile body',
-      fallback:
-        currentDominoStyleOption?.body?.color ||
-        currentDominoStyleOption?.preview?.[0] ||
-        '#f8f8fb'
-    },
-    {
-      key: 'dominoDotColor',
-      label: 'Dots',
-      fallback:
-        currentDominoDotStyleOption?.color ||
-        currentDominoStyleOption?.pip?.color ||
-        '#121314'
-    },
-    {
-      key: 'dominoFrameColor',
-      label: 'Frame',
-      fallback:
-        currentDominoFrameStyleOption?.color ||
-        currentDominoStyleOption?.accent?.color ||
-        '#d8af37'
-    }
-  ].forEach((entry) => {
-    const item = document.createElement('div');
-    item.className = 'config-option';
-    item.style.alignItems = 'stretch';
-    const label = document.createElement('span');
-    label.textContent = entry.label;
-    item.appendChild(label);
-    const colorInput = document.createElement('input');
-    colorInput.type = 'color';
-    colorInput.value = appearance[entry.key] || entry.fallback || '#ffffff';
-    colorInput.style.width = '100%';
-    colorInput.style.height = '2rem';
-    colorInput.style.borderRadius = '0.55rem';
-    colorInput.style.border = '1px solid rgba(255,255,255,0.18)';
-    colorInput.style.background = 'rgba(15,23,42,0.72)';
-    colorInput.style.padding = '0.2rem';
-    colorInput.addEventListener('input', () => {
-      appearance[entry.key] = colorInput.value;
-      applyAppearanceChange({ refresh: false });
-    });
-    item.appendChild(colorInput);
-    const resetButton = document.createElement('button');
-    resetButton.type = 'button';
-    resetButton.className = 'config-option';
-    resetButton.style.padding = '0.3rem 0.4rem';
-    resetButton.style.marginTop = '0.25rem';
-    resetButton.style.fontSize = '0.58rem';
-    resetButton.textContent = 'Use style default';
-    resetButton.addEventListener('click', () => {
-      appearance[entry.key] = null;
-      applyAppearanceChange({ refresh: false });
-      refreshConfigUI();
-    });
-    item.appendChild(resetButton);
-    customColorGrid.appendChild(item);
-  });
-  customDominoColorWrapper.appendChild(customColorGrid);
-  const customColorNote = document.createElement('p');
-  customColorNote.textContent =
-    'These colors override presets and let you tune tile body, dots, and frame independently.';
-  customColorNote.style.margin = '0';
-  customColorNote.style.fontSize = '0.65rem';
-  customColorNote.style.color = 'rgba(226,232,240,0.7)';
-  customColorNote.style.lineHeight = '1.4';
-  customDominoColorWrapper.appendChild(customColorNote);
-  configSectionsEl.appendChild(customDominoColorWrapper);
 
   const feedbackWrapper = document.createElement('div');
   feedbackWrapper.className = 'config-section';


### PR DESCRIPTION
### Motivation
- Simplify the Domino Royale table setup UI by removing redundant color selection controls to reduce user confusion and streamline onboarding.
- Make the seating option label clearer by renaming the existing localized label to an English term and placing it earlier in the setup order for discoverability.

### Description
- Removed the `Domino quick color presets` section and the `Custom domino colors` section from the Domino setup UI by deleting their generation code inside `refreshConfigUI` in `webapp/public/domino-royal-game.js`.
- Renamed the chair section label from the localized `Stolat` to `Chairs` and moved the `chairTheme` entry so it appears directly under `Table Theme` in the `TABLE_SETUP_SECTIONS` array in `webapp/public/domino-royal-game.js`.
- Removed the now-unused `DOMINO_COLOR_PRESETS` and `matchesDominoColorPreset` helper definitions from the same file since their UI was removed.

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` to validate there are no syntax errors and it succeeded.
- Verified via project search that the old labels/sections (`Domino quick color presets`, `Custom domino colors`, `Stolat`) were removed/renamed in `webapp/public/domino-royal-game.js`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1e242616c832987ea1803ab0060f1)