### PR TITLE
fix(pool-ai): stabilize legal target selection across turns

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -368,6 +368,95 @@ function resolveBallId (ball, fallback, indexByColour) {
   return fallback
 }
 
+function valueToNumericId (value) {
+  if (Number.isFinite(value)) return Number(value)
+  if (typeof value !== 'string') return null
+  const match = value.match(/(\d+)/)
+  if (!match) return null
+  const parsed = Number.parseInt(match[1], 10)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function collectSuggestedLegalIds (state) {
+  const collected = []
+  if (!state || typeof state !== 'object') return collected
+
+  if (Array.isArray(state.legalBallIds)) collected.push(...state.legalBallIds)
+
+  const suggestion = state.legalTargetSuggestion
+  if (suggestion != null) {
+    if (Array.isArray(suggestion)) {
+      collected.push(...suggestion)
+    } else {
+      collected.push(
+        suggestion.targetBallId,
+        suggestion.suggestedTargetBallId,
+        suggestion.id,
+        suggestion.ballId
+      )
+    }
+  }
+
+  if (Array.isArray(state.legalTargetSuggestions)) {
+    for (const entry of state.legalTargetSuggestions) {
+      if (entry == null) continue
+      if (typeof entry === 'number' || typeof entry === 'string') {
+        collected.push(entry)
+        continue
+      }
+      collected.push(
+        entry.targetBallId,
+        entry.suggestedTargetBallId,
+        entry.id,
+        entry.ballId
+      )
+    }
+  }
+
+  return collected
+}
+
+function normalizedLegalBallIds (state, balls) {
+  const raw = collectSuggestedLegalIds(state)
+  if (!raw.length) return []
+
+  const ids = new Set()
+  const colourHints = new Set()
+
+  for (const value of raw) {
+    const asId = valueToNumericId(value)
+    if (Number.isFinite(asId)) {
+      ids.add(asId)
+      continue
+    }
+    if (typeof value === 'string') {
+      colourHints.add(value.toLowerCase())
+    }
+  }
+
+  const matches = []
+  for (const ball of balls) {
+    if (!ball || ball.pocketed) continue
+    const variants = [
+      ball.id,
+      ball.number,
+      ball.ballNumber,
+      ball.markerNumber,
+      ball.helperNumber,
+      ball.aiHelperNumber,
+      ball.hiddenNumber
+    ]
+    const hasIdMatch = variants.some(v => Number.isFinite(v) && ids.has(Number(v)))
+    const colour = (ball.colour || ball.color || '').toString().toLowerCase()
+    const hasColourMatch = colour && colourHints.has(colour)
+    if (hasIdMatch || hasColourMatch) {
+      matches.push(ball.id)
+    }
+  }
+
+  return [...new Set(matches)]
+}
+
 function normaliseAimRequest (req) {
   const state = req?.state || {}
   const indexByColour = { red: 0, yellow: 0 }
@@ -385,7 +474,8 @@ function normaliseAimRequest (req) {
     state: {
       ...state,
       balls,
-      cueBallId
+      cueBallId,
+      legalBallIds: normalizedLegalBallIds(state, balls)
     }
   }
 }
@@ -400,7 +490,19 @@ function chooseTargets (req) {
     : []
   if (legalBallIds.length > 0) {
     const legalTargets = balls.filter(ball => legalBallIds.includes(ball.id))
-    if (legalTargets.length > 0) return legalTargets
+    if (legalTargets.length > 0) {
+      return legalTargets
+    }
+    // If we received legal target guidance but ID mapping failed, keep
+    // consistency by falling back to the nearest legal suggestion anchor.
+    const hint = req?.state?.legalTargetSuggestion?.suggestedAimPoint
+    if (hint && Number.isFinite(hint.x) && Number.isFinite(hint.y)) {
+      const nearest = balls.reduce((best, ball) => {
+        if (!best) return ball
+        return dist(ball, hint) < dist(best, hint) ? ball : best
+      }, null)
+      if (nearest) return [nearest]
+    }
   }
   if (req.game === 'NINE_BALL') {
     const lowest = balls.reduce((m, b) => (b.id < m.id ? b : m), balls[0])
@@ -907,7 +1009,6 @@ function calibrateSpinSideForNextBall (req, cue, target, pocket, spin, power) {
   }
   return best.spin
 }
-
 
 function buildSpinCandidates (cue, target, pocket, req) {
   const base = [


### PR DESCRIPTION
### Motivation
- The pool AI could lose consistent target guidance after the opening shots when incoming legal-target metadata used different shapes or IDs than the runtime-normalized ball set, causing the bot to pick broad/default targets.
- Normalize and prefer legal-target hints so AI keeps aiming at the intended targets across successive turns.

### Description
- Added helpers to normalize incoming legal-target hints from multiple shapes: `valueToNumericId`, `collectSuggestedLegalIds`, and `normalizedLegalBallIds` in `lib/poolAi.js`.
- `normaliseAimRequest` now populates `state.legalBallIds` with normalized IDs derived from `legalBallIds`, `legalTargetSuggestion`, or `legalTargetSuggestions` to bridge metadata formats to runtime ball IDs.
- `chooseTargets` now prefers those normalized legal targets when present and includes a fallback that anchors selection to `legalTargetSuggestion.suggestedAimPoint` by choosing the nearest ball if ID mapping fails.
- Minor formatting/lint adjustments to satisfy project lint rules.

### Testing
- Ran `npx eslint lib/poolAi.js --fix` and the auto-fix completed successfully.
- Ran `npx eslint lib/poolAi.js` with no remaining errors after the fix.
- Verified module loads and `planShot` exists via `node -e "import('./lib/poolAi.js').then(m=>console.log(typeof m.planShot==='function'?'ok':'bad'))"`, which printed `ok`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6a4f2182083298ed13701ab0da6b0)