### PR TITLE
Tune Ludo Battle Royale table/chair sizing and token/dice alignment

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -30,8 +30,8 @@ const BASIS_TRANSCODER_PATH = 'https://cdn.jsdelivr.net/npm/three@0.164.0/exampl
 const DEFAULT_HDRI_RESOLUTIONS = ['4k'];
 
 const MODEL_SCALE = 0.75;
-const CHAIR_SIZE_SCALE = 1.3;
-const TABLE_RADIUS = 3.4 * MODEL_SCALE;
+const CHAIR_SIZE_SCALE = 1.04;
+const TABLE_RADIUS = 3.06 * MODEL_SCALE;
 const BASE_TABLE_HEIGHT = 0.94 * MODEL_SCALE;
 const STOOL_SCALE = 1.5 * 1.3 * CHAIR_SIZE_SCALE;
 const SEAT_WIDTH = 0.9 * MODEL_SCALE * STOOL_SCALE;
@@ -46,7 +46,7 @@ const BASE_COLUMN_HEIGHT = 0.5 * MODEL_SCALE * STOOL_SCALE;
 const CARD_SCALE = 0.95;
 const CARD_W = 0.4 * MODEL_SCALE * CARD_SCALE;
 const HUMAN_SEAT_ROTATION_OFFSET = Math.PI / 8;
-const AI_CHAIR_GAP = CARD_W * 0.4;
+const AI_CHAIR_GAP = CARD_W * 0.65;
 const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 1.1;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
 const TABLE_HEIGHT_LIFT = 0.025 * MODEL_SCALE;
@@ -104,7 +104,7 @@ const LEVEL_TILE_COUNTS = (() => {
 const BASE_LEVEL_TILES = PYRAMID_LEVELS[0];
 const TOTAL_BOARD_TILES = LEVEL_TILE_COUNTS.reduce((sum, count) => sum + count, 0);
 const RAW_BOARD_SIZE = 1.125;
-const BOARD_SCALE = 2.7 * 0.68 * 1.15 * 1.06; // make board footprint visibly wider
+const BOARD_SCALE = 2.7 * 0.68 * 1.15 * 1.06 * 0.9; // compact board footprint for tighter table fit
 const BOARD_DISPLAY_SIZE = RAW_BOARD_SIZE * BOARD_SCALE;
 const BOARD_RADIUS = BOARD_DISPLAY_SIZE / 2;
 
@@ -214,12 +214,12 @@ const TOKEN_MULTI_OCCUPANT_RADIUS = TILE_SIZE * 0.24 * TOKEN_RADIUS_SCALE * TOKE
 const DICE_PLAYER_EXTRA_OFFSET = TILE_SIZE * 1.8;
 const TOP_TILE_EXTRA_LEVELS = 1;
 const TOKEN_REST_RAIL_INSET_BY_SEAT = Object.freeze([
-  TILE_SIZE * 1.12,
-  TILE_SIZE * 0.86,
-  TILE_SIZE * 1.12,
-  TILE_SIZE * 0.86
+  TILE_SIZE * 0.95,
+  TILE_SIZE * 0.73,
+  TILE_SIZE * 0.95,
+  TILE_SIZE * 0.73
 ]);
-const TOKEN_REST_MIN_RADIUS = BOARD_RADIUS + TILE_SIZE * 2.72;
+const TOKEN_REST_MIN_RADIUS = BOARD_RADIUS + TILE_SIZE * 2.9;
 const TOKEN_REST_LATERAL_BY_SEAT = Object.freeze([
   -TOKEN_RADIUS * 0.08,
   TOKEN_RADIUS * 0.02,
@@ -2690,7 +2690,7 @@ function buildArena(scene, renderer, host, cameraRef, disposeHandlers, appearanc
     woodOption: resolvedWoodOption,
     clothOption,
     baseOption,
-    includeBase: false,
+    includeBase: true,
     shapeOption,
     rotationY: 0
   });
@@ -2711,7 +2711,7 @@ function buildArena(scene, renderer, host, cameraRef, disposeHandlers, appearanc
     0
   );
   const attachBoard = (info, group) => {
-    boardGroup.position.set(0, info.surfaceY + 0.004, 0);
+    boardGroup.position.set(0, info.surfaceY + 0.001, 0);
     boardLookTarget.set(0, info.surfaceY + targetLift + CAMERA_TARGET_EXTRA, 0);
     group.add(boardGroup);
   };
@@ -3129,7 +3129,7 @@ function buildSnakeBoard(
 
   const diceGroup = new THREE.Group();
   const baseLevelTop = levelPlacements[0].tileTopY;
-  const diceBaseY = baseLevelTop + DICE_SIZE * 0.5 + TILE_SIZE * 0.02;
+  const diceBaseY = baseLevelTop + DICE_SIZE * 0.5 - TILE_SIZE * 0.015;
   const diceAnchorZ =
     baseHalf +
     DICE_THROW_LANDING_MARGIN +
@@ -3500,7 +3500,7 @@ function updateTokens(
       const baseVector = basePos ? basePos.clone() : serpentineIndexToXZ(rawPosition).clone();
       baseVector.x += offsetX;
       baseVector.z += offsetZ;
-      baseVector.y += TOKEN_HEIGHT * 0.02;
+      baseVector.y += TOKEN_HEIGHT * 0.005;
       worldPos = baseVector;
     } else {
       const seatAnchor = Number.isFinite(seatIndex) ? seatAnchors?.[seatIndex] : null;
@@ -3546,7 +3546,7 @@ function updateTokens(
             .addScaledVector(lateral, railSpread);
           worldPos = railWorld.clone();
           boardRoot.worldToLocal(worldPos);
-          worldPos.y = TOKEN_HEIGHT * 0.62;
+          worldPos.y = TOKEN_HEIGHT * 0.52;
         }
       }
       if (!worldPos) {

--- a/webapp/src/utils/murlanTable.js
+++ b/webapp/src/utils/murlanTable.js
@@ -566,8 +566,8 @@ export function createMurlanStyleTable({
   const baseLift = 0.02 * scaleFactor;
   const minBaseHeight = 0.2 * scaleFactor;
   const maxBaseHeight = Math.max(minBaseHeight, tableY + baseLift);
-  // Keep table-top height unchanged while extending the pedestal downward a bit more so the base reaches the ground cleanly.
-  baseHeight = maxBaseHeight * 1.24;
+  // Keep table-top height unchanged while extending the pedestal further downward so the base reaches the ground cleanly.
+  baseHeight = maxBaseHeight * 1.36;
 
   const baseMat = includeBase
     ? new ThreeNamespace.MeshPhysicalMaterial({


### PR DESCRIPTION
### Motivation
- Make the Ludo Battle Royale arena visually tighter on mobile portrait by shrinking the table and board, reducing chair scale by ~20%, and pushing chairs outward. 
- Ensure tokens and dice sit visually on the table surface (lower their Y offsets) and move front-of-player/reserve tokens slightly farther outward so they don't overlap the table rim. 
- Make the table base/legs reach the ground more clearly so the pedestal looks grounded.

### Description
- Reduced chair scale and table radius by updating `CHAIR_SIZE_SCALE` and `TABLE_RADIUS` in `webapp/src/components/SnakeBoard3D.jsx` so chairs appear ~20% smaller and the table footprint is reduced. 
- Increased seat gap (`AI_CHAIR_GAP`) to move chairs farther outward and reduced `BOARD_SCALE` by `0.9` to compact the board footprint in `webapp/src/components/SnakeBoard3D.jsx`. 
- Lowered placement offsets for board and dice by adjusting `boardGroup.position.y` and `diceBaseY`, and reduced token vertical offsets (`TOKEN_HEIGHT` multipliers) so board pieces sit closer to the table surface in `webapp/src/components/SnakeBoard3D.jsx`. 
- Adjusted token rest radii by changing `TOKEN_REST_RAIL_INSET_BY_SEAT` and `TOKEN_REST_MIN_RADIUS` so reserve/front tokens rest slightly farther from the table rim in `webapp/src/components/SnakeBoard3D.jsx`. 
- Enabled rendering of the table base for this scene (`includeBase: true`) and increased the pedestal extension factor (`baseHeight = maxBaseHeight * 1.36`) so legs reach the ground in `webapp/src/utils/murlanTable.js`.

### Testing
- Ran lint on the modified files with `npm run -s lint -- webapp/src/components/SnakeBoard3D.jsx webapp/src/utils/murlanTable.js`, which executed but surfaced existing repo-wide lint issues and ignore-pattern warnings affecting global output. 
- No unit or visual regression tests were run for this purely visual/tuning change in this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d91c1b95dc8329b81db635c0f24c99)