### PR TITLE
Fix turn resolution and multiplayer roll ownership in SnakeAndLadder

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1238,6 +1238,7 @@ export default function SnakeAndLadder() {
   const [playerColors, setPlayerColors] = useState([]);
   const [, setRollColor] = useState('#fff');
   const [currentTurn, setCurrentTurn] = useState(0); // 0 = player
+  const [turnOwnerId, setTurnOwnerId] = useState(null);
   const [ranking, setRanking] = useState([]);
   const [turnOrder, setTurnOrder] = useState([]);
   const [initialRolls, setInitialRolls] = useState([]);
@@ -2177,34 +2178,57 @@ export default function SnakeAndLadder() {
         if (playerId === myAccountId) setPos(0);
       }, 1000);
     };
-    const onTurn = ({ playerId, seatIndex }) => {
-      let idx = -1;
+    const resolveTurnIndex = ({ playerId, seatIndex, currentTurn: currentTurnPayload }) => {
+      const players = playersRef.current;
+      const totalPlayers = players.length;
+      if (totalPlayers <= 0) return -1;
 
-      if (Number.isInteger(seatIndex)) {
-        idx = seatIndex;
-      } else {
-        idx = playersRef.current.findIndex((pl) => pl.id === playerId);
+      const idxById = players.findIndex((pl) => pl.id === playerId);
+      const normalizeIndex = (candidate) => {
+        if (!Number.isInteger(candidate)) return -1;
+        if (candidate >= 0 && candidate < totalPlayers) return candidate;
+        if (candidate > 0 && candidate - 1 < totalPlayers) return candidate - 1;
+        return -1;
+      };
 
-        // Some servers emit the active seat index instead of a playerId.
-        if (idx === -1 && Number.isInteger(playerId)) {
-          idx = playerId;
-        }
+      if (idxById >= 0) {
+        const seatNormalized = normalizeIndex(seatIndex);
+        if (seatNormalized === idxById) return idxById;
+        const currentTurnNormalized = normalizeIndex(currentTurnPayload);
+        if (currentTurnNormalized === idxById) return idxById;
       }
 
-      if (idx >= 0) {
-        setCurrentTurn(idx);
-        setDiceCount(playerDiceCounts[idx] ?? 1);
-        const turnBelongsToMe = playersRef.current[idx]?.id === myAccountId;
-        if (turnBelongsToMe) {
-          // Keep roll CTA visible for immediate extra turns.
-          setRollCooldown(0);
-        }
-        if (!turnBelongsToMe) setPendingExtraRoll(false);
+      const seatIndexResolved = normalizeIndex(seatIndex);
+      if (seatIndexResolved >= 0) return seatIndexResolved;
+
+      const currentTurnResolved = normalizeIndex(currentTurnPayload);
+      if (currentTurnResolved >= 0) return currentTurnResolved;
+
+      if (idxById >= 0) return idxById;
+      return normalizeIndex(playerId);
+    };
+
+    const onTurn = ({ playerId, seatIndex, currentTurn: currentTurnPayload }) => {
+      const idx = resolveTurnIndex({ playerId, seatIndex, currentTurn: currentTurnPayload });
+      if (idx < 0) return;
+
+      setCurrentTurn(idx);
+      const resolvedTurnOwnerId = playersRef.current[idx]?.id ?? playerId ?? null;
+      setTurnOwnerId(resolvedTurnOwnerId);
+      setDiceCount(playerDiceCounts[idx] ?? 1);
+      const turnBelongsToMe = resolvedTurnOwnerId === myAccountId;
+      if (turnBelongsToMe) {
+        // Keep roll CTA visible for immediate extra turns and avoid stale lock states.
+        setRollCooldown(0);
+        setMoving(false);
+      } else {
+        setPendingExtraRoll(false);
       }
     };
     const onStarted = () => {
       setSetupPhase(false);
       setWaitingForPlayers(false);
+      setTurnOwnerId(null);
       if (myAccountId) {
         unseatTable(myAccountId, tableId).catch(() => {});
       }
@@ -2214,9 +2238,13 @@ export default function SnakeAndLadder() {
       setTimeout(() => setRollResult(null), 2000);
       playDiceRollSound();
       const rollerId = playerId ?? playersRef.current[currentTurn]?.id;
-      if (rollerId === myAccountId && Number(value) === 6) {
+      const rolledSix = Array.isArray(value)
+        ? value.some((v) => Number(v) === 6)
+        : Number(value) === 6;
+      if (rollerId === myAccountId && rolledSix) {
         setPendingExtraRoll(true);
         setRollCooldown(0);
+        setTurnOwnerId(myAccountId);
       }
     };
     const onWon = ({ playerId }) => {
@@ -2313,7 +2341,7 @@ export default function SnakeAndLadder() {
     socket.on('playerReset', onReset);
     socket.on('turnChanged', onTurn);
     socket.on('turnUpdate', ({ currentTurn, playerId, seatIndex }) =>
-      onTurn({ playerId, seatIndex: Number.isInteger(currentTurn) ? currentTurn : seatIndex })
+      onTurn({ currentTurn, playerId, seatIndex })
     );
     socket.on('lobbyUpdate', ({ players: list, maxPlayers }) => {
       handleCapacity(maxPlayers);
@@ -3201,8 +3229,10 @@ export default function SnakeAndLadder() {
     : 0;
   const myPlayerIndex = computedIndex >= 0 ? computedIndex : null;
   const hasLocalExtraRoll = pendingExtraRoll;
+  const multiplayerTurnBelongsToMe =
+    myPlayerIndex !== null && (turnOwnerId === accountId || currentTurn === myPlayerIndex);
   const isMyTurnForRoll =
-    myPlayerIndex !== null && (currentTurn === myPlayerIndex || hasLocalExtraRoll);
+    myPlayerIndex !== null && (isMultiplayer ? multiplayerTurnBelongsToMe || hasLocalExtraRoll : currentTurn === myPlayerIndex || hasLocalExtraRoll);
   const rollReady = isMultiplayer
     ? true
     : hasLocalExtraRoll || rollCooldown === 0;


### PR DESCRIPTION
### Motivation
- Resolve inconsistent turn handling when server emits different payload shapes (`playerId`, `seatIndex`, or `currentTurn`) and ensure correct roll ownership in multiplayer games.
- Prevent stale roll lock states and incorrect move/roll availability for clients when turns are reported ambiguously.

### Description
- Added new state `turnOwnerId` to track which player currently owns the turn and reset it on game start via `setTurnOwnerId(null)` in `onStarted`.
- Introduced `resolveTurnIndex` helper to normalize and resolve the active seat index from multiple payload forms (`playerId`, `seatIndex`, `currentTurn`) with logic to handle 0/1-based seat indices and fallbacks.
- Updated `onTurn` to use `resolveTurnIndex`, set `currentTurn`, set `turnOwnerId`, and clear stale roll locks by resetting `setRollCooldown(0)` and `setMoving(false)` when the turn belongs to the local player.
- Adjusted `onRolled` to detect sixes for single or array roll values and set `turnOwnerId` to the roller when granting an extra roll, and wired `socket.on('turnUpdate')` to pass the `currentTurn` payload through.
- Modified turn/roll availability logic by computing `multiplayerTurnBelongsToMe` and updating `isMyTurnForRoll` to respect multiplayer ownership and local extra-rolls.

### Testing
- Ran the frontend unit test suite (`npm test`) and linters; the test suite passed without regressions.
- Performed a development build (`npm run build`) to ensure no type/build errors and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9c6b7bff48329afb56c6deaf814d1)