### PR TITLE
Replace capture VFX with smaller procedural 3D models (drone, jet, bazooka, missile, explosion)

### DIFF
--- a/webapp/public/chess-royale.html
+++ b/webapp/public/chess-royale.html
@@ -422,6 +422,110 @@ function playBombSound(){ playTone(82,0.24,BOMB_VOLUME,'triangle'); playTone(45,
 function playSlashSound(){ playTone(640,0.08,SLASH_VOLUME,'square'); playTone(420,0.12,SLASH_VOLUME*0.9,'triangle'); }
 function playDroneSound(){ playTone(220,0.22,DRONE_VOLUME,'sawtooth'); playTone(330,0.16,DRONE_VOLUME*0.85,'triangle'); }
 
+function addBox(group,size,position,color,roughness=0.7,metalness=0.2){
+  const mesh=new THREE.Mesh(
+    new THREE.BoxGeometry(size[0],size[1],size[2]),
+    new THREE.MeshStandardMaterial({color,roughness,metalness})
+  );
+  mesh.position.set(position[0],position[1],position[2]);
+  mesh.castShadow=true; mesh.receiveShadow=true;
+  group.add(mesh);
+  return mesh;
+}
+function addCylinder(group,radiusTop,radiusBottom,height,position,rotation,color,radialSegments=18,roughness=0.62,metalness=0.28){
+  const mesh=new THREE.Mesh(
+    new THREE.CylinderGeometry(radiusTop,radiusBottom,height,radialSegments),
+    new THREE.MeshStandardMaterial({color,roughness,metalness})
+  );
+  mesh.position.set(position[0],position[1],position[2]);
+  mesh.rotation.set(rotation[0],rotation[1],rotation[2]);
+  mesh.castShadow=true; mesh.receiveShadow=true;
+  group.add(mesh);
+  return mesh;
+}
+function addSphere(group,radius,position,color,roughness=0.45,metalness=0.25,transparent=false,opacity=1){
+  const mesh=new THREE.Mesh(
+    new THREE.SphereGeometry(radius,16,16),
+    new THREE.MeshStandardMaterial({color,roughness,metalness,transparent,opacity})
+  );
+  mesh.position.set(position[0],position[1],position[2]);
+  mesh.castShadow=true; mesh.receiveShadow=true;
+  group.add(mesh);
+  return mesh;
+}
+function createPolygonMesh(points,depth,color,roughness=0.65,metalness=0.24){
+  const shape=new THREE.Shape();
+  shape.moveTo(points[0][0],points[0][1]);
+  for(let i=1;i<points.length;i+=1) shape.lineTo(points[i][0],points[i][1]);
+  shape.closePath();
+  const geometry=new THREE.ExtrudeGeometry(shape,{depth,bevelEnabled:false,curveSegments:1});
+  geometry.translate(0,0,-depth/2);
+  geometry.rotateX(Math.PI/2);
+  const mesh=new THREE.Mesh(geometry,new THREE.MeshStandardMaterial({color,roughness,metalness}));
+  mesh.castShadow=true; mesh.receiveShadow=true;
+  return mesh;
+}
+function createTriangleDroneModel(){
+  const root=new THREE.Group();
+  addCylinder(root,0.14,0.19,2.75,[0,0,0],[0,0,Math.PI/2],'#cfd3d6',20);
+  const nose=new THREE.Mesh(new THREE.ConeGeometry(0.18,0.72,20),new THREE.MeshStandardMaterial({color:'#d9dde0',roughness:0.5,metalness:0.18}));
+  nose.position.set(1.7,0,0); nose.rotation.z=-Math.PI/2; nose.castShadow=true; root.add(nose);
+  addCylinder(root,0.18,0.14,0.48,[-1.58,0,0],[0,0,Math.PI/2],'#879095',14);
+  const deltaWing=createPolygonMesh([[-1.2,-1.65],[1.0,0],[-1.2,1.65]],0.08,'#aeb4ae',0.82,0.08);
+  deltaWing.position.set(-0.15,-0.06,0); root.add(deltaWing);
+  const spine=createPolygonMesh([[-0.55,-0.18],[0.9,0],[-0.55,0.18]],0.06,'#7d858a',0.55,0.22);
+  spine.position.set(0.15,0.03,0); root.add(spine);
+  addSphere(root,0.09,[1.05,0,0],'#1f2428',0.22,0.35);
+  const propeller=new THREE.Group(); propeller.position.set(-1.95,0,0);
+  addBox(propeller,[0.05,1.0,0.08],[0,0,0],'#191d20',0.6,0.12);
+  const blade2=new THREE.Mesh(new THREE.BoxGeometry(0.05,1.0,0.08),new THREE.MeshStandardMaterial({color:'#191d20',roughness:0.6}));
+  blade2.rotation.x=Math.PI/2; blade2.castShadow=true; propeller.add(blade2);
+  addSphere(propeller,0.07,[0,0,0],'#41484d',0.45,0.25);
+  root.add(propeller);
+  root.scale.setScalar(0.5);
+  return { root, propeller };
+}
+function createFighterJetModel(){
+  const root=new THREE.Group();
+  addCylinder(root,0.18,0.24,3.4,[0,0,0],[0,0,Math.PI/2],'#b8bec5',24);
+  const nose=new THREE.Mesh(new THREE.ConeGeometry(0.19,0.9,24),new THREE.MeshStandardMaterial({color:'#d7dbe0',roughness:0.45,metalness:0.2}));
+  nose.position.set(2.15,0,0); nose.rotation.z=-Math.PI/2; nose.castShadow=true; root.add(nose);
+  const cockpit=new THREE.Mesh(new THREE.SphereGeometry(0.22,18,18),new THREE.MeshStandardMaterial({color:'#2d3945',roughness:0.18,metalness:0.3}));
+  cockpit.scale.set(1.2,0.65,0.7); cockpit.position.set(0.75,0.18,0); cockpit.castShadow=true; root.add(cockpit);
+  const wing=createPolygonMesh([[-1.6,-2.05],[0.85,0],[-0.1,2.05]],0.09,'#9fa7ae',0.68,0.16);
+  wing.position.set(-0.15,-0.04,0); root.add(wing);
+  root.scale.setScalar(0.5);
+  return root;
+}
+function createBazookaModel(){
+  const root=new THREE.Group();
+  addCylinder(root,0.12,0.14,1.55,[0,0,0],[0,0,Math.PI/2],'#7e868c',18,0.55,0.28);
+  addCylinder(root,0.09,0.09,0.38,[0.86,0,0],[0,0,Math.PI/2],'#929aa0',14,0.45,0.18);
+  addBox(root,[0.28,0.12,0.18],[-0.18,0.18,0],'#6d757b',0.65,0.2);
+  addBox(root,[0.16,0.18,0.06],[-0.05,-0.16,0],'#596066',0.7,0.16);
+  root.scale.setScalar(0.5);
+  return root;
+}
+function createMissileModel(){
+  const root=new THREE.Group();
+  addCylinder(root,0.05,0.06,0.72,[0,0,0],[0,0,Math.PI/2],'#c9ced3',14,0.42,0.12);
+  const nose=new THREE.Mesh(new THREE.ConeGeometry(0.055,0.18,14),new THREE.MeshStandardMaterial({color:'#f0f2f4',roughness:0.32,metalness:0.16}));
+  nose.position.set(0.45,0,0); nose.rotation.z=-Math.PI/2; nose.castShadow=true; root.add(nose);
+  addBox(root,[0.1,0.02,0.16],[-0.18,0,0],'#7f868d',0.58,0.12);
+  addBox(root,[0.1,0.16,0.02],[-0.18,0,0],'#7f868d',0.58,0.12);
+  root.scale.setScalar(0.5);
+  return root;
+}
+function createExplosionModel(){
+  const root=new THREE.Group();
+  const flash=addSphere(root,0.18,[0,0.25,0],'#ffe59a',0.08,0,true,1);
+  const fire=[]; const smoke=[];
+  for(let i=0;i<4;i+=1) fire.push(addSphere(root,0.18+i*0.05,[0,0.22+i*0.06,0],i%2===0?'#ff9c2f':'#ff5b2d',0.2,0,true,0.95-i*0.15));
+  for(let i=0;i<6;i+=1) smoke.push(addSphere(root,0.18+i*0.035,[0,0.18+i*0.08,0],'#646b72',1,0,true,0.42-i*0.04));
+  root.scale.setScalar(0.5);
+  return { root, flash, fire, smoke };
+}
+
 function animateSlashAt(target){
   return new Promise(resolve=>{
     if(!scene||!THREE||!target) return resolve();
@@ -439,26 +543,40 @@ function animateSlashAt(target){
 function animateMissileStrike(from,to){
   return new Promise(resolve=>{
     if(!scene||!THREE||!from||!to) return resolve();
-    const drone=new THREE.Mesh(new THREE.SphereGeometry(0.12,12,12), new THREE.MeshStandardMaterial({color:0x7dd3fc, emissive:0x0ea5e9, emissiveIntensity:1.4}));
-    const missile=new THREE.Mesh(new THREE.SphereGeometry(0.08,10,10), new THREE.MeshBasicMaterial({color:0xf59e0b}));
-    const blast=new THREE.Mesh(new THREE.SphereGeometry(0.16,12,12), new THREE.MeshBasicMaterial({color:0xffb703, transparent:true, opacity:0}));
+    const {root:drone, propeller}=createTriangleDroneModel();
+    const jet=createFighterJetModel();
+    const bazooka=createBazookaModel();
+    const missile=createMissileModel();
+    const explosion=createExplosionModel();
     drone.position.copy(from.clone().add(new THREE.Vector3(0,1.0,0)));
+    jet.position.copy(from.clone().add(new THREE.Vector3(-0.8,1.35,0.45)));
+    bazooka.position.copy(from.clone().add(new THREE.Vector3(-0.25,0.25,-0.22)));
+    bazooka.lookAt(to.clone().add(new THREE.Vector3(0,0.35,0)));
     missile.position.copy(from.clone().add(new THREE.Vector3(0,0.45,0)));
-    blast.position.copy(to.clone().add(new THREE.Vector3(0,0.38,0)));
-    scene.add(drone); scene.add(missile); scene.add(blast); playDroneSound();
+    explosion.root.position.copy(to.clone().add(new THREE.Vector3(0,0.38,0)));
+    explosion.root.visible=false;
+    scene.add(drone); scene.add(jet); scene.add(bazooka); scene.add(missile); scene.add(explosion.root); playDroneSound();
     const t0=performance.now(), dur=340;
     const tick=now=>{
       const t=Math.min(1,(now-t0)/dur);
       drone.position.lerpVectors(from.clone().add(new THREE.Vector3(0,1.0,0)), to.clone().add(new THREE.Vector3(0,1.0,0)), t);
+      jet.position.lerpVectors(from.clone().add(new THREE.Vector3(-0.8,1.35,0.45)), to.clone().add(new THREE.Vector3(-0.25,1.2,0.2)), t);
       missile.position.lerpVectors(from.clone().add(new THREE.Vector3(0,0.45,0)), to.clone().add(new THREE.Vector3(0,0.45,0)), t);
+      propeller.rotation.x=now*0.04;
       if(t>=1){
         playBombSound();
         const e0=performance.now(); const ed=220;
         const boom=ev=>{
-          const et=Math.min(1,(ev-e0)/ed); blast.scale.setScalar(1+2.8*et); blast.material.opacity=0.95*(1-et);
+          const et=Math.min(1,(ev-e0)/ed);
+          explosion.root.visible=true;
+          explosion.root.scale.setScalar(0.5 + 1.4*et);
+          explosion.flash.scale.setScalar(1.4 + et*4.2);
+          explosion.flash.material.opacity=0.95*(1-et);
+          explosion.fire.forEach((mesh,i)=>{ mesh.material.opacity=Math.max(0,0.92-et-i*0.1); });
+          explosion.smoke.forEach((mesh,i)=>{ mesh.material.opacity=Math.max(0,0.42-et*0.3-i*0.03); });
           if(et<1) requestAnimationFrame(boom);
           else{
-            [drone,missile,blast].forEach(n=>{ scene.remove(n); n.geometry.dispose(); n.material.dispose(); });
+            [drone,jet,bazooka,missile,explosion.root].forEach(n=>{ scene.remove(n); });
             resolve();
           }
         };


### PR DESCRIPTION
### Motivation
- Replace the simple sphere placeholders used during capture strikes with richer procedural geometry so the capture VFX matches the provided Three.js reference style and appears visually consistent.
- Make all added capture assets (drone, fighter jet, bazooka, missiles, explosion) 50% smaller to match the requested scale reduction.

### Description
- Added lightweight helper builders: `addBox`, `addCylinder`, `addSphere`, and `createPolygonMesh` to `webapp/public/chess-royale.html` for constructing procedural meshes with the same material style as the reference code.
- Implemented procedural rigs matching the reference: `createTriangleDroneModel`, `createFighterJetModel`, `createBazookaModel`, `createMissileModel`, and `createExplosionModel`, each scaled by `root.scale.setScalar(0.5)` to reduce size by 50%.
- Reworked `animateMissileStrike` to instantiate and animate the new models together (drone flight, jet pass, bazooka orientation, missile travel, propeller spin, and explosion growth/fade) and to clean up the added objects when the animation completes.
- Kept the change localized to the capture strike code in `webapp/public/chess-royale.html` and reused existing audio calls (`playDroneSound` / `playBombSound`).

### Testing
- Ran `git diff --check -- webapp/public/chess-royale.html` to validate there are no whitespace/conflict markers and it completed with no issues.
- No automated unit or integration tests were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d88449108c8329bc74a1af912cd314)