### PR TITLE
Camera: prefer rail-overhead for pair/break/out-of-frame targets and tighten replay logic

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -20405,9 +20405,10 @@ const powerRef = useRef(hud.power);
                   ? THREE.MathUtils.clamp(1 - Math.exp(-dt / smoothTime), 0, 1)
                   : 1;
               const cuePos2 = new THREE.Vector2(cueBall.pos.x, cueBall.pos.y);
-                const cueAnchor = activeShotView.startCuePos ?? cuePos2;
+              const cueAnchor = activeShotView.startCuePos ?? cuePos2;
               let focusTargetVec3 = null;
               let desiredPosition = null;
+              let pairTargetBall = null;
               const axis = activeShotView.axis ?? 'short';
               let railDir = activeShotView.railDir;
               if (!Number.isFinite(railDir) || railDir === 0) {
@@ -20459,6 +20460,7 @@ const powerRef = useRef(hud.power);
                   activeShotView.targetId != null
                     ? ballsList.find((b) => b.id === activeShotView.targetId)
                     : null;
+                pairTargetBall = targetBall ?? null;
                 let targetPos2;
                 if (targetBall?.active) {
                   targetPos2 = new THREE.Vector2(targetBall.pos.x, targetBall.pos.y);
@@ -20719,6 +20721,53 @@ const powerRef = useRef(hud.power);
                   );
                   focusTargetVec3 = lookAnchor.multiplyScalar(worldScaleFactor);
                   desiredPosition = desired.multiplyScalar(worldScaleFactor);
+                }
+              }
+              if (
+                activeShotView.stage === 'pair' &&
+                !activeShotView.preferRailOverhead &&
+                desiredPosition &&
+                focusTargetVec3
+              ) {
+                let shouldForceRailOverhead = false;
+                if (!pairTargetBall?.active) {
+                  shouldForceRailOverhead = true;
+                } else {
+                  const previewCamera = camera.clone();
+                  previewCamera.position.copy(desiredPosition);
+                  previewCamera.lookAt(focusTargetVec3);
+                  previewCamera.updateProjectionMatrix();
+                  previewCamera.updateMatrixWorld();
+                  const frameMargin = 0.86;
+                  const isPointInPreviewFrame = (point) => {
+                    if (!point) return false;
+                    const ndc = point.clone().project(previewCamera);
+                    return (
+                      Number.isFinite(ndc.x) &&
+                      Number.isFinite(ndc.y) &&
+                      Number.isFinite(ndc.z) &&
+                      Math.abs(ndc.x) <= frameMargin &&
+                      Math.abs(ndc.y) <= frameMargin &&
+                      ndc.z >= -1 &&
+                      ndc.z <= 1
+                    );
+                  };
+                  const cueWorld = new THREE.Vector3(
+                    cueBall.pos.x * worldScaleFactor,
+                    BALL_CENTER_Y,
+                    cueBall.pos.y * worldScaleFactor
+                  );
+                  const targetWorld = new THREE.Vector3(
+                    pairTargetBall.pos.x * worldScaleFactor,
+                    BALL_CENTER_Y,
+                    pairTargetBall.pos.y * worldScaleFactor
+                  );
+                  shouldForceRailOverhead =
+                    !isPointInPreviewFrame(cueWorld) || !isPointInPreviewFrame(targetWorld);
+                }
+                if (shouldForceRailOverhead) {
+                  activeShotView.preferRailOverhead = true;
+                  activeShotView.lockOverheadFocus = true;
                 }
               }
               const broadcastRailDir =
@@ -21530,7 +21579,7 @@ const powerRef = useRef(hud.power);
                 cueBall,
                 fallback: shortRailDir
               });
-          const preferRailOverhead = true;
+          const preferRailOverhead = Boolean(isBreakShot);
           const now = performance.now();
           const activationDelay = null;
           const activationTravel = 0;
@@ -21642,6 +21691,7 @@ const powerRef = useRef(hud.power);
             shotPrediction?.ballId === ballId &&
             predictedAlignment != null &&
             predictedAlignment >= POCKET_GUARANTEED_ALIGNMENT;
+          if (!forceCornerCapture && !isGuaranteedPocket) return null;
           const allowEarly = forceCornerCapture;
           if (!allowEarly && bestScore < POCKET_CAM.dotThreshold) return null;
           const predictedTravelForBall =
@@ -26167,6 +26217,10 @@ const powerRef = useRef(hud.power);
             const storedTarget = lastCameraTargetRef.current?.clone();
             if (storedTarget) actionView.smoothedTarget = storedTarget;
           }
+          if (actionView && !earlyPocketView) {
+            actionView.preferRailOverhead = true;
+            actionView.lockOverheadFocus = true;
+          }
           const ranges = spinRangeRef.current || {};
           const powerSpinScale = 0.55 + clampedPower * 0.45;
           const topspinPowerScale = resolveTopspinPowerScale(clampedPower);
@@ -26364,6 +26418,20 @@ const powerRef = useRef(hud.power);
             updatePocketCameraState(false);
             pocketViewActivated = false;
           }
+          if (!pocketViewActivated && actionView && isBreakShot) {
+            const activationNow = performance.now();
+            actionView.pendingActivation = false;
+            actionView.activationDelay = null;
+            actionView.activationTravel = 0;
+            actionView.strokeReadyAt = 0;
+            actionView.preferRailOverhead = true;
+            actionView.lockOverheadFocus = true;
+            actionView.lastUpdate = activationNow;
+            activeShotView = actionView;
+            suspendedActionView = null;
+            updateCamera();
+            pocketViewActivated = true;
+          }
           if (!pocketViewActivated && actionView) {
             const cameraHoldUntil = Math.max(
               holdUntil || 0,
@@ -26375,28 +26443,39 @@ const powerRef = useRef(hud.power);
               !requiresCueBallMovementTrigger &&
               (!isLongShot || forceActionActivation) &&
               !isMaxPowerShot;
-            actionView.pendingActivation = true;
-            const baseDelay = actionView.activationDelay ?? null;
-            const delayed = requiresCueBallMovementTrigger ? baseDelay ?? 0 : now;
-            actionView.activationDelay = delayed > 0 ? delayed : null;
-            actionView.strokeReadyAt = shouldActivateActionView ? strokeReadyAt : now + 1;
-            const baseTravel = actionView.activationTravel ?? 0;
-            actionView.activationTravel = Math.max(
-              baseTravel,
-              requiresCueBallMovementTrigger
-                ? CUEBALL_CAMERA_SWITCH_MIN_TRAVEL
-                : forceImmediateRailOverheadView
-                  ? 0
-                  : isMaxPowerShot
-                    ? BALL_R * 6
-                    : 0
-            );
-            if (forceImmediateRailOverheadView) {
-              powerImpactHoldRef.current = 0;
-              actionView.activationDelay = now;
-              actionView.strokeReadyAt = now;
+            if (shouldActivateActionView) {
+              actionView.pendingActivation = false;
+              actionView.activationDelay = null;
+              actionView.activationTravel = 0;
+              actionView.strokeReadyAt = 0;
+              actionView.lastUpdate = now;
+              activeShotView = actionView;
+              suspendedActionView = null;
+              updateCamera();
+            } else {
+              actionView.pendingActivation = true;
+              const baseDelay = actionView.activationDelay ?? null;
+              const delayed = requiresCueBallMovementTrigger ? baseDelay ?? 0 : now;
+              actionView.activationDelay = delayed > 0 ? delayed : null;
+              actionView.strokeReadyAt = shouldActivateActionView ? strokeReadyAt : now + 1;
+              const baseTravel = actionView.activationTravel ?? 0;
+              actionView.activationTravel = Math.max(
+                baseTravel,
+                requiresCueBallMovementTrigger
+                  ? CUEBALL_CAMERA_SWITCH_MIN_TRAVEL
+                  : forceImmediateRailOverheadView
+                    ? 0
+                    : isMaxPowerShot
+                      ? BALL_R * 6
+                      : 0
+              );
+              if (forceImmediateRailOverheadView) {
+                powerImpactHoldRef.current = 0;
+                actionView.activationDelay = now;
+                actionView.strokeReadyAt = now;
+              }
+              suspendedActionView = actionView;
             }
-            suspendedActionView = actionView;
           }
           openingShotViewSuppressedRef.current = false;
           if (ENABLE_CUE_STROKE_ANIMATION && shotRecording) {
@@ -28619,7 +28698,7 @@ const powerRef = useRef(hud.power);
           pottedBalls,
           shotContext
         }) => {
-          if (!recording) return null;
+          if (!recording || !hadObjectPot) return null;
           const tags = new Set(recording.replayTags ?? []);
           if (hadObjectPot) tags.add('pot');
           const potCount = pottedBalls.filter((entry) => entry.id !== 'cue').length;
@@ -28629,12 +28708,11 @@ const powerRef = useRef(hud.power);
           const priority = ['multi', 'bank', 'long', 'power', 'spin'];
           const primary = priority.find((tag) => tags.has(tag)) ?? 'default';
           const zoomOnly = recording.zoomOnly && !tags.has('long') && !tags.has('bank');
-          const shouldReplay = hadObjectPot || Boolean(recording.replayFoul) || tags.size > 0;
           return {
-            shouldReplay,
+            shouldReplay: hadObjectPot || tags.size > 0,
             banner: selectReplayBanner(primary),
             zoomOnly,
-            tags: Array.from(tags ?? []),
+            tags: Array.from(tags),
             primaryTag: primary
           };
         };
@@ -28651,7 +28729,9 @@ const powerRef = useRef(hud.power);
             pottedBalls: potted,
             shotContext: shotContextRef.current
           });
-          let shouldStartReplay = false;
+          let shouldStartReplay =
+            Boolean(replayDecision?.shouldReplay) &&
+            (shotRecording?.frames?.length ?? 0) > 1;
           let replayBannerText = replayDecision?.banner ?? selectReplayBanner('default');
           let replayAccent = replayDecision?.primaryTag ?? 'default';
           let postShotSnapshot = null;
@@ -28885,10 +28965,9 @@ const powerRef = useRef(hud.power);
           shotRecording.replayTags = replayDecision.tags;
           shotRecording.zoomOnly = replayDecision.zoomOnly;
         }
-        const replayEventDetected = shotWasFoul || hadObjectPot;
         shouldStartReplay =
-          Boolean(replayDecision?.shouldReplay || replayEventDetected) &&
-          (shotRecording?.frames?.length ?? 0) >= 1;
+          Boolean(replayDecision?.shouldReplay) &&
+          (shotRecording?.frames?.length ?? 0) > 1;
         const shooterSeat = currentState?.activePlayer === 'B' ? 'B' : 'A';
         if (potted.length) {
           const newPots = potted.filter(
@@ -29158,7 +29237,7 @@ const powerRef = useRef(hud.power);
           pocketSwitchIntentRef.current = null;
           lastPocketBallRef.current = null;
           updatePocketCameraState(false);
-          if (autoReplayEnabled && shouldStartReplay && postShotSnapshot) {
+          if (shouldStartReplay && postShotSnapshot) {
             const recordingForReplay = shotRecording;
             const launchReplay = () => {
               replayBannerTimeoutRef.current = null;


### PR DESCRIPTION
### Motivation
- Improve shot camera behavior to prefer rail-overhead views when pair targets are offscreen or for break shots, and make action camera activation more deterministic for those cases.
- Prevent spurious replay triggers by tightening the conditions under which a shot recording is considered replay-worthy.
- Reduce edge-case bugs around pair-stage focus and corner-capture pocket cameras.

### Description
- Add `pairTargetBall` tracking and a preview frustum check that forces `activeShotView.preferRailOverhead` and `activeShotView.lockOverheadFocus` when the cue or pair target would be offscreen from the pair camera preview.
- Force rail-overhead and lock focus for `actionView` when there is no `earlyPocketView` and when handling break shots, and immediately activate the action view for break shots (setting `pendingActivation`, `activationDelay`, `activationTravel`, and `lastUpdate` appropriately then calling `updateCamera`).
- Simplify the action view activation path for cases where activation should be immediate, and preserve the prior delayed activation path for other cases.
- Require guaranteed pocket for corner capture by adding `if (!forceCornerCapture && !isGuaranteedPocket) return null;` in the pocket camera scoring path.
- Tighten replay decision logic by requiring `hadObjectPot` to be true in `resolveReplayDecision`, only treating recordings with more than one frame as eligible for automatic replay, and removing the previous `autoReplayEnabled` gating so replay launch is controlled by the refined conditions.

### Testing
- Ran the project test suite with `yarn test` and all unit tests completed successfully.
- Ran the linter with `yarn lint` and no new lint errors were reported.
- Performed a production build via `yarn build` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d375d8be988329bc74ac267e288d1e)