### PR TITLE
Adjust Snake & Ladder weapon size, token rest positions, and camera framing

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -257,7 +257,8 @@ const TOKEN_REST_LATERAL_BY_SEAT = Object.freeze([
 const SEAT_RAIL_DICE_GAP = Math.max(DICE_SIZE * 0.95, TOKEN_RADIUS * 2.75);
 const SEAT_RAIL_SLOT_OFFSET = SEAT_RAIL_DICE_GAP * 0.5;
 const SEAT_RAIL_FORWARD_BIAS = TILE_SIZE * 0.08;
-const WEAPON_DISPLAY_SIZE_MULTIPLIER = 2;
+const WEAPON_DISPLAY_SIZE_MULTIPLIER = 1.4;
+const WEAPON_REST_VERTICAL_OFFSET = -TOKEN_HEIGHT * 0.16;
 const WEAPON_PARKING_OUTWARD_OFFSET = TILE_SIZE * 0.34;
 
 const PAVEMENT_EXTRA_SCALE = 1.18;
@@ -303,16 +304,16 @@ const LANDSCAPE_INITIAL_CAMERA_DISTANCE_FACTOR = 0.62;
 const POINTER_TAP_MAX_DISTANCE = 14;
 const POINTER_TAP_MAX_DURATION_MS = 420;
 const PORTRAIT_CAMERA_TUNING = Object.freeze({
-  backOffset: 1.78,
+  backOffset: 1.92,
   forwardOffset: 0,
-  heightOffset: 3.62,
-  targetLift: 0.038 * MODEL_SCALE
+  heightOffset: 3.78,
+  targetLift: 0.03 * MODEL_SCALE
 });
 const LANDSCAPE_CAMERA_TUNING = Object.freeze({
-  backOffset: 0.6,
+  backOffset: 0.7,
   forwardOffset: 0,
-  heightOffset: 1.2,
-  targetLift: 0.09 * MODEL_SCALE
+  heightOffset: 1.28,
+  targetLift: 0.075 * MODEL_SCALE
 });
 const SHOW_BOARD_RAILS = false;
 const COIN_RAISE = TILE_SIZE * 0.24;
@@ -3454,9 +3455,9 @@ function getSeatRailLayout(board, seatIndex, fallbackRadiusOffset = 0, customIns
     }
   }
   if (seatDirection.z < -0.2) {
-    restRadius += TILE_SIZE * 0.52;
+    restRadius += TILE_SIZE * 0.7;
   } else if (seatDirection.z > 0.2) {
-    restRadius -= TILE_SIZE * 0.46;
+    restRadius -= TILE_SIZE * 0.62;
   }
   restRadius = Math.max(restRadius + fallbackRadiusOffset, TOKEN_REST_MIN_RADIUS);
 
@@ -4620,7 +4621,7 @@ function updateSeatWeaponDisplays(board, players = []) {
         .copy(railLayout.railLocal)
         .addScaledVector(railLayout.lateral, sideSign * SEAT_RAIL_SLOT_OFFSET)
         .addScaledVector(railLayout.seatDirection, WEAPON_PARKING_OUTWARD_OFFSET);
-      holder.position.y = railLayout.railHeightY;
+      holder.position.y = railLayout.railHeightY + WEAPON_REST_VERTICAL_OFFSET;
     } else {
       const seatWorld = new THREE.Vector3();
       anchor.getWorldPosition(seatWorld);
@@ -4634,7 +4635,7 @@ function updateSeatWeaponDisplays(board, players = []) {
         .addScaledVector(seatDirection, radius)
         .addScaledVector(lateral, (seatIndex % 2 === 0 ? 1 : -1) * TOKEN_RADIUS * 0.22);
       holder.position.copy(markerPos);
-      holder.position.y = tableY + TOKEN_HEIGHT * 0.44;
+      holder.position.y = tableY + TOKEN_HEIGHT * 0.44 + WEAPON_REST_VERTICAL_OFFSET;
     }
     holder.lookAt(boardLookTarget.x, holder.position.y, boardLookTarget.z);
   });


### PR DESCRIPTION
### Motivation
- Improve visual alignment of player capture-weapons and tokens so weapons sit at the same perceived level as tokens and appear smaller relative to tokens. 
- Shift top/bottom player token placements inward/outward to better match table/seat visuals. 
- Nudge camera framing slightly farther, higher and looking a bit more downward to improve composition in portrait and landscape.

### Description
- Reduced weapon display scale by ~30% by changing `WEAPON_DISPLAY_SIZE_MULTIPLIER` from `2` to `1.4` in `webapp/src/components/SnakeBoard3D.jsx` so seat-side weapon props render smaller. 
- Added `WEAPON_REST_VERTICAL_OFFSET = -TOKEN_HEIGHT * 0.16` and applied it to parked weapon placement in both rail-layout and fallback placement so weapons sit closer to token height. 
- Adjusted seat rail rest radius bias in `getSeatRailLayout` by increasing inward/outward deltas for `seatDirection.z` (`+ TILE_SIZE * 0.52 -> + TILE_SIZE * 0.7` and `- TILE_SIZE * 0.46 -> - TILE_SIZE * 0.62`) so bottom-seat tokens are pulled inward and top-seat tokens pushed outward toward the seat. 
- Tuned camera parameters: portrait `backOffset` `1.78 -> 1.92`, `heightOffset` `3.62 -> 3.78`, `targetLift` `0.038 -> 0.03`; landscape `backOffset` `0.6 -> 0.7`, `heightOffset` `1.2 -> 1.28`, `targetLift` `0.09 -> 0.075` to move the camera slightly farther, a bit higher, and make it look a touch more downward.

### Testing
- Ran `npx eslint webapp/src/components/SnakeBoard3D.jsx`, which completed with a project ignore warning but no lint errors reported. 
- Changes were committed to `webapp/src/components/SnakeBoard3D.jsx` and verified via a local git commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de6e6012048329a3cc9f11eb149f39)