### PR TITLE
Disable Pool Royale replays and restore LT carbon-fiber table finish textures

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -723,7 +723,7 @@ export const POOL_ROYALE_STORE_ITEMS = [
     optionId: 'carbonFiberChalk',
     name: 'LT Black Finish',
     price: 1160,
-    description: 'Solid black molded-plastic finish with no wood grain texture.',
+    description: 'Black LT carbon-fiber weave finish with deep matte highlights.',
     thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberChalk
   },
   {
@@ -732,7 +732,7 @@ export const POOL_ROYALE_STORE_ITEMS = [
     optionId: 'carbonFiberChalkGrey',
     name: 'LT Grey Finish',
     price: 1170,
-    description: 'Solid grey molded-plastic finish with no wood grain texture.',
+    description: 'Grey LT carbon-fiber weave finish with neutral satin contrast.',
     thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberChalkGrey
   },
   {
@@ -741,7 +741,7 @@ export const POOL_ROYALE_STORE_ITEMS = [
     optionId: 'carbonFiberChalkBeige',
     name: 'LT Dark Grey Finish',
     price: 1180,
-    description: 'Solid dark-grey molded-plastic finish with no wood grain texture.',
+    description: 'Dark-grey LT carbon-fiber weave finish with stronger depth.',
     thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberChalkBeige
   },
   {
@@ -750,7 +750,7 @@ export const POOL_ROYALE_STORE_ITEMS = [
     optionId: 'carbonFiberChalkDarkBlue',
     name: 'LT Burgundy Finish',
     price: 1190,
-    description: 'Solid burgundy molded-plastic finish with no wood grain texture.',
+    description: 'Burgundy LT carbon-fiber weave finish with rich warm accents.',
     thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberChalkDarkBlue
   },
   {
@@ -759,7 +759,7 @@ export const POOL_ROYALE_STORE_ITEMS = [
     optionId: 'carbonFiberChalkWhite',
     name: 'LT Milk Cream Finish',
     price: 1200,
-    description: 'Solid milk-cream molded-plastic finish with no wood grain texture.',
+    description: 'Milk-cream LT carbon-fiber weave finish with soft bright tones.',
     thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberChalkWhite
   },
   {

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1148,7 +1148,6 @@ const TABLE_FINISH_STORAGE_KEY = 'poolRoyaleTableFinish';
 const CLOTH_COLOR_STORAGE_KEY = 'poolRoyaleClothColor';
 const TABLE_BASE_STORAGE_KEY = 'poolRoyaleTableBase';
 const POCKET_LINER_STORAGE_KEY = 'poolPocketLiner';
-const POOL_ROYALE_REPLAY_ENABLED = true;
 const POOL_ROYALE_VOICE_COMMENTARY_ENABLED = false;
 const SKIP_REPLAYS_STORAGE_KEY = 'poolRoyaleSkipReplays';
 const COMMENTARY_PRESET_STORAGE_KEY = 'poolRoyaleCommentaryPreset';
@@ -2476,7 +2475,7 @@ function scaleWoodRepeatVector (repeatVec, scale) {
 
 const LT_CARBON_TEXTURE_REPEAT = Object.freeze({ x: 16, y: 4 });
 let CARBON_FIBER_TILE_CANVAS = null;
-let CARBON_FIBER_TILE_TEXTURE = null;
+const CARBON_FIBER_TILE_TEXTURES = new Map();
 
 function createCarbonFiberPatternCanvas(size = 128) {
   if (typeof document === 'undefined') return null;
@@ -2527,11 +2526,28 @@ function getCarbonFiberPatternCanvas() {
   return CARBON_FIBER_TILE_CANVAS;
 }
 
-function getCarbonFiberTileTexture() {
-  if (CARBON_FIBER_TILE_TEXTURE) return CARBON_FIBER_TILE_TEXTURE;
+function getCarbonFiberTileTexture(tintHex = 0x0c0f14) {
+  const tintColor = new THREE.Color(tintHex);
+  const tintKey = tintColor.getHexString();
+  if (CARBON_FIBER_TILE_TEXTURES.has(tintKey)) {
+    return CARBON_FIBER_TILE_TEXTURES.get(tintKey);
+  }
   const canvas = getCarbonFiberPatternCanvas();
   if (!canvas) return null;
-  const texture = new THREE.CanvasTexture(canvas);
+  const tintedCanvas = document.createElement('canvas');
+  tintedCanvas.width = canvas.width;
+  tintedCanvas.height = canvas.height;
+  const tintedCtx = tintedCanvas.getContext('2d');
+  if (!tintedCtx) return null;
+  tintedCtx.drawImage(canvas, 0, 0);
+  tintedCtx.globalCompositeOperation = 'multiply';
+  tintedCtx.fillStyle = `#${tintKey}`;
+  tintedCtx.fillRect(0, 0, tintedCanvas.width, tintedCanvas.height);
+  tintedCtx.globalCompositeOperation = 'screen';
+  tintedCtx.fillStyle = 'rgba(255,255,255,0.08)';
+  tintedCtx.fillRect(0, 0, tintedCanvas.width, tintedCanvas.height);
+  tintedCtx.globalCompositeOperation = 'source-over';
+  const texture = new THREE.CanvasTexture(tintedCanvas);
   applySRGBColorSpace(texture);
   texture.wrapS = THREE.RepeatWrapping;
   texture.wrapT = THREE.RepeatWrapping;
@@ -2541,13 +2557,13 @@ function getCarbonFiberTileTexture() {
   texture.magFilter = THREE.LinearFilter;
   texture.anisotropy = resolveTextureAnisotropy(texture.anisotropy ?? 1);
   texture.needsUpdate = true;
-  CARBON_FIBER_TILE_TEXTURE = texture;
-  return CARBON_FIBER_TILE_TEXTURE;
+  CARBON_FIBER_TILE_TEXTURES.set(tintKey, texture);
+  return texture;
 }
 
 function applyLtCarbonFiberTexture(material) {
   if (!material) return;
-  const carbonTexture = getCarbonFiberTileTexture();
+  const carbonTexture = getCarbonFiberTileTexture(material.color?.getHex?.() ?? 0x0c0f14);
   if (!carbonTexture) return;
   material.map = carbonTexture;
   material.normalMap = null;
@@ -12847,14 +12863,7 @@ function PoolRoyaleGame({
     );
   });
   const clothTextureSourceId = DEFAULT_CLOTH_TEXTURE_SOURCE_ID;
-  const [skipAllReplays, setSkipAllReplays] = useState(() => {
-    if (typeof window !== 'undefined') {
-      const stored = window.localStorage.getItem(SKIP_REPLAYS_STORAGE_KEY);
-      if (stored === '1') return true;
-      if (stored === '0') return false;
-    }
-    return !POOL_ROYALE_REPLAY_ENABLED;
-  });
+  const [skipAllReplays] = useState(true);
   const [commentaryPresetId, setCommentaryPresetId] = useState(DEFAULT_COMMENTARY_PRESET_ID);
   const [commentaryMuted, setCommentaryMuted] = useState(!POOL_ROYALE_VOICE_COMMENTARY_ENABLED);
   const skipReplayRef = useRef(() => {});
@@ -32599,32 +32608,6 @@ const powerRef = useRef(hud.power);
               </button>
             </div>
             <div className="mt-4 max-h-72 space-y-4 overflow-y-auto pr-1">
-              <div className="rounded-xl border border-white/10 bg-white/5 p-3">
-                <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
-                  Replays
-                </h3>
-                <button
-                  type="button"
-                  onClick={() => setSkipAllReplays((prev) => !prev)}
-                  aria-pressed={skipAllReplays}
-                  className={`mt-2 flex w-full items-center justify-between gap-3 rounded-full px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.24em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
-                    skipAllReplays
-                      ? 'bg-emerald-400 text-black shadow-[0_0_18px_rgba(16,185,129,0.65)]'
-                      : 'bg-white/10 text-white/80 hover:bg-white/20'
-                  }`}
-                >
-                  <span>Skip all replays</span>
-                  <span
-                    className={`rounded-full border px-2 py-0.5 text-[10px] tracking-[0.3em] ${
-                      skipAllReplays
-                        ? 'border-black/30 text-black/70'
-                        : 'border-white/30 text-white/70'
-                    }`}
-                  >
-                    {skipAllReplays ? 'On' : 'Off'}
-                  </span>
-                </button>
-              </div>
               <div>
                 <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
                   Table Finish


### PR DESCRIPTION
### Motivation
- Remove replay playback and its menu controls for Pool Royale to stop automatic replay interruptions during matches. 
- Restore the LT table finishes to use the carbon-fiber fiber look and preserve the exact tint/texture appearance used previously. 

### Description
- Hard-forces replay skipping in Pool Royale by making replay state always skip (`skipAllReplays` defaults to `true`) and removing the in-menu replay toggle UI so replay controls no longer appear in the Table Setup panel (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Reworked LT carbon-fiber texture generation to produce tinted carbon-fiber tile textures per finish color and cache them by tint, replacing the single shared texture (introduces `CARBON_FIBER_TILE_TEXTURES` Map and a `getCarbonFiberTileTexture(tintHex)` flow) so LT finishes keep the correct fiber pattern and colors (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Updated store item descriptions for LT finishes to reflect the restored carbon-fiber weave presentation (`webapp/src/config/poolRoyaleInventoryConfig.js`).

### Testing
- Ran lint checks targeted at modified files with `npx eslint webapp/src/pages/Games/PoolRoyale.jsx webapp/src/config/poolRoyaleInventoryConfig.js`, which completed but produced repository ignore warnings. 
- Ran stricter lint with `npx eslint --no-ignore webapp/src/pages/Games/PoolRoyale.jsx webapp/src/config/poolRoyaleInventoryConfig.js`, which failed due to pre-existing style issues in the repo unrelated to these changes (errors reported by ESLint, not introduced by this patch).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d21fecde9483298a78d817e243c27b)