### PR TITLE
Enable dynamic cue-camera tracking at shot trigger

### DIFF
--- a/Assets/Scripts/Gameplay/CueController.cs
+++ b/Assets/Scripts/Gameplay/CueController.cs
@@ -48,6 +48,10 @@ namespace Aiming
         [Header("Camera sync")]
         [Tooltip("Optional cue camera that should mirror pull/push stroke motion for player, AI, and replay capture.")]
         public CueCamera cueCamera;
+        [Tooltip("When enabled, the cue camera stays active at shot trigger and dynamically turns to keep both cue ball and target ball tracked during the strike window.")]
+        public bool enableDynamicCueTrackingOnShotTrigger = true;
+        [Tooltip("Optional override to force an immediate rail-overhead handoff at shot trigger instead of dynamic cue tracking.")]
+        public bool forceImmediateRailOverheadOnShotTrigger;
         [Tooltip("Broadcast camera director used to force immediate rail-overhead switching at shot trigger.")]
         public ShotBroadcastCameraDirector broadcastCameraDirector;
         public CueStrikePhysics strikePhysics = new CueStrikePhysics();
@@ -173,7 +177,20 @@ namespace Aiming
         {
             if (cueCamera != null)
             {
-                cueCamera.SendMessage("SwitchToRailOverheadAfterPullback", SendMessageOptions.DontRequireReceiver);
+                if (enableDynamicCueTrackingOnShotTrigger)
+                {
+                    cueCamera.BeginShot(objectBall);
+                }
+
+                if (forceImmediateRailOverheadOnShotTrigger)
+                {
+                    cueCamera.SwitchToRailOverheadImmediate();
+                }
+            }
+
+            if (forceImmediateRailOverheadOnShotTrigger && broadcastCameraDirector != null)
+            {
+                broadcastCameraDirector.ForceRailOverheadForNextShot();
             }
         }
 


### PR DESCRIPTION
### Motivation
- Make the cue camera actively track the cue ball and targeted object ball during the strike window instead of always cutting to a rail-overhead view, improving visual clarity of the shot and preserving a dynamic broadcast feel.

### Description
- Added two inspector flags to `CueController`: `enableDynamicCueTrackingOnShotTrigger` (default `true`) and `forceImmediateRailOverheadOnShotTrigger` to control shot-trigger camera behavior.
- Changed the shot-trigger workflow in `TriggerShotBroadcastCamera()` to start the cue camera in shot mode via `cueCamera.BeginShot(objectBall)` when dynamic tracking is enabled, and to call `cueCamera.SwitchToRailOverheadImmediate()` and `broadcastCameraDirector.ForceRailOverheadForNextShot()` only when the immediate override is requested.
- Only `Assets/Scripts/Gameplay/CueController.cs` was modified.

### Testing
- Attempted to run unit tests with `dotnet test billiards.Tests/Billiards.Tests.csproj` but the `dotnet` runtime is not available in this environment (`dotnet: command not found`), so no automated tests executed here.
- Local runtime test recommendation: run `dotnet test billiards.Tests/Billiards.Tests.csproj` or validate in-editor playmode to confirm camera switching and dynamic tracking behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3df7b9120832984d0e852264562fa)