### PR TITLE
Improve UK AI attacking consistency on makeable shots

### DIFF
--- a/lib/poolUkAdvancedAi.js
+++ b/lib/poolUkAdvancedAi.js
@@ -58,6 +58,11 @@
 const shotMemory = new Map()
 const MIN_POT_PROBABILITY = 0.44
 const STRAIGHT_SHOT_THRESHOLD = Math.PI / 15 // ~12 degrees
+const EASY_POT_FORCE_ATTACK_PROBABILITY = 0.58
+const EASY_POT_FORCE_ATTACK_RISK = 0.2
+const ATTACK_IF_COMPETITIVE_PROBABILITY = 0.47
+const ATTACK_IF_COMPETITIVE_RISK = 0.34
+const ATTACK_EV_MARGIN = 0.08
 const POCKET_MOUTH_WIDTH_FACTOR = 2.45
 const POCKET_ENTRY_DEPTH_FACTOR = 1.85
 const JAW_GUARD_FACTOR = 1.18
@@ -916,19 +921,29 @@ function safetyEV (state, colour) {
   return 0.3 + 0.4 * (d / maxD)
 }
 
+function evaluatePotProfile (state, colour, shot) {
+  const risk = foulRisk(shot, state)
+  if (risk > 0.65) return null
+  const analyticPpot = estimatePotProbability(shot, state)
+  const mc = monteCarloShotValue(state, shot, colour)
+  const Ppot = analyticPpot * 0.5 + mc.potProbability * 0.5
+  if (Ppot < MIN_POT_PROBABILITY) return null
+  return { risk, Ppot, shapeScore: mc.shapeScore }
+}
+
 function evaluateCandidates (state, colour, candidates) {
   let best = null
+  let bestPot = null
+  let bestSafety = null
   for (const c of candidates) {
     let EV = 0
+    let potProfile = null
     if (c.actionType === 'safety') {
       EV = safetyEV(state, colour)
     } else {
-      const risk = foulRisk(c, state)
-      if (risk > 0.65) continue
-      const analyticPpot = estimatePotProbability(c, state)
-      const mc = monteCarloShotValue(state, c, colour)
-      const Ppot = analyticPpot * 0.5 + mc.potProbability * 0.5
-      if (Ppot < MIN_POT_PROBABILITY) continue
+      potProfile = evaluatePotProfile(state, colour, c)
+      if (!potProfile) continue
+      const { risk, Ppot, shapeScore } = potProfile
       const nextState = { ...state, balls: state.balls.map(b => ({ ...b })) }
       const target = nextState.balls.find(b => b.id === c.targetBall.id)
       target.pocketed = true
@@ -945,10 +960,30 @@ function evaluateCandidates (state, colour, candidates) {
       const straightBoost = typeof c.angle === 'number' ? Math.max(0, (Math.PI / 10 - c.angle) / (Math.PI / 10)) * 0.25 : 0
       const positionWeight = 1.4
       const shapeWindow = nextShapeWindow(nextState, colour)
-      EV = Ppot * (baseValue + nextBest * positionWeight + straightBoost + shapeWindow * 0.75 + mc.shapeScore * 0.65) - riskPenalty(risk)
+      EV = Ppot * (baseValue + nextBest * positionWeight + straightBoost + shapeWindow * 0.75 + shapeScore * 0.65) - riskPenalty(risk)
     }
+    const scored = { c, EV, ...(potProfile || {}) }
     if (!best || EV > best.EV) {
-      best = { c, EV }
+      best = scored
+    }
+    if (c.actionType === 'pot') {
+      if (!bestPot || EV > bestPot.EV) bestPot = scored
+    } else if (!bestSafety || EV > bestSafety.EV) {
+      bestSafety = scored
+    }
+  }
+  if (bestPot) {
+    const isEasyHighValuePot =
+      bestPot.Ppot >= EASY_POT_FORCE_ATTACK_PROBABILITY &&
+      bestPot.risk <= EASY_POT_FORCE_ATTACK_RISK
+    if (isEasyHighValuePot) return bestPot
+    if (
+      bestSafety &&
+      bestPot.Ppot >= ATTACK_IF_COMPETITIVE_PROBABILITY &&
+      bestPot.risk <= ATTACK_IF_COMPETITIVE_RISK &&
+      bestPot.EV >= bestSafety.EV - ATTACK_EV_MARGIN
+    ) {
+      return bestPot
     }
   }
   return best


### PR DESCRIPTION
### Motivation
- Players reported the AI opening with defensive/safety plays even when clear, easy pots existed, causing inconsistent attacking behavior across the rack; the change aims to make the AI prefer sensible attacking options earlier and maintain consistency throughout a turn. 
- The intent is to centralize pot-quality scoring and make attack-vs-safety decisions depend on clear, numeric thresholds (pot probability, foul risk, EV margin) rather than occasionally favouring safeties by default.

### Description
- Added explicit attack thresholds and tuning constants (`EASY_POT_FORCE_ATTACK_PROBABILITY`, `EASY_POT_FORCE_ATTACK_RISK`, `ATTACK_IF_COMPETITIVE_PROBABILITY`, `ATTACK_IF_COMPETITIVE_RISK`, `ATTACK_EV_MARGIN`) to bias decision-making toward clear makeable pots.  
- Introduced `evaluatePotProfile(state, colour, shot)` to produce a consistent pot profile (`risk`, blended `Ppot`, `shapeScore`) and perform the initial probability/risk gate.  
- Refactored `evaluateCandidates` to track the best pot and the best safety separately, compute EV using the pot profile (including MC `shapeScore`), and prefer returning the best pot when it meets the easy/competitive attack criteria; otherwise fall back to the original safety/pot EV comparison.  
- Kept existing foul-avoidance and minimum-probability gating but centralized and re-used the checks to reduce duplicated logic (file changed: `lib/poolUkAdvancedAi.js`).

### Testing
- Ran `node --check lib/poolUkAdvancedAi.js` to validate syntax, which completed successfully.  
- Reviewed the diff to ensure changes are isolated to `lib/poolUkAdvancedAi.js` and that no runtime-breaking edits were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d74c19ff9c8329b78b10b347aef73d)