### PR TITLE
Adjust Ludo Battle Royal arena grounding, lower board, and spread chairs outward

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -514,9 +514,9 @@ const HUMAN_SEAT_ROTATION_OFFSET = Math.PI / 8;
 const AI_CHAIR_GAP = CARD_W * 0.74;
 const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 0.85;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
-const TABLE_HEIGHT_LIFT = 0.05 * MODEL_SCALE;
+const TABLE_HEIGHT_LIFT = 0.015 * MODEL_SCALE;
 const TABLE_HEIGHT = STOOL_HEIGHT + TABLE_HEIGHT_LIFT;
-const AI_CHAIR_RADIUS = TABLE_RADIUS + SEAT_DEPTH / 2 + AI_CHAIR_GAP + 0.06 * MODEL_SCALE;
+const AI_CHAIR_RADIUS = TABLE_RADIUS + SEAT_DEPTH / 2 + AI_CHAIR_GAP + 0.14 * MODEL_SCALE;
 
 const DEFAULT_PLAYER_COUNT = 4;
 const clampPlayerCount = (value) =>
@@ -626,7 +626,7 @@ const DEFAULT_CLOTH_OPTION = TABLE_CLOTH_OPTIONS[0];
 const DEFAULT_BASE_OPTION = TABLE_BASE_OPTIONS[0];
 const TABLE_MODEL_TARGET_DIAMETER = TABLE_RADIUS * 2;
 const TABLE_MODEL_TARGET_HEIGHT = TABLE_HEIGHT;
-const TABLE_LEG_EXTENSION_FACTOR = 1.08;
+const TABLE_LEG_EXTENSION_FACTOR = 1.14;
 const BASIS_TRANSCODER_PATH = 'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/';
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
 const PREFERRED_TEXTURE_SIZES = ['4k', '2k', '1k'];
@@ -3779,7 +3779,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       updateTokenSurfaceOffset(arena.tableThemeId);
 
       if (boardGroup) {
-        boardGroup.position.set(0, tableInfo.surfaceY + 0.004, 0);
+        boardGroup.position.set(0, tableInfo.surfaceY + 0.0006, 0);
         applyBoardGroupScale(boardGroup, tableInfo);
         tableInfo.group.add(boardGroup);
       }
@@ -4560,7 +4560,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       const arenaState = arenaRef.current;
       if (!arenaState?.tableInfo?.group) return;
       const nextBoardGroup = new THREE.Group();
-      nextBoardGroup.position.set(0, arenaState.tableInfo.surfaceY + 0.004, 0);
+      nextBoardGroup.position.set(0, arenaState.tableInfo.surfaceY + 0.0006, 0);
       applyBoardGroupScale(nextBoardGroup, arenaState.tableInfo);
       nextBoardGroup.rotation.y = BOARD_ROTATION_Y;
       arenaState.tableInfo.group.add(nextBoardGroup);
@@ -4860,7 +4860,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     updateTokenSurfaceOffset(tableInfo.themeId || tableTheme?.id || 'murlan-default');
 
     const boardGroup = new THREE.Group();
-    boardGroup.position.set(0, tableInfo.surfaceY + 0.004, 0);
+    boardGroup.position.set(0, tableInfo.surfaceY + 0.0006, 0);
     applyBoardGroupScale(boardGroup, tableInfo);
     boardGroup.rotation.y = BOARD_ROTATION_Y;
     tableInfo.group.add(boardGroup);


### PR DESCRIPTION
### Motivation
- Improve visual grounding of the Ludo battle-royale scene so the table, board, tokens and dice sit more convincingly on the HDRI floor. 
- Move chairs slightly outward from the table to increase visible clearance and avoid overlap with the table edge. 
- Lower the board/tokens/dice assembly toward the table surface and extend table legs so chair and table bottoms meet the ground plane.

### Description
- Modified `webapp/src/pages/Games/LudoBattleRoyal.jsx` to tune arena geometry and placement. 
- Reduced `TABLE_HEIGHT_LIFT` from `0.05 * MODEL_SCALE` to `0.015 * MODEL_SCALE` so the tabletop/board stack sits lower. 
- Increased `AI_CHAIR_RADIUS` extra offset from `0.06 * MODEL_SCALE` to `0.14 * MODEL_SCALE` to pull chairs slightly outward. 
- Increased `TABLE_LEG_EXTENSION_FACTOR` from `1.08` to `1.14` so table legs extend further downward. 
- Lowered board vertical placement by changing `boardGroup.position.set(0, tableInfo.surfaceY + 0.004, 0)` (and equivalent places) to use `+ 0.0006` so board/tokens/dice align closer to the table surface.

### Testing
- Ran lint on the modified file with `npx eslint webapp/src/pages/Games/LudoBattleRoyal.jsx`, which produced no ESLint errors for the file (the file is ignored by the current ESLint config; linter reported the ignore warning). 
- No other automated unit or integration tests were run for this UI/3D visual tweak in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9204b773c832986257cd6b6704784)