### PR TITLE
fix(pool-royale): restore immediate shot commit on slider release

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -26697,6 +26697,10 @@ const powerRef = useRef(hud.power);
               rotationX: cueStick.rotation.x,
               rotationY: cueStick.rotation.y
             };
+            // Restore legacy shot feel: slider release applies physics immediately,
+            // while the cue stroke animation continues as visual feedback only.
+            commitShotImpact();
+            pendingImpactRef.current = null;
             cueStrokeStateRef.current = {
               startTime,
               idlePos: idlePos.clone(),
@@ -26717,6 +26721,7 @@ const powerRef = useRef(hud.power);
               // Slider release should drive an immediate forward strike from the
               // currently pulled cue position back to contact.
               forwardOnly: true,
+              shotApplied: true,
               onImpact: commitShotImpact,
               animationStyle: strokeStyle,
               motionTechnique: strokeProfile.motion ?? strokeStyle,


### PR DESCRIPTION
### Motivation
- Players reported the slider-release shot no longer fired immediately, degrading the shooting feel and responsiveness. 
- The intent is to restore the previous (legacy) behavior where releasing the power slider applies shot physics immediately while keeping the cue stroke animation as visual feedback.

### Description
- Call `commitShotImpact()` immediately on slider release inside `webapp/src/pages/Games/PoolRoyale.jsx` so shot physics are applied right away. 
- Clear `pendingImpactRef.current` to avoid duplicate scheduled fallbacks after the immediate commit. 
- Mark the cue stroke state as already applied by setting `shotApplied: true` on `cueStrokeStateRef.current` so the on-screen cue animation continues as visual-only feedback without re-triggering physics. 
- Changes are limited to the Pool Royale shot handling path and do not modify other gameplay systems.

### Testing
- Ran `npm test -- --runInBand test/poolRoyaleShotState.test.js test/poolRoyaleCueStrokeTimeline.test.js test/cueShotImpact.test.js` and all suites passed. 
- Test summary: 3 test suites passed, 11 tests passed, 0 snapshots (tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df4efcc18483299fd8041c816d7702)