### PR TITLE
Enhance shot / broadcast camera tracking and disable PoolRoyale auto-replay

### DIFF
--- a/billiards.Unity/CueCamera.cs
+++ b/billiards.Unity/CueCamera.cs
@@ -236,6 +236,40 @@ public class CueCamera : MonoBehaviour
     // Time to keep the cue camera locked on the strike after trigger before
     // switching to broadcast follow cameras.
     public float cueStrikeCameraHoldSeconds = 0.14f;
+    [Header("Broadcast shot behavior")]
+    // Switch to the rail-overhead broadcast framing immediately once a shot is
+    // triggered instead of waiting on the cue-strike hold timer.
+    public bool immediateRailBroadcastOnShot = false;
+    // Keep a fixed rail-overhead camera position during the entire shot so the
+    // view tracks action by turning/looking only (no zoom/dolly moves).
+    public bool lockRailBroadcastPositionDuringShot = true;
+    // Keep the rail-overhead camera active for the whole shot window and avoid
+    // corner-pocket cut-ins.
+    public bool forceRailOverheadForWholeShot = false;
+    [Header("Cue hold tracking")]
+    // During the cue-strike hold window keep cue camera position fixed and only
+    // rotate/turn to follow the target so it stays inside frame without zoom.
+    public bool turnOnlyCueTrackingDuringShotHold = true;
+    // Responsiveness of cue camera turn/look while holding position after shot.
+    public float cueHoldTurnSpeed = 10f;
+    // Weight to bias cue-hold look target toward target ball (1) vs cue ball (0).
+    [Range(0f, 1f)]
+    public float cueHoldTargetBias = 0.72f;
+    [Header("Pocket cut guarantee")]
+    // Only cut to pocket camera if target enters this inner capture radius.
+    public float pocketGuaranteedInnerRadius = 0.14f;
+    // Require inward motion before pocket camera cut unless already below lip.
+    [Range(0f, 1f)]
+    public float pocketGuaranteedInwardDot = 0.82f;
+    // Minimum planar speed for the inward-motion guarantee check.
+    public float pocketGuaranteedMinPlanarSpeed = 0.05f;
+    [Header("Shot tracking handoff")]
+    // Distance from rail used to detect target-ball rail contact for cue-ball handoff.
+    public float railBounceSwitchDistance = 0.055f;
+    // If target velocity direction changes below this dot after rail contact,
+    // treat it as a bounce and hand cue tracking back to cue ball.
+    [Range(-1f, 1f)]
+    public float railBounceDirectionDotThreshold = 0.35f;
 
     private float yaw;
     // Blend controlling how far the cue view slides toward the cue ball. 0 keeps
@@ -266,6 +300,15 @@ public class CueCamera : MonoBehaviour
     private bool hasSmoothedCueDistance;
     private float cueStrikeHoldUntilTime;
     private bool holdCueAimDuringShot;
+    private bool hasShotRailAnchor;
+    private Vector3 shotRailAnchorPosition;
+    private bool hasCueHoldAnchor;
+    private Vector3 cueHoldAnchorPosition;
+    private float cueHoldAnchorFov;
+    private Vector3 lastTargetPlanarVelocity;
+    private bool hasLastTargetPlanarVelocity;
+    private bool targetWasNearRail;
+    private bool handoffToCueBallAfterRailBounce;
     private Vector3 ballInHandTargetPosition;
     [Header("Occlusion settings")]
     // Layers that should be considered when preventing the camera from getting
@@ -330,8 +373,13 @@ public class CueCamera : MonoBehaviour
         shotInProgress = true;
         ballInHandActive = false;
         usingTargetCamera = false;
-        holdCueAimDuringShot = cueStrikeCameraHoldSeconds > 0f;
+        holdCueAimDuringShot = !immediateRailBroadcastOnShot && cueStrikeCameraHoldSeconds > 0f;
         cueStrikeHoldUntilTime = Time.time + Mathf.Max(0f, cueStrikeCameraHoldSeconds);
+        hasShotRailAnchor = false;
+        hasCueHoldAnchor = false;
+        hasLastTargetPlanarVelocity = false;
+        targetWasNearRail = false;
+        handoffToCueBallAfterRailBounce = false;
 
         int aimSide = nextShotIsAi ? -defaultShortRailSign : defaultShortRailSign;
         cueAimSideSign = aimSide;
@@ -401,7 +449,19 @@ public class CueCamera : MonoBehaviour
         }
         else if (holdCueAimDuringShot && Time.time < cueStrikeHoldUntilTime)
         {
-            PositionCueAimCamera(Time.deltaTime, false);
+            if (TrySwitchToGuaranteedPocketCamera())
+            {
+                return;
+            }
+
+            if (turnOnlyCueTrackingDuringShotHold)
+            {
+                UpdateCueHoldTrackingCamera();
+            }
+            else
+            {
+                PositionCueAimCamera(Time.deltaTime, false);
+            }
         }
         else
         {
@@ -744,35 +804,24 @@ public class CueCamera : MonoBehaviour
         currentBall = CueBall;
         yaw = Mathf.LerpAngle(yaw, targetViewYaw, Time.deltaTime * shotSnapSpeed);
 
-        Vector3 cornerPocket;
-        float dynamicPocketRadius = Mathf.Max(0.01f, cornerPocketCameraRadius);
-        if (TargetBall != null)
-        {
-            Rigidbody targetRb = TargetBall.GetComponent<Rigidbody>();
-            if (targetRb != null && targetRb.velocity.sqrMagnitude > velocityThreshold)
-            {
-                dynamicPocketRadius += Mathf.Max(0f, cornerPocketApproachRadius);
-            }
-        }
-        bool shouldUsePocketCamera = TargetBall != null
-            && TargetBall.gameObject.activeInHierarchy
-            && TryGetCornerPocketForBall(TargetBall.position, dynamicPocketRadius, out cornerPocket);
-        if (shouldUsePocketCamera)
-        {
-            usingTargetCamera = true;
-            pocketCameraAwaitingDrop = true;
-            pocketDropDetected = false;
-            pocketCameraStartTime = Time.time;
-            pocketCameraReleaseTime = float.PositiveInfinity;
-            trackedCornerPocket = cornerPocket;
-            // Keep pocket framing anchored to the tracked pocket so the
-            // transition does not chase the travelling balls.
-            targetViewFocus = GetBroadcastFocus(cornerPocket);
-            UpdateTargetCamera();
-            return;
-        }
+        targetViewFocus = GetDynamicShotBroadcastFocus();
 
-        ApplyBroadcastCamera(targetViewFocus, false);
+        if (forceRailOverheadForWholeShot)
+        {
+            usingTargetCamera = false;
+            pocketCameraAwaitingDrop = false;
+            pocketDropDetected = false;
+            ApplyBroadcastCamera(targetViewFocus, false);
+        }
+        else
+        {
+            if (TrySwitchToGuaranteedPocketCamera())
+            {
+                return;
+            }
+
+            ApplyBroadcastCamera(targetViewFocus, false);
+        }
 
         bool cueMoving = IsMoving(CueBall);
         bool targetMoving = TargetBall != null && IsMoving(TargetBall);
@@ -1021,7 +1070,196 @@ public class CueCamera : MonoBehaviour
             lookTarget.y -= Mathf.Max(0f, broadcastLookDownOffset);
         }
 
+        if (shotInProgress && !isPocketCamera && lockRailBroadcastPositionDuringShot)
+        {
+            if (!hasShotRailAnchor)
+            {
+                Vector3 anchor = focus - forward * distance + Vector3.up * height;
+                anchor.x = 0f;
+                shotRailAnchorPosition = anchor;
+                hasShotRailAnchor = true;
+            }
+
+            ApplyLockedRailBroadcastCamera(shotRailAnchorPosition, lookTarget, focus, minimumHeightOffset);
+            return;
+        }
+
         ApplyShortRailCamera(focus, forward, distance, height, minimumHeightOffset, lookTarget);
+    }
+
+    private void ApplyLockedRailBroadcastCamera(
+        Vector3 lockedPosition,
+        Vector3 lookTarget,
+        Vector3 focus,
+        float minimumHeightOffset)
+    {
+        float minRailHeight = railHeight + tableAssetHeightOffset + Mathf.Max(0f, railClearance);
+        float minimumHeight = focus.y + Mathf.Max(minimumHeightAboveFocus, minimumHeightOffset);
+        minimumHeight = Mathf.Max(minimumHeight, minRailHeight);
+
+        Vector3 position = lockedPosition;
+        position.x = 0f;
+        position.y = Mathf.Max(position.y, minimumHeight);
+
+        transform.position = position;
+        transform.LookAt(lookTarget);
+    }
+
+    private Vector3 GetDynamicShotBroadcastFocus()
+    {
+        Vector3 desired = CueBall != null ? CueBall.position : tableBounds.center;
+        bool hasCue = CueBall != null && CueBall.gameObject.activeInHierarchy;
+        bool hasTarget = TargetBall != null && TargetBall.gameObject.activeInHierarchy;
+        if (hasCue && hasTarget)
+        {
+            desired = (CueBall.position + TargetBall.position) * 0.5f;
+        }
+        else if (hasTarget)
+        {
+            desired = TargetBall.position;
+        }
+
+        return GetBroadcastFocus(desired);
+    }
+
+    private void UpdateCueHoldTrackingCamera()
+    {
+        if (CueBall == null)
+        {
+            return;
+        }
+
+        if (!hasCueHoldAnchor)
+        {
+            hasCueHoldAnchor = true;
+            cueHoldAnchorPosition = transform.position;
+            if (cachedCamera == null)
+            {
+                cachedCamera = GetComponent<Camera>();
+            }
+
+            Camera cam = cachedCamera != null ? cachedCamera : Camera.main;
+            cueHoldAnchorFov = cam != null ? cam.fieldOfView : cueRaisedFieldOfView;
+        }
+
+        Transform primaryBall = GetPrimaryShotTrackingBall();
+        bool followTarget = primaryBall != null && primaryBall == TargetBall;
+
+        Vector3 desiredLook = CueBall.position;
+        if (followTarget && TargetBall != null && TargetBall.gameObject.activeInHierarchy)
+        {
+            float bias = Mathf.Clamp01(cueHoldTargetBias);
+            desiredLook = Vector3.Lerp(CueBall.position, TargetBall.position, bias);
+        }
+        else if (primaryBall != null && primaryBall.gameObject.activeInHierarchy)
+        {
+            desiredLook = primaryBall.position;
+        }
+
+        Vector3 toLook = desiredLook - cueHoldAnchorPosition;
+        if (toLook.sqrMagnitude < 0.0001f)
+        {
+            toLook = transform.forward;
+        }
+
+        Quaternion desiredRotation = Quaternion.LookRotation(toLook.normalized, Vector3.up);
+        float turnSpeed = Mathf.Max(0f, cueHoldTurnSpeed);
+        float t = turnSpeed <= 0f ? 1f : 1f - Mathf.Exp(-turnSpeed * Time.deltaTime);
+
+        transform.position = cueHoldAnchorPosition;
+        transform.rotation = Quaternion.Slerp(transform.rotation, desiredRotation, t);
+
+        if (cachedCamera == null)
+        {
+            cachedCamera = GetComponent<Camera>();
+        }
+
+        Camera camera = cachedCamera != null ? cachedCamera : Camera.main;
+        if (camera != null)
+        {
+            camera.fieldOfView = cueHoldAnchorFov;
+        }
+    }
+
+    private Transform GetPrimaryShotTrackingBall()
+    {
+        if (CueBall == null)
+        {
+            return TargetBall;
+        }
+
+        if (ShouldHandoffToCueBall())
+        {
+            return CueBall;
+        }
+
+        if (TargetBall != null && TargetBall.gameObject.activeInHierarchy)
+        {
+            return TargetBall;
+        }
+
+        return CueBall;
+    }
+
+    private bool ShouldHandoffToCueBall()
+    {
+        if (CueBall == null)
+        {
+            return false;
+        }
+
+        if (TargetBall == null || !TargetBall.gameObject.activeInHierarchy)
+        {
+            return true;
+        }
+
+        if (IsBallDroppedIntoAnyCornerPocket(TargetBall.position))
+        {
+            return true;
+        }
+
+        if (handoffToCueBallAfterRailBounce)
+        {
+            return true;
+        }
+
+        Rigidbody targetRb = TargetBall.GetComponent<Rigidbody>();
+        if (targetRb == null)
+        {
+            return false;
+        }
+
+        Vector3 currentPlanarVelocity = new Vector3(targetRb.velocity.x, 0f, targetRb.velocity.z);
+        bool nearRail = DistanceToRail(TargetBall.position, tableBounds) <= Mathf.Max(0.005f, railBounceSwitchDistance);
+
+        if (targetWasNearRail && !nearRail && hasLastTargetPlanarVelocity)
+        {
+            bool haveVelocity = currentPlanarVelocity.sqrMagnitude > 0.0001f && lastTargetPlanarVelocity.sqrMagnitude > 0.0001f;
+            if (haveVelocity)
+            {
+                float directionDot = Vector3.Dot(lastTargetPlanarVelocity.normalized, currentPlanarVelocity.normalized);
+                if (directionDot <= railBounceDirectionDotThreshold)
+                {
+                    handoffToCueBallAfterRailBounce = true;
+                }
+            }
+        }
+
+        targetWasNearRail = nearRail;
+        if (currentPlanarVelocity.sqrMagnitude > 0.0001f)
+        {
+            lastTargetPlanarVelocity = currentPlanarVelocity;
+            hasLastTargetPlanarVelocity = true;
+        }
+
+        return handoffToCueBallAfterRailBounce;
+    }
+
+    private static float DistanceToRail(Vector3 point, Bounds bounds)
+    {
+        float dx = Mathf.Min(Mathf.Abs(point.x - bounds.min.x), Mathf.Abs(bounds.max.x - point.x));
+        float dz = Mathf.Min(Mathf.Abs(point.z - bounds.min.z), Mathf.Abs(bounds.max.z - point.z));
+        return Mathf.Min(dx, dz);
     }
 
     private void CacheStandingCameraPose()
@@ -1386,6 +1624,11 @@ public class CueCamera : MonoBehaviour
         shotInProgress = false;
         usingTargetCamera = false;
         holdCueAimDuringShot = false;
+        hasShotRailAnchor = false;
+        hasCueHoldAnchor = false;
+        hasLastTargetPlanarVelocity = false;
+        targetWasNearRail = false;
+        handoffToCueBallAfterRailBounce = false;
         pocketCameraAwaitingDrop = false;
         pocketDropDetected = false;
         pocketCameraStartTime = 0f;
@@ -1450,6 +1693,93 @@ public class CueCamera : MonoBehaviour
 
         float dropThreshold = railHeight + tableAssetHeightOffset - Mathf.Max(0f, pocketDropDepth);
         return ballPosition.y <= dropThreshold;
+    }
+
+    private bool IsBallDroppedIntoAnyCornerPocket(Vector3 ballPosition)
+    {
+        Vector3 pocket;
+        if (!TryGetCornerPocketForBall(ballPosition, Mathf.Max(0.01f, cornerPocketCameraRadius), out pocket))
+        {
+            return false;
+        }
+
+        float dropThreshold = railHeight + tableAssetHeightOffset - Mathf.Max(0f, pocketDropDepth);
+        if (ballPosition.y > dropThreshold)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private bool TrySwitchToGuaranteedPocketCamera()
+    {
+        Vector3 guaranteedPocket;
+        if (!IsGuaranteedPocketCut(TargetBall, out guaranteedPocket))
+        {
+            return false;
+        }
+
+        usingTargetCamera = true;
+        pocketCameraAwaitingDrop = true;
+        pocketDropDetected = false;
+        pocketCameraStartTime = Time.time;
+        pocketCameraReleaseTime = float.PositiveInfinity;
+        trackedCornerPocket = guaranteedPocket;
+        targetViewFocus = GetBroadcastFocus(guaranteedPocket);
+        UpdateTargetCamera();
+        return true;
+    }
+
+    private bool IsGuaranteedPocketCut(Transform targetBall, out Vector3 pocket)
+    {
+        pocket = Vector3.zero;
+        if (targetBall == null || !targetBall.gameObject.activeInHierarchy)
+        {
+            return false;
+        }
+
+        float triggerRadius = Mathf.Max(0.01f, cornerPocketCameraRadius);
+        if (!TryGetCornerPocketForBall(targetBall.position, triggerRadius, out pocket))
+        {
+            return false;
+        }
+
+        Vector2 ballXZ = new Vector2(targetBall.position.x, targetBall.position.z);
+        Vector2 pocketXZ = new Vector2(pocket.x, pocket.z);
+        float innerRadius = Mathf.Max(0.01f, Mathf.Min(triggerRadius, pocketGuaranteedInnerRadius));
+        bool inInnerCapture = (ballXZ - pocketXZ).sqrMagnitude <= innerRadius * innerRadius;
+
+        float dropThreshold = railHeight + tableAssetHeightOffset - Mathf.Max(0f, pocketDropDepth);
+        bool belowPocketLip = targetBall.position.y <= dropThreshold;
+        if (belowPocketLip)
+        {
+            return true;
+        }
+
+        Rigidbody rb = targetBall.GetComponent<Rigidbody>();
+        if (rb == null)
+        {
+            return false;
+        }
+
+        Vector3 planarVel = new Vector3(rb.velocity.x, 0f, rb.velocity.z);
+        float minSpeed = Mathf.Max(0f, pocketGuaranteedMinPlanarSpeed);
+        if (planarVel.sqrMagnitude <= minSpeed * minSpeed)
+        {
+            return false;
+        }
+
+        Vector3 toPocket = pocket - targetBall.position;
+        toPocket.y = 0f;
+        if (toPocket.sqrMagnitude < 0.0001f)
+        {
+            return inInnerCapture;
+        }
+
+        float inwardDot = Vector3.Dot(planarVel.normalized, toPocket.normalized);
+        bool movingInward = inwardDot >= Mathf.Clamp01(pocketGuaranteedInwardDot);
+        return inInnerCapture && movingInward;
     }
 
     private static float GetShortRailYaw(int sideSign)

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -3621,7 +3621,7 @@ const LIGHTING_PRESET_MAP = Object.freeze(
 );
 
 const FRAME_RATE_STORAGE_KEY = 'snookerFrameRate';
-const AUTO_REPLAY_STORAGE_KEY = 'poolRoyaleAutoReplay';
+const ENABLE_POOL_ROYALE_REPLAY = false;
 const FRAME_RATE_OPTIONS = Object.freeze([
   {
     id: 'fhd60',
@@ -13268,16 +13268,7 @@ function PoolRoyaleGame({
     return DEFAULT_FRAME_RATE_ID;
   });
   const [broadcastSystemId, setBroadcastSystemId] = useState(() => DEFAULT_BROADCAST_SYSTEM_ID);
-  const [autoReplayEnabled, setAutoReplayEnabled] = useState(() => {
-    if (typeof window === 'undefined') return true;
-    try {
-      const stored = window.localStorage.getItem(AUTO_REPLAY_STORAGE_KEY);
-      if (stored == null) return true;
-      return stored !== '0';
-    } catch {
-      return true;
-    }
-  });
+  const autoReplayEnabled = false;
   const initialTableSlot = 0;
   const [activeTableSlot, setActiveTableSlot] = useState(initialTableSlot);
   const [tableSelectionOpen, setTableSelectionOpen] = useState(false);
@@ -14923,11 +14914,6 @@ function PoolRoyaleGame({
       window.localStorage.setItem(BROADCAST_SYSTEM_STORAGE_KEY, broadcastSystemId);
     }
   }, [broadcastSystemId]);
-  useEffect(() => {
-    if (typeof window !== 'undefined') {
-      window.localStorage.setItem(AUTO_REPLAY_STORAGE_KEY, autoReplayEnabled ? '1' : '0');
-    }
-  }, [autoReplayEnabled]);
   useEffect(() => {
     if (!configOpen) return undefined;
     const handleKeyDown = (event) => {
@@ -17562,7 +17548,11 @@ const powerRef = useRef(hud.power);
         } else if (hasState) {
           recording.replayFoul = null;
         }
-        pendingRemoteReplayRef.current = { ...recording };
+        if (ENABLE_POOL_ROYALE_REPLAY) {
+          pendingRemoteReplayRef.current = { ...recording };
+        } else {
+          pendingRemoteReplayRef.current = null;
+        }
         incomingRemoteShotRef.current = null;
         remoteShotActiveRef.current = false;
         remoteShotUntilRef.current = 0;
@@ -17792,6 +17782,9 @@ const powerRef = useRef(hud.power);
   }, [aiOpponentEnabled, frameState, hud.turn, hud.over]);
 
   useEffect(() => {
+    if (shotActive || pocketCameraActive) {
+      return;
+    }
     const sph = sphRef.current;
     if (!sph || !cameraRef.current) return;
     const restore = inHandCameraRestoreRef.current;
@@ -17818,10 +17811,10 @@ const powerRef = useRef(hud.power);
       inHandCameraRestoreRef.current = null;
       cameraUpdateRef.current?.();
     }
-  }, [hud.inHand]);
+  }, [hud.inHand, pocketCameraActive, shotActive]);
 
   useEffect(() => {
-    if (replayActive) return;
+    if (replayActive || shotActive || pocketCameraActive) return;
     const controls = topViewControlsRef.current;
     if (hud.inHand) {
       if (controls?.exit && (inHandTopViewRef.current || topViewRef.current)) {
@@ -17834,7 +17827,7 @@ const powerRef = useRef(hud.power);
       controls.exit(true);
       inHandTopViewRef.current = false;
     }
-  }, [hud.inHand, replayActive]);
+  }, [hud.inHand, pocketCameraActive, replayActive, shotActive]);
 
   useEffect(() => {
     const host = mountRef.current;
@@ -21492,6 +21485,7 @@ const powerRef = useRef(hud.power);
             cueId: cueBall.id,
             targetId: targetId ?? null,
             stage: 'pair',
+            primaryFocus: 'target',
             exitAfterHold: false,
             resume: followView ?? null,
             orbitSnapshot,
@@ -21520,7 +21514,8 @@ const powerRef = useRef(hud.power);
             startCuePos: new THREE.Vector2(cueBall.pos.x, cueBall.pos.y),
             targetInitialPos: targetBall
               ? new THREE.Vector2(targetBall.pos.x, targetBall.pos.y)
-              : null
+              : null,
+            lastTargetRailHitAt: targetBall?.lastRailHitAt ?? null
           };
         };
         const makePocketCameraView = (ballId, followView, options = {}) => {
@@ -29111,7 +29106,12 @@ const powerRef = useRef(hud.power);
           pocketSwitchIntentRef.current = null;
           lastPocketBallRef.current = null;
           updatePocketCameraState(false);
-          if (autoReplayEnabled && shouldStartReplay && postShotSnapshot) {
+          if (
+            ENABLE_POOL_ROYALE_REPLAY &&
+            autoReplayEnabled &&
+            shouldStartReplay &&
+            postShotSnapshot
+          ) {
             const recordingForReplay = shotRecording;
             const launchReplay = () => {
               replayBannerTimeoutRef.current = null;
@@ -30722,21 +30722,40 @@ const powerRef = useRef(hud.power);
               if (activeShotView.axis === 'short' && targetBall) {
                 maybeForceShortRailPocketView(targetBall);
               }
-              if (!targetBall?.active) {
+              const targetDroppedOrMissing = !targetBall?.active;
+              const targetRailHitAt = targetBall?.lastRailHitAt ?? null;
+              const targetBouncedRail =
+                targetBall &&
+                targetRailHitAt &&
+                (!activeShotView.lastTargetRailHitAt ||
+                  targetRailHitAt > activeShotView.lastTargetRailHitAt);
+              if (targetBouncedRail) {
+                activeShotView.lastTargetRailHitAt = targetRailHitAt;
+              }
+              if (targetDroppedOrMissing || targetBouncedRail) {
+                activeShotView.stage = 'cue';
+                activeShotView.primaryFocus = 'cue';
+                activeShotView.targetId = null;
+              } else if (activeShotView.hitConfirmed) {
+                const targetSpeed = targetBall.vel.length() * frameScale;
+                if (targetSpeed <= STOP_EPS) {
+                  activeShotView.stage = 'cue';
+                  activeShotView.primaryFocus = 'cue';
+                  activeShotView.targetId = null;
+                }
+              }
+            }
+            if (activeShotView.stage === 'cue') {
+              const cueSpeed = cueBall.vel.length() * frameScale;
+              if (cueSpeed <= STOP_EPS) {
                 activeShotView.exitAfterHold = true;
                 activeShotView.holdUntil = Math.max(
                   activeShotView.holdUntil ?? 0,
                   now + ACTION_CAM.followHoldMs
                 );
-              } else if (activeShotView.hitConfirmed) {
-                const targetSpeed = targetBall.vel.length() * frameScale;
-                if (targetSpeed <= STOP_EPS) {
-                  activeShotView.exitAfterHold = true;
-                  activeShotView.holdUntil = Math.max(
-                    activeShotView.holdUntil ?? 0,
-                    now + ACTION_CAM.followHoldMs
-                  );
-                }
+              } else {
+                activeShotView.exitAfterHold = false;
+                activeShotView.holdUntil = null;
               }
             }
             if (activeShotView.exitAfterHold) {
@@ -30827,11 +30846,6 @@ const powerRef = useRef(hud.power);
               pocketIntent = null;
               pocketSwitchIntentRef.current = null;
             }
-            const movingBalls = ballsList.filter(
-              (b) => b.active && b.vel.length() * frameScale >= STOP_EPS
-            );
-            const movingCount = movingBalls.length;
-            const lastPocketBall = lastPocketBallRef.current;
             let bestPocketView = null;
             for (const ball of ballsList) {
               if (!ball.active) continue;
@@ -30851,26 +30865,14 @@ const powerRef = useRef(hud.power);
                   shotPrediction?.railNormal === undefined);
               const qualifiesAsGuaranteed =
                 isDirectPrediction && predictedAlignment >= POCKET_GUARANTEED_ALIGNMENT;
-              const allowDuringChaos =
-                movingCount <= POCKET_CHAOS_MOVING_THRESHOLD ||
-                matchesIntent ||
-                qualifiesAsGuaranteed ||
-                (lastPocketBall && lastPocketBall === ball.id);
-              if (!allowDuringChaos) continue;
-              if (
-                movingCount > POCKET_CHAOS_MOVING_THRESHOLD &&
-                !matchesIntent &&
-                !qualifiesAsGuaranteed &&
-                lastPocketBall &&
-                lastPocketBall !== ball.id
-              ) {
+              if (!qualifiesAsGuaranteed) {
                 continue;
               }
               const baseScore = candidate.score ?? 0;
               let priority = baseScore;
-              if (matchesIntent && (pocketIntent?.forced ?? false)) priority += 1.2;
-              else if (matchesIntent) priority += 0.6;
-              if (qualifiesAsGuaranteed) priority += 0.4;
+              if (matchesIntent && (pocketIntent?.forced ?? false)) priority += 0.6;
+              else if (matchesIntent) priority += 0.3;
+              priority += 0.4;
               if (candidate.forcedEarly) priority += 0.3;
               candidate.priority = priority;
               candidate.intentMatched = matchesIntent;
@@ -33394,33 +33396,6 @@ const powerRef = useRef(hud.power);
                     );
                   })}
                 </div>
-              </div>
-              <div>
-                <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
-                  Replay Controls
-                </h3>
-                <button
-                  type="button"
-                  onClick={() => setAutoReplayEnabled((prev) => !prev)}
-                  aria-pressed={autoReplayEnabled}
-                  className={`mt-2 w-full rounded-2xl border px-4 py-2 text-left transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
-                    autoReplayEnabled
-                      ? 'border-emerald-300 bg-emerald-300/90 text-black shadow-[0_0_16px_rgba(16,185,129,0.55)]'
-                      : 'border-white/20 bg-white/10 text-white/80 hover:bg-white/20'
-                  }`}
-                >
-                  <span className="flex items-center justify-between gap-2">
-                    <span className="text-[11px] font-semibold uppercase tracking-[0.28em]">
-                      Auto Replay
-                    </span>
-                    <span className="text-[10px] font-semibold uppercase tracking-[0.2em]">
-                      {autoReplayEnabled ? 'On' : 'Off'}
-                    </span>
-                  </span>
-                  <span className="mt-1 block text-[10px] uppercase tracking-[0.16em] text-white/60">
-                    Replays keep live graphics quality and appear on potted/foul moments.
-                  </span>
-                </button>
               </div>
             </div>
           </div>


### PR DESCRIPTION
### Motivation
- Improve broadcast and cue-camera behaviour during shots to provide more stable rail-overhead framing, guarantee pocket cut-ins under tighter criteria, and avoid jittery zoom/dolly motion during a shot.
- Add logic to keep the cue camera anchored while holding the shot and to hand off tracking between target and cue ball when rail bounces occur.
- Disable the automatic replay feature in the PoolRoyale web UI and remove persistent auto-replay state to simplify replay behaviour and avoid unexpected replays.

### Description
- Extended `CueCamera` with new serialized settings for broadcast shot behavior, cue-hold tracking, pocket-cut guarantees, and rail-bounce handoff tuning, and added backing fields to maintain shot/anchor state (`hasShotRailAnchor`, `shotRailAnchorPosition`, `hasCueHoldAnchor`, etc.).
- Added shot-time camera modes: immediate rail broadcast (`immediateRailBroadcastOnShot`), locked rail broadcast position (`lockRailBroadcastPositionDuringShot`) implemented via `ApplyLockedRailBroadcastCamera`, and cue-hold-only tracking implemented via `UpdateCueHoldTrackingCamera` that preserves position and only rotates to follow a biased look target.
- Implemented guaranteed pocket-cut detection and switching via `IsGuaranteedPocketCut`, `TrySwitchToGuaranteedPocketCamera`, and `IsBallDroppedIntoAnyCornerPocket` with configurable inner radius, inward-motion dot threshold, and minimum planar speed.
- Added rail-bounce handoff heuristics (`ShouldHandoffToCueBall`, `DistanceToRail`) that detect when a target ball bounces off a rail and request the camera to hand tracking back to the cue ball.
- Anchors and transient shot state are initialized in `BeginShot` and cleared in `EndShot`, and various update paths (`Update`, `UpdateBroadcastCamera`, `UpdateTargetCamera`) were adjusted to integrate the new behaviors and early pocket-camera switching.
- Webapp `PoolRoyale.jsx` changes disable automatic replays by introducing `ENABLE_POOL_ROYALE_REPLAY` (set to `false`), replace the mutable `autoReplayEnabled` local state with a disabled constant, remove persistent localStorage writes for auto-replay, and guard replay enqueue/launch code paths with `ENABLE_POOL_ROYALE_REPLAY` so recordings are not queued or auto-started.
- Webapp pocket-camera logic and action-view logic were hardened to track recent rail hits (`lastTargetRailHitAt`), prefer guaranteed pocket views more conservatively, and adjust priority scoring for pocket candidates; also removed the Auto Replay UI control from the settings panel.
- Updated several `useEffect` dependencies to include `pocketCameraActive` and `shotActive` so camera/state restores are suppressed while a shot or pocket camera is active.

### Testing
- Performed a local webapp typecheck/build (`npm run build` / equivalent) to validate `PoolRoyale.jsx` changes and the updated TypeScript/JSX logic, and the build completed without type or syntax errors.
- Opened the Unity project to let the C# compiler validate the `CueCamera.cs` changes and confirmed there were no compile-time errors in the editor.
- No new automated unit tests were added for these features.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d34049feb08329901a08a9f385db7a)