### PR TITLE
Adjust jet missile launch timing to occur over the board

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -8425,7 +8425,7 @@ function Chess3D({
           orbitEntryPos: jetApproach,
           orbitExitPos: jetAttack,
           exitPos: jetExit,
-          missileReleaseTime: 0,
+          missileReleaseTime: CAPTURE_JET_TOTAL * CAPTURE_JET_MISSILE_RELEASE_RATIO,
           attackFromRightSide,
           jetFx,
           missileFx


### PR DESCRIPTION
### Motivation
- Ensure the jet-fired missile is launched visually when the jet is flying over the board (so the player sees the launch), while preserving the original animation duration and travel times.

### Description
- Changed the jet FX payload in `webapp/src/pages/Games/ChessBattleRoyal.jsx` so `missileReleaseTime` is set to `CAPTURE_JET_TOTAL * CAPTURE_JET_MISSILE_RELEASE_RATIO` instead of `0`, shifting only the missile launch timing without altering `CAPTURE_JET_TOTAL` or travel constants.

### Testing
- No automated tests were run for this timing-only visual tweak.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da5702bef88329aa982be7b85a70e4)