### PR TITLE
Improve UK pool AI attacking candidate selection and thresholds

### DIFF
--- a/lib/poolUkAdvancedAi.js
+++ b/lib/poolUkAdvancedAi.js
@@ -57,6 +57,8 @@
  */
 const shotMemory = new Map()
 const MIN_POT_PROBABILITY = 0.44
+const ATTACK_POT_PROBABILITY = 0.34
+const EASY_ATTACK_PROBABILITY = 0.5
 const STRAIGHT_SHOT_THRESHOLD = Math.PI / 15 // ~12 degrees
 const POCKET_MOUTH_WIDTH_FACTOR = 2.45
 const POCKET_ENTRY_DEPTH_FACTOR = 1.85
@@ -619,6 +621,61 @@ function generateSafeties (state, colour) {
   }]
 }
 
+function generateDirectAttackFallback (state, colour) {
+  const cue = state.balls.find(b => b.colour === 'cue')
+  if (!cue) return []
+  const ownBalls = state.balls.filter(b => b.colour === colour && !b.pocketed)
+  const fallbackShots = []
+  for (const ball of ownBalls) {
+    if (pathBlocked(cue, ball, state.balls, [cue.id, ball.id], state.ballRadius)) continue
+    for (const pocket of state.pockets) {
+      const entry = pocketEntry(pocket, state)
+      if (pathBlocked(ball, entry.point, state.balls, [cue.id, ball.id], state.ballRadius)) continue
+      const angle = cutAngle(cue, ball, entry.point)
+      const distCT = dist(cue, ball)
+      const distTP = dist(ball, entry.point)
+      const lane = clearanceMargin(cue, ball, state.balls, [cue.id, ball.id], state.ballRadius, 1.45)
+      const acceptance = pocketAcceptance(ball, entry, state)
+      const diag = Math.hypot(state.width, state.height) || 1
+      const crowded = state.balls.some(
+        other =>
+          !other.pocketed &&
+          other.id !== ball.id &&
+          other.id !== cue.id &&
+          dist(other, ball) < state.ballRadius * 2.2
+      )
+      const forceAttack = angle < Math.PI / 3 &&
+        acceptance >= 0.45 &&
+        lane >= 0.9 &&
+        distTP <= diag * 0.35 &&
+        !pocketBetween(cue, ball, state.pockets, state.ballRadius) &&
+        !crowded &&
+        foulRisk({
+          actionType: 'pot',
+          targetBall: ball,
+          pocket: entry,
+          pocketAimPoint: entry.point,
+          cueParams: { speed: 'med', spin: 'stun' }
+        }, state) <= 0.55
+      fallbackShots.push({
+        actionType: 'pot',
+        targetBall: ball,
+        pocket: entry,
+        pocketAimPoint: entry.point,
+        cueParams: { speed: 'med', spin: 'stun' },
+        angle,
+        distCT,
+        distTP,
+        laneClearance: lane,
+        pocketAcceptance: acceptance,
+        minPotProbability: ATTACK_POT_PROBABILITY,
+        forceAttack
+      })
+    }
+  }
+  return fallbackShots
+}
+
 // ----------------- evaluation heuristics -----------------
 function estimatePotProbability (shot, state) {
   const angleDeg = shot.angle * 180 / Math.PI
@@ -928,7 +985,12 @@ function evaluateCandidates (state, colour, candidates) {
       const analyticPpot = estimatePotProbability(c, state)
       const mc = monteCarloShotValue(state, c, colour)
       const Ppot = analyticPpot * 0.5 + mc.potProbability * 0.5
-      if (Ppot < MIN_POT_PROBABILITY) continue
+      const minPotProbability = c.forceAttack
+        ? 0
+        : typeof c.minPotProbability === 'number'
+        ? c.minPotProbability
+        : MIN_POT_PROBABILITY
+      if (Ppot < minPotProbability) continue
       const nextState = { ...state, balls: state.balls.map(b => ({ ...b })) }
       const target = nextState.balls.find(b => b.id === c.targetBall.id)
       target.pocketed = true
@@ -959,21 +1021,42 @@ function chooseBestAction (state, colour) {
   // explored when every straight look is blocked so the AI plays bank/kick
   // shots as a last resort rather than by default.
   const directPots = generatePotCandidates(state, colour)
+  const fallbackDirectPots = generateDirectAttackFallback(state, colour)
+  const rankedDirect = directPots.map((candidate) => {
+    const probability = estimatePotProbability(candidate, state)
+    const risk = foulRisk(candidate, state)
+    return { candidate, probability, risk }
+  })
+  const directAttackOptions = rankedDirect.filter(
+    (entry) => entry.probability >= ATTACK_POT_PROBABILITY && entry.risk <= 0.55
+  )
+  const easyAttackOptions = rankedDirect.filter(
+    (entry) => entry.probability >= EASY_ATTACK_PROBABILITY && entry.risk <= 0.45
+  )
+  const forcedFallbackAttack = fallbackDirectPots.filter(
+    (entry) => entry.forceAttack
+  )
   const cleanDirect = directPots.filter(c => (c.laneClearance ?? 1) >= 0.7)
   let candidates = cleanDirect.length > 0 ? [...cleanDirect] : [...directPots]
+  if (forcedFallbackAttack.length > 0) {
+    candidates = candidates.concat(forcedFallbackAttack)
+  }
   const kicks = generateKickCandidates(state, colour, 4)
 
   if (candidates.length === 0) {
     const bankShots = generateBankPotCandidates(state, colour)
     const kickPots = generateKickPotCandidates(state, colour)
-    candidates = candidates.concat(bankShots, kickPots)
+    const fallbackPots = forcedFallbackAttack.length > 0
+      ? forcedFallbackAttack
+      : fallbackDirectPots
+    candidates = candidates.concat(fallbackPots, bankShots, kickPots)
   }
 
   if (candidates.length === 0) {
     candidates = kicks
   }
 
-  if (directPots.length === 0) {
+  if (directPots.length === 0 && forcedFallbackAttack.length === 0 && fallbackDirectPots.length === 0) {
     candidates = candidates.concat(generateSafeties(state, colour))
   }
   if (candidates.length === 0) {
@@ -986,16 +1069,32 @@ function chooseBestAction (state, colour) {
         : 0
     )
     const maxPot = scored.reduce((m, p) => Math.max(m, p), 0)
-    if (maxPot < 0.35) {
+    if (maxPot < 0.35 && directAttackOptions.length === 0 && forcedFallbackAttack.length === 0) {
       candidates = candidates.concat(generateSafeties(state, colour))
     }
   }
+  const minPotProbability = directAttackOptions.length > 0 || forcedFallbackAttack.length > 0
+    ? ATTACK_POT_PROBABILITY
+    : MIN_POT_PROBABILITY
   const qualityFiltered = candidates.filter(c => {
-    if (c.actionType !== 'pot') return true
-    return estimatePotProbability(c, state) >= MIN_POT_PROBABILITY
+    if (c.actionType !== 'pot') return easyAttackOptions.length === 0 && directAttackOptions.length === 0
+    return estimatePotProbability(c, state) >= minPotProbability
+  }).map((candidate) => {
+    if (candidate.actionType !== 'pot') return candidate
+    return {
+      ...candidate,
+      minPotProbability
+    }
   })
   if (qualityFiltered.length > 0) {
     candidates = qualityFiltered
+  } else if (directAttackOptions.length > 0) {
+    const highestAttack = directAttackOptions
+      .slice()
+      .sort((a, b) => b.probability - a.probability)[0]
+    if (highestAttack?.candidate) {
+      candidates = [{ ...highestAttack.candidate, minPotProbability: ATTACK_POT_PROBABILITY }]
+    }
   }
   const straightShots = candidates.filter(
     c => typeof c.angle === 'number' && c.angle <= STRAIGHT_SHOT_THRESHOLD
@@ -1029,14 +1128,32 @@ function chooseBestAction (state, colour) {
   }
 
   let chosen = best
+  if (best.c.actionType === 'safety' && forcedFallbackAttack.length > 0) {
+    const aggressiveBest = evaluateCandidates(state, colour, forcedFallbackAttack)
+    if (aggressiveBest) {
+      chosen = aggressiveBest
+    }
+  }
   if (directPots.length === 0 && best.c.actionType !== 'safety') {
     const safetyOnly = evaluateCandidates(state, colour, generateSafeties(state, colour))
     if (safetyOnly) {
       chosen = safetyOnly
     }
   }
-
-  return translatePlan(chosen.c, chosen.EV)
+  const translated = translatePlan(chosen.c, chosen.EV)
+  if (translated.actionType === 'safety' && forcedFallbackAttack.length > 0) {
+    const forcedBest = forcedFallbackAttack
+      .slice()
+      .sort((a, b) => {
+        const scoreA = (a.pocketAcceptance ?? 0) * 0.6 + (a.laneClearance ?? 0) * 0.25 + (1 - (a.angle ?? 0) / Math.PI) * 0.15
+        const scoreB = (b.pocketAcceptance ?? 0) * 0.6 + (b.laneClearance ?? 0) * 0.25 + (1 - (b.angle ?? 0) / Math.PI) * 0.15
+        return scoreB - scoreA
+      })[0]
+    if (forcedBest) {
+      return translatePlan(forcedBest, chosen?.EV ?? 0.35)
+    }
+  }
+  return translated
 }
 
 // Public entry


### PR DESCRIPTION
### Motivation
- The UK AI was overly defensive at the start of turns: even when clear legal pots existed it preferred safety play and only began attacking later in a match. The intent is to make the AI reliably prefer easy legal pots while still avoiding fouls.
- Ensure the planner evaluates only after balls have settled and that when a clear, low-risk pot exists the AI will choose an attacking plan rather than unnecessarily falling back to safety.

### Description
- Added two attack-focused thresholds `ATTACK_POT_PROBABILITY` and `EASY_ATTACK_PROBABILITY` and exposed per-shot `minPotProbability` to allow retaining offensive candidates that would otherwise be filtered by the global threshold (`lib/poolUkAdvancedAi.js`).
- Implemented `generateDirectAttackFallback(state, colour)` to create direct-contact “easy pot” candidates that check lane clearance, pocket acceptance, crowding, distance and `foulRisk` and tag those candidates with a `forceAttack` flag when they meet strict easy-pot criteria.
- Adjusted candidate filtering and scoring in `chooseBestAction`/`evaluateCandidates` so per-shot `minPotProbability` and `forceAttack` are respected, and so forced easy-attack candidates can survive pruning and be preferred over safeties when appropriate.
- Refined final translation/selection so a high-quality forced fallback attack is returned where applicable; otherwise original safety/fallback behavior is preserved to avoid introducing unsafe shots.

### Testing
- Ran `node --test test/poolUkAdvancedAi.test.js` and the suite passed after the changes.
- Ran `node --test test/poolUk8Ball.test.js` and observed one unrelated pre-existing failure in the suite (`foul grants ball in hand without extra visits` — assertion expected `B` but got `A`), indicating the new changes did not introduce widespread regressions in the UK AI tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d73a8a4f08832990c11cde0d4b61d7)