### PR TITLE
Add hexagon/oval/diamond table shapes, table cloth options, and adjust chairs/pieces for Checkers Battle Royal

### DIFF
--- a/webapp/src/config/chessBattleInventoryConfig.js
+++ b/webapp/src/config/chessBattleInventoryConfig.js
@@ -1,5 +1,6 @@
 import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from './murlanThemes.js';
 import { MURLAN_TABLE_FINISHES } from './murlanTableFinishes.js';
+import { TABLE_CLOTH_OPTIONS } from '../utils/tableCustomizationOptions.js';
 import {
   POOL_ROYALE_DEFAULT_HDRI_ID,
   POOL_ROYALE_HDRI_VARIANTS
@@ -70,11 +71,13 @@ export const CHESS_CHAIR_OPTIONS = Object.freeze([
 ]);
 
 export const CHESS_TABLE_OPTIONS = Object.freeze([...MURLAN_TABLE_THEMES]);
+export const CHESS_TABLE_CLOTH_OPTIONS = Object.freeze([...TABLE_CLOTH_OPTIONS]);
 
 export const CHESS_BATTLE_DEFAULT_UNLOCKS = Object.freeze({
   chairColor: [CHESS_CHAIR_OPTIONS[0]?.id],
   tables: [CHESS_TABLE_OPTIONS[0]?.id],
   tableFinish: [MURLAN_TABLE_FINISHES[0]?.id],
+  tableCloth: [CHESS_TABLE_CLOTH_OPTIONS[0]?.id],
   sideColor: ['amberGlow', 'mintVale'],
   boardTheme: ['classic'],
   headStyle: ['current'],
@@ -96,6 +99,12 @@ export const CHESS_BATTLE_OPTION_LABELS = Object.freeze({
   ),
   tableFinish: Object.freeze(
     MURLAN_TABLE_FINISHES.reduce((acc, option) => {
+      acc[option.id] = option.label;
+      return acc;
+    }, {})
+  ),
+  tableCloth: Object.freeze(
+    CHESS_TABLE_CLOTH_OPTIONS.reduce((acc, option) => {
       acc[option.id] = option.label;
       return acc;
     }, {})
@@ -174,6 +183,19 @@ export const CHESS_BATTLE_OPTION_THUMBNAILS = Object.freeze({
 });
 
 export const CHESS_BATTLE_STORE_ITEMS = [
+  ...CHESS_TABLE_CLOTH_OPTIONS.map((cloth, idx) => ({
+    id: `chess-table-cloth-${cloth.id}`,
+    type: 'tableCloth',
+    optionId: cloth.id,
+    name: cloth.label,
+    price: cloth.price ?? 640 + idx * 20,
+    description:
+      cloth.description ||
+      `${cloth.label} cloth finish shared with Texas Hold'em customization.`,
+    swatches: cloth.swatches || [cloth.feltTop, cloth.feltBottom, cloth.emissive],
+    thumbnail: cloth.thumbnail,
+    previewShape: 'table'
+  })),
   ...MURLAN_TABLE_FINISHES.map((finish, idx) => ({
     id: `chess-table-finish-${finish.id}`,
     type: 'tableFinish',

--- a/webapp/src/config/murlanThemes.js
+++ b/webapp/src/config/murlanThemes.js
@@ -167,9 +167,37 @@ export const MURLAN_TABLE_THEMES = [
     id: 'murlan-default',
     label: 'Octagon Table',
     source: 'procedural',
+    shapeId: 'classicOctagon',
     price: 0,
     thumbnail: polyHavenThumb('CoffeeTable_01'),
     description: 'Standard Murlan Royale table with a streamlined, pedestal-free setup.'
+  },
+  {
+    id: 'oval-table',
+    label: 'Oval Table',
+    source: 'procedural',
+    shapeId: 'grandOval',
+    price: 1080,
+    thumbnail: polyHavenThumb('coffee_table_round_01'),
+    description: 'Grand oval battle table tailored for portrait-screen framing.'
+  },
+  {
+    id: 'diamond-edge',
+    label: 'Diamond Edge Table',
+    source: 'procedural',
+    shapeId: 'diamondEdge',
+    price: 1120,
+    thumbnail: polyHavenThumb('modern_coffee_table_01'),
+    description: 'Diamond edge silhouette with clean rails and tighter center play area.'
+  },
+  {
+    id: 'hexagon-table',
+    label: 'Hexagon Table',
+    source: 'procedural',
+    shapeId: 'royaleHexagon',
+    price: 1160,
+    thumbnail: polyHavenThumb('side_table_01'),
+    description: 'Hexagon variant matching octagon proportions with six clean sides.'
   },
   ...POLYHAVEN_TABLE_THEMES
 ];

--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -23,7 +23,8 @@ import {
 import { ARENA_CAMERA_DEFAULTS } from '../../utils/arenaCameraConfig.js';
 import {
   createMurlanStyleTable,
-  applyTableMaterials
+  applyTableMaterials,
+  TABLE_SHAPE_OPTIONS
 } from '../../utils/murlanTable.js';
 import AvatarTimer from '../../components/AvatarTimer.jsx';
 import BottomLeftIcons from '../../components/BottomLeftIcons.jsx';
@@ -32,6 +33,7 @@ import {
   CHESS_BATTLE_OPTION_LABELS,
   CHESS_BATTLE_OPTION_THUMBNAILS,
   CHESS_CHAIR_OPTIONS,
+  CHESS_TABLE_CLOTH_OPTIONS,
   CHESS_TABLE_OPTIONS
 } from '../../config/chessBattleInventoryConfig.js';
 import {
@@ -102,7 +104,7 @@ const CHECKERS_TABLE_TRIM_HEIGHT_SCALE = 0.66;
 const CHECKERS_TABLE_TRIM_RADIUS_SCALE = 0.74;
 const CHECKERS_CAMERA_FRAME_COMPENSATION = 1.08;
 // Lower chairs toward the floor for stronger downward screen placement.
-const CHAIR_GROUND_SINK = 0.32;
+const CHAIR_GROUND_SINK = 0.36;
 const CHECKERS_GRAPHICS_PROFILE_STORAGE_KEY =
   'checkersBattleRoyalGraphicsProfile';
 const CHECKERS_DEFAULT_GRAPHICS_PROFILE_ID = 'hz90_2k';
@@ -270,9 +272,9 @@ const CHAIR_MODEL_URLS = [
   'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/SheenChair/glTF-Binary/SheenChair.glb',
   'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/AntiqueChair/glTF-Binary/AntiqueChair.glb'
 ];
-// Requested tweak: make chairs about 20% smaller than the current setup.
-const CHAIR_VISUAL_SCALE = 0.8;
-const CHAIR_TARGET_SCALE_FACTOR = 0.8;
+// Portrait-screen tuning request: chairs ~15% larger than the previous setup.
+const CHAIR_VISUAL_SCALE = 0.92;
+const CHAIR_TARGET_SCALE_FACTOR = 0.92;
 const TARGET_CHAIR_SIZE = new THREE.Vector3(
   1.3162499970197679 * CHAIR_TARGET_SCALE_FACTOR,
   1.9173749900311232 * CHAIR_TARGET_SCALE_FACTOR,
@@ -292,6 +294,7 @@ const TOUCH_TAP_MAX_DURATION_MS = 360;
 const MOUSE_PICK_RADIUS_IN_TILES = 0.58;
 const TOUCH_PICK_RADIUS_IN_TILES = 0.74;
 const CHECKER_PIECE_SCALE = 0.88;
+const CHECKER_PIECE_HEIGHT_OFFSET = 0.07;
 const CHECKERS_HIGHLIGHT_COLORS = Object.freeze({
   selection: '#ff8e6e',
   move: '#7ef9a1',
@@ -325,6 +328,27 @@ const AI_SEARCH_DEPTH = 6;
 const CAPTURE_STRIP_OFFSET_ROWS = 1.15;
 const CAPTURE_STRIP_PIECE_GAP = 0.82;
 const ONLINE_SOCKET_CONNECT_TIMEOUT_MS = 6000;
+const TABLE_SHAPE_BY_ID = Object.freeze(
+  TABLE_SHAPE_OPTIONS.reduce((acc, option) => {
+    if (option?.id) acc[option.id] = option;
+    return acc;
+  }, {})
+);
+const TABLE_IDS_WITH_FINISH_AND_CLOTH = new Set([
+  'murlan-default',
+  'oval-table',
+  'diamond-edge',
+  'hexagon-table'
+]);
+
+const supportsTableFinishAndCloth = (tableId = '') =>
+  TABLE_IDS_WITH_FINISH_AND_CLOTH.has(String(tableId || '').trim().toLowerCase());
+
+const resolveTableShape = (tableId = '') => {
+  const tableTheme = CHESS_TABLE_OPTIONS.find((option) => option.id === tableId);
+  const shapeId = tableTheme?.shapeId || 'classicOctagon';
+  return TABLE_SHAPE_BY_ID[shapeId] || TABLE_SHAPE_OPTIONS[0];
+};
 
 async function ensureOnlineSocketConnected(timeoutMs = ONLINE_SOCKET_CONNECT_TIMEOUT_MS) {
   if (socket.connected) return true;
@@ -1375,6 +1399,7 @@ export default function CheckersBattleRoyal() {
   const cameraRef = useRef(null);
   const controlsRef = useRef(null);
   const tableRef = useRef(null);
+  const activeTableIdRef = useRef(null);
   const chairsRef = useRef([]);
   const keyLightRef = useRef(null);
   const shadowCatcherRef = useRef(null);
@@ -1460,6 +1485,13 @@ export default function CheckersBattleRoyal() {
       ),
     [inventory]
   );
+  const unlockedTableCloths = useMemo(
+    () =>
+      CHESS_TABLE_CLOTH_OPTIONS.filter((opt) =>
+        isChessOptionUnlocked('tableCloth', opt.id, inventory)
+      ),
+    [inventory]
+  );
   const unlockedBoardThemes = useMemo(
     () =>
       CHECKERS_BOARD_THEME_OPTIONS.filter((opt) =>
@@ -1485,6 +1517,7 @@ export default function CheckersBattleRoyal() {
       tableId: inventory.tables?.[0] || CHESS_TABLE_OPTIONS[0]?.id,
       chairId: inventory.chairColor?.[0] || CHESS_CHAIR_OPTIONS[0]?.id,
       tableFinish: inventory.tableFinish?.[0] || MURLAN_TABLE_FINISHES[0]?.id,
+      tableCloth: inventory.tableCloth?.[0] || CHESS_TABLE_CLOTH_OPTIONS[0]?.id,
       hdriId: inventory.environmentHdri?.[0] || POOL_ROYALE_DEFAULT_HDRI_ID,
       boardTheme:
         inventory.boardTheme?.[0] || CHECKERS_BOARD_THEME_OPTIONS[0]?.id,
@@ -1615,6 +1648,10 @@ export default function CheckersBattleRoyal() {
         unlockedTableFinishes.find((opt) => opt.id === prev.tableFinish)?.id ||
         unlockedTableFinishes[0]?.id ||
         MURLAN_TABLE_FINISHES[0]?.id,
+      tableCloth:
+        unlockedTableCloths.find((opt) => opt.id === prev.tableCloth)?.id ||
+        unlockedTableCloths[0]?.id ||
+        CHESS_TABLE_CLOTH_OPTIONS[0]?.id,
       boardTheme:
         unlockedBoardThemes.find((opt) => opt.id === prev.boardTheme)?.id ||
         unlockedBoardThemes[0]?.id ||
@@ -1628,6 +1665,7 @@ export default function CheckersBattleRoyal() {
     unlockedBoardThemes,
     unlockedChairOptions,
     unlockedHdriOptions,
+    unlockedTableCloths,
     unlockedTableFinishes,
     unlockedTableOptions
   ]);
@@ -1643,6 +1681,12 @@ export default function CheckersBattleRoyal() {
         appearance.tableFinish,
         resolvedAccountId
       );
+    if (appearance.tableCloth)
+      setChessBattleEquippedOption(
+        'tableCloth',
+        appearance.tableCloth,
+        resolvedAccountId
+      );
     if (appearance.boardTheme)
       setChessBattleEquippedOption('boardTheme', appearance.boardTheme, resolvedAccountId);
     if (appearance.hdriId)
@@ -1655,6 +1699,7 @@ export default function CheckersBattleRoyal() {
     appearance.boardTheme,
     appearance.chairId,
     appearance.hdriId,
+    appearance.tableCloth,
     appearance.tableFinish,
     appearance.tableId,
     resolvedAccountId
@@ -1704,7 +1749,7 @@ export default function CheckersBattleRoyal() {
 
           pieceGroup.position.set(
             x + (c - 3.5) * tile,
-            y + tile * 0.1,
+            y + tile * CHECKER_PIECE_HEIGHT_OFFSET,
             z + (r - 3.5) * tile
           );
           pieceGroup.userData = { r, c, side: piece.side };
@@ -1741,7 +1786,7 @@ export default function CheckersBattleRoyal() {
           });
           checker.position.set(
             x + centered * tile * CAPTURE_STRIP_PIECE_GAP,
-            y + tile * 0.1,
+            y + tile * CHECKER_PIECE_HEIGHT_OFFSET,
             z + edge * (3.5 + CAPTURE_STRIP_OFFSET_ROWS + row * 0.74) * tile
           );
           group.add(checker);
@@ -2217,18 +2262,37 @@ export default function CheckersBattleRoyal() {
       };
 
       try {
+        const selectedTableId =
+          CHESS_TABLE_OPTIONS.find((option) => option.id === appearance.tableId)
+            ?.id || CHESS_TABLE_OPTIONS[0]?.id;
+        const selectedShape = resolveTableShape(selectedTableId);
         const table = createMurlanStyleTable({
           arena: scene,
           renderer,
           tableRadius: TABLE_RADIUS,
-          tableHeight: TABLE_HEIGHT
+          tableHeight: TABLE_HEIGHT,
+          shapeOption: selectedShape,
+          rotationY:
+            selectedShape?.id === 'classicOctagon' ||
+            selectedShape?.id === 'royaleHexagon'
+              ? Math.PI / 8
+              : 0
         });
         const finish =
           MURLAN_TABLE_FINISHES.find((f) => f.id === appearance.tableFinish) ||
           MURLAN_TABLE_FINISHES[0];
-        applyTableMaterials(table.parts, finish);
+        const cloth =
+          CHESS_TABLE_CLOTH_OPTIONS.find(
+            (clothOption) => clothOption.id === appearance.tableCloth
+          ) || CHESS_TABLE_CLOTH_OPTIONS[0];
+        applyTableMaterials(
+          table.materials,
+          { woodOption: finish?.woodOption, clothOption: cloth },
+          renderer
+        );
         reduceCheckersTableBase(table.group);
         tableRef.current = table;
+        activeTableIdRef.current = selectedTableId;
       } catch (error) {
         console.error('Checkers table load failed:', error);
       }
@@ -2666,13 +2730,45 @@ export default function CheckersBattleRoyal() {
 
   useEffect(() => {
     const scene = sceneRef.current;
+    const renderer = rendererRef.current;
     if (!scene) return;
+
+    const selectedTableId =
+      CHESS_TABLE_OPTIONS.find((option) => option.id === appearance.tableId)?.id ||
+      CHESS_TABLE_OPTIONS[0]?.id;
+    if (selectedTableId && activeTableIdRef.current !== selectedTableId) {
+      tableRef.current?.dispose?.();
+      const selectedShape = resolveTableShape(selectedTableId);
+      const rebuiltTable = createMurlanStyleTable({
+        arena: scene,
+        renderer,
+        tableRadius: TABLE_RADIUS,
+        tableHeight: TABLE_HEIGHT,
+        shapeOption: selectedShape,
+        rotationY:
+          selectedShape?.id === 'classicOctagon' ||
+          selectedShape?.id === 'royaleHexagon'
+            ? Math.PI / 8
+            : 0
+      });
+      reduceCheckersTableBase(rebuiltTable.group);
+      tableRef.current = rebuiltTable;
+      activeTableIdRef.current = selectedTableId;
+    }
 
     const finish =
       MURLAN_TABLE_FINISHES.find((f) => f.id === appearance.tableFinish) ||
       MURLAN_TABLE_FINISHES[0];
-    if (tableRef.current?.parts)
-      applyTableMaterials(tableRef.current.parts, finish);
+    const cloth =
+      CHESS_TABLE_CLOTH_OPTIONS.find(
+        (clothOption) => clothOption.id === appearance.tableCloth
+      ) || CHESS_TABLE_CLOTH_OPTIONS[0];
+    if (tableRef.current?.materials)
+      applyTableMaterials(
+        tableRef.current.materials,
+        { woodOption: finish?.woodOption, clothOption: cloth },
+        renderer
+      );
 
     const chairOption =
       CHESS_CHAIR_OPTIONS.find((c) => c.id === appearance.chairId) ||
@@ -2922,33 +3018,6 @@ export default function CheckersBattleRoyal() {
               </button>
               <div className="mt-3 rounded-xl border border-white/10 bg-white/5 p-3">
                 <div className="mb-2 text-[11px] uppercase tracking-[0.2em] text-white/70">
-                  Table Finish
-                </div>
-                <div className="mb-3 grid max-h-40 grid-cols-2 gap-2 overflow-auto">
-                  {unlockedTableFinishes.map((opt) => (
-                    <button
-                      key={opt.id}
-                      onClick={() =>
-                        setAppearance((prev) => ({
-                          ...prev,
-                          tableFinish: opt.id
-                        }))
-                      }
-                      className={`rounded-xl border px-2 py-2 text-[11px] ${appearance.tableFinish === opt.id ? 'border-cyan-300 bg-cyan-500/20 text-cyan-100' : 'border-white/15 bg-white/5 text-white/70'}`}
-                    >
-                      {opt.thumbnail ? (
-                        <img
-                          src={opt.thumbnail}
-                          alt={`${opt.label} thumbnail`}
-                          className="mb-1 h-10 w-full rounded object-cover"
-                        />
-                      ) : null}
-                      {opt.label}
-                    </button>
-                  ))}
-                </div>
-
-                <div className="mb-2 text-[11px] uppercase tracking-[0.2em] text-white/70">
                   Tables
                 </div>
                 <div className="mb-3 grid max-h-40 grid-cols-2 gap-2 overflow-auto">
@@ -2971,6 +3040,63 @@ export default function CheckersBattleRoyal() {
                     </button>
                   ))}
                 </div>
+                {supportsTableFinishAndCloth(appearance.tableId) ? (
+                  <>
+                    <div className="mb-2 text-[11px] uppercase tracking-[0.2em] text-white/70">
+                      Table Cloth
+                    </div>
+                    <div className="mb-3 grid max-h-40 grid-cols-2 gap-2 overflow-auto">
+                      {unlockedTableCloths.map((opt) => (
+                        <button
+                          key={opt.id}
+                          onClick={() =>
+                            setAppearance((prev) => ({
+                              ...prev,
+                              tableCloth: opt.id
+                            }))
+                          }
+                          className={`rounded-xl border px-2 py-2 text-[11px] ${appearance.tableCloth === opt.id ? 'border-cyan-300 bg-cyan-500/20 text-cyan-100' : 'border-white/15 bg-white/5 text-white/70'}`}
+                        >
+                          {opt.thumbnail ? (
+                            <img
+                              src={opt.thumbnail}
+                              alt={`${opt.label} thumbnail`}
+                              className="mb-1 h-10 w-full rounded object-cover"
+                            />
+                          ) : null}
+                          {opt.label}
+                        </button>
+                      ))}
+                    </div>
+
+                    <div className="mb-2 text-[11px] uppercase tracking-[0.2em] text-white/70">
+                      Table Finish
+                    </div>
+                    <div className="mb-3 grid max-h-40 grid-cols-2 gap-2 overflow-auto">
+                      {unlockedTableFinishes.map((opt) => (
+                        <button
+                          key={opt.id}
+                          onClick={() =>
+                            setAppearance((prev) => ({
+                              ...prev,
+                              tableFinish: opt.id
+                            }))
+                          }
+                          className={`rounded-xl border px-2 py-2 text-[11px] ${appearance.tableFinish === opt.id ? 'border-cyan-300 bg-cyan-500/20 text-cyan-100' : 'border-white/15 bg-white/5 text-white/70'}`}
+                        >
+                          {opt.thumbnail ? (
+                            <img
+                              src={opt.thumbnail}
+                              alt={`${opt.label} thumbnail`}
+                              className="mb-1 h-10 w-full rounded object-cover"
+                            />
+                          ) : null}
+                          {opt.label}
+                        </button>
+                      ))}
+                    </div>
+                  </>
+                ) : null}
 
                 <div className="mb-2 text-[11px] uppercase tracking-[0.2em] text-white/70">
                   Board

--- a/webapp/src/utils/murlanTable.js
+++ b/webapp/src/utils/murlanTable.js
@@ -355,6 +355,29 @@ export const TABLE_SHAPE_OPTIONS = Object.freeze([
       const rimInnerShape = createRoundedRectangleShape(innerWidth, innerHeight, 0.1 * factor);
       return { topShape, feltShape, rimInnerShape, feltRadius: Math.max(feltWidth, feltHeight) * 0.5 };
     }
+  },
+  {
+    id: 'royaleHexagon',
+    label: 'Hexagon Royale',
+    preview: {
+      clipPath: 'polygon(25% 8%, 75% 8%, 100% 50%, 75% 92%, 25% 92%, 0% 50%)'
+    },
+    thumbnail: swatchThumbnail(['#0f172a', '#1e293b', '#22d3ee']),
+    createShapes: ({ radius }) => {
+      const sideStretch = 1.06;
+      const topShape = scaleShape2D(
+        createRegularPolygonShape(6, radius),
+        sideStretch,
+        1
+      );
+      const feltShape = scaleShape2D(
+        createRegularPolygonShape(6, radius * 0.8),
+        sideStretch,
+        1
+      );
+      const rimInnerShape = scaleShape2D(feltShape, 0.96, 0.96);
+      return { topShape, feltShape, rimInnerShape };
+    }
   }
 ]);
 


### PR DESCRIPTION
### Motivation
- Support more table shapes (hexagon, oval, diamond edge) and let players buy/apply table cloths like in Texas Hold'em so table customization is richer and usable in Checkers Battle Royal. 
- Ensure table cloth and table finish only appear when applicable to the selected table shape to avoid confusing UI. 
- Improve portrait-screen framing by nudging chairs and checker pieces visually downward and adjusting chair scale to match the requested look.

### Description
- Added a new procedural table shape `royaleHexagon` to `TABLE_SHAPE_OPTIONS` and exposed procedural table themes (`oval-table`, `diamond-edge`, `hexagon-table`) in `MURLAN_TABLE_THEMES` so they are selectable as table options. (`webapp/src/utils/murlanTable.js`, `webapp/src/config/murlanThemes.js`)
- Pulled shared `TABLE_CLOTH_OPTIONS` into the Chess/Checkers inventory and added `tableCloth` defaults, labels and store items so cloth options can be bought/equipped for Checkers. (`webapp/src/config/chessBattleInventoryConfig.js`)
- Wired table shape selection into the Checkers scene: resolve procedural `shapeOption` from the selected table, rebuild the procedural table when `tableId` changes, and apply wood finish + cloth via `table.materials` using explicit `{ woodOption, clothOption }` so cloth/finish changes actually update the model. (`webapp/src/pages/Games/CheckersBattleRoyal.jsx`)
- UI: show `Table Cloth` and `Table Finish` menu sections only for supported table IDs (`murlan-default`, `oval-table`, `diamond-edge`, `hexagon-table`) to hide irrelevant options for other tables. (`webapp/src/pages/Games/CheckersBattleRoyal.jsx`)
- Portrait visual tweaks: changed chair scale/targets and grounding (`CHAIR_VISUAL_SCALE`, `CHAIR_TARGET_SCALE_FACTOR`, `CHAIR_GROUND_SINK`) and lowered checker piece vertical placement (`CHECKER_PIECE_HEIGHT_OFFSET`) so chairs and pieces appear slightly more down on screen. (`webapp/src/pages/Games/CheckersBattleRoyal.jsx`)

### Testing
- Ran a production build for the web app using `cd webapp && npm run -s build`, which completed successfully (Vite build finished); pre-existing chunk-size warnings were observed but unrelated to this change. 
- Verified the new procedural shape, cloth and finish code paths are used at runtime by rebuilding the procedural table when `tableId` changes in the scene (manual code inspection and local build verification).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2553ba0548329bc858238c8d7057d)