### PR TITLE
Refine Pool Royale camera flow: defer rail-overhead switching and hide 2D icon during broadcast

### DIFF
--- a/Assets/Scripts/Gameplay/CueController.cs
+++ b/Assets/Scripts/Gameplay/CueController.cs
@@ -171,14 +171,9 @@ namespace Aiming
 
         void TriggerShotBroadcastCamera()
         {
-            if (broadcastCameraDirector != null)
-            {
-                broadcastCameraDirector.ForceRailOverheadForNextShot();
-            }
-
             if (cueCamera != null)
             {
-                cueCamera.SendMessage("SwitchToRailOverheadImmediate", SendMessageOptions.DontRequireReceiver);
+                cueCamera.SendMessage("SwitchToRailOverheadAfterPullback", SendMessageOptions.DontRequireReceiver);
             }
         }
 

--- a/billiards.Unity/CueCamera.cs
+++ b/billiards.Unity/CueCamera.cs
@@ -284,6 +284,17 @@ public class CueCamera : MonoBehaviour
     public float cueBallExitLookAheadSeconds = 0.45f;
     // Keep break shot broadcast on the same short-rail side as the white-line end.
     public bool breakUsesWhiteLineRailSide = true;
+    [Header("2D view icon")]
+    // Optional 2D-view icon that stays visible in aiming mode.
+    public GameObject twoDViewIcon;
+    // Hide the 2D-view icon while broadcast cameras are active.
+    public bool hide2DIconDuringBroadcast = true;
+    [Header("Rail-overhead selection")]
+    // Moving-ball threshold for forcing rail-overhead in crowded action.
+    [Min(2)]
+    public int crowdedActionBallCount = 4;
+    // Side padding around cue->target lane used for crowd detection.
+    public float crowdedLanePadding = 0.11f;
 
     private float yaw;
     // Blend controlling how far the cue view slides toward the cue ball. 0 keeps
@@ -328,6 +339,9 @@ public class CueCamera : MonoBehaviour
     private bool hasLastTargetPlanarVelocity;
     private bool targetWasNearRail;
     private bool handoffToCueBallAfterRailBounce;
+    private bool forceRailOverheadForCurrentShot;
+    private bool deferRailOverheadSwitchUntilPullback;
+    private float railOverheadSwitchAfterTime;
     private Vector3 ballInHandTargetPosition;
     [Header("Occlusion settings")]
     // Layers that should be considered when preventing the camera from getting
@@ -410,6 +424,7 @@ public class CueCamera : MonoBehaviour
         cueAimSideSign = aimSide;
         bool breakShot = breakUsesWhiteLineRailSide && IsLikelyBreakShot(target);
         broadcastSideSign = breakShot ? aimSide : -aimSide;
+        forceRailOverheadForCurrentShot = ShouldPreferRailOverheadAtShotStart(target);
 
         Vector3 focus = CueBall != null ? CueBall.position : tableBounds.center;
         targetViewFocus = GetBroadcastFocus(focus);
@@ -426,6 +441,11 @@ public class CueCamera : MonoBehaviour
             shotPullbackStartRotation = transform.rotation;
         }
 
+        if (deferRailOverheadSwitchUntilPullback)
+        {
+            ScheduleRailOverheadAfterPullback();
+        }
+
         nextShotIsAi = false;
     }
 
@@ -437,6 +457,7 @@ public class CueCamera : MonoBehaviour
     public void SwitchToRailOverheadImmediate()
     {
         forceImmediateRailOverheadOnNextShot = true;
+        deferRailOverheadSwitchUntilPullback = false;
 
         if (!shotInProgress)
         {
@@ -449,6 +470,22 @@ public class CueCamera : MonoBehaviour
         pocketCameraAwaitingDrop = false;
         pocketDropDetected = false;
         UpdateBroadcastCamera();
+    }
+
+    /// <summary>
+    /// Queues rail-overhead switching for the end of the pullback transition.
+    /// </summary>
+    public void SwitchToRailOverheadAfterPullback()
+    {
+        forceImmediateRailOverheadOnNextShot = true;
+        deferRailOverheadSwitchUntilPullback = true;
+
+        if (!shotInProgress)
+        {
+            return;
+        }
+
+        ScheduleRailOverheadAfterPullback();
     }
 
     private void Awake()
@@ -469,6 +506,7 @@ public class CueCamera : MonoBehaviour
         }
         targetViewFocus = GetBroadcastFocus(CueBall != null ? CueBall.position : tableBounds.center);
         ballInHandActive = startWithBallInHand;
+        Update2DViewIconVisibility();
         if (cacheStandingCameraOnStart)
         {
             CacheStandingCameraPose();
@@ -494,7 +532,17 @@ public class CueCamera : MonoBehaviour
             {
                 UpdateCueAimCamera();
             }
+            Update2DViewIconVisibility();
             return;
+        }
+
+        if (deferRailOverheadSwitchUntilPullback && Time.time >= railOverheadSwitchAfterTime)
+        {
+            deferRailOverheadSwitchUntilPullback = false;
+            holdCueAimDuringShot = false;
+            usingTargetCamera = false;
+            pocketCameraAwaitingDrop = false;
+            pocketDropDetected = false;
         }
 
         if (usingTargetCamera)
@@ -527,6 +575,8 @@ public class CueCamera : MonoBehaviour
             holdCueAimDuringShot = false;
             UpdateBroadcastCamera();
         }
+
+        Update2DViewIconVisibility();
     }
 
     private void UpdateCueAimCamera()
@@ -864,8 +914,9 @@ public class CueCamera : MonoBehaviour
         yaw = Mathf.LerpAngle(yaw, targetViewYaw, Time.deltaTime * shotSnapSpeed);
 
         targetViewFocus = GetDynamicShotBroadcastFocus();
+        forceRailOverheadForCurrentShot = forceRailOverheadForCurrentShot || ShouldForceRailOverheadFromLiveAction();
 
-        if (forceRailOverheadForWholeShot)
+        if (forceRailOverheadForWholeShot || forceRailOverheadForCurrentShot)
         {
             usingTargetCamera = false;
             pocketCameraAwaitingDrop = false;
@@ -1768,6 +1819,9 @@ public class CueCamera : MonoBehaviour
         hasLastTargetPlanarVelocity = false;
         targetWasNearRail = false;
         handoffToCueBallAfterRailBounce = false;
+        forceRailOverheadForCurrentShot = false;
+        deferRailOverheadSwitchUntilPullback = false;
+        railOverheadSwitchAfterTime = 0f;
         pocketCameraAwaitingDrop = false;
         pocketDropDetected = false;
         pocketCameraStartTime = 0f;
@@ -1778,6 +1832,153 @@ public class CueCamera : MonoBehaviour
         broadcastSideSign = -cueAimSideSign;
         yaw = GetShortRailYaw(cueAimSideSign);
         targetViewYaw = GetShortRailYaw(broadcastSideSign);
+        Update2DViewIconVisibility();
+    }
+
+    private void ScheduleRailOverheadAfterPullback()
+    {
+        float pullbackDuration = enableShotPullbackFromStanding ? Mathf.Max(0f, shotPullbackDuration) : 0f;
+        railOverheadSwitchAfterTime = Time.time + pullbackDuration;
+        holdCueAimDuringShot = pullbackDuration > 0f;
+        cueStrikeHoldUntilTime = Mathf.Max(cueStrikeHoldUntilTime, railOverheadSwitchAfterTime);
+    }
+
+    private bool ShouldPreferRailOverheadAtShotStart(Transform target)
+    {
+        if (target != null && target.gameObject.activeInHierarchy)
+        {
+            bool nearRail = DistanceToRail(target.position, tableBounds) <= Mathf.Max(0.005f, railBounceSwitchDistance);
+            if (nearRail)
+            {
+                return true;
+            }
+        }
+
+        return IsCrowdedShotLane();
+    }
+
+    private bool ShouldForceRailOverheadFromLiveAction()
+    {
+        bool railBounce = ShouldHandoffToCueBall();
+        bool oppositeDirectionTravel = AreCueAndTargetMovingOppositeDirections();
+        bool crowdedMotion = CountMovingActiveBalls() >= Mathf.Max(2, crowdedActionBallCount);
+        return railBounce || oppositeDirectionTravel || crowdedMotion;
+    }
+
+    private bool AreCueAndTargetMovingOppositeDirections()
+    {
+        Rigidbody cueRb = CueBall != null ? CueBall.GetComponent<Rigidbody>() : null;
+        Rigidbody targetRb = TargetBall != null ? TargetBall.GetComponent<Rigidbody>() : null;
+        if (cueRb == null || targetRb == null)
+        {
+            return false;
+        }
+
+        Vector3 cuePlanar = new Vector3(cueRb.velocity.x, 0f, cueRb.velocity.z);
+        Vector3 targetPlanar = new Vector3(targetRb.velocity.x, 0f, targetRb.velocity.z);
+        if (cuePlanar.sqrMagnitude < 0.0004f || targetPlanar.sqrMagnitude < 0.0004f)
+        {
+            return false;
+        }
+
+        return Vector3.Dot(cuePlanar.normalized, targetPlanar.normalized) <= -0.15f;
+    }
+
+    private bool IsCrowdedShotLane()
+    {
+        if (CueBall == null || TargetBall == null || Balls == null || Balls.Length == 0)
+        {
+            return false;
+        }
+
+        Vector3 laneStart = CueBall.position;
+        Vector3 laneEnd = TargetBall.position;
+        Vector3 lane = laneEnd - laneStart;
+        lane.y = 0f;
+        float laneLength = lane.magnitude;
+        if (laneLength < 0.0001f)
+        {
+            return false;
+        }
+
+        Vector3 laneDir = lane / laneLength;
+        float lanePadding = Mathf.Max(0.02f, crowdedLanePadding);
+        int nearbyBallCount = 0;
+        for (int i = 0; i < Balls.Length; i++)
+        {
+            Transform ball = Balls[i];
+            if (ball == null || !ball.gameObject.activeInHierarchy || ball == CueBall || ball == TargetBall)
+            {
+                continue;
+            }
+
+            Vector3 planar = ball.position - laneStart;
+            planar.y = 0f;
+            float along = Vector3.Dot(planar, laneDir);
+            if (along < 0f || along > laneLength)
+            {
+                continue;
+            }
+
+            Vector3 closest = laneStart + laneDir * along;
+            Vector2 ballXZ = new Vector2(ball.position.x, ball.position.z);
+            Vector2 closestXZ = new Vector2(closest.x, closest.z);
+            float distance = Vector2.Distance(ballXZ, closestXZ);
+            if (distance <= lanePadding)
+            {
+                nearbyBallCount++;
+                if (nearbyBallCount >= 2)
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private int CountMovingActiveBalls()
+    {
+        if (Balls == null || Balls.Length == 0)
+        {
+            int fallbackMoving = 0;
+            if (IsMoving(CueBall))
+            {
+                fallbackMoving++;
+            }
+
+            if (IsMoving(TargetBall))
+            {
+                fallbackMoving++;
+            }
+
+            return fallbackMoving;
+        }
+
+        int moving = 0;
+        for (int i = 0; i < Balls.Length; i++)
+        {
+            if (IsMoving(Balls[i]))
+            {
+                moving++;
+            }
+        }
+
+        return moving;
+    }
+
+    private void Update2DViewIconVisibility()
+    {
+        if (twoDViewIcon == null)
+        {
+            return;
+        }
+
+        bool showIcon = !(hide2DIconDuringBroadcast && shotInProgress);
+        if (twoDViewIcon.activeSelf != showIcon)
+        {
+            twoDViewIcon.SetActive(showIcon);
+        }
     }
 
     private bool TryGetCornerPocketForBall(Vector3 ballPosition, float triggerRadius, out Vector3 pocket)
@@ -1853,6 +2054,11 @@ public class CueCamera : MonoBehaviour
 
     private bool TrySwitchToGuaranteedPocketCamera()
     {
+        if (forceRailOverheadForCurrentShot)
+        {
+            return false;
+        }
+
         Vector3 guaranteedPocket;
         if (!IsGuaranteedPocketCut(TargetBall, out guaranteedPocket))
         {


### PR DESCRIPTION
### Motivation
- Improve shot presentation/readability by deferring the rail-overhead broadcast cut until after the camera pullback so the pre-shot aiming framing remains readable. 
- Prefer rail-overhead broadcast for complex shots (bank/double-rail, cue/target moving in opposite directions, or crowded multi-ball lanes) to keep the action clear. 
- Keep the 2D aiming/icon UI visible during player aiming but hide it during broadcast views to avoid visual clutter.

### Description
- Changed `CueController.TriggerShotBroadcastCamera` to request a deferred handoff by sending `SwitchToRailOverheadAfterPullback` to the cue camera instead of forcing an immediate cut at strike time. (Assets/Scripts/Gameplay/CueController.cs)
- Extended `CueCamera` with inspector-configurable fields `twoDViewIcon`, `hide2DIconDuringBroadcast`, `crowdedActionBallCount`, and `crowdedLanePadding` to control the 2D icon and crowded-shot thresholds. (billiards.Unity/CueCamera.cs)
- Added deferred rail-overhead switching state and scheduling (`deferRailOverheadSwitchUntilPullback`, `railOverheadSwitchAfterTime`) and a new public `SwitchToRailOverheadAfterPullback` method; scheduled switching is applied after the pullback duration. (billiards.Unity/CueCamera.cs)
- Implemented shot-complexity heuristics and live-action checks (`ShouldPreferRailOverheadAtShotStart`, `ShouldForceRailOverheadFromLiveAction`, `AreCueAndTargetMovingOppositeDirections`, `IsCrowdedShotLane`, `CountMovingActiveBalls`) and a gate to prevent pocket-camera cut-ins when rail-overhead is required. (billiards.Unity/CueCamera.cs)
- Added `Update2DViewIconVisibility` and hooked it into `Awake`, `LateUpdate`, and `EndShot` to keep the 2D icon visible during aiming and hidden during broadcast shots when configured. (billiards.Unity/CueCamera.cs)

### Testing
- Ran `git diff --check -- Assets/Scripts/Gameplay/CueController.cs billiards.Unity/CueCamera.cs` to verify no trivial diff issues and found no whitespace/format problems (passed). 
- No PlayMode or editor Unity runtime tests were executed in this environment; runtime verification (PlayMode tests / in-editor play sessions) is recommended to confirm timing/visual behavior on device.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3bc2a144c83298d76b402142b786a)