### PR TITLE
Improve Ludo broadcast camera framing and human camera control

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1430,7 +1430,8 @@ const CAMERA_DOLLY_FACTOR = ARENA_CAMERA_DEFAULTS.wheelDeltaFactor;
 const CAMERA_TARGET_LIFT = 0.028 * MODEL_SCALE;
 const CAMERA_SIDE_LOOK_EXTRA = 0.13;
 const CAMERA_TURN_PLAYER_LERP = 0.58;
-const CAMERA_BROADCAST_TARGET_BLEND = 0;
+const CAMERA_BROADCAST_TARGET_BLEND = 0.6;
+const CAMERA_BROADCAST_SIDE_BLEND = 0.82;
 const CAMERA_SIDE_AVATAR_BLEND = 1.08;
 const USER_TURN_CAMERA_PULLBACK = 0.15 * MODEL_SCALE;
 const USER_TURN_CAMERA_LIFT = 0.09 * MODEL_SCALE;
@@ -1455,8 +1456,8 @@ const PORTRAIT_CAMERA_TUNING = Object.freeze({
   targetLift: 0.055 * MODEL_SCALE
 });
 const CAMERA_EXTRA_PULLBACK = 0;
-const CAMERA_EXTRA_LIFT = 0.058;
-const PORTRAIT_CAMERA_EXTRA_LIFT = 0.04;
+const CAMERA_EXTRA_LIFT = 0.064;
+const PORTRAIT_CAMERA_EXTRA_LIFT = 0.048;
 const CAMERA_PLAYER_CENTER_X_EPSILON = 0.0001;
 const CAMERA_LOOK_YAW_LIMIT = THREE.MathUtils.degToRad(26);
 const CAMERA_LOOK_YAW_DRAG_FACTOR = 0.0055;
@@ -3655,8 +3656,8 @@ const TOKEN_THINNESS_SCALE = 0.86;
 const TOKEN_RAIL_OUTWARD_PUSH = 0.108;
 const CAPTURE_ANIMATION_HEIGHT_COMPENSATION = TABLE_VERTICAL_LOWERING;
 const CAMERA_TURN_VIEW_DURATION_MS = 520;
-const CAMERA_BROADCAST_ANIMATION_MS = 560;
-const CAMERA_RETURN_ANIMATION_MS = 620;
+const CAMERA_BROADCAST_ANIMATION_MS = 700;
+const CAMERA_RETURN_ANIMATION_MS = 760;
 const ROCK_TOKEN_REFERENCE_SCALE = Object.freeze({ x: 0.78, y: 0.92, z: 0.74 });
 const TOKEN_TYPE_SCALE_PROFILE = Object.freeze({
   pawn: {
@@ -6176,10 +6177,10 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         const followedTarget = cameraTurnStateRef.current.followObject.getWorldPosition(new THREE.Vector3());
         const liftedTarget = resolveFocusCameraState(followedTarget, CAMERA_TARGET_LIFT + 0.02);
         if (liftedTarget) {
-          controls.target.lerp(liftedTarget.target, 0.28);
+          controls.target.lerp(liftedTarget.target, 0.18);
           if (cameraTurnStateRef.current.followOffset?.isVector3) {
             const followCameraTarget = liftedTarget.target.clone().add(cameraTurnStateRef.current.followOffset);
-            camera.position.lerp(followCameraTarget, 0.18);
+            camera.position.lerp(followCameraTarget, 0.12);
           }
           cameraTurnStateRef.current.currentTarget = controls.target.clone();
         }
@@ -7046,7 +7047,16 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     const arena = arenaRef.current;
     if (!camera || !arena?.boardLookTarget || !focusTarget?.isVector3) return null;
     const boardLookTarget = arena.boardLookTarget;
-    const target = boardLookTarget.clone().lerp(focusTarget, CAMERA_BROADCAST_TARGET_BLEND);
+    const sideDistance = Math.min(
+      1,
+      Math.abs(focusTarget.x - boardLookTarget.x) / Math.max(BOARD_CLOTH_HALF * 0.75, 0.01)
+    );
+    const dynamicBlend = THREE.MathUtils.lerp(
+      CAMERA_BROADCAST_TARGET_BLEND,
+      CAMERA_BROADCAST_SIDE_BLEND,
+      sideDistance
+    );
+    const target = boardLookTarget.clone().lerp(focusTarget, dynamicBlend);
     target.y = (arena.tableInfo?.surfaceY ?? target.y) + offset;
 
     return { position: camera.position.clone(), target };
@@ -7101,10 +7111,21 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     return baseTarget;
   }, []);
 
+  const shouldRespectUserCamera = useCallback(
+    (player) => {
+      if (player !== 0) return false;
+      if (humanSelectionRef.current) return true;
+      const state = stateRef.current;
+      if (!state || state.winner) return false;
+      return state.turn === 0;
+    },
+    []
+  );
+
   const setCameraViewForTurn = useCallback((player, duration = CAMERA_TURN_VIEW_DURATION_MS, { force = false } = {}) => {
     cancelCameraViewAnimation();
     if (isCamera2d || !LUDO_CAMERA_AUTO_LOOK_ENABLED) return;
-    if (player === 0 && preserveUserTurnCameraRef.current && !force) return;
+    if (!force && (preserveUserTurnCameraRef.current || shouldRespectUserCamera(player))) return;
     if (player !== 0) {
       preserveUserTurnCameraRef.current = false;
     }
@@ -7144,13 +7165,14 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     const nextView = resolveTurnCameraState(player, CAMERA_TARGET_LIFT);
     if (!nextView) return;
     animateCameraPose(nextView.target, nextView.position, duration);
-  }, [animateCameraPose, cancelCameraViewAnimation, isCamera2d, resolveTurnCameraState]);
+  }, [animateCameraPose, cancelCameraViewAnimation, isCamera2d, resolveTurnCameraState, shouldRespectUserCamera]);
 
   const setCameraFocus = useCallback(
     (focus = {}) => {
       const state = stateRef.current;
       const controls = controlsRef.current;
       if (!state || !controls || isCamera2d || !LUDO_CAMERA_AUTO_LOOK_ENABLED) return;
+      if (!focus.force && shouldRespectUserCamera(state.turn)) return;
       const { object, target, follow = false, ttl = 0, priority = 0, force = false, offset = CAMERA_TARGET_LIFT } = focus;
       if (!force && priority < cameraTurnStateRef.current.activePriority) return;
 
@@ -7206,7 +7228,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         }, Math.max(0, ttl * 1000));
       }
     },
-    [animateCameraPose, isCamera2d, resolveFocusCameraState, resolveTurnCameraState, resolveTurnLookTarget]
+    [animateCameraPose, isCamera2d, resolveFocusCameraState, resolveTurnCameraState, resolveTurnLookTarget, shouldRespectUserCamera]
   );
 
   const getWorldForProgress = (player, progress, tokenIndex) => {
@@ -7488,8 +7510,21 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       const state = stateRef.current;
       if (state) state.turn = nextTurn;
       updateTurnIndicator(nextTurn);
-      setCameraViewForTurn(nextTurn);
-      setCameraFocus({ target: resolveTurnLookTarget(nextTurn), priority: 1, force: true });
+      const shouldLockHumanCamera = nextTurn === 0;
+      preserveUserTurnCameraRef.current = shouldLockHumanCamera;
+      if (!shouldLockHumanCamera) {
+        setCameraViewForTurn(nextTurn);
+        setCameraFocus({ target: resolveTurnLookTarget(nextTurn), priority: 1, force: true });
+      }
+      if (diceRef.current && !shouldLockHumanCamera) {
+        setCameraFocus({
+          object: diceRef.current,
+          follow: true,
+          priority: 4,
+          force: true,
+          offset: CAMERA_TARGET_LIFT + 0.022
+        });
+      }
       updated = true;
       const status =
         nextTurn === 0
@@ -7593,12 +7628,19 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     const target = entering ? 0 : current + roll;
     if (target > GOAL_PROGRESS) return advanceTurn(false);
     if (entering) {
-      setCameraViewForTurn(player, CAMERA_TURN_VIEW_DURATION_MS, { force: true });
+      const seatSideTarget = getWorldForProgress(player, 0, tokenIndex);
+      const isSideSeat = player === 1 || player === 3;
+      const enteringOffset = isSideSeat ? CAMERA_TARGET_LIFT + 0.035 : CAMERA_TARGET_LIFT + 0.02;
+      if (player !== 0) {
+        setCameraViewForTurn(player, CAMERA_TURN_VIEW_DURATION_MS, { force: true });
+      }
       setCameraFocus({
-        target: resolveTurnLookTarget(player),
+        target: seatSideTarget,
         follow: false,
-        priority: 3,
-        force: true
+        priority: 6,
+        ttl: 0.95,
+        force: true,
+        offset: enteringOffset
       });
     }
     const captureVictims = getCaptureVictims(player, target);
@@ -7692,7 +7734,16 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     baseTarget.y = baseHeight;
     stopDiceTransition();
     dice.userData.isRolling = true;
-    setCameraViewForTurn(player, CAMERA_TURN_VIEW_DURATION_MS, { force: true });
+    if (player !== 0) {
+      setCameraViewForTurn(player, CAMERA_TURN_VIEW_DURATION_MS, { force: true });
+    }
+    setCameraFocus({
+      object: dice,
+      follow: false,
+      priority: 5,
+      force: true,
+      offset: CAMERA_TARGET_LIFT + 0.025
+    });
     playDiceSound();
     const landingFocus = baseTarget.clone();
     const value = await spinDice(dice, {


### PR DESCRIPTION
### Motivation
- Increase board visibility on phone (portrait) and make broadcast camera actually frame left/right action (dice and side tokens) rather than always centering on the board. 
- Make broadcast camera movement smoother and more stable, and avoid overriding a human player's manual camera while they are selecting/moving tokens.

### Description
- Raised camera lift constants (`CAMERA_EXTRA_LIFT`, `PORTRAIT_CAMERA_EXTRA_LIFT`) and increased broadcast animation durations (`CAMERA_BROADCAST_ANIMATION_MS`, `CAMERA_RETURN_ANIMATION_MS`) to improve visibility and smoothness. 
- Added `CAMERA_BROADCAST_SIDE_BLEND` and made `resolveFocusCameraState` compute a dynamic blend toward the focus target based on side distance so left/right lane activity is pulled into frame. 
- Reduced follow lerp aggressiveness in the render loop to make tracking smoother and less jumpy for broadcast follow targets. 
- Introduced `shouldRespectUserCamera` and updated `setCameraViewForTurn` / `setCameraFocus` logic so the auto-camera will not override a human player's manually adjusted view during their turn or while making a selection. 
- When advancing turns and moving dice, updated logic to hold/track the dice for the upcoming player (for non-human turns) and to explicitly focus on side-seat token entry so left/right players entering the board are visible. 

### Testing
- Ran unit tests: `npm run -s test -- --runInBand test/onlineGamePolicy.test.js` and the suite passed (5 tests). 
- Ran lint checks: `npx eslint webapp/src/pages/Games/LudoBattleRoyal.jsx --max-warnings=0`, which reported the file is ignored by repo lint config (no file-level lint gate applied for this path).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcb60df47c83299f350fa712294c6c)