### PR TITLE
Restore Pool Royale replays and align cinema/newman HDRI orientation

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -75,7 +75,8 @@ const POOL_ROYALE_HDRI_PLACEMENTS = Object.freeze({
     cameraHeightM: 1.58,
     groundRadiusMultiplier: 5.2,
     groundResolution: 112,
-    arenaScale: 1.26
+    arenaScale: 1.26,
+    rotationY: Math.PI / 2
   },
   churchMeetingRoom: {
     cameraHeightM: 1.56,
@@ -135,7 +136,8 @@ const POOL_ROYALE_HDRI_PLACEMENTS = Object.freeze({
     cameraHeightM: 1.58,
     groundRadiusMultiplier: 5,
     groundResolution: 112,
-    arenaScale: 1.24
+    arenaScale: 1.24,
+    rotationY: Math.PI / 2
   },
   lapa: {
     cameraHeightM: 1.58,

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1148,6 +1148,7 @@ const TABLE_FINISH_STORAGE_KEY = 'poolRoyaleTableFinish';
 const CLOTH_COLOR_STORAGE_KEY = 'poolRoyaleClothColor';
 const TABLE_BASE_STORAGE_KEY = 'poolRoyaleTableBase';
 const POCKET_LINER_STORAGE_KEY = 'poolPocketLiner';
+const POOL_ROYALE_REPLAY_ENABLED = true;
 const POOL_ROYALE_VOICE_COMMENTARY_ENABLED = false;
 const SKIP_REPLAYS_STORAGE_KEY = 'poolRoyaleSkipReplays';
 const COMMENTARY_PRESET_STORAGE_KEY = 'poolRoyaleCommentaryPreset';
@@ -12863,7 +12864,14 @@ function PoolRoyaleGame({
     );
   });
   const clothTextureSourceId = DEFAULT_CLOTH_TEXTURE_SOURCE_ID;
-  const [skipAllReplays] = useState(true);
+  const [skipAllReplays, setSkipAllReplays] = useState(() => {
+    if (typeof window !== 'undefined') {
+      const stored = window.localStorage.getItem(SKIP_REPLAYS_STORAGE_KEY);
+      if (stored === '1') return true;
+      if (stored === '0') return false;
+    }
+    return !POOL_ROYALE_REPLAY_ENABLED;
+  });
   const [commentaryPresetId, setCommentaryPresetId] = useState(DEFAULT_COMMENTARY_PRESET_ID);
   const [commentaryMuted, setCommentaryMuted] = useState(!POOL_ROYALE_VOICE_COMMENTARY_ENABLED);
   const skipReplayRef = useRef(() => {});
@@ -32608,6 +32616,32 @@ const powerRef = useRef(hud.power);
               </button>
             </div>
             <div className="mt-4 max-h-72 space-y-4 overflow-y-auto pr-1">
+              <div className="rounded-xl border border-white/10 bg-white/5 p-3">
+                <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
+                  Replays
+                </h3>
+                <button
+                  type="button"
+                  onClick={() => setSkipAllReplays((prev) => !prev)}
+                  aria-pressed={skipAllReplays}
+                  className={`mt-2 flex w-full items-center justify-between gap-3 rounded-full px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.24em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
+                    skipAllReplays
+                      ? 'bg-emerald-400 text-black shadow-[0_0_18px_rgba(16,185,129,0.65)]'
+                      : 'bg-white/10 text-white/80 hover:bg-white/20'
+                  }`}
+                >
+                  <span>Skip all replays</span>
+                  <span
+                    className={`rounded-full border px-2 py-0.5 text-[10px] tracking-[0.3em] ${
+                      skipAllReplays
+                        ? 'border-black/30 text-black/70'
+                        : 'border-white/30 text-white/70'
+                    }`}
+                  >
+                    {skipAllReplays ? 'On' : 'Off'}
+                  </span>
+                </button>
+              </div>
               <div>
                 <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
                   Table Finish


### PR DESCRIPTION
### Motivation
- Restore Pool Royale replay behavior to the previously active flow and make the replay toggle available again so recorded shots behave exactly as before the forced-disable change. 
- Ensure the table and decorative layout align with the long side of certain HDRI environments by rotating those HDRIs so the table appears in the intended direction.

### Description
- Reintroduced `POOL_ROYALE_REPLAY_ENABLED = true` and restored the `skipAllReplays` state to load/save from `localStorage` and expose the setter via `useState` in `webapp/src/pages/Games/PoolRoyale.jsx` so replay activation follows the original logic. 
- Restored the in-menu `Replays` control (`Skip all replays` toggle) in the Table Setup panel so users can enable/disable replays at runtime. 
- Added `rotationY: Math.PI / 2` to the `cinemaLobby` and `newmanLobby` entries in `POOL_ROYALE_HDRI_PLACEMENTS` inside `webapp/src/config/poolRoyaleInventoryConfig.js` to rotate those HDRIs so tables/decor align along their long side.

### Testing
- Ran `npm --prefix webapp run build` to validate the web bundle, and the build completed successfully (Vite emitted only non-blocking chunk-size warnings).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d22e3387348329be1dae905eb56b42)