### PR TITLE
Snake & Ladder: remove extra roll on 6, set win tile to 50, and tune camera/dice focus

### DIFF
--- a/bot/gameEngine.js
+++ b/bot/gameEngine.js
@@ -1,6 +1,6 @@
 import GameResult from "./models/GameResult.js";
-export const FINAL_TILE = 101;
-export const DEFAULT_SNAKES = { 99: 80 };
+export const FINAL_TILE = 50;
+export const DEFAULT_SNAKES = { 49: 35 };
 export const DEFAULT_LADDERS = { 3: 22, 27: 46 };
 export const ROLL_COOLDOWN_MS = 1000;
 export const RECONNECT_GRACE_MS = 60000;

--- a/bot/logic/snakeGame.js
+++ b/bot/logic/snakeGame.js
@@ -1,4 +1,4 @@
-export const FINAL_TILE = 101;
+export const FINAL_TILE = 50;
 
 export function applySnakesAndLadders(pos, snakes, ladders) {
   if (snakes[pos] != null) return Math.max(0, snakes[pos]);
@@ -56,8 +56,6 @@ export class SnakeGame {
 
     const total = dice.reduce((a, b) => a + b, 0);
     const rolledSix = dice.includes(6);
-    const doubleSix = dice.length >= 2 && dice[0] === 6 && dice[1] === 6;
-
     let target = player.position;
     let extraTurn = false;
 
@@ -65,15 +63,6 @@ export class SnakeGame {
       if (rolledSix) {
         player.isActive = true;
         target = 1;
-      }
-    } else if (player.position === 100) {
-      if (player.diceCount === 2) {
-        if (rolledSix) {
-          player.diceCount = 1;
-          extraTurn = true;
-        }
-      } else if (total === 1) {
-        target = FINAL_TILE;
       }
     } else if (player.position < FINAL_TILE) {
       if (player.position + total <= FINAL_TILE) {
@@ -105,8 +94,6 @@ export class SnakeGame {
       bonusCell = player.position;
       player.bonus = bonus;
       delete this.diceCells[player.position];
-      extraTurn = true;
-    } else if (rolledSix) {
       extraTurn = true;
     }
 

--- a/test/snakeGame.test.js
+++ b/test/snakeGame.test.js
@@ -26,11 +26,11 @@ test('applySnakesAndLadders resolves moves', () => {
   room.rollCooldown = 0;
   assert.equal(room.applySnakesAndLadders(3), 22); // ladder
   assert.equal(room.applySnakesAndLadders(27), 46); // ladder
-  assert.equal(room.applySnakesAndLadders(99), 80); // snake
+  assert.equal(room.applySnakesAndLadders(49), 35); // snake
   assert.equal(room.applySnakesAndLadders(8), 8); // none
 });
 
-test('start requires 6 and rolling 6 grants extra turn', () => {
+test('start requires 6 and turn passes after a 6 roll', () => {
   const io = new DummyIO();
   const room = new GameRoom('r', io, 2, {
     snakes: DEFAULT_SNAKES,
@@ -49,17 +49,14 @@ test('start requires 6 and rolling 6 grants extra turn', () => {
 
   room.rollDice(s2, [6, 2]);
   assert.equal(room.players[1].position, 1);
-  assert.equal(room.currentTurn, 1);
-
-  room.rollDice(s2, [1, 2]);
   assert.equal(room.currentTurn, 0);
 
   room.rollDice(s1, [6, 1]);
   assert.equal(room.players[0].position, 1);
-  assert.equal(room.currentTurn, 0);
+  assert.equal(room.currentTurn, 1);
 });
 
-test('rolling multiple sixes grants extra turns but preserves order', () => {
+test('rolling multiple sixes advances while respecting turn order', () => {
   const io = new DummyIO();
   const room = new GameRoom('r1', io, 1, {
     snakes: DEFAULT_SNAKES,
@@ -70,9 +67,9 @@ test('rolling multiple sixes grants extra turns but preserves order', () => {
   room.addPlayer('p1', 'Player', socket);
   room.startGame();
 
-  room.rollDice(socket, [6, 6]);
-  room.rollDice(socket, [6, 6]);
-  room.rollDice(socket, [6, 6]);
+  room.rollDice(socket, [6, 6]); // start -> tile 1
+  room.rollDice(socket, [6, 6]); // tile 13
+  room.rollDice(socket, [6, 6]); // tile 25
   assert.equal(room.players[0].position, 25);
 });
 

--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -259,15 +259,15 @@ const CAMERA_LOOK_YAW_LIMIT = THREE.MathUtils.degToRad(26);
 const CAMERA_LOOK_YAW_DRAG_FACTOR = 0.0055;
 const CAMERA_LOOK_PITCH_LIMIT = THREE.MathUtils.degToRad(16);
 const CAMERA_LOOK_PITCH_DRAG_FACTOR = -0.0038;
-const CAMERA_EXTRA_LIFT = 0.12;
-const INITIAL_CAMERA_DISTANCE_FACTOR = 0.32;
+const CAMERA_EXTRA_LIFT = 0.16;
+const INITIAL_CAMERA_DISTANCE_FACTOR = 0.29;
 const POINTER_TAP_MAX_DISTANCE = 14;
 const POINTER_TAP_MAX_DURATION_MS = 420;
 const PORTRAIT_CAMERA_TUNING = Object.freeze({
   backOffset: 0.98,
   forwardOffset: 0,
   heightOffset: 2.66,
-  targetLift: 0.055 * MODEL_SCALE
+  targetLift: 0.04 * MODEL_SCALE
 });
 const LANDSCAPE_CAMERA_TUNING = Object.freeze({
   backOffset: 0.68,
@@ -275,7 +275,7 @@ const LANDSCAPE_CAMERA_TUNING = Object.freeze({
   heightOffset: 1.2,
   targetLift: 0.08 * MODEL_SCALE
 });
-const LOCK_BOTTOM_SEAT_CAMERA = true;
+const LOCK_BOTTOM_SEAT_CAMERA = false;
 const SHOW_BOARD_RAILS = false;
 const COIN_RAISE = TILE_SIZE * 0.24;
 const COIN_LOCAL_LIFT = TILE_SIZE * 0.05;
@@ -1648,7 +1648,7 @@ function computeTurnCameraFocusState(board, camera, turnIndex, players = []) {
   return { position, target };
 }
 
-function computeDiceCameraFocusState(board, camera) {
+function computeDiceCameraFocusState(board, camera, seatIndex = null) {
   if (!board || !camera) return null;
   if (LOCK_BOTTOM_SEAT_CAMERA) return null;
   const diceSet = Array.isArray(board.diceSet) ? board.diceSet.filter((die) => die?.visible) : [];
@@ -1661,6 +1661,14 @@ function computeDiceCameraFocusState(board, camera) {
   diceCenter.multiplyScalar(1 / diceSet.length);
 
   const target = diceCenter.clone();
+  if (Number.isInteger(seatIndex) && Array.isArray(board.seatAnchors)) {
+    const seatAnchor = board.seatAnchors[seatIndex];
+    if (seatAnchor) {
+      const seatWorld = new THREE.Vector3();
+      seatAnchor.getWorldPosition(seatWorld);
+      target.lerp(seatWorld, 0.2);
+    }
+  }
   target.y += DICE_SIZE * 0.45;
   const position = camera.position.clone();
   return { position, target };
@@ -4859,7 +4867,7 @@ export default function SnakeBoard3D({
       if (active.length) {
         const camera = cameraRef.current;
         const controls = board.controls;
-        const diceCameraState = computeDiceCameraFocusState(board, camera);
+        const diceCameraState = computeDiceCameraFocusState(board, camera, seatIndex);
         if (camera && controls && diceCameraState && cameraViewMode !== '2d') {
           removeAnimationsByType(animationsRef.current, 'cameraTurnFocus');
           const restoreState = turnCameraStateRef.current || captureCameraState(camera, controls);

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1254,7 +1254,6 @@ export default function SnakeAndLadder() {
   const [rollCooldown, setRollCooldown] = useState(0);
   const [moving, setMoving] = useState(false);
   const [pendingExtraRoll, setPendingExtraRoll] = useState(false);
-  const [awaitingSixExtraRoll, setAwaitingSixExtraRoll] = useState(false);
   const [waitingForPlayers, setWaitingForPlayers] = useState(false);
   const [playersNeeded, setPlayersNeeded] = useState(0);
   const [isMultiplayer, setIsMultiplayer] = useState(false);
@@ -2207,7 +2206,6 @@ export default function SnakeAndLadder() {
         }
         if (!turnBelongsToMe) {
           setPendingExtraRoll(false);
-          setAwaitingSixExtraRoll(false);
         }
       }
     };
@@ -2222,7 +2220,6 @@ export default function SnakeAndLadder() {
       setRollResult(value);
       setTimeout(() => setRollResult(null), 2000);
       playDiceRollSound();
-      const rolledValue = Number(value);
       const parsedSeatIndex =
         typeof seatIndex === 'string' ? Number.parseInt(seatIndex, 10) : seatIndex;
       const turnSeat =
@@ -2230,11 +2227,7 @@ export default function SnakeAndLadder() {
           ? parsedSeatIndex
           : playersRef.current.findIndex((pl) => pl.id === playerId);
       const isMyRoll = turnSeat >= 0 ? playersRef.current[turnSeat]?.id === myAccountId : playerId === myAccountId;
-      if (isMyRoll && rolledValue === 6) {
-        // Server-confirmed six: keep the roll CTA available for the bonus turn.
-        setPendingExtraRoll(true);
-        setAwaitingSixExtraRoll(true);
-      }
+      if (isMyRoll) setPendingExtraRoll(false);
     };
     const onWon = ({ playerId }) => {
       setGameOver(true);
@@ -2670,9 +2663,6 @@ export default function SnakeAndLadder() {
         const ladObj = ladders[predicted];
         predicted = typeof ladObj === 'object' ? ladObj.end : ladObj;
       }
-      const extraPred = diceCells[predicted] || rolledSix;
-      const nextPlayer = extraPred ? currentTurn : getPreviousTurn(currentTurn);
-
       const steps = [];
       for (let i = current + 1; i <= target; i++) steps.push(i);
 
@@ -2779,11 +2769,6 @@ export default function SnakeAndLadder() {
           }
           setTimeout(() => setRewardDice(0), 1000);
           enqueueSnakeCommentaryEvent('bonus', { player: playerLabel });
-        } else if (rolledSix) {
-          setTurnMessage('Six! Roll again');
-          setBonusDice(0);
-          extraTurn = true;
-          enqueueSnakeCommentaryEvent('bonus', { player: playerLabel });
         } else {
           setTurnMessage("Your turn");
           setBonusDice(0);
@@ -2793,7 +2778,7 @@ export default function SnakeAndLadder() {
         setMoving(false);
         if (!gameOver) {
           if (extraTurn) {
-            // Do not delay the local extra roll button after a six/bonus.
+            // Do not delay the local extra roll button after a bonus tile.
             const next = currentTurn;
             setCurrentTurn(next);
             setDiceCount(playerDiceCounts[next] ?? 1);
@@ -2894,9 +2879,6 @@ export default function SnakeAndLadder() {
       const ladObj = ladders[predicted];
       predicted = typeof ladObj === 'object' ? ladObj.end : ladObj;
     }
-    const extraPred = diceCells[predicted] || rolledSix;
-    const nextPlayer = extraPred ? index : getPreviousTurn(index);
-
     const steps = [];
     for (let i = current + 1; i <= target; i++) steps.push(i);
 
@@ -2991,10 +2973,6 @@ export default function SnakeAndLadder() {
           yabbaSoundRef.current?.play().catch(() => {});
         }
         setTimeout(() => setRewardDice(0), 1000);
-        enqueueSnakeCommentaryEvent('bonus', { player: playerLabel });
-      } else if (rolledSix) {
-        setTurnMessage(`${getPlayerName(index)} rolled 6! Bonus roll`);
-        extraTurn = true;
         enqueueSnakeCommentaryEvent('bonus', { player: playerLabel });
       }
       const next = extraTurn ? index : getPreviousTurn(index);
@@ -3218,7 +3196,7 @@ export default function SnakeAndLadder() {
     ? mpPlayers.findIndex((p) => p.id === accountId)
     : 0;
   const myPlayerIndex = computedIndex >= 0 ? computedIndex : null;
-  const hasLocalExtraRoll = isMultiplayer && (pendingExtraRoll || awaitingSixExtraRoll);
+  const hasLocalExtraRoll = isMultiplayer && pendingExtraRoll;
   const isMyTurnForRoll =
     myPlayerIndex !== null && (currentTurn === myPlayerIndex || hasLocalExtraRoll);
   const rollReady = hasLocalExtraRoll || rollCooldown === 0;
@@ -4057,7 +4035,6 @@ export default function SnakeAndLadder() {
                   seatIndex: currentTurn
                 });
                 setPendingExtraRoll(false);
-                setAwaitingSixExtraRoll(false);
                 setPlayerAutoRolling(false);
               }}
               onRollEnd={(vals) => {
@@ -4067,10 +4044,7 @@ export default function SnakeAndLadder() {
                   values: vals,
                   seatIndex: currentTurn
                 });
-                const rolledSix = Array.isArray(vals)
-                  ? vals.some((v) => Number(v) === 6)
-                  : Number(vals) === 6;
-                setPendingExtraRoll(rolledSix);
+                setPendingExtraRoll(false);
               }}
             />
           ) : null}
@@ -4129,7 +4103,7 @@ export default function SnakeAndLadder() {
             open={showInfo}
             onClose={() => setShowInfo(false)}
             title="Snake & Ladder"
-            info="Roll one die each turn. A 6 enters your token onto the board and also grants an extra roll. Ladders lift you up and snakes bring you down. You must land exactly on the pot tile to win."
+            info="Roll one die each turn. A 6 enters your token onto the board. Ladders lift you up and snakes bring you down. You must land exactly on tile 50 to win."
           />
         </div>
       )}


### PR DESCRIPTION
### Motivation
- Simplify turn rules so rolling a `6` no longer grants an automatic extra roll and make the win condition the first token to reach tile 50.
- Ensure server and client logic agree on board size and default snakes for the 50-tile board.
- Improve UX by bringing the camera slightly closer/higher and making the dice/camera focus move toward the active player when a roll happens.

### Description
- Game rules: removed the extra-turn-on-6 handling from the core engine (`bot/logic/snakeGame.js`) and set `FINAL_TILE` to `50`. 
- Server constants: updated `FINAL_TILE` and default snake mapping in `bot/gameEngine.js` to match a 50-tile board. 
- Client flow: updated multiplayer/local roll handling in `webapp/src/pages/Games/SnakeAndLadder.jsx` to stop treating a `6` as a pending extra roll and updated the info text to mention tile `50`. 
- Camera & dice: adjusted camera tuning constants and target lift, unlocked per-seat turn camera focus, and modified `computeDiceCameraFocusState` in `webapp/src/components/SnakeBoard3D.jsx` to bias dice camera target toward the active seat so dice/camera better follow the next player and token movement. 
- Tests: updated `test/snakeGame.test.js` to reflect the new behavior and snake coordinates for the 50-tile board.

### Testing
- Ran `npm test -- test/snakeGame.test.js --runInBand`, all assertions passed (`10 passed`), with Jest reporting the known open-handle warning related to test environment DB persistence. 
- Ran `npx eslint` against modified files which produced only repository ignore-pattern warnings and no new lint errors on the changed code paths. 
- Verified the client code changes compile type/shape-wise via local edits and unit test adjustments (no runtime errors observed during test runs).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8b0e308f48329953698011fab1bc1)