### PR TITLE
Ludo: Lock 3D camera zoom, bring camera closer, and ground HDRI/chairs

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -763,8 +763,8 @@ const CAMERA_BROADCAST_TARGET_BLEND = 0.5;
 const LUDO_CAMERA_AUTO_LOOK_ENABLED = true;
 const CAMERA_FREE_LOOK_AZIMUTH_RANGE = Infinity;
 const CAMERA_FREE_LOOK_POLAR_DELTA = THREE.MathUtils.degToRad(55);
-const CAMERA_ZOOM_MIN_FACTOR = 0.8;
-const CAMERA_ZOOM_MAX_FACTOR = 1.6;
+const CAMERA_ZOOM_MIN_FACTOR = 1;
+const CAMERA_ZOOM_MAX_FACTOR = 1;
 const LUDO_CAMERA_PHI_MIN = THREE.MathUtils.degToRad(18);
 const LUDO_CAMERA_PHI_MAX = THREE.MathUtils.degToRad(88);
 const LANDSCAPE_CAMERA_TUNING = Object.freeze({
@@ -785,7 +785,7 @@ const LUDO_HDRI_MAIN_SCENE_FACING_ROTATION_Y = Math.PI / 2;
 
 const DEFAULT_STOOL_THEME = Object.freeze({ legColor: '#1f1f1f' });
 const DEFAULT_HDRI_RESOLUTIONS = Object.freeze(['2k']);
-const DEFAULT_HDRI_CAMERA_HEIGHT_M = 1.5;
+const DEFAULT_HDRI_CAMERA_HEIGHT_M = 1.2;
 const MIN_HDRI_CAMERA_HEIGHT_M = 0.8;
 const DEFAULT_HDRI_RADIUS_MULTIPLIER = 6;
 const MIN_HDRI_RADIUS = 24;
@@ -2092,8 +2092,8 @@ const BOARD_ROTATION_Y = -Math.PI / 2;
 const CAMERA_BASE_RADIUS = Math.max(TABLE_RADIUS, BOARD_RADIUS);
 const CAMERA_EXTRA_ZOOM_IN = 0.82;
 const CAMERA_EXTRA_ZOOM_OUT = 1.26;
-const INITIAL_CAMERA_DISTANCE_FACTOR = 1;
-const PORTRAIT_INITIAL_CAMERA_DISTANCE_FACTOR = 1;
+const INITIAL_CAMERA_DISTANCE_FACTOR = 0.8;
+const PORTRAIT_INITIAL_CAMERA_DISTANCE_FACTOR = 0.74;
 const CAM = {
   fov: CAMERA_FOV,
   near: CAMERA_NEAR,
@@ -3872,13 +3872,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       }
     });
     if (!hasBounds) return;
-    let floorMinY = box.min.y;
-    if (tableGroup) {
-      const tableBounds = new THREE.Box3().setFromObject(tableGroup);
-      if (!tableBounds.isEmpty() && Number.isFinite(tableBounds.min.y)) {
-        floorMinY = tableBounds.min.y;
-      }
-    }
+    const floorMinY = box.min.y;
     environmentFloorRef.current = floorMinY;
     const skybox = envSkyboxRef.current;
     const boardLookTarget = arena.boardLookTarget ?? boardLookTargetRef.current;
@@ -3920,13 +3914,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       }
     });
     if (!hasBounds || !Number.isFinite(bounds.min.y)) return;
-    let floorMinY = bounds.min.y;
-    if (tableGroup) {
-      const tableBounds = new THREE.Box3().setFromObject(tableGroup);
-      if (!tableBounds.isEmpty() && Number.isFinite(tableBounds.min.y)) {
-        floorMinY = tableBounds.min.y;
-      }
-    }
+    const floorMinY = bounds.min.y;
     const yShift = -floorMinY;
     if (Math.abs(yShift) <= 1e-4) {
       environmentFloorRef.current = 0;
@@ -5162,7 +5150,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     boardLookTargetRef.current = boardLookTarget;
     const initialCameraDirection = camera.position.clone().sub(boardLookTarget).normalize();
     const initialDistanceFactor = isPortrait ? PORTRAIT_INITIAL_CAMERA_DISTANCE_FACTOR : INITIAL_CAMERA_DISTANCE_FACTOR;
-    const desiredInitialCameraRadius = CAM.maxR;
+    const desiredInitialCameraRadius = clamp(CAM.maxR * initialDistanceFactor, CAM.minR, CAM.maxR);
     camera.position.copy(boardLookTarget).add(initialCameraDirection.multiplyScalar(desiredInitialCameraRadius));
     camera.position.y += CAMERA_3D_HEIGHT_BOOST + (isPortrait ? PORTRAIT_CAMERA_EXTRA_LIFT : CAMERA_EXTRA_LIFT);
     camera.lookAt(boardLookTarget);
@@ -5171,7 +5159,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     controls.enableDamping = true;
     controls.dampingFactor = 0.08;
     controls.enablePan = false;
-    controls.enableZoom = true;
+    controls.enableZoom = false;
     controls.enableRotate = false;
     controls.zoomSpeed = CAMERA_DOLLY_FACTOR;
     const initialCameraRadius = camera.position.distanceTo(boardLookTarget);


### PR DESCRIPTION
### Motivation
- Implement the requested visual fixes for the Ludo Battle Royal 3D scene: remove camera zoom, ensure table and chairs are grounded together under the HDRI skybox, and move the gameplay camera closer to the table for a better framing.

### Description
- Disabled interactive zoom by setting `CAMERA_ZOOM_MIN_FACTOR` and `CAMERA_ZOOM_MAX_FACTOR` to `1` and turning off `controls.enableZoom` in `LudoBattleRoyal.jsx` so wheel/pinch no longer changes camera distance.
- Brought the default 3D camera closer to the table by introducing and applying smaller initial distance factors (`INITIAL_CAMERA_DISTANCE_FACTOR = 0.8` and `PORTRAIT_INITIAL_CAMERA_DISTANCE_FACTOR = 0.74`) and computing `desiredInitialCameraRadius` with `clamp(CAM.maxR * initialDistanceFactor, CAM.minR, CAM.maxR)` when positioning the camera.
- Improved HDRI grounding so the floor alignment uses the full arena bounds (table + chairs) instead of favoring table-only bounds by using `box.min.y` / `bounds.min.y` directly in `updateEnvironmentFloor` and `groundArenaToHdriFloor` (removed the table-only override logic).
- Adjusted grounded HDRI camera height by lowering `DEFAULT_HDRI_CAMERA_HEIGHT_M` from `1.5` to `1.2` to better match the grounded table/chair setup.

### Testing
- Built the web client with `npm --prefix webapp run -s build` and the build completed successfully (Vite produced standard chunk-size/dynamic-import warnings only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da542d06ec8329a4d9152549d54c57)