### PR TITLE
Improve Pool Royale action camera pair tracking after shot trigger

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -20476,28 +20476,35 @@ const powerRef = useRef(hud.power);
               const heightBase = TABLE_Y + TABLE.THICK;
               const standingPhi = STANDING_VIEW_PHI;
               if (activeShotView.stage === 'pair') {
-                const targetBall =
+                let targetBall =
                   activeShotView.targetId != null
                     ? ballsList.find((b) => b.id === activeShotView.targetId)
                     : null;
+                if (!targetBall?.active && shooting) {
+                  targetBall =
+                    ballsList.find(
+                      (b) => b?.active && b.id !== cueBall.id && b.vel.lengthSq() > STOP_EPS * STOP_EPS
+                    ) ??
+                    targetBall;
+                }
                 pairTargetBall = targetBall ?? null;
                 let targetPos2;
                 if (targetBall?.active) {
                   targetPos2 = new THREE.Vector2(targetBall.pos.x, targetBall.pos.y);
-                  if (!shooting) {
-                    activeShotView.targetLastPos = targetPos2.clone();
-                  }
+                  activeShotView.targetLastPos = targetPos2.clone();
                 } else if (activeShotView.targetLastPos) {
                   targetPos2 = activeShotView.targetLastPos.clone();
                 } else {
                   targetPos2 = cueAnchor.clone().add(new THREE.Vector2(0, BALL_R * 6));
                 }
-                const targetAnchor = activeShotView.targetInitialPos
-                  ? activeShotView.targetInitialPos.clone()
-                  : targetPos2;
-                const mid = cueAnchor.clone().add(targetAnchor).multiplyScalar(0.5);
-                const span = Math.max(targetAnchor.distanceTo(cueAnchor), BALL_R * 4);
-                const forward = targetAnchor.clone().sub(cueAnchor);
+                const trackedCuePos = shooting ? cuePos2 : cueAnchor.clone();
+                const targetAnchor =
+                  shooting || !activeShotView.targetInitialPos
+                    ? targetPos2.clone()
+                    : activeShotView.targetInitialPos.clone();
+                const mid = trackedCuePos.clone().add(targetAnchor).multiplyScalar(0.5);
+                const span = Math.max(targetAnchor.distanceTo(trackedCuePos), BALL_R * 4);
+                const forward = targetAnchor.clone().sub(trackedCuePos);
                 if (forward.lengthSq() < 1e-6) forward.set(0, 1);
                 forward.normalize();
                 const side = new THREE.Vector2(-forward.y, forward.x);


### PR DESCRIPTION
### Motivation
- Ensure the cue/action camera dynamically turns and continues tracking cue ball + target ball once a shot is triggered so the broadcast framing stays relevant during impacts and fast spreads.

### Description
- In `webapp/src/pages/Games/PoolRoyale.jsx` update the `activeShotView.stage === 'pair'` logic to resolve a live `targetBall` fallback when the originally predicted target is inactive during `shooting`.
- Persist `activeShotView.targetLastPos` continuously when the target is active so the camera uses a live last-known target position rather than a stale pre-shot anchor.
- Use a tracked cue position (`trackedCuePos`) while shooting so `mid`, `span`, and `forward` (pair framing) are computed relative to the moving cue ball instead of the pre-shot anchor.
- Keep existing framing/clamping logic but feed it the dynamic cue/target positions so the action camera smoothly follows the shot.

### Testing
- Ran production build with `cd webapp && npm run build`, which completed successfully (build warnings only) and produced the distribution artifacts.
- Attempted to run project lint via `npm run eslint`, but the script is missing in this environment so linting was not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3df7b9120832984d0e852264562fa)