### PR TITLE
Align cue shot power to power slider (PoolRoyale)

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1916,7 +1916,6 @@ const CUE_PULL_GLOBAL_VISIBILITY_BOOST = 0.86; // trim global pullback so charge
 const CUE_PULL_RETURN_PUSH = 0.97; // push the cue forward to contact more decisively after pullback
 const CUE_FOLLOW_THROUGH_MIN = BALL_R * 3.9; // keep low-power shots visibly pushing through the cue ball
 const CUE_FOLLOW_THROUGH_MAX = BALL_R * 8.4; // extend top-end follow-through so powerful shots visibly punch forward
-const CUE_POWER_GAMMA = 1.85; // ease-in curve to keep low-power strokes controllable
 const CUE_STRIKE_DURATION_MS = 260;
 const PLAYER_CUE_STRIKE_MIN_MS = 120;
 const PLAYER_CUE_STRIKE_MAX_MS = 1400;
@@ -26210,7 +26209,9 @@ const powerRef = useRef(hud.power);
         if (shotPrediction.railNormal) replayTags.add('bank');
           pocketSwitchIntentRef.current = null;
           lastPocketBallRef.current = null;
-          const curvedPower = Math.pow(clampedPower, CUE_POWER_GAMMA);
+          // Keep launch power aligned with the slider value so the forward
+          // cue push transfers the same user-selected strength to the cue ball.
+          const curvedPower = clampedPower;
           lastShotPower = clampedPower;
           const isMaxPowerShot = clampedPower >= MAX_POWER_BOUNCE_THRESHOLD;
           if (isMaxPowerShot) {


### PR DESCRIPTION
### Motivation
- The forward cue push was not transferring the value from the UI power slider to the cue ball, so shot velocity did not match the selected slider strength.

### Description
- Change launch power to use the slider value directly by setting `curvedPower = clampedPower` in `webapp/src/pages/Games/PoolRoyale.jsx` so the forward cue strike transmits the selected strength to the cue ball.
- Remove the now-unused `CUE_POWER_GAMMA` constant and its previous easing behavior to avoid conflicting power mapping.
- Keep existing cue stroke animation and strike flow intact while ensuring shot velocity reflects the slider.

### Testing
- Ran `npm run build` in `webapp/` and the production build completed successfully with Vite (build finished; Vite reported chunk-size warnings but no failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc867777a08329b40331d70abf16b0)