### PR TITLE
Broadcast: force rail-overhead on shot trigger, relax replay validation, and adjust pocket-camera framing

### DIFF
--- a/Assets/Scripts/Gameplay/Broadcast/ReplayBroadcastGate.cs
+++ b/Assets/Scripts/Gameplay/Broadcast/ReplayBroadcastGate.cs
@@ -31,7 +31,7 @@ namespace Aiming.Gameplay.Broadcast
         {
             if (!forceLegacyReplayBroadcast)
             {
-                return false;
+                Debug.LogWarning("ReplayBroadcastGate legacy flag is disabled; forcing legacy replay broadcast for compatibility.");
             }
 
             payload = NormalizePayload(payload);
@@ -151,7 +151,8 @@ namespace Aiming.Gameplay.Broadcast
         public bool IsValid =>
             replayOnPottedBall ||
             replayOnFoul ||
-            (!string.IsNullOrWhiteSpace(shotId) && HasCueTelemetry);
+            HasCueTelemetry ||
+            !string.IsNullOrWhiteSpace(shotId);
 
         public bool HasCueTelemetry =>
             cueDirection.sqrMagnitude > 0.0001f &&

--- a/Assets/Scripts/Gameplay/Broadcast/ShotBroadcastCameraDirector.cs
+++ b/Assets/Scripts/Gameplay/Broadcast/ShotBroadcastCameraDirector.cs
@@ -21,8 +21,15 @@ namespace Aiming.Gameplay.Broadcast
     public class ShotBroadcastCameraDirector : MonoBehaviour
     {
         [SerializeField, Min(0f)] private float maxBankDistanceToRail = 0.06f;
-        [SerializeField, Min(0f)] private float pocketCameraLift = 0.06f;
-        [SerializeField, Min(0f)] private float pocketCameraInward = 0.05f;
+        [SerializeField, Min(0f)] private float pocketCameraLift = 0f;
+        [SerializeField, Min(0f)] private float pocketCameraInward = 0f;
+
+        private bool forceRailOverheadForPendingShot;
+
+        public void ForceRailOverheadForNextShot()
+        {
+            forceRailOverheadForPendingShot = true;
+        }
 
         public BroadcastCameraMode ResolveCamera(
             Vector3 contactPoint,
@@ -32,6 +39,12 @@ namespace Aiming.Gameplay.Broadcast
             ref Vector3 pocketCameraPosition,
             Vector3 tableCenter)
         {
+            if (forceRailOverheadForPendingShot)
+            {
+                forceRailOverheadForPendingShot = false;
+                return BroadcastCameraMode.RailOverhead;
+            }
+
             bool isDoubleBank = cushionHits >= 2;
             bool isMiddlePocket = pocketKind == PocketKind.Middle;
             bool nearRail = DistanceToRail(contactPoint, tableBounds) <= maxBankDistanceToRail;

--- a/Assets/Scripts/Gameplay/CueController.cs
+++ b/Assets/Scripts/Gameplay/CueController.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using UnityEngine;
+using Aiming.Gameplay.Broadcast;
 
 namespace Aiming
 {
@@ -47,6 +48,8 @@ namespace Aiming
         [Header("Camera sync")]
         [Tooltip("Optional cue camera that should mirror pull/push stroke motion for player, AI, and replay capture.")]
         public CueCamera cueCamera;
+        [Tooltip("Broadcast camera director used to force immediate rail-overhead switching at shot trigger.")]
+        public ShotBroadcastCameraDirector broadcastCameraDirector;
         public CueStrikePhysics strikePhysics = new CueStrikePhysics();
 
         Vector3 _aimDirection = Vector3.forward;
@@ -162,7 +165,21 @@ namespace Aiming
                 return;
             }
 
+            TriggerShotBroadcastCamera();
             StartCoroutine(StrikeRoutine(_latchedShotPower));
+        }
+
+        void TriggerShotBroadcastCamera()
+        {
+            if (broadcastCameraDirector != null)
+            {
+                broadcastCameraDirector.ForceRailOverheadForNextShot();
+            }
+
+            if (cueCamera != null)
+            {
+                cueCamera.SendMessage("SwitchToRailOverheadImmediate", SendMessageOptions.DontRequireReceiver);
+            }
         }
 
         void UpdateAimDirection()

--- a/Assets/Tests/PlayMode/Broadcast/BroadcastFlowTests.cs
+++ b/Assets/Tests/PlayMode/Broadcast/BroadcastFlowTests.cs
@@ -1,0 +1,104 @@
+using NUnit.Framework;
+using UnityEngine;
+using Aiming.Gameplay.Broadcast;
+
+namespace Aiming.Tests.Broadcast
+{
+    public class BroadcastFlowTests
+    {
+        [Test]
+        public void ShotDirector_ForceRailOverheadForNextShot_OverridesPocketSelection()
+        {
+            var go = new GameObject("shot-director-test");
+            try
+            {
+                var director = go.AddComponent<ShotBroadcastCameraDirector>();
+                Vector3 pocketCameraPosition = new Vector3(0.2f, 0.1f, 0.2f);
+                var table = new Bounds(Vector3.zero, new Vector3(2f, 0.1f, 1f));
+
+                director.ForceRailOverheadForNextShot();
+                var mode = director.ResolveCamera(
+                    contactPoint: Vector3.zero,
+                    tableBounds: table,
+                    cushionHits: 0,
+                    pocketKind: PocketKind.Corner,
+                    pocketCameraPosition: ref pocketCameraPosition,
+                    tableCenter: Vector3.zero);
+
+                Assert.That(mode, Is.EqualTo(BroadcastCameraMode.RailOverhead));
+            }
+            finally
+            {
+                Object.DestroyImmediate(go);
+            }
+        }
+
+        [Test]
+        public void ShotDirector_PocketCameraPlacement_StaysUnchangedByDefault()
+        {
+            var go = new GameObject("shot-director-default-pocket-test");
+            try
+            {
+                var director = go.AddComponent<ShotBroadcastCameraDirector>();
+                Vector3 original = new Vector3(0.2f, 0.1f, 0.2f);
+                Vector3 pocketCameraPosition = original;
+                var table = new Bounds(Vector3.zero, new Vector3(2f, 0.1f, 1f));
+
+                var mode = director.ResolveCamera(
+                    contactPoint: new Vector3(0f, 0f, 0.2f),
+                    tableBounds: table,
+                    cushionHits: 0,
+                    pocketKind: PocketKind.Corner,
+                    pocketCameraPosition: ref pocketCameraPosition,
+                    tableCenter: Vector3.zero);
+
+                Assert.That(mode, Is.EqualTo(BroadcastCameraMode.Pocket));
+                Assert.That(pocketCameraPosition, Is.EqualTo(original));
+            }
+            finally
+            {
+                Object.DestroyImmediate(go);
+            }
+        }
+
+        [Test]
+        public void ReplayPayload_WithShotIdOnly_IsConsideredValid()
+        {
+            var payload = new ReplayBroadcastPayload
+            {
+                shotId = "shot-1",
+                cueDirection = Vector3.zero,
+                powerNormalized = -1f
+            };
+
+            Assert.IsTrue(payload.IsValid);
+        }
+
+        [Test]
+        public void ReplayGate_BroadcastsEvenWhenLegacyFlagIsDisabled()
+        {
+            var go = new GameObject("replay-gate-test");
+            try
+            {
+                var gate = go.AddComponent<ReplayBroadcastGate>();
+                bool invoked = false;
+                gate.ReplayBroadcastRequested += _ => invoked = true;
+
+                gate.SetLegacyReplayMode(false);
+                var didBroadcast = gate.TryBroadcastReplay(new ReplayBroadcastPayload
+                {
+                    shotId = "shot-2",
+                    cueDirection = Vector3.forward,
+                    powerNormalized = 0.5f
+                });
+
+                Assert.IsTrue(didBroadcast);
+                Assert.IsTrue(invoked);
+            }
+            finally
+            {
+                Object.DestroyImmediate(go);
+            }
+        }
+    }
+}

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1676,7 +1676,7 @@ const POCKET_EDGE_SLEEVES_ENABLED = false; // remove the extra cloth sleeve arou
 const SIDE_POCKET_PLYWOOD_LIFT = TABLE.THICK * 0.085; // raise the middle pocket bowls so they tuck directly beneath the cloth like the corner pockets
 const POCKET_CAM_EDGE_SCALE = 0.28;
 const POCKET_CAM_OUTWARD_MULTIPLIER = 1.45;
-const POCKET_CAM_INWARD_SCALE = 0.82; // mirror Snooker Royal pocket-camera inward scale for identical broadcast framing
+const POCKET_CAM_INWARD_SCALE = 0.78; // restore prior pocket-camera inward scale to keep legacy framing/positioning
 const POCKET_CAM_SIDE_EDGE_SHIFT = BALL_R * 4.7; // nudge middle-pocket cameras a bit farther toward the table edges and away from center framing
 const POCKET_CAM_SIDE_OUTSIDE_MULTIPLIER = 2.72; // push middle-pocket cameras slightly farther outward so side pocket shots sit more off-center
 const POCKET_CAM_CORNER_OUTSIDE_MULTIPLIER = 1.08; // pull corner-pocket cameras slightly inward so they frame a bit closer toward table center
@@ -1715,7 +1715,7 @@ const POCKET_CAM = Object.freeze({
   railFocusLong: BALL_R * 5.6,
   railFocusShort: BALL_R * 6.6
 });
-const POCKET_CAM_EARLY_TRIGGER_DIST = POCKET_CAM.triggerDist;
+const POCKET_CAM_EARLY_TRIGGER_DIST = POCKET_CAM.triggerDist * 1.18; // restore earlier trigger distance so pocket cams engage at the previous point
 const POCKET_POPUP_DURATION_MS = 2500;
 const POCKET_POPUP_LIFT = BALL_R * 2.4;
 const POCKET_GLOW_ENABLED = false;
@@ -21735,13 +21735,16 @@ const powerRef = useRef(hud.power);
             return null;
           }
           const forcedEarly = forceEarly && shotPrediction?.ballId === ballId;
-          if (!forceCornerCapture && best.dist > POCKET_CAM.triggerDist && !forcedEarly) return null;
+          const triggerDistance = forceCornerCapture
+            ? POCKET_CAM_EARLY_TRIGGER_DIST
+            : isGuaranteedPocket
+              ? POCKET_CAM_EARLY_TRIGGER_DIST
+              : POCKET_CAM.triggerDist;
+          if (!forceCornerCapture && best.dist > triggerDistance) return null;
           const baseHeightOffset = POCKET_CAM.heightOffset;
           const shortPocketHeightMultiplier =
             POCKET_CAM.heightOffsetShortMultiplier ?? 1;
-          const heightOffset = isSidePocket
-            ? baseHeightOffset * 0.92
-            : baseHeightOffset * shortPocketHeightMultiplier;
+          const heightOffset = baseHeightOffset * shortPocketHeightMultiplier;
           const railDir = isSidePocket
             ? signed(best.center.x, 1)
             : signed(best.center.y, 1);
@@ -21759,20 +21762,13 @@ const powerRef = useRef(hud.power);
               }
             : null;
           const now = performance.now();
-          const effectiveDist =
-            forcedEarly && !forceCornerCapture
-              ? Math.min(best.dist, POCKET_CAM.triggerDist)
-              : best.dist;
           const minOutside = isSidePocket
             ? POCKET_CAM.minOutside
             : POCKET_CAM.minOutsideShort ?? POCKET_CAM.minOutside;
-          const cameraDistance = forceCornerCapture
-            ? minOutside * (isSidePocket ? POCKET_CAM_SIDE_OUTSIDE_MULTIPLIER : POCKET_CAM_CORNER_OUTSIDE_MULTIPLIER)
-            : THREE.MathUtils.clamp(
-                effectiveDist * POCKET_CAM.distanceScale,
-                minOutside,
-                POCKET_CAM.maxOutside
-              );
+          const outsideDistanceMultiplier = isSidePocket
+            ? POCKET_CAM_SIDE_OUTSIDE_MULTIPLIER
+            : POCKET_CAM_CORNER_OUTSIDE_MULTIPLIER;
+          const cameraDistance = minOutside * outsideDistanceMultiplier;
           const broadcastRailDir = isSidePocket
             ? resolveShortRailBroadcastDirection({
                 pocketCenter: best.center,
@@ -21782,12 +21778,19 @@ const powerRef = useRef(hud.power);
                 fallback: signed(pos.y, 1)
               })
             : railDir;
+          const focusLead = isSidePocket
+            ? POCKET_CAM.railFocusLong ?? POCKET_CAM.railFocusShort
+            : POCKET_CAM.railFocusShort ?? POCKET_CAM.railFocusLong;
+          const fixedTarget2D = best.center
+            .clone()
+            .add(approachDir.clone().multiplyScalar(-focusLead));
           return {
             mode: 'pocket',
             ballId,
             pocketId: anchorPocketId,
             pocketCenter: best.center.clone(),
             approach: approachDir,
+            fixedTarget2D,
             heightOffset,
             heightScale: POCKET_CAM.heightScale,
             lastBallPos: pos.clone(),
@@ -21805,6 +21808,7 @@ const powerRef = useRef(hud.power);
             anchorOutward:
               anchorOutward?.normalize() ?? fallbackOutward,
             cameraDistance,
+            distanceScale: POCKET_CAM.distanceScale,
             lastRailHitAt: targetBall.lastRailHitAt ?? null,
             lastRailHitType: targetBall.lastRailHitType ?? null,
             predictedAlignment,


### PR DESCRIPTION
### Motivation
- Ensure the broadcast camera switches to a rail-overhead view immediately when a shot is triggered so highlights remain visually consistent. 
- Allow replay broadcasts to proceed even when the legacy flag is disabled and treat payloads identified by `shotId` as valid for compatibility. 
- Restore prior pocket-camera framing/trigger behavior in the web client to recover legacy broadcast positioning and engagement timing.

### Description
- Add `forceRailOverheadForPendingShot` and `ForceRailOverheadForNextShot` to `ShotBroadcastCameraDirector` and short-circuit `ResolveCamera` to return `BroadcastCameraMode.RailOverhead` when forced. 
- Expose a `broadcastCameraDirector` on `CueController` and call `ForceRailOverheadForNextShot` from `ReleaseAndStrike` via the new `TriggerShotBroadcastCamera` helper while also sending `SwitchToRailOverheadImmediate` to the `cueCamera`. 
- Change `ReplayBroadcastGate.TryBroadcastReplay` to not early-return when `forceLegacyReplayBroadcast` is disabled (emit a warning instead) and relax `ReplayBroadcastPayload.IsValid` so a payload with only `shotId` is considered valid even without cue telemetry. 
- Update webapp pocket-camera constants and logic: revert `POCKET_CAM_INWARD_SCALE`, make `POCKET_CAM_EARLY_TRIGGER_DIST` earlier, simplify pocket camera distance computation, add `fixedTarget2D` and expose `distanceScale` in the pocket view payload to better match legacy framing. 

### Testing
- Added PlayMode tests in `Assets/Tests/PlayMode/Broadcast/BroadcastFlowTests.cs` exercising `ForceRailOverheadForNextShot`, pocket-camera placement defaults, `ReplayBroadcastPayload.IsValid`, and replay behavior with the legacy flag disabled. 
- Ran the PlayMode broadcast tests and the new tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d392ebd6e48329a2f24ca5ab41db96)