### PR TITLE
Tune Pool Royale action camera, increase spin, and improve AI shot selection

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1741,9 +1741,9 @@ const ACTION_CAM = Object.freeze({
   heightOffset: BALL_R * 9.2,
   smoothingTime: 0.24,
   followSmoothingTime: 0.18,
-  followDistance: BALL_R * 54,
+  followDistance: BALL_R * 42,
   followHeightOffset: BALL_R * 7.4,
-  followHoldMs: 900
+  followHoldMs: 520
 });
 /**
  * Pool Camera Direction
@@ -1793,7 +1793,7 @@ const POCKET_VIEW_POST_POT_HOLD_MS =
   POCKET_DROP_RING_HOLD_MS + POCKET_DROP_REST_HOLD_MS;
 const POCKET_VIEW_MAX_HOLD_MS = 2200;
 const POCKET_VIEW_EARLY_HOLD_MS = 320;
-const SPIN_GLOBAL_SCALE = 0.98; // slightly stronger global spin so english/follow/draw feel closer to real-table response
+const SPIN_GLOBAL_SCALE = 1.176; // increase global spin response by ~20% so english/follow/draw are more pronounced
 // Spin controller adapted from the open-source Billiards solver physics (MIT License).
 const SPIN_TABLE_REFERENCE_WIDTH = 2.627;
 const SPIN_TABLE_REFERENCE_HEIGHT = 1.07707;
@@ -27563,11 +27563,23 @@ const powerRef = useRef(hud.power);
             );
           };
           const scoredPots = potShots
-            .map((plan) => ({ plan, score: scorePotPlan(plan) }))
+            .map((plan) => {
+              const score = scorePotPlan(plan);
+              const potChance = Number.isFinite(plan?.potChance) ? plan.potChance : 0;
+              const difficultyNorm = Math.max(PLAY_W + PLAY_H, BALL_R * 120);
+              const difficultyPenalty = Number.isFinite(plan?.difficulty)
+                ? Math.min(plan.difficulty / difficultyNorm, 1)
+                : 1;
+              const weightedScore =
+                potChance * 0.62 + score * 0.46 - difficultyPenalty * 0.18;
+              return { plan, score, weightedScore, potChance };
+            })
             .sort(
               (a, b) =>
-                (b.plan?.potChance ?? b.score ?? 0) -
-                  (a.plan?.potChance ?? a.score ?? 0) ||
+                (b.weightedScore ?? b.score ?? 0) -
+                  (a.weightedScore ?? a.score ?? 0) ||
+                (b.potChance ?? b.plan?.potChance ?? 0) -
+                  (a.potChance ?? a.plan?.potChance ?? 0) ||
                 b.score - a.score ||
                 (a.plan?.difficulty ?? 0) - (b.plan?.difficulty ?? 0)
             );
@@ -27579,7 +27591,14 @@ const powerRef = useRef(hud.power);
           const playableCushionPots = scoredPots.filter(
             (entry) => entry.plan && isPlayablePlan(entry.plan, { allowCushion: true })
           );
-          const bestPot = playableCushionPots[0]?.plan ?? null;
+          const HIGH_CONFIDENCE_POT_THRESHOLD = isRotationVariant ? 0.68 : 0.64;
+          const highConfidencePots = playableCushionPots.filter(
+            (entry) => (entry.potChance ?? entry.plan?.potChance ?? 0) >= HIGH_CONFIDENCE_POT_THRESHOLD
+          );
+          const bestPot =
+            highConfidencePots[0]?.plan ??
+            playableCushionPots[0]?.plan ??
+            null;
           const bestSafetyCandidate =
             safetyShots.find((plan) => isPlayablePlan(plan, { allowCushion: true })) ?? null;
           const bestSafety =


### PR DESCRIPTION
### Motivation
- Make the action camera follow the cue ball briefly during/after a shot then switch back, to match requested dynamic follow behavior.
- Increase overall visible spinning (english/follow/draw) by ~20% to make cue effects more pronounced.
- Prevent the AI from choosing low-probability, high-difficulty pots that leave easy follow-up shots by favoring higher-probability targets.

### Description
- Reduced action-camera follow window by lowering `ACTION_CAM.followDistance` from `BALL_R * 54` to `BALL_R * 42` and `ACTION_CAM.followHoldMs` from `900` to `520` in `webapp/src/pages/Games/PoolRoyale.jsx` to produce a shorter, subtler follow then switch behavior.
- Increased global spin response by raising `SPIN_GLOBAL_SCALE` from `0.98` to `1.176` in `webapp/src/pages/Games/PoolRoyale.jsx` to produce ~20% stronger spin effects.
- Re-ranked AI pot candidates by computing a `weightedScore` that combines `potChance`, the existing `scorePotPlan` value, and a `difficultyPenalty`, then sorting by `weightedScore` and applying a `HIGH_CONFIDENCE_POT_THRESHOLD` (0.68 for rotation variants, 0.64 otherwise) to prefer high-probability pots before falling back to lower-confidence options, all implemented in `webapp/src/pages/Games/PoolRoyale.jsx`.

### Testing
- Ran targeted unit tests: `npm test -- --runInBand test/poolRoyaleSpinController.test.js test/poolUkAdvancedAi.test.js`.
- Result: both test suites passed (2 suites, 13 tests total all passing).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5d6582adc8329aa5adc661421e989)