### PR TITLE
Pool Royale: force rail-overhead on break/bank/double‑bank and fix replay frame camera

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -15071,6 +15071,7 @@ function PoolRoyaleGame({
     contactMade: false,
     cushionAfterContact: false,
     railContactCountAfterContact: 0,
+    doubleBankBroadcastCutApplied: false,
     attemptsPenaltyApplied: false
   });
   const shotReplayRef = useRef(null);
@@ -25834,6 +25835,7 @@ const powerRef = useRef(hud.power);
           contactMade: false,
           cushionAfterContact: false,
           railContactCountAfterContact: 0,
+          doubleBankBroadcastCutApplied: false,
           attemptsPenaltyApplied: false,
           spin: {
             x: appliedSpinSnapshot.x ?? 0,
@@ -26050,6 +26052,8 @@ const powerRef = useRef(hud.power);
               isMiddlePocketIntent ||
               hasLikelyPocketIntent ||
               isCrowdedShot);
+          const prioritizeRailOverheadCut =
+            forceImmediateRailOverheadView || isBreakShot || Boolean(shotPrediction?.railNormal);
           const allowRailOverheadActionView = true;
           const allowLongShotCameraSwitch =
             (forceImmediateRailOverheadView || !suppressOpeningShotViews) &&
@@ -26097,8 +26101,17 @@ const powerRef = useRef(hud.power);
                 }
               )
             : null;
+          if (actionView && prioritizeRailOverheadCut) {
+            actionView.preferRailOverhead = true;
+            actionView.pendingActivation = false;
+            actionView.activationDelay = null;
+            actionView.activationTravel = 0;
+          }
           const earlyPocketView =
-            !suppressPocketCameras && shotPrediction.ballId && followView
+            !prioritizeRailOverheadCut &&
+            !suppressPocketCameras &&
+            shotPrediction.ballId &&
+            followView
               ? makePocketCameraView(shotPrediction.ballId, followView, {
                   forceEarly: true
                 })
@@ -26308,9 +26321,11 @@ const powerRef = useRef(hud.power);
           }
           if (!pocketViewActivated && actionView) {
             const shouldActivateActionView =
-              (!isLongShot || forceActionActivation) && !isMaxPowerShot;
+              (prioritizeRailOverheadCut || !isLongShot || forceActionActivation) &&
+              (!isMaxPowerShot || prioritizeRailOverheadCut);
             const holdUntil = powerImpactHoldRef.current || 0;
-            const holdActive = holdUntil > performance.now();
+            const holdActive =
+              !prioritizeRailOverheadCut && holdUntil > performance.now();
             if (shouldActivateActionView && !holdActive) {
               suspendedActionView = null;
               activeShotView = actionView;
@@ -28957,6 +28972,7 @@ const powerRef = useRef(hud.power);
           contactMade: false,
           cushionAfterContact: false,
           railContactCountAfterContact: 0,
+          doubleBankBroadcastCutApplied: false,
           attemptsPenaltyApplied: false,
           spin: { x: 0, y: 0 }
         };
@@ -29228,23 +29244,21 @@ const powerRef = useRef(hud.power);
             applyReplayCueStroke(playback, targetTime);
             updateReplayTrail(playback.cuePath, targetTime);
             if (!LOCK_REPLAY_CAMERA) {
-              const currentFrameCamera = frameA?.camera ?? null;
-              const nextFrameCamera = frameB?.camera ?? currentFrameCamera;
+              const nextFrameCamera = frameB?.camera ?? frameA?.camera ?? null;
               const previousFrameCamera =
                 replayFrameCameraRef.current?.frameB ??
                 replayFrameCameraRef.current?.frameA ??
                 null;
-              const cameraChanged =
-                hasReplayCameraChanged(previousFrameCamera, currentFrameCamera) ||
-                hasReplayCameraChanged(previousFrameCamera, nextFrameCamera);
-              if ((currentFrameCamera || nextFrameCamera) && (cameraChanged || !replayFrameCameraRef.current)) {
+              if (
+                nextFrameCamera &&
+                (!replayFrameCameraRef.current ||
+                  hasReplayCameraChanged(previousFrameCamera, nextFrameCamera))
+              ) {
                 replayFrameCameraRef.current = {
-                  frameA: currentFrameCamera ?? nextFrameCamera,
-                  frameB: nextFrameCamera ?? currentFrameCamera,
-                  alpha
+                  frameA: nextFrameCamera,
+                  frameB: nextFrameCamera,
+                  alpha: 0
                 };
-              } else if (replayFrameCameraRef.current) {
-                replayFrameCameraRef.current.alpha = alpha;
               }
             } else {
               replayFrameCameraRef.current = null;
@@ -30482,6 +30496,20 @@ const powerRef = useRef(hud.power);
               shotContextRef.current.cushionAfterContact = true;
               shotContextRef.current.railContactCountAfterContact =
                 (shotContextRef.current.railContactCountAfterContact ?? 0) + 1;
+              if (
+                (shotContextRef.current.railContactCountAfterContact ?? 0) >= 2 &&
+                !shotContextRef.current.doubleBankBroadcastCutApplied
+              ) {
+                shotContextRef.current.doubleBankBroadcastCutApplied = true;
+                if (activeShotView?.mode === 'action') {
+                  activeShotView.preferRailOverhead = true;
+                  activeShotView.pendingActivation = false;
+                  activeShotView.activationDelay = null;
+                  activeShotView.activationTravel = 0;
+                }
+                queuedPocketView = null;
+                enterTopView(true, { variant: 'rail' });
+              }
             }
             if (railImpact) {
               applyRailImpulse(b, railImpact);


### PR DESCRIPTION
### Motivation
- Make broadcast behavior deterministic for critical shots by immediately switching to the rail-overhead (broadcast) camera on break shots and when a shot is rail/bank-prioritized.  
- Ensure double-bank and cushion-based shots cut instantly to the rail-overhead feed rather than being pre-empted by pocket cams.  
- Restore reliable replay framing by aligning Pool Royale's replay camera handoff with the Snooker replay logic so the replay frame is visible and consistent.

### Description
- Added a per-shot flag `doubleBankBroadcastCutApplied` to `shotContextRef` and reset it at shot initialization to avoid repeated triggers. (modified `webapp/src/pages/Games/PoolRoyale.jsx`).
- When a shot is determined to require rail-overhead priority (break, predicted `railNormal`, crowded/complex/cushion cases), force the action camera into rail-overhead immediately by setting `actionView.preferRailOverhead` and clearing activation delays so the rail-overhead cut happens at shot start. (changes in the camera selection / actionView creation logic in `PoolRoyale.jsx`).
- Prevent early pocket-camera activation from pre-empting rail-overhead when `prioritizeRailOverheadCut` is true by gating early pocket view creation/activation. (updated pocket/action view gating in `PoolRoyale.jsx`).
- Detect double-bank behavior during live physics updates (increment `railContactCountAfterContact` when cushions are hit) and on the second post-contact rail hit, if not yet applied, mark the flag, clear queued pocket views and immediately call `enterTopView(true, { variant: 'rail' })` to switch to the rail overhead broadcast. (live physics loop changes in `PoolRoyale.jsx`).
- Adjust replay camera handoff to prefer the latest valid replay camera sample (use `frameB?.camera ?? frameA?.camera`) and create a stable `replayFrameCameraRef.current` entry (single-frame with `alpha: 0`) instead of using inconsistent frameA/frameB alpha blending; this mirrors Snooker logic and makes the replay framing visible and stable. (replay playback changes in `PoolRoyale.jsx`).
- Summary of file changed: `webapp/src/pages/Games/PoolRoyale.jsx` (camera selection/action view logic, replay frame camera logic, shot context bookkeeping).

### Testing
- Ran the production build: `npm --prefix webapp run -s build`, which completed successfully; Vite emitted existing chunk-size/dynamic-import warnings but the build finished without error.  
- No automated unit tests were modified or run as part of this change; behavior changes were implemented in the game client logic and validated by a successful build.  
- Manual runtime verification is recommended (playbreak, cushion/bank shots, double-bank cases and replay playback) to confirm camera handoffs and replay frame visibility in the running application.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4a1cccb608329bf90a9f6a9816ce8)