### PR TITLE
Improve AI pocket aiming with jaw-assisted targeting

### DIFF
--- a/Assets/Resources/AimingConfig.asset
+++ b/Assets/Resources/AimingConfig.asset
@@ -17,6 +17,9 @@ MonoBehaviour:
   shortDist: 0.8
   mediumDist: 1.6
   pocketApproachDepth: 0.12
+  straightPocketApproachDepth: 0.06
+  jawAssistMinAngleDeg: 8
+  jawAssistLateralOffset: 0.022
   cuePathClearanceRadiusScale: 0.92
   cutAnglePenalty: 0.55
   distancePenalty: 0.2

--- a/Assets/Scripts/Aiming/AdaptiveAimingEngine.cs
+++ b/Assets/Scripts/Aiming/AdaptiveAimingEngine.cs
@@ -147,8 +147,36 @@ namespace Aiming
             if (toPocket.sqrMagnitude < 1e-8f)
                 return normalized;
 
-            float depth = config ? config.pocketApproachDepth : 0.12f;
-            normalized.pocketPos = ctx.pocketPos - toPocket.normalized * Mathf.Max(depth, ctx.ballRadius * 0.5f);
+            Vector3 objectToPocketDir = toPocket.normalized;
+            Vector3 objectToCueDir = (ctx.cueBallPos - ctx.objectBallPos).normalized;
+            float cutAngleDeg = Mathf.Acos(Mathf.Clamp(Vector3.Dot(objectToPocketDir, objectToCueDir), -1f, 1f)) * Mathf.Rad2Deg;
+
+            float baseDepth = config ? config.pocketApproachDepth : 0.12f;
+            float straightDepth = config ? config.straightPocketApproachDepth : 0.06f;
+            float minDepth = ctx.ballRadius * 0.5f;
+            float depth = cutAngleDeg <= (config ? config.straightAngleDeg : 5f) ? straightDepth : baseDepth;
+            depth = Mathf.Max(depth, minDepth);
+
+            Vector3 target = ctx.pocketPos - objectToPocketDir * depth;
+            float jawAssistMinAngle = config ? config.jawAssistMinAngleDeg : 8f;
+            if (cutAngleDeg >= jawAssistMinAngle)
+            {
+                Vector3 lateral = Vector3.Cross(Vector3.up, objectToPocketDir).normalized;
+                if (lateral.sqrMagnitude > 1e-8f)
+                {
+                    float sideSign = Mathf.Sign(Vector3.Dot(objectToCueDir, lateral));
+                    if (Mathf.Approximately(sideSign, 0f))
+                    {
+                        sideSign = 1f;
+                    }
+
+                    float jawAssist = config ? config.jawAssistLateralOffset : 0.022f;
+                    float maxByBall = ctx.ballRadius * 0.9f;
+                    target += lateral * sideSign * Mathf.Min(jawAssist, maxByBall);
+                }
+            }
+
+            normalized.pocketPos = target;
             return normalized;
         }
 

--- a/Assets/Scripts/Aiming/AimingConfig.cs
+++ b/Assets/Scripts/Aiming/AimingConfig.cs
@@ -16,6 +16,12 @@ namespace Aiming
         [Header("AI competitiveness")]
         [Tooltip("Offsets pocket targeting away from jaw collisions by aiming slightly inside the pocket entrance.")]
         public float pocketApproachDepth = 0.12f;
+        [Tooltip("Depth used for near-straight pots so the AI targets the mouth center instead of overcutting into a jaw.")]
+        public float straightPocketApproachDepth = 0.06f;
+        [Tooltip("Above this cut angle, AI starts using jaw-assisted target offsets for angled pots.")]
+        public float jawAssistMinAngleDeg = 8f;
+        [Tooltip("Lateral offset from pocket centerline used to guide angled shots through the jaw side.")]
+        public float jawAssistLateralOffset = 0.022f;
         [Tooltip("Rejects candidate aims where cue-to-contact line is significantly blocked.")]
         public float cuePathClearanceRadiusScale = 0.92f;
         [Tooltip("Penalty weight for harder cut angles so easier pots are preferred.")]


### PR DESCRIPTION
### Motivation
- Reduce missed pots by altering AI target selection so nearly-straight shots aim at the pocket entrance center while angled cuts use the pocket jaw as a guide. 
- The previous single inward offset could overcut into jaw geometry or fail to bias angled shots toward the jaw side. 
- Keep behavior tunable so designers can iterate without code changes via `AimingConfig`.

### Description
- Enhanced `AdaptiveAimingEngine.NormalizePocketTarget` to compute the shot cut angle and choose an approach depth based on whether a shot is effectively straight or not. 
- For straight shots the AI uses `straightPocketApproachDepth` to aim shallower toward the center mouth, and for larger cuts it uses `pocketApproachDepth`. 
- For angled shots above `jawAssistMinAngleDeg` the code computes a lateral vector from the pocket centerline and applies a `jawAssistLateralOffset` toward the jaw side inferred from cue/object geometry. 
- Added new tuning fields to `AimingConfig` (`straightPocketApproachDepth`, `jawAssistMinAngleDeg`, `jawAssistLateralOffset`) and updated `Assets/Resources/AimingConfig.asset` with defaults so the change is active out-of-the-box.

### Testing
- Ran `git diff --check` on the modified files to verify no whitespace/patch issues, and it completed with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5f5121b1c8329bcc115a205914890)