### PR TITLE
Ludo: enlarge tokens, remove yabba-dabba six-roll SFX, and make turn camera look-only with fallback

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -889,7 +889,7 @@ function abgBbox(obj) {
 
 function measureProceduralTokenHeight() {
   if (proceduralTokenHeight) return proceduralTokenHeight;
-  proceduralTokenHeight = 0.09;
+  proceduralTokenHeight = 0.117;
   return proceduralTokenHeight;
 }
 
@@ -4457,7 +4457,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     // Procedural dice SFX is generated with Web Audio (no binary asset).
     diceSoundRef.current = null;
     diceRewardSoundRef.current = new Audio('/assets/sounds/successful.mp3');
-    sixRollSoundRef.current = new Audio('/assets/sounds/yabba-dabba-doo.mp3');
+    sixRollSoundRef.current = null;
     hahaSoundRef.current = new Audio('/assets/sounds/Haha.mp3');
     giftBombSoundRef.current = new Audio(bombSound);
     applyVolume(vol);
@@ -5564,10 +5564,6 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       diceRewardSoundRef.current.currentTime = 0;
       diceRewardSoundRef.current.play().catch(() => {});
     }
-    if (sixRollSoundRef.current) {
-      sixRollSoundRef.current.currentTime = 0;
-      sixRollSoundRef.current.play().catch(() => {});
-    }
     if (cheerSoundRef.current) {
       cheerSoundRef.current.currentTime = 0;
       cheerSoundRef.current.play().catch(() => {});
@@ -5728,11 +5724,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           position: initialBottomView.position.clone(),
           target: initialBottomView.target.clone()
         };
-        animateCameraPose(
-          cameraTurnStateRef.current.baseTurnView.target,
-          cameraTurnStateRef.current.baseTurnView.position,
-          duration
-        );
+        animateCameraPose(cameraTurnStateRef.current.baseTurnView.target, null, duration);
         return;
       }
       if (camera && controls) {
@@ -5744,8 +5736,19 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     }
     const nextView = resolveTurnCameraState(player, CAMERA_TARGET_LIFT);
     if (!nextView) return;
-    animateCameraPose(nextView.target, nextView.position, duration);
+    animateCameraPose(nextView.target, null, duration);
   }, [animateCameraPose, cancelCameraViewAnimation, isCamera2d, resolveTurnCameraState]);
+
+  const playerHasTokenOnBoard = useCallback((player) => {
+    const state = stateRef.current;
+    if (!state?.progress?.[player]) return false;
+    return state.progress[player].some((progress) => progress >= 0 && progress < GOAL_PROGRESS);
+  }, []);
+
+  const resolvePreviewTurnForCamera = useCallback((turn) => {
+    const playerCycle = Math.max(1, activePlayerCount);
+    return (turn + playerCycle - 1) % playerCycle;
+  }, [activePlayerCount]);
 
   const setCameraFocus = useCallback(
     (focus = {}) => {
@@ -6079,7 +6082,8 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       const state = stateRef.current;
       if (state) state.turn = nextTurn;
       updateTurnIndicator(nextTurn);
-      setCameraViewForTurn(nextTurn);
+      const cameraTurn = playerHasTokenOnBoard(nextTurn) ? nextTurn : resolvePreviewTurnForCamera(nextTurn);
+      setCameraViewForTurn(cameraTurn);
       const diceObject = diceRef.current;
       if (diceObject?.isObject3D) {
         setCameraFocus({
@@ -6091,7 +6095,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           force: true
         });
       } else {
-        setCameraFocus({ target: resolveTurnLookTarget(nextTurn), priority: 1, force: true });
+        setCameraFocus({ target: resolveTurnLookTarget(cameraTurn), priority: 1, force: true });
       }
       updated = true;
       const status =


### PR DESCRIPTION
### Motivation
- Improve visual clarity by making Ludo tokens larger so they are more prominent on mobile portrait screens. 
- Remove an intrusive “yabba-dabba-doo” audio cue when six is rolled / token enters the board. 
- Make turn transitions less jarring by keeping the camera position steady and only changing the look target, and skip board-look for players without tokens on the board.

### Description
- Increased procedural token target height by ~30% by changing `measureProceduralTokenHeight()` from `0.09` to `0.117` in `webapp/src/pages/Games/LudoBattleRoyal.jsx` so cloned tokens are scaled up. 
- Disabled the six-roll clip by not initializing `sixRollSoundRef.current` (set to `null`) and removed its playback in `playSixRollSound()` so the `yabba-dabba-doo` audio no longer plays. 
- Converted turn camera transitions to look-only by calling `animateCameraPose(..., null, ...)` instead of supplying a position, preventing camera position movement during turn animations. 
- Added camera-turn fallback logic: new helpers `playerHasTokenOnBoard` and `resolvePreviewTurnForCamera` are used in `advanceTurn()` so if the newly active player has no tokens on the board the camera previews the next seat instead of focusing the board. 

### Testing
- Built the web app with `npm --prefix webapp run -s build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8a0e193548329b6c3d87c2e61c7d4)