### PR TITLE
Pool Royale: tighten rail-overhead camera switching, fix ball overlaps and ensure aim-line visibility

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1537,8 +1537,8 @@ const SPIN_GRAVITY = 9.81;
 const ROLLING_RESISTANCE = 0.011;
 const BALL_BALL_FRICTION = 0.105;
 const BALL_CONTACT_EPS = BALL_R * 0.012; // broaden contact tolerance slightly so grazing touches resolve instead of tunneling
-const BALL_COLLISION_SLOP = BALL_R * 0.0015; // keep resting balls stable by ignoring microscopic overlap noise
-const BALL_COLLISION_BAUMGARTE = 0.82; // stronger overlap correction so touching balls map more precisely on every substep
+const BALL_COLLISION_SLOP = BALL_R * 0.0002; // reduce allowed penetration so resting balls no longer visibly overlap
+const BALL_COLLISION_BAUMGARTE = 1.0; // fully correct detected overlap each substep to keep physical ball diameter exact
 const RAIL_FRICTION = 0.16;
 const STOP_EPS = 0.0074;
 const STOP_SOFTENING = 0.96; // ease balls into a stop instead of hard-braking at the speed threshold
@@ -1947,6 +1947,7 @@ const CUE_OBSTRUCTION_SAMPLE_MIN = 6;
 const CUE_OBSTRUCTION_SAMPLE_MAX = 22;
 const CUE_OBSTRUCTION_POINT_RADIUS = Math.max(BALL_R * 0.38, CUE_TIP_RADIUS * 2.3);
 const CUE_CUSHION_HELPER_EXTRA_CLEARANCE = BALL_R * 0.34;
+const CUE_OBSTRUCTION_BALL_MARGIN = BALL_R * 0.12; // extra spacing so cue helpers clear balls/cushions instead of clipping through
 // Match the 2D aiming configuration for side spin while letting top/back spin reach the full cue-tip radius.
 const MAX_SPIN_CONTACT_OFFSET = BALL_R * PHYSICS_PROFILE.maxTipOffsetRatio;
 const MAX_SPIN_FORWARD = MAX_SPIN_CONTACT_OFFSET;
@@ -20787,7 +20788,7 @@ const powerRef = useRef(hud.power);
                 }
                 if (shouldForceRailOverhead) {
                   activeShotView.preferRailOverhead = true;
-                  activeShotView.lockOverheadFocus = true;
+                  activeShotView.lockOverheadFocus = false;
                 }
               }
               const broadcastRailDir =
@@ -21558,7 +21559,13 @@ const powerRef = useRef(hud.power);
           targetId,
           followView,
           railNormal,
-          { longShot = false, travelDistance = 0, isBreakShot = false } = {}
+          {
+            longShot = false,
+            travelDistance = 0,
+            isBreakShot = false,
+            forceRailOverheadAtTrigger = false,
+            lockOverheadFocusAtTrigger = false
+          } = {}
         ) => {
           if (!cueBall) return null;
           const ballsList = ballsRef.current || [];
@@ -21599,7 +21606,7 @@ const powerRef = useRef(hud.power);
                 cueBall,
                 fallback: shortRailDir
               });
-          const preferRailOverhead = Boolean(isBreakShot);
+          const preferRailOverhead = Boolean(isBreakShot || forceRailOverheadAtTrigger);
           const now = performance.now();
           const activationDelay = null;
           const activationTravel = 0;
@@ -21627,7 +21634,7 @@ const powerRef = useRef(hud.power);
             hasSwitchedRail: true,
             railNormal: railNormal ? railNormal.clone() : null,
             preferRailOverhead,
-            lockOverheadFocus: true,
+            lockOverheadFocus: Boolean(lockOverheadFocusAtTrigger),
             longShot,
             travelDistance,
             activationDelay,
@@ -24482,6 +24489,20 @@ const powerRef = useRef(hud.power);
       );
       targetPower.visible = false;
       table.add(targetPower);
+      const ensureGuideLineVisibility = (line, renderOrder = 8) => {
+        if (!line) return;
+        line.frustumCulled = false;
+        line.renderOrder = renderOrder;
+      };
+      [
+        aim,
+        aimPower,
+        cueAfter,
+        cueAfterPower,
+        tick,
+        target,
+        targetPower
+      ].forEach((line) => ensureGuideLineVisibility(line));
       const replayTrailGeom = new THREE.BufferGeometry();
       replayTrail = new THREE.Line(
         replayTrailGeom,
@@ -26171,6 +26192,18 @@ const powerRef = useRef(hud.power);
               : 1;
           const hasCueTargetDirectionSplit =
             cueVsTargetAlignment < RAIL_OVERHEAD_OPPOSITE_DIRECTION_DOT;
+          const cueToTargetDistance =
+            targetBallForPrediction?.pos && cue?.pos
+              ? cue.pos.distanceTo(targetBallForPrediction.pos)
+              : 0;
+          const isShortRangeStraightShot =
+            !isLongShot &&
+            cueToTargetDistance > 0 &&
+            cueToTargetDistance <= BALL_R * 14 &&
+            cueVsTargetAlignment >= 0.97 &&
+            !Boolean(shotPrediction?.railNormal) &&
+            !isMiddlePocketIntent;
+          const keepPlayerCameraForShortStraightShot = isShortRangeStraightShot;
           const shotCrowdBallCount = (() => {
             if (!prediction?.targetBall || !Array.isArray(balls)) return 0;
             const cueToTarget = prediction.targetBall.pos.clone().sub(cue.pos);
@@ -26192,12 +26225,15 @@ const powerRef = useRef(hud.power);
             return count;
           })();
           const isCrowdedShot = shotCrowdBallCount >= RAIL_OVERHEAD_CROWD_BALL_THRESHOLD;
+          const forceRailOverheadForDirectionSplit =
+            hasCueTargetDirectionSplit && !isShortRangeStraightShot;
           const forceImmediateRailOverheadView =
             isBreakShot ||
             Boolean(shotPrediction?.railNormal) ||
-            hasCueTargetDirectionSplit ||
-            (isMiddlePocketIntent && hasCueTargetDirectionSplit) ||
+            isMiddlePocketIntent ||
+            forceRailOverheadForDirectionSplit ||
             isCrowdedShot;
+          const lockRailOverheadFocusAtTrigger = false;
           const allowRailOverheadActionView = true;
           const allowLongShotCameraSwitch =
             (forceImmediateRailOverheadView || !suppressOpeningShotViews) &&
@@ -26241,7 +26277,9 @@ const powerRef = useRef(hud.power);
                 {
                   longShot: isLongShot,
                   travelDistance: predictedTravel,
-                  isBreakShot
+                  isBreakShot,
+                  forceRailOverheadAtTrigger: forceImmediateRailOverheadView,
+                  lockOverheadFocusAtTrigger: lockRailOverheadFocusAtTrigger
                 }
               )
             : null;
@@ -26259,7 +26297,7 @@ const powerRef = useRef(hud.power);
           }
           if (actionView && !earlyPocketView) {
             actionView.preferRailOverhead = true;
-            actionView.lockOverheadFocus = true;
+            actionView.lockOverheadFocus = false;
           }
           const ranges = spinRangeRef.current || {};
           const powerSpinScale = 0.55 + clampedPower * 0.45;
@@ -26465,7 +26503,7 @@ const powerRef = useRef(hud.power);
             actionView.activationTravel = 0;
             actionView.strokeReadyAt = 0;
             actionView.preferRailOverhead = true;
-            actionView.lockOverheadFocus = true;
+            actionView.lockOverheadFocus = false;
             actionView.lastUpdate = activationNow;
             activeShotView = actionView;
             suspendedActionView = null;
@@ -26483,7 +26521,8 @@ const powerRef = useRef(hud.power);
             const shouldActivateActionView =
               !requiresCueBallMovementTrigger &&
               pulledBackAtStrike &&
-              (forceImmediateRailOverheadView || !isLongShot || forceActionActivation);
+              !keepPlayerCameraForShortStraightShot &&
+              (forceImmediateRailOverheadView || isLongShot || forceActionActivation);
             if (shouldActivateActionView) {
               actionView.pendingActivation = false;
               actionView.activationDelay = null;
@@ -29807,7 +29846,7 @@ const powerRef = useRef(hud.power);
               TMP_VEC3_OBSTRUCTION_TARGET.set(b.pos.x, BALL_CENTER_Y, b.pos.y);
               const gap =
                 point.distanceTo(TMP_VEC3_OBSTRUCTION_TARGET) -
-                (BALL_R + CUE_OBSTRUCTION_POINT_RADIUS);
+                (BALL_R + CUE_OBSTRUCTION_POINT_RADIUS + CUE_OBSTRUCTION_BALL_MARGIN);
               if (gap < minDistance) minDistance = gap;
             }
             for (const box of cushionBoxes) {
@@ -30716,7 +30755,7 @@ const powerRef = useRef(hud.power);
                   }
                   d = 0;
                 }
-                const penetration = Math.max(0, targetDist - d);
+                const penetration = Math.max(0, minDist - d);
                 const overlap =
                   penetration > BALL_COLLISION_SLOP
                     ? ((penetration - BALL_COLLISION_SLOP) * BALL_COLLISION_BAUMGARTE) / 2


### PR DESCRIPTION
### Motivation
- Ensure rail-overhead broadcast camera switches immediately at shot trigger for opening/breaks and other forced-overhead scenarios so cue/target remain framed correctly.
- Use the rail-overhead camera when cue and target travel diverge or the lane is crowded, while preserving the player camera for short-range straight shots.
- Eliminate helper/cue clipping and visible ball overlap by enforcing the actual physical diameter and stronger overlap correction in the simulation.
- Make aiming/target/cue-follow guide lines always visible across the table so players can see aim, target and cue-follow lines everywhere.

### Description
- Tightened action-camera trigger logic in `webapp/src/pages/Games/PoolRoyale.jsx` by extending `makeActionCameraView` to accept `forceRailOverheadAtTrigger` and `lockOverheadFocusAtTrigger` and propagating a `forceImmediateRailOverheadView` flag at shot trigger for break, bank, middle-pocket intents, crowded lanes and cue/target direction splits.
- Preserved player camera for short-range straight shots by computing `isShortRangeStraightShot` and skipping action-camera takeover when that condition is true.
- Disabled/removed rigid overhead focus locking in the action/pair activation path so framing isn't held too strictly after trigger (`lockOverheadFocus` set to `false` by default in affected paths).
- Reduced allowed penetration and increased overlap correction by changing constants: `BALL_COLLISION_SLOP` tightened and `BALL_COLLISION_BAUMGARTE` set to `1.0`, adjusted penetration resolution to compare against `minDist`, and added `CUE_OBSTRUCTION_BALL_MARGIN` to increase cue-helper clearance around balls.
- Ensured guide lines are always visible by adding `ensureGuideLineVisibility` (disables frustum culling and sets `renderOrder`) for `aim`, `aimPower`, `cueAfter`, `cueAfterPower`, `tick`, `target`, and `targetPower` line objects.

### Testing
- Ran `npm test -- --runInBand test/poolRoyaleSpinController.test.js` and the suite passed (7 tests, all green).
- Ran ESLint on the changed path via `npx eslint webapp/src/pages/Games/PoolRoyale.jsx` and observed a repository ignore warning (file ignored by ESLint config), no code errors reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4007fa4c08329865e6f8ffc61b1ef)