### PR TITLE
Remove bottom avatar green ring and preserve PolyHaven HDRI background mapping

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -639,11 +639,11 @@ async function loadPolyHavenHdriEnvironment(renderer, config = {}) {
           }
           const pmrem = new THREE.PMREMGenerator(renderer);
           pmrem.compileEquirectangularShader();
+          texture.mapping = THREE.EquirectangularReflectionMapping;
           const envMap = pmrem.fromEquirectangular(texture).texture;
           envMap.name = `${config?.assetId ?? 'polyhaven'}-env`;
-          texture.dispose();
           pmrem.dispose();
-          finish({ envMap, url });
+          finish({ envMap, url, backgroundMap: texture });
         },
         undefined,
         () => {
@@ -4008,8 +4008,16 @@ export default function MurlanRoyaleArena({ search }) {
       if (!envResult?.envMap || !three.scene) return;
       const prevDispose = disposeEnvironmentRef.current;
       const prevTexture = envTextureRef.current;
+      const prevBackground = three.environmentTexture || null;
       three.scene.environment = envResult.envMap;
-      three.scene.background = envResult.envMap;
+      three.scene.background = envResult.backgroundMap || envResult.envMap;
+      const rotationY = Number.isFinite(activeVariant?.rotationY) ? activeVariant.rotationY : 0;
+      if ('backgroundRotation' in three.scene) {
+        three.scene.backgroundRotation.set(0, rotationY, 0);
+      }
+      if ('environmentRotation' in three.scene) {
+        three.scene.environmentRotation.set(0, rotationY, 0);
+      }
       if ('backgroundIntensity' in three.scene && typeof activeVariant?.backgroundIntensity === 'number') {
         three.scene.backgroundIntensity = activeVariant.backgroundIntensity;
       }
@@ -4018,19 +4026,24 @@ export default function MurlanRoyaleArena({ search }) {
       }
       three.renderer.toneMappingExposure = activeVariant?.exposure ?? three.renderer.toneMappingExposure;
       envTextureRef.current = envResult.envMap;
+      three.environmentTexture = envResult.backgroundMap || null;
       disposeEnvironmentRef.current = () => {
         if (three.scene) {
           if (three.scene.environment === envResult.envMap) {
             three.scene.environment = null;
           }
-          if (three.scene.background === envResult.envMap) {
+          if (three.scene.background === envResult.backgroundMap || three.scene.background === envResult.envMap) {
             three.scene.background = null;
           }
         }
+        envResult.backgroundMap?.dispose?.();
         envResult.envMap.dispose?.();
       };
       if (prevDispose && prevTexture !== envResult.envMap) {
         prevDispose();
+      }
+      if (prevBackground && prevBackground !== envResult.backgroundMap) {
+        prevBackground.dispose?.();
       }
     },
     [activeHdriPolicy, resolvedHdriResolution]
@@ -5312,7 +5325,7 @@ export default function MurlanRoyaleArena({ search }) {
                 <AvatarTimer
                   index={idx}
                   photoUrl={activePlayer?.avatar}
-                  active={isTurn}
+                  active={isTurn && idx !== humanPlayerIndex}
                   isTurn={isTurn}
                   timerPct={1}
                   name={activePlayer?.name}


### PR DESCRIPTION
### Motivation
- Remove the green active ring shown around the bottom (human) avatar while keeping turn indicators for other seats to match UX expectations. 
- Preserve the original PolyHaven HDRI mapping/scale for accurate visual fidelity and ensure the arena/table is oriented to the HDRI "main view".

### Description
- Disable the avatar `active` ring for the human seat only when rendering player avatars in `MurlanRoyaleArena.jsx` so the bottom player no longer shows the green timer ring while other seats still show turn state. 
- When loading PolyHaven HDRIs, keep the original equirectangular texture as the scene `background` (set `texture.mapping = THREE.EquirectangularReflectionMapping`) and pass it through as `backgroundMap` instead of discarding it, so the original mapping and size are preserved. 
- Apply per-variant `rotationY` to background/environment rotations (when scene supports `backgroundRotation`/`environmentRotation`) so the table/arena faces the HDRI’s main view. 
- Improve environment cleanup by tracking and disposing both the PMREM-generated env map and the retained equirectangular background texture when switching environments to avoid leaking textures. 

### Testing
- Ran unit tests: `npm test -- --runInBand test/murlan.test.js`, which passed (1 test suite, 12 tests all passed). 
- Ran ESLint on the modified file with `npx eslint webapp/src/pages/Games/MurlanRoyaleArena.jsx`, which reported a file-ignore warning due to existing project ignore rules but no new lint errors in active checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4fb5525688329843dc47b4c11409e)