### PR TITLE
Scale Chess/Checkers arena visuals down by 15%

### DIFF
--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -56,7 +56,10 @@ import { getCustomHdriVariantsForGame } from '../../utils/customHdriCatalog.js';
 import { socket } from '../../utils/socket.js';
 
 const SIZE = 8;
-const CHECKERS_ARENA_SCALE = 0.48;
+const CHECKERS_ARENA_BASE_SCALE = 0.48;
+// Requested visual tuning: make the arena setup 15% smaller while preserving
+// the exact same layout relationships between table, board, pieces, and chairs.
+const CHECKERS_ARENA_SCALE = CHECKERS_ARENA_BASE_SCALE * 0.85;
 const MODEL_SCALE = 0.75 * CHECKERS_ARENA_SCALE;
 const STOOL_SCALE = 0.92 * CHECKERS_ARENA_SCALE;
 const TABLE_RADIUS = 3.0 * MODEL_SCALE;


### PR DESCRIPTION
### Motivation
- Reduce the rendered size of the Chess/Checkers Battle Royal arena (table, board, pieces, chairs) by 15% while keeping the exact same layout and relative placement of all elements.

### Description
- Introduced `CHECKERS_ARENA_BASE_SCALE` and set `CHECKERS_ARENA_SCALE = CHECKERS_ARENA_BASE_SCALE * 0.85` in `webapp/src/pages/Games/CheckersBattleRoyal.jsx` so the arena, board, pieces, and chairs are uniformly scaled down while preserving layout math.

### Testing
- Ran `npm run build` in `webapp/` and the production build completed successfully (Vite reported existing chunk-size warnings but no build errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6958177d08329b491fc9de3a0faf8)