### PR TITLE
Snake & Ladder: win on tile 50, remove extra-turn on 6, single-die mode, and winner metadata

### DIFF
--- a/bot/gameEngine.js
+++ b/bot/gameEngine.js
@@ -1,6 +1,6 @@
 import GameResult from "./models/GameResult.js";
-export const FINAL_TILE = 101;
-export const DEFAULT_SNAKES = { 99: 80 };
+export const FINAL_TILE = 50;
+export const DEFAULT_SNAKES = { 49: 30 };
 export const DEFAULT_LADDERS = { 3: 22, 27: 46 };
 export const ROLL_COOLDOWN_MS = 1000;
 export const RECONNECT_GRACE_MS = 60000;
@@ -217,7 +217,7 @@ export class GameRoom {
     if (this.gameType === 'snake') {
       this.players.forEach((p) => {
         p.position = 0;
-        p.diceCount = 2;
+        p.diceCount = 1;
         p.isActive = false;
       });
     }
@@ -333,7 +333,11 @@ export class GameRoom {
         }).catch((err) =>
           console.error('Failed to store game result:', err.message)
         );
-        this.io.to(this.id).emit('gameWon', { playerId: player.playerId });
+        this.io.to(this.id).emit('gameWon', {
+          playerId: player.playerId,
+          winnerName: player.name,
+          winningTile: FINAL_TILE,
+        });
         return;
       }
 
@@ -404,7 +408,11 @@ export class GameRoom {
         }).catch((err) =>
           console.error('Failed to store game result:', err.message)
         );
-        this.io.to(this.id).emit('gameWon', { playerId: winner.playerId });
+        this.io.to(this.id).emit('gameWon', {
+          playerId: winner.playerId,
+          winnerName: winner.name,
+          winningTile: this.gameType === 'snake' ? FINAL_TILE : undefined,
+        });
         return;
       }
     }

--- a/bot/logic/snakeGame.js
+++ b/bot/logic/snakeGame.js
@@ -1,4 +1,4 @@
-export const FINAL_TILE = 101;
+export const FINAL_TILE = 50;
 
 export function applySnakesAndLadders(pos, snakes, ladders) {
   if (snakes[pos] != null) return Math.max(0, snakes[pos]);
@@ -22,7 +22,7 @@ export class SnakeGame {
       id,
       name,
       position: 0,
-      diceCount: 2,
+      diceCount: 1,
       isActive: false,
     });
   }
@@ -40,7 +40,7 @@ export class SnakeGame {
     const player = this.players[this.currentTurn];
     if (!player) return null;
 
-    const diceToRoll = Math.max(1, player.diceCount || 2);
+    const diceToRoll = Math.max(1, player.diceCount || 1);
     const rand = () => Math.floor(Math.random() * 6) + 1;
     const provided = Array.isArray(diceValues)
       ? diceValues
@@ -56,8 +56,6 @@ export class SnakeGame {
 
     const total = dice.reduce((a, b) => a + b, 0);
     const rolledSix = dice.includes(6);
-    const doubleSix = dice.length >= 2 && dice[0] === 6 && dice[1] === 6;
-
     let target = player.position;
     let extraTurn = false;
 
@@ -65,15 +63,6 @@ export class SnakeGame {
       if (rolledSix) {
         player.isActive = true;
         target = 1;
-      }
-    } else if (player.position === 100) {
-      if (player.diceCount === 2) {
-        if (rolledSix) {
-          player.diceCount = 1;
-          extraTurn = true;
-        }
-      } else if (total === 1) {
-        target = FINAL_TILE;
       }
     } else if (player.position < FINAL_TILE) {
       if (player.position + total <= FINAL_TILE) {
@@ -93,7 +82,7 @@ export class SnakeGame {
     for (const p of this.players) {
       if (p !== player && p.position === player.position && p.position > 0) {
         p.position = 0;
-        p.diceCount = 2;
+        p.diceCount = 1;
         p.isActive = false;
       }
     }
@@ -105,8 +94,6 @@ export class SnakeGame {
       bonusCell = player.position;
       player.bonus = bonus;
       delete this.diceCells[player.position];
-      extraTurn = true;
-    } else if (rolledSix) {
       extraTurn = true;
     }
 


### PR DESCRIPTION
### Motivation
- Align gameplay with the requested rules: first token to reach the top tile `50` wins, and rolling a `6` should not grant an extra roll. 
- Simplify dice flow to a single-die mode so turn progression matches the new rule set.
- Surface clearer winner information in server events so clients can announce the winner and the winning tile.

### Description
- Changed the final board tile from `101` to `50` by updating `FINAL_TILE` in `bot/logic/snakeGame.js` and `bot/gameEngine.js`.
- Removed the automatic extra-turn-on-`6` behavior in the snake game logic so only bonus dice cells grant extra turns; updated dice handling to use a single die by default (`diceCount` now defaults/resets to `1`).
- Adjusted capture/reset behavior so captured players' `diceCount` is reset to `1`.
- Updated `DEFAULT_SNAKES` to better fit the 50-tile board (`49 -> 30`).
- Enhanced `gameWon` event payload to include `winnerName` and `winningTile` so clients receive explicit winner metadata.

### Testing
- Ran a Node smoke check that simulates reaching tile `50` which verified the game marks `finished` when a player lands on `50` using: `node --input-type=module -e "import { SnakeGame, FINAL_TILE } from './bot/logic/snakeGame.js'; ..."`; the script reported success.
- Ran a Node check that rolls a `6` to confirm no extra turn is granted and the turn advances, using: `node --input-type=module -e "import { SnakeGame } from './bot/logic/snakeGame.js'; ..."`; the script reported success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8b0e308f48329953698011fab1bc1)