### PR TITLE
Tune Chess Battle Royal 3D layout for board visibility and side vehicle placement

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -1966,14 +1966,18 @@ const CUSTOMIZATION_SECTIONS = [
 
 const SHAPE_CUSTOMIZATION_TABLE_IDS = new Set(['hexagonTable', 'murlan-default', 'grandOval']);
 const BOARD_SURFACE_OFFSETS_BY_SHAPE = Object.freeze({
-  classicOctagon: -0.065,
-  hexagonTable: -0.065,
-  grandOval: -0.065,
-  diamondEdge: -0.065
+  classicOctagon: -0.155,
+  hexagonTable: -0.155,
+  grandOval: -0.155,
+  diamondEdge: -0.155
 });
 const LOWER_PROFILE_TABLE_SHAPE_IDS = new Set(['classicOctagon', 'hexagonTable', 'grandOval', 'diamondEdge']);
 const LOWER_PROFILE_TABLE_HEIGHT_DELTA = 0.12;
-const SIDE_PARKED_AIRCRAFT_SCALE_MULTIPLIER = 4;
+const SIDE_PARKED_AIRCRAFT_SCALE_MULTIPLIER = 5;
+const SIDE_AIRPAD_INWARD_TILES = 0.34;
+const SIDE_AIRPAD_SLOT_SPREAD_TILES = 0.18;
+const SIDE_AIRPAD_ALTITUDE_OFFSET = 0.34;
+const SIDE_AIRPAD_TRUCK_ALTITUDE_OFFSET = 0.26;
 
 function getTableHeightForShape(shapeId) {
   if (LOWER_PROFILE_TABLE_SHAPE_IDS.has(shapeId)) {
@@ -8628,7 +8632,7 @@ function Chess3D({
     camera = new THREE.PerspectiveCamera(CAM.fov, 1, CAM.near, CAM.far);
     const isPortrait = host.clientHeight > host.clientWidth;
     const cameraSeatAngle = Math.PI / 2;
-    const cameraBackOffset = (isPortrait ? 2.55 : 1.78) + 0.35;
+    const cameraBackOffset = (isPortrait ? 2.42 : 1.68) + 0.28;
     const cameraForwardOffset = isPortrait ? 0.08 : 0.2;
     const cameraHeightOffset = isPortrait ? 1.72 : 1.34;
     const cameraRadius = chairDistance + cameraBackOffset - cameraForwardOffset;
@@ -9298,7 +9302,8 @@ function Chess3D({
       return { root };
     };
     const getAirPadAnchor = (isWhiteSide, kind = 'jet', slot = 0) => {
-      const sideX = isWhiteSide ? -(half + BOARD.rim + tile * 0.98) : half + BOARD.rim + tile * 0.98;
+      const edgeX = half - tile * SIDE_AIRPAD_INWARD_TILES;
+      const sideX = isWhiteSide ? -edgeX : edgeX;
       const laneMap = {
         jet: tile * 1.48,
         drone: tile * 0.74,
@@ -9306,9 +9311,12 @@ function Chess3D({
         truck: -tile * 1.48
       };
       const laneBase = laneMap[kind] ?? laneMap.helicopter;
-      const laneShift = slot === 0 ? -tile * 0.22 : tile * 0.22;
+      const laneShift = slot === 0 ? -tile * SIDE_AIRPAD_SLOT_SPREAD_TILES : tile * SIDE_AIRPAD_SLOT_SPREAD_TILES;
       const zOffset = laneBase + laneShift;
-      const yOffset = kind === 'truck' ? currentPieceYOffset + 0.14 : currentPieceYOffset + 0.26;
+      const yOffset =
+        kind === 'truck'
+          ? currentPieceYOffset + SIDE_AIRPAD_TRUCK_ALTITUDE_OFFSET
+          : currentPieceYOffset + SIDE_AIRPAD_ALTITUDE_OFFSET;
       return new THREE.Vector3(sideX, yOffset, zOffset);
     };
     const acquireParkedAirUnit = (isWhiteSide, kind) => {
@@ -12550,12 +12558,18 @@ function Chess3D({
                 };
             const depth = anchor?.depth ?? 3;
             const avatarSize = anchor ? clamp(1.32 - (depth - 2.6) * 0.22, 0.86, 1.2) : 1;
+            const avatarInteractive = !configOpen && viewMode !== '3d';
+            const isTopSeat = player.index === 1;
+            const avatarVisualStyle =
+              viewMode === '3d' && isTopSeat
+                ? { opacity: 0.62, transform: `${positionStyle.transform} translateY(-12%)` }
+                : null;
             return (
               <div
                 key={`chess-seat-${player.index}`}
-                className="absolute pointer-events-auto flex flex-col items-center"
+                className={`absolute flex flex-col items-center ${avatarInteractive ? 'pointer-events-auto' : 'pointer-events-none'}`}
                 data-player-index={player.index}
-                style={positionStyle}
+                style={avatarVisualStyle ? { ...positionStyle, ...avatarVisualStyle } : positionStyle}
               >
                 <AvatarTimer
                   index={player.index}


### PR DESCRIPTION
### Motivation
- Improve visual clarity in 3D portrait play by bringing side vehicles and their pads onto the board edge, lowering the board for certain table shapes so it sits on the cloth, and reduce avatar/UI interference. 
- Make side vehicle scaling/placement tunable with explicit constants so future adjustments are easier.

### Description
- Adjusted lower-profile table offset values in `BOARD_SURFACE_OFFSETS_BY_SHAPE` (octagon/hexagon/oval/diamond) to lower the board relative to the table cloth (`webapp/src/pages/Games/ChessBattleRoyal.jsx`).
- Increased parked side-vehicle scale from `SIDE_PARKED_AIRCRAFT_SCALE_MULTIPLIER = 4` to `5` and added new tuning constants `SIDE_AIRPAD_INWARD_TILES`, `SIDE_AIRPAD_SLOT_SPREAD_TILES`, `SIDE_AIRPAD_ALTITUDE_OFFSET`, and `SIDE_AIRPAD_TRUCK_ALTITUDE_OFFSET` to control pad inward offset, slot spread and heights.
- Moved air-pad anchors inward and raised pad Y offsets by updating `getAirPadAnchor` to use the new constants so parked `jet`, `helicopter`, `drone` and `truck` sit closer/on the board edge.
- Pulled the 3D gameplay camera slightly closer by reducing `cameraBackOffset`, and reduced avatar interference by disabling avatar pointer events while the menu is open or in 3D and softening the top-seat avatar visual when in 3D.

### Testing
- Ran a production build with `npm -C webapp run build`, which completed successfully and produced the app bundle; Vite emitted non-blocking chunk size/dynamic-import warnings but the build passed.
- No automated unit tests were added or modified in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddf80e2a8483298ae4bb39a80535ad)