### PR TITLE
Checkers: chair/table customization — add hexagon table, cloth support, and chair placement/scale

### DIFF
--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -23,8 +23,10 @@ import {
 import { ARENA_CAMERA_DEFAULTS } from '../../utils/arenaCameraConfig.js';
 import {
   createMurlanStyleTable,
-  applyTableMaterials
+  applyTableMaterials,
+  TABLE_SHAPE_OPTIONS
 } from '../../utils/murlanTable.js';
+import { TABLE_CLOTH_OPTIONS } from '../../utils/tableCustomizationOptions.js';
 import AvatarTimer from '../../components/AvatarTimer.jsx';
 import BottomLeftIcons from '../../components/BottomLeftIcons.jsx';
 import GiftPopup from '../../components/GiftPopup.jsx';
@@ -102,7 +104,6 @@ const CHECKERS_TABLE_TRIM_HEIGHT_SCALE = 0.66;
 const CHECKERS_TABLE_TRIM_RADIUS_SCALE = 0.74;
 const CHECKERS_CAMERA_FRAME_COMPENSATION = 1.08;
 // Lower chairs toward the floor for stronger downward screen placement.
-const CHAIR_GROUND_SINK = 0.32;
 const CHECKERS_GRAPHICS_PROFILE_STORAGE_KEY =
   'checkersBattleRoyalGraphicsProfile';
 const CHECKERS_DEFAULT_GRAPHICS_PROFILE_ID = 'hz90_2k';
@@ -270,8 +271,9 @@ const CHAIR_MODEL_URLS = [
   'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/SheenChair/glTF-Binary/SheenChair.glb',
   'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/AntiqueChair/glTF-Binary/AntiqueChair.glb'
 ];
-// Requested tweak: make chairs about 20% smaller than the current setup.
-const CHAIR_VISUAL_SCALE = 0.8;
+const CHAIR_GROUND_SINK = 0.44;
+// Requested tweak: make chairs about 15% bigger than the current setup.
+const CHAIR_VISUAL_SCALE = 0.92;
 const CHAIR_TARGET_SCALE_FACTOR = 0.8;
 const TARGET_CHAIR_SIZE = new THREE.Vector3(
   1.3162499970197679 * CHAIR_TARGET_SCALE_FACTOR,
@@ -296,6 +298,18 @@ const CHECKERS_HIGHLIGHT_COLORS = Object.freeze({
   selection: '#ff8e6e',
   move: '#7ef9a1',
   capture: '#ff8e6e'
+});
+const CHECKERS_PROCEDURAL_TABLE_IDS = new Set([
+  'murlan-default',
+  'ovalTable',
+  'diamondEdge',
+  'hexagonTable'
+]);
+const CHECKERS_TABLE_SHAPE_BY_ID = Object.freeze({
+  'murlan-default': 'classicOctagon',
+  ovalTable: 'grandOval',
+  diamondEdge: 'diamondEdge',
+  hexagonTable: 'hexagonTable'
 });
 
 const CHECKERS_CHIP_SET_BY_ID = Object.freeze({
@@ -1440,10 +1454,38 @@ export default function CheckersBattleRoyal() {
   }, [resolvedAccountId]);
 
   const unlockedTableOptions = useMemo(
-    () =>
-      CHESS_TABLE_OPTIONS.filter((opt) =>
+    () => {
+      const baseUnlocked = CHESS_TABLE_OPTIONS.filter((opt) =>
         isChessOptionUnlocked('tables', opt.id, inventory)
-      ),
+      );
+      const specialProcedural = [
+        {
+          id: 'ovalTable',
+          label: 'Oval Table',
+          thumbnail:
+            TABLE_SHAPE_OPTIONS.find((option) => option.id === 'grandOval')
+              ?.thumbnail
+        },
+        {
+          id: 'diamondEdge',
+          label: 'Diamond Edge Table',
+          thumbnail:
+            TABLE_SHAPE_OPTIONS.find((option) => option.id === 'diamondEdge')
+              ?.thumbnail
+        },
+        {
+          id: 'hexagonTable',
+          label: 'Hexagon Table',
+          thumbnail:
+            TABLE_SHAPE_OPTIONS.find((option) => option.id === 'hexagonTable')
+              ?.thumbnail
+        }
+      ].filter((opt) => isChessOptionUnlocked('tables', opt.id, inventory));
+      const deduped = new Map(
+        [...baseUnlocked, ...specialProcedural].map((opt) => [opt.id, opt])
+      );
+      return Array.from(deduped.values());
+    },
     [inventory]
   );
   const unlockedChairOptions = useMemo(
@@ -1458,6 +1500,15 @@ export default function CheckersBattleRoyal() {
       MURLAN_TABLE_FINISHES.filter((opt) =>
         isChessOptionUnlocked('tableFinish', opt.id, inventory)
       ),
+    [inventory]
+  );
+  const unlockedTableCloths = useMemo(
+    () => {
+      const unlocked = TABLE_CLOTH_OPTIONS.filter((opt) =>
+        isChessOptionUnlocked('tableCloth', opt.id, inventory)
+      );
+      return unlocked.length ? unlocked : [TABLE_CLOTH_OPTIONS[0]];
+    },
     [inventory]
   );
   const unlockedBoardThemes = useMemo(
@@ -1485,6 +1536,7 @@ export default function CheckersBattleRoyal() {
       tableId: inventory.tables?.[0] || CHESS_TABLE_OPTIONS[0]?.id,
       chairId: inventory.chairColor?.[0] || CHESS_CHAIR_OPTIONS[0]?.id,
       tableFinish: inventory.tableFinish?.[0] || MURLAN_TABLE_FINISHES[0]?.id,
+      tableCloth: inventory.tableCloth?.[0] || TABLE_CLOTH_OPTIONS[0]?.id,
       hdriId: inventory.environmentHdri?.[0] || POOL_ROYALE_DEFAULT_HDRI_ID,
       boardTheme:
         inventory.boardTheme?.[0] || CHECKERS_BOARD_THEME_OPTIONS[0]?.id,
@@ -1494,6 +1546,9 @@ export default function CheckersBattleRoyal() {
   );
 
   const [appearance, setAppearance] = useState(inv);
+  const showTableSurfaceOptions = CHECKERS_PROCEDURAL_TABLE_IDS.has(
+    appearance.tableId
+  );
   const unlockedPieceStyleIds = useMemo(
     () =>
       Object.keys(CHECKERS_CHIP_SET_BY_ID).filter((id) =>
@@ -1615,6 +1670,10 @@ export default function CheckersBattleRoyal() {
         unlockedTableFinishes.find((opt) => opt.id === prev.tableFinish)?.id ||
         unlockedTableFinishes[0]?.id ||
         MURLAN_TABLE_FINISHES[0]?.id,
+      tableCloth:
+        unlockedTableCloths.find((opt) => opt.id === prev.tableCloth)?.id ||
+        unlockedTableCloths[0]?.id ||
+        TABLE_CLOTH_OPTIONS[0]?.id,
       boardTheme:
         unlockedBoardThemes.find((opt) => opt.id === prev.boardTheme)?.id ||
         unlockedBoardThemes[0]?.id ||
@@ -1628,6 +1687,7 @@ export default function CheckersBattleRoyal() {
     unlockedBoardThemes,
     unlockedChairOptions,
     unlockedHdriOptions,
+    unlockedTableCloths,
     unlockedTableFinishes,
     unlockedTableOptions
   ]);
@@ -1643,6 +1703,12 @@ export default function CheckersBattleRoyal() {
         appearance.tableFinish,
         resolvedAccountId
       );
+    if (appearance.tableCloth)
+      setChessBattleEquippedOption(
+        'tableCloth',
+        appearance.tableCloth,
+        resolvedAccountId
+      );
     if (appearance.boardTheme)
       setChessBattleEquippedOption('boardTheme', appearance.boardTheme, resolvedAccountId);
     if (appearance.hdriId)
@@ -1655,6 +1721,7 @@ export default function CheckersBattleRoyal() {
     appearance.boardTheme,
     appearance.chairId,
     appearance.hdriId,
+    appearance.tableCloth,
     appearance.tableFinish,
     appearance.tableId,
     resolvedAccountId
@@ -2217,16 +2284,33 @@ export default function CheckersBattleRoyal() {
       };
 
       try {
+        const desiredShapeId =
+          CHECKERS_TABLE_SHAPE_BY_ID[appearance.tableId] || 'classicOctagon';
+        const desiredShape =
+          TABLE_SHAPE_OPTIONS.find((shape) => shape.id === desiredShapeId) ||
+          TABLE_SHAPE_OPTIONS[0];
         const table = createMurlanStyleTable({
           arena: scene,
           renderer,
           tableRadius: TABLE_RADIUS,
-          tableHeight: TABLE_HEIGHT
+          tableHeight: TABLE_HEIGHT,
+          shapeOption: desiredShape
         });
+        table.userData = { selectedTableId: appearance.tableId };
         const finish =
           MURLAN_TABLE_FINISHES.find((f) => f.id === appearance.tableFinish) ||
           MURLAN_TABLE_FINISHES[0];
-        applyTableMaterials(table.parts, finish);
+        const cloth =
+          TABLE_CLOTH_OPTIONS.find((clothOpt) => clothOpt.id === appearance.tableCloth) ||
+          TABLE_CLOTH_OPTIONS[0];
+        applyTableMaterials(
+          table.materials,
+          {
+            woodOption: finish?.woodOption,
+            clothOption: cloth
+          },
+          renderer
+        );
         reduceCheckersTableBase(table.group);
         tableRef.current = table;
       } catch (error) {
@@ -2668,11 +2752,42 @@ export default function CheckersBattleRoyal() {
     const scene = sceneRef.current;
     if (!scene) return;
 
+    const desiredShapeId =
+      CHECKERS_TABLE_SHAPE_BY_ID[appearance.tableId] || 'classicOctagon';
+    const currentShapeId = tableRef.current?.shapeId || 'classicOctagon';
+    if (tableRef.current && currentShapeId !== desiredShapeId) {
+      const currentTable = tableRef.current;
+      currentTable.dispose?.();
+      const shapeOption =
+        TABLE_SHAPE_OPTIONS.find((shape) => shape.id === desiredShapeId) ||
+        TABLE_SHAPE_OPTIONS[0];
+      const rebuilt = createMurlanStyleTable({
+        arena: scene,
+        renderer: rendererRef.current,
+        tableRadius: TABLE_RADIUS,
+        tableHeight: TABLE_HEIGHT,
+        shapeOption
+      });
+      rebuilt.userData = { selectedTableId: appearance.tableId };
+      reduceCheckersTableBase(rebuilt.group);
+      tableRef.current = rebuilt;
+    }
     const finish =
       MURLAN_TABLE_FINISHES.find((f) => f.id === appearance.tableFinish) ||
       MURLAN_TABLE_FINISHES[0];
-    if (tableRef.current?.parts)
-      applyTableMaterials(tableRef.current.parts, finish);
+    const cloth =
+      TABLE_CLOTH_OPTIONS.find((clothOpt) => clothOpt.id === appearance.tableCloth) ||
+      TABLE_CLOTH_OPTIONS[0];
+    if (tableRef.current?.materials) {
+      applyTableMaterials(
+        tableRef.current.materials,
+        {
+          woodOption: finish?.woodOption,
+          clothOption: cloth
+        },
+        rendererRef.current
+      );
+    }
 
     const chairOption =
       CHESS_CHAIR_OPTIONS.find((c) => c.id === appearance.chairId) ||
@@ -2922,33 +3037,6 @@ export default function CheckersBattleRoyal() {
               </button>
               <div className="mt-3 rounded-xl border border-white/10 bg-white/5 p-3">
                 <div className="mb-2 text-[11px] uppercase tracking-[0.2em] text-white/70">
-                  Table Finish
-                </div>
-                <div className="mb-3 grid max-h-40 grid-cols-2 gap-2 overflow-auto">
-                  {unlockedTableFinishes.map((opt) => (
-                    <button
-                      key={opt.id}
-                      onClick={() =>
-                        setAppearance((prev) => ({
-                          ...prev,
-                          tableFinish: opt.id
-                        }))
-                      }
-                      className={`rounded-xl border px-2 py-2 text-[11px] ${appearance.tableFinish === opt.id ? 'border-cyan-300 bg-cyan-500/20 text-cyan-100' : 'border-white/15 bg-white/5 text-white/70'}`}
-                    >
-                      {opt.thumbnail ? (
-                        <img
-                          src={opt.thumbnail}
-                          alt={`${opt.label} thumbnail`}
-                          className="mb-1 h-10 w-full rounded object-cover"
-                        />
-                      ) : null}
-                      {opt.label}
-                    </button>
-                  ))}
-                </div>
-
-                <div className="mb-2 text-[11px] uppercase tracking-[0.2em] text-white/70">
                   Tables
                 </div>
                 <div className="mb-3 grid max-h-40 grid-cols-2 gap-2 overflow-auto">
@@ -2971,6 +3059,63 @@ export default function CheckersBattleRoyal() {
                     </button>
                   ))}
                 </div>
+
+                {showTableSurfaceOptions ? (
+                  <>
+                    <div className="mb-2 text-[11px] uppercase tracking-[0.2em] text-white/70">
+                      Table Finish
+                    </div>
+                    <div className="mb-3 grid max-h-40 grid-cols-2 gap-2 overflow-auto">
+                      {unlockedTableFinishes.map((opt) => (
+                        <button
+                          key={opt.id}
+                          onClick={() =>
+                            setAppearance((prev) => ({
+                              ...prev,
+                              tableFinish: opt.id
+                            }))
+                          }
+                          className={`rounded-xl border px-2 py-2 text-[11px] ${appearance.tableFinish === opt.id ? 'border-cyan-300 bg-cyan-500/20 text-cyan-100' : 'border-white/15 bg-white/5 text-white/70'}`}
+                        >
+                          {opt.thumbnail ? (
+                            <img
+                              src={opt.thumbnail}
+                              alt={`${opt.label} thumbnail`}
+                              className="mb-1 h-10 w-full rounded object-cover"
+                            />
+                          ) : null}
+                          {opt.label}
+                        </button>
+                      ))}
+                    </div>
+                    <div className="mb-2 text-[11px] uppercase tracking-[0.2em] text-white/70">
+                      Table Cloth
+                    </div>
+                    <div className="mb-3 grid max-h-40 grid-cols-2 gap-2 overflow-auto">
+                      {unlockedTableCloths.map((opt) => (
+                        <button
+                          key={opt.id}
+                          onClick={() =>
+                            setAppearance((prev) => ({
+                              ...prev,
+                              tableCloth: opt.id
+                            }))
+                          }
+                          className={`rounded-xl border px-2 py-2 text-[11px] ${appearance.tableCloth === opt.id ? 'border-cyan-300 bg-cyan-500/20 text-cyan-100' : 'border-white/15 bg-white/5 text-white/70'}`}
+                        >
+                          {opt.thumbnail ? (
+                            <img
+                              src={opt.thumbnail}
+                              alt={`${opt.label} thumbnail`}
+                              className="mb-1 h-10 w-full rounded object-cover"
+                            />
+                          ) : null}
+                          {opt.label}
+                        </button>
+                      ))}
+                    </div>
+                  </>
+                ) : null}
 
                 <div className="mb-2 text-[11px] uppercase tracking-[0.2em] text-white/70">
                   Board

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -116,6 +116,8 @@ import {
   TEXAS_HOLDEM_OPTION_LABELS,
   TEXAS_HOLDEM_STORE_ITEMS
 } from '../config/texasHoldemInventoryConfig.js';
+import { TABLE_CLOTH_OPTIONS } from '../utils/tableCustomizationOptions.js';
+import { TABLE_SHAPE_OPTIONS } from '../utils/murlanTable.js';
 import {
   SNAKE_DEFAULT_LOADOUT,
   SNAKE_OPTION_LABELS,
@@ -179,12 +181,72 @@ const AIR_HOCKEY_TYPE_LABELS = {
 const CHESS_TYPE_LABELS = {
   tables: 'Table Models',
   tableFinish: 'Table Finish',
+  tableCloth: 'Table Cloth',
   chairColor: 'Chairs',
   sideColor: 'Piece Colors',
   boardTheme: 'Board Themes',
   headStyle: 'Pawn Heads',
   environmentHdri: 'HDR Environments'
 };
+const CHECKERS_BATTLE_TYPE_LABELS = {
+  ...CHESS_TYPE_LABELS,
+  tableCloth: 'Table Cloth'
+};
+
+const CHECKERS_PROCEDURAL_TABLES = [
+  {
+    id: 'murlan-default',
+    label: 'Octagon Table',
+    thumbnail:
+      TABLE_SHAPE_OPTIONS.find((option) => option.id === 'classicOctagon')
+        ?.thumbnail
+  },
+  {
+    id: 'ovalTable',
+    label: 'Oval Table',
+    thumbnail:
+      TABLE_SHAPE_OPTIONS.find((option) => option.id === 'grandOval')?.thumbnail
+  },
+  {
+    id: 'diamondEdge',
+    label: 'Diamond Edge Table',
+    thumbnail:
+      TABLE_SHAPE_OPTIONS.find((option) => option.id === 'diamondEdge')
+        ?.thumbnail
+  },
+  {
+    id: 'hexagonTable',
+    label: 'Hexagon Table',
+    thumbnail:
+      TABLE_SHAPE_OPTIONS.find((option) => option.id === 'hexagonTable')
+        ?.thumbnail
+  }
+];
+
+const CHECKERS_BATTLE_STORE_ITEMS = [
+  ...CHESS_BATTLE_STORE_ITEMS,
+  ...CHECKERS_PROCEDURAL_TABLES.filter((table) => table.id !== 'murlan-default')
+    .map((table, idx) => ({
+      id: `checkers-table-${table.id}`,
+      type: 'tables',
+      optionId: table.id,
+      name: table.label,
+      price: 980 + idx * 45,
+      description: `${table.label} layout for Checkers Battle Royal.`,
+      thumbnail: table.thumbnail,
+      previewShape: 'table'
+    })),
+  ...TABLE_CLOTH_OPTIONS.slice(1).map((option, idx) => ({
+    id: `checkers-cloth-${option.id}`,
+    type: 'tableCloth',
+    optionId: option.id,
+    name: option.label,
+    price: 360 + idx * 35,
+    description: 'Premium table cloth option for procedural checkers tables.',
+    thumbnail: option.thumbnail,
+    previewShape: 'table'
+  }))
+];
 const TAVULL_TYPE_LABELS = {
   tableFinish: 'Table Finish',
   chairColor: 'Chairs',
@@ -1613,7 +1675,7 @@ export default function Store() {
         key: createItemKey(item.type, item.optionId),
         slug: 'chessbattleroyal'
       })),
-      checkersbattleroyal: CHESS_BATTLE_STORE_ITEMS.map((item) => ({
+      checkersbattleroyal: CHECKERS_BATTLE_STORE_ITEMS.map((item) => ({
         ...item,
         key: createItemKey(item.type, item.optionId),
         slug: 'checkersbattleroyal'
@@ -1735,7 +1797,7 @@ export default function Store() {
       poolroyale: TYPE_LABELS,
       airhockey: AIR_HOCKEY_TYPE_LABELS,
       chessbattleroyal: CHESS_TYPE_LABELS,
-      checkersbattleroyal: CHESS_TYPE_LABELS,
+      checkersbattleroyal: CHECKERS_BATTLE_TYPE_LABELS,
       fourinrowroyale: FOUR_IN_ROW_TYPE_LABELS,
       tavullbattleroyal: TAVULL_TYPE_LABELS,
       ludobattleroyal: LUDO_TYPE_LABELS,

--- a/webapp/src/utils/murlanTable.js
+++ b/webapp/src/utils/murlanTable.js
@@ -355,6 +355,21 @@ export const TABLE_SHAPE_OPTIONS = Object.freeze([
       const rimInnerShape = createRoundedRectangleShape(innerWidth, innerHeight, 0.1 * factor);
       return { topShape, feltShape, rimInnerShape, feltRadius: Math.max(feltWidth, feltHeight) * 0.5 };
     }
+  },
+  {
+    id: 'hexagonTable',
+    label: 'Hexagon Table',
+    preview: {
+      clipPath: 'polygon(50% 0%, 90% 25%, 90% 75%, 50% 100%, 10% 75%, 10% 25%)'
+    },
+    thumbnail: swatchThumbnail(['#0f172a', '#111827', '#22d3ee']),
+    createShapes: ({ radius }) => {
+      const sideStretch = 1.08;
+      const topShape = scaleShape2D(createRegularPolygonShape(6, radius), sideStretch, 1);
+      const feltShape = scaleShape2D(createRegularPolygonShape(6, radius * 0.8), sideStretch, 1);
+      const rimInnerShape = scaleShape2D(feltShape, 0.96, 0.96);
+      return { topShape, feltShape, rimInnerShape };
+    }
   }
 ]);
 


### PR DESCRIPTION
### Motivation
- Implement user-requested arena appearance changes: lower chairs visually, increase chair size by ~15%, and keep Checkers-specific rendering isolated. 
- Allow players to change table, chairs and table cloth for Checkers and add additional procedural table shapes (oval, diamond edge, hexagon) plus table cloth catalog items so users can purchase and apply cloths. 
- Show table cloth and table finish controls only for supported procedural table shapes (octagon/oval/diamond/hexagon) and hide them for other tables.

### Description
- Added a new `hexagonTable` entry to `TABLE_SHAPE_OPTIONS` in `webapp/src/utils/murlanTable.js` to provide a hexagonal procedural table shape and preview metadata. 
- Updated `webapp/src/pages/Games/CheckersBattleRoyal.jsx` to lower chair grounding (`CHAIR_GROUND_SINK`) and increase visual scale (`CHAIR_VISUAL_SCALE`), to map checkers table IDs to procedural `TABLE_SHAPE_OPTIONS`, and to rebuild the procedural table when the selected shape changes. 
- Wired `tableCloth` into Checkers inventory/equipped-option flow and applied cloth textures when building or updating the table via `applyTableMaterials` (table material application now includes both wood finish and cloth). 
- Adjusted the in-game menu UI to always show table selection and to conditionally show `Table Finish` and `Table Cloth` controls only when the selected table ID is one of the supported procedural shapes. 
- Extended the Store logic in `webapp/src/pages/Store.jsx` to provide a Checkers-specific store composition (`CHECKERS_BATTLE_STORE_ITEMS`) that includes the procedural table variants and Texas Hold'em `tableCloth` entries, and added type labels for `tableCloth` so cloth items are purchasable for Checkers. 

### Testing
- Ran the targeted unit test with `npm test -- test/checkersBattleHdriCatalog.test.js --runInBand` and it passed. 
- Built the web client with `cd webapp && npm run build` and the Vite production build completed successfully. 
- Ran lint checks; `npx eslint` in the repo respected ignore patterns (warnings), while `npx eslint --no-ignore` reported style errors across files (lint failures), so formatting/style fixes may be required separately.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2745be4108329b1bf2394f03fa132)