### PR TITLE
Improve UK AI attack consistency by prioritizing easy pots

### DIFF
--- a/lib/poolUkAdvancedAi.js
+++ b/lib/poolUkAdvancedAi.js
@@ -57,6 +57,8 @@
  */
 const shotMemory = new Map()
 const MIN_POT_PROBABILITY = 0.44
+const EASY_POT_ATTACK_THRESHOLD = 0.52
+const EASY_POT_FOUL_RISK_CAP = 0.48
 const STRAIGHT_SHOT_THRESHOLD = Math.PI / 15 // ~12 degrees
 const POCKET_MOUTH_WIDTH_FACTOR = 2.45
 const POCKET_ENTRY_DEPTH_FACTOR = 1.85
@@ -918,8 +920,11 @@ function safetyEV (state, colour) {
 
 function evaluateCandidates (state, colour, candidates) {
   let best = null
+  let bestPot = null
+  let bestSafety = null
   for (const c of candidates) {
     let EV = 0
+    let potProbability = 0
     if (c.actionType === 'safety') {
       EV = safetyEV(state, colour)
     } else {
@@ -928,6 +933,7 @@ function evaluateCandidates (state, colour, candidates) {
       const analyticPpot = estimatePotProbability(c, state)
       const mc = monteCarloShotValue(state, c, colour)
       const Ppot = analyticPpot * 0.5 + mc.potProbability * 0.5
+      potProbability = Ppot
       if (Ppot < MIN_POT_PROBABILITY) continue
       const nextState = { ...state, balls: state.balls.map(b => ({ ...b })) }
       const target = nextState.balls.find(b => b.id === c.targetBall.id)
@@ -947,11 +953,18 @@ function evaluateCandidates (state, colour, candidates) {
       const shapeWindow = nextShapeWindow(nextState, colour)
       EV = Ppot * (baseValue + nextBest * positionWeight + straightBoost + shapeWindow * 0.75 + mc.shapeScore * 0.65) - riskPenalty(risk)
     }
+    const scored = { c, EV, potProbability }
     if (!best || EV > best.EV) {
-      best = { c, EV }
+      best = scored
+    }
+    if (c.actionType === 'pot') {
+      if (!bestPot || EV > bestPot.EV) bestPot = scored
+    } else if (!bestSafety || EV > bestSafety.EV) {
+      bestSafety = scored
     }
   }
-  return best
+  if (!best) return null
+  return { ...best, bestPot, bestSafety }
 }
 
 function chooseBestAction (state, colour) {
@@ -997,6 +1010,18 @@ function chooseBestAction (state, colour) {
   if (qualityFiltered.length > 0) {
     candidates = qualityFiltered
   }
+  const attackReadyPots = candidates.filter(c => {
+    if (c.actionType !== 'pot') return false
+    const potProbability = estimatePotProbability(c, state)
+    if (potProbability < EASY_POT_ATTACK_THRESHOLD) return false
+    if (foulRisk(c, state) > EASY_POT_FOUL_RISK_CAP) return false
+    return (c.laneClearance ?? 1) >= 0.62
+  })
+  if (attackReadyPots.length > 0) {
+    // Keep the AI in "attack mode" whenever there is a legal, high-confidence
+    // pot available. This prevents mid-turn drift into unnecessary safeties.
+    candidates = attackReadyPots
+  }
   const straightShots = candidates.filter(
     c => typeof c.angle === 'number' && c.angle <= STRAIGHT_SHOT_THRESHOLD
   )
@@ -1029,6 +1054,13 @@ function chooseBestAction (state, colour) {
   }
 
   let chosen = best
+  if (
+    best.c?.actionType === 'safety' &&
+    best.bestPot &&
+    best.bestPot.potProbability >= EASY_POT_ATTACK_THRESHOLD
+  ) {
+    chosen = best.bestPot
+  }
   if (directPots.length === 0 && best.c.actionType !== 'safety') {
     const safetyOnly = evaluateCandidates(state, colour, generateSafeties(state, colour))
     if (safetyOnly) {


### PR DESCRIPTION
### Motivation
- The UK advanced AI was drifting into safety play even when clear, makeable pots were available, causing inconsistent attacking behavior during a visit.
- The goal is to keep the AI attacking on easy legal pots while still avoiding fouls and high-risk plays.

### Description
- Updated `lib/poolUkAdvancedAi.js` to add `EASY_POT_ATTACK_THRESHOLD` and `EASY_POT_FOUL_RISK_CAP` constants to identify low-risk, high-confidence pots. 
- Enhanced candidate evaluation in `evaluateCandidates` to return bookkeeping for `bestPot` and `bestSafety` and include per-candidate `potProbability` for downstream selection.
- Added an `attackReadyPots` filter in `chooseBestAction` that narrows candidates to legal pots meeting the threshold and foul-risk cap, and forces pot preference when a high-confidence pot exists.
- Kept existing safeguards: foul risk checks, lane clearance, and minimum pot probability remain enforced.

### Testing
- Ran `node --test test/poolUkAdvancedAi.test.js` and all tests passed (6/6 subtests passed). 
- Ran `node --test test/poolAi.test.js` and all tests passed (22/22 subtests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d73a8a4f08832990c11cde0d4b61d7)