### PR TITLE
Adjust Pool Royale broadcast camera switching and pocket-cam gating

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -18079,13 +18079,9 @@ const powerRef = useRef(hud.power);
         if (shooting) {
           preShotTopViewRef.current = topViewRef.current;
           preShotTopViewLockRef.current = topViewLockedRef.current;
-          shotCameraHoldTimeoutRef.current = window.setTimeout(() => {
-            shotCameraHoldTimeoutRef.current = null;
-            if (!shooting) return;
-            topViewRef.current = true;
-            topViewLockedRef.current = true;
-            enterTopView(true, { variant: 'rail' });
-          }, SHOT_CAMERA_HOLD_MS);
+          topViewRef.current = true;
+          topViewLockedRef.current = true;
+          enterTopView(true, { variant: 'rail' });
         } else if (!preShotTopViewRef.current) {
           exitTopView(true);
         } else {
@@ -20808,6 +20804,33 @@ const powerRef = useRef(hud.power);
                   camera.lookAt(activeShotView.smoothedTarget);
                   lookTarget = activeShotView.smoothedTarget;
                   renderCamera = camera;
+                  if (activeShotView.stage === 'pair' && activeShotView.targetId != null) {
+                    const targetBall = ballsList.find((b) => b.id === activeShotView.targetId);
+                    if (targetBall?.active) {
+                      const cueWorld = new THREE.Vector3(
+                        cueBall.pos.x * worldScaleFactor,
+                        BALL_CENTER_Y * worldScaleFactor,
+                        cueBall.pos.y * worldScaleFactor
+                      ).project(camera);
+                      const targetWorld = new THREE.Vector3(
+                        targetBall.pos.x * worldScaleFactor,
+                        BALL_CENTER_Y * worldScaleFactor,
+                        targetBall.pos.y * worldScaleFactor
+                      ).project(camera);
+                      const inFrame = (projected) =>
+                        Number.isFinite(projected.x) &&
+                        Number.isFinite(projected.y) &&
+                        Number.isFinite(projected.z) &&
+                        projected.z > -1 &&
+                        projected.z < 1 &&
+                        Math.abs(projected.x) < 0.94 &&
+                        Math.abs(projected.y) < 0.92;
+                      if (!inFrame(cueWorld) || !inFrame(targetWorld)) {
+                        activeShotView.preferRailOverhead = true;
+                        activeShotView.lockOverheadFocus = true;
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -21530,7 +21553,7 @@ const powerRef = useRef(hud.power);
                 cueBall,
                 fallback: shortRailDir
               });
-          const preferRailOverhead = true;
+          const preferRailOverhead = Boolean(isBreakShot);
           const now = performance.now();
           const activationDelay = null;
           const activationTravel = 0;
@@ -21558,7 +21581,7 @@ const powerRef = useRef(hud.power);
             hasSwitchedRail: true,
             railNormal: railNormal ? railNormal.clone() : null,
             preferRailOverhead,
-            lockOverheadFocus: true,
+            lockOverheadFocus: preferRailOverhead,
             longShot,
             travelDistance,
             activationDelay,
@@ -21644,6 +21667,7 @@ const powerRef = useRef(hud.power);
             predictedAlignment >= POCKET_GUARANTEED_ALIGNMENT;
           const allowEarly = forceCornerCapture;
           if (!allowEarly && bestScore < POCKET_CAM.dotThreshold) return null;
+          if (!forceCornerCapture && !isGuaranteedPocket) return null;
           const predictedTravelForBall =
             shotPrediction?.ballId === ballId
               ? shotPrediction?.travel ?? null


### PR DESCRIPTION
### Motivation
- Ensure broadcast framing uses the rail-overhead camera immediately when a shot is triggered (especially the break) to match broadcast expectations and avoid delayed/incorrect pocket cuts. 
- Prevent pocket cameras from stealing framing for shots that are unlikely to pot and keep action cameras from losing the cue/target pair out of frame. 

### Description
- Immediately enter the rail-overhead/top view when a shot starts by removing the delayed `SHOT_CAMERA_HOLD_MS` timeout and calling `enterTopView(true, { variant: 'rail' })` in `setShootingState` in `PoolRoyale.jsx`. 
- Make action-camera instances default to preferring rail-overhead only for break shots by changing `preferRailOverhead` to `Boolean(isBreakShot)` and tying `lockOverheadFocus` to that preference. 
- Add a frame-guard when composing the action view so if either the cue ball or the target ball would leave the action camera frame the code flips `activeShotView.preferRailOverhead` and `lockOverheadFocus` to fall back to the rail-overhead camera. 
- Tighten pocket-camera gating so pocket views are only created for guaranteed pot trajectories (based on prediction alignment) unless an explicit forced-corner capture is requested. 
- All changes are contained to `webapp/src/pages/Games/PoolRoyale.jsx` and preserve existing replay/recording paths. 

### Testing
- Ran the focused unit test `jest --runTestsByPath test/poolRoyaleCueStrokeTimeline.test.js`, which passed (4 tests, 1 suite). 
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx`, which reported the file is ignored by repo ESLint settings (warning only) and produced no parse/runtime errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d36e4dc7c48329b43b6b745eb4affe)