### PR TITLE
Sync Pool Royale slider release with cue stroke pullback

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -32454,6 +32454,7 @@ const powerRef = useRef(hud.power);
   // NEW Big Pull Slider (right side): drag DOWN to set power, releases → fire()
   // --------------------------------------------------
   const sliderRef = useRef(null);
+  const sliderResetRafRef = useRef(0);
   const showPowerSlider = hud.turn === 0 && !hud.over && !replayActive && !shotActive;
   useEffect(() => {
     if (!showPowerSlider) {
@@ -32468,6 +32469,10 @@ const powerRef = useRef(hud.power);
       labels: true,
       onChange: (v) => applyPower(v / 100),
       onStart: () => {
+        if (sliderResetRafRef.current) {
+          cancelAnimationFrame(sliderResetRafRef.current);
+          sliderResetRafRef.current = 0;
+        }
         captureCueStickAnchor();
       },
       onCommit: (sliderValue) => {
@@ -32476,15 +32481,35 @@ const powerRef = useRef(hud.power);
           powerRef.current
         );
         fireRef.current?.(releasePower);
-        requestAnimationFrame(() => {
-          slider.set(slider.min, { animate: true });
-          applyPower(0);
-        });
+        const resetStart = performance.now();
+        const fromValue = slider.get();
+        const resetDurationMs = 160;
+        const easeOut = (t) => 1 - Math.pow(1 - t, 3);
+        const tickReset = () => {
+          const elapsed = performance.now() - resetStart;
+          const t = THREE.MathUtils.clamp(elapsed / resetDurationMs, 0, 1);
+          const nextValue = THREE.MathUtils.lerp(fromValue, slider.min, easeOut(t));
+          slider.set(nextValue, { animate: false });
+          if (t < 1) {
+            sliderResetRafRef.current = requestAnimationFrame(tickReset);
+            return;
+          }
+          sliderResetRafRef.current = 0;
+          slider.set(slider.min, { animate: false });
+        };
+        if (sliderResetRafRef.current) {
+          cancelAnimationFrame(sliderResetRafRef.current);
+        }
+        sliderResetRafRef.current = requestAnimationFrame(tickReset);
       }
     });
     sliderInstanceRef.current = slider;
     applySliderLock();
     return () => {
+      if (sliderResetRafRef.current) {
+        cancelAnimationFrame(sliderResetRafRef.current);
+        sliderResetRafRef.current = 0;
+      }
       sliderInstanceRef.current = null;
       slider.destroy();
     };


### PR DESCRIPTION
### Motivation
- The visible power slider was snapping to zero immediately on release, which could visually desynchronize the UI from the cue stroke animation and felt wrong compared to the reference technique. 
- The goal is to commit the shot power immediately on release while letting the slider visually decay back to zero in sync with the cue pull/strike animation.

### Description
- Added a `sliderResetRafRef` (`useRef`) and lifecycle guards to cancel any in-flight slider reset animation when a new drag starts or on unmount to avoid stale RAF updates. 
- Replaced the immediate post-release snap with a 160ms cubic ease-out fallback that animates the slider value to `slider.min` using `requestAnimationFrame` while the shot is already committed via `fireRef.current?.(releasePower)`. 
- Ensured cleanup by cancelling the RAF in the effect return so the slider reset stops when the slider unmounts. 
- File modified: `webapp/src/pages/Games/PoolRoyale.jsx` (integration of `PoolRoyalePowerSlider` release behavior).

### Testing
- Ran the production build with `cd webapp && npm run build`, which completed successfully. 
- The build surfaced existing Vite warnings about large chunks / dynamic imports but these are unrelated and non-blocking to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddb4bd0cac8329b3725a0181356402)