### PR TITLE
Add AI auto-target selection based on potting probability

### DIFF
--- a/Assets/Scripts/Aiming/AdaptiveAimingEngine.cs
+++ b/Assets/Scripts/Aiming/AdaptiveAimingEngine.cs
@@ -75,6 +75,12 @@ namespace Aiming
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public AimSolution GetAimSolution(in ShotContext ctx)
         {
+            TryGetAimSolution(ctx, out AimSolution solution, visualize: true);
+            return solution;
+        }
+
+        public bool TryGetAimSolution(in ShotContext ctx, out AimSolution solution, bool visualize)
+        {
             ShotContext evalCtx = NormalizePocketTarget(ctx);
             var info = classifier.Classify(evalCtx, config);
             if (!info.losCueToObj || !info.losObjToPocket)
@@ -91,9 +97,14 @@ namespace Aiming
                     debugNote = !info.losCueToObj ? "Blocked: cue→object" : "Blocked: object→pocket"
                 };
 
-                DrawGuideLine(blocked.aimStart, blocked.aimEnd);
-                if (showDebug) overlay.UpdateOverlay(evalCtx, info, blocked);
-                return blocked;
+                if (visualize)
+                {
+                    DrawGuideLine(blocked.aimStart, blocked.aimEnd);
+                    if (showDebug) overlay.UpdateOverlay(evalCtx, info, blocked);
+                }
+
+                solution = blocked;
+                return false;
             }
 
             var sol = SelectBestSolution(evalCtx, info);
@@ -101,6 +112,7 @@ namespace Aiming
             {
                 sol = BuildDefaultSolution(evalCtx, info);
             }
+
             sol.recommendedPower01 = RecommendPower(info.distBucket, ctx.requiresPower);
             if (ctx.highSpin)
             {
@@ -116,10 +128,14 @@ namespace Aiming
                 sol.cueElevationDeg = (ctx.requiresPower && info.isRailShot) ? config.elevationForPower : 0f;
             }
 
-            DrawGuideLine(sol.aimStart, sol.aimEnd);
-            if (showDebug) overlay.UpdateOverlay(evalCtx, info, sol);
+            if (visualize)
+            {
+                DrawGuideLine(sol.aimStart, sol.aimEnd);
+                if (showDebug) overlay.UpdateOverlay(evalCtx, info, sol);
+            }
 
-            return sol;
+            solution = sol;
+            return sol.isValid;
         }
 
         void DrawGuideLine(Vector3 start, Vector3 end)

--- a/Assets/Scripts/Gameplay/AutoTargetSelector.cs
+++ b/Assets/Scripts/Gameplay/AutoTargetSelector.cs
@@ -1,0 +1,102 @@
+using UnityEngine;
+
+namespace Aiming
+{
+    /// <summary>
+    /// Chooses the most pot-able target by evaluating all object-ball / pocket pairs.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public class AutoTargetSelector : MonoBehaviour
+    {
+        [SerializeField] private AdaptiveAimingEngine aiming;
+        [SerializeField] private Transform cueBall;
+        [SerializeField] private Transform[] objectBalls = new Transform[0];
+        [SerializeField] private Transform[] pockets = new Transform[0];
+        [SerializeField] private Bounds tableBounds;
+        [SerializeField, Min(0.001f)] private float ballRadius = 0.028575f;
+        [SerializeField, Min(0f)] private float cueDistancePenalty = 0.8f;
+        [SerializeField, Min(0f)] private float pocketDistancePenalty = 0.35f;
+        [SerializeField, Range(0f, 2f)] private float cutAnglePenalty = 1.1f;
+
+        public bool TrySelectBest(out Transform bestObjectBall, out Transform bestPocket, out float bestProbability, out AimSolution bestSolution)
+        {
+            bestObjectBall = null;
+            bestPocket = null;
+            bestSolution = default;
+            bestProbability = 0f;
+
+            if (aiming == null || cueBall == null || objectBalls == null || pockets == null)
+            {
+                return false;
+            }
+
+            LayerMask mask = aiming.config ? aiming.config.collisionMask : default;
+            bool hasTarget = false;
+
+            for (int i = 0; i < objectBalls.Length; i++)
+            {
+                Transform objectBall = objectBalls[i];
+                if (objectBall == null || !objectBall.gameObject.activeInHierarchy || objectBall == cueBall)
+                    continue;
+
+                for (int p = 0; p < pockets.Length; p++)
+                {
+                    Transform pocket = pockets[p];
+                    if (pocket == null || !pocket.gameObject.activeInHierarchy)
+                        continue;
+
+                    ShotContext ctx = new ShotContext
+                    {
+                        cueBallPos = cueBall.position,
+                        objectBallPos = objectBall.position,
+                        pocketPos = pocket.position,
+                        ballRadius = ballRadius,
+                        tableBounds = tableBounds,
+                        requiresPower = false,
+                        highSpin = false,
+                        collisionMask = mask
+                    };
+
+                    if (!aiming.TryGetAimSolution(ctx, out AimSolution sol, visualize: false))
+                        continue;
+
+                    float probability = EstimateProbability(ctx, sol, mask);
+                    if (!hasTarget || probability > bestProbability)
+                    {
+                        bestProbability = probability;
+                        bestObjectBall = objectBall;
+                        bestPocket = pocket;
+                        bestSolution = sol;
+                        hasTarget = true;
+                    }
+                }
+            }
+
+            return hasTarget;
+        }
+
+        float EstimateProbability(in ShotContext ctx, in AimSolution sol, LayerMask mask)
+        {
+            float losRadius = ctx.ballRadius * 0.98f;
+            bool cueToObjClear = PhysicsUtil.SphereLineClear(ctx.cueBallPos, ctx.objectBallPos, losRadius, mask);
+            bool objToPocketClear = PhysicsUtil.SphereLineClear(ctx.objectBallPos, ctx.pocketPos, losRadius, mask);
+            bool cueToAimClear = PhysicsUtil.SphereLineClear(ctx.cueBallPos, sol.aimEnd, ctx.ballRadius * 0.92f, mask);
+            if (!cueToObjClear || !objToPocketClear || !cueToAimClear)
+                return 0f;
+
+            Vector3 cueToObject = ctx.objectBallPos - ctx.cueBallPos;
+            Vector3 objectToPocket = ctx.pocketPos - ctx.objectBallPos;
+            if (cueToObject.sqrMagnitude < 1e-8f || objectToPocket.sqrMagnitude < 1e-8f)
+                return 0f;
+
+            float cutAngle = Vector3.Angle(cueToObject, objectToPocket);
+            float cueDistance = cueToObject.magnitude;
+            float pocketDistance = objectToPocket.magnitude;
+
+            float cutFactor = Mathf.Exp(-(cutAngle / 90f) * cutAnglePenalty);
+            float cueDistanceFactor = 1f / (1f + cueDistancePenalty * cueDistance);
+            float pocketDistanceFactor = 1f / (1f + pocketDistancePenalty * pocketDistance);
+            return Mathf.Clamp01(cutFactor * cueDistanceFactor * pocketDistanceFactor);
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/CueController.cs
+++ b/Assets/Scripts/Gameplay/CueController.cs
@@ -16,6 +16,7 @@ namespace Aiming
         public AdaptiveAimingEngine aiming;
         public Transform cueTip;
         public Transform cueBall, objectBall, pocket;
+        public AutoTargetSelector autoTargetSelector;
         public Rigidbody cueBallBody;
         public Bounds tableBounds;
         public float ballRadius = 0.028575f;
@@ -27,6 +28,7 @@ namespace Aiming
         public float pullRange = 0.34f;
 
         [Header("Aiming feel")]
+        [Range(0f, 1f)] public float minimumAutoTargetProbability = 0.05f;
         [Range(1f, 30f)] public float rotationDamping = 14f;
         public bool allowAimAdjustWhileCharging = false;
 
@@ -64,7 +66,13 @@ namespace Aiming
 
         void Update()
         {
-            if (aiming == null || cueBall == null || objectBall == null || pocket == null)
+            if (aiming == null || cueBall == null)
+            {
+                return;
+            }
+
+            RefreshAutoTarget();
+            if (objectBall == null || pocket == null)
             {
                 return;
             }
@@ -177,6 +185,22 @@ namespace Aiming
             }
         }
 
+
+        void RefreshAutoTarget()
+        {
+            if (autoTargetSelector == null)
+            {
+                return;
+            }
+
+            if (autoTargetSelector.TrySelectBest(out Transform bestBall, out Transform bestPocket, out float probability, out _)
+                && probability >= minimumAutoTargetProbability)
+            {
+                objectBall = bestBall;
+                pocket = bestPocket;
+            }
+        }
+
         void UpdateAimDirection()
         {
             var sol = BuildAimSolution();
@@ -266,7 +290,12 @@ namespace Aiming
                 highSpin = spinInput.sqrMagnitude > 0.0001f,
                 collisionMask = aiming.config ? aiming.config.collisionMask : default
             };
-            return aiming.GetAimSolution(ctx);
+            if (aiming.TryGetAimSolution(ctx, out AimSolution solution, visualize: true))
+            {
+                return solution;
+            }
+
+            return solution;
         }
 
         bool AreBallsMoving()


### PR DESCRIPTION
### Motivation
- Improve AI shot selection so the agent chooses the object-ball/pocket pair with the highest potting probability rather than a fixed target. 
- Allow the AI to avoid blocked or low-probability shots by evaluating ball positions, line-of-sight, and simple heuristics before selecting a target. 

### Description
- Added a new `AutoTargetSelector` component that iterates all object-ball and pocket combinations, requests aim solutions from the aiming engine, rejects blocked candidates, and scores each candidate using cut-angle and distance heuristics to produce a potting probability. 
- Implemented `EstimateProbability` which combines LOS checks (`PhysicsUtil.SphereLineClear`) with a score built from `cutAngle`, `cueDistance`, and `pocketDistance` (configurable penalties) to pick the best target. 
- Extended `AdaptiveAimingEngine` with `TryGetAimSolution(in ShotContext, out AimSolution, bool visualize)` so callers can evaluate many candidates without forcing debug visualization, and kept `GetAimSolution` as a thin wrapper that preserves existing visual behavior. 
- Integrated auto-targeting into `CueController` by adding `RefreshAutoTarget()` which queries `AutoTargetSelector` each update and switches `objectBall`/`pocket` when a candidate exceeds a configurable `minimumAutoTargetProbability`, and added the new serialized fields required. 
- Modified files: `Assets/Scripts/Gameplay/AutoTargetSelector.cs` (new), `Assets/Scripts/Aiming/AdaptiveAimingEngine.cs` (added `TryGetAimSolution`), and `Assets/Scripts/Gameplay/CueController.cs` (auto-target integration and config). 

### Testing
- Ran `git diff --check` for the changed files (`Assets/Scripts/Aiming/AdaptiveAimingEngine.cs`, `Assets/Scripts/Gameplay/CueController.cs`, `Assets/Scripts/Gameplay/AutoTargetSelector.cs`) and it reported no whitespace/merge errors. 
- No Unity Editor/playmode or automated runtime physics tests were executed in this environment, so in-engine validation and playtesting are still required to verify behavior and tune scoring weights.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d61918c2d483299991c49f6bc3cee0)