### PR TITLE
Avoid cushion-skimming aim for corner pockets

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -136,6 +136,11 @@ function classifyPocket (pocket, width, height, tolerance = 1e-3) {
 }
 
 function pocketMouthGeometry (pocket, radius, width, height, target = null) {
+  const edgeTol = Math.max(radius * 3.5, Math.min(width, height) * 0.06)
+  const nearLeft = pocket.x <= edgeTol
+  const nearRight = pocket.x >= width - edgeTol
+  const nearTop = pocket.y <= edgeTol
+  const nearBottom = pocket.y >= height - edgeTol
   const normal = pocketNormal(pocket, width, height)
   const pocketType = classifyPocket(pocket, width, height)
   const axis = { x: -normal.y, y: normal.x }
@@ -159,6 +164,11 @@ function pocketMouthGeometry (pocket, radius, width, height, target = null) {
   }
 
   return {
+    pocketType,
+    nearLeft,
+    nearRight,
+    nearTop,
+    nearBottom,
     normal,
     axis,
     mouthCenter,
@@ -173,6 +183,7 @@ function pocketMouthGeometry (pocket, radius, width, height, target = null) {
 function pocketEntry (pocket, radius, width, height, target) {
   const mouth = pocketMouthGeometry(pocket, radius, width, height, target)
   let dir = mouth.normal
+  let cutness = 0
 
   if (target) {
     const targetDir = { x: pocket.x - target.x, y: pocket.y - target.y }
@@ -187,6 +198,7 @@ function pocketEntry (pocket, radius, width, height, target) {
     }
     const blendedLen = Math.hypot(dir.x, dir.y) || 1
     dir = { x: dir.x / blendedLen, y: dir.y / blendedLen }
+    cutness = 1 - Math.max(0, unitTargetDir.x * mouth.normal.x + unitTargetDir.y * mouth.normal.y)
   }
 
   const offset = radius * 1.05
@@ -195,10 +207,23 @@ function pocketEntry (pocket, radius, width, height, target) {
     y: pocket.y - dir.y * offset
   }
   const blend = target ? 0.64 : 0.4
-  return {
+  const point = {
     x: centerDriven.x * (1 - blend) + mouth.preferredEntry.x * blend,
     y: centerDriven.y * (1 - blend) + mouth.preferredEntry.y * blend
   }
+
+  // Corner-pocket safety: keep both coordinates away from the adjacent
+  // cushions on steeper cuts so the object-ball lane enters through
+  // the jaw opening instead of skimming a cushion first.
+  if (target && mouth.pocketType === 'corner') {
+    const minInset = radius * (0.86 + Math.min(0.78, cutness * 0.92))
+    if (mouth.nearLeft) point.x = Math.max(point.x, minInset)
+    if (mouth.nearRight) point.x = Math.min(point.x, width - minInset)
+    if (mouth.nearTop) point.y = Math.max(point.y, minInset)
+    if (mouth.nearBottom) point.y = Math.min(point.y, height - minInset)
+  }
+
+  return point
 }
 
 function pocketAlignment (pocket, target, width, height) {

--- a/test/poolAi.test.js
+++ b/test/poolAi.test.js
@@ -440,6 +440,33 @@ test('biases pocket entry toward far jaw lane when near jaw is crowded', () => {
   assert(decision.targetPocket.x > 500, 'entry should shift to the far/right jaw lane')
 })
 
+test('keeps corner-pocket aim away from both cushions on steep cuts', () => {
+  const decision = planShot({
+    game: 'AMERICAN_BILLIARDS',
+    state: {
+      balls: [
+        { id: 0, x: 770, y: 340, vx: 0, vy: 0, pocketed: false },
+        { id: 3, x: 480, y: 120, vx: 0, vy: 0, pocketed: false }
+      ],
+      pockets: [
+        { x: 0, y: 0 }
+      ],
+      width: 1000,
+      height: 500,
+      ballRadius: 10,
+      friction: 0.01,
+      legalBallIds: [3]
+    },
+    timeBudgetMs: 120,
+    rngSeed: 31
+  })
+
+  assert.equal(decision.targetBallId, 3)
+  assert(decision.targetPocket, 'expected a selected pocket entry')
+  assert(decision.targetPocket.x >= 11.5, `corner entry x hugs cushion: ${decision.targetPocket.x}`)
+  assert(decision.targetPocket.y >= 11.5, `corner entry y hugs cushion: ${decision.targetPocket.y}`)
+})
+
 
 test('eight-pool targets black when only 8 remains and group metadata is missing', () => {
   const decision = planShot({

--- a/webapp/public/lib/poolAi.js
+++ b/webapp/public/lib/poolAi.js
@@ -193,6 +193,11 @@ function pocketMouthProfile (pocket, radius, width, height) {
     mouth,
     jawA,
     jawB,
+    nearLeft,
+    nearRight,
+    nearTop,
+    nearBottom,
+    isCorner: (nearLeft || nearRight) && (nearTop || nearBottom),
     lateral: { x: lateral.x / lateralLen, y: lateral.y / lateralLen },
     halfSpan: lateralLen * 0.5
   }
@@ -265,10 +270,24 @@ function pocketEntry (pocket, radius, width, height, target, options = null) {
   }
 
   const offset = Math.max(radius * 0.34, Math.min(radius * 0.48, radius * 0.38 + safeHalfGap * 0.08))
-  return {
+  const point = {
     x: mouth.x + profile.lateral.x * lateralOffset - dir.x * offset,
     y: mouth.y + profile.lateral.y * lateralOffset - dir.y * offset
   }
+
+  // Corner-pocket safety: for bigger cut angles, keep entry away from both
+  // adjacent cushions so the target lane goes through the open jaw window.
+  if (target && profile.isCorner) {
+    const normalDot = Math.max(0, dir.x * normal.x + dir.y * normal.y)
+    const cutness = 1 - normalDot
+    const minInset = radius * (0.86 + Math.min(0.78, cutness * 0.92))
+    if (profile.nearLeft) point.x = Math.max(point.x, minInset)
+    if (profile.nearRight) point.x = Math.min(point.x, width - minInset)
+    if (profile.nearTop) point.y = Math.max(point.y, minInset)
+    if (profile.nearBottom) point.y = Math.min(point.y, height - minInset)
+  }
+
+  return point
 }
 
 function pocketEntryOptionsForTarget (req, target) {


### PR DESCRIPTION
### Motivation
- Corner-pocket cut shots were producing aim lines that skimmed adjacent cushions instead of entering through the pocket jaw, causing poor AI potting behaviour. 
- Improve reliability for steep cut/corner pots by biasing aim points into the jaw opening and away from both nearby rails.

### Description
- Add corner-aware metadata (`pocketType`, `nearLeft`, `nearRight`, `nearTop`, `nearBottom`) to `pocketMouthGeometry` in `lib/poolAi.js` so pocket logic can detect adjacent rails. 
- Compute a `cutness` measure and enforce a dynamic `minInset` inside `pocketEntry` to clamp returned aim points away from both cushions on steeper corner cuts in `lib/poolAi.js`.
- Mirror the same safety/clamping changes in the client bundle copy at `webapp/public/lib/poolAi.js` so runtime behaviour matches the shared planner. 
- Add a regression test `keeps corner-pocket aim away from both cushions on steep cuts` in `test/poolAi.test.js` that exercises a steep corner pot and asserts the chosen entry point keeps safe clearance from both adjacent rails.

### Testing
- Ran `npm test -- test/poolAi.test.js --runInBand` and the suite passed; the file-level tests completed successfully and the new regression test passed. 
- All existing pocket/aiming-related tests remained green after the change (tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6378ace8083298bcb8692281743aa)