### PR TITLE
Ludo: remove yabba-dabba-doo SFX, make turn camera look-only, and enlarge tokens

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -889,7 +889,7 @@ function abgBbox(obj) {
 
 function measureProceduralTokenHeight() {
   if (proceduralTokenHeight) return proceduralTokenHeight;
-  proceduralTokenHeight = 0.09;
+  proceduralTokenHeight = 0.117;
   return proceduralTokenHeight;
 }
 
@@ -5564,10 +5564,6 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       diceRewardSoundRef.current.currentTime = 0;
       diceRewardSoundRef.current.play().catch(() => {});
     }
-    if (sixRollSoundRef.current) {
-      sixRollSoundRef.current.currentTime = 0;
-      sixRollSoundRef.current.play().catch(() => {});
-    }
     if (cheerSoundRef.current) {
       cheerSoundRef.current.currentTime = 0;
       cheerSoundRef.current.play().catch(() => {});
@@ -5730,7 +5726,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         };
         animateCameraPose(
           cameraTurnStateRef.current.baseTurnView.target,
-          cameraTurnStateRef.current.baseTurnView.position,
+          null,
           duration
         );
         return;
@@ -5744,7 +5740,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     }
     const nextView = resolveTurnCameraState(player, CAMERA_TARGET_LIFT);
     if (!nextView) return;
-    animateCameraPose(nextView.target, nextView.position, duration);
+    animateCameraPose(nextView.target, null, duration);
   }, [animateCameraPose, cancelCameraViewAnimation, isCamera2d, resolveTurnCameraState]);
 
   const setCameraFocus = useCallback(
@@ -6346,14 +6342,6 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       bounceHeight: dice.userData?.bounceHeight ?? 0.06
     });
     dice.userData.isRolling = false;
-    setCameraFocus({
-      target: landingFocus,
-      follow: false,
-      ttl: 1.6 + DICE_RESULT_EXTRA_HOLD_MS / 1000,
-      priority: 3,
-      offset: CAMERA_TARGET_LIFT + 0.03,
-      force: true
-    });
     setUi((s) => ({
       ...s,
       dice: value,
@@ -6368,6 +6356,15 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     scheduleDiceClear();
     const options = getMovableTokens(player, value);
     if (!options.length) {
+      const playerCycle = Math.max(1, activePlayerCount);
+      const upcomingTurn = value === 6 ? player : (player + playerCycle - 1) % playerCycle;
+      setCameraFocus({
+        target: resolveTurnLookTarget(upcomingTurn, CAMERA_TARGET_LIFT),
+        follow: false,
+        ttl: 0.4,
+        priority: 3,
+        force: true
+      });
       clearTurnAdvanceTimeout();
       turnAdvanceTimeoutRef.current = window.setTimeout(() => {
         turnAdvanceTimeoutRef.current = null;
@@ -6375,6 +6372,14 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       }, DICE_RESULT_EXTRA_HOLD_MS);
       return;
     }
+    setCameraFocus({
+      target: landingFocus,
+      follow: false,
+      ttl: 1.6 + DICE_RESULT_EXTRA_HOLD_MS / 1000,
+      priority: 3,
+      offset: CAMERA_TARGET_LIFT + 0.03,
+      force: true
+    });
     if (player === 0) {
       beginHumanSelection(value, options);
       return;


### PR DESCRIPTION
### Motivation
- Reduce intrusive entry SFX by stopping the six-roll `yabba-dabba-doo` sound from playing during token-entry/celebration flows. 
- Make turn transitions less jarring by only changing what the camera looks at (target) instead of moving the camera position. 
- Improve clarity when a player has no movable tokens by skipping the board landing focus and previewing the upcoming player's look. 
- Make tokens visually larger (~30%) to match requested sizing.

### Description
- Increased procedural token height constant by changing `measureProceduralTokenHeight()` from `0.09` to `0.117` (approx +30%). (file: `webapp/src/pages/Games/LudoBattleRoyal.jsx`)
- Removed playback of the specific six-roll audio reference so the `yabba-dabba-doo` effect is no longer played in `playSixRollSound`. (file: `webapp/src/pages/Games/LudoBattleRoyal.jsx`)
- Updated turn camera behavior so `setCameraViewForTurn` calls `animateCameraPose` with a `null` position argument to avoid moving the camera position and only update the look target. (file: `webapp/src/pages/Games/LudoBattleRoyal.jsx`)
- Adjusted dice result handling so when `getMovableTokens` returns no options the camera focus is set toward the upcoming player (`resolveTurnLookTarget`) instead of focusing on the dice/board landing. Also re-applies the landing focus only when there are valid move options. (file: `webapp/src/pages/Games/LudoBattleRoyal.jsx`)

### Testing
- Ran `npx eslint webapp/src/pages/Games/LudoBattleRoyal.jsx` which completed but reported the file is ignored by the repo ESLint config (warning only). 
- Ran `npx eslint --no-ignore webapp/src/pages/Games/LudoBattleRoyal.jsx` which produced the same ignore warning; no lint errors were reported for the modified code paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8a0e193548329b6c3d87c2e61c7d4)