### PR TITLE
Reduce capture FX size, align timing with Ludo missile sequence, and fix impact alignment in Chess Battle Royal

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -88,19 +88,23 @@ const clamp01 = (value, fallback = 0) => {
 const smoothEase = (t) => t * t * (3 - 2 * t);
 const FORWARD = new THREE.Vector3(1, 0, 0);
 const WORLD_UP = new THREE.Vector3(0, 1, 0);
-const CAPTURE_DRONE_LIFT_TIME = 2.0;
-const CAPTURE_DRONE_CRUISE_TIME = 2.8;
-const CAPTURE_DRONE_DIVE_TIME = 1.7;
+const LUDO_CAPTURE_MISSILE_TRAVEL_TIME = 1.85;
+const LUDO_CAPTURE_EXPLOSION_TIME = 0.92;
+const LUDO_CAPTURE_TOTAL_TIME = LUDO_CAPTURE_MISSILE_TRAVEL_TIME + LUDO_CAPTURE_EXPLOSION_TIME;
+const CAPTURE_DRONE_LIFT_TIME = LUDO_CAPTURE_TOTAL_TIME * (2.0 / 6.5);
+const CAPTURE_DRONE_CRUISE_TIME = LUDO_CAPTURE_TOTAL_TIME * (2.8 / 6.5);
+const CAPTURE_DRONE_DIVE_TIME = LUDO_CAPTURE_TOTAL_TIME * (1.7 / 6.5);
 const CAPTURE_DRONE_TOTAL = CAPTURE_DRONE_LIFT_TIME + CAPTURE_DRONE_CRUISE_TIME + CAPTURE_DRONE_DIVE_TIME;
-const CAPTURE_JET_TOTAL = 9.2;
-const CAPTURE_JET_MISSILE_DROP_1 = 2.25;
-const CAPTURE_JET_MISSILE_DROP_2 = 2.75;
-const CAPTURE_JET_MISSILE_TRAVEL_1 = 1.45;
-const CAPTURE_JET_MISSILE_TRAVEL_2 = 1.65;
-const CAPTURE_GROUND_FIRE_TIME = 1.2;
-const CAPTURE_GROUND_TRAVEL_TIME = 2.3;
+const CAPTURE_JET_TOTAL = LUDO_CAPTURE_TOTAL_TIME;
+const CAPTURE_JET_MISSILE_DROP_1 = CAPTURE_JET_TOTAL * (2.25 / 9.2);
+const CAPTURE_JET_MISSILE_DROP_2 = CAPTURE_JET_TOTAL * (2.75 / 9.2);
+const CAPTURE_JET_MISSILE_TRAVEL_1 = CAPTURE_JET_TOTAL * (1.45 / 9.2);
+const CAPTURE_JET_MISSILE_TRAVEL_2 = CAPTURE_JET_TOTAL * (1.65 / 9.2);
+const CAPTURE_GROUND_FIRE_TIME = LUDO_CAPTURE_TOTAL_TIME * (1.2 / 3.5);
+const CAPTURE_GROUND_TRAVEL_TIME = LUDO_CAPTURE_TOTAL_TIME * (2.3 / 3.5);
 const CAPTURE_GROUND_TOTAL = CAPTURE_GROUND_FIRE_TIME + CAPTURE_GROUND_TRAVEL_TIME;
-const CAPTURE_MISSILE_SCALE = 0.31; // 50% smaller than previous 0.62 scale.
+const CAPTURE_JET_SCALE = 0.29; // 50% of previous 0.58.
+const CAPTURE_MISSILE_SCALE = 0.155; // 50% of previous 0.31.
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
 const BASIS_TRANSCODER_PATH = 'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/';
 
@@ -8003,6 +8007,7 @@ function Chess3D({
     };
     const createFxDrone = () => {
       const root = new THREE.Group();
+      root.scale.setScalar(0.5);
       addFxCylinder(root, 0.14, 0.19, 2.75, [0, 0, 0], [0, 0, Math.PI / 2], '#cfd3d6', 20);
       addFxCylinder(root, 0.18, 0.14, 0.48, [-1.58, 0, 0], [0, 0, Math.PI / 2], '#879095', 14);
       const nose = new THREE.Mesh(
@@ -8135,7 +8140,7 @@ function Chess3D({
     const createFxExplosion = (position) => {
       const root = new THREE.Group();
       root.position.copy(position);
-      root.scale.setScalar(0.86);
+      root.scale.setScalar(0.43);
       const flash = addFxSphere(root, 0.18, [0, 0.25, 0], '#ffe59a', 1);
       const fire = [];
       const smoke = [];
@@ -8152,7 +8157,7 @@ function Chess3D({
       captureFxGroup.add(explosion.root);
       playAudio(bombSoundRef, { maxDurationMs: 520 });
       playAudio(missileImpactSoundRef);
-      activeCaptureFx.push({ type: 'explosion', t: 0, duration: 0.8, explosion });
+      activeCaptureFx.push({ type: 'explosion', t: 0, duration: LUDO_CAPTURE_EXPLOSION_TIME, explosion });
     };
     const qBezier = (a, b, c, t) => {
       const ab = new THREE.Vector3().copy(a).lerp(b, t);
@@ -8172,7 +8177,7 @@ function Chess3D({
       const pieceType = (movingType || '').toUpperCase();
       if (pieceType === 'B' || pieceType === 'R') {
         const jetFx = createFxJet();
-        jetFx.root.scale.setScalar(0.58);
+        jetFx.root.scale.setScalar(CAPTURE_JET_SCALE);
         jetFx.root.position.copy(fromPos).add(new THREE.Vector3(0, 1.4, 0));
         captureFxGroup.add(jetFx.root);
         const missileFx1 = createFxMissile();
@@ -8198,7 +8203,7 @@ function Chess3D({
       }
       if (pieceType === 'Q') {
         const jetFx = createFxJet();
-        jetFx.root.scale.setScalar(0.58);
+        jetFx.root.scale.setScalar(CAPTURE_JET_SCALE);
         jetFx.root.position.copy(fromPos).add(new THREE.Vector3(0, 1.4, 0));
         captureFxGroup.add(jetFx.root);
         const missileFx1 = createFxMissile();
@@ -8251,8 +8256,8 @@ function Chess3D({
         const missileFx = createFxMissile();
         missileFx.root.scale.setScalar(CAPTURE_MISSILE_SCALE);
         captureFxGroup.add(missileFx.root);
-        activeCaptureFx.push({ type: 'missile', t: 0, duration: 1.25, from: fromPos.clone(), to: targetPos.clone(), missileFx });
-        return { moveDelayMs: 1250 };
+        activeCaptureFx.push({ type: 'missile', t: 0, duration: LUDO_CAPTURE_MISSILE_TRAVEL_TIME, from: fromPos.clone(), to: targetPos.clone(), missileFx });
+        return { moveDelayMs: LUDO_CAPTURE_TOTAL_TIME * 1000 };
       }
       launchExplosion(targetPos.clone());
       return { moveDelayMs: 280 };
@@ -9790,8 +9795,8 @@ function Chess3D({
               }
             };
 
-            const target1 = fx.to.clone().add(new THREE.Vector3(-0.26, 0, 0.2));
-            const target2 = fx.to.clone().add(new THREE.Vector3(0.22, 0, -0.15));
+            const target1 = fx.to.clone();
+            const target2 = fx.to.clone();
             updateJetMissileFx(fx.missileFx1, CAPTURE_JET_MISSILE_DROP_1, CAPTURE_JET_MISSILE_TRAVEL_1, -1.15, target1);
             updateJetMissileFx(fx.missileFx2, CAPTURE_JET_MISSILE_DROP_2, CAPTURE_JET_MISSILE_TRAVEL_2, 1.15, target2, 0.04);
 


### PR DESCRIPTION
### Motivation
- Bring Chess capture animation timing in line with the Ludo missile sequence so multi-game FX feel consistent. 
- Make drone, jet, missile and explosion visuals ~50% smaller to match requested scale and reduce visual clutter. 
- Ensure explosions occur exactly at the target position instead of slightly offset to improve visual accuracy.

### Description
- Updated timing to use Ludo-derived constants: added `LUDO_CAPTURE_MISSILE_TRAVEL_TIME`, `LUDO_CAPTURE_EXPLOSION_TIME`, and `LUDO_CAPTURE_TOTAL_TIME`, and derived drone/jet/ground phase timings from them in `webapp/src/pages/Games/ChessBattleRoyal.jsx`.
- Reduced FX scales by ~50% by setting `root.scale.setScalar(0.5)` for the drone, `CAPTURE_JET_SCALE = 0.29`, `CAPTURE_MISSILE_SCALE = 0.155`, and `explosion.root.scale` from `0.86` to `0.43`.
- Aligned durations and move delays to the new shared timing: jet and missile durations now use the Ludo-based totals and `moveDelayMs` is returned based on `LUDO_CAPTURE_TOTAL_TIME` for missiles and jets.
- Fixed jet missile impact alignment by removing lateral offsets and using `fx.to.clone()` for both jet missiles so explosions trigger at the exact target position.

### Testing
- Ran `npx eslint webapp/src/pages/Games/ChessBattleRoyal.jsx` and `npx eslint --no-ignore webapp/src/pages/Games/ChessBattleRoyal.jsx`, which completed but reported the file is ignored by project ESLint settings (warning only).
- No unit tests were run for this change in this rollout; changes were committed with the message `Adjust chess battle capture FX scale, impact position, and timing`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9144509688329a92154eecfdb4674)