### PR TITLE
Adjust Pool Royale LT finishes, trim table base, add LT colors, and tweak in‑hand icon

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -527,8 +527,12 @@ const TABLE_FINISH_THUMBNAILS = Object.freeze({
   carbonFiberChalk: swatchThumbnail(['#0c0f14', '#171b22', '#303844']),
   carbonFiberChalkGrey: swatchThumbnail(['#5f6774', '#7f8794', '#c5cdd9']),
   carbonFiberChalkBeige: swatchThumbnail(['#2b313a', '#414854', '#646d7a']),
-  carbonFiberChalkDarkBlue: swatchThumbnail(['#5d1a2a', '#7f2a3d', '#a34860']),
-  carbonFiberChalkWhite: swatchThumbnail(['#ebddc9', '#f8efe1', '#fff9ee'])
+  carbonFiberChalkDarkBlue: swatchThumbnail(['#6f3a2f', '#8d5546', '#b27a67']),
+  carbonFiberChalkWhite: swatchThumbnail(['#d8c8af', '#ece0cd', '#f7efdf']),
+  carbonFiberChalkDarkGreen: swatchThumbnail(['#1f3e33', '#2f5a4a', '#4c7a66']),
+  carbonFiberChalkDarkYellow: swatchThumbnail(['#6a5418', '#8f7426', '#b59a4a']),
+  carbonFiberChalkDarkBrown: swatchThumbnail(['#4a2f23', '#684235', '#8a5d4c']),
+  carbonFiberChalkDarkRed: swatchThumbnail(['#5a1f24', '#7c3037', '#a14a53'])
 });
 
 const POCKET_LINER_THUMBNAILS = Object.freeze({
@@ -631,7 +635,11 @@ export const POOL_ROYALE_OPTION_LABELS = Object.freeze({
     carbonFiberChalkGrey: 'LT Grey',
     carbonFiberChalkBeige: 'LT Dark Grey',
     carbonFiberChalkDarkBlue: 'LT Burgundy',
-    carbonFiberChalkWhite: 'LT Milk Cream'
+    carbonFiberChalkWhite: 'LT Milk Cream',
+    carbonFiberChalkDarkGreen: 'LT Dark Green',
+    carbonFiberChalkDarkYellow: 'LT Dark Yellow',
+    carbonFiberChalkDarkBrown: 'LT Dark Brown',
+    carbonFiberChalkDarkRed: 'LT Dark Red'
   }),
   chromeColor: Object.freeze({
     chrome: 'Chrome',
@@ -763,6 +771,42 @@ export const POOL_ROYALE_STORE_ITEMS = [
     price: 1200,
     description: 'Milk-cream LT carbon-fiber weave finish with soft bright tones.',
     thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberChalkWhite
+  },
+  {
+    id: 'finish-carbonFiberChalkDarkGreen',
+    type: 'tableFinish',
+    optionId: 'carbonFiberChalkDarkGreen',
+    name: 'LT Dark Green Finish',
+    price: 1210,
+    description: 'Dark-green LT molded finish with deep forest undertones.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberChalkDarkGreen
+  },
+  {
+    id: 'finish-carbonFiberChalkDarkYellow',
+    type: 'tableFinish',
+    optionId: 'carbonFiberChalkDarkYellow',
+    name: 'LT Dark Yellow Finish',
+    price: 1220,
+    description: 'Dark-yellow LT molded finish with warm golden depth.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberChalkDarkYellow
+  },
+  {
+    id: 'finish-carbonFiberChalkDarkBrown',
+    type: 'tableFinish',
+    optionId: 'carbonFiberChalkDarkBrown',
+    name: 'LT Dark Brown Finish',
+    price: 1230,
+    description: 'Dark-brown LT molded finish with cocoa-toned satin sheen.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberChalkDarkBrown
+  },
+  {
+    id: 'finish-carbonFiberChalkDarkRed',
+    type: 'tableFinish',
+    optionId: 'carbonFiberChalkDarkRed',
+    name: 'LT Dark Red Finish',
+    price: 1240,
+    description: 'Dark-red LT molded finish with rich ruby undertones.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberChalkDarkRed
   },
   {
     id: 'chrome-chrome',

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1863,7 +1863,7 @@ const LEG_RADIUS_SCALE = 1.2; // 20% thicker cylindrical legs
 const BASE_LEG_LENGTH_SCALE = 0.72; // previous leg extension factor used for baseline stance
 const LEG_ELEVATION_SCALE = 0.96; // shorten the current leg extension to lower the playfield
 const LEG_LENGTH_SHRINK = 0.867; // lengthen legs to extend the base downward with the taller table stance
-const BASE_HEIGHT_REDUCTION = 0.74; // trim table bases a bit more from the bottom so the full table sits lower on screen
+const BASE_HEIGHT_REDUCTION = 0.7; // trim table bases a touch more from the bottom while preserving framing
 const LEG_LENGTH_SCALE =
   BASE_LEG_LENGTH_SCALE * LEG_ELEVATION_SCALE * LEG_LENGTH_SHRINK * BASE_HEIGHT_REDUCTION;
 const LEG_HEIGHT_OFFSET = FRAME_TOP_Y - 0.3; // relationship between leg room and visible leg height
@@ -3257,9 +3257,9 @@ const TABLE_FINISHES = Object.freeze({
   carbonFiberChalk: createStandardWoodFinish({
     id: 'carbonFiberChalk',
     label: 'LT Black',
-    rail: 0x0c0f14,
-    base: 0x0c0f14,
-    trim: 0x0c0f14,
+    rail: 0x171b23,
+    base: 0x171b23,
+    trim: 0x171b23,
     woodTextureId: 'plastic_monoblock_lt_black',
     woodRepeatScale: 1,
     disableWoodPattern: true,
@@ -3269,9 +3269,9 @@ const TABLE_FINISHES = Object.freeze({
   carbonFiberChalkGrey: createStandardWoodFinish({
     id: 'carbonFiberChalkGrey',
     label: 'LT Grey',
-    rail: 0x6f7681,
-    base: 0x6f7681,
-    trim: 0x6f7681,
+    rail: 0x6c7482,
+    base: 0x6c7482,
+    trim: 0x6c7482,
     woodTextureId: 'plastic_monoblock_lt_grey',
     woodRepeatScale: 1,
     disableWoodPattern: true,
@@ -3281,9 +3281,9 @@ const TABLE_FINISHES = Object.freeze({
   carbonFiberChalkBeige: createStandardWoodFinish({
     id: 'carbonFiberChalkBeige',
     label: 'LT Dark Grey',
-    rail: 0x2f353e,
-    base: 0x2f353e,
-    trim: 0x2f353e,
+    rail: 0x3b424d,
+    base: 0x3b424d,
+    trim: 0x3b424d,
     woodTextureId: 'plastic_monoblock_lt_dark_grey',
     woodRepeatScale: 1,
     disableWoodPattern: true,
@@ -3293,9 +3293,9 @@ const TABLE_FINISHES = Object.freeze({
   carbonFiberChalkDarkBlue: createStandardWoodFinish({
     id: 'carbonFiberChalkDarkBlue',
     label: 'LT Burgundy',
-    rail: 0x652335,
-    base: 0x652335,
-    trim: 0x652335,
+    rail: 0x6f3a2f,
+    base: 0x6f3a2f,
+    trim: 0x6f3a2f,
     woodTextureId: 'plastic_monoblock_lt_burgundy',
     woodRepeatScale: 1,
     disableWoodPattern: true,
@@ -3305,10 +3305,58 @@ const TABLE_FINISHES = Object.freeze({
   carbonFiberChalkWhite: createStandardWoodFinish({
     id: 'carbonFiberChalkWhite',
     label: 'LT Milk Cream',
-    rail: 0xefe2cf,
-    base: 0xefe2cf,
-    trim: 0xefe2cf,
+    rail: 0xd8c8af,
+    base: 0xd8c8af,
+    trim: 0xd8c8af,
     woodTextureId: 'plastic_monoblock_lt_milk_cream',
+    woodRepeatScale: 1,
+    disableWoodPattern: true,
+    surfaceStyle: 'matte',
+    useBrandCarbonTexture: false
+  }),
+  carbonFiberChalkDarkGreen: createStandardWoodFinish({
+    id: 'carbonFiberChalkDarkGreen',
+    label: 'LT Dark Green',
+    rail: 0x1f3e33,
+    base: 0x1f3e33,
+    trim: 0x1f3e33,
+    woodTextureId: 'plastic_monoblock_lt_dark_green',
+    woodRepeatScale: 1,
+    disableWoodPattern: true,
+    surfaceStyle: 'matte',
+    useBrandCarbonTexture: false
+  }),
+  carbonFiberChalkDarkYellow: createStandardWoodFinish({
+    id: 'carbonFiberChalkDarkYellow',
+    label: 'LT Dark Yellow',
+    rail: 0x6a5418,
+    base: 0x6a5418,
+    trim: 0x6a5418,
+    woodTextureId: 'plastic_monoblock_lt_dark_yellow',
+    woodRepeatScale: 1,
+    disableWoodPattern: true,
+    surfaceStyle: 'matte',
+    useBrandCarbonTexture: false
+  }),
+  carbonFiberChalkDarkBrown: createStandardWoodFinish({
+    id: 'carbonFiberChalkDarkBrown',
+    label: 'LT Dark Brown',
+    rail: 0x4a2f23,
+    base: 0x4a2f23,
+    trim: 0x4a2f23,
+    woodTextureId: 'plastic_monoblock_lt_dark_brown',
+    woodRepeatScale: 1,
+    disableWoodPattern: true,
+    surfaceStyle: 'matte',
+    useBrandCarbonTexture: false
+  }),
+  carbonFiberChalkDarkRed: createStandardWoodFinish({
+    id: 'carbonFiberChalkDarkRed',
+    label: 'LT Dark Red',
+    rail: 0x5a1f24,
+    base: 0x5a1f24,
+    trim: 0x5a1f24,
+    woodTextureId: 'plastic_monoblock_lt_dark_red',
     woodRepeatScale: 1,
     disableWoodPattern: true,
     surfaceStyle: 'matte',
@@ -3327,7 +3375,11 @@ const TABLE_FINISH_OPTIONS = Object.freeze(
     TABLE_FINISHES.carbonFiberChalkGrey,
     TABLE_FINISHES.carbonFiberChalkBeige,
     TABLE_FINISHES.carbonFiberChalkDarkBlue,
-    TABLE_FINISHES.carbonFiberChalkWhite
+    TABLE_FINISHES.carbonFiberChalkWhite,
+    TABLE_FINISHES.carbonFiberChalkDarkGreen,
+    TABLE_FINISHES.carbonFiberChalkDarkYellow,
+    TABLE_FINISHES.carbonFiberChalkDarkBrown,
+    TABLE_FINISHES.carbonFiberChalkDarkRed
   ].filter(Boolean)
 );
 
@@ -23635,11 +23687,15 @@ const powerRef = useRef(hud.power);
       };
       const layoutDecorativeTables = (environmentId = environmentHdriRef.current) => {
         disposeDecorativeTables();
+        const decorDisabledEnvironments = new Set([
+          'dancingHall',
+          'abandonedHall',
+          'abandoned_hall_01',
+          'oldHall',
+          'musicHall02'
+        ]);
         if (
-          environmentId === 'dancingHall' ||
-          environmentId === 'abandonedHall' ||
-          environmentId === 'oldHall' ||
-          environmentId === 'musicHall02'
+          decorDisabledEnvironments.has(environmentId)
         ) {
           return;
         }
@@ -31341,8 +31397,8 @@ const powerRef = useRef(hud.power);
                 (TMP_VEC3_IN_HAND_ICON.x * 0.5 + 0.5) * rect.width + rect.left;
               const screenY =
                 (-TMP_VEC3_IN_HAND_ICON.y * 0.5 + 0.5) * rect.height + rect.top;
-              const offsetX = 0;
-              const offsetY = 0;
+              const offsetX = 26;
+              const offsetY = -20;
               const clampedX = clamp(
                 screenX + offsetX,
                 rect.left + 16,
@@ -34077,7 +34133,7 @@ const powerRef = useRef(hud.power);
           onPointerMove={handleInHandIconPointerMove}
           onPointerUp={handleInHandIconPointerUp}
           onPointerCancel={handleInHandIconPointerUp}
-          className={`fixed z-40 flex h-10 w-10 items-center justify-center rounded-full border border-white/70 bg-emerald-500/90 text-xl text-white shadow-[0_12px_24px_rgba(0,0,0,0.45)] backdrop-blur transition relative ${
+          className={`fixed z-40 flex h-8 w-8 items-center justify-center rounded-full border border-white/70 bg-emerald-500/90 text-base text-white shadow-[0_12px_24px_rgba(0,0,0,0.45)] backdrop-blur transition relative ${
             canDragInHandIcon ? '' : 'opacity-70'
           }`}
           style={{ opacity: 0, pointerEvents: 'none', transform: 'translate(-9999px, -9999px)' }}

--- a/webapp/src/utils/woodMaterials.js
+++ b/webapp/src/utils/woodMaterials.js
@@ -737,8 +737,8 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
       textureSize: 2048,
       ...makeInlinePlasticMonoblockPattern({
         id: 'plastic-monoblock-lt-black-rail',
-        base: '#0b0d10',
-        sheen: '#1a1f28'
+        base: '#161b23',
+        sheen: '#2b3340'
       })
     },
     frame: {
@@ -747,8 +747,8 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
       textureSize: 2048,
       ...makeInlinePlasticMonoblockPattern({
         id: 'plastic-monoblock-lt-black-frame',
-        base: '#0b0d10',
-        sheen: '#1a1f28'
+        base: '#161b23',
+        sheen: '#2b3340'
       })
     }
   }),
@@ -762,8 +762,8 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
       textureSize: 2048,
       ...makeInlinePlasticMonoblockPattern({
         id: 'plastic-monoblock-lt-grey-rail',
-        base: '#585f6b',
-        sheen: '#7b8391'
+        base: '#6c7482',
+        sheen: '#949dac'
       })
     },
     frame: {
@@ -772,8 +772,8 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
       textureSize: 2048,
       ...makeInlinePlasticMonoblockPattern({
         id: 'plastic-monoblock-lt-grey-frame',
-        base: '#585f6b',
-        sheen: '#7b8391'
+        base: '#6c7482',
+        sheen: '#949dac'
       })
     }
   }),
@@ -787,8 +787,8 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
       textureSize: 2048,
       ...makeInlinePlasticMonoblockPattern({
         id: 'plastic-monoblock-lt-dark-grey-rail',
-        base: '#2d323b',
-        sheen: '#434a56'
+        base: '#3b424d',
+        sheen: '#56606e'
       })
     },
     frame: {
@@ -797,8 +797,8 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
       textureSize: 2048,
       ...makeInlinePlasticMonoblockPattern({
         id: 'plastic-monoblock-lt-dark-grey-frame',
-        base: '#2d323b',
-        sheen: '#434a56'
+        base: '#3b424d',
+        sheen: '#56606e'
       })
     }
   }),
@@ -812,8 +812,8 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
       textureSize: 2048,
       ...makeInlinePlasticMonoblockPattern({
         id: 'plastic-monoblock-lt-burgundy-rail',
-        base: '#5f1d2c',
-        sheen: '#7f2e43'
+        base: '#6f3a2f',
+        sheen: '#8d5546'
       })
     },
     frame: {
@@ -822,8 +822,8 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
       textureSize: 2048,
       ...makeInlinePlasticMonoblockPattern({
         id: 'plastic-monoblock-lt-burgundy-frame',
-        base: '#5f1d2c',
-        sheen: '#7f2e43'
+        base: '#6f3a2f',
+        sheen: '#8d5546'
       })
     }
   }),
@@ -837,8 +837,8 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
       textureSize: 2048,
       ...makeInlinePlasticMonoblockPattern({
         id: 'plastic-monoblock-lt-milk-cream-rail',
-        base: '#e9dcc9',
-        sheen: '#f8efe1'
+        base: '#d8c8af',
+        sheen: '#ece0cd'
       })
     },
     frame: {
@@ -847,8 +847,108 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
       textureSize: 2048,
       ...makeInlinePlasticMonoblockPattern({
         id: 'plastic-monoblock-lt-milk-cream-frame',
-        base: '#e9dcc9',
-        sheen: '#f8efe1'
+        base: '#d8c8af',
+        sheen: '#ece0cd'
+      })
+    }
+  }),
+  Object.freeze({
+    id: 'plastic_monoblock_lt_dark_green',
+    label: 'LT Dark Green',
+    source: 'TonPlaygram molded-plastic satin texture (LT Dark Green)',
+    rail: {
+      repeat: { x: 7.2, y: 7.2 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlinePlasticMonoblockPattern({
+        id: 'plastic-monoblock-lt-dark-green-rail',
+        base: '#1f3e33',
+        sheen: '#2f5a4a'
+      })
+    },
+    frame: {
+      repeat: { x: 7.2, y: 7.2 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlinePlasticMonoblockPattern({
+        id: 'plastic-monoblock-lt-dark-green-frame',
+        base: '#1f3e33',
+        sheen: '#2f5a4a'
+      })
+    }
+  }),
+  Object.freeze({
+    id: 'plastic_monoblock_lt_dark_yellow',
+    label: 'LT Dark Yellow',
+    source: 'TonPlaygram molded-plastic satin texture (LT Dark Yellow)',
+    rail: {
+      repeat: { x: 7.2, y: 7.2 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlinePlasticMonoblockPattern({
+        id: 'plastic-monoblock-lt-dark-yellow-rail',
+        base: '#6a5418',
+        sheen: '#8f7426'
+      })
+    },
+    frame: {
+      repeat: { x: 7.2, y: 7.2 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlinePlasticMonoblockPattern({
+        id: 'plastic-monoblock-lt-dark-yellow-frame',
+        base: '#6a5418',
+        sheen: '#8f7426'
+      })
+    }
+  }),
+  Object.freeze({
+    id: 'plastic_monoblock_lt_dark_brown',
+    label: 'LT Dark Brown',
+    source: 'TonPlaygram molded-plastic satin texture (LT Dark Brown)',
+    rail: {
+      repeat: { x: 7.2, y: 7.2 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlinePlasticMonoblockPattern({
+        id: 'plastic-monoblock-lt-dark-brown-rail',
+        base: '#4a2f23',
+        sheen: '#684235'
+      })
+    },
+    frame: {
+      repeat: { x: 7.2, y: 7.2 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlinePlasticMonoblockPattern({
+        id: 'plastic-monoblock-lt-dark-brown-frame',
+        base: '#4a2f23',
+        sheen: '#684235'
+      })
+    }
+  }),
+  Object.freeze({
+    id: 'plastic_monoblock_lt_dark_red',
+    label: 'LT Dark Red',
+    source: 'TonPlaygram molded-plastic satin texture (LT Dark Red)',
+    rail: {
+      repeat: { x: 7.2, y: 7.2 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlinePlasticMonoblockPattern({
+        id: 'plastic-monoblock-lt-dark-red-rail',
+        base: '#5a1f24',
+        sheen: '#7c3037'
+      })
+    },
+    frame: {
+      repeat: { x: 7.2, y: 7.2 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlinePlasticMonoblockPattern({
+        id: 'plastic-monoblock-lt-dark-red-frame',
+        base: '#5a1f24',
+        sheen: '#7c3037'
       })
     }
   }),


### PR DESCRIPTION
### Motivation
- Bring LT (molded/plastic) table finishes into correct visual range (burgundy was near-black; blacks/greys should be brighter; milk-cream darker) and add requested dark LT color variants. 
- Slightly shorten/trim table bases so the playfield sits lower on screen while keeping camera framing stable. 
- Remove decorative secondary/snooker tables from the abandoned-hall HDRI so only the main playing table remains. 
- Make the ball-in-hand UI less obtrusive by shrinking and offsetting the hand icon so it doesn’t cover the cue ball.

### Description
- Tuned LT finish color values and textures in `webapp/src/utils/woodMaterials.js` (adjusted black/grey/burgundy/milk-cream hexes and added new `plastic_monoblock_lt_*` texture entries for dark green, dark yellow, dark brown and dark red).
- Exposed the new LT finishes in the Pool Royale finish set by updating `webapp/src/pages/Games/PoolRoyale.jsx` (added `carbonFiberChalkDarkGreen`, `carbonFiberChalkDarkYellow`, `carbonFiberChalkDarkBrown`, `carbonFiberChalkDarkRed`, and adjusted `BASE_HEIGHT_REDUCTION` to shorten the table base/legs slightly).
- Updated inventory/store metadata in `webapp/src/config/poolRoyaleInventoryConfig.js` to add thumbnails, swatches, labels and purchasable `finish-...` store items for the new LT finishes and to reflect the adjusted swatches for corrected variants.
- Kept existing texture/workflow (same molded/plastic patterns) and added matching material ids so visuals reuse the same pipeline.
- Disabled decorative/secondary tables in environments where they should be suppressed by making `layoutDecorativeTables` skip a set that includes the abandoned-hall variants (keeps only the main playing table for that HDRI).
- Reduced the ball-in-hand icon size and moved its screen offset so it sits away from the cueball (changes in `webapp/src/pages/Games/PoolRoyale.jsx`: size from `h-10 w-10` → `h-8 w-8` and offset from `0,0` → `26,-20`).

### Testing
- Ran `node --check webapp/src/config/poolRoyaleInventoryConfig.js` and `node --check webapp/src/utils/woodMaterials.js`; both checks completed successfully.
- Built the web client with `npm --prefix webapp run -s build`; build completed successfully (Vite produced standard chunk-size warnings unrelated to these changes).
- Ran ESLint during the rollout and resolved reported issues; final `build` completed without blocking errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d265c35bc0832994e0d073d4b4901a)