### PR TITLE
Add cinematic capture animations and procedural SFX

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -591,7 +591,12 @@ input:focus {
 
 .bomb-explosion {
   animation: bomb-pop 1s forwards;
-  filter: drop-shadow(0 0 18px rgba(248, 113, 113, 0.95));
+  width: 84px;
+  height: 84px;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at center, rgba(255, 243, 199, 0.95) 0%, rgba(255, 157, 66, 0.82) 35%, rgba(244, 63, 94, 0.35) 62%, rgba(0, 0, 0, 0) 78%);
+  filter: drop-shadow(0 0 20px rgba(248, 113, 113, 0.95));
 }
 
 @keyframes bomb-pop {
@@ -610,6 +615,10 @@ input:focus {
   filter: drop-shadow(0 0 14px rgba(250, 204, 21, 0.9));
 }
 
+.chess-capture-slice-second {
+  animation-delay: 0.06s;
+}
+
 @keyframes chess-capture-slice-pop {
   0% {
     transform: translate(-50%, -50%) rotate(-20deg) scale(0.4);
@@ -626,20 +635,67 @@ input:focus {
 }
 
 .chess-capture-drone {
-  animation: chess-capture-drone-fly 0.85s linear forwards;
+  animation: chess-capture-drone-fly 0.9s linear forwards;
   filter: drop-shadow(0 0 12px rgba(56, 189, 248, 0.95));
+}
+
+.chess-capture-jet {
+  animation: chess-capture-jet-fly 0.98s linear forwards;
+  filter: drop-shadow(0 0 12px rgba(148, 163, 184, 0.95));
+}
+
+@keyframes chess-capture-jet-fly {
+  0% {
+    transform: translate(-50%, -50%) translate(0px, 0px) scale(0.62) rotate(-8deg);
+    opacity: 0;
+  }
+  20% {
+    transform: translate(-50%, -50%) translate(calc(var(--flight-dx, 0px) * 0.45), calc(var(--flight-dy, 0px) * 0.42 - var(--flight-arc, 90px))) scale(0.86) rotate(2deg);
+    opacity: 1;
+  }
+  100% {
+    transform: translate(-50%, -50%) translate(var(--flight-dx, 0px), var(--flight-dy, 0px)) scale(1.08) rotate(7deg);
+    opacity: 0;
+  }
+}
+
+.chess-capture-bazooka {
+  animation: chess-capture-bazooka-fire 0.84s ease-out forwards;
+  filter: drop-shadow(0 0 12px rgba(148, 163, 184, 0.95));
+}
+
+@keyframes chess-capture-bazooka-fire {
+  0% {
+    transform: translate(-50%, -50%) translate(0px, 0px) scale(0.66) rotate(-14deg);
+    opacity: 0;
+  }
+  18% {
+    opacity: 1;
+  }
+  60% {
+    transform: translate(-50%, -50%) translate(calc(var(--flight-dx, 0px) * 0.55), calc(var(--flight-dy, 0px) * 0.5 - var(--flight-arc, 60px))) scale(0.92) rotate(-8deg);
+    opacity: 1;
+  }
+  100% {
+    transform: translate(-50%, -50%) translate(var(--flight-dx, 0px), var(--flight-dy, 0px)) scale(1.02) rotate(-4deg);
+    opacity: 0;
+  }
 }
 
 @keyframes chess-capture-drone-fly {
   0% {
-    transform: translate(-120%, -160%) scale(0.45);
+    transform: translate(-50%, -50%) translate(0px, 0px) scale(0.45);
     opacity: 0;
   }
   20% {
     opacity: 1;
   }
+  58% {
+    transform: translate(-50%, -50%) translate(calc(var(--flight-dx, 0px) * 0.55), calc(var(--flight-dy, 0px) * 0.5 - var(--flight-arc, 100px))) scale(0.82);
+    opacity: 1;
+  }
   100% {
-    transform: translate(60%, -80%) scale(0.95);
+    transform: translate(-50%, -50%) translate(var(--flight-dx, 0px), var(--flight-dy, 0px)) scale(0.95);
     opacity: 0;
   }
 }
@@ -651,20 +707,199 @@ input:focus {
 
 @keyframes chess-capture-missile-hit {
   0% {
-    transform: translate(120%, -120%) scale(0.5) rotate(-18deg);
+    transform: translate(-50%, -50%) translate(0px, 0px) scale(0.5) rotate(-18deg);
     opacity: 0;
   }
   30% {
     opacity: 1;
   }
   65% {
-    transform: translate(-30%, -20%) scale(1.08) rotate(12deg);
+    transform: translate(-50%, -50%) translate(calc(var(--flight-dx, 0px) * 0.6), calc(var(--flight-dy, 0px) * 0.58 - var(--flight-arc, 70px))) scale(1.08) rotate(12deg);
     opacity: 1;
   }
   100% {
-    transform: translate(-50%, -50%) scale(1.9) rotate(12deg);
+    transform: translate(-50%, -50%) translate(var(--flight-dx, 0px), var(--flight-dy, 0px)) scale(1.9) rotate(12deg);
     opacity: 0;
   }
+}
+
+.chess-capture-model {
+  position: relative;
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.chess-capture-model span {
+  position: absolute;
+  display: block;
+}
+
+.chess-capture-model.drone .body,
+.chess-capture-model.jet .body {
+  left: 14%;
+  top: 38%;
+  width: 66%;
+  height: 24%;
+  border-radius: 999px;
+  background: linear-gradient(180deg, #e2e8f0 0%, #94a3b8 100%);
+}
+
+.chess-capture-model.drone .wing {
+  left: 24%;
+  top: 14%;
+  width: 48%;
+  height: 72%;
+  clip-path: polygon(0 50%, 100% 0, 100% 100%);
+  background: #a3b4c6;
+}
+
+.chess-capture-model.drone .tail {
+  left: 7%;
+  top: 43%;
+  width: 15%;
+  height: 14%;
+  border-radius: 999px;
+  background: #6b7280;
+}
+
+.chess-capture-model.drone .prop {
+  left: 0%;
+  top: 32%;
+  width: 18%;
+  height: 36%;
+}
+
+.chess-capture-model.drone .prop::before,
+.chess-capture-model.drone .prop::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  margin: auto;
+  background: #111827;
+}
+
+.chess-capture-model.drone .prop::before {
+  width: 100%;
+  height: 12%;
+}
+
+.chess-capture-model.drone .prop::after {
+  width: 12%;
+  height: 100%;
+}
+
+.chess-capture-model.jet .body {
+  width: 74%;
+  left: 12%;
+}
+
+.chess-capture-model.jet .wing {
+  left: 20%;
+  top: 11%;
+  width: 54%;
+  height: 78%;
+  clip-path: polygon(0 50%, 100% 6%, 80% 50%, 100% 94%);
+  background: #94a3b8;
+}
+
+.chess-capture-model.jet .tail {
+  left: 10%;
+  top: 30%;
+  width: 20%;
+  height: 40%;
+  clip-path: polygon(0 50%, 100% 0, 72% 50%, 100% 100%);
+  background: #cbd5e1;
+}
+
+.chess-capture-model.jet .cockpit {
+  left: 58%;
+  top: 30%;
+  width: 14%;
+  height: 34%;
+  border-radius: 999px;
+  background: #0f172a;
+}
+
+.chess-capture-model.bazooka .tube {
+  left: 10%;
+  top: 34%;
+  width: 78%;
+  height: 32%;
+  border-radius: 999px;
+  background: linear-gradient(180deg, #cbd5e1 0%, #64748b 100%);
+}
+
+.chess-capture-model.bazooka .grip {
+  left: 36%;
+  top: 56%;
+  width: 12%;
+  height: 24%;
+  border-radius: 3px;
+  background: #1f2937;
+}
+
+.chess-capture-model.bazooka .tip {
+  right: 6%;
+  top: 36%;
+  width: 14%;
+  height: 28%;
+  clip-path: polygon(0 0, 100% 50%, 0 100%);
+  background: #e2e8f0;
+}
+
+.chess-capture-model.missile .body {
+  left: 16%;
+  top: 37%;
+  width: 64%;
+  height: 26%;
+  border-radius: 999px;
+  background: linear-gradient(180deg, #e5e7eb 0%, #9ca3af 100%);
+}
+
+.chess-capture-model.missile .tip {
+  right: 10%;
+  top: 34%;
+  width: 14%;
+  height: 32%;
+  clip-path: polygon(0 0, 100% 50%, 0 100%);
+  background: #f3f4f6;
+}
+
+.chess-capture-model.missile .fins {
+  left: 18%;
+  top: 24%;
+  width: 14%;
+  height: 52%;
+  background: linear-gradient(180deg, #6b7280 0%, #4b5563 100%);
+  clip-path: polygon(0 10%, 100% 0, 100% 100%, 0 90%);
+}
+
+.chess-capture-model.sword .blade {
+  left: 42%;
+  top: 8%;
+  width: 14%;
+  height: 70%;
+  clip-path: polygon(50% 0, 100% 14%, 75% 100%, 25% 100%, 0 14%);
+  background: linear-gradient(180deg, #f8fafc 0%, #cbd5e1 100%);
+}
+
+.chess-capture-model.sword .guard {
+  left: 29%;
+  top: 62%;
+  width: 40%;
+  height: 8%;
+  border-radius: 999px;
+  background: #fbbf24;
+}
+
+.chess-capture-model.sword .handle {
+  left: 44%;
+  top: 70%;
+  width: 10%;
+  height: 22%;
+  border-radius: 999px;
+  background: #4b5563;
 }
 
 /* Larger token variant used for inactive pieces */

--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -988,9 +988,9 @@ const CHECK_SOUND_URL =
 const CHECKMATE_SOUND_URL =
   'https://raw.githubusercontent.com/lichess-org/lila/master/public/sound/standard/End.mp3';
 const LAUGH_SOUND_URL = '/assets/sounds/Haha.mp3';
-const SWORD_SLASH_SOUND_URL = '/assets/sounds/punch-03-352040.mp3';
-const DRONE_FLY_SOUND_URL = '/assets/sounds/ufo-sound-effect-240256.mp3';
-const MISSILE_FIRE_SOUND_URL = '/assets/sounds/launch-85216.mp3';
+const DRONE_ATTACK_SOUND_URL = '/assets/sounds/ufo-sound-effect-240256.mp3';
+const JET_ATTACK_SOUND_URL = '/assets/sounds/race-care-151963.mp3';
+const BAZOOKA_FIRE_SOUND_URL = '/assets/sounds/launch-85216.mp3';
 const MISSILE_IMPACT_SOUND_URL = '/assets/sounds/080998_bullet-hit-39870.mp3';
 
 const BEAUTIFUL_GAME_THEME_CONFIGS = Object.freeze([
@@ -6031,6 +6031,7 @@ function Chess3D({
   const laughSoundRef = useRef(null);
   const swordSoundRef = useRef(null);
   const droneSoundRef = useRef(null);
+  const jetSoundRef = useRef(null);
   const missileLaunchSoundRef = useRef(null);
   const missileImpactSoundRef = useRef(null);
   const laughTimeoutRef = useRef(null);
@@ -6973,7 +6974,7 @@ function Chess3D({
         } catch {}
       }
     }
-    [swordSoundRef, droneSoundRef, missileLaunchSoundRef, missileImpactSoundRef].forEach((ref) => {
+    [swordSoundRef, droneSoundRef, jetSoundRef, missileLaunchSoundRef, missileImpactSoundRef].forEach((ref) => {
       if (!ref.current) return;
       ref.current.volume = effectiveSoundEnabled ? volume : 0;
       if (!effectiveSoundEnabled) {
@@ -7010,7 +7011,7 @@ function Chess3D({
       if (laughSoundRef.current) {
         laughSoundRef.current.volume = settingsRef.current.soundEnabled ? volume : 0;
       }
-      [swordSoundRef, droneSoundRef, missileLaunchSoundRef, missileImpactSoundRef].forEach((ref) => {
+      [swordSoundRef, droneSoundRef, jetSoundRef, missileLaunchSoundRef, missileImpactSoundRef].forEach((ref) => {
         if (!ref.current) return;
         ref.current.volume = settingsRef.current.soundEnabled ? volume : 0;
       });
@@ -7328,14 +7329,63 @@ function Chess3D({
     mateSoundRef.current.volume = baseVolume;
     laughSoundRef.current = new Audio(LAUGH_SOUND_URL);
     laughSoundRef.current.volume = baseVolume;
-    swordSoundRef.current = new Audio(SWORD_SLASH_SOUND_URL);
-    swordSoundRef.current.volume = baseVolume;
-    droneSoundRef.current = new Audio(DRONE_FLY_SOUND_URL);
+    droneSoundRef.current = new Audio(DRONE_ATTACK_SOUND_URL);
     droneSoundRef.current.volume = baseVolume;
-    missileLaunchSoundRef.current = new Audio(MISSILE_FIRE_SOUND_URL);
+    swordSoundRef.current = null;
+    missileLaunchSoundRef.current = new Audio(BAZOOKA_FIRE_SOUND_URL);
     missileLaunchSoundRef.current.volume = baseVolume;
     missileImpactSoundRef.current = new Audio(MISSILE_IMPACT_SOUND_URL);
     missileImpactSoundRef.current.volume = baseVolume;
+    jetSoundRef.current = new Audio(JET_ATTACK_SOUND_URL);
+    jetSoundRef.current.volume = baseVolume;
+    let synthCtx = null;
+
+    const ensureSynthContext = () => {
+      if (typeof window === 'undefined') return null;
+      const Ctx = window.AudioContext || window.webkitAudioContext;
+      if (!Ctx) return null;
+      if (!synthCtx) synthCtx = new Ctx();
+      if (synthCtx.state === 'suspended') synthCtx.resume().catch(() => {});
+      return synthCtx;
+    };
+
+    const playProceduralSfx = (type) => {
+      if (!settingsRef.current.soundEnabled || isGameMuted()) return;
+      const ctx = ensureSynthContext();
+      if (!ctx) return;
+      const now = ctx.currentTime + 0.005;
+      const gainNode = ctx.createGain();
+      const master = clamp(getGameVolume() * 0.8, 0, 1);
+      gainNode.gain.setValueAtTime(master, now);
+      gainNode.connect(ctx.destination);
+
+      const tone = (freqStart, freqEnd, duration, wave = 'sawtooth', volume = 0.18) => {
+        const osc = ctx.createOscillator();
+        const g = ctx.createGain();
+        osc.type = wave;
+        osc.frequency.setValueAtTime(freqStart, now);
+        osc.frequency.exponentialRampToValueAtTime(Math.max(30, freqEnd), now + duration);
+        g.gain.setValueAtTime(0.0001, now);
+        g.gain.exponentialRampToValueAtTime(volume, now + 0.015);
+        g.gain.exponentialRampToValueAtTime(0.0001, now + duration);
+        osc.connect(g);
+        g.connect(gainNode);
+        osc.start(now);
+        osc.stop(now + duration + 0.02);
+      };
+
+      if (type === 'drone') {
+        tone(220, 160, 0.28, 'triangle', 0.12);
+      } else if (type === 'jet') {
+        tone(680, 210, 0.3, 'sawtooth', 0.2);
+      } else if (type === 'launch') {
+        tone(180, 900, 0.14, 'square', 0.16);
+      } else if (type === 'impact') {
+        tone(900, 90, 0.24, 'sawtooth', 0.2);
+      } else if (type === 'sword') {
+        tone(1200, 340, 0.09, 'triangle', 0.12);
+      }
+    };
 
     let stopCameraTween = () => {};
     let onResize = null;
@@ -7932,90 +7982,180 @@ function Chess3D({
       envSkyboxRef.current?.scale?.x ?? baseSkyboxScaleRef.current ?? 1;
     syncSkyboxToCamera();
 
-    const createExplosion = (pos) => {
+    const worldToScreen = (worldPos) => {
       const rect = renderer.domElement.getBoundingClientRect();
-      const v = pos.clone().project(camera);
-      const x = rect.left + ((v.x + 1) / 2) * rect.width;
-      const y = rect.top + ((-v.y + 1) / 2) * rect.height;
+      const projected = worldPos.clone().project(camera);
+      return {
+        x: rect.left + ((projected.x + 1) / 2) * rect.width,
+        y: rect.top + ((-projected.y + 1) / 2) * rect.height
+      };
+    };
+
+    const createExplosion = (pos) => {
+      const { x, y } = worldToScreen(pos);
       const el = document.createElement('div');
-      el.textContent = '💨';
       el.className = 'bomb-explosion';
       el.style.position = 'fixed';
       el.style.transform = 'translate(-50%, -50%) scale(1)';
-      el.style.fontSize = '64px';
       el.style.pointerEvents = 'none';
       el.style.zIndex = '200';
       el.style.left = `${x}px`;
       el.style.top = `${y}px`;
       document.body.appendChild(el);
+      playAudio(bombSoundRef, { maxDurationMs: 520 });
       setTimeout(() => el.remove(), 1000);
     };
 
     const createScreenEffect = ({
-      pos,
+      pos = null,
+      fromPos = null,
+      toPos = null,
       className,
-      text,
+      contentType = 'drone',
       fontSize = 56,
-      durationMs = 900
+      durationMs = 900,
+      arcHeightPx = 90
     }) => {
-      if (!pos) return;
-      const rect = renderer.domElement.getBoundingClientRect();
-      const v = pos.clone().project(camera);
-      const x = rect.left + ((v.x + 1) / 2) * rect.width;
-      const y = rect.top + ((-v.y + 1) / 2) * rect.height;
+      if (!pos && (!fromPos || !toPos)) return;
+      const start = fromPos ? worldToScreen(fromPos) : worldToScreen(pos);
+      const end = toPos ? worldToScreen(toPos) : start;
+      const dx = end.x - start.x;
+      const dy = end.y - start.y;
       const el = document.createElement('div');
-      el.textContent = text;
       el.className = className;
       el.style.position = 'fixed';
       el.style.transform = 'translate(-50%, -50%)';
-      el.style.fontSize = `${fontSize}px`;
+      el.style.width = `${fontSize}px`;
+      el.style.height = `${Math.max(20, fontSize * 0.42)}px`;
       el.style.pointerEvents = 'none';
       el.style.zIndex = '201';
-      el.style.left = `${x}px`;
-      el.style.top = `${y}px`;
+      el.style.left = `${start.x}px`;
+      el.style.top = `${start.y}px`;
+      el.style.setProperty('--flight-dx', `${dx}px`);
+      el.style.setProperty('--flight-dy', `${dy}px`);
+      el.style.setProperty('--flight-arc', `${Math.max(32, arcHeightPx)}px`);
+      if (contentType === 'drone') {
+        el.innerHTML = '<span class="chess-capture-model drone"><span class="body"></span><span class="wing"></span><span class="tail"></span><span class="prop"></span></span>';
+      } else if (contentType === 'jet') {
+        el.innerHTML = '<span class="chess-capture-model jet"><span class="body"></span><span class="wing"></span><span class="tail"></span><span class="cockpit"></span></span>';
+      } else if (contentType === 'bazooka') {
+        el.innerHTML = '<span class="chess-capture-model bazooka"><span class="tube"></span><span class="grip"></span><span class="tip"></span></span>';
+      } else if (contentType === 'missile') {
+        el.innerHTML = '<span class="chess-capture-model missile"><span class="body"></span><span class="tip"></span><span class="fins"></span></span>';
+      } else if (contentType === 'sword') {
+        el.innerHTML = '<span class="chess-capture-model sword"><span class="blade"></span><span class="guard"></span><span class="handle"></span></span>';
+      }
       document.body.appendChild(el);
       setTimeout(() => el.remove(), durationMs);
     };
 
     const playCaptureAnimation = ({ fromPos, targetPos, movingType, distance }) => {
       const pieceType = (movingType || '').toUpperCase();
-      const longRangeStrike = ['B', 'R', 'Q'].includes(pieceType) && distance >= 2;
-      if (longRangeStrike) {
+      if (pieceType === 'B') {
         createScreenEffect({
-          pos: fromPos,
+          fromPos,
+          toPos: targetPos,
           className: 'chess-capture-drone',
-          text: '🚁',
+          contentType: 'drone',
           fontSize: 52,
-          durationMs: 850
+          durationMs: 900,
+          arcHeightPx: 120
+        });
+        setTimeout(() => createExplosion(targetPos), 740);
+        playAudio(droneSoundRef);
+        setTimeout(() => playAudio(missileImpactSoundRef), 730);
+        return { moveDelayMs: 780 };
+      }
+      if (pieceType === 'Q') {
+        createScreenEffect({
+          fromPos,
+          toPos: targetPos,
+          className: 'chess-capture-jet',
+          contentType: 'jet',
+          fontSize: 78,
+          durationMs: 980,
+          arcHeightPx: 135
+        });
+        setTimeout(() => {
+          createScreenEffect({
+            fromPos,
+            toPos: targetPos,
+            className: 'chess-capture-missile',
+            contentType: 'missile',
+            fontSize: 62,
+            durationMs: 620,
+            arcHeightPx: 88
+          });
+        }, 190);
+        setTimeout(() => createExplosion(targetPos), 700);
+        playAudio(jetSoundRef);
+        setTimeout(() => playAudio(missileLaunchSoundRef), 180);
+        setTimeout(() => playAudio(missileImpactSoundRef), 670);
+        return { moveDelayMs: 760 };
+      }
+      if (pieceType === 'R' || pieceType === 'N') {
+        createScreenEffect({
+          fromPos,
+          toPos: targetPos,
+          className: 'chess-capture-bazooka',
+          contentType: 'bazooka',
+          fontSize: 68,
+          durationMs: 820,
+          arcHeightPx: 70
+        });
+        setTimeout(() => {
+          createScreenEffect({
+            fromPos,
+            toPos: targetPos,
+            className: 'chess-capture-missile',
+            contentType: 'missile',
+            fontSize: 58,
+            durationMs: 560,
+            arcHeightPx: 60
+          });
+        }, 140);
+        setTimeout(() => createExplosion(targetPos), 580);
+        playAudio(missileLaunchSoundRef);
+        setTimeout(() => playAudio(missileImpactSoundRef), 560);
+        return { moveDelayMs: 620 };
+      }
+      if (pieceType === 'K' || pieceType === 'P' || distance <= 1.5) {
+        createScreenEffect({
+          pos: targetPos,
+          className: 'chess-capture-slice',
+          contentType: 'sword',
+          fontSize: 64,
+          durationMs: 680
         });
         setTimeout(() => {
           createScreenEffect({
             pos: targetPos,
-            className: 'chess-capture-missile',
-            text: '🚀',
-            fontSize: 54,
-            durationMs: 760
+            className: 'chess-capture-slice chess-capture-slice-second',
+            contentType: 'sword',
+            fontSize: 68,
+            durationMs: 620
           });
-        }, 180);
-        setTimeout(() => createExplosion(targetPos), 350);
-        playAudio(droneSoundRef);
-        setTimeout(() => playAudio(missileLaunchSoundRef), 140);
-        setTimeout(() => playAudio(missileImpactSoundRef), 360);
-        return { moveDelayMs: 520 };
+        }, 120);
+        playProceduralSfx('sword');
+        setTimeout(() => playProceduralSfx('sword'), 120);
+        setTimeout(() => playProceduralSfx('impact'), 200);
+        return { moveDelayMs: 280 };
       }
-      if (distance <= 1.5) {
+      if (distance >= 2) {
         createScreenEffect({
-          pos: targetPos,
-          className: 'chess-capture-slice',
-          text: '⚔️',
+          pos: fromPos,
+          className: 'chess-capture-bazooka',
+          contentType: 'bazooka',
           fontSize: 64,
-          durationMs: 620
+          durationMs: 700
         });
-        playAudio(swordSoundRef);
-        return { moveDelayMs: 220 };
+        setTimeout(() => createExplosion(targetPos), 260);
+        playProceduralSfx('launch');
+        setTimeout(() => playProceduralSfx('impact'), 280);
+        return { moveDelayMs: 360 };
       }
       createExplosion(targetPos);
-      playAudio(missileImpactSoundRef);
+      playProceduralSfx('impact');
       return { moveDelayMs: 280 };
     };
 
@@ -9530,8 +9670,13 @@ function Chess3D({
       laughSoundRef.current?.pause();
       swordSoundRef.current?.pause();
       droneSoundRef.current?.pause();
+      jetSoundRef.current?.pause();
       missileLaunchSoundRef.current?.pause();
       missileImpactSoundRef.current?.pause();
+      if (synthCtx && typeof synthCtx.close === 'function') {
+        synthCtx.close().catch(() => {});
+        synthCtx = null;
+      }
       clearLaughTimeout();
     };
   }, []);


### PR DESCRIPTION
### Motivation
- Improve the visual and audio feedback for piece captures by replacing simple emoji effects with richer animated models and timed explosions.  
- Support multiple attack styles (drone, jet, bazooka, missile, sword) and unify flight trajectories so effects can animate from source to target.  
- Provide reliable sound feedback via asset-backed audio plus a lightweight procedural synth for short SFX and fallback usage.

### Description
- Added extensive CSS for capture visuals including `.chess-capture-*` animations and a small DOM model system (`.chess-capture-model`) for `drone`, `jet`, `bazooka`, `missile`, and `sword` visuals.  
- Reworked capture logic in `ChessBattleRoyal.jsx`: introduced `worldToScreen`, refactored `createExplosion`/`createScreenEffect` to accept `fromPos`/`toPos`, and render model HTML into the page with per-effect timing, arc and flight deltas.  
- Replaced/renamed several sound constants and refs, added `jetSoundRef`, switched some effects to use `playProceduralSfx` (procedural WebAudio synth) and kept sampled audio for launches/impacts; implemented `ensureSynthContext` and cleanup of the synth AudioContext.  
- Adjusted timings and returned `moveDelayMs` per capture type, removed emoji text usage, and updated cleanup to close the synth context and pause new sound refs.

### Testing
- Ran the repository build with `yarn build` which completed successfully.  
- Executed the automated test suite with `yarn test` and the existing tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7de6d46b88329b53b2b9c145d41e0)