### PR TITLE
Murlan Royale: adjust avatar positions, side camera bias, and side-hand alignment

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2359,10 +2359,12 @@ const CAMERA_PLAY_NEXT_TURN_DELAY_MS = 520;
 const CAMERA_PLAY_TURN_DURATION_MS = 300;
 const CAMERA_TARGET_TURN_SNAP_DISTANCE = 0.018 * MODEL_SCALE;
 const CAMERA_PLAYER_TARGET_WEIGHT = 0.45;
-const CAMERA_SIDE_LOOK_EXTRA = 0.22 * MODEL_SCALE;
+const CAMERA_SIDE_LOOK_EXTRA = 0.34 * MODEL_SCALE;
 const CAMERA_INWARD_RADIUS_FACTOR = 0.72;
 const CAMERA_UP_TILT_FORWARD_BLEND = 0.34 * MODEL_SCALE;
 const CAMERA_UP_TILT_FORWARD_LERP = 0.14;
+const SIDE_AVATAR_INWARD_PERCENT = 2.4;
+const HUMAN_AVATAR_TOP_NUDGE_PERCENT = 7.5;
 
 const PLAYER_COLORS = ['#f97316', '#38bdf8', '#a78bfa', '#22c55e'];
 const FALLBACK_SEAT_POSITIONS = [
@@ -3626,6 +3628,13 @@ export default function MurlanRoyaleArena({ search }) {
     const discardSet = new Set(state.discardPile.map((card) => card.id));
 
     const seatConfigs = three.seatConfigs;
+    const humanSeatConfig = seatConfigs.find((seat) => state.players[seat.seatIndex]?.isHuman) ?? null;
+    const sharedHorizontalAxis = humanSeatConfig?.right?.clone?.() ?? new THREE.Vector3(1, 0, 0);
+    if (sharedHorizontalAxis.lengthSq() > 1e-6) {
+      sharedHorizontalAxis.normalize();
+    } else {
+      sharedHorizontalAxis.set(1, 0, 0);
+    }
     const cardMap = three.cardMap;
     const humanTurn = state.status === 'PLAYING' && state.players[state.activePlayer]?.isHuman;
     humanTurnRef.current = humanTurn;
@@ -3667,7 +3676,9 @@ export default function MurlanRoyaleArena({ search }) {
         const fanYaw = HUMAN_HAND_UNIFORM_YAW_FROM_LEFT
           ? HUMAN_HAND_FAN_MAX_YAW
           : normalizedOffset * (isHumanCard ? HUMAN_HAND_FAN_MAX_YAW : AI_HAND_FAN_MAX_YAW) * fanDirection;
-        const layoutAxis = right?.clone?.() ?? new THREE.Vector3(1, 0, 0);
+        const layoutAxis = isHumanCard
+          ? right?.clone?.() ?? sharedHorizontalAxis.clone()
+          : sharedHorizontalAxis.clone();
         if (layoutAxis.lengthSq() > 1e-6) {
           layoutAxis.normalize();
         } else {
@@ -3708,7 +3719,7 @@ export default function MurlanRoyaleArena({ search }) {
 
     const tableAnchor = three.tableAnchor.clone();
     const tableCount = state.tableCards.length;
-    const humanSeat = seatConfigs.find((seat) => state.players[seat.seatIndex]?.isHuman);
+    const humanSeat = humanSeatConfig;
     const bottomCardSpacing = Math.max(humanSeat?.spacing ?? 0, COMMUNITY_CARD_SPACING);
     const bottomCardMaxSpread = Math.max(humanSeat?.maxSpread ?? 0, COMMUNITY_CARD_MAX_SPREAD);
     const tableSpread = tableCount > 1
@@ -5276,29 +5287,32 @@ export default function MurlanRoyaleArena({ search }) {
             const activePlayer = gameState.players?.[idx] ?? player;
             const anchor = seatAnchorMap.get(idx);
             const fallback = FALLBACK_SEAT_POSITIONS[idx % FALLBACK_SEAT_POSITIONS.length];
+            const inwardX = anchor
+              ? anchor.x < 50
+                ? anchor.x + SIDE_AVATAR_INWARD_PERCENT
+                : anchor.x > 50
+                  ? anchor.x - SIDE_AVATAR_INWARD_PERCENT
+                  : anchor.x
+              : null;
             const isSideSeat = Boolean(anchor) && (anchor.x <= 35 || anchor.x >= 65);
             const sideSeatTopLift = isSideSeat ? 12 : 0;
-            const positionStyle = idx === humanPlayerIndex
+            const positionStyle = anchor
               ? {
-                  position: 'fixed',
-                  left: '50%',
-                  bottom: 'calc(12rem + env(safe-area-inset-bottom, 0px))',
-                  transform: 'translateX(-50%)',
-                  zIndex: 24
+                  position: 'absolute',
+                  left: `${inwardX}%`,
+                  top: `${clampValue(
+                    anchor.y - sideSeatTopLift - (idx === humanPlayerIndex ? HUMAN_AVATAR_TOP_NUDGE_PERCENT : 0),
+                    -10,
+                    110
+                  )}%`,
+                  transform: 'translate(-50%, -50%)'
                 }
-              : anchor
-                ? {
-                    position: 'absolute',
-                    left: `${anchor.x}%`,
-                    top: `${clampValue(anchor.y - sideSeatTopLift, -10, 110)}%`,
-                    transform: 'translate(-50%, -50%)'
-                  }
-                : {
-                    position: 'absolute',
-                    left: fallback.left,
-                    top: fallback.top,
-                    transform: 'translate(-50%, -50%)'
-                  };
+              : {
+                  position: 'absolute',
+                  left: fallback.left,
+                  top: fallback.top,
+                  transform: 'translate(-50%, -50%)'
+                };
             const avatarSize = anchor ? clampValue(1.25 - (anchor.depth - 2.4) * 0.12, 0.85, 1.25) : 1;
             const color = PLAYER_COLORS[idx % PLAYER_COLORS.length];
             const isTurn = gameState.activePlayer === idx;


### PR DESCRIPTION
### Motivation
- Improve portrait UX by keeping the player avatar HUD tied to the in-scene seat (not fixed center) and nudging it upward to avoid centering over the table. 
- Make camera framing clearer when side players take a turn by biasing the look toward the active left/right seat. 
- Make left/right (AI) hand layouts visually consistent with the bottom player's horizontal card line so cards appear more aligned and inward toward the table center.

### Description
- Increased side-turn camera bias by raising `CAMERA_SIDE_LOOK_EXTRA` to `0.34 * MODEL_SCALE` to shift camera focus more toward left/right active seats. 
- Added `SIDE_AVATAR_INWARD_PERCENT` and `HUMAN_AVATAR_TOP_NUDGE_PERCENT` constants and use them to nudge side avatars slightly inward and to raise the human avatar HUD when attached to its seat anchor. 
- Replaced the fixed bottom-centre avatar placement with anchor-driven positioning so the human avatar marker follows the seat anchor and honors the top nudge for portrait screens. 
- Aligned AI/non-human hand layout axis to use a shared horizontal axis derived from the human seat `right` vector so side hands present in a straighter, more consistent horizontal line with the bottom player. 
- Changes are located in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` and include small normalization and layout adjustments for seat and card positioning.

### Testing
- Ran the production build with `npm -C webapp run build`, which completed successfully; Vite emitted non-blocking chunk-size warnings but the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4b1ade6148329a62fe634bbb79fd1)