### PR TITLE
Pool Royale: rail-overhead camera triggers, aim-line visibility, and collision/placement fixes

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1393,6 +1393,7 @@ const CURRENT_RATIO = innerLong / Math.max(1e-6, innerShort);
   );
 const MM_TO_UNITS = (innerLong / WIDTH_REF) / TABLE_SURFACE_COMPENSATION;
 const BALL_SIZE_SCALE = 1; // lock ball size to the official 57.15mm reference diameter
+const BALL_DIAMETER_MM = 57.15;
 const BALL_DIAMETER = BALL_D_REF * MM_TO_UNITS * BALL_SIZE_SCALE;
 const BALL_SCALE = BALL_DIAMETER / 4;
 const BALL_R = BALL_DIAMETER / 2;
@@ -1466,6 +1467,10 @@ console.assert(
   Math.abs(BALL_DIAMETER - BALL_R * 2) <= 0.1 * MM_TO_UNITS,
   'Ball diameter mismatch after scaling.'
 );
+console.assert(
+  Math.abs(BALL_D_REF - BALL_DIAMETER_MM) <= 0.05,
+  'Ball reference diameter must stay on the official 57.15mm standard.'
+);
 const CLOTH_LIFT = (() => {
   const ballR = BALL_R;
   const microEpsRatio = 0.022857142857142857;
@@ -1537,8 +1542,8 @@ const SPIN_GRAVITY = 9.81;
 const ROLLING_RESISTANCE = 0.011;
 const BALL_BALL_FRICTION = 0.105;
 const BALL_CONTACT_EPS = BALL_R * 0.012; // broaden contact tolerance slightly so grazing touches resolve instead of tunneling
-const BALL_COLLISION_SLOP = BALL_R * 0.0015; // keep resting balls stable by ignoring microscopic overlap noise
-const BALL_COLLISION_BAUMGARTE = 0.82; // stronger overlap correction so touching balls map more precisely on every substep
+const BALL_COLLISION_SLOP = BALL_R * 0.0008; // reduce tolerated penetration so balls do not visually overlap at rest
+const BALL_COLLISION_BAUMGARTE = 0.9; // increase overlap correction so touching balls separate faster per substep
 const RAIL_FRICTION = 0.16;
 const STOP_EPS = 0.0074;
 const STOP_SOFTENING = 0.96; // ease balls into a stop instead of hard-braking at the speed threshold
@@ -1898,6 +1903,8 @@ const ORBIT_FOCUS_BASE_Y = TABLE_Y + 0.07;
 const CAMERA_CUE_SURFACE_MARGIN = BALL_R * 0.42; // keep orbit height aligned with the cue while leaving a safe buffer above
 const CUE_TIP_CLEARANCE = BALL_R * 0.24; // widen the visible air gap so the cue sits a little farther from the cue ball
 const CUE_TIP_GAP = BALL_R * 1.42 + CUE_TIP_CLEARANCE; // pull the cue tip slightly farther back so the blue tip remains visible
+const IN_HAND_RAIL_CLEARANCE = BALL_R * 1.06; // keep in-hand helper clear from cushion noses
+const IN_HAND_CUE_HELPER_CLEARANCE = BALL_R * 1.05; // prevent helper placement from clipping through cue helper geometry
 const CUE_PULL_BASE = BALL_R * 10 * 0.95 * 2.05;
 const CUE_PULL_MIN_VISUAL = BALL_R * 1.75; // guarantee a clear visible pull even when clearance is tight
 const CUE_PULL_VISUAL_FUDGE = BALL_R * 2.5; // allow extra travel before obstructions cancel the pull
@@ -21627,7 +21634,7 @@ const powerRef = useRef(hud.power);
             hasSwitchedRail: true,
             railNormal: railNormal ? railNormal.clone() : null,
             preferRailOverhead,
-            lockOverheadFocus: true,
+            lockOverheadFocus: !isBreakShot,
             longShot,
             travelDistance,
             activationDelay,
@@ -24380,6 +24387,8 @@ const powerRef = useRef(hud.power);
       ]);
       const aim = new THREE.Line(aimGeom, aimMat);
       aim.visible = false;
+      aim.frustumCulled = false;
+      aim.renderOrder = 12;
       table.add(aim);
       const aimPowerGeom = new THREE.BufferGeometry().setFromPoints([
         new THREE.Vector3(),
@@ -24397,6 +24406,8 @@ const powerRef = useRef(hud.power);
         })
       );
       aimPower.visible = false;
+      aimPower.frustumCulled = false;
+      aimPower.renderOrder = 12;
       table.add(aimPower);
       const cueAfterGeom = new THREE.BufferGeometry().setFromPoints([
         new THREE.Vector3(),
@@ -24414,6 +24425,8 @@ const powerRef = useRef(hud.power);
         })
       );
       cueAfter.visible = false;
+      cueAfter.frustumCulled = false;
+      cueAfter.renderOrder = 12;
       table.add(cueAfter);
       const cueAfterPowerGeom = new THREE.BufferGeometry().setFromPoints([
         new THREE.Vector3(),
@@ -24431,6 +24444,8 @@ const powerRef = useRef(hud.power);
         })
       );
       cueAfterPower.visible = false;
+      cueAfterPower.frustumCulled = false;
+      cueAfterPower.renderOrder = 12;
       table.add(cueAfterPower);
       const tickGeom = new THREE.BufferGeometry().setFromPoints([
         new THREE.Vector3(),
@@ -24446,6 +24461,8 @@ const powerRef = useRef(hud.power);
         })
       );
       tick.visible = false;
+      tick.frustumCulled = false;
+      tick.renderOrder = 12;
       table.add(tick);
 
       const targetGeom = new THREE.BufferGeometry().setFromPoints([
@@ -24464,6 +24481,8 @@ const powerRef = useRef(hud.power);
         })
       );
       target.visible = false;
+      target.frustumCulled = false;
+      target.renderOrder = 12;
       table.add(target);
       const targetPowerGeom = new THREE.BufferGeometry().setFromPoints([
         new THREE.Vector3(),
@@ -24481,6 +24500,8 @@ const powerRef = useRef(hud.power);
         })
       );
       targetPower.visible = false;
+      targetPower.frustumCulled = false;
+      targetPower.renderOrder = 12;
       table.add(targetPower);
       const replayTrailGeom = new THREE.BufferGeometry();
       replayTrail = new THREE.Line(
@@ -25207,9 +25228,32 @@ const powerRef = useRef(hud.power);
       const isSpotFree = (point, clearanceMultiplier = 2.05) => {
         if (!point) return false;
         const clearance = BALL_R * clearanceMultiplier;
+        const railLimitX = RAIL_LIMIT_X - IN_HAND_RAIL_CLEARANCE;
+        const railLimitY = RAIL_LIMIT_Y - IN_HAND_RAIL_CLEARANCE;
+        if (Math.abs(point.x) > railLimitX || Math.abs(point.y) > railLimitY) {
+          return false;
+        }
         for (const ball of balls) {
           if (!ball.active || ball === cue) continue;
           if (point.distanceTo(ball.pos) <= clearance) {
+            return false;
+          }
+        }
+        const cueTipTarget = TMP_VEC3_A;
+        const cueButtTarget = TMP_VEC3_B;
+        if (cueStick?.getWorldPosition) {
+          cueTipTarget.copy(cueTipLocal).applyEuler(cueStick.rotation).add(cueStick.position);
+          cueButtTarget.copy(cueButtLocal).applyEuler(cueStick.rotation).add(cueStick.position);
+          const helperClearance = Math.max(
+            IN_HAND_CUE_HELPER_CLEARANCE,
+            clearance * 0.5
+          );
+          if (
+            point.distanceToSquared(TMP_VEC2_A.set(cueTipTarget.x, cueTipTarget.z)) <=
+              helperClearance * helperClearance ||
+            point.distanceToSquared(TMP_VEC2_B.set(cueButtTarget.x, cueButtTarget.z)) <=
+              helperClearance * helperClearance
+          ) {
             return false;
           }
         }
@@ -26171,6 +26215,11 @@ const powerRef = useRef(hud.power);
               : 1;
           const hasCueTargetDirectionSplit =
             cueVsTargetAlignment < RAIL_OVERHEAD_OPPOSITE_DIRECTION_DOT;
+          const isShortStraightShot =
+            isShortShot &&
+            cueVsTargetAlignment >= 0.965 &&
+            !shotPrediction?.railNormal &&
+            !isMiddlePocketIntent;
           const shotCrowdBallCount = (() => {
             if (!prediction?.targetBall || !Array.isArray(balls)) return 0;
             const cueToTarget = prediction.targetBall.pos.clone().sub(cue.pos);
@@ -26193,11 +26242,12 @@ const powerRef = useRef(hud.power);
           })();
           const isCrowdedShot = shotCrowdBallCount >= RAIL_OVERHEAD_CROWD_BALL_THRESHOLD;
           const forceImmediateRailOverheadView =
-            isBreakShot ||
-            Boolean(shotPrediction?.railNormal) ||
-            hasCueTargetDirectionSplit ||
-            (isMiddlePocketIntent && hasCueTargetDirectionSplit) ||
-            isCrowdedShot;
+            !isShortStraightShot &&
+            (isBreakShot ||
+              Boolean(shotPrediction?.railNormal) ||
+              isMiddlePocketIntent ||
+              hasCueTargetDirectionSplit ||
+              isCrowdedShot);
           const allowRailOverheadActionView = true;
           const allowLongShotCameraSwitch =
             (forceImmediateRailOverheadView || !suppressOpeningShotViews) &&
@@ -26259,7 +26309,7 @@ const powerRef = useRef(hud.power);
           }
           if (actionView && !earlyPocketView) {
             actionView.preferRailOverhead = true;
-            actionView.lockOverheadFocus = true;
+            actionView.lockOverheadFocus = false;
           }
           const ranges = spinRangeRef.current || {};
           const powerSpinScale = 0.55 + clampedPower * 0.45;
@@ -26465,10 +26515,11 @@ const powerRef = useRef(hud.power);
             actionView.activationTravel = 0;
             actionView.strokeReadyAt = 0;
             actionView.preferRailOverhead = true;
-            actionView.lockOverheadFocus = true;
+            actionView.lockOverheadFocus = false;
             actionView.lastUpdate = activationNow;
             activeShotView = actionView;
             suspendedActionView = null;
+            powerImpactHoldRef.current = 0;
             updateCamera();
             pocketViewActivated = true;
           }
@@ -26482,13 +26533,18 @@ const powerRef = useRef(hud.power);
             const pulledBackAtStrike = startPull > 0.003;
             const shouldActivateActionView =
               !requiresCueBallMovementTrigger &&
-              pulledBackAtStrike &&
+              (forceImmediateRailOverheadView || pulledBackAtStrike) &&
               (forceImmediateRailOverheadView || !isLongShot || forceActionActivation);
             if (shouldActivateActionView) {
               actionView.pendingActivation = false;
               actionView.activationDelay = null;
               actionView.activationTravel = 0;
               actionView.strokeReadyAt = 0;
+              if (forceImmediateRailOverheadView) {
+                actionView.preferRailOverhead = true;
+                actionView.lockOverheadFocus = false;
+                powerImpactHoldRef.current = 0;
+              }
               actionView.lastUpdate = now;
               activeShotView = actionView;
               suspendedActionView = null;


### PR DESCRIPTION
### Motivation
- Make broadcast camera behavior more predictable for break, bank, middle-pocket and split-direction shots so both cue and target remain framed when important shots occur.
- Ensure the player can always see aiming helpers (aim line, target, cue-after and tick/power variants) across the table.
- Eliminate visual ball overlaps and prevent in-hand helper placement from clipping into rails, cue helper geometry, or other balls.

### Description
- Camera: updated action-view / shot activation to force rail-overhead broadcast in key cases and to avoid holding the old camera unnecessarily by setting `lockOverheadFocus` based on `isBreakShot` and enabling faster activation when forced; changed the `forceImmediateRailOverheadView` predicate to include bank shots, middle-pocket intent and cue-vs-target direction splits while preserving player camera on short straight shots (added `isShortStraightShot`).
- Camera activation: allow immediate activation for forced rail-overhead cases by clearing camera hold (`powerImpactHoldRef.current = 0`) and by changing the activation gating so forced cases can trigger even with minimal pullback.
- Aiming visuals: disabled frustum culling and set `renderOrder = 12` for core guide lines (`aim`, `aimPower`, `cueAfter`, `cueAfterPower`, `tick`, `target`, `targetPower`) to keep these lines visible everywhere.
- In-hand placement / helpers: added `IN_HAND_RAIL_CLEARANCE` and `IN_HAND_CUE_HELPER_CLEARANCE` and tightened `isSpotFree` to reject placements too close to rails, other balls, or the cue tip/butt helper geometry (samples cue helper world positions before allowing placement).
- Ball size & collision: added `BALL_DIAMETER_MM` assertion to lock the reference diameter to the official `57.15mm`, reduced `BALL_COLLISION_SLOP`, and increased `BALL_COLLISION_BAUMGARTE` to reduce visible interpenetration and separate touching balls faster.
- Minor: inserted constants and small safety checks used by the above logic; all changes are contained in `webapp/src/pages/Games/PoolRoyale.jsx`.

### Testing
- Built the web app: ran `npm run build` in `webapp/` and the production build completed successfully (Vite build finished with usual chunk-size and import warnings unrelated to this change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4007fa4c08329865e6f8ffc61b1ef)