### PR TITLE
Improve Pool Royale broadcast camera timing, pocket-camera framing, and replay frame fallback

### DIFF
--- a/Assets/Scripts/Gameplay/Broadcast/ReplayBroadcastGate.cs
+++ b/Assets/Scripts/Gameplay/Broadcast/ReplayBroadcastGate.cs
@@ -101,12 +101,16 @@ namespace Aiming.Gameplay.Broadcast
         {
             if (replayFrameRoot == null && replayFrameCanvasGroup != null)
             {
-                replayFrameRoot = replayFrameCanvasGroup.transform.root.gameObject;
+                replayFrameRoot = replayFrameCanvasGroup.gameObject;
             }
 
             if (replayFrameCanvasGroup == null && replayFrameRoot != null)
             {
-                replayFrameCanvasGroup = replayFrameRoot.GetComponentInChildren<CanvasGroup>(true);
+                replayFrameCanvasGroup = replayFrameRoot.GetComponent<CanvasGroup>();
+                if (replayFrameCanvasGroup == null)
+                {
+                    replayFrameCanvasGroup = replayFrameRoot.GetComponentInChildren<CanvasGroup>(true);
+                }
             }
 
             if (replayFrameRoot == null && replayFrameCanvasGroup == null)
@@ -114,7 +118,7 @@ namespace Aiming.Gameplay.Broadcast
                 replayFrameCanvasGroup = GetComponentInChildren<CanvasGroup>(true);
                 if (replayFrameCanvasGroup != null)
                 {
-                    replayFrameRoot = replayFrameCanvasGroup.transform.root.gameObject;
+                    replayFrameRoot = replayFrameCanvasGroup.gameObject;
                 }
             }
         }

--- a/Assets/Scripts/Gameplay/Broadcast/ShotBroadcastCameraDirector.cs
+++ b/Assets/Scripts/Gameplay/Broadcast/ShotBroadcastCameraDirector.cs
@@ -15,8 +15,9 @@ namespace Aiming.Gameplay.Broadcast
     }
 
     /// <summary>
-    /// Routes highlight camera selection for broadcast: bank/double rail + middle pockets
-    /// use rail overhead, corner pockets use pocket cameras.
+    /// Routes highlight camera selection for broadcast: bank/double rail shots use
+    /// rail overhead, while pocket shots use pocket cameras with configurable
+    /// lift/inward offsets.
     /// </summary>
     public class ShotBroadcastCameraDirector : MonoBehaviour
     {
@@ -46,10 +47,9 @@ namespace Aiming.Gameplay.Broadcast
             }
 
             bool isDoubleBank = cushionHits >= 2;
-            bool isMiddlePocket = pocketKind == PocketKind.Middle;
             bool nearRail = DistanceToRail(contactPoint, tableBounds) <= maxBankDistanceToRail;
 
-            if (isDoubleBank || isMiddlePocket || nearRail)
+            if (isDoubleBank || nearRail)
             {
                 return BroadcastCameraMode.RailOverhead;
             }

--- a/billiards.Unity/CueCamera.cs
+++ b/billiards.Unity/CueCamera.cs
@@ -313,6 +313,7 @@ public class CueCamera : MonoBehaviour
     private float smoothedCueDistance;
     private bool hasSmoothedCueDistance;
     private float cueStrikeHoldUntilTime;
+    private bool forceImmediateRailOverheadOnNextShot;
     private bool holdCueAimDuringShot;
     private bool hasShotRailAnchor;
     private Vector3 shotRailAnchorPosition;
@@ -391,8 +392,12 @@ public class CueCamera : MonoBehaviour
         shotInProgress = true;
         ballInHandActive = false;
         usingTargetCamera = false;
-        holdCueAimDuringShot = !immediateRailBroadcastOnShot && cueStrikeCameraHoldSeconds > 0f;
-        cueStrikeHoldUntilTime = Time.time + Mathf.Max(0f, cueStrikeCameraHoldSeconds);
+        bool forceImmediate = forceImmediateRailOverheadOnNextShot;
+        forceImmediateRailOverheadOnNextShot = false;
+        holdCueAimDuringShot = !forceImmediate && !immediateRailBroadcastOnShot && cueStrikeCameraHoldSeconds > 0f;
+        cueStrikeHoldUntilTime = holdCueAimDuringShot
+            ? Time.time + Mathf.Max(0f, cueStrikeCameraHoldSeconds)
+            : Time.time;
         shotStartedTime = Time.time;
         hasShotRailAnchor = false;
         hasShotPullbackAnchor = false;
@@ -422,6 +427,28 @@ public class CueCamera : MonoBehaviour
         }
 
         nextShotIsAi = false;
+    }
+
+    /// <summary>
+    /// Forces an immediate handoff to rail-overhead broadcast framing. If called
+    /// before BeginShot it applies to the next shot start; if called mid-shot it
+    /// cancels cue-hold and pocket tracking delays right away.
+    /// </summary>
+    public void SwitchToRailOverheadImmediate()
+    {
+        forceImmediateRailOverheadOnNextShot = true;
+
+        if (!shotInProgress)
+        {
+            return;
+        }
+
+        holdCueAimDuringShot = false;
+        cueStrikeHoldUntilTime = Time.time;
+        usingTargetCamera = false;
+        pocketCameraAwaitingDrop = false;
+        pocketDropDetected = false;
+        UpdateBroadcastCamera();
     }
 
     private void Awake()
@@ -1059,24 +1086,7 @@ public class CueCamera : MonoBehaviour
 
         if (isPocketCamera)
         {
-            float halfLength = Mathf.Max(0.0001f, tableBounds.extents.z);
-            float middleZone = Mathf.Clamp01(pocketCameraMiddleZone) * halfLength;
-            float zFromCenter = Mathf.Abs(sourceFocus.z - tableBounds.center.z);
-            bool isMiddlePocketBand = zFromCenter <= middleZone;
-            if (isMiddlePocketBand)
-            {
-                float sideSign = Mathf.Sign(sourceFocus.x);
-                if (Mathf.Approximately(sideSign, 0f))
-                {
-                    sideSign = 1f;
-                }
-
-                float maxX = Mathf.Max(0f, tableBounds.extents.x - broadcastFrameMargin);
-                float sideOffset = Mathf.Clamp(Mathf.Abs(pocketCameraMiddleSideOffset), 0f, maxX);
-                focus.x = Mathf.Clamp(sideSign * sideOffset, -maxX, maxX);
-                focus.z = sourceFocus.z;
-                height += Mathf.Max(0f, pocketCameraMiddleHeightOffset);
-            }
+            focus = sourceFocus;
         }
 
         float distance = useStandingCameraForBroadcast && cachedStandingCamera
@@ -1868,7 +1878,7 @@ public class CueCamera : MonoBehaviour
             return false;
         }
 
-        float triggerRadius = Mathf.Max(0.01f, cornerPocketCameraRadius);
+        float triggerRadius = Mathf.Max(0.01f, cornerPocketCameraRadius + Mathf.Max(0f, cornerPocketApproachRadius));
         if (!TryGetCornerPocketForBall(targetBall.position, triggerRadius, out pocket))
         {
             return false;
@@ -1876,7 +1886,7 @@ public class CueCamera : MonoBehaviour
 
         Vector2 ballXZ = new Vector2(targetBall.position.x, targetBall.position.z);
         Vector2 pocketXZ = new Vector2(pocket.x, pocket.z);
-        float innerRadius = Mathf.Max(0.01f, Mathf.Min(triggerRadius, pocketGuaranteedInnerRadius));
+        float innerRadius = Mathf.Max(0.01f, Mathf.Min(triggerRadius, pocketGuaranteedInnerRadius + Mathf.Max(0f, cornerPocketApproachRadius)));
         bool inInnerCapture = (ballXZ - pocketXZ).sqrMagnitude <= innerRadius * innerRadius;
 
         float dropThreshold = railHeight + tableAssetHeightOffset - Mathf.Max(0f, pocketDropDepth);


### PR DESCRIPTION
### Motivation
- Remove visible delays and inconsistent framing when cutting between cue/rail and pocket cameras so broadcast cuts feel immediate and consistent for both corner and middle pockets.
- Make pocket-camera viewpoints share the same baseline positioning and distance-from-pocket behavior so middle-pocket views match corner-pocket framing.
- Ensure the replay frame UI reliably shows/hides by fixing how the replay frame references are resolved.

### Description
- Added `SwitchToRailOverheadImmediate()` and a `forceImmediateRailOverheadOnNextShot` flag to `CueCamera` so the cue-trigger path can force an immediate rail-overhead handoff and cancel cue-hold/pocket-hold timers (this also makes `SendMessage("SwitchToRailOverheadImmediate")` effective). 
- Adjusted pocket-camera framing in `CueCamera` to use the same baseline `sourceFocus` positioning for pocket cameras so middle-pocket views no longer apply a separate offset path. 
- Expanded the corner-pocket detection radii in `CueCamera` by including `cornerPocketApproachRadius` in both trigger and inner-capture radius calculations so pocket cut-ins can occur earlier (before the ball reaches the jaw). 
- Updated `ShotBroadcastCameraDirector` to stop forcing rail-overhead for middle pockets and only route to rail-overhead on double-bank or near-rail conditions, while keeping lift/inward pocket offsets configurable. 
- Fixed `ReplayBroadcastGate.EnsureReplayFrameReferences()` to bind `replayFrameRoot` and `replayFrameCanvasGroup` to the actual replay frame GameObject/`CanvasGroup` (prefer `gameObject`/`GetComponent<CanvasGroup>()` before falling back to `GetComponentInChildren`) so `SetReplayFrameVisible` targets the correct object.

### Testing
- Ran `git diff --check` and the check completed with no reported whitespace/patch issues. 
- Searched and inspected key symbols with `rg` for `SwitchToRailOverheadImmediate`, `forceImmediateRailOverheadOnNextShot`, and `cornerPocketApproachRadius`, and for the replay-frame changes (`replayFrameCanvasGroup.gameObject` / `GetComponent<CanvasGroup>`), confirming the edits are present. 
- Committed the changes; no Unity runtime/editor integration tests were run in this environment, so runtime verification should be performed in-editor to validate camera timing and replay-frame visibility.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d39f78a390832991da3a0271f80310)