### PR TITLE
Fix camera drag direction, dice landing for side seats, and dice reroll timing in Snake & Ladder

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -258,7 +258,7 @@ const CAMERA_TOPDOWN_RADIUS_FACTOR = 2.35;
 const CAMERA_TOPDOWN_MIN_RADIUS_FACTOR = 1.2;
 const CAMERA_TOPDOWN_MAX_RADIUS_FACTOR = 3.6;
 const CAMERA_LOOK_YAW_LIMIT = THREE.MathUtils.degToRad(26);
-const CAMERA_LOOK_YAW_DRAG_FACTOR = -0.0055;
+const CAMERA_LOOK_YAW_DRAG_FACTOR = 0.0055;
 const CAMERA_LOOK_PITCH_LIMIT = THREE.MathUtils.degToRad(16);
 const CAMERA_LOOK_PITCH_DRAG_FACTOR = -0.0038;
 const CAMERA_EXTRA_LIFT = 0.12;
@@ -266,8 +266,8 @@ const INITIAL_CAMERA_DISTANCE_FACTOR = 0.35;
 const PORTRAIT_CAMERA_TUNING = Object.freeze({
   backOffset: 1.14,
   forwardOffset: 0,
-  heightOffset: 1.86,
-  targetLift: 0.08 * MODEL_SCALE
+  heightOffset: 2.02,
+  targetLift: 0.07 * MODEL_SCALE
 });
 const LANDSCAPE_CAMERA_TUNING = Object.freeze({
   backOffset: 0.68,
@@ -300,19 +300,9 @@ const DICE_SEAT_ADJUSTMENTS = [
   },
   {
     forward: {
-      start: TILE_SIZE * 0.24,
-      bounce: TILE_SIZE * 0.28,
-      base: TILE_SIZE * 0.42
-    },
-    front: {
-      start: TILE_SIZE * 0.64,
-      bounce: TILE_SIZE * 0.98,
-      base: TILE_SIZE * 1.36
-    },
-    side: {
-      start: TILE_SIZE * 0.4,
-      bounce: TILE_SIZE * 0.48,
-      base: TILE_SIZE * 0.6
+      start: TILE_SIZE * 0.12,
+      bounce: TILE_SIZE * 0.1,
+      base: TILE_SIZE * 0.18
     }
   },
   {
@@ -324,19 +314,9 @@ const DICE_SEAT_ADJUSTMENTS = [
   },
   {
     forward: {
-      start: TILE_SIZE * 0.24,
-      bounce: TILE_SIZE * 0.28,
-      base: TILE_SIZE * 0.42
-    },
-    front: {
-      start: TILE_SIZE * 0.64,
-      bounce: TILE_SIZE * 0.98,
-      base: TILE_SIZE * 1.36
-    },
-    side: {
-      start: -TILE_SIZE * 0.4,
-      bounce: -TILE_SIZE * 0.48,
-      base: -TILE_SIZE * 0.6
+      start: TILE_SIZE * 0.12,
+      bounce: TILE_SIZE * 0.1,
+      base: TILE_SIZE * 0.18
     }
   }
 ];

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -184,7 +184,7 @@ const PENULTIMATE_TILE = FINAL_TILE - 1;
 const TURN_TIME = 15;
 const AI_ROLL_DELAY_MS = 3400;
 const AI_EXTRA_ROLL_DELAY_MS = 2600;
-const TURN_ADVANCE_AFTER_DICE_MS = 1400;
+const TURN_ADVANCE_AFTER_DICE_MS = 2000;
 const DEFAULT_CAPACITY = 4;
 const COMMENTARY_PRESET_STORAGE_KEY = 'snakeCommentaryPreset';
 const COMMENTARY_MUTE_STORAGE_KEY = 'snakeCommentaryMute';
@@ -3150,10 +3150,11 @@ export default function SnakeAndLadder() {
   const hasLocalExtraRoll = isMultiplayer && pendingExtraRoll;
   const isMyTurnForRoll =
     myPlayerIndex !== null && (currentTurn === myPlayerIndex || hasLocalExtraRoll);
+  const rollReady = hasLocalExtraRoll || rollCooldown === 0;
   const canRoll =
     isMyTurnForRoll &&
     !moving &&
-    rollCooldown === 0 &&
+    rollReady &&
     !gameOver &&
     !waitingForPlayers &&
     !playerAutoRolling &&


### PR DESCRIPTION
### Motivation
- Fix inverted horizontal camera drag so on-screen finger movement (left/right) matches the camera look direction and make the portrait view sit a bit higher and look slightly more downward for better readability. 
- Ensure dice land in front of the active player for top/left/right seats the same way they do for the bottom player. 
- Make dice results remain visible longer and ensure extra-roll (six) immediately enables roll UI in multiplayer so the roll icon appears when a bonus roll is earned.

### Description
- Changed camera drag sign by flipping `CAMERA_LOOK_YAW_DRAG_FACTOR` to `0.0055` so horizontal drag follows the finger direction (`webapp/src/components/SnakeBoard3D.jsx`).
- Tuned portrait camera (`PORTRAIT_CAMERA_TUNING`) by increasing `heightOffset` and slightly lowering `targetLift` to lift the view and angle it a bit more downward (`webapp/src/components/SnakeBoard3D.jsx`).
- Normalized dice seat adjustments in `DICE_SEAT_ADJUSTMENTS` so non-bottom seats use consistent forward/bounce/base offsets and land dice in front of the active player (`webapp/src/components/SnakeBoard3D.jsx`).
- Increased the post-dice delay constant `TURN_ADVANCE_AFTER_DICE_MS` from `1400` to `2000` so dice results remain visible for 2 seconds before advancing the turn (`webapp/src/pages/Games/SnakeAndLadder.jsx`).
- Allowed multiplayer extra-roll readiness to bypass cooldown gating by adding `rollReady = hasLocalExtraRoll || rollCooldown === 0` and using that in `canRoll`, so the roll button/anchor can appear immediately when a six/bonus is earned (`webapp/src/pages/Games/SnakeAndLadder.jsx`).

### Testing
- Built the web app with `cd webapp && npm run build`, and the build completed successfully (production build finished).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d241c151f88329a857b52bc1efe57d)