### PR TITLE
Improve Pool Royale AI targeting, jaw-aware pocketing, and rail-overhead camera switching

### DIFF
--- a/lib/poolUkAdvancedAi.js
+++ b/lib/poolUkAdvancedAi.js
@@ -16,6 +16,9 @@
  * @property {number} x
  * @property {number} y
  * @property {'TL'|'TR'|'ML'|'MR'|'BL'|'BR'} name
+ * @property {{x:number,y:number}} [mouth]
+ * @property {{x:number,y:number}} [jawA]
+ * @property {{x:number,y:number}} [jawB]
  *
  * @typedef {Object} TableState
  * @property {Ball[]} balls
@@ -68,6 +71,14 @@ const POCKET_MOUTH_WIDTH_FACTOR = 2.45
 const POCKET_ENTRY_DEPTH_FACTOR = 1.85
 const JAW_GUARD_FACTOR = 1.18
 const MONTE_CARLO_SAMPLES = 28
+
+function finitePoint (point) {
+  return (
+    point &&
+    Number.isFinite(point.x) &&
+    Number.isFinite(point.y)
+  )
+}
 
 function normaliseColourKey (input) {
   const value = typeof input === 'string' ? input : input?.colour
@@ -193,12 +204,10 @@ function pocketBetween (cue, ball, pockets, radius) {
 function pocketEntry (pocket, state) {
   const r = state.ballRadius || 0
   const name = pocket.name
-  const halfMouth = r * POCKET_MOUTH_WIDTH_FACTOR
+  const halfMouthFallback = r * POCKET_MOUTH_WIDTH_FACTOR
   const depth = r * POCKET_ENTRY_DEPTH_FACTOR
   const isLeft = name === 'TL' || name === 'ML' || name === 'BL'
-  const isRight = name === 'TR' || name === 'MR' || name === 'BR'
   const isTop = name === 'TL' || name === 'TR'
-  const isBottom = name === 'BL' || name === 'BR'
   const isMiddle = name === 'ML' || name === 'MR'
 
   let inward = { x: 0, y: 0 }
@@ -217,20 +226,44 @@ function pocketEntry (pocket, state) {
     tangent = { x: -inward.y, y: inward.x }
   }
 
-  const point = {
-    x: pocket.x + inward.x * depth,
-    y: pocket.y + inward.y * depth
+  const mouth = finitePoint(pocket.mouth)
+    ? { x: pocket.mouth.x, y: pocket.mouth.y }
+    : {
+        x: pocket.x + inward.x * depth,
+        y: pocket.y + inward.y * depth
+      }
+  const hasJawHints = finitePoint(pocket.jawA) && finitePoint(pocket.jawB)
+  const jawNear = hasJawHints
+    ? { x: pocket.jawA.x, y: pocket.jawA.y }
+    : {
+        x: mouth.x - tangent.x * halfMouthFallback,
+        y: mouth.y - tangent.y * halfMouthFallback
+      }
+  const jawFar = hasJawHints
+    ? { x: pocket.jawB.x, y: pocket.jawB.y }
+    : {
+        x: mouth.x + tangent.x * halfMouthFallback,
+        y: mouth.y + tangent.y * halfMouthFallback
+      }
+  const jawVector = { x: jawFar.x - jawNear.x, y: jawFar.y - jawNear.y }
+  const jawSpan = Math.hypot(jawVector.x, jawVector.y) || 1
+  const tangentDir = {
+    x: jawVector.x / jawSpan,
+    y: jawVector.y / jawSpan
   }
-  const jawNear = {
-    x: point.x - tangent.x * halfMouth,
-    y: point.y - tangent.y * halfMouth
-  }
-  const jawFar = {
-    x: point.x + tangent.x * halfMouth,
-    y: point.y + tangent.y * halfMouth
-  }
+  const halfMouth = jawSpan * 0.5
 
-  return { x: point.x, y: point.y, name, point, inward, tangent, halfMouth, jawNear, jawFar }
+  return {
+    x: mouth.x,
+    y: mouth.y,
+    name,
+    point: mouth,
+    inward,
+    tangent: tangentDir,
+    halfMouth,
+    jawNear,
+    jawFar
+  }
 }
 
 function pocketAcceptance (ball, entry, state) {
@@ -253,8 +286,10 @@ function pocketAcceptance (ball, entry, state) {
   const laneWidth = Math.max(0, farProj - nearProj)
   const effectiveGap = Math.max(0, laneWidth - r * JAW_GUARD_FACTOR)
   const gapScore = Math.max(0, Math.min(1, effectiveGap / (entry.halfMouth * 1.9)))
+  const cleanView = effectiveGap >= r * 1.7
+  const jawGuideBonus = cleanView ? 0.12 : 0
 
-  return Math.max(0, Math.min(1, gapScore * 0.72 + facing * 0.28))
+  return Math.max(0, Math.min(1, gapScore * 0.68 + facing * 0.24 + jawGuideBonus))
 }
 
 function contactPointTowardsPocket (target, pocket, radius) {
@@ -355,39 +390,39 @@ function generatePotCandidates (state, colour) {
         bestDist = d
         bestPocket = entry
         bestAcceptance = acceptance
+      }
+    }
+    if (bestPocket && !pathBlocked(ball, bestPocket.point, state.balls, [cue.id, ball.id], state.ballRadius)) {
+      const laneClearance = clearanceMargin(
+        cue,
+        ball,
+        state.balls,
+        [cue.id, ball.id],
+        state.ballRadius,
+        1.4
+      )
+      if (laneClearance < 0.7) continue
+      const angle = bestAngle
+      if (Number.isFinite(angle) && angle > Math.PI * 0.55) continue
+      const distCT = dist(cue, ball)
+      const distTP = bestDist
+      for (const params of CUE_VARIATIONS) {
+        shots.push({
+          actionType: 'pot',
+          targetBall: ball,
+          pocket: bestPocket,
+          pocketAimPoint: bestPocket.point,
+          cueParams: params,
+          angle,
+          distCT,
+          distTP,
+          laneClearance,
+          pocketAcceptance: bestAcceptance
+        })
+      }
     }
   }
-  if (bestPocket && !pathBlocked(ball, bestPocket.point, state.balls, [cue.id, ball.id], state.ballRadius)) {
-    const laneClearance = clearanceMargin(
-      cue,
-      ball,
-      state.balls,
-      [cue.id, ball.id],
-      state.ballRadius,
-      1.4
-    )
-    if (laneClearance < 0.7) continue
-    const angle = bestAngle
-    if (Number.isFinite(angle) && angle > Math.PI * 0.55) continue
-    const distCT = dist(cue, ball)
-    const distTP = bestDist
-    for (const params of CUE_VARIATIONS) {
-      shots.push({
-        actionType: 'pot',
-        targetBall: ball,
-        pocket: bestPocket,
-        pocketAimPoint: bestPocket.point,
-        cueParams: params,
-        angle,
-        distCT,
-        distTP,
-        laneClearance,
-        pocketAcceptance: bestAcceptance
-      })
-    }
-  }
-}
-return shots
+  return shots
 }
 
 function mirrorPocket (pocket, width, height, rail) {
@@ -673,13 +708,13 @@ function estimatePotProbability (shot, state) {
   const laneClearance = typeof shot.laneClearance === 'number'
     ? shot.laneClearance
     : clearanceMargin(
-        cueBall,
-        shot.targetBall,
-        state.balls,
-        [shot.targetBall.id, cueBall.id],
-        state.ballRadius,
-        1.6
-      )
+      cueBall,
+      shot.targetBall,
+      state.balls,
+      [shot.targetBall.id, cueBall.id],
+      state.ballRadius,
+      1.6
+    )
   if (laneClearance < 0.72) return 0
   const clearanceScore = Math.max(0, Math.min(1, (laneClearance - 0.72) / 0.62))
 

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -26303,6 +26303,8 @@ const powerRef = useRef(hud.power);
           }
           const shouldForceImmediateRailOverhead =
             Boolean(shotPrediction?.railNormal) ||
+            hasCueTargetDirectionSplit ||
+            Boolean(shotPrediction?.targetInitialPos && shotPrediction?.dir && cueVsTargetAlignment < 0.2) ||
             (shotContextRef.current?.railContactCountAfterContact ?? 0) >= 2;
           if (shouldForceImmediateRailOverhead) {
             queuedPocketView = null;
@@ -26638,6 +26640,19 @@ const powerRef = useRef(hud.power);
           const targetRemaining = duration - elapsed;
           const desiredWindow = Math.max(AI_MIN_AIM_PREVIEW_MS, targetRemaining);
           return Math.min(maxRemaining, desiredWindow);
+        };
+        const buildAiPlanningSnapshotKey = (ballsList) => {
+          if (!Array.isArray(ballsList) || ballsList.length === 0) return 'none';
+          return ballsList
+            .filter((ball) => ball?.active)
+            .slice()
+            .sort((a, b) => String(a.id).localeCompare(String(b.id)))
+            .map((ball) => {
+              const x = Math.round((ball?.pos?.x ?? 0) * 100);
+              const y = Math.round((ball?.pos?.y ?? 0) * 100);
+              return `${ball.id}:${x}:${y}`;
+            })
+            .join('|');
         };
         const scheduleEarlyAiShot = (plan) => {
           if (!plan || plan.type !== 'pot') {
@@ -27726,6 +27741,42 @@ const powerRef = useRef(hud.power);
               return colour.toUpperCase();
           }
         };
+        const resolveAiPocketJawGeometry = (localPocketCenter, localPocketId) => {
+          if (!localPocketCenter) return null;
+          const tableJaws = table?.userData?.pocketJaws;
+          if (!Array.isArray(tableJaws) || tableJaws.length < 2) return null;
+          const nearby = tableJaws
+            .map((jaw) => ({
+              jaw,
+              distance: jaw?.center?.distanceTo?.(localPocketCenter) ?? Infinity
+            }))
+            .filter((entry) => Number.isFinite(entry.distance))
+            .sort((a, b) => a.distance - b.distance)
+            .slice(0, 6);
+          if (nearby.length < 2) return null;
+          const closest = nearby[0]?.distance ?? Infinity;
+          const radiusWindow = Math.max(BALL_R * 8.5, closest * 1.65);
+          const inPocket = nearby
+            .filter((entry) => entry.distance <= radiusWindow)
+            .slice(0, 4);
+          if (inPocket.length < 2) return null;
+          inPocket.sort((a, b) => a.jaw.center.x - b.jaw.center.x || a.jaw.center.y - b.jaw.center.y);
+          const jawA = inPocket[0]?.jaw?.center;
+          const jawB = inPocket[inPocket.length - 1]?.jaw?.center;
+          if (!(jawA && jawB)) return null;
+          const middlePocket = localPocketId === 'TM' || localPocketId === 'BM';
+          const mouth = middlePocket
+            ? new THREE.Vector2(
+                (jawA.x + jawB.x) * 0.5,
+                (jawA.y + jawB.y) * 0.5
+              )
+            : localPocketCenter.clone();
+          return {
+            mouth,
+            jawA: jawA.clone(),
+            jawB: jawB.clone()
+          };
+        };
 
         const normalizeAiGroup = (value) => {
           if (!value) return undefined;
@@ -27810,7 +27861,17 @@ const powerRef = useRef(hud.power);
           const pockets = pocketPositions.map((center, idx) => {
             const aiPos = toAi(center);
             const localId = POCKET_IDS[idx] ?? `P${idx}`;
-            return { x: aiPos.x, y: aiPos.y, name: mapLocalPocketToAi(localId) };
+            const jawGeometry = resolveAiPocketJawGeometry(center, localId);
+            return {
+              x: aiPos.x,
+              y: aiPos.y,
+              name: mapLocalPocketToAi(localId),
+              mouth: jawGeometry?.mouth
+                ? toAi(jawGeometry.mouth)
+                : aiPos,
+              jawA: jawGeometry?.jawA ? toAi(jawGeometry.jawA) : undefined,
+              jawB: jawGeometry?.jawB ? toAi(jawGeometry.jawB) : undefined
+            };
           });
           const aiBalls = [];
           allBalls.forEach((ball) => {
@@ -28121,15 +28182,28 @@ const powerRef = useRef(hud.power);
             const remaining = Math.max(0, deadline - now);
             const ballsList =
               ballsRef.current?.length > 0 ? ballsRef.current : balls;
+            const planningSnapshotKey = buildAiPlanningSnapshotKey(ballsList);
             if (!allStopped(ballsList)) {
               aiPlanRef.current = null;
               updateAiPlanningState(null, { bestPot: null, bestSafety: null }, remaining / 1000);
               aiThinkingHandle = requestAnimationFrame(think);
               return;
             }
-            const options = evaluateShotOptions();
-            const plan = normalizeAiPlanAim(options.bestPot ?? options.bestSafety ?? null);
+            let plan = aiPlanRef.current;
+            let options = null;
+            const currentPlanKey = plan ? planKey(plan) : null;
+            const shouldReplan = !plan || plan._snapshotKey !== planningSnapshotKey;
+            if (shouldReplan) {
+              options = evaluateShotOptions();
+              plan = normalizeAiPlanAim(options.bestPot ?? options.bestSafety ?? null);
+            } else {
+              options = {
+                bestPot: plan?.type === 'pot' ? plan : null,
+                bestSafety: plan?.type === 'safety' ? plan : null
+              };
+            }
             if (plan) {
+              plan._snapshotKey = planningSnapshotKey;
               aiPlanRef.current = plan;
               aimDirRef.current.copy(plan.aimDir);
               const cueBall = cueRef.current ?? cue;
@@ -28144,7 +28218,9 @@ const powerRef = useRef(hud.power);
               }
             }
             updateAiPlanningState(plan, options, remaining / 1000);
-            scheduleEarlyAiShot(plan);
+            if (plan && (shouldReplan || currentPlanKey !== planKey(plan))) {
+              scheduleEarlyAiShot(plan);
+            }
             if (remaining > 0) {
               aiThinkingHandle = requestAnimationFrame(think);
             } else {
@@ -28706,8 +28782,12 @@ const powerRef = useRef(hud.power);
           try {
             cancelAiShotPreview();
             aiCueViewBlendRef.current = AI_CAMERA_DROP_BLEND;
-            const options = evaluateShotOptions();
-            let plan = normalizeAiPlanAim(options.bestPot ?? options.bestSafety ?? null);
+            const planningSnapshotKey = buildAiPlanningSnapshotKey(ballsList);
+            let plan = aiPlanRef.current;
+            if (!plan || plan._snapshotKey !== planningSnapshotKey) {
+              const options = evaluateShotOptions();
+              plan = normalizeAiPlanAim(options.bestPot ?? options.bestSafety ?? null);
+            }
             if (!plan) {
               const cuePos = cue?.pos ? cue.pos.clone() : null;
               if (!cuePos) return;
@@ -28725,6 +28805,7 @@ const powerRef = useRef(hud.power);
                 spin: { x: 0, y: 0 }
               };
             }
+            plan._snapshotKey = planningSnapshotKey;
             plan = refineAiPotAimLine(plan);
             const frameSnapshot = frameRef.current ?? frameState;
             const breakState = frameSnapshot?.meta?.state ?? null;


### PR DESCRIPTION
### Motivation
- Reduce AI jitter and wrong target switching by making the AI pick a target only after balls have settled and keep that choice while the table snapshot is unchanged. 
- Improve aiming accuracy by exposing pocket mouth/jaw geometry to the AI so it aims for the pocket mouth and uses jaw guides when appropriate. 
- Immediately switch to the rail-overhead broadcast camera for cushion/double/banked shot intents so players (and viewers) can see the planned rail interactions.

### Description
- Add optional pocket geometry fields (`mouth`, `jawA`, `jawB`) and a `finitePoint` helper in `lib/poolUkAdvancedAi.js`, and use them in `pocketEntry` to compute mouth/tangent/jaw span when available. 
- Improve `pocketAcceptance` scoring to add a small `jawGuideBonus` for clean jaw views and adjust how gap/face contributions are combined. 
- In `webapp/src/pages/Games/PoolRoyale.jsx` add a snapshot key builder and cache logic so the AI: keeps one stable plan per settled table snapshot, only re-plans when ball positions (snapshot) change, and reuses the cached plan during the `aiShoot` commit if the snapshot is still valid. 
- Extract live pocket jaw geometry from `table.userData.pocketJaws` and pass `mouth/jawA/jawB` into the UK advanced AI state (`computeUkAdvancedPlan`) so the advanced planner can consume live jaw mapping. 
- Tighten camera switching heuristics to force rail-overhead activation not only when a `railNormal` prediction exists but also when cue/target direction splits or explicit target-initial-position indicators imply banks/kicks/doubles. 

### Testing
- Linted modified AI file with `npx eslint lib/poolUkAdvancedAi.js` and resolved reported issues; lint passed for the modified file. 
- Built the webapp with `npm --prefix webapp run build`; the build completed successfully (Vite produced non-blocking chunk-size warnings about bundle size/dynamic imports). 
- No unit test changes were required; existing build + lint validations succeeded in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d77fee14548329b7f7aedf7ec6737a)