### PR TITLE
Add corner-pocket safety to AI aiming to avoid cushion-first shots

### DIFF
--- a/Assets/Scripts/Aiming/AdaptiveAimingEngine.cs
+++ b/Assets/Scripts/Aiming/AdaptiveAimingEngine.cs
@@ -247,7 +247,53 @@ namespace Aiming
                 }
             }
 
+            aimPoint = EnforceCornerPocketSafety(ctx, cfg, inward, entranceCenter, aimPoint);
             return aimPoint;
+        }
+
+        static Vector3 EnforceCornerPocketSafety(in ShotContext ctx, AimingConfig cfg, Vector3 inward, Vector3 entranceCenter, Vector3 aimPoint)
+        {
+            // Side pockets have only one inward axis and do not need corner-jaw correction.
+            if (Mathf.Abs(inward.x) < 0.01f || Mathf.Abs(inward.z) < 0.01f)
+                return aimPoint;
+
+            Vector3 shot = aimPoint - ctx.objectBallPos;
+            if (shot.sqrMagnitude < 1e-8f)
+                return aimPoint;
+
+            float minToward = cfg ? cfg.cornerPocketAxisTowardMin : 0.14f;
+            float blend = cfg ? cfg.cornerPocketSafetyBlend : 0.72f;
+            Vector3 axisX = new Vector3(Mathf.Sign(inward.x), 0f, 0f);
+            Vector3 axisZ = new Vector3(0f, 0f, Mathf.Sign(inward.z));
+
+            float xToward = Vector3.Dot(shot.normalized, axisX);
+            float zToward = Vector3.Dot(shot.normalized, axisZ);
+            if (xToward >= minToward && zToward >= minToward)
+                return aimPoint;
+
+            float worst = Mathf.Min(xToward, zToward);
+            float deficiency = Mathf.Clamp01((minToward - worst) / Mathf.Max(minToward, 1e-4f));
+            float correction = Mathf.Clamp01(deficiency * Mathf.Clamp01(blend));
+            if (correction <= 1e-4f)
+                return aimPoint;
+
+            float maxDepthBoost = Mathf.Max(ctx.ballRadius * 0.8f, 0.015f);
+            Vector3 deeperCenter = entranceCenter + inward * (maxDepthBoost * correction);
+            Vector3 corrected = Vector3.Lerp(aimPoint, deeperCenter, correction);
+
+            // Final guard: if still too flat on one axis, hard snap to deeper center.
+            Vector3 correctedShot = corrected - ctx.objectBallPos;
+            if (correctedShot.sqrMagnitude > 1e-8f)
+            {
+                Vector3 correctedDir = correctedShot.normalized;
+                if (Vector3.Dot(correctedDir, axisX) < minToward * 0.7f ||
+                    Vector3.Dot(correctedDir, axisZ) < minToward * 0.7f)
+                {
+                    corrected = deeperCenter;
+                }
+            }
+
+            return corrected;
         }
 
         static Vector3 ResolvePocketInwardDirection(in ShotContext ctx)

--- a/Assets/Scripts/Aiming/AimingConfig.cs
+++ b/Assets/Scripts/Aiming/AimingConfig.cs
@@ -38,6 +38,10 @@ namespace Aiming
         [Range(0f, 1f)] public float jawFarSideAutoBias = 0.85f;
         [Tooltip("Keeps jaw-guided targets away from the first-jaw side by reserving part of the pocket mouth as a dead zone.")]
         [Range(0f, 0.95f)] public float jawNearSideDeadZoneRatio = 0.3f;
+        [Tooltip("For corner pockets, minimum directional component toward each adjacent cushion axis; higher values avoid cushion-first lines.")]
+        [Range(0f, 0.8f)] public float cornerPocketAxisTowardMin = 0.14f;
+        [Tooltip("How strongly corner-pocket correction blends targets back toward center/deeper pocket when cushion-first risk is detected.")]
+        [Range(0f, 1f)] public float cornerPocketSafetyBlend = 0.72f;
         [Tooltip("Rejects candidate aims where cue-to-contact line is significantly blocked.")]
         public float cuePathClearanceRadiusScale = 0.92f;
         [Tooltip("Penalty weight for harder cut angles so easier pots are preferred.")]


### PR DESCRIPTION
### Motivation
- Corner-pocket shots were producing AI aim lines that track too close to the cushions/jaws, causing unrealistic cushion-first contacts and misses.
- The goal is to bias corner-pocket target points deeper/centered when the computed object→pocket line is too “flat” toward one cushion axis to reduce these failure modes.

### Description
- Added two new tuning fields to `AimingConfig`: `cornerPocketAxisTowardMin` and `cornerPocketSafetyBlend` with sensible defaults so designers can adjust behavior without code changes.
- Implemented `EnforceCornerPocketSafety(...)` and invoked it as a final pass inside `AdaptiveAimingEngine.ComputePocketAimPoint` after jaw-guided lateral offsets are computed.
- The safety pass only runs for corner pockets (both `inward.x` and `inward.z` present), checks directional components toward both adjacent cushion axes, and blends the aim point toward a deeper/centered entrance when a cushion-first risk is detected.
- If blending does not produce a sufficiently safe direction, the routine can hard-snap the aim to a deeper centerline as a final guard.

### Testing
- Attempted to run unit tests with `dotnet test billiards.Tests/Billiards.Tests.csproj`, but the command failed because `dotnet` is not installed in the current environment.
- No automated test run succeeded in this environment; changes are limited to aiming heuristics and should be validated with in-editor playtesting and CI that has the proper tooling installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6378ace8083298bcb8692281743aa)