### PR TITLE
Default to hexagon table, support 8-player octagon seating and lobby update

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -267,8 +267,10 @@ const AI_CHAIR_GAP = CARD_W * 0.4;
 const AI_CHAIR_RADIUS = TABLE_RADIUS + SEAT_DEPTH / 2 + AI_CHAIR_GAP;
 const DEFAULT_PLAYER_COUNT = 6;
 const MIN_PLAYER_COUNT = 2;
-const MAX_PLAYER_COUNT = 6;
+const MAX_PLAYER_COUNT = 8;
 const DIAMOND_SHAPE_ID = 'diamondEdge';
+const CLASSIC_OCTAGON_SHAPE_ID = 'classicOctagon';
+const HEXAGON_SHAPE_ID = 'hexagonTable';
 // Keep betting units aligned with the 2D classic experience (public/texas-holdem.js uses ANTE = 10).
 const CLASSIC_ANTE = 10;
 const ANTE = CLASSIC_ANTE;
@@ -813,14 +815,34 @@ const CUSTOMIZATION_SECTIONS = [
 const TABLE_STYLE_MENU_THEME_IDS = new Set(['murlan-default', 'diamondEdge', 'ovalTable', 'hexagonTable']);
 const TABLE_STYLE_MENU_SHAPE_IDS = new Set(['classicOctagon', 'grandOval', 'diamondEdge', 'hexagonTable']);
 
+const HEXAGON_SHAPE_INDEX = (() => {
+  const index = TABLE_SHAPE_OPTIONS.findIndex((option) => option.id === HEXAGON_SHAPE_ID);
+  return index >= 0 ? index : 0;
+})();
+
+const CLASSIC_OCTAGON_SHAPE_INDEX = (() => {
+  const index = TABLE_SHAPE_OPTIONS.findIndex((option) => option.id === CLASSIC_OCTAGON_SHAPE_ID);
+  return index >= 0 ? index : 0;
+})();
+
 const NON_DIAMOND_SHAPE_INDEX = (() => {
   const index = TABLE_SHAPE_OPTIONS.findIndex((option) => option.id !== DIAMOND_SHAPE_ID);
   return index >= 0 ? index : 0;
 })();
 
+DEFAULT_APPEARANCE.tableShape = HEXAGON_SHAPE_INDEX;
+
 function enforceShapeForPlayers(appearance, playerCount) {
   const safe = { ...appearance };
   const shapeOption = TABLE_SHAPE_OPTIONS[safe.tableShape];
+  if (playerCount >= MAX_PLAYER_COUNT) {
+    safe.tableShape = CLASSIC_OCTAGON_SHAPE_INDEX;
+    return safe;
+  }
+  if (shapeOption?.id === CLASSIC_OCTAGON_SHAPE_ID) {
+    safe.tableShape = HEXAGON_SHAPE_INDEX;
+    return safe;
+  }
   if (playerCount > 4 && shapeOption?.id === DIAMOND_SHAPE_ID) {
     safe.tableShape = NON_DIAMOND_SHAPE_INDEX;
   }
@@ -830,6 +852,14 @@ function enforceShapeForPlayers(appearance, playerCount) {
 function getEffectiveShapeConfig(shapeIndex, playerCount) {
   const fallback = TABLE_SHAPE_OPTIONS[NON_DIAMOND_SHAPE_INDEX] ?? TABLE_SHAPE_OPTIONS[0];
   const requested = TABLE_SHAPE_OPTIONS[shapeIndex] ?? fallback;
+  if (playerCount >= MAX_PLAYER_COUNT) {
+    const octagon = TABLE_SHAPE_OPTIONS[CLASSIC_OCTAGON_SHAPE_INDEX] ?? fallback;
+    return { option: octagon, rotationY: 0, forced: requested?.id !== octagon?.id };
+  }
+  if (requested?.id === CLASSIC_OCTAGON_SHAPE_ID) {
+    const hexagon = TABLE_SHAPE_OPTIONS[HEXAGON_SHAPE_INDEX] ?? fallback;
+    return { option: hexagon, rotationY: 0, forced: true };
+  }
   if (requested?.id === DIAMOND_SHAPE_ID && playerCount > 4) {
     return { option: fallback, rotationY: 0, forced: true };
   }
@@ -956,21 +986,46 @@ function buildClassicOctagonAngles(count) {
     (7 * Math.PI) / 8,
     (5 * Math.PI) / 8
   ];
-  // Skip the two slots that sit immediately to the human player's left and right
-  // so opponents remain on the flat edges in front of the user.
-  const preferredSlots = [0, 2, 3, 4, 5, 6];
+  // Keep existing slot order for 6-handed tables and append the two seats
+  // next to the human player for 7-8 handed tables.
+  const preferredSlots = [0, 2, 3, 4, 5, 6, 1, 7];
+  const fallbackAngleStep = (Math.PI * 2) / Math.max(safeCount, 1);
   const angles = [];
   for (let i = 0; i < safeCount; i += 1) {
     const slotIndex = preferredSlots[i];
     if (slotIndex == null) {
-      const fallbackAngle =
-        Math.PI / 2 - HUMAN_SEAT_ROTATION_OFFSET - (i / safeCount) * Math.PI * 2;
+      const fallbackAngle = slotAngles[0] - i * fallbackAngleStep;
       angles.push(fallbackAngle);
     } else {
       angles.push(slotAngles[slotIndex]);
     }
   }
   return angles;
+}
+
+function buildHexagonSeatAngles(count) {
+  if (!Number.isFinite(count) || count <= 0) {
+    return [];
+  }
+  const safeCount = Math.max(1, Math.floor(count));
+  const sideCenterAngles = [
+    -Math.PI / 2,
+    -Math.PI / 6,
+    Math.PI / 6,
+    Math.PI / 2,
+    (5 * Math.PI) / 6,
+    (-5 * Math.PI) / 6
+  ];
+  if (safeCount <= sideCenterAngles.length) {
+    return sideCenterAngles.slice(0, safeCount);
+  }
+  const extraCount = safeCount - sideCenterAngles.length;
+  const extras = [];
+  for (let i = 0; i < extraCount; i += 1) {
+    const t = (i + 1) / (extraCount + 1);
+    extras.push(THREE.MathUtils.lerp(Math.PI / 2, (5 * Math.PI) / 6, t));
+  }
+  return [...sideCenterAngles.slice(0, 4), ...extras, ...sideCenterAngles.slice(4)];
 }
 
 function normalizeAppearance(value = {}) {
@@ -2025,12 +2080,14 @@ function createSeatLayout(count, tableInfo = null, options = {}) {
   const cardinalAngles = useCardinal ? buildCardinalSeatAngles(safeCount) : null;
   const classicAngles =
     tableInfo?.shapeId === 'classicOctagon' ? buildClassicOctagonAngles(safeCount) : null;
+  const hexagonAngles =
+    tableInfo?.shapeId === HEXAGON_SHAPE_ID ? buildHexagonSeatAngles(safeCount) : null;
   const seatLayerDrop = NON_CLASSIC_TABLE_PLAYER_LAYER_LOCKED_SHAPES.has(tableInfo?.shapeId)
     ? 0
     : NON_CLASSIC_TABLE_PLAYER_LAYER_DROP;
   for (let i = 0; i < safeCount; i += 1) {
     const baseAngle = Math.PI / 2 - HUMAN_SEAT_ROTATION_OFFSET + (i / safeCount) * Math.PI * 2;
-    const angle = classicAngles?.[i] ?? cardinalAngles?.[i] ?? baseAngle;
+    const angle = classicAngles?.[i] ?? hexagonAngles?.[i] ?? cardinalAngles?.[i] ?? baseAngle;
     const isHuman = i === 0;
     const isBottomSideOpponent = !isHuman && (i === 1 || i === safeCount - 1);
     const forward = new THREE.Vector3(Math.cos(angle), 0, Math.sin(angle));
@@ -6608,7 +6665,12 @@ function TexasHoldemArena({ search }) {
                       {options.map((option) => {
                         const selected = appearance[key] === option.idx;
                         const disabled =
-                          key === 'tableShape' && option.id === DIAMOND_SHAPE_ID && effectivePlayerCount > 4;
+                          key === 'tableShape' &&
+                          (
+                            (option.id === DIAMOND_SHAPE_ID && effectivePlayerCount > 4) ||
+                            (option.id === CLASSIC_OCTAGON_SHAPE_ID && effectivePlayerCount < MAX_PLAYER_COUNT) ||
+                            (option.id !== CLASSIC_OCTAGON_SHAPE_ID && effectivePlayerCount >= MAX_PLAYER_COUNT)
+                          );
                         return (
                           <button
                             key={option.id}

--- a/webapp/src/pages/Games/TexasHoldemLobby.jsx
+++ b/webapp/src/pages/Games/TexasHoldemLobby.jsx
@@ -42,7 +42,7 @@ export default function TexasHoldemLobby() {
   const [cleanupMatch, setCleanupMatch] = useState(() => () => {});
   const startBet = stake.amount / 100;
 
-  const totalPlayers = Math.min(Math.max(2, opponents + 1), 6);
+  const totalPlayers = Math.min(Math.max(2, opponents + 1), 8);
   const flagPickerCount = mode === 'local' ? totalPlayers : 1;
 
   const openAiFlagPicker = () => {
@@ -204,11 +204,11 @@ export default function TexasHoldemLobby() {
             </div>
             <div>
               <h3 className="text-lg font-semibold text-white">Opponents</h3>
-              <p className="text-xs text-white/60">Choose how many players you want to face.</p>
+              <p className="text-xs text-white/60">Choose how many players you want to face (up to 8 total players).</p>
             </div>
           </div>
-          <div className="mt-4 grid grid-cols-5 gap-2">
-            {Array.from({ length: 5 }, (_, idx) => idx + 1).map((count) => {
+          <div className="mt-4 grid grid-cols-4 gap-2">
+            {Array.from({ length: 7 }, (_, idx) => idx + 1).map((count) => {
               const isSelected = opponents === count;
               return (
                 <button


### PR DESCRIPTION
### Motivation
- Use the hexagon table as the default layout for standard Texas Hold'em games and keep chairs/cards/chips anchored to the straight sides of the hexagon.
- Only use the classic octagon shape when an 8-player table is selected so the extra two seats can be placed next to the bottom/human player without altering existing seats.
- Allow up to 8 players from the lobby UI and automatically use the octagon layout for 8-player games.

### Description
- Increased `MAX_PLAYER_COUNT` from `6` to `8` and updated lobby/player clamping to allow up to 8 total players (`webapp/src/pages/Games/TexasHoldemArena.jsx`, `webapp/src/pages/Games/TexasHoldemLobby.jsx`).
- Set hexagon as the default table shape by initializing `DEFAULT_APPEARANCE.tableShape` to the hexagon shape index and added constants for shape IDs/indices (`HEXAGON_SHAPE_ID`, `CLASSIC_OCTAGON_SHAPE_ID`, `HEXAGON_SHAPE_INDEX`, `CLASSIC_OCTAGON_SHAPE_INDEX`).
- Updated shape enforcement logic in `enforceShapeForPlayers` and `getEffectiveShapeConfig` so the octagon is forced only for 8-player tables and hexagon is used for other counts; prevented invalid shape selections for given player counts.
- Added `buildHexagonSeatAngles` and integrated hexagon seat-angle handling into `createSeatLayout`, and updated `buildClassicOctagonAngles` to preserve existing 6-seat order and append the two extra seats next to the bottom/human seat for 7–8 player tables, so chairs/cards/chips align with straight sides.
- Constrained the customization UI so table-shape options are disabled appropriately by player count, and updated the lobby UI to present opponent choices up to 7 opponents (8 players total) and clarified copy (`webapp/src/pages/Games/TexasHoldemLobby.jsx`).

### Testing
- Ran `npm run build` which completed successfully (TypeScript build via `tsc`).
- Ran `npx eslint webapp/src/pages/Games/TexasHoldemArena.jsx webapp/src/pages/Games/TexasHoldemLobby.jsx` which reported the files are ignored by repo lint patterns (no lint errors in changed logic were reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2a410322483299f23744a8bd035d7)