### PR TITLE
Keep player turn after rolling 6 and add touch-friendly dice control (Snake & Ladder)

### DIFF
--- a/examples/snake-ladder/ReactClient.jsx
+++ b/examples/snake-ladder/ReactClient.jsx
@@ -63,6 +63,8 @@ export default function ReactClient({
   if (!state) return <div style={{ color: '#fff' }}>Loading...</div>;
 
   const current = state.players[state.currentPlayer]?.id;
+  const isMyTurn = socket.id === current && !state.winner;
+  const rolledSix = state.diceRoll === 6 && socket.id === current;
 
   return (
     <div
@@ -91,9 +93,14 @@ export default function ReactClient({
         </h3>
         <p style={{ margin: '4px 0' }}>Current Player: {current}</p>
         <p style={{ margin: '4px 0 12px' }}>Last Dice Roll: {state.diceRoll}</p>
+        {rolledSix && (
+          <p style={{ margin: '4px 0 12px', color: '#86efac', fontWeight: 700 }}>
+            You rolled a 6 — tap the dice to roll again.
+          </p>
+        )}
         <button
           onClick={rollDice}
-          disabled={socket.id !== current || state.winner}
+          disabled={!isMyTurn}
           style={{
             border: 'none',
             borderRadius: 999,
@@ -101,12 +108,35 @@ export default function ReactClient({
             fontWeight: 700,
             background: 'linear-gradient(90deg, #22c55e, #14b8a6)',
             color: '#082f49',
-            cursor:
-              socket.id !== current || state.winner ? 'not-allowed' : 'pointer',
-            opacity: socket.id !== current || state.winner ? 0.45 : 1
+            cursor: !isMyTurn ? 'not-allowed' : 'pointer',
+            opacity: !isMyTurn ? 0.45 : 1
           }}
         >
           Roll Dice
+        </button>
+        <button
+          onClick={rollDice}
+          disabled={!isMyTurn}
+          aria-label="Roll Dice"
+          style={{
+            marginLeft: 10,
+            width: 42,
+            height: 42,
+            borderRadius: '50%',
+            border: '1px solid rgba(148,163,184,0.4)',
+            background: isMyTurn
+              ? 'linear-gradient(180deg, #f8fafc, #cbd5e1)'
+              : 'linear-gradient(180deg, #94a3b8, #64748b)',
+            color: '#0f172a',
+            fontSize: 22,
+            lineHeight: 1,
+            cursor: !isMyTurn ? 'not-allowed' : 'pointer',
+            opacity: !isMyTurn ? 0.5 : 1,
+            verticalAlign: 'middle'
+          }}
+          title="Tap dice to roll"
+        >
+          🎲
         </button>
         {state.winner && (
           <p style={{ margin: '12px 0 0' }}>Winner: {state.winner}</p>

--- a/examples/snake-ladder/gameLogic.js
+++ b/examples/snake-ladder/gameLogic.js
@@ -75,7 +75,7 @@ export class Game {
     current.position = newPos;
     if (newPos === BOARD_SIZE) {
       this.winner = current.id;
-    } else {
+    } else if (value !== 6) {
       this.currentPlayer = (this.currentPlayer + 1) % this.players.length;
     }
   }


### PR DESCRIPTION
### Motivation
- Ensure game rule parity: a player who rolls a 6 should keep their turn (able to roll again) and the UI should make this clear to human players. 
- Improve mobile/touch UX by exposing a clear dice icon control that can be tapped to roll during the player’s active turn. 

### Description
- Updated server turn flow in `examples/snake-ladder/gameLogic.js` so the current player does not advance when the dice value is `6` (the turn only advances when the roll is not `6`), while preserving winning behavior. 
- Added client-side helpers `isMyTurn` and `rolledSix` in `examples/snake-ladder/ReactClient.jsx` and used them to keep roll controls active only for the active player. 
- Replaced the previous disabled-check logic on the roll button with `isMyTurn`, added a touch-friendly dice icon button (`🎲`) that mirrors the same enable/disable behavior, and added an on-screen message when a 6 is rolled (`You rolled a 6 — tap the dice to roll again.`). 

### Testing
- Ran a Node.js logic check that programmatically simulates rolls and asserts that rolling `6` keeps `currentPlayer` unchanged and a subsequent non-6 roll passes the turn, and the script completed successfully. 
- No automated UI screenshot tests were run for the client changes in this environment; only the server-side turn logic was verified by the automated script.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8e05e52f88329a2d6431cf6da6ea9)