### PR TITLE
Honor pending extra-roll and enable dice tap for human turns in Snake & Ladder

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -3195,7 +3195,7 @@ export default function SnakeAndLadder() {
     ? mpPlayers.findIndex((p) => p.id === accountId)
     : 0;
   const myPlayerIndex = computedIndex >= 0 ? computedIndex : null;
-  const hasLocalExtraRoll = isMultiplayer && pendingExtraRoll;
+  const hasLocalExtraRoll = pendingExtraRoll;
   const isMyTurnForRoll =
     myPlayerIndex !== null && (currentTurn === myPlayerIndex || hasLocalExtraRoll);
   const rollReady = hasLocalExtraRoll || rollCooldown === 0;
@@ -4004,7 +4004,7 @@ export default function SnakeAndLadder() {
             clickable={
               !aiRollingIndex &&
               !playerAutoRolling &&
-              rollCooldown === 0 &&
+              (pendingExtraRoll || rollCooldown === 0) &&
               currentTurn === 0 &&
               !moving
             }


### PR DESCRIPTION
### Motivation
- Ensure a human player who earned an extra roll (e.g. by rolling a 6 or landing on a bonus dice cell) sees the roll CTA/icon and can tap the dice to roll again immediately, both in singleplayer and multiplayer flows.

### Description
- Relaxed the local-extra-roll check by changing `hasLocalExtraRoll` to use `pendingExtraRoll` for humans regardless of `isMultiplayer`, and updated the hidden `DiceRoller` `clickable` condition to allow interaction when `(pendingExtraRoll || rollCooldown === 0)` in `webapp/src/pages/Games/SnakeAndLadder.jsx`.

### Testing
- Built the web client with `npm -C webapp run build`, which completed successfully (Vite production build).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8e05e52f88329a2d6431cf6da6ea9)