### PR TITLE
Speed up AI dice pacing and make camera look-at follow without zoom (Snake & Ladder)

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -1633,13 +1633,6 @@ function computeTurnCameraFocusState(board, camera, turnIndex, players = []) {
   const direction = seatWorld.clone().sub(boardLookTarget).setY(0);
   if (direction.lengthSq() < 1e-6) return null;
   direction.normalize();
-  const isTopOrBottomSeat = Math.abs(direction.z) >= Math.abs(direction.x);
-  if (isTopOrBottomSeat) {
-    return {
-      position: camera.position.clone(),
-      target: boardLookTarget.clone()
-    };
-  }
   if (seatIndex === 1) target.x += CAMERA_SIDE_LOOK_EXTRA;
   if (seatIndex === 3) target.x -= CAMERA_SIDE_LOOK_EXTRA;
   const boardToCamera = camera.position.clone().sub(boardLookTarget).setY(0);
@@ -1669,13 +1662,7 @@ function computeDiceCameraFocusState(board, camera) {
 
   const target = diceCenter.clone();
   target.y += DICE_SIZE * 0.45;
-  const currentDistance = camera.position.distanceTo(boardLookTarget);
-  const direction = camera.position.clone().sub(boardLookTarget).setY(0);
-  if (direction.lengthSq() < 1e-6) direction.set(0, 0, 1);
-  direction.normalize();
-
-  const position = target.clone().addScaledVector(direction, currentDistance);
-  position.y = camera.position.y;
+  const position = camera.position.clone();
   return { position, target };
 }
 

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -182,9 +182,9 @@ const SNAKE_SFX = Object.freeze({
 const FINAL_TILE = BOARD_FINAL_TILE;
 const PENULTIMATE_TILE = FINAL_TILE - 1;
 const TURN_TIME = 15;
-const AI_ROLL_DELAY_MS = 3400;
-const AI_EXTRA_ROLL_DELAY_MS = 2600;
-const TURN_ADVANCE_AFTER_DICE_MS = 3000;
+const AI_ROLL_DELAY_MS = 1400;
+const AI_EXTRA_ROLL_DELAY_MS = 900;
+const TURN_ADVANCE_AFTER_DICE_MS = 2000;
 const DEFAULT_CAPACITY = 4;
 const COMMENTARY_PRESET_STORAGE_KEY = 'snakeCommentaryPreset';
 const COMMENTARY_MUTE_STORAGE_KEY = 'snakeCommentaryMute';
@@ -2993,6 +2993,7 @@ export default function SnakeAndLadder() {
         setTimeout(() => setRewardDice(0), 1000);
         enqueueSnakeCommentaryEvent('bonus', { player: playerLabel });
       } else if (rolledSix) {
+        setTurnMessage(`${getPlayerName(index)} rolled 6! Bonus roll`);
         extraTurn = true;
         enqueueSnakeCommentaryEvent('bonus', { player: playerLabel });
       }


### PR DESCRIPTION
### Motivation
- Improve the feel of turns by making AI dice rolls faster and reducing the delay between a shown dice result and the next turn.
- Make camera behavior clearer: keep camera distance fixed and only reorient its look target so players can see token movement and dice results without an intrusive zoom.

### Description
- Reduced AI timers by changing `AI_ROLL_DELAY_MS` from `3400` to `1400` and `AI_EXTRA_ROLL_DELAY_MS` from `2600` to `900` in `webapp/src/pages/Games/SnakeAndLadder.jsx`.
- Shortened the turn handoff after dice settle by changing `TURN_ADVANCE_AFTER_DICE_MS` from `3000` to `2000` so the landed value remains visible for ~2s before advancing turn in `SnakeAndLadder.jsx`.
- Added an explicit turn message when an AI rolls a six by calling `setTurnMessage(`${getPlayerName(index)} rolled 6! Bonus roll`)` so bonus rolls are visually obvious in `SnakeAndLadder.jsx`.
- Adjusted camera focus logic in `webapp/src/components/SnakeBoard3D.jsx` so `computeTurnCameraFocusState` and `computeDiceCameraFocusState` keep the camera position unchanged and only update the look `target` (no zoom/move-in), ensuring the view orients toward the active player or dice result without changing camera distance.

### Testing
- Ran the production build with `npm --prefix webapp run build`; the build completed successfully (Vite produced non-blocking chunk-size warnings only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8a256b23c832990ca1b5bb150d2c9)