### PR TITLE
Fix Pool Royale AI pot aiming after opening shot

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -27955,12 +27955,26 @@ const powerRef = useRef(hud.power);
             plan.aimDir = null;
             return plan;
           }
-          const aimDir = plan.aimDir.clone();
+          let aimDir = plan.aimDir.clone();
           if (aimDir.lengthSq() < 1e-6) return plan;
           aimDir.normalize();
           plan.aimDir = aimDir;
           if (plan.type !== 'pot' || plan.viaCushion || !plan.targetBall?.active) {
             return plan;
+          }
+          if (plan.pocketCenter && plan.targetBall?.pos) {
+            const pocketVector = plan.pocketCenter.clone().sub(plan.targetBall.pos);
+            if (pocketVector.lengthSq() > 1e-6) {
+              const ghost = plan.targetBall.pos
+                .clone()
+                .sub(pocketVector.normalize().multiplyScalar(BALL_R * 2));
+              const ghostDir = ghost.sub(cueBall.pos);
+              if (ghostDir.lengthSq() > 1e-6) {
+                plan.aimDir = ghostDir.normalize();
+                aimDir = plan.aimDir.clone();
+                plan.cueToTarget = cueBall.pos.distanceTo(plan.targetBall.pos);
+              }
+            }
           }
           const contact = calcTarget(cueBall, aimDir, activeBalls);
           const hitBall = contact?.targetBall ?? null;


### PR DESCRIPTION
### Motivation
- The AI was aiming directly at object balls after the first shot instead of aligning each pot attempt to the selected pocket, causing missed pot-lines on subsequent turns.

### Description
- Reworked `normalizeAiPlanAim` in `webapp/src/pages/Games/PoolRoyale.jsx` to recompute a ghost-ball aiming line from the target ball toward the chosen `pocketCenter` when a pot plan is available.
- The code now computes a `ghost` position (target minus pocket direction scaled by `BALL_R * 2`) and replaces `plan.aimDir` with the normalized vector from the cue to that ghost so collision checks use the pocket-aligned direction.
- Switched the local `aimDir` to a mutable `let` and refresh it after the ghost-line override so `calcTarget` validates the corrected pot line, while leaving the existing angle-probing and fallback correction logic intact.

### Testing
- Ran the production build with `npm -C webapp run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d772f612208329ba8169bcca190261)