### PR TITLE
Adjust Chess Royale jet/missile pacing and explosion sizing

### DIFF
--- a/webapp/public/chess-royale.html
+++ b/webapp/public/chess-royale.html
@@ -249,7 +249,7 @@ const MISSILE_TRAIL_COUNT=5;
 const MISSILE_TRAIL_SPACING=0.08;
 const JET_HEIGHT=0.19;
 const JET_SIZE=0.31;
-const JET_SPEED_FACTOR=1.38;
+const JET_SPEED_FACTOR=2.07; // 50% slower jet + jet-fired missile travel timing
 const DRONE_SIZE=0.048;
 const scalePieceNode=node=>{ if(!node) return; if(!node.userData.baseScale) node.userData.baseScale=node.scale.clone(); node.scale.copy(node.userData.baseScale).multiplyScalar(PIECE_SIZE_MULTIPLIER); };
 
@@ -465,7 +465,7 @@ function setTravelOrientation(node,from,to,bank=0){
 }
 function getJetIngressAndEgress(from,to){
   const center=from.clone().lerp(to,0.5);
-  const margin=2.2;
+  const margin=2.0; // bring the fly-by path closer so it appears on-screen a bit earlier
   const useTop=Math.random()>0.5;
   const zEdge=center.z+(useTop?margin:-margin);
   const entry=new THREE.Vector3(center.x,JET_HEIGHT,zEdge);
@@ -547,7 +547,7 @@ function animateTinyExplosion(position,color=0xffb703){
     const e0=performance.now(), ed=180;
     const boom=ev=>{
       const et=Math.min(1,(ev-e0)/ed);
-      blast.scale.setScalar(1+0.68*et);
+      blast.scale.setScalar(1+0.56*et); // slightly smaller blast growth
       blast.material.opacity=0.85*(1-et);
       if(et<1) requestAnimationFrame(boom);
       else{


### PR DESCRIPTION
### Motivation

- Improve readability of fast visual FX by slowing down jet fly-bys and their missiles so the player can track motion more easily.
- Make the jet pass appear on-screen slightly earlier so the approach is more visible to players on small/portrait screens.
- Tone down small explosion visuals so captures feel less overwhelming and match the slower pacing.

### Description

- Increased `JET_SPEED_FACTOR` in `webapp/public/chess-royale.html` from `1.38` to `2.07` to slow the fighter jet fly-by and associated jet-fired missile timing by ~50%.
- Reduced the ingress/egress path margin in `getJetIngressAndEgress` from `2.2` to `2.0` to bring the fly-by path closer so the jet appears on-screen a bit earlier.
- Reduced tiny explosion growth in `animateTinyExplosion` by changing the scale growth term from `1 + 0.68 * t` to `1 + 0.56 * t` for a slightly smaller blast visual.
- All edits were made in the single file `webapp/public/chess-royale.html`.

### Testing

- Ran basic repository static checks (`git diff --check`) and local status verification which completed without flagged issues.
- No automated unit/integration tests were added or modified for this visual/timing tweak.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da253da8808329a5f77076495209a0)