### PR TITLE
Tune Checkers Battle Royal furniture grounding and add requested HDRIs

### DIFF
--- a/test/checkersBattleHdriCatalog.test.js
+++ b/test/checkersBattleHdriCatalog.test.js
@@ -1,0 +1,43 @@
+import {
+  POOL_ROYALE_HDRI_VARIANTS,
+  POOL_ROYALE_STORE_ITEMS
+} from '../webapp/src/config/poolRoyaleInventoryConfig.js';
+
+const REQUIRED_CHECKERS_HDRI_IDS = [
+  'churchMeetingRoom',
+  'polyHavenStudio',
+  'cinemaLobby',
+  'warmBar',
+  'pineAttic',
+  'rostockArches',
+  'vignaioliNight',
+  'stPetersSquareNight',
+  'zwingerNight',
+  'winterEvening',
+  'rathaus',
+  'newmanLobby',
+  'lapa',
+  'medievalCafe',
+  'crossfitGym',
+  'voortrekkerInterior'
+];
+
+describe('Checkers Battle Royal shared HDRI catalog', () => {
+  test('contains all requested HDRI variants in shared inventory options', () => {
+    const ids = new Set(POOL_ROYALE_HDRI_VARIANTS.map((option) => option.id));
+    REQUIRED_CHECKERS_HDRI_IDS.forEach((id) => {
+      expect(ids.has(id)).toBe(true);
+    });
+  });
+
+  test('contains all requested HDRI variants in store purchasables', () => {
+    const storeHdriIds = new Set(
+      POOL_ROYALE_STORE_ITEMS.filter((item) => item.type === 'environmentHdri').map(
+        (item) => item.optionId
+      )
+    );
+    REQUIRED_CHECKERS_HDRI_IDS.forEach((id) => {
+      expect(storeHdriIds.has(id)).toBe(true);
+    });
+  });
+});

--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -77,11 +77,59 @@ const POOL_ROYALE_HDRI_PLACEMENTS = Object.freeze({
     groundResolution: 112,
     arenaScale: 1.26
   },
+  churchMeetingRoom: {
+    cameraHeightM: 1.56,
+    groundRadiusMultiplier: 4.9,
+    groundResolution: 112,
+    arenaScale: 1.23
+  },
+  warmBar: {
+    cameraHeightM: 1.52,
+    groundRadiusMultiplier: 4.6,
+    groundResolution: 112,
+    arenaScale: 1.2
+  },
   pineAttic: {
     cameraHeightM: 1.56,
     groundRadiusMultiplier: 4.8,
     groundResolution: 112,
     arenaScale: 1.22
+  },
+  rostockArches: {
+    cameraHeightM: 1.6,
+    groundRadiusMultiplier: 5.3,
+    groundResolution: 112,
+    arenaScale: 1.28
+  },
+  vignaioliNight: {
+    cameraHeightM: 1.57,
+    groundRadiusMultiplier: 5,
+    groundResolution: 112,
+    arenaScale: 1.25
+  },
+  stPetersSquareNight: {
+    cameraHeightM: 1.62,
+    groundRadiusMultiplier: 5.6,
+    groundResolution: 112,
+    arenaScale: 1.33
+  },
+  zwingerNight: {
+    cameraHeightM: 1.6,
+    groundRadiusMultiplier: 5.4,
+    groundResolution: 112,
+    arenaScale: 1.29
+  },
+  winterEvening: {
+    cameraHeightM: 1.58,
+    groundRadiusMultiplier: 5.1,
+    groundResolution: 112,
+    arenaScale: 1.26
+  },
+  rathaus: {
+    cameraHeightM: 1.58,
+    groundRadiusMultiplier: 5.1,
+    groundResolution: 112,
+    arenaScale: 1.26
   },
   newmanLobby: {
     cameraHeightM: 1.58,
@@ -94,6 +142,12 @@ const POOL_ROYALE_HDRI_PLACEMENTS = Object.freeze({
     groundRadiusMultiplier: 5.1,
     groundResolution: 112,
     arenaScale: 1.26
+  },
+  medievalCafe: {
+    cameraHeightM: 1.56,
+    groundRadiusMultiplier: 4.9,
+    groundResolution: 112,
+    arenaScale: 1.23
   },
   crossfitGym: {
     cameraHeightM: 1.54,
@@ -267,6 +321,32 @@ const RAW_POOL_ROYALE_HDRI_VARIANTS = [
     description: 'Moody lobby reflections with warm marquee accents.'
   },
   {
+    id: 'churchMeetingRoom',
+    name: 'Church Meeting Room',
+    assetId: 'church_meeting_room',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 2560,
+    exposure: 1.08,
+    environmentIntensity: 1.05,
+    backgroundIntensity: 1,
+    swatches: ['#78716c', '#e7e5e4'],
+    description: 'Quiet church hall ambience with soft diffuse overhead light.'
+  },
+  {
+    id: 'warmBar',
+    name: 'Warm Bar',
+    assetId: 'warm_bar',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 2580,
+    exposure: 1.09,
+    environmentIntensity: 1.06,
+    backgroundIntensity: 1.01,
+    swatches: ['#78350f', '#f97316'],
+    description: 'Cozy bar interior with rich amber highlights and warm reflections.'
+  },
+  {
     id: 'pineAttic',
     name: 'Pine Attic',
     assetId: 'pine_attic',
@@ -278,6 +358,84 @@ const RAW_POOL_ROYALE_HDRI_VARIANTS = [
     backgroundIntensity: 1,
     swatches: ['#854d0e', '#eab308'],
     description: 'Attic daylight filtered through pine timbers and warm wood bounce.'
+  },
+  {
+    id: 'rostockArches',
+    name: 'Rostock Arches',
+    assetId: 'rostock_arches',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 2620,
+    exposure: 1.07,
+    environmentIntensity: 1.04,
+    backgroundIntensity: 0.99,
+    swatches: ['#475569', '#cbd5e1'],
+    description: 'Historic stone arches with cool exterior spill and broad contrast.'
+  },
+  {
+    id: 'vignaioliNight',
+    name: 'Vignaioli Night',
+    assetId: 'vignaioli_night',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 2640,
+    exposure: 1.1,
+    environmentIntensity: 1.07,
+    backgroundIntensity: 1.02,
+    swatches: ['#1d4ed8', '#f59e0b'],
+    description: 'Nighttime courtyard with colorful practicals and cinematic contrast.'
+  },
+  {
+    id: 'stPetersSquareNight',
+    name: 'St. Peters Square Night',
+    assetId: 'st_peters_square_night',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 2660,
+    exposure: 1.09,
+    environmentIntensity: 1.06,
+    backgroundIntensity: 1.01,
+    swatches: ['#0f172a', '#f8fafc'],
+    description: 'Grand night plaza lighting with polished marble bounce and deep sky.'
+  },
+  {
+    id: 'zwingerNight',
+    name: 'Zwinger Night',
+    assetId: 'zwinger_night',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 2680,
+    exposure: 1.08,
+    environmentIntensity: 1.05,
+    backgroundIntensity: 1,
+    swatches: ['#1e3a8a', '#fcd34d'],
+    description: 'Illuminated baroque architecture with balanced cool-warm contrast.'
+  },
+  {
+    id: 'winterEvening',
+    name: 'Winter Evening',
+    assetId: 'winter_evening',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 2700,
+    exposure: 1.06,
+    environmentIntensity: 1.03,
+    backgroundIntensity: 0.98,
+    swatches: ['#334155', '#93c5fd'],
+    description: 'Cold dusk atmosphere with soft ambient fill and muted reflections.'
+  },
+  {
+    id: 'rathaus',
+    name: 'Rathaus',
+    assetId: 'rathaus',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 2710,
+    exposure: 1.08,
+    environmentIntensity: 1.05,
+    backgroundIntensity: 1,
+    swatches: ['#374151', '#fbbf24'],
+    description: 'Historic town hall lighting with warm facades and neutral shadows.'
   },
   {
     id: 'newmanLobby',
@@ -304,6 +462,19 @@ const RAW_POOL_ROYALE_HDRI_VARIANTS = [
     backgroundIntensity: 1,
     swatches: ['#0f766e', '#facc15'],
     description: 'Open urban scene with rich night color contrast and lively reflections.'
+  },
+  {
+    id: 'medievalCafe',
+    name: 'Medieval Cafe',
+    assetId: 'medieval_cafe',
+    preferredResolutions: ['4k', '2k'],
+    fallbackResolution: '4k',
+    price: 2760,
+    exposure: 1.08,
+    environmentIntensity: 1.05,
+    backgroundIntensity: 1,
+    swatches: ['#7c2d12', '#fcd34d'],
+    description: 'Rustic café ambience with warm practical lights and cozy interior bounce.'
   },
   {
     id: 'crossfitGym',

--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -56,7 +56,7 @@ import { socket } from '../../utils/socket.js';
 const SIZE = 8;
 const CHECKERS_ARENA_SCALE = 0.52;
 const MODEL_SCALE = 0.75 * CHECKERS_ARENA_SCALE;
-const STOOL_SCALE = 1.12 * CHECKERS_ARENA_SCALE;
+const STOOL_SCALE = 0.92 * CHECKERS_ARENA_SCALE;
 const TABLE_RADIUS = 3.4 * MODEL_SCALE;
 const BASE_TABLE_HEIGHT = 1.08 * MODEL_SCALE;
 const SEAT_THICKNESS = 0.09 * MODEL_SCALE * STOOL_SCALE;
@@ -264,14 +264,18 @@ const CHAIR_MODEL_URLS = [
   'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/SheenChair/glTF-Binary/SheenChair.glb',
   'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/AntiqueChair/glTF-Binary/AntiqueChair.glb'
 ];
+const CHAIR_TARGET_SCALE_FACTOR = 0.84;
 const TARGET_CHAIR_SIZE = new THREE.Vector3(
-  1.3162499970197679,
-  1.9173749900311232,
-  1.7001562547683715
+  1.3162499970197679 * CHAIR_TARGET_SCALE_FACTOR,
+  1.9173749900311232 * CHAIR_TARGET_SCALE_FACTOR,
+  1.7001562547683715 * CHAIR_TARGET_SCALE_FACTOR
 );
 const TARGET_CHAIR_MIN_Y = -CHAIR_BASE_HEIGHT;
 const TARGET_CHAIR_CENTER_Z = -0.1553906416893005;
 const CHAIR_GROUNDING_EPSILON = 0.012 * MODEL_SCALE;
+const SHADOW_CATCHER_SIZE = CHECKERS_ROOM_HALF_SPAN * 2.9;
+const SHADOW_CATCHER_OPACITY = 0.26;
+const SHADOW_CATCHER_ELEVATION = 0.004;
 const MOVE_SOUND_URL = '/assets/sounds/domino-pieces-1-32112 (mp3cut.net).mp3';
 const TAP_MAX_DISTANCE_PX = 16;
 const TAP_MAX_DURATION_MS = 340;
@@ -1111,6 +1115,21 @@ function resolveArenaFloorY(...groups) {
   return hasObject && Number.isFinite(box.min.y) ? box.min.y : 0;
 }
 
+function alignArenaGroundArtifacts({ shadowCatcher, skybox, table, board, chairs }) {
+  const floorY = resolveArenaFloorY(
+    table?.group,
+    board,
+    ...((chairs || []).filter(Boolean))
+  );
+  if (shadowCatcher) {
+    shadowCatcher.position.y = floorY + SHADOW_CATCHER_ELEVATION;
+  }
+  if (skybox?.userData?.cameraHeight) {
+    skybox.position.y = floorY + skybox.userData.cameraHeight;
+  }
+  return floorY;
+}
+
 function reduceCheckersTableBase(tableGroup) {
   if (!tableGroup) return;
   tableGroup.traverse((node) => {
@@ -1333,6 +1352,8 @@ export default function CheckersBattleRoyal() {
   const controlsRef = useRef(null);
   const tableRef = useRef(null);
   const chairsRef = useRef([]);
+  const keyLightRef = useRef(null);
+  const shadowCatcherRef = useRef(null);
   const envRef = useRef({ map: null, skybox: null });
   const boardThemeRef = useRef(CHECKERS_BOARD_THEME_OPTIONS[0]);
   const gltfBoardRef = useRef(null);
@@ -1804,6 +1825,7 @@ export default function CheckersBattleRoyal() {
     renderer.toneMapping = THREE.ACESFilmicToneMapping;
     applyRendererSRGB(renderer);
     renderer.shadowMap.enabled = true;
+    renderer.shadowMap.type = THREE.PCFSoftShadowMap;
     mount.appendChild(renderer.domElement);
 
     const camera = new THREE.PerspectiveCamera(
@@ -1856,7 +1878,32 @@ export default function CheckersBattleRoyal() {
     const key = new THREE.DirectionalLight('#ffffff', 1.08);
     key.position.set(18, 26, 12);
     key.castShadow = true;
+    key.shadow.mapSize.set(2048, 2048);
+    key.shadow.bias = -0.00008;
+    key.shadow.normalBias = 0.03;
+    key.shadow.radius = 2.8;
+    key.shadow.camera.near = 1;
+    key.shadow.camera.far = 120;
+    key.shadow.camera.left = -16;
+    key.shadow.camera.right = 16;
+    key.shadow.camera.top = 16;
+    key.shadow.camera.bottom = -16;
+    keyLightRef.current = key;
     scene.add(key);
+    const shadowCatcher = new THREE.Mesh(
+      new THREE.CircleGeometry(SHADOW_CATCHER_SIZE, 72),
+      new THREE.ShadowMaterial({
+        color: '#000000',
+        transparent: true,
+        opacity: SHADOW_CATCHER_OPACITY
+      })
+    );
+    shadowCatcher.rotation.x = -Math.PI / 2;
+    shadowCatcher.receiveShadow = true;
+    shadowCatcher.position.y = SHADOW_CATCHER_ELEVATION;
+    shadowCatcher.renderOrder = 1;
+    shadowCatcherRef.current = shadowCatcher;
+    scene.add(shadowCatcher);
 
     const piecesGroup = new THREE.Group();
     piecesGroupRef.current = piecesGroup;
@@ -2271,6 +2318,14 @@ export default function CheckersBattleRoyal() {
         )
       };
 
+      alignArenaGroundArtifacts({
+        shadowCatcher: shadowCatcherRef.current,
+        skybox: envRef.current?.skybox,
+        table: tableRef.current,
+        board: gltfBoardRef.current || proceduralBoard,
+        chairs: chairsRef.current
+      });
+
       setupPickTiles();
       renderPieces();
       renderCapturedPieces();
@@ -2664,15 +2719,33 @@ export default function CheckersBattleRoyal() {
           groundRadius,
           skyboxResolution
         );
-        const floorY = resolveArenaFloorY(
-          tableRef.current?.group,
-          gltfBoardRef.current,
-          ...((chairsRef.current || []).filter(Boolean))
-        );
-        skybox.position.y = floorY + cameraHeight;
+        skybox.userData.cameraHeight = cameraHeight;
         if (typeof variant?.rotationY === 'number')
           skybox.rotation.y = variant.rotationY;
         scene.add(skybox);
+        alignArenaGroundArtifacts({
+          shadowCatcher: shadowCatcherRef.current,
+          skybox,
+          table: tableRef.current,
+          board: gltfBoardRef.current,
+          chairs: chairsRef.current
+        });
+        const keyLight = keyLightRef.current;
+        if (keyLight) {
+          const lightAngle =
+            (typeof variant?.rotationY === 'number' ? variant.rotationY : 0) +
+            Math.PI * 0.28;
+          keyLight.position.set(
+            Math.cos(lightAngle) * 18,
+            25,
+            Math.sin(lightAngle) * 18
+          );
+          keyLight.intensity = THREE.MathUtils.clamp(
+            (variant?.environmentIntensity ?? 1.06) * 0.92,
+            0.72,
+            1.2
+          );
+        }
         envRef.current = { map: envMap, skybox, hdriId: appearance.hdriId };
       } catch (error) {
         console.error('Checkers HDRI swap failed:', error);


### PR DESCRIPTION
### Motivation
- Fix visual issues where chairs appeared too large and chair/table legs did not reliably touch the HDRI-grounded floor, and add requested Poly Haven HDRIs to the shared Battle Royale catalog so they appear in the store and inventory. 

### Description
- Reduced chair/stool scale and tightened the imported chair footprint by adding `CHAIR_TARGET_SCALE_FACTOR` and lowering `STOOL_SCALE` so chairs render smaller on screen and match the requested visual scale. 
- Improved grounding and HDRI alignment by adding `alignArenaGroundArtifacts(...)`, wiring it to arena build and HDRI swaps, and using `resolveArenaFloorY(...)` so table/chair bottoms align with the HDRI-grounded floor. 
- Added a soft shadow-catcher plane and tuned renderer/directional-light shadow parameters (`PCFSoftShadowMap`, shadow map size, bias, radius, camera extents) and re-oriented key light on HDRI swap to produce more natural HDRI-derived shadows. 
- Expanded `POOL_ROYALE_HDRI_PLACEMENTS` and `RAW_POOL_ROYALE_HDRI_VARIANTS` in `webapp/src/config/poolRoyaleInventoryConfig.js` to add the requested Poly Haven HDRIs (Church Meeting Room, Warm Bar, Rostock Arches, Vignaioli Night, St. Peters Square Night, Zwinger Night, Winter Evening, Rathaus, Medieval Cafe plus the already-present variants such as Poly Haven Studio, Cinema Lobby, Pine Attic, Newman Lobby, Lapa, Crossfit Gym, Voortrekker Interior). 
- Added a regression test `test/checkersBattleHdriCatalog.test.js` that verifies the new HDRI IDs are present in the shared HDRI variants and in store purchasables. 

### Testing
- Ran the new unit test and an existing HDRI inventory test with: `npm test -- --runInBand test/checkersBattleHdriCatalog.test.js test/texasHoldemInventoryConfig.test.js`, and both suites passed. 
- Test result: 2 test suites, 4 tests — all passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d21239f2608329a0481c3702d91bde)