### PR TITLE
Lock Ludo Battle Royal camera to player seat (look-only, no zoom)

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -3799,6 +3799,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
   const humanSelectionRef = useRef(null);
   const fitRef = useRef(() => {});
   const cameraRef = useRef(null);
+  const seatLockedCameraPositionRef = useRef(null);
   const boardLookTargetRef = useRef(null);
   const saved3dCameraStateRef = useRef(null);
   const captureFxRef = useRef(null);
@@ -4105,7 +4106,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       controls.target.copy(boardLookTarget);
       controls.enableRotate = false;
       controls.enablePan = false;
-      controls.enableZoom = true;
+      controls.enableZoom = false;
       controls.minPolarAngle = topDownPolar;
       controls.maxPolarAngle = topDownPolar;
       controls.minAzimuthAngle = -Infinity;
@@ -4133,6 +4134,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       } else {
         fitRef.current?.();
       }
+      seatLockedCameraPositionRef.current = camera.position.clone();
       saved3dCameraStateRef.current = null;
     }
 
@@ -5691,6 +5693,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     controls.minDistance = initialCameraRadius * CAMERA_ZOOM_MIN_FACTOR;
     controls.maxDistance = initialCameraRadius * CAMERA_ZOOM_MAX_FACTOR;
     controlsRef.current = controls;
+    seatLockedCameraPositionRef.current = camera.position.clone();
     baseCameraRadiusRef.current = initialCameraRadius;
     syncSkyboxToCameraRef.current = () => {
       if (!camera || !boardLookTarget) return;
@@ -5996,32 +5999,16 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       const deltaY = clientY - lookState.lastY;
       lookState.lastX = clientX;
       lookState.lastY = clientY;
-      const isTouchDrag = event.pointerType === 'touch';
       lookState.yaw = clamp(
         lookState.yaw + deltaX * CAMERA_LOOK_YAW_DRAG_FACTOR,
         -CAMERA_LOOK_YAW_LIMIT,
         CAMERA_LOOK_YAW_LIMIT
       );
-      if (isTouchDrag && camera && controls && Math.abs(deltaY) > 0.001) {
-        const elementHeight = Math.max(renderer?.domElement?.clientHeight ?? 0, 1);
-        const rotateSpeed = Number.isFinite(controls.rotateSpeed) ? controls.rotateSpeed : 1;
-        const verticalAngle = (2 * Math.PI * deltaY * rotateSpeed) / elementHeight;
-        const offset = camera.position.clone().sub(controls.target);
-        const spherical = new THREE.Spherical().setFromVector3(offset);
-        spherical.phi = clamp(
-          spherical.phi + verticalAngle,
-          controls.minPolarAngle,
-          controls.maxPolarAngle
-        );
-        offset.setFromSpherical(spherical);
-        camera.position.copy(controls.target).add(offset);
-      } else if (!isTouchDrag) {
-        lookState.pitch = clamp(
-          lookState.pitch + deltaY * CAMERA_LOOK_PITCH_DRAG_FACTOR,
-          CAMERA_LOOK_MIN_PITCH,
-          CAMERA_LOOK_PITCH_LIMIT
-        );
-      }
+      lookState.pitch = clamp(
+        lookState.pitch + deltaY * CAMERA_LOOK_PITCH_DRAG_FACTOR,
+        CAMERA_LOOK_MIN_PITCH,
+        CAMERA_LOOK_PITCH_LIMIT
+      );
       applyCameraLookOffset();
       if (stateRef.current?.turn === 0) {
         preserveUserTurnCameraRef.current = true;
@@ -6178,10 +6165,6 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         const liftedTarget = resolveFocusCameraState(followedTarget, CAMERA_TARGET_LIFT + 0.02);
         if (liftedTarget) {
           controls.target.lerp(liftedTarget.target, 0.18);
-          if (cameraTurnStateRef.current.followOffset?.isVector3) {
-            const followCameraTarget = liftedTarget.target.clone().add(cameraTurnStateRef.current.followOffset);
-            camera.position.lerp(followCameraTarget, 0.12);
-          }
           cameraTurnStateRef.current.currentTarget = controls.target.clone();
         }
       }
@@ -6240,6 +6223,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       controls?.dispose();
       controls = null;
       cameraRef.current = null;
+      seatLockedCameraPositionRef.current = null;
       boardLookTargetRef.current = null;
       saved3dCameraStateRef.current = null;
       stopDiceTransition();
@@ -6937,15 +6921,16 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
   }, []);
 
   const animateCameraPose = useCallback((toTarget, toPosition = null, duration = 300) => {
+    void toPosition;
     const resolvedDuration = resolveFrameSyncedDuration(duration, { min: 220, max: 1200 });
     const controls = controlsRef.current;
     const camera = cameraRef.current;
     if (!controls || !camera || !toTarget) return;
-    const fromPosition = camera.position.clone();
-    const destinationPosition =
-      toPosition?.isVector3
-        ? toPosition.clone()
-        : camera.position.clone();
+    const lockedSeatPosition = seatLockedCameraPositionRef.current?.isVector3
+      ? seatLockedCameraPositionRef.current.clone()
+      : camera.position.clone();
+    const fromPosition = lockedSeatPosition.clone();
+    const destinationPosition = lockedSeatPosition.clone();
     if (!cameraTurnStateRef.current.currentTarget) {
       cameraTurnStateRef.current.currentTarget = controls.target.clone();
     }
@@ -6968,7 +6953,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       const t = Math.min(1, (now - started) / Math.max(resolvedDuration, 1));
       const eased = easeSmooth(t);
       controls.target.copy(fromTarget).lerp(destination, eased);
-      camera.position.copy(fromPosition).lerp(destinationPosition, eased);
+      camera.position.copy(fromPosition);
       cameraTurnStateRef.current.currentTarget.copy(controls.target);
       controls.update();
       if (t < 1) {


### PR DESCRIPTION
### Motivation
- Players requested the Ludo Battle Royal camera remain fixed at the chair/seat position so the view only turns/looks from that anchor and never translates or zooms.

### Description
- Added `seatLockedCameraPositionRef` and capture/restored the locked seat camera pose when the 3D view is initialized or restored from 2D mode so the camera remains anchored to the chair position.
- Changed pointer-drag handling so drag only updates yaw/pitch look offsets (no camera position changes) and applied those offsets via the existing look-target logic.
- Removed camera position lerping when following objects (token-follow) and changed `animateCameraPose` to use the locked seat position so camera transitions only change the look target, not camera world position.
- Disabled zoom in the 2D toggle path and ensured the locked seat position is preserved/cleared across setup and cleanup lifecycle events.

### Testing
- Ran linter: `npx eslint webapp/src/pages/Games/LudoBattleRoyal.jsx` which reported an ignore-file warning from repo ignore settings (no errors).
- Ran linter with no-ignore: `npx eslint --no-ignore webapp/src/pages/Games/LudoBattleRoyal.jsx` which produced the same ignore warning (no errors).
- No unit tests were changed or executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcd38a50a8832992cd25a95d166c2b)