### PR TITLE
Chess Battle Royal: shorten jet pass, move flypath closer, and fire dual missiles

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -95,11 +95,11 @@ const CAPTURE_DRONE_LIFT_TIME = 0.144;
 const CAPTURE_DRONE_CRUISE_TIME = 2.62;
 const CAPTURE_DRONE_DIVE_TIME = 1.28;
 const CAPTURE_DRONE_TOTAL = CAPTURE_DRONE_LIFT_TIME + CAPTURE_DRONE_CRUISE_TIME + CAPTURE_DRONE_DIVE_TIME;
-const CAPTURE_JET_SPEED_FACTOR = 2.75; // slightly faster jet pass while keeping readability
+const CAPTURE_JET_SPEED_FACTOR = 2.3; // shorten jet pass while preserving perceived travel speed
 const CAPTURE_JET_TOTAL = CAPTURE_DRONE_TOTAL * CAPTURE_JET_SPEED_FACTOR;
-const CAPTURE_JET_MISSILE_TRAVEL = 1.65 * CAPTURE_JET_SPEED_FACTOR;
+const CAPTURE_JET_MISSILE_TRAVEL = 1.2 * CAPTURE_JET_SPEED_FACTOR;
 const CAPTURE_JET_MISSILE_RELEASE_RATIO = 0.58;
-const CAPTURE_JET_MISSILE_ENTRY_RELEASE_RATIO = 0.06;
+const CAPTURE_JET_MISSILE_ENTRY_RELEASE_RATIO = 0.34; // release once the jet is clearly above the board
 const CAPTURE_JET_TRIMMED_START_RATIO = CAPTURE_JET_MISSILE_RELEASE_RATIO; // skip initial silent segment and start near the missile cue
 const CAPTURE_GROUND_FIRE_TIME = 0.12;
 const CAPTURE_GROUND_TRAVEL_TIME = 2.9;
@@ -108,11 +108,11 @@ const CAPTURE_DRONE_SCALE = 0.058;
 const CAPTURE_JET_SCALE = 0.0695;
 const CAPTURE_DRONE_ALTITUDE = 1.36;
 const CAPTURE_FLIGHT_ALTITUDE = CAPTURE_DRONE_ALTITUDE;
-const CAPTURE_JET_ALTITUDE = CAPTURE_FLIGHT_ALTITUDE - 0.86;
+const CAPTURE_JET_ALTITUDE = CAPTURE_FLIGHT_ALTITUDE - 1.0;
 const CAPTURE_MISSILE_SCALE = 0.0595;
 const CAPTURE_EXPLOSION_SCALE = 0.158; // slightly smaller capture explosion
 const CAPTURE_EDGE_PATH_FACTOR = 0.52;
-const CAPTURE_JET_EDGE_PATH_FACTOR = 0.08;
+const CAPTURE_JET_EDGE_PATH_FACTOR = 0.02;
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
 const BASIS_TRANSCODER_PATH = 'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/';
 
@@ -8397,12 +8397,12 @@ function Chess3D({
           THREE.MathUtils.clamp((fromPos.z + targetPos.z) * 0.5, -entryClamp, entryClamp)
         );
         const jetApproach = new THREE.Vector3(
-          THREE.MathUtils.lerp(sideLane, fromPos.x, 0.7),
+          THREE.MathUtils.lerp(sideLane, fromPos.x, 0.84),
           attackAltitude,
           THREE.MathUtils.clamp((fromPos.z + targetPos.z) * 0.5, -entryClamp, entryClamp)
         );
         const jetAttack = new THREE.Vector3(
-          THREE.MathUtils.lerp(sideLane, targetPos.x, 0.72),
+          THREE.MathUtils.lerp(sideLane, targetPos.x, 0.86),
           attackAltitude - 0.06,
           THREE.MathUtils.clamp(targetPos.z, -entryClamp, entryClamp)
         );
@@ -8413,10 +8413,12 @@ function Chess3D({
         );
         jetFx.root.position.copy(jetStart);
         captureFxGroup.add(jetFx.root);
-        const missileFx = createFxMissile();
-        missileFx.root.scale.setScalar(CAPTURE_MISSILE_SCALE);
-        missileFx.root.visible = false;
-        captureFxGroup.add(missileFx.root);
+        const missileFx = [createFxGroundMissile(), createFxGroundMissile()];
+        missileFx.forEach((missile) => {
+          missile.root.scale.setScalar(CAPTURE_MISSILE_SCALE);
+          missile.root.visible = false;
+          captureFxGroup.add(missile.root);
+        });
         activeCaptureFx.push({
           type: 'jet',
           t: 0,
@@ -10073,15 +10075,17 @@ function Chess3D({
             });
 
             const missileReleaseTime = fx.missileReleaseTime ?? CAPTURE_JET_TOTAL * CAPTURE_JET_MISSILE_RELEASE_RATIO;
+            const jetMissiles = Array.isArray(fx.missileFx) ? fx.missileFx : [fx.missileFx].filter(Boolean);
             if (fx.t < missileReleaseTime) {
-              fx.missileFx.root.visible = false;
+              jetMissiles.forEach((missile) => {
+                missile.root.visible = false;
+              });
             } else if (fx.t <= missileReleaseTime + CAPTURE_JET_MISSILE_TRAVEL) {
               if (Math.abs(fx.t - missileReleaseTime) < dt * 1.2) playAudio(missileLaunchSoundRef);
               const mu = smoothEase(
                 clamp01((fx.t - missileReleaseTime) / CAPTURE_JET_MISSILE_TRAVEL)
               );
-              const boardShotAnchor = fx.orbitEntryPos.clone().lerp(fx.orbitExitPos, 0.7);
-              const launchPos = boardShotAnchor.clone().add(new THREE.Vector3(0, 0.015, 0));
+              const launchPos = jetPos.clone().add(new THREE.Vector3(0, -0.015, 0));
               const { pos: missilePos, next: missileNext } = getCaptureOrbitPose({
                 from: launchPos,
                 to: fx.to.clone(),
@@ -10092,12 +10096,26 @@ function Chess3D({
                 liftSplit: 0.15,
                 strikeSplit: 0.82
               });
-              fx.missileFx.root.visible = true;
-              fx.missileFx.root.position.copy(missilePos);
               captureDir.copy(missileNext).sub(missilePos).normalize();
-              fx.missileFx.root.quaternion.setFromUnitVectors(FORWARD, captureDir);
+              const missileSide = new THREE.Vector3().crossVectors(WORLD_UP, captureDir).normalize();
+              const missileSpread = 0.06;
+              jetMissiles.forEach((missile, idx) => {
+                const laneSign = idx === 0 ? -1 : 1;
+                missile.root.visible = true;
+                missile.root.position.copy(missilePos).addScaledVector(missileSide, laneSign * missileSpread);
+                missile.root.quaternion.setFromUnitVectors(FORWARD, captureDir);
+                missile.trail?.forEach((puff, trailIdx) => {
+                  puff.position.set(
+                    -0.55 - trailIdx * 0.16,
+                    Math.sin(fx.t * 8.2 + trailIdx + idx * 0.4) * 0.02,
+                    0
+                  );
+                });
+              });
             } else {
-              fx.missileFx.root.visible = false;
+              jetMissiles.forEach((missile) => {
+                missile.root.visible = false;
+              });
               if (!fx.hasExploded) {
                 fx.hasExploded = true;
                 launchExplosion(fx.to);
@@ -10106,7 +10124,9 @@ function Chess3D({
 
             if (u >= 1) {
               captureFxGroup.remove(fx.jetFx.root);
-              captureFxGroup.remove(fx.missileFx.root);
+              jetMissiles.forEach((missile) => {
+                captureFxGroup.remove(missile.root);
+              });
               activeCaptureFx.splice(i, 1);
             }
           } else if (fx.type === 'javelin') {


### PR DESCRIPTION
### Motivation
- Improve capture FX so the queen's jet enters the screen faster by flying closer to the board while preserving perceived speed.
- Ensure the jet fires two missiles simultaneously and that those missiles match the visual size of the ground/javelin (bazooka-like) missile.
- Trigger missile launch when the jet is above the board and tighten the animation timing for snappier feedback.

### Description
- Tuned timing and geometry constants: reduced `CAPTURE_JET_SPEED_FACTOR`, adjusted `CAPTURE_JET_MISSILE_TRAVEL`, raised `CAPTURE_JET_MISSILE_ENTRY_RELEASE_RATIO`, lowered `CAPTURE_JET_ALTITUDE`, and tightened `CAPTURE_JET_EDGE_PATH_FACTOR` in `ChessBattleRoyal.jsx`.
- Moved the jet approach/attack interpolation closer to the board by changing jet approach/attack lerp factors from `0.7/0.72` to `0.84/0.86` for a faster on-screen entry.
- Replaced the single jet missile with two missiles by creating an array of `createFxGroundMissile()` instances (using `CAPTURE_MISSILE_SCALE`), adding both to the FX group, and updating runtime logic to animate both in parallel with a small lateral spread computed from the flight direction.
- Adjusted missile launch to compute launch origin from the live `jetPos` so missiles are released while the jet is above the board and updated trail positioning and visibility handling for both missiles.

### Testing
- Ran the production build with `npm --prefix webapp run build`, which completed successfully (Vite build with warnings about large chunks but no errors).
- No automated unit tests were modified or run; only the webapp build step was executed and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da6e7ae2ac8329985ed4fcc5eb1641)