### PR TITLE
Improve Pool Royale AI fallback shot consistency

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -1112,51 +1112,60 @@ function fallbackAimAtTarget (req) {
   const cueBallId = resolveCueBallId(req.state)
   const cue = req.state.balls.find(b => b.id === cueBallId)
   const targets = chooseTargets(req)
+  const r = req.state.ballRadius
   if (!cue || targets.length === 0) return null
 
   let best = null
   for (const target of targets) {
-    let bestPocket = null
-    let bestAlign = -Infinity
     for (const pocket of req.state.pockets) {
+      const entry = pocketEntry(pocket, r, req.state.width, req.state.height, target)
+      const ghost = ghostPointForTargetPocket(target, pocket, req)
+      if (!ghost) continue
+
+      const blocked = pathBlocked(cue, ghost, req.state.balls, [cueBallId, target.id], r, 1.1) ||
+        pathBlocked(target, entry, req.state.balls, [cueBallId, target.id], r) ||
+        req.state.balls.some(
+          b => b.id !== cueBallId && b.id !== target.id && !b.pocketed && dist(b, entry) < r * 1.1
+        )
+      if (blocked) continue
+
+      const shotVec = { x: target.x - cue.x, y: target.y - cue.y }
+      const potVec = { x: entry.x - target.x, y: entry.y - target.y }
+      let cut = Math.abs(Math.atan2(potVec.y, potVec.x) - Math.atan2(shotVec.y, shotVec.x))
+      if (cut > Math.PI) cut = Math.abs(cut - Math.PI * 2)
+      const cutScore = 1 - Math.min(cut / (Math.PI / 2), 1)
       const align = pocketAlignment(pocket, target, req.state.width, req.state.height)
-      if (align > bestAlign) {
-        bestAlign = align
-        bestPocket = pocket
+      const openness = pocketEntranceOpenness(target, pocket, req)
+      const laneClearance = Math.max(0, clearanceMargin(cue, target, req.state.balls, [cueBallId, target.id], r, 1.2))
+      const clearanceScore = Math.max(0, Math.min((laneClearance - 0.35) / 0.9, 1))
+      const cueDistance = dist(cue, target)
+      const distanceScore = Math.max(0, 1 - cueDistance / Math.max(r * 52, 1))
+      const score =
+        cutScore * 0.42 +
+        align * 0.23 +
+        openness * 0.2 +
+        clearanceScore * 0.1 +
+        distanceScore * 0.05
+
+      const angle = Math.atan2(ghost.y - cue.y, ghost.x - cue.x)
+      const candidate = {
+        angleRad: angle,
+        power: 0.62 * POWER_SCALE,
+        spin: { top: 0, side: 0, back: 0 },
+        targetBallId: target.id,
+        targetPocket: pocket,
+        aimPoint: ghost,
+        quality: Math.max(0, Math.min(score * 0.55, 0.38)),
+        rationale: 'fallback-aim-consistent'
       }
-    }
-    if (!bestPocket) continue
-    const entry = pocketEntry(bestPocket, req.state.ballRadius, req.state.width, req.state.height, target)
-    const ghost = {
-      x: target.x - (entry.x - target.x) * (req.state.ballRadius * 2 / dist(target, entry)),
-      y: target.y - (entry.y - target.y) * (req.state.ballRadius * 2 / dist(target, entry))
-    }
-    if (
-      ghost.x < req.state.ballRadius ||
-      ghost.x > req.state.width - req.state.ballRadius ||
-      ghost.y < req.state.ballRadius ||
-      ghost.y > req.state.height - req.state.ballRadius
-    ) {
-      continue
-    }
-    const angle = Math.atan2(ghost.y - cue.y, ghost.x - cue.x)
-    const candidate = {
-      angleRad: angle,
-      power: 0.65 * POWER_SCALE,
-      spin: { top: 0, side: 0, back: 0 },
-      targetBallId: target.id,
-      targetPocket: bestPocket,
-      aimPoint: ghost,
-      quality: 0,
-      rationale: 'fallback-aim'
-    }
-    if (!best || bestAlign > best.align) {
-      best = { ...candidate, align: bestAlign }
+      if (!best || score > best.score) {
+        best = { ...candidate, score }
+      }
     }
   }
 
   if (!best) return null
-  const { align: _align, ...rest } = best
+  const { score: _score, ...rest } = best
   return rest
 }
 
@@ -1337,7 +1346,11 @@ export function planShot (req) {
     if (best.quality >= MIN_COMPETITIVE_QUALITY) return best
     if (hasViableShot) return best
   }
-  if (!hasViableShot) return safetyShot(req)
+  if (!hasViableShot) {
+    fallback = fallbackAimAtTarget(req)
+    if (fallback) return fallback
+    return safetyShot(req)
+  }
   fallback = fallbackAimAtTarget(req)
   if (fallback) return fallback
   return safetyShot(req)


### PR DESCRIPTION
### Motivation
- The AI would pick a simplistic fallback (often drifting to a low-quality pocket choice) after the opening shot, causing inconsistent aiming and rhythm; a more stable fallback is needed so post-opening shots behave more like the first shot.

### Description
- Rewrote `fallbackAimAtTarget` in `lib/poolAi.js` to evaluate each target/pocket pair and score candidates using cut angle, pocket alignment, pocket openness, lane clearance, and cue-to-target distance.
- Added physical plausibility checks (`ghostPointForTargetPocket`, `pathBlocked`, entry congestion) so fallback candidates are only returned when the cue->ghost and target->entry paths are clear.
- Tuned fallback output to a neutral, consistent profile (`power: 0.62 * POWER_SCALE`, zero spin) and labeled the decision with `rationale: 'fallback-aim-consistent'` to aid debugging/telemetry.
- Adjusted `planShot` control flow so the improved fallback is attempted before falling back to a pure safety shot when no fully evaluated viable shot exists.

### Testing
- Ran `npm run build` and TypeScript compilation completed successfully.
- Ran the test suite with `npm test -- --runInBand`; the run produced a failing test: `test/poolRoyaleMatchmakingMeta.test.js` (expected `room-77` but received a generated UUID), which appears unrelated to the AI fallback changes and is the single failing test from the run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6a01ffb888329927610fc5f5117da)