### PR TITLE
Adjust Chess Battle Royale parked vehicles and inward flight behavior

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -120,8 +120,8 @@ const CAPTURE_AIR_STRIKE_BOARD_CLEARANCE = 0; // measure air-strike altitude str
 const CAPTURE_AIR_STRIKE_ALTITUDE_MULTIPLIER = 1; // align jet/helicopter flight height with drone altitude
 const CAPTURE_JET_ALTITUDE = CAPTURE_DRONE_REFERENCE_BOARD_ALTITUDE * CAPTURE_AIR_STRIKE_ALTITUDE_MULTIPLIER;
 const CAPTURE_HELICOPTER_ALTITUDE_BOOST = 0; // keep helicopter and jet at the same flight altitude
-const CAPTURE_AIR_STRIKE_PATH_RADIUS_FACTOR = 0.3; // shorten loops so jet/helicopter stay closer to board center
-const CAPTURE_AIR_STRIKE_PATH_EDGE_MARGIN_TILES = 2.05; // keep turns further inside board bounds
+const CAPTURE_AIR_STRIKE_PATH_RADIUS_FACTOR = 0.22; // tighten loops so jet/helicopter stay nearer board center
+const CAPTURE_AIR_STRIKE_PATH_EDGE_MARGIN_TILES = 2.28; // keep turns further inside board bounds
 const CAPTURE_AIR_STRIKE_BOTTOM_PLAYER_BIAS_TILES = 0.02; // reduce portrait bottom bias so aircraft stay nearer center
 const CAPTURE_MISSILE_SCALE = 0.068;
 const CAPTURE_JAVELIN_MISSILE_SCALE = CAPTURE_MISSILE_SCALE * 1.48; // make javelin missile bigger
@@ -9286,16 +9286,16 @@ function Chess3D({
       return { root };
     };
     const getAirPadAnchor = (isWhiteSide, kind = 'jet', slot = 0) => {
-      const sideX = isWhiteSide ? -(half + BOARD.rim + tile * 1.34) : half + BOARD.rim + tile * 1.34;
+      const sideX = isWhiteSide ? -(half + BOARD.rim + tile * 0.98) : half + BOARD.rim + tile * 0.98;
       const laneMap = {
-        jet: tile * 2.05,
+        jet: tile * 1.48,
         helicopter: 0,
-        truck: -tile * 2.05
+        truck: -tile * 1.48
       };
       const laneBase = laneMap[kind] ?? laneMap.helicopter;
-      const laneShift = slot === 0 ? -tile * 0.3 : tile * 0.3;
+      const laneShift = slot === 0 ? -tile * 0.22 : tile * 0.22;
       const zOffset = laneBase + laneShift;
-      const yOffset = kind === 'truck' ? currentPieceYOffset + 0.04 : currentPieceYOffset + 0.12;
+      const yOffset = kind === 'truck' ? currentPieceYOffset + 0.14 : currentPieceYOffset + 0.26;
       return new THREE.Vector3(sideX, yOffset, zOffset);
     };
     const acquireParkedAirUnit = (isWhiteSide, kind) => {
@@ -11562,10 +11562,10 @@ function Chess3D({
                 to: fx.to,
                 progress: mu,
                 launchHeight: 0.08,
-                orbitHeight: CAPTURE_FLIGHT_ALTITUDE * 0.48,
-                orbitRadiusMul: 0.9,
-                minOrbitCycles: 0.34,
-                orbitSplit: 0.88,
+                orbitHeight: CAPTURE_FLIGHT_ALTITUDE * 0.42,
+                orbitRadiusMul: 0.58,
+                minOrbitCycles: 0.22,
+                orbitSplit: 0.84,
                 returnSplit: 0.72
               });
             }
@@ -11593,8 +11593,10 @@ function Chess3D({
             const jetTimelineU = clamp01(fx.t / CAPTURE_JET_TOTAL);
             const jetU = THREE.MathUtils.lerp(CAPTURE_JET_TRIMMED_START_RATIO, 1, jetTimelineU);
             fx.jetFx.root.scale.setScalar(CAPTURE_JET_SCALE);
-            const launchPos = getLiveLaunchPosition(fx.launchPos, fx.movingMesh, 0);
-            fx.launchPos.copy(launchPos);
+            const launchPos = fx.returnToOrigin
+              ? fx.launchPos.clone()
+              : getLiveLaunchPosition(fx.launchPos, fx.movingMesh, 0);
+            if (!fx.returnToOrigin) fx.launchPos.copy(launchPos);
             const { pos: jetPos, next: jetNext } = getCaptureLoopPose({
               from: launchPos,
               to: fx.to,


### PR DESCRIPTION
### Motivation

- Parked jets, helicopters and support trucks were visually too low and too far from the playable board area on portrait screens, causing them to appear off-surface or off-screen. 
- Jet/helicopter fly paths were extending beyond the visible board; aircraft should fly closer to the board center so they remain on-screen in portrait. 
- Launch/return behavior should use the parked pad as the origin and destination when aircraft are configured to `returnToOrigin`, while drones should still launch from the truck and crash on the target.

### Description

- Updated capture path tuning constants (`CAPTURE_AIR_STRIKE_PATH_RADIUS_FACTOR`, `CAPTURE_AIR_STRIKE_PATH_EDGE_MARGIN_TILES`) to tighten air strike loops so jets/helicopters stay nearer the board center.  The changes live in `webapp/src/pages/Games/ChessBattleRoyal.jsx`.
- Repositioned and raised parking anchors in `getAirPadAnchor`: reduced side offsets, moved lane distances inward, tightened slot shift (`laneShift`), and increased `yOffset` so parked jets/helicopters/trucks sit visually on the board parking surface.
- Reduced drone orbit geometry by lowering `orbitHeight`, decreasing `orbitRadiusMul`, and trimming `minOrbitCycles`/`orbitSplit` so the drone loop is smaller and closer to center while preserving the crash-on-target behavior.
- Fixed jet launch origin logic so when `returnToOrigin` is true the jet uses its parked `launchPos` (pad) rather than the live piece position; missiles and return-to-origin cleanup still return/park units as before.

### Testing

- Ran the production build with `npm -C webapp run build`, which completed successfully.
- Build produced non-blocking Vite warnings about large chunks / dynamic-import placement but there were no build failures and the updated `ChessBattleRoyal.jsx` compiled into the production bundle.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddd36bace08329b9a7c9745be40dd9)