### PR TITLE
Raise Ludo camera and stabilize chair rendering to prevent shrinking

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1400,6 +1400,16 @@ TARGET_CHAIR_SIZE.y *= 0.84;
 const TARGET_CHAIR_MIN_Y = -0.8570624993294478 * CHAIR_SIZE_SCALE + 0.07 * CHAIR_SIZE_SCALE;
 const TARGET_CHAIR_CENTER_Z = -0.1553906416893005 * CHAIR_SIZE_SCALE;
 
+const stabilizeChairModelRenderState = (root) => {
+  if (!root?.isObject3D) return;
+  root.traverse((obj) => {
+    if (!obj?.isMesh) return;
+    obj.castShadow = true;
+    obj.receiveShadow = true;
+    obj.frustumCulled = false;
+  });
+};
+
 const FALLBACK_SEAT_POSITIONS = [
   { left: '50%', top: '84%' },
   { left: '80%', top: '56%' },
@@ -1457,7 +1467,7 @@ const PORTRAIT_CAMERA_TUNING = Object.freeze({
   targetLift: 0.055 * MODEL_SCALE
 });
 const CAMERA_EXTRA_PULLBACK = 0;
-const CAMERA_EXTRA_LIFT = 0.064;
+const CAMERA_EXTRA_LIFT = 0.076;
 const PORTRAIT_CAMERA_EXTRA_LIFT = 0.048;
 const CAMERA_PLAYER_CENTER_X_EPSILON = 0.0001;
 const CAMERA_LOOK_YAW_LIMIT = THREE.MathUtils.degToRad(26);
@@ -4569,6 +4579,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
 
       arena.chairs.forEach(({ group }) => {
         const clone = chairBuild.chairTemplate.clone(true);
+        stabilizeChairModelRenderState(clone);
         group.add(clone);
         group.userData.chairModel = clone;
       });
@@ -5761,12 +5772,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       group.lookAt(new THREE.Vector3(0, seatPos.y, 0));
 
       const chairModel = chairTemplate.clone(true);
-      chairModel.traverse((obj) => {
-        if (obj.isMesh) {
-          obj.castShadow = true;
-          obj.receiveShadow = true;
-        }
-      });
+      stabilizeChairModelRenderState(chairModel);
       group.add(chairModel);
       group.userData.chairModel = chairModel;
 


### PR DESCRIPTION
### Motivation
- Improve visual framing of the Ludo Battle Royal arena by lifting the 3D camera slightly so board and chairs appear higher on the screen in portrait mode.
- Prevent intermittent visual "shrinking" of chair meshes that appears when the camera moves or focus animations run by eliminating unstable culling behavior on imported chair models.

### Description
- Increased the camera vertical framing by updating `CAMERA_EXTRA_LIFT` from `0.064` to `0.076` in `webapp/src/pages/Games/LudoBattleRoyal.jsx` to raise camera framing without changing camera/turn logic.
- Added a helper `stabilizeChairModelRenderState(root)` that sets `castShadow = true`, `receiveShadow = true` and `frustumCulled = false` on chair meshes to keep full chair geometry visible during camera transitions.
- Applied `stabilizeChairModelRenderState` when chairs are initially created and when chair templates are rebuilt (theme/quality refresh) so the fix persists across appearance updates.

### Testing
- Ran the production build with `npm -C webapp run -s build`, which completed successfully.
- Build produced only existing non-blocking Vite warnings about chunk sizes/dynamic imports which are unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dce2cf91ac8329877c3f708594778a)