### PR TITLE
Pool Royale: force rail-overhead camera for middle-pocket pots, banks, and breaks

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -21558,7 +21558,12 @@ const powerRef = useRef(hud.power);
           targetId,
           followView,
           railNormal,
-          { longShot = false, travelDistance = 0, isBreakShot = false } = {}
+          {
+            longShot = false,
+            travelDistance = 0,
+            isBreakShot = false,
+            isBankShot = false
+          } = {}
         ) => {
           if (!cueBall) return null;
           const ballsList = ballsRef.current || [];
@@ -21599,7 +21604,7 @@ const powerRef = useRef(hud.power);
                 cueBall,
                 fallback: shortRailDir
               });
-          const preferRailOverhead = Boolean(isBreakShot);
+          const preferRailOverhead = Boolean(isBreakShot || isBankShot);
           const now = performance.now();
           const activationDelay = null;
           const activationTravel = 0;
@@ -26241,7 +26246,8 @@ const powerRef = useRef(hud.power);
                 {
                   longShot: isLongShot,
                   travelDistance: predictedTravel,
-                  isBreakShot
+                  isBreakShot,
+                  isBankShot: Boolean(shotPrediction?.railNormal)
                 }
               )
             : null;
@@ -31253,6 +31259,27 @@ const powerRef = useRef(hud.power);
                 const shouldForceCornerPocketView =
                   !topViewRef.current &&
                   pocketIndex < 4;
+                const shouldForceMiddlePocketRailOverhead =
+                  !topViewRef.current &&
+                  pocketIndex >= 4;
+                if (shouldForceMiddlePocketRailOverhead) {
+                  const now = performance.now();
+                  const overheadView = activeShotView?.mode === 'action'
+                    ? activeShotView
+                    : suspendedActionView?.mode === 'action'
+                      ? suspendedActionView
+                      : null;
+                  if (overheadView) {
+                    overheadView.preferRailOverhead = true;
+                    overheadView.lockOverheadFocus = true;
+                    overheadView.holdUntil = Math.max(
+                      overheadView.holdUntil ?? now,
+                      now + POCKET_VIEW_POST_POT_HOLD_MS
+                    );
+                  }
+                  overheadBroadcastVariantRef.current = 'rail';
+                  updatePocketCameraState(false);
+                }
                 if (shouldForceCornerPocketView) {
                   const sph = sphRef.current;
                   const resumeView = sph
@@ -31440,6 +31467,27 @@ const powerRef = useRef(hud.power);
               const shouldForceCornerPocketView =
                 !topViewRef.current &&
                 pocketIndex < 4;
+              const shouldForceMiddlePocketRailOverhead =
+                !topViewRef.current &&
+                pocketIndex >= 4;
+              if (shouldForceMiddlePocketRailOverhead) {
+                const now = performance.now();
+                const overheadView = activeShotView?.mode === 'action'
+                  ? activeShotView
+                  : suspendedActionView?.mode === 'action'
+                    ? suspendedActionView
+                    : null;
+                if (overheadView) {
+                  overheadView.preferRailOverhead = true;
+                  overheadView.lockOverheadFocus = true;
+                  overheadView.holdUntil = Math.max(
+                    overheadView.holdUntil ?? now,
+                    now + POCKET_VIEW_POST_POT_HOLD_MS
+                  );
+                }
+                overheadBroadcastVariantRef.current = 'rail';
+                updatePocketCameraState(false);
+              }
               if (shouldForceCornerPocketView) {
                 const sph = sphRef.current;
                 const resumeView = sph


### PR DESCRIPTION
### Motivation
- Ensure the rail overhead broadcast camera is used for bank shots, break shots, and when targets drop into the middle (side) pockets, so the broadcast framing is consistent for those events while keeping corner-pocket framing unchanged.

### Description
- Added an `isBankShot` flag to `makeActionCameraView` and treat `isBankShot` the same as `isBreakShot` by setting `preferRailOverhead` when either is true in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Wire bank-shot detection into action-camera creation by passing `isBankShot: Boolean(shotPrediction?.railNormal)` when building the `actionView`.
- When a ball is potted into a middle pocket (side pocket index >= 4) force/keep rail-overhead coverage by marking the active or suspended action view with `preferRailOverhead = true`, `lockOverheadFocus = true`, extending its `holdUntil`, setting `overheadBroadcastVariantRef.current = 'rail'`, and calling `updatePocketCameraState(false)` in both pot code paths.
- Changes are localized to `webapp/src/pages/Games/PoolRoyale.jsx` and preserve existing corner-pocket pocket-camera behavior.

### Testing
- Attempted `npm run lint` but the project does not define a `lint` script so lint was not run. 
- Ran `npm run build` in the `webapp` package and the production build completed successfully with normal build warnings (bundle-size and dynamic-import notes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3f6cfd07c8329b7f53370d59ea77b)