### PR TITLE
Improve AI pocket-mouth aiming consistency

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -140,7 +140,7 @@ function pocketMouthGeometry (pocket, radius, width, height, target = null) {
   const pocketType = classifyPocket(pocket, width, height)
   const axis = { x: -normal.y, y: normal.x }
   const mouthHalfWidth = radius * (pocketType === 'side' ? 2.95 : 2.55)
-  const playableHalfWidth = Math.max(radius * 0.7, mouthHalfWidth - radius * 1.08)
+  const playableHalfWidth = Math.max(radius * 0.68, mouthHalfWidth - radius * 1.02)
   const mouthCenter = {
     x: pocket.x - normal.x * radius * 1.04,
     y: pocket.y - normal.y * radius * 1.04
@@ -152,10 +152,10 @@ function pocketMouthGeometry (pocket, radius, width, height, target = null) {
     const len = Math.hypot(approach.x, approach.y) || 1
     const approachUnit = { x: approach.x / len, y: approach.y / len }
     const sideProjection = approachUnit.x * axis.x + approachUnit.y * axis.y
-    // Move away from the first/near jaw and bias toward the far jaw lane.
-    // This helps steep cuts avoid clipping the first cushion cut.
+    // Keep baseline entry at pocket mouth center and only apply a mild
+    // anti-jaw offset on very steep cuts.
     const jawDirection = sideProjection >= 0 ? -1 : 1
-    lateralBias = jawDirection * playableHalfWidth * 0.58
+    lateralBias = jawDirection * playableHalfWidth * 0.24
   }
 
   return {
@@ -194,7 +194,7 @@ function pocketEntry (pocket, radius, width, height, target) {
     x: pocket.x - dir.x * offset,
     y: pocket.y - dir.y * offset
   }
-  const blend = target ? 0.64 : 0.4
+  const blend = target ? 0.28 : 0.2
   return {
     x: centerDriven.x * (1 - blend) + mouth.preferredEntry.x * blend,
     y: centerDriven.y * (1 - blend) + mouth.preferredEntry.y * blend

--- a/test/poolAi.test.js
+++ b/test/poolAi.test.js
@@ -440,6 +440,32 @@ test('biases pocket entry toward far jaw lane when near jaw is crowded', () => {
   assert(decision.targetPocket.x > 500, 'entry should shift to the far/right jaw lane')
 })
 
+test('keeps pocket entry near mouth center when jaws are clear', () => {
+  const decision = planShot({
+    game: 'AMERICAN_BILLIARDS',
+    state: {
+      balls: [
+        { id: 0, x: 640, y: 320, vx: 0, vy: 0, pocketed: false },
+        { id: 3, x: 500, y: 205, vx: 0, vy: 0, pocketed: false }
+      ],
+      pockets: [
+        { x: 500, y: 0 }
+      ],
+      width: 1000,
+      height: 500,
+      ballRadius: 10,
+      friction: 0.01,
+      legalBallIds: [3]
+    },
+    timeBudgetMs: 120,
+    rngSeed: 29
+  })
+
+  assert.equal(decision.targetBallId, 3)
+  assert(decision.targetPocket, 'expected a selected pocket entry')
+  assert(Math.abs(decision.targetPocket.x - 500) < 7, 'entry should remain near pocket-mouth center')
+})
+
 
 test('eight-pool targets black when only 8 remains and group metadata is missing', () => {
   const decision = planShot({


### PR DESCRIPTION
### Motivation

- Reduce cases where the AI over-biases aim toward a pocket jaw so it instead aims more centrally at the pocket mouth between the jaws in normal (unjammed) situations.

### Description

- Tweak pocket geometry in `lib/poolAi.js` by adjusting `pocketMouthGeometry` to slightly tighten the `playableHalfWidth` and reduce the aggressive lateral anti-jaw bias, and by reducing the pocket-entry blending weight in `pocketEntry` so aim points favor the pocket-mouth center more.
- Keep the anti-jaw bias behaviour for crowded-jaw situations but apply it more mildly so steep cuts still receive protection without pushing the entry point too far off-center.
- Add a regression test `keeps pocket entry near mouth center when jaws are clear` in `test/poolAi.test.js` to assert that selected pocket entries stay near the mouth center when the jaws are not crowded.

### Testing

- Ran `npm test -- test/poolAi.test.js --runInBand` and all tests passed (20/20) for the modified test file.
- The modified tests exercise pocket-entry selection behaviors including the new mouth-center regression and existing jaw-crowding cases, and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d627d067308329bbff051b764b2be4)