### PR TITLE
Adjust Checkers Battle Royal chair size and piece board contact

### DIFF
--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -272,8 +272,8 @@ const CHAIR_MODEL_URLS = [
   'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/AntiqueChair/glTF-Binary/AntiqueChair.glb'
 ];
 const CHAIR_GROUND_SINK = 0.44;
-// Requested tweak: make chairs about 15% bigger than the current setup.
-const CHAIR_VISUAL_SCALE = 0.92;
+// Visual tuning for portrait screens: make chairs slightly bigger.
+const CHAIR_VISUAL_SCALE = 1.0;
 const CHAIR_TARGET_SCALE_FACTOR = 0.8;
 const TARGET_CHAIR_SIZE = new THREE.Vector3(
   1.3162499970197679 * CHAIR_TARGET_SCALE_FACTOR,
@@ -294,6 +294,8 @@ const TOUCH_TAP_MAX_DURATION_MS = 360;
 const MOUSE_PICK_RADIUS_IN_TILES = 0.58;
 const TOUCH_PICK_RADIUS_IN_TILES = 0.74;
 const CHECKER_PIECE_SCALE = 0.88;
+// Keep chips visually seated on the board surface instead of floating above it.
+const CHECKER_PIECE_SURFACE_OFFSET_MULTIPLIER = 0.035;
 const CHECKERS_HIGHLIGHT_COLORS = Object.freeze({
   selection: '#ff8e6e',
   move: '#7ef9a1',
@@ -1771,7 +1773,7 @@ export default function CheckersBattleRoyal() {
 
           pieceGroup.position.set(
             x + (c - 3.5) * tile,
-            y + tile * 0.1,
+            y + tile * CHECKER_PIECE_SURFACE_OFFSET_MULTIPLIER,
             z + (r - 3.5) * tile
           );
           pieceGroup.userData = { r, c, side: piece.side };
@@ -1808,7 +1810,7 @@ export default function CheckersBattleRoyal() {
           });
           checker.position.set(
             x + centered * tile * CAPTURE_STRIP_PIECE_GAP,
-            y + tile * 0.1,
+            y + tile * CHECKER_PIECE_SURFACE_OFFSET_MULTIPLIER,
             z + edge * (3.5 + CAPTURE_STRIP_OFFSET_ROWS + row * 0.74) * tile
           );
           group.add(checker);


### PR DESCRIPTION
### Motivation
- Improve visual composition on portrait/mobile framing by making chairs slightly larger so they read better against the table and camera framing.
- Ensure checker chips sit flush with the GLTF/procedural board surface so pieces do not appear to float above the board texture.

### Description
- Increased the chair visual scale by changing `CHAIR_VISUAL_SCALE` from `0.92` to `1.0` in `webapp/src/pages/Games/CheckersBattleRoyal.jsx`.
- Added a new constant `CHECKER_PIECE_SURFACE_OFFSET_MULTIPLIER` to control checker chip Y placement near the board surface.
- Replaced the previous hard Y offsets for both active board pieces and captured-strip pieces to use `y + tile * CHECKER_PIECE_SURFACE_OFFSET_MULTIPLIER` so chips sit closer to the board.
- Changes are limited to `webapp/src/pages/Games/CheckersBattleRoyal.jsx` and related build artifacts produced by the app build.

### Testing
- Ran `cd webapp && npm run -s build`, which completed successfully and produced the production build artifacts.
- Build emitted non-blocking Vite chunking warnings unrelated to these visual tweaks, but the build succeeded (no test failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d295cba56483299a7b2f2a0413b553)