### PR TITLE
Fix Pool Royale cue strike power latching

### DIFF
--- a/Assets/Scripts/Gameplay/CueController.cs
+++ b/Assets/Scripts/Gameplay/CueController.cs
@@ -35,8 +35,10 @@ namespace Aiming
         [Header("Strike feel")]
         public float strikeDuration = 0.12f;
         public float strikeHoldDuration = 0.05f;
-        [Tooltip("Minimum impulse used when slider power is above zero.")]
+        [Tooltip("Minimum impulse used whenever a valid shot is released.")]
         [Min(0f)] public float minStrikeImpulse = 0.25f;
+        [Tooltip("Smallest normalized power that still produces cue-ball movement when charge/release was valid.")]
+        [Range(0f, 0.5f)] public float minimumShotPowerNormalized = 0.06f;
         public float maxStrikeImpulse = 6.5f;
         [Tooltip("Normalized strike progress where the hit is fired once.")]
         [Range(0.75f, 0.99f)] public float hitProgress = 0.9f;
@@ -162,8 +164,8 @@ namespace Aiming
             }
 
             float recoveredPower = RecoverPowerFromCueDepth(_chargedCueDepth);
-            _latchedShotPower = Mathf.Clamp01(Mathf.Max(Mathf.Max(_power, recoveredPower), _maxPowerDuringCharge));
-            if (_latchedShotPower <= 0.02f)
+            _latchedShotPower = ResolveReleasedShotPower(_power, recoveredPower, _maxPowerDuringCharge);
+            if (_latchedShotPower <= 0f)
             {
                 _shotState = ShotState.Idle;
                 _maxPowerDuringCharge = 0f;
@@ -378,6 +380,18 @@ namespace Aiming
             UpdateCuePose();
         }
 
+
+        float ResolveReleasedShotPower(float sliderPower, float recoveredPower, float maxChargePower)
+        {
+            float raw = Mathf.Clamp01(Mathf.Max(Mathf.Max(sliderPower, recoveredPower), maxChargePower));
+            if (raw <= 0f)
+            {
+                return 0f;
+            }
+
+            return Mathf.Max(minimumShotPowerNormalized, raw);
+        }
+
         void ApplyStrikeImpulse(Vector3 strikeDirection, float shotPower)
         {
             if (cueBallBody == null)
@@ -386,6 +400,11 @@ namespace Aiming
             }
 
             float normalizedPower = Mathf.Clamp01(shotPower);
+            if (normalizedPower > 0f)
+            {
+                normalizedPower = Mathf.Max(minimumShotPowerNormalized, normalizedPower);
+            }
+
             if (normalizedPower <= 0f)
             {
                 return;


### PR DESCRIPTION
### Motivation
- Prevent valid cue-stick pull/push animations from playing while delivering zero or near-zero physical impulse to the cue ball, which produced the foul/no-power feel during releases.
- Keep the existing visual cue stroke while guaranteeing a minimum physical strike when a release is considered a valid shot.

### Description
- Updated `Assets/Scripts/Gameplay/CueController.cs` to add a new public setting `minimumShotPowerNormalized` and clarified the `minStrikeImpulse` tooltip to reflect the new behavior.
- Replaced the inline shot-power clamp with a dedicated `ResolveReleasedShotPower` method that latches the slider/recovered/max-charge power and returns zero only when raw power is zero.
- Enforced the `minimumShotPowerNormalized` floor in `ApplyStrikeImpulse` so any non-zero resolved shot always produces a minimum physical impulse while still scaling with the normalized slider value.
- Left `StrikeRoutine` visual timing and cue pull/push animation logic unchanged so stroke appearance is preserved while impulse application is fixed.

### Testing
- Ran automated test command `dotnet test billiards.Tests/Billiards.Tests.csproj`, which could not run in this environment because `dotnet` is not installed (test run failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddafeff6d4832988f0228a1725b547)