### PR TITLE
Fix snake table extra-turn handling on roll of six

### DIFF
--- a/bot/server.js
+++ b/bot/server.js
@@ -2441,14 +2441,21 @@ io.on('connection', (socket) => {
       if (!player) return;
       const dice = Math.floor(Math.random() * 6) + 1;
       player.position += dice;
+      const extraTurn = dice === 6;
       io.to(tableId).emit('diceRolled', {
+        playerId: accountId,
+        value: dice,
         accountId,
         dice,
-        newPosition: player.position
+        newPosition: player.position,
+        extraTurn
       });
-      const idx = table.players.findIndex((p) => p.id === accountId);
-      const nextIndex = (idx + 1) % table.players.length;
-      table.currentTurn = table.players[nextIndex].id;
+
+      if (!extraTurn) {
+        const idx = table.players.findIndex((p) => p.id === accountId);
+        const nextIndex = (idx + 1) % table.players.length;
+        table.currentTurn = table.players[nextIndex].id;
+      }
       io.to(tableId).emit('turnUpdate', { currentTurn: table.currentTurn });
       return;
     }


### PR DESCRIPTION
### Motivation
- Players who roll a 6 on the lobby/table snake flow should keep the turn and be able to roll again so the client can show the roll CTA immediately.
- The frontend needs a clear signal when a roll grants an extra turn so it can restore UI state reliably.

### Description
- Updated the `rollDice` socket handler for table-based snake games in `bot/server.js` to compute `extraTurn` as `dice === 6` and preserve the current player when `extraTurn` is true.
- Extended the emitted `diceRolled` payload to include normalized fields `playerId` and `value` as well as an `extraTurn` boolean while keeping existing fields for compatibility.`
- Advance `table.currentTurn` only when `extraTurn` is false and continue to emit `turnUpdate` after each roll so clients stay synchronized.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d93d964ac483298634cc5a3011e8a7)