### PR TITLE
Normalize Pool Royale cue stroke payloads so replay shows cue push/follow-through

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -22897,17 +22897,73 @@ const powerRef = useRef(hud.power);
             normalizeVector3Snapshot(value, { x: 0, y: BALL_CENTER_Y, z: 0 });
           const cueStroke = cueStrokeRaw
             ? {
-                warmup: normalizeStrokeVec(cueStrokeRaw.warmup),
-                start: normalizeStrokeVec(cueStrokeRaw.start ?? cueStrokeRaw.warmup),
-                impact: normalizeStrokeVec(cueStrokeRaw.impact ?? cueStrokeRaw.start),
-                settle: normalizeStrokeVec(cueStrokeRaw.settle ?? cueStrokeRaw.impact),
+                warmup: normalizeStrokeVec(cueStrokeRaw.warmup ?? cueStrokeRaw.idle),
+                start: normalizeStrokeVec(
+                  cueStrokeRaw.start ?? cueStrokeRaw.pull ?? cueStrokeRaw.warmup
+                ),
+                idle: normalizeStrokeVec(cueStrokeRaw.idle ?? cueStrokeRaw.warmup),
+                pull: normalizeStrokeVec(
+                  cueStrokeRaw.pull ?? cueStrokeRaw.start ?? cueStrokeRaw.warmup
+                ),
+                impact: normalizeStrokeVec(
+                  cueStrokeRaw.impact ?? cueStrokeRaw.follow ?? cueStrokeRaw.start
+                ),
+                follow: normalizeStrokeVec(
+                  cueStrokeRaw.follow ?? cueStrokeRaw.settle ?? cueStrokeRaw.impact
+                ),
+                settle: normalizeStrokeVec(
+                  cueStrokeRaw.settle ?? cueStrokeRaw.follow ?? cueStrokeRaw.impact
+                ),
                 rotationX: Number.isFinite(cueStrokeRaw.rotationX) ? cueStrokeRaw.rotationX : 0,
                 rotationY: Number.isFinite(cueStrokeRaw.rotationY) ? cueStrokeRaw.rotationY : 0,
                 pullback: Math.max(0, cueStrokeRaw.pullbackDuration ?? cueStrokeRaw.pullback ?? 0),
-                forward: Math.max(0, cueStrokeRaw.forwardDuration ?? cueStrokeRaw.forward ?? 0),
+                forward: Math.max(
+                  0,
+                  cueStrokeRaw.releaseDuration ??
+                    cueStrokeRaw.forwardDuration ??
+                    cueStrokeRaw.release ??
+                    cueStrokeRaw.forward ??
+                    0
+                ),
+                release: Math.max(
+                  0,
+                  cueStrokeRaw.releaseDuration ??
+                    cueStrokeRaw.forwardDuration ??
+                    cueStrokeRaw.release ??
+                    cueStrokeRaw.forward ??
+                    0
+                ),
                 settleTime: Math.max(
                   0,
-                  cueStrokeRaw.settleDuration ?? cueStrokeRaw.settleTime ?? 0
+                  cueStrokeRaw.followDuration ??
+                    cueStrokeRaw.settleDuration ??
+                    cueStrokeRaw.followTime ??
+                    cueStrokeRaw.settleTime ??
+                    0
+                ),
+                followDuration: Math.max(
+                  0,
+                  cueStrokeRaw.followDuration ??
+                    cueStrokeRaw.settleDuration ??
+                    cueStrokeRaw.followTime ??
+                    cueStrokeRaw.settleTime ??
+                    0
+                ),
+                recoverTime: Math.max(
+                  0,
+                  cueStrokeRaw.recoverDuration ??
+                    cueStrokeRaw.returnDuration ??
+                    cueStrokeRaw.recoverTime ??
+                    cueStrokeRaw.returnTime ??
+                    0
+                ),
+                recoverDuration: Math.max(
+                  0,
+                  cueStrokeRaw.recoverDuration ??
+                    cueStrokeRaw.returnDuration ??
+                    cueStrokeRaw.recoverTime ??
+                    cueStrokeRaw.returnTime ??
+                    0
                 ),
                 startOffset: Math.max(0, cueStrokeRaw.startOffset ?? 0)
               }


### PR DESCRIPTION
### Motivation
- Replays were sometimes starting with a static cue pose because recorded stroke payloads used different field names or lacked the full cue state, causing the forward/push phase to be missing in playback.
- The cue forward push and follow-through are visually important to match live shot appearance and must be reconstructed deterministically from recorded data.

### Description
- Normalize recorded `cueStroke` payloads in `PoolRoyale` so replay always has canonical pose keys (`idle`, `pull`, `impact`, `follow`) derived from legacy and new aliases.
- Map timing aliases into the replay stroke (support `releaseDuration` / `release`, `followDuration` / `followTime`, `recoverDuration` / `recoverTime`, etc.) so release/follow/recover windows are preserved in playback.
- Preserve backwards compatibility by falling back to older keys (`warmup`, `start`, `settle`, `forward`) when newer names are not present.
- Changed file: `webapp/src/pages/Games/PoolRoyale.jsx` (normalizes and expands `cueStroke` construction inside `trimReplayRecording`).

### Testing
- Ran the repository linter on the modified file with `npm run -s lint -- webapp/src/pages/Games/PoolRoyale.jsx`, which completed and produced the existing React detection warning but did not surface errors for the change.
- No other automated tests were run in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da3ee9f9148329b081c64d0e606069)