### PR TITLE
Reduce Domino Royal arena scale (scale 0.97)

### DIFF
--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -80,6 +80,10 @@ export default function DominoRoyalArena() {
         <div id="configSections" />
       </div>
       <style>{`
+        #app {
+          transform: scale(0.97);
+          transform-origin: center center;
+        }
         #viewToggle {
           position: fixed !important;
           right: calc(0.38rem + env(safe-area-inset-right, 0px)) !important;


### PR DESCRIPTION
### Motivation
- Make the in-game domino pieces appear slightly smaller on-screen by reducing the rendered arena scale per design request.

### Description
- Added a small CSS transform to `#app` in `webapp/src/pages/Games/DominoRoyalArena.jsx`: `transform: scale(0.97); transform-origin: center center;`, keeping the change confined to the requested file.

### Testing
- Ran `npm --prefix webapp run build`, and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db82efb5748329bf0b7c05e502f8e9)