### PR TITLE
Use jet for rook/bishop captures and reduce missile visuals by ~50%

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -100,6 +100,7 @@ const CAPTURE_JET_MISSILE_TRAVEL_2 = 1.65;
 const CAPTURE_GROUND_FIRE_TIME = 1.2;
 const CAPTURE_GROUND_TRAVEL_TIME = 2.3;
 const CAPTURE_GROUND_TOTAL = CAPTURE_GROUND_FIRE_TIME + CAPTURE_GROUND_TRAVEL_TIME;
+const CAPTURE_MISSILE_SCALE = 0.31; // 50% smaller than previous 0.62 scale.
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
 const BASIS_TRANSCODER_PATH = 'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/';
 
@@ -8170,22 +8171,30 @@ function Chess3D({
     const playCaptureAnimation = ({ fromPos, targetPos, movingType, distance, deltaR = 0, deltaC = 0 }) => {
       const pieceType = (movingType || '').toUpperCase();
       if (pieceType === 'B' || pieceType === 'R') {
-        const droneFx = createFxDrone();
-        droneFx.root.scale.setScalar(0.5);
-        droneFx.root.position.copy(fromPos).add(new THREE.Vector3(0, 0.32, 0));
-        captureFxGroup.add(droneFx.root);
-        playAudio(droneSoundRef, { maxDurationMs: CAPTURE_DRONE_TOTAL * 1000 });
+        const jetFx = createFxJet();
+        jetFx.root.scale.setScalar(0.58);
+        jetFx.root.position.copy(fromPos).add(new THREE.Vector3(0, 1.4, 0));
+        captureFxGroup.add(jetFx.root);
+        const missileFx1 = createFxMissile();
+        const missileFx2 = createFxMissile();
+        missileFx1.root.scale.setScalar(CAPTURE_MISSILE_SCALE);
+        missileFx2.root.scale.setScalar(CAPTURE_MISSILE_SCALE);
+        missileFx1.root.visible = false;
+        missileFx2.root.visible = false;
+        captureFxGroup.add(missileFx1.root);
+        captureFxGroup.add(missileFx2.root);
+        playAudio({ current: jetFlySound }, { maxDurationMs: CAPTURE_JET_TOTAL * 1000 });
         activeCaptureFx.push({
-          type: 'drone',
+          type: 'jet',
           t: 0,
-          duration: CAPTURE_DRONE_TOTAL,
+          duration: CAPTURE_JET_TOTAL,
           from: fromPos.clone(),
-          lift: fromPos.clone().lerp(targetPos, 0.2).add(new THREE.Vector3(0, 1.25, 0.35)),
-          cruise: fromPos.clone().lerp(targetPos, 0.64).add(new THREE.Vector3(0, 1.48, 0.1)),
           to: targetPos.clone(),
-          droneFx
+          jetFx,
+          missileFx1,
+          missileFx2
         });
-        return { moveDelayMs: CAPTURE_DRONE_TOTAL * 1000 };
+        return { moveDelayMs: CAPTURE_JET_TOTAL * 1000 };
       }
       if (pieceType === 'Q') {
         const jetFx = createFxJet();
@@ -8194,8 +8203,8 @@ function Chess3D({
         captureFxGroup.add(jetFx.root);
         const missileFx1 = createFxMissile();
         const missileFx2 = createFxMissile();
-        missileFx1.root.scale.setScalar(0.62);
-        missileFx2.root.scale.setScalar(0.62);
+        missileFx1.root.scale.setScalar(CAPTURE_MISSILE_SCALE);
+        missileFx2.root.scale.setScalar(CAPTURE_MISSILE_SCALE);
         missileFx1.root.visible = false;
         missileFx2.root.visible = false;
         captureFxGroup.add(missileFx1.root);
@@ -8215,7 +8224,7 @@ function Chess3D({
       }
       if (pieceType === 'N' || pieceType === 'K' || pieceType === 'P') {
         const missileFx = createFxGroundMissile();
-        missileFx.root.scale.setScalar(0.62);
+        missileFx.root.scale.setScalar(CAPTURE_MISSILE_SCALE);
         missileFx.root.visible = false;
         captureFxGroup.add(missileFx.root);
         playAudio(missileLaunchSoundRef);
@@ -8240,7 +8249,7 @@ function Chess3D({
       if (distance >= 2) {
         playAudio(missileLaunchSoundRef);
         const missileFx = createFxMissile();
-        missileFx.root.scale.setScalar(0.62);
+        missileFx.root.scale.setScalar(CAPTURE_MISSILE_SCALE);
         captureFxGroup.add(missileFx.root);
         activeCaptureFx.push({ type: 'missile', t: 0, duration: 1.25, from: fromPos.clone(), to: targetPos.clone(), missileFx });
         return { moveDelayMs: 1250 };


### PR DESCRIPTION
### Motivation
- Make the capture visual language match the requested design where the previous "drone" appearance becomes a jet for heavier captures. 
- Reduce visual size of all missile FX so missiles appear about 50% smaller and better scaled to the scene.

### Description
- Added a shared constant `CAPTURE_MISSILE_SCALE` and applied it to jet missiles, ground missiles, and long-range missiles so missile meshes render at the new smaller scale.
- Replaced the drone-based capture path for bishops/rooks with the jet sequence (createFxJet + paired missiles) and updated the active FX object to reference the jet and its missiles.
- Updated missile scaling in the queen, ground-javelin, and ranged-missile branches so all missile types use `CAPTURE_MISSILE_SCALE` while keeping existing timing and sound behavior.
- Modified only `webapp/src/pages/Games/ChessBattleRoyal.jsx` (capture FX logic and related constants) to implement the changes.

### Testing
- Ran the production build with `npm --prefix webapp run build` and the build completed successfully (Vite produced only non-blocking warnings about chunking). 
- Built assets were emitted (dist bundle) and no runtime test failures were reported during the build step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d90f5c26088329987a43f40b3671cf)