### PR TITLE
Pool Royale: force earlier rail‑overhead broadcast on break release and double‑bank shots

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -26112,7 +26112,12 @@ const powerRef = useRef(hud.power);
           const preferZoomReplay =
             replayTags.size > 0 && !replayTags.has('long') && !replayTags.has('bank');
           const frameStateCurrent = frameRef.current ?? null;
-          const isBreakShot = (frameStateCurrent?.currentBreak ?? 0) === 0;
+          const breakInProgressNow = Boolean(
+            frameStateCurrent?.meta?.breakInProgress ??
+              frameStateCurrent?.meta?.state?.breakInProgress
+          );
+          const isBreakShot =
+            breakInProgressNow || (frameStateCurrent?.currentBreak ?? 0) === 0;
           const powerScale = SHOT_MIN_FACTOR + SHOT_POWER_RANGE * curvedPower;
           const speedBase = SHOT_BASE_SPEED * (isBreakShot ? SHOT_BREAK_MULTIPLIER : 1);
           const base = shotAimDir
@@ -26482,8 +26487,8 @@ const powerRef = useRef(hud.power);
             const pulledBackAtStrike = startPull > 0.003;
             const shouldActivateActionView =
               !requiresCueBallMovementTrigger &&
-              pulledBackAtStrike &&
-              (forceImmediateRailOverheadView || !isLongShot || forceActionActivation);
+              (forceImmediateRailOverheadView ||
+                (pulledBackAtStrike && (!isLongShot || forceActionActivation)));
             if (shouldActivateActionView) {
               actionView.pendingActivation = false;
               actionView.activationDelay = null;
@@ -30654,6 +30659,26 @@ const powerRef = useRef(hud.power);
               shotContextRef.current.cushionAfterContact = true;
               shotContextRef.current.railContactCountAfterContact =
                 (shotContextRef.current.railContactCountAfterContact ?? 0) + 1;
+              const isDoubleBankRuntime =
+                (shotContextRef.current.railContactCountAfterContact ?? 0) >= 2;
+              if (isDoubleBankRuntime) {
+                if (activeShotView?.mode === 'action') {
+                  activeShotView.preferRailOverhead = true;
+                  activeShotView.lockOverheadFocus = true;
+                }
+                if (suspendedActionView?.mode === 'action') {
+                  suspendedActionView.preferRailOverhead = true;
+                  suspendedActionView.lockOverheadFocus = true;
+                  suspendedActionView.pendingActivation = false;
+                  suspendedActionView.activationDelay = null;
+                  suspendedActionView.activationTravel = 0;
+                  suspendedActionView.strokeReadyAt = 0;
+                  suspendedActionView.lastUpdate = performance.now();
+                  activeShotView = suspendedActionView;
+                  suspendedActionView = null;
+                  updateCamera();
+                }
+              }
             }
             if (railImpact) {
               applyRailImpulse(b, railImpact);


### PR DESCRIPTION
### Motivation
- Improve broadcast camera responsiveness for Pool Royale so break shots and multi-rail (double‑bank) shots immediately use the rail overhead broadcast view.
- Fix cases where the rail overhead camera switched too late after the player releases the power slider or where double‑bank sequences weren’t promoted to the overhead broadcast quickly.

### Description
- Tightened break detection by checking `frameRef.current?.meta?.breakInProgress` in addition to the existing `currentBreak === 0` check to reliably treat opening breaks as break shots (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Adjusted action‑camera activation logic so forced rail‑overhead conditions (breaks, bank/rail predictions, crowded/opposing‑direction shots) can activate immediately on slider release instead of waiting for the previous pullback gating; simplified the `shouldActivateActionView` condition to prefer forced rail overheads.
- Added runtime handling for double‑bank detection by checking `shotContextRef.current.railContactCountAfterContact >= 2` and, when true, forcing `preferRailOverhead`/`lockOverheadFocus` and promoting any pending `suspendedActionView` to `activeShotView` with an immediate `updateCamera()` call.
- All changes are located in `webapp/src/pages/Games/PoolRoyale.jsx` and are implemented as small, localized edits to shot handling, camera activation, and rail‑impact handling logic.

### Testing
- `npm run build` executed from `webapp/` and completed successfully (production build output generated). 
- Vite reported non‑blocking warnings about large chunks and some dynamic/static import patterns, but the build itself succeeded without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3ed6667a08329b37545b70cf6d207)