### PR TITLE
Improve AI pocket-mouth targeting with jaw clearance bias

### DIFF
--- a/Assets/Resources/AimingConfig.asset
+++ b/Assets/Resources/AimingConfig.asset
@@ -17,6 +17,15 @@ MonoBehaviour:
   shortDist: 0.8
   mediumDist: 1.6
   pocketApproachDepth: 0.12
+  straightPocketCenterAngleDeg: 7
+  jawGuideStartAngleDeg: 12
+  jawGuideMaxAngleDeg: 50
+  jawGuideOffsetMin: 0.01
+  jawGuideOffsetMax: 0.028
+  pocketApproachExtraDepthMax: 0.02
+  pocketMouthHalfWidth: 0.06
+  pocketBallClearanceRadiusScale: 1.08
+  jawFarSideBias: 0.8
   cuePathClearanceRadiusScale: 0.92
   cutAnglePenalty: 0.55
   distancePenalty: 0.2

--- a/Assets/Scripts/Aiming/AdaptiveAimingEngine.cs
+++ b/Assets/Scripts/Aiming/AdaptiveAimingEngine.cs
@@ -166,8 +166,8 @@ namespace Aiming
                 return ctx.pocketPos;
 
             inward.Normalize();
-            float depth = cfg ? cfg.pocketApproachDepth : 0.12f;
-            Vector3 entranceCenter = ctx.pocketPos + inward * Mathf.Max(depth, ctx.ballRadius * 0.5f);
+            float baseDepth = cfg ? cfg.pocketApproachDepth : 0.12f;
+            Vector3 entranceCenter = ctx.pocketPos + inward * Mathf.Max(baseDepth, ctx.ballRadius * 0.5f);
 
             Vector3 objectToCue = ctx.cueBallPos - ctx.objectBallPos;
             if (objectToCue.sqrMagnitude < 1e-8f)
@@ -191,6 +191,10 @@ namespace Aiming
                 maxAngle = startAngle + 1f;
 
             float t = Mathf.InverseLerp(startAngle, maxAngle, cutAngleDeg);
+            float extraDepth = cfg ? cfg.pocketApproachExtraDepthMax : 0.02f;
+            float effectiveDepth = Mathf.Max(baseDepth + extraDepth * t, ctx.ballRadius * 0.5f);
+            entranceCenter = ctx.pocketPos + inward * effectiveDepth;
+
             float minOffset = cfg ? cfg.jawGuideOffsetMin : 0.01f;
             float maxOffset = cfg ? cfg.jawGuideOffsetMax : 0.028f;
             float offset = Mathf.Lerp(minOffset, maxOffset, t);
@@ -201,10 +205,25 @@ namespace Aiming
                 return entranceCenter;
 
             lateral.Normalize();
-            float sideSign = Mathf.Sign(Vector3.Cross(cueDir, pocketApproachDir).y);
+            float incomingSide = Mathf.Sign(Vector3.Dot(cueDir, lateral));
+            float farJawSide = -incomingSide;
+            float fallbackSide = Mathf.Sign(Vector3.Cross(cueDir, pocketApproachDir).y);
+            if (Mathf.Approximately(farJawSide, 0f))
+                farJawSide = fallbackSide;
+
+            float farJawBias = cfg ? cfg.jawFarSideBias : 0.8f;
+            float rawSide = Mathf.Lerp(fallbackSide, farJawSide, Mathf.Clamp01(farJawBias));
+            float sideSign = Mathf.Sign(rawSide);
             if (Mathf.Approximately(sideSign, 0f))
                 return entranceCenter;
 
+            float mouthHalfWidth = cfg ? cfg.pocketMouthHalfWidth : 0.06f;
+            float clearanceRadius = ctx.ballRadius * (cfg ? cfg.pocketBallClearanceRadiusScale : 1.08f);
+            float maxAllowedOffset = Mathf.Max(0f, mouthHalfWidth - clearanceRadius);
+            if (maxAllowedOffset <= 1e-4f)
+                return entranceCenter;
+
+            offset = Mathf.Min(offset, maxAllowedOffset);
             return entranceCenter + lateral * sideSign * offset;
         }
 

--- a/Assets/Scripts/Aiming/AimingConfig.cs
+++ b/Assets/Scripts/Aiming/AimingConfig.cs
@@ -26,6 +26,14 @@ namespace Aiming
         public float jawGuideOffsetMin = 0.01f;
         [Tooltip("Maximum lateral offset from pocket-center target used when jaw guidance is active.")]
         public float jawGuideOffsetMax = 0.028f;
+        [Tooltip("Additional inward depth at steep cuts so the object ball line points deeper into the mouth entrance.")]
+        public float pocketApproachExtraDepthMax = 0.02f;
+        [Tooltip("Estimated half-width of a pocket mouth at the table entrance used for AI target clamping.")]
+        public float pocketMouthHalfWidth = 0.06f;
+        [Tooltip("Safety scale for ball radius when checking if there is enough entrance gap for a jaw-guided target.")]
+        public float pocketBallClearanceRadiusScale = 1.08f;
+        [Tooltip("Bias toward aiming at the far jaw side (away from first jaw impact) on cut shots.")]
+        [Range(0f, 1f)] public float jawFarSideBias = 0.8f;
         [Tooltip("Rejects candidate aims where cue-to-contact line is significantly blocked.")]
         public float cuePathClearanceRadiusScale = 0.92f;
         [Tooltip("Penalty weight for harder cut angles so easier pots are preferred.")]

--- a/Assets/Tests/PlayMode/PocketAimTargetingTests.cs
+++ b/Assets/Tests/PlayMode/PocketAimTargetingTests.cs
@@ -36,6 +36,7 @@ namespace Aiming.Tests
             cfg.jawGuideMaxAngleDeg = 50f;
             cfg.jawGuideOffsetMin = 0.01f;
             cfg.jawGuideOffsetMax = 0.03f;
+            cfg.pocketApproachExtraDepthMax = 0f;
 
             var ctx = new ShotContext
             {
@@ -51,6 +52,70 @@ namespace Aiming.Tests
             Assert.That(Mathf.Abs(aimPoint.x), Is.GreaterThan(0.009f));
             Assert.That(Mathf.Abs(aimPoint.x), Is.LessThanOrEqualTo(0.03f));
             Assert.That(Mathf.Abs(aimPoint.z - centerOnly.z), Is.LessThan(0.0001f));
+        }
+
+        [Test]
+        public void AngledShotPrefersFarJawSide()
+        {
+            var cfg = ScriptableObject.CreateInstance<AimingConfig>();
+            cfg.pocketApproachDepth = 0.12f;
+            cfg.straightPocketCenterAngleDeg = 7f;
+            cfg.jawGuideStartAngleDeg = 10f;
+            cfg.jawGuideMaxAngleDeg = 50f;
+            cfg.jawGuideOffsetMin = 0.01f;
+            cfg.jawGuideOffsetMax = 0.03f;
+            cfg.jawFarSideBias = 1f;
+            cfg.pocketApproachExtraDepthMax = 0f;
+
+            var ctx = new ShotContext
+            {
+                objectBallPos = Vector3.zero,
+                cueBallPos = new Vector3(0.55f, 0f, -1f),
+                pocketPos = new Vector3(0f, 0f, 2f),
+                ballRadius = 0.028f,
+                tableBounds = new Bounds(Vector3.zero, new Vector3(2f, 0.2f, 4f))
+            };
+
+            Vector3 aimPoint = AdaptiveAimingEngine.ComputePocketAimPoint(ctx, cfg);
+            Vector3 entranceCenter = new Vector3(0f, 0f, 1.88f);
+            Vector3 inward = (entranceCenter - ctx.pocketPos).normalized;
+            Vector3 lateral = Vector3.Cross(Vector3.up, inward).normalized;
+            Vector3 cueDir = (ctx.cueBallPos - ctx.objectBallPos).normalized;
+
+            float incomingSide = Mathf.Sign(Vector3.Dot(cueDir, lateral));
+            float offsetSide = Mathf.Sign(Vector3.Dot(aimPoint - entranceCenter, lateral));
+            Assert.That(offsetSide, Is.EqualTo(-incomingSide));
+        }
+
+        [Test]
+        public void JawGuideOffsetIsClampedByPocketGapAndBallSize()
+        {
+            var cfg = ScriptableObject.CreateInstance<AimingConfig>();
+            cfg.pocketApproachDepth = 0.12f;
+            cfg.straightPocketCenterAngleDeg = 7f;
+            cfg.jawGuideStartAngleDeg = 10f;
+            cfg.jawGuideMaxAngleDeg = 50f;
+            cfg.jawGuideOffsetMin = 0.02f;
+            cfg.jawGuideOffsetMax = 0.05f;
+            cfg.pocketMouthHalfWidth = 0.04f;
+            cfg.pocketBallClearanceRadiusScale = 1.1f;
+            cfg.pocketApproachExtraDepthMax = 0f;
+
+            var ctx = new ShotContext
+            {
+                objectBallPos = Vector3.zero,
+                cueBallPos = new Vector3(0.75f, 0f, -1f),
+                pocketPos = new Vector3(0f, 0f, 2f),
+                ballRadius = 0.028f,
+                tableBounds = new Bounds(Vector3.zero, new Vector3(2f, 0.2f, 4f))
+            };
+
+            Vector3 aimPoint = AdaptiveAimingEngine.ComputePocketAimPoint(ctx, cfg);
+            Vector3 entranceCenter = new Vector3(0f, 0f, 1.88f);
+            float lateralOffset = Mathf.Abs(aimPoint.x - entranceCenter.x);
+            float maxAllowed = cfg.pocketMouthHalfWidth - (ctx.ballRadius * cfg.pocketBallClearanceRadiusScale);
+
+            Assert.That(lateralOffset, Is.LessThanOrEqualTo(maxAllowed + 0.0001f));
         }
 
         [Test]


### PR DESCRIPTION
### Motivation
- Make AI aiming target the pocket mouth entrance (not just pocket center) for steep cut shots so the target line actually points into the pocket mouth.
- Avoid selecting lateral targets that collide with the pocket jaw or don't physically fit the ball through the pocket entrance by considering ball size vs pocket gap.
- Prefer the far jaw side on cut shots (avoid the first jaw/cushion contact) to increase pot reliability on angled shots.

### Description
- Added new tuning fields to `AimingConfig`: `pocketApproachExtraDepthMax`, `pocketMouthHalfWidth`, `pocketBallClearanceRadiusScale`, and `jawFarSideBias`, and set defaults in `Assets/Resources/AimingConfig.asset`.
- Updated `AdaptiveAimingEngine.ComputePocketAimPoint` to: scale the inward entrance depth with cut angle, bias lateral aiming toward the far jaw side using incoming direction + `jawFarSideBias`, and clamp lateral offset by `pocketMouthHalfWidth - (ballRadius * pocketBallClearanceRadiusScale)` so the chosen target fits the entrance gap.
- Kept existing straight-shot behavior unchanged and only apply jaw-guided logic beyond the straight-pocket threshold.
- Added/updated PlayMode NUnit tests in `Assets/Tests/PlayMode/PocketAimTargetingTests.cs` to verify jaw-guided lateral offset, far-jaw preference, and clamping by pocket gap/ball size.

### Testing
- Added targeted NUnit PlayMode tests for the pocket-aiming logic (new tests included in the repo) but Unity Editor / PlayMode tests were not executed in this environment.
- Basic repository checks (`git diff --check` / commit) were performed and the changes applied cleanly; no Unity test runner was available here to run the new PlayMode tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6074ede0c83299b32c65f4fdfb67f)