### PR TITLE
Shrink Ludo arena slightly and adjust camera offsets to preserve framing

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -489,7 +489,10 @@ const ABG_COLOR_B = /\b(black|ebony|dark|b)\b/i;
 let proceduralTokenHeight = null;
 
 const BASE_ARENA_SCALE = 0.85;
-const ARENA_SCALE = 0.72;
+// Keep the exact layout, but make the full table setup (table + board + chairs + attached animations)
+// slightly smaller in world space.
+const LUDO_ARENA_SHRINK_FACTOR = 0.94;
+const ARENA_SCALE = 0.72 * LUDO_ARENA_SHRINK_FACTOR;
 const ARENA_SCALE_RATIO = ARENA_SCALE / BASE_ARENA_SCALE;
 const MODEL_SCALE = 0.75 * ARENA_SCALE;
 const TABLE_RADIUS = 3.4 * MODEL_SCALE;
@@ -585,14 +588,14 @@ const CAMERA_FREE_LOOK_POLAR_DELTA = THREE.MathUtils.degToRad(55);
 const LUDO_CAMERA_PHI_MIN = THREE.MathUtils.degToRad(18);
 const LUDO_CAMERA_PHI_MAX = THREE.MathUtils.degToRad(88);
 const LANDSCAPE_CAMERA_TUNING = Object.freeze({
-  backOffset: 1.08 * ARENA_SCALE_RATIO,
-  forwardOffset: 0.44 * ARENA_SCALE_RATIO,
-  heightOffset: 1.24 * ARENA_SCALE_RATIO
+  backOffset: 1.08 * ARENA_SCALE_RATIO * LUDO_ARENA_SHRINK_FACTOR,
+  forwardOffset: 0.44 * ARENA_SCALE_RATIO * LUDO_ARENA_SHRINK_FACTOR,
+  heightOffset: 1.24 * ARENA_SCALE_RATIO * LUDO_ARENA_SHRINK_FACTOR
 });
 const PORTRAIT_CAMERA_TUNING = Object.freeze({
-  backOffset: 0.82 * ARENA_SCALE_RATIO,
-  forwardOffset: 0.7 * ARENA_SCALE_RATIO,
-  heightOffset: 1.18 * ARENA_SCALE_RATIO,
+  backOffset: 0.82 * ARENA_SCALE_RATIO * LUDO_ARENA_SHRINK_FACTOR,
+  forwardOffset: 0.7 * ARENA_SCALE_RATIO * LUDO_ARENA_SHRINK_FACTOR,
+  heightOffset: 1.18 * ARENA_SCALE_RATIO * LUDO_ARENA_SHRINK_FACTOR,
   targetLift: 0.075 * MODEL_SCALE
 });
 


### PR DESCRIPTION
### Motivation
- Make the Ludo table + chairs + board (and attached animations) render slightly smaller while keeping the existing layout and composition unchanged.

### Description
- Introduced `LUDO_ARENA_SHRINK_FACTOR` and applied it to `ARENA_SCALE` so the full arena geometry is uniformly reduced in world space in `webapp/src/pages/Games/LudoBattleRoyal.jsx`.
- Scaled portrait and landscape camera tuning offsets by the same shrink factor so camera framing remains consistent with the previous composition.
- Kept all layout logic, scene anchors, and board scaling routines unchanged so behavior and relative placement are preserved.

### Testing
- Ran the production build with `npm --prefix webapp run build` which completed successfully (Vite build finished and assets were emitted).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8f3b0e3548329aa85ed3fbe2e8b15)