### PR TITLE
Snake & Ladders: align camera drag, tweak 2D framing, lower avatar and add dice handoff + touch hotspot

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -269,6 +269,8 @@ const LANDSCAPE_CAMERA_TUNING = Object.freeze({
 const SHOW_BOARD_RAILS = false;
 const COIN_RAISE = TILE_SIZE * 0.24;
 const COIN_LOCAL_LIFT = TILE_SIZE * 0.05;
+const CAMERA_2D_DISTANCE_FACTOR = 2.45;
+const CAMERA_2D_FORWARD_FACTOR = 0.7;
 
 const AVATAR_ANCHOR_HEIGHT = SEAT_THICKNESS / 2 + BACK_HEIGHT * 0.85;
 
@@ -2216,6 +2218,39 @@ function createDiceSettleAnimation(diceArray, { basePositions, baseY, startState
   };
 }
 
+function createDiceHandoffAnimation(diceArray, { basePositions, baseY }) {
+  if (!Array.isArray(diceArray) || !diceArray.length || !Array.isArray(basePositions) || !basePositions.length) {
+    return null;
+  }
+  const startPositions = diceArray.map((die) => die.position.clone());
+  const duration = 380;
+  return {
+    type: 'diceHandoff',
+    start: performance.now(),
+    update(now) {
+      const t = clamp01((now - this.start) / duration);
+      const eased = easeInOutCubic(t);
+      diceArray.forEach((die, index) => {
+        const from = startPositions[index] || die.position;
+        const to = basePositions[index] || die.position;
+        die.position.copy(from.clone().lerp(to, eased));
+        die.position.y = baseY;
+      });
+      if (t >= 1) {
+        diceArray.forEach((die, index) => {
+          const to = basePositions[index];
+          if (to) {
+            die.position.copy(to);
+            die.position.y = baseY;
+          }
+        });
+        return true;
+      }
+      return false;
+    }
+  };
+}
+
 function createTileLabel(number) {
   const size = 256;
   const canvas = document.createElement('canvas');
@@ -3928,9 +3963,9 @@ export default function SnakeBoard3D({
           mouseButtons: { ...controls.mouseButtons }
         };
       }
-      const topDownDistance = clamp(CAM.minR * 2.25, CAM.minR * 1.55, CAM.maxR * 0.96);
+      const topDownDistance = clamp(CAM.minR * CAMERA_2D_DISTANCE_FACTOR, CAM.minR * 1.55, CAM.maxR * 0.96);
       const verticalDistance = Math.cos(topDownPolar) * topDownDistance;
-      const forwardDistance = Math.sin(topDownPolar) * topDownDistance;
+      const forwardDistance = Math.sin(topDownPolar) * topDownDistance * CAMERA_2D_FORWARD_FACTOR;
       camera.position.set(
         boardLookTarget.x,
         boardLookTarget.y + verticalDistance,
@@ -4164,7 +4199,7 @@ export default function SnakeBoard3D({
       }
 
       const look = headLookRef.current;
-      look.yaw = clamp(look.yaw - deltaX * 0.0016, -0.52, 0.52);
+      look.yaw = clamp(look.yaw + deltaX * 0.0016, -0.52, 0.52);
       look.pitch = clamp(look.pitch + deltaY * 0.00125, -0.34, 0.34);
     };
     const onPointerEnd = (event) => {
@@ -4633,6 +4668,30 @@ export default function SnakeBoard3D({
   }, [slide, onSlideComplete, cameraViewMode]);
 
   useEffect(() => {
+    const board = boardRef.current;
+    if (!board || !Number.isInteger(currentTurn) || currentTurn < 0) return;
+    if (diceStateRef.current?.currentId != null) return;
+    const seatCount = Array.isArray(board.seatAnchors) ? board.seatAnchors.length : 0;
+    if (seatCount <= 0) return;
+    const seatIndex = Math.max(0, Math.min(seatCount - 1, currentTurn));
+    const visibleDice = Array.isArray(board.diceSet) ? board.diceSet.filter((die) => die?.visible) : [];
+    if (!visibleDice.length) return;
+    const layout = computeDiceThrowLayout(board, seatIndex, visibleDice.length);
+    const basePositions = Array.isArray(layout.basePositions) ? layout.basePositions : [];
+    if (!basePositions.length) return;
+    removeAnimationsByType(animationsRef.current, 'diceHandoff');
+    const handoffAnimation = createDiceHandoffAnimation(visibleDice, {
+      basePositions,
+      baseY: board.diceBaseY ?? 0
+    });
+    if (handoffAnimation) animationsRef.current.push(handoffAnimation);
+    diceStateRef.current = {
+      ...(diceStateRef.current || {}),
+      lastSeatIndex: seatIndex
+    };
+  }, [currentTurn]);
+
+  useEffect(() => {
     if (!diceEvent || !boardRef.current) return;
     const board = boardRef.current;
     const diceSet = board.diceSet || [];
@@ -4642,6 +4701,7 @@ export default function SnakeBoard3D({
     if (diceEvent.phase === 'start') {
       removeAnimationsByType(animationsRef.current, 'cameraDiceZoom');
       removeAnimationsByType(animationsRef.current, 'diceRoll');
+      removeAnimationsByType(animationsRef.current, 'diceHandoff');
       const count = Math.max(1, Math.min(diceEvent.count ?? diceSet.length, diceSet.length));
       const prevState = diceStateRef.current || {};
       const rawSeatIndex = Number.isInteger(diceEvent.seatIndex)

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -340,7 +340,7 @@ function resolveAiTokenShapes(options, count) {
 }
 
 const FALLBACK_SEAT_POSITIONS = [
-  { left: '50%', top: '82%' },
+  { left: '50%', top: '88%' },
   { left: '78%', top: '54%' },
   { left: '48%', top: '22%' },
   { left: '22%', top: '55%' }
@@ -1408,7 +1408,7 @@ export default function SnakeAndLadder() {
   const diceRollIdRef = useRef(0);
   const [diceBoardEvent, setDiceBoardEvent] = useState(null);
   const [seatAnchors, setSeatAnchors] = useState([]);
-  const [, setDiceAnchor] = useState(null);
+  const [diceAnchor, setDiceAnchor] = useState(null);
 
   const seatAnchorMap = useMemo(() => {
     const map = new Map();
@@ -3709,7 +3709,7 @@ export default function SnakeAndLadder() {
               ? {
                   position: 'absolute',
                   left: `${anchor.x}%`,
-                  top: `${anchor.y}%`,
+                  top: `${Math.min(96, anchor.y + (seatIndex === 0 ? 5.8 : 0))}%`,
                   transform: 'translate(-50%, -50%)'
                 }
               : {
@@ -4013,6 +4013,24 @@ export default function SnakeAndLadder() {
           )}
         </div>
       )}
+      {canRoll && diceAnchor ? (
+        <button
+          type="button"
+          onClick={handleRollButtonClick}
+          className="fixed z-30 pointer-events-auto rounded-full"
+          style={{
+            left: `${diceAnchor.x}%`,
+            top: `${diceAnchor.y}%`,
+            width: '5.4rem',
+            height: '5.4rem',
+            transform: 'translate(-50%, -50%)',
+            background: 'radial-gradient(circle, rgba(250,204,21,0.22), rgba(250,204,21,0) 68%)',
+            border: '1px solid rgba(250,204,21,0.35)',
+            boxShadow: '0 0 18px rgba(250,204,21,0.24)'
+          }}
+          aria-label="Roll dice"
+        />
+      ) : null}
       {!watchOnly && (
         <div className="pointer-events-auto">
           <InfoPopup


### PR DESCRIPTION
### Motivation

- Improve mobile UX so camera drag matches Domino Battle Royal (finger turns camera toward the same visual side), the 2D camera frames the whole table more centrally, the bottom avatar does not block the dice, and dice behaviour is clearer across turns.

### Description

- Tweak camera tuning by adding `CAMERA_2D_DISTANCE_FACTOR` and `CAMERA_2D_FORWARD_FACTOR` and using them to raise and re-center the 2D camera framing in `webapp/src/components/SnakeBoard3D.jsx`.
- Flip horizontal drag yaw sign in `SnakeBoard3D.jsx` so side swipes rotate the view in the same visual direction as finger movement (matches Domino semantics).
- Add `createDiceHandoffAnimation` in `SnakeBoard3D.jsx` and wire it to run on turn change (`currentTurn`) to animate visible dice toward the active player, and ensure any handoff animation is removed when a new roll starts.
- Add a `diceAnchor` state and expose a tappable dice hotspot overlay in `webapp/src/pages/Games/SnakeAndLadder.jsx` that appears at the projected dice anchor when `canRoll` so users can touch the dice area to roll, and lower the bottom avatar anchor/fallback placement so the avatar blocks the dice less.

### Testing

- Ran repository lint (`npm run -s lint -- webapp/src/components/SnakeBoard3D.jsx webapp/src/pages/Games/SnakeAndLadder.jsx`), which produced many pre-existing repository-wide lint errors unrelated to these files; this run is considered a partial failure due to unrelated files.
- Ran targeted ESLint on the two changed files (`npx eslint --no-ignore webapp/src/components/SnakeBoard3D.jsx webapp/src/pages/Games/SnakeAndLadder.jsx`) which completed with only repo-ignore warnings and no new errors introduced in those files.
- No unit test changes were made or run for game logic in this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2191f0c0c8329bc20a473f4a8a796)