### PR TITLE
Delay fighter-jet missile release and anchor launch to jet in Chess Battle Royal

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -98,7 +98,7 @@ const CAPTURE_DRONE_TOTAL = CAPTURE_DRONE_LIFT_TIME + CAPTURE_DRONE_CRUISE_TIME 
 const CAPTURE_JET_SPEED_FACTOR = 2.95; // slightly slower jet pass for better readability
 const CAPTURE_JET_TOTAL = CAPTURE_DRONE_TOTAL * CAPTURE_JET_SPEED_FACTOR;
 const CAPTURE_JET_MISSILE_TRAVEL = 1.65 * CAPTURE_JET_SPEED_FACTOR;
-const CAPTURE_JET_MISSILE_RELEASE_RATIO = 0.58;
+const CAPTURE_JET_MISSILE_RELEASE_RATIO = 0.68; // release only after the jet is clearly above the board
 const CAPTURE_JET_TRIMMED_START_RATIO = CAPTURE_JET_MISSILE_RELEASE_RATIO; // skip initial silent segment and start near the missile cue
 const CAPTURE_GROUND_FIRE_TIME = 0.12;
 const CAPTURE_GROUND_TRAVEL_TIME = 2.9;
@@ -8425,7 +8425,8 @@ function Chess3D({
           orbitEntryPos: jetApproach,
           orbitExitPos: jetAttack,
           exitPos: jetExit,
-          missileReleaseTime: 0,
+          missileReleaseTime: CAPTURE_JET_TOTAL * CAPTURE_JET_MISSILE_RELEASE_RATIO,
+          missileLaunchPos: null,
           attackFromRightSide,
           jetFx,
           missileFx
@@ -10076,8 +10077,10 @@ function Chess3D({
               const mu = smoothEase(
                 clamp01((fx.t - missileReleaseTime) / CAPTURE_JET_MISSILE_TRAVEL)
               );
-              const boardShotAnchor = fx.orbitEntryPos.clone().lerp(fx.orbitExitPos, 0.7);
-              const launchPos = boardShotAnchor.clone().add(new THREE.Vector3(0, 0.015, 0));
+              if (!fx.missileLaunchPos) {
+                fx.missileLaunchPos = fx.jetFx.root.localToWorld(new THREE.Vector3(2.42, -0.08, 0));
+              }
+              const launchPos = fx.missileLaunchPos.clone();
               const { pos: missilePos, next: missileNext } = getCaptureOrbitPose({
                 from: launchPos,
                 to: fx.to.clone(),


### PR DESCRIPTION
### Motivation
- Missiles fired by the fighter-jet were visually launching too early (before the jet was clearly over the board), reducing readability of the capture animation.
- The goal is to ensure the missile is released when the jet is visibly above the board and appears to come from the jet model itself.

### Description
- Updated `CAPTURE_JET_MISSILE_RELEASE_RATIO` from `0.58` to `0.68` so the jet waits longer before releasing missiles (`webapp/src/pages/Games/ChessBattleRoyal.jsx`).
- Initialize the jet FX entry with `missileReleaseTime: CAPTURE_JET_TOTAL * CAPTURE_JET_MISSILE_RELEASE_RATIO` and added `missileLaunchPos` to the active FX object to store the actual world-space launch point.
- Changed missile spawn logic to compute the launch position from the live jet transform using `fx.jetFx.root.localToWorld(...)` at release time so the missile visibly originates from the jet.

### Testing
- Ran lint for the target file via `npm run -s lint -- webapp/src/pages/Games/ChessBattleRoyal.jsx`, which completed but reported repository-wide lint errors and ignore patterns unrelated to this change (no file-specific lint blocking the change).
- No unit or integration tests were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da53a78c4483299954617054e2b1a7)