### PR TITLE
Adjust Domino Royale tile scale to be 15% smaller

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -6582,7 +6582,7 @@ const RAIL_TOP = CLOTH_TOP + 0.04 * MODEL_SCALE;
 
 const SCALE = MODEL_SCALE * 0.92;
 const DOMINO_SHRINK_FACTOR = 0.8;
-const DOMINO_EXTRA_SHRINK_FACTOR = 0.85; // 15% smaller dominoes
+const DOMINO_EXTRA_SHRINK_FACTOR = 0.7225; // 15% smaller than the previous in-game domino size (0.85 * 0.85)
 const DOMINO_SCALE =
   1.5 *
   1.26 *


### PR DESCRIPTION
### Motivation
- Reduce the rendered Domino Royale tile size by changing the extra shrink factor used in the domino scale math so dominoes appear 15% smaller.

### Description
- Updated `DOMINO_EXTRA_SHRINK_FACTOR` in `webapp/public/domino-royal-game.js` from `0.85` to `0.7225` and clarified the inline comment, which affects `DOMINO_SCALE` and downstream `DOMINO_WORLD_SCALE`, `DOMINO_WIDTH`, and `DOMINO_LENGTH` calculations while leaving table and chair scaling constants unchanged.

### Testing
- Ran `npm test -- --runInBand test/dominoRoyalHdriCatalog.test.js` and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db6ad6602c83298d57f6a213d1281d)