### PR TITLE
Pool Royale: make action camera follow cue ball during shots

### DIFF
--- a/billiards.Unity/CueCamera.cs
+++ b/billiards.Unity/CueCamera.cs
@@ -242,7 +242,9 @@ public class CueCamera : MonoBehaviour
     public bool immediateRailBroadcastOnShot = true;
     // Keep a fixed rail-overhead camera position during the entire shot so the
     // view tracks action by turning/looking only (no zoom/dolly moves).
-    public bool lockRailBroadcastPositionDuringShot = true;
+    // Disabled by default so action camera can dynamically follow cue-ball
+    // movement for both player and AI turns.
+    public bool lockRailBroadcastPositionDuringShot = false;
     // Keep the rail-overhead camera active for the whole shot window and avoid
     // corner-pocket cut-ins.
     public bool forceRailOverheadForWholeShot = false;
@@ -1222,14 +1224,13 @@ public class CueCamera : MonoBehaviour
 
     private Vector3 GetDynamicShotBroadcastFocus()
     {
+        // Keep action camera focus dynamic on the cue ball while the shot runs.
+        // This matches both player and AI shot broadcasts and avoids drift to a
+        // midpoint lock between cue and target balls.
         Vector3 desired = CueBall != null ? CueBall.position : tableBounds.center;
         bool hasCue = CueBall != null && CueBall.gameObject.activeInHierarchy;
         bool hasTarget = TargetBall != null && TargetBall.gameObject.activeInHierarchy;
-        if (hasCue && hasTarget)
-        {
-            desired = (CueBall.position + TargetBall.position) * 0.5f;
-        }
-        else if (hasTarget)
+        if (!hasCue && hasTarget)
         {
             desired = TargetBall.position;
         }


### PR DESCRIPTION
### Motivation
- Improve shot clarity by keeping the action/broadcast camera dynamic on the cue ball during both player and AI shots instead of locking to a rail anchor or midpoint between balls.

### Description
- Set `lockRailBroadcastPositionDuringShot = false` by default in `billiards.Unity/CueCamera.cs` to disable the fixed rail-overhead anchor during shots.
- Updated `GetDynamicShotBroadcastFocus` in `billiards.Unity/CueCamera.cs` to prioritize `CueBall.position` and only fallback to `TargetBall` when the cue ball is unavailable.

### Testing
- Performed code inspection and repository checks using `git diff` and `git status`, and committed the change; no automated Unity PlayMode or runtime tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d41206dc248329a3f34de0ca486e85)