### PR TITLE
Fix turn resolution so roll CTA remains after rolling 6 in Snake & Ladder

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -2182,7 +2182,13 @@ export default function SnakeAndLadder() {
       const totalPlayers = players.length;
       if (totalPlayers <= 0) return -1;
 
-      const idxById = players.findIndex((pl) => pl.id === playerId);
+      const resolveByPlayerId = (candidate) => {
+        if (candidate == null) return -1;
+        const asString = String(candidate);
+        return players.findIndex((pl) => String(pl.id) === asString);
+      };
+
+      const idxById = resolveByPlayerId(playerId);
       const normalizeIndex = (candidate) => {
         if (!Number.isInteger(candidate)) return -1;
         if (candidate >= 0 && candidate < totalPlayers) return candidate;
@@ -2203,8 +2209,13 @@ export default function SnakeAndLadder() {
       const currentTurnResolved = normalizeIndex(currentTurnPayload);
       if (currentTurnResolved >= 0) return currentTurnResolved;
 
+      const currentTurnById = resolveByPlayerId(currentTurnPayload);
+      if (currentTurnById >= 0) return currentTurnById;
+
       if (idxById >= 0) return idxById;
-      return normalizeIndex(playerId);
+      const numericFromPlayerId = normalizeIndex(playerId);
+      if (numericFromPlayerId >= 0) return numericFromPlayerId;
+      return resolveByPlayerId(seatIndex);
     };
 
     const onTurn = ({ playerId, seatIndex, currentTurn: currentTurnPayload }) => {


### PR DESCRIPTION
### Motivation
- The multiplayer client sometimes failed to map server `turnUpdate`/`turnChanged` payloads when `currentTurn` was sent as a player/account ID string, which could hide the roll CTA after a rolled 6 (extra turn).

### Description
- Improve `resolveTurnIndex` in `webapp/src/pages/Games/SnakeAndLadder.jsx` to match player/account IDs (string) and add a robust fallback order that tries ID-based resolution first, then numeric `seatIndex`/`currentTurn`, and final fallbacks so the local turn index is resolved correctly.

### Testing
- Ran `npm --prefix webapp run build` and the build completed successfully; Vite produced non-blocking chunk/dynamic-import warnings but the production build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db259e870c8329b36b25592b1a6ad5)