### PR TITLE
Tighten Domino Royal tile scale and spacing

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -6582,7 +6582,7 @@ const RAIL_TOP = CLOTH_TOP + 0.04 * MODEL_SCALE;
 
 const SCALE = MODEL_SCALE * 0.92;
 const DOMINO_SHRINK_FACTOR = 0.8;
-const DOMINO_EXTRA_SHRINK_FACTOR = 0.7225; // 15% smaller than the previous in-game domino size (0.85 * 0.85)
+const DOMINO_EXTRA_SHRINK_FACTOR = 0.66; // smaller dominoes for tighter mobile readability
 const DOMINO_SCALE =
   1.5 *
   1.26 *
@@ -6594,16 +6594,16 @@ const DOMINO_WORLD_SCALE = SCALE * DOMINO_SCALE;
 const DOMINO_WIDTH = DOMINO_WORLD_SCALE * 0.1;
 const DOMINO_LENGTH = DOMINO_WORLD_SCALE * (0.016 / 0.22) * 2;
 const DOUBLE_END_SHIFT = Math.max(0, (DOMINO_LENGTH - DOMINO_WIDTH) / 2);
-const DOMINO_CHAIN_GAP = DOMINO_LENGTH * 0.0025; // keep chain tiles touching without visible overlap
+const DOMINO_CHAIN_GAP = 0; // keep chain tiles touching edge-to-edge without overlap
 const DOMINO_HAND_GAP = DOMINO_WIDTH + DOMINO_CHAIN_GAP;
-const PLAYER_HAND_GAP_SCALE = 0.84;
+const PLAYER_HAND_GAP_SCALE = 0.72;
 const PLAYER_HAND_OUTWARD_OFFSET = DOMINO_WIDTH * 0.34;
 const PLAYER_HAND_VERTICAL_RAISE = DOMINO_WIDTH * 0.11;
 const HUMAN_HAND_OUTWARD_OFFSET = DOMINO_WIDTH * 3.2;
 const HUMAN_HAND_VERTICAL_OFFSET = DOMINO_WIDTH * 0.065;
 const HUMAN_BOTTOM_EXTRA_OUTWARD = DOMINO_WIDTH * 0.42;
 const HUMAN_BOTTOM_EXTRA_RAISE = DOMINO_WIDTH * 0.145;
-const HUMAN_BOTTOM_HAND_GAP_SCALE = 0.88;
+const HUMAN_BOTTOM_HAND_GAP_SCALE = 0.76;
 const TILE_UP_H = 0.2 * DOMINO_WORLD_SCALE * DOMINO_HEIGHT_ADJUST;
 const TILE_UP_HALF = TILE_UP_H / 2;
 const CHAIN_EDGE_PADDING = Math.max(0.18, DOMINO_LENGTH * 0.52);
@@ -8229,7 +8229,7 @@ function computeHandSlotPosition(
 
   const EDGE_SPAN = CLOTH_RADIUS - 0.28;
   const BASE_GAP = DOMINO_HAND_GAP;
-  const MIN_GAP = DOMINO_LENGTH * 0.95;
+  const MIN_GAP = DOMINO_LENGTH * 0.72;
   const MAX_SPAN = Math.max(0, EDGE_SPAN * 2 - DOMINO_LENGTH * 0.6);
 
   const gapBase =

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-04-12-domino-table-scale-20pct-v20';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-04-12-domino-spacing-tightness-v21';
 
 export default function DominoRoyalArena() {
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- Improve mobile/portrait readability by rendering domino tiles smaller and reducing gaps so player hands and table tiles appear closer together without overlapping.
- Ensure table chain tiles sit edge-to-edge (touching) while avoiding visible overlap for a tighter visual layout.

### Description
- Reduced the domino world scale by lowering `DOMINO_EXTRA_SHRINK_FACTOR` (smaller tiles) in `webapp/public/domino-royal-game.js`.
- Removed the extra chain gap by setting `DOMINO_CHAIN_GAP` to `0` so placed tiles touch edge-to-edge on the table in `webapp/public/domino-royal-game.js`.
- Tightened player hand spacing by decreasing `PLAYER_HAND_GAP_SCALE` and `HUMAN_BOTTOM_HAND_GAP_SCALE`, and lowered the enforced `MIN_GAP` used when computing hand slot positions, all in `webapp/public/domino-royal-game.js`.
- Bumped the in-page script version string to `2026-04-12-domino-spacing-tightness-v21` in `webapp/src/pages/Games/DominoRoyalArena.jsx` so clients will fetch the updated script.

### Testing
- Ran `npm run --prefix webapp build` and the production build completed successfully (Vite produced non-blocking bundle warnings about chunk sizes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db78e2fa7c8329b6fd32f019928c54)