### PR TITLE
Restore Pool Royale AI aiming to pre-Apr-9 Monte Carlo baseline

### DIFF
--- a/Assets/Scripts/Aiming/AdaptiveAimingEngine.cs
+++ b/Assets/Scripts/Aiming/AdaptiveAimingEngine.cs
@@ -399,19 +399,13 @@ namespace Aiming
 
         float ScoreAttempt(in ShotContext ctx, in ShotInfo info, in AimSolution attempt)
         {
-            Vector3 cueDirRaw = attempt.aimEnd - ctx.cueBallPos;
-            if (cueDirRaw.sqrMagnitude < 1e-8f)
-                return 10f;
-
-            Vector3 cueDir = cueDirRaw.normalized;
+            Vector3 cueDir = (attempt.aimEnd - ctx.cueBallPos).normalized;
             Vector3 idealDir = (ctx.objectBallPos - ctx.cueBallPos).normalized;
             float directionalMiss = 1f - Mathf.Clamp01(Vector3.Dot(cueDir, idealDir));
 
             float cutPenalty = (config ? config.cutAnglePenalty : 0.55f) * (info.angleDeg / 90f);
             float distancePenalty = (config ? config.distancePenalty : 0.2f) * Vector3.Distance(ctx.cueBallPos, attempt.aimEnd);
-            float potLinePenalty = EvaluatePotLinePenalty(ctx, attempt);
-            float scratchRiskPenalty = EvaluateScratchRiskPenalty(ctx, cueDir);
-            return directionalMiss + cutPenalty + distancePenalty + potLinePenalty + scratchRiskPenalty;
+            return directionalMiss + cutPenalty + distancePenalty;
         }
 
         AimSolution SelectWithMonteCarlo(in ShotContext ctx, in ShotInfo info, AimSolution[] solutions, float[] deterministicScores, int count)
@@ -471,58 +465,11 @@ namespace Aiming
 
             Vector3 objectToPocketDir = objectToPocket / objectToPocketDistance;
             float hitAlignment = Mathf.Clamp01(Vector3.Dot(cueDir, cueToObjectDir));
-            Vector3 sampledObjectTravel = EstimateObjectTravelDirection(ctx, cueDir);
-            float cutAlignment = sampledObjectTravel.sqrMagnitude > 1e-8f
-                ? Mathf.Clamp01(Vector3.Dot(sampledObjectTravel, objectToPocketDir))
-                : Mathf.Clamp01(Vector3.Dot(cueToObjectDir, objectToPocketDir));
+            float cutAlignment = Mathf.Clamp01(Vector3.Dot(cueToObjectDir, objectToPocketDir));
             float powerPenalty = Mathf.Abs(shotPower01 - RecommendPower(info.distBucket, ctx.requiresPower)) * 0.15f;
             float missPenalty = (1f - hitAlignment) * 1.5f + (1f - cutAlignment) * 1.2f;
-            float scratchRiskPenalty = EvaluateScratchRiskPenalty(ctx, cueDir);
 
-            return missPenalty + powerPenalty + scratchRiskPenalty + (info.angleDeg / 90f) * 0.15f;
-        }
-
-        static Vector3 EstimateObjectTravelDirection(in ShotContext ctx, Vector3 cueDir)
-        {
-            Vector3 cueToObject = ctx.objectBallPos - ctx.cueBallPos;
-            if (cueToObject.sqrMagnitude <= 1e-8f)
-                return Vector3.zero;
-
-            Vector3 contactNormal = cueToObject.normalized;
-            float forwardComponent = Mathf.Max(0f, Vector3.Dot(cueDir, contactNormal));
-            if (forwardComponent <= 1e-5f)
-                return Vector3.zero;
-
-            Vector3 objectTravel = contactNormal * forwardComponent;
-            return objectTravel.sqrMagnitude > 1e-8f ? objectTravel.normalized : Vector3.zero;
-        }
-
-        float EvaluatePotLinePenalty(in ShotContext ctx, in AimSolution attempt)
-        {
-            Vector3 objectToPocket = ctx.pocketPos - ctx.objectBallPos;
-            if (objectToPocket.sqrMagnitude < 1e-8f)
-                return 0f;
-
-            Vector3 projectedObjectTravel = ctx.objectBallPos - attempt.aimEnd;
-            if (projectedObjectTravel.sqrMagnitude < 1e-8f)
-                return 1.2f;
-
-            float alignment = Mathf.Clamp01(Vector3.Dot(projectedObjectTravel.normalized, objectToPocket.normalized));
-            return (1f - alignment) * 1.35f;
-        }
-
-        float EvaluateScratchRiskPenalty(in ShotContext ctx, Vector3 cueDir)
-        {
-            Vector3 objectToPocket = ctx.pocketPos - ctx.objectBallPos;
-            if (objectToPocket.sqrMagnitude < 1e-8f)
-                return 0f;
-
-            float sameLane = Mathf.Clamp01(Vector3.Dot(cueDir, objectToPocket.normalized));
-            if (sameLane < 0.82f)
-                return 0f;
-
-            // Very aligned cue paths tend to follow the object toward the same pocket (scratch risk).
-            return (sameLane - 0.82f) * 1.1f;
+            return missPenalty + powerPenalty + (info.angleDeg / 90f) * 0.15f;
         }
 
         static Vector3 ApplyDirectionalNoise(Vector3 baseDir, float jitterDeg, int seed)


### PR DESCRIPTION
### Motivation
- Restore the AI aiming and selection behavior to the Monte Carlo baseline used prior to the April 9, 2026 scoring additions so Pool Royale AI reproduces the previous aiming decisions. 
- Only AI aiming/AI logic should be changed while leaving other gameplay, UI, camera, and asset systems untouched. 

### Description
- Reverted changes in `Assets/Scripts/Aiming/AdaptiveAimingEngine.cs` to restore `ScoreAttempt` to use only directional miss, cut-angle penalty, and distance penalty. 
- Restored Monte Carlo rollout scoring in `ScoreMonteCarloRollout` to the previous alignment-based model using `hitAlignment`, `cutAlignment`, and `powerPenalty`. 
- Removed the later-added extra heuristics (`EstimateObjectTravelDirection`, `EvaluatePotLinePenalty`, and `EvaluateScratchRiskPenalty`) and their usage so selection returns to the prior Monte Carlo baseline. 
- The change is limited to `Assets/Scripts/Aiming/AdaptiveAimingEngine.cs` and does not modify non-AI files. 

### Testing
- No automated unit or integration tests were executed against the modified code during this change. 
- Repository inspection (diff/status) was used to verify that only `Assets/Scripts/Aiming/AdaptiveAimingEngine.cs` was modified and the Monte Carlo selection path is active.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7cdeefbd48329bb5cd0337650a517)