### PR TITLE
Refine snake dice landing, 2D camera framing and bottom avatar placement

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -270,7 +270,7 @@ const SHOW_BOARD_RAILS = false;
 const COIN_RAISE = TILE_SIZE * 0.24;
 const COIN_LOCAL_LIFT = TILE_SIZE * 0.05;
 const CAMERA_2D_DISTANCE_FACTOR = 2.45;
-const CAMERA_2D_FORWARD_FACTOR = 0.7;
+const CAMERA_2D_FRAME_PADDING = 1.14;
 
 const AVATAR_ANCHOR_HEIGHT = SEAT_THICKNESS / 2 + BACK_HEIGHT * 0.85;
 
@@ -1961,7 +1961,8 @@ function computeDiceThrowLayout(board, seatIndex, count) {
   const boardHalf = (BASE_LEVEL_TILES * TILE_SIZE) / 2;
   const boardEdgeDistance = boardHalf + BOARD_EDGE_BUFFER;
   const baseStartDistance = boardHalf + DICE_THROW_START_EXTRA;
-  const settleBaseDistance = boardHalf + DICE_THROW_LANDING_MARGIN + DICE_RETREAT_EXTRA;
+  const settleBaseDistance =
+    boardHalf + DICE_THROW_LANDING_MARGIN * 0.72 + DICE_RETREAT_EXTRA * 0.35;
 
   const seatAdjust = DICE_SEAT_ADJUSTMENTS[seatIndex] ?? {};
   const forwardAdjust = seatAdjust.forward ?? {};
@@ -1993,16 +1994,16 @@ function computeDiceThrowLayout(board, seatIndex, count) {
 
   for (let i = 0; i < count; i += 1) {
     const offset = (i - centerOffset) * spacing;
-    const lateralJitter = (Math.random() - 0.5) * DICE_SIZE * 0.75;
-    const bounceJitter = (Math.random() - 0.5) * DICE_SIZE * 0.35;
-    const retreatExtra = Math.random() * DICE_SIZE * 0.8;
-    const outwardJitter = Math.random() * DICE_SIZE * 0.9;
+    const lateralJitter = (Math.random() - 0.5) * DICE_SIZE * 0.38;
+    const bounceJitter = (Math.random() - 0.5) * DICE_SIZE * 0.2;
+    const retreatExtra = Math.random() * DICE_SIZE * 0.22;
+    const outwardJitter = Math.random() * DICE_SIZE * 0.18;
 
-    const startDistance = startBaseDistance + Math.random() * DICE_SIZE * 0.9;
-    const bounceDistance = bounceBaseDistance + (Math.random() - 0.5) * DICE_SIZE * 0.12;
+    const startDistance = startBaseDistance + Math.random() * DICE_SIZE * 0.7;
+    const bounceDistance = bounceBaseDistance + (Math.random() - 0.5) * DICE_SIZE * 0.08;
     const settleDistance = Math.max(
-      bounceDistance + DICE_SIZE * 0.35,
-      settleDistanceBase + (Math.random() - 0.1) * DICE_SIZE * 0.6
+      bounceDistance + DICE_SIZE * 0.22,
+      settleDistanceBase + (Math.random() - 0.1) * DICE_SIZE * 0.3
     );
 
     const start = centerLocal
@@ -3963,9 +3964,17 @@ export default function SnakeBoard3D({
           mouseButtons: { ...controls.mouseButtons }
         };
       }
-      const topDownDistance = clamp(CAM.minR * CAMERA_2D_DISTANCE_FACTOR, CAM.minR * 1.55, CAM.maxR * 0.96);
+      const boardRadius = Math.max(BOARD_RADIUS, TABLE_RADIUS * 0.56);
+      const verticalFov = THREE.MathUtils.degToRad(camera.fov || CAMERA_FOV);
+      const horizontalFov = 2 * Math.atan(Math.tan(verticalFov / 2) * Math.max(camera.aspect || 1, 1e-3));
+      const limitingFov = Math.min(verticalFov, horizontalFov);
+      const fitDistance =
+        limitingFov > 1e-4
+          ? (boardRadius / Math.tan(limitingFov / 2)) * CAMERA_2D_FRAME_PADDING
+          : CAM.minR * CAMERA_2D_DISTANCE_FACTOR;
+      const topDownDistance = clamp(fitDistance, CAM.minR * 1.7, CAM.maxR * 0.98);
       const verticalDistance = Math.cos(topDownPolar) * topDownDistance;
-      const forwardDistance = Math.sin(topDownPolar) * topDownDistance * CAMERA_2D_FORWARD_FACTOR;
+      const forwardDistance = 0;
       camera.position.set(
         boardLookTarget.x,
         boardLookTarget.y + verticalDistance,

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -184,7 +184,7 @@ const PENULTIMATE_TILE = FINAL_TILE - 1;
 const TURN_TIME = 15;
 const AI_ROLL_DELAY_MS = 3400;
 const AI_EXTRA_ROLL_DELAY_MS = 2600;
-const TURN_ADVANCE_AFTER_DICE_MS = 2300;
+const TURN_ADVANCE_AFTER_DICE_MS = 1400;
 const DEFAULT_CAPACITY = 4;
 const COMMENTARY_PRESET_STORAGE_KEY = 'snakeCommentaryPreset';
 const COMMENTARY_MUTE_STORAGE_KEY = 'snakeCommentaryMute';
@@ -345,6 +345,7 @@ const FALLBACK_SEAT_POSITIONS = [
   { left: '48%', top: '22%' },
   { left: '22%', top: '55%' }
 ];
+const SELF_AVATAR_SCREEN_DOWN_OFFSET_PERCENT = 8.8;
 
 const clampValue = (value, min, max) => Math.max(min, Math.min(max, value));
 
@@ -3709,7 +3710,10 @@ export default function SnakeAndLadder() {
               ? {
                   position: 'absolute',
                   left: `${anchor.x}%`,
-                  top: `${Math.min(96, anchor.y + (seatIndex === 0 ? 5.8 : 0))}%`,
+                  top: `${Math.min(
+                    97,
+                    anchor.y + (seatIndex === 0 ? SELF_AVATAR_SCREEN_DOWN_OFFSET_PERCENT : 0)
+                  )}%`,
                   transform: 'translate(-50%, -50%)'
                 }
               : {


### PR DESCRIPTION
### Motivation
- Make dice settle visually consistent with the provided reference so the landing pose clearly shows the result and then advance the turn. 
- Use the 2D camera to guarantee the whole board stays centered and visible in portrait view. 
- Push the local player's avatar slightly farther down so it does not overlap the board center.

### Description
- Tuned dice throw/settle layout in `webapp/src/components/SnakeBoard3D.jsx` by reducing lateral/bounce/retreat jitter and bringing settle distances closer to the board center to produce tighter, more stable landings (`lateralJitter`, `bounceJitter`, `retreatExtra`, `outwardJitter`, `startDistance`, `bounceDistance`, `settleDistance`).
- Improved 2D top-down framing in `webapp/src/components/SnakeBoard3D.jsx` by computing a FOV-based fit distance and applying `CAMERA_2D_FRAME_PADDING` so the board center is on-screen and the board fits the portrait frame (removed the previous forward bias in 2D mode).
- Reduced post-roll handoff delay by changing `TURN_ADVANCE_AFTER_DICE_MS` in `webapp/src/pages/Games/SnakeAndLadder.jsx` from `2300`ms to `1400`ms so turns advance faster after showing the dice result.
- Moved the local bottom avatar downwards by adding `SELF_AVATAR_SCREEN_DOWN_OFFSET_PERCENT` and applying it to the seat-0 avatar top calculation in `webapp/src/pages/Games/SnakeAndLadder.jsx` to avoid center overlap.

### Testing
- Ran the production build with `npm --prefix webapp run build`, which completed successfully.
- Build emitted existing Vite warnings about chunk sizes and dynamic import placement only and did not fail; no new build errors were introduced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d21f222fa48329a0c24d2bbe758978)