### PR TITLE
Ensure extra-roll CTA reappears on a 6 and make tile 50 the final tile

### DIFF
--- a/bot/gameEngine.js
+++ b/bot/gameEngine.js
@@ -1,6 +1,6 @@
 import GameResult from "./models/GameResult.js";
-export const FINAL_TILE = 101;
-export const DEFAULT_SNAKES = { 99: 80 };
+export const FINAL_TILE = 50;
+export const DEFAULT_SNAKES = { 49: 32 };
 export const DEFAULT_LADDERS = { 3: 22, 27: 46 };
 export const ROLL_COOLDOWN_MS = 1000;
 export const RECONNECT_GRACE_MS = 60000;
@@ -298,7 +298,12 @@ export class GameRoom {
       if (!result) return;
 
       const total = result.dice.reduce((a, b) => a + b, 0);
-      this.io.to(this.id).emit('diceRolled', { playerId: player.playerId, value: total });
+      this.io.to(this.id).emit('diceRolled', {
+        playerId: player.playerId,
+        value: total,
+        dice: result.dice,
+        extraTurn: !!result.extraTurn
+      });
       const from = prevPositions[playerIndex];
       const to = result.path.length ? result.path[result.path.length - 1] : from;
 

--- a/bot/logic/snakeGame.js
+++ b/bot/logic/snakeGame.js
@@ -1,4 +1,4 @@
-export const FINAL_TILE = 101;
+export const FINAL_TILE = 50;
 
 export function applySnakesAndLadders(pos, snakes, ladders) {
   if (snakes[pos] != null) return Math.max(0, snakes[pos]);
@@ -66,7 +66,7 @@ export class SnakeGame {
         player.isActive = true;
         target = 1;
       }
-    } else if (player.position === 100) {
+    } else if (player.position === FINAL_TILE - 1) {
       if (player.diceCount === 2) {
         if (rolledSix) {
           player.diceCount = 1;

--- a/webapp/src/components/SnakeBoard.jsx
+++ b/webapp/src/components/SnakeBoard.jsx
@@ -99,7 +99,7 @@ function buildPyramidLayout() {
 
 const BOARD_LAYOUT = buildPyramidLayout();
 export const BOARD_CELL_COUNT = BOARD_LAYOUT.totalCells;
-export const FINAL_TILE = BOARD_CELL_COUNT + 1;
+export const FINAL_TILE = BOARD_CELL_COUNT;
 const BOARD_WIDTH_UNITS = BOARD_LAYOUT.widthUnits;
 const BOARD_HEIGHT_UNITS = BOARD_LAYOUT.heightUnits;
 const CENTER_COLUMN = BOARD_LAYOUT.centerColumn;

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -2209,10 +2209,14 @@ export default function SnakeAndLadder() {
         unseatTable(myAccountId, tableId).catch(() => {});
       }
     };
-    const onRolled = ({ value }) => {
+    const onRolled = ({ value, playerId, extraTurn }) => {
       setRollResult(value);
       setTimeout(() => setRollResult(null), 2000);
       playDiceRollSound();
+      if (playerId === myAccountId) {
+        setPendingExtraRoll(Boolean(extraTurn));
+        if (extraTurn) setRollCooldown(0);
+      }
     };
     const onWon = ({ playerId }) => {
       setGameOver(true);
@@ -4043,10 +4047,6 @@ export default function SnakeAndLadder() {
                   values: vals,
                   seatIndex: currentTurn
                 });
-                const rolledSix = Array.isArray(vals)
-                  ? vals.some((v) => Number(v) === 6)
-                  : Number(vals) === 6;
-                setPendingExtraRoll(rolledSix);
               }}
             />
           ) : null}


### PR DESCRIPTION
### Motivation
- Fix a multiplayer UX bug where a player who earned an extra turn (e.g., by rolling a 6) did not see the `ROLL` CTA reappear in the same place.
- Align game rules so the board ends at tile 50 and the first token to reach tile 50 is declared the winner.

### Description
- Server: updated `bot/gameEngine.js` to set `FINAL_TILE = 50` and include raw `dice` and an authoritative `extraTurn` flag in the `diceRolled` event payload (`diceRolled: { playerId, value, dice, extraTurn }`).
- Logic: updated `bot/logic/snakeGame.js` to use `FINAL_TILE = 50` and changed the penultimate-tile check to `player.position === FINAL_TILE - 1` so finishing logic is correct for a 50-tile board and `finished` is set when a token reaches tile 50.
- Client: adjusted `webapp/src/pages/Games/SnakeAndLadder.jsx` to rely on the server `extraTurn` value in the `onRolled` handler and set `pendingExtraRoll`/`rollCooldown` from that authoritative value for the local player, removing the previous inference from local dice animation results; also removed the local `rolledSix` inference used for multiplayer extra-roll logic.
- UI/Board: aligned board constant in `webapp/src/components/SnakeBoard.jsx` by changing `FINAL_TILE` to match the board cell count so UI and rules remain consistent.
- Minor: updated default snake mapping in `bot/gameEngine.js` to stay within the new 50-tile range.

### Testing
- Ran a direct Node.js logic sanity check using `node -e` to instantiate `SnakeGame` and simulate rolls, which verified that extra turns after rolling a 6 are granted and that the game finishes when a token reaches tile 50 (success).
- Ran `npx eslint` against modified files; the targeted logic change behaved correctly, however a full `--no-ignore` lint run surfaced many pre-existing style rule violations in these files (baseline in repo) that are unrelated to the functional fix (lint run reported errors/warnings).
- Verified server `diceRolled` emits include `dice` and `extraTurn` and client `onRolled` consumes `extraTurn` to restore the local roll CTA (manual event-driven validation via code inspection and the Node check above).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d87e2516548329a41e9a9333d8a55c)