### PR TITLE
Refine Snake & Ladder board visuals, camera controls, and dice pacing

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -248,14 +248,17 @@ const STAIR_CONNECTIONS = LEVEL_START_INDICES.slice(0, -1).map((start, index) =>
 const COIN_SPIN_SPEED = Math.PI / 7;
 const TEXTURE_REPEAT_SCALE = 0.85;
 const CAMERA_DOLLY_FACTOR = ARENA_CAMERA_DEFAULTS.wheelDeltaFactor;
-const CAMERA_EXTRA_LIFT = 0.12;
+const CAMERA_EXTRA_LIFT = 0.28;
 const INITIAL_CAMERA_DISTANCE_FACTOR = 0.96;
 const PORTRAIT_CAMERA_TUNING = Object.freeze({
-  backOffset: 0.82,
-  forwardOffset: 0.6,
-  heightOffset: 1.1,
+  backOffset: 0.78,
+  forwardOffset: 0.72,
+  heightOffset: 1.28,
   targetLift: 0.06 * MODEL_SCALE
 });
+const CAMERA_HEAD_YAW_LIMIT = THREE.MathUtils.degToRad(42);
+const CAMERA_HEAD_PITCH_DOWN_LIMIT = THREE.MathUtils.degToRad(38);
+const CAMERA_HEAD_PITCH_UP_LIMIT = THREE.MathUtils.degToRad(78);
 const COIN_RAISE = TILE_SIZE * 0.24;
 const COIN_LOCAL_LIFT = TILE_SIZE * 0.05;
 
@@ -2523,6 +2526,30 @@ function createJumpLaneResolver(entries = []) {
   return (start) => laneByStart.get(start) ?? { lane: 0, direction: 1 };
 }
 
+function createJumpPathResolver(entries = []) {
+  const sorted = [...entries].sort((a, b) => {
+    const spanA = Math.abs(a[0] - a[1]);
+    const spanB = Math.abs(b[0] - b[1]);
+    return spanB - spanA;
+  });
+  const ranges = [];
+  const byStart = new Map();
+  sorted.forEach(([start, end]) => {
+    const minTile = Math.min(start, end);
+    const maxTile = Math.max(start, end);
+    let lane = 0;
+    while (
+      ranges.some((range) => range.lane === lane && !(maxTile < range.minTile || minTile > range.maxTile))
+    ) {
+      lane += 1;
+    }
+    const direction = lane % 2 === 0 ? 1 : -1;
+    ranges.push({ lane, minTile, maxTile });
+    byStart.set(start, { lane, direction });
+  });
+  return (start) => byStart.get(start) ?? { lane: 0, direction: 1 };
+}
+
 function buildArena(scene, renderer, host, cameraRef, disposeHandlers, appearanceOptions = {}) {
   const arenaTheme = appearanceOptions.arena ?? {};
   const tableTheme = appearanceOptions.tableTheme || {};
@@ -2658,25 +2685,25 @@ function buildArena(scene, renderer, host, cameraRef, disposeHandlers, appearanc
   controls.enableDamping = true;
   controls.dampingFactor = 0.08;
   controls.enablePan = false;
-  controls.enableZoom = false;
+  controls.enableZoom = true;
   controls.zoomSpeed = CAMERA_DOLLY_FACTOR;
-  controls.enableRotate = false;
-  controls.rotateSpeed = 0;
-  controls.touches = { ONE: THREE.TOUCH.NONE, TWO: THREE.TOUCH.NONE };
+  controls.enableRotate = true;
+  controls.rotateSpeed = 0.72;
+  controls.touches = { ONE: THREE.TOUCH.ROTATE, TWO: THREE.TOUCH.DOLLY_PAN };
   controls.mouseButtons = {
     LEFT: null,
     MIDDLE: THREE.MOUSE.DOLLY,
     RIGHT: null
   };
   const initialCameraRadius = camera.position.distanceTo(boardLookTarget);
-  controls.minDistance = initialCameraRadius;
-  controls.maxDistance = initialCameraRadius;
-  controls.minPolarAngle = CAM.phiMin;
-  controls.maxPolarAngle = CAM.phiMax;
+  controls.minDistance = clamp(initialCameraRadius * 0.8, CAM.minR * 0.82, CAM.maxR);
+  controls.maxDistance = clamp(initialCameraRadius * 1.28, CAM.minR, CAM.maxR * 1.12);
+  controls.minPolarAngle = CAMERA_HEAD_PITCH_DOWN_LIMIT;
+  controls.maxPolarAngle = CAMERA_HEAD_PITCH_UP_LIMIT;
   controls.target.copy(boardLookTarget);
   const initialAzimuth = controls.getAzimuthalAngle();
-  controls.minAzimuthAngle = initialAzimuth;
-  controls.maxAzimuthAngle = initialAzimuth;
+  controls.minAzimuthAngle = initialAzimuth - CAMERA_HEAD_YAW_LIMIT;
+  controls.maxAzimuthAngle = initialAzimuth + CAMERA_HEAD_YAW_LIMIT;
   controls.update();
   const startCameraState = {
     position: camera.position.clone(),
@@ -2697,8 +2724,8 @@ function buildArena(scene, renderer, host, cameraRef, disposeHandlers, appearanc
     const radius = clamp(Math.max(needed, currentRadius), CAM.minR, CAM.maxR);
     const dir = camera.position.clone().sub(boardLookTarget).normalize();
     camera.position.copy(boardLookTarget).addScaledVector(dir, radius);
-    controls.minDistance = radius;
-    controls.maxDistance = radius;
+    controls.minDistance = clamp(radius * 0.8, CAM.minR * 0.82, CAM.maxR);
+    controls.maxDistance = clamp(radius * 1.28, CAM.minR, CAM.maxR * 1.12);
     controls.update();
   };
 
@@ -2821,7 +2848,6 @@ function buildSnakeBoard(
   boardRotationRoot.add(tileGroup);
 
   const boardTheme = appearanceOptions.board ?? {};
-  const railTheme = appearanceOptions.rail ?? {};
   const snakeTheme = appearanceOptions.snakeSkin ?? {};
   const diceTheme = appearanceOptions.dice ?? {};
   const highlightColors = createHighlightColors(boardTheme);
@@ -2836,7 +2862,6 @@ function buildSnakeBoard(
   boardRotationRoot.add(labelGroup);
 
   const platformMeshes = [];
-  const railingInfos = [];
   const addLayer = (sizeX, sizeY, sizeZ, y, color) => {
     const mesh = new THREE.Mesh(
       new THREE.BoxGeometry(sizeX, sizeY, sizeZ),
@@ -2927,58 +2952,6 @@ function buildSnakeBoard(
     { tileTopY: 0.88 * preciseBoardScale + tileHeight },
     { tileTopY: 1.66 * preciseBoardScale + tileHeight }
   ];
-  railingInfos.push(
-    {
-      halfSize: Math.max(levelDimensions[0].halfX, levelDimensions[0].halfZ),
-      topY: -0.15 * preciseBoardScale,
-      gapWidth: RAIL_GAP_WIDTH,
-      walkwayCenter: 0,
-      levelIndex: 0
-    },
-    {
-      halfSize: Math.max(levelDimensions[1].halfX, levelDimensions[1].halfZ),
-      topY: 0.07 * preciseBoardScale,
-      gapWidth: RAIL_GAP_WIDTH,
-      walkwayCenter: 0,
-      levelIndex: 1
-    },
-    {
-      halfSize: Math.max(levelDimensions[2].halfX, levelDimensions[2].halfZ),
-      topY: 0.88 * preciseBoardScale,
-      gapWidth: RAIL_GAP_WIDTH,
-      walkwayCenter: 0,
-      levelIndex: 2
-    }
-  );
-
-  railingInfos.forEach(({ halfSize, topY, gapWidth, walkwayCenter, levelIndex }) => {
-    const startIndex = LEVEL_START_INDICES[levelIndex] ?? 1;
-    const startPos = indexToPosition.get(startIndex);
-    const entryConfig = getRailingEntryConfig(levelIndex, indexToPosition);
-    let gapCenter;
-    if (entryConfig.center != null) {
-      gapCenter = entryConfig.center;
-    } else if (startPos) {
-      gapCenter = entryConfig.axis === 'z' ? startPos.z : startPos.x;
-    } else {
-      gapCenter = entryConfig.axis === 'z' ? 0 : walkwayCenter;
-    }
-    addChromeRailings(
-      platformGroup,
-      {
-        halfSize,
-        topY,
-        railHeight: RAIL_HEIGHT,
-        gapWidth,
-        gapCenter,
-        entrySide: entryConfig.side,
-        addNet: levelIndex > 0
-      },
-      platformMeshes,
-      railTheme
-    );
-  });
-
   const baseHalf = Math.max(levelDimensions[0].halfX, levelDimensions[0].halfZ);
   const baseStart = new THREE.Vector3(
     -baseHalf - TILE_SIZE * 0.8,
@@ -3496,7 +3469,7 @@ function updateLadders(group, ladders, indexToPosition, serpentineIndexToXZ, rai
   group.userData.paths = new Map();
 
   const ladderEntries = parseJumpMap(ladders).filter(([a, b]) => b > a);
-  const resolveLadderLane = createJumpLaneResolver(ladderEntries);
+  const resolveLadderLane = createJumpPathResolver(ladderEntries);
   ladderEntries.forEach(([start, end]) => {
     const laneConfig = resolveLadderLane(start);
     const A = (indexToPosition.get(start) || serpentineIndexToXZ(start)).clone();
@@ -3516,10 +3489,10 @@ function updateLadders(group, ladders, indexToPosition, serpentineIndexToXZ, rai
     const baseLift = LADDER_BASE_LIFT;
     const archHeight = Math.min(TILE_SIZE * 1.05, LADDER_ARCH_BASE + len * LADDER_ARCH_SCALE);
     const swayAmount = Math.min(TILE_SIZE * 0.22, LADDER_SWAY_BASE + len * LADDER_SWAY_SCALE);
-    const laneOffset = laneConfig.direction * laneConfig.lane * TILE_SIZE * 0.1;
+    const laneOffset = laneConfig.direction * laneConfig.lane * TILE_SIZE * 0.18;
 
-    const startPoint = pullPointTowardCenter(A.clone().addScaledVector(up, baseLift));
-    const endPoint = pullPointTowardCenter(B.clone().addScaledVector(up, baseLift));
+    const startPoint = A.clone().addScaledVector(up, baseLift);
+    const endPoint = B.clone().addScaledVector(up, baseLift);
     const quarterLift = archHeight * LADDER_INNER_LIFT_RATIO;
     const threeQuarterLift = archHeight * LADDER_OUTER_LIFT_RATIO;
     const clearance = Math.max(LADDER_CLEARANCE, archHeight * 0.3);
@@ -3644,7 +3617,7 @@ function updateSnakes(group, snakes, indexToPosition, serpentineIndexToXZ, snake
   });
 
   const entries = parseJumpMap(snakes).filter(([a, b]) => b < a);
-  const resolveSnakeLane = createJumpLaneResolver(entries);
+  const resolveSnakeLane = createJumpPathResolver(entries);
 
   group.userData.paths = new Map();
 
@@ -3652,8 +3625,8 @@ function updateSnakes(group, snakes, indexToPosition, serpentineIndexToXZ, snake
     const laneConfig = resolveSnakeLane(start);
     const baseStart = (indexToPosition.get(start) || serpentineIndexToXZ(start)).clone();
     const baseEnd = (indexToPosition.get(end) || serpentineIndexToXZ(end)).clone();
-    const startPoint = pullPointTowardCenter(baseStart.clone().add(new THREE.Vector3(0, SNAKE_BASE_LIFT, 0)), TILE_EDGE_INSET * 0.8);
-    const endPoint = pullPointTowardCenter(baseEnd.clone().add(new THREE.Vector3(0, SNAKE_BASE_LIFT, 0)), TILE_EDGE_INSET * 0.8);
+    const startPoint = baseStart.clone().add(new THREE.Vector3(0, SNAKE_BASE_LIFT, 0));
+    const endPoint = baseEnd.clone().add(new THREE.Vector3(0, SNAKE_BASE_LIFT, 0));
     const length = Math.abs(start - end);
     const archHeight = Math.min(TILE_SIZE * 0.9, SNAKE_ARCH_BASE + length * SNAKE_ARCH_SCALE);
     const peak = startPoint.clone().lerp(endPoint, 0.5).add(new THREE.Vector3(0, archHeight + SNAKE_CURVE_CLEARANCE, 0));
@@ -3664,8 +3637,8 @@ function updateSnakes(group, snakes, indexToPosition, serpentineIndexToXZ, snake
       lateral.normalize();
     }
     const lateralAmount =
-      Math.min(TILE_SIZE * 0.18, SNAKE_LATERAL_BASE + length * SNAKE_LATERAL_SCALE) +
-      laneConfig.direction * laneConfig.lane * TILE_SIZE * 0.06;
+      Math.min(TILE_SIZE * 0.26, SNAKE_LATERAL_BASE + length * SNAKE_LATERAL_SCALE) +
+      laneConfig.direction * laneConfig.lane * TILE_SIZE * 0.12;
     const peakLeft = peak.clone().addScaledVector(lateral, lateralAmount);
     const peakRight = peak.clone().addScaledVector(lateral, -lateralAmount);
     const neckPoint = startPoint

--- a/webapp/src/config/snakeInventoryConfig.js
+++ b/webapp/src/config/snakeInventoryConfig.js
@@ -72,10 +72,6 @@ const SNAKE_THEME_THUMBNAILS = Object.freeze({
     onyxChrome: swatchThumbnail(['#111827', '#1f2937', '#e5e7eb']),
     auroraQuartz: swatchThumbnail(['#22d3ee', '#a855f7', '#f0abfc'])
   },
-  railTheme: {
-    obsidianSteel: swatchThumbnail(['#1f2937', '#0f172a', '#93c5fd']),
-    emberBrass: swatchThumbnail(['#f59e0b', '#92400e', '#fde68a'])
-  },
   tokenFinish: {
     matteVelvet: swatchThumbnail(['#6b7280', '#1f2937', '#e2e8f0']),
     holographicPulse: swatchThumbnail(['#a855f7', '#22d3ee', '#f0abfc'])
@@ -101,7 +97,6 @@ export const SNAKE_DEFAULT_UNLOCKS = Object.freeze({
   boardPalette: ['desertMarble'],
   snakeSkin: ['emeraldScales'],
   diceTheme: ['imperialIvory'],
-  railTheme: ['platinumOak'],
   tokenFinish: ['ceramicSheen'],
   tokenColor: ['amberGlow', 'mintVale', 'royalWave', 'roseMist'],
   tableFinish: [SNAKE_TABLE_FINISH_OPTIONS[0].id],
@@ -132,11 +127,6 @@ export const SNAKE_OPTION_LABELS = Object.freeze({
     imperialIvory: 'Imperial Ivory',
     onyxChrome: 'Onyx Chrome',
     auroraQuartz: 'Aurora Quartz'
-  }),
-  railTheme: Object.freeze({
-    platinumOak: 'Platinum & Oak',
-    obsidianSteel: 'Obsidian Steel',
-    emberBrass: 'Ember Brass'
   }),
   tokenFinish: Object.freeze({
     ceramicSheen: 'Ceramic Sheen',
@@ -229,24 +219,6 @@ export const SNAKE_STORE_ITEMS = [
     price: 470,
     description: 'Iridescent quartz finish with neon cyan pips and pink rims.',
     thumbnail: SNAKE_THEME_THUMBNAILS.diceTheme.auroraQuartz
-  },
-  {
-    id: 'rail-obsidianSteel',
-    type: 'railTheme',
-    optionId: 'obsidianSteel',
-    name: 'Obsidian Steel Rails',
-    price: 620,
-    description: 'Graphite rails with steel nets and cool blue ladder hardware.',
-    thumbnail: SNAKE_THEME_THUMBNAILS.railTheme.obsidianSteel
-  },
-  {
-    id: 'rail-emberBrass',
-    type: 'railTheme',
-    optionId: 'emberBrass',
-    name: 'Ember Brass Rails',
-    price: 640,
-    description: 'Brass and ember rails with warm ladder rungs and vivid nets.',
-    thumbnail: SNAKE_THEME_THUMBNAILS.railTheme.emberBrass
   },
   {
     id: 'token-matteVelvet',
@@ -367,7 +339,6 @@ export const SNAKE_DEFAULT_LOADOUT = [
   { type: 'boardPalette', optionId: 'desertMarble', label: 'Desert Marble Board' },
   { type: 'snakeSkin', optionId: 'emeraldScales', label: 'Emerald Scales Skin' },
   { type: 'diceTheme', optionId: 'imperialIvory', label: 'Imperial Ivory Dice' },
-  { type: 'railTheme', optionId: 'platinumOak', label: 'Platinum & Oak Rails' },
   { type: 'tokenFinish', optionId: 'ceramicSheen', label: 'Ceramic Sheen Tokens' },
   { type: 'tokenColor', optionId: 'amberGlow', label: 'Amber Glow Tokens' },
   { type: 'headStyle', optionId: 'current', label: 'Current Pawn Heads' },

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -185,6 +185,7 @@ const TURN_TIME = 15;
 const AI_ROLL_DELAY_MS = 3400;
 const AI_EXTRA_ROLL_DELAY_MS = 2600;
 const TURN_ADVANCE_AFTER_DICE_MS = 850;
+const DICE_RESULT_VISIBLE_MS = 2300;
 const DEFAULT_CAPACITY = 4;
 const COMMENTARY_PRESET_STORAGE_KEY = 'snakeCommentaryPreset';
 const COMMENTARY_MUTE_STORAGE_KEY = 'snakeCommentaryMute';
@@ -542,48 +543,6 @@ const DICE_THEME_OPTIONS = Object.freeze([
     bodyMetalness: 0.52,
     pipEmissive: '#0ea5e9',
     rimEmissive: '#be185d'
-  }
-]);
-
-const RAIL_THEME_OPTIONS = Object.freeze([
-  {
-    id: 'platinumOak',
-    label: 'Platinum & Oak',
-    metal: '#f3f4f6',
-    woodLight: '#d6b68c',
-    woodDark: '#8b5e34',
-    netColor: '#f8fafc',
-    netPrimary: 'rgba(148, 163, 184, 0.7)',
-    netSecondary: 'rgba(15, 23, 42, 0.35)',
-    netOpacity: 0.58,
-    ladderRail: '#ffffff',
-    ladderRung: '#eab308'
-  },
-  {
-    id: 'obsidianSteel',
-    label: 'Obsidian Steel',
-    metal: '#e5e7eb',
-    woodLight: '#4b5563',
-    woodDark: '#1f2937',
-    netColor: '#cbd5f5',
-    netPrimary: 'rgba(96, 165, 250, 0.75)',
-    netSecondary: 'rgba(37, 99, 235, 0.35)',
-    netOpacity: 0.52,
-    ladderRail: '#cbd5f5',
-    ladderRung: '#60a5fa'
-  },
-  {
-    id: 'emberBrass',
-    label: 'Ember Brass',
-    metal: '#fbbf24',
-    woodLight: '#fb923c',
-    woodDark: '#7c2d12',
-    netColor: '#fee2e2',
-    netPrimary: 'rgba(248, 113, 113, 0.7)',
-    netSecondary: 'rgba(185, 28, 28, 0.4)',
-    netOpacity: 0.6,
-    ladderRail: '#fcd34d',
-    ladderRung: '#fb7185'
   }
 ]);
 
@@ -989,7 +948,6 @@ function normalizeAppearance(value = {}) {
     }
   });
   normalized.snakeSkin = 0;
-  normalized.railTheme = 0;
   normalized.tokenFinish = 0;
   return normalized;
 }
@@ -999,7 +957,6 @@ function resolveAppearance(appearance) {
   const arena = ARENA_THEME_OPTIONS[normalized.arenaTheme] ?? ARENA_THEME_OPTIONS[0];
   const board = BOARD_PALETTE_OPTIONS[normalized.boardPalette] ?? BOARD_PALETTE_OPTIONS[0];
   const dice = DICE_THEME_OPTIONS[normalized.diceTheme] ?? DICE_THEME_OPTIONS[0];
-  const rail = RAIL_THEME_OPTIONS[0];
   const token = TOKEN_FINISH_OPTIONS[0];
   const tokenShape = TOKEN_SHAPE_OPTIONS[normalized.tokenShape] ?? TOKEN_SHAPE_OPTIONS[0];
   const pawnHead = PAWN_HEAD_PRESET_OPTIONS[normalized.headStyle] ?? PAWN_HEAD_PRESET_OPTIONS[0];
@@ -1020,7 +977,10 @@ function resolveAppearance(appearance) {
     },
     board: { ...board },
     dice: { ...dice },
-    rail: { ...rail },
+    rail: {
+      ladderRail: board.highlightLadder ?? '#ffffff',
+      ladderRung: board.highlightNormal ?? '#eab308'
+    },
     token: { ...token },
     tokenShape,
     pawnHead,
@@ -2207,7 +2167,7 @@ export default function SnakeAndLadder() {
     };
     const onRolled = ({ value }) => {
       setRollResult(value);
-      setTimeout(() => setRollResult(null), 2000);
+      setTimeout(() => setRollResult(null), DICE_RESULT_VISIBLE_MS);
       playDiceRollSound();
     };
     const onWon = ({ playerId }) => {
@@ -2574,7 +2534,7 @@ export default function SnakeAndLadder() {
       hahaSoundRef.current.currentTime = 0;
       hahaSoundRef.current.play().catch(() => {});
     }
-    setTimeout(() => setRollResult(null), 2000);
+    setTimeout(() => setRollResult(null), DICE_RESULT_VISIBLE_MS);
 
     setTimeout(() => {
       setDiceVisible(false);
@@ -2767,17 +2727,24 @@ export default function SnakeAndLadder() {
         setMoving(false);
         if (!gameOver) {
           const next = extraTurn ? currentTurn : getPreviousTurn(currentTurn);
-          setCurrentTurn(next);
-          setDiceCount(playerDiceCounts[next] ?? 1);
-          if (extraTurn && next === 0) {
-            // Do not delay the local extra roll button after a six/bonus.
-            setRollCooldown(0);
+          const applyNextTurn = () => {
+            setCurrentTurn(next);
+            setDiceCount(playerDiceCounts[next] ?? 1);
+          };
+          if (extraTurn) {
+            applyNextTurn();
+            if (next === 0) {
+              // Do not delay the local extra roll button after a six/bonus.
+              setRollCooldown(0);
+            }
+          } else {
+            setTimeout(applyNextTurn, DICE_RESULT_VISIBLE_MS);
           }
         }
       };
 
       moveSeq(steps, 'normal', ctx, () => applyEffect(target), 'forward');
-    }, 2000);
+    }, DICE_RESULT_VISIBLE_MS);
   };
 
   const triggerAIRoll = (index) => {
@@ -2823,7 +2790,7 @@ export default function SnakeAndLadder() {
       hahaSoundRef.current.currentTime = 0;
       hahaSoundRef.current.play().catch(() => {});
     }
-    setTimeout(() => setRollResult(null), 2000);
+    setTimeout(() => setRollResult(null), DICE_RESULT_VISIBLE_MS);
     setTimeout(() => {
       setDiceVisible(false);
     let positions = [...aiPositions];
@@ -2965,9 +2932,16 @@ export default function SnakeAndLadder() {
         enqueueSnakeCommentaryEvent('bonus', { player: playerLabel });
       }
       const next = extraTurn ? index : getPreviousTurn(index);
-      if (next === 0) setTurnMessage('Your turn');
-      setCurrentTurn(next);
-      setDiceCount(playerDiceCounts[next] ?? 1);
+      const applyNextTurn = () => {
+        if (next === 0) setTurnMessage('Your turn');
+        setCurrentTurn(next);
+        setDiceCount(playerDiceCounts[next] ?? 1);
+      };
+      if (extraTurn) {
+        applyNextTurn();
+      } else {
+        setTimeout(applyNextTurn, DICE_RESULT_VISIBLE_MS);
+      }
       setDiceVisible(true);
       setMoving(false);
       if (extraTurn && next === index) {
@@ -2979,7 +2953,7 @@ export default function SnakeAndLadder() {
       applyEffectHelper(startPos, ctx, (finalPos, type) => finalizeMove(finalPos, type, startPos));
 
     moveSeq(steps, 'normal', ctx, () => applyEffect(target), 'forward');
-    }, 2000);
+    }, DICE_RESULT_VISIBLE_MS);
   };
 
   useEffect(() => {

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -253,7 +253,6 @@ const SNAKE_TYPE_LABELS = {
   boardPalette: 'Board Palette',
   snakeSkin: 'Snake Skins',
   diceTheme: 'Dice Finish',
-  railTheme: 'Rails & Nets',
   tokenFinish: 'Token Finish',
   tokenColor: 'Token Colors',
   headStyle: 'Pawn Heads',
@@ -592,7 +591,6 @@ const TYPE_SWATCHES = {
   boardPalette: ['#38bdf8', '#10b981'],
   snakeSkin: ['#16a34a', '#65a30d'],
   diceTheme: ['#f8fafc', '#e11d48'],
-  railTheme: ['#1e293b', '#64748b'],
   tokenFinish: ['#facc15', '#fb7185'],
   tokenColor: ['#f59e0b', '#10b981'],
   default: ['#22c55e', '#0ea5e9']
@@ -927,10 +925,6 @@ const USAGE_BY_TYPE = {
   diceTheme: {
     title: 'Dice finish',
     description: 'Updates dice materials shown in each roll and replay.'
-  },
-  railTheme: {
-    title: 'Rails & nets',
-    description: 'Changes the board rails and nets for Snake arenas.'
   },
   tokenFinish: {
     title: 'Token finish',


### PR DESCRIPTION
### Motivation
- Remove Rails/Nets cosmetic elements from Snake game visuals and store metadata so the board art and shop reflect the new design direction. 
- Improve jump path precision for snakes and ladders so they attach exactly to tile positions and avoid visual overlap. 
- Make the 3D camera feel more like a seated player: higher, slightly pushed forward, and allow constrained head-like look + zoom without free panning. 
- Make dice result display and turn transitions clearer by holding visible roll results for a short, consistent window before advancing turns.

### Description
- Removed rail/net cosmetics from Snake inventory/store configuration and from the Snake board railing generation so rails/nets no longer appear in store options or are generated on the board. 
- Added `createJumpPathResolver` and replaced previous lane resolver usages so ladders/snakes compute non-overlapping lanes and their curves now anchor directly to source/target tile tops (less inward pulling and improved touch accuracy). 
- Camera and controls updates in `SnakeBoard3D.jsx`: increased `CAMERA_EXTRA_LIFT`, tuned `PORTRAIT_CAMERA_TUNING`, enabled constrained zoom/rotate (`OrbitControls.enableZoom = true`, `enableRotate = true`), added head-like limits (`CAMERA_HEAD_YAW_LIMIT`, `CAMERA_HEAD_PITCH_*`), and relaxed min/max distances so users can zoom while keeping seat framing. 
- Dice/turn pacing updates in `SnakeAndLadder.jsx`: introduced `DICE_RESULT_VISIBLE_MS = 2300` and replaced hard-coded 2s timeouts so roll results remain visible ~2.3s before non-extra-turns advance, while extra-turns (six/bonus) remain immediate for the rolling player. 

### Testing
- Ran `npm test -- --runInBand test/snakeGame.test.js` and the test suite assertions passed (`10/10` tests in that file), however Jest exited non-zero due to existing async/mongoose teardown open-handle warnings (pre-existing in suite). 
- Built the webapp with `npm --prefix webapp run build` which completed successfully. 
- Ran `npx eslint --no-ignore` on edited files which reported existing style issues in `webapp/src/config/snakeInventoryConfig.js` (these were present before this change and are not behavioral regressions).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d20800ee408329b14a83b140e5886b)