### PR TITLE
Domino Royal: reduce domino and chair visual size by 20%

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -944,7 +944,7 @@ const dimIntensity = (value = 1) => value * LIGHT_INTENSITY_FACTOR;
 
 const MODEL_SCALE = 0.7;
 const CAMERA_LAYOUT_SCALE = MODEL_SCALE / 0.75;
-const DOMINO_AND_CHAIR_SHRINK_FACTOR = 0.765; // ~10% smaller than current arena sizing for dominoes/chairs
+const DOMINO_AND_CHAIR_SHRINK_FACTOR = 0.612; // additional 20% shrink from current size for dominoes/chairs
 const LEGACY_TABLE_SIZE_REDUCTION_FACTOR = 0.68;
 const TABLE_SHRINK_FACTOR = 0.8;
 const TABLE_AND_CHAIR_SHRINK_FACTOR = 0.765; // ~10% smaller than current arena furniture sizing


### PR DESCRIPTION
### Motivation
- Reduce the on-screen size of domino pieces and chairs in the Domino Battle Royal arena to apply a 20% smaller visual scale for improved proportions.

### Description
- Updated the shared scale constant `DOMINO_AND_CHAIR_SHRINK_FACTOR` from `0.765` to `0.612` in `webapp/public/domino-royal-game.js` so dominoes and chairs render 20% smaller while preserving existing layout logic.

### Testing
- Ran a syntax check with `node --check webapp/public/domino-royal-game.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db5bf711348329988f69c6cac7f990)