### PR TITLE
Murlan Royale: lower chairs and slightly reduce arena props to match HDRI

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -105,7 +105,7 @@ const CHARACTER_PROPORTION_SCALE = 2.0;
 const ENABLE_3D_HUMAN_CHARACTERS = false;
 const ARENA_GROWTH = 1.45; // expanded arena footprint for wider walkways
 const CHAIR_SIZE_SCALE = 1;
-const ARENA_PROP_SCALE = 0.9; // Slightly smaller arena props so table/chairs/cards better match HDRI scale in portrait.
+const ARENA_PROP_SCALE = 0.86; // Slightly smaller arena props so table/chairs/cards better match HDRI scale in portrait.
 const TOP_SEAT_AVATAR_UP_LIFT = 3.8; // Portrait-space lift for the visual top player's avatar badge.
 
 const TABLE_RADIUS = 3.22 * MODEL_SCALE * ARENA_PROP_SCALE;
@@ -2321,7 +2321,7 @@ const COMMUNITY_CARD_DIRECTIONAL_LIFT = 0;
 const COMMUNITY_CARD_SIDE_ORIENTATION_YAW = 0;
 const TABLE_CARD_AREA_FORWARD_SHIFT = 0.72 * MODEL_SCALE;
 const DEAL_CARD_STEP_DELAY_MS = 60;
-const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 0.85 - 0.03 * MODEL_SCALE;
+const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 0.85 - 0.06 * MODEL_SCALE;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
 const CHAIR_GROUND_DROP = 0.035 * MODEL_SCALE;
 const TABLE_HEIGHT_LIFT = 0.02 * MODEL_SCALE;


### PR DESCRIPTION
### Motivation
- Visually align the Murlan Royale table, chairs, and cards with HDRI scale in portrait by lowering chairs slightly and making arena props a bit smaller so elements read correctly on mobile screens.

### Description
- Adjusted layout constants in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` by reducing `ARENA_PROP_SCALE` from `0.9` to `0.86` and increasing the chair base offset (`CHAIR_BASE_HEIGHT` change from `-0.03 * MODEL_SCALE` to `-0.06 * MODEL_SCALE`) so chairs sit lower and the table/chairs/cards render slightly smaller.

### Testing
- Ran `npm test -- --runInBand test/murlan.test.js` which passed (1 test suite, 12 tests all green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d615bd6a5083299d32921efb85cddd)