### PR TITLE
Add helicopter capture animation and refresh Ludo airstrike FX shapes

### DIFF
--- a/webapp/src/config/ludoBattleOptions.js
+++ b/webapp/src/config/ludoBattleOptions.js
@@ -116,6 +116,11 @@ export const CAPTURE_ANIMATION_OPTIONS = Object.freeze([
     id: 'fighterJetAttack',
     label: 'Fighter Jet Attack',
     description: 'Fast fighter jet strike adapted from Chess Battle Royal scale.'
+  },
+  {
+    id: 'helicopterAttack',
+    label: 'Helicopter Strike',
+    description: 'Attack helicopter run that launches twin missiles on a jet-style path.'
   }
 ]);
 

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -219,39 +219,40 @@ function createCaptureMissileFx() {
 function createCaptureDroneFx() {
   const root = new THREE.Group();
   root.scale.setScalar(0.3);
-  addFxCylinder(root, 0.14, 0.19, 2.75, [0, 0, 0], [0, 0, Math.PI / 2], '#cfd3d6', 20);
+  addFxCylinder(root, 0.13, 0.18, 2.85, [0, 0, 0], [0, 0, Math.PI / 2], '#c3cbd1', 24);
   const nose = new THREE.Mesh(
-    new THREE.ConeGeometry(0.18, 0.72, 20),
-    new THREE.MeshStandardMaterial({ color: '#d9dde0', roughness: 0.5, metalness: 0.18 })
+    new THREE.ConeGeometry(0.17, 0.68, 22),
+    new THREE.MeshStandardMaterial({ color: '#d8dce0', roughness: 0.48, metalness: 0.2 })
   );
-  nose.position.set(1.7, 0, 0);
+  nose.position.set(1.74, 0, 0);
   nose.rotation.z = -Math.PI / 2;
   nose.castShadow = true;
   root.add(nose);
-  addFxCylinder(root, 0.18, 0.14, 0.48, [-1.58, 0, 0], [0, 0, Math.PI / 2], '#879095', 14);
+  addFxCylinder(root, 0.17, 0.13, 0.58, [-1.62, 0, 0], [0, 0, Math.PI / 2], '#778188', 16);
   const deltaWing = createFxPolygon(
     [
-      [-1.2, -1.65],
-      [1.0, 0],
-      [-1.2, 1.65]
+      [-1.25, -1.7],
+      [1.05, 0],
+      [-1.3, 1.7]
     ],
     0.08,
-    '#aeb4ae',
-    0.82,
-    0.08
+    '#a8b0b7',
+    0.74,
+    0.12
   );
-  deltaWing.position.set(-0.15, -0.06, 0);
+  deltaWing.position.set(-0.14, -0.06, 0);
   root.add(deltaWing);
+  addFxBox(root, [0.65, 0.08, 0.24], [-0.12, 0.2, 0], '#889198', 0.58, 0.2);
   const spine = createFxPolygon(
     [
-      [-0.55, -0.18],
-      [0.9, 0],
-      [-0.55, 0.18]
+      [-0.52, -0.16],
+      [0.92, 0],
+      [-0.52, 0.16]
     ],
     0.06,
-    '#7d858a',
+    '#798289',
     0.55,
-    0.22
+    0.24
   );
   spine.position.set(0.15, 0.03, 0);
   root.add(spine);
@@ -272,6 +273,8 @@ function createCaptureDroneFx() {
   const finRight = finLeft.clone();
   finRight.position.z = 0.25;
   root.add(finRight);
+  addFxCylinder(root, 0.04, 0.04, 0.64, [0.28, -0.22, -0.55], [Math.PI / 2, 0, 0], '#656e76', 12, 0.54, 0.22);
+  addFxCylinder(root, 0.04, 0.04, 0.64, [0.28, -0.22, 0.55], [Math.PI / 2, 0, 0], '#656e76', 12, 0.54, 0.22);
   addFxSphere(root, 0.09, [1.05, 0, 0], '#1f2428', 0.22, 0.35);
   const propeller = new THREE.Group();
   propeller.position.set(-1.95, 0, 0);
@@ -306,30 +309,36 @@ function createCaptureDroneFx() {
 
 function createCaptureJetFx() {
   const root = new THREE.Group();
-  addFxCylinder(root, 0.16, 0.22, 3.1, [0, 0, 0], [0, 0, Math.PI / 2], '#b8bec5', 24);
+  addFxCylinder(root, 0.15, 0.21, 3.18, [0, 0, 0], [0, 0, Math.PI / 2], '#bcc3c9', 28);
   const nose = new THREE.Mesh(
-    new THREE.ConeGeometry(0.17, 0.96, 24),
-    new THREE.MeshStandardMaterial({ color: '#d7dbe0', roughness: 0.45, metalness: 0.2 })
+    new THREE.ConeGeometry(0.16, 1.02, 24),
+    new THREE.MeshStandardMaterial({ color: '#d9dde2', roughness: 0.42, metalness: 0.2 })
   );
-  nose.position.set(2.0, 0, 0);
+  nose.position.set(2.04, 0, 0);
   nose.rotation.z = -Math.PI / 2;
   nose.castShadow = true;
   root.add(nose);
-  const cockpit = addFxSphere(root, 0.2, [0.62, 0.15, 0], '#2d3945', 0.18, 0.3);
-  cockpit.scale.set(1.2, 0.58, 0.64);
-  const wing = createFxPolygon([[-1.52, -2.32], [0.75, 0], [-0.35, 2.32]], 0.1, '#9fa7ae', 0.68, 0.16);
-  wing.position.set(-0.2, -0.05, 0);
+  const cockpit = addFxSphere(root, 0.21, [0.66, 0.16, 0], '#273745', 0.16, 0.34);
+  cockpit.scale.set(1.25, 0.56, 0.62);
+  const wing = createFxPolygon([[-1.6, -2.25], [0.8, 0], [-0.4, 2.25]], 0.1, '#9ba4ac', 0.66, 0.18);
+  wing.position.set(-0.18, -0.04, 0);
   root.add(wing);
-  const tailWing = createFxPolygon([[-0.92, -1.1], [0.3, 0], [-0.35, 1.1]], 0.08, '#959ea5', 0.65, 0.18);
-  tailWing.position.set(-1.35, 0.04, 0);
+  const canardLeft = createFxPolygon([[-0.42, -0.52], [0.2, 0], [-0.18, 0.52]], 0.05, '#8f99a2', 0.63, 0.2);
+  canardLeft.position.set(0.58, 0.01, -0.42);
+  root.add(canardLeft);
+  const canardRight = canardLeft.clone();
+  canardRight.position.z = 0.42;
+  root.add(canardRight);
+  const tailWing = createFxPolygon([[-0.95, -1.18], [0.33, 0], [-0.38, 1.18]], 0.08, '#929ca4', 0.64, 0.2);
+  tailWing.position.set(-1.36, 0.06, 0);
   root.add(tailWing);
-  const fin = createFxPolygon([[-0.52, 0], [0.22, 0], [-0.1, 0.95]], 0.05, '#8e979f', 0.6, 0.18);
+  const fin = createFxPolygon([[-0.54, 0], [0.24, 0], [-0.1, 1.02]], 0.05, '#8b959d', 0.58, 0.2);
   fin.rotation.z = Math.PI / 2;
-  fin.position.set(-1.1, 0.55, 0);
+  fin.position.set(-1.12, 0.58, 0);
   root.add(fin);
-  const engineLeft = addFxCylinder(root, 0.12, 0.1, 0.78, [-1.95, -0.08, -0.2], [0, 0, Math.PI / 2], '#727b83', 16);
+  const engineLeft = addFxCylinder(root, 0.12, 0.1, 0.84, [-1.98, -0.08, -0.22], [0, 0, Math.PI / 2], '#6f7881', 18);
   const engineRight = engineLeft.clone();
-  engineRight.position.z = 0.2;
+  engineRight.position.z = 0.22;
   root.add(engineRight);
   const leftStore = new THREE.Group();
   addFxCylinder(leftStore, 0.04, 0.05, 0.55, [0, 0, 0], [0, 0, Math.PI / 2], '#d8dbdf', 12, 0.4, 0.18);
@@ -362,6 +371,77 @@ function createCaptureJetFx() {
   }
   root.visible = false;
   return { root, trail };
+}
+
+function createCaptureHelicopterFx() {
+  const root = new THREE.Group();
+  addFxCylinder(root, 0.18, 0.22, 2.56, [0, 0, 0], [0, 0, Math.PI / 2], '#86909a', 24, 0.56, 0.26);
+  const nose = new THREE.Mesh(
+    new THREE.ConeGeometry(0.2, 0.88, 22),
+    new THREE.MeshStandardMaterial({ color: '#99a3ad', roughness: 0.5, metalness: 0.2 })
+  );
+  nose.position.set(1.7, 0, 0);
+  nose.rotation.z = -Math.PI / 2;
+  nose.castShadow = true;
+  root.add(nose);
+  const cockpit = addFxSphere(root, 0.26, [0.72, 0.18, 0], '#22303d', 0.18, 0.28);
+  cockpit.scale.set(1.2, 0.68, 0.72);
+  addFxCylinder(root, 0.08, 0.1, 1.25, [-1.7, 0.1, 0], [0, 0, Math.PI / 2], '#6f7881', 16, 0.56, 0.24);
+  addFxBox(root, [1.0, 0.08, 0.1], [0.2, -0.28, 0], '#4f5963', 0.6, 0.2);
+  addFxBox(root, [1.1, 0.08, 0.1], [-0.15, -0.28, -0.5], '#4f5963', 0.6, 0.2);
+  addFxBox(root, [1.1, 0.08, 0.1], [-0.15, -0.28, 0.5], '#4f5963', 0.6, 0.2);
+  const rotor = new THREE.Group();
+  rotor.position.set(-0.1, 0.47, 0);
+  addFxBox(rotor, [0.08, 0.08, 0.08], [0, 0, 0], '#1b1f24', 0.52, 0.2);
+  addFxBox(rotor, [0.14, 0.02, 1.9], [0, 0, 0], '#12161a', 0.44, 0.12);
+  const rotorCross = new THREE.Mesh(
+    new THREE.BoxGeometry(1.9, 0.02, 0.14),
+    new THREE.MeshStandardMaterial({ color: '#12161a', roughness: 0.44, metalness: 0.12 })
+  );
+  rotorCross.castShadow = true;
+  rotor.add(rotorCross);
+  root.add(rotor);
+  const tailRotor = new THREE.Group();
+  tailRotor.position.set(-2.18, 0.12, 0);
+  addFxBox(tailRotor, [0.04, 0.4, 0.08], [0, 0, 0], '#15191d', 0.52, 0.14);
+  const tailRotorCross = new THREE.Mesh(
+    new THREE.BoxGeometry(0.04, 0.08, 0.4),
+    new THREE.MeshStandardMaterial({ color: '#15191d', roughness: 0.52, metalness: 0.14 })
+  );
+  tailRotorCross.castShadow = true;
+  tailRotor.add(tailRotorCross);
+  root.add(tailRotor);
+  const missileLeft = new THREE.Group();
+  addFxCylinder(missileLeft, 0.04, 0.05, 0.55, [0, 0, 0], [0, 0, Math.PI / 2], '#d8dbdf', 12, 0.4, 0.18);
+  const missileNose = new THREE.Mesh(
+    new THREE.ConeGeometry(0.05, 0.14, 12),
+    new THREE.MeshStandardMaterial({ color: '#eceef0', roughness: 0.35, metalness: 0.16 })
+  );
+  missileNose.position.set(0.34, 0, 0);
+  missileNose.rotation.z = -Math.PI / 2;
+  missileLeft.add(missileNose);
+  missileLeft.position.set(0.22, -0.18, -0.62);
+  root.add(missileLeft);
+  const missileRight = missileLeft.clone();
+  missileRight.position.z = 0.62;
+  root.add(missileRight);
+  const trail = [];
+  for (let i = 0; i < 6; i += 1) {
+    trail.push(
+      addFxSphere(
+        root,
+        0.11 + i * 0.03,
+        [-1.76 - i * 0.2, 0, 0],
+        i < 2 ? '#f7a94b' : '#8b949b',
+        i < 2 ? 0.22 : 1,
+        0,
+        true,
+        i < 2 ? 0.85 - i * 0.18 : 0.28 - (i - 2) * 0.045
+      )
+    );
+  }
+  root.visible = false;
+  return { root, rotor, tailRotor, trail };
 }
 
 function createCaptureExplosionFx() {
@@ -5924,11 +6004,13 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         const primaryFx =
           resolvedCaptureAnimationId === 'droneAttack'
             ? createCaptureDroneFx()
+            : resolvedCaptureAnimationId === 'helicopterAttack'
+            ? createCaptureHelicopterFx()
             : resolvedCaptureAnimationId === 'fighterJetAttack'
             ? createCaptureJetFx()
             : createCaptureMissileFx();
         const jetMissiles =
-          resolvedCaptureAnimationId === 'fighterJetAttack'
+          resolvedCaptureAnimationId === 'fighterJetAttack' || resolvedCaptureAnimationId === 'helicopterAttack'
             ? [createCaptureMissileFx(), createCaptureMissileFx()]
             : [];
         const explosion = createCaptureExplosionFx();
@@ -5951,6 +6033,8 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         const animationScaleFactor =
           selectedCaptureAnimationId === 'fighterJetAttack'
             ? 0.36
+            : selectedCaptureAnimationId === 'helicopterAttack'
+            ? 0.3
             : selectedCaptureAnimationId === 'droneAttack'
             ? 0.21
             : 1;
@@ -5984,11 +6068,15 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         const baseTravelTime =
           selectedCaptureAnimationId === 'fighterJetAttack'
             ? 1460
+            : selectedCaptureAnimationId === 'helicopterAttack'
+            ? 1780
             : selectedCaptureAnimationId === 'droneAttack'
             ? 1960
             : 1780;
         const travelTime =
-          selectedCaptureAnimationId === 'fighterJetAttack' || selectedCaptureAnimationId === 'droneAttack'
+          selectedCaptureAnimationId === 'fighterJetAttack' ||
+          selectedCaptureAnimationId === 'droneAttack' ||
+          selectedCaptureAnimationId === 'helicopterAttack'
             ? baseTravelTime * 1.2
             : baseTravelTime;
         const explosionTime = 920;
@@ -6068,6 +6156,8 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           const apexHeight =
             selectedCaptureAnimationId === 'fighterJetAttack'
               ? liveTarget.y + topStrikeLift.y * 0.88
+              : selectedCaptureAnimationId === 'helicopterAttack'
+              ? liveTarget.y + topStrikeLift.y * 0.82
               : liveTarget.y + topStrikeLift.y;
           const apex = new THREE.Vector3(
             arenaCenter.x + Math.cos(cruiseAngle) * orbitalRadius,
@@ -6077,6 +6167,8 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           const phaseSplit =
             selectedCaptureAnimationId === 'fighterJetAttack'
               ? 0.78
+              : selectedCaptureAnimationId === 'helicopterAttack'
+              ? 0.8
               : selectedCaptureAnimationId === 'droneAttack'
               ? 1
               : 0.84;
@@ -6121,6 +6213,12 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             if (primaryFx.propeller) {
               primaryFx.propeller.rotation.y += 0.9;
             }
+            if (primaryFx.rotor) {
+              primaryFx.rotor.rotation.y += 0.5;
+            }
+            if (primaryFx.tailRotor) {
+              primaryFx.tailRotor.rotation.x += 0.9;
+            }
             primaryFx.trail.forEach((puff, i) => {
               puff.position.set(
                 -0.55 - i * 0.16,
@@ -6134,7 +6232,10 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
                   ? clamp(0.85 - u * 0.45 - i * 0.12, 0.2, 0.85)
                   : clamp(0.24 - (i - 2) * 0.04, 0.06, 0.24);
             });
-            if (selectedCaptureAnimationId === 'fighterJetAttack' && jetMissiles.length) {
+            if (
+              (selectedCaptureAnimationId === 'fighterJetAttack' || selectedCaptureAnimationId === 'helicopterAttack') &&
+              jetMissiles.length
+            ) {
               const releaseStart = travelTime * 0.56;
               const releaseEnd = travelTime * 0.96;
               const missileTravel = Math.max(280, releaseEnd - releaseStart - 100);
@@ -6177,7 +6278,10 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
                 });
               });
             }
-            if (selectedCaptureAnimationId === 'fighterJetAttack' && u > 0.88) {
+            if (
+              (selectedCaptureAnimationId === 'fighterJetAttack' || selectedCaptureAnimationId === 'helicopterAttack') &&
+              u > 0.88
+            ) {
               const retreatDir = pos.clone().sub(dynamicTo).setY(0).normalize();
               primaryFx.root.position.addScaledVector(retreatDir, (u - 0.88) * 1.5);
             }


### PR DESCRIPTION
### Motivation
- Provide a new helicopter capture animation that matches the requested behavior: keep current jet/drone visual sizes, add a helicopter that is slightly smaller than the fighter jet and flies slower, and make it launch two missiles that follow the same jet-style flight path and match the helicopter-mounted missile size.

### Description
- Added a new capture animation option `helicopterAttack` in `webapp/src/config/ludoBattleOptions.js` so the helicopter can be selected and stored via `CAPTURE_ANIMATION_OPTIONS`.
- Refreshed the procedural FX meshes for the drone and fighter jet in `webapp/src/pages/Games/LudoBattleRoyal.jsx` by tweaking shapes, proportions and trail visuals while preserving the existing gameplay scaling behavior.
- Implemented a new procedural helicopter FX rig via `createCaptureHelicopterFx()` in `webapp/src/pages/Games/LudoBattleRoyal.jsx` which includes main/tail rotors and two mounted missiles.
- Integrated helicopter sequencing into the capture flow (`playCaptureMissileSequence`), including helicopter-specific `animationScaleFactor`, slower `baseTravelTime`/`travelTime`, rotor animation, and branching so helicopter attacks launch exactly two missiles using the same missile flight logic/Bezier path as the fighter jet.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully (Vite warnings about chunk sizes were present but no build failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da9536d79c8329b84ac991a0d3afae)