### PR TITLE
Ludo Battle Royal: scale up vehicles, adjust rotors, missiles and truck visuals

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -91,9 +91,9 @@ const GLB_MAGIC = 0x46546c67;
 const GLB_VERSION = 2;
 const GLB_JSON_CHUNK = 0x4e4f534a;
 const GLB_BIN_CHUNK = 0x004e4942;
-const CAPTURE_JET_SIZE_MULTIPLIER = 1.26;
-const CAPTURE_DRONE_SIZE_MULTIPLIER = 0.74;
-const CAPTURE_HELICOPTER_SIZE_MULTIPLIER = 1.104;
+const CAPTURE_JET_SIZE_MULTIPLIER = 1.26 * 1.15;
+const CAPTURE_DRONE_SIZE_MULTIPLIER = 0.74 * 1.15;
+const CAPTURE_HELICOPTER_SIZE_MULTIPLIER = 1.104 * 1.15;
 const CAPTURE_MISSILE_SIZE_MULTIPLIER = 0.9;
 const CAPTURE_AIRCRAFT_SLOW_FACTOR = 1.4;
 const CAPTURE_AIRCRAFT_ORBIT_INWARD_FACTOR = 0.68;
@@ -110,10 +110,10 @@ const CAPTURE_PARK_FORWARD_OFFSET_BY_TYPE = {
   missile: 0.08
 };
 const CAPTURE_PARK_SCALE_BY_TYPE = Object.freeze({
-  fighter: 1.4,
-  helicopter: 1.2,
+  fighter: 1.4 * 1.15,
+  helicopter: 1.2 * 1.15,
   missile: 1.15,
-  drone: 1
+  drone: 1.15
 });
 const CAPTURE_AIR_ATTACK_ID_SET = new Set(['fighterJetAttack', 'helicopterAttack', 'droneAttack', 'missileJavelin']);
 const CAPTURE_ATTACK_TUNING = Object.freeze({
@@ -914,7 +914,7 @@ function createFxPolygon(points, depth, color, roughness = 0.62, metalness = 0.1
   return mesh;
 }
 
-function createCaptureMissileFx() {
+function createCaptureMissileFx({ withTrail = true } = {}) {
   const root = new THREE.Group();
   root.userData.lockCaptureTexture = true;
   const body = addFxCylinder(root, 0.09, 0.1, 1.18, [0, 0, 0], [0, 0, Math.PI / 2], '#d3d8de', 16, 0.3, 0.86);
@@ -936,19 +936,21 @@ function createCaptureMissileFx() {
   addFxBox(root, [0.12, 0.22, 0.024], [-0.44, 0, 0], '#5e7035', 0.28, 0.72);
 
   const trail = [];
-  for (let i = 0; i < 5; i += 1) {
-    trail.push(
-      addFxSphere(
-        root,
-        0.12 + i * 0.03,
-        [-0.84 - i * 0.19, 0, 0],
-        i < 2 ? '#f6af4b' : '#8f989d',
-        i < 2 ? 0.2 : 1,
-        0,
-        true,
-        i < 2 ? 0.8 - i * 0.15 : 0.26 - (i - 2) * 0.04
-      )
-    );
+  if (withTrail) {
+    for (let i = 0; i < 5; i += 1) {
+      trail.push(
+        addFxSphere(
+          root,
+          0.12 + i * 0.03,
+          [-0.84 - i * 0.19, 0, 0],
+          i < 2 ? '#f6af4b' : '#8f989d',
+          i < 2 ? 0.2 : 1,
+          0,
+          true,
+          i < 2 ? 0.8 - i * 0.15 : 0.26 - (i - 2) * 0.04
+        )
+      );
+    }
   }
 
   root.visible = false;
@@ -973,7 +975,18 @@ async function createCaptureMissileTruckFx() {
   cabin.castShadow = true;
   cabin.receiveShadow = true;
   root.add(cabin);
-  addFxBox(root, [0.42, 0.22, 0.86], [0.94, 0.48, 0], '#050608', 0.16, 0.56);
+  const cabinWindow = addFxBox(root, [0.42, 0.22, 0.86], [0.94, 0.48, 0], '#050608', 0.16, 0.56);
+  cabinWindow.material = createCaptureVehicleMaterial('truck', { color: '#050608', roughness: 0.12, metalness: 0.42 });
+
+  const wheelOffsets = [
+    [-0.72, -0.34, -0.56],
+    [-0.72, -0.34, 0.56],
+    [0.72, -0.34, -0.56],
+    [0.72, -0.34, 0.56]
+  ];
+  wheelOffsets.forEach(([x, y, z]) => {
+    addFxCylinder(root, 0.22, 0.22, 0.18, [x, y, z], [Math.PI / 2, 0, 0], '#050608', 16, 0.9, 0.08);
+  });
 
   const launcher = new THREE.Group();
   launcher.position.set(-0.12, 0.96, 0);
@@ -1001,9 +1014,9 @@ async function createCaptureMissileTruckFx() {
   let reloadMissileLocalPosition = null;
   let reloadMissileLocalRotation = null;
   missileOffsets.forEach((offset, missileIndex) => {
-    const missile = createCaptureMissileFx();
+    const missile = createCaptureMissileFx({ withTrail: false });
     missile.root.visible = true;
-    missile.root.scale.setScalar(0.92);
+    missile.root.scale.set(0.92, 1.14, 1.14);
     missile.root.position.set(offset[0], offset[1], offset[2]);
     missile.root.rotation.set(0, 0, Math.PI / 3.4);
     if (missileIndex === 1) {
@@ -1018,7 +1031,7 @@ async function createCaptureMissileTruckFx() {
   });
 
   root.add(launcher);
-  root.scale.setScalar(1.15);
+  root.scale.setScalar(1.15 * 1.15);
   root.visible = true;
   return { root, launcher, reloadMissile, reloadMissileLocalPosition, reloadMissileLocalRotation };
 }
@@ -6538,12 +6551,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       const appliedDeltaMs = Math.min(deltaMs, maxFrameTime);
       lastRenderTime = now - Math.max(0, deltaMs - appliedDeltaMs);
       const delta = appliedDeltaMs / 1000;
-      parkedCaptureVehiclesRef.current.forEach((entry) => {
-        spinHelicopterRotorAssembly(entry, delta);
-        if (entry?.dronePropeller?.isObject3D) {
-          entry.dronePropeller.rotation.x += delta * 40;
-        }
-      });
+      // Keep parked aircraft static; rotor/propeller animation only runs during active strikes.
 
       const state = stateRef.current;
       if (state?.animation?.active) {
@@ -6957,7 +6965,10 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         parkedReloadMissileLocalPosition = parkedEntry?.reloadMissileLocalPosition ?? null;
         parkedReloadMissileLocalRotation = parkedEntry?.reloadMissileLocalRotation ?? null;
         stopCaptureVehicleSounds();
-        if (isHelicopterAttack) playHelicopterSound();
+        if (isHelicopterAttack) {
+          stopFighterJetSound();
+          playHelicopterSound();
+        }
         if (isDroneAttack) playDroneSound();
         if (isFighterJetAttack) playFighterJetSound();
         const primaryFx =
@@ -6967,13 +6978,13 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             ? await createCaptureHelicopterFx()
             : resolvedCaptureAnimationId === 'fighterJetAttack'
             ? await createCaptureJetFx()
-            : createCaptureMissileFx();
+            : createCaptureMissileFx({ withTrail: true });
         if (isFighterJetAttack || isHelicopterAttack) {
           fitCaptureVehicleToPlayerKing(primaryFx.root, attackerPlayer);
         }
         const jetMissiles =
           resolvedCaptureAnimationId === 'fighterJetAttack' || resolvedCaptureAnimationId === 'helicopterAttack'
-            ? [createCaptureMissileFx(), createCaptureMissileFx()]
+            ? [createCaptureMissileFx({ withTrail: true }), createCaptureMissileFx({ withTrail: true })]
             : [];
         const explosion = createCaptureExplosionFx();
         scene.add(primaryFx.root);
@@ -7277,7 +7288,9 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             primaryFx.root.position.copy(pos);
             primaryFx.root.quaternion.setFromUnitVectors(MISSILE_FORWARD, dir);
             trackAttackCamera(pos, dynamicTo, u);
-            const isVerticalImpactVehicle = selectedCaptureAnimationId === 'missileJavelin';
+            const isVerticalImpactVehicle =
+              selectedCaptureAnimationId === 'missileJavelin' ||
+              selectedCaptureAnimationId === 'droneAttack';
             if (isVerticalImpactVehicle && u > phaseSplit) {
               primaryFx.root.quaternion.setFromUnitVectors(MISSILE_FORWARD, new THREE.Vector3(0, -1, 0));
             }
@@ -7375,6 +7388,10 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
                   dynamicTo,
                   clamp(missileU + 0.03, 0, 1)
                 );
+                if (missileU >= 0.74) {
+                  missileNext.x = missilePos.x;
+                  missileNext.z = missilePos.z;
+                }
                 const missileDir = missileNext.clone().sub(missilePos).normalize();
                 jetMissile.root.visible = true;
                 jetMissile.root.position.copy(missilePos);

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -957,6 +957,53 @@ function createCaptureMissileFx({ withTrail = true } = {}) {
   return { root, trail };
 }
 
+function createCaptureTruckDroneFx({ parked = false, withTrail = true } = {}) {
+  const droneCore = createCaptureMissileFx({ withTrail });
+  const { root } = droneCore;
+  const triangleBody = [];
+  const deltaWing = createFxPolygon(
+    [
+      [-0.46, -0.9],
+      [0.42, 0],
+      [-0.46, 0.9]
+    ],
+    0.05,
+    '#7f888f',
+    0.62,
+    0.18
+  );
+  deltaWing.position.set(-0.14, -0.02, 0);
+  root.add(deltaWing);
+  triangleBody.push(deltaWing);
+
+  const upperSpine = createFxPolygon(
+    [
+      [-0.24, -0.08],
+      [0.44, 0],
+      [-0.24, 0.08]
+    ],
+    0.04,
+    '#687178',
+    0.58,
+    0.2
+  );
+  upperSpine.position.set(0.08, 0.08, 0);
+  root.add(upperSpine);
+  triangleBody.push(upperSpine);
+
+  triangleBody.forEach((node) => {
+    node.visible = !parked;
+  });
+
+  const setTriangularBodyVisible = (visible) => {
+    triangleBody.forEach((node) => {
+      node.visible = !!visible;
+    });
+  };
+
+  return { ...droneCore, triangleBody, setTriangularBodyVisible };
+}
+
 async function createCaptureMissileTruckFx() {
   const root = new THREE.Group();
   root.userData.lockCaptureTexture = true;
@@ -1007,22 +1054,23 @@ async function createCaptureMissileTruckFx() {
 
   const missileOffsets = [
     [-0.42, 0.4, -0.3],
-    [0, 0.42, 0],
     [0.42, 0.4, 0.3]
   ];
   let reloadMissile = null;
   let reloadMissileLocalPosition = null;
   let reloadMissileLocalRotation = null;
+  let reloadDroneSetTriangularBodyVisible = null;
   missileOffsets.forEach((offset, missileIndex) => {
-    const missile = createCaptureMissileFx({ withTrail: false });
+    const missile = createCaptureTruckDroneFx({ parked: true, withTrail: false });
     missile.root.visible = true;
     missile.root.scale.set(0.92, 1.14, 1.14);
     missile.root.position.set(offset[0], offset[1], offset[2]);
     missile.root.rotation.set(0, 0, Math.PI / 3.4);
-    if (missileIndex === 1) {
+    if (missileIndex === 0) {
       reloadMissile = missile.root;
       reloadMissileLocalPosition = missile.root.position.clone();
       reloadMissileLocalRotation = missile.root.rotation.clone();
+      reloadDroneSetTriangularBodyVisible = missile.setTriangularBodyVisible;
     }
     const strut = addFxBox(launcher, [0.06, 0.22, 0.06], [offset[0] - 0.08, 0.18, offset[2]], '#111418', 0.56, 0.28);
     strut.rotation.z = -Math.PI * 0.24;
@@ -1033,7 +1081,14 @@ async function createCaptureMissileTruckFx() {
   root.add(launcher);
   root.scale.setScalar(1.15 * 1.15);
   root.visible = true;
-  return { root, launcher, reloadMissile, reloadMissileLocalPosition, reloadMissileLocalRotation };
+  return {
+    root,
+    launcher,
+    reloadMissile,
+    reloadMissileLocalPosition,
+    reloadMissileLocalRotation,
+    reloadDroneSetTriangularBodyVisible
+  };
 }
 
 async function createCaptureDroneFx() {
@@ -4652,6 +4707,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         reloadMissile: missileFx.reloadMissile ?? null,
         reloadMissileLocalPosition: missileFx.reloadMissileLocalPosition ?? null,
         reloadMissileLocalRotation: missileFx.reloadMissileLocalRotation ?? null,
+        reloadDroneSetTriangularBodyVisible: missileFx.reloadDroneSetTriangularBodyVisible ?? null,
         jetPark,
         helicopterPark,
         dronePark,
@@ -6917,6 +6973,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         let parkedReloadMissile = null;
         let parkedReloadMissileLocalPosition = null;
         let parkedReloadMissileLocalRotation = null;
+        let parkedReloadDroneSetTriangularBodyVisible = null;
         let parkedLaunch = null;
         let isMissileTruckAttack = false;
         try {
@@ -6964,6 +7021,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         parkedReloadMissile = parkedEntry?.reloadMissile ?? null;
         parkedReloadMissileLocalPosition = parkedEntry?.reloadMissileLocalPosition ?? null;
         parkedReloadMissileLocalRotation = parkedEntry?.reloadMissileLocalRotation ?? null;
+        parkedReloadDroneSetTriangularBodyVisible = parkedEntry?.reloadDroneSetTriangularBodyVisible ?? null;
         stopCaptureVehicleSounds();
         if (isHelicopterAttack) {
           stopFighterJetSound();
@@ -6978,7 +7036,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             ? await createCaptureHelicopterFx()
             : resolvedCaptureAnimationId === 'fighterJetAttack'
             ? await createCaptureJetFx()
-            : createCaptureMissileFx({ withTrail: true });
+            : createCaptureTruckDroneFx({ parked: false, withTrail: true });
         if (isFighterJetAttack || isHelicopterAttack) {
           fitCaptureVehicleToPlayerKing(primaryFx.root, attackerPlayer);
         }
@@ -7018,7 +7076,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             ? parkedEntry?.helicopter?.scale
             : resolvedCaptureAnimationId === 'droneAttack'
             ? parkedEntry?.drone?.scale
-            : parkedEntry?.missile?.scale;
+            : parkedEntry?.reloadMissile?.scale;
         if (parkedScale?.isVector3) {
           primaryFx.root.scale.copy(parkedScale);
         } else {
@@ -7049,6 +7107,9 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           launchAnchor.copy(parkedMissileWorld);
           if (Number.isFinite(tableSurfaceY)) {
             launchAnchor.y = Math.max(launchAnchor.y, tableSurfaceY + 0.014);
+          }
+          if (typeof parkedReloadDroneSetTriangularBodyVisible === 'function') {
+            parkedReloadDroneSetTriangularBodyVisible(false);
           }
           parkedReloadMissile.visible = false;
         } else if (parkedVehicleToRestore?.isObject3D) {
@@ -7530,6 +7591,9 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
                 parkedReloadMissileLocalRotation.z
               );
             }
+            if (typeof parkedReloadDroneSetTriangularBodyVisible === 'function') {
+              parkedReloadDroneSetTriangularBodyVisible(false);
+            }
             parkedReloadMissile.visible = true;
           }
           if (primaryFx.root.parent) primaryFx.root.parent.remove(primaryFx.root);
@@ -7554,6 +7618,9 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
                 parkedReloadMissileLocalRotation.y,
                 parkedReloadMissileLocalRotation.z
               );
+            }
+            if (typeof parkedReloadDroneSetTriangularBodyVisible === 'function') {
+              parkedReloadDroneSetTriangularBodyVisible(false);
             }
             parkedReloadMissile.visible = true;
           }


### PR DESCRIPTION
### Motivation
- Improve visibility and realism of capture animations by enlarging aircraft/vehicle models and making missile strikes behave more consistently. 
- Keep parked vehicles visually stable (no idle rotor spin) and avoid overlapping audio between helicopter and jet fly loops. 
- Make truck-mounted missiles look and behave like stored payloads (thicker, hidden trails while parked) and ensure air-launched weapons hit targets vertically.

### Description
- Increased size multipliers for jet, drone and helicopter and bumped parked display scales for fighter/helicopter/drone/truck to ~+15% by updating capture size/park scale constants and truck root scale in `webapp/src/pages/Games/LudoBattleRoyal.jsx`.
- Made parked aircraft static by removing idle rotor/propeller updates from the main render loop and kept rotor/propeller spin only inside active capture/strike animation paths.
- Added a configurable `withTrail` flag to `createCaptureMissileFx` and disabled trails for truck-mounted missiles while keeping launch missiles' trails enabled, and increased truck-mounted missile thickness by scaling missile root non-uniformly.
- Updated missile flight terminal behavior so missiles (including drone strikes) snap into a vertical terminal descent by locking X/Z during the final arc, and ensured helicopter audio start explicitly stops the fighter-jet loop to avoid sound overlap.
- Improved truck visuals by making the cabin/window material darker and adding black tyres rendered via `addFxCylinder` calls.

### Testing
- Built the web app with `npm -C webapp run -s build` and the production build completed successfully (Vite emitted non-blocking chunk-size/dynamic-import warnings). 
- No unit tests were added or changed; no automated game-play tests were run in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df33a1bd108329b3d5ed2af2f427fb)