### PR TITLE
Improve AI pocket aiming with jaw-guided targets

### DIFF
--- a/Assets/Scripts/Aiming/AdaptiveAimingEngine.cs
+++ b/Assets/Scripts/Aiming/AdaptiveAimingEngine.cs
@@ -143,13 +143,52 @@ namespace Aiming
         ShotContext NormalizePocketTarget(in ShotContext ctx)
         {
             var normalized = ctx;
+            normalized.pocketPos = ComputePocketAimPoint(ctx, config);
+            return normalized;
+        }
+
+        public static Vector3 ComputePocketAimPoint(in ShotContext ctx, AimingConfig cfg)
+        {
             Vector3 toPocket = ctx.pocketPos - ctx.objectBallPos;
             if (toPocket.sqrMagnitude < 1e-8f)
-                return normalized;
+                return ctx.pocketPos;
 
-            float depth = config ? config.pocketApproachDepth : 0.12f;
-            normalized.pocketPos = ctx.pocketPos - toPocket.normalized * Mathf.Max(depth, ctx.ballRadius * 0.5f);
-            return normalized;
+            Vector3 pocketDir = toPocket.normalized;
+            float depth = cfg ? cfg.pocketApproachDepth : 0.12f;
+            Vector3 entranceCenter = ctx.pocketPos - pocketDir * Mathf.Max(depth, ctx.ballRadius * 0.5f);
+
+            Vector3 objectToCue = ctx.cueBallPos - ctx.objectBallPos;
+            if (objectToCue.sqrMagnitude < 1e-8f)
+                return entranceCenter;
+
+            Vector3 cueDir = objectToCue.normalized;
+            float cutDot = Mathf.Clamp(Vector3.Dot(-pocketDir, cueDir), -1f, 1f);
+            float cutAngleDeg = Mathf.Acos(cutDot) * Mathf.Rad2Deg;
+            float straightThreshold = cfg ? cfg.straightPocketCenterAngleDeg : 7f;
+            if (cutAngleDeg <= straightThreshold)
+                return entranceCenter;
+
+            float startAngle = cfg ? cfg.jawGuideStartAngleDeg : 12f;
+            float maxAngle = cfg ? cfg.jawGuideMaxAngleDeg : 50f;
+            if (maxAngle <= startAngle)
+                maxAngle = startAngle + 1f;
+
+            float t = Mathf.InverseLerp(startAngle, maxAngle, cutAngleDeg);
+            float minOffset = cfg ? cfg.jawGuideOffsetMin : 0.01f;
+            float maxOffset = cfg ? cfg.jawGuideOffsetMax : 0.028f;
+            float offset = Mathf.Lerp(minOffset, maxOffset, t);
+            offset = Mathf.Clamp(offset, 0f, Mathf.Max(0f, maxOffset));
+
+            Vector3 lateral = Vector3.Cross(Vector3.up, pocketDir);
+            if (lateral.sqrMagnitude < 1e-8f)
+                return entranceCenter;
+
+            lateral.Normalize();
+            float sideSign = Mathf.Sign(Vector3.Cross(cueDir, pocketDir).y);
+            if (Mathf.Approximately(sideSign, 0f))
+                return entranceCenter;
+
+            return entranceCenter + lateral * sideSign * offset;
         }
 
         AimSolution SelectBestSolution(in ShotContext ctx, in ShotInfo info)

--- a/Assets/Scripts/Aiming/AimingConfig.cs
+++ b/Assets/Scripts/Aiming/AimingConfig.cs
@@ -16,6 +16,16 @@ namespace Aiming
         [Header("AI competitiveness")]
         [Tooltip("Offsets pocket targeting away from jaw collisions by aiming slightly inside the pocket entrance.")]
         public float pocketApproachDepth = 0.12f;
+        [Tooltip("Cut-angle threshold that keeps the pocket target centered (straight pots).")]
+        public float straightPocketCenterAngleDeg = 7f;
+        [Tooltip("Cut-angle where jaw-guided targeting starts blending in.")]
+        public float jawGuideStartAngleDeg = 12f;
+        [Tooltip("Cut-angle where jaw-guided targeting reaches full lateral offset.")]
+        public float jawGuideMaxAngleDeg = 50f;
+        [Tooltip("Minimum lateral offset from pocket-center target used when jaw guidance is active.")]
+        public float jawGuideOffsetMin = 0.01f;
+        [Tooltip("Maximum lateral offset from pocket-center target used when jaw guidance is active.")]
+        public float jawGuideOffsetMax = 0.028f;
         [Tooltip("Rejects candidate aims where cue-to-contact line is significantly blocked.")]
         public float cuePathClearanceRadiusScale = 0.92f;
         [Tooltip("Penalty weight for harder cut angles so easier pots are preferred.")]

--- a/Assets/Tests/PlayMode/PocketAimTargetingTests.cs
+++ b/Assets/Tests/PlayMode/PocketAimTargetingTests.cs
@@ -1,0 +1,54 @@
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Aiming.Tests
+{
+    public class PocketAimTargetingTests
+    {
+        [Test]
+        public void StraightShotTargetsPocketEntranceCenter()
+        {
+            var cfg = ScriptableObject.CreateInstance<AimingConfig>();
+            cfg.pocketApproachDepth = 0.12f;
+            cfg.straightPocketCenterAngleDeg = 7f;
+
+            var ctx = new ShotContext
+            {
+                objectBallPos = Vector3.zero,
+                cueBallPos = new Vector3(0f, 0f, -1f),
+                pocketPos = new Vector3(0f, 0f, 2f),
+                ballRadius = 0.028f
+            };
+
+            Vector3 aimPoint = AdaptiveAimingEngine.ComputePocketAimPoint(ctx, cfg);
+            Vector3 expected = new Vector3(0f, 0f, 1.88f);
+            Assert.That(Vector3.Distance(aimPoint, expected), Is.LessThan(0.0001f));
+        }
+
+        [Test]
+        public void AngledShotUsesJawGuidedLateralOffset()
+        {
+            var cfg = ScriptableObject.CreateInstance<AimingConfig>();
+            cfg.pocketApproachDepth = 0.12f;
+            cfg.straightPocketCenterAngleDeg = 7f;
+            cfg.jawGuideStartAngleDeg = 10f;
+            cfg.jawGuideMaxAngleDeg = 50f;
+            cfg.jawGuideOffsetMin = 0.01f;
+            cfg.jawGuideOffsetMax = 0.03f;
+
+            var ctx = new ShotContext
+            {
+                objectBallPos = Vector3.zero,
+                cueBallPos = new Vector3(0.55f, 0f, -1f),
+                pocketPos = new Vector3(0f, 0f, 2f),
+                ballRadius = 0.028f
+            };
+
+            Vector3 aimPoint = AdaptiveAimingEngine.ComputePocketAimPoint(ctx, cfg);
+            Vector3 centerOnly = new Vector3(0f, 0f, 1.88f);
+            Assert.That(Mathf.Abs(aimPoint.x), Is.GreaterThan(0.009f));
+            Assert.That(Mathf.Abs(aimPoint.x), Is.LessThanOrEqualTo(0.03f));
+            Assert.That(Mathf.Abs(aimPoint.z - centerOnly.z), Is.LessThan(0.0001f));
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Ensure AI aiming uses the pocket jaws as a guide for angled shots while still aiming the entrance center for near-straight pots to increase pot reliability and more human-like behaviour.
- Provide configurable tuning so designers can control when jaw-guided offsets start and how large they become.
- Add automated tests that assert center-targeting for straight shots and lateral jaw offsets for angled shots.

### Description
- Added new tuning fields to `AimingConfig` (`straightPocketCenterAngleDeg`, `jawGuideStartAngleDeg`, `jawGuideMaxAngleDeg`, `jawGuideOffsetMin`, `jawGuideOffsetMax`) to control straight vs jaw-guided behaviour and offset magnitude (`Assets/Scripts/Aiming/AimingConfig.cs`).
- Implemented `ComputePocketAimPoint(in ShotContext, AimingConfig)` and switched `NormalizePocketTarget` to use it; the function computes the pocket entrance center, measures the cut angle, and blends a lateral offset toward the jaw based on configured angle thresholds and offsets (`Assets/Scripts/Aiming/AdaptiveAimingEngine.cs`).
- New play-mode tests assert that straight shots target the pocket entrance center and angled shots produce a lateral jaw-guided offset within the configured bounds (`Assets/Tests/PlayMode/PocketAimTargetingTests.cs`).

### Testing
- Added `Assets/Tests/PlayMode/PocketAimTargetingTests.cs` containing two tests for center and jaw-guided targeting which are ready to run under the project test runner.
- An attempted automated run `dotnet test billiards.Tests/billiards.Tests.csproj --nologo` failed in this environment with `/bin/bash: line 1: dotnet: command not found`, so tests were not executed here.
- No other CI or Unity play-mode tests were executed in this container; changes compile-time behaviour was limited to the edited aiming code and test additions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5f5121b1c8329bcc115a205914890)