### PR TITLE
Adjust Snake & Ladder parked weapon placement and size

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -257,7 +257,8 @@ const TOKEN_REST_LATERAL_BY_SEAT = Object.freeze([
 const SEAT_RAIL_DICE_GAP = Math.max(DICE_SIZE * 0.95, TOKEN_RADIUS * 2.75);
 const SEAT_RAIL_SLOT_OFFSET = SEAT_RAIL_DICE_GAP * 0.5;
 const SEAT_RAIL_FORWARD_BIAS = TILE_SIZE * 0.08;
-const WEAPON_DISPLAY_SIZE_MULTIPLIER = 2.25;
+const WEAPON_DISPLAY_SIZE_MULTIPLIER = 2;
+const WEAPON_PARKING_OUTWARD_OFFSET = TILE_SIZE * 0.34;
 
 const PAVEMENT_EXTRA_SCALE = 1.18;
 const PAVEMENT_THICKNESS = TILE_SIZE * 0.4;
@@ -4615,7 +4616,10 @@ function updateSeatWeaponDisplays(board, players = []) {
     );
     if (railLayout) {
       const sideSign = seatIndex % 2 === 0 ? 1 : -1;
-      holder.position.copy(railLayout.railLocal).addScaledVector(railLayout.lateral, sideSign * SEAT_RAIL_SLOT_OFFSET);
+      holder.position
+        .copy(railLayout.railLocal)
+        .addScaledVector(railLayout.lateral, sideSign * SEAT_RAIL_SLOT_OFFSET)
+        .addScaledVector(railLayout.seatDirection, WEAPON_PARKING_OUTWARD_OFFSET);
       holder.position.y = railLayout.railHeightY;
     } else {
       const seatWorld = new THREE.Vector3();


### PR DESCRIPTION
### Motivation
- Parked weapon models on the Snake & Ladder 3D board should sit next to the table (in their parking position) instead of overlapping the rail, and they should appear slightly smaller to better match the intended layout.
- Make the parked weapon placement easier to tune by introducing a dedicated constant for the outward offset.

### Description
- Reduced `WEAPON_DISPLAY_SIZE_MULTIPLIER` from `2.25` to `2` so parked weapon models render slightly smaller.
- Added a new `WEAPON_PARKING_OUTWARD_OFFSET` constant and used it in the seat weapon placement calculation to move holders outward along `railLayout.seatDirection` so weapons sit next to the table.
- Applied the outward offset in `updateSeatWeaponDisplays` by adding `.addScaledVector(railLayout.seatDirection, WEAPON_PARKING_OUTWARD_OFFSET)` to the holder placement logic.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully.
- The build emitted non-blocking Vite chunking warnings but finished without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de502427488329a388aeafc63837b7)