### PR TITLE
Tune Ludo chairs, camera framing, and missile impact behavior

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -507,7 +507,7 @@ const BACK_THICKNESS = 0.08 * MODEL_SCALE * STOOL_SCALE;
 const ARM_THICKNESS = 0.125 * MODEL_SCALE * STOOL_SCALE;
 const ARM_HEIGHT = 0.3 * MODEL_SCALE * STOOL_SCALE;
 const ARM_DEPTH = SEAT_DEPTH * 0.75;
-const CHAIR_LEG_TRIM_FACTOR = 0.72;
+const CHAIR_LEG_TRIM_FACTOR = 0.62;
 const BASE_COLUMN_HEIGHT = 0.5 * MODEL_SCALE * STOOL_SCALE * CHAIR_LEG_TRIM_FACTOR;
 const CARD_SCALE = 0.95;
 const CARD_W = 0.4 * MODEL_SCALE * CARD_SCALE;
@@ -555,8 +555,8 @@ const CHAIR_MODEL_URLS = [
 const TARGET_CHAIR_SIZE = new THREE.Vector3(1.3162499970197679, 1.9173749900311232, 1.7001562547683715).multiplyScalar(
   CHAIR_SIZE_SCALE
 );
-TARGET_CHAIR_SIZE.y *= 0.92;
-const TARGET_CHAIR_MIN_Y = -0.8570624993294478 * CHAIR_SIZE_SCALE + 0.045 * CHAIR_SIZE_SCALE;
+TARGET_CHAIR_SIZE.y *= 0.84;
+const TARGET_CHAIR_MIN_Y = -0.8570624993294478 * CHAIR_SIZE_SCALE + 0.01 * CHAIR_SIZE_SCALE;
 const TARGET_CHAIR_CENTER_Z = -0.1553906416893005 * CHAIR_SIZE_SCALE;
 
 const FALLBACK_SEAT_POSITIONS = [
@@ -605,11 +605,11 @@ const LANDSCAPE_CAMERA_TUNING = Object.freeze({
 const PORTRAIT_CAMERA_TUNING = Object.freeze({
   backOffset: 0.54 * ARENA_SCALE_RATIO * LUDO_ARENA_SHRINK_FACTOR,
   forwardOffset: 1.08 * ARENA_SCALE_RATIO * LUDO_ARENA_SHRINK_FACTOR,
-  heightOffset: 1.08 * ARENA_SCALE_RATIO * LUDO_ARENA_SHRINK_FACTOR,
+  heightOffset: 1.2 * ARENA_SCALE_RATIO * LUDO_ARENA_SHRINK_FACTOR,
   targetLift: 0.044 * MODEL_SCALE
 });
-const CAMERA_EXTRA_PULLBACK = 0.18 * MODEL_SCALE;
-const CAMERA_EXTRA_LIFT = 0.22 * MODEL_SCALE;
+const CAMERA_EXTRA_PULLBACK = 0.24 * MODEL_SCALE;
+const CAMERA_EXTRA_LIFT = 0.3 * MODEL_SCALE;
 const CAMERA_SEATED_INWARD_OFFSET = 0.42 * MODEL_SCALE;
 const CAMERA_SEATED_EYE_HEIGHT = 0.7 * MODEL_SCALE;
 const LUDO_HDRI_MAIN_SCENE_FACING_ROTATION_Y = Math.PI / 2;
@@ -5591,11 +5591,12 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           resolvedImpactPoint?.isVector3 === true
             ? resolvedImpactPoint
             : targetPosition?.clone?.() ?? launchAnchor.clone();
-        const impactAnchor = safeImpactPoint.clone().add(new THREE.Vector3(0, 0.06, 0));
         const from = launchAnchor.clone();
-        const travelTime = 1850;
-        const explosionTime = 920;
-        const boardCenter = new THREE.Vector3(0, from.y, 0);
+        const arcTravelTime = 980;
+        const dropTravelTime = 420;
+        const travelTime = arcTravelTime + dropTravelTime;
+        const explosionTime = 1080;
+        const cruiseHeight = Math.max(from.y, safeImpactPoint.y) + bishopHeight * 1.35;
         const started = performance.now();
         let explosionTriggered = false;
 
@@ -5607,10 +5608,10 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           explosion.root.visible = true;
           const fireLife = clamp(1 - elapsedSinceImpact / 0.88, 0, 1);
           const smokeLife = clamp(1 - elapsedSinceImpact / (explosionTime / 1000), 0, 1);
-          const fireGrow = 0.72 + elapsedSinceImpact * 1.55;
-          const smokeGrow = 0.72 + elapsedSinceImpact * 0.88;
+          const fireGrow = 0.88 + elapsedSinceImpact * 1.9;
+          const smokeGrow = 0.8 + elapsedSinceImpact * 1.02;
 
-          explosion.flash.scale.setScalar(0.44 + elapsedSinceImpact * 1.15);
+          explosion.flash.scale.setScalar(0.56 + elapsedSinceImpact * 1.42);
           explosion.flash.material.opacity = fireLife;
           explosion.fire.forEach((mesh, i) => {
             const angle = elapsedSinceImpact * 5 + i * 1.35;
@@ -5619,8 +5620,8 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
               0.11 + elapsedSinceImpact * 0.24 + i * 0.03,
               Math.sin(angle) * (0.06 + elapsedSinceImpact * 0.13)
             );
-            mesh.scale.setScalar(fireGrow * (0.78 + i * 0.13));
-            mesh.material.opacity = fireLife * (0.98 - i * 0.08);
+            mesh.scale.setScalar(fireGrow * (0.86 + i * 0.16));
+            mesh.material.opacity = fireLife * (1.05 - i * 0.06);
           });
           explosion.smoke.forEach((mesh, i) => {
             const angle = i * 1.1 + elapsedSinceImpact * 1.8;
@@ -5629,7 +5630,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
               0.12 + elapsedSinceImpact * (0.16 + i * 0.036),
               Math.sin(angle) * (0.06 + i * 0.024)
             );
-            mesh.scale.setScalar(smokeGrow * (0.66 + i * 0.12));
+            mesh.scale.setScalar(smokeGrow * (0.74 + i * 0.13));
             mesh.material.opacity = smokeLife * (0.45 - i * 0.04);
           });
         };
@@ -5651,30 +5652,27 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
               fallbackPosition: safeImpactPoint
             }) ?? safeImpactPoint.clone();
           const dynamicFrom = liveFrom.clone().add(new THREE.Vector3(0, bishopHeight * 0.54, 0));
-          const dynamicTo = liveTarget.clone().add(new THREE.Vector3(0, 0.06, 0));
-          const dynamicStartAngle = Math.atan2(dynamicFrom.z, dynamicFrom.x);
-          const dynamicEndAngle = Math.atan2(dynamicTo.z, dynamicTo.x);
-          const dynamicDelta = ((dynamicEndAngle - dynamicStartAngle + Math.PI * 3) % (Math.PI * 2)) - Math.PI;
-          const dynamicOrbitAngle = dynamicStartAngle + Math.PI * 2 + dynamicDelta;
-          const dynamicStartRadius = Math.max(dynamicFrom.clone().setY(0).length(), BOARD_RADIUS * 0.92);
-          const dynamicEndRadius = Math.max(dynamicTo.clone().setY(0).length(), BOARD_RADIUS * 0.92);
+          const dynamicTopTarget = liveTarget.clone().add(new THREE.Vector3(0, cruiseHeight, 0));
+          const dynamicImpact = liveTarget.clone().add(new THREE.Vector3(0, 0.012, 0));
           if (elapsed < travelTime) {
-            const u = easeSmooth(elapsed / travelTime);
-            const nextU = clamp(u + 0.02, 0, 1);
-            const orbitAt = (v) => {
-              const t = clamp(v, 0, 1);
-              const orbitCurve = easeSmooth(t);
-              const angle = dynamicStartAngle + (dynamicOrbitAngle - dynamicStartAngle) * orbitCurve;
-              const radius = THREE.MathUtils.lerp(dynamicStartRadius, dynamicEndRadius, orbitCurve);
-              const orbitLift = bishopHeight * (0.22 + Math.sin(Math.PI * orbitCurve) * 0.2);
-              return new THREE.Vector3(
-                boardCenter.x + Math.cos(angle) * radius,
-                dynamicFrom.y + orbitLift,
-                boardCenter.z + Math.sin(angle) * radius
-              );
+            const inDrop = elapsed >= arcTravelTime;
+            const segmentElapsed = inDrop ? elapsed - arcTravelTime : elapsed;
+            const segmentDuration = inDrop ? dropTravelTime : arcTravelTime;
+            const uRaw = clamp(segmentElapsed / Math.max(1, segmentDuration), 0, 1);
+            const u = easeSmooth(uRaw);
+            const nextU = clamp(u + 0.025, 0, 1);
+
+            const arcControlA = dynamicFrom.clone().lerp(dynamicTopTarget, 0.34).add(new THREE.Vector3(0, bishopHeight * 0.24, 0));
+            const arcControlB = dynamicFrom.clone().lerp(dynamicTopTarget, 0.72).add(new THREE.Vector3(0, bishopHeight * 0.38, 0));
+            const arcAt = (t) => cubicBezier(dynamicFrom, arcControlA, arcControlB, dynamicTopTarget, t);
+            const dropAt = (t) => {
+              const p = dynamicTopTarget.clone().lerp(dynamicImpact, t);
+              p.x = dynamicImpact.x;
+              p.z = dynamicImpact.z;
+              return p;
             };
-            const pos = orbitAt(u);
-            const next = orbitAt(nextU);
+            const pos = inDrop ? dropAt(u) : arcAt(u);
+            const next = inDrop ? dropAt(nextU) : arcAt(nextU);
             const dir = next.clone().sub(pos).normalize();
             const right = dir.clone().cross(MISSILE_WORLD_UP).normalize();
             missile.root.visible = true;
@@ -5683,15 +5681,15 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             missile.trail.forEach((puff, i) => {
               puff.position.set(
                 -0.55 - i * 0.16,
-                Math.sin(elapsed * 0.02 + i) * 0.02,
-                Math.sin(elapsed * 0.012 + i * 0.4) * 0.01 + right.z * 0.005
+                Math.sin(elapsed * 0.02 + i) * 0.018,
+                Math.sin(elapsed * 0.01 + i * 0.4) * 0.008 + right.z * 0.004
               );
-              const s = 0.85 + i * 0.16 + ((elapsed * 0.0018 + i * 0.18) % 1) * 0.6;
+              const s = 0.92 + i * 0.2 + ((elapsed * 0.0022 + i * 0.18) % 1) * 0.72;
               puff.scale.setScalar(s);
               puff.material.opacity =
                 i < 2
-                  ? clamp(0.85 - u * 0.45 - i * 0.12, 0.2, 0.85)
-                  : clamp(0.24 - (i - 2) * 0.04, 0.06, 0.24);
+                  ? clamp(0.92 - uRaw * 0.38 - i * 0.1, 0.24, 0.92)
+                  : clamp(0.28 - (i - 2) * 0.045, 0.08, 0.28);
             });
             updateExplosionRig(-1);
             requestAnimationFrame(tick);
@@ -5700,7 +5698,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
 
           missile.root.visible = false;
           const explosionElapsed = (elapsed - travelTime) / 1000;
-          explosion.root.position.copy(liveTarget.clone().add(new THREE.Vector3(0, 0.01, 0)));
+          explosion.root.position.copy(liveTarget.clone().add(new THREE.Vector3(0, 0.015, 0)));
           updateExplosionRig(explosionElapsed);
           if (!explosionTriggered) {
             explosionTriggered = true;


### PR DESCRIPTION
### Motivation
- Reduce visual chair height and keep them grounded so seating looks tighter on mobile portrait screens.
- Raise and slightly pull the gameplay camera back to give a higher, clearer view of the table in portrait orientation.
- Make capture/missile strikes land precisely on the tile from above and increase the perceived impact intensity for clearer feedback.

### Description
- Adjusted chair sizing and grounding: changed `CHAIR_LEG_TRIM_FACTOR`, reduced `TARGET_CHAIR_SIZE.y`, and lowered `TARGET_CHAIR_MIN_Y` so chairs are shorter but remain aligned to the arena floor (file: `webapp/src/pages/Games/LudoBattleRoyal.jsx`).
- Camera framing tuned: increased portrait `heightOffset` and bumped `CAMERA_EXTRA_PULLBACK` and `CAMERA_EXTRA_LIFT` to lift the camera and pull it slightly away from the table for a higher/wider view.
- Reworked missile trajectory and mapping: split the missile flight into an `arcTravelTime` and `dropTravelTime`, compute a `cruiseHeight`, route the missile to an overhead control point using a cubic Bezier arc then descend vertically to a precise impact point on the live token/tile, and use `resolveLiveTokenPosition` to prefer live token anchors.
- Intensified impact FX: increased explosion `fireGrow`, `smokeGrow`, flash scale and adjusted component scales/opacity and explosion duration and positioning to make effects stronger and centered on the impacted tile.

### Testing
- Built the webapp with `npm --prefix webapp run build` and the production build completed successfully (vite build finished and assets produced).
- The build reported chunk-size warnings but completed; no unit/integration test suite was run in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9e6db3ee08329ad6bd7ebae3bc389)