### PR TITLE
Adjust Ludo Battle Royal arena scale and piece/table alignment

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -489,15 +489,16 @@ const ABG_COLOR_B = /\b(black|ebony|dark|b)\b/i;
 let proceduralTokenHeight = null;
 
 const BASE_ARENA_SCALE = 0.85;
-// Keep the exact layout, but make the full table setup (table + board + chairs + attached animations)
-// ~30% smaller in world space while preserving the exact relative layout.
-const LUDO_ARENA_SHRINK_FACTOR = 0.6;
+// Keep the exact layout, but scale down the whole arena (table + board + chairs + attached animations)
+// so it appears smaller on screen while preserving the relative placement.
+const LUDO_ARENA_SHRINK_FACTOR = 0.55;
 const ARENA_SCALE = 0.72 * LUDO_ARENA_SHRINK_FACTOR;
 const ARENA_SCALE_RATIO = ARENA_SCALE / BASE_ARENA_SCALE;
 const MODEL_SCALE = 0.75 * ARENA_SCALE;
 const TABLE_RADIUS = 3.18 * MODEL_SCALE;
 const BASE_TABLE_HEIGHT = 1.08 * MODEL_SCALE;
-const CHAIR_GLOBAL_SCALE = 0.64;
+// Chairs requested to be ~20% smaller than the current setup.
+const CHAIR_GLOBAL_SCALE = 0.512;
 const STOOL_SCALE = 1.5 * 1.3 * CHAIR_GLOBAL_SCALE;
 const SEAT_WIDTH = 0.9 * MODEL_SCALE * STOOL_SCALE;
 const SEAT_DEPTH = 0.95 * MODEL_SCALE * STOOL_SCALE;
@@ -626,7 +627,8 @@ const DEFAULT_CLOTH_OPTION = TABLE_CLOTH_OPTIONS[0];
 const DEFAULT_BASE_OPTION = TABLE_BASE_OPTIONS[0];
 const TABLE_MODEL_TARGET_DIAMETER = TABLE_RADIUS * 2;
 const TABLE_MODEL_TARGET_HEIGHT = TABLE_HEIGHT;
-const TABLE_LEG_EXTENSION_FACTOR = 1.08;
+// Stretch the lower table section further downward so legs/base reach the floor more reliably.
+const TABLE_LEG_EXTENSION_FACTOR = 1.2;
 const BASIS_TRANSCODER_PATH = 'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/';
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
 const PREFERRED_TEXTURE_SIZES = ['4k', '2k', '1k'];
@@ -1985,9 +1987,10 @@ const PLAYER_COLOR_ORDER = Object.freeze([0, 1, 2, 3]);
 const DEFAULT_PLAYER_COLORS = Object.freeze(
   PLAYER_COLOR_ORDER.map((boardIndex) => BOARD_COLORS[boardIndex])
 );
-const TOKEN_TRACK_SURFACE_OFFSET = -0.001;
-const TOKEN_HOME_SURFACE_OFFSET = 0.002;
-const TOKEN_GOAL_SURFACE_OFFSET = 0.0018;
+// Lower token resting heights so pieces visually touch the board/table surface.
+const TOKEN_TRACK_SURFACE_OFFSET = -0.0045;
+const TOKEN_HOME_SURFACE_OFFSET = -0.0015;
+const TOKEN_GOAL_SURFACE_OFFSET = -0.0015;
 const TOKEN_TRACK_HEIGHT = PLAYFIELD_HEIGHT + TOKEN_TRACK_SURFACE_OFFSET;
 const TOKEN_HOME_HEIGHT = PLAYFIELD_HEIGHT + TOKEN_HOME_SURFACE_OFFSET;
 const TOKEN_GOAL_HEIGHT = PLAYFIELD_HEIGHT + TOKEN_GOAL_SURFACE_OFFSET;
@@ -2008,7 +2011,8 @@ const TOKEN_RAIL_CENTER_PULL_PER_PLAYER = Object.freeze([
 const TOKEN_RAIL_HEIGHT_LIFT = 0;
 const NON_OCTAGON_TOKEN_SURFACE_OFFSET = -0.0075;
 let tokenSurfaceOffset = 0;
-const TOKEN_FRONT_OUTWARD_SHIFT = 0.036;
+// Push front rail tokens a bit farther outward from the table edge.
+const TOKEN_FRONT_OUTWARD_SHIFT = 0.05;
 const TOKEN_MOVE_SPEED = 2.45;
 const TOKEN_STEP_DURATION_SECONDS = 0.34;
 const LUDO_CAPTURE_MISSILE_LAUNCH_SOUND_URL = '/assets/sounds/launch-85216.mp3';
@@ -2066,7 +2070,8 @@ const DICE_PIP_RADIUS = DICE_SIZE * 0.093;
 const DICE_PIP_DEPTH = DICE_SIZE * 0.018;
 const DICE_PIP_SPREAD = DICE_SIZE * 0.3;
 const DICE_FACE_INSET = DICE_SIZE * 0.064;
-const DICE_BASE_HEIGHT = DICE_SIZE / 2 + 0.029;
+// Lower dice so they sit closer to (and visually touch) the table surface.
+const DICE_BASE_HEIGHT = DICE_SIZE / 2 + 0.022;
 const DICE_PIP_RIM_INNER = DICE_PIP_RADIUS * 0.78;
 const DICE_PIP_RIM_OUTER = DICE_PIP_RADIUS * 1.08;
 const DICE_PIP_RIM_OFFSET = DICE_SIZE * 0.0048;


### PR DESCRIPTION
### Motivation
- Make the Ludo Battle Royal arena match the requested visual adjustments: overall table/board smaller on screen, chairs ~20% smaller, tokens and dice lowered to touch the table surface, front tokens shifted slightly outward, and table legs extended downward.

### Description
- Updated arena/chair/table/token/dice tuning constants in `webapp/src/pages/Games/LudoBattleRoyal.jsx` to implement the visual changes: `LUDO_ARENA_SHRINK_FACTOR` -> `0.55`, `CHAIR_GLOBAL_SCALE` -> `0.512`, `TABLE_LEG_EXTENSION_FACTOR` -> `1.2`, token surface offsets `TOKEN_TRACK_SURFACE_OFFSET`, `TOKEN_HOME_SURFACE_OFFSET`, `TOKEN_GOAL_SURFACE_OFFSET` lowered, `TOKEN_FRONT_OUTWARD_SHIFT` increased to `0.05`, and `DICE_BASE_HEIGHT` reduced to bring dice closer to the table surface.
- Kept all layout math and relative placement unchanged so the arena preserves existing relationships while appearing smaller and better aligned with the table surface.

### Testing
- Ran `npx eslint webapp/src/pages/Games/LudoBattleRoyal.jsx`; the run completed and reported only an ignore-pattern warning from repo config and no lint errors.
- Ran `npx eslint --no-ignore webapp/src/pages/Games/LudoBattleRoyal.jsx`; the run completed with the same ignore-pattern warning and no lint errors.
- No automated unit tests were run for this change in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9197ed4788329b13c39ee6adf5168)