### PR TITLE
Fix Pool Royale replay fallback when shot frames are sparse

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -22551,16 +22551,57 @@ const powerRef = useRef(hud.power);
           }
         };
 
+        const ensureReplayRecording = (recording, postShotSnapshot) => {
+          if (!recording) return null;
+          const frameTimeMs =
+            Number.isFinite(recording?.frameTimeMs) && recording.frameTimeMs > 0
+              ? recording.frameTimeMs
+              : 1000 / 60;
+          const normalizedFrames = Array.isArray(recording?.frames)
+            ? recording.frames
+                .filter(Boolean)
+                .map((frame, index) => ({
+                  ...frame,
+                  t: Number.isFinite(frame?.t) ? frame.t : index * frameTimeMs
+                }))
+            : [];
+          if (normalizedFrames.length === 0) {
+            const seedBalls = Array.isArray(recording.startState)
+              ? recording.startState
+              : null;
+            if (!seedBalls) return null;
+            normalizedFrames.push({
+              t: 0,
+              balls: seedBalls,
+              camera: null,
+              cue: null
+            });
+          }
+          if (normalizedFrames.length === 1 && Array.isArray(postShotSnapshot)) {
+            normalizedFrames.push({
+              ...normalizedFrames[0],
+              t: Math.max(frameTimeMs, normalizedFrames[0]?.t ?? 0),
+              balls: postShotSnapshot
+            });
+          }
+          return {
+            ...recording,
+            frameTimeMs,
+            frames: normalizedFrames
+          };
+        };
+
         const startShotReplay = (postShotSnapshot) => {
           if (replayPlaybackRef.current) return;
-          if (!shotRecording || !shotRecording.frames?.length) return;
-          const trimmed = trimReplayRecording(shotRecording);
+          const replayRecording = ensureReplayRecording(shotRecording, postShotSnapshot);
+          if (!replayRecording || !replayRecording.frames?.length) return;
+          const trimmed = trimReplayRecording(replayRecording);
           const duration = trimmed.duration;
           if (!Number.isFinite(duration) || duration <= 0) return;
           cueStrokeStateRef.current = null;
           pendingImpactRef.current = null;
           setReplayActive(true);
-          setReplayFoul(shotRecording?.replayFoul ?? null);
+          setReplayFoul(replayRecording?.replayFoul ?? null);
           overheadBroadcastVariantRef.current = 'replay';
           storeReplayCameraFrame();
           resetCameraForReplay();
@@ -22580,8 +22621,8 @@ const powerRef = useRef(hud.power);
           pocketDropRef.current = new Map();
           replayPlaybackRef.current = replayPlayback;
           lastReplayFrameAt = 0;
-          shotReplayRef.current = shotRecording;
-          applyBallSnapshot(shotRecording.startState ?? []);
+          shotReplayRef.current = replayRecording;
+          applyBallSnapshot(replayRecording.startState ?? []);
           updateReplayTrail(replayPlayback.cuePath, 0);
           primeReplayCueStick(replayPlayback);
           const path = replayPlayback.cuePath ?? [];


### PR DESCRIPTION
### Motivation
- Replays sometimes showed the banner/commentary but no visual clip because recorded shot data could be too sparse or missing normalized frame timing.
- The replay startup logic must reliably produce a playable frame sequence for events like fouls or potted balls so the clip is always visible.

### Description
- Added `ensureReplayRecording(recording, postShotSnapshot)` to normalize a recording's `frameTimeMs` and `frames`, filter invalid frames, and synthesize fallback frames when necessary (seed from `startState`, and add a second frame from `postShotSnapshot` when only one frame exists). 
- Updated `startShotReplay` to call `ensureReplayRecording` and use the normalized recording for trimming, duration checks, `replayFoul`, `shotReplayRef`, and `applyBallSnapshot` so playback does not abort on sparse raw data. 
- Kept existing trimming/playing logic (`trimReplayRecording`, camera/cue priming, trail update) but now operate on the validated recording to avoid early returns when frames are insufficient.

### Testing
- Ran `npm --prefix webapp run build`, which completed successfully (Vite build finished and produced assets); the build emitted unrelated warnings about chunk size and mixed dynamic/static imports but the build passed. 
- Verified that `PoolRoyale.jsx` now normalizes replay input before attempting playback and avoids early exits when recordings have few frames.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d231fbad048329b92b9455439d3e0b)