### PR TITLE
Restore Snake & Ladder logic/rules to 06:00 baseline

### DIFF
--- a/bot/logic/snakeGame.js
+++ b/bot/logic/snakeGame.js
@@ -1,4 +1,4 @@
-export const FINAL_TILE = 50;
+export const FINAL_TILE = 101;
 
 export function applySnakesAndLadders(pos, snakes, ladders) {
   if (snakes[pos] != null) return Math.max(0, snakes[pos]);
@@ -22,7 +22,7 @@ export class SnakeGame {
       id,
       name,
       position: 0,
-      diceCount: 1,
+      diceCount: 2,
       isActive: false,
     });
   }
@@ -40,7 +40,7 @@ export class SnakeGame {
     const player = this.players[this.currentTurn];
     if (!player) return null;
 
-    const diceToRoll = Math.max(1, player.diceCount || 1);
+    const diceToRoll = Math.max(1, player.diceCount || 2);
     const rand = () => Math.floor(Math.random() * 6) + 1;
     const provided = Array.isArray(diceValues)
       ? diceValues
@@ -56,13 +56,24 @@ export class SnakeGame {
 
     const total = dice.reduce((a, b) => a + b, 0);
     const rolledSix = dice.includes(6);
+    const doubleSix = dice.length >= 2 && dice[0] === 6 && dice[1] === 6;
+
     let target = player.position;
-    let extraTurn = rolledSix;
+    let extraTurn = false;
 
     if (player.position === 0) {
       if (rolledSix) {
         player.isActive = true;
         target = 1;
+      }
+    } else if (player.position === 100) {
+      if (player.diceCount === 2) {
+        if (rolledSix) {
+          player.diceCount = 1;
+          extraTurn = true;
+        }
+      } else if (total === 1) {
+        target = FINAL_TILE;
       }
     } else if (player.position < FINAL_TILE) {
       if (player.position + total <= FINAL_TILE) {
@@ -82,7 +93,7 @@ export class SnakeGame {
     for (const p of this.players) {
       if (p !== player && p.position === player.position && p.position > 0) {
         p.position = 0;
-        p.diceCount = 1;
+        p.diceCount = 2;
         p.isActive = false;
       }
     }
@@ -94,6 +105,9 @@ export class SnakeGame {
       bonusCell = player.position;
       player.bonus = bonus;
       delete this.diceCells[player.position];
+      extraTurn = true;
+    } else if (rolledSix) {
+      extraTurn = true;
     }
 
     if (player.position === FINAL_TILE) {

--- a/examples/snake-ladder/ReactClient.jsx
+++ b/examples/snake-ladder/ReactClient.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { io } from 'socket.io-client';
 
 const PYRAMID_ROW_LENGTHS = [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 15];
-const BOARD_SIZE = 50;
+const BOARD_SIZE = 100;
 
 function buildPyramidRows() {
   const rows = [];
@@ -63,7 +63,6 @@ export default function ReactClient({
   if (!state) return <div style={{ color: '#fff' }}>Loading...</div>;
 
   const current = state.players[state.currentPlayer]?.id;
-  const winnerName = state.players.find((player) => player.id === state.winner)?.name || state.winner;
 
   return (
     <div
@@ -110,7 +109,7 @@ export default function ReactClient({
           Roll Dice
         </button>
         {state.winner && (
-          <p style={{ margin: '12px 0 0' }}>Winner: {winnerName}</p>
+          <p style={{ margin: '12px 0 0' }}>Winner: {state.winner}</p>
         )}
       </div>
 

--- a/examples/snake-ladder/gameLogic.js
+++ b/examples/snake-ladder/gameLogic.js
@@ -1,9 +1,16 @@
-export const BOARD_SIZE = 50;
+export const BOARD_SIZE = 100;
 
 export const DEFAULT_SNAKES = {
   16: 6,
   48: 26,
-  49: 11
+  49: 11,
+  56: 53,
+  62: 19,
+  64: 60,
+  87: 24,
+  93: 73,
+  95: 75,
+  98: 78
 };
 
 export const DEFAULT_LADDERS = {
@@ -11,8 +18,11 @@ export const DEFAULT_LADDERS = {
   4: 14,
   9: 31,
   21: 42,
-  28: 47,
-  36: 44
+  28: 84,
+  36: 44,
+  51: 67,
+  71: 91,
+  80: 100
 };
 
 export class Game {
@@ -57,29 +67,15 @@ export class Game {
     if (this.winner) return;
     const current = this.players[this.currentPlayer];
     if (!current || current.id !== playerId) return;
-
     const value = Math.floor(Math.random() * 6) + 1;
     this.diceRoll = value;
-
     let newPos = current.position + value;
     if (newPos > BOARD_SIZE) newPos = current.position;
-
-    if (newPos === BOARD_SIZE) {
-      current.position = BOARD_SIZE;
-      this.winner = current.id;
-      return;
-    }
-
     newPos = this.snakes[newPos] || this.ladders[newPos] || newPos;
     current.position = newPos;
-
     if (newPos === BOARD_SIZE) {
       this.winner = current.id;
-      return;
-    }
-
-    const getsExtraRoll = value === 6;
-    if (!getsExtraRoll) {
+    } else {
       this.currentPlayer = (this.currentPlayer + 1) % this.players.length;
     }
   }

--- a/test/snakeGame.test.js
+++ b/test/snakeGame.test.js
@@ -26,11 +26,11 @@ test('applySnakesAndLadders resolves moves', () => {
   room.rollCooldown = 0;
   assert.equal(room.applySnakesAndLadders(3), 22); // ladder
   assert.equal(room.applySnakesAndLadders(27), 46); // ladder
-  assert.equal(room.applySnakesAndLadders(49), 35); // snake
+  assert.equal(room.applySnakesAndLadders(99), 80); // snake
   assert.equal(room.applySnakesAndLadders(8), 8); // none
 });
 
-test('start requires 6 and rolling 6 grants another turn', () => {
+test('start requires 6 and rolling 6 grants extra turn', () => {
   const io = new DummyIO();
   const room = new GameRoom('r', io, 2, {
     snakes: DEFAULT_SNAKES,
@@ -43,28 +43,23 @@ test('start requires 6 and rolling 6 grants another turn', () => {
   room.addPlayer('p2', 'Player2', s2);
   room.startGame();
 
-  room.rollDice(s1, [2]);
+  room.rollDice(s1, [2, 4]);
   assert.equal(room.players[0].position, 0);
   assert.equal(room.currentTurn, 1);
 
-  room.rollDice(s2, [6]);
+  room.rollDice(s2, [6, 2]);
   assert.equal(room.players[1].position, 1);
   assert.equal(room.currentTurn, 1);
 
-  room.rollDice(s2, [1]);
-  assert.equal(room.players[1].position, 2);
+  room.rollDice(s2, [1, 2]);
   assert.equal(room.currentTurn, 0);
 
-  room.rollDice(s1, [6]);
+  room.rollDice(s1, [6, 1]);
   assert.equal(room.players[0].position, 1);
   assert.equal(room.currentTurn, 0);
-
-  room.rollDice(s1, [1]);
-  assert.equal(room.players[0].position, 2);
-  assert.equal(room.currentTurn, 1);
 });
 
-test('rolling multiple sixes advances with repeated bonus turns', () => {
+test('rolling multiple sixes grants extra turns but preserves order', () => {
   const io = new DummyIO();
   const room = new GameRoom('r1', io, 1, {
     snakes: DEFAULT_SNAKES,
@@ -75,11 +70,10 @@ test('rolling multiple sixes advances with repeated bonus turns', () => {
   room.addPlayer('p1', 'Player', socket);
   room.startGame();
 
-  room.rollDice(socket, [6]); // start -> tile 1, extra turn
-  room.rollDice(socket, [6]); // tile 7, extra turn
-  room.rollDice(socket, [6]); // tile 13, extra turn
-  room.rollDice(socket, [1]); // tile 14
-  assert.equal(room.players[0].position, 14);
+  room.rollDice(socket, [6, 6]);
+  room.rollDice(socket, [6, 6]);
+  room.rollDice(socket, [6, 6]);
+  assert.equal(room.players[0].position, 25);
 });
 
 test('room starts when reaching custom capacity', async () => {
@@ -130,7 +124,7 @@ test('player wins when landing on the final tile', () => {
 
   room.players[0].position = FINAL_TILE - 3;
   room.players[0].isActive = true;
-  room.rollDice(socket, [3]);
+  room.rollDice(socket, [1, 2]);
 
   assert.equal(room.players[0].position, FINAL_TILE);
   assert.equal(room.status, 'finished');
@@ -149,10 +143,10 @@ test('rolling too quickly triggers anti-cheat', () => {
   room.addPlayer('p1', 'Cheater', socket);
   room.startGame();
 
-  room.rollDice(socket, [6]); // first roll activates token
+  room.rollDice(socket, [6, 2]); // first roll activates token
   const pos = room.players[0].position;
   room.rollCooldown = 1000;
-  room.rollDice(socket, [3]); // second roll immediately should be rejected
+  room.rollDice(socket, [3, 2]); // second roll immediately should be rejected
 
   assert.equal(room.players[0].position, pos);
   const err = emitted.find(e => e.event === 'error');
@@ -168,11 +162,11 @@ test('repeated cheating results in removal', () => {
   room.startGame();
 
   room.rollCooldown = 1000;
-  room.rollDice(socket, [6]); // valid roll
+  room.rollDice(socket, [6, 2]); // valid roll
   // Three rapid rolls to trigger warnings
-  room.rollDice(socket, [2]);
-  room.rollDice(socket, [2]);
-  room.rollDice(socket, [2]);
+  room.rollDice(socket, [2, 2]);
+  room.rollDice(socket, [2, 2]);
+  room.rollDice(socket, [2, 2]);
 
   const warnings = emitted.filter(e => e.event === 'cheatWarning');
   assert.ok(warnings.length >= 3, 'should emit cheat warnings');
@@ -198,7 +192,7 @@ test('landing on another player sends them to start', () => {
   room.players[1].position = 3;
   room.currentTurn = 0;
 
-  room.rollDice(s1, [2]); // land on player 2
+  room.rollDice(s1, [1, 1]); // land on player 2
 
   assert.equal(room.players[0].position, 3);
   assert.equal(room.players[1].position, 0);
@@ -235,27 +229,4 @@ test('dice cells are shared across players', () => {
     clearTimeout(room.turnTimer);
     room.turnTimer = null;
   }
-});
-
-test('dice cell bonus does not grant extra turn unless roll is 6', () => {
-  const io = new DummyIO();
-  const s1 = { id: 's1', join: () => {}, emit: () => {} };
-  const s2 = { id: 's2', join: () => {}, emit: () => {} };
-  const room = new GameRoom('dice-turn', io, 2, {
-    snakes: {},
-    ladders: {},
-    diceCells: { 5: 2 }
-  });
-  room.rollCooldown = 0;
-  room.addPlayer('p1', 'A', s1);
-  room.addPlayer('p2', 'B', s2);
-  room.startGame();
-
-  room.players[0].position = 4;
-  room.players[0].isActive = true;
-  room.currentTurn = 0;
-
-  room.rollDice(s1, [1]);
-  assert.equal(room.players[0].position, 5);
-  assert.equal(room.currentTurn, 1);
 });

--- a/webapp/src/components/SnakeBoard.jsx
+++ b/webapp/src/components/SnakeBoard.jsx
@@ -99,7 +99,7 @@ function buildPyramidLayout() {
 
 const BOARD_LAYOUT = buildPyramidLayout();
 export const BOARD_CELL_COUNT = BOARD_LAYOUT.totalCells;
-export const FINAL_TILE = BOARD_CELL_COUNT;
+export const FINAL_TILE = BOARD_CELL_COUNT + 1;
 const BOARD_WIDTH_UNITS = BOARD_LAYOUT.widthUnits;
 const BOARD_HEIGHT_UNITS = BOARD_LAYOUT.heightUnits;
 const CENTER_COLUMN = BOARD_LAYOUT.centerColumn;

--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -121,7 +121,7 @@ const DICE_PIP_RIM_OUTER = DICE_PIP_RADIUS * 1.08;
 const DICE_PIP_RIM_OFFSET = DICE_SIZE * 0.0048;
 const DICE_PIP_SPREAD = DICE_SIZE * 0.3;
 const DICE_FACE_INSET = DICE_SIZE * 0.064;
-const DICE_ROLL_DURATION = 1100;
+const DICE_ROLL_DURATION = 900;
 const DICE_SETTLE_DURATION = 320;
 const DICE_BOUNCE_HEIGHT = DICE_SIZE * 0.6;
 const DICE_THROW_LANDING_MARGIN = TILE_SIZE * 1.8;
@@ -178,11 +178,16 @@ const PYRAMID_PLATFORM_THICKNESS = TILE_SIZE * 0.48 * PYRAMID_HEIGHT_MULTIPLIER;
 const PYRAMID_LEVEL_GAP = TILE_SIZE * 0.12 * PYRAMID_HEIGHT_MULTIPLIER;
 
 const CAMERA_FOLLOW_MIN_TILE = Infinity;
+const CAMERA_FOLLOW_BACK_TILES = 5;
 
 const TURN_CAMERA_TURN_IN_DURATION = 620;
 const DICE_CAMERA_LOOK_IN_DURATION = 360;
-const DICE_CAMERA_LOOK_HOLD_DURATION = 1200;
+const DICE_CAMERA_LOOK_HOLD_DURATION = 900;
 const DICE_CAMERA_LOOK_OUT_DURATION = 420;
+const BOARD_AUTO_ROTATE_IN_DURATION = 520;
+const BOARD_AUTO_ROTATE_HOLD_DURATION = 0;
+const BOARD_AUTO_ROTATE_OUT_DURATION = 520;
+
 const BOARD_TILE_HEIGHT = TILE_SIZE * 0.14 * PYRAMID_HEIGHT_MULTIPLIER;
 const TILE_SIDE_COLOR = new THREE.Color(0x8b5e34);
 const TILE_BOTTOM_COLOR = new THREE.Color(0x3d2514);
@@ -259,15 +264,15 @@ const CAMERA_LOOK_YAW_LIMIT = THREE.MathUtils.degToRad(26);
 const CAMERA_LOOK_YAW_DRAG_FACTOR = 0.0055;
 const CAMERA_LOOK_PITCH_LIMIT = THREE.MathUtils.degToRad(16);
 const CAMERA_LOOK_PITCH_DRAG_FACTOR = -0.0038;
-const CAMERA_EXTRA_LIFT = 0.16;
-const INITIAL_CAMERA_DISTANCE_FACTOR = 0.29;
+const CAMERA_EXTRA_LIFT = 0.12;
+const INITIAL_CAMERA_DISTANCE_FACTOR = 0.35;
 const POINTER_TAP_MAX_DISTANCE = 14;
 const POINTER_TAP_MAX_DURATION_MS = 420;
 const PORTRAIT_CAMERA_TUNING = Object.freeze({
-  backOffset: 0.98,
+  backOffset: 1.06,
   forwardOffset: 0,
-  heightOffset: 2.66,
-  targetLift: 0.04 * MODEL_SCALE
+  heightOffset: 2.54,
+  targetLift: 0.055 * MODEL_SCALE
 });
 const LANDSCAPE_CAMERA_TUNING = Object.freeze({
   backOffset: 0.68,
@@ -275,7 +280,7 @@ const LANDSCAPE_CAMERA_TUNING = Object.freeze({
   heightOffset: 1.2,
   targetLift: 0.08 * MODEL_SCALE
 });
-const LOCK_BOTTOM_SEAT_CAMERA = false;
+const LOCK_BOTTOM_SEAT_CAMERA = true;
 const SHOW_BOARD_RAILS = false;
 const COIN_RAISE = TILE_SIZE * 0.24;
 const COIN_LOCAL_LIFT = TILE_SIZE * 0.05;
@@ -1607,6 +1612,62 @@ function shouldFollowTileChange(_fromIndex, toIndex) {
   return to >= CAMERA_FOLLOW_MIN_TILE;
 }
 
+function normalizeAngle(value) {
+  let angle = value;
+  while (angle <= -Math.PI) angle += Math.PI * 2;
+  while (angle > Math.PI) angle -= Math.PI * 2;
+  return angle;
+}
+
+function createBoardRotationAnimation(board, toRotationY, { onComplete } = {}) {
+  const rotationRoot = board?.rotationRoot;
+  if (!rotationRoot || !Number.isFinite(toRotationY)) return null;
+  const fromRotation = rotationRoot.rotation.y;
+  const targetRotation = fromRotation + normalizeAngle(toRotationY - fromRotation);
+  const start = performance.now();
+  const total = BOARD_AUTO_ROTATE_IN_DURATION + BOARD_AUTO_ROTATE_HOLD_DURATION + BOARD_AUTO_ROTATE_OUT_DURATION;
+
+  return {
+    type: 'boardAutoRotate',
+    update: (now) => {
+      const elapsed = now - start;
+      if (elapsed <= BOARD_AUTO_ROTATE_IN_DURATION) {
+        const t = easeInOut(Math.min(Math.max(elapsed / BOARD_AUTO_ROTATE_IN_DURATION, 0), 1));
+        rotationRoot.rotation.y = THREE.MathUtils.lerp(fromRotation, targetRotation, t);
+        return false;
+      }
+      if (elapsed <= BOARD_AUTO_ROTATE_IN_DURATION + BOARD_AUTO_ROTATE_HOLD_DURATION) {
+        rotationRoot.rotation.y = targetRotation;
+        return false;
+      }
+      if (elapsed <= total) {
+        const t = BOARD_AUTO_ROTATE_OUT_DURATION > 0
+          ? easeInOut(Math.min(Math.max((elapsed - BOARD_AUTO_ROTATE_IN_DURATION - BOARD_AUTO_ROTATE_HOLD_DURATION) / BOARD_AUTO_ROTATE_OUT_DURATION, 0), 1))
+          : 1;
+        rotationRoot.rotation.y = THREE.MathUtils.lerp(targetRotation, fromRotation, t);
+        return false;
+      }
+      rotationRoot.rotation.y = fromRotation;
+      if (typeof onComplete === 'function') onComplete();
+      return true;
+    }
+  };
+}
+
+function computeBoardFacingRotation(board, camera, tileIndex) {
+  if (!board || !camera || tileIndex == null) return null;
+  const tile = board.indexToPosition.get(tileIndex) || board.serpentineIndexToXZ(tileIndex);
+  const boardLookTarget = board.boardLookTarget;
+  if (!tile || !boardLookTarget) return null;
+  const localDir = tile.clone().setY(0);
+  if (localDir.lengthSq() < 1e-6) return null;
+  const cameraDir = camera.position.clone().sub(boardLookTarget).setY(0);
+  if (cameraDir.lengthSq() < 1e-6) return null;
+  const tileAngle = Math.atan2(localDir.x, localDir.z);
+  const cameraAngle = Math.atan2(cameraDir.x, cameraDir.z);
+  return normalizeAngle(cameraAngle - tileAngle);
+}
+
 function computeTurnCameraFocusState(board, camera, turnIndex, players = []) {
   if (!board || !camera) return null;
   if (LOCK_BOTTOM_SEAT_CAMERA) return null;
@@ -1633,6 +1694,13 @@ function computeTurnCameraFocusState(board, camera, turnIndex, players = []) {
   const direction = seatWorld.clone().sub(boardLookTarget).setY(0);
   if (direction.lengthSq() < 1e-6) return null;
   direction.normalize();
+  const isTopOrBottomSeat = Math.abs(direction.z) >= Math.abs(direction.x);
+  if (isTopOrBottomSeat) {
+    return {
+      position: camera.position.clone(),
+      target: boardLookTarget.clone()
+    };
+  }
   if (seatIndex === 1) target.x += CAMERA_SIDE_LOOK_EXTRA;
   if (seatIndex === 3) target.x -= CAMERA_SIDE_LOOK_EXTRA;
   const boardToCamera = camera.position.clone().sub(boardLookTarget).setY(0);
@@ -1648,7 +1716,7 @@ function computeTurnCameraFocusState(board, camera, turnIndex, players = []) {
   return { position, target };
 }
 
-function computeDiceCameraFocusState(board, camera, seatIndex = null) {
+function computeDiceCameraFocusState(board, camera) {
   if (!board || !camera) return null;
   if (LOCK_BOTTOM_SEAT_CAMERA) return null;
   const diceSet = Array.isArray(board.diceSet) ? board.diceSet.filter((die) => die?.visible) : [];
@@ -1661,16 +1729,14 @@ function computeDiceCameraFocusState(board, camera, seatIndex = null) {
   diceCenter.multiplyScalar(1 / diceSet.length);
 
   const target = diceCenter.clone();
-  if (Number.isInteger(seatIndex) && Array.isArray(board.seatAnchors)) {
-    const seatAnchor = board.seatAnchors[seatIndex];
-    if (seatAnchor) {
-      const seatWorld = new THREE.Vector3();
-      seatAnchor.getWorldPosition(seatWorld);
-      target.lerp(seatWorld, 0.2);
-    }
-  }
   target.y += DICE_SIZE * 0.45;
-  const position = camera.position.clone();
+  const currentDistance = camera.position.distanceTo(boardLookTarget);
+  const direction = camera.position.clone().sub(boardLookTarget).setY(0);
+  if (direction.lengthSq() < 1e-6) direction.set(0, 0, 1);
+  direction.normalize();
+
+  const position = target.clone().addScaledVector(direction, currentDistance);
+  position.y = camera.position.y;
   return { position, target };
 }
 
@@ -1681,9 +1747,22 @@ function computeTokenFollowCameraState(board, camera, fromIndex, toIndex) {
   if (!boardLookTarget) return null;
   const toPos = (board.indexToPosition.get(toIndex) || board.serpentineIndexToXZ(toIndex))?.clone();
   if (!toPos) return null;
-  const target = boardLookTarget.clone().lerp(toPos, CAMERA_BROADCAST_TARGET_BLEND);
-  target.y = boardLookTarget.y;
-  const position = camera.position.clone();
+  const fromPos = (board.indexToPosition.get(fromIndex) || board.serpentineIndexToXZ(fromIndex))?.clone();
+  const pathDir = fromPos
+    ? toPos.clone().sub(fromPos).setY(0)
+    : toPos.clone().sub(boardLookTarget).setY(0);
+  if (pathDir.lengthSq() < 1e-6) {
+    pathDir.copy(toPos.clone().sub(boardLookTarget).setY(0));
+  }
+  if (pathDir.lengthSq() < 1e-6) return null;
+  pathDir.normalize();
+
+  const behindDirection = pathDir.clone().multiplyScalar(-1);
+  const followDistance = TILE_SIZE * CAMERA_FOLLOW_BACK_TILES;
+  const target = toPos.clone();
+  target.y += TILE_SIZE * 0.18;
+  const position = target.clone().addScaledVector(behindDirection, followDistance);
+  position.y = Math.max(camera.position.y, boardLookTarget.y + CAMERA_EXTRA_LIFT);
   return { position, target };
 }
 
@@ -3775,61 +3854,42 @@ function quadraticBezier(a, b, c, t) {
 
 function createCaptureMissileRig() {
   const root = new THREE.Group();
-  const bodyMat = new THREE.MeshStandardMaterial({ color: '#bfc5ca', roughness: 0.42, metalness: 0.12 });
-  const noseMat = new THREE.MeshStandardMaterial({ color: '#eef1f4', roughness: 0.28, metalness: 0.12 });
-  const finMatA = new THREE.MeshStandardMaterial({ color: '#7d858b', roughness: 0.58, metalness: 0.12 });
-  const finMatB = new THREE.MeshStandardMaterial({ color: '#727a80', roughness: 0.58, metalness: 0.12 });
+  const bodyMat = new THREE.MeshStandardMaterial({ color: '#c9ced3', roughness: 0.42, metalness: 0.12 });
+  const noseMat = new THREE.MeshStandardMaterial({ color: '#f0f2f4', roughness: 0.32, metalness: 0.16 });
+  const finMat = new THREE.MeshStandardMaterial({ color: '#7f868d', roughness: 0.58, metalness: 0.12 });
+  const smokeMat = new THREE.MeshStandardMaterial({
+    color: '#90989d',
+    roughness: 1,
+    metalness: 0,
+    transparent: true,
+    opacity: 0.2
+  });
 
-  const body = new THREE.Mesh(new THREE.CylinderGeometry(0.07, 0.08, 1.02, 16), bodyMat);
+  const body = new THREE.Mesh(new THREE.CylinderGeometry(0.08, 0.09, 1, 16), bodyMat);
   body.rotation.z = Math.PI / 2;
   body.castShadow = true;
-  body.receiveShadow = true;
   root.add(body);
 
-  const nose = new THREE.Mesh(new THREE.ConeGeometry(0.08, 0.24, 16), noseMat);
-  nose.position.set(0.63, 0, 0);
+  const nose = new THREE.Mesh(new THREE.ConeGeometry(0.095, 0.24, 16), noseMat);
+  nose.position.set(0.6, 0, 0);
   nose.rotation.z = -Math.PI / 2;
   nose.castShadow = true;
-  nose.receiveShadow = true;
   root.add(nose);
 
-  const finA = new THREE.Mesh(new THREE.BoxGeometry(0.14, 0.02, 0.28), finMatA);
-  finA.position.set(-0.15, 0, 0);
+  const finA = new THREE.Mesh(new THREE.BoxGeometry(0.12, 0.02, 0.24), finMat);
+  finA.position.set(-0.25, 0, 0);
   finA.castShadow = true;
-  finA.receiveShadow = true;
   root.add(finA);
-  const finB = new THREE.Mesh(new THREE.BoxGeometry(0.14, 0.28, 0.02), finMatA);
-  finB.position.set(-0.15, 0, 0);
+  const finB = new THREE.Mesh(new THREE.BoxGeometry(0.12, 0.24, 0.02), finMat);
+  finB.position.set(-0.25, 0, 0);
   finB.castShadow = true;
-  finB.receiveShadow = true;
   root.add(finB);
-  const finC = new THREE.Mesh(new THREE.BoxGeometry(0.1, 0.02, 0.18), finMatB);
-  finC.position.set(-0.36, 0, 0);
-  finC.castShadow = true;
-  finC.receiveShadow = true;
-  root.add(finC);
-  const finD = new THREE.Mesh(new THREE.BoxGeometry(0.1, 0.18, 0.02), finMatB);
-  finD.position.set(-0.36, 0, 0);
-  finD.castShadow = true;
-  finD.receiveShadow = true;
-  root.add(finD);
 
   const trail = [];
-  for (let i = 0; i < 5; i += 1) {
-    const isFire = i < 2;
-    const puff = new THREE.Mesh(
-      new THREE.SphereGeometry(0.1 + i * 0.025, 16, 16),
-      new THREE.MeshStandardMaterial({
-        color: isFire ? '#f6af4b' : '#8f989d',
-        roughness: isFire ? 0.2 : 1,
-        metalness: 0,
-        transparent: true,
-        opacity: isFire ? 0.8 - i * 0.15 : 0.26 - (i - 2) * 0.04
-      })
-    );
-    puff.position.set(-0.7 - i * 0.16, 0, 0);
+  for (let i = 0; i < 4; i += 1) {
+    const puff = new THREE.Mesh(new THREE.SphereGeometry(0.08 + i * 0.02, 16, 16), smokeMat.clone());
+    puff.position.set(-0.55 - i * 0.14, 0, 0);
     puff.castShadow = true;
-    puff.receiveShadow = true;
     trail.push(puff);
     root.add(puff);
   }
@@ -4647,9 +4707,13 @@ export default function SnakeBoard3D({
     if (cameraViewMode !== '2d' && movement && shouldFollowTileChange(movement.from, movement.to)) {
       const camera = cameraRef.current;
       const controls = board.controls;
-      if (camera && controls) {
+      const facingRotation = computeBoardFacingRotation(board, camera, movement.to);
+      if (camera && controls && Number.isFinite(facingRotation)) {
         removeAnimationsByType(animationsRef.current, 'cameraDiceZoom');
         removeAnimationsByType(animationsRef.current, 'cameraTokenFollow');
+        removeAnimationsByType(animationsRef.current, 'boardAutoRotate');
+        const rotateAnimation = createBoardRotationAnimation(board, facingRotation);
+        if (rotateAnimation) animationsRef.current.push(rotateAnimation);
         const followState = computeTokenFollowCameraState(board, camera, movement.from, movement.to);
         if (followState) {
           const followAnimation = createCameraTransitionAnimation(camera, controls, {
@@ -4731,8 +4795,14 @@ export default function SnakeBoard3D({
     const camera = cameraRef.current;
     const controls = board.controls;
     if (cameraViewMode !== '2d' && camera && controls && shouldFollowTileChange(slide.from, slide.to)) {
+      const facingRotation = computeBoardFacingRotation(board, camera, slide.to);
       removeAnimationsByType(animationsRef.current, 'cameraDiceZoom');
       removeAnimationsByType(animationsRef.current, 'cameraTokenFollow');
+      removeAnimationsByType(animationsRef.current, 'boardAutoRotate');
+      if (Number.isFinite(facingRotation)) {
+        const rotateAnimation = createBoardRotationAnimation(board, facingRotation);
+        if (rotateAnimation) animationsRef.current.push(rotateAnimation);
+      }
       const followState = computeTokenFollowCameraState(board, camera, slide.from, slide.to);
       if (followState) {
         const followAnimation = createCameraTransitionAnimation(camera, controls, {
@@ -4867,7 +4937,7 @@ export default function SnakeBoard3D({
       if (active.length) {
         const camera = cameraRef.current;
         const controls = board.controls;
-        const diceCameraState = computeDiceCameraFocusState(board, camera, seatIndex);
+        const diceCameraState = computeDiceCameraFocusState(board, camera);
         if (camera && controls && diceCameraState && cameraViewMode !== '2d') {
           removeAnimationsByType(animationsRef.current, 'cameraTurnFocus');
           const restoreState = turnCameraStateRef.current || captureCameraState(camera, controls);
@@ -4965,10 +5035,7 @@ export default function SnakeBoard3D({
     explosion.root.visible = false;
     const bbox = new THREE.Box3().setFromObject(attacker);
     const tokenHeight = Math.max(TOKEN_HEIGHT * 5, bbox.max.y - bbox.min.y);
-    const tokenWidth = Math.max(TOKEN_RADIUS * 2, bbox.max.x - bbox.min.x, bbox.max.z - bbox.min.z);
-    const missileLengthScale = (tokenHeight / 1.02) * 1.04;
-    const missileThicknessScale = ((tokenWidth * 0.46) / 0.16) * 0.36;
-    missile.root.scale.set(missileLengthScale, missileThicknessScale, missileThicknessScale);
+    missile.root.scale.set(tokenHeight, tokenHeight * 0.38, tokenHeight * 0.38);
 
     const startTime = performance.now();
     const flightDuration = CAPTURE_MISSILE_FLIGHT_MS;

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -182,8 +182,8 @@ const SNAKE_SFX = Object.freeze({
 const FINAL_TILE = BOARD_FINAL_TILE;
 const PENULTIMATE_TILE = FINAL_TILE - 1;
 const TURN_TIME = 15;
-const AI_ROLL_DELAY_MS = 1400;
-const AI_EXTRA_ROLL_DELAY_MS = 900;
+const AI_ROLL_DELAY_MS = 3400;
+const AI_EXTRA_ROLL_DELAY_MS = 2600;
 const TURN_ADVANCE_AFTER_DICE_MS = 2000;
 const DEFAULT_CAPACITY = 4;
 const COMMENTARY_PRESET_STORAGE_KEY = 'snakeCommentaryPreset';
@@ -1163,7 +1163,7 @@ export default function SnakeAndLadder() {
   const [, setDiceVisible] = useState(true);
   const [photoUrl, setPhotoUrl] = useState(loadAvatar() || '');
   const [myName, setMyName] = useState('You');
-  const [pot, setPot] = useState(100);
+  const [pot, setPot] = useState(101);
   const [token, setToken] = useState("TPC");
   const [celebrate, setCelebrate] = useState(false);
   const [leftWinner, setLeftWinner] = useState(null);
@@ -2179,19 +2179,15 @@ export default function SnakeAndLadder() {
     };
     const onTurn = ({ playerId, seatIndex }) => {
       let idx = -1;
-      const parsedSeatIndex =
-        typeof seatIndex === 'string' ? Number.parseInt(seatIndex, 10) : seatIndex;
-      const parsedPlayerIndex =
-        typeof playerId === 'string' ? Number.parseInt(playerId, 10) : playerId;
 
-      if (Number.isInteger(parsedSeatIndex)) {
-        idx = parsedSeatIndex;
+      if (Number.isInteger(seatIndex)) {
+        idx = seatIndex;
       } else {
         idx = playersRef.current.findIndex((pl) => pl.id === playerId);
 
         // Some servers emit the active seat index instead of a playerId.
-        if (idx === -1 && Number.isInteger(parsedPlayerIndex)) {
-          idx = parsedPlayerIndex;
+        if (idx === -1 && Number.isInteger(playerId)) {
+          idx = playerId;
         }
       }
 
@@ -2202,11 +2198,8 @@ export default function SnakeAndLadder() {
         if (turnBelongsToMe) {
           // Keep roll CTA visible for immediate extra turns.
           setRollCooldown(0);
-          setPlayerAutoRolling(false);
         }
-        if (!turnBelongsToMe) {
-          setPendingExtraRoll(false);
-        }
+        if (!turnBelongsToMe) setPendingExtraRoll(false);
       }
     };
     const onStarted = () => {
@@ -2216,18 +2209,10 @@ export default function SnakeAndLadder() {
         unseatTable(myAccountId, tableId).catch(() => {});
       }
     };
-    const onRolled = ({ value, playerId, seatIndex }) => {
+    const onRolled = ({ value }) => {
       setRollResult(value);
       setTimeout(() => setRollResult(null), 2000);
       playDiceRollSound();
-      const parsedSeatIndex =
-        typeof seatIndex === 'string' ? Number.parseInt(seatIndex, 10) : seatIndex;
-      const turnSeat =
-        Number.isInteger(parsedSeatIndex)
-          ? parsedSeatIndex
-          : playersRef.current.findIndex((pl) => pl.id === playerId);
-      const isMyRoll = turnSeat >= 0 ? playersRef.current[turnSeat]?.id === myAccountId : playerId === myAccountId;
-      if (isMyRoll) setPendingExtraRoll(Number(value) === 6);
     };
     const onWon = ({ playerId }) => {
       setGameOver(true);
@@ -2663,6 +2648,9 @@ export default function SnakeAndLadder() {
         const ladObj = ladders[predicted];
         predicted = typeof ladObj === 'object' ? ladObj.end : ladObj;
       }
+      const extraPred = diceCells[predicted] || rolledSix;
+      const nextPlayer = extraPred ? currentTurn : getPreviousTurn(currentTurn);
+
       const steps = [];
       for (let i = current + 1; i <= target; i++) steps.push(i);
 
@@ -2751,7 +2739,7 @@ export default function SnakeAndLadder() {
             setDiceCount(1);
           }, 2000);
         }
-        let extraTurn = rolledSix;
+        let extraTurn = false;
         if (diceCells[finalPos]) {
           const bonus = diceCells[finalPos];
           setDiceCells((d) => {
@@ -2761,7 +2749,8 @@ export default function SnakeAndLadder() {
           });
           setBonusDice(bonus);
           setRewardDice(bonus);
-          setTurnMessage('Bonus');
+          setTurnMessage('Bonus roll');
+          extraTurn = true;
           if (!muted) {
             diceRewardSoundRef.current?.play().catch(() => {});
             yabbaSoundRef.current?.play().catch(() => {});
@@ -2769,8 +2758,10 @@ export default function SnakeAndLadder() {
           setTimeout(() => setRewardDice(0), 1000);
           enqueueSnakeCommentaryEvent('bonus', { player: playerLabel });
         } else if (rolledSix) {
-          setTurnMessage('Rolled 6 — roll again');
+          setTurnMessage('Six! Roll again');
           setBonusDice(0);
+          extraTurn = true;
+          enqueueSnakeCommentaryEvent('bonus', { player: playerLabel });
         } else {
           setTurnMessage("Your turn");
           setBonusDice(0);
@@ -2780,7 +2771,7 @@ export default function SnakeAndLadder() {
         setMoving(false);
         if (!gameOver) {
           if (extraTurn) {
-            // Do not delay the local extra roll button after a bonus tile.
+            // Do not delay the local extra roll button after a six/bonus.
             const next = currentTurn;
             setCurrentTurn(next);
             setDiceCount(playerDiceCounts[next] ?? 1);
@@ -2881,6 +2872,9 @@ export default function SnakeAndLadder() {
       const ladObj = ladders[predicted];
       predicted = typeof ladObj === 'object' ? ladObj.end : ladObj;
     }
+    const extraPred = diceCells[predicted] || rolledSix;
+    const nextPlayer = extraPred ? index : getPreviousTurn(index);
+
     const steps = [];
     for (let i = current + 1; i <= target; i++) steps.push(i);
 
@@ -2958,7 +2952,7 @@ export default function SnakeAndLadder() {
         setMoving(false);
         return;
       }
-      let extraTurn = rolledSix;
+      let extraTurn = false;
       if (diceCells[finalPos]) {
         const bonus = diceCells[finalPos];
         setDiceCells((d) => {
@@ -2968,16 +2962,17 @@ export default function SnakeAndLadder() {
         });
         setBonusDice(bonus);
         setRewardDice(bonus);
-        setTurnMessage('Bonus');
+        setTurnMessage('Bonus roll');
+        extraTurn = true;
         if (!muted) {
           diceRewardSoundRef.current?.play().catch(() => {});
           yabbaSoundRef.current?.play().catch(() => {});
         }
         setTimeout(() => setRewardDice(0), 1000);
         enqueueSnakeCommentaryEvent('bonus', { player: playerLabel });
-      }
-      if (rolledSix && !extraTurn) {
-        setTurnMessage(`${playerName(index)} rolled 6 — bonus turn`);
+      } else if (rolledSix) {
+        extraTurn = true;
+        enqueueSnakeCommentaryEvent('bonus', { player: playerLabel });
       }
       const next = extraTurn ? index : getPreviousTurn(index);
       if (next === 0) setTurnMessage('Your turn');
@@ -3207,10 +3202,11 @@ export default function SnakeAndLadder() {
   const canRoll =
     isMyTurnForRoll &&
     !moving &&
+    rollReady &&
     !gameOver &&
     !waitingForPlayers &&
+    !playerAutoRolling &&
     aiRollingIndex == null &&
-    (isMultiplayer || (rollReady && !playerAutoRolling)) &&
     !watchOnly;
   const hasTurnMessage =
     turnMessage !== null &&
@@ -3225,13 +3221,8 @@ export default function SnakeAndLadder() {
 
   const handleRollButtonClick = useCallback(() => {
     if (!canRoll) return;
-    if (isMultiplayer) {
-      socket.emit('rollDice');
-      setPendingExtraRoll(false);
-      return;
-    }
     diceRollerDivRef.current?.click();
-  }, [canRoll, isMultiplayer]);
+  }, [canRoll]);
 
   const renderPreview = (key, option) => {
     switch (key) {
@@ -4020,7 +4011,7 @@ export default function SnakeAndLadder() {
             numDice={diceCount}
             trigger={aiRollingIndex != null ? aiRollTrigger : playerAutoRolling ? playerRollTrigger : undefined}
             showButton={false}
-            muted
+            muted={muted}
             fixedSoundVolume={1}
           />
         </div>
@@ -4031,7 +4022,7 @@ export default function SnakeAndLadder() {
             <DiceRoller
               clickable
               showButton={false}
-              muted
+              muted={muted}
               fixedSoundVolume={1}
               emitRollEvent
               divRef={diceRollerDivRef}
@@ -4044,7 +4035,6 @@ export default function SnakeAndLadder() {
                   seatIndex: currentTurn
                 });
                 setPendingExtraRoll(false);
-                setPlayerAutoRolling(false);
               }}
               onRollEnd={(vals) => {
                 startDiceBoardAnimation({
@@ -4053,7 +4043,10 @@ export default function SnakeAndLadder() {
                   values: vals,
                   seatIndex: currentTurn
                 });
-                setPendingExtraRoll(false);
+                const rolledSix = Array.isArray(vals)
+                  ? vals.some((v) => Number(v) === 6)
+                  : Number(vals) === 6;
+                setPendingExtraRoll(rolledSix);
               }}
             />
           ) : null}
@@ -4077,14 +4070,14 @@ export default function SnakeAndLadder() {
           )}
         </div>
       )}
-      {canRoll ? (
+      {canRoll && diceAnchor ? (
         <button
           type="button"
           onClick={handleRollButtonClick}
-          className="fixed z-30 pointer-events-auto rounded-full flex items-center justify-center"
+          className="fixed z-30 pointer-events-auto rounded-full"
           style={{
-            left: diceAnchor ? `${diceAnchor.x}%` : 'calc(100% - 4.4rem)',
-            top: diceAnchor ? `${diceAnchor.y}%` : 'calc(100% - 9.6rem)',
+            left: `${diceAnchor.x}%`,
+            top: `${diceAnchor.y}%`,
             width: '5.4rem',
             height: '5.4rem',
             transform: 'translate(-50%, -50%)',
@@ -4093,16 +4086,7 @@ export default function SnakeAndLadder() {
             boxShadow: '0 0 18px rgba(250,204,21,0.24)'
           }}
           aria-label="Roll dice"
-        >
-          <span
-            className="text-3xl"
-            role="img"
-            aria-hidden="true"
-            style={{ filter: 'drop-shadow(0 0 6px rgba(250,204,21,0.55))' }}
-          >
-            🎲
-          </span>
-        </button>
+        />
       ) : null}
       {!watchOnly && (
         <div className="pointer-events-auto">
@@ -4121,7 +4105,7 @@ export default function SnakeAndLadder() {
             open={showInfo}
             onClose={() => setShowInfo(false)}
             title="Snake & Ladder"
-            info="Roll one die each turn. A 6 enters your token onto the board. Ladders lift you up and snakes bring you down. You must land exactly on tile 50 to win."
+            info="Roll one die each turn. A 6 enters your token onto the board and also grants an extra roll. Ladders lift you up and snakes bring you down. You must land exactly on the pot tile to win."
           />
         </div>
       )}
@@ -4130,7 +4114,7 @@ export default function SnakeAndLadder() {
           <HintPopup
             open={showExactHelp}
             onClose={() => setShowExactHelp(false)}
-            message={`You must roll the exact number to land on tile ${FINAL_TILE}.`}
+            message="You must roll the exact number to land on the pot."
           />
         </div>
       )}


### PR DESCRIPTION
### Motivation
- Restore the Snake & Ladder gameplay logic and rule flow to the exact baseline that existed at 06:00 to satisfy gameplay/regression requirements. 
- Keep non-rule functionality and UI stable while aligning server, examples, frontend, and tests to the earlier ruleset.

### Description
- Reinstated earlier Snake & Ladder rule semantics across server, examples, tests and frontend by reverting affected game files to the pre‑06:00 baseline; primary files updated include `bot/logic/snakeGame.js`, `examples/snake-ladder/*`, `test/snakeGame.test.js`, `webapp/src/components/SnakeBoard.jsx`, `webapp/src/components/SnakeBoard3D.jsx`, and `webapp/src/pages/Games/SnakeAndLadder.jsx`.
- Backend/game engine changes include restoring `FINAL_TILE` to a 101-style target, default `diceCount` to 2, multi-dice handling, restoring start-on-6 & extra-turn rules, applying snakes/ladders resolution via `applySnakesAndLadders`, capture behavior that resets opponents to start and resets their dice state, and reintroducing dice-cell bonus handling that grants bonus rolls.
- Example client and gameLogic updated to use a 100-cell board and original `DEFAULT_SNAKES`/`DEFAULT_LADDERS` mapping so examples reflect the rolled-back ruleset.
- Frontend/game page and 3D board changes restore turn-flow, pending extra-roll handling, dice-cell bonus UX, exact-win requirements and camera/dice timing/visual tuning so client behavior matches the server rules again.

### Testing
- Ran `npm test -- --runInBand test/snakeGame.test.js` as the primary automated validation for the restored rules.
- Result: test suite failed with 1 suite run, 4 failed, 6 passed (10 tests total); failing tests were: `applySnakesAndLadders resolves moves`, `rolling multiple sixes grants extra turns but preserves order`, `player wins when landing on the final tile`, and `landing on another player sends them to start` (assertion mismatches observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8d742f4dc8329bef22ec3891266b7)