### PR TITLE
Murlan Royale: raise top avatar badge and increase camera turn range

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -106,7 +106,7 @@ const ENABLE_3D_HUMAN_CHARACTERS = false;
 const ARENA_GROWTH = 1.45; // expanded arena footprint for wider walkways
 const CHAIR_SIZE_SCALE = 1;
 const ARENA_PROP_SCALE = 0.94; // Slightly shrink arena props so table/chairs/cards sit better against HDRI scale.
-const TOP_SEAT_AVATAR_UP_LIFT = 3.2; // Portrait-space lift for the visual top player's avatar badge.
+const TOP_SEAT_AVATAR_UP_LIFT = 3.8; // Portrait-space lift for the visual top player's avatar badge.
 
 const TABLE_RADIUS = 3.22 * MODEL_SCALE * ARENA_PROP_SCALE;
 const CHAIR_COUNT = 4;
@@ -2361,7 +2361,7 @@ const CAMERA_PLAY_NEXT_TURN_DELAY_MS = 520;
 const CAMERA_PLAY_TURN_DURATION_MS = 300;
 const CAMERA_TARGET_TURN_SNAP_DISTANCE = 0.018 * MODEL_SCALE;
 const CAMERA_PLAYER_TARGET_WEIGHT = 0.52;
-const CAMERA_SIDE_LOOK_EXTRA = 0.28 * MODEL_SCALE;
+const CAMERA_SIDE_LOOK_EXTRA = 0.34 * MODEL_SCALE;
 const CAMERA_INWARD_RADIUS_FACTOR = 0.72 * ARENA_PROP_SCALE;
 const CAMERA_UP_TILT_FORWARD_BLEND = 0.34 * MODEL_SCALE;
 const CAMERA_UP_TILT_FORWARD_LERP = 0.14;
@@ -4913,7 +4913,7 @@ export default function MurlanRoyaleArena({ search }) {
       controls.maxPolarAngle = ARENA_CAMERA_DEFAULTS.phiMax;
       const cameraOffset = camera.position.clone().sub(target);
       const cameraSpherical = new THREE.Spherical().setFromVector3(cameraOffset);
-      const horizontalSwing = THREE.MathUtils.degToRad(isPortrait ? 28 : 24);
+      const horizontalSwing = THREE.MathUtils.degToRad(isPortrait ? 32 : 27);
       const lockedPolarAngle = THREE.MathUtils.clamp(
         cameraSpherical.phi,
         ARENA_CAMERA_DEFAULTS.phiMin,
@@ -4925,7 +4925,7 @@ export default function MurlanRoyaleArena({ search }) {
       controls.maxAzimuthAngle = cameraSpherical.theta + horizontalSwing;
       controls.minDistance = desiredRadius;
       controls.maxDistance = desiredRadius;
-      controls.rotateSpeed = 0.6;
+      controls.rotateSpeed = 0.68;
       controls.target.copy(target);
       controls.update();
       cameraLockedPositionRef.current.copy(camera.position);


### PR DESCRIPTION
### Motivation
- Lift the top player's avatar badge slightly higher in portrait so the user's avatar appears more upward on the screen.
- Make the camera turn farther left/right and feel a bit more responsive during opponent turns so visual turns are more noticeable.

### Description
- Increased `TOP_SEAT_AVATAR_UP_LIFT` from `3.2` to `3.8` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to move the top-seat avatar badge upward.
- Increased `CAMERA_SIDE_LOOK_EXTRA` from `0.28 * MODEL_SCALE` to `0.34 * MODEL_SCALE`, widened the azimuth swing to `32°/27°` for portrait/landscape, and raised `OrbitControls.rotateSpeed` from `0.6` to `0.68` to make camera turns farther and slightly faster.

### Testing
- Ran `npm run build` from `webapp/` and the build completed successfully.
- The build produced existing non-blocking Vite chunk-size warnings but no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d51c4ca3a48329bd9f6fbb6c14e745)