### PR TITLE
Lower Ludo table, normalize token sizes, push tokens outward, and use Chess helicopter SFX

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1240,7 +1240,7 @@ const HUMAN_SEAT_ROTATION_OFFSET = Math.PI / 8;
 const AI_CHAIR_GAP = CARD_W * 0.74;
 const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 1.1;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
-const TABLE_VERTICAL_LOWERING = 0.09 * MODEL_SCALE;
+const TABLE_VERTICAL_LOWERING = 0.145 * MODEL_SCALE;
 const TABLE_HEIGHT_LIFT = 0.025 * MODEL_SCALE - TABLE_VERTICAL_LOWERING;
 const TABLE_HEIGHT = STOOL_HEIGHT + TABLE_HEIGHT_LIFT;
 const CHAIR_OUTWARD_OFFSET = 0.23 * MODEL_SCALE;
@@ -2812,14 +2812,14 @@ const TOKEN_RAIL_CENTER_PULL_PER_PLAYER = Object.freeze([
 const TOKEN_RAIL_HEIGHT_LIFT = 0;
 const NON_OCTAGON_TOKEN_SURFACE_OFFSET = -0.0075;
 let tokenSurfaceOffset = 0;
-const TOKEN_FRONT_OUTWARD_SHIFT = 0.082;
+const TOKEN_FRONT_OUTWARD_SHIFT = 0.094;
 const TOKEN_MOVE_SPEED = 2.45;
 const TOKEN_STEP_DURATION_SECONDS = 0.34;
 const LUDO_CAPTURE_MISSILE_LAUNCH_SOUND_URL = '/assets/sounds/launch-85216.mp3';
 const LUDO_CAPTURE_MISSILE_IMPACT_SOUND_URL = '/assets/sounds/080998_bullet-hit-39870.mp3';
 const LUDO_CAPTURE_DRONE_SOUND_URL = '/assets/sounds/spinning.mp3';
 const LUDO_CAPTURE_FIGHTER_SOUND_URL = '/assets/sounds/race-care-151963.mp3';
-const LUDO_CAPTURE_HELICOPTER_SOUND_URL = 'https://assets.mixkit.co/active_storage/sfx/209/209-preview.mp3';
+const LUDO_CAPTURE_HELICOPTER_SOUND_URL = '/assets/sounds/dragon-studio-helicopter-sound-8d-372463.mp3';
 const TOKEN_STEP_JUMP_HEIGHT = 0.03;
 const TOKEN_STEP_JUMP_PHASE = 0.7;
 const keyFor = (r, c) => `${r},${c}`;
@@ -3575,18 +3575,18 @@ const easeOutCubic = (t) => 1 - Math.pow(1 - t, 3);
 
 const TOKEN_SELECTION_SCALE = 1.08;
 const TOKEN_SIZE_MULTIPLIER = 1.4;
-const TOKEN_RAIL_OUTWARD_PUSH = 0.148;
+const TOKEN_RAIL_OUTWARD_PUSH = 0.172;
 const CAPTURE_ANIMATION_HEIGHT_COMPENSATION = TABLE_VERTICAL_LOWERING;
 const CAMERA_TURN_VIEW_DURATION_MS = 520;
 const CAMERA_BROADCAST_ANIMATION_MS = 560;
 const CAMERA_RETURN_ANIMATION_MS = 620;
 const TOKEN_TYPE_SCALE_PROFILE = Object.freeze({
-  pawn: { x: 0.386, y: 0.336, z: 0.369 },
+  pawn: { x: 0.94, y: 0.94, z: 0.9 },
   knight: { x: 0.94, y: 0.94, z: 0.9 },
   rook: { x: 0.94, y: 0.94, z: 0.9 },
-  bishop: { x: 2.686, y: 3.312, z: 2.57 },
-  queen: { x: 2.686, y: 3.485, z: 2.57 },
-  king: { x: 2.686, y: 3.656, z: 2.57 }
+  bishop: { x: 0.94, y: 0.94, z: 0.9 },
+  queen: { x: 0.94, y: 0.94, z: 0.9 },
+  king: { x: 0.94, y: 0.94, z: 0.9 }
 });
 
 function setTokenHighlight(token, active) {


### PR DESCRIPTION
### Motivation
- Make the Ludo Battle Royal table/board/dice visually grounded, correct inconsistent token proportions, nudge tokens slightly outward for better spacing, and reuse the existing helicopter fly sound from Chess for capture FX.

### Description
- Increased `TABLE_VERTICAL_LOWERING` to lower the full table stack and kept `CAPTURE_ANIMATION_HEIGHT_COMPENSATION` tied to this value so FX heights remain aligned; changed in `webapp/src/pages/Games/LudoBattleRoyal.jsx`.
- Nudged token placement outward by increasing `TOKEN_FRONT_OUTWARD_SHIFT` and `TOKEN_RAIL_OUTWARD_PUSH` in the same file to spread player tokens a bit more.
- Normalized `TOKEN_TYPE_SCALE_PROFILE` so all piece types use the same scale profile (matching the current rook/rock baseline) to avoid some pieces appearing too large or thin.
- Switched `LUDO_CAPTURE_HELICOPTER_SOUND_URL` to the local helicopter SFX used by Chess: `/assets/sounds/dragon-studio-helicopter-sound-8d-372463.mp3`.

### Testing
- Ran `npx eslint webapp/src/pages/Games/LudoBattleRoyal.jsx`, which produced a repository ignore warning but no lint errors from the change.
- Ran `npm test -- --runInBand test/checkersOnlineReadiness.test.js` and the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db81bad0e48329b8fd3440edabefa0)