### PR TITLE
Tune Ludo Battle Royale token sizing, rail offsets, and table height

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1218,7 +1218,7 @@ const ARENA_SCALE = 0.72 * LUDO_ARENA_SHRINK_FACTOR;
 const ARENA_SCALE_RATIO = ARENA_SCALE / BASE_ARENA_SCALE;
 const MODEL_SCALE = 0.75 * ARENA_SCALE;
 const TABLE_RADIUS = 3.48 * MODEL_SCALE;
-const TABLE_HEIGHT_SCALE = 0.67;
+const TABLE_HEIGHT_SCALE = 0.62;
 const BASE_TABLE_HEIGHT = 1.03 * MODEL_SCALE * TABLE_HEIGHT_SCALE;
 const TABLE_VISUAL_SCALE = 0.85;
 const TABLE_EDGE_INSET = TABLE_RADIUS * (1 - TABLE_VISUAL_SCALE);
@@ -1419,7 +1419,7 @@ function createAiUniqueLoadout(activePlayerCount) {
   return byPlayer;
 }
 const TABLE_MODEL_TARGET_HEIGHT = TABLE_HEIGHT;
-const TABLE_LEG_EXTENSION_FACTOR = 1.34;
+const TABLE_LEG_EXTENSION_FACTOR = 1.22;
 const BASIS_TRANSCODER_PATH = 'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/';
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
 const PREFERRED_TEXTURE_SIZES = ['4k', '2k', '1k'];
@@ -2811,7 +2811,7 @@ const TOKEN_RAIL_CENTER_PULL_PER_PLAYER = Object.freeze([
 const TOKEN_RAIL_HEIGHT_LIFT = 0;
 const NON_OCTAGON_TOKEN_SURFACE_OFFSET = -0.0075;
 let tokenSurfaceOffset = 0;
-const TOKEN_FRONT_OUTWARD_SHIFT = 0.058;
+const TOKEN_FRONT_OUTWARD_SHIFT = 0.072;
 const TOKEN_MOVE_SPEED = 2.45;
 const TOKEN_STEP_DURATION_SECONDS = 0.34;
 const LUDO_CAPTURE_MISSILE_LAUNCH_SOUND_URL = '/assets/sounds/launch-85216.mp3';
@@ -3574,17 +3574,17 @@ const easeOutCubic = (t) => 1 - Math.pow(1 - t, 3);
 
 const TOKEN_SELECTION_SCALE = 1.08;
 const TOKEN_SIZE_MULTIPLIER = 1.4;
-const TOKEN_RAIL_OUTWARD_PUSH = 0.105;
+const TOKEN_RAIL_OUTWARD_PUSH = 0.125;
 const CAMERA_TURN_VIEW_DURATION_MS = 520;
 const CAMERA_BROADCAST_ANIMATION_MS = 560;
 const CAMERA_RETURN_ANIMATION_MS = 620;
 const TOKEN_TYPE_SCALE_PROFILE = Object.freeze({
-  pawn: { x: 0.482, y: 0.42, z: 0.461 },
+  pawn: { x: 0.386, y: 0.336, z: 0.369 },
   knight: { x: 0.94, y: 0.94, z: 0.9 },
   rook: { x: 0.94, y: 0.94, z: 0.9 },
-  bishop: { x: 2.066, y: 2.548, z: 1.977 },
-  queen: { x: 2.066, y: 2.681, z: 1.977 },
-  king: { x: 2.066, y: 2.812, z: 1.977 }
+  bishop: { x: 2.686, y: 3.312, z: 2.57 },
+  queen: { x: 2.686, y: 3.485, z: 2.57 },
+  king: { x: 2.686, y: 3.656, z: 2.57 }
 });
 
 function setTokenHighlight(token, active) {


### PR DESCRIPTION
### Motivation

- Improve play readability and visual balance by nudging player tokens slightly farther from the table edge, resizing GLTF token pieces to match requested proportions, and shortening the table so the board/pieces/dice align better with the new height while preserving the existing camera.

### Description

- Updated layout and sizing constants in `webapp/src/pages/Games/LudoBattleRoyal.jsx` to implement the visual changes requested: reduced `TABLE_HEIGHT_SCALE` from `0.67` to `0.62` and lowered `TABLE_LEG_EXTENSION_FACTOR` from `1.34` to `1.22` to shorten the table and trim legs.
- Increased token rail offsets by changing `TOKEN_FRONT_OUTWARD_SHIFT` from `0.058` to `0.072` and `TOKEN_RAIL_OUTWARD_PUSH` from `0.105` to `0.125` so player tokens sit slightly more outward from the table edge.
- Adjusted per-piece GLTF scale profile in `TOKEN_TYPE_SCALE_PROFILE` so `pawn` is ~20% smaller (`{ x:0.386, y:0.336, z:0.369 }`) and `bishop`, `queen`, and `king` are ~30% larger (updated scale values applied to those entries).

### Testing

- Built the webapp with `npm --prefix webapp run -s build` and the production build completed successfully (bundle generation succeeded, with informational warnings about dynamic import/chunking).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db6d835d008329915ef5752c15b112)