### PR TITLE
Tune Ludo arena proportions, chair spacing, token rail pull, and table base

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -491,7 +491,7 @@ let proceduralTokenHeight = null;
 const BASE_ARENA_SCALE = 0.85;
 // Keep the exact layout, but make the full table setup (table + board + chairs + attached animations)
 // slightly smaller in world space.
-const LUDO_ARENA_SHRINK_FACTOR = 0.94;
+const LUDO_ARENA_SHRINK_FACTOR = 0.92;
 const ARENA_SCALE = 0.72 * LUDO_ARENA_SHRINK_FACTOR;
 const ARENA_SCALE_RATIO = ARENA_SCALE / BASE_ARENA_SCALE;
 const MODEL_SCALE = 0.75 * ARENA_SCALE;
@@ -510,7 +510,7 @@ const BASE_COLUMN_HEIGHT = 0.5 * MODEL_SCALE * STOOL_SCALE;
 const CARD_SCALE = 0.95;
 const CARD_W = 0.4 * MODEL_SCALE * CARD_SCALE;
 const HUMAN_SEAT_ROTATION_OFFSET = Math.PI / 8;
-const AI_CHAIR_GAP = CARD_W * 0.4;
+const AI_CHAIR_GAP = CARD_W * 0.52;
 const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 0.85;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
 const TABLE_HEIGHT_LIFT = 0.05 * MODEL_SCALE;
@@ -1992,10 +1992,10 @@ const TOKEN_RAIL_BASE_FORWARD_SHIFT = Object.freeze([0.012, 0, 0, 0]);
 const TOKEN_RAIL_SIDE_MULTIPLIER = Object.freeze([1.12, 1.12, 1.12, 1.12]);
 const TOKEN_RAIL_CENTER_PULL_DEFAULT = 0.048;
 const TOKEN_RAIL_CENTER_PULL_PER_PLAYER = Object.freeze([
-  0.056,
-  0.052,
-  0.056,
-  0.052
+  0.068,
+  0.062,
+  0.068,
+  0.062
 ]);
 const TOKEN_RAIL_HEIGHT_LIFT = 0.0045;
 const NON_OCTAGON_TOKEN_SURFACE_OFFSET = -0.006;

--- a/webapp/src/utils/murlanTable.js
+++ b/webapp/src/utils/murlanTable.js
@@ -566,7 +566,7 @@ export function createMurlanStyleTable({
   const baseLift = 0.03 * scaleFactor;
   const minBaseHeight = 0.2 * scaleFactor;
   const maxBaseHeight = Math.max(minBaseHeight, tableY + baseLift);
-  baseHeight = Math.min(Math.max(baseHeight, minBaseHeight), maxBaseHeight);
+  baseHeight = maxBaseHeight;
 
   const baseMat = includeBase
     ? new ThreeNamespace.MeshPhysicalMaterial({


### PR DESCRIPTION
### Motivation
- Make the Ludo table/board/chairs setup render slightly smaller while keeping the same layout and camera framing.  
- Pull player tokens slightly inward toward the board center and push chairs a bit outward from the table.  
- Ensure the procedural table pedestal extends down to touch the ground while keeping tabletop height unchanged.

### Description
- Reduced `LUDO_ARENA_SHRINK_FACTOR` from `0.94` to `0.92` so the full table + board + chairs arrangement is rendered a bit smaller while preserving layout relationships (`webapp/src/pages/Games/LudoBattleRoyal.jsx`).  
- Increased `AI_CHAIR_GAP` (from `CARD_W * 0.4` to `CARD_W * 0.52`) to push chairs slightly farther from the table (`webapp/src/pages/Games/LudoBattleRoyal.jsx`).  
- Increased `TOKEN_RAIL_CENTER_PULL_PER_PLAYER` values to pull token rail home pads a bit inward toward the center (`webapp/src/pages/Games/LudoBattleRoyal.jsx`).  
- Changed procedural table base logic to set `baseHeight` to `maxBaseHeight` so the pedestal extends down to the floor while the tabletop remains positioned by `tableHeight` (`webapp/src/utils/murlanTable.js`).

### Testing
- Ran the production build with `npm -C webapp run build` and the build completed successfully.  
- The build produced non-blocking Vite warnings about chunk sizes and some mixed static/dynamic imports, which are unrelated to this change.  
- No unit/integration tests were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8fa8352e48329b0eaaaaa8eb34210)