### PR TITLE
Pool Royale: add Skip Replay, widen HUD/spin spacing, and brighten LT table finishes

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -2485,12 +2485,12 @@ function scaleWoodRepeatVector (repeatVec, scale) {
   return vec
 }
 
-const LT_CARBON_TEXTURE_REPEAT = Object.freeze({ x: 20, y: 5.2 });
+const LT_CARBON_TEXTURE_REPEAT = Object.freeze({ x: 24, y: 6.2 });
 let CARBON_FIBER_TILE_CANVAS = null;
 const CARBON_FIBER_TILE_TEXTURES = new Map();
-const LT_MATTE_PLASTIC_TEXTURE_REPEAT = Object.freeze({ x: 8.6, y: 3.2 });
+const LT_MATTE_PLASTIC_TEXTURE_REPEAT = Object.freeze({ x: 10.2, y: 3.9 });
 const LT_MATTE_PLASTIC_TEXTURES = new Map();
-const LT_FINISH_BRIGHTNESS_LIFT = 0.2;
+const LT_FINISH_BRIGHTNESS_LIFT = 0.24;
 const LT_FINISH_CONTRAST_BOOST = 1.26;
 const LT_MATTE_NORMAL_SCALE = 0.88;
 
@@ -14296,8 +14296,8 @@ function PoolRoyaleGame({
   const bottomLeftChatGiftLiftPx = 12;
   const sideActionButtonStepPx = 60;
   const rightHudShiftPx = portraitViewport ? 30 : 12;
-  const spinControllerRightOffsetPx = portraitViewport ? 8 : 6;
-  const bottomHudLeftPx = -56;
+  const spinControllerRightOffsetPx = portraitViewport ? 2 : 4;
+  const bottomHudLeftPx = -64;
   const viewButtonsOffsetPx = 32;
   const viewToggleButtonDropPx = 0;
   const sideControlsBottomPx =
@@ -33083,6 +33083,49 @@ const powerRef = useRef(hud.power);
               </button>
             </div>
             <div className="mt-4 max-h-72 space-y-4 overflow-y-auto pr-1">
+              {ENABLE_SHOT_REPLAY ? (
+                <div>
+                  <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
+                    Replay Controls
+                  </h3>
+                  <button
+                    type="button"
+                    onClick={() => skipReplayRef.current?.()}
+                    className="mt-2 w-full rounded-2xl border border-white/20 bg-white/10 px-4 py-2 text-left text-white/80 transition-all duration-200 hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300"
+                  >
+                    <span className="flex items-center justify-between gap-2">
+                      <span className="text-[11px] font-semibold uppercase tracking-[0.28em]">
+                        Skip replay now
+                      </span>
+                    </span>
+                    <span className="mt-1 block text-[10px] uppercase tracking-[0.16em] text-white/60">
+                      Immediately close the active replay and return to gameplay.
+                    </span>
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setAutoReplayEnabled((prev) => !prev)}
+                    aria-pressed={autoReplayEnabled}
+                    className={`mt-2 w-full rounded-2xl border px-4 py-2 text-left transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
+                      autoReplayEnabled
+                        ? 'border-emerald-300 bg-emerald-300/90 text-black shadow-[0_0_16px_rgba(16,185,129,0.55)]'
+                        : 'border-white/20 bg-white/10 text-white/80 hover:bg-white/20'
+                    }`}
+                  >
+                    <span className="flex items-center justify-between gap-2">
+                      <span className="text-[11px] font-semibold uppercase tracking-[0.28em]">
+                        Auto Replay
+                      </span>
+                      <span className="text-[10px] font-semibold uppercase tracking-[0.2em]">
+                        {autoReplayEnabled ? 'On' : 'Off'}
+                      </span>
+                    </span>
+                    <span className="mt-1 block text-[10px] uppercase tracking-[0.16em] text-white/60">
+                      Replays keep live graphics quality and appear on potted/foul moments.
+                    </span>
+                  </button>
+                </div>
+              ) : null}
               <div>
                 <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
                   Table Finish
@@ -33493,49 +33536,6 @@ const powerRef = useRef(hud.power);
                   })}
                 </div>
               </div>
-              {ENABLE_SHOT_REPLAY ? (
-                <div>
-                  <h3 className="text-[10px] uppercase tracking-[0.35em] text-emerald-100/70">
-                    Replay Controls
-                  </h3>
-                  <button
-                    type="button"
-                    onClick={() => skipReplayRef.current?.()}
-                    className="mt-2 w-full rounded-2xl border border-white/20 bg-white/10 px-4 py-2 text-left text-white/80 transition-all duration-200 hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300"
-                  >
-                    <span className="flex items-center justify-between gap-2">
-                      <span className="text-[11px] font-semibold uppercase tracking-[0.28em]">
-                        Skip replay now
-                      </span>
-                    </span>
-                    <span className="mt-1 block text-[10px] uppercase tracking-[0.16em] text-white/60">
-                      Immediately close the active replay and return to gameplay.
-                    </span>
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setAutoReplayEnabled((prev) => !prev)}
-                    aria-pressed={autoReplayEnabled}
-                    className={`mt-2 w-full rounded-2xl border px-4 py-2 text-left transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
-                      autoReplayEnabled
-                        ? 'border-emerald-300 bg-emerald-300/90 text-black shadow-[0_0_16px_rgba(16,185,129,0.55)]'
-                        : 'border-white/20 bg-white/10 text-white/80 hover:bg-white/20'
-                    }`}
-                  >
-                    <span className="flex items-center justify-between gap-2">
-                      <span className="text-[11px] font-semibold uppercase tracking-[0.28em]">
-                        Auto Replay
-                      </span>
-                      <span className="text-[10px] font-semibold uppercase tracking-[0.2em]">
-                        {autoReplayEnabled ? 'On' : 'Off'}
-                      </span>
-                    </span>
-                    <span className="mt-1 block text-[10px] uppercase tracking-[0.16em] text-white/60">
-                      Replays keep live graphics quality and appear on potted/foul moments.
-                    </span>
-                  </button>
-                </div>
-              ) : null}
             </div>
           </div>
         )}


### PR DESCRIPTION
### Motivation
- Make the replay skip option immediately accessible by placing the same “Skip replay now” control at the top of the Pool Royale settings menu, matching Snooker Royal UX.
- Reduce overlap between the avatar/points frame and the spin controller on portrait phones by increasing their horizontal separation.
- Improve LT (plastic/carbon) table finishes so colors and pattern density are brighter and more visible — closer to the oak veneer appearance.

### Description
- Moved the `Replay Controls` block so `Skip replay now` and `Auto Replay` are shown first in the in-game Pool Royale settings panel rather than lower in the list (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Adjusted HUD/layout offsets to increase spacing: changed `spinControllerRightOffsetPx` (portrait/default) and `bottomHudLeftPx` to push the spin controller right and nudge the bottom HUD left to reduce overlap.
- Tuned LT finish rendering constants to increase pattern density and brightness by updating `LT_CARBON_TEXTURE_REPEAT`, `LT_MATTE_PLASTIC_TEXTURE_REPEAT`, and `LT_FINISH_BRIGHTNESS_LIFT` in `PoolRoyale.jsx`.
- Removed the previous lower-copy of the Replay Controls so the single controls block appears at the top of the configuration list.

### Testing
- Built the web app with `npm -C webapp run build`, which completed successfully and produced the production bundles.
- Vite reported existing chunk-size/dynamic-import warnings during build, but the build finished normally and the change did not introduce new build failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4e223e57883299d9ac6770938a985)