### PR TITLE
Fix Pool Royale replay fallback for short shots

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -28417,7 +28417,7 @@ const powerRef = useRef(hud.power);
             : null;
         }
         const shotWasFoul = Boolean(safeState?.foul);
-        if (shotWasFoul && (shotRecording?.frames?.length ?? 0) > 1) {
+        if (shotWasFoul && shotRecording) {
           const foulBanner = 'Foul';
           if (replayDecision) {
             const replayTags = new Set(replayDecision.tags ?? []);
@@ -28442,7 +28442,7 @@ const powerRef = useRef(hud.power);
           replayAccent = replayDecision.primaryTag ?? 'foul';
         }
         const isFinalShot =
-          Boolean(safeState?.frameOver) && (shotRecording?.frames?.length ?? 0) > 1;
+          Boolean(safeState?.frameOver) && Boolean(shotRecording);
         if (isFinalShot) {
           if (replayDecision) {
             const replayTags = new Set(replayDecision.tags ?? []);
@@ -28473,7 +28473,7 @@ const powerRef = useRef(hud.power);
         shouldStartReplay =
           !skipAllReplaysRef.current &&
           Boolean(replayDecision?.shouldReplay) &&
-          (shotRecording?.frames?.length ?? 0) > 1;
+          Boolean(shotRecording);
         const shooterSeat = currentState?.activePlayer === 'B' ? 'B' : 'A';
         if (potted.length) {
           const newPots = potted.filter(


### PR DESCRIPTION
### Motivation
- Pool Royale could skip showing replays for very quick shots (short pots, instant fouls, final shots) because replay eligibility required recordings to contain multiple captured frames, which prevented the existing fallback that synthesizes missing end frames from running.

### Description
- Replace strict `frames.length > 1` gating with checks that accept the presence of a `shotRecording` so the foul/final-shot logic and the final `shouldStartReplay` gate in `webapp/src/pages/Games/PoolRoyale.jsx` rely on `shotRecording` presence and allow the `startShotReplay` fallback to synthesize missing frames and launch playback.

### Testing
- Ran `npm test -- poolRoyaleCueStrokeTimeline.test.js --runInBand`, which passed (4 tests, all green).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1e7a06018832993c8da3b23acc5c4)