### PR TITLE
Ludo: orient parked vehicles to face board center & preserve Chess BR GLTF textures

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -103,6 +103,7 @@ const CAPTURE_PARK_FORWARD_OFFSET_BY_TYPE = {
   drone: 0.04,
   missile: 0.1
 };
+const CAPTURE_PARK_ORIENTATION_FORWARD = new THREE.Vector3(1, 0, 0);
 
 function getCaptureVehicleTexture(kind = 'generic') {
   if (CAPTURE_VEHICLE_TEXTURE_CACHE.has(kind)) return CAPTURE_VEHICLE_TEXTURE_CACHE.get(kind);
@@ -581,6 +582,15 @@ function paintMeshMaterials(node, painter) {
   });
 }
 
+function hasPreserveCaptureGltfTextureTag(node) {
+  let current = node;
+  while (current) {
+    if (current?.userData?.preserveCaptureGltfTexture) return true;
+    current = current.parent ?? null;
+  }
+  return false;
+}
+
 function applyMilitaryJetLook(root) {
   if (!root) return;
   applyCaptureTextureToOpaqueMeshes(root, 'fighter');
@@ -851,7 +861,8 @@ async function createCaptureMissileTruckFx() {
     const model = loadedTruck.clone(true);
     fitObjectToTargetSize(model, 6.95);
     model.rotation.y = Math.PI;
-    applyMilitaryTruckLook(model);
+    model.userData.preserveCaptureGltfTexture = true;
+    root.userData.preserveCaptureGltfTexture = true;
     root.add(model);
   } else {
     const body = new THREE.Mesh(
@@ -916,7 +927,9 @@ async function createCaptureDroneFx() {
     const model = loadedDrone.clone(true);
     fitObjectToTargetSize(model, 3.85 * CAPTURE_DRONE_SIZE_MULTIPLIER);
     model.rotation.y = Math.PI;
-    const propeller = applyMilitaryDroneLook(model);
+    const propeller = findDroneMotorMesh(model);
+    model.userData.preserveCaptureGltfTexture = true;
+    root.userData.preserveCaptureGltfTexture = true;
     root.add(model);
     const trail = [];
     for (let i = 0; i < 5; i += 1) {
@@ -1049,7 +1062,8 @@ async function createCaptureJetFx() {
     const model = loadedJet.clone(true);
     fitObjectToTargetSize(model, 9.2 * CAPTURE_JET_SIZE_MULTIPLIER * 0.86);
     model.rotation.set(0, Math.PI, 0);
-    applyMilitaryJetLook(model);
+    model.userData.preserveCaptureGltfTexture = true;
+    root.userData.preserveCaptureGltfTexture = true;
     root.add(model);
     const trail = [];
     for (let i = 0; i < 6; i += 1) {
@@ -1151,7 +1165,8 @@ async function createCaptureHelicopterFx() {
     const model = loadedHelicopter.clone(true);
     fitObjectToTargetSize(model, 7.68 * CAPTURE_HELICOPTER_SIZE_MULTIPLIER);
     model.rotation.y = Math.PI;
-    applyMilitaryHelicopterLook(model);
+    model.userData.preserveCaptureGltfTexture = true;
+    root.userData.preserveCaptureGltfTexture = true;
     root.add(model);
     const trail = [];
     for (let i = 0; i < 6; i += 1) {
@@ -4432,6 +4447,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     const themedTexture = getPlayerCaptureVehicleTexture(tokenColor);
     vehicleRoot.traverse((node) => {
       if (!node?.isMesh) return;
+      if (hasPreserveCaptureGltfTextureTag(node)) return;
       const name = String(node.name || '').toLowerCase();
       if (/rotor|propell|blade|fan/.test(name)) return;
       const mats = Array.isArray(node.material) ? node.material : [node.material];
@@ -4568,10 +4584,17 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       helicopterFx.root.position.copy(helicopterPark);
       droneFx.root.position.copy(dronePark);
       missileFx.root.position.copy(missilePark);
-      jetFx.root.lookAt(arena.boardLookTarget);
-      helicopterFx.root.lookAt(arena.boardLookTarget);
-      droneFx.root.lookAt(arena.boardLookTarget);
-      missileFx.root.lookAt(arena.boardLookTarget);
+      const orientParkedVehicleTowardBoardCenter = (vehicleRoot) => {
+        if (!vehicleRoot?.position || !arena.boardLookTarget) return;
+        const toCenter = arena.boardLookTarget.clone().sub(vehicleRoot.position).setY(0);
+        if (toCenter.lengthSq() < 1e-6) return;
+        toCenter.normalize();
+        vehicleRoot.quaternion.setFromUnitVectors(CAPTURE_PARK_ORIENTATION_FORWARD, toCenter);
+      };
+      orientParkedVehicleTowardBoardCenter(jetFx.root);
+      orientParkedVehicleTowardBoardCenter(helicopterFx.root);
+      orientParkedVehicleTowardBoardCenter(droneFx.root);
+      orientParkedVehicleTowardBoardCenter(missileFx.root);
       // eslint-disable-next-line no-await-in-loop
       await applyCaptureVehiclePlayerTheme(jetFx.root, playerIndex);
       // eslint-disable-next-line no-await-in-loop


### PR DESCRIPTION
### Motivation
- Parked capture vehicles on the Ludo table need to keep their positions but visually face the board center so their noses/fronts point inward for consistent presentation. 
- When GLTF models (jet, helicopter, drone, truck) are provided from the Chess Battle Royal asset set, their original PBR textures/materials should be preserved instead of being repainted. 
- Player theming should still apply to fallback or procedurally-created meshes while not clobbering authentic GLTF texture mappings.

### Description
- Added `CAPTURE_PARK_ORIENTATION_FORWARD` and replaced `lookAt` calls with a quaternion computed via `setFromUnitVectors(CAPTURE_PARK_ORIENTATION_FORWARD, toCenter)` so parked vehicles rotate their model forward axis toward the board center. 
- Mark loaded GLTF vehicle roots with `userData.preserveCaptureGltfTexture = true` (and propagate to `root.userData`) for `jet`, `helicopter`, `drone`, and `truck` so loaded assets keep their original materials. 
- Added `hasPreserveCaptureGltfTextureTag(node)` to detect GLTF-tagged nodes and skip repainting logic in `applyCaptureVehiclePlayerTheme`, preventing player tint/theme replacement from overriding GLTF textures. 
- For loaded drone models, preserved the real propeller mesh by using `findDroneMotorMesh(model)` and avoided the previous full repaint path so rotors remain correct while still allowing FX/attachments and avatar badges.

### Testing
- Ran `npx eslint webapp/src/pages/Games/LudoBattleRoyal.jsx` which reported only repository ignore warnings and no lint errors. 
- Ran `npx eslint --no-ignore webapp/src/pages/Games/LudoBattleRoyal.jsx` which also returned only ignore-related warnings in this environment and no rule failures. 
- Manual runtime verification note: changes are limited to orientation and texture-preservation logic in `webapp/src/pages/Games/LudoBattleRoyal.jsx` and should be validated in-browser to confirm visual orientation and that Chess BR GLTF textures remain intact during gameplay.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddc34ee6e48329ba7ba5d2942442bc)