### PR TITLE
Adjust pool AI to target pocket mouth entrance (jaw-guided aiming)

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -124,29 +124,84 @@ function pocketNormal (pocket, width, height) {
   return { x: dir.x / len, y: dir.y / len }
 }
 
-function pocketEntry (pocket, radius, width, height, target) {
-  const normal = pocketNormal(pocket, width, height)
-  let dir = normal
+function classifyPocket (pocket, width, height) {
+  const edgeBandX = Math.max(width * 0.26, 1)
+  const edgeBandY = Math.max(height * 0.26, 1)
+  const nearLeft = pocket.x <= edgeBandX
+  const nearRight = pocket.x >= width - edgeBandX
+  const nearTop = pocket.y <= edgeBandY
+  const nearBottom = pocket.y >= height - edgeBandY
 
-  if (target) {
-    const targetDir = { x: pocket.x - target.x, y: pocket.y - target.y }
-    const len = Math.hypot(targetDir.x, targetDir.y) || 1
-    const unitTargetDir = { x: targetDir.x / len, y: targetDir.y / len }
-    // Blend target-driven line with pocket inward normal so the AI
-    // prefers hitting a central entrance trajectory instead of grazing
-    // the near jaw on steep cuts.
-    dir = {
-      x: unitTargetDir.x * 0.62 + normal.x * 0.38,
-      y: unitTargetDir.y * 0.62 + normal.y * 0.38
+  if ((nearLeft || nearRight) && (nearTop || nearBottom)) {
+    return {
+      kind: 'corner',
+      sx: nearLeft ? 1 : -1,
+      sy: nearTop ? 1 : -1
     }
-    const blendedLen = Math.hypot(dir.x, dir.y) || 1
-    dir = { x: dir.x / blendedLen, y: dir.y / blendedLen }
   }
 
-  const offset = radius * 1.05
   return {
-    x: pocket.x - dir.x * offset,
-    y: pocket.y - dir.y * offset
+    kind: 'side',
+    side: nearLeft ? 'left' : nearRight ? 'right' : nearTop ? 'top' : 'bottom'
+  }
+}
+
+function pocketMouthGeometry (pocket, radius, width, height) {
+  const cls = classifyPocket(pocket, width, height)
+  if (cls.kind === 'corner') {
+    const jawInset = radius * 1.95
+    const jawA = { x: pocket.x + cls.sx * jawInset, y: pocket.y }
+    const jawB = { x: pocket.x, y: pocket.y + cls.sy * jawInset }
+    const mid = { x: (jawA.x + jawB.x) / 2, y: (jawA.y + jawB.y) / 2 }
+    const inward = pocketNormal(pocket, width, height)
+    return { jawA, jawB, inward, mid }
+  }
+
+  const jawSpread = radius * 2.35
+  if (cls.side === 'left' || cls.side === 'right') {
+    const jawA = { x: pocket.x, y: pocket.y - jawSpread }
+    const jawB = { x: pocket.x, y: pocket.y + jawSpread }
+    const inward = { x: cls.side === 'left' ? 1 : -1, y: 0 }
+    const mid = { x: pocket.x, y: pocket.y }
+    return { jawA, jawB, inward, mid }
+  }
+
+  const jawA = { x: pocket.x - jawSpread, y: pocket.y }
+  const jawB = { x: pocket.x + jawSpread, y: pocket.y }
+  const inward = { x: 0, y: cls.side === 'top' ? 1 : -1 }
+  const mid = { x: pocket.x, y: pocket.y }
+  return { jawA, jawB, inward, mid }
+}
+
+function pocketEntry (pocket, radius, width, height, target) {
+  const { jawA, jawB, inward, mid } = pocketMouthGeometry(pocket, radius, width, height)
+  const mouth = { x: jawB.x - jawA.x, y: jawB.y - jawA.y }
+  const mouthLen = Math.hypot(mouth.x, mouth.y) || 1
+  const tangent = { x: mouth.x / mouthLen, y: mouth.y / mouthLen }
+
+  // Start from true pocket entrance (between cushion jaw cuts), then bias
+  // slightly toward the better jaw according to target approach angle.
+  let t = 0.5
+  if (target) {
+    const approach = { x: mid.x - target.x, y: mid.y - target.y }
+    const approachLen = Math.hypot(approach.x, approach.y) || 1
+    const align = (approach.x / approachLen) * tangent.x + (approach.y / approachLen) * tangent.y
+    t = Math.max(0.2, Math.min(0.8, 0.5 + align * 0.22))
+  }
+
+  const jawPick = {
+    x: jawA.x + mouth.x * t,
+    y: jawA.y + mouth.y * t
+  }
+
+  const entry = {
+    x: jawPick.x + inward.x * radius * 0.18,
+    y: jawPick.y + inward.y * radius * 0.18
+  }
+
+  return {
+    x: Math.max(radius, Math.min(width - radius, entry.x)),
+    y: Math.max(radius, Math.min(height - radius, entry.y))
   }
 }
 

--- a/webapp/public/lib/poolAi.js
+++ b/webapp/public/lib/poolAi.js
@@ -123,29 +123,84 @@ function pocketNormal (pocket, width, height) {
   return { x: dir.x / len, y: dir.y / len }
 }
 
-function pocketEntry (pocket, radius, width, height, target) {
-  const normal = pocketNormal(pocket, width, height)
-  let dir = normal
+function classifyPocket (pocket, width, height) {
+  const edgeBandX = Math.max(width * 0.26, 1)
+  const edgeBandY = Math.max(height * 0.26, 1)
+  const nearLeft = pocket.x <= edgeBandX
+  const nearRight = pocket.x >= width - edgeBandX
+  const nearTop = pocket.y <= edgeBandY
+  const nearBottom = pocket.y >= height - edgeBandY
 
-  if (target) {
-    const targetDir = { x: pocket.x - target.x, y: pocket.y - target.y }
-    const len = Math.hypot(targetDir.x, targetDir.y) || 1
-    const unitTargetDir = { x: targetDir.x / len, y: targetDir.y / len }
-    // Blend target-driven line with pocket inward normal so the AI
-    // prefers hitting a central entrance trajectory instead of grazing
-    // the near jaw on steep cuts.
-    dir = {
-      x: unitTargetDir.x * 0.62 + normal.x * 0.38,
-      y: unitTargetDir.y * 0.62 + normal.y * 0.38
+  if ((nearLeft || nearRight) && (nearTop || nearBottom)) {
+    return {
+      kind: 'corner',
+      sx: nearLeft ? 1 : -1,
+      sy: nearTop ? 1 : -1
     }
-    const blendedLen = Math.hypot(dir.x, dir.y) || 1
-    dir = { x: dir.x / blendedLen, y: dir.y / blendedLen }
   }
 
-  const offset = radius * 1.05
   return {
-    x: pocket.x - dir.x * offset,
-    y: pocket.y - dir.y * offset
+    kind: 'side',
+    side: nearLeft ? 'left' : nearRight ? 'right' : nearTop ? 'top' : 'bottom'
+  }
+}
+
+function pocketMouthGeometry (pocket, radius, width, height) {
+  const cls = classifyPocket(pocket, width, height)
+  if (cls.kind === 'corner') {
+    const jawInset = radius * 1.95
+    const jawA = { x: pocket.x + cls.sx * jawInset, y: pocket.y }
+    const jawB = { x: pocket.x, y: pocket.y + cls.sy * jawInset }
+    const mid = { x: (jawA.x + jawB.x) / 2, y: (jawA.y + jawB.y) / 2 }
+    const inward = pocketNormal(pocket, width, height)
+    return { jawA, jawB, inward, mid }
+  }
+
+  const jawSpread = radius * 2.35
+  if (cls.side === 'left' || cls.side === 'right') {
+    const jawA = { x: pocket.x, y: pocket.y - jawSpread }
+    const jawB = { x: pocket.x, y: pocket.y + jawSpread }
+    const inward = { x: cls.side === 'left' ? 1 : -1, y: 0 }
+    const mid = { x: pocket.x, y: pocket.y }
+    return { jawA, jawB, inward, mid }
+  }
+
+  const jawA = { x: pocket.x - jawSpread, y: pocket.y }
+  const jawB = { x: pocket.x + jawSpread, y: pocket.y }
+  const inward = { x: 0, y: cls.side === 'top' ? 1 : -1 }
+  const mid = { x: pocket.x, y: pocket.y }
+  return { jawA, jawB, inward, mid }
+}
+
+function pocketEntry (pocket, radius, width, height, target) {
+  const { jawA, jawB, inward, mid } = pocketMouthGeometry(pocket, radius, width, height)
+  const mouth = { x: jawB.x - jawA.x, y: jawB.y - jawA.y }
+  const mouthLen = Math.hypot(mouth.x, mouth.y) || 1
+  const tangent = { x: mouth.x / mouthLen, y: mouth.y / mouthLen }
+
+  // Start from true pocket entrance (between cushion jaw cuts), then bias
+  // slightly toward the better jaw according to target approach angle.
+  let t = 0.5
+  if (target) {
+    const approach = { x: mid.x - target.x, y: mid.y - target.y }
+    const approachLen = Math.hypot(approach.x, approach.y) || 1
+    const align = (approach.x / approachLen) * tangent.x + (approach.y / approachLen) * tangent.y
+    t = Math.max(0.2, Math.min(0.8, 0.5 + align * 0.22))
+  }
+
+  const jawPick = {
+    x: jawA.x + mouth.x * t,
+    y: jawA.y + mouth.y * t
+  }
+
+  const entry = {
+    x: jawPick.x + inward.x * radius * 0.18,
+    y: jawPick.y + inward.y * radius * 0.18
+  }
+
+  return {
+    x: Math.max(radius, Math.min(width - radius, entry.x)),
+    y: Math.max(radius, Math.min(height - radius, entry.y))
   }
 }
 


### PR DESCRIPTION
### Motivation
- The AI was aiming toward the back/center of pockets and missing steep cut shots because it ignored the true pocket mouth (the opening between the two cushion jaw cuts). 
- The goal is to make the planner target the pocket entrance (the jaw/mouth) and use the cushion cut geometry and approach angle to guide the aim point so cut shots feed into the pocket properly.

### Description
- Added `classifyPocket` to distinguish `corner` vs `side` pockets and compute pocket semantics based on table size and pocket position. 
- Added `pocketMouthGeometry` to compute jaw endpoints (`jawA`, `jawB`), the mouth tangent, inward normal and a mouth midpoint for each pocket. 
- Reworked `pocketEntry` to pick a point along the jaw-mouth segment, bias that pick by the target ball approach angle, nudge slightly inward toward the mouth, and clamp the final entry to table bounds. 
- Applied the same changes to both `lib/poolAi.js` and `webapp/public/lib/poolAi.js` so runtime and public copies remain consistent.

### Testing
- Ran `node --check webapp/public/lib/poolAi.js` and it completed without syntax errors. 
- Ran `node --check lib/poolAi.js` and it completed without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5ff64f28c8329956a323098214616)