### PR TITLE
Tune Chess Battle Royal jet/drone capture timing and trajectories

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -95,9 +95,9 @@ const CAPTURE_DRONE_LIFT_TIME = 0.144;
 const CAPTURE_DRONE_CRUISE_TIME = 2.62;
 const CAPTURE_DRONE_DIVE_TIME = 1.28;
 const CAPTURE_DRONE_TOTAL = CAPTURE_DRONE_LIFT_TIME + CAPTURE_DRONE_CRUISE_TIME + CAPTURE_DRONE_DIVE_TIME;
-const CAPTURE_JET_TOTAL = CAPTURE_DRONE_TOTAL * 1.5; // fighter jet now flies 50% slower
-const CAPTURE_JET_MISSILE_TRAVEL = 1.65 * 1.5; // jet missile now travels 50% slower
-const CAPTURE_JET_MISSILE_RELEASE_RATIO = 0.58;
+const CAPTURE_JET_TOTAL = CAPTURE_DRONE_TOTAL * 0.9; // jet is slightly faster than drone, but no longer too fast visually
+const CAPTURE_JET_MISSILE_TRAVEL = 3.02; // align with drone pacing, only a little faster
+const CAPTURE_JET_MISSILE_RELEASE_RATIO = 0.34; // launch much earlier so strike starts almost immediately
 const CAPTURE_GROUND_FIRE_TIME = 0.12;
 const CAPTURE_GROUND_TRAVEL_TIME = 2.9;
 const CAPTURE_GROUND_TOTAL = CAPTURE_GROUND_FIRE_TIME + CAPTURE_GROUND_TRAVEL_TIME;
@@ -1013,7 +1013,6 @@ const CHECKMATE_SOUND_URL =
   'https://raw.githubusercontent.com/lichess-org/lila/master/public/sound/standard/End.mp3';
 const LAUGH_SOUND_URL = '/assets/sounds/Haha.mp3';
 const DRONE_FLY_SOUND_URL = '/assets/sounds/spinning.mp3';
-const JET_FLY_SOUND_URL = '/assets/sounds/race-care-151963.mp3';
 const BAZOOKA_FIRE_SOUND_URL = '/assets/sounds/launch-85216.mp3';
 const MISSILE_IMPACT_SOUND_URL = '/assets/sounds/080998_bullet-hit-39870.mp3';
 
@@ -7360,8 +7359,6 @@ function Chess3D({
     missileLaunchSoundRef.current.volume = baseVolume;
     missileImpactSoundRef.current = new Audio(MISSILE_IMPACT_SOUND_URL);
     missileImpactSoundRef.current.volume = baseVolume;
-    const jetFlySound = new Audio(JET_FLY_SOUND_URL);
-    jetFlySound.volume = baseVolume;
 
     let stopCameraTween = () => {};
     let onResize = null;
@@ -8400,8 +8397,8 @@ function Chess3D({
         const jetFx = createFxJet();
         jetFx.root.scale.setScalar(CAPTURE_JET_SCALE);
         const attackFromRightSide = fromPos.x >= 0;
-        const borderOffset = half + tile * CAPTURE_EDGE_PATH_FACTOR;
-        const entryClamp = half - tile * 0.22;
+        const borderOffset = half + tile * 0.18;
+        const entryClamp = half - tile * 0.14;
         const attackAltitude = CAPTURE_JET_ALTITUDE - 0.05;
         const sideLane = attackFromRightSide ? borderOffset : -borderOffset;
         const jetStart = new THREE.Vector3(
@@ -8430,7 +8427,6 @@ function Chess3D({
         missileFx.root.scale.setScalar(CAPTURE_MISSILE_SCALE);
         missileFx.root.visible = false;
         captureFxGroup.add(missileFx.root);
-        playAudio({ current: jetFlySound }, { maxDurationMs: CAPTURE_JET_TOTAL * 1000 });
         activeCaptureFx.push({
           type: 'jet',
           t: 0,
@@ -10020,9 +10016,7 @@ function Chess3D({
               } else {
                 const dropU = smoothEase((mu - 0.68) / 0.32);
                 const pos = diagonalEnd.clone().lerp(fx.to, dropU);
-                const next = diagonalEnd.clone().lerp(fx.to, clamp01(dropU + 0.04));
-                next.x = pos.x;
-                next.z = pos.z;
+                const next = diagonalEnd.clone().lerp(fx.to, clamp01(dropU + 0.06));
                 pose = { pos, next };
               }
             }
@@ -10310,7 +10304,6 @@ function Chess3D({
       laughSoundRef.current?.pause();
       swordSoundRef.current?.pause();
       droneSoundRef.current?.pause();
-      jetFlySound?.pause?.();
       missileLaunchSoundRef.current?.pause();
       missileImpactSoundRef.current?.pause();
       activeCaptureFx.splice(0, activeCaptureFx.length);


### PR DESCRIPTION
### Motivation
- Improve visual pacing of the Queen capture sequence by making the jet/jet-missile timing match the drone more closely and bring the jet into view earlier. 
- Remove the distracting initial jet fly-by sound while keeping capture audio for drones and missiles. 
- Keep drone approach visually diagonal so it hits targets on a diagonal vector rather than snapping to vertical.

### Description
- Adjusted capture timing constants: changed `CAPTURE_JET_TOTAL`, `CAPTURE_JET_MISSILE_TRAVEL`, and `CAPTURE_JET_MISSILE_RELEASE_RATIO` in `webapp/src/pages/Games/ChessBattleRoyal.jsx` to pace jet movement and missile release relative to the drone. 
- Removed the `JET_FLY_SOUND_URL` usage and the initial `jetFlySound` playback so the jet no longer plays an initial fly-by sound, while leaving other audio (drone/missile) intact. 
- Moved the jet ingress lane closer to the board by modifying `borderOffset` and `entryClamp` to make the jet appear nearer the board earlier. 
- Kept the drone terminal approach diagonal by adjusting the final interpolation for the drone `next` pose so the capture direction preserves a diagonal strike vector. 

### Testing
- Ran unit tests: `npm run test -- --runInBand test/chessBattleInventoryConfig.test.js` which passed (1 test suite, 3 tests passed). 
- Ran lint check: `npx eslint webapp/src/pages/Games/ChessBattleRoyal.jsx` produced an eslint ignore warning for the file (no actionable lint errors processed due to repo ignore settings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da2b0c97e883299aa5a73d14036b0c)