### PR TITLE
Snake & Ladder: shrink player weapons, adjust token rail positions, and tweak camera tuning

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -257,7 +257,7 @@ const TOKEN_REST_LATERAL_BY_SEAT = Object.freeze([
 const SEAT_RAIL_DICE_GAP = Math.max(DICE_SIZE * 0.95, TOKEN_RADIUS * 2.75);
 const SEAT_RAIL_SLOT_OFFSET = SEAT_RAIL_DICE_GAP * 0.5;
 const SEAT_RAIL_FORWARD_BIAS = TILE_SIZE * 0.08;
-const WEAPON_DISPLAY_SIZE_MULTIPLIER = 2;
+const WEAPON_DISPLAY_SIZE_MULTIPLIER = 1.4;
 const WEAPON_PARKING_OUTWARD_OFFSET = TILE_SIZE * 0.34;
 
 const PAVEMENT_EXTRA_SCALE = 1.18;
@@ -303,16 +303,16 @@ const LANDSCAPE_INITIAL_CAMERA_DISTANCE_FACTOR = 0.62;
 const POINTER_TAP_MAX_DISTANCE = 14;
 const POINTER_TAP_MAX_DURATION_MS = 420;
 const PORTRAIT_CAMERA_TUNING = Object.freeze({
-  backOffset: 1.78,
+  backOffset: 2.02,
   forwardOffset: 0,
-  heightOffset: 3.62,
-  targetLift: 0.038 * MODEL_SCALE
+  heightOffset: 3.82,
+  targetLift: 0.016 * MODEL_SCALE
 });
 const LANDSCAPE_CAMERA_TUNING = Object.freeze({
-  backOffset: 0.6,
+  backOffset: 0.78,
   forwardOffset: 0,
-  heightOffset: 1.2,
-  targetLift: 0.09 * MODEL_SCALE
+  heightOffset: 1.32,
+  targetLift: 0.06 * MODEL_SCALE
 });
 const SHOW_BOARD_RAILS = false;
 const COIN_RAISE = TILE_SIZE * 0.24;
@@ -3454,9 +3454,9 @@ function getSeatRailLayout(board, seatIndex, fallbackRadiusOffset = 0, customIns
     }
   }
   if (seatDirection.z < -0.2) {
-    restRadius += TILE_SIZE * 0.52;
+    restRadius += TILE_SIZE * 0.74;
   } else if (seatDirection.z > 0.2) {
-    restRadius -= TILE_SIZE * 0.46;
+    restRadius -= TILE_SIZE * 0.68;
   }
   restRadius = Math.max(restRadius + fallbackRadiusOffset, TOKEN_REST_MIN_RADIUS);
 
@@ -4562,6 +4562,7 @@ function createSeatWeaponMesh(weaponType = 'fighter') {
       ? TOKEN_HEIGHT * 0.75
       : TOKEN_HEIGHT * 0.85;
   group.scale.setScalar(displayScale * 1.5 * WEAPON_DISPLAY_SIZE_MULTIPLIER);
+  group.position.y -= TOKEN_HEIGHT * 0.34;
   group.rotation.x = WEAPON_PARKED_PITCH_BY_KIND[weaponType] ?? 0;
   rig.trail?.forEach((puff) => {
     if (!puff?.material) return;


### PR DESCRIPTION
### Motivation
- Improve visual staging for Snake & Ladder so player weapons sit at the same visual level as tokens, appear 30% smaller, and reserve tokens for top/bottom players are offset inward/outward for better composition.
- Move the default arena camera slightly back, a bit higher and with a smaller target lift so the shot looks a little farther and tilted more downward on mobile portrait screens.

### Description
- Reduced parked seat weapon visual scale by changing `WEAPON_DISPLAY_SIZE_MULTIPLIER` from `2` to `1.4` so weapons render ~30% smaller (file: `webapp/src/components/SnakeBoard3D.jsx`).
- Lowered the parked weapon rig anchor vertically by subtracting `TOKEN_HEIGHT * 0.34` from the weapon group Y so weapons sit closer to the token rail (file: `webapp/src/components/SnakeBoard3D.jsx`).
- Adjusted reserve token rail bias for seat z-direction so bottom player reserve token is pulled more inward and top player reserve token is pushed more outward by changing the seat-direction radius deltas from `+0.52 / -0.46` to `+0.74 / -0.68` (file: `webapp/src/components/SnakeBoard3D.jsx`).
- Tuned camera portrait and landscape defaults to move the camera a bit farther and higher while lowering `targetLift` to create a slightly steeper downward view by modifying `PORTRAIT_CAMERA_TUNING` and `LANDSCAPE_CAMERA_TUNING` (file: `webapp/src/components/SnakeBoard3D.jsx`).

### Testing
- Ran a production build of the web client with `cd webapp && npm run -s build`, which completed successfully (build finished with standard warnings about chunking but no errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de6e6012048329a3cc9f11eb149f39)