### PR TITLE
Adjust Ludo broadcast camera for token-entry turns

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -7602,6 +7602,15 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     const entering = current < 0;
     const target = entering ? 0 : current + roll;
     if (target > GOAL_PROGRESS) return advanceTurn(false);
+    if (entering) {
+      setCameraViewForTurn(player, CAMERA_TURN_VIEW_DURATION_MS, { force: true });
+      setCameraFocus({
+        target: resolveTurnLookTarget(player),
+        follow: false,
+        priority: 3,
+        force: true
+      });
+    }
     const captureVictims = getCaptureVictims(player, target);
     const hasCapture = captureVictims.length > 0;
     const finalizeMove = () => {


### PR DESCRIPTION
### Motivation
- Keep the broadcast camera aligned with the active player when a token is entering the board and preserve the left/right side-facing orientation used for normal turn framing instead of drifting to a generic board-centric view.

### Description
- Detect token-entry in `moveToken` inside `webapp/src/pages/Games/LudoBattleRoyal.jsx` and call `setCameraViewForTurn(player, CAMERA_TURN_VIEW_DURATION_MS, { force: true })` to restore the active-turn framing.
- Immediately call `setCameraFocus({ target: resolveTurnLookTarget(player), follow: false, priority: 3, force: true })` for token-entry to enforce the side-oriented look for left/right players.

### Testing
- Ran `cd webapp && npx eslint src/pages/Games/LudoBattleRoyal.jsx`, which executed and produced only an ignore warning and no lint errors.
- Ran `cd webapp && npx eslint --no-ignore src/pages/Games/LudoBattleRoyal.jsx`, which also reported the file is ignored by repo ESLint config and produced no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc9bbb5510832988d96a93a2083b74)