### PR TITLE
Adjust Chess Battle Royal jet and helicopter fly paths for portrait board visibility

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -10917,54 +10917,42 @@ function Chess3D({
               value.z = THREE.MathUtils.clamp(value.z, -boardClamp, boardClamp);
               return value;
             };
-            const arenaCenter = new THREE.Vector3(0, fx.from.y, 0);
-            const fromOffset = fx.from.clone().sub(arenaCenter).setY(0);
-            const toOffset = fx.to.clone().sub(arenaCenter).setY(0);
-            const fallbackRadius = boardClamp * 0.64;
-            const fromRadius = Math.max(fromOffset.length(), fallbackRadius);
-            const toRadius = Math.max(toOffset.length(), fallbackRadius);
-            const jetFlightAltitude = Math.max(CAPTURE_JET_ALTITUDE, fx.to.y + Math.max(tile * 0.28, 0.11));
-            const orbitalRadius = Math.min(
-              boardClamp * 0.72,
-              Math.max(fromRadius, toRadius, boardClamp * 0.66)
+            const fromOffset = fx.from.clone().setY(0);
+            const toOffset = fx.to.clone().setY(0);
+            const bishopHeightAltitude = currentPieceYOffset + Math.max(tile * 0.56, 0.28);
+            const jetFlightAltitude = Math.max(
+              fx.to.y + Math.max(tile * 0.14, 0.08),
+              bishopHeightAltitude
             );
-            const fromAngle = Math.atan2(fromOffset.z, fromOffset.x);
-            const toAngle = Math.atan2(toOffset.z, toOffset.x);
-            let angularDelta = toAngle - fromAngle;
-            if (angularDelta <= 0) angularDelta += Math.PI * 2;
-            angularDelta = Math.max(angularDelta + Math.PI * 0.9, Math.PI * 1.8);
-            const cruiseAngle = fromAngle + angularDelta * 0.7;
+            const laneX = THREE.MathUtils.clamp((fx.from.x + fx.to.x) * 0.12, -boardClamp * 0.2, boardClamp * 0.2);
+            const laneStart = clampToBoard(new THREE.Vector3(laneX, jetFlightAltitude, fx.from.z));
+            const laneTarget = clampToBoard(new THREE.Vector3(laneX, jetFlightAltitude, fx.to.z));
+            const laneTravelSign = Math.sign(laneTarget.z - laneStart.z) || Math.sign(toOffset.z - fromOffset.z) || 1;
             const topStrikeHeight = Math.max(tile * 2.2, 0.42);
-            const apex = new THREE.Vector3(
-              arenaCenter.x + Math.cos(cruiseAngle) * orbitalRadius,
-              jetFlightAltitude,
-              arenaCenter.z + Math.sin(cruiseAngle) * orbitalRadius
-            );
+            const apex = laneStart
+              .clone()
+              .lerp(laneTarget, 0.54)
+              .add(new THREE.Vector3(0, Math.max(tile * 0.05, 0.03), 0));
             let jetPos = null;
             let jetNext = null;
             const pathAt = (valueU) => {
               const t = clamp01(valueU);
               if (t < phaseSplit) {
                 const a = smoothEase(t / phaseSplit);
-                const orbitAngle = fromAngle + angularDelta * a;
-                const ring = new THREE.Vector3(
-                  arenaCenter.x + Math.cos(orbitAngle) * orbitalRadius,
-                  jetFlightAltitude,
-                  arenaCenter.z + Math.sin(orbitAngle) * orbitalRadius
+                const laneMid = laneStart.clone().lerp(apex, a);
+                return clampToBoard(
+                  qBezier(
+                    laneStart,
+                    laneStart.clone().lerp(apex, 0.5).add(new THREE.Vector3(0, Math.max(tile * 0.04, 0.02), 0)),
+                    laneMid,
+                    a
+                  )
                 );
-                return clampToBoard(fx.from.clone().lerp(ring, 0.78 + a * 0.22));
               }
               const d = smoothEase((t - phaseSplit) / (1 - phaseSplit));
-              const toRadial = fx.to.clone().sub(arenaCenter).setY(0);
-              if (toRadial.lengthSq() < 1e-6) {
-                toRadial.set(Math.cos(fromAngle + angularDelta), 0, Math.sin(fromAngle + angularDelta));
-              } else {
-                toRadial.normalize();
-              }
-              const flyByEnd = fx.to
+              const flyByEnd = laneTarget
                 .clone()
-                .add(toRadial.multiplyScalar(orbitalRadius * 0.85))
-                .add(new THREE.Vector3(0, Math.max(tile * 0.08, 0.03), 0));
+                .add(new THREE.Vector3(0, Math.max(tile * 0.07, 0.03), laneTravelSign * boardClamp * 0.52));
               return clampToBoard(qBezier(apex, apex.clone().lerp(flyByEnd, 0.5), flyByEnd, d));
             };
             if (jetU < 1) {
@@ -11064,56 +11052,42 @@ function Chess3D({
               value.z = THREE.MathUtils.clamp(value.z, -boardClamp, boardClamp);
               return value;
             };
-            const arenaCenter = new THREE.Vector3(0, fx.from.y, 0);
-            const fromOffset = fx.from.clone().sub(arenaCenter).setY(0);
-            const toOffset = fx.to.clone().sub(arenaCenter).setY(0);
-            const fallbackRadius = boardClamp * 0.64;
-            const fromRadius = Math.max(fromOffset.length(), fallbackRadius);
-            const toRadius = Math.max(toOffset.length(), fallbackRadius);
+            const fromOffset = fx.from.clone().setY(0);
+            const toOffset = fx.to.clone().setY(0);
+            const bishopHeightAltitude = currentPieceYOffset + Math.max(tile * 0.62, 0.31);
             const helicopterFlightAltitude = Math.max(
-              CAPTURE_JET_ALTITUDE + CAPTURE_HELICOPTER_ALTITUDE_BOOST,
-              fx.to.y + Math.max(tile * 0.38, 0.15)
+              fx.to.y + Math.max(tile * 0.18, 0.1),
+              bishopHeightAltitude + Math.max(tile * 0.06, 0.04)
             );
-            const orbitalRadius = Math.min(
-              boardClamp * 0.72,
-              Math.max(fromRadius, toRadius, boardClamp * 0.66)
-            );
-            const fromAngle = Math.atan2(fromOffset.z, fromOffset.x);
-            const toAngle = Math.atan2(toOffset.z, toOffset.x);
-            let angularDelta = toAngle - fromAngle;
-            if (angularDelta <= 0) angularDelta += Math.PI * 2;
-            if (angularDelta < Math.PI / 3) angularDelta += Math.PI * 2;
-            const cruiseAngle = fromAngle + angularDelta * 0.7;
+            const laneX = THREE.MathUtils.clamp((fx.from.x + fx.to.x) * 0.14, -boardClamp * 0.2, boardClamp * 0.2);
+            const laneStart = clampToBoard(new THREE.Vector3(laneX, helicopterFlightAltitude, fx.from.z));
+            const laneTarget = clampToBoard(new THREE.Vector3(laneX, helicopterFlightAltitude, fx.to.z));
+            const laneTravelSign = Math.sign(laneTarget.z - laneStart.z) || Math.sign(toOffset.z - fromOffset.z) || 1;
             const topStrikeHeight = Math.max(tile * 2.2, 0.42);
-            const apex = new THREE.Vector3(
-              arenaCenter.x + Math.cos(cruiseAngle) * orbitalRadius,
-              helicopterFlightAltitude,
-              arenaCenter.z + Math.sin(cruiseAngle) * orbitalRadius
-            );
+            const apex = laneStart
+              .clone()
+              .lerp(laneTarget, 0.54)
+              .add(new THREE.Vector3(0, Math.max(tile * 0.06, 0.035), 0));
             let heliPos = null;
             let heliNext = null;
             const pathAt = (valueU) => {
               const t = clamp01(valueU);
               if (t < phaseSplit) {
                 const a = smoothEase(t / phaseSplit);
-                const orbitAngle = fromAngle + angularDelta * a;
-                const ring = new THREE.Vector3(
-                  arenaCenter.x + Math.cos(orbitAngle) * orbitalRadius,
-                  helicopterFlightAltitude,
-                  arenaCenter.z + Math.sin(orbitAngle) * orbitalRadius
+                const laneMid = laneStart.clone().lerp(apex, a);
+                return clampToBoard(
+                  qBezier(
+                    laneStart,
+                    laneStart.clone().lerp(apex, 0.5).add(new THREE.Vector3(0, Math.max(tile * 0.05, 0.025), 0)),
+                    laneMid,
+                    a
+                  )
                 );
-                return clampToBoard(fx.from.clone().lerp(ring, 0.78 + a * 0.22));
               }
               const d = smoothEase((t - phaseSplit) / (1 - phaseSplit));
-              const retreatDir = apex.clone().sub(fx.to).setY(0);
-              if (retreatDir.lengthSq() < 1e-6) {
-                retreatDir.set(Math.cos(fromAngle + angularDelta), 0, Math.sin(fromAngle + angularDelta));
-              }
-              retreatDir.normalize();
-              const flyAwayEnd = apex
+              const flyAwayEnd = laneTarget
                 .clone()
-                .add(retreatDir.multiplyScalar(orbitalRadius * 1.35))
-                .add(new THREE.Vector3(0, Math.max(tile * 0.08, 0.03), 0));
+                .add(new THREE.Vector3(0, Math.max(tile * 0.08, 0.04), laneTravelSign * boardClamp * 0.56));
               return clampToBoard(qBezier(apex, apex.clone().lerp(flyAwayEnd, 0.5), flyAwayEnd, d));
             };
             if (heliU < 1) {


### PR DESCRIPTION
### Motivation
- Improve visibility of fighter-jet and helicopter capture FX in phone portrait (2D) view by keeping vehicles vertically above the board and near piece height. 
- Make air-strike carriers appear just above board pieces (approx. the height of two bishops) so they are readable from the portrait camera.

### Description
- Replace wide orbital/orbit-angle flight math with a centered lane-based trajectory so aircraft X is clamped near board center and travel primarily along board depth (`z`).
- Anchor jet and helicopter flight altitudes to a bishop-height reference derived from `currentPieceYOffset` and tile scale so carriers fly close above pieces; helicopter altitude is slightly higher than jet.
- Remove reliance on the previous `arenaCenter` orbital geometry and compute `laneX`, `laneStart`, `laneTarget`, `apex` and lane `qBezier` paths for both `jet` and `helicopter` FX while keeping missile release and orientation logic unchanged.
- Modified file: `webapp/src/pages/Games/ChessBattleRoyal.jsx` (pathing/altitude logic only; missile visibility/orientation code left intact).

### Testing
- Ran unit tests: `npm test -- --runInBand test/chessBattleInventoryConfig.test.js` which passed (3 tests, 0 failures).
- No automated visual screenshot tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbd76ad6f88329965375bac3c3a333)