### PR TITLE
Fix aircraft orientation, size, and circular board-centered fly paths

### DIFF
--- a/webapp/public/chess-royale.html
+++ b/webapp/public/chess-royale.html
@@ -247,11 +247,11 @@ const MISSILE_HEIGHT=0.078;
 const MISSILE_SIZE=0.02;
 const MISSILE_TRAIL_COUNT=5;
 const MISSILE_TRAIL_SPACING=0.08;
-const JET_HEIGHT=0.132;
-const JET_SIZE=0.31;
+const JET_HEIGHT=0.102; // slightly lower flight so aircraft sit closer to the board
+const JET_SIZE=0.217; // 30% smaller than previous 0.31 size
 const JET_SPEED_FACTOR=2.65; // slower jet pacing for longer, more readable fly-bys
-const DRONE_SIZE=0.048;
-const AIRCRAFT_UPRIGHT_CORRECTION=Math.PI; // keeps jets/helicopters visually upright on screen
+const DRONE_SIZE=0.0336; // 30% smaller than previous 0.048 size
+const AIRCRAFT_UPRIGHT_CORRECTION=0; // prevent upside-down orientation during flight
 const scalePieceNode=node=>{ if(!node) return; if(!node.userData.baseScale) node.userData.baseScale=node.scale.clone(); node.scale.copy(node.userData.baseScale).multiplyScalar(PIECE_SIZE_MULTIPLIER); };
 
 const files='abcdefgh';
@@ -465,13 +465,19 @@ function setTravelOrientation(node,from,to,bank=0,pitchOffset=0){
   node.rotation.set(pitchOffset,-heading,bank);
 }
 function getJetIngressAndEgress(from,to){
-  const center=from.clone().lerp(to,0.5);
-  const margin=1.25; // keep fly-by near the board so the jet appears earlier on-screen
-  const useTop=Math.random()>0.5;
-  const zEdge=center.z+(useTop?margin:-margin);
-  const entry=new THREE.Vector3(center.x,JET_HEIGHT,zEdge);
-  const exit=new THREE.Vector3(center.x,JET_HEIGHT,-zEdge);
-  return {entry,exit,center};
+  const center=getBoardCenterWorld().setY(JET_HEIGHT);
+  const radius=0.92; // tighter circle so the aircraft remain visually closer to the board
+  const startAngle=Math.atan2((from.z-center.z),(from.x-center.x));
+  const entry=center.clone().add(new THREE.Vector3(Math.cos(startAngle)*radius,0,Math.sin(startAngle)*radius));
+  return {entry,center,radius,startAngle};
+}
+
+function getBoardCenterWorld(){
+  return new THREE.Vector3(
+    origin[0]+(vx[0]*3.5)+(vz[0]*3.5),
+    boardY+.02+BOARD_PIECE_VERTICAL_LIFT,
+    origin[1]+(vx[1]*3.5)+(vz[1]*3.5)
+  );
 }
 
 function getJetNoseWorldPosition(jet){
@@ -631,11 +637,11 @@ function animateJetMissileStrike(from,to){
     if(!scene||!THREE||!from||!to) return resolve();
     const jet=buildJetMesh();
     const missile=buildMissileMesh();
-    const {entry,exit,center}=getJetIngressAndEgress(from,to);
+    const {entry,center,radius,startAngle}=getJetIngressAndEgress(from,to);
     const targetLow=to.clone().add(new THREE.Vector3(0,MISSILE_HEIGHT,0));
-    const approach=from.clone().lerp(to,0.62).add(new THREE.Vector3(0,JET_HEIGHT,0));
-    const turnPoint=to.clone().add(new THREE.Vector3(0,JET_HEIGHT,0.48*Math.sign(exit.z||1)));
-    const loopPoint=from.clone().lerp(to,0.4).add(new THREE.Vector3(0,JET_HEIGHT,-0.42*Math.sign(exit.z||1)));
+    const quarterPoint=center.clone().add(new THREE.Vector3(Math.cos(startAngle+Math.PI*0.5)*radius,0,Math.sin(startAngle+Math.PI*0.5)*radius));
+    const halfPoint=center.clone().add(new THREE.Vector3(Math.cos(startAngle+Math.PI)*radius,0,Math.sin(startAngle+Math.PI)*radius));
+    const threeQuarterPoint=center.clone().add(new THREE.Vector3(Math.cos(startAngle+Math.PI*1.5)*radius,0,Math.sin(startAngle+Math.PI*1.5)*radius));
     const missileCurve=[];
     jet.position.copy(entry);
     missile.visible=false;
@@ -654,14 +660,17 @@ function animateJetMissileStrike(from,to){
       if(elapsed<=phaseA){
         const t=Math.min(1,elapsed/phaseA);
         const eased=t*t*(3-2*t);
-        jet.position.lerpVectors(entry,approach,eased);
+        jet.position.lerpVectors(entry,quarterPoint,eased);
         jet.position.y=JET_HEIGHT+Math.sin(t*Math.PI)*0.03;
-        setTravelOrientation(jet,entry,approach,Math.sin(t*Math.PI)*0.05,AIRCRAFT_UPRIGHT_CORRECTION);
+        setTravelOrientation(jet,entry,quarterPoint,Math.sin(t*Math.PI)*0.05,AIRCRAFT_UPRIGHT_CORRECTION);
       }else if(elapsed<=phaseA+phaseB){
         const t=Math.min(1,(elapsed-phaseA)/phaseB);
-        jet.position.lerpVectors(approach,turnPoint,t);
+        const angle=startAngle+(Math.PI*0.5)+(Math.PI*t);
+        jet.position.copy(center.clone().add(new THREE.Vector3(Math.cos(angle)*radius,0,Math.sin(angle)*radius)));
         jet.position.y+=Math.sin(t*Math.PI)*0.05;
-        setTravelOrientation(jet,approach,to,Math.sin(t*Math.PI)*0.04,AIRCRAFT_UPRIGHT_CORRECTION);
+        const prevAngle=angle-0.04;
+        const fromPoint=center.clone().add(new THREE.Vector3(Math.cos(prevAngle)*radius,0,Math.sin(prevAngle)*radius));
+        setTravelOrientation(jet,fromPoint,jet.position,Math.sin(t*Math.PI)*0.04,AIRCRAFT_UPRIGHT_CORRECTION);
         if(!missileLaunched){
           missileLaunched=true;
           missile.visible=true;
@@ -671,13 +680,12 @@ function animateJetMissileStrike(from,to){
         if(missileLaunched) updateMissileRig(missile,missileCurve,Math.min(1,t*0.9));
       }else if(elapsed<=total){
         const t=Math.min(1,(elapsed-phaseA-phaseB)/phaseC);
-        const uTurn=t<0.5
-          ? turnPoint.clone().lerp(loopPoint,t*2)
-          : loopPoint.clone().lerp(exit,(t-0.5)*2);
-        const uFrom=t<0.5 ? turnPoint : loopPoint;
-        jet.position.copy(uTurn);
+        const angle=startAngle+(Math.PI*1.5)+(Math.PI*0.5*t);
+        const nextPos=center.clone().add(new THREE.Vector3(Math.cos(angle)*radius,0,Math.sin(angle)*radius));
+        const travelFrom=t<0.5 ? halfPoint : threeQuarterPoint;
+        jet.position.copy(nextPos);
         jet.position.y=JET_HEIGHT+Math.sin(t*Math.PI)*0.045;
-        setTravelOrientation(jet,uFrom,exit,-Math.sin(t*Math.PI)*0.05,AIRCRAFT_UPRIGHT_CORRECTION);
+        setTravelOrientation(jet,travelFrom,nextPos,-Math.sin(t*Math.PI)*0.05,AIRCRAFT_UPRIGHT_CORRECTION);
         if(missileLaunched) updateMissileRig(missile,missileCurve,0.9+(t*0.1));
       }else{
         scene.remove(jet);
@@ -707,12 +715,13 @@ function animateDroneKamikaze(from,to){
     const blast=new THREE.Mesh(new THREE.SphereGeometry(0.07,12,12), new THREE.MeshBasicMaterial({color:0xfb7185, transparent:true, opacity:0}));
     drone.add(body,propHub,propBladeA,propBladeB);
     const flightHeight=JET_HEIGHT;
-    const lateral=Math.sign((to.x-from.x)||1);
-    const depth=Math.sign((to.z-from.z)||1);
-    const start=from.clone().add(new THREE.Vector3(0,flightHeight,0.52*depth));
-    const strikePoint=to.clone().add(new THREE.Vector3(0,flightHeight,0));
-    const turnPoint=to.clone().add(new THREE.Vector3(0.36*lateral,flightHeight,0.54*depth));
-    const exit=from.clone().add(new THREE.Vector3(-0.5*lateral,flightHeight,-0.58*depth));
+    const boardCenter=getBoardCenterWorld().setY(flightHeight);
+    const radius=0.86;
+    const baseAngle=Math.atan2((from.z-boardCenter.z),(from.x-boardCenter.x));
+    const start=boardCenter.clone().add(new THREE.Vector3(Math.cos(baseAngle)*radius,0,Math.sin(baseAngle)*radius));
+    const strikePoint=boardCenter.clone().add(new THREE.Vector3(Math.cos(baseAngle+Math.PI*0.5)*radius,0,Math.sin(baseAngle+Math.PI*0.5)*radius));
+    const turnPoint=boardCenter.clone().add(new THREE.Vector3(Math.cos(baseAngle+Math.PI)*radius,0,Math.sin(baseAngle+Math.PI)*radius));
+    const exit=boardCenter.clone().add(new THREE.Vector3(Math.cos(baseAngle+Math.PI*1.5)*radius,0,Math.sin(baseAngle+Math.PI*1.5)*radius));
     drone.position.copy(start); smokeTrail.position.copy(start); blast.position.copy(to.clone().add(new THREE.Vector3(0,0.14,0)));
     scene.add(drone); scene.add(smokeTrail); scene.add(blast); playDroneSound();
     const t0=performance.now(), phaseA=560, phaseB=760, total=phaseA+phaseB;


### PR DESCRIPTION
### Motivation
- Fix visual issues with aircraft models (F15 and military helicopter/drone) that were appearing upside-down and not positioned correctly relative to the board. 
- Make aircraft 30% smaller and visually closer to the board while keeping the same fly duration, using a circular ("O") flight path centered on the board.

### Description
- Reduced aircraft scales and lowered altitude by updating constants: `JET_SIZE` (0.31 → `0.217`), `DRONE_SIZE` (0.048 → `0.0336`) and `JET_HEIGHT` (0.132 → `0.102`) in `webapp/public/chess-royale.html`.
- Removed the previous pitch flip correction by setting `AIRCRAFT_UPRIGHT_CORRECTION=0` so jets/helicopters retain an upright visual orientation during flight.
- Replaced linear ingress/egress pathing with board-centered circular routing by adding `getBoardCenterWorld()` and updating `getJetIngressAndEgress()` to return a center, radius and start angle for an O-shaped trajectory.
- Updated `animateJetMissileStrike()` and `animateDroneKamikaze()` to follow the new circular path geometry (quarter/half/three-quarter points computed around the board center) while preserving the original phase durations and overall timing.

### Testing
- Repository sanity checks were performed and completed successfully (local diff and status checks against the modified file showed the intended changes).
- No automated unit or integration tests were executed as part of this change; visual verification in a browser is recommended to confirm orientation, scale, and circular flight behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc91ace7e883298903eb7423da2ba0)