### PR TITLE
Improve Pool Royal AI shot consistency between turns

### DIFF
--- a/lib/poolAi.js
+++ b/lib/poolAi.js
@@ -56,6 +56,48 @@ function createRng (seed) {
   }
 }
 
+function mixHash32 (hash, value) {
+  hash ^= value >>> 0
+  hash = Math.imul(hash, 16777619) >>> 0
+  return hash
+}
+
+function quantizeCoord (value, scale = 10) {
+  if (!Number.isFinite(value)) return 0
+  return Math.round(value * scale)
+}
+
+function deterministicSeedFromState (req) {
+  const state = req?.state || {}
+  let hash = 2166136261
+  const gameCode = String(req?.game || '')
+  for (let i = 0; i < gameCode.length; i++) {
+    hash = mixHash32(hash, gameCode.charCodeAt(i))
+  }
+
+  hash = mixHash32(hash, quantizeCoord(state.width, 1))
+  hash = mixHash32(hash, quantizeCoord(state.height, 1))
+  hash = mixHash32(hash, quantizeCoord(state.ballRadius, 100))
+
+  const balls = Array.isArray(state.balls) ? state.balls : []
+  for (const ball of balls) {
+    hash = mixHash32(hash, quantizeCoord(ball?.id, 1))
+    hash = mixHash32(hash, quantizeCoord(ball?.x))
+    hash = mixHash32(hash, quantizeCoord(ball?.y))
+    hash = mixHash32(hash, ball?.pocketed ? 1 : 0)
+  }
+
+  const pockets = Array.isArray(state.pockets) ? state.pockets : []
+  for (const pocket of pockets) {
+    hash = mixHash32(hash, quantizeCoord(pocket?.x))
+    hash = mixHash32(hash, quantizeCoord(pocket?.y))
+  }
+
+  hash = mixHash32(hash, state.ballInHand ? 1 : 0)
+  hash = mixHash32(hash, state.breakInProgress ? 1 : 0)
+  return hash >>> 0
+}
+
 function dist (a, b) {
   const dx = a.x - b.x
   const dy = a.y - b.y
@@ -1241,12 +1283,13 @@ export function planShot (req) {
   const r = req.state.ballRadius
   const cueBallId = resolveCueBallId(req.state)
   const start = Date.now()
-  const deadline = req.timeBudgetMs ? start + req.timeBudgetMs : Infinity
   const thinkingBudget = Number.isFinite(req.timeBudgetMs) ? Math.max(120, req.timeBudgetMs) : 700
+  const deadline = Number.isFinite(req.timeBudgetMs) ? start + thinkingBudget : Infinity
   const budgetScale = Math.min(2.4, Math.max(0.7, thinkingBudget / 700))
   const lookaheadDepth = Math.max(4, Math.min(8, Math.round(LOOKAHEAD_DEPTH * budgetScale)))
   const mcSamples = Math.max(48, Math.min(220, Math.round(MONTE_CARLO_BASE_SAMPLES * budgetScale)))
-  const rng = Number.isFinite(req.rngSeed) ? createRng(req.rngSeed) : Math.random
+  const seededRng = createRng(Number.isFinite(req.rngSeed) ? req.rngSeed : deterministicSeedFromState(req))
+  const rng = seededRng
   let best = null
   let fallback = null
   let hasViableShot = false
@@ -1384,8 +1427,14 @@ export function planShot (req) {
       Math.abs(best.spin?.top || 0) < 1e-6 &&
       Math.abs(best.spin?.side || 0) < 1e-6 &&
       Math.abs(best.spin?.back || 0) < 1e-6
-    if (neutralSpin && best.power > 0.5 * POWER_SCALE && best.quality >= 0.45) {
-      best.power = 0.5 * POWER_SCALE
+    if (neutralSpin && !req.state?.breakInProgress) {
+      if (best.power > 0.5 * POWER_SCALE && best.quality >= 0.45) {
+        best.power = 0.5 * POWER_SCALE
+      } else if (best.power > 0.66 * POWER_SCALE && best.quality >= 0.3) {
+        // Keep routine pots on a repeatable "pro rhythm":
+        // moderate speed improves consistency across consecutive visits.
+        best.power = 0.66 * POWER_SCALE
+      }
     }
     const suggestion = findSuggestedTarget(req, best.targetBallId)
     if (suggestion) {

--- a/test/poolAi.test.js
+++ b/test/poolAi.test.js
@@ -562,3 +562,34 @@ test('maps legalTargetSuggestion position to nearest live ball for consistent ta
 
   assert.equal(decision.targetBallId, 10)
 })
+
+test('keeps shot planning deterministic when rngSeed is omitted', () => {
+  const req = {
+    game: 'AMERICAN_BILLIARDS',
+    state: {
+      balls: [
+        { id: 0, x: 120, y: 240, vx: 0, vy: 0, pocketed: false },
+        { id: 2, x: 360, y: 200, vx: 0, vy: 0, pocketed: false },
+        { id: 9, x: 680, y: 260, vx: 0, vy: 0, pocketed: false }
+      ],
+      pockets: [
+        { x: 0, y: 0 }, { x: 500, y: 0 }, { x: 1000, y: 0 },
+        { x: 0, y: 500 }, { x: 500, y: 500 }, { x: 1000, y: 500 }
+      ],
+      width: 1000,
+      height: 500,
+      ballRadius: 10,
+      friction: 0.01,
+      legalBallIds: [2]
+    },
+    timeBudgetMs: 100
+  }
+
+  const first = planShot(req)
+  const second = planShot(req)
+
+  assert.equal(second.targetBallId, first.targetBallId)
+  assert.equal(second.angleRad, first.angleRad)
+  assert.equal(second.power, first.power)
+  assert.deepEqual(second.spin, first.spin)
+})


### PR DESCRIPTION
### Motivation
- Players reported inconsistent AI behaviour after the opening shot, producing non-repeatable rhythm and accuracy between subsequent turns.
- The planner relied on non-deterministic randomness when `rngSeed` was omitted and had a subtle time-budget mismatch that could prematurely cut exploration.
- Routine neutral-spin pots occasionally used higher powers causing an inconsistent “feel” between shots.

### Description
- Added a deterministic state-hash fallback seed via `deterministicSeedFromState` (and helpers `mixHash32`/`quantizeCoord`) to ensure stable RNG when `req.rngSeed` is not provided in `lib/poolAi.js`.
- Switched the planner to use the seeded RNG and updated seeding at planner start so identical table states produce consistent decisions across calls to `planShot`.
- Fixed time-budget/deadline logic so the internal `thinkingBudget` minimum is used to compute `deadline`, preventing early cut-offs during low `timeBudgetMs` values.
- Constrained neutral-spin, non-break routine pots to a repeatable power band (cap to `0.5` or `0.66` scaled values depending on quality) to keep AI shot rhythm consistent.
- Added a regression test `keeps shot planning deterministic when rngSeed is omitted` in `test/poolAi.test.js` to ensure repeated `planShot` calls without `rngSeed` return identical `targetBallId`, `angleRad`, `power`, and `spin`.

### Testing
- Ran `node --test test/poolAi.test.js` and all tests in that file passed (22/22). 
- Ran `node --test test/poolUk8Ball.test.js`; this run shows an existing unrelated failure in `foul grants ball in hand without extra visits` which was not introduced by these changes. 
- Iterated locally to resolve an initial non-determinism and time-budget-related test failure in `test/poolAi.test.js` and validated the final `poolAi` test suite passes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7297490d88329870a558601386801)