### PR TITLE
Adjust Ludo table height and token sizing/rail spacing

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1218,7 +1218,7 @@ const ARENA_SCALE = 0.72 * LUDO_ARENA_SHRINK_FACTOR;
 const ARENA_SCALE_RATIO = ARENA_SCALE / BASE_ARENA_SCALE;
 const MODEL_SCALE = 0.75 * ARENA_SCALE;
 const TABLE_RADIUS = 3.48 * MODEL_SCALE;
-const TABLE_HEIGHT_SCALE = 0.76;
+const TABLE_HEIGHT_SCALE = 0.72;
 const BASE_TABLE_HEIGHT = 1.03 * MODEL_SCALE * TABLE_HEIGHT_SCALE;
 const TABLE_VISUAL_SCALE = 0.85;
 const TABLE_EDGE_INSET = TABLE_RADIUS * (1 - TABLE_VISUAL_SCALE);
@@ -1419,7 +1419,7 @@ function createAiUniqueLoadout(activePlayerCount) {
   return byPlayer;
 }
 const TABLE_MODEL_TARGET_HEIGHT = TABLE_HEIGHT;
-const TABLE_LEG_EXTENSION_FACTOR = 1.58;
+const TABLE_LEG_EXTENSION_FACTOR = 1.46;
 const BASIS_TRANSCODER_PATH = 'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/';
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
 const PREFERRED_TEXTURE_SIZES = ['4k', '2k', '1k'];
@@ -2811,7 +2811,7 @@ const TOKEN_RAIL_CENTER_PULL_PER_PLAYER = Object.freeze([
 const TOKEN_RAIL_HEIGHT_LIFT = 0;
 const NON_OCTAGON_TOKEN_SURFACE_OFFSET = -0.0075;
 let tokenSurfaceOffset = 0;
-const TOKEN_FRONT_OUTWARD_SHIFT = 0.046;
+const TOKEN_FRONT_OUTWARD_SHIFT = 0.058;
 const TOKEN_MOVE_SPEED = 2.45;
 const TOKEN_STEP_DURATION_SECONDS = 0.34;
 const LUDO_CAPTURE_MISSILE_LAUNCH_SOUND_URL = '/assets/sounds/launch-85216.mp3';
@@ -3574,17 +3574,17 @@ const easeOutCubic = (t) => 1 - Math.pow(1 - t, 3);
 
 const TOKEN_SELECTION_SCALE = 1.08;
 const TOKEN_SIZE_MULTIPLIER = 1.4;
-const TOKEN_RAIL_OUTWARD_PUSH = 0.065;
+const TOKEN_RAIL_OUTWARD_PUSH = 0.082;
 const CAMERA_TURN_VIEW_DURATION_MS = 520;
 const CAMERA_BROADCAST_ANIMATION_MS = 560;
 const CAMERA_RETURN_ANIMATION_MS = 620;
 const TOKEN_TYPE_SCALE_PROFILE = Object.freeze({
-  pawn: { x: 0.752, y: 0.656, z: 0.72 },
+  pawn: { x: 0.602, y: 0.525, z: 0.576 },
   knight: { x: 0.94, y: 0.94, z: 0.9 },
   rook: { x: 0.94, y: 0.94, z: 0.9 },
-  bishop: { x: 1.222, y: 1.508, z: 1.17 },
-  queen: { x: 1.222, y: 1.586, z: 1.17 },
-  king: { x: 1.222, y: 1.664, z: 1.17 }
+  bishop: { x: 1.589, y: 1.96, z: 1.521 },
+  queen: { x: 1.589, y: 2.062, z: 1.521 },
+  king: { x: 1.589, y: 2.163, z: 1.521 }
 });
 
 function setTokenHighlight(token, active) {


### PR DESCRIPTION
### Motivation

- Make player tokens sit slightly farther from the table edge and rails to match visual layout adjustments.
- Resize specific token pieces so the king/queen/bishop appear ~30% larger and pawns ~20% smaller for clearer visual hierarchy.
- Shorten the table (trim legs) so the board, tokens and dice align with a lower table while preserving the existing camera framing.

### Description

- Updated Ludo arena/table constants in `webapp/src/pages/Games/LudoBattleRoyal.jsx` to lower overall table height by changing `TABLE_HEIGHT_SCALE` from `0.76` to `0.72` and reduce `TABLE_LEG_EXTENSION_FACTOR` from `1.58` to `1.46` so models sit shorter in-world.
- Increased outward placement of rail/home anchors by bumping `TOKEN_FRONT_OUTWARD_SHIFT` from `0.046` to `0.058` and `TOKEN_RAIL_OUTWARD_PUSH` from `0.065` to `0.082` so tokens are pushed slightly farther from the table edge.
- Adjusted `TOKEN_TYPE_SCALE_PROFILE` to make `bishop`, `queen`, and `king` larger and `pawn` smaller (values updated to match ~+30% for bishop/queen/king and ~-20% for pawn).
- Changes are confined to the Ludo arena rendering constants and should automatically affect board, token and dice placement without modifying camera code.

### Testing

- Ran `npm --prefix webapp run -s build` and the production build completed successfully (build artifacts produced).
- Ran `npm --prefix webapp run -s lint` which exited non-zero (lint failed) in this environment and should be checked/fixed if necessary before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db63f689f48329aa8e36f9ff7560d5)