### PR TITLE
Fix AI pocket aiming to target pocket mouth entrance

### DIFF
--- a/Assets/Scripts/Aiming/AdaptiveAimingEngine.cs
+++ b/Assets/Scripts/Aiming/AdaptiveAimingEngine.cs
@@ -149,20 +149,37 @@ namespace Aiming
 
         public static Vector3 ComputePocketAimPoint(in ShotContext ctx, AimingConfig cfg)
         {
-            Vector3 toPocket = ctx.pocketPos - ctx.objectBallPos;
-            if (toPocket.sqrMagnitude < 1e-8f)
+            Vector3 inward = ResolvePocketInwardDirection(ctx);
+            if (inward.sqrMagnitude < 1e-8f)
+            {
+                Vector3 toCenter = ctx.tableBounds.center - ctx.pocketPos;
+                inward = new Vector3(toCenter.x, 0f, toCenter.z);
+            }
+
+            if (inward.sqrMagnitude < 1e-8f)
+            {
+                Vector3 toPocketFallback = ctx.pocketPos - ctx.objectBallPos;
+                inward = -new Vector3(toPocketFallback.x, 0f, toPocketFallback.z);
+            }
+
+            if (inward.sqrMagnitude < 1e-8f)
                 return ctx.pocketPos;
 
-            Vector3 pocketDir = toPocket.normalized;
+            inward.Normalize();
             float depth = cfg ? cfg.pocketApproachDepth : 0.12f;
-            Vector3 entranceCenter = ctx.pocketPos - pocketDir * Mathf.Max(depth, ctx.ballRadius * 0.5f);
+            Vector3 entranceCenter = ctx.pocketPos + inward * Mathf.Max(depth, ctx.ballRadius * 0.5f);
 
             Vector3 objectToCue = ctx.cueBallPos - ctx.objectBallPos;
             if (objectToCue.sqrMagnitude < 1e-8f)
                 return entranceCenter;
 
+            Vector3 objectToEntrance = entranceCenter - ctx.objectBallPos;
+            if (objectToEntrance.sqrMagnitude < 1e-8f)
+                return entranceCenter;
+
             Vector3 cueDir = objectToCue.normalized;
-            float cutDot = Mathf.Clamp(Vector3.Dot(-pocketDir, cueDir), -1f, 1f);
+            Vector3 pocketApproachDir = objectToEntrance.normalized;
+            float cutDot = Mathf.Clamp(Vector3.Dot(-pocketApproachDir, cueDir), -1f, 1f);
             float cutAngleDeg = Mathf.Acos(cutDot) * Mathf.Rad2Deg;
             float straightThreshold = cfg ? cfg.straightPocketCenterAngleDeg : 7f;
             if (cutAngleDeg <= straightThreshold)
@@ -179,16 +196,50 @@ namespace Aiming
             float offset = Mathf.Lerp(minOffset, maxOffset, t);
             offset = Mathf.Clamp(offset, 0f, Mathf.Max(0f, maxOffset));
 
-            Vector3 lateral = Vector3.Cross(Vector3.up, pocketDir);
+            Vector3 lateral = Vector3.Cross(Vector3.up, inward);
             if (lateral.sqrMagnitude < 1e-8f)
                 return entranceCenter;
 
             lateral.Normalize();
-            float sideSign = Mathf.Sign(Vector3.Cross(cueDir, pocketDir).y);
+            float sideSign = Mathf.Sign(Vector3.Cross(cueDir, pocketApproachDir).y);
             if (Mathf.Approximately(sideSign, 0f))
                 return entranceCenter;
 
             return entranceCenter + lateral * sideSign * offset;
+        }
+
+        static Vector3 ResolvePocketInwardDirection(in ShotContext ctx)
+        {
+            Bounds bounds = ctx.tableBounds;
+            if (bounds.size.sqrMagnitude < 1e-8f)
+                return Vector3.zero;
+
+            Vector3 min = bounds.min;
+            Vector3 max = bounds.max;
+            float nearEdgeEpsilon = Mathf.Max(ctx.ballRadius * 2.5f, 0.14f);
+
+            float dxMin = Mathf.Abs(ctx.pocketPos.x - min.x);
+            float dxMax = Mathf.Abs(max.x - ctx.pocketPos.x);
+            float dzMin = Mathf.Abs(ctx.pocketPos.z - min.z);
+            float dzMax = Mathf.Abs(max.z - ctx.pocketPos.z);
+
+            float x = 0f;
+            if (dxMin <= nearEdgeEpsilon && dxMin <= dxMax) x = 1f;
+            else if (dxMax <= nearEdgeEpsilon) x = -1f;
+
+            float z = 0f;
+            if (dzMin <= nearEdgeEpsilon && dzMin <= dzMax) z = 1f;
+            else if (dzMax <= nearEdgeEpsilon) z = -1f;
+
+            if (Mathf.Approximately(x, 0f) && Mathf.Approximately(z, 0f))
+            {
+                float centerDx = Mathf.Abs(ctx.pocketPos.x - bounds.center.x);
+                float centerDz = Mathf.Abs(ctx.pocketPos.z - bounds.center.z);
+                if (centerDx >= centerDz) x = ctx.pocketPos.x < bounds.center.x ? 1f : -1f;
+                else z = ctx.pocketPos.z < bounds.center.z ? 1f : -1f;
+            }
+
+            return new Vector3(x, 0f, z).normalized;
         }
 
         AimSolution SelectBestSolution(in ShotContext ctx, in ShotInfo info)

--- a/Assets/Tests/PlayMode/PocketAimTargetingTests.cs
+++ b/Assets/Tests/PlayMode/PocketAimTargetingTests.cs
@@ -17,7 +17,8 @@ namespace Aiming.Tests
                 objectBallPos = Vector3.zero,
                 cueBallPos = new Vector3(0f, 0f, -1f),
                 pocketPos = new Vector3(0f, 0f, 2f),
-                ballRadius = 0.028f
+                ballRadius = 0.028f,
+                tableBounds = new Bounds(Vector3.zero, new Vector3(2f, 0.2f, 4f))
             };
 
             Vector3 aimPoint = AdaptiveAimingEngine.ComputePocketAimPoint(ctx, cfg);
@@ -41,7 +42,8 @@ namespace Aiming.Tests
                 objectBallPos = Vector3.zero,
                 cueBallPos = new Vector3(0.55f, 0f, -1f),
                 pocketPos = new Vector3(0f, 0f, 2f),
-                ballRadius = 0.028f
+                ballRadius = 0.028f,
+                tableBounds = new Bounds(Vector3.zero, new Vector3(2f, 0.2f, 4f))
             };
 
             Vector3 aimPoint = AdaptiveAimingEngine.ComputePocketAimPoint(ctx, cfg);
@@ -49,6 +51,34 @@ namespace Aiming.Tests
             Assert.That(Mathf.Abs(aimPoint.x), Is.GreaterThan(0.009f));
             Assert.That(Mathf.Abs(aimPoint.x), Is.LessThanOrEqualTo(0.03f));
             Assert.That(Mathf.Abs(aimPoint.z - centerOnly.z), Is.LessThan(0.0001f));
+        }
+
+        [Test]
+        public void CornerPocketUsesTableEntranceNotPocketBack()
+        {
+            var cfg = ScriptableObject.CreateInstance<AimingConfig>();
+            cfg.pocketApproachDepth = 0.12f;
+            cfg.straightPocketCenterAngleDeg = 10f;
+            cfg.jawGuideStartAngleDeg = 20f;
+
+            var ctxA = new ShotContext
+            {
+                objectBallPos = new Vector3(-0.4f, 0f, 0.4f),
+                cueBallPos = new Vector3(-0.4f, 0f, -0.8f),
+                pocketPos = new Vector3(-1f, 0f, 2f),
+                ballRadius = 0.028f,
+                tableBounds = new Bounds(Vector3.zero, new Vector3(2f, 0.2f, 4f))
+            };
+
+            var ctxB = ctxA;
+            ctxB.objectBallPos = new Vector3(-0.7f, 0f, 1.4f);
+
+            Vector3 aimA = AdaptiveAimingEngine.ComputePocketAimPoint(ctxA, cfg);
+            Vector3 aimB = AdaptiveAimingEngine.ComputePocketAimPoint(ctxB, cfg);
+            Vector3 expectedEntrance = new Vector3(-0.9151472f, 0f, 1.9151472f);
+
+            Assert.That(Vector3.Distance(aimA, expectedEntrance), Is.LessThan(0.0002f));
+            Assert.That(Vector3.Distance(aimB, expectedEntrance), Is.LessThan(0.0002f));
         }
     }
 }


### PR DESCRIPTION
### Motivation
- AI aiming was drifting toward the back of the pocket instead of the physical mouth entrance between the cushion jaw cuts, causing poor cut targeting for side/corner shots.
- The goal is to have the aiming logic consider the entrance direction (the gap between cushion cuts) so the AI aims into the mouth and uses jaw geometry to guide lateral offsets.

### Description
- Updated `AdaptiveAimingEngine.ComputePocketAimPoint` to compute the pocket entrance as an inward point from table geometry instead of using the pocket-to-object vector. 
- Added `ResolvePocketInwardDirection` which infers the pocket inward/entrance direction from `ShotContext.tableBounds` and proximity to table edges, with safe fallbacks when bounds are not available. 
- Applied jaw-guided lateral offset relative to the computed entrance orientation and used the `entranceCenter` approach vector when computing cut angle and side sign. 
- Tests updated: `Assets/Tests/PlayMode/PocketAimTargetingTests.cs` now supplies `tableBounds` in scenarios and includes a new `CornerPocketUsesTableEntranceNotPocketBack` regression test; primary logic changes are in `Assets/Scripts/Aiming/AdaptiveAimingEngine.cs`.

### Testing
- Added and adjusted Unity PlayMode tests under `Assets/Tests/PlayMode/PocketAimTargetingTests.cs` to validate entrance-centred aiming and a corner-pocket regression; these tests are intended to run in the Unity test runner. 
- Attempted to run `dotnet test billiards.Tests/billiards.Tests.csproj` in this environment but `dotnet` is not available, so automated test execution could not be completed here. 
- Recommend running the updated PlayMode tests in the Unity Editor/CI (Unity Test Runner) to validate the behavior on actual engine runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5ff64f28c8329956a323098214616)