### PR TITLE
Fix jet capture missile release timing and capture resolve delay

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -8425,14 +8425,16 @@ function Chess3D({
           orbitEntryPos: jetApproach,
           orbitExitPos: jetAttack,
           exitPos: jetExit,
-          missileReleaseTime: 0,
+          missileReleaseTime: CAPTURE_JET_TOTAL * CAPTURE_JET_MISSILE_RELEASE_RATIO,
           attackFromRightSide,
           jetFx,
           missileFx
         });
         return {
           moveDelayMs: CAPTURE_JET_TOTAL * 1000,
-          captureResolveDelayMs: CAPTURE_JET_MISSILE_TRAVEL * 1000
+          captureResolveDelayMs:
+            (CAPTURE_JET_TOTAL * CAPTURE_JET_MISSILE_RELEASE_RATIO + CAPTURE_JET_MISSILE_TRAVEL) *
+            1000
         };
       }
       if (pieceType === 'N' || pieceType === 'K' || pieceType === 'P') {


### PR DESCRIPTION
### Motivation
- Ensure jet capture resolves after the missile is actually released and travels to the target by accounting for the missile release timing in the capture timing calculations.

### Description
- Set `missileReleaseTime` for jet captures to `CAPTURE_JET_TOTAL * CAPTURE_JET_MISSILE_RELEASE_RATIO` and update `captureResolveDelayMs` to `(CAPTURE_JET_TOTAL * CAPTURE_JET_MISSILE_RELEASE_RATIO + CAPTURE_JET_MISSILE_TRAVEL) * 1000` so the resolve delay includes both release delay and missile travel time.

### Testing
- Ran existing frontend automated checks (`npm test` and `npm run lint`) and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da5702bef88329aa982be7b85a70e4)