### PR TITLE
Pool Royale: stabilize AI shot timing and improve fallback planning

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -6176,6 +6176,7 @@ const SHORT_RAIL_POCKET_TRIGGER =
 const SHORT_RAIL_POCKET_INTENT_COOLDOWN_MS = 280;
 const AI_MIN_SHOT_TIME_MS = 5000;
 const AI_MAX_SHOT_TIME_MS = 7000;
+const AI_TARGET_SHOT_TIME_MS = 5600; // keep AI pacing steady between turns instead of swinging from min/max timing
 const AI_MIN_AIM_PREVIEW_MS = 900;
 const AI_EARLY_SHOT_DIFFICULTY = 120;
 const AI_EARLY_SHOT_CUE_DISTANCE = PLAY_H * 0.55;
@@ -27566,14 +27567,22 @@ const powerRef = useRef(hud.power);
           const playableCushionPots = scoredPots.filter(
             (entry) => entry.plan && isPlayablePlan(entry.plan, { allowCushion: true })
           );
-          const bestPot = playableCushionPots[0]?.plan ?? null;
+          const relaxedPot =
+            scoredPots.find((entry) => entry?.plan && isFirstContactLegal(entry.plan))?.plan ??
+            scoredPots[0]?.plan ??
+            null;
+          const bestPot = playableCushionPots[0]?.plan ?? relaxedPot;
           const bestSafetyCandidate =
             safetyShots.find((plan) => isPlayablePlan(plan, { allowCushion: true })) ?? null;
           const bestSafety =
             activeVariantId === 'uk' && bestPot ? null : bestSafetyCandidate;
+          const relaxedSafety =
+            !bestPot && !bestSafety
+              ? safetyShots.find((plan) => plan && isFirstContactLegal(plan)) ?? safetyShots[0] ?? null
+              : null;
           return {
             bestPot,
-            bestSafety
+            bestSafety: bestSafety ?? relaxedSafety
           };
         };
 
@@ -27955,7 +27964,8 @@ const powerRef = useRef(hud.power);
             return;
           }
           const started = performance.now();
-          const windowDuration = THREE.MathUtils.randInt(
+          const windowDuration = THREE.MathUtils.clamp(
+            AI_TARGET_SHOT_TIME_MS,
             AI_MIN_SHOT_TIME_MS,
             AI_MAX_SHOT_TIME_MS
           );


### PR DESCRIPTION
### Motivation

- Players reported AI inconsistency: strong first/second shots followed by abrupt low-quality fallback behavior and irregular shot rhythm; the change aims to make AI pacing and fallback choices more consistent.

### Description

- Introduced `AI_TARGET_SHOT_TIME_MS = 5600` and use it to produce a stable AI shot window duration instead of fully randomizing between `AI_MIN_SHOT_TIME_MS` and `AI_MAX_SHOT_TIME_MS`, keeping AI pre-shot rhythm steady (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Adjusted pot selection logic to prefer a legal-contact relaxed pot (`relaxedPot`) when no strictly playable cushion pot exists, before falling back to weaker aim behavior (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Added a relaxed safety fallback (`relaxedSafety`) used when both strict pot and strict safety are unavailable so the AI preserves a coherent legal plan instead of degrading abruptly (`webapp/src/pages/Games/PoolRoyale.jsx`).

### Testing

- Ran `npm --prefix webapp run build` to validate the front-end bundle and compilation; the build completed successfully.
- Build produced unrelated Vite chunk-size/dynamic-import warnings but no errors; the modified module compiled and was included in the production build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d693a5db008329946171c93e6446ac)