### PR TITLE
Align capture vehicle rotors, drone visuals, cockpit color and jet exhaust mapping in Ludo

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -670,7 +670,7 @@ function applyMilitaryHelicopterLook(root, topRotor = null, tailRotor = null) {
       /rotor|propell|blade|fan/.test(name);
     paintMeshMaterials(node, (mat) => {
       if (/window|cockpit|glass|canopy/.test(name)) {
-        mat.color.setHex(0x0c1016);
+        mat.color.setHex(0x000000);
         if ('metalness' in mat) mat.metalness = 0.38;
         if ('roughness' in mat) mat.roughness = 0.2;
         if ('opacity' in mat) mat.opacity = 0.95;
@@ -705,7 +705,12 @@ function applyMilitaryDroneLook(root, propeller = null) {
   if (!root) return null;
   applyCaptureTextureToOpaqueMeshes(root, 'drone');
   const motor = propeller ?? findDroneMotorMesh(root);
+  const trimNodes = [];
   root.traverse((node) => {
+    if (node?.isObject3D) {
+      const objectName = `${node.name || ''}`.toLowerCase();
+      if (/triangle/.test(objectName)) trimNodes.push(node);
+    }
     if (!node?.isMesh) return;
     const name = `${node.name || ''}`.toLowerCase();
     const isMotor = node === motor || /propell|rotor|blade|fan|motor/.test(name);
@@ -720,6 +725,7 @@ function applyMilitaryDroneLook(root, propeller = null) {
       if ('roughness' in mat) mat.roughness = 0.52;
     });
   });
+  trimNodes.forEach((node) => node.parent?.remove?.(node));
   return motor;
 }
 
@@ -1060,23 +1066,6 @@ async function createCaptureDroneFx() {
   );
   spine.position.set(0.15, 0.03, 0);
   root.add(spine);
-  const finLeft = createFxPolygon(
-    [
-      [-0.28, 0],
-      [0.22, 0],
-      [-0.04, 0.55]
-    ],
-    0.04,
-    '#838b90',
-    0.55,
-    0.24
-  );
-  finLeft.rotation.z = Math.PI / 2;
-  finLeft.position.set(-0.4, 0.35, -0.25);
-  root.add(finLeft);
-  const finRight = finLeft.clone();
-  finRight.position.z = 0.25;
-  root.add(finRight);
   addFxCylinder(root, 0.04, 0.04, 0.64, [0.28, -0.22, -0.55], [Math.PI / 2, 0, 0], '#656e76', 12, 0.54, 0.22);
   addFxCylinder(root, 0.04, 0.04, 0.64, [0.28, -0.22, 0.55], [Math.PI / 2, 0, 0], '#656e76', 12, 0.54, 0.22);
   addFxSphere(root, 0.09, [1.05, 0, 0], '#1f2428', 0.22, 0.35);
@@ -1156,8 +1145,12 @@ async function createCaptureJetFx() {
         )
       );
     }
+    const exhaustAnchors = exhaustNodes
+      .map((node) => node?.getWorldPosition?.(new THREE.Vector3()))
+      .filter(Boolean)
+      .map((world) => root.worldToLocal(world.clone()));
     root.visible = false;
-    return { root, trail, exhaustTrail, exhaustNodes };
+    return { root, trail, exhaustTrail, exhaustNodes, exhaustAnchors };
   }
   const body = new THREE.Mesh(
     new THREE.CylinderGeometry(0.15, 0.21, 3.18, 28),
@@ -1246,7 +1239,13 @@ async function createCaptureJetFx() {
   }
   applyMilitaryJetLook(root);
   root.visible = false;
-  return { root, trail, exhaustTrail, exhaustNodes: [engineLeft, engineRight] };
+  return {
+    root,
+    trail,
+    exhaustTrail,
+    exhaustNodes: [engineLeft, engineRight],
+    exhaustAnchors: [engineLeft.position.clone(), engineRight.position.clone()]
+  };
 }
 
 async function createCaptureHelicopterFx() {
@@ -1259,7 +1258,7 @@ async function createCaptureHelicopterFx() {
     model.rotation.y = Math.PI;
     applyMilitaryHelicopterLook(model);
     const { topRotor, tailRotor } = findHelicopterRotorNodes(model);
-    const topRotorAxis = inferRotorSpinAxis(topRotor, 'y');
+    const topRotorAxis = new THREE.Vector3(0, 1, 0);
     const tailRotorAxis = inferRotorSpinAxis(tailRotor, 'x');
     root.add(model);
     root.visible = false;
@@ -1282,7 +1281,7 @@ async function createCaptureHelicopterFx() {
   nose.rotation.z = -Math.PI / 2;
   nose.castShadow = true;
   root.add(nose);
-  const cockpit = addFxSphere(root, 0.26, [0.72, 0.18, 0], '#22303d', 0.18, 0.28);
+  const cockpit = addFxSphere(root, 0.26, [0.72, 0.18, 0], '#000000', 0.18, 0.28);
   cockpit.scale.set(1.2, 0.68, 0.72);
   addFxCylinder(root, 0.08, 0.1, 1.25, [-1.7, 0.1, 0], [0, 0, Math.PI / 2], '#6f7881', 16, 0.56, 0.24);
   addFxBox(root, [1.0, 0.08, 0.1], [0.2, -0.28, 0], '#4f5963', 0.6, 0.2);
@@ -6554,18 +6553,17 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         if (entry?.helicopterRotor?.isObject3D) {
           entry.helicopterRotor.rotateOnAxis(
             entry.helicopterTopRotorAxis ?? new THREE.Vector3(0, 1, 0),
-            delta * 26
+            delta * 32
           );
         }
         if (entry?.helicopterTailRotor?.isObject3D) {
           entry.helicopterTailRotor.rotateOnAxis(
             entry.helicopterTailRotorAxis ?? new THREE.Vector3(1, 0, 0),
-            delta * 30
+            delta * 32
           );
         }
         if (entry?.dronePropeller?.isObject3D) {
-          entry.dronePropeller.rotation.y += delta * 12;
-          entry.dronePropeller.rotation.x += delta * 12;
+          entry.dronePropeller.rotation.x += delta * 40;
         }
       });
 
@@ -7272,14 +7270,13 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
               primaryFx.root.quaternion.setFromUnitVectors(MISSILE_FORWARD, new THREE.Vector3(0, -1, 0));
             }
             if (primaryFx.propeller) {
-              primaryFx.propeller.rotation.y += 1.2;
-              primaryFx.propeller.rotation.x += 1.2;
+              primaryFx.propeller.rotation.x += dt * 40;
             }
             if (primaryFx.rotor) {
-              primaryFx.rotor.rotateOnAxis(primaryFx.topRotorAxis ?? new THREE.Vector3(0, 1, 0), dt * 36);
+              primaryFx.rotor.rotateOnAxis(primaryFx.topRotorAxis ?? new THREE.Vector3(0, 1, 0), dt * 32);
             }
             if (primaryFx.tailRotor) {
-              primaryFx.tailRotor.rotateOnAxis(primaryFx.tailRotorAxis ?? new THREE.Vector3(1, 0, 0), dt * 40);
+              primaryFx.tailRotor.rotateOnAxis(primaryFx.tailRotorAxis ?? new THREE.Vector3(1, 0, 0), dt * 32);
             }
             primaryFx.trail.forEach((puff, i) => {
               const isJetTrail = selectedCaptureAnimationId === 'fighterJetAttack';
@@ -7309,10 +7306,16 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
               primaryFx.exhaustTrail.forEach((puff, i) => {
                 const lane = i % 2 === 0 ? -1 : 1;
                 const pairIndex = Math.floor(i / 2);
+                const exhaustAnchor = Array.isArray(primaryFx.exhaustAnchors)
+                  ? primaryFx.exhaustAnchors[lane < 0 ? 0 : 1] || primaryFx.exhaustAnchors[0] || null
+                  : null;
+                const baseX = exhaustAnchor?.x ?? -1.7;
+                const baseY = exhaustAnchor?.y ?? 0;
+                const baseZ = exhaustAnchor?.z ?? lane * 0.22;
                 puff.position.set(
-                  -1.7 - pairIndex * 0.24,
-                  Math.sin(elapsed * 0.022 + i * 0.45) * 0.025,
-                  lane * 0.22 + Math.sin(elapsed * 0.013 + i * 0.33) * 0.02
+                  baseX - pairIndex * 0.24,
+                  baseY + Math.sin(elapsed * 0.022 + i * 0.45) * 0.025,
+                  baseZ + Math.sin(elapsed * 0.013 + i * 0.33) * 0.02
                 );
                 const glowPulse = 0.82 + Math.sin(elapsed * 0.024 + i * 0.7) * 0.18;
                 const baseScale = pairIndex < 2 ? 0.86 : 1.02 + (pairIndex - 2) * 0.12;


### PR DESCRIPTION
### Motivation
- Make Ludo capture vehicle visuals and animations consistent with Chess/Snake implementations by fixing rotor spin axes/speeds and jet exhaust mapping. 
- Remove unintended small triangles on the drone and ensure cockpits render true black for clearer visuals.

### Description
- Force helicopter cockpit/window material to true black in `applyMilitaryHelicopterLook` and procedural helicopter cockpit creation. (file: `webapp/src/pages/Games/LudoBattleRoyal.jsx`)
- Force loaded helicopter top rotor to spin on the Y axis and normalize parked/active rotor spin rates to a consistent value (adjusted from 26/30/36/40 to 32 where applicable). (file: `webapp/src/pages/Games/LudoBattleRoyal.jsx`)
- Change drone propeller animation to a single-axis spin (X) and increase spin rate for better visual match; remove procedural small fin triangles from the drone fallback mesh. (file: `webapp/src/pages/Games/LudoBattleRoyal.jsx`)
- Trim any `triangle`-named nodes from loaded drone models during `applyMilitaryDroneLook` so the two small triangles above the drone are removed at load time. (file: `webapp/src/pages/Games/LudoBattleRoyal.jsx`)
- Anchor fighter jet exhaust/smoke puffs to detected exhaust/engine nodes by computing `exhaustAnchors` from `exhaustNodes` (world->local), and use those anchors when positioning exhaust trail puffs instead of fixed offsets so the smoke tail maps to the model correctly. (file: `webapp/src/pages/Games/LudoBattleRoyal.jsx`)
- Minor cleanup: return shapes from `createCaptureJetFx`/`createCaptureDroneFx` now include `exhaustAnchors` when available to enable correct trail placement. (file: `webapp/src/pages/Games/LudoBattleRoyal.jsx`)

### Testing
- Ran the production build with `npm --prefix webapp run -s build`, which completed successfully; Vite emitted non-blocking chunk-size/dynamic-import warnings only. 
- No automated unit tests were run as part of this change; visual behavior was updated in code paths exercised by the runtime build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de5782fe14832996d02a3941f8b56b)