### PR TITLE
Adjust Ludo capture vehicle visuals and placement

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -547,6 +547,12 @@ function applyMilitaryJetLook(root) {
         if ('opacity' in mat) mat.opacity = 0.94;
         return;
       }
+      if (/engine|exhaust|nozzle|thruster/.test(name)) {
+        mat.color.set('#15181d');
+        if ('metalness' in mat) mat.metalness = 0.84;
+        if ('roughness' in mat) mat.roughness = 0.28;
+        return;
+      }
       if (/missile|rocket|store|pod/.test(name)) {
         mat.color.set('#d8dde3');
         if ('metalness' in mat) mat.metalness = 0.88;
@@ -634,7 +640,7 @@ function applyMilitaryTruckLook(root) {
     if (!node?.isMesh) return;
     const name = `${node.name || ''}`.toLowerCase();
     paintMeshMaterials(node, (mat) => {
-      if (/window|windshield|glass|cockpit/.test(name)) {
+      if (/window|windshield|wind|glass|cockpit|cab/.test(name)) {
         mat.color.setHex(0x06080c);
         if ('metalness' in mat) mat.metalness = 0.58;
         if ('roughness' in mat) mat.roughness = 0.2;
@@ -642,7 +648,7 @@ function applyMilitaryTruckLook(root) {
         if ('opacity' in mat) mat.opacity = 0.95;
         return;
       }
-      if (/wheel|tire/.test(name)) {
+      if (/wheel|tire|tyre|rim/.test(name)) {
         mat.color.setHex(0x111111);
         if ('metalness' in mat) mat.metalness = 0.25;
         if ('roughness' in mat) mat.roughness = 0.78;
@@ -755,11 +761,11 @@ function createCaptureMissileFx() {
   const root = new THREE.Group();
   root.userData.lockCaptureTexture = true;
   const body = addFxCylinder(root, 0.09, 0.1, 1.18, [0, 0, 0], [0, 0, Math.PI / 2], '#d3d8de', 16, 0.3, 0.86);
-  body.material = createCaptureVehicleMaterial('missile', { color: '#b6d3bc', roughness: 0.38, metalness: 0.62 });
+  body.material = createCaptureVehicleMaterial('missile', { color: '#d9dde2', roughness: 0.2, metalness: 0.86 });
 
   const nose = new THREE.Mesh(
     new THREE.ConeGeometry(0.1, 0.28, 16),
-    new THREE.MeshStandardMaterial({ color: '#edf1f6', roughness: 0.22, metalness: 0.9 })
+    createCaptureVehicleMaterial('missile', { color: '#eef2f6', roughness: 0.16, metalness: 0.9 })
   );
   nose.position.set(0.74, 0, 0);
   nose.rotation.z = -Math.PI / 2;
@@ -767,10 +773,10 @@ function createCaptureMissileFx() {
   nose.receiveShadow = true;
   root.add(nose);
 
-  addFxBox(root, [0.17, 0.025, 0.34], [-0.19, 0, 0], '#cfd5dc', 0.34, 0.82);
-  addFxBox(root, [0.17, 0.34, 0.025], [-0.19, 0, 0], '#cfd5dc', 0.34, 0.82);
-  addFxBox(root, [0.12, 0.024, 0.22], [-0.44, 0, 0], '#0f1419', 0.5, 0.36);
-  addFxBox(root, [0.12, 0.22, 0.024], [-0.44, 0, 0], '#0f1419', 0.5, 0.36);
+  addFxBox(root, [0.17, 0.025, 0.34], [-0.19, 0, 0], '#8f979e', 0.28, 0.72);
+  addFxBox(root, [0.17, 0.34, 0.025], [-0.19, 0, 0], '#8f979e', 0.28, 0.72);
+  addFxBox(root, [0.12, 0.024, 0.22], [-0.44, 0, 0], '#101419', 0.34, 0.58);
+  addFxBox(root, [0.12, 0.22, 0.024], [-0.44, 0, 0], '#101419', 0.34, 0.58);
 
   const trail = [];
   for (let i = 0; i < 5; i += 1) {
@@ -822,23 +828,23 @@ async function createCaptureMissileTruckFx() {
   }
 
   const launcher = new THREE.Group();
-  launcher.position.set(-0.26, 0.56, 0);
-  launcher.rotation.z = -0.34;
-  addFxBox(launcher, [1.6, 0.05, 0.96], [0, 0, 0], '#1f2125', 0.62, 0.24);
-  const support = addFxBox(launcher, [0.12, 0.36, 0.18], [-0.46, -0.19, 0], '#0f1114', 0.5, 0.36);
+  launcher.position.set(-0.2, 0.72, 0);
+  launcher.rotation.z = 0;
+  addFxBox(launcher, [1.42, 0.06, 0.98], [0, 0, 0], '#1f2125', 0.62, 0.24);
+  const support = addFxBox(launcher, [0.16, 0.42, 0.2], [-0.44, -0.24, 0], '#0f1114', 0.5, 0.36);
   support.rotation.z = 0.22;
 
   const missileOffsets = [
-    [-0.3, 0.08, -0.28],
-    [0.05, 0.08, 0],
-    [0.4, 0.08, 0.28]
+    [-0.36, 0.54, -0.3],
+    [0, 0.54, 0],
+    [0.36, 0.54, 0.3]
   ];
   missileOffsets.forEach((offset) => {
     const missile = createCaptureMissileFx();
     missile.root.visible = true;
-    missile.root.scale.setScalar(0.38);
+    missile.root.scale.setScalar(0.62);
     missile.root.position.set(offset[0], offset[1], offset[2]);
-    missile.root.rotation.z = 0;
+    missile.root.rotation.z = Math.PI / 2;
     launcher.add(missile.root);
   });
 
@@ -987,21 +993,22 @@ async function createCaptureJetFx() {
   if (loadedJet) {
     const model = loadedJet.clone(true);
     fitObjectToTargetSize(model, 9.2 * CAPTURE_JET_SIZE_MULTIPLIER * 0.86);
-    model.rotation.set(Math.PI, Math.PI, 0);
+    model.rotation.set(0, Math.PI, 0);
     applyMilitaryJetLook(model);
     root.add(model);
     const trail = [];
     for (let i = 0; i < 6; i += 1) {
+      const isFire = i < 2;
       trail.push(
         addFxSphere(
           root,
-          0.11 + i * 0.03,
-          [-1.95 - i * 0.2, 0, 0],
-          i < 2 ? '#f7a94b' : '#8b949b',
-          i < 2 ? 0.22 : 1,
+          0.1 + i * 0.028,
+          [-1.92 - i * 0.22, 0, i % 2 === 0 ? -0.15 : 0.15],
+          isFire ? '#ff9a3d' : '#6d747b',
+          isFire ? 0.22 : 1,
           0,
           true,
-          i < 2 ? 0.85 - i * 0.18 : 0.28 - (i - 2) * 0.045
+          isFire ? 0.82 - i * 0.16 : 0.3 - (i - 2) * 0.045
         )
       );
     }
@@ -1062,19 +1069,20 @@ async function createCaptureJetFx() {
   root.add(rightStore);
   const trail = [];
   for (let i = 0; i < 6; i += 1) {
-    trail.push(
-      addFxSphere(
-        root,
-        0.11 + i * 0.03,
-        [-1.95 - i * 0.2, 0, 0],
-        i < 2 ? '#f7a94b' : '#8b949b',
-        i < 2 ? 0.22 : 1,
-        0,
-        true,
-        i < 2 ? 0.85 - i * 0.18 : 0.28 - (i - 2) * 0.045
-      )
-    );
-  }
+      const isFire = i < 2;
+      trail.push(
+        addFxSphere(
+          root,
+          0.1 + i * 0.028,
+          [-1.92 - i * 0.22, 0, i % 2 === 0 ? -0.16 : 0.16],
+          isFire ? '#ff9a3d' : '#6d747b',
+          isFire ? 0.22 : 1,
+          0,
+          true,
+          isFire ? 0.82 - i * 0.16 : 0.3 - (i - 2) * 0.045
+        )
+      );
+    }
   applyMilitaryJetLook(root);
   root.visible = false;
   return { root, trail };
@@ -4429,7 +4437,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       .clone()
       .addScaledVector(inward, CAPTURE_PARK_FORWARD_OFFSET)
       .addScaledVector(side, CAPTURE_PARK_SIDE_OFFSET * sideSign);
-    park.y = (arena.tableInfo?.surfaceY ?? park.y) + 0.08;
+    park.y = (arena.tableInfo?.surfaceY ?? park.y) + 0.18;
     return park;
   }, []);
 


### PR DESCRIPTION
### Motivation
- Improve visibility and visual consistency of capture-vehicle animations (jet, truck, missile) on the Ludo Battle Royal table so weapons are readable and correctly oriented during capture FX.
- Match javelin/missile styling with the existing short-missile appearance used in Chess Battle Royal for visual coherence.
- Ensure launcher/wheels/windows map reliably across different imported vehicle models and make parked vehicle placement more visible on the tabletop.

### Description
- Added engine/exhaust material mapping in `applyMilitaryJetLook` to darken engine/nozzle parts and improved cockpit/window handling so windows render black and non-reflective as expected.
- Corrected loaded jet model orientation by changing the model rotation in `createCaptureJetFx` so the jet is upright instead of upside-down, and retuned jet trail particles to emit fire/smoke colors and offsets from rear engines.
- Expanded truck material name matching in `applyMilitaryTruckLook` to include `wind`, `cab`, `tyre`, and `rim` variants and force black styling for windows and wheels to ensure consistent appearance.
- Rebuilt the missile-truck roof launcher in `createCaptureMissileTruckFx`: adjusted launcher position/rotation, raised the launcher and support, placed three larger missiles vertically above the roof support, and rotated/scaled missiles to resemble javelin orientation.
- Retuned missile material construction in `createCaptureMissileFx` to use `createCaptureVehicleMaterial('missile', ...)` with colors/metalness/roughness that align with the short-missile look used in Chess Battle Royal.
- Raised parked capture-vehicle anchor height in `resolveCaptureParkingAnchors` so parked jets/trucks/missiles sit higher above the table surface and are more visible.

### Testing
- Ran `npx eslint webapp/src/pages/Games/LudoBattleRoyal.jsx` which reported the file is ignored by repo ESLint patterns but produced no syntax errors.
- Ran `npx eslint --no-ignore webapp/src/pages/Games/LudoBattleRoyal.jsx` to check the file explicitly, which emitted the same ignore-warning but no lint errors were reported.
- Verified the modified file is the only source changed: `webapp/src/pages/Games/LudoBattleRoyal.jsx` (no automated unit or visual tests were run in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd34b2ceec8329b848e989e837f5c8)