### PR TITLE
Adjust Chess Battle Royal arena proportions and per-shape board height

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -241,13 +241,13 @@ const BOARD_VISUAL_Y_OFFSET = -0.08;
 const BOARD_SURFACE_DROP = 0.05;
 
 const RAW_BOARD_SIZE = BOARD.N * BOARD.tile + BOARD.rim * 2;
-const BOARD_SCALE = 0.053;
+const BOARD_SCALE = 0.049;
 const BOARD_DISPLAY_SIZE = RAW_BOARD_SIZE * BOARD_SCALE;
 const BOARD_MODEL_SPAN_BIAS = 1.18;
 const HIGHLIGHT_VERTICAL_OFFSET = 0.18;
 const PIECE_SELECTION_LIFT = 0.18;
 
-const TABLE_RADIUS = 3.05 * MODEL_SCALE;
+const TABLE_RADIUS = 2.78 * MODEL_SCALE;
 const SEAT_WIDTH = 0.9 * MODEL_SCALE * STOOL_SCALE;
 const SEAT_DEPTH = 0.95 * MODEL_SCALE * STOOL_SCALE;
 const SEAT_THICKNESS = 0.09 * MODEL_SCALE * STOOL_SCALE;
@@ -268,7 +268,7 @@ const CAMERA_TABLE_SPAN_FACTOR = 2.6;
 
 const WALL_PROXIMITY_FACTOR = 0.5; // Bring arena walls 50% closer
 const WALL_HEIGHT_MULTIPLIER = 2; // Double wall height
-const CHAIR_SCALE = 1.2;
+const CHAIR_SCALE = 1.06;
 const CHAIR_CLEARANCE = AI_CHAIR_GAP;
 const PLAYER_CHAIR_EXTRA_CLEARANCE = 0;
 const CAMERA_PHI_OFFSET = 0;
@@ -284,6 +284,13 @@ const MIN_RENDER_PIXEL_RATIO = 0.85;
 const SEAT_LABEL_HEIGHT = 0.74;
 const SEAT_LABEL_FORWARD_OFFSET = -0.32;
 const AVATAR_ANCHOR_HEIGHT = SEAT_THICKNESS / 2 + BACK_HEIGHT * 0.85;
+const BOARD_SURFACE_SHAPE_OFFSETS = Object.freeze({
+  classicOctagon: -0.05,
+  grandOval: -0.05,
+  diamondEdge: -0.06,
+  hexagonTable: -0.055
+});
+
 const FALLBACK_SEAT_POSITIONS = [
   { left: '50%', top: '85%' },
   { left: '50%', top: '12%' }
@@ -1757,7 +1764,11 @@ function alignBoardGroupToTableSurface(boardGroup, tableInfo) {
   const surfaceY = Number.isFinite(tableInfo?.surfaceY)
     ? tableInfo.surfaceY
     : TABLE_HEIGHT;
-  return alignGroupToFloorY(boardGroup, surfaceY + BOARD_GROUP_Y_OFFSET);
+  const shapeId = tableInfo?.shapeId;
+  const shapeOffset = Number.isFinite(BOARD_SURFACE_SHAPE_OFFSETS[shapeId])
+    ? BOARD_SURFACE_SHAPE_OFFSETS[shapeId]
+    : 0;
+  return alignGroupToFloorY(boardGroup, surfaceY + BOARD_GROUP_Y_OFFSET + shapeOffset);
 }
 
 function alignArenaContentsToRoom(groups = [], roomHalfWidth, roomHalfDepth) {


### PR DESCRIPTION
### Motivation
- The table/chairs/board were visually too large compared to HDRI environments and several table shapes (octagon, hexagon, oval, diamond) placed the board and pieces noticeably high above the cloth surface. 
- Make the scene proportions match HDRI scale and ensure the board and pieces sit flush with the table cloth for those problematic shapes.

### Description
- Reduced global scene sizes by shrinking `BOARD_SCALE` from `0.053` to `0.049`, `TABLE_RADIUS` from `3.05 * MODEL_SCALE` to `2.78 * MODEL_SCALE`, and `CHAIR_SCALE` from `1.2` to `1.06` in `webapp/src/pages/Games/ChessBattleRoyal.jsx` to make tables/chairs/board appear smaller. 
- Added `BOARD_SURFACE_SHAPE_OFFSETS` (shape-specific vertical offsets) for `classicOctagon`, `grandOval`, `diamondEdge`, and `hexagonTable` so those shapes can lower the board slightly. 
- Updated `alignBoardGroupToTableSurface` to apply the per-shape offset when aligning the board group to the table surface so the board and pieces sit lower on affected table shapes.

### Testing
- Ran ESLint via `npx eslint webapp/src/pages/Games/ChessBattleRoyal.jsx`, which completed with a single file-ignore warning (no rule errors). 
- Ran the unit test `npm test -- --runInBand test/chessLobbyPreferredSideMatchmaking.test.js`, which passed (1 test, 1 suite passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5e49e78708329a1e0136c2951e461)