### PR TITLE
Remove extra turn on 6, set final tile to 50, and improve 3D camera & token focus

### DIFF
--- a/bot/gameEngine.js
+++ b/bot/gameEngine.js
@@ -1,6 +1,6 @@
 import GameResult from "./models/GameResult.js";
-export const FINAL_TILE = 101;
-export const DEFAULT_SNAKES = { 99: 80 };
+export const FINAL_TILE = 50;
+export const DEFAULT_SNAKES = { 49: 30 };
 export const DEFAULT_LADDERS = { 3: 22, 27: 46 };
 export const ROLL_COOLDOWN_MS = 1000;
 export const RECONNECT_GRACE_MS = 60000;

--- a/bot/logic/snakeGame.js
+++ b/bot/logic/snakeGame.js
@@ -1,4 +1,4 @@
-export const FINAL_TILE = 101;
+export const FINAL_TILE = 50;
 
 export function applySnakesAndLadders(pos, snakes, ladders) {
   if (snakes[pos] != null) return Math.max(0, snakes[pos]);
@@ -56,7 +56,6 @@ export class SnakeGame {
 
     const total = dice.reduce((a, b) => a + b, 0);
     const rolledSix = dice.includes(6);
-    const doubleSix = dice.length >= 2 && dice[0] === 6 && dice[1] === 6;
 
     let target = player.position;
     let extraTurn = false;
@@ -65,15 +64,6 @@ export class SnakeGame {
       if (rolledSix) {
         player.isActive = true;
         target = 1;
-      }
-    } else if (player.position === 100) {
-      if (player.diceCount === 2) {
-        if (rolledSix) {
-          player.diceCount = 1;
-          extraTurn = true;
-        }
-      } else if (total === 1) {
-        target = FINAL_TILE;
       }
     } else if (player.position < FINAL_TILE) {
       if (player.position + total <= FINAL_TILE) {
@@ -105,8 +95,6 @@ export class SnakeGame {
       bonusCell = player.position;
       player.bonus = bonus;
       delete this.diceCells[player.position];
-      extraTurn = true;
-    } else if (rolledSix) {
       extraTurn = true;
     }
 

--- a/test/snakeGame.test.js
+++ b/test/snakeGame.test.js
@@ -26,11 +26,11 @@ test('applySnakesAndLadders resolves moves', () => {
   room.rollCooldown = 0;
   assert.equal(room.applySnakesAndLadders(3), 22); // ladder
   assert.equal(room.applySnakesAndLadders(27), 46); // ladder
-  assert.equal(room.applySnakesAndLadders(99), 80); // snake
+  assert.equal(room.applySnakesAndLadders(49), 30); // snake
   assert.equal(room.applySnakesAndLadders(8), 8); // none
 });
 
-test('start requires 6 and rolling 6 grants extra turn', () => {
+test('start requires 6 and turns advance after each roll', () => {
   const io = new DummyIO();
   const room = new GameRoom('r', io, 2, {
     snakes: DEFAULT_SNAKES,
@@ -49,17 +49,17 @@ test('start requires 6 and rolling 6 grants extra turn', () => {
 
   room.rollDice(s2, [6, 2]);
   assert.equal(room.players[1].position, 1);
-  assert.equal(room.currentTurn, 1);
-
-  room.rollDice(s2, [1, 2]);
   assert.equal(room.currentTurn, 0);
 
-  room.rollDice(s1, [6, 1]);
-  assert.equal(room.players[0].position, 1);
+  room.rollDice(s1, [1, 2]);
+  assert.equal(room.currentTurn, 1);
+
+  room.rollDice(s2, [6, 1]);
+  assert.equal(room.players[1].position, 8);
   assert.equal(room.currentTurn, 0);
 });
 
-test('rolling multiple sixes grants extra turns but preserves order', () => {
+test('single-player room still progresses without six bonus turns', () => {
   const io = new DummyIO();
   const room = new GameRoom('r1', io, 1, {
     snakes: DEFAULT_SNAKES,
@@ -72,8 +72,7 @@ test('rolling multiple sixes grants extra turns but preserves order', () => {
 
   room.rollDice(socket, [6, 6]);
   room.rollDice(socket, [6, 6]);
-  room.rollDice(socket, [6, 6]);
-  assert.equal(room.players[0].position, 25);
+  assert.equal(room.players[0].position, 13);
 });
 
 test('room starts when reaching custom capacity', async () => {

--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -264,10 +264,10 @@ const INITIAL_CAMERA_DISTANCE_FACTOR = 0.32;
 const POINTER_TAP_MAX_DISTANCE = 14;
 const POINTER_TAP_MAX_DURATION_MS = 420;
 const PORTRAIT_CAMERA_TUNING = Object.freeze({
-  backOffset: 0.98,
-  forwardOffset: 0,
-  heightOffset: 2.66,
-  targetLift: 0.055 * MODEL_SCALE
+  backOffset: 0.9,
+  forwardOffset: 0.08,
+  heightOffset: 2.78,
+  targetLift: 0.04 * MODEL_SCALE
 });
 const LANDSCAPE_CAMERA_TUNING = Object.freeze({
   backOffset: 0.68,
@@ -275,7 +275,7 @@ const LANDSCAPE_CAMERA_TUNING = Object.freeze({
   heightOffset: 1.2,
   targetLift: 0.08 * MODEL_SCALE
 });
-const LOCK_BOTTOM_SEAT_CAMERA = true;
+const LOCK_BOTTOM_SEAT_CAMERA = false;
 const SHOW_BOARD_RAILS = false;
 const COIN_RAISE = TILE_SIZE * 0.24;
 const COIN_LOCAL_LIFT = TILE_SIZE * 0.05;
@@ -1648,7 +1648,7 @@ function computeTurnCameraFocusState(board, camera, turnIndex, players = []) {
   return { position, target };
 }
 
-function computeDiceCameraFocusState(board, camera) {
+function computeDiceCameraFocusState(board, camera, turnIndex = null, players = []) {
   if (!board || !camera) return null;
   if (LOCK_BOTTOM_SEAT_CAMERA) return null;
   const diceSet = Array.isArray(board.diceSet) ? board.diceSet.filter((die) => die?.visible) : [];
@@ -1661,7 +1661,20 @@ function computeDiceCameraFocusState(board, camera) {
   diceCenter.multiplyScalar(1 / diceSet.length);
 
   const target = diceCenter.clone();
-  target.y += DICE_SIZE * 0.45;
+  const anchors = Array.isArray(board.seatAnchors) ? board.seatAnchors : [];
+  const player = Array.isArray(players) && Number.isInteger(turnIndex) ? players[turnIndex] : null;
+  const rawSeatIndex = Number.isFinite(player?.seatIndex)
+    ? Number(player.seatIndex)
+    : Number.isInteger(turnIndex)
+    ? turnIndex
+    : Number(turnIndex);
+  const seatIndex = Math.trunc(rawSeatIndex);
+  if (Number.isFinite(seatIndex) && seatIndex >= 0 && seatIndex < anchors.length) {
+    const seatWorld = new THREE.Vector3();
+    anchors[seatIndex]?.getWorldPosition?.(seatWorld);
+    target.lerp(seatWorld, 0.28);
+  }
+  target.y = boardLookTarget.y;
   const position = camera.position.clone();
   return { position, target };
 }
@@ -3362,15 +3375,12 @@ function updateTokens(
 
     let emissiveHex = 0x000000;
     let emissiveIntensity = 0.2;
-    if (burning.includes(index)) {
+    if (burning.includes(index) || index === rollingIndex) {
       emissiveHex = 0x7f1d1d;
       emissiveIntensity = 0.65;
-    } else if (index === rollingIndex) {
-      emissiveHex = 0x0ea5e9;
-      emissiveIntensity = 0.45;
     } else if (index === currentTurn) {
-      emissiveHex = 0x1d4ed8;
-      emissiveIntensity = 0.4;
+      emissiveHex = 0x7f1d1d;
+      emissiveIntensity = 0.55;
     }
 
     if (mat) {
@@ -4859,7 +4869,7 @@ export default function SnakeBoard3D({
       if (active.length) {
         const camera = cameraRef.current;
         const controls = board.controls;
-        const diceCameraState = computeDiceCameraFocusState(board, camera);
+        const diceCameraState = computeDiceCameraFocusState(board, camera, currentTurn, players);
         if (camera && controls && diceCameraState && cameraViewMode !== '2d') {
           removeAnimationsByType(animationsRef.current, 'cameraTurnFocus');
           const restoreState = turnCameraStateRef.current || captureCameraState(camera, controls);
@@ -4923,7 +4933,7 @@ export default function SnakeBoard3D({
         lastSeatIndex
       };
     }
-  }, [diceEvent, cameraViewMode]);
+  }, [diceEvent, cameraViewMode, currentTurn, players]);
 
   useEffect(() => {
     if (!captureEvent || !boardRef.current) return;

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -2670,7 +2670,7 @@ export default function SnakeAndLadder() {
         const ladObj = ladders[predicted];
         predicted = typeof ladObj === 'object' ? ladObj.end : ladObj;
       }
-      const extraPred = diceCells[predicted] || rolledSix;
+      const extraPred = Boolean(diceCells[predicted]);
       const nextPlayer = extraPred ? currentTurn : getPreviousTurn(currentTurn);
 
       const steps = [];
@@ -2778,11 +2778,6 @@ export default function SnakeAndLadder() {
             yabbaSoundRef.current?.play().catch(() => {});
           }
           setTimeout(() => setRewardDice(0), 1000);
-          enqueueSnakeCommentaryEvent('bonus', { player: playerLabel });
-        } else if (rolledSix) {
-          setTurnMessage('Six! Roll again');
-          setBonusDice(0);
-          extraTurn = true;
           enqueueSnakeCommentaryEvent('bonus', { player: playerLabel });
         } else {
           setTurnMessage("Your turn");
@@ -2894,7 +2889,7 @@ export default function SnakeAndLadder() {
       const ladObj = ladders[predicted];
       predicted = typeof ladObj === 'object' ? ladObj.end : ladObj;
     }
-    const extraPred = diceCells[predicted] || rolledSix;
+    const extraPred = Boolean(diceCells[predicted]);
     const nextPlayer = extraPred ? index : getPreviousTurn(index);
 
     const steps = [];
@@ -2991,10 +2986,6 @@ export default function SnakeAndLadder() {
           yabbaSoundRef.current?.play().catch(() => {});
         }
         setTimeout(() => setRewardDice(0), 1000);
-        enqueueSnakeCommentaryEvent('bonus', { player: playerLabel });
-      } else if (rolledSix) {
-        setTurnMessage(`${getPlayerName(index)} rolled 6! Bonus roll`);
-        extraTurn = true;
         enqueueSnakeCommentaryEvent('bonus', { player: playerLabel });
       }
       const next = extraTurn ? index : getPreviousTurn(index);
@@ -4067,10 +4058,7 @@ export default function SnakeAndLadder() {
                   values: vals,
                   seatIndex: currentTurn
                 });
-                const rolledSix = Array.isArray(vals)
-                  ? vals.some((v) => Number(v) === 6)
-                  : Number(vals) === 6;
-                setPendingExtraRoll(rolledSix);
+                setPendingExtraRoll(false);
               }}
             />
           ) : null}


### PR DESCRIPTION
### Motivation
- Make snake-and-ladder gameplay deterministic: eliminate the automatic extra roll when rolling a 6 and have the game finish when a token reaches the top tile (tile 50). 
- Improve player experience by tightening portrait camera framing and making camera/dice focus follow the active seat and token movements.
- Unify token visual feedback so rolling/active tokens have the same flame-like emissive style.

### Description
- Game rules: changed final board tile from `101` to `50` and updated default snakes mapping to match the 50-tile board by editing `bot/gameEngine.js` and `bot/logic/snakeGame.js` (replaced `FINAL_TILE` and adjusted defaults). 
- Turn flow: removed the extra-turn-on-6 behavior from server logic in `bot/logic/snakeGame.js` and updated client-side roll handling in `webapp/src/pages/Games/SnakeAndLadder.jsx` so extra turns only occur from bonus dice cells; local, AI, and multiplayer code paths were adjusted to stop granting extra turns for a `6`.
- Camera & dice focus: tuned portrait camera offsets and target lift in `webapp/src/components/SnakeBoard3D.jsx` to be slightly closer and higher and to look a bit more downward, unlocked seat-based camera cues, and updated `computeDiceCameraFocusState` to blend dice focus toward the active seat (accepts `turnIndex`/`players`).
- Token visuals: changed token emissive rules so `rolling` tokens and `burning` tokens use the same flame-like emissive and increased highlight intensity for active tokens in `webapp/src/components/SnakeBoard3D.jsx`.
- Tests: updated `test/snakeGame.test.js` expectations to reflect the new board size and turn flow.

### Testing
- Ran the unit integration tests: `npm test -- test/snakeGame.test.js test/snakeApi.test.js` and confirmed both suites pass (suites passed; there is a repo-wide Jest teardown warning but tests complete successfully). 
- Verified updated server-side `rollDice` behavior produces the correct `movePlayer`, `diceCellsUpdate`, and `gameWon` events in the `GameRoom` flow during the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8b0e308f48329953698011fab1bc1)