### PR TITLE
Sync Domino Royal public HDRI catalog, bump script version, and add validation test

### DIFF
--- a/test/dominoRoyalHdriCatalog.test.js
+++ b/test/dominoRoyalHdriCatalog.test.js
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+import { POOL_ROYALE_HDRI_VARIANTS } from '../webapp/src/config/poolRoyaleInventoryConfig.js';
+
+const DOMINO_PUBLIC_SCRIPT = 'webapp/public/domino-royal-game.js';
+
+function readDominoHdriIdsFromPublicScript() {
+  const script = readFileSync(DOMINO_PUBLIC_SCRIPT, 'utf8');
+  const match = script.match(/const POOL_ROYALE_HDRI_VARIANTS = Object\.freeze\(\[(.*?)\]\);/s);
+  assert.ok(match, 'Expected Domino public script to declare POOL_ROYALE_HDRI_VARIANTS');
+  const arrayBody = match[1];
+  return new Set(Array.from(arrayBody.matchAll(/id:\s*'([^']+)'/g), (entry) => entry[1]));
+}
+
+test('Domino Royal public HDRI catalog includes every shared Pool Royale HDRI id', () => {
+  const dominoHdriIds = readDominoHdriIdsFromPublicScript();
+  const missingIds = POOL_ROYALE_HDRI_VARIANTS.map((variant) => variant.id).filter(
+    (id) => !dominoHdriIds.has(id)
+  );
+
+  assert.deepEqual(
+    missingIds,
+    [],
+    `Domino public catalog is missing shared HDRI ids: ${missingIds.join(', ')}`
+  );
+});

--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -3393,6 +3393,166 @@ const POOL_ROYALE_HDRI_VARIANTS = Object.freeze([
     exposure: 1.1,
     environmentIntensity: 1.06,
     backgroundIntensity: 1.02
+  },
+  {
+    id: 'polyHavenStudio',
+    name: 'Poly Haven Studio',
+    assetId: 'poly_haven_studio',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '2k',
+    exposure: 1.14,
+    environmentIntensity: 1.1,
+    backgroundIntensity: 1.05
+  },
+  {
+    id: 'cinemaLobby',
+    name: 'Cinema Lobby',
+    assetId: 'cinema_lobby',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '2k',
+    exposure: 1.1,
+    environmentIntensity: 1.07,
+    backgroundIntensity: 1.02
+  },
+  {
+    id: 'churchMeetingRoom',
+    name: 'Church Meeting Room',
+    assetId: 'church_meeting_room',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '2k',
+    exposure: 1.08,
+    environmentIntensity: 1.05,
+    backgroundIntensity: 1
+  },
+  {
+    id: 'warmBar',
+    name: 'Warm Bar',
+    assetId: 'warm_bar',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '2k',
+    exposure: 1.09,
+    environmentIntensity: 1.06,
+    backgroundIntensity: 1.01
+  },
+  {
+    id: 'pineAttic',
+    name: 'Pine Attic',
+    assetId: 'pine_attic',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '2k',
+    exposure: 1.08,
+    environmentIntensity: 1.05,
+    backgroundIntensity: 1
+  },
+  {
+    id: 'rostockArches',
+    name: 'Rostock Arches',
+    assetId: 'rostock_arches',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '2k',
+    exposure: 1.07,
+    environmentIntensity: 1.04,
+    backgroundIntensity: 0.99
+  },
+  {
+    id: 'vignaioliNight',
+    name: 'Vignaioli Night',
+    assetId: 'vignaioli_night',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '2k',
+    exposure: 1.1,
+    environmentIntensity: 1.07,
+    backgroundIntensity: 1.02
+  },
+  {
+    id: 'stPetersSquareNight',
+    name: 'St. Peters Square Night',
+    assetId: 'st_peters_square_night',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '2k',
+    exposure: 1.09,
+    environmentIntensity: 1.06,
+    backgroundIntensity: 1.01
+  },
+  {
+    id: 'zwingerNight',
+    name: 'Zwinger Night',
+    assetId: 'zwinger_night',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '2k',
+    exposure: 1.08,
+    environmentIntensity: 1.05,
+    backgroundIntensity: 1
+  },
+  {
+    id: 'winterEvening',
+    name: 'Winter Evening',
+    assetId: 'winter_evening',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '2k',
+    exposure: 1.06,
+    environmentIntensity: 1.03,
+    backgroundIntensity: 0.98
+  },
+  {
+    id: 'rathaus',
+    name: 'Rathaus',
+    assetId: 'rathaus',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '2k',
+    exposure: 1.08,
+    environmentIntensity: 1.05,
+    backgroundIntensity: 1
+  },
+  {
+    id: 'newmanLobby',
+    name: 'Newman Lobby',
+    assetId: 'newman_lobby',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '2k',
+    exposure: 1.1,
+    environmentIntensity: 1.06,
+    backgroundIntensity: 1.01
+  },
+  {
+    id: 'lapa',
+    name: 'Lapa',
+    assetId: 'lapa',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '2k',
+    exposure: 1.09,
+    environmentIntensity: 1.05,
+    backgroundIntensity: 1
+  },
+  {
+    id: 'medievalCafe',
+    name: 'Medieval Cafe',
+    assetId: 'medieval_cafe',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '2k',
+    exposure: 1.08,
+    environmentIntensity: 1.05,
+    backgroundIntensity: 1
+  },
+  {
+    id: 'crossfitGym',
+    name: 'Crossfit Gym',
+    assetId: 'crossfit_gym',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '2k',
+    exposure: 1.09,
+    environmentIntensity: 1.06,
+    backgroundIntensity: 1.01
+  },
+  {
+    id: 'voortrekkerInterior',
+    name: 'Voortrekker Interior',
+    assetId: 'voortrekker_interior',
+    preferredResolutions: ['8k', '4k', '2k'],
+    fallbackResolution: '2k',
+    exposure: 1.07,
+    environmentIntensity: 1.04,
+    backgroundIntensity: 0.99
   }
 ]);
 

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-04-08-domino-hdri-original-size-v15';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-04-08-domino-hdri-catalog-sync-v16';
 
 export default function DominoRoyalArena() {
   useEffect(() => {


### PR DESCRIPTION
### Motivation

- Ensure the Domino Royal public game script exposes the full set of shared Pool Royale HDRI variants so client UI options match the canonical inventory.
- Prevent drift between the server-side `POOL_ROYALE_HDRI_VARIANTS` config and the inlined public script that the game loads.
- Bump the inline game script version to reflect the catalog update.

### Description

- Added a set of HDRI variant entries to the `POOL_ROYALE_HDRI_VARIANTS` array in `webapp/public/domino-royal-game.js` so the public script includes the shared HDRIs.
- Updated the Domino Royal script version constant in `webapp/src/pages/Games/DominoRoyalArena.jsx` to `2026-04-08-domino-hdri-catalog-sync-v16`.
- Added a unit test `test/dominoRoyalHdriCatalog.test.js` that reads the public script and asserts every `id` from `webapp/src/config/poolRoyaleInventoryConfig.js` is present in the public catalog.

### Testing

- Ran the new unit test file `test/dominoRoyalHdriCatalog.test.js` using the Node test runner with `node --test` and it passed.
- Ran the repository test suite (via `npm test`) and the test suite passed including the new validation test.
- No other automated test failures were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d63ef36da483299a7c255056d05e8c)