### PR TITLE
Snake & Ladder: preserve extra-roll on 6 and add touch roll support

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -2209,10 +2209,15 @@ export default function SnakeAndLadder() {
         unseatTable(myAccountId, tableId).catch(() => {});
       }
     };
-    const onRolled = ({ value }) => {
+    const onRolled = ({ value, playerId }) => {
       setRollResult(value);
       setTimeout(() => setRollResult(null), 2000);
       playDiceRollSound();
+      const rollerId = playerId ?? playersRef.current[currentTurn]?.id;
+      if (rollerId === myAccountId && Number(value) === 6) {
+        setPendingExtraRoll(true);
+        setRollCooldown(0);
+      }
     };
     const onWon = ({ playerId }) => {
       setGameOver(true);
@@ -3198,7 +3203,9 @@ export default function SnakeAndLadder() {
   const hasLocalExtraRoll = pendingExtraRoll;
   const isMyTurnForRoll =
     myPlayerIndex !== null && (currentTurn === myPlayerIndex || hasLocalExtraRoll);
-  const rollReady = hasLocalExtraRoll || rollCooldown === 0;
+  const rollReady = isMultiplayer
+    ? true
+    : hasLocalExtraRoll || rollCooldown === 0;
   const canRoll =
     isMyTurnForRoll &&
     !moving &&
@@ -4063,6 +4070,7 @@ export default function SnakeAndLadder() {
             <button
               type="button"
               onClick={handleRollButtonClick}
+              onTouchStart={handleRollButtonClick}
               className="pointer-events-auto px-6 py-3 rounded-full font-semibold text-sm text-[#f7e7a4] shadow-lg bg-gradient-to-b from-[#2b2b2b] to-[#121212] border border-[rgba(255,215,0,0.45)]"
             >
               ROLL
@@ -4074,6 +4082,7 @@ export default function SnakeAndLadder() {
         <button
           type="button"
           onClick={handleRollButtonClick}
+          onTouchStart={handleRollButtonClick}
           className="fixed z-30 pointer-events-auto rounded-full"
           style={{
             left: `${diceAnchor.x}%`,


### PR DESCRIPTION
### Motivation
- Improve player experience so a human who rolls a 6 immediately sees the roll UI and can take the extra roll without waiting for cooldowns. 
- Ensure multiplayer turns are not blocked by local cooldown logic so remote-driven turn events keep the local UI responsive. 
- Support mobile touch input so users can roll by touching the dice or roll button.

### Description
- Update `onRolled` handler to accept `playerId` and when the current human player rolled a `6` set `pendingExtraRoll` and clear the local roll cooldown. (file: `webapp/src/pages/Games/SnakeAndLadder.jsx`)
- Change `rollReady` logic to allow rolling during multiplayer turns by bypassing local cooldown gating when `isMultiplayer` is true. (file: `webapp/src/pages/Games/SnakeAndLadder.jsx`)
- Add `onTouchStart` handlers to the main roll CTA and dice anchor overlay so touch devices can trigger `handleRollButtonClick`. (file: `webapp/src/pages/Games/SnakeAndLadder.jsx`)

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully. 
- The build produced standard Vite warnings about chunk sizes/dynamic imports but no errors and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d900e1825083298b2ccd06b39bb008)