### PR TITLE
Allow extra roll on 6 and end game at tile 50 (snake-ladder)

### DIFF
--- a/examples/snake-ladder/ReactClient.jsx
+++ b/examples/snake-ladder/ReactClient.jsx
@@ -1,31 +1,29 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { io } from 'socket.io-client';
 
-const PYRAMID_ROW_LENGTHS = [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 15];
-const BOARD_SIZE = 100;
-
-function buildPyramidRows() {
+function buildRows(boardSize) {
   const rows = [];
-  let value = 1;
+  const columns = 10;
+  const totalRows = Math.ceil(boardSize / columns);
 
-  for (let row = PYRAMID_ROW_LENGTHS.length - 1; row >= 0; row -= 1) {
-    const rowSize = PYRAMID_ROW_LENGTHS[row];
+  for (let row = totalRows - 1; row >= 0; row -= 1) {
+    const start = row * columns + 1;
+    const end = Math.min(start + columns - 1, boardSize);
     const values = [];
 
-    for (let col = 0; col < rowSize; col += 1) {
-      if (value <= BOARD_SIZE) values.push(value);
-      value += 1;
+    for (let tile = start; tile <= end; tile += 1) {
+      values.push(tile);
     }
 
-    if (row % 2 === 1) values.reverse();
-    rows.unshift(values);
+    if ((totalRows - row) % 2 === 0) values.reverse();
+    rows.push(values);
   }
 
   return rows;
 }
 
-function getCellAccent(value) {
-  if (value === BOARD_SIZE) return '#17b26a';
+function getCellAccent(value, boardSize) {
+  if (value === boardSize) return '#17b26a';
   if (value <= 10) return '#3b82f6';
   if (value % 10 === 0) return '#f59e0b';
   return '#7c3aed';
@@ -39,7 +37,8 @@ export default function ReactClient({
   const [state, setState] = useState(null);
   const [socket] = useState(() => io(serverUrl));
 
-  const rows = useMemo(() => buildPyramidRows(), []);
+  const boardSize = state?.boardSize || 50;
+  const rows = useMemo(() => buildRows(boardSize), [boardSize]);
   const playersByTile = useMemo(() => {
     if (!state) return {};
 
@@ -122,7 +121,7 @@ export default function ReactClient({
               gap: 6,
               gridTemplateColumns: `repeat(${row.length}, minmax(18px, 1fr))`,
               marginBottom: 6,
-              width: `${(row.length / PYRAMID_ROW_LENGTHS[PYRAMID_ROW_LENGTHS.length - 1]) * 100}%`,
+              width: '100%',
               marginInline: 'auto'
             }}
           >
@@ -138,10 +137,10 @@ export default function ReactClient({
                     position: 'relative',
                     minHeight: 42,
                     borderRadius: 10,
-                    border: `1px solid ${getCellAccent(tile)}99`,
+                    border: `1px solid ${getCellAccent(tile, boardSize)}99`,
                     background:
                       'linear-gradient(180deg, rgba(15,23,42,0.95), rgba(30,41,59,0.92))',
-                    boxShadow: `inset 0 0 0 1px ${getCellAccent(tile)}33`
+                    boxShadow: `inset 0 0 0 1px ${getCellAccent(tile, boardSize)}33`
                   }}
                 >
                   <span

--- a/examples/snake-ladder/gameLogic.js
+++ b/examples/snake-ladder/gameLogic.js
@@ -1,4 +1,4 @@
-export const BOARD_SIZE = 100;
+export const BOARD_SIZE = 50;
 
 export const DEFAULT_SNAKES = {
   16: 6,
@@ -75,7 +75,10 @@ export class Game {
     current.position = newPos;
     if (newPos === BOARD_SIZE) {
       this.winner = current.id;
-    } else {
+      return;
+    }
+
+    if (value !== 6) {
       this.currentPlayer = (this.currentPlayer + 1) % this.players.length;
     }
   }
@@ -88,7 +91,8 @@ export class Game {
       diceRoll: this.diceRoll,
       snakes: this.snakes,
       ladders: this.ladders,
-      winner: this.winner
+      winner: this.winner,
+      boardSize: BOARD_SIZE
     };
   }
 }


### PR DESCRIPTION
### Motivation
- Players who roll a 6 must be allowed to roll again and keep the roll button available for their turn.  
- The game must end immediately and declare a winner when any token reaches tile 50.  
- The client board rendering must reflect the server board size so UI and rules remain consistent.

### Description
- Changed the board size constant from `100` to `50` by updating `BOARD_SIZE` in `examples/snake-ladder/gameLogic.js`.  
- Updated `rollDice` in `examples/snake-ladder/gameLogic.js` to immediately declare a winner when a token lands on `BOARD_SIZE` and to only advance `currentPlayer` when the roll value is not `6`, enabling extra turns on 6.  
- Added `boardSize` to the game state returned by `getState()` so the client can render the correct board dimensions.  
- Reworked client board generation in `examples/snake-ladder/ReactClient.jsx` to build rows dynamically from `boardSize` (10 columns per row), updated `getCellAccent` to accept `boardSize`, and adjusted layout styles to use full width for rows and the new accent logic.

### Testing
- Ran `node --check examples/snake-ladder/gameLogic.js`, which completed successfully.  
- Ran `node --check examples/snake-ladder/ReactClient.jsx`, which failed because `node --check` does not support `.jsx` file checking in this environment (syntax check not applicable here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d87e2516548329a41e9a9333d8a55c)