### PR TITLE
Make javelin missiles launch from moving chess piece and tighten orbit path

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -8309,7 +8309,15 @@ function Chess3D({
       return { pos, next };
     };
 
-    const playCaptureAnimation = ({ fromPos, targetPos, movingType, distance, deltaR = 0, deltaC = 0 }) => {
+    const playCaptureAnimation = ({
+      fromPos,
+      targetPos,
+      movingType,
+      movingMesh = null,
+      distance,
+      deltaR = 0,
+      deltaC = 0
+    }) => {
       const pieceType = (movingType || '').toUpperCase();
       if (pieceType === 'B' || pieceType === 'R') {
         const droneFx = createFxDrone();
@@ -8377,6 +8385,12 @@ function Chess3D({
         missileFx.root.scale.setScalar(CAPTURE_MISSILE_SCALE);
         missileFx.root.visible = false;
         captureFxGroup.add(missileFx.root);
+        const launchBase = new THREE.Vector3();
+        if (movingMesh?.getWorldPosition) {
+          movingMesh.getWorldPosition(launchBase);
+        } else {
+          launchBase.copy(fromPos);
+        }
         playAudio(missileLaunchSoundRef);
         activeCaptureFx.push({
           type: 'javelin',
@@ -8384,7 +8398,7 @@ function Chess3D({
           duration: CAPTURE_GROUND_TOTAL,
           from: fromPos.clone(),
           to: targetPos.clone(),
-          launchPos: fromPos.clone().add(new THREE.Vector3(0, 0.22, 0)),
+          launchPos: launchBase.add(new THREE.Vector3(0, 0.22, 0)),
           deltaR,
           deltaC,
           missileFx
@@ -9356,6 +9370,7 @@ function Chess3D({
           fromPos: fromWorldPos,
           targetPos: worldPos,
           movingType: movingPiece?.t,
+          movingMesh: pieceMeshes[sel.r][sel.c],
           distance: Math.hypot(rr - sel.r, cc - sel.c),
           deltaR: rr - sel.r,
           deltaC: cc - sel.c
@@ -9980,8 +9995,8 @@ function Chess3D({
                 to: fx.to.clone().add(new THREE.Vector3(0, 0.02, 0)),
                 progress: mu,
                 launchHeight: 0.02,
-                orbitHeight: CAPTURE_FLIGHT_ALTITUDE * 0.5,
-                orbitRadiusMul: 1.12,
+                orbitHeight: CAPTURE_FLIGHT_ALTITUDE * 0.34,
+                orbitRadiusMul: 1.08,
                 minOrbitCycles: 1.45,
                 orbitSplit: 0.88
               });


### PR DESCRIPTION
### Motivation
- Fix visual bug where bazooka/javelin missiles appeared to launch from the board rather than the piece making the move and match the Ludo missile "orbit then strike" readability.
- Keep capture FX behavior consistent while improving launch origin accuracy and on-screen clarity for portrait/mobile viewing.

### Description
- Added a `movingMesh` parameter to `playCaptureAnimation` and pass the active piece mesh (`pieceMeshes[sel.r][sel.c]`) when resolving a capture so the FX can read the actual world position via `getWorldPosition`.
- Compute a `launchBase` from `movingMesh.getWorldPosition` (falling back to `fromPos`) and use it for the javelin `launchPos` so the missile visibly fires from the attacking piece.
- Tuned the javelin orbit parameters used by `getCaptureRingOrbitPose`: changed `orbitHeight` from `CAPTURE_FLIGHT_ALTITUDE * 0.5` to `* 0.34` and `orbitRadiusMul` from `1.12` to `1.08` to keep the orbit lower and tighter above the board.
- Modified file: `webapp/src/pages/Games/ChessBattleRoyal.jsx` (updates around `playCaptureAnimation` and the javelin orbit call).

### Testing
- Ran the production build with `cd webapp && npm run -s build`, which completed successfully (build warnings about large chunks were emitted but did not fail the build).
- Attempted `cd webapp && npm run -s lint`, but no `lint` script is defined in this project so no linter run was performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9c38909748329acdb691a18194e76)