### PR TITLE
Pool Royale: replay fallback, cloth color fixes, and spin UI offset

### DIFF
--- a/webapp/src/config/poolRoyaleClothPresets.js
+++ b/webapp/src/config/poolRoyaleClothPresets.js
@@ -51,13 +51,13 @@ const CABAN_TONE_GROUPS = Object.freeze([
     idPrefix: 'cabanBlue',
     label: 'Blue',
     tones: ['Sky', 'Royal', 'Navy'],
-    hex: ['#4fa6f5', '#2f74d4', '#1f4e9c']
+    hex: ['#57b4ff', '#347fe6', '#2559bc']
   },
   {
     idPrefix: 'cabanGreen',
     label: 'Green',
     tones: ['Mint', 'Classic', 'Forest'],
-    hex: ['#5fc46f', '#3f9554', '#2c6e40']
+    hex: ['#66ce78', '#47a35d', '#347b4b']
   },
   {
     idPrefix: 'cabanBeige',
@@ -81,7 +81,7 @@ export const POOL_ROYALE_CLOTH_VARIANTS = Object.freeze(
     group.hex.map((hex, index) => ({
       id: `${group.idPrefix}${group.tones[index]}`,
       name: `${group.label} ${group.tones[index]}`,
-      sourceId: 'caban',
+      sourceId: `${group.idPrefix}-${group.tones[index].toLowerCase()}`,
       tone: group.label.toLowerCase(),
       baseColor: toNumber(hex),
       palette: buildPalette(hex),

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -14296,6 +14296,7 @@ function PoolRoyaleGame({
   const bottomLeftChatGiftLiftPx = 12;
   const sideActionButtonStepPx = 60;
   const rightHudShiftPx = portraitViewport ? 30 : 12;
+  const spinControllerRightOffsetPx = rightHudShiftPx + (portraitViewport ? 14 : 8);
   const bottomHudLeftPx = -56;
   const viewButtonsOffsetPx = 32;
   const viewToggleButtonDropPx = 0;
@@ -22891,10 +22892,42 @@ const powerRef = useRef(hud.power);
           }
         };
 
+        const cloneReplayBallState = (balls = []) =>
+          Array.isArray(balls)
+            ? balls.map((entry) => ({
+                ...entry,
+                pos: entry?.pos?.clone?.() ?? entry?.pos,
+                vel: entry?.vel?.clone?.() ?? entry?.vel,
+                spin: entry?.spin?.clone?.() ?? entry?.spin,
+                omega: entry?.omega?.clone?.() ?? entry?.omega
+              }))
+            : [];
+
+        const buildSyntheticReplayFrames = (recording, postShotSnapshot) => {
+          const startBalls = cloneReplayBallState(recording?.startState ?? []);
+          const postBalls = cloneReplayBallState(postShotSnapshot ?? []);
+          const fallbackStart = startBalls.length ? startBalls : postBalls;
+          const fallbackEnd = postBalls.length ? postBalls : fallbackStart;
+          if (!fallbackStart.length || !fallbackEnd.length) return [];
+          return [
+            { t: 0, balls: fallbackStart },
+            { t: 0.9, balls: fallbackEnd }
+          ];
+        };
+
         const startShotReplay = (postShotSnapshot) => {
           if (replayPlaybackRef.current) return;
-          if (!shotRecording || !shotRecording.frames?.length) return;
-          const trimmed = trimReplayRecording(shotRecording);
+          if (!shotRecording) return;
+          const hasCapturedFrames =
+            Array.isArray(shotRecording.frames) && shotRecording.frames.length > 0;
+          const recordingWithFrames = hasCapturedFrames
+            ? shotRecording
+            : {
+                ...shotRecording,
+                frames: buildSyntheticReplayFrames(shotRecording, postShotSnapshot)
+              };
+          if (!recordingWithFrames.frames?.length) return;
+          const trimmed = trimReplayRecording(recordingWithFrames);
           const duration = trimmed.duration;
           if (!Number.isFinite(duration) || duration <= 0) return;
           setReplayActive(true);
@@ -34479,7 +34512,7 @@ const powerRef = useRef(hud.power);
                 transformOrigin: 'bottom center'
               }
             : {
-                right: `${rightHudShiftPx}px`,
+                right: `${spinControllerRightOffsetPx}px`,
                 bottom: `${12 + chromeUiLiftPx + sharedHudLiftPx + spinControllerLiftPx - sharedBottomControlsDropPx}px`,
                 transform: `scale(${uiScale * 0.88})`,
                 transformOrigin: 'bottom right'


### PR DESCRIPTION
### Motivation
- Replays could show only commentary text when a shot recording lacked captured frames, so provide a visual fallback so users still see a replay.
- Blue and green table cloth tones were drifting toward each other and interfering via shared texture source; make tones distinct and isolate sources so colors don't conflict.
- The spin controller sat too close to avatar HUD elements on portrait/mobile screens and needs a subtle rightward offset to avoid overlap.

### Description
- Added `cloneReplayBallState` and `buildSyntheticReplayFrames` and updated `startShotReplay` to synthesize minimal start/end frames when `shotRecording.frames` is missing so `trimReplayRecording` and the replay pipeline still run (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Introduced `spinControllerRightOffsetPx` and applied it to the spin controller positioning so the spin control shifts slightly to the right in portrait/desktop layouts (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Tuned cloth preset palettes by brightening and clarifying blue/green hex values and assigned distinct `sourceId` values per variant to prevent cross-variant texture interference (`webapp/src/config/poolRoyaleClothPresets.js`).

### Testing
- Ran `npm --prefix webapp run build` and the build completed successfully without new runtime/build errors (Vite chunk-size warnings remained unchanged). 
- No automated unit tests were added or modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4d5aae9ec8329896bf1d75e522849)