### PR TITLE
Use committed power slider value for Pool Royale shot impact

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -26062,7 +26062,7 @@ const powerRef = useRef(hud.power);
       };
 
       // Fire (slider triggers on release)
-      const fire = () => {
+      const fire = (powerOverride = null) => {
         const currentHud = hudRef.current;
         const frameSnapshot = frameRef.current ?? frameState;
         const fullTableHandPlacement =
@@ -26160,7 +26160,10 @@ const powerRef = useRef(hud.power);
         } else {
           aimDir.normalize();
         }
-        const clampedPower = clampPower(powerRef.current, 0);
+        const resolvedPower = Number.isFinite(powerOverride)
+          ? powerOverride
+          : powerRef.current;
+        const clampedPower = clampPower(resolvedPower, 0);
         const strokeStyle = cueStrokeAnimationStyleRef.current ?? DEFAULT_CUE_STROKE_STYLE;
         const strokeProfile = resolveCueStrokeProfile(strokeStyle, clampedPower);
         const rawSpin = applySpinConstraints(aimDir, true);
@@ -32461,8 +32464,8 @@ const powerRef = useRef(hud.power);
       onStart: () => {
         captureCueStickAnchor();
       },
-      onCommit: () => {
-        fireRef.current?.();
+      onCommit: (sliderValue) => {
+        fireRef.current?.((sliderValue ?? 0) / 100);
         requestAnimationFrame(() => {
           slider.set(slider.min, { animate: true });
           applyPower(0);


### PR DESCRIPTION
### Motivation
- The cue stick animation played on release but the cue-ball sometimes received no/incorrect impulse because the slider UI could reset before the shot computed power.
- Ensure the physics impulse at impact exactly matches the committed slider power so the cue ball starts moving immediately with the intended force.

### Description
- Changed the `fire` function signature to accept an optional `powerOverride` and resolve the shot power with `Number.isFinite(powerOverride) ? powerOverride : powerRef.current` before clamping with `clampPower`.
- Wired the power slider `onCommit` to pass the committed slider value into `fire` as `fireRef.current((sliderValue ?? 0) / 100)` so the latched slider value is used at impact time.
- Modified file: `webapp/src/pages/Games/PoolRoyale.jsx` to implement the override and hook the slider commit handler; existing strike timing and animation logic was preserved.

### Testing
- Ran focused Jest suites with `npm test -- --runInBand test/poolRoyaleCueStrokeTimeline.test.js test/cueShotImpact.test.js`, and both test suites passed (2 passed, 2 total; 7 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcafb384788329be7a063d17643c4f)