### PR TITLE
Pool Royale AI: prefer attacking baseline pot when available

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -27875,6 +27875,16 @@ const powerRef = useRef(hud.power);
             const stateSnapshot = frameRef.current ?? frameState;
             const advancedPlan = computeUkAdvancedPlan(balls, cue, stateSnapshot);
             if (!advancedPlan) return baseline;
+            const baselinePot = baseline?.bestPot ?? null;
+            const baselinePotChance = Number.isFinite(baselinePot?.potChance)
+              ? baselinePot.potChance
+              : Number.isFinite(baselinePot?.quality)
+                ? baselinePot.quality
+                : 0;
+            const baselinePotLooksAttackable =
+              baselinePot?.type === 'pot' &&
+              baselinePot?.targetBall?.active &&
+              baselinePotChance >= 0.4;
             const result = { ...baseline };
             if (advancedPlan.type === 'pot') {
               result.bestPot = advancedPlan;
@@ -27882,6 +27892,13 @@ const powerRef = useRef(hud.power);
             } else {
               result.bestSafety = advancedPlan;
               if (!result.bestPot) result.bestPot = baseline.bestPot;
+              // Keep AI attacking whenever a legal pot is reasonably makeable.
+              // This prevents the mid-rack drift toward repetitive safeties when
+              // the baseline planner still sees clear pot routes.
+              if (baselinePotLooksAttackable) {
+                result.bestPot = baselinePot;
+                result.bestSafety = null;
+              }
             }
             return result;
           } catch (err) {


### PR DESCRIPTION
### Motivation
- Fix inconsistent AI behavior where the advanced UK planner would choose a safety even though the baseline evaluator still had a clear, legal pot available, causing the AI to shift from attacking early to overly defensive mid-rack. 
- Ensure the AI remains consistently aggressive when a reasonable pot exists while retaining advanced-planner benefits for stronger pot picks.

### Description
- Added logic to `evaluateShotOptions` in `webapp/src/pages/Games/PoolRoyale.jsx` to compute a `baselinePotLooksAttackable` gate using the baseline `bestPot`'s `potChance` or `quality` and whether the `targetBall` is active. 
- When the advanced UK planner returns a `safety` but `baselinePotLooksAttackable` is true, the code now forces `result.bestPot` to the baseline pot and clears the safety (`result.bestSafety = null`).
- Kept the original behavior where an advanced-plan pot overrides the baseline, only intervening when advanced suggests safety but a baseline pot remains reasonably makeable.

### Testing
- Ran the linter with `npm run -s lint -- webapp/src/pages/Games/PoolRoyale.jsx`, which surfaced pre-existing repository-wide lint issues and ignore-pattern behavior and therefore did not produce a clean pass (lint failed due to unrelated, large repo errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d74c19ff9c8329b78b10b347aef73d)