### PR TITLE
Tune Chess Battle Royal flight paths and truck launcher orientation

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -93,13 +93,13 @@ const LUDO_CAPTURE_MISSILE_TRAVEL_TIME = 2.52;
 const LUDO_CAPTURE_EXPLOSION_TIME = 2.6;
 const LUDO_CAPTURE_TOTAL_TIME = LUDO_CAPTURE_MISSILE_TRAVEL_TIME + LUDO_CAPTURE_EXPLOSION_TIME;
 const CAPTURE_DRONE_LIFT_TIME = 0.144;
-const CAPTURE_DRONE_CRUISE_TIME = 2.24;
-const CAPTURE_DRONE_DIVE_TIME = 0.94;
+const CAPTURE_DRONE_CRUISE_TIME = 2.7;
+const CAPTURE_DRONE_DIVE_TIME = 1.18;
 const CAPTURE_DRONE_TOTAL = CAPTURE_DRONE_LIFT_TIME + CAPTURE_DRONE_CRUISE_TIME + CAPTURE_DRONE_DIVE_TIME;
 const CAPTURE_JET_SPEED_FACTOR = 4.9 / CAPTURE_DRONE_TOTAL; // slower than prior tuning for clearer portrait tracking
 const PROFILE_VIEW_ROTATION_TYPES = new Set(['K', 'N']);
 const PROFILE_VIEW_ROTATION_RADIANS = Math.PI / 2;
-const CAPTURE_JET_TOTAL = CAPTURE_DRONE_TOTAL + 1.85; // longer strike cycle so jet/helicopter read slower in portrait
+const CAPTURE_JET_TOTAL = CAPTURE_DRONE_TOTAL + 2.35; // longer strike cycle so jet/helicopter read slower in portrait
 const CAPTURE_JET_MISSILE_TRAVEL = Math.max(0.28, CAPTURE_JET_TOTAL * (0.96 - 0.56) - 0.1);
 const CAPTURE_HELICOPTER_SPEED_FACTOR = 1; // keep helicopter pacing identical to jet so both share the same visible loop
 const CAPTURE_HELICOPTER_TOTAL = CAPTURE_JET_TOTAL; // helicopter mirrors jet timing for synchronized air-strike pacing
@@ -108,12 +108,12 @@ const CAPTURE_JET_MISSILE_RELEASE_RATIO = 0.62;
 const CAPTURE_JET_MISSILE_ENTRY_RELEASE_RATIO = 0.56; // release while entering the enemy-side U-turn
 const CAPTURE_JET_TRIMMED_START_RATIO = 0; // keep takeoff visible from the live piece location
 const CAPTURE_GROUND_FIRE_TIME = 0;
-const CAPTURE_GROUND_TRAVEL_TIME = 3.8; // slower low-altitude ground strike so launches are easier to read in portrait
+const CAPTURE_GROUND_TRAVEL_TIME = 4.8; // slower low-altitude ground strike so launches are easier to read in portrait
 const CAPTURE_GROUND_TOTAL = CAPTURE_GROUND_FIRE_TIME + CAPTURE_GROUND_TRAVEL_TIME;
 const CAPTURE_DRONE_SCALE = 0.0432; // 20% smaller baseline drone
 const CAPTURE_JET_SCALE = CAPTURE_DRONE_SCALE * 1.12; // trim jet size slightly so it reads cleaner in portrait view
 const CAPTURE_HELICOPTER_SCALE = CAPTURE_DRONE_SCALE * 1.2; // keep helicopter larger than drone while respecting 20% downsize
-const CAPTURE_DRONE_ALTITUDE = 1.05; // keep aircraft lower so they stay visually close to the board
+const CAPTURE_DRONE_ALTITUDE = 0.88; // keep aircraft lower so they stay visually close to the board
 const CAPTURE_FLIGHT_ALTITUDE = CAPTURE_DRONE_ALTITUDE;
 const CAPTURE_DRONE_REFERENCE_BOARD_ALTITUDE = CAPTURE_FLIGHT_ALTITUDE * 0.56; // cruise height the drone visually keeps above board
 const CAPTURE_AIR_STRIKE_BOARD_CLEARANCE = 0; // measure air-strike altitude strictly from board plane
@@ -123,9 +123,9 @@ const CAPTURE_HELICOPTER_ALTITUDE_BOOST = 0; // keep helicopter and jet at the s
 const CAPTURE_AIR_STRIKE_PATH_RADIUS_FACTOR = 0.18; // tighter loops so flight path stays more inward on-screen
 const CAPTURE_AIR_STRIKE_PATH_EDGE_MARGIN_TILES = 2.62; // higher margin keeps turns further away from board edges
 const CAPTURE_AIR_STRIKE_BOTTOM_PLAYER_BIAS_TILES = 0.02; // reduce portrait bottom bias so aircraft stay nearer center
-const CAPTURE_DRONE_ORBIT_RADIUS_MUL = 0.4; // run drone path more inward and closer to board center
-const CAPTURE_DRONE_ORBIT_HEIGHT_MUL = 0.34; // lower drone route to keep it close to board surface
-const CAPTURE_AIR_STRIKE_ORBIT_HEIGHT_MUL = 0.28; // lower jet/helicopter route so aircraft feel closer to board
+const CAPTURE_DRONE_ORBIT_RADIUS_MUL = 0.34; // run drone path more inward and closer to board center
+const CAPTURE_DRONE_ORBIT_HEIGHT_MUL = 0.26; // lower drone route to keep it close to board surface
+const CAPTURE_AIR_STRIKE_ORBIT_HEIGHT_MUL = 0.22; // lower jet/helicopter route so aircraft feel closer to board
 const CAPTURE_DRONE_ORBIT_CYCLES = 0.22; // baseline loop cadence shared by drone/jet/helicopter
 const CAPTURE_DRONE_ORBIT_SPLIT = 0.84;
 const CAPTURE_DRONE_RETURN_SPLIT = 0.72;
@@ -9344,10 +9344,11 @@ function Chess3D({
           tip.castShadow = true;
           missile.add(tip);
           missile.position.set(-Math.max(size.x * 0.12, 0.16), 0.1, lane * Math.max(size.z, 0.84));
-          missile.rotation.z = Math.PI * 0.26;
+          missile.rotation.y = Math.PI; // flip to opposite direction so the rack points outward like the reference truck
+          missile.rotation.z = Math.PI * 0.2;
           rack.add(missile);
         });
-        rack.rotation.z = Math.PI * 0.06;
+        rack.rotation.z = Math.PI * 0.03;
         rack.position.set(center.x - Math.max(size.x * 0.08, 0.14), rackY, center.z);
         target.add(rack);
       };
@@ -9758,7 +9759,7 @@ function Chess3D({
         const isWhiteSide = Boolean(movingMesh?.userData?.w);
         const parkedTruck = acquireParkedSupportUnit(isWhiteSide);
         const launchBase = parkedTruck?.homePosition?.clone?.() || getAirPadAnchor(isWhiteSide, 'truck', 0);
-        missileFx.root.position.copy(launchBase.clone().add(new THREE.Vector3(0, 0.14, 0)));
+        missileFx.root.position.copy(launchBase.clone().add(new THREE.Vector3(0, 0.1, 0)));
         captureFxGroup.add(missileFx.root);
         playAudio(missileLaunchSoundRef);
         activeCaptureFx.push({
@@ -9814,7 +9815,7 @@ function Chess3D({
         const isWhiteSide = Boolean(movingMesh?.userData?.w);
         const parkedTruck = acquireParkedSupportUnit(isWhiteSide);
         const launchBase = parkedTruck?.homePosition?.clone?.() || getAirPadAnchor(isWhiteSide, 'truck', 0);
-        missileFx.root.position.copy(launchBase.clone().add(new THREE.Vector3(0, 0.14, 0)));
+        missileFx.root.position.copy(launchBase.clone().add(new THREE.Vector3(0, 0.1, 0)));
         captureFxGroup.add(missileFx.root);
         playAudio(missileLaunchSoundRef);
         activeCaptureFx.push({
@@ -11989,7 +11990,7 @@ function Chess3D({
             } else if (fx.t < impactTime) {
               const mu = smoothEase((fx.t - CAPTURE_GROUND_FIRE_TIME) / CAPTURE_GROUND_TRAVEL_TIME);
               const control = launchPos.clone().lerp(fx.to, 0.5);
-              control.y += fx.verticalStrike ? 0.62 : fx.directPath ? 0.18 : 0.42;
+              control.y += fx.verticalStrike ? 0.48 : fx.directPath ? 0.12 : 0.3;
               const missilePos = fx.directPath
                 ? launchPos.clone().lerp(fx.to, mu)
                 : qBezier(launchPos, control, fx.to, mu);


### PR DESCRIPTION
### Motivation
- Make capture animations (drone, jet, helicopter, truck-fired missiles) more readable on portrait screens by slowing motion so takeoff and landing are visible.
- Lower and tighten aircraft flight loops so strikes appear closer to the board and are easier to track visually.
- Orient truck roof missiles to match the provided reference and reduce their launch height so long missiles follow a lower-profile trajectory.

### Description
- Increased drone cruise/dive durations by changing `CAPTURE_DRONE_CRUISE_TIME` and `CAPTURE_DRONE_DIVE_TIME` to slow drone motion, and increased `CAPTURE_JET_TOTAL` so jet/helicopter cycles are longer.
- Slowed ground-fired long missile motion by raising `CAPTURE_GROUND_TRAVEL_TIME` to lengthen truck-fired missile travel.
- Lowered flight altitude and tightened orbits by reducing `CAPTURE_DRONE_ALTITUDE`, `CAPTURE_DRONE_ORBIT_RADIUS_MUL`, `CAPTURE_DRONE_ORBIT_HEIGHT_MUL`, and `CAPTURE_AIR_STRIKE_ORBIT_HEIGHT_MUL` so aircraft fly lower and more inward.
- Flipped the truck roof missile models by setting `missile.rotation.y = Math.PI` and reduced the rack tilt (`rack.rotation.z`) so top missiles point the opposite direction and the launcher matches the reference orientation.
- Lowered missile spawn offsets for truck-launched effects (changed missile root position y from `0.14` to `0.1`) and reduced javelin arc control heights (adjusted `control.y` blends) for a lower-impact profile.

### Testing
- Ran the production build with `npm --prefix webapp run build` and the build completed successfully (vite build finished without fatal errors).
- Verified the modified `webapp/src/pages/Games/ChessBattleRoyal.jsx` file compiles as part of the build and the changed symbols referenced during the rollout resolved correctly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de40e8a62883299e8618781ea21701)