### PR TITLE
Add table-shape & cloth customization to Checkers Battle Royal; adjust chairs/pieces and add hexagon shape

### DIFF
--- a/webapp/src/config/chessBattleInventoryConfig.js
+++ b/webapp/src/config/chessBattleInventoryConfig.js
@@ -1,5 +1,7 @@
 import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from './murlanThemes.js';
 import { MURLAN_TABLE_FINISHES } from './murlanTableFinishes.js';
+import { TABLE_CLOTH_OPTIONS } from '../utils/tableCustomizationOptions.js';
+import { TABLE_SHAPE_OPTIONS } from '../utils/murlanTable.js';
 import {
   POOL_ROYALE_DEFAULT_HDRI_ID,
   POOL_ROYALE_HDRI_VARIANTS
@@ -75,6 +77,8 @@ export const CHESS_BATTLE_DEFAULT_UNLOCKS = Object.freeze({
   chairColor: [CHESS_CHAIR_OPTIONS[0]?.id],
   tables: [CHESS_TABLE_OPTIONS[0]?.id],
   tableFinish: [MURLAN_TABLE_FINISHES[0]?.id],
+  tableCloth: [TABLE_CLOTH_OPTIONS[0]?.id],
+  tableShape: [TABLE_SHAPE_OPTIONS[0]?.id],
   sideColor: ['amberGlow', 'mintVale'],
   boardTheme: ['classic'],
   headStyle: ['current'],
@@ -96,6 +100,18 @@ export const CHESS_BATTLE_OPTION_LABELS = Object.freeze({
   ),
   tableFinish: Object.freeze(
     MURLAN_TABLE_FINISHES.reduce((acc, option) => {
+      acc[option.id] = option.label;
+      return acc;
+    }, {})
+  ),
+  tableCloth: Object.freeze(
+    TABLE_CLOTH_OPTIONS.reduce((acc, option) => {
+      acc[option.id] = option.label;
+      return acc;
+    }, {})
+  ),
+  tableShape: Object.freeze(
+    TABLE_SHAPE_OPTIONS.reduce((acc, option) => {
       acc[option.id] = option.label;
       return acc;
     }, {})
@@ -206,6 +222,26 @@ export const CHESS_BATTLE_STORE_ITEMS = [
       `${option.label} seating tuned for Chess Battle Royal.`,
     thumbnail: option.thumbnail,
     previewShape: 'chair'
+  })),
+  ...TABLE_CLOTH_OPTIONS.slice(1).map((option, idx) => ({
+    id: `chess-table-cloth-${option.id}`,
+    type: 'tableCloth',
+    optionId: option.id,
+    name: option.label,
+    price: 360 + idx * 30,
+    description: 'Swap a premium cloth texture for supported arena tables.',
+    thumbnail: option.thumbnail,
+    previewShape: 'table'
+  })),
+  ...TABLE_SHAPE_OPTIONS.slice(1).map((option, idx) => ({
+    id: `chess-table-shape-${option.id}`,
+    type: 'tableShape',
+    optionId: option.id,
+    name: option.label,
+    price: 680 + idx * 65,
+    description: 'Change the procedural arena silhouette.',
+    thumbnail: option.thumbnail,
+    previewShape: 'table'
   })),
   {
     id: 'chess-side-marble',
@@ -415,6 +451,8 @@ export const CHESS_BATTLE_DEFAULT_LOADOUT = [
     optionId: MURLAN_TABLE_FINISHES[0]?.id,
     label: MURLAN_TABLE_FINISHES[0]?.label
   },
+  { type: 'tableCloth', optionId: TABLE_CLOTH_OPTIONS[0]?.id, label: TABLE_CLOTH_OPTIONS[0]?.label },
+  { type: 'tableShape', optionId: TABLE_SHAPE_OPTIONS[0]?.id, label: TABLE_SHAPE_OPTIONS[0]?.label },
   { type: 'sideColor', optionId: 'amberGlow', label: 'Amber Glow Pieces' },
   { type: 'sideColor', optionId: 'mintVale', label: 'Mint Vale Pieces' },
   { type: 'boardTheme', optionId: 'classic', label: 'Classic Board' },

--- a/webapp/src/config/murlanThemes.js
+++ b/webapp/src/config/murlanThemes.js
@@ -171,6 +171,33 @@ export const MURLAN_TABLE_THEMES = [
     thumbnail: polyHavenThumb('CoffeeTable_01'),
     description: 'Standard Murlan Royale table with a streamlined, pedestal-free setup.'
   },
+  {
+    id: 'ovalTable',
+    label: 'Oval Table',
+    source: 'procedural',
+    shapeId: 'grandOval',
+    price: 1040,
+    thumbnail: polyHavenThumb('coffee_table_round_01'),
+    description: 'Wide oval arena table with a smoother edge profile.'
+  },
+  {
+    id: 'diamondEdge',
+    label: 'Diamond Edge Table',
+    source: 'procedural',
+    shapeId: 'diamondEdge',
+    price: 1080,
+    thumbnail: polyHavenThumb('gothic_coffee_table'),
+    description: 'Diamond-edge silhouette with compact premium footprint.'
+  },
+  {
+    id: 'hexagonTable',
+    label: 'Hexagon Table',
+    source: 'procedural',
+    shapeId: 'royalHexagon',
+    price: 1120,
+    thumbnail: polyHavenThumb('modern_coffee_table_02'),
+    description: 'Hexagon variant built from the octagon arena family.'
+  },
   ...POLYHAVEN_TABLE_THEMES
 ];
 

--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -23,8 +23,10 @@ import {
 import { ARENA_CAMERA_DEFAULTS } from '../../utils/arenaCameraConfig.js';
 import {
   createMurlanStyleTable,
-  applyTableMaterials
+  applyTableMaterials,
+  TABLE_SHAPE_OPTIONS
 } from '../../utils/murlanTable.js';
+import { TABLE_CLOTH_OPTIONS } from '../../utils/tableCustomizationOptions.js';
 import AvatarTimer from '../../components/AvatarTimer.jsx';
 import BottomLeftIcons from '../../components/BottomLeftIcons.jsx';
 import GiftPopup from '../../components/GiftPopup.jsx';
@@ -102,7 +104,7 @@ const CHECKERS_TABLE_TRIM_HEIGHT_SCALE = 0.66;
 const CHECKERS_TABLE_TRIM_RADIUS_SCALE = 0.74;
 const CHECKERS_CAMERA_FRAME_COMPENSATION = 1.08;
 // Lower chairs toward the floor for stronger downward screen placement.
-const CHAIR_GROUND_SINK = 0.32;
+const CHAIR_GROUND_SINK = 0.4;
 const CHECKERS_GRAPHICS_PROFILE_STORAGE_KEY =
   'checkersBattleRoyalGraphicsProfile';
 const CHECKERS_DEFAULT_GRAPHICS_PROFILE_ID = 'hz90_2k';
@@ -270,9 +272,16 @@ const CHAIR_MODEL_URLS = [
   'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/SheenChair/glTF-Binary/SheenChair.glb',
   'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/AntiqueChair/glTF-Binary/AntiqueChair.glb'
 ];
-// Requested tweak: make chairs about 20% smaller than the current setup.
-const CHAIR_VISUAL_SCALE = 0.8;
-const CHAIR_TARGET_SCALE_FACTOR = 0.8;
+// Portrait calibration: make chairs about 15% bigger than current setup.
+const CHAIR_VISUAL_SCALE = 0.92;
+const CHAIR_TARGET_SCALE_FACTOR = 0.92;
+const PIECE_Y_OFFSET = 0.06;
+const TABLES_WITH_CLOTH_AND_FINISH = new Set([
+  'murlan-default',
+  'ovalTable',
+  'diamondEdge',
+  'hexagonTable'
+]);
 const TARGET_CHAIR_SIZE = new THREE.Vector3(
   1.3162499970197679 * CHAIR_TARGET_SCALE_FACTOR,
   1.9173749900311232 * CHAIR_TARGET_SCALE_FACTOR,
@@ -355,6 +364,25 @@ async function ensureOnlineSocketConnected(timeoutMs = ONLINE_SOCKET_CONNECT_TIM
     socket.once('error', handleError);
     socket.connect?.();
   });
+}
+
+function resolveShapeForTable(tableId, explicitShapeId) {
+  if (explicitShapeId) {
+    const explicit = TABLE_SHAPE_OPTIONS.find((shape) => shape.id === explicitShapeId);
+    if (explicit) return explicit;
+  }
+  const mappedShapeId =
+    tableId === 'ovalTable'
+      ? 'grandOval'
+      : tableId === 'diamondEdge'
+        ? 'diamondEdge'
+        : tableId === 'hexagonTable'
+          ? 'royalHexagon'
+          : 'classicOctagon';
+  return (
+    TABLE_SHAPE_OPTIONS.find((shape) => shape.id === mappedShapeId) ||
+    TABLE_SHAPE_OPTIONS[0]
+  );
 }
 
 const createCheckerMesh = ({
@@ -1460,6 +1488,20 @@ export default function CheckersBattleRoyal() {
       ),
     [inventory]
   );
+  const unlockedTableCloths = useMemo(
+    () =>
+      TABLE_CLOTH_OPTIONS.filter((opt) =>
+        isChessOptionUnlocked('tableCloth', opt.id, inventory)
+      ),
+    [inventory]
+  );
+  const unlockedTableShapes = useMemo(
+    () =>
+      TABLE_SHAPE_OPTIONS.filter((opt) =>
+        isChessOptionUnlocked('tableShape', opt.id, inventory)
+      ),
+    [inventory]
+  );
   const unlockedBoardThemes = useMemo(
     () =>
       CHECKERS_BOARD_THEME_OPTIONS.filter((opt) =>
@@ -1485,6 +1527,8 @@ export default function CheckersBattleRoyal() {
       tableId: inventory.tables?.[0] || CHESS_TABLE_OPTIONS[0]?.id,
       chairId: inventory.chairColor?.[0] || CHESS_CHAIR_OPTIONS[0]?.id,
       tableFinish: inventory.tableFinish?.[0] || MURLAN_TABLE_FINISHES[0]?.id,
+      tableCloth: inventory.tableCloth?.[0] || TABLE_CLOTH_OPTIONS[0]?.id,
+      tableShape: inventory.tableShape?.[0] || TABLE_SHAPE_OPTIONS[0]?.id,
       hdriId: inventory.environmentHdri?.[0] || POOL_ROYALE_DEFAULT_HDRI_ID,
       boardTheme:
         inventory.boardTheme?.[0] || CHECKERS_BOARD_THEME_OPTIONS[0]?.id,
@@ -1615,6 +1659,14 @@ export default function CheckersBattleRoyal() {
         unlockedTableFinishes.find((opt) => opt.id === prev.tableFinish)?.id ||
         unlockedTableFinishes[0]?.id ||
         MURLAN_TABLE_FINISHES[0]?.id,
+      tableCloth:
+        unlockedTableCloths.find((opt) => opt.id === prev.tableCloth)?.id ||
+        unlockedTableCloths[0]?.id ||
+        TABLE_CLOTH_OPTIONS[0]?.id,
+      tableShape:
+        unlockedTableShapes.find((opt) => opt.id === prev.tableShape)?.id ||
+        unlockedTableShapes[0]?.id ||
+        TABLE_SHAPE_OPTIONS[0]?.id,
       boardTheme:
         unlockedBoardThemes.find((opt) => opt.id === prev.boardTheme)?.id ||
         unlockedBoardThemes[0]?.id ||
@@ -1628,7 +1680,9 @@ export default function CheckersBattleRoyal() {
     unlockedBoardThemes,
     unlockedChairOptions,
     unlockedHdriOptions,
+    unlockedTableCloths,
     unlockedTableFinishes,
+    unlockedTableShapes,
     unlockedTableOptions
   ]);
 
@@ -1643,6 +1697,18 @@ export default function CheckersBattleRoyal() {
         appearance.tableFinish,
         resolvedAccountId
       );
+    if (appearance.tableCloth)
+      setChessBattleEquippedOption(
+        'tableCloth',
+        appearance.tableCloth,
+        resolvedAccountId
+      );
+    if (appearance.tableShape)
+      setChessBattleEquippedOption(
+        'tableShape',
+        appearance.tableShape,
+        resolvedAccountId
+      );
     if (appearance.boardTheme)
       setChessBattleEquippedOption('boardTheme', appearance.boardTheme, resolvedAccountId);
     if (appearance.hdriId)
@@ -1655,7 +1721,9 @@ export default function CheckersBattleRoyal() {
     appearance.boardTheme,
     appearance.chairId,
     appearance.hdriId,
+    appearance.tableCloth,
     appearance.tableFinish,
+    appearance.tableShape,
     appearance.tableId,
     resolvedAccountId
   ]);
@@ -1704,7 +1772,7 @@ export default function CheckersBattleRoyal() {
 
           pieceGroup.position.set(
             x + (c - 3.5) * tile,
-            y + tile * 0.1,
+            y + tile * PIECE_Y_OFFSET,
             z + (r - 3.5) * tile
           );
           pieceGroup.userData = { r, c, side: piece.side };
@@ -1741,7 +1809,7 @@ export default function CheckersBattleRoyal() {
           });
           checker.position.set(
             x + centered * tile * CAPTURE_STRIP_PIECE_GAP,
-            y + tile * 0.1,
+            y + tile * PIECE_Y_OFFSET,
             z + edge * (3.5 + CAPTURE_STRIP_OFFSET_ROWS + row * 0.74) * tile
           );
           group.add(checker);
@@ -2217,16 +2285,29 @@ export default function CheckersBattleRoyal() {
       };
 
       try {
+        const shapeOption = resolveShapeForTable(
+          appearance.tableId,
+          appearance.tableShape
+        );
+        const clothOption =
+          TABLE_CLOTH_OPTIONS.find((cloth) => cloth.id === appearance.tableCloth) ||
+          TABLE_CLOTH_OPTIONS[0];
         const table = createMurlanStyleTable({
           arena: scene,
           renderer,
           tableRadius: TABLE_RADIUS,
-          tableHeight: TABLE_HEIGHT
+          tableHeight: TABLE_HEIGHT,
+          shapeOption,
+          clothOption
         });
         const finish =
           MURLAN_TABLE_FINISHES.find((f) => f.id === appearance.tableFinish) ||
           MURLAN_TABLE_FINISHES[0];
-        applyTableMaterials(table.parts, finish);
+        applyTableMaterials(
+          table.materials,
+          { woodOption: finish?.woodOption, clothOption },
+          renderer
+        );
         reduceCheckersTableBase(table.group);
         tableRef.current = table;
       } catch (error) {
@@ -2671,8 +2752,31 @@ export default function CheckersBattleRoyal() {
     const finish =
       MURLAN_TABLE_FINISHES.find((f) => f.id === appearance.tableFinish) ||
       MURLAN_TABLE_FINISHES[0];
-    if (tableRef.current?.parts)
-      applyTableMaterials(tableRef.current.parts, finish);
+    const clothOption =
+      TABLE_CLOTH_OPTIONS.find((cloth) => cloth.id === appearance.tableCloth) ||
+      TABLE_CLOTH_OPTIONS[0];
+    const shapeOption = resolveShapeForTable(appearance.tableId, appearance.tableShape);
+    const tableShapeChanged = tableRef.current?.shapeId !== shapeOption?.id;
+    if (tableShapeChanged) {
+      tableRef.current?.dispose?.();
+      const rebuilt = createMurlanStyleTable({
+        arena: scene,
+        renderer: rendererRef.current,
+        tableRadius: TABLE_RADIUS,
+        tableHeight: TABLE_HEIGHT,
+        shapeOption,
+        clothOption
+      });
+      reduceCheckersTableBase(rebuilt.group);
+      tableRef.current = rebuilt;
+    }
+    if (tableRef.current?.materials) {
+      applyTableMaterials(
+        tableRef.current.materials,
+        { woodOption: finish?.woodOption, clothOption },
+        rendererRef.current
+      );
+    }
 
     const chairOption =
       CHESS_CHAIR_OPTIONS.find((c) => c.id === appearance.chairId) ||
@@ -2862,6 +2966,9 @@ export default function CheckersBattleRoyal() {
 
   const optionButton = (active) =>
     `rounded-lg border px-2 py-1 text-[11px] ${active ? 'border-cyan-300 bg-cyan-500/20 text-cyan-100' : 'border-white/15 bg-white/5 text-white/70'}`;
+  const supportsSurfaceCustomization = TABLES_WITH_CLOTH_AND_FINISH.has(
+    appearance.tableId
+  );
 
   if (mode === 'online' && redirecting) {
     return (
@@ -2922,33 +3029,6 @@ export default function CheckersBattleRoyal() {
               </button>
               <div className="mt-3 rounded-xl border border-white/10 bg-white/5 p-3">
                 <div className="mb-2 text-[11px] uppercase tracking-[0.2em] text-white/70">
-                  Table Finish
-                </div>
-                <div className="mb-3 grid max-h-40 grid-cols-2 gap-2 overflow-auto">
-                  {unlockedTableFinishes.map((opt) => (
-                    <button
-                      key={opt.id}
-                      onClick={() =>
-                        setAppearance((prev) => ({
-                          ...prev,
-                          tableFinish: opt.id
-                        }))
-                      }
-                      className={`rounded-xl border px-2 py-2 text-[11px] ${appearance.tableFinish === opt.id ? 'border-cyan-300 bg-cyan-500/20 text-cyan-100' : 'border-white/15 bg-white/5 text-white/70'}`}
-                    >
-                      {opt.thumbnail ? (
-                        <img
-                          src={opt.thumbnail}
-                          alt={`${opt.label} thumbnail`}
-                          className="mb-1 h-10 w-full rounded object-cover"
-                        />
-                      ) : null}
-                      {opt.label}
-                    </button>
-                  ))}
-                </div>
-
-                <div className="mb-2 text-[11px] uppercase tracking-[0.2em] text-white/70">
                   Tables
                 </div>
                 <div className="mb-3 grid max-h-40 grid-cols-2 gap-2 overflow-auto">
@@ -2971,6 +3051,88 @@ export default function CheckersBattleRoyal() {
                     </button>
                   ))}
                 </div>
+                <div className="mb-2 text-[11px] uppercase tracking-[0.2em] text-white/70">
+                  Table Shape
+                </div>
+                <div className="mb-3 grid max-h-40 grid-cols-2 gap-2 overflow-auto">
+                  {unlockedTableShapes.map((opt) => (
+                    <button
+                      key={opt.id}
+                      onClick={() =>
+                        setAppearance((prev) => ({
+                          ...prev,
+                          tableShape: opt.id
+                        }))
+                      }
+                      className={`rounded-xl border px-2 py-2 text-[11px] ${appearance.tableShape === opt.id ? 'border-cyan-300 bg-cyan-500/20 text-cyan-100' : 'border-white/15 bg-white/5 text-white/70'}`}
+                    >
+                      {opt.thumbnail ? (
+                        <img
+                          src={opt.thumbnail}
+                          alt={`${opt.label} thumbnail`}
+                          className="mb-1 h-10 w-full rounded object-cover"
+                        />
+                      ) : null}
+                      {opt.label}
+                    </button>
+                  ))}
+                </div>
+                {supportsSurfaceCustomization ? (
+                  <>
+                    <div className="mb-2 text-[11px] uppercase tracking-[0.2em] text-white/70">
+                      Table Finish
+                    </div>
+                    <div className="mb-3 grid max-h-40 grid-cols-2 gap-2 overflow-auto">
+                      {unlockedTableFinishes.map((opt) => (
+                        <button
+                          key={opt.id}
+                          onClick={() =>
+                            setAppearance((prev) => ({
+                              ...prev,
+                              tableFinish: opt.id
+                            }))
+                          }
+                          className={`rounded-xl border px-2 py-2 text-[11px] ${appearance.tableFinish === opt.id ? 'border-cyan-300 bg-cyan-500/20 text-cyan-100' : 'border-white/15 bg-white/5 text-white/70'}`}
+                        >
+                          {opt.thumbnail ? (
+                            <img
+                              src={opt.thumbnail}
+                              alt={`${opt.label} thumbnail`}
+                              className="mb-1 h-10 w-full rounded object-cover"
+                            />
+                          ) : null}
+                          {opt.label}
+                        </button>
+                      ))}
+                    </div>
+                    <div className="mb-2 text-[11px] uppercase tracking-[0.2em] text-white/70">
+                      Table Cloth
+                    </div>
+                    <div className="mb-3 grid max-h-40 grid-cols-2 gap-2 overflow-auto">
+                      {unlockedTableCloths.map((opt) => (
+                        <button
+                          key={opt.id}
+                          onClick={() =>
+                            setAppearance((prev) => ({
+                              ...prev,
+                              tableCloth: opt.id
+                            }))
+                          }
+                          className={`rounded-xl border px-2 py-2 text-[11px] ${appearance.tableCloth === opt.id ? 'border-cyan-300 bg-cyan-500/20 text-cyan-100' : 'border-white/15 bg-white/5 text-white/70'}`}
+                        >
+                          {opt.thumbnail ? (
+                            <img
+                              src={opt.thumbnail}
+                              alt={`${opt.label} thumbnail`}
+                              className="mb-1 h-10 w-full rounded object-cover"
+                            />
+                          ) : null}
+                          {opt.label}
+                        </button>
+                      ))}
+                    </div>
+                  </>
+                ) : null}
 
                 <div className="mb-2 text-[11px] uppercase tracking-[0.2em] text-white/70">
                   Board

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -179,6 +179,8 @@ const AIR_HOCKEY_TYPE_LABELS = {
 const CHESS_TYPE_LABELS = {
   tables: 'Table Models',
   tableFinish: 'Table Finish',
+  tableCloth: 'Table Cloth',
+  tableShape: 'Table Shape',
   chairColor: 'Chairs',
   sideColor: 'Piece Colors',
   boardTheme: 'Board Themes',

--- a/webapp/src/utils/murlanTable.js
+++ b/webapp/src/utils/murlanTable.js
@@ -355,6 +355,22 @@ export const TABLE_SHAPE_OPTIONS = Object.freeze([
       const rimInnerShape = createRoundedRectangleShape(innerWidth, innerHeight, 0.1 * factor);
       return { topShape, feltShape, rimInnerShape, feltRadius: Math.max(feltWidth, feltHeight) * 0.5 };
     }
+  },
+  {
+    id: 'royalHexagon',
+    label: 'Hexagon Royale',
+    preview: {
+      clipPath:
+        'polygon(50% 0%, 87% 25%, 87% 75%, 50% 100%, 13% 75%, 13% 25%)'
+    },
+    thumbnail: swatchThumbnail(['#0f172a', '#1e293b', '#22d3ee']),
+    createShapes: ({ radius }) => {
+      const widthScale = 1.1;
+      const topShape = scaleShape2D(createRegularPolygonShape(6, radius), widthScale, 1);
+      const feltShape = scaleShape2D(createRegularPolygonShape(6, radius * 0.8), widthScale, 1);
+      const rimInnerShape = scaleShape2D(feltShape, 0.96, 0.96);
+      return { topShape, feltShape, rimInnerShape };
+    }
   }
 ]);
 


### PR DESCRIPTION
### Motivation
- Surface customization for battle-royale tables must allow selecting cloths and finishes and support new silhouettes (oval, diamond-edge, hexagon). 
- Chairs and pieces need visual alignment on portrait/mobile: chairs slightly larger and visually lower, and pieces positioned a bit lower on the board. 
- Users must be able to purchase table cloths (shared with Texas Hold’em) and choose table shapes in the in-game customization UI. 
- Table cloth/finish controls should only be shown for supported procedural table models. 

### Description
- Added a new procedural table shape `royalHexagon` to `webapp/src/utils/murlanTable.js` and created helpers for hexagon shapes. 
- Added new Murlan table themes (`ovalTable`, `diamondEdge`, `hexagonTable`) to `webapp/src/config/murlanThemes.js` so these table models are available across inventory flows. 
- Extended inventory & store for chess/checkers in `webapp/src/config/chessBattleInventoryConfig.js` with `tableCloth` and `tableShape` support (labels, default unlocks, store items, and default loadout entries). 
- Updated `CheckersBattleRoyal` (`webapp/src/pages/Games/CheckersBattleRoyal.jsx`) to: increase chair scale and lower grounding (`CHAIR_VISUAL_SCALE`, `CHAIR_GROUND_SINK`), lower piece Y placement (`PIECE_Y_OFFSET`), import/use `TABLE_CLOTH_OPTIONS` and `TABLE_SHAPE_OPTIONS`, resolve the effective shape via `resolveShapeForTable`, pass `shapeOption` and `clothOption` into `createMurlanStyleTable`, apply finish+cloth materials to `table.materials`, rebuild the procedural table when the selected shape changes, and add UI controls for Table Shape and Table Cloth while showing Table Finish/Table Cloth only for supported models (controlled via `TABLES_WITH_CLOTH_AND_FINISH`). 
- Added `tableCloth`/`tableShape` labels to store UI (`webapp/src/pages/Store.jsx`). 

### Testing
- Ran `npm test -- test/texasHoldemInventoryConfig.test.js --runInBand` and it passed. 
- Ran `npm test -- test/texasHoldemInventoryConfig.test.js test/inventoryCrossGameConfig.test.js --runInBand` and it failed due to an existing/default mismatch in `inventoryCrossGameConfig` (environment-specific default stool/table expectation), unrelated to the new table/cloth wiring.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2553ba0548329bc858238c8d7057d)