### PR TITLE
Adjust Ludo Battle Royal camera framing and broadcast focus behavior

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1451,12 +1451,13 @@ const LANDSCAPE_CAMERA_TUNING = Object.freeze({
 const PORTRAIT_CAMERA_TUNING = Object.freeze({
   backOffset: 0.74,
   forwardOffset: 0,
-  heightOffset: 2.22,
+  heightOffset: 2.3,
   targetLift: 0.055 * MODEL_SCALE
 });
 const CAMERA_EXTRA_PULLBACK = 0;
 const CAMERA_EXTRA_LIFT = 0.044;
 const PORTRAIT_CAMERA_EXTRA_LIFT = 0.04;
+const CAMERA_PLAYER_CENTER_X_EPSILON = 0.0001;
 const CAMERA_LOOK_YAW_LIMIT = THREE.MathUtils.degToRad(26);
 const CAMERA_LOOK_YAW_DRAG_FACTOR = 0.0055;
 const CAMERA_LOOK_PITCH_LIMIT = THREE.MathUtils.degToRad(22);
@@ -7093,9 +7094,19 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     if (player === 0) {
       const initialBottomView = initialBottomCameraViewRef.current;
       if (initialBottomView?.position?.isVector3 && initialBottomView?.target?.isVector3) {
+        const boardLookTarget = boardLookTargetRef.current;
+        const alignedPosition = initialBottomView.position.clone();
+        const alignedTarget = initialBottomView.target.clone();
+        if (boardLookTarget?.isVector3) {
+          alignedPosition.x = boardLookTarget.x;
+          alignedTarget.x = boardLookTarget.x;
+          if (Math.abs(alignedTarget.z - boardLookTarget.z) > CAMERA_PLAYER_CENTER_X_EPSILON) {
+            alignedTarget.z = boardLookTarget.z;
+          }
+        }
         cameraTurnStateRef.current.baseTurnView = {
-          position: initialBottomView.position.clone(),
-          target: initialBottomView.target.clone()
+          position: alignedPosition,
+          target: alignedTarget
         };
         animateCameraPose(
           cameraTurnStateRef.current.baseTurnView.target,
@@ -7208,7 +7219,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     const state = stateRef.current;
     if (!state) return;
     const { skipCameraFollow = false } = options;
-    const shouldFollowCamera = !skipCameraFollow && player !== 0;
+    const shouldFollowCamera = !skipCameraFollow;
     const fromProgress = state.progress[player][tokenIndex];
     const path = [];
     if (fromProgress < 0) {


### PR DESCRIPTION
### Motivation
- Improve portrait framing so the Ludo board reads centered and a bit higher on mobile portrait screens. 
- Restore broadcast camera behavior so token movement, dice rolls and turn-focus consistently direct the camera as intended.

### Description
- Raised the portrait baseline by changing `PORTRAIT_CAMERA_TUNING.heightOffset` from `2.22` to `2.3` in `webapp/src/pages/Games/LudoBattleRoyal.jsx` to lift the view slightly. 
- When restoring the player-0 (user) turn view, align the saved camera `position` and `target` X coordinate to the board center (`boardLookTarget.x`) and snap the target Z when it deviates, so the board's vertical line appears centered. 
- Allow camera-follow for token movement for any player by changing the follow condition in `scheduleMove` so `shouldFollowCamera` is `!skipCameraFollow` (previously excluded player 0), restoring expected broadcast follow behavior.

### Testing
- Ran `npm --prefix webapp run build` and the Vite production build completed successfully, producing the application bundle. 
- Verified the modified file compiles as part of the production bundle and build artifacts were emitted without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc0681f62c83298b98ce8d7fd07fa4)