### PR TITLE
Rank pool shot candidates by estimated pot chance and switch targets when lanes blocked

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -546,6 +546,44 @@ function clearShotCandidates (req) {
   return candidates
 }
 
+
+function rankCandidatesByPotChance (req, candidatePairs, rng = Math.random) {
+  const cueBallId = resolveCueBallId(req.state)
+  const cue = req.state.balls.find(b => b.id === cueBallId)
+  if (!cue) return []
+  const r = req.state.ballRadius
+  const ranked = []
+
+  for (const pair of candidatePairs) {
+    const target = pair?.target
+    const pocket = pair?.pocket
+    if (!target || !pocket) continue
+    const entry = pocketEntry(pocket, r, req.state.width, req.state.height, target)
+    const ghost = ghostPointForTargetPocket(target, pocket, req)
+    if (!ghost) continue
+
+    const cueLaneBlocked = pathBlocked(cue, ghost, req.state.balls, [cueBallId, target.id], r, 1.1)
+    const objectLaneBlocked = pathBlocked(target, entry, req.state.balls, [cueBallId, target.id], r)
+    const mouthBlocked = req.state.balls.some(
+      b => b.id !== cueBallId && b.id !== target.id && !b.pocketed && dist(b, entry) < r * 1.1
+    )
+    if (cueLaneBlocked || objectLaneBlocked || mouthBlocked) {
+      continue
+    }
+
+    const potChance = monteCarloPotChance(req, cue, target, entry, ghost, req.state.balls, 42, rng)
+    const entrance = pocketEntranceOpenness(target, pocket, req)
+    const lane = clearanceMargin(cue, target, req.state.balls, [cueBallId, target.id], r, 1.3)
+    const laneScore = Math.max(0, Math.min((lane - 0.45) / 0.85, 1))
+    const rank = potChance * 0.72 + entrance * 0.16 + laneScore * 0.12
+
+    ranked.push({ target, pocket, potChance, rank })
+  }
+
+  ranked.sort((a, b) => b.rank - a.rank || b.potChance - a.potChance)
+  return ranked
+}
+
 function findSuggestedTarget (req, primaryTargetId = null) {
   const cueBallId = resolveCueBallId(req.state)
   const cue = req.state.balls.find(b => b.id === cueBallId)
@@ -1086,15 +1124,23 @@ export function planShot (req) {
     { top: 0.2, side: -0.3, back: 0 }
   ]
 
-  // first, gather candidate target/pocket pairs meeting strict criteria
-  let candidatePairs = clearShotCandidates(req)
+  // first, gather target/pocket options and rank them by pot probability.
+  // If a target path is blocked, the ranked list naturally falls back to
+  // a different pocket or even a different target with higher make chance.
+  const strictPairs = clearShotCandidates(req)
+  const fallbackPairs = chooseTargets(req).flatMap(target =>
+    req.state.pockets.map(pocket => ({ target, pocket }))
+  )
+  const rankedPairs = rankCandidatesByPotChance(
+    req,
+    strictPairs.length > 0 ? strictPairs : fallbackPairs,
+    rng
+  )
+  let candidatePairs = rankedPairs
   if (candidatePairs.length === 0) {
-    // fallback: evaluate all target/pocket combinations
-    const pockets = req.state.pockets
-    const targets = chooseTargets(req)
-    candidatePairs = targets.flatMap(t => pockets.map(p => ({ target: t, pocket: p })))
+    candidatePairs = strictPairs.length > 0 ? strictPairs : fallbackPairs
   } else {
-    candidatePairs = candidatePairs.slice(0, Math.min(candidatePairs.length, 18))
+    candidatePairs = candidatePairs.slice(0, Math.min(candidatePairs.length, 24))
   }
 
   for (const strict of [true, false]) {

--- a/test/poolAi.test.js
+++ b/test/poolAi.test.js
@@ -510,3 +510,28 @@ test('power stays in a controlled range for routine pots', () => {
 
   assert(decision.power >= 0.35 && decision.power <= 0.7, `unexpected power ${decision.power}`);
 });
+
+test('switches to another target when highest-value lane is blocked', () => {
+  const decision = planShot({
+    game: 'AMERICAN_BILLIARDS',
+    state: {
+      balls: [
+        { id: 0, x: 140, y: 250, vx: 0, vy: 0, pocketed: false },
+        { id: 1, x: 450, y: 250, vx: 0, vy: 0, pocketed: false },
+        { id: 2, x: 420, y: 140, vx: 0, vy: 0, pocketed: false },
+        // blocks the 1-ball path to the right pocket
+        { id: 12, x: 700, y: 250, vx: 0, vy: 0, pocketed: false }
+      ],
+      pockets: [{ x: 1000, y: 250 }],
+      width: 1000,
+      height: 500,
+      ballRadius: 10,
+      friction: 0.01,
+      legalBallIds: [1, 2]
+    },
+    rngSeed: 29,
+    timeBudgetMs: 120
+  });
+
+  assert.equal(decision.targetBallId, 2);
+});

--- a/webapp/public/lib/poolAi.js
+++ b/webapp/public/lib/poolAi.js
@@ -576,6 +576,44 @@ function clearShotCandidates (req) {
   return candidates
 }
 
+
+function rankCandidatesByPotChance (req, candidatePairs, rng = Math.random) {
+  const cueBallId = resolveCueBallId(req.state)
+  const cue = req.state.balls.find(b => b.id === cueBallId)
+  if (!cue) return []
+  const r = req.state.ballRadius
+  const ranked = []
+
+  for (const pair of candidatePairs) {
+    const target = pair?.target
+    const pocket = pair?.pocket
+    if (!target || !pocket) continue
+    const entry = pocketEntry(pocket, r, req.state.width, req.state.height, target)
+    const ghost = ghostPointForTargetPocket(target, pocket, req)
+    if (!ghost) continue
+
+    const cueLaneBlocked = pathBlocked(cue, ghost, req.state.balls, [cueBallId, target.id], r, 1.1)
+    const objectLaneBlocked = pathBlocked(target, entry, req.state.balls, [cueBallId, target.id], r)
+    const mouthBlocked = req.state.balls.some(
+      b => b.id !== cueBallId && b.id !== target.id && !b.pocketed && dist(b, entry) < r * 1.1
+    )
+    if (cueLaneBlocked || objectLaneBlocked || mouthBlocked) {
+      continue
+    }
+
+    const potChance = monteCarloPotChance(req, cue, target, entry, ghost, req.state.balls, 42, rng)
+    const entrance = pocketEntranceOpenness(target, pocket, req)
+    const lane = clearanceMargin(cue, target, req.state.balls, [cueBallId, target.id], r, 1.3)
+    const laneScore = Math.max(0, Math.min((lane - 0.45) / 0.85, 1))
+    const rank = potChance * 0.72 + entrance * 0.16 + laneScore * 0.12
+
+    ranked.push({ target, pocket, potChance, rank })
+  }
+
+  ranked.sort((a, b) => b.rank - a.rank || b.potChance - a.potChance)
+  return ranked
+}
+
 function findSuggestedTarget (req, primaryTargetId = null) {
   const cueBallId = resolveCueBallId(req.state)
   const cue = req.state.balls.find(b => b.id === cueBallId)
@@ -1016,15 +1054,23 @@ export function planShot (req) {
     { top: 0.2, side: -0.3, back: 0 }
   ]
 
-  // first, gather candidate target/pocket pairs meeting strict criteria
-  let candidatePairs = clearShotCandidates(req)
+  // first, gather target/pocket options and rank them by pot probability.
+  // If a target path is blocked, the ranked list naturally falls back to
+  // a different pocket or even a different target with higher make chance.
+  const strictPairs = clearShotCandidates(req)
+  const fallbackPairs = chooseTargets(req).flatMap(target =>
+    req.state.pockets.map(pocket => ({ target, pocket }))
+  )
+  const rankedPairs = rankCandidatesByPotChance(
+    req,
+    strictPairs.length > 0 ? strictPairs : fallbackPairs,
+    rng
+  )
+  let candidatePairs = rankedPairs
   if (candidatePairs.length === 0) {
-    // fallback: evaluate all target/pocket combinations
-    const pockets = req.state.pockets
-    const targets = chooseTargets(req)
-    candidatePairs = targets.flatMap(t => pockets.map(p => ({ target: t, pocket: p })))
+    candidatePairs = strictPairs.length > 0 ? strictPairs : fallbackPairs
   } else {
-    candidatePairs = candidatePairs.slice(0, Math.min(candidatePairs.length, 18))
+    candidatePairs = candidatePairs.slice(0, Math.min(candidatePairs.length, 24))
   }
 
   for (const strict of [true, false]) {


### PR DESCRIPTION
### Motivation
- Improve AI target selection so it prefers shots with higher potting probability and automatically switches pocket/target when the cue-to-target or target-to-pocket lanes (or pocket mouth) are blocked.

### Description
- Added a new `rankCandidatesByPotChance(req, candidatePairs, rng)` pipeline that filters blocked cue/object lanes and pocket mouths, uses `monteCarloPotChance` to estimate make probability, and returns a ranked list of target/pocket pairs (`lib/poolAi.js` and mirrored in `webapp/public/lib/poolAi.js`).
- Updated `planShot` to consume the probability-ranked candidate list first (falling back to strict/general candidate pools when needed) and increased the candidate slice limit to explore more high-value options (`lib/poolAi.js` and `webapp/public/lib/poolAi.js`).
- Added a regression test `switches to another target when highest-value lane is blocked` to `test/poolAi.test.js` that verifies the AI will pick a different legal target when the preferred lane is obstructed.
- No API surface changes; game-mode filters and legality checks remain unchanged.

### Testing
- Executed the unit suite with `node --test test/poolAi.test.js` and all tests passed successfully (20 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d61918c2d483299991c49f6bc3cee0)