### PR TITLE
Show HDRI thumbnails in Murlan menu and preserve PolyHaven resolution mapping

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -511,8 +511,14 @@ const HDRI_RESOLUTION_STACK = Object.freeze(['8k', '4k', '2k']);
 export const POOL_ROYALE_HDRI_VARIANTS = Object.freeze(
   RAW_POOL_ROYALE_HDRI_VARIANTS.map((variant) => ({
     ...variant,
-    preferredResolutions: HDRI_RESOLUTION_STACK,
-    fallbackResolution: HDRI_RESOLUTION_STACK[0],
+    preferredResolutions:
+      Array.isArray(variant.preferredResolutions) && variant.preferredResolutions.length
+        ? variant.preferredResolutions
+        : HDRI_RESOLUTION_STACK,
+    fallbackResolution:
+      variant.fallbackResolution ||
+      (Array.isArray(variant.preferredResolutions) && variant.preferredResolutions[0]) ||
+      HDRI_RESOLUTION_STACK[0],
     thumbnail: polyHavenThumb(variant.assetId),
     ...(POOL_ROYALE_HDRI_PLACEMENTS[variant.id] || {})
   }))

--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1188,6 +1188,7 @@ const CUSTOMIZATION_SECTIONS = [
   { key: 'tableShape', label: 'Table Shape', options: TABLE_SHAPE_OPTIONS },
   { key: 'tableCloth', label: 'Table Cloth', options: MURLAN_TABLE_CLOTHS },
   { key: 'tableFinish', label: 'Table Finish', options: MURLAN_TABLE_FINISHES },
+  { key: 'environmentHdri', label: 'Arena HDRI', options: MURLAN_HDRI_OPTIONS },
   { key: 'cards', label: 'Cards', options: CARD_THEMES },
   { key: 'stools', label: 'Stools', options: STOOL_THEMES },
   ...(ENABLE_3D_HUMAN_CHARACTERS
@@ -4251,12 +4252,21 @@ export default function MurlanRoyaleArena({ search }) {
           : ['#0ea5e9', '#312e81'];
         return (
           <div className="relative h-14 w-full overflow-hidden rounded-xl border border-white/10 bg-slate-950/60">
-            <div
-              className="absolute inset-0"
-              style={{
-                backgroundImage: `radial-gradient(circle at 30% 30%, ${primary}, transparent 45%), radial-gradient(circle at 80% 60%, ${secondary}, transparent 55%), linear-gradient(135deg, ${primary}99, ${secondary}dd)`
-              }}
-            />
+            {option?.thumbnail ? (
+              <img
+                src={option.thumbnail}
+                alt={option.label || 'HDRI option'}
+                className="absolute inset-0 h-full w-full object-cover opacity-90"
+                loading="lazy"
+              />
+            ) : (
+              <div
+                className="absolute inset-0"
+                style={{
+                  backgroundImage: `radial-gradient(circle at 30% 30%, ${primary}, transparent 45%), radial-gradient(circle at 80% 60%, ${secondary}, transparent 55%), linear-gradient(135deg, ${primary}99, ${secondary}dd)`
+                }}
+              />
+            )}
             <div className="absolute inset-0 bg-gradient-to-br from-black/40 via-transparent to-black/60" />
             <div className="absolute bottom-1 left-1 rounded-md bg-black/60 px-2 py-0.5 text-[0.55rem] font-semibold uppercase tracking-wide text-emerald-100/80">
               HDRI


### PR DESCRIPTION
### Motivation
- Ensure HDRI options owned in inventory are visible in the Murlan Royale customization UI and render their real thumbnails in the menu. 
- Preserve each HDRI variant's original PolyHaven resolution preferences so runtime loading picks the intended asset resolution.

### Description
- Add `environmentHdri` to the Murlan customization sections so HDRIs show up in the arena customization menu (`webapp/src/pages/Games/MurlanRoyaleArena.jsx`).
- Update the HDRI preview renderer to display `option.thumbnail` when available, with the previous gradient swatch fallback retained (`webapp/src/pages/Games/MurlanRoyaleArena.jsx`).
- Change `POOL_ROYALE_HDRI_VARIANTS` mapping to keep per-variant `preferredResolutions` and `fallbackResolution` when present, falling back to the global stack only if a variant has no resolution info (`webapp/src/config/poolRoyaleInventoryConfig.js`).

### Testing
- Ran `npm test -- test/checkersBattleHdriCatalog.test.js --runInBand` and it passed.
- Ran `npm test -- test/inventoryCrossGameConfig.test.js test/texasHoldemHdriPreload.test.js --runInBand`; `test/texasHoldemHdriPreload.test.js` passed and `test/inventoryCrossGameConfig.test.js` failed (existing default-stools mismatch observed during validation).
- No UI screenshot tests were run in this environment; changes are limited to preview rendering and configuration mapping.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d49fb4f920832999cdd443248d7162)