### PR TITLE
Ludo: trim chairs, lock camera, and stabilize HDRI alignment

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -266,12 +266,13 @@ const CAMERA_LOOK_PITCH_LIMIT = THREE.MathUtils.degToRad(16);
 const CAMERA_LOOK_PITCH_DRAG_FACTOR = -0.0038;
 const CAMERA_EXTRA_LIFT = 0.12;
 const INITIAL_CAMERA_DISTANCE_FACTOR = 0.35;
+const CHAIR_BOTTOM_TRIM_SCALE_Y = 0.88;
 const POINTER_TAP_MAX_DISTANCE = 14;
 const POINTER_TAP_MAX_DURATION_MS = 420;
 const PORTRAIT_CAMERA_TUNING = Object.freeze({
-  backOffset: 1.06,
+  backOffset: 1.22,
   forwardOffset: 0,
-  heightOffset: 2.54,
+  heightOffset: 2.74,
   targetLift: 0.055 * MODEL_SCALE
 });
 const LANDSCAPE_CAMERA_TUNING = Object.freeze({
@@ -1181,6 +1182,16 @@ function fitChairModelToFootprint(model) {
   model.position.add(offset);
 }
 
+function trimChairFromBottom(model, trimScaleY = CHAIR_BOTTOM_TRIM_SCALE_Y) {
+  if (!model || !Number.isFinite(trimScaleY) || trimScaleY <= 0 || trimScaleY >= 1) return;
+  const before = new THREE.Box3().setFromObject(model);
+  if (!Number.isFinite(before.max.y)) return;
+  model.scale.y *= trimScaleY;
+  const after = new THREE.Box3().setFromObject(model);
+  if (!Number.isFinite(after.max.y)) return;
+  model.position.y += before.max.y - after.max.y;
+}
+
 function extractChairMaterials(model) {
   const upholstery = new Set();
   const metal = new Set();
@@ -1445,6 +1456,7 @@ function createProceduralChair(theme) {
   foot.receiveShadow = true;
   chair.add(foot);
 
+  trimChairFromBottom(chair);
   return {
     chairTemplate: chair,
     materials: {
@@ -1465,12 +1477,14 @@ async function loadChairTemplate(theme, renderer = null) {
       if (!theme?.preserveMaterials) {
         applyChairThemeMaterials({ chairMaterials: mats }, theme);
       }
+      trimChairFromBottom(polyhaven);
       return { chairTemplate: polyhaven, materials: mats };
     }
     const gltfChair = await loadGltfChair(renderer);
     if (!theme?.preserveMaterials) {
       applyChairThemeMaterials({ chairMaterials: gltfChair.materials }, theme);
     }
+    trimChairFromBottom(gltfChair.chairTemplate);
     return gltfChair;
   } catch (error) {
     console.error('Falling back to procedural chair', error);
@@ -2630,19 +2644,11 @@ function buildArena(scene, renderer, host, cameraRef, disposeHandlers, appearanc
   scene.background = toThreeColor(arenaTheme.background, '#030712');
 
   let environmentCleanup = null;
-  const hdriZoomState = { texture: null, baseDistance: null };
+  const hdriZoomState = { texture: null };
   const updateHdriZoom = (camera, target) => {
     if (!hdriZoomState.texture || !camera || !target) return;
-    const distance = camera.position.distanceTo(target);
-    if (!hdriZoomState.baseDistance) {
-      hdriZoomState.baseDistance = distance;
-    }
-    const base = hdriZoomState.baseDistance || distance;
-    const ratio = clamp(distance / base, 0.7, 1.4);
-    const zoom = 1 / ratio;
-    hdriZoomState.texture.repeat.set(zoom, zoom);
-    hdriZoomState.texture.offset.set((1 - zoom) / 2, (1 - zoom) / 2);
-    hdriZoomState.texture.needsUpdate = true;
+    hdriZoomState.texture.repeat.set(1, 1);
+    hdriZoomState.texture.offset.set(0, 0);
   };
   if (environmentHdri) {
     loadPolyHavenHdriEnvironment(renderer, environmentHdri).then((result) => {
@@ -2650,14 +2656,19 @@ function buildArena(scene, renderer, host, cameraRef, disposeHandlers, appearanc
       scene.environment = result.envMap;
       scene.background = result.backgroundTexture || result.envMap;
       hdriZoomState.texture = result.backgroundTexture || null;
-      hdriZoomState.baseDistance = null;
+      const rotationY = Number.isFinite(environmentHdri.rotationY) ? environmentHdri.rotationY : 0;
+      if ('backgroundRotation' in scene) {
+        scene.backgroundRotation = new THREE.Euler(0, rotationY, 0);
+      }
+      if ('environmentRotation' in scene) {
+        scene.environmentRotation = new THREE.Euler(0, rotationY, 0);
+      }
       environmentCleanup = () => {
         scene.environment = null;
         scene.background = toThreeColor(arenaTheme.background, '#030712');
         result.envMap?.dispose?.();
         result.backgroundTexture?.dispose?.();
         hdriZoomState.texture = null;
-        hdriZoomState.baseDistance = null;
       };
     });
   }
@@ -4339,6 +4350,7 @@ export default function SnakeBoard3D({
       if (cameraViewModeRef.current === '2d') {
         return;
       }
+      if (LOCK_BOTTOM_SEAT_CAMERA) return;
 
       const look = headLookRef.current;
       look.yaw = clamp(
@@ -4388,6 +4400,7 @@ export default function SnakeBoard3D({
       pinchState.mode = null;
     };
     const onWheel = (event) => {
+      if (LOCK_BOTTOM_SEAT_CAMERA) return;
       const isTopDown = cameraViewModeRef.current === '2d';
       event.preventDefault();
       const factor = isTopDown ? CAMERA_TOPDOWN_ZOOM_WHEEL_FACTOR : CAMERA_3D_ZOOM_WHEEL_FACTOR;
@@ -4396,6 +4409,7 @@ export default function SnakeBoard3D({
       applyCameraZoomScale(clamp(zoomScale, bounds[0], bounds[1]));
     };
     const tryApplyPinchZoom = () => {
+      if (LOCK_BOTTOM_SEAT_CAMERA) return;
       if (pinchState.pointers.size < 2) {
         pinchState.distance = null;
         pinchState.mode = null;
@@ -4593,22 +4607,26 @@ export default function SnakeBoard3D({
           }
         }
         if (cameraViewModeRef.current !== '2d') {
-          const look = headLookRef.current;
           const baseTarget = board?.controls?.target || board?.boardLookTarget || arena.boardLookTarget;
-          if (baseTarget) {
-            const forward = baseTarget.clone().sub(camera.position);
-            const focusDistance = forward.length();
-            if (focusDistance > 1e-6) {
-              forward.normalize();
-              const right = new THREE.Vector3().crossVectors(forward, WORLD_UP);
-              if (right.lengthSq() > 1e-6) {
-                right.normalize();
-                const up = new THREE.Vector3().crossVectors(right, forward).normalize();
-                const lookTarget = baseTarget
-                  .clone()
-                  .addScaledVector(right, look.yaw * focusDistance * 0.52)
-                  .addScaledVector(up, look.pitch * focusDistance * 0.4);
-                camera.lookAt(lookTarget);
+          if (LOCK_BOTTOM_SEAT_CAMERA) {
+            if (baseTarget) camera.lookAt(baseTarget);
+          } else {
+            const look = headLookRef.current;
+            if (baseTarget) {
+              const forward = baseTarget.clone().sub(camera.position);
+              const focusDistance = forward.length();
+              if (focusDistance > 1e-6) {
+                forward.normalize();
+                const right = new THREE.Vector3().crossVectors(forward, WORLD_UP);
+                if (right.lengthSq() > 1e-6) {
+                  right.normalize();
+                  const up = new THREE.Vector3().crossVectors(right, forward).normalize();
+                  const lookTarget = baseTarget
+                    .clone()
+                    .addScaledVector(right, look.yaw * focusDistance * 0.52)
+                    .addScaledVector(up, look.pitch * focusDistance * 0.4);
+                  camera.lookAt(lookTarget);
+                }
               }
             }
           }


### PR DESCRIPTION
### Motivation
- Improve Ludo Battle Royal visual framing by shortening chair legs, matching Domino camera behavior, and keeping the table/chairs grounded in HDRI environments. 

### Description
- Added `trimChairFromBottom` and `CHAIR_BOTTOM_TRIM_SCALE_Y` and applied the trim to procedural chairs and loaded GLTF/PolyHaven chair templates to shorten chairs from the bottom while preserving seat/top placement. 
- Tuned portrait camera constants by updating `PORTRAIT_CAMERA_TUNING.backOffset` and `heightOffset` to pull the camera slightly farther and a bit higher. 
- Locked 3D camera interaction to Domino-style fixed behavior by gating drag-look, wheel zoom and pinch zoom handlers behind `LOCK_BOTTOM_SEAT_CAMERA` and forcing a stable `camera.lookAt(...)` when the lock is enabled. 
- Stabilized HDRI handling by removing dynamic background zoom, fixing HDRI texture `repeat`/`offset`, and applying HDRI rotation to `scene.backgroundRotation` and `scene.environmentRotation` so the HDRI can be oriented to face the main scene. 
- All changes made in `webapp/src/components/SnakeBoard3D.jsx` (chair fitting/trim, camera tuning/controls, and HDRI handling). 

### Testing
- Ran linting on the modified component with `npx eslint --no-ignore --no-warn-ignored webapp/src/components/SnakeBoard3D.jsx`, which completed without syntax errors reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9d8d24a388329972c13a86b761647)