### PR TITLE
Adjust Ludo Battle Royal capture vehicles and missile visuals

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -92,6 +92,7 @@ const CAPTURE_AIRCRAFT_ORBIT_INWARD_FACTOR = 0.72;
 const CAPTURE_AIRCRAFT_ALTITUDE_FACTOR = 0.82;
 const CAPTURE_PARK_FORWARD_OFFSET = 1.18;
 const CAPTURE_PARK_SIDE_OFFSET = 0.58;
+const CAPTURE_PARK_SURFACE_LIFT = 0.14;
 const CAPTURE_VEHICLE_HEIGHT_TO_KING = 1.35;
 const CAPTURE_PARK_BOX_TARGET_SIZE = 0.17;
 
@@ -110,7 +111,7 @@ function getCaptureVehicleTexture(kind = 'generic') {
     drone: ['#14532d', '#1f7a42', '#0f2f1e', '#6fbf7e'],
     fighter: ['#14532d', '#1f7a42', '#0f2f1e', '#6fbf7e'],
     helicopter: ['#f59e0b', '#fbbf24', '#7c4a03', '#fde68a'],
-    missile: ['#14532d', '#1f7a42', '#0f2f1e', '#6fbf7e'],
+    missile: ['#556b2f', '#7a8f45', '#3b4c22', '#95a86a'],
     truck: ['#f59e0b', '#fbbf24', '#7c4a03', '#fde68a'],
     generic: ['#55606a', '#74818b', '#313940', '#99a6af']
   };
@@ -642,13 +643,35 @@ function applyMilitaryTruckLook(root) {
         if ('opacity' in mat) mat.opacity = 0.95;
         return;
       }
-      if (/wheel|tire/.test(name)) {
+      if (/wheel|tire|tyre|rim/.test(name)) {
         mat.color.setHex(0x111111);
         if ('metalness' in mat) mat.metalness = 0.25;
         if ('roughness' in mat) mat.roughness = 0.78;
       }
     });
   });
+}
+
+function createEngineFireSmokeTrail(root, anchors = [[-1.95, 0, 0]]) {
+  const trail = [];
+  anchors.forEach((anchor) => {
+    for (let i = 0; i < 6; i += 1) {
+      const isFire = i < 2;
+      trail.push(
+        addFxSphere(
+          root,
+          0.09 + i * 0.028,
+          [anchor[0] - i * 0.2, anchor[1], anchor[2]],
+          isFire ? '#f7a94b' : '#7f888f',
+          isFire ? 0.22 : 1,
+          0,
+          true,
+          isFire ? 0.85 - i * 0.18 : 0.26 - (i - 2) * 0.04
+        )
+      );
+    }
+  });
+  return trail;
 }
 
 function easeSmooth(t) {
@@ -755,11 +778,11 @@ function createCaptureMissileFx() {
   const root = new THREE.Group();
   root.userData.lockCaptureTexture = true;
   const body = addFxCylinder(root, 0.09, 0.1, 1.18, [0, 0, 0], [0, 0, Math.PI / 2], '#d3d8de', 16, 0.3, 0.86);
-  body.material = createCaptureVehicleMaterial('missile', { color: '#b6d3bc', roughness: 0.38, metalness: 0.62 });
+  body.material = createCaptureVehicleMaterial('missile', { color: '#556b2f', roughness: 0.3, metalness: 0.82 });
 
   const nose = new THREE.Mesh(
     new THREE.ConeGeometry(0.1, 0.28, 16),
-    new THREE.MeshStandardMaterial({ color: '#edf1f6', roughness: 0.22, metalness: 0.9 })
+    createCaptureVehicleMaterial('missile', { color: '#7a8f45', roughness: 0.2, metalness: 0.86 })
   );
   nose.position.set(0.74, 0, 0);
   nose.rotation.z = -Math.PI / 2;
@@ -767,10 +790,10 @@ function createCaptureMissileFx() {
   nose.receiveShadow = true;
   root.add(nose);
 
-  addFxBox(root, [0.17, 0.025, 0.34], [-0.19, 0, 0], '#cfd5dc', 0.34, 0.82);
-  addFxBox(root, [0.17, 0.34, 0.025], [-0.19, 0, 0], '#cfd5dc', 0.34, 0.82);
-  addFxBox(root, [0.12, 0.024, 0.22], [-0.44, 0, 0], '#0f1419', 0.5, 0.36);
-  addFxBox(root, [0.12, 0.22, 0.024], [-0.44, 0, 0], '#0f1419', 0.5, 0.36);
+  addFxBox(root, [0.17, 0.025, 0.34], [-0.19, 0, 0], '#6b7f3d', 0.24, 0.76);
+  addFxBox(root, [0.17, 0.34, 0.025], [-0.19, 0, 0], '#6b7f3d', 0.24, 0.76);
+  addFxBox(root, [0.12, 0.024, 0.22], [-0.44, 0, 0], '#5e7035', 0.28, 0.72);
+  addFxBox(root, [0.12, 0.22, 0.024], [-0.44, 0, 0], '#5e7035', 0.28, 0.72);
 
   const trail = [];
   for (let i = 0; i < 5; i += 1) {
@@ -822,23 +845,23 @@ async function createCaptureMissileTruckFx() {
   }
 
   const launcher = new THREE.Group();
-  launcher.position.set(-0.26, 0.56, 0);
-  launcher.rotation.z = -0.34;
-  addFxBox(launcher, [1.6, 0.05, 0.96], [0, 0, 0], '#1f2125', 0.62, 0.24);
-  const support = addFxBox(launcher, [0.12, 0.36, 0.18], [-0.46, -0.19, 0], '#0f1114', 0.5, 0.36);
-  support.rotation.z = 0.22;
+  launcher.position.set(-0.26, 0.66, 0);
+  addFxBox(launcher, [1.38, 0.06, 0.92], [0, 0, 0], '#1f2125', 0.62, 0.24);
+  addFxBox(launcher, [1.08, 0.16, 0.72], [0.04, 0.11, 0], '#171b20', 0.58, 0.28);
+  const support = addFxBox(launcher, [0.15, 0.22, 0.2], [-0.5, -0.12, 0], '#0f1114', 0.5, 0.36);
+  support.rotation.z = 0.06;
 
   const missileOffsets = [
-    [-0.3, 0.08, -0.28],
-    [0.05, 0.08, 0],
-    [0.4, 0.08, 0.28]
+    [-0.36, 0.16, -0.24],
+    [0.02, 0.16, 0],
+    [0.4, 0.16, 0.24]
   ];
   missileOffsets.forEach((offset) => {
     const missile = createCaptureMissileFx();
     missile.root.visible = true;
-    missile.root.scale.setScalar(0.38);
+    missile.root.scale.setScalar(0.56);
     missile.root.position.set(offset[0], offset[1], offset[2]);
-    missile.root.rotation.z = 0;
+    missile.root.rotation.z = Math.PI / 2;
     launcher.add(missile.root);
   });
 
@@ -987,24 +1010,13 @@ async function createCaptureJetFx() {
   if (loadedJet) {
     const model = loadedJet.clone(true);
     fitObjectToTargetSize(model, 9.2 * CAPTURE_JET_SIZE_MULTIPLIER * 0.86);
-    model.rotation.set(Math.PI, Math.PI, 0);
+    model.rotation.set(0, Math.PI, 0);
     applyMilitaryJetLook(model);
     root.add(model);
-    const trail = [];
-    for (let i = 0; i < 6; i += 1) {
-      trail.push(
-        addFxSphere(
-          root,
-          0.11 + i * 0.03,
-          [-1.95 - i * 0.2, 0, 0],
-          i < 2 ? '#f7a94b' : '#8b949b',
-          i < 2 ? 0.22 : 1,
-          0,
-          true,
-          i < 2 ? 0.85 - i * 0.18 : 0.28 - (i - 2) * 0.045
-        )
-      );
-    }
+    const trail = createEngineFireSmokeTrail(root, [
+      [-1.95, -0.03, -0.22],
+      [-1.95, -0.03, 0.22]
+    ]);
     root.visible = false;
     return { root, trail };
   }
@@ -1060,21 +1072,10 @@ async function createCaptureJetFx() {
   const rightStore = leftStore.clone();
   rightStore.position.z = 1.15;
   root.add(rightStore);
-  const trail = [];
-  for (let i = 0; i < 6; i += 1) {
-    trail.push(
-      addFxSphere(
-        root,
-        0.11 + i * 0.03,
-        [-1.95 - i * 0.2, 0, 0],
-        i < 2 ? '#f7a94b' : '#8b949b',
-        i < 2 ? 0.22 : 1,
-        0,
-        true,
-        i < 2 ? 0.85 - i * 0.18 : 0.28 - (i - 2) * 0.045
-      )
-    );
-  }
+  const trail = createEngineFireSmokeTrail(root, [
+    [-1.95, -0.08, -0.22],
+    [-1.95, -0.08, 0.22]
+  ]);
   applyMilitaryJetLook(root);
   root.visible = false;
   return { root, trail };
@@ -4429,7 +4430,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       .clone()
       .addScaledVector(inward, CAPTURE_PARK_FORWARD_OFFSET)
       .addScaledVector(side, CAPTURE_PARK_SIDE_OFFSET * sideSign);
-    park.y = (arena.tableInfo?.surfaceY ?? park.y) + 0.08;
+    park.y = (arena.tableInfo?.surfaceY ?? park.y) + CAPTURE_PARK_SURFACE_LIFT;
     return park;
   }, []);
 


### PR DESCRIPTION
### Motivation
- Improve visibility and correctness of parked capture vehicles/weapons on the Ludo Battle Royal table so players can clearly see mounted equipment during idle/preview states.
- Match the Ludo javelin missile appearance to the short-missile texture/tone used in the Chess Battle Royal so visuals are consistent across games.
- Fix orientation and add exhaust effects for the fighter jet, and ensure truck wheels/windows render as true black for the requested aesthetic.

### Description
- Added a `CAPTURE_PARK_SURFACE_LIFT` constant and raised parked vehicle anchor height in `resolveCaptureParkingAnchors` so parked vehicles sit visibly above the table surface (`webapp/src/pages/Games/LudoBattleRoyal.jsx`).
- Updated missile palette and materials in `createCaptureMissileFx` to use olive/green tones and `createCaptureVehicleMaterial('missile', ...)` so Ludo javelins reuse the short-missile styling used in Chess Battle Royal.
- Reworked the missile-truck roof launcher in `createCaptureMissileTruckFx` to mount three larger, vertically oriented missiles on a raised roof platform, adjusted launcher placement and missile scale/rotation.
- Expanded truck material name matching in `applyMilitaryTruckLook` to include `tyre` and `rim` variants so wheels and rims are enforced as dark/black, and ensured window meshes are assigned dark/transparent materials.
- Fixed fighter jet model orientation by adjusting `model.rotation` in `createCaptureJetFx` and added twin engine fire/smoke trails via a new helper `createEngineFireSmokeTrail` to generate rear exhaust puff visuals.
- Added `createEngineFireSmokeTrail` helper to centralize engine exhaust trail creation and reused it for jet and fallback jet mesh trails.

### Testing
- Ran `npm run -s build` in `webapp` and the production build completed successfully with no errors (build warnings only, no failures).
- Verified the modified file `webapp/src/pages/Games/LudoBattleRoyal.jsx` was the only source file changed for these visual adjustments and that the application bundle built.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd34b2ceec8329b848e989e837f5c8)