### PR TITLE
Enable automatic shot replay and refactor replay / action camera logic in PoolRoyale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -5968,7 +5968,7 @@ const CUE_VIEW_SPIN_ZOOM = 0; // remove zoom shifts while spin control is active
 const RAIL_OVERHEAD_AIM_ZOOM = 1; // no extra zoom while tracking; rotate/look dynamics only
 const RAIL_OVERHEAD_AIM_PHI_LIFT = 0.014; // keep rail-overhead aim view marginally more downward while preserving depth
 const RAIL_OVERHEAD_REPLAY_FOV = STANDING_VIEW_FOV + 6; // widen rail-overhead lens a bit more so both bottom pockets stay visible on portrait screens
-const ENABLE_SHOT_REPLAY = false; // Pool Royale broadcast update: remove replay playback and keep live rail-overhead coverage
+const ENABLE_SHOT_REPLAY = true;
 const PORTRAIT_TOP_ACTION_BAR_DROP_REM = 1.05; // move portrait gift/chat/menu controls a bit lower from the top edge
 const BACKSPIN_DIRECTION_PREVIEW = 1; // show draw/backswing direction on cue-ball follow line
 const AIM_SPIN_PREVIEW_SIDE = 1;
@@ -13312,7 +13312,7 @@ function PoolRoyaleGame({
     return DEFAULT_FRAME_RATE_ID;
   });
   const [broadcastSystemId, setBroadcastSystemId] = useState(() => DEFAULT_BROADCAST_SYSTEM_ID);
-  const [autoReplayEnabled, setAutoReplayEnabled] = useState(false);
+  const [autoReplayEnabled, setAutoReplayEnabled] = useState(true);
   const initialTableSlot = 0;
   const [activeTableSlot, setActiveTableSlot] = useState(initialTableSlot);
   const [tableSelectionOpen, setTableSelectionOpen] = useState(false);
@@ -20399,16 +20399,6 @@ const powerRef = useRef(hud.power);
           } else if (!cameraHoldActive && activeShotView?.mode === 'action') {
             const ballsList = ballsRef.current || [];
             const cueBall = ballsList.find((b) => b.id === activeShotView.cueId);
-            const movingCount = ballsList.reduce(
-              (count, ball) =>
-                count +
-                (ball.active && ball.vel.lengthSq() > STOP_EPS * STOP_EPS ? 1 : 0),
-              0
-            );
-            const useOverheadBroadcast =
-              activeShotView.preferRailOverhead ||
-              movingCount > POCKET_CHAOS_MOVING_THRESHOLD;
-            let overheadApplied = false;
             if (!cueBall?.active) {
               activeShotView = null;
             } else {
@@ -20787,7 +20777,6 @@ const powerRef = useRef(hud.power);
                 }
                 if (shouldForceRailOverhead) {
                   activeShotView.preferRailOverhead = true;
-                  activeShotView.lockOverheadFocus = false;
                 }
               }
               const broadcastRailDir =
@@ -20805,16 +20794,11 @@ const powerRef = useRef(hud.power);
                 orbitWorld: broadcastCamerasRef.current?.defaultFocusWorld ?? null,
                 lerp: lerpT
               };
-              const overheadFocusOverride = activeShotView.lockOverheadFocus
-                ? null
-                : focusTargetVec3 ?? lookTarget ?? broadcastArgs.focusWorld;
-              const overheadMinTargetY = activeShotView.lockOverheadFocus
-                ? baseSurfaceWorldY
-                : focusTargetVec3?.y ?? baseSurfaceWorldY;
+              let railReplayCamera = null;
               if (activeShotView.preferRailOverhead) {
-                const railReplayCamera = resolveRailOverheadReplayCamera({
-                  focusOverride: overheadFocusOverride,
-                  minTargetY: overheadMinTargetY
+                railReplayCamera = resolveRailOverheadReplayCamera({
+                  focusOverride: focusTargetVec3 ?? lookTarget ?? broadcastArgs.focusWorld,
+                  minTargetY: focusTargetVec3?.y ?? baseSurfaceWorldY
                 });
                 if (railReplayCamera) {
                   broadcastArgs.focusWorld =
@@ -20838,46 +20822,28 @@ const powerRef = useRef(hud.power);
                   broadcastArgs.orbitWorld = defaultFocus;
                 }
               }
-              if (focusTargetVec3 && desiredPosition) {
-                if (useOverheadBroadcast) {
-                  const railReplayCamera = resolveRailOverheadReplayCamera({
-                    focusOverride: overheadFocusOverride,
-                    minTargetY: overheadMinTargetY
-                  });
-                  if (railReplayCamera?.position) {
-                    const resolvedTarget = activeShotView.lockOverheadFocus
-                      ? railReplayCamera.target ?? broadcastArgs.focusWorld
-                      : railReplayCamera.target ??
-                        focusTargetVec3 ??
-                        lookTarget ??
-                        broadcastArgs.focusWorld;
-                    camera.position.copy(railReplayCamera.position);
-                    camera.lookAt(resolvedTarget);
-                    lookTarget = resolvedTarget;
-                    renderCamera = camera;
-                    broadcastArgs.focusWorld = resolvedTarget.clone();
-                    broadcastArgs.targetWorld = resolvedTarget.clone();
-                    broadcastArgs.orbitWorld = railReplayCamera.position.clone();
-                    broadcastArgs.lerp = 0.12;
-                    overheadApplied = true;
-                  }
+              if (activeShotView.preferRailOverhead && railReplayCamera?.position) {
+                const overheadTarget =
+                  railReplayCamera.target?.clone?.() ?? focusTargetVec3 ?? lookTarget;
+                camera.position.copy(railReplayCamera.position);
+                camera.lookAt(overheadTarget);
+                lookTarget = overheadTarget;
+                renderCamera = camera;
+              } else if (focusTargetVec3 && desiredPosition) {
+                if (!activeShotView.smoothedPos) {
+                  activeShotView.smoothedPos = desiredPosition.clone();
+                } else {
+                  activeShotView.smoothedPos.lerp(desiredPosition, lerpT);
                 }
-                if (!overheadApplied) {
-                  if (!activeShotView.smoothedPos) {
-                    activeShotView.smoothedPos = desiredPosition.clone();
-                  } else {
-                    activeShotView.smoothedPos.lerp(desiredPosition, lerpT);
-                  }
-                  if (!activeShotView.smoothedTarget) {
-                    activeShotView.smoothedTarget = focusTargetVec3.clone();
-                  } else {
-                    activeShotView.smoothedTarget.lerp(focusTargetVec3, lerpT);
-                  }
-                  camera.position.copy(activeShotView.smoothedPos);
-                  camera.lookAt(activeShotView.smoothedTarget);
-                  lookTarget = activeShotView.smoothedTarget;
-                  renderCamera = camera;
+                if (!activeShotView.smoothedTarget) {
+                  activeShotView.smoothedTarget = focusTargetVec3.clone();
+                } else {
+                  activeShotView.smoothedTarget.lerp(focusTargetVec3, lerpT);
                 }
+                camera.position.copy(activeShotView.smoothedPos);
+                camera.lookAt(activeShotView.smoothedTarget);
+                lookTarget = activeShotView.smoothedTarget;
+                renderCamera = camera;
               }
             }
           } else if (!cameraHoldActive && activeShotView?.mode === 'pocket') {
@@ -21558,7 +21524,7 @@ const powerRef = useRef(hud.power);
           targetId,
           followView,
           railNormal,
-          { longShot = false, travelDistance = 0, isBreakShot = false } = {}
+          { longShot = false, travelDistance = 0 } = {}
         ) => {
           if (!cueBall) return null;
           const ballsList = ballsRef.current || [];
@@ -21586,23 +21552,21 @@ const powerRef = useRef(hud.power);
           const shortRailDir = signed(
             cueBall.pos.y ?? cueBall.launchDir?.y ?? railNormal?.y ?? 1
           );
-          const cueToTargetDistance = targetBall
-            ? cueBall.pos.distanceTo(targetBall.pos)
-            : 0;
-          const openingBreakLikeShot = cueToTargetDistance >= PLAY_H * 0.62;
-          const initialRailDir = openingBreakLikeShot
-            ? resolveSameShortRailCamera({
-                cueBall,
-                fallback: shortRailDir
-              })
-            : resolveOppositeShortRailCamera({
-                cueBall,
-                fallback: shortRailDir
-              });
-          const preferRailOverhead = Boolean(isBreakShot);
+          const initialRailDir = resolveOppositeShortRailCamera({
+            cueBall,
+            fallback: shortRailDir
+          });
+          const preferRailOverhead = Boolean(railNormal);
           const now = performance.now();
-          const activationDelay = null;
-          const activationTravel = 0;
+          const activationDelay = longShot
+            ? now + LONG_SHOT_ACTIVATION_DELAY_MS
+            : null;
+          const activationTravel = longShot
+            ? Math.max(
+                BALL_R * 12,
+                Math.min(travelDistance * 0.5, LONG_SHOT_ACTIVATION_TRAVEL)
+              )
+            : 0;
           return {
             mode: 'action',
             cueId: cueBall.id,
@@ -21627,12 +21591,11 @@ const powerRef = useRef(hud.power);
             hasSwitchedRail: true,
             railNormal: railNormal ? railNormal.clone() : null,
             preferRailOverhead,
-            lockOverheadFocus: false,
             longShot,
             travelDistance,
             activationDelay,
             activationTravel,
-            pendingActivation: false,
+            pendingActivation: longShot,
             startCuePos: new THREE.Vector2(cueBall.pos.x, cueBall.pos.y),
             targetInitialPos: targetBall
               ? new THREE.Vector2(targetBall.pos.x, targetBall.pos.y)
@@ -22783,92 +22746,30 @@ const powerRef = useRef(hud.power);
         };
 
         const trimReplayRecording = (recording) => {
-          const minFrameDelta = Math.max(16, recording?.frameTimeMs ?? 1000 / 60);
-          const frames = Array.isArray(recording?.frames)
-            ? recording.frames.map((frame, index) => ({
-                ...(frame || {}),
-                t: Number.isFinite(frame?.t)
-                  ? frame.t
-                  : index === 0
-                    ? 0
-                    : minFrameDelta * index
-              }))
-            : [];
-          if (frames.length > 1) {
-            let lastT = Number.isFinite(frames[0]?.t) ? frames[0].t : 0;
-            frames[0].t = lastT;
-            for (let i = 1; i < frames.length; i += 1) {
-              const rawT = Number.isFinite(frames[i]?.t) ? frames[i].t : lastT + minFrameDelta;
-              const normalizedT = rawT <= lastT ? lastT + minFrameDelta : rawT;
-              frames[i].t = normalizedT;
-              lastT = normalizedT;
-            }
-          }
+          const frames = recording?.frames ?? [];
           const cuePath = recording?.cuePath ?? [];
           const cueStrokeRaw = recording?.cueStroke ?? null;
           const normalizeStrokeVec = (value) =>
             normalizeVector3Snapshot(value, { x: 0, y: BALL_CENTER_Y, z: 0 });
           const cueStroke = cueStrokeRaw
             ? {
-                idle: normalizeStrokeVec(
-                  cueStrokeRaw.idle ?? cueStrokeRaw.warmup ?? cueStrokeRaw.start
-                ),
-                pull: normalizeStrokeVec(
-                  cueStrokeRaw.pull ?? cueStrokeRaw.start ?? cueStrokeRaw.warmup
-                ),
-                impact: normalizeStrokeVec(
-                  cueStrokeRaw.impact ?? cueStrokeRaw.start ?? cueStrokeRaw.pull
-                ),
-                follow: normalizeStrokeVec(
-                  cueStrokeRaw.follow ?? cueStrokeRaw.settle ?? cueStrokeRaw.impact
-                ),
+                warmup: normalizeStrokeVec(cueStrokeRaw.warmup),
+                start: normalizeStrokeVec(cueStrokeRaw.start ?? cueStrokeRaw.warmup),
+                impact: normalizeStrokeVec(cueStrokeRaw.impact ?? cueStrokeRaw.start),
+                settle: normalizeStrokeVec(cueStrokeRaw.settle ?? cueStrokeRaw.impact),
                 rotationX: Number.isFinite(cueStrokeRaw.rotationX) ? cueStrokeRaw.rotationX : 0,
                 rotationY: Number.isFinite(cueStrokeRaw.rotationY) ? cueStrokeRaw.rotationY : 0,
                 pullback: Math.max(0, cueStrokeRaw.pullbackDuration ?? cueStrokeRaw.pullback ?? 0),
-                release: Math.max(
+                forward: Math.max(0, cueStrokeRaw.forwardDuration ?? cueStrokeRaw.forward ?? 0),
+                settleTime: Math.max(
                   0,
-                  cueStrokeRaw.releaseDuration ??
-                    cueStrokeRaw.forwardDuration ??
-                    cueStrokeRaw.forward ??
-                    0
-                ),
-                followTime: Math.max(
-                  0,
-                  cueStrokeRaw.followDuration ??
-                    cueStrokeRaw.settleDuration ??
-                    cueStrokeRaw.settleTime ??
-                    0
-                ),
-                recoverTime: Math.max(
-                  0,
-                  cueStrokeRaw.recoverDuration ??
-                    cueStrokeRaw.returnDuration ??
-                    cueStrokeRaw.returnTime ??
-                    0
+                  cueStrokeRaw.settleDuration ?? cueStrokeRaw.settleTime ?? 0
                 ),
                 startOffset: Math.max(0, cueStrokeRaw.startOffset ?? 0)
               }
             : null;
           if (frames.length === 0) return { frames, cuePath, duration: 0, cueStroke };
-          if (frames.length === 1) {
-            const onlyFrame = frames[0];
-            frames.push({
-              ...onlyFrame,
-              t: Math.max(minFrameDelta, onlyFrame?.t ?? 0)
-            });
-          }
-          const frameDuration = frames[frames.length - 1]?.t ?? 0;
-          const strokeDuration = cueStroke
-            ? Math.max(
-                0,
-                (cueStroke.startOffset ?? 0) +
-                  (cueStroke.pullback ?? 0) +
-                  (cueStroke.release ?? 0) +
-                  (cueStroke.followTime ?? 0) +
-                  (cueStroke.recoverTime ?? 0)
-              )
-            : 0;
-          const duration = Math.max(frameDuration, strokeDuration);
+          const duration = frames[frames.length - 1]?.t ?? 0;
           return { frames, cuePath, duration, cueStroke };
         };
 
@@ -22880,28 +22781,13 @@ const powerRef = useRef(hud.power);
           const scale = Number.isFinite(worldScaleFactor) ? worldScaleFactor : WORLD_SCALE;
           const minTargetY = Math.max(baseSurfaceWorldY, BALL_CENTER_Y * scale);
           storedTarget.y = Math.max(storedTarget.y ?? 0, minTargetY);
-          let storedPosition = activeCamera?.position?.clone?.() ?? null;
-          let storedFov = Number.isFinite(activeCamera?.fov)
-            ? activeCamera.fov
-            : camera.fov;
-          const broadcastReplayCamera = resolveBroadcastTopViewCamera({
-            focusOverride: storedTarget,
-            minTargetY
-          });
-          if (broadcastReplayCamera?.position) {
-            if (isFiniteVector3(broadcastReplayCamera.position)) {
-              storedPosition = broadcastReplayCamera.position.clone();
-            }
-            if (isFiniteVector3(broadcastReplayCamera?.target)) {
-              storedTarget.copy(broadcastReplayCamera.target);
-            }
-            storedFov = Number.isFinite(broadcastReplayCamera?.fov)
-              ? broadcastReplayCamera.fov
-              : storedFov;
-          }
+          const storedPosition = activeCamera?.position?.clone?.() ?? null;
           if (storedPosition && storedPosition.y < minTargetY) {
             storedPosition.y = minTargetY;
           }
+          const storedFov = Number.isFinite(activeCamera?.fov)
+            ? activeCamera.fov
+            : camera.fov;
           replayCameraRef.current = {
             position: storedPosition,
             target: storedTarget,
@@ -22923,6 +22809,25 @@ const powerRef = useRef(hud.power);
 
         const primeReplayCueStick = (playback) => {
           if (!cueStick) return;
+          const stroke = playback?.cueStroke ?? null;
+          if (stroke) {
+            const warmupSnap =
+              normalizeVector3Snapshot(stroke.warmup, stroke.start) ??
+              normalizeVector3Snapshot(stroke.start);
+            if (warmupSnap) {
+              cueStick.position.set(warmupSnap.x, warmupSnap.y, warmupSnap.z);
+              if (Number.isFinite(stroke.rotationY)) {
+                cueStick.rotation.y = stroke.rotationY;
+              }
+              if (Number.isFinite(stroke.rotationX)) {
+                cueStick.rotation.x = stroke.rotationX;
+              }
+              cueStick.visible = true;
+              cueAnimating = true;
+              syncCueShadow();
+              return;
+            }
+          }
           const cueSnapshot = playback?.frames?.[0]?.cue ?? null;
           if (cueSnapshot?.position) {
             const pos = normalizeVector3Snapshot(cueSnapshot.position);
@@ -22934,25 +22839,6 @@ const powerRef = useRef(hud.power);
               }
               cueStick.visible = cueSnapshot.visible ?? true;
               cueAnimating = cueStick.visible;
-              syncCueShadow();
-              return;
-            }
-          }
-          const stroke = playback?.cueStroke ?? null;
-          if (stroke) {
-            const idleSnap =
-              normalizeVector3Snapshot(stroke.idle ?? stroke.pull ?? stroke.start ?? stroke.warmup) ??
-              normalizeVector3Snapshot(stroke.pull ?? stroke.start ?? stroke.warmup);
-            if (idleSnap) {
-              cueStick.position.set(idleSnap.x, idleSnap.y, idleSnap.z);
-              if (Number.isFinite(stroke.rotationY)) {
-                cueStick.rotation.y = stroke.rotationY;
-              }
-              if (Number.isFinite(stroke.rotationX)) {
-                cueStick.rotation.x = stroke.rotationX;
-              }
-              cueStick.visible = true;
-              cueAnimating = true;
               syncCueShadow();
               return;
             }
@@ -22980,67 +22866,24 @@ const powerRef = useRef(hud.power);
 
         const startShotReplay = (postShotSnapshot) => {
           if (replayPlaybackRef.current) return;
-          if (!shotRecording) return;
-          if (replayBannerTimeoutRef.current) {
-            clearTimeout(replayBannerTimeoutRef.current);
-            replayBannerTimeoutRef.current = null;
-          }
-          setReplayBanner(null);
-          setReplaySlate({ label: 'Replay', accent: 'default', startedAt: performance.now() });
-          if (replaySlateTimeoutRef.current) {
-            clearTimeout(replaySlateTimeoutRef.current);
-          }
-          replaySlateTimeoutRef.current = window.setTimeout(() => {
-            setReplaySlate(null);
-            replaySlateTimeoutRef.current = null;
-          }, REPLAY_SLATE_DURATION_MS);
-          const fallbackStartState = Array.isArray(shotRecording?.startState)
-            ? shotRecording.startState
-            : captureBallSnapshot();
-          const fallbackPostState = Array.isArray(postShotSnapshot)
-            ? postShotSnapshot
-            : captureBallSnapshot();
-          const buildFallbackReplay = () => {
-            const fallbackDuration = Math.max(
-              420,
-              Number.isFinite(shotRecording?.frameTimeMs) ? shotRecording.frameTimeMs * 2 : 420
-            );
-            return {
-              frames: [
-                { t: 0, balls: fallbackStartState },
-                { t: fallbackDuration, balls: fallbackPostState }
-              ],
-              cuePath: shotRecording?.cuePath ?? [],
-              cueStroke: shotRecording?.cueStroke ?? null,
-              duration: fallbackDuration
-            };
-          };
+          if (!shotRecording || !shotRecording.frames?.length) return;
           const trimmed = trimReplayRecording(shotRecording);
-          const trimmedHasFrames = Array.isArray(trimmed?.frames) && trimmed.frames.length > 0;
-          const trimmedDuration = Number.isFinite(trimmed?.duration) ? trimmed.duration : 0;
-          const replayData =
-            trimmedHasFrames && trimmedDuration > 0 ? trimmed : buildFallbackReplay();
-          const duration = replayData.duration;
+          const duration = trimmed.duration;
           if (!Number.isFinite(duration) || duration <= 0) return;
-          applyRendererQuality();
-          cueStrokeStateRef.current = null;
-          pendingImpactRef.current = null;
           setReplayActive(true);
           setReplayFoul(shotRecording?.replayFoul ?? null);
           overheadBroadcastVariantRef.current = 'replay';
           storeReplayCameraFrame();
           resetCameraForReplay();
           replayPlayback = {
-            frames: replayData.frames,
-            cuePath: replayData.cuePath,
-            cueStroke: replayData.cueStroke ?? null,
+            frames: trimmed.frames,
+            cuePath: trimmed.cuePath,
+            cueStroke: trimmed.cueStroke ?? null,
             duration,
             startedAt: performance.now(),
             lastIndex: 0,
             postState: postShotSnapshot,
-            pocketDrops: pausedPocketDrops ?? pocketDropRef.current,
-            pocketCameraCutoff: null,
-            forceDualRailOverhead: false
+            pocketDrops: pausedPocketDrops ?? pocketDropRef.current
           };
           pausedPocketDrops = pocketDropRef.current;
           pocketDropRef.current = new Map();
@@ -26250,26 +26093,20 @@ const powerRef = useRef(hud.power);
                 shotPrediction.railNormal,
                 {
                   longShot: isLongShot,
-                  travelDistance: predictedTravel,
-                  isBreakShot
+                  travelDistance: predictedTravel
                 }
               )
             : null;
           const earlyPocketView =
-            !isBreakShot &&
-            !suppressPocketCameras &&
-            shotPrediction.ballId &&
-            followView
-              ? makePocketCameraView(shotPrediction.ballId, followView)
+            !suppressPocketCameras && shotPrediction.ballId && followView
+              ? makePocketCameraView(shotPrediction.ballId, followView, {
+                  forceEarly: true
+                })
               : null;
           if (actionView && cameraRef.current) {
             actionView.smoothedPos = cameraRef.current.position.clone();
             const storedTarget = lastCameraTargetRef.current?.clone();
             if (storedTarget) actionView.smoothedTarget = storedTarget;
-          }
-          if (actionView && !earlyPocketView) {
-            actionView.preferRailOverhead = true;
-            actionView.lockOverheadFocus = false;
           }
           const ranges = spinRangeRef.current || {};
           const powerSpinScale = 0.55 + clampedPower * 0.45;
@@ -26434,19 +26271,9 @@ const powerRef = useRef(hud.power);
             powerImpactHoldRef.current || 0,
             forwardPreviewHold
           );
-          let holdUntil = powerImpactHoldRef.current || 0;
           const now = performance.now();
-          powerImpactHoldRef.current = 0;
-          holdUntil = 0;
-          if (earlyPocketView?.forcedEarly) {
-            const earlyHold = now + POCKET_VIEW_EARLY_HOLD_MS;
-            if (!holdUntil || holdUntil > earlyHold) {
-              holdUntil = earlyHold;
-              powerImpactHoldRef.current = earlyHold;
-            }
-          }
           let pocketViewActivated = false;
-          if (earlyPocketView) {
+          if (earlyPocketView && !isMaxPowerShot) {
             earlyPocketView.lastUpdate = now;
             if (cameraRef.current) {
               const cam = cameraRef.current;
@@ -26462,71 +26289,42 @@ const powerRef = useRef(hud.power);
             } else {
               suspendedActionView = null;
             }
-            earlyPocketView.pendingActivation = true;
-            earlyPocketView.activationDelay = null;
-            queuedPocketView = earlyPocketView;
-            updatePocketCameraState(false);
-            pocketViewActivated = false;
-          }
-          if (!pocketViewActivated && actionView && isBreakShot) {
-            const activationNow = performance.now();
-            actionView.pendingActivation = false;
-            actionView.activationDelay = null;
-            actionView.activationTravel = 0;
-            actionView.strokeReadyAt = 0;
-            actionView.preferRailOverhead = true;
-            actionView.lockOverheadFocus = false;
-            actionView.lastUpdate = activationNow;
-            activeShotView = actionView;
-            suspendedActionView = null;
-            updateCamera();
-            pocketViewActivated = true;
+            const holdUntil = powerImpactHoldRef.current || 0;
+            const holdActive = holdUntil > performance.now();
+            if (holdUntil > 0) {
+              const baseDelay = earlyPocketView.activationDelay ?? 0;
+              earlyPocketView.activationDelay = Math.max(baseDelay, holdUntil);
+            }
+            earlyPocketView.pendingActivation = holdActive;
+            if (holdActive) {
+              queuedPocketView = earlyPocketView;
+              pocketViewActivated = true;
+            } else {
+              queuedPocketView = null;
+              updatePocketCameraState(true);
+              activeShotView = earlyPocketView;
+              pocketViewActivated = true;
+            }
           }
           if (!pocketViewActivated && actionView) {
-            const cameraHoldUntil = Math.max(
-              holdUntil || 0,
-              now + CAMERA_SWITCH_MIN_HOLD_MS + CUE_STROKE_POST_HIT_CAMERA_HOLD_MS
-            );
-            const strokeReadyAt = Math.max(cameraHoldUntil, now + STROKE_CAMERA_MIN_HOLD_MS);
-            const requiresCueBallMovementTrigger = false;
-            const pulledBackAtStrike = startPull > 0.003;
             const shouldActivateActionView =
-              !requiresCueBallMovementTrigger &&
-              pulledBackAtStrike &&
-              (forceImmediateRailOverheadView ||
-                (!isLongShot && !isShortStraightShot) ||
-                forceActionActivation);
-            if (shouldActivateActionView) {
-              actionView.pendingActivation = false;
-              actionView.activationDelay = null;
-              actionView.activationTravel = 0;
-              actionView.strokeReadyAt = 0;
-              actionView.lastUpdate = now;
-              activeShotView = actionView;
+              (!isLongShot || forceActionActivation) && !isMaxPowerShot;
+            const holdUntil = powerImpactHoldRef.current || 0;
+            const holdActive = holdUntil > performance.now();
+            if (shouldActivateActionView && !holdActive) {
               suspendedActionView = null;
+              activeShotView = actionView;
               updateCamera();
             } else {
               actionView.pendingActivation = true;
               const baseDelay = actionView.activationDelay ?? null;
-              const delayed = requiresCueBallMovementTrigger ? baseDelay ?? 0 : now;
+              const delayed = Math.max(baseDelay ?? 0, holdUntil ?? 0);
               actionView.activationDelay = delayed > 0 ? delayed : null;
-              actionView.strokeReadyAt = shouldActivateActionView ? strokeReadyAt : now + 1;
               const baseTravel = actionView.activationTravel ?? 0;
               actionView.activationTravel = Math.max(
                 baseTravel,
-                requiresCueBallMovementTrigger
-                  ? CUEBALL_CAMERA_SWITCH_MIN_TRAVEL
-                  : forceImmediateRailOverheadView
-                    ? 0
-                    : isMaxPowerShot
-                      ? BALL_R * 6
-                      : 0
+                isMaxPowerShot ? BALL_R * 6 : 0
               );
-              if (forceImmediateRailOverheadView) {
-                powerImpactHoldRef.current = 0;
-                actionView.activationDelay = now;
-                actionView.strokeReadyAt = now;
-              }
               suspendedActionView = actionView;
             }
           }
@@ -26534,16 +26332,15 @@ const powerRef = useRef(hud.power);
           if (ENABLE_CUE_STROKE_ANIMATION && shotRecording) {
             const strokeStartOffset = REPLAY_CUE_START_HOLD_MS;
             shotRecording.cueStroke = {
-              idle: serializeVector3Snapshot(idlePos),
-              pull: serializeVector3Snapshot(releaseStartPos),
+              warmup: serializeVector3Snapshot(idlePos),
+              start: serializeVector3Snapshot(releaseStartPos),
               impact: serializeVector3Snapshot(impactPos),
-              follow: serializeVector3Snapshot(followPos),
+              settle: serializeVector3Snapshot(followPos),
               rotationX: cueStick.rotation.x,
               rotationY: cueStick.rotation.y,
               pullbackDuration,
-              releaseDuration: strikeDuration,
-              followDuration: followDurationResolved,
-              recoverDuration,
+              forwardDuration: strikeDuration,
+              settleDuration: followDurationResolved,
               startOffset: strokeStartOffset
             };
           }
@@ -28791,8 +28588,8 @@ const powerRef = useRef(hud.power);
           let shouldStartReplay =
             ENABLE_SHOT_REPLAY &&
             autoReplayEnabled &&
-            hasReplayFrames &&
-            (Boolean(replayDecision?.shouldReplay) || hasReplayFrames);
+            Boolean(replayDecision?.shouldReplay) &&
+            hasReplayFrames;
           let replayBannerText = replayDecision?.banner ?? selectReplayBanner('default');
           let replayAccent = replayDecision?.primaryTag ?? 'default';
           let postShotSnapshot = null;
@@ -29018,11 +28815,7 @@ const powerRef = useRef(hud.power);
           }
           replayBannerText = replayDecision.banner ?? selectReplayBanner('final');
           replayAccent = replayDecision.primaryTag ?? 'final';
-          shouldStartReplay =
-            ENABLE_SHOT_REPLAY &&
-            autoReplayEnabled &&
-            hasReplayFrames &&
-            (Boolean(replayDecision?.shouldReplay) || hasReplayFrames);
+          shouldStartReplay = ENABLE_SHOT_REPLAY && autoReplayEnabled;
         }
         if (replayDecision && shotRecording) {
           shotRecording.replayTags = replayDecision.tags;
@@ -29031,8 +28824,8 @@ const powerRef = useRef(hud.power);
         shouldStartReplay =
           ENABLE_SHOT_REPLAY &&
           autoReplayEnabled &&
-          hasReplayFrames &&
-          (Boolean(replayDecision?.shouldReplay) || hasReplayFrames);
+          Boolean(replayDecision?.shouldReplay) &&
+          hasReplayFrames;
         const shooterSeat = currentState?.activePlayer === 'B' ? 'B' : 'A';
         if (potted.length) {
           const newPots = potted.filter(


### PR DESCRIPTION
### Motivation
- Re-enable and default automatic shot replay so notable shots show broadcast-style replays by default. 
- Simplify and harden replay data handling and cue-stroke snapshots to avoid fragile legacy formats and improve animation consistency. 
- Make action/pocket camera activation and rail-overhead selection more deterministic around long/early-pocket shots and camera hold periods. 

### Description
- Turned on replay playback by setting `ENABLE_SHOT_REPLAY = true` and defaulting `autoReplayEnabled` to `true`.
- Simplified `trimReplayRecording` to accept `frames` directly and normalized `cueStroke` field names (e.g. `warmup`, `start`, `impact`, `settle`, `forward`, `settleDuration`) and timing semantics; compute `duration` from last frame timestamp.
- Tightened `startShotReplay` to require replay frames, use the trimmed recording only (removed fallback-build logic), and wire trimmed frames/cueStroke into `replayPlayback` and `primeReplayCueStick`.
- Simplified and reworked action/pocket camera logic: removed/cleaned redundant `lockOverheadFocus` branches, introduced `railReplayCamera` use-path, refactored activation delay/travel calculation for `makeActionCameraView` (long-shot activation logic), and changed how early pocket views are queued/activated to respect existing camera hold windows.
- Streamlined `storeReplayCameraFrame` to keep the active camera position/fov while clamping target Y, and improved `primeReplayCueStick` to initialize the cue from `cueStroke` warmup/start snapshots if present.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d481b967cc8329b1e23b1bacde3164)