### PR TITLE
Fix Ludo air-unit visuals and rotor/exhaust behavior

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -609,6 +609,12 @@ function findJetCockpitAndExhaustNodes(root) {
   return { cockpitNodes, exhaustNodes };
 }
 
+function getNodePositionInRootSpace(root, node) {
+  if (!root || !node?.isObject3D) return null;
+  const worldPos = node.getWorldPosition(new THREE.Vector3());
+  return root.worldToLocal(worldPos);
+}
+
 function findHelicopterRotorNodes(root) {
   let topRotor = null;
   let tailRotor = null;
@@ -670,7 +676,7 @@ function applyMilitaryHelicopterLook(root, topRotor = null, tailRotor = null) {
       /rotor|propell|blade|fan/.test(name);
     paintMeshMaterials(node, (mat) => {
       if (/window|cockpit|glass|canopy/.test(name)) {
-        mat.color.setHex(0x0c1016);
+        mat.color.setHex(0x000000);
         if ('metalness' in mat) mat.metalness = 0.38;
         if ('roughness' in mat) mat.roughness = 0.2;
         if ('opacity' in mat) mat.opacity = 0.95;
@@ -710,6 +716,14 @@ function applyMilitaryDroneLook(root, propeller = null) {
     const name = `${node.name || ''}`.toLowerCase();
     const isMotor = node === motor || /propell|rotor|blade|fan|motor/.test(name);
     paintMeshMaterials(node, (mat) => {
+      if (/window|windshield|glass|cockpit|canopy/.test(name)) {
+        mat.color.setHex(0x000000);
+        if ('metalness' in mat) mat.metalness = 0.58;
+        if ('roughness' in mat) mat.roughness = 0.2;
+        if ('transparent' in mat) mat.transparent = true;
+        if ('opacity' in mat) mat.opacity = 0.95;
+        return;
+      }
       if (isMotor || /engine|exhaust|rear|tail/.test(name)) {
         mat.color.setHex(0x11151a);
         if ('metalness' in mat) mat.metalness = 0.72;
@@ -1060,26 +1074,9 @@ async function createCaptureDroneFx() {
   );
   spine.position.set(0.15, 0.03, 0);
   root.add(spine);
-  const finLeft = createFxPolygon(
-    [
-      [-0.28, 0],
-      [0.22, 0],
-      [-0.04, 0.55]
-    ],
-    0.04,
-    '#838b90',
-    0.55,
-    0.24
-  );
-  finLeft.rotation.z = Math.PI / 2;
-  finLeft.position.set(-0.4, 0.35, -0.25);
-  root.add(finLeft);
-  const finRight = finLeft.clone();
-  finRight.position.z = 0.25;
-  root.add(finRight);
   addFxCylinder(root, 0.04, 0.04, 0.64, [0.28, -0.22, -0.55], [Math.PI / 2, 0, 0], '#656e76', 12, 0.54, 0.22);
   addFxCylinder(root, 0.04, 0.04, 0.64, [0.28, -0.22, 0.55], [Math.PI / 2, 0, 0], '#656e76', 12, 0.54, 0.22);
-  addFxSphere(root, 0.09, [1.05, 0, 0], '#1f2428', 0.22, 0.35);
+  addFxSphere(root, 0.09, [1.05, 0, 0], '#000000', 0.22, 0.35);
   const propeller = new THREE.Group();
   propeller.position.set(-1.95, 0, 0);
   addFxBox(propeller, [0.05, 1.0, 0.08], [0, 0, 0], '#191d20', 0.6, 0.12);
@@ -1156,8 +1153,11 @@ async function createCaptureJetFx() {
         )
       );
     }
+    const exhaustAnchors = exhaustNodes
+      .map((node) => getNodePositionInRootSpace(root, node))
+      .filter(Boolean);
     root.visible = false;
-    return { root, trail, exhaustTrail, exhaustNodes };
+    return { root, trail, exhaustTrail, exhaustNodes, exhaustAnchors };
   }
   const body = new THREE.Mesh(
     new THREE.CylinderGeometry(0.15, 0.21, 3.18, 28),
@@ -1246,7 +1246,13 @@ async function createCaptureJetFx() {
   }
   applyMilitaryJetLook(root);
   root.visible = false;
-  return { root, trail, exhaustTrail, exhaustNodes: [engineLeft, engineRight] };
+  return {
+    root,
+    trail,
+    exhaustTrail,
+    exhaustNodes: [engineLeft, engineRight],
+    exhaustAnchors: [engineLeft.position.clone(), engineRight.position.clone()]
+  };
 }
 
 async function createCaptureHelicopterFx() {
@@ -1259,7 +1265,7 @@ async function createCaptureHelicopterFx() {
     model.rotation.y = Math.PI;
     applyMilitaryHelicopterLook(model);
     const { topRotor, tailRotor } = findHelicopterRotorNodes(model);
-    const topRotorAxis = inferRotorSpinAxis(topRotor, 'y');
+    const topRotorAxis = new THREE.Vector3(0, 1, 0);
     const tailRotorAxis = inferRotorSpinAxis(tailRotor, 'x');
     root.add(model);
     root.visible = false;
@@ -1282,7 +1288,7 @@ async function createCaptureHelicopterFx() {
   nose.rotation.z = -Math.PI / 2;
   nose.castShadow = true;
   root.add(nose);
-  const cockpit = addFxSphere(root, 0.26, [0.72, 0.18, 0], '#22303d', 0.18, 0.28);
+  const cockpit = addFxSphere(root, 0.26, [0.72, 0.18, 0], '#000000', 0.18, 0.28);
   cockpit.scale.set(1.2, 0.68, 0.72);
   addFxCylinder(root, 0.08, 0.1, 1.25, [-1.7, 0.1, 0], [0, 0, Math.PI / 2], '#6f7881', 16, 0.56, 0.24);
   addFxBox(root, [1.0, 0.08, 0.1], [0.2, -0.28, 0], '#4f5963', 0.6, 0.2);
@@ -6564,8 +6570,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           );
         }
         if (entry?.dronePropeller?.isObject3D) {
-          entry.dronePropeller.rotation.y += delta * 12;
-          entry.dronePropeller.rotation.x += delta * 12;
+          entry.dronePropeller.rotation.x += delta * 40;
         }
       });
 
@@ -7272,8 +7277,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
               primaryFx.root.quaternion.setFromUnitVectors(MISSILE_FORWARD, new THREE.Vector3(0, -1, 0));
             }
             if (primaryFx.propeller) {
-              primaryFx.propeller.rotation.y += 1.2;
-              primaryFx.propeller.rotation.x += 1.2;
+              primaryFx.propeller.rotation.x += dt * 40;
             }
             if (primaryFx.rotor) {
               primaryFx.rotor.rotateOnAxis(primaryFx.topRotorAxis ?? new THREE.Vector3(0, 1, 0), dt * 36);
@@ -7307,12 +7311,15 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             });
             if (selectedCaptureAnimationId === 'fighterJetAttack' && Array.isArray(primaryFx.exhaustTrail)) {
               primaryFx.exhaustTrail.forEach((puff, i) => {
-                const lane = i % 2 === 0 ? -1 : 1;
+                const laneIndex = i % 2;
                 const pairIndex = Math.floor(i / 2);
+                const laneSign = laneIndex === 0 ? -1 : 1;
+                const exhaustAnchors = Array.isArray(primaryFx.exhaustAnchors) ? primaryFx.exhaustAnchors : [];
+                const laneAnchor = exhaustAnchors[laneIndex] || new THREE.Vector3(-1.72, -0.04, laneSign * 0.22);
                 puff.position.set(
-                  -1.7 - pairIndex * 0.24,
-                  Math.sin(elapsed * 0.022 + i * 0.45) * 0.025,
-                  lane * 0.22 + Math.sin(elapsed * 0.013 + i * 0.33) * 0.02
+                  laneAnchor.x - pairIndex * 0.24,
+                  laneAnchor.y + Math.sin(elapsed * 0.022 + i * 0.45) * 0.025,
+                  laneAnchor.z + Math.sin(elapsed * 0.013 + i * 0.33) * 0.02
                 );
                 const glowPulse = 0.82 + Math.sin(elapsed * 0.024 + i * 0.7) * 0.18;
                 const baseScale = pairIndex < 2 ? 0.86 : 1.02 + (pairIndex - 2) * 0.12;


### PR DESCRIPTION
### Motivation
- Make Ludo Battle Royal air-unit visuals and motion match existing references (Chess Battle Royal / Snake and Ladder) by fixing rotor spin axis, drone propeller rotation, exhaust mapping, and cockpit tint.

### Description
- Force helicopter main rotor axis to world Y by setting `topRotorAxis = new THREE.Vector3(0, 1, 0)` when loading the helicopter model instead of relying on inferred axis. (`createCaptureHelicopterFx`)
- Change drone propeller spin to a single-axis X rotation with time-scaled velocity (`entry.dronePropeller.rotation.x += delta * 40` and `primaryFx.propeller.rotation.x += dt * 40`). (`LudoBattleRoyal.jsx` loop and attack tick)
- Remove the two small upper drone triangle fins from the procedural fallback drone model by deleting the `finLeft` / `finRight` creation and clones in `createCaptureDroneFx`.
- Blacken cockpits/windows for helicopter, drone and fallback meshes by setting cockpit/window material color to `#000000` in `applyMilitaryHelicopterLook`, `applyMilitaryDroneLook`, and fallback cockpit creation points.
- Anchor jet exhaust smoke to detected exhaust node positions by adding `getNodePositionInRootSpace(root, node)`, collecting `exhaustAnchors` for loaded models, providing fallback anchors for procedural jets, and using those anchors when positioning `primaryFx.exhaustTrail` puffs.

### Testing
- Ran `npx eslint webapp/src/pages/Games/LudoBattleRoyal.jsx`, which completed with a repo ignore warning but no blocking errors. (exit 0)
- Ran `npx eslint --no-ignore webapp/src/pages/Games/LudoBattleRoyal.jsx`, which reported the file matched an ignore pattern (warning) and produced no lint errors (exit 0).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de5782fe14832996d02a3941f8b56b)