### PR TITLE
Improve AI pocket targeting around jaw cuts

### DIFF
--- a/Assets/Scripts/Aiming/AdaptiveAimingEngine.cs
+++ b/Assets/Scripts/Aiming/AdaptiveAimingEngine.cs
@@ -212,7 +212,9 @@ namespace Aiming
                 farJawSide = fallbackSide;
 
             float farJawBias = cfg ? cfg.jawFarSideBias : 0.8f;
-            float rawSide = Mathf.Lerp(fallbackSide, farJawSide, Mathf.Clamp01(farJawBias));
+            float autoFarBias = cfg ? cfg.jawFarSideAutoBias : 0.85f;
+            float cutDrivenFarBias = Mathf.Lerp(farJawBias, 1f, Mathf.Clamp01(t * autoFarBias));
+            float rawSide = Mathf.Lerp(fallbackSide, farJawSide, Mathf.Clamp01(cutDrivenFarBias));
             float sideSign = Mathf.Sign(rawSide);
             if (Mathf.Approximately(sideSign, 0f))
                 return entranceCenter;
@@ -224,7 +226,28 @@ namespace Aiming
                 return entranceCenter;
 
             offset = Mathf.Min(offset, maxAllowedOffset);
-            return entranceCenter + lateral * sideSign * offset;
+            float deadZoneRatio = cfg ? cfg.jawNearSideDeadZoneRatio : 0.3f;
+            float minFarSideOffset = maxAllowedOffset * Mathf.Clamp01(deadZoneRatio) * t;
+            offset = Mathf.Max(offset, minFarSideOffset);
+
+            Vector3 aimPoint = entranceCenter + lateral * sideSign * offset;
+            Vector3 shotToAim = aimPoint - ctx.objectBallPos;
+            if (shotToAim.sqrMagnitude > 1e-8f)
+            {
+                Vector3 shotDir = shotToAim.normalized;
+                float inwardDot = Vector3.Dot(shotDir, inward);
+                if (inwardDot < 0.12f)
+                {
+                    Vector3 inwardOnly = Vector3.Project(shotToAim, inward);
+                    if (inwardOnly.sqrMagnitude > 1e-8f)
+                    {
+                        float safeLateral = Mathf.Min(Mathf.Abs(Vector3.Dot(shotToAim, lateral)), maxAllowedOffset * 0.75f);
+                        aimPoint = ctx.objectBallPos + inwardOnly.normalized * inwardOnly.magnitude + lateral * sideSign * safeLateral;
+                    }
+                }
+            }
+
+            return aimPoint;
         }
 
         static Vector3 ResolvePocketInwardDirection(in ShotContext ctx)

--- a/Assets/Scripts/Aiming/AimingConfig.cs
+++ b/Assets/Scripts/Aiming/AimingConfig.cs
@@ -34,6 +34,10 @@ namespace Aiming
         public float pocketBallClearanceRadiusScale = 1.08f;
         [Tooltip("Bias toward aiming at the far jaw side (away from first jaw impact) on cut shots.")]
         [Range(0f, 1f)] public float jawFarSideBias = 0.8f;
+        [Tooltip("High-cut shots automatically increase far-jaw preference to avoid clipping the first jaw cut.")]
+        [Range(0f, 1f)] public float jawFarSideAutoBias = 0.85f;
+        [Tooltip("Keeps jaw-guided targets away from the first-jaw side by reserving part of the pocket mouth as a dead zone.")]
+        [Range(0f, 0.95f)] public float jawNearSideDeadZoneRatio = 0.3f;
         [Tooltip("Rejects candidate aims where cue-to-contact line is significantly blocked.")]
         public float cuePathClearanceRadiusScale = 0.92f;
         [Tooltip("Penalty weight for harder cut angles so easier pots are preferred.")]

--- a/Assets/Tests/PlayMode/PocketAimTargetingTests.cs
+++ b/Assets/Tests/PlayMode/PocketAimTargetingTests.cs
@@ -119,6 +119,47 @@ namespace Aiming.Tests
         }
 
         [Test]
+        public void SteepCutAutoBiasesToFarJawAndAvoidsNearJawDeadZone()
+        {
+            var cfg = ScriptableObject.CreateInstance<AimingConfig>();
+            cfg.pocketApproachDepth = 0.12f;
+            cfg.straightPocketCenterAngleDeg = 7f;
+            cfg.jawGuideStartAngleDeg = 10f;
+            cfg.jawGuideMaxAngleDeg = 50f;
+            cfg.jawGuideOffsetMin = 0.008f;
+            cfg.jawGuideOffsetMax = 0.03f;
+            cfg.pocketMouthHalfWidth = 0.06f;
+            cfg.pocketBallClearanceRadiusScale = 1.05f;
+            cfg.jawFarSideBias = 0f;
+            cfg.jawFarSideAutoBias = 1f;
+            cfg.jawNearSideDeadZoneRatio = 0.35f;
+
+            var ctx = new ShotContext
+            {
+                objectBallPos = Vector3.zero,
+                cueBallPos = new Vector3(1f, 0f, -0.2f),
+                pocketPos = new Vector3(0f, 0f, 2f),
+                ballRadius = 0.028f,
+                tableBounds = new Bounds(Vector3.zero, new Vector3(2f, 0.2f, 4f))
+            };
+
+            Vector3 aimPoint = AdaptiveAimingEngine.ComputePocketAimPoint(ctx, cfg);
+            Vector3 entranceCenter = new Vector3(0f, 0f, 1.88f);
+            Vector3 inward = (entranceCenter - ctx.pocketPos).normalized;
+            Vector3 lateral = Vector3.Cross(Vector3.up, inward).normalized;
+            Vector3 cueDir = (ctx.cueBallPos - ctx.objectBallPos).normalized;
+
+            float incomingSide = Mathf.Sign(Vector3.Dot(cueDir, lateral));
+            float offsetSide = Mathf.Sign(Vector3.Dot(aimPoint - entranceCenter, lateral));
+            float maxAllowed = cfg.pocketMouthHalfWidth - (ctx.ballRadius * cfg.pocketBallClearanceRadiusScale);
+            float minDeadZoneOffset = maxAllowed * cfg.jawNearSideDeadZoneRatio * 0.5f;
+            float offset = Mathf.Abs(Vector3.Dot(aimPoint - entranceCenter, lateral));
+
+            Assert.That(offsetSide, Is.EqualTo(-incomingSide));
+            Assert.That(offset, Is.GreaterThan(minDeadZoneOffset));
+        }
+
+        [Test]
         public void CornerPocketUsesTableEntranceNotPocketBack()
         {
             var cfg = ScriptableObject.CreateInstance<AimingConfig>();


### PR DESCRIPTION
### Motivation
- Fix AI aiming so the target line is directed toward the pocket mouth entrance (not the pocket back) and to account for ball radius vs pocket gap when selecting lateral aim points.  
- Reduce cases where the AI clips the first jaw/cushion on cut shots by preferring the far-jaw side for steep cuts and reserving a near-jaw dead zone.  
- Provide tunable parameters so designers can balance conservatism vs risk for different pocket geometries.

### Description
- Added two new tuning fields to `AimingConfig`: `jawFarSideAutoBias` and `jawNearSideDeadZoneRatio` to control cut-driven far-jaw biasing and a near-jaw dead zone; file: `Assets/Scripts/Aiming/AimingConfig.cs`.  
- Updated `ComputePocketAimPoint` in `AdaptiveAimingEngine` to: auto-increase far-jaw preference for steep cuts (`t`-driven blending to full far-jaw), clamp lateral offset by `pocketMouthHalfWidth` minus scaled ball radius, and enforce a minimum far-side offset (dead zone) when appropriate; file: `Assets/Scripts/Aiming/AdaptiveAimingEngine.cs`.  
- Added an inward-direction safety correction that nudges aim points to ensure the object-ball → aim direction projects sufficiently into the pocket mouth (reduces aggressive sideways aims that would glance the jaw).  
- Added a PlayMode test `SteepCutAutoBiasesToFarJawAndAvoidsNearJawDeadZone` validating far-jaw selection and minimal dead-zone clearance; file: `Assets/Tests/PlayMode/PocketAimTargetingTests.cs`.

### Testing
- Ran `git diff --check` locally to validate formatting and diff sanity, and it completed successfully.  
- Added a PlayMode test covering the new behavior (test added but not executed in this rollout).  
- No full test-suite or CI run was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d611f1eba88329ad11bf9ac820a0e3)