### PR TITLE
Domino Royal: shorten table, enlarge/move chairs outward, and lower dominos

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -945,7 +945,7 @@ const dimIntensity = (value = 1) => value * LIGHT_INTENSITY_FACTOR;
 const MODEL_SCALE = 0.7;
 const CAMERA_LAYOUT_SCALE = MODEL_SCALE / 0.75;
 const TABLE_RADIUS_SCALE = 0.79;
-const TABLE_HEIGHT_SCALE = 0.82;
+const TABLE_HEIGHT_SCALE = 0.79;
 const ARENA_GROWTH = 1.45;
 const TABLE_RADIUS = 3.4 * MODEL_SCALE * TABLE_RADIUS_SCALE;
 const BASE_TABLE_HEIGHT = 1.08 * MODEL_SCALE * TABLE_HEIGHT_SCALE;
@@ -966,9 +966,9 @@ const BASE_RADIUS = 0.72 * MODEL_SCALE;
 const FOOT_RING_RADIUS = 0.52 * MODEL_SCALE;
 const FOOT_RING_TUBE = 0.04 * MODEL_SCALE;
 const CHAIR_GAP = 0.04 * MODEL_SCALE;
-const CHAIR_OUTWARD_OFFSET = 0.31 * MODEL_SCALE;
+const CHAIR_OUTWARD_OFFSET = 0.35 * MODEL_SCALE;
 const CHAIR_RADIUS = TABLE_RADIUS + SEAT_DEPTH * 0.38 + CHAIR_GAP + CHAIR_OUTWARD_OFFSET;
-const CHAIR_VISUAL_SCALE = 1.48;
+const CHAIR_VISUAL_SCALE = 1.54;
 const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 0.85;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
 const TABLE_HEIGHT_LIFT = 0.038 * MODEL_SCALE * TABLE_HEIGHT_SCALE;
@@ -6577,7 +6577,7 @@ const TILE_UP_HALF = TILE_UP_H / 2;
 const XMAX = CLOTH_RADIUS - 0.32 - DOMINO_CHAIN_GAP * 0.5;
 const ZMAX = CLOTH_RADIUS - 0.32 - DOMINO_CHAIN_GAP * 0.5;
 const HAND_Y = RAIL_TOP + TILE_UP_HALF - 0.0025;
-const CHAIN_TILE_Y = CLOTH_TOP + 0.006; // keep dominoes visually lower so they align with the shorter table
+const CHAIN_TILE_Y = CLOTH_TOP + 0.0045; // keep dominoes visually lower so they align with the shorter table
 
 function getTileSpanAlongChain(isDouble = false) {
   return (isDouble ? DOMINO_WIDTH : DOMINO_LENGTH) * 0.5;
@@ -6986,7 +6986,7 @@ let chain = [];
 const boneyardStackG = new THREE.Group();
 const BONEYARD_STACK_POSITION = new THREE.Vector3(
   0,
-  CLOTH_TOP + 0.0075,
+  CLOTH_TOP + 0.006,
   CLOTH_RADIUS * 0.45
 );
 boneyardStackG.position.copy(BONEYARD_STACK_POSITION);
@@ -8200,7 +8200,7 @@ function computeHandSlotPosition(
 
   const gapBase =
     (openFlat ? BASE_GAP * 1.04 : BASE_GAP * 0.94) * PLAYER_HAND_GAP_SCALE;
-  const handY = openFlat ? CLOTH_TOP + 0.018 : HAND_Y + PLAYER_HAND_VERTICAL_RAISE;
+  const handY = openFlat ? CLOTH_TOP + 0.016 : HAND_Y + PLAYER_HAND_VERTICAL_RAISE;
   const safeCount = Math.max(1, handCount | 0);
   const safeSlot = THREE.MathUtils.clamp(slotIndex | 0, 0, safeCount - 1);
   const seatLength = Math.hypot(x0, z0) || 1;


### PR DESCRIPTION
### Motivation
- Make small visual adjustments so chairs appear a bit larger and sit slightly farther from the table to improve composition around the Domino Battle Royal table. 
- Reduce overall table height modestly to match the requested shorter table profile. 
- Lower domino placement (chains, boneyard and flat-hand placement) to visually align tiles with the new table height.

### Description
- Updated layout constants in `webapp/public/domino-royal-game.js` to implement the visual changes. 
- Reduced `TABLE_HEIGHT_SCALE` from `0.82` to `0.79` to shorten the table profile. 
- Increased chair separation and size by changing `CHAIR_OUTWARD_OFFSET` from `0.31 * MODEL_SCALE` to `0.35 * MODEL_SCALE` and `CHAIR_VISUAL_SCALE` from `1.48` to `1.54`. 
- Lowered domino vertical offsets by adjusting `CHAIN_TILE_Y` from `CLOTH_TOP + 0.006` to `CLOTH_TOP + 0.0045`, `BONEYARD_STACK_POSITION.y` from `CLOTH_TOP + 0.0075` to `CLOTH_TOP + 0.006`, and the flat-hand `handY` open-flat value from `CLOTH_TOP + 0.018` to `CLOTH_TOP + 0.016`.

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` which completed successfully with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6aa9e611c832995423c60ef17371c)