### PR TITLE
Adjust Ludo arena proportions and piece/table grounding

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -491,13 +491,13 @@ let proceduralTokenHeight = null;
 const BASE_ARENA_SCALE = 0.85;
 // Keep the exact layout, but make the full table setup (table + board + chairs + attached animations)
 // ~30% smaller in world space while preserving the exact relative layout.
-const LUDO_ARENA_SHRINK_FACTOR = 0.64;
+const LUDO_ARENA_SHRINK_FACTOR = 0.6;
 const ARENA_SCALE = 0.72 * LUDO_ARENA_SHRINK_FACTOR;
 const ARENA_SCALE_RATIO = ARENA_SCALE / BASE_ARENA_SCALE;
 const MODEL_SCALE = 0.75 * ARENA_SCALE;
 const TABLE_RADIUS = 3.18 * MODEL_SCALE;
 const BASE_TABLE_HEIGHT = 1.08 * MODEL_SCALE;
-const CHAIR_GLOBAL_SCALE = 0.8;
+const CHAIR_GLOBAL_SCALE = 0.64;
 const STOOL_SCALE = 1.5 * 1.3 * CHAIR_GLOBAL_SCALE;
 const SEAT_WIDTH = 0.9 * MODEL_SCALE * STOOL_SCALE;
 const SEAT_DEPTH = 0.95 * MODEL_SCALE * STOOL_SCALE;
@@ -626,6 +626,7 @@ const DEFAULT_CLOTH_OPTION = TABLE_CLOTH_OPTIONS[0];
 const DEFAULT_BASE_OPTION = TABLE_BASE_OPTIONS[0];
 const TABLE_MODEL_TARGET_DIAMETER = TABLE_RADIUS * 2;
 const TABLE_MODEL_TARGET_HEIGHT = TABLE_HEIGHT;
+const TABLE_LEG_EXTENSION_FACTOR = 1.08;
 const BASIS_TRANSCODER_PATH = 'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/';
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
 const PREFERRED_TEXTURE_SIZES = ['4k', '2k', '1k'];
@@ -1440,9 +1441,15 @@ function fitTableModelToArena(model, tableThemeId = null) {
   if (scaleY !== 1 || scaleXZ !== 1) {
     model.scale.set(model.scale.x * scaleXZ, model.scale.y * scaleY, model.scale.z * scaleXZ);
   }
+  if (TABLE_LEG_EXTENSION_FACTOR !== 1) {
+    const stretchedScaleY = model.scale.y * TABLE_LEG_EXTENSION_FACTOR;
+    model.scale.set(model.scale.x, stretchedScaleY, model.scale.z);
+  }
   const scaledBox = new THREE.Box3().setFromObject(model);
   const center = scaledBox.getCenter(new THREE.Vector3());
-  model.position.add(new THREE.Vector3(-center.x, -scaledBox.min.y, -center.z));
+  const topAfterStretch = scaledBox.max.y;
+  const topCorrection = targetHeight - topAfterStretch;
+  model.position.add(new THREE.Vector3(-center.x, -scaledBox.min.y + topCorrection, -center.z));
   const recenteredBox = new THREE.Box3().setFromObject(model);
   const radius = Math.max(
     Math.abs(recenteredBox.max.x),
@@ -1978,9 +1985,9 @@ const PLAYER_COLOR_ORDER = Object.freeze([0, 1, 2, 3]);
 const DEFAULT_PLAYER_COLORS = Object.freeze(
   PLAYER_COLOR_ORDER.map((boardIndex) => BOARD_COLORS[boardIndex])
 );
-const TOKEN_TRACK_SURFACE_OFFSET = 0.001;
-const TOKEN_HOME_SURFACE_OFFSET = 0.0045;
-const TOKEN_GOAL_SURFACE_OFFSET = 0.0042;
+const TOKEN_TRACK_SURFACE_OFFSET = -0.001;
+const TOKEN_HOME_SURFACE_OFFSET = 0.002;
+const TOKEN_GOAL_SURFACE_OFFSET = 0.0018;
 const TOKEN_TRACK_HEIGHT = PLAYFIELD_HEIGHT + TOKEN_TRACK_SURFACE_OFFSET;
 const TOKEN_HOME_HEIGHT = PLAYFIELD_HEIGHT + TOKEN_HOME_SURFACE_OFFSET;
 const TOKEN_GOAL_HEIGHT = PLAYFIELD_HEIGHT + TOKEN_GOAL_SURFACE_OFFSET;
@@ -2001,7 +2008,7 @@ const TOKEN_RAIL_CENTER_PULL_PER_PLAYER = Object.freeze([
 const TOKEN_RAIL_HEIGHT_LIFT = 0;
 const NON_OCTAGON_TOKEN_SURFACE_OFFSET = -0.0075;
 let tokenSurfaceOffset = 0;
-const TOKEN_FRONT_OUTWARD_SHIFT = 0.022;
+const TOKEN_FRONT_OUTWARD_SHIFT = 0.036;
 const TOKEN_MOVE_SPEED = 2.45;
 const TOKEN_STEP_DURATION_SECONDS = 0.34;
 const LUDO_CAPTURE_MISSILE_LAUNCH_SOUND_URL = '/assets/sounds/launch-85216.mp3';
@@ -2059,7 +2066,7 @@ const DICE_PIP_RADIUS = DICE_SIZE * 0.093;
 const DICE_PIP_DEPTH = DICE_SIZE * 0.018;
 const DICE_PIP_SPREAD = DICE_SIZE * 0.3;
 const DICE_FACE_INSET = DICE_SIZE * 0.064;
-const DICE_BASE_HEIGHT = DICE_SIZE / 2 + 0.039;
+const DICE_BASE_HEIGHT = DICE_SIZE / 2 + 0.029;
 const DICE_PIP_RIM_INNER = DICE_PIP_RADIUS * 0.78;
 const DICE_PIP_RIM_OUTER = DICE_PIP_RADIUS * 1.08;
 const DICE_PIP_RIM_OFFSET = DICE_SIZE * 0.0048;


### PR DESCRIPTION
### Motivation
- Improve on-screen proportions so the Ludo table+board reads smaller and tokens/dice sit visually closer to the table while chairs become ~20% smaller and table legs extend downward.

### Description
- Modified scene/layout constants in `webapp/src/pages/Games/LudoBattleRoyal.jsx`: set `LUDO_ARENA_SHRINK_FACTOR` to `0.6`, `CHAIR_GLOBAL_SCALE` to `0.64`, increased `TOKEN_FRONT_OUTWARD_SHIFT` to `0.036`, lowered `DICE_BASE_HEIGHT` to `DICE_SIZE / 2 + 0.029`, and adjusted `TOKEN_TRACK_SURFACE_OFFSET`, `TOKEN_HOME_SURFACE_OFFSET`, and `TOKEN_GOAL_SURFACE_OFFSET` to bring pieces closer to the surface.
- Added `TABLE_LEG_EXTENSION_FACTOR = 1.08` and applied a controlled vertical stretch in `fitTableModelToArena` so table legs extend downward while the tabletop top is corrected back to the target surface height.
- Token/dice positioning and rail layout now consume the updated constants so front tokens are pushed slightly outward and dice/rails are placed at the lowered heights.
- Change scope is limited to `webapp/src/pages/Games/LudoBattleRoyal.jsx` (constants and table-fit logic).

### Testing
- Built the webapp production bundle with `npm --prefix webapp run -s build`, which completed successfully (Vite emitted existing chunk-size warnings but no errors).
- No automated unit tests were changed or executed as part of this PR; visual verification was not automated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d91527c04083299e9f58a7b4ffa933)