### PR TITLE
Improve Pool UK AI attacking consistency and shot timing checks

### DIFF
--- a/lib/poolUkAdvancedAi.js
+++ b/lib/poolUkAdvancedAi.js
@@ -56,7 +56,8 @@
  * Each entry: { success:number, attempts:number }
  */
 const shotMemory = new Map()
-const MIN_POT_PROBABILITY = 0.44
+const MIN_POT_PROBABILITY = 0.32
+const EASY_POT_PROBABILITY = 0.5
 const STRAIGHT_SHOT_THRESHOLD = Math.PI / 15 // ~12 degrees
 const POCKET_MOUTH_WIDTH_FACTOR = 2.45
 const POCKET_ENTRY_DEPTH_FACTOR = 1.85
@@ -495,6 +496,43 @@ function generateKickPotCandidates (state, colour) {
     }
   }
 
+  return shots
+}
+
+function generateAggressivePotCandidates (state, colour) {
+  // Relaxed fallback used to keep the AI attacking when a legal target is
+  // available but strict pocket heuristics reject every standard pot.
+  const cue = state.balls.find(b => b.colour === 'cue')
+  const balls = visibleOwnBalls(state, colour)
+  const shots = []
+  for (const ball of balls) {
+    for (const pocket of state.pockets) {
+      const entry = pocketEntry(pocket, state)
+      if (pathBlocked(ball, entry.point, state.balls, [cue.id, ball.id], state.ballRadius)) continue
+      const acceptance = pocketAcceptance(ball, entry, state)
+      if (acceptance < 0.12) continue
+      const angle = cutAngle(cue, ball, entry.point)
+      if (!Number.isFinite(angle) || angle > Math.PI * 0.8) continue
+      const distCT = dist(cue, ball)
+      const distTP = dist(ball, entry.point)
+      shots.push({
+        actionType: 'pot',
+        targetBall: ball,
+        pocket: entry,
+        pocketAimPoint: entry.point,
+        cueParams: { speed: 'med', spin: 'stun' },
+        angle,
+        distCT,
+        distTP,
+        laneClearance: Math.max(
+          0.6,
+          clearanceMargin(cue, ball, state.balls, [cue.id, ball.id], state.ballRadius, 1.45)
+        ),
+        pocketAcceptance: Math.max(acceptance, 0.2),
+        aggressiveFallback: true
+      })
+    }
+  }
   return shots
 }
 
@@ -964,6 +1002,13 @@ function chooseBestAction (state, colour) {
   const kicks = generateKickCandidates(state, colour, 4)
 
   if (candidates.length === 0) {
+    const aggressive = generateAggressivePotCandidates(state, colour)
+    if (aggressive.length > 0) {
+      candidates = aggressive
+    }
+  }
+
+  if (candidates.length === 0) {
     const bankShots = generateBankPotCandidates(state, colour)
     const kickPots = generateKickPotCandidates(state, colour)
     candidates = candidates.concat(bankShots, kickPots)
@@ -979,16 +1024,6 @@ function chooseBestAction (state, colour) {
   if (candidates.length === 0) {
     // No clear potting opportunity – fall back to defensive play.
     candidates = generateSafeties(state, colour)
-  } else {
-    const scored = candidates.map(c =>
-      c.actionType === 'pot'
-        ? estimatePotProbability(c, state)
-        : 0
-    )
-    const maxPot = scored.reduce((m, p) => Math.max(m, p), 0)
-    if (maxPot < 0.35) {
-      candidates = candidates.concat(generateSafeties(state, colour))
-    }
   }
   const qualityFiltered = candidates.filter(c => {
     if (c.actionType !== 'pot') return true
@@ -996,6 +1031,13 @@ function chooseBestAction (state, colour) {
   })
   if (qualityFiltered.length > 0) {
     candidates = qualityFiltered
+  }
+  const easyPotCandidates = candidates.filter(
+    c => c.actionType === 'pot' && estimatePotProbability(c, state) >= EASY_POT_PROBABILITY
+  )
+  if (easyPotCandidates.length > 0) {
+    // Keep attacking consistency whenever we have legal high-confidence pots.
+    candidates = easyPotCandidates
   }
   const straightShots = candidates.filter(
     c => typeof c.angle === 'number' && c.angle <= STRAIGHT_SHOT_THRESHOLD
@@ -1028,19 +1070,20 @@ function chooseBestAction (state, colour) {
     }
   }
 
-  let chosen = best
-  if (directPots.length === 0 && best.c.actionType !== 'safety') {
-    const safetyOnly = evaluateCandidates(state, colour, generateSafeties(state, colour))
-    if (safetyOnly) {
-      chosen = safetyOnly
-    }
-  }
-
-  return translatePlan(chosen.c, chosen.EV)
+  return translatePlan(best.c, best.EV)
 }
 
 // Public entry
 export function selectShot (state, rules = {}) {
+  // AI should only commit to target selection once balls are fully stationary.
+  const ballsStillMoving = state?.balls?.some(ball => {
+    const vx = Number(ball?.vx ?? 0)
+    const vy = Number(ball?.vy ?? 0)
+    const speed = Number(ball?.speed ?? Math.hypot(vx, vy))
+    return Number.isFinite(speed) && speed > 0.02
+  })
+  if (ballsStillMoving) return null
+
   let colour = normaliseBallOn(state.ballOn) ?? state.ballOn
   if (!state.isOpenTable && colour) {
     const hasOwn = state.balls.some(b => b.colour === colour && !b.pocketed)

--- a/test/poolUkAdvancedAi.test.js
+++ b/test/poolUkAdvancedAi.test.js
@@ -146,3 +146,21 @@ test('avoids clustered targets', () => {
   const plan = selectShot(state, {});
   assert.equal(plan.actionType, 'safety');
 });
+
+test('waits for balls to stop before planning a shot', () => {
+  const state = {
+    balls: [
+      { id: 0, colour: 'cue', x: 100, y: 200, vx: 0.1, vy: 0 },
+      { id: 1, colour: 'blue', x: 220, y: 200 }
+    ],
+    pockets: makePockets(),
+    width: 1000,
+    height: 500,
+    ballRadius: 10,
+    ballOn: 'blue',
+    isOpenTable: false,
+    shotsRemaining: 1
+  };
+  const plan = selectShot(state, {});
+  assert.equal(plan, null);
+});


### PR DESCRIPTION
### Motivation
- Fix AI behavior that played safe despite easy legal pots and introduce consistent attacking from opening shot to endgame. 
- Ensure the AI only chooses its next shot after balls have come to rest to avoid planning while physics are still resolving. 

### Description
- Lowered strict pot-quality floor and added an `EASY_POT_PROBABILITY` band so high-confidence pots are preferred and keep the AI attacking (changes in `lib/poolUkAdvancedAi.js`).
- Added `generateAggressivePotCandidates` to relax pocket acceptance when strict filters remove all viable pot lines so the AI still evaluates legal attacking options.
- Removed the unconditional safety re-insertion that could override evaluated attacking plans and simplified the final choice to return the best-evaluated candidate directly.
- Added a stationary-ball guard to `selectShot` so the function returns `null` while any ball reports nontrivial motion and updated tests in `test/poolUkAdvancedAi.test.js` to validate this behavior.

### Testing
- Ran `npm test -- test/poolUkAdvancedAi.test.js` and the suite passed (all tests in that file succeeded).
- Ran `npm test -- test/poolUk8Ball.test.js -t "AI plays safety when own ball is blocked|AI targets black when own balls cleared"` and the targeted checks passed.
- Changes touch `lib/poolUkAdvancedAi.js` and `test/poolUkAdvancedAi.test.js` and the automated tests above passed after the adjustments.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d74c19ff9c8329b78b10b347aef73d)