### PR TITLE
Improve helicopter capture FX: rotor detection, spin axis, sound fallbacks, and asset loading fixes

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -101,7 +101,7 @@ const PROFILE_VIEW_ROTATION_TYPES = new Set(['K', 'N']);
 const PROFILE_VIEW_ROTATION_RADIANS = Math.PI / 2;
 const CAPTURE_JET_TOTAL = CAPTURE_DRONE_TOTAL * CAPTURE_JET_SPEED_FACTOR;
 const CAPTURE_JET_MISSILE_TRAVEL = 1.06 * CAPTURE_JET_SPEED_FACTOR;
-const CAPTURE_HELICOPTER_SPEED_FACTOR = 1.56; // slower helicopter pass so propeller motion reads clearly
+const CAPTURE_HELICOPTER_SPEED_FACTOR = 1.74; // slower helicopter pass so propeller motion reads clearly
 const CAPTURE_HELICOPTER_TOTAL = CAPTURE_JET_TOTAL * CAPTURE_HELICOPTER_SPEED_FACTOR;
 const CAPTURE_HELICOPTER_MISSILE_TRAVEL = CAPTURE_JET_MISSILE_TRAVEL * CAPTURE_HELICOPTER_SPEED_FACTOR;
 const CAPTURE_JET_MISSILE_RELEASE_RATIO = 0.58;
@@ -130,8 +130,8 @@ const CAPTURE_MODEL_URLS = Object.freeze({
     'https://cdn.statically.io/gh/srcejon/sdrangel-3d-models/main/drone.glb'
   ],
   helicopter: [
-    'https://cdn.jsdelivr.net/gh/srcejon/sdrangel-3d-models@main/helicopter.glb',
     'https://raw.githubusercontent.com/srcejon/sdrangel-3d-models/main/helicopter.glb',
+    'https://cdn.jsdelivr.net/gh/srcejon/sdrangel-3d-models@main/helicopter.glb',
     'https://cdn.statically.io/gh/srcejon/sdrangel-3d-models/main/helicopter.glb'
   ],
   fighter: [
@@ -1042,7 +1042,11 @@ const CHECKMATE_SOUND_URL =
   'https://raw.githubusercontent.com/lichess-org/lila/master/public/sound/standard/End.mp3';
 const LAUGH_SOUND_URL = '/assets/sounds/Haha.mp3';
 const DRONE_FLY_SOUND_URL = '/assets/sounds/spinning.mp3';
-const HELICOPTER_FLY_SOUND_URL = 'https://assets.mixkit.co/active_storage/sfx/209/209-preview.mp3';
+// Keep MP3 first for mobile browser compatibility, with CC0 fallback.
+const HELICOPTER_FLY_SOUND_URLS = [
+  '/assets/sounds/spinning.mp3',
+  'https://opengameart.org/sites/default/files/heli.ogg'
+];
 const JET_FLY_SOUND_URL = '/assets/sounds/race-care-151963.mp3';
 const BAZOOKA_FIRE_SOUND_URL = '/assets/sounds/launch-85216.mp3';
 const MISSILE_IMPACT_SOUND_URL = '/assets/sounds/080998_bullet-hit-39870.mp3';
@@ -2866,6 +2870,84 @@ function normalizeModel(object, targetSize) {
   object.position.x -= center.x;
   object.position.z -= center.z;
   object.position.y -= normalized.min.y;
+}
+
+function findCaptureRotors(model, role = 'main', limit = 4) {
+  if (!model) return [];
+  const modelBounds = new THREE.Box3().setFromObject(model);
+  const modelSize = new THREE.Vector3();
+  modelBounds.getSize(modelSize);
+  const maxModelDim = Math.max(modelSize.x, modelSize.y, modelSize.z) || 1;
+  const roleMatchers =
+    role === 'tail'
+      ? [/tail/i, /back/i, /rear/i]
+      : [/main/i, /top/i, /upper/i];
+  const scored = [];
+  model.traverse((node) => {
+    if (!node || node === model) return;
+    const name = `${node.name || ''}`.toLowerCase();
+    if (!/rotor|propell|blade|fan/.test(name)) return;
+    const bounds = new THREE.Box3().setFromObject(node);
+    const size = new THREE.Vector3();
+    bounds.getSize(size);
+    const maxDim = Math.max(size.x, size.y, size.z) || 0;
+    const minDim = Math.min(size.x || 0, size.y || 0, size.z || 0);
+    if (!Number.isFinite(maxDim) || maxDim <= 0 || maxDim > maxModelDim * 0.45) return;
+    if (!Number.isFinite(minDim) || minDim > maxModelDim * 0.18) return;
+    const roleMatch = roleMatchers.some((matcher) => matcher.test(name));
+    const spanBias = maxDim / Math.max(minDim, 1e-3);
+    const sizeBias = role === 'main' ? maxDim * 0.35 : -maxDim;
+    const score = (roleMatch ? 3 : 0) + spanBias * 0.08 + sizeBias;
+    scored.push({ node, score });
+  });
+  scored.sort((a, b) => b.score - a.score);
+  return scored.slice(0, limit).map((item) => item.node);
+}
+
+function inferRotorSpinAxis(rotor) {
+  if (!rotor) return new THREE.Vector3(0, 1, 0);
+  const rotorWorldQ = new THREE.Quaternion();
+  rotor.getWorldQuaternion(rotorWorldQ);
+  const rotorWorldQInv = rotorWorldQ.clone().invert();
+  let bestAxis = null;
+  let bestArea = 0;
+  rotor.traverse((node) => {
+    if (!node?.isMesh || !node.geometry) return;
+    const geometry = node.geometry;
+    if (!geometry.boundingBox) geometry.computeBoundingBox();
+    const box = geometry.boundingBox;
+    if (!box) return;
+    const size = new THREE.Vector3();
+    box.getSize(size);
+    if (!Number.isFinite(size.x + size.y + size.z)) return;
+    const dims = [Math.abs(size.x), Math.abs(size.y), Math.abs(size.z)];
+    const minDim = Math.min(...dims);
+    const maxDim = Math.max(...dims);
+    if (maxDim <= 1e-5 || minDim > maxDim * 0.38) return;
+    const area = dims[0] * dims[1] * dims[2];
+    const minIndex = dims.indexOf(minDim);
+    const axisLocal =
+      minIndex === 0
+        ? new THREE.Vector3(1, 0, 0)
+        : minIndex === 1
+          ? new THREE.Vector3(0, 1, 0)
+          : new THREE.Vector3(0, 0, 1);
+    const meshWorldQ = new THREE.Quaternion();
+    node.getWorldQuaternion(meshWorldQ);
+    const axisInRotor = axisLocal
+      .clone()
+      .applyQuaternion(meshWorldQ)
+      .applyQuaternion(rotorWorldQInv)
+      .normalize();
+    if (area > bestArea) {
+      bestArea = area;
+      bestAxis = axisInRotor;
+    }
+  });
+  if (!bestAxis || !Number.isFinite(bestAxis.lengthSq()) || bestAxis.lengthSq() < 1e-4) {
+    return new THREE.Vector3(0, 1, 0);
+  }
+  return bestAxis;
 }
 
 function prepareCaptureModel(root) {
@@ -7064,7 +7146,9 @@ function Chess3D({
     }
     [swordSoundRef, droneSoundRef, helicopterSoundRef, missileLaunchSoundRef, missileImpactSoundRef].forEach((ref) => {
       if (!ref.current) return;
-      ref.current.volume = effectiveSoundEnabled ? volume : 0;
+      const targetVolume =
+        ref === helicopterSoundRef ? Math.min(1, volume * 1.18) : volume;
+      ref.current.volume = effectiveSoundEnabled ? targetVolume : 0;
       if (!effectiveSoundEnabled) {
         try {
           ref.current.pause();
@@ -7101,7 +7185,9 @@ function Chess3D({
       }
       [swordSoundRef, droneSoundRef, helicopterSoundRef, missileLaunchSoundRef, missileImpactSoundRef].forEach((ref) => {
         if (!ref.current) return;
-        ref.current.volume = settingsRef.current.soundEnabled ? volume : 0;
+        const targetVolume =
+          ref === helicopterSoundRef ? Math.min(1, volume * 1.18) : volume;
+        ref.current.volume = settingsRef.current.soundEnabled ? targetVolume : 0;
       });
     };
     window.addEventListener('gameVolumeChanged', handleVolumeChange);
@@ -7421,8 +7507,17 @@ function Chess3D({
     swordSoundRef.current.volume = baseVolume;
     droneSoundRef.current = new Audio(DRONE_FLY_SOUND_URL);
     droneSoundRef.current.volume = baseVolume;
-    helicopterSoundRef.current = new Audio(HELICOPTER_FLY_SOUND_URL);
-    helicopterSoundRef.current.volume = baseVolume;
+    const helicopterSoundUrl =
+      HELICOPTER_FLY_SOUND_URLS.find((url) => {
+        const ext = url.split('.').pop()?.toLowerCase();
+        if (!ext) return true;
+        const probe = new Audio();
+        return probe.canPlayType?.(`audio/${ext}`) !== '';
+      }) || HELICOPTER_FLY_SOUND_URLS[0];
+    helicopterSoundRef.current = new Audio(helicopterSoundUrl);
+    helicopterSoundRef.current.preload = 'auto';
+    helicopterSoundRef.current.loop = true;
+    helicopterSoundRef.current.volume = Math.min(1, baseVolume * 1.18);
     missileLaunchSoundRef.current = new Audio(BAZOOKA_FIRE_SOUND_URL);
     missileLaunchSoundRef.current.volume = baseVolume;
     missileImpactSoundRef.current = new Audio(MISSILE_IMPACT_SOUND_URL);
@@ -8048,6 +8143,12 @@ function Chess3D({
             const resourcePath = resolvedUrl.substring(0, resolvedUrl.lastIndexOf('/') + 1);
             loader.setResourcePath(resourcePath);
             loader.setPath('');
+            loader.manager.setURLModifier((assetUrl) => {
+              if (!assetUrl) return assetUrl;
+              if (/^(data:|blob:|https?:\/\/)/i.test(assetUrl)) return assetUrl;
+              const cleaned = assetUrl.replace(/^\.?\//, '');
+              return `${resourcePath}${cleaned}`;
+            });
             // eslint-disable-next-line no-await-in-loop
             const gltf = await new Promise((resolve, reject) => {
               loader.load(resolvedUrl, resolve, undefined, reject);
@@ -8125,40 +8226,6 @@ function Chess3D({
       );
       mesh.castShadow = true;
       return mesh;
-    };
-    const findCaptureRotor = (model, role = 'main') => {
-      if (!model) return null;
-      const modelBounds = new THREE.Box3().setFromObject(model);
-      const modelSize = new THREE.Vector3();
-      modelBounds.getSize(modelSize);
-      const maxModelDim = Math.max(modelSize.x, modelSize.y, modelSize.z) || 1;
-      const roleMatchers =
-        role === 'tail'
-          ? [/tail/i, /back/i, /rear/i]
-          : [/main/i, /top/i, /upper/i];
-      let best = null;
-      let bestScore = Number.NEGATIVE_INFINITY;
-      model.traverse((node) => {
-        if (!node || node === model) return;
-        const name = `${node.name || ''}`.toLowerCase();
-        if (!/rotor|propell|blade|fan/.test(name)) return;
-        const bounds = new THREE.Box3().setFromObject(node);
-        const size = new THREE.Vector3();
-        bounds.getSize(size);
-        const maxDim = Math.max(size.x, size.y, size.z) || 0;
-        const minDim = Math.min(size.x || 0, size.y || 0, size.z || 0);
-        if (!Number.isFinite(maxDim) || maxDim <= 0 || maxDim > maxModelDim * 0.45) return;
-        if (!Number.isFinite(minDim) || minDim > maxModelDim * 0.18) return;
-        const roleMatch = roleMatchers.some((matcher) => matcher.test(name));
-        const spanBias = maxDim / Math.max(minDim, 1e-3);
-        const sizeBias = role === 'main' ? maxDim * 0.35 : -maxDim;
-        const score = (roleMatch ? 3 : 0) + spanBias * 0.08 + sizeBias;
-        if (score > bestScore) {
-          bestScore = score;
-          best = node;
-        }
-      });
-      return best;
     };
     const findJetExhaustAnchor = (model) => {
       if (!model) return new THREE.Vector3(-1.9, 0, 0);
@@ -8286,13 +8353,24 @@ function Chess3D({
       if (model) {
         const root = new THREE.Group();
         root.add(model);
-        let topRotor = findCaptureRotor(model, 'main');
-        const tailRotor = findCaptureRotor(model, 'tail');
-        if (!topRotor) {
-          const topFallback = findCaptureRotor(model, 'tail');
-          topRotor = topFallback && topFallback !== tailRotor ? topFallback : null;
+        let topRotors = findCaptureRotors(model, 'main', 6);
+        const [tailRotor] = findCaptureRotors(model, 'tail', 1);
+        if (!topRotors.length) {
+          topRotors = findCaptureRotors(model, 'tail', 6).filter((rotor) => rotor !== tailRotor);
         }
-        return { root, topRotor, tailRotor, exhaustClouds: [] };
+        topRotors.forEach((rotor) => {
+          rotor.userData = {
+            ...(rotor.userData || {}),
+            spinAxis: inferRotorSpinAxis(rotor)
+          };
+        });
+        if (tailRotor) {
+          tailRotor.userData = {
+            ...(tailRotor.userData || {}),
+            spinAxis: inferRotorSpinAxis(tailRotor)
+          };
+        }
+        return { root, topRotors, tailRotor, exhaustClouds: [] };
       }
       const root = new THREE.Group();
       addFxCylinder(root, 0.2, 0.24, 2.5, [0.05, 0, 0], [0, 0, Math.PI / 2], '#96a0a8', 20);
@@ -8314,13 +8392,15 @@ function Chess3D({
       addFxBox(tailRotor, [0.03, 0.38, 0.03], [0, 0, 0], '#21272d', 0.55, 0.08);
       addFxBox(tailRotor, [0.03, 0.03, 0.38], [0, 0, 0], '#21272d', 0.55, 0.08);
       root.add(tailRotor);
+      topRotor.userData = { ...(topRotor.userData || {}), spinAxis: new THREE.Vector3(0, 1, 0) };
+      tailRotor.userData = { ...(tailRotor.userData || {}), spinAxis: new THREE.Vector3(1, 0, 0) };
       const exhaustClouds = [];
       for (let i = 0; i < 6; i += 1) {
         exhaustClouds.push(
           addFxSphere(root, 0.1 + i * 0.024, [-1.05 - i * 0.18, 0, 0], '#8b949b', 1, 0, true, 0.26 - i * 0.03)
         );
       }
-      return { root, topRotor, tailRotor, exhaustClouds };
+      return { root, topRotors: [topRotor], tailRotor, exhaustClouds };
     };
     const createFxJet = () => {
       const model = cloneCaptureUnitTemplate('fighter');
@@ -8636,8 +8716,9 @@ function Chess3D({
         const entryClamp = half - tile * 0.12;
         const attackAltitude = CAPTURE_JET_ALTITUDE - 0.1;
         const sideLane = attackFromRightSide ? borderOffset : -borderOffset;
+        const heliStartLane = sideLane - Math.sign(sideLane || 1) * tile * 0.58;
         const heliStart = new THREE.Vector3(
-          sideLane,
+          heliStartLane,
           CAPTURE_JET_ALTITUDE,
           THREE.MathUtils.clamp((fromPos.z + targetPos.z) * 0.5, -entryClamp, entryClamp)
         );
@@ -10487,8 +10568,14 @@ function Chess3D({
             captureDir.copy(heliNext).sub(heliPos).normalize();
             const heliForward = captureDir.clone();
             fx.helicopterFx.root.quaternion.setFromUnitVectors(FORWARD, captureDir);
-            fx.helicopterFx.topRotor?.rotateY(dt * 26);
-            fx.helicopterFx.tailRotor?.rotateX(dt * 35);
+            fx.helicopterFx.topRotors?.forEach((rotor) => {
+              const spinAxis = rotor?.userData?.spinAxis || new THREE.Vector3(0, 1, 0);
+              rotor?.rotateOnAxis(spinAxis, dt * 30);
+            });
+            {
+              const tailSpinAxis = fx.helicopterFx.tailRotor?.userData?.spinAxis || new THREE.Vector3(1, 0, 0);
+              fx.helicopterFx.tailRotor?.rotateOnAxis(tailSpinAxis, dt * 36);
+            }
             fx.helicopterFx.exhaustClouds?.forEach((puff, idx) => {
               puff.position.set(-1 - idx * 0.2, Math.sin(fx.t * 6.2 + idx * 0.4) * 0.03, 0);
             });


### PR DESCRIPTION
### Motivation
- Make helicopter capture effects more visually correct by detecting multiple rotors and inferring proper spin axes instead of assuming fixed child names. 
- Improve helicopter audio compatibility across browsers by providing MP3-first fallbacks and selecting playable formats at runtime. 
- Fix model asset loading for relative/embedded GLTF parts and tweak helicopter timing/scale for clearer motion. 

### Description
- Increased `CAPTURE_HELICOPTER_SPEED_FACTOR` to slow helicopter pass for clearer propeller motion. 
- Replaced single `findCaptureRotor` with `findCaptureRotors` and added `inferRotorSpinAxis` to detect multiple rotor nodes and compute per-rotor spin axes from mesh bounds. 
- Updated helicopter FX construction to attach `userData.spinAxis` to discovered rotors and to rotate rotors using `rotateOnAxis` with the inferred axes. 
- Added a selection array `HELICOPTER_FLY_SOUND_URLS` and runtime probe to pick the first playable URL, and made the helicopter audio loop, preload, and slightly louder by default. 
- Adjusted sound-volume logic so helicopter audio gets a modest boost (`* 1.18`) in volume handling hooks. 
- Added a `loader.manager.setURLModifier` in `loadCaptureUnitTemplate` to resolve relative asset URLs against the model resource path. 
- Minor path/position tweak (`heliStartLane`) to make helicopter entry positioning more robust. 

### Testing
- Built the webapp with `npm run build` to validate bundling and loader changes and the build completed successfully. 
- Ran the repository test suite with `npm test` (existing automated tests) and all tests passed. 
- Performed automated asset-loading checks by exercising the capture unit loader; GLTF assets loaded without unresolved relative-path errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db5f298a5083298e68507c95d97143)