### PR TITLE
Pool Royale: cue-follow action camera, immediate cushion rail cut, and replay skip toggle fix

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -14974,6 +14974,12 @@ function PoolRoyaleGame({
     }
   }, [autoReplayEnabled]);
   useEffect(() => {
+    if (!ENABLE_SHOT_REPLAY) return;
+    if (!autoReplayEnabled && replayActive) {
+      skipReplayRef.current?.();
+    }
+  }, [autoReplayEnabled, replayActive]);
+  useEffect(() => {
     if (!configOpen) return undefined;
     const handleKeyDown = (event) => {
       if (event.key === 'Escape') {
@@ -21539,20 +21545,22 @@ const powerRef = useRef(hud.power);
           });
           const preferRailOverhead = Boolean(railNormal);
           const now = performance.now();
-          const activationDelay = longShot
+          const forceImmediateRailOverhead = Boolean(railNormal);
+          const activationDelay = !forceImmediateRailOverhead && longShot
             ? now + LONG_SHOT_ACTIVATION_DELAY_MS
             : null;
-          const activationTravel = longShot
+          const activationTravel = !forceImmediateRailOverhead && longShot
             ? Math.max(
                 BALL_R * 12,
                 Math.min(travelDistance * 0.5, LONG_SHOT_ACTIVATION_TRAVEL)
               )
             : 0;
+          const beginsWithCueFollow = targetId != null;
           return {
             mode: 'action',
             cueId: cueBall.id,
             targetId: targetId ?? null,
-            stage: 'pair',
+            stage: beginsWithCueFollow ? 'followCue' : 'pair',
             exitAfterHold: false,
             resume: followView ?? null,
             orbitSnapshot,
@@ -21564,6 +21572,7 @@ const powerRef = useRef(hud.power);
               : null,
             holdUntil: null,
             hitConfirmed: false,
+            queuedPairStageAfterCueFollow: beginsWithCueFollow,
             lastCueDir: cueBall.vel.clone(),
             cueLookAhead: longShot ? BALL_R * 9 : BALL_R * 6,
             axis,
@@ -21576,7 +21585,7 @@ const powerRef = useRef(hud.power);
             travelDistance,
             activationDelay,
             activationTravel,
-            pendingActivation: longShot,
+            pendingActivation: !forceImmediateRailOverhead && longShot,
             startCuePos: new THREE.Vector2(cueBall.pos.x, cueBall.pos.y),
             targetInitialPos: targetBall
               ? new THREE.Vector2(targetBall.pos.x, targetBall.pos.y)
@@ -30791,6 +30800,22 @@ const powerRef = useRef(hud.power);
             if (cueBall.vel.lengthSq() > 1e-6) {
               activeShotView.lastCueDir = cueBall.vel.clone().normalize();
             }
+            if (
+              activeShotView.stage === 'followCue' &&
+              activeShotView.queuedPairStageAfterCueFollow &&
+              activeShotView.hitConfirmed
+            ) {
+              activeShotView.stage = 'pair';
+              activeShotView.queuedPairStageAfterCueFollow = false;
+              activeShotView.lastUpdate = now;
+              if (cameraRef.current) {
+                activeShotView.smoothedPos = cameraRef.current.position.clone();
+                const storedTarget = lastCameraTargetRef.current?.clone();
+                if (storedTarget) {
+                  activeShotView.smoothedTarget = storedTarget;
+                }
+              }
+            }
             if (activeShotView.stage === 'pair') {
               const targetBall =
                 activeShotView.targetId != null
@@ -33105,23 +33130,23 @@ const powerRef = useRef(hud.power);
                   <button
                     type="button"
                     onClick={() => setAutoReplayEnabled((prev) => !prev)}
-                    aria-pressed={autoReplayEnabled}
+                    aria-pressed={!autoReplayEnabled}
                     className={`mt-2 w-full rounded-2xl border px-4 py-2 text-left transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 ${
-                      autoReplayEnabled
+                      !autoReplayEnabled
                         ? 'border-emerald-300 bg-emerald-300/90 text-black shadow-[0_0_16px_rgba(16,185,129,0.55)]'
                         : 'border-white/20 bg-white/10 text-white/80 hover:bg-white/20'
                     }`}
                   >
                     <span className="flex items-center justify-between gap-2">
                       <span className="text-[11px] font-semibold uppercase tracking-[0.28em]">
-                        Auto Replay
+                        Skip all replays
                       </span>
                       <span className="text-[10px] font-semibold uppercase tracking-[0.2em]">
-                        {autoReplayEnabled ? 'On' : 'Off'}
+                        {autoReplayEnabled ? 'Off' : 'On'}
                       </span>
                     </span>
                     <span className="mt-1 block text-[10px] uppercase tracking-[0.16em] text-white/60">
-                      Replays keep live graphics quality and appear on potted/foul moments.
+                      Turn this on to disable automatic replay playback for every shot.
                     </span>
                   </button>
                 </div>


### PR DESCRIPTION
### Motivation
- Make the action/broadcast camera follow the cue ball first and then switch to the paired cue/target framing so broadcasts read as the user requested.
- Ensure shots that are directed at cushions (rail-directed / `railNormal`) switch to the rail-overhead broadcast immediately without long-shot activation delay/travel gating.
- Fix the replay control in the settings menu so players can actually toggle automatic replay playback and immediately skip an active replay when disabling it.

### Description
- Start action `mode: 'action'` views in a cue-follow stage when there is a target by setting `stage` to `'followCue'` and adding `queuedPairStageAfterCueFollow` to `webapp/src/pages/Games/PoolRoyale.jsx`.
- Transition from `followCue` to `pair` once the first impact is confirmed by checking `activeShotView.hitConfirmed` and flipping `stage` and smoothing state in the main update loop.
- Bypass long-shot activation delay/travel gates when `railNormal` is present by treating rail-directed shots as `forceImmediateRailOverhead` and setting `pendingActivation` false and suppressing activation delay/travel for those shots.
- Make the replay setting clearer and functional by relabeling the toggle to "Skip all replays", inverting the `aria-pressed` display logic and label text, updating the descriptive copy, and adding a `useEffect` that calls `skipReplayRef.current()` when autoplay is turned off while a replay is active.

### Testing
- Ran `npm -C webapp run build` and the production build completed successfully.
- Build produced non-blocking Vite warnings about large chunks and dynamic/static imports, which are unrelated to this change; no build errors occurred.
- No additional automated unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4ec1791288329b25b5bb914e5080d)