### PR TITLE
Lock Pool Royale shot camera to player-set framing at stroke start

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -25884,6 +25884,23 @@ const powerRef = useRef(hud.power);
             y: appliedSpinSnapshot.y ?? 0
           }
         };
+        const focusStoreAtShot = ensureOrbitFocus();
+        focusStoreAtShot.ballId = null;
+        const shotFocusScale =
+          Number.isFinite(worldScaleFactor) && Math.abs(worldScaleFactor) > 1e-6
+            ? worldScaleFactor
+            : WORLD_SCALE;
+        const lockedShotTargetWorld =
+          lastCameraTargetRef.current?.clone?.() ??
+          cameraRef.current?.position?.clone?.() ??
+          new THREE.Vector3(
+            playerOffsetRef.current,
+            ORBIT_FOCUS_BASE_Y,
+            0
+          ).multiplyScalar(shotFocusScale);
+        focusStoreAtShot.target.copy(
+          lockedShotTargetWorld.clone().divideScalar(shotFocusScale)
+        );
         setShootingState(true);
         powerImpactHoldRef.current = Math.max(
           powerImpactHoldRef.current || 0,


### PR DESCRIPTION
### Motivation
- Prevent the live camera from chasing or zooming on the cue ball during a shot and keep the camera exactly where the player left it when they fire. 
- Preserve existing broadcast behavior (rail-overhead and pocket cameras) while making the player’s selected framing the baseline for the shot.

### Description
- At shot start capture and lock the orbit focus by calling `ensureOrbitFocus()` and clearing `orbitFocus.ballId` so the orbit focus will not switch to the cue ball. 
- Compute a safe focus target using `lastCameraTargetRef`, `cameraRef.position`, or a default `playerOffset` and copy it into the orbit focus store (taking `worldScaleFactor` / `WORLD_SCALE` into account). 
- Changes are localized to `webapp/src/pages/Games/PoolRoyale.jsx` around the shot-start handling code so broadcast camera transitions remain unchanged. 

### Testing
- Ran `npm test -- test/poolRoyaleOnlineFlow.test.js --runInBand` and the suite passed. 
- The modified tests run completed successfully with the `poolRoyaleOnlineFlow` suite passing all assertions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d33a7a4e48832982591c02bab082f0)