### PR TITLE
Scale Chess Battle Royal lounge set down by 15%

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -15449,13 +15449,14 @@ const powerRef = useRef(hud.power);
       const CHESS_BATTLE_TABLE_SPAN_UNITS = 5.1;
       const CHESS_BATTLE_BOARD_SPAN_UNITS = 1.9008;
       const CHESS_BATTLE_CHAIR_MAX_DIM = 1.917;
+      const CHESS_BATTLE_LAYOUT_SCALE = 0.85; // keep layout proportions, make the full chess lounge set 15% smaller
       const chessBattleScale = TABLE_H / CHESS_BATTLE_TABLE_HEIGHT_UNITS;
       const chessBattleTargetSpan =
-        CHESS_BATTLE_TABLE_SPAN_UNITS * chessBattleScale;
+        CHESS_BATTLE_TABLE_SPAN_UNITS * chessBattleScale * CHESS_BATTLE_LAYOUT_SCALE;
       const chessBattleTargetBoard =
-        CHESS_BATTLE_BOARD_SPAN_UNITS * chessBattleScale;
+        CHESS_BATTLE_BOARD_SPAN_UNITS * chessBattleScale * CHESS_BATTLE_LAYOUT_SCALE;
       const chessBattleTargetChair =
-        CHESS_BATTLE_CHAIR_MAX_DIM * chessBattleScale;
+        CHESS_BATTLE_CHAIR_MAX_DIM * chessBattleScale * CHESS_BATTLE_LAYOUT_SCALE;
       const fitGroupToChessBattle = (group) => {
         if (!group) return;
         const box = new THREE.Box3().setFromObject(group);


### PR DESCRIPTION
### Motivation
- Reduce the visual size of the Chess Battle Royal lounge (table + chairs + board with pieces) by 15% while preserving the original layout proportions and placement logic.

### Description
- Introduced `CHESS_BATTLE_LAYOUT_SCALE = 0.85` and applied it to the chess lounge sizing calculations for `chessBattleTargetSpan`, `chessBattleTargetBoard`, and `chessBattleTargetChair` in `webapp/src/pages/Games/SnookerRoyal.jsx` so the set is uniformly scaled down.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully (Vite produced non-blocking chunk-size warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d692c9298c8329a0c73350c1b82d2f)