### PR TITLE
Adjust jet capture missile timing in ChessBattleRoyal

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -8416,6 +8416,7 @@ function Chess3D({
         missileFx.root.scale.setScalar(CAPTURE_MISSILE_SCALE);
         missileFx.root.visible = false;
         captureFxGroup.add(missileFx.root);
+        const jetMissileReleaseTime = CAPTURE_JET_TOTAL * CAPTURE_JET_MISSILE_RELEASE_RATIO;
         activeCaptureFx.push({
           type: 'jet',
           t: 0,
@@ -8425,14 +8426,15 @@ function Chess3D({
           orbitEntryPos: jetApproach,
           orbitExitPos: jetAttack,
           exitPos: jetExit,
-          missileReleaseTime: 0,
+          missileReleaseTime: jetMissileReleaseTime,
           attackFromRightSide,
           jetFx,
           missileFx
         });
+        const jetMissileImpactDelayMs = (jetMissileReleaseTime + CAPTURE_JET_MISSILE_TRAVEL) * 1000;
         return {
-          moveDelayMs: CAPTURE_JET_TOTAL * 1000,
-          captureResolveDelayMs: CAPTURE_JET_MISSILE_TRAVEL * 1000
+          moveDelayMs: jetMissileImpactDelayMs,
+          captureResolveDelayMs: jetMissileImpactDelayMs
         };
       }
       if (pieceType === 'N' || pieceType === 'K' || pieceType === 'P') {


### PR DESCRIPTION
### Motivation
- Ensure the capture animation resolves when the jet-fired missile actually impacts, so capture timing aligns with visual/audio effects instead of the jet flight duration.

### Description
- Compute `jetMissileReleaseTime = CAPTURE_JET_TOTAL * CAPTURE_JET_MISSILE_RELEASE_RATIO`, set `missileReleaseTime` on the active capture FX, calculate `jetMissileImpactDelayMs = (jetMissileReleaseTime + CAPTURE_JET_MISSILE_TRAVEL) * 1000`, and use that value for the returned `moveDelayMs` and `captureResolveDelayMs`.

### Testing
- Ran the frontend test suite with `yarn test` and built the app with `yarn build`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da5702bef88329aa982be7b85a70e4)