### PR TITLE
Adjust Snake & Ladder 3D camera framing and seat reserve positions

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -227,16 +227,16 @@ const TOKEN_MULTI_OCCUPANT_RADIUS = TILE_SIZE * 0.24 * TOKEN_RADIUS_SCALE * TOKE
 const DICE_PLAYER_EXTRA_OFFSET = TILE_SIZE * 1.8;
 const TOP_TILE_EXTRA_LEVELS = 1;
 const TOKEN_REST_RAIL_INSET_BY_SEAT = Object.freeze([
-  TILE_SIZE * 1.24,
-  TILE_SIZE * 1.2,
-  TILE_SIZE * 0.48,
-  TILE_SIZE * 0.62
+  TILE_SIZE * 1.34,
+  TILE_SIZE * 1.28,
+  TILE_SIZE * 0.4,
+  TILE_SIZE * 0.72
 ]);
 const WEAPON_REST_RAIL_INSET_BY_SEAT = Object.freeze([
-  TILE_SIZE * 1.32,
-  TILE_SIZE * 1.26,
-  TILE_SIZE * 0.54,
-  TILE_SIZE * 0.88
+  TILE_SIZE * 1.42,
+  TILE_SIZE * 1.34,
+  TILE_SIZE * 0.46,
+  TILE_SIZE * 0.96
 ]);
 const TOKEN_REST_MIN_RADIUS = BOARD_RADIUS + TILE_SIZE * 2.08;
 const TOKEN_REST_LATERAL_BY_SEAT = Object.freeze([
@@ -292,10 +292,10 @@ const INITIAL_CAMERA_DISTANCE_FACTOR = 0.56;
 const POINTER_TAP_MAX_DISTANCE = 14;
 const POINTER_TAP_MAX_DURATION_MS = 420;
 const PORTRAIT_CAMERA_TUNING = Object.freeze({
-  backOffset: 1.24,
+  backOffset: 1.46,
   forwardOffset: 0,
-  heightOffset: 2.98,
-  targetLift: 0.074 * MODEL_SCALE
+  heightOffset: 3.16,
+  targetLift: 0.062 * MODEL_SCALE
 });
 const LANDSCAPE_CAMERA_TUNING = Object.freeze({
   backOffset: 0.6,


### PR DESCRIPTION
### Motivation
- Improve the Snake & Ladder 3D view so the camera sits farther back, a bit higher and looks slightly more down to give a clearer view of the table in portrait mobile layout.
- Pull the bottom/left/right player tokens (and their weapon displays) closer to the table edge while nudging the top player’s token/weapon slightly outward to better match on-screen composition in portrait.

### Description
- Tuning of portrait camera parameters in `webapp/src/components/SnakeBoard3D.jsx` by updating `PORTRAIT_CAMERA_TUNING` (`backOffset`, `heightOffset`, and `targetLift`) so the camera is farther back, slightly higher, and aims a bit lower on screen.
- Adjusted `TOKEN_REST_RAIL_INSET_BY_SEAT` per-seat values to move reserve tokens inward for bottom/left/right seats and outward for the top seat.
- Mirrored the same positional tuning in `WEAPON_REST_RAIL_INSET_BY_SEAT` so weapon displays/animations remain visually aligned with tokens.
- The single modified file is `webapp/src/components/SnakeBoard3D.jsx` and changes are limited to numeric tuning constants (no behavioral refactors).

### Testing
- Ran the production build with `cd webapp && npm run -s build`, which completed successfully (build finished in ~35s) with only standard bundle-size/warning messages.
- No automated unit tests were modified or executed as part of this change; build validation is green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de1fabc2548329b55dcdb957656839)