### PR TITLE
Snake & Ladder: single-die rolls and extra-turn-on-6 (with roll icon)

### DIFF
--- a/bot/gameEngine.js
+++ b/bot/gameEngine.js
@@ -217,7 +217,7 @@ export class GameRoom {
     if (this.gameType === 'snake') {
       this.players.forEach((p) => {
         p.position = 0;
-        p.diceCount = 2;
+        p.diceCount = 1;
         p.isActive = false;
       });
     }

--- a/bot/logic/snakeGame.js
+++ b/bot/logic/snakeGame.js
@@ -22,7 +22,7 @@ export class SnakeGame {
       id,
       name,
       position: 0,
-      diceCount: 2,
+      diceCount: 1,
       isActive: false,
     });
   }
@@ -40,7 +40,7 @@ export class SnakeGame {
     const player = this.players[this.currentTurn];
     if (!player) return null;
 
-    const diceToRoll = Math.max(1, player.diceCount || 2);
+    const diceToRoll = Math.max(1, player.diceCount || 1);
     const rand = () => Math.floor(Math.random() * 6) + 1;
     const provided = Array.isArray(diceValues)
       ? diceValues
@@ -57,7 +57,7 @@ export class SnakeGame {
     const total = dice.reduce((a, b) => a + b, 0);
     const rolledSix = dice.includes(6);
     let target = player.position;
-    let extraTurn = false;
+    let extraTurn = rolledSix;
 
     if (player.position === 0) {
       if (rolledSix) {
@@ -82,7 +82,7 @@ export class SnakeGame {
     for (const p of this.players) {
       if (p !== player && p.position === player.position && p.position > 0) {
         p.position = 0;
-        p.diceCount = 2;
+        p.diceCount = 1;
         p.isActive = false;
       }
     }

--- a/test/snakeGame.test.js
+++ b/test/snakeGame.test.js
@@ -30,7 +30,7 @@ test('applySnakesAndLadders resolves moves', () => {
   assert.equal(room.applySnakesAndLadders(8), 8); // none
 });
 
-test('start requires 6 and turn passes after a 6 roll', () => {
+test('start requires 6 and rolling 6 grants another turn', () => {
   const io = new DummyIO();
   const room = new GameRoom('r', io, 2, {
     snakes: DEFAULT_SNAKES,
@@ -43,20 +43,28 @@ test('start requires 6 and turn passes after a 6 roll', () => {
   room.addPlayer('p2', 'Player2', s2);
   room.startGame();
 
-  room.rollDice(s1, [2, 4]);
+  room.rollDice(s1, [2]);
   assert.equal(room.players[0].position, 0);
   assert.equal(room.currentTurn, 1);
 
-  room.rollDice(s2, [6, 2]);
+  room.rollDice(s2, [6]);
   assert.equal(room.players[1].position, 1);
+  assert.equal(room.currentTurn, 1);
+
+  room.rollDice(s2, [1]);
+  assert.equal(room.players[1].position, 2);
   assert.equal(room.currentTurn, 0);
 
-  room.rollDice(s1, [6, 1]);
+  room.rollDice(s1, [6]);
   assert.equal(room.players[0].position, 1);
+  assert.equal(room.currentTurn, 0);
+
+  room.rollDice(s1, [1]);
+  assert.equal(room.players[0].position, 2);
   assert.equal(room.currentTurn, 1);
 });
 
-test('rolling multiple sixes advances while respecting turn order', () => {
+test('rolling multiple sixes advances with repeated bonus turns', () => {
   const io = new DummyIO();
   const room = new GameRoom('r1', io, 1, {
     snakes: DEFAULT_SNAKES,
@@ -67,10 +75,11 @@ test('rolling multiple sixes advances while respecting turn order', () => {
   room.addPlayer('p1', 'Player', socket);
   room.startGame();
 
-  room.rollDice(socket, [6, 6]); // start -> tile 1
-  room.rollDice(socket, [6, 6]); // tile 13
-  room.rollDice(socket, [6, 6]); // tile 25
-  assert.equal(room.players[0].position, 25);
+  room.rollDice(socket, [6]); // start -> tile 1, extra turn
+  room.rollDice(socket, [6]); // tile 7, extra turn
+  room.rollDice(socket, [6]); // tile 13, extra turn
+  room.rollDice(socket, [1]); // tile 14
+  assert.equal(room.players[0].position, 14);
 });
 
 test('room starts when reaching custom capacity', async () => {
@@ -121,7 +130,7 @@ test('player wins when landing on the final tile', () => {
 
   room.players[0].position = FINAL_TILE - 3;
   room.players[0].isActive = true;
-  room.rollDice(socket, [1, 2]);
+  room.rollDice(socket, [3]);
 
   assert.equal(room.players[0].position, FINAL_TILE);
   assert.equal(room.status, 'finished');
@@ -140,10 +149,10 @@ test('rolling too quickly triggers anti-cheat', () => {
   room.addPlayer('p1', 'Cheater', socket);
   room.startGame();
 
-  room.rollDice(socket, [6, 2]); // first roll activates token
+  room.rollDice(socket, [6]); // first roll activates token
   const pos = room.players[0].position;
   room.rollCooldown = 1000;
-  room.rollDice(socket, [3, 2]); // second roll immediately should be rejected
+  room.rollDice(socket, [3]); // second roll immediately should be rejected
 
   assert.equal(room.players[0].position, pos);
   const err = emitted.find(e => e.event === 'error');
@@ -159,11 +168,11 @@ test('repeated cheating results in removal', () => {
   room.startGame();
 
   room.rollCooldown = 1000;
-  room.rollDice(socket, [6, 2]); // valid roll
+  room.rollDice(socket, [6]); // valid roll
   // Three rapid rolls to trigger warnings
-  room.rollDice(socket, [2, 2]);
-  room.rollDice(socket, [2, 2]);
-  room.rollDice(socket, [2, 2]);
+  room.rollDice(socket, [2]);
+  room.rollDice(socket, [2]);
+  room.rollDice(socket, [2]);
 
   const warnings = emitted.filter(e => e.event === 'cheatWarning');
   assert.ok(warnings.length >= 3, 'should emit cheat warnings');
@@ -189,7 +198,7 @@ test('landing on another player sends them to start', () => {
   room.players[1].position = 3;
   room.currentTurn = 0;
 
-  room.rollDice(s1, [1, 1]); // land on player 2
+  room.rollDice(s1, [2]); // land on player 2
 
   assert.equal(room.players[0].position, 3);
   assert.equal(room.players[1].position, 0);

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -2751,7 +2751,7 @@ export default function SnakeAndLadder() {
             setDiceCount(1);
           }, 2000);
         }
-        let extraTurn = false;
+        let extraTurn = rolledSix;
         if (diceCells[finalPos]) {
           const bonus = diceCells[finalPos];
           setDiceCells((d) => {
@@ -2769,6 +2769,9 @@ export default function SnakeAndLadder() {
           }
           setTimeout(() => setRewardDice(0), 1000);
           enqueueSnakeCommentaryEvent('bonus', { player: playerLabel });
+        } else if (rolledSix) {
+          setTurnMessage('Rolled 6 — roll again');
+          setBonusDice(0);
         } else {
           setTurnMessage("Your turn");
           setBonusDice(0);
@@ -2956,7 +2959,7 @@ export default function SnakeAndLadder() {
         setMoving(false);
         return;
       }
-      let extraTurn = false;
+      let extraTurn = rolledSix;
       if (diceCells[finalPos]) {
         const bonus = diceCells[finalPos];
         setDiceCells((d) => {
@@ -2974,6 +2977,9 @@ export default function SnakeAndLadder() {
         }
         setTimeout(() => setRewardDice(0), 1000);
         enqueueSnakeCommentaryEvent('bonus', { player: playerLabel });
+      }
+      if (rolledSix && !extraTurn) {
+        setTurnMessage(`${playerName(index)} rolled 6 — bonus turn`);
       }
       const next = extraTurn ? index : getPreviousTurn(index);
       if (next === 0) setTurnMessage('Your turn');
@@ -4072,7 +4078,7 @@ export default function SnakeAndLadder() {
         <button
           type="button"
           onClick={handleRollButtonClick}
-          className="fixed z-30 pointer-events-auto rounded-full"
+          className="fixed z-30 pointer-events-auto rounded-full flex items-center justify-center"
           style={{
             left: `${diceAnchor.x}%`,
             top: `${diceAnchor.y}%`,
@@ -4084,7 +4090,16 @@ export default function SnakeAndLadder() {
             boxShadow: '0 0 18px rgba(250,204,21,0.24)'
           }}
           aria-label="Roll dice"
-        />
+        >
+          <span
+            className="text-3xl"
+            role="img"
+            aria-hidden="true"
+            style={{ filter: 'drop-shadow(0 0 6px rgba(250,204,21,0.55))' }}
+          >
+            🎲
+          </span>
+        </button>
       ) : null}
       {!watchOnly && (
         <div className="pointer-events-auto">


### PR DESCRIPTION
### Motivation
- Make the Snake & Ladder turn rules match the requested gameplay: a single die per roll and an immediate extra roll when a 6 is thrown, while keeping existing bonus-tile extra rolls.

### Description
- Change server-side game logic to use one die per roll and treat rolling a `6` as an automatic extra turn by updating `bot/logic/snakeGame.js` (player `diceCount` default -> `1`, roll logic uses one die and sets `extraTurn` when a six is rolled).
- Initialize players with a single die on room start by updating `bot/gameEngine.js` (set `p.diceCount = 1` on `startGame`).
- Update front-end turn flow and messages in `webapp/src/pages/Games/SnakeAndLadder.jsx` so both human and AI flows honor `6` → extra turn, provide clear turn text (`Rolled 6 — roll again` / `rolled 6 — bonus turn`) and keep bonus-tile behavior compatible.
- Add a visible on-board roll hotspot icon (`🎲`) so human players have a clear re-roll affordance when it is their turn or they receive an extra roll.
- Update unit tests in `test/snakeGame.test.js` to reflect single-die behavior and extra-turn-on-6 semantics.

### Testing
- Ran the game unit tests with `node --test test/snakeGame.test.js`; all assertions passed (10 tests) though the test run logged a Mongo `GameResult` persistence buffering timeout in this environment which did not affect test assertions.
- Updated tests exercised start behavior, multiple sixes extra-turn chains, capture/reset, dice cell bonus consumption, anti-cheat timing, and final-tile win behavior and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8c3e4dae883299da820aa1b8323b8)