### PR TITLE
Pool Royale: dynamic action camera tracks cue ball without zoom

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -20448,6 +20448,13 @@ const powerRef = useRef(hud.power);
                       );
                 activeShotView.railDir = railDir;
               }
+              if (activeShotView.dynamicCueLook) {
+                railDir = resolveOppositeShortRailCamera({
+                  cueBall,
+                  fallback: Number.isFinite(railDir) && railDir !== 0 ? railDir : 1
+                });
+                activeShotView.railDir = railDir;
+              }
               if (!activeShotView.hasSwitchedRail) {
                 const cueMoving = cueBall.vel.lengthSq() > STOP_EPS * STOP_EPS;
                 if (shooting || cueMoving) {
@@ -20526,22 +20533,29 @@ const powerRef = useRef(hud.power);
                     activeShotView.longShot ? LONG_SHOT_SHORT_RAIL_OFFSET : 0;
                   const heightLift =
                     activeShotView.longShot ? BALL_R * 2.5 : 0;
-                  const baseDistance = computeShortRailBroadcastDistance(camera);
+                  const baseDistance =
+                    activeShotView.fixedShortRailDistance ??
+                    computeShortRailBroadcastDistance(camera);
+                  if (!Number.isFinite(activeShotView.fixedShortRailDistance)) {
+                    activeShotView.fixedShortRailDistance = baseDistance;
+                  }
                   const pairFraming = computeShortRailPairFraming(
                     camera,
                     cuePos2,
                     targetPos2
                   );
-                  const desiredDistance = Math.max(
-                    baseDistance + longShotPullback,
-                    pairFraming ? pairFraming.requiredDistance : 0
-                  );
+                  const desiredDistance = baseDistance + longShotPullback;
                   const desired = new THREE.Vector3(
                     0,
                     heightBase + ACTION_CAM.heightOffset + heightLift,
                     railDir * desiredDistance
                   );
                   const lookAnchor = anchor.clone();
+                  lookAnchor.x = THREE.MathUtils.lerp(
+                    lookAnchor.x,
+                    cueBall.pos.x,
+                    activeShotView.dynamicCueLook ? 0.55 : 0.25
+                  );
                   if (activeShotView.longShot) {
                     lookAnchor.x = THREE.MathUtils.lerp(
                       lookAnchor.x,
@@ -20655,18 +20669,25 @@ const powerRef = useRef(hud.power);
                     activeShotView.longShot ? LONG_SHOT_SHORT_RAIL_OFFSET : 0;
                   const heightLift =
                     activeShotView.longShot ? BALL_R * 2.2 : 0;
-                  const baseDistance = computeShortRailBroadcastDistance(camera);
+                  const baseDistance =
+                    activeShotView.fixedShortRailDistance ??
+                    computeShortRailBroadcastDistance(camera);
+                  if (!Number.isFinite(activeShotView.fixedShortRailDistance)) {
+                    activeShotView.fixedShortRailDistance = baseDistance;
+                  }
                   const cueFraming = computeShortRailPairFraming(camera, cuePos2);
-                  const desiredDistance = Math.max(
-                    baseDistance + longShotPullback,
-                    cueFraming ? cueFraming.requiredDistance : 0
-                  );
+                  const desiredDistance = baseDistance + longShotPullback;
                   const desired = new THREE.Vector3(
                     0,
                     heightBase + ACTION_CAM.followHeightOffset + heightLift,
                     railDir * desiredDistance
                   );
                   const lookAnchor = anchor.clone();
+                  lookAnchor.x = THREE.MathUtils.lerp(
+                    lookAnchor.x,
+                    cueBall.pos.x,
+                    activeShotView.dynamicCueLook ? 0.7 : 0.3
+                  );
                   if (activeShotView.longShot) {
                     lookAnchor.x = THREE.MathUtils.lerp(
                       lookAnchor.x,
@@ -21628,6 +21649,8 @@ const powerRef = useRef(hud.power);
             railNormal: railNormal ? railNormal.clone() : null,
             preferRailOverhead,
             lockOverheadFocus: false,
+            dynamicCueLook: true,
+            fixedShortRailDistance: null,
             longShot,
             travelDistance,
             activationDelay,


### PR DESCRIPTION
### Motivation
- Allow the action camera to rotate and follow the cue ball during shots (player and AI) instead of staying locked to a static rail side, while avoiding unwanted zoom/distance changes during the shot. 

### Description
- Added per-shot flags `dynamicCueLook` and `fixedShortRailDistance` to the action-camera view payload in `webapp/src/pages/Games/PoolRoyale.jsx`. 
- When `dynamicCueLook` is set the code re-resolves `railDir` from the live `cueBall` using `resolveOppositeShortRailCamera` so the camera can turn toward the cue ball as the shot evolves. 
- Capture and reuse a `fixedShortRailDistance` (computed once at shot start) and use it for subsequent frames so `desiredDistance` no longer re-expands each update and the camera does not zoom/pump. 
- Increased the look-bias toward the cue ball (`lookAnchor.x` lerp) in both the pair and follow branches so the camera target visibly turns toward the cue ball while preserving existing cinematic constraints. 

### Testing
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx`, which completed but reported the file is ignored by repository ignore rules (warning). 
- Ran `npx eslint --no-ignore webapp/src/pages/Games/PoolRoyale.jsx`, which completed with the same ignore-related warning and produced no lint errors. 
- No other automated test failures were observed for the modified file during this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d40bb6d0b083298852b90fcb8260cf)