### PR TITLE
Reduce domino size (DOMINO_EXTRA_SHRINK_FACTOR -> 0.64) and bump script version

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -6582,7 +6582,7 @@ const RAIL_TOP = CLOTH_TOP + 0.04 * MODEL_SCALE;
 
 const SCALE = MODEL_SCALE * 0.92;
 const DOMINO_SHRINK_FACTOR = 0.8;
-const DOMINO_EXTRA_SHRINK_FACTOR = 0.7225; // 15% smaller than the previous in-game domino size (0.85 * 0.85)
+const DOMINO_EXTRA_SHRINK_FACTOR = 0.64; // slightly smaller dominoes only
 const DOMINO_SCALE =
   1.5 *
   1.26 *

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-04-12-domino-table-scale-20pct-v20';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-04-12-domino-size-only-v22';
 
 export default function DominoRoyalArena() {
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- Reduce the in-game domino piece size slightly to improve visual fit and spacing without altering table scaling.

### Description
- Change `DOMINO_EXTRA_SHRINK_FACTOR` in `webapp/public/domino-royal-game.js` from `0.7225` to `0.64`, which adjusts the computed `DOMINO_SCALE` and all derived domino dimensions, and update `DOMINO_ROYAL_SCRIPT_VERSION` in `webapp/src/pages/Games/DominoRoyalArena.jsx` to `'2026-04-12-domino-size-only-v22'`.

### Testing
- Ran the automated test and build steps (`yarn test` and `yarn build`) and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db78e2fa7c8329b6fd32f019928c54)