### PR TITLE
Fix Pool Royale cue strike to reliably transfer slider power

### DIFF
--- a/Assets/Scripts/Gameplay/CueController.cs
+++ b/Assets/Scripts/Gameplay/CueController.cs
@@ -35,7 +35,8 @@ namespace Aiming
         [Header("Strike feel")]
         public float strikeDuration = 0.12f;
         public float strikeHoldDuration = 0.05f;
-        public float baseStrikeImpulse = 1.8f;
+        [Tooltip("Minimum impulse used when slider power is above zero.")]
+        [Min(0f)] public float minStrikeImpulse = 0.25f;
         public float maxStrikeImpulse = 6.5f;
         [Tooltip("Normalized strike progress where the hit is fired once.")]
         [Range(0.75f, 0.99f)] public float hitProgress = 0.9f;
@@ -384,7 +385,20 @@ namespace Aiming
                 return;
             }
 
-            float impulseMagnitude = Mathf.Lerp(baseStrikeImpulse, maxStrikeImpulse, Mathf.Clamp01(shotPower));
+            float normalizedPower = Mathf.Clamp01(shotPower);
+            if (normalizedPower <= 0f)
+            {
+                return;
+            }
+
+            if (cueBallBody.isKinematic)
+            {
+                cueBallBody.isKinematic = false;
+            }
+
+            cueBallBody.WakeUp();
+
+            float impulseMagnitude = Mathf.Lerp(minStrikeImpulse, maxStrikeImpulse, normalizedPower);
             strikePhysics.Apply(cueBallBody, strikeDirection, impulseMagnitude, spinInput, ballRadius);
         }
 


### PR DESCRIPTION
### Motivation
- Players observed the cue animation moving but the cue ball not receiving the slider power, indicating the strike impulse path could fail when the rigidbody was in a non-responsive state or when slider mapping was unclear.

### Description
- Replaced the old baseline impulse with a clearer `minStrikeImpulse` field and preserved `maxStrikeImpulse` in `Assets/Scripts/Gameplay/CueController.cs` to make slider->impulse mapping explicit.
- Clamp shot power to `[0,1]` and skip applying any impulse only when normalized power is zero, ensuring low-but-nonzero slider settings produce motion.
- If the cue ball rigidbody is `isKinematic`, switch it back to dynamic and call `WakeUp()` before applying the impulse to guarantee the physics engine accepts the force.
- Compute `impulseMagnitude` via `Mathf.Lerp(minStrikeImpulse, maxStrikeImpulse, normalizedPower)` and pass it to the existing `strikePhysics.Apply(...)` call.

### Testing
- Ran a repository-level check with `git diff --check` which reported no whitespace or diff errors and succeeded. 
- Performed static inspection of the `ReleaseAndStrike` -> `StrikeRoutine` -> `ApplyStrikeImpulse` flow and committed the change successfully; Unity PlayMode/runtime tests were not executed in this environment and are recommended in-editor to validate feel and tuning of `minStrikeImpulse`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc867777a08329b40331d70abf16b0)