### PR TITLE
Tune Domino Royal table/tile sizing via JSX runtime patching

### DIFF
--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,14 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-04-12-domino-layout-camera-tune-v21';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-04-12-domino-layout-camera-tune-v22';
+
+const DOMINO_RUNTIME_TUNING_REPLACEMENTS = Object.freeze([
+  ['const TABLE_RADIUS_SCALE = 1.08;', 'const TABLE_RADIUS_SCALE = 0.92;'],
+  ['const DOMINO_EXTRA_SHRINK_FACTOR = 0.74;', 'const DOMINO_EXTRA_SHRINK_FACTOR = 1.11;'],
+  ['const HAND_Y = RAIL_TOP + TILE_UP_HALF - 0.0025;', 'const HAND_Y = RAIL_TOP + TILE_UP_HALF + 0.0035;'],
+  ['const CHAIN_TILE_Y = CLOTH_TOP + 0.0018;', 'const CHAIN_TILE_Y = CLOTH_TOP + 0.0082;']
+]);
 
 export default function DominoRoyalArena() {
   useEffect(() => {
@@ -35,25 +42,54 @@ export default function DominoRoyalArena() {
     const normalizedBasePath = basePath.endsWith('/') ? basePath : `${basePath}/`;
     const script = document.createElement('script');
     script.type = 'module';
-    script.src = `${normalizedBasePath}domino-royal-game.js?v=${DOMINO_ROYAL_SCRIPT_VERSION}`;
     script.dataset.dominoRoyalScript = 'true';
-    script.onload = () => {
-      if (statusNode) {
-        statusNode.textContent = 'Ready';
+
+    let cancelled = false;
+    let runtimeScriptUrl = '';
+
+    const loadRuntime = async () => {
+      const sourceUrl = `${normalizedBasePath}domino-royal-game.js?v=${DOMINO_ROYAL_SCRIPT_VERSION}`;
+      const response = await fetch(sourceUrl, { cache: 'no-store' });
+      if (!response.ok) {
+        throw new Error(`Failed to fetch Domino Royal runtime (${response.status})`);
       }
+      let source = await response.text();
+      DOMINO_RUNTIME_TUNING_REPLACEMENTS.forEach(([from, to]) => {
+        source = source.replace(from, to);
+      });
+      runtimeScriptUrl = URL.createObjectURL(
+        new Blob([source], { type: 'text/javascript' })
+      );
+      if (cancelled) return;
+      script.src = runtimeScriptUrl;
+      script.onload = () => {
+        if (statusNode) {
+          statusNode.textContent = 'Ready';
+        }
+      };
+      script.onerror = () => {
+        if (statusNode) {
+          statusNode.textContent = 'Game failed to load. Please refresh and try again.';
+        }
+      };
+      document.body.appendChild(script);
     };
-    script.onerror = () => {
+
+    loadRuntime().catch(() => {
       if (statusNode) {
         statusNode.textContent = 'Game failed to load. Please refresh and try again.';
       }
-    };
-    document.body.appendChild(script);
+    });
 
     return () => {
+      cancelled = true;
       if (typeof window.__dominoRoyalCleanup === 'function') {
         window.__dominoRoyalCleanup('react-unmount');
       }
       script.remove();
+      if (runtimeScriptUrl) {
+        URL.revokeObjectURL(runtimeScriptUrl);
+      }
       if (appRoot) {
         appRoot.replaceChildren();
       }


### PR DESCRIPTION
### Motivation
- Make the Domino Battle Royal table visually smaller from all sides while keeping table height, increase domino size ~50%, and raise domino placement slightly to match requested visual adjustments without editing the shipped runtime `domino-royal-game.js` file.
- Apply the changes at load time from the React arena loader so runtime code is tuned only in the `.jsx` loader (preserves original `.js` file and designer workflow).

### Description
- Changed `webapp/src/pages/Games/DominoRoyalArena.jsx` to fetch `domino-royal-game.js` as text, apply a small set of string replacements, and execute the modified runtime via a blob URL instead of attaching the original script URL directly.
- Added `DOMINO_RUNTIME_TUNING_REPLACEMENTS` that replace runtime constants to: reduce `TABLE_RADIUS_SCALE` (1.08 -> 0.92), increase `DOMINO_EXTRA_SHRINK_FACTOR` (0.74 -> 1.11) to make dominos ~50% larger, and raise `HAND_Y` / `CHAIN_TILE_Y` offsets to lift dominos slightly upward.
- Bumped `DOMINO_ROYAL_SCRIPT_VERSION` to `2026-04-12-domino-layout-camera-tune-v22` so builds use the new loader behavior.
- Added cleanup to revoke generated blob URLs on React unmount and basic fetch error handling with status messaging.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully (Vite chunk-size and dynamic-import warnings are unchanged and unrelated to this change).
- Verified the change was committed (`webapp/src/pages/Games/DominoRoyalArena.jsx` updated) and no other runtime `.js` files were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbee51f1f48329884679779b0e8ae1)