### PR TITLE
Adjust Chess Battle Royal arena prop sizing to better match HDRI scale

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -226,14 +226,14 @@ const resolveHdriVariant = (value) => {
   return CHESS_HDRI_OPTIONS[idx] ?? CHESS_HDRI_OPTIONS[DEFAULT_HDRI_INDEX] ?? CHESS_HDRI_OPTIONS[0];
 };
 
-const MODEL_SCALE = 0.62;
+const MODEL_SCALE = 0.53;
 const STOOL_SCALE = 1.5 * 1.05;
 const CARD_SCALE = 0.95;
 
 const BOARD = { N: 8, tile: 4.2, rim: 3, baseH: 0.8 };
 const PIECE_Y = 1.2; // baseline height for meshes
 const PIECE_PLACEMENT_Y_OFFSET = 0.28;
-const PIECE_SCALE_FACTOR = 0.85;
+const PIECE_SCALE_FACTOR = 0.78;
 const PIECE_FOOTPRINT_RATIO = 0.86;
 const BOARD_GROUP_Y_OFFSET = 0;
 const BOARD_MODEL_Y_OFFSET = -0.12;
@@ -241,7 +241,7 @@ const BOARD_VISUAL_Y_OFFSET = -0.08;
 const BOARD_SURFACE_DROP = 0.05;
 
 const RAW_BOARD_SIZE = BOARD.N * BOARD.tile + BOARD.rim * 2;
-const BOARD_SCALE = 0.0405;
+const BOARD_SCALE = 0.035;
 const BOARD_DISPLAY_SIZE = RAW_BOARD_SIZE * BOARD_SCALE;
 const BOARD_MODEL_SPAN_BIAS = 1.18;
 const HIGHLIGHT_VERTICAL_OFFSET = 0.18;
@@ -268,7 +268,7 @@ const CAMERA_TABLE_SPAN_FACTOR = 2.6;
 
 const WALL_PROXIMITY_FACTOR = 0.5; // Bring arena walls 50% closer
 const WALL_HEIGHT_MULTIPLIER = 2; // Double wall height
-const CHAIR_SCALE = 1.04;
+const CHAIR_SCALE = 0.9;
 const CHAIR_CLEARANCE = AI_CHAIR_GAP;
 const PLAYER_CHAIR_EXTRA_CLEARANCE = 0;
 const CAMERA_PHI_OFFSET = 0;


### PR DESCRIPTION
### Motivation
- Visual assets (table, chair, board, pieces) in the Chess Battle Royal arena appeared too large against HDRI environments, so global scale constants were tuned to improve on-screen proportion and portrait/mobile balance.

### Description
- Lowered `MODEL_SCALE` from `0.62` to `0.53` in `webapp/src/pages/Games/ChessBattleRoyal.jsx` to reduce overall arena object sizes. 
- Reduced `PIECE_SCALE_FACTOR` from `0.85` to `0.78` to keep chess pieces proportionate with the smaller table. 
- Reduced `BOARD_SCALE` from `0.0405` to `0.035` so the displayed board matches the resized table and HDRI framing. 
- Lowered `CHAIR_SCALE` from `1.04` to `0.9` so seating proportions align with the resized table and board.

### Testing
- Ran the production build with `npm --prefix webapp run build`, which completed successfully and produced the app bundle. 
- Vite reported existing chunk-size and mixed dynamic/static-import warnings which are unrelated to these constant tweaks and remained unchanged during the build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d60827eff08329b516a673a310bbbe)