### PR TITLE
Adjust Ludo battle royale broadcast camera behavior for entry/no-move turns

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -7289,13 +7289,25 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       if (typeof onComplete === 'function') onComplete();
       return;
     }
-      if (token && shouldFollowCamera) {
+    if (token && shouldFollowCamera) {
+      const isEnteringFromHome = fromProgress < 0;
+      const entryTurnLookTarget = isEnteringFromHome ? resolveTurnLookTarget(player) : null;
+      if (entryTurnLookTarget?.isVector3) {
+        setCameraFocus({
+          target: entryTurnLookTarget,
+          follow: false,
+          ttl: 1.05,
+          priority: 6,
+          offset: CAMERA_TARGET_LIFT + 0.02
+        });
+      } else {
         setCameraFocus({
           object: token,
           follow: true,
           priority: 6,
           offset: CAMERA_TARGET_LIFT + 0.02
         });
+      }
       }
     state.animation = {
       active: true,
@@ -7693,7 +7705,6 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     dice.userData.isRolling = true;
     setCameraViewForTurn(player, CAMERA_TURN_VIEW_DURATION_MS, { force: true });
     playDiceSound();
-    const landingFocus = baseTarget.clone();
     const value = await spinDice(dice, {
       duration: resolveFrameSyncedDuration(AUTO_ROLL_DURATION_MS, { min: 620, max: 1400 }),
       targetPosition: baseTarget,
@@ -7709,16 +7720,20 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       playSixRollSound();
     }
     scheduleDiceClear();
-    setCameraFocus({
-      target: landingFocus,
-      follow: false,
-      ttl: 0.88,
-      priority: 2,
-      offset: CAMERA_TARGET_LIFT + 0.03,
-      force: true
-    });
     const options = getMovableTokens(player, value);
     const hasBoardTokenBeforeRoll = hasAnyTokenOnBoard(player);
+    const shouldBroadcastDiceLandingFocus = hasBoardTokenBeforeRoll && options.length > 0;
+    if (shouldBroadcastDiceLandingFocus) {
+      const landingFocus = baseTarget.clone();
+      setCameraFocus({
+        target: landingFocus,
+        follow: false,
+        ttl: 0.88,
+        priority: 2,
+        offset: CAMERA_TARGET_LIFT + 0.03,
+        force: true
+      });
+    }
     if (!options.length) {
       const playerCycle = Math.max(1, activePlayerCount);
       const upcomingTurn = value === 6 ? player : (player + playerCycle - 1) % playerCycle;


### PR DESCRIPTION
### Motivation
- Improve broadcast readability by preventing the camera from centering the board when the active player has no tokens on the board or no legal moves after a dice roll. 
- Make token-entry camera behavior consistent with turn-side emphasis by looking left/right for side players when tokens enter from home.

### Description
- When scheduling a token move (`scheduleMove`), if the token is entering from home the camera now prefers the turn-side look target (`resolveTurnLookTarget`) with a short TTL and priority instead of immediately switching to follow the token.
- When resolving dice results (`rollDice`), the dice-landing broadcast focus is only set if the player already has at least one token on the board and there is at least one movable option (`hasAnyTokenOnBoard(player) && options.length > 0`), which prevents unnecessary board-looking on non-actionable turns.
- Kept existing follow behavior as a fallback so tokens are still followed for regular moves, and adjusted small TTL/priority values for entry focus to match existing camera logic.

### Testing
- Ran `git diff --check webapp/src/pages/Games/LudoBattleRoyal.jsx` to verify no whitespace/patch issues and it passed. 
- Ran `npm run -s lint -- webapp/src/pages/Games/LudoBattleRoyal.jsx`, which exercised repository lint rules but failed due to many pre-existing, unrelated lint errors across the repo; the target change is limited to `LudoBattleRoyal.jsx` and is syntactically valid. 
- Manually inspected modified regions (camera focus and dice handling) and confirmed inserted logic paths for entry/no-move conditions are present and properly guarded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc8ec0b9388329b7ad9e299761e5f6)