### PR TITLE
Ludo: center board vertical line, re-enable broadcast follow, and raise camera framing

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1428,14 +1428,14 @@ const CAMERA_NEAR = ARENA_CAMERA_DEFAULTS.near;
 const CAMERA_FAR = ARENA_CAMERA_DEFAULTS.far;
 const CAMERA_DOLLY_FACTOR = ARENA_CAMERA_DEFAULTS.wheelDeltaFactor;
 const CAMERA_TARGET_LIFT = 0.028 * MODEL_SCALE;
-const CAMERA_SIDE_LOOK_EXTRA = 0.72 * MODEL_SCALE;
+const CAMERA_SIDE_LOOK_EXTRA = 0;
 const CAMERA_TURN_PLAYER_LERP = 0.44;
 const CAMERA_BROADCAST_TARGET_BLEND = 0;
 const CAMERA_SIDE_AVATAR_BLEND = 0.84;
 const USER_TURN_CAMERA_PULLBACK = 0.15 * MODEL_SCALE;
 const USER_TURN_CAMERA_LIFT = 0.09 * MODEL_SCALE;
 const LUDO_CAMERA_AUTO_LOOK_ENABLED = true;
-const LUDO_CAMERA_BROADCAST_LOCKED_POSITION = true;
+const LUDO_CAMERA_BROADCAST_LOCKED_POSITION = false;
 const CAMERA_FREE_LOOK_AZIMUTH_RANGE = THREE.MathUtils.degToRad(26);
 const CAMERA_FREE_LOOK_POLAR_DELTA = THREE.MathUtils.degToRad(16);
 const CAMERA_ZOOM_MIN_FACTOR = 1;
@@ -1455,7 +1455,7 @@ const PORTRAIT_CAMERA_TUNING = Object.freeze({
   targetLift: 0.055 * MODEL_SCALE
 });
 const CAMERA_EXTRA_PULLBACK = 0;
-const CAMERA_EXTRA_LIFT = 0.044;
+const CAMERA_EXTRA_LIFT = 0.058;
 const PORTRAIT_CAMERA_EXTRA_LIFT = 0.04;
 const CAMERA_LOOK_YAW_LIMIT = THREE.MathUtils.degToRad(26);
 const CAMERA_LOOK_YAW_DRAG_FACTOR = 0.0055;
@@ -5632,6 +5632,14 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     );
     boardLookTargetRef.current = boardLookTarget;
     const initialCameraDirection = camera.position.clone().sub(boardLookTarget).normalize();
+    if (Math.abs(initialCameraDirection.x) > 1e-4) {
+      const zSign = Math.sign(initialCameraDirection.z) || 1;
+      initialCameraDirection.set(
+        0,
+        initialCameraDirection.y,
+        zSign * Math.max(Math.abs(initialCameraDirection.z), 1e-3)
+      ).normalize();
+    }
     const initialDistanceFactor = isPortrait ? PORTRAIT_INITIAL_CAMERA_DISTANCE_FACTOR : INITIAL_CAMERA_DISTANCE_FACTOR;
     const desiredInitialCameraRadius = clamp(CAM.maxR * initialDistanceFactor, CAM.minR, CAM.maxR);
     camera.position.copy(boardLookTarget).add(initialCameraDirection.multiplyScalar(desiredInitialCameraRadius));


### PR DESCRIPTION
### Motivation
- Improve portrait framing so the board vertical line sits in the center of the screen and the camera feels slightly higher for better visibility.  
- Restore dynamic broadcast behaviour so the camera looks toward the dice, next player turn, and token movement rather than remaining locked.  
- Remove lateral side-offsets during turn transitions to keep the board visually centered during player turns.

### Description
- Changed `LUDO_CAMERA_BROADCAST_LOCKED_POSITION` from `true` to `false` to re-enable dynamic broadcast following during live actions.  
- Increased `CAMERA_EXTRA_LIFT` from `0.044` to `0.058` to raise the 3D camera framing for portrait screens.  
- Set `CAMERA_SIDE_LOOK_EXTRA` to `0` (was `0.72 * MODEL_SCALE`) to remove side look nudges and keep the board center aligned during turn views.  
- Adjusted initial camera direction calculation to zero out lateral X drift so the initial camera yaw is straight down the board axis (added logic near `initialCameraDirection` to keep X=0 and preserve Z sign).

All changes are in `webapp/src/pages/Games/LudoBattleRoyal.jsx`.

### Testing
- Ran `npx eslint webapp/src/pages/Games/LudoBattleRoyal.jsx` which produced a repo ignore warning for the file (no lint errors from the changed code).  
- Ran unit tests with `npm test -- --runInBand test/onlineGamePolicy.test.js` and the suite passed (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc0681f62c83298b98ce8d7fd07fa4)