### PR TITLE
Fix missing extra-roll button after six in Snake & Ladder multiplayer

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1254,6 +1254,7 @@ export default function SnakeAndLadder() {
   const [rollCooldown, setRollCooldown] = useState(0);
   const [moving, setMoving] = useState(false);
   const [pendingExtraRoll, setPendingExtraRoll] = useState(false);
+  const [awaitingSixExtraRoll, setAwaitingSixExtraRoll] = useState(false);
   const [waitingForPlayers, setWaitingForPlayers] = useState(false);
   const [playersNeeded, setPlayersNeeded] = useState(0);
   const [isMultiplayer, setIsMultiplayer] = useState(false);
@@ -2199,7 +2200,10 @@ export default function SnakeAndLadder() {
           // Keep roll CTA visible for immediate extra turns.
           setRollCooldown(0);
         }
-        if (!turnBelongsToMe) setPendingExtraRoll(false);
+        if (!turnBelongsToMe) {
+          setPendingExtraRoll(false);
+          setAwaitingSixExtraRoll(false);
+        }
       }
     };
     const onStarted = () => {
@@ -2209,10 +2213,21 @@ export default function SnakeAndLadder() {
         unseatTable(myAccountId, tableId).catch(() => {});
       }
     };
-    const onRolled = ({ value }) => {
+    const onRolled = ({ value, playerId, seatIndex }) => {
       setRollResult(value);
       setTimeout(() => setRollResult(null), 2000);
       playDiceRollSound();
+      const rolledValue = Number(value);
+      const turnSeat =
+        Number.isInteger(seatIndex)
+          ? seatIndex
+          : playersRef.current.findIndex((pl) => pl.id === playerId);
+      const isMyRoll = turnSeat >= 0 ? playersRef.current[turnSeat]?.id === myAccountId : playerId === myAccountId;
+      if (isMyRoll && rolledValue === 6) {
+        // Server-confirmed six: keep the roll CTA available for the bonus turn.
+        setPendingExtraRoll(true);
+        setAwaitingSixExtraRoll(true);
+      }
     };
     const onWon = ({ playerId }) => {
       setGameOver(true);
@@ -3195,7 +3210,7 @@ export default function SnakeAndLadder() {
     ? mpPlayers.findIndex((p) => p.id === accountId)
     : 0;
   const myPlayerIndex = computedIndex >= 0 ? computedIndex : null;
-  const hasLocalExtraRoll = isMultiplayer && pendingExtraRoll;
+  const hasLocalExtraRoll = isMultiplayer && (pendingExtraRoll || awaitingSixExtraRoll);
   const isMyTurnForRoll =
     myPlayerIndex !== null && (currentTurn === myPlayerIndex || hasLocalExtraRoll);
   const rollReady = hasLocalExtraRoll || rollCooldown === 0;
@@ -4035,6 +4050,7 @@ export default function SnakeAndLadder() {
                   seatIndex: currentTurn
                 });
                 setPendingExtraRoll(false);
+                setAwaitingSixExtraRoll(false);
               }}
               onRollEnd={(vals) => {
                 startDiceBoardAnimation({


### PR DESCRIPTION
### Motivation
- Players who rolled a 6 in multiplayer could lose the roll CTA due to timing between local animation state and server turn/roll events.
- The intent is to ensure the extra roll button/icon reappears in the same place for the bonus turn so the local player can immediately roll again.

### Description
- Added a new `awaitingSixExtraRoll` state and incorporated it into roll eligibility so a server-confirmed six keeps the roll CTA available in `webapp/src/pages/Games/SnakeAndLadder.jsx`.
- Wired server `onRolled` handler to set `awaitingSixExtraRoll` (and `pendingExtraRoll`) when the server reports that your roll value is `6` and to compute the roll owner using `playerId`/`seatIndex`.
- Cleared both `pendingExtraRoll` and `awaitingSixExtraRoll` when the active turn changes and when a new local roll starts to avoid stale state.

### Testing
- Ran a production build with `npm --prefix webapp run -s build`, which completed successfully (Vite emitted non-blocking warnings about chunking but the build succeeded).
- Confirmed the updated `DiceRoller`/turn handlers compile and the change is limited to `webapp/src/pages/Games/SnakeAndLadder.jsx`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d88c1703ac832988d1fbf2a7586433)