### PR TITLE
Restore slider release power as primary source for Pool Royale shot commit

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -32522,9 +32522,13 @@ const powerRef = useRef(hud.power);
         sliderShotPowerRef.current = clampPower(powerRef.current, 0);
         captureCueStickAnchor();
       },
-      onCommit: () => {
+      onCommit: (sliderValue) => {
+        const releasePower = clampPower(
+          Number.isFinite(sliderValue) ? sliderValue / 100 : shotPowerRef.current,
+          shotDragPowerRef.current
+        );
         const committedShot = resolveCommittedShot({
-          capturedDragPower: shotPowerRef.current,
+          capturedDragPower: releasePower,
           fallbackPower: shotDragPowerRef.current,
           minStrikePower: 0.02
         });


### PR DESCRIPTION
### Motivation
- Fix a regression where releasing the power slider could be ignored due to stale drag refs, preventing the shot from firing as expected. 
- Ensure the in-game shooting behavior matches the expected flow where the actual release value is used to determine strike vs idle while keeping existing shot-state machinery intact.

### Description
- Updated the slider `onCommit` path in `webapp/src/pages/Games/PoolRoyale.jsx` to accept the `sliderValue` and compute a `releasePower` via `clampPower(...)` before calling `resolveCommittedShot`.
- Passed the `releasePower` as `capturedDragPower` into `resolveCommittedShot` so strike decisions use the real release event value rather than stale refs.
- Left the rest of the shot flow unchanged, including state updates to `shotPowerRef`, `shotDragPowerRef`, `shotStateRef`, the `fireRef` trigger, and the slider reset animation using `easeOutShot`.

### Testing
- Ran `npm test -- --runInBand test/poolRoyaleShotState.test.js` and all tests passed. 
- Test summary: 1 test suite, 4 tests — all passed (`PASS test/poolRoyaleShotState.test.js`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df4efcc18483299fd8041c816d7702)