### PR TITLE
Adjust Ludo broadcast camera turn/focus behavior

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -6082,16 +6082,6 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         }
         if (!seg) {
           const done = anim.onComplete;
-          if (anim.token) {
-            setCameraFocus({
-              target: anim.token.position.clone(),
-              follow: false,
-              ttl: 1.4,
-              priority: 2,
-              offset: CAMERA_TARGET_LIFT + 0.02,
-              force: true
-            });
-          }
           clearAnimationHighlights(anim);
           state.animation = null;
           if (typeof done === 'function') done();
@@ -6120,16 +6110,6 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             anim.elapsed = 0;
             if (anim.segment >= anim.segments.length) {
               const done = anim.onComplete;
-              if (anim.token) {
-                setCameraFocus({
-                  target: anim.token.position.clone(),
-                  follow: false,
-                  ttl: 1.5,
-                  priority: 2,
-                  offset: CAMERA_TARGET_LIFT + 0.02,
-                  force: true
-                });
-              }
               clearAnimationHighlights(anim);
               state.animation = null;
               if (typeof done === 'function') {
@@ -7489,6 +7469,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
   const advanceTurn = (extraTurn) => {
     clearTurnAdvanceTimeout();
     clearHumanSelection();
+    cancelCameraFocusAnimation();
     let nextTurn = 0;
     let updated = false;
     setUi((s) => {
@@ -7732,6 +7713,8 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         offset: CAMERA_TARGET_LIFT + 0.03,
         force: true
       });
+    } else {
+      setCameraViewForTurn(player, CAMERA_TURN_VIEW_DURATION_MS, { force: true });
     }
     if (!options.length) {
       const playerCycle = Math.max(1, activePlayerCount);


### PR DESCRIPTION
### Motivation
- Prevent the broadcast camera from being locked to a token/board after a move ends so it can follow turn logic immediately.  
- Ensure the camera does not pull to the board when a player has no tokens on the board or no available moves after a roll.  
- Clear any pending camera follow/TTL when advancing turns so the camera immediately hands off to the next player.

### Description
- Removed post-move `setCameraFocus(...)` calls at animation completion so finishing a token path no longer forces a lingering board/token focus.  
- Call `cancelCameraFocusAnimation()` during `advanceTurn(...)` to reset follow/TTL/focus state before switching to the next player.  
- Preserve per-turn framing by calling `setCameraViewForTurn(...)` when the active player has no board tokens or no movable options instead of forcing a board focus, and only focus landing when appropriate (keeps dice follow and per-turn look behavior consistent).

### Testing
- Built the web client with `npm run build` in `webapp/` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dca2d2edb48329b2611396f1aeff27)