### PR TITLE
Snake & Ladder: use one die per turn, make 6 grant extra turns, remove dice-cell extra-turns, UI/audio fixes

### DIFF
--- a/bot/gameEngine.js
+++ b/bot/gameEngine.js
@@ -217,7 +217,7 @@ export class GameRoom {
     if (this.gameType === 'snake') {
       this.players.forEach((p) => {
         p.position = 0;
-        p.diceCount = 2;
+        p.diceCount = 1;
         p.isActive = false;
       });
     }

--- a/bot/logic/snakeGame.js
+++ b/bot/logic/snakeGame.js
@@ -22,7 +22,7 @@ export class SnakeGame {
       id,
       name,
       position: 0,
-      diceCount: 2,
+      diceCount: 1,
       isActive: false,
     });
   }
@@ -40,7 +40,7 @@ export class SnakeGame {
     const player = this.players[this.currentTurn];
     if (!player) return null;
 
-    const diceToRoll = Math.max(1, player.diceCount || 2);
+    const diceToRoll = Math.max(1, player.diceCount || 1);
     const rand = () => Math.floor(Math.random() * 6) + 1;
     const provided = Array.isArray(diceValues)
       ? diceValues
@@ -57,7 +57,7 @@ export class SnakeGame {
     const total = dice.reduce((a, b) => a + b, 0);
     const rolledSix = dice.includes(6);
     let target = player.position;
-    let extraTurn = false;
+    let extraTurn = rolledSix;
 
     if (player.position === 0) {
       if (rolledSix) {
@@ -82,7 +82,7 @@ export class SnakeGame {
     for (const p of this.players) {
       if (p !== player && p.position === player.position && p.position > 0) {
         p.position = 0;
-        p.diceCount = 2;
+        p.diceCount = 1;
         p.isActive = false;
       }
     }
@@ -94,7 +94,6 @@ export class SnakeGame {
       bonusCell = player.position;
       player.bonus = bonus;
       delete this.diceCells[player.position];
-      extraTurn = true;
     }
 
     if (player.position === FINAL_TILE) {

--- a/test/snakeGame.test.js
+++ b/test/snakeGame.test.js
@@ -30,7 +30,7 @@ test('applySnakesAndLadders resolves moves', () => {
   assert.equal(room.applySnakesAndLadders(8), 8); // none
 });
 
-test('start requires 6 and turn passes after a 6 roll', () => {
+test('start requires 6 and rolling 6 grants another turn', () => {
   const io = new DummyIO();
   const room = new GameRoom('r', io, 2, {
     snakes: DEFAULT_SNAKES,
@@ -43,20 +43,28 @@ test('start requires 6 and turn passes after a 6 roll', () => {
   room.addPlayer('p2', 'Player2', s2);
   room.startGame();
 
-  room.rollDice(s1, [2, 4]);
+  room.rollDice(s1, [2]);
   assert.equal(room.players[0].position, 0);
   assert.equal(room.currentTurn, 1);
 
-  room.rollDice(s2, [6, 2]);
+  room.rollDice(s2, [6]);
   assert.equal(room.players[1].position, 1);
+  assert.equal(room.currentTurn, 1);
+
+  room.rollDice(s2, [1]);
+  assert.equal(room.players[1].position, 2);
   assert.equal(room.currentTurn, 0);
 
-  room.rollDice(s1, [6, 1]);
+  room.rollDice(s1, [6]);
   assert.equal(room.players[0].position, 1);
+  assert.equal(room.currentTurn, 0);
+
+  room.rollDice(s1, [1]);
+  assert.equal(room.players[0].position, 2);
   assert.equal(room.currentTurn, 1);
 });
 
-test('rolling multiple sixes advances while respecting turn order', () => {
+test('rolling multiple sixes advances with repeated bonus turns', () => {
   const io = new DummyIO();
   const room = new GameRoom('r1', io, 1, {
     snakes: DEFAULT_SNAKES,
@@ -67,10 +75,11 @@ test('rolling multiple sixes advances while respecting turn order', () => {
   room.addPlayer('p1', 'Player', socket);
   room.startGame();
 
-  room.rollDice(socket, [6, 6]); // start -> tile 1
-  room.rollDice(socket, [6, 6]); // tile 13
-  room.rollDice(socket, [6, 6]); // tile 25
-  assert.equal(room.players[0].position, 25);
+  room.rollDice(socket, [6]); // start -> tile 1, extra turn
+  room.rollDice(socket, [6]); // tile 7, extra turn
+  room.rollDice(socket, [6]); // tile 13, extra turn
+  room.rollDice(socket, [1]); // tile 14
+  assert.equal(room.players[0].position, 14);
 });
 
 test('room starts when reaching custom capacity', async () => {
@@ -121,7 +130,7 @@ test('player wins when landing on the final tile', () => {
 
   room.players[0].position = FINAL_TILE - 3;
   room.players[0].isActive = true;
-  room.rollDice(socket, [1, 2]);
+  room.rollDice(socket, [3]);
 
   assert.equal(room.players[0].position, FINAL_TILE);
   assert.equal(room.status, 'finished');
@@ -140,10 +149,10 @@ test('rolling too quickly triggers anti-cheat', () => {
   room.addPlayer('p1', 'Cheater', socket);
   room.startGame();
 
-  room.rollDice(socket, [6, 2]); // first roll activates token
+  room.rollDice(socket, [6]); // first roll activates token
   const pos = room.players[0].position;
   room.rollCooldown = 1000;
-  room.rollDice(socket, [3, 2]); // second roll immediately should be rejected
+  room.rollDice(socket, [3]); // second roll immediately should be rejected
 
   assert.equal(room.players[0].position, pos);
   const err = emitted.find(e => e.event === 'error');
@@ -159,11 +168,11 @@ test('repeated cheating results in removal', () => {
   room.startGame();
 
   room.rollCooldown = 1000;
-  room.rollDice(socket, [6, 2]); // valid roll
+  room.rollDice(socket, [6]); // valid roll
   // Three rapid rolls to trigger warnings
-  room.rollDice(socket, [2, 2]);
-  room.rollDice(socket, [2, 2]);
-  room.rollDice(socket, [2, 2]);
+  room.rollDice(socket, [2]);
+  room.rollDice(socket, [2]);
+  room.rollDice(socket, [2]);
 
   const warnings = emitted.filter(e => e.event === 'cheatWarning');
   assert.ok(warnings.length >= 3, 'should emit cheat warnings');
@@ -189,7 +198,7 @@ test('landing on another player sends them to start', () => {
   room.players[1].position = 3;
   room.currentTurn = 0;
 
-  room.rollDice(s1, [1, 1]); // land on player 2
+  room.rollDice(s1, [2]); // land on player 2
 
   assert.equal(room.players[0].position, 3);
   assert.equal(room.players[1].position, 0);
@@ -226,4 +235,28 @@ test('dice cells are shared across players', () => {
     clearTimeout(room.turnTimer);
     room.turnTimer = null;
   }
+});
+
+test('dice cell reward does not grant an extra turn', () => {
+  const io = new DummyIO();
+  const room = new GameRoom('dice-no-extra', io, 2, {
+    snakes: {},
+    ladders: {},
+    diceCells: { 5: 2 }
+  });
+  room.rollCooldown = 0;
+  const s1 = { id: 's1', join: () => {}, emit: () => {} };
+  const s2 = { id: 's2', join: () => {}, emit: () => {} };
+  room.addPlayer('p1', 'A', s1);
+  room.addPlayer('p2', 'B', s2);
+  room.startGame();
+
+  room.players[0].position = 4;
+  room.players[0].isActive = true;
+  room.currentTurn = 0;
+
+  room.rollDice(s1, [1]);
+
+  assert.equal(room.players[0].position, 5);
+  assert.equal(room.currentTurn, 1);
 });

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -89,7 +89,6 @@ import GiftPopup from "../../components/GiftPopup.jsx";
 import { giftSounds } from "../../utils/giftSounds.js";
 import { moveSeq, flashHighlight, applyEffect as applyEffectHelper } from "../../utils/moveHelpers.js";
 import { getSnakeInventory, isSnakeOptionUnlocked, snakeAccountId } from "../../utils/snakeInventory.js";
-import { createDiceRollAudio } from "../../utils/diceAudio.js";
 import {
   buildSnakeCommentaryLine,
   createSnakeMatchCommentaryScript,
@@ -1163,7 +1162,7 @@ export default function SnakeAndLadder() {
   const [, setDiceVisible] = useState(true);
   const [photoUrl, setPhotoUrl] = useState(loadAvatar() || '');
   const [myName, setMyName] = useState('You');
-  const [pot, setPot] = useState(101);
+  const [pot, setPot] = useState(0);
   const [token, setToken] = useState("TPC");
   const [celebrate, setCelebrate] = useState(false);
   const [leftWinner, setLeftWinner] = useState(null);
@@ -1783,20 +1782,12 @@ export default function SnakeAndLadder() {
   const badLuckSoundRef = useRef(null);
   const cheerSoundRef = useRef(null);
   const timerSoundRef = useRef(null);
-  const diceRollSoundRef = useRef(null);
   const timerRef = useRef(null);
   const aiRollTimeoutRef = useRef(null);
   const reloadingRef = useRef(false);
   const turnEndRef = useRef(Date.now() + TURN_TIME * 1000);
   const aiRollTimeRef = useRef(null);
   const prevTimeLeftRef = useRef(TURN_TIME);
-
-  const playDiceRollSound = useCallback(() => {
-    if (muted || !diceRollSoundRef.current) return;
-    diceRollSoundRef.current.volume = 1;
-    diceRollSoundRef.current.currentTime = 0;
-    diceRollSoundRef.current.play().catch(() => {});
-  }, [muted]);
 
   const getPreviousTurn = useCallback(
     (turn) => {
@@ -1848,8 +1839,6 @@ export default function SnakeAndLadder() {
     cheerSoundRef.current.volume = vol;
     timerSoundRef.current = new Audio(SNAKE_SFX.timer);
     timerSoundRef.current.volume = vol;
-    diceRollSoundRef.current = createDiceRollAudio({ muted });
-    if (diceRollSoundRef.current) diceRollSoundRef.current.volume = 1;
     return () => {
       moveSoundRef.current?.pause();
       snakeSoundRef.current?.pause();
@@ -1863,7 +1852,6 @@ export default function SnakeAndLadder() {
       badLuckSoundRef.current?.pause();
       cheerSoundRef.current?.pause();
       timerSoundRef.current?.pause();
-      diceRollSoundRef.current?.pause();
     };
   }, [accountId, muted]);
 
@@ -1881,7 +1869,6 @@ export default function SnakeAndLadder() {
       badLuckSoundRef,
       cheerSoundRef,
       timerSoundRef,
-      diceRollSoundRef,
     ].forEach((r) => {
       if (r.current) r.current.muted = muted;
     });
@@ -2187,7 +2174,7 @@ export default function SnakeAndLadder() {
       if (Number.isInteger(parsedSeatIndex)) {
         idx = parsedSeatIndex;
       } else {
-        idx = playersRef.current.findIndex((pl) => pl.id === playerId);
+        idx = playersRef.current.findIndex((pl) => String(pl.id) === String(playerId));
 
         // Some servers emit the active seat index instead of a playerId.
         if (idx === -1 && Number.isInteger(parsedPlayerIndex)) {
@@ -2198,7 +2185,7 @@ export default function SnakeAndLadder() {
       if (idx >= 0) {
         setCurrentTurn(idx);
         setDiceCount(playerDiceCounts[idx] ?? 1);
-        const turnBelongsToMe = playersRef.current[idx]?.id === myAccountId;
+        const turnBelongsToMe = String(playersRef.current[idx]?.id) === String(myAccountId);
         if (turnBelongsToMe) {
           // Keep roll CTA visible for immediate extra turns.
           setRollCooldown(0);
@@ -2219,14 +2206,15 @@ export default function SnakeAndLadder() {
     const onRolled = ({ value, playerId, seatIndex }) => {
       setRollResult(value);
       setTimeout(() => setRollResult(null), 2000);
-      playDiceRollSound();
       const parsedSeatIndex =
         typeof seatIndex === 'string' ? Number.parseInt(seatIndex, 10) : seatIndex;
       const turnSeat =
         Number.isInteger(parsedSeatIndex)
           ? parsedSeatIndex
-          : playersRef.current.findIndex((pl) => pl.id === playerId);
-      const isMyRoll = turnSeat >= 0 ? playersRef.current[turnSeat]?.id === myAccountId : playerId === myAccountId;
+          : playersRef.current.findIndex((pl) => String(pl.id) === String(playerId));
+      const isMyRoll = turnSeat >= 0
+        ? String(playersRef.current[turnSeat]?.id) === String(myAccountId)
+        : String(playerId) === String(myAccountId);
       if (isMyRoll) setPendingExtraRoll(false);
     };
     const onWon = ({ playerId }) => {
@@ -2588,7 +2576,6 @@ export default function SnakeAndLadder() {
     const willCapture = aiPositions.some((p) => p === preview);
 
     setRollResult(value);
-    playDiceRollSound();
     if (willCapture && preview > 4 && !muted) {
       hahaSoundRef.current.currentTime = 0;
       hahaSoundRef.current.play().catch(() => {});
@@ -2751,7 +2738,7 @@ export default function SnakeAndLadder() {
             setDiceCount(1);
           }, 2000);
         }
-        let extraTurn = false;
+        let extraTurn = rolledSix;
         if (diceCells[finalPos]) {
           const bonus = diceCells[finalPos];
           setDiceCells((d) => {
@@ -2762,13 +2749,15 @@ export default function SnakeAndLadder() {
           setBonusDice(bonus);
           setRewardDice(bonus);
           setTurnMessage('Bonus roll');
-          extraTurn = true;
           if (!muted) {
             diceRewardSoundRef.current?.play().catch(() => {});
             yabbaSoundRef.current?.play().catch(() => {});
           }
           setTimeout(() => setRewardDice(0), 1000);
           enqueueSnakeCommentaryEvent('bonus', { player: playerLabel });
+        } else if (rolledSix) {
+          setTurnMessage('Rolled 6 — roll again');
+          setBonusDice(0);
         } else {
           setTurnMessage("Your turn");
           setBonusDice(0);
@@ -2835,7 +2824,6 @@ export default function SnakeAndLadder() {
 
     setTurnMessage(<>{playerName(index)} rolled {value}</>);
     setRollResult(value);
-    playDiceRollSound();
     if (capture && preview > 4 && !muted) {
       hahaSoundRef.current.currentTime = 0;
       hahaSoundRef.current.play().catch(() => {});
@@ -2956,7 +2944,7 @@ export default function SnakeAndLadder() {
         setMoving(false);
         return;
       }
-      let extraTurn = false;
+      let extraTurn = rolledSix;
       if (diceCells[finalPos]) {
         const bonus = diceCells[finalPos];
         setDiceCells((d) => {
@@ -2967,13 +2955,15 @@ export default function SnakeAndLadder() {
         setBonusDice(bonus);
         setRewardDice(bonus);
         setTurnMessage('Bonus roll');
-        extraTurn = true;
         if (!muted) {
           diceRewardSoundRef.current?.play().catch(() => {});
           yabbaSoundRef.current?.play().catch(() => {});
         }
         setTimeout(() => setRewardDice(0), 1000);
         enqueueSnakeCommentaryEvent('bonus', { player: playerLabel });
+      }
+      if (rolledSix && !diceCells[finalPos]) {
+        setTurnMessage(`${playerName(index)} rolled 6 — bonus turn`);
       }
       const next = extraTurn ? index : getPreviousTurn(index);
       if (next === 0) setTurnMessage('Your turn');
@@ -4072,7 +4062,7 @@ export default function SnakeAndLadder() {
         <button
           type="button"
           onClick={handleRollButtonClick}
-          className="fixed z-30 pointer-events-auto rounded-full"
+          className="fixed z-30 pointer-events-auto rounded-full flex items-center justify-center"
           style={{
             left: `${diceAnchor.x}%`,
             top: `${diceAnchor.y}%`,
@@ -4084,7 +4074,16 @@ export default function SnakeAndLadder() {
             boxShadow: '0 0 18px rgba(250,204,21,0.24)'
           }}
           aria-label="Roll dice"
-        />
+        >
+          <span
+            className="text-3xl"
+            role="img"
+            aria-hidden="true"
+            style={{ filter: 'drop-shadow(0 0 6px rgba(250,204,21,0.55))' }}
+          >
+            🎲
+          </span>
+        </button>
       ) : null}
       {!watchOnly && (
         <div className="pointer-events-auto">


### PR DESCRIPTION
### Motivation

- Align game rules so players roll a single die by default and only rolling a 6 grants an extra turn.
- Ensure dice-cell rewards give extra dice but do not automatically grant an immediate extra turn.
- Simplify client behavior around dice audio and make ID comparisons robust across types.
- Update tests to reflect the changed rules and prevent regressions.

### Description

- Server: changed default `diceCount` from `2` to `1` in `bot/gameEngine.js` and `bot/logic/snakeGame.js` and ensured captured players are reset to `diceCount = 1`.
- Game logic: made `diceToRoll` fallback to `1`, compute `extraTurn` based on whether a 6 was rolled (`rolledSix`) and stopped awarding an extra turn when landing on a `diceCells` reward.
- Tests: updated `test/snakeGame.test.js` expectations to use single-die rolls, adjusted scenarios for repeated sixes, and added a new test `dice cell reward does not grant an extra turn`.
- Client: removed dice-roll audio references and `createDiceRollAudio` usage, defaulted `pot` to `0`, made player/account ID comparisons robust by coercing to `String`, updated turn/roll UI messaging and adjusted the roll button markup to include a visible emoji and centered layout.

### Testing

- Ran unit tests via `npm test` and the updated test suite completed successfully.
- `test/snakeGame.test.js` was updated and all its cases (including the new dice-cell/no-extra-turn test) passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8c3e4dae883299da820aa1b8323b8)