### PR TITLE
Make Domino Royal dominoes and chairs 20% smaller

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -944,7 +944,7 @@ const dimIntensity = (value = 1) => value * LIGHT_INTENSITY_FACTOR;
 
 const MODEL_SCALE = 0.7;
 const CAMERA_LAYOUT_SCALE = MODEL_SCALE / 0.75;
-const DOMINO_AND_CHAIR_SHRINK_FACTOR = 0.765; // ~10% smaller than current arena sizing for dominoes/chairs
+const DOMINO_AND_CHAIR_SHRINK_FACTOR = 0.612; // 20% smaller than the previous domino/chair sizing
 const LEGACY_TABLE_SIZE_REDUCTION_FACTOR = 0.68;
 const TABLE_SHRINK_FACTOR = 0.8;
 const TABLE_AND_CHAIR_SHRINK_FACTOR = 0.765; // ~10% smaller than current arena furniture sizing

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-04-12-domino-table-scale-20pct-v20';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-04-12-domino-chair-scale-20pct-v21';
 
 export default function DominoRoyalArena() {
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- Reduce the visual size of domino pieces and chairs in the Domino Royal arena by 20% and ensure clients load the updated arena script.

### Description
- Updated `DOMINO_AND_CHAIR_SHRINK_FACTOR` in `webapp/public/domino-royal-game.js` from `0.765` to `0.612` to scale down both dominoes and chairs.
- Bumped the cache-busting script version `DOMINO_ROYAL_SCRIPT_VERSION` in `webapp/src/pages/Games/DominoRoyalArena.jsx` to `2026-04-12-domino-chair-scale-20pct-v21` so clients will fetch the new script.

### Testing
- Ran `npm test -- test/dominoRoyalHdriCatalog.test.js --runInBand` and the test suite passed (1 test, 1 suite).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db5bf711348329988f69c6cac7f990)