### PR TITLE
Chess Battle Royal: add oval/diamond/hexagon tables, align cloth surface and stabilize live table swaps

### DIFF
--- a/webapp/src/config/chessBattleInventoryConfig.js
+++ b/webapp/src/config/chessBattleInventoryConfig.js
@@ -4,7 +4,7 @@ import {
   POOL_ROYALE_DEFAULT_HDRI_ID,
   POOL_ROYALE_HDRI_VARIANTS
 } from './poolRoyaleInventoryConfig.js';
-import { swatchThumbnail } from './storeThumbnails.js';
+import { polyHavenThumb, swatchThumbnail } from './storeThumbnails.js';
 
 const DEFAULT_HDRI_ID = POOL_ROYALE_DEFAULT_HDRI_ID || POOL_ROYALE_HDRI_VARIANTS[0]?.id;
 
@@ -69,7 +69,37 @@ export const CHESS_CHAIR_OPTIONS = Object.freeze([
   ...BASE_CHAIR_OPTIONS
 ]);
 
-export const CHESS_TABLE_OPTIONS = Object.freeze([...MURLAN_TABLE_THEMES]);
+const CHESS_SPECIAL_TABLE_OPTIONS = Object.freeze([
+  {
+    id: 'ovalTable',
+    label: 'Oval Table',
+    source: 'procedural',
+    price: 1120,
+    thumbnail: polyHavenThumb('modern_coffee_table_02'),
+    description: 'Oval battle table profile mirrored from Texas Hold’em table variants.'
+  },
+  {
+    id: 'diamondEdge',
+    label: 'Diamond Edge Table',
+    source: 'procedural',
+    price: 1160,
+    thumbnail: polyHavenThumb('gothic_coffee_table'),
+    description: 'Diamond-edge tournament table profile shared with Texas Hold’em.'
+  },
+  {
+    id: 'hexagonTable',
+    label: 'Hexagon Table',
+    source: 'procedural',
+    price: 1140,
+    thumbnail: polyHavenThumb('round_wooden_table_02'),
+    description: 'Hexagon battle table profile shared with Texas Hold’em.'
+  }
+]);
+
+export const CHESS_TABLE_OPTIONS = Object.freeze([
+  ...MURLAN_TABLE_THEMES,
+  ...CHESS_SPECIAL_TABLE_OPTIONS
+]);
 
 export const CHESS_BATTLE_DEFAULT_UNLOCKS = Object.freeze({
   chairColor: [CHESS_CHAIR_OPTIONS[0]?.id],

--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -1857,6 +1857,13 @@ const DEFAULT_CLOTH_OPTION = TABLE_CLOTH_OPTIONS[0];
 const DEFAULT_BASE_OPTION = TABLE_BASE_OPTIONS[0];
 const DEFAULT_TABLE_SHAPE_OPTION =
   TABLE_SHAPE_OPTIONS.find((option) => option.id !== 'diamondEdge') || TABLE_SHAPE_OPTIONS[0];
+const TABLE_STYLE_MENU_THEME_IDS = new Set(['murlan-default', 'diamondEdge', 'ovalTable', 'hexagonTable']);
+const TABLE_THEME_TO_SHAPE_ID = Object.freeze({
+  'murlan-default': 'classicOctagon',
+  ovalTable: 'grandOval',
+  diamondEdge: 'diamondEdge',
+  hexagonTable: 'hexagonTable'
+});
 
 const PRESERVE_NATIVE_PIECE_IDS = new Set([BEAUTIFUL_GAME_SWAP_SET_ID]);
 
@@ -1892,10 +1899,16 @@ function normalizeAppearance(value = {}) {
   return normalized;
 }
 
-function getEffectiveShapeConfig() {
+function getEffectiveShapeConfig(tableThemeId) {
   const fallback = DEFAULT_TABLE_SHAPE_OPTION ?? TABLE_SHAPE_OPTIONS[0];
-  const requested = DEFAULT_TABLE_SHAPE_OPTION ?? fallback;
-  return { option: requested ?? fallback, rotationY: 0, forced: false };
+  const requestedShapeId = TABLE_THEME_TO_SHAPE_ID[tableThemeId] || fallback?.id;
+  const requested =
+    TABLE_SHAPE_OPTIONS.find((option) => option.id === requestedShapeId) || fallback;
+  let rotationY = 0;
+  if (requested?.id === 'hexagonTable') rotationY = Math.PI / 6;
+  if (requested?.id === 'classicOctagon') rotationY = Math.PI / 8;
+  if (requested?.id === 'diamondEdge') rotationY = Math.PI / 4;
+  return { option: requested ?? fallback, rotationY, forced: false };
 }
 
 const DEFAULT_CHAIR_THEME = Object.freeze({ legColor: '#1f1f1f' });
@@ -6033,6 +6046,7 @@ function Chess3D({
     pixelRatioScale: RENDER_PIXEL_RATIO_SCALE
   });
   const aiMovingRef = useRef(false);
+  const tableRebuildTokenRef = useRef(0);
   const boardMaterialCacheRef = useRef({ gltf: new Map(), procedural: null });
   const pawnHeadMaterialCacheRef = useRef(new Map());
   const rankSwapAppliedRef = useRef(false);
@@ -6373,15 +6387,22 @@ function Chess3D({
     setMoveMode('click');
   }, [viewMode]);
 
+  const normalizedAppearance = useMemo(() => normalizeAppearance(appearance), [appearance]);
+  const activeTableTheme = TABLE_THEME_OPTIONS[normalizedAppearance.tables] ?? TABLE_THEME_OPTIONS[0];
+  const showTableSurfaceOptions = TABLE_STYLE_MENU_THEME_IDS.has(activeTableTheme?.id);
+
   const customizationSections = useMemo(
     () =>
-      CUSTOMIZATION_SECTIONS.map((section) => ({
-        ...section,
-        options: section.options
-          .map((option, idx) => ({ ...option, idx }))
-          .filter(({ id }) => isChessOptionUnlocked(section.key, id, chessInventory))
-      })).filter((section) => section.options.length > 0),
-    [chessInventory]
+      CUSTOMIZATION_SECTIONS
+        .filter((section) => (section.key === 'tableFinish' ? showTableSurfaceOptions : true))
+        .map((section) => ({
+          ...section,
+          options: section.options
+            .map((option, idx) => ({ ...option, idx }))
+            .filter(({ id }) => isChessOptionUnlocked(section.key, id, chessInventory))
+        }))
+        .filter((section) => section.options.length > 0),
+    [chessInventory, showTableSurfaceOptions]
   );
 
   const quickSideOptions = useMemo(
@@ -6985,7 +7006,7 @@ function Chess3D({
     const baseOption = DEFAULT_BASE_OPTION;
     const chairOption = CHAIR_COLOR_OPTIONS[normalized.chairColor] ?? CHAIR_COLOR_OPTIONS[0];
     const tableTheme = TABLE_THEME_OPTIONS[normalized.tables] ?? TABLE_THEME_OPTIONS[0];
-    const { option: shapeOption, rotationY } = getEffectiveShapeConfig();
+    const { option: shapeOption, rotationY } = getEffectiveShapeConfig(tableTheme?.id);
     const boardTheme = palette.board ?? BEAUTIFUL_GAME_THEME;
     const pieceStyleOption = palette.pieces ?? DEFAULT_PIECE_STYLE;
     const headPreset = palette.head ?? HEAD_PRESET_OPTIONS[0].preset;
@@ -6998,6 +7019,7 @@ function Chess3D({
       const rotationChanged = Math.abs((arena.tableInfo?.rotationY ?? 0) - rotationY) > 1e-3;
 
       const rebuildTable = async () => {
+        const rebuildToken = ++tableRebuildTokenRef.current;
         const { boardGroup } = arena;
         if (boardGroup && arena.tableInfo?.group) {
           arena.tableInfo.group.remove(boardGroup);
@@ -7017,6 +7039,14 @@ function Chess3D({
           textureCache: arena.textureCache,
           fallbackTexture: arena.fallbackTexture
         });
+        if (rebuildToken !== tableRebuildTokenRef.current) {
+          if (boardGroup && !boardGroup.parent && arena.tableInfo?.group) {
+            arena.tableInfo.group.add(boardGroup);
+            alignBoardGroupToTableSurface(boardGroup, arena.tableInfo);
+          }
+          nextTable?.dispose?.();
+          return;
+        }
         if (!arenaRef.current) {
           nextTable?.dispose?.();
           return;
@@ -7281,7 +7311,7 @@ function Chess3D({
       const baseOption = DEFAULT_BASE_OPTION;
       const chairOption = CHAIR_COLOR_OPTIONS[normalizedAppearance.chairColor] ?? CHAIR_COLOR_OPTIONS[0];
       const tableTheme = TABLE_THEME_OPTIONS[normalizedAppearance.tables] ?? TABLE_THEME_OPTIONS[0];
-      const { option: shapeOption, rotationY } = getEffectiveShapeConfig();
+      const { option: shapeOption, rotationY } = getEffectiveShapeConfig(tableTheme?.id);
       const pieceMaterials = createPieceMaterials(pieceStyleOption);
       disposers.push(() => {
         disposePieceMaterials(pieceMaterials);

--- a/webapp/src/utils/murlanTable.js
+++ b/webapp/src/utils/murlanTable.js
@@ -312,7 +312,12 @@ export const TABLE_SHAPE_OPTIONS = Object.freeze([
       const topShape = scaleShape2D(createRegularPolygonShape(8, radius), octagonSideStretch, 1);
       const feltShape = scaleShape2D(createRegularPolygonShape(8, radius * 0.8), octagonSideStretch, 1);
       const rimInnerShape = scaleShape2D(feltShape, 0.96, 0.96);
-      return { topShape, feltShape, rimInnerShape };
+      return {
+        topShape,
+        feltShape,
+        rimInnerShape,
+        clothRiseMultiplier: 0.82
+      };
     }
   },
   {
@@ -560,15 +565,9 @@ export function createMurlanStyleTable({
   const rimDepth = 0.06 * scaleFactor;
   const trimHeight = 0.08 * scaleFactor;
   const trimOffset = 0.06 * scaleFactor;
-  const clothRise = 0.07 * scaleFactor;
+  const defaultClothRise = 0.07 * scaleFactor;
   let baseHeight = 0.66 * scaleFactor;
-  const tableY = tableHeight - clothRise;
   const baseLift = 0.03 * scaleFactor;
-
-  const minBaseHeight = tableY > 0 ? tableY * 2 : 0;
-  if (baseHeight < minBaseHeight) {
-    baseHeight = minBaseHeight;
-  }
 
   const baseMat = includeBase
     ? new ThreeNamespace.MeshPhysicalMaterial({
@@ -624,6 +623,12 @@ export function createMurlanStyleTable({
   const feltShape = shapeData?.feltShape ?? createRegularPolygonShape(8, tableRadius * 0.8);
   const rimInnerShape = shapeData?.rimInnerShape ?? scaleShape2D(feltShape, 0.97, 0.97);
   const feltRadius = shapeData?.feltRadius ?? tableRadius * (0.72 / 0.9);
+  const clothRise = defaultClothRise * (shapeData?.clothRiseMultiplier ?? 1);
+  const tableY = tableHeight - clothRise;
+  const minBaseHeight = tableY > 0 ? tableY * 2 : 0;
+  if (baseHeight < minBaseHeight) {
+    baseHeight = minBaseHeight;
+  }
   const curveSegments = Math.max(1, Math.round((shapeOption?.curveSegments ?? 32) / 4));
 
   const outerOutline = getShapeOutlinePoints(topShape, curveSegments * 8);


### PR DESCRIPTION
### Motivation
- Expose the Texas-style procedural table shapes (oval, diamond-edge, hexagon) to Chess so players can purchase and use the same premium table profiles used by Texas Hold’em.
- Ensure the table cloth surface sits level with other table tops for the octagon-family shapes so pieces/board align visually.
- Prevent piece/board resets when the player changes the table by making the async table rebuild robust to rapid swaps.

### Description
- Added `ovalTable`, `diamondEdge`, and `hexagonTable` entries into Chess inventory so they are available to the store and unlock pipeline (`webapp/src/config/chessBattleInventoryConfig.js`).
- Mapped table theme → procedural shape and rotation by introducing `TABLE_THEME_TO_SHAPE_ID` and updating `getEffectiveShapeConfig(tableThemeId)` so selected table model drives the procedural shape resolution (`webapp/src/pages/Games/ChessBattleRoyal.jsx`).
- Show `Table Finish` / `Table Cloth` UI only when the active table theme is one of the supported procedural styles by adding `TABLE_STYLE_MENU_THEME_IDS` and filtering `CUSTOMIZATION_SECTIONS` (`webapp/src/pages/Games/ChessBattleRoyal.jsx`).
- Hardened table rebuild logic with a `tableRebuildTokenRef` and per-rebuild token check to cancel stale async rebuilds and reattach the board if the rebuild was superseded, preventing pieces from being detached/reset during quick table swaps (`webapp/src/pages/Games/ChessBattleRoyal.jsx`).
- Tuned procedural table generation to allow shape-specific cloth rise by returning a `clothRiseMultiplier` from `TABLE_SHAPE_OPTIONS` for the octagon and applying it in `createMurlanStyleTable`, so felt surface aligns with other tops while preserving the table base (`webapp/src/utils/murlanTable.js`).

### Testing
- Ran unit tests with `npm test -- test/inventoryCrossGameConfig.test.js test/texasHoldemInventoryConfig.test.js --runInBand`, where `test/texasHoldemInventoryConfig.test.js` passed and `test/inventoryCrossGameConfig.test.js` failed due to an existing cross-game default unlock mismatch unrelated to the new table entries (assertion comparing default stool/chair ids).
- Built the web app with `npm --prefix webapp run build` and the build completed successfully (Vite emitted existing chunk-size warnings only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4d3c38b3c83298d814e647843ef61)