### PR TITLE
Adjust capture vehicle sizing, add missile-truck payloads/wheels and refine attack animations

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1007,16 +1007,16 @@ async function createCaptureMissileTruckFx() {
 
   const missileOffsets = [
     [-0.42, 0.4, -0.3],
+    [0, 0.42, 0],
     [0.42, 0.4, 0.3]
   ];
-  const parkedDronePayloads = [];
   let reloadMissile = null;
   let reloadMissileLocalPosition = null;
   let reloadMissileLocalRotation = null;
   missileOffsets.forEach((offset, missileIndex) => {
     const missile = createCaptureMissileFx({ withTrail: false });
     missile.root.visible = true;
-    missile.root.scale.set(0.92, 1.14, 1.14);
+    missile.root.scale.setScalar(0.92);
     missile.root.position.set(offset[0], offset[1], offset[2]);
     missile.root.rotation.set(0, 0, Math.PI / 3.4);
     if (missileIndex === 1) {
@@ -1024,7 +1024,6 @@ async function createCaptureMissileTruckFx() {
       reloadMissileLocalPosition = missile.root.position.clone();
       reloadMissileLocalRotation = missile.root.rotation.clone();
     }
-    parkedDronePayloads.push(missile.root);
     const strut = addFxBox(launcher, [0.06, 0.22, 0.06], [offset[0] - 0.08, 0.18, offset[2]], '#111418', 0.56, 0.28);
     strut.rotation.z = -Math.PI * 0.24;
     strut.material = createCaptureVehicleMaterial('truck', { color: '#111418', roughness: 0.56, metalness: 0.28 });
@@ -1037,10 +1036,41 @@ async function createCaptureMissileTruckFx() {
   return {
     root,
     launcher,
-    parkedDronePayloads,
     reloadMissile,
     reloadMissileLocalPosition,
     reloadMissileLocalRotation
+  };
+}
+
+async function createCaptureDroneLauncherTruckFx() {
+  const truckFx = await createCaptureMissileTruckFx();
+  if (!truckFx?.root || !truckFx?.launcher) return truckFx;
+  const parkedDronePayloads = [];
+  const preserve = new Set([truckFx.reloadMissile]);
+  [...truckFx.launcher.children].forEach((child) => {
+    if (!child?.isObject3D) return;
+    const isMissilePayload = child.userData?.lockCaptureTexture === true;
+    if (!isMissilePayload) return;
+    if (!preserve.has(child)) {
+      truckFx.launcher.remove(child);
+    }
+  });
+  const droneOffsets = [
+    [-0.42, 0.4, -0.3],
+    [0.42, 0.4, 0.3]
+  ];
+  droneOffsets.forEach((offset) => {
+    const dronePayload = createCaptureMissileFx({ withTrail: false });
+    dronePayload.root.visible = true;
+    dronePayload.root.scale.set(0.92, 1.14, 1.14);
+    dronePayload.root.position.set(offset[0], offset[1], offset[2]);
+    dronePayload.root.rotation.set(0, 0, Math.PI / 3.4);
+    parkedDronePayloads.push(dronePayload.root);
+    truckFx.launcher.add(dronePayload.root);
+  });
+  return {
+    ...truckFx,
+    parkedDronePayloads
   };
 }
 
@@ -4587,7 +4617,8 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         CAPTURE_ANIMATION_OPTIONS[optionIndex]?.id ?? CAPTURE_ANIMATION_OPTIONS[0]?.id ?? 'missileJavelin';
       if (entry?.jet) entry.jet.visible = selectedCaptureAnimationId === 'fighterJetAttack';
       if (entry?.helicopter) entry.helicopter.visible = selectedCaptureAnimationId === 'helicopterAttack';
-      if (entry?.drone) entry.drone.visible = selectedCaptureAnimationId === 'droneAttack';
+      if (entry?.drone) entry.drone.visible = false;
+      if (entry?.droneTruck) entry.droneTruck.visible = selectedCaptureAnimationId === 'droneAttack';
       if (entry?.missile) entry.missile.visible = selectedCaptureAnimationId === 'missileJavelin';
     });
   }, [aiLoadoutByPlayer]);
@@ -4600,6 +4631,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       entry?.helicopter?.parent?.remove?.(entry.helicopter);
       entry?.drone?.parent?.remove?.(entry.drone);
       entry?.missile?.parent?.remove?.(entry.missile);
+      entry?.droneTruck?.parent?.remove?.(entry.droneTruck);
     });
     parkedCaptureVehiclesRef.current.clear();
 
@@ -4612,7 +4644,9 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       const droneFx = await createCaptureDroneFx();
       // eslint-disable-next-line no-await-in-loop
       const missileFx = await createCaptureMissileTruckFx();
-      if (!jetFx?.root || !helicopterFx?.root || !droneFx?.root || !missileFx?.root) continue;
+      // eslint-disable-next-line no-await-in-loop
+      const droneTruckFx = await createCaptureDroneLauncherTruckFx();
+      if (!jetFx?.root || !helicopterFx?.root || !droneFx?.root || !missileFx?.root || !droneTruckFx?.root) continue;
       fitCaptureVehicleToPlayerKing(jetFx.root, playerIndex);
       fitCaptureVehicleToPlayerKing(helicopterFx.root, playerIndex);
       fitCaptureVehicleToPlayerKing(droneFx.root, playerIndex);
@@ -4620,36 +4654,44 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       fitObjectToTargetSize(helicopterFx.root, CAPTURE_PARK_BOX_TARGET_SIZE);
       fitObjectToTargetSize(droneFx.root, CAPTURE_PARK_BOX_TARGET_SIZE);
       fitObjectToTargetSize(missileFx.root, CAPTURE_PARK_TRUCK_BOX_TARGET_SIZE);
+      fitObjectToTargetSize(droneTruckFx.root, CAPTURE_PARK_TRUCK_BOX_TARGET_SIZE);
       jetFx.root.scale.multiplyScalar(CAPTURE_PARK_SCALE_BY_TYPE.fighter);
       helicopterFx.root.scale.multiplyScalar(CAPTURE_PARK_SCALE_BY_TYPE.helicopter);
       missileFx.root.scale.multiplyScalar(CAPTURE_PARK_SCALE_BY_TYPE.missile);
+      droneTruckFx.root.scale.multiplyScalar(CAPTURE_PARK_SCALE_BY_TYPE.missile);
       const jetPark = resolveCaptureParkingAnchors(playerIndex, 'fighter');
       const helicopterPark = resolveCaptureParkingAnchors(playerIndex, 'helicopter');
       const dronePark = resolveCaptureParkingAnchors(playerIndex, 'drone');
       const missilePark = resolveCaptureParkingAnchors(playerIndex, 'missile');
-      if (!jetPark || !helicopterPark || !dronePark || !missilePark) continue;
+      const droneTruckPark = resolveCaptureParkingAnchors(playerIndex, 'missile');
+      if (!jetPark || !helicopterPark || !dronePark || !missilePark || !droneTruckPark) continue;
       jetFx.root.position.copy(jetPark);
       helicopterFx.root.position.copy(helicopterPark);
       droneFx.root.position.copy(dronePark);
       missileFx.root.position.copy(missilePark);
+      droneTruckFx.root.position.copy(droneTruckPark);
       const tableSurfaceY = arena.tableInfo?.surfaceY;
       alignObjectBottomToY(jetFx.root, tableSurfaceY);
       alignObjectBottomToY(helicopterFx.root, tableSurfaceY);
       alignObjectBottomToY(droneFx.root, tableSurfaceY);
       alignObjectBottomToY(missileFx.root, tableSurfaceY);
+      alignObjectBottomToY(droneTruckFx.root, tableSurfaceY);
       orientCaptureVehicleTowardBoardCenter(jetFx.root, arena.boardLookTarget);
       orientCaptureVehicleTowardBoardCenter(helicopterFx.root, arena.boardLookTarget);
       orientCaptureVehicleTowardBoardCenter(droneFx.root, arena.boardLookTarget);
       orientCaptureVehicleTowardBoardCenter(missileFx.root, arena.boardLookTarget);
+      orientCaptureVehicleTowardBoardCenter(droneTruckFx.root, arena.boardLookTarget);
       arena.scene.add(jetFx.root);
       arena.scene.add(helicopterFx.root);
       arena.scene.add(droneFx.root);
       arena.scene.add(missileFx.root);
+      arena.scene.add(droneTruckFx.root);
       const parkedEntry = {
         jet: jetFx.root,
         helicopter: helicopterFx.root,
         drone: droneFx.root,
         missile: missileFx.root,
+        droneTruck: droneTruckFx.root,
         helicopterRotor: helicopterFx.rotor ?? null,
         helicopterTailRotor: helicopterFx.tailRotor ?? null,
         helicopterRotorNodes: Array.isArray(helicopterFx.rotorNodes) ? helicopterFx.rotorNodes : [],
@@ -4657,7 +4699,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         helicopterTailRotorAxis: helicopterFx.tailRotorAxis ?? new THREE.Vector3(1, 0, 0),
         dronePropeller: droneFx.propeller ?? null,
         missileLauncher: missileFx.launcher ?? null,
-        parkedDronePayloads: Array.isArray(missileFx.parkedDronePayloads) ? missileFx.parkedDronePayloads : [],
+        droneTruckPayloads: Array.isArray(droneTruckFx.parkedDronePayloads) ? droneTruckFx.parkedDronePayloads : [],
         nextDronePayloadIndex: 0,
         reloadMissile: missileFx.reloadMissile ?? null,
         reloadMissileLocalPosition: missileFx.reloadMissileLocalPosition ?? null,
@@ -4665,7 +4707,8 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         jetPark,
         helicopterPark,
         dronePark,
-        missilePark
+        missilePark,
+        droneTruckPark
       };
       parkedCaptureVehiclesRef.current.set(playerIndex, {
         ...parkedEntry
@@ -6779,6 +6822,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         entry?.helicopter?.parent?.remove?.(entry.helicopter);
         entry?.drone?.parent?.remove?.(entry.drone);
         entry?.missile?.parent?.remove?.(entry.missile);
+        entry?.droneTruck?.parent?.remove?.(entry.droneTruck);
       });
       parkedCaptureVehiclesRef.current.clear();
       arenaRef.current = null;
@@ -6958,7 +7002,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             : isHelicopterAttack
             ? parkedEntry?.helicopterPark?.clone?.()
             : isDroneAttack
-            ? parkedEntry?.dronePark?.clone?.()
+            ? parkedEntry?.droneTruckPark?.clone?.() ?? parkedEntry?.dronePark?.clone?.()
             : isMissileTruckAttack
             ? parkedEntry?.missilePark?.clone?.()
             : null;
@@ -6968,15 +7012,15 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             : resolvedCaptureAnimationId === 'helicopterAttack'
             ? parkedEntry?.helicopter
             : resolvedCaptureAnimationId === 'droneAttack'
-            ? parkedEntry?.drone
+            ? parkedEntry?.droneTruck ?? parkedEntry?.drone
             : resolvedCaptureAnimationId === 'missileJavelin'
             ? parkedEntry?.missile
             : null;
         parkedReloadMissile = parkedEntry?.reloadMissile ?? null;
         parkedReloadMissileLocalPosition = parkedEntry?.reloadMissileLocalPosition ?? null;
         parkedReloadMissileLocalRotation = parkedEntry?.reloadMissileLocalRotation ?? null;
-        if (isMissileTruckAttack) {
-          const parkedPayloads = Array.isArray(parkedEntry?.parkedDronePayloads) ? parkedEntry.parkedDronePayloads : [];
+        if (isDroneAttack) {
+          const parkedPayloads = Array.isArray(parkedEntry?.droneTruckPayloads) ? parkedEntry.droneTruckPayloads : [];
           if (parkedPayloads.length > 0) {
             const nextPayloadIndex = Number.isFinite(parkedEntry?.nextDronePayloadIndex)
               ? parkedEntry.nextDronePayloadIndex
@@ -6990,7 +7034,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           stopFighterJetSound();
           playHelicopterSound();
         }
-        if (isDroneAttack || isMissileTruckAttack) playDroneSound();
+        if (isDroneAttack) playDroneSound();
         if (isFighterJetAttack) playFighterJetSound();
         const primaryFx =
           resolvedCaptureAnimationId === 'droneAttack'
@@ -6999,7 +7043,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             ? await createCaptureHelicopterFx()
             : resolvedCaptureAnimationId === 'fighterJetAttack'
             ? await createCaptureJetFx()
-            : await createCaptureDroneFx();
+            : createCaptureMissileFx({ withTrail: true });
         if (isFighterJetAttack || isHelicopterAttack) {
           fitCaptureVehicleToPlayerKing(primaryFx.root, attackerPlayer);
         }
@@ -7064,15 +7108,14 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           resolveTokenAnchorPoint(attackerToken, startPosition, 0) ||
           startPosition.clone();
         const launchAnchor = tokenWorldPos.clone().add(new THREE.Vector3(0, bishopHeight * 0.52, 0));
-        if (isMissileTruckAttack && (parkedDronePayload?.isObject3D || parkedReloadMissile?.isObject3D)) {
+        if (isDroneAttack && parkedDronePayload?.isObject3D) {
           const parkedMissileWorld = new THREE.Vector3();
-          const activePayload = parkedDronePayload?.isObject3D ? parkedDronePayload : parkedReloadMissile;
-          activePayload.getWorldPosition(parkedMissileWorld);
+          parkedDronePayload.getWorldPosition(parkedMissileWorld);
           launchAnchor.copy(parkedMissileWorld);
           if (Number.isFinite(tableSurfaceY)) {
             launchAnchor.y = Math.max(launchAnchor.y, tableSurfaceY + 0.014);
           }
-          activePayload.visible = false;
+          parkedDronePayload.visible = false;
         } else if (parkedVehicleToRestore?.isObject3D) {
           parkedVehicleToRestore.visible = false;
         }
@@ -7541,21 +7584,23 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             parkedVehicleToRestore.position.y = tableSurfaceY + 0.002;
             orientCaptureVehicleTowardBoardCenter(parkedVehicleToRestore, boardLookTargetRef.current ?? new THREE.Vector3());
           }
-          if (isMissileTruckAttack && (parkedDronePayload?.isObject3D || parkedReloadMissile?.isObject3D)) {
+          if (isDroneAttack && parkedDronePayload?.isObject3D) {
             if (parkedDronePayload?.isObject3D) {
               parkedDronePayload.visible = true;
             }
-            if (parkedReloadMissile?.isObject3D && parkedReloadMissileLocalPosition?.isVector3) {
+          }
+          if (isMissileTruckAttack && parkedReloadMissile?.isObject3D) {
+            if (parkedReloadMissileLocalPosition?.isVector3) {
               parkedReloadMissile.position.copy(parkedReloadMissileLocalPosition);
             }
-            if (parkedReloadMissile?.isObject3D && parkedReloadMissileLocalRotation) {
+            if (parkedReloadMissileLocalRotation) {
               parkedReloadMissile.rotation.set(
                 parkedReloadMissileLocalRotation.x,
                 parkedReloadMissileLocalRotation.y,
                 parkedReloadMissileLocalRotation.z
               );
             }
-            if (parkedReloadMissile?.isObject3D) parkedReloadMissile.visible = true;
+            parkedReloadMissile.visible = true;
           }
           if (primaryFx.root.parent) primaryFx.root.parent.remove(primaryFx.root);
           jetMissiles.forEach((entry) => {
@@ -7569,21 +7614,23 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         } catch (error) {
           stopCaptureVehicleSounds();
           if (parkedVehicleToRestore?.isObject3D) parkedVehicleToRestore.visible = true;
-          if (isMissileTruckAttack && (parkedDronePayload?.isObject3D || parkedReloadMissile?.isObject3D)) {
+          if (isDroneAttack && parkedDronePayload?.isObject3D) {
             if (parkedDronePayload?.isObject3D) {
               parkedDronePayload.visible = true;
             }
-            if (parkedReloadMissile?.isObject3D && parkedReloadMissileLocalPosition?.isVector3) {
+          }
+          if (isMissileTruckAttack && parkedReloadMissile?.isObject3D) {
+            if (parkedReloadMissileLocalPosition?.isVector3) {
               parkedReloadMissile.position.copy(parkedReloadMissileLocalPosition);
             }
-            if (parkedReloadMissile?.isObject3D && parkedReloadMissileLocalRotation) {
+            if (parkedReloadMissileLocalRotation) {
               parkedReloadMissile.rotation.set(
                 parkedReloadMissileLocalRotation.x,
                 parkedReloadMissileLocalRotation.y,
                 parkedReloadMissileLocalRotation.z
               );
             }
-            if (parkedReloadMissile?.isObject3D) parkedReloadMissile.visible = true;
+            parkedReloadMissile.visible = true;
           }
           captureFxRef.current = null;
           resolve();

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -91,9 +91,9 @@ const GLB_MAGIC = 0x46546c67;
 const GLB_VERSION = 2;
 const GLB_JSON_CHUNK = 0x4e4f534a;
 const GLB_BIN_CHUNK = 0x004e4942;
-const CAPTURE_JET_SIZE_MULTIPLIER = 1.26;
-const CAPTURE_DRONE_SIZE_MULTIPLIER = 0.74;
-const CAPTURE_HELICOPTER_SIZE_MULTIPLIER = 1.104;
+const CAPTURE_JET_SIZE_MULTIPLIER = 1.26 * 1.15;
+const CAPTURE_DRONE_SIZE_MULTIPLIER = 0.74 * 1.15;
+const CAPTURE_HELICOPTER_SIZE_MULTIPLIER = 1.104 * 1.15;
 const CAPTURE_MISSILE_SIZE_MULTIPLIER = 0.9;
 const CAPTURE_AIRCRAFT_SLOW_FACTOR = 1.4;
 const CAPTURE_AIRCRAFT_ORBIT_INWARD_FACTOR = 0.68;
@@ -110,10 +110,10 @@ const CAPTURE_PARK_FORWARD_OFFSET_BY_TYPE = {
   missile: 0.08
 };
 const CAPTURE_PARK_SCALE_BY_TYPE = Object.freeze({
-  fighter: 1.4,
-  helicopter: 1.2,
+  fighter: 1.4 * 1.15,
+  helicopter: 1.2 * 1.15,
   missile: 1.15,
-  drone: 1
+  drone: 1.15
 });
 const CAPTURE_AIR_ATTACK_ID_SET = new Set(['fighterJetAttack', 'helicopterAttack', 'droneAttack', 'missileJavelin']);
 const CAPTURE_ATTACK_TUNING = Object.freeze({
@@ -914,7 +914,7 @@ function createFxPolygon(points, depth, color, roughness = 0.62, metalness = 0.1
   return mesh;
 }
 
-function createCaptureMissileFx() {
+function createCaptureMissileFx({ withTrail = true } = {}) {
   const root = new THREE.Group();
   root.userData.lockCaptureTexture = true;
   const body = addFxCylinder(root, 0.09, 0.1, 1.18, [0, 0, 0], [0, 0, Math.PI / 2], '#d3d8de', 16, 0.3, 0.86);
@@ -936,19 +936,21 @@ function createCaptureMissileFx() {
   addFxBox(root, [0.12, 0.22, 0.024], [-0.44, 0, 0], '#5e7035', 0.28, 0.72);
 
   const trail = [];
-  for (let i = 0; i < 5; i += 1) {
-    trail.push(
-      addFxSphere(
-        root,
-        0.12 + i * 0.03,
-        [-0.84 - i * 0.19, 0, 0],
-        i < 2 ? '#f6af4b' : '#8f989d',
-        i < 2 ? 0.2 : 1,
-        0,
-        true,
-        i < 2 ? 0.8 - i * 0.15 : 0.26 - (i - 2) * 0.04
-      )
-    );
+  if (withTrail) {
+    for (let i = 0; i < 5; i += 1) {
+      trail.push(
+        addFxSphere(
+          root,
+          0.12 + i * 0.03,
+          [-0.84 - i * 0.19, 0, 0],
+          i < 2 ? '#f6af4b' : '#8f989d',
+          i < 2 ? 0.2 : 1,
+          0,
+          true,
+          i < 2 ? 0.8 - i * 0.15 : 0.26 - (i - 2) * 0.04
+        )
+      );
+    }
   }
 
   root.visible = false;
@@ -973,7 +975,18 @@ async function createCaptureMissileTruckFx() {
   cabin.castShadow = true;
   cabin.receiveShadow = true;
   root.add(cabin);
-  addFxBox(root, [0.42, 0.22, 0.86], [0.94, 0.48, 0], '#050608', 0.16, 0.56);
+  const cabinWindow = addFxBox(root, [0.42, 0.22, 0.86], [0.94, 0.48, 0], '#050608', 0.16, 0.56);
+  cabinWindow.material = createCaptureVehicleMaterial('truck', { color: '#050608', roughness: 0.12, metalness: 0.42 });
+
+  const wheelOffsets = [
+    [-0.72, -0.34, -0.56],
+    [-0.72, -0.34, 0.56],
+    [0.72, -0.34, -0.56],
+    [0.72, -0.34, 0.56]
+  ];
+  wheelOffsets.forEach(([x, y, z]) => {
+    addFxCylinder(root, 0.22, 0.22, 0.18, [x, y, z], [Math.PI / 2, 0, 0], '#050608', 16, 0.9, 0.08);
+  });
 
   const launcher = new THREE.Group();
   launcher.position.set(-0.12, 0.96, 0);
@@ -994,16 +1007,16 @@ async function createCaptureMissileTruckFx() {
 
   const missileOffsets = [
     [-0.42, 0.4, -0.3],
-    [0, 0.42, 0],
     [0.42, 0.4, 0.3]
   ];
+  const parkedDronePayloads = [];
   let reloadMissile = null;
   let reloadMissileLocalPosition = null;
   let reloadMissileLocalRotation = null;
   missileOffsets.forEach((offset, missileIndex) => {
-    const missile = createCaptureMissileFx();
+    const missile = createCaptureMissileFx({ withTrail: false });
     missile.root.visible = true;
-    missile.root.scale.setScalar(0.92);
+    missile.root.scale.set(0.92, 1.14, 1.14);
     missile.root.position.set(offset[0], offset[1], offset[2]);
     missile.root.rotation.set(0, 0, Math.PI / 3.4);
     if (missileIndex === 1) {
@@ -1011,6 +1024,7 @@ async function createCaptureMissileTruckFx() {
       reloadMissileLocalPosition = missile.root.position.clone();
       reloadMissileLocalRotation = missile.root.rotation.clone();
     }
+    parkedDronePayloads.push(missile.root);
     const strut = addFxBox(launcher, [0.06, 0.22, 0.06], [offset[0] - 0.08, 0.18, offset[2]], '#111418', 0.56, 0.28);
     strut.rotation.z = -Math.PI * 0.24;
     strut.material = createCaptureVehicleMaterial('truck', { color: '#111418', roughness: 0.56, metalness: 0.28 });
@@ -1018,9 +1032,16 @@ async function createCaptureMissileTruckFx() {
   });
 
   root.add(launcher);
-  root.scale.setScalar(1.15);
+  root.scale.setScalar(1.15 * 1.15);
   root.visible = true;
-  return { root, launcher, reloadMissile, reloadMissileLocalPosition, reloadMissileLocalRotation };
+  return {
+    root,
+    launcher,
+    parkedDronePayloads,
+    reloadMissile,
+    reloadMissileLocalPosition,
+    reloadMissileLocalRotation
+  };
 }
 
 async function createCaptureDroneFx() {
@@ -4636,6 +4657,8 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         helicopterTailRotorAxis: helicopterFx.tailRotorAxis ?? new THREE.Vector3(1, 0, 0),
         dronePropeller: droneFx.propeller ?? null,
         missileLauncher: missileFx.launcher ?? null,
+        parkedDronePayloads: Array.isArray(missileFx.parkedDronePayloads) ? missileFx.parkedDronePayloads : [],
+        nextDronePayloadIndex: 0,
         reloadMissile: missileFx.reloadMissile ?? null,
         reloadMissileLocalPosition: missileFx.reloadMissileLocalPosition ?? null,
         reloadMissileLocalRotation: missileFx.reloadMissileLocalRotation ?? null,
@@ -6538,12 +6561,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       const appliedDeltaMs = Math.min(deltaMs, maxFrameTime);
       lastRenderTime = now - Math.max(0, deltaMs - appliedDeltaMs);
       const delta = appliedDeltaMs / 1000;
-      parkedCaptureVehiclesRef.current.forEach((entry) => {
-        spinHelicopterRotorAssembly(entry, delta);
-        if (entry?.dronePropeller?.isObject3D) {
-          entry.dronePropeller.rotation.x += delta * 40;
-        }
-      });
+      // Keep parked aircraft static; rotor/propeller animation only runs during active strikes.
 
       const state = stateRef.current;
       if (state?.animation?.active) {
@@ -6906,6 +6924,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     new Promise((resolve) => {
       void (async () => {
         let parkedVehicleToRestore = null;
+        let parkedDronePayload = null;
         let parkedReloadMissile = null;
         let parkedReloadMissileLocalPosition = null;
         let parkedReloadMissileLocalRotation = null;
@@ -6956,9 +6975,22 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         parkedReloadMissile = parkedEntry?.reloadMissile ?? null;
         parkedReloadMissileLocalPosition = parkedEntry?.reloadMissileLocalPosition ?? null;
         parkedReloadMissileLocalRotation = parkedEntry?.reloadMissileLocalRotation ?? null;
+        if (isMissileTruckAttack) {
+          const parkedPayloads = Array.isArray(parkedEntry?.parkedDronePayloads) ? parkedEntry.parkedDronePayloads : [];
+          if (parkedPayloads.length > 0) {
+            const nextPayloadIndex = Number.isFinite(parkedEntry?.nextDronePayloadIndex)
+              ? parkedEntry.nextDronePayloadIndex
+              : 0;
+            parkedDronePayload = parkedPayloads[((nextPayloadIndex % parkedPayloads.length) + parkedPayloads.length) % parkedPayloads.length];
+            parkedEntry.nextDronePayloadIndex = (nextPayloadIndex + 1) % parkedPayloads.length;
+          }
+        }
         stopCaptureVehicleSounds();
-        if (isHelicopterAttack) playHelicopterSound();
-        if (isDroneAttack) playDroneSound();
+        if (isHelicopterAttack) {
+          stopFighterJetSound();
+          playHelicopterSound();
+        }
+        if (isDroneAttack || isMissileTruckAttack) playDroneSound();
         if (isFighterJetAttack) playFighterJetSound();
         const primaryFx =
           resolvedCaptureAnimationId === 'droneAttack'
@@ -6967,13 +6999,13 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             ? await createCaptureHelicopterFx()
             : resolvedCaptureAnimationId === 'fighterJetAttack'
             ? await createCaptureJetFx()
-            : createCaptureMissileFx();
+            : await createCaptureDroneFx();
         if (isFighterJetAttack || isHelicopterAttack) {
           fitCaptureVehicleToPlayerKing(primaryFx.root, attackerPlayer);
         }
         const jetMissiles =
           resolvedCaptureAnimationId === 'fighterJetAttack' || resolvedCaptureAnimationId === 'helicopterAttack'
-            ? [createCaptureMissileFx(), createCaptureMissileFx()]
+            ? [createCaptureMissileFx({ withTrail: true }), createCaptureMissileFx({ withTrail: true })]
             : [];
         const explosion = createCaptureExplosionFx();
         scene.add(primaryFx.root);
@@ -7032,14 +7064,15 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           resolveTokenAnchorPoint(attackerToken, startPosition, 0) ||
           startPosition.clone();
         const launchAnchor = tokenWorldPos.clone().add(new THREE.Vector3(0, bishopHeight * 0.52, 0));
-        if (isMissileTruckAttack && parkedReloadMissile?.isObject3D) {
+        if (isMissileTruckAttack && (parkedDronePayload?.isObject3D || parkedReloadMissile?.isObject3D)) {
           const parkedMissileWorld = new THREE.Vector3();
-          parkedReloadMissile.getWorldPosition(parkedMissileWorld);
+          const activePayload = parkedDronePayload?.isObject3D ? parkedDronePayload : parkedReloadMissile;
+          activePayload.getWorldPosition(parkedMissileWorld);
           launchAnchor.copy(parkedMissileWorld);
           if (Number.isFinite(tableSurfaceY)) {
             launchAnchor.y = Math.max(launchAnchor.y, tableSurfaceY + 0.014);
           }
-          parkedReloadMissile.visible = false;
+          activePayload.visible = false;
         } else if (parkedVehicleToRestore?.isObject3D) {
           parkedVehicleToRestore.visible = false;
         }
@@ -7277,7 +7310,9 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             primaryFx.root.position.copy(pos);
             primaryFx.root.quaternion.setFromUnitVectors(MISSILE_FORWARD, dir);
             trackAttackCamera(pos, dynamicTo, u);
-            const isVerticalImpactVehicle = selectedCaptureAnimationId === 'missileJavelin';
+            const isVerticalImpactVehicle =
+              selectedCaptureAnimationId === 'missileJavelin' ||
+              selectedCaptureAnimationId === 'droneAttack';
             if (isVerticalImpactVehicle && u > phaseSplit) {
               primaryFx.root.quaternion.setFromUnitVectors(MISSILE_FORWARD, new THREE.Vector3(0, -1, 0));
             }
@@ -7375,6 +7410,10 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
                   dynamicTo,
                   clamp(missileU + 0.03, 0, 1)
                 );
+                if (missileU >= 0.74) {
+                  missileNext.x = missilePos.x;
+                  missileNext.z = missilePos.z;
+                }
                 const missileDir = missileNext.clone().sub(missilePos).normalize();
                 jetMissile.root.visible = true;
                 jetMissile.root.position.copy(missilePos);
@@ -7502,18 +7541,21 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             parkedVehicleToRestore.position.y = tableSurfaceY + 0.002;
             orientCaptureVehicleTowardBoardCenter(parkedVehicleToRestore, boardLookTargetRef.current ?? new THREE.Vector3());
           }
-          if (isMissileTruckAttack && parkedReloadMissile?.isObject3D) {
-            if (parkedReloadMissileLocalPosition?.isVector3) {
+          if (isMissileTruckAttack && (parkedDronePayload?.isObject3D || parkedReloadMissile?.isObject3D)) {
+            if (parkedDronePayload?.isObject3D) {
+              parkedDronePayload.visible = true;
+            }
+            if (parkedReloadMissile?.isObject3D && parkedReloadMissileLocalPosition?.isVector3) {
               parkedReloadMissile.position.copy(parkedReloadMissileLocalPosition);
             }
-            if (parkedReloadMissileLocalRotation) {
+            if (parkedReloadMissile?.isObject3D && parkedReloadMissileLocalRotation) {
               parkedReloadMissile.rotation.set(
                 parkedReloadMissileLocalRotation.x,
                 parkedReloadMissileLocalRotation.y,
                 parkedReloadMissileLocalRotation.z
               );
             }
-            parkedReloadMissile.visible = true;
+            if (parkedReloadMissile?.isObject3D) parkedReloadMissile.visible = true;
           }
           if (primaryFx.root.parent) primaryFx.root.parent.remove(primaryFx.root);
           jetMissiles.forEach((entry) => {
@@ -7527,18 +7569,21 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         } catch (error) {
           stopCaptureVehicleSounds();
           if (parkedVehicleToRestore?.isObject3D) parkedVehicleToRestore.visible = true;
-          if (isMissileTruckAttack && parkedReloadMissile?.isObject3D) {
-            if (parkedReloadMissileLocalPosition?.isVector3) {
+          if (isMissileTruckAttack && (parkedDronePayload?.isObject3D || parkedReloadMissile?.isObject3D)) {
+            if (parkedDronePayload?.isObject3D) {
+              parkedDronePayload.visible = true;
+            }
+            if (parkedReloadMissile?.isObject3D && parkedReloadMissileLocalPosition?.isVector3) {
               parkedReloadMissile.position.copy(parkedReloadMissileLocalPosition);
             }
-            if (parkedReloadMissileLocalRotation) {
+            if (parkedReloadMissile?.isObject3D && parkedReloadMissileLocalRotation) {
               parkedReloadMissile.rotation.set(
                 parkedReloadMissileLocalRotation.x,
                 parkedReloadMissileLocalRotation.y,
                 parkedReloadMissileLocalRotation.z
               );
             }
-            parkedReloadMissile.visible = true;
+            if (parkedReloadMissile?.isObject3D) parkedReloadMissile.visible = true;
           }
           captureFxRef.current = null;
           resolve();


### PR DESCRIPTION
### Motivation
- Increase visual scale of airborne capture vehicles and their parked representations so models better fit the board and feel consistent.  
- Make missile visuals and missile-truck payloads more configurable and visually complete (windows, wheels, payload cycling).  
- Improve animation/sound behavior so parked aircraft stay static and payloads are correctly hidden/restored during attacks.  

### Description
- Increased core size multipliers for jets, drones and helicopters by 1.15 via `CAPTURE_JET_SIZE_MULTIPLIER`, `CAPTURE_DRONE_SIZE_MULTIPLIER`, `CAPTURE_HELICOPTER_SIZE_MULTIPLIER`, and applied the same scale factor to park scale entries in `CAPTURE_PARK_SCALE_BY_TYPE`.  
- Modified `createCaptureMissileFx` to accept an options object (`{ withTrail = true }`) and only build the trail when `withTrail` is true.  
- Enhanced `createCaptureMissileTruckFx` to add a cabin window material, add four wheel cylinders, collect missile payloads into `parkedDronePayloads`, use non-uniform missile root scaling, remove the middle missile offset, increase launcher root scale, and return `parkedDronePayloads` with existing reload properties.  
- Added `parkedDronePayloads` and `nextDronePayloadIndex` to parked vehicle entries so missile-truck payloads can be rotated/consumed during attacks.  
- Stop animating parked rotors/propellers in the main render loop and only animate rotors during active strike sequences.  
- In `playCaptureMissileSequence` implemented selection and cycling of a parked payload for `missileJavelin` attacks, hide the active payload during launch and restore visibility after the sequence, and use the active payload position when available for launch anchoring.  
- Adjusted sound handling so helicopter attacks stop fighter-jet sound before playing helicopter sound, and both drone and missile-truck attacks play drone sound.  
- Marked `droneAttack` as a vertical-impact vehicle and applied a small trajectory tweak for jet missiles to lock lateral coordinates late in flight.  

### Testing
- Built the webapp with `yarn build` to verify compilation and asset pipeline successfully completed; build succeeded.  
- Ran unit tests with `yarn test` and linting with `yarn lint`; automated tests and linters passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df33a1bd108329b3d5ed2af2f427fb)