### PR TITLE
Ludo Battle Royal: improve turn broadcast camera and ABG token scale/orientation

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1428,10 +1428,10 @@ const CAMERA_NEAR = ARENA_CAMERA_DEFAULTS.near;
 const CAMERA_FAR = ARENA_CAMERA_DEFAULTS.far;
 const CAMERA_DOLLY_FACTOR = ARENA_CAMERA_DEFAULTS.wheelDeltaFactor;
 const CAMERA_TARGET_LIFT = 0.028 * MODEL_SCALE;
-const CAMERA_SIDE_LOOK_EXTRA = 0.075;
+const CAMERA_SIDE_LOOK_EXTRA = 0.14;
 const CAMERA_TURN_PLAYER_LERP = 0.52;
 const CAMERA_BROADCAST_TARGET_BLEND = 0;
-const CAMERA_SIDE_AVATAR_BLEND = 0.84;
+const CAMERA_SIDE_AVATAR_BLEND = 1.1;
 const USER_TURN_CAMERA_PULLBACK = 0.15 * MODEL_SCALE;
 const USER_TURN_CAMERA_LIFT = 0.09 * MODEL_SCALE;
 const LUDO_CAMERA_AUTO_LOOK_ENABLED = true;
@@ -1732,7 +1732,7 @@ function measureProceduralTokenHeight() {
   return proceduralTokenHeight;
 }
 
-const STANDARD_TOKEN_FOOTPRINT = Object.freeze({ x: 0.054, z: 0.054 });
+const STANDARD_TOKEN_FOOTPRINT = Object.freeze({ x: 0.05, z: 0.05 });
 
 function abgPreparePiece(src) {
   const clone = abgCloneWithMats(src);
@@ -1796,11 +1796,11 @@ function resolveAbgPrototype(proto, colorKey, type) {
 function applyTokenFacingRotation(token) {
   if (!token?.rotation) return;
   const typeKey = String(token.userData?.tokenType || '').toLowerCase();
-  if (typeKey === 'king') {
+  if (typeKey === 'king' || typeKey === 'k') {
     token.rotation.set(0, Math.PI, 0);
     return;
   }
-  if (typeKey === 'knight' || typeKey === 'horse') {
+  if (typeKey === 'knight' || typeKey === 'horse' || typeKey === 'n') {
     token.rotation.set(0, Math.PI / 4, 0);
     return;
   }
@@ -7712,7 +7712,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     scheduleDiceClear();
     const options = getMovableTokens(player, value);
     const hasBoardTokenBeforeRoll = hasAnyTokenOnBoard(player);
-    if (options.length) {
+    if (options.length && !hasBoardTokenBeforeRoll) {
       setCameraFocus({
         target: landingFocus,
         follow: false,
@@ -7732,6 +7732,10 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         advanceTurn(value === 6);
       }, 900);
       return;
+    }
+    if (hasBoardTokenBeforeRoll) {
+      setCameraViewForTurn(player, CAMERA_TURN_VIEW_DURATION_MS, { force: true });
+      setCameraFocus({ target: resolveTurnLookTarget(player), priority: 1, force: true });
     }
     if (player === 0) {
       setCameraViewForTurn(0, CAMERA_TURN_VIEW_DURATION_MS, { force: true });


### PR DESCRIPTION
### Motivation
- Make the broadcast camera behavior clearer and more cinematic by keeping the view focused on the active player, biasing the side-view further left/right so side-seat avatars remain visible, and avoiding pointless board framing when no token movement occurs.  
- Align ABG (asset-based) token visuals with expectations by slightly thinning token footprints and ensuring chess-like pieces (king/knight) face the correct direction when using both full names and compact type keys.

### Description
- Tuning: increased `CAMERA_SIDE_LOOK_EXTRA` from `0.075` to `0.14` and `CAMERA_SIDE_AVATAR_BLEND` from `0.84` to `1.1` to push left/right turn framing further toward player avatars (file: `webapp/src/pages/Games/LudoBattleRoyal.jsx`).
- Dice-to-move camera flow: changed the dice result handling so landing-focus is applied only when there were no board tokens before the roll, and when the player already has tokens on the board the camera returns to that player turn view before movement (updates around `rollDice` and camera focus logic in `LudoBattleRoyal.jsx`).
- Token visuals: reduced the standardized token footprint from `{ x: 0.054, z: 0.054 }` to `{ x: 0.05, z: 0.05 }` to make ABG token pieces slightly thinner (in `LudoBattleRoyal.jsx`).
- Orientation fixes: updated `applyTokenFacingRotation` to treat compact type keys the same as named types so king (`'k'`) and knight (`'n'`) get the intended rotations (180° for king, 45° for knight) in `LudoBattleRoyal.jsx`.

### Testing
- Ran `npx eslint webapp/src/pages/Games/LudoBattleRoyal.jsx` which reported an ignore-warning (repo ignore rules) and no lint errors for the file in this environment.  
- Ran `npx eslint --no-ignore webapp/src/pages/Games/LudoBattleRoyal.jsx` which also surfaced the ignore warning but no code errors.  
- No unit tests or build runs were executed as part of this change in the current environment; manual validation of camera interactions and token visuals is recommended in-device (portrait mobile) to verify framing and token orientation during dice rolls and token moves.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc7745b4048329a36f6ebea4b8e2b1)