### PR TITLE
Domino Royale: shrink table/chairs by 20% and retune camera framing

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -944,7 +944,7 @@ const dimIntensity = (value = 1) => value * LIGHT_INTENSITY_FACTOR;
 
 const MODEL_SCALE = 0.7;
 const CAMERA_LAYOUT_SCALE = MODEL_SCALE / 0.75;
-const TABLE_SIZE_REDUCTION_FACTOR = 0.85;
+const TABLE_SIZE_REDUCTION_FACTOR = 0.68; // 20% smaller than previous 0.85 baseline
 const TABLE_RADIUS_SCALE = 0.79 * TABLE_SIZE_REDUCTION_FACTOR;
 const TABLE_HEIGHT_SCALE = 0.79 * TABLE_SIZE_REDUCTION_FACTOR;
 const ARENA_GROWTH = 1.45;
@@ -1014,12 +1014,12 @@ const CAMERA_LATERAL_OFFSET = {
   landscape: 0 * CAMERA_LAYOUT_SCALE
 };
 const CAMERA_REAR_OFFSET = {
-  portrait: 1.06 * CAMERA_LAYOUT_SCALE,
-  landscape: 0.62 * CAMERA_LAYOUT_SCALE
+  portrait: 1.06 * CAMERA_LAYOUT_SCALE * 0.8,
+  landscape: 0.62 * CAMERA_LAYOUT_SCALE * 0.8
 };
 const CAMERA_HEIGHT_BOOST = {
-  portrait: 1.79 * CAMERA_LAYOUT_SCALE,
-  landscape: 1.03 * CAMERA_LAYOUT_SCALE
+  portrait: 1.79 * CAMERA_LAYOUT_SCALE * 0.8,
+  landscape: 1.03 * CAMERA_LAYOUT_SCALE * 0.8
 };
 const CAMERA_LOOK_YAW_LIMIT = THREE.MathUtils.degToRad(26);
 const CAMERA_LOOK_YAW_DRAG_FACTOR = -0.0055;

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-04-12-domino-chair-outward-spacing-v19';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-04-12-domino-table-scale-20pct-v20';
 
 export default function DominoRoyalArena() {
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- Reduce the Domino Battle Royal table and chair visual scale by 20% so the table + chair arrangement reads smaller on mobile and matches new design direction.
- Keep the in-game camera framing visually consistent after the environment downscale so player view and touch targets remain familiar.
- Ensure dominoes sit correctly on the lowered table surface after the height change.

### Description
- Lowered `TABLE_SIZE_REDUCTION_FACTOR` from `0.85` to `0.68` in `webapp/public/domino-royal-game.js` so the table, stools, and chair visuals scale down ~20%.
- Scaled the 3D camera offsets by `0.8` by multiplying `CAMERA_REAR_OFFSET` and `CAMERA_HEIGHT_BOOST` in `webapp/public/domino-royal-game.js` to preserve existing framing with the smaller table.
- Left domino vertical placement driven by `CLOTH_TOP`/`TABLE_HEIGHT` (via `CHAIN_TILE_Y = CLOTH_TOP + 0.0034`) so dominoes automatically sit lower with the reduced table height.
- Bumped the client script version `DOMINO_ROYAL_SCRIPT_VERSION` in `webapp/src/pages/Games/DominoRoyalArena.jsx` to `2026-04-12-domino-table-scale-20pct-v20` so browsers fetch the updated tuning.

### Testing
- Ran `npm test -- --runInBand test/dominoRoyalHdriCatalog.test.js` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db3e00b7d8832995690758fe1f5898)