### PR TITLE
Adjust jet/drone scales and queen jet flight path (slower, closer entry)

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -95,22 +95,22 @@ const CAPTURE_DRONE_LIFT_TIME = 0.144;
 const CAPTURE_DRONE_CRUISE_TIME = 2.62;
 const CAPTURE_DRONE_DIVE_TIME = 1.28;
 const CAPTURE_DRONE_TOTAL = CAPTURE_DRONE_LIFT_TIME + CAPTURE_DRONE_CRUISE_TIME + CAPTURE_DRONE_DIVE_TIME;
-const CAPTURE_JET_SPEED_FACTOR = 1.7; // fly a bit slower than the previous 1.5x pacing
+const CAPTURE_JET_SPEED_FACTOR = 3.4; // 50% slower jet flight than previous pacing
 const CAPTURE_JET_TOTAL = CAPTURE_DRONE_TOTAL * CAPTURE_JET_SPEED_FACTOR;
 const CAPTURE_JET_MISSILE_TRAVEL = 1.65 * CAPTURE_JET_SPEED_FACTOR;
 const CAPTURE_JET_MISSILE_RELEASE_RATIO = 0.58;
 const CAPTURE_GROUND_FIRE_TIME = 0.12;
 const CAPTURE_GROUND_TRAVEL_TIME = 2.9;
 const CAPTURE_GROUND_TOTAL = CAPTURE_GROUND_FIRE_TIME + CAPTURE_GROUND_TRAVEL_TIME;
-const CAPTURE_DRONE_SCALE = 0.0625;
-const CAPTURE_JET_SCALE = 0.058;
+const CAPTURE_DRONE_SCALE = 0.058;
+const CAPTURE_JET_SCALE = 0.0625;
 const CAPTURE_DRONE_ALTITUDE = 1.36;
 const CAPTURE_FLIGHT_ALTITUDE = CAPTURE_DRONE_ALTITUDE;
 const CAPTURE_JET_ALTITUDE = CAPTURE_FLIGHT_ALTITUDE - 0.86;
 const CAPTURE_MISSILE_SCALE = 0.0595;
 const CAPTURE_EXPLOSION_SCALE = 0.176; // slightly smaller capture explosion
 const CAPTURE_EDGE_PATH_FACTOR = 0.52;
-const CAPTURE_JET_EDGE_PATH_FACTOR = 0.2;
+const CAPTURE_JET_EDGE_PATH_FACTOR = 0.08;
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
 const BASIS_TRANSCODER_PATH = 'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/';
 
@@ -8403,21 +8403,21 @@ function Chess3D({
         jetFx.root.scale.setScalar(CAPTURE_JET_SCALE);
         const attackFromRightSide = fromPos.x >= 0;
         const borderOffset = half + tile * CAPTURE_JET_EDGE_PATH_FACTOR;
-        const entryClamp = half - tile * 0.22;
+        const entryClamp = half - tile * 0.12;
         const attackAltitude = CAPTURE_JET_ALTITUDE - 0.05;
         const sideLane = attackFromRightSide ? borderOffset : -borderOffset;
         const jetStart = new THREE.Vector3(
           sideLane,
           CAPTURE_JET_ALTITUDE,
-          THREE.MathUtils.clamp(fromPos.z, -entryClamp, entryClamp)
+          THREE.MathUtils.clamp((fromPos.z + targetPos.z) * 0.5, -entryClamp, entryClamp)
         );
         const jetApproach = new THREE.Vector3(
-          THREE.MathUtils.lerp(sideLane, fromPos.x, 0.5),
+          THREE.MathUtils.lerp(sideLane, fromPos.x, 0.7),
           attackAltitude,
-          THREE.MathUtils.clamp(fromPos.z, -entryClamp, entryClamp)
+          THREE.MathUtils.clamp((fromPos.z + targetPos.z) * 0.5, -entryClamp, entryClamp)
         );
         const jetAttack = new THREE.Vector3(
-          THREE.MathUtils.lerp(sideLane, targetPos.x, 0.52),
+          THREE.MathUtils.lerp(sideLane, targetPos.x, 0.72),
           attackAltitude - 0.06,
           THREE.MathUtils.clamp(targetPos.z, -entryClamp, entryClamp)
         );


### PR DESCRIPTION
### Motivation
- Make the queen-capture FX visually closer and less abrupt by swapping drone/jet sizes, bringing the jet entrance nearer above the board, and slowing the jet animation by 50% for clearer, less jarring captures.
- Improve entry positioning so the queen jet appears centered between source and target depth and approaches from a nearer lane to match portrait-screen visuals.

### Description
- Updated constants in `webapp/src/pages/Games/ChessBattleRoyal.jsx`: changed `CAPTURE_JET_SPEED_FACTOR` from `1.7` to `3.4` to make jet flight 50% slower, swapped `CAPTURE_DRONE_SCALE` and `CAPTURE_JET_SCALE` values so the drone uses the former jet size and the jet uses the former drone size, and tightened `CAPTURE_JET_EDGE_PATH_FACTOR` from `0.2` to `0.08` to move the entry lane closer to the board.
- Adjusted queen jet entry math in the `playCaptureAnimation` path: reduced `entryClamp` from `tile * 0.22` to `tile * 0.12`, set jet start/approach Z to the average of source and target (`(fromPos.z + targetPos.z) * 0.5`), and changed approach/attack lerp factors from `0.5/0.52` to `0.7/0.72` so the jet approaches and aligns nearer to the piece and board.
- Kept missile timing/sequence intact but updated durations that derive from `CAPTURE_JET_SPEED_FACTOR` so audio and missile release scales with the new timing.

### Testing
- Ran the unit test suite for inventory config with `npm test -- --runInBand test/chessBattleInventoryConfig.test.js`, and the test suite passed (`3 passed`).
- No other automated tests were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da4061d328832991fa2bf83fbded14)