### PR TITLE
Make action camera follow cue ball dynamically during shots

### DIFF
--- a/billiards.Unity/CueCamera.cs
+++ b/billiards.Unity/CueCamera.cs
@@ -240,10 +240,10 @@ public class CueCamera : MonoBehaviour
     // Switch to the rail-overhead broadcast framing immediately once a shot is
     // triggered instead of waiting on the cue-strike hold timer.
     public bool immediateRailBroadcastOnShot = true;
-    // Keep a fixed rail-overhead camera position during the entire shot so the
-    // view tracks action by turning/looking only (no zoom/dolly moves).
-    // Disabled by default so action camera can dynamically follow cue-ball
-    // movement for both player and AI turns.
+    // Legacy compatibility toggle kept in the inspector for existing scenes.
+    // The action camera now always stays dynamic during live shots so it can
+    // follow cue-ball movement for both player and AI turns.
+    [System.Obsolete("Rail broadcast lock is deprecated. Action camera is always dynamic during shots.")]
     public bool lockRailBroadcastPositionDuringShot = false;
     // Keep the rail-overhead camera active for the whole shot window and avoid
     // corner-pocket cut-ins.
@@ -492,6 +492,9 @@ public class CueCamera : MonoBehaviour
 
     private void Awake()
     {
+        // Force legacy lock off so existing prefabs/scenes cannot freeze the
+        // action camera position during player or AI shots.
+        lockRailBroadcastPositionDuringShot = false;
         cachedCamera = GetComponent<Camera>();
         defaultShortRailSign = startLookingTowardPositiveZ ? 1 : -1;
         cueAimSideSign = defaultShortRailSign;
@@ -1163,20 +1166,6 @@ public class CueCamera : MonoBehaviour
         else
         {
             lookTarget.y -= Mathf.Max(0f, broadcastLookDownOffset);
-        }
-
-        if (shotInProgress && !isPocketCamera && lockRailBroadcastPositionDuringShot)
-        {
-            if (!hasShotRailAnchor)
-            {
-                Vector3 anchor = focus - forward * distance + Vector3.up * height;
-                anchor.x = 0f;
-                shotRailAnchorPosition = anchor;
-                hasShotRailAnchor = true;
-            }
-
-            ApplyLockedRailBroadcastCamera(shotRailAnchorPosition, lookTarget, focus, minimumHeightOffset);
-            return;
         }
 
         ApplyShortRailCamera(focus, forward, distance, height, minimumHeightOffset, lookTarget);


### PR DESCRIPTION
### Motivation
- Prevent the broadcast rail-overhead camera from freezing its world-space anchor during a shot so the action camera can dynamically follow the cue ball for both player and AI turns.

### Description
- Marked the legacy `lockRailBroadcastPositionDuringShot` inspector toggle as deprecated to signal it is no longer honored at runtime.
- Force-disabled the legacy `lockRailBroadcastPositionDuringShot` flag in `Awake()` to prevent old prefabs/scenes from re-enabling the static rail lock.
- Removed the positional-lock branch from `ApplyBroadcastCamera` so the short-rail broadcast path is always used and the camera remains dynamic during shots.
- Changed file: `billiards.Unity/CueCamera.cs`.

### Testing
- Ran `rg -n "lockRailBroadcastPositionDuringShot|GetDynamicShotBroadcastFocus" billiards.Unity/CueCamera.cs` to confirm the deprecated flag remains but dynamic focus is used; command succeeded.
- Inspected the diff of `billiards.Unity/CueCamera.cs` to verify the removal of the locked-path and the `Awake()` override that forces the flag off; inspection succeeded.
- No full unit or integration tests were executed as part of this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d416f0b4d08329a18dc11eaa8fb616)