### PR TITLE
Seat weapon displays and capture weapon integration; camera, dice and token tuning

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -49,7 +49,7 @@ const HUMAN_SEAT_ROTATION_OFFSET = Math.PI / 8;
 const AI_CHAIR_GAP = CARD_W * 0.4;
 const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 1.1;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
-const TABLE_HEIGHT_LIFT = -0.01 * MODEL_SCALE;
+const TABLE_HEIGHT_LIFT = -0.045 * MODEL_SCALE;
 const TABLE_HEIGHT = STOOL_HEIGHT + TABLE_HEIGHT_LIFT;
 const TABLE_MODEL_TARGET_DIAMETER = TABLE_RADIUS * 2;
 const TABLE_MODEL_TARGET_HEIGHT = TABLE_HEIGHT;
@@ -121,8 +121,8 @@ const DICE_PIP_RIM_OUTER = DICE_PIP_RADIUS * 1.08;
 const DICE_PIP_RIM_OFFSET = DICE_SIZE * 0.0048;
 const DICE_PIP_SPREAD = DICE_SIZE * 0.3;
 const DICE_FACE_INSET = DICE_SIZE * 0.064;
-const DICE_ROLL_DURATION = 720;
-const DICE_SETTLE_DURATION = 260;
+const DICE_ROLL_DURATION = 520;
+const DICE_SETTLE_DURATION = 180;
 const DICE_BOUNCE_HEIGHT = DICE_SIZE * 0.6;
 const DICE_THROW_LANDING_MARGIN = TILE_SIZE * 1.8;
 const DICE_THROW_START_EXTRA = TILE_SIZE * 3.6;
@@ -181,9 +181,9 @@ const CAMERA_FOLLOW_MIN_TILE = Infinity;
 const CAMERA_FOLLOW_BACK_TILES = 5;
 
 const TURN_CAMERA_TURN_IN_DURATION = 620;
-const DICE_CAMERA_LOOK_IN_DURATION = 260;
-const DICE_CAMERA_LOOK_HOLD_DURATION = 560;
-const DICE_CAMERA_LOOK_OUT_DURATION = 280;
+const DICE_CAMERA_LOOK_IN_DURATION = 180;
+const DICE_CAMERA_LOOK_HOLD_DURATION = 380;
+const DICE_CAMERA_LOOK_OUT_DURATION = 180;
 const BOARD_AUTO_ROTATE_IN_DURATION = 520;
 const BOARD_AUTO_ROTATE_HOLD_DURATION = 0;
 const BOARD_AUTO_ROTATE_OUT_DURATION = 520;
@@ -214,12 +214,12 @@ const TOKEN_MULTI_OCCUPANT_RADIUS = TILE_SIZE * 0.24 * TOKEN_RADIUS_SCALE * TOKE
 const DICE_PLAYER_EXTRA_OFFSET = TILE_SIZE * 1.8;
 const TOP_TILE_EXTRA_LEVELS = 1;
 const TOKEN_REST_RAIL_INSET_BY_SEAT = Object.freeze([
+  TILE_SIZE * 0.94,
   TILE_SIZE * 0.78,
-  TILE_SIZE * 0.64,
-  TILE_SIZE * 0.78,
-  TILE_SIZE * 0.64
+  TILE_SIZE * 0.94,
+  TILE_SIZE * 0.78
 ]);
-const TOKEN_REST_MIN_RADIUS = BOARD_RADIUS + TILE_SIZE * 2.48;
+const TOKEN_REST_MIN_RADIUS = BOARD_RADIUS + TILE_SIZE * 2.08;
 const TOKEN_REST_LATERAL_BY_SEAT = Object.freeze([
   -TOKEN_RADIUS * 0.08,
   TOKEN_RADIUS * 0.02,
@@ -280,7 +280,6 @@ const LANDSCAPE_CAMERA_TUNING = Object.freeze({
   heightOffset: 1.2,
   targetLift: 0.08 * MODEL_SCALE
 });
-const LOCK_BOTTOM_SEAT_CAMERA = true;
 const SHOW_BOARD_RAILS = false;
 const COIN_RAISE = TILE_SIZE * 0.24;
 const COIN_LOCAL_LIFT = TILE_SIZE * 0.05;
@@ -1670,7 +1669,6 @@ function computeBoardFacingRotation(board, camera, tileIndex) {
 
 function computeTurnCameraFocusState(board, camera, turnIndex, players = []) {
   if (!board || !camera) return null;
-  if (LOCK_BOTTOM_SEAT_CAMERA) return null;
   const anchors = Array.isArray(board.seatAnchors) ? board.seatAnchors : [];
   const player = Array.isArray(players) ? players[turnIndex] : null;
   const rawSeatIndex = Number.isFinite(player?.seatIndex)
@@ -1718,7 +1716,6 @@ function computeTurnCameraFocusState(board, camera, turnIndex, players = []) {
 
 function computeDiceCameraFocusState(board, camera) {
   if (!board || !camera) return null;
-  if (LOCK_BOTTOM_SEAT_CAMERA) return null;
   const diceSet = Array.isArray(board.diceSet) ? board.diceSet.filter((die) => die?.visible) : [];
   if (!diceSet.length) return null;
   const boardLookTarget = board.boardLookTarget;
@@ -1730,19 +1727,12 @@ function computeDiceCameraFocusState(board, camera) {
 
   const target = diceCenter.clone();
   target.y += DICE_SIZE * 0.45;
-  const currentDistance = camera.position.distanceTo(boardLookTarget);
-  const direction = camera.position.clone().sub(boardLookTarget).setY(0);
-  if (direction.lengthSq() < 1e-6) direction.set(0, 0, 1);
-  direction.normalize();
-
-  const position = target.clone().addScaledVector(direction, currentDistance);
-  position.y = camera.position.y;
+  const position = camera.position.clone();
   return { position, target };
 }
 
 function computeTokenFollowCameraState(board, camera, fromIndex, toIndex) {
   if (!board || !camera) return null;
-  if (LOCK_BOTTOM_SEAT_CAMERA) return null;
   const boardLookTarget = board.boardLookTarget;
   if (!boardLookTarget) return null;
   const toPos = (board.indexToPosition.get(toIndex) || board.serpentineIndexToXZ(toIndex))?.clone();
@@ -1757,12 +1747,9 @@ function computeTokenFollowCameraState(board, camera, fromIndex, toIndex) {
   if (pathDir.lengthSq() < 1e-6) return null;
   pathDir.normalize();
 
-  const behindDirection = pathDir.clone().multiplyScalar(-1);
-  const followDistance = TILE_SIZE * CAMERA_FOLLOW_BACK_TILES;
   const target = toPos.clone();
   target.y += TILE_SIZE * 0.18;
-  const position = target.clone().addScaledVector(behindDirection, followDistance);
-  position.y = Math.max(camera.position.y, boardLookTarget.y + CAMERA_EXTRA_LIFT);
+  const position = camera.position.clone();
   return { position, target };
 }
 
@@ -3546,7 +3533,7 @@ function updateTokens(
             .addScaledVector(lateral, railSpread);
           worldPos = railWorld.clone();
           boardRoot.worldToLocal(worldPos);
-          worldPos.y = TOKEN_HEIGHT * 0.62;
+          worldPos.y = TOKEN_HEIGHT * 0.44;
         }
       }
       if (!worldPos) {
@@ -3991,6 +3978,123 @@ function updateCaptureExplosionRig(rig, elapsedSinceImpact) {
   });
 }
 
+function cloneCaptureDisplayVehicle(board, weaponType = 'fighter') {
+  const source = board?.captureFx?.vehicles?.[weaponType]?.root;
+  if (!source) return null;
+  const clone = source.clone(true);
+  clone.visible = true;
+  clone.traverse((obj) => {
+    obj.visible = true;
+    if (obj.isMesh) {
+      obj.castShadow = true;
+      obj.receiveShadow = true;
+      if (obj.material?.transparent) {
+        obj.material = obj.material.clone();
+        obj.material.opacity = Math.max(0.45, obj.material.opacity ?? 1);
+      }
+    }
+  });
+  return clone;
+}
+
+function createSeatWeaponMesh(weaponType = 'fighter') {
+  const group = new THREE.Group();
+  const bodyMat = new THREE.MeshStandardMaterial({ color: '#d4d4d8', roughness: 0.36, metalness: 0.28 });
+  const accentMat = new THREE.MeshStandardMaterial({ color: '#475569', roughness: 0.5, metalness: 0.22 });
+  if (weaponType === 'supportTruck') {
+    const base = new THREE.Mesh(new THREE.BoxGeometry(TOKEN_RADIUS * 2.2, TOKEN_HEIGHT * 0.45, TOKEN_RADIUS), bodyMat);
+    const cab = new THREE.Mesh(new THREE.BoxGeometry(TOKEN_RADIUS * 0.9, TOKEN_HEIGHT * 0.62, TOKEN_RADIUS * 0.82), accentMat);
+    cab.position.set(TOKEN_RADIUS * 0.36, TOKEN_HEIGHT * 0.5, 0);
+    group.add(base, cab);
+  } else if (weaponType === 'helicopter') {
+    const body = new THREE.Mesh(new THREE.CapsuleGeometry(TOKEN_RADIUS * 0.32, TOKEN_RADIUS * 1.1, 8, 12), bodyMat);
+    body.rotation.z = Math.PI / 2;
+    const rotor = new THREE.Mesh(new THREE.BoxGeometry(TOKEN_RADIUS * 2.2, TOKEN_HEIGHT * 0.1, TOKEN_HEIGHT * 0.08), accentMat);
+    rotor.position.y = TOKEN_HEIGHT * 0.36;
+    group.add(body, rotor);
+  } else if (weaponType === 'drone') {
+    const core = new THREE.Mesh(new THREE.SphereGeometry(TOKEN_RADIUS * 0.36, 16, 12), bodyMat);
+    const armA = new THREE.Mesh(new THREE.BoxGeometry(TOKEN_RADIUS * 1.8, TOKEN_HEIGHT * 0.1, TOKEN_HEIGHT * 0.1), accentMat);
+    const armB = armA.clone();
+    armB.rotation.y = Math.PI / 2;
+    group.add(core, armA, armB);
+  } else {
+    const body = new THREE.Mesh(new THREE.CylinderGeometry(TOKEN_RADIUS * 0.24, TOKEN_RADIUS * 0.32, TOKEN_RADIUS * 1.8, 14), bodyMat);
+    body.rotation.z = Math.PI / 2;
+    const nose = new THREE.Mesh(new THREE.ConeGeometry(TOKEN_RADIUS * 0.24, TOKEN_RADIUS * 0.58, 12), accentMat);
+    nose.position.x = TOKEN_RADIUS * 1.04;
+    nose.rotation.z = -Math.PI / 2;
+    group.add(body, nose);
+  }
+  group.traverse((obj) => {
+    if (obj.isMesh) {
+      obj.castShadow = true;
+      obj.receiveShadow = true;
+    }
+  });
+  return group;
+}
+
+function updateSeatWeaponDisplays(board, players = []) {
+  if (!board?.weaponDisplayGroup || !Array.isArray(board?.seatAnchors)) return;
+  const anchors = board.seatAnchors;
+  const boardLookTarget = board.boardLookTarget;
+  if (!boardLookTarget) return;
+  const keep = new Set();
+  const fallbackOrder = ['fighter', 'helicopter', 'supportTruck', 'drone'];
+  const tableY = Number.isFinite(board?.tableInfo?.surfaceY) ? board.tableInfo.surfaceY : boardLookTarget.y;
+
+  players.forEach((player, index) => {
+    const seatIndex = Number.isFinite(player?.seatIndex) ? player.seatIndex : index;
+    const anchor = anchors[seatIndex];
+    if (!anchor) return;
+    keep.add(index);
+    let holder = board.weaponDisplayGroup.userData.byPlayer?.get(index);
+    if (!holder) {
+      holder = new THREE.Group();
+      holder.userData.weaponType = null;
+      board.weaponDisplayGroup.add(holder);
+      if (!board.weaponDisplayGroup.userData.byPlayer) board.weaponDisplayGroup.userData.byPlayer = new Map();
+      board.weaponDisplayGroup.userData.byPlayer.set(index, holder);
+    }
+    const weaponType = player?.weaponType || fallbackOrder[index % fallbackOrder.length];
+    if (holder.userData.weaponType !== weaponType) {
+      while (holder.children.length) {
+        const child = holder.children.pop();
+        if (child) holder.remove(child);
+      }
+      const vehicleClone = cloneCaptureDisplayVehicle(board, weaponType);
+      holder.add(vehicleClone || createSeatWeaponMesh(weaponType));
+      holder.userData.weaponType = weaponType;
+    }
+    const seatWorld = new THREE.Vector3();
+    anchor.getWorldPosition(seatWorld);
+    const seatDirection = seatWorld.clone().sub(boardLookTarget).setY(0);
+    if (seatDirection.lengthSq() < 1e-6) return;
+    seatDirection.normalize();
+    const lateral = new THREE.Vector3(-seatDirection.z, 0, seatDirection.x);
+    const radius = TOKEN_REST_MIN_RADIUS + TILE_SIZE * 0.16;
+    const markerPos = boardLookTarget
+      .clone()
+      .addScaledVector(seatDirection, radius)
+      .addScaledVector(lateral, (seatIndex % 2 === 0 ? 1 : -1) * TOKEN_RADIUS * 0.22);
+    holder.position.copy(markerPos);
+    holder.position.y = tableY + TOKEN_HEIGHT * 0.24;
+    holder.lookAt(boardLookTarget.x, holder.position.y, boardLookTarget.z);
+    const displayScale = weaponType === 'supportTruck' ? 0.26 : 0.22;
+    holder.scale.setScalar(displayScale);
+  });
+
+  const byPlayer = board.weaponDisplayGroup.userData.byPlayer;
+  if (!(byPlayer instanceof Map)) return;
+  byPlayer.forEach((group, index) => {
+    if (!keep.has(index)) {
+      group.parent?.remove(group);
+      byPlayer.delete(index);
+    }
+  });
+}
+
 export default function SnakeBoard3D({
   players = [],
   highlight,
@@ -4259,12 +4363,18 @@ export default function SnakeBoard3D({
       arena.updateCameraTarget,
       appearanceMemo
     );
+    const weaponDisplayGroup = new THREE.Group();
+    weaponDisplayGroup.name = 'seatWeaponDisplayGroup';
+    weaponDisplayGroup.userData.byPlayer = new Map();
+    arena.boardGroup.add(weaponDisplayGroup);
     boardRef.current = {
       ...board,
       boardLookTarget: arena.boardLookTarget,
       controls: arena.controls,
       seatAnchors: arena.seatAnchors ?? [],
-      startCameraState: arena.startCameraState ?? null
+      startCameraState: arena.startCameraState ?? null,
+      tableInfo: arena.tableInfo ?? null,
+      weaponDisplayGroup
     };
     const captureVehicles = {
       fighter: createCaptureVehicleRig('fighter'),
@@ -4703,6 +4813,7 @@ export default function SnakeBoard3D({
       boardRoot: board.root,
       tableInfo: board.tableInfo
     });
+    updateSeatWeaponDisplays(board, players);
 
     const sanitizedPositions = players.map((player) => {
       const raw = Number(player?.position);
@@ -4729,13 +4840,9 @@ export default function SnakeBoard3D({
     if (cameraViewMode !== '2d' && movement && shouldFollowTileChange(movement.from, movement.to)) {
       const camera = cameraRef.current;
       const controls = board.controls;
-      const facingRotation = computeBoardFacingRotation(board, camera, movement.to);
-      if (camera && controls && Number.isFinite(facingRotation)) {
+      if (camera && controls) {
         removeAnimationsByType(animationsRef.current, 'cameraDiceZoom');
         removeAnimationsByType(animationsRef.current, 'cameraTokenFollow');
-        removeAnimationsByType(animationsRef.current, 'boardAutoRotate');
-        const rotateAnimation = createBoardRotationAnimation(board, facingRotation);
-        if (rotateAnimation) animationsRef.current.push(rotateAnimation);
         const followState = computeTokenFollowCameraState(board, camera, movement.from, movement.to);
         if (followState) {
           const followAnimation = createCameraTransitionAnimation(camera, controls, {
@@ -4817,14 +4924,8 @@ export default function SnakeBoard3D({
     const camera = cameraRef.current;
     const controls = board.controls;
     if (cameraViewMode !== '2d' && camera && controls && shouldFollowTileChange(slide.from, slide.to)) {
-      const facingRotation = computeBoardFacingRotation(board, camera, slide.to);
       removeAnimationsByType(animationsRef.current, 'cameraDiceZoom');
       removeAnimationsByType(animationsRef.current, 'cameraTokenFollow');
-      removeAnimationsByType(animationsRef.current, 'boardAutoRotate');
-      if (Number.isFinite(facingRotation)) {
-        const rotateAnimation = createBoardRotationAnimation(board, facingRotation);
-        if (rotateAnimation) animationsRef.current.push(rotateAnimation);
-      }
       const followState = computeTokenFollowCameraState(board, camera, slide.from, slide.to);
       if (followState) {
         const followAnimation = createCameraTransitionAnimation(camera, controls, {
@@ -5048,7 +5149,12 @@ export default function SnakeBoard3D({
     const startPos = (board.indexToPosition.get(captureEvent.fromCell) || board.serpentineIndexToXZ(captureEvent.fromCell)).clone();
     const targetPos = (board.indexToPosition.get(captureEvent.targetCell) || board.serpentineIndexToXZ(captureEvent.targetCell)).clone();
     startPos.y = targetPos.y = board.baseLevelTop + TOKEN_HEIGHT * 0.85;
-    const launch = startPos.clone().add(new THREE.Vector3(0, TOKEN_HEIGHT * 1.6, 0));
+    const parkedWeapon =
+      board.weaponDisplayGroup?.userData?.byPlayer instanceof Map
+        ? board.weaponDisplayGroup.userData.byPlayer.get(captureEvent.attackerIndex)
+        : null;
+    const launchBase = parkedWeapon?.position?.clone?.() ?? startPos.clone();
+    const launch = launchBase.clone().add(new THREE.Vector3(0, TOKEN_HEIGHT * 1.6, 0));
     const impact = targetPos.clone().add(new THREE.Vector3(0, TOKEN_HEIGHT * 1.2, 0));
     const control = launch.clone().lerp(impact, 0.48);
     control.y += TOKEN_HEIGHT * 6.8;
@@ -5072,11 +5178,9 @@ export default function SnakeBoard3D({
     const controls = board.controls;
     if (cameraViewMode !== '2d' && camera && controls) {
       const focusTarget = launch.clone().lerp(impact, 0.54);
-      const currentOffset = camera.position.clone().sub(controls.target);
       const desiredTarget = focusTarget.clone().add(new THREE.Vector3(0, TOKEN_HEIGHT * 1.8, 0));
-      const desiredPosition = desiredTarget.clone().add(currentOffset);
       const captureCameraAnimation = createCameraTransitionAnimation(camera, controls, {
-        toPosition: desiredPosition,
+        toPosition: camera.position.clone(),
         toTarget: desiredTarget,
         durationIn: 180,
         hold: Math.max(140, flightDuration - 220),

--- a/webapp/src/config/snakeInventoryConfig.js
+++ b/webapp/src/config/snakeInventoryConfig.js
@@ -27,10 +27,10 @@ const SNAKE_TOKEN_SHAPE_OPTIONS = Object.freeze([
   { id: 'king', label: 'King Token' }
 ]);
 const SNAKE_CAPTURE_WEAPON_OPTIONS = Object.freeze([
+  { id: 'drone', label: 'Drone' },
   { id: 'fighter', label: 'Fighter Jet' },
   { id: 'helicopter', label: 'Military Helicopter' },
-  { id: 'supportTruck', label: 'Support Truck' },
-  { id: 'drone', label: 'Drone' }
+  { id: 'supportTruck', label: 'Support Truck' }
 ]);
 
 export const SNAKE_PAWN_HEAD_OPTIONS = Object.freeze([
@@ -114,7 +114,7 @@ export const SNAKE_DEFAULT_UNLOCKS = Object.freeze({
   tableFinish: [SNAKE_TABLE_FINISH_OPTIONS[0].id],
   headStyle: [SNAKE_PAWN_HEAD_OPTIONS[0].id],
   tokenShape: [SNAKE_TOKEN_SHAPE_OPTIONS[0].id],
-  captureWeapon: [SNAKE_CAPTURE_WEAPON_OPTIONS[0].id],
+  captureWeapon: ['drone'],
   tables: [MURLAN_TABLE_THEMES[0].id],
   stools: [MURLAN_STOOL_THEMES[0].id],
   environmentHdri: [POOL_ROYALE_DEFAULT_HDRI_ID]
@@ -163,6 +163,15 @@ export const SNAKE_OPTION_LABELS = Object.freeze({
 
 export const SNAKE_STORE_ITEMS = [
   {
+    id: 'capture-fighter',
+    type: 'captureWeapon',
+    optionId: 'fighter',
+    name: 'F15 Fighter Jet',
+    price: 460,
+    description: 'Capture eliminations use the F15 flypath and strike animation.',
+    thumbnail: SNAKE_THEME_THUMBNAILS.captureWeapon.fighter
+  },
+  {
     id: 'capture-helicopter',
     type: 'captureWeapon',
     optionId: 'helicopter',
@@ -179,15 +188,6 @@ export const SNAKE_STORE_ITEMS = [
     price: 390,
     description: 'Capture eliminations use an armored truck flypath animation.',
     thumbnail: SNAKE_THEME_THUMBNAILS.captureWeapon.supportTruck
-  },
-  {
-    id: 'capture-drone',
-    type: 'captureWeapon',
-    optionId: 'drone',
-    name: 'Combat Drone',
-    price: 360,
-    description: 'Capture eliminations use a drone strike flypath.',
-    thumbnail: SNAKE_THEME_THUMBNAILS.captureWeapon.drone
   },
   {
     id: 'arena-crystalLagoon',

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -182,10 +182,10 @@ const SNAKE_SFX = Object.freeze({
 const FINAL_TILE = BOARD_FINAL_TILE;
 const PENULTIMATE_TILE = FINAL_TILE - 1;
 const TURN_TIME = 15;
-const AI_ROLL_DELAY_MS = 2400;
-const AI_EXTRA_ROLL_DELAY_MS = 1500;
-const TURN_ADVANCE_AFTER_DICE_MS = 1200;
-const DICE_RESULT_HOLD_MS = 1400;
+const AI_ROLL_DELAY_MS = 1300;
+const AI_EXTRA_ROLL_DELAY_MS = 850;
+const TURN_ADVANCE_AFTER_DICE_MS = 850;
+const DICE_RESULT_HOLD_MS = 2000;
 const DEFAULT_CAPACITY = 4;
 const COMMENTARY_PRESET_STORAGE_KEY = 'snakeCommentaryPreset';
 const COMMENTARY_MUTE_STORAGE_KEY = 'snakeCommentaryMute';
@@ -813,10 +813,10 @@ const TOKEN_SHAPE_OPTIONS = Object.freeze([
   { id: 'king', label: 'King', pieceType: 'king', source: 'ludoBattleRoyal' }
 ]);
 const CAPTURE_WEAPON_OPTIONS = Object.freeze([
+  { id: 'drone', label: 'Drone' },
   { id: 'fighter', label: 'Fighter Jet' },
   { id: 'helicopter', label: 'Military Helicopter' },
-  { id: 'supportTruck', label: 'Support Truck' },
-  { id: 'drone', label: 'Drone' }
+  { id: 'supportTruck', label: 'Support Truck' }
 ]);
 
 const SNAKE_SKIN_OPTIONS = Object.freeze([
@@ -1748,8 +1748,8 @@ export default function SnakeAndLadder() {
     });
     if (victims.length && cell > 0) {
       const selectedWeapon = resolvedAppearance?.captureWeapon?.id || CAPTURE_WEAPON_OPTIONS[0].id;
-      const randomWeapon = CAPTURE_WEAPON_OPTIONS[Math.floor(Math.random() * CAPTURE_WEAPON_OPTIONS.length)]?.id;
-      const weaponType = mover === 0 ? selectedWeapon : (randomWeapon || selectedWeapon);
+      const aiWeapon = mover > 0 ? aiWeaponLoadout[mover - 1] : null;
+      const weaponType = mover === 0 ? selectedWeapon : (aiWeapon || selectedWeapon);
       setBurning((b) => [...new Set([...b, ...victims])]);
       const settleCapture = () => {
         if (!muted) {
@@ -3212,6 +3212,14 @@ export default function SnakeAndLadder() {
 
   const playerHeadPreset = resolvedAppearance?.pawnHead?.preset ?? null;
   const playerHeadPresetId = resolvedAppearance?.pawnHead?.id ?? 'current';
+  const aiWeaponLoadout = useMemo(
+    () =>
+      Array.from({ length: ai }, () => {
+        const random = CAPTURE_WEAPON_OPTIONS[Math.floor(Math.random() * CAPTURE_WEAPON_OPTIONS.length)];
+        return random?.id || CAPTURE_WEAPON_OPTIONS[0].id;
+      }),
+    [ai]
+  );
 
   const players = isMultiplayer
     ? mpPlayers.map((p, i) => ({
@@ -3220,7 +3228,8 @@ export default function SnakeAndLadder() {
         photoUrl: p.photoUrl || '/assets/icons/profile.svg',
         type: 'normal',
         color: playerColors[i] || '#fff',
-        seatIndex: seatAssignments.get(i)
+        seatIndex: seatAssignments.get(i),
+        weaponType: CAPTURE_WEAPON_OPTIONS[i % CAPTURE_WEAPON_OPTIONS.length]?.id || CAPTURE_WEAPON_OPTIONS[0].id
       }))
     : [
         {
@@ -3229,6 +3238,7 @@ export default function SnakeAndLadder() {
           type: tokenType,
           color: playerColors[0],
           seatIndex: 0,
+          weaponType: resolvedAppearance?.captureWeapon?.id || CAPTURE_WEAPON_OPTIONS[0].id,
           tokenShape: resolvedAppearance?.tokenShape,
           headPreset: playerHeadPreset,
           headPresetId: playerHeadPresetId
@@ -3239,6 +3249,7 @@ export default function SnakeAndLadder() {
           type: 'normal',
           color: playerColors[i + 1],
           seatIndex: i + 1,
+          weaponType: aiWeaponLoadout[i] || CAPTURE_WEAPON_OPTIONS[0].id,
           tokenShape: aiTokenShapes[i] || TOKEN_SHAPE_OPTIONS[i % TOKEN_SHAPE_OPTIONS.length],
           headPreset: null,
           headPresetId: 'current'


### PR DESCRIPTION
### Motivation
- Add per-seat weapon visuals for capture effects and let capture animations launch from parked displays to improve visual clarity.
- Relax the bottom-seat camera lock and refine camera/dice timing to produce snappier, more consistent camera cues during rolls and captures.
- Tweak token/rest positions, table height and other scale constants to improve alignment of tokens and UI elements.

### Description
- Introduces a `weaponDisplayGroup` on the board and three helpers: `cloneCaptureDisplayVehicle`, `createSeatWeaponMesh`, and `updateSeatWeaponDisplays`, and hooks `updateSeatWeaponDisplays` into the token update flow to render per-player weapon markers.  
- Capture animations now use the parked weapon position (if available) as the launch base and keep the camera position stable during capture focus; missile launch origin logic was updated accordingly.  
- Removes the `LOCK_BOTTOM_SEAT_CAMERA` early-return behavior from camera focus compute functions to allow turn/dice/capture camera cues for all seats.  
- Adjusts multiple tuning constants including `TABLE_HEIGHT_LIFT`, `DICE_ROLL_DURATION`, `DICE_SETTLE_DURATION`, `DICE_CAMERA_LOOK_*`, `TOKEN_REST_*` values and a token vertical offset change to improve pacing and layout.  
- Adds `drone` to capture weapon options, reorders capture weapon lists, makes `drone` the default unlocked capture weapon, adds a `capture-fighter` store item, and wires AI players to receive randomized `aiWeaponLoadout` which is used in `capturePieces`; player objects now carry a `weaponType`.  
- Minor camera and animation flow updates remove some automatic board rotations and preserve camera state during token follow and capture transitions.

### Testing
- Ran the test suite with `yarn test` which completed successfully.  
- Verified a production build with `yarn build` which completed without errors.  
- Ran the linter via `yarn lint` with no new linting errors introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddd716093c8329ae9de4661844c14d)