### PR TITLE
Add screen-space animated capture effects with new visuals and sounds

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -591,7 +591,12 @@ input:focus {
 
 .bomb-explosion {
   animation: bomb-pop 1s forwards;
-  filter: drop-shadow(0 0 18px rgba(248, 113, 113, 0.95));
+  width: 84px;
+  height: 84px;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at center, rgba(255, 243, 199, 0.95) 0%, rgba(255, 157, 66, 0.82) 35%, rgba(244, 63, 94, 0.35) 62%, rgba(0, 0, 0, 0) 78%);
+  filter: drop-shadow(0 0 20px rgba(248, 113, 113, 0.95));
 }
 
 @keyframes bomb-pop {
@@ -608,6 +613,10 @@ input:focus {
 .chess-capture-slice {
   animation: chess-capture-slice-pop 0.62s ease-out forwards;
   filter: drop-shadow(0 0 14px rgba(250, 204, 21, 0.9));
+}
+
+.chess-capture-slice-second {
+  animation-delay: 0.06s;
 }
 
 @keyframes chess-capture-slice-pop {
@@ -628,6 +637,44 @@ input:focus {
 .chess-capture-drone {
   animation: chess-capture-drone-fly 0.85s linear forwards;
   filter: drop-shadow(0 0 12px rgba(56, 189, 248, 0.95));
+}
+
+.chess-capture-jet {
+  animation: chess-capture-jet-fly 0.92s linear forwards;
+  filter: drop-shadow(0 0 12px rgba(148, 163, 184, 0.95));
+}
+
+@keyframes chess-capture-jet-fly {
+  0% {
+    transform: translate(-160%, -110%) scale(0.62) rotate(-8deg);
+    opacity: 0;
+  }
+  15% {
+    opacity: 1;
+  }
+  100% {
+    transform: translate(80%, -40%) scale(1.08) rotate(7deg);
+    opacity: 0;
+  }
+}
+
+.chess-capture-bazooka {
+  animation: chess-capture-bazooka-fire 0.84s ease-out forwards;
+  filter: drop-shadow(0 0 12px rgba(148, 163, 184, 0.95));
+}
+
+@keyframes chess-capture-bazooka-fire {
+  0% {
+    transform: translate(-60%, -30%) scale(0.66) rotate(-14deg);
+    opacity: 0;
+  }
+  18% {
+    opacity: 1;
+  }
+  100% {
+    transform: translate(8%, -44%) scale(1.02) rotate(-4deg);
+    opacity: 0;
+  }
 }
 
 @keyframes chess-capture-drone-fly {
@@ -665,6 +712,185 @@ input:focus {
     transform: translate(-50%, -50%) scale(1.9) rotate(12deg);
     opacity: 0;
   }
+}
+
+.chess-capture-model {
+  position: relative;
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.chess-capture-model span {
+  position: absolute;
+  display: block;
+}
+
+.chess-capture-model.drone .body,
+.chess-capture-model.jet .body {
+  left: 14%;
+  top: 38%;
+  width: 66%;
+  height: 24%;
+  border-radius: 999px;
+  background: linear-gradient(180deg, #e2e8f0 0%, #94a3b8 100%);
+}
+
+.chess-capture-model.drone .wing {
+  left: 24%;
+  top: 14%;
+  width: 48%;
+  height: 72%;
+  clip-path: polygon(0 50%, 100% 0, 100% 100%);
+  background: #a3b4c6;
+}
+
+.chess-capture-model.drone .tail {
+  left: 7%;
+  top: 43%;
+  width: 15%;
+  height: 14%;
+  border-radius: 999px;
+  background: #6b7280;
+}
+
+.chess-capture-model.drone .prop {
+  left: 0%;
+  top: 32%;
+  width: 18%;
+  height: 36%;
+}
+
+.chess-capture-model.drone .prop::before,
+.chess-capture-model.drone .prop::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  margin: auto;
+  background: #111827;
+}
+
+.chess-capture-model.drone .prop::before {
+  width: 100%;
+  height: 12%;
+}
+
+.chess-capture-model.drone .prop::after {
+  width: 12%;
+  height: 100%;
+}
+
+.chess-capture-model.jet .body {
+  width: 74%;
+  left: 12%;
+}
+
+.chess-capture-model.jet .wing {
+  left: 20%;
+  top: 11%;
+  width: 54%;
+  height: 78%;
+  clip-path: polygon(0 50%, 100% 6%, 80% 50%, 100% 94%);
+  background: #94a3b8;
+}
+
+.chess-capture-model.jet .tail {
+  left: 10%;
+  top: 30%;
+  width: 20%;
+  height: 40%;
+  clip-path: polygon(0 50%, 100% 0, 72% 50%, 100% 100%);
+  background: #cbd5e1;
+}
+
+.chess-capture-model.jet .cockpit {
+  left: 58%;
+  top: 30%;
+  width: 14%;
+  height: 34%;
+  border-radius: 999px;
+  background: #0f172a;
+}
+
+.chess-capture-model.bazooka .tube {
+  left: 10%;
+  top: 34%;
+  width: 78%;
+  height: 32%;
+  border-radius: 999px;
+  background: linear-gradient(180deg, #cbd5e1 0%, #64748b 100%);
+}
+
+.chess-capture-model.bazooka .grip {
+  left: 36%;
+  top: 56%;
+  width: 12%;
+  height: 24%;
+  border-radius: 3px;
+  background: #1f2937;
+}
+
+.chess-capture-model.bazooka .tip {
+  right: 6%;
+  top: 36%;
+  width: 14%;
+  height: 28%;
+  clip-path: polygon(0 0, 100% 50%, 0 100%);
+  background: #e2e8f0;
+}
+
+.chess-capture-model.missile .body {
+  left: 16%;
+  top: 37%;
+  width: 64%;
+  height: 26%;
+  border-radius: 999px;
+  background: linear-gradient(180deg, #e5e7eb 0%, #9ca3af 100%);
+}
+
+.chess-capture-model.missile .tip {
+  right: 10%;
+  top: 34%;
+  width: 14%;
+  height: 32%;
+  clip-path: polygon(0 0, 100% 50%, 0 100%);
+  background: #f3f4f6;
+}
+
+.chess-capture-model.missile .fins {
+  left: 18%;
+  top: 24%;
+  width: 14%;
+  height: 52%;
+  background: linear-gradient(180deg, #6b7280 0%, #4b5563 100%);
+  clip-path: polygon(0 10%, 100% 0, 100% 100%, 0 90%);
+}
+
+.chess-capture-model.sword .blade {
+  left: 42%;
+  top: 8%;
+  width: 14%;
+  height: 70%;
+  clip-path: polygon(50% 0, 100% 14%, 75% 100%, 25% 100%, 0 14%);
+  background: linear-gradient(180deg, #f8fafc 0%, #cbd5e1 100%);
+}
+
+.chess-capture-model.sword .guard {
+  left: 29%;
+  top: 62%;
+  width: 40%;
+  height: 8%;
+  border-radius: 999px;
+  background: #fbbf24;
+}
+
+.chess-capture-model.sword .handle {
+  left: 44%;
+  top: 70%;
+  width: 10%;
+  height: 22%;
+  border-radius: 999px;
+  background: #4b5563;
 }
 
 /* Larger token variant used for inactive pieces */

--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -988,9 +988,9 @@ const CHECK_SOUND_URL =
 const CHECKMATE_SOUND_URL =
   'https://raw.githubusercontent.com/lichess-org/lila/master/public/sound/standard/End.mp3';
 const LAUGH_SOUND_URL = '/assets/sounds/Haha.mp3';
-const SWORD_SLASH_SOUND_URL = '/assets/sounds/punch-03-352040.mp3';
 const DRONE_FLY_SOUND_URL = '/assets/sounds/ufo-sound-effect-240256.mp3';
-const MISSILE_FIRE_SOUND_URL = '/assets/sounds/launch-85216.mp3';
+const JET_FLY_SOUND_URL = '/assets/sounds/race-care-151963.mp3';
+const BAZOOKA_FIRE_SOUND_URL = '/assets/sounds/launch-85216.mp3';
 const MISSILE_IMPACT_SOUND_URL = '/assets/sounds/080998_bullet-hit-39870.mp3';
 
 const BEAUTIFUL_GAME_THEME_CONFIGS = Object.freeze([
@@ -7328,14 +7328,16 @@ function Chess3D({
     mateSoundRef.current.volume = baseVolume;
     laughSoundRef.current = new Audio(LAUGH_SOUND_URL);
     laughSoundRef.current.volume = baseVolume;
-    swordSoundRef.current = new Audio(SWORD_SLASH_SOUND_URL);
+    swordSoundRef.current = new Audio('/assets/sounds/punch-03-352040.mp3');
     swordSoundRef.current.volume = baseVolume;
     droneSoundRef.current = new Audio(DRONE_FLY_SOUND_URL);
     droneSoundRef.current.volume = baseVolume;
-    missileLaunchSoundRef.current = new Audio(MISSILE_FIRE_SOUND_URL);
+    missileLaunchSoundRef.current = new Audio(BAZOOKA_FIRE_SOUND_URL);
     missileLaunchSoundRef.current.volume = baseVolume;
     missileImpactSoundRef.current = new Audio(MISSILE_IMPACT_SOUND_URL);
     missileImpactSoundRef.current.volume = baseVolume;
+    const jetFlySound = new Audio(JET_FLY_SOUND_URL);
+    jetFlySound.volume = baseVolume;
 
     let stopCameraTween = () => {};
     let onResize = null;
@@ -7932,17 +7934,26 @@ function Chess3D({
       envSkyboxRef.current?.scale?.x ?? baseSkyboxScaleRef.current ?? 1;
     syncSkyboxToCamera();
 
+    const activeCaptureFx = new Set();
+    const projectToScreen = (worldPos) => {
+      if (!worldPos) return null;
+      const rect = renderer.domElement.getBoundingClientRect();
+      const v = worldPos.clone().project(camera);
+      return {
+        x: rect.left + ((v.x + 1) / 2) * rect.width,
+        y: rect.top + ((-v.y + 1) / 2) * rect.height
+      };
+    };
+
     const createExplosion = (pos) => {
       const rect = renderer.domElement.getBoundingClientRect();
       const v = pos.clone().project(camera);
       const x = rect.left + ((v.x + 1) / 2) * rect.width;
       const y = rect.top + ((-v.y + 1) / 2) * rect.height;
       const el = document.createElement('div');
-      el.textContent = '💨';
       el.className = 'bomb-explosion';
       el.style.position = 'fixed';
       el.style.transform = 'translate(-50%, -50%) scale(1)';
-      el.style.fontSize = '64px';
       el.style.pointerEvents = 'none';
       el.style.zIndex = '200';
       el.style.left = `${x}px`;
@@ -7951,70 +7962,257 @@ function Chess3D({
       setTimeout(() => el.remove(), 1000);
     };
 
-    const createScreenEffect = ({
-      pos,
+    const animateEffect = ({
+      fromPos,
+      toPos,
       className,
-      text,
-      fontSize = 56,
-      durationMs = 900
+      contentType = 'drone',
+      widthPx = 56,
+      heightPx = Math.max(20, widthPx * 0.42),
+      durationMs = 900,
+      style = 'linear'
     }) => {
-      if (!pos) return;
-      const rect = renderer.domElement.getBoundingClientRect();
-      const v = pos.clone().project(camera);
-      const x = rect.left + ((v.x + 1) / 2) * rect.width;
-      const y = rect.top + ((-v.y + 1) / 2) * rect.height;
+      const start = projectToScreen(fromPos);
+      const end = projectToScreen(toPos || fromPos);
+      if (!start || !end) return;
       const el = document.createElement('div');
-      el.textContent = text;
       el.className = className;
       el.style.position = 'fixed';
       el.style.transform = 'translate(-50%, -50%)';
-      el.style.fontSize = `${fontSize}px`;
+      el.style.width = `${widthPx}px`;
+      el.style.height = `${heightPx}px`;
       el.style.pointerEvents = 'none';
       el.style.zIndex = '201';
-      el.style.left = `${x}px`;
-      el.style.top = `${y}px`;
+      el.style.left = `${start.x}px`;
+      el.style.top = `${start.y}px`;
+      el.style.animation = 'none';
+      if (contentType === 'drone') {
+        el.innerHTML = '<span class="chess-capture-model drone"><span class="body"></span><span class="wing"></span><span class="tail"></span><span class="prop"></span></span>';
+      } else if (contentType === 'jet') {
+        el.innerHTML = '<span class="chess-capture-model jet"><span class="body"></span><span class="wing"></span><span class="tail"></span><span class="cockpit"></span></span>';
+      } else if (contentType === 'bazooka') {
+        el.innerHTML = '<span class="chess-capture-model bazooka"><span class="tube"></span><span class="grip"></span><span class="tip"></span></span>';
+      } else if (contentType === 'missile') {
+        el.innerHTML = '<span class="chess-capture-model missile"><span class="body"></span><span class="tip"></span><span class="fins"></span></span>';
+      } else if (contentType === 'sword') {
+        el.innerHTML = '<span class="chess-capture-model sword"><span class="blade"></span><span class="guard"></span><span class="handle"></span></span>';
+      }
       document.body.appendChild(el);
-      setTimeout(() => el.remove(), durationMs);
+      const fx = { raf: 0, dead: false, remove: () => {
+        if (fx.dead) return;
+        fx.dead = true;
+        cancelAnimationFrame(fx.raf);
+        el.remove();
+        activeCaptureFx.delete(fx);
+      } };
+      activeCaptureFx.add(fx);
+
+      const startAt = performance.now();
+      const droneLiftRatio = 2 / 6.5;
+      const droneCruiseRatio = 2.8 / 6.5;
+      const setPosition = (x, y, angle = 0, opacity = 1, scale = 1) => {
+        el.style.left = `${x}px`;
+        el.style.top = `${y}px`;
+        el.style.opacity = `${opacity}`;
+        el.style.transform = `translate(-50%, -50%) rotate(${angle}rad) scale(${scale})`;
+      };
+
+      const run = (now) => {
+        if (fx.dead) return;
+        const t = clamp01((now - startAt) / durationMs);
+        if (style === 'drone') {
+          const liftAnchor = { x: start.x + (end.x - start.x) * 0.2, y: start.y - 120 };
+          const cruiseAnchor = { x: start.x + (end.x - start.x) * 0.66, y: end.y - 145 };
+          let p1 = start;
+          let p2 = liftAnchor;
+          let localT = 0;
+          if (t <= droneLiftRatio) {
+            localT = ease(clamp01(t / droneLiftRatio));
+            p1 = start;
+            p2 = liftAnchor;
+          } else if (t <= droneLiftRatio + droneCruiseRatio) {
+            localT = ease(clamp01((t - droneLiftRatio) / droneCruiseRatio));
+            p1 = liftAnchor;
+            p2 = cruiseAnchor;
+          } else {
+            localT = ease(
+              clamp01((t - droneLiftRatio - droneCruiseRatio) / (1 - droneLiftRatio - droneCruiseRatio))
+            );
+            p1 = cruiseAnchor;
+            p2 = end;
+          }
+          const x = p1.x + (p2.x - p1.x) * localT;
+          const y =
+            p1.y + (p2.y - p1.y) * localT + Math.sin((t * Math.PI * 4) % (Math.PI * 2)) * 6;
+          const angle = Math.atan2(p2.y - p1.y, p2.x - p1.x);
+          setPosition(x, y, angle, 1 - t * 0.12, 0.78 + t * 0.26);
+        } else if (style === 'jet') {
+          const launch = { x: start.x, y: start.y - 55 };
+          const flyTo = { x: end.x + 20, y: end.y - 120 };
+          const u = ease(t);
+          const x = launch.x + (flyTo.x - launch.x) * u;
+          const y = launch.y + (flyTo.y - launch.y) * u + Math.sin(u * Math.PI * 1.6) * 12;
+          setPosition(x, y, Math.atan2(flyTo.y - launch.y, flyTo.x - launch.x), 1 - t * 0.08, 0.9 + t * 0.18);
+        } else if (style === 'projectile') {
+          const control = { x: start.x + (end.x - start.x) * 0.5, y: Math.min(start.y, end.y) - 90 };
+          const u = ease(t);
+          const x = (1 - u) * (1 - u) * start.x + 2 * (1 - u) * u * control.x + u * u * end.x;
+          const y = (1 - u) * (1 - u) * start.y + 2 * (1 - u) * u * control.y + u * u * end.y;
+          setPosition(x, y, Math.atan2(end.y - control.y, end.x - control.x), 1, 0.86 + t * 0.2);
+        } else if (style === 'aim') {
+          const angle = Math.atan2(end.y - start.y, end.x - start.x);
+          setPosition(start.x, start.y, angle, 1 - t * 0.4, 0.92 + t * 0.08);
+        } else {
+          const u = ease(t);
+          const x = start.x + (end.x - start.x) * u;
+          const y = start.y + (end.y - start.y) * u;
+          setPosition(x, y, 0, 1 - t, 1);
+        }
+        if (t >= 1) {
+          fx.remove();
+          return;
+        }
+        fx.raf = requestAnimationFrame(run);
+      };
+      fx.raf = requestAnimationFrame(run);
+      return fx;
     };
 
     const playCaptureAnimation = ({ fromPos, targetPos, movingType, distance }) => {
       const pieceType = (movingType || '').toUpperCase();
-      const longRangeStrike = ['B', 'R', 'Q'].includes(pieceType) && distance >= 2;
-      if (longRangeStrike) {
-        createScreenEffect({
-          pos: fromPos,
+      if (pieceType === 'B') {
+        animateEffect({
+          fromPos,
+          toPos: targetPos,
           className: 'chess-capture-drone',
-          text: '🚁',
-          fontSize: 52,
-          durationMs: 850
+          contentType: 'drone',
+          widthPx: 52,
+          durationMs: 860,
+          style: 'drone'
+        });
+        playAudio(droneSoundRef, { maxDurationMs: 740 });
+        setTimeout(() => {
+          animateEffect({
+            fromPos,
+            toPos: targetPos,
+            className: 'chess-capture-missile',
+            contentType: 'missile',
+            widthPx: 54,
+            durationMs: 360,
+            style: 'projectile'
+          });
+          playAudio(missileLaunchSoundRef);
+        }, 460);
+        setTimeout(() => {
+          createExplosion(targetPos);
+          playAudio(bombSoundRef, { maxDurationMs: 520 });
+          playAudio(missileImpactSoundRef);
+        }, 820);
+        return { moveDelayMs: 860 };
+      }
+      if (pieceType === 'Q') {
+        animateEffect({
+          fromPos,
+          toPos: targetPos,
+          className: 'chess-capture-jet',
+          contentType: 'jet',
+          widthPx: 78,
+          durationMs: 920,
+          style: 'jet'
+        });
+        playAudio({ current: jetFlySound }, { maxDurationMs: 780 });
+        setTimeout(() => {
+          animateEffect({
+            fromPos,
+            toPos: targetPos,
+            className: 'chess-capture-missile',
+            contentType: 'missile',
+            widthPx: 62,
+            durationMs: 380,
+            style: 'projectile'
+          });
+          playAudio(missileLaunchSoundRef);
+        }, 300);
+        setTimeout(() => {
+          createExplosion(targetPos);
+          playAudio(bombSoundRef, { maxDurationMs: 520 });
+          playAudio(missileImpactSoundRef);
+        }, 760);
+        return { moveDelayMs: 840 };
+      }
+      if (pieceType === 'R' || pieceType === 'N') {
+        animateEffect({
+          fromPos,
+          toPos: targetPos,
+          className: 'chess-capture-bazooka',
+          contentType: 'bazooka',
+          widthPx: 68,
+          durationMs: 300,
+          style: 'aim'
         });
         setTimeout(() => {
-          createScreenEffect({
-            pos: targetPos,
+          animateEffect({
+            fromPos,
+            toPos: targetPos,
             className: 'chess-capture-missile',
-            text: '🚀',
-            fontSize: 54,
-            durationMs: 760
+            contentType: 'missile',
+            widthPx: 58,
+            durationMs: 340,
+            style: 'projectile'
           });
+          playAudio(missileLaunchSoundRef);
         }, 180);
-        setTimeout(() => createExplosion(targetPos), 350);
-        playAudio(droneSoundRef);
-        setTimeout(() => playAudio(missileLaunchSoundRef), 140);
-        setTimeout(() => playAudio(missileImpactSoundRef), 360);
-        return { moveDelayMs: 520 };
+        setTimeout(() => {
+          createExplosion(targetPos);
+          playAudio(bombSoundRef, { maxDurationMs: 520 });
+          playAudio(missileImpactSoundRef);
+        }, 560);
+        return { moveDelayMs: 620 };
       }
-      if (distance <= 1.5) {
-        createScreenEffect({
-          pos: targetPos,
+      if (pieceType === 'K' || pieceType === 'P' || distance <= 1.5) {
+        animateEffect({
+          fromPos: targetPos,
+          toPos: targetPos,
           className: 'chess-capture-slice',
-          text: '⚔️',
-          fontSize: 64,
-          durationMs: 620
+          contentType: 'sword',
+          widthPx: 64,
+          durationMs: 220
         });
+        setTimeout(() => {
+          animateEffect({
+            fromPos: targetPos,
+            toPos: targetPos,
+            className: 'chess-capture-slice chess-capture-slice-second',
+            contentType: 'sword',
+            widthPx: 68,
+            durationMs: 220
+          });
+        }, 120);
         playAudio(swordSoundRef);
-        return { moveDelayMs: 220 };
+        setTimeout(() => playAudio(swordSoundRef), 120);
+        setTimeout(() => playAudio(missileImpactSoundRef), 200);
+        return { moveDelayMs: 280 };
+      }
+      if (distance >= 2) {
+        animateEffect({
+          fromPos,
+          toPos: targetPos,
+          className: 'chess-capture-missile',
+          contentType: 'missile',
+          widthPx: 54,
+          durationMs: 340,
+          style: 'projectile'
+        });
+        playAudio(missileLaunchSoundRef);
+        setTimeout(() => {
+          createExplosion(targetPos);
+          playAudio(bombSoundRef, { maxDurationMs: 520 });
+          playAudio(missileImpactSoundRef);
+        }, 340);
+        return { moveDelayMs: 360 };
       }
       createExplosion(targetPos);
+      playAudio(bombSoundRef, { maxDurationMs: 420 });
       playAudio(missileImpactSoundRef);
       return { moveDelayMs: 280 };
     };
@@ -9530,8 +9728,11 @@ function Chess3D({
       laughSoundRef.current?.pause();
       swordSoundRef.current?.pause();
       droneSoundRef.current?.pause();
+      jetFlySound?.pause?.();
       missileLaunchSoundRef.current?.pause();
       missileImpactSoundRef.current?.pause();
+      activeCaptureFx.forEach((fx) => fx?.remove?.());
+      activeCaptureFx.clear();
       clearLaughTimeout();
     };
   }, []);


### PR DESCRIPTION
### Motivation
- Replace simple emoji-based capture visuals with richer screen-space animations (drone, jet, bazooka, missile, sword) and synchronized sounds to make captures more engaging.
- Provide deterministic positioning and lifetime management for transient effects so they can be cleaned up on dispose.

### Description
- Added a large set of CSS rules to `index.css` for new capture models and keyframe animations, and redesigned `.bomb-explosion` into a circular radial-gradient element with size and drop-shadow adjustments.
- Replaced the simple `createScreenEffect` with `animateEffect` and added `projectToScreen` to compute screen coordinates from world positions; `animateEffect` supports multiple `contentType` and `style` behaviors (drone, jet, bazooka, missile, sword, projectile, aim) and drives DOM animation via `requestAnimationFrame`.
- Implemented orchestration in `ChessBattleRoyal.jsx` to map piece types to effect sequences and audio cues, introduced `JET_FLY_SOUND_URL` and `BAZOOKA_FIRE_SOUND_URL`, created a local `jetFlySound`, changed missile launch audio usage, and updated `swordSoundRef` initialization path.
- Added runtime management with `activeCaptureFx` to track and remove running effects on cleanup and paused/removed `jetFlySound` on dispose.

### Testing
- Ran the app build (`npm run build`) locally and the build completed successfully.
- Executed the repository unit test suite (`npm test`) and lint checks (`npm run lint`), and they all passed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7de6d46b88329b53b2b9c145d41e0)