### PR TITLE
Improve corner-pocket AI lane selection

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -170,6 +170,40 @@ function pocketMouthGeometry (pocket, radius, width, height, target = null) {
   }
 }
 
+function cornerPocketRailClearance (pocket, point, width, height) {
+  const tolerance = 1e-3
+  const nearLeft = Math.abs(pocket.x) <= tolerance
+  const nearRight = Math.abs(pocket.x - width) <= tolerance
+  const nearTop = Math.abs(pocket.y) <= tolerance
+  const nearBottom = Math.abs(pocket.y - height) <= tolerance
+
+  const xRailGap = nearLeft
+    ? point.x
+    : nearRight
+      ? width - point.x
+      : Infinity
+  const yRailGap = nearTop
+    ? point.y
+    : nearBottom
+      ? height - point.y
+      : Infinity
+
+  return Math.min(xRailGap, yRailGap)
+}
+
+function cornerPocketLaneSafety (target, entry, pocket, req) {
+  if (!target || !entry || !pocket || !req?.state) return 1
+  if (classifyPocket(pocket, req.state.width, req.state.height) !== 'corner') return 1
+  const radius = req.state.ballRadius || 0
+  const startGap = cornerPocketRailClearance(pocket, target, req.state.width, req.state.height)
+  const endGap = cornerPocketRailClearance(pocket, entry, req.state.width, req.state.height)
+  const laneGap = Math.min(startGap, endGap)
+  const safeGap = radius * 1.45
+  const hardFailGap = radius * 0.82
+  if (laneGap <= hardFailGap) return 0
+  return Math.max(0, Math.min((laneGap - hardFailGap) / Math.max(safeGap - hardFailGap, 1e-6), 1))
+}
+
 function pocketEntry (pocket, radius, width, height, target) {
   const mouth = pocketMouthGeometry(pocket, radius, width, height, target)
   let dir = mouth.normal
@@ -195,10 +229,19 @@ function pocketEntry (pocket, radius, width, height, target) {
     y: pocket.y - dir.y * offset
   }
   const blend = target ? 0.64 : 0.4
-  return {
+  const entry = {
     x: centerDriven.x * (1 - blend) + mouth.preferredEntry.x * blend,
     y: centerDriven.y * (1 - blend) + mouth.preferredEntry.y * blend
   }
+  if (classifyPocket(pocket, width, height) !== 'corner') return entry
+
+  const minRailGap = radius * 0.95
+  const tolerance = 1e-3
+  if (Math.abs(pocket.x) <= tolerance) entry.x = Math.max(entry.x, minRailGap)
+  if (Math.abs(pocket.x - width) <= tolerance) entry.x = Math.min(entry.x, width - minRailGap)
+  if (Math.abs(pocket.y) <= tolerance) entry.y = Math.max(entry.y, minRailGap)
+  if (Math.abs(pocket.y - height) <= tolerance) entry.y = Math.min(entry.y, height - minRailGap)
+  return entry
 }
 
 function pocketAlignment (pocket, target, width, height) {
@@ -524,6 +567,7 @@ function clearShotCandidates (req) {
       const weightedView = viewScore * (0.7 + 0.3 * entryAlignment)
       const entranceOpenness = pocketEntranceOpenness(target, pocket, req)
       const pocketView = weightedView * (0.68 + 0.32 * entranceOpenness)
+      const cornerLaneSafety = cornerPocketLaneSafety(target, entry, pocket, req)
       const approachStraightness = 1 - Math.min(cut / (Math.PI / 2), 1)
       const cueToTarget = cue ? dist(cue, target) : 0
       const distanceScore = cue ? Math.max(0, 1 - cueToTarget / (r * 60)) : 0
@@ -532,11 +576,12 @@ function clearShotCandidates (req) {
         pocketView * 0.52 +
         approachStraightness * 0.31 +
         distanceScore * 0.08 +
+        cornerLaneSafety * 0.19 +
         entranceOpenness * 0.17 -
         pocketTravelPenalty * 0.08
 
       // require fairly central hit and open pocket view
-      if (cut <= maxCut && pocketView >= minView) {
+      if (cut <= maxCut && pocketView >= minView && cornerLaneSafety >= 0.3) {
         candidates.push({ target, pocket, cut, view: pocketView, rank })
       }
     }
@@ -909,6 +954,10 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
   const viewScore = Math.min(viewAngle / (Math.PI / 2), 1)
   const entryAlignment = pocketAlignment(pocket, target, req.state.width, req.state.height)
   const pocketOpen = viewScore * (0.7 + 0.3 * entryAlignment)
+  const cornerLaneSafety = cornerPocketLaneSafety(target, entry, pocket, req)
+  if (cornerLaneSafety <= 0.1) {
+    return null
+  }
   const cueToTarget = dist(cue, target)
   const shotLengthFactor = Math.min(cueToTarget / (r * 40), 2)
   const cutSeverity = Math.min(cutAngle / (Math.PI / 2), 1)
@@ -941,6 +990,7 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
       0.46 * potChance +
         0.15 * pocketOpen +
         0.13 * centerAlign +
+        0.1 * cornerLaneSafety +
         0.06 * nextScore +
         0.03 * nearHole +
         0.14 * runoutPotential +


### PR DESCRIPTION
### Motivation
- Corner-pocket pot lines were frequently skimming cushions and producing jaw/cushion-first aims when the AI attempted corner pots, reducing realism and success rate.
- The goal is to bias the planner away from target->pocket lanes that pass too close to adjacent rails so the object ball is aimed more centrally into the pocket mouth.

### Description
- Added `cornerPocketRailClearance` and `cornerPocketLaneSafety` helpers to measure rail clearance for corner-pocket approach lanes and produce a normalized safety score.
- Updated `pocketEntry` so corner pocket entries are clamped away from rail faces, reducing near-jaw / cushion-first entry points for corner pockets.
- Integrated `cornerLaneSafety` into `clearShotCandidates` ranking and filtering so corner approaches with insufficient rail clearance are deprioritized or rejected.
- Incorporated `cornerLaneSafety` into the full `evaluate` quality score with a hard rejection threshold for very unsafe corner lanes.

### Testing
- Performed a JavaScript syntax/check run with `node --check lib/poolAi.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6378ace8083298bcb8692281743aa)