### PR TITLE
Increase Snake & Ladder tile size and outward spacing

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -446,13 +446,13 @@ function createPreciseSnakeTiles(scale = 1) {
   const center = 3;
   const spiral = buildSpiralGrid(7).slice(0, 48);
   const colors = ['#e34b4b', '#46d04d', '#4056d8', '#e8b84a'];
-  const outwardSpread = 1.49; // nudge tiles a bit farther from center
+  const outwardSpread = 1.56; // nudge tiles a bit farther from center
   const preciseTiles = spiral.map((cell, index) => {
     let level = 0;
     let localIndex = index;
     let baseTop = 0.07;
     let riseStep = 0.012;
-    let size = 1.03; // make each tile slightly larger for readability
+    let size = 1.08; // make each tile slightly larger for readability
     if (index >= 24 && index < 40) {
       level = 1;
       localIndex = index - 24;
@@ -463,7 +463,7 @@ function createPreciseSnakeTiles(scale = 1) {
       localIndex = index - 40;
       baseTop = 1.66;
       riseStep = 0.048;
-      size = 1.0;
+      size = 1.04;
     }
     const dx = cell.col - center;
     const dz = cell.row - center;
@@ -481,7 +481,7 @@ function createPreciseSnakeTiles(scale = 1) {
     x: -outwardSpread * 0.54 * scale,
     z: 0,
     y: 2.46 * scale,
-    size: 0.98 * scale,
+    size: 1.03 * scale,
     color: '#3ccfc5'
   });
   preciseTiles.push({
@@ -489,7 +489,7 @@ function createPreciseSnakeTiles(scale = 1) {
     x: outwardSpread * 0.34 * scale,
     z: 0,
     y: 2.9 * scale,
-    size: 1.12 * scale,
+    size: 1.18 * scale,
     color: '#51d95a'
   });
   return preciseTiles;


### PR DESCRIPTION
### Motivation
- Improve readability and touch clarity by making the Snake & Ladder board tiles slightly larger and nudging them a bit farther outward on screen.

### Description
- Adjusted values in `webapp/src/components/SnakeBoard3D.jsx`: `outwardSpread` `1.49` → `1.56`, base tile multiplier `1.03` → `1.08`, upper-tier tile multiplier `1.00` → `1.04`, tile 49 size `0.98` → `1.03`, and tile 50 size `1.12` → `1.18`.

### Testing
- Ran `npx eslint webapp/src/components/SnakeBoard3D.jsx` and `npx eslint --no-ignore webapp/src/components/SnakeBoard3D.jsx`, which completed but reported the file is ignored by the repository lint ignore patterns, and no other automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1fcb731188329a9c7b6f86a84e4fd)