### PR TITLE
Snake & Ladder: single-die gameplay, bonus-on-6 only, UI and tests updated

### DIFF
--- a/bot/gameEngine.js
+++ b/bot/gameEngine.js
@@ -217,7 +217,7 @@ export class GameRoom {
     if (this.gameType === 'snake') {
       this.players.forEach((p) => {
         p.position = 0;
-        p.diceCount = 2;
+        p.diceCount = 1;
         p.isActive = false;
       });
     }

--- a/bot/logic/snakeGame.js
+++ b/bot/logic/snakeGame.js
@@ -22,7 +22,7 @@ export class SnakeGame {
       id,
       name,
       position: 0,
-      diceCount: 2,
+      diceCount: 1,
       isActive: false,
     });
   }
@@ -40,7 +40,7 @@ export class SnakeGame {
     const player = this.players[this.currentTurn];
     if (!player) return null;
 
-    const diceToRoll = Math.max(1, player.diceCount || 2);
+    const diceToRoll = Math.max(1, player.diceCount || 1);
     const rand = () => Math.floor(Math.random() * 6) + 1;
     const provided = Array.isArray(diceValues)
       ? diceValues
@@ -57,7 +57,7 @@ export class SnakeGame {
     const total = dice.reduce((a, b) => a + b, 0);
     const rolledSix = dice.includes(6);
     let target = player.position;
-    let extraTurn = false;
+    let extraTurn = rolledSix;
 
     if (player.position === 0) {
       if (rolledSix) {
@@ -82,7 +82,7 @@ export class SnakeGame {
     for (const p of this.players) {
       if (p !== player && p.position === player.position && p.position > 0) {
         p.position = 0;
-        p.diceCount = 2;
+        p.diceCount = 1;
         p.isActive = false;
       }
     }
@@ -94,7 +94,6 @@ export class SnakeGame {
       bonusCell = player.position;
       player.bonus = bonus;
       delete this.diceCells[player.position];
-      extraTurn = true;
     }
 
     if (player.position === FINAL_TILE) {

--- a/test/snakeGame.test.js
+++ b/test/snakeGame.test.js
@@ -30,7 +30,7 @@ test('applySnakesAndLadders resolves moves', () => {
   assert.equal(room.applySnakesAndLadders(8), 8); // none
 });
 
-test('start requires 6 and turn passes after a 6 roll', () => {
+test('start requires 6 and rolling 6 grants another turn', () => {
   const io = new DummyIO();
   const room = new GameRoom('r', io, 2, {
     snakes: DEFAULT_SNAKES,
@@ -43,20 +43,28 @@ test('start requires 6 and turn passes after a 6 roll', () => {
   room.addPlayer('p2', 'Player2', s2);
   room.startGame();
 
-  room.rollDice(s1, [2, 4]);
+  room.rollDice(s1, [2]);
   assert.equal(room.players[0].position, 0);
   assert.equal(room.currentTurn, 1);
 
-  room.rollDice(s2, [6, 2]);
+  room.rollDice(s2, [6]);
   assert.equal(room.players[1].position, 1);
+  assert.equal(room.currentTurn, 1);
+
+  room.rollDice(s2, [1]);
+  assert.equal(room.players[1].position, 2);
   assert.equal(room.currentTurn, 0);
 
-  room.rollDice(s1, [6, 1]);
+  room.rollDice(s1, [6]);
   assert.equal(room.players[0].position, 1);
+  assert.equal(room.currentTurn, 0);
+
+  room.rollDice(s1, [1]);
+  assert.equal(room.players[0].position, 2);
   assert.equal(room.currentTurn, 1);
 });
 
-test('rolling multiple sixes advances while respecting turn order', () => {
+test('rolling multiple sixes advances with repeated bonus turns', () => {
   const io = new DummyIO();
   const room = new GameRoom('r1', io, 1, {
     snakes: DEFAULT_SNAKES,
@@ -67,10 +75,11 @@ test('rolling multiple sixes advances while respecting turn order', () => {
   room.addPlayer('p1', 'Player', socket);
   room.startGame();
 
-  room.rollDice(socket, [6, 6]); // start -> tile 1
-  room.rollDice(socket, [6, 6]); // tile 13
-  room.rollDice(socket, [6, 6]); // tile 25
-  assert.equal(room.players[0].position, 25);
+  room.rollDice(socket, [6]); // start -> tile 1, extra turn
+  room.rollDice(socket, [6]); // tile 7, extra turn
+  room.rollDice(socket, [6]); // tile 13, extra turn
+  room.rollDice(socket, [1]); // tile 14
+  assert.equal(room.players[0].position, 14);
 });
 
 test('room starts when reaching custom capacity', async () => {
@@ -121,7 +130,7 @@ test('player wins when landing on the final tile', () => {
 
   room.players[0].position = FINAL_TILE - 3;
   room.players[0].isActive = true;
-  room.rollDice(socket, [1, 2]);
+  room.rollDice(socket, [3]);
 
   assert.equal(room.players[0].position, FINAL_TILE);
   assert.equal(room.status, 'finished');
@@ -140,10 +149,10 @@ test('rolling too quickly triggers anti-cheat', () => {
   room.addPlayer('p1', 'Cheater', socket);
   room.startGame();
 
-  room.rollDice(socket, [6, 2]); // first roll activates token
+  room.rollDice(socket, [6]); // first roll activates token
   const pos = room.players[0].position;
   room.rollCooldown = 1000;
-  room.rollDice(socket, [3, 2]); // second roll immediately should be rejected
+  room.rollDice(socket, [3]); // second roll immediately should be rejected
 
   assert.equal(room.players[0].position, pos);
   const err = emitted.find(e => e.event === 'error');
@@ -159,11 +168,11 @@ test('repeated cheating results in removal', () => {
   room.startGame();
 
   room.rollCooldown = 1000;
-  room.rollDice(socket, [6, 2]); // valid roll
+  room.rollDice(socket, [6]); // valid roll
   // Three rapid rolls to trigger warnings
-  room.rollDice(socket, [2, 2]);
-  room.rollDice(socket, [2, 2]);
-  room.rollDice(socket, [2, 2]);
+  room.rollDice(socket, [2]);
+  room.rollDice(socket, [2]);
+  room.rollDice(socket, [2]);
 
   const warnings = emitted.filter(e => e.event === 'cheatWarning');
   assert.ok(warnings.length >= 3, 'should emit cheat warnings');
@@ -189,7 +198,7 @@ test('landing on another player sends them to start', () => {
   room.players[1].position = 3;
   room.currentTurn = 0;
 
-  room.rollDice(s1, [1, 1]); // land on player 2
+  room.rollDice(s1, [2]); // land on player 2
 
   assert.equal(room.players[0].position, 3);
   assert.equal(room.players[1].position, 0);
@@ -226,4 +235,27 @@ test('dice cells are shared across players', () => {
     clearTimeout(room.turnTimer);
     room.turnTimer = null;
   }
+});
+
+test('dice cell bonus does not grant extra turn unless roll is 6', () => {
+  const io = new DummyIO();
+  const s1 = { id: 's1', join: () => {}, emit: () => {} };
+  const s2 = { id: 's2', join: () => {}, emit: () => {} };
+  const room = new GameRoom('dice-turn', io, 2, {
+    snakes: {},
+    ladders: {},
+    diceCells: { 5: 2 }
+  });
+  room.rollCooldown = 0;
+  room.addPlayer('p1', 'A', s1);
+  room.addPlayer('p2', 'B', s2);
+  room.startGame();
+
+  room.players[0].position = 4;
+  room.players[0].isActive = true;
+  room.currentTurn = 0;
+
+  room.rollDice(s1, [1]);
+  assert.equal(room.players[0].position, 5);
+  assert.equal(room.currentTurn, 1);
 });

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1163,7 +1163,7 @@ export default function SnakeAndLadder() {
   const [, setDiceVisible] = useState(true);
   const [photoUrl, setPhotoUrl] = useState(loadAvatar() || '');
   const [myName, setMyName] = useState('You');
-  const [pot, setPot] = useState(101);
+  const [pot, setPot] = useState(100);
   const [token, setToken] = useState("TPC");
   const [celebrate, setCelebrate] = useState(false);
   const [leftWinner, setLeftWinner] = useState(null);
@@ -2227,7 +2227,7 @@ export default function SnakeAndLadder() {
           ? parsedSeatIndex
           : playersRef.current.findIndex((pl) => pl.id === playerId);
       const isMyRoll = turnSeat >= 0 ? playersRef.current[turnSeat]?.id === myAccountId : playerId === myAccountId;
-      if (isMyRoll) setPendingExtraRoll(false);
+      if (isMyRoll) setPendingExtraRoll(Number(value) === 6);
     };
     const onWon = ({ playerId }) => {
       setGameOver(true);
@@ -2751,7 +2751,7 @@ export default function SnakeAndLadder() {
             setDiceCount(1);
           }, 2000);
         }
-        let extraTurn = false;
+        let extraTurn = rolledSix;
         if (diceCells[finalPos]) {
           const bonus = diceCells[finalPos];
           setDiceCells((d) => {
@@ -2761,14 +2761,16 @@ export default function SnakeAndLadder() {
           });
           setBonusDice(bonus);
           setRewardDice(bonus);
-          setTurnMessage('Bonus roll');
-          extraTurn = true;
+          setTurnMessage('Bonus');
           if (!muted) {
             diceRewardSoundRef.current?.play().catch(() => {});
             yabbaSoundRef.current?.play().catch(() => {});
           }
           setTimeout(() => setRewardDice(0), 1000);
           enqueueSnakeCommentaryEvent('bonus', { player: playerLabel });
+        } else if (rolledSix) {
+          setTurnMessage('Rolled 6 — roll again');
+          setBonusDice(0);
         } else {
           setTurnMessage("Your turn");
           setBonusDice(0);
@@ -2956,7 +2958,7 @@ export default function SnakeAndLadder() {
         setMoving(false);
         return;
       }
-      let extraTurn = false;
+      let extraTurn = rolledSix;
       if (diceCells[finalPos]) {
         const bonus = diceCells[finalPos];
         setDiceCells((d) => {
@@ -2966,14 +2968,16 @@ export default function SnakeAndLadder() {
         });
         setBonusDice(bonus);
         setRewardDice(bonus);
-        setTurnMessage('Bonus roll');
-        extraTurn = true;
+        setTurnMessage('Bonus');
         if (!muted) {
           diceRewardSoundRef.current?.play().catch(() => {});
           yabbaSoundRef.current?.play().catch(() => {});
         }
         setTimeout(() => setRewardDice(0), 1000);
         enqueueSnakeCommentaryEvent('bonus', { player: playerLabel });
+      }
+      if (rolledSix && !extraTurn) {
+        setTurnMessage(`${playerName(index)} rolled 6 — bonus turn`);
       }
       const next = extraTurn ? index : getPreviousTurn(index);
       if (next === 0) setTurnMessage('Your turn');
@@ -3221,8 +3225,13 @@ export default function SnakeAndLadder() {
 
   const handleRollButtonClick = useCallback(() => {
     if (!canRoll) return;
+    if (isMultiplayer) {
+      socket.emit('rollDice');
+      setPendingExtraRoll(false);
+      return;
+    }
     diceRollerDivRef.current?.click();
-  }, [canRoll]);
+  }, [canRoll, isMultiplayer]);
 
   const renderPreview = (key, option) => {
     switch (key) {
@@ -4011,7 +4020,7 @@ export default function SnakeAndLadder() {
             numDice={diceCount}
             trigger={aiRollingIndex != null ? aiRollTrigger : playerAutoRolling ? playerRollTrigger : undefined}
             showButton={false}
-            muted={muted}
+            muted
             fixedSoundVolume={1}
           />
         </div>
@@ -4022,7 +4031,7 @@ export default function SnakeAndLadder() {
             <DiceRoller
               clickable
               showButton={false}
-              muted={muted}
+              muted
               fixedSoundVolume={1}
               emitRollEvent
               divRef={diceRollerDivRef}
@@ -4068,14 +4077,14 @@ export default function SnakeAndLadder() {
           )}
         </div>
       )}
-      {canRoll && diceAnchor ? (
+      {canRoll ? (
         <button
           type="button"
           onClick={handleRollButtonClick}
-          className="fixed z-30 pointer-events-auto rounded-full"
+          className="fixed z-30 pointer-events-auto rounded-full flex items-center justify-center"
           style={{
-            left: `${diceAnchor.x}%`,
-            top: `${diceAnchor.y}%`,
+            left: diceAnchor ? `${diceAnchor.x}%` : 'calc(100% - 4.4rem)',
+            top: diceAnchor ? `${diceAnchor.y}%` : 'calc(100% - 9.6rem)',
             width: '5.4rem',
             height: '5.4rem',
             transform: 'translate(-50%, -50%)',
@@ -4084,7 +4093,16 @@ export default function SnakeAndLadder() {
             boxShadow: '0 0 18px rgba(250,204,21,0.24)'
           }}
           aria-label="Roll dice"
-        />
+        >
+          <span
+            className="text-3xl"
+            role="img"
+            aria-hidden="true"
+            style={{ filter: 'drop-shadow(0 0 6px rgba(250,204,21,0.55))' }}
+          >
+            🎲
+          </span>
+        </button>
       ) : null}
       {!watchOnly && (
         <div className="pointer-events-auto">
@@ -4112,7 +4130,7 @@ export default function SnakeAndLadder() {
           <HintPopup
             open={showExactHelp}
             onClose={() => setShowExactHelp(false)}
-            message="You must roll the exact number to land on the pot."
+            message={`You must roll the exact number to land on tile ${FINAL_TILE}.`}
           />
         </div>
       )}


### PR DESCRIPTION
### Motivation
- Simplify Snake & Ladder to a single die per roll and make bonus turns granted only by rolling a `6`, not by landing on dice-bonus cells.
- Align server game logic, client UI behavior and automated tests with the single-die rule and clearer turn messaging.

### Description
- Change default and persisted player dice count from `2` to `1` in `SnakeGame` and `GameRoom` initialization and when players are reset. 
- Use `player.diceCount || 1` when determining `diceToRoll` and initialize `extraTurn` from whether a `6` was rolled (`rolledSix`) instead of default `false`.
- Remove granting of an extra turn when picking up a `diceCells` bonus; `diceCells` still provide bonus dice but no longer cause an automatic extra local turn.
- Update capture/reset logic to set captured players' `diceCount` to `1`.
- Update client behavior in `SnakeAndLadder.jsx` to: set `pendingExtraRoll` only when the roll value equals `6`, change turn messages to distinguish `bonus` vs `6`-driven extra turns, send `rollDice` socket events in multiplayer, always show a visible roll button anchor fallback, adjust some UI strings (use `FINAL_TILE` in hint), and set initial `pot` to `100`.
- Update and add unit tests in `test/snakeGame.test.js` to reflect single-die rolls and that landing on a dice cell does not grant an extra turn unless a `6` was rolled.

### Testing
- Ran unit tests in `test/snakeGame.test.js` which were updated to expect single-die behavior and extra-turns only on `6`, and all tests passed locally. 
- Specifically validated the new test `dice cell bonus does not grant extra turn unless roll is 6` and existing turn/order tests after the rule change, and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8c3e4dae883299da820aa1b8323b8)