### PR TITLE
Tune Ludo Battle Royal camera turn behavior and token styling

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1428,7 +1428,7 @@ const CAMERA_NEAR = ARENA_CAMERA_DEFAULTS.near;
 const CAMERA_FAR = ARENA_CAMERA_DEFAULTS.far;
 const CAMERA_DOLLY_FACTOR = ARENA_CAMERA_DEFAULTS.wheelDeltaFactor;
 const CAMERA_TARGET_LIFT = 0.028 * MODEL_SCALE;
-const CAMERA_SIDE_LOOK_EXTRA = 0;
+const CAMERA_SIDE_LOOK_EXTRA = 0.085 * MODEL_SCALE;
 const CAMERA_TURN_PLAYER_LERP = 0.44;
 const CAMERA_BROADCAST_TARGET_BLEND = 0;
 const CAMERA_SIDE_AVATAR_BLEND = 0.84;
@@ -1732,7 +1732,7 @@ function measureProceduralTokenHeight() {
   return proceduralTokenHeight;
 }
 
-const STANDARD_TOKEN_FOOTPRINT = Object.freeze({ x: 0.054, z: 0.054 });
+const STANDARD_TOKEN_FOOTPRINT = Object.freeze({ x: 0.05, z: 0.05 });
 
 function abgPreparePiece(src) {
   const clone = abgCloneWithMats(src);
@@ -3711,6 +3711,12 @@ function clearTokenHighlight(token) {
   setTokenHighlight(token, false);
 }
 
+function applyTokenIdleRotation(token) {
+  if (!token) return;
+  const baseY = Number.isFinite(token.userData?.baseRotationY) ? token.userData.baseRotationY : 0;
+  token.rotation.set(0, baseY, 0);
+}
+
 const areColorArraysEqual = (a = [], b = []) => {
   if (a.length !== b.length) return false;
   return a.every((value, idx) => value === b[idx]);
@@ -5038,7 +5044,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         const target = home.clone();
         target.y = homeHeight;
         token.position.copy(target);
-        token.rotation.set(0, 0, 0);
+        applyTokenIdleRotation(token);
       }
     });
 
@@ -7547,7 +7553,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       const pos = state.startPads[player][token].clone();
       pos.y = getTokenRailHeight(player);
       tokenNode.position.copy(pos);
-      tokenNode.rotation.set(0, 0, 0);
+      applyTokenIdleRotation(tokenNode);
       opponents.push(resolvePlayerLabel(player));
     });
     return { count: opponents.length, opponents };
@@ -7586,7 +7592,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       const finalPos = getWorldForProgress(player, target, tokenIndex);
       state.progress[player][tokenIndex] = target;
       state.tokens[player][tokenIndex].position.copy(finalPos);
-      state.tokens[player][tokenIndex].rotation.set(0, 0, 0);
+      applyTokenIdleRotation(state.tokens[player][tokenIndex]);
       updateTokenStacks();
       const winner = checkWin(player);
       advanceTurn(!winner && roll === 6);
@@ -7679,7 +7685,6 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       offset: CAMERA_TARGET_LIFT + 0.03
     });
     playDiceSound();
-    const landingFocus = baseTarget.clone();
     const value = await spinDice(dice, {
       duration: resolveFrameSyncedDuration(AUTO_ROLL_DURATION_MS, { min: 620, max: 1400 }),
       targetPosition: baseTarget,
@@ -7697,16 +7702,6 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     scheduleDiceClear();
     const options = getMovableTokens(player, value);
     const hasBoardTokenBeforeRoll = hasAnyTokenOnBoard(player);
-    if (options.length) {
-      setCameraFocus({
-        target: landingFocus,
-        follow: false,
-        ttl: 1.2,
-        priority: 2,
-        offset: CAMERA_TARGET_LIFT + 0.03,
-        force: true
-      });
-    }
     if (!options.length) {
       const playerCycle = Math.max(1, activePlayerCount);
       const upcomingTurn = value === 6 ? player : (player + playerCycle - 1) % playerCycle;
@@ -7735,7 +7730,10 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       }, DICE_RESULT_EXTRA_HOLD_MS);
       return;
     }
-    moveToken(player, choice.token, value, { skipCameraFollow: !hasBoardTokenBeforeRoll });
+    if (hasBoardTokenBeforeRoll) {
+      setCameraViewForTurn(player, CAMERA_TURN_VIEW_DURATION_MS, { force: true });
+    }
+    moveToken(player, choice.token, value, { skipCameraFollow: true });
   };
 
   rollDiceRef.current = rollDice;
@@ -8315,10 +8313,13 @@ async function buildLudoBoard(
           token.scale.z * typeScale.z
         );
       }
+      let baseRotationY = 0;
       if (typeKey === 'king') {
-        token.rotation.y = Math.PI;
+        baseRotationY = Math.PI;
+        token.rotation.y = baseRotationY;
       } else if (typeKey === 'knight' || typeKey === 'horse') {
-        token.rotation.y = Math.PI / 4;
+        baseRotationY = Math.PI / 4;
+        token.rotation.y = baseRotationY;
       }
       const label = createTokenCountLabel();
       if (label) {
@@ -8330,6 +8331,7 @@ async function buildLudoBoard(
       token.userData.tokenType = type;
       token.userData.playerIndex = playerIdx;
       token.userData.tokenIndex = i;
+      token.userData.baseRotationY = baseRotationY;
       token.traverse((node) => {
         if (!node.userData) node.userData = {};
         node.userData.tokenGroup = token;


### PR DESCRIPTION
### Motivation
- Improve camera framing so left/right seat turns look further toward their avatars, making players more visible when viewing left/right turns.
- Keep camera behavior focused on the active player and dice where appropriate and avoid refocusing to the board when there is no token movement.
- Make tokens visually a bit thinner and preserve intentional model orientations (e.g., king rotated 180°) across resets and moves.

### Description
- Increased the side-seat camera bias by changing `CAMERA_SIDE_LOOK_EXTRA` to `0.085 * MODEL_SCALE` so left/right player turns look more left/right.
- Reduced the procedural token footprint by updating `STANDARD_TOKEN_FOOTPRINT` from `{ x: 0.054, z: 0.054 }` to `{ x: 0.05, z: 0.05 }` to produce slightly thinner tokens.
- Added `applyTokenIdleRotation(token)` and stored `token.userData.baseRotationY` for tokens so base orientation (e.g., `king` at `Math.PI`) is preserved; applied this helper wherever tokens were previously reset to `rotation.set(0,0,0)`.
- Adjusted dice/turn camera flow: removed the intermediate board refocus to dice landing, and for AI moves the flow now sets the stable turn view when the player already has tokens on board and calls `moveToken(..., { skipCameraFollow: true })` to avoid unnecessary board-look camera cuts.

### Testing
- Ran `npx eslint --no-ignore webapp/src/pages/Games/LudoBattleRoyal.jsx`; the lint run completed but the file is currently ignored by repo eslint config which produced a warning and no lint errors.
- No unit tests were changed or executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc6eb3bf008329af47eea74efcb8cf)