### PR TITLE
Tweak AI pot/selection logic, fix replay foul timing & detection, add alligator table finishes/textures

### DIFF
--- a/lib/poolUkAdvancedAi.js
+++ b/lib/poolUkAdvancedAi.js
@@ -56,8 +56,9 @@
  * Each entry: { success:number, attempts:number }
  */
 const shotMemory = new Map()
-const MIN_POT_PROBABILITY = 0.36
+const MIN_POT_PROBABILITY = 0.42
 const STRAIGHT_SHOT_THRESHOLD = Math.PI / 12 // ~15 degrees
+const AI_POT_CONFIDENCE_EXPONENT = 1.2
 
 function normaliseColourKey (input) {
   const value = typeof input === 'string' ? input : input?.colour
@@ -789,7 +790,8 @@ function evaluateCandidates (state, colour, candidates) {
       const straightBoost = typeof c.angle === 'number' ? Math.max(0, (Math.PI / 10 - c.angle) / (Math.PI / 10)) * 0.25 : 0
       const positionWeight = 1.4
       const shapeWindow = nextShapeWindow(nextState, colour)
-      EV = Ppot * (baseValue + nextBest * positionWeight + straightBoost + shapeWindow * 0.75) - riskPenalty(risk)
+      const confidentPot = Math.pow(Ppot, AI_POT_CONFIDENCE_EXPONENT)
+      EV = confidentPot * (baseValue + nextBest * positionWeight + straightBoost + shapeWindow * 0.75) - riskPenalty(risk)
     }
     if (!best || EV > best.EV) {
       best = { c, EV }
@@ -803,7 +805,7 @@ function chooseBestAction (state, colour) {
   // explored when every straight look is blocked so the AI plays bank/kick
   // shots as a last resort rather than by default.
   const directPots = generatePotCandidates(state, colour)
-  const cleanDirect = directPots.filter(c => (c.laneClearance ?? 1) >= 0.7)
+  const cleanDirect = directPots.filter(c => (c.laneClearance ?? 1) >= 0.75)
   let candidates = cleanDirect.length > 0 ? [...cleanDirect] : [...directPots]
   const kicks = generateKickCandidates(state, colour, 4)
 

--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -544,7 +544,13 @@ const TABLE_FINISH_THUMBNAILS = Object.freeze({
   carbonFiberSnakeChalkBeige: swatchThumbnail(['#45505c', '#5f6b79', '#84909e']),
   carbonFiberSnakeChalkDarkBlue: swatchThumbnail(['#6a3a31', '#8d5546', '#aa6f5c']),
   carbonFiberSnakeChalkWhite: swatchThumbnail(['#dacbb7', '#ecdecb', '#f7ede0']),
-  carbonFiberSnakeChalkDarkGreen: swatchThumbnail(['#36523f', '#4a6f56', '#6a9878'])
+  carbonFiberSnakeChalkDarkGreen: swatchThumbnail(['#36523f', '#4a6f56', '#6a9878']),
+  carbonFiberAlligatorOlive: swatchThumbnail(['#45573a', '#62774f', '#87996d']),
+  carbonFiberAlligatorSwamp: swatchThumbnail(['#2e4733', '#3f5f46', '#5f7c64']),
+  carbonFiberAlligatorClay: swatchThumbnail(['#5c4939', '#7a624d', '#a3876d']),
+  carbonFiberAlligatorSand: swatchThumbnail(['#786850', '#98856a', '#bba88a']),
+  carbonFiberAlligatorMoss: swatchThumbnail(['#3f4f3c', '#5a6b54', '#7f9075']),
+  carbonFiberAlligatorNight: swatchThumbnail(['#253128', '#36443a', '#566258'])
 });
 
 const POCKET_LINER_THUMBNAILS = Object.freeze({
@@ -657,7 +663,13 @@ export const POOL_ROYALE_OPTION_LABELS = Object.freeze({
     carbonFiberSnakeChalkBeige: 'LT Dark Grey Snake',
     carbonFiberSnakeChalkDarkBlue: 'LT Burgundy Snake',
     carbonFiberSnakeChalkWhite: 'LT Milk Cream Snake',
-    carbonFiberSnakeChalkDarkGreen: 'LT Dark Green Snake'
+    carbonFiberSnakeChalkDarkGreen: 'LT Dark Green Snake',
+    carbonFiberAlligatorOlive: 'LT Olive Alligator',
+    carbonFiberAlligatorSwamp: 'LT Swamp Alligator',
+    carbonFiberAlligatorClay: 'LT Clay Alligator',
+    carbonFiberAlligatorSand: 'LT Sand Alligator',
+    carbonFiberAlligatorMoss: 'LT Moss Alligator',
+    carbonFiberAlligatorNight: 'LT Night Alligator'
   }),
   chromeColor: Object.freeze({
     chrome: 'Chrome',
@@ -879,6 +891,60 @@ export const POOL_ROYALE_STORE_ITEMS = [
     price: 1300,
     description: 'Dark-green LT snake-weave finish with matching LT color tone and weave scale.',
     thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberSnakeChalkDarkGreen
+  },
+  {
+    id: 'finish-carbonFiberAlligatorOlive',
+    type: 'tableFinish',
+    optionId: 'carbonFiberAlligatorOlive',
+    name: 'LT Olive Alligator Finish',
+    price: 1310,
+    description: 'Olive LT alligator-scale texture with natural reptile tone transitions.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberAlligatorOlive
+  },
+  {
+    id: 'finish-carbonFiberAlligatorSwamp',
+    type: 'tableFinish',
+    optionId: 'carbonFiberAlligatorSwamp',
+    name: 'LT Swamp Alligator Finish',
+    price: 1320,
+    description: 'Swamp-green LT alligator texture tuned to deep marsh tones.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberAlligatorSwamp
+  },
+  {
+    id: 'finish-carbonFiberAlligatorClay',
+    type: 'tableFinish',
+    optionId: 'carbonFiberAlligatorClay',
+    name: 'LT Clay Alligator Finish',
+    price: 1330,
+    description: 'Clay-brown LT alligator pattern with warm hide-inspired contrast.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberAlligatorClay
+  },
+  {
+    id: 'finish-carbonFiberAlligatorSand',
+    type: 'tableFinish',
+    optionId: 'carbonFiberAlligatorSand',
+    name: 'LT Sand Alligator Finish',
+    price: 1340,
+    description: 'Sand LT alligator scales with brighter khaki highlights.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberAlligatorSand
+  },
+  {
+    id: 'finish-carbonFiberAlligatorMoss',
+    type: 'tableFinish',
+    optionId: 'carbonFiberAlligatorMoss',
+    name: 'LT Moss Alligator Finish',
+    price: 1350,
+    description: 'Moss LT alligator texture balancing olive and slate greens.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberAlligatorMoss
+  },
+  {
+    id: 'finish-carbonFiberAlligatorNight',
+    type: 'tableFinish',
+    optionId: 'carbonFiberAlligatorNight',
+    name: 'LT Night Alligator Finish',
+    price: 1360,
+    description: 'Night LT alligator scales with muted charcoal-green depth.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberAlligatorNight
   },
   {
     id: 'chrome-chrome',

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1819,6 +1819,7 @@ const SHOT_POWER_MULTIPLIER = 2.109375;
 const SHOT_POWER_INCREASE = 1.5; // match Snooker Royale standard shot lift
 const SHOT_POWER_ADJUSTMENT = 0.72; // reduce overall Pool Royale power by an additional 20%
 const SHOT_POWER_BOOST = 1.5; // increase overall shot power by 25%
+const SHOT_GLOBAL_POWER_SCALE = 0.85; // reduce all shot output by an additional 15%
 const SHOT_FORCE_BOOST =
   1.5 *
   0.75 *
@@ -1830,7 +1831,8 @@ const SHOT_FORCE_BOOST =
   SHOT_POWER_MULTIPLIER *
   SHOT_POWER_INCREASE *
   SHOT_POWER_ADJUSTMENT *
-  SHOT_POWER_BOOST;
+  SHOT_POWER_BOOST *
+  SHOT_GLOBAL_POWER_SCALE;
 const SHOT_BREAK_MULTIPLIER = 1.5;
 const SHOT_BASE_SPEED = 3.3 * 0.3 * 1.65 * SHOT_FORCE_BOOST;
 const SHOT_MIN_FACTOR = 0.25;
@@ -3463,6 +3465,78 @@ const TABLE_FINISHES = Object.freeze({
     disableWoodPattern: true,
     surfaceStyle: 'matte',
     useBrandCarbonTexture: false
+  }),
+  carbonFiberAlligatorOlive: createStandardWoodFinish({
+    id: 'carbonFiberAlligatorOlive',
+    label: 'LT Olive Alligator',
+    rail: 0x556b3f,
+    base: 0x556b3f,
+    trim: 0x556b3f,
+    woodTextureId: 'plastic_monoblock_lt_olive_alligator',
+    woodRepeatScale: 1,
+    disableWoodPattern: true,
+    surfaceStyle: 'matte',
+    useBrandCarbonTexture: false
+  }),
+  carbonFiberAlligatorSwamp: createStandardWoodFinish({
+    id: 'carbonFiberAlligatorSwamp',
+    label: 'LT Swamp Alligator',
+    rail: 0x3f5a3c,
+    base: 0x3f5a3c,
+    trim: 0x3f5a3c,
+    woodTextureId: 'plastic_monoblock_lt_swamp_alligator',
+    woodRepeatScale: 1,
+    disableWoodPattern: true,
+    surfaceStyle: 'matte',
+    useBrandCarbonTexture: false
+  }),
+  carbonFiberAlligatorClay: createStandardWoodFinish({
+    id: 'carbonFiberAlligatorClay',
+    label: 'LT Clay Alligator',
+    rail: 0x6f5b45,
+    base: 0x6f5b45,
+    trim: 0x6f5b45,
+    woodTextureId: 'plastic_monoblock_lt_clay_alligator',
+    woodRepeatScale: 1,
+    disableWoodPattern: true,
+    surfaceStyle: 'matte',
+    useBrandCarbonTexture: false
+  }),
+  carbonFiberAlligatorSand: createStandardWoodFinish({
+    id: 'carbonFiberAlligatorSand',
+    label: 'LT Sand Alligator',
+    rail: 0x8a7b5e,
+    base: 0x8a7b5e,
+    trim: 0x8a7b5e,
+    woodTextureId: 'plastic_monoblock_lt_sand_alligator',
+    woodRepeatScale: 1,
+    disableWoodPattern: true,
+    surfaceStyle: 'matte',
+    useBrandCarbonTexture: false
+  }),
+  carbonFiberAlligatorMoss: createStandardWoodFinish({
+    id: 'carbonFiberAlligatorMoss',
+    label: 'LT Moss Alligator',
+    rail: 0x4f6048,
+    base: 0x4f6048,
+    trim: 0x4f6048,
+    woodTextureId: 'plastic_monoblock_lt_moss_alligator',
+    woodRepeatScale: 1,
+    disableWoodPattern: true,
+    surfaceStyle: 'matte',
+    useBrandCarbonTexture: false
+  }),
+  carbonFiberAlligatorNight: createStandardWoodFinish({
+    id: 'carbonFiberAlligatorNight',
+    label: 'LT Night Alligator',
+    rail: 0x2f3c32,
+    base: 0x2f3c32,
+    trim: 0x2f3c32,
+    woodTextureId: 'plastic_monoblock_lt_night_alligator',
+    woodRepeatScale: 1,
+    disableWoodPattern: true,
+    surfaceStyle: 'matte',
+    useBrandCarbonTexture: false
   })
 });
 
@@ -3487,7 +3561,13 @@ const TABLE_FINISH_OPTIONS = Object.freeze(
     TABLE_FINISHES.carbonFiberSnakeChalkBeige,
     TABLE_FINISHES.carbonFiberSnakeChalkDarkBlue,
     TABLE_FINISHES.carbonFiberSnakeChalkWhite,
-    TABLE_FINISHES.carbonFiberSnakeChalkDarkGreen
+    TABLE_FINISHES.carbonFiberSnakeChalkDarkGreen,
+    TABLE_FINISHES.carbonFiberAlligatorOlive,
+    TABLE_FINISHES.carbonFiberAlligatorSwamp,
+    TABLE_FINISHES.carbonFiberAlligatorClay,
+    TABLE_FINISHES.carbonFiberAlligatorSand,
+    TABLE_FINISHES.carbonFiberAlligatorMoss,
+    TABLE_FINISHES.carbonFiberAlligatorNight
   ].filter(Boolean)
 );
 
@@ -6132,7 +6212,7 @@ const BREAK_DICE_ROLL_SOUND_URL = '/assets/sounds/u_qpfzpydtro-dice-142528.mp3';
 const REPLAY_CUE_MIN_PULLBACK_MS = 0; // defer to recorded cue pullback like Snooker Royal
 const REPLAY_CUE_MIN_RELEASE_MS = 0; // defer to recorded stroke durations like Snooker Royal
 const REPLAY_FOUL_WRONG_BALL_IMPACT_WINDOW_MS = 220;
-const REPLAY_FOUL_WRONG_BALL_IMPACT_SLOW_FACTOR = 0.35;
+const REPLAY_FOUL_WRONG_BALL_IMPACT_SLOW_FACTOR = 0.82;
 const CUE_STROKE_POST_HIT_CAMERA_HOLD_MS = 90; // shorten post-hit hold so rail-overhead broadcast can engage earlier
 // Keep the live stroke timing aligned with the reference cue motion:
 // quick push forward and a short hold before snapping back to idle.
@@ -23001,6 +23081,8 @@ const powerRef = useRef(hud.power);
             cueStroke: trimmed.cueStroke ?? null,
             duration,
             startedAt: performance.now(),
+            elapsed: 0,
+            lastNow: performance.now(),
             lastIndex: 0,
             postState: postShotSnapshot,
             pocketDrops: pausedPocketDrops ?? pocketDropRef.current
@@ -28782,6 +28864,49 @@ const powerRef = useRef(hud.power);
         } catch (err) {
           console.error('Pool Royale shot resolution failed:', err);
         }
+        const detectOpponentPotFoul = () => {
+          if (!currentState || !Array.isArray(potted) || potted.length === 0) return null;
+          const metaState = currentState?.meta?.state;
+          const variant = currentState?.meta?.variant;
+          if (!metaState || !variant) return null;
+          const shooterSeat = currentState?.activePlayer === 'B' ? 'B' : 'A';
+          const shooterAssignment = metaState?.assignments?.[shooterSeat] ?? null;
+          if (!shooterAssignment) return null;
+          const pottedObjectBalls = potted.filter((entry) => String(entry?.id || '').toLowerCase() !== 'cue');
+          if (!pottedObjectBalls.length) return null;
+          if (variant === '8ball') {
+            const normalized = String(shooterAssignment).toUpperCase();
+            for (const entry of pottedObjectBalls) {
+              const numeric = Number.parseInt(String(entry?.id ?? ''), 10);
+              if (!Number.isFinite(numeric) || numeric === 8) continue;
+              const group = numeric >= 9 ? 'STRIPE' : 'SOLID';
+              if (group !== normalized) {
+                return { points: 0, reason: 'opponent ball potted' };
+              }
+            }
+          }
+          if (variant === 'uk') {
+            const normalized = String(shooterAssignment).toLowerCase();
+            for (const entry of pottedObjectBalls) {
+              const color = String(entry?.color || '').toLowerCase();
+              if (!color || color === 'black') continue;
+              const group = color.includes('red') ? 'red' : color.includes('blue') || color.includes('yellow') ? 'blue' : null;
+              if (group && group !== normalized) {
+                return { points: 0, reason: 'opponent ball potted' };
+              }
+            }
+          }
+          return null;
+        };
+        if (!safeState?.foul) {
+          const opponentPotFoul = detectOpponentPotFoul();
+          if (opponentPotFoul) {
+            safeState = {
+              ...safeState,
+              foul: opponentPotFoul
+            };
+          }
+        }
         if (isTraining) {
           const disableRuleEnding = !trainingRulesRef.current;
           const remainingTrainingObjectBalls = balls.filter((entry) => entry?.id !== 'cue' && entry?.active).length;
@@ -28912,8 +29037,8 @@ const powerRef = useRef(hud.power);
             : null;
         }
         const shotWasFoul = Boolean(safeState?.foul);
-        if (shotWasFoul && (shotRecording?.frames?.length ?? 0) > 1) {
-          const foulBanner = 'Foul';
+        if (shotWasFoul) {
+          const foulBanner = 'Faul';
           if (replayDecision) {
             const replayTags = new Set(replayDecision.tags ?? []);
             replayTags.add('foul');
@@ -29351,7 +29476,18 @@ const powerRef = useRef(hud.power);
           };
           const frames = playback.frames || [];
           const duration = Number.isFinite(playback.duration) ? playback.duration : 0;
-          const elapsed = now - playback.startedAt;
+          const foulReplay = Boolean(replayFoul);
+          const previousNow = Number.isFinite(playback.lastNow) ? playback.lastNow : playback.startedAt;
+          const rawElapsedStep = Math.max(0, now - previousNow);
+          playback.lastNow = now;
+          const projectedElapsed = Math.max(0, (playback.elapsed ?? 0) + rawElapsedStep);
+          const shouldApplyFoulSlowdown =
+            foulReplay && projectedElapsed <= REPLAY_FOUL_WRONG_BALL_IMPACT_WINDOW_MS;
+          const elapsedStep = shouldApplyFoulSlowdown
+            ? rawElapsedStep * REPLAY_FOUL_WRONG_BALL_IMPACT_SLOW_FACTOR
+            : rawElapsedStep;
+          playback.elapsed = Math.max(0, (playback.elapsed ?? 0) + elapsedStep);
+          const elapsed = playback.elapsed;
           if (frames.length === 0) {
             finishReplayPlayback(playback);
             scheduleNext();
@@ -32767,25 +32903,25 @@ const powerRef = useRef(hud.power);
       )}
 
       {replayBanner && (
-        <div className="pointer-events-none absolute top-4 right-4 z-50">
-          <div
-            className="flex items-center gap-2 rounded-full bg-gradient-to-r from-emerald-300 to-cyan-300 px-5 py-2 text-xs font-bold uppercase tracking-[0.28em] text-slate-900 shadow-[0_12px_32px_rgba(0,0,0,0.45)] ring-2 ring-white/30"
-            aria-live="polite"
+        <div className="pointer-events-none absolute top-4 right-4 z-50" aria-live="polite">
+          <span
+            className={`text-sm font-black uppercase tracking-[0.28em] drop-shadow-[0_4px_16px_rgba(0,0,0,0.62)] ${
+              replayBanner === 'Faul' ? 'text-red-500' : 'text-emerald-400'
+            }`}
           >
-            <span className="drop-shadow-[0_1px_2px_rgba(255,255,255,0.35)]">
-              {replayBanner}
-            </span>
-          </div>
+            {replayBanner}
+          </span>
         </div>
       )}
       {replaySlate && (
         <div className="pointer-events-none absolute inset-0 z-[105] flex items-center justify-center">
-          <div className="rounded-2xl border border-white/35 bg-black/72 px-8 py-5 text-center shadow-[0_22px_48px_rgba(0,0,0,0.6)] backdrop-blur-sm">
-            <p className="text-[10px] font-semibold uppercase tracking-[0.34em] text-white/70">Replay frame</p>
-            <p className="mt-2 text-2xl font-black uppercase tracking-[0.2em] text-white">
-              {replaySlate.label || 'Replay'}
-            </p>
-          </div>
+          <p
+            className={`text-2xl font-black uppercase tracking-[0.2em] drop-shadow-[0_4px_18px_rgba(0,0,0,0.72)] ${
+              replaySlate.accent === 'foul' ? 'text-red-500' : 'text-emerald-400'
+            }`}
+          >
+            {replaySlate.label || 'Replay'}
+          </p>
         </div>
       )}
       {ruleToast && (
@@ -33079,22 +33215,14 @@ const powerRef = useRef(hud.power);
       )}
 
       {replayActive && (
-        <div className="pointer-events-none absolute inset-0 z-40">
-          <div className="absolute inset-0 rounded-[28px] border border-white/12 shadow-[0_0_32px_rgba(0,0,0,0.55),0_0_0_8px_rgba(0,0,0,0.45)]" />
-          <div className="absolute inset-0 rounded-[28px] bg-gradient-to-b from-black/55 via-transparent to-black/55" />
-          <div className="absolute inset-x-10 top-6 h-px bg-gradient-to-r from-transparent via-white/35 to-transparent" />
-          <div className="absolute inset-x-10 bottom-6 h-px bg-gradient-to-r from-transparent via-white/35 to-transparent" />
-        </div>
-      )}
-      {replayActive && (
         <>
           <div className="pointer-events-none absolute left-4 top-4 z-50">
-            <div className="rounded-full border border-white/25 bg-black/70 px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.34em] text-white shadow-[0_12px_32px_rgba(0,0,0,0.45)]">
+            <div className="text-[11px] font-semibold uppercase tracking-[0.34em] text-white drop-shadow-[0_4px_16px_rgba(0,0,0,0.62)]">
               Replay
             </div>
             {replayFoul && (
-              <div className="mt-2 rounded-full border border-red-300/70 bg-red-500/30 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.28em] text-red-100 shadow-[0_10px_28px_rgba(0,0,0,0.45)]">
-                Foul{replayFoul.reason ? `: ${replayFoul.reason}` : ''}
+              <div className="mt-1 text-[11px] font-black uppercase tracking-[0.28em] text-red-500 drop-shadow-[0_4px_16px_rgba(0,0,0,0.62)]">
+                Faul
               </div>
             )}
           </div>

--- a/webapp/src/utils/woodMaterials.js
+++ b/webapp/src/utils/woodMaterials.js
@@ -426,26 +426,20 @@ const makeInlinePlasticMonoblockPattern = ({ id, base = '#2b2f36', sheen = '#3f4
   return { mapUrl: fallback, roughnessMapUrl: null, normalMapUrl: null };
 };
 
-const makeInlinePlasticSnakePattern = ({ id, base = '#2b2f36', sheen = '#3f4652' }) => {
-  const pattern = svgDataUrl(`
-<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256">
-  <defs>
-    <linearGradient id="${id}-plastic" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="${base}"/>
-      <stop offset="45%" stop-color="${sheen}"/>
-      <stop offset="100%" stop-color="${base}"/>
-    </linearGradient>
-    <pattern id="${id}-snake" patternUnits="userSpaceOnUse" width="64" height="64">
-      <path d="M32 0 C50 0 64 14 64 32 C64 50 50 64 32 64 C14 64 0 50 0 32 C0 14 14 0 32 0Z" fill="none" stroke="#ffffff" stroke-opacity="0.11" stroke-width="2.2"/>
-      <path d="M32 7 C46 7 57 18 57 32 C57 46 46 57 32 57 C18 57 7 46 7 32 C7 18 18 7 32 7Z" fill="none" stroke="#000000" stroke-opacity="0.14" stroke-width="1.3"/>
-      <path d="M0 32 C0 14 14 0 32 0 C50 0 64 14 64 32" fill="none" stroke="#ffffff" stroke-opacity="0.08" stroke-width="1.2"/>
-    </pattern>
-  </defs>
-  <rect width="256" height="256" fill="url(#${id}-plastic)"/>
-  <rect width="256" height="256" fill="url(#${id}-snake)"/>
-</svg>`);
-  return { mapUrl: pattern, roughnessMapUrl: null, normalMapUrl: null };
-};
+const OPEN_GAME_ART_SNAKE_TEXTURE_URL = 'https://opengameart.org/sites/default/files/snakeskin_0.png';
+const OPEN_GAME_ART_ALLIGATOR_TEXTURE_URL = 'https://opengameart.org/sites/default/files/alligatorskin_0.png';
+
+const makeInlinePlasticSnakePattern = () => ({
+  mapUrl: OPEN_GAME_ART_SNAKE_TEXTURE_URL,
+  roughnessMapUrl: null,
+  normalMapUrl: null
+});
+
+const makeInlinePlasticAlligatorPattern = () => ({
+  mapUrl: OPEN_GAME_ART_ALLIGATOR_TEXTURE_URL,
+  roughnessMapUrl: null,
+  normalMapUrl: null
+});
 const makeInlineCarbonFiberPattern = ({ id }) => {
   if (typeof document !== 'undefined') {
     const canvas = document.createElement('canvas');
@@ -515,7 +509,7 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
   Object.freeze({
     id: 'plastic_monoblock_lt_black_snake',
     label: 'LT Black Snake',
-    source: 'TonPlaygram molded-plastic satin snake texture (LT Black)',
+    source: 'OpenGameArt CC0 snakeskin texture (Simple Textures pack)',
     rail: {
       repeat: { x: 7.2, y: 7.2 },
       rotation: 0,
@@ -540,7 +534,7 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
   Object.freeze({
     id: 'plastic_monoblock_lt_grey_snake',
     label: 'LT Grey Snake',
-    source: 'TonPlaygram molded-plastic satin snake texture (LT Grey)',
+    source: 'OpenGameArt CC0 snakeskin texture (Simple Textures pack)',
     rail: {
       repeat: { x: 7.2, y: 7.2 },
       rotation: 0,
@@ -565,7 +559,7 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
   Object.freeze({
     id: 'plastic_monoblock_lt_dark_grey_snake',
     label: 'LT Dark Grey Snake',
-    source: 'TonPlaygram molded-plastic satin snake texture (LT Dark Grey)',
+    source: 'OpenGameArt CC0 snakeskin texture (Simple Textures pack)',
     rail: {
       repeat: { x: 7.2, y: 7.2 },
       rotation: 0,
@@ -590,7 +584,7 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
   Object.freeze({
     id: 'plastic_monoblock_lt_burgundy_snake',
     label: 'LT Burgundy Snake',
-    source: 'TonPlaygram molded-plastic satin snake texture (LT Burgundy)',
+    source: 'OpenGameArt CC0 snakeskin texture (Simple Textures pack)',
     rail: {
       repeat: { x: 7.2, y: 7.2 },
       rotation: 0,
@@ -615,7 +609,7 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
   Object.freeze({
     id: 'plastic_monoblock_lt_milk_cream_snake',
     label: 'LT Milk Cream Snake',
-    source: 'TonPlaygram molded-plastic satin snake texture (LT Milk Cream)',
+    source: 'OpenGameArt CC0 snakeskin texture (Simple Textures pack)',
     rail: {
       repeat: { x: 7.2, y: 7.2 },
       rotation: 0,
@@ -640,7 +634,7 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
   Object.freeze({
     id: 'plastic_monoblock_lt_dark_green_snake',
     label: 'LT Dark Green Snake',
-    source: 'TonPlaygram molded-plastic satin snake texture (LT Dark Green)',
+    source: 'OpenGameArt CC0 snakeskin texture (Simple Textures pack)',
     rail: {
       repeat: { x: 7.2, y: 7.2 },
       rotation: 0,
@@ -659,6 +653,156 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
         id: 'plastic-monoblock-lt-dark-green-snake-frame',
         base: '#2b4533',
         sheen: '#3d6148'
+      })
+    }
+  }),
+  Object.freeze({
+    id: 'plastic_monoblock_lt_olive_alligator',
+    label: 'LT Olive Alligator',
+    source: 'OpenGameArt CC0 alligator skin texture (Simple Textures pack)',
+    rail: {
+      repeat: { x: 6.8, y: 6.8 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlinePlasticAlligatorPattern({
+        id: 'plastic-monoblock-lt-olive-alligator-rail',
+        base: '#4c5d3f',
+        sheen: '#6d7d58'
+      })
+    },
+    frame: {
+      repeat: { x: 6.8, y: 6.8 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlinePlasticAlligatorPattern({
+        id: 'plastic-monoblock-lt-olive-alligator-frame',
+        base: '#4c5d3f',
+        sheen: '#6d7d58'
+      })
+    }
+  }),
+  Object.freeze({
+    id: 'plastic_monoblock_lt_swamp_alligator',
+    label: 'LT Swamp Alligator',
+    source: 'OpenGameArt CC0 alligator skin texture (Simple Textures pack)',
+    rail: {
+      repeat: { x: 6.8, y: 6.8 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlinePlasticAlligatorPattern({
+        id: 'plastic-monoblock-lt-swamp-alligator-rail',
+        base: '#304b36',
+        sheen: '#48624d'
+      })
+    },
+    frame: {
+      repeat: { x: 6.8, y: 6.8 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlinePlasticAlligatorPattern({
+        id: 'plastic-monoblock-lt-swamp-alligator-frame',
+        base: '#304b36',
+        sheen: '#48624d'
+      })
+    }
+  }),
+  Object.freeze({
+    id: 'plastic_monoblock_lt_clay_alligator',
+    label: 'LT Clay Alligator',
+    source: 'OpenGameArt CC0 alligator skin texture (Simple Textures pack)',
+    rail: {
+      repeat: { x: 6.8, y: 6.8 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlinePlasticAlligatorPattern({
+        id: 'plastic-monoblock-lt-clay-alligator-rail',
+        base: '#5f4c3c',
+        sheen: '#816a56'
+      })
+    },
+    frame: {
+      repeat: { x: 6.8, y: 6.8 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlinePlasticAlligatorPattern({
+        id: 'plastic-monoblock-lt-clay-alligator-frame',
+        base: '#5f4c3c',
+        sheen: '#816a56'
+      })
+    }
+  }),
+  Object.freeze({
+    id: 'plastic_monoblock_lt_sand_alligator',
+    label: 'LT Sand Alligator',
+    source: 'OpenGameArt CC0 alligator skin texture (Simple Textures pack)',
+    rail: {
+      repeat: { x: 6.8, y: 6.8 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlinePlasticAlligatorPattern({
+        id: 'plastic-monoblock-lt-sand-alligator-rail',
+        base: '#7e6e56',
+        sheen: '#a49277'
+      })
+    },
+    frame: {
+      repeat: { x: 6.8, y: 6.8 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlinePlasticAlligatorPattern({
+        id: 'plastic-monoblock-lt-sand-alligator-frame',
+        base: '#7e6e56',
+        sheen: '#a49277'
+      })
+    }
+  }),
+  Object.freeze({
+    id: 'plastic_monoblock_lt_moss_alligator',
+    label: 'LT Moss Alligator',
+    source: 'OpenGameArt CC0 alligator skin texture (Simple Textures pack)',
+    rail: {
+      repeat: { x: 6.8, y: 6.8 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlinePlasticAlligatorPattern({
+        id: 'plastic-monoblock-lt-moss-alligator-rail',
+        base: '#435340',
+        sheen: '#60715c'
+      })
+    },
+    frame: {
+      repeat: { x: 6.8, y: 6.8 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlinePlasticAlligatorPattern({
+        id: 'plastic-monoblock-lt-moss-alligator-frame',
+        base: '#435340',
+        sheen: '#60715c'
+      })
+    }
+  }),
+  Object.freeze({
+    id: 'plastic_monoblock_lt_night_alligator',
+    label: 'LT Night Alligator',
+    source: 'OpenGameArt CC0 alligator skin texture (Simple Textures pack)',
+    rail: {
+      repeat: { x: 6.8, y: 6.8 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlinePlasticAlligatorPattern({
+        id: 'plastic-monoblock-lt-night-alligator-rail',
+        base: '#263129',
+        sheen: '#3a453c'
+      })
+    },
+    frame: {
+      repeat: { x: 6.8, y: 6.8 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlinePlasticAlligatorPattern({
+        id: 'plastic-monoblock-lt-night-alligator-frame',
+        base: '#263129',
+        sheen: '#3a453c'
       })
     }
   }),


### PR DESCRIPTION
### Motivation

- Make the AI more conservative and confidence-aware when valuing pot attempts and prefer cleaner direct lanes.  
- Improve replay handling for fouls by smoothing the slowdown timing and ensuring opponent-ball pot fouls are detected and signalled.  
- Expand table finish options with a new set of LT alligator-scale finishes and standardise snake/alligator texture sources.  

### Description

- AI: raised `MIN_POT_PROBABILITY` and increased `laneClearance` requirement, added `AI_POT_CONFIDENCE_EXPONENT` and apply `Math.pow(Ppot, AI_POT_CONFIDENCE_EXPONENT)` when computing EV in `evaluateCandidates` (file: `lib/poolUkAdvancedAi.js`).  
- Replay/foul: introduced `lastNow`/`elapsed` bookkeeping on replay playback and apply `REPLAY_FOUL_WRONG_BALL_IMPACT_SLOW_FACTOR` conditionally to slow only the relevant window; added opponent-pot foul detection (`detectOpponentPotFoul`) and inject foul into `safeState` when appropriate (file: `webapp/src/pages/Games/PoolRoyale.jsx`).  
- Shot tuning: added `SHOT_GLOBAL_POWER_SCALE` and applied it to overall `SHOT_FORCE_BOOST` so Pool Royale shot output is further softened (file: `webapp/src/pages/Games/PoolRoyale.jsx`).  
- UI: updated replay banner/slate/foul copy and styling (some labels now show `Faul` and colours updated) and adjusted replay overlay rendering for fouls and banners (file: `webapp/src/pages/Games/PoolRoyale.jsx`).  
- Assets/finishes: added six new LT alligator table finishes (thumbnails, option labels and store items) in `webapp/src/config/poolRoyaleInventoryConfig.js` and registered corresponding table finish definitions into `TABLE_FINISHES`.  
- Textures: replaced inline SVG snake pattern with OpenGameArt CC0 snakeskin and added OpenGameArt alligator textures; introduced `makeInlinePlasticAlligatorPattern` and new `WOOD_GRAIN_OPTIONS` entries for alligator finishes (file: `webapp/src/utils/woodMaterials.js`).  

### Testing

- Ran unit tests via `yarn test` and they passed.  
- Built the web client with `yarn build` to exercise asset and config changes and the build completed successfully.  
- Ran linter/type checks with `yarn lint` and no issues were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4fe023fa08329b219962eeedf8257)