### PR TITLE
Align Pool Royale slider release with cue stroke sync

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -32455,6 +32455,7 @@ const powerRef = useRef(hud.power);
   // --------------------------------------------------
   const sliderRef = useRef(null);
   const sliderResetRafRef = useRef(0);
+  const sliderShotPowerRef = useRef(0);
   const showPowerSlider = hud.turn === 0 && !hud.over && !replayActive && !shotActive;
   useEffect(() => {
     if (!showPowerSlider) {
@@ -32473,14 +32474,18 @@ const powerRef = useRef(hud.power);
           cancelAnimationFrame(sliderResetRafRef.current);
           sliderResetRafRef.current = 0;
         }
+        sliderShotPowerRef.current = clampPower(powerRef.current, 0);
         captureCueStickAnchor();
       },
       onCommit: (sliderValue) => {
         const releasePower = clampPower(
-          Number.isFinite(sliderValue) ? sliderValue / 100 : powerRef.current,
+          Number.isFinite(sliderValue) ? sliderValue / 100 : sliderShotPowerRef.current,
           powerRef.current
         );
-        fireRef.current?.(releasePower);
+        sliderShotPowerRef.current = releasePower;
+        if (releasePower > 0.02) {
+          fireRef.current?.(releasePower);
+        }
         const resetStart = performance.now();
         const fromValue = slider.get();
         const resetDurationMs = 160;


### PR DESCRIPTION
### Motivation

- Ensure the visible power slider behavior produces identical, stable shot power values for the cue stroke so the cue animation and shot impulse stay in sync.
- Prevent micro-pulls from accidentally triggering a shot by gating release firing for trivial values.

### Description

- Added `sliderShotPowerRef` and capture its value on slider `onStart` so the shot power snapshot is stable across the drag-release interaction in `webapp/src/pages/Games/PoolRoyale.jsx`.
- On slider `onCommit` use the captured `sliderShotPowerRef` as a fallback when client release values are noisy and reuse the snapshot for the committed release; update `sliderShotPowerRef` with the final `releasePower`.
- Gate firing so `fireRef.current` is only called when `releasePower > 0.02`, and kept the existing eased slider reset animation after commit.

### Testing

- Ran the unit tests for cue stroke timeline and spin controller with `npm test -- --runInBand test/poolRoyaleCueStrokeTimeline.test.js test/poolRoyaleSpinController.test.js` and both suites passed.
- Test summary: `Test Suites: 2 passed, 2 total` and `Tests: 11 passed, 11 total`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddc37241448329aa529f2b9840b9d0)