### PR TITLE
Show owned custom HDRI thumbnails in Texas Hold'em menu

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -46,6 +46,7 @@ import {
 } from '../../utils/textToSpeech.js';
 import { TEXAS_DEFAULT_HDRI_ID, TEXAS_HDRI_OPTIONS, TEXAS_TABLE_FINISH_OPTIONS } from '../../config/texasHoldemInventoryConfig.js';
 import { resolveTexasHoldemHdriUrl } from '../../utils/texasHoldemHdriPreload.js';
+import { getCustomHdriVariantsForGame } from '../../utils/customHdriCatalog.js';
 import GiftPopup from '../../components/GiftPopup.jsx';
 import InfoPopup from '../../components/InfoPopup.jsx';
 import QuickMessagePopup from '../../components/QuickMessagePopup.jsx';
@@ -971,7 +972,7 @@ function buildClassicOctagonAngles(count) {
   return angles;
 }
 
-function normalizeAppearance(value = {}) {
+function normalizeAppearance(value = {}, hdriOptionCount = TEXAS_HDRI_OPTIONS.length) {
   const normalized = { ...DEFAULT_APPEARANCE };
   const entries = [
     ['tableFinish', TEXAS_TABLE_FINISH_OPTIONS.length],
@@ -981,7 +982,7 @@ function normalizeAppearance(value = {}) {
     ['tableTheme', TEXAS_TABLE_THEME_OPTIONS.length],
     ['tableShape', TABLE_SHAPE_OPTIONS.length],
     ['cards', CARD_THEMES.length],
-    ['environmentHdri', TEXAS_HDRI_OPTIONS.length]
+    ['environmentHdri', hdriOptionCount]
   ];
   entries.forEach(([key, max]) => {
     const raw = Number(value?.[key]);
@@ -3144,6 +3145,30 @@ function TexasHoldemArena({ search }) {
     () => getTexasHoldemInventory(resolvedAccountId),
     [resolvedAccountId, inventoryVersion]
   );
+  const texasHdriOptions = useMemo(() => {
+    const customVariants = getCustomHdriVariantsForGame(
+      'texasholdem',
+      resolvedAccountId,
+      texasInventory?.environmentHdri
+    );
+    if (!customVariants.length) {
+      return TEXAS_HDRI_OPTIONS;
+    }
+    const seen = new Set(TEXAS_HDRI_OPTIONS.map((variant) => variant?.id).filter(Boolean));
+    const uniqueCustom = customVariants
+      .filter((variant) => {
+        if (!variant?.id || seen.has(variant.id)) return false;
+        seen.add(variant.id);
+        return true;
+      })
+      .map((variant) => ({
+        ...variant,
+        label:
+          variant?.label ||
+          `${variant?.name || 'Custom'} HDRI`
+      }));
+    return uniqueCustom.length ? [...TEXAS_HDRI_OPTIONS, ...uniqueCustom] : TEXAS_HDRI_OPTIONS;
+  }, [resolvedAccountId, texasInventory]);
   const [gameState, setGameState] = useState(() => {
     const players = buildPlayers(searchOptions);
     const baseState = buildInitialState(players, searchOptions.token, searchOptions.stake);
@@ -3229,7 +3254,7 @@ function TexasHoldemArena({ search }) {
       const stored = window.localStorage?.getItem(APPEARANCE_STORAGE_KEY);
       if (!stored) return { ...DEFAULT_APPEARANCE };
       const parsed = JSON.parse(stored);
-      return normalizeAppearance(parsed);
+      return normalizeAppearance(parsed, texasHdriOptions.length);
     } catch (error) {
       console.warn('Failed to load Texas Hold\'em appearance', error);
       return { ...DEFAULT_APPEARANCE };
@@ -3237,14 +3262,14 @@ function TexasHoldemArena({ search }) {
   });
   const [turnCountdown, setTurnCountdown] = useState(TURN_DURATION);
   const appearanceRef = useRef(appearance);
-  const hdriVariantRef = useRef(TEXAS_HDRI_OPTIONS[TEXAS_DEFAULT_HDRI_INDEX] ?? TEXAS_HDRI_OPTIONS[0] ?? null);
+  const hdriVariantRef = useRef(texasHdriOptions[TEXAS_DEFAULT_HDRI_INDEX] ?? texasHdriOptions[0] ?? null);
   const disposeEnvironmentRef = useRef(null);
   const envTextureRef = useRef(null);
   const hdriApplyRequestRef = useRef(0);
   const hdriFallbackRetryCountRef = useRef(0);
   const ensureAppearanceUnlocked = useCallback(
     (value = DEFAULT_APPEARANCE) => {
-      const normalized = normalizeAppearance(value);
+      const normalized = normalizeAppearance(value, texasHdriOptions.length);
       const map = {
         tableFinish: TEXAS_TABLE_FINISH_OPTIONS,
         tableCloth: TABLE_CLOTH_OPTIONS,
@@ -3253,7 +3278,7 @@ function TexasHoldemArena({ search }) {
         tableTheme: TEXAS_TABLE_THEME_OPTIONS,
         tableShape: TABLE_SHAPE_OPTIONS,
         cards: CARD_THEMES,
-        environmentHdri: TEXAS_HDRI_OPTIONS
+        environmentHdri: texasHdriOptions
       };
       let changed = false;
       const next = { ...normalized };
@@ -3271,7 +3296,7 @@ function TexasHoldemArena({ search }) {
       });
       return changed ? next : normalized;
     },
-    [texasInventory]
+    [texasHdriOptions, texasInventory]
   );
   useEffect(() => {
     if (effectivePlayerCount > 4) {
@@ -3294,7 +3319,7 @@ function TexasHoldemArena({ search }) {
     () =>
       CUSTOMIZATION_SECTIONS.map((section) => ({
         ...section,
-        options: section.options
+        options: (section.key === 'environmentHdri' ? texasHdriOptions : section.options)
           .map((option, idx) => ({ ...option, idx }))
           .filter(({ id }) => isTexasOptionUnlocked(section.key, id, texasInventory))
       }))
@@ -3304,7 +3329,7 @@ function TexasHoldemArena({ search }) {
           const tableTheme = TEXAS_TABLE_THEME_OPTIONS[appearance.tableTheme] ?? TEXAS_TABLE_THEME_OPTIONS[0];
           return TABLE_STYLE_MENU_THEME_IDS.has(tableTheme?.id);
         }),
-    [appearance.tableTheme, texasInventory]
+    [appearance.tableTheme, texasHdriOptions, texasInventory]
   );
   const [frameRateId, setFrameRateId] = useState(() => {
     if (typeof window !== 'undefined') {
@@ -3426,8 +3451,15 @@ function TexasHoldemArena({ search }) {
         setInventoryVersion((value) => value + 1);
       }
     };
+    const handleCustomHdriUpdate = () => {
+      setInventoryVersion((value) => value + 1);
+    };
     window.addEventListener('texasHoldemInventoryUpdate', handler);
-    return () => window.removeEventListener('texasHoldemInventoryUpdate', handler);
+    window.addEventListener('customHdriCatalogUpdate', handleCustomHdriUpdate);
+    return () => {
+      window.removeEventListener('texasHoldemInventoryUpdate', handler);
+      window.removeEventListener('customHdriCatalogUpdate', handleCustomHdriUpdate);
+    };
   }, [resolvedAccountId]);
 
   useEffect(() => {
@@ -4061,7 +4093,7 @@ function TexasHoldemArena({ search }) {
     }
     const three = threeRef.current;
     if (!three) return;
-    const normalized = normalizeAppearance(appearance);
+    const normalized = normalizeAppearance(appearance, texasHdriOptions.length);
     const safe = enforceShapeForPlayers(normalized, effectivePlayerCount);
     const tableTheme = TEXAS_TABLE_THEME_OPTIONS[safe.tableTheme] ?? TEXAS_TABLE_THEME_OPTIONS[0];
     const woodOption = resolveEffectiveWoodOption({
@@ -4073,9 +4105,9 @@ function TexasHoldemArena({ search }) {
     const chairOption = TEXAS_CHAIR_THEME_OPTIONS[safe.chairTheme] ?? TEXAS_CHAIR_THEME_OPTIONS[0];
     const environmentOption =
       withHdriResolutionPreferences(
-        TEXAS_HDRI_OPTIONS[safe.environmentHdri] ??
-          TEXAS_HDRI_OPTIONS[TEXAS_DEFAULT_HDRI_INDEX] ??
-          TEXAS_HDRI_OPTIONS[0],
+        texasHdriOptions[safe.environmentHdri] ??
+          texasHdriOptions[TEXAS_DEFAULT_HDRI_INDEX] ??
+          texasHdriOptions[0],
         preferredHdriResolutionsRef.current,
         hdriResolutionProfile.fallbackResolution
       );
@@ -4258,7 +4290,7 @@ function TexasHoldemArena({ search }) {
     ) {
       void applyHdriEnvironment(environmentOption);
     }
-  }, [appearance, effectivePlayerCount, hdriResolutionId]);
+  }, [appearance, effectivePlayerCount, hdriResolutionId, texasHdriOptions]);
 
   const renderPreview = useCallback((type, option) => {
     switch (type) {
@@ -4469,7 +4501,7 @@ function TexasHoldemArena({ search }) {
   }, [applyRendererQuality, frameQualityProfile]);
 
   const applyHdriEnvironment = useCallback(
-    async (variantConfig = hdriVariantRef.current || TEXAS_HDRI_OPTIONS[TEXAS_DEFAULT_HDRI_INDEX] || TEXAS_HDRI_OPTIONS[0]) => {
+    async (variantConfig = hdriVariantRef.current || texasHdriOptions[TEXAS_DEFAULT_HDRI_INDEX] || texasHdriOptions[0]) => {
       const three = threeRef.current;
       if (!three?.renderer || !three.scene) return;
       const activeVariant = variantConfig || hdriVariantRef.current;
@@ -4542,7 +4574,7 @@ function TexasHoldemArena({ search }) {
       hdriVariantRef.current = activeVariant;
       loadedHdriResolutionIdRef.current = usedFallbackEnvironment ? null : currentHdriResolutionId;
     },
-    [hdriResolutionId]
+    [hdriResolutionId, texasHdriOptions]
   );
 
   useEffect(() => {
@@ -4579,13 +4611,13 @@ function TexasHoldemArena({ search }) {
     rim.position.set(-4, 3, -4);
     scene.add(rim);
 
-    const initialAppearanceRaw = normalizeAppearance(appearanceRef.current);
+    const initialAppearanceRaw = normalizeAppearance(appearanceRef.current, texasHdriOptions.length);
     const initialAppearance = enforceShapeForPlayers(initialAppearanceRaw, effectivePlayerCount);
     const initialEnvironment =
       withHdriResolutionPreferences(
-        TEXAS_HDRI_OPTIONS[initialAppearance.environmentHdri] ??
-          TEXAS_HDRI_OPTIONS[TEXAS_DEFAULT_HDRI_INDEX] ??
-          TEXAS_HDRI_OPTIONS[0],
+        texasHdriOptions[initialAppearance.environmentHdri] ??
+          texasHdriOptions[TEXAS_DEFAULT_HDRI_INDEX] ??
+          texasHdriOptions[0],
         preferredHdriResolutionsRef.current,
         hdriResolutionProfile.fallbackResolution
       );


### PR DESCRIPTION
### Motivation

- Owned/custom HDRI uploads were not appearing with thumbnails in the Texas Hold'em customization menu, so users who own custom HDRIs couldn't see/select their thumbnails from the in-game menu.

### Description

- Merge owned custom HDRI variants from `getCustomHdriVariantsForGame` into the in-game HDRI option list and de-duplicate them so owned HDRIs appear alongside built-in `TEXAS_HDRI_OPTIONS` with preserved `thumbnail`/`label` metadata.  
- Make HDRI option handling dynamic by adding `texasHdriOptions` and update `normalizeAppearance` to accept a dynamic HDRI option count so stored appearance indices remain valid when the list grows.  
- Switch appearance unlock checks and the customization menu generation to use `texasHdriOptions` for the `environmentHdri` section so owned HDRIs render in the menu grid and can be selected.  
- Wire a listener for `customHdriCatalogUpdate` and bump local inventory version so newly minted/uploaded HDRIs refresh the menu immediately, and use the merged `texasHdriOptions` when applying HDRI environments at runtime.

### Testing

- Ran `npx eslint --no-ignore webapp/src/pages/Games/TexasHoldemArena.jsx` which completed (the repository's ESLint config shows the file is ignored in this environment; no lint errors for the file were reported).  
- Ran `npx eslint webapp/src/pages/Games/TexasHoldemArena.jsx` (default mode) which reported the file is ignored by repo ignore patterns and produced no additional errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1eae479bc8329aefa6a442b27e22c)