### PR TITLE
Domino Royal: device-aware 120Hz graphics, PolyHaven HDRI sizing, and grounded furniture

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -67,6 +67,11 @@ function isTelegramRuntime() {
 }
 
 const IS_TELEGRAM_RUNTIME = isTelegramRuntime();
+const IS_HIGH_REFRESH_MOBILE =
+  typeof navigator !== 'undefined' &&
+  (/(Android|iPhone|iPad|iPod|Mobile)/i.test(navigator.userAgent || '') ||
+    detectCoarsePointer() ||
+    (navigator.maxTouchPoints ?? 0) > 1);
 const MURLAN_3D_ASSET_RESOLUTION = Object.freeze({
   tableClothTextureSize: 2048,
   chairClothTextureSize: 2048,
@@ -76,24 +81,26 @@ const MURLAN_3D_ASSET_RESOLUTION = Object.freeze({
 const FRAME_RATE_TEXTURE_SIZE_MAP = Object.freeze({
   fhd60: 2048,
   qhd90: 4096,
-  uhd120: 8192
+  uhd120: IS_HIGH_REFRESH_MOBILE ? 4096 : 8192
 });
 
 const DOMINO_TEXTURE_SIZE_MAP = Object.freeze({
   fhd60: 2048,
   qhd90: 4096,
-  uhd120: 8192
+  uhd120: IS_HIGH_REFRESH_MOBILE ? 4096 : 8192
 });
 const FRAME_RATE_MODEL_RESOLUTION_ORDER_MAP = Object.freeze({
   fhd60: Object.freeze(['2k', '1k']),
   qhd90: Object.freeze(['4k', '2k', '1k']),
-  uhd120: Object.freeze(['8k', '4k', '2k', '1k'])
+  uhd120: IS_HIGH_REFRESH_MOBILE
+    ? Object.freeze(['4k', '2k', '1k'])
+    : Object.freeze(['8k', '4k', '2k', '1k'])
 });
 
 const AVATAR_TEXTURE_SIZE_MAP = Object.freeze({
   fhd60: 2048,
   qhd90: 4096,
-  uhd120: 8192
+  uhd120: IS_HIGH_REFRESH_MOBILE ? 4096 : 8192
 });
 const LEGACY_FRAME_RATE_ALIASES = Object.freeze({
   hd50: 'fhd60'
@@ -445,7 +452,7 @@ function resolveInitialFrameRateId() {
 function resolveGraphicsHdriResolutionId(qualityId = DEFAULT_FRAME_RATE_ID) {
   switch (qualityId) {
     case 'uhd120':
-      return '8k';
+      return IS_HIGH_REFRESH_MOBILE ? '4k' : '8k';
     case 'qhd90':
       return '4k';
     case 'fhd60':
@@ -4056,7 +4063,11 @@ function getUnlockedOptions(key, inventory = dominoInventory) {
 
 function resolveHdriPolicyForFrameRate(qualityId = DEFAULT_FRAME_RATE_ID, fps = 60) {
   if (qualityId === 'uhd120') {
-    return Object.freeze({ preferredResolutions: Object.freeze(['4k']) });
+    return Object.freeze({
+      preferredResolutions: Object.freeze(
+        IS_HIGH_REFRESH_MOBILE ? ['4k', '2k'] : ['8k', '6k', '4k']
+      )
+    });
   }
   if (qualityId === 'qhd90' || fps >= 90) {
     return Object.freeze({ preferredResolutions: Object.freeze(['2k']) });
@@ -4774,6 +4785,8 @@ arenaG.add(tableThemeG);
 let hallwayDoorState = null;
 let hallwayDoorZ = 0;
 let walkwayEntryZ = TABLE_RADIUS * 2.4;
+let arenaFloorMesh = null;
+let arenaCarpetMesh = null;
 
 if (!USE_MINIMAL_STAGE) {
   const floor = new THREE.Mesh(
@@ -4788,6 +4801,7 @@ if (!USE_MINIMAL_STAGE) {
   floor.position.y = 0;
   floor.receiveShadow = true;
   arenaG.add(floor);
+  arenaFloorMesh = floor;
 
   const carpetTextures = getPoolCarpetTextures(renderer);
   const carpetMat = new THREE.MeshStandardMaterial({
@@ -4814,6 +4828,7 @@ if (!USE_MINIMAL_STAGE) {
   carpet.position.y = 0.01;
   carpet.receiveShadow = true;
   arenaG.add(carpet);
+  arenaCarpetMesh = carpet;
 
   const wallMaterial = new THREE.MeshStandardMaterial({
     color: 0xb9ddff,
@@ -5662,6 +5677,7 @@ async function applyTableTheme(
   if (!theme?.assetId) {
     activeTableThemeId = null;
     setProceduralTableVisible(true);
+    syncArenaGroundToFurniture();
     return;
   }
   setProceduralTableVisible(true);
@@ -5685,6 +5701,7 @@ async function applyTableTheme(
     tableThemeG.visible = true;
     setProceduralTableVisible(false);
     activeTableThemeId = theme.id;
+    syncArenaGroundToFurniture();
   } catch (error) {
     console.warn('Failed to load table theme', error);
     if (theme.id !== DEFAULT_TABLE_THEME_OPTION?.id && DEFAULT_TABLE_THEME_OPTION?.assetId) {
@@ -5711,18 +5728,47 @@ async function applyTableTheme(
         tableThemeG.visible = true;
         setProceduralTableVisible(false);
         activeTableThemeId = DEFAULT_TABLE_THEME_OPTION.id;
+        syncArenaGroundToFurniture();
       } catch (fallbackError) {
         console.warn('Failed to load fallback Poly Haven table theme', fallbackError);
         setProceduralTableVisible(true);
+        syncArenaGroundToFurniture();
       }
     } else {
       setProceduralTableVisible(true);
+      syncArenaGroundToFurniture();
     }
   }
 }
 
 const tableParts = {};
 const chairs = [];
+
+function syncArenaGroundToFurniture() {
+  if (USE_MINIMAL_STAGE || !arenaFloorMesh) return;
+  const floorCandidates = [];
+  const tableRoot = tableThemeG.visible ? tableThemeG : tableG;
+  if (tableRoot?.children?.length) {
+    const tableBounds = new THREE.Box3().setFromObject(tableRoot);
+    if (Number.isFinite(tableBounds.min.y)) {
+      floorCandidates.push(tableBounds.min.y);
+    }
+  }
+  chairs.forEach((chairRoot) => {
+    if (!chairRoot) return;
+    const chairBounds = new THREE.Box3().setFromObject(chairRoot);
+    if (Number.isFinite(chairBounds.min.y)) {
+      floorCandidates.push(chairBounds.min.y);
+    }
+  });
+  if (!floorCandidates.length) return;
+  const groundedY = Math.min(...floorCandidates);
+  arenaFloorMesh.position.y = groundedY;
+  if (arenaCarpetMesh) {
+    arenaCarpetMesh.position.y = groundedY + 0.01;
+  }
+}
+
 let seatLabelMesh = null;
 let seatLabelShouldDisplay = shouldShowSeatLabel;
 const seatAvatars = [];
@@ -7412,6 +7458,7 @@ function placeChairsWithOption(option, chairData, token) {
   });
 
   refreshSeatBadges(seatAvatarSources, buildSeatNames(N));
+  syncArenaGroundToFurniture();
 }
 
 async function buildChairs(

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-04-05-domino-hdri-native-scale-v13';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-04-05-domino-hdri-grounding-v14';
 
 export default function DominoRoyalArena() {
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- Ensure 120 Hz selection uses practical asset/HDRI sizes on phones (4k) but keeps 8k on desktop to balance visual quality and memory/CPU on mobile devices.
- Use authentic PolyHaven HDRI sizes when selecting HDRI assets so the runtime requests the correct resolutions from the manifest.
- Make the table and chairs visually grounded by aligning the arena floor/carpet to the bottom-most bounds of loaded table and chair models.

### Description
- Added a device-class check `IS_HIGH_REFRESH_MOBILE` and made `uhd120` behave differently on touch/mobile devices versus desktop by switching `FRAME_RATE_TEXTURE_SIZE_MAP`, `DOMINO_TEXTURE_SIZE_MAP`, `AVATAR_TEXTURE_SIZE_MAP`, and `FRAME_RATE_MODEL_RESOLUTION_ORDER_MAP` to prefer 4k on mobile and 8k on desktop for 120Hz.
- Updated HDRI selection logic via `resolveGraphicsHdriResolutionId` and `resolveHdriPolicyForFrameRate` so 120Hz on mobile prefers `4k` (and falls back to `2k`), while desktop retains higher native orders (e.g. `8k`, `6k`, `4k`).
- Implemented arena grounding: introduced `arenaFloorMesh`/`arenaCarpetMesh`, added `syncArenaGroundToFurniture()` to compute the lowest `min.y` from table/theme and chairs and reposition the floor/carpet, and call it after table theme loads/fallbacks and after chairs are placed.
- Bumped the script version constant to `2026-04-05-domino-hdri-grounding-v14` so clients load the updated runtime script; primary edits are in `webapp/public/domino-royal-game.js` and the script version bump in `webapp/src/pages/Games/DominoRoyalArena.jsx`.

Files changed: `webapp/public/domino-royal-game.js`, `webapp/src/pages/Games/DominoRoyalArena.jsx`.

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` which passed with no syntax errors.
- Verified build with `cd webapp && npm run build` which completed successfully (Vite emitted non-blocking chunk-size/dynamic-import warnings only).
- Noted `node --check` on the `.jsx` entry is not supported in this environment, so `webapp/src/pages/Games/DominoRoyalArena.jsx` was not `--check` validated by Node directly, but the overall site build succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d295719c9c8329a2927bcd4c5a07d5)