### PR TITLE
Anchor broadcast/pocket cameras to avoid dynamic ball-follow

### DIFF
--- a/billiards.Unity/CueCamera.cs
+++ b/billiards.Unity/CueCamera.cs
@@ -342,7 +342,6 @@ public class CueCamera : MonoBehaviour
         if (target != null && target.gameObject.activeInHierarchy)
         {
             currentBall = target;
-            targetViewFocus = GetBroadcastFocus(target.position);
         }
         targetViewYaw = GetShortRailYaw(broadcastSideSign);
         yaw = targetViewYaw;
@@ -766,7 +765,9 @@ public class CueCamera : MonoBehaviour
             pocketCameraStartTime = Time.time;
             pocketCameraReleaseTime = float.PositiveInfinity;
             trackedCornerPocket = cornerPocket;
-            targetViewFocus = GetBroadcastFocus(TargetBall.position);
+            // Keep pocket framing anchored to the tracked pocket so the
+            // transition does not chase the travelling balls.
+            targetViewFocus = GetBroadcastFocus(cornerPocket);
             UpdateTargetCamera();
             return;
         }
@@ -797,7 +798,6 @@ public class CueCamera : MonoBehaviour
     {
         if (TargetBall != null && TargetBall.gameObject.activeInHierarchy)
         {
-            targetViewFocus = GetBroadcastFocus(TargetBall.position);
             currentBall = TargetBall;
         }
 


### PR DESCRIPTION
### Motivation
- Players should keep the camera framing they set during the shot and the broadcast/pocket cameras must not dynamically zoom or chase the cue ball or object ball after strike. 
- The change prevents jarring re-centering/zoom behavior during pocket approaches and preserves a stable broadcast composition. 

### Description
- Stop re-centering the post-strike broadcast focus onto the target ball in `BeginShot` so `targetViewFocus` remains anchored to the cue/player framing captured at shot start (`billiards.Unity/CueCamera.cs`).
- When switching to a pocket camera, lock the pocket-camera focus to the tracked pocket location instead of the moving ball so the framing does not chase rolling balls (`UpdateBroadcastCamera`).
- Remove the per-frame retargeting of `targetViewFocus` to the `TargetBall` in `UpdateTargetCamera` so the active target camera preserves stable framing while the ball is moving.

### Testing
- Ran `dotnet test billiards.Tests` in this environment and it failed because `dotnet` is not installed, so unit tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d33a7a4e48832982591c02bab082f0)