### PR TITLE
Add hexagon table support to Texas Hold'em menu and store

### DIFF
--- a/test/texasHoldemInventoryConfig.test.js
+++ b/test/texasHoldemInventoryConfig.test.js
@@ -40,4 +40,11 @@ describe("Texas Hold'em HDRI inventory", () => {
       expect(storeHdriIds.has(id)).toBe(true);
     });
   });
+
+  test('includes hexagon table shape in store purchasables', () => {
+    const texasShapeIds = new Set(
+      TEXAS_HOLDEM_STORE_ITEMS.filter((item) => item.type === 'tableShape').map((item) => item.optionId)
+    );
+    expect(texasShapeIds.has('hexagonTable')).toBe(true);
+  });
 });

--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -810,7 +810,8 @@ const CUSTOMIZATION_SECTIONS = [
   { key: 'cards', label: 'Cards', options: CARD_THEMES },
   { key: 'environmentHdri', label: 'HDRI Environment', options: TEXAS_HDRI_OPTIONS }
 ];
-const TABLE_STYLE_MENU_THEME_IDS = new Set(['murlan-default', 'diamondEdge', 'ovalTable']);
+const TABLE_STYLE_MENU_THEME_IDS = new Set(['murlan-default', 'diamondEdge', 'ovalTable', 'hexagonTable']);
+const TABLE_STYLE_MENU_SHAPE_IDS = new Set(['classicOctagon', 'grandOval', 'diamondEdge', 'hexagonTable']);
 
 const NON_DIAMOND_SHAPE_INDEX = (() => {
   const index = TABLE_SHAPE_OPTIONS.findIndex((option) => option.id !== DIAMOND_SHAPE_ID);
@@ -3303,9 +3304,12 @@ function TexasHoldemArena({ search }) {
         .filter((section) => {
           if (section.key !== 'tableFinish' && section.key !== 'tableCloth') return true;
           const tableTheme = TEXAS_TABLE_THEME_OPTIONS[appearance.tableTheme] ?? TEXAS_TABLE_THEME_OPTIONS[0];
-          return TABLE_STYLE_MENU_THEME_IDS.has(tableTheme?.id);
+          const tableShape = TABLE_SHAPE_OPTIONS[appearance.tableShape] ?? TABLE_SHAPE_OPTIONS[0];
+          const proceduralThemeSupportsSurface =
+            tableTheme?.source === 'procedural' && TABLE_STYLE_MENU_SHAPE_IDS.has(tableShape?.id);
+          return TABLE_STYLE_MENU_THEME_IDS.has(tableTheme?.id) || proceduralThemeSupportsSurface;
         }),
-    [appearance.tableTheme, texasInventory]
+    [appearance.tableShape, appearance.tableTheme, texasInventory]
   );
   const [frameRateId, setFrameRateId] = useState(() => {
     if (typeof window !== 'undefined') {


### PR DESCRIPTION
### Motivation
- Expose the new hexagon procedural table shape in the Texas Hold'em customization UI so it behaves like the existing octagon/oval/diamond shapes and allows surface customization (cloth/finish).

### Description
- Added `hexagonTable` to the theme allow-list used for showing table finish/cloth options and introduced `TABLE_STYLE_MENU_SHAPE_IDS` to mark shapes that support surface customization in `webapp/src/pages/Games/TexasHoldemArena.jsx`.
- Updated the customization section filter to consider the selected `tableShape` when deciding visibility of `tableFinish` and `tableCloth` so procedural table themes (including `hexagonTable`) keep the same menu logic as other special shapes.
- Added a regression test `test/texasHoldemInventoryConfig.test.js` to assert `hexagonTable` is present among purchasable `tableShape` store items.

### Testing
- Ran `npm test -- test/texasHoldemInventoryConfig.test.js --runInBand` and the suite passed (3 tests, all green).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d29c9e862483299dd0375b9be8e483)