### PR TITLE
Pool Royale: force rail-overhead broadcast on middle-pocket pots

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -31253,6 +31253,9 @@ const powerRef = useRef(hud.power);
                 const shouldForceCornerPocketView =
                   !topViewRef.current &&
                   pocketIndex < 4;
+                const shouldForceRailOverheadPocketView =
+                  !topViewRef.current &&
+                  pocketIndex >= 4;
                 if (shouldForceCornerPocketView) {
                   const sph = sphRef.current;
                   const resumeView = sph
@@ -31286,6 +31289,13 @@ const powerRef = useRef(hud.power);
                     updatePocketCameraState(true);
                     activeShotView = forcedCornerView;
                   }
+                } else if (shouldForceRailOverheadPocketView) {
+                  if (activeShotView?.mode === 'action') {
+                    suspendedActionView = activeShotView;
+                  }
+                  activeShotView = null;
+                  updatePocketCameraState(false);
+                  enterTopView(true, { variant: 'rail' });
                 }
                 if (
                   activeShotView?.mode === 'pocket' &&
@@ -31440,6 +31450,9 @@ const powerRef = useRef(hud.power);
               const shouldForceCornerPocketView =
                 !topViewRef.current &&
                 pocketIndex < 4;
+              const shouldForceRailOverheadPocketView =
+                !topViewRef.current &&
+                pocketIndex >= 4;
               if (shouldForceCornerPocketView) {
                 const sph = sphRef.current;
                 const resumeView = sph
@@ -31473,6 +31486,13 @@ const powerRef = useRef(hud.power);
                   updatePocketCameraState(true);
                   activeShotView = forcedCornerView;
                 }
+              } else if (shouldForceRailOverheadPocketView) {
+                if (activeShotView?.mode === 'action') {
+                  suspendedActionView = activeShotView;
+                }
+                activeShotView = null;
+                updatePocketCameraState(false);
+                enterTopView(true, { variant: 'rail' });
               }
               if (
                 activeShotView?.mode === 'pocket' &&


### PR DESCRIPTION
### Motivation
- Ensure middle-pocket pots (`TM`/`BM`) reliably switch the broadcast to the rail-overhead camera so middle-pocket pots are shown with the same rail-overhead framing used for bank shots and the break.

### Description
- Added explicit middle-pocket handling in both cue-ball and object-ball pot resolution paths in `webapp/src/pages/Games/PoolRoyale.jsx` by introducing `shouldForceRailOverheadPocketView` for `pocketIndex >= 4`.
- When a middle pocket pot is detected the code now suspends any active `action` view, clears `activeShotView`, updates pocket camera state, and calls `enterTopView(true, { variant: 'rail' })` to activate the rail-overhead broadcast framing.
- Preserved existing corner-pocket `makePocketCameraView(..., { forceCornerCapture: true })` behavior and left bank/break action-view logic unchanged.

### Testing
- Ran `npm test -- --runInBand test/poolRoyaleCueStrokeTimeline.test.js` which passed (4 tests, 1 suite).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3f6cfd07c8329b7f53370d59ea77b)