### PR TITLE
Improve Pool Royale AI shot quality, power control, and safety fallback

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -44,6 +44,7 @@ const LOOKAHEAD_DEPTH = 6
 const LOOKAHEAD_CANDIDATES = 14
 const MONTE_CARLO_BASE_SAMPLES = 128
 const POWER_SCALE = 0.8
+const MIN_COMPETITIVE_QUALITY = 0.16
 
 function createRng (seed) {
   let state = (seed ?? 0) >>> 0
@@ -548,6 +549,98 @@ export function estimateCueAfterShot (cue, target, pocket, power, spin, table) {
   return result
 }
 
+function recommendedPowerForPot (cue, target, entry, cutAngle, req) {
+  const r = Math.max(req?.state?.ballRadius || 0, 1)
+  const tableDiag = Math.hypot(req.state.width, req.state.height) || 1
+  const cueToTarget = dist(cue, target)
+  const targetToPocket = dist(target, entry)
+  const travelNorm = Math.min((cueToTarget * 0.6 + targetToPocket * 0.85) / (tableDiag * 0.72), 1)
+  const cutSeverity = Math.min(Math.abs(cutAngle) / (Math.PI / 2), 1)
+  const base = 0.37 + travelNorm * 0.35 + cutSeverity * 0.16
+  const pocketTightness = Math.min(targetToPocket / (r * 30), 1)
+  const controlOffset = pocketTightness * 0.06
+  return Math.max(0.36, Math.min(0.92, base + controlOffset)) * POWER_SCALE
+}
+
+function projectedScratchRisk (cueAfter, req) {
+  const r = req.state.ballRadius
+  const closeToPocket = (req.state.pockets || []).some(p => dist(cueAfter, p) < r * 1.35)
+  if (closeToPocket) return 1
+  let worst = 0
+  for (const pocket of (req.state.pockets || [])) {
+    const d = dist(cueAfter, pocket)
+    const score = Math.max(0, 1 - d / (r * 14))
+    if (score > worst) worst = score
+  }
+  return Math.min(worst, 1)
+}
+
+function mirrorPointAcrossRail (point, rail, state) {
+  switch (rail) {
+    case 'left': return { x: -point.x, y: point.y }
+    case 'right': return { x: state.width * 2 - point.x, y: point.y }
+    case 'top': return { x: point.x, y: -point.y }
+    case 'bottom': return { x: point.x, y: state.height * 2 - point.y }
+    default: return null
+  }
+}
+
+function firstRailContact (cue, mirroredTarget, rail, state) {
+  const dx = mirroredTarget.x - cue.x
+  const dy = mirroredTarget.y - cue.y
+  if (Math.abs(dx) < 1e-6 && Math.abs(dy) < 1e-6) return null
+  if (rail === 'left' || rail === 'right') {
+    const xRail = rail === 'left' ? 0 : state.width
+    if (Math.abs(dx) < 1e-6) return null
+    const t = (xRail - cue.x) / dx
+    if (t <= 0 || t >= 1) return null
+    const y = cue.y + dy * t
+    if (y <= 0 || y >= state.height) return null
+    return { x: xRail, y }
+  }
+  const yRail = rail === 'top' ? 0 : state.height
+  if (Math.abs(dy) < 1e-6) return null
+  const t = (yRail - cue.y) / dy
+  if (t <= 0 || t >= 1) return null
+  const x = cue.x + dx * t
+  if (x <= 0 || x >= state.width) return null
+  return { x, y: yRail }
+}
+
+function oneCushionKickShot (req) {
+  const cueBallId = resolveCueBallId(req.state)
+  const cue = req.state.balls.find(b => b.id === cueBallId)
+  if (!cue) return null
+  const legalTargets = chooseTargets(req)
+  if (!legalTargets.length) return null
+  const rails = ['left', 'right', 'top', 'bottom']
+  let best = null
+  for (const target of legalTargets) {
+    for (const rail of rails) {
+      const mirrored = mirrorPointAcrossRail(target, rail, req.state)
+      if (!mirrored) continue
+      const cushion = firstRailContact(cue, mirrored, rail, req.state)
+      if (!cushion) continue
+      if (pathBlocked(cue, cushion, req.state.balls, [cueBallId], req.state.ballRadius, 1.05)) continue
+      if (pathBlocked(cushion, target, req.state.balls, [cueBallId, target.id], req.state.ballRadius, 1.05)) continue
+      const distance = dist(cue, cushion) + dist(cushion, target)
+      const tableDiag = Math.hypot(req.state.width, req.state.height) || 1
+      const difficulty = Math.min(distance / (tableDiag * 1.2), 1)
+      const candidate = {
+        angleRad: Math.atan2(cushion.y - cue.y, cushion.x - cue.x),
+        power: Math.max(0.48 * POWER_SCALE, Math.min(0.84 * POWER_SCALE, (0.46 + difficulty * 0.36) * POWER_SCALE)),
+        spin: { top: 0, side: 0, back: 0.08 },
+        targetBallId: target.id,
+        aimPoint: cushion,
+        quality: 0.28 - difficulty * 0.18,
+        rationale: `one-cushion-kick rail=${rail} target=${target.id}`
+      }
+      if (!best || candidate.quality > best.quality) best = candidate
+    }
+  }
+  return best
+}
+
 function clampPointToTable (point, table, margin = 1) {
   if (!table) return { ...point }
   const inset = (table.ballRadius || 0) * margin
@@ -757,13 +850,17 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
   const cueToTarget = dist(cue, target)
   const shotLengthFactor = Math.min(cueToTarget / (r * 40), 2)
   const cutSeverity = Math.min(cutAngle / (Math.PI / 2), 1)
+  const recommendedPower = recommendedPowerForPot(cue, target, entry, cutAngle, req)
+  const powerDeviation = Math.abs(power - recommendedPower) / Math.max(0.25 * POWER_SCALE, 1e-6)
   const pocketTightness = 1 - pocketOpen
   const difficultyPenalty = 0.25 * (0.5 * cutSeverity + 0.3 * shotLengthFactor + 0.2 * pocketTightness)
   const spinPenalty =
     Math.abs(spin.side || 0) * 0.06 +
     Math.max(0, spin.back || 0) * 0.12 +
     Math.max(0, spin.top || 0) * 0.04
-  const powerControlPenalty = Math.max(0, power - (0.5 * POWER_SCALE)) * 0.35
+  const powerControlPenalty =
+    Math.max(0, power - (0.5 * POWER_SCALE)) * 0.24 +
+    Math.max(0, powerDeviation - 0.12) * 0.2
   const clearanceScore = Math.max(0, Math.min((laneClearance - 0.5) / 0.7, 1))
   if (strict && (centerAlign < 0.5 || pocketOpen < 0.3)) {
     return null
@@ -774,6 +871,7 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
   const runoutPotential = options.skipLookahead
     ? 0
     : estimateRunoutPotential(req, cueAfter, target.id, balls, lookaheadDepth, rng)
+  const scratchProjection = projectedScratchRisk(cueAfter, req)
   const quality = Math.max(
     0,
     Math.min(
@@ -786,6 +884,7 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
         0.14 * runoutPotential +
         0.11 * clearanceScore -
         0.21 * risk -
+        scratchProjection * 0.18 -
         (scratchAfterImpact ? 0.2 : 0) -
         spinPenalty -
         powerControlPenalty -
@@ -810,6 +909,8 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
 function safetyShot (req) {
   const cueBallId = resolveCueBallId(req.state)
   const cue = req.state.balls.find(b => b.id === cueBallId)
+  const oneCushion = oneCushionKickShot(req)
+  if (oneCushion) return oneCushion
   const corners = [
     { x: 0, y: 0 },
     { x: req.state.width, y: 0 },
@@ -823,7 +924,7 @@ function safetyShot (req) {
     power: 0.5 * POWER_SCALE,
     spin: { top: 0, side: 0, back: 0 },
     quality: 0,
-    rationale: 'safety'
+    rationale: 'safety-distance'
   }
 }
 
@@ -1013,7 +1114,7 @@ export function planShot (req) {
           for (const spin of spins.concat(defaultSpins)) {
             if (power === powers[0] && spin === spins[0]) continue
             if (Date.now() > deadline) {
-              return best && best.quality >= 0.1 ? best : fallbackAimAtTarget(req) || safetyShot(req)
+              return best && best.quality >= MIN_COMPETITIVE_QUALITY ? best : fallbackAimAtTarget(req) || safetyShot(req)
             }
             const cand = evaluate(
               req,
@@ -1053,7 +1154,7 @@ export function planShot (req) {
       best.suggestedTargetBallId = suggestion.suggestedTargetBallId
       best.suggestedAimPoint = suggestion.suggestedAimPoint
     }
-    if (best.quality >= 0.1) return best
+    if (best.quality >= MIN_COMPETITIVE_QUALITY) return best
     if (hasViableShot) return best
   }
   if (!hasViableShot) return safetyShot(req)

--- a/test/poolAi.test.js
+++ b/test/poolAi.test.js
@@ -319,7 +319,7 @@ test('avoids unnecessary spin when natural position is good', () => {
     timeBudgetMs: 50
   };
   const decision = planShot(req);
-  assert.equal(decision.power, 0.4);
+  assert(decision.power >= 0.4 && decision.power <= 0.56, `unexpected power ${decision.power}`);
   assert.deepEqual(decision.spin, { top: 0, side: 0, back: 0 });
 });
 
@@ -435,4 +435,50 @@ test('eight-pool targets black when only 8 remains and group metadata is missing
   });
 
   assert.equal(decision.targetBallId, 8);
+});
+
+test('safety uses one-cushion kick to reach legal target when direct lane is blocked', () => {
+  const decision = planShot({
+    game: 'AMERICAN_BILLIARDS',
+    state: {
+      balls: [
+        { id: 0, x: 40, y: 120, vx: 0, vy: 0, pocketed: false },
+        { id: 2, x: 280, y: 120, vx: 0, vy: 0, pocketed: false },
+        { id: 10, x: 170, y: 120, vx: 0, vy: 0, pocketed: false }
+      ],
+      pockets: [{ x: 0, y: 0 }, { x: 300, y: 0 }, { x: 0, y: 240 }, { x: 300, y: 240 }],
+      width: 300,
+      height: 240,
+      ballRadius: 10,
+      friction: 0.01,
+      legalBallIds: [2]
+    },
+    rngSeed: 17,
+    timeBudgetMs: 80
+  });
+
+  assert.equal(decision.targetBallId, 2);
+  assert.match(decision.rationale, /one-cushion-kick/);
+});
+
+test('power stays in a controlled range for routine pots', () => {
+  const decision = planShot({
+    game: 'AMERICAN_BILLIARDS',
+    state: {
+      balls: [
+        { id: 0, x: 140, y: 250, vx: 0, vy: 0, pocketed: false },
+        { id: 1, x: 420, y: 250, vx: 0, vy: 0, pocketed: false }
+      ],
+      pockets: [{ x: 1000, y: 250 }],
+      width: 1000,
+      height: 500,
+      ballRadius: 10,
+      friction: 0.01,
+      legalBallIds: [1]
+    },
+    rngSeed: 21,
+    timeBudgetMs: 80
+  });
+
+  assert(decision.power >= 0.35 && decision.power <= 0.7, `unexpected power ${decision.power}`);
 });


### PR DESCRIPTION
### Motivation
- Reduce the AI choosing low-percentage or glitchy pots and make it behave more like a competitive human player by matching power, avoiding scratches, and using legal cushion play when direct lanes are blocked.
- Ensure the AI prefers centrally-entering pocket trajectories and avoids hitting opponents or potting the cue ball where possible.

### Description
- Added `recommendedPowerForPot(...)` and integrated a `powerDeviation` penalty into the shot `evaluate(...)` logic so power choices better match cut angle and travel distance (file `lib/poolAi.js`).
- Introduced `projectedScratchRisk(...)` and factored it into shot quality to protect the cue ball beyond immediate line checks (file `lib/poolAi.js`).
- Implemented a one-cushion kick fallback `oneCushionKickShot(...)` and call it from `safetyShot(...)` so the AI can legally contact targets via a cushion when direct lanes are blocked (file `lib/poolAi.js`).
- Raised the aggressive-shot acceptance floor via `MIN_COMPETITIVE_QUALITY` to avoid forcing low-quality attempts and adjusted safety/fallback selection accordingly (file `lib/poolAi.js`).
- Updated tests to cover the new behaviors and relaxed/adjusted an old power assertion to reflect adaptive power selection (file `test/poolAi.test.js`).

### Testing
- Ran `node --test test/poolAi.test.js test/poolUkAdvancedAi.test.js` and both suites passed (new and existing pool AI tests green).
- Attempted `node --test test/poolAi.test.js test/poolUkAdvancedAi.test.js test/poolRoyaleAiAimCompensation.test.js` and it failed because `poolRoyaleAiAimCompensation.test.js` uses Jest globals like `describe` which are not available under Node's built-in test runner.  (This is a test-runner mismatch, not a regression in the AI code.)
- New/changed unit tests in `test/poolAi.test.js` ran successfully under the Node test runner and validate one-cushion kick selection and controlled power ranges.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5e695deb083299ab206710b0d24a9)