### PR TITLE
Adjust Domino HDRI resolution and arena scale; update camera offsets and script version

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -445,7 +445,7 @@ function resolveInitialFrameRateId() {
 function resolveGraphicsHdriResolutionId(qualityId = DEFAULT_FRAME_RATE_ID) {
   switch (qualityId) {
     case 'uhd120':
-      return isMobileDevice ? '4k' : '8k';
+      return '8k';
     case 'qhd90':
       return '4k';
     case 'fhd60':
@@ -935,7 +935,8 @@ scene.background = null;
 const LIGHT_INTENSITY_FACTOR = 1;
 const dimIntensity = (value = 1) => value * LIGHT_INTENSITY_FACTOR;
 
-const MODEL_SCALE = 0.75;
+const MODEL_SCALE = 0.7;
+const CAMERA_LAYOUT_SCALE = MODEL_SCALE / 0.75;
 const TABLE_RADIUS_SCALE = 0.8835;
 const TABLE_HEIGHT_SCALE = 0.95;
 const ARENA_GROWTH = 1.45;
@@ -998,9 +999,18 @@ const CAMERA_MIN_RADIUS = CAMERA_BASE_RADIUS * 0.55;
 const CAMERA_MAX_RADIUS = CAMERA_BASE_RADIUS * 3.2;
 const CAMERA_DEFAULT_AZIMUTH =
   CHAIR_SEAT_ANGLES[HUMAN_SEAT_INDEX] ?? Math.PI / 2;
-const CAMERA_LATERAL_OFFSET = { portrait: 0, landscape: 0 };
-const CAMERA_REAR_OFFSET = { portrait: 1.14, landscape: 0.68 };
-const CAMERA_HEIGHT_BOOST = { portrait: 1.86, landscape: 1.08 };
+const CAMERA_LATERAL_OFFSET = {
+  portrait: 0 * CAMERA_LAYOUT_SCALE,
+  landscape: 0 * CAMERA_LAYOUT_SCALE
+};
+const CAMERA_REAR_OFFSET = {
+  portrait: 1.14 * CAMERA_LAYOUT_SCALE,
+  landscape: 0.68 * CAMERA_LAYOUT_SCALE
+};
+const CAMERA_HEIGHT_BOOST = {
+  portrait: 1.86 * CAMERA_LAYOUT_SCALE,
+  landscape: 1.08 * CAMERA_LAYOUT_SCALE
+};
 const CAMERA_LOOK_YAW_LIMIT = THREE.MathUtils.degToRad(26);
 const CAMERA_LOOK_YAW_DRAG_FACTOR = -0.0055;
 const CAMERA_LOOK_PITCH_LIMIT = THREE.MathUtils.degToRad(16);
@@ -4046,9 +4056,7 @@ function getUnlockedOptions(key, inventory = dominoInventory) {
 
 function resolveHdriPolicyForFrameRate(qualityId = DEFAULT_FRAME_RATE_ID, fps = 60) {
   if (qualityId === 'uhd120') {
-    return isMobileDevice
-      ? Object.freeze({ preferredResolutions: Object.freeze(['2k']) })
-      : Object.freeze({ preferredResolutions: Object.freeze(['4k']) });
+    return Object.freeze({ preferredResolutions: Object.freeze(['4k']) });
   }
   if (qualityId === 'qhd90' || fps >= 90) {
     return Object.freeze({ preferredResolutions: Object.freeze(['2k']) });

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-04-04-domino-dot-head-match-v12';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-04-05-domino-hdri-native-scale-v13';
 
 export default function DominoRoyalArena() {
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- Keep HDRI at the original high-quality source resolution for best visuals and avoid unnecessary mobile downscaling for the UHD profile. 
- Reduce the in-world size of the table, chairs and dominos so the set can be re-proportioned while preserving the current visual framing. 
- Ensure camera offsets are scaled with the model change so player framing and proportions remain consistent. 
- Force clients to load the updated runtime script to pick up the new assets and layout. 

### Description
- Changed `resolveGraphicsHdriResolutionId` so the `uhd120` profile uses native `8k` HDRI as primary source. 
- Updated `resolveHdriPolicyForFrameRate` to provide a `4k` preferred fallback for the UHD profile. 
- Reduced arena physical scale by changing `MODEL_SCALE` from `0.75` to `0.7` and introduced `CAMERA_LAYOUT_SCALE = MODEL_SCALE / 0.75`. 
- Scaled camera layout constants (`CAMERA_REAR_OFFSET`, `CAMERA_HEIGHT_BOOST`, and `CAMERA_LATERAL_OFFSET`) to multiply by `CAMERA_LAYOUT_SCALE` so camera framing adapts to the new model scale. 
- Bumped the Domino runtime loader version (`DOMINO_ROYAL_SCRIPT_VERSION`) so clients will fetch the updated `domino-royal-game.js`. 

### Testing
- Ran the production build with `npm --prefix webapp run build` and the build completed successfully. 
- Vite reported existing non-blocking warnings about chunk size and mixed static/dynamic imports, which are pre-existing and did not block the build. 
- No automated unit/integration tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d287c2a7788329a188edc0bf02bb52)