### PR TITLE
Pool Royale: broadcast camera & replay adjustments, LT finish and leg leveler fixes

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2482,7 +2482,7 @@ function scaleWoodRepeatVector (repeatVec, scale) {
 const LT_CARBON_TEXTURE_REPEAT = Object.freeze({ x: 16, y: 4 });
 let CARBON_FIBER_TILE_CANVAS = null;
 const CARBON_FIBER_TILE_TEXTURES = new Map();
-const LT_MATTE_PLASTIC_TEXTURE_REPEAT = Object.freeze({ x: 9, y: 3.2 });
+const LT_MATTE_PLASTIC_TEXTURE_REPEAT = Object.freeze({ x: 11.5, y: 4.1 });
 const LT_MATTE_PLASTIC_TEXTURES = new Map();
 
 function createCarbonFiberPatternCanvas(size = 128) {
@@ -2579,7 +2579,7 @@ function applyLtCarbonFiberTexture(material) {
   material.needsUpdate = true;
 }
 
-function getLtMattePlasticTextureSet(tintHex = 0x0c0f14, size = 320) {
+function getLtMattePlasticTextureSet(tintHex = 0x0c0f14, size = 768) {
   if (typeof document === 'undefined') return null;
   const tintColor = new THREE.Color(tintHex);
   const key = `${tintColor.getHexString()}-${size}`;
@@ -2610,22 +2610,22 @@ function getLtMattePlasticTextureSet(tintHex = 0x0c0f14, size = 320) {
   for (let y = 0; y < size; y += 1) {
     for (let x = 0; x < size; x += 1) {
       const i = (y * size + x) * 4;
-      const dither = Math.sin(x * 0.34 + y * 0.26) * 0.5 + Math.cos(x * 0.17 - y * 0.23) * 0.5;
-      const grain = (Math.sin((x + y) * 0.9) + Math.cos((x - y) * 0.78)) * 0.5;
-      const micropit = Math.sin(x * 1.37) * Math.cos(y * 1.49);
-      const colorLift = THREE.MathUtils.clamp(dither * 6 + grain * 4, -16, 16);
-      const boostedR = THREE.MathUtils.lerp(tintR, 255, 0.12);
-      const boostedG = THREE.MathUtils.lerp(tintG, 255, 0.12);
-      const boostedB = THREE.MathUtils.lerp(tintB, 255, 0.12);
+      const dither = Math.sin(x * 0.41 + y * 0.31) * 0.5 + Math.cos(x * 0.23 - y * 0.27) * 0.5;
+      const grain = (Math.sin((x + y) * 1.28) + Math.cos((x - y) * 1.14)) * 0.5;
+      const micropit = Math.sin(x * 2.1) * Math.cos(y * 2.24);
+      const colorLift = THREE.MathUtils.clamp(dither * 5 + grain * 5.8, -12, 18);
+      const boostedR = THREE.MathUtils.lerp(tintR, 255, 0.16);
+      const boostedG = THREE.MathUtils.lerp(tintG, 255, 0.16);
+      const boostedB = THREE.MathUtils.lerp(tintB, 255, 0.16);
       colorImage.data[i] = THREE.MathUtils.clamp(boostedR + colorLift, 0, 255);
       colorImage.data[i + 1] = THREE.MathUtils.clamp(boostedG + colorLift, 0, 255);
       colorImage.data[i + 2] = THREE.MathUtils.clamp(boostedB + colorLift, 0, 255);
       colorImage.data[i + 3] = 255;
-      normalImage.data[i] = THREE.MathUtils.clamp(128 + dither * 18, 0, 255);
-      normalImage.data[i + 1] = THREE.MathUtils.clamp(128 + grain * 18, 0, 255);
-      normalImage.data[i + 2] = THREE.MathUtils.clamp(215 + micropit * 28, 0, 255);
+      normalImage.data[i] = THREE.MathUtils.clamp(128 + dither * 22, 0, 255);
+      normalImage.data[i + 1] = THREE.MathUtils.clamp(128 + grain * 24, 0, 255);
+      normalImage.data[i + 2] = THREE.MathUtils.clamp(208 + micropit * 40, 0, 255);
       normalImage.data[i + 3] = 255;
-      const rough = THREE.MathUtils.clamp(214 + dither * 16 + grain * 12 + micropit * 10, 150, 255);
+      const rough = THREE.MathUtils.clamp(228 + dither * 8 + grain * 8 + micropit * 6, 176, 255);
       roughImage.data[i] = rough;
       roughImage.data[i + 1] = rough;
       roughImage.data[i + 2] = rough;
@@ -2645,7 +2645,7 @@ function getLtMattePlasticTextureSet(tintHex = 0x0c0f14, size = 320) {
     texture.repeat.set(LT_MATTE_PLASTIC_TEXTURE_REPEAT.x, LT_MATTE_PLASTIC_TEXTURE_REPEAT.y);
     texture.generateMipmaps = true;
     texture.minFilter = THREE.LinearMipmapLinearFilter;
-    texture.magFilter = THREE.LinearFilter;
+    texture.magFilter = THREE.NearestFilter;
     texture.anisotropy = resolveTextureAnisotropy(texture.anisotropy ?? 1);
     texture.needsUpdate = true;
     if (idx === 0) {
@@ -3770,7 +3770,8 @@ const BROADCAST_SYSTEM_OPTIONS = Object.freeze([
   }
 ]);
 const DEFAULT_BROADCAST_SYSTEM_ID = 'rail-overhead';
-const RAIL_OVERHEAD_AND_POCKET_CAMERA_ONLY = true; // keep potting sequences on broadcast rail/pocket cameras and avoid 2D top-view cutaways
+const RAIL_OVERHEAD_AND_POCKET_CAMERA_ONLY = false; // allow rail-overhead action switches while keeping broadcast framing in 3D
+const BROADCAST_EXCLUDE_MIDDLE_POCKET_CAMERAS = true; // remove middle-pocket camera cuts from broadcast/replay camera capture
 const resolveBroadcastSystem = (id) =>
   BROADCAST_SYSTEM_OPTIONS.find((opt) => opt.id === id) ??
   BROADCAST_SYSTEM_OPTIONS.find((opt) => opt.id === DEFAULT_BROADCAST_SYSTEM_ID) ??
@@ -11909,7 +11910,12 @@ export function Table3D(
       rubberRing.castShadow = false;
       rubberRing.receiveShadow = true;
       group.add(rubberRing, disc, stem);
-      group.position.set(center.x, ctx.floorY, center.z);
+      const legBottomY =
+        Number.isFinite(ctx?.legY) && Number.isFinite(ctx?.legH)
+          ? ctx.legY - ctx.legH * 0.5
+          : ctx.floorY;
+      const levelerMidY = levelerHeight * 0.5 + rubberHeight;
+      group.position.set(center.x, legBottomY - levelerMidY, center.z);
       tagBasePart(group, 'trim');
       return group;
     });
@@ -21597,6 +21603,9 @@ const powerRef = useRef(hud.power);
           );
           const anchorOutward = getPocketCameraOutward(anchorId);
           const isSidePocket = anchorPocketId === 'TM' || anchorPocketId === 'BM';
+          if (!forceCornerCapture && BROADCAST_EXCLUDE_MIDDLE_POCKET_CAMERAS && isSidePocket) {
+            return null;
+          }
           const triggerDistance = forceCornerCapture
             ? POCKET_CAM_EARLY_TRIGGER_DIST
             : isGuaranteedPocket
@@ -26119,14 +26128,9 @@ const powerRef = useRef(hud.power);
           playCueHit(clampedPower * 0.6);
 
           if (cameraRef.current && sphRef.current) {
-            if (forceImmediateRailOverheadView) {
-              enterTopView(true, { variant: 'rail' });
-              setIsTopDownView(true);
-            } else {
-              topViewRef.current = false;
-              topViewLockedRef.current = false;
-              setIsTopDownView(false);
-            }
+            topViewRef.current = false;
+            topViewLockedRef.current = false;
+            setIsTopDownView(false);
             const sph = sphRef.current;
             const bounds = cameraBoundsRef.current;
             const standingView = bounds?.standing;
@@ -28531,7 +28535,7 @@ const powerRef = useRef(hud.power);
           pottedBalls,
           shotContext
         }) => {
-          if (!recording || !hadObjectPot) return null;
+          if (!recording) return null;
           const tags = new Set(recording.replayTags ?? []);
           if (hadObjectPot) tags.add('pot');
           const potCount = pottedBalls.filter((entry) => entry.id !== 'cue').length;
@@ -28541,8 +28545,9 @@ const powerRef = useRef(hud.power);
           const priority = ['multi', 'bank', 'long', 'power', 'spin'];
           const primary = priority.find((tag) => tags.has(tag)) ?? 'default';
           const zoomOnly = recording.zoomOnly && !tags.has('long') && !tags.has('bank');
+          const shouldReplay = hadObjectPot || Boolean(recording.replayFoul) || tags.size > 0;
           return {
-            shouldReplay: hadObjectPot || tags.size > 0,
+            shouldReplay,
             banner: selectReplayBanner(primary),
             zoomOnly,
             tags: Array.from(tags ?? []),
@@ -28788,13 +28793,18 @@ const powerRef = useRef(hud.power);
           }
           replayBannerText = replayDecision.banner ?? selectReplayBanner('final');
           replayAccent = replayDecision.primaryTag ?? 'final';
-          shouldStartReplay = false;
+          shouldStartReplay =
+            Boolean(replayDecision?.shouldReplay) &&
+            (shotRecording?.frames?.length ?? 0) > 1;
         }
         if (replayDecision && shotRecording) {
           shotRecording.replayTags = replayDecision.tags;
           shotRecording.zoomOnly = replayDecision.zoomOnly;
         }
-        shouldStartReplay = false;
+        shouldStartReplay =
+          shouldStartReplay &&
+          Boolean(replayDecision?.shouldReplay) &&
+          (shotRecording?.frames?.length ?? 0) > 1;
         const shooterSeat = currentState?.activePlayer === 'B' ? 'B' : 'A';
         if (potted.length) {
           const newPots = potted.filter(


### PR DESCRIPTION
### Motivation
- Align broadcast/replay behavior with live production needs by removing undesirable middle-pocket and 2D/top-down cutaways, and ensure replays appear for fouls and pot events with the same broadcast framing.
- Improve LT table finish visuals to be brighter, crisper and less blurry for higher perceived quality on mobile screens.
- Precisely position rounded metallic leg levelers so they sit exactly at the bottom/center of classic cylindrical legs.

### Description
- Disable middle-pocket camera cuts for broadcast/replay by adding `BROADCAST_EXCLUDE_MIDDLE_POCKET_CAMERAS` and returning `null` from `makePocketCameraView` when the anchor pocket is a side/middle pocket and exclusion is enabled (file: `webapp/src/pages/Games/PoolRoyale.jsx`).
- Keep live shot camera switching in 3D by preventing the immediate top-down/rail variant transition during a shot and forcing the orbit/state to stay in 3D framing (file: `webapp/src/pages/Games/PoolRoyale.jsx`).
- Improve replay gating: `resolveReplayDecision` no longer requires `hadObjectPot` for a decision, includes `recording.replayFoul` as a trigger, sets `shouldReplay` accordingly, and arms `shouldStartReplay` only when a valid recording with frames exists (file: `webapp/src/pages/Games/PoolRoyale.jsx`).
- Tune LT matte/plastic finish generation: increase procedural texture resolution from `320`→`768`, increase pattern repeat, refine dither/grain/micropit parameters, adjust normal/roughness amplitudes, and use `NearestFilter` for `magFilter` to sharpen the pattern (file: `webapp/src/pages/Games/PoolRoyale.jsx`).
- Reposition leg leveler groups so the chrome leveler geometry is placed relative to the leg bottom centerline using `ctx.legY`/`ctx.legH` and computed `levelerMidY`, improving alignment for `classicCylinders` and `openPortal` bases (file: `webapp/src/pages/Games/PoolRoyale.jsx`).

### Testing
- Ran unit tests: `npm run test -- poolRoyaleSpinController.test.js` and the suite passed (`PASS`, 7/7 tests).
- No other automated tests were executed in this change; visual verification (screenshots) was not produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d28f7744b88329b58871bdf492d502)