### PR TITLE
Speed up AI dice & turn pacing, show extra-roll badge, and keep camera fixed during turn focus

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -1633,21 +1633,8 @@ function computeTurnCameraFocusState(board, camera, turnIndex, players = []) {
   const direction = seatWorld.clone().sub(boardLookTarget).setY(0);
   if (direction.lengthSq() < 1e-6) return null;
   direction.normalize();
-  const isTopOrBottomSeat = Math.abs(direction.z) >= Math.abs(direction.x);
-  if (isTopOrBottomSeat) {
-    return {
-      position: camera.position.clone(),
-      target: boardLookTarget.clone()
-    };
-  }
   if (seatIndex === 1) target.x += CAMERA_SIDE_LOOK_EXTRA;
   if (seatIndex === 3) target.x -= CAMERA_SIDE_LOOK_EXTRA;
-  const boardToCamera = camera.position.clone().sub(boardLookTarget).setY(0);
-  if (boardToCamera.lengthSq() > 1e-6) {
-    boardToCamera.normalize();
-    if (direction.dot(boardToCamera) >= 0.82) return null;
-  }
-
   // Keep the camera exactly where the player left it (including manual zoom distance)
   // and only rotate the look target for turn-focus cues.
   const position = camera.position.clone();
@@ -1669,13 +1656,8 @@ function computeDiceCameraFocusState(board, camera) {
 
   const target = diceCenter.clone();
   target.y += DICE_SIZE * 0.45;
-  const currentDistance = camera.position.distanceTo(boardLookTarget);
-  const direction = camera.position.clone().sub(boardLookTarget).setY(0);
-  if (direction.lengthSq() < 1e-6) direction.set(0, 0, 1);
-  direction.normalize();
-
-  const position = target.clone().addScaledVector(direction, currentDistance);
-  position.y = camera.position.y;
+  // Keep fixed camera distance/zoom: only adjust look target to the dice result.
+  const position = camera.position.clone();
   return { position, target };
 }
 

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -182,9 +182,9 @@ const SNAKE_SFX = Object.freeze({
 const FINAL_TILE = BOARD_FINAL_TILE;
 const PENULTIMATE_TILE = FINAL_TILE - 1;
 const TURN_TIME = 15;
-const AI_ROLL_DELAY_MS = 3400;
-const AI_EXTRA_ROLL_DELAY_MS = 2600;
-const TURN_ADVANCE_AFTER_DICE_MS = 3000;
+const AI_ROLL_DELAY_MS = 1600;
+const AI_EXTRA_ROLL_DELAY_MS = 1200;
+const TURN_ADVANCE_AFTER_DICE_MS = 2000;
 const DEFAULT_CAPACITY = 4;
 const COMMENTARY_PRESET_STORAGE_KEY = 'snakeCommentaryPreset';
 const COMMENTARY_MUTE_STORAGE_KEY = 'snakeCommentaryMute';
@@ -4083,13 +4083,20 @@ export default function SnakeAndLadder() {
             </div>
           )}
           {canRoll && (
-            <button
-              type="button"
-              onClick={handleRollButtonClick}
-              className="pointer-events-auto px-6 py-3 rounded-full font-semibold text-sm text-[#f7e7a4] shadow-lg bg-gradient-to-b from-[#2b2b2b] to-[#121212] border border-[rgba(255,215,0,0.45)]"
-            >
-              ROLL
-            </button>
+            <div className="pointer-events-auto flex flex-col items-center gap-2">
+              {pendingExtraRoll && (
+                <div className="rounded-full border border-amber-300/70 bg-black/70 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.22em] text-amber-200">
+                  🎲 Extra roll
+                </div>
+              )}
+              <button
+                type="button"
+                onClick={handleRollButtonClick}
+                className="px-6 py-3 rounded-full font-semibold text-sm text-[#f7e7a4] shadow-lg bg-gradient-to-b from-[#2b2b2b] to-[#121212] border border-[rgba(255,215,0,0.45)]"
+              >
+                ROLL
+              </button>
+            </div>
           )}
         </div>
       )}


### PR DESCRIPTION
### Motivation
- Make turn flow snappier by accelerating AI dice cadence and shortening the delay before advancing turns so results are visible but gameplay feels faster. 
- Give clear visual feedback when a player has an extra roll so they know the roll CTA is available immediately. 
- Ensure the camera reorients to follow the active player or dice result without zooming (no perceptual jump in distance).

### Description
- Reduced AI timing constants in `SnakeAndLadder.jsx` by setting `AI_ROLL_DELAY_MS` to `1600`, `AI_EXTRA_ROLL_DELAY_MS` to `1200`, and `TURN_ADVANCE_AFTER_DICE_MS` to `2000` to speed AI rolls and shorten post-roll handoff. 
- Added a small `🎲 Extra roll` badge above the roll button in the bottom UI when `pendingExtraRoll` is true so the local player sees an explicit extra-roll indicator. 
- Updated `computeTurnCameraFocusState` in `SnakeBoard3D.jsx` to always reorient the board look target toward the active player's side and removed conditions that skipped reorientation, while preserving the original camera position. 
- Updated `computeDiceCameraFocusState` in `SnakeBoard3D.jsx` so the camera position remains fixed and only the camera `target` is adjusted to look at the dice center, avoiding zoom-like movement when focusing dice results. 

### Testing
- Built the web app with `npm --prefix webapp run build` and the production build completed successfully. 
- Ran ESLint with the project settings; the linter reported file-ignore warnings for the two modified files but no errors (no blocking lint failures). 
- Smoke-tested by running the build step and confirming the bundle completed without errors (see build output warnings about chunk sizes but no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8a256b23c832990ca1b5bb150d2c9)