### PR TITLE
Adjust Chess Battle Royale jet/helicopter fly path, altitude, and speed

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -99,10 +99,10 @@ const CAPTURE_DRONE_TOTAL = CAPTURE_DRONE_LIFT_TIME + CAPTURE_DRONE_CRUISE_TIME 
 const CAPTURE_JET_SPEED_FACTOR = 4.9 / CAPTURE_DRONE_TOTAL; // slower than prior tuning for clearer portrait tracking
 const PROFILE_VIEW_ROTATION_TYPES = new Set(['K', 'N']);
 const PROFILE_VIEW_ROTATION_RADIANS = Math.PI / 2;
-const CAPTURE_JET_TOTAL = 5.2; // just a bit slower pass for better visual tracking
+const CAPTURE_JET_TOTAL = 7.4; // slower cinematic pass so the full fly path is clearly visible
 const CAPTURE_JET_MISSILE_TRAVEL = Math.max(0.28, CAPTURE_JET_TOTAL * (0.96 - 0.56) - 0.1);
-const CAPTURE_HELICOPTER_SPEED_FACTOR = 6.2 / CAPTURE_JET_TOTAL; // keep helicopter pacing aligned with the slightly longer pass
-const CAPTURE_HELICOPTER_TOTAL = 6.2; // just a bit slower than prior tuning
+const CAPTURE_HELICOPTER_SPEED_FACTOR = 8.6 / CAPTURE_JET_TOTAL; // keep helicopter pacing aligned with the slower cinematic loop
+const CAPTURE_HELICOPTER_TOTAL = 8.6; // slower helicopter pass so the board loop remains visible
 const CAPTURE_HELICOPTER_MISSILE_TRAVEL = Math.max(0.28, CAPTURE_HELICOPTER_TOTAL * (0.96 - 0.56) - 0.1);
 const CAPTURE_JET_MISSILE_RELEASE_RATIO = 0.62;
 const CAPTURE_JET_MISSILE_ENTRY_RELEASE_RATIO = 0.56; // release while entering the enemy-side U-turn
@@ -115,8 +115,8 @@ const CAPTURE_JET_SCALE = 0.086; // slightly bigger jet silhouette
 const CAPTURE_HELICOPTER_SCALE = CAPTURE_JET_SCALE * 0.8;
 const CAPTURE_DRONE_ALTITUDE = 1.36;
 const CAPTURE_FLIGHT_ALTITUDE = CAPTURE_DRONE_ALTITUDE;
-const CAPTURE_JET_ALTITUDE = CAPTURE_FLIGHT_ALTITUDE - 1.24; // keep jet lower, closer to board in portrait view
-const CAPTURE_HELICOPTER_ALTITUDE_BOOST = 0.08; // helicopter still above jet, but closer to board
+const CAPTURE_JET_ALTITUDE = CAPTURE_FLIGHT_ALTITUDE - 1.12; // keep aircraft just above piece heads with a visible safety gap
+const CAPTURE_HELICOPTER_ALTITUDE_BOOST = 0.03; // helicopter follows the same low loop with only a slight offset
 const CAPTURE_MISSILE_SCALE = 0.0595;
 const CAPTURE_JAVELIN_MISSILE_SCALE = CAPTURE_MISSILE_SCALE * 1.48; // make javelin missile bigger
 const CAPTURE_EXPLOSION_SCALE = 0.158; // slightly smaller capture explosion
@@ -9102,10 +9102,10 @@ function Chess3D({
       }) => {
         const attackFromTopSide = attackerPos.z >= 0;
         const attackerSideSign = attackFromTopSide ? 1 : -1;
-        const edgeInset = tile * 0.3;
+        const edgeInset = tile * 0.16;
         const attackerLaneZ = attackerSideSign * (half - edgeInset);
         const enemyLaneZ = -attackerSideSign * (half - edgeInset);
-        const xClamp = half * 0.28;
+        const xClamp = half - tile * 0.22;
         const laneX = THREE.MathUtils.clamp(
           THREE.MathUtils.lerp(attackerPos.x, victimPos.x, 0.5),
           -xClamp,
@@ -9119,31 +9119,31 @@ function Chess3D({
         );
         const startPos = new THREE.Vector3(laneX, baseAltitude, attackerLaneZ);
         const entryPos = new THREE.Vector3(
-          THREE.MathUtils.lerp(laneX, victimPos.x, 0.34),
-          baseAltitude - turnAltitudeDrop * 0.28,
-          THREE.MathUtils.lerp(attackerLaneZ, victimPos.z, 0.42)
+          THREE.MathUtils.lerp(laneX, victimPos.x, 0.18),
+          baseAltitude - turnAltitudeDrop * 0.2,
+          THREE.MathUtils.lerp(attackerLaneZ, victimPos.z, 0.2)
         );
         const turnEntryPos = new THREE.Vector3(
-          THREE.MathUtils.lerp(laneX, victimPos.x, 0.86),
-          baseAltitude - turnAltitudeDrop * 0.58,
-          THREE.MathUtils.lerp(victimPos.z, enemyLaneZ, 0.86)
+          THREE.MathUtils.lerp(laneX, victimPos.x, 0.94),
+          baseAltitude - turnAltitudeDrop * 0.38,
+          THREE.MathUtils.lerp(victimPos.z, enemyLaneZ, 0.94)
         );
         const turnExitPos = new THREE.Vector3(
-          THREE.MathUtils.lerp(laneX, victimPos.x, 0.42),
-          baseAltitude - turnAltitudeDrop,
-          THREE.MathUtils.lerp(victimPos.z, enemyLaneZ, 0.9)
+          THREE.MathUtils.lerp(laneX, victimPos.x, 0.16),
+          baseAltitude - turnAltitudeDrop * 0.62,
+          THREE.MathUtils.lerp(victimPos.z, enemyLaneZ, 0.96)
         );
         const turnControlPos = new THREE.Vector3(
           turnBendX,
-          baseAltitude - turnAltitudeDrop * 0.72,
+          baseAltitude - turnAltitudeDrop * 0.54,
           enemyLaneZ
         );
         const returnEntryPos = new THREE.Vector3(
-          THREE.MathUtils.lerp(laneX, victimPos.x, 0.26),
-          baseAltitude - turnAltitudeDrop * 0.4,
-          THREE.MathUtils.lerp(enemyLaneZ, attackerLaneZ, 0.56)
+          THREE.MathUtils.lerp(laneX, victimPos.x, 0.1),
+          baseAltitude - turnAltitudeDrop * 0.28,
+          THREE.MathUtils.lerp(enemyLaneZ, attackerLaneZ, 0.82)
         );
-        const exitPos = new THREE.Vector3(laneX, baseAltitude - turnAltitudeDrop * 0.2, attackerLaneZ);
+        const exitPos = new THREE.Vector3(laneX, baseAltitude, attackerLaneZ);
         return {
           attackFromTopSide,
           startPos,
@@ -9213,7 +9213,7 @@ function Chess3D({
         const path = buildAirStrikePath({
           attackerPos: fromPos,
           victimPos: targetPos,
-          baseAltitude: CAPTURE_JET_ALTITUDE
+          baseAltitude: Math.max(CAPTURE_JET_ALTITUDE, targetPos.y + tile * 0.62)
         });
         jetFx.root.position.copy(path.startPos);
         captureFxGroup.add(jetFx.root);
@@ -9253,7 +9253,7 @@ function Chess3D({
         const path = buildAirStrikePath({
           attackerPos: fromPos,
           victimPos: targetPos,
-          baseAltitude: CAPTURE_JET_ALTITUDE + CAPTURE_HELICOPTER_ALTITUDE_BOOST,
+          baseAltitude: Math.max(CAPTURE_JET_ALTITUDE, targetPos.y + tile * 0.62) + CAPTURE_HELICOPTER_ALTITUDE_BOOST,
           turnAltitudeDrop: 0.06
         });
         helicopterFx.root.position.copy(path.startPos);
@@ -9295,7 +9295,7 @@ function Chess3D({
         const path = buildAirStrikePath({
           attackerPos: fromPos,
           victimPos: targetPos,
-          baseAltitude: CAPTURE_JET_ALTITUDE
+          baseAltitude: Math.max(CAPTURE_JET_ALTITUDE, targetPos.y + tile * 0.62)
         });
         jetFx.root.position.copy(path.startPos);
         captureFxGroup.add(jetFx.root);
@@ -10909,71 +10909,56 @@ function Chess3D({
           } else if (fx.type === 'jet') {
             const jetTimelineU = clamp01(fx.t / CAPTURE_JET_TOTAL);
             const jetU = THREE.MathUtils.lerp(CAPTURE_JET_TRIMMED_START_RATIO, 1, jetTimelineU);
-            const phaseSplit = 0.84; // mirror Ludo fighterJetAttack split
-            const boardInset = tile * 0.28;
-            const boardClamp = half - boardInset;
-            const clampToBoard = (value) => {
-              value.x = THREE.MathUtils.clamp(value.x, -boardClamp, boardClamp);
-              value.z = THREE.MathUtils.clamp(value.z, -boardClamp, boardClamp);
-              return value;
-            };
-            const arenaCenter = new THREE.Vector3(0, fx.from.y, 0);
-            const fromOffset = fx.from.clone().sub(arenaCenter).setY(0);
-            const toOffset = fx.to.clone().sub(arenaCenter).setY(0);
-            const fallbackRadius = boardClamp * 0.64;
-            const fromRadius = Math.max(fromOffset.length(), fallbackRadius);
-            const toRadius = Math.max(toOffset.length(), fallbackRadius);
-            const jetFlightAltitude = Math.max(CAPTURE_JET_ALTITUDE, fx.to.y + Math.max(tile * 0.22, 0.08));
-            const orbitalRadius = Math.min(
-              boardClamp * 0.72,
-              Math.max(fromRadius, toRadius, boardClamp * 0.66)
-            );
-            const fromAngle = Math.atan2(fromOffset.z, fromOffset.x);
-            const toAngle = Math.atan2(toOffset.z, toOffset.x);
-            let angularDelta = toAngle - fromAngle;
-            if (angularDelta <= 0) angularDelta += Math.PI * 2;
-            angularDelta = Math.max(angularDelta + Math.PI * 0.9, Math.PI * 1.8);
-            const cruiseAngle = fromAngle + angularDelta * 0.7;
+            const flyPathNodes = [
+              fx.from,
+              fx.orbitEntryPos,
+              fx.turnEntryPos,
+              fx.turnControlPos,
+              fx.orbitExitPos,
+              fx.returnEntryPos,
+              fx.exitPos
+            ].filter(Boolean);
             const topStrikeHeight = Math.max(tile * 2.2, 0.42);
-            const apex = new THREE.Vector3(
-              arenaCenter.x + Math.cos(cruiseAngle) * orbitalRadius,
-              jetFlightAltitude,
-              arenaCenter.z + Math.sin(cruiseAngle) * orbitalRadius
-            );
-            let jetPos = null;
-            let jetNext = null;
-            const pathAt = (valueU) => {
-              const t = clamp01(valueU);
-              if (t < phaseSplit) {
-                const a = smoothEase(t / phaseSplit);
-                const orbitAngle = fromAngle + angularDelta * a;
-                const ring = new THREE.Vector3(
-                  arenaCenter.x + Math.cos(orbitAngle) * orbitalRadius,
-                  jetFlightAltitude,
-                  arenaCenter.z + Math.sin(orbitAngle) * orbitalRadius
-                );
-                return clampToBoard(fx.from.clone().lerp(ring, 0.78 + a * 0.22));
+            const sampleFlyPath = (pathU) => {
+              const safeU = clamp01(pathU);
+              if (flyPathNodes.length < 2) {
+                const fallback = fx.exitPos?.clone() || fx.from.clone();
+                return { pos: fallback, next: fallback.clone().add(new THREE.Vector3(0.08, 0, 0)) };
               }
-              const d = smoothEase((t - phaseSplit) / (1 - phaseSplit));
-              const toRadial = fx.to.clone().sub(arenaCenter).setY(0);
-              if (toRadial.lengthSq() < 1e-6) {
-                toRadial.set(Math.cos(fromAngle + angularDelta), 0, Math.sin(fromAngle + angularDelta));
-              } else {
-                toRadial.normalize();
+              const segmentLengths = [];
+              let totalLen = 0;
+              for (let idx = 0; idx < flyPathNodes.length - 1; idx += 1) {
+                const len = flyPathNodes[idx].distanceTo(flyPathNodes[idx + 1]);
+                segmentLengths.push(len);
+                totalLen += len;
               }
-              const flyByEnd = fx.to
-                .clone()
-                .add(toRadial.multiplyScalar(orbitalRadius * 0.85))
-                .add(new THREE.Vector3(0, Math.max(tile * 0.08, 0.03), 0));
-              return clampToBoard(qBezier(apex, apex.clone().lerp(flyByEnd, 0.5), flyByEnd, d));
+              const targetDistance = totalLen * safeU;
+              let acc = 0;
+              for (let idx = 0; idx < segmentLengths.length; idx += 1) {
+                const len = segmentLengths[idx];
+                if (targetDistance <= acc + len || idx === segmentLengths.length - 1) {
+                  const localU = len <= 1e-6 ? 0 : (targetDistance - acc) / len;
+                  const pos = flyPathNodes[idx].clone().lerp(flyPathNodes[idx + 1], clamp01(localU));
+                  const nextStep = Math.min(1, safeU + 0.02);
+                  const nextDistance = totalLen * nextStep;
+                  let nextAcc = 0;
+                  for (let n = 0; n < segmentLengths.length; n += 1) {
+                    const nextLen = segmentLengths[n];
+                    if (nextDistance <= nextAcc + nextLen || n === segmentLengths.length - 1) {
+                      const nextLocalU = nextLen <= 1e-6 ? 0 : (nextDistance - nextAcc) / nextLen;
+                      const next = flyPathNodes[n].clone().lerp(flyPathNodes[n + 1], clamp01(nextLocalU));
+                      return { pos, next };
+                    }
+                    nextAcc += nextLen;
+                  }
+                  return { pos, next: pos.clone().add(new THREE.Vector3(0.08, 0, 0)) };
+                }
+                acc += len;
+              }
+              const end = flyPathNodes[flyPathNodes.length - 1].clone();
+              return { pos: end, next: end.clone().add(new THREE.Vector3(0.08, 0, 0)) };
             };
-            if (jetU < 1) {
-              jetPos = pathAt(jetU);
-              jetNext = pathAt(clamp01(jetU + 0.02));
-            } else {
-              jetPos = clampToBoard(fx.exitPos.clone());
-              jetNext = clampToBoard(fx.exitPos.clone().add(new THREE.Vector3(0.08, 0, 0)));
-            }
+            const { pos: jetPos, next: jetNext } = sampleFlyPath(jetU);
             fx.jetFx.root.position.copy(jetPos);
             captureDir.copy(jetNext).sub(jetPos).normalize();
             const jetForward = captureDir.clone();
@@ -11056,73 +11041,56 @@ function Chess3D({
           } else if (fx.type === 'helicopter') {
             const heliTimelineU = clamp01(fx.t / CAPTURE_HELICOPTER_TOTAL);
             const heliU = THREE.MathUtils.lerp(CAPTURE_JET_TRIMMED_START_RATIO, 1, heliTimelineU);
-            const phaseSplit = 0.8; // mirror Ludo helicopterAttack split
-            const boardInset = tile * 0.28;
-            const boardClamp = half - boardInset;
-            const clampToBoard = (value) => {
-              value.x = THREE.MathUtils.clamp(value.x, -boardClamp, boardClamp);
-              value.z = THREE.MathUtils.clamp(value.z, -boardClamp, boardClamp);
-              return value;
-            };
-            const arenaCenter = new THREE.Vector3(0, fx.from.y, 0);
-            const fromOffset = fx.from.clone().sub(arenaCenter).setY(0);
-            const toOffset = fx.to.clone().sub(arenaCenter).setY(0);
-            const fallbackRadius = boardClamp * 0.64;
-            const fromRadius = Math.max(fromOffset.length(), fallbackRadius);
-            const toRadius = Math.max(toOffset.length(), fallbackRadius);
-            const helicopterFlightAltitude = Math.max(
-              CAPTURE_JET_ALTITUDE + CAPTURE_HELICOPTER_ALTITUDE_BOOST,
-              fx.to.y + Math.max(tile * 0.3, 0.11)
-            );
-            const orbitalRadius = Math.min(
-              boardClamp * 0.72,
-              Math.max(fromRadius, toRadius, boardClamp * 0.66)
-            );
-            const fromAngle = Math.atan2(fromOffset.z, fromOffset.x);
-            const toAngle = Math.atan2(toOffset.z, toOffset.x);
-            let angularDelta = toAngle - fromAngle;
-            if (angularDelta <= 0) angularDelta += Math.PI * 2;
-            if (angularDelta < Math.PI / 3) angularDelta += Math.PI * 2;
-            const cruiseAngle = fromAngle + angularDelta * 0.7;
+            const flyPathNodes = [
+              fx.from,
+              fx.orbitEntryPos,
+              fx.turnEntryPos,
+              fx.turnControlPos,
+              fx.orbitExitPos,
+              fx.returnEntryPos,
+              fx.exitPos
+            ].filter(Boolean);
             const topStrikeHeight = Math.max(tile * 2.2, 0.42);
-            const apex = new THREE.Vector3(
-              arenaCenter.x + Math.cos(cruiseAngle) * orbitalRadius,
-              helicopterFlightAltitude,
-              arenaCenter.z + Math.sin(cruiseAngle) * orbitalRadius
-            );
-            let heliPos = null;
-            let heliNext = null;
-            const pathAt = (valueU) => {
-              const t = clamp01(valueU);
-              if (t < phaseSplit) {
-                const a = smoothEase(t / phaseSplit);
-                const orbitAngle = fromAngle + angularDelta * a;
-                const ring = new THREE.Vector3(
-                  arenaCenter.x + Math.cos(orbitAngle) * orbitalRadius,
-                  helicopterFlightAltitude,
-                  arenaCenter.z + Math.sin(orbitAngle) * orbitalRadius
-                );
-                return clampToBoard(fx.from.clone().lerp(ring, 0.78 + a * 0.22));
+            const sampleFlyPath = (pathU) => {
+              const safeU = clamp01(pathU);
+              if (flyPathNodes.length < 2) {
+                const fallback = fx.exitPos?.clone() || fx.from.clone();
+                return { pos: fallback, next: fallback.clone().add(new THREE.Vector3(0.08, 0, 0)) };
               }
-              const d = smoothEase((t - phaseSplit) / (1 - phaseSplit));
-              const retreatDir = apex.clone().sub(fx.to).setY(0);
-              if (retreatDir.lengthSq() < 1e-6) {
-                retreatDir.set(Math.cos(fromAngle + angularDelta), 0, Math.sin(fromAngle + angularDelta));
+              const segmentLengths = [];
+              let totalLen = 0;
+              for (let idx = 0; idx < flyPathNodes.length - 1; idx += 1) {
+                const len = flyPathNodes[idx].distanceTo(flyPathNodes[idx + 1]);
+                segmentLengths.push(len);
+                totalLen += len;
               }
-              retreatDir.normalize();
-              const flyAwayEnd = apex
-                .clone()
-                .add(retreatDir.multiplyScalar(orbitalRadius * 1.35))
-                .add(new THREE.Vector3(0, Math.max(tile * 0.08, 0.03), 0));
-              return clampToBoard(qBezier(apex, apex.clone().lerp(flyAwayEnd, 0.5), flyAwayEnd, d));
+              const targetDistance = totalLen * safeU;
+              let acc = 0;
+              for (let idx = 0; idx < segmentLengths.length; idx += 1) {
+                const len = segmentLengths[idx];
+                if (targetDistance <= acc + len || idx === segmentLengths.length - 1) {
+                  const localU = len <= 1e-6 ? 0 : (targetDistance - acc) / len;
+                  const pos = flyPathNodes[idx].clone().lerp(flyPathNodes[idx + 1], clamp01(localU));
+                  const nextStep = Math.min(1, safeU + 0.02);
+                  const nextDistance = totalLen * nextStep;
+                  let nextAcc = 0;
+                  for (let n = 0; n < segmentLengths.length; n += 1) {
+                    const nextLen = segmentLengths[n];
+                    if (nextDistance <= nextAcc + nextLen || n === segmentLengths.length - 1) {
+                      const nextLocalU = nextLen <= 1e-6 ? 0 : (nextDistance - nextAcc) / nextLen;
+                      const next = flyPathNodes[n].clone().lerp(flyPathNodes[n + 1], clamp01(nextLocalU));
+                      return { pos, next };
+                    }
+                    nextAcc += nextLen;
+                  }
+                  return { pos, next: pos.clone().add(new THREE.Vector3(0.08, 0, 0)) };
+                }
+                acc += len;
+              }
+              const end = flyPathNodes[flyPathNodes.length - 1].clone();
+              return { pos: end, next: end.clone().add(new THREE.Vector3(0.08, 0, 0)) };
             };
-            if (heliU < 1) {
-              heliPos = pathAt(heliU);
-              heliNext = pathAt(clamp01(heliU + 0.02));
-            } else {
-              heliPos = clampToBoard(fx.exitPos.clone());
-              heliNext = clampToBoard(fx.exitPos.clone().add(new THREE.Vector3(0.08, 0, 0)));
-            }
+            const { pos: heliPos, next: heliNext } = sampleFlyPath(heliU);
             fx.helicopterFx.root.position.copy(heliPos);
             captureDir.copy(heliNext).sub(heliPos).normalize();
             const heliForward = captureDir.clone();


### PR DESCRIPTION
### Motivation
- Make the jet and helicopter capture passes follow a precise, repeatable perimeter-style fly path and slow the runs so the full trajectory is visible in portrait gameplay.
- Keep aircraft cruising just above piece heads with a consistent, small safety gap so effects read clearly on-screen.

### Description
- Increased capture durations (`CAPTURE_JET_TOTAL` -> `7.4`, `CAPTURE_HELICOPTER_TOTAL` -> `8.6`) and adjusted related speed factors to create a slower, cinematic pass.
- Tuned cruising heights (`CAPTURE_JET_ALTITUDE` and `CAPTURE_HELICOPTER_ALTITUDE_BOOST`) and enforced per-target altitude clamping when creating airstrike paths (`baseAltitude: Math.max(CAPTURE_JET_ALTITUDE, targetPos.y + tile * 0.62)`), so aircraft fly just above piece heads with a consistent gap.
- Re-shaped air-strike control points in `buildAirStrikePath` (smaller `edgeInset`, modified `xClamp`, and adjusted `entry/turn/return/exit` positions) so paths hug the board perimeter more closely and match the marked visual route.
- Replaced the previous orbital runtime math with distance-based sampling of precomputed path nodes for both `jet` and `helicopter` (collecting `orbitEntryPos`, `turnEntryPos`, `turnControlPos`, `orbitExitPos`, `returnEntryPos`, `exitPos`) so the runtime movement follows an exact, repeatable fly path.
- File changed: `webapp/src/pages/Games/ChessBattleRoyal.jsx`.

### Testing
- Ran `npm -C webapp run build` and the production build completed successfully (vite build finished; assets emitted). 
- Build reported chunk-size warnings for large bundles but finished without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbed91be888329aea59d8ac0d79dde)