### PR TITLE
Scale down Four In Row table & chairs (~30%) and preserve camera framing

### DIFF
--- a/webapp/src/pages/Games/FourInRowRoyal.jsx
+++ b/webapp/src/pages/Games/FourInRowRoyal.jsx
@@ -43,9 +43,11 @@ import { fourInRowAccountId, getFourInRowInventory } from '../../utils/fourInRow
 import { applyRendererSRGB } from '../../utils/colorSpace.js';
 
 const MODEL_SCALE = 0.75;
-const TABLE_RADIUS = 3.4 * MODEL_SCALE;
+const TABLE_AND_CHAIR_SCALE = 0.7;
+const TABLE_RADIUS = 3.4 * MODEL_SCALE * TABLE_AND_CHAIR_SCALE;
 const TABLE_HEIGHT = 1.2;
 const CHAIR_DISTANCE = TABLE_RADIUS + 1.3;
+const CAMERA_RADIUS_COMPENSATION = (3.4 * MODEL_SCALE + 1.3) - CHAIR_DISTANCE;
 const BOARD_TABLE_CLEARANCE = 0.2;
 const BOARD_VERTICAL_LIFT = 0.06;
 const INTRO_MESSAGE_DURATION_MS = 2200;
@@ -64,9 +66,13 @@ const DROP_PREVIEW_DELAY = 0.09;
 const DROP_BASE_DURATION = 0.2;
 const DROP_ROW_DURATION_STEP = 0.03;
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/v1/decoders/';
-const TARGET_CHAIR_SIZE = new THREE.Vector3(1.3162499970197679, 1.9173749900311232, 1.7001562547683715);
-const TARGET_CHAIR_MIN_Y = -0.8570624993294478;
-const TARGET_CHAIR_CENTER_Z = -0.1553906416893005;
+const TARGET_CHAIR_SIZE = new THREE.Vector3(
+  1.3162499970197679 * TABLE_AND_CHAIR_SCALE,
+  1.9173749900311232 * TABLE_AND_CHAIR_SCALE,
+  1.7001562547683715 * TABLE_AND_CHAIR_SCALE
+);
+const TARGET_CHAIR_MIN_Y = -0.8570624993294478 * TABLE_AND_CHAIR_SCALE;
+const TARGET_CHAIR_CENTER_Z = -0.1553906416893005 * TABLE_AND_CHAIR_SCALE;
 
 const GRAPHICS_PRESETS = Object.freeze([
   { id: 'balanced', label: 'Balanced', pixelRatioScale: 1, shadowMapSize: 1024 },
@@ -553,7 +559,7 @@ export default function FourInRowRoyal() {
     const perspective = new THREE.PerspectiveCamera(47, 1, 0.1, 200);
     const isPortrait = mount.clientHeight > mount.clientWidth;
     const cameraSeatAngle = Math.PI / 2;
-    const cameraBackOffset = (isPortrait ? 2.55 : 1.78) + 0.35;
+    const cameraBackOffset = (isPortrait ? 2.55 : 1.78) + 0.35 + CAMERA_RADIUS_COMPENSATION;
     const cameraForwardOffset = isPortrait ? 0.08 : 0.2;
     const cameraHeightOffset = isPortrait ? 1.86 : 1.44;
     const cameraRadius = CHAIR_DISTANCE + cameraBackOffset - cameraForwardOffset;


### PR DESCRIPTION
### Motivation
- Reduce the visual size of the Four In Row table and chairs by ~30% to match a requested smaller arena footprint. 
- Ensure imported chair models and procedural chairs match the new scale so they remain aligned with the board and floor.
- Keep the initial camera framing visually consistent after the scale change so the portrait layout composition is unchanged.

### Description
- Introduced `TABLE_AND_CHAIR_SCALE = 0.7` and applied it to the table geometry by updating `TABLE_RADIUS` calculation in `webapp/src/pages/Games/FourInRowRoyal.jsx`.
- Adjusted chair-related fitting targets (`TARGET_CHAIR_SIZE`, `TARGET_CHAIR_MIN_Y`, `TARGET_CHAIR_CENTER_Z`) so GLTF/polyhaven chairs are scaled and positioned consistently with the smaller props.
- Added `CAMERA_RADIUS_COMPENSATION` and applied it to the camera setup (`cameraBackOffset`) so the initial camera radius/position preserves the previous visual framing despite smaller table/chairs.

### Testing
- Ran `npx eslint webapp/src/pages/Games/FourInRowRoyal.jsx`, which reported the file is ignored by the repo lint ignore pattern (no lint errors for the change in this environment).
- Ran `npx eslint --no-ignore webapp/src/pages/Games/FourInRowRoyal.jsx`, which produced the same ignore-related warning but no other lint errors.
- No additional automated unit or runtime tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc728334848329804081920f999ea3)