### PR TITLE
Fix Pool Royale rack spacing to prevent overlapping balls

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2292,8 +2292,14 @@ function generateRackPositions(ballCount, layout, ballRadius, startZ) {
   if (ballCount <= 0 || !Number.isFinite(ballRadius) || !Number.isFinite(startZ)) {
     return positions;
   }
-  const columnSpacing = ballRadius * 2 + 0.002 * (ballRadius / 0.0525);
-  const rowSpacing = ballRadius * 1.9;
+  const diameter = ballRadius * 2;
+  const rackGap = Math.max(ballRadius * 0.028, 0.00075 * (ballRadius / 0.0525));
+  const columnSpacing = diameter + rackGap;
+  const halfColumn = columnSpacing * 0.5;
+  const baseRowSpacing = Math.sqrt(
+    Math.max(0, diameter * diameter - halfColumn * halfColumn)
+  );
+  const rowSpacing = baseRowSpacing + rackGap * 0.55;
   if (layout === 'diamond') {
     const rows = [1, 2, 3, 2, 1];
     let index = 0;


### PR DESCRIPTION
### Motivation
- Balls in the initial rack could spawn overlapping/too-close under certain table/camera scales, producing visual collisions and mapping issues in portrait/mobile views.
- The goal is to compute rack spacing from the real ball diameter and a small safety gap instead of relying on fixed magic multipliers so racks always generate with clean separations.

### Description
- Updated `generateRackPositions` in `webapp/src/pages/Games/PoolRoyale.jsx` to derive spacing from `diameter = ballRadius * 2` and a small configurable `rackGap`.
- Replaced the prior fixed multipliers with `columnSpacing = diameter + rackGap` and a geometry-based `rowSpacing` computed from `sqrt(diameter^2 - (halfColumn^2))` plus a tuned gap term.
- The new spacing is used for both `triangle` and `diamond` rack layouts so all rack patterns avoid initial overlap.

### Testing
- Ran the linter for the changed file with `npm run -s lint -- webapp/src/pages/Games/PoolRoyale.jsx`, which completed with an environment React detection warning but produced no lint errors for the modified file.
- No other automated unit or integration tests were run in this change; the file was staged and committed after the change (`webapp/src/pages/Games/PoolRoyale.jsx`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3da1383508329a65cc8494ab36ad6)