### PR TITLE
Improve Pool AI aiming, power calibration, and position planning

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -656,7 +656,7 @@ export function estimateCueAfterShot (cue, target, pocket, power, spin, table) {
   return result
 }
 
-function recommendedPowerForPot (cue, target, entry, cutAngle, req) {
+function recommendedPowerForPot (cue, target, entry, cutAngle, req, options = {}) {
   const r = Math.max(req?.state?.ballRadius || 0, 1)
   const tableDiag = Math.hypot(req.state.width, req.state.height) || 1
   const cueToTarget = dist(cue, target)
@@ -666,7 +666,28 @@ function recommendedPowerForPot (cue, target, entry, cutAngle, req) {
   const base = 0.37 + travelNorm * 0.35 + cutSeverity * 0.16
   const pocketTightness = Math.min(targetToPocket / (r * 30), 1)
   const controlOffset = pocketTightness * 0.06
-  return Math.max(0.36, Math.min(0.92, base + controlOffset)) * POWER_SCALE
+  let recommended = Math.max(0.36, Math.min(0.92, base + controlOffset))
+
+  const desiredCueAfter = options?.desiredCueAfter
+  if (desiredCueAfter && Number.isFinite(desiredCueAfter.x) && Number.isFinite(desiredCueAfter.y)) {
+    const neutralCueAfter = estimateCueAfterShot(
+      cue,
+      target,
+      entry,
+      recommended * POWER_SCALE,
+      options?.spin || { top: 0, side: 0, back: 0 },
+      req.state
+    )
+    const currentError = dist(neutralCueAfter, desiredCueAfter)
+    const normalizer = Math.max(Math.hypot(req.state.width, req.state.height) * 0.36, r * 24)
+    const errorRatio = Math.min(currentError / normalizer, 1)
+    if (errorRatio > 0.2) {
+      recommended += Math.min(0.12, errorRatio * 0.18)
+    } else {
+      recommended -= Math.min(0.08, (0.2 - errorRatio) * 0.22)
+    }
+  }
+  return Math.max(0.34, Math.min(0.95, recommended)) * POWER_SCALE
 }
 
 function projectedScratchRisk (cueAfter, req) {
@@ -847,6 +868,46 @@ function estimateRunoutPotential (req, cueAfter, targetId, balls, depth = 1, rng
   return best
 }
 
+function resolveDesiredCueAfter (req, target, cueAfterBase) {
+  const nextTargets = nextTargetsAfter(target.id, req)
+  if (!nextTargets.length) return null
+  const next = nextTargets
+    .slice()
+    .sort((a, b) => dist(a, cueAfterBase) - dist(b, cueAfterBase))[0]
+  if (!next) return null
+  return { x: next.x, y: next.y, id: next.id }
+}
+
+function positionalErrorForNextShot (req, target, cueAfter) {
+  const nextTargets = nextTargetsAfter(target.id, req)
+  if (!nextTargets.length) return 0
+  const d = nextTargets.reduce((min, b) => Math.min(min, dist(cueAfter, b)), Infinity)
+  const scale = Math.max(Math.hypot(req.state.width, req.state.height) * 0.26, req.state.ballRadius * 18)
+  return Math.min(d / scale, 1)
+}
+
+function calibrateSpinSideForNextBall (req, cue, target, pocket, spin, power) {
+  const entry = pocketEntry(pocket, req.state.ballRadius, req.state.width, req.state.height, target)
+  const nextNeutral = estimateCueAfterShot(cue, target, entry, power, { ...spin, side: 0 }, req.state)
+  const desiredCueAfter = resolveDesiredCueAfter(req, target, nextNeutral)
+  if (!desiredCueAfter) return spin
+
+  const sideAmplitude = Math.abs(spin.side || 0)
+  if (sideAmplitude < 0.04) return spin
+  const sideSigns = [Math.sign(spin.side || 0) || 1, -1]
+  let best = { spin, error: Infinity, scratch: Infinity }
+  for (const sign of sideSigns) {
+    const trialSpin = { ...spin, side: sideAmplitude * sign }
+    const cueAfter = estimateCueAfterShot(cue, target, entry, power, trialSpin, req.state)
+    const error = dist(cueAfter, desiredCueAfter)
+    const scratch = projectedScratchRisk(cueAfter, req)
+    if (error + scratch * req.state.ballRadius * 24 < best.error + best.scratch * req.state.ballRadius * 24) {
+      best = { spin: trialSpin, error, scratch }
+    }
+  }
+  return best.spin
+}
+
 
 function buildSpinCandidates (cue, target, pocket, req) {
   const base = [
@@ -879,8 +940,9 @@ function buildSpinCandidates (cue, target, pocket, req) {
     side: Math.max(-0.35, Math.min(0.35, sideProjection))
   }
   adaptive.top = Math.max(0, adaptive.top - adaptive.back)
+  const calibratedAdaptive = calibrateSpinSideForNextBall(req, cue, target, pocket, adaptive, 0.68 * POWER_SCALE)
 
-  return [adaptive, ...base]
+  return [calibratedAdaptive, adaptive, ...base]
 }
 
 function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict = false, options = {}) {
@@ -961,7 +1023,11 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
   const cueToTarget = dist(cue, target)
   const shotLengthFactor = Math.min(cueToTarget / (r * 40), 2)
   const cutSeverity = Math.min(cutAngle / (Math.PI / 2), 1)
-  const recommendedPower = recommendedPowerForPot(cue, target, entry, cutAngle, req)
+  const desiredCueAfter = resolveDesiredCueAfter(req, target, cueAfter)
+  const recommendedPower = recommendedPowerForPot(cue, target, entry, cutAngle, req, {
+    desiredCueAfter,
+    spin
+  })
   const powerDeviation = Math.abs(power - recommendedPower) / Math.max(0.25 * POWER_SCALE, 1e-6)
   const pocketTightness = 1 - pocketOpen
   const difficultyPenalty = 0.25 * (0.5 * cutSeverity + 0.3 * shotLengthFactor + 0.2 * pocketTightness)
@@ -983,6 +1049,7 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
     ? 0
     : estimateRunoutPotential(req, cueAfter, target.id, balls, lookaheadDepth, rng)
   const scratchProjection = projectedScratchRisk(cueAfter, req)
+  const positionalError = positionalErrorForNextShot(req, target, cueAfter)
   const quality = Math.max(
     0,
     Math.min(
@@ -995,6 +1062,7 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
         0.03 * nearHole +
         0.14 * runoutPotential +
         0.11 * clearanceScore -
+        positionalError * 0.1 -
         0.21 * risk -
         scratchProjection * 0.18 -
         (scratchAfterImpact ? 0.2 : 0) -
@@ -1012,7 +1080,7 @@ function evaluate (req, cue, target, pocket, power, spin, ballsOverride, strict 
     targetPocket: entry,
     aimPoint: ghost,
     quality,
-    rationale: `target=${target.id} pocket=(${pocket.x.toFixed(0)},${pocket.y.toFixed(0)}) angle=${angle.toFixed(2)} power=${power.toFixed(2)} spin=${spin.top.toFixed(2)},${spin.side.toFixed(2)},${spin.back.toFixed(2)} pc=${potChance.toFixed(2)} ca=${centerAlign.toFixed(2)} nh=${nearHole.toFixed(2)} np=${nextScore.toFixed(2)} r=${risk.toFixed(2)}`,
+    rationale: `target=${target.id} pocket=(${pocket.x.toFixed(0)},${pocket.y.toFixed(0)}) angle=${angle.toFixed(2)} power=${power.toFixed(2)} spin=${spin.top.toFixed(2)},${spin.side.toFixed(2)},${spin.back.toFixed(2)} pc=${potChance.toFixed(2)} ca=${centerAlign.toFixed(2)} nh=${nearHole.toFixed(2)} np=${nextScore.toFixed(2)} pe=${positionalError.toFixed(2)} r=${risk.toFixed(2)}`,
     nextScore,
     hasNext
   }


### PR DESCRIPTION
### Motivation
- Improve AI target selection, aiming accuracy, and shot-power choice so the bot leaves better cue-ball position for the next shot. 
- Make side-spin decisions aware of next-shot shape so the AI avoids picking the wrong spin side and reduces errant leaves/scratches. 

### Description
- Updated `lib/poolAi.js` to make power selection aware of the desired next-shot cue-ball position by extending `recommendedPowerForPot` with an `options` argument and using a `desiredCueAfter` signal. 
- Added positional planning helpers `resolveDesiredCueAfter` and `positionalErrorForNextShot` to compute a target leave and a positional-error metric used in evaluation. 
- Implemented `calibrateSpinSideForNextBall` to test both english directions and pick side-spin that better reaches the next target while accounting for scratch risk, and integrated this into `buildSpinCandidates`. 
- Integrated positional error into the shot `quality` computation and included `pe` (positional error) in the `rationale` string to aid tuning and debugging. 

### Testing
- Ran unit tests for the pool AI and aim compensation modules using `npm test -- --runInBand test/poolAi.test.js` and `npm test -- --runInBand test/poolRoyaleAiAimCompensation.test.js`. 
- Both test suites passed (all tests green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d64d8fd58083299f9cce0ac36652e6)