### PR TITLE
Adjust Chess Battle Royal attack paths and support-unit missile behavior

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -9884,8 +9884,33 @@ function Chess3D({
       shortCenterHop.y = centerAltitude;
       const centerHover = shortCenterHop.clone().lerp(centerPoint, 0.58);
       const endPoint = returnToOrigin ? launchPos.clone() : targetPos.clone();
+      const useCenterUTurn = returnToOrigin && (animationId === 'fighterJetAttack' || animationId === 'helicopterAttack');
       const pathAt = (v) => {
         const p = clamp(v, 0, 1);
+        if (useCenterUTurn) {
+          const entrySplit = 0.34;
+          const turnSplit = 0.72;
+          if (p < entrySplit) {
+            const a = smoothEase(p / entrySplit);
+            return qBezier(launchPos, shortCenterHop, centerHover, a);
+          }
+          if (p < turnSplit) {
+            const turnU = smoothEase((p - entrySplit) / Math.max(0.001, turnSplit - entrySplit));
+            const radius = Math.max(tile * 0.55, approachLen * 0.24);
+            const startDir = centerHover.clone().sub(centerPoint);
+            startDir.y = 0;
+            if (startDir.lengthSq() < 1e-6) startDir.copy(approachDir).multiplyScalar(-1);
+            startDir.normalize();
+            const startAngle = Math.atan2(startDir.z, startDir.x);
+            const angle = startAngle + turnU * Math.PI;
+            const uTurnPos = centerPoint.clone().add(new THREE.Vector3(Math.cos(angle) * radius, 0, Math.sin(angle) * radius));
+            uTurnPos.y = centerAltitude;
+            return uTurnPos;
+          }
+          const r = smoothEase((p - turnSplit) / Math.max(0.001, 1 - turnSplit));
+          const returnControl = centerHover.clone().lerp(launchPos, 0.48);
+          return qBezier(centerHover, returnControl, endPoint, r);
+        }
         if (p < 0.52) {
           const a = smoothEase(p / 0.52);
           return qBezier(launchPos, shortCenterHop, centerHover, a);
@@ -9936,7 +9961,9 @@ function Chess3D({
           launchPos: launchBase.add(new THREE.Vector3(0, 0.03, 0)),
           movingMesh,
           missileFx,
-          directPath: false
+          directPath: false,
+          sourceUnit: parkedTruck,
+          fixedLaunch: true
         });
         return {
           moveDelayMs: CAPTURE_GROUND_TOTAL * 1000,
@@ -9949,6 +9976,10 @@ function Chess3D({
           const isWhiteSide = Boolean(movingMesh?.userData?.w);
           const parkedDrone = acquireParkedAirUnit(isWhiteSide, 'drone');
           const droneFx = parkedDrone || createFxDrone({ forceProcedural: true });
+          const missileFx = createFxGroundMissile();
+          missileFx.root.scale.setScalar(CAPTURE_PAWN_JAVELIN_SCALE);
+          missileFx.root.visible = true;
+          captureFxGroup.add(missileFx.root);
           droneFx.root.scale.setScalar(CAPTURE_DRONE_SCALE);
           if (!parkedDrone) {
             const launchBase = getAirPadAnchor(isWhiteSide, 'drone', 0);
@@ -9956,6 +9987,7 @@ function Chess3D({
             captureFxGroup.add(droneFx.root);
           }
           const launchBase = parkedDrone?.homePosition?.clone?.() || getAirPadAnchor(isWhiteSide, 'drone', 0);
+          missileFx.root.position.copy(launchBase.clone().add(new THREE.Vector3(0, 0.08, 0)));
           playAudio(droneSoundRef, { maxDurationMs: CAPTURE_GROUND_TOTAL * 1000 });
           activeCaptureFx.push({
             type: 'drone',
@@ -9967,7 +9999,9 @@ function Chess3D({
             movingMesh,
             returnToOrigin: true,
             sourceUnit: parkedDrone,
-            droneFx
+            droneFx,
+            missileFx,
+            fixedLaunch: true
           });
           return {
             moveDelayMs: CAPTURE_GROUND_TOTAL * 1000,
@@ -9993,7 +10027,9 @@ function Chess3D({
           movingMesh,
           missileFx,
           directPath: false,
-          verticalStrike: true
+          verticalStrike: true,
+          sourceUnit: parkedTruck,
+          fixedLaunch: true
         });
         return {
           moveDelayMs: CAPTURE_GROUND_TOTAL * 1000,
@@ -11909,32 +11945,33 @@ function Chess3D({
           const u = clamp01(fx.t / fx.duration);
           if (fx.type === 'drone') {
             const impactTime = CAPTURE_GROUND_FIRE_TIME + CAPTURE_GROUND_TRAVEL_TIME;
-            const launchPos = fx.returnToOrigin
-              ? fx.launchPos.clone()
-              : getLiveLaunchPosition(fx.launchPos, fx.movingMesh, 0);
-            if (!fx.returnToOrigin) fx.launchPos.copy(launchPos);
+            const launchPos = fx.launchPos.clone();
             fx.droneFx.root.scale.setScalar(CAPTURE_DRONE_SCALE);
-            let pose = null;
+            fx.droneFx.root.visible = true;
+            fx.droneFx.root.position.copy(launchPos);
+            fx.droneFx.root.quaternion.setFromUnitVectors(FORWARD, new THREE.Vector3(-Math.sign(launchPos.x || 1), 0, 0));
+            let missilePose = null;
             if (fx.t < CAPTURE_GROUND_FIRE_TIME) {
-              pose = { pos: launchPos.clone(), next: launchPos.clone().add(new THREE.Vector3(0.05, 0, 0)) };
+              fx.missileFx.root.visible = true;
+              fx.missileFx.root.position.copy(launchPos);
             } else if (fx.t < impactTime) {
               const mu = smoothEase((fx.t - CAPTURE_GROUND_FIRE_TIME) / CAPTURE_GROUND_TRAVEL_TIME);
-              pose = getCaptureLudoStyleAirPose({
-                animationId: 'droneAttack',
+              missilePose = getCaptureDirectStrikePose({
                 launchPos,
-                targetPos: fx.to,
+                targetPos: fx.to.clone(),
                 progress: mu,
-                returnToOrigin: false
+                altitude: CAPTURE_DRONE_REFERENCE_BOARD_ALTITUDE * 0.92,
+                verticalCrash: true
               });
             }
-            if (!pose) {
-              fx.droneFx.root.visible = false;
-            } else {
-              fx.droneFx.root.visible = true;
-              const { pos, next } = pose;
-              fx.droneFx.root.position.copy(constrainInsideBoardPerimeter(pos));
+            if (missilePose) {
+              const { pos, next } = missilePose;
+              fx.missileFx.root.visible = true;
+              fx.missileFx.root.position.copy(constrainInsideBoardPerimeter(pos));
               captureDir.copy(next).sub(pos).normalize();
-              fx.droneFx.root.quaternion.setFromUnitVectors(FORWARD, captureDir);
+              fx.missileFx.root.quaternion.setFromUnitVectors(FORWARD, captureDir);
+            } else {
+              fx.missileFx.root.visible = false;
             }
             fx.droneFx.propeller.rotation.x += dt * 40;
             fx.droneFx.exhaustClouds?.forEach((puff, idx) => {
@@ -11943,13 +11980,23 @@ function Chess3D({
               puff.scale.setScalar(s);
             });
             if (fx.t >= impactTime) {
-              launchExplosion(fx.to);
-              if (fx.sourceUnit) {
-                returnParkedAirUnit(fx.sourceUnit);
-              } else {
-                captureFxGroup.remove(fx.droneFx.root);
+              if (!fx.hasExploded) {
+                fx.hasExploded = true;
+                launchExplosion(fx.to);
+                fx.reloading = true;
+                fx.reloadEndsAt = fx.t + CAPTURE_RELOAD_SHOW_TIME;
+                fx.missileFx.root.position.copy(launchPos);
+                fx.missileFx.root.visible = true;
+              } else if (fx.reloading && fx.t >= fx.reloadEndsAt) {
+                fx.missileFx.root.visible = false;
+                captureFxGroup.remove(fx.missileFx.root);
+                if (fx.sourceUnit) {
+                  returnParkedAirUnit(fx.sourceUnit);
+                } else {
+                  captureFxGroup.remove(fx.droneFx.root);
+                }
+                activeCaptureFx.splice(i, 1);
               }
-              activeCaptureFx.splice(i, 1);
             }
           } else if (fx.type === 'jet') {
             const jetTimelineU = clamp01(fx.t / CAPTURE_JET_TOTAL);
@@ -12184,8 +12231,8 @@ function Chess3D({
               activeCaptureFx.splice(i, 1);
             }
           } else if (fx.type === 'javelin') {
-            const launchPos = getLiveLaunchPosition(fx.launchPos, fx.movingMesh, 0);
-            fx.launchPos.copy(launchPos);
+            const launchPos = fx.fixedLaunch ? fx.launchPos.clone() : getLiveLaunchPosition(fx.launchPos, fx.movingMesh, 0);
+            if (!fx.fixedLaunch) fx.launchPos.copy(launchPos);
             const impactTime = CAPTURE_GROUND_FIRE_TIME + CAPTURE_GROUND_TRAVEL_TIME;
             if (fx.t < CAPTURE_GROUND_FIRE_TIME) {
               fx.missileFx.root.visible = true;
@@ -12230,6 +12277,9 @@ function Chess3D({
               } else if (fx.reloading && fx.t >= fx.reloadEndsAt) {
                 fx.missileFx.root.visible = false;
                 captureFxGroup.remove(fx.missileFx.root);
+                if (fx.sourceUnit?.root?.position && fx.sourceUnit?.homePosition) {
+                  fx.sourceUnit.root.position.copy(fx.sourceUnit.homePosition);
+                }
                 activeCaptureFx.splice(i, 1);
               }
             }


### PR DESCRIPTION
### Motivation

- Make drone, truck, helicopter and jet capture strikes visually match direct vertical / inward U-turn launches so attacks read clearly in portrait gameplay. 
- Keep support units (drone/truck) visually present at their parking pads while their missiles launch and show a short reload visual so parking lanes are not empty after an explosion. 
- Prevent ground javelin launches from drifting with the moved piece by anchoring launches to the parked vehicle location.

### Description

- Updated `webapp/src/pages/Games/ChessBattleRoyal.jsx` to add a center-inbound U-turn profile (`useCenterUTurn`) for return-to-origin air paths used by `fighterJetAttack` and `helicopterAttack`, producing a diagonal inward lift → U-turn → return-to-parking motion. 
- Reworked drone capture flow so the drone stays parked and a dedicated ground missile (`missileFx`) is spawned from the drone parking position and routed with `getCaptureDirectStrikePose` for a vertical/direct strike; added visible reload state after explosion and preserved the parked drone (fields: `missileFx`, `fixedLaunch`, `sourceUnit`). 
- Changed truck/rook and pawn/truck javelin launches to always originate from the parked truck pad by setting `fixedLaunch` and `sourceUnit` on the effect object, and preserved reload visibility and restoration of the parked truck position after reload completes. 
- Adjusted active effect update logic to respect `fixedLaunch` when resolving live launch positions, added missile reload timing via `CAPTURE_RELOAD_SHOW_TIME`, and ensured parked units are returned to their `homePosition` after reload cleanup.

### Testing

- Ran the targeted unit tests with `npm test -- --runInBand test/chessBattleInventoryConfig.test.js`, and the suite passed. 
- Ran `npx eslint webapp/src/pages/Games/ChessBattleRoyal.jsx` which reported a repository ignore warning only (no lint errors in the changed file reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df50945e6483298fe6b4c37b5492f9)