### PR TITLE
Add cinematic piece-aware capture effects and SFX to Chess Battle Royal

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -593,6 +593,95 @@ input:focus {
   animation: bomb-pop 1s forwards;
 }
 
+.chess-capture-slash,
+.chess-capture-drone,
+.chess-capture-missile,
+.chess-capture-shockwave {
+  transform: translate(-50%, -50%);
+  font-size: 2rem;
+  will-change: transform, opacity, left, top;
+}
+
+.chess-capture-slash {
+  animation: chess-slash-pop 340ms ease-out forwards;
+}
+
+.chess-capture-drone {
+  animation: chess-drone-fly 680ms ease-in-out forwards;
+}
+
+.chess-capture-missile {
+  animation: chess-missile-strike 620ms ease-in forwards;
+}
+
+.chess-capture-shockwave {
+  animation: chess-shockwave-pop 520ms ease-out forwards;
+}
+
+@keyframes chess-slash-pop {
+  0% {
+    opacity: 0;
+    transform: translate(-70%, -52%) scale(0.8) rotate(-20deg);
+  }
+  35% {
+    opacity: 1;
+    transform: translate(-52%, -50%) scale(1.3) rotate(12deg);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(-42%, -46%) scale(1.7) rotate(24deg);
+  }
+}
+
+@keyframes chess-drone-fly {
+  0% {
+    opacity: 0;
+    left: var(--fx-x-start, auto);
+    top: var(--fx-y-start, auto);
+    transform: translate(-50%, -50%) scale(0.8);
+  }
+  20% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+    left: var(--fx-x-end, auto);
+    top: var(--fx-y-end, auto);
+    transform: translate(-50%, -50%) scale(1.1);
+  }
+}
+
+@keyframes chess-missile-strike {
+  0% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(0.7) rotate(-15deg);
+  }
+  20% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+    left: var(--fx-x-end, auto);
+    top: var(--fx-y-end, auto);
+    transform: translate(-50%, -50%) scale(1.25) rotate(8deg);
+  }
+}
+
+@keyframes chess-shockwave-pop {
+  0% {
+    opacity: 0.2;
+    transform: translate(-50%, -50%) scale(0.65);
+  }
+  30% {
+    opacity: 1;
+    transform: translate(-50%, -50%) scale(1.15);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(2.1);
+  }
+}
+
 @keyframes bomb-pop {
   to {
     transform: scale(3);

--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -988,6 +988,11 @@ const CHECK_SOUND_URL =
 const CHECKMATE_SOUND_URL =
   'https://raw.githubusercontent.com/lichess-org/lila/master/public/sound/standard/End.mp3';
 const LAUGH_SOUND_URL = '/assets/sounds/Haha.mp3';
+const CAPTURE_STYLE = Object.freeze({
+  SLASH: 'slash',
+  BLAST: 'blast',
+  DRONE: 'drone'
+});
 
 const BEAUTIFUL_GAME_THEME_CONFIGS = Object.freeze([
   {
@@ -8754,6 +8759,96 @@ function Chess3D({
     }
     clearHighlightsRef.current = clearHighlights;
 
+    let captureFxAudioCtx = null;
+    const getCaptureFxAudioCtx = () => {
+      if (typeof window === 'undefined') return null;
+      if (captureFxAudioCtx) return captureFxAudioCtx;
+      const AudioContextCtor = window.AudioContext || window.webkitAudioContext;
+      if (!AudioContextCtor) return null;
+      captureFxAudioCtx = new AudioContextCtor();
+      return captureFxAudioCtx;
+    };
+    const playCaptureSynth = (style) => {
+      if (!settingsRef.current.soundEnabled) return;
+      const ctx = getCaptureFxAudioCtx();
+      if (!ctx) return;
+      const now = ctx.currentTime;
+      const gain = ctx.createGain();
+      gain.connect(ctx.destination);
+      gain.gain.setValueAtTime(0.001, now);
+      if (style === CAPTURE_STYLE.SLASH) {
+        const osc = ctx.createOscillator();
+        osc.type = 'sawtooth';
+        osc.frequency.setValueAtTime(900, now);
+        osc.frequency.exponentialRampToValueAtTime(230, now + 0.12);
+        gain.gain.exponentialRampToValueAtTime(0.09, now + 0.01);
+        gain.gain.exponentialRampToValueAtTime(0.001, now + 0.14);
+        osc.connect(gain);
+        osc.start(now);
+        osc.stop(now + 0.16);
+        return;
+      }
+      if (style === CAPTURE_STYLE.DRONE) {
+        const osc = ctx.createOscillator();
+        osc.type = 'triangle';
+        osc.frequency.setValueAtTime(420, now);
+        osc.frequency.exponentialRampToValueAtTime(120, now + 0.36);
+        gain.gain.exponentialRampToValueAtTime(0.06, now + 0.03);
+        gain.gain.exponentialRampToValueAtTime(0.001, now + 0.38);
+        osc.connect(gain);
+        osc.start(now);
+        osc.stop(now + 0.4);
+      }
+    };
+    const worldToViewport = (pos) => {
+      const rect = renderer.domElement.getBoundingClientRect();
+      const v = pos.clone().project(camera);
+      return {
+        x: rect.left + ((v.x + 1) / 2) * rect.width,
+        y: rect.top + ((-v.y + 1) / 2) * rect.height
+      };
+    };
+    const spawnOverlayFx = ({ className, text, worldPos, durationMs = 650, styles = {} }) => {
+      if (typeof document === 'undefined' || !worldPos) return null;
+      const point = worldToViewport(worldPos);
+      const el = document.createElement('div');
+      el.className = className;
+      el.textContent = text;
+      el.style.position = 'fixed';
+      el.style.left = `${point.x}px`;
+      el.style.top = `${point.y}px`;
+      el.style.setProperty('--fx-x-start', `${point.x}px`);
+      el.style.setProperty('--fx-y-start', `${point.y}px`);
+      el.style.setProperty('--fx-x-end', `${point.x}px`);
+      el.style.setProperty('--fx-y-end', `${point.y}px`);
+      el.style.pointerEvents = 'none';
+      el.style.zIndex = '220';
+      Object.entries(styles).forEach(([key, value]) => {
+        el.style.setProperty(key, value);
+      });
+      document.body.appendChild(el);
+      window.setTimeout(() => {
+        try {
+          el.remove();
+        } catch {}
+      }, durationMs);
+      return el;
+    };
+    const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+    const animatePieceToPromise = (mesh, target, duration = 0.28) =>
+      new Promise((resolve) => {
+        animatePieceTo(mesh, target, duration, resolve);
+      });
+    const resolveCaptureStyle = (pieceType, moveDistance) => {
+      if ((pieceType === 'B' || pieceType === 'Q' || pieceType === 'R') && moveDistance >= 3) {
+        return CAPTURE_STYLE.DRONE;
+      }
+      if (moveDistance <= 1.6 || pieceType === 'P' || pieceType === 'N' || pieceType === 'K') {
+        return CAPTURE_STYLE.SLASH;
+      }
+      return CAPTURE_STYLE.BLAST;
+    };
+
     const isPlayerPiece = (piece) => {
       if (!piece) return false;
       if (onlineRef.current.enabled) {
@@ -8808,7 +8903,7 @@ function Chess3D({
       if (captureSquares.length) highlightMoves(captureSquares, palette?.capture);
     }
 
-    function moveSelTo(rr, cc, options = {}) {
+    async function moveSelTo(rr, cc, options = {}) {
       const { byAi = false } = options;
       const finalizeAiMove = () => {
         if (byAi) aiMovingRef.current = false;
@@ -8852,9 +8947,17 @@ function Chess3D({
       const capturedPieceLabel = capturedPiece ? PIECE_LABELS[capturedPiece.t] || 'piece' : null;
       const fromSquare = resolveChessSquare(sel.r, sel.c);
       const toSquare = resolveChessSquare(rr, cc);
+      const moveDistance = Math.max(Math.abs(rr - sel.r), Math.abs(cc - sel.c));
+      const captureStyle = capturedPiece
+        ? resolveCaptureStyle(movingPiece?.t, moveDistance)
+        : null;
       // capture mesh if any
       const targetMesh = pieceMeshes[rr][cc];
-      if (targetMesh) {
+      const movingMesh = pieceMeshes[sel.r][sel.c];
+      let captureResolved = false;
+      const resolveCaptureMesh = async () => {
+        if (!targetMesh || captureResolved) return;
+        captureResolved = true;
         const worldPos = new THREE.Vector3();
         targetMesh.getWorldPosition(worldPos);
         const capturingWhite = board[sel.r][sel.c].w;
@@ -8871,17 +8974,73 @@ function Chess3D({
           : -half - BOARD.rim - 1 - row * captureRowSpacing;
         cancelPieceAnimation(targetMesh);
         targetMesh.position.y = captureY;
-        animatePieceTo(
+        await animatePieceToPromise(
           targetMesh,
           new THREE.Vector3(capX, captureY, capZ),
           0.35
         );
+        pieceMeshes[rr][cc] = null;
         createExplosion(worldPos);
         if (bombSoundRef.current && settingsRef.current.soundEnabled) {
           bombSoundRef.current.currentTime = 0;
           bombSoundRef.current.play().catch(() => {});
         }
-        pieceMeshes[rr][cc] = null;
+      };
+      if (targetMesh) {
+        const fromPos = piecePosition(sel.r, sel.c, currentPieceYOffset);
+        const targetPos = piecePosition(rr, cc, currentPieceYOffset);
+        if (captureStyle === CAPTURE_STYLE.SLASH && movingMesh) {
+          playCaptureSynth(CAPTURE_STYLE.SLASH);
+          spawnOverlayFx({
+            className: 'chess-capture-slash',
+            text: '⚔️',
+            worldPos: targetPos,
+            durationMs: 340
+          });
+          const lungePos = targetPos.clone().lerp(fromPos, 0.35);
+          cancelPieceAnimation(movingMesh);
+          await animatePieceToPromise(movingMesh, lungePos, 0.16);
+          await resolveCaptureMesh();
+        } else if (captureStyle === CAPTURE_STYLE.DRONE) {
+          playCaptureSynth(CAPTURE_STYLE.DRONE);
+          const drone = spawnOverlayFx({
+            className: 'chess-capture-drone',
+            text: '🛸',
+            worldPos: fromPos,
+            durationMs: 700
+          });
+          const missile = spawnOverlayFx({
+            className: 'chess-capture-missile',
+            text: '🚀',
+            worldPos: fromPos.clone().lerp(targetPos, 0.55),
+            durationMs: 700
+          });
+          const end = worldToViewport(targetPos);
+          if (drone) {
+            drone.style.setProperty('--fx-x-end', `${end.x}px`);
+            drone.style.setProperty('--fx-y-end', `${end.y - 16}px`);
+          }
+          if (missile) {
+            missile.style.setProperty('--fx-x-end', `${end.x}px`);
+            missile.style.setProperty('--fx-y-end', `${end.y}px`);
+          }
+          await wait(320);
+          spawnOverlayFx({
+            className: 'chess-capture-shockwave',
+            text: '💥',
+            worldPos: targetPos,
+            durationMs: 520
+          });
+          await resolveCaptureMesh();
+        } else {
+          spawnOverlayFx({
+            className: 'chess-capture-shockwave',
+            text: '💥',
+            worldPos: targetPos,
+            durationMs: 460
+          });
+          await resolveCaptureMesh();
+        }
       }
       // move board
       const movedPiece = movingPiece;
@@ -8921,7 +9080,7 @@ function Chess3D({
       m.userData.t = board[rr][cc].t;
       cancelPieceAnimation(m);
       const targetPosition = piecePosition(rr, cc, currentPieceYOffset);
-      animatePieceTo(m, targetPosition, 0.32);
+      await animatePieceToPromise(m, targetPosition, 0.32);
       if (isCastlingMove && Number.isInteger(rookFromC)) {
         pieceMeshes[sel.r][rookFromC] = null;
       }


### PR DESCRIPTION
### Motivation
- Improve feedback and spectacle for captures by adding per-piece cinematic effects (sword slash, explosion/blast, drone+missile) so captures feel distinct and rewarding. 
- Make long-range captures (bishops/rooks/queens) visually different from short-range captures (pawns/knights/kings) and ensure audio/visual sequencing runs before movement resolves.

### Description
- Added a capture style enum `CAPTURE_STYLE` and routing logic via `resolveCaptureStyle(pieceType, moveDistance)` to choose `slash`, `blast`, or `drone` effects. 
- Implemented WebAudio synth SFX helper `playCaptureSynth` (lightweight synthesized SFX for `SLASH` and `DRONE`) and an audio context factory `getCaptureFxAudioCtx`. 
- Added overlay FX helpers `worldToViewport`, `spawnOverlayFx`, `wait`, and `animatePieceToPromise` and wired them into capture flow so overlay icons (`⚔️`, `🛸`, `🚀`, `💥`) animate over the board. 
- Converted `moveSelTo` to `async` and implemented staged capture sequence: pre-move effects (slash lunge or drone+missile+impact), resolve target removal (`animatePieceToPromise` + `createExplosion`), then animate attacker to destination; preserved existing capture bookkeeping. 
- Added CSS classes and keyframes to `webapp/src/index.css` for new overlay animations (`.chess-capture-slash`, `.chess-capture-drone`, `.chess-capture-missile`, `.chess-capture-shockwave`) and minimal positioning variables. 
- Files changed: `webapp/src/pages/Games/ChessBattleRoyal.jsx` and `webapp/src/index.css`.

### Testing
- Ran a production build with `npm --prefix webapp run build`, which completed successfully (build passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d74c05ee8c83298331bde89479e899)