### PR TITLE
Tweak model, piece, board and chair scaling/offsets in ChessBattleRoyal scene

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -226,22 +226,22 @@ const resolveHdriVariant = (value) => {
   return CHESS_HDRI_OPTIONS[idx] ?? CHESS_HDRI_OPTIONS[DEFAULT_HDRI_INDEX] ?? CHESS_HDRI_OPTIONS[0];
 };
 
-const MODEL_SCALE = 0.62;
+const MODEL_SCALE = 0.58;
 const STOOL_SCALE = 1.5 * 1.05;
 const CARD_SCALE = 0.95;
 
 const BOARD = { N: 8, tile: 4.2, rim: 3, baseH: 0.8 };
 const PIECE_Y = 1.2; // baseline height for meshes
 const PIECE_PLACEMENT_Y_OFFSET = 0.28;
-const PIECE_SCALE_FACTOR = 0.85;
+const PIECE_SCALE_FACTOR = 0.83;
 const PIECE_FOOTPRINT_RATIO = 0.86;
 const BOARD_GROUP_Y_OFFSET = 0;
 const BOARD_MODEL_Y_OFFSET = -0.12;
-const BOARD_VISUAL_Y_OFFSET = -0.08;
+const BOARD_VISUAL_Y_OFFSET = -0.03;
 const BOARD_SURFACE_DROP = 0.05;
 
 const RAW_BOARD_SIZE = BOARD.N * BOARD.tile + BOARD.rim * 2;
-const BOARD_SCALE = 0.0405;
+const BOARD_SCALE = 0.0385;
 const BOARD_DISPLAY_SIZE = RAW_BOARD_SIZE * BOARD_SCALE;
 const BOARD_MODEL_SPAN_BIAS = 1.18;
 const HIGHLIGHT_VERTICAL_OFFSET = 0.18;
@@ -268,7 +268,7 @@ const CAMERA_TABLE_SPAN_FACTOR = 2.6;
 
 const WALL_PROXIMITY_FACTOR = 0.5; // Bring arena walls 50% closer
 const WALL_HEIGHT_MULTIPLIER = 2; // Double wall height
-const CHAIR_SCALE = 1.04;
+const CHAIR_SCALE = 0.98;
 const CHAIR_CLEARANCE = AI_CHAIR_GAP;
 const PLAYER_CHAIR_EXTRA_CLEARANCE = 0;
 const CAMERA_PHI_OFFSET = 0;


### PR DESCRIPTION
### Motivation
- Improve visual proportions and spacing in the Chess Battle Royal scene by reducing several model scales and adjusting board offsets to better align pieces and furniture.

### Description
- Lowered `MODEL_SCALE` from `0.62` to `0.58` to reduce overall model size in the scene.
- Reduced `PIECE_SCALE_FACTOR` from `0.85` to `0.83` and adjusted `PIECE`/`BOARD` related offsets including `BOARD_VISUAL_Y_OFFSET` from `-0.08` to `-0.03` to refine piece placement and visual alignment.
- Decreased `BOARD_SCALE` from `0.0405` to `0.0385` to slightly shrink the displayed board size and changed `CHAIR_SCALE` from `1.04` to `0.98` to better match table/chair proportions.
- No functional behavior or runtime logic was altered; this change only updates layout and sizing constants in `ChessBattleRoyal.jsx`.

### Testing
- Ran the repository build with `yarn build` and the test suite with `yarn test`, and both commands completed successfully.
- Linting checks were executed as part of the CI test run and passed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d60827eff08329b516a673a310bbbe)