### PR TITLE
Tune Chess Battle Royal jet/drone/javelin FX for portrait visibility

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -101,13 +101,14 @@ const CAPTURE_JET_MISSILE_TRAVEL = 2.6;
 const CAPTURE_GROUND_FIRE_TIME = 0.12;
 const CAPTURE_GROUND_TRAVEL_TIME = 3.9;
 const CAPTURE_GROUND_TOTAL = CAPTURE_GROUND_FIRE_TIME + CAPTURE_GROUND_TRAVEL_TIME;
-const CAPTURE_DRONE_SCALE = 0.0735;
-const CAPTURE_JET_SCALE = 0.0588;
+const CAPTURE_DRONE_SCALE = 0.0625;
+const CAPTURE_JET_SCALE = 0.05;
 const CAPTURE_DRONE_ALTITUDE = 1.36;
 const CAPTURE_FLIGHT_ALTITUDE = CAPTURE_DRONE_ALTITUDE;
 const CAPTURE_JET_ALTITUDE = CAPTURE_FLIGHT_ALTITUDE - 0.74;
-const CAPTURE_MISSILE_SCALE = 0.07;
+const CAPTURE_MISSILE_SCALE = 0.0595;
 const CAPTURE_EXPLOSION_SCALE = 0.196;
+const CAPTURE_EDGE_PATH_FACTOR = 0.68;
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
 const BASIS_TRANSCODER_PATH = 'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/';
 
@@ -8399,18 +8400,29 @@ function Chess3D({
         const jetFx = createFxJet();
         jetFx.root.scale.setScalar(CAPTURE_JET_SCALE);
         const topSeat = fromPos.z < 0;
-        const borderOffset = half + tile * 0.9;
+        const borderOffset = half + tile * CAPTURE_EDGE_PATH_FACTOR;
+        const entryClamp = half - tile * 0.22;
+        const attackAltitude = CAPTURE_JET_ALTITUDE - 0.08;
+        const edgeLane = topSeat ? -borderOffset : borderOffset;
         const jetStart = new THREE.Vector3(
-          THREE.MathUtils.clamp(fromPos.x, -half + tile * 0.4, half - tile * 0.4),
+          THREE.MathUtils.clamp(fromPos.x, -entryClamp, entryClamp),
           CAPTURE_JET_ALTITUDE,
-          topSeat ? -borderOffset : borderOffset
+          edgeLane
         );
-        const jetApproach = fromPos.clone().add(new THREE.Vector3(0, CAPTURE_JET_ALTITUDE - 0.05, 0));
-        const jetAttack = targetPos.clone().add(new THREE.Vector3(0, CAPTURE_JET_ALTITUDE - 0.12, 0));
+        const jetApproach = new THREE.Vector3(
+          THREE.MathUtils.clamp(fromPos.x, -entryClamp, entryClamp),
+          attackAltitude,
+          THREE.MathUtils.lerp(edgeLane, fromPos.z, 0.2)
+        );
+        const jetAttack = new THREE.Vector3(
+          THREE.MathUtils.clamp(targetPos.x, -entryClamp, entryClamp),
+          attackAltitude - 0.04,
+          THREE.MathUtils.lerp(edgeLane, targetPos.z, 0.26)
+        );
         const jetExit = new THREE.Vector3(
-          THREE.MathUtils.clamp(targetPos.x, -half + tile * 0.4, half - tile * 0.4),
+          THREE.MathUtils.clamp(targetPos.x, -entryClamp, entryClamp),
           CAPTURE_JET_ALTITUDE - 0.08,
-          topSeat ? -borderOffset : borderOffset
+          edgeLane
         );
         jetFx.root.position.copy(jetStart);
         captureFxGroup.add(jetFx.root);
@@ -10000,10 +10012,10 @@ function Chess3D({
                 to: fx.to.clone().add(new THREE.Vector3(0, 0.02, 0)),
                 progress: mu,
                 launchHeight: 0.02,
-                orbitHeight: CAPTURE_FLIGHT_ALTITUDE * 0.28,
-                orbitRadiusMul: 0.74,
-                minOrbitCycles: 0.24,
-                orbitSplit: 0.74
+                orbitHeight: CAPTURE_FLIGHT_ALTITUDE * 0.2,
+                orbitRadiusMul: 0.56,
+                minOrbitCycles: 0.14,
+                orbitSplit: 0.68
               });
             }
             if (!pose) {
@@ -10040,8 +10052,8 @@ function Chess3D({
             } else if (jetU < orbitSplit) {
               const orbitU = smoothEase((jetU - enterSplit) / (orbitSplit - enterSplit));
               const uControl = fx.orbitEntryPos.clone().lerp(fx.orbitExitPos, 0.4);
-              uControl.y = CAPTURE_JET_ALTITUDE - 0.42;
-              uControl.z += fx.topSeat ? 0.65 : -0.65;
+              uControl.y = CAPTURE_JET_ALTITUDE - 0.3;
+              uControl.z += fx.topSeat ? 0.28 : -0.28;
               jetPos = qBezier(fx.orbitEntryPos, uControl, fx.orbitExitPos, orbitU);
               jetNext = qBezier(fx.orbitEntryPos, uControl, fx.orbitExitPos, clamp01(orbitU + 0.04));
             } else if (jetU < exitSplit) {
@@ -10106,16 +10118,23 @@ function Chess3D({
               fx.missileFx.root.position.copy(launchPos);
             } else if (fx.t < impactTime) {
               const mu = smoothEase((fx.t - CAPTURE_GROUND_FIRE_TIME) / CAPTURE_GROUND_TRAVEL_TIME);
-              const { pos: missilePos, next: missileNext } = getCaptureRingOrbitPose({
-                from: launchPos,
-                to: fx.to.clone().add(new THREE.Vector3(0, 0.02, 0)),
-                progress: mu,
-                launchHeight: 0.02,
-                orbitHeight: CAPTURE_FLIGHT_ALTITUDE * 0.28,
-                orbitRadiusMul: 0.74,
-                minOrbitCycles: 0.24,
-                orbitSplit: 0.74
-              });
+              const targetTop = fx.to.clone().add(new THREE.Vector3(0, 0.3, 0));
+              const diagonalEnd = launchPos.clone().lerp(targetTop, 0.78);
+              const diagonalLift = CAPTURE_FLIGHT_ALTITUDE * 0.12;
+              let missilePos;
+              let missileNext;
+              if (mu < 0.72) {
+                const diagU = smoothEase(mu / 0.72);
+                const control = launchPos.clone().lerp(diagonalEnd, 0.5).add(new THREE.Vector3(0, diagonalLift, 0));
+                missilePos = qBezier(launchPos, control, diagonalEnd, diagU);
+                missileNext = qBezier(launchPos, control, diagonalEnd, clamp01(diagU + 0.03));
+              } else {
+                const dropU = smoothEase((mu - 0.72) / 0.28);
+                missilePos = diagonalEnd.clone().lerp(fx.to, dropU);
+                missileNext = diagonalEnd.clone().lerp(fx.to, clamp01(dropU + 0.04));
+                missileNext.x = missilePos.x;
+                missileNext.z = missilePos.z;
+              }
 
               fx.missileFx.root.visible = true;
               fx.missileFx.root.position.copy(missilePos);


### PR DESCRIPTION
### Motivation
- Improve visibility of aerial capture FX on phones in portrait orientation by keeping flight paths near board edges and making flying assets less visually dominant.  
- Make drone, jet, and javelin sizes ~15% smaller and change javelin launch to a diagonal-to-vertical strike to match display constraints and requested motion.

### Description
- Reduced FX scales: `CAPTURE_DRONE_SCALE` from 0.0735 -> 0.0625, `CAPTURE_JET_SCALE` from 0.0588 -> 0.05, and `CAPTURE_MISSILE_SCALE` from 0.07 -> 0.0595.  
- Added `CAPTURE_EDGE_PATH_FACTOR` and moved jet entry/approach/attack/exit positions to be clamped near the board edge lane so the jet remains visible when entering/exiting (`jetStart`, `jetApproach`, `jetAttack`, `jetExit`).  
- Tightened jet orbit control (lowered control point Y and reduced lateral Z offset) so the jet path runs closer to the board edges and is less deep off-screen.  
- Shortened/tightened drone orbit envelope by lowering orbit height, reducing orbit radius multiplier, and reducing min orbit cycles and split parameters so drone arcs stay nearer the board.  
- Reworked javelin flight: replaced the ring-orbit pose with a diagonal Bezier launch toward an elevated intermediate point and then a near-vertical terminal drop to the target so the whole path is shorter and remains on-screen in portrait mode.  
- All edits are localized to `webapp/src/pages/Games/ChessBattleRoyal.jsx` (capture FX constants and animation/path logic).

### Testing
- Ran `npm -s run test -- test/chessBattleInventoryConfig.test.js` and the suite passed.  
- No other automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da0b207c44832981e62109d7e07273)