### PR TITLE
Add procedural drone/jet/bazooka/sword capture VFX and WebAudio SFX for Chess Battle Royal

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -591,7 +591,12 @@ input:focus {
 
 .bomb-explosion {
   animation: bomb-pop 1s forwards;
-  filter: drop-shadow(0 0 18px rgba(248, 113, 113, 0.95));
+  width: 84px;
+  height: 84px;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at center, rgba(255, 243, 199, 0.95) 0%, rgba(255, 157, 66, 0.82) 35%, rgba(244, 63, 94, 0.35) 62%, rgba(0, 0, 0, 0) 78%);
+  filter: drop-shadow(0 0 20px rgba(248, 113, 113, 0.95));
 }
 
 @keyframes bomb-pop {
@@ -608,6 +613,10 @@ input:focus {
 .chess-capture-slice {
   animation: chess-capture-slice-pop 0.62s ease-out forwards;
   filter: drop-shadow(0 0 14px rgba(250, 204, 21, 0.9));
+}
+
+.chess-capture-slice-second {
+  animation-delay: 0.06s;
 }
 
 @keyframes chess-capture-slice-pop {
@@ -628,6 +637,44 @@ input:focus {
 .chess-capture-drone {
   animation: chess-capture-drone-fly 0.85s linear forwards;
   filter: drop-shadow(0 0 12px rgba(56, 189, 248, 0.95));
+}
+
+.chess-capture-jet {
+  animation: chess-capture-jet-fly 0.92s linear forwards;
+  filter: drop-shadow(0 0 12px rgba(148, 163, 184, 0.95));
+}
+
+@keyframes chess-capture-jet-fly {
+  0% {
+    transform: translate(-160%, -110%) scale(0.62) rotate(-8deg);
+    opacity: 0;
+  }
+  15% {
+    opacity: 1;
+  }
+  100% {
+    transform: translate(80%, -40%) scale(1.08) rotate(7deg);
+    opacity: 0;
+  }
+}
+
+.chess-capture-bazooka {
+  animation: chess-capture-bazooka-fire 0.84s ease-out forwards;
+  filter: drop-shadow(0 0 12px rgba(148, 163, 184, 0.95));
+}
+
+@keyframes chess-capture-bazooka-fire {
+  0% {
+    transform: translate(-60%, -30%) scale(0.66) rotate(-14deg);
+    opacity: 0;
+  }
+  18% {
+    opacity: 1;
+  }
+  100% {
+    transform: translate(8%, -44%) scale(1.02) rotate(-4deg);
+    opacity: 0;
+  }
 }
 
 @keyframes chess-capture-drone-fly {
@@ -665,6 +712,185 @@ input:focus {
     transform: translate(-50%, -50%) scale(1.9) rotate(12deg);
     opacity: 0;
   }
+}
+
+.chess-capture-model {
+  position: relative;
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.chess-capture-model span {
+  position: absolute;
+  display: block;
+}
+
+.chess-capture-model.drone .body,
+.chess-capture-model.jet .body {
+  left: 14%;
+  top: 38%;
+  width: 66%;
+  height: 24%;
+  border-radius: 999px;
+  background: linear-gradient(180deg, #e2e8f0 0%, #94a3b8 100%);
+}
+
+.chess-capture-model.drone .wing {
+  left: 24%;
+  top: 14%;
+  width: 48%;
+  height: 72%;
+  clip-path: polygon(0 50%, 100% 0, 100% 100%);
+  background: #a3b4c6;
+}
+
+.chess-capture-model.drone .tail {
+  left: 7%;
+  top: 43%;
+  width: 15%;
+  height: 14%;
+  border-radius: 999px;
+  background: #6b7280;
+}
+
+.chess-capture-model.drone .prop {
+  left: 0%;
+  top: 32%;
+  width: 18%;
+  height: 36%;
+}
+
+.chess-capture-model.drone .prop::before,
+.chess-capture-model.drone .prop::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  margin: auto;
+  background: #111827;
+}
+
+.chess-capture-model.drone .prop::before {
+  width: 100%;
+  height: 12%;
+}
+
+.chess-capture-model.drone .prop::after {
+  width: 12%;
+  height: 100%;
+}
+
+.chess-capture-model.jet .body {
+  width: 74%;
+  left: 12%;
+}
+
+.chess-capture-model.jet .wing {
+  left: 20%;
+  top: 11%;
+  width: 54%;
+  height: 78%;
+  clip-path: polygon(0 50%, 100% 6%, 80% 50%, 100% 94%);
+  background: #94a3b8;
+}
+
+.chess-capture-model.jet .tail {
+  left: 10%;
+  top: 30%;
+  width: 20%;
+  height: 40%;
+  clip-path: polygon(0 50%, 100% 0, 72% 50%, 100% 100%);
+  background: #cbd5e1;
+}
+
+.chess-capture-model.jet .cockpit {
+  left: 58%;
+  top: 30%;
+  width: 14%;
+  height: 34%;
+  border-radius: 999px;
+  background: #0f172a;
+}
+
+.chess-capture-model.bazooka .tube {
+  left: 10%;
+  top: 34%;
+  width: 78%;
+  height: 32%;
+  border-radius: 999px;
+  background: linear-gradient(180deg, #cbd5e1 0%, #64748b 100%);
+}
+
+.chess-capture-model.bazooka .grip {
+  left: 36%;
+  top: 56%;
+  width: 12%;
+  height: 24%;
+  border-radius: 3px;
+  background: #1f2937;
+}
+
+.chess-capture-model.bazooka .tip {
+  right: 6%;
+  top: 36%;
+  width: 14%;
+  height: 28%;
+  clip-path: polygon(0 0, 100% 50%, 0 100%);
+  background: #e2e8f0;
+}
+
+.chess-capture-model.missile .body {
+  left: 16%;
+  top: 37%;
+  width: 64%;
+  height: 26%;
+  border-radius: 999px;
+  background: linear-gradient(180deg, #e5e7eb 0%, #9ca3af 100%);
+}
+
+.chess-capture-model.missile .tip {
+  right: 10%;
+  top: 34%;
+  width: 14%;
+  height: 32%;
+  clip-path: polygon(0 0, 100% 50%, 0 100%);
+  background: #f3f4f6;
+}
+
+.chess-capture-model.missile .fins {
+  left: 18%;
+  top: 24%;
+  width: 14%;
+  height: 52%;
+  background: linear-gradient(180deg, #6b7280 0%, #4b5563 100%);
+  clip-path: polygon(0 10%, 100% 0, 100% 100%, 0 90%);
+}
+
+.chess-capture-model.sword .blade {
+  left: 42%;
+  top: 8%;
+  width: 14%;
+  height: 70%;
+  clip-path: polygon(50% 0, 100% 14%, 75% 100%, 25% 100%, 0 14%);
+  background: linear-gradient(180deg, #f8fafc 0%, #cbd5e1 100%);
+}
+
+.chess-capture-model.sword .guard {
+  left: 29%;
+  top: 62%;
+  width: 40%;
+  height: 8%;
+  border-radius: 999px;
+  background: #fbbf24;
+}
+
+.chess-capture-model.sword .handle {
+  left: 44%;
+  top: 70%;
+  width: 10%;
+  height: 22%;
+  border-radius: 999px;
+  background: #4b5563;
 }
 
 /* Larger token variant used for inactive pieces */

--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -988,10 +988,6 @@ const CHECK_SOUND_URL =
 const CHECKMATE_SOUND_URL =
   'https://raw.githubusercontent.com/lichess-org/lila/master/public/sound/standard/End.mp3';
 const LAUGH_SOUND_URL = '/assets/sounds/Haha.mp3';
-const SWORD_SLASH_SOUND_URL = '/assets/sounds/punch-03-352040.mp3';
-const DRONE_FLY_SOUND_URL = '/assets/sounds/ufo-sound-effect-240256.mp3';
-const MISSILE_FIRE_SOUND_URL = '/assets/sounds/launch-85216.mp3';
-const MISSILE_IMPACT_SOUND_URL = '/assets/sounds/080998_bullet-hit-39870.mp3';
 
 const BEAUTIFUL_GAME_THEME_CONFIGS = Object.freeze([
   {
@@ -7328,14 +7324,58 @@ function Chess3D({
     mateSoundRef.current.volume = baseVolume;
     laughSoundRef.current = new Audio(LAUGH_SOUND_URL);
     laughSoundRef.current.volume = baseVolume;
-    swordSoundRef.current = new Audio(SWORD_SLASH_SOUND_URL);
-    swordSoundRef.current.volume = baseVolume;
-    droneSoundRef.current = new Audio(DRONE_FLY_SOUND_URL);
-    droneSoundRef.current.volume = baseVolume;
-    missileLaunchSoundRef.current = new Audio(MISSILE_FIRE_SOUND_URL);
-    missileLaunchSoundRef.current.volume = baseVolume;
-    missileImpactSoundRef.current = new Audio(MISSILE_IMPACT_SOUND_URL);
-    missileImpactSoundRef.current.volume = baseVolume;
+    swordSoundRef.current = null;
+    droneSoundRef.current = null;
+    missileLaunchSoundRef.current = null;
+    missileImpactSoundRef.current = null;
+    let synthCtx = null;
+
+    const ensureSynthContext = () => {
+      if (typeof window === 'undefined') return null;
+      const Ctx = window.AudioContext || window.webkitAudioContext;
+      if (!Ctx) return null;
+      if (!synthCtx) synthCtx = new Ctx();
+      if (synthCtx.state === 'suspended') synthCtx.resume().catch(() => {});
+      return synthCtx;
+    };
+
+    const playProceduralSfx = (type) => {
+      if (!settingsRef.current.soundEnabled || isGameMuted()) return;
+      const ctx = ensureSynthContext();
+      if (!ctx) return;
+      const now = ctx.currentTime + 0.005;
+      const gainNode = ctx.createGain();
+      const master = clamp(getGameVolume() * 0.8, 0, 1);
+      gainNode.gain.setValueAtTime(master, now);
+      gainNode.connect(ctx.destination);
+
+      const tone = (freqStart, freqEnd, duration, wave = 'sawtooth', volume = 0.18) => {
+        const osc = ctx.createOscillator();
+        const g = ctx.createGain();
+        osc.type = wave;
+        osc.frequency.setValueAtTime(freqStart, now);
+        osc.frequency.exponentialRampToValueAtTime(Math.max(30, freqEnd), now + duration);
+        g.gain.setValueAtTime(0.0001, now);
+        g.gain.exponentialRampToValueAtTime(volume, now + 0.015);
+        g.gain.exponentialRampToValueAtTime(0.0001, now + duration);
+        osc.connect(g);
+        g.connect(gainNode);
+        osc.start(now);
+        osc.stop(now + duration + 0.02);
+      };
+
+      if (type === 'drone') {
+        tone(220, 160, 0.28, 'triangle', 0.12);
+      } else if (type === 'jet') {
+        tone(680, 210, 0.3, 'sawtooth', 0.2);
+      } else if (type === 'launch') {
+        tone(180, 900, 0.14, 'square', 0.16);
+      } else if (type === 'impact') {
+        tone(900, 90, 0.24, 'sawtooth', 0.2);
+      } else if (type === 'sword') {
+        tone(1200, 340, 0.09, 'triangle', 0.12);
+      }
+    };
 
     let stopCameraTween = () => {};
     let onResize = null;
@@ -7938,11 +7978,9 @@ function Chess3D({
       const x = rect.left + ((v.x + 1) / 2) * rect.width;
       const y = rect.top + ((-v.y + 1) / 2) * rect.height;
       const el = document.createElement('div');
-      el.textContent = '💨';
       el.className = 'bomb-explosion';
       el.style.position = 'fixed';
       el.style.transform = 'translate(-50%, -50%) scale(1)';
-      el.style.fontSize = '64px';
       el.style.pointerEvents = 'none';
       el.style.zIndex = '200';
       el.style.left = `${x}px`;
@@ -7954,7 +7992,7 @@ function Chess3D({
     const createScreenEffect = ({
       pos,
       className,
-      text,
+      contentType = 'drone',
       fontSize = 56,
       durationMs = 900
     }) => {
@@ -7964,27 +8002,37 @@ function Chess3D({
       const x = rect.left + ((v.x + 1) / 2) * rect.width;
       const y = rect.top + ((-v.y + 1) / 2) * rect.height;
       const el = document.createElement('div');
-      el.textContent = text;
       el.className = className;
       el.style.position = 'fixed';
       el.style.transform = 'translate(-50%, -50%)';
-      el.style.fontSize = `${fontSize}px`;
+      el.style.width = `${fontSize}px`;
+      el.style.height = `${Math.max(20, fontSize * 0.42)}px`;
       el.style.pointerEvents = 'none';
       el.style.zIndex = '201';
       el.style.left = `${x}px`;
       el.style.top = `${y}px`;
+      if (contentType === 'drone') {
+        el.innerHTML = '<span class="chess-capture-model drone"><span class="body"></span><span class="wing"></span><span class="tail"></span><span class="prop"></span></span>';
+      } else if (contentType === 'jet') {
+        el.innerHTML = '<span class="chess-capture-model jet"><span class="body"></span><span class="wing"></span><span class="tail"></span><span class="cockpit"></span></span>';
+      } else if (contentType === 'bazooka') {
+        el.innerHTML = '<span class="chess-capture-model bazooka"><span class="tube"></span><span class="grip"></span><span class="tip"></span></span>';
+      } else if (contentType === 'missile') {
+        el.innerHTML = '<span class="chess-capture-model missile"><span class="body"></span><span class="tip"></span><span class="fins"></span></span>';
+      } else if (contentType === 'sword') {
+        el.innerHTML = '<span class="chess-capture-model sword"><span class="blade"></span><span class="guard"></span><span class="handle"></span></span>';
+      }
       document.body.appendChild(el);
       setTimeout(() => el.remove(), durationMs);
     };
 
     const playCaptureAnimation = ({ fromPos, targetPos, movingType, distance }) => {
       const pieceType = (movingType || '').toUpperCase();
-      const longRangeStrike = ['B', 'R', 'Q'].includes(pieceType) && distance >= 2;
-      if (longRangeStrike) {
+      if (pieceType === 'B') {
         createScreenEffect({
           pos: fromPos,
           className: 'chess-capture-drone',
-          text: '🚁',
+          contentType: 'drone',
           fontSize: 52,
           durationMs: 850
         });
@@ -7992,30 +8040,99 @@ function Chess3D({
           createScreenEffect({
             pos: targetPos,
             className: 'chess-capture-missile',
-            text: '🚀',
+            contentType: 'missile',
             fontSize: 54,
             durationMs: 760
           });
         }, 180);
         setTimeout(() => createExplosion(targetPos), 350);
-        playAudio(droneSoundRef);
-        setTimeout(() => playAudio(missileLaunchSoundRef), 140);
-        setTimeout(() => playAudio(missileImpactSoundRef), 360);
+        playProceduralSfx('drone');
+        setTimeout(() => playProceduralSfx('launch'), 140);
+        setTimeout(() => playProceduralSfx('impact'), 360);
         return { moveDelayMs: 520 };
       }
-      if (distance <= 1.5) {
+      if (pieceType === 'Q') {
+        createScreenEffect({
+          pos: fromPos,
+          className: 'chess-capture-jet',
+          contentType: 'jet',
+          fontSize: 78,
+          durationMs: 920
+        });
+        setTimeout(() => {
+          createScreenEffect({
+            pos: targetPos,
+            className: 'chess-capture-missile',
+            contentType: 'missile',
+            fontSize: 62,
+            durationMs: 760
+          });
+        }, 250);
+        setTimeout(() => createExplosion(targetPos), 420);
+        playProceduralSfx('jet');
+        setTimeout(() => playProceduralSfx('launch'), 210);
+        setTimeout(() => playProceduralSfx('impact'), 430);
+        return { moveDelayMs: 560 };
+      }
+      if (pieceType === 'R' || pieceType === 'N') {
+        createScreenEffect({
+          pos: fromPos,
+          className: 'chess-capture-bazooka',
+          contentType: 'bazooka',
+          fontSize: 68,
+          durationMs: 840
+        });
+        setTimeout(() => {
+          createScreenEffect({
+            pos: targetPos,
+            className: 'chess-capture-missile',
+            contentType: 'missile',
+            fontSize: 58,
+            durationMs: 760
+          });
+        }, 130);
+        setTimeout(() => createExplosion(targetPos), 330);
+        playProceduralSfx('launch');
+        setTimeout(() => playProceduralSfx('impact'), 340);
+        return { moveDelayMs: 500 };
+      }
+      if (pieceType === 'K' || pieceType === 'P' || distance <= 1.5) {
         createScreenEffect({
           pos: targetPos,
           className: 'chess-capture-slice',
-          text: '⚔️',
+          contentType: 'sword',
           fontSize: 64,
-          durationMs: 620
+          durationMs: 680
         });
-        playAudio(swordSoundRef);
-        return { moveDelayMs: 220 };
+        setTimeout(() => {
+          createScreenEffect({
+            pos: targetPos,
+            className: 'chess-capture-slice chess-capture-slice-second',
+            contentType: 'sword',
+            fontSize: 68,
+            durationMs: 620
+          });
+        }, 120);
+        playProceduralSfx('sword');
+        setTimeout(() => playProceduralSfx('sword'), 120);
+        setTimeout(() => playProceduralSfx('impact'), 200);
+        return { moveDelayMs: 280 };
+      }
+      if (distance >= 2) {
+        createScreenEffect({
+          pos: fromPos,
+          className: 'chess-capture-bazooka',
+          contentType: 'bazooka',
+          fontSize: 64,
+          durationMs: 700
+        });
+        setTimeout(() => createExplosion(targetPos), 260);
+        playProceduralSfx('launch');
+        setTimeout(() => playProceduralSfx('impact'), 280);
+        return { moveDelayMs: 360 };
       }
       createExplosion(targetPos);
-      playAudio(missileImpactSoundRef);
+      playProceduralSfx('impact');
       return { moveDelayMs: 280 };
     };
 
@@ -9532,6 +9649,10 @@ function Chess3D({
       droneSoundRef.current?.pause();
       missileLaunchSoundRef.current?.pause();
       missileImpactSoundRef.current?.pause();
+      if (synthCtx && typeof synthCtx.close === 'function') {
+        synthCtx.close().catch(() => {});
+        synthCtx = null;
+      }
       clearLaughTimeout();
     };
   }, []);


### PR DESCRIPTION
### Motivation
- Match the provided capture animation style using procedural (no binary) visuals so captures look identical and scale to the chess board size.
- Map piece types to in-game effects so long-range pieces show vehicles/missiles while king/pawn use an improved two-slice sword effect.
- Avoid shipping binary audio assets by using procedural Web Audio synthesis for weapon/impact SFX.

### Description
- Replaced emoji-based capture overlays with DOM/CSS procedural models and keyframe animations for `drone`, `jet`, `bazooka`, `missile`, `sword`, and `explosion` visuals, and tuned sizes/positions to project onto the board correctly.
- Updated capture routing in `playCaptureAnimation` so piece types use the requested mapping: bishops → drone, rooks+knights → bazooka, queen → fighter jet, king+pawns → two-slice procedural sword; adjusted animation timings and move delays to preserve sequencing.
- Switched from playing static audio files to a small Web Audio synth (`playProceduralSfx`) that generates drone/jet/launch/impact/sword tones at runtime and added safe AudioContext creation and cleanup on unmount (no new binary assets added).
- Files changed: `webapp/src/pages/Games/ChessBattleRoyal.jsx` (capture logic, WebAudio synth, effect DOM insertion) and `webapp/src/index.css` (new classes/keyframes and procedural model styling).

### Testing
- Ran lint with `npm run -s lint -- webapp/src/pages/Games/ChessBattleRoyal.jsx webapp/src/index.css`; lint reported the repository's large pre-existing baseline issues and produced many errors unrelated to this change (not introduced by this PR).
- Ran unit tests for inventory alignment with `npm run -s test -- --runInBand test/inventoryCrossGameConfig.test.js`; the test run failed with 2 unrelated failures in the inventory alignment suite (these failures predate this change and are outside the modified files).
- No new automated tests were added; visual verification expected in a browser to confirm board-relative sizing and animation timing (manual QA recommended).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7de6d46b88329b53b2b9c145d41e0)