### PR TITLE
Fix Snake multiplayer extra-turn roll CTA mapping

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -2177,29 +2177,48 @@ export default function SnakeAndLadder() {
         if (playerId === myAccountId) setPos(0);
       }, 1000);
     };
-    const onTurn = ({ playerId, seatIndex }) => {
-      let idx = -1;
+    const resolveTurnIndex = ({ playerId, seatIndex, currentTurn: currentTurnPayload }) => {
+      const players = playersRef.current;
+      const totalPlayers = players.length;
+      if (totalPlayers <= 0) return -1;
 
-      if (Number.isInteger(seatIndex)) {
-        idx = seatIndex;
-      } else {
-        idx = playersRef.current.findIndex((pl) => pl.id === playerId);
+      const idxById = players.findIndex((pl) => pl.id === playerId);
+      const normalizeIndex = (candidate) => {
+        if (!Number.isInteger(candidate)) return -1;
+        if (candidate >= 0 && candidate < totalPlayers) return candidate;
+        if (candidate > 0 && candidate - 1 < totalPlayers) return candidate - 1;
+        return -1;
+      };
 
-        // Some servers emit the active seat index instead of a playerId.
-        if (idx === -1 && Number.isInteger(playerId)) {
-          idx = playerId;
-        }
+      if (idxById >= 0) {
+        const seatNormalized = normalizeIndex(seatIndex);
+        if (seatNormalized === idxById) return idxById;
+        const currentTurnNormalized = normalizeIndex(currentTurnPayload);
+        if (currentTurnNormalized === idxById) return idxById;
       }
 
-      if (idx >= 0) {
-        setCurrentTurn(idx);
-        setDiceCount(playerDiceCounts[idx] ?? 1);
-        const turnBelongsToMe = playersRef.current[idx]?.id === myAccountId;
-        if (turnBelongsToMe) {
-          // Keep roll CTA visible for immediate extra turns.
-          setRollCooldown(0);
-        }
-        if (!turnBelongsToMe) setPendingExtraRoll(false);
+      const seatIndexResolved = normalizeIndex(seatIndex);
+      if (seatIndexResolved >= 0) return seatIndexResolved;
+
+      const currentTurnResolved = normalizeIndex(currentTurnPayload);
+      if (currentTurnResolved >= 0) return currentTurnResolved;
+
+      if (idxById >= 0) return idxById;
+      return normalizeIndex(playerId);
+    };
+
+    const onTurn = ({ playerId, seatIndex, currentTurn: currentTurnPayload }) => {
+      const idx = resolveTurnIndex({ playerId, seatIndex, currentTurn: currentTurnPayload });
+      if (idx < 0) return;
+
+      setCurrentTurn(idx);
+      setDiceCount(playerDiceCounts[idx] ?? 1);
+      const turnBelongsToMe = playersRef.current[idx]?.id === myAccountId;
+      if (turnBelongsToMe) {
+        // Keep roll CTA visible for immediate extra turns.
+        setRollCooldown(0);
+      } else {
+        setPendingExtraRoll(false);
       }
     };
     const onStarted = () => {
@@ -2313,7 +2332,7 @@ export default function SnakeAndLadder() {
     socket.on('playerReset', onReset);
     socket.on('turnChanged', onTurn);
     socket.on('turnUpdate', ({ currentTurn, playerId, seatIndex }) =>
-      onTurn({ playerId, seatIndex: Number.isInteger(currentTurn) ? currentTurn : seatIndex })
+      onTurn({ currentTurn, playerId, seatIndex })
     );
     socket.on('lobbyUpdate', ({ players: list, maxPlayers }) => {
       handleCapacity(maxPlayers);


### PR DESCRIPTION
### Motivation
- Fix a bug where a human player who rolled a six saw the "Your turn" message but the roll icon/CTA did not appear and they could not roll again. 
- The root cause was incorrect resolution of the active turn index when server payloads provided `seatIndex`/`currentTurn` using mixed 0-based/1-based conventions or different fields.

### Description
- Added a new `resolveTurnIndex` helper in `webapp/src/pages/Games/SnakeAndLadder.jsx` that normalizes `seatIndex`, `currentTurn` and `playerId` and supports both 0-based and 1-based server payloads. 
- Replaced the previous `onTurn` logic to use `resolveTurnIndex` and only clear `pendingExtraRoll` when the resolved active player is not the local player. 
- Updated the `turnUpdate` socket handler to pass the full payload into `onTurn` (`{ currentTurn, playerId, seatIndex }`) so the resolver can make a correct decision.

### Testing
- Ran a production build with `npm --prefix webapp run -s build`, which completed successfully. 
- Verified local code compiles and the modified `SnakeAndLadder.jsx` file was included in the build without runtime build errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9c6b7bff48329afb56c6deaf814d1)