### PR TITLE
Adjust Ludo Battle Royal token sizes and shorten table height

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1218,7 +1218,7 @@ const ARENA_SCALE = 0.72 * LUDO_ARENA_SHRINK_FACTOR;
 const ARENA_SCALE_RATIO = ARENA_SCALE / BASE_ARENA_SCALE;
 const MODEL_SCALE = 0.75 * ARENA_SCALE;
 const TABLE_RADIUS = 3.48 * MODEL_SCALE;
-const TABLE_HEIGHT_SCALE = 0.67;
+const TABLE_HEIGHT_SCALE = 0.64;
 const BASE_TABLE_HEIGHT = 1.03 * MODEL_SCALE * TABLE_HEIGHT_SCALE;
 const TABLE_VISUAL_SCALE = 0.85;
 const TABLE_EDGE_INSET = TABLE_RADIUS * (1 - TABLE_VISUAL_SCALE);
@@ -1240,7 +1240,7 @@ const HUMAN_SEAT_ROTATION_OFFSET = Math.PI / 8;
 const AI_CHAIR_GAP = CARD_W * 0.74;
 const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 1.1;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
-const TABLE_HEIGHT_LIFT = 0.025 * MODEL_SCALE;
+const TABLE_HEIGHT_LIFT = 0.015 * MODEL_SCALE;
 const TABLE_HEIGHT = STOOL_HEIGHT + TABLE_HEIGHT_LIFT;
 const CHAIR_OUTWARD_OFFSET = 0.23 * MODEL_SCALE;
 const CHAIR_INWARD_PULL = 0.1 * MODEL_SCALE;
@@ -1419,7 +1419,7 @@ function createAiUniqueLoadout(activePlayerCount) {
   return byPlayer;
 }
 const TABLE_MODEL_TARGET_HEIGHT = TABLE_HEIGHT;
-const TABLE_LEG_EXTENSION_FACTOR = 1.34;
+const TABLE_LEG_EXTENSION_FACTOR = 1.24;
 const BASIS_TRANSCODER_PATH = 'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/';
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
 const PREFERRED_TEXTURE_SIZES = ['4k', '2k', '1k'];
@@ -3574,17 +3574,17 @@ const easeOutCubic = (t) => 1 - Math.pow(1 - t, 3);
 
 const TOKEN_SELECTION_SCALE = 1.08;
 const TOKEN_SIZE_MULTIPLIER = 1.4;
-const TOKEN_RAIL_OUTWARD_PUSH = 0.105;
+const TOKEN_RAIL_OUTWARD_PUSH = 0.125;
 const CAMERA_TURN_VIEW_DURATION_MS = 520;
 const CAMERA_BROADCAST_ANIMATION_MS = 560;
 const CAMERA_RETURN_ANIMATION_MS = 620;
 const TOKEN_TYPE_SCALE_PROFILE = Object.freeze({
-  pawn: { x: 0.482, y: 0.42, z: 0.461 },
+  pawn: { x: 0.3856, y: 0.336, z: 0.3688 },
   knight: { x: 0.94, y: 0.94, z: 0.9 },
   rook: { x: 0.94, y: 0.94, z: 0.9 },
-  bishop: { x: 2.066, y: 2.548, z: 1.977 },
-  queen: { x: 2.066, y: 2.681, z: 1.977 },
-  king: { x: 2.066, y: 2.812, z: 1.977 }
+  bishop: { x: 2.6858, y: 3.3124, z: 2.5701 },
+  queen: { x: 2.6858, y: 3.4853, z: 2.5701 },
+  king: { x: 2.6858, y: 3.6556, z: 2.5701 }
 });
 
 function setTokenHighlight(token, active) {


### PR DESCRIPTION
### Motivation
- Make Ludo GLTF tokens and table match requested visual changes: push player tokens slightly farther out from the table edge, make king/queen/bishop larger and pawns smaller, and shorten the table/legs while keeping the camera unchanged.

### Description
- Updated constants in `webapp/src/pages/Games/LudoBattleRoyal.jsx` to lower the table and trim legs by changing `TABLE_HEIGHT_SCALE` (0.67 → 0.64), `TABLE_HEIGHT_LIFT` (0.025 → 0.015) and `TABLE_LEG_EXTENSION_FACTOR` (1.34 → 1.24).
- Increased token rail push via `TOKEN_RAIL_OUTWARD_PUSH` (0.105 → 0.125) so player tokens sit slightly farther outward from the table edge.
- Adjusted GLTF token scale profile in `TOKEN_TYPE_SCALE_PROFILE` so `pawn` is ~20% smaller and `bishop`, `queen`, `king` are ~30% larger (updated numeric XYZ scale entries).
- Changes keep camera constants and the existing surface-based alignment logic intact so board, tokens and dice remain positioned relative to the table surface without modifying camera behavior.

### Testing
- Ran the production build with `npm -C webapp run build` and the build completed successfully; Vite emitted non-blocking chunk/dynamic-import warnings only.
- Verified the app source bundle updated (`webapp/src/pages/Games/LudoBattleRoyal.jsx`) and no other functional tests failed during the build step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db6d835d008329915ef5752c15b112)