### PR TITLE
Adjust Ludo arena scale, chair size, and token/dice/table base alignment

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -491,13 +491,14 @@ let proceduralTokenHeight = null;
 const BASE_ARENA_SCALE = 0.85;
 // Keep the exact layout, but make the full table setup (table + board + chairs + attached animations)
 // ~30% smaller in world space while preserving the exact relative layout.
-const LUDO_ARENA_SHRINK_FACTOR = 0.7;
+const LUDO_ARENA_SHRINK_FACTOR = 0.64;
 const ARENA_SCALE = 0.72 * LUDO_ARENA_SHRINK_FACTOR;
 const ARENA_SCALE_RATIO = ARENA_SCALE / BASE_ARENA_SCALE;
 const MODEL_SCALE = 0.75 * ARENA_SCALE;
 const TABLE_RADIUS = 3.18 * MODEL_SCALE;
 const BASE_TABLE_HEIGHT = 1.08 * MODEL_SCALE;
-const STOOL_SCALE = 1.5 * 1.3;
+const CHAIR_GLOBAL_SCALE = 0.8;
+const STOOL_SCALE = 1.5 * 1.3 * CHAIR_GLOBAL_SCALE;
 const SEAT_WIDTH = 0.9 * MODEL_SCALE * STOOL_SCALE;
 const SEAT_DEPTH = 0.95 * MODEL_SCALE * STOOL_SCALE;
 const SEAT_THICKNESS = 0.09 * MODEL_SCALE * STOOL_SCALE;
@@ -539,7 +540,7 @@ const ANIMATION_BASE_FPS = 60;
 const MIN_ANIMATION_SPEED_MULTIPLIER = 0.62;
 const MAX_ANIMATION_SPEED_MULTIPLIER = 1.2;
 const AVATAR_ANCHOR_HEIGHT = SEAT_THICKNESS / 2 + BACK_HEIGHT * 0.85;
-const CHAIR_SIZE_SCALE = 1;
+const CHAIR_SIZE_SCALE = CHAIR_GLOBAL_SCALE;
 const CHAIR_MODEL_URLS = [
   'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AntiqueChair/glTF-Binary/AntiqueChair.glb',
   'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/SheenChair/glTF-Binary/SheenChair.glb',
@@ -1977,9 +1978,9 @@ const PLAYER_COLOR_ORDER = Object.freeze([0, 1, 2, 3]);
 const DEFAULT_PLAYER_COLORS = Object.freeze(
   PLAYER_COLOR_ORDER.map((boardIndex) => BOARD_COLORS[boardIndex])
 );
-const TOKEN_TRACK_SURFACE_OFFSET = 0.002;
-const TOKEN_HOME_SURFACE_OFFSET = 0.008;
-const TOKEN_GOAL_SURFACE_OFFSET = 0.0065;
+const TOKEN_TRACK_SURFACE_OFFSET = 0.001;
+const TOKEN_HOME_SURFACE_OFFSET = 0.0045;
+const TOKEN_GOAL_SURFACE_OFFSET = 0.0042;
 const TOKEN_TRACK_HEIGHT = PLAYFIELD_HEIGHT + TOKEN_TRACK_SURFACE_OFFSET;
 const TOKEN_HOME_HEIGHT = PLAYFIELD_HEIGHT + TOKEN_HOME_SURFACE_OFFSET;
 const TOKEN_GOAL_HEIGHT = PLAYFIELD_HEIGHT + TOKEN_GOAL_SURFACE_OFFSET;
@@ -1997,9 +1998,10 @@ const TOKEN_RAIL_CENTER_PULL_PER_PLAYER = Object.freeze([
   0.098,
   0.092
 ]);
-const TOKEN_RAIL_HEIGHT_LIFT = 0.0002;
-const NON_OCTAGON_TOKEN_SURFACE_OFFSET = -0.006;
+const TOKEN_RAIL_HEIGHT_LIFT = 0;
+const NON_OCTAGON_TOKEN_SURFACE_OFFSET = -0.0075;
 let tokenSurfaceOffset = 0;
+const TOKEN_FRONT_OUTWARD_SHIFT = 0.022;
 const TOKEN_MOVE_SPEED = 2.45;
 const TOKEN_STEP_DURATION_SECONDS = 0.34;
 const LUDO_CAPTURE_MISSILE_LAUNCH_SOUND_URL = '/assets/sounds/launch-85216.mp3';
@@ -2057,7 +2059,7 @@ const DICE_PIP_RADIUS = DICE_SIZE * 0.093;
 const DICE_PIP_DEPTH = DICE_SIZE * 0.018;
 const DICE_PIP_SPREAD = DICE_SIZE * 0.3;
 const DICE_FACE_INSET = DICE_SIZE * 0.064;
-const DICE_BASE_HEIGHT = DICE_SIZE / 2 + 0.047;
+const DICE_BASE_HEIGHT = DICE_SIZE / 2 + 0.039;
 const DICE_PIP_RIM_INNER = DICE_PIP_RADIUS * 0.78;
 const DICE_PIP_RIM_OUTER = DICE_PIP_RADIUS * 1.08;
 const DICE_PIP_RIM_OFFSET = DICE_SIZE * 0.0048;
@@ -4262,6 +4264,10 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       const baseForwardShift = TOKEN_RAIL_BASE_FORWARD_SHIFT[player] ?? 0;
       if (baseForwardShift !== 0) {
         base.add(forward.clone().multiplyScalar(baseForwardShift));
+      }
+
+      if (TOKEN_FRONT_OUTWARD_SHIFT !== 0) {
+        base.add(forward.clone().multiplyScalar(TOKEN_FRONT_OUTWARD_SHIFT));
       }
 
       const forwardOffset = forward.clone().multiplyScalar(RAIL_TOKEN_FORWARD_SPACING);

--- a/webapp/src/utils/murlanTable.js
+++ b/webapp/src/utils/murlanTable.js
@@ -563,11 +563,11 @@ export function createMurlanStyleTable({
   const clothRise = 0.07 * scaleFactor;
   let baseHeight = 0.38 * scaleFactor;
   const tableY = tableHeight - clothRise;
-  const baseLift = 0.03 * scaleFactor;
+  const baseLift = 0.02 * scaleFactor;
   const minBaseHeight = 0.2 * scaleFactor;
   const maxBaseHeight = Math.max(minBaseHeight, tableY + baseLift);
   // Keep table-top height unchanged while extending the pedestal downward a bit more so the base reaches the ground cleanly.
-  baseHeight = maxBaseHeight * 1.14;
+  baseHeight = maxBaseHeight * 1.24;
 
   const baseMat = includeBase
     ? new ThreeNamespace.MeshPhysicalMaterial({


### PR DESCRIPTION
### Motivation
- Make the Ludo battle-royale scene visually match the requested layout: smaller table/board, chairs ~20% smaller, tokens and dice sit closer to the table surface, front tokens moved slightly outward, and procedural table pedestal extended downwards so legs better reach the ground.

### Description
- Reduced overall arena/table scale by changing `LUDO_ARENA_SHRINK_FACTOR` from `0.7` to `0.64` in `webapp/src/pages/Games/LudoBattleRoyal.jsx` so the table/board render smaller on screen.
- Added a global chair scale (`CHAIR_GLOBAL_SCALE = 0.8`) and applied it to procedural/imported chair sizing by updating `STOOL_SCALE` and `CHAIR_SIZE_SCALE` in `webapp/src/pages/Games/LudoBattleRoyal.jsx` to make chairs ~20% smaller.
- Lowered token/dice resting heights by adjusting `TOKEN_TRACK_SURFACE_OFFSET`, `TOKEN_HOME_SURFACE_OFFSET`, `TOKEN_GOAL_SURFACE_OFFSET`, `NON_OCTAGON_TOKEN_SURFACE_OFFSET`, `TOKEN_RAIL_HEIGHT_LIFT`, and `DICE_BASE_HEIGHT` in `webapp/src/pages/Games/LudoBattleRoyal.jsx` so tokens and dice sit closer to the table surface.
- Nudged front token rails outward by adding `TOKEN_FRONT_OUTWARD_SHIFT = 0.022` and applying it in the rail layout code in `webapp/src/pages/Games/LudoBattleRoyal.jsx` so tokens in front of players move slightly outward.
- Extended the procedural table base so the pedestal reaches the ground more cleanly by lowering `baseLift` and increasing the applied pedestal stretch (`baseHeight = maxBaseHeight * 1.24`) in `webapp/src/utils/murlanTable.js`.

### Testing
- Ran a production build with `cd webapp && npm run -s build` and the build completed successfully (Vite produced non-blocking chunk-size / dynamic-import warnings that existed previously).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d911dcfe3483298c29ecc8de9503e7)