### PR TITLE
Adjust jet capture missile release timing and impact delay

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -99,6 +99,7 @@ const CAPTURE_JET_SPEED_FACTOR = 2.95; // slightly slower jet pass for better re
 const CAPTURE_JET_TOTAL = CAPTURE_DRONE_TOTAL * CAPTURE_JET_SPEED_FACTOR;
 const CAPTURE_JET_MISSILE_TRAVEL = 1.65 * CAPTURE_JET_SPEED_FACTOR;
 const CAPTURE_JET_MISSILE_RELEASE_RATIO = 0.58;
+const CAPTURE_JET_MISSILE_ENTRY_RELEASE_RATIO = 0.06;
 const CAPTURE_JET_TRIMMED_START_RATIO = CAPTURE_JET_MISSILE_RELEASE_RATIO; // skip initial silent segment and start near the missile cue
 const CAPTURE_GROUND_FIRE_TIME = 0.12;
 const CAPTURE_GROUND_TRAVEL_TIME = 2.9;
@@ -8425,14 +8426,17 @@ function Chess3D({
           orbitEntryPos: jetApproach,
           orbitExitPos: jetAttack,
           exitPos: jetExit,
-          missileReleaseTime: 0,
+          missileReleaseTime: CAPTURE_JET_TOTAL * CAPTURE_JET_MISSILE_ENTRY_RELEASE_RATIO,
           attackFromRightSide,
           jetFx,
           missileFx
         });
+        const jetImpactDelayMs =
+          (CAPTURE_JET_TOTAL * CAPTURE_JET_MISSILE_ENTRY_RELEASE_RATIO + CAPTURE_JET_MISSILE_TRAVEL) *
+          1000;
         return {
-          moveDelayMs: CAPTURE_JET_TOTAL * 1000,
-          captureResolveDelayMs: CAPTURE_JET_MISSILE_TRAVEL * 1000
+          moveDelayMs: jetImpactDelayMs,
+          captureResolveDelayMs: jetImpactDelayMs
         };
       }
       if (pieceType === 'N' || pieceType === 'K' || pieceType === 'P') {


### PR DESCRIPTION
### Motivation
- Make the jet capture FX timing more realistic by releasing the missile earlier during the jet entry phase and aligning movement/capture resolution with the missile impact time.
- Fix incorrect/zero initial `missileReleaseTime` and mismatched delay values so capture resolution waits for the missile travel time from release.

### Description
- Add `CAPTURE_JET_MISSILE_ENTRY_RELEASE_RATIO` constant and use it to determine when the jet releases its missile during the approach (`0.06`).
- Set the active capture entry `missileReleaseTime` to `CAPTURE_JET_TOTAL * CAPTURE_JET_MISSILE_ENTRY_RELEASE_RATIO` instead of `0`.
- Compute `jetImpactDelayMs` as `(CAPTURE_JET_TOTAL * CAPTURE_JET_MISSILE_ENTRY_RELEASE_RATIO + CAPTURE_JET_MISSILE_TRAVEL) * 1000` and use it for both `moveDelayMs` and `captureResolveDelayMs` so resolution occurs at impact.

### Testing
- Ran the frontend build with `yarn build` and it completed successfully.
- Executed unit tests with `yarn test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da5702bef88329aa982be7b85a70e4)