### PR TITLE
Lock rail broadcast camera during shots and switch immediately on trigger

### DIFF
--- a/billiards.Unity/CueCamera.cs
+++ b/billiards.Unity/CueCamera.cs
@@ -235,7 +235,10 @@ public class CueCamera : MonoBehaviour
     [Header("Shot timing")]
     // Time to keep the cue camera locked on the strike after trigger before
     // switching to broadcast follow cameras.
-    public float cueStrikeCameraHoldSeconds = 0.14f;
+    public float cueStrikeCameraHoldSeconds = 0f;
+    // When enabled, the broadcast shot camera keeps a fixed overhead short-rail
+    // position and only turns to follow cue/target action.
+    public bool lockBroadcastPositionDuringShot = true;
 
     private float yaw;
     // Blend controlling how far the cue view slides toward the cue ball. 0 keeps
@@ -266,6 +269,10 @@ public class CueCamera : MonoBehaviour
     private bool hasSmoothedCueDistance;
     private float cueStrikeHoldUntilTime;
     private bool holdCueAimDuringShot;
+    private bool hasLockedBroadcastAnchor;
+    private Vector3 lockedBroadcastFocus;
+    private float lockedBroadcastHeight;
+    private float lockedBroadcastDistance;
     private Vector3 ballInHandTargetPosition;
     [Header("Occlusion settings")]
     // Layers that should be considered when preventing the camera from getting
@@ -332,6 +339,7 @@ public class CueCamera : MonoBehaviour
         usingTargetCamera = false;
         holdCueAimDuringShot = cueStrikeCameraHoldSeconds > 0f;
         cueStrikeHoldUntilTime = Time.time + Mathf.Max(0f, cueStrikeCameraHoldSeconds);
+        hasLockedBroadcastAnchor = false;
 
         int aimSide = nextShotIsAi ? -defaultShortRailSign : defaultShortRailSign;
         cueAimSideSign = aimSide;
@@ -958,6 +966,15 @@ public class CueCamera : MonoBehaviour
             }
         }
 
+        bool lockBroadcast = shotInProgress && lockBroadcastPositionDuringShot && !isPocketCamera;
+
+        if (lockBroadcast)
+        {
+            focus = tableBounds.center;
+            focus.x = 0f;
+            focus.y = Mathf.Max(focus.y, tableBounds.center.y);
+        }
+
         float minRailHeight = railHeight + tableAssetHeightOffset + Mathf.Max(0f, railClearance);
         float baseHeight = Mathf.Max(broadcastHeight, focus.y + minimumHeightAboveFocus);
         float heightOffset = baseHeight;
@@ -998,20 +1015,41 @@ public class CueCamera : MonoBehaviour
             }
         }
 
-        float distance = useStandingCameraForBroadcast && cachedStandingCamera
-            ? Mathf.Max(standingCameraDistance - Mathf.Max(0f, standingCameraDistanceInset), broadcastMinDistance)
-            : ComputeBroadcastDistance(focus, height, forward, cam, broadcastBounds);
-        if (isPocketCamera)
+        float distance;
+        if (lockBroadcast && hasLockedBroadcastAnchor)
         {
-            distance = Mathf.Max(distance - Mathf.Max(0f, pocketCameraDistanceInset), broadcastMinDistance);
+            focus = lockedBroadcastFocus;
+            height = lockedBroadcastHeight;
+            distance = lockedBroadcastDistance;
         }
         else
         {
-            distance = Mathf.Max(distance - Mathf.Max(0f, broadcastDistanceInset), broadcastMinDistance);
+            distance = useStandingCameraForBroadcast && cachedStandingCamera
+                ? Mathf.Max(standingCameraDistance - Mathf.Max(0f, standingCameraDistanceInset), broadcastMinDistance)
+                : ComputeBroadcastDistance(focus, height, forward, cam, broadcastBounds);
+            if (isPocketCamera)
+            {
+                distance = Mathf.Max(distance - Mathf.Max(0f, pocketCameraDistanceInset), broadcastMinDistance);
+            }
+            else
+            {
+                distance = Mathf.Max(distance - Mathf.Max(0f, broadcastDistanceInset), broadcastMinDistance);
+            }
+            distance = Mathf.Clamp(distance, broadcastMinDistance, broadcastMaxDistance);
+
+            if (lockBroadcast)
+            {
+                hasLockedBroadcastAnchor = true;
+                lockedBroadcastFocus = focus;
+                lockedBroadcastHeight = height;
+                lockedBroadcastDistance = distance;
+            }
         }
-        distance = Mathf.Clamp(distance, broadcastMinDistance, broadcastMaxDistance);
+
         float minimumHeightOffset = Mathf.Max(minimumHeightAboveFocus, height - focus.y);
-        Vector3 lookTarget = focus + Vector3.up * Mathf.Max(0f, broadcastHeightPadding);
+        Vector3 lookTarget = lockBroadcast
+            ? GetLiveShotLookTarget(focus)
+            : focus + Vector3.up * Mathf.Max(0f, broadcastHeightPadding);
         if (isPocketCamera)
         {
             lookTarget.y -= Mathf.Max(0f, pocketCameraLookDownOffset);
@@ -1022,6 +1060,33 @@ public class CueCamera : MonoBehaviour
         }
 
         ApplyShortRailCamera(focus, forward, distance, height, minimumHeightOffset, lookTarget);
+    }
+
+    private Vector3 GetLiveShotLookTarget(Vector3 fallbackFocus)
+    {
+        Vector3 focus = fallbackFocus;
+        int count = 0;
+
+        if (CueBall != null && CueBall.gameObject.activeInHierarchy)
+        {
+            focus += CueBall.position;
+            count++;
+        }
+
+        if (TargetBall != null && TargetBall.gameObject.activeInHierarchy)
+        {
+            focus += TargetBall.position;
+            count++;
+        }
+
+        if (count > 0)
+        {
+            focus /= (count + 1);
+        }
+
+        focus.y = Mathf.Max(focus.y, tableBounds.center.y);
+        focus += Vector3.up * Mathf.Max(0f, broadcastHeightPadding);
+        return focus;
     }
 
     private void CacheStandingCameraPose()
@@ -1346,6 +1411,7 @@ public class CueCamera : MonoBehaviour
         SetBallInHandActive(true);
         shotInProgress = false;
         usingTargetCamera = false;
+        hasLockedBroadcastAnchor = false;
         currentBall = CueBall;
     }
 
@@ -1386,6 +1452,7 @@ public class CueCamera : MonoBehaviour
         shotInProgress = false;
         usingTargetCamera = false;
         holdCueAimDuringShot = false;
+        hasLockedBroadcastAnchor = false;
         pocketCameraAwaitingDrop = false;
         pocketDropDetected = false;
         pocketCameraStartTime = 0f;


### PR DESCRIPTION
### Motivation

- Ensure the camera cuts immediately to the short-rail broadcast view when a shot is triggered so the whole table is visible as the cue/target leave the cue-camera frame.  
- Keep the broadcast rig from changing distance/zoom mid-shot while still letting the view turn to keep the cue ball and target ball in frame.  

### Description

- Set `cueStrikeCameraHoldSeconds` to `0f` so the system switches to broadcast view immediately when `BeginShot` is called.  
- Add a new flag `lockBroadcastPositionDuringShot` (default `true`) and locked-anchor state (`hasLockedBroadcastAnchor`, `lockedBroadcastFocus`, `lockedBroadcastHeight`, `lockedBroadcastDistance`) so the broadcast camera keeps a fixed overhead short-rail position for the duration of the shot.  
- When locked, compute and cache a broadcast anchor once and reuse the cached `focus/height/distance` during the shot while updating only the camera `lookTarget` to follow live cue and target positions via the new `GetLiveShotLookTarget` helper.  
- Clear the locked broadcast anchor in `EndShot` and in the cue-ball restore flow to avoid stale anchors across shots.  

### Testing

- Ran `git diff --check billiards.Unity/CueCamera.cs` which produced no warnings or whitespace errors and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d34049feb08329901a08a9f385db7a)