### PR TITLE
Scale and reposition parked side vehicles for Chess Battle Royal

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -1973,7 +1973,9 @@ const BOARD_SURFACE_OFFSETS_BY_SHAPE = Object.freeze({
 });
 const LOWER_PROFILE_TABLE_SHAPE_IDS = new Set(['classicOctagon', 'hexagonTable', 'grandOval', 'diamondEdge']);
 const LOWER_PROFILE_TABLE_HEIGHT_DELTA = 0.12;
-const SIDE_PARKED_AIRCRAFT_SCALE_MULTIPLIER = 5;
+const SIDE_PARKED_AIRCRAFT_SCALE_MULTIPLIER = 25;
+const SIDE_PARKED_AIR_UNITS_INWARD_OFFSET = 0.34;
+const SIDE_PARKED_AIR_UNITS_BOARD_LEVEL_LIFT = 0.18;
 
 function getTableHeightForShape(shapeId) {
   if (LOWER_PROFILE_TABLE_SHAPE_IDS.has(shapeId)) {
@@ -9298,7 +9300,8 @@ function Chess3D({
       return { root };
     };
     const getAirPadAnchor = (isWhiteSide, kind = 'jet', slot = 0) => {
-      const sideX = isWhiteSide ? -(half + BOARD.rim + tile * 0.28) : half + BOARD.rim + tile * 0.28;
+      const sideX =
+        (isWhiteSide ? -1 : 1) * (half - tile * SIDE_PARKED_AIR_UNITS_INWARD_OFFSET);
       const laneMap = {
         jet: tile * 1.48,
         drone: tile * 0.74,
@@ -9308,7 +9311,10 @@ function Chess3D({
       const laneBase = laneMap[kind] ?? laneMap.helicopter;
       const laneShift = slot === 0 ? -tile * 0.22 : tile * 0.22;
       const zOffset = laneBase + laneShift;
-      const yOffset = kind === 'truck' ? currentPieceYOffset + 0.02 : currentPieceYOffset + 0.04;
+      const yOffset =
+        currentPieceYOffset +
+        SIDE_PARKED_AIR_UNITS_BOARD_LEVEL_LIFT +
+        (kind === 'truck' ? 0.02 : 0.04);
       return new THREE.Vector3(sideX, yOffset, zOffset);
     };
     const acquireParkedAirUnit = (isWhiteSide, kind) => {


### PR DESCRIPTION
### Motivation

- Bring the side parked vehicles (helicopter, jet, drone, truck) visually onto the board by making them larger, raising their parking height to board level, and pulling them inward so they sit on the board rather than outside the rim.

### Description

- Increased the parked-side vehicle scale multiplier by changing `SIDE_PARKED_AIRCRAFT_SCALE_MULTIPLIER` from `5` to `25` to achieve the requested ~5x visual size increase for parked helicopter/jet/drone/truck. (modified `webapp/src/pages/Games/ChessBattleRoyal.jsx`).
- Added `SIDE_PARKED_AIR_UNITS_INWARD_OFFSET` and `SIDE_PARKED_AIR_UNITS_BOARD_LEVEL_LIFT` constants and applied them to the anchor calculation so side units are pulled inward toward the board and lifted to sit at board level. (modified `getAirPadAnchor` in `webapp/src/pages/Games/ChessBattleRoyal.jsx`).
- Preserved a small truck-specific lower bias by keeping a slightly different per-kind Y offset for the truck anchor. (see updated `yOffset` logic in `getAirPadAnchor`).

### Testing

- Ran `npm run lint -- webapp/src/pages/Games/ChessBattleRoyal.jsx`, which reported repository-wide lint failures in unrelated generated/dist files and that the target file is ignored by the current eslint patterns, so the run did not produce a clean pass for the repo. 
- No other automated unit or visual tests were run in this change; manual visual verification is recommended in a local dev server to confirm the vehicles render at the expected size/position.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de1c611ea4832998dea52f0d7a9d7c)