### PR TITLE
Adjust Chess Battle Royale player board size and vertical position

### DIFF
--- a/webapp/public/chess-royale.html
+++ b/webapp/public/chess-royale.html
@@ -13,8 +13,8 @@
   html,body{height:100vh;height:100dvh;overscroll-behavior:none;}
   body{margin:0;background:var(--bg);color:var(--fg);font-family:'Luckiest Guy','Comic Sans MS',cursive;overflow:hidden;}
   .ui{position:fixed;inset:0;pointer-events:none;}
-  .scoreboard{position:absolute;top:10px;left:0;right:0;display:flex;align-items:center;justify-content:center;}
-  .score{background:rgba(11,18,32,0.85);backdrop-filter:blur(8px);border:1px solid #233050;border-radius:12px;padding:6px 10px;display:flex;align-items:center;gap:8px;box-shadow:0 12px 32px rgba(0,0,0,0.35);}
+  .scoreboard{position:absolute;top:4px;left:0;right:0;display:flex;align-items:center;justify-content:center;}
+  .score{background:rgba(11,18,32,0.85);backdrop-filter:blur(8px);border:1px solid #233050;border-radius:11px;padding:5px 9px;display:flex;align-items:center;gap:7px;box-shadow:0 12px 32px rgba(0,0,0,0.35);transform:scale(0.94);transform-origin:top center;}
   .badge{padding:2px 8px;border-radius:999px;font-weight:800;color:#fff;display:flex;align-items:center;gap:4px;}
   .p1{background:var(--p1);} .p2{background:var(--p2);}
   .avatar{width:20px;height:20px;border-radius:50%;background-size:cover;background-position:center;display:flex;align-items:center;justify-content:center;font-size:16px;}


### PR DESCRIPTION
### Motivation
- Make the top player board visually a bit smaller and lift it slightly higher on screen to match portrait/mobile layout preferences.
- Keep the change minimal and stable so it only affects the scoreboard sizing/position without altering game logic or layout elsewhere.

### Description
- Updated CSS in `webapp/public/chess-royale.html` to shift the scoreboard upward by changing `.scoreboard { top: 10px; }` to `top: 4px;`.
- Reduced the visual footprint of the player board by tightening radius/padding/gap on `.score` and applying `transform: scale(0.94)` with `transform-origin: top center` to ensure it visually shrinks while anchoring upward.
- Changes are limited to the single file `webapp/public/chess-royale.html` and only touch the scoreboard-related style rules.

### Testing
- Ran an automated diff check with `git diff -- webapp/public/chess-royale.html` to confirm only the intended CSS lines changed, which succeeded.
- Ran a repository status check with `git status --short` and inspected the modified lines via `nl -ba webapp/public/chess-royale.html` to validate the edits, all succeeded; no unit or UI tests were executed for this cosmetic change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6ab3048588329b65f37b68a7c9f25)