### PR TITLE
Fix Snake & Ladder extra-roll button visibility and adjust portrait camera framing

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -269,10 +269,10 @@ const INITIAL_CAMERA_DISTANCE_FACTOR = 0.35;
 const POINTER_TAP_MAX_DISTANCE = 14;
 const POINTER_TAP_MAX_DURATION_MS = 420;
 const PORTRAIT_CAMERA_TUNING = Object.freeze({
-  backOffset: 1.14,
+  backOffset: 1.06,
   forwardOffset: 0,
-  heightOffset: 2.42,
-  targetLift: 0.07 * MODEL_SCALE
+  heightOffset: 2.5,
+  targetLift: 0.058 * MODEL_SCALE
 });
 const LANDSCAPE_CAMERA_TUNING = Object.freeze({
   backOffset: 0.68,

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -2130,15 +2130,20 @@ export default function SnakeAndLadder() {
       }, 1000);
     };
     const onTurn = ({ playerId, seatIndex }) => {
+      const players = playersRef.current;
+      const seatAssignments = computeSeatAssignments(players, myAccountId);
       let idx = -1;
 
       if (Number.isInteger(seatIndex)) {
-        idx = seatIndex;
-      } else {
-        idx = playersRef.current.findIndex((pl) => pl.id === playerId);
+        idx = players.findIndex((_, playerIdx) => seatAssignments.get(playerIdx) === seatIndex);
+        if (idx === -1 && seatIndex >= 0 && seatIndex < players.length) idx = seatIndex;
+      }
 
-        // Some servers emit the active seat index instead of a playerId.
-        if (idx === -1 && Number.isInteger(playerId)) {
+      if (idx === -1 && playerId != null) {
+        idx = players.findIndex((pl) => pl.id === playerId);
+
+        // Some servers emit the active player index instead of a playerId.
+        if (idx === -1 && Number.isInteger(playerId) && playerId >= 0 && playerId < players.length) {
           idx = playerId;
         }
       }
@@ -2146,7 +2151,7 @@ export default function SnakeAndLadder() {
       if (idx >= 0) {
         setCurrentTurn(idx);
         setDiceCount(playerDiceCounts[idx] ?? 1);
-        const turnBelongsToMe = playersRef.current[idx]?.id === myAccountId;
+        const turnBelongsToMe = players[idx]?.id === myAccountId;
         if (turnBelongsToMe) {
           // Keep roll CTA visible for immediate extra turns.
           setRollCooldown(0);
@@ -3147,9 +3152,16 @@ export default function SnakeAndLadder() {
     ? mpPlayers.findIndex((p) => p.id === accountId)
     : 0;
   const myPlayerIndex = computedIndex >= 0 ? computedIndex : null;
+  const mySeatIndex =
+    myPlayerIndex !== null && seatAssignments.has(myPlayerIndex)
+      ? seatAssignments.get(myPlayerIndex)
+      : null;
   const hasLocalExtraRoll = isMultiplayer && pendingExtraRoll;
   const isMyTurnForRoll =
-    myPlayerIndex !== null && (currentTurn === myPlayerIndex || hasLocalExtraRoll);
+    myPlayerIndex !== null &&
+    (currentTurn === myPlayerIndex ||
+      (mySeatIndex != null && currentTurn === mySeatIndex) ||
+      hasLocalExtraRoll);
   const rollReady = hasLocalExtraRoll || rollCooldown === 0;
   const canRoll =
     isMyTurnForRoll &&


### PR DESCRIPTION
### Motivation
- Improve mobile portrait framing so the camera appears slightly closer, a bit higher and looks marginally more downward for better table visibility on phones.
- Fix a multiplayer turn-identification bug where server `seatIndex` events could be misinterpreted, causing the local bottom player to lose the extra-roll CTA after rolling a 6.

### Description
- Tuned portrait camera constants in `webapp/src/components/SnakeBoard3D.jsx` by adjusting `PORTRAIT_CAMERA_TUNING` (`backOffset`, `heightOffset`, `targetLift`) to bring the camera slightly closer and higher on screen.
- Mapped incoming `seatIndex` turn events to the correct local player index in `webapp/src/pages/Games/SnakeAndLadder.jsx` before updating `currentTurn`, handling both `seatIndex` and `playerId` variants robustly.
- Improved local roll eligibility logic in `SnakeAndLadder.jsx` by checking both player index and seat index (and pending extra-roll state) so the roll CTA remains visible when the server uses seat-based turn messages.
- Changed code references: `computeSeatAssignments` is used to resolve seat->player mapping and `pendingExtraRoll`/`rollCooldown` logic is preserved to keep extra-roll behavior consistent.

### Testing
- Ran `npx eslint webapp/src/pages/Games/SnakeAndLadder.jsx webapp/src/components/SnakeBoard3D.jsx`, which completed but reported the files are ignored by current ESLint ignore settings (warnings only).
- Built the web client with `npm --prefix webapp run build`, which completed successfully (Vite produced unrelated chunk-size warnings but the build succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7ea026e00832985c9b958a5a975ba)