### PR TITLE
Adjust Ludo arena seating, camera, and table layout depth

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -507,16 +507,19 @@ const BACK_THICKNESS = 0.08 * MODEL_SCALE * STOOL_SCALE;
 const ARM_THICKNESS = 0.125 * MODEL_SCALE * STOOL_SCALE;
 const ARM_HEIGHT = 0.3 * MODEL_SCALE * STOOL_SCALE;
 const ARM_DEPTH = SEAT_DEPTH * 0.75;
-const BASE_COLUMN_HEIGHT = 0.5 * MODEL_SCALE * STOOL_SCALE;
+const BASE_COLUMN_HEIGHT = 0.46 * MODEL_SCALE * STOOL_SCALE;
 const CARD_SCALE = 0.95;
 const CARD_W = 0.4 * MODEL_SCALE * CARD_SCALE;
 const HUMAN_SEAT_ROTATION_OFFSET = Math.PI / 8;
 const AI_CHAIR_GAP = CARD_W * 0.74;
-const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 0.85;
+const CHAIR_VERTICAL_DROP = 0.045 * MODEL_SCALE;
+const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 0.85 - CHAIR_VERTICAL_DROP;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
 const TABLE_HEIGHT_LIFT = 0.015 * MODEL_SCALE;
-const TABLE_HEIGHT = STOOL_HEIGHT + TABLE_HEIGHT_LIFT;
-const AI_CHAIR_RADIUS = TABLE_RADIUS + SEAT_DEPTH / 2 + AI_CHAIR_GAP + 0.19 * MODEL_SCALE;
+const TABLE_EXTRA_DROP = 0.078 * MODEL_SCALE;
+const TABLE_HEIGHT = STOOL_HEIGHT + TABLE_HEIGHT_LIFT - TABLE_EXTRA_DROP;
+const CHAIR_OUTWARD_PUSH = 0.14 * MODEL_SCALE;
+const AI_CHAIR_RADIUS = TABLE_RADIUS + SEAT_DEPTH / 2 + AI_CHAIR_GAP + 0.19 * MODEL_SCALE + CHAIR_OUTWARD_PUSH;
 
 const DEFAULT_PLAYER_COUNT = 4;
 const clampPlayerCount = (value) =>
@@ -594,8 +597,8 @@ const LANDSCAPE_CAMERA_TUNING = Object.freeze({
   heightOffset: 1.24 * ARENA_SCALE_RATIO * LUDO_ARENA_SHRINK_FACTOR
 });
 const PORTRAIT_CAMERA_TUNING = Object.freeze({
-  backOffset: 0.82 * ARENA_SCALE_RATIO * LUDO_ARENA_SHRINK_FACTOR,
-  forwardOffset: 0.7 * ARENA_SCALE_RATIO * LUDO_ARENA_SHRINK_FACTOR,
+  backOffset: 0.76 * ARENA_SCALE_RATIO * LUDO_ARENA_SHRINK_FACTOR,
+  forwardOffset: 0.76 * ARENA_SCALE_RATIO * LUDO_ARENA_SHRINK_FACTOR,
   heightOffset: 1.18 * ARENA_SCALE_RATIO * LUDO_ARENA_SHRINK_FACTOR,
   targetLift: 0.075 * MODEL_SCALE
 });
@@ -626,7 +629,8 @@ const DEFAULT_CLOTH_OPTION = TABLE_CLOTH_OPTIONS[0];
 const DEFAULT_BASE_OPTION = TABLE_BASE_OPTIONS[0];
 const TABLE_MODEL_TARGET_DIAMETER = TABLE_RADIUS * 2;
 const TABLE_MODEL_TARGET_HEIGHT = TABLE_HEIGHT;
-const TABLE_LEG_EXTENSION_FACTOR = 1.18;
+const TABLE_LEG_EXTENSION_FACTOR = 1.28;
+const TABLE_BASE_EXTENSION_MULTIPLIER = 1.38;
 const BASIS_TRANSCODER_PATH = 'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/';
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
 const PREFERRED_TEXTURE_SIZES = ['4k', '2k', '1k'];
@@ -3769,7 +3773,8 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           woodOption,
           clothOption,
           baseOption,
-          includeBase: true
+          includeBase: true,
+          baseExtensionMultiplier: TABLE_BASE_EXTENSION_MULTIPLIER
         });
         applyTableMaterials(procedural.materials, { woodOption, clothOption, baseOption }, renderer);
         tableInfo = { ...procedural, themeId: tableTheme?.id || procedural.shapeId };

--- a/webapp/src/utils/murlanTable.js
+++ b/webapp/src/utils/murlanTable.js
@@ -551,7 +551,8 @@ export function createMurlanStyleTable({
   baseOption = DEFAULT_TABLE_BASE_OPTION,
   includeBase = true,
   shapeOption = TABLE_SHAPE_OPTIONS[0],
-  rotationY = 0
+  rotationY = 0,
+  baseExtensionMultiplier = 1.24
 } = {}) {
   if (!arena) throw new Error('createMurlanStyleTable requires an arena group.');
 
@@ -567,7 +568,7 @@ export function createMurlanStyleTable({
   const minBaseHeight = 0.2 * scaleFactor;
   const maxBaseHeight = Math.max(minBaseHeight, tableY + baseLift);
   // Keep table-top height unchanged while extending the pedestal downward a bit more so the base reaches the ground cleanly.
-  baseHeight = maxBaseHeight * 1.24;
+  baseHeight = maxBaseHeight * Math.max(1, baseExtensionMultiplier || 1.24);
 
   const baseMat = includeBase
     ? new ThreeNamespace.MeshPhysicalMaterial({


### PR DESCRIPTION
### Motivation
- Visually move chairs slightly outward and make them sit lower by trimming leg height so seats appear closer to the floor. 
- Bring the camera a bit closer for tighter framing on the table in portrait. 
- Lower the table (board + tokens + dice/animations) more than the chairs and extend the table base/legs so imported and procedural tables reach the HDRI floor.

### Description
- Tuned numeric layout constants in `webapp/src/pages/Games/LudoBattleRoyal.jsx` to push chairs outward and lower seats (`CHAIR_VERTICAL_DROP`, `CHAIR_OUTWARD_PUSH`, `AI_CHAIR_RADIUS`, `BASE_COLUMN_HEIGHT`, `TABLE_EXTRA_DROP`, `TABLE_HEIGHT`).
- Tightened portrait camera offsets in `PORTRAIT_CAMERA_TUNING` so the camera frames the table closer in portrait mode.
- Increased imported-model leg stretch factor and added a configurable procedural base extension multiplier (`TABLE_LEG_EXTENSION_FACTOR`, `TABLE_BASE_EXTENSION_MULTIPLIER`) and passed it into procedural table creation.
- Added an optional `baseExtensionMultiplier` parameter to `createMurlanStyleTable` in `webapp/src/utils/murlanTable.js` and applied it when calculating procedural base height so the table pedestal can extend deeper without raising the table-top.

### Testing
- Built the webapp: ran `npm -C webapp run -s build` successfully and produced a production build (Vite build completed). 
- Attempted to run a lint check for the two modified files but no `lint` script exists in `webapp/package.json`, so that check was not performed. 
- Vite reported unrelated chunk-size/dynamic-import warnings during the build, but the build finished successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9303d099083298fb1d2772410b864)