### PR TITLE
Improve turn resolution and roll availability in SnakeAndLadder

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -2177,29 +2177,50 @@ export default function SnakeAndLadder() {
         if (playerId === myAccountId) setPos(0);
       }, 1000);
     };
-    const onTurn = ({ playerId, seatIndex }) => {
-      let idx = -1;
+    const resolveTurnIndex = ({ playerId, seatIndex, currentTurn: currentTurnPayload }) => {
+      const players = playersRef.current;
+      const totalPlayers = players.length;
+      if (totalPlayers <= 0) return -1;
 
-      if (Number.isInteger(seatIndex)) {
-        idx = seatIndex;
-      } else {
-        idx = playersRef.current.findIndex((pl) => pl.id === playerId);
+      const idxById = players.findIndex((pl) => pl.id === playerId);
+      const normalizeIndex = (candidate) => {
+        if (!Number.isInteger(candidate)) return -1;
+        if (candidate >= 0 && candidate < totalPlayers) return candidate;
+        if (candidate > 0 && candidate - 1 < totalPlayers) return candidate - 1;
+        return -1;
+      };
 
-        // Some servers emit the active seat index instead of a playerId.
-        if (idx === -1 && Number.isInteger(playerId)) {
-          idx = playerId;
-        }
+      if (idxById >= 0) {
+        const seatNormalized = normalizeIndex(seatIndex);
+        if (seatNormalized === idxById) return idxById;
+        const currentTurnNormalized = normalizeIndex(currentTurnPayload);
+        if (currentTurnNormalized === idxById) return idxById;
       }
 
-      if (idx >= 0) {
-        setCurrentTurn(idx);
-        setDiceCount(playerDiceCounts[idx] ?? 1);
-        const turnBelongsToMe = playersRef.current[idx]?.id === myAccountId;
-        if (turnBelongsToMe) {
-          // Keep roll CTA visible for immediate extra turns.
-          setRollCooldown(0);
-        }
-        if (!turnBelongsToMe) setPendingExtraRoll(false);
+      const seatIndexResolved = normalizeIndex(seatIndex);
+      if (seatIndexResolved >= 0) return seatIndexResolved;
+
+      const currentTurnResolved = normalizeIndex(currentTurnPayload);
+      if (currentTurnResolved >= 0) return currentTurnResolved;
+
+      if (idxById >= 0) return idxById;
+      return normalizeIndex(playerId);
+    };
+
+    const onTurn = ({ playerId, seatIndex, currentTurn: currentTurnPayload }) => {
+      const idx = resolveTurnIndex({ playerId, seatIndex, currentTurn: currentTurnPayload });
+      if (idx < 0) return;
+
+      setCurrentTurn(idx);
+      setDiceCount(playerDiceCounts[idx] ?? 1);
+      const turnBelongsToMe = playersRef.current[idx]?.id === myAccountId;
+      if (turnBelongsToMe) {
+        // Keep roll CTA visible for immediate extra turns.
+        setRollCooldown(0);
+        // Safety: if movement state got stuck, never block the local extra-roll CTA.
+        setMoving(false);
+      } else {
+        setPendingExtraRoll(false);
       }
     };
     const onStarted = () => {
@@ -2313,7 +2334,7 @@ export default function SnakeAndLadder() {
     socket.on('playerReset', onReset);
     socket.on('turnChanged', onTurn);
     socket.on('turnUpdate', ({ currentTurn, playerId, seatIndex }) =>
-      onTurn({ playerId, seatIndex: Number.isInteger(currentTurn) ? currentTurn : seatIndex })
+      onTurn({ currentTurn, playerId, seatIndex })
     );
     socket.on('lobbyUpdate', ({ players: list, maxPlayers }) => {
       handleCapacity(maxPlayers);
@@ -3206,9 +3227,10 @@ export default function SnakeAndLadder() {
   const rollReady = isMultiplayer
     ? true
     : hasLocalExtraRoll || rollCooldown === 0;
+  const movementBlocksRoll = !isMultiplayer && moving;
   const canRoll =
     isMyTurnForRoll &&
-    !moving &&
+    !movementBlocksRoll &&
     rollReady &&
     !gameOver &&
     !waitingForPlayers &&
@@ -4025,7 +4047,7 @@ export default function SnakeAndLadder() {
       )}
       {isMultiplayer && myPlayerIndex !== null && (
         <div className="sr-only" aria-hidden="true">
-          {isMyTurnForRoll && !moving ? (
+          {isMyTurnForRoll ? (
             <DiceRoller
               clickable
               showButton={false}


### PR DESCRIPTION
### Motivation
- Fix incorrect or inconsistent determination of which player/seat has the current turn when servers send different event payload shapes. 
- Prevent the local roll CTA from being permanently blocked if movement state gets stuck during local extra turns. 
- Ensure UI behavior for roll availability is consistent between single-player and multiplayer modes.

### Description
- Add a `resolveTurnIndex` helper that normalizes and resolves a turn index from `playerId`, `seatIndex`, or `currentTurn` payloads and handles 0-based and 1-based seat indices. 
- Replace previous `onTurn` logic to use `resolveTurnIndex` and early-return on invalid indices, and set `setMoving(false)` when the turn belongs to the local player to unblock the roll CTA. 
- Update the `turnUpdate` socket handler to forward the `currentTurn` property into `onTurn` intact. 
- Introduce `movementBlocksRoll` to only block roll availability due to movement in single-player mode, and relax the DiceRoller visibility check to better support local extra rolls.

### Testing
- Ran the test suite with `yarn test` and all tests passed. 
- Ran the linter with `yarn lint` and there were no lint errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9c6b7bff48329afb56c6deaf814d1)