### PR TITLE
Adjust Chess Battle Royal side vehicles and lower profile table shapes

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -1971,6 +1971,16 @@ const BOARD_SURFACE_OFFSETS_BY_SHAPE = Object.freeze({
   grandOval: -0.065,
   diamondEdge: -0.065
 });
+const LOWER_PROFILE_TABLE_SHAPE_IDS = new Set(['classicOctagon', 'hexagonTable', 'grandOval', 'diamondEdge']);
+const LOWER_PROFILE_TABLE_HEIGHT_DELTA = 0.12;
+const SIDE_PARKED_AIRCRAFT_SCALE_MULTIPLIER = 4;
+
+function getTableHeightForShape(shapeId) {
+  if (LOWER_PROFILE_TABLE_SHAPE_IDS.has(shapeId)) {
+    return TABLE_HEIGHT - LOWER_PROFILE_TABLE_HEIGHT_DELTA;
+  }
+  return TABLE_HEIGHT;
+}
 
 function normalizeAppearance(value = {}) {
   const normalized = { ...DEFAULT_APPEARANCE };
@@ -7865,6 +7875,7 @@ function Chess3D({
     const chairOption = CHAIR_COLOR_OPTIONS[normalized.chairColor] ?? CHAIR_COLOR_OPTIONS[0];
     const tableTheme = TABLE_THEME_OPTIONS[normalized.tables] ?? TABLE_THEME_OPTIONS[0];
     const { option: shapeOption, rotationY } = getEffectiveShapeConfigForTableTheme(tableTheme);
+    const shapeTableHeight = getTableHeightForShape(shapeOption?.id);
     const boardTheme = palette.board ?? BEAUTIFUL_GAME_THEME;
     const pieceStyleOption = palette.pieces ?? DEFAULT_PIECE_STYLE;
     const headPreset = palette.head ?? HEAD_PRESET_OPTIONS[0].preset;
@@ -7885,7 +7896,7 @@ function Chess3D({
           arena: arena.arenaGroup,
           renderer: arena.renderer,
           tableRadius: TABLE_RADIUS,
-          tableHeight: TABLE_HEIGHT,
+          tableHeight: shapeTableHeight,
           woodOption,
           clothOption,
           baseOption,
@@ -8185,6 +8196,7 @@ function Chess3D({
       const chairOption = CHAIR_COLOR_OPTIONS[normalizedAppearance.chairColor] ?? CHAIR_COLOR_OPTIONS[0];
       const tableTheme = TABLE_THEME_OPTIONS[normalizedAppearance.tables] ?? TABLE_THEME_OPTIONS[0];
       const { option: shapeOption, rotationY } = getEffectiveShapeConfigForTableTheme(tableTheme);
+      const shapeTableHeight = getTableHeightForShape(shapeOption?.id);
       const pieceMaterials = createPieceMaterials(pieceStyleOption);
       disposers.push(() => {
         disposePieceMaterials(pieceMaterials);
@@ -8437,7 +8449,7 @@ function Chess3D({
       arena,
       renderer,
       tableRadius: TABLE_RADIUS,
-      tableHeight: TABLE_HEIGHT,
+      tableHeight: shapeTableHeight,
       woodOption,
       clothOption,
       baseOption,
@@ -9289,6 +9301,7 @@ function Chess3D({
       const sideX = isWhiteSide ? -(half + BOARD.rim + tile * 0.98) : half + BOARD.rim + tile * 0.98;
       const laneMap = {
         jet: tile * 1.48,
+        drone: tile * 0.74,
         helicopter: 0,
         truck: -tile * 1.48
       };
@@ -9968,9 +9981,11 @@ function Chess3D({
       airPadGroup.add(marker);
     };
     addAirPadMarker(getAirPadAnchor(true, 'jet'), 'J');
+    addAirPadMarker(getAirPadAnchor(true, 'drone'), 'D');
     addAirPadMarker(getAirPadAnchor(true, 'helicopter'), 'H');
     addAirPadMarker(getAirPadAnchor(true, 'truck'), 'T');
     addAirPadMarker(getAirPadAnchor(false, 'jet'), 'J');
+    addAirPadMarker(getAirPadAnchor(false, 'drone'), 'D');
     addAirPadMarker(getAirPadAnchor(false, 'helicopter'), 'H');
     addAirPadMarker(getAirPadAnchor(false, 'truck'), 'T');
 
@@ -10323,9 +10338,9 @@ function Chess3D({
       ];
       sides.forEach(({ isWhite, badge }) => {
         const skin = resolveSideVehicleSkin(isWhite);
-        for (let slot = 0; slot < 2; slot += 1) {
+        for (let slot = 0; slot < 1; slot += 1) {
           const jet = createFxJet();
-          jet.root.scale.setScalar(CAPTURE_JET_SCALE * 1.15);
+          jet.root.scale.setScalar(CAPTURE_JET_SCALE * 1.15 * SIDE_PARKED_AIRCRAFT_SCALE_MULTIPLIER);
           if (skin) applyVehicleSkinToModel(jet.root, skin);
           attachVehicleAvatarBadge(jet.root, badge, isWhite ? 1 : -1);
           const jetPad = getAirPadAnchor(isWhite, 'jet', slot);
@@ -10345,7 +10360,9 @@ function Chess3D({
           });
 
           const helicopter = createFxHelicopter();
-          helicopter.root.scale.setScalar(CAPTURE_HELICOPTER_SCALE * 1.15);
+          helicopter.root.scale.setScalar(
+            CAPTURE_HELICOPTER_SCALE * 1.15 * SIDE_PARKED_AIRCRAFT_SCALE_MULTIPLIER
+          );
           if (skin) applyVehicleSkinToModel(helicopter.root, skin, (node) =>
             /rotor|propell|blade|fan|window|cockpit|glass|canopy/.test(`${node.name || ''}`.toLowerCase())
           );
@@ -10366,8 +10383,30 @@ function Chess3D({
             root: helicopter.root
           });
         }
+        const sideDrone = createFxDrone();
+        sideDrone.root.scale.setScalar(CAPTURE_DRONE_SCALE * 1.15 * SIDE_PARKED_AIRCRAFT_SCALE_MULTIPLIER);
+        if (skin) applyVehicleSkinToModel(sideDrone.root, skin);
+        attachVehicleAvatarBadge(sideDrone.root, badge, isWhite ? 1 : -1);
+        const dronePad = getAirPadAnchor(isWhite, 'drone', 0);
+        sideDrone.root.position.copy(dronePad);
+        sideDrone.root.rotation.y = isWhite ? -Math.PI * 0.13 : Math.PI * 1.13;
+        const droneHomeRotation = sideDrone.root.rotation.clone();
+        airPadGroup.add(sideDrone.root);
+        parkedAirUnits.push({
+          kind: 'drone',
+          isWhite,
+          slot: 0,
+          busy: false,
+          homePosition: dronePad.clone(),
+          homeRotation: droneHomeRotation,
+          ...sideDrone,
+          root: sideDrone.root
+        });
+
         const supportTruck = createFxSupportTruck();
-        supportTruck.root.scale.setScalar(CAPTURE_HELICOPTER_SCALE * 1.15);
+        supportTruck.root.scale.setScalar(
+          CAPTURE_HELICOPTER_SCALE * 1.15 * SIDE_PARKED_AIRCRAFT_SCALE_MULTIPLIER
+        );
         if (skin) {
           applyVehicleSkinToModel(
             supportTruck.root,


### PR DESCRIPTION
### Motivation
- Improve visual clarity and balance on portrait/mobile screens by enlarging side vehicles and adding missing drone units.
- Reduce clutter by ensuring each side displays one jet and one helicopter instead of duplicates.
- Make specific procedural table shapes match a lower profile so the board, pieces and flight paths sit visually closer to the Gothic coffee table height.

### Description
- Scaled parked side vehicles (jet, helicopter, support truck) by a multiplier via `SIDE_PARKED_AIRCRAFT_SCALE_MULTIPLIER = 4` and reduced parked aircraft slots to one per side in `webapp/src/pages/Games/ChessBattleRoyal.jsx`.
- Added a parked `drone` per side, created a `drone` lane in the air-pad anchor map and added `D` pad markers so drone placement is visible and consistent with other side pads.
- Introduced shape-specific table height adjustment with `getTableHeightForShape` and `LOWER_PROFILE_TABLE_SHAPE_IDS` (affecting `classicOctagon`, `hexagonTable`, `grandOval`, `diamondEdge`) and applied this `shapeTableHeight` to both initial `buildTableFromTheme` and live table rebuild flows so board/pieces/vehicle anchors align to the new surface height.
- All changes are implemented in `webapp/src/pages/Games/ChessBattleRoyal.jsx` and use the existing `createFxJet`, `createFxHelicopter`, `createFxDrone`, `createFxSupportTruck` and `getAirPadAnchor` helpers to retain skins/behaviour.

### Testing
- Ran the unit tests for chess table inventory with `npm test -- --runTestsByPath test/chessBattleInventoryConfig.test.js` and they passed: `PASS test/chessBattleInventoryConfig.test.js` (3 tests).
- No other automated tests were modified or added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dded24f1a88329a739fcb62fef090d)