### PR TITLE
Increase Chess Battle Royal table, board, chair, and piece scale

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -226,14 +226,14 @@ const resolveHdriVariant = (value) => {
   return CHESS_HDRI_OPTIONS[idx] ?? CHESS_HDRI_OPTIONS[DEFAULT_HDRI_INDEX] ?? CHESS_HDRI_OPTIONS[0];
 };
 
-const MODEL_SCALE = 0.58;
+const MODEL_SCALE = 0.62;
 const STOOL_SCALE = 1.5 * 1.05;
 const CARD_SCALE = 0.95;
 
 const BOARD = { N: 8, tile: 4.2, rim: 3, baseH: 0.8 };
 const PIECE_Y = 1.2; // baseline height for meshes
 const PIECE_PLACEMENT_Y_OFFSET = 0.28;
-const PIECE_SCALE_FACTOR = 0.83;
+const PIECE_SCALE_FACTOR = 0.88;
 const PIECE_FOOTPRINT_RATIO = 0.86;
 const BOARD_GROUP_Y_OFFSET = 0;
 const BOARD_MODEL_Y_OFFSET = -0.12;
@@ -241,7 +241,7 @@ const BOARD_VISUAL_Y_OFFSET = -0.03;
 const BOARD_SURFACE_DROP = 0.05;
 
 const RAW_BOARD_SIZE = BOARD.N * BOARD.tile + BOARD.rim * 2;
-const BOARD_SCALE = 0.0385;
+const BOARD_SCALE = 0.041;
 const BOARD_DISPLAY_SIZE = RAW_BOARD_SIZE * BOARD_SCALE;
 const BOARD_MODEL_SPAN_BIAS = 1.18;
 const HIGHLIGHT_VERTICAL_OFFSET = 0.18;
@@ -268,7 +268,7 @@ const CAMERA_TABLE_SPAN_FACTOR = 2.6;
 
 const WALL_PROXIMITY_FACTOR = 0.5; // Bring arena walls 50% closer
 const WALL_HEIGHT_MULTIPLIER = 2; // Double wall height
-const CHAIR_SCALE = 0.98;
+const CHAIR_SCALE = 1.03;
 const CHAIR_CLEARANCE = AI_CHAIR_GAP;
 const PLAYER_CHAIR_EXTRA_CLEARANCE = 0;
 const CAMERA_PHI_OFFSET = 0;


### PR DESCRIPTION
### Motivation
- Improve on-screen readability and presence of the Chess Battle Royal scene by making the table, board and pieces a bit larger so they read better on mobile portrait screens.
- Keep visual proportions balanced between the table, chairs and pieces while minimizing layout regressions.

### Description
- Increased scene scale by changing `MODEL_SCALE` from `0.58` to `0.62` in `webapp/src/pages/Games/ChessBattleRoyal.jsx` to enlarge the overall table/scene.
- Increased piece sizing by updating `PIECE_SCALE_FACTOR` from `0.83` to `0.88` so pieces remain proportionally larger with the board.
- Increased board display scale by updating `BOARD_SCALE` from `0.0385` to `0.041` so the board appears larger with the table.
- Slightly increased chairs by changing `CHAIR_SCALE` from `0.98` to `1.03` to maintain visual balance with the larger table and board.

### Testing
- Ran the production build with `npm --prefix webapp run build`, which completed successfully (Vite build succeeded). 
- Vite reported unrelated chunk-size and dynamic-import warnings; no build failures were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d628eaaed08329b5ae6bc4c604c3dd)