### PR TITLE
Adjust jet capture missile release timing and resolve delay

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -8425,14 +8425,15 @@ function Chess3D({
           orbitEntryPos: jetApproach,
           orbitExitPos: jetAttack,
           exitPos: jetExit,
-          missileReleaseTime: 0,
+          missileReleaseTime: CAPTURE_JET_TOTAL * CAPTURE_JET_MISSILE_RELEASE_RATIO,
           attackFromRightSide,
           jetFx,
           missileFx
         });
         return {
           moveDelayMs: CAPTURE_JET_TOTAL * 1000,
-          captureResolveDelayMs: CAPTURE_JET_MISSILE_TRAVEL * 1000
+          captureResolveDelayMs:
+            (CAPTURE_JET_TOTAL * CAPTURE_JET_MISSILE_RELEASE_RATIO + CAPTURE_JET_MISSILE_TRAVEL) * 1000
         };
       }
       if (pieceType === 'N' || pieceType === 'K' || pieceType === 'P') {


### PR DESCRIPTION
### Motivation
- Ensure jet capture missiles are released in sync with the jet animation and that the capture resolution waits for missile release plus travel time instead of using an immediate or incorrect delay.

### Description
- Set `missileReleaseTime` to `CAPTURE_JET_TOTAL * CAPTURE_JET_MISSILE_RELEASE_RATIO` and update `captureResolveDelayMs` to `(CAPTURE_JET_TOTAL * CAPTURE_JET_MISSILE_RELEASE_RATIO + CAPTURE_JET_MISSILE_TRAVEL) * 1000`, keeping `moveDelayMs` unchanged.

### Testing
- Ran the frontend test suite with `yarn test` and the linter with `yarn lint`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da5702bef88329aa982be7b85a70e4)