### PR TITLE
Murlan Royale: reduce arena prop scale and lower chair positions

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -105,7 +105,7 @@ const CHARACTER_PROPORTION_SCALE = 2.0;
 const ENABLE_3D_HUMAN_CHARACTERS = false;
 const ARENA_GROWTH = 1.45; // expanded arena footprint for wider walkways
 const CHAIR_SIZE_SCALE = 1;
-const ARENA_PROP_SCALE = 0.86; // Slightly smaller arena props so table/chairs/cards better match HDRI scale in portrait.
+const ARENA_PROP_SCALE = 0.82; // Slightly smaller arena props so table/chairs/cards better match HDRI scale in portrait.
 const TOP_SEAT_AVATAR_UP_LIFT = 3.8; // Portrait-space lift for the visual top player's avatar badge.
 
 const TABLE_RADIUS = 3.22 * MODEL_SCALE * ARENA_PROP_SCALE;
@@ -2324,6 +2324,7 @@ const DEAL_CARD_STEP_DELAY_MS = 60;
 const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 0.85 - 0.06 * MODEL_SCALE;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
 const CHAIR_GROUND_DROP = 0.035 * MODEL_SCALE;
+const CHAIR_SCREEN_LOWER_OFFSET = 0.03 * MODEL_SCALE; // Push chairs visually lower on portrait screens without shifting table interaction anchors.
 const TABLE_HEIGHT_LIFT = 0.02 * MODEL_SCALE;
 const TABLE_HEIGHT = STOOL_HEIGHT + TABLE_HEIGHT_LIFT;
 const TABLE_SIDE_TRIM_SCALE = 0.86;
@@ -4787,7 +4788,7 @@ export default function MurlanRoyaleArena({ search }) {
         const chairBaseHeight = CHAIR_BASE_HEIGHT - 0.04 * MODEL_SCALE;
         chair.position.set(x, chairBaseHeight, z);
         groundObjectToY(chair, 0);
-        chair.position.y -= CHAIR_GROUND_DROP;
+        chair.position.y -= CHAIR_GROUND_DROP + CHAIR_SCREEN_LOWER_OFFSET;
         chair.lookAt(new THREE.Vector3(0, chair.position.y, 0));
         arenaGroup.add(chair);
 


### PR DESCRIPTION
### Motivation
- Align the visual scale of table, chairs and cards with HDRI backdrop in portrait view by making arena props slightly smaller and lowering chair visuals.

### Description
- Reduced `ARENA_PROP_SCALE` from `0.86` to `0.82` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` so table/chairs/cards render a bit smaller against HDRIs.
- Added `CHAIR_SCREEN_LOWER_OFFSET = 0.03 * MODEL_SCALE` to nudge chairs visually lower on portrait screens without altering interaction anchors.
- Applied `CHAIR_SCREEN_LOWER_OFFSET` when setting `chair.position.y` so chair groups appear slightly lower on screen.

### Testing
- Ran unit tests for the affected area with `npm test -- --runInBand test/murlan.test.js`, and the suite passed (`12 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6197d7bc08329811b0f519b415360)