### PR TITLE
Align Pool Royale AI aim correction with Snooker ghost-ball logic

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -27880,6 +27880,20 @@ const powerRef = useRef(hud.power);
             return plan;
           }
           let corrected = null;
+          if (plan.pocketCenter && plan.targetBall?.pos) {
+            const toPocket = plan.pocketCenter.clone().sub(plan.targetBall.pos);
+            if (toPocket.lengthSq() > 1e-6) {
+              const toPocketDir = toPocket.normalize();
+              const ghost = plan.targetBall.pos
+                .clone()
+                .sub(toPocketDir.multiplyScalar(BALL_R * 2));
+              const cueVec = ghost.sub(cueBall.pos);
+              if (cueVec.lengthSq() > 1e-6) {
+                corrected = cueVec.normalize();
+                plan.cueToTarget = cueBall.pos.distanceTo(ghost);
+              }
+            }
+          }
           if (!corrected && plan.targetBall?.pos) {
             const direct = plan.targetBall.pos.clone().sub(cueBall.pos);
             if (direct.lengthSq() > 1e-6) {


### PR DESCRIPTION
### Motivation
- Make Pool Royale AI use the same ghost-ball pocket-based aim correction already used by Snooker Royal so pot aiming target logic is consistent across games while preserving each game's rules and shot-selection logic.

### Description
- Updated `normalizeAiPlanAim` in `webapp/src/pages/Games/PoolRoyale.jsx` to first try a ghost-ball aim derived from `plan.pocketCenter` and the `targetBall` before falling back to direct target-ball aiming for pot plans.
- The ghost-ball is computed by taking the target→pocket direction, offsetting the target by `BALL_R * 2` along that direction, and using cue→ghost as the new `aimDir` and `cueToTarget` distance.
- The change only applies to non-cushion pot plans with an active `targetBall` and preserves existing path/contact checks and fallback behaviors.
- No other AI shot-selection or game-rule logic was modified.

### Testing
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx` which reported the file is ignored by lint patterns but produced no lint errors.
- Ran `npm run lint -- webapp/src/pages/Games/PoolRoyale.jsx` with the same ignore-warning and no lint errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d66f4e21308329a115e333e8bb6543)