### PR TITLE
Ludo: raise board & dice, unify table width, and normalize token sizing

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -2384,9 +2384,10 @@ function fitTableModelToArena(model, tableThemeId = null) {
   };
 }
 
-function getTableWidthScale(tableThemeId) {
-  if (!tableThemeId) return 1;
-  return tableThemeId === 'gothic_coffee_table' ? 1.03 : 1.06;
+const OCTAGON_REFERENCE_TABLE_WIDTH_SCALE = 1.06;
+
+function getTableWidthScale() {
+  return OCTAGON_REFERENCE_TABLE_WIDTH_SCALE;
 }
 
 function applyBoardGroupScale(boardGroup, tableInfo) {
@@ -2788,7 +2789,7 @@ const BOARD_DISPLAY_SIZE = RAW_BOARD_SIZE * BOARD_SCALE;
 const BOARD_CLOTH_HALF = BOARD_DISPLAY_SIZE / 2;
 const BOARD_RADIUS = BOARD_DISPLAY_SIZE / 2;
 const PLAYFIELD_HEIGHT = 0.018;
-const BOARD_GROUP_SURFACE_OFFSET = -0.0055;
+const BOARD_GROUP_SURFACE_OFFSET = -0.0025;
 const TILE_HALF_HEIGHT = PLAYFIELD_HEIGHT / 2;
 const MARKER_SURFACE_OFFSET = 0.002;
 const STAR_MARKER_SURFACE_INSET = 0.001;
@@ -2933,9 +2934,10 @@ const TOKEN_RAIL_CENTER_PULL_PER_PLAYER = Object.freeze([
   0.128
 ]);
 const TOKEN_RAIL_HEIGHT_LIFT = 0.0035;
-const NON_OCTAGON_TOKEN_SURFACE_OFFSET = -0.0075;
+const NON_OCTAGON_TOKEN_SURFACE_OFFSET = 0;
 const SHAPED_TABLE_TOKEN_SURFACE_LIFT = 0.005;
 const SHAPED_TABLE_DICE_SURFACE_LIFT = 0.0055;
+const OCTAGON_REFERENCE_TOKEN_SURFACE_OFFSET = SHAPED_TABLE_TOKEN_SURFACE_LIFT;
 let tokenSurfaceOffset = 0;
 const TOKEN_FRONT_OUTWARD_SHIFT = 0.082;
 const TOKEN_MOVE_SPEED = 2.45;
@@ -3000,10 +3002,8 @@ function getShapedTableHeightLift(tableThemeId) {
   return isShapedLudoTable(tableThemeId) ? SHAPED_TABLE_TOKEN_SURFACE_LIFT : 0;
 }
 
-function updateTokenSurfaceOffset(tableThemeId) {
-  tokenSurfaceOffset =
-    (tableThemeId === 'murlan-default' ? 0 : NON_OCTAGON_TOKEN_SURFACE_OFFSET) +
-    getShapedTableHeightLift(tableThemeId);
+function updateTokenSurfaceOffset() {
+  tokenSurfaceOffset = OCTAGON_REFERENCE_TOKEN_SURFACE_OFFSET + NON_OCTAGON_TOKEN_SURFACE_OFFSET;
 }
 
 const DICE_SIZE = 0.076;
@@ -3719,14 +3719,14 @@ const CAPTURE_ANIMATION_HEIGHT_COMPENSATION = TABLE_VERTICAL_LOWERING;
 const CAMERA_TURN_VIEW_DURATION_MS = 520;
 const CAMERA_BROADCAST_ANIMATION_MS = 560;
 const CAMERA_RETURN_ANIMATION_MS = 620;
-const ROCK_TOKEN_REFERENCE_SCALE = Object.freeze({ x: 0.94, y: 0.94, z: 0.9 });
+const ROCK_TOKEN_REFERENCE_SCALE = Object.freeze({ x: 0.94, y: 0.94, z: 0.94 });
 const TOKEN_TYPE_SCALE_PROFILE = Object.freeze({
   pawn: ROCK_TOKEN_REFERENCE_SCALE,
   knight: ROCK_TOKEN_REFERENCE_SCALE,
   rook: ROCK_TOKEN_REFERENCE_SCALE,
-  bishop: { x: ROCK_TOKEN_REFERENCE_SCALE.x * 1.3, y: ROCK_TOKEN_REFERENCE_SCALE.y * 1.3, z: ROCK_TOKEN_REFERENCE_SCALE.z * 1.3 },
-  queen: { x: ROCK_TOKEN_REFERENCE_SCALE.x * 1.3, y: ROCK_TOKEN_REFERENCE_SCALE.y * 1.3, z: ROCK_TOKEN_REFERENCE_SCALE.z * 1.3 },
-  king: { x: ROCK_TOKEN_REFERENCE_SCALE.x * 1.3, y: ROCK_TOKEN_REFERENCE_SCALE.y * 1.3, z: ROCK_TOKEN_REFERENCE_SCALE.z * 1.3 }
+  bishop: ROCK_TOKEN_REFERENCE_SCALE,
+  queen: ROCK_TOKEN_REFERENCE_SCALE,
+  king: ROCK_TOKEN_REFERENCE_SCALE
 });
 
 function setTokenHighlight(token, active) {
@@ -5365,7 +5365,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
 
       const heightLocal =
         diceObj.userData?.railHeight ?? diceObj.userData?.baseHeight ?? DICE_BASE_HEIGHT;
-      const diceShapeLift = isShapedLudoTable(table?.themeId) ? SHAPED_TABLE_DICE_SURFACE_LIFT : 0;
+      const diceShapeLift = SHAPED_TABLE_DICE_SURFACE_LIFT;
       const heightWorld = heightLocal * scaleWorld.y;
 
       const fallbackDirs = [


### PR DESCRIPTION
### Motivation
- Improve visual alignment for the Ludo Battle Royal scene so the board, tokens and dice sit slightly higher on screen and match the octagon table baseline. 
- Make table width consistent across themes by using the octagon table as the reference so token rails and board sizing align uniformly. 
- Standardize token piece sizes and thickness so all player tokens share the same physical height/scale and feel like a unified chess-like set.

### Description
- Raised the Ludo board group offset by changing `BOARD_GROUP_SURFACE_OFFSET` from `-0.0055` to `-0.0025` to make board/tokens/dice render higher. (file: `webapp/src/pages/Games/LudoBattleRoyal.jsx`)
- Introduced `OCTAGON_REFERENCE_TABLE_WIDTH_SCALE` and made `getTableWidthScale()` return that constant to normalize table width to the octagon reference. (file: `webapp/src/pages/Games/LudoBattleRoyal.jsx`)
- Aligned token vertical placement by replacing theme-dependent offsets with an octagon-reference baseline using `OCTAGON_REFERENCE_TOKEN_SURFACE_OFFSET` and simplified `updateTokenSurfaceOffset()` to apply that baseline. (file: `webapp/src/pages/Games/LudoBattleRoyal.jsx`)
- Normalized all token type scale profiles by unifying `ROCK_TOKEN_REFERENCE_SCALE` across x/y/z and setting `TOKEN_TYPE_SCALE_PROFILE` so `pawn/knight/rook/bishop/queen/king` use the same reference scale, removing per-piece scale multipliers. (file: `webapp/src/pages/Games/LudoBattleRoyal.jsx`)
- Made dice placement use the shared shaped-table dice lift (`SHAPED_TABLE_DICE_SURFACE_LIFT`) so dice anchor heights follow the same elevated table reference. (file: `webapp/src/pages/Games/LudoBattleRoyal.jsx`)

### Testing
- Built the web app with `npm --prefix webapp run build` and the build completed successfully (vite build finished). 
- No automated unit tests were changed; visual verification is recommended in a portrait mobile viewport to confirm board/tokens/dice alignment and token proportions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbcb40de948329b0daa769db75eaf1)