### PR TITLE
Adjust Ludo token sizes and refine camera broadcast / touch behavior

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -755,7 +755,7 @@ const CAMERA_NEAR = ARENA_CAMERA_DEFAULTS.near;
 const CAMERA_FAR = ARENA_CAMERA_DEFAULTS.far;
 const CAMERA_DOLLY_FACTOR = ARENA_CAMERA_DEFAULTS.wheelDeltaFactor;
 const CAMERA_TARGET_LIFT = 0.028 * MODEL_SCALE;
-const CAMERA_SIDE_LOOK_EXTRA = 0.2 * MODEL_SCALE;
+const CAMERA_SIDE_LOOK_EXTRA = 0.3 * MODEL_SCALE;
 const CAMERA_TURN_PLAYER_LERP = 0.44;
 const CAMERA_BROADCAST_TARGET_BLEND = 0.5;
 const LUDO_CAMERA_AUTO_LOOK_ENABLED = true;
@@ -788,6 +788,8 @@ const CAMERA_LOOK_MIN_PITCH = THREE.MathUtils.degToRad(-10);
 const CAMERA_LOOK_PITCH_DRAG_FACTOR = -0.0038;
 const CAMERA_LOOK_YAW_RECENTER_SPEED = 0.055;
 const LUDO_CAMERA_CUSTOM_LOOK_ENABLED = true;
+const CAMERA_TOUCH_PULL_FORWARD_FACTOR = 0.0032;
+const CAMERA_TOUCH_PULL_FORWARD_MAX_RATIO = 0.32;
 const HDRI_GROUND_ALIGNMENT_OFFSET = -0.085 * MODEL_SCALE;
 const LUDO_HDRI_MAIN_SCENE_FACING_ROTATION_Y = Math.PI / 2;
 
@@ -2997,6 +2999,14 @@ const easeOutCubic = (t) => 1 - Math.pow(1 - t, 3);
 
 const TOKEN_SELECTION_SCALE = 1.08;
 const TOKEN_SIZE_MULTIPLIER = 1.4;
+const TOKEN_TYPE_SIZE_MULTIPLIER = Object.freeze({
+  pawn: 0.94,
+  knight: 0.94,
+  rook: 0.94,
+  bishop: 1.08,
+  queen: 1.08,
+  king: 1.08
+});
 
 function setTokenHighlight(token, active) {
   if (!token) return;
@@ -5498,16 +5508,33 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       const deltaY = clientY - lookState.lastY;
       lookState.lastX = clientX;
       lookState.lastY = clientY;
+      const isTouchDrag = event.pointerType === 'touch';
       lookState.yaw = clamp(
         lookState.yaw + deltaX * CAMERA_LOOK_YAW_DRAG_FACTOR,
         -CAMERA_LOOK_YAW_LIMIT,
         CAMERA_LOOK_YAW_LIMIT
       );
-      lookState.pitch = clamp(
-        lookState.pitch + deltaY * CAMERA_LOOK_PITCH_DRAG_FACTOR,
-        CAMERA_LOOK_MIN_PITCH,
-        CAMERA_LOOK_PITCH_LIMIT
-      );
+      if (isTouchDrag && deltaY > 0 && camera && controls) {
+        const toTarget = controls.target.clone().sub(camera.position);
+        const distance = toTarget.length();
+        if (distance > 1e-6) {
+          const maxForwardShift = Math.max(0, distance * CAMERA_TOUCH_PULL_FORWARD_MAX_RATIO);
+          const forwardShift = Math.min(
+            maxForwardShift,
+            deltaY * CAMERA_TOUCH_PULL_FORWARD_FACTOR * Math.max(distance, 1)
+          );
+          if (forwardShift > 0) {
+            const dir = toTarget.normalize();
+            camera.position.addScaledVector(dir, forwardShift);
+          }
+        }
+      } else if (!isTouchDrag) {
+        lookState.pitch = clamp(
+          lookState.pitch + deltaY * CAMERA_LOOK_PITCH_DRAG_FACTOR,
+          CAMERA_LOOK_MIN_PITCH,
+          CAMERA_LOOK_PITCH_LIMIT
+        );
+      }
       applyCameraLookOffset();
       controls?.update();
     };
@@ -7713,6 +7740,11 @@ async function buildLudoBoard(
         }
       }
       token.scale.multiplyScalar(TOKEN_SIZE_MULTIPLIER);
+      const typeKey = String(type || '').toLowerCase();
+      const typeScale =
+        TOKEN_TYPE_SIZE_MULTIPLIER[typeKey] ??
+        (typeKey === 'castle' ? TOKEN_TYPE_SIZE_MULTIPLIER.rook : 1);
+      token.scale.multiplyScalar(typeScale);
       const label = createTokenCountLabel();
       if (label) {
         token.add(label);


### PR DESCRIPTION
### Motivation
- Improve visual clarity and framing for Ludo Battle Royal by making small pieces slightly smaller and large pieces slightly larger so avatars and tokens read better on mobile portrait screens. 
- Make broadcast camera lock look further left/right for player turns so player avatars are more likely to appear in-frame. 
- Provide a touch-friendly camera gesture where pulling down brings the camera closer to the board (2D-like view) while upward swipes no longer change pitch, matching mobile portrait expectations.

### Description
- Increased side-look offset by changing `CAMERA_SIDE_LOOK_EXTRA` from `0.2 * MODEL_SCALE` to `0.3 * MODEL_SCALE` to shift turn-locked camera further laterally. (modified `webapp/src/pages/Games/LudoBattleRoyal.jsx`).
- Added per-piece scale adjustments via a new `TOKEN_TYPE_SIZE_MULTIPLIER` mapping and applied it when token models are instantiated to make `pawn/knight/rook` ~6% smaller and `bishop/queen/king` ~8% larger while preserving the existing `TOKEN_SIZE_MULTIPLIER` pipeline. (added constants and multiplication in `LudoBattleRoyal.jsx`).
- Implemented touch-specific camera pull-forward logic by introducing `CAMERA_TOUCH_PULL_FORWARD_FACTOR` and `CAMERA_TOUCH_PULL_FORWARD_MAX_RATIO` and applying forward camera movement when the pointer is `touch` and the drag delta Y is positive (downwards); upward touch drags no longer change pitch, while mouse/desktop drag retains previous pitch behavior. (updated `onPointerMove` handler in `LudoBattleRoyal.jsx`).

### Testing
- Ran the production build: `npm --prefix webapp run -s build`, which completed successfully. 
- Build produced only existing Vite warnings about large chunks/dynamic imports and no runtime build errors were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da8aaf60dc8329a8218a566a4ba85d)