### PR TITLE
Fix Pool Royale cue force application at stroke impact

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -26432,40 +26432,17 @@ const powerRef = useRef(hud.power);
               spinSide = baseSide * SIDE_SPIN_MULTIPLIER * topspinPowerScale;
             }
           }
-          let shotImpactCommitted = false;
+          const impactPayload = {
+            applied: false,
+            base,
+            aimDir: shotAimDir,
+            physicsSpin: { x: spinSide, y: spinTop },
+            clampedPower,
+            liftStrength
+          };
           const commitShotImpact = () => {
-            if (shotImpactCommitted) return;
-            shotImpactCommitted = true;
-            cue.vel.copy(base);
-            if (cue.spin) {
-              cue.spin.set(spinSide, spinTop);
-            }
-            if (cue.omega) {
-              cue.omega.set(0, 0, 0);
-              TMP_VEC3_A.set(shotAimDir.x, 0, shotAimDir.y);
-              if (TMP_VEC3_A.lengthSq() > 1e-8) TMP_VEC3_A.normalize();
-              TMP_VEC3_B.set(-TMP_VEC3_A.z, 0, TMP_VEC3_A.x);
-              if (TMP_VEC3_B.lengthSq() > 1e-8) TMP_VEC3_B.normalize();
-              TMP_VEC3_C.copy(TMP_VEC3_B).multiplyScalar(scaledSpin.x * BALL_R);
-              TMP_VEC3_C.y += scaledSpin.y * BALL_R;
-              const impulseMag = BALL_MASS * base.length();
-              TMP_VEC3_D.copy(TMP_VEC3_A).multiplyScalar(impulseMag);
-              TMP_VEC3_E.copy(TMP_VEC3_C).cross(TMP_VEC3_D);
-              cue.omega.addScaledVector(TMP_VEC3_E, 1 / BALL_INERTIA);
-            }
-            if (cue.pendingSpin) cue.pendingSpin.set(0, 0);
-            cue.spinMode = 'standard';
-            cue.swerveStrength = 0;
-            cue.swervePowerStrength = 0;
-            resetSpinRef.current?.();
-            cueLiftRef.current.lift = 0;
-            cueLiftRef.current.startLift = 0;
-            cue.impacted = false;
-            cue.launchDir = shotAimDir.clone().normalize();
-            maxPowerLiftTriggered = false;
-            cue.lift = 0;
-            cue.liftVel = 0;
-            playCueHit(clampedPower * 0.6);
+            applyShotAtImpact(impactPayload);
+            pendingImpactRef.current = null;
           };
 
           if (cameraRef.current && sphRef.current) {
@@ -26688,6 +26665,13 @@ const powerRef = useRef(hud.power);
               animationStyle: strokeStyle,
               motionTechnique: strokeProfile.motion ?? strokeStyle,
               releaseStartsFromCurrentPull: true
+            };
+            pendingImpactRef.current = {
+              time:
+                startTime +
+                Math.max(0, pullbackDuration) +
+                Math.max(1, strikeDuration) * (strokeProfile.impactThreshold ?? 0.9),
+              apply: commitShotImpact
             };
           } else {
             commitShotImpact();


### PR DESCRIPTION
### Motivation
- The cue stick animation was moving but the physics impulse from the power slider wasn't always transferred to the cue ball, leaving the cue ball stationary after release.  
- Ensure the exact slider-defined force and shot direction are applied at the precise impact moment, and make the commit robust to skipped animation frames.  
- Used `skill-creator` to follow the local workflow for making a small, targeted gameplay fix.

### Description
- Centralized impact logic by creating an `impactPayload` (power, direction, spin, lift, etc.) and routing it through the existing `applyShotAtImpact` helper so physics application is idempotent and consistent.  
- Replaced the previous inline impact math path with a single `commitShotImpact` that calls `applyShotAtImpact(impactPayload)`.  
- Added a fallback timed `pendingImpactRef` scheduled at the cue-stroke impact threshold so the force is applied even if the animation callback is missed by a long frame.  
- File changed: `webapp/src/pages/Games/PoolRoyale.jsx` (wires slider -> payload -> physics, and schedules fallback impact commit).

### Testing
- Ran the production build with `npm --prefix webapp run build` and it completed successfully (Vite build finished; only non-blocking chunk-size/dynamic-import warnings were reported).  
- No automated unit tests were modified; change validated via the build output only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcafb384788329be7a063d17643c4f)