### PR TITLE
Fix helicopter rotor selection, preserve GLB material look, and align F15 exhaust smoke to engine origin

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -2866,7 +2866,8 @@ function normalizeModel(object, targetSize) {
   object.position.y -= normalized.min.y;
 }
 
-function prepareCaptureModel(root) {
+function prepareCaptureModel(root, options = {}) {
+  const preserveOriginalMaterialLook = options.preserveOriginalMaterialLook !== false;
   root.traverse((child) => {
     if (!child?.isMesh) return;
     child.castShadow = true;
@@ -2877,7 +2878,7 @@ function prepareCaptureModel(root) {
       if (material?.emissiveMap) {
         applySRGBColorSpace(material.emissiveMap);
       }
-      if (material && 'envMapIntensity' in material) {
+      if (!preserveOriginalMaterialLook && material && 'envMapIntensity' in material) {
         material.envMapIntensity = 1.1;
         material.needsUpdate = true;
       }
@@ -8052,7 +8053,7 @@ function Chess3D({
             });
             const model = (gltf.scene || gltf.scenes?.[0])?.clone?.(true);
             if (!model) continue;
-            prepareCaptureModel(model);
+            prepareCaptureModel(model, { preserveOriginalMaterialLook: true });
             normalizeModel(model, targetSize);
             captureUnitTemplates[key] = model;
             return model;
@@ -8070,7 +8071,7 @@ function Chess3D({
       const template = captureUnitTemplates[key];
       if (!template) return null;
       const clone = cloneSkinned(template);
-      prepareCaptureModel(clone);
+      prepareCaptureModel(clone, { preserveOriginalMaterialLook: true });
       return clone;
     };
 
@@ -8145,14 +8146,52 @@ function Chess3D({
         bounds.getSize(size);
         const maxDim = Math.max(size.x, size.y, size.z) || 0;
         if (!Number.isFinite(maxDim) || maxDim <= 0 || maxDim > maxModelDim * 0.45) return;
+        const center = new THREE.Vector3();
+        bounds.getCenter(center);
+        const normalizedHeight = modelSize.y > 0 ? (center.y - modelBounds.min.y) / modelSize.y : 0.5;
+        if (role === 'main' && normalizedHeight < 0.52) return;
+        if (role === 'tail' && normalizedHeight > 0.72) return;
+        if (node.parent === model && node.children?.length) return;
         const roleMatch = roleMatchers.some((matcher) => matcher.test(name));
-        const score = (roleMatch ? 2 : 0) - maxDim;
+        const placementScore = role === 'main' ? normalizedHeight : 1 - Math.abs(normalizedHeight - 0.45);
+        const score = (roleMatch ? 2 : 0) + placementScore - maxDim;
         if (score > bestScore) {
           bestScore = score;
           best = node;
         }
       });
       return best;
+    };
+    const resolveJetExhaustOrigin = (model) => {
+      const bounds = new THREE.Box3().setFromObject(model);
+      const center = new THREE.Vector3();
+      bounds.getCenter(center);
+      let best = null;
+      let bestScore = Number.NEGATIVE_INFINITY;
+      model.traverse((node) => {
+        if (!node?.isMesh) return;
+        const name = `${node.name || ''}`.toLowerCase();
+        if (!/engine|exhaust|nozzle|thruster|afterburn/.test(name)) return;
+        const nodeBounds = new THREE.Box3().setFromObject(node);
+        if (!Number.isFinite(nodeBounds.min.x)) return;
+        const nodeCenter = new THREE.Vector3();
+        nodeBounds.getCenter(nodeCenter);
+        const rearBias = center.x - nodeCenter.x;
+        const centerBias = Math.abs(nodeCenter.z - center.z) * 0.25;
+        const score = rearBias - centerBias + 0.5;
+        if (score > bestScore) {
+          bestScore = score;
+          best = nodeBounds;
+        }
+      });
+      if (best) {
+        return new THREE.Vector3(best.min.x + 0.04, (best.min.y + best.max.y) * 0.5, (best.min.z + best.max.z) * 0.5);
+      }
+      return new THREE.Vector3(
+        Number.isFinite(bounds.min.x) ? bounds.min.x + 0.08 : -1.9,
+        Number.isFinite(bounds.min.y) && Number.isFinite(bounds.max.y) ? (bounds.min.y + bounds.max.y) * 0.5 : 0,
+        Number.isFinite(bounds.min.z) && Number.isFinite(bounds.max.z) ? (bounds.min.z + bounds.max.z) * 0.5 : 0
+      );
     };
     const createJetExhaustClouds = (root, count = 8, start = [-1.95, 0, 0], stepX = 0.26) => {
       const clouds = [];
@@ -8315,16 +8354,22 @@ function Chess3D({
           model.getObjectByName('cockpit') ||
           model.getObjectByName('Cockpit') ||
           model;
-        const modelBounds = new THREE.Box3().setFromObject(model);
-        const engineX = Number.isFinite(modelBounds.min.x) ? modelBounds.min.x + 0.08 : -1.9;
-        const centerY = Number.isFinite(modelBounds.min.y) && Number.isFinite(modelBounds.max.y)
-          ? (modelBounds.min.y + modelBounds.max.y) * 0.5
-          : 0;
-        const centerZ = Number.isFinite(modelBounds.min.z) && Number.isFinite(modelBounds.max.z)
-          ? (modelBounds.min.z + modelBounds.max.z) * 0.5
-          : 0;
-        const exhaustClouds = createJetExhaustClouds(root, 8, [engineX, centerY, centerZ], 0.22);
-        return { root, cockpit, leftStore: null, rightStore: null, exhaustClouds };
+        const exhaustOrigin = resolveJetExhaustOrigin(model);
+        const exhaustClouds = createJetExhaustClouds(
+          root,
+          8,
+          [exhaustOrigin.x, exhaustOrigin.y, exhaustOrigin.z],
+          0.22
+        );
+        return {
+          root,
+          cockpit,
+          leftStore: null,
+          rightStore: null,
+          exhaustClouds,
+          exhaustOrigin,
+          exhaustStep: 0.22
+        };
       }
       const root = new THREE.Group();
       addFxCylinder(root, 0.16, 0.22, 3.1, [0, 0, 0], [0, 0, Math.PI / 2], '#b8bec5', 24);
@@ -8366,8 +8411,10 @@ function Chess3D({
       const rightStore = leftStore.clone();
       rightStore.position.z = 1.15;
       root.add(rightStore);
-      const exhaustClouds = createJetExhaustClouds(root, 8, [-1.95, 0, 0], 0.26);
-      return { root, cockpit, leftStore, rightStore, exhaustClouds };
+      const exhaustOrigin = new THREE.Vector3(-1.95, 0, 0);
+      const exhaustStep = 0.26;
+      const exhaustClouds = createJetExhaustClouds(root, 8, [exhaustOrigin.x, exhaustOrigin.y, exhaustOrigin.z], exhaustStep);
+      return { root, cockpit, leftStore, rightStore, exhaustClouds, exhaustOrigin, exhaustStep };
     };
     const createFxMissile = () => {
       const root = new THREE.Group();
@@ -10362,8 +10409,14 @@ function Chess3D({
             captureDir.copy(jetNext).sub(jetPos).normalize();
             const jetForward = captureDir.clone();
             fx.jetFx.root.quaternion.setFromUnitVectors(FORWARD, captureDir);
+            const jetExhaustOrigin = fx.jetFx.exhaustOrigin || new THREE.Vector3(-1.75, 0, 0);
+            const jetExhaustStep = Number.isFinite(fx.jetFx.exhaustStep) ? fx.jetFx.exhaustStep : 0.24;
             fx.jetFx.exhaustClouds?.forEach((puff, idx) => {
-              puff.position.set(-1.75 - idx * 0.24, Math.sin(fx.t * 8.4 + idx * 0.5) * 0.03, 0);
+              puff.position.set(
+                jetExhaustOrigin.x - idx * jetExhaustStep,
+                jetExhaustOrigin.y + Math.sin(fx.t * 8.4 + idx * 0.5) * 0.03,
+                jetExhaustOrigin.z
+              );
               const s = 0.82 + idx * 0.14 + ((fx.t * 1.65 + idx * 0.11) % 1) * 0.5;
               puff.scale.setScalar(s);
             });


### PR DESCRIPTION
### Motivation
- Ensure only the helicopter's top (and tail) rotor nodes are animated so the whole helicopter model doesn't spin. 
- Preserve original GLB texture / UV mapping and material appearance for capture vehicles instead of forcing material changes on load/clone. 
- Place the F15 jet fire/smoke trail at the engine/nozzle core rather than a hardcoded offset so the trail follows the actual model geometry.

### Description
- Added an `options` parameter to `prepareCaptureModel` and a `preserveOriginalMaterialLook` flag to avoid forcing `envMapIntensity` and other overrides when requested, and invoked it with `preserveOriginalMaterialLook: true` when loading and cloning capture models (changes in `webapp/src/pages/Games/ChessBattleRoyal.jsx`).
- Tightened rotor detection in `findCaptureRotor` by rejecting candidates based on normalized vertical position in the model, avoiding nodes that are direct children with many children, and adding a placement score so top/tail rotors are chosen reliably. 
- Implemented `resolveJetExhaustOrigin(model)` to find engine/nozzle-like meshes (`engine`, `exhaust`, `nozzle`, `thruster`, `afterburn`) and compute a best exhaust anchor from their bounds. 
- Updated jet FX creation to store `exhaustOrigin` and `exhaustStep` and changed per-frame exhaust animation to place smoke puffs relative to the detected `exhaustOrigin` (falling back to previous offsets when detection fails). 

### Testing
- Ran the production build with `npm --prefix webapp run build` which completed successfully. 
- The change is limited to `webapp/src/pages/Games/ChessBattleRoyal.jsx` and the build artifacts were produced without errors (bundle warnings are unchanged build-size warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db1a7aa51c83299fb493b43a35b989)