### PR TITLE
Align Chess Battle Royal missile FX with Ludo battle royale behavior

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -8109,25 +8109,25 @@ function Chess3D({
     };
     const createFxMissile = () => {
       const root = new THREE.Group();
-      addFxCylinder(root, 0.07, 0.08, 1.02, [0, 0, 0], [0, 0, Math.PI / 2], '#bfc5ca', 16, 0.42, 0.12);
+      addFxCylinder(root, 0.09, 0.1, 1.18, [0, 0, 0], [0, 0, Math.PI / 2], '#bfc5ca', 16, 0.42, 0.12);
       const nose = new THREE.Mesh(
-        new THREE.ConeGeometry(0.08, 0.24, 16),
+        new THREE.ConeGeometry(0.1, 0.28, 16),
         new THREE.MeshStandardMaterial({ color: '#eef1f4', roughness: 0.28, metalness: 0.12 })
       );
-      nose.position.set(0.63, 0, 0);
+      nose.position.set(0.74, 0, 0);
       nose.rotation.z = -Math.PI / 2;
       root.add(nose);
-      addFxBox(root, [0.14, 0.02, 0.28], [-0.15, 0, 0], '#7d858b', 0.58, 0.12);
-      addFxBox(root, [0.14, 0.28, 0.02], [-0.15, 0, 0], '#7d858b', 0.58, 0.12);
-      addFxBox(root, [0.1, 0.02, 0.18], [-0.36, 0, 0], '#727a80', 0.58, 0.12);
-      addFxBox(root, [0.1, 0.18, 0.02], [-0.36, 0, 0], '#727a80', 0.58, 0.12);
+      addFxBox(root, [0.17, 0.025, 0.34], [-0.19, 0, 0], '#7d858b', 0.58, 0.12);
+      addFxBox(root, [0.17, 0.34, 0.025], [-0.19, 0, 0], '#7d858b', 0.58, 0.12);
+      addFxBox(root, [0.12, 0.024, 0.22], [-0.44, 0, 0], '#727a80', 0.58, 0.12);
+      addFxBox(root, [0.12, 0.22, 0.024], [-0.44, 0, 0], '#727a80', 0.58, 0.12);
       const trail = [];
       for (let i = 0; i < 5; i += 1) {
         trail.push(
           addFxSphere(
             root,
-            0.1 + i * 0.025,
-            [-0.7 - i * 0.16, 0, 0],
+            0.12 + i * 0.03,
+            [-0.84 - i * 0.19, 0, 0],
             i < 2 ? '#f6af4b' : '#8f989d',
             i < 2 ? 0.2 : 1,
             0,
@@ -8141,15 +8141,16 @@ function Chess3D({
     const createFxExplosion = (position) => {
       const root = new THREE.Group();
       root.position.copy(position);
-      const flash = addFxSphere(root, 0.18, [0, 0.25, 0], '#ffe59a', 0.08, 0, true, 1);
+      const flash = addFxSphere(root, 0.24, [0, 0.25, 0], '#ffe59a', 0.08, 0, true, 1);
       const fire = [];
       const smoke = [];
       for (let i = 0; i < 4; i += 1) {
-        fire.push(addFxSphere(root, 0.18 + i * 0.05, [0, 0.22 + i * 0.06, 0], i % 2 === 0 ? '#ff9c2f' : '#ff5b2d', 0.2, 0, true, 0.95 - i * 0.15));
+        fire.push(addFxSphere(root, 0.24 + i * 0.065, [0, 0.22 + i * 0.06, 0], i % 2 === 0 ? '#ff9c2f' : '#ff5b2d', 0.2, 0, true, 0.95 - i * 0.15));
       }
       for (let i = 0; i < 6; i += 1) {
-        smoke.push(addFxSphere(root, 0.18 + i * 0.035, [0, 0.18 + i * 0.08, 0], '#646b72', 1, 0, true, 0.42 - i * 0.04));
+        smoke.push(addFxSphere(root, 0.22 + i * 0.045, [0, 0.18 + i * 0.08, 0], '#646b72', 1, 0, true, 0.42 - i * 0.04));
       }
+      root.scale.setScalar(0.46);
       return { root, flash, fire, smoke };
     };
     const getReferenceBishopSize = (attackerMesh, isWhiteSide) => {
@@ -8277,6 +8278,8 @@ function Chess3D({
           to: impactAnchor,
           missileFx,
           bishopHeight,
+          attackerMesh,
+          targetMesh,
           explosionTriggered: false,
           travelDuration: missileTravelDuration,
           explosionDuration
@@ -9908,12 +9911,16 @@ function Chess3D({
               activeCaptureFx.splice(i, 1);
             }
           } else if (fx.type === 'royaleMissile') {
-            const boardCenter = new THREE.Vector3(0, fx.from.y, 0);
+            const liveFrom = getLivePieceWorldPosition(fx.attackerMesh, fx.from);
+            const liveTarget = getLivePieceWorldPosition(fx.targetMesh, fx.to);
+            const dynamicFrom = liveFrom.clone().add(new THREE.Vector3(0, fx.bishopHeight * 0.54, 0));
+            const dynamicTo = liveTarget.clone().add(new THREE.Vector3(0, 0.06, 0));
+            const boardCenter = new THREE.Vector3(0, dynamicFrom.y, 0);
             const boardRadius = (BOARD.N * BOARD.tile) / 2;
-            const startRadius = Math.max(fx.from.clone().setY(0).length(), boardRadius * 0.92);
-            const endRadius = Math.max(fx.to.clone().setY(0).length(), boardRadius * 0.92);
-            const startAngle = Math.atan2(fx.from.z, fx.from.x);
-            const endAngle = Math.atan2(fx.to.z, fx.to.x);
+            const startRadius = Math.max(dynamicFrom.clone().setY(0).length(), boardRadius * 0.92);
+            const endRadius = Math.max(dynamicTo.clone().setY(0).length(), boardRadius * 0.92);
+            const startAngle = Math.atan2(dynamicFrom.z, dynamicFrom.x);
+            const endAngle = Math.atan2(dynamicTo.z, dynamicTo.x);
             const finalDelta = ((endAngle - startAngle + Math.PI * 3) % (Math.PI * 2)) - Math.PI;
             const fullOrbitAngle = startAngle + Math.PI * 2 + finalDelta;
             if (fx.t <= fx.travelDuration) {
@@ -9926,12 +9933,13 @@ function Chess3D({
                 const orbitLift = fx.bishopHeight * (0.22 + Math.sin(Math.PI * orbitU) * 0.2);
                 return new THREE.Vector3(
                   boardCenter.x + Math.cos(angle) * radius,
-                  fx.from.y + orbitLift,
+                  dynamicFrom.y + orbitLift,
                   boardCenter.z + Math.sin(angle) * radius
                 );
               };
               const missilePos = orbitPointAt(easedTravel);
               const missileNext = orbitPointAt(nextTravel);
+              const right = captureDir.copy(missileNext).sub(missilePos).normalize().cross(WORLD_UP).normalize();
               fx.missileFx.root.visible = true;
               fx.missileFx.root.position.copy(missilePos);
               captureDir.copy(missileNext).sub(missilePos).normalize();
@@ -9940,7 +9948,7 @@ function Chess3D({
                 puff.position.set(
                   -0.55 - idx * 0.16,
                   Math.sin(fx.t * 20 + idx) * 0.02,
-                  Math.sin(fx.t * 12 + idx * 0.4) * 0.01
+                  Math.sin(fx.t * 12 + idx * 0.4) * 0.01 + right.z * 0.005
                 );
                 const s = 0.85 + idx * 0.16 + ((fx.t * 1.8 + idx * 0.18) % 1) * 0.6;
                 puff.scale.setScalar(s);
@@ -9953,7 +9961,11 @@ function Chess3D({
               fx.missileFx.root.visible = false;
               if (!fx.explosionTriggered) {
                 fx.explosionTriggered = true;
-                launchExplosion(fx.to, { scale: 0.46, duration: fx.explosionDuration, impactSoundMaxDurationMs: 320 });
+                launchExplosion(dynamicTo.clone().add(new THREE.Vector3(0, -0.05, 0)), {
+                  scale: 1,
+                  duration: fx.explosionDuration,
+                  impactSoundMaxDurationMs: 320
+                });
               }
             }
             if (u >= 1) {


### PR DESCRIPTION
### Motivation
- Make Chess Battle Royal capture FX visually and behaviorally identical to the Ludo Battle Royal implementation so missiles match size, trail, explosion, and orbital motion while still mapping launches and impacts to actual chess pieces.
- Ensure missiles track live piece positions so effects spawn from the correct attacker and explode at the correct target even if pieces are moving in the live scene.

### Description
- Updated procedural missile geometry (body radius/length, nose cone size/position, box/fins) and trail sphere sizes/offsets to match the Ludo missile proportions in `webapp/src/pages/Games/ChessBattleRoyal.jsx`.
- Enlarged explosion procedural geometry (flash/fire/smoke radii) and set base scale to match the Ludo-style footprint and visual intensity.
- Store `attackerMesh` and `targetMesh` on the `royaleMissile` FX object and changed the runtime pathing to sample live world positions with `getLivePieceWorldPosition` so launch/impact anchors follow the actual chess piece transforms during flight.
- Adjusted orbital trajectory math to use the dynamic launch/impact anchors, compute orientation with `setFromUnitVectors(FORWARD, captureDir)`, nudge explosion placement slightly toward the surface, and preserve existing audio/timing hooks.

### Testing
- Ran the project lint command `npm run lint -- webapp/src/pages/Games/ChessBattleRoyal.jsx` to validate the changed file, but the lint run reported a monorepo-wide failure and many pre-existing unrelated lint errors preventing a clean pass.
- Observed that the repository ESLint configuration currently ignores the target file in some runs, so automated linting of only this file is influenced by the monorepo lint scope and ignore settings.
- No other automated unit or integration tests were executed as part of this change in this environment due to the monorepo lint failures and current CI not being invoked.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8ce78dc1483298c943cd64dc4f130)