### PR TITLE
Snake & Ladder: lower board, tune dice/camera pacing, larger tokens, broadcast capture FX & store items

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -49,7 +49,7 @@ const HUMAN_SEAT_ROTATION_OFFSET = Math.PI / 8;
 const AI_CHAIR_GAP = CARD_W * 0.4;
 const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 1.1;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
-const TABLE_HEIGHT_LIFT = 0.025 * MODEL_SCALE;
+const TABLE_HEIGHT_LIFT = -0.01 * MODEL_SCALE;
 const TABLE_HEIGHT = STOOL_HEIGHT + TABLE_HEIGHT_LIFT;
 const TABLE_MODEL_TARGET_DIAMETER = TABLE_RADIUS * 2;
 const TABLE_MODEL_TARGET_HEIGHT = TABLE_HEIGHT;
@@ -121,8 +121,8 @@ const DICE_PIP_RIM_OUTER = DICE_PIP_RADIUS * 1.08;
 const DICE_PIP_RIM_OFFSET = DICE_SIZE * 0.0048;
 const DICE_PIP_SPREAD = DICE_SIZE * 0.3;
 const DICE_FACE_INSET = DICE_SIZE * 0.064;
-const DICE_ROLL_DURATION = 900;
-const DICE_SETTLE_DURATION = 320;
+const DICE_ROLL_DURATION = 720;
+const DICE_SETTLE_DURATION = 260;
 const DICE_BOUNCE_HEIGHT = DICE_SIZE * 0.6;
 const DICE_THROW_LANDING_MARGIN = TILE_SIZE * 1.8;
 const DICE_THROW_START_EXTRA = TILE_SIZE * 3.6;
@@ -181,9 +181,9 @@ const CAMERA_FOLLOW_MIN_TILE = Infinity;
 const CAMERA_FOLLOW_BACK_TILES = 5;
 
 const TURN_CAMERA_TURN_IN_DURATION = 620;
-const DICE_CAMERA_LOOK_IN_DURATION = 360;
-const DICE_CAMERA_LOOK_HOLD_DURATION = 900;
-const DICE_CAMERA_LOOK_OUT_DURATION = 420;
+const DICE_CAMERA_LOOK_IN_DURATION = 260;
+const DICE_CAMERA_LOOK_HOLD_DURATION = 560;
+const DICE_CAMERA_LOOK_OUT_DURATION = 280;
 const BOARD_AUTO_ROTATE_IN_DURATION = 520;
 const BOARD_AUTO_ROTATE_HOLD_DURATION = 0;
 const BOARD_AUTO_ROTATE_OUT_DURATION = 520;
@@ -199,7 +199,7 @@ const TILE_100_SUPPORT_RADIUS = TILE_SIZE * 0.58;
 const TILE_100_SUPPORT_HEIGHT_EXTRA = TILE_SIZE * 0.25;
 
 const TOKEN_RADIUS_SCALE = 1.19;
-const TOKEN_SCALE_MULTIPLIER = 1.16;
+const TOKEN_SCALE_MULTIPLIER = 1.62;
 const TOKEN_RADIUS = TILE_SIZE * 0.3 * TOKEN_RADIUS_SCALE * TOKEN_SCALE_MULTIPLIER;
 const TOKEN_HEIGHT = 0.09 * TOKEN_SCALE_MULTIPLIER;
 const CHESS_TOKEN_HEIGHT_SCALE = 1;
@@ -214,12 +214,12 @@ const TOKEN_MULTI_OCCUPANT_RADIUS = TILE_SIZE * 0.24 * TOKEN_RADIUS_SCALE * TOKE
 const DICE_PLAYER_EXTRA_OFFSET = TILE_SIZE * 1.8;
 const TOP_TILE_EXTRA_LEVELS = 1;
 const TOKEN_REST_RAIL_INSET_BY_SEAT = Object.freeze([
-  TILE_SIZE * 1.12,
-  TILE_SIZE * 0.86,
-  TILE_SIZE * 1.12,
-  TILE_SIZE * 0.86
+  TILE_SIZE * 0.78,
+  TILE_SIZE * 0.64,
+  TILE_SIZE * 0.78,
+  TILE_SIZE * 0.64
 ]);
-const TOKEN_REST_MIN_RADIUS = BOARD_RADIUS + TILE_SIZE * 2.72;
+const TOKEN_REST_MIN_RADIUS = BOARD_RADIUS + TILE_SIZE * 2.48;
 const TOKEN_REST_LATERAL_BY_SEAT = Object.freeze([
   -TOKEN_RADIUS * 0.08,
   TOKEN_RADIUS * 0.02,
@@ -366,8 +366,8 @@ const SNAKE_LATERAL_SCALE = TILE_SIZE * 0.0064;
 const SNAKE_CURVE_CLEARANCE = TILE_SIZE * 0.34;
 const SNAKE_NECK_LIFT_RATIO = 0.42;
 const SNAKE_TAIL_LIFT_RATIO = 0.36;
-const CAPTURE_MISSILE_FLIGHT_MS = 760;
-const CAPTURE_EXPLOSION_MS = 680;
+const CAPTURE_MISSILE_FLIGHT_MS = 620;
+const CAPTURE_EXPLOSION_MS = 560;
 const CAPTURE_TOKEN_ADVANCE_MS = 420;
 
 function pullPointTowardCenter(point, amount = TILE_EDGE_INSET) {
@@ -2711,7 +2711,7 @@ function buildArena(scene, renderer, host, cameraRef, disposeHandlers, appearanc
     0
   );
   const attachBoard = (info, group) => {
-    boardGroup.position.set(0, info.surfaceY + 0.004, 0);
+    boardGroup.position.set(0, info.surfaceY - 0.01, 0);
     boardLookTarget.set(0, info.surfaceY + targetLift + CAMERA_TARGET_EXTRA, 0);
     group.add(boardGroup);
   };
@@ -3852,7 +3852,7 @@ function quadraticBezier(a, b, c, t) {
   return ab.lerp(bc, t);
 }
 
-function createCaptureMissileRig() {
+function createCaptureVehicleRig(kind = 'fighter') {
   const root = new THREE.Group();
   const bodyMat = new THREE.MeshStandardMaterial({ color: '#c9ced3', roughness: 0.42, metalness: 0.12 });
   const noseMat = new THREE.MeshStandardMaterial({ color: '#f0f2f4', roughness: 0.32, metalness: 0.16 });
@@ -3865,25 +3865,42 @@ function createCaptureMissileRig() {
     opacity: 0.2
   });
 
-  const body = new THREE.Mesh(new THREE.CylinderGeometry(0.08, 0.09, 1, 16), bodyMat);
-  body.rotation.z = Math.PI / 2;
-  body.castShadow = true;
-  root.add(body);
+  if (kind === 'supportTruck') {
+    const chassis = new THREE.Mesh(new THREE.BoxGeometry(0.95, 0.22, 0.3), bodyMat);
+    chassis.castShadow = true;
+    root.add(chassis);
+    const cabin = new THREE.Mesh(new THREE.BoxGeometry(0.32, 0.2, 0.28), noseMat);
+    cabin.position.set(0.26, 0.2, 0);
+    cabin.castShadow = true;
+    root.add(cabin);
+    const launcher = new THREE.Mesh(new THREE.BoxGeometry(0.42, 0.1, 0.22), finMat);
+    launcher.position.set(-0.2, 0.24, 0);
+    launcher.castShadow = true;
+    root.add(launcher);
+  } else {
+    const body = new THREE.Mesh(
+      new THREE.CylinderGeometry(kind === 'drone' ? 0.06 : 0.08, kind === 'drone' ? 0.06 : 0.09, 1, 16),
+      bodyMat
+    );
+    body.rotation.z = Math.PI / 2;
+    body.castShadow = true;
+    root.add(body);
 
-  const nose = new THREE.Mesh(new THREE.ConeGeometry(0.095, 0.24, 16), noseMat);
-  nose.position.set(0.6, 0, 0);
-  nose.rotation.z = -Math.PI / 2;
-  nose.castShadow = true;
-  root.add(nose);
+    const nose = new THREE.Mesh(new THREE.ConeGeometry(0.095, 0.24, 16), noseMat);
+    nose.position.set(0.6, 0, 0);
+    nose.rotation.z = -Math.PI / 2;
+    nose.castShadow = true;
+    root.add(nose);
 
-  const finA = new THREE.Mesh(new THREE.BoxGeometry(0.12, 0.02, 0.24), finMat);
-  finA.position.set(-0.25, 0, 0);
-  finA.castShadow = true;
-  root.add(finA);
-  const finB = new THREE.Mesh(new THREE.BoxGeometry(0.12, 0.24, 0.02), finMat);
-  finB.position.set(-0.25, 0, 0);
-  finB.castShadow = true;
-  root.add(finB);
+    const finA = new THREE.Mesh(new THREE.BoxGeometry(0.12, 0.02, kind === 'helicopter' ? 0.4 : 0.24), finMat);
+    finA.position.set(kind === 'drone' ? 0 : -0.25, 0, 0);
+    finA.castShadow = true;
+    root.add(finA);
+    const finB = new THREE.Mesh(new THREE.BoxGeometry(0.12, kind === 'drone' ? 0.12 : 0.24, 0.02), finMat);
+    finB.position.set(-0.25, 0, 0);
+    finB.castShadow = true;
+    root.add(finB);
+  }
 
   const trail = [];
   for (let i = 0; i < 4; i += 1) {
@@ -3894,7 +3911,7 @@ function createCaptureMissileRig() {
     root.add(puff);
   }
   root.visible = false;
-  return { root, trail };
+  return { root, trail, kind };
 }
 
 function createCaptureExplosionRig() {
@@ -4249,11 +4266,16 @@ export default function SnakeBoard3D({
       seatAnchors: arena.seatAnchors ?? [],
       startCameraState: arena.startCameraState ?? null
     };
-    const captureMissile = createCaptureMissileRig();
+    const captureVehicles = {
+      fighter: createCaptureVehicleRig('fighter'),
+      helicopter: createCaptureVehicleRig('helicopter'),
+      drone: createCaptureVehicleRig('drone'),
+      supportTruck: createCaptureVehicleRig('supportTruck')
+    };
     const captureExplosion = createCaptureExplosionRig();
-    scene.add(captureMissile.root);
+    Object.values(captureVehicles).forEach((vehicle) => scene.add(vehicle.root));
     scene.add(captureExplosion.root);
-    boardRef.current.captureFx = { missile: captureMissile, explosion: captureExplosion };
+    boardRef.current.captureFx = { vehicles: captureVehicles, explosion: captureExplosion };
     startCameraMinYRef.current = arena.startCameraState?.position?.y ?? null;
     const getCameraConstraints = () => {
       if (cameraViewModeRef.current === '2d') {
@@ -5008,7 +5030,9 @@ export default function SnakeBoard3D({
     if (captureFxIdRef.current === captureEvent.id) return;
     captureFxIdRef.current = captureEvent.id;
     const board = boardRef.current;
-    const missile = board.captureFx?.missile;
+    const vehicleKind = captureEvent.weaponType || 'fighter';
+    const vehicleMap = board.captureFx?.vehicles || {};
+    const missile = vehicleMap[vehicleKind] || vehicleMap.fighter || Object.values(vehicleMap)[0];
     const explosion = board.captureFx?.explosion;
     if (!missile || !explosion) {
       onCaptureAnimationComplete?.(captureEvent.id);
@@ -5031,6 +5055,9 @@ export default function SnakeBoard3D({
 
     attacker.position.copy(startPos);
     attacker.userData.isSliding = true;
+    Object.values(vehicleMap).forEach((vehicle) => {
+      if (vehicle?.root) vehicle.root.visible = false;
+    });
     missile.root.visible = true;
     explosion.root.visible = false;
     const bbox = new THREE.Box3().setFromObject(attacker);
@@ -5041,6 +5068,25 @@ export default function SnakeBoard3D({
     const flightDuration = CAPTURE_MISSILE_FLIGHT_MS;
     const impactDuration = CAPTURE_EXPLOSION_MS;
     const advanceDuration = CAPTURE_TOKEN_ADVANCE_MS;
+    const camera = cameraRef.current;
+    const controls = board.controls;
+    if (cameraViewMode !== '2d' && camera && controls) {
+      const focusTarget = launch.clone().lerp(impact, 0.54);
+      const currentOffset = camera.position.clone().sub(controls.target);
+      const desiredTarget = focusTarget.clone().add(new THREE.Vector3(0, TOKEN_HEIGHT * 1.8, 0));
+      const desiredPosition = desiredTarget.clone().add(currentOffset);
+      const captureCameraAnimation = createCameraTransitionAnimation(camera, controls, {
+        toPosition: desiredPosition,
+        toTarget: desiredTarget,
+        durationIn: 180,
+        hold: Math.max(140, flightDuration - 220),
+        durationOut: 200,
+        type: 'cameraCaptureFocus',
+        returnPosition: turnCameraStateRef.current?.position,
+        returnTarget: turnCameraStateRef.current?.target
+      });
+      if (captureCameraAnimation) animationsRef.current.push(captureCameraAnimation);
+    }
     animationsRef.current.push({
       update: (now) => {
         const elapsed = now - startTime;
@@ -5053,6 +5099,9 @@ export default function SnakeBoard3D({
           missile.root.visible = true;
           missile.root.position.copy(pos);
           missile.root.quaternion.setFromUnitVectors(new THREE.Vector3(1, 0, 0), dir);
+          if (vehicleKind === 'supportTruck') {
+            missile.root.rotation.z = Math.PI * 0.08;
+          }
           missile.trail.forEach((puff, i) => {
             puff.position.set(-0.38 - i * 0.12, Math.sin(now * 0.01 * 8 + i) * 0.015, 0);
             const s = 0.8 + i * 0.16 + ((now * 0.0018 + i * 0.2) % 1) * 0.5;

--- a/webapp/src/config/snakeInventoryConfig.js
+++ b/webapp/src/config/snakeInventoryConfig.js
@@ -26,6 +26,12 @@ const SNAKE_TOKEN_SHAPE_OPTIONS = Object.freeze([
   { id: 'queen', label: 'Queen Token' },
   { id: 'king', label: 'King Token' }
 ]);
+const SNAKE_CAPTURE_WEAPON_OPTIONS = Object.freeze([
+  { id: 'fighter', label: 'Fighter Jet' },
+  { id: 'helicopter', label: 'Military Helicopter' },
+  { id: 'supportTruck', label: 'Support Truck' },
+  { id: 'drone', label: 'Drone' }
+]);
 
 export const SNAKE_PAWN_HEAD_OPTIONS = Object.freeze([
   { id: 'current', label: 'Current' },
@@ -89,6 +95,12 @@ const SNAKE_THEME_THUMBNAILS = Object.freeze({
     rook: swatchThumbnail(['#f8fafc', '#1f2937', '#f97316']),
     queen: swatchThumbnail(['#f8fafc', '#1f2937', '#ec4899']),
     king: swatchThumbnail(['#f8fafc', '#1f2937', '#f59e0b'])
+  },
+  captureWeapon: {
+    fighter: swatchThumbnail(['#9ca3af', '#475569', '#cbd5e1']),
+    helicopter: swatchThumbnail(['#84cc16', '#3f6212', '#bef264']),
+    supportTruck: swatchThumbnail(['#f97316', '#7c2d12', '#fdba74']),
+    drone: swatchThumbnail(['#60a5fa', '#1d4ed8', '#bfdbfe'])
   }
 });
 
@@ -102,6 +114,7 @@ export const SNAKE_DEFAULT_UNLOCKS = Object.freeze({
   tableFinish: [SNAKE_TABLE_FINISH_OPTIONS[0].id],
   headStyle: [SNAKE_PAWN_HEAD_OPTIONS[0].id],
   tokenShape: [SNAKE_TOKEN_SHAPE_OPTIONS[0].id],
+  captureWeapon: [SNAKE_CAPTURE_WEAPON_OPTIONS[0].id],
   tables: [MURLAN_TABLE_THEMES[0].id],
   stools: [MURLAN_STOOL_THEMES[0].id],
   environmentHdri: [POOL_ROYALE_DEFAULT_HDRI_ID]
@@ -137,6 +150,7 @@ export const SNAKE_OPTION_LABELS = Object.freeze({
   headStyle: mapLabels(SNAKE_PAWN_HEAD_OPTIONS),
   tableFinish: mapLabels(SNAKE_TABLE_FINISH_OPTIONS),
   tokenShape: mapLabels(SNAKE_TOKEN_SHAPE_OPTIONS),
+  captureWeapon: mapLabels(SNAKE_CAPTURE_WEAPON_OPTIONS),
   tables: mapLabels(MURLAN_TABLE_THEMES),
   stools: mapLabels(MURLAN_STOOL_THEMES),
   environmentHdri: Object.freeze(
@@ -148,6 +162,33 @@ export const SNAKE_OPTION_LABELS = Object.freeze({
 });
 
 export const SNAKE_STORE_ITEMS = [
+  {
+    id: 'capture-helicopter',
+    type: 'captureWeapon',
+    optionId: 'helicopter',
+    name: 'Military Helicopter',
+    price: 420,
+    description: 'Capture eliminations use a helicopter flypath and strike animation.',
+    thumbnail: SNAKE_THEME_THUMBNAILS.captureWeapon.helicopter
+  },
+  {
+    id: 'capture-supportTruck',
+    type: 'captureWeapon',
+    optionId: 'supportTruck',
+    name: 'Support Truck',
+    price: 390,
+    description: 'Capture eliminations use an armored truck flypath animation.',
+    thumbnail: SNAKE_THEME_THUMBNAILS.captureWeapon.supportTruck
+  },
+  {
+    id: 'capture-drone',
+    type: 'captureWeapon',
+    optionId: 'drone',
+    name: 'Combat Drone',
+    price: 360,
+    description: 'Capture eliminations use a drone strike flypath.',
+    thumbnail: SNAKE_THEME_THUMBNAILS.captureWeapon.drone
+  },
   {
     id: 'arena-crystalLagoon',
     type: 'arenaTheme',
@@ -351,6 +392,11 @@ export const SNAKE_DEFAULT_LOADOUT = [
     type: 'tokenShape',
     optionId: SNAKE_TOKEN_SHAPE_OPTIONS[0].id,
     label: SNAKE_TOKEN_SHAPE_OPTIONS[0].label
+  },
+  {
+    type: 'captureWeapon',
+    optionId: SNAKE_CAPTURE_WEAPON_OPTIONS[0].id,
+    label: SNAKE_CAPTURE_WEAPON_OPTIONS[0].label
   },
   { type: 'tables', optionId: MURLAN_TABLE_THEMES[0].id, label: MURLAN_TABLE_THEMES[0].label },
   { type: 'stools', optionId: MURLAN_STOOL_THEMES[0].id, label: MURLAN_STOOL_THEMES[0].label },

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -182,9 +182,10 @@ const SNAKE_SFX = Object.freeze({
 const FINAL_TILE = BOARD_FINAL_TILE;
 const PENULTIMATE_TILE = FINAL_TILE - 1;
 const TURN_TIME = 15;
-const AI_ROLL_DELAY_MS = 3400;
-const AI_EXTRA_ROLL_DELAY_MS = 2600;
-const TURN_ADVANCE_AFTER_DICE_MS = 2000;
+const AI_ROLL_DELAY_MS = 2400;
+const AI_EXTRA_ROLL_DELAY_MS = 1500;
+const TURN_ADVANCE_AFTER_DICE_MS = 1200;
+const DICE_RESULT_HOLD_MS = 1400;
 const DEFAULT_CAPACITY = 4;
 const COMMENTARY_PRESET_STORAGE_KEY = 'snakeCommentaryPreset';
 const COMMENTARY_MUTE_STORAGE_KEY = 'snakeCommentaryMute';
@@ -811,6 +812,12 @@ const TOKEN_SHAPE_OPTIONS = Object.freeze([
   { id: 'queen', label: 'Queen', pieceType: 'queen', source: 'ludoBattleRoyal' },
   { id: 'king', label: 'King', pieceType: 'king', source: 'ludoBattleRoyal' }
 ]);
+const CAPTURE_WEAPON_OPTIONS = Object.freeze([
+  { id: 'fighter', label: 'Fighter Jet' },
+  { id: 'helicopter', label: 'Military Helicopter' },
+  { id: 'supportTruck', label: 'Support Truck' },
+  { id: 'drone', label: 'Drone' }
+]);
 
 const SNAKE_SKIN_OPTIONS = Object.freeze([
   {
@@ -849,6 +856,7 @@ const SNAKE_CUSTOMIZATION_SECTIONS = [
   { key: 'boardPalette', label: 'Board Palette', options: BOARD_PALETTE_OPTIONS },
   { key: 'diceTheme', label: 'Dice Finish', options: DICE_THEME_OPTIONS },
   { key: 'tokenShape', label: 'Token Shape', options: TOKEN_SHAPE_OPTIONS },
+  { key: 'captureWeapon', label: 'Capture Weapon', options: CAPTURE_WEAPON_OPTIONS },
   { key: 'headStyle', label: 'Pawn Heads', options: PAWN_HEAD_PRESET_OPTIONS },
   { key: 'tableFinish', label: 'Table Finish', options: TABLE_FINISH_OPTIONS },
   { key: 'tables', label: 'Table Models', options: TABLE_THEME_OPTIONS },
@@ -917,6 +925,7 @@ const DEFAULT_APPEARANCE = Object.freeze({
   boardPalette: 0,
   diceTheme: 0,
   tokenShape: 0,
+  captureWeapon: 0,
   headStyle: 0,
   tableFinish: 0,
   tables: 0,
@@ -935,6 +944,7 @@ function normalizeAppearance(value = {}) {
     ['boardPalette', BOARD_PALETTE_OPTIONS.length],
     ['diceTheme', DICE_THEME_OPTIONS.length],
     ['tokenShape', TOKEN_SHAPE_OPTIONS.length],
+    ['captureWeapon', CAPTURE_WEAPON_OPTIONS.length],
     ['headStyle', PAWN_HEAD_PRESET_OPTIONS.length],
     ['tableFinish', TABLE_FINISH_OPTIONS.length],
     ['tables', TABLE_THEME_OPTIONS.length],
@@ -959,6 +969,7 @@ function resolveAppearance(appearance) {
   const dice = DICE_THEME_OPTIONS[normalized.diceTheme] ?? DICE_THEME_OPTIONS[0];
   const token = TOKEN_FINISH_OPTIONS[0];
   const tokenShape = TOKEN_SHAPE_OPTIONS[normalized.tokenShape] ?? TOKEN_SHAPE_OPTIONS[0];
+  const captureWeapon = CAPTURE_WEAPON_OPTIONS[normalized.captureWeapon] ?? CAPTURE_WEAPON_OPTIONS[0];
   const pawnHead = PAWN_HEAD_PRESET_OPTIONS[normalized.headStyle] ?? PAWN_HEAD_PRESET_OPTIONS[0];
   const tableFinish = TABLE_FINISH_OPTIONS[normalized.tableFinish] ?? TABLE_FINISH_OPTIONS[0];
   const snakeSkin = SNAKE_SKIN_OPTIONS[0];
@@ -979,6 +990,7 @@ function resolveAppearance(appearance) {
     dice: { ...dice },
     token: { ...token },
     tokenShape,
+    captureWeapon,
     pawnHead,
     tableFinish,
     snakeSkin: { ...snakeSkin },
@@ -1457,7 +1469,7 @@ export default function SnakeAndLadder() {
   }, []);
 
   const startCaptureAnimation = useCallback(
-    ({ attackerIndex, fromCell, targetCell, victimIndices = [], onComplete }) => {
+    ({ attackerIndex, fromCell, targetCell, victimIndices = [], weaponType, onComplete }) => {
       if (!victimIndices.length || targetCell <= 0) {
         if (typeof onComplete === 'function') onComplete();
         return false;
@@ -1472,6 +1484,7 @@ export default function SnakeAndLadder() {
         attackerIndex,
         fromCell,
         targetCell,
+        weaponType,
         victimIndices,
         onComplete
       };
@@ -1734,6 +1747,9 @@ export default function SnakeAndLadder() {
       if (idx !== mover && p === cell) victims.push(idx);
     });
     if (victims.length && cell > 0) {
+      const selectedWeapon = resolvedAppearance?.captureWeapon?.id || CAPTURE_WEAPON_OPTIONS[0].id;
+      const randomWeapon = CAPTURE_WEAPON_OPTIONS[Math.floor(Math.random() * CAPTURE_WEAPON_OPTIONS.length)]?.id;
+      const weaponType = mover === 0 ? selectedWeapon : (randomWeapon || selectedWeapon);
       setBurning((b) => [...new Set([...b, ...victims])]);
       const settleCapture = () => {
         if (!muted) {
@@ -1763,6 +1779,7 @@ export default function SnakeAndLadder() {
         attackerIndex: mover,
         fromCell: attackerFrom,
         targetCell: cell,
+        weaponType,
         victimIndices: victims,
         onComplete: settleCapture
       });
@@ -2243,7 +2260,7 @@ export default function SnakeAndLadder() {
     };
     const onRolled = ({ value, playerId }) => {
       setRollResult(value);
-      setTimeout(() => setRollResult(null), 2000);
+      setTimeout(() => setRollResult(null), DICE_RESULT_HOLD_MS);
       playDiceRollSound();
       const rollerId = playerId ?? playersRef.current[currentTurn]?.id;
       if (rollerId === myAccountId && Number(value) === 6) {
@@ -2615,7 +2632,7 @@ export default function SnakeAndLadder() {
       hahaSoundRef.current.currentTime = 0;
       hahaSoundRef.current.play().catch(() => {});
     }
-    setTimeout(() => setRollResult(null), 2000);
+    setTimeout(() => setRollResult(null), DICE_RESULT_HOLD_MS);
 
     setTimeout(() => {
       setDiceVisible(false);
@@ -2824,7 +2841,7 @@ export default function SnakeAndLadder() {
       };
 
       moveSeq(steps, 'normal', ctx, () => applyEffect(target), 'forward');
-    }, 2000);
+    }, DICE_RESULT_HOLD_MS);
   };
 
   const triggerAIRoll = (index) => {
@@ -2870,7 +2887,7 @@ export default function SnakeAndLadder() {
       hahaSoundRef.current.currentTime = 0;
       hahaSoundRef.current.play().catch(() => {});
     }
-    setTimeout(() => setRollResult(null), 2000);
+    setTimeout(() => setRollResult(null), DICE_RESULT_HOLD_MS);
     setTimeout(() => {
       setDiceVisible(false);
     let positions = [...aiPositions];
@@ -3033,7 +3050,7 @@ export default function SnakeAndLadder() {
       applyEffectHelper(startPos, ctx, (finalPos, type) => finalizeMove(finalPos, type, startPos));
 
     moveSeq(steps, 'normal', ctx, () => applyEffect(target), 'forward');
-    }, 2000);
+    }, DICE_RESULT_HOLD_MS);
   };
 
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- Present the Snake & Ladder arena slightly lower on screen and match dice/turn pacing to the Battle Royale cadence for a smoother broadcast feel.
- Make tokens more visible by increasing size and moving reserve tokens forward onto the table rail area.
- Replace single capture missile with broadcast-style capture vehicles and camera focus so captures read like a spectator broadcast.
- Expose capture weapon as a purchasable/customizable loadout and use random weapon selection for AI captures while honoring the player-selected weapon.

### Description
- Lowered board/table presentation by changing `TABLE_HEIGHT_LIFT` and moving the board group position in `webapp/src/components/SnakeBoard3D.jsx` so the board sits slightly lower on the table.  
- Tuned dice and camera timing by reducing `DICE_ROLL_DURATION`, `DICE_SETTLE_DURATION`, and the dice camera timing constants to speed look-in/hold/out behavior; added `DICE_RESULT_HOLD_MS` to `webapp/src/pages/Games/SnakeAndLadder.jsx` and replaced hard-coded 2s waits with the new constant.  
- Increased token visual scale by raising `TOKEN_SCALE_MULTIPLIER` to `1.62` and adjusted `TOKEN_REST_RAIL_INSET_BY_SEAT` and `TOKEN_REST_MIN_RADIUS` to place reserve tokens more on the wooden rail (all in `SnakeBoard3D.jsx`).  
- Reworked capture FX to support multiple vehicle kinds (`fighter`, `helicopter`, `drone`, `supportTruck`) via `createCaptureVehicleRig` and a `vehicles` map on `board.captureFx`, wired into the capture animation flow and camera focus (`SnakeBoard3D.jsx`).  
- Added UI/appearance/store plumbing: `CAPTURE_WEAPON_OPTIONS`, `captureWeapon` appearance field, customization section entries, default loadout entry and new `captureWeapon` store items and thumbnails in `webapp/src/pages/Games/SnakeAndLadder.jsx` and `webapp/src/config/snakeInventoryConfig.js`.  
- Capture flow: `startCaptureAnimation` now accepts `weaponType`, `capturePieces` selects the player-chosen weapon for player captures and a randomized weapon for AI captures, and the selected vehicle drives the capture flight/visuals (changes in `SnakeAndLadder.jsx` and `SnakeBoard3D.jsx`).  

### Testing
- Built the web app with `npm --prefix webapp run build` and the production build completed successfully (vite build finished).  
- Verified the modified modules compile in the production bundle with no runtime build errors; build emitted chunk-size warnings only (informational).  
- No automated unit tests were added or run beyond the production build step above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddcea63c4083299acd63e53c92e629)