### PR TITLE
Improve Ludo camera framing, preserve user camera on human turn, and tweak animation timings

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1430,7 +1430,8 @@ const CAMERA_DOLLY_FACTOR = ARENA_CAMERA_DEFAULTS.wheelDeltaFactor;
 const CAMERA_TARGET_LIFT = 0.028 * MODEL_SCALE;
 const CAMERA_SIDE_LOOK_EXTRA = 0.13;
 const CAMERA_TURN_PLAYER_LERP = 0.58;
-const CAMERA_BROADCAST_TARGET_BLEND = 0;
+const CAMERA_BROADCAST_TARGET_BLEND = 0.6;
+const CAMERA_BROADCAST_SIDE_BLEND = 0.82;
 const CAMERA_SIDE_AVATAR_BLEND = 1.08;
 const USER_TURN_CAMERA_PULLBACK = 0.15 * MODEL_SCALE;
 const USER_TURN_CAMERA_LIFT = 0.09 * MODEL_SCALE;
@@ -1455,8 +1456,8 @@ const PORTRAIT_CAMERA_TUNING = Object.freeze({
   targetLift: 0.055 * MODEL_SCALE
 });
 const CAMERA_EXTRA_PULLBACK = 0;
-const CAMERA_EXTRA_LIFT = 0.058;
-const PORTRAIT_CAMERA_EXTRA_LIFT = 0.04;
+const CAMERA_EXTRA_LIFT = 0.064;
+const PORTRAIT_CAMERA_EXTRA_LIFT = 0.048;
 const CAMERA_PLAYER_CENTER_X_EPSILON = 0.0001;
 const CAMERA_LOOK_YAW_LIMIT = THREE.MathUtils.degToRad(26);
 const CAMERA_LOOK_YAW_DRAG_FACTOR = 0.0055;
@@ -3655,8 +3656,8 @@ const TOKEN_THINNESS_SCALE = 0.86;
 const TOKEN_RAIL_OUTWARD_PUSH = 0.108;
 const CAPTURE_ANIMATION_HEIGHT_COMPENSATION = TABLE_VERTICAL_LOWERING;
 const CAMERA_TURN_VIEW_DURATION_MS = 520;
-const CAMERA_BROADCAST_ANIMATION_MS = 560;
-const CAMERA_RETURN_ANIMATION_MS = 620;
+const CAMERA_BROADCAST_ANIMATION_MS = 700;
+const CAMERA_RETURN_ANIMATION_MS = 760;
 const ROCK_TOKEN_REFERENCE_SCALE = Object.freeze({ x: 0.78, y: 0.92, z: 0.74 });
 const TOKEN_TYPE_SCALE_PROFILE = Object.freeze({
   pawn: {
@@ -6176,10 +6177,10 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         const followedTarget = cameraTurnStateRef.current.followObject.getWorldPosition(new THREE.Vector3());
         const liftedTarget = resolveFocusCameraState(followedTarget, CAMERA_TARGET_LIFT + 0.02);
         if (liftedTarget) {
-          controls.target.lerp(liftedTarget.target, 0.28);
+          controls.target.lerp(liftedTarget.target, 0.18);
           if (cameraTurnStateRef.current.followOffset?.isVector3) {
             const followCameraTarget = liftedTarget.target.clone().add(cameraTurnStateRef.current.followOffset);
-            camera.position.lerp(followCameraTarget, 0.18);
+            camera.position.lerp(followCameraTarget, 0.12);
           }
           cameraTurnStateRef.current.currentTarget = controls.target.clone();
         }
@@ -7046,7 +7047,16 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     const arena = arenaRef.current;
     if (!camera || !arena?.boardLookTarget || !focusTarget?.isVector3) return null;
     const boardLookTarget = arena.boardLookTarget;
-    const target = boardLookTarget.clone().lerp(focusTarget, CAMERA_BROADCAST_TARGET_BLEND);
+    const sideDistance = Math.min(
+      1,
+      Math.abs(focusTarget.x - boardLookTarget.x) / Math.max(BOARD_CLOTH_HALF * 0.75, 0.01)
+    );
+    const dynamicBlend = THREE.MathUtils.lerp(
+      CAMERA_BROADCAST_TARGET_BLEND,
+      CAMERA_BROADCAST_SIDE_BLEND,
+      sideDistance
+    );
+    const target = boardLookTarget.clone().lerp(focusTarget, dynamicBlend);
     target.y = (arena.tableInfo?.surfaceY ?? target.y) + offset;
 
     return { position: camera.position.clone(), target };
@@ -7101,10 +7111,21 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     return baseTarget;
   }, []);
 
+  const shouldRespectUserCamera = useCallback(
+    (player) => {
+      if (player !== 0) return false;
+      if (humanSelectionRef.current) return true;
+      const state = stateRef.current;
+      if (!state || state.winner) return false;
+      return state.turn === 0;
+    },
+    []
+  );
+
   const setCameraViewForTurn = useCallback((player, duration = CAMERA_TURN_VIEW_DURATION_MS, { force = false } = {}) => {
     cancelCameraViewAnimation();
     if (isCamera2d || !LUDO_CAMERA_AUTO_LOOK_ENABLED) return;
-    if (player === 0 && preserveUserTurnCameraRef.current && !force) return;
+    if (!force && (preserveUserTurnCameraRef.current || shouldRespectUserCamera(player))) return;
     if (player !== 0) {
       preserveUserTurnCameraRef.current = false;
     }
@@ -7144,13 +7165,14 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     const nextView = resolveTurnCameraState(player, CAMERA_TARGET_LIFT);
     if (!nextView) return;
     animateCameraPose(nextView.target, nextView.position, duration);
-  }, [animateCameraPose, cancelCameraViewAnimation, isCamera2d, resolveTurnCameraState]);
+  }, [animateCameraPose, cancelCameraViewAnimation, isCamera2d, resolveTurnCameraState, shouldRespectUserCamera]);
 
   const setCameraFocus = useCallback(
     (focus = {}) => {
       const state = stateRef.current;
       const controls = controlsRef.current;
       if (!state || !controls || isCamera2d || !LUDO_CAMERA_AUTO_LOOK_ENABLED) return;
+      if (!focus.force && shouldRespectUserCamera(state.turn)) return;
       const { object, target, follow = false, ttl = 0, priority = 0, force = false, offset = CAMERA_TARGET_LIFT } = focus;
       if (!force && priority < cameraTurnStateRef.current.activePriority) return;
 
@@ -7206,7 +7228,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         }, Math.max(0, ttl * 1000));
       }
     },
-    [animateCameraPose, isCamera2d, resolveFocusCameraState, resolveTurnCameraState, resolveTurnLookTarget]
+    [animateCameraPose, isCamera2d, resolveFocusCameraState, resolveTurnCameraState, resolveTurnLookTarget, shouldRespectUserCamera]
   );
 
   const getWorldForProgress = (player, progress, tokenIndex) => {
@@ -7488,8 +7510,21 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       const state = stateRef.current;
       if (state) state.turn = nextTurn;
       updateTurnIndicator(nextTurn);
-      setCameraViewForTurn(nextTurn);
-      setCameraFocus({ target: resolveTurnLookTarget(nextTurn), priority: 1, force: true });
+      const shouldLockHumanCamera = nextTurn === 0;
+      preserveUserTurnCameraRef.current = shouldLockHumanCamera;
+      if (!shouldLockHumanCamera) {
+        setCameraViewForTurn(nextTurn);
+        setCameraFocus({ target: resolveTurnLookTarget(nextTurn), priority: 1, force: true });
+      }
+      if (diceRef.current && !shouldLockHumanCamera) {
+        setCameraFocus({
+          object: diceRef.current,
+          follow: true,
+          priority: 4,
+          force: true,
+          offset: CAMERA_TARGET_LIFT + 0.022
+        });
+      }
       updated = true;
       const status =
         nextTurn === 0
@@ -7593,13 +7628,20 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     const target = entering ? 0 : current + roll;
     if (target > GOAL_PROGRESS) return advanceTurn(false);
     if (entering) {
-      setCameraViewForTurn(player, CAMERA_TURN_VIEW_DURATION_MS, { force: true });
-      setCameraFocus({
-        target: resolveTurnLookTarget(player),
-        follow: false,
-        priority: 3,
-        force: true
-      });
+      const seatSideTarget = getWorldForProgress(player, 0, tokenIndex);
+      const isSideSeat = player === 1 || player === 3;
+      const enteringOffset = isSideSeat ? CAMERA_TARGET_LIFT + 0.035 : CAMERA_TARGET_LIFT + 0.02;
+      if (player !== 0) {
+        setCameraViewForTurn(player, CAMERA_TURN_VIEW_DURATION_MS, { force: true });
+        setCameraFocus({
+          target: seatSideTarget,
+          follow: false,
+          priority: 6,
+          ttl: 0.95,
+          force: true,
+          offset: enteringOffset
+        });
+      }
     }
     const captureVictims = getCaptureVictims(player, target);
     const hasCapture = captureVictims.length > 0;
@@ -7683,6 +7725,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     const dice = diceRef.current;
     if (!dice || dice.userData?.isRolling) return;
     const player = state.turn;
+    const isHumanTurn = player === 0;
     const baseHeight = dice.userData?.baseHeight ?? DICE_BASE_HEIGHT;
     const rollTargets = dice.userData?.rollTargets;
     const clothLimit = dice.userData?.clothLimit ?? BOARD_CLOTH_HALF - 0.12;
@@ -7692,7 +7735,18 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     baseTarget.y = baseHeight;
     stopDiceTransition();
     dice.userData.isRolling = true;
-    setCameraViewForTurn(player, CAMERA_TURN_VIEW_DURATION_MS, { force: true });
+    if (!isHumanTurn) {
+      setCameraViewForTurn(player, CAMERA_TURN_VIEW_DURATION_MS, { force: true });
+      setCameraFocus({
+        object: dice,
+        follow: false,
+        priority: 5,
+        force: true,
+        offset: CAMERA_TARGET_LIFT + 0.025
+      });
+    } else {
+      preserveUserTurnCameraRef.current = true;
+    }
     playDiceSound();
     const landingFocus = baseTarget.clone();
     const value = await spinDice(dice, {
@@ -7723,14 +7777,18 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         offset: CAMERA_TARGET_LIFT + 0.03,
         force: true
       });
-    } else {
+    } else if (!isHumanTurn) {
       setCameraViewForTurn(player, CAMERA_TURN_VIEW_DURATION_MS, { force: true });
     }
     if (!options.length) {
       const playerCycle = Math.max(1, activePlayerCount);
       const upcomingTurn = value === 6 ? player : (player + playerCycle - 1) % playerCycle;
-      setCameraViewForTurn(upcomingTurn, CAMERA_TURN_VIEW_DURATION_MS, { force: true });
-      setCameraFocus({ target: resolveTurnLookTarget(upcomingTurn), priority: 1, force: true });
+      if (upcomingTurn !== 0) {
+        setCameraViewForTurn(upcomingTurn, CAMERA_TURN_VIEW_DURATION_MS, { force: true });
+        setCameraFocus({ target: resolveTurnLookTarget(upcomingTurn), priority: 1, force: true });
+      } else {
+        preserveUserTurnCameraRef.current = true;
+      }
       clearTurnAdvanceTimeout();
       turnAdvanceTimeoutRef.current = window.setTimeout(() => {
         turnAdvanceTimeoutRef.current = null;
@@ -7739,7 +7797,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       return;
     }
     if (player === 0) {
-      setCameraViewForTurn(0, CAMERA_TURN_VIEW_DURATION_MS, { force: true });
+      preserveUserTurnCameraRef.current = true;
       beginHumanSelection(value, options, { skipCameraFollow: !hasBoardTokenBeforeRoll });
       return;
     }


### PR DESCRIPTION
### Motivation
- Improve camera framing during broadcasts, side-seat interactions, token entry and dice rolls for clearer visuals.
- Respect and preserve a human player's manual camera adjustments while still allowing automated framing for non-human turns.
- Soften camera movements and timing to produce smoother transitions and better focus on relevant objects.
- Adjust lift/offset constants to compensate for device orientation and seat positions for more consistent framing.

### Description
- Introduced dynamic side blending by adding `CAMERA_BROADCAST_SIDE_BLEND` and computing a `sideDistance` to lerp between center and side broadcast blends in `resolveFocusCameraState`.
- Adjusted camera tuning constants including `CAMERA_BROADCAST_TARGET_BLEND`, `CAMERA_EXTRA_LIFT`, `PORTRAIT_CAMERA_EXTRA_LIFT`, and extended animation durations `CAMERA_BROADCAST_ANIMATION_MS` and `CAMERA_RETURN_ANIMATION_MS` for smoother motion.
- Reduced immediate camera lerp rates (`controls.target.lerp` and `camera.position.lerp`) to slow passive follow adjustments and added `shouldRespectUserCamera` helper to prevent automated overrides of a human player's camera; integrated this into `setCameraViewForTurn` and `setCameraFocus`.
- Changed turn/dice handling to preserve the human camera on player 0 (via `preserveUserTurnCameraRef`), only auto-framing dice for non-human players, and added focused framing for tokens entering from side seats with tailored offsets, priorities and TTLs.

### Testing
- Ran the unit test suite with `yarn test` and all tests passed.
- Ran the linter with `yarn lint` and no issues were reported.
- Performed a production build with `yarn build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcb60df47c83299f350fa712294c6c)