### PR TITLE
Adjust chair positioning and grounding for portrait/mobile framing in CheckersBattleRoyal

### DIFF
--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -74,7 +74,10 @@ const BOARD_MODEL_OUTER_TO_PLAYABLE_RATIO = 1.14;
 // sit exactly on the playable dark squares instead of drifting toward the
 // decorative rim.
 const CHECKERS_PLAYABLE_MAPPING_RATIO = 1.44;
-const CHAIR_DISTANCE = TABLE_RADIUS + 0.56 * CHECKERS_ARENA_SCALE;
+// Portrait mobile framing tweak: push chairs a touch away from the table.
+const CHAIR_OUTWARD_OFFSET = 0.12 * CHECKERS_ARENA_SCALE;
+const CHAIR_DISTANCE =
+  TABLE_RADIUS + (0.56 + CHAIR_OUTWARD_OFFSET) * CHECKERS_ARENA_SCALE;
 const SEAT_WIDTH = 0.9 * MODEL_SCALE * STOOL_SCALE;
 const SEAT_DEPTH = 0.95 * MODEL_SCALE * STOOL_SCALE;
 const SEAT_THICKNESS_SCALED = 0.09 * MODEL_SCALE * STOOL_SCALE;
@@ -96,6 +99,8 @@ const CHECKERS_TABLE_BASE_HEIGHT_SCALE = 0.68;
 const CHECKERS_TABLE_BASE_RADIUS_SCALE = 0.56;
 const CHECKERS_TABLE_TRIM_HEIGHT_SCALE = 0.72;
 const CHECKERS_TABLE_TRIM_RADIUS_SCALE = 0.74;
+// Sink chairs slightly into the floor so seat/back read lower in portrait view.
+const CHAIR_GROUND_SINK = 0.16 * CHECKERS_ARENA_SCALE;
 const CHECKERS_CAMERA_FRAME_COMPENSATION = 1.08;
 const CHECKERS_GRAPHICS_PROFILE_STORAGE_KEY =
   'checkersBattleRoyalGraphicsProfile';
@@ -2230,7 +2235,10 @@ export default function CheckersBattleRoyal() {
           });
           g.position.set(0, CHAIR_BASE_HEIGHT, z);
           g.rotation.y = ry;
-          groundGroupToFloor(g, -CHAIR_GROUNDING_EPSILON);
+          groundGroupToFloor(
+            g,
+            -CHAIR_GROUNDING_EPSILON - CHAIR_GROUND_SINK
+          );
           scene.add(g);
           return g;
         };
@@ -2250,7 +2258,10 @@ export default function CheckersBattleRoyal() {
           const g = createProceduralChairFallback(chairColor, legColor);
           g.position.set(0, CHAIR_BASE_HEIGHT, z);
           g.rotation.y = ry;
-          groundGroupToFloor(g, -CHAIR_GROUNDING_EPSILON);
+          groundGroupToFloor(
+            g,
+            -CHAIR_GROUNDING_EPSILON - CHAIR_GROUND_SINK
+          );
           scene.add(g);
           return g;
         };


### PR DESCRIPTION
### Motivation
- Improve chair placement and visual alignment in portrait/mobile camera framing by nudging chairs slightly outward and lowering their apparent height relative to the floor.

### Description
- Add `CHAIR_OUTWARD_OFFSET` and `CHAIR_GROUND_SINK` constants and update `CHAIR_DISTANCE` to include the outward offset for portrait framing tweaks.
- Apply the sink offset when grounding chair groups by passing `-CHAIR_GROUND_SINK` into `groundGroupToFloor` for both GLTF and fallback chair builds.
- Add brief comments explaining the purpose of the offsets and the portrait framing rationale.

### Testing
- Ran the project linter and the frontend unit test suite locally with a development build and verified no regressions in the affected component; all automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d22b7c48148329b00e981b7afa7e4f)