### PR TITLE
Add Monte Carlo rollout scoring to Pool Royale AI planner

### DIFF
--- a/lib/poolUkAdvancedAi.js
+++ b/lib/poolUkAdvancedAi.js
@@ -61,6 +61,7 @@ const STRAIGHT_SHOT_THRESHOLD = Math.PI / 15 // ~12 degrees
 const POCKET_MOUTH_WIDTH_FACTOR = 2.45
 const POCKET_ENTRY_DEPTH_FACTOR = 1.85
 const JAW_GUARD_FACTOR = 1.18
+const MONTE_CARLO_SAMPLES = 28
 
 function normaliseColourKey (input) {
   const value = typeof input === 'string' ? input : input?.colour
@@ -831,6 +832,78 @@ function riskPenalty (risk) {
   return risk // linear for simplicity
 }
 
+function hashSeedFromShot (shot, state) {
+  const id = shot?.targetBall?.id ?? 0
+  const angle = Math.round((shot?.angle ?? 0) * 1000)
+  const dist = Math.round((shot?.distTP ?? 0) + (shot?.distCT ?? 0))
+  const speed = shot?.cueParams?.speed === 'soft' ? 17 : shot?.cueParams?.speed === 'firm' ? 91 : 53
+  return ((id * 73856093) ^ (angle * 19349663) ^ (dist * 83492791) ^ (speed * 2654435761) ^ state.width ^ state.height) >>> 0
+}
+
+function seededRandom (seed) {
+  let x = (seed || 1) >>> 0
+  return function rand () {
+    x ^= x << 13
+    x ^= x >>> 17
+    x ^= x << 5
+    return ((x >>> 0) / 4294967296)
+  }
+}
+
+function monteCarloShotValue (state, shot, colour, samples = MONTE_CARLO_SAMPLES) {
+  if (!shot || shot.actionType !== 'pot' || !shot.targetBall || !shot.pocket) {
+    return { potProbability: 0, shapeScore: 0 }
+  }
+  const baseProbability = estimatePotProbability(shot, state)
+  if (baseProbability <= 0) return { potProbability: 0, shapeScore: 0 }
+  const rng = seededRandom(hashSeedFromShot(shot, state))
+  const diag = Math.hypot(state.width, state.height) || 1
+  let pots = 0
+  let cumulativeShape = 0
+  for (let i = 0; i < samples; i++) {
+    const jitterAngle = (rng() - 0.5) * (Math.PI / 70)
+    const jitterPos = (rng() - 0.5) * state.ballRadius * 0.75
+    const jitterPower = (rng() - 0.5) * 0.12
+    const localShot = {
+      ...shot,
+      angle: Math.max(0, (shot.angle ?? 0) + jitterAngle),
+      cueParams: { ...(shot.cueParams || {}), powerNoise: jitterPower }
+    }
+    const candidateP = Math.max(
+      0,
+      Math.min(
+        1,
+        estimatePotProbability(localShot, state) - Math.abs(jitterPos) / (state.ballRadius * 4)
+      )
+    )
+    if (rng() < candidateP) {
+      pots += 1
+      const rollout = simulateCueRollout(state, localShot)
+      const shapeCue = { x: rollout.x + jitterPos, y: rollout.y + jitterPos * 0.6 }
+      const center = { x: state.width / 2, y: state.height / 2 }
+      const centerScore = 1 - Math.min(dist(shapeCue, center) / diag, 1)
+      const nextEase = nextShapeWindow(
+        {
+          ...state,
+          balls: state.balls.map(ball => {
+            if (ball.id === shot.targetBall.id) return { ...ball, pocketed: true }
+            if (ball.colour === 'cue') return { ...ball, x: shapeCue.x, y: shapeCue.y }
+            return { ...ball }
+          })
+        },
+        colour
+      )
+      cumulativeShape += centerScore * 0.45 + nextEase * 0.55
+    }
+  }
+  const potProbability = pots / Math.max(1, samples)
+  const shapeScore = pots > 0 ? cumulativeShape / pots : 0
+  return {
+    potProbability: baseProbability * 0.45 + potProbability * 0.55,
+    shapeScore
+  }
+}
+
 function safetyEV (state, colour) {
   // heuristic: leaving opponent far gives low EV for them
   const oppColour = colour === 'blue' ? 'red' : 'blue'
@@ -852,7 +925,9 @@ function evaluateCandidates (state, colour, candidates) {
     } else {
       const risk = foulRisk(c, state)
       if (risk > 0.65) continue
-      const Ppot = estimatePotProbability(c, state)
+      const analyticPpot = estimatePotProbability(c, state)
+      const mc = monteCarloShotValue(state, c, colour)
+      const Ppot = analyticPpot * 0.5 + mc.potProbability * 0.5
       if (Ppot < MIN_POT_PROBABILITY) continue
       const nextState = { ...state, balls: state.balls.map(b => ({ ...b })) }
       const target = nextState.balls.find(b => b.id === c.targetBall.id)
@@ -870,7 +945,7 @@ function evaluateCandidates (state, colour, candidates) {
       const straightBoost = typeof c.angle === 'number' ? Math.max(0, (Math.PI / 10 - c.angle) / (Math.PI / 10)) * 0.25 : 0
       const positionWeight = 1.4
       const shapeWindow = nextShapeWindow(nextState, colour)
-      EV = Ppot * (baseValue + nextBest * positionWeight + straightBoost + shapeWindow * 0.75) - riskPenalty(risk)
+      EV = Ppot * (baseValue + nextBest * positionWeight + straightBoost + shapeWindow * 0.75 + mc.shapeScore * 0.65) - riskPenalty(risk)
     }
     if (!best || EV > best.EV) {
       best = { c, EV }


### PR DESCRIPTION
### Motivation
- Improve shot evaluation realism by augmenting analytic heuristics with stochastic rollouts that model aim/power jitter and post-shot cue-ball shape.
- Make Monte Carlo estimates deterministic per-shot so AI decisions remain stable across runs while still exploring execution variance.
- Encourage the AI to prefer shots that both pot and leave good position for the next turn.

### Description
- Added `MONTE_CARLO_SAMPLES` configuration and deterministic RNG helpers `hashSeedFromShot` and `seededRandom` in `lib/poolUkAdvancedAi.js`.
- Implemented `monteCarloShotValue(state, shot, colour)` which performs seeded sampling of aim/power jitter to estimate pot probability and a shape score derived from simulated cue-ball rollouts.
- Blended analytic pot probability with Monte Carlo probability when computing `Ppot`, and incorporated the Monte Carlo `shapeScore` into candidate EV calculation in `evaluateCandidates` so position quality influences decisions.
- Minor cleanup to remove an unused variable in the Monte Carlo function and keep the code paths cohesive; change affects only `lib/poolUkAdvancedAi.js`.

### Testing
- Ran static syntax check with `node --check lib/poolUkAdvancedAi.js` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d65cdc8b2083299f6c7ccf31bc90a2)