### PR TITLE
Fix Pool Royale AI replanning to use live settled table state

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -25983,7 +25983,7 @@ const powerRef = useRef(hud.power);
           breakRollStateRef.current !== 'done' ||
           !cue?.active ||
           (inHandPlacementActive && !cueBallPlacedFromHandRef.current) ||
-          !allStopped(balls) ||
+          !allStopped((ballsRef.current?.length > 0 ? ballsRef.current : balls)) ||
           currentHud?.over ||
           replayPlaybackRef.current
         )
@@ -27888,9 +27888,16 @@ const powerRef = useRef(hud.power);
           try {
             const baseline = evaluateShotOptionsBaseline();
             const variantId = activeVariantRef.current?.id ?? variantKey;
-            if (variantId !== 'uk' || !cue?.active) return baseline;
+            const liveCue = cueRef.current ?? cue;
+            const liveBalls =
+              ballsRef.current?.length > 0 ? ballsRef.current : balls;
+            if (variantId !== 'uk' || !liveCue?.active) return baseline;
             const stateSnapshot = frameRef.current ?? frameState;
-            const advancedPlan = computeUkAdvancedPlan(balls, cue, stateSnapshot);
+            const advancedPlan = computeUkAdvancedPlan(
+              liveBalls,
+              liveCue,
+              stateSnapshot
+            );
             if (!advancedPlan) return baseline;
             const result = { ...baseline };
             if (advancedPlan.type === 'pot') {
@@ -28035,7 +28042,9 @@ const powerRef = useRef(hud.power);
             aiPlanCacheRef.current = { key: null, plan: null };
             setAiPlanning(null);
           }
-          if (!allStopped(balls)) {
+          const liveBalls =
+            ballsRef.current?.length > 0 ? ballsRef.current : balls;
+          if (!allStopped(liveBalls)) {
             aiPlanRef.current = null;
             setAiPlanning(null);
             aiThinkingHandle = requestAnimationFrame(startAiThinking);
@@ -28645,7 +28654,7 @@ const powerRef = useRef(hud.power);
               return;
             }
           }
-          if (!allStopped(balls)) {
+          if (!allStopped(ballsList)) {
             aiRetryTimeoutRef.current = window.setTimeout(() => {
               aiRetryTimeoutRef.current = null;
               aiShoot.current();


### PR DESCRIPTION
### Motivation
- AI was making shot decisions from render-captured or stale positions and sometimes planned/reacted before the table was fully settled, causing poor target selection after the first shot. 
- Planning and aiming must be computed on each shot using the exact, current cue/ball positions only when all balls are at full stop. 
- Changes aim to make AI behaviour consistent by removing advance predictions from stale state and ensuring every shot is recalculated from the live table snapshot.

### Description
- Switch UK advanced planning to use live references by passing `ballsRef` / `cueRef` into `computeUkAdvancedPlan` instead of render-captured `balls` / `cue`. 
- Tighten AI gating so `startAiThinking`, `evaluateShotOptions`, `fire`, and `aiShoot` use the live ball array (`ballsRef.current` when available) when checking `allStopped` or building plans. 
- Keep existing fallbacks and normalization logic intact while ensuring plans and early-shot previews are derived from the settled, live table state. 
- Modified file: `webapp/src/pages/Games/PoolRoyale.jsx` (AI planning and firing paths updated to reference live state).

### Testing
- Ran lint check with `npx eslint webapp/src/pages/Games/PoolRoyale.jsx`, which completed (file is ignored by repo eslint ignore rules in this environment so a warning was emitted). 
- Performed a full build using `npm run -s build`, which completed successfully. 
- No automated unit tests were modified; change focused on in-place AI runtime logic and gating.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7d5d5509c83299f6a664b4e55bbbb)