### PR TITLE
Chess Battle Royale: make Octagon default, add purchasable shapes, and include LT table finishes

### DIFF
--- a/test/chessBattleInventoryConfig.test.js
+++ b/test/chessBattleInventoryConfig.test.js
@@ -1,0 +1,34 @@
+import {
+  CHESS_BATTLE_ROYAL_DEFAULT_UNLOCKS,
+  CHESS_BATTLE_ROYAL_STORE_ITEMS,
+  CHESS_BATTLE_TABLE_OPTIONS,
+  CHESS_TABLE_FINISH_OPTIONS
+} from '../webapp/src/config/chessBattleInventoryConfig.js';
+
+describe('chess battle inventory config', () => {
+  test('defaults to octagon table for battle royal', () => {
+    expect(CHESS_BATTLE_TABLE_OPTIONS[0]?.id).toBe('murlan-default');
+    expect(CHESS_BATTLE_ROYAL_DEFAULT_UNLOCKS.tables[0]).toBe('murlan-default');
+  });
+
+  test('store includes octagon, hexagon, and oval table shapes', () => {
+    const tableIds = new Set(
+      CHESS_BATTLE_ROYAL_STORE_ITEMS.filter((item) => item.type === 'tables').map((item) => item.optionId)
+    );
+    expect(tableIds.has('murlan-default')).toBe(true);
+    expect(tableIds.has('hexagonTable')).toBe(true);
+    expect(tableIds.has('grandOval')).toBe(true);
+  });
+
+  test('includes LT table finishes in both options and store purchasables', () => {
+    const finishIds = new Set(CHESS_TABLE_FINISH_OPTIONS.map((option) => option.id));
+    const storeFinishIds = new Set(
+      CHESS_BATTLE_ROYAL_STORE_ITEMS.filter((item) => item.type === 'tableFinish').map((item) => item.optionId)
+    );
+
+    ['carbonFiberChalk', 'carbonFiberSnakeChalk', 'carbonFiberAlligatorNight'].forEach((id) => {
+      expect(finishIds.has(id)).toBe(true);
+      expect(storeFinishIds.has(id)).toBe(true);
+    });
+  });
+});

--- a/webapp/src/config/chessBattleInventoryConfig.js
+++ b/webapp/src/config/chessBattleInventoryConfig.js
@@ -2,7 +2,8 @@ import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from './murlanThemes.js';
 import { MURLAN_TABLE_FINISHES } from './murlanTableFinishes.js';
 import {
   POOL_ROYALE_DEFAULT_HDRI_ID,
-  POOL_ROYALE_HDRI_VARIANTS
+  POOL_ROYALE_HDRI_VARIANTS,
+  POOL_ROYALE_STORE_ITEMS
 } from './poolRoyaleInventoryConfig.js';
 import { swatchThumbnail } from './storeThumbnails.js';
 
@@ -71,22 +72,22 @@ export const CHESS_CHAIR_OPTIONS = Object.freeze([
 
 const PROCEDURAL_TABLE_OPTIONS = [
   {
-    id: 'hexagonTable',
-    label: 'Hexagon Table',
-    source: 'procedural',
-    proceduralShapeId: 'hexagonTable',
-    price: 0,
-    description: 'Default six-sided battle table tuned for Chess Battle Royal.',
-    thumbnail: swatchThumbnail(['#0f172a', '#111827', '#22d3ee'])
-  },
-  {
     id: 'murlan-default',
     label: 'Octagon Table',
     source: 'procedural',
     proceduralShapeId: 'classicOctagon',
-    price: 980,
-    description: 'Classic octagon battle table with shared royale proportions.',
+    price: 0,
+    description: 'Default octagon battle table with shared royale proportions.',
     thumbnail: swatchThumbnail(['#0f172a', '#1f2937', '#38bdf8'])
+  },
+  {
+    id: 'hexagonTable',
+    label: 'Hexagon Table',
+    source: 'procedural',
+    proceduralShapeId: 'hexagonTable',
+    price: 980,
+    description: 'Six-sided battle table tuned for Chess Battle Royal.',
+    thumbnail: swatchThumbnail(['#0f172a', '#111827', '#22d3ee'])
   },
   {
     id: 'grandOval',
@@ -113,8 +114,8 @@ export const CHESS_TABLE_OPTIONS = Object.freeze([
   ...MURLAN_TABLE_THEMES.filter((theme) => theme.id !== 'murlan-default')
 ]);
 
-const CHESS_BATTLE_REMOVED_TABLE_IDS = new Set(['hexagonTable', 'murlan-default', 'diamondEdge']);
-const CHESS_BATTLE_DEFAULT_TABLE_ID = 'coffee_table_round_01';
+const CHESS_BATTLE_REMOVED_TABLE_IDS = new Set(['diamondEdge']);
+const CHESS_BATTLE_DEFAULT_TABLE_ID = 'murlan-default';
 
 export const CHESS_BATTLE_TABLE_OPTIONS = Object.freeze(
   CHESS_TABLE_OPTIONS
@@ -126,10 +127,58 @@ export const CHESS_BATTLE_TABLE_OPTIONS = Object.freeze(
     })
 );
 
+const POOL_ROYALE_LT_TABLE_FINISH_IDS = new Set([
+  'carbonFiberChalk',
+  'carbonFiberChalkGrey',
+  'carbonFiberChalkBeige',
+  'carbonFiberChalkDarkBlue',
+  'carbonFiberChalkWhite',
+  'carbonFiberChalkDarkGreen',
+  'carbonFiberChalkDarkYellow',
+  'carbonFiberChalkDarkBrown',
+  'carbonFiberChalkDarkRed',
+  'carbonFiberSnakeChalk',
+  'carbonFiberSnakeChalkGrey',
+  'carbonFiberSnakeChalkBeige',
+  'carbonFiberSnakeChalkDarkBlue',
+  'carbonFiberSnakeChalkWhite',
+  'carbonFiberSnakeChalkDarkGreen',
+  'carbonFiberAlligatorOlive',
+  'carbonFiberAlligatorSwamp',
+  'carbonFiberAlligatorClay',
+  'carbonFiberAlligatorSand',
+  'carbonFiberAlligatorMoss',
+  'carbonFiberAlligatorNight'
+]);
+
+const CHESS_LT_TABLE_FINISHES = Object.freeze(
+  POOL_ROYALE_STORE_ITEMS.filter(
+    (item) => item.type === 'tableFinish' && POOL_ROYALE_LT_TABLE_FINISH_IDS.has(item.optionId)
+  ).map((item) => ({
+    id: item.optionId,
+    label: item.name.replace(/\s*Finish$/i, ''),
+    description: item.description,
+    price: item.price,
+    swatches: item.swatches,
+    thumbnail: item.thumbnail,
+    woodOption: Object.freeze({
+      id: item.optionId,
+      label: item.name.replace(/\s*Finish$/i, ''),
+      presetId: 'smokedOak',
+      grainId: 'dark_wood'
+    })
+  }))
+);
+
+export const CHESS_TABLE_FINISH_OPTIONS = Object.freeze([
+  ...MURLAN_TABLE_FINISHES,
+  ...CHESS_LT_TABLE_FINISHES
+]);
+
 export const CHESS_BATTLE_DEFAULT_UNLOCKS = Object.freeze({
   chairColor: [CHESS_CHAIR_OPTIONS[0]?.id],
   tables: [CHESS_TABLE_OPTIONS[0]?.id],
-  tableFinish: [MURLAN_TABLE_FINISHES[0]?.id],
+  tableFinish: [CHESS_TABLE_FINISH_OPTIONS[0]?.id],
   sideColor: ['amberGlow', 'mintVale'],
   boardTheme: ['classic'],
   headStyle: ['current'],
@@ -150,7 +199,7 @@ export const CHESS_BATTLE_OPTION_LABELS = Object.freeze({
     }, {})
   ),
   tableFinish: Object.freeze(
-    MURLAN_TABLE_FINISHES.reduce((acc, option) => {
+    CHESS_TABLE_FINISH_OPTIONS.reduce((acc, option) => {
       acc[option.id] = option.label;
       return acc;
     }, {})
@@ -229,7 +278,7 @@ export const CHESS_BATTLE_OPTION_THUMBNAILS = Object.freeze({
 });
 
 export const CHESS_BATTLE_STORE_ITEMS = [
-  ...MURLAN_TABLE_FINISHES.map((finish, idx) => ({
+  ...CHESS_TABLE_FINISH_OPTIONS.map((finish, idx) => ({
     id: `chess-table-finish-${finish.id}`,
     type: 'tableFinish',
     optionId: finish.id,
@@ -240,7 +289,7 @@ export const CHESS_BATTLE_STORE_ITEMS = [
     thumbnail: finish.thumbnail,
     previewShape: 'table'
   })),
-  ...CHESS_TABLE_OPTIONS.slice(1).map((theme, idx) => ({
+  ...CHESS_TABLE_OPTIONS.map((theme, idx) => ({
     id: `chess-table-${theme.id}`,
     type: 'tables',
     optionId: theme.id,
@@ -471,8 +520,8 @@ export const CHESS_BATTLE_DEFAULT_LOADOUT = [
   { type: 'chairColor', optionId: CHESS_CHAIR_OPTIONS[0]?.id, label: CHESS_CHAIR_OPTIONS[0]?.label },
   {
     type: 'tableFinish',
-    optionId: MURLAN_TABLE_FINISHES[0]?.id,
-    label: MURLAN_TABLE_FINISHES[0]?.label
+    optionId: CHESS_TABLE_FINISH_OPTIONS[0]?.id,
+    label: CHESS_TABLE_FINISH_OPTIONS[0]?.label
   },
   { type: 'sideColor', optionId: 'amberGlow', label: 'Amber Glow Pieces' },
   { type: 'sideColor', optionId: 'mintVale', label: 'Mint Vale Pieces' },

--- a/webapp/src/config/tavullBattleInventoryConfig.js
+++ b/webapp/src/config/tavullBattleInventoryConfig.js
@@ -1,6 +1,5 @@
 import { MURLAN_STOOL_THEMES } from './murlanThemes.js';
-import { MURLAN_TABLE_FINISHES } from './murlanTableFinishes.js';
-import { CHESS_TABLE_OPTIONS } from './chessBattleInventoryConfig.js';
+import { CHESS_TABLE_FINISH_OPTIONS, CHESS_TABLE_OPTIONS } from './chessBattleInventoryConfig.js';
 import { FOUR_IN_ROW_BOARD_FRAME_FINISH_OPTIONS } from './fourInRowInventoryConfig.js';
 import {
   POOL_ROYALE_DEFAULT_HDRI_ID,
@@ -71,7 +70,7 @@ export const TAVULL_BATTLE_CHAIR_OPTIONS = Object.freeze([
 ]);
 
 export const TAVULL_BATTLE_BOARD_FINISH_OPTIONS = Object.freeze([
-  ...MURLAN_TABLE_FINISHES
+  ...CHESS_TABLE_FINISH_OPTIONS
 ]);
 export const TAVULL_BATTLE_FRAME_FINISH_OPTIONS = Object.freeze([
   ...FOUR_IN_ROW_BOARD_FRAME_FINISH_OPTIONS
@@ -105,7 +104,7 @@ export const TAVULL_BATTLE_TRIANGLE_COLOR_OPTIONS = Object.freeze(
 export const TAVULL_BATTLE_DEFAULT_UNLOCKS = Object.freeze({
   chairColor: [TAVULL_BATTLE_CHAIR_OPTIONS[0]?.id],
   tables: [CHESS_TABLE_OPTIONS[0]?.id],
-  tableFinish: [MURLAN_TABLE_FINISHES[0]?.id],
+  tableFinish: [CHESS_TABLE_FINISH_OPTIONS[0]?.id],
   boardFinish: [TAVULL_BATTLE_BOARD_FINISH_OPTIONS[0]?.id],
   frameFinish: [TAVULL_BATTLE_FRAME_FINISH_OPTIONS[0]?.id],
   triangleColor: [TAVULL_BATTLE_TRIANGLE_COLOR_OPTIONS[0]?.id],
@@ -123,7 +122,7 @@ const reduceLabels = (options, labelKey = 'label') =>
 export const TAVULL_BATTLE_OPTION_LABELS = Object.freeze({
   chairColor: reduceLabels(TAVULL_BATTLE_CHAIR_OPTIONS),
   tables: reduceLabels(CHESS_TABLE_OPTIONS),
-  tableFinish: reduceLabels(MURLAN_TABLE_FINISHES),
+  tableFinish: reduceLabels(CHESS_TABLE_FINISH_OPTIONS),
   boardFinish: reduceLabels(TAVULL_BATTLE_BOARD_FINISH_OPTIONS),
   frameFinish: reduceLabels(TAVULL_BATTLE_FRAME_FINISH_OPTIONS),
   triangleColor: reduceLabels(TAVULL_BATTLE_TRIANGLE_COLOR_OPTIONS),
@@ -136,7 +135,7 @@ export const TAVULL_BATTLE_OPTION_LABELS = Object.freeze({
 });
 
 export const TAVULL_BATTLE_STORE_ITEMS = [
-  ...MURLAN_TABLE_FINISHES.map((finish, idx) => ({
+  ...CHESS_TABLE_FINISH_OPTIONS.map((finish, idx) => ({
     id: `tavull-table-finish-${finish.id}`,
     type: 'tableFinish',
     optionId: finish.id,
@@ -147,7 +146,7 @@ export const TAVULL_BATTLE_STORE_ITEMS = [
     thumbnail: finish.thumbnail,
     previewShape: 'table'
   })),
-  ...CHESS_TABLE_OPTIONS.slice(1).map((theme, idx) => ({
+  ...CHESS_TABLE_OPTIONS.map((theme, idx) => ({
     id: `tavull-table-${theme.id}`,
     type: 'tables',
     optionId: theme.id,

--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -46,9 +46,9 @@ import {
 import {
   CHESS_CHAIR_OPTIONS,
   CHESS_BATTLE_TABLE_OPTIONS,
-  CHESS_BATTLE_OPTION_THUMBNAILS
+  CHESS_BATTLE_OPTION_THUMBNAILS,
+  CHESS_TABLE_FINISH_OPTIONS
 } from '../../config/chessBattleInventoryConfig.js';
-import { MURLAN_TABLE_FINISHES } from '../../config/murlanTableFinishes.js';
 import {
   chessBattleAccountId,
   getChessBattleInventory,
@@ -1855,7 +1855,7 @@ const APPEARANCE_STORAGE_KEY = 'chessBattleRoyalAppearance';
 const CHAIR_COLOR_OPTIONS = Object.freeze([...CHESS_CHAIR_OPTIONS]);
 const TABLE_THEME_OPTIONS = Object.freeze([...CHESS_BATTLE_TABLE_OPTIONS]);
 
-const TABLE_FINISH_OPTIONS = Object.freeze([...MURLAN_TABLE_FINISHES]);
+const TABLE_FINISH_OPTIONS = Object.freeze([...CHESS_TABLE_FINISH_OPTIONS]);
 const DEFAULT_TABLE_FINISH = TABLE_FINISH_OPTIONS[0];
 const DEFAULT_WOOD_OPTION = DEFAULT_TABLE_FINISH?.woodOption ?? TABLE_WOOD_OPTIONS[0];
 const DEFAULT_CLOTH_OPTION = TABLE_CLOTH_OPTIONS[0];
@@ -1873,7 +1873,7 @@ const CUSTOMIZATION_SECTIONS = [
   { key: 'environmentHdri', label: 'HDR Environment', options: CHESS_HDRI_OPTIONS }
 ];
 
-const SHAPE_CUSTOMIZATION_TABLE_IDS = new Set(['hexagonTable', 'murlan-default', 'grandOval', 'diamondEdge']);
+const SHAPE_CUSTOMIZATION_TABLE_IDS = new Set(['hexagonTable', 'murlan-default', 'grandOval']);
 const BOARD_SURFACE_OFFSETS_BY_SHAPE = Object.freeze({
   classicOctagon: -0.065,
   hexagonTable: -0.065,
@@ -7822,7 +7822,7 @@ function Chess3D({
       );
       const theta = Number.isFinite(current.theta) ? current.theta : -Math.PI / 4;
 
-      const initialRadius = CAMERA_SAFE_MAX_RADIUS;
+      const initialRadius = CAMERA_3D_MAX_RADIUS;
       const default3d = new THREE.Spherical(initialRadius, CAMERA_DEFAULT_PHI, theta);
 
       if (mode === '2d') {
@@ -7853,7 +7853,7 @@ function Chess3D({
         controls.maxDistance = CAMERA_3D_MAX_RADIUS;
         const restore = cameraMemory.last3d || default3d;
         const target = new THREE.Spherical(
-          clamp(CAMERA_SAFE_MAX_RADIUS, CAMERA_3D_MIN_RADIUS, CAMERA_3D_MAX_RADIUS),
+          clamp(CAMERA_3D_MAX_RADIUS, CAMERA_3D_MIN_RADIUS, CAMERA_3D_MAX_RADIUS),
           clamp(restore.phi, CAMERA_PULL_FORWARD_MIN, CAM.phiMax),
           Number.isFinite(restore.theta) ? restore.theta : default3d.theta
         );


### PR DESCRIPTION
### Motivation
- Make the Octagon table the default Chess Battle Royale table and ensure the octagon/hexagon/oval shapes are available to players in the customization menu and store. 
- Make Pool Royale "LT" table-finish variants (carbon fiber / snake / alligator variants) purchasable and usable in Chess so players can select the LT finishes there as well. 
- Preserve existing UI behavior for table cloth/table finish visibility (only show cloth/finish controls for the supported procedural shapes) and adjust camera default to match the requested perceived table/chair size when zoomed out.

### Description
- Set the Chess Battle Royale procedural default to the octagon `murlan-default` and ensure table theme ordering includes octagon, hexagon, and oval by updating `webapp/src/config/chessBattleInventoryConfig.js` (reordered procedural table options, removed only `diamondEdge` from the battle-royal removed set, and exposed all table themes in the store items). 
- Add Pool Royale LT finish IDs and construct `CHESS_LT_TABLE_FINISHES` from `POOL_ROYALE_STORE_ITEMS`, then merge them into `CHESS_TABLE_FINISH_OPTIONS` so LT finishes are present in Chess options and store purchasables (changes in `webapp/src/config/chessBattleInventoryConfig.js`). 
- Propagate Chess finish changes into Tavull so shared stores/catalogs align by switching Tavull to use `CHESS_TABLE_FINISH_OPTIONS` and `CHESS_TABLE_OPTIONS` instead of separate Murlan finish lists (changes in `webapp/src/config/tavullBattleInventoryConfig.js`). 
- Update runtime & UI to use the new Chess finish/options: use `CHESS_TABLE_FINISH_OPTIONS` in `ChessBattleRoyal.jsx`, keep the cloth/finish menu visible only for the supported procedural shapes (`hexagonTable`, `murlan-default`, `grandOval`), and set the initial 3D camera radius to the maximum 3D radius so the default zoomed-out view matches the requested visual size (changes in `webapp/src/pages/Games/ChessBattleRoyal.jsx`). 
- Add unit tests that assert the new defaults, store presence of the octagon/hexagon/oval shapes and LT finishes via `test/chessBattleInventoryConfig.test.js`.

### Testing
- Added `test/chessBattleInventoryConfig.test.js` and ran targeted unit tests with `npm test -- test/chessBattleInventoryConfig.test.js test/texasHoldemInventoryConfig.test.js`, both suites passed. 
- Focused automated verification covers: default table is `murlan-default` (octagon), the Chess store exposes `murlan-default`, `hexagonTable`, and `grandOval`, and LT finish IDs are present in both `CHESS_TABLE_FINISH_OPTIONS` and `CHESS_BATTLE_STORE_ITEMS` (tests passed). 
- Local per-change smoke runs were used to keep shared inventory modules in sync and validate Tavull mappings (no additional regressions found in the tested areas).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d61bd6c22c8329bbf92ee5a3eb686c)