### PR TITLE
Adjust Checkers Battle Royal chair scale and vertical alignment

### DIFF
--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -56,12 +56,12 @@ import { socket } from '../../utils/socket.js';
 const SIZE = 8;
 const CHECKERS_ARENA_SCALE = 0.52;
 const MODEL_SCALE = 0.75 * CHECKERS_ARENA_SCALE;
-const STOOL_SCALE = 0.92 * CHECKERS_ARENA_SCALE;
+const STOOL_SCALE = 0.88 * CHECKERS_ARENA_SCALE;
 const TABLE_RADIUS = 3.4 * MODEL_SCALE;
 const BASE_TABLE_HEIGHT = 1.08 * MODEL_SCALE;
 const SEAT_THICKNESS = 0.09 * MODEL_SCALE * STOOL_SCALE;
 const CHAIR_BASE_HEIGHT =
-  BASE_TABLE_HEIGHT - SEAT_THICKNESS * 0.85 - 0.14 * MODEL_SCALE;
+  BASE_TABLE_HEIGHT - SEAT_THICKNESS * 0.85 - 0.17 * MODEL_SCALE;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
 const TABLE_HEIGHT = STOOL_HEIGHT + 0.05 * MODEL_SCALE;
 const BOARD_SCALE = 0.064 * CHECKERS_ARENA_SCALE;
@@ -264,7 +264,7 @@ const CHAIR_MODEL_URLS = [
   'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/SheenChair/glTF-Binary/SheenChair.glb',
   'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/AntiqueChair/glTF-Binary/AntiqueChair.glb'
 ];
-const CHAIR_TARGET_SCALE_FACTOR = 0.84;
+const CHAIR_TARGET_SCALE_FACTOR = 0.8;
 const TARGET_CHAIR_SIZE = new THREE.Vector3(
   1.3162499970197679 * CHAIR_TARGET_SCALE_FACTOR,
   1.9173749900311232 * CHAIR_TARGET_SCALE_FACTOR,


### PR DESCRIPTION
### Motivation
- Make checkers chairs slightly smaller and lower their vertical placement so chair legs line up visually with the bottom of the table base.

### Description
- Reduced `STOOL_SCALE` from `0.92` to `0.88`, lowered the chair baseline by increasing the subtraction in `CHAIR_BASE_HEIGHT` from `0.14 * MODEL_SCALE` to `0.17 * MODEL_SCALE`, and reduced `CHAIR_TARGET_SCALE_FACTOR` from `0.84` to `0.8` so both GLTF chairs and procedural fallbacks match the new proportions.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully (Vite produced only non-blocking warnings about chunking and dynamic imports).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2154590388329a7efb173a25612e8)