### PR TITLE
Tune Ludo Battle Royal table scale, token sizes/shapes and broadcast camera behavior

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1217,7 +1217,8 @@ const ARENA_SCALE = 0.72 * LUDO_ARENA_SHRINK_FACTOR;
 const ARENA_SCALE_RATIO = ARENA_SCALE / BASE_ARENA_SCALE;
 const MODEL_SCALE = 0.75 * ARENA_SCALE;
 const TABLE_RADIUS = 3.48 * MODEL_SCALE;
-const BASE_TABLE_HEIGHT = 1.03 * MODEL_SCALE;
+const TABLE_HEIGHT_SCALE = 0.8;
+const BASE_TABLE_HEIGHT = 1.03 * MODEL_SCALE * TABLE_HEIGHT_SCALE;
 const CHAIR_GLOBAL_SCALE = 0.5;
 const STOOL_SCALE = 1.5 * 1.3 * CHAIR_GLOBAL_SCALE;
 const SEAT_WIDTH = 0.9 * MODEL_SCALE * STOOL_SCALE;
@@ -1334,8 +1335,8 @@ const PORTRAIT_CAMERA_TUNING = Object.freeze({
   targetLift: 0.055 * MODEL_SCALE
 });
 const CAMERA_EXTRA_PULLBACK = 0;
-const CAMERA_EXTRA_LIFT = 0.058;
-const PORTRAIT_CAMERA_EXTRA_LIFT = 0.054;
+const CAMERA_EXTRA_LIFT = 0.072;
+const PORTRAIT_CAMERA_EXTRA_LIFT = 0.068;
 const CAMERA_LOOK_YAW_LIMIT = THREE.MathUtils.degToRad(26);
 const CAMERA_LOOK_YAW_DRAG_FACTOR = 0.0055;
 const CAMERA_LOOK_PITCH_LIMIT = THREE.MathUtils.degToRad(22);
@@ -1347,7 +1348,7 @@ const CAMERA_TOUCH_PULL_FORWARD_FACTOR = 0.0032;
 const CAMERA_TOUCH_PULL_FORWARD_MAX_RATIO = 0.32;
 const CAMERA_TOUCH_PULL_BACK_MAX_RATIO = 0.4;
 const CAMERA_TOUCH_LIFT_FACTOR = 0.0016;
-const CAMERA_TOUCH_LIFT_MAX = 0.065 * MODEL_SCALE;
+const CAMERA_TOUCH_LIFT_MAX = 0.082 * MODEL_SCALE;
 const HDRI_GROUND_ALIGNMENT_OFFSET = -0.085 * MODEL_SCALE;
 const LUDO_HDRI_MAIN_SCENE_FACING_ROTATION_Y = Math.PI / 2;
 
@@ -1710,6 +1711,63 @@ function abgPreparePiece(src) {
   return group;
 }
 
+function buildChessBattleKnightPrototype() {
+  const root = new THREE.Group();
+  const baseMat = new THREE.MeshStandardMaterial({ color: 0xffffff, roughness: 0.42, metalness: 0.2 });
+  const base = new THREE.Mesh(
+    new THREE.CylinderGeometry(0.032, 0.038, 0.012, 24),
+    baseMat.clone()
+  );
+  base.position.y = 0.006;
+  root.add(base);
+
+  const torso = new THREE.Mesh(
+    new THREE.CylinderGeometry(0.024, 0.028, 0.028, 24),
+    baseMat.clone()
+  );
+  torso.position.y = 0.025;
+  root.add(torso);
+
+  const shape = new THREE.Shape();
+  const pts = [
+    [-0.018, 0.0],
+    [-0.005, 0.004],
+    [0.006, 0.022],
+    [0.016, 0.03],
+    [0.024, 0.038],
+    [0.014, 0.042],
+    [0.006, 0.04],
+    [0.001, 0.048],
+    [0.006, 0.06],
+    [0.001, 0.064],
+    [-0.005, 0.055],
+    [-0.013, 0.049],
+    [-0.017, 0.04],
+    [-0.022, 0.032],
+    [-0.021, 0.025],
+    [-0.014, 0.02],
+    [-0.017, 0.012],
+    [-0.022, 0.006]
+  ];
+  shape.moveTo(pts[0][0], pts[0][1]);
+  pts.slice(1).forEach(([x, y]) => shape.lineTo(x, y));
+  shape.lineTo(pts[0][0], pts[0][1]);
+  const head = new THREE.Mesh(
+    new THREE.ExtrudeGeometry(shape, {
+      depth: 0.018,
+      bevelEnabled: true,
+      bevelSize: 0.0018,
+      bevelThickness: 0.0018
+    }),
+    baseMat.clone()
+  );
+  head.rotation.y = Math.PI / 2;
+  head.position.set(0, 0.036, -0.009);
+  root.add(head);
+
+  return abgPreparePiece(root);
+}
+
 function tintGltfToken(node, tint) {
   if (!node || !tint) return;
   const target = new THREE.Color(tint);
@@ -1811,6 +1869,7 @@ async function getAbgAssets() {
           proto[color][type] = abgPreparePiece(proto[color][type]);
         }
       });
+      proto[color].n = buildChessBattleKnightPrototype();
     });
 
     return { proto, boardPrototype: abgCloneWithMats(boardNode) };
@@ -3561,13 +3620,16 @@ const easeOutCubic = (t) => 1 - Math.pow(1 - t, 3);
 
 const TOKEN_SELECTION_SCALE = 1.08;
 const TOKEN_SIZE_MULTIPLIER = 1.4;
+const CAMERA_TURN_VIEW_DURATION_MS = 520;
+const CAMERA_BROADCAST_ANIMATION_MS = 560;
+const CAMERA_RETURN_ANIMATION_MS = 620;
 const TOKEN_TYPE_SCALE_PROFILE = Object.freeze({
-  pawn: { x: 0.75, y: 0.75, z: 0.72 },
-  knight: { x: 0.94, y: 0.94, z: 0.9 },
-  rook: { x: 0.94, y: 0.94, z: 0.9 },
-  bishop: { x: 1.37, y: 1.39, z: 1.42 },
-  queen: { x: 1.37, y: 1.39, z: 1.42 },
-  king: { x: 1.39, y: 1.42, z: 1.44 }
+  pawn: { x: 0.6, y: 0.6, z: 0.576 },
+  knight: { x: 0.84, y: 0.94, z: 0.76 },
+  rook: { x: 0.84, y: 0.94, z: 0.78 },
+  bishop: { x: 1.644, y: 1.668, z: 1.704 },
+  queen: { x: 1.644, y: 1.668, z: 1.704 },
+  king: { x: 1.668, y: 1.704, z: 1.728 }
 });
 
 function setTokenHighlight(token, active) {
@@ -7148,7 +7210,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     return baseTarget;
   }, []);
 
-  const setCameraViewForTurn = useCallback((player, duration = 420, { force = false } = {}) => {
+  const setCameraViewForTurn = useCallback((player, duration = CAMERA_TURN_VIEW_DURATION_MS, { force = false } = {}) => {
     cancelCameraViewAnimation();
     if (isCamera2d || !LUDO_CAMERA_AUTO_LOOK_ENABLED) return;
     if (player === 0 && preserveUserTurnCameraRef.current && !force) return;
@@ -7222,7 +7284,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         } else {
           cameraTurnStateRef.current.followOffset = null;
         }
-        animateCameraPose(nextFocusState.target, nextFocusState.position, 380);
+        animateCameraPose(nextFocusState.target, nextFocusState.position, CAMERA_BROADCAST_ANIMATION_MS);
       }
       if (ttl > 0) {
         if (cameraFocusTimeoutRef.current) {
@@ -7237,7 +7299,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           if (returnTarget) {
             const restoreFocusState = resolveFocusCameraState(returnTarget, CAMERA_TARGET_LIFT);
             if (restoreFocusState) {
-              animateCameraPose(restoreFocusState.target, restoreFocusState.position, 420);
+              animateCameraPose(restoreFocusState.target, restoreFocusState.position, CAMERA_RETURN_ANIMATION_MS);
             }
           }
         }, Math.max(0, ttl * 1000));
@@ -7784,9 +7846,10 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     dice.userData.isRolling = true;
     setCameraFocus({
       object: dice,
-      follow: true,
-      priority: 4,
-      offset: CAMERA_TARGET_LIFT + 0.04
+      follow: false,
+      priority: 2,
+      ttl: 0.9,
+      offset: CAMERA_TARGET_LIFT + 0.03
     });
     playDiceSound();
     const landingFocus = baseTarget.clone();
@@ -7796,14 +7859,6 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       bounceHeight: dice.userData?.bounceHeight ?? 0.06
     });
     dice.userData.isRolling = false;
-    setCameraFocus({
-      target: landingFocus,
-      follow: false,
-      ttl: 1.6 + DICE_RESULT_EXTRA_HOLD_MS / 1000,
-      priority: 3,
-      offset: CAMERA_TARGET_LIFT + 0.03,
-      force: true
-    });
     setUi((s) => ({
       ...s,
       dice: value,
@@ -7818,19 +7873,29 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     scheduleDiceClear();
     const options = getMovableTokens(player, value);
     const hasBoardTokenBeforeRoll = hasAnyTokenOnBoard(player);
+    if (options.length) {
+      setCameraFocus({
+        target: landingFocus,
+        follow: false,
+        ttl: 1.2,
+        priority: 2,
+        offset: CAMERA_TARGET_LIFT + 0.03,
+        force: true
+      });
+    }
     if (!options.length) {
       const playerCycle = Math.max(1, activePlayerCount);
       const upcomingTurn = value === 6 ? player : (player + playerCycle - 1) % playerCycle;
-      setCameraViewForTurn(upcomingTurn, 280, { force: true });
+      setCameraViewForTurn(upcomingTurn, CAMERA_TURN_VIEW_DURATION_MS, { force: true });
       clearTurnAdvanceTimeout();
       turnAdvanceTimeoutRef.current = window.setTimeout(() => {
         turnAdvanceTimeoutRef.current = null;
         advanceTurn(value === 6);
-      }, 550);
+      }, 900);
       return;
     }
     if (player === 0) {
-      setCameraViewForTurn(0, 260, { force: true });
+      setCameraViewForTurn(0, CAMERA_TURN_VIEW_DURATION_MS, { force: true });
       beginHumanSelection(value, options);
       return;
     }
@@ -7838,7 +7903,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     if (!choice) {
       const playerCycle = Math.max(1, activePlayerCount);
       const upcomingTurn = value === 6 ? player : (player + playerCycle - 1) % playerCycle;
-      setCameraViewForTurn(upcomingTurn, 300, { force: true });
+      setCameraViewForTurn(upcomingTurn, CAMERA_TURN_VIEW_DURATION_MS, { force: true });
       clearTurnAdvanceTimeout();
       turnAdvanceTimeoutRef.current = window.setTimeout(() => {
         turnAdvanceTimeoutRef.current = null;


### PR DESCRIPTION
### Motivation
- Reduce the visible table height so the arena fits better on portrait screens while preserving board & token alignment.
- Adjust token proportions to match requested sizing: smaller pawns, larger kings/queens/bishops, slimmer rooks/knights and use the ChessBattle-style knight silhouette for visual parity. 
- Give users slightly more upward camera headroom and make broadcast camera motion smoother and less jumpy when dice/board focus is unnecessary. 

### Description
- Lowered the full table vertical scale by 20% using a new `TABLE_HEIGHT_SCALE` and applied it to table height math so board and attachments keep their relative layout (`webapp/src/pages/Games/LudoBattleRoyal.jsx`).
- Updated token scale profile (`TOKEN_TYPE_SCALE_PROFILE`) so pawns are 20% smaller, king/queen/bishop are ~20% larger, and rook/knight use thinner x/z profiles to appear slimmer.
- Added a procedural Chess-style knight prototype via `buildChessBattleKnightPrototype()` and wired it into ABG prototype resolution for `n` (knight) tokens so knights use the Chess Battle Royal silhouette.
- Increased camera lift values (`CAMERA_EXTRA_LIFT`, `PORTRAIT_CAMERA_EXTRA_LIFT`, `CAMERA_TOUCH_LIFT_MAX`) to allow lifting the camera a bit more (portrait and touch cases).
- Smoothed broadcast camera behavior by adding configurable animation durations (`CAMERA_TURN_VIEW_DURATION_MS`, `CAMERA_BROADCAST_ANIMATION_MS`, `CAMERA_RETURN_ANIMATION_MS`), reducing aggressive dice-following (weaker dice follow + TTL), and changing the no-move flow to return the camera to the upcoming player and wait before advancing the turn.
- Minor timing adjustments where dice roll / no-move branches use the new durations and slightly longer wait before advancing turn to reduce jitter and unnecessary board-looking.

### Testing
- Ran `npm run build` successfully (TypeScript build completed). 
- Ran `npx eslint` against the modified file and observed only a project ignore-pattern warning; no syntax errors were reported for the edited code path.
- Verified the changed file in the patch is `webapp/src/pages/Games/LudoBattleRoyal.jsx` and unit/integration test suites were not modified in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db4266377483299b0b66a1b21ebce5)