### PR TITLE
Align Snake board weapon placement and tighten dice landing positions

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -242,10 +242,10 @@ const TOKEN_REST_RAIL_INSET_BY_SEAT = Object.freeze([
   TILE_SIZE * 1.08
 ]);
 const WEAPON_REST_RAIL_INSET_BY_SEAT = Object.freeze([
-  TILE_SIZE * 1.24,
-  TILE_SIZE * 1.62,
-  TILE_SIZE * 0.3,
-  TILE_SIZE * 1.52
+  TILE_SIZE * 1.42,
+  TILE_SIZE * 1.52,
+  TILE_SIZE * 0.08,
+  TILE_SIZE * 1.08
 ]);
 const TOKEN_REST_MIN_RADIUS = BOARD_RADIUS + TILE_SIZE * 2.08;
 const TOKEN_REST_LATERAL_BY_SEAT = Object.freeze([
@@ -273,7 +273,7 @@ const WEAPON_PARKED_Y_DROP_BY_KIND = Object.freeze({
   supportTruck: TOKEN_HEIGHT * 1.78,
   javelin: TOKEN_HEIGHT * 1.72
 });
-const WEAPON_REST_HEIGHT_OFFSET = -TOKEN_HEIGHT * 0.78;
+const WEAPON_REST_HEIGHT_OFFSET = -TOKEN_HEIGHT * 1.34;
 
 const PAVEMENT_EXTRA_SCALE = 1.18;
 const PAVEMENT_THICKNESS = TILE_SIZE * 0.4;
@@ -340,37 +340,37 @@ const DICE_CENTER_VECTOR = new THREE.Vector3();
 const BOARD_FRONT_VECTOR = new THREE.Vector3(0, 0, 1);
 const BOARD_SIDE_VECTOR = new THREE.Vector3(1, 0, 0);
 
-const SIDE_SEAT_THROW_START_EXTRA = TILE_SIZE * 2.4;
-const SIDE_SEAT_THROW_BOUNCE_EXTRA = TILE_SIZE * 1.65;
-const SIDE_SEAT_THROW_SETTLE_EXTRA = TILE_SIZE * 1.45;
+const SIDE_SEAT_THROW_START_EXTRA = 0;
+const SIDE_SEAT_THROW_BOUNCE_EXTRA = 0;
+const SIDE_SEAT_THROW_SETTLE_EXTRA = 0;
 
 const DICE_SEAT_ADJUSTMENTS = [
   {
     forward: {
-      start: TILE_SIZE * 0.12,
-      bounce: TILE_SIZE * 0.1,
-      base: TILE_SIZE * 0.18
+      start: 0,
+      bounce: 0,
+      base: 0
     }
   },
   {
     forward: {
-      start: TILE_SIZE * 0.12,
-      bounce: TILE_SIZE * 0.1,
-      base: TILE_SIZE * 0.18
+      start: 0,
+      bounce: 0,
+      base: 0
     }
   },
   {
     forward: {
-      start: TILE_SIZE * 0.12,
-      bounce: TILE_SIZE * 0.1,
-      base: TILE_SIZE * 0.18
+      start: 0,
+      bounce: 0,
+      base: 0
     }
   },
   {
     forward: {
-      start: TILE_SIZE * 0.12,
-      bounce: TILE_SIZE * 0.1,
-      base: TILE_SIZE * 0.18
+      start: 0,
+      bounce: 0,
+      base: 0
     }
   }
 ];
@@ -2199,7 +2199,7 @@ function computeDiceThrowLayout(board, seatIndex, count) {
   const boardEdgeDistance = boardHalf + BOARD_EDGE_BUFFER;
   const baseStartDistance = boardHalf + DICE_THROW_START_EXTRA;
   const settleBaseDistance =
-    boardHalf + DICE_THROW_LANDING_MARGIN * 0.72 + DICE_RETREAT_EXTRA * 0.35;
+    boardHalf + DICE_THROW_LANDING_MARGIN * 0.52 + DICE_RETREAT_EXTRA * 0.12;
 
   const seatAdjust = DICE_SEAT_ADJUSTMENTS[seatIndex] ?? {};
   const forwardAdjust = seatAdjust.forward ?? {};


### PR DESCRIPTION
### Motivation
- Tokens and capture-weapon models around the octagon table needed consistent rail/inset and vertical alignment so weapons visually sit at the same table plane as tokens in the 2D camera view. 
- Dice landing and per-seat throw tuning required adjustment so dice land closer to the board guide area and behave uniformly across seats.

### Description
- Updated per-seat inset for weapons to match token rail insets by setting `WEAPON_REST_RAIL_INSET_BY_SEAT` to the same values as `TOKEN_REST_RAIL_INSET_BY_SEAT` in `webapp/src/components/SnakeBoard3D.jsx`.
- Lowered parked weapon vertical placement by changing `WEAPON_REST_HEIGHT_OFFSET` to bring weapon displays down to the perceived table/token height.
- Disabled side-seat throw offsets and cleared per-seat forward offsets by zeroing `SIDE_SEAT_THROW_*` constants and `DICE_SEAT_ADJUSTMENTS.forward` values so all seats use a consistent dice-throw geometry.
- Brought dice settle/landing positions slightly inward by reducing the settle distance formula (`DICE_THROW_LANDING_MARGIN` and `DICE_RETREAT_EXTRA` multipliers) so the dice landing point sits closer to the board guide area.

### Testing
- Ran `./node_modules/.bin/eslint webapp/src/components/SnakeBoard3D.jsx` which completed with a lint warning only (file ignored by project ignore patterns) and no lint errors.
- Attempted `npm run -s lint -- webapp/src/components/SnakeBoard3D.jsx` in the environment; no blocking lint errors were reported during the change cycle.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df57d9b1208329896386bbbeab116a)