### PR TITLE
Adjust Ludo Battle Royal arena proportions and grounding alignment

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -491,11 +491,11 @@ let proceduralTokenHeight = null;
 const BASE_ARENA_SCALE = 0.85;
 // Keep the exact layout, but make the full table setup (table + board + chairs + attached animations)
 // slightly smaller in world space.
-const LUDO_ARENA_SHRINK_FACTOR = 0.86;
+const LUDO_ARENA_SHRINK_FACTOR = 0.84;
 const ARENA_SCALE = 0.72 * LUDO_ARENA_SHRINK_FACTOR;
 const ARENA_SCALE_RATIO = ARENA_SCALE / BASE_ARENA_SCALE;
 const MODEL_SCALE = 0.75 * ARENA_SCALE;
-const TABLE_RADIUS = 3.28 * MODEL_SCALE;
+const TABLE_RADIUS = 3.18 * MODEL_SCALE;
 const BASE_TABLE_HEIGHT = 1.08 * MODEL_SCALE;
 const STOOL_SCALE = 1.5 * 1.3;
 const SEAT_WIDTH = 0.9 * MODEL_SCALE * STOOL_SCALE;
@@ -515,7 +515,7 @@ const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 0.85;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
 const TABLE_HEIGHT_LIFT = 0.05 * MODEL_SCALE;
 const TABLE_HEIGHT = STOOL_HEIGHT + TABLE_HEIGHT_LIFT;
-const AI_CHAIR_RADIUS = TABLE_RADIUS + SEAT_DEPTH / 2 + AI_CHAIR_GAP;
+const AI_CHAIR_RADIUS = TABLE_RADIUS + SEAT_DEPTH / 2 + AI_CHAIR_GAP + 0.06 * MODEL_SCALE;
 
 const DEFAULT_PLAYER_COUNT = 4;
 const clampPlayerCount = (value) =>
@@ -1990,14 +1990,14 @@ const RAIL_TOKEN_SIDE_SPACING = 0.06;
 const TOKEN_HOME_HEIGHT_OFFSETS = Object.freeze([0, 0.0035, 0.0035, 0.0035]);
 const TOKEN_RAIL_BASE_FORWARD_SHIFT = Object.freeze([0.012, 0, 0, 0]);
 const TOKEN_RAIL_SIDE_MULTIPLIER = Object.freeze([1.12, 1.12, 1.12, 1.12]);
-const TOKEN_RAIL_CENTER_PULL_DEFAULT = 0.066;
+const TOKEN_RAIL_CENTER_PULL_DEFAULT = 0.078;
 const TOKEN_RAIL_CENTER_PULL_PER_PLAYER = Object.freeze([
-  0.086,
-  0.08,
-  0.086,
-  0.08
+  0.098,
+  0.092,
+  0.098,
+  0.092
 ]);
-const TOKEN_RAIL_HEIGHT_LIFT = 0.0016;
+const TOKEN_RAIL_HEIGHT_LIFT = 0.0002;
 const NON_OCTAGON_TOKEN_SURFACE_OFFSET = -0.006;
 let tokenSurfaceOffset = 0;
 const TOKEN_MOVE_SPEED = 2.45;

--- a/webapp/src/utils/murlanTable.js
+++ b/webapp/src/utils/murlanTable.js
@@ -566,8 +566,8 @@ export function createMurlanStyleTable({
   const baseLift = 0.03 * scaleFactor;
   const minBaseHeight = 0.2 * scaleFactor;
   const maxBaseHeight = Math.max(minBaseHeight, tableY + baseLift);
-  // Keep table-top height unchanged while extending the pedestal downward slightly.
-  baseHeight = maxBaseHeight * 1.06;
+  // Keep table-top height unchanged while extending the pedestal downward a bit more so the base reaches the ground cleanly.
+  baseHeight = maxBaseHeight * 1.14;
 
   const baseMat = includeBase
     ? new ThreeNamespace.MeshPhysicalMaterial({


### PR DESCRIPTION
### Motivation
- Make the Ludo Battle Royal table/board/chairs/tokens visually slightly smaller and better grounded while preserving the exact layout and current camera framing. 
- Pull player tokens a bit toward the board center, push chairs slightly outward from the table, shorten the table sides, and extend the table base downward so table and chairs sit flush with HDRI ground. 

### Description
- Reduced the arena scale by changing `LUDO_ARENA_SHRINK_FACTOR` from `0.86` to `0.84` and shortened the table footprint by changing `TABLE_RADIUS` from `3.28 * MODEL_SCALE` to `3.18 * MODEL_SCALE` in `LudoBattleRoyal.jsx`. 
- Nudged seating outward by increasing `AI_CHAIR_RADIUS` (added `+ 0.06 * MODEL_SCALE`) so chairs sit slightly farther from the table in `LudoBattleRoyal.jsx`. 
- Pulled token rails inward and lowered their resting lift by increasing `TOKEN_RAIL_CENTER_PULL_DEFAULT` and `TOKEN_RAIL_CENTER_PULL_PER_PLAYER` values and reducing `TOKEN_RAIL_HEIGHT_LIFT` to `0.0002` so tokens sit closer to the table surface in `LudoBattleRoyal.jsx`. 
- Extended the procedural table pedestal downward by increasing the computed `baseHeight` multiplier from `1.06` to `1.14` in `createMurlanStyleTable` within `murlanTable.js`, preserving tabletop height while making the base reach the HDRI floor more cleanly. 
- Changes are conservative and focused on positional/constants updates so existing animations, board layout, and camera logic remain intact and framing is preserved. 

### Testing
- Ran `npm run build` which executes `tsc` and completed successfully. 
- Ran `npx eslint webapp/src/pages/Games/LudoBattleRoyal.jsx webapp/src/utils/murlanTable.js`, which returned only ignore warnings due to repository eslint ignore rules and no lint errors were reported. 
- No automated visual tests were run in this change; behavior relies on constant adjustments and should be validated in a visual device/emulator to confirm final framing and grounding.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9073e8c90832989852f8c6afbc83e)