### PR TITLE
Restore Ludo camera auto-focus and start in standing max-zoom view

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -591,7 +591,7 @@ const CAMERA_TARGET_LIFT = 0.028 * MODEL_SCALE;
 const CAMERA_SIDE_LOOK_EXTRA = 0.2 * MODEL_SCALE;
 const CAMERA_TURN_PLAYER_LERP = 0.44;
 const CAMERA_BROADCAST_TARGET_BLEND = 0.5;
-const LUDO_CAMERA_AUTO_LOOK_ENABLED = false;
+const LUDO_CAMERA_AUTO_LOOK_ENABLED = true;
 const CAMERA_FREE_LOOK_AZIMUTH_RANGE = Infinity;
 const CAMERA_FREE_LOOK_POLAR_DELTA = THREE.MathUtils.degToRad(55);
 const CAMERA_ZOOM_MIN_FACTOR = 0.8;
@@ -4971,8 +4971,12 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     controls.maxPolarAngle = Math.min(CAM.phiMax, initialPolar + CAMERA_FREE_LOOK_POLAR_DELTA);
     controls.minDistance = initialCameraRadius * CAMERA_ZOOM_MIN_FACTOR;
     controls.maxDistance = initialCameraRadius * CAMERA_ZOOM_MAX_FACTOR;
+    if (controls.maxDistance > 0) {
+      const lookDirection = camera.position.clone().sub(boardLookTarget).normalize();
+      camera.position.copy(boardLookTarget).add(lookDirection.multiplyScalar(controls.maxDistance));
+    }
     controlsRef.current = controls;
-    baseCameraRadiusRef.current = initialCameraRadius;
+    baseCameraRadiusRef.current = camera.position.distanceTo(boardLookTarget);
     syncSkyboxToCameraRef.current = () => {
       if (!camera || !boardLookTarget) return;
       const skybox = envSkyboxRef.current;
@@ -5052,44 +5056,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       arenaGroup.add(group);
       chairs.push({ group, anchor: avatarAnchor });
     }
-    const selfChairGroup = chairs[0]?.group;
-    if (selfChairGroup && camera && controls && boardLookTargetRef.current) {
-      const boardTarget = boardLookTargetRef.current.clone();
-      const seatWorld = selfChairGroup.getWorldPosition(new THREE.Vector3());
-      const inwardDirection = boardTarget.clone().sub(seatWorld).setY(0);
-      if (inwardDirection.lengthSq() > 1e-6) {
-        inwardDirection.normalize();
-        const seatedEyePosition = seatWorld.clone().addScaledVector(inwardDirection, CAMERA_SEATED_INWARD_OFFSET);
-        seatedEyePosition.y =
-          (tableInfo.surfaceY ?? TABLE_HEIGHT) +
-          (isPortrait ? PORTRAIT_CAMERA_SEATED_EYE_HEIGHT : CAMERA_SEATED_EYE_HEIGHT);
-
-        const desiredRadius = clamp(
-          CAM.maxR * initialDistanceFactor * CAMERA_SEATED_DISTANCE_FACTOR,
-          CAM.minR,
-          CAM.maxR
-        );
-        const fromTarget = seatedEyePosition.clone().sub(boardTarget).setY(0);
-        if (fromTarget.lengthSq() > 1e-6) {
-          fromTarget.normalize();
-          seatedEyePosition
-            .copy(boardTarget)
-            .addScaledVector(fromTarget, desiredRadius);
-          seatedEyePosition.y =
-            (tableInfo.surfaceY ?? TABLE_HEIGHT) +
-            (isPortrait ? PORTRAIT_CAMERA_SEATED_EYE_HEIGHT : CAMERA_SEATED_EYE_HEIGHT);
-        }
-
-        camera.position.copy(seatedEyePosition);
-        controls.target.copy(boardTarget);
-        camera.lookAt(boardTarget);
-        const seatedRadius = camera.position.distanceTo(boardTarget);
-        controls.minDistance = seatedRadius * CAMERA_ZOOM_MIN_FACTOR;
-        controls.maxDistance = seatedRadius * CAMERA_ZOOM_MAX_FACTOR;
-        baseCameraRadiusRef.current = seatedRadius;
-        controls.update();
-      }
-    }
+    controls.update();
     groundArenaToHdriFloor({ preserveView: true });
     updateEnvironmentFloor();
 


### PR DESCRIPTION
### Motivation
- Players should start the Ludo Battle Royal match in a standing/overview camera (max zoom-out) instead of a low seated view, and the camera should automatically focus on the active player/dice/token during turns as before.

### Description
- Re-enabled automatic camera turn/focus by setting `LUDO_CAMERA_AUTO_LOOK_ENABLED = true` in `LudoBattleRoyal.jsx` so turn/dice/token focus logic can run again.
- Force the initial camera to the farthest allowed zoom-out by repositioning the camera along its look direction using `controls.maxDistance` immediately after `OrbitControls` initialization.
- Use the actual camera distance to the board for `baseCameraRadiusRef` via `camera.position.distanceTo(boardLookTarget)` so skybox scaling and zoom clamping remain consistent with the new start view.
- Removed the post-chair seated-eye override that forced a low/close starting pose and replaced it with a simple `controls.update()` to keep the view synced.

### Testing
- Ran `npx eslint webapp/src/pages/Games/LudoBattleRoyal.jsx` (and a second run with `--no-ignore`); the file is ignored by repo eslint patterns so no lint errors were reported for this change.
- Local commit was created containing the change to `webapp/src/pages/Games/LudoBattleRoyal.jsx` and no automated test failures were produced by the commands run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da2bd15f3c83299be194455e8581de)