### PR TITLE
Lower fighter jet and drone flight heights in Chess Royale

### DIFF
--- a/webapp/public/chess-royale.html
+++ b/webapp/public/chess-royale.html
@@ -247,7 +247,7 @@ const MISSILE_HEIGHT=0.095;
 const MISSILE_SIZE=0.02;
 const MISSILE_TRAIL_COUNT=5;
 const MISSILE_TRAIL_SPACING=0.08;
-const JET_HEIGHT=0.19;
+const JET_HEIGHT=0.165;
 const JET_SIZE=0.31;
 const JET_SPEED_FACTOR=2.0; // keep jet and jet-fired missile travel at 50% slower pacing
 const DRONE_SIZE=0.048;
@@ -705,8 +705,8 @@ function animateDroneKamikaze(from,to){
     const smokeTrail=new THREE.Mesh(new THREE.SphereGeometry(0.024,8,8), new THREE.MeshBasicMaterial({color:0x9ca3af, transparent:true, opacity:0.72}));
     const blast=new THREE.Mesh(new THREE.SphereGeometry(0.07,12,12), new THREE.MeshBasicMaterial({color:0xfb7185, transparent:true, opacity:0}));
     drone.add(body,propHub,propBladeA,propBladeB);
-    const start=from.clone().add(new THREE.Vector3(0,0.09,0));
-    const end=to.clone().add(new THREE.Vector3(Math.sign((to.x-from.x)||1)*0.17,0.11,Math.sign((to.z-from.z)||1)*0.17));
+    const start=from.clone().add(new THREE.Vector3(0,0.075,0));
+    const end=to.clone().add(new THREE.Vector3(Math.sign((to.x-from.x)||1)*0.17,0.095,Math.sign((to.z-from.z)||1)*0.17));
     const radius=Math.max(0.3,Math.min(0.66,from.distanceTo(to)*0.24));
     drone.position.copy(start); smokeTrail.position.copy(start); blast.position.copy(to.clone().add(new THREE.Vector3(0,0.17,0)));
     scene.add(drone); scene.add(smokeTrail); scene.add(blast); playDroneSound();
@@ -718,7 +718,7 @@ function animateDroneKamikaze(from,to){
       const midB=start.clone().lerp(end,0.62).add(new THREE.Vector3(-radius*0.72,0.035,-radius*0.88));
       const p=cubic(start,midA,midB,end,t);
       drone.position.copy(p);
-      drone.position.y=Math.max(boardY+0.075,p.y);
+      drone.position.y=Math.max(boardY+0.06,p.y);
       smokeTrail.position.lerpVectors(start,p,0.9);
       smokeTrail.material.opacity=0.72*(1-t);
       propHub.rotation.x=t*Math.PI*24;


### PR DESCRIPTION
### Motivation
- Improve on-screen visuals by bringing the fighter jet and kamikaze drone flight paths closer to the chess board so passes look nearer to the play surface on portrait/mobile screens.

### Description
- Adjusted flight path tuning in `webapp/public/chess-royale.html`: reduced `JET_HEIGHT` from `0.19` to `0.165`, lowered drone start/end Y offsets (`0.09` → `0.075`, `0.11` → `0.095`) and reduced the in-flight clamp from `boardY + 0.075` to `boardY + 0.06` so both jet and drone routes stay visually closer to the board.

### Testing
- Performed repository checks (`git diff -- webapp/public/chess-royale.html` and `nl -ba webapp/public/chess-royale.html | sed -n '240,260p;700,730p'`) and committed the change; the checks and commit completed successfully and no automated runtime tests were executed because this is a visual tuning change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbfa6386988329bd9916c2332dbf01)