### PR TITLE
Tweak Snake & Ladder tile spacing and size for improved readability

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -446,13 +446,13 @@ function createPreciseSnakeTiles(scale = 1) {
   const center = 3;
   const spiral = buildSpiralGrid(7).slice(0, 48);
   const colors = ['#e34b4b', '#46d04d', '#4056d8', '#e8b84a'];
-  const outwardSpread = 1.44;
+  const outwardSpread = 1.49; // nudge tiles a bit farther from center
   const preciseTiles = spiral.map((cell, index) => {
     let level = 0;
     let localIndex = index;
     let baseTop = 0.07;
     let riseStep = 0.012;
-    let size = 0.98;
+    let size = 1.03; // make each tile slightly larger for readability
     if (index >= 24 && index < 40) {
       level = 1;
       localIndex = index - 24;
@@ -463,7 +463,7 @@ function createPreciseSnakeTiles(scale = 1) {
       localIndex = index - 40;
       baseTop = 1.66;
       riseStep = 0.048;
-      size = 0.96;
+      size = 1.0;
     }
     const dx = cell.col - center;
     const dz = cell.row - center;
@@ -481,7 +481,7 @@ function createPreciseSnakeTiles(scale = 1) {
     x: -outwardSpread * 0.54 * scale,
     z: 0,
     y: 2.46 * scale,
-    size: 0.94 * scale,
+    size: 0.98 * scale,
     color: '#3ccfc5'
   });
   preciseTiles.push({
@@ -489,7 +489,7 @@ function createPreciseSnakeTiles(scale = 1) {
     x: outwardSpread * 0.34 * scale,
     z: 0,
     y: 2.9 * scale,
-    size: 1.08 * scale,
+    size: 1.12 * scale,
     color: '#51d95a'
   });
   return preciseTiles;


### PR DESCRIPTION
### Motivation
- Improve visual clarity of the Snake & Ladder board by making tiles slightly larger and nudging them outward so they read better on screen.
- Keep change minimal and isolated to layout/visual parameters rather than gameplay logic.

### Description
- Adjusted the precise tile layout in `createPreciseSnakeTiles` in `webapp/src/components/SnakeBoard3D.jsx` by increasing `outwardSpread` from `1.44` to `1.49` to push tiles slightly farther from the center.
- Increased the default tile size multipliers for the spiral tiles and top tiles (`size` values: `0.98 -> 1.03`, upper-level `0.96 -> 1.0`, tile 49 `0.94 -> 0.98`, tile 50 `1.08 -> 1.12`) so tiles appear larger and more readable.
- Changes are localized to `createPreciseSnakeTiles` and `preciseTiles` construction and do not modify game rules or other board systems.

### Testing
- Ran `npm run build` inside the `webapp/` folder and the production build completed successfully.
- Build output contained existing Vite warnings about a duplicated `case` clause and large chunk sizes, which are unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1fa42bbd08329a4b23a8110639260)