### PR TITLE
Improve Ludo camera: dynamic broadcast blending, respect human camera, and timing/lerp tweaks

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1430,7 +1430,8 @@ const CAMERA_DOLLY_FACTOR = ARENA_CAMERA_DEFAULTS.wheelDeltaFactor;
 const CAMERA_TARGET_LIFT = 0.028 * MODEL_SCALE;
 const CAMERA_SIDE_LOOK_EXTRA = 0.13;
 const CAMERA_TURN_PLAYER_LERP = 0.58;
-const CAMERA_BROADCAST_TARGET_BLEND = 0;
+const CAMERA_BROADCAST_TARGET_BLEND = 0.6;
+const CAMERA_BROADCAST_SIDE_BLEND = 0.82;
 const CAMERA_SIDE_AVATAR_BLEND = 1.08;
 const USER_TURN_CAMERA_PULLBACK = 0.15 * MODEL_SCALE;
 const USER_TURN_CAMERA_LIFT = 0.09 * MODEL_SCALE;
@@ -1455,8 +1456,8 @@ const PORTRAIT_CAMERA_TUNING = Object.freeze({
   targetLift: 0.055 * MODEL_SCALE
 });
 const CAMERA_EXTRA_PULLBACK = 0;
-const CAMERA_EXTRA_LIFT = 0.058;
-const PORTRAIT_CAMERA_EXTRA_LIFT = 0.04;
+const CAMERA_EXTRA_LIFT = 0.064;
+const PORTRAIT_CAMERA_EXTRA_LIFT = 0.048;
 const CAMERA_PLAYER_CENTER_X_EPSILON = 0.0001;
 const CAMERA_LOOK_YAW_LIMIT = THREE.MathUtils.degToRad(26);
 const CAMERA_LOOK_YAW_DRAG_FACTOR = 0.0055;
@@ -3655,8 +3656,8 @@ const TOKEN_THINNESS_SCALE = 0.86;
 const TOKEN_RAIL_OUTWARD_PUSH = 0.108;
 const CAPTURE_ANIMATION_HEIGHT_COMPENSATION = TABLE_VERTICAL_LOWERING;
 const CAMERA_TURN_VIEW_DURATION_MS = 520;
-const CAMERA_BROADCAST_ANIMATION_MS = 560;
-const CAMERA_RETURN_ANIMATION_MS = 620;
+const CAMERA_BROADCAST_ANIMATION_MS = 700;
+const CAMERA_RETURN_ANIMATION_MS = 760;
 const ROCK_TOKEN_REFERENCE_SCALE = Object.freeze({ x: 0.78, y: 0.92, z: 0.74 });
 const TOKEN_TYPE_SCALE_PROFILE = Object.freeze({
   pawn: {
@@ -6176,10 +6177,10 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         const followedTarget = cameraTurnStateRef.current.followObject.getWorldPosition(new THREE.Vector3());
         const liftedTarget = resolveFocusCameraState(followedTarget, CAMERA_TARGET_LIFT + 0.02);
         if (liftedTarget) {
-          controls.target.lerp(liftedTarget.target, 0.28);
+          controls.target.lerp(liftedTarget.target, 0.18);
           if (cameraTurnStateRef.current.followOffset?.isVector3) {
             const followCameraTarget = liftedTarget.target.clone().add(cameraTurnStateRef.current.followOffset);
-            camera.position.lerp(followCameraTarget, 0.18);
+            camera.position.lerp(followCameraTarget, 0.12);
           }
           cameraTurnStateRef.current.currentTarget = controls.target.clone();
         }
@@ -7046,7 +7047,16 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     const arena = arenaRef.current;
     if (!camera || !arena?.boardLookTarget || !focusTarget?.isVector3) return null;
     const boardLookTarget = arena.boardLookTarget;
-    const target = boardLookTarget.clone().lerp(focusTarget, CAMERA_BROADCAST_TARGET_BLEND);
+    const sideDistance = Math.min(
+      1,
+      Math.abs(focusTarget.x - boardLookTarget.x) / Math.max(BOARD_CLOTH_HALF * 0.75, 0.01)
+    );
+    const dynamicBlend = THREE.MathUtils.lerp(
+      CAMERA_BROADCAST_TARGET_BLEND,
+      CAMERA_BROADCAST_SIDE_BLEND,
+      sideDistance
+    );
+    const target = boardLookTarget.clone().lerp(focusTarget, dynamicBlend);
     target.y = (arena.tableInfo?.surfaceY ?? target.y) + offset;
 
     return { position: camera.position.clone(), target };
@@ -7101,10 +7111,22 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     return baseTarget;
   }, []);
 
+  const shouldRespectUserCamera = useCallback(
+    (player) => {
+      if (player !== 0) return false;
+      if (humanSelectionRef.current) return true;
+      const state = stateRef.current;
+      if (!state || state.winner) return false;
+      return Boolean(state.animation?.active && state.animation.player === 0);
+    },
+    []
+  );
+
   const setCameraViewForTurn = useCallback((player, duration = CAMERA_TURN_VIEW_DURATION_MS, { force = false } = {}) => {
     cancelCameraViewAnimation();
     if (isCamera2d || !LUDO_CAMERA_AUTO_LOOK_ENABLED) return;
-    if (player === 0 && preserveUserTurnCameraRef.current && !force) return;
+    if (shouldRespectUserCamera(player)) return;
+    if (!force && preserveUserTurnCameraRef.current) return;
     if (player !== 0) {
       preserveUserTurnCameraRef.current = false;
     }
@@ -7144,14 +7166,24 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     const nextView = resolveTurnCameraState(player, CAMERA_TARGET_LIFT);
     if (!nextView) return;
     animateCameraPose(nextView.target, nextView.position, duration);
-  }, [animateCameraPose, cancelCameraViewAnimation, isCamera2d, resolveTurnCameraState]);
+  }, [animateCameraPose, cancelCameraViewAnimation, isCamera2d, resolveTurnCameraState, shouldRespectUserCamera]);
 
   const setCameraFocus = useCallback(
     (focus = {}) => {
       const state = stateRef.current;
       const controls = controlsRef.current;
       if (!state || !controls || isCamera2d || !LUDO_CAMERA_AUTO_LOOK_ENABLED) return;
-      const { object, target, follow = false, ttl = 0, priority = 0, force = false, offset = CAMERA_TARGET_LIFT } = focus;
+      const {
+        object,
+        target,
+        follow = false,
+        ttl = 0,
+        priority = 0,
+        force = false,
+        offset = CAMERA_TARGET_LIFT,
+        allowDuringHumanMove = false
+      } = focus;
+      if (!allowDuringHumanMove && shouldRespectUserCamera(state.turn)) return;
       if (!force && priority < cameraTurnStateRef.current.activePriority) return;
 
       let nextTarget = null;
@@ -7206,7 +7238,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         }, Math.max(0, ttl * 1000));
       }
     },
-    [animateCameraPose, isCamera2d, resolveFocusCameraState, resolveTurnCameraState, resolveTurnLookTarget]
+    [animateCameraPose, isCamera2d, resolveFocusCameraState, resolveTurnCameraState, resolveTurnLookTarget, shouldRespectUserCamera]
   );
 
   const getWorldForProgress = (player, progress, tokenIndex) => {
@@ -7488,8 +7520,21 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       const state = stateRef.current;
       if (state) state.turn = nextTurn;
       updateTurnIndicator(nextTurn);
-      setCameraViewForTurn(nextTurn);
-      setCameraFocus({ target: resolveTurnLookTarget(nextTurn), priority: 1, force: true });
+      const shouldLockHumanCamera = nextTurn === 0;
+      preserveUserTurnCameraRef.current = shouldLockHumanCamera;
+      if (!shouldLockHumanCamera) {
+        setCameraViewForTurn(nextTurn);
+        setCameraFocus({ target: resolveTurnLookTarget(nextTurn), priority: 1, force: true });
+      }
+      if (diceRef.current && !shouldLockHumanCamera) {
+        setCameraFocus({
+          object: diceRef.current,
+          follow: true,
+          priority: 4,
+          force: true,
+          offset: CAMERA_TARGET_LIFT + 0.022
+        });
+      }
       updated = true;
       const status =
         nextTurn === 0
@@ -7593,13 +7638,20 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     const target = entering ? 0 : current + roll;
     if (target > GOAL_PROGRESS) return advanceTurn(false);
     if (entering) {
-      setCameraViewForTurn(player, CAMERA_TURN_VIEW_DURATION_MS, { force: true });
-      setCameraFocus({
-        target: resolveTurnLookTarget(player),
-        follow: false,
-        priority: 3,
-        force: true
-      });
+      const seatSideTarget = getWorldForProgress(player, 0, tokenIndex);
+      const isSideSeat = player === 1 || player === 3;
+      const enteringOffset = isSideSeat ? CAMERA_TARGET_LIFT + 0.035 : CAMERA_TARGET_LIFT + 0.02;
+      if (player !== 0) {
+        setCameraViewForTurn(player, CAMERA_TURN_VIEW_DURATION_MS, { force: true });
+        setCameraFocus({
+          target: seatSideTarget,
+          follow: false,
+          priority: 6,
+          ttl: 0.95,
+          force: true,
+          offset: enteringOffset
+        });
+      }
     }
     const captureVictims = getCaptureVictims(player, target);
     const hasCapture = captureVictims.length > 0;
@@ -7692,7 +7744,16 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     baseTarget.y = baseHeight;
     stopDiceTransition();
     dice.userData.isRolling = true;
-    setCameraViewForTurn(player, CAMERA_TURN_VIEW_DURATION_MS, { force: true });
+    if (player !== 0) {
+      setCameraViewForTurn(player, CAMERA_TURN_VIEW_DURATION_MS, { force: true });
+      setCameraFocus({
+        object: dice,
+        follow: false,
+        priority: 5,
+        force: true,
+        offset: CAMERA_TARGET_LIFT + 0.025
+      });
+    }
     playDiceSound();
     const landingFocus = baseTarget.clone();
     const value = await spinDice(dice, {
@@ -7714,7 +7775,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     const hasBoardMoveOption = options.some((option) => !option.entering);
     const keepTurnCameraFraming = !hasBoardTokenBeforeRoll || !options.length || !hasBoardMoveOption;
     scheduleDiceClear();
-    if (!keepTurnCameraFraming) {
+    if (!keepTurnCameraFraming && player !== 0) {
       setCameraFocus({
         target: landingFocus,
         follow: false,
@@ -7723,7 +7784,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         offset: CAMERA_TARGET_LIFT + 0.03,
         force: true
       });
-    } else {
+    } else if (player !== 0) {
       setCameraViewForTurn(player, CAMERA_TURN_VIEW_DURATION_MS, { force: true });
     }
     if (!options.length) {
@@ -7739,7 +7800,6 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       return;
     }
     if (player === 0) {
-      setCameraViewForTurn(0, CAMERA_TURN_VIEW_DURATION_MS, { force: true });
       beginHumanSelection(value, options, { skipCameraFollow: !hasBoardTokenBeforeRoll });
       return;
     }


### PR DESCRIPTION
### Motivation
- Make broadcast/focus camera framing better for side seats and more dynamic relative to board position. 
- Prevent automatic camera changes from overriding a human player's manual camera during their turn or move. 
- Tune animation timing, lift offsets and smoothing to produce a more natural camera feel.

### Description
- Introduced dynamic broadcast blending by changing `CAMERA_BROADCAST_TARGET_BLEND` and adding `CAMERA_BROADCAST_SIDE_BLEND`, and updated `resolveFocusCameraState` to interpolate blend based on horizontal side distance. 
- Added `shouldRespectUserCamera` helper and wired it into `setCameraViewForTurn` and `setCameraFocus` to avoid forcing camera changes during human moves, and added `allowDuringHumanMove` flag to `setCameraFocus`. 
- Reduced in-loop lerp factors for `controls.target` and `camera.position` to slow automatic recentering, and increased `CAMERA_BROADCAST_ANIMATION_MS` and `CAMERA_RETURN_ANIMATION_MS` along with small increases to `CAMERA_EXTRA_LIFT` and `PORTRAIT_CAMERA_EXTRA_LIFT`. 
- Prevented camera juggling for the local player in `advanceTurn`, `rollDice`, and `moveToken` by skipping or lowering focus changes for `player === 0`, and added more targeted focus behavior for side-seat enters and dice rolls.

### Testing
- Ran the project's automated test suite with `yarn test` and all tests passed. 
- Ran `yarn build` to ensure the bundle compiles without errors. 
- Ran linters with `yarn lint` and addressed no lint failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcb60df47c83299f350fa712294c6c)