### PR TITLE
Pool Royale: disable replays and restore LT carbon-fiber table textures

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -723,7 +723,7 @@ export const POOL_ROYALE_STORE_ITEMS = [
     optionId: 'carbonFiberChalk',
     name: 'LT Black Finish',
     price: 1160,
-    description: 'Solid black molded-plastic finish with no wood grain texture.',
+    description: 'Carbon-fiber weave finish tuned to the LT black palette.',
     thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberChalk
   },
   {
@@ -732,7 +732,7 @@ export const POOL_ROYALE_STORE_ITEMS = [
     optionId: 'carbonFiberChalkGrey',
     name: 'LT Grey Finish',
     price: 1170,
-    description: 'Solid grey molded-plastic finish with no wood grain texture.',
+    description: 'Carbon-fiber weave finish tuned to the LT grey palette.',
     thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberChalkGrey
   },
   {
@@ -741,7 +741,7 @@ export const POOL_ROYALE_STORE_ITEMS = [
     optionId: 'carbonFiberChalkBeige',
     name: 'LT Dark Grey Finish',
     price: 1180,
-    description: 'Solid dark-grey molded-plastic finish with no wood grain texture.',
+    description: 'Carbon-fiber weave finish tuned to the LT dark-grey palette.',
     thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberChalkBeige
   },
   {
@@ -750,7 +750,7 @@ export const POOL_ROYALE_STORE_ITEMS = [
     optionId: 'carbonFiberChalkDarkBlue',
     name: 'LT Burgundy Finish',
     price: 1190,
-    description: 'Solid burgundy molded-plastic finish with no wood grain texture.',
+    description: 'Carbon-fiber weave finish tuned to the LT burgundy palette.',
     thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberChalkDarkBlue
   },
   {
@@ -759,7 +759,7 @@ export const POOL_ROYALE_STORE_ITEMS = [
     optionId: 'carbonFiberChalkWhite',
     name: 'LT Milk Cream Finish',
     price: 1200,
-    description: 'Solid milk-cream molded-plastic finish with no wood grain texture.',
+    description: 'Carbon-fiber weave finish tuned to the LT milk-cream palette.',
     thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberChalkWhite
   },
   {

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1148,9 +1148,7 @@ const TABLE_FINISH_STORAGE_KEY = 'poolRoyaleTableFinish';
 const CLOTH_COLOR_STORAGE_KEY = 'poolRoyaleClothColor';
 const TABLE_BASE_STORAGE_KEY = 'poolRoyaleTableBase';
 const POCKET_LINER_STORAGE_KEY = 'poolPocketLiner';
-const POOL_ROYALE_REPLAY_ENABLED = true;
 const POOL_ROYALE_VOICE_COMMENTARY_ENABLED = false;
-const SKIP_REPLAYS_STORAGE_KEY = 'poolRoyaleSkipReplays';
 const COMMENTARY_PRESET_STORAGE_KEY = 'poolRoyaleCommentaryPreset';
 const COMMENTARY_MUTE_STORAGE_KEY = 'poolRoyaleCommentaryMute';
 const DEFAULT_CUE_STROKE_STYLE = 'featherLine';
@@ -12847,14 +12845,7 @@ function PoolRoyaleGame({
     );
   });
   const clothTextureSourceId = DEFAULT_CLOTH_TEXTURE_SOURCE_ID;
-  const [skipAllReplays, setSkipAllReplays] = useState(() => {
-    if (typeof window !== 'undefined') {
-      const stored = window.localStorage.getItem(SKIP_REPLAYS_STORAGE_KEY);
-      if (stored === '1') return true;
-      if (stored === '0') return false;
-    }
-    return !POOL_ROYALE_REPLAY_ENABLED;
-  });
+  const [skipAllReplays] = useState(true);
   const [commentaryPresetId, setCommentaryPresetId] = useState(DEFAULT_COMMENTARY_PRESET_ID);
   const [commentaryMuted, setCommentaryMuted] = useState(!POOL_ROYALE_VOICE_COMMENTARY_ENABLED);
   const skipReplayRef = useRef(() => {});
@@ -14579,14 +14570,6 @@ function PoolRoyaleGame({
       window.localStorage.setItem(CLOTH_COLOR_STORAGE_KEY, clothColorId);
     }
   }, [clothColorId]);
-  useEffect(() => {
-    if (typeof window !== 'undefined') {
-      window.localStorage.setItem(
-        SKIP_REPLAYS_STORAGE_KEY,
-        skipAllReplays ? '1' : '0'
-      );
-    }
-  }, [skipAllReplays]);
   useEffect(() => {
     if (typeof window !== 'undefined') {
       window.localStorage.setItem(POCKET_LINER_STORAGE_KEY, pocketLinerId);
@@ -32599,32 +32582,6 @@ const powerRef = useRef(hud.power);
               </button>
             </div>
             <div className="mt-4 max-h-72 space-y-4 overflow-y-auto pr-1">
-              <div className="rounded-xl border border-white/10 bg-white/5 p-3">
-                <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
-                  Replays
-                </h3>
-                <button
-                  type="button"
-                  onClick={() => setSkipAllReplays((prev) => !prev)}
-                  aria-pressed={skipAllReplays}
-                  className={`mt-2 flex w-full items-center justify-between gap-3 rounded-full px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.24em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
-                    skipAllReplays
-                      ? 'bg-emerald-400 text-black shadow-[0_0_18px_rgba(16,185,129,0.65)]'
-                      : 'bg-white/10 text-white/80 hover:bg-white/20'
-                  }`}
-                >
-                  <span>Skip all replays</span>
-                  <span
-                    className={`rounded-full border px-2 py-0.5 text-[10px] tracking-[0.3em] ${
-                      skipAllReplays
-                        ? 'border-black/30 text-black/70'
-                        : 'border-white/30 text-white/70'
-                    }`}
-                  >
-                    {skipAllReplays ? 'On' : 'Off'}
-                  </span>
-                </button>
-              </div>
               <div>
                 <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
                   Table Finish

--- a/webapp/src/utils/woodMaterials.js
+++ b/webapp/src/utils/woodMaterials.js
@@ -730,126 +730,86 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
   Object.freeze({
     id: 'plastic_monoblock_lt_black',
     label: 'LT Black',
-    source: 'TonPlaygram molded-plastic satin texture (LT Black)',
+    source: 'TonPlaygram carbon-fiber weave (LT Black)',
     rail: {
       repeat: { x: 7.2, y: 7.2 },
       rotation: 0,
       textureSize: 2048,
-      ...makeInlinePlasticMonoblockPattern({
-        id: 'plastic-monoblock-lt-black-rail',
-        base: '#0b0d10',
-        sheen: '#1a1f28'
-      })
+      ...makeInlineCarbonFiberPattern({ id: 'lt-black-carbon-rail' })
     },
     frame: {
       repeat: { x: 7.2, y: 7.2 },
       rotation: 0,
       textureSize: 2048,
-      ...makeInlinePlasticMonoblockPattern({
-        id: 'plastic-monoblock-lt-black-frame',
-        base: '#0b0d10',
-        sheen: '#1a1f28'
-      })
+      ...makeInlineCarbonFiberPattern({ id: 'lt-black-carbon-frame' })
     }
   }),
   Object.freeze({
     id: 'plastic_monoblock_lt_grey',
     label: 'LT Grey',
-    source: 'TonPlaygram molded-plastic satin texture (LT Grey)',
+    source: 'TonPlaygram carbon-fiber weave (LT Grey)',
     rail: {
       repeat: { x: 7.2, y: 7.2 },
       rotation: 0,
       textureSize: 2048,
-      ...makeInlinePlasticMonoblockPattern({
-        id: 'plastic-monoblock-lt-grey-rail',
-        base: '#585f6b',
-        sheen: '#7b8391'
-      })
+      ...makeInlineCarbonFiberPattern({ id: 'lt-grey-carbon-rail' })
     },
     frame: {
       repeat: { x: 7.2, y: 7.2 },
       rotation: 0,
       textureSize: 2048,
-      ...makeInlinePlasticMonoblockPattern({
-        id: 'plastic-monoblock-lt-grey-frame',
-        base: '#585f6b',
-        sheen: '#7b8391'
-      })
+      ...makeInlineCarbonFiberPattern({ id: 'lt-grey-carbon-frame' })
     }
   }),
   Object.freeze({
     id: 'plastic_monoblock_lt_dark_grey',
     label: 'LT Dark Grey',
-    source: 'TonPlaygram molded-plastic satin texture (LT Dark Grey)',
+    source: 'TonPlaygram carbon-fiber weave (LT Dark Grey)',
     rail: {
       repeat: { x: 7.2, y: 7.2 },
       rotation: 0,
       textureSize: 2048,
-      ...makeInlinePlasticMonoblockPattern({
-        id: 'plastic-monoblock-lt-dark-grey-rail',
-        base: '#2d323b',
-        sheen: '#434a56'
-      })
+      ...makeInlineCarbonFiberPattern({ id: 'lt-dark-grey-carbon-rail' })
     },
     frame: {
       repeat: { x: 7.2, y: 7.2 },
       rotation: 0,
       textureSize: 2048,
-      ...makeInlinePlasticMonoblockPattern({
-        id: 'plastic-monoblock-lt-dark-grey-frame',
-        base: '#2d323b',
-        sheen: '#434a56'
-      })
+      ...makeInlineCarbonFiberPattern({ id: 'lt-dark-grey-carbon-frame' })
     }
   }),
   Object.freeze({
     id: 'plastic_monoblock_lt_burgundy',
     label: 'LT Burgundy',
-    source: 'TonPlaygram molded-plastic satin texture (LT Burgundy)',
+    source: 'TonPlaygram carbon-fiber weave (LT Burgundy)',
     rail: {
       repeat: { x: 7.2, y: 7.2 },
       rotation: 0,
       textureSize: 2048,
-      ...makeInlinePlasticMonoblockPattern({
-        id: 'plastic-monoblock-lt-burgundy-rail',
-        base: '#5f1d2c',
-        sheen: '#7f2e43'
-      })
+      ...makeInlineCarbonFiberPattern({ id: 'lt-burgundy-carbon-rail' })
     },
     frame: {
       repeat: { x: 7.2, y: 7.2 },
       rotation: 0,
       textureSize: 2048,
-      ...makeInlinePlasticMonoblockPattern({
-        id: 'plastic-monoblock-lt-burgundy-frame',
-        base: '#5f1d2c',
-        sheen: '#7f2e43'
-      })
+      ...makeInlineCarbonFiberPattern({ id: 'lt-burgundy-carbon-frame' })
     }
   }),
   Object.freeze({
     id: 'plastic_monoblock_lt_milk_cream',
     label: 'LT Milk Cream',
-    source: 'TonPlaygram molded-plastic satin texture (LT Milk Cream)',
+    source: 'TonPlaygram carbon-fiber weave (LT Milk Cream)',
     rail: {
       repeat: { x: 7.2, y: 7.2 },
       rotation: 0,
       textureSize: 2048,
-      ...makeInlinePlasticMonoblockPattern({
-        id: 'plastic-monoblock-lt-milk-cream-rail',
-        base: '#e9dcc9',
-        sheen: '#f8efe1'
-      })
+      ...makeInlineCarbonFiberPattern({ id: 'lt-milk-cream-carbon-rail' })
     },
     frame: {
       repeat: { x: 7.2, y: 7.2 },
       rotation: 0,
       textureSize: 2048,
-      ...makeInlinePlasticMonoblockPattern({
-        id: 'plastic-monoblock-lt-milk-cream-frame',
-        base: '#e9dcc9',
-        sheen: '#f8efe1'
-      })
+      ...makeInlineCarbonFiberPattern({ id: 'lt-milk-cream-carbon-frame' })
     }
   }),
   Object.freeze({


### PR DESCRIPTION
### Motivation
- Remove replay playback from the Pool Royale experience so matches open and play without automatic replay sequences or a replay toggle in the setup menu.
- Restore the LT table finish materials to use the previously preferred carbon-fiber weave textures and colors so the LT finishes match the visual look from the earlier build.

### Description
- Disabled replay behavior at runtime by removing the `POOL_ROYALE_REPLAY_ENABLED` default-on behavior and forcing the replay state to skip replays via `skipAllReplays` (`PoolRoyale.jsx`).
- Removed the setup UI for toggling replays and the `SKIP_REPLAYS` localStorage persistence so no replay control appears in the Table Setup panel (`PoolRoyale.jsx`).
- Restored LT table finish texture sources to the carbon-fiber generation by switching LT finish entries to use `makeInlineCarbonFiberPattern` and updating their `source` strings in `webapp/src/utils/woodMaterials.js`.
- Updated store copy for the LT table finishes to describe them as carbon-fiber weave finishes in `webapp/src/config/poolRoyaleInventoryConfig.js`.

### Testing
- Ran the production build with `cd webapp && npm run build`, and the build completed successfully (Vite produced only non-blocking warnings about chunk sizes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d21fecde9483298a78d817e243c27b)