### PR TITLE
Adjust Ludo broadcast camera for no-move and entry turns

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -4598,12 +4598,12 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
   }, []);
 
   const beginHumanSelection = useCallback(
-    (roll, options) => {
+    (roll, options, { skipCameraFollow = false } = {}) => {
       const state = stateRef.current;
       if (!state || !Array.isArray(options) || !options.length) return;
       clearHumanSelection();
       const normalized = options.map((option) => ({ token: option.token, entering: option.entering }));
-      humanSelectionRef.current = { roll, options: normalized };
+      humanSelectionRef.current = { roll, options: normalized, skipCameraFollow };
       normalized.forEach((option) => {
         const token = state.tokens?.[0]?.[option.token];
         if (token) {
@@ -5914,7 +5914,9 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       );
       if (!option) return false;
       clearHumanSelection();
-      moveToken(0, option.token, selection.roll);
+      moveToken(0, option.token, selection.roll, {
+        skipCameraFollow: selection.skipCameraFollow || option.entering
+      });
       return true;
     };
     const getCameraLookTarget = () => {
@@ -7708,17 +7710,20 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     if (value === 6) {
       playSixRollSound();
     }
-    scheduleDiceClear();
-    setCameraFocus({
-      target: landingFocus,
-      follow: false,
-      ttl: 0.88,
-      priority: 2,
-      offset: CAMERA_TARGET_LIFT + 0.03,
-      force: true
-    });
-    const options = getMovableTokens(player, value);
     const hasBoardTokenBeforeRoll = hasAnyTokenOnBoard(player);
+    const options = getMovableTokens(player, value);
+    const keepTurnCameraFraming = !hasBoardTokenBeforeRoll || !options.length;
+    scheduleDiceClear();
+    if (!keepTurnCameraFraming) {
+      setCameraFocus({
+        target: landingFocus,
+        follow: false,
+        ttl: 0.88,
+        priority: 2,
+        offset: CAMERA_TARGET_LIFT + 0.03,
+        force: true
+      });
+    }
     if (!options.length) {
       const playerCycle = Math.max(1, activePlayerCount);
       const upcomingTurn = value === 6 ? player : (player + playerCycle - 1) % playerCycle;
@@ -7732,7 +7737,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     }
     if (player === 0) {
       setCameraViewForTurn(0, CAMERA_TURN_VIEW_DURATION_MS, { force: true });
-      beginHumanSelection(value, options);
+      beginHumanSelection(value, options, { skipCameraFollow: !hasBoardTokenBeforeRoll });
       return;
     }
     const choice = chooseMoveOption(state, player, value, options);
@@ -7747,7 +7752,9 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       }, DICE_RESULT_EXTRA_HOLD_MS);
       return;
     }
-    moveToken(player, choice.token, value, { skipCameraFollow: hasBoardTokenBeforeRoll });
+    moveToken(player, choice.token, value, {
+      skipCameraFollow: !hasBoardTokenBeforeRoll || choice.entering
+    });
   };
 
   rollDiceRef.current = rollDice;


### PR DESCRIPTION
### Motivation
- Improve broadcast camera behavior in Ludo so the camera does not snap to the board/dice landing when the current player has no tokens on board or has no legal moves after a roll.
- Ensure entry moves from left/right seats preserve the left/right turn-facing orientation instead of forcing a token-follow broadcast shot.
- Make human token selection respect the same `skipCameraFollow` behavior used for AI moves so manual choices behave consistently.

### Description
- Added an optional `skipCameraFollow` parameter to `beginHumanSelection` and persisted it on `humanSelectionRef` as `skipCameraFollow` so selection state carries camera intent (`webapp/src/pages/Games/LudoBattleRoyal.jsx`).
- When handling a human token tap, call `moveToken` with `skipCameraFollow: selection.skipCameraFollow || option.entering` so entry moves or selections that requested no follow respect the flag.
- Modified `rollDice` flow to only call `setCameraFocus` on the dice landing point when the framing should change (i.e., the player already has tokens on the board and there are legal moves); otherwise the camera keeps the turn-facing framing.
- Adjusted AI/move invocation to pass `skipCameraFollow` for entry/no-board-token cases (`moveToken` now receives `skipCameraFollow: !hasBoardTokenBeforeRoll || choice.entering`).

### Testing
- Ran `npx eslint webapp/src/pages/Games/LudoBattleRoyal.jsx` and `npx eslint --no-ignore webapp/src/pages/Games/LudoBattleRoyal.jsx`; the linter run shows the file is ignored by project ignore settings but reported no lint errors for the modified code.
- Verified the change compiles/commits locally (code updated and committed); no runtime automated tests were executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc8ec0b9388329b7ad9e299761e5f6)