### PR TITLE
Adjust Ludo arena scale and camera framing

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -490,8 +490,8 @@ let proceduralTokenHeight = null;
 
 const BASE_ARENA_SCALE = 0.85;
 // Keep the exact layout, but make the full table setup (table + board + chairs + attached animations)
-// another ~15% smaller in world space while preserving the exact relative layout.
-const LUDO_ARENA_SHRINK_FACTOR = 0.51;
+// slightly smaller in world space while preserving the exact relative layout.
+const LUDO_ARENA_SHRINK_FACTOR = 0.48;
 const ARENA_SCALE = 0.72 * LUDO_ARENA_SHRINK_FACTOR;
 const ARENA_SCALE_RATIO = ARENA_SCALE / BASE_ARENA_SCALE;
 const MODEL_SCALE = 0.75 * ARENA_SCALE;
@@ -596,14 +596,14 @@ const CAMERA_ZOOM_MAX_FACTOR = 1.35;
 const LUDO_CAMERA_PHI_MIN = THREE.MathUtils.degToRad(18);
 const LUDO_CAMERA_PHI_MAX = THREE.MathUtils.degToRad(88);
 const LANDSCAPE_CAMERA_TUNING = Object.freeze({
-  backOffset: 0.66 * ARENA_SCALE_RATIO * LUDO_ARENA_SHRINK_FACTOR,
+  backOffset: 0.74 * ARENA_SCALE_RATIO * LUDO_ARENA_SHRINK_FACTOR,
   forwardOffset: 0.9 * ARENA_SCALE_RATIO * LUDO_ARENA_SHRINK_FACTOR,
-  heightOffset: 0.72 * ARENA_SCALE_RATIO * LUDO_ARENA_SHRINK_FACTOR
+  heightOffset: 0.8 * ARENA_SCALE_RATIO * LUDO_ARENA_SHRINK_FACTOR
 });
 const PORTRAIT_CAMERA_TUNING = Object.freeze({
-  backOffset: 0.54 * ARENA_SCALE_RATIO * LUDO_ARENA_SHRINK_FACTOR,
+  backOffset: 0.64 * ARENA_SCALE_RATIO * LUDO_ARENA_SHRINK_FACTOR,
   forwardOffset: 1.08 * ARENA_SCALE_RATIO * LUDO_ARENA_SHRINK_FACTOR,
-  heightOffset: 0.7 * ARENA_SCALE_RATIO * LUDO_ARENA_SHRINK_FACTOR,
+  heightOffset: 0.8 * ARENA_SCALE_RATIO * LUDO_ARENA_SHRINK_FACTOR,
   targetLift: 0.044 * MODEL_SCALE
 });
 
@@ -1883,7 +1883,7 @@ const BOARD_ROTATION_Y = -Math.PI / 2;
 const CAMERA_BASE_RADIUS = Math.max(TABLE_RADIUS, BOARD_RADIUS);
 const CAMERA_EXTRA_ZOOM_IN = 0.82;
 const CAMERA_EXTRA_ZOOM_OUT = 1.26;
-const INITIAL_CAMERA_DISTANCE_FACTOR = 0.58;
+const INITIAL_CAMERA_DISTANCE_FACTOR = 0.64;
 const CAM = {
   fov: CAMERA_FOV,
   near: CAMERA_NEAR,
@@ -1896,7 +1896,7 @@ const CAM = {
 const CAMERA_2D_DISTANCE_FACTOR = 1.08;
 const CAMERA_2D_MAX_DISTANCE_FACTOR = 1.32;
 const CAMERA_3D_VERTICAL_DROP = 0.028 * MODEL_SCALE;
-const CAMERA_3D_HEIGHT_BOOST = 0.028 * MODEL_SCALE;
+const CAMERA_3D_HEIGHT_BOOST = 0.038 * MODEL_SCALE;
 const CAMERA_LOOKDOWN_TARGET_OFFSET = 0.022 * MODEL_SCALE;
 const TRACK_COORDS = Object.freeze([
   [6, 1],


### PR DESCRIPTION
### Motivation
- Improve mobile portrait framing so the full Ludo table (board, tokens, dice, chairs) remains grounded but appears slightly smaller and more fully visible on-screen.
- Nudge the camera slightly farther back and higher to match the requested visual composition for portrait-oriented phones.

### Description
- Reduced arena scale by changing `LUDO_ARENA_SHRINK_FACTOR` from `0.51` to `0.48` to make the table/board/chairs/dice/token group slightly smaller while preserving layout proportions (`webapp/src/pages/Games/LudoBattleRoyal.jsx`).
- Tuned camera tuning values for both landscape and portrait by adjusting `LANDSCAPE_CAMERA_TUNING.backOffset`/`heightOffset` and `PORTRAIT_CAMERA_TUNING.backOffset`/`heightOffset` to place the camera farther back and a bit higher.
- Increased `INITIAL_CAMERA_DISTANCE_FACTOR` from `0.58` to `0.64` to start the camera farther from the board.
- Increased `CAMERA_3D_HEIGHT_BOOST` from `0.028 * MODEL_SCALE` to `0.038 * MODEL_SCALE` to lift the initial camera vertically for improved top-down visibility.

### Testing
- Ran the production build with `npm --prefix webapp run build`, which completed successfully and produced the `dist/` output.
- The build emitted size/dynamic-import warnings from Vite but finished without errors (no failing automated tests were run in this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9cabf3fd8832983684e3db6c1de8e)