### PR TITLE
Fix Pool Royale AI to re-aim using live cue/ball state each turn

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -27928,9 +27928,16 @@ const powerRef = useRef(hud.power);
           try {
             const baseline = evaluateShotOptionsBaseline();
             const variantId = activeVariantRef.current?.id ?? variantKey;
-            if (variantId !== 'uk' || !cue?.active) return baseline;
+            const cueBall = cueRef.current ?? cue;
+            if (variantId !== 'uk' || !cueBall?.active) return baseline;
             const stateSnapshot = frameRef.current ?? frameState;
-            const advancedPlan = computeUkAdvancedPlan(balls, cue, stateSnapshot);
+            const ballsSnapshot =
+              ballsRef.current?.length > 0 ? ballsRef.current : balls;
+            const advancedPlan = computeUkAdvancedPlan(
+              ballsSnapshot,
+              cueBall,
+              stateSnapshot
+            );
             if (!advancedPlan) return baseline;
             const result = { ...baseline };
             if (advancedPlan.type === 'pot') {
@@ -27947,8 +27954,8 @@ const powerRef = useRef(hud.power);
           }
         };
         const normalizeAiPlanAim = (plan) => {
-          if (!plan || !cue?.active) return plan;
-          const cueBall = cue;
+          const cueBall = cueRef.current ?? cue;
+          if (!plan || !cueBall?.active) return plan;
           const activeBalls =
             ballsRef.current?.length > 0 ? ballsRef.current : balls;
           if (!plan.aimDir || !Number.isFinite(plan.aimDir.x) || !Number.isFinite(plan.aimDir.y)) {
@@ -28125,13 +28132,15 @@ const powerRef = useRef(hud.power);
             if (plan) {
               aiPlanRef.current = plan;
               aimDirRef.current.copy(plan.aimDir);
-              alignStandingCameraToAim(cue, plan.aimDir, { preserveOrbit: false });
+              const cueBall = cueRef.current ?? cue;
+              alignStandingCameraToAim(cueBall, plan.aimDir, { preserveOrbit: false });
             } else {
               aiPlanRef.current = null;
               const fallbackDir = resolveAutoAimDirection();
               if (fallbackDir) {
                 aimDirRef.current.copy(fallbackDir);
-                alignStandingCameraToAim(cue, fallbackDir, { preserveOrbit: false });
+                const cueBall = cueRef.current ?? cue;
+                alignStandingCameraToAim(cueBall, fallbackDir, { preserveOrbit: false });
               }
             }
             updateAiPlanningState(plan, options, remaining / 1000);
@@ -28148,13 +28157,14 @@ const powerRef = useRef(hud.power);
           think();
         };
         const resolveAutoAimDirection = (options = {}) => {
-          if (!cue?.active) return null;
+          const cueBall = cueRef.current ?? cue;
+          if (!cueBall?.active) return null;
           const ballsList =
             ballsRef.current?.length > 0 ? ballsRef.current : balls;
           if (!Array.isArray(ballsList) || ballsList.length === 0) return null;
           const frameSnapshot = frameRef.current ?? frameState;
-          const cuePos = cue?.pos
-            ? new THREE.Vector2(cue.pos.x, cue.pos.y)
+          const cuePos = cueBall?.pos
+            ? new THREE.Vector2(cueBall.pos.x, cueBall.pos.y)
             : null;
           if (!cuePos) return null;
 


### PR DESCRIPTION
### Motivation
- The AI produced correct aim on the opening shot but could drift into incorrect straight-line aims on subsequent shots because it evaluated plans using stale closure state rather than the live physics state. 
- The change ensures per-shot planning always uses the current cue/ball positions so pot-targeting stays accurate across the frame.

### Description
- Read the live cue object via `cueRef.current ?? cue` and live ball list via `ballsRef.current` when computing advanced UK AI plans in `evaluateShotOptions`. 
- Use the live cue ball for contact/collision checks in `normalizeAiPlanAim` so aim correction and `cueToTarget` calculations reflect the current table state. 
- Align AI preview camera and fallback auto-aim with the current cue ball in `startAiThinking` and `resolveAutoAimDirection`, and pass the live balls/cue into `computeUkAdvancedPlan`.

### Testing
- Ran `npm test -- --runInBand test/poolRoyaleAiAimCompensation.test.js test/poolRoyalePocketAim.test.js` and both suites passed. 
- Test output: `PASS test/poolRoyaleAiAimCompensation.test.js` and `PASS test/poolRoyalePocketAim.test.js` (2 suites, 6 tests total passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d772f612208329ba8169bcca190261)