### PR TITLE
Adjust Chess Battle Royal token scale and board grounding

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -285,10 +285,10 @@ const CARD_SCALE = 0.95;
 
 const BOARD = { N: 8, tile: 4.2, rim: 3, baseH: 0.8 };
 const PIECE_Y = 1.2; // baseline height for meshes
-const PIECE_PLACEMENT_Y_OFFSET = 0.28;
+const PIECE_PLACEMENT_Y_OFFSET = 0.24; // Lower tokens slightly so they stay grounded on the board after shrinking.
 const LAYOUT_SCALE_FACTOR = 0.7225;
 const TABLE_LAYOUT_SCALE_FACTOR = 0.85; // Keep the same table/board/chair proportions, but 15% smaller than current.
-const PIECE_SCALE_FACTOR = 0.79 * LAYOUT_SCALE_FACTOR * 1.5; // Make chess pieces 20% bigger than before (1.25 -> 1.5).
+const PIECE_SCALE_FACTOR = 0.79 * LAYOUT_SCALE_FACTOR * 1.5 * 0.85; // Shrink tokens by 15% while preserving the existing style proportions.
 const PIECE_FOOTPRINT_RATIO = 0.86;
 const BOARD_GROUP_Y_OFFSET = 0.035;
 const BOARD_MODEL_Y_OFFSET = -0.12;


### PR DESCRIPTION
### Motivation
- Players requested chess tokens be visually smaller (about 15%) and remain visually grounded on the board after shrinking to improve fit and appearance on small screens.

### Description
- Reduced token scale by multiplying `PIECE_SCALE_FACTOR` with `0.85` in `webapp/src/pages/Games/ChessBattleRoyal.jsx` to make pieces 15% smaller.
- Lowered vertical placement by changing `PIECE_PLACEMENT_Y_OFFSET` from `0.28` to `0.24` so scaled-down tokens stay visually grounded on the board.
- Change scope is limited to `webapp/src/pages/Games/ChessBattleRoyal.jsx`.

### Testing
- Run `npm test -- --runInBand test/chessBattleInventoryConfig.test.js` and the suite passed: 1 test suite, 3 tests all succeeding.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db45661f148329b380db1ae787e65a)