### PR TITLE
Adjust Chess Battle Royal arena proportions and board surface alignment

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -233,7 +233,7 @@ const CARD_SCALE = 0.95;
 const BOARD = { N: 8, tile: 4.2, rim: 3, baseH: 0.8 };
 const PIECE_Y = 1.2; // baseline height for meshes
 const PIECE_PLACEMENT_Y_OFFSET = 0.28;
-const PIECE_SCALE_FACTOR = 0.92;
+const PIECE_SCALE_FACTOR = 0.88;
 const PIECE_FOOTPRINT_RATIO = 0.86;
 const BOARD_GROUP_Y_OFFSET = 0;
 const BOARD_MODEL_Y_OFFSET = -0.12;
@@ -241,13 +241,13 @@ const BOARD_VISUAL_Y_OFFSET = -0.08;
 const BOARD_SURFACE_DROP = 0.05;
 
 const RAW_BOARD_SIZE = BOARD.N * BOARD.tile + BOARD.rim * 2;
-const BOARD_SCALE = 0.053;
+const BOARD_SCALE = 0.049;
 const BOARD_DISPLAY_SIZE = RAW_BOARD_SIZE * BOARD_SCALE;
 const BOARD_MODEL_SPAN_BIAS = 1.18;
 const HIGHLIGHT_VERTICAL_OFFSET = 0.18;
 const PIECE_SELECTION_LIFT = 0.18;
 
-const TABLE_RADIUS = 3.05 * MODEL_SCALE;
+const TABLE_RADIUS = 2.86 * MODEL_SCALE;
 const SEAT_WIDTH = 0.9 * MODEL_SCALE * STOOL_SCALE;
 const SEAT_DEPTH = 0.95 * MODEL_SCALE * STOOL_SCALE;
 const SEAT_THICKNESS = 0.09 * MODEL_SCALE * STOOL_SCALE;
@@ -268,7 +268,7 @@ const CAMERA_TABLE_SPAN_FACTOR = 2.6;
 
 const WALL_PROXIMITY_FACTOR = 0.5; // Bring arena walls 50% closer
 const WALL_HEIGHT_MULTIPLIER = 2; // Double wall height
-const CHAIR_SCALE = 1.2;
+const CHAIR_SCALE = 1.08;
 const CHAIR_CLEARANCE = AI_CHAIR_GAP;
 const PLAYER_CHAIR_EXTRA_CLEARANCE = 0;
 const CAMERA_PHI_OFFSET = 0;
@@ -1757,7 +1757,11 @@ function alignBoardGroupToTableSurface(boardGroup, tableInfo) {
   const surfaceY = Number.isFinite(tableInfo?.surfaceY)
     ? tableInfo.surfaceY
     : TABLE_HEIGHT;
-  return alignGroupToFloorY(boardGroup, surfaceY + BOARD_GROUP_Y_OFFSET);
+  const surfaceOffset =
+    BOARD_SURFACE_OFFSETS_BY_SHAPE[tableInfo?.shapeId] ??
+    BOARD_SURFACE_OFFSETS_BY_SHAPE[tableInfo?.themeId] ??
+    0;
+  return alignGroupToFloorY(boardGroup, surfaceY + BOARD_GROUP_Y_OFFSET + surfaceOffset);
 }
 
 function alignArenaContentsToRoom(groups = [], roomHalfWidth, roomHalfDepth) {
@@ -1870,6 +1874,12 @@ const CUSTOMIZATION_SECTIONS = [
 ];
 
 const SHAPE_CUSTOMIZATION_TABLE_IDS = new Set(['hexagonTable', 'murlan-default', 'grandOval', 'diamondEdge']);
+const BOARD_SURFACE_OFFSETS_BY_SHAPE = Object.freeze({
+  classicOctagon: -0.065,
+  hexagonTable: -0.065,
+  grandOval: -0.065,
+  diamondEdge: -0.07
+});
 
 function normalizeAppearance(value = {}) {
   const normalized = { ...DEFAULT_APPEARANCE };


### PR DESCRIPTION
### Motivation
- The table, chairs, board and pieces appeared too large relative to the HDRI environment, causing visual mismatch in the arena presentation.
- For non-round procedural table shapes (octagon/hexagon/oval/diamond) the board and pieces were positioned too high and visually floating above the cloth instead of touching it.

### Description
- Reduced visual footprint by lowering `PIECE_SCALE_FACTOR` to `0.88`, `BOARD_SCALE` to `0.049`, `TABLE_RADIUS` to `2.86 * MODEL_SCALE`, and `CHAIR_SCALE` to `1.08` in `webapp/src/pages/Games/ChessBattleRoyal.jsx`.
- Added a `BOARD_SURFACE_OFFSETS_BY_SHAPE` mapping with per-shape vertical offsets for `classicOctagon`, `hexagonTable`, `grandOval`, and `diamondEdge`.
- Updated `alignBoardGroupToTableSurface` to apply the per-shape `surfaceOffset` so the board/pieces sit down onto the table cloth for shaped tables.
- All changes are confined to `webapp/src/pages/Games/ChessBattleRoyal.jsx`.

### Testing
- Ran the production build with `npm --prefix webapp run build` which completed successfully.
- Build completed with Vite warnings about chunk sizes and dynamic imports but no build failures were produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5e49e78708329a1e0136c2951e461)