### PR TITLE
Adjust capture attack paths: direct drone strikes, U‑turn jet/heli approach, and truck reload visuals

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -9331,6 +9331,7 @@ function Chess3D({
     };
     const createFxSupportTruck = () => {
       const root = new THREE.Group();
+      let reloadMissile = null;
       const addRoofLongMissiles = (target, referenceObject) => {
         if (!target) return;
         const bounds = referenceObject ? new THREE.Box3().setFromObject(referenceObject) : new THREE.Box3();
@@ -9375,6 +9376,7 @@ function Chess3D({
           missile.add(tip);
           missile.position.set(-Math.max(size.x * 0.12, 0.16), 0.1, lane * Math.max(size.z, 0.84));
           missile.rotation.z = Math.PI * 0.22; // tilt launchers upward so missile heads point up
+          if (!reloadMissile) reloadMissile = missile;
           rack.add(missile);
         });
         rack.rotation.z = -Math.PI * 0.05;
@@ -9400,7 +9402,7 @@ function Chess3D({
       root.add(cabin);
       addFxBox(root, [0.42, 0.22, 0.86], [0.94, 0.48, 0], '#050608', 0.16, 0.56);
       addRoofLongMissiles(root, root);
-      return { root };
+      return { root, reloadMissile };
     };
     const getAirPadAnchor = (isWhiteSide, kind = 'jet', slot = 0) => {
       const sideX =
@@ -9906,6 +9908,63 @@ function Chess3D({
       }
       return { pos, next };
     };
+    const getCaptureAirUTurnPose = ({
+      launchPos,
+      targetPos,
+      progress,
+      returnToOrigin = true
+    }) => {
+      const u = clamp01(progress);
+      const boardCenter = getBoardCenterWorldPosition();
+      const shortMissileAltitude = Math.max(
+        targetPos.y + tile * 0.24,
+        launchPos.y + CAPTURE_DRONE_REFERENCE_BOARD_ALTITUDE * 0.9
+      );
+      const flightAltitude = shortMissileAltitude;
+      const inwardVector = boardCenter.clone().sub(launchPos);
+      inwardVector.y = 0;
+      if (inwardVector.lengthSq() < 1e-6) {
+        inwardVector.set(-Math.sign(launchPos.x || 1), 0, 0);
+      } else {
+        inwardVector.normalize();
+      }
+      const sideVector = inwardVector.clone().cross(WORLD_UP).normalize();
+      const inwardLiftPoint = launchPos.clone().addScaledVector(inwardVector, tile * 1.05);
+      inwardLiftPoint.addScaledVector(sideVector, tile * 0.35 * Math.sign(launchPos.z || 1));
+      inwardLiftPoint.y = flightAltitude;
+      const turnRadius = Math.max(tile * 0.9, 0.26);
+      const turnCenter = boardCenter.clone().setY(flightAltitude);
+      const turnStart = turnCenter.clone().addScaledVector(sideVector, -turnRadius);
+      const turnEnd = turnCenter.clone().addScaledVector(sideVector, turnRadius);
+      if (u < 0.28) {
+        const su = smoothEase(u / 0.28);
+        const pos = qBezier(launchPos, inwardLiftPoint, turnStart, su);
+        const next = qBezier(launchPos, inwardLiftPoint, turnStart, clamp01(su + 0.05));
+        return { pos: constrainInsideBoardPerimeter(pos), next: constrainInsideBoardPerimeter(next) };
+      }
+      if (u < 0.66) {
+        const su = smoothEase((u - 0.28) / 0.38);
+        const arcAngle = Math.PI * (1 - su);
+        const pos = turnCenter.clone().addScaledVector(sideVector, Math.cos(arcAngle) * turnRadius);
+        pos.addScaledVector(inwardVector, Math.sin(arcAngle) * turnRadius * 0.48);
+        const nextAngle = Math.PI * (1 - clamp01(su + 0.06));
+        const next = turnCenter.clone().addScaledVector(sideVector, Math.cos(nextAngle) * turnRadius);
+        next.addScaledVector(inwardVector, Math.sin(nextAngle) * turnRadius * 0.48);
+        return { pos: constrainInsideBoardPerimeter(pos), next: constrainInsideBoardPerimeter(next) };
+      }
+      if (returnToOrigin) {
+        const su = smoothEase((u - 0.66) / 0.34);
+        const descentPoint = launchPos.clone().add(new THREE.Vector3(0, tile * 0.08, 0));
+        const pos = qBezier(turnEnd, inwardLiftPoint, descentPoint, su);
+        const next = qBezier(turnEnd, inwardLiftPoint, descentPoint, clamp01(su + 0.06));
+        return { pos: constrainInsideBoardPerimeter(pos), next: constrainInsideBoardPerimeter(next) };
+      }
+      const su = smoothEase((u - 0.66) / 0.34);
+      const strikeTop = new THREE.Vector3(targetPos.x, flightAltitude, targetPos.z);
+      const pos = turnEnd.clone().lerp(strikeTop, su);
+      const next = turnEnd.clone().lerp(strikeTop, clamp01(su + 0.06));
+      return { pos: constrainInsideBoardPerimeter(pos), next: constrainInsideBoardPerimeter(next) };
+    };
 
     const playCaptureAnimation = ({
       fromPos,
@@ -9923,6 +9982,7 @@ function Chess3D({
         missileFx.root.scale.setScalar(CAPTURE_ROOK_JAVELIN_SCALE);
         const isWhiteSide = Boolean(movingMesh?.userData?.w);
         const parkedTruck = acquireParkedSupportUnit(isWhiteSide);
+        if (parkedTruck?.reloadMissile) parkedTruck.reloadMissile.visible = false;
         const launchBase = parkedTruck?.homePosition?.clone?.() || getAirPadAnchor(isWhiteSide, 'truck', 0);
         missileFx.root.position.copy(launchBase.clone().add(new THREE.Vector3(0, 0.14, 0)));
         captureFxGroup.add(missileFx.root);
@@ -9947,15 +10007,12 @@ function Chess3D({
         if (pieceType === 'N') {
           suppressTimerBeepUntilRef.current = performance.now() + CAPTURE_GROUND_TOTAL * 1000;
           const isWhiteSide = Boolean(movingMesh?.userData?.w);
-          const parkedDrone = acquireParkedAirUnit(isWhiteSide, 'drone');
-          const droneFx = parkedDrone || createFxDrone({ forceProcedural: true });
+          const parkedDrone = parkedAirUnits.find((unit) => unit?.isWhite === isWhiteSide && unit?.kind === 'drone');
+          const droneFx = createFxDrone({ forceProcedural: true });
           droneFx.root.scale.setScalar(CAPTURE_DRONE_SCALE);
-          if (!parkedDrone) {
-            const launchBase = getAirPadAnchor(isWhiteSide, 'drone', 0);
-            droneFx.root.position.copy(launchBase.clone().add(new THREE.Vector3(0, 0.08, 0)));
-            captureFxGroup.add(droneFx.root);
-          }
-          const launchBase = parkedDrone?.homePosition?.clone?.() || getAirPadAnchor(isWhiteSide, 'drone', 0);
+          const launchBase = getAirPadAnchor(isWhiteSide, 'drone', 0);
+          droneFx.root.position.copy(launchBase.clone().add(new THREE.Vector3(0, 0.08, 0)));
+          captureFxGroup.add(droneFx.root);
           playAudio(droneSoundRef, { maxDurationMs: CAPTURE_GROUND_TOTAL * 1000 });
           activeCaptureFx.push({
             type: 'drone',
@@ -9965,8 +10022,8 @@ function Chess3D({
             to: targetPos.clone(),
             launchPos: launchBase.add(new THREE.Vector3(0, 0.08, 0)),
             movingMesh,
-            returnToOrigin: true,
-            sourceUnit: parkedDrone,
+            returnToOrigin: false,
+            reloadUnit: parkedDrone,
             droneFx
           });
           return {
@@ -9979,6 +10036,7 @@ function Chess3D({
         missileFx.root.scale.setScalar(CAPTURE_PAWN_JAVELIN_SCALE);
         const isWhiteSide = Boolean(movingMesh?.userData?.w);
         const parkedTruck = acquireParkedSupportUnit(isWhiteSide);
+        if (parkedTruck?.reloadMissile) parkedTruck.reloadMissile.visible = false;
         const launchBase = parkedTruck?.homePosition?.clone?.() || getAirPadAnchor(isWhiteSide, 'truck', 0);
         missileFx.root.position.copy(launchBase.clone().add(new THREE.Vector3(0, 0.14, 0)));
         captureFxGroup.add(missileFx.root);
@@ -9993,7 +10051,8 @@ function Chess3D({
           movingMesh,
           missileFx,
           directPath: false,
-          verticalStrike: true
+          verticalStrike: true,
+          reloadUnit: parkedTruck
         });
         return {
           moveDelayMs: CAPTURE_GROUND_TOTAL * 1000,
@@ -11919,12 +11978,13 @@ function Chess3D({
               pose = { pos: launchPos.clone(), next: launchPos.clone().add(new THREE.Vector3(0.05, 0, 0)) };
             } else if (fx.t < impactTime) {
               const mu = smoothEase((fx.t - CAPTURE_GROUND_FIRE_TIME) / CAPTURE_GROUND_TRAVEL_TIME);
-              pose = getCaptureLudoStyleAirPose({
-                animationId: 'droneAttack',
+              pose = getCaptureDirectStrikePose({
                 launchPos,
                 targetPos: fx.to,
                 progress: mu,
-                returnToOrigin: false
+                altitude: CAPTURE_DRONE_REFERENCE_BOARD_ALTITUDE * 0.92,
+                returnToOrigin: false,
+                verticalCrash: true
               });
             }
             if (!pose) {
@@ -11943,13 +12003,18 @@ function Chess3D({
               puff.scale.setScalar(s);
             });
             if (fx.t >= impactTime) {
-              launchExplosion(fx.to);
-              if (fx.sourceUnit) {
-                returnParkedAirUnit(fx.sourceUnit);
-              } else {
+              if (!fx.hasExploded) {
+                fx.hasExploded = true;
+                launchExplosion(fx.to);
+                fx.reloading = true;
+                fx.reloadEndsAt = fx.t + CAPTURE_RELOAD_SHOW_TIME;
+                if (fx.reloadUnit?.reloadMissile) fx.reloadUnit.reloadMissile.visible = true;
+                fx.droneFx.root.position.copy(launchPos);
+                fx.droneFx.root.visible = true;
+              } else if (fx.reloading && fx.t >= fx.reloadEndsAt) {
                 captureFxGroup.remove(fx.droneFx.root);
+                activeCaptureFx.splice(i, 1);
               }
-              activeCaptureFx.splice(i, 1);
             }
           } else if (fx.type === 'jet') {
             const jetTimelineU = clamp01(fx.t / CAPTURE_JET_TOTAL);
@@ -11959,8 +12024,7 @@ function Chess3D({
               ? fx.launchPos.clone()
               : getLiveLaunchPosition(fx.launchPos, fx.movingMesh, 0);
             if (!fx.returnToOrigin) fx.launchPos.copy(launchPos);
-            const { pos: jetPos, next: jetNext } = getCaptureLudoStyleAirPose({
-              animationId: 'fighterJetAttack',
+            const { pos: jetPos, next: jetNext } = getCaptureAirUTurnPose({
               launchPos,
               targetPos: fx.to,
               progress: jetU,
@@ -12074,8 +12138,7 @@ function Chess3D({
               ? fx.launchPos.clone()
               : getLiveLaunchPosition(fx.launchPos, fx.movingMesh, 0);
             if (!fx.returnToOrigin) fx.launchPos.copy(launchPos);
-            const { pos: heliPos, next: heliNext } = getCaptureLudoStyleAirPose({
-              animationId: 'helicopterAttack',
+            const { pos: heliPos, next: heliNext } = getCaptureAirUTurnPose({
               launchPos,
               targetPos: fx.to,
               progress: heliU,
@@ -12224,6 +12287,7 @@ function Chess3D({
                 launchExplosion(fx.to);
                 fx.reloading = true;
                 fx.reloadEndsAt = fx.t + CAPTURE_RELOAD_SHOW_TIME;
+                if (fx.reloadUnit?.reloadMissile) fx.reloadUnit.reloadMissile.visible = true;
                 fx.missileFx.root.position.copy(launchPos);
                 fx.missileFx.root.visible = true;
                 fx.missileFx.root.quaternion.setFromUnitVectors(FORWARD, new THREE.Vector3(-Math.sign(launchPos.x || 1), 0, 0));


### PR DESCRIPTION
### Motivation
- Make capture animations feel more direct and consistent with short-missile strikes by changing drone behaviour to a vertical direct strike and keeping the parking slots populated. 
- Give jet and helicopter attacks a clearer inward lift and U-turn ingress/egress so their flight reads like a coordinated air‑strike and returns to the exact parking pad. 
- Make truck-launched missiles visibly reload on the parked truck after the explosion so parking slots are not left empty.

### Description
- Added a new flight path helper `getCaptureAirUTurnPose` that lifts air units diagonally inward toward board center, performs a U-turn arc at strike altitude, releases missiles, and returns to origin; jet and helicopter FX now use this path. (modified `webapp/src/pages/Games/ChessBattleRoyal.jsx`)
- Changed drone capture to spawn a transient drone FX from the drone parking anchor and use the direct vertical strike flow via `getCaptureDirectStrikePose` with `verticalCrash`, so the parked drone remains visually present. (modified `playCaptureAnimation` and active FX handling)
- Exposed a `reloadMissile` reference on the parked support truck FX and wired `reloadUnit` handling so truck roof launcher becomes hidden at launch and is restored after explosion + reload timing. (modified `createFxSupportTruck`, pickup/reload logic and `playCaptureAnimation` javelin flows)
- Added small lifecycle changes to active FX entries (`reloadUnit`, `reloadEndsAt`, `reloading`, `hasExploded`) so missiles and transient FX are shown/hidden correctly during impact and reload phases.

### Testing
- Ran the project lint command scoped to the chess file; lint produced repository-wide errors from generated/dist files and unrelated pre-existing issues so it did not serve as a pass/fail indicator for this change. (lint run: failed due to unrelated repo errors)
- Verified the file `webapp/src/pages/Games/ChessBattleRoyal.jsx` compiles locally as part of development edits and the new helper and reload fields are used consistently across jet/helicopter/drone/truck FX flows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df50945e6483298fe6b4c37b5492f9)