### PR TITLE
Adjust Chess Battle Royal jet and drone capture behavior

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -95,22 +95,22 @@ const CAPTURE_DRONE_LIFT_TIME = 0.144;
 const CAPTURE_DRONE_CRUISE_TIME = 2.62;
 const CAPTURE_DRONE_DIVE_TIME = 1.28;
 const CAPTURE_DRONE_TOTAL = CAPTURE_DRONE_LIFT_TIME + CAPTURE_DRONE_CRUISE_TIME + CAPTURE_DRONE_DIVE_TIME;
-const CAPTURE_JET_SPEED_FACTOR = 1.7; // fly a bit slower than the previous 1.5x pacing
+const CAPTURE_JET_SPEED_FACTOR = 3.4; // 50% slower flight than current tuning (duration doubled)
 const CAPTURE_JET_TOTAL = CAPTURE_DRONE_TOTAL * CAPTURE_JET_SPEED_FACTOR;
 const CAPTURE_JET_MISSILE_TRAVEL = 1.65 * CAPTURE_JET_SPEED_FACTOR;
 const CAPTURE_JET_MISSILE_RELEASE_RATIO = 0.58;
 const CAPTURE_GROUND_FIRE_TIME = 0.12;
 const CAPTURE_GROUND_TRAVEL_TIME = 2.9;
 const CAPTURE_GROUND_TOTAL = CAPTURE_GROUND_FIRE_TIME + CAPTURE_GROUND_TRAVEL_TIME;
-const CAPTURE_DRONE_SCALE = 0.0625;
-const CAPTURE_JET_SCALE = 0.058;
+const CAPTURE_DRONE_SCALE = 0.058;
+const CAPTURE_JET_SCALE = 0.0625;
 const CAPTURE_DRONE_ALTITUDE = 1.36;
 const CAPTURE_FLIGHT_ALTITUDE = CAPTURE_DRONE_ALTITUDE;
 const CAPTURE_JET_ALTITUDE = CAPTURE_FLIGHT_ALTITUDE - 0.86;
 const CAPTURE_MISSILE_SCALE = 0.0595;
 const CAPTURE_EXPLOSION_SCALE = 0.176; // slightly smaller capture explosion
 const CAPTURE_EDGE_PATH_FACTOR = 0.52;
-const CAPTURE_JET_EDGE_PATH_FACTOR = 0.2;
+const CAPTURE_JET_EDGE_PATH_FACTOR = 0.08;
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
 const BASIS_TRANSCODER_PATH = 'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/';
 
@@ -8403,23 +8403,28 @@ function Chess3D({
         jetFx.root.scale.setScalar(CAPTURE_JET_SCALE);
         const attackFromRightSide = fromPos.x >= 0;
         const borderOffset = half + tile * CAPTURE_JET_EDGE_PATH_FACTOR;
-        const entryClamp = half - tile * 0.22;
-        const attackAltitude = CAPTURE_JET_ALTITUDE - 0.05;
+        const entryClamp = half - tile * 0.14;
+        const attackAltitude = CAPTURE_JET_ALTITUDE - 0.03;
         const sideLane = attackFromRightSide ? borderOffset : -borderOffset;
+        const centerLaneZ = THREE.MathUtils.clamp(
+          THREE.MathUtils.lerp(fromPos.z, targetPos.z, 0.45),
+          -entryClamp,
+          entryClamp
+        );
         const jetStart = new THREE.Vector3(
           sideLane,
-          CAPTURE_JET_ALTITUDE,
-          THREE.MathUtils.clamp(fromPos.z, -entryClamp, entryClamp)
+          CAPTURE_JET_ALTITUDE + 0.02,
+          centerLaneZ
         );
         const jetApproach = new THREE.Vector3(
-          THREE.MathUtils.lerp(sideLane, fromPos.x, 0.5),
+          THREE.MathUtils.lerp(sideLane, fromPos.x, 0.72),
           attackAltitude,
-          THREE.MathUtils.clamp(fromPos.z, -entryClamp, entryClamp)
+          centerLaneZ
         );
         const jetAttack = new THREE.Vector3(
-          THREE.MathUtils.lerp(sideLane, targetPos.x, 0.52),
-          attackAltitude - 0.06,
-          THREE.MathUtils.clamp(targetPos.z, -entryClamp, entryClamp)
+          THREE.MathUtils.lerp(sideLane, targetPos.x, 0.74),
+          attackAltitude - 0.04,
+          centerLaneZ
         );
         const jetExit = new THREE.Vector3(
           attackFromRightSide ? -borderOffset : borderOffset,


### PR DESCRIPTION
### Motivation
- Make Queen capture VFX match the requested visual balance by swapping sizes between the drone and the jet. 
- Bring the jet entrance visually closer to the board and centred so it appears above the board sooner after a queen move. 
- Slow the jet attack to be less abrupt by reducing its perceived speed by 50%.

### Description
- Updated capture tuning constants in `webapp/src/pages/Games/ChessBattleRoyal.jsx` by doubling `CAPTURE_JET_SPEED_FACTOR` (from `1.7` to `3.4`) so jet flight/missile timings are 50% slower. 
- Swapped the VFX scales by changing `CAPTURE_DRONE_SCALE` to `0.058` and `CAPTURE_JET_SCALE` to `0.0625` so the drone now uses the previous jet size and the jet uses the previous drone size. 
- Tightened the jet entry path and centring logic by reducing `CAPTURE_JET_EDGE_PATH_FACTOR` (from `0.2` to `0.08`), moving `entryClamp` closer, introducing a `centerLaneZ` computed from `fromPos.z` and `targetPos.z`, and adjusting approach/attack interpolation weights and altitudes (`jetStart`, `jetApproach`, `jetAttack`). 
- Changes are localized to `webapp/src/pages/Games/ChessBattleRoyal.jsx` and only affect queen (jet) and drone capture VFX and related timing.

### Testing
- Ran the production build with `npm --prefix webapp run build`, which completed successfully. 
- Build finished with non-blocking Vite warnings about chunking/dynamic imports but no errors, and the adjusted `ChessBattleRoyal` bundle was built into `dist/`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da4061d328832991fa2bf83fbded14)