### PR TITLE
Scale down Chess Battle Royal table, chairs, board, and pieces

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -226,14 +226,14 @@ const resolveHdriVariant = (value) => {
   return CHESS_HDRI_OPTIONS[idx] ?? CHESS_HDRI_OPTIONS[DEFAULT_HDRI_INDEX] ?? CHESS_HDRI_OPTIONS[0];
 };
 
-const MODEL_SCALE = 0.58;
+const MODEL_SCALE = 0.55;
 const STOOL_SCALE = 1.5 * 1.05;
 const CARD_SCALE = 0.95;
 
 const BOARD = { N: 8, tile: 4.2, rim: 3, baseH: 0.8 };
 const PIECE_Y = 1.2; // baseline height for meshes
 const PIECE_PLACEMENT_Y_OFFSET = 0.28;
-const PIECE_SCALE_FACTOR = 0.83;
+const PIECE_SCALE_FACTOR = 0.79;
 const PIECE_FOOTPRINT_RATIO = 0.86;
 const BOARD_GROUP_Y_OFFSET = 0;
 const BOARD_MODEL_Y_OFFSET = -0.12;
@@ -241,7 +241,7 @@ const BOARD_VISUAL_Y_OFFSET = -0.03;
 const BOARD_SURFACE_DROP = 0.05;
 
 const RAW_BOARD_SIZE = BOARD.N * BOARD.tile + BOARD.rim * 2;
-const BOARD_SCALE = 0.0385;
+const BOARD_SCALE = 0.0368;
 const BOARD_DISPLAY_SIZE = RAW_BOARD_SIZE * BOARD_SCALE;
 const BOARD_MODEL_SPAN_BIAS = 1.18;
 const HIGHLIGHT_VERTICAL_OFFSET = 0.18;


### PR DESCRIPTION
### Motivation
- Make the Chess Battle Royal furniture and board slightly smaller so the table, chairs, board, and pieces appear a bit more compact on-screen as requested.

### Description
- Tuned the scene scale constants in `webapp/src/pages/Games/ChessBattleRoyal.jsx` by updating `MODEL_SCALE` from `0.58` to `0.55` to reduce table/chair base size. 
- Reduced chess piece sizing by changing `PIECE_SCALE_FACTOR` from `0.83` to `0.79` so pieces remain proportional to the smaller table. 
- Reduced board visual scale by changing `BOARD_SCALE` from `0.0385` to `0.0368` so the board and pieces fit the adjusted layout. 
- All derived geometry (e.g. `TABLE_RADIUS`, seat dimensions, table heights) continue to be calculated from these constants so scene proportions are preserved.

### Testing
- Ran `npm test -- chessBattleInventoryConfig.test.js` which passed (3 tests passed). 
- Ran `npx eslint` on the modified file and observed a project ignore warning (file ignored by project ESLint settings), so no lint errors were reported for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d62b98be5883298a0078f136aa4ccf)