### PR TITLE
Adjust Murlan Royale camera targeting, avatar HUD, and card layout

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -31,6 +31,7 @@ import {
   aiChooseAction,
   canBeat,
   detectCombo,
+  rankValue,
   sortHand
 } from '../../../../lib/murlan.js';
 import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
@@ -2304,8 +2305,9 @@ const HUMAN_HAND_DIRECTIONAL_LIFT = 0.05 * MODEL_SCALE;
 const HUMAN_HAND_BOTTOM_INWARD_TILT_X = THREE.MathUtils.degToRad(5);
 const AI_HAND_CARD_SPACING = HUMAN_HAND_CARD_SPACING;
 const AI_HAND_CARD_MAX_SPREAD = HUMAN_HAND_CARD_MAX_SPREAD;
-const AI_HAND_FAN_MAX_YAW = HUMAN_HAND_FAN_MAX_YAW;
-const AI_HAND_FAN_ARC_LIFT = HUMAN_HAND_FAN_ARC_LIFT;
+const AI_HAND_FAN_MAX_YAW = 0;
+const AI_HAND_FAN_ARC_LIFT = 0;
+const AI_HAND_DIRECTIONAL_LIFT = 0;
 const COMMUNITY_CARD_TOP_TILT = THREE.MathUtils.degToRad(12);
 const COMMUNITY_CARD_SCALE = 1.08;
 const COMMUNITY_CARD_SPACING = CARD_W * 1.08;
@@ -2359,7 +2361,7 @@ const CAMERA_PLAY_NEXT_TURN_DELAY_MS = 520;
 const CAMERA_PLAY_TURN_DURATION_MS = 300;
 const CAMERA_TARGET_TURN_SNAP_DISTANCE = 0.018 * MODEL_SCALE;
 const CAMERA_PLAYER_TARGET_WEIGHT = 0.45;
-const CAMERA_SIDE_LOOK_EXTRA = 0.32 * MODEL_SCALE;
+const CAMERA_SIDE_LOOK_EXTRA = 0.44 * MODEL_SCALE;
 const CAMERA_INWARD_RADIUS_FACTOR = 0.72;
 const CAMERA_UP_TILT_FORWARD_BLEND = 0.34 * MODEL_SCALE;
 const CAMERA_UP_TILT_FORWARD_LERP = 0.14;
@@ -3669,9 +3671,11 @@ export default function MurlanRoyaleArena({ search }) {
         const radial = player.isHuman ? radius : radius + AI_CARD_OUTWARD;
         const fanArcLift = isHumanCard ? HUMAN_HAND_FAN_ARC_LIFT : AI_HAND_FAN_ARC_LIFT;
         const fanDirection = HUMAN_HAND_FAN_DIRECTION;
-        const fanYaw = HUMAN_HAND_UNIFORM_YAW_FROM_LEFT
-          ? HUMAN_HAND_FAN_MAX_YAW
-          : normalizedOffset * (isHumanCard ? HUMAN_HAND_FAN_MAX_YAW : AI_HAND_FAN_MAX_YAW) * fanDirection;
+        const fanYaw = isHumanCard
+          ? (HUMAN_HAND_UNIFORM_YAW_FROM_LEFT
+              ? HUMAN_HAND_FAN_MAX_YAW
+              : normalizedOffset * HUMAN_HAND_FAN_MAX_YAW * fanDirection)
+          : normalizedOffset * AI_HAND_FAN_MAX_YAW;
         const layoutAxis = (!isHumanCard && sharedHorizontalAxis)
           ? sharedHorizontalAxis.clone()
           : (right?.clone?.() ?? new THREE.Vector3(1, 0, 0));
@@ -3683,7 +3687,11 @@ export default function MurlanRoyaleArena({ search }) {
         const target = forward.clone().multiplyScalar(radial).addScaledVector(layoutAxis, lateral);
         target.addScaledVector(forward, HUMAN_HAND_CLOSER_OFFSET);
         target.addScaledVector(layoutAxis, HUMAN_HAND_LEFT_SHIFT);
-        target.y = baseHeight + centerWeight * fanArcLift + HUMAN_HAND_BOTTOM_SHIFT_Y + HUMAN_HAND_UP_SHIFT_Y + leftWeight * HUMAN_HAND_DIRECTIONAL_LIFT;
+        target.y = baseHeight
+          + centerWeight * fanArcLift
+          + HUMAN_HAND_BOTTOM_SHIFT_Y
+          + HUMAN_HAND_UP_SHIFT_Y
+          + leftWeight * (isHumanCard ? HUMAN_HAND_DIRECTIONAL_LIFT : AI_HAND_DIRECTIONAL_LIFT);
         if (isHumanCard && selectionSet.has(card.id)) target.y += HUMAN_SELECTION_OFFSET;
         mesh.scale.setScalar(HUMAN_HAND_CARD_SCALE);
         const handLookTarget = focus.clone().addScaledVector(forward, 2.4 * MODEL_SCALE);
@@ -3730,7 +3738,11 @@ export default function MurlanRoyaleArena({ search }) {
     }
     const communityLookTarget = humanSeat?.focus?.clone().addScaledVector(humanSeat.forward, 2.4 * MODEL_SCALE)
       ?? tableLookBase.clone();
-    state.tableCards.forEach((card, idx) => {
+    const orderedTableCards =
+      state.tableCombo?.type === ComboType.STRAIGHT || state.tableCombo?.type === ComboType.STRAIGHT_FLUSH
+        ? [...state.tableCards].sort((a, b) => rankValue(a.rank, GAME_CONFIG) - rankValue(b.rank, GAME_CONFIG))
+        : state.tableCards;
+    orderedTableCards.forEach((card, idx) => {
       const entry = cardMap.get(card.id);
       if (!entry) return;
       const mesh = entry.mesh;
@@ -5295,7 +5307,11 @@ export default function MurlanRoyaleArena({ search }) {
                   ? {
                       position: 'absolute',
                       left: `${inwardAnchorX}%`,
-                      top: `${clampValue(anchor.y - sideSeatTopLift - topSeatLift, -12, 110)}%`,
+                      top: `${clampValue(
+                        anchor.y - sideSeatTopLift - topSeatLift,
+                        -12,
+                        Number.parseFloat(fallback.top) <= 30 ? 34 : 110
+                      )}%`,
                       transform: 'translate(-50%, -50%)',
                       zIndex: 24
                     }
@@ -5310,7 +5326,11 @@ export default function MurlanRoyaleArena({ search }) {
                 ? {
                     position: 'absolute',
                     left: `${inwardAnchorX}%`,
-                    top: `${clampValue(anchor.y - sideSeatTopLift - topSeatLift, -12, 110)}%`,
+                    top: `${clampValue(
+                      anchor.y - sideSeatTopLift - topSeatLift,
+                      -12,
+                      Number.parseFloat(fallback.top) <= 30 ? 34 : 110
+                    )}%`,
                     transform: 'translate(-50%, -50%)'
                   }
                 : {
@@ -5338,7 +5358,7 @@ export default function MurlanRoyaleArena({ search }) {
                   name={activePlayer?.name}
                   color={color}
                   size={avatarSize}
-                  frameScale={idx === humanPlayerIndex ? 2 : 1}
+                  frameScale={1}
                 />
                 <span className="text-[0.65rem] font-semibold uppercase tracking-wide text-white/80 drop-shadow">
                   {handCount} cards
@@ -5503,13 +5523,13 @@ export default function MurlanRoyaleArena({ search }) {
           />
         </div>
         {!isLandscapeViewport && (
-          <div className="pointer-events-none fixed bottom-[8.6rem] left-1/2 z-20 w-[min(88vw,26rem)] -translate-x-1/2 text-center">
-            <div className="rounded-2xl border border-sky-200/55 bg-[radial-gradient(circle_at_top,rgba(56,189,248,0.24),rgba(12,23,42,0.92)_60%)] px-3.5 py-2.5 shadow-[0_12px_34px_rgba(2,132,199,0.36),inset_0_1px_0_rgba(255,255,255,0.32)] backdrop-blur-[3px]">
-              <p className="text-sm font-semibold tracking-wide text-white drop-shadow-[0_2px_8px_rgba(0,0,0,0.85)]">{uiState.message}</p>
+          <div className="pointer-events-none fixed left-1/2 top-[54%] z-20 w-[min(74vw,19rem)] -translate-x-1/2 text-center">
+            <div className="rounded-xl border border-sky-200/45 bg-[radial-gradient(circle_at_top,rgba(56,189,248,0.2),rgba(12,23,42,0.9)_62%)] px-3 py-1.5 shadow-[0_10px_26px_rgba(2,132,199,0.32),inset_0_1px_0_rgba(255,255,255,0.28)] backdrop-blur-[2px]">
+              <p className="text-[0.72rem] font-semibold tracking-wide text-white drop-shadow-[0_2px_8px_rgba(0,0,0,0.85)]">{uiState.message}</p>
               {uiState.tableSummary && (
-                <p className="mt-1 text-xs font-medium tracking-wide text-sky-100 drop-shadow-[0_2px_6px_rgba(0,0,0,0.8)]">{uiState.tableSummary}</p>
+                <p className="mt-0.5 text-[0.62rem] font-medium tracking-wide text-sky-100 drop-shadow-[0_2px_6px_rgba(0,0,0,0.8)]">{uiState.tableSummary}</p>
               )}
-              {actionError && <p className="mt-1.5 text-[11px] font-semibold text-red-300 drop-shadow-[0_2px_6px_rgba(0,0,0,0.8)]">{actionError}</p>}
+              {actionError && <p className="mt-1 text-[10px] font-semibold text-red-300 drop-shadow-[0_2px_6px_rgba(0,0,0,0.8)]">{actionError}</p>}
             </div>
           </div>
         )}


### PR DESCRIPTION
### Motivation
- Improve camera side-looking to better match player requests to look more left/right when turning. 
- Stabilize avatar HUD placement so the top avatar does not drift toward the table center when looking straight. 
- Make AI player hands render as a single horizontal line like the bottom player's cards and ensure community straights display low-to-high left-to-right. 

### Description
- Increased side-look camera offset by changing `CAMERA_SIDE_LOOK_EXTRA` from `0.32 * MODEL_SCALE` to `0.44 * MODEL_SCALE` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx`. 
- Reduced AI hand fan and vertical lifting by setting `AI_HAND_FAN_MAX_YAW`, `AI_HAND_FAN_ARC_LIFT`, and `AI_HAND_DIRECTIONAL_LIFT` to `0` and updated the `fanYaw`/`target.y` calculations so side players’ cards align as a straight horizontal line. 
- Imported and used `rankValue` from `lib/murlan.js` to deterministically sort `STRAIGHT` and `STRAIGHT_FLUSH` community cards low-to-high (left-to-right) before positioning them on the table. 
- Clamped seat anchor top positioning to prevent the top avatar from sliding toward the center by tightening the `top` clamp for certain fallback positions. 
- Normalized avatar frame scaling by forcing `frameScale` to `1` for non-selected video frames so the bottom-player avatar ring/timer matches other avatars. 
- Moved and reduced the size/style of the bottom commentary/info panel so it sits under the community-card area and appears smaller on portrait mobile. 

### Testing
- Ran unit tests with `npm test -- test/murlan.test.js --runInBand` and all tests passed (`12 passed`). 
- Ran `npx eslint webapp/src/pages/Games/MurlanRoyaleArena.jsx` which produced a repository ignore warning only and no lint errors for the file itself.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4bcbdf17c832990a0173a3012e9bf)