### PR TITLE
Ludo Battle Royal: start camera in standing view and max zoomed-out

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -612,10 +612,6 @@ const PORTRAIT_CAMERA_TUNING = Object.freeze({
 const CAMERA_EXTRA_PULLBACK = 0.3 * MODEL_SCALE;
 const CAMERA_EXTRA_LIFT = 0.52 * MODEL_SCALE;
 const PORTRAIT_CAMERA_EXTRA_LIFT = 1.52 * MODEL_SCALE;
-const CAMERA_SEATED_INWARD_OFFSET = 0.72 * MODEL_SCALE;
-const CAMERA_SEATED_EYE_HEIGHT = 0.9 * MODEL_SCALE;
-const PORTRAIT_CAMERA_SEATED_EYE_HEIGHT = 1.02 * MODEL_SCALE;
-const CAMERA_SEATED_DISTANCE_FACTOR = 0.62;
 const LUDO_HDRI_MAIN_SCENE_FACING_ROTATION_Y = Math.PI / 2;
 
 const DEFAULT_STOOL_THEME = Object.freeze({ legColor: '#1f1f1f' });
@@ -1896,7 +1892,7 @@ const CAMERA_BASE_RADIUS = Math.max(TABLE_RADIUS, BOARD_RADIUS);
 const CAMERA_EXTRA_ZOOM_IN = 0.82;
 const CAMERA_EXTRA_ZOOM_OUT = 1.26;
 const INITIAL_CAMERA_DISTANCE_FACTOR = 1;
-const PORTRAIT_INITIAL_CAMERA_DISTANCE_FACTOR = 1.1;
+const PORTRAIT_INITIAL_CAMERA_DISTANCE_FACTOR = 1;
 const CAM = {
   fov: CAMERA_FOV,
   near: CAMERA_NEAR,
@@ -4941,7 +4937,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     boardLookTargetRef.current = boardLookTarget;
     const initialCameraDirection = camera.position.clone().sub(boardLookTarget).normalize();
     const initialDistanceFactor = isPortrait ? PORTRAIT_INITIAL_CAMERA_DISTANCE_FACTOR : INITIAL_CAMERA_DISTANCE_FACTOR;
-    const desiredInitialCameraRadius = clamp(CAM.maxR * initialDistanceFactor, CAM.minR, CAM.maxR);
+    const desiredInitialCameraRadius = CAM.maxR;
     camera.position.copy(boardLookTarget).add(initialCameraDirection.multiplyScalar(desiredInitialCameraRadius));
     camera.position.y += CAMERA_3D_HEIGHT_BOOST + (isPortrait ? PORTRAIT_CAMERA_EXTRA_LIFT : CAMERA_EXTRA_LIFT);
     camera.lookAt(boardLookTarget);
@@ -5052,44 +5048,10 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       arenaGroup.add(group);
       chairs.push({ group, anchor: avatarAnchor });
     }
-    const selfChairGroup = chairs[0]?.group;
-    if (selfChairGroup && camera && controls && boardLookTargetRef.current) {
-      const boardTarget = boardLookTargetRef.current.clone();
-      const seatWorld = selfChairGroup.getWorldPosition(new THREE.Vector3());
-      const inwardDirection = boardTarget.clone().sub(seatWorld).setY(0);
-      if (inwardDirection.lengthSq() > 1e-6) {
-        inwardDirection.normalize();
-        const seatedEyePosition = seatWorld.clone().addScaledVector(inwardDirection, CAMERA_SEATED_INWARD_OFFSET);
-        seatedEyePosition.y =
-          (tableInfo.surfaceY ?? TABLE_HEIGHT) +
-          (isPortrait ? PORTRAIT_CAMERA_SEATED_EYE_HEIGHT : CAMERA_SEATED_EYE_HEIGHT);
-
-        const desiredRadius = clamp(
-          CAM.maxR * initialDistanceFactor * CAMERA_SEATED_DISTANCE_FACTOR,
-          CAM.minR,
-          CAM.maxR
-        );
-        const fromTarget = seatedEyePosition.clone().sub(boardTarget).setY(0);
-        if (fromTarget.lengthSq() > 1e-6) {
-          fromTarget.normalize();
-          seatedEyePosition
-            .copy(boardTarget)
-            .addScaledVector(fromTarget, desiredRadius);
-          seatedEyePosition.y =
-            (tableInfo.surfaceY ?? TABLE_HEIGHT) +
-            (isPortrait ? PORTRAIT_CAMERA_SEATED_EYE_HEIGHT : CAMERA_SEATED_EYE_HEIGHT);
-        }
-
-        camera.position.copy(seatedEyePosition);
-        controls.target.copy(boardTarget);
-        camera.lookAt(boardTarget);
-        const seatedRadius = camera.position.distanceTo(boardTarget);
-        controls.minDistance = seatedRadius * CAMERA_ZOOM_MIN_FACTOR;
-        controls.maxDistance = seatedRadius * CAMERA_ZOOM_MAX_FACTOR;
-        baseCameraRadiusRef.current = seatedRadius;
-        controls.update();
-      }
-    }
+    controls.minDistance = CAM.minR;
+    controls.maxDistance = CAM.maxR * CAMERA_ZOOM_MAX_FACTOR;
+    baseCameraRadiusRef.current = desiredInitialCameraRadius;
+    controls.update();
     groundArenaToHdriFloor({ preserveView: true });
     updateEnvironmentFloor();
 


### PR DESCRIPTION
### Motivation
- Players reported the game opening in a low, seated camera view instead of a standing/overview framing and requested the initial view be maximally zoomed out for better context.
- The startup seated-eye override was moving the camera too close and conflicted with the intended turn/dice/token focus behavior.
- The goal is to start with a wide arena framing while preserving the existing per-turn and dice/token focus logic that drives look/follow during gameplay.

### Description
- Changed portrait startup factor so portrait uses the same baseline as landscape by setting `PORTRAIT_INITIAL_CAMERA_DISTANCE_FACTOR` to `1` in `webapp/src/pages/Games/LudoBattleRoyal.jsx`.
- Force the initial camera radius to the arena maximum by assigning `desiredInitialCameraRadius = CAM.maxR` instead of clamping a smaller startup factor.
- Removed the startup seated-eye override block that previously repositioned the camera near the player chair and instead set `controls.minDistance`/`controls.maxDistance` to `CAM.minR`/`CAM.maxR * CAMERA_ZOOM_MAX_FACTOR` and `baseCameraRadiusRef.current` to the desired initial radius.
- All edits are contained in `webapp/src/pages/Games/LudoBattleRoyal.jsx` and keep existing `setCameraFocus` / `setCameraViewForTurn` flows intact for dice and token actions.

### Testing
- Built the webapp with `npm --prefix webapp run build` and the build completed successfully.
- No unit tests were added or modified for this change and no automated visual regression test was available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da2bd15f3c83299be194455e8581de)