### PR TITLE
Adjust Snake board seat token and weapon placement

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -236,15 +236,15 @@ const TOKEN_MULTI_OCCUPANT_RADIUS = TILE_SIZE * 0.24 * TOKEN_RADIUS_SCALE * TOKE
 const DICE_PLAYER_EXTRA_OFFSET = TILE_SIZE * 1.8;
 const TOP_TILE_EXTRA_LEVELS = 1;
 const TOKEN_REST_RAIL_INSET_BY_SEAT = Object.freeze([
-  TILE_SIZE * 1.18,
+  TILE_SIZE * 1.46,
   TILE_SIZE * 1.52,
-  TILE_SIZE * 0.26,
+  TILE_SIZE * 0.08,
   TILE_SIZE * 1.08
 ]);
 const WEAPON_REST_RAIL_INSET_BY_SEAT = Object.freeze([
-  TILE_SIZE * 1.24,
+  TILE_SIZE * 1.48,
   TILE_SIZE * 1.62,
-  TILE_SIZE * 0.3,
+  TILE_SIZE * 0.1,
   TILE_SIZE * 1.22
 ]);
 const TOKEN_REST_MIN_RADIUS = BOARD_RADIUS + TILE_SIZE * 2.08;
@@ -258,7 +258,7 @@ const SEAT_RAIL_DICE_GAP = Math.max(DICE_SIZE * 0.95, TOKEN_RADIUS * 2.75);
 const SEAT_RAIL_SLOT_OFFSET = SEAT_RAIL_DICE_GAP * 0.5;
 const SEAT_RAIL_FORWARD_BIAS = TILE_SIZE * 0.08;
 const WEAPON_DISPLAY_SIZE_MULTIPLIER = 1.4;
-const WEAPON_PARKING_OUTWARD_OFFSET = TILE_SIZE * 0.34;
+const WEAPON_PARKING_OUTWARD_OFFSET = TILE_SIZE * 0.12;
 
 const PAVEMENT_EXTRA_SCALE = 1.18;
 const PAVEMENT_THICKNESS = TILE_SIZE * 0.4;
@@ -407,9 +407,9 @@ const CAPTURE_RETURN_MS = 620;
 const CAPTURE_VERTICAL_STRIKE_LIFT = TOKEN_HEIGHT * 8.8;
 const CAPTURE_MULTI_SHOT_COUNT = 2;
 const WEAPON_PARKED_PITCH_BY_KIND = Object.freeze({
-  fighter: THREE.MathUtils.degToRad(10),
-  helicopter: THREE.MathUtils.degToRad(8),
-  drone: THREE.MathUtils.degToRad(6),
+  fighter: 0,
+  helicopter: 0,
+  drone: 0,
   supportTruck: 0,
   javelin: 0
 });
@@ -3454,9 +3454,9 @@ function getSeatRailLayout(board, seatIndex, fallbackRadiusOffset = 0, customIns
     }
   }
   if (seatDirection.z < -0.2) {
-    restRadius += TILE_SIZE * 0.74;
+    restRadius += TILE_SIZE * 0.94;
   } else if (seatDirection.z > 0.2) {
-    restRadius -= TILE_SIZE * 0.68;
+    restRadius -= TILE_SIZE * 0.92;
   }
   restRadius = Math.max(restRadius + fallbackRadiusOffset, TOKEN_REST_MIN_RADIUS);
 
@@ -4621,7 +4621,7 @@ function updateSeatWeaponDisplays(board, players = []) {
         .copy(railLayout.railLocal)
         .addScaledVector(railLayout.lateral, sideSign * SEAT_RAIL_SLOT_OFFSET)
         .addScaledVector(railLayout.seatDirection, WEAPON_PARKING_OUTWARD_OFFSET);
-      holder.position.y = railLayout.railHeightY;
+      holder.position.y = railLayout.railHeightY - TOKEN_HEIGHT * 0.2;
     } else {
       const seatWorld = new THREE.Vector3();
       anchor.getWorldPosition(seatWorld);


### PR DESCRIPTION
### Motivation
- Fix visual issues where parked capture weapons were floating too high and tilted diagonally relative to player tokens on the Snake & Ladder board.
- Move the bottom player token inward (visually closer to the table) and push the top player token outward toward the top chair so tokens align better with player chairs on portrait screens. 
- Keep token/weapon placement consistent with the game's portrait-oriented visual directions.

### Description
- Updated seat/rest inset constants in `webapp/src/components/SnakeBoard3D.jsx` by changing `TOKEN_REST_RAIL_INSET_BY_SEAT` and `WEAPON_REST_RAIL_INSET_BY_SEAT` to reposition reserve tokens and parked weapons per seat. 
- Reduced forward/outward weapon push by changing `WEAPON_PARKING_OUTWARD_OFFSET` to `TILE_SIZE * 0.12` so parked weapons are closer to token lanes. 
- Flattened parked weapons by zeroing per-weapon pitch in `WEAPON_PARKED_PITCH_BY_KIND` (all weapon pitches set to `0`).
- Lowered parked weapon anchors so weapon holders are placed closer to token/table height by subtracting `TOKEN_HEIGHT * 0.2` from `railLayout.railHeightY` in `updateSeatWeaponDisplays`.
- Increased the seat-direction z bias in `getSeatRailLayout` to pull bottom seats more inward and push top seats more outward by tuning the `restRadius` adjustments for `seatDirection.z`.

### Testing
- Ran the production build with `npm --prefix webapp run build`, which completed successfully (Vite produced size/dynamic-import warnings but the build finished without errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de73f004708329a6a54a043af463d0)