### PR TITLE
Fix Pool Royale cue stroke to finish at cue-ball contact

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -22710,7 +22710,6 @@ const powerRef = useRef(hud.power);
             const safeStrikeDuration = Math.max(1, strikeDuration ?? 120);
             const safeHoldDuration = Math.max(0, holdDuration ?? 50);
             const safeRecoverDuration = Math.max(0, recoverDuration ?? 0);
-            const strikeExtraFollow = Math.max(0, stroke.strikeExtraFollow ?? 0);
             const pushT = THREE.MathUtils.clamp(elapsed / safeStrikeDuration, 0, 1);
             const easedPush = easeOutCubic(pushT);
             const normalizedStroke = ensureCueStrokeForwardMotion({
@@ -22720,9 +22719,8 @@ const powerRef = useRef(hud.power);
             });
             const resolvedPullPos = normalizedStroke.pullPos ?? pullPos ?? impactPos;
             const resolvedImpactPos = normalizedStroke.impactPos ?? impactPos ?? pullPos;
-            const strikeTargetPos = tmpCueStrokeA
-              .copy(resolvedImpactPos)
-              .add(tmpCueStrokeB.copy(normalizedStroke.direction).multiplyScalar(strikeExtraFollow));
+            const strikeTargetPos = tmpCueStrokeA.copy(resolvedImpactPos);
+            const strikeWobbleScale = Math.max(0, 1 - pushT);
 
             cueStick.visible = true;
             cueStick.position.lerpVectors(resolvedPullPos, strikeTargetPos, easedPush);
@@ -22730,12 +22728,20 @@ const powerRef = useRef(hud.power);
             cueStick.rotation.x = baseRotationX ?? cueStick.rotation.x;
             cueStick.rotation.y =
               (baseRotationY ?? cueStick.rotation.y) +
-              Math.sin(pushT * Math.PI) * 0.0012;
-            if (!stroke.shotApplied && pushT > 0.9) {
+              Math.sin(pushT * Math.PI) * 0.0012 * strikeWobbleScale;
+            if (!stroke.shotApplied && pushT >= 0.9) {
               stroke.shotApplied = true;
               stroke.onImpact?.();
             }
+            if (elapsed < safeStrikeDuration) {
+              cueAnimating = true;
+              syncCueShadow();
+              return true;
+            }
             if (elapsed < safeStrikeDuration + safeHoldDuration) {
+              cueStick.position.copy(resolvedImpactPos);
+              cueStick.rotation.x = baseRotationX ?? cueStick.rotation.x;
+              cueStick.rotation.y = baseRotationY ?? cueStick.rotation.y;
               cueAnimating = true;
               syncCueShadow();
               return true;


### PR DESCRIPTION
### Motivation
- The live forward-only cue stroke could visually overshoot past the cue-ball, leaving the cue appearing pulled instead of stopping at contact. 
- The visual behavior needed to pin the cue at the contact/impact point so the shot reads clearly to the player and the hit action triggers exactly at contact. 
- Reduce excessive wobble near impact so the cue settles naturally when it reaches the ball.

### Description
- Updated the forward-only cue stroke implementation in `webapp/src/pages/Games/PoolRoyale.jsx` to drive the cue from the visible pulled position directly to the computed impact/contact point instead of advancing past it. 
- Added a `strikeWobbleScale` to damp strike wobble as the push nears impact and reduced the wobble contribution to `cueStick.rotation.y`. 
- Made the impact-hold explicit by copying `resolvedImpactPos` into the cue during the hold window (`cueStick.position.copy(resolvedImpactPos)`), and adjusted the hit application threshold to fire at the expected moment. 
- Removed the overshoot `strikeExtraFollow` usage for the forward-only path so the cue no longer advances past the contact point.

### Testing
- Ran the production build with `cd webapp && npm run -s build`, which completed successfully and produced the app bundle with the usual Vite warnings about chunk sizes; build succeeded. 
- Attempted `cd webapp && npm run -s lint`, but the repository does not provide a lint script / the lint step was not applicable in this environment. 
- No new compile errors were introduced by the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db2eef7730832980a416ae8e5eb746)