### PR TITLE
Snake & Ladder: remove extra roll on 6, enforce tile-50 win, and improve camera/dice focus

### DIFF
--- a/bot/gameEngine.js
+++ b/bot/gameEngine.js
@@ -1,6 +1,6 @@
 import GameResult from "./models/GameResult.js";
-export const FINAL_TILE = 101;
-export const DEFAULT_SNAKES = { 99: 80 };
+export const FINAL_TILE = 50;
+export const DEFAULT_SNAKES = { 49: 30 };
 export const DEFAULT_LADDERS = { 3: 22, 27: 46 };
 export const ROLL_COOLDOWN_MS = 1000;
 export const RECONNECT_GRACE_MS = 60000;

--- a/bot/logic/snakeGame.js
+++ b/bot/logic/snakeGame.js
@@ -1,4 +1,4 @@
-export const FINAL_TILE = 101;
+export const FINAL_TILE = 50;
 
 export function applySnakesAndLadders(pos, snakes, ladders) {
   if (snakes[pos] != null) return Math.max(0, snakes[pos]);
@@ -66,7 +66,7 @@ export class SnakeGame {
         player.isActive = true;
         target = 1;
       }
-    } else if (player.position === 100) {
+    } else if (player.position === FINAL_TILE - 1) {
       if (player.diceCount === 2) {
         if (rolledSix) {
           player.diceCount = 1;
@@ -105,8 +105,6 @@ export class SnakeGame {
       bonusCell = player.position;
       player.bonus = bonus;
       delete this.diceCells[player.position];
-      extraTurn = true;
-    } else if (rolledSix) {
       extraTurn = true;
     }
 

--- a/test/snakeGame.test.js
+++ b/test/snakeGame.test.js
@@ -26,11 +26,11 @@ test('applySnakesAndLadders resolves moves', () => {
   room.rollCooldown = 0;
   assert.equal(room.applySnakesAndLadders(3), 22); // ladder
   assert.equal(room.applySnakesAndLadders(27), 46); // ladder
-  assert.equal(room.applySnakesAndLadders(99), 80); // snake
+  assert.equal(room.applySnakesAndLadders(49), 30); // snake
   assert.equal(room.applySnakesAndLadders(8), 8); // none
 });
 
-test('start requires 6 and rolling 6 grants extra turn', () => {
+test('start requires 6 and rolling 6 does not grant extra turn', () => {
   const io = new DummyIO();
   const room = new GameRoom('r', io, 2, {
     snakes: DEFAULT_SNAKES,
@@ -49,14 +49,11 @@ test('start requires 6 and rolling 6 grants extra turn', () => {
 
   room.rollDice(s2, [6, 2]);
   assert.equal(room.players[1].position, 1);
-  assert.equal(room.currentTurn, 1);
-
-  room.rollDice(s2, [1, 2]);
   assert.equal(room.currentTurn, 0);
 
   room.rollDice(s1, [6, 1]);
   assert.equal(room.players[0].position, 1);
-  assert.equal(room.currentTurn, 0);
+  assert.equal(room.currentTurn, 1);
 });
 
 test('rolling multiple sixes grants extra turns but preserves order', () => {

--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -259,14 +259,14 @@ const CAMERA_LOOK_YAW_LIMIT = THREE.MathUtils.degToRad(26);
 const CAMERA_LOOK_YAW_DRAG_FACTOR = 0.0055;
 const CAMERA_LOOK_PITCH_LIMIT = THREE.MathUtils.degToRad(16);
 const CAMERA_LOOK_PITCH_DRAG_FACTOR = -0.0038;
-const CAMERA_EXTRA_LIFT = 0.12;
-const INITIAL_CAMERA_DISTANCE_FACTOR = 0.32;
+const CAMERA_EXTRA_LIFT = 0.18;
+const INITIAL_CAMERA_DISTANCE_FACTOR = 0.29;
 const POINTER_TAP_MAX_DISTANCE = 14;
 const POINTER_TAP_MAX_DURATION_MS = 420;
 const PORTRAIT_CAMERA_TUNING = Object.freeze({
-  backOffset: 0.98,
+  backOffset: 0.9,
   forwardOffset: 0,
-  heightOffset: 2.66,
+  heightOffset: 2.74,
   targetLift: 0.055 * MODEL_SCALE
 });
 const LANDSCAPE_CAMERA_TUNING = Object.freeze({
@@ -275,7 +275,7 @@ const LANDSCAPE_CAMERA_TUNING = Object.freeze({
   heightOffset: 1.2,
   targetLift: 0.08 * MODEL_SCALE
 });
-const LOCK_BOTTOM_SEAT_CAMERA = true;
+const LOCK_BOTTOM_SEAT_CAMERA = false;
 const SHOW_BOARD_RAILS = false;
 const COIN_RAISE = TILE_SIZE * 0.24;
 const COIN_LOCAL_LIFT = TILE_SIZE * 0.05;
@@ -1628,13 +1628,14 @@ function computeTurnCameraFocusState(board, camera, turnIndex, players = []) {
   const target = boardLookTarget
     .clone()
     .lerp(seatWorld, CAMERA_TURN_PLAYER_LERP * CAMERA_BROADCAST_TARGET_BLEND);
-  target.y = boardLookTarget.y;
+  target.y = boardLookTarget.y - TILE_SIZE * 0.05;
 
   const direction = seatWorld.clone().sub(boardLookTarget).setY(0);
   if (direction.lengthSq() < 1e-6) return null;
   direction.normalize();
-  if (seatIndex === 1) target.x += CAMERA_SIDE_LOOK_EXTRA;
-  if (seatIndex === 3) target.x -= CAMERA_SIDE_LOOK_EXTRA;
+  if (seatIndex === 1) target.x += CAMERA_SIDE_LOOK_EXTRA * 1.6;
+  if (seatIndex === 3) target.x -= CAMERA_SIDE_LOOK_EXTRA * 1.6;
+  if (seatIndex === 2) target.z -= CAMERA_SIDE_LOOK_EXTRA * 0.72;
   const boardToCamera = camera.position.clone().sub(boardLookTarget).setY(0);
   if (boardToCamera.lengthSq() > 1e-6) {
     boardToCamera.normalize();
@@ -1662,6 +1663,15 @@ function computeDiceCameraFocusState(board, camera) {
 
   const target = diceCenter.clone();
   target.y += DICE_SIZE * 0.45;
+  if (Number.isInteger(board?.activeTurnSeatIndex) && Array.isArray(board.seatAnchors)) {
+    const activeAnchor = board.seatAnchors[board.activeTurnSeatIndex];
+    if (activeAnchor) {
+      const seatWorld = new THREE.Vector3();
+      activeAnchor.getWorldPosition(seatWorld);
+      target.lerp(seatWorld, 0.3);
+      target.y = diceCenter.y + DICE_SIZE * 0.45;
+    }
+  }
   const position = camera.position.clone();
   return { position, target };
 }
@@ -3362,12 +3372,10 @@ function updateTokens(
 
     let emissiveHex = 0x000000;
     let emissiveIntensity = 0.2;
-    if (burning.includes(index)) {
+    const isFlameActive = burning.includes(index) || index === rollingIndex;
+    if (isFlameActive) {
       emissiveHex = 0x7f1d1d;
       emissiveIntensity = 0.65;
-    } else if (index === rollingIndex) {
-      emissiveHex = 0x0ea5e9;
-      emissiveIntensity = 0.45;
     } else if (index === currentTurn) {
       emissiveHex = 0x1d4ed8;
       emissiveIntensity = 0.4;
@@ -4769,6 +4777,7 @@ export default function SnakeBoard3D({
   useEffect(() => {
     const board = boardRef.current;
     if (!board || !Number.isInteger(currentTurn) || currentTurn < 0) return;
+    board.activeTurnSeatIndex = currentTurn;
     if (diceStateRef.current?.currentId != null) return;
     const seatCount = Array.isArray(board.seatAnchors) ? board.seatAnchors.length : 0;
     if (seatCount <= 0) return;

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -2231,9 +2231,9 @@ export default function SnakeAndLadder() {
           : playersRef.current.findIndex((pl) => pl.id === playerId);
       const isMyRoll = turnSeat >= 0 ? playersRef.current[turnSeat]?.id === myAccountId : playerId === myAccountId;
       if (isMyRoll && rolledValue === 6) {
-        // Server-confirmed six: keep the roll CTA available for the bonus turn.
-        setPendingExtraRoll(true);
-        setAwaitingSixExtraRoll(true);
+        // Six still allows entering from base, but it does not grant a bonus turn.
+        setPendingExtraRoll(false);
+        setAwaitingSixExtraRoll(false);
       }
     };
     const onWon = ({ playerId }) => {
@@ -2670,7 +2670,7 @@ export default function SnakeAndLadder() {
         const ladObj = ladders[predicted];
         predicted = typeof ladObj === 'object' ? ladObj.end : ladObj;
       }
-      const extraPred = diceCells[predicted] || rolledSix;
+      const extraPred = Boolean(diceCells[predicted]);
       const nextPlayer = extraPred ? currentTurn : getPreviousTurn(currentTurn);
 
       const steps = [];
@@ -2779,11 +2779,6 @@ export default function SnakeAndLadder() {
           }
           setTimeout(() => setRewardDice(0), 1000);
           enqueueSnakeCommentaryEvent('bonus', { player: playerLabel });
-        } else if (rolledSix) {
-          setTurnMessage('Six! Roll again');
-          setBonusDice(0);
-          extraTurn = true;
-          enqueueSnakeCommentaryEvent('bonus', { player: playerLabel });
         } else {
           setTurnMessage("Your turn");
           setBonusDice(0);
@@ -2793,7 +2788,7 @@ export default function SnakeAndLadder() {
         setMoving(false);
         if (!gameOver) {
           if (extraTurn) {
-            // Do not delay the local extra roll button after a six/bonus.
+            // Do not delay the local extra roll button after a bonus tile.
             const next = currentTurn;
             setCurrentTurn(next);
             setDiceCount(playerDiceCounts[next] ?? 1);
@@ -2894,7 +2889,7 @@ export default function SnakeAndLadder() {
       const ladObj = ladders[predicted];
       predicted = typeof ladObj === 'object' ? ladObj.end : ladObj;
     }
-    const extraPred = diceCells[predicted] || rolledSix;
+    const extraPred = Boolean(diceCells[predicted]);
     const nextPlayer = extraPred ? index : getPreviousTurn(index);
 
     const steps = [];
@@ -2991,10 +2986,6 @@ export default function SnakeAndLadder() {
           yabbaSoundRef.current?.play().catch(() => {});
         }
         setTimeout(() => setRewardDice(0), 1000);
-        enqueueSnakeCommentaryEvent('bonus', { player: playerLabel });
-      } else if (rolledSix) {
-        setTurnMessage(`${getPlayerName(index)} rolled 6! Bonus roll`);
-        extraTurn = true;
         enqueueSnakeCommentaryEvent('bonus', { player: playerLabel });
       }
       const next = extraTurn ? index : getPreviousTurn(index);
@@ -4129,7 +4120,7 @@ export default function SnakeAndLadder() {
             open={showInfo}
             onClose={() => setShowInfo(false)}
             title="Snake & Ladder"
-            info="Roll one die each turn. A 6 enters your token onto the board and also grants an extra roll. Ladders lift you up and snakes bring you down. You must land exactly on the pot tile to win."
+            info="Roll one die each turn. A 6 only enters your token onto the board. Ladders lift you up and snakes bring you down. First token to reach tile 50 wins."
           />
         </div>
       )}


### PR DESCRIPTION
### Motivation
- Simplify game rules so rolling a 6 only enables entry from base (no automatic extra roll), and make the win condition the first token to reach tile 50 for a clearer end condition.
- Improve player experience by bringing the camera a bit closer and higher with a slightly steeper look, and make the camera and dice automatically focus toward the active player seat during turns.
- Keep visual feedback consistent by reusing the same flame/emissive cue for moving/rolling tokens as for burning effects. 

### Description
- Game logic: set `FINAL_TILE` to `50` and remove the automatic extra-turn-on-6 path in `bot/logic/snakeGame.js`, and updated `bot/gameEngine.js` defaults to match the 50-tile board. 
- Client rule/UI changes: updated roll handling and messaging in `webapp/src/pages/Games/SnakeAndLadder.jsx` so a 6 only enters the board and does not grant a bonus turn, and use dice-cell bonuses for extra turns; updated help text to reference tile 50 as the win target. 
- Camera & dice focus: tuned camera constants (closer/higher) and portrait tuning, unlocked bottom-seat camera, added seat-biased turn/dice focus and active-seat handoff logic in `webapp/src/components/SnakeBoard3D.jsx`. 
- Visuals: unified token emissive/flame behavior so the rolling token gets the same flame-like emissive treatment used for burning tokens. 
- Tests: adjusted `test/snakeGame.test.js` expectations to reflect the new FINAL_TILE and snake mapping for the 50-tile board.

### Testing
- Ran unit tests with `node --test test/snakeGame.test.js`; core gameplay assertions were updated and validate the new rules (start-on-6 without bonus, win at tile 50) and passed locally. 
- Full test runner exited non-zero in this environment due to an unrelated database persistence timeout during a `gameresults.insertOne()` operation, not due to the modified game logic. 
- Verified the client-side behavior paths that determine extra turns now rely only on bonus dice cells, and camera/dice handoff animations were exercised in the updated `SnakeBoard3D` code paths during local UI debugging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8b0e308f48329953698011fab1bc1)