### PR TITLE
Enable and simplify shot replay and rail-overhead broadcast logic in PoolRoyale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5968,7 +5968,7 @@ const CUE_VIEW_SPIN_ZOOM = 0; // remove zoom shifts while spin control is active
 const RAIL_OVERHEAD_AIM_ZOOM = 1; // no extra zoom while tracking; rotate/look dynamics only
 const RAIL_OVERHEAD_AIM_PHI_LIFT = 0.014; // keep rail-overhead aim view marginally more downward while preserving depth
 const RAIL_OVERHEAD_REPLAY_FOV = STANDING_VIEW_FOV + 6; // widen rail-overhead lens a bit more so both bottom pockets stay visible on portrait screens
-const ENABLE_SHOT_REPLAY = false; // Pool Royale broadcast update: remove replay playback and keep live rail-overhead coverage
+const ENABLE_SHOT_REPLAY = true;
 const PORTRAIT_TOP_ACTION_BAR_DROP_REM = 1.05; // move portrait gift/chat/menu controls a bit lower from the top edge
 const BACKSPIN_DIRECTION_PREVIEW = 1; // show draw/backswing direction on cue-ball follow line
 const AIM_SPIN_PREVIEW_SIDE = 1;
@@ -13312,7 +13312,7 @@ function PoolRoyaleGame({
     return DEFAULT_FRAME_RATE_ID;
   });
   const [broadcastSystemId, setBroadcastSystemId] = useState(() => DEFAULT_BROADCAST_SYSTEM_ID);
-  const [autoReplayEnabled, setAutoReplayEnabled] = useState(false);
+  const [autoReplayEnabled, setAutoReplayEnabled] = useState(true);
   const initialTableSlot = 0;
   const [activeTableSlot, setActiveTableSlot] = useState(initialTableSlot);
   const [tableSelectionOpen, setTableSelectionOpen] = useState(false);
@@ -20399,16 +20399,6 @@ const powerRef = useRef(hud.power);
           } else if (!cameraHoldActive && activeShotView?.mode === 'action') {
             const ballsList = ballsRef.current || [];
             const cueBall = ballsList.find((b) => b.id === activeShotView.cueId);
-            const movingCount = ballsList.reduce(
-              (count, ball) =>
-                count +
-                (ball.active && ball.vel.lengthSq() > STOP_EPS * STOP_EPS ? 1 : 0),
-              0
-            );
-            const useOverheadBroadcast =
-              activeShotView.preferRailOverhead ||
-              movingCount > POCKET_CHAOS_MOVING_THRESHOLD;
-            let overheadApplied = false;
             if (!cueBall?.active) {
               activeShotView = null;
             } else {
@@ -20787,7 +20777,6 @@ const powerRef = useRef(hud.power);
                 }
                 if (shouldForceRailOverhead) {
                   activeShotView.preferRailOverhead = true;
-                  activeShotView.lockOverheadFocus = false;
                 }
               }
               const broadcastRailDir =
@@ -20805,16 +20794,11 @@ const powerRef = useRef(hud.power);
                 orbitWorld: broadcastCamerasRef.current?.defaultFocusWorld ?? null,
                 lerp: lerpT
               };
-              const overheadFocusOverride = activeShotView.lockOverheadFocus
-                ? null
-                : focusTargetVec3 ?? lookTarget ?? broadcastArgs.focusWorld;
-              const overheadMinTargetY = activeShotView.lockOverheadFocus
-                ? baseSurfaceWorldY
-                : focusTargetVec3?.y ?? baseSurfaceWorldY;
+              let railReplayCamera = null;
               if (activeShotView.preferRailOverhead) {
-                const railReplayCamera = resolveRailOverheadReplayCamera({
-                  focusOverride: overheadFocusOverride,
-                  minTargetY: overheadMinTargetY
+                railReplayCamera = resolveRailOverheadReplayCamera({
+                  focusOverride: focusTargetVec3 ?? lookTarget ?? broadcastArgs.focusWorld,
+                  minTargetY: focusTargetVec3?.y ?? baseSurfaceWorldY
                 });
                 if (railReplayCamera) {
                   broadcastArgs.focusWorld =
@@ -20838,46 +20822,28 @@ const powerRef = useRef(hud.power);
                   broadcastArgs.orbitWorld = defaultFocus;
                 }
               }
-              if (focusTargetVec3 && desiredPosition) {
-                if (useOverheadBroadcast) {
-                  const railReplayCamera = resolveRailOverheadReplayCamera({
-                    focusOverride: overheadFocusOverride,
-                    minTargetY: overheadMinTargetY
-                  });
-                  if (railReplayCamera?.position) {
-                    const resolvedTarget = activeShotView.lockOverheadFocus
-                      ? railReplayCamera.target ?? broadcastArgs.focusWorld
-                      : railReplayCamera.target ??
-                        focusTargetVec3 ??
-                        lookTarget ??
-                        broadcastArgs.focusWorld;
-                    camera.position.copy(railReplayCamera.position);
-                    camera.lookAt(resolvedTarget);
-                    lookTarget = resolvedTarget;
-                    renderCamera = camera;
-                    broadcastArgs.focusWorld = resolvedTarget.clone();
-                    broadcastArgs.targetWorld = resolvedTarget.clone();
-                    broadcastArgs.orbitWorld = railReplayCamera.position.clone();
-                    broadcastArgs.lerp = 0.12;
-                    overheadApplied = true;
-                  }
+              if (activeShotView.preferRailOverhead && railReplayCamera?.position) {
+                const overheadTarget =
+                  railReplayCamera.target?.clone?.() ?? focusTargetVec3 ?? lookTarget;
+                camera.position.copy(railReplayCamera.position);
+                camera.lookAt(overheadTarget);
+                lookTarget = overheadTarget;
+                renderCamera = camera;
+              } else if (focusTargetVec3 && desiredPosition) {
+                if (!activeShotView.smoothedPos) {
+                  activeShotView.smoothedPos = desiredPosition.clone();
+                } else {
+                  activeShotView.smoothedPos.lerp(desiredPosition, lerpT);
                 }
-                if (!overheadApplied) {
-                  if (!activeShotView.smoothedPos) {
-                    activeShotView.smoothedPos = desiredPosition.clone();
-                  } else {
-                    activeShotView.smoothedPos.lerp(desiredPosition, lerpT);
-                  }
-                  if (!activeShotView.smoothedTarget) {
-                    activeShotView.smoothedTarget = focusTargetVec3.clone();
-                  } else {
-                    activeShotView.smoothedTarget.lerp(focusTargetVec3, lerpT);
-                  }
-                  camera.position.copy(activeShotView.smoothedPos);
-                  camera.lookAt(activeShotView.smoothedTarget);
-                  lookTarget = activeShotView.smoothedTarget;
-                  renderCamera = camera;
+                if (!activeShotView.smoothedTarget) {
+                  activeShotView.smoothedTarget = focusTargetVec3.clone();
+                } else {
+                  activeShotView.smoothedTarget.lerp(focusTargetVec3, lerpT);
                 }
+                camera.position.copy(activeShotView.smoothedPos);
+                camera.lookAt(activeShotView.smoothedTarget);
+                lookTarget = activeShotView.smoothedTarget;
+                renderCamera = camera;
               }
             }
           } else if (!cameraHoldActive && activeShotView?.mode === 'pocket') {
@@ -21627,7 +21593,6 @@ const powerRef = useRef(hud.power);
             hasSwitchedRail: true,
             railNormal: railNormal ? railNormal.clone() : null,
             preferRailOverhead,
-            lockOverheadFocus: false,
             longShot,
             travelDistance,
             activationDelay,
@@ -22880,28 +22845,13 @@ const powerRef = useRef(hud.power);
           const scale = Number.isFinite(worldScaleFactor) ? worldScaleFactor : WORLD_SCALE;
           const minTargetY = Math.max(baseSurfaceWorldY, BALL_CENTER_Y * scale);
           storedTarget.y = Math.max(storedTarget.y ?? 0, minTargetY);
-          let storedPosition = activeCamera?.position?.clone?.() ?? null;
-          let storedFov = Number.isFinite(activeCamera?.fov)
-            ? activeCamera.fov
-            : camera.fov;
-          const broadcastReplayCamera = resolveBroadcastTopViewCamera({
-            focusOverride: storedTarget,
-            minTargetY
-          });
-          if (broadcastReplayCamera?.position) {
-            if (isFiniteVector3(broadcastReplayCamera.position)) {
-              storedPosition = broadcastReplayCamera.position.clone();
-            }
-            if (isFiniteVector3(broadcastReplayCamera?.target)) {
-              storedTarget.copy(broadcastReplayCamera.target);
-            }
-            storedFov = Number.isFinite(broadcastReplayCamera?.fov)
-              ? broadcastReplayCamera.fov
-              : storedFov;
-          }
+          const storedPosition = activeCamera?.position?.clone?.() ?? null;
           if (storedPosition && storedPosition.y < minTargetY) {
             storedPosition.y = minTargetY;
           }
+          const storedFov = Number.isFinite(activeCamera?.fov)
+            ? activeCamera.fov
+            : camera.fov;
           replayCameraRef.current = {
             position: storedPosition,
             target: storedTarget,
@@ -22923,6 +22873,25 @@ const powerRef = useRef(hud.power);
 
         const primeReplayCueStick = (playback) => {
           if (!cueStick) return;
+          const stroke = playback?.cueStroke ?? null;
+          if (stroke) {
+            const warmupSnap =
+              normalizeVector3Snapshot(stroke.warmup, stroke.start) ??
+              normalizeVector3Snapshot(stroke.start);
+            if (warmupSnap) {
+              cueStick.position.set(warmupSnap.x, warmupSnap.y, warmupSnap.z);
+              if (Number.isFinite(stroke.rotationY)) {
+                cueStick.rotation.y = stroke.rotationY;
+              }
+              if (Number.isFinite(stroke.rotationX)) {
+                cueStick.rotation.x = stroke.rotationX;
+              }
+              cueStick.visible = true;
+              cueAnimating = true;
+              syncCueShadow();
+              return;
+            }
+          }
           const cueSnapshot = playback?.frames?.[0]?.cue ?? null;
           if (cueSnapshot?.position) {
             const pos = normalizeVector3Snapshot(cueSnapshot.position);
@@ -22934,25 +22903,6 @@ const powerRef = useRef(hud.power);
               }
               cueStick.visible = cueSnapshot.visible ?? true;
               cueAnimating = cueStick.visible;
-              syncCueShadow();
-              return;
-            }
-          }
-          const stroke = playback?.cueStroke ?? null;
-          if (stroke) {
-            const idleSnap =
-              normalizeVector3Snapshot(stroke.idle ?? stroke.pull ?? stroke.start ?? stroke.warmup) ??
-              normalizeVector3Snapshot(stroke.pull ?? stroke.start ?? stroke.warmup);
-            if (idleSnap) {
-              cueStick.position.set(idleSnap.x, idleSnap.y, idleSnap.z);
-              if (Number.isFinite(stroke.rotationY)) {
-                cueStick.rotation.y = stroke.rotationY;
-              }
-              if (Number.isFinite(stroke.rotationX)) {
-                cueStick.rotation.x = stroke.rotationX;
-              }
-              cueStick.visible = true;
-              cueAnimating = true;
               syncCueShadow();
               return;
             }
@@ -22980,67 +22930,24 @@ const powerRef = useRef(hud.power);
 
         const startShotReplay = (postShotSnapshot) => {
           if (replayPlaybackRef.current) return;
-          if (!shotRecording) return;
-          if (replayBannerTimeoutRef.current) {
-            clearTimeout(replayBannerTimeoutRef.current);
-            replayBannerTimeoutRef.current = null;
-          }
-          setReplayBanner(null);
-          setReplaySlate({ label: 'Replay', accent: 'default', startedAt: performance.now() });
-          if (replaySlateTimeoutRef.current) {
-            clearTimeout(replaySlateTimeoutRef.current);
-          }
-          replaySlateTimeoutRef.current = window.setTimeout(() => {
-            setReplaySlate(null);
-            replaySlateTimeoutRef.current = null;
-          }, REPLAY_SLATE_DURATION_MS);
-          const fallbackStartState = Array.isArray(shotRecording?.startState)
-            ? shotRecording.startState
-            : captureBallSnapshot();
-          const fallbackPostState = Array.isArray(postShotSnapshot)
-            ? postShotSnapshot
-            : captureBallSnapshot();
-          const buildFallbackReplay = () => {
-            const fallbackDuration = Math.max(
-              420,
-              Number.isFinite(shotRecording?.frameTimeMs) ? shotRecording.frameTimeMs * 2 : 420
-            );
-            return {
-              frames: [
-                { t: 0, balls: fallbackStartState },
-                { t: fallbackDuration, balls: fallbackPostState }
-              ],
-              cuePath: shotRecording?.cuePath ?? [],
-              cueStroke: shotRecording?.cueStroke ?? null,
-              duration: fallbackDuration
-            };
-          };
+          if (!shotRecording || !shotRecording.frames?.length) return;
           const trimmed = trimReplayRecording(shotRecording);
-          const trimmedHasFrames = Array.isArray(trimmed?.frames) && trimmed.frames.length > 0;
-          const trimmedDuration = Number.isFinite(trimmed?.duration) ? trimmed.duration : 0;
-          const replayData =
-            trimmedHasFrames && trimmedDuration > 0 ? trimmed : buildFallbackReplay();
-          const duration = replayData.duration;
+          const duration = trimmed.duration;
           if (!Number.isFinite(duration) || duration <= 0) return;
-          applyRendererQuality();
-          cueStrokeStateRef.current = null;
-          pendingImpactRef.current = null;
           setReplayActive(true);
           setReplayFoul(shotRecording?.replayFoul ?? null);
           overheadBroadcastVariantRef.current = 'replay';
           storeReplayCameraFrame();
           resetCameraForReplay();
           replayPlayback = {
-            frames: replayData.frames,
-            cuePath: replayData.cuePath,
-            cueStroke: replayData.cueStroke ?? null,
+            frames: trimmed.frames,
+            cuePath: trimmed.cuePath,
+            cueStroke: trimmed.cueStroke ?? null,
             duration,
             startedAt: performance.now(),
             lastIndex: 0,
             postState: postShotSnapshot,
-            pocketDrops: pausedPocketDrops ?? pocketDropRef.current,
-            pocketCameraCutoff: null,
-            forceDualRailOverhead: false
+            pocketDrops: pausedPocketDrops ?? pocketDropRef.current
           };
           pausedPocketDrops = pocketDropRef.current;
           pocketDropRef.current = new Map();
@@ -26269,7 +26176,6 @@ const powerRef = useRef(hud.power);
           }
           if (actionView && !earlyPocketView) {
             actionView.preferRailOverhead = true;
-            actionView.lockOverheadFocus = false;
           }
           const ranges = spinRangeRef.current || {};
           const powerSpinScale = 0.55 + clampedPower * 0.45;
@@ -26475,7 +26381,6 @@ const powerRef = useRef(hud.power);
             actionView.activationTravel = 0;
             actionView.strokeReadyAt = 0;
             actionView.preferRailOverhead = true;
-            actionView.lockOverheadFocus = false;
             actionView.lastUpdate = activationNow;
             activeShotView = actionView;
             suspendedActionView = null;
@@ -28791,8 +28696,8 @@ const powerRef = useRef(hud.power);
           let shouldStartReplay =
             ENABLE_SHOT_REPLAY &&
             autoReplayEnabled &&
-            hasReplayFrames &&
-            (Boolean(replayDecision?.shouldReplay) || hasReplayFrames);
+            Boolean(replayDecision?.shouldReplay) &&
+            hasReplayFrames;
           let replayBannerText = replayDecision?.banner ?? selectReplayBanner('default');
           let replayAccent = replayDecision?.primaryTag ?? 'default';
           let postShotSnapshot = null;
@@ -29018,11 +28923,7 @@ const powerRef = useRef(hud.power);
           }
           replayBannerText = replayDecision.banner ?? selectReplayBanner('final');
           replayAccent = replayDecision.primaryTag ?? 'final';
-          shouldStartReplay =
-            ENABLE_SHOT_REPLAY &&
-            autoReplayEnabled &&
-            hasReplayFrames &&
-            (Boolean(replayDecision?.shouldReplay) || hasReplayFrames);
+          shouldStartReplay = ENABLE_SHOT_REPLAY && autoReplayEnabled;
         }
         if (replayDecision && shotRecording) {
           shotRecording.replayTags = replayDecision.tags;
@@ -29031,8 +28932,8 @@ const powerRef = useRef(hud.power);
         shouldStartReplay =
           ENABLE_SHOT_REPLAY &&
           autoReplayEnabled &&
-          hasReplayFrames &&
-          (Boolean(replayDecision?.shouldReplay) || hasReplayFrames);
+          Boolean(replayDecision?.shouldReplay) &&
+          hasReplayFrames;
         const shooterSeat = currentState?.activePlayer === 'B' ? 'B' : 'A';
         if (potted.length) {
           const newPots = potted.filter(


### PR DESCRIPTION
### Motivation
- Re-enable automatic shot replay playback and make replay behavior more reliable and predictable for Pool Royale broadcast coverage. 
- Simplify and harden rail-overhead broadcast camera selection and replay camera storage to avoid edge-case fallbacks and slipping camera targets.
- Improve cue stick priming for replay playback so recorded stroke warmup/start poses are restored when available.

### Description
- Set `ENABLE_SHOT_REPLAY` to `true` and default `autoReplayEnabled` to `true` to re-enable automatic replay playback. 
- Simplify replay decision checks to require `Boolean(replayDecision?.shouldReplay) && hasReplayFrames` and adjust special-case final-shot logic to always allow replay when appropriate. 
- Refactor rail-overhead action view handling by removing `lockOverheadFocus` usage, consolidating how `railReplayCamera` is resolved and applied, and cleaning up smoothed position/target logic. 
- Streamline replay camera storage in `storeReplayCameraFrame` by keeping the active camera position and fov, and relax previous broadcast-top-view override logic. 
- Update `primeReplayCueStick` to prefer using recorded `cueStroke.warmup`/`start` snapshots (and rotation) when available, before falling back to per-frame cue snapshots or cue-path positioning. 
- Simplify `startShotReplay` to require recorded frames, use trimmed replay data, and remove the old fallback-build path and some banner/slate preflight clutter.

### Testing
- Ran the frontend unit test suite with `yarn test` and all tests completed successfully. 
- Ran linting with `yarn lint` and no new lint errors were reported. 
- Performed a local development build with `yarn build` and the webapp built successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d481b967cc8329b1e23b1bacde3164)