### PR TITLE
Fix Domino chairs to face with yaw-only (keep all legs grounded)

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -7664,7 +7664,6 @@ function placeChairsWithOption(option, chairData, token) {
     disposeChairResources(chair);
   }
 
-  const lookTarget = new THREE.Vector3(0, TABLE_HEIGHT, 0);
   const seatBottomOffset = -chairTemplateBounds.min.y;
   const labelHeight = seatBottomOffset + chairTemplateBounds.max.y + 0.12;
   const labelDepth = -chairTemplateBounds.getSize(new THREE.Vector3()).z * 0.35;
@@ -7676,7 +7675,9 @@ function placeChairsWithOption(option, chairData, token) {
     const basis = seatBasisForAngle(angle, radius);
     const wrapper = new THREE.Group();
     wrapper.position.set(basis.position.x, 0, basis.position.z);
-    wrapper.lookAt(lookTarget);
+    const flatLookTarget = wrapper.position.clone().add(basis.forward);
+    flatLookTarget.y = wrapper.position.y;
+    wrapper.lookAt(flatLookTarget);
 
     const chair = cloneChairWithTheme(chairData, option);
     chair.position.y = -seatBottomOffset;

--- a/webapp/src/utils/dominoArena.js
+++ b/webapp/src/utils/dominoArena.js
@@ -799,7 +799,6 @@ export function buildDominoArena({ scene, renderer }) {
     TABLE_DIMENSIONS.outerHalfWidth + CHAIR_DIMENSIONS.seatDepth / 2 + CHAIR_GAP;
   const chairHeight =
     CHAIR_DIMENSIONS.baseThickness + CHAIR_DIMENSIONS.columnHeight + CHAIR_DIMENSIONS.seatThickness;
-  const lookTarget = new THREE.Vector3(0, chairHeight, 0);
   const dominoFacing = new THREE.Vector3(1, 0, 0);
   const chairs = [
     { position: new THREE.Vector3(0, 0, chairRadius) },
@@ -809,8 +808,10 @@ export function buildDominoArena({ scene, renderer }) {
   ].map(({ position, forward }) => {
     const chair = createDominoChair(DEFAULT_CHAIR_OPTION, renderer, sharedChairMaterials);
     chair.position.copy(position);
-    const forwardDir = forward?.clone().normalize() ?? lookTarget.clone().sub(chair.position).normalize();
-    chair.lookAt(chair.position.clone().add(forwardDir));
+    const forwardDir = forward?.clone().normalize() ?? new THREE.Vector3(0, 0, -1);
+    const flatLookTarget = chair.position.clone().add(forwardDir);
+    flatLookTarget.y = chair.position.y;
+    chair.lookAt(flatLookTarget);
     chair.rotateY(Math.PI);
     table.group.add(chair);
     chair.traverse((child) => {


### PR DESCRIPTION
### Motivation
- Chairs in the Domino Battle Royal scene were pitched toward an elevated look target, causing two chair legs to appear lifted off the floor; the intent is to keep chairs visually grounded with only yaw rotation. 

### Description
- Updated chair orientation in `webapp/public/domino-royal-game.js` so seat wrappers use a flattened look target (zeroed Y) when calling `lookAt`, preventing pitch. 
- Applied the same grounding-safe facing logic in the shared arena utility `webapp/src/utils/dominoArena.js` for chairs created there, using a flat forward fallback and zeroing the Y before `lookAt`. 
- Replaced elevated `lookTarget` usage with `flatLookTarget` computed from the chair/wrapper position plus forward direction and forced to the wrapper/chair Y to ensure yaw-only rotation. 

### Testing
- Ran the targeted unit test: `npm test -- --runInBand test/dominoRoyalHdriCatalog.test.js`, and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d66c364f4483299e607cb3a5bc32cf)