### PR TITLE
Add numerous Poly Haven HDRI environment variants to pool royale options

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -3393,6 +3393,166 @@ const POOL_ROYALE_HDRI_VARIANTS = Object.freeze([
     exposure: 1.1,
     environmentIntensity: 1.06,
     backgroundIntensity: 1.02
+  },
+  {
+    id: 'polyHavenStudio',
+    name: 'Poly Haven Studio',
+    assetId: 'poly_haven_studio',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '2k',
+    exposure: 1.14,
+    environmentIntensity: 1.1,
+    backgroundIntensity: 1.05
+  },
+  {
+    id: 'cinemaLobby',
+    name: 'Cinema Lobby',
+    assetId: 'cinema_lobby',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '2k',
+    exposure: 1.1,
+    environmentIntensity: 1.07,
+    backgroundIntensity: 1.02
+  },
+  {
+    id: 'churchMeetingRoom',
+    name: 'Church Meeting Room',
+    assetId: 'church_meeting_room',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '2k',
+    exposure: 1.08,
+    environmentIntensity: 1.05,
+    backgroundIntensity: 1
+  },
+  {
+    id: 'warmBar',
+    name: 'Warm Bar',
+    assetId: 'warm_bar',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '2k',
+    exposure: 1.09,
+    environmentIntensity: 1.06,
+    backgroundIntensity: 1.01
+  },
+  {
+    id: 'pineAttic',
+    name: 'Pine Attic',
+    assetId: 'pine_attic',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '2k',
+    exposure: 1.08,
+    environmentIntensity: 1.05,
+    backgroundIntensity: 1
+  },
+  {
+    id: 'rostockArches',
+    name: 'Rostock Arches',
+    assetId: 'rostock_arches',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '2k',
+    exposure: 1.07,
+    environmentIntensity: 1.04,
+    backgroundIntensity: 0.99
+  },
+  {
+    id: 'vignaioliNight',
+    name: 'Vignaioli Night',
+    assetId: 'vignaioli_night',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '2k',
+    exposure: 1.1,
+    environmentIntensity: 1.07,
+    backgroundIntensity: 1.02
+  },
+  {
+    id: 'stPetersSquareNight',
+    name: 'St. Peters Square Night',
+    assetId: 'st_peters_square_night',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '2k',
+    exposure: 1.09,
+    environmentIntensity: 1.06,
+    backgroundIntensity: 1.01
+  },
+  {
+    id: 'zwingerNight',
+    name: 'Zwinger Night',
+    assetId: 'zwinger_night',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '2k',
+    exposure: 1.08,
+    environmentIntensity: 1.05,
+    backgroundIntensity: 1
+  },
+  {
+    id: 'winterEvening',
+    name: 'Winter Evening',
+    assetId: 'winter_evening',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '2k',
+    exposure: 1.06,
+    environmentIntensity: 1.03,
+    backgroundIntensity: 0.98
+  },
+  {
+    id: 'rathaus',
+    name: 'Rathaus',
+    assetId: 'rathaus',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '2k',
+    exposure: 1.08,
+    environmentIntensity: 1.05,
+    backgroundIntensity: 1
+  },
+  {
+    id: 'newmanLobby',
+    name: 'Newman Lobby',
+    assetId: 'newman_lobby',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '2k',
+    exposure: 1.1,
+    environmentIntensity: 1.06,
+    backgroundIntensity: 1.01
+  },
+  {
+    id: 'lapa',
+    name: 'Lapa',
+    assetId: 'lapa',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '2k',
+    exposure: 1.09,
+    environmentIntensity: 1.05,
+    backgroundIntensity: 1
+  },
+  {
+    id: 'medievalCafe',
+    name: 'Medieval Cafe',
+    assetId: 'medieval_cafe',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '2k',
+    exposure: 1.08,
+    environmentIntensity: 1.05,
+    backgroundIntensity: 1
+  },
+  {
+    id: 'crossfitGym',
+    name: 'Crossfit Gym',
+    assetId: 'crossfit_gym',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '2k',
+    exposure: 1.09,
+    environmentIntensity: 1.06,
+    backgroundIntensity: 1.01
+  },
+  {
+    id: 'voortrekkerInterior',
+    name: 'Voortrekker Interior',
+    assetId: 'voortrekker_interior',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '2k',
+    exposure: 1.07,
+    environmentIntensity: 1.04,
+    backgroundIntensity: 0.99
   }
 ]);
 


### PR DESCRIPTION
### Motivation
- Expand the available environment HDRI options to provide more background and lighting choices for scenes in the game.

### Description
- Add multiple new HDRI variant objects to `POOL_ROYALE_HDRI_VARIANTS` (for example: `polyHavenStudio`, `cinemaLobby`, `churchMeetingRoom`, `warmBar`, `pineAttic`, `rostockArches`, `vignaioliNight`, `stPetersSquareNight`, `zwingerNight`, `winterEvening`, `rathaus`, `newmanLobby`, `lapa`, `medievalCafe`, `crossfitGym`, `voortrekkerInterior`).
- Each new variant contains `id`, `name`, `assetId`, `preferredResolutions`, `fallbackResolution`, `exposure`, `environmentIntensity`, and `backgroundIntensity` fields to control resolution fallbacks and lighting parameters.
- The existing mapping that builds `ENVIRONMENT_HDRI_OPTIONS` from `POOL_ROYALE_HDRI_VARIANTS` remains in place so the new variants are surfaced with labels and thumbnails automatically.

### Testing
- Ran lint with `npm run lint` and it passed.
- Built the webapp with `npm run build` and the build succeeded.
- Executed unit tests with `npm test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d63ef36da483299a7c255056d05e8c)