### PR TITLE
Pool Royale: LT finish color fixes, added LT finishes, shorter table stance, and in‑hand icon polish

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -524,11 +524,15 @@ const TABLE_FINISH_THUMBNAILS = Object.freeze({
   woodTable001: polyHavenThumb('wood_table_001'),
   darkWood: polyHavenThumb('dark_wood'),
   rosewoodVeneer01: polyHavenThumb('rosewood_veneer_01'),
-  carbonFiberChalk: swatchThumbnail(['#0c0f14', '#171b22', '#303844']),
-  carbonFiberChalkGrey: swatchThumbnail(['#5f6774', '#7f8794', '#c5cdd9']),
-  carbonFiberChalkBeige: swatchThumbnail(['#2b313a', '#414854', '#646d7a']),
-  carbonFiberChalkDarkBlue: swatchThumbnail(['#5d1a2a', '#7f2a3d', '#a34860']),
-  carbonFiberChalkWhite: swatchThumbnail(['#ebddc9', '#f8efe1', '#fff9ee'])
+  carbonFiberChalk: swatchThumbnail(['#1a2028', '#313946', '#4a5667']),
+  carbonFiberChalkGrey: swatchThumbnail(['#676f7c', '#8e97a6', '#c5cdd9']),
+  carbonFiberChalkBeige: swatchThumbnail(['#39414b', '#505a67', '#727d8b']),
+  carbonFiberChalkDarkBlue: swatchThumbnail(['#5b2f26', '#7c4a3b', '#9a6453']),
+  carbonFiberChalkWhite: swatchThumbnail(['#d2c2ac', '#e5d5c1', '#f2e8da']),
+  carbonFiberChalkDarkGreen: swatchThumbnail(['#2b4533', '#3d6148', '#5b8769']),
+  carbonFiberChalkDarkYellow: swatchThumbnail(['#876426', '#a27b33', '#c19947']),
+  carbonFiberChalkDarkBrown: swatchThumbnail(['#5a3a2a', '#734a37', '#8f614a']),
+  carbonFiberChalkDarkRed: swatchThumbnail(['#6a2323', '#8a3434', '#a74a4a'])
 });
 
 const POCKET_LINER_THUMBNAILS = Object.freeze({
@@ -631,7 +635,11 @@ export const POOL_ROYALE_OPTION_LABELS = Object.freeze({
     carbonFiberChalkGrey: 'LT Grey',
     carbonFiberChalkBeige: 'LT Dark Grey',
     carbonFiberChalkDarkBlue: 'LT Burgundy',
-    carbonFiberChalkWhite: 'LT Milk Cream'
+    carbonFiberChalkWhite: 'LT Milk Cream',
+    carbonFiberChalkDarkGreen: 'LT Dark Green',
+    carbonFiberChalkDarkYellow: 'LT Dark Yellow',
+    carbonFiberChalkDarkBrown: 'LT Dark Brown',
+    carbonFiberChalkDarkRed: 'LT Dark Red'
   }),
   chromeColor: Object.freeze({
     chrome: 'Chrome',
@@ -725,7 +733,7 @@ export const POOL_ROYALE_STORE_ITEMS = [
     optionId: 'carbonFiberChalk',
     name: 'LT Black Finish',
     price: 1160,
-    description: 'Black LT carbon-fiber weave finish with deep matte highlights.',
+    description: 'Black LT carbon-fiber weave finish with a brighter charcoal tone.',
     thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberChalk
   },
   {
@@ -734,7 +742,7 @@ export const POOL_ROYALE_STORE_ITEMS = [
     optionId: 'carbonFiberChalkGrey',
     name: 'LT Grey Finish',
     price: 1170,
-    description: 'Grey LT carbon-fiber weave finish with neutral satin contrast.',
+    description: 'Grey LT carbon-fiber weave finish tuned a touch brighter for clarity.',
     thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberChalkGrey
   },
   {
@@ -743,7 +751,7 @@ export const POOL_ROYALE_STORE_ITEMS = [
     optionId: 'carbonFiberChalkBeige',
     name: 'LT Dark Grey Finish',
     price: 1180,
-    description: 'Dark-grey LT carbon-fiber weave finish with stronger depth.',
+    description: 'Dark-grey LT carbon-fiber weave finish with a slightly brighter lift.',
     thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberChalkBeige
   },
   {
@@ -752,7 +760,7 @@ export const POOL_ROYALE_STORE_ITEMS = [
     optionId: 'carbonFiberChalkDarkBlue',
     name: 'LT Burgundy Finish',
     price: 1190,
-    description: 'Burgundy LT carbon-fiber weave finish with rich warm accents.',
+    description: 'Burgundy LT finish shifted to rosewood-brown warmth.',
     thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberChalkDarkBlue
   },
   {
@@ -761,8 +769,44 @@ export const POOL_ROYALE_STORE_ITEMS = [
     optionId: 'carbonFiberChalkWhite',
     name: 'LT Milk Cream Finish',
     price: 1200,
-    description: 'Milk-cream LT carbon-fiber weave finish with soft bright tones.',
+    description: 'Milk-cream LT carbon-fiber weave finish with a deeper cream tone.',
     thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberChalkWhite
+  },
+  {
+    id: 'finish-carbonFiberChalkDarkGreen',
+    type: 'tableFinish',
+    optionId: 'carbonFiberChalkDarkGreen',
+    name: 'LT Dark Green Finish',
+    price: 1210,
+    description: 'Dark-green LT carbon-fiber weave finish with rich forest depth.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberChalkDarkGreen
+  },
+  {
+    id: 'finish-carbonFiberChalkDarkYellow',
+    type: 'tableFinish',
+    optionId: 'carbonFiberChalkDarkYellow',
+    name: 'LT Dark Yellow Finish',
+    price: 1220,
+    description: 'Dark-yellow LT carbon-fiber weave finish with mustard-gold warmth.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberChalkDarkYellow
+  },
+  {
+    id: 'finish-carbonFiberChalkDarkBrown',
+    type: 'tableFinish',
+    optionId: 'carbonFiberChalkDarkBrown',
+    name: 'LT Dark Brown Finish',
+    price: 1230,
+    description: 'Dark-brown LT carbon-fiber weave finish with earthy depth.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberChalkDarkBrown
+  },
+  {
+    id: 'finish-carbonFiberChalkDarkRed',
+    type: 'tableFinish',
+    optionId: 'carbonFiberChalkDarkRed',
+    name: 'LT Dark Red Finish',
+    price: 1240,
+    description: 'Dark-red LT carbon-fiber weave finish with deep crimson character.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberChalkDarkRed
   },
   {
     id: 'chrome-chrome',

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1863,7 +1863,7 @@ const LEG_RADIUS_SCALE = 1.2; // 20% thicker cylindrical legs
 const BASE_LEG_LENGTH_SCALE = 0.72; // previous leg extension factor used for baseline stance
 const LEG_ELEVATION_SCALE = 0.96; // shorten the current leg extension to lower the playfield
 const LEG_LENGTH_SHRINK = 0.867; // lengthen legs to extend the base downward with the taller table stance
-const BASE_HEIGHT_REDUCTION = 0.74; // trim table bases a bit more from the bottom so the full table sits lower on screen
+const BASE_HEIGHT_REDUCTION = 0.69; // trim table bases slightly more from the bottom to shorten the table stance
 const LEG_LENGTH_SCALE =
   BASE_LEG_LENGTH_SCALE * LEG_ELEVATION_SCALE * LEG_LENGTH_SHRINK * BASE_HEIGHT_REDUCTION;
 const LEG_HEIGHT_OFFSET = FRAME_TOP_Y - 0.3; // relationship between leg room and visible leg height
@@ -1889,7 +1889,7 @@ const TABLE_HEIGHT_DROP = (TABLE_H + TABLE.THICK) * 0.2; // lower the full table
 const TABLE_Y = BASE_TABLE_Y + LEG_ELEVATION_DELTA - TABLE_HEIGHT_DROP;
 const LEG_BASE_DROP = LEG_ROOM_HEIGHT * 0.3;
 const FLOOR_Y = TABLE_Y - TABLE.THICK - LEG_ROOM_HEIGHT - LEG_BASE_DROP + 0.3;
-const ORBIT_FOCUS_BASE_Y = TABLE_Y + 0.05;
+const ORBIT_FOCUS_BASE_Y = TABLE_Y + 0.07;
 const CAMERA_CUE_SURFACE_MARGIN = BALL_R * 0.42; // keep orbit height aligned with the cue while leaving a safe buffer above
 const CUE_TIP_CLEARANCE = BALL_R * 0.24; // widen the visible air gap so the cue sits a little farther from the cue ball
 const CUE_TIP_GAP = BALL_R * 1.42 + CUE_TIP_CLEARANCE; // pull the cue tip slightly farther back so the blue tip remains visible
@@ -3257,9 +3257,9 @@ const TABLE_FINISHES = Object.freeze({
   carbonFiberChalk: createStandardWoodFinish({
     id: 'carbonFiberChalk',
     label: 'LT Black',
-    rail: 0x0c0f14,
-    base: 0x0c0f14,
-    trim: 0x0c0f14,
+    rail: 0x1a2028,
+    base: 0x1a2028,
+    trim: 0x1a2028,
     woodTextureId: 'plastic_monoblock_lt_black',
     woodRepeatScale: 1,
     disableWoodPattern: true,
@@ -3269,9 +3269,9 @@ const TABLE_FINISHES = Object.freeze({
   carbonFiberChalkGrey: createStandardWoodFinish({
     id: 'carbonFiberChalkGrey',
     label: 'LT Grey',
-    rail: 0x6f7681,
-    base: 0x6f7681,
-    trim: 0x6f7681,
+    rail: 0x7a8290,
+    base: 0x7a8290,
+    trim: 0x7a8290,
     woodTextureId: 'plastic_monoblock_lt_grey',
     woodRepeatScale: 1,
     disableWoodPattern: true,
@@ -3281,9 +3281,9 @@ const TABLE_FINISHES = Object.freeze({
   carbonFiberChalkBeige: createStandardWoodFinish({
     id: 'carbonFiberChalkBeige',
     label: 'LT Dark Grey',
-    rail: 0x2f353e,
-    base: 0x2f353e,
-    trim: 0x2f353e,
+    rail: 0x3b434d,
+    base: 0x3b434d,
+    trim: 0x3b434d,
     woodTextureId: 'plastic_monoblock_lt_dark_grey',
     woodRepeatScale: 1,
     disableWoodPattern: true,
@@ -3293,9 +3293,9 @@ const TABLE_FINISHES = Object.freeze({
   carbonFiberChalkDarkBlue: createStandardWoodFinish({
     id: 'carbonFiberChalkDarkBlue',
     label: 'LT Burgundy',
-    rail: 0x652335,
-    base: 0x652335,
-    trim: 0x652335,
+    rail: 0x6f3a2f,
+    base: 0x6f3a2f,
+    trim: 0x6f3a2f,
     woodTextureId: 'plastic_monoblock_lt_burgundy',
     woodRepeatScale: 1,
     disableWoodPattern: true,
@@ -3305,10 +3305,58 @@ const TABLE_FINISHES = Object.freeze({
   carbonFiberChalkWhite: createStandardWoodFinish({
     id: 'carbonFiberChalkWhite',
     label: 'LT Milk Cream',
-    rail: 0xefe2cf,
-    base: 0xefe2cf,
-    trim: 0xefe2cf,
+    rail: 0xd2c2ac,
+    base: 0xd2c2ac,
+    trim: 0xd2c2ac,
     woodTextureId: 'plastic_monoblock_lt_milk_cream',
+    woodRepeatScale: 1,
+    disableWoodPattern: true,
+    surfaceStyle: 'matte',
+    useBrandCarbonTexture: false
+  }),
+  carbonFiberChalkDarkGreen: createStandardWoodFinish({
+    id: 'carbonFiberChalkDarkGreen',
+    label: 'LT Dark Green',
+    rail: 0x2b4533,
+    base: 0x2b4533,
+    trim: 0x2b4533,
+    woodTextureId: 'plastic_monoblock_lt_dark_green',
+    woodRepeatScale: 1,
+    disableWoodPattern: true,
+    surfaceStyle: 'matte',
+    useBrandCarbonTexture: false
+  }),
+  carbonFiberChalkDarkYellow: createStandardWoodFinish({
+    id: 'carbonFiberChalkDarkYellow',
+    label: 'LT Dark Yellow',
+    rail: 0x876426,
+    base: 0x876426,
+    trim: 0x876426,
+    woodTextureId: 'plastic_monoblock_lt_dark_yellow',
+    woodRepeatScale: 1,
+    disableWoodPattern: true,
+    surfaceStyle: 'matte',
+    useBrandCarbonTexture: false
+  }),
+  carbonFiberChalkDarkBrown: createStandardWoodFinish({
+    id: 'carbonFiberChalkDarkBrown',
+    label: 'LT Dark Brown',
+    rail: 0x5a3a2a,
+    base: 0x5a3a2a,
+    trim: 0x5a3a2a,
+    woodTextureId: 'plastic_monoblock_lt_dark_brown',
+    woodRepeatScale: 1,
+    disableWoodPattern: true,
+    surfaceStyle: 'matte',
+    useBrandCarbonTexture: false
+  }),
+  carbonFiberChalkDarkRed: createStandardWoodFinish({
+    id: 'carbonFiberChalkDarkRed',
+    label: 'LT Dark Red',
+    rail: 0x6a2323,
+    base: 0x6a2323,
+    trim: 0x6a2323,
+    woodTextureId: 'plastic_monoblock_lt_dark_red',
     woodRepeatScale: 1,
     disableWoodPattern: true,
     surfaceStyle: 'matte',
@@ -3327,7 +3375,11 @@ const TABLE_FINISH_OPTIONS = Object.freeze(
     TABLE_FINISHES.carbonFiberChalkGrey,
     TABLE_FINISHES.carbonFiberChalkBeige,
     TABLE_FINISHES.carbonFiberChalkDarkBlue,
-    TABLE_FINISHES.carbonFiberChalkWhite
+    TABLE_FINISHES.carbonFiberChalkWhite,
+    TABLE_FINISHES.carbonFiberChalkDarkGreen,
+    TABLE_FINISHES.carbonFiberChalkDarkYellow,
+    TABLE_FINISHES.carbonFiberChalkDarkBrown,
+    TABLE_FINISHES.carbonFiberChalkDarkRed
   ].filter(Boolean)
 );
 
@@ -23554,6 +23606,9 @@ const powerRef = useRef(hud.power);
       const buildSecondaryDecor = () => buildDecorGroup({ table: secondaryTableRef.current, variant: 'pool' });
       const refreshSecondaryDecor = () => {
         disposeSecondaryDecor();
+        if (environmentHdriRef.current === 'abandonedHall') {
+          return;
+        }
       };
       refreshSecondaryTableDecorRef.current = refreshSecondaryDecor;
       clearSecondaryTableDecorRef.current = disposeSecondaryDecor;
@@ -31341,8 +31396,8 @@ const powerRef = useRef(hud.power);
                 (TMP_VEC3_IN_HAND_ICON.x * 0.5 + 0.5) * rect.width + rect.left;
               const screenY =
                 (-TMP_VEC3_IN_HAND_ICON.y * 0.5 + 0.5) * rect.height + rect.top;
-              const offsetX = 0;
-              const offsetY = 0;
+              const offsetX = 28;
+              const offsetY = -22;
               const clampedX = clamp(
                 screenX + offsetX,
                 rect.left + 16,
@@ -34077,53 +34132,53 @@ const powerRef = useRef(hud.power);
           onPointerMove={handleInHandIconPointerMove}
           onPointerUp={handleInHandIconPointerUp}
           onPointerCancel={handleInHandIconPointerUp}
-          className={`fixed z-40 flex h-10 w-10 items-center justify-center rounded-full border border-white/70 bg-emerald-500/90 text-xl text-white shadow-[0_12px_24px_rgba(0,0,0,0.45)] backdrop-blur transition relative ${
+          className={`fixed z-40 flex h-8 w-8 items-center justify-center rounded-full border border-white/70 bg-emerald-500/90 text-base text-white shadow-[0_12px_24px_rgba(0,0,0,0.45)] backdrop-blur transition relative ${
             canDragInHandIcon ? '' : 'opacity-70'
           }`}
           style={{ opacity: 0, pointerEvents: 'none', transform: 'translate(-9999px, -9999px)' }}
         >
           <span
             aria-hidden="true"
-            className="pointer-events-none absolute -top-3 left-1/2 -translate-x-1/2"
+            className="pointer-events-none absolute -top-2.5 left-1/2 -translate-x-1/2"
             style={{
               width: 0,
               height: 0,
-              borderLeft: '6px solid transparent',
-              borderRight: '6px solid transparent',
-              borderBottom: '8px solid rgba(255,255,255,0.85)'
+              borderLeft: '5px solid transparent',
+              borderRight: '5px solid transparent',
+              borderBottom: '7px solid rgba(255,255,255,0.85)'
             }}
           />
           <span
             aria-hidden="true"
-            className="pointer-events-none absolute -bottom-3 left-1/2 -translate-x-1/2"
+            className="pointer-events-none absolute -bottom-2.5 left-1/2 -translate-x-1/2"
             style={{
               width: 0,
               height: 0,
-              borderLeft: '6px solid transparent',
-              borderRight: '6px solid transparent',
-              borderTop: '8px solid rgba(255,255,255,0.85)'
+              borderLeft: '5px solid transparent',
+              borderRight: '5px solid transparent',
+              borderTop: '7px solid rgba(255,255,255,0.85)'
             }}
           />
           <span
             aria-hidden="true"
-            className="pointer-events-none absolute -left-3 top-1/2 -translate-y-1/2"
+            className="pointer-events-none absolute -left-2.5 top-1/2 -translate-y-1/2"
             style={{
               width: 0,
               height: 0,
-              borderTop: '6px solid transparent',
-              borderBottom: '6px solid transparent',
-              borderRight: '8px solid rgba(255,255,255,0.85)'
+              borderTop: '5px solid transparent',
+              borderBottom: '5px solid transparent',
+              borderRight: '7px solid rgba(255,255,255,0.85)'
             }}
           />
           <span
             aria-hidden="true"
-            className="pointer-events-none absolute -right-3 top-1/2 -translate-y-1/2"
+            className="pointer-events-none absolute -right-2.5 top-1/2 -translate-y-1/2"
             style={{
               width: 0,
               height: 0,
-              borderTop: '6px solid transparent',
-              borderBottom: '6px solid transparent',
-              borderLeft: '8px solid rgba(255,255,255,0.85)'
+              borderTop: '5px solid transparent',
+              borderBottom: '5px solid transparent',
+              borderLeft: '7px solid rgba(255,255,255,0.85)'
             }}
           />
           <span aria-hidden="true">✋️</span>

--- a/webapp/src/utils/woodMaterials.js
+++ b/webapp/src/utils/woodMaterials.js
@@ -737,8 +737,8 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
       textureSize: 2048,
       ...makeInlinePlasticMonoblockPattern({
         id: 'plastic-monoblock-lt-black-rail',
-        base: '#0b0d10',
-        sheen: '#1a1f28'
+        base: '#1a2028',
+        sheen: '#313946'
       })
     },
     frame: {
@@ -747,8 +747,8 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
       textureSize: 2048,
       ...makeInlinePlasticMonoblockPattern({
         id: 'plastic-monoblock-lt-black-frame',
-        base: '#0b0d10',
-        sheen: '#1a1f28'
+        base: '#1a2028',
+        sheen: '#313946'
       })
     }
   }),
@@ -762,8 +762,8 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
       textureSize: 2048,
       ...makeInlinePlasticMonoblockPattern({
         id: 'plastic-monoblock-lt-grey-rail',
-        base: '#585f6b',
-        sheen: '#7b8391'
+        base: '#676f7c',
+        sheen: '#8e97a6'
       })
     },
     frame: {
@@ -772,8 +772,8 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
       textureSize: 2048,
       ...makeInlinePlasticMonoblockPattern({
         id: 'plastic-monoblock-lt-grey-frame',
-        base: '#585f6b',
-        sheen: '#7b8391'
+        base: '#676f7c',
+        sheen: '#8e97a6'
       })
     }
   }),
@@ -787,8 +787,8 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
       textureSize: 2048,
       ...makeInlinePlasticMonoblockPattern({
         id: 'plastic-monoblock-lt-dark-grey-rail',
-        base: '#2d323b',
-        sheen: '#434a56'
+        base: '#39414b',
+        sheen: '#505a67'
       })
     },
     frame: {
@@ -797,8 +797,8 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
       textureSize: 2048,
       ...makeInlinePlasticMonoblockPattern({
         id: 'plastic-monoblock-lt-dark-grey-frame',
-        base: '#2d323b',
-        sheen: '#434a56'
+        base: '#39414b',
+        sheen: '#505a67'
       })
     }
   }),
@@ -812,8 +812,8 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
       textureSize: 2048,
       ...makeInlinePlasticMonoblockPattern({
         id: 'plastic-monoblock-lt-burgundy-rail',
-        base: '#5f1d2c',
-        sheen: '#7f2e43'
+        base: '#5b2f26',
+        sheen: '#7c4a3b'
       })
     },
     frame: {
@@ -822,8 +822,8 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
       textureSize: 2048,
       ...makeInlinePlasticMonoblockPattern({
         id: 'plastic-monoblock-lt-burgundy-frame',
-        base: '#5f1d2c',
-        sheen: '#7f2e43'
+        base: '#5b2f26',
+        sheen: '#7c4a3b'
       })
     }
   }),
@@ -837,8 +837,8 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
       textureSize: 2048,
       ...makeInlinePlasticMonoblockPattern({
         id: 'plastic-monoblock-lt-milk-cream-rail',
-        base: '#e9dcc9',
-        sheen: '#f8efe1'
+        base: '#d2c2ac',
+        sheen: '#e5d5c1'
       })
     },
     frame: {
@@ -847,8 +847,108 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
       textureSize: 2048,
       ...makeInlinePlasticMonoblockPattern({
         id: 'plastic-monoblock-lt-milk-cream-frame',
-        base: '#e9dcc9',
-        sheen: '#f8efe1'
+        base: '#d2c2ac',
+        sheen: '#e5d5c1'
+      })
+    }
+  }),
+  Object.freeze({
+    id: 'plastic_monoblock_lt_dark_green',
+    label: 'LT Dark Green',
+    source: 'TonPlaygram molded-plastic satin texture (LT Dark Green)',
+    rail: {
+      repeat: { x: 7.2, y: 7.2 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlinePlasticMonoblockPattern({
+        id: 'plastic-monoblock-lt-dark-green-rail',
+        base: '#2b4533',
+        sheen: '#3d6148'
+      })
+    },
+    frame: {
+      repeat: { x: 7.2, y: 7.2 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlinePlasticMonoblockPattern({
+        id: 'plastic-monoblock-lt-dark-green-frame',
+        base: '#2b4533',
+        sheen: '#3d6148'
+      })
+    }
+  }),
+  Object.freeze({
+    id: 'plastic_monoblock_lt_dark_yellow',
+    label: 'LT Dark Yellow',
+    source: 'TonPlaygram molded-plastic satin texture (LT Dark Yellow)',
+    rail: {
+      repeat: { x: 7.2, y: 7.2 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlinePlasticMonoblockPattern({
+        id: 'plastic-monoblock-lt-dark-yellow-rail',
+        base: '#876426',
+        sheen: '#a27b33'
+      })
+    },
+    frame: {
+      repeat: { x: 7.2, y: 7.2 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlinePlasticMonoblockPattern({
+        id: 'plastic-monoblock-lt-dark-yellow-frame',
+        base: '#876426',
+        sheen: '#a27b33'
+      })
+    }
+  }),
+  Object.freeze({
+    id: 'plastic_monoblock_lt_dark_brown',
+    label: 'LT Dark Brown',
+    source: 'TonPlaygram molded-plastic satin texture (LT Dark Brown)',
+    rail: {
+      repeat: { x: 7.2, y: 7.2 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlinePlasticMonoblockPattern({
+        id: 'plastic-monoblock-lt-dark-brown-rail',
+        base: '#5a3a2a',
+        sheen: '#734a37'
+      })
+    },
+    frame: {
+      repeat: { x: 7.2, y: 7.2 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlinePlasticMonoblockPattern({
+        id: 'plastic-monoblock-lt-dark-brown-frame',
+        base: '#5a3a2a',
+        sheen: '#734a37'
+      })
+    }
+  }),
+  Object.freeze({
+    id: 'plastic_monoblock_lt_dark_red',
+    label: 'LT Dark Red',
+    source: 'TonPlaygram molded-plastic satin texture (LT Dark Red)',
+    rail: {
+      repeat: { x: 7.2, y: 7.2 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlinePlasticMonoblockPattern({
+        id: 'plastic-monoblock-lt-dark-red-rail',
+        base: '#6a2323',
+        sheen: '#8a3434'
+      })
+    },
+    frame: {
+      repeat: { x: 7.2, y: 7.2 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlinePlasticMonoblockPattern({
+        id: 'plastic-monoblock-lt-dark-red-frame',
+        base: '#6a2323',
+        sheen: '#8a3434'
       })
     }
   }),


### PR DESCRIPTION
### Motivation
- Fix LT table finish tones that appeared too dark (burgundy read as black, milk‑cream too light, blacks/greys too dim) and add a few dark LT variants requested for the LT finish palette.
- Make the playfield stance slightly shorter by trimming the table base/legs so the table fits better on portrait screens while keeping existing framing.
- Prevent decorative secondary tables from showing in the `abandonedHall` HDRI and reduce the ball‑in‑hand UI occlusion by resizing and offsetting the hand icon.

### Description
- Adjusted LT finish colors and added new LT finishes by updating `TABLE_FINISHES` in `webapp/src/pages/Games/PoolRoyale.jsx` to tune `rail/base/trim` hex values and to add `carbonFiberChalkDarkGreen`, `carbonFiberChalkDarkYellow`, `carbonFiberChalkDarkBrown`, and `carbonFiberChalkDarkRed`.
- Added matching molded‑plastic LT texture entries in `webapp/src/utils/woodMaterials.js` (new `plastic_monoblock_lt_*` entries and adjusted base/sheen colors) so the finishes keep the same texture while changing color only.
- Exposed updated swatches, labels and new purchasable items in the store by updating `webapp/src/config/poolRoyaleInventoryConfig.js` (thumbnails, `POOL_ROYALE_OPTION_LABELS`, and `POOL_ROYALE_STORE_ITEMS`) to include the new LT options and revised descriptions.
- Shortened the table stance and preserved camera framing by changing `BASE_HEIGHT_REDUCTION` and nudging `ORBIT_FOCUS_BASE_Y` in `PoolRoyale.jsx`, and added a guard so `refreshSecondaryDecor` returns early when `environmentHdriRef.current === 'abandonedHall'` to keep only the main playing table in that HDRI.
- Polished the ball‑in‑hand UI by reducing the hand icon size and arrow sizes and adding an offset (`offsetX`, `offsetY`) so the in‑hand icon is slightly away from the cue ball during placement in `PoolRoyale.jsx`.

### Testing
- Ran `npx eslint` on the three modified files and observed the repo ESLint ignore rules report (files ignored) which surfaced 3 warnings when run with defaults.
- Ran `npx eslint --no-ignore` which produced many style errors, but these are pre‑existing project lint violations and not introduced by this change set; no runtime tests or visual validation could be performed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d265c35bc0832994e0d073d4b4901a)