### PR TITLE
Adjust Ludo arena proportions, seating and token offsets

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -491,11 +491,11 @@ let proceduralTokenHeight = null;
 const BASE_ARENA_SCALE = 0.85;
 // Keep the exact layout, but make the full table setup (table + board + chairs + attached animations)
 // slightly smaller in world space.
-const LUDO_ARENA_SHRINK_FACTOR = 0.88;
+const LUDO_ARENA_SHRINK_FACTOR = 0.86;
 const ARENA_SCALE = 0.72 * LUDO_ARENA_SHRINK_FACTOR;
 const ARENA_SCALE_RATIO = ARENA_SCALE / BASE_ARENA_SCALE;
 const MODEL_SCALE = 0.75 * ARENA_SCALE;
-const TABLE_RADIUS = 3.4 * MODEL_SCALE;
+const TABLE_RADIUS = 3.28 * MODEL_SCALE;
 const BASE_TABLE_HEIGHT = 1.08 * MODEL_SCALE;
 const STOOL_SCALE = 1.5 * 1.3;
 const SEAT_WIDTH = 0.9 * MODEL_SCALE * STOOL_SCALE;
@@ -510,7 +510,7 @@ const BASE_COLUMN_HEIGHT = 0.5 * MODEL_SCALE * STOOL_SCALE;
 const CARD_SCALE = 0.95;
 const CARD_W = 0.4 * MODEL_SCALE * CARD_SCALE;
 const HUMAN_SEAT_ROTATION_OFFSET = Math.PI / 8;
-const AI_CHAIR_GAP = CARD_W * 0.62;
+const AI_CHAIR_GAP = CARD_W * 0.74;
 const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 0.85;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
 const TABLE_HEIGHT_LIFT = 0.05 * MODEL_SCALE;
@@ -1458,7 +1458,7 @@ function fitTableModelToArena(model, tableThemeId = null) {
 
 function getTableWidthScale(tableThemeId) {
   if (!tableThemeId) return 1;
-  return tableThemeId === 'gothic_coffee_table' ? 1 : 1.06;
+  return tableThemeId === 'gothic_coffee_table' ? 0.98 : 1.02;
 }
 
 function applyBoardGroupScale(boardGroup, tableInfo) {
@@ -1990,14 +1990,14 @@ const RAIL_TOKEN_SIDE_SPACING = 0.06;
 const TOKEN_HOME_HEIGHT_OFFSETS = Object.freeze([0, 0.0035, 0.0035, 0.0035]);
 const TOKEN_RAIL_BASE_FORWARD_SHIFT = Object.freeze([0.012, 0, 0, 0]);
 const TOKEN_RAIL_SIDE_MULTIPLIER = Object.freeze([1.12, 1.12, 1.12, 1.12]);
-const TOKEN_RAIL_CENTER_PULL_DEFAULT = 0.058;
+const TOKEN_RAIL_CENTER_PULL_DEFAULT = 0.066;
 const TOKEN_RAIL_CENTER_PULL_PER_PLAYER = Object.freeze([
-  0.078,
-  0.072,
-  0.078,
-  0.072
+  0.086,
+  0.08,
+  0.086,
+  0.08
 ]);
-const TOKEN_RAIL_HEIGHT_LIFT = 0.0045;
+const TOKEN_RAIL_HEIGHT_LIFT = 0.0016;
 const NON_OCTAGON_TOKEN_SURFACE_OFFSET = -0.006;
 let tokenSurfaceOffset = 0;
 const TOKEN_MOVE_SPEED = 2.45;

--- a/webapp/src/utils/murlanTable.js
+++ b/webapp/src/utils/murlanTable.js
@@ -566,7 +566,8 @@ export function createMurlanStyleTable({
   const baseLift = 0.03 * scaleFactor;
   const minBaseHeight = 0.2 * scaleFactor;
   const maxBaseHeight = Math.max(minBaseHeight, tableY + baseLift);
-  baseHeight = maxBaseHeight;
+  // Keep table-top height unchanged while extending the pedestal downward slightly.
+  baseHeight = maxBaseHeight * 1.06;
 
   const baseMat = includeBase
     ? new ThreeNamespace.MeshPhysicalMaterial({


### PR DESCRIPTION
### Motivation
- Make the Ludo table/board/chairs/token arrangement a bit smaller while keeping the same layout and camera framing, and adjust seating and token positions so tokens sit closer to the table and chairs sit slightly further out. 

### Description
- Reduced global arena scale by changing `LUDO_ARENA_SHRINK_FACTOR` from `0.88` to `0.86` and slightly reduced `TABLE_RADIUS` to `3.28 * MODEL_SCALE` in `webapp/src/pages/Games/LudoBattleRoyal.jsx` to shrink the overall setup while preserving layout logic. 
- Increased chair spacing by raising `AI_CHAIR_GAP` (via `CARD_W * 0.74`) so chairs are pushed outward from the table. 
- Pulled tokens inward and lowered their rail height by increasing `TOKEN_RAIL_CENTER_PULL_DEFAULT` and per-player `TOKEN_RAIL_CENTER_PULL_PER_PLAYER` values and reducing `TOKEN_RAIL_HEIGHT_LIFT` so tokens sit closer to the table surface. 
- Narrowed loaded table width scaling for theme models by adjusting `getTableWidthScale` to return `0.98`/`1.02` instead of `1`/`1.06` so table sides appear slightly smaller across themes. 
- Kept tabletop height/framing intact and extended the procedural pedestal downward by multiplying the computed `baseHeight` by `1.06` in `webapp/src/utils/murlanTable.js` so the table base reaches the ground more convincingly without raising the top surface. 

### Testing
- Ran `npm run -s build` and the build completed successfully. 
- Ran `npx eslint webapp/src/pages/Games/LudoBattleRoyal.jsx webapp/src/utils/murlanTable.js` which produced repository ignore warnings for those files but no code errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d90065bcb48329a8bc058ade37f5c9)