### PR TITLE
Improve Pool Royale AI attacking consistency and shot-settle gating

### DIFF
--- a/Assets/Scripts/Aiming/AdaptiveAimingEngine.cs
+++ b/Assets/Scripts/Aiming/AdaptiveAimingEngine.cs
@@ -399,13 +399,19 @@ namespace Aiming
 
         float ScoreAttempt(in ShotContext ctx, in ShotInfo info, in AimSolution attempt)
         {
-            Vector3 cueDir = (attempt.aimEnd - ctx.cueBallPos).normalized;
+            Vector3 cueDirRaw = attempt.aimEnd - ctx.cueBallPos;
+            if (cueDirRaw.sqrMagnitude < 1e-8f)
+                return 10f;
+
+            Vector3 cueDir = cueDirRaw.normalized;
             Vector3 idealDir = (ctx.objectBallPos - ctx.cueBallPos).normalized;
             float directionalMiss = 1f - Mathf.Clamp01(Vector3.Dot(cueDir, idealDir));
 
             float cutPenalty = (config ? config.cutAnglePenalty : 0.55f) * (info.angleDeg / 90f);
             float distancePenalty = (config ? config.distancePenalty : 0.2f) * Vector3.Distance(ctx.cueBallPos, attempt.aimEnd);
-            return directionalMiss + cutPenalty + distancePenalty;
+            float potLinePenalty = EvaluatePotLinePenalty(ctx, attempt);
+            float scratchRiskPenalty = EvaluateScratchRiskPenalty(ctx, cueDir);
+            return directionalMiss + cutPenalty + distancePenalty + potLinePenalty + scratchRiskPenalty;
         }
 
         AimSolution SelectWithMonteCarlo(in ShotContext ctx, in ShotInfo info, AimSolution[] solutions, float[] deterministicScores, int count)
@@ -465,11 +471,58 @@ namespace Aiming
 
             Vector3 objectToPocketDir = objectToPocket / objectToPocketDistance;
             float hitAlignment = Mathf.Clamp01(Vector3.Dot(cueDir, cueToObjectDir));
-            float cutAlignment = Mathf.Clamp01(Vector3.Dot(cueToObjectDir, objectToPocketDir));
+            Vector3 sampledObjectTravel = EstimateObjectTravelDirection(ctx, cueDir);
+            float cutAlignment = sampledObjectTravel.sqrMagnitude > 1e-8f
+                ? Mathf.Clamp01(Vector3.Dot(sampledObjectTravel, objectToPocketDir))
+                : Mathf.Clamp01(Vector3.Dot(cueToObjectDir, objectToPocketDir));
             float powerPenalty = Mathf.Abs(shotPower01 - RecommendPower(info.distBucket, ctx.requiresPower)) * 0.15f;
             float missPenalty = (1f - hitAlignment) * 1.5f + (1f - cutAlignment) * 1.2f;
+            float scratchRiskPenalty = EvaluateScratchRiskPenalty(ctx, cueDir);
 
-            return missPenalty + powerPenalty + (info.angleDeg / 90f) * 0.15f;
+            return missPenalty + powerPenalty + scratchRiskPenalty + (info.angleDeg / 90f) * 0.15f;
+        }
+
+        static Vector3 EstimateObjectTravelDirection(in ShotContext ctx, Vector3 cueDir)
+        {
+            Vector3 cueToObject = ctx.objectBallPos - ctx.cueBallPos;
+            if (cueToObject.sqrMagnitude <= 1e-8f)
+                return Vector3.zero;
+
+            Vector3 contactNormal = cueToObject.normalized;
+            float forwardComponent = Mathf.Max(0f, Vector3.Dot(cueDir, contactNormal));
+            if (forwardComponent <= 1e-5f)
+                return Vector3.zero;
+
+            Vector3 objectTravel = contactNormal * forwardComponent;
+            return objectTravel.sqrMagnitude > 1e-8f ? objectTravel.normalized : Vector3.zero;
+        }
+
+        float EvaluatePotLinePenalty(in ShotContext ctx, in AimSolution attempt)
+        {
+            Vector3 objectToPocket = ctx.pocketPos - ctx.objectBallPos;
+            if (objectToPocket.sqrMagnitude < 1e-8f)
+                return 0f;
+
+            Vector3 projectedObjectTravel = ctx.objectBallPos - attempt.aimEnd;
+            if (projectedObjectTravel.sqrMagnitude < 1e-8f)
+                return 1.2f;
+
+            float alignment = Mathf.Clamp01(Vector3.Dot(projectedObjectTravel.normalized, objectToPocket.normalized));
+            return (1f - alignment) * 1.35f;
+        }
+
+        float EvaluateScratchRiskPenalty(in ShotContext ctx, Vector3 cueDir)
+        {
+            Vector3 objectToPocket = ctx.pocketPos - ctx.objectBallPos;
+            if (objectToPocket.sqrMagnitude < 1e-8f)
+                return 0f;
+
+            float sameLane = Mathf.Clamp01(Vector3.Dot(cueDir, objectToPocket.normalized));
+            if (sameLane < 0.82f)
+                return 0f;
+
+            // Very aligned cue paths tend to follow the object toward the same pocket (scratch risk).
+            return (sameLane - 0.82f) * 1.1f;
         }
 
         static Vector3 ApplyDirectionalNoise(Vector3 baseDir, float jitterDeg, int seed)

--- a/Assets/Scripts/Gameplay/CueController.cs
+++ b/Assets/Scripts/Gameplay/CueController.cs
@@ -17,6 +17,8 @@ namespace Aiming
         public Transform cueTip;
         public Transform cueBall, objectBall, pocket;
         public Rigidbody cueBallBody;
+        [Tooltip("All table ball rigidbodies to monitor. AI/cue waits until every listed ball is fully settled before re-aiming.")]
+        public Rigidbody[] monitoredBallBodies;
         public Bounds tableBounds;
         public float ballRadius = 0.028575f;
 
@@ -41,6 +43,11 @@ namespace Aiming
         [Range(0.02f, 0.25f)] public float contactDrivePortion = 0.1f;
         [Tooltip("Minimum pull used for strike animation so the cue visibly drives forward every shot.")]
         [Min(0f)] public float minimumVisualPull = 0.025f;
+        [Header("Motion settle")]
+        [Tooltip("Linear velocity threshold used to decide whether a ball is still moving.")]
+        [Min(0f)] public float settleLinearVelocitySqr = 0.0004f;
+        [Tooltip("Angular velocity threshold used to decide whether a ball is still spinning/moving.")]
+        [Min(0f)] public float settleAngularVelocitySqr = 0.0009f;
 
         [Header("Spin input")]
         [Tooltip("Receives normalized spin values from the existing on-screen spin controller.")]
@@ -271,7 +278,40 @@ namespace Aiming
 
         bool AreBallsMoving()
         {
-            return cueBallBody != null && cueBallBody.velocity.sqrMagnitude > 0.0004f;
+            if (IsBodyMoving(cueBallBody))
+            {
+                return true;
+            }
+
+            if (monitoredBallBodies == null || monitoredBallBodies.Length == 0)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < monitoredBallBodies.Length; i++)
+            {
+                if (IsBodyMoving(monitoredBallBodies[i]))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        bool IsBodyMoving(Rigidbody body)
+        {
+            if (body == null)
+            {
+                return false;
+            }
+
+            if (body.velocity.sqrMagnitude > settleLinearVelocitySqr)
+            {
+                return true;
+            }
+
+            return body.angularVelocity.sqrMagnitude > settleAngularVelocitySqr;
         }
 
         IEnumerator StrikeRoutine(float shotPower)


### PR DESCRIPTION
### Motivation
- Fix inconsistent AI behavior where it sometimes switches to overly safe play despite easy legal pots, and only attacks late in the game.  
- Ensure AI/aiming only re-evaluates targets after the full table has settled so decisions use the real, stable table state.  
- Reduce fouls/scratch risk by preferring aim lines that both have higher pot probability and avoid cue-follow/scratch-prone lanes.

### Description
- Added per-table settle gating to the controller by introducing `monitoredBallBodies` and `IsBodyMoving` with configurable `settleLinearVelocitySqr` and `settleAngularVelocitySqr` so `CueController.AreBallsMoving()` waits until every monitored ball is settled before re-aiming (file: `Assets/Scripts/Gameplay/CueController.cs`).
- Improved deterministic shot scoring in `AdaptiveAimingEngine.ScoreAttempt()` to penalize aim candidates that are poorly aligned with the pot line and to penalize scratch-prone cue paths using the new helpers `EvaluatePotLinePenalty()` and `EvaluateScratchRiskPenalty()` (file: `Assets/Scripts/Aiming/AdaptiveAimingEngine.cs`).
- Made Monte Carlo rollouts more realistic by estimating object-ball travel from sampled cue directions via `EstimateObjectTravelDirection()` and using that to compute cut/pocket alignment inside `ScoreMonteCarloRollout()` so stochastic selection better reflects pot probability.
- Added guards for degenerate directions and tuned the combined scoring to blend directional miss, cut penalty, distance penalty, pot-line alignment, and scratch risk for more consistent attacking behavior across the whole frame.

### Testing
- Attempted a headless Unity run with `unity-editor -batchmode -quit`, but the Unity editor binary is not available in this environment so the run failed.  
- No Unity playmode or editor tests were executed in this CI environment; therefore no automated playmode/unit tests passed or failed here.  
- Recommend running Unity playmode tests locally/CI, including `Assets/Tests/PlayMode/DecisionTreeTests.cs`, `Assets/Tests/PlayMode/PocketAimTargetingTests.cs`, and `Assets/Tests/PlayMode/StrategiesTests.cs`, to validate aiming, pocket targeting, and strategy behavior in-editor.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d73a8a4f08832990c11cde0d4b61d7)