### PR TITLE
Fix cue-stick release so live stroke pushes to cue-ball contact

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -22710,7 +22710,6 @@ const powerRef = useRef(hud.power);
             const safeStrikeDuration = Math.max(1, strikeDuration ?? 120);
             const safeHoldDuration = Math.max(0, holdDuration ?? 50);
             const safeRecoverDuration = Math.max(0, recoverDuration ?? 0);
-            const strikeExtraFollow = Math.max(0, stroke.strikeExtraFollow ?? 0);
             const pushT = THREE.MathUtils.clamp(elapsed / safeStrikeDuration, 0, 1);
             const easedPush = easeOutCubic(pushT);
             const normalizedStroke = ensureCueStrokeForwardMotion({
@@ -22720,22 +22719,29 @@ const powerRef = useRef(hud.power);
             });
             const resolvedPullPos = normalizedStroke.pullPos ?? pullPos ?? impactPos;
             const resolvedImpactPos = normalizedStroke.impactPos ?? impactPos ?? pullPos;
-            const strikeTargetPos = tmpCueStrokeA
-              .copy(resolvedImpactPos)
-              .add(tmpCueStrokeB.copy(normalizedStroke.direction).multiplyScalar(strikeExtraFollow));
+            // Live strike must drive forward into cue-ball contact and stop there.
+            const strikeContactPos = tmpCueStrokeA.copy(resolvedImpactPos);
 
             cueStick.visible = true;
-            cueStick.position.lerpVectors(resolvedPullPos, strikeTargetPos, easedPush);
+            cueStick.position.lerpVectors(resolvedPullPos, strikeContactPos, easedPush);
             cueStick.position.y -= (strikeDip ?? 0.003) * pushT;
             cueStick.rotation.x = baseRotationX ?? cueStick.rotation.x;
             cueStick.rotation.y =
               (baseRotationY ?? cueStick.rotation.y) +
               Math.sin(pushT * Math.PI) * 0.0012;
-            if (!stroke.shotApplied && pushT > 0.9) {
+            const impactThreshold = THREE.MathUtils.clamp(
+              stroke.strikeImpactThreshold ?? 0.9,
+              0.6,
+              1
+            );
+            if (!stroke.shotApplied && pushT >= impactThreshold) {
               stroke.shotApplied = true;
               stroke.onImpact?.();
             }
             if (elapsed < safeStrikeDuration + safeHoldDuration) {
+              if (elapsed >= safeStrikeDuration) {
+                cueStick.position.copy(strikeContactPos);
+              }
               cueAnimating = true;
               syncCueShadow();
               return true;
@@ -22751,7 +22757,7 @@ const powerRef = useRef(hud.power);
               const eased = easeInOutCubic(t);
               cueStick.visible = true;
               cueStick.position.lerpVectors(
-                followPos ?? impactPos ?? pullPos,
+                strikeContactPos ?? followPos ?? impactPos ?? pullPos,
                 idlePos ?? impactPos ?? pullPos,
                 eased
               );


### PR DESCRIPTION
### Motivation
- Players observed the cue stick remaining pulled instead of visibly pushing into the cue ball at shoot time, causing poor shot feedback and inconsistent visual/physics alignment.

### Description
- Updated the live `forwardOnly` cue stroke path in `webapp/src/pages/Games/PoolRoyale.jsx` to drive the cue from the currently-visible pulled position directly to the contact point (`strikeContactPos`) and stop there during the hold phase.
- Replaced the previous overshoot/follow behavior during the strike phase so the visual now aligns with the moment the shot impact is applied.
- Introduced a clamped configurable impact threshold `strikeImpactThreshold` (defaulted/clamped around `0.9`) so impact firing occurs deterministically during the forward push.
- Adjusted the hold/recover interpolation to use the resolved contact position so the cue remains at contact during hold then recovers cleanly back to idle.

### Testing
- Ran `npm test -- test/poolRoyaleCueStrokeTimeline.test.js --runInBand` and the suite passed (4 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db2eef7730832980a416ae8e5eb746)