### PR TITLE
Adjust Snake & Ladder portrait camera framing

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -292,9 +292,9 @@ const INITIAL_CAMERA_DISTANCE_FACTOR = 0.56;
 const POINTER_TAP_MAX_DISTANCE = 14;
 const POINTER_TAP_MAX_DURATION_MS = 420;
 const PORTRAIT_CAMERA_TUNING = Object.freeze({
-  backOffset: 1.16,
+  backOffset: 1.24,
   forwardOffset: 0,
-  heightOffset: 2.88,
+  heightOffset: 2.98,
   targetLift: 0.074 * MODEL_SCALE
 });
 const LANDSCAPE_CAMERA_TUNING = Object.freeze({


### PR DESCRIPTION
### Motivation
- Nudge the portrait camera slightly upward and outward so the board appears a bit higher on the screen and slightly farther from the table in mobile/portrait play.

### Description
- Increased `PORTRAIT_CAMERA_TUNING.backOffset` from `1.16` to `1.24` and `PORTRAIT_CAMERA_TUNING.heightOffset` from `2.88` to `2.98` in `webapp/src/components/SnakeBoard3D.jsx`.

### Testing
- Ran `npx eslint --no-ignore webapp/src/components/SnakeBoard3D.jsx`, which finished with a file-ignore warning from repo lint config and reported no lint errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de1b972ea08329a18d1c88e57ed300)