### PR TITLE
Fix Pool AI target consistency using legal target suggestions

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -390,14 +390,67 @@ function normaliseAimRequest (req) {
   }
 }
 
+
+function resolveLegalTargetIds (req) {
+  const state = req?.state || {}
+  const balls = Array.isArray(state.balls) ? state.balls : []
+  const cueBallId = resolveCueBallId(state)
+  const legalIds = new Set(
+    (Array.isArray(state.legalBallIds) ? state.legalBallIds : [])
+      .map(value => Number(value))
+      .filter(Number.isFinite)
+  )
+
+  const hints = []
+  if (Array.isArray(state.legalTargetSuggestions)) hints.push(...state.legalTargetSuggestions)
+  if (state.legalTargetSuggestion) hints.push(state.legalTargetSuggestion)
+
+  for (const hint of hints) {
+    if (!hint) continue
+    const idCandidate = [
+      hint.id,
+      hint.ballId,
+      hint.targetBallId,
+      hint.number,
+      hint.markerNumber,
+      hint.ball?.id,
+      hint.ball?.ballId,
+      hint.ball?.number,
+      hint.ball?.markerNumber
+    ]
+      .map(value => Number(value))
+      .find(Number.isFinite)
+
+    if (Number.isFinite(idCandidate)) {
+      legalIds.add(idCandidate)
+      continue
+    }
+
+    const targetPos = hint.ball || hint.target || hint.targetBall || hint.position || hint
+    if (!targetPos || !Number.isFinite(targetPos.x) || !Number.isFinite(targetPos.y)) continue
+    const radius = Number.isFinite(state.ballRadius) ? state.ballRadius : 10
+    let nearest = null
+    let nearestDistance = Infinity
+    for (const ball of balls) {
+      if (!ball || ball.pocketed || ball.id === cueBallId) continue
+      const d = dist(ball, targetPos)
+      if (d < nearestDistance) {
+        nearestDistance = d
+        nearest = ball
+      }
+    }
+    if (nearest && nearestDistance <= radius * 3.5) {
+      legalIds.add(nearest.id)
+    }
+  }
+
+  return Array.from(legalIds)
+}
+
 function chooseTargets (req) {
   const cueBallId = resolveCueBallId(req.state)
   const balls = req.state.balls.filter(b => !b.pocketed && b.id !== cueBallId)
-  const legalBallIds = Array.isArray(req.state.legalBallIds)
-    ? req.state.legalBallIds
-      .map(value => Number(value))
-      .filter(Number.isFinite)
-    : []
+  const legalBallIds = resolveLegalTargetIds(req)
   if (legalBallIds.length > 0) {
     const legalTargets = balls.filter(ball => legalBallIds.includes(ball.id))
     if (legalTargets.length > 0) return legalTargets
@@ -451,12 +504,8 @@ function chooseTargets (req) {
 function nextTargetsAfter (targetId, req) {
   const cueBallId = resolveCueBallId(req.state)
   const cloned = req.state.balls.filter(b => !b.pocketed && b.id !== targetId && b.id !== cueBallId)
-  const legalBallIds = Array.isArray(req.state.legalBallIds)
-    ? req.state.legalBallIds
-      .map(value => Number(value))
-      .filter(Number.isFinite)
-      .filter(id => id !== targetId)
-    : []
+  const legalBallIds = resolveLegalTargetIds(req)
+    .filter(id => id !== targetId)
   if (legalBallIds.length > 0) {
     const legalTargets = cloned.filter(ball => legalBallIds.includes(ball.id))
     if (legalTargets.length > 0) return legalTargets

--- a/test/poolAi.test.js
+++ b/test/poolAi.test.js
@@ -510,3 +510,55 @@ test('power stays in a controlled range for routine pots', () => {
 
   assert(decision.power >= 0.35 && decision.power <= 0.7, `unexpected power ${decision.power}`);
 });
+
+test('uses legalTargetSuggestion ballId when legalBallIds are missing', () => {
+  const decision = planShot({
+    game: 'AMERICAN_BILLIARDS',
+    state: {
+      balls: [
+        { id: 0, x: 110, y: 250, vx: 0, vy: 0, pocketed: false },
+        { id: 2, x: 340, y: 150, vx: 0, vy: 0, pocketed: false },
+        { id: 11, x: 360, y: 340, vx: 0, vy: 0, pocketed: false }
+      ],
+      pockets: [
+        { x: 0, y: 0 }, { x: 500, y: 0 }, { x: 1000, y: 0 },
+        { x: 0, y: 500 }, { x: 500, y: 500 }, { x: 1000, y: 500 }
+      ],
+      width: 1000,
+      height: 500,
+      ballRadius: 10,
+      friction: 0.01,
+      legalTargetSuggestion: { ballId: 11 }
+    },
+    timeBudgetMs: 100,
+    rngSeed: 41
+  })
+
+  assert.equal(decision.targetBallId, 11)
+})
+
+test('maps legalTargetSuggestion position to nearest live ball for consistent targeting', () => {
+  const decision = planShot({
+    game: 'AMERICAN_BILLIARDS',
+    state: {
+      balls: [
+        { id: 0, x: 120, y: 260, vx: 0, vy: 0, pocketed: false },
+        { id: 3, x: 420, y: 250, vx: 0, vy: 0, pocketed: false },
+        { id: 10, x: 650, y: 250, vx: 0, vy: 0, pocketed: false }
+      ],
+      pockets: [
+        { x: 0, y: 0 }, { x: 500, y: 0 }, { x: 1000, y: 0 },
+        { x: 0, y: 500 }, { x: 500, y: 500 }, { x: 1000, y: 500 }
+      ],
+      width: 1000,
+      height: 500,
+      ballRadius: 10,
+      friction: 0.01,
+      legalTargetSuggestion: { target: { x: 647, y: 252 } }
+    },
+    timeBudgetMs: 100,
+    rngSeed: 43
+  })
+
+  assert.equal(decision.targetBallId, 10)
+})

--- a/webapp/public/lib/poolAi.js
+++ b/webapp/public/lib/poolAi.js
@@ -505,14 +505,67 @@ function normaliseAimRequest (req) {
   }
 }
 
+
+function resolveLegalTargetIds (req) {
+  const state = req?.state || {}
+  const balls = Array.isArray(state.balls) ? state.balls : []
+  const cueBallId = resolveCueBallId(state)
+  const legalIds = new Set(
+    (Array.isArray(state.legalBallIds) ? state.legalBallIds : [])
+      .map(value => Number(value))
+      .filter(Number.isFinite)
+  )
+
+  const hints = []
+  if (Array.isArray(state.legalTargetSuggestions)) hints.push(...state.legalTargetSuggestions)
+  if (state.legalTargetSuggestion) hints.push(state.legalTargetSuggestion)
+
+  for (const hint of hints) {
+    if (!hint) continue
+    const idCandidate = [
+      hint.id,
+      hint.ballId,
+      hint.targetBallId,
+      hint.number,
+      hint.markerNumber,
+      hint.ball?.id,
+      hint.ball?.ballId,
+      hint.ball?.number,
+      hint.ball?.markerNumber
+    ]
+      .map(value => Number(value))
+      .find(Number.isFinite)
+
+    if (Number.isFinite(idCandidate)) {
+      legalIds.add(idCandidate)
+      continue
+    }
+
+    const targetPos = hint.ball || hint.target || hint.targetBall || hint.position || hint
+    if (!targetPos || !Number.isFinite(targetPos.x) || !Number.isFinite(targetPos.y)) continue
+    const radius = Number.isFinite(state.ballRadius) ? state.ballRadius : 10
+    let nearest = null
+    let nearestDistance = Infinity
+    for (const ball of balls) {
+      if (!ball || ball.pocketed || ball.id === cueBallId) continue
+      const d = dist(ball, targetPos)
+      if (d < nearestDistance) {
+        nearestDistance = d
+        nearest = ball
+      }
+    }
+    if (nearest && nearestDistance <= radius * 3.5) {
+      legalIds.add(nearest.id)
+    }
+  }
+
+  return Array.from(legalIds)
+}
+
 function chooseTargets (req) {
   const cueBallId = resolveCueBallId(req.state)
   const balls = req.state.balls.filter(b => !b.pocketed && b.id !== cueBallId)
-  const legalBallIds = Array.isArray(req.state.legalBallIds)
-    ? req.state.legalBallIds
-      .map(value => Number(value))
-      .filter(Number.isFinite)
-    : []
+  const legalBallIds = resolveLegalTargetIds(req)
   if (legalBallIds.length > 0) {
     const legalTargets = balls.filter(ball => legalBallIds.includes(ball.id))
     if (legalTargets.length > 0) return legalTargets
@@ -566,12 +619,8 @@ function chooseTargets (req) {
 function nextTargetsAfter (targetId, req) {
   const cueBallId = resolveCueBallId(req.state)
   const cloned = req.state.balls.filter(b => !b.pocketed && b.id !== targetId && b.id !== cueBallId)
-  const legalBallIds = Array.isArray(req.state.legalBallIds)
-    ? req.state.legalBallIds
-      .map(value => Number(value))
-      .filter(Number.isFinite)
-      .filter(id => id !== targetId)
-    : []
+  const legalBallIds = resolveLegalTargetIds(req)
+    .filter(id => id !== targetId)
   if (legalBallIds.length > 0) {
     const legalTargets = cloned.filter(ball => legalBallIds.includes(ball.id))
     if (legalTargets.length > 0) return legalTargets


### PR DESCRIPTION
### Motivation
- The AI became inconsistent across turns when `legalBallIds` metadata was absent or unstable, causing it to lose track of which object balls are legal after the first shot.  
- The planner already computes a `suggestedAimPoint` but did not reliably use incoming legal-target hints; we need the AI to respect server/client-provided legal-target suggestions so targeting remains consistent.  

### Description
- Added `resolveLegalTargetIds(req)` to unify legal-target resolution from `state.legalBallIds`, `state.legalTargetSuggestion`, and `state.legalTargetSuggestions`, accepting both id-based hints and position-based hints mapped to the nearest live ball.  
- Replaced inline `legalBallIds` extraction in `chooseTargets` and `nextTargetsAfter` with `resolveLegalTargetIds(req)` so both immediate selection and lookahead planning follow the same legal-target guidance.  
- Mirrored the same change in the web bundle at `webapp/public/lib/poolAi.js` so runtime assets match the source planner.  
- Added regression tests in `test/poolAi.test.js` that cover `legalTargetSuggestion.ballId` and a coordinate-based `legalTargetSuggestion.target` mapping to the nearest live ball.  

### Testing
- Ran the unit test file with `node --test test/poolAi.test.js` and all tests passed (21/21).  
- Verified the new logic is applied in both `lib/poolAi.js` and `webapp/public/lib/poolAi.js` and that the new tests assert expected target selection behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6a4f2182083298ed13701ab0da6b0)