### PR TITLE
Snake & Ladder: keep extra roll on 6 and end game at tile 50

### DIFF
--- a/examples/snake-ladder/ReactClient.jsx
+++ b/examples/snake-ladder/ReactClient.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { io } from 'socket.io-client';
 
 const PYRAMID_ROW_LENGTHS = [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 15];
-const BOARD_SIZE = 100;
+const BOARD_SIZE = 50;
 
 function buildPyramidRows() {
   const rows = [];
@@ -63,6 +63,7 @@ export default function ReactClient({
   if (!state) return <div style={{ color: '#fff' }}>Loading...</div>;
 
   const current = state.players[state.currentPlayer]?.id;
+  const winnerName = state.players.find((player) => player.id === state.winner)?.name || state.winner;
 
   return (
     <div
@@ -109,7 +110,7 @@ export default function ReactClient({
           Roll Dice
         </button>
         {state.winner && (
-          <p style={{ margin: '12px 0 0' }}>Winner: {state.winner}</p>
+          <p style={{ margin: '12px 0 0' }}>Winner: {winnerName}</p>
         )}
       </div>
 

--- a/examples/snake-ladder/gameLogic.js
+++ b/examples/snake-ladder/gameLogic.js
@@ -1,16 +1,9 @@
-export const BOARD_SIZE = 100;
+export const BOARD_SIZE = 50;
 
 export const DEFAULT_SNAKES = {
   16: 6,
   48: 26,
-  49: 11,
-  56: 53,
-  62: 19,
-  64: 60,
-  87: 24,
-  93: 73,
-  95: 75,
-  98: 78
+  49: 11
 };
 
 export const DEFAULT_LADDERS = {
@@ -18,11 +11,8 @@ export const DEFAULT_LADDERS = {
   4: 14,
   9: 31,
   21: 42,
-  28: 84,
-  36: 44,
-  51: 67,
-  71: 91,
-  80: 100
+  28: 47,
+  36: 44
 };
 
 export class Game {
@@ -67,15 +57,29 @@ export class Game {
     if (this.winner) return;
     const current = this.players[this.currentPlayer];
     if (!current || current.id !== playerId) return;
+
     const value = Math.floor(Math.random() * 6) + 1;
     this.diceRoll = value;
+
     let newPos = current.position + value;
     if (newPos > BOARD_SIZE) newPos = current.position;
+
+    if (newPos === BOARD_SIZE) {
+      current.position = BOARD_SIZE;
+      this.winner = current.id;
+      return;
+    }
+
     newPos = this.snakes[newPos] || this.ladders[newPos] || newPos;
     current.position = newPos;
+
     if (newPos === BOARD_SIZE) {
       this.winner = current.id;
-    } else {
+      return;
+    }
+
+    const getsExtraRoll = value === 6;
+    if (!getsExtraRoll) {
       this.currentPlayer = (this.currentPlayer + 1) % this.players.length;
     }
   }


### PR DESCRIPTION
### Motivation
- Players who roll a 6 lost their immediate extra turn because the turn advanced and the Roll Dice control disappeared, so the extra-roll flow needed to be restored. 
- The game required a shorter board and a clear finish condition so the first token to reach tile 50 wins immediately.

### Description
- Set the board target to `BOARD_SIZE = 50` in both `examples/snake-ladder/gameLogic.js` and `examples/snake-ladder/ReactClient.jsx` and adjusted snakes/ladders to fit the 50-tile board. 
- Updated `rollDice` so the server declares a winner immediately when a token reaches tile 50 (before or after snakes/ladders) and returns early to stop further turn changes. 
- Changed turn progression so the current player only advances when the roll is not `6`, preserving the same active player and keeping the Roll Dice control visible for an immediate extra roll. 
- Updated the client to compute and show the winner's player name (`winnerName`) and to keep the Roll Dice button enabled/disabled based on `currentPlayer` and `state.winner`.

### Testing
- Ran `node --check examples/snake-ladder/gameLogic.js` which completed without errors. 
- Ran `node --check examples/snake-ladder/server.js` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d87e2516548329a41e9a9333d8a55c)