### PR TITLE
Pool Royale: restore replay flow and add cue-shot pullback to rail broadcast camera

### DIFF
--- a/billiards.Unity/CueCamera.cs
+++ b/billiards.Unity/CueCamera.cs
@@ -239,7 +239,7 @@ public class CueCamera : MonoBehaviour
     [Header("Broadcast shot behavior")]
     // Switch to the rail-overhead broadcast framing immediately once a shot is
     // triggered instead of waiting on the cue-strike hold timer.
-    public bool immediateRailBroadcastOnShot = false;
+    public bool immediateRailBroadcastOnShot = true;
     // Keep a fixed rail-overhead camera position during the entire shot so the
     // view tracks action by turning/looking only (no zoom/dolly moves).
     public bool lockRailBroadcastPositionDuringShot = true;
@@ -255,6 +255,13 @@ public class CueCamera : MonoBehaviour
     // Weight to bias cue-hold look target toward target ball (1) vs cue ball (0).
     [Range(0f, 1f)]
     public float cueHoldTargetBias = 0.72f;
+    [Header("Shot pullback transition")]
+    // Blend from the standing/cue trigger pose into the short-rail broadcast
+    // anchor while the shot starts. Keeps the move readable instead of a hard cut.
+    public bool enableShotPullbackFromStanding = true;
+    // Duration used to pull back from the shot-trigger pose to the outside
+    // short-rail edge camera.
+    public float shotPullbackDuration = 0.28f;
     [Header("Pocket cut guarantee")]
     // Only cut to pocket camera if target enters this inner capture radius.
     public float pocketGuaranteedInnerRadius = 0.14f;
@@ -312,6 +319,10 @@ public class CueCamera : MonoBehaviour
     private bool hasCueHoldAnchor;
     private Vector3 cueHoldAnchorPosition;
     private float cueHoldAnchorFov;
+    private bool hasShotPullbackAnchor;
+    private Vector3 shotPullbackStartPosition;
+    private Quaternion shotPullbackStartRotation;
+    private float shotStartedTime;
     private Vector3 lastTargetPlanarVelocity;
     private bool hasLastTargetPlanarVelocity;
     private bool targetWasNearRail;
@@ -382,7 +393,9 @@ public class CueCamera : MonoBehaviour
         usingTargetCamera = false;
         holdCueAimDuringShot = !immediateRailBroadcastOnShot && cueStrikeCameraHoldSeconds > 0f;
         cueStrikeHoldUntilTime = Time.time + Mathf.Max(0f, cueStrikeCameraHoldSeconds);
+        shotStartedTime = Time.time;
         hasShotRailAnchor = false;
+        hasShotPullbackAnchor = false;
         hasCueHoldAnchor = false;
         hasLastTargetPlanarVelocity = false;
         targetWasNearRail = false;
@@ -401,6 +414,12 @@ public class CueCamera : MonoBehaviour
         }
         targetViewYaw = GetShortRailYaw(broadcastSideSign);
         yaw = targetViewYaw;
+        if (enableShotPullbackFromStanding)
+        {
+            hasShotPullbackAnchor = true;
+            shotPullbackStartPosition = transform.position;
+            shotPullbackStartRotation = transform.rotation;
+        }
 
         nextShotIsAi = false;
     }
@@ -1114,8 +1133,30 @@ public class CueCamera : MonoBehaviour
         position.x = 0f;
         position.y = Mathf.Max(position.y, minimumHeight);
 
-        transform.position = position;
-        transform.LookAt(lookTarget);
+        Vector3 finalPosition = position;
+        Quaternion finalRotation = Quaternion.LookRotation((lookTarget - finalPosition).normalized, Vector3.up);
+        if (shotInProgress && enableShotPullbackFromStanding && hasShotPullbackAnchor)
+        {
+            float duration = Mathf.Max(0f, shotPullbackDuration);
+            if (duration > 0.0001f)
+            {
+                float elapsed = Mathf.Max(0f, Time.time - shotStartedTime);
+                float blend = Mathf.Clamp01(elapsed / duration);
+                float eased = 1f - Mathf.Pow(1f - blend, 3f);
+                finalPosition = Vector3.Lerp(shotPullbackStartPosition, position, eased);
+                finalPosition.x = 0f;
+                finalPosition.y = Mathf.Max(finalPosition.y, minimumHeight);
+                Quaternion startRotation = shotPullbackStartRotation;
+                if (startRotation == default(Quaternion))
+                {
+                    startRotation = transform.rotation;
+                }
+                finalRotation = Quaternion.Slerp(startRotation, finalRotation, eased);
+            }
+        }
+
+        transform.position = finalPosition;
+        transform.rotation = finalRotation;
     }
 
     private Vector3 GetDynamicShotBroadcastFocus()
@@ -1712,6 +1753,7 @@ public class CueCamera : MonoBehaviour
         usingTargetCamera = false;
         holdCueAimDuringShot = false;
         hasShotRailAnchor = false;
+        hasShotPullbackAnchor = false;
         hasCueHoldAnchor = false;
         hasLastTargetPlanarVelocity = false;
         targetWasNearRail = false;

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -29158,8 +29158,40 @@ const powerRef = useRef(hud.power);
           pocketSwitchIntentRef.current = null;
           lastPocketBallRef.current = null;
           updatePocketCameraState(false);
-          shotReplayRef.current = null;
-          shotRecording = null;
+          if (autoReplayEnabled && shouldStartReplay && postShotSnapshot) {
+            const recordingForReplay = shotRecording;
+            const launchReplay = () => {
+              replayBannerTimeoutRef.current = null;
+              setReplayBanner(null);
+              const slateLead = triggerReplaySlate(replayBannerText, { accent: replayAccent });
+              const beginReplay = () => {
+                shotRecording = recordingForReplay;
+                if (recordingForReplay) {
+                  startShotReplay(postShotSnapshot);
+                } else {
+                  shotReplayRef.current = null;
+                }
+                shotRecording = null;
+              };
+              if (slateLead > 0) {
+                window.setTimeout(beginReplay, slateLead);
+              } else {
+                beginReplay();
+              }
+            };
+            if (replayBannerTimeoutRef.current) {
+              clearTimeout(replayBannerTimeoutRef.current);
+              replayBannerTimeoutRef.current = null;
+            }
+            setReplayBanner(replayBannerText);
+            replayBannerTimeoutRef.current = window.setTimeout(
+              launchReplay,
+              GOOD_SHOT_REPLAY_DELAY_MS
+            );
+          } else {
+            shotReplayRef.current = null;
+            shotRecording = null;
+          }
           aiPlanRef.current = null;
           aiPlanCacheRef.current = { key: null, plan: null };
           clearEarlyAiShot();
@@ -32586,6 +32618,28 @@ const powerRef = useRef(hud.power);
         </div>
       )}
 
+      {replayBanner && (
+        <div className="pointer-events-none absolute top-4 right-4 z-50">
+          <div
+            className="flex items-center gap-2 rounded-full bg-gradient-to-r from-emerald-300 to-cyan-300 px-5 py-2 text-xs font-bold uppercase tracking-[0.28em] text-slate-900 shadow-[0_12px_32px_rgba(0,0,0,0.45)] ring-2 ring-white/30"
+            aria-live="polite"
+          >
+            <span className="drop-shadow-[0_1px_2px_rgba(255,255,255,0.35)]">
+              {replayBanner}
+            </span>
+          </div>
+        </div>
+      )}
+      {replaySlate && (
+        <div className="pointer-events-none absolute inset-0 z-[105] flex items-center justify-center">
+          <div className="rounded-2xl border border-white/35 bg-black/72 px-8 py-5 text-center shadow-[0_22px_48px_rgba(0,0,0,0.6)] backdrop-blur-sm">
+            <p className="text-[10px] font-semibold uppercase tracking-[0.34em] text-white/70">Replay frame</p>
+            <p className="mt-2 text-2xl font-black uppercase tracking-[0.2em] text-white">
+              {replaySlate.label || 'Replay'}
+            </p>
+          </div>
+        </div>
+      )}
       {ruleToast && (
         <div className="pointer-events-none absolute left-1/2 top-6 z-50 -translate-x-1/2 px-3 text-center">
           <span className="text-sm font-bold uppercase tracking-[0.24em] text-white drop-shadow-[0_2px_10px_rgba(0,0,0,0.45)]">
@@ -32874,6 +32928,47 @@ const powerRef = useRef(hud.power);
         <div className="pointer-events-none absolute top-6 left-1/2 z-50 -translate-x-1/2 px-4 py-2 text-center text-xs font-semibold uppercase tracking-[0.28em] text-white/80">
           Scroll and click to change the cue
         </div>
+      )}
+
+      {replayActive && (
+        <div className="pointer-events-none absolute inset-0 z-40">
+          <div className="absolute inset-0 rounded-[28px] border border-white/12 shadow-[0_0_32px_rgba(0,0,0,0.55),0_0_0_8px_rgba(0,0,0,0.45)]" />
+          <div className="absolute inset-0 rounded-[28px] bg-gradient-to-b from-black/55 via-transparent to-black/55" />
+          <div className="absolute inset-x-10 top-6 h-px bg-gradient-to-r from-transparent via-white/35 to-transparent" />
+          <div className="absolute inset-x-10 bottom-6 h-px bg-gradient-to-r from-transparent via-white/35 to-transparent" />
+        </div>
+      )}
+      {replayActive && (
+        <>
+          <div className="pointer-events-none absolute left-4 top-4 z-50">
+            <div className="rounded-full border border-white/25 bg-black/70 px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.34em] text-white shadow-[0_12px_32px_rgba(0,0,0,0.45)]">
+              Replay
+            </div>
+            {replayFoul && (
+              <div className="mt-2 rounded-full border border-red-300/70 bg-red-500/30 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.28em] text-red-100 shadow-[0_10px_28px_rgba(0,0,0,0.45)]">
+                Foul{replayFoul.reason ? `: ${replayFoul.reason}` : ''}
+              </div>
+            )}
+          </div>
+          <div className="pointer-events-auto absolute right-8 top-1/2 z-50 flex -translate-y-1/2 items-center">
+            <button
+              type="button"
+              onClick={() => skipReplayRef.current?.()}
+              className="pointer-events-auto flex h-10 w-10 items-center justify-center rounded-full border border-white/25 bg-black/70 text-white shadow-[0_12px_32px_rgba(0,0,0,0.45)] transition-colors duration-200 hover:bg-black/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                className="h-5 w-5"
+                aria-hidden="true"
+              >
+                <path d="M4 7.25a1 1 0 0 1 1.6-.8l6 4.75a1 1 0 0 1 0 1.6l-6 4.75A1 1 0 0 1 4 16.75zM12.5 7.25a1 1 0 0 1 1.6-.8l6 4.75a1 1 0 0 1 0 1.6l-6 4.75a1 1 0 0 1-1.6-.8z" />
+              </svg>
+              <span className="sr-only">Skip replay</span>
+            </button>
+          </div>
+        </>
       )}
 
 
@@ -33347,6 +33442,33 @@ const powerRef = useRef(hud.power);
                     );
                   })}
                 </div>
+              </div>
+              <div>
+                <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
+                  Replay Controls
+                </h3>
+                <button
+                  type="button"
+                  onClick={() => setAutoReplayEnabled((prev) => !prev)}
+                  aria-pressed={autoReplayEnabled}
+                  className={`mt-2 w-full rounded-2xl border px-4 py-2 text-left transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
+                    autoReplayEnabled
+                      ? 'border-emerald-300 bg-emerald-300/90 text-black shadow-[0_0_16px_rgba(16,185,129,0.55)]'
+                      : 'border-white/20 bg-white/10 text-white/80 hover:bg-white/20'
+                  }`}
+                >
+                  <span className="flex items-center justify-between gap-2">
+                    <span className="text-[11px] font-semibold uppercase tracking-[0.28em]">
+                      Auto Replay
+                    </span>
+                    <span className="text-[10px] font-semibold uppercase tracking-[0.2em]">
+                      {autoReplayEnabled ? 'On' : 'Off'}
+                    </span>
+                  </span>
+                  <span className="mt-1 block text-[10px] uppercase tracking-[0.16em] text-white/60">
+                    Replays keep live graphics quality and appear on potted/foul moments.
+                  </span>
+                </button>
               </div>
             </div>
           </div>


### PR DESCRIPTION
### Motivation
- Replay playback and UI had been removed and needs to be restored so good-shot/foul replays run using the live broadcast capture as before. 
- The cue camera should remain on the outside short-rail during shots and avoid sudden hard cuts by blending from the standing/cue trigger pose to the locked rail position. 
- The shot behavior must apply for both player and AI-triggered shots and preserve no-zoom rotation-only tracking while the broadcast camera follows the action.

### Description
- Reinstated replay launch and playback flow in `webapp/src/pages/Games/PoolRoyale.jsx` so `shotRecording` is used to schedule the replay banner, slate and `startShotReplay` at `GOOD_SHOT_REPLAY_DELAY_MS` and restored the `Auto Replay` toggle and replay HUD (`replayBanner`, `replaySlate`, replay overlay and skip button). 
- Restored the in-game replay path to use the broadcast capture and preserved the recorded camera snapshot usage so replay playback follows the same rendering/fps path as live broadcast. 
- Updated `billiards.Unity/CueCamera.cs` to default `immediateRailBroadcastOnShot = true`, added shot pullback state (`shotPullbackStartPosition`, `shotPullbackStartRotation`, `shotStartedTime`) and configurable pullback (`enableShotPullbackFromStanding`, `shotPullbackDuration`) and blended from the trigger pose into the locked rail broadcast anchor inside `ApplyLockedRailBroadcastCamera`. 
- Ensured pullback and locked-position/no-zoom behavior are initialized in `BeginShot` and cleared in `EndShot`, and left existing cue-hold tracking logic (`turnOnlyCueTrackingDuringShotHold`) intact so tracking favors rotation/look without zoom/dolly during the shot.

### Testing
- Ran the unit test `npm -s test -- test/poolRoyaleCueStrokeTimeline.test.js` which passed (`4 tests, 1 suite` passed). 
- No additional automated UI or integration tests were available in this environment; changes were limited to the replay flow/UI and `CueCamera` shot behavior files (`webapp/src/pages/Games/PoolRoyale.jsx`, `billiards.Unity/CueCamera.cs`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d35e4754408329b562373e5d508c49)