### PR TITLE
Lock Ludo camera to seat position and restrict camera motion

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1437,6 +1437,7 @@ const USER_TURN_CAMERA_PULLBACK = 0.15 * MODEL_SCALE;
 const USER_TURN_CAMERA_LIFT = 0.09 * MODEL_SCALE;
 const LUDO_CAMERA_AUTO_LOOK_ENABLED = true;
 const LUDO_CAMERA_BROADCAST_LOCKED_POSITION = false;
+const LUDO_CAMERA_SEAT_LOCK_ENABLED = true;
 const CAMERA_FREE_LOOK_AZIMUTH_RANGE = THREE.MathUtils.degToRad(26);
 const CAMERA_FREE_LOOK_POLAR_DELTA = THREE.MathUtils.degToRad(16);
 const CAMERA_ZOOM_MIN_FACTOR = 1;
@@ -3787,6 +3788,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
   const cameraFocusTimeoutRef = useRef(null);
   const cameraFocusFrameRef = useRef(0);
   const cameraViewFrameRef = useRef(0);
+  const cameraSeatLockPositionRef = useRef(null);
   const preserveUserTurnCameraRef = useRef(false);
   const cameraTurnStateRef = useRef({
     currentTarget: null,
@@ -4132,6 +4134,9 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         controls.target.copy(saved.target);
       } else {
         fitRef.current?.();
+      }
+      if (LUDO_CAMERA_SEAT_LOCK_ENABLED) {
+        cameraSeatLockPositionRef.current = camera.position.clone();
       }
       saved3dCameraStateRef.current = null;
     }
@@ -5773,6 +5778,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     }
     controls.minDistance = CAM.minR;
     controls.maxDistance = CAM.maxR * CAMERA_ZOOM_MAX_FACTOR;
+    cameraSeatLockPositionRef.current = camera.position.clone();
     baseCameraRadiusRef.current = desiredInitialCameraRadius;
     controls.update();
     groundArenaToHdriFloor({ preserveView: true });
@@ -5996,32 +6002,16 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       const deltaY = clientY - lookState.lastY;
       lookState.lastX = clientX;
       lookState.lastY = clientY;
-      const isTouchDrag = event.pointerType === 'touch';
       lookState.yaw = clamp(
         lookState.yaw + deltaX * CAMERA_LOOK_YAW_DRAG_FACTOR,
         -CAMERA_LOOK_YAW_LIMIT,
         CAMERA_LOOK_YAW_LIMIT
       );
-      if (isTouchDrag && camera && controls && Math.abs(deltaY) > 0.001) {
-        const elementHeight = Math.max(renderer?.domElement?.clientHeight ?? 0, 1);
-        const rotateSpeed = Number.isFinite(controls.rotateSpeed) ? controls.rotateSpeed : 1;
-        const verticalAngle = (2 * Math.PI * deltaY * rotateSpeed) / elementHeight;
-        const offset = camera.position.clone().sub(controls.target);
-        const spherical = new THREE.Spherical().setFromVector3(offset);
-        spherical.phi = clamp(
-          spherical.phi + verticalAngle,
-          controls.minPolarAngle,
-          controls.maxPolarAngle
-        );
-        offset.setFromSpherical(spherical);
-        camera.position.copy(controls.target).add(offset);
-      } else if (!isTouchDrag) {
-        lookState.pitch = clamp(
-          lookState.pitch + deltaY * CAMERA_LOOK_PITCH_DRAG_FACTOR,
-          CAMERA_LOOK_MIN_PITCH,
-          CAMERA_LOOK_PITCH_LIMIT
-        );
-      }
+      lookState.pitch = clamp(
+        lookState.pitch + deltaY * CAMERA_LOOK_PITCH_DRAG_FACTOR,
+        CAMERA_LOOK_MIN_PITCH,
+        CAMERA_LOOK_PITCH_LIMIT
+      );
       applyCameraLookOffset();
       if (stateRef.current?.turn === 0) {
         preserveUserTurnCameraRef.current = true;
@@ -6173,7 +6163,12 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         setSeatAnchors([]);
       }
 
-      if (!isCamera2d && cameraTurnStateRef.current.followObject?.isObject3D && controls) {
+      if (
+        !isCamera2d &&
+        cameraTurnStateRef.current.followObject?.isObject3D &&
+        controls &&
+        !LUDO_CAMERA_SEAT_LOCK_ENABLED
+      ) {
         const followedTarget = cameraTurnStateRef.current.followObject.getWorldPosition(new THREE.Vector3());
         const liftedTarget = resolveFocusCameraState(followedTarget, CAMERA_TARGET_LIFT + 0.02);
         if (liftedTarget) {
@@ -6942,10 +6937,15 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     const camera = cameraRef.current;
     if (!controls || !camera || !toTarget) return;
     const fromPosition = camera.position.clone();
+    const lockedSeatPosition = cameraSeatLockPositionRef.current?.isVector3
+      ? cameraSeatLockPositionRef.current
+      : null;
     const destinationPosition =
-      toPosition?.isVector3
-        ? toPosition.clone()
-        : camera.position.clone();
+      LUDO_CAMERA_SEAT_LOCK_ENABLED && lockedSeatPosition
+        ? lockedSeatPosition.clone()
+        : toPosition?.isVector3
+          ? toPosition.clone()
+          : camera.position.clone();
     if (!cameraTurnStateRef.current.currentTarget) {
       cameraTurnStateRef.current.currentTarget = controls.target.clone();
     }


### PR DESCRIPTION
### Motivation
- Players require a fixed-seat viewpoint for Ludo Battle Royal where the camera does not translate away from the chair, only rotates to look around, and no zoom/dolly is allowed.
- Make camera transitions preserve a single seat position while still allowing the look target to update for turn/focus events and spectator broadcasts.

### Description
- Added `LUDO_CAMERA_SEAT_LOCK_ENABLED` flag and a `cameraSeatLockPositionRef` to store the locked camera position (file: `webapp/src/pages/Games/LudoBattleRoyal.jsx`).
- Updated `animateCameraPose` to prefer the locked seat position when the seat-lock mode is enabled so camera position stays fixed while `controls.target` (look) can still animate.
- Removed touch-drag orbit behavior that altered camera radius/position and limited drag to yaw/pitch adjustments only, preventing unexpected camera moves or zooming.
- Resynced/stored the seat-lock camera position after initial 3D camera setup and when returning from 2D view, and disabled follow-object position lerping while seat-lock is enabled.

### Testing
- Built the web app with `npm --prefix webapp run -s build` and the production build completed successfully.
- Attempted linting but no dedicated `lint` script exists for the `webapp` package, so only the build run was used as an automated verification step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcd38a50a8832992cd25a95d166c2b)