### PR TITLE
Fix Snake extra roll on six and refine portrait camera angle

### DIFF
--- a/bot/logic/snakeGame.js
+++ b/bot/logic/snakeGame.js
@@ -106,7 +106,7 @@ export class SnakeGame {
       player.bonus = bonus;
       delete this.diceCells[player.position];
       extraTurn = true;
-    } else if (doubleSix) {
+    } else if (rolledSix) {
       extraTurn = true;
     }
 

--- a/test/snakeGame.test.js
+++ b/test/snakeGame.test.js
@@ -30,7 +30,7 @@ test('applySnakesAndLadders resolves moves', () => {
   assert.equal(room.applySnakesAndLadders(8), 8); // none
 });
 
-test('start requires 6 and rolling 6 does not grant extra turn', () => {
+test('start requires 6 and rolling 6 grants extra turn', () => {
   const io = new DummyIO();
   const room = new GameRoom('r', io, 2, {
     snakes: DEFAULT_SNAKES,
@@ -49,11 +49,14 @@ test('start requires 6 and rolling 6 does not grant extra turn', () => {
 
   room.rollDice(s2, [6, 2]);
   assert.equal(room.players[1].position, 1);
+  assert.equal(room.currentTurn, 1);
+
+  room.rollDice(s2, [1, 2]);
   assert.equal(room.currentTurn, 0);
 
   room.rollDice(s1, [6, 1]);
   assert.equal(room.players[0].position, 1);
-  assert.equal(room.currentTurn, 1);
+  assert.equal(room.currentTurn, 0);
 });
 
 test('rolling multiple sixes grants extra turns but preserves order', () => {
@@ -227,4 +230,3 @@ test('dice cells are shared across players', () => {
     room.turnTimer = null;
   }
 });
-

--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -269,10 +269,10 @@ const INITIAL_CAMERA_DISTANCE_FACTOR = 0.35;
 const POINTER_TAP_MAX_DISTANCE = 14;
 const POINTER_TAP_MAX_DURATION_MS = 420;
 const PORTRAIT_CAMERA_TUNING = Object.freeze({
-  backOffset: 1.14,
+  backOffset: 1.06,
   forwardOffset: 0,
-  heightOffset: 2.42,
-  targetLift: 0.07 * MODEL_SCALE
+  heightOffset: 2.54,
+  targetLift: 0.055 * MODEL_SCALE
 });
 const LANDSCAPE_CAMERA_TUNING = Object.freeze({
   backOffset: 0.68,


### PR DESCRIPTION
### Motivation
- Players who rolled a 6 could get stuck because the client/server logic only awarded an extra roll for double-sixes; this change restores the intended UX where any roll containing a 6 grants an immediate extra turn. 
- The camera framing in portrait mode needed a small tweak so the table appears slightly closer, a bit higher, and the view looks slightly more downward on phone portrait screens for better token visibility.

### Description
- Treat any roll that includes a six as an extra turn by changing the extra-turn condition in `bot/logic/snakeGame.js` from `doubleSix` to `rolledSix` so extra rolls are awarded consistently. 
- Update `test/snakeGame.test.js` to reflect the intended extra-turn behavior after rolling a six and adjust assertions accordingly. 
- Tune portrait camera defaults in `webapp/src/components/SnakeBoard3D.jsx` by adjusting `backOffset`, `heightOffset`, and `targetLift` so the camera sits a bit closer, slightly higher, and looks slightly more down at the table.

### Testing
- Ran the unit test file with `node --test test/snakeGame.test.js`, and all tests/subtests passed (10 subtests passed). 
- The test run did surface a non-blocking database warning about storing game results, but it did not cause any test failures and all assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7ea026e00832985c9b958a5a975ba)