### PR TITLE
Restore Pool Royale broadcast and replay logic to legacy baseline

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1676,11 +1676,11 @@ const POCKET_EDGE_SLEEVES_ENABLED = false; // remove the extra cloth sleeve arou
 const SIDE_POCKET_PLYWOOD_LIFT = TABLE.THICK * 0.085; // raise the middle pocket bowls so they tuck directly beneath the cloth like the corner pockets
 const POCKET_CAM_EDGE_SCALE = 0.28;
 const POCKET_CAM_OUTWARD_MULTIPLIER = 1.45;
-const POCKET_CAM_INWARD_SCALE = 0.78; // restore prior pocket-camera inward scale to keep legacy framing/positioning
-const POCKET_CAM_SIDE_EDGE_SHIFT = 0; // keep middle-pocket camera offset centered so side pockets match corner-pocket distance framing
-const POCKET_CAM_CORNER_OUTSIDE_MULTIPLIER = 0.94; // move corner-pocket cameras a bit inward (closer to the pocket center framing)
-const POCKET_CAM_SIDE_OUTSIDE_MULTIPLIER = POCKET_CAM_CORNER_OUTSIDE_MULTIPLIER; // enforce identical center-distance framing for middle and corner pockets
-const POCKET_CAM_SIDE_LATERAL_BIAS = 1; // align side-pocket outward vectors with corner-style radial vectors for consistent pocket camera geometry
+const POCKET_CAM_INWARD_SCALE = 0.82; // mirror Snooker Royal pocket-camera inward scale for identical broadcast framing
+const POCKET_CAM_SIDE_EDGE_SHIFT = BALL_R * 4.7; // nudge middle-pocket cameras a bit farther toward the table edges and away from center framing
+const POCKET_CAM_SIDE_OUTSIDE_MULTIPLIER = 2.72; // push middle-pocket cameras slightly farther outward so side pocket shots sit more off-center
+const POCKET_CAM_CORNER_OUTSIDE_MULTIPLIER = 1.08; // pull corner-pocket cameras slightly inward so they frame a bit closer toward table center
+const POCKET_CAM_SIDE_LATERAL_BIAS = 0.34; // bias only middle-pocket outward vectors toward the nearest edge; corner-pocket vectors stay unchanged
 const POCKET_CAM_BASE_MIN_OUTSIDE =
   (Math.max(SIDE_RAIL_INNER_THICKNESS, END_RAIL_INNER_THICKNESS) * 0.92 +
     POCKET_VIS_R * 1.95 +
@@ -1700,8 +1700,8 @@ const POCKET_CAM = Object.freeze({
     POCKET_CAM_BASE_MIN_OUTSIDE * 1.6 * POCKET_CAM_INWARD_SCALE +
     BALL_DIAMETER * 2.5,
   maxOutside: BALL_R * 30,
-  // Lift pocket cameras a bit higher across all pockets (corners + middle).
-  heightOffset: BALL_R * 2.76,
+  // Lift pocket cameras slightly higher so pocket closeups read a touch more top-down.
+  heightOffset: BALL_R * 2.58,
   heightOffsetShortMultiplier: 1.28,
   outwardOffset: POCKET_CAM_BASE_OUTWARD_OFFSET * POCKET_CAM_INWARD_SCALE,
   outwardOffsetShort:
@@ -1715,7 +1715,7 @@ const POCKET_CAM = Object.freeze({
   railFocusLong: BALL_R * 5.6,
   railFocusShort: BALL_R * 6.6
 });
-const POCKET_CAM_EARLY_TRIGGER_DIST = POCKET_CAM.triggerDist * 1.18; // restore earlier trigger distance so pocket cams engage at the previous point
+const POCKET_CAM_EARLY_TRIGGER_DIST = POCKET_CAM.triggerDist;
 const POCKET_POPUP_DURATION_MS = 2500;
 const POCKET_POPUP_LIFT = BALL_R * 2.4;
 const POCKET_GLOW_ENABLED = false;
@@ -1878,7 +1878,7 @@ const CLASSIC_SHORT_RAIL_CENTER_PULL = TABLE.WALL * 0.55; // additional inward s
 const PORTAL_POCKET_CLEARANCE = TABLE.WALL * 1.1; // pull the open-portal uprights away from the pocket drop line
 const PORTAL_LEG_CENTER_PULL = TABLE.WALL * 1.08; // slide open-portal legs further inward along the short rail
 const PORTAL_SHORT_RAIL_CENTER_PULL = TABLE.WALL * 0.46; // pull portal uprights toward the visual centre of the short rail
-const LEG_LEVELER_RADIUS_SCALE = 1.08; // slightly shrink the rounded metallic leveler so it reads less oversized on portrait screens
+const LEG_LEVELER_RADIUS_SCALE = 1.18; // make leveler plates slightly wider than table-leg radius
 const LEG_LEVELER_HEIGHT_SCALE = 0.2; // keep each plate low and rounded, similar to real metal levelers
 const LEG_LEVELER_STEM_RADIUS_SCALE = 0.42; // the inner cylinder that inserts into the leg center
 const LEG_LEVELER_STEM_HEIGHT_SCALE = 0.34; // visible neck before it disappears into the leg
@@ -1890,7 +1890,7 @@ const SKIRT_RAIL_GAP_FILL = TABLE.THICK * 0.095; // raise the apron further so i
 const BASE_HEIGHT_FILL = BASE_HEIGHT_REDUCTION; // keep custom bases aligned with the shorter leg height
 // adjust overall table position so the shorter legs bring the playfield closer to floor level
 const BASE_TABLE_Y = -2 + (TABLE_H - 0.75) + TABLE_H + TABLE_LIFT - TABLE_DROP;
-const TABLE_HEIGHT_DROP = (TABLE_H + TABLE.THICK) * 0.24; // lower the full table assembly a bit more so portal leg bottoms sit down onto their chrome levelers
+const TABLE_HEIGHT_DROP = (TABLE_H + TABLE.THICK) * 0.2; // lower the full table assembly a touch more while keeping rail/camera framing stable
 const TABLE_Y = BASE_TABLE_Y + LEG_ELEVATION_DELTA - TABLE_HEIGHT_DROP;
 const LEG_BASE_DROP = LEG_ROOM_HEIGHT * 0.3;
 const FLOOR_Y = TABLE_Y - TABLE.THICK - LEG_ROOM_HEIGHT - LEG_BASE_DROP + 0.3;
@@ -2479,14 +2479,11 @@ function scaleWoodRepeatVector (repeatVec, scale) {
   return vec
 }
 
-const LT_CARBON_TEXTURE_REPEAT = Object.freeze({ x: 20, y: 5.2 });
+const LT_CARBON_TEXTURE_REPEAT = Object.freeze({ x: 16, y: 4 });
 let CARBON_FIBER_TILE_CANVAS = null;
 const CARBON_FIBER_TILE_TEXTURES = new Map();
-const LT_MATTE_PLASTIC_TEXTURE_REPEAT = Object.freeze({ x: 10.5, y: 3.8 });
+const LT_MATTE_PLASTIC_TEXTURE_REPEAT = Object.freeze({ x: 9, y: 3.2 });
 const LT_MATTE_PLASTIC_TEXTURES = new Map();
-const LT_FINISH_BRIGHTNESS_LIFT = 0.16;
-const LT_FINISH_CONTRAST_BOOST = 1.2;
-const LT_MATTE_NORMAL_SCALE = 0.68;
 
 function createCarbonFiberPatternCanvas(size = 128) {
   if (typeof document === 'undefined') return null;
@@ -2555,22 +2552,9 @@ function getCarbonFiberTileTexture(tintHex = 0x0c0f14) {
   tintedCtx.fillStyle = `#${tintKey}`;
   tintedCtx.fillRect(0, 0, tintedCanvas.width, tintedCanvas.height);
   tintedCtx.globalCompositeOperation = 'screen';
-  tintedCtx.fillStyle = 'rgba(255,255,255,0.12)';
+  tintedCtx.fillStyle = 'rgba(255,255,255,0.08)';
   tintedCtx.fillRect(0, 0, tintedCanvas.width, tintedCanvas.height);
   tintedCtx.globalCompositeOperation = 'source-over';
-  const imageData = tintedCtx.getImageData(0, 0, tintedCanvas.width, tintedCanvas.height);
-  const pixels = imageData.data;
-  for (let i = 0; i < pixels.length; i += 4) {
-    const applyCurve = (value) => {
-      const normalized = value / 255;
-      const contrasted = (normalized - 0.5) * LT_FINISH_CONTRAST_BOOST + 0.5 + LT_FINISH_BRIGHTNESS_LIFT;
-      return THREE.MathUtils.clamp(Math.round(contrasted * 255), 0, 255);
-    };
-    pixels[i] = applyCurve(pixels[i]);
-    pixels[i + 1] = applyCurve(pixels[i + 1]);
-    pixels[i + 2] = applyCurve(pixels[i + 2]);
-  }
-  tintedCtx.putImageData(imageData, 0, 0);
   const texture = new THREE.CanvasTexture(tintedCanvas);
   applySRGBColorSpace(texture);
   texture.wrapS = THREE.RepeatWrapping;
@@ -2629,17 +2613,17 @@ function getLtMattePlasticTextureSet(tintHex = 0x0c0f14, size = 320) {
       const dither = Math.sin(x * 0.34 + y * 0.26) * 0.5 + Math.cos(x * 0.17 - y * 0.23) * 0.5;
       const grain = (Math.sin((x + y) * 0.9) + Math.cos((x - y) * 0.78)) * 0.5;
       const micropit = Math.sin(x * 1.37) * Math.cos(y * 1.49);
-      const colorLift = THREE.MathUtils.clamp(dither * 9 + grain * 6, -22, 22);
-      const boostedR = THREE.MathUtils.lerp(tintR, 255, 0.18);
-      const boostedG = THREE.MathUtils.lerp(tintG, 255, 0.18);
-      const boostedB = THREE.MathUtils.lerp(tintB, 255, 0.18);
+      const colorLift = THREE.MathUtils.clamp(dither * 6 + grain * 4, -16, 16);
+      const boostedR = THREE.MathUtils.lerp(tintR, 255, 0.12);
+      const boostedG = THREE.MathUtils.lerp(tintG, 255, 0.12);
+      const boostedB = THREE.MathUtils.lerp(tintB, 255, 0.12);
       colorImage.data[i] = THREE.MathUtils.clamp(boostedR + colorLift, 0, 255);
       colorImage.data[i + 1] = THREE.MathUtils.clamp(boostedG + colorLift, 0, 255);
       colorImage.data[i + 2] = THREE.MathUtils.clamp(boostedB + colorLift, 0, 255);
       colorImage.data[i + 3] = 255;
-      normalImage.data[i] = THREE.MathUtils.clamp(128 + dither * 22, 0, 255);
-      normalImage.data[i + 1] = THREE.MathUtils.clamp(128 + grain * 22, 0, 255);
-      normalImage.data[i + 2] = THREE.MathUtils.clamp(220 + micropit * 34, 0, 255);
+      normalImage.data[i] = THREE.MathUtils.clamp(128 + dither * 18, 0, 255);
+      normalImage.data[i + 1] = THREE.MathUtils.clamp(128 + grain * 18, 0, 255);
+      normalImage.data[i + 2] = THREE.MathUtils.clamp(215 + micropit * 28, 0, 255);
       normalImage.data[i + 3] = 255;
       const rough = THREE.MathUtils.clamp(214 + dither * 16 + grain * 12 + micropit * 10, 150, 255);
       roughImage.data[i] = rough;
@@ -2661,7 +2645,7 @@ function getLtMattePlasticTextureSet(tintHex = 0x0c0f14, size = 320) {
     texture.repeat.set(LT_MATTE_PLASTIC_TEXTURE_REPEAT.x, LT_MATTE_PLASTIC_TEXTURE_REPEAT.y);
     texture.generateMipmaps = true;
     texture.minFilter = THREE.LinearMipmapLinearFilter;
-    texture.magFilter = THREE.LinearFilter;
+    texture.magFilter = THREE.NearestFilter;
     texture.anisotropy = resolveTextureAnisotropy(texture.anisotropy ?? 1);
     texture.needsUpdate = true;
     if (idx === 0) {
@@ -2705,7 +2689,7 @@ function applyMonoMattePlasticSurface(material) {
     material.envMapIntensity = 0.12;
   }
   if ('normalScale' in material && material.normalMap) {
-    material.normalScale = new THREE.Vector2(LT_MATTE_NORMAL_SCALE, LT_MATTE_NORMAL_SCALE);
+    material.normalScale = new THREE.Vector2(0.5, 0.5);
   }
   material.needsUpdate = true;
 }
@@ -3787,7 +3771,7 @@ const BROADCAST_SYSTEM_OPTIONS = Object.freeze([
 ]);
 const DEFAULT_BROADCAST_SYSTEM_ID = 'rail-overhead';
 const RAIL_OVERHEAD_AND_POCKET_CAMERA_ONLY = true; // enforce only rail-overhead + pocket cameras during shot broadcast
-const BROADCAST_EXCLUDE_MIDDLE_POCKET_CAMERAS = true; // disable middle-pocket broadcast cuts and use only corner-pocket cameras for guaranteed pots
+const BROADCAST_EXCLUDE_MIDDLE_POCKET_CAMERAS = false; // keep side-pocket cuts enabled to match Snooker Royal broadcast/replay routing
 const resolveBroadcastSystem = (id) =>
   BROADCAST_SYSTEM_OPTIONS.find((opt) => opt.id === id) ??
   BROADCAST_SYSTEM_OPTIONS.find((opt) => opt.id === DEFAULT_BROADCAST_SYSTEM_ID) ??
@@ -5962,7 +5946,6 @@ const CUE_VIEW_SPIN_ZOOM = 0; // remove zoom shifts while spin control is active
 const RAIL_OVERHEAD_AIM_ZOOM = 1; // no extra zoom while tracking; rotate/look dynamics only
 const RAIL_OVERHEAD_AIM_PHI_LIFT = 0.014; // keep rail-overhead aim view marginally more downward while preserving depth
 const RAIL_OVERHEAD_REPLAY_FOV = STANDING_VIEW_FOV + 6; // widen rail-overhead lens a bit more so both bottom pockets stay visible on portrait screens
-const ENABLE_SHOT_REPLAY = false; // Pool Royale broadcast update: remove replay playback and keep live rail-overhead coverage
 const PORTRAIT_TOP_ACTION_BAR_DROP_REM = 1.05; // move portrait gift/chat/menu controls a bit lower from the top edge
 const BACKSPIN_DIRECTION_PREVIEW = 1; // show draw/backswing direction on cue-ball follow line
 const AIM_SPIN_PREVIEW_SIDE = 1;
@@ -5975,8 +5958,8 @@ const LONG_SHOT_ACTIVATION_TRAVEL = PLAY_H * 0.28;
 const LONG_SHOT_SPEED_SWITCH_THRESHOLD =
   SHOT_BASE_SPEED * 0.82; // skip long-shot cam switch if cue ball launches faster
 const LONG_SHOT_SHORT_RAIL_OFFSET = BALL_R * 18;
-const GOOD_SHOT_REPLAY_DELAY_MS = 320; // start replay sequence sooner so replay frame/slate appears promptly after resolution
-const REPLAY_TRANSITION_LEAD_MS = 180; // shorten slate lead-in to reduce perceived dead time before replay playback
+const GOOD_SHOT_REPLAY_DELAY_MS = 900;
+const REPLAY_TRANSITION_LEAD_MS = 420;
 const REPLAY_SLATE_DURATION_MS = 1200;
 const REPLAY_TIMEOUT_GRACE_MS = 750;
 const REMATCH_DECISION_MS = 15000;
@@ -6048,19 +6031,16 @@ const REPLAY_CUE_MIN_PULLBACK_MS = 0; // defer to recorded cue pullback like Sno
 const REPLAY_CUE_MIN_RELEASE_MS = 0; // defer to recorded stroke durations like Snooker Royal
 const REPLAY_FOUL_WRONG_BALL_IMPACT_WINDOW_MS = 220;
 const REPLAY_FOUL_WRONG_BALL_IMPACT_SLOW_FACTOR = 0.35;
-const CUE_STROKE_POST_HIT_CAMERA_HOLD_MS = 90; // shorten post-hit hold so rail-overhead broadcast can engage earlier
+const CUE_STROKE_POST_HIT_CAMERA_HOLD_MS = 420;
 // Keep the live stroke timing aligned with the reference cue motion:
 // quick push forward and a short hold before snapping back to idle.
 const LIVE_CUE_FORWARD_DURATION_MS = 180;
 const LIVE_CUE_IMPACT_HOLD_MS = 90;
-const CAMERA_SWITCH_MIN_HOLD_MS = 70; // cut mandatory lock further so rail-overhead camera switches in noticeably earlier
+const CAMERA_SWITCH_MIN_HOLD_MS = 420;
 const CUEBALL_EARLY_CAMERA_SWITCH_SPEED = BALL_R * 24;
 const CUEBALL_CAMERA_SWITCH_MIN_TRAVEL = BALL_R * 1.15;
-const STROKE_CAMERA_MIN_HOLD_MS = 90; // lower minimum stroke hold to avoid delayed shot camera transitions
+const STROKE_CAMERA_MIN_HOLD_MS = 210;
 const CUEBALL_CAMERA_SWITCH_MIN_SPEED = BALL_R * 3.8;
-const RAIL_OVERHEAD_OPPOSITE_DIRECTION_DOT = 0.45;
-const RAIL_OVERHEAD_CROWD_RADIUS = BALL_DIAMETER * 1.8;
-const RAIL_OVERHEAD_CROWD_BALL_THRESHOLD = 3;
 const PORTRAIT_HUD_HORIZONTAL_NUDGE_PX = 34;
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
 const BREAK_DIE_SIZE = BALL_R * 2.25;
@@ -11963,9 +11943,8 @@ export function Table3D(
       rubberRing.castShadow = false;
       rubberRing.receiveShadow = true;
       group.add(rubberRing, disc, stem);
-      const legBottomY = Number.isFinite(center?.legBottomY)
-        ? center.legBottomY
-        : Number.isFinite(ctx?.legY) && Number.isFinite(ctx?.legH)
+      const legBottomY =
+        Number.isFinite(ctx?.legY) && Number.isFinite(ctx?.legH)
           ? ctx.legY - ctx.legH * 0.5
           : ctx.floorY;
       const levelerMidY = levelerHeight * 0.5 + rubberHeight;
@@ -12061,8 +12040,7 @@ export function Table3D(
           legMeshes.push(leg);
           levelerCenters.push({
             x: side * legOffsetX,
-            z: signZ * portalZ,
-            legBottomY: legBaseY
+            z: signZ * portalZ
           });
         });
         portal.position.set(0, 0, signZ * portalZ);
@@ -13306,7 +13284,16 @@ function PoolRoyaleGame({
     return DEFAULT_FRAME_RATE_ID;
   });
   const [broadcastSystemId, setBroadcastSystemId] = useState(() => DEFAULT_BROADCAST_SYSTEM_ID);
-  const [autoReplayEnabled, setAutoReplayEnabled] = useState(false);
+  const [autoReplayEnabled, setAutoReplayEnabled] = useState(() => {
+    if (typeof window === 'undefined') return true;
+    try {
+      const stored = window.localStorage.getItem(AUTO_REPLAY_STORAGE_KEY);
+      if (stored == null) return true;
+      return stored !== '0';
+    } catch {
+      return true;
+    }
+  });
   const initialTableSlot = 0;
   const [activeTableSlot, setActiveTableSlot] = useState(initialTableSlot);
   const [tableSelectionOpen, setTableSelectionOpen] = useState(false);
@@ -14954,7 +14941,6 @@ function PoolRoyaleGame({
   }, [broadcastSystemId]);
   useEffect(() => {
     if (typeof window !== 'undefined') {
-      if (!ENABLE_SHOT_REPLAY) return;
       window.localStorage.setItem(AUTO_REPLAY_STORAGE_KEY, autoReplayEnabled ? '1' : '0');
     }
   }, [autoReplayEnabled]);
@@ -21733,16 +21719,13 @@ const powerRef = useRef(hud.power);
             return null;
           }
           const forcedEarly = forceEarly && shotPrediction?.ballId === ballId;
-          const triggerDistance = forceCornerCapture
-            ? POCKET_CAM_EARLY_TRIGGER_DIST
-            : isGuaranteedPocket
-              ? POCKET_CAM_EARLY_TRIGGER_DIST
-              : POCKET_CAM.triggerDist;
-          if (!forceCornerCapture && best.dist > triggerDistance) return null;
+          if (!forceCornerCapture && best.dist > POCKET_CAM.triggerDist && !forcedEarly) return null;
           const baseHeightOffset = POCKET_CAM.heightOffset;
           const shortPocketHeightMultiplier =
             POCKET_CAM.heightOffsetShortMultiplier ?? 1;
-          const heightOffset = baseHeightOffset * shortPocketHeightMultiplier;
+          const heightOffset = isSidePocket
+            ? baseHeightOffset * 0.92
+            : baseHeightOffset * shortPocketHeightMultiplier;
           const railDir = isSidePocket
             ? signed(best.center.x, 1)
             : signed(best.center.y, 1);
@@ -21760,13 +21743,20 @@ const powerRef = useRef(hud.power);
               }
             : null;
           const now = performance.now();
+          const effectiveDist =
+            forcedEarly && !forceCornerCapture
+              ? Math.min(best.dist, POCKET_CAM.triggerDist)
+              : best.dist;
           const minOutside = isSidePocket
             ? POCKET_CAM.minOutside
             : POCKET_CAM.minOutsideShort ?? POCKET_CAM.minOutside;
-          const outsideDistanceMultiplier = isSidePocket
-            ? POCKET_CAM_SIDE_OUTSIDE_MULTIPLIER
-            : POCKET_CAM_CORNER_OUTSIDE_MULTIPLIER;
-          const cameraDistance = minOutside * outsideDistanceMultiplier;
+          const cameraDistance = forceCornerCapture
+            ? minOutside * (isSidePocket ? POCKET_CAM_SIDE_OUTSIDE_MULTIPLIER : POCKET_CAM_CORNER_OUTSIDE_MULTIPLIER)
+            : THREE.MathUtils.clamp(
+                effectiveDist * POCKET_CAM.distanceScale,
+                minOutside,
+                POCKET_CAM.maxOutside
+              );
           const broadcastRailDir = isSidePocket
             ? resolveShortRailBroadcastDirection({
                 pocketCenter: best.center,
@@ -21776,19 +21766,12 @@ const powerRef = useRef(hud.power);
                 fallback: signed(pos.y, 1)
               })
             : railDir;
-          const focusLead = isSidePocket
-            ? POCKET_CAM.railFocusLong ?? POCKET_CAM.railFocusShort
-            : POCKET_CAM.railFocusShort ?? POCKET_CAM.railFocusLong;
-          const fixedTarget2D = best.center
-            .clone()
-            .add(approachDir.clone().multiplyScalar(-focusLead));
           return {
             mode: 'pocket',
             ballId,
             pocketId: anchorPocketId,
             pocketCenter: best.center.clone(),
             approach: approachDir,
-            fixedTarget2D,
             heightOffset,
             heightScale: POCKET_CAM.heightScale,
             lastBallPos: pos.clone(),
@@ -21806,7 +21789,6 @@ const powerRef = useRef(hud.power);
             anchorOutward:
               anchorOutward?.normalize() ?? fallbackOutward,
             cameraDistance,
-            distanceScale: POCKET_CAM.distanceScale,
             lastRailHitAt: targetBall.lastRailHitAt ?? null,
             lastRailHitType: targetBall.lastRailHitType ?? null,
             predictedAlignment,
@@ -26163,35 +26145,11 @@ const powerRef = useRef(hud.power);
             shotAimDir && shotPrediction?.dir
               ? shotAimDir.clone().normalize().dot(shotPrediction.dir.clone().normalize())
               : 1;
-          const hasCueTargetDirectionSplit =
-            cueVsTargetAlignment < RAIL_OVERHEAD_OPPOSITE_DIRECTION_DOT;
-          const shotCrowdBallCount = (() => {
-            if (!prediction?.targetBall || !Array.isArray(balls)) return 0;
-            const cueToTarget = prediction.targetBall.pos.clone().sub(cue.pos);
-            const span = cueToTarget.length();
-            if (!Number.isFinite(span) || span <= 1e-6) return 0;
-            cueToTarget.multiplyScalar(1 / span);
-            let count = 0;
-            for (const ball of balls) {
-              if (!ball?.active) continue;
-              if (ball.id === cue.id || ball.id === prediction.targetBall.id) continue;
-              const toBall = ball.pos.clone().sub(cue.pos);
-              const projection = toBall.dot(cueToTarget);
-              if (projection < 0 || projection > span) continue;
-              const nearest = cue.pos.clone().add(cueToTarget.clone().multiplyScalar(projection));
-              if (ball.pos.distanceTo(nearest) <= RAIL_OVERHEAD_CROWD_RADIUS) {
-                count += 1;
-              }
-            }
-            return count;
-          })();
-          const isCrowdedShot = shotCrowdBallCount >= RAIL_OVERHEAD_CROWD_BALL_THRESHOLD;
+          const hasCueTargetDirectionSplit = cueVsTargetAlignment < 0.45;
           const forceImmediateRailOverheadView =
             isBreakShot ||
             Boolean(shotPrediction?.railNormal) ||
-            hasCueTargetDirectionSplit ||
-            (isMiddlePocketIntent && hasCueTargetDirectionSplit) ||
-            isCrowdedShot;
+            (isMiddlePocketIntent && hasCueTargetDirectionSplit);
           const allowRailOverheadActionView = true;
           const allowLongShotCameraSwitch =
             (forceImmediateRailOverheadView || !suppressOpeningShotViews) &&
@@ -26473,11 +26431,10 @@ const powerRef = useRef(hud.power);
             );
             const strokeReadyAt = Math.max(cameraHoldUntil, now + STROKE_CAMERA_MIN_HOLD_MS);
             const requiresCueBallMovementTrigger = false;
-            const pulledBackAtStrike = startPull > 0.003;
             const shouldActivateActionView =
               !requiresCueBallMovementTrigger &&
-              pulledBackAtStrike &&
-              (forceImmediateRailOverheadView || !isLongShot || forceActionActivation);
+              (!isLongShot || forceActionActivation) &&
+              !isMaxPowerShot;
             if (shouldActivateActionView) {
               actionView.pendingActivation = false;
               actionView.activationDelay = null;
@@ -28754,11 +28711,6 @@ const powerRef = useRef(hud.power);
 
         // Resolve shot
         function resolve() {
-          // Guarantee at least one fresh terminal replay sample before we decide
-          // whether to launch replay, so short shots still get a visible replay frame.
-          if (shotRecording) {
-            recordReplayFrame(performance.now());
-          }
           const variantId = activeVariantRef.current?.id ?? 'american';
           const shotEvents = [];
           const firstContactColor = toBallColorId(firstHit);
@@ -28769,12 +28721,9 @@ const powerRef = useRef(hud.power);
             pottedBalls: potted,
             shotContext: shotContextRef.current
           });
-          const hasReplayFrames = (shotRecording?.frames?.length ?? 0) > 1;
           let shouldStartReplay =
-            ENABLE_SHOT_REPLAY &&
-            autoReplayEnabled &&
-            hasReplayFrames &&
-            (Boolean(replayDecision?.shouldReplay) || hasReplayFrames);
+            Boolean(replayDecision?.shouldReplay) &&
+            (shotRecording?.frames?.length ?? 0) > 1;
           let replayBannerText = replayDecision?.banner ?? selectReplayBanner('default');
           let replayAccent = replayDecision?.primaryTag ?? 'default';
           let postShotSnapshot = null;
@@ -29001,20 +28950,16 @@ const powerRef = useRef(hud.power);
           replayBannerText = replayDecision.banner ?? selectReplayBanner('final');
           replayAccent = replayDecision.primaryTag ?? 'final';
           shouldStartReplay =
-            ENABLE_SHOT_REPLAY &&
-            autoReplayEnabled &&
-            hasReplayFrames &&
-            (Boolean(replayDecision?.shouldReplay) || hasReplayFrames);
+            Boolean(replayDecision?.shouldReplay) &&
+            (shotRecording?.frames?.length ?? 0) > 1;
         }
         if (replayDecision && shotRecording) {
           shotRecording.replayTags = replayDecision.tags;
           shotRecording.zoomOnly = replayDecision.zoomOnly;
         }
         shouldStartReplay =
-          ENABLE_SHOT_REPLAY &&
-          autoReplayEnabled &&
-          hasReplayFrames &&
-          (Boolean(replayDecision?.shouldReplay) || hasReplayFrames);
+          Boolean(replayDecision?.shouldReplay) &&
+          (shotRecording?.frames?.length ?? 0) > 1;
         const shooterSeat = currentState?.activePlayer === 'B' ? 'B' : 'A';
         if (potted.length) {
           const newPots = potted.filter(
@@ -29479,20 +29424,7 @@ const powerRef = useRef(hud.power);
           remoteAimRef.current = null;
         }
         if (!shooting && !shotRecording && !replayPlaybackRef.current && pendingRemoteReplayRef.current) {
-          const pending = pendingRemoteReplayRef.current;
           pendingRemoteReplayRef.current = null;
-          if (ENABLE_SHOT_REPLAY && autoReplayEnabled && pending?.frames?.length > 1) {
-            shotRecording = {
-              ...pending,
-              startTime: pending.startTime ?? nowMs,
-              startState: pending.startState ?? captureBallSnapshot(),
-              zoomOnly: pending.zoomOnly ?? false,
-              replayTags: pending.replayTags ?? ['remote']
-            };
-            shotReplayRef.current = shotRecording;
-            const postState = pending.postState ?? captureBallSnapshot();
-            startShotReplay(postState);
-          }
         }
         const frameTiming = frameTimingRef.current;
         const targetFrameTime =
@@ -33582,35 +33514,33 @@ const powerRef = useRef(hud.power);
                   })}
                 </div>
               </div>
-              {ENABLE_SHOT_REPLAY ? (
-                <div>
-                  <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
-                    Replay Controls
-                  </h3>
-                  <button
-                    type="button"
-                    onClick={() => setAutoReplayEnabled((prev) => !prev)}
-                    aria-pressed={autoReplayEnabled}
-                    className={`mt-2 w-full rounded-2xl border px-4 py-2 text-left transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
-                      autoReplayEnabled
-                        ? 'border-emerald-300 bg-emerald-300/90 text-black shadow-[0_0_16px_rgba(16,185,129,0.55)]'
-                        : 'border-white/20 bg-white/10 text-white/80 hover:bg-white/20'
-                    }`}
-                  >
-                    <span className="flex items-center justify-between gap-2">
-                      <span className="text-[11px] font-semibold uppercase tracking-[0.28em]">
-                        Auto Replay
-                      </span>
-                      <span className="text-[10px] font-semibold uppercase tracking-[0.2em]">
-                        {autoReplayEnabled ? 'On' : 'Off'}
-                      </span>
+              <div>
+                <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
+                  Replay Controls
+                </h3>
+                <button
+                  type="button"
+                  onClick={() => setAutoReplayEnabled((prev) => !prev)}
+                  aria-pressed={autoReplayEnabled}
+                  className={`mt-2 w-full rounded-2xl border px-4 py-2 text-left transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
+                    autoReplayEnabled
+                      ? 'border-emerald-300 bg-emerald-300/90 text-black shadow-[0_0_16px_rgba(16,185,129,0.55)]'
+                      : 'border-white/20 bg-white/10 text-white/80 hover:bg-white/20'
+                  }`}
+                >
+                  <span className="flex items-center justify-between gap-2">
+                    <span className="text-[11px] font-semibold uppercase tracking-[0.28em]">
+                      Auto Replay
                     </span>
-                    <span className="mt-1 block text-[10px] uppercase tracking-[0.16em] text-white/60">
-                      Replays keep live graphics quality and appear on potted/foul moments.
+                    <span className="text-[10px] font-semibold uppercase tracking-[0.2em]">
+                      {autoReplayEnabled ? 'On' : 'Off'}
                     </span>
-                  </button>
-                </div>
-              ) : null}
+                  </span>
+                  <span className="mt-1 block text-[10px] uppercase tracking-[0.16em] text-white/60">
+                    Replays keep live graphics quality and appear on potted/foul moments.
+                  </span>
+                </button>
+              </div>
             </div>
           </div>
         )}
@@ -34045,15 +33975,17 @@ const powerRef = useRef(hud.power);
             aria-pressed={isTopDownView && !isRailOverheadView}
             onClick={() => {
               if (!isPortrait) return;
-              setIsRailOverheadView(false);
+              setIsRailOverheadView(true);
               setIsTopDownView(true);
             }}
-            className={`flex h-12 w-12 items-center justify-center rounded-full border text-[11px] font-semibold uppercase tracking-[0.2em] shadow-[0_12px_32px_rgba(0,0,0,0.45)] backdrop-blur transition ${
+            disabled
+            className={`flex h-12 w-12 items-center justify-center rounded-full border text-[11px] font-semibold uppercase tracking-[0.2em] shadow-[0_12px_32px_rgba(0,0,0,0.45)] backdrop-blur transition disabled:cursor-not-allowed disabled:opacity-45 ${
               isTopDownView && !isRailOverheadView
                 ? 'border-emerald-300 bg-emerald-300/20 text-emerald-100'
                 : 'border-white/30 bg-black/70 text-white hover:bg-black/60'
             }`}
-            aria-label="Switch to 2D view"
+            aria-label="2D view disabled during broadcast"
+            title="2D view is disabled for Pool Royale broadcast"
           >
             <span aria-hidden="true">2D</span>
           </button>


### PR DESCRIPTION
### Motivation
- The Pool Royale broadcast and replay flow had been modified and caused regressions in camera routing, replay triggering, and UI behavior compared to the earlier baseline, so the code was reverted to the prior stable behavior. 
- The goal is to restore parity with the earlier, trusted broadcast/replay logic (alignment with Snooker Royal style routing and legacy replay timing). 
- Surface/visual tuning changes that were mixed into the same area were also reverted where they affected how broadcast/replay frames were captured and shown.

### Description
- Restored the legacy broadcast/replay decision flow in `webapp/src/pages/Games/PoolRoyale.jsx`, including re-enabling replay triggering and the auto-replay UI and persistence (`AUTO_REPLAY_STORAGE_KEY` behavior). 
- Reverted camera and replay timing constants to the previous baseline (e.g. `GOOD_SHOT_REPLAY_DELAY_MS`, `REPLAY_TRANSITION_LEAD_MS`, `CUE_STROKE_POST_HIT_CAMERA_HOLD_MS`, `CAMERA_SWITCH_MIN_HOLD_MS`, `STROKE_CAMERA_MIN_HOLD_MS`) and restored `POCKET_CAM` trigger/geometry and inclusion of middle-pocket cameras (`BROADCAST_EXCLUDE_MIDDLE_POCKET_CAMERAS = false`). 
- Reinstated prior pocket-camera distance/height behavior and action/rail-overhead activation heuristics so pocket cuts and rail-overhead handoffs behave as before. 
- Reverted several visual/material parameter edits that were present in the same file (carbon/matte texture repeat and texture generation params, normal/roughness/magFilter settings, leg leveler sizing and table height drop) to the earlier values that matched the legacy baseline.

### Testing
- Built the webapp with `npm --prefix webapp run build` and the Vite production build completed successfully (non-blocking chunk-size warnings were emitted). 
- Lint was attempted via `npm --prefix webapp run -s lint -- src/pages/Games/PoolRoyale.jsx` but no lint script/output was available in this environment so no lint result was produced. 
- No additional automated unit tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3cbf1b2b88329afa4cd748544e51d)