### PR TITLE
Fix cue strike timing to trigger on forward contact

### DIFF
--- a/Assets/Scripts/Gameplay/CueController.cs
+++ b/Assets/Scripts/Gameplay/CueController.cs
@@ -37,7 +37,7 @@ namespace Aiming
         public float strikeHoldDuration = 0.05f;
         public float baseStrikeImpulse = 1.8f;
         public float maxStrikeImpulse = 6.5f;
-        [Tooltip("Normalized strike progress where the hit is fired once.")]
+        [Tooltip("Normalized strike progress where the hit is fired once after the cue has actually pushed forward into cue-ball contact.")]
         [Range(0.75f, 0.99f)] public float hitProgress = 0.9f;
         [Tooltip("How much of the strike stays for the final idle->contact micro drive.")]
         [Range(0.02f, 0.25f)] public float contactDrivePortion = 0.1f;
@@ -327,7 +327,7 @@ namespace Aiming
             float elapsed = 0f;
             bool didStrike = false;
             float contactStartT = Mathf.Clamp01(1f - contactDrivePortion);
-            float hitT = Mathf.Clamp01(Mathf.Max(hitProgress, contactStartT));
+            float hitT = Mathf.Clamp01(hitProgress);
             _currentCueDepth = startDepth;
             UpdateCuePose();
 
@@ -350,7 +350,9 @@ namespace Aiming
                 _currentCueDepth = cueDepth;
                 UpdateCuePose();
 
-                if (!didStrike && t >= hitT)
+                bool reachedCueBallContact = cueDepth <= hitDepth + 0.0001f;
+                bool reachedHitMoment = t >= hitT;
+                if (!didStrike && reachedCueBallContact && reachedHitMoment)
                 {
                     didStrike = true;
                     ApplyStrikeImpulse(strikeDirection, shotPower);


### PR DESCRIPTION
### Motivation
- Ensure the visual cue push and the physical shot impulse stay in sync so the cue no longer appears stuck pulled or fires early when taking a shot.

### Description
- Gate the strike impulse inside `Assets/Scripts/Gameplay/CueController.cs` so `ApplyStrikeImpulse` only runs when the cue has actually pushed forward into contact (`_currentCueDepth` reaches contact/hit depth) and the configured `hitProgress` timing has been reached, and update the `hitProgress` inspector tooltip to document the forward-contact requirement.

### Testing
- No automated gameplay or unit tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db2eef7730832980a416ae8e5eb746)