### PR TITLE
Pool Royale: use corner/rail/cue broadcast cams, fix replay camera/trigger, improve LT finish & leg levelers

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2482,7 +2482,7 @@ function scaleWoodRepeatVector (repeatVec, scale) {
 const LT_CARBON_TEXTURE_REPEAT = Object.freeze({ x: 16, y: 4 });
 let CARBON_FIBER_TILE_CANVAS = null;
 const CARBON_FIBER_TILE_TEXTURES = new Map();
-const LT_MATTE_PLASTIC_TEXTURE_REPEAT = Object.freeze({ x: 9, y: 3.2 });
+const LT_MATTE_PLASTIC_TEXTURE_REPEAT = Object.freeze({ x: 10.8, y: 3.8 });
 const LT_MATTE_PLASTIC_TEXTURES = new Map();
 
 function createCarbonFiberPatternCanvas(size = 128) {
@@ -2579,7 +2579,7 @@ function applyLtCarbonFiberTexture(material) {
   material.needsUpdate = true;
 }
 
-function getLtMattePlasticTextureSet(tintHex = 0x0c0f14, size = 320) {
+function getLtMattePlasticTextureSet(tintHex = 0x0c0f14, size = 768) {
   if (typeof document === 'undefined') return null;
   const tintColor = new THREE.Color(tintHex);
   const key = `${tintColor.getHexString()}-${size}`;
@@ -2610,22 +2610,23 @@ function getLtMattePlasticTextureSet(tintHex = 0x0c0f14, size = 320) {
   for (let y = 0; y < size; y += 1) {
     for (let x = 0; x < size; x += 1) {
       const i = (y * size + x) * 4;
-      const dither = Math.sin(x * 0.34 + y * 0.26) * 0.5 + Math.cos(x * 0.17 - y * 0.23) * 0.5;
-      const grain = (Math.sin((x + y) * 0.9) + Math.cos((x - y) * 0.78)) * 0.5;
-      const micropit = Math.sin(x * 1.37) * Math.cos(y * 1.49);
-      const colorLift = THREE.MathUtils.clamp(dither * 6 + grain * 4, -16, 16);
-      const boostedR = THREE.MathUtils.lerp(tintR, 255, 0.12);
-      const boostedG = THREE.MathUtils.lerp(tintG, 255, 0.12);
-      const boostedB = THREE.MathUtils.lerp(tintB, 255, 0.12);
+      const dither = Math.sin(x * 0.42 + y * 0.31) * 0.48 + Math.cos(x * 0.22 - y * 0.27) * 0.52;
+      const grain = (Math.sin((x + y) * 1.15) + Math.cos((x - y) * 0.98)) * 0.5;
+      const micropit = Math.sin(x * 1.67) * Math.cos(y * 1.71);
+      const weave = Math.sin(x * 2.15) * Math.sin(y * 2.07);
+      const colorLift = THREE.MathUtils.clamp(dither * 5 + grain * 4 + weave * 2.4, -14, 18);
+      const boostedR = THREE.MathUtils.lerp(tintR, 255, 0.16);
+      const boostedG = THREE.MathUtils.lerp(tintG, 255, 0.16);
+      const boostedB = THREE.MathUtils.lerp(tintB, 255, 0.16);
       colorImage.data[i] = THREE.MathUtils.clamp(boostedR + colorLift, 0, 255);
       colorImage.data[i + 1] = THREE.MathUtils.clamp(boostedG + colorLift, 0, 255);
       colorImage.data[i + 2] = THREE.MathUtils.clamp(boostedB + colorLift, 0, 255);
       colorImage.data[i + 3] = 255;
-      normalImage.data[i] = THREE.MathUtils.clamp(128 + dither * 18, 0, 255);
-      normalImage.data[i + 1] = THREE.MathUtils.clamp(128 + grain * 18, 0, 255);
-      normalImage.data[i + 2] = THREE.MathUtils.clamp(215 + micropit * 28, 0, 255);
+      normalImage.data[i] = THREE.MathUtils.clamp(128 + dither * 21 + weave * 10, 0, 255);
+      normalImage.data[i + 1] = THREE.MathUtils.clamp(128 + grain * 20 + weave * 10, 0, 255);
+      normalImage.data[i + 2] = THREE.MathUtils.clamp(216 + micropit * 26 + weave * 8, 0, 255);
       normalImage.data[i + 3] = 255;
-      const rough = THREE.MathUtils.clamp(214 + dither * 16 + grain * 12 + micropit * 10, 150, 255);
+      const rough = THREE.MathUtils.clamp(228 + dither * 13 + grain * 11 + micropit * 9 + weave * 9, 168, 255);
       roughImage.data[i] = rough;
       roughImage.data[i + 1] = rough;
       roughImage.data[i + 2] = rough;
@@ -2686,10 +2687,10 @@ function applyMonoMattePlasticSurface(material) {
     material.reflectivity = 0;
   }
   if ('envMapIntensity' in material) {
-    material.envMapIntensity = 0.12;
+    material.envMapIntensity = 0.08;
   }
   if ('normalScale' in material && material.normalMap) {
-    material.normalScale = new THREE.Vector2(0.5, 0.5);
+    material.normalScale = new THREE.Vector2(0.62, 0.62);
   }
   material.needsUpdate = true;
 }
@@ -6776,7 +6777,7 @@ const getPocketCenterById = (id) => {
       return null;
   }
 };
-const POCKET_CAMERA_IDS = ['TL', 'TR', 'BL', 'BR', 'TM', 'BM'];
+const POCKET_CAMERA_IDS = ['TL', 'TR', 'BL', 'BR'];
 const CORNER_POCKET_CAMERA_IDS = ['TL', 'TR', 'BL', 'BR'];
 const POCKET_CAMERA_OUTWARD = Object.freeze({
   TL: new THREE.Vector2(-1, -1).normalize(),
@@ -6833,6 +6834,13 @@ const resolveLikelyPocketIntent = ({ ball, direction }) => {
 };
 const resolvePocketCameraAnchor = (pocketId, center, approachDir, ballPos) => {
   if (!pocketId) return null;
+  const resolveMiddlePocketToCorner = (middleId) => {
+    const source = ballPos?.clone?.() ?? center?.clone?.() ?? null;
+    const isTopHalf = source ? source.y < 0 : false;
+    if (middleId === 'TM') return isTopHalf ? 'TL' : 'BL';
+    if (middleId === 'BM') return isTopHalf ? 'TR' : 'BR';
+    return null;
+  };
   switch (pocketId) {
     case 'TL':
     case 'TR':
@@ -6840,11 +6848,13 @@ const resolvePocketCameraAnchor = (pocketId, center, approachDir, ballPos) => {
     case 'BR':
       return pocketId;
     case 'TM':
-      return 'TM';
+      return resolveMiddlePocketToCorner('TM');
     case 'BM':
-      return 'BM';
+      return resolveMiddlePocketToCorner('BM');
     default:
-      return pocketId;
+      return CORNER_POCKET_CAMERA_IDS.includes(pocketId)
+        ? pocketId
+        : resolveMiddlePocketToCorner(pocketId);
   }
 };
 const pocketIdFromCenter = (center) => {
@@ -11909,7 +11919,8 @@ export function Table3D(
       rubberRing.castShadow = false;
       rubberRing.receiveShadow = true;
       group.add(rubberRing, disc, stem);
-      group.position.set(center.x, ctx.floorY, center.z);
+      const yOffset = Number.isFinite(center?.yOffset) ? center.yOffset : 0;
+      group.position.set(center.x, ctx.floorY + yOffset, center.z);
       tagBasePart(group, 'trim');
       return group;
     });
@@ -11961,7 +11972,11 @@ export function Table3D(
       return attachLegLevelers(
         ctx,
         { meshes: legs, legMeshes: legs },
-        positions.map(([x, z]) => ({ x, z }))
+        positions.map(([x, z]) => ({
+          x,
+          z,
+          yOffset: -(BALL_R * 0.12)
+        }))
       );
     },
     openPortal: (ctx) => {
@@ -21827,24 +21842,23 @@ const powerRef = useRef(hud.power);
           }));
 
         const captureReplayCameraSnapshot = () => {
+          const liveCamera = activeRenderCameraRef.current ?? camera;
+          if (!liveCamera) return null;
           const scale = Number.isFinite(worldScaleFactor) ? worldScaleFactor : WORLD_SCALE;
           const minTargetY = Math.max(baseSurfaceWorldY, BALL_CENTER_Y * scale);
           const targetSnapshot = lastCameraTargetRef.current
             ? lastCameraTargetRef.current.clone()
             : broadcastCamerasRef.current?.defaultFocusWorld?.clone?.() ?? null;
-          const railSnapshot = resolveRailOverheadReplayCamera({
-            focusOverride: targetSnapshot,
-            minTargetY,
-            preferredRail: railOverheadSideRef.current
-          });
           const cameraMode =
             pocketCameraStateRef.current && activeShotView?.mode === 'pocket'
               ? `pocket:${activeShotView?.anchorId ?? activeShotView?.pocketId ?? 'active'}`
-              : 'broadcast';
-          const resolvedPosition = railSnapshot?.position?.clone?.() ?? null;
-          const resolvedTarget = railSnapshot?.target?.clone?.() ?? targetSnapshot;
-          const resolvedFov = Number.isFinite(railSnapshot?.fov)
-            ? railSnapshot.fov
+              : cueViewHoldRef.current || lookModeRef.current
+                ? 'cue'
+                : 'broadcast';
+          const resolvedPosition = liveCamera.position?.clone?.() ?? null;
+          const resolvedTarget = targetSnapshot ?? null;
+          const resolvedFov = Number.isFinite(liveCamera?.fov)
+            ? liveCamera.fov
             : camera.fov;
           const safePosition = isFiniteVector3(resolvedPosition) ? resolvedPosition : null;
           const safeTarget = isFiniteVector3(resolvedTarget) ? resolvedTarget : null;
@@ -22745,21 +22759,6 @@ const powerRef = useRef(hud.power);
           let storedFov = Number.isFinite(activeCamera?.fov)
             ? activeCamera.fov
             : camera.fov;
-          const broadcastReplayCamera = resolveBroadcastTopViewCamera({
-            focusOverride: storedTarget,
-            minTargetY
-          });
-          if (broadcastReplayCamera?.position) {
-            if (isFiniteVector3(broadcastReplayCamera.position)) {
-              storedPosition = broadcastReplayCamera.position.clone();
-            }
-            if (isFiniteVector3(broadcastReplayCamera?.target)) {
-              storedTarget.copy(broadcastReplayCamera.target);
-            }
-            storedFov = Number.isFinite(broadcastReplayCamera?.fov)
-              ? broadcastReplayCamera.fov
-              : storedFov;
-          }
           if (storedPosition && storedPosition.y < minTargetY) {
             storedPosition.y = minTargetY;
           }
@@ -28794,7 +28793,9 @@ const powerRef = useRef(hud.power);
           shotRecording.replayTags = replayDecision.tags;
           shotRecording.zoomOnly = replayDecision.zoomOnly;
         }
-        shouldStartReplay = false;
+        shouldStartReplay =
+          Boolean(replayDecision?.shouldReplay) &&
+          (shotRecording?.frames?.length ?? 0) > 1;
         const shooterSeat = currentState?.activePlayer === 'B' ? 'B' : 'A';
         if (potted.length) {
           const newPots = potted.filter(


### PR DESCRIPTION
### Motivation
- Enforce broadcast framing to use corner pocket cameras (plus rail overhead and cue camera) and avoid middle-pocket cams during live broadcasting so portrait broadcasts remain consistent. 
- Ensure replays actually play the same framing that happened live and trigger reliably for fouls and potted-ball events. 
- Improve the LT table finish visual: brighter, sharper, higher-detail matte look and make the rounded metallic levelers sit precisely at the bottom of classic cylindrical legs.

### Description
- Removed middle-pocket IDs from `POCKET_CAMERA_IDS` and remapped middle-pocket anchors (`TM`/`BM`) to nearest corner anchors with a small top/bottom heuristic so broadcast uses corner pocket cameras only, while keeping corner pocket logic intact (changes in `webapp/src/pages/Games/PoolRoyale.jsx`).
- Replay logic: only start replay when a replay decision exists and the captured `shotRecording` contains more than one frame, and capture/store the replay camera snapshot from the current live active render camera (`activeRenderCameraRef` / live cue/broadcast camera) so replay framing matches the broadcast exactly. 
- LT finish/fabric: increased `LT` matte-plastic texture resolution and repeat, tightened procedural detail (weave/grain/micropit maths), boosted color lift and normal/detail contributions, and reduced `envMapIntensity` and adjusted `normalScale` for a sharper, more matte finish. 
- Table leg levelers: added a small `yOffset` and lowered classic cylinder leveler placements so rounded metallic feet align with the bottom of the legs while keeping `openPortal` base behavior unchanged.

### Testing
- Built the web frontend with `npm --prefix webapp run build` and the production build completed successfully (vite build completed and assets emitted). 
- Verified the only application source file changed in this PR is `webapp/src/pages/Games/PoolRoyale.jsx` and the app build artifacts were produced without fatal errors. 
- No unit tests were modified or run; manual visual verification is recommended in a device/browser to confirm broadcast camera selection, replay framing parity, LT finish appearance, and leveler placement.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d28f7744b88329b58871bdf492d502)