### PR TITLE
Adjust chess arena scale and lower board on shaped tables

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -226,7 +226,7 @@ const resolveHdriVariant = (value) => {
   return CHESS_HDRI_OPTIONS[idx] ?? CHESS_HDRI_OPTIONS[DEFAULT_HDRI_INDEX] ?? CHESS_HDRI_OPTIONS[0];
 };
 
-const MODEL_SCALE = 0.75;
+const MODEL_SCALE = 0.68;
 const STOOL_SCALE = 1.5 * 1.3;
 const CARD_SCALE = 0.95;
 
@@ -241,7 +241,7 @@ const BOARD_VISUAL_Y_OFFSET = -0.08;
 const BOARD_SURFACE_DROP = 0.05;
 
 const RAW_BOARD_SIZE = BOARD.N * BOARD.tile + BOARD.rim * 2;
-const BOARD_SCALE = 0.049;
+const BOARD_SCALE = 0.044;
 const BOARD_DISPLAY_SIZE = RAW_BOARD_SIZE * BOARD_SCALE;
 const BOARD_MODEL_SPAN_BIAS = 1.18;
 const HIGHLIGHT_VERTICAL_OFFSET = 0.18;
@@ -268,7 +268,7 @@ const CAMERA_TABLE_SPAN_FACTOR = 2.6;
 
 const WALL_PROXIMITY_FACTOR = 0.5; // Bring arena walls 50% closer
 const WALL_HEIGHT_MULTIPLIER = 2; // Double wall height
-const CHAIR_SCALE = 1.08;
+const CHAIR_SCALE = 0.95;
 const CHAIR_CLEARANCE = AI_CHAIR_GAP;
 const PLAYER_CHAIR_EXTRA_CLEARANCE = 0;
 const CAMERA_PHI_OFFSET = 0;
@@ -1875,10 +1875,10 @@ const CUSTOMIZATION_SECTIONS = [
 
 const SHAPE_CUSTOMIZATION_TABLE_IDS = new Set(['hexagonTable', 'murlan-default', 'grandOval', 'diamondEdge']);
 const BOARD_SURFACE_OFFSETS_BY_SHAPE = Object.freeze({
-  classicOctagon: -0.065,
-  hexagonTable: -0.065,
-  grandOval: -0.065,
-  diamondEdge: -0.07
+  classicOctagon: -0.12,
+  hexagonTable: -0.12,
+  grandOval: -0.12,
+  diamondEdge: -0.125
 });
 
 function normalizeAppearance(value = {}) {


### PR DESCRIPTION
### Motivation
- Make table, chairs, board and pieces visually smaller to better match HDRI environment proportions and mobile portrait view. 
- Fix floating board/pieces when certain shaped tables are selected so the board touches the table cloth/top surface for octagon/hexagon/oval/diamond shapes.

### Description
- Reduced arena model scale by changing `MODEL_SCALE` from `0.75` to `0.68` in `webapp/src/pages/Games/ChessBattleRoyal.jsx` to shrink the table/chairs/board/pieces.
- Reduced board visual size by changing `BOARD_SCALE` from `0.049` to `0.044` to improve HDRI proportioning.
- Reduced `CHAIR_SCALE` from `1.08` to `0.95` to keep chair proportions consistent after the arena scale change.
- Lowered board alignment offsets for shaped tables by updating `BOARD_SURFACE_OFFSETS_BY_SHAPE` for `classicOctagon`, `hexagonTable`, `grandOval`, and `diamondEdge` so the board and pieces sit down onto the cloth (`-0.065 -> -0.12`, `-0.07 -> -0.125`).

### Testing
- Ran the targeted unit test: `npm test -- --runInBand test/chessLobbyPreferredSideMatchmaking.test.js`, which passed.
- No automated visual/screenshot tests were executed in this environment; visual verification should be performed on device/browser to confirm proportions and board contact with table surfaces.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5eb6203ac832981e488c198faa4bf)