### PR TITLE
Fix Domino chair tilt to keep all legs grounded

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -7664,7 +7664,6 @@ function placeChairsWithOption(option, chairData, token) {
     disposeChairResources(chair);
   }
 
-  const lookTarget = new THREE.Vector3(0, TABLE_HEIGHT, 0);
   const seatBottomOffset = -chairTemplateBounds.min.y;
   const labelHeight = seatBottomOffset + chairTemplateBounds.max.y + 0.12;
   const labelDepth = -chairTemplateBounds.getSize(new THREE.Vector3()).z * 0.35;
@@ -7676,7 +7675,7 @@ function placeChairsWithOption(option, chairData, token) {
     const basis = seatBasisForAngle(angle, radius);
     const wrapper = new THREE.Group();
     wrapper.position.set(basis.position.x, 0, basis.position.z);
-    wrapper.lookAt(lookTarget);
+    wrapper.lookAt(new THREE.Vector3(0, wrapper.position.y, 0));
 
     const chair = cloneChairWithTheme(chairData, option);
     chair.position.y = -seatBottomOffset;


### PR DESCRIPTION
### Motivation
- Chairs were tilting upward because the wrapper `lookAt` targeted the table height, which caused chair models to pitch and lift two legs off the ground; the intent is to keep chairs facing the table center horizontally while keeping all four legs grounded.

### Description
- Changed the chair wrapper orientation in `webapp/public/domino-royal-game.js` to use `wrapper.lookAt(new THREE.Vector3(0, wrapper.position.y, 0))` instead of looking at `TABLE_HEIGHT`, so the wrapper only rotates on the horizontal plane and chairs no longer pitch vertically.

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d66c364f4483299e607cb3a5bc32cf)