### PR TITLE
Lower Ludo table and nudge tokens/dice outward

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1218,7 +1218,7 @@ const ARENA_SCALE = 0.72 * LUDO_ARENA_SHRINK_FACTOR;
 const ARENA_SCALE_RATIO = ARENA_SCALE / BASE_ARENA_SCALE;
 const MODEL_SCALE = 0.75 * ARENA_SCALE;
 const TABLE_RADIUS = 3.48 * MODEL_SCALE;
-const TABLE_HEIGHT_SCALE = 0.85;
+const TABLE_HEIGHT_SCALE = 0.83;
 const BASE_TABLE_HEIGHT = 1.03 * MODEL_SCALE * TABLE_HEIGHT_SCALE;
 const TABLE_VISUAL_SCALE = 0.85;
 const TABLE_EDGE_INSET = TABLE_RADIUS * (1 - TABLE_VISUAL_SCALE);
@@ -1419,7 +1419,7 @@ function createAiUniqueLoadout(activePlayerCount) {
   return byPlayer;
 }
 const TABLE_MODEL_TARGET_HEIGHT = TABLE_HEIGHT;
-const TABLE_LEG_EXTENSION_FACTOR = 1.65;
+const TABLE_LEG_EXTENSION_FACTOR = 1.58;
 const BASIS_TRANSCODER_PATH = 'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/';
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
 const PREFERRED_TEXTURE_SIZES = ['4k', '2k', '1k'];
@@ -2801,17 +2801,17 @@ const RAIL_TOKEN_SIDE_SPACING = 0.06;
 const TOKEN_HOME_HEIGHT_OFFSETS = Object.freeze([0, 0.0035, 0.0035, 0.0035]);
 const TOKEN_RAIL_BASE_FORWARD_SHIFT = Object.freeze([0.012, 0, 0, 0]);
 const TOKEN_RAIL_SIDE_MULTIPLIER = Object.freeze([1.12, 1.12, 1.12, 1.12]);
-const TOKEN_RAIL_CENTER_PULL_DEFAULT = 0.094;
+const TOKEN_RAIL_CENTER_PULL_DEFAULT = 0.088;
 const TOKEN_RAIL_CENTER_PULL_PER_PLAYER = Object.freeze([
-  0.116,
   0.11,
-  0.116,
-  0.11
+  0.104,
+  0.11,
+  0.104
 ]);
 const TOKEN_RAIL_HEIGHT_LIFT = 0;
 const NON_OCTAGON_TOKEN_SURFACE_OFFSET = -0.0075;
 let tokenSurfaceOffset = 0;
-const TOKEN_FRONT_OUTWARD_SHIFT = 0.038;
+const TOKEN_FRONT_OUTWARD_SHIFT = 0.046;
 const TOKEN_MOVE_SPEED = 2.45;
 const TOKEN_STEP_DURATION_SECONDS = 0.34;
 const LUDO_CAPTURE_MISSILE_LAUNCH_SOUND_URL = '/assets/sounds/launch-85216.mp3';


### PR DESCRIPTION
### Motivation
- Make the Ludo arena feel slightly lower by trimming the table underside so the board sits a bit lower on screen while keeping the camera unchanged.
- Move player tokens/dice/rails slightly farther outward from the table center so tokens appear more away from the center and align with the new table height.

### Description
- Reduced the table profile by changing `TABLE_HEIGHT_SCALE` from `0.85` to `0.83` so the whole table/board setup sits lower in world space.
- Shortened the underside/bottom trim by lowering `TABLE_LEG_EXTENSION_FACTOR` from `1.65` to `1.58` to reduce leg stretch below the table top.
- Pushed token rails outward by decreasing `TOKEN_RAIL_CENTER_PULL_DEFAULT` from `0.094` to `0.088` and adjusting `TOKEN_RAIL_CENTER_PULL_PER_PLAYER` to `[0.11, 0.104, 0.11, 0.104]` so each player rail sits a bit more outward.
- Increased `TOKEN_FRONT_OUTWARD_SHIFT` from `0.038` to `0.046` so tokens are shifted slightly farther forward/outward; board, tokens and dice use existing table-height placement logic and will follow the new surface values.
- Camera code/logic was not modified so existing camera framing and behavior remain unchanged.

### Testing
- Ran lint on the changed file with `npm run lint -- webapp/src/pages/Games/LudoBattleRoyal.jsx`, which completed with no ESLint errors (only a tooling warning about React version detection).
- No automated visual tests were available in this environment, so visual verification should be performed on a device (portrait mobile) to confirm token spacing and table height appear as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db5dad88d08329b977bb2de94477a6)