### PR TITLE
Enhance broadcast/cue-hold camera behavior, pocket cut guarantees, and shot tracking handoffs

### DIFF
--- a/billiards.Unity/CueCamera.cs
+++ b/billiards.Unity/CueCamera.cs
@@ -236,6 +236,47 @@ public class CueCamera : MonoBehaviour
     // Time to keep the cue camera locked on the strike after trigger before
     // switching to broadcast follow cameras.
     public float cueStrikeCameraHoldSeconds = 0.14f;
+    [Header("Broadcast shot behavior")]
+    // Switch to the rail-overhead broadcast framing immediately once a shot is
+    // triggered instead of waiting on the cue-strike hold timer.
+    public bool immediateRailBroadcastOnShot = false;
+    // Keep a fixed rail-overhead camera position during the entire shot so the
+    // view tracks action by turning/looking only (no zoom/dolly moves).
+    public bool lockRailBroadcastPositionDuringShot = true;
+    // Keep the rail-overhead camera active for the whole shot window and avoid
+    // corner-pocket cut-ins.
+    public bool forceRailOverheadForWholeShot = false;
+    [Header("Cue hold tracking")]
+    // During the cue-strike hold window keep cue camera position fixed and only
+    // rotate/turn to follow the target so it stays inside frame without zoom.
+    public bool turnOnlyCueTrackingDuringShotHold = true;
+    // Responsiveness of cue camera turn/look while holding position after shot.
+    public float cueHoldTurnSpeed = 10f;
+    // Weight to bias cue-hold look target toward target ball (1) vs cue ball (0).
+    [Range(0f, 1f)]
+    public float cueHoldTargetBias = 0.72f;
+    [Header("Pocket cut guarantee")]
+    // Only cut to pocket camera if target enters this inner capture radius.
+    public float pocketGuaranteedInnerRadius = 0.14f;
+    // Require inward motion before pocket camera cut unless already below lip.
+    [Range(0f, 1f)]
+    public float pocketGuaranteedInwardDot = 0.82f;
+    // Minimum planar speed for the inward-motion guarantee check.
+    public float pocketGuaranteedMinPlanarSpeed = 0.05f;
+    [Header("Shot tracking handoff")]
+    // Distance from rail used to detect target-ball rail contact for cue-ball handoff.
+    public float railBounceSwitchDistance = 0.055f;
+    // If target velocity direction changes below this dot after rail contact,
+    // treat it as a bounce and hand cue tracking back to cue ball.
+    [Range(-1f, 1f)]
+    public float railBounceDirectionDotThreshold = 0.35f;
+    // Switch from cue-hold tracking to rail overhead before cue/target exits frame.
+    [Range(0.01f, 0.45f)]
+    public float frameEdgeSwitchThreshold = 0.08f;
+    // Look-ahead time used to detect cue-ball path heading toward table exit.
+    public float cueBallExitLookAheadSeconds = 0.45f;
+    // Keep break shot broadcast on the same short-rail side as the white-line end.
+    public bool breakUsesWhiteLineRailSide = true;
 
     private float yaw;
     // Blend controlling how far the cue view slides toward the cue ball. 0 keeps
@@ -266,6 +307,15 @@ public class CueCamera : MonoBehaviour
     private bool hasSmoothedCueDistance;
     private float cueStrikeHoldUntilTime;
     private bool holdCueAimDuringShot;
+    private bool hasShotRailAnchor;
+    private Vector3 shotRailAnchorPosition;
+    private bool hasCueHoldAnchor;
+    private Vector3 cueHoldAnchorPosition;
+    private float cueHoldAnchorFov;
+    private Vector3 lastTargetPlanarVelocity;
+    private bool hasLastTargetPlanarVelocity;
+    private bool targetWasNearRail;
+    private bool handoffToCueBallAfterRailBounce;
     private Vector3 ballInHandTargetPosition;
     [Header("Occlusion settings")]
     // Layers that should be considered when preventing the camera from getting
@@ -330,12 +380,18 @@ public class CueCamera : MonoBehaviour
         shotInProgress = true;
         ballInHandActive = false;
         usingTargetCamera = false;
-        holdCueAimDuringShot = cueStrikeCameraHoldSeconds > 0f;
+        holdCueAimDuringShot = !immediateRailBroadcastOnShot && cueStrikeCameraHoldSeconds > 0f;
         cueStrikeHoldUntilTime = Time.time + Mathf.Max(0f, cueStrikeCameraHoldSeconds);
+        hasShotRailAnchor = false;
+        hasCueHoldAnchor = false;
+        hasLastTargetPlanarVelocity = false;
+        targetWasNearRail = false;
+        handoffToCueBallAfterRailBounce = false;
 
         int aimSide = nextShotIsAi ? -defaultShortRailSign : defaultShortRailSign;
         cueAimSideSign = aimSide;
-        broadcastSideSign = -aimSide;
+        bool breakShot = breakUsesWhiteLineRailSide && IsLikelyBreakShot(target);
+        broadcastSideSign = breakShot ? aimSide : -aimSide;
 
         Vector3 focus = CueBall != null ? CueBall.position : tableBounds.center;
         targetViewFocus = GetBroadcastFocus(focus);
@@ -401,7 +457,24 @@ public class CueCamera : MonoBehaviour
         }
         else if (holdCueAimDuringShot && Time.time < cueStrikeHoldUntilTime)
         {
-            PositionCueAimCamera(Time.deltaTime, false);
+            if (TrySwitchToGuaranteedPocketCamera())
+            {
+                return;
+            }
+
+            if (turnOnlyCueTrackingDuringShotHold)
+            {
+                UpdateCueHoldTrackingCamera();
+                if (ShouldSwitchToBroadcastBeforeFrameExit())
+                {
+                    holdCueAimDuringShot = false;
+                    UpdateBroadcastCamera();
+                }
+            }
+            else
+            {
+                PositionCueAimCamera(Time.deltaTime, false);
+            }
         }
         else
         {
@@ -744,35 +817,24 @@ public class CueCamera : MonoBehaviour
         currentBall = CueBall;
         yaw = Mathf.LerpAngle(yaw, targetViewYaw, Time.deltaTime * shotSnapSpeed);
 
-        Vector3 cornerPocket;
-        float dynamicPocketRadius = Mathf.Max(0.01f, cornerPocketCameraRadius);
-        if (TargetBall != null)
-        {
-            Rigidbody targetRb = TargetBall.GetComponent<Rigidbody>();
-            if (targetRb != null && targetRb.velocity.sqrMagnitude > velocityThreshold)
-            {
-                dynamicPocketRadius += Mathf.Max(0f, cornerPocketApproachRadius);
-            }
-        }
-        bool shouldUsePocketCamera = TargetBall != null
-            && TargetBall.gameObject.activeInHierarchy
-            && TryGetCornerPocketForBall(TargetBall.position, dynamicPocketRadius, out cornerPocket);
-        if (shouldUsePocketCamera)
-        {
-            usingTargetCamera = true;
-            pocketCameraAwaitingDrop = true;
-            pocketDropDetected = false;
-            pocketCameraStartTime = Time.time;
-            pocketCameraReleaseTime = float.PositiveInfinity;
-            trackedCornerPocket = cornerPocket;
-            // Keep pocket framing anchored to the tracked pocket so the
-            // transition does not chase the travelling balls.
-            targetViewFocus = GetBroadcastFocus(cornerPocket);
-            UpdateTargetCamera();
-            return;
-        }
+        targetViewFocus = GetDynamicShotBroadcastFocus();
 
-        ApplyBroadcastCamera(targetViewFocus, false);
+        if (forceRailOverheadForWholeShot)
+        {
+            usingTargetCamera = false;
+            pocketCameraAwaitingDrop = false;
+            pocketDropDetected = false;
+            ApplyBroadcastCamera(targetViewFocus, false);
+        }
+        else
+        {
+            if (TrySwitchToGuaranteedPocketCamera())
+            {
+                return;
+            }
+
+            ApplyBroadcastCamera(targetViewFocus, false);
+        }
 
         bool cueMoving = IsMoving(CueBall);
         bool targetMoving = TargetBall != null && IsMoving(TargetBall);
@@ -1021,7 +1083,270 @@ public class CueCamera : MonoBehaviour
             lookTarget.y -= Mathf.Max(0f, broadcastLookDownOffset);
         }
 
+        if (shotInProgress && !isPocketCamera && lockRailBroadcastPositionDuringShot)
+        {
+            if (!hasShotRailAnchor)
+            {
+                Vector3 anchor = focus - forward * distance + Vector3.up * height;
+                anchor.x = 0f;
+                shotRailAnchorPosition = anchor;
+                hasShotRailAnchor = true;
+            }
+
+            ApplyLockedRailBroadcastCamera(shotRailAnchorPosition, lookTarget, focus, minimumHeightOffset);
+            return;
+        }
+
         ApplyShortRailCamera(focus, forward, distance, height, minimumHeightOffset, lookTarget);
+    }
+
+    private void ApplyLockedRailBroadcastCamera(
+        Vector3 lockedPosition,
+        Vector3 lookTarget,
+        Vector3 focus,
+        float minimumHeightOffset)
+    {
+        float minRailHeight = railHeight + tableAssetHeightOffset + Mathf.Max(0f, railClearance);
+        float minimumHeight = focus.y + Mathf.Max(minimumHeightAboveFocus, minimumHeightOffset);
+        minimumHeight = Mathf.Max(minimumHeight, minRailHeight);
+
+        Vector3 position = lockedPosition;
+        position.x = 0f;
+        position.y = Mathf.Max(position.y, minimumHeight);
+
+        transform.position = position;
+        transform.LookAt(lookTarget);
+    }
+
+    private Vector3 GetDynamicShotBroadcastFocus()
+    {
+        Vector3 desired = CueBall != null ? CueBall.position : tableBounds.center;
+        bool hasCue = CueBall != null && CueBall.gameObject.activeInHierarchy;
+        bool hasTarget = TargetBall != null && TargetBall.gameObject.activeInHierarchy;
+        if (hasCue && hasTarget)
+        {
+            desired = (CueBall.position + TargetBall.position) * 0.5f;
+        }
+        else if (hasTarget)
+        {
+            desired = TargetBall.position;
+        }
+
+        return GetBroadcastFocus(desired);
+    }
+
+    private void UpdateCueHoldTrackingCamera()
+    {
+        if (CueBall == null)
+        {
+            return;
+        }
+
+        if (!hasCueHoldAnchor)
+        {
+            hasCueHoldAnchor = true;
+            cueHoldAnchorPosition = transform.position;
+            if (cachedCamera == null)
+            {
+                cachedCamera = GetComponent<Camera>();
+            }
+
+            Camera cam = cachedCamera != null ? cachedCamera : Camera.main;
+            cueHoldAnchorFov = cam != null ? cam.fieldOfView : cueRaisedFieldOfView;
+        }
+
+        Transform primaryBall = GetPrimaryShotTrackingBall();
+        bool followTarget = primaryBall != null && primaryBall == TargetBall;
+
+        Vector3 desiredLook = CueBall.position;
+        if (followTarget && TargetBall != null && TargetBall.gameObject.activeInHierarchy)
+        {
+            float bias = Mathf.Clamp01(cueHoldTargetBias);
+            desiredLook = Vector3.Lerp(CueBall.position, TargetBall.position, bias);
+        }
+        else if (primaryBall != null && primaryBall.gameObject.activeInHierarchy)
+        {
+            desiredLook = primaryBall.position;
+        }
+
+        Vector3 toLook = desiredLook - cueHoldAnchorPosition;
+        if (toLook.sqrMagnitude < 0.0001f)
+        {
+            toLook = transform.forward;
+        }
+
+        Quaternion desiredRotation = Quaternion.LookRotation(toLook.normalized, Vector3.up);
+        float turnSpeed = Mathf.Max(0f, cueHoldTurnSpeed);
+        float t = turnSpeed <= 0f ? 1f : 1f - Mathf.Exp(-turnSpeed * Time.deltaTime);
+
+        transform.position = cueHoldAnchorPosition;
+        transform.rotation = Quaternion.Slerp(transform.rotation, desiredRotation, t);
+
+        if (cachedCamera == null)
+        {
+            cachedCamera = GetComponent<Camera>();
+        }
+
+        Camera camera = cachedCamera != null ? cachedCamera : Camera.main;
+        if (camera != null)
+        {
+            camera.fieldOfView = cueHoldAnchorFov;
+        }
+    }
+
+    private Transform GetPrimaryShotTrackingBall()
+    {
+        if (CueBall == null)
+        {
+            return TargetBall;
+        }
+
+        if (ShouldHandoffToCueBall())
+        {
+            return CueBall;
+        }
+
+        if (TargetBall != null && TargetBall.gameObject.activeInHierarchy)
+        {
+            return TargetBall;
+        }
+
+        return CueBall;
+    }
+
+    private bool ShouldHandoffToCueBall()
+    {
+        if (CueBall == null)
+        {
+            return false;
+        }
+
+        if (TargetBall == null || !TargetBall.gameObject.activeInHierarchy)
+        {
+            return true;
+        }
+
+        if (IsBallDroppedIntoAnyCornerPocket(TargetBall.position))
+        {
+            return true;
+        }
+
+        if (handoffToCueBallAfterRailBounce)
+        {
+            return true;
+        }
+
+        Rigidbody targetRb = TargetBall.GetComponent<Rigidbody>();
+        if (targetRb == null)
+        {
+            return false;
+        }
+
+        Vector3 currentPlanarVelocity = new Vector3(targetRb.velocity.x, 0f, targetRb.velocity.z);
+        bool nearRail = DistanceToRail(TargetBall.position, tableBounds) <= Mathf.Max(0.005f, railBounceSwitchDistance);
+
+        if (targetWasNearRail && !nearRail && hasLastTargetPlanarVelocity)
+        {
+            bool haveVelocity = currentPlanarVelocity.sqrMagnitude > 0.0001f && lastTargetPlanarVelocity.sqrMagnitude > 0.0001f;
+            if (haveVelocity)
+            {
+                float directionDot = Vector3.Dot(lastTargetPlanarVelocity.normalized, currentPlanarVelocity.normalized);
+                if (directionDot <= railBounceDirectionDotThreshold)
+                {
+                    handoffToCueBallAfterRailBounce = true;
+                }
+            }
+        }
+
+        targetWasNearRail = nearRail;
+        if (currentPlanarVelocity.sqrMagnitude > 0.0001f)
+        {
+            lastTargetPlanarVelocity = currentPlanarVelocity;
+            hasLastTargetPlanarVelocity = true;
+        }
+
+        return handoffToCueBallAfterRailBounce;
+    }
+
+    private bool IsLikelyBreakShot(Transform target)
+    {
+        if (CueBall == null || target == null || !target.gameObject.activeInHierarchy)
+        {
+            return false;
+        }
+
+        float cueToTarget = Vector3.Distance(CueBall.position, target.position);
+        float longDistanceThreshold = tableBounds.extents.z * 1.2f;
+        if (cueToTarget < longDistanceThreshold)
+        {
+            return false;
+        }
+
+        float cueSide = Mathf.Abs(CueBall.position.z - tableBounds.center.z);
+        return cueSide >= tableBounds.extents.z * 0.45f;
+    }
+
+    private bool ShouldSwitchToBroadcastBeforeFrameExit()
+    {
+        Transform primary = GetPrimaryShotTrackingBall();
+        if (IsNearViewportEdge(primary))
+        {
+            return true;
+        }
+
+        if (primary != CueBall && IsNearViewportEdge(CueBall))
+        {
+            return true;
+        }
+
+        if (primary != TargetBall && IsNearViewportEdge(TargetBall))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private bool IsNearViewportEdge(Transform ball)
+    {
+        if (ball == null || !ball.gameObject.activeInHierarchy)
+        {
+            return false;
+        }
+
+        if (cachedCamera == null)
+        {
+            cachedCamera = GetComponent<Camera>();
+        }
+
+        Camera cam = cachedCamera != null ? cachedCamera : Camera.main;
+        if (cam == null)
+        {
+            return false;
+        }
+
+        Vector3 predicted = ball.position;
+        Rigidbody rb = ball.GetComponent<Rigidbody>();
+        if (rb != null && ball == CueBall)
+        {
+            predicted += rb.velocity * Mathf.Max(0f, cueBallExitLookAheadSeconds);
+        }
+
+        Vector3 view = cam.WorldToViewportPoint(predicted);
+        if (view.z <= 0f)
+        {
+            return true;
+        }
+
+        float edge = Mathf.Clamp(frameEdgeSwitchThreshold, 0.01f, 0.45f);
+        return view.x <= edge || view.x >= 1f - edge || view.y <= edge || view.y >= 1f - edge;
+    }
+
+    private static float DistanceToRail(Vector3 point, Bounds bounds)
+    {
+        float dx = Mathf.Min(Mathf.Abs(point.x - bounds.min.x), Mathf.Abs(bounds.max.x - point.x));
+        float dz = Mathf.Min(Mathf.Abs(point.z - bounds.min.z), Mathf.Abs(bounds.max.z - point.z));
+        return Mathf.Min(dx, dz);
     }
 
     private void CacheStandingCameraPose()
@@ -1386,6 +1711,11 @@ public class CueCamera : MonoBehaviour
         shotInProgress = false;
         usingTargetCamera = false;
         holdCueAimDuringShot = false;
+        hasShotRailAnchor = false;
+        hasCueHoldAnchor = false;
+        hasLastTargetPlanarVelocity = false;
+        targetWasNearRail = false;
+        handoffToCueBallAfterRailBounce = false;
         pocketCameraAwaitingDrop = false;
         pocketDropDetected = false;
         pocketCameraStartTime = 0f;
@@ -1450,6 +1780,93 @@ public class CueCamera : MonoBehaviour
 
         float dropThreshold = railHeight + tableAssetHeightOffset - Mathf.Max(0f, pocketDropDepth);
         return ballPosition.y <= dropThreshold;
+    }
+
+    private bool IsBallDroppedIntoAnyCornerPocket(Vector3 ballPosition)
+    {
+        Vector3 pocket;
+        if (!TryGetCornerPocketForBall(ballPosition, Mathf.Max(0.01f, cornerPocketCameraRadius), out pocket))
+        {
+            return false;
+        }
+
+        float dropThreshold = railHeight + tableAssetHeightOffset - Mathf.Max(0f, pocketDropDepth);
+        if (ballPosition.y > dropThreshold)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private bool TrySwitchToGuaranteedPocketCamera()
+    {
+        Vector3 guaranteedPocket;
+        if (!IsGuaranteedPocketCut(TargetBall, out guaranteedPocket))
+        {
+            return false;
+        }
+
+        usingTargetCamera = true;
+        pocketCameraAwaitingDrop = true;
+        pocketDropDetected = false;
+        pocketCameraStartTime = Time.time;
+        pocketCameraReleaseTime = float.PositiveInfinity;
+        trackedCornerPocket = guaranteedPocket;
+        targetViewFocus = GetBroadcastFocus(guaranteedPocket);
+        UpdateTargetCamera();
+        return true;
+    }
+
+    private bool IsGuaranteedPocketCut(Transform targetBall, out Vector3 pocket)
+    {
+        pocket = Vector3.zero;
+        if (targetBall == null || !targetBall.gameObject.activeInHierarchy)
+        {
+            return false;
+        }
+
+        float triggerRadius = Mathf.Max(0.01f, cornerPocketCameraRadius);
+        if (!TryGetCornerPocketForBall(targetBall.position, triggerRadius, out pocket))
+        {
+            return false;
+        }
+
+        Vector2 ballXZ = new Vector2(targetBall.position.x, targetBall.position.z);
+        Vector2 pocketXZ = new Vector2(pocket.x, pocket.z);
+        float innerRadius = Mathf.Max(0.01f, Mathf.Min(triggerRadius, pocketGuaranteedInnerRadius));
+        bool inInnerCapture = (ballXZ - pocketXZ).sqrMagnitude <= innerRadius * innerRadius;
+
+        float dropThreshold = railHeight + tableAssetHeightOffset - Mathf.Max(0f, pocketDropDepth);
+        bool belowPocketLip = targetBall.position.y <= dropThreshold;
+        if (belowPocketLip)
+        {
+            return true;
+        }
+
+        Rigidbody rb = targetBall.GetComponent<Rigidbody>();
+        if (rb == null)
+        {
+            return false;
+        }
+
+        Vector3 planarVel = new Vector3(rb.velocity.x, 0f, rb.velocity.z);
+        float minSpeed = Mathf.Max(0f, pocketGuaranteedMinPlanarSpeed);
+        if (planarVel.sqrMagnitude <= minSpeed * minSpeed)
+        {
+            return false;
+        }
+
+        Vector3 toPocket = pocket - targetBall.position;
+        toPocket.y = 0f;
+        if (toPocket.sqrMagnitude < 0.0001f)
+        {
+            return inInnerCapture;
+        }
+
+        float inwardDot = Vector3.Dot(planarVel.normalized, toPocket.normalized);
+        bool movingInward = inwardDot >= Mathf.Clamp01(pocketGuaranteedInwardDot);
+        return inInnerCapture && movingInward;
     }
 
     private static float GetShortRailYaw(int sideSign)

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5855,7 +5855,7 @@ const BREAK_VIEW = Object.freeze({
 const CAMERA_RAIL_SAFETY = 0.006;
 const TOP_VIEW_MARGIN = 1.14; // keep both near pockets visible on portrait
 const TOP_VIEW_MIN_RADIUS_SCALE = 1.11; // lift the 2D camera slightly higher so portrait top view reads more elevated
-const TOP_VIEW_PHI = 0; // lock the 2D view to a straight-overhead camera
+const TOP_VIEW_PHI = 0; // lock explicit 2D mode to straight overhead
 const TOP_VIEW_RADIUS_SCALE = 1.11; // keep 2D framing a little higher so the camera sits a bit farther up
 const TOP_VIEW_REFERENCE_ASPECT = 9 / 16; // keep 2D framing anchored to portrait proportions across rotations
 const TOP_VIEW_RESOLVED_PHI = TOP_VIEW_PHI;
@@ -5867,8 +5867,8 @@ const RAIL_OVERHEAD_SCREEN_OFFSET = Object.freeze({
   x: TOP_VIEW_SCREEN_OFFSET.x,
   z: TOP_VIEW_SCREEN_OFFSET.z + PLAY_H * 0.014 // nudge rail-overhead framing a touch more inward so bottom pockets remain visible on portrait
 });
-const RAIL_OVERHEAD_TOP_VIEW_MIN_RADIUS_SCALE = TOP_VIEW_MIN_RADIUS_SCALE; // keep rail overhead aligned with 2D framing
-const RAIL_OVERHEAD_TOP_VIEW_RADIUS_SCALE = TOP_VIEW_RADIUS_SCALE * 1.035; // lift rail-overhead camera slightly higher for clearer broadcast context
+const RAIL_OVERHEAD_TOP_VIEW_MIN_RADIUS_SCALE = TOP_VIEW_MIN_RADIUS_SCALE * 0.97; // broadcast rail view sits closer than strict top-view mode
+const RAIL_OVERHEAD_TOP_VIEW_RADIUS_SCALE = TOP_VIEW_RADIUS_SCALE * 0.95; // keep broadcast in 3D perspective instead of 2D-like overhead
 const REPLAY_TOP_VIEW_MARGIN = TOP_VIEW_MARGIN;
 const REPLAY_TOP_VIEW_MIN_RADIUS_SCALE = TOP_VIEW_MIN_RADIUS_SCALE;
 const REPLAY_TOP_VIEW_PHI = TOP_VIEW_PHI;
@@ -5877,7 +5877,7 @@ const REPLAY_TOP_VIEW_RESOLVED_PHI = TOP_VIEW_RESOLVED_PHI;
 const REPLAY_TOP_VIEW_SCREEN_OFFSET = TOP_VIEW_SCREEN_OFFSET;
 const BROADCAST_TOP_VIEW_MARGIN = TOP_VIEW_MARGIN;
 const BROADCAST_TOP_VIEW_MIN_RADIUS_SCALE = TOP_VIEW_MIN_RADIUS_SCALE;
-const BROADCAST_TOP_VIEW_PHI = 0;
+const BROADCAST_TOP_VIEW_PHI = 0.18; // keep broadcast camera visibly 3D (not flat 2D top view)
 const BROADCAST_TOP_VIEW_RADIUS_SCALE = TOP_VIEW_RADIUS_SCALE;
 const BROADCAST_TOP_VIEW_RESOLVED_PHI = BROADCAST_TOP_VIEW_PHI;
 const BROADCAST_TOP_VIEW_SCREEN_OFFSET = TOP_VIEW_SCREEN_OFFSET;
@@ -5892,9 +5892,8 @@ const BROADCAST_TOP_VIEW_VARIANTS = Object.freeze({
 });
 const resolveBroadcastTopViewVariant = (variant) =>
   BROADCAST_TOP_VIEW_VARIANTS[variant] ?? BROADCAST_TOP_VIEW_VARIANTS.pool;
-// Keep the rail overhead broadcast framing nearly identical to the 2D top view while
-// leaving a small tilt for depth cues.
-const RAIL_OVERHEAD_PHI = TOP_VIEW_RESOLVED_PHI + 0.01; // keep overhead framing close to 2D while adding a slight broadcast tilt
+// Keep rail-overhead clearly broadcast/3D and avoid 2D-style straight-down framing.
+const RAIL_OVERHEAD_PHI = Math.max(BROADCAST_TOP_VIEW_RESOLVED_PHI, TOP_VIEW_RESOLVED_PHI + 0.18);
 const BROADCAST_MARGIN_WIDTH = (PLAY_W / 2) * (TOP_VIEW_MARGIN - 1);
 const BROADCAST_MARGIN_LENGTH = (PLAY_H / 2) * (TOP_VIEW_MARGIN - 1);
 const computeTopViewBroadcastDistance = (aspect = 1, fov = STANDING_VIEW_FOV) => {
@@ -5909,7 +5908,7 @@ const computeTopViewBroadcastDistance = (aspect = 1, fov = STANDING_VIEW_FOV) =>
     (halfLength / Math.tan(halfVertical)) * RAIL_OVERHEAD_TOP_VIEW_RADIUS_SCALE;
   return Math.max(widthDistance, lengthDistance);
 };
-const RAIL_OVERHEAD_DISTANCE_BIAS = 1; // keep overhead rail/broadcast framing identical to 2D view
+const RAIL_OVERHEAD_DISTANCE_BIAS = 0.94; // pull broadcast rail camera inward for stronger depth versus 2D mode
 const SHORT_RAIL_CAMERA_DISTANCE =
   computeTopViewBroadcastDistance() * RAIL_OVERHEAD_DISTANCE_BIAS; // match the 2D top view framing distance for overhead rail cuts while keeping a touch of breathing room
 const SIDE_RAIL_CAMERA_DISTANCE = SHORT_RAIL_CAMERA_DISTANCE; // keep side-rail framing aligned with the top view scale
@@ -5944,7 +5943,7 @@ const CUE_VIEW_AIM_SLOW_FACTOR = 0.35; // slow pointer rotation while blended to
 const CUE_VIEW_AIM_LINE_LERP = 0.1; // aiming line interpolation factor while the camera is near cue view
 const STANDING_VIEW_AIM_LINE_LERP = 0.2; // aiming line interpolation factor while the camera is near standing view
 const CUE_VIEW_SPIN_ZOOM = 0; // remove zoom shifts while spin control is active
-const RAIL_OVERHEAD_AIM_ZOOM = 0.94; // gently pull the rail overhead view closer for middle-pocket aims
+const RAIL_OVERHEAD_AIM_ZOOM = 1; // no extra zoom while tracking; rotate/look dynamics only
 const RAIL_OVERHEAD_AIM_PHI_LIFT = 0.014; // keep rail-overhead aim view marginally more downward while preserving depth
 const RAIL_OVERHEAD_REPLAY_FOV = STANDING_VIEW_FOV + 6; // widen rail-overhead lens a bit more so both bottom pockets stay visible on portrait screens
 const PORTRAIT_TOP_ACTION_BAR_DROP_REM = 1.05; // move portrait gift/chat/menu controls a bit lower from the top edge
@@ -6198,6 +6197,23 @@ const resolveOppositeShortRailCamera = ({ cueBall = null, fallback = 1 } = {}) =
     return -signed(meaningful, fallback);
   }
   return -signed(fallback, 1);
+};
+const resolveSameShortRailCamera = ({ cueBall = null, fallback = 1 } = {}) => {
+  if (!cueBall) {
+    return signed(fallback, 1);
+  }
+  const references = [
+    Number.isFinite(cueBall.pos?.y) ? cueBall.pos.y : null,
+    Number.isFinite(cueBall.launchDir?.y) ? cueBall.launchDir.y : null,
+    Number.isFinite(cueBall.vel?.y) ? cueBall.vel.y : null
+  ];
+  const meaningful = references.find(
+    (value) => Number.isFinite(value) && Math.abs(value) > BALL_R * 0.1
+  );
+  if (meaningful != null) {
+    return signed(meaningful, fallback);
+  }
+  return signed(fallback, 1);
 };
 const computeStandingViewHeight = (
   targetHeight,
@@ -19720,6 +19736,7 @@ const powerRef = useRef(hud.power);
 
         const maybeForceShortRailPocketView = (ball) => {
           if (!ball?.active) return;
+          if (!shotPrediction || String(shotPrediction.ballId) !== String(ball.id)) return;
           const posY = ball.pos?.y;
           if (!Number.isFinite(posY)) return;
           if (Math.abs(posY) < SHORT_RAIL_POCKET_TRIGGER) return;
@@ -19733,6 +19750,26 @@ const powerRef = useRef(hud.power);
           const travelSign = forward > 0 ? 1 : -1;
           const railSign = posY > 0 ? 1 : posY < 0 ? -1 : travelSign;
           if (travelSign !== railSign) return;
+          const predictedDir = shotPrediction?.dir?.clone?.();
+          if (!predictedDir || predictedDir.lengthSq() < 1e-6) return;
+          predictedDir.normalize();
+          const centers = pocketCenters();
+          let bestCorner = null;
+          let bestDot = -Infinity;
+          for (const center of centers) {
+            const id = pocketIdFromCenter(center);
+            const isCorner = id === 'TL' || id === 'TR' || id === 'BL' || id === 'BR';
+            if (!isCorner) continue;
+            const toPocket = center.clone().sub(ball.pos);
+            if (toPocket.lengthSq() < 1e-6) continue;
+            const dot = toPocket.normalize().dot(predictedDir);
+            if (dot > bestDot) {
+              bestDot = dot;
+              bestCorner = { center, id };
+            }
+          }
+          if (!bestCorner) return;
+          if (bestDot < POCKET_GUARANTEED_ALIGNMENT) return;
           const now = performance.now();
           const currentIntent = pocketSwitchIntentRef.current;
           if (currentIntent?.ballId === ball.id && currentIntent.forced) {
@@ -19746,7 +19783,8 @@ const powerRef = useRef(hud.power);
           pocketSwitchIntentRef.current = {
             ballId: ball.id,
             forced: true,
-            allowEarly: true,
+            allowEarly: false,
+            preferredPocketId: bestCorner.id,
             createdAt: now
           };
         };
@@ -21479,10 +21517,19 @@ const powerRef = useRef(hud.power);
           const shortRailDir = signed(
             cueBall.pos.y ?? cueBall.launchDir?.y ?? railNormal?.y ?? 1
           );
-          const initialRailDir = resolveOppositeShortRailCamera({
-            cueBall,
-            fallback: shortRailDir
-          });
+          const cueToTargetDistance = targetBall
+            ? cueBall.pos.distanceTo(targetBall.pos)
+            : 0;
+          const openingBreakLikeShot = cueToTargetDistance >= PLAY_H * 0.62;
+          const initialRailDir = openingBreakLikeShot
+            ? resolveSameShortRailCamera({
+                cueBall,
+                fallback: shortRailDir
+              })
+            : resolveOppositeShortRailCamera({
+                cueBall,
+                fallback: shortRailDir
+              });
           const preferRailOverhead = true;
           const now = performance.now();
           const activationDelay = null;
@@ -29111,40 +29158,8 @@ const powerRef = useRef(hud.power);
           pocketSwitchIntentRef.current = null;
           lastPocketBallRef.current = null;
           updatePocketCameraState(false);
-          if (autoReplayEnabled && shouldStartReplay && postShotSnapshot) {
-            const recordingForReplay = shotRecording;
-            const launchReplay = () => {
-              replayBannerTimeoutRef.current = null;
-              setReplayBanner(null);
-              const slateLead = triggerReplaySlate(replayBannerText, { accent: replayAccent });
-              const beginReplay = () => {
-                shotRecording = recordingForReplay;
-                if (recordingForReplay) {
-                  startShotReplay(postShotSnapshot);
-                } else {
-                  shotReplayRef.current = null;
-                }
-                shotRecording = null;
-              };
-              if (slateLead > 0) {
-                window.setTimeout(beginReplay, slateLead);
-              } else {
-                beginReplay();
-              }
-            };
-            if (replayBannerTimeoutRef.current) {
-              clearTimeout(replayBannerTimeoutRef.current);
-              replayBannerTimeoutRef.current = null;
-            }
-            setReplayBanner(replayBannerText);
-            replayBannerTimeoutRef.current = window.setTimeout(
-              launchReplay,
-              GOOD_SHOT_REPLAY_DELAY_MS
-            );
-          } else {
-            shotReplayRef.current = null;
-            shotRecording = null;
-          }
+          shotReplayRef.current = null;
+          shotRecording = null;
           aiPlanRef.current = null;
           aiPlanCacheRef.current = { key: null, plan: null };
           clearEarlyAiShot();
@@ -32571,28 +32586,6 @@ const powerRef = useRef(hud.power);
         </div>
       )}
 
-      {replayBanner && (
-        <div className="pointer-events-none absolute top-4 right-4 z-50">
-          <div
-            className="flex items-center gap-2 rounded-full bg-gradient-to-r from-emerald-300 to-cyan-300 px-5 py-2 text-xs font-bold uppercase tracking-[0.28em] text-slate-900 shadow-[0_12px_32px_rgba(0,0,0,0.45)] ring-2 ring-white/30"
-            aria-live="polite"
-          >
-            <span className="drop-shadow-[0_1px_2px_rgba(255,255,255,0.35)]">
-              {replayBanner}
-            </span>
-          </div>
-        </div>
-      )}
-      {replaySlate && (
-        <div className="pointer-events-none absolute inset-0 z-[105] flex items-center justify-center">
-          <div className="rounded-2xl border border-white/35 bg-black/72 px-8 py-5 text-center shadow-[0_22px_48px_rgba(0,0,0,0.6)] backdrop-blur-sm">
-            <p className="text-[10px] font-semibold uppercase tracking-[0.34em] text-white/70">Replay frame</p>
-            <p className="mt-2 text-2xl font-black uppercase tracking-[0.2em] text-white">
-              {replaySlate.label || 'Replay'}
-            </p>
-          </div>
-        </div>
-      )}
       {ruleToast && (
         <div className="pointer-events-none absolute left-1/2 top-6 z-50 -translate-x-1/2 px-3 text-center">
           <span className="text-sm font-bold uppercase tracking-[0.24em] text-white drop-shadow-[0_2px_10px_rgba(0,0,0,0.45)]">
@@ -32883,46 +32876,6 @@ const powerRef = useRef(hud.power);
         </div>
       )}
 
-      {replayActive && (
-        <div className="pointer-events-none absolute inset-0 z-40">
-          <div className="absolute inset-0 rounded-[28px] border border-white/12 shadow-[0_0_32px_rgba(0,0,0,0.55),0_0_0_8px_rgba(0,0,0,0.45)]" />
-          <div className="absolute inset-0 rounded-[28px] bg-gradient-to-b from-black/55 via-transparent to-black/55" />
-          <div className="absolute inset-x-10 top-6 h-px bg-gradient-to-r from-transparent via-white/35 to-transparent" />
-          <div className="absolute inset-x-10 bottom-6 h-px bg-gradient-to-r from-transparent via-white/35 to-transparent" />
-        </div>
-      )}
-      {replayActive && (
-        <>
-          <div className="pointer-events-none absolute left-4 top-4 z-50">
-            <div className="rounded-full border border-white/25 bg-black/70 px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.34em] text-white shadow-[0_12px_32px_rgba(0,0,0,0.45)]">
-              Replay
-            </div>
-            {replayFoul && (
-              <div className="mt-2 rounded-full border border-red-300/70 bg-red-500/30 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.28em] text-red-100 shadow-[0_10px_28px_rgba(0,0,0,0.45)]">
-                Foul{replayFoul.reason ? `: ${replayFoul.reason}` : ''}
-              </div>
-            )}
-          </div>
-          <div className="pointer-events-auto absolute right-8 top-1/2 z-50 flex -translate-y-1/2 items-center">
-            <button
-              type="button"
-              onClick={() => skipReplayRef.current?.()}
-              className="pointer-events-auto flex h-10 w-10 items-center justify-center rounded-full border border-white/25 bg-black/70 text-white shadow-[0_12px_32px_rgba(0,0,0,0.45)] transition-colors duration-200 hover:bg-black/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300"
-            >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                fill="currentColor"
-                className="h-5 w-5"
-                aria-hidden="true"
-              >
-                <path d="M4 7.25a1 1 0 0 1 1.6-.8l6 4.75a1 1 0 0 1 0 1.6l-6 4.75A1 1 0 0 1 4 16.75zM12.5 7.25a1 1 0 0 1 1.6-.8l6 4.75a1 1 0 0 1 0 1.6l-6 4.75a1 1 0 0 1-1.6-.8z" />
-              </svg>
-              <span className="sr-only">Skip replay</span>
-            </button>
-          </div>
-        </>
-      )}
 
       {(!isPortrait || (isPortrait && configOpen && !isFreePractice && !hideNonEssentialHud)) && (
       <div
@@ -33394,33 +33347,6 @@ const powerRef = useRef(hud.power);
                     );
                   })}
                 </div>
-              </div>
-              <div>
-                <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
-                  Replay Controls
-                </h3>
-                <button
-                  type="button"
-                  onClick={() => setAutoReplayEnabled((prev) => !prev)}
-                  aria-pressed={autoReplayEnabled}
-                  className={`mt-2 w-full rounded-2xl border px-4 py-2 text-left transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
-                    autoReplayEnabled
-                      ? 'border-emerald-300 bg-emerald-300/90 text-black shadow-[0_0_16px_rgba(16,185,129,0.55)]'
-                      : 'border-white/20 bg-white/10 text-white/80 hover:bg-white/20'
-                  }`}
-                >
-                  <span className="flex items-center justify-between gap-2">
-                    <span className="text-[11px] font-semibold uppercase tracking-[0.28em]">
-                      Auto Replay
-                    </span>
-                    <span className="text-[10px] font-semibold uppercase tracking-[0.2em]">
-                      {autoReplayEnabled ? 'On' : 'Off'}
-                    </span>
-                  </span>
-                  <span className="mt-1 block text-[10px] uppercase tracking-[0.16em] text-white/60">
-                    Replays keep live graphics quality and appear on potted/foul moments.
-                  </span>
-                </button>
               </div>
             </div>
           </div>


### PR DESCRIPTION
### Motivation
- Provide more robust broadcast framing and camera behavior during shots including immediate rail cuts, locked rail positions, and improved cue-hold tracking so the camera keeps a stable, readable view during and after strikes.
- Guarantee pocket cut-ins only when a ball is clearly committing to a corner pocket and implement safer handoffs between tracking the target ball and the cue ball when rails/bounces occur.
- Align web client broadcast/top-view constants and logic with the new rail-overhead behaviour and improve pocket intent prediction and replay cleanup in the UI.

### Description
- Added multiple new broadcast and hold tuning fields to `CueCamera` (`immediateRailBroadcastOnShot`, `lockRailBroadcastPositionDuringShot`, `forceRailOverheadForWholeShot`, `turnOnlyCueTrackingDuringShotHold`, `cueHoldTurnSpeed`, `cueHoldTargetBias`, pocket guarantee and rail-handoff parameters) and new private state fields to support anchors and velocity heuristics.
- Implemented locked rail broadcast (`ApplyLockedRailBroadcastCamera` + `GetDynamicShotBroadcastFocus`) and cue-hold rotation-only tracking (`UpdateCueHoldTrackingCamera`) with bias toward target ball via `cueHoldTargetBias`, plus logic to optionally trigger immediate rail broadcast on shot and to prefer same-side rail for likely break shots (`IsLikelyBreakShot`).
- Implemented guaranteed pocket cut detection and handling via `IsGuaranteedPocketCut`, `TrySwitchToGuaranteedPocketCamera`, `IsBallDroppedIntoAnyCornerPocket`, and improved pocket tracking/release state flows; added rail-bounce handoff detection using planar velocity comparisons (`ShouldHandoffToCueBall`, `DistanceToRail`).
- Added viewport-edge lookahead and handoff checks (`IsNearViewportEdge`, `ShouldSwitchToBroadcastBeforeFrameExit`) to force broadcast switch before tracked objects exit view, and reset new shot state in `EndShot`.
- Web client updates in `PoolRoyale.jsx` include top/broadcast view constant adjustments (`BROADCAST_TOP_VIEW_PHI`, `RAIL_OVERHEAD_PHI`, `RAIL_OVERHEAD_DISTANCE_BIAS`, `RAIL_OVERHEAD_AIM_ZOOM`), added `resolveSameShortRailCamera`, logic to prefer same-side rail for opening/break-like shots, stricter pocket intent gating by matching `shotPrediction` and requiring alignment with a corner pocket, and removed/cleaned up the previous auto-replay launch path and related UI banner flow.

### Testing
- Ran the web client static checks and unit tests (`npm run lint` and `npm test`) and an application build (`npm run build`), all of which completed without errors.
- Performed a webapp smoke run (local dev server) to verify new camera constants and pocket intent logic do not throw runtime exceptions and UI renders correctly. 
- Compiled the Unity project scripts to validate C# changes (editor script compile), and the code compiles cleanly with no C# compile errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d34049feb08329901a08a9f385db7a)