### PR TITLE
Fix Pool Royale cue stick and power slider synchronization

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1912,6 +1912,7 @@ const STRIKE_TIME = 120;
 const HOLD_TIME = 50;
 const IDLE_GAP = 0;
 const CONTACT_GAP = CUE_TIP_GAP;
+const SLIDER_MIN_SHOT_POWER = 0.02;
 const CUE_PULL_VISUAL_FUDGE = BALL_R * 2.5; // allow extra travel before obstructions cancel the pull
 const CUE_PULL_VISUAL_MULTIPLIER = 1.28;
 const CUE_PULL_DISTANCE_SCALE = 0.5;
@@ -26178,7 +26179,7 @@ const powerRef = useRef(hud.power);
             : powerRef.current;
         const clampedPower = clampPower(resolvedPower, 0);
         shotPowerRef.current = clampedPower;
-        shotStateRef.current = clampedPower > 0.02 ? 'striking' : 'idle';
+        shotStateRef.current = clampedPower > SLIDER_MIN_SHOT_POWER ? 'striking' : 'idle';
         const strokeStyle = cueStrokeAnimationStyleRef.current ?? DEFAULT_CUE_STROKE_STYLE;
         const strokeProfile = resolveCueStrokeProfile(strokeStyle, clampedPower);
         const rawSpin = applySpinConstraints(aimDir, true);
@@ -32493,6 +32494,7 @@ const powerRef = useRef(hud.power);
       labels: true,
       onChange: (v) => {
         const normalizedPower = clampPower(v / 100, 0);
+        sliderShotPowerRef.current = normalizedPower;
         shotDragPowerRef.current = normalizedPower;
         if (shotStateRef.current === 'dragging') {
           shotPowerRef.current = normalizedPower;
@@ -32505,21 +32507,25 @@ const powerRef = useRef(hud.power);
           sliderResetRafRef.current = 0;
         }
         shotStateRef.current = 'dragging';
-        shotDragPowerRef.current = clampPower(powerRef.current, 0);
+        shotDragPowerRef.current = clampPower(slider.get() / 100, 0);
         shotPowerRef.current = shotDragPowerRef.current;
-        sliderShotPowerRef.current = clampPower(powerRef.current, 0);
+        sliderShotPowerRef.current = shotDragPowerRef.current;
         captureCueStickAnchor();
       },
       onCommit: (sliderValue) => {
         const releasePower = clampPower(
-          Number.isFinite(sliderValue) ? sliderValue / 100 : sliderShotPowerRef.current,
-          powerRef.current
+          shotStateRef.current === 'dragging'
+            ? shotDragPowerRef.current
+            : Number.isFinite(sliderValue)
+              ? sliderValue / 100
+              : sliderShotPowerRef.current,
+          0
         );
         shotPowerRef.current = releasePower;
-        shotDragPowerRef.current = releasePower;
+        shotDragPowerRef.current = 0;
         sliderShotPowerRef.current = releasePower;
-        shotStateRef.current = releasePower > 0.02 ? 'striking' : 'idle';
-        if (releasePower > 0.02) {
+        shotStateRef.current = releasePower > SLIDER_MIN_SHOT_POWER ? 'striking' : 'idle';
+        if (releasePower > SLIDER_MIN_SHOT_POWER) {
           fireRef.current?.(releasePower);
         }
         const resetStart = performance.now();
@@ -32531,12 +32537,14 @@ const powerRef = useRef(hud.power);
           const t = THREE.MathUtils.clamp(elapsed / resetDurationMs, 0, 1);
           const nextValue = THREE.MathUtils.lerp(fromValue, slider.min, easeOut(t));
           slider.set(nextValue, { animate: false });
+          applyPower(clampPower(nextValue / 100, 0));
           if (t < 1) {
             sliderResetRafRef.current = requestAnimationFrame(tickReset);
             return;
           }
           sliderResetRafRef.current = 0;
           slider.set(slider.min, { animate: false });
+          applyPower(0);
         };
         if (sliderResetRafRef.current) {
           cancelAnimationFrame(sliderResetRafRef.current);


### PR DESCRIPTION
### Motivation

- The cue, slider and shot flow were occasionally desynced: live slider state was used at strike instead of a captured release value, pointer drag/release flow could leave the cue and HUD out of sync, and the cue pull/strike timing needed to match the reference implementation.

### Description

- Added a single `SLIDER_MIN_SHOT_POWER` constant and switched idle/striking threshold checks to use it to keep transitions consistent.
- Introduced and used `sliderShotPowerRef` and preserved a captured `shotDragPowerRef` on drag start so release uses the captured power (not a live HUD value); on release the captured power is moved into `shotPowerRef` and the shot state transitions to `striking` only if above the threshold.
- Updated slider handlers (`onChange`, `onStart`, `onCommit`) to: seed drag power from the actual slider value, `captureCueStickAnchor()` on start, preserve the shot power on commit and call `fireRef.current` exactly once when appropriate, and animate the slider UI back to zero while explicitly updating HUD power during the reset.
- Kept all changes local to the existing shot architecture and refs so cue pullback/strike timing, easing, and impact application remain compatible with the existing cue stroke animation logic.

### Testing

- Ran the focused timeline unit tests with `npm test -- poolRoyaleCueStrokeTimeline.test.js --runInBand`, and the suite passed (4 tests, all green).
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx`; linter reported a repository ignore warning only (no new lint errors related to the changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddf18c7a2083299a2a130fa47ec331)