### PR TITLE
Scale down Chess Battle Royal scene (table, chairs, board, pieces)

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -226,14 +226,14 @@ const resolveHdriVariant = (value) => {
   return CHESS_HDRI_OPTIONS[idx] ?? CHESS_HDRI_OPTIONS[DEFAULT_HDRI_INDEX] ?? CHESS_HDRI_OPTIONS[0];
 };
 
-const MODEL_SCALE = 0.55;
+const MODEL_SCALE = 0.52;
 const STOOL_SCALE = 1.5 * 1.05;
 const CARD_SCALE = 0.95;
 
 const BOARD = { N: 8, tile: 4.2, rim: 3, baseH: 0.8 };
 const PIECE_Y = 1.2; // baseline height for meshes
 const PIECE_PLACEMENT_Y_OFFSET = 0.28;
-const PIECE_SCALE_FACTOR = 0.79;
+const PIECE_SCALE_FACTOR = 0.75;
 const PIECE_FOOTPRINT_RATIO = 0.86;
 const BOARD_GROUP_Y_OFFSET = 0;
 const BOARD_MODEL_Y_OFFSET = -0.12;
@@ -241,7 +241,7 @@ const BOARD_VISUAL_Y_OFFSET = -0.03;
 const BOARD_SURFACE_DROP = 0.05;
 
 const RAW_BOARD_SIZE = BOARD.N * BOARD.tile + BOARD.rim * 2;
-const BOARD_SCALE = 0.0368;
+const BOARD_SCALE = 0.0352;
 const BOARD_DISPLAY_SIZE = RAW_BOARD_SIZE * BOARD_SCALE;
 const BOARD_MODEL_SPAN_BIAS = 1.18;
 const HIGHLIGHT_VERTICAL_OFFSET = 0.18;


### PR DESCRIPTION
### Motivation
- The Chess Battle Royal scene needed a slightly smaller table/chair/board/piece layout so the play area appears less large on-screen and matches the requested visual scale.

### Description
- Adjusted scene scale constants in `webapp/src/pages/Games/ChessBattleRoyal.jsx` to reduce visual size of the environment and assets.
- Changed `MODEL_SCALE` from `0.55` to `0.52` to uniformly reduce table and chair sizing.
- Reduced piece sizing by setting `PIECE_SCALE_FACTOR` from `0.79` to `0.75` so pieces remain visually consistent with the smaller board.
- Reduced board display size by changing `BOARD_SCALE` from `0.0368` to `0.0352` so the chessboard appears slightly smaller.

### Testing
- Ran a production build with `npm -C webapp run build` and the build completed successfully.
- Build emitted existing Vite chunk-size warnings but they are non-blocking and pre-existing; no build errors occurred.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d63797ca5883299527959b53a1ccf0)