### PR TITLE
Refine Snake & Ladder visuals, camera controls, and dice pacing

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -251,11 +251,12 @@ const CAMERA_DOLLY_FACTOR = ARENA_CAMERA_DEFAULTS.wheelDeltaFactor;
 const CAMERA_EXTRA_LIFT = 0.12;
 const INITIAL_CAMERA_DISTANCE_FACTOR = 0.96;
 const PORTRAIT_CAMERA_TUNING = Object.freeze({
-  backOffset: 0.82,
-  forwardOffset: 0.6,
-  heightOffset: 1.1,
+  backOffset: 0.86,
+  forwardOffset: 0.74,
+  heightOffset: 1.32,
   targetLift: 0.06 * MODEL_SCALE
 });
+const SHOW_BOARD_RAILS = false;
 const COIN_RAISE = TILE_SIZE * 0.24;
 const COIN_LOCAL_LIFT = TILE_SIZE * 0.05;
 
@@ -2511,14 +2512,36 @@ function parseJumpMap(data = {}) {
 
 function createJumpLaneResolver(entries = []) {
   const laneByStart = new Map();
-  const densityByBucket = new Map();
-  entries.forEach(([start, end]) => {
-    const bucket = Math.floor((Math.min(start, end) - 1) / 6);
-    const density = densityByBucket.get(bucket) ?? 0;
-    const lane = density % 3;
-    const direction = density % 2 === 0 ? 1 : -1;
-    laneByStart.set(start, { lane, direction });
-    densityByBucket.set(bucket, density + 1);
+  const laneRanges = [];
+  const normalized = [...entries]
+    .map(([start, end]) => ({
+      start,
+      end,
+      min: Math.min(start, end),
+      max: Math.max(start, end),
+      span: Math.abs(end - start)
+    }))
+    .sort((a, b) => b.span - a.span || a.start - b.start);
+
+  normalized.forEach((entry) => {
+    let chosenLane = -1;
+    for (let laneIndex = 0; laneIndex < laneRanges.length; laneIndex += 1) {
+      const overlaps = laneRanges[laneIndex].some(
+        (range) => !(entry.max < range.min - 1 || entry.min > range.max + 1)
+      );
+      if (!overlaps) {
+        chosenLane = laneIndex;
+        break;
+      }
+    }
+    if (chosenLane < 0) {
+      chosenLane = laneRanges.length;
+      laneRanges.push([]);
+    }
+    laneRanges[chosenLane].push({ min: entry.min, max: entry.max });
+    const lane = Math.min(chosenLane, 4);
+    const direction = chosenLane % 2 === 0 ? 1 : -1;
+    laneByStart.set(entry.start, { lane, direction });
   });
   return (start) => laneByStart.get(start) ?? { lane: 0, direction: 1 };
 }
@@ -2658,7 +2681,7 @@ function buildArena(scene, renderer, host, cameraRef, disposeHandlers, appearanc
   controls.enableDamping = true;
   controls.dampingFactor = 0.08;
   controls.enablePan = false;
-  controls.enableZoom = false;
+  controls.enableZoom = true;
   controls.zoomSpeed = CAMERA_DOLLY_FACTOR;
   controls.enableRotate = false;
   controls.rotateSpeed = 0;
@@ -2669,8 +2692,8 @@ function buildArena(scene, renderer, host, cameraRef, disposeHandlers, appearanc
     RIGHT: null
   };
   const initialCameraRadius = camera.position.distanceTo(boardLookTarget);
-  controls.minDistance = initialCameraRadius;
-  controls.maxDistance = initialCameraRadius;
+  controls.minDistance = CAM.minR;
+  controls.maxDistance = CAM.maxR;
   controls.minPolarAngle = CAM.phiMin;
   controls.maxPolarAngle = CAM.phiMax;
   controls.target.copy(boardLookTarget);
@@ -2697,8 +2720,8 @@ function buildArena(scene, renderer, host, cameraRef, disposeHandlers, appearanc
     const radius = clamp(Math.max(needed, currentRadius), CAM.minR, CAM.maxR);
     const dir = camera.position.clone().sub(boardLookTarget).normalize();
     camera.position.copy(boardLookTarget).addScaledVector(dir, radius);
-    controls.minDistance = radius;
-    controls.maxDistance = radius;
+    controls.minDistance = Math.max(CAM.minR, needed * 0.92);
+    controls.maxDistance = CAM.maxR;
     controls.update();
   };
 
@@ -2821,7 +2844,6 @@ function buildSnakeBoard(
   boardRotationRoot.add(tileGroup);
 
   const boardTheme = appearanceOptions.board ?? {};
-  const railTheme = appearanceOptions.rail ?? {};
   const snakeTheme = appearanceOptions.snakeSkin ?? {};
   const diceTheme = appearanceOptions.dice ?? {};
   const highlightColors = createHighlightColors(boardTheme);
@@ -2951,33 +2973,34 @@ function buildSnakeBoard(
     }
   );
 
-  railingInfos.forEach(({ halfSize, topY, gapWidth, walkwayCenter, levelIndex }) => {
-    const startIndex = LEVEL_START_INDICES[levelIndex] ?? 1;
-    const startPos = indexToPosition.get(startIndex);
-    const entryConfig = getRailingEntryConfig(levelIndex, indexToPosition);
-    let gapCenter;
-    if (entryConfig.center != null) {
-      gapCenter = entryConfig.center;
-    } else if (startPos) {
-      gapCenter = entryConfig.axis === 'z' ? startPos.z : startPos.x;
-    } else {
-      gapCenter = entryConfig.axis === 'z' ? 0 : walkwayCenter;
-    }
-    addChromeRailings(
-      platformGroup,
-      {
-        halfSize,
-        topY,
-        railHeight: RAIL_HEIGHT,
-        gapWidth,
-        gapCenter,
-        entrySide: entryConfig.side,
-        addNet: levelIndex > 0
-      },
-      platformMeshes,
-      railTheme
-    );
-  });
+  if (SHOW_BOARD_RAILS) {
+    railingInfos.forEach(({ halfSize, topY, gapWidth, walkwayCenter, levelIndex }) => {
+      const startIndex = LEVEL_START_INDICES[levelIndex] ?? 1;
+      const startPos = indexToPosition.get(startIndex);
+      const entryConfig = getRailingEntryConfig(levelIndex, indexToPosition);
+      let gapCenter;
+      if (entryConfig.center != null) {
+        gapCenter = entryConfig.center;
+      } else if (startPos) {
+        gapCenter = entryConfig.axis === 'z' ? startPos.z : startPos.x;
+      } else {
+        gapCenter = entryConfig.axis === 'z' ? 0 : walkwayCenter;
+      }
+      addChromeRailings(
+        platformGroup,
+        {
+          halfSize,
+          topY,
+          railHeight: RAIL_HEIGHT,
+          gapWidth,
+          gapCenter,
+          entrySide: entryConfig.side,
+          addNet: levelIndex > 0
+        },
+        platformMeshes
+      );
+    });
+  }
 
   const baseHalf = Math.max(levelDimensions[0].halfX, levelDimensions[0].halfZ);
   const baseStart = new THREE.Vector3(
@@ -3516,10 +3539,10 @@ function updateLadders(group, ladders, indexToPosition, serpentineIndexToXZ, rai
     const baseLift = LADDER_BASE_LIFT;
     const archHeight = Math.min(TILE_SIZE * 1.05, LADDER_ARCH_BASE + len * LADDER_ARCH_SCALE);
     const swayAmount = Math.min(TILE_SIZE * 0.22, LADDER_SWAY_BASE + len * LADDER_SWAY_SCALE);
-    const laneOffset = laneConfig.direction * laneConfig.lane * TILE_SIZE * 0.1;
+    const laneOffset = laneConfig.direction * laneConfig.lane * TILE_SIZE * 0.14;
 
-    const startPoint = pullPointTowardCenter(A.clone().addScaledVector(up, baseLift));
-    const endPoint = pullPointTowardCenter(B.clone().addScaledVector(up, baseLift));
+    const startPoint = pullPointTowardCenter(A.clone().addScaledVector(up, baseLift), TILE_EDGE_INSET * 0.2);
+    const endPoint = pullPointTowardCenter(B.clone().addScaledVector(up, baseLift), TILE_EDGE_INSET * 0.2);
     const quarterLift = archHeight * LADDER_INNER_LIFT_RATIO;
     const threeQuarterLift = archHeight * LADDER_OUTER_LIFT_RATIO;
     const clearance = Math.max(LADDER_CLEARANCE, archHeight * 0.3);
@@ -3652,8 +3675,14 @@ function updateSnakes(group, snakes, indexToPosition, serpentineIndexToXZ, snake
     const laneConfig = resolveSnakeLane(start);
     const baseStart = (indexToPosition.get(start) || serpentineIndexToXZ(start)).clone();
     const baseEnd = (indexToPosition.get(end) || serpentineIndexToXZ(end)).clone();
-    const startPoint = pullPointTowardCenter(baseStart.clone().add(new THREE.Vector3(0, SNAKE_BASE_LIFT, 0)), TILE_EDGE_INSET * 0.8);
-    const endPoint = pullPointTowardCenter(baseEnd.clone().add(new THREE.Vector3(0, SNAKE_BASE_LIFT, 0)), TILE_EDGE_INSET * 0.8);
+    const startPoint = pullPointTowardCenter(
+      baseStart.clone().add(new THREE.Vector3(0, SNAKE_BASE_LIFT, 0)),
+      TILE_EDGE_INSET * 0.2
+    );
+    const endPoint = pullPointTowardCenter(
+      baseEnd.clone().add(new THREE.Vector3(0, SNAKE_BASE_LIFT, 0)),
+      TILE_EDGE_INSET * 0.2
+    );
     const length = Math.abs(start - end);
     const archHeight = Math.min(TILE_SIZE * 0.9, SNAKE_ARCH_BASE + length * SNAKE_ARCH_SCALE);
     const peak = startPoint.clone().lerp(endPoint, 0.5).add(new THREE.Vector3(0, archHeight + SNAKE_CURVE_CLEARANCE, 0));
@@ -3665,7 +3694,7 @@ function updateSnakes(group, snakes, indexToPosition, serpentineIndexToXZ, snake
     }
     const lateralAmount =
       Math.min(TILE_SIZE * 0.18, SNAKE_LATERAL_BASE + length * SNAKE_LATERAL_SCALE) +
-      laneConfig.direction * laneConfig.lane * TILE_SIZE * 0.06;
+      laneConfig.direction * laneConfig.lane * TILE_SIZE * 0.1;
     const peakLeft = peak.clone().addScaledVector(lateral, lateralAmount);
     const peakRight = peak.clone().addScaledVector(lateral, -lateralAmount);
     const neckPoint = startPoint
@@ -3801,6 +3830,7 @@ export default function SnakeBoard3D({
   const turnCameraStateRef = useRef(null);
   const startCameraMinYRef = useRef(null);
   const previousTurnRef = useRef(null);
+  const headLookRef = useRef({ yaw: 0, pitch: 0 });
   const lastFrameTimeRef = useRef(0);
   const frameRateRef = useRef(Math.max(30, frameRate || 90));
   const cameraViewModeRef = useRef(cameraViewMode);
@@ -3812,7 +3842,6 @@ export default function SnakeBoard3D({
   const appearanceMemo = useMemo(() => appearance || {}, [keyForEffect, appearance]);
   const tokenTheme = appearanceMemo?.token;
   const tokenShape = appearanceMemo?.tokenShape;
-  const railTheme = appearanceMemo?.rail;
   const snakeTheme = appearanceMemo?.snakeSkin;
 
   useEffect(() => {
@@ -3902,8 +3931,9 @@ export default function SnakeBoard3D({
       controls.enableZoom = true;
       controls.minPolarAngle = topDownPolar;
       controls.maxPolarAngle = topDownPolar;
-      controls.minAzimuthAngle = -Infinity;
-      controls.maxAzimuthAngle = Infinity;
+      const lockedAzimuth = controls.getAzimuthalAngle();
+      controls.minAzimuthAngle = lockedAzimuth;
+      controls.maxAzimuthAngle = lockedAzimuth;
       controls.minDistance = CAM.minR;
       controls.maxDistance = CAM.maxR;
       controls.touches = { ONE: THREE.TOUCH.DOLLY, TWO: THREE.TOUCH.DOLLY };
@@ -4056,16 +4086,20 @@ export default function SnakeBoard3D({
       const absX = Math.abs(deltaX);
       const absY = Math.abs(deltaY);
 
-      if (absY >= absX && absY >= 0.25 && typeof onCameraTiltChange === 'function') {
-        const nextTilt = clamp01(cameraTiltRef.current + deltaY * 0.0015);
-        if (Math.abs(nextTilt - cameraTiltRef.current) > 0.0001) {
-          cameraTiltRef.current = nextTilt;
-          onCameraTiltChange(nextTilt);
+      if (cameraViewModeRef.current === '2d') {
+        if (absY >= absX && absY >= 0.25 && typeof onCameraTiltChange === 'function') {
+          const nextTilt = clamp01(cameraTiltRef.current + deltaY * 0.0015);
+          if (Math.abs(nextTilt - cameraTiltRef.current) > 0.0001) {
+            cameraTiltRef.current = nextTilt;
+            onCameraTiltChange(nextTilt);
+          }
         }
         return;
       }
 
-      if (cameraViewModeRef.current === '2d') return;
+      const look = headLookRef.current;
+      look.yaw = clamp(look.yaw - deltaX * 0.0016, -0.52, 0.52);
+      look.pitch = clamp(look.pitch + deltaY * 0.00125, -0.34, 0.34);
     };
     const onPointerEnd = (event) => {
       if (dragState.pointerId !== event.pointerId) return;
@@ -4220,6 +4254,27 @@ export default function SnakeBoard3D({
             diceAnchorCallbackRef.current(null);
           }
         }
+        if (cameraViewModeRef.current !== '2d') {
+          const look = headLookRef.current;
+          const baseTarget = board?.controls?.target || board?.boardLookTarget || arena.boardLookTarget;
+          if (baseTarget) {
+            const forward = baseTarget.clone().sub(camera.position);
+            const focusDistance = forward.length();
+            if (focusDistance > 1e-6) {
+              forward.normalize();
+              const right = new THREE.Vector3().crossVectors(forward, WORLD_UP);
+              if (right.lengthSq() > 1e-6) {
+                right.normalize();
+                const up = new THREE.Vector3().crossVectors(right, forward).normalize();
+                const lookTarget = baseTarget
+                  .clone()
+                  .addScaledVector(right, look.yaw * focusDistance * 0.52)
+                  .addScaledVector(up, look.pitch * focusDistance * 0.4);
+                camera.lookAt(lookTarget);
+              }
+            }
+          }
+        }
         renderer.render(scene, camera);
       }
     });
@@ -4355,10 +4410,9 @@ export default function SnakeBoard3D({
       ladders,
       boardRef.current.indexToPosition,
       boardRef.current.serpentineIndexToXZ,
-      railTextureRef.current,
-      railTheme
+      railTextureRef.current
     );
-  }, [ladders, ladderOffsets, keyForEffect, railTheme]);
+  }, [ladders, ladderOffsets, keyForEffect]);
 
   useEffect(() => {
     if (!boardRef.current || !snakeTextureRef.current) return;

--- a/webapp/src/config/snakeInventoryConfig.js
+++ b/webapp/src/config/snakeInventoryConfig.js
@@ -72,10 +72,6 @@ const SNAKE_THEME_THUMBNAILS = Object.freeze({
     onyxChrome: swatchThumbnail(['#111827', '#1f2937', '#e5e7eb']),
     auroraQuartz: swatchThumbnail(['#22d3ee', '#a855f7', '#f0abfc'])
   },
-  railTheme: {
-    obsidianSteel: swatchThumbnail(['#1f2937', '#0f172a', '#93c5fd']),
-    emberBrass: swatchThumbnail(['#f59e0b', '#92400e', '#fde68a'])
-  },
   tokenFinish: {
     matteVelvet: swatchThumbnail(['#6b7280', '#1f2937', '#e2e8f0']),
     holographicPulse: swatchThumbnail(['#a855f7', '#22d3ee', '#f0abfc'])
@@ -101,7 +97,6 @@ export const SNAKE_DEFAULT_UNLOCKS = Object.freeze({
   boardPalette: ['desertMarble'],
   snakeSkin: ['emeraldScales'],
   diceTheme: ['imperialIvory'],
-  railTheme: ['platinumOak'],
   tokenFinish: ['ceramicSheen'],
   tokenColor: ['amberGlow', 'mintVale', 'royalWave', 'roseMist'],
   tableFinish: [SNAKE_TABLE_FINISH_OPTIONS[0].id],
@@ -132,11 +127,6 @@ export const SNAKE_OPTION_LABELS = Object.freeze({
     imperialIvory: 'Imperial Ivory',
     onyxChrome: 'Onyx Chrome',
     auroraQuartz: 'Aurora Quartz'
-  }),
-  railTheme: Object.freeze({
-    platinumOak: 'Platinum & Oak',
-    obsidianSteel: 'Obsidian Steel',
-    emberBrass: 'Ember Brass'
   }),
   tokenFinish: Object.freeze({
     ceramicSheen: 'Ceramic Sheen',
@@ -229,24 +219,6 @@ export const SNAKE_STORE_ITEMS = [
     price: 470,
     description: 'Iridescent quartz finish with neon cyan pips and pink rims.',
     thumbnail: SNAKE_THEME_THUMBNAILS.diceTheme.auroraQuartz
-  },
-  {
-    id: 'rail-obsidianSteel',
-    type: 'railTheme',
-    optionId: 'obsidianSteel',
-    name: 'Obsidian Steel Rails',
-    price: 620,
-    description: 'Graphite rails with steel nets and cool blue ladder hardware.',
-    thumbnail: SNAKE_THEME_THUMBNAILS.railTheme.obsidianSteel
-  },
-  {
-    id: 'rail-emberBrass',
-    type: 'railTheme',
-    optionId: 'emberBrass',
-    name: 'Ember Brass Rails',
-    price: 640,
-    description: 'Brass and ember rails with warm ladder rungs and vivid nets.',
-    thumbnail: SNAKE_THEME_THUMBNAILS.railTheme.emberBrass
   },
   {
     id: 'token-matteVelvet',
@@ -367,7 +339,6 @@ export const SNAKE_DEFAULT_LOADOUT = [
   { type: 'boardPalette', optionId: 'desertMarble', label: 'Desert Marble Board' },
   { type: 'snakeSkin', optionId: 'emeraldScales', label: 'Emerald Scales Skin' },
   { type: 'diceTheme', optionId: 'imperialIvory', label: 'Imperial Ivory Dice' },
-  { type: 'railTheme', optionId: 'platinumOak', label: 'Platinum & Oak Rails' },
   { type: 'tokenFinish', optionId: 'ceramicSheen', label: 'Ceramic Sheen Tokens' },
   { type: 'tokenColor', optionId: 'amberGlow', label: 'Amber Glow Tokens' },
   { type: 'headStyle', optionId: 'current', label: 'Current Pawn Heads' },

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -184,7 +184,7 @@ const PENULTIMATE_TILE = FINAL_TILE - 1;
 const TURN_TIME = 15;
 const AI_ROLL_DELAY_MS = 3400;
 const AI_EXTRA_ROLL_DELAY_MS = 2600;
-const TURN_ADVANCE_AFTER_DICE_MS = 850;
+const TURN_ADVANCE_AFTER_DICE_MS = 2300;
 const DEFAULT_CAPACITY = 4;
 const COMMENTARY_PRESET_STORAGE_KEY = 'snakeCommentaryPreset';
 const COMMENTARY_MUTE_STORAGE_KEY = 'snakeCommentaryMute';
@@ -542,48 +542,6 @@ const DICE_THEME_OPTIONS = Object.freeze([
     bodyMetalness: 0.52,
     pipEmissive: '#0ea5e9',
     rimEmissive: '#be185d'
-  }
-]);
-
-const RAIL_THEME_OPTIONS = Object.freeze([
-  {
-    id: 'platinumOak',
-    label: 'Platinum & Oak',
-    metal: '#f3f4f6',
-    woodLight: '#d6b68c',
-    woodDark: '#8b5e34',
-    netColor: '#f8fafc',
-    netPrimary: 'rgba(148, 163, 184, 0.7)',
-    netSecondary: 'rgba(15, 23, 42, 0.35)',
-    netOpacity: 0.58,
-    ladderRail: '#ffffff',
-    ladderRung: '#eab308'
-  },
-  {
-    id: 'obsidianSteel',
-    label: 'Obsidian Steel',
-    metal: '#e5e7eb',
-    woodLight: '#4b5563',
-    woodDark: '#1f2937',
-    netColor: '#cbd5f5',
-    netPrimary: 'rgba(96, 165, 250, 0.75)',
-    netSecondary: 'rgba(37, 99, 235, 0.35)',
-    netOpacity: 0.52,
-    ladderRail: '#cbd5f5',
-    ladderRung: '#60a5fa'
-  },
-  {
-    id: 'emberBrass',
-    label: 'Ember Brass',
-    metal: '#fbbf24',
-    woodLight: '#fb923c',
-    woodDark: '#7c2d12',
-    netColor: '#fee2e2',
-    netPrimary: 'rgba(248, 113, 113, 0.7)',
-    netSecondary: 'rgba(185, 28, 28, 0.4)',
-    netOpacity: 0.6,
-    ladderRail: '#fcd34d',
-    ladderRung: '#fb7185'
   }
 ]);
 
@@ -989,7 +947,6 @@ function normalizeAppearance(value = {}) {
     }
   });
   normalized.snakeSkin = 0;
-  normalized.railTheme = 0;
   normalized.tokenFinish = 0;
   return normalized;
 }
@@ -999,7 +956,6 @@ function resolveAppearance(appearance) {
   const arena = ARENA_THEME_OPTIONS[normalized.arenaTheme] ?? ARENA_THEME_OPTIONS[0];
   const board = BOARD_PALETTE_OPTIONS[normalized.boardPalette] ?? BOARD_PALETTE_OPTIONS[0];
   const dice = DICE_THEME_OPTIONS[normalized.diceTheme] ?? DICE_THEME_OPTIONS[0];
-  const rail = RAIL_THEME_OPTIONS[0];
   const token = TOKEN_FINISH_OPTIONS[0];
   const tokenShape = TOKEN_SHAPE_OPTIONS[normalized.tokenShape] ?? TOKEN_SHAPE_OPTIONS[0];
   const pawnHead = PAWN_HEAD_PRESET_OPTIONS[normalized.headStyle] ?? PAWN_HEAD_PRESET_OPTIONS[0];
@@ -1020,7 +976,6 @@ function resolveAppearance(appearance) {
     },
     board: { ...board },
     dice: { ...dice },
-    rail: { ...rail },
     token: { ...token },
     tokenShape,
     pawnHead,
@@ -2766,12 +2721,18 @@ export default function SnakeAndLadder() {
         setPendingExtraRoll(extraTurn);
         setMoving(false);
         if (!gameOver) {
-          const next = extraTurn ? currentTurn : getPreviousTurn(currentTurn);
-          setCurrentTurn(next);
-          setDiceCount(playerDiceCounts[next] ?? 1);
-          if (extraTurn && next === 0) {
+          if (extraTurn) {
             // Do not delay the local extra roll button after a six/bonus.
-            setRollCooldown(0);
+            const next = currentTurn;
+            setCurrentTurn(next);
+            setDiceCount(playerDiceCounts[next] ?? 1);
+            if (next === 0) setRollCooldown(0);
+          } else {
+            const next = getPreviousTurn(currentTurn);
+            setTimeout(() => {
+              setCurrentTurn(next);
+              setDiceCount(playerDiceCounts[next] ?? 1);
+            }, TURN_ADVANCE_AFTER_DICE_MS);
           }
         }
       };
@@ -2966,8 +2927,15 @@ export default function SnakeAndLadder() {
       }
       const next = extraTurn ? index : getPreviousTurn(index);
       if (next === 0) setTurnMessage('Your turn');
-      setCurrentTurn(next);
-      setDiceCount(playerDiceCounts[next] ?? 1);
+      if (extraTurn) {
+        setCurrentTurn(next);
+        setDiceCount(playerDiceCounts[next] ?? 1);
+      } else {
+        setTimeout(() => {
+          setCurrentTurn(next);
+          setDiceCount(playerDiceCounts[next] ?? 1);
+        }, TURN_ADVANCE_AFTER_DICE_MS);
+      }
       setDiceVisible(true);
       setMoving(false);
       if (extraTurn && next === index) {
@@ -3279,27 +3247,6 @@ export default function SnakeAndLadder() {
           </div>
         );
       }
-      case 'railTheme': {
-        const metal = option.metal ?? '#f3f4f6';
-        const woodLight = option.woodLight ?? '#d6b68c';
-        const woodDark = option.woodDark ?? '#8b5e34';
-        return (
-          <div className="w-full h-14 rounded-xl border border-white/10 flex flex-col justify-center gap-2 px-3">
-            <div
-              className="h-2 rounded-full"
-              style={{ background: `linear-gradient(90deg, ${metal}, ${lightenHex(metal, 0.2)})` }}
-            />
-            <div
-              className="h-2 rounded-full"
-              style={{ background: `linear-gradient(90deg, ${woodLight}, ${woodDark})` }}
-            />
-            <div
-              className="h-2 rounded-full"
-              style={{ background: `linear-gradient(90deg, ${metal}, ${darkenHex(metal, 0.2)})` }}
-            />
-          </div>
-        );
-      }
       case 'tokenFinish': {
         const accent = option.accentTarget ?? '#f8fafc';
         return (
@@ -3339,21 +3286,6 @@ export default function SnakeAndLadder() {
               }}
             />
           </div>
-        );
-      }
-      case 'tableFinish': {
-        const swatches = option.swatches || ['#cbd5f5', '#475569'];
-        return (
-          <div
-            className="w-full h-14 rounded-xl border border-white/10"
-            style={{
-              backgroundImage: option.thumbnail
-                ? `url(${option.thumbnail})`
-                : `linear-gradient(135deg, ${swatches[0]}, ${swatches[1]})`,
-              backgroundSize: 'cover',
-              backgroundPosition: 'center'
-            }}
-          />
         );
       }
       case 'tables': {


### PR DESCRIPTION
### Motivation
- Remove decorative rails/nets from inventory and runtime so board visuals are simplified and rails are no longer purchasable.
- Improve ladder/snake geometry so jump paths anchor precisely to tiles and avoid overlapping lanes.
- Make camera behavior clearer for portrait/2D use and introduce small head-look controls for natural 3D viewing without moving seats.
- Make dice/turn pacing more predictable: show roll result before advancing non-extra turns.

### Description
- Removed rail-theme inventory/store entries, default unlocks and option labels from `webapp/src/config/snakeInventoryConfig.js` so rails/nets are no longer exposed as customization items.
- Disabled board rail/net rendering via `SHOW_BOARD_RAILS = false` and removed use of the rail appearance in `webapp/src/components/SnakeBoard3D.jsx`.
- Reworked jump lane resolver and lane placement logic in `SnakeBoard3D.jsx` to assign lanes by span and avoid overlaps, and tightened `pullPointTowardCenter` usage and lane offsets for both ladders and snakes so endpoints align more precisely with tiles.
- Camera adjustments in `SnakeBoard3D.jsx`: raised portrait tuning (`PORTRAIT_CAMERA_TUNING`), enabled zoom, loosened distance constraints so users can zoom farther/closer, locked 2D azimuth, and added a 3D head-look control (`headLookRef`) so drag left/right/up/down adjusts camera look target without translating seats.
- Dice/turn logic changes in `webapp/src/pages/Games/SnakeAndLadder.jsx`: increased `TURN_ADVANCE_AFTER_DICE_MS` from `850` to `2300` for non-extra-turn progression, and adjusted local/AI turn advancement so six/bonus extra-rolls remain immediate for the same player while other turns advance after the delay.
- Small UI cleanup: removed rail/theme preview case and duplicate `tableFinish` preview branches to match removed rail theming.
- Committed changes with message: "Refine snake board camera, dice pacing, and remove rail cosmetics".

### Testing
- Built production webapp with `npm --prefix webapp run build` and the build completed successfully.
- Ran the Snake game unit tests with `npm test -- test/snakeGame.test.js --runInBand`; the test suite passed but the Jest run exhibited async teardown / open-handle warnings (existing backend async behavior caused non-clean exit) which should be investigated separately.
- Ran ESLint on the touched files with `npx eslint webapp/src/components/SnakeBoard3D.jsx webapp/src/config/snakeInventoryConfig.js webapp/src/pages/Games/SnakeAndLadder.jsx` and the repo ESLint config ignored those paths (no new lint errors reported by the CI lint step).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d20800ee408329b14a83b140e5886b)