### PR TITLE
Scale down Ludo Battle Royal table setup by ~30%

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -490,8 +490,8 @@ let proceduralTokenHeight = null;
 
 const BASE_ARENA_SCALE = 0.85;
 // Keep the exact layout, but make the full table setup (table + board + chairs + attached animations)
-// slightly smaller in world space.
-const LUDO_ARENA_SHRINK_FACTOR = 0.84;
+// ~30% smaller in world space while preserving the exact relative layout.
+const LUDO_ARENA_SHRINK_FACTOR = 0.7;
 const ARENA_SCALE = 0.72 * LUDO_ARENA_SHRINK_FACTOR;
 const ARENA_SCALE_RATIO = ARENA_SCALE / BASE_ARENA_SCALE;
 const MODEL_SCALE = 0.75 * ARENA_SCALE;


### PR DESCRIPTION
### Motivation
- Reduce the rendered size of the Ludo Battle Royal table, chairs, board and attached animations by about 30% while keeping the exact same layout and proportions.

### Description
- Updated `LUDO_ARENA_SHRINK_FACTOR` from `0.84` to `0.7` in `webapp/src/pages/Games/LudoBattleRoyal.jsx` so all dependent scale constants (table, chairs, board, pieces, animations) are uniformly reduced.
- Clarified the inline comment to state the intent: an approximate 30% shrink while preserving relative layout.

### Testing
- Ran `npx eslint webapp/src/pages/Games/LudoBattleRoyal.jsx`, which completed successfully but reported the file is ignored by current ignore patterns (warning only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d90ed52fe48329b29fd25d0b674078)