### PR TITLE
Improve Pool Royale AI pocket-mouth aiming

### DIFF
--- a/test/poolRoyalePocketAim.test.js
+++ b/test/poolRoyalePocketAim.test.js
@@ -1,0 +1,57 @@
+import { resolvePocketMouthAimPoint } from '../webapp/src/pages/Games/poolRoyalePocketAim.js';
+
+describe('Pool Royale pocket-mouth aim targeting', () => {
+  it('returns an entry point pulled inward from the pocket center', () => {
+    const result = resolvePocketMouthAimPoint({
+      pocketCenter: { x: -1, y: -1 },
+      targetPos: { x: -0.4, y: -0.7 },
+      mouthWidth: 0.2,
+      baseRadius: 0.1,
+      pocketType: 'corner'
+    });
+
+    expect(result).toBeTruthy();
+    const inwardDot =
+      (result.point.x + 1) * 1 +
+      (result.point.y + 1) * 1;
+    expect(inwardDot).toBeGreaterThan(0);
+  });
+
+  it('keeps lateral shift within a safe center-lane corridor', () => {
+    const mouthWidth = 0.22;
+    const halfMouth = mouthWidth * 0.5;
+    const result = resolvePocketMouthAimPoint({
+      pocketCenter: { x: 1, y: -1 },
+      targetPos: { x: 0.9, y: -0.15 },
+      mouthWidth,
+      baseRadius: 0.11,
+      pocketType: 'corner'
+    });
+
+    expect(result).toBeTruthy();
+    expect(Math.abs(result.lateralBias)).toBeLessThanOrEqual(1);
+
+    const inward = { x: -1 / Math.sqrt(2), y: 1 / Math.sqrt(2) };
+    const lateral = { x: -inward.y, y: inward.x };
+    const dx = result.point.x - 1;
+    const dy = result.point.y + 1;
+    const lateralOffset = dx * lateral.x + dy * lateral.y;
+    expect(Math.abs(lateralOffset)).toBeLessThan(halfMouth * 0.4);
+  });
+
+  it('works for side pockets and keeps aim between jaws', () => {
+    const result = resolvePocketMouthAimPoint({
+      pocketCenter: { x: -1.1, y: 0 },
+      targetPos: { x: -0.6, y: 0.42 },
+      mouthWidth: 0.24,
+      baseRadius: 0.12,
+      pocketType: 'side'
+    });
+
+    expect(result).toBeTruthy();
+    // Side pocket inward is +X in this setup, so entry should move right.
+    expect(result.point.x).toBeGreaterThan(-1.1);
+    // Should still stay near the middle lane, not near a jaw edge.
+    expect(Math.abs(result.point.y)).toBeLessThan(0.05);
+  });
+});

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -113,6 +113,7 @@ import {
   shouldApplyPoolSuggestion
 } from './poolRoyaleAimSuggestion.js';
 import { sampleCueStrokeTimeline } from './poolRoyaleCueStrokeTimeline.js';
+import { resolvePocketMouthAimPoint } from './poolRoyalePocketAim.js';
 import { polyHavenThumb } from '../../config/storeThumbnails.js';
 
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/v1/decoders/';
@@ -6892,34 +6893,20 @@ const resolvePocketEntranceForTarget = (targetPos, pocketIndex) => {
   const centers = pocketCenters();
   const pocketCenter = centers[pocketIndex];
   if (!pocketCenter) return null;
-  const inward = pocketCenter.clone().multiplyScalar(-1);
-  if (inward.lengthSq() < MICRO_EPS * MICRO_EPS) {
-    return pocketCenter.clone();
-  }
-  inward.normalize();
-  const lateral = new THREE.Vector2(-inward.y, inward.x);
-  const targetVec = targetPos?.clone?.()?.sub?.(pocketCenter) ?? null;
+
   const baseRadius = pocketIndex >= 4 ? SIDE_POCKET_RADIUS : POCKET_VIS_R;
-  const mouthHalfWidth = (pocketIndex >= 4 ? POCKET_SIDE_MOUTH : POCKET_CORNER_MOUTH) * 0.5;
-  const entranceBase = pocketCenter
-    .clone()
-    .add(inward.clone().multiplyScalar(baseRadius * 0.62));
-  if (!targetVec || targetVec.lengthSq() < 1e-6) {
-    return entranceBase;
-  }
-  targetVec.normalize();
-  const lateralBias = THREE.MathUtils.clamp(targetVec.dot(lateral), -1, 1);
-  const inwardAlignment = THREE.MathUtils.clamp(targetVec.dot(inward), -1, 1);
-  const sideShift =
-    mouthHalfWidth *
-    (pocketIndex >= 4 ? 0.44 : 0.36) *
-    lateralBias *
-    (0.7 + 0.3 * Math.max(0, inwardAlignment));
-  const depthShift = baseRadius * 0.18 * Math.max(0, inwardAlignment);
-  return entranceBase
-    .clone()
-    .addScaledVector(lateral, sideShift)
-    .addScaledVector(inward, depthShift);
+  const mouthWidth = pocketIndex >= 4 ? POCKET_SIDE_MOUTH : POCKET_CORNER_MOUTH;
+  const entry = resolvePocketMouthAimPoint({
+    pocketCenter,
+    targetPos,
+    baseRadius,
+    mouthWidth,
+    pocketType: pocketIndex >= 4 ? 'side' : 'corner',
+    microEps: MICRO_EPS
+  });
+
+  if (!entry?.point) return pocketCenter.clone();
+  return new THREE.Vector2(entry.point.x, entry.point.y);
 };
 const resolvePocketHolderDirection = (center, pocketId = null) => {
   const absX = Math.abs(center?.x ?? 0);

--- a/webapp/src/pages/Games/poolRoyalePocketAim.js
+++ b/webapp/src/pages/Games/poolRoyalePocketAim.js
@@ -1,0 +1,63 @@
+export const resolvePocketMouthAimPoint = ({
+  pocketCenter,
+  targetPos,
+  mouthWidth,
+  baseRadius,
+  pocketType = 'corner',
+  microEps = 1e-6
+} = {}) => {
+  if (!pocketCenter || !Number.isFinite(pocketCenter.x) || !Number.isFinite(pocketCenter.y)) {
+    return null;
+  }
+  if (!Number.isFinite(mouthWidth) || mouthWidth <= 0) return null;
+  if (!Number.isFinite(baseRadius) || baseRadius <= 0) return null;
+
+  const inwardX = -pocketCenter.x;
+  const inwardY = -pocketCenter.y;
+  const inwardLen = Math.hypot(inwardX, inwardY);
+  if (inwardLen <= microEps) {
+    return {
+      point: {
+        x: pocketCenter.x,
+        y: pocketCenter.y
+      },
+      lateralBias: 0,
+      inwardAlignment: 0
+    };
+  }
+
+  const inwardDir = { x: inwardX / inwardLen, y: inwardY / inwardLen };
+  const lateralDir = { x: -inwardDir.y, y: inwardDir.x };
+
+  const targetVecX = (targetPos?.x ?? pocketCenter.x) - pocketCenter.x;
+  const targetVecY = (targetPos?.y ?? pocketCenter.y) - pocketCenter.y;
+  const targetLen = Math.hypot(targetVecX, targetVecY);
+  const targetDir =
+    targetLen > microEps
+      ? { x: targetVecX / targetLen, y: targetVecY / targetLen }
+      : inwardDir;
+
+  const lateralBiasRaw = targetDir.x * lateralDir.x + targetDir.y * lateralDir.y;
+  const inwardAlignmentRaw = targetDir.x * inwardDir.x + targetDir.y * inwardDir.y;
+  const lateralBias = Math.max(-1, Math.min(1, lateralBiasRaw));
+  const inwardAlignment = Math.max(-1, Math.min(1, inwardAlignmentRaw));
+
+  const isSidePocket = pocketType === 'side';
+  // Aim corridor is intentionally narrower than the geometric mouth so AI seeks
+  // the center lane between the two jaws instead of flirting with one jaw.
+  const corridorHalfWidth = (mouthWidth * 0.5) * (isSidePocket ? 0.3 : 0.34);
+  const entranceDepth =
+    baseRadius * (isSidePocket ? 0.72 : 0.68) + baseRadius * 0.14 * Math.max(0, inwardAlignment);
+
+  const sideShiftScale = (isSidePocket ? 0.28 : 0.32) * (0.6 + 0.4 * Math.max(0, inwardAlignment));
+  const sideShift = corridorHalfWidth * lateralBias * sideShiftScale;
+
+  return {
+    point: {
+      x: pocketCenter.x + inwardDir.x * entranceDepth + lateralDir.x * sideShift,
+      y: pocketCenter.y + inwardDir.y * entranceDepth + lateralDir.y * sideShift
+    },
+    lateralBias,
+    inwardAlignment
+  };
+};


### PR DESCRIPTION
### Motivation
- Make AI aim at the pocket mouth center lane between the jaws instead of hugging jaw edges so pot attempts align with photographed references (pocket mouth between jaws). 
- Reduce false-positive jaw contacts and improve consistency across corner and side pockets by narrowing the AI entry corridor and tuning inward depth and lateral bias.

### Description
- Added a new utility `resolvePocketMouthAimPoint` in `webapp/src/pages/Games/poolRoyalePocketAim.js` that computes a mouth-centered entry point with controlled inward depth and constrained lateral shift. 
- Updated `resolvePocketEntranceForTarget` in `webapp/src/pages/Games/PoolRoyale.jsx` to call `resolvePocketMouthAimPoint` (imported from `poolRoyalePocketAim.js`) and return a jaw-safe `THREE.Vector2` entry for shot planning. 
- Added focused unit tests in `test/poolRoyalePocketAim.test.js` that verify inward pull, lateral corridor bounds, and correct behavior for side pockets. 
- Kept existing aim-compensation logic (`poolRoyaleAiAimCompensation`) intact and integrated the new mouth-centering entry so the overall shot-planning flow targets the pocket mouth consistently.

### Testing
- Ran `npm test -- test/poolRoyalePocketAim.test.js test/poolRoyaleAimSuggestion.test.js test/poolRoyaleAiAimCompensation.test.js` and all suites passed. 
- Test results: 3 test suites, 10 tests total, all passed (PASS).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d627d067308329bbff051b764b2be4)