### PR TITLE
Fix Pool Royale AI shot consistency after opening shot

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -26902,10 +26902,10 @@ const powerRef = useRef(hud.power);
             ballsRef.current?.length > 0 ? ballsRef.current : balls;
           const state = frameRef.current ?? frameState;
           const activeVariantId = activeVariantRef.current?.id ?? variantKey;
-          const shouldAnalyzeLeave =
-            aiOpponentEnabled &&
-            hudRef.current?.turn === 1 &&
-            aiTurnShotCountRef.current > 0;
+          // Keep shot-selection behavior consistent across the whole AI turn.
+          // Prioritizing leave-position only after the opening shot made later shots
+          // feel less accurate than the first one.
+          const shouldAnalyzeLeave = false;
           const isRotationVariant =
             activeVariantId === 'american' || activeVariantId === '9ball';
           const activeBalls = ballsList.filter((b) => b.active);


### PR DESCRIPTION
### Motivation
- Ensure AI maintains the same precision and pacing as the opening shot by removing the post-opening cue-ball "leave" weighting that made later AI shots feel less accurate.

### Description
- In `webapp/src/pages/Games/PoolRoyale.jsx` the AI shot-evaluation baseline now forces `shouldAnalyzeLeave = false` inside `evaluateShotOptionsBaseline`, and an inline comment was added explaining the consistency rationale.

### Testing
- Ran `npm test -- test/poolAi.test.js test/poolUkAdvancedAi.test.js --runInBand` and both test suites passed (2 suites, 27 tests total, all PASS).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7297490d88329870a558601386801)