### PR TITLE
Fix Snake & Ladder extra-roll button disappearing after rolling a 6

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -2198,6 +2198,7 @@ export default function SnakeAndLadder() {
         if (turnBelongsToMe) {
           // Keep roll CTA visible for immediate extra turns.
           setRollCooldown(0);
+          setMoving(false);
         }
         if (!turnBelongsToMe) setPendingExtraRoll(false);
       }
@@ -3196,8 +3197,15 @@ export default function SnakeAndLadder() {
         }))
       ];
 
+  const candidatePlayerIds = useMemo(() => {
+    const ids = [accountId, resolvedAccountId, getPlayerId(), getTelegramId()]
+      .map((id) => (id == null ? '' : String(id).trim()))
+      .filter(Boolean);
+    return Array.from(new Set(ids));
+  }, [accountId, resolvedAccountId]);
+
   const computedIndex = isMultiplayer
-    ? mpPlayers.findIndex((p) => p.id === accountId)
+    ? mpPlayers.findIndex((p) => candidatePlayerIds.includes(String(p.id)))
     : 0;
   const myPlayerIndex = computedIndex >= 0 ? computedIndex : null;
   const hasLocalExtraRoll = pendingExtraRoll;


### PR DESCRIPTION
### Motivation
- Players reported that after landing on a 6 the UI shows "Your turn" but the roll icon/CTA remains hidden so the player cannot roll again, indicating a stale movement lock or incorrect local-player detection. 
- The multiplayer player identity resolution could miss the local client in some environments, causing the UI to not enable roll controls when it should.

### Description
- When the server emits a turn for the local player, clear any stale movement lock by calling `setMoving(false)` in `webapp/src/pages/Games/SnakeAndLadder.jsx` so the roll CTA/icon becomes available immediately. 
- Improve local-player detection by introducing `candidatePlayerIds` (a `useMemo` that normalizes `accountId`, `resolvedAccountId`, `getPlayerId()` and `getTelegramId()`), and use it when computing `computedIndex` so the client reliably recognizes "my" seat. 
- These changes ensure that extra turns awarded by rolling a six keep the roll controls visible and clickable for human players without changing the existing turn/roll logic.

### Testing
- Ran `npm run build` in `webapp/` which completed successfully (Vite emitted only non-blocking chunk warnings) indicating the code compiles and the bundle builds correctly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9c6b7bff48329afb56c6deaf814d1)