### PR TITLE
Adjust Ludo Battle Royal bottom player avatar vertical offset

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -389,7 +389,7 @@ const FALLBACK_SEAT_POSITIONS = [
   { left: '52%', top: '24%' },
   { left: '20%', top: '56%' }
 ];
-const SELF_AVATAR_BOTTOM_OFFSET_PERCENT = 2;
+const SELF_AVATAR_BOTTOM_OFFSET_PERCENT = 4;
 
 const colorNumberToHex = (value) => `#${value.toString(16).padStart(6, '0')}`;
 


### PR DESCRIPTION
### Motivation
- Make the local player's avatar on the bottom of the Ludo Battle Royal screen sit lower in portrait view so it appears closer to the page roof edge.

### Description
- Increased `SELF_AVATAR_BOTTOM_OFFSET_PERCENT` from `2` to `4` in `webapp/src/pages/Games/LudoBattleRoyal.jsx` to move the self avatar downward.

### Testing
- Ran `npm --prefix webapp run build` which completed successfully (Vite emitted non-blocking chunk-size warnings).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d24f9752a08329907e263c4cea4bb6)