### PR TITLE
Fix Pool Royale cue stroke impact fallback when cue model is unavailable

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -22663,7 +22663,16 @@ const powerRef = useRef(hud.power);
         const updateCueStroke = (now) => {
           const stroke = cueStrokeStateRef.current;
           if (!cueStick) {
-            return Boolean(cueAnimating);
+            if (stroke && !stroke.shotApplied) {
+              stroke.shotApplied = true;
+              stroke.onImpact?.();
+            }
+            cueAnimating = false;
+            cuePullCurrentRef.current = 0;
+            cuePullTargetRef.current = 0;
+            cueStrokeStateRef.current = null;
+            pendingImpactRef.current = null;
+            return false;
           }
           if (!stroke) {
             if (cueAnimating) {


### PR DESCRIPTION
### Motivation
- Ensure the power selected on the big pull slider is always transferred to the cue ball even if the visual cue stick mesh is missing or unavailable so shots don't get dropped.

### Description
- In `webapp/src/pages/Games/PoolRoyale.jsx` update `updateCueStroke` to commit the shot impact (`stroke.onImpact?.()`) once when `cueStick` is null and then clear cue animation/pull state and pending impact to avoid a stuck stroke.

### Testing
- Ran the unit test suite for the cue stroke timeline with `npm test -- test/poolRoyaleCueStrokeTimeline.test.js --runInBand` and the test file passed (4 tests, all green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc765782548329b70b80e4a2ebfaa4)