### PR TITLE
Adjust Snake & Ladder floor widths to align with tiles

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -2856,7 +2856,7 @@ function buildSnakeBoard(
     { minX: Number.POSITIVE_INFINITY, maxX: Number.NEGATIVE_INFINITY, minZ: Number.POSITIVE_INFINITY, maxZ: Number.NEGATIVE_INFINITY },
     { minX: Number.POSITIVE_INFINITY, maxX: Number.NEGATIVE_INFINITY, minZ: Number.POSITIVE_INFINITY, maxZ: Number.NEGATIVE_INFINITY }
   ];
-  const levelMargins = [TILE_SIZE * 0.78, TILE_SIZE * 0.7, TILE_SIZE * 0.62];
+  const levelMargins = [TILE_SIZE * 0.44, TILE_SIZE * 0.4, TILE_SIZE * 0.36];
   preciseTiles.forEach((tileSpec) => {
     const level = getTileLevelById(tileSpec.id);
     const half = tileSpec.size / 2;
@@ -2886,8 +2886,13 @@ function buildSnakeBoard(
     };
   });
 
-  const baseSize = Math.max(levelDimensions[0].sizeX, levelDimensions[0].sizeZ);
-  addLayer(baseSize, 0.42 * preciseBoardScale, baseSize, -0.36 * preciseBoardScale, '#5a5a5a');
+  addLayer(
+    levelDimensions[0].sizeX * 1.03,
+    0.42 * preciseBoardScale,
+    levelDimensions[0].sizeZ * 1.03,
+    -0.36 * preciseBoardScale,
+    '#5a5a5a'
+  );
   addLayer(levelDimensions[0].sizeX, 0.24 * preciseBoardScale, levelDimensions[0].sizeZ, -0.05 * preciseBoardScale, '#444f5d');
   addLayer(levelDimensions[1].sizeX, 0.24 * preciseBoardScale, levelDimensions[1].sizeZ, 0.76 * preciseBoardScale, '#555555');
   addLayer(levelDimensions[2].sizeX, 0.24 * preciseBoardScale, levelDimensions[2].sizeZ, 1.54 * preciseBoardScale, '#666666');


### PR DESCRIPTION
### Motivation

- Floors on the 3D Snake & Ladder board were visually too wide compared to the tile layout, producing excess side overhang. 
- The change reduces platform margins so the floor geometry better matches the tile footprint and improves visual alignment.

### Description

- Reduced the per-level floor margin values in `webapp/src/components/SnakeBoard3D.jsx` by changing `levelMargins` from `[TILE_SIZE * 0.78, TILE_SIZE * 0.7, TILE_SIZE * 0.62]` to `[TILE_SIZE * 0.44, TILE_SIZE * 0.4, TILE_SIZE * 0.36]` so platforms hug tiles more closely. 
- Replaced the previous square base sizing with level-specific dimensions for the base platform by using `levelDimensions[0].sizeX * 1.03` and `levelDimensions[0].sizeZ * 1.03` (a minimal 3% safety pad) when calling `addLayer`, removing unnecessary width on the sides.
- Modified file: `webapp/src/components/SnakeBoard3D.jsx`.

### Testing

- Ran the production build with `npm --prefix webapp run build`, which completed successfully. 
- Build output contained pre-existing non-blocking Vite warnings about duplicate `case` labels and large chunks, and no new errors were introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d200f24f1083299e04912383bdc8de)