### PR TITLE
Fix snake extra-roll freeze after player roll

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -2724,7 +2724,7 @@ export default function SnakeAndLadder() {
       const finalizeMove = (finalPos, type, effectStart) => {
         const effectOrigin = Number.isFinite(effectStart) ? effectStart : finalPos;
         setPos(finalPos);
-        setHighlight({ cell: finalPos, type, color: playerColors[index] });
+        setHighlight({ cell: finalPos, type, color: playerColors[0] });
         setTrail([]);
         setTokenType(type);
         setTimeout(() => setHighlight(null), 2300);


### PR DESCRIPTION
### Motivation
- Prevent a runtime crash during local player move finalization that could leave the UI stuck and block the extra-roll flow after rolling a six by fixing an incorrect player color reference.

### Description
- In `webapp/src/pages/Games/SnakeAndLadder.jsx` replaced `playerColors[index]` with `playerColors[0]` inside `finalizeMove` so the local/human player highlight uses a defined index.

### Testing
- Ran `npx eslint --no-ignore webapp/src/pages/Games/SnakeAndLadder.jsx` which produced the repository ignore warning and no lint errors for the applied change (file is skipped by repo ignore settings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddc401532483298cf1fc1a4c95f5ab)