### PR TITLE
Ground table/chairs in Chess Battle Royal and stop options from resetting on change

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -1787,6 +1787,17 @@ function alignArenaContentsToRoom(groups = [], roomHalfWidth, roomHalfDepth) {
   return new THREE.Vector3(shiftX, 0, shiftZ);
 }
 
+function groundArenaGroups(groups = [], floorY = 0) {
+  const currentFloor = computeGroupFloorY(groups);
+  const offset = floorY - currentFloor;
+  if (!Number.isFinite(offset) || Math.abs(offset) <= 1e-4) return offset;
+  groups.forEach((group) => {
+    if (!group) return;
+    group.position.y += offset;
+  });
+  return offset;
+}
+
 const CAMERA_BASE_RADIUS = Math.max(TABLE_RADIUS, BOARD_DISPLAY_SIZE / 2);
 const cameraPhiMin = clamp(
   ARENA_CAMERA_DEFAULTS.phiMin + CAMERA_PHI_OFFSET - CAMERA_TOPDOWN_EXTRA,
@@ -7055,10 +7066,9 @@ function Chess3D({
           cam.position.x += placementDelta.x;
           cam.position.z += placementDelta.z;
         });
-        const updatedFloorY = computeGroupFloorY([
-          nextTable?.group,
-          ...(arena.chairs || []).map((chair) => chair.group)
-        ]);
+        const arenaGroups = [nextTable?.group, ...(arena.chairs || []).map((chair) => chair.group)];
+        groundArenaGroups(arenaGroups, 0);
+        const updatedFloorY = computeGroupFloorY(arenaGroups);
         environmentFloorRef.current = updatedFloorY;
         arena.environmentFloorY = updatedFloorY;
         updateEnvironmentRef.current?.(hdriVariantRef.current);
@@ -7550,6 +7560,7 @@ function Chess3D({
     );
     arena.tablePlacementOffset = tablePlacementOffset.clone();
 
+    groundArenaGroups([tableInfo?.group, chairA.group, chairB.group], 0);
     const environmentFloorY = computeGroupFloorY([tableInfo?.group, chairA.group, chairB.group]);
     environmentFloorRef.current = environmentFloorY;
     arena.environmentFloorY = environmentFloorY;
@@ -9509,7 +9520,7 @@ function Chess3D({
                                 type="button"
                                 onClick={() =>
                                   setAppearance((prev) =>
-                                    normalizeAppearance({
+                                    ({
                                       ...prev,
                                       [activeCustomizationSection.key]: option.idx
                                     })


### PR DESCRIPTION
### Motivation
- Table and chair models could float relative to the HDRI grounded floor because assemblies were not snapped to a shared floor Y. 
- Changing a single customization option would sometimes trigger a full normalization that remapped other appearance fields and reset user selections.

### Description
- Added a `groundArenaGroups(groups, floorY)` helper to compute the groups' floor (`computeGroupFloorY`) and translate their Y so legs/tables sit on the floor plane. 
- Applied `groundArenaGroups(...)` after table/chair rebuilds and during initial scene setup so table and chair legs reliably touch the ground. 
- Replaced the `setAppearance` call that ran `normalizeAppearance(...)` on every option button click with a minimal update that only mutates the selected key to avoid implicit remapping of other appearance fields.
- Changes are confined to `webapp/src/pages/Games/ChessBattleRoyal.jsx` (grounding helper + usage, and option-click update behavior). 

### Testing
- Ran a production build with Vite using `npm -C webapp run build`, which completed successfully (build emitted non-blocking warnings about large chunks but no compile errors). 
- No additional automated unit tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4b913bee48329862170003bfc11d7)