### PR TITLE
Fix helicopter FX: restore textures, spin top rotor(s), and use CC0 helicopter SFX

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -1042,7 +1042,8 @@ const CHECKMATE_SOUND_URL =
   'https://raw.githubusercontent.com/lichess-org/lila/master/public/sound/standard/End.mp3';
 const LAUGH_SOUND_URL = '/assets/sounds/Haha.mp3';
 const DRONE_FLY_SOUND_URL = '/assets/sounds/spinning.mp3';
-const HELICOPTER_FLY_SOUND_URL = 'https://assets.mixkit.co/active_storage/sfx/209/209-preview.mp3';
+// OpenGameArt "Helicopter SFX" (CC0): https://opengameart.org/content/helicopter-sfx
+const HELICOPTER_FLY_SOUND_URL = 'https://opengameart.org/sites/default/files/heli.ogg';
 const JET_FLY_SOUND_URL = '/assets/sounds/race-care-151963.mp3';
 const BAZOOKA_FIRE_SOUND_URL = '/assets/sounds/launch-85216.mp3';
 const MISSILE_IMPACT_SOUND_URL = '/assets/sounds/080998_bullet-hit-39870.mp3';
@@ -2868,13 +2869,49 @@ function normalizeModel(object, targetSize) {
   object.position.y -= normalized.min.y;
 }
 
-function prepareCaptureModel(root) {
+function findCaptureRotors(model, role = 'main', limit = 4) {
+  if (!model) return [];
+  const modelBounds = new THREE.Box3().setFromObject(model);
+  const modelSize = new THREE.Vector3();
+  modelBounds.getSize(modelSize);
+  const maxModelDim = Math.max(modelSize.x, modelSize.y, modelSize.z) || 1;
+  const roleMatchers =
+    role === 'tail'
+      ? [/tail/i, /back/i, /rear/i]
+      : [/main/i, /top/i, /upper/i];
+  const scored = [];
+  model.traverse((node) => {
+    if (!node || node === model) return;
+    const name = `${node.name || ''}`.toLowerCase();
+    if (!/rotor|propell|blade|fan/.test(name)) return;
+    const bounds = new THREE.Box3().setFromObject(node);
+    const size = new THREE.Vector3();
+    bounds.getSize(size);
+    const maxDim = Math.max(size.x, size.y, size.z) || 0;
+    const minDim = Math.min(size.x || 0, size.y || 0, size.z || 0);
+    if (!Number.isFinite(maxDim) || maxDim <= 0 || maxDim > maxModelDim * 0.45) return;
+    if (!Number.isFinite(minDim) || minDim > maxModelDim * 0.18) return;
+    const roleMatch = roleMatchers.some((matcher) => matcher.test(name));
+    const spanBias = maxDim / Math.max(minDim, 1e-3);
+    const sizeBias = role === 'main' ? maxDim * 0.35 : -maxDim;
+    const score = (roleMatch ? 3 : 0) + spanBias * 0.08 + sizeBias;
+    scored.push({ node, score });
+  });
+  scored.sort((a, b) => b.score - a.score);
+  return scored.slice(0, limit).map((item) => item.node);
+}
+
+function prepareCaptureModel(root, options = {}) {
+  const { fallbackTexture = null } = options;
   root.traverse((child) => {
     if (!child?.isMesh) return;
     child.castShadow = true;
     child.receiveShadow = true;
     const materials = Array.isArray(child.material) ? child.material : [child.material];
     materials.forEach((material) => {
+      if (fallbackTexture && !material?.map && !material?.emissiveMap) {
+        material.map = fallbackTexture;
+      }
       if (material?.map) applySRGBColorSpace(material.map);
       if (material?.emissiveMap) {
         applySRGBColorSpace(material.emissiveMap);
@@ -8054,7 +8091,9 @@ function Chess3D({
             });
             const model = (gltf.scene || gltf.scenes?.[0])?.clone?.(true);
             if (!model) continue;
-            prepareCaptureModel(model);
+            prepareCaptureModel(model, {
+              fallbackTexture: key === 'helicopter' ? fallbackTexture : null
+            });
             normalizeModel(model, targetSize);
             captureUnitTemplates[key] = model;
             return model;
@@ -8072,7 +8111,9 @@ function Chess3D({
       const template = captureUnitTemplates[key];
       if (!template) return null;
       const clone = cloneSkinned(template);
-      prepareCaptureModel(clone);
+      prepareCaptureModel(clone, {
+        fallbackTexture: key === 'helicopter' ? fallbackTexture : null
+      });
       return clone;
     };
 
@@ -8125,40 +8166,6 @@ function Chess3D({
       );
       mesh.castShadow = true;
       return mesh;
-    };
-    const findCaptureRotor = (model, role = 'main') => {
-      if (!model) return null;
-      const modelBounds = new THREE.Box3().setFromObject(model);
-      const modelSize = new THREE.Vector3();
-      modelBounds.getSize(modelSize);
-      const maxModelDim = Math.max(modelSize.x, modelSize.y, modelSize.z) || 1;
-      const roleMatchers =
-        role === 'tail'
-          ? [/tail/i, /back/i, /rear/i]
-          : [/main/i, /top/i, /upper/i];
-      let best = null;
-      let bestScore = Number.NEGATIVE_INFINITY;
-      model.traverse((node) => {
-        if (!node || node === model) return;
-        const name = `${node.name || ''}`.toLowerCase();
-        if (!/rotor|propell|blade|fan/.test(name)) return;
-        const bounds = new THREE.Box3().setFromObject(node);
-        const size = new THREE.Vector3();
-        bounds.getSize(size);
-        const maxDim = Math.max(size.x, size.y, size.z) || 0;
-        const minDim = Math.min(size.x || 0, size.y || 0, size.z || 0);
-        if (!Number.isFinite(maxDim) || maxDim <= 0 || maxDim > maxModelDim * 0.45) return;
-        if (!Number.isFinite(minDim) || minDim > maxModelDim * 0.18) return;
-        const roleMatch = roleMatchers.some((matcher) => matcher.test(name));
-        const spanBias = maxDim / Math.max(minDim, 1e-3);
-        const sizeBias = role === 'main' ? maxDim * 0.35 : -maxDim;
-        const score = (roleMatch ? 3 : 0) + spanBias * 0.08 + sizeBias;
-        if (score > bestScore) {
-          bestScore = score;
-          best = node;
-        }
-      });
-      return best;
     };
     const findJetExhaustAnchor = (model) => {
       if (!model) return new THREE.Vector3(-1.9, 0, 0);
@@ -8286,13 +8293,12 @@ function Chess3D({
       if (model) {
         const root = new THREE.Group();
         root.add(model);
-        let topRotor = findCaptureRotor(model, 'main');
-        const tailRotor = findCaptureRotor(model, 'tail');
-        if (!topRotor) {
-          const topFallback = findCaptureRotor(model, 'tail');
-          topRotor = topFallback && topFallback !== tailRotor ? topFallback : null;
+        let topRotors = findCaptureRotors(model, 'main', 6);
+        const [tailRotor] = findCaptureRotors(model, 'tail', 1);
+        if (!topRotors.length) {
+          topRotors = findCaptureRotors(model, 'tail', 6).filter((rotor) => rotor !== tailRotor);
         }
-        return { root, topRotor, tailRotor, exhaustClouds: [] };
+        return { root, topRotors, tailRotor, exhaustClouds: [] };
       }
       const root = new THREE.Group();
       addFxCylinder(root, 0.2, 0.24, 2.5, [0.05, 0, 0], [0, 0, Math.PI / 2], '#96a0a8', 20);
@@ -8320,7 +8326,7 @@ function Chess3D({
           addFxSphere(root, 0.1 + i * 0.024, [-1.05 - i * 0.18, 0, 0], '#8b949b', 1, 0, true, 0.26 - i * 0.03)
         );
       }
-      return { root, topRotor, tailRotor, exhaustClouds };
+      return { root, topRotors: [topRotor], tailRotor, exhaustClouds };
     };
     const createFxJet = () => {
       const model = cloneCaptureUnitTemplate('fighter');
@@ -10487,7 +10493,9 @@ function Chess3D({
             captureDir.copy(heliNext).sub(heliPos).normalize();
             const heliForward = captureDir.clone();
             fx.helicopterFx.root.quaternion.setFromUnitVectors(FORWARD, captureDir);
-            fx.helicopterFx.topRotor?.rotateY(dt * 26);
+            fx.helicopterFx.topRotors?.forEach((rotor) => {
+              rotor?.rotateY(dt * 26);
+            });
             fx.helicopterFx.tailRotor?.rotateX(dt * 35);
             fx.helicopterFx.exhaustClouds?.forEach((puff, idx) => {
               puff.position.set(-1 - idx * 0.2, Math.sin(fx.t * 6.2 + idx * 0.4) * 0.03, 0);


### PR DESCRIPTION
### Motivation
- The helicopter capture FX sometimes appeared without visible top rotor or with missing textures and used a non-open SFX URL, so the visuals and audio needed to be made reliable and license-safe. 

### Description
- Replaced the helicopter sound URL with a CC0 OpenGameArt source and added an inline license reference (`HELICOPTER_FLY_SOUND_URL`).
- Added `findCaptureRotors` to detect multiple candidate top-rotor nodes in GLTFs so blades split across meshes are found and animated.
- Updated `prepareCaptureModel` to accept an `options` object and a `fallbackTexture` so original model maps are preserved and a fallback is only applied when a mesh lacks maps.
- Wired the fallback texture into capture-model loading and cloning for the helicopter only, and changed the helicopter FX to rotate all detected top rotors each frame while preserving the tail rotor animation.

### Testing
- Ran the production build with `npm --prefix webapp run build`, which completed successfully (build artifacts produced).
- No unit tests were added or changed; build reported pre-existing Vite chunking warnings that are unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db5f298a5083298e68507c95d97143)