### PR TITLE
Immediate locked rail-overhead broadcast on shot

### DIFF
--- a/billiards.Unity/CueCamera.cs
+++ b/billiards.Unity/CueCamera.cs
@@ -236,6 +236,16 @@ public class CueCamera : MonoBehaviour
     // Time to keep the cue camera locked on the strike after trigger before
     // switching to broadcast follow cameras.
     public float cueStrikeCameraHoldSeconds = 0.14f;
+    [Header("Broadcast shot behavior")]
+    // Switch to the rail-overhead broadcast framing immediately once a shot is
+    // triggered instead of waiting on the cue-strike hold timer.
+    public bool immediateRailBroadcastOnShot = true;
+    // Keep a fixed rail-overhead camera position during the entire shot so the
+    // view tracks action by turning/looking only (no zoom/dolly moves).
+    public bool lockRailBroadcastPositionDuringShot = true;
+    // Keep the rail-overhead camera active for the whole shot window and avoid
+    // corner-pocket cut-ins.
+    public bool forceRailOverheadForWholeShot = true;
 
     private float yaw;
     // Blend controlling how far the cue view slides toward the cue ball. 0 keeps
@@ -266,6 +276,8 @@ public class CueCamera : MonoBehaviour
     private bool hasSmoothedCueDistance;
     private float cueStrikeHoldUntilTime;
     private bool holdCueAimDuringShot;
+    private bool hasShotRailAnchor;
+    private Vector3 shotRailAnchorPosition;
     private Vector3 ballInHandTargetPosition;
     [Header("Occlusion settings")]
     // Layers that should be considered when preventing the camera from getting
@@ -330,8 +342,9 @@ public class CueCamera : MonoBehaviour
         shotInProgress = true;
         ballInHandActive = false;
         usingTargetCamera = false;
-        holdCueAimDuringShot = cueStrikeCameraHoldSeconds > 0f;
+        holdCueAimDuringShot = !immediateRailBroadcastOnShot && cueStrikeCameraHoldSeconds > 0f;
         cueStrikeHoldUntilTime = Time.time + Mathf.Max(0f, cueStrikeCameraHoldSeconds);
+        hasShotRailAnchor = false;
 
         int aimSide = nextShotIsAi ? -defaultShortRailSign : defaultShortRailSign;
         cueAimSideSign = aimSide;
@@ -744,35 +757,47 @@ public class CueCamera : MonoBehaviour
         currentBall = CueBall;
         yaw = Mathf.LerpAngle(yaw, targetViewYaw, Time.deltaTime * shotSnapSpeed);
 
-        Vector3 cornerPocket;
-        float dynamicPocketRadius = Mathf.Max(0.01f, cornerPocketCameraRadius);
-        if (TargetBall != null)
-        {
-            Rigidbody targetRb = TargetBall.GetComponent<Rigidbody>();
-            if (targetRb != null && targetRb.velocity.sqrMagnitude > velocityThreshold)
-            {
-                dynamicPocketRadius += Mathf.Max(0f, cornerPocketApproachRadius);
-            }
-        }
-        bool shouldUsePocketCamera = TargetBall != null
-            && TargetBall.gameObject.activeInHierarchy
-            && TryGetCornerPocketForBall(TargetBall.position, dynamicPocketRadius, out cornerPocket);
-        if (shouldUsePocketCamera)
-        {
-            usingTargetCamera = true;
-            pocketCameraAwaitingDrop = true;
-            pocketDropDetected = false;
-            pocketCameraStartTime = Time.time;
-            pocketCameraReleaseTime = float.PositiveInfinity;
-            trackedCornerPocket = cornerPocket;
-            // Keep pocket framing anchored to the tracked pocket so the
-            // transition does not chase the travelling balls.
-            targetViewFocus = GetBroadcastFocus(cornerPocket);
-            UpdateTargetCamera();
-            return;
-        }
+        targetViewFocus = GetDynamicShotBroadcastFocus();
 
-        ApplyBroadcastCamera(targetViewFocus, false);
+        if (forceRailOverheadForWholeShot)
+        {
+            usingTargetCamera = false;
+            pocketCameraAwaitingDrop = false;
+            pocketDropDetected = false;
+            ApplyBroadcastCamera(targetViewFocus, false);
+        }
+        else
+        {
+            Vector3 cornerPocket;
+            float dynamicPocketRadius = Mathf.Max(0.01f, cornerPocketCameraRadius);
+            if (TargetBall != null)
+            {
+                Rigidbody targetRb = TargetBall.GetComponent<Rigidbody>();
+                if (targetRb != null && targetRb.velocity.sqrMagnitude > velocityThreshold)
+                {
+                    dynamicPocketRadius += Mathf.Max(0f, cornerPocketApproachRadius);
+                }
+            }
+            bool shouldUsePocketCamera = TargetBall != null
+                && TargetBall.gameObject.activeInHierarchy
+                && TryGetCornerPocketForBall(TargetBall.position, dynamicPocketRadius, out cornerPocket);
+            if (shouldUsePocketCamera)
+            {
+                usingTargetCamera = true;
+                pocketCameraAwaitingDrop = true;
+                pocketDropDetected = false;
+                pocketCameraStartTime = Time.time;
+                pocketCameraReleaseTime = float.PositiveInfinity;
+                trackedCornerPocket = cornerPocket;
+                // Keep pocket framing anchored to the tracked pocket so the
+                // transition does not chase the travelling balls.
+                targetViewFocus = GetBroadcastFocus(cornerPocket);
+                UpdateTargetCamera();
+                return;
+            }
+
+            ApplyBroadcastCamera(targetViewFocus, false);
+        }
 
         bool cueMoving = IsMoving(CueBall);
         bool targetMoving = TargetBall != null && IsMoving(TargetBall);
@@ -1021,7 +1046,56 @@ public class CueCamera : MonoBehaviour
             lookTarget.y -= Mathf.Max(0f, broadcastLookDownOffset);
         }
 
+        if (shotInProgress && !isPocketCamera && lockRailBroadcastPositionDuringShot)
+        {
+            if (!hasShotRailAnchor)
+            {
+                Vector3 anchor = focus - forward * distance + Vector3.up * height;
+                anchor.x = 0f;
+                shotRailAnchorPosition = anchor;
+                hasShotRailAnchor = true;
+            }
+
+            ApplyLockedRailBroadcastCamera(shotRailAnchorPosition, lookTarget, focus, minimumHeightOffset);
+            return;
+        }
+
         ApplyShortRailCamera(focus, forward, distance, height, minimumHeightOffset, lookTarget);
+    }
+
+    private void ApplyLockedRailBroadcastCamera(
+        Vector3 lockedPosition,
+        Vector3 lookTarget,
+        Vector3 focus,
+        float minimumHeightOffset)
+    {
+        float minRailHeight = railHeight + tableAssetHeightOffset + Mathf.Max(0f, railClearance);
+        float minimumHeight = focus.y + Mathf.Max(minimumHeightAboveFocus, minimumHeightOffset);
+        minimumHeight = Mathf.Max(minimumHeight, minRailHeight);
+
+        Vector3 position = lockedPosition;
+        position.x = 0f;
+        position.y = Mathf.Max(position.y, minimumHeight);
+
+        transform.position = position;
+        transform.LookAt(lookTarget);
+    }
+
+    private Vector3 GetDynamicShotBroadcastFocus()
+    {
+        Vector3 desired = CueBall != null ? CueBall.position : tableBounds.center;
+        bool hasCue = CueBall != null && CueBall.gameObject.activeInHierarchy;
+        bool hasTarget = TargetBall != null && TargetBall.gameObject.activeInHierarchy;
+        if (hasCue && hasTarget)
+        {
+            desired = (CueBall.position + TargetBall.position) * 0.5f;
+        }
+        else if (hasTarget)
+        {
+            desired = TargetBall.position;
+        }
+
+        return GetBroadcastFocus(desired);
     }
 
     private void CacheStandingCameraPose()
@@ -1386,6 +1460,7 @@ public class CueCamera : MonoBehaviour
         shotInProgress = false;
         usingTargetCamera = false;
         holdCueAimDuringShot = false;
+        hasShotRailAnchor = false;
         pocketCameraAwaitingDrop = false;
         pocketDropDetected = false;
         pocketCameraStartTime = 0f;


### PR DESCRIPTION
### Motivation
- Make the broadcast view cut to the rail-overhead camera as soon as a shot is triggered so the whole table is visible and the cue/target balls remain in frame without zooming or dolly motion.
- Prevent corner-pocket cut-ins and avoid camera zooming during shots to keep a stable overhead broadcast look that only rotates/looks to follow action.

### Description
- Added three configurable toggles to `billiards.Unity/CueCamera.cs`: `immediateRailBroadcastOnShot`, `lockRailBroadcastPositionDuringShot`, and `forceRailOverheadForWholeShot` to control immediate switching, fixed-position rail tracking, and rail-only shot coverage respectively.
- Modified `BeginShot` to optionally skip the cue-strike hold and initialize shot anchor state when `immediateRailBroadcastOnShot` is enabled by setting `holdCueAimDuringShot` and `hasShotRailAnchor` appropriately.
- Updated `UpdateBroadcastCamera` to compute a dynamic shot focus (`GetDynamicShotBroadcastFocus`) that biases between the cue ball and target ball, and to optionally force rail-overhead coverage for the entire shot window.
- Implemented a locked rail broadcast path (`ApplyLockedRailBroadcastCamera`) that records a `shotRailAnchorPosition` and applies a stable position with only look/rotation changes while the shot is in progress, and reset anchor state in `EndShot`.

### Testing
- Ran repository validation commands `git diff --check` and `git status --short` and they completed with no issues.
- Verified the commit with `git show --stat --oneline HEAD` and the change was recorded successfully.
- No automated runtime/Unity play-mode tests were executed in this rollout; runtime verification in Unity play mode is recommended to confirm shot transitions and framing behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d34049feb08329901a08a9f385db7a)