### PR TITLE
Follow dice with broadcast camera on roll and speed up no-move handoff in Ludo

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -7703,6 +7703,13 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     stopDiceTransition();
     dice.userData.isRolling = true;
     setCameraViewForTurn(player, CAMERA_TURN_VIEW_DURATION_MS, { force: true });
+    setCameraFocus({
+      object: dice,
+      follow: true,
+      priority: 5,
+      force: true,
+      offset: CAMERA_TARGET_LIFT + 0.028
+    });
     playDiceSound();
     const landingFocus = baseTarget.clone();
     const value = await spinDice(dice, {
@@ -7741,7 +7748,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       turnAdvanceTimeoutRef.current = window.setTimeout(() => {
         turnAdvanceTimeoutRef.current = null;
         advanceTurn(value === 6);
-      }, 900);
+      }, 250);
       return;
     }
     if (player === 0) {


### PR DESCRIPTION
### Motivation
- Improve broadcast camera behavior for Ludo Battle Royal so the camera does not linger on the board when the player has no tokens or no moves, and so it follows the dice when a player throws (matching the requested UX). 

### Description
- In `webapp/src/pages/Games/LudoBattleRoyal.jsx` the `rollDice` flow now calls `setCameraFocus(...)` with the `dice` object and `follow: true` immediately after `setCameraViewForTurn(...)` so the broadcast camera follows the dice while the roll is animated. 
- Reduced the handoff delay in the `!options.length` (no-move) branch from `900ms` to `250ms` so the next-player camera/turn transition happens more promptly. 
- Kept existing guards that avoid board-focus when the player has no tokens or no available moves; this change only adds dice-following and speeds up handoff timing.

### Testing
- Built the webapp with `cd webapp && npm run build` and the Vite production build completed successfully. 
- No automated unit tests were added or modified for this change; build succeeded (with standard bundle warnings) so the change is verified to compile.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dca2d2edb48329b2611396f1aeff27)