### PR TITLE
Align Pool Royale cue pullback with reference power-slider stroke

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -25907,12 +25907,11 @@ const powerRef = useRef(hud.power);
         const slider = sliderInstanceRef.current;
         const dragging = Boolean(slider?.dragging);
         const cappedMax = Number.isFinite(maxPull) ? Math.max(0, maxPull) : CUE_PULL_BASE;
-        const effectiveMax = Math.max(cappedMax + CUE_PULL_VISUAL_FUDGE, CUE_PULL_MIN_VISUAL);
+        const effectiveMax = Math.max(cappedMax, CUE_PULL_MIN_VISUAL);
         const desiredTarget = preserveLarger
           ? Math.max(cuePullCurrentRef.current ?? 0, pullTarget ?? 0)
           : pullTarget ?? 0;
-        const boostedTarget = desiredTarget * CUE_PULL_GLOBAL_VISIBILITY_BOOST;
-        const clampedTarget = THREE.MathUtils.clamp(boostedTarget, 0, effectiveMax);
+        const clampedTarget = THREE.MathUtils.clamp(desiredTarget, 0, effectiveMax);
         const smoothing = instant || dragging
           ? 1
           : Number.isFinite(smoothingOverride)
@@ -25974,14 +25973,10 @@ const powerRef = useRef(hud.power);
       };
       const computePullTargetFromPower = (power, maxPull = CUE_PULL_BASE) => {
         const ratio = THREE.MathUtils.clamp(power ?? 0, 0, 1);
-        const style = cueStrokeAnimationStyleRef.current ?? DEFAULT_CUE_STROKE_STYLE;
-        const styleRatio = resolveCueStrokeProfile(style, ratio).pullRatio;
+        const pullRange = 0.34;
+        const target = pullRange * easeOutCubic(ratio);
         const effectiveMax = Number.isFinite(maxPull) ? Math.max(maxPull, 0) : CUE_PULL_BASE;
-        const amplifiedMax = Math.max(effectiveMax, CUE_PULL_MIN_VISUAL);
-        const visualMax = effectiveMax + CUE_PULL_VISUAL_FUDGE;
-        const target =
-          amplifiedMax * styleRatio * CUE_PULL_VISUAL_MULTIPLIER * CUE_PULL_DISTANCE_SCALE;
-        return Math.min(target, visualMax);
+        return THREE.MathUtils.clamp(target, 0, Math.max(effectiveMax, CUE_PULL_MIN_VISUAL));
       };
       // Easing adapted from easings.net (MIT) for a smoother pull/release cue stroke.
       const easeInOutCubic = (t) =>
@@ -26508,7 +26503,7 @@ const powerRef = useRef(hud.power);
           const maxPull = Number.isFinite(rawMaxPull) ? rawMaxPull : CUE_PULL_BASE;
           // Mirror the reference stroke pullback curve exactly:
           // pull = pullRange * easeOutCubic(power), then push forward on strike.
-          const pullRange = 0.24;
+          const pullRange = 0.34;
           const pullTarget = pullRange * strokeProfile.pullRatio;
           const pulledNow = cuePullCurrentRef.current ?? pullTarget;
           const startPull = THREE.MathUtils.clamp(pulledNow, 0, Math.max(maxPull, 0));


### PR DESCRIPTION
### Motivation
- Ensure the Pool Royale cue pull/push behavior matches the reference power-slider implementation so the cue stick visuals, pull depth and strike timing are consistent with the known-good code.

### Description
- Adjusted `computeCuePull` in `webapp/src/pages/Games/PoolRoyale.jsx` to clamp the pull target directly (removed the extra visibility boost/fudge that altered the core pull target path).
- Replaced the power → pull mapping with the reference formula `pullRange * easeOutCubic(power)` using `pullRange = 0.34` in `computePullTargetFromPower` so slider power maps to pull depth exactly like the provided code.
- Updated the live stroke setup to use `pullRange = 0.34` (was `0.24`) when converting pulled cue position into the forward strike, keeping release motion consistent with the new mapping.

### Testing
- Ran the production build with `npm --prefix webapp run build` to validate compilation and bundling, and the build completed successfully (only existing Vite warnings about chunk size and mixed static/dynamic imports were emitted).
- No automated unit tests were added or run for this change in this rollout; in-browser manual interaction testing (drag slider/release to verify cue pull and cue-ball movement) should be performed during QA since runtime visual validation cannot be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddd351c0dc83299c8e7fea5eedf77b)