### PR TITLE
Match Pool Royale cue stroke timing to reference push animation

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -22661,7 +22661,7 @@ const powerRef = useRef(hud.power);
           if (forwardOnly) {
             const safeStrikeDuration = Math.max(1, strikeDuration ?? 120);
             const safeHoldDuration = Math.max(0, holdDuration ?? 50);
-            const safeRecoverDuration = Math.max(90, recoverDuration ?? 0);
+            const safeRecoverDuration = Math.max(0, recoverDuration ?? 0);
             const impactThreshold = THREE.MathUtils.clamp(
               strikeImpactThreshold ?? 0.9,
               0,
@@ -25791,15 +25791,16 @@ const powerRef = useRef(hud.power);
         const p = THREE.MathUtils.clamp(powerRatio ?? 0, 0, 1);
         const pullbackDuration = THREE.MathUtils.lerp(90, 170, p);
         return {
-          // Keep a shorter charge-up while preserving a visible pullback/strike cycle.
+          // Match the reference cue workflow exactly:
+          // drag = pull back, release = immediate forward strike.
           motion: 'classic',
           pullRatio: easeOutCubic(p),
           pullSmoothing: 1,
-          strikeDuration: Math.max(LIVE_CUE_FORWARD_DURATION_MS, 170),
-          holdDuration: Math.max(LIVE_CUE_IMPACT_HOLD_MS, 80),
+          strikeDuration: 120,
+          holdDuration: 50,
           pullbackDuration,
           recoverDuration: 0,
-          impactThreshold: 0.88,
+          impactThreshold: 0.9,
           forwardOnly: false,
           cameraExtraHoldMs: 240,
           spinScale: 0.22


### PR DESCRIPTION
### Motivation

- The cue stick forward motion and impact timing needed to match the reference technique so the visible animation and the power transmission from the slider feel identical to the sample implementation. 
- Preserve the existing slider-to-shot power linkage and spin mapping while fixing only the cue animation timing and impact cadence.

### Description

- Updated `resolveCueStrokeProfile` in `webapp/src/pages/Games/PoolRoyale.jsx` to use a fixed forward strike of `120ms`, a `50ms` hold, `recoverDuration: 0`, and `impactThreshold: 0.9` so the drag/release behaves like the reference push animation. 
- Changed the forward-only stroke branch to stop forcing a 90ms minimum recover window by using `Math.max(0, recoverDuration ?? 0)` so the release finishes immediately after hold when appropriate. 
- Kept all existing shot-power and spin calculations intact so the slider still controls shot power and spin-to-physics mapping is preserved.

### Testing

- Ran the cue stroke timeline unit tests with `npm test -- test/poolRoyaleCueStrokeTimeline.test.js`, and the suite passed (`4 tests, 0 failures`).
- No other automated tests were changed and existing pool-related logic was left untouched aside from the stroke timing adjustments.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da356c6b688329a55ccdb7861153e1)