### PR TITLE
Improve Pool Royal AI shot selection and pocket targeting

### DIFF
--- a/Assets/Resources/AimingConfig.asset
+++ b/Assets/Resources/AimingConfig.asset
@@ -16,6 +16,10 @@ MonoBehaviour:
   ctePivotDeg: 3
   shortDist: 0.8
   mediumDist: 1.6
+  pocketApproachDepth: 0.12
+  cuePathClearanceRadiusScale: 0.92
+  cutAnglePenalty: 0.55
+  distancePenalty: 0.2
   sideSpinAmount: 0.35
   verticalSpinAmount: 0.35
   tipOffsetMax: 0.85

--- a/Assets/Scripts/Aiming/AdaptiveAimingEngine.cs
+++ b/Assets/Scripts/Aiming/AdaptiveAimingEngine.cs
@@ -75,15 +75,16 @@ namespace Aiming
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public AimSolution GetAimSolution(in ShotContext ctx)
         {
-            var info = classifier.Classify(ctx, config);
+            ShotContext evalCtx = NormalizePocketTarget(ctx);
+            var info = classifier.Classify(evalCtx, config);
             if (!info.losCueToObj || !info.losObjToPocket)
             {
                 var blocked = new AimSolution
                 {
                     isValid = false,
                     strategyUsed = "None",
-                    aimStart = ctx.cueBallPos,
-                    aimEnd = ctx.objectBallPos,
+                    aimStart = evalCtx.cueBallPos,
+                    aimEnd = evalCtx.objectBallPos,
                     recommendedPower01 = 0f,
                     tipOffset = Vector2.zero,
                     cueElevationDeg = 0f,
@@ -91,31 +92,15 @@ namespace Aiming
                 };
 
                 DrawGuideLine(blocked.aimStart, blocked.aimEnd);
-                if (showDebug) overlay.UpdateOverlay(ctx, info, blocked);
+                if (showDebug) overlay.UpdateOverlay(evalCtx, info, blocked);
                 return blocked;
             }
 
-            IAimingStrategy strat;
-            if (info.isStraight)
+            var sol = SelectBestSolution(evalCtx, info);
+            if (!sol.isValid)
             {
-                strat = ghost;
+                sol = BuildDefaultSolution(evalCtx, info);
             }
-            else if (info.isRailShot || info.angleDeg < 30f)
-            {
-                strat = contact;
-            }
-            else if (info.angleDeg <= 45f)
-            {
-                bool longOrSpin = (info.distBucket == ShotClassifier.DistBucket.Long) || ctx.highSpin;
-                strat = longOrSpin ? cte : ghost;
-            }
-            else
-            {
-                strat = fractional;
-            }
-            if ((ctx.requiresPower || ctx.highSpin) && info.distBucket != ShotClassifier.DistBucket.Short) strat = cte;
-
-            var sol = strat.Solve(ctx, info, config);
             sol.recommendedPower01 = RecommendPower(info.distBucket, ctx.requiresPower);
             if (ctx.highSpin)
             {
@@ -130,10 +115,9 @@ namespace Aiming
                     Mathf.Clamp(vert, -config.tipOffsetMax, config.tipOffsetMax));
                 sol.cueElevationDeg = (ctx.requiresPower && info.isRailShot) ? config.elevationForPower : 0f;
             }
-            sol.strategyUsed = strat.Name;
 
             DrawGuideLine(sol.aimStart, sol.aimEnd);
-            if (showDebug) overlay.UpdateOverlay(ctx, info, sol);
+            if (showDebug) overlay.UpdateOverlay(evalCtx, info, sol);
 
             return sol;
         }
@@ -154,6 +138,79 @@ namespace Aiming
                 case ShotClassifier.DistBucket.Medium: return requiresPower ? 0.70f : 0.50f;
                 default: return requiresPower ? 0.90f : 0.70f;
             }
+        }
+
+        ShotContext NormalizePocketTarget(in ShotContext ctx)
+        {
+            var normalized = ctx;
+            Vector3 toPocket = ctx.pocketPos - ctx.objectBallPos;
+            if (toPocket.sqrMagnitude < 1e-8f)
+                return normalized;
+
+            float depth = config ? config.pocketApproachDepth : 0.12f;
+            normalized.pocketPos = ctx.pocketPos - toPocket.normalized * Mathf.Max(depth, ctx.ballRadius * 0.5f);
+            return normalized;
+        }
+
+        AimSolution SelectBestSolution(in ShotContext ctx, in ShotInfo info)
+        {
+            IAimingStrategy[] candidates = { ghost, contact, fractional, cte };
+            bool hasBest = false;
+            float bestScore = float.MaxValue;
+            AimSolution best = default;
+
+            foreach (var candidate in candidates)
+            {
+                var attempt = candidate.Solve(ctx, info, config);
+                if (!attempt.isValid)
+                    continue;
+
+                if (!IsCuePathClear(ctx.cueBallPos, attempt.aimEnd, ctx))
+                    continue;
+
+                float score = ScoreAttempt(ctx, info, attempt);
+                if (score < bestScore)
+                {
+                    bestScore = score;
+                    best = attempt;
+                    best.strategyUsed = candidate.Name;
+                    best.debugNote = $"{attempt.debugNote} score={score:0.###}";
+                    hasBest = true;
+                }
+            }
+
+            if (!hasBest)
+                return default;
+
+            best.isValid = true;
+            return best;
+        }
+
+        AimSolution BuildDefaultSolution(in ShotContext ctx, in ShotInfo info)
+        {
+            IAimingStrategy fallback = info.isStraight ? ghost :
+                (info.isRailShot || info.angleDeg < 30f) ? contact :
+                (info.angleDeg <= 45f) ? ghost : fractional;
+            var sol = fallback.Solve(ctx, info, config);
+            sol.strategyUsed = fallback.Name;
+            return sol;
+        }
+
+        bool IsCuePathClear(Vector3 cue, Vector3 target, in ShotContext ctx)
+        {
+            float clearance = ctx.ballRadius * (config ? config.cuePathClearanceRadiusScale : 0.92f);
+            return PhysicsUtil.SphereLineClear(cue, target, clearance, ctx.collisionMask);
+        }
+
+        float ScoreAttempt(in ShotContext ctx, in ShotInfo info, in AimSolution attempt)
+        {
+            Vector3 cueDir = (attempt.aimEnd - ctx.cueBallPos).normalized;
+            Vector3 idealDir = (ctx.objectBallPos - ctx.cueBallPos).normalized;
+            float directionalMiss = 1f - Mathf.Clamp01(Vector3.Dot(cueDir, idealDir));
+
+            float cutPenalty = (config ? config.cutAnglePenalty : 0.55f) * (info.angleDeg / 90f);
+            float distancePenalty = (config ? config.distancePenalty : 0.2f) * Vector3.Distance(ctx.cueBallPos, attempt.aimEnd);
+            return directionalMiss + cutPenalty + distancePenalty;
         }
     }
 }

--- a/Assets/Scripts/Aiming/AimingConfig.cs
+++ b/Assets/Scripts/Aiming/AimingConfig.cs
@@ -13,6 +13,16 @@ namespace Aiming
         public float shortDist = 0.8f;
         public float mediumDist = 1.6f;
 
+        [Header("AI competitiveness")]
+        [Tooltip("Offsets pocket targeting away from jaw collisions by aiming slightly inside the pocket entrance.")]
+        public float pocketApproachDepth = 0.12f;
+        [Tooltip("Rejects candidate aims where cue-to-contact line is significantly blocked.")]
+        public float cuePathClearanceRadiusScale = 0.92f;
+        [Tooltip("Penalty weight for harder cut angles so easier pots are preferred.")]
+        public float cutAnglePenalty = 0.55f;
+        [Tooltip("Penalty weight for long cue-ball travel.")]
+        public float distancePenalty = 0.2f;
+
         [Header("Spin")]
         public float sideSpinAmount = 0.35f;
         public float verticalSpinAmount = 0.35f;


### PR DESCRIPTION
### Motivation
- The existing AI sometimes aims at low-percentage lines (jaw hits / long cuts) and ignores easier pots, producing glitchy, uncompetitive play. 
- The goal is to make AI choose more reliable, center-pocket approaches and prefer simpler/easier shots via tunable heuristics.

### Description
- Added new AI tuning fields to `AimingConfig` and the default resource asset: `pocketApproachDepth`, `cuePathClearanceRadiusScale`, `cutAnglePenalty`, and `distancePenalty` so behavior is adjustable without code changes (`Assets/Scripts/Aiming/AimingConfig.cs`, `Assets/Resources/AimingConfig.asset`).
- Reworked `AdaptiveAimingEngine.GetAimSolution` to normalize the pocket target inward (`NormalizePocketTarget`) so aim lines target the pocket entrance instead of raw center, reducing jaw collisions (`Assets/Scripts/Aiming/AdaptiveAimingEngine.cs`).
- Replaced the single-branch strategy selection with candidate evaluation across `Ghost`, `Contact`, `Fractional`, and `CTE` strategies, rejecting blocked cue paths and scoring candidates by directional miss + cut-angle penalty + travel distance, then choosing the best-scoring valid attempt (`SelectBestSolution`, `ScoreAttempt`, `IsCuePathClear`, `BuildDefaultSolution`).
- Updated debug overlay and guide-line drawing to operate against the evaluated/normalized shot context so debug visuals reflect the selected candidate.

### Testing
- Attempted to run unit tests with `dotnet test billiards.Tests/Billiards.Tests.csproj`, but the test run failed because `dotnet` is not available in the container (environment error).
- No other automated test runs were executed in this environment; changes are confined to aiming logic and config and should be exercised via playmode tests / Unity editor validation in CI or locally with Unity and the .NET SDK installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5e12d1e7c8329ac841476ded7cc30)