### PR TITLE
Refine capture FX: downsize aircraft, simplify airstrike pathing, and apply gold accents to pieces

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -111,13 +111,14 @@ const CAPTURE_GROUND_FIRE_TIME = 0;
 const CAPTURE_GROUND_TRAVEL_TIME = 2.3;
 const CAPTURE_GROUND_TOTAL = CAPTURE_GROUND_FIRE_TIME + CAPTURE_GROUND_TRAVEL_TIME;
 const CAPTURE_DRONE_SCALE = 0.058;
-const CAPTURE_JET_SCALE = 0.0724992; // 20% smaller than the previous jet scale so portrait fly-bys stay tighter
-const CAPTURE_HELICOPTER_SCALE = 0.10176; // extra 20% smaller for tighter portrait framing
+const CAPTURE_JET_SCALE = 0.05799936; // additional 20% downsize from current jet scale
+const CAPTURE_HELICOPTER_SCALE = 0.081408; // additional 20% downsize from current helicopter scale
 const CAPTURE_DRONE_ALTITUDE = 1.36;
 const CAPTURE_FLIGHT_ALTITUDE = CAPTURE_DRONE_ALTITUDE;
-const CAPTURE_AIR_STRIKE_BOARD_CLEARANCE = -0.1; // lower jet/helicopter so they sit visibly closer to the board on portrait screens
-const CAPTURE_AIR_STRIKE_MIN_ALTITUDE = -0.14; // keep aircraft lower and tighter to the board plane for portrait framing
-const CAPTURE_JET_ALTITUDE = CAPTURE_AIR_STRIKE_MIN_ALTITUDE;
+const CAPTURE_DRONE_REFERENCE_BOARD_ALTITUDE = CAPTURE_FLIGHT_ALTITUDE * 0.56; // cruise height the drone visually keeps above board
+const CAPTURE_AIR_STRIKE_BOARD_CLEARANCE = 0; // measure air-strike altitude strictly from board plane
+const CAPTURE_AIR_STRIKE_ALTITUDE_MULTIPLIER = 3; // jet/helicopter fly 3x higher than the drone reference altitude
+const CAPTURE_JET_ALTITUDE = CAPTURE_DRONE_REFERENCE_BOARD_ALTITUDE * CAPTURE_AIR_STRIKE_ALTITUDE_MULTIPLIER;
 const CAPTURE_HELICOPTER_ALTITUDE_BOOST = 0; // keep helicopter and jet at the same flight altitude
 const CAPTURE_AIR_STRIKE_PATH_RADIUS_FACTOR = 0.42; // tighter radius so jet/helicopter path stays centered above the board
 const CAPTURE_AIR_STRIKE_PATH_EDGE_MARGIN_TILES = 1.6; // pull entry/turn points farther in from board edges
@@ -1193,7 +1194,7 @@ const BEAUTIFUL_GAME_PIECE_STYLE = Object.freeze({
     emissiveIntensity: 0.18
   },
   accent: '#ffffff',
-  goldAccent: '#ffffff',
+  goldAccent: '#d4af37',
   whiteAccent: { color: '#ffffff' },
   blackAccent: '#ffffff'
 });
@@ -3637,6 +3638,48 @@ function isInsideReferenceGoldBand(child, piece, pieceType) {
   return bands.some((band) => Math.min(band.max, testBand.max) - Math.max(band.min, testBand.min) >= 0.02);
 }
 
+function forceBeautifulGameGoldParts(mesh, colorKey = 'white', pieceStyle = BEAUTIFUL_GAME_PIECE_STYLE) {
+  if (!mesh) return;
+  const goldAccent = pieceStyle?.goldAccent || '#d4af37';
+  const accentFallback =
+    colorKey === 'black'
+      ? pieceStyle?.blackAccent?.color || pieceStyle?.blackAccent || pieceStyle?.accent
+      : pieceStyle?.whiteAccent?.color || pieceStyle?.whiteAccent || pieceStyle?.accent;
+  const accentColor = goldAccent || accentFallback || '#d4af37';
+  const pieceType =
+    (mesh?.userData?.__pieceType || mesh?.userData?.t || mesh?.userData?.type || '').toString().toUpperCase() || '';
+  mesh.traverse((child) => {
+    if (!child?.isMesh) return;
+    const name = child.name?.toLowerCase?.() ?? '';
+    const referenceBandMatch = isInsideReferenceGoldBand(child, mesh, pieceType);
+    const shouldAccent =
+      child.userData?.__abgGold ||
+      referenceBandMatch ||
+      name.includes('collar') ||
+      name.includes('crown') ||
+      name.includes('ring') ||
+      name.includes('cross') ||
+      name.includes('band') ||
+      name.includes('rim');
+    if (!shouldAccent) return;
+    const mats = Array.isArray(child.material) ? child.material : [child.material];
+    mats.forEach((mat) => {
+      if (!mat) return;
+      if (mat.color?.set) {
+        mat.color.set(accentColor);
+      } else {
+        mat.color = new THREE.Color(accentColor);
+      }
+      mat.metalness = clamp01((mat.metalness ?? 0.35) + 0.22);
+      mat.roughness = clamp01((mat.roughness ?? 0.34) * 0.7);
+      if (Number.isFinite(mat.clearcoat)) mat.clearcoat = clamp01(Math.max(mat.clearcoat, 0.42));
+      if (Number.isFinite(mat.clearcoatRoughness)) {
+        mat.clearcoatRoughness = clamp01(Math.min(mat.clearcoatRoughness, 0.2));
+      }
+    });
+  });
+}
+
 function markBeautifulGameGoldMeshes(piecePrototypes) {
   ['white', 'black'].forEach((side) => {
     Object.entries(piecePrototypes?.[side] || {}).forEach(([pieceType, piece]) => {
@@ -3662,6 +3705,7 @@ function harmonizeBeautifulGamePieces(piecePrototypes, pieceStyle = BEAUTIFUL_GA
             child.receiveShadow = true;
           }
         });
+        forceBeautifulGameGoldParts(piece, colorKey, pieceStyle);
       });
     });
     return;
@@ -3765,6 +3809,11 @@ function harmonizeBeautifulGamePieces(piecePrototypes, pieceStyle = BEAUTIFUL_GA
       accentize(piece, colorKey, pieceType)
     );
   });
+  ['white', 'black'].forEach((colorKey) => {
+    Object.values(piecePrototypes[colorKey] || {}).forEach((piece) =>
+      forceBeautifulGameGoldParts(piece, colorKey, pieceStyle)
+    );
+  });
 }
 
 function applyBeautifulGameStyleToMeshes(meshes, pieceStyle = BEAUTIFUL_GAME_PIECE_STYLE) {
@@ -3778,6 +3827,8 @@ function applyBeautifulGameStyleToMeshes(meshes, pieceStyle = BEAUTIFUL_GAME_PIE
           child.receiveShadow = true;
         }
       });
+      const colorKey = mesh?.userData?.__pieceColor === 'black' ? 'black' : 'white';
+      forceBeautifulGameGoldParts(mesh, colorKey, pieceStyle);
     });
     return;
   }
@@ -3876,6 +3927,7 @@ function applyBeautifulGameStyleToMeshes(meshes, pieceStyle = BEAUTIFUL_GAME_PIE
     const colorKey = mesh.userData?.__pieceColor === 'black' ? 'black' : 'white';
     recolorMesh(mesh, colorKey);
     accentize(mesh, colorKey);
+    forceBeautifulGameGoldParts(mesh, colorKey, pieceStyle);
   });
 }
 
@@ -9226,64 +9278,46 @@ function Chess3D({
           typeof window !== 'undefined'
             ? (window.innerWidth || 1) / Math.max(window.innerHeight || 1, 1)
             : 1;
-        const portraitTightening = viewportAspect < 1 ? THREE.MathUtils.lerp(0.84, 1, viewportAspect) : 1;
+        const portraitTightening = viewportAspect < 1 ? THREE.MathUtils.lerp(0.86, 1, viewportAspect) : 1;
         const attackFromTopSide = attackerPos.z >= 0;
-        const attackerSideSign = attackFromTopSide ? 1 : -1;
-        const boardPathHalf = half * CAPTURE_AIR_STRIKE_PATH_RADIUS_FACTOR * portraitTightening;
-        const edgeInset = tile * CAPTURE_AIR_STRIKE_PATH_EDGE_MARGIN_TILES;
-        const laneBound = Math.max(tile * 1.42, boardPathHalf - edgeInset);
-        const bottomPlayerBias = tile * CAPTURE_AIR_STRIKE_BOTTOM_PLAYER_BIAS_TILES;
-        const towardBottom = (z) =>
-          THREE.MathUtils.clamp(z - bottomPlayerBias, -boardPathHalf, boardPathHalf);
-        const attackerLaneZ = attackerSideSign * laneBound;
-        const enemyLaneZ = -attackerSideSign * laneBound;
-        const xClamp = laneBound;
-        const laneMidX = THREE.MathUtils.lerp(attackerPos.x, victimPos.x, 0.5);
-        const laneX = THREE.MathUtils.clamp(
-          THREE.MathUtils.lerp(laneMidX, 0, 0.72),
-          -xClamp * 0.72,
-          xClamp * 0.72
+        const center = new THREE.Vector3(
+          THREE.MathUtils.clamp((attackerPos.x + victimPos.x) * 0.5, -half * 0.38, half * 0.38),
+          baseAltitude,
+          THREE.MathUtils.clamp((attackerPos.z + victimPos.z) * 0.5, -half * 0.38, half * 0.38)
         );
-        const turnBendDirection = victimPos.x >= laneX ? 1 : -1;
-        const turnBendX = THREE.MathUtils.clamp(
-          laneX + turnBendDirection * tile * 0.58,
-          -xClamp * 0.96,
-          xClamp * 0.96
-        );
-        const startPos = new THREE.Vector3(laneX, baseAltitude, towardBottom(attackerLaneZ));
-        const entryPos = new THREE.Vector3(
-          THREE.MathUtils.lerp(laneX, victimPos.x, 0.5),
-          baseAltitude - turnAltitudeDrop * 0.26,
-          towardBottom(THREE.MathUtils.lerp(attackerLaneZ, victimPos.z, 0.4))
-        );
-        const turnEntryPos = new THREE.Vector3(
-          THREE.MathUtils.lerp(laneX, victimPos.x, 1.03),
-          baseAltitude - turnAltitudeDrop * 0.46,
-          towardBottom(THREE.MathUtils.lerp(victimPos.z, enemyLaneZ, 0.94))
-        );
-        const turnExitPos = new THREE.Vector3(
-          THREE.MathUtils.lerp(laneX, victimPos.x, 0.16),
-          baseAltitude - turnAltitudeDrop * 0.72,
-          towardBottom(THREE.MathUtils.lerp(victimPos.z, enemyLaneZ, 0.97))
-        );
-        const turnControlPos = new THREE.Vector3(
-          THREE.MathUtils.lerp(turnBendX, victimPos.x, -0.08),
-          baseAltitude - turnAltitudeDrop * 0.62,
-          towardBottom(THREE.MathUtils.lerp(enemyLaneZ, victimPos.z, -0.06))
-        );
-        const uTurnApexPos = new THREE.Vector3(
-          THREE.MathUtils.lerp(turnBendX, victimPos.x, -0.14),
-          baseAltitude - turnAltitudeDrop * 0.7,
-          towardBottom(THREE.MathUtils.lerp(enemyLaneZ, victimPos.z, -0.14))
-        );
-        const returnEntryPos = new THREE.Vector3(
-          THREE.MathUtils.lerp(laneX, victimPos.x, -0.05),
-          baseAltitude - turnAltitudeDrop * 0.28,
-          towardBottom(THREE.MathUtils.lerp(enemyLaneZ, attackerLaneZ, 0.68))
-        );
-        const exitPos = new THREE.Vector3(laneX, baseAltitude, towardBottom(attackerLaneZ));
+        const radiusX = half * CAPTURE_AIR_STRIKE_PATH_RADIUS_FACTOR * portraitTightening;
+        const radiusZ = radiusX * 0.92;
+        const startAngle = attackFromTopSide ? Math.PI * 0.22 : Math.PI * 1.22;
+        const arc = (turns) => {
+          const angle = startAngle + turns * Math.PI * 2;
+          return new THREE.Vector3(
+            center.x + Math.cos(angle) * radiusX,
+            baseAltitude - Math.sin(turns * Math.PI * 2) * turnAltitudeDrop * 0.24,
+            center.z + Math.sin(angle) * radiusZ
+          );
+        };
+        const startPos = arc(0);
+        const entryPos = arc(0.125);
+        const turnEntryPos = arc(0.25);
+        const turnControlPos = arc(0.5);
+        const uTurnApexPos = arc(0.625);
+        const turnExitPos = arc(0.75);
+        const returnEntryPos = arc(0.875);
+        const exitPos = arc(1);
+        const flyPathNodes = [
+          startPos.clone(),
+          entryPos.clone(),
+          turnEntryPos.clone(),
+          turnControlPos.clone(),
+          uTurnApexPos.clone(),
+          turnExitPos.clone(),
+          returnEntryPos.clone(),
+          exitPos.clone()
+        ];
         return {
           attackFromTopSide,
+          center,
+          flyPathNodes,
           startPos,
           entryPos,
           turnEntryPos,
@@ -9352,7 +9386,7 @@ function Chess3D({
         const path = buildAirStrikePath({
           attackerPos: fromPos,
           victimPos: targetPos,
-          baseAltitude: Math.max(CAPTURE_JET_ALTITUDE, targetPos.y + CAPTURE_AIR_STRIKE_BOARD_CLEARANCE)
+          baseAltitude: targetPos.y + CAPTURE_AIR_STRIKE_BOARD_CLEARANCE + CAPTURE_JET_ALTITUDE
         });
         jetFx.root.position.copy(path.startPos);
         captureFxGroup.add(jetFx.root);
@@ -9377,6 +9411,7 @@ function Chess3D({
           exitPos: path.exitPos,
           missileReleaseTime: CAPTURE_JET_TOTAL * CAPTURE_JET_MISSILE_ENTRY_RELEASE_RATIO,
           attackFromTopSide: path.attackFromTopSide,
+          flyPathNodes: path.flyPathNodes,
           jetFx,
           missileFx
         });
@@ -9394,8 +9429,7 @@ function Chess3D({
           attackerPos: fromPos,
           victimPos: targetPos,
           baseAltitude:
-            Math.max(CAPTURE_JET_ALTITUDE, targetPos.y + CAPTURE_AIR_STRIKE_BOARD_CLEARANCE) +
-            CAPTURE_HELICOPTER_ALTITUDE_BOOST,
+            targetPos.y + CAPTURE_AIR_STRIKE_BOARD_CLEARANCE + CAPTURE_JET_ALTITUDE + CAPTURE_HELICOPTER_ALTITUDE_BOOST,
           turnAltitudeDrop: 0.06
         });
         helicopterFx.root.position.copy(path.startPos);
@@ -9422,6 +9456,7 @@ function Chess3D({
           exitPos: path.exitPos,
           missileReleaseTime: CAPTURE_HELICOPTER_TOTAL * CAPTURE_JET_MISSILE_ENTRY_RELEASE_RATIO,
           attackFromTopSide: path.attackFromTopSide,
+          flyPathNodes: path.flyPathNodes,
           helicopterFx,
           missileFx
         });
@@ -9438,7 +9473,7 @@ function Chess3D({
         const path = buildAirStrikePath({
           attackerPos: fromPos,
           victimPos: targetPos,
-          baseAltitude: Math.max(CAPTURE_JET_ALTITUDE, targetPos.y + CAPTURE_AIR_STRIKE_BOARD_CLEARANCE)
+          baseAltitude: targetPos.y + CAPTURE_AIR_STRIKE_BOARD_CLEARANCE + CAPTURE_JET_ALTITUDE
         });
         jetFx.root.position.copy(path.startPos);
         captureFxGroup.add(jetFx.root);
@@ -9463,6 +9498,7 @@ function Chess3D({
           exitPos: path.exitPos,
           missileReleaseTime: CAPTURE_JET_TOTAL * CAPTURE_JET_MISSILE_ENTRY_RELEASE_RATIO,
           attackFromTopSide: path.attackFromTopSide,
+          flyPathNodes: path.flyPathNodes,
           jetFx,
           missileFx
         });
@@ -11053,16 +11089,18 @@ function Chess3D({
           } else if (fx.type === 'jet') {
             const jetTimelineU = clamp01(fx.t / CAPTURE_JET_TOTAL);
             const jetU = THREE.MathUtils.lerp(CAPTURE_JET_TRIMMED_START_RATIO, 1, jetTimelineU);
-            const flyPathNodes = [
-              fx.from,
-              fx.orbitEntryPos,
-              fx.turnEntryPos,
-              fx.turnControlPos,
-              fx.uTurnApexPos,
-              fx.orbitExitPos,
-              fx.returnEntryPos,
-              fx.exitPos
-            ].filter(Boolean);
+            const flyPathNodes = Array.isArray(fx.flyPathNodes) && fx.flyPathNodes.length >= 4
+              ? fx.flyPathNodes
+              : [
+                  fx.from,
+                  fx.orbitEntryPos,
+                  fx.turnEntryPos,
+                  fx.turnControlPos,
+                  fx.uTurnApexPos,
+                  fx.orbitExitPos,
+                  fx.returnEntryPos,
+                  fx.exitPos
+                ].filter(Boolean);
             const topStrikeHeight = Math.max(tile * 2.2, 0.42);
             const sampleFlyPath = (pathU) => {
               const safeU = clamp01(pathU);
@@ -11071,7 +11109,12 @@ function Chess3D({
                 return { pos: fallback, next: fallback.clone().add(new THREE.Vector3(0.08, 0, 0)) };
               }
               if (!fx.jetPathCurve || fx.jetPathCurveNodeCount !== flyPathNodes.length) {
-                fx.jetPathCurve = new THREE.CatmullRomCurve3(flyPathNodes.map((n) => n.clone()), false, 'catmullrom', 0.28);
+                fx.jetPathCurve = new THREE.CatmullRomCurve3(
+                  flyPathNodes.map((n) => n.clone()),
+                  true,
+                  'catmullrom',
+                  0.24
+                );
                 fx.jetPathCurveNodeCount = flyPathNodes.length;
               }
               const pos = fx.jetPathCurve.getPointAt(safeU);
@@ -11168,16 +11211,18 @@ function Chess3D({
           } else if (fx.type === 'helicopter') {
             const heliTimelineU = clamp01(fx.t / CAPTURE_HELICOPTER_TOTAL);
             const heliU = THREE.MathUtils.lerp(CAPTURE_JET_TRIMMED_START_RATIO, 1, heliTimelineU);
-            const flyPathNodes = [
-              fx.from,
-              fx.orbitEntryPos,
-              fx.turnEntryPos,
-              fx.turnControlPos,
-              fx.uTurnApexPos,
-              fx.orbitExitPos,
-              fx.returnEntryPos,
-              fx.exitPos
-            ].filter(Boolean);
+            const flyPathNodes = Array.isArray(fx.flyPathNodes) && fx.flyPathNodes.length >= 4
+              ? fx.flyPathNodes
+              : [
+                  fx.from,
+                  fx.orbitEntryPos,
+                  fx.turnEntryPos,
+                  fx.turnControlPos,
+                  fx.uTurnApexPos,
+                  fx.orbitExitPos,
+                  fx.returnEntryPos,
+                  fx.exitPos
+                ].filter(Boolean);
             const topStrikeHeight = Math.max(tile * 2.2, 0.42);
             const sampleFlyPath = (pathU) => {
               const safeU = clamp01(pathU);
@@ -11186,7 +11231,12 @@ function Chess3D({
                 return { pos: fallback, next: fallback.clone().add(new THREE.Vector3(0.08, 0, 0)) };
               }
               if (!fx.heliPathCurve || fx.heliPathCurveNodeCount !== flyPathNodes.length) {
-                fx.heliPathCurve = new THREE.CatmullRomCurve3(flyPathNodes.map((n) => n.clone()), false, 'catmullrom', 0.28);
+                fx.heliPathCurve = new THREE.CatmullRomCurve3(
+                  flyPathNodes.map((n) => n.clone()),
+                  true,
+                  'catmullrom',
+                  0.24
+                );
                 fx.heliPathCurveNodeCount = flyPathNodes.length;
               }
               const pos = fx.heliPathCurve.getPointAt(safeU);


### PR DESCRIPTION
### Motivation

- Improve portrait/vertical framing of capture cinematics by adjusting aircraft scales and flight altitudes and simplify the fly-by path computation for more predictable visuals. 
- Ensure beautiful-game gold accents are consistently applied across preserved and recolored piece materials for clearer visual identity. 

### Description

- Tweak capture constants including further reduced `CAPTURE_JET_SCALE` and `CAPTURE_HELICOPTER_SCALE`, introduce `CAPTURE_DRONE_REFERENCE_BOARD_ALTITUDE`, `CAPTURE_AIR_STRIKE_ALTITUDE_MULTIPLIER`, and compute `CAPTURE_JET_ALTITUDE` from those values. 
- Replace the previous lane-based airstrike path calculation with a center-based circular arc generator that returns `flyPathNodes` and a `center` point, and make `CatmullRomCurve3` use a closed curve with adjusted tension (`true`, 0.24). 
- Propagate `flyPathNodes` into active capture FX and fall back to legacy node arrays when absent, and adjust base altitude usage when creating jet/helicopter paths. 
- Add `forceBeautifulGameGoldParts` to apply gold accent coloring and surface properties to candidate sub-meshes and call it from `harmonizeBeautifulGamePieces`, `markBeautifulGameGoldMeshes` flow, and `applyBeautifulGameStyleToMeshes`, and set the default `goldAccent` in `BEAUTIFUL_GAME_PIECE_STYLE` to `#d4af37`. 
- Minor tuning: adjust `portraitTightening` lerp value and other small constants for tighter on-board visuals. 

### Testing

- Ran unit and component tests with `yarn test` and all tests passed. 
- Verified production build with `yarn build` completed successfully. 
- Ran linter with `yarn lint` and fixed reported issues, with no remaining lint errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcc19929108329be279b3dcaa85e7a)