### PR TITLE
Lower and center aircraft flight paths over board for Chess Battle Royale

### DIFF
--- a/webapp/public/chess-royale.html
+++ b/webapp/public/chess-royale.html
@@ -247,7 +247,8 @@ const MISSILE_HEIGHT=0.095;
 const MISSILE_SIZE=0.02;
 const MISSILE_TRAIL_COUNT=5;
 const MISSILE_TRAIL_SPACING=0.08;
-const JET_HEIGHT=0.19;
+const DEFAULT_AIRCRAFT_FLIGHT_HEIGHT=0.13;
+let aircraftFlightHeight=DEFAULT_AIRCRAFT_FLIGHT_HEIGHT;
 const JET_SIZE=0.31;
 const JET_SPEED_FACTOR=2.0; // keep jet and jet-fired missile travel at 50% slower pacing
 const DRONE_SIZE=0.048;
@@ -383,6 +384,7 @@ function onModel(gltf){
   function placeGroup(color, code, squares){ const arr=pool[color][code]; for(let i=0;i<squares.length;i++){ const node=arr[i]; if(!node) continue; const sq=squares[i]; const baseY=((typeof node.position.y==='number')?node.position.y:(boardY+.02))+BOARD_PIECE_VERTICAL_LIFT; node.userData.baseY=baseY; const v=squareCenterVec3(sq); v.y=baseY; node.position.set(v.x, v.y, v.z); piecesBySquare[sq]=node; } }
   placeGroup('w','p',startW.p); placeGroup('w','r',startW.r); placeGroup('w','n',startW.n); placeGroup('w','b',startW.b); placeGroup('w','q',startW.q); placeGroup('w','k',startW.k);
   placeGroup('b','p',startB.p); placeGroup('b','r',startB.r); placeGroup('b','n',startB.n); placeGroup('b','b',startB.b); placeGroup('b','q',startB.q); placeGroup('b','k',startB.k);
+  aircraftFlightHeight=resolveAircraftFlightHeight(pool);
   const el=renderer.domElement; el.addEventListener('pointerdown',onPointerDown,{passive:false}); window.addEventListener('pointermove',onPointerMove,{passive:false}); window.addEventListener('pointerup',onPointerUp,{passive:false}); window.addEventListener('contextmenu',e=>{e.preventDefault();},{passive:false});
   badge.textContent='Ready'; ready=true; updateTurn(); applyZoom();
 }
@@ -463,13 +465,34 @@ function setTravelOrientation(node,from,to,bank=0){
   const heading=Math.atan2(dir.z,dir.x);
   node.rotation.set(0,-heading,bank);
 }
+function getAircraftFlightHeight(){
+  return Math.max(boardY+0.085, aircraftFlightHeight||DEFAULT_AIRCRAFT_FLIGHT_HEIGHT);
+}
+
+function resolveAircraftFlightHeight(pool){
+  try{
+    const bishops=[...(pool?.w?.b||[]), ...(pool?.b?.b||[])].filter(Boolean);
+    if(!bishops.length) return getAircraftFlightHeight();
+    const boardSurface=boardY+0.02+BOARD_PIECE_VERTICAL_LIFT;
+    const bishopHeights=bishops.map(node=>{
+      const box=new THREE.Box3().setFromObject(node);
+      const baseY=(typeof node.userData?.baseY==='number')?node.userData.baseY:boardSurface;
+      return Math.max(0.02,box.max.y-baseY);
+    });
+    const avgBishopHeight=bishopHeights.reduce((a,b)=>a+b,0)/bishopHeights.length;
+    const desired=boardSurface+(avgBishopHeight*2.0);
+    return Math.max(boardY+0.082, Math.min(boardY+0.17, desired));
+  }catch(_){
+    return getAircraftFlightHeight();
+  }
+}
+
 function getJetIngressAndEgress(from,to){
   const center=from.clone().lerp(to,0.5);
-  const margin=1.25; // keep fly-by near the board so the jet appears earlier on-screen
-  const useTop=Math.random()>0.5;
-  const zEdge=center.z+(useTop?margin:-margin);
-  const entry=new THREE.Vector3(center.x,JET_HEIGHT,zEdge);
-  const exit=new THREE.Vector3(center.x,JET_HEIGHT,-zEdge);
+  const laneHalfSpan=Math.max(0.42,Math.min(0.92,from.distanceTo(to)*0.52));
+  const flightY=getAircraftFlightHeight();
+  const entry=new THREE.Vector3(center.x,flightY,center.z+laneHalfSpan);
+  const exit=new THREE.Vector3(center.x,flightY,center.z-laneHalfSpan);
   return {entry,exit,center};
 }
 
@@ -632,9 +655,10 @@ function animateJetMissileStrike(from,to){
     const missile=buildMissileMesh();
     const {entry,exit,center}=getJetIngressAndEgress(from,to);
     const targetLow=to.clone().add(new THREE.Vector3(0,MISSILE_HEIGHT,0));
-    const approach=from.clone().lerp(to,0.62).add(new THREE.Vector3(0,JET_HEIGHT,0));
-    const turnPoint=to.clone().add(new THREE.Vector3(0,JET_HEIGHT,0.48*Math.sign(exit.z||1)));
-    const loopPoint=from.clone().lerp(to,0.4).add(new THREE.Vector3(0,JET_HEIGHT,-0.42*Math.sign(exit.z||1)));
+    const flightY=getAircraftFlightHeight();
+    const approach=from.clone().lerp(to,0.64).setY(flightY);
+    const turnPoint=to.clone().set(center.x,flightY,center.z+0.16);
+    const loopPoint=from.clone().lerp(to,0.45).set(center.x,flightY,center.z-0.12);
     const missileCurve=[];
     jet.position.copy(entry);
     missile.visible=false;
@@ -654,12 +678,12 @@ function animateJetMissileStrike(from,to){
         const t=Math.min(1,elapsed/phaseA);
         const eased=t*t*(3-2*t);
         jet.position.lerpVectors(entry,approach,eased);
-        jet.position.y=JET_HEIGHT+Math.sin(t*Math.PI)*0.03;
+        jet.position.y=flightY+Math.sin(t*Math.PI)*0.014;
         setTravelOrientation(jet,entry,approach,Math.sin(t*Math.PI)*0.05);
       }else if(elapsed<=phaseA+phaseB){
         const t=Math.min(1,(elapsed-phaseA)/phaseB);
         jet.position.lerpVectors(approach,turnPoint,t);
-        jet.position.y+=Math.sin(t*Math.PI)*0.05;
+        jet.position.y=flightY+Math.sin(t*Math.PI)*0.018;
         setTravelOrientation(jet,approach,to,Math.sin(t*Math.PI)*0.04);
         if(!missileLaunched){
           missileLaunched=true;
@@ -675,7 +699,7 @@ function animateJetMissileStrike(from,to){
           : loopPoint.clone().lerp(exit,(t-0.5)*2);
         const uFrom=t<0.5 ? turnPoint : loopPoint;
         jet.position.copy(uTurn);
-        jet.position.y=JET_HEIGHT+Math.sin(t*Math.PI)*0.045;
+        jet.position.y=flightY+Math.sin(t*Math.PI)*0.014;
         setTravelOrientation(jet,uFrom,exit,-Math.sin(t*Math.PI)*0.05);
         if(missileLaunched) updateMissileRig(missile,missileCurve,0.9+(t*0.1));
       }else{
@@ -705,20 +729,23 @@ function animateDroneKamikaze(from,to){
     const smokeTrail=new THREE.Mesh(new THREE.SphereGeometry(0.024,8,8), new THREE.MeshBasicMaterial({color:0x9ca3af, transparent:true, opacity:0.72}));
     const blast=new THREE.Mesh(new THREE.SphereGeometry(0.07,12,12), new THREE.MeshBasicMaterial({color:0xfb7185, transparent:true, opacity:0}));
     drone.add(body,propHub,propBladeA,propBladeB);
-    const start=from.clone().add(new THREE.Vector3(0,0.09,0));
-    const end=to.clone().add(new THREE.Vector3(Math.sign((to.x-from.x)||1)*0.17,0.11,Math.sign((to.z-from.z)||1)*0.17));
-    const radius=Math.max(0.3,Math.min(0.66,from.distanceTo(to)*0.24));
+    const flightY=Math.max(boardY+0.078,getAircraftFlightHeight()-0.012);
+    const center=from.clone().lerp(to,0.5);
+    const laneHalfSpan=Math.max(0.36,Math.min(0.72,from.distanceTo(to)*0.45));
+    const start=new THREE.Vector3(center.x,flightY,center.z+laneHalfSpan);
+    const end=to.clone().add(new THREE.Vector3(0,0.105,0));
+    const radius=Math.max(0.12,Math.min(0.2,from.distanceTo(to)*0.12));
     drone.position.copy(start); smokeTrail.position.copy(start); blast.position.copy(to.clone().add(new THREE.Vector3(0,0.17,0)));
     scene.add(drone); scene.add(smokeTrail); scene.add(blast); playDroneSound();
     const t0=performance.now(), dur=700;
     const cubic=(a,b,c,d,t)=>new THREE.Vector3().copy(a).multiplyScalar((1-t)**3).add(b.clone().multiplyScalar(3*(1-t)*(1-t)*t)).add(c.clone().multiplyScalar(3*(1-t)*t*t)).add(d.clone().multiplyScalar(t*t*t));
     const tick=now=>{
       const t=Math.min(1,(now-t0)/dur);
-      const midA=start.clone().lerp(end,0.3).add(new THREE.Vector3(radius,0.04,radius*0.75));
-      const midB=start.clone().lerp(end,0.62).add(new THREE.Vector3(-radius*0.72,0.035,-radius*0.88));
+      const midA=start.clone().lerp(end,0.32).add(new THREE.Vector3(radius*0.3,0.018,-radius*0.22));
+      const midB=start.clone().lerp(end,0.65).add(new THREE.Vector3(-radius*0.2,0.014,radius*0.15));
       const p=cubic(start,midA,midB,end,t);
       drone.position.copy(p);
-      drone.position.y=Math.max(boardY+0.075,p.y);
+      drone.position.y=Math.max(boardY+0.072,p.y);
       smokeTrail.position.lerpVectors(start,p,0.9);
       smokeTrail.material.opacity=0.72*(1-t);
       propHub.rotation.x=t*Math.PI*24;


### PR DESCRIPTION
### Motivation
- Make F-15 and helicopter/drone fly-bys appear just above the chess board so they are visible in portrait 2D view and approximately the height of two bishops above the board surface. 
- Keep aircraft trajectories vertically centered over the board and reduce lateral/vertical drift so strikes are readable and cinematic on small/portrait screens.

### Description
- Updated `webapp/public/chess-royale.html` to replace the fixed `JET_HEIGHT` with `DEFAULT_AIRCRAFT_FLIGHT_HEIGHT` and a runtime `aircraftFlightHeight` variable. 
- Added `resolveAircraftFlightHeight(pool)` and `getAircraftFlightHeight()` to compute a low flight altitude from bishop mesh heights (roughly “two bishops” above board) and set `aircraftFlightHeight` once pieces are placed. 
- Reworked `getJetIngressAndEgress()` to produce a tight, centered ingress/egress lane above the board using the computed flight height. 
- Adjusted `animateJetMissileStrike()` to use the new flight height for approach/turn/loop points and reduced vertical bobbing for better on-screen visibility. 
- Tightened `animateDroneKamikaze()` path and midpoints, reduced lateral spread and radii, and nudged drone baseline heights so helicopters/drones also fly lower and centered above the board.

### Testing
- Performed automated repository searches for updated identifiers (`JET_HEIGHT`, `DEFAULT_AIRCRAFT_FLIGHT_HEIGHT`, `resolveAircraftFlightHeight`, `getAircraftFlightHeight`) and confirmed the edits are present and localized to `webapp/public/chess-royale.html` (succeeded). 
- Inspected the file diff to verify the intended changes were applied to the flight-path logic (succeeded). 
- Wrote the modified file and ran basic file-update/replace operations used during the change (succeeded). 
- No unit or runtime integration tests were executed in this environment; manual playtesting in a browser / device emulator is recommended to validate portrait-camera visibility and tweak numeric offsets if needed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbd76ad6f88329965375bac3c3a333)