### PR TITLE
Adjust Ludo arena sizing and table/chair/token positioning

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -491,14 +491,14 @@ let proceduralTokenHeight = null;
 const BASE_ARENA_SCALE = 0.85;
 // Keep the exact layout, but scale down the whole arena (table + board + chairs + attached animations)
 // so it appears smaller on screen while preserving the relative placement.
-const LUDO_ARENA_SHRINK_FACTOR = 0.55;
+const LUDO_ARENA_SHRINK_FACTOR = 0.5;
 const ARENA_SCALE = 0.72 * LUDO_ARENA_SHRINK_FACTOR;
 const ARENA_SCALE_RATIO = ARENA_SCALE / BASE_ARENA_SCALE;
 const MODEL_SCALE = 0.75 * ARENA_SCALE;
 const TABLE_RADIUS = 3.18 * MODEL_SCALE;
 const BASE_TABLE_HEIGHT = 1.08 * MODEL_SCALE;
 // Chairs requested to be ~20% smaller than the current setup.
-const CHAIR_GLOBAL_SCALE = 0.512;
+const CHAIR_GLOBAL_SCALE = 0.4096;
 const STOOL_SCALE = 1.5 * 1.3 * CHAIR_GLOBAL_SCALE;
 const SEAT_WIDTH = 0.9 * MODEL_SCALE * STOOL_SCALE;
 const SEAT_DEPTH = 0.95 * MODEL_SCALE * STOOL_SCALE;
@@ -517,7 +517,7 @@ const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 0.85;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
 const TABLE_HEIGHT_LIFT = 0.05 * MODEL_SCALE;
 const TABLE_HEIGHT = STOOL_HEIGHT + TABLE_HEIGHT_LIFT;
-const AI_CHAIR_RADIUS = TABLE_RADIUS + SEAT_DEPTH / 2 + AI_CHAIR_GAP + 0.06 * MODEL_SCALE;
+const AI_CHAIR_RADIUS = TABLE_RADIUS + SEAT_DEPTH / 2 + AI_CHAIR_GAP + 0.2 * MODEL_SCALE;
 
 const DEFAULT_PLAYER_COUNT = 4;
 const clampPlayerCount = (value) =>
@@ -628,7 +628,7 @@ const DEFAULT_BASE_OPTION = TABLE_BASE_OPTIONS[0];
 const TABLE_MODEL_TARGET_DIAMETER = TABLE_RADIUS * 2;
 const TABLE_MODEL_TARGET_HEIGHT = TABLE_HEIGHT;
 // Stretch the lower table section further downward so legs/base reach the floor more reliably.
-const TABLE_LEG_EXTENSION_FACTOR = 1.2;
+const TABLE_LEG_EXTENSION_FACTOR = 1.35;
 const BASIS_TRANSCODER_PATH = 'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/';
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
 const PREFERRED_TEXTURE_SIZES = ['4k', '2k', '1k'];
@@ -1988,9 +1988,9 @@ const DEFAULT_PLAYER_COLORS = Object.freeze(
   PLAYER_COLOR_ORDER.map((boardIndex) => BOARD_COLORS[boardIndex])
 );
 // Lower token resting heights so pieces visually touch the board/table surface.
-const TOKEN_TRACK_SURFACE_OFFSET = -0.0045;
-const TOKEN_HOME_SURFACE_OFFSET = -0.0015;
-const TOKEN_GOAL_SURFACE_OFFSET = -0.0015;
+const TOKEN_TRACK_SURFACE_OFFSET = -0.0065;
+const TOKEN_HOME_SURFACE_OFFSET = -0.0035;
+const TOKEN_GOAL_SURFACE_OFFSET = -0.0035;
 const TOKEN_TRACK_HEIGHT = PLAYFIELD_HEIGHT + TOKEN_TRACK_SURFACE_OFFSET;
 const TOKEN_HOME_HEIGHT = PLAYFIELD_HEIGHT + TOKEN_HOME_SURFACE_OFFSET;
 const TOKEN_GOAL_HEIGHT = PLAYFIELD_HEIGHT + TOKEN_GOAL_SURFACE_OFFSET;
@@ -2012,7 +2012,7 @@ const TOKEN_RAIL_HEIGHT_LIFT = 0;
 const NON_OCTAGON_TOKEN_SURFACE_OFFSET = -0.0075;
 let tokenSurfaceOffset = 0;
 // Push front rail tokens a bit farther outward from the table edge.
-const TOKEN_FRONT_OUTWARD_SHIFT = 0.05;
+const TOKEN_FRONT_OUTWARD_SHIFT = 0.07;
 const TOKEN_MOVE_SPEED = 2.45;
 const TOKEN_STEP_DURATION_SECONDS = 0.34;
 const LUDO_CAPTURE_MISSILE_LAUNCH_SOUND_URL = '/assets/sounds/launch-85216.mp3';
@@ -2071,7 +2071,7 @@ const DICE_PIP_DEPTH = DICE_SIZE * 0.018;
 const DICE_PIP_SPREAD = DICE_SIZE * 0.3;
 const DICE_FACE_INSET = DICE_SIZE * 0.064;
 // Lower dice so they sit closer to (and visually touch) the table surface.
-const DICE_BASE_HEIGHT = DICE_SIZE / 2 + 0.022;
+const DICE_BASE_HEIGHT = DICE_SIZE / 2 + 0.01;
 const DICE_PIP_RIM_INNER = DICE_PIP_RADIUS * 0.78;
 const DICE_PIP_RIM_OUTER = DICE_PIP_RADIUS * 1.08;
 const DICE_PIP_RIM_OFFSET = DICE_SIZE * 0.0048;
@@ -3784,7 +3784,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       updateTokenSurfaceOffset(arena.tableThemeId);
 
       if (boardGroup) {
-        boardGroup.position.set(0, tableInfo.surfaceY + 0.004, 0);
+        boardGroup.position.set(0, tableInfo.surfaceY, 0);
         applyBoardGroupScale(boardGroup, tableInfo);
         tableInfo.group.add(boardGroup);
       }
@@ -4565,7 +4565,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       const arenaState = arenaRef.current;
       if (!arenaState?.tableInfo?.group) return;
       const nextBoardGroup = new THREE.Group();
-      nextBoardGroup.position.set(0, arenaState.tableInfo.surfaceY + 0.004, 0);
+      nextBoardGroup.position.set(0, arenaState.tableInfo.surfaceY, 0);
       applyBoardGroupScale(nextBoardGroup, arenaState.tableInfo);
       nextBoardGroup.rotation.y = BOARD_ROTATION_Y;
       arenaState.tableInfo.group.add(nextBoardGroup);
@@ -4865,7 +4865,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     updateTokenSurfaceOffset(tableInfo.themeId || tableTheme?.id || 'murlan-default');
 
     const boardGroup = new THREE.Group();
-    boardGroup.position.set(0, tableInfo.surfaceY + 0.004, 0);
+    boardGroup.position.set(0, tableInfo.surfaceY, 0);
     applyBoardGroupScale(boardGroup, tableInfo);
     boardGroup.rotation.y = BOARD_ROTATION_Y;
     tableInfo.group.add(boardGroup);


### PR DESCRIPTION
### Motivation
- Make the Ludo Battle Royal arena elements appear smaller on-screen and ensure tokens/dice visually contact the table surface.

### Description
- Scaled the arena down by changing `LUDO_ARENA_SHRINK_FACTOR` from `0.55` to `0.5` so the table+board footprint appears smaller (`webapp/src/pages/Games/LudoBattleRoyal.jsx`).
- Reduced chairs by ~20% via `CHAIR_GLOBAL_SCALE` (`0.512` → `0.4096`) and increased `AI_CHAIR_RADIUS` so seats sit farther from the table.
- Extended table leg stretch by increasing `TABLE_LEG_EXTENSION_FACTOR` from `1.2` to `1.35` so the lower table section reaches the floor more reliably.
- Lowered board placement by removing the prior `+0.004` vertical offset when attaching `boardGroup` to the table (updated all build/rebuild code paths).
- Adjusted piece heights and spacing by decreasing `TOKEN_*_SURFACE_OFFSET` and `DICE_BASE_HEIGHT`, and increased `TOKEN_FRONT_OUTWARD_SHIFT` (`0.05` → `0.07`) so tokens/dice visually touch the board/table and front-rail tokens move slightly outward.

### Testing
- Ran `npm -C webapp run build` which completed successfully and produced the production bundle.
- Build emitted existing Vite warnings about mixed static/dynamic imports and large chunk sizes but the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d91c1b95dc8329b81db635c0f24c99)