### PR TITLE
Include HDRI Environment thumbnails in Texas Hold'em customization menu

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -807,7 +807,8 @@ const CUSTOMIZATION_SECTIONS = [
   { key: 'chairTheme', label: 'Chairs', options: TEXAS_CHAIR_THEME_OPTIONS },
   { key: 'tableCloth', label: 'Table Cloth', options: TABLE_CLOTH_OPTIONS },
   { key: 'tableShape', label: 'Table Shape', options: TABLE_SHAPE_OPTIONS },
-  { key: 'cards', label: 'Cards', options: CARD_THEMES }
+  { key: 'cards', label: 'Cards', options: CARD_THEMES },
+  { key: 'environmentHdri', label: 'HDRI Environment', options: TEXAS_HDRI_OPTIONS }
 ];
 const TABLE_STYLE_MENU_THEME_IDS = new Set(['murlan-default', 'diamondEdge', 'ovalTable']);
 


### PR DESCRIPTION
### Motivation
- Players could not see or select HDRI environment thumbnails in the Texas Hold'em in-game menu because the HDRI section was not included in the customization sections.

### Description
- Added the `environmentHdri` section to `CUSTOMIZATION_SECTIONS` in `webapp/src/pages/Games/TexasHoldemArena.jsx` by inserting `{ key: 'environmentHdri', label: 'HDRI Environment', options: TEXAS_HDRI_OPTIONS }`, enabling HDRI thumbnail cards to appear in the menu.

### Testing
- Ran `npx eslint webapp/src/pages/Games/TexasHoldemArena.jsx` (lint invoked; file is ignored by current lint config) and `npm --prefix webapp run build`, and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1fc2cdae88329aaf5e65ed5be464a)