### PR TITLE
Ludo: Lock 3D camera to look-only, disable 3D zoom, and normalize token thickness

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -780,13 +780,15 @@ const PORTRAIT_CAMERA_TUNING = Object.freeze({
 const CAMERA_EXTRA_PULLBACK = 0;
 const CAMERA_EXTRA_LIFT = 0.12;
 const PORTRAIT_CAMERA_EXTRA_LIFT = 0.12;
-const CAMERA_LOOK_YAW_LIMIT = THREE.MathUtils.degToRad(26);
+const CAMERA_LOOK_YAW_LIMIT = THREE.MathUtils.degToRad(30);
 const CAMERA_LOOK_YAW_DRAG_FACTOR = -0.0055;
-const CAMERA_LOOK_PITCH_LIMIT = THREE.MathUtils.degToRad(16);
-const CAMERA_LOOK_MIN_PITCH = 0;
-const CAMERA_LOOK_PITCH_DRAG_FACTOR = -0.0038;
+const CAMERA_LOOK_PITCH_LIMIT = THREE.MathUtils.degToRad(24);
+const CAMERA_LOOK_MIN_PITCH = THREE.MathUtils.degToRad(-12);
+const CAMERA_LOOK_PITCH_DRAG_FACTOR = -0.0042;
 const CAMERA_LOOK_YAW_RECENTER_SPEED = 0.055;
-const LUDO_CAMERA_CUSTOM_LOOK_ENABLED = false;
+const LUDO_CAMERA_CUSTOM_LOOK_ENABLED = true;
+const LUDO_BROADCAST_LOCKED_CAMERA = true;
+const TOKEN_UNIFORM_THICKNESS_FACTOR = 0.94;
 const HDRI_GROUND_ALIGNMENT_OFFSET = -0.085 * MODEL_SCALE;
 const LUDO_HDRI_MAIN_SCENE_FACING_ROTATION_Y = Math.PI / 2;
 
@@ -1118,6 +1120,18 @@ function abgBbox(obj) {
   const size = new THREE.Vector3();
   box.getSize(size);
   return { box, size };
+}
+
+function normalizeTokenThickness(token, targetThickness) {
+  if (!token || !Number.isFinite(targetThickness) || targetThickness <= 0) return false;
+  const { size } = abgBbox(token);
+  const currentThickness = Math.max(size.x, size.z);
+  if (!Number.isFinite(currentThickness) || currentThickness <= 1e-5) return false;
+  const ratio = targetThickness / currentThickness;
+  token.scale.x *= ratio;
+  token.scale.z *= ratio;
+  token.updateMatrixWorld(true);
+  return true;
 }
 
 function measureProceduralTokenHeight() {
@@ -3509,9 +3523,9 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       controls.maxDistance = max2dDistance;
     } else {
       const saved = saved3dCameraStateRef.current;
-      controls.enableRotate = saved?.enableRotate ?? true;
+      controls.enableRotate = LUDO_CAMERA_CUSTOM_LOOK_ENABLED ? false : saved?.enableRotate ?? true;
       controls.enablePan = saved?.enablePan ?? false;
-      controls.enableZoom = true;
+      controls.enableZoom = false;
       controls.minPolarAngle = saved?.minPolarAngle ?? CAM.phiMin;
       controls.maxPolarAngle = saved?.maxPolarAngle ?? CAM.phiMax;
       controls.minAzimuthAngle = saved?.minAzimuthAngle ?? -Infinity;
@@ -5176,7 +5190,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     controls.dampingFactor = 0.08;
     controls.enablePan = false;
     controls.enableZoom = false;
-    controls.enableRotate = true;
+    controls.enableRotate = !LUDO_CAMERA_CUSTOM_LOOK_ENABLED;
     controls.zoomSpeed = CAMERA_DOLLY_FACTOR;
     const initialCameraRadius = camera.position.distanceTo(boardLookTarget);
     controls.minDistance = initialCameraRadius * CAMERA_ZOOM_MIN_FACTOR;
@@ -5680,7 +5694,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         const liftedTarget = resolveFocusCameraState(followedTarget, CAMERA_TARGET_LIFT + 0.02);
         if (liftedTarget) {
           controls.target.lerp(liftedTarget.target, 0.28);
-          if (cameraTurnStateRef.current.followOffset?.isVector3) {
+          if (!LUDO_BROADCAST_LOCKED_CAMERA && cameraTurnStateRef.current.followOffset?.isVector3) {
             const followCameraTarget = liftedTarget.target.clone().add(cameraTurnStateRef.current.followOffset);
             camera.position.lerp(followCameraTarget, 0.18);
           }
@@ -6423,7 +6437,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
 
       const nextFocusState = resolveFocusCameraState(nextTarget, offset);
       if (nextFocusState) {
-        if (cameraTurnStateRef.current.followObject) {
+        if (cameraTurnStateRef.current.followObject && !LUDO_BROADCAST_LOCKED_CAMERA) {
           const camera = cameraRef.current;
           cameraTurnStateRef.current.followOffset = camera
             ? camera.position.clone().sub(nextFocusState.target)
@@ -7682,6 +7696,7 @@ async function buildLudoBoard(
   addCenterHome(scene, playerColors);
   addBoardMarkers(scene, cellToWorld, playerColors);
 
+  let uniformTokenThickness = null;
   const tokens = playerColors.slice(0, playerCount).map((color, playerIdx) => {
     const playerTokenPieceOption = Array.isArray(tokenPieceByPlayer)
       ? tokenPieceByPlayer[playerIdx]
@@ -7711,6 +7726,17 @@ async function buildLudoBoard(
         }
       }
       token.scale.multiplyScalar(TOKEN_SIZE_MULTIPLIER);
+      const { size: tokenSize } = abgBbox(token);
+      const tokenThickness = Math.max(tokenSize.x, tokenSize.z);
+      if (Number.isFinite(tokenThickness) && tokenThickness > 1e-5) {
+        if (type === 'p' && uniformTokenThickness == null) {
+          uniformTokenThickness = tokenThickness * TOKEN_UNIFORM_THICKNESS_FACTOR;
+        }
+        if (uniformTokenThickness == null) {
+          uniformTokenThickness = tokenThickness * TOKEN_UNIFORM_THICKNESS_FACTOR;
+        }
+        normalizeTokenThickness(token, uniformTokenThickness);
+      }
       const label = createTokenCountLabel();
       if (label) {
         token.add(label);


### PR DESCRIPTION
### Motivation
- Improve mobile portrait play for Ludo Battle Royal by making 3D touch input a look-only control (no orbit/zoom) so swipes tilt the view without moving the camera, matching the requested UX from Chess Battle Royal broadcast behavior. 
- Ensure the broadcast camera frames events by retargeting look direction only (no dolly/zoom) so dice rolls, token motion and capture animations are always composed without moving the camera. 
- Make token visuals consistent by normalizing piece thickness across different token models so pawns and other pieces share a unified silhouette and proportion.

### Description
- Enabled custom look mode via `LUDO_CAMERA_CUSTOM_LOOK_ENABLED = true` and increased yaw/pitch ranges by updating `CAMERA_LOOK_YAW_LIMIT`, `CAMERA_LOOK_PITCH_LIMIT`, `CAMERA_LOOK_MIN_PITCH`, and `CAMERA_LOOK_PITCH_DRAG_FACTOR`. 
- Disabled 3D zoom by ensuring `controls.enableZoom` is set to `false` for 3D mode while preserving 2D zoom behavior in the top-down view. 
- Added `LUDO_BROADCAST_LOCKED_CAMERA` to lock broadcast camera position so follow/focus logic only updates `controls.target` (look) and not `camera.position` unless unlocked. 
- Implemented token thickness normalization by adding `normalizeTokenThickness()` and applying a pawn-based baseline (`TOKEN_UNIFORM_THICKNESS_FACTOR`) when building tokens in `buildLudoBoard`, so all tokens are adjusted to a consistent X/Z scale while preserving height and overall scale multiplier. 
- Changes are limited to `webapp/src/pages/Games/LudoBattleRoyal.jsx`.

### Testing
- Ran `npx eslint webapp/src/pages/Games/LudoBattleRoyal.jsx` which produced a repo ignore warning but reported no lint errors. (warning only — no errors)
- Ran `npx eslint --no-ignore webapp/src/pages/Games/LudoBattleRoyal.jsx` which produced the same ignore warning and no lint errors.
- No unit tests were run as part of this change; only lint checks were executed and passed with warnings about ignore patterns.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da7ce62e24832988ff0fd4c235c2ad)