### PR TITLE
Pool Royale: Fix replay startup, add "Skip all replays" and tune LT cloth/finish textures

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2488,11 +2488,11 @@ function scaleWoodRepeatVector (repeatVec, scale) {
 const LT_CARBON_TEXTURE_REPEAT = Object.freeze({ x: 20, y: 5.2 });
 let CARBON_FIBER_TILE_CANVAS = null;
 const CARBON_FIBER_TILE_TEXTURES = new Map();
-const LT_MATTE_PLASTIC_TEXTURE_REPEAT = Object.freeze({ x: 10.5, y: 3.8 });
+const LT_MATTE_PLASTIC_TEXTURE_REPEAT = Object.freeze({ x: 8.6, y: 3.2 });
 const LT_MATTE_PLASTIC_TEXTURES = new Map();
-const LT_FINISH_BRIGHTNESS_LIFT = 0.16;
-const LT_FINISH_CONTRAST_BOOST = 1.2;
-const LT_MATTE_NORMAL_SCALE = 0.68;
+const LT_FINISH_BRIGHTNESS_LIFT = 0.2;
+const LT_FINISH_CONTRAST_BOOST = 1.26;
+const LT_MATTE_NORMAL_SCALE = 0.88;
 
 function createCarbonFiberPatternCanvas(size = 128) {
   if (typeof document === 'undefined') return null;
@@ -2601,7 +2601,7 @@ function applyLtCarbonFiberTexture(material) {
   material.needsUpdate = true;
 }
 
-function getLtMattePlasticTextureSet(tintHex = 0x0c0f14, size = 320) {
+function getLtMattePlasticTextureSet(tintHex = 0x0c0f14, size = 512) {
   if (typeof document === 'undefined') return null;
   const tintColor = new THREE.Color(tintHex);
   const key = `${tintColor.getHexString()}-${size}`;
@@ -2647,7 +2647,7 @@ function getLtMattePlasticTextureSet(tintHex = 0x0c0f14, size = 320) {
       normalImage.data[i + 1] = THREE.MathUtils.clamp(128 + grain * 22, 0, 255);
       normalImage.data[i + 2] = THREE.MathUtils.clamp(220 + micropit * 34, 0, 255);
       normalImage.data[i + 3] = 255;
-      const rough = THREE.MathUtils.clamp(214 + dither * 16 + grain * 12 + micropit * 10, 150, 255);
+      const rough = THREE.MathUtils.clamp(226 + dither * 16 + grain * 14 + micropit * 12, 170, 255);
       roughImage.data[i] = rough;
       roughImage.data[i + 1] = rough;
       roughImage.data[i + 2] = rough;
@@ -2667,7 +2667,7 @@ function getLtMattePlasticTextureSet(tintHex = 0x0c0f14, size = 320) {
     texture.repeat.set(LT_MATTE_PLASTIC_TEXTURE_REPEAT.x, LT_MATTE_PLASTIC_TEXTURE_REPEAT.y);
     texture.generateMipmaps = true;
     texture.minFilter = THREE.LinearMipmapLinearFilter;
-    texture.magFilter = THREE.LinearFilter;
+    texture.magFilter = THREE.NearestFilter;
     texture.anisotropy = resolveTextureAnisotropy(texture.anisotropy ?? 1);
     texture.needsUpdate = true;
     if (idx === 0) {
@@ -2690,7 +2690,7 @@ function applyMonoMattePlasticSurface(material) {
     material.metalness = 0;
   }
   if ('roughness' in material) {
-    material.roughness = 0.94;
+    material.roughness = 0.98;
   }
   if ('clearcoat' in material) {
     material.clearcoat = 0;
@@ -2708,7 +2708,7 @@ function applyMonoMattePlasticSurface(material) {
     material.reflectivity = 0;
   }
   if ('envMapIntensity' in material) {
-    material.envMapIntensity = 0.12;
+    material.envMapIntensity = 0.08;
   }
   if ('normalScale' in material && material.normalMap) {
     material.normalScale = new THREE.Vector2(LT_MATTE_NORMAL_SCALE, LT_MATTE_NORMAL_SCALE);
@@ -3644,6 +3644,7 @@ const LIGHTING_PRESET_MAP = Object.freeze(
 
 const FRAME_RATE_STORAGE_KEY = 'snookerFrameRate';
 const AUTO_REPLAY_STORAGE_KEY = 'poolRoyaleAutoReplay';
+const SKIP_REPLAYS_STORAGE_KEY = 'poolRoyaleSkipReplays';
 const FRAME_RATE_OPTIONS = Object.freeze([
   {
     id: 'fhd60',
@@ -4490,6 +4491,7 @@ const createClothTextures = (() => {
           loadTextureWithFallbacks(loader, normalCandidates, false),
           loadTextureWithFallbacks(loader, roughnessCandidates, false)
         ]);
+        map = neutralizePolyHavenColorMap(map);
 
         [map, normal, roughness].forEach((tex) =>
           applyTextureDefaults(tex, { isPolyHaven: true })
@@ -13225,6 +13227,7 @@ function PoolRoyaleGame({
   const [commentaryPresetId, setCommentaryPresetId] = useState(DEFAULT_COMMENTARY_PRESET_ID);
   const [commentaryMuted, setCommentaryMuted] = useState(!POOL_ROYALE_VOICE_COMMENTARY_ENABLED);
   const skipReplayRef = useRef(() => {});
+  const skipAllReplaysRef = useRef(false);
   const cueStrokeAnimationStyleRef = useRef(DEFAULT_CUE_STROKE_STYLE);
   const commentaryMutedRef = useRef(commentaryMuted);
   const commentaryReadyRef = useRef(false);
@@ -13243,6 +13246,12 @@ function PoolRoyaleGame({
       pendingCommentaryLinesRef.current = null;
     }
   }, [commentaryMuted]);
+  useEffect(() => {
+    skipAllReplaysRef.current = skipAllReplays;
+    if (skipAllReplays) {
+      skipReplayRef.current?.();
+    }
+  }, [skipAllReplays]);
   useEffect(() => {
     if (!POOL_ROYALE_VOICE_COMMENTARY_ENABLED) return;
     if (typeof window !== 'undefined') {
@@ -13312,7 +13321,22 @@ function PoolRoyaleGame({
     return DEFAULT_FRAME_RATE_ID;
   });
   const [broadcastSystemId, setBroadcastSystemId] = useState(() => DEFAULT_BROADCAST_SYSTEM_ID);
-  const [autoReplayEnabled, setAutoReplayEnabled] = useState(true);
+  const [autoReplayEnabled, setAutoReplayEnabled] = useState(() => {
+    if (typeof window !== 'undefined') {
+      const stored = window.localStorage.getItem(AUTO_REPLAY_STORAGE_KEY);
+      if (stored === '0') return false;
+      if (stored === '1') return true;
+    }
+    return true;
+  });
+  const [skipAllReplays, setSkipAllReplays] = useState(() => {
+    if (typeof window !== 'undefined') {
+      const stored = window.localStorage.getItem(SKIP_REPLAYS_STORAGE_KEY);
+      if (stored === '1') return true;
+      if (stored === '0') return false;
+    }
+    return false;
+  });
   const initialTableSlot = 0;
   const [activeTableSlot, setActiveTableSlot] = useState(initialTableSlot);
   const [tableSelectionOpen, setTableSelectionOpen] = useState(false);
@@ -14964,6 +14988,11 @@ function PoolRoyaleGame({
       window.localStorage.setItem(AUTO_REPLAY_STORAGE_KEY, autoReplayEnabled ? '1' : '0');
     }
   }, [autoReplayEnabled]);
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(SKIP_REPLAYS_STORAGE_KEY, skipAllReplays ? '1' : '0');
+    }
+  }, [skipAllReplays]);
   useEffect(() => {
     if (!configOpen) return undefined;
     const handleKeyDown = (event) => {
@@ -22747,7 +22776,10 @@ const powerRef = useRef(hud.power);
         };
 
         const trimReplayRecording = (recording) => {
-          const frames = recording?.frames ?? [];
+          const rawFrames = recording?.frames ?? [];
+          const frames = rawFrames
+            .map((frame) => ({ ...frame, t: Number(frame?.t) || 0 }))
+            .sort((a, b) => a.t - b.t);
           const cuePath = recording?.cuePath ?? [];
           const cueStrokeRaw = recording?.cueStroke ?? null;
           const normalizeStrokeVec = (value) =>
@@ -22770,7 +22802,22 @@ const powerRef = useRef(hud.power);
               }
             : null;
           if (frames.length === 0) return { frames, cuePath, duration: 0, cueStroke };
-          const duration = frames[frames.length - 1]?.t ?? 0;
+          let duration = frames[frames.length - 1]?.t ?? 0;
+          if (!Number.isFinite(duration) || duration <= 0) {
+            const frameSeed = frames[frames.length - 1] ?? frames[0];
+            const fallbackDuration = 180;
+            frames.push({
+              ...frameSeed,
+              t: fallbackDuration
+            });
+            duration = fallbackDuration;
+          } else if (frames.length === 1) {
+            frames.push({
+              ...frames[0],
+              t: duration + 16
+            });
+            duration = frames[1].t;
+          }
           return { frames, cuePath, duration, cueStroke };
         };
 
@@ -28600,10 +28647,11 @@ const powerRef = useRef(hud.power);
             pottedBalls: potted,
             shotContext: shotContextRef.current
           });
-          const hasReplayFrames = (shotRecording?.frames?.length ?? 0) > 1;
+          const hasReplayFrames = (shotRecording?.frames?.length ?? 0) > 0;
           let shouldStartReplay =
             ENABLE_SHOT_REPLAY &&
             autoReplayEnabled &&
+            !skipAllReplaysRef.current &&
             Boolean(replayDecision?.shouldReplay) &&
             hasReplayFrames;
           let replayBannerText = replayDecision?.banner ?? selectReplayBanner('default');
@@ -28831,7 +28879,10 @@ const powerRef = useRef(hud.power);
           }
           replayBannerText = replayDecision.banner ?? selectReplayBanner('final');
           replayAccent = replayDecision.primaryTag ?? 'final';
-          shouldStartReplay = ENABLE_SHOT_REPLAY && autoReplayEnabled;
+          shouldStartReplay =
+            ENABLE_SHOT_REPLAY &&
+            autoReplayEnabled &&
+            !skipAllReplaysRef.current;
         }
         if (replayDecision && shotRecording) {
           shotRecording.replayTags = replayDecision.tags;
@@ -28840,6 +28891,7 @@ const powerRef = useRef(hud.power);
         shouldStartReplay =
           ENABLE_SHOT_REPLAY &&
           autoReplayEnabled &&
+          !skipAllReplaysRef.current &&
           Boolean(replayDecision?.shouldReplay) &&
           hasReplayFrames;
         const shooterSeat = currentState?.activePlayer === 'B' ? 'B' : 'A';
@@ -29307,7 +29359,12 @@ const powerRef = useRef(hud.power);
         if (!shooting && !shotRecording && !replayPlaybackRef.current && pendingRemoteReplayRef.current) {
           const pending = pendingRemoteReplayRef.current;
           pendingRemoteReplayRef.current = null;
-          if (ENABLE_SHOT_REPLAY && autoReplayEnabled && pending?.frames?.length > 1) {
+          if (
+            ENABLE_SHOT_REPLAY &&
+            autoReplayEnabled &&
+            !skipAllReplaysRef.current &&
+            pending?.frames?.length > 1
+          ) {
             shotRecording = {
               ...pending,
               startTime: pending.startTime ?? nowMs,
@@ -33469,6 +33526,28 @@ const powerRef = useRef(hud.power);
                   <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
                     Replay Controls
                   </h3>
+                  <button
+                    type="button"
+                    onClick={() => setSkipAllReplays((prev) => !prev)}
+                    aria-pressed={skipAllReplays}
+                    className={`mt-2 w-full rounded-2xl border px-4 py-2 text-left transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
+                      skipAllReplays
+                        ? 'border-emerald-300 bg-emerald-300/90 text-black shadow-[0_0_16px_rgba(16,185,129,0.55)]'
+                        : 'border-white/20 bg-white/10 text-white/80 hover:bg-white/20'
+                    }`}
+                  >
+                    <span className="flex items-center justify-between gap-2">
+                      <span className="text-[11px] font-semibold uppercase tracking-[0.28em]">
+                        Skip all replays
+                      </span>
+                      <span className="text-[10px] font-semibold uppercase tracking-[0.2em]">
+                        {skipAllReplays ? 'On' : 'Off'}
+                      </span>
+                    </span>
+                    <span className="mt-1 block text-[10px] uppercase tracking-[0.16em] text-white/60">
+                      Skip active replay playback immediately and suppress upcoming replays.
+                    </span>
+                  </button>
                   <button
                     type="button"
                     onClick={() => setAutoReplayEnabled((prev) => !prev)}


### PR DESCRIPTION
### Motivation
- Replays sometimes did not appear for very short or malformed replay recordings, causing playback to silently abort.  The menu also lacked a global "skip replays" switch that other games provide.  
- LT (carbon/fiber/matte) table variants needed stronger tonal/roughness response and crisper texture detail so materials read as rougher matte surfaces.  
- PolyHaven cloth albedo maps could bias non-green cloth tones (color cross-contamination) and must be neutralized before tinting so each cloth keeps its intended tone.

### Description
- Replay reliability: normalize and sort replay frames, coerce numeric timestamps, and synthesize a minimal second frame/fallback duration when the recording has an invalid or zero duration so playback can start. (changes in `trimReplayRecording` and related logic).  
- Skip-all-replays: added `SKIP_REPLAYS_STORAGE_KEY`, persistent `skipAllReplays` state, a menu control in the Pool Royale settings to toggle "Skip all replays", a `skipAllReplaysRef` to cancel active playback immediately, and gating checks so both local and pending-remote replays respect the skip flag.  
- Cloth/PolyHaven neutralization: call `neutralizePolyHavenColorMap` on downloaded PolyHaven cloth color maps before tinting so cloth albedo does not shift unrelated tones.  
- LT finish / matte tuning: increased matte texture generation resolution, tightened repeat, increased roughness generation and normal scale, switched magnification filter to reduce blurring, and adjusted material roughness/env map intensity to feel rougher/matte.  
- All changes are contained in `webapp/src/pages/Games/PoolRoyale.jsx` and only touch the Pool Royale client-side rendering / UI and texture generation code.

### Testing
- Ran the Pool Royale online-flow unit tests with: `npm run test -- test/poolRoyaleOnlineFlow.test.js`, and the suite passed (all tests green).  
- No browser screenshots were generated in this environment; visual verification is recommended on device/emulator for cloth/finish appearance and the new menu control behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4b05dfc2483298fe4a33832b974fa)