### PR TITLE
Pool Royale: reduce shot power, refine replay foul UX, add LT alligator table finishes

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -544,7 +544,13 @@ const TABLE_FINISH_THUMBNAILS = Object.freeze({
   carbonFiberSnakeChalkBeige: swatchThumbnail(['#45505c', '#5f6b79', '#84909e']),
   carbonFiberSnakeChalkDarkBlue: swatchThumbnail(['#6a3a31', '#8d5546', '#aa6f5c']),
   carbonFiberSnakeChalkWhite: swatchThumbnail(['#dacbb7', '#ecdecb', '#f7ede0']),
-  carbonFiberSnakeChalkDarkGreen: swatchThumbnail(['#36523f', '#4a6f56', '#6a9878'])
+  carbonFiberSnakeChalkDarkGreen: swatchThumbnail(['#36523f', '#4a6f56', '#6a9878']),
+  carbonFiberAlligatorChalk: swatchThumbnail(['#2d3a2d', '#445644', '#5f745f']),
+  carbonFiberAlligatorChalkGrey: swatchThumbnail(['#6f7667', '#8d967f', '#b3bc9f']),
+  carbonFiberAlligatorChalkBeige: swatchThumbnail(['#4c5548', '#65705f', '#85947c']),
+  carbonFiberAlligatorChalkDarkBlue: swatchThumbnail(['#5f4638', '#7a5d4a', '#9a775f']),
+  carbonFiberAlligatorChalkWhite: swatchThumbnail(['#bdb79e', '#d6cfb6', '#ebe4ce']),
+  carbonFiberAlligatorChalkDarkGreen: swatchThumbnail(['#3c4f33', '#57704a', '#76955f'])
 });
 
 const POCKET_LINER_THUMBNAILS = Object.freeze({
@@ -657,7 +663,13 @@ export const POOL_ROYALE_OPTION_LABELS = Object.freeze({
     carbonFiberSnakeChalkBeige: 'LT Dark Grey Snake',
     carbonFiberSnakeChalkDarkBlue: 'LT Burgundy Snake',
     carbonFiberSnakeChalkWhite: 'LT Milk Cream Snake',
-    carbonFiberSnakeChalkDarkGreen: 'LT Dark Green Snake'
+    carbonFiberSnakeChalkDarkGreen: 'LT Dark Green Snake',
+    carbonFiberAlligatorChalk: 'LT Black Alligator',
+    carbonFiberAlligatorChalkGrey: 'LT Grey Alligator',
+    carbonFiberAlligatorChalkBeige: 'LT Dark Grey Alligator',
+    carbonFiberAlligatorChalkDarkBlue: 'LT Burgundy Alligator',
+    carbonFiberAlligatorChalkWhite: 'LT Milk Cream Alligator',
+    carbonFiberAlligatorChalkDarkGreen: 'LT Dark Green Alligator'
   }),
   chromeColor: Object.freeze({
     chrome: 'Chrome',
@@ -879,6 +891,60 @@ export const POOL_ROYALE_STORE_ITEMS = [
     price: 1300,
     description: 'Dark-green LT snake-weave finish with matching LT color tone and weave scale.',
     thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberSnakeChalkDarkGreen
+  },
+  {
+    id: 'finish-carbonFiberAlligatorChalk',
+    type: 'tableFinish',
+    optionId: 'carbonFiberAlligatorChalk',
+    name: 'LT Black Alligator Finish',
+    price: 1310,
+    description: 'Black LT alligator-skin texture finish tuned to natural alligator tones.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberAlligatorChalk
+  },
+  {
+    id: 'finish-carbonFiberAlligatorChalkGrey',
+    type: 'tableFinish',
+    optionId: 'carbonFiberAlligatorChalkGrey',
+    name: 'LT Grey Alligator Finish',
+    price: 1320,
+    description: 'Grey LT alligator-skin texture finish tuned to natural alligator tones.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberAlligatorChalkGrey
+  },
+  {
+    id: 'finish-carbonFiberAlligatorChalkBeige',
+    type: 'tableFinish',
+    optionId: 'carbonFiberAlligatorChalkBeige',
+    name: 'LT Dark Grey Alligator Finish',
+    price: 1330,
+    description: 'Dark-grey LT alligator-skin texture finish tuned to natural alligator tones.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberAlligatorChalkBeige
+  },
+  {
+    id: 'finish-carbonFiberAlligatorChalkDarkBlue',
+    type: 'tableFinish',
+    optionId: 'carbonFiberAlligatorChalkDarkBlue',
+    name: 'LT Burgundy Alligator Finish',
+    price: 1340,
+    description: 'Burgundy LT alligator-skin texture finish tuned to natural alligator tones.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberAlligatorChalkDarkBlue
+  },
+  {
+    id: 'finish-carbonFiberAlligatorChalkWhite',
+    type: 'tableFinish',
+    optionId: 'carbonFiberAlligatorChalkWhite',
+    name: 'LT Milk Cream Alligator Finish',
+    price: 1350,
+    description: 'Milk-cream LT alligator-skin texture finish tuned to natural alligator tones.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberAlligatorChalkWhite
+  },
+  {
+    id: 'finish-carbonFiberAlligatorChalkDarkGreen',
+    type: 'tableFinish',
+    optionId: 'carbonFiberAlligatorChalkDarkGreen',
+    name: 'LT Dark Green Alligator Finish',
+    price: 1360,
+    description: 'Dark-green LT alligator-skin texture finish tuned to natural alligator tones.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberAlligatorChalkDarkGreen
   },
   {
     id: 'chrome-chrome',

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1815,7 +1815,7 @@ const SPIN_AFTER_IMPACT_DEFLECTION_SCALE = 0; // disable preview-only spin defle
 // Pool Royale pace now mirrors Snooker Royale to keep ball travel identical between modes.
 // Apply an extra 15% reduction to keep Pool Royale strokes slightly softer than Snooker Royal.
 const SHOT_POWER_REDUCTION = 0.425;
-const SHOT_POWER_MULTIPLIER = 2.109375;
+const SHOT_POWER_MULTIPLIER = 1.79296875; // reduce total shot power by 15%
 const SHOT_POWER_INCREASE = 1.5; // match Snooker Royale standard shot lift
 const SHOT_POWER_ADJUSTMENT = 0.72; // reduce overall Pool Royale power by an additional 20%
 const SHOT_POWER_BOOST = 1.5; // increase overall shot power by 25%
@@ -3463,6 +3463,78 @@ const TABLE_FINISHES = Object.freeze({
     disableWoodPattern: true,
     surfaceStyle: 'matte',
     useBrandCarbonTexture: false
+  }),
+  carbonFiberAlligatorChalk: createStandardWoodFinish({
+    id: 'carbonFiberAlligatorChalk',
+    label: 'LT Black Alligator',
+    rail: 0x3a4a39,
+    base: 0x3a4a39,
+    trim: 0x3a4a39,
+    woodTextureId: 'plastic_monoblock_lt_black_alligator',
+    woodRepeatScale: 1,
+    disableWoodPattern: true,
+    surfaceStyle: 'matte',
+    useBrandCarbonTexture: false
+  }),
+  carbonFiberAlligatorChalkGrey: createStandardWoodFinish({
+    id: 'carbonFiberAlligatorChalkGrey',
+    label: 'LT Grey Alligator',
+    rail: 0x8b927e,
+    base: 0x8b927e,
+    trim: 0x8b927e,
+    woodTextureId: 'plastic_monoblock_lt_grey_alligator',
+    woodRepeatScale: 1,
+    disableWoodPattern: true,
+    surfaceStyle: 'matte',
+    useBrandCarbonTexture: false
+  }),
+  carbonFiberAlligatorChalkBeige: createStandardWoodFinish({
+    id: 'carbonFiberAlligatorChalkBeige',
+    label: 'LT Dark Grey Alligator',
+    rail: 0x65705f,
+    base: 0x65705f,
+    trim: 0x65705f,
+    woodTextureId: 'plastic_monoblock_lt_dark_grey_alligator',
+    woodRepeatScale: 1,
+    disableWoodPattern: true,
+    surfaceStyle: 'matte',
+    useBrandCarbonTexture: false
+  }),
+  carbonFiberAlligatorChalkDarkBlue: createStandardWoodFinish({
+    id: 'carbonFiberAlligatorChalkDarkBlue',
+    label: 'LT Burgundy Alligator',
+    rail: 0x7a5d4a,
+    base: 0x7a5d4a,
+    trim: 0x7a5d4a,
+    woodTextureId: 'plastic_monoblock_lt_burgundy_alligator',
+    woodRepeatScale: 1,
+    disableWoodPattern: true,
+    surfaceStyle: 'matte',
+    useBrandCarbonTexture: false
+  }),
+  carbonFiberAlligatorChalkWhite: createStandardWoodFinish({
+    id: 'carbonFiberAlligatorChalkWhite',
+    label: 'LT Milk Cream Alligator',
+    rail: 0xd6cfb6,
+    base: 0xd6cfb6,
+    trim: 0xd6cfb6,
+    woodTextureId: 'plastic_monoblock_lt_milk_cream_alligator',
+    woodRepeatScale: 1,
+    disableWoodPattern: true,
+    surfaceStyle: 'matte',
+    useBrandCarbonTexture: false
+  }),
+  carbonFiberAlligatorChalkDarkGreen: createStandardWoodFinish({
+    id: 'carbonFiberAlligatorChalkDarkGreen',
+    label: 'LT Dark Green Alligator',
+    rail: 0x57704a,
+    base: 0x57704a,
+    trim: 0x57704a,
+    woodTextureId: 'plastic_monoblock_lt_dark_green_alligator',
+    woodRepeatScale: 1,
+    disableWoodPattern: true,
+    surfaceStyle: 'matte',
+    useBrandCarbonTexture: false
   })
 });
 
@@ -3487,7 +3559,13 @@ const TABLE_FINISH_OPTIONS = Object.freeze(
     TABLE_FINISHES.carbonFiberSnakeChalkBeige,
     TABLE_FINISHES.carbonFiberSnakeChalkDarkBlue,
     TABLE_FINISHES.carbonFiberSnakeChalkWhite,
-    TABLE_FINISHES.carbonFiberSnakeChalkDarkGreen
+    TABLE_FINISHES.carbonFiberSnakeChalkDarkGreen,
+    TABLE_FINISHES.carbonFiberAlligatorChalk,
+    TABLE_FINISHES.carbonFiberAlligatorChalkGrey,
+    TABLE_FINISHES.carbonFiberAlligatorChalkBeige,
+    TABLE_FINISHES.carbonFiberAlligatorChalkDarkBlue,
+    TABLE_FINISHES.carbonFiberAlligatorChalkWhite,
+    TABLE_FINISHES.carbonFiberAlligatorChalkDarkGreen
   ].filter(Boolean)
 );
 
@@ -6132,7 +6210,7 @@ const BREAK_DICE_ROLL_SOUND_URL = '/assets/sounds/u_qpfzpydtro-dice-142528.mp3';
 const REPLAY_CUE_MIN_PULLBACK_MS = 0; // defer to recorded cue pullback like Snooker Royal
 const REPLAY_CUE_MIN_RELEASE_MS = 0; // defer to recorded stroke durations like Snooker Royal
 const REPLAY_FOUL_WRONG_BALL_IMPACT_WINDOW_MS = 220;
-const REPLAY_FOUL_WRONG_BALL_IMPACT_SLOW_FACTOR = 0.35;
+const REPLAY_FOUL_WRONG_BALL_IMPACT_SLOW_FACTOR = 0.72; // slight slow-motion on foul impact
 const CUE_STROKE_POST_HIT_CAMERA_HOLD_MS = 90; // shorten post-hit hold so rail-overhead broadcast can engage earlier
 // Keep the live stroke timing aligned with the reference cue motion:
 // quick push forward and a short hold before snapping back to idle.
@@ -15168,6 +15246,7 @@ function PoolRoyaleGame({
   const shotReplayRef = useRef(null);
   const replayPlaybackRef = useRef(null);
   const [replayBanner, setReplayBanner] = useState(null);
+  const [replayBannerAccent, setReplayBannerAccent] = useState('good');
   const replayBannerTimeoutRef = useRef(null);
   const [trainingPenaltyPopup, setTrainingPenaltyPopup] = useState(null);
   const trainingPenaltyPopupTimeoutRef = useRef(null);
@@ -23002,6 +23081,10 @@ const powerRef = useRef(hud.power);
             duration,
             startedAt: performance.now(),
             lastIndex: 0,
+            replayFoul: shotRecording?.replayFoul ?? null,
+            firstCueImpactMs: Number.isFinite(shotRecording?.firstCueImpactMs)
+              ? shotRecording.firstCueImpactMs
+              : null,
             postState: postShotSnapshot,
             pocketDrops: pausedPocketDrops ?? pocketDropRef.current
           };
@@ -28912,8 +28995,8 @@ const powerRef = useRef(hud.power);
             : null;
         }
         const shotWasFoul = Boolean(safeState?.foul);
-        if (shotWasFoul && (shotRecording?.frames?.length ?? 0) > 1) {
-          const foulBanner = 'Foul';
+        if (shotWasFoul && (shotRecording?.frames?.length ?? 0) > 0) {
+          const foulBanner = 'Faul';
           if (replayDecision) {
             const replayTags = new Set(replayDecision.tags ?? []);
             replayTags.add('foul');
@@ -28921,8 +29004,8 @@ const powerRef = useRef(hud.power);
               ...replayDecision,
               tags: Array.from(replayTags),
               shouldReplay: true,
-              banner: replayDecision.banner ?? foulBanner,
-              primaryTag: replayDecision.primaryTag ?? 'foul'
+              banner: foulBanner,
+              primaryTag: 'foul'
             };
           } else {
             replayDecision = {
@@ -28933,8 +29016,8 @@ const powerRef = useRef(hud.power);
               primaryTag: 'foul'
             };
           }
-          replayBannerText = replayDecision.banner ?? foulBanner;
-          replayAccent = replayDecision.primaryTag ?? 'foul';
+          replayBannerText = foulBanner;
+          replayAccent = 'foul';
         }
         const isFinalShot =
           Boolean(safeState?.frameOver) && (shotRecording?.frames?.length ?? 0) > 1;
@@ -29247,6 +29330,7 @@ const powerRef = useRef(hud.power);
             const launchReplay = () => {
               replayBannerTimeoutRef.current = null;
               setReplayBanner(null);
+              setReplayBannerAccent('good');
               const slateLead = triggerReplaySlate(replayBannerText, { accent: replayAccent });
               const beginReplay = () => {
                 shotRecording = recordingForReplay;
@@ -29268,11 +29352,13 @@ const powerRef = useRef(hud.power);
               replayBannerTimeoutRef.current = null;
             }
             setReplayBanner(replayBannerText);
+            setReplayBannerAccent(replayAccent === 'foul' ? 'foul' : 'good');
             replayBannerTimeoutRef.current = window.setTimeout(
               launchReplay,
               GOOD_SHOT_REPLAY_DELAY_MS
             );
           } else {
+            setReplayBannerAccent('good');
             shotReplayRef.current = null;
             shotRecording = null;
           }
@@ -29358,7 +29444,23 @@ const powerRef = useRef(hud.power);
             return;
           }
           try {
-            const targetTime = Math.min(elapsed, duration);
+            let targetTime = Math.min(elapsed, duration);
+            if (playback.replayFoul && Number.isFinite(playback.firstCueImpactMs)) {
+              const impactAt = playback.firstCueImpactMs;
+              const halfWindow = REPLAY_FOUL_WRONG_BALL_IMPACT_WINDOW_MS * 0.5;
+              const slowStart = Math.max(0, impactAt - halfWindow);
+              const slowEnd = Math.min(duration, impactAt + halfWindow);
+              if (targetTime > slowStart) {
+                const span = Math.max(slowEnd - slowStart, 1e-6);
+                const capped = Math.min(targetTime, slowEnd);
+                const slowedSection =
+                  (capped - slowStart) * REPLAY_FOUL_WRONG_BALL_IMPACT_SLOW_FACTOR;
+                targetTime =
+                  slowStart +
+                  slowedSection +
+                  Math.max(0, targetTime - slowEnd);
+              }
+            }
             let frameIndex = playback.lastIndex ?? 0;
             while (frameIndex < frames.length - 1 && frames[frameIndex + 1].t <= targetTime) {
               frameIndex += 1;
@@ -29391,7 +29493,8 @@ const powerRef = useRef(hud.power);
               cueStick.position.y = Math.max(cueStick.position.y, CUE_Y + BALL_R * 0.06);
             }
             renderer.render(scene, frameCamera ?? camera);
-            const finished = elapsed >= duration || elapsed - duration >= REPLAY_TIMEOUT_GRACE_MS;
+            const finished =
+              targetTime >= duration || elapsed - duration >= REPLAY_TIMEOUT_GRACE_MS;
             if (finished) {
               finishReplayPlayback(playback);
             }
@@ -32768,24 +32871,21 @@ const powerRef = useRef(hud.power);
 
       {replayBanner && (
         <div className="pointer-events-none absolute top-4 right-4 z-50">
-          <div
-            className="flex items-center gap-2 rounded-full bg-gradient-to-r from-emerald-300 to-cyan-300 px-5 py-2 text-xs font-bold uppercase tracking-[0.28em] text-slate-900 shadow-[0_12px_32px_rgba(0,0,0,0.45)] ring-2 ring-white/30"
+          <p
+            className={`text-xs font-black uppercase tracking-[0.3em] drop-shadow-[0_2px_12px_rgba(0,0,0,0.6)] ${
+              replayBannerAccent === 'foul' ? 'text-red-500' : 'text-emerald-400'
+            }`}
             aria-live="polite"
           >
-            <span className="drop-shadow-[0_1px_2px_rgba(255,255,255,0.35)]">
-              {replayBanner}
-            </span>
-          </div>
+            {replayBanner}
+          </p>
         </div>
       )}
       {replaySlate && (
         <div className="pointer-events-none absolute inset-0 z-[105] flex items-center justify-center">
-          <div className="rounded-2xl border border-white/35 bg-black/72 px-8 py-5 text-center shadow-[0_22px_48px_rgba(0,0,0,0.6)] backdrop-blur-sm">
-            <p className="text-[10px] font-semibold uppercase tracking-[0.34em] text-white/70">Replay frame</p>
-            <p className="mt-2 text-2xl font-black uppercase tracking-[0.2em] text-white">
-              {replaySlate.label || 'Replay'}
-            </p>
-          </div>
+          <p className="text-2xl font-black uppercase tracking-[0.2em] text-white drop-shadow-[0_8px_24px_rgba(0,0,0,0.75)]">
+            {replaySlate.label || 'Replay'}
+          </p>
         </div>
       )}
       {ruleToast && (
@@ -33079,23 +33179,13 @@ const powerRef = useRef(hud.power);
       )}
 
       {replayActive && (
-        <div className="pointer-events-none absolute inset-0 z-40">
-          <div className="absolute inset-0 rounded-[28px] border border-white/12 shadow-[0_0_32px_rgba(0,0,0,0.55),0_0_0_8px_rgba(0,0,0,0.45)]" />
-          <div className="absolute inset-0 rounded-[28px] bg-gradient-to-b from-black/55 via-transparent to-black/55" />
-          <div className="absolute inset-x-10 top-6 h-px bg-gradient-to-r from-transparent via-white/35 to-transparent" />
-          <div className="absolute inset-x-10 bottom-6 h-px bg-gradient-to-r from-transparent via-white/35 to-transparent" />
-        </div>
-      )}
-      {replayActive && (
         <>
           <div className="pointer-events-none absolute left-4 top-4 z-50">
             <div className="rounded-full border border-white/25 bg-black/70 px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.34em] text-white shadow-[0_12px_32px_rgba(0,0,0,0.45)]">
               Replay
             </div>
             {replayFoul && (
-              <div className="mt-2 rounded-full border border-red-300/70 bg-red-500/30 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.28em] text-red-100 shadow-[0_10px_28px_rgba(0,0,0,0.45)]">
-                Foul{replayFoul.reason ? `: ${replayFoul.reason}` : ''}
-              </div>
+              <p className="mt-2 text-[12px] font-black uppercase tracking-[0.28em] text-red-500 drop-shadow-[0_2px_10px_rgba(0,0,0,0.55)]">Faul</p>
             )}
           </div>
           <div className="pointer-events-auto absolute right-8 top-1/2 z-50 flex -translate-y-1/2 items-center">

--- a/webapp/src/utils/woodMaterials.js
+++ b/webapp/src/utils/woodMaterials.js
@@ -446,6 +446,27 @@ const makeInlinePlasticSnakePattern = ({ id, base = '#2b2f36', sheen = '#3f4652'
 </svg>`);
   return { mapUrl: pattern, roughnessMapUrl: null, normalMapUrl: null };
 };
+
+const makeInlinePlasticAlligatorPattern = ({ id, base = '#4a5b3b', sheen = '#6d8157' }) => {
+  const pattern = svgDataUrl(`
+<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256">
+  <defs>
+    <linearGradient id="${id}-plastic" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="${base}"/>
+      <stop offset="45%" stop-color="${sheen}"/>
+      <stop offset="100%" stop-color="${base}"/>
+    </linearGradient>
+    <pattern id="${id}-gator" patternUnits="userSpaceOnUse" width="72" height="72">
+      <path d="M8 8 H36 Q44 8 44 16 V34 Q44 42 36 42 H8 Q0 42 0 34 V16 Q0 8 8 8Z" fill="none" stroke="#ffffff" stroke-opacity="0.11" stroke-width="2"/>
+      <path d="M48 20 H64 Q72 20 72 28 V52 Q72 60 64 60 H48 Q40 60 40 52 V28 Q40 20 48 20Z" fill="none" stroke="#000000" stroke-opacity="0.16" stroke-width="2"/>
+      <path d="M6 48 H30 Q38 48 38 56 V70 H6 Q0 70 0 64 V56 Q0 48 6 48Z" fill="none" stroke="#ffffff" stroke-opacity="0.08" stroke-width="1.8"/>
+    </pattern>
+  </defs>
+  <rect width="256" height="256" fill="url(#${id}-plastic)"/>
+  <rect width="256" height="256" fill="url(#${id}-gator)"/>
+</svg>`);
+  return { mapUrl: pattern, roughnessMapUrl: null, normalMapUrl: null };
+};
 const makeInlineCarbonFiberPattern = ({ id }) => {
   if (typeof document !== 'undefined') {
     const canvas = document.createElement('canvas');
@@ -661,6 +682,48 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
         sheen: '#3d6148'
       })
     }
+  }),
+  Object.freeze({
+    id: 'plastic_monoblock_lt_black_alligator',
+    label: 'LT Black Alligator',
+    source: 'TonPlaygram molded-plastic satin alligator texture (LT Black)',
+    rail: { repeat: { x: 7, y: 7 }, rotation: 0, textureSize: 2048, ...makeInlinePlasticAlligatorPattern({ id: 'plastic-monoblock-lt-black-alligator-rail', base: '#1f2a1f', sheen: '#344535' }) },
+    frame: { repeat: { x: 7, y: 7 }, rotation: 0, textureSize: 2048, ...makeInlinePlasticAlligatorPattern({ id: 'plastic-monoblock-lt-black-alligator-frame', base: '#1f2a1f', sheen: '#344535' }) }
+  }),
+  Object.freeze({
+    id: 'plastic_monoblock_lt_grey_alligator',
+    label: 'LT Grey Alligator',
+    source: 'TonPlaygram molded-plastic satin alligator texture (LT Grey)',
+    rail: { repeat: { x: 7, y: 7 }, rotation: 0, textureSize: 2048, ...makeInlinePlasticAlligatorPattern({ id: 'plastic-monoblock-lt-grey-alligator-rail', base: '#6f7667', sheen: '#8d967f' }) },
+    frame: { repeat: { x: 7, y: 7 }, rotation: 0, textureSize: 2048, ...makeInlinePlasticAlligatorPattern({ id: 'plastic-monoblock-lt-grey-alligator-frame', base: '#6f7667', sheen: '#8d967f' }) }
+  }),
+  Object.freeze({
+    id: 'plastic_monoblock_lt_dark_grey_alligator',
+    label: 'LT Dark Grey Alligator',
+    source: 'TonPlaygram molded-plastic satin alligator texture (LT Dark Grey)',
+    rail: { repeat: { x: 7, y: 7 }, rotation: 0, textureSize: 2048, ...makeInlinePlasticAlligatorPattern({ id: 'plastic-monoblock-lt-dark-grey-alligator-rail', base: '#4c5548', sheen: '#65705f' }) },
+    frame: { repeat: { x: 7, y: 7 }, rotation: 0, textureSize: 2048, ...makeInlinePlasticAlligatorPattern({ id: 'plastic-monoblock-lt-dark-grey-alligator-frame', base: '#4c5548', sheen: '#65705f' }) }
+  }),
+  Object.freeze({
+    id: 'plastic_monoblock_lt_burgundy_alligator',
+    label: 'LT Burgundy Alligator',
+    source: 'TonPlaygram molded-plastic satin alligator texture (LT Burgundy)',
+    rail: { repeat: { x: 7, y: 7 }, rotation: 0, textureSize: 2048, ...makeInlinePlasticAlligatorPattern({ id: 'plastic-monoblock-lt-burgundy-alligator-rail', base: '#5f4638', sheen: '#7a5d4a' }) },
+    frame: { repeat: { x: 7, y: 7 }, rotation: 0, textureSize: 2048, ...makeInlinePlasticAlligatorPattern({ id: 'plastic-monoblock-lt-burgundy-alligator-frame', base: '#5f4638', sheen: '#7a5d4a' }) }
+  }),
+  Object.freeze({
+    id: 'plastic_monoblock_lt_milk_cream_alligator',
+    label: 'LT Milk Cream Alligator',
+    source: 'TonPlaygram molded-plastic satin alligator texture (LT Milk Cream)',
+    rail: { repeat: { x: 7, y: 7 }, rotation: 0, textureSize: 2048, ...makeInlinePlasticAlligatorPattern({ id: 'plastic-monoblock-lt-milk-cream-alligator-rail', base: '#bdb79e', sheen: '#d6cfb6' }) },
+    frame: { repeat: { x: 7, y: 7 }, rotation: 0, textureSize: 2048, ...makeInlinePlasticAlligatorPattern({ id: 'plastic-monoblock-lt-milk-cream-alligator-frame', base: '#bdb79e', sheen: '#d6cfb6' }) }
+  }),
+  Object.freeze({
+    id: 'plastic_monoblock_lt_dark_green_alligator',
+    label: 'LT Dark Green Alligator',
+    source: 'TonPlaygram molded-plastic satin alligator texture (LT Dark Green)',
+    rail: { repeat: { x: 7, y: 7 }, rotation: 0, textureSize: 2048, ...makeInlinePlasticAlligatorPattern({ id: 'plastic-monoblock-lt-dark-green-alligator-rail', base: '#3c4f33', sheen: '#57704a' }) },
+    frame: { repeat: { x: 7, y: 7 }, rotation: 0, textureSize: 2048, ...makeInlinePlasticAlligatorPattern({ id: 'plastic-monoblock-lt-dark-green-alligator-frame', base: '#3c4f33', sheen: '#57704a' }) }
   }),
   Object.freeze({
     id: 'acg_birch_studio',


### PR DESCRIPTION
### Motivation
- Make replay comments plain text and ensure fouls produce a clearly visible replay with a red `Faul` label. 
- Add a subtle slow-motion emphasis around foul impacts to make faults clearer to players. 
- Introduce additional LT rail/frame finishes with an alligator-skin texture family to expand cosmetic options and match snake-style finishes. 
- Soften gameplay by reducing overall shot power to improve mobile/portrait feel and parity with Snooker Royale.

### Description
- Reduced shot strength by lowering the core multiplier (`SHOT_POWER_MULTIPLIER`) to apply an overall ~15% power reduction and adjusted related shot constants used to compute `SHOT_BASE_SPEED` and derived values (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Reworked replay UI and flow so replay comments render as plain text (removed framed slate/banner containers), added `replayBannerAccent` state, standardized foul banner text to `Faul`, and kept non-foul comments green (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Ensured fouls always mark recordings for replay and flow into the replay decision logic, added a slight slow-motion window around the recorded first cue impact by adjusting replay `targetTime` during playback, and carried `replayFoul` / `firstCueImpactMs` into the `replayPlayback` object (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Added a procedural alligator-skin SVG generator and six new LT alligator texture entries in `WOOD_GRAIN_OPTIONS`, created corresponding `TABLE_FINISHES` entries, and updated inventory labels, thumbnails and store items for the six new finishes (`webapp/src/utils/woodMaterials.js`, `webapp/src/pages/Games/PoolRoyale.jsx`, `webapp/src/config/poolRoyaleInventoryConfig.js`).

### Testing
- Ran the production build with `npm -C webapp run build`, which completed successfully. 
- No unit/integration tests were modified; the change set was validated by the successful Vite production build (bundle warnings about chunk size are unrelated to these changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4fe023fa08329b219962eeedf8257)