### PR TITLE
Add LT Alligator table finishes, refine shot scaling, AI aiming, replay foul slowdown, and replay UI

### DIFF
--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -544,7 +544,13 @@ const TABLE_FINISH_THUMBNAILS = Object.freeze({
   carbonFiberSnakeChalkBeige: swatchThumbnail(['#45505c', '#5f6b79', '#84909e']),
   carbonFiberSnakeChalkDarkBlue: swatchThumbnail(['#6a3a31', '#8d5546', '#aa6f5c']),
   carbonFiberSnakeChalkWhite: swatchThumbnail(['#dacbb7', '#ecdecb', '#f7ede0']),
-  carbonFiberSnakeChalkDarkGreen: swatchThumbnail(['#36523f', '#4a6f56', '#6a9878'])
+  carbonFiberSnakeChalkDarkGreen: swatchThumbnail(['#36523f', '#4a6f56', '#6a9878']),
+  carbonFiberAlligatorOlive: swatchThumbnail(['#45573a', '#62774f', '#87996d']),
+  carbonFiberAlligatorSwamp: swatchThumbnail(['#2e4733', '#3f5f46', '#5f7c64']),
+  carbonFiberAlligatorClay: swatchThumbnail(['#5c4939', '#7a624d', '#a3876d']),
+  carbonFiberAlligatorSand: swatchThumbnail(['#786850', '#98856a', '#bba88a']),
+  carbonFiberAlligatorMoss: swatchThumbnail(['#3f4f3c', '#5a6b54', '#7f9075']),
+  carbonFiberAlligatorNight: swatchThumbnail(['#253128', '#36443a', '#566258'])
 });
 
 const POCKET_LINER_THUMBNAILS = Object.freeze({
@@ -657,7 +663,13 @@ export const POOL_ROYALE_OPTION_LABELS = Object.freeze({
     carbonFiberSnakeChalkBeige: 'LT Dark Grey Snake',
     carbonFiberSnakeChalkDarkBlue: 'LT Burgundy Snake',
     carbonFiberSnakeChalkWhite: 'LT Milk Cream Snake',
-    carbonFiberSnakeChalkDarkGreen: 'LT Dark Green Snake'
+    carbonFiberSnakeChalkDarkGreen: 'LT Dark Green Snake',
+    carbonFiberAlligatorOlive: 'LT Olive Alligator',
+    carbonFiberAlligatorSwamp: 'LT Swamp Alligator',
+    carbonFiberAlligatorClay: 'LT Clay Alligator',
+    carbonFiberAlligatorSand: 'LT Sand Alligator',
+    carbonFiberAlligatorMoss: 'LT Moss Alligator',
+    carbonFiberAlligatorNight: 'LT Night Alligator'
   }),
   chromeColor: Object.freeze({
     chrome: 'Chrome',
@@ -879,6 +891,60 @@ export const POOL_ROYALE_STORE_ITEMS = [
     price: 1300,
     description: 'Dark-green LT snake-weave finish with matching LT color tone and weave scale.',
     thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberSnakeChalkDarkGreen
+  },
+  {
+    id: 'finish-carbonFiberAlligatorOlive',
+    type: 'tableFinish',
+    optionId: 'carbonFiberAlligatorOlive',
+    name: 'LT Olive Alligator Finish',
+    price: 1310,
+    description: 'Olive LT alligator-scale texture with natural reptile tone transitions.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberAlligatorOlive
+  },
+  {
+    id: 'finish-carbonFiberAlligatorSwamp',
+    type: 'tableFinish',
+    optionId: 'carbonFiberAlligatorSwamp',
+    name: 'LT Swamp Alligator Finish',
+    price: 1320,
+    description: 'Swamp-green LT alligator texture tuned to deep marsh tones.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberAlligatorSwamp
+  },
+  {
+    id: 'finish-carbonFiberAlligatorClay',
+    type: 'tableFinish',
+    optionId: 'carbonFiberAlligatorClay',
+    name: 'LT Clay Alligator Finish',
+    price: 1330,
+    description: 'Clay-brown LT alligator pattern with warm hide-inspired contrast.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberAlligatorClay
+  },
+  {
+    id: 'finish-carbonFiberAlligatorSand',
+    type: 'tableFinish',
+    optionId: 'carbonFiberAlligatorSand',
+    name: 'LT Sand Alligator Finish',
+    price: 1340,
+    description: 'Sand LT alligator scales with brighter khaki highlights.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberAlligatorSand
+  },
+  {
+    id: 'finish-carbonFiberAlligatorMoss',
+    type: 'tableFinish',
+    optionId: 'carbonFiberAlligatorMoss',
+    name: 'LT Moss Alligator Finish',
+    price: 1350,
+    description: 'Moss LT alligator texture balancing olive and slate greens.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberAlligatorMoss
+  },
+  {
+    id: 'finish-carbonFiberAlligatorNight',
+    type: 'tableFinish',
+    optionId: 'carbonFiberAlligatorNight',
+    name: 'LT Night Alligator Finish',
+    price: 1360,
+    description: 'Night LT alligator scales with muted charcoal-green depth.',
+    thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberAlligatorNight
   },
   {
     id: 'chrome-chrome',

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1819,6 +1819,7 @@ const SHOT_POWER_MULTIPLIER = 2.109375;
 const SHOT_POWER_INCREASE = 1.5; // match Snooker Royale standard shot lift
 const SHOT_POWER_ADJUSTMENT = 0.72; // reduce overall Pool Royale power by an additional 20%
 const SHOT_POWER_BOOST = 1.5; // increase overall shot power by 25%
+const SHOT_GLOBAL_POWER_SCALE = 0.85; // reduce all shot output by an additional 15%
 const SHOT_FORCE_BOOST =
   1.5 *
   0.75 *
@@ -1830,7 +1831,8 @@ const SHOT_FORCE_BOOST =
   SHOT_POWER_MULTIPLIER *
   SHOT_POWER_INCREASE *
   SHOT_POWER_ADJUSTMENT *
-  SHOT_POWER_BOOST;
+  SHOT_POWER_BOOST *
+  SHOT_GLOBAL_POWER_SCALE;
 const SHOT_BREAK_MULTIPLIER = 1.5;
 const SHOT_BASE_SPEED = 3.3 * 0.3 * 1.65 * SHOT_FORCE_BOOST;
 const SHOT_MIN_FACTOR = 0.25;
@@ -3463,6 +3465,78 @@ const TABLE_FINISHES = Object.freeze({
     disableWoodPattern: true,
     surfaceStyle: 'matte',
     useBrandCarbonTexture: false
+  }),
+  carbonFiberAlligatorOlive: createStandardWoodFinish({
+    id: 'carbonFiberAlligatorOlive',
+    label: 'LT Olive Alligator',
+    rail: 0x556b3f,
+    base: 0x556b3f,
+    trim: 0x556b3f,
+    woodTextureId: 'plastic_monoblock_lt_olive_alligator',
+    woodRepeatScale: 1,
+    disableWoodPattern: true,
+    surfaceStyle: 'matte',
+    useBrandCarbonTexture: false
+  }),
+  carbonFiberAlligatorSwamp: createStandardWoodFinish({
+    id: 'carbonFiberAlligatorSwamp',
+    label: 'LT Swamp Alligator',
+    rail: 0x3f5a3c,
+    base: 0x3f5a3c,
+    trim: 0x3f5a3c,
+    woodTextureId: 'plastic_monoblock_lt_swamp_alligator',
+    woodRepeatScale: 1,
+    disableWoodPattern: true,
+    surfaceStyle: 'matte',
+    useBrandCarbonTexture: false
+  }),
+  carbonFiberAlligatorClay: createStandardWoodFinish({
+    id: 'carbonFiberAlligatorClay',
+    label: 'LT Clay Alligator',
+    rail: 0x6f5b45,
+    base: 0x6f5b45,
+    trim: 0x6f5b45,
+    woodTextureId: 'plastic_monoblock_lt_clay_alligator',
+    woodRepeatScale: 1,
+    disableWoodPattern: true,
+    surfaceStyle: 'matte',
+    useBrandCarbonTexture: false
+  }),
+  carbonFiberAlligatorSand: createStandardWoodFinish({
+    id: 'carbonFiberAlligatorSand',
+    label: 'LT Sand Alligator',
+    rail: 0x8a7b5e,
+    base: 0x8a7b5e,
+    trim: 0x8a7b5e,
+    woodTextureId: 'plastic_monoblock_lt_sand_alligator',
+    woodRepeatScale: 1,
+    disableWoodPattern: true,
+    surfaceStyle: 'matte',
+    useBrandCarbonTexture: false
+  }),
+  carbonFiberAlligatorMoss: createStandardWoodFinish({
+    id: 'carbonFiberAlligatorMoss',
+    label: 'LT Moss Alligator',
+    rail: 0x4f6048,
+    base: 0x4f6048,
+    trim: 0x4f6048,
+    woodTextureId: 'plastic_monoblock_lt_moss_alligator',
+    woodRepeatScale: 1,
+    disableWoodPattern: true,
+    surfaceStyle: 'matte',
+    useBrandCarbonTexture: false
+  }),
+  carbonFiberAlligatorNight: createStandardWoodFinish({
+    id: 'carbonFiberAlligatorNight',
+    label: 'LT Night Alligator',
+    rail: 0x2f3c32,
+    base: 0x2f3c32,
+    trim: 0x2f3c32,
+    woodTextureId: 'plastic_monoblock_lt_night_alligator',
+    woodRepeatScale: 1,
+    disableWoodPattern: true,
+    surfaceStyle: 'matte',
+    useBrandCarbonTexture: false
   })
 });
 
@@ -3487,7 +3561,13 @@ const TABLE_FINISH_OPTIONS = Object.freeze(
     TABLE_FINISHES.carbonFiberSnakeChalkBeige,
     TABLE_FINISHES.carbonFiberSnakeChalkDarkBlue,
     TABLE_FINISHES.carbonFiberSnakeChalkWhite,
-    TABLE_FINISHES.carbonFiberSnakeChalkDarkGreen
+    TABLE_FINISHES.carbonFiberSnakeChalkDarkGreen,
+    TABLE_FINISHES.carbonFiberAlligatorOlive,
+    TABLE_FINISHES.carbonFiberAlligatorSwamp,
+    TABLE_FINISHES.carbonFiberAlligatorClay,
+    TABLE_FINISHES.carbonFiberAlligatorSand,
+    TABLE_FINISHES.carbonFiberAlligatorMoss,
+    TABLE_FINISHES.carbonFiberAlligatorNight
   ].filter(Boolean)
 );
 
@@ -6132,7 +6212,7 @@ const BREAK_DICE_ROLL_SOUND_URL = '/assets/sounds/u_qpfzpydtro-dice-142528.mp3';
 const REPLAY_CUE_MIN_PULLBACK_MS = 0; // defer to recorded cue pullback like Snooker Royal
 const REPLAY_CUE_MIN_RELEASE_MS = 0; // defer to recorded stroke durations like Snooker Royal
 const REPLAY_FOUL_WRONG_BALL_IMPACT_WINDOW_MS = 220;
-const REPLAY_FOUL_WRONG_BALL_IMPACT_SLOW_FACTOR = 0.35;
+const REPLAY_FOUL_WRONG_BALL_IMPACT_SLOW_FACTOR = 0.82;
 const CUE_STROKE_POST_HIT_CAMERA_HOLD_MS = 90; // shorten post-hit hold so rail-overhead broadcast can engage earlier
 // Keep the live stroke timing aligned with the reference cue motion:
 // quick push forward and a short hold before snapping back to idle.
@@ -23001,6 +23081,8 @@ const powerRef = useRef(hud.power);
             cueStroke: trimmed.cueStroke ?? null,
             duration,
             startedAt: performance.now(),
+            elapsed: 0,
+            lastNow: performance.now(),
             lastIndex: 0,
             postState: postShotSnapshot,
             pocketDrops: pausedPocketDrops ?? pocketDropRef.current
@@ -27700,13 +27782,10 @@ const powerRef = useRef(hud.power);
             ) {
               return null;
             }
-            const aimPoint = new THREE.Vector2(
+            const fallbackAimPoint = new THREE.Vector2(
               aimPointRaw.x - width / 2,
               aimPointRaw.y - height / 2
             );
-            const aimDir = aimPoint.clone().sub(cueBall.pos);
-            if (aimDir.lengthSq() < 1e-6) aimDir.set(0, 1);
-            aimDir.normalize();
             const targetBall =
               allBalls.find(
                 (b) => String(b.id) === String(plan.targetId)
@@ -27723,6 +27802,19 @@ const powerRef = useRef(hud.power);
               localPocketId != null ? POCKET_IDS.indexOf(localPocketId) : -1;
             const pocketCenter =
               pocketIndex >= 0 ? pocketPositions[pocketIndex].clone() : null;
+            const aimPoint =
+              plan.actionType === 'pot' && targetBall?.pos && pocketCenter
+                ? (() => {
+                    const pocketToBall = targetBall.pos.clone().sub(pocketCenter);
+                    if (pocketToBall.lengthSq() < 1e-6) return fallbackAimPoint.clone();
+                    return targetBall.pos
+                      .clone()
+                      .add(pocketToBall.normalize().multiplyScalar(BALL_R * 2.04));
+                  })()
+                : fallbackAimPoint.clone();
+            const aimDir = aimPoint.clone().sub(cueBall.pos);
+            if (aimDir.lengthSq() < 1e-6) aimDir.set(0, 1);
+            aimDir.normalize();
             const cueToAim = cueBall.pos.distanceTo(aimPoint);
             const pocketDistance =
               targetBall && pocketCenter
@@ -27820,6 +27912,20 @@ const powerRef = useRef(hud.power);
           }
           if (corrected) {
             plan.aimDir = corrected;
+          }
+          if (plan.type === 'pot' && plan.targetBall?.pos && plan.pocketCenter?.clone) {
+            const ghostDir = plan.targetBall.pos.clone().sub(plan.pocketCenter);
+            if (ghostDir.lengthSq() > 1e-6) {
+              const ghostPoint = plan.targetBall.pos
+                .clone()
+                .add(ghostDir.normalize().multiplyScalar(BALL_R * 2.04));
+              const refined = ghostPoint.sub(cueBall.pos);
+              if (refined.lengthSq() > 1e-6) {
+                refined.normalize();
+                plan.aimDir = refined;
+                plan.cueToTarget = cueBall.pos.distanceTo(plan.targetBall.pos);
+              }
+            }
           }
           return plan;
         };
@@ -28912,8 +29018,8 @@ const powerRef = useRef(hud.power);
             : null;
         }
         const shotWasFoul = Boolean(safeState?.foul);
-        if (shotWasFoul && (shotRecording?.frames?.length ?? 0) > 1) {
-          const foulBanner = 'Foul';
+        if (shotWasFoul) {
+          const foulBanner = 'Faul';
           if (replayDecision) {
             const replayTags = new Set(replayDecision.tags ?? []);
             replayTags.add('foul');
@@ -28921,8 +29027,8 @@ const powerRef = useRef(hud.power);
               ...replayDecision,
               tags: Array.from(replayTags),
               shouldReplay: true,
-              banner: replayDecision.banner ?? foulBanner,
-              primaryTag: replayDecision.primaryTag ?? 'foul'
+              banner: foulBanner,
+              primaryTag: 'foul'
             };
           } else {
             replayDecision = {
@@ -29351,7 +29457,18 @@ const powerRef = useRef(hud.power);
           };
           const frames = playback.frames || [];
           const duration = Number.isFinite(playback.duration) ? playback.duration : 0;
-          const elapsed = now - playback.startedAt;
+          const foulReplay = Boolean(replayFoul);
+          const previousNow = Number.isFinite(playback.lastNow) ? playback.lastNow : playback.startedAt;
+          const rawElapsedStep = Math.max(0, now - previousNow);
+          playback.lastNow = now;
+          const projectedElapsed = Math.max(0, (playback.elapsed ?? 0) + rawElapsedStep);
+          const shouldApplyFoulSlowdown =
+            foulReplay && projectedElapsed <= REPLAY_FOUL_WRONG_BALL_IMPACT_WINDOW_MS;
+          const elapsedStep = shouldApplyFoulSlowdown
+            ? rawElapsedStep * REPLAY_FOUL_WRONG_BALL_IMPACT_SLOW_FACTOR
+            : rawElapsedStep;
+          playback.elapsed = Math.max(0, (playback.elapsed ?? 0) + elapsedStep);
+          const elapsed = playback.elapsed;
           if (frames.length === 0) {
             finishReplayPlayback(playback);
             scheduleNext();
@@ -32767,25 +32884,25 @@ const powerRef = useRef(hud.power);
       )}
 
       {replayBanner && (
-        <div className="pointer-events-none absolute top-4 right-4 z-50">
-          <div
-            className="flex items-center gap-2 rounded-full bg-gradient-to-r from-emerald-300 to-cyan-300 px-5 py-2 text-xs font-bold uppercase tracking-[0.28em] text-slate-900 shadow-[0_12px_32px_rgba(0,0,0,0.45)] ring-2 ring-white/30"
-            aria-live="polite"
+        <div className="pointer-events-none absolute top-4 right-4 z-50" aria-live="polite">
+          <span
+            className={`text-sm font-black uppercase tracking-[0.28em] drop-shadow-[0_4px_16px_rgba(0,0,0,0.62)] ${
+              replayBanner === 'Faul' ? 'text-red-500' : 'text-emerald-400'
+            }`}
           >
-            <span className="drop-shadow-[0_1px_2px_rgba(255,255,255,0.35)]">
-              {replayBanner}
-            </span>
-          </div>
+            {replayBanner}
+          </span>
         </div>
       )}
       {replaySlate && (
         <div className="pointer-events-none absolute inset-0 z-[105] flex items-center justify-center">
-          <div className="rounded-2xl border border-white/35 bg-black/72 px-8 py-5 text-center shadow-[0_22px_48px_rgba(0,0,0,0.6)] backdrop-blur-sm">
-            <p className="text-[10px] font-semibold uppercase tracking-[0.34em] text-white/70">Replay frame</p>
-            <p className="mt-2 text-2xl font-black uppercase tracking-[0.2em] text-white">
-              {replaySlate.label || 'Replay'}
-            </p>
-          </div>
+          <p
+            className={`text-2xl font-black uppercase tracking-[0.2em] drop-shadow-[0_4px_18px_rgba(0,0,0,0.72)] ${
+              replaySlate.accent === 'foul' ? 'text-red-500' : 'text-emerald-400'
+            }`}
+          >
+            {replaySlate.label || 'Replay'}
+          </p>
         </div>
       )}
       {ruleToast && (
@@ -33079,22 +33196,14 @@ const powerRef = useRef(hud.power);
       )}
 
       {replayActive && (
-        <div className="pointer-events-none absolute inset-0 z-40">
-          <div className="absolute inset-0 rounded-[28px] border border-white/12 shadow-[0_0_32px_rgba(0,0,0,0.55),0_0_0_8px_rgba(0,0,0,0.45)]" />
-          <div className="absolute inset-0 rounded-[28px] bg-gradient-to-b from-black/55 via-transparent to-black/55" />
-          <div className="absolute inset-x-10 top-6 h-px bg-gradient-to-r from-transparent via-white/35 to-transparent" />
-          <div className="absolute inset-x-10 bottom-6 h-px bg-gradient-to-r from-transparent via-white/35 to-transparent" />
-        </div>
-      )}
-      {replayActive && (
         <>
           <div className="pointer-events-none absolute left-4 top-4 z-50">
-            <div className="rounded-full border border-white/25 bg-black/70 px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.34em] text-white shadow-[0_12px_32px_rgba(0,0,0,0.45)]">
+            <div className="text-[11px] font-semibold uppercase tracking-[0.34em] text-white drop-shadow-[0_4px_16px_rgba(0,0,0,0.62)]">
               Replay
             </div>
             {replayFoul && (
-              <div className="mt-2 rounded-full border border-red-300/70 bg-red-500/30 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.28em] text-red-100 shadow-[0_10px_28px_rgba(0,0,0,0.45)]">
-                Foul{replayFoul.reason ? `: ${replayFoul.reason}` : ''}
+              <div className="mt-1 text-[11px] font-black uppercase tracking-[0.28em] text-red-500 drop-shadow-[0_4px_16px_rgba(0,0,0,0.62)]">
+                Faul
               </div>
             )}
           </div>

--- a/webapp/src/utils/woodMaterials.js
+++ b/webapp/src/utils/woodMaterials.js
@@ -446,6 +446,27 @@ const makeInlinePlasticSnakePattern = ({ id, base = '#2b2f36', sheen = '#3f4652'
 </svg>`);
   return { mapUrl: pattern, roughnessMapUrl: null, normalMapUrl: null };
 };
+
+const makeInlinePlasticAlligatorPattern = ({ id, base = '#4f5a43', sheen = '#7a8668' }) => {
+  const pattern = svgDataUrl(`
+<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256">
+  <defs>
+    <linearGradient id="${id}-plastic" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="${base}"/>
+      <stop offset="45%" stop-color="${sheen}"/>
+      <stop offset="100%" stop-color="${base}"/>
+    </linearGradient>
+    <pattern id="${id}-alligator" patternUnits="userSpaceOnUse" width="72" height="72">
+      <path d="M4 18 L24 6 L42 14 L36 34 L16 40 Z" fill="none" stroke="#000000" stroke-opacity="0.22" stroke-width="1.6"/>
+      <path d="M38 40 L58 30 L68 44 L58 62 L38 64 L30 52 Z" fill="none" stroke="#ffffff" stroke-opacity="0.12" stroke-width="1.2"/>
+      <path d="M8 50 L24 42 L38 52 L32 68 L12 70 L4 60 Z" fill="none" stroke="#ffffff" stroke-opacity="0.1" stroke-width="1.1"/>
+    </pattern>
+  </defs>
+  <rect width="256" height="256" fill="url(#${id}-plastic)"/>
+  <rect width="256" height="256" fill="url(#${id}-alligator)"/>
+</svg>`);
+  return { mapUrl: pattern, roughnessMapUrl: null, normalMapUrl: null };
+};
 const makeInlineCarbonFiberPattern = ({ id }) => {
   if (typeof document !== 'undefined') {
     const canvas = document.createElement('canvas');
@@ -659,6 +680,156 @@ export const WOOD_GRAIN_OPTIONS = Object.freeze([
         id: 'plastic-monoblock-lt-dark-green-snake-frame',
         base: '#2b4533',
         sheen: '#3d6148'
+      })
+    }
+  }),
+  Object.freeze({
+    id: 'plastic_monoblock_lt_olive_alligator',
+    label: 'LT Olive Alligator',
+    source: 'TonPlaygram molded-plastic satin alligator texture (LT Olive)',
+    rail: {
+      repeat: { x: 6.8, y: 6.8 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlinePlasticAlligatorPattern({
+        id: 'plastic-monoblock-lt-olive-alligator-rail',
+        base: '#4c5d3f',
+        sheen: '#6d7d58'
+      })
+    },
+    frame: {
+      repeat: { x: 6.8, y: 6.8 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlinePlasticAlligatorPattern({
+        id: 'plastic-monoblock-lt-olive-alligator-frame',
+        base: '#4c5d3f',
+        sheen: '#6d7d58'
+      })
+    }
+  }),
+  Object.freeze({
+    id: 'plastic_monoblock_lt_swamp_alligator',
+    label: 'LT Swamp Alligator',
+    source: 'TonPlaygram molded-plastic satin alligator texture (LT Swamp)',
+    rail: {
+      repeat: { x: 6.8, y: 6.8 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlinePlasticAlligatorPattern({
+        id: 'plastic-monoblock-lt-swamp-alligator-rail',
+        base: '#304b36',
+        sheen: '#48624d'
+      })
+    },
+    frame: {
+      repeat: { x: 6.8, y: 6.8 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlinePlasticAlligatorPattern({
+        id: 'plastic-monoblock-lt-swamp-alligator-frame',
+        base: '#304b36',
+        sheen: '#48624d'
+      })
+    }
+  }),
+  Object.freeze({
+    id: 'plastic_monoblock_lt_clay_alligator',
+    label: 'LT Clay Alligator',
+    source: 'TonPlaygram molded-plastic satin alligator texture (LT Clay)',
+    rail: {
+      repeat: { x: 6.8, y: 6.8 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlinePlasticAlligatorPattern({
+        id: 'plastic-monoblock-lt-clay-alligator-rail',
+        base: '#5f4c3c',
+        sheen: '#816a56'
+      })
+    },
+    frame: {
+      repeat: { x: 6.8, y: 6.8 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlinePlasticAlligatorPattern({
+        id: 'plastic-monoblock-lt-clay-alligator-frame',
+        base: '#5f4c3c',
+        sheen: '#816a56'
+      })
+    }
+  }),
+  Object.freeze({
+    id: 'plastic_monoblock_lt_sand_alligator',
+    label: 'LT Sand Alligator',
+    source: 'TonPlaygram molded-plastic satin alligator texture (LT Sand)',
+    rail: {
+      repeat: { x: 6.8, y: 6.8 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlinePlasticAlligatorPattern({
+        id: 'plastic-monoblock-lt-sand-alligator-rail',
+        base: '#7e6e56',
+        sheen: '#a49277'
+      })
+    },
+    frame: {
+      repeat: { x: 6.8, y: 6.8 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlinePlasticAlligatorPattern({
+        id: 'plastic-monoblock-lt-sand-alligator-frame',
+        base: '#7e6e56',
+        sheen: '#a49277'
+      })
+    }
+  }),
+  Object.freeze({
+    id: 'plastic_monoblock_lt_moss_alligator',
+    label: 'LT Moss Alligator',
+    source: 'TonPlaygram molded-plastic satin alligator texture (LT Moss)',
+    rail: {
+      repeat: { x: 6.8, y: 6.8 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlinePlasticAlligatorPattern({
+        id: 'plastic-monoblock-lt-moss-alligator-rail',
+        base: '#435340',
+        sheen: '#60715c'
+      })
+    },
+    frame: {
+      repeat: { x: 6.8, y: 6.8 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlinePlasticAlligatorPattern({
+        id: 'plastic-monoblock-lt-moss-alligator-frame',
+        base: '#435340',
+        sheen: '#60715c'
+      })
+    }
+  }),
+  Object.freeze({
+    id: 'plastic_monoblock_lt_night_alligator',
+    label: 'LT Night Alligator',
+    source: 'TonPlaygram molded-plastic satin alligator texture (LT Night)',
+    rail: {
+      repeat: { x: 6.8, y: 6.8 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlinePlasticAlligatorPattern({
+        id: 'plastic-monoblock-lt-night-alligator-rail',
+        base: '#263129',
+        sheen: '#3a453c'
+      })
+    },
+    frame: {
+      repeat: { x: 6.8, y: 6.8 },
+      rotation: 0,
+      textureSize: 2048,
+      ...makeInlinePlasticAlligatorPattern({
+        id: 'plastic-monoblock-lt-night-alligator-frame',
+        base: '#263129',
+        sheen: '#3a453c'
       })
     }
   }),


### PR DESCRIPTION
### Motivation

- Add a set of new LT "Alligator" table finishes (visuals, thumbnails and store items) to expand table customization.
- Introduce a global shot power scale to further tune Pool Royale shot output and keep parity with Snooker Royale adjustments.
- Improve AI pot aiming accuracy by biasing aim toward the pocket/ghost point and refine aim fallback behavior.
- Make replay foul slowdowns less disruptive by limiting and softening the time-dilation to the wrong-ball impact window and update replay UI/labels.

### Description

- Added new table finish thumbnails to `poolRoyaleInventoryConfig.js` and new option labels and store item entries for `carbonFiberAlligator*` finishes.
- Added `SHOT_GLOBAL_POWER_SCALE` and multiplied it into `SHOT_FORCE_BOOST` to reduce overall shot output, and adjusted related constants in `PoolRoyale.jsx`.
- Enhanced AI planning in `PoolRoyale.jsx` by computing a pocket-aware `aimPoint` for `pot` actions and applying an additional "ghost" refinement to set `aimDir` when appropriate.
- Reworked replay timing to track `elapsed` and `lastNow`, apply `REPLAY_FOUL_WRONG_BALL_IMPACT_SLOW_FACTOR` only during the wrong-ball impact window, and changed the slow factor value from `0.35` to `0.82`.
- Updated replay/foul UI rendering and styles in `PoolRoyale.jsx`, including localized foul banner text (`Faul`), slate/replay color accents, and adjusted layout classnames for banners and overlays.
- Implemented inline alligator SVG pattern generator `makeInlinePlasticAlligatorPattern` and added corresponding `WOOD_GRAIN_OPTIONS` entries in `woodMaterials.js` for Olive/Swamp/Clay/Sand/Moss/Night alligator variants.

### Testing

- Ran unit tests with `yarn test` and they passed.
- Ran linting with `yarn lint` and no lint errors were reported.
- Built the webapp with `yarn build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4fe023fa08329b219962eeedf8257)