### PR TITLE
Ensure cue impact commits for forward-only Pool Royale strokes

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -22738,7 +22738,11 @@ const powerRef = useRef(hud.power);
             cueStick.rotation.y =
               (baseRotationY ?? cueStick.rotation.y) +
               Math.sin(pushT * Math.PI) * 0.0012 * strikeWobbleScale;
-            if (!stroke.shotApplied && pushT >= 0.9) {
+            // Guarantee impact commit even if a long frame skips over the
+            // push window and lands directly in hold/recover.
+            const reachedImpactThreshold =
+              pushT >= 0.9 || elapsed >= safeStrikeDuration;
+            if (!stroke.shotApplied && reachedImpactThreshold) {
               stroke.shotApplied = true;
               stroke.onImpact?.();
             }


### PR DESCRIPTION
### Motivation
- Fix a case where the cue stick animation would visually push forward but the shot physics were not applied (the cue ball did not launch) when a long frame skipped the push window during forward-only strokes.

### Description
- In `webapp/src/pages/Games/PoolRoyale.jsx` call the impact handler when either the normal push threshold (`pushT >= 0.9`) or the strike duration has elapsed (`elapsed >= safeStrikeDuration`), ensuring `stroke.onImpact` is always committed for forward-only stroke animations.

### Testing
- Built the web app with `cd webapp && npm run -s build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc867777a08329b40331d70abf16b0)