### PR TITLE
Adjust Chess Battle Royal airstrike timing, lower flight paths, and flip truck roof launcher

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -92,14 +92,14 @@ const WORLD_UP = new THREE.Vector3(0, 1, 0);
 const LUDO_CAPTURE_MISSILE_TRAVEL_TIME = 2.52;
 const LUDO_CAPTURE_EXPLOSION_TIME = 2.6;
 const LUDO_CAPTURE_TOTAL_TIME = LUDO_CAPTURE_MISSILE_TRAVEL_TIME + LUDO_CAPTURE_EXPLOSION_TIME;
-const CAPTURE_DRONE_LIFT_TIME = 0.144;
-const CAPTURE_DRONE_CRUISE_TIME = 2.24;
-const CAPTURE_DRONE_DIVE_TIME = 0.94;
+const CAPTURE_DRONE_LIFT_TIME = 0.28;
+const CAPTURE_DRONE_CRUISE_TIME = 2.9;
+const CAPTURE_DRONE_DIVE_TIME = 1.18;
 const CAPTURE_DRONE_TOTAL = CAPTURE_DRONE_LIFT_TIME + CAPTURE_DRONE_CRUISE_TIME + CAPTURE_DRONE_DIVE_TIME;
 const CAPTURE_JET_SPEED_FACTOR = 4.9 / CAPTURE_DRONE_TOTAL; // slower than prior tuning for clearer portrait tracking
 const PROFILE_VIEW_ROTATION_TYPES = new Set(['K', 'N']);
 const PROFILE_VIEW_ROTATION_RADIANS = Math.PI / 2;
-const CAPTURE_JET_TOTAL = CAPTURE_DRONE_TOTAL + 1.85; // longer strike cycle so jet/helicopter read slower in portrait
+const CAPTURE_JET_TOTAL = CAPTURE_DRONE_TOTAL + 2.45; // longer strike cycle so jet/helicopter read slower in portrait and show takeoff/landing
 const CAPTURE_JET_MISSILE_TRAVEL = Math.max(0.28, CAPTURE_JET_TOTAL * (0.96 - 0.56) - 0.1);
 const CAPTURE_HELICOPTER_SPEED_FACTOR = 1; // keep helicopter pacing identical to jet so both share the same visible loop
 const CAPTURE_HELICOPTER_TOTAL = CAPTURE_JET_TOTAL; // helicopter mirrors jet timing for synchronized air-strike pacing
@@ -107,15 +107,15 @@ const CAPTURE_HELICOPTER_MISSILE_TRAVEL = Math.max(0.28, CAPTURE_HELICOPTER_TOTA
 const CAPTURE_JET_MISSILE_RELEASE_RATIO = 0.62;
 const CAPTURE_JET_MISSILE_ENTRY_RELEASE_RATIO = 0.56; // release while entering the enemy-side U-turn
 const CAPTURE_JET_TRIMMED_START_RATIO = 0; // keep takeoff visible from the live piece location
-const CAPTURE_GROUND_FIRE_TIME = 0;
-const CAPTURE_GROUND_TRAVEL_TIME = 3.8; // slower low-altitude ground strike so launches are easier to read in portrait
+const CAPTURE_GROUND_FIRE_TIME = 0.42;
+const CAPTURE_GROUND_TRAVEL_TIME = 4.45; // slower low-altitude ground strike so launches are easier to read in portrait
 const CAPTURE_GROUND_TOTAL = CAPTURE_GROUND_FIRE_TIME + CAPTURE_GROUND_TRAVEL_TIME;
 const CAPTURE_DRONE_SCALE = 0.0432; // 20% smaller baseline drone
 const CAPTURE_JET_SCALE = CAPTURE_DRONE_SCALE * 1.12; // trim jet size slightly so it reads cleaner in portrait view
 const CAPTURE_HELICOPTER_SCALE = CAPTURE_DRONE_SCALE * 1.2; // keep helicopter larger than drone while respecting 20% downsize
-const CAPTURE_DRONE_ALTITUDE = 1.05; // keep aircraft lower so they stay visually close to the board
+const CAPTURE_DRONE_ALTITUDE = 0.88; // keep aircraft lower so they stay visually close to the board
 const CAPTURE_FLIGHT_ALTITUDE = CAPTURE_DRONE_ALTITUDE;
-const CAPTURE_DRONE_REFERENCE_BOARD_ALTITUDE = CAPTURE_FLIGHT_ALTITUDE * 0.56; // cruise height the drone visually keeps above board
+const CAPTURE_DRONE_REFERENCE_BOARD_ALTITUDE = CAPTURE_FLIGHT_ALTITUDE * 0.48; // cruise height the drone visually keeps above board
 const CAPTURE_AIR_STRIKE_BOARD_CLEARANCE = 0; // measure air-strike altitude strictly from board plane
 const CAPTURE_AIR_STRIKE_ALTITUDE_MULTIPLIER = 1; // align jet/helicopter flight height with drone altitude
 const CAPTURE_JET_ALTITUDE = CAPTURE_DRONE_REFERENCE_BOARD_ALTITUDE * CAPTURE_AIR_STRIKE_ALTITUDE_MULTIPLIER;
@@ -124,8 +124,8 @@ const CAPTURE_AIR_STRIKE_PATH_RADIUS_FACTOR = 0.18; // tighter loops so flight p
 const CAPTURE_AIR_STRIKE_PATH_EDGE_MARGIN_TILES = 2.62; // higher margin keeps turns further away from board edges
 const CAPTURE_AIR_STRIKE_BOTTOM_PLAYER_BIAS_TILES = 0.02; // reduce portrait bottom bias so aircraft stay nearer center
 const CAPTURE_DRONE_ORBIT_RADIUS_MUL = 0.4; // run drone path more inward and closer to board center
-const CAPTURE_DRONE_ORBIT_HEIGHT_MUL = 0.34; // lower drone route to keep it close to board surface
-const CAPTURE_AIR_STRIKE_ORBIT_HEIGHT_MUL = 0.28; // lower jet/helicopter route so aircraft feel closer to board
+const CAPTURE_DRONE_ORBIT_HEIGHT_MUL = 0.24; // lower drone route to keep it close to board surface
+const CAPTURE_AIR_STRIKE_ORBIT_HEIGHT_MUL = 0.2; // lower jet/helicopter route so aircraft feel closer to board
 const CAPTURE_DRONE_ORBIT_CYCLES = 0.22; // baseline loop cadence shared by drone/jet/helicopter
 const CAPTURE_DRONE_ORBIT_SPLIT = 0.84;
 const CAPTURE_DRONE_RETURN_SPLIT = 0.72;
@@ -134,11 +134,11 @@ const CAPTURE_AIR_MISSILE_RELEASE_END_RATIO = 0.74;
 const CAPTURE_AIR_MISSILE_ARC_SPLIT = 0.84;
 const CAPTURE_AIR_MISSILE_DROP_PORTION = 0.16;
 const CAPTURE_AIR_MISSILE_SIDE_OFFSET = 0.032;
-const CAPTURE_AIR_MISSILE_TOP_HEIGHT_TILE_MUL = 1.5;
-const CAPTURE_AIR_MISSILE_TOP_HEIGHT_MIN = 0.28;
-const CAPTURE_AIR_MISSILE_TOP_BLEND = 0.68;
-const CAPTURE_AIR_MISSILE_TOP_EXTRA_LIFT = 0.06;
-const CAPTURE_AIR_MISSILE_DROP_HEIGHT_MUL = 0.78;
+const CAPTURE_AIR_MISSILE_TOP_HEIGHT_TILE_MUL = 1.16;
+const CAPTURE_AIR_MISSILE_TOP_HEIGHT_MIN = 0.18;
+const CAPTURE_AIR_MISSILE_TOP_BLEND = 0.54;
+const CAPTURE_AIR_MISSILE_TOP_EXTRA_LIFT = 0.03;
+const CAPTURE_AIR_MISSILE_DROP_HEIGHT_MUL = 0.56;
 const CAPTURE_MISSILE_SCALE = 0.068;
 const CAPTURE_JAVELIN_MISSILE_SCALE = CAPTURE_MISSILE_SCALE * 1.48; // make javelin missile bigger
 const CAPTURE_PAWN_JAVELIN_SCALE = CAPTURE_JAVELIN_MISSILE_SCALE * 0.72;
@@ -9344,10 +9344,11 @@ function Chess3D({
           tip.castShadow = true;
           missile.add(tip);
           missile.position.set(-Math.max(size.x * 0.12, 0.16), 0.1, lane * Math.max(size.z, 0.84));
-          missile.rotation.z = Math.PI * 0.26;
+          missile.rotation.z = -Math.PI * 0.26;
           rack.add(missile);
         });
         rack.rotation.z = Math.PI * 0.06;
+        rack.rotation.y = Math.PI; // flip launcher direction so roof missiles point opposite
         rack.position.set(center.x - Math.max(size.x * 0.08, 0.14), rackY, center.z);
         target.add(rack);
       };


### PR DESCRIPTION
### Motivation
- Improve visual clarity of capture FX on portrait/mobile by making drone/jet/helicopter and truck missiles slower and more readable during takeoff/landing. 
- Keep aircraft and missile trajectories lower and closer to the board so launches and impacts are easier to follow on small screens. 
- Match the requested reference for truck roof missile orientation by flipping the launcher direction.

### Description
- Tuned timing for capture flights by changing `CAPTURE_DRONE_LIFT_TIME`, `CAPTURE_DRONE_CRUISE_TIME`, `CAPTURE_DRONE_DIVE_TIME`, and `CAPTURE_JET_TOTAL` to lengthen lift/cruise/dive and jet/helicopter cycles in `webapp/src/pages/Games/ChessBattleRoyal.jsx`.
- Slowed and moved ground strikes by setting `CAPTURE_GROUND_FIRE_TIME` and increasing `CAPTURE_GROUND_TRAVEL_TIME`.
- Lowered flight and orbit heights by adjusting `CAPTURE_DRONE_ALTITUDE`, `CAPTURE_DRONE_REFERENCE_BOARD_ALTITUDE`, `CAPTURE_DRONE_ORBIT_HEIGHT_MUL`, and `CAPTURE_AIR_STRIKE_ORBIT_HEIGHT_MUL` so aircraft fly closer to the board.
- Reduced air-missile arc height and drop behavior by updating missile tuning constants (`CAPTURE_AIR_MISSILE_TOP_HEIGHT_TILE_MUL`, `CAPTURE_AIR_MISSILE_TOP_HEIGHT_MIN`, `CAPTURE_AIR_MISSILE_TOP_BLEND`, `CAPTURE_AIR_MISSILE_TOP_EXTRA_LIFT`, and `CAPTURE_AIR_MISSILE_DROP_HEIGHT_MUL`) and inverted the roof missile tilt sign so missiles visually aim the other way.
- Flipped the support truck roof launcher by adding `rack.rotation.y = Math.PI` where the launcher rack is built, so roof missiles point in the opposite direction.

### Testing
- Ran the production build with `npm -C webapp run build`, which completed successfully (Vite build finished with standard chunking warnings but produced the `dist/` artifacts).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de40e8a62883299e8618781ea21701)