### PR TITLE
Add procedural 3D capture FX system and update capture animations/CSS

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -605,66 +605,103 @@ input:focus {
   }
 }
 
-.chess-capture-slice {
-  animation: chess-capture-slice-pop 0.62s ease-out forwards;
-  filter: drop-shadow(0 0 14px rgba(250, 204, 21, 0.9));
-}
-
-@keyframes chess-capture-slice-pop {
-  0% {
-    transform: translate(-50%, -50%) rotate(-20deg) scale(0.4);
-    opacity: 0;
-  }
-  35% {
-    transform: translate(-50%, -50%) rotate(8deg) scale(1.2);
-    opacity: 1;
-  }
-  100% {
-    transform: translate(-50%, -90%) rotate(18deg) scale(1.6);
-    opacity: 0;
-  }
+.chess-capture-procedural {
+  position: fixed;
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+  z-index: 201;
+  opacity: 0;
 }
 
 .chess-capture-drone {
-  animation: chess-capture-drone-fly 0.85s linear forwards;
-  filter: drop-shadow(0 0 12px rgba(56, 189, 248, 0.95));
+  border-radius: 999px;
+  background:
+    radial-gradient(circle at 62% 50%, #141f29 0 14%, transparent 16%),
+    linear-gradient(90deg, #8ea4b9 0 78%, #c9d5dd 78% 100%);
+  clip-path: polygon(0% 46%, 17% 18%, 76% 30%, 100% 50%, 76% 70%, 17% 82%);
+  filter: drop-shadow(0 0 14px rgba(56, 189, 248, 0.95));
+  animation: chess-capture-drone-fly 0.86s linear forwards;
 }
 
 @keyframes chess-capture-drone-fly {
-  0% {
-    transform: translate(-120%, -160%) scale(0.45);
-    opacity: 0;
-  }
-  20% {
-    opacity: 1;
-  }
-  100% {
-    transform: translate(60%, -80%) scale(0.95);
-    opacity: 0;
-  }
+  0% { transform: translate(-130%, -170%) scale(0.42) rotate(-12deg); opacity: 0; }
+  22% { opacity: 1; }
+  100% { transform: translate(70%, -75%) scale(1.04) rotate(5deg); opacity: 0; }
 }
 
-.chess-capture-missile {
-  animation: chess-capture-missile-hit 0.75s ease-in forwards;
-  filter: drop-shadow(0 0 18px rgba(251, 146, 60, 0.95));
+.chess-capture-drone-missile,
+.chess-capture-bazooka-round,
+.chess-capture-fighter-jet-bomb {
+  border-radius: 999px;
+  background: linear-gradient(90deg, #f3f5f7 0 58%, #b6bec7 58% 100%);
+  filter: drop-shadow(0 0 16px rgba(251, 146, 60, 0.95));
+  animation: chess-capture-projectile-hit 0.74s ease-in forwards;
 }
 
-@keyframes chess-capture-missile-hit {
-  0% {
-    transform: translate(120%, -120%) scale(0.5) rotate(-18deg);
-    opacity: 0;
-  }
-  30% {
-    opacity: 1;
-  }
-  65% {
-    transform: translate(-30%, -20%) scale(1.08) rotate(12deg);
-    opacity: 1;
-  }
-  100% {
-    transform: translate(-50%, -50%) scale(1.9) rotate(12deg);
-    opacity: 0;
-  }
+@keyframes chess-capture-projectile-hit {
+  0% { transform: translate(120%, -120%) scale(0.46) rotate(-14deg); opacity: 0; }
+  28% { opacity: 1; }
+  66% { transform: translate(-24%, -24%) scale(1.04) rotate(10deg); opacity: 1; }
+  100% { transform: translate(-50%, -50%) scale(1.88) rotate(12deg); opacity: 0; }
+}
+
+.chess-capture-bazooka {
+  border-radius: 999px;
+  background:
+    linear-gradient(90deg, #707880 0 16%, #8f98a1 16% 82%, #c5ced5 82% 100%);
+  filter: drop-shadow(0 0 14px rgba(192, 132, 252, 0.82));
+  animation: chess-capture-bazooka-kick 0.82s ease-out forwards;
+}
+
+@keyframes chess-capture-bazooka-kick {
+  0% { transform: translate(-70%, -50%) scale(0.78) rotate(-8deg); opacity: 0; }
+  24% { opacity: 1; }
+  58% { transform: translate(-40%, -55%) scale(1) rotate(7deg); opacity: 1; }
+  100% { transform: translate(-58%, -56%) scale(0.9) rotate(8deg); opacity: 0; }
+}
+
+.chess-capture-fighter-jet {
+  border-radius: 999px;
+  background:
+    radial-gradient(circle at 65% 50%, #1c2732 0 12%, transparent 14%),
+    linear-gradient(90deg, #9fa9b2 0 78%, #dbe2e7 78% 100%);
+  clip-path: polygon(0 52%, 12% 28%, 45% 24%, 74% 10%, 100% 50%, 74% 90%, 45% 76%, 12% 72%);
+  filter: drop-shadow(0 0 16px rgba(125, 211, 252, 0.9));
+  animation: chess-capture-fighter-fly 0.9s linear forwards;
+}
+
+@keyframes chess-capture-fighter-fly {
+  0% { transform: translate(-150%, -190%) scale(0.44) rotate(-10deg); opacity: 0; }
+  22% { opacity: 1; }
+  100% { transform: translate(90%, -82%) scale(1.05) rotate(8deg); opacity: 0; }
+}
+
+.chess-capture-sword-slice-a,
+.chess-capture-sword-slice-b {
+  border-radius: 999px;
+  background:
+    linear-gradient(180deg, #fdfefe 0 72%, #adb6bf 72% 100%);
+  filter: drop-shadow(0 0 15px rgba(250, 204, 21, 0.95));
+}
+
+.chess-capture-sword-slice-a {
+  animation: chess-capture-sword-a 0.62s ease-out forwards;
+}
+
+.chess-capture-sword-slice-b {
+  animation: chess-capture-sword-b 0.62s ease-out forwards;
+}
+
+@keyframes chess-capture-sword-a {
+  0% { transform: translate(-120%, -10%) rotate(-46deg) scale(0.3); opacity: 0; }
+  32% { transform: translate(-50%, -50%) rotate(-18deg) scale(1.05); opacity: 1; }
+  100% { transform: translate(-18%, -95%) rotate(8deg) scale(1.42); opacity: 0; }
+}
+
+@keyframes chess-capture-sword-b {
+  0% { transform: translate(18%, -120%) rotate(48deg) scale(0.26); opacity: 0; }
+  34% { transform: translate(-52%, -52%) rotate(18deg) scale(1.02); opacity: 1; }
+  100% { transform: translate(-78%, -10%) rotate(-12deg) scale(1.38); opacity: 0; }
 }
 
 /* Larger token variant used for inactive pieces */

--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -7951,68 +7951,535 @@ function Chess3D({
       setTimeout(() => el.remove(), 1000);
     };
 
-    const createScreenEffect = ({
-      pos,
-      className,
-      text,
-      fontSize = 56,
-      durationMs = 900
-    }) => {
+    const createProceduralCaptureEffect = ({ pos, className, durationMs = 900, widthPx = 72, heightPx = 30 }) => {
       if (!pos) return;
       const rect = renderer.domElement.getBoundingClientRect();
       const v = pos.clone().project(camera);
       const x = rect.left + ((v.x + 1) / 2) * rect.width;
       const y = rect.top + ((-v.y + 1) / 2) * rect.height;
       const el = document.createElement('div');
-      el.textContent = text;
-      el.className = className;
-      el.style.position = 'fixed';
-      el.style.transform = 'translate(-50%, -50%)';
-      el.style.fontSize = `${fontSize}px`;
-      el.style.pointerEvents = 'none';
-      el.style.zIndex = '201';
+      el.className = `${className} chess-capture-procedural`;
       el.style.left = `${x}px`;
       el.style.top = `${y}px`;
+      el.style.width = `${widthPx}px`;
+      el.style.height = `${heightPx}px`;
       document.body.appendChild(el);
       setTimeout(() => el.remove(), durationMs);
     };
 
-    const playCaptureAnimation = ({ fromPos, targetPos, movingType, distance }) => {
-      const pieceType = (movingType || '').toUpperCase();
-      const longRangeStrike = ['B', 'R', 'Q'].includes(pieceType) && distance >= 2;
-      if (longRangeStrike) {
-        createScreenEffect({
-          pos: fromPos,
-          className: 'chess-capture-drone',
-          text: '🚁',
-          fontSize: 52,
-          durationMs: 850
+    const createCaptureFxSystem = () => {
+      const FORWARD = new THREE.Vector3(1, 0, 0);
+      const nowSeconds = () => performance.now() / 1000;
+      const instances = [];
+      const reusableDir = new THREE.Vector3();
+
+      const fxClamp = (v, min, max) => Math.max(min, Math.min(max, v));
+      const ease = (t) => t * t * (3 - 2 * t);
+      const quadraticBezier = (a, b, c, t) => {
+        const ab = new THREE.Vector3().copy(a).lerp(b, t);
+        const bc = new THREE.Vector3().copy(b).lerp(c, t);
+        return ab.lerp(bc, t);
+      };
+      const cubicBezier = (a, b, c, d, t) => {
+        const ab = new THREE.Vector3().copy(a).lerp(b, t);
+        const bc = new THREE.Vector3().copy(b).lerp(c, t);
+        const cd = new THREE.Vector3().copy(c).lerp(d, t);
+        const abbc = ab.lerp(bc, t);
+        const bccd = bc.lerp(cd, t);
+        return abbc.lerp(bccd, t);
+      };
+      const fxAddBox = (group, size, position, color, roughness = 0.7, metalness = 0.2) => {
+        const mesh = new THREE.Mesh(
+          new THREE.BoxGeometry(size[0], size[1], size[2]),
+          new THREE.MeshStandardMaterial({ color, roughness, metalness })
+        );
+        mesh.position.set(position[0], position[1], position[2]);
+        mesh.castShadow = true;
+        mesh.receiveShadow = true;
+        group.add(mesh);
+        return mesh;
+      };
+      const fxAddCylinder = (
+        group,
+        radiusTop,
+        radiusBottom,
+        height,
+        position,
+        rotation,
+        color,
+        radialSegments = 18,
+        roughness = 0.62,
+        metalness = 0.28
+      ) => {
+        const mesh = new THREE.Mesh(
+          new THREE.CylinderGeometry(radiusTop, radiusBottom, height, radialSegments),
+          new THREE.MeshStandardMaterial({ color, roughness, metalness })
+        );
+        mesh.position.set(position[0], position[1], position[2]);
+        mesh.rotation.set(rotation[0], rotation[1], rotation[2]);
+        mesh.castShadow = true;
+        mesh.receiveShadow = true;
+        group.add(mesh);
+        return mesh;
+      };
+      const fxAddSphere = (group, radius, position, color, roughness = 0.45, metalness = 0.25, transparent = false, opacity = 1) => {
+        const mesh = new THREE.Mesh(
+          new THREE.SphereGeometry(radius, 16, 16),
+          new THREE.MeshStandardMaterial({ color, roughness, metalness, transparent, opacity })
+        );
+        mesh.position.set(position[0], position[1], position[2]);
+        mesh.castShadow = true;
+        mesh.receiveShadow = true;
+        group.add(mesh);
+        return mesh;
+      };
+      const createExplosionRig = () => {
+        const root = new THREE.Group();
+        const flash = fxAddSphere(root, 0.18, [0, 0.25, 0], '#ffe59a', 0.08, 0, true, 1);
+        const fire = [];
+        const smoke = [];
+        for (let i = 0; i < 4; i += 1) {
+          fire.push(fxAddSphere(root, 0.18 + i * 0.05, [0, 0.22 + i * 0.06, 0], i % 2 === 0 ? '#ff9c2f' : '#ff5b2d', 0.2, 0, true, 0.95 - i * 0.15));
+        }
+        for (let i = 0; i < 6; i += 1) {
+          smoke.push(fxAddSphere(root, 0.18 + i * 0.035, [0, 0.18 + i * 0.08, 0], '#646b72', 1, 0, true, 0.42 - i * 0.04));
+        }
+        root.visible = false;
+        return { root, flash, fire, smoke };
+      };
+      const updateExplosionRig = (rig, elapsedSinceImpact) => {
+        if (elapsedSinceImpact < 0 || elapsedSinceImpact > 2.6) {
+          rig.root.visible = false;
+          return;
+        }
+        rig.root.visible = true;
+        const fireLife = fxClamp(1 - elapsedSinceImpact / 0.9, 0, 1);
+        const smokeLife = fxClamp(1 - elapsedSinceImpact / 2.6, 0, 1);
+        const fireGrow = 1 + elapsedSinceImpact * 4.5;
+        const smokeGrow = 1 + elapsedSinceImpact * 2.3;
+        rig.flash.scale.setScalar(1.4 + elapsedSinceImpact * 6);
+        rig.flash.material.opacity = fireLife;
+        rig.fire.forEach((mesh, i) => {
+          const angle = elapsedSinceImpact * 5 + i * 1.35;
+          mesh.position.set(
+            Math.cos(angle) * (0.1 + elapsedSinceImpact * 0.35),
+            0.18 + elapsedSinceImpact * 0.55 + i * 0.05,
+            Math.sin(angle) * (0.1 + elapsedSinceImpact * 0.28)
+          );
+          mesh.scale.setScalar(fireGrow * (0.7 + i * 0.18));
+          mesh.material.opacity = fireLife * (0.95 - i * 0.12);
         });
-        setTimeout(() => {
-          createScreenEffect({
-            pos: targetPos,
-            className: 'chess-capture-missile',
-            text: '🚀',
-            fontSize: 54,
-            durationMs: 760
+        rig.smoke.forEach((mesh, i) => {
+          const angle = i * 1.1 + elapsedSinceImpact * 1.8;
+          mesh.position.set(
+            Math.cos(angle) * (0.14 + i * 0.08),
+            0.25 + elapsedSinceImpact * (0.55 + i * 0.1),
+            Math.sin(angle) * (0.14 + i * 0.08)
+          );
+          mesh.scale.setScalar(smokeGrow * (0.75 + i * 0.16));
+          mesh.material.opacity = smokeLife * (0.45 - i * 0.04);
+        });
+      };
+      const createTriangleDrone = () => {
+        const root = new THREE.Group();
+        fxAddCylinder(root, 0.14, 0.19, 2.75, [0, 0, 0], [0, 0, Math.PI / 2], '#cfd3d6', 20);
+        const nose = new THREE.Mesh(
+          new THREE.ConeGeometry(0.18, 0.72, 20),
+          new THREE.MeshStandardMaterial({ color: '#d9dde0', roughness: 0.5, metalness: 0.18 })
+        );
+        nose.position.set(1.7, 0, 0);
+        nose.rotation.z = -Math.PI / 2;
+        root.add(nose);
+        fxAddCylinder(root, 0.18, 0.14, 0.48, [-1.58, 0, 0], [0, 0, Math.PI / 2], '#879095', 14);
+        const wingGeom = new THREE.BoxGeometry(1.3, 0.06, 2.1);
+        const wing = new THREE.Mesh(wingGeom, new THREE.MeshStandardMaterial({ color: '#aeb4ae', roughness: 0.82, metalness: 0.08 }));
+        wing.position.set(-0.3, -0.05, 0);
+        root.add(wing);
+        const propeller = new THREE.Group();
+        propeller.position.set(-1.95, 0, 0);
+        fxAddBox(propeller, [0.05, 1.0, 0.08], [0, 0, 0], '#191d20', 0.6, 0.12);
+        const blade2 = new THREE.Mesh(new THREE.BoxGeometry(0.05, 1.0, 0.08), new THREE.MeshStandardMaterial({ color: '#191d20', roughness: 0.6 }));
+        blade2.rotation.x = Math.PI / 2;
+        propeller.add(blade2);
+        fxAddSphere(propeller, 0.07, [0, 0, 0], '#41484d', 0.45, 0.25);
+        root.add(propeller);
+        const exhaustClouds = [];
+        for (let i = 0; i < 4; i += 1) {
+          exhaustClouds.push(fxAddSphere(root, 0.08 + i * 0.015, [-2.15 - i * 0.24, 0, 0], '#8d979d', 1, 0, true, 0.21 - i * 0.03));
+        }
+        return { root, propeller, exhaustClouds };
+      };
+      const createFighterJet = () => {
+        const root = new THREE.Group();
+        fxAddCylinder(root, 0.18, 0.24, 3.4, [0, 0, 0], [0, 0, Math.PI / 2], '#b8bec5', 24);
+        const nose = new THREE.Mesh(
+          new THREE.ConeGeometry(0.19, 0.9, 24),
+          new THREE.MeshStandardMaterial({ color: '#d7dbe0', roughness: 0.45, metalness: 0.2 })
+        );
+        nose.position.set(2.15, 0, 0);
+        nose.rotation.z = -Math.PI / 2;
+        root.add(nose);
+        const cockpit = new THREE.Mesh(new THREE.SphereGeometry(0.22, 18, 18), new THREE.MeshStandardMaterial({ color: '#2d3945', roughness: 0.18, metalness: 0.3 }));
+        cockpit.scale.set(1.2, 0.65, 0.7);
+        cockpit.position.set(0.75, 0.18, 0);
+        root.add(cockpit);
+        fxAddBox(root, [1.35, 0.08, 2.2], [-0.2, -0.03, 0], '#9fa7ae', 0.68, 0.16);
+        const leftStore = new THREE.Group();
+        fxAddCylinder(leftStore, 0.04, 0.05, 0.55, [0, 0, 0], [0, 0, Math.PI / 2], '#d8dbdf', 12, 0.4, 0.18);
+        const rightStore = leftStore.clone();
+        leftStore.position.set(0.25, -0.25, -1.15);
+        rightStore.position.set(0.25, -0.25, 1.15);
+        root.add(leftStore, rightStore);
+        return { root, leftStore, rightStore };
+      };
+      const createMissile = (colorBody = '#c9ced3') => {
+        const root = new THREE.Group();
+        fxAddCylinder(root, 0.05, 0.06, 0.72, [0, 0, 0], [0, 0, Math.PI / 2], colorBody, 14, 0.42, 0.12);
+        const nose = new THREE.Mesh(new THREE.ConeGeometry(0.055, 0.18, 14), new THREE.MeshStandardMaterial({ color: '#f0f2f4', roughness: 0.32, metalness: 0.16 }));
+        nose.position.set(0.45, 0, 0);
+        nose.rotation.z = -Math.PI / 2;
+        root.add(nose);
+        const trail = [];
+        for (let i = 0; i < 4; i += 1) {
+          trail.push(fxAddSphere(root, 0.08 + i * 0.02, [-0.5 - i * 0.14, 0, 0], '#90989d', 1, 0, true, 0.22 - i * 0.03));
+        }
+        return { root, trail };
+      };
+      const createGroundLauncher = () => {
+        const root = new THREE.Group();
+        fxAddCylinder(root, 0.25, 0.32, 0.16, [0, 0.08, 0], [0, 0, 0], '#4d5358', 18, 0.9, 0.12);
+        const tubeRig = new THREE.Group();
+        tubeRig.position.set(0.02, 0.46, 0);
+        root.add(tubeRig);
+        fxAddCylinder(tubeRig, 0.12, 0.14, 1.55, [0, 0, 0], [0, 0, Math.PI / 2], '#7e868c', 18, 0.55, 0.28);
+        return { root, tubeRig, muzzleLocal: new THREE.Vector3(0.98, 0, 0) };
+      };
+      const createGroundMissile = () => {
+        const root = new THREE.Group();
+        fxAddCylinder(root, 0.07, 0.08, 1.02, [0, 0, 0], [0, 0, Math.PI / 2], '#bfc5ca', 16, 0.42, 0.12);
+        const trail = [];
+        for (let i = 0; i < 5; i += 1) {
+          trail.push(fxAddSphere(root, 0.1 + i * 0.025, [-0.7 - i * 0.16, 0, 0], i < 2 ? '#f6af4b' : '#8f989d', i < 2 ? 0.2 : 1, 0, true, i < 2 ? 0.8 - i * 0.15 : 0.26 - (i - 2) * 0.04));
+        }
+        return { root, trail };
+      };
+      const makeTileHatch = (from, tileSize, movingWhite) => {
+        const halfTile = tileSize * 0.5;
+        const pivot = new THREE.Group();
+        const panel = new THREE.Mesh(
+          new THREE.BoxGeometry(tileSize * 0.96, Math.max(0.05, tileSize * 0.06), tileSize * 0.96),
+          new THREE.MeshStandardMaterial({ color: '#4f443b', roughness: 0.88, metalness: 0.1 })
+        );
+        const opponentIsNegativeZ = Boolean(movingWhite);
+        const hingeZ = opponentIsNegativeZ ? -halfTile : halfTile;
+        panel.position.set(0, 0, -hingeZ);
+        pivot.position.copy(from).setY(0.2).add(new THREE.Vector3(0, 0, hingeZ));
+        pivot.add(panel);
+        pivot.renderOrder = 21;
+        scene.add(pivot);
+        return {
+          pivot,
+          panel,
+          setOpenFactor: (v) => {
+            const open = fxClamp(v, 0, 1);
+            const angle = (opponentIsNegativeZ ? -1 : 1) * open * (Math.PI * 0.58);
+            pivot.rotation.x = angle;
+          }
+        };
+      };
+
+      const updateInstance = (inst, t) => {
+        const elapsed = t - inst.startAt;
+        if (elapsed < 0) return true;
+        if (elapsed > inst.life + 3) return false;
+        if (inst.type === 'drone') {
+          const hatchOpenT = fxClamp(elapsed / 0.45, 0, 1);
+          const hatchCloseT = elapsed > 5.8 ? fxClamp((elapsed - 5.8) / 0.6, 0, 1) : 0;
+          inst.hatch.setOpenFactor(hatchOpenT * (1 - hatchCloseT));
+          const local = fxClamp((elapsed - 0.65) / 4.8, 0, 1);
+          const liftEnd = inst.from.clone().add(new THREE.Vector3(-0.45 * inst.tileSize, 2.0 * inst.tileSize, 0.22 * inst.tileSize));
+          const cruiseEnd = inst.target.clone().add(new THREE.Vector3(-0.5 * inst.tileSize, 2.3 * inst.tileSize, 0.15 * inst.tileSize));
+          const pos = new THREE.Vector3();
+          const next = new THREE.Vector3();
+          let phase = 'lift';
+          if (local < 0.32) {
+            const u = ease(local / 0.32);
+            pos.copy(inst.from).add(new THREE.Vector3(0, -1.25 * inst.tileSize * (1 - u), 0)).lerp(liftEnd, u);
+            pos.z += Math.sin(u * Math.PI * 3) * 0.12 * inst.scale;
+            next.copy(inst.from).lerp(liftEnd, Math.min(1, u + 0.04));
+          } else if (local < 0.73) {
+            const u = ease((local - 0.32) / 0.41);
+            pos.copy(liftEnd).lerp(cruiseEnd, u);
+            pos.y += Math.sin(u * Math.PI * 2) * 0.1 * inst.scale;
+            pos.z += Math.sin(u * Math.PI * 2.4) * 0.16 * inst.scale;
+            next.copy(liftEnd).lerp(cruiseEnd, Math.min(1, u + 0.03)); phase = 'cruise';
+          } else {
+            const u = ease((local - 0.73) / 0.27);
+            pos.copy(cruiseEnd).lerp(inst.target, u);
+            next.copy(cruiseEnd).lerp(inst.target, Math.min(1, u + 0.05));
+            phase = 'dive';
+          }
+          reusableDir.copy(next).sub(pos).normalize();
+          inst.drone.root.position.copy(pos);
+          inst.drone.root.quaternion.setFromUnitVectors(FORWARD, reusableDir);
+          const bank = phase === 'lift' ? -0.12 : phase === 'cruise' ? Math.sin(elapsed * 2.4) * 0.06 : 0.03;
+          inst.drone.root.quaternion.multiply(new THREE.Quaternion().setFromAxisAngle(reusableDir, bank));
+          inst.drone.propeller.rotation.x = elapsed * 36;
+          inst.drone.exhaustClouds.forEach((puff, i) => {
+            puff.position.set(-2.1 - i * 0.22 - ((elapsed * 1.4 + i * 0.18) % 1) * 0.2, Math.sin(elapsed * 3 + i) * 0.03, 0);
+            puff.scale.setScalar(0.8 + i * 0.18 + ((elapsed * 1.2 + i * 0.15) % 1) * 0.55);
+            puff.material.opacity = phase === 'dive' ? 0.08 : 0.2 - i * 0.03;
           });
-        }, 180);
-        setTimeout(() => createExplosion(targetPos), 350);
+          const launchTime = 4.3;
+          const impactTime = 4.95;
+          if (elapsed >= launchTime && elapsed <= impactTime) {
+            const u = ease((elapsed - launchTime) / Math.max(0.001, impactTime - launchTime));
+            const control = inst.from.clone().lerp(inst.target, 0.45); control.y = inst.target.y + 1.8 * inst.tileSize;
+            const nextU = fxClamp(u + 0.025, 0, 1);
+            const p = quadraticBezier(inst.from, control, inst.target, u);
+            const n = quadraticBezier(inst.from, control, inst.target, nextU);
+            reusableDir.copy(n).sub(p).normalize();
+            inst.missile.root.visible = true;
+            inst.missile.root.position.copy(p);
+            inst.missile.root.quaternion.setFromUnitVectors(FORWARD, reusableDir);
+          } else {
+            inst.missile.root.visible = false;
+          }
+          updateExplosionRig(inst.explosion, elapsed - impactTime);
+          return elapsed <= inst.life;
+        }
+        if (inst.type === 'jet') {
+          const hatchOpenT = fxClamp(elapsed / 0.55, 0, 1);
+          const hatchCloseT = elapsed > 5.7 ? fxClamp((elapsed - 5.7) / 0.65, 0, 1) : 0;
+          inst.hatch.setOpenFactor(hatchOpenT * (1 - hatchCloseT));
+          const trackStart = 0.75;
+          const outboundEnd = 3.1;
+          const returnEnd = 5.2;
+          const descendEnd = 5.85;
+          const pos = new THREE.Vector3();
+          const next = new THREE.Vector3();
+          if (elapsed < trackStart) {
+            const u = ease(fxClamp(elapsed / trackStart, 0, 1));
+            pos.copy(inst.from).add(new THREE.Vector3(0, -1.3 * inst.tileSize * (1 - u), 0)).lerp(inst.jetStart, u);
+            next.copy(inst.from).lerp(inst.jetStart, Math.min(1, u + 0.03));
+          } else if (elapsed < outboundEnd) {
+            const u = ease((elapsed - trackStart) / (outboundEnd - trackStart));
+            pos.copy(inst.jetStart).lerp(inst.jetEnd, u);
+            pos.y += Math.sin(u * Math.PI) * 0.45 * inst.scale;
+            pos.z += Math.sin(u * Math.PI * 1.65) * 0.35 * inst.scale;
+            const nu = Math.min(1, u + 0.02);
+            next.copy(inst.jetStart).lerp(inst.jetEnd, nu);
+          } else if (elapsed < returnEnd) {
+            const u = ease((elapsed - outboundEnd) / (returnEnd - outboundEnd));
+            pos.copy(inst.jetEnd).lerp(inst.jetStart, u);
+            pos.y += Math.sin((1 - u) * Math.PI) * 0.35 * inst.scale;
+            const nu = Math.min(1, u + 0.02);
+            next.copy(inst.jetEnd).lerp(inst.jetStart, nu);
+          } else {
+            const u = ease(fxClamp((elapsed - returnEnd) / (descendEnd - returnEnd), 0, 1));
+            pos.copy(inst.jetStart).lerp(inst.from.clone().add(new THREE.Vector3(0, -1.3 * inst.tileSize, 0)), u);
+            next.copy(inst.jetStart).lerp(inst.from, Math.min(1, u + 0.04));
+          }
+          reusableDir.copy(next).sub(pos).normalize();
+          inst.jet.root.position.copy(pos);
+          inst.jet.root.quaternion.setFromUnitVectors(FORWARD, reusableDir);
+          inst.jet.root.quaternion.multiply(new THREE.Quaternion().setFromAxisAngle(reusableDir, Math.sin(elapsed * 1.5) * 0.03));
+          const drops = [
+            { missile: inst.missileA, explosion: inst.explosionA, dropTime: 2.05, travel: 1.25, target: inst.target.clone().add(new THREE.Vector3(-0.18 * inst.tileSize, 0, 0.06 * inst.tileSize)) },
+            { missile: inst.missileB, explosion: inst.explosionB, dropTime: 2.45, travel: 1.4, target: inst.target.clone().add(new THREE.Vector3(0.16 * inst.tileSize, 0, -0.08 * inst.tileSize)) }
+          ];
+          drops.forEach(({ missile, explosion, dropTime, travel, target }) => {
+            if (elapsed >= dropTime && elapsed <= dropTime + travel) {
+              const dropStart = pos.clone().add(new THREE.Vector3(0, -0.25 * inst.scale, 0));
+              const control = dropStart.clone().lerp(target, 0.45); control.y = target.y + 1.8 * inst.tileSize;
+              const mu = ease((elapsed - dropTime) / travel);
+              const mn = fxClamp(mu + 0.025, 0, 1);
+              const mp = quadraticBezier(dropStart, control, target, mu);
+              const mnx = quadraticBezier(dropStart, control, target, mn);
+              reusableDir.copy(mnx).sub(mp).normalize();
+              missile.root.visible = true;
+              missile.root.position.copy(mp);
+              missile.root.quaternion.setFromUnitVectors(FORWARD, reusableDir);
+            } else {
+              missile.root.visible = false;
+            }
+            updateExplosionRig(explosion, elapsed - (dropTime + travel));
+          });
+          return elapsed <= inst.life;
+        }
+        if (inst.type === 'bazooka') {
+          const hatchOpenT = fxClamp(elapsed / 0.5, 0, 1);
+          const hatchCloseT = elapsed > 4.1 ? fxClamp((elapsed - 4.1) / 0.55, 0, 1) : 0;
+          inst.hatch.setOpenFactor(hatchOpenT * (1 - hatchCloseT));
+          const launcherRiseT = fxClamp((elapsed - 0.45) / 0.5, 0, 1);
+          const launcherDropT = elapsed > 3.45 ? fxClamp((elapsed - 3.45) / 0.65, 0, 1) : 0;
+          const launcherY = inst.from.y + (-1.15 * inst.tileSize * (1 - launcherRiseT)) - (1.15 * inst.tileSize * launcherDropT);
+          inst.launcher.root.position.set(inst.from.x, launcherY, inst.from.z);
+          const fireTime = 1.0;
+          const travelTime = 1.9;
+          const impactTime = fireTime + travelTime;
+          const aim = inst.target.clone().add(new THREE.Vector3(0, 1.3 * inst.tileSize, -0.1 * inst.scale)).sub(inst.launcher.root.position).normalize();
+          inst.launcher.tubeRig.quaternion.setFromUnitVectors(FORWARD, aim);
+          if (elapsed < fireTime) {
+            inst.groundMissile.root.visible = false;
+            updateExplosionRig(inst.explosion, -1);
+            return true;
+          }
+          if (elapsed < impactTime) {
+            const u = ease((elapsed - fireTime) / travelTime);
+            const nextU = fxClamp(u + 0.02, 0, 1);
+            const control1 = new THREE.Vector3(inst.from.x + 0.35 * inst.tileSize, inst.from.y + 1.1 * inst.tileSize, inst.from.z - 0.1 * inst.scale);
+            const control2 = new THREE.Vector3(inst.target.x - 0.25 * inst.tileSize, inst.target.y + 1.9 * inst.tileSize, inst.target.z + 0.12 * inst.scale);
+            const p = cubicBezier(inst.from, control1, control2, inst.target, u);
+            const n = cubicBezier(inst.from, control1, control2, inst.target, nextU);
+            reusableDir.copy(n).sub(p).normalize();
+            inst.groundMissile.root.visible = true;
+            inst.groundMissile.root.position.copy(p);
+            inst.groundMissile.root.quaternion.setFromUnitVectors(FORWARD, reusableDir);
+            updateExplosionRig(inst.explosion, -1);
+            return true;
+          }
+          inst.groundMissile.root.visible = false;
+          updateExplosionRig(inst.explosion, elapsed - impactTime);
+          return elapsed <= inst.life;
+        }
+        return false;
+      };
+      const disposeObject = (obj) => {
+        obj?.traverse?.((node) => {
+          if (node.geometry) node.geometry.dispose?.();
+          if (Array.isArray(node.material)) node.material.forEach((m) => m?.dispose?.());
+          else node.material?.dispose?.();
+        });
+        obj?.parent?.remove(obj);
+      };
+      const spawnDrone = (from, target, scale = 1, movingWhite = true) => {
+        const tileSize = Math.max(0.2, 2.75 * scale);
+        const drone = createTriangleDrone();
+        const missile = createMissile('#c9ced3');
+        const explosion = createExplosionRig();
+        const hatch = makeTileHatch(from, tileSize, movingWhite);
+        [drone.root, missile.root, explosion.root].forEach((node) => {
+          node.scale.setScalar(scale);
+          node.renderOrder = 20;
+          scene.add(node);
+        });
+        missile.root.visible = false;
+        explosion.root.position.copy(target);
+        instances.push({ type: 'drone', startAt: nowSeconds(), life: 6.8, from: from.clone(), target: target.clone(), drone, missile, explosion, hatch, tileSize, nodes: [drone.root, missile.root, explosion.root, hatch.pivot], scale });
+      };
+      const spawnJet = (from, target, scale = 1, movingWhite = true) => {
+        const tileSize = Math.max(0.2, (3.4 * scale) / 2 * 2);
+        const jet = createFighterJet();
+        const missileA = createMissile('#c9ced3');
+        const missileB = createMissile('#c9ced3');
+        const explosionA = createExplosionRig();
+        const explosionB = createExplosionRig();
+        const hatch = makeTileHatch(from, tileSize, movingWhite);
+        [jet.root, missileA.root, missileB.root, explosionA.root, explosionB.root].forEach((node) => {
+          node.scale.setScalar(scale);
+          node.renderOrder = 20;
+          scene.add(node);
+        });
+        missileA.root.visible = false;
+        missileB.root.visible = false;
+        explosionA.root.position.copy(target);
+        explosionB.root.position.copy(target);
+        const jetStart = from.clone().add(new THREE.Vector3(-8.5 * scale, 7.0 * scale, -2.2 * scale));
+        const jetEnd = target.clone().add(new THREE.Vector3(8.8 * scale, 7.3 * scale, 2.3 * scale));
+        instances.push({ type: 'jet', startAt: nowSeconds(), life: 6.6, from: from.clone(), target: target.clone(), jet, missileA, missileB, explosionA, explosionB, hatch, tileSize, jetStart, jetEnd, nodes: [jet.root, missileA.root, missileB.root, explosionA.root, explosionB.root, hatch.pivot], scale });
+      };
+      const spawnBazooka = (from, target, scale = 1, movingWhite = true) => {
+        const tileSize = Math.max(0.2, 1.55 * scale);
+        const launcher = createGroundLauncher();
+        const groundMissile = createGroundMissile();
+        const explosion = createExplosionRig();
+        const hatch = makeTileHatch(from, tileSize, movingWhite);
+        [launcher.root, groundMissile.root, explosion.root].forEach((node) => {
+          node.scale.setScalar(scale);
+          node.renderOrder = 20;
+          scene.add(node);
+        });
+        launcher.root.position.copy(from).setY(from.y - 1.15 * tileSize);
+        groundMissile.root.visible = false;
+        explosion.root.position.copy(target);
+        instances.push({ type: 'bazooka', startAt: nowSeconds(), life: 4.8, from: from.clone(), target: target.clone(), launcher, groundMissile, explosion, hatch, tileSize, nodes: [launcher.root, groundMissile.root, explosion.root, hatch.pivot], scale });
+      };
+      return {
+        triggerDrone: spawnDrone,
+        triggerJet: spawnJet,
+        triggerBazooka: spawnBazooka,
+        update: (timeSec) => {
+          for (let i = instances.length - 1; i >= 0; i -= 1) {
+            if (updateInstance(instances[i], timeSec)) continue;
+            const done = instances.splice(i, 1)[0];
+            done.nodes?.forEach(disposeObject);
+          }
+        },
+        dispose: () => {
+          while (instances.length) {
+            const inst = instances.pop();
+            inst.nodes?.forEach(disposeObject);
+          }
+        }
+      };
+    };
+
+    const captureFxSystem = createCaptureFxSystem();
+    disposers.push(() => captureFxSystem.dispose());
+
+    const playCaptureAnimation = ({ fromPos, targetPos, movingType, distance, movingWhite }) => {
+      const pieceType = (movingType || '').toUpperCase();
+      const tileSize = Math.max(0.2, currentTileSize);
+      const droneScale = tileSize / 2.75;
+      const jetScale = (tileSize * 2) / 3.4;
+      const bazookaScale = tileSize / 1.55;
+
+      if (pieceType === 'B') {
+        captureFxSystem.triggerDrone(fromPos, targetPos, droneScale, movingWhite);
         playAudio(droneSoundRef);
         setTimeout(() => playAudio(missileLaunchSoundRef), 140);
-        setTimeout(() => playAudio(missileImpactSoundRef), 360);
-        return { moveDelayMs: 520 };
+        setTimeout(() => playAudio(missileImpactSoundRef), 2950);
+        return { moveDelayMs: 3400 };
       }
-      if (distance <= 1.5) {
-        createScreenEffect({
+
+      if (pieceType === 'R' || pieceType === 'N') {
+        captureFxSystem.triggerBazooka(fromPos, targetPos, bazookaScale, movingWhite);
+        setTimeout(() => playAudio(missileLaunchSoundRef), 980);
+        setTimeout(() => playAudio(missileImpactSoundRef), 2860);
+        return { moveDelayMs: 3050 };
+      }
+
+      if (pieceType === 'Q') {
+        captureFxSystem.triggerJet(fromPos, targetPos, jetScale, movingWhite);
+        playAudio(droneSoundRef);
+        setTimeout(() => playAudio(missileLaunchSoundRef), 2050);
+        setTimeout(() => playAudio(missileLaunchSoundRef), 2450);
+        setTimeout(() => playAudio(missileImpactSoundRef), 3320);
+        setTimeout(() => playAudio(missileImpactSoundRef), 3680);
+        return { moveDelayMs: 4400 };
+      }
+
+      if (pieceType === 'K' || pieceType === 'P' || distance <= 1.5) {
+        const boardScale = clamp(currentTileSize / BOARD.tile, 0.75, 1.65);
+        createProceduralCaptureEffect({
           pos: targetPos,
-          className: 'chess-capture-slice',
-          text: '⚔️',
-          fontSize: 64,
+          className: 'chess-capture-sword-slice-a',
+          widthPx: 64 * boardScale,
+          heightPx: 58 * boardScale,
           durationMs: 620
         });
+        setTimeout(() => {
+          createProceduralCaptureEffect({
+            pos: targetPos,
+            className: 'chess-capture-sword-slice-b',
+            widthPx: 70 * boardScale,
+            heightPx: 62 * boardScale,
+            durationMs: 620
+          });
+        }, 110);
         playAudio(swordSoundRef);
-        return { moveDelayMs: 220 };
+        return { moveDelayMs: 260 };
       }
       createExplosion(targetPos);
       playAudio(missileImpactSoundRef);
@@ -8981,7 +9448,8 @@ function Chess3D({
           fromPos: fromWorldPos,
           targetPos: worldPos,
           movingType: movingPiece?.t,
-          distance: Math.hypot(rr - sel.r, cc - sel.c)
+          distance: Math.hypot(rr - sel.r, cc - sel.c),
+          movingWhite: capturingWhite
         });
         moveDelayMs = Math.max(0, captureFx?.moveDelayMs ?? 0);
         pieceMeshes[rr][cc] = null;
@@ -9447,6 +9915,8 @@ function Chess3D({
           }
         }
       }
+
+      captureFxSystem.update(now * 0.001);
 
       controls?.update();
       const targetInterval = renderSettingsRef.current.targetFrameIntervalMs || targetFrameIntervalMs;


### PR DESCRIPTION
### Motivation
- Replace simple emoji/slice screen effects with richer procedural 3D capture visual effects that better match piece types and ranges.
- Provide reusable, GPU-driven FX rigs (drone, fighter jet, bazooka, missiles, explosions, sword slices) that can be spawned per capture and cleaned up safely.

### Description
- Replace the old DOM emoji-based `createScreenEffect` flow with a new `createCaptureFxSystem` in `ChessBattleRoyal.jsx` that builds procedural Three.js rigs and exposes `triggerDrone`, `triggerJet`, and `triggerBazooka` along with update/dispose logic.
- Implement multiple FX primitives and helpers (`fxAddBox`, `fxAddCylinder`, `fxAddSphere`, bezier helpers, hatch/tile rig, explosion rigs, missile/jet/drone generators) and wire them into the capture flow with piece-type-specific timing and audio triggers.
- Hook the procedural FX system into the main render loop with `captureFxSystem.update(...)` and ensure disposers are registered to clean up generated scene nodes and geometries.
- Replace and expand CSS animations in `index.css`, adding `.chess-capture-procedural` and classes for drones, bazooka, fighter, missiles, sword slices, and tuning keyframes to match the new visual assets.

### Testing
- Ran the webapp build with `yarn build` which completed successfully. 
- Ran the test suite with `yarn test` which passed without failures. 
- Ran linter via `yarn lint` to verify style/formatting changes and it completed with no blocking errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d795cf12f4832987da40a403ed0e1b)