### PR TITLE
Improve capture vehicle GLB loading and texture patching for drone/helicopter/fighter

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -89,6 +89,10 @@ const CAPTURE_VEHICLE_MODEL_FILES = {
   helicopter: 'helicopter.glb',
   fighter: 'f15.glb'
 };
+const GLB_MAGIC = 0x46546c67;
+const GLB_VERSION = 2;
+const GLB_JSON_CHUNK = 0x4e4f534a;
+const GLB_BIN_CHUNK = 0x004e4942;
 
 function getCaptureVehicleTexture(kind = 'generic') {
   if (CAPTURE_VEHICLE_TEXTURE_CACHE.has(kind)) return CAPTURE_VEHICLE_TEXTURE_CACHE.get(kind);
@@ -167,6 +171,23 @@ async function loadCaptureVehicleModel(kind) {
     const urls = CAPTURE_VEHICLE_MODEL_HOSTS.map((host) => `${host}/${file}`);
     const loader = new GLTFLoader();
     loader.setCrossOrigin('anonymous');
+    const imageCache = new Map();
+    for (const url of urls) {
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        const rawBuffer = await fetchBuffer(url);
+        // eslint-disable-next-line no-await-in-loop
+        const patchedBuffer = await patchGlbImagesToDataUris(rawBuffer, kind, url, urls, imageCache);
+        // eslint-disable-next-line no-await-in-loop
+        const gltf = await parseObjectFromBuffer(loader, patchedBuffer);
+        const modelRoot = gltf || null;
+        if (!modelRoot) continue;
+        prepareLoadedModel(modelRoot, { preserveGltfTextureMapping: true });
+        return modelRoot;
+      } catch (error) {
+        console.warn(`Capture ${kind} model load failed`, url, error);
+      }
+    }
     for (const url of urls) {
       try {
         // eslint-disable-next-line no-await-in-loop
@@ -183,6 +204,232 @@ async function loadCaptureVehicleModel(kind) {
   })();
   CAPTURE_VEHICLE_MODEL_CACHE.set(kind, promise);
   return promise;
+}
+
+function isDataUri(uri) {
+  return typeof uri === 'string' && uri.startsWith('data:');
+}
+
+function isAbsoluteUrl(uri) {
+  return /^https?:\/\//i.test(uri) || uri.startsWith('blob:');
+}
+
+function uniqueStrings(values) {
+  return Array.from(new Set(values));
+}
+
+function buildImageCandidates(imageUri, sourceUrl, modelUrls) {
+  if (isAbsoluteUrl(imageUri)) return uniqueStrings([imageUri]);
+  return uniqueStrings([
+    imageUri,
+    new URL(imageUri, sourceUrl).href,
+    ...modelUrls.map((modelUrl) => new URL(imageUri, modelUrl).href)
+  ]);
+}
+
+function decodeGlb(buffer) {
+  const view = new DataView(buffer);
+  if (view.byteLength < 20) throw new Error('GLB too small to parse');
+  if (view.getUint32(0, true) !== GLB_MAGIC) throw new Error('Asset is not a GLB file');
+  if (view.getUint32(4, true) !== GLB_VERSION) throw new Error('Unsupported GLB version');
+
+  const totalLength = view.getUint32(8, true);
+  const bytes = new Uint8Array(buffer, 0, totalLength);
+  const decoder = new TextDecoder();
+
+  let offset = 12;
+  let json = null;
+  let binChunk = null;
+
+  while (offset + 8 <= totalLength) {
+    const chunkLength = view.getUint32(offset, true);
+    const chunkType = view.getUint32(offset + 4, true);
+    offset += 8;
+    const chunkBytes = bytes.slice(offset, offset + chunkLength);
+    offset += chunkLength;
+    if (chunkType === GLB_JSON_CHUNK) {
+      json = JSON.parse(decoder.decode(chunkBytes).trim());
+    } else if (chunkType === GLB_BIN_CHUNK) {
+      binChunk = chunkBytes;
+    }
+  }
+
+  if (!json) throw new Error('GLB missing JSON chunk');
+  return { json, binChunk };
+}
+
+function createMinimalGlbBuffer(json, binChunk) {
+  const encoder = new TextEncoder();
+  const rawJson = encoder.encode(JSON.stringify(json));
+  const jsonPadding = (4 - (rawJson.length % 4)) % 4;
+  const paddedJson = new Uint8Array(rawJson.length + jsonPadding);
+  paddedJson.set(rawJson);
+  paddedJson.fill(0x20, rawJson.length);
+
+  let paddedBin = null;
+  if (binChunk) {
+    const binPadding = (4 - (binChunk.length % 4)) % 4;
+    paddedBin = new Uint8Array(binChunk.length + binPadding);
+    paddedBin.set(binChunk);
+  }
+
+  const totalLength = 12 + 8 + paddedJson.length + (paddedBin ? 8 + paddedBin.length : 0);
+  const buffer = new ArrayBuffer(totalLength);
+  const view = new DataView(buffer);
+  const bytes = new Uint8Array(buffer);
+
+  view.setUint32(0, GLB_MAGIC, true);
+  view.setUint32(4, GLB_VERSION, true);
+  view.setUint32(8, totalLength, true);
+
+  let offset = 12;
+  view.setUint32(offset, paddedJson.length, true);
+  view.setUint32(offset + 4, GLB_JSON_CHUNK, true);
+  offset += 8;
+  bytes.set(paddedJson, offset);
+  offset += paddedJson.length;
+
+  if (paddedBin) {
+    view.setUint32(offset, paddedBin.length, true);
+    view.setUint32(offset + 4, GLB_BIN_CHUNK, true);
+    offset += 8;
+    bytes.set(paddedBin, offset);
+  }
+
+  return buffer;
+}
+
+function extractBufferViewBytes(json, binChunk, bufferViewIndex) {
+  if (!binChunk) return null;
+  const bufferViews = Array.isArray(json?.bufferViews) ? json.bufferViews : [];
+  const view = bufferViews[bufferViewIndex];
+  if (!view) return null;
+  const byteOffset = typeof view.byteOffset === 'number' ? view.byteOffset : 0;
+  const byteLength = typeof view.byteLength === 'number' ? view.byteLength : 0;
+  if (byteLength <= 0) return null;
+  return binChunk.slice(byteOffset, byteOffset + byteLength);
+}
+
+function bytesToBase64(bytes) {
+  let binary = '';
+  const chunkSize = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    const chunk = bytes.subarray(i, i + chunkSize);
+    binary += String.fromCharCode(...chunk);
+  }
+  return btoa(binary);
+}
+
+function bytesToDataUri(bytes, mimeType) {
+  return `data:${mimeType};base64,${bytesToBase64(bytes)}`;
+}
+
+async function fetchBuffer(url) {
+  const response = await fetch(url, { mode: 'cors' });
+  if (!response.ok) throw new Error(`Fetch failed: ${response.status}`);
+  return response.arrayBuffer();
+}
+
+async function fetchBlob(url) {
+  const response = await fetch(url, { mode: 'cors' });
+  if (!response.ok) throw new Error(`Fetch blob failed: ${response.status}`);
+  return response.blob();
+}
+
+function parseObjectFromBuffer(loader, buffer) {
+  return new Promise((resolve, reject) => {
+    loader.parse(
+      buffer,
+      '',
+      (gltf) => resolve(gltf?.scene || gltf?.scenes?.[0] || null),
+      (error) => reject(error)
+    );
+  });
+}
+
+async function blobToDataUri(blob) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(typeof reader.result === 'string' ? reader.result : '');
+    reader.onerror = () => reject(new Error('Failed to convert blob to data URI'));
+    reader.readAsDataURL(blob);
+  });
+}
+
+function makePlaceholderTextureDataUri(primary, secondary) {
+  const canvas = document.createElement('canvas');
+  canvas.width = 64;
+  canvas.height = 64;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return 'data:image/png;base64,';
+  ctx.fillStyle = primary;
+  ctx.fillRect(0, 0, 64, 64);
+  ctx.fillStyle = secondary;
+  ctx.fillRect(0, 0, 32, 32);
+  ctx.fillRect(32, 32, 32, 32);
+  ctx.strokeStyle = 'rgba(255,255,255,0.25)';
+  ctx.lineWidth = 2;
+  ctx.strokeRect(1, 1, 62, 62);
+  return canvas.toDataURL('image/png');
+}
+
+async function resolveExternalImageToDataUri(imageUri, kind, sourceUrl, modelUrls, cache) {
+  if (isDataUri(imageUri)) return imageUri;
+  const placeholderColors = {
+    drone: ['#7c8791', '#4f5861'],
+    helicopter: ['#6f7763', '#4f5648'],
+    fighter: ['#98a1a9', '#646d76']
+  };
+  const [primary, secondary] = placeholderColors[kind] ?? ['#6e7681', '#4f5861'];
+  const placeholderDataUri = makePlaceholderTextureDataUri(primary, secondary);
+  const candidates = buildImageCandidates(imageUri, sourceUrl, modelUrls);
+  for (const candidate of candidates) {
+    if (!isAbsoluteUrl(candidate)) continue;
+    const cached = cache.get(candidate);
+    if (cached) return cached;
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      const blob = await fetchBlob(candidate);
+      // eslint-disable-next-line no-await-in-loop
+      const dataUri = await blobToDataUri(blob);
+      if (dataUri) {
+        cache.set(candidate, dataUri);
+        return dataUri;
+      }
+    } catch (err) {
+      // ignore candidate
+    }
+  }
+  return placeholderDataUri;
+}
+
+async function patchGlbImagesToDataUris(buffer, kind, sourceUrl, modelUrls, cache) {
+  const { json, binChunk } = decodeGlb(buffer);
+  const cloned = JSON.parse(JSON.stringify(json));
+  const images = Array.isArray(cloned.images) ? cloned.images : [];
+  if (!images.length) return buffer;
+
+  for (let i = 0; i < images.length; i += 1) {
+    const image = images[i];
+    if (typeof image.uri === 'string') {
+      // eslint-disable-next-line no-await-in-loop
+      image.uri = await resolveExternalImageToDataUri(image.uri, kind, sourceUrl, modelUrls, cache);
+      delete image.bufferView;
+      image.mimeType = image.mimeType ?? 'image/png';
+      continue;
+    }
+    if (typeof image.bufferView === 'number') {
+      const bytes = extractBufferViewBytes(cloned, binChunk, image.bufferView);
+      if (bytes?.length) {
+        const mimeType = typeof image.mimeType === 'string' ? image.mimeType : 'image/png';
+        image.uri = bytesToDataUri(bytes, mimeType);
+        delete image.bufferView;
+        image.mimeType = mimeType;
+      }
+    }
+  }
+
+  return createMinimalGlbBuffer(cloned, binChunk);
 }
 
 function applyCaptureTextureToOpaqueMeshes(root, kind) {


### PR DESCRIPTION
### Motivation
- Ensure the real GLB geometries for the drone, military helicopter and F-15 fighter are used reliably (avoid falling back to procedural placeholders) while keeping the existing visual sizes and fit behavior. 
- Harden the loader against external/missing textures by converting referenced and embedded images to data URIs before parsing so models with external texture refs load correctly in-browser.

### Description
- Added GLB parsing and helper utilities: `decodeGlb`, `createMinimalGlbBuffer`, `extractBufferViewBytes`, `bytesToDataUri`, `bytesToBase64`, `fetchBuffer`, `fetchBlob`, `parseObjectFromBuffer`, `blobToDataUri`, `makePlaceholderTextureDataUri`, `resolveExternalImageToDataUri`, and `patchGlbImagesToDataUris` inside `webapp/src/pages/Games/LudoBattleRoyal.jsx`.
- Updated `loadCaptureVehicleModel` to first fetch the raw GLB, patch its images into data URIs and parse that patched buffer, with a fallback to the existing `GLTFLoader.loadAsync` path; an `imageCache` is used to avoid refetching candidate images.
- Kept existing model file mapping (`drone.glb`, `helicopter.glb`, `f15.glb`) and preserved sizing/fit calls (`fitObjectToTargetSize` / existing target sizes), so only the loading/texture resolution path changed.
- Implemented conservative placeholder textures for missing images so models can still load when assets are incomplete.

### Testing
- Ran the production build with `npm --prefix webapp run build` and the build completed successfully. 
- No new unit tests were added; existing application build was used as validation and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db1b3da7108329bdecffdbb862baa0)