### PR TITLE
Round rails/legs and tweak textures, broadcast & camera logic in PoolRoyale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -806,7 +806,7 @@ const CHROME_CORNER_POCKET_EDGE_ROUND_SCALE = 0.9; // strongly round the outer c
 const CHROME_SIDE_POCKET_RADIUS_SCALE =
   CORNER_POCKET_INWARD_SCALE *
   CHROME_CORNER_POCKET_RADIUS_SCALE; // match the middle chrome arches to the corner pocket radius
-const WOOD_RAIL_CORNER_RADIUS_SCALE = 0; // keep the wooden rail edges squared off for a straight outside angle
+const WOOD_RAIL_CORNER_RADIUS_SCALE = 0.12; // softly round only the exterior wooden rail corners while preserving interior cushion/pocket geometry
 const CHROME_SIDE_NOTCH_THROAT_SCALE = 0; // disable secondary throat so the side chrome uses a single arch
 const CHROME_SIDE_NOTCH_HEIGHT_SCALE = 0.85; // reuse snooker notch height profile
 const CHROME_SIDE_NOTCH_RADIUS_SCALE = 1;
@@ -1610,7 +1610,7 @@ const CUSHION_HEIGHT_DROP = TABLE.THICK * 0.01; // trim the cushion tops a touch
 const CUSHION_FIELD_CLIP_RATIO = 0.152; // trim the cushion extrusion right at the cloth plane so no geometry sinks underneath the surface
 const SIDE_RAIL_EXTRA_DEPTH = TABLE.THICK * 1.12; // deepen side aprons so the lower edge flares out more prominently
 const END_RAIL_EXTRA_DEPTH = SIDE_RAIL_EXTRA_DEPTH; // drop the end rails to match the side apron depth
-const RAIL_OUTER_EDGE_RADIUS_RATIO = 0; // keep exterior wooden rail edges straight so frame sides read with clean angles
+const RAIL_OUTER_EDGE_RADIUS_RATIO = 0.085; // round exterior wooden rail edge profile to remove sharp octagon-like corners
 const POCKET_RECESS_DEPTH =
   BALL_R * 0.24; // keep the pocket throat visible without sinking the rim
 const POCKET_DROP_GRAVITY = 42; // steeper gravity for a natural fall into the leather cradle
@@ -2645,7 +2645,7 @@ function getLtMattePlasticTextureSet(tintHex = 0x0c0f14, size = 320) {
     texture.repeat.set(LT_MATTE_PLASTIC_TEXTURE_REPEAT.x, LT_MATTE_PLASTIC_TEXTURE_REPEAT.y);
     texture.generateMipmaps = true;
     texture.minFilter = THREE.LinearMipmapLinearFilter;
-    texture.magFilter = THREE.LinearFilter;
+    texture.magFilter = THREE.NearestFilter;
     texture.anisotropy = resolveTextureAnisotropy(texture.anisotropy ?? 1);
     texture.needsUpdate = true;
     if (idx === 0) {
@@ -3770,7 +3770,8 @@ const BROADCAST_SYSTEM_OPTIONS = Object.freeze([
   }
 ]);
 const DEFAULT_BROADCAST_SYSTEM_ID = 'rail-overhead';
-const RAIL_OVERHEAD_AND_POCKET_CAMERA_ONLY = true; // keep potting sequences on broadcast rail/pocket cameras and avoid 2D top-view cutaways
+const RAIL_OVERHEAD_AND_POCKET_CAMERA_ONLY = false; // allow rail-overhead action switches while keeping broadcast framing in 3D
+const BROADCAST_EXCLUDE_MIDDLE_POCKET_CAMERAS = true; // remove middle-pocket camera cuts from broadcast/replay camera capture
 const resolveBroadcastSystem = (id) =>
   BROADCAST_SYSTEM_OPTIONS.find((opt) => opt.id === id) ??
   BROADCAST_SYSTEM_OPTIONS.find((opt) => opt.id === DEFAULT_BROADCAST_SYSTEM_ID) ??
@@ -11909,7 +11910,12 @@ export function Table3D(
       rubberRing.castShadow = false;
       rubberRing.receiveShadow = true;
       group.add(rubberRing, disc, stem);
-      group.position.set(center.x, ctx.floorY, center.z);
+      const legBottomY =
+        Number.isFinite(ctx?.legY) && Number.isFinite(ctx?.legH)
+          ? ctx.legY - ctx.legH * 0.5
+          : ctx.floorY;
+      const levelerMidY = levelerHeight * 0.5 + rubberHeight;
+      group.position.set(center.x, legBottomY - levelerMidY, center.z);
       tagBasePart(group, 'trim');
       return group;
     });
@@ -11972,7 +11978,17 @@ export function Table3D(
       const thickness = ctx.legR;
       const legWidth = thickness * 1.35;
       const legHeight = ctx.legH * 0.94;
-      const legGeom = new THREE.BoxGeometry(legWidth, legHeight, frameDepth);
+      const portalLegRadius = Math.max(
+        0.005,
+        Math.min(legWidth, frameDepth) * 0.22
+      );
+      const legGeom = new RoundedBoxGeometry(
+        legWidth,
+        legHeight,
+        frameDepth,
+        6,
+        portalLegRadius
+      );
       const legOffsetX = Math.max(
         legWidth * 0.5,
         frameWidth - legWidth * 0.65 - PORTAL_LEG_CENTER_PULL
@@ -21597,6 +21613,9 @@ const powerRef = useRef(hud.power);
           );
           const anchorOutward = getPocketCameraOutward(anchorId);
           const isSidePocket = anchorPocketId === 'TM' || anchorPocketId === 'BM';
+          if (!forceCornerCapture && BROADCAST_EXCLUDE_MIDDLE_POCKET_CAMERAS && isSidePocket) {
+            return null;
+          }
           const triggerDistance = forceCornerCapture
             ? POCKET_CAM_EARLY_TRIGGER_DIST
             : isGuaranteedPocket
@@ -26119,14 +26138,9 @@ const powerRef = useRef(hud.power);
           playCueHit(clampedPower * 0.6);
 
           if (cameraRef.current && sphRef.current) {
-            if (forceImmediateRailOverheadView) {
-              enterTopView(true, { variant: 'rail' });
-              setIsTopDownView(true);
-            } else {
-              topViewRef.current = false;
-              topViewLockedRef.current = false;
-              setIsTopDownView(false);
-            }
+            topViewRef.current = false;
+            topViewLockedRef.current = false;
+            setIsTopDownView(false);
             const sph = sphRef.current;
             const bounds = cameraBoundsRef.current;
             const standingView = bounds?.standing;
@@ -26238,6 +26252,8 @@ const powerRef = useRef(hud.power);
           );
           let holdUntil = powerImpactHoldRef.current || 0;
           const now = performance.now();
+          powerImpactHoldRef.current = 0;
+          holdUntil = 0;
           if (earlyPocketView?.forcedEarly) {
             const earlyHold = now + POCKET_VIEW_EARLY_HOLD_MS;
             if (!holdUntil || holdUntil > earlyHold) {
@@ -26245,7 +26261,6 @@ const powerRef = useRef(hud.power);
               powerImpactHoldRef.current = earlyHold;
             }
           }
-          const holdActive = holdUntil > now;
           let pocketViewActivated = false;
           if (earlyPocketView) {
             earlyPocketView.lastUpdate = now;
@@ -26263,13 +26278,11 @@ const powerRef = useRef(hud.power);
             } else {
               suspendedActionView = null;
             }
-            queuedPocketView = null;
-            earlyPocketView.pendingActivation = false;
+            earlyPocketView.pendingActivation = true;
             earlyPocketView.activationDelay = null;
-            powerImpactHoldRef.current = 0;
-            updatePocketCameraState(true);
-            activeShotView = earlyPocketView;
-            pocketViewActivated = true;
+            queuedPocketView = earlyPocketView;
+            updatePocketCameraState(false);
+            pocketViewActivated = false;
           }
           if (!pocketViewActivated && actionView) {
             const cameraHoldUntil = Math.max(
@@ -26282,33 +26295,28 @@ const powerRef = useRef(hud.power);
               !requiresCueBallMovementTrigger &&
               (!isLongShot || forceActionActivation) &&
               !isMaxPowerShot;
-            if (shouldActivateActionView && (!holdActive || forceImmediateRailOverheadView)) {
-              actionView.pendingActivation = false;
-              actionView.activationDelay = null;
-              actionView.activationTravel = 0;
-              actionView.strokeReadyAt = 0;
-              suspendedActionView = null;
-              activeShotView = actionView;
-              updateCamera();
-            } else {
-              actionView.pendingActivation = true;
-              const baseDelay = actionView.activationDelay ?? null;
-              const delayed = requiresCueBallMovementTrigger
-                ? baseDelay ?? 0
-                : Math.max(baseDelay ?? 0, holdUntil ?? 0);
-              actionView.activationDelay = delayed > 0 ? delayed : null;
-              actionView.strokeReadyAt = strokeReadyAt;
-              const baseTravel = actionView.activationTravel ?? 0;
-              actionView.activationTravel = Math.max(
-                baseTravel,
-                requiresCueBallMovementTrigger
-                  ? CUEBALL_CAMERA_SWITCH_MIN_TRAVEL
+            actionView.pendingActivation = true;
+            const baseDelay = actionView.activationDelay ?? null;
+            const delayed = requiresCueBallMovementTrigger ? baseDelay ?? 0 : now;
+            actionView.activationDelay = delayed > 0 ? delayed : null;
+            actionView.strokeReadyAt = shouldActivateActionView ? strokeReadyAt : now + 1;
+            const baseTravel = actionView.activationTravel ?? 0;
+            actionView.activationTravel = Math.max(
+              baseTravel,
+              requiresCueBallMovementTrigger
+                ? CUEBALL_CAMERA_SWITCH_MIN_TRAVEL
+                : forceImmediateRailOverheadView
+                  ? 0
                   : isMaxPowerShot
                     ? BALL_R * 6
                     : 0
-              );
-              suspendedActionView = actionView;
+            );
+            if (forceImmediateRailOverheadView) {
+              powerImpactHoldRef.current = 0;
+              actionView.activationDelay = now;
+              actionView.strokeReadyAt = now;
             }
+            suspendedActionView = actionView;
           }
           openingShotViewSuppressedRef.current = false;
           if (ENABLE_CUE_STROKE_ANIMATION && shotRecording) {
@@ -28531,7 +28539,7 @@ const powerRef = useRef(hud.power);
           pottedBalls,
           shotContext
         }) => {
-          if (!recording || !hadObjectPot) return null;
+          if (!recording) return null;
           const tags = new Set(recording.replayTags ?? []);
           if (hadObjectPot) tags.add('pot');
           const potCount = pottedBalls.filter((entry) => entry.id !== 'cue').length;
@@ -28541,8 +28549,9 @@ const powerRef = useRef(hud.power);
           const priority = ['multi', 'bank', 'long', 'power', 'spin'];
           const primary = priority.find((tag) => tags.has(tag)) ?? 'default';
           const zoomOnly = recording.zoomOnly && !tags.has('long') && !tags.has('bank');
+          const shouldReplay = hadObjectPot || Boolean(recording.replayFoul) || tags.size > 0;
           return {
-            shouldReplay: hadObjectPot || tags.size > 0,
+            shouldReplay,
             banner: selectReplayBanner(primary),
             zoomOnly,
             tags: Array.from(tags ?? []),
@@ -28788,13 +28797,18 @@ const powerRef = useRef(hud.power);
           }
           replayBannerText = replayDecision.banner ?? selectReplayBanner('final');
           replayAccent = replayDecision.primaryTag ?? 'final';
-          shouldStartReplay = false;
+          shouldStartReplay =
+            Boolean(replayDecision?.shouldReplay) &&
+            (shotRecording?.frames?.length ?? 0) > 1;
         }
         if (replayDecision && shotRecording) {
           shotRecording.replayTags = replayDecision.tags;
           shotRecording.zoomOnly = replayDecision.zoomOnly;
         }
-        shouldStartReplay = false;
+        const replayEventDetected = shotWasFoul || hadObjectPot;
+        shouldStartReplay =
+          Boolean(replayDecision?.shouldReplay || replayEventDetected) &&
+          (shotRecording?.frames?.length ?? 0) >= 1;
         const shooterSeat = currentState?.activePlayer === 'B' ? 'B' : 'A';
         if (potted.length) {
           const newPots = potted.filter(
@@ -30632,7 +30646,12 @@ const powerRef = useRef(hud.power);
             const strokeReadyAt = suspendedActionView.strokeReadyAt ?? 0;
             const strokeSettled = now >= strokeReadyAt;
             const cueMoving = cueSpeed >= CUEBALL_CAMERA_SWITCH_MIN_SPEED;
-            const cueTravelReady = travel >= CUEBALL_CAMERA_SWITCH_MIN_TRAVEL;
+            const cueTravelReady =
+              travel >=
+              Math.max(
+                0,
+                suspendedActionView.activationTravel ?? CUEBALL_CAMERA_SWITCH_MIN_TRAVEL
+              );
             if (travelReady && delayReady && holdReady && strokeSettled && cueMoving && cueTravelReady) {
               const pending = suspendedActionView;
               pending.pendingActivation = false;


### PR DESCRIPTION
### Motivation
- Improve visual polish by softening exterior wood/rail corners and using rounded portal legs to remove harsh angles.
- Fix leg leveler vertical placement to use computed leg geometry when available instead of a fixed floor Y.
- Reduce texture blurring on matte plastic surfaces and stabilize camera/broadcast behavior by changing pocket/replay activation rules.

### Description
- Softened wooden rail exterior geometry by setting `WOOD_RAIL_CORNER_RADIUS_SCALE` to `0.12` and `RAIL_OUTER_EDGE_RADIUS_RATIO` to `0.085`.
- Replaced portal leg `BoxGeometry` with `RoundedBoxGeometry` and introduced `portalLegRadius` for smoother leg corners.
- Adjusted leveler group placement in `createLegLevelerSet` to compute `legBottomY` from `ctx.legY` and `ctx.legH` when available and offset the leveler by `levelerMidY`.
- Changed matte plastic texture sampling from `THREE.LinearFilter` to `THREE.NearestFilter` for `magFilter` in `getLtMattePlasticTextureSet`.
- Altered broadcast/camera flags: set `RAIL_OVERHEAD_AND_POCKET_CAMERA_ONLY` to `false` and added `BROADCAST_EXCLUDE_MIDDLE_POCKET_CAMERAS = true` to remove middle-pocket camera cuts from broadcast/replay.
- Prevented early activation of middle/side pocket cameras when excluded, and reworked early pocket view queuing and action view activation logic to use `pendingActivation`/`activationDelay`/`activationTravel` consistently and to respect `suspendedActionView.activationTravel` when deciding cue-travel readiness.
- Reset pocket/camera hold timers (`powerImpactHoldRef`) at stroke start to avoid stale holds, and simplified the top-view toggle after a strike so it no longer forces a rail/top view.
- Refined replay decision logic in `resolveReplayDecision` to consider `recording.replayFoul` and to gate automatic replay start on `replayDecision.shouldReplay` and recorded frame counts.

### Testing
- Ran the repository linting with `yarn lint` and the test suite with `yarn test`, both of which completed successfully.
- Performed a production build with `yarn build` to validate bundling, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d28f7744b88329b58871bdf492d502)