### PR TITLE
Adjust parked vehicles and inward flight paths for Chess Battle Royal

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -120,8 +120,9 @@ const CAPTURE_AIR_STRIKE_BOARD_CLEARANCE = 0; // measure air-strike altitude str
 const CAPTURE_AIR_STRIKE_ALTITUDE_MULTIPLIER = 1; // align jet/helicopter flight height with drone altitude
 const CAPTURE_JET_ALTITUDE = CAPTURE_DRONE_REFERENCE_BOARD_ALTITUDE * CAPTURE_AIR_STRIKE_ALTITUDE_MULTIPLIER;
 const CAPTURE_HELICOPTER_ALTITUDE_BOOST = 0; // keep helicopter and jet at the same flight altitude
-const CAPTURE_AIR_STRIKE_PATH_RADIUS_FACTOR = 0.3; // shorten loops so jet/helicopter stay closer to board center
-const CAPTURE_AIR_STRIKE_PATH_EDGE_MARGIN_TILES = 2.05; // keep turns further inside board bounds
+const CAPTURE_AIR_STRIKE_PATH_RADIUS_FACTOR = 0.24; // shorten loops so jet/helicopter stay closer to board center
+const CAPTURE_AIR_STRIKE_PATH_EDGE_MARGIN_TILES = 0.86; // keep turns further inside board bounds
+const CAPTURE_DRONE_PATH_EDGE_MARGIN_TILES = 0.72; // keep drone path slightly tighter than default board clamp
 const CAPTURE_AIR_STRIKE_BOTTOM_PLAYER_BIAS_TILES = 0.02; // reduce portrait bottom bias so aircraft stay nearer center
 const CAPTURE_MISSILE_SCALE = 0.068;
 const CAPTURE_JAVELIN_MISSILE_SCALE = CAPTURE_MISSILE_SCALE * 1.48; // make javelin missile bigger
@@ -9286,16 +9287,16 @@ function Chess3D({
       return { root };
     };
     const getAirPadAnchor = (isWhiteSide, kind = 'jet', slot = 0) => {
-      const sideX = isWhiteSide ? -(half + BOARD.rim + tile * 1.34) : half + BOARD.rim + tile * 1.34;
+      const sideX = isWhiteSide ? -(half + BOARD.rim + tile * 0.86) : half + BOARD.rim + tile * 0.86;
       const laneMap = {
-        jet: tile * 2.05,
+        jet: tile * 1.46,
         helicopter: 0,
-        truck: -tile * 2.05
+        truck: -tile * 1.46
       };
       const laneBase = laneMap[kind] ?? laneMap.helicopter;
       const laneShift = slot === 0 ? -tile * 0.3 : tile * 0.3;
       const zOffset = laneBase + laneShift;
-      const yOffset = kind === 'truck' ? currentPieceYOffset + 0.04 : currentPieceYOffset + 0.12;
+      const yOffset = kind === 'truck' ? currentPieceYOffset + 0.08 : currentPieceYOffset + 0.17;
       return new THREE.Vector3(sideX, yOffset, zOffset);
     };
     const acquireParkedAirUnit = (isWhiteSide, kind) => {
@@ -11563,7 +11564,7 @@ function Chess3D({
                 progress: mu,
                 launchHeight: 0.08,
                 orbitHeight: CAPTURE_FLIGHT_ALTITUDE * 0.48,
-                orbitRadiusMul: 0.9,
+                orbitRadiusMul: 0.64,
                 minOrbitCycles: 0.34,
                 orbitSplit: 0.88,
                 returnSplit: 0.72
@@ -11574,7 +11575,7 @@ function Chess3D({
             } else {
               fx.droneFx.root.visible = true;
               const { pos, next } = pose;
-              fx.droneFx.root.position.copy(constrainInsideBoardPerimeter(pos));
+              fx.droneFx.root.position.copy(constrainInsideBoardPerimeter(pos, CAPTURE_DRONE_PATH_EDGE_MARGIN_TILES));
               captureDir.copy(next).sub(pos).normalize();
               fx.droneFx.root.quaternion.setFromUnitVectors(FORWARD, captureDir);
             }
@@ -11593,8 +11594,10 @@ function Chess3D({
             const jetTimelineU = clamp01(fx.t / CAPTURE_JET_TOTAL);
             const jetU = THREE.MathUtils.lerp(CAPTURE_JET_TRIMMED_START_RATIO, 1, jetTimelineU);
             fx.jetFx.root.scale.setScalar(CAPTURE_JET_SCALE);
-            const launchPos = getLiveLaunchPosition(fx.launchPos, fx.movingMesh, 0);
-            fx.launchPos.copy(launchPos);
+            const launchPos = fx.returnToOrigin
+              ? fx.launchPos.clone()
+              : getLiveLaunchPosition(fx.launchPos, fx.movingMesh, 0);
+            if (!fx.returnToOrigin) fx.launchPos.copy(launchPos);
             const { pos: jetPos, next: jetNext } = getCaptureLoopPose({
               from: launchPos,
               to: fx.to,
@@ -11607,7 +11610,9 @@ function Chess3D({
               returnToOrigin: Boolean(fx.returnToOrigin),
               sideSign: fx.to.x - launchPos.x >= 0 ? 1 : -1
             });
-            fx.jetFx.root.position.copy(constrainInsideBoardPerimeter(jetPos));
+            fx.jetFx.root.position.copy(
+              constrainInsideBoardPerimeter(jetPos, CAPTURE_AIR_STRIKE_PATH_EDGE_MARGIN_TILES)
+            );
             captureDir.copy(jetNext).sub(jetPos).normalize();
             const jetForward = captureDir.clone();
             fx.jetFx.root.quaternion.setFromUnitVectors(FORWARD, captureDir);
@@ -11674,7 +11679,9 @@ function Chess3D({
               }
               captureDir.copy(missileNext).sub(missilePos).normalize();
               missile.root.visible = true;
-              missile.root.position.copy(constrainInsideBoardPerimeter(missilePos));
+              missile.root.position.copy(
+                constrainInsideBoardPerimeter(missilePos, CAPTURE_AIR_STRIKE_PATH_EDGE_MARGIN_TILES)
+              );
               missile.root.quaternion.setFromUnitVectors(FORWARD, captureDir);
             });
             if (!anyMissileVisible && fx.t > releaseEnd + missileTravel) {
@@ -11718,7 +11725,9 @@ function Chess3D({
               returnToOrigin: Boolean(fx.returnToOrigin),
               sideSign: fx.to.x - launchPos.x >= 0 ? 1 : -1
             });
-            fx.helicopterFx.root.position.copy(constrainInsideBoardPerimeter(heliPos));
+            fx.helicopterFx.root.position.copy(
+              constrainInsideBoardPerimeter(heliPos, CAPTURE_AIR_STRIKE_PATH_EDGE_MARGIN_TILES)
+            );
             captureDir.copy(heliNext).sub(heliPos).normalize();
             const heliForward = captureDir.clone();
             fx.helicopterFx.root.quaternion.setFromUnitVectors(FORWARD, captureDir);
@@ -11784,7 +11793,9 @@ function Chess3D({
               }
               captureDir.copy(missileNext).sub(missilePos).normalize();
               missile.root.visible = true;
-              missile.root.position.copy(constrainInsideBoardPerimeter(missilePos));
+              missile.root.position.copy(
+                constrainInsideBoardPerimeter(missilePos, CAPTURE_AIR_STRIKE_PATH_EDGE_MARGIN_TILES)
+              );
               missile.root.quaternion.setFromUnitVectors(FORWARD, captureDir);
             });
             if (!anyMissileVisible && fx.t > releaseEnd + missileTravel) {


### PR DESCRIPTION
### Motivation
- Parked jets, helicopters and support trucks were visually clipped at the board edge and sat too low relative to the board surface. 
- Fighter jet and helicopter fly paths could drift off-screen in portrait view and the jet was being launched from the live piece position instead of its parking spot. 
- Drone launch origin and path needed to be tighter and originate from the parked truck while preserving kamikaze impact behavior.

### Description
- Tightened air-strike loops by reducing `CAPTURE_AIR_STRIKE_PATH_RADIUS_FACTOR` and introduced explicit inward clamp margins via `CAPTURE_AIR_STRIKE_PATH_EDGE_MARGIN_TILES` and `CAPTURE_DRONE_PATH_EDGE_MARGIN_TILES` in `webapp/src/pages/Games/ChessBattleRoyal.jsx`.
- Pulled parked units inward and raised them by adjusting `getAirPadAnchor` side offsets, lane distances and `yOffset` so jets/helicopters/trucks sit on the board surface and closer to center (updated lane multipliers and sideX calculation).
- Reduced drone orbit radius (`orbitRadiusMul` for drone loop) to make the drone path smaller and more centered, and kept drone launch semantics from the parked truck via `fx.returnToOrigin` logic.
- Ensured jets and helicopters that `returnToOrigin` launch from their parked `launchPos` (do not re-snap to the live piece mid-flight) and applied the new clamp margin to all air unit positions and missiles using `constrainInsideBoardPerimeter` with the margin parameter.

### Testing
- Ran the production build with `npm --prefix webapp run build`, which completed successfully and produced the application bundle.
- Build emitted non-blocking warnings about large chunks and mixed dynamic/static imports but no errors occurred during the build step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddc17bff94832991fa7ff211ed7510)