### PR TITLE
Add table shape/cloth/base customization and gated UI for Chess Battle Royal

### DIFF
--- a/test/chessBattleInventoryConfig.test.js
+++ b/test/chessBattleInventoryConfig.test.js
@@ -1,0 +1,21 @@
+import {
+  CHESS_BATTLE_DEFAULT_UNLOCKS,
+  CHESS_BATTLE_STORE_ITEMS
+} from '../webapp/src/config/chessBattleInventoryConfig.js';
+
+describe('Chess Battle Royal table customization inventory', () => {
+  test('includes texas-style premium table shapes in store purchasables', () => {
+    const storeShapeIds = new Set(
+      CHESS_BATTLE_STORE_ITEMS.filter((item) => item.type === 'tableShape').map((item) => item.optionId)
+    );
+    expect(storeShapeIds.has('diamondEdge')).toBe(true);
+    expect(storeShapeIds.has('grandOval')).toBe(true);
+    expect(storeShapeIds.has('hexagonTable')).toBe(true);
+  });
+
+  test('default unlocks include octagon table shape and default cloth/base', () => {
+    expect(CHESS_BATTLE_DEFAULT_UNLOCKS.tableShape?.[0]).toBe('classicOctagon');
+    expect(CHESS_BATTLE_DEFAULT_UNLOCKS.tableCloth?.length).toBeGreaterThan(0);
+    expect(CHESS_BATTLE_DEFAULT_UNLOCKS.tableBase?.length).toBeGreaterThan(0);
+  });
+});

--- a/webapp/src/config/chessBattleInventoryConfig.js
+++ b/webapp/src/config/chessBattleInventoryConfig.js
@@ -1,5 +1,7 @@
 import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from './murlanThemes.js';
 import { MURLAN_TABLE_FINISHES } from './murlanTableFinishes.js';
+import { TABLE_CLOTH_OPTIONS, TABLE_BASE_OPTIONS } from '../utils/tableCustomizationOptions.js';
+import { TABLE_SHAPE_OPTIONS } from '../utils/murlanTable.js';
 import {
   POOL_ROYALE_DEFAULT_HDRI_ID,
   POOL_ROYALE_HDRI_VARIANTS
@@ -74,6 +76,9 @@ export const CHESS_TABLE_OPTIONS = Object.freeze([...MURLAN_TABLE_THEMES]);
 export const CHESS_BATTLE_DEFAULT_UNLOCKS = Object.freeze({
   chairColor: [CHESS_CHAIR_OPTIONS[0]?.id],
   tables: [CHESS_TABLE_OPTIONS[0]?.id],
+  tableShape: [TABLE_SHAPE_OPTIONS[0]?.id],
+  tableCloth: [TABLE_CLOTH_OPTIONS[0]?.id],
+  tableBase: [TABLE_BASE_OPTIONS[0]?.id],
   tableFinish: [MURLAN_TABLE_FINISHES[0]?.id],
   sideColor: ['amberGlow', 'mintVale'],
   boardTheme: ['classic'],
@@ -96,6 +101,24 @@ export const CHESS_BATTLE_OPTION_LABELS = Object.freeze({
   ),
   tableFinish: Object.freeze(
     MURLAN_TABLE_FINISHES.reduce((acc, option) => {
+      acc[option.id] = option.label;
+      return acc;
+    }, {})
+  ),
+  tableShape: Object.freeze(
+    TABLE_SHAPE_OPTIONS.reduce((acc, option) => {
+      acc[option.id] = option.label;
+      return acc;
+    }, {})
+  ),
+  tableCloth: Object.freeze(
+    TABLE_CLOTH_OPTIONS.reduce((acc, option) => {
+      acc[option.id] = option.label;
+      return acc;
+    }, {})
+  ),
+  tableBase: Object.freeze(
+    TABLE_BASE_OPTIONS.reduce((acc, option) => {
       acc[option.id] = option.label;
       return acc;
     }, {})
@@ -174,6 +197,36 @@ export const CHESS_BATTLE_OPTION_THUMBNAILS = Object.freeze({
 });
 
 export const CHESS_BATTLE_STORE_ITEMS = [
+  ...TABLE_SHAPE_OPTIONS.slice(1).map((shape, idx) => ({
+    id: `chess-table-shape-${shape.id}`,
+    type: 'tableShape',
+    optionId: shape.id,
+    name: shape.label,
+    price: 700 + idx * 80,
+    description: 'Switch the battle table silhouette without changing the match state.',
+    thumbnail: shape.thumbnail,
+    previewShape: 'table'
+  })),
+  ...TABLE_CLOTH_OPTIONS.slice(1).map((cloth, idx) => ({
+    id: `chess-table-cloth-${cloth.id}`,
+    type: 'tableCloth',
+    optionId: cloth.id,
+    name: cloth.label,
+    price: 360 + idx * 35,
+    description: 'Premium felt packs for supported tournament table shapes.',
+    thumbnail: cloth.thumbnail,
+    previewShape: 'table'
+  })),
+  ...TABLE_BASE_OPTIONS.slice(1).map((base, idx) => ({
+    id: `chess-table-base-${base.id}`,
+    type: 'tableBase',
+    optionId: base.id,
+    name: base.label,
+    price: 420 + idx * 35,
+    description: 'Pedestal and trim upgrades for supported tournament table shapes.',
+    thumbnail: base.thumbnail,
+    previewShape: 'table'
+  })),
   ...MURLAN_TABLE_FINISHES.map((finish, idx) => ({
     id: `chess-table-finish-${finish.id}`,
     type: 'tableFinish',
@@ -409,6 +462,9 @@ export const CHESS_BATTLE_STORE_ITEMS = [
 
 export const CHESS_BATTLE_DEFAULT_LOADOUT = [
   { type: 'tables', optionId: CHESS_TABLE_OPTIONS[0]?.id, label: CHESS_TABLE_OPTIONS[0]?.label },
+  { type: 'tableShape', optionId: TABLE_SHAPE_OPTIONS[0]?.id, label: TABLE_SHAPE_OPTIONS[0]?.label },
+  { type: 'tableCloth', optionId: TABLE_CLOTH_OPTIONS[0]?.id, label: TABLE_CLOTH_OPTIONS[0]?.label },
+  { type: 'tableBase', optionId: TABLE_BASE_OPTIONS[0]?.id, label: TABLE_BASE_OPTIONS[0]?.label },
   { type: 'chairColor', optionId: CHESS_CHAIR_OPTIONS[0]?.id, label: CHESS_CHAIR_OPTIONS[0]?.label },
   {
     type: 'tableFinish',

--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -1839,7 +1839,13 @@ const FALLBACK_FLAG = '🇺🇸';
 const DEFAULT_APPEARANCE = {
   chairColor: 0,
   tables: 0,
+  tableShape: Math.max(
+    0,
+    TABLE_SHAPE_OPTIONS.findIndex((option) => option.id === (DEFAULT_TABLE_SHAPE_OPTION?.id || 'classicOctagon'))
+  ),
+  tableCloth: 0,
   tableFinish: 0,
+  tableBase: 0,
   boardColor: 0,
   whitePieceStyle: 0,
   blackPieceStyle: 1,
@@ -1857,12 +1863,21 @@ const DEFAULT_CLOTH_OPTION = TABLE_CLOTH_OPTIONS[0];
 const DEFAULT_BASE_OPTION = TABLE_BASE_OPTIONS[0];
 const DEFAULT_TABLE_SHAPE_OPTION =
   TABLE_SHAPE_OPTIONS.find((option) => option.id !== 'diamondEdge') || TABLE_SHAPE_OPTIONS[0];
+const TABLE_SHAPE_IDS_WITH_FINISH_CONTROLS = new Set([
+  'classicOctagon',
+  'hexagonTable',
+  'grandOval',
+  'diamondEdge'
+]);
 
 const PRESERVE_NATIVE_PIECE_IDS = new Set([BEAUTIFUL_GAME_SWAP_SET_ID]);
 
 const CUSTOMIZATION_SECTIONS = [
   { key: 'tables', label: 'Table Model', options: TABLE_THEME_OPTIONS },
+  { key: 'tableShape', label: 'Table Shape', options: TABLE_SHAPE_OPTIONS },
+  { key: 'tableCloth', label: 'Table Cloth', options: TABLE_CLOTH_OPTIONS },
   { key: 'tableFinish', label: 'Table Finish', options: TABLE_FINISH_OPTIONS },
+  { key: 'tableBase', label: 'Table Base', options: TABLE_BASE_OPTIONS },
   { key: 'chairColor', label: 'Chairs', options: CHAIR_COLOR_OPTIONS },
   { key: 'environmentHdri', label: 'HDR Environment', options: CHESS_HDRI_OPTIONS }
 ];
@@ -1874,7 +1889,10 @@ function normalizeAppearance(value = {}) {
     : null;
   const entries = [
     ['tables', TABLE_THEME_OPTIONS.length],
+    ['tableShape', TABLE_SHAPE_OPTIONS.length],
+    ['tableCloth', TABLE_CLOTH_OPTIONS.length],
     ['tableFinish', TABLE_FINISH_OPTIONS.length],
+    ['tableBase', TABLE_BASE_OPTIONS.length],
     ['chairColor', CHAIR_COLOR_OPTIONS.length],
     ['environmentHdri', CHESS_HDRI_OPTIONS.length]
   ];
@@ -1892,9 +1910,13 @@ function normalizeAppearance(value = {}) {
   return normalized;
 }
 
-function getEffectiveShapeConfig() {
+function getEffectiveShapeConfig(appearanceValue = DEFAULT_APPEARANCE) {
+  const appearanceShapeIndex = Number(appearanceValue?.tableShape);
   const fallback = DEFAULT_TABLE_SHAPE_OPTION ?? TABLE_SHAPE_OPTIONS[0];
-  const requested = DEFAULT_TABLE_SHAPE_OPTION ?? fallback;
+  const requested =
+    (Number.isFinite(appearanceShapeIndex) &&
+      TABLE_SHAPE_OPTIONS[Math.max(0, Math.min(TABLE_SHAPE_OPTIONS.length - 1, Math.round(appearanceShapeIndex)))]) ||
+    fallback;
   return { option: requested ?? fallback, rotationY: 0, forced: false };
 }
 
@@ -6374,14 +6396,23 @@ function Chess3D({
   }, [viewMode]);
 
   const customizationSections = useMemo(
-    () =>
-      CUSTOMIZATION_SECTIONS.map((section) => ({
+    () => {
+      const normalized = normalizeAppearance(appearance);
+      const selectedShape = TABLE_SHAPE_OPTIONS[normalized.tableShape]?.id;
+      const showSurfaceControls = TABLE_SHAPE_IDS_WITH_FINISH_CONTROLS.has(selectedShape);
+      return CUSTOMIZATION_SECTIONS.map((section) => ({
         ...section,
         options: section.options
           .map((option, idx) => ({ ...option, idx }))
           .filter(({ id }) => isChessOptionUnlocked(section.key, id, chessInventory))
-      })).filter((section) => section.options.length > 0),
-    [chessInventory]
+      }))
+        .filter((section) => section.options.length > 0)
+        .filter((section) => {
+          if (showSurfaceControls) return true;
+          return !['tableCloth', 'tableFinish', 'tableBase'].includes(section.key);
+        });
+    },
+    [appearance, chessInventory]
   );
 
   const quickSideOptions = useMemo(
@@ -6425,7 +6456,10 @@ function Chess3D({
       const normalized = normalizeAppearance(value);
       const map = {
         tables: TABLE_THEME_OPTIONS,
+        tableShape: TABLE_SHAPE_OPTIONS,
+        tableCloth: TABLE_CLOTH_OPTIONS,
         tableFinish: TABLE_FINISH_OPTIONS,
+        tableBase: TABLE_BASE_OPTIONS,
         chairColor: CHAIR_COLOR_OPTIONS,
         environmentHdri: CHESS_HDRI_OPTIONS
       };
@@ -6487,6 +6521,29 @@ function Chess3D({
             className="absolute inset-0"
             style={{ background: `linear-gradient(135deg, ${swatches[0]}, ${swatches[1]})` }}
           />
+          <div className={overlay} />
+        </div>
+      );
+    }
+    if (key === 'tableCloth' || key === 'tableBase' || key === 'tableShape') {
+      const swatches = Array.isArray(option.swatches) && option.swatches.length >= 2
+        ? option.swatches
+        : [option.feltTop || option.baseColor || '#0f172a', option.feltBottom || option.trimColor || '#334155'];
+      return (
+        <div className={baseClass}>
+          {option.thumbnail ? (
+            <img
+              src={option.thumbnail}
+              alt={option.label || 'Table option'}
+              className="absolute inset-0 h-full w-full object-cover opacity-85"
+              loading="lazy"
+            />
+          ) : (
+            <div
+              className="absolute inset-0"
+              style={{ background: `linear-gradient(135deg, ${swatches[0]}, ${swatches[1]})` }}
+            />
+          )}
           <div className={overlay} />
         </div>
       );
@@ -6981,11 +7038,11 @@ function Chess3D({
     const isBeautifulGameSet = (arena.activePieceSetId || nextPieceSetId || '').startsWith('beautifulGame');
     const tableFinish = TABLE_FINISH_OPTIONS[normalized.tableFinish] ?? DEFAULT_TABLE_FINISH;
     const woodOption = tableFinish?.woodOption ?? DEFAULT_WOOD_OPTION;
-    const clothOption = DEFAULT_CLOTH_OPTION;
-    const baseOption = DEFAULT_BASE_OPTION;
+    const clothOption = TABLE_CLOTH_OPTIONS[normalized.tableCloth] ?? DEFAULT_CLOTH_OPTION;
+    const baseOption = TABLE_BASE_OPTIONS[normalized.tableBase] ?? DEFAULT_BASE_OPTION;
     const chairOption = CHAIR_COLOR_OPTIONS[normalized.chairColor] ?? CHAIR_COLOR_OPTIONS[0];
     const tableTheme = TABLE_THEME_OPTIONS[normalized.tables] ?? TABLE_THEME_OPTIONS[0];
-    const { option: shapeOption, rotationY } = getEffectiveShapeConfig();
+    const { option: shapeOption, rotationY } = getEffectiveShapeConfig(normalized);
     const boardTheme = palette.board ?? BEAUTIFUL_GAME_THEME;
     const pieceStyleOption = palette.pieces ?? DEFAULT_PIECE_STYLE;
     const headPreset = palette.head ?? HEAD_PRESET_OPTIONS[0].preset;
@@ -7281,7 +7338,7 @@ function Chess3D({
       const baseOption = DEFAULT_BASE_OPTION;
       const chairOption = CHAIR_COLOR_OPTIONS[normalizedAppearance.chairColor] ?? CHAIR_COLOR_OPTIONS[0];
       const tableTheme = TABLE_THEME_OPTIONS[normalizedAppearance.tables] ?? TABLE_THEME_OPTIONS[0];
-      const { option: shapeOption, rotationY } = getEffectiveShapeConfig();
+      const { option: shapeOption, rotationY } = getEffectiveShapeConfig(appearance);
       const pieceMaterials = createPieceMaterials(pieceStyleOption);
       disposers.push(() => {
         disposePieceMaterials(pieceMaterials);


### PR DESCRIPTION
### Motivation
- Provide Chess Battle Royal the same premium table silhouettes used by Texas Hold’em (diamond edge, oval, hexagon) and allow players to buy cloth and base upgrades in the store. 
- Ensure table cloth and finish controls only appear for shapes that support those surfaces and avoid full-page refresh when switching table appearance so board and pieces remain in-place.

### Description
- Extended `CHESS_BATTLE_*` inventory to include `tableShape`, `tableCloth`, and `tableBase` options, added labels and default unlocks, and added purchasable store items for table shapes, cloths and bases in `webapp/src/config/chessBattleInventoryConfig.js`.
- Added persistent appearance state fields and normalization for `tableShape`, `tableCloth`, and `tableBase`, wired them into table construction so `createMurlanStyleTable` / `buildTableFromTheme` receive the selected cloth/base and shape and materials are applied via `applyTableMaterials` in `webapp/src/pages/Games/ChessBattleRoyal.jsx`.
- Updated customization menu logic so `Table Cloth`, `Table Finish`, and `Table Base` sections are only shown when the selected shape is one of the supported shapes (`classicOctagon`, `hexagonTable`, `grandOval`, `diamondEdge`), and added previews for the new options.
- Added a focused Jest test `test/chessBattleInventoryConfig.test.js` to assert the presence of premium shapes in the Chess store and default unlocks for shape/cloth/base.

### Testing
- Ran `jest test/chessBattleInventoryConfig.test.js --runInBand` and the new test suite passed.
- A combined run of `jest test/chessBattleInventoryConfig.test.js test/inventoryCrossGameConfig.test.js --runInBand` initially failed due to an existing, unrelated cross-game default stool/chair assertion in `inventoryCrossGameConfig.test.js` and not because of the Chess changes. The focused Chess test passed after isolating the suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4d3c38b3c83298d814e647843ef61)