### PR TITLE
Tune Ludo Battle Royal arena scale, seating, token pull, table width and base framing

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -491,7 +491,7 @@ let proceduralTokenHeight = null;
 const BASE_ARENA_SCALE = 0.85;
 // Keep the exact layout, but make the full table setup (table + board + chairs + attached animations)
 // slightly smaller in world space.
-const LUDO_ARENA_SHRINK_FACTOR = 0.92;
+const LUDO_ARENA_SHRINK_FACTOR = 0.88;
 const ARENA_SCALE = 0.72 * LUDO_ARENA_SHRINK_FACTOR;
 const ARENA_SCALE_RATIO = ARENA_SCALE / BASE_ARENA_SCALE;
 const MODEL_SCALE = 0.75 * ARENA_SCALE;
@@ -510,7 +510,7 @@ const BASE_COLUMN_HEIGHT = 0.5 * MODEL_SCALE * STOOL_SCALE;
 const CARD_SCALE = 0.95;
 const CARD_W = 0.4 * MODEL_SCALE * CARD_SCALE;
 const HUMAN_SEAT_ROTATION_OFFSET = Math.PI / 8;
-const AI_CHAIR_GAP = CARD_W * 0.52;
+const AI_CHAIR_GAP = CARD_W * 0.62;
 const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 0.85;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
 const TABLE_HEIGHT_LIFT = 0.05 * MODEL_SCALE;
@@ -1458,7 +1458,7 @@ function fitTableModelToArena(model, tableThemeId = null) {
 
 function getTableWidthScale(tableThemeId) {
   if (!tableThemeId) return 1;
-  return tableThemeId === 'gothic_coffee_table' ? 1 : 1.12;
+  return tableThemeId === 'gothic_coffee_table' ? 1 : 1.06;
 }
 
 function applyBoardGroupScale(boardGroup, tableInfo) {
@@ -1868,7 +1868,7 @@ const BOARD_ROTATION_Y = -Math.PI / 2;
 const CAMERA_BASE_RADIUS = Math.max(TABLE_RADIUS, BOARD_RADIUS);
 const CAMERA_EXTRA_ZOOM_IN = 0.9;
 const CAMERA_EXTRA_ZOOM_OUT = 1.26;
-const INITIAL_CAMERA_DISTANCE_FACTOR = 0.93;
+const INITIAL_CAMERA_DISTANCE_FACTOR = 0.89;
 const CAM = {
   fov: CAMERA_FOV,
   near: CAMERA_NEAR,
@@ -1990,12 +1990,12 @@ const RAIL_TOKEN_SIDE_SPACING = 0.06;
 const TOKEN_HOME_HEIGHT_OFFSETS = Object.freeze([0, 0.0035, 0.0035, 0.0035]);
 const TOKEN_RAIL_BASE_FORWARD_SHIFT = Object.freeze([0.012, 0, 0, 0]);
 const TOKEN_RAIL_SIDE_MULTIPLIER = Object.freeze([1.12, 1.12, 1.12, 1.12]);
-const TOKEN_RAIL_CENTER_PULL_DEFAULT = 0.048;
+const TOKEN_RAIL_CENTER_PULL_DEFAULT = 0.058;
 const TOKEN_RAIL_CENTER_PULL_PER_PLAYER = Object.freeze([
-  0.068,
-  0.062,
-  0.068,
-  0.062
+  0.078,
+  0.072,
+  0.078,
+  0.072
 ]);
 const TOKEN_RAIL_HEIGHT_LIFT = 0.0045;
 const NON_OCTAGON_TOKEN_SURFACE_OFFSET = -0.006;
@@ -3754,7 +3754,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           woodOption,
           clothOption,
           baseOption,
-          includeBase: false
+          includeBase: true
         });
         applyTableMaterials(procedural.materials, { woodOption, clothOption, baseOption }, renderer);
         tableInfo = { ...procedural, themeId: tableTheme?.id || procedural.shapeId };
@@ -4839,7 +4839,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         woodOption,
         clothOption,
         baseOption,
-        includeBase: false
+        includeBase: true
       });
       applyTableMaterials(procedural.materials, { woodOption, clothOption, baseOption }, renderer);
       tableInfo = { ...procedural, themeId: tableTheme?.id || procedural.shapeId };


### PR DESCRIPTION
### Motivation
- Improve visual framing and proportions of the Ludo Battle Royal arena so the table/board/chairs/animations read slightly smaller while preserving the exact layout.
- Pull player tokens marginally inward and push chairs slightly outward to improve on-screen composition in portrait mobile view.
- Ensure the table base extends to the ground so the table looks properly grounded from broadcast and showroom camera angles.

### Description
- Reduced overall arena scale by changing `LUDO_ARENA_SHRINK_FACTOR` from `0.92` to `0.88` and adjusted `ARENA`/`MODEL_SCALE` derived values to keep layout relationships intact in `webapp/src/pages/Games/LudoBattleRoyal.jsx`.
- Increased chair radial gap by updating `AI_CHAIR_GAP` (from `CARD_W * 0.52` to `CARD_W * 0.62`) so chairs are pushed slightly outward from the table.
- Pulled tokens inward by increasing `TOKEN_RAIL_CENTER_PULL_DEFAULT` and the per-player `TOKEN_RAIL_CENTER_PULL_PER_PLAYER` values.
- Reduced non-gothic table width scaling by changing `getTableWidthScale` default from `1.12` to `1.06` so table sides read a bit narrower.
- Enabled procedural table base generation (`includeBase: true`) in both initial and rebuild table creation paths so the base extends down to ground.
- Tweaked camera framing by lowering `INITIAL_CAMERA_DISTANCE_FACTOR` from `0.93` to `0.89` to preserve visual framing after the geometry adjustments.

### Testing
- Ran `npm run build` which completed successfully with TypeScript compilation passing.
- Ran `npx eslint webapp/src/pages/Games/LudoBattleRoyal.jsx` and `npx eslint --no-ignore` which reported the file is ignored by repo lint settings and produced a warning; no lint errors were introduced by the change.
- Verified the modified file is `webapp/src/pages/Games/LudoBattleRoyal.jsx` and that the project builds cleanly after the edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8fd7bf5d48329a12570f7006254b0)