### PR TITLE
Adjust Murlan Royale chair height and arena prop scale for portrait HDRI fit

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -105,7 +105,7 @@ const CHARACTER_PROPORTION_SCALE = 2.0;
 const ENABLE_3D_HUMAN_CHARACTERS = false;
 const ARENA_GROWTH = 1.45; // expanded arena footprint for wider walkways
 const CHAIR_SIZE_SCALE = 1;
-const ARENA_PROP_SCALE = 0.94; // Slightly shrink arena props so table/chairs/cards sit better against HDRI scale.
+const ARENA_PROP_SCALE = 0.9; // Slightly smaller arena props so table/chairs/cards better match HDRI scale in portrait.
 const TOP_SEAT_AVATAR_UP_LIFT = 3.8; // Portrait-space lift for the visual top player's avatar badge.
 
 const TABLE_RADIUS = 3.22 * MODEL_SCALE * ARENA_PROP_SCALE;
@@ -2321,7 +2321,7 @@ const COMMUNITY_CARD_DIRECTIONAL_LIFT = 0;
 const COMMUNITY_CARD_SIDE_ORIENTATION_YAW = 0;
 const TABLE_CARD_AREA_FORWARD_SHIFT = 0.72 * MODEL_SCALE;
 const DEAL_CARD_STEP_DELAY_MS = 60;
-const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 0.85;
+const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 0.85 - 0.03 * MODEL_SCALE;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
 const CHAIR_GROUND_DROP = 0.035 * MODEL_SCALE;
 const TABLE_HEIGHT_LIFT = 0.02 * MODEL_SCALE;


### PR DESCRIPTION
### Motivation
- Lower chairs and slightly reduce table/chair/card scale so the Murlan Royale scene matches the promoted HDRI proportions in portrait view.

### Description
- Changed `ARENA_PROP_SCALE` from `0.94` to `0.9` and reduced `CHAIR_BASE_HEIGHT` by `0.03 * MODEL_SCALE` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to make arena props and seating render a bit smaller and lower.

### Testing
- Ran `npm run -s build` which completed successfully, and ran `npx eslint webapp/src/pages/Games/MurlanRoyaleArena.jsx` which reported a project ignore warning but no lint errors for the file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d608d4bfd0832981fc4a6916578245)