### PR TITLE
Improve Pool Royale AI legal-target consistency across turns

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -368,6 +368,80 @@ function resolveBallId (ball, fallback, indexByColour) {
   return fallback
 }
 
+function normaliseTargetToken (token) {
+  if (token == null) return null
+  if (Number.isFinite(token)) return Number(token)
+  if (typeof token !== 'string') return null
+  const value = token.trim().toUpperCase()
+  if (!value) return null
+  const directNumber = Number(value)
+  if (Number.isFinite(directNumber)) return directNumber
+  const numberedBall = /^BALL[_\s-]?(\d+)$/i.exec(value)
+  if (numberedBall) return Number.parseInt(numberedBall[1], 10)
+  if (value === 'BLACK' || value === 'EIGHT') return 8
+  if (value === 'SOLID' || value === 'SOLIDS' || value === 'RED') return 'SOLIDS'
+  if (value === 'STRIPE' || value === 'STRIPES' || value === 'BLUE' || value === 'YELLOW') return 'STRIPES'
+  return value
+}
+
+function legalTargetMatch (ball, token) {
+  const normalized = normaliseTargetToken(token)
+  if (normalized == null) return false
+  if (Number.isFinite(normalized)) return ball.id === normalized
+  if (normalized === 'SOLIDS') return ball.id >= 1 && ball.id <= 7
+  if (normalized === 'STRIPES') return ball.id >= 9 && ball.id <= 15
+  return false
+}
+
+function extractTargetTokens (value) {
+  if (value == null) return []
+  if (Array.isArray(value)) return value.flatMap(extractTargetTokens)
+  if (Number.isFinite(value) || typeof value === 'string') return [value]
+  if (typeof value !== 'object') return []
+  return [
+    value.id,
+    value.ballId,
+    value.targetBallId,
+    value.number,
+    value.ballNumber,
+    value.colour,
+    value.color,
+    value.type
+  ].flatMap(extractTargetTokens)
+}
+
+function legalTargetIdsForState (state, balls) {
+  const raw = [
+    state?.legalBallIds,
+    state?.ballOn,
+    state?.legalTargets,
+    state?.legalTargetSuggestion,
+    state?.nextLegalTargetSuggestion
+  ]
+  const tokens = raw.flatMap(extractTargetTokens)
+  if (tokens.length === 0) return []
+  const ids = new Set()
+  for (const ball of balls) {
+    if (ball?.pocketed) continue
+    if (tokens.some(token => legalTargetMatch(ball, token))) ids.add(ball.id)
+  }
+  return Array.from(ids)
+}
+
+function preferredLegalTargetId (state, legalTargetIds) {
+  if (!Array.isArray(legalTargetIds) || legalTargetIds.length === 0) return null
+  const suggestionTokens = extractTargetTokens([
+    state?.legalTargetSuggestion,
+    state?.nextLegalTargetSuggestion
+  ])
+  for (const token of suggestionTokens) {
+    const normalized = normaliseTargetToken(token)
+    if (!Number.isFinite(normalized)) continue
+    if (legalTargetIds.includes(normalized)) return normalized
+  }
+  return null
+}
+
 function normaliseAimRequest (req) {
   const state = req?.state || {}
   const indexByColour = { red: 0, yellow: 0 }
@@ -393,13 +467,17 @@ function normaliseAimRequest (req) {
 function chooseTargets (req) {
   const cueBallId = resolveCueBallId(req.state)
   const balls = req.state.balls.filter(b => !b.pocketed && b.id !== cueBallId)
-  const legalBallIds = Array.isArray(req.state.legalBallIds)
-    ? req.state.legalBallIds
-      .map(value => Number(value))
-      .filter(Number.isFinite)
-    : []
+  const legalBallIds = legalTargetIdsForState(req.state, balls)
   if (legalBallIds.length > 0) {
-    const legalTargets = balls.filter(ball => legalBallIds.includes(ball.id))
+    const preferredId = preferredLegalTargetId(req.state, legalBallIds)
+    const legalTargets = balls
+      .filter(ball => legalBallIds.includes(ball.id))
+      .sort((a, b) => {
+        if (preferredId == null) return 0
+        if (a.id === preferredId) return -1
+        if (b.id === preferredId) return 1
+        return 0
+      })
     if (legalTargets.length > 0) return legalTargets
   }
   if (req.game === 'NINE_BALL') {
@@ -451,12 +529,7 @@ function chooseTargets (req) {
 function nextTargetsAfter (targetId, req) {
   const cueBallId = resolveCueBallId(req.state)
   const cloned = req.state.balls.filter(b => !b.pocketed && b.id !== targetId && b.id !== cueBallId)
-  const legalBallIds = Array.isArray(req.state.legalBallIds)
-    ? req.state.legalBallIds
-      .map(value => Number(value))
-      .filter(Number.isFinite)
-      .filter(id => id !== targetId)
-    : []
+  const legalBallIds = legalTargetIdsForState(req.state, cloned).filter(id => id !== targetId)
   if (legalBallIds.length > 0) {
     const legalTargets = cloned.filter(ball => legalBallIds.includes(ball.id))
     if (legalTargets.length > 0) return legalTargets

--- a/test/poolAi.test.js
+++ b/test/poolAi.test.js
@@ -489,6 +489,52 @@ test('safety uses one-cushion kick to reach legal target when direct lane is blo
   assert.match(decision.rationale, /one-cushion-kick/);
 });
 
+test('accepts ballOn legal-target tokens so target lock stays consistent across turns', () => {
+  const decision = planShot({
+    game: 'AMERICAN_BILLIARDS',
+    state: {
+      balls: [
+        { id: 0, x: 120, y: 250, vx: 0, vy: 0, pocketed: false },
+        { id: 2, x: 360, y: 240, vx: 0, vy: 0, pocketed: false },
+        { id: 11, x: 640, y: 260, vx: 0, vy: 0, pocketed: false }
+      ],
+      pockets: [{ x: 0, y: 0 }, { x: 1000, y: 0 }, { x: 0, y: 500 }, { x: 1000, y: 500 }],
+      width: 1000,
+      height: 500,
+      ballRadius: 10,
+      friction: 0.01,
+      ballOn: ['BALL_11']
+    },
+    rngSeed: 25,
+    timeBudgetMs: 80
+  });
+
+  assert.equal(decision.targetBallId, 11);
+});
+
+test('uses legalTargetSuggestion as legal target input for stable AI targeting', () => {
+  const decision = planShot({
+    game: 'AMERICAN_BILLIARDS',
+    state: {
+      balls: [
+        { id: 0, x: 140, y: 260, vx: 0, vy: 0, pocketed: false },
+        { id: 2, x: 320, y: 250, vx: 0, vy: 0, pocketed: false },
+        { id: 3, x: 580, y: 250, vx: 0, vy: 0, pocketed: false }
+      ],
+      pockets: [{ x: 1000, y: 250 }, { x: 1000, y: 500 }],
+      width: 1000,
+      height: 500,
+      ballRadius: 10,
+      friction: 0.01,
+      legalTargetSuggestion: { targetBallId: 3 }
+    },
+    rngSeed: 33,
+    timeBudgetMs: 80
+  });
+
+  assert.equal(decision.targetBallId, 3);
+});
+
 test('power stays in a controlled range for routine pots', () => {
   const decision = planShot({
     game: 'AMERICAN_BILLIARDS',

--- a/webapp/public/lib/poolAi.js
+++ b/webapp/public/lib/poolAi.js
@@ -483,6 +483,80 @@ function resolveBallId (ball, fallback, indexByColour) {
   return fallback
 }
 
+function normaliseTargetToken (token) {
+  if (token == null) return null
+  if (Number.isFinite(token)) return Number(token)
+  if (typeof token !== 'string') return null
+  const value = token.trim().toUpperCase()
+  if (!value) return null
+  const directNumber = Number(value)
+  if (Number.isFinite(directNumber)) return directNumber
+  const numberedBall = /^BALL[_\s-]?(\d+)$/i.exec(value)
+  if (numberedBall) return Number.parseInt(numberedBall[1], 10)
+  if (value === 'BLACK' || value === 'EIGHT') return 8
+  if (value === 'SOLID' || value === 'SOLIDS' || value === 'RED') return 'SOLIDS'
+  if (value === 'STRIPE' || value === 'STRIPES' || value === 'BLUE' || value === 'YELLOW') return 'STRIPES'
+  return value
+}
+
+function legalTargetMatch (ball, token) {
+  const normalized = normaliseTargetToken(token)
+  if (normalized == null) return false
+  if (Number.isFinite(normalized)) return ball.id === normalized
+  if (normalized === 'SOLIDS') return ball.id >= 1 && ball.id <= 7
+  if (normalized === 'STRIPES') return ball.id >= 9 && ball.id <= 15
+  return false
+}
+
+function extractTargetTokens (value) {
+  if (value == null) return []
+  if (Array.isArray(value)) return value.flatMap(extractTargetTokens)
+  if (Number.isFinite(value) || typeof value === 'string') return [value]
+  if (typeof value !== 'object') return []
+  return [
+    value.id,
+    value.ballId,
+    value.targetBallId,
+    value.number,
+    value.ballNumber,
+    value.colour,
+    value.color,
+    value.type
+  ].flatMap(extractTargetTokens)
+}
+
+function legalTargetIdsForState (state, balls) {
+  const raw = [
+    state?.legalBallIds,
+    state?.ballOn,
+    state?.legalTargets,
+    state?.legalTargetSuggestion,
+    state?.nextLegalTargetSuggestion
+  ]
+  const tokens = raw.flatMap(extractTargetTokens)
+  if (tokens.length === 0) return []
+  const ids = new Set()
+  for (const ball of balls) {
+    if (ball?.pocketed) continue
+    if (tokens.some(token => legalTargetMatch(ball, token))) ids.add(ball.id)
+  }
+  return Array.from(ids)
+}
+
+function preferredLegalTargetId (state, legalTargetIds) {
+  if (!Array.isArray(legalTargetIds) || legalTargetIds.length === 0) return null
+  const suggestionTokens = extractTargetTokens([
+    state?.legalTargetSuggestion,
+    state?.nextLegalTargetSuggestion
+  ])
+  for (const token of suggestionTokens) {
+    const normalized = normaliseTargetToken(token)
+    if (!Number.isFinite(normalized)) continue
+    if (legalTargetIds.includes(normalized)) return normalized
+  }
+  return null
+}
+
 function normaliseAimRequest (req) {
   const state = req?.state || {}
   const indexByColour = { red: 0, yellow: 0 }
@@ -508,13 +582,17 @@ function normaliseAimRequest (req) {
 function chooseTargets (req) {
   const cueBallId = resolveCueBallId(req.state)
   const balls = req.state.balls.filter(b => !b.pocketed && b.id !== cueBallId)
-  const legalBallIds = Array.isArray(req.state.legalBallIds)
-    ? req.state.legalBallIds
-      .map(value => Number(value))
-      .filter(Number.isFinite)
-    : []
+  const legalBallIds = legalTargetIdsForState(req.state, balls)
   if (legalBallIds.length > 0) {
-    const legalTargets = balls.filter(ball => legalBallIds.includes(ball.id))
+    const preferredId = preferredLegalTargetId(req.state, legalBallIds)
+    const legalTargets = balls
+      .filter(ball => legalBallIds.includes(ball.id))
+      .sort((a, b) => {
+        if (preferredId == null) return 0
+        if (a.id === preferredId) return -1
+        if (b.id === preferredId) return 1
+        return 0
+      })
     if (legalTargets.length > 0) return legalTargets
   }
   if (req.game === 'NINE_BALL') {
@@ -566,12 +644,7 @@ function chooseTargets (req) {
 function nextTargetsAfter (targetId, req) {
   const cueBallId = resolveCueBallId(req.state)
   const cloned = req.state.balls.filter(b => !b.pocketed && b.id !== targetId && b.id !== cueBallId)
-  const legalBallIds = Array.isArray(req.state.legalBallIds)
-    ? req.state.legalBallIds
-      .map(value => Number(value))
-      .filter(Number.isFinite)
-      .filter(id => id !== targetId)
-    : []
+  const legalBallIds = legalTargetIdsForState(req.state, cloned).filter(id => id !== targetId)
   if (legalBallIds.length > 0) {
     const legalTargets = cloned.filter(ball => legalBallIds.includes(ball.id))
     if (legalTargets.length > 0) return legalTargets


### PR DESCRIPTION
### Motivation

- Fix AI inconsistency after the first shot where the agent loses track of legal targets because metadata can arrive in multiple shapes (strings, tokens, structured suggestions) beyond numeric `legalBallIds`.
- Make the AI resilient to different legal-target sources so the suggested/legal target state remains stable across turns.

### Description

- Added a normalization layer (`normaliseTargetToken`, `legalTargetMatch`, `extractTargetTokens`, `legalTargetIdsForState`, `preferredLegalTargetId`) to accept numeric ids, `BALL_<n>` tokens, color/group aliases (`SOLIDS`/`STRIPES`/`BLACK`/`RED`/`BLUE`), and structured suggestion objects.
- Updated target selection to derive legal targets from multiple state fields (`legalBallIds`, `ballOn`, `legalTargets`, `legalTargetSuggestion`, `nextLegalTargetSuggestion`) and to bias selection toward a suggested legal target when present.
- Applied the same fixes to both runtime AI files (`lib/poolAi.js` and `webapp/public/lib/poolAi.js`) so server and client behaviors match.
- Added regression tests (`test/poolAi.test.js`) that verify `ballOn` tokens (e.g., `BALL_11`) and `legalTargetSuggestion` correctly constrain/drive AI targeting.

### Testing

- Ran the unit test file with `node --test test/poolAi.test.js` and all tests passed (21/21 passing). 
- The changes were validated by the updated test cases that exercise token parsing and suggestion-prioritization logic, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6a4f2182083298ed13701ab0da6b0)