### PR TITLE
Ensure Pool Royale cue strike always applies slider power to cue ball

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -26423,6 +26423,7 @@ const powerRef = useRef(hud.power);
           const commitShotImpact = () => {
             if (shotImpactCommitted) return;
             shotImpactCommitted = true;
+            pendingImpactRef.current = null;
             cue.vel.copy(base);
             if (cue.spin) {
               cue.spin.set(spinSide, spinTop);
@@ -26549,6 +26550,12 @@ const powerRef = useRef(hud.power);
           const strikeHoldDuration = strokeProfile.holdDuration ?? LIVE_CUE_IMPACT_HOLD_MS;
           const pullbackDuration = strokeProfile.pullbackDuration ?? 0;
           const startTime = performance.now();
+          // Fallback: guarantee the cue-ball impulse is applied even if a frame skip
+          // causes the cue animation impact callback to be missed.
+          pendingImpactRef.current = {
+            time: startTime + Math.max(0, strikeDuration) * 0.9,
+            apply: commitShotImpact
+          };
           const impactPos = idlePos.clone();
           const followPos = impactPos.clone();
           const followDurationResolved = strikeHoldDuration;
@@ -26683,6 +26690,7 @@ const powerRef = useRef(hud.power);
             cuePullCurrentRef.current = 0;
             cuePullTargetRef.current = 0;
             cueStrokeStateRef.current = null;
+            pendingImpactRef.current = null;
             if (cameraRef.current && sphRef.current) {
               topViewRef.current = false;
               topViewLockedRef.current = false;


### PR DESCRIPTION
### Motivation
- Players reported the cuestick animating forward but the cueball not receiving the slider power because the physics impulse could be missed during the animation.

### Description
- Added a timed fallback `pendingImpactRef.current` in `webapp/src/pages/Games/PoolRoyale.jsx` that calls `commitShotImpact` near the end of the forward strike to guarantee the cue-ball impulse is applied.
- `commitShotImpact` now clears `pendingImpactRef.current` before applying `cue.vel` and spin to prevent double application of the impulse.
- The non-animated immediate-strike branch now also clears `pendingImpactRef.current` during cleanup to keep pending state consistent.

### Testing
- Ran the production build with `npm --prefix webapp run build`, which completed successfully (Vite build succeeded; only non-blocking chunk-size/dynamic-import warnings were reported).
- No unit tests were added or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc765782548329b70b80e4a2ebfaa4)