### PR TITLE
Restore Pool Royale replay controls and align lobby HDRIs

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -75,7 +75,8 @@ const POOL_ROYALE_HDRI_PLACEMENTS = Object.freeze({
     cameraHeightM: 1.58,
     groundRadiusMultiplier: 5.2,
     groundResolution: 112,
-    arenaScale: 1.26
+    arenaScale: 1.26,
+    rotationY: Math.PI / 2
   },
   churchMeetingRoom: {
     cameraHeightM: 1.56,
@@ -135,7 +136,8 @@ const POOL_ROYALE_HDRI_PLACEMENTS = Object.freeze({
     cameraHeightM: 1.58,
     groundRadiusMultiplier: 5,
     groundResolution: 112,
-    arenaScale: 1.24
+    arenaScale: 1.24,
+    rotationY: Math.PI / 2
   },
   lapa: {
     cameraHeightM: 1.58,

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1148,6 +1148,7 @@ const TABLE_FINISH_STORAGE_KEY = 'poolRoyaleTableFinish';
 const CLOTH_COLOR_STORAGE_KEY = 'poolRoyaleClothColor';
 const TABLE_BASE_STORAGE_KEY = 'poolRoyaleTableBase';
 const POCKET_LINER_STORAGE_KEY = 'poolPocketLiner';
+const POOL_ROYALE_REPLAY_ENABLED = true;
 const POOL_ROYALE_VOICE_COMMENTARY_ENABLED = false;
 const SKIP_REPLAYS_STORAGE_KEY = 'poolRoyaleSkipReplays';
 const COMMENTARY_PRESET_STORAGE_KEY = 'poolRoyaleCommentaryPreset';
@@ -12863,7 +12864,14 @@ function PoolRoyaleGame({
     );
   });
   const clothTextureSourceId = DEFAULT_CLOTH_TEXTURE_SOURCE_ID;
-  const [skipAllReplays] = useState(true);
+  const [skipAllReplays, setSkipAllReplays] = useState(() => {
+    if (typeof window !== 'undefined') {
+      const stored = window.localStorage.getItem(SKIP_REPLAYS_STORAGE_KEY);
+      if (stored === '1') return true;
+      if (stored === '0') return false;
+    }
+    return !POOL_ROYALE_REPLAY_ENABLED;
+  });
   const [commentaryPresetId, setCommentaryPresetId] = useState(DEFAULT_COMMENTARY_PRESET_ID);
   const [commentaryMuted, setCommentaryMuted] = useState(!POOL_ROYALE_VOICE_COMMENTARY_ENABLED);
   const skipReplayRef = useRef(() => {});
@@ -32608,6 +32616,32 @@ const powerRef = useRef(hud.power);
               </button>
             </div>
             <div className="mt-4 max-h-72 space-y-4 overflow-y-auto pr-1">
+              <div className="rounded-xl border border-white/10 bg-white/5 p-3">
+                <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
+                  Replays
+                </h3>
+                <button
+                  type="button"
+                  onClick={() => setSkipAllReplays((prev) => !prev)}
+                  aria-pressed={skipAllReplays}
+                  className={`mt-2 flex w-full items-center justify-between gap-3 rounded-full px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.24em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
+                    skipAllReplays
+                      ? 'bg-emerald-400 text-black shadow-[0_0_18px_rgba(16,185,129,0.65)]'
+                      : 'bg-white/10 text-white/80 hover:bg-white/20'
+                  }`}
+                >
+                  <span>Skip all replays</span>
+                  <span
+                    className={`rounded-full border px-2 py-0.5 text-[10px] tracking-[0.3em] ${
+                      skipAllReplays
+                        ? 'border-black/30 text-black/70'
+                        : 'border-white/30 text-white/70'
+                    }`}
+                  >
+                    {skipAllReplays ? 'On' : 'Off'}
+                  </span>
+                </button>
+              </div>
               <div>
                 <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
                   Table Finish


### PR DESCRIPTION
### Motivation
- Re-enable player-facing replay behavior for Pool Royale and make the replay preference persist and controllable again to restore the previous UX.
- Align the visual orientation of pool tables with HDRI environments where the long axis should match the HDRI long side for consistent lighting and reflections.

### Description
- Restored replay activation by adding `POOL_ROYALE_REPLAY_ENABLED = true` and initializing the `skipAllReplays` state from `localStorage` (`SKIP_REPLAYS_STORAGE_KEY`) so stored preferences are respected in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Restored the in-game Replay settings control block (the `Skip all replays` toggle) in the Pool Royale settings panel so players can toggle replay playback from the UI in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Rotated the `cinemaLobby` and `newmanLobby` HDRI placements by adding `rotationY: Math.PI / 2` in `webapp/src/config/poolRoyaleInventoryConfig.js` so the table direction aligns with the HDRI long axis.

### Testing
- Ran `npm --prefix webapp run build` and the Vite production build completed successfully (build artifacts produced, warnings only about chunk size and dynamic/static imports).
- No automated unit tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d22e3387348329be1dae905eb56b42)