### PR TITLE
Improve Pool Royale AI attacking consistency and shot planning

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -26905,7 +26905,7 @@ const powerRef = useRef(hud.power);
           // Keep shot-selection behavior consistent across the whole AI turn.
           // Prioritizing leave-position only after the opening shot made later shots
           // feel less accurate than the first one.
-          const shouldAnalyzeLeave = false;
+          const shouldAnalyzeLeave = true;
           const isRotationVariant =
             activeVariantId === 'american' || activeVariantId === '9ball';
           const activeBalls = ballsList.filter((b) => b.active);
@@ -27590,17 +27590,30 @@ const powerRef = useRef(hud.power);
               a.difficulty - b.difficulty
           );
           const playableCushionPots = scoredPots.filter(
-            (entry) => entry.plan && isPlayablePlan(entry.plan, { allowCushion: true })
+            (entry) =>
+              entry.plan &&
+              Number.isFinite(entry.score) &&
+              entry.score > -Infinity &&
+              isPlayablePlan(entry.plan, { allowCushion: true })
           );
+          const strongAttackingPot = playableCushionPots.find(({ plan }) => {
+            const potChance = Number.isFinite(plan?.potChance) ? plan.potChance : plan?.quality ?? 0;
+            const contactConfidence = Number.isFinite(plan?.contactConfidence)
+              ? plan.contactConfidence
+              : plan?.viaCushion
+                ? 0.82
+                : 0.9;
+            return potChance >= 0.42 && contactConfidence >= 0.72;
+          });
           const relaxedPot =
             scoredPots.find((entry) => entry?.plan && isFirstContactLegal(entry.plan))?.plan ??
             scoredPots[0]?.plan ??
             null;
-          const bestPot = playableCushionPots[0]?.plan ?? relaxedPot;
+          const bestPot = strongAttackingPot?.plan ?? playableCushionPots[0]?.plan ?? relaxedPot;
           const bestSafetyCandidate =
             safetyShots.find((plan) => isPlayablePlan(plan, { allowCushion: true })) ?? null;
-          const bestSafety =
-            activeVariantId === 'uk' && bestPot ? null : bestSafetyCandidate;
+          const shouldUseSafety = !bestPot;
+          const bestSafety = shouldUseSafety ? bestSafetyCandidate : null;
           const relaxedSafety =
             !bestPot && !bestSafety
               ? safetyShots.find((plan) => plan && isFirstContactLegal(plan)) ?? safetyShots[0] ?? null


### PR DESCRIPTION
### Motivation
- The AI was switching to defensive/safety play even when clear, easy pot opportunities existed early in a frame, causing inconsistent attacking behavior from start to finish.
- The AI must evaluate only after balls are settled and select the plan that maximizes pot probability while avoiding fouls/scratches and preserving a good cue-ball leave.

### Description
- Enabled next-shot leave analysis by setting `shouldAnalyzeLeave = true` inside `evaluateShotOptionsBaseline` so pot scoring accounts for cue-ball position after a successful pot (file: `webapp/src/pages/Games/PoolRoyale.jsx`).
- Tightened pot-plan filtering to require finite plan scores before considering them (`scoredPots` -> `playableCushionPots`) so only legal/playable pot plans are promoted.
- Added a `strongAttackingPot` heuristic that prefers plans with `potChance >= 0.42` and sufficient `contactConfidence` and made `bestPot` prefer this plan before other pot fallbacks.
- Changed safety selection so a safety is chosen only when no viable `bestPot` exists, preventing passive choices when legal pot opportunities are present.

### Testing
- Ran `npm test -- --runInBand test/poolAi.test.js test/poolRoyaleAimSuggestion.test.js` and both suites passed.  
- Test results: `test/poolAi.test.js` — PASS, `test/poolRoyaleAimSuggestion.test.js` — PASS.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d73a8a4f08832990c11cde0d4b61d7)