### PR TITLE
Fix chair grounding and facing by adjusting target bounds and lookAt logic

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -2272,12 +2272,12 @@ async function loadPolyhavenModel(
   throw lastError || new Error(`Failed to load Poly Haven model for ${assetId}`);
 }
 const TARGET_CHAIR_SIZE = new THREE.Vector3(
-  1.3952249968409541,
-  2.0324174894329905,
-  1.802165630054474
+  1.3162499970197679,
+  1.9173749900311232,
+  1.7001562547683715
 );
-const TARGET_CHAIR_MIN_Y = -0.9084862492892147;
-const TARGET_CHAIR_CENTER_Z = -0.16471408019065854;
+const TARGET_CHAIR_MIN_Y = -0.8570624993294478;
+const TARGET_CHAIR_CENTER_Z = -0.1553906416893005;
 
 const clamp01f = (value) => Math.min(1, Math.max(0, value));
 const normalizeHue = (h) => {
@@ -7664,7 +7664,6 @@ function placeChairsWithOption(option, chairData, token) {
     disposeChairResources(chair);
   }
 
-  const lookTarget = new THREE.Vector3(0, TABLE_HEIGHT, 0);
   const seatBottomOffset = -chairTemplateBounds.min.y;
   const labelHeight = seatBottomOffset + chairTemplateBounds.max.y + 0.12;
   const labelDepth = -chairTemplateBounds.getSize(new THREE.Vector3()).z * 0.35;
@@ -7676,7 +7675,7 @@ function placeChairsWithOption(option, chairData, token) {
     const basis = seatBasisForAngle(angle, radius);
     const wrapper = new THREE.Group();
     wrapper.position.set(basis.position.x, 0, basis.position.z);
-    wrapper.lookAt(lookTarget);
+    wrapper.lookAt(new THREE.Vector3(0, wrapper.position.y, 0));
 
     const chair = cloneChairWithTheme(chairData, option);
     chair.position.y = -seatBottomOffset;

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-04-08-domino-hdri-catalog-sync-v16';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-04-08-domino-chair-grounding-fix-v17';
 
 export default function DominoRoyalArena() {
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- Correct chair sizing and vertical grounding so procedural chairs sit at the intended floor level and look straight toward the table center at their own height.
- Bump the inline game script version to reflect the fix and trigger appropriate cache invalidation/deploys.

### Description
- Updated `TARGET_CHAIR_SIZE`, `TARGET_CHAIR_MIN_Y`, and `TARGET_CHAIR_CENTER_Z` to new calibrated values to change the target chair bounds and grounding behavior.
- Replaced the previous global `lookTarget` usage with a per-wrapper look target by calling `wrapper.lookAt(new THREE.Vector3(0, wrapper.position.y, 0))` to prevent chairs from tilting toward a fixed table height.
- Removed the now-unused `lookTarget` dependency in `placeChairsWithOption` and adjusted surrounding code accordingly.
- Bumped `DOMINO_ROYAL_SCRIPT_VERSION` to `2026-04-08-domino-chair-grounding-fix-v17` in `DominoRoyalArena.jsx`.

### Testing
- Ran the frontend build with `yarn build` and the build completed successfully.
- Executed the test suite with `yarn test` and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d66c364f4483299e607cb3a5bc32cf)