### PR TITLE
Reduce and lower chairs in Checkers Battle Royal

### DIFF
--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -101,8 +101,8 @@ const CHECKERS_TABLE_BASE_RADIUS_SCALE = 0.56;
 const CHECKERS_TABLE_TRIM_HEIGHT_SCALE = 0.66;
 const CHECKERS_TABLE_TRIM_RADIUS_SCALE = 0.74;
 const CHECKERS_CAMERA_FRAME_COMPENSATION = 1.08;
-// Sink grounded chairs enough to be clearly lower than previous builds.
-const CHAIR_GROUND_SINK = 0.24;
+// Lower chairs toward the floor for stronger downward screen placement.
+const CHAIR_GROUND_SINK = 0.32;
 const CHECKERS_GRAPHICS_PROFILE_STORAGE_KEY =
   'checkersBattleRoyalGraphicsProfile';
 const CHECKERS_DEFAULT_GRAPHICS_PROFILE_ID = 'hz90_2k';
@@ -270,6 +270,8 @@ const CHAIR_MODEL_URLS = [
   'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/SheenChair/glTF-Binary/SheenChair.glb',
   'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/AntiqueChair/glTF-Binary/AntiqueChair.glb'
 ];
+// Requested tweak: make chairs about 20% smaller than the current setup.
+const CHAIR_VISUAL_SCALE = 0.8;
 const CHAIR_TARGET_SCALE_FACTOR = 0.8;
 const TARGET_CHAIR_SIZE = new THREE.Vector3(
   1.3162499970197679 * CHAIR_TARGET_SCALE_FACTOR,
@@ -2250,6 +2252,7 @@ export default function CheckersBattleRoyal() {
               mat.needsUpdate = true;
             });
           });
+          g.scale.setScalar(CHAIR_VISUAL_SCALE);
           g.position.set(0, CHAIR_HEIGHT, z);
           g.rotation.y = ry;
           groundGroupToFloor(
@@ -2273,6 +2276,7 @@ export default function CheckersBattleRoyal() {
         const legColor = chairOption?.legColor || '#111827';
         const makeFallback = (z, ry) => {
           const g = createProceduralChairFallback(chairColor, legColor);
+          g.scale.setScalar(CHAIR_VISUAL_SCALE);
           g.position.set(0, CHAIR_HEIGHT, z);
           g.rotation.y = ry;
           groundGroupToFloor(


### PR DESCRIPTION
### Motivation
- Adjust portrait/mobile visuals so arena chairs appear about 20% smaller and sit lower on the screen for better composition and onboarding.

### Description
- Added `CHAIR_VISUAL_SCALE = 0.8` and applied it to both GLTF chair instances and the procedural fallback via `g.scale.setScalar(CHAIR_VISUAL_SCALE)` in `webapp/src/pages/Games/CheckersBattleRoyal.jsx`.
- Increased `CHAIR_GROUND_SINK` from `0.24` to `0.32` to sink chairs closer to the floor for a stronger downward placement on portrait screens.
- Changes affect chair construction paths used when loading mapped GLTF chairs and when falling back to the procedural chair template to keep appearances consistent.

### Testing
- Ran `npm --prefix webapp run -s build` and the production build completed successfully (warnings only, build succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d24df3e5a08329a4a463cf586abd5d)