### PR TITLE
Domino Royale: defer live avatar frame, scale down furniture/domino, and center table in HDRI

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -944,12 +944,12 @@ const dimIntensity = (value = 1) => value * LIGHT_INTENSITY_FACTOR;
 
 const MODEL_SCALE = 0.7;
 const CAMERA_LAYOUT_SCALE = MODEL_SCALE / 0.75;
-const TABLE_RADIUS_SCALE = 0.82;
+const TABLE_RADIUS_SCALE = 0.72;
 const TABLE_HEIGHT_SCALE = 0.95;
-const ARENA_GROWTH = 1.45;
+const ARENA_GROWTH = 1.72;
 const TABLE_RADIUS = 3.4 * MODEL_SCALE * TABLE_RADIUS_SCALE;
 const BASE_TABLE_HEIGHT = 1.08 * MODEL_SCALE * TABLE_HEIGHT_SCALE;
-const STOOL_SCALE = 1.5 * 1.38;
+const STOOL_SCALE = 1.32 * 1.38;
 const SEAT_WIDTH = 0.9 * MODEL_SCALE * STOOL_SCALE;
 const SEAT_DEPTH = 0.95 * MODEL_SCALE * STOOL_SCALE;
 const SEAT_THICKNESS = 0.09 * MODEL_SCALE * STOOL_SCALE;
@@ -1011,8 +1011,8 @@ const CAMERA_LATERAL_OFFSET = {
   landscape: 0 * CAMERA_LAYOUT_SCALE
 };
 const CAMERA_REAR_OFFSET = {
-  portrait: 1.14 * CAMERA_LAYOUT_SCALE,
-  landscape: 0.68 * CAMERA_LAYOUT_SCALE
+  portrait: 1.3 * CAMERA_LAYOUT_SCALE,
+  landscape: 0.8 * CAMERA_LAYOUT_SCALE
 };
 const CAMERA_HEIGHT_BOOST = {
   portrait: 1.86 * CAMERA_LAYOUT_SCALE,
@@ -5770,34 +5770,39 @@ const tableParts = {};
 const chairs = [];
 
 function centerFurnitureInHdri() {
-  const centerCandidates = [];
   const tableRoot = tableThemeG.visible ? tableThemeG : tableG;
+  let targetCenter = null;
   if (tableRoot?.children?.length) {
     const tableBounds = new THREE.Box3().setFromObject(tableRoot);
     const tableCenter = tableBounds.getCenter(new THREE.Vector3());
     if (Number.isFinite(tableCenter.x) && Number.isFinite(tableCenter.z)) {
-      centerCandidates.push(tableCenter);
+      targetCenter = tableCenter;
     }
   }
-  chairs.forEach((chairRoot) => {
-    if (!chairRoot) return;
-    const chairBounds = new THREE.Box3().setFromObject(chairRoot);
-    const chairCenter = chairBounds.getCenter(new THREE.Vector3());
-    if (Number.isFinite(chairCenter.x) && Number.isFinite(chairCenter.z)) {
-      centerCandidates.push(chairCenter);
+  if (!targetCenter) {
+    const centerCandidates = [];
+    chairs.forEach((chairRoot) => {
+      if (!chairRoot) return;
+      const chairBounds = new THREE.Box3().setFromObject(chairRoot);
+      const chairCenter = chairBounds.getCenter(new THREE.Vector3());
+      if (Number.isFinite(chairCenter.x) && Number.isFinite(chairCenter.z)) {
+        centerCandidates.push(chairCenter);
+      }
+    });
+    if (centerCandidates.length) {
+      targetCenter = centerCandidates.reduce(
+        (acc, center) => acc.add(center),
+        new THREE.Vector3()
+      );
+      targetCenter.multiplyScalar(1 / centerCandidates.length);
     }
-  });
-  if (!centerCandidates.length) {
+  }
+  if (!targetCenter) {
     arenaG.position.set(0, arenaG.position.y, 0);
     return;
   }
-  const avgCenter = centerCandidates.reduce(
-    (acc, center) => acc.add(center),
-    new THREE.Vector3()
-  );
-  avgCenter.multiplyScalar(1 / centerCandidates.length);
-  arenaG.position.x -= avgCenter.x;
-  arenaG.position.z -= avgCenter.z;
+  arenaG.position.x = -targetCenter.x;
+  arenaG.position.z = -targetCenter.z;
 }
 
 function syncArenaGroundToFurniture() {
@@ -6386,7 +6391,7 @@ const RAIL_TOP = CLOTH_TOP + 0.04 * MODEL_SCALE;
 })();
 
 const SCALE = MODEL_SCALE * 0.92;
-const DOMINO_SCALE = 1.5 * 1.22; // upscale tiles for stronger readability
+const DOMINO_SCALE = 1.3 * 1.22; // tuned smaller to match HDRI room proportions
 const DOMINO_WORLD_SCALE = SCALE * DOMINO_SCALE;
 const DOMINO_WIDTH = DOMINO_WORLD_SCALE * 0.1;
 const DOMINO_LENGTH = DOMINO_WORLD_SCALE * (0.016 / 0.22) * 2;

--- a/webapp/src/components/GameLiveAvatarOverlay.jsx
+++ b/webapp/src/components/GameLiveAvatarOverlay.jsx
@@ -257,6 +257,18 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
     };
   }, [anchorElement, liveMode]);
 
+  useEffect(() => {
+    if (typeof document === 'undefined' || gameSlug !== 'domino-royal') {
+      return undefined;
+    }
+    document.documentElement.dataset.dominoLiveAvatarActive = liveMode
+      ? 'true'
+      : 'false';
+    return () => {
+      delete document.documentElement.dataset.dominoLiveAvatarActive;
+    };
+  }, [gameSlug, liveMode]);
+
   return (
     <>
       {children}

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-04-08-domino-hdri-original-size-v15';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-04-08-domino-hdri-centered-scale-v16';
 
 export default function DominoRoyalArena() {
   useEffect(() => {
@@ -165,6 +165,10 @@ export default function DominoRoyalArena() {
         .seat-badge.is-self .seat-badge-avatar,
         .seat-badge.is-self .seat-badge-core {
           transform: none !important;
+        }
+        html[data-domino-live-avatar-active="false"] .seat-badge.is-self .avatar-timer-ring,
+        html:not([data-domino-live-avatar-active]) .seat-badge.is-self .avatar-timer-ring {
+          opacity: 0 !important;
         }
         .seat-badge-name {
           font-size: 0.69rem !important;


### PR DESCRIPTION
### Motivation
- Prevent the large circular avatar frame from displaying until the player activates live video so the avatar appears normal at game start. 
- Make table, chairs and domino pieces visually smaller and farther from arena walls to better match HDRI room proportions and feel more realistic. 
- Ensure the table is consistently centered in the HDRI view so furniture doesn't hug the walls and main HDRI view is visible. 

### Description
- Publish Domino live-avatar state from `GameLiveAvatarOverlay` to the document root via `document.documentElement.dataset.dominoLiveAvatarActive` so DOM/CSS can hide the avatar ring until activation (`webapp/src/components/GameLiveAvatarOverlay.jsx`).
- Add Domino-specific CSS to `DominoRoyalArena.jsx` to hide the self player `avatar-timer-ring` when `data-domino-live-avatar-active` is not `true`, and bump the game script version to force clients to fetch the updated runtime (`webapp/src/pages/Games/DominoRoyalArena.jsx`).
- Tune scene proportions in the runtime: reduce `TABLE_RADIUS_SCALE` (0.82→0.72), increase `ARENA_GROWTH` (1.45→1.72), adjust `STOOL_SCALE`, nudge `CAMERA_REAR_OFFSET`, and reduce `DOMINO_SCALE` (1.5→1.3) so table, chairs and dominoes appear smaller and further from walls (`webapp/public/domino-royal-game.js`).
- Make `centerFurnitureInHdri()` deterministic by centering around the table's center when available and falling back to an averaged chair center, and set `arenaG.position` directly to keep the table visually centered in HDRI (`webapp/public/domino-royal-game.js`).

### Testing
- Built the web app with `npm --prefix webapp run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d61e15e7648329b396c5ebc8792290)