### PR TITLE
Tune Murlan Royale camera focus, seat overlays, and side-hand alignment

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2358,8 +2358,8 @@ const CAMERA_PLAY_FOLLOW_HOLD_MS = 420;
 const CAMERA_PLAY_NEXT_TURN_DELAY_MS = 520;
 const CAMERA_PLAY_TURN_DURATION_MS = 300;
 const CAMERA_TARGET_TURN_SNAP_DISTANCE = 0.018 * MODEL_SCALE;
-const CAMERA_PLAYER_TARGET_WEIGHT = 0.45;
-const CAMERA_SIDE_LOOK_EXTRA = 0.22 * MODEL_SCALE;
+const CAMERA_PLAYER_TARGET_WEIGHT = 0.5;
+const CAMERA_SIDE_LOOK_EXTRA = 0.32 * MODEL_SCALE;
 const CAMERA_INWARD_RADIUS_FACTOR = 0.72;
 const CAMERA_UP_TILT_FORWARD_BLEND = 0.34 * MODEL_SCALE;
 const CAMERA_UP_TILT_FORWARD_LERP = 0.14;
@@ -2367,9 +2367,9 @@ const CAMERA_UP_TILT_FORWARD_LERP = 0.14;
 const PLAYER_COLORS = ['#f97316', '#38bdf8', '#a78bfa', '#22c55e'];
 const FALLBACK_SEAT_POSITIONS = [
   { left: '50%', top: '78%' },
-  { left: '80%', top: '50%' },
-  { left: '20%', top: '50%' },
-  { left: '50%', top: '22%' }
+  { left: '74%', top: '50%' },
+  { left: '26%', top: '50%' },
+  { left: '50%', top: '16%' }
 ];
 
 const AI_NAME_TRANSLATIONS = Object.freeze({
@@ -3629,6 +3629,7 @@ export default function MurlanRoyaleArena({ search }) {
     const cardMap = three.cardMap;
     const humanTurn = state.status === 'PLAYING' && state.players[state.activePlayer]?.isHuman;
     humanTurnRef.current = humanTurn;
+    const humanSeat = seatConfigs.find((seat) => state.players[seat.seatIndex]?.isHuman) ?? null;
     state.players.forEach((player, idx) => {
       const seat = seatConfigs[idx];
       if (!seat) return;
@@ -3667,7 +3668,11 @@ export default function MurlanRoyaleArena({ search }) {
         const fanYaw = HUMAN_HAND_UNIFORM_YAW_FROM_LEFT
           ? HUMAN_HAND_FAN_MAX_YAW
           : normalizedOffset * (isHumanCard ? HUMAN_HAND_FAN_MAX_YAW : AI_HAND_FAN_MAX_YAW) * fanDirection;
-        const layoutAxis = right?.clone?.() ?? new THREE.Vector3(1, 0, 0);
+        const layoutAxis = (
+          !isHumanCard && humanSeat?.right?.lengthSq?.() > 1e-6
+            ? humanSeat.right.clone()
+            : right?.clone?.()
+        ) ?? new THREE.Vector3(1, 0, 0);
         if (layoutAxis.lengthSq() > 1e-6) {
           layoutAxis.normalize();
         } else {
@@ -3708,7 +3713,6 @@ export default function MurlanRoyaleArena({ search }) {
 
     const tableAnchor = three.tableAnchor.clone();
     const tableCount = state.tableCards.length;
-    const humanSeat = seatConfigs.find((seat) => state.players[seat.seatIndex]?.isHuman);
     const bottomCardSpacing = Math.max(humanSeat?.spacing ?? 0, COMMUNITY_CARD_SPACING);
     const bottomCardMaxSpread = Math.max(humanSeat?.maxSpread ?? 0, COMMUNITY_CARD_MAX_SPREAD);
     const tableSpread = tableCount > 1
@@ -4765,7 +4769,7 @@ export default function MurlanRoyaleArena({ search }) {
 
         const angle = CUSTOM_SEAT_ANGLES[i] ?? Math.PI / 2 - (i / CHAIR_COUNT) * Math.PI * 2;
         const isHumanSeat = Boolean(player?.isHuman);
-        const seatRadius = (isHumanSeat ? chairRadius : AI_CHAIR_RADIUS) * CHAIR_SEAT_INWARD_FACTOR;
+        const seatRadius = (isHumanSeat ? chairRadius : AI_CHAIR_RADIUS) * (isHumanSeat ? CHAIR_SEAT_INWARD_FACTOR : CHAIR_SEAT_INWARD_FACTOR * 0.97);
         const x = Math.cos(angle) * seatRadius;
         const z = Math.sin(angle) * seatRadius;
         const chairBaseHeight = CHAIR_BASE_HEIGHT - 0.04 * MODEL_SCALE;
@@ -5276,8 +5280,6 @@ export default function MurlanRoyaleArena({ search }) {
             const activePlayer = gameState.players?.[idx] ?? player;
             const anchor = seatAnchorMap.get(idx);
             const fallback = FALLBACK_SEAT_POSITIONS[idx % FALLBACK_SEAT_POSITIONS.length];
-            const isSideSeat = Boolean(anchor) && (anchor.x <= 35 || anchor.x >= 65);
-            const sideSeatTopLift = isSideSeat ? 12 : 0;
             const positionStyle = idx === humanPlayerIndex
               ? {
                   position: 'fixed',
@@ -5289,8 +5291,8 @@ export default function MurlanRoyaleArena({ search }) {
               : anchor
                 ? {
                     position: 'absolute',
-                    left: `${anchor.x}%`,
-                    top: `${clampValue(anchor.y - sideSeatTopLift, -10, 110)}%`,
+                    left: fallback.left,
+                    top: fallback.top,
                     transform: 'translate(-50%, -50%)'
                   }
                 : {


### PR DESCRIPTION
### Motivation
- Improve player avatar placement so the top avatar sits higher on portrait screens and side avatars remain at their player positions instead of drifting toward the table center.  
- Make turn-camera framing bias more pronounced to look further left/right when side players have the turn.  
- Align left/right (AI) hand card layout to match the bottom player's horizontal-style presentation for visual consistency.  

### Description
- Increased camera turn focus bias by raising `CAMERA_PLAYER_TARGET_WEIGHT` from `0.45` to `0.5` and `CAMERA_SIDE_LOOK_EXTRA` from `0.22` to `0.32 * MODEL_SCALE` to push the camera more toward the active side during turns in `webapp/src/pages/Games/MurlanRoyaleArena.jsx`.  
- Updated fallback overlay positions in `FALLBACK_SEAT_POSITIONS` so side avatars are nudged inward and top avatar is higher (`{ left: '74%', top: '50%' }`, `{ left: '26%', top: '50%' }`, `{ left: '50%', top: '16%' }`).  
- Stabilized overlay anchoring by using fixed fallback slot positions for non-human avatars (use `FALLBACK_SEAT_POSITIONS` for `left`/`top`) instead of projecting dynamic anchor positions, keeping overlays at player seats during camera motion.  
- Slightly moved AI chair placement inward by adjusting `seatRadius` for non-human seats to `CHAIR_SEAT_INWARD_FACTOR * 0.97` so side players sit a bit closer to the table center.  
- Changed non-human hand layout axis so AI/side hands use the human seat's `right` axis when available (`humanSeat.right`) instead of their own `right` vector, producing a horizontal-style hand layout consistent with the bottom player.  

All changes are in `webapp/src/pages/Games/MurlanRoyaleArena.jsx`.

### Testing
- Ran the production build with `npm --prefix webapp run build`, which completed successfully (Vite build finished and generated `dist/` assets).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4b1ade6148329a62fe634bbb79fd1)