### PR TITLE
Domino Royal: slightly enlarge chairs and move them outward

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -966,7 +966,9 @@ const BASE_RADIUS = 0.72 * MODEL_SCALE;
 const FOOT_RING_RADIUS = 0.52 * MODEL_SCALE;
 const FOOT_RING_TUBE = 0.04 * MODEL_SCALE;
 const CHAIR_GAP = 0.04 * MODEL_SCALE;
-const CHAIR_RADIUS = TABLE_RADIUS + SEAT_DEPTH * 0.38 + CHAIR_GAP;
+const CHAIR_OUTWARD_OFFSET = 0.05 * MODEL_SCALE;
+const CHAIR_RADIUS = TABLE_RADIUS + SEAT_DEPTH * 0.38 + CHAIR_GAP + CHAIR_OUTWARD_OFFSET;
+const CHAIR_VISUAL_SCALE = 1.06;
 const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 0.85;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
 const TABLE_HEIGHT_LIFT = 0.05 * MODEL_SCALE * TABLE_HEIGHT_SCALE;
@@ -7678,6 +7680,7 @@ function placeChairsWithOption(option, chairData, token) {
     wrapper.lookAt(new THREE.Vector3(0, wrapper.position.y, 0));
 
     const chair = cloneChairWithTheme(chairData, option);
+    chair.scale.multiplyScalar(CHAIR_VISUAL_SCALE);
     chair.position.y = -seatBottomOffset;
     wrapper.add(chair);
 


### PR DESCRIPTION
### Motivation
- Small visual tuning to make Domino Battle Royal seating read better by making chairs a bit larger and sitting slightly farther away from the table for improved readability and spacing.

### Description
- Updated `webapp/public/domino-royal-game.js` to add `CHAIR_OUTWARD_OFFSET` and include it in `CHAIR_RADIUS`, and added `CHAIR_VISUAL_SCALE` which is applied to each cloned chair when instantiated so chairs appear slightly bigger.

### Testing
- Ran a syntax check with `node --check webapp/public/domino-royal-game.js` which completed successfully. 
- Ran the targeted unit test `npm test -- test/dominoRoyalHdriCatalog.test.js --runInBand` which passed (1 test, 1 suite).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6746d078c83299afaa79f3342cbd4)