### PR TITLE
Winner banner + confetti, castling drag/drop, and capture animation tuning

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -56,9 +56,10 @@ import {
   isChessOptionUnlocked
 } from '../../utils/chessBattleInventory.js';
 import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
-import { avatarToName } from '../../utils/avatarUtils.js';
+import { avatarToName, getAvatarUrl } from '../../utils/avatarUtils.js';
 import { getAIOpponentFlag } from '../../utils/aiOpponentFlag.js';
 import { ipToFlag } from '../../utils/conflictMatchmaking.js';
+import coinConfetti from '../../utils/coinConfetti.ts';
 import AvatarTimer from '../../components/AvatarTimer.jsx';
 import BottomLeftIcons from '../../components/BottomLeftIcons.jsx';
 import GiftPopup from '../../components/GiftPopup.jsx';
@@ -93,13 +94,13 @@ const LUDO_CAPTURE_MISSILE_TRAVEL_TIME = 2.52;
 const LUDO_CAPTURE_EXPLOSION_TIME = 2.6;
 const LUDO_CAPTURE_TOTAL_TIME = LUDO_CAPTURE_MISSILE_TRAVEL_TIME + LUDO_CAPTURE_EXPLOSION_TIME;
 const CAPTURE_DRONE_LIFT_TIME = 0.28;
-const CAPTURE_DRONE_CRUISE_TIME = 2.9;
-const CAPTURE_DRONE_DIVE_TIME = 1.18;
+const CAPTURE_DRONE_CRUISE_TIME = 3.45;
+const CAPTURE_DRONE_DIVE_TIME = 1.34;
 const CAPTURE_DRONE_TOTAL = CAPTURE_DRONE_LIFT_TIME + CAPTURE_DRONE_CRUISE_TIME + CAPTURE_DRONE_DIVE_TIME;
 const CAPTURE_JET_SPEED_FACTOR = 4.9 / CAPTURE_DRONE_TOTAL; // slower than prior tuning for clearer portrait tracking
 const PROFILE_VIEW_ROTATION_TYPES = new Set(['K', 'N']);
 const PROFILE_VIEW_ROTATION_RADIANS = Math.PI / 2;
-const CAPTURE_JET_TOTAL = CAPTURE_DRONE_TOTAL + 2.45; // longer strike cycle so jet/helicopter read slower in portrait and show takeoff/landing
+const CAPTURE_JET_TOTAL = CAPTURE_DRONE_TOTAL + 3.2; // slower strike cycle so jet/helicopter movement is easier to follow in portrait
 const CAPTURE_JET_MISSILE_TRAVEL = Math.max(0.28, CAPTURE_JET_TOTAL * (0.96 - 0.56) - 0.1);
 const CAPTURE_HELICOPTER_SPEED_FACTOR = 1; // keep helicopter pacing identical to jet so both share the same visible loop
 const CAPTURE_HELICOPTER_TOTAL = CAPTURE_JET_TOTAL; // helicopter mirrors jet timing for synchronized air-strike pacing
@@ -108,24 +109,24 @@ const CAPTURE_JET_MISSILE_RELEASE_RATIO = 0.62;
 const CAPTURE_JET_MISSILE_ENTRY_RELEASE_RATIO = 0.56; // release while entering the enemy-side U-turn
 const CAPTURE_JET_TRIMMED_START_RATIO = 0; // keep takeoff visible from the live piece location
 const CAPTURE_GROUND_FIRE_TIME = 0.42;
-const CAPTURE_GROUND_TRAVEL_TIME = 4.45; // slower low-altitude ground strike so launches are easier to read in portrait
+const CAPTURE_GROUND_TRAVEL_TIME = 5.4; // make drone/ground strike visibly slower
 const CAPTURE_GROUND_TOTAL = CAPTURE_GROUND_FIRE_TIME + CAPTURE_GROUND_TRAVEL_TIME;
 const CAPTURE_DRONE_SCALE = 0.0432; // 20% smaller baseline drone
 const CAPTURE_JET_SCALE = CAPTURE_DRONE_SCALE * 1.12; // trim jet size slightly so it reads cleaner in portrait view
 const CAPTURE_HELICOPTER_SCALE = CAPTURE_DRONE_SCALE * 1.2; // keep helicopter larger than drone while respecting 20% downsize
-const CAPTURE_DRONE_ALTITUDE = 0.88; // keep aircraft lower so they stay visually close to the board
+const CAPTURE_DRONE_ALTITUDE = 0.56; // keep all aircraft noticeably lower on portrait view
 const CAPTURE_FLIGHT_ALTITUDE = CAPTURE_DRONE_ALTITUDE;
-const CAPTURE_DRONE_REFERENCE_BOARD_ALTITUDE = CAPTURE_FLIGHT_ALTITUDE * 0.48; // cruise height the drone visually keeps above board
+const CAPTURE_DRONE_REFERENCE_BOARD_ALTITUDE = CAPTURE_FLIGHT_ALTITUDE * 0.32; // keep cruise height closer to board
 const CAPTURE_AIR_STRIKE_BOARD_CLEARANCE = 0; // measure air-strike altitude strictly from board plane
 const CAPTURE_AIR_STRIKE_ALTITUDE_MULTIPLIER = 1; // align jet/helicopter flight height with drone altitude
 const CAPTURE_JET_ALTITUDE = CAPTURE_DRONE_REFERENCE_BOARD_ALTITUDE * CAPTURE_AIR_STRIKE_ALTITUDE_MULTIPLIER;
 const CAPTURE_HELICOPTER_ALTITUDE_BOOST = 0; // keep helicopter and jet at the same flight altitude
 const CAPTURE_AIR_STRIKE_PATH_RADIUS_FACTOR = 0.18; // tighter loops so flight path stays more inward on-screen
-const CAPTURE_AIR_STRIKE_PATH_EDGE_MARGIN_TILES = 2.62; // higher margin keeps turns further away from board edges
+const CAPTURE_AIR_STRIKE_PATH_EDGE_MARGIN_TILES = 3.55; // tighten perimeter so routes stay close to center
 const CAPTURE_AIR_STRIKE_BOTTOM_PLAYER_BIAS_TILES = 0.02; // reduce portrait bottom bias so aircraft stay nearer center
-const CAPTURE_DRONE_ORBIT_RADIUS_MUL = 0.4; // run drone path more inward and closer to board center
-const CAPTURE_DRONE_ORBIT_HEIGHT_MUL = 0.24; // lower drone route to keep it close to board surface
-const CAPTURE_AIR_STRIKE_ORBIT_HEIGHT_MUL = 0.2; // lower jet/helicopter route so aircraft feel closer to board
+const CAPTURE_DRONE_ORBIT_RADIUS_MUL = 0.18; // shorter inward route
+const CAPTURE_DRONE_ORBIT_HEIGHT_MUL = 0.1; // lower drone route further
+const CAPTURE_AIR_STRIKE_ORBIT_HEIGHT_MUL = 0.08; // lower jet/helicopter route further
 const CAPTURE_DRONE_ORBIT_CYCLES = 0.22; // baseline loop cadence shared by drone/jet/helicopter
 const CAPTURE_DRONE_ORBIT_SPLIT = 0.84;
 const CAPTURE_DRONE_RETURN_SPLIT = 0.72;
@@ -133,8 +134,8 @@ const CAPTURE_AIR_MISSILE_RELEASE_START_RATIO = 0.46;
 const CAPTURE_AIR_MISSILE_RELEASE_END_RATIO = 0.74;
 const CAPTURE_AIR_MISSILE_ARC_SPLIT = 0.84;
 const CAPTURE_AIR_MISSILE_DROP_PORTION = 0.16;
-const CAPTURE_AIR_MISSILE_SIDE_OFFSET = 0.032;
-const CAPTURE_AIR_MISSILE_TOP_HEIGHT_TILE_MUL = 1.16;
+const CAPTURE_AIR_MISSILE_SIDE_OFFSET = 0.02;
+const CAPTURE_AIR_MISSILE_TOP_HEIGHT_TILE_MUL = 0.72;
 const CAPTURE_AIR_MISSILE_TOP_HEIGHT_MIN = 0.18;
 const CAPTURE_AIR_MISSILE_TOP_BLEND = 0.54;
 const CAPTURE_AIR_MISSILE_TOP_EXTRA_LIFT = 0.03;
@@ -7051,6 +7052,8 @@ function Chess3D({
   const [showChat, setShowChat] = useState(false);
   const [showGift, setShowGift] = useState(false);
   const [chatBubbles, setChatBubbles] = useState([]);
+  const [winnerBanner, setWinnerBanner] = useState(null);
+  const winnerCelebrationRef = useRef(null);
   const [ui, setUi] = useState({
     turnWhite: true,
     status: 'White to move',
@@ -7524,6 +7527,26 @@ function Chess3D({
     const [whitePlayer, blackPlayer] = playersRef.current || [];
     return isWhite ? whitePlayer?.name || 'White' : blackPlayer?.name || 'Black';
   }, []);
+  const resolveChessSidePhoto = useCallback((isWhite) => {
+    const [whitePlayer, blackPlayer] = playersRef.current || [];
+    return isWhite ? whitePlayer?.photoUrl || '🙂' : blackPlayer?.photoUrl || '🤖';
+  }, []);
+
+  useEffect(() => {
+    const isCheckmate = typeof ui.status === 'string' && ui.status.toLowerCase().includes('checkmate');
+    if (!ui.winner || !isCheckmate) {
+      setWinnerBanner(null);
+      winnerCelebrationRef.current = null;
+      return;
+    }
+    if (winnerCelebrationRef.current === ui.winner) return;
+    winnerCelebrationRef.current = ui.winner;
+    const isWhiteWinner = ui.winner === 'White';
+    const winnerName = resolveChessSideName(isWhiteWinner);
+    const winnerPhotoUrl = getAvatarUrl(resolveChessSidePhoto(isWhiteWinner) || '/assets/icons/profile.svg');
+    setWinnerBanner({ winnerName, winnerPhotoUrl });
+    coinConfetti(70);
+  }, [ui.winner, ui.status, resolveChessSideName, resolveChessSidePhoto]);
 
   const resolveCommentarySpeaker = useCallback(() => {
     const speakers = [CHESS_BATTLE_SPEAKERS.lead, CHESS_BATTLE_SPEAKERS.analyst];
@@ -9560,12 +9583,12 @@ function Chess3D({
     const getAirStrikeCenterFlightTarget = (from, to) => {
       const centerBias = THREE.MathUtils.clamp(
         (Math.abs(from.x) + Math.abs(to.x)) / Math.max(tile * 8, 0.001),
-        0.56,
-        0.9
+        0.78,
+        0.96
       );
       const flightTarget = to.clone();
       flightTarget.x = THREE.MathUtils.lerp(to.x, 0, centerBias);
-      flightTarget.z = THREE.MathUtils.lerp(to.z, 0, 0.4);
+      flightTarget.z = THREE.MathUtils.lerp(to.z, 0, 0.68);
       return constrainInsideBoardPerimeter(flightTarget, CAPTURE_AIR_STRIKE_PATH_EDGE_MARGIN_TILES);
     };
     const getCaptureOrbitPose = ({
@@ -11232,7 +11255,14 @@ function Chess3D({
       }
       if (promoted && currentPiecePrototypes) {
         const color = board[rr][cc].w ? 'white' : 'black';
-        const queenProto = currentPiecePrototypes[color]?.Q;
+        const liveQueenMesh = allPieceMeshes.find(
+          (mesh) =>
+            mesh &&
+            mesh !== m &&
+            mesh.userData?.t === 'Q' &&
+            Boolean(mesh.userData?.w) === Boolean(board[rr][cc].w)
+        );
+        const queenProto = liveQueenMesh || currentPiecePrototypes[color]?.Q;
         if (queenProto) {
           const replacement = cloneWithShadows(queenProto);
           replacement.position.copy(m.position);
@@ -11357,6 +11387,20 @@ function Chess3D({
       clearHighlights();
       finalizeAiMove();
     }
+
+    const resolveCastlingDropTarget = (targetR, targetC) => {
+      if (!sel) return null;
+      const selectedPiece = board[sel.r]?.[sel.c];
+      const targetPiece = board[targetR]?.[targetC];
+      if (!selectedPiece || selectedPiece.t !== 'K' || !targetPiece) return null;
+      if (targetPiece.t !== 'R' || targetPiece.w !== selectedPiece.w) return null;
+      if (targetR !== sel.r) return null;
+      const castleDestC = targetC > sel.c ? 6 : 2;
+      if (legal.some(([r, c]) => r === targetR && c === castleDestC)) {
+        return { r: targetR, c: castleDestC };
+      }
+      return null;
+    };
 
     const dragState = {
       active: false,
@@ -11509,6 +11553,11 @@ function Chess3D({
       dragState.mesh = null;
       dragState.from = null;
       if (controls) controls.enabled = true;
+      const castleDropTarget = tileHit ? resolveCastlingDropTarget(tileHit.r, tileHit.c) : null;
+      if (castleDropTarget) {
+        moveSelTo(castleDropTarget.r, castleDropTarget.c);
+        return;
+      }
       if (tileHit && sel && legal.some(([r, c]) => r === tileHit.r && c === tileHit.c)) {
         moveSelTo(tileHit.r, tileHit.c);
         return;
@@ -11573,6 +11622,11 @@ function Chess3D({
         targetPiece.w !== board[sel.r][sel.c]?.w
       ) {
         moveSelTo(ud.r, ud.c);
+        return;
+      }
+      const castleTarget = resolveCastlingDropTarget(ud.r, ud.c);
+      if (castleTarget) {
+        moveSelTo(castleTarget.r, castleTarget.c);
         return;
       }
       if (ud.type === 'piece') selectAt(ud.r, ud.c);
@@ -12709,6 +12763,20 @@ function Chess3D({
             {ui.winner ? `${ui.winner} Wins` : ui.status}
           </div>
         </div>
+        {winnerBanner && (
+          <div className="absolute inset-0 pointer-events-none z-30 flex items-center justify-center">
+            <div className="px-5 py-4 rounded-2xl bg-[rgba(7,10,18,0.78)] border border-[rgba(255,215,0,0.45)] backdrop-blur-md shadow-[0_16px_48px_rgba(0,0,0,0.5)] flex flex-col items-center gap-2">
+              <img
+                src={winnerBanner.winnerPhotoUrl}
+                alt={`${winnerBanner.winnerName} avatar`}
+                className="w-16 h-16 rounded-full border-2 border-yellow-300 object-cover"
+              />
+              <p className="text-[0.65rem] uppercase tracking-[0.28em] text-yellow-200/90">Winner</p>
+              <p className="text-lg font-semibold text-white leading-none">{winnerBanner.winnerName}</p>
+              <p className="text-xs uppercase tracking-[0.16em] text-yellow-100/85">Checkmate</p>
+            </div>
+          </div>
+        )}
       </div>
       {chatBubbles.map((bubble) => (
         <div key={bubble.id} className="chat-bubble chess-battle-chat-bubble">


### PR DESCRIPTION
### Motivation
- Surface a clear victory celebration on checkmate with the winning avatar and confetti to improve endgame feedback.
- Make capture/air-strike flight timings and geometry more readable on portrait/smaller views by retuning constants for altitude, timing, radii and missile arcs.
- Allow castle moves to be completed by dragging/dropping onto the rook to improve UX for drag interactions and AI selection.

### Description
- Added winner UI state and celebration: introduced `winnerBanner` state, `winnerCelebrationRef`, `resolveChessSidePhoto`, and a centered banner overlay that shows the winner name/photo on checkmate and triggers `coinConfetti(70)`; imported `getAvatarUrl` and `coinConfetti`.
- Tuned capture/air-strike behavior by changing many `CAPTURE_*` constants (timings, altitudes, orbit radii/height multipliers, edge margins, missile height/side offsets, etc.) to slow/shorten/bring aircraft and missiles visually closer to the board in portrait mode.
- Adjusted `getAirStrikeCenterFlightTarget` center bias and Z lerp to keep flight targets more central on-screen.
- Improved promotion handling by preferring an existing live queen mesh when replacing a promoted pawn instead of always cloning the prototype, avoiding visual glitches when a queen already exists on the board.
- Added `resolveCastlingDropTarget` helper and integrated it into pointer/touch/AI interactions so dragging or clicking on a rook while a king is selected will complete castling to `c=2` or `c=6` when legal.
- Minor UI: added the winner overlay markup and styling near the main scene and used avatar image `alt` attributes for accessibility.

### Testing
- Ran the test suite with `yarn test` and all tests completed successfully.
- Performed an automated build with `yarn build` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de4aecd7648329a9020c83c3938a99)