### PR TITLE
Adjust Chess Royale jet/helicopter altitude, orientation, and flight pacing

### DIFF
--- a/webapp/public/chess-royale.html
+++ b/webapp/public/chess-royale.html
@@ -243,14 +243,15 @@ const SHORT_CAPTURE_DISTANCE=1.45;
 const BOMB_VOLUME=0.16; // reduced from previous loud mix
 const SLASH_VOLUME=0.14;
 const DRONE_VOLUME=0.13;
-const MISSILE_HEIGHT=0.095;
+const MISSILE_HEIGHT=0.078;
 const MISSILE_SIZE=0.02;
 const MISSILE_TRAIL_COUNT=5;
 const MISSILE_TRAIL_SPACING=0.08;
-const JET_HEIGHT=0.165;
+const JET_HEIGHT=0.132;
 const JET_SIZE=0.31;
-const JET_SPEED_FACTOR=2.0; // keep jet and jet-fired missile travel at 50% slower pacing
+const JET_SPEED_FACTOR=2.65; // slower jet pacing for longer, more readable fly-bys
 const DRONE_SIZE=0.048;
+const AIRCRAFT_UPRIGHT_CORRECTION=Math.PI; // keeps jets/helicopters visually upright on screen
 const scalePieceNode=node=>{ if(!node) return; if(!node.userData.baseScale) node.userData.baseScale=node.scale.clone(); node.scale.copy(node.userData.baseScale).multiplyScalar(PIECE_SIZE_MULTIPLIER); };
 
 const files='abcdefgh';
@@ -457,11 +458,11 @@ function buildJetMesh(){
   jet.scale.setScalar(JET_SIZE);
   return jet;
 }
-function setTravelOrientation(node,from,to,bank=0){
+function setTravelOrientation(node,from,to,bank=0,pitchOffset=0){
   const dir=to.clone().sub(from);
   if(dir.lengthSq()<1e-6) return;
   const heading=Math.atan2(dir.z,dir.x);
-  node.rotation.set(0,-heading,bank);
+  node.rotation.set(pitchOffset,-heading,bank);
 }
 function getJetIngressAndEgress(from,to){
   const center=from.clone().lerp(to,0.5);
@@ -655,12 +656,12 @@ function animateJetMissileStrike(from,to){
         const eased=t*t*(3-2*t);
         jet.position.lerpVectors(entry,approach,eased);
         jet.position.y=JET_HEIGHT+Math.sin(t*Math.PI)*0.03;
-        setTravelOrientation(jet,entry,approach,Math.sin(t*Math.PI)*0.05);
+        setTravelOrientation(jet,entry,approach,Math.sin(t*Math.PI)*0.05,AIRCRAFT_UPRIGHT_CORRECTION);
       }else if(elapsed<=phaseA+phaseB){
         const t=Math.min(1,(elapsed-phaseA)/phaseB);
         jet.position.lerpVectors(approach,turnPoint,t);
         jet.position.y+=Math.sin(t*Math.PI)*0.05;
-        setTravelOrientation(jet,approach,to,Math.sin(t*Math.PI)*0.04);
+        setTravelOrientation(jet,approach,to,Math.sin(t*Math.PI)*0.04,AIRCRAFT_UPRIGHT_CORRECTION);
         if(!missileLaunched){
           missileLaunched=true;
           missile.visible=true;
@@ -676,7 +677,7 @@ function animateJetMissileStrike(from,to){
         const uFrom=t<0.5 ? turnPoint : loopPoint;
         jet.position.copy(uTurn);
         jet.position.y=JET_HEIGHT+Math.sin(t*Math.PI)*0.045;
-        setTravelOrientation(jet,uFrom,exit,-Math.sin(t*Math.PI)*0.05);
+        setTravelOrientation(jet,uFrom,exit,-Math.sin(t*Math.PI)*0.05,AIRCRAFT_UPRIGHT_CORRECTION);
         if(missileLaunched) updateMissileRig(missile,missileCurve,0.9+(t*0.1));
       }else{
         scene.remove(jet);
@@ -705,45 +706,65 @@ function animateDroneKamikaze(from,to){
     const smokeTrail=new THREE.Mesh(new THREE.SphereGeometry(0.024,8,8), new THREE.MeshBasicMaterial({color:0x9ca3af, transparent:true, opacity:0.72}));
     const blast=new THREE.Mesh(new THREE.SphereGeometry(0.07,12,12), new THREE.MeshBasicMaterial({color:0xfb7185, transparent:true, opacity:0}));
     drone.add(body,propHub,propBladeA,propBladeB);
-    const start=from.clone().add(new THREE.Vector3(0,0.075,0));
-    const end=to.clone().add(new THREE.Vector3(Math.sign((to.x-from.x)||1)*0.17,0.095,Math.sign((to.z-from.z)||1)*0.17));
-    const radius=Math.max(0.3,Math.min(0.66,from.distanceTo(to)*0.24));
-    drone.position.copy(start); smokeTrail.position.copy(start); blast.position.copy(to.clone().add(new THREE.Vector3(0,0.17,0)));
+    const flightHeight=JET_HEIGHT;
+    const lateral=Math.sign((to.x-from.x)||1);
+    const depth=Math.sign((to.z-from.z)||1);
+    const start=from.clone().add(new THREE.Vector3(0,flightHeight,0.52*depth));
+    const strikePoint=to.clone().add(new THREE.Vector3(0,flightHeight,0));
+    const turnPoint=to.clone().add(new THREE.Vector3(0.36*lateral,flightHeight,0.54*depth));
+    const exit=from.clone().add(new THREE.Vector3(-0.5*lateral,flightHeight,-0.58*depth));
+    drone.position.copy(start); smokeTrail.position.copy(start); blast.position.copy(to.clone().add(new THREE.Vector3(0,0.14,0)));
     scene.add(drone); scene.add(smokeTrail); scene.add(blast); playDroneSound();
-    const t0=performance.now(), dur=700;
-    const cubic=(a,b,c,d,t)=>new THREE.Vector3().copy(a).multiplyScalar((1-t)**3).add(b.clone().multiplyScalar(3*(1-t)*(1-t)*t)).add(c.clone().multiplyScalar(3*(1-t)*t*t)).add(d.clone().multiplyScalar(t*t*t));
+    const t0=performance.now(), phaseA=560, phaseB=760, total=phaseA+phaseB;
+    let blastTriggered=false;
     const tick=now=>{
-      const t=Math.min(1,(now-t0)/dur);
-      const midA=start.clone().lerp(end,0.3).add(new THREE.Vector3(radius,0.04,radius*0.75));
-      const midB=start.clone().lerp(end,0.62).add(new THREE.Vector3(-radius*0.72,0.035,-radius*0.88));
-      const p=cubic(start,midA,midB,end,t);
-      drone.position.copy(p);
-      drone.position.y=Math.max(boardY+0.06,p.y);
-      smokeTrail.position.lerpVectors(start,p,0.9);
-      smokeTrail.material.opacity=0.72*(1-t);
-      propHub.rotation.x=t*Math.PI*24;
-      propBladeA.rotation.z=t*Math.PI*24;
-      propBladeB.rotation.y=t*Math.PI*24;
-      drone.scale.setScalar(1+Math.sin(t*Math.PI*6)*0.03);
-      setTravelOrientation(drone,start,p,Math.sin(t*Math.PI*2)*0.08);
-      if(t<1) requestAnimationFrame(tick);
-      else{
-        playBombSound();
-        const e0=performance.now(), ed=220;
-        const boom=ev=>{
-          const et=Math.min(1,(ev-e0)/ed); blast.scale.setScalar(1+1.2*et); blast.material.opacity=0.9*(1-et);
-          if(et<1) requestAnimationFrame(boom);
-          else{
-            [drone,smokeTrail,blast].forEach(n=>{ scene.remove(n); n.traverse?.(o=>{ if(o.geometry) o.geometry.dispose(); if(o.material){ if(Array.isArray(o.material)) o.material.forEach(m=>m.dispose()); else o.material.dispose(); }}); if(n.geometry) n.geometry.dispose(); if(n.material) n.material.dispose(); });
-            resolve();
-          }
-        };
-        requestAnimationFrame(boom);
+      const elapsed=now-t0;
+      const propSpin=elapsed*0.05;
+      propHub.rotation.x=propSpin;
+      propBladeA.rotation.z=propSpin;
+      propBladeB.rotation.y=propSpin;
+      drone.scale.setScalar(1+Math.sin(elapsed*0.018)*0.03);
+      if(elapsed<=phaseA){
+        const t=Math.min(1,elapsed/phaseA);
+        const p=start.clone().lerp(strikePoint,t);
+        const travelFrom=t<0.01?start:start.clone().lerp(strikePoint,Math.max(0,t-0.02));
+        drone.position.copy(p);
+        smokeTrail.position.lerpVectors(start,p,0.88);
+        smokeTrail.material.opacity=0.72*(1-t*0.68);
+        setTravelOrientation(drone,travelFrom,p,Math.sin(t*Math.PI)*0.07,AIRCRAFT_UPRIGHT_CORRECTION);
+      }else if(elapsed<=total){
+        const t=Math.min(1,(elapsed-phaseA)/phaseB);
+        const uTurn=t<0.5
+          ? strikePoint.clone().lerp(turnPoint,t*2)
+          : turnPoint.clone().lerp(exit,(t-0.5)*2);
+        const travelFrom=t<0.5 ? strikePoint : turnPoint;
+        drone.position.copy(uTurn);
+        smokeTrail.position.lerpVectors(strikePoint,uTurn,0.9);
+        smokeTrail.material.opacity=0.28+((1-t)*0.36);
+        setTravelOrientation(drone,travelFrom,uTurn,-Math.sin(t*Math.PI)*0.07,AIRCRAFT_UPRIGHT_CORRECTION);
+        if(!blastTriggered && t>0.42){
+          blastTriggered=true;
+          playBombSound();
+          const e0=performance.now(), ed=260;
+          const boom=ev=>{
+            const et=Math.min(1,(ev-e0)/ed);
+            blast.scale.setScalar(1+1.25*et);
+            blast.material.opacity=0.9*(1-et);
+            if(et<1) requestAnimationFrame(boom);
+          };
+          requestAnimationFrame(boom);
+        }
+      }else{
+        [drone,smokeTrail,blast].forEach(n=>{ scene.remove(n); n.traverse?.(o=>{ if(o.geometry) o.geometry.dispose(); if(o.material){ if(Array.isArray(o.material)) o.material.forEach(m=>m.dispose()); else o.material.dispose(); }}); if(n.geometry) n.geometry.dispose(); if(n.material) n.material.dispose(); });
+        resolve();
+        return;
       }
+      requestAnimationFrame(tick);
     };
     requestAnimationFrame(tick);
   });
 }
+
 
 function evaluateGameState(){
   const nextMoves=genLegal(state);


### PR DESCRIPTION
### Motivation
- Make aircraft effects read closer to the chess board and easier to follow by lowering flight heights and slowing the fly-by pacing.
- Fix jets/helicopters rendering upside-down and give the drone a clearer approach/exit (U-turn) so captures feel visually coherent on-screen.

### Description
- Tuned flight constants by lowering `MISSILE_HEIGHT` (0.095 → 0.078) and `JET_HEIGHT` (0.165 → 0.132), increasing `JET_SPEED_FACTOR` (2.0 → 2.65), and adding `AIRCRAFT_UPRIGHT_CORRECTION` to control upright orientation.
- Extended `setTravelOrientation` to accept a `pitchOffset` parameter and use it to keep aircraft visually upright instead of inverted.
- Applied the upright correction to jet travel phases inside `animateJetMissileStrike` and to the drone calls so both aircraft types maintain correct orientation.
- Reworked `animateDroneKamikaze` to fly at the jet altitude, slow its timing (`phaseA`/`phaseB`), perform a visible U-turn exit, and adjust smoke/blast timing for a clearer strike animation.

### Testing
- Verified updated symbols exist via `rg` checks for `JET_HEIGHT`, `JET_SPEED_FACTOR`, and `AIRCRAFT_UPRIGHT_CORRECTION`, and confirmed replacements were applied.
- Created a commit containing the changes and validated repository status with `git status --short` showing `webapp/public/chess-royale.html` modified.
- No automated rendering or unit tests were run in CI for these visual changes, so manual/visual verification in a browser is recommended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc881b85a4832986ad1e680afbb290)