### PR TITLE
Adjust Ludo broadcast camera framing for no-move and entry turns

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -7245,6 +7245,12 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     return state.progress[player].some((progress) => Number.isFinite(progress) && progress >= 0 && progress < GOAL_PROGRESS);
   }, []);
 
+  const shouldKeepTurnCameraFraming = useCallback((player, options = []) => {
+    const hasBoardToken = hasAnyTokenOnBoard(player);
+    const hasMoves = Array.isArray(options) && options.length > 0;
+    return !hasBoardToken || !hasMoves;
+  }, [hasAnyTokenOnBoard]);
+
   const scheduleMove = (player, tokenIndex, targetProgress, onComplete, options = {}) => {
     const state = stateRef.current;
     if (!state) return;
@@ -7710,9 +7716,8 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     if (value === 6) {
       playSixRollSound();
     }
-    const hasBoardTokenBeforeRoll = hasAnyTokenOnBoard(player);
     const options = getMovableTokens(player, value);
-    const keepTurnCameraFraming = !hasBoardTokenBeforeRoll || !options.length;
+    const keepTurnCameraFraming = shouldKeepTurnCameraFraming(player, options);
     scheduleDiceClear();
     if (!keepTurnCameraFraming) {
       setCameraFocus({
@@ -7737,7 +7742,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     }
     if (player === 0) {
       setCameraViewForTurn(0, CAMERA_TURN_VIEW_DURATION_MS, { force: true });
-      beginHumanSelection(value, options, { skipCameraFollow: !hasBoardTokenBeforeRoll });
+      beginHumanSelection(value, options, { skipCameraFollow: keepTurnCameraFraming });
       return;
     }
     const choice = chooseMoveOption(state, player, value, options);
@@ -7752,8 +7757,11 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       }, DICE_RESULT_EXTRA_HOLD_MS);
       return;
     }
+    if (choice.entering && (player === 1 || player === 3)) {
+      setCameraViewForTurn(player, CAMERA_TURN_VIEW_DURATION_MS, { force: true });
+    }
     moveToken(player, choice.token, value, {
-      skipCameraFollow: !hasBoardTokenBeforeRoll || choice.entering
+      skipCameraFollow: keepTurnCameraFraming || choice.entering
     });
   };
 


### PR DESCRIPTION
### Motivation
- Prevent the broadcast camera from jumping to the board when a player has no tokens on board or no legal moves, keeping the turn-facing framing instead.
- Ensure side players (left/right seats) keep the same left/right turn-facing camera when their token is entering the board, matching how we frame for a player turn.

### Description
- Added `shouldKeepTurnCameraFraming(player, options)` to centralize the rule that keeps turn framing when the player has no tokens on board or has no available moves.
- Updated the roll resolution flow in `rollDice` to use `shouldKeepTurnCameraFraming` when deciding whether to focus the camera on the landing/board vs keep turn framing, and passed the result into `beginHumanSelection` as `skipCameraFollow`.
- When an AI-controlled left/right player (player `1` or `3`) makes an entry move, force the turn-view framing via `setCameraViewForTurn` so the camera looks left/right consistently during entry moves.
- Adjusted `moveToken` invocation to compute `skipCameraFollow` from the new helper and to respect `choice.entering` so camera-follow behavior is consistent for human and AI moves.

### Testing
- Built the webapp with `cd webapp && npm run build`, and the Vite production build completed successfully.
- The build emitted existing non-blocking warnings about chunk size and mixed static/dynamic imports, but no errors related to the camera changes were produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc9bbb5510832988d96a93a2083b74)