### PR TITLE
Match Ludo capture missile to bazooka geometry and halve FX size

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -150,36 +150,27 @@ function addFxSphere(
 
 function createCaptureMissileFx() {
   const root = new THREE.Group();
-  addFxCylinder(root, 0.07, 0.08, 1.02, [0, 0, 0], [0, 0, Math.PI / 2], '#bfc5ca', 16, 0.42, 0.12);
+  addFxCylinder(root, 0.05, 0.06, 0.72, [0, 0, 0], [0, 0, Math.PI / 2], '#c9ced3', 14, 0.42, 0.12);
 
   const nose = new THREE.Mesh(
-    new THREE.ConeGeometry(0.08, 0.24, 16),
-    new THREE.MeshStandardMaterial({ color: '#eef1f4', roughness: 0.28, metalness: 0.12 })
+    new THREE.ConeGeometry(0.055, 0.18, 14),
+    new THREE.MeshStandardMaterial({ color: '#f0f2f4', roughness: 0.3, metalness: 0.15 })
   );
-  nose.position.set(0.63, 0, 0);
+  nose.position.set(0.45, 0, 0);
   nose.rotation.z = -Math.PI / 2;
   nose.castShadow = true;
   root.add(nose);
 
-  addFxBox(root, [0.14, 0.02, 0.28], [-0.15, 0, 0], '#7d858b', 0.58, 0.12);
-  addFxBox(root, [0.14, 0.28, 0.02], [-0.15, 0, 0], '#7d858b', 0.58, 0.12);
-  addFxBox(root, [0.1, 0.02, 0.18], [-0.36, 0, 0], '#727a80', 0.58, 0.12);
-  addFxBox(root, [0.1, 0.18, 0.02], [-0.36, 0, 0], '#727a80', 0.58, 0.12);
+  addFxBox(root, [0.1, 0.02, 0.16], [-0.18, 0, 0], '#7f868d', 0.58, 0.12);
+  addFxBox(root, [0.1, 0.16, 0.02], [-0.18, 0, 0], '#7f868d', 0.58, 0.12);
 
-  const trail = [];
-  for (let i = 0; i < 5; i += 1) {
-    const puff = addFxSphere(
-      root,
-      0.1 + i * 0.025,
-      [-0.7 - i * 0.16, 0, 0],
-      i < 2 ? '#f6af4b' : '#8f989d',
-      i < 2 ? 0.2 : 1,
-      0,
-      true,
-      i < 2 ? 0.8 - i * 0.15 : 0.26 - (i - 2) * 0.04
-    );
-    trail.push(puff);
-  }
+  const trail = [
+    addFxSphere(root, 0.08, [-0.5, 0, 0], '#90989d', 1, 0, true, 0.22),
+    addFxSphere(root, 0.1, [-0.64, 0, 0], '#90989d', 1, 0, true, 0.18),
+    addFxSphere(root, 0.12, [-0.78, 0, 0], '#90989d', 1, 0, true, 0.14),
+    addFxSphere(root, 0.14, [-0.92, 0, 0], '#90989d', 1, 0, true, 0.1)
+  ];
+
   root.visible = false;
   return { root, trail };
 }
@@ -217,6 +208,7 @@ function createCaptureExplosionFx() {
       )
     );
   }
+  root.scale.setScalar(0.5);
   root.visible = false;
   return { root, flash, fire, smoke };
 }
@@ -5387,8 +5379,9 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         captureFxRef.current = { missile: missile.root, explosion: explosion.root };
 
         const { kingHeight, kingWidth } = getReferenceKingSize(attackerPlayer, attackerToken);
-        const missileLengthScale = kingHeight / 1.02;
-        const missileThicknessScale = ((kingWidth * 0.5) / 0.16) * 0.98;
+        const missileScaleMultiplier = 0.5;
+        const missileLengthScale = (kingHeight / 1.02) * missileScaleMultiplier;
+        const missileThicknessScale = (((kingWidth * 0.5) / 0.16) * 0.98) * missileScaleMultiplier;
         missile.root.scale.set(missileLengthScale, missileThicknessScale, missileThicknessScale);
 
         const from = startPosition.clone().add(new THREE.Vector3(0, kingHeight * 0.55, 0));


### PR DESCRIPTION
### Motivation

- Make the capture missile visuals match the bazooka-launched missile geometry exactly and reduce both missile and explosion visual size by ~50% for better visual balance in the Ludo capture sequence.

### Description

- Updated `createCaptureMissileFx` in `webapp/src/pages/Games/LudoBattleRoyal.jsx` to use the same procedural geometry/profile used by the bazooka missile (body cylinder parameters, nose cone, fins/boxes and a 4-puff trail).
- Scaled the capture explosion down by setting the explosion root `scale` to `0.5` while keeping existing animation/timing code unchanged in `createCaptureExplosionFx`.
- Applied a `missileScaleMultiplier = 0.5` when computing `missile.root.scale` in the capture sequence (`playCaptureMissileSequence`) so both length and thickness are reduced by half.
- The only modified file is `webapp/src/pages/Games/LudoBattleRoyal.jsx` and changes preserve existing FX animation logic and timing.

### Testing

- Ran the production build with `npm --prefix webapp run build` and the build completed successfully.
- Vite emitted pre-existing chunk-size/dynamic-import warnings during the build but they are non-blocking and did not prevent a successful build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d884d191b4832991475c62bfd69da3)