### PR TITLE
Pool Royale: sync slider & cue return to shot rhythm

### DIFF
--- a/webapp/public/power-slider.css
+++ b/webapp/public/power-slider.css
@@ -11,6 +11,8 @@
   --ps-glow: rgba(255, 0, 0, 0.6);
   --ps-tooltip-bg: rgba(0, 0, 0, 0.8);
   --ps-tooltip-color: #fff;
+  --ps-return-duration: 0.15s;
+  --ps-return-ease: cubic-bezier(0.22, 1, 0.36, 1);
 
   position: relative;
   width: var(--ps-width);
@@ -97,7 +99,7 @@
   top: 0;
   left: 100%;
   transform: translate(0, 0);
-  transition: transform 0.15s ease;
+  transition: transform var(--ps-return-duration) var(--ps-return-ease);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -139,7 +141,7 @@
   white-space: nowrap;
   transform-origin: 50% 100%;
   transition:
-    transform 0.15s ease,
+    transform var(--ps-return-duration) var(--ps-return-ease),
     opacity 0.15s ease;
   pointer-events: none;
 }

--- a/webapp/public/power-slider.js
+++ b/webapp/public/power-slider.js
@@ -99,6 +99,7 @@ export class PowerSlider {
 
     this._setupPowerBar();
 
+    this.setReturnAnimation();
     this.set(value);
   }
 
@@ -129,6 +130,19 @@ export class PowerSlider {
     this.el.classList.remove('ps-locked');
     this.el.tabIndex = 0;
     this.el.setAttribute('aria-disabled', 'false');
+  }
+
+  setReturnAnimation({ durationMs = 150, easing = 'cubic-bezier(0.22, 1, 0.36, 1)' } = {}) {
+    const safeDurationMs = Number.isFinite(durationMs)
+      ? Math.min(480, Math.max(70, durationMs))
+      : 150;
+    this.el.style.setProperty('--ps-return-duration', `${safeDurationMs}ms`);
+    this.el.style.setProperty('--ps-return-ease', easing || 'cubic-bezier(0.22, 1, 0.36, 1)');
+  }
+
+  resetToMinWithRhythm(opts = {}) {
+    this.setReturnAnimation(opts);
+    this.set(this.min, { animate: true });
   }
 
   destroy() {

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -25867,13 +25867,14 @@ const powerRef = useRef(hud.power);
       const resolveCueStrokeProfile = (_styleId, powerRatio = 0) => {
         const p = THREE.MathUtils.clamp(powerRatio ?? 0, 0, 1);
         const pullbackDuration = THREE.MathUtils.lerp(90, 170, p);
+        const strikeDuration = THREE.MathUtils.lerp(132, 96, p);
         return {
           // Match the reference cue workflow exactly:
           // drag = pull back, release = immediate forward strike.
           motion: 'classic',
           pullRatio: easeOutCubic(p),
           pullSmoothing: 1,
-          strikeDuration: 120,
+          strikeDuration,
           holdDuration: 50,
           pullbackDuration,
           recoverDuration: 0,
@@ -26064,8 +26065,9 @@ const powerRef = useRef(hud.power);
           !allStopped((ballsRef.current?.length > 0 ? ballsRef.current : balls)) ||
           currentHud?.over ||
           replayPlaybackRef.current
-        )
-          return;
+        ) {
+          return { triggered: false };
+        }
         if (breakWinnerSeatRef.current === 'A') {
           breakWinnerSeatRef.current = null;
         }
@@ -26235,6 +26237,11 @@ const powerRef = useRef(hud.power);
             .multiplyScalar(speedBase * powerScale);
           const predictedCueSpeed = base.length();
           shotPrediction.speed = predictedCueSpeed;
+          const normalizedShotSpeed = THREE.MathUtils.clamp(
+            predictedCueSpeed / Math.max(speedBase * SHOT_MAX_FACTOR, 1e-6),
+            0,
+            1
+          );
           if (shouldRecordReplay) {
             const frameTiming = frameTimingRef.current;
             const frameTimeMs =
@@ -26685,6 +26692,15 @@ const powerRef = useRef(hud.power);
               updateCamera();
             }
           }
+          const sliderResetDurationMs = THREE.MathUtils.lerp(
+            205,
+            108,
+            normalizedShotSpeed
+          );
+          return {
+            triggered: true,
+            sliderResetDurationMs
+          };
         };
         let aiThinkingHandle = null;
         const planKey = (plan) =>
@@ -32442,9 +32458,14 @@ const powerRef = useRef(hud.power);
         captureCueStickAnchor();
       },
       onCommit: () => {
-        fireRef.current?.();
+        const shotResult = fireRef.current?.();
+        if (!shotResult?.triggered) {
+          return;
+        }
         requestAnimationFrame(() => {
-          slider.set(slider.min, { animate: true });
+          slider.resetToMinWithRhythm({
+            durationMs: shotResult.sliderResetDurationMs
+          });
           applyPower(0);
         });
       }


### PR DESCRIPTION
### Motivation
- Ensure the pull UI (handle + percent label) and the visible cuestick return to their idle positions only after a shot is actually triggered and in the same rhythm as the shot, without interfering with shot triggering logic.
- Make the slider return timing configurable and derived from shot speed so the visual reset matches cue movement pacing.

### Description
- Added CSS variables `--ps-return-duration` and `--ps-return-ease` and wired the handle/tooltip transitions to those variables in `webapp/public/power-slider.css` so return timing/easing is configurable via JS.
- Extended `PowerSlider` (`webapp/public/power-slider.js`) with `setReturnAnimation` and `resetToMinWithRhythm` methods and call `setReturnAnimation()` from the constructor to initialize defaults.
- Changed the Pool Royale shot flow (`webapp/src/pages/Games/PoolRoyale.jsx`) so `onCommit` first calls `fire()` and only resets the slider when `fire()` indicates a successful trigger; the slider reset uses `resetToMinWithRhythm` with a duration derived from shot speed.
- Made `fire()` return a shot result object (`{ triggered, sliderResetDurationMs }`), computed a `normalizedShotSpeed`, and scaled `strikeDuration` with power in `resolveCueStrokeProfile` so cue return timing and UI reset are rhythm-aligned.

### Testing
- Ran the unit test command `npm test -- --runInBand test/poolRoyaleShotState.test.js test/poolRoyaleCueStrokeTimeline.test.js` which executed the updated cue/stroke tests.
- Result: both suites passed (`PASS test/poolRoyaleCueStrokeTimeline.test.js`, `PASS test/poolRoyaleShotState.test.js`), with 8 tests total passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df5dac796c832993c2150572318413)