### PR TITLE
Fix power transfer from slider to cue; ensure impact commit and safe cue timing

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -22707,9 +22707,15 @@ const powerRef = useRef(hud.power);
           } = stroke;
           const elapsed = Math.max(0, now - startTime);
           if (forwardOnly) {
-            const safeStrikeDuration = Math.max(1, strikeDuration ?? 120);
-            const safeHoldDuration = Math.max(0, holdDuration ?? 50);
-            const safeRecoverDuration = Math.max(0, recoverDuration ?? 0);
+            const safeStrikeDuration = Number.isFinite(strikeDuration)
+              ? Math.max(1, strikeDuration)
+              : 120;
+            const safeHoldDuration = Number.isFinite(holdDuration)
+              ? Math.max(0, holdDuration)
+              : 50;
+            const safeRecoverDuration = Number.isFinite(recoverDuration)
+              ? Math.max(0, recoverDuration)
+              : 0;
             const pushT = THREE.MathUtils.clamp(elapsed / safeStrikeDuration, 0, 1);
             const easedPush = easeOutCubic(pushT);
             const normalizedStroke = ensureCueStrokeForwardMotion({
@@ -22771,6 +22777,10 @@ const powerRef = useRef(hud.power);
             cueStick.rotation.x = baseRotationX ?? cueStick.rotation.x;
             cueStick.rotation.y = baseRotationY ?? cueStick.rotation.y;
             cueStick.visible = false;
+            if (!stroke.shotApplied) {
+              stroke.shotApplied = true;
+              stroke.onImpact?.();
+            }
             syncCueShadow();
             cueAnimating = false;
             cuePullCurrentRef.current = 0;
@@ -26065,7 +26075,7 @@ const powerRef = useRef(hud.power);
           currentHud?.over ||
           replayPlaybackRef.current
         )
-          return;
+          return false;
         if (breakWinnerSeatRef.current === 'A') {
           breakWinnerSeatRef.current = null;
         }
@@ -26692,6 +26702,7 @@ const powerRef = useRef(hud.power);
               updateCamera();
             }
           }
+          return true;
         };
         let aiThinkingHandle = null;
         const planKey = (plan) =>
@@ -32448,8 +32459,11 @@ const powerRef = useRef(hud.power);
       onStart: () => {
         captureCueStickAnchor();
       },
-      onCommit: () => {
-        fireRef.current?.();
+      onCommit: (value) => {
+        const committedPower = Number.isFinite(value) ? value / 100 : slider.get() / 100;
+        applyPower(committedPower);
+        const fired = fireRef.current?.();
+        if (!fired) return;
         requestAnimationFrame(() => {
           slider.set(slider.min, { animate: true });
           applyPower(0);


### PR DESCRIPTION
### Motivation
- The cue stick animation could finish without applying the impact when timing inputs were invalid, causing the cue ball to receive no velocity despite the slider being pulled. 
- The power slider reset logic cleared the visible slider value even when a shot did not actually start, breaking the user expectation that the released power is applied to the shot.

### Description
- Added safe finite fallbacks for forward-only cue stroke durations so the forward strike phase cannot be skipped when duration inputs are invalid. (update in `webapp/src/pages/Games/PoolRoyale.jsx`).
- Added a fallback impact commit at the end of the forward-only cue animation path so the shot always transfers impulse/spin to the cue ball if the normal impact threshold was missed. (update in `webapp/src/pages/Games/PoolRoyale.jsx`).
- Made `fire()` return a boolean (`false` if preconditions prevent firing, `true` when a shot is started) and used that to guard the slider reset so power is only cleared when a shot actually begins. (update in `webapp/src/pages/Games/PoolRoyale.jsx`).
- Changed slider `onCommit` handling to capture the committed slider value immediately, apply that power to HUD state, then call `fire()` and only reset the slider/power when `fire()` indicates a shot started. (update in `webapp/src/pages/Games/PoolRoyale.jsx`).

### Testing
- Built the project with `npm run build` and the build succeeded. 
- Ran the unit tests `npm test -- --runInBand test/poolRoyaleCueStrokeTimeline.test.js test/cueShotImpact.test.js` and both test suites passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc765782548329b70b80e4a2ebfaa4)