### PR TITLE
Fix Pool Royale cue shot power capture/sync on slider release

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -26174,7 +26174,7 @@ const powerRef = useRef(hud.power);
         }
         const resolvedPower = Number.isFinite(powerOverride)
           ? powerOverride
-          : shotPowerRef.current > 0
+          : shotStateRef.current === 'striking' || shotStateRef.current === 'dragging'
             ? shotPowerRef.current
             : powerRef.current;
         const clampedPower = clampPower(resolvedPower, 0);
@@ -32521,15 +32521,9 @@ const powerRef = useRef(hud.power);
         sliderShotPowerRef.current = clampPower(powerRef.current, 0);
         captureCueStickAnchor();
       },
-      onCommit: (sliderValue) => {
+      onCommit: () => {
         const capturedShotPower = clampPower(shotDragPowerRef.current, 0);
-        const releasePower = clampPower(
-          Number.isFinite(sliderValue) ? sliderValue / 100 : capturedShotPower,
-          powerRef.current
-        );
-        const finalShotPower = Number.isFinite(sliderValue)
-          ? releasePower
-          : capturedShotPower;
+        const finalShotPower = capturedShotPower;
         shotPowerRef.current = finalShotPower;
         shotDragPowerRef.current = finalShotPower;
         sliderShotPowerRef.current = finalShotPower;


### PR DESCRIPTION
### Motivation
- Slider release could desync cue animation and physics because the release path recomputed power from the live slider instead of using the captured drag power, causing stale refs / race when the UI animated back to zero. 
- The change aligns the shot power source with the reference technique so the cue pull, strike timing, and applied impulse come from a preserved captured value (`shotPowerRef`).

### Description
- Resolve shot power selection to prefer `shotPowerRef` while `shotStateRef.current` is `'dragging'` or `'striking'`, falling back to `powerRef` otherwise, by changing the `resolvedPower` computation used when firing. 
- Simplify slider `onCommit` to capture the in-drag power (`shotDragPowerRef`) as the canonical `finalShotPower`, set `shotPowerRef`/`shotDragPowerRef`/`sliderShotPowerRef` accordingly, transition `shotStateRef` to `'striking'` when appropriate, and call the existing `fireRef.current` with the captured value. 
- Keep the slider UI reset animation (animated return-to-zero) intact while ensuring the strike uses the preserved captured power so visual UI motion no longer races the physics impulse.
- Changes made only to `webapp/src/pages/Games/PoolRoyale.jsx` to preserve surrounding architecture and reuse existing stroke/animation logic (`PULL_RANGE`, `STRIKE_TIME`, `HOLD_TIME`, easing helpers, cue stroke state, etc.).

### Testing
- Ran focused Jest suites with: `npm test -- --runInBand test/cueShotImpact.test.js test/poolRoyaleCueStrokeTimeline.test.js`, both suites passed.
- Test results: `PASS test/poolRoyaleCueStrokeTimeline.test.js` and `PASS test/cueShotImpact.test.js` (2 suites, 7 tests total).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddfd33cd288329989f9ff8374293c0)