### PR TITLE
Synchronize Pool Royale cue stroke and power slider lifecycle

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -15418,6 +15418,9 @@ const showRuleToast = useCallback((message) => {
   }, 3000);
 }, []);
 const powerRef = useRef(hud.power);
+const shotPowerRef = useRef(hud.power);
+const sliderShotStateRef = useRef('idle');
+const powerResetRafRef = useRef(null);
   const clampPower = useCallback((value, fallback = 0) => {
     if (!Number.isFinite(value)) return fallback;
     return THREE.MathUtils.clamp(value, 0, 1);
@@ -15433,6 +15436,15 @@ const powerRef = useRef(hud.power);
   useEffect(() => {
     powerRef.current = hud.power;
   }, [hud.power]);
+  useEffect(
+    () => () => {
+      if (powerResetRafRef.current) {
+        cancelAnimationFrame(powerResetRafRef.current);
+        powerResetRafRef.current = null;
+      }
+    },
+    []
+  );
   const hudRef = useRef(hud);
   useEffect(() => {
     hudRef.current = hud;
@@ -32466,8 +32478,18 @@ const powerRef = useRef(hud.power);
       value: powerRef.current * 100,
       cueSrc: '/assets/snooker/cue.webp',
       labels: true,
-      onChange: (v) => applyPower(v / 100),
+      onChange: (v) => {
+        const normalized = clampPower(v / 100, 0);
+        shotPowerRef.current = normalized;
+        applyPower(normalized);
+      },
       onStart: () => {
+        sliderShotStateRef.current = 'dragging';
+        if (powerResetRafRef.current) {
+          cancelAnimationFrame(powerResetRafRef.current);
+          powerResetRafRef.current = null;
+        }
+        shotPowerRef.current = clampPower(powerRef.current, 0);
         captureCueStickAnchor();
       },
       onCommit: (sliderValue) => {
@@ -32475,11 +32497,34 @@ const powerRef = useRef(hud.power);
           Number.isFinite(sliderValue) ? sliderValue / 100 : powerRef.current,
           powerRef.current
         );
+        shotPowerRef.current = releasePower;
+        sliderShotStateRef.current = releasePower > 0.02 ? 'striking' : 'idle';
         fireRef.current?.(releasePower);
-        requestAnimationFrame(() => {
-          slider.set(slider.min, { animate: true });
+
+        const resetFrom = clampPower(powerRef.current, releasePower);
+        const resetStart = performance.now();
+        const resetDurationMs = 160;
+        const resetTick = () => {
+          const t = THREE.MathUtils.clamp(
+            (performance.now() - resetStart) / resetDurationMs,
+            0,
+            1
+          );
+          const eased = easeOutCubic(t);
+          const nextPower = THREE.MathUtils.lerp(resetFrom, 0, eased);
+          applyPower(nextPower);
+          slider.set(nextPower * 100, { animate: false });
+          if (t < 1) {
+            powerResetRafRef.current = requestAnimationFrame(resetTick);
+            return;
+          }
+          powerResetRafRef.current = null;
+          sliderShotStateRef.current = 'idle';
+          shotPowerRef.current = 0;
+          slider.set(slider.min, { animate: false });
           applyPower(0);
-        });
+        };
+        powerResetRafRef.current = requestAnimationFrame(resetTick);
       }
     });
     sliderInstanceRef.current = slider;
@@ -32488,7 +32533,7 @@ const powerRef = useRef(hud.power);
       sliderInstanceRef.current = null;
       slider.destroy();
     };
-  }, [applySliderLock, captureCueStickAnchor, showPowerSlider]);
+  }, [applyPower, applySliderLock, captureCueStickAnchor, clampPower, showPowerSlider]);
   useEffect(() => {
     if (shotActive || hud.over || hud.turn !== 0) return;
     const slider = sliderInstanceRef.current;


### PR DESCRIPTION
### Motivation
- Ensure the cue strike uses the exact power at slider release (drag → release → strike) rather than relying on transient HUD power during the slider reset animation.
- Mirror the reference technique where the slider latches release power, triggers the strike immediately, and the visible slider eases back to zero independently.

### Description
- Introduced `shotPowerRef`, `sliderShotStateRef`, and `powerResetRafRef` to track latched release power, slider lifecycle state, and any pending reset RAF respectively in `PoolRoyale.jsx`.
- Updated the big pull slider callbacks so `onChange` updates both HUD power and the latched shot power, `onStart` marks the slider as `'dragging'`, cancels pending reset RAFs and captures the current snapshot, and `onCommit` latches the release value, sets slider state to `'striking'` or `'idle'` as appropriate, calls `fireRef.current` with the exact release power, then runs a 160ms ease-out animation to return the visible slider to zero (without affecting the fired latched value).
- Added RAF cleanup effect to cancel any pending reset animation when the component unmounts, and expanded the slider effect dependency array to include the new helpers (`applyPower`, `clampPower`, etc.).
- All changes are contained in `webapp/src/pages/Games/PoolRoyale.jsx` and are compatible with the existing `PoolRoyalePowerSlider` implementation.

### Testing
- Ran the production build: `npm --prefix webapp run build` and the build completed successfully (Vite produced non-blocking chunk size warnings but the build artifact was produced).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddb4bd0cac8329b3725a0181356402)