### PR TITLE
Fix Pool Royale slider release power propagation

### DIFF
--- a/power-slider.js
+++ b/power-slider.js
@@ -222,6 +222,9 @@ export class PowerSlider {
 
   _pointerUp(e) {
     if (!this.dragging) return;
+    if (e?.type === 'pointerup' && Number.isFinite(e.clientY)) {
+      this._updateFromClientY(e.clientY);
+    }
     this.dragging = false;
     try {
       this.el.releasePointerCapture(e.pointerId);

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -32471,7 +32471,11 @@ const powerRef = useRef(hud.power);
         captureCueStickAnchor();
       },
       onCommit: (sliderValue) => {
-        fireRef.current?.((sliderValue ?? 0) / 100);
+        const releasePower = clampPower(
+          Number.isFinite(sliderValue) ? sliderValue / 100 : powerRef.current,
+          powerRef.current
+        );
+        fireRef.current?.(releasePower);
         requestAnimationFrame(() => {
           slider.set(slider.min, { animate: true });
           applyPower(0);


### PR DESCRIPTION
### Motivation
- Users reported the cue ball sometimes launched with no or stale power when releasing the big pull slider, so the release path needs to reliably sample the final pointer Y and pass the correct normalized power into the shot `fire()` logic.

### Description
- Hardened the slider release handler in `power-slider.js` to sample the final pointer `clientY` on `_pointerUp` before committing the value so the last dragged position is applied. 
- Updated Pool Royale slider commit logic in `webapp/src/pages/Games/PoolRoyale.jsx` to compute a safe `releasePower` using the committed `sliderValue` when available and falling back to `powerRef.current` otherwise, then pass the clamped `releasePower` into `fire()`.
- These changes ensure the normalized power at release is used for the cue-ball launch, preventing quick-release/stale-value edge cases.

### Testing
- Ran `node --check power-slider.js` and `node --check pool-royale-power-slider.js`, which completed successfully. 
- Ran the project linter for the modified files with `npm run -s lint -- power-slider.js webapp/src/pages/Games/PoolRoyale.jsx`, which executed but the repo contains many unrelated existing lint errors in generated/dist files; no new syntax errors were introduced by this change. 
- Verified the local diff shows only the two intended edits and that the slider now applies the final pointer position before commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd20d7b02c8329b954aa1d7fe288a8)