### PR TITLE
Raise portrait 3D seat camera to clear chair occlusion

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -1013,11 +1013,11 @@ const CAMERA_LATERAL_OFFSET = {
   landscape: 0 * CAMERA_LAYOUT_SCALE
 };
 const CAMERA_REAR_OFFSET = {
-  portrait: 1.06 * CAMERA_LAYOUT_SCALE,
+  portrait: 0.78 * CAMERA_LAYOUT_SCALE,
   landscape: 0.62 * CAMERA_LAYOUT_SCALE
 };
 const CAMERA_HEIGHT_BOOST = {
-  portrait: 1.79 * CAMERA_LAYOUT_SCALE,
+  portrait: 2.15 * CAMERA_LAYOUT_SCALE,
   landscape: 1.03 * CAMERA_LAYOUT_SCALE
 };
 const CAMERA_LOOK_YAW_LIMIT = THREE.MathUtils.degToRad(26);


### PR DESCRIPTION
### Motivation
- Portrait (phone) seated 3D camera was being occluded by the chair back, so camera placement needs to be lifted and pulled less far behind the seat to keep the board visible.

### Description
- Modified `webapp/public/domino-royal-game.js` to reduce `CAMERA_REAR_OFFSET.portrait` from `1.06 * CAMERA_LAYOUT_SCALE` to `0.78 * CAMERA_LAYOUT_SCALE` and increase `CAMERA_HEIGHT_BOOST.portrait` from `1.79 * CAMERA_LAYOUT_SCALE` to `2.15 * CAMERA_LAYOUT_SCALE` so the portrait camera sits higher and closer to the seat target.

### Testing
- Ran `node --check webapp/public/domino-royal-game.js`, which completed without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9e1dd615883298efd1526550032b8)