### PR TITLE
Pool Royale: animate power-slider return to match cue strike rhythm

### DIFF
--- a/webapp/public/power-slider.js
+++ b/webapp/public/power-slider.js
@@ -9,6 +9,7 @@ export class PowerSlider {
       cueSrc = '',
       onChange,
       onCommit,
+      onStart,
       theme = 'default',
       labels = false
     } = opts;
@@ -20,7 +21,9 @@ export class PowerSlider {
     this.step = step;
     this.onChange = onChange;
     this.onCommit = onCommit;
+    this.onStart = onStart;
     this.locked = false;
+    this._returnAnimFrame = null;
 
     this.el = document.createElement('div');
     this.el.className = `ps ps-theme-${theme}`;
@@ -117,6 +120,33 @@ export class PowerSlider {
     if (typeof this.onChange === 'function') this.onChange(value);
   }
 
+  animateTo(v, { duration = 160 } = {}) {
+    this._cancelReturnAnimation();
+    const target = this._clamp(this._step(v));
+    const start = this.value;
+    if (!Number.isFinite(duration) || duration <= 0 || Math.abs(target - start) < 1e-6) {
+      this.set(target, { animate: true });
+      return;
+    }
+    const startedAt = performance.now();
+    const step = (now) => {
+      const t = Math.min(1, Math.max(0, (now - startedAt) / duration));
+      const eased = 1 - (1 - t) * (1 - t);
+      const next = start + (target - start) * eased;
+      this.set(next, { animate: true });
+      if (t >= 1) {
+        this._returnAnimFrame = null;
+        return;
+      }
+      this._returnAnimFrame = requestAnimationFrame(step);
+    };
+    this._returnAnimFrame = requestAnimationFrame(step);
+  }
+
+  animateToMin({ duration = 160 } = {}) {
+    this.animateTo(this.min, { duration });
+  }
+
   lock() {
     this.locked = true;
     this.el.classList.add('ps-locked');
@@ -132,6 +162,7 @@ export class PowerSlider {
   }
 
   destroy() {
+    this._cancelReturnAnimation();
     this.el.removeEventListener('pointerdown', this._onPointerDown);
     this.el.removeEventListener('wheel', this._onWheel);
     this.el.removeEventListener('keydown', this._onKeyDown);
@@ -219,7 +250,9 @@ export class PowerSlider {
   _pointerDown(e) {
     if (this.locked) return;
     e.preventDefault();
+    this._cancelReturnAnimation();
     this.dragging = true;
+    if (typeof this.onStart === 'function') this.onStart(this.value);
     this.el.classList.add('ps-no-animate');
     this.el.setPointerCapture(e.pointerId);
     this._updateFromClientY(e.clientY);
@@ -245,6 +278,8 @@ export class PowerSlider {
   _wheel(e) {
     if (this.locked) return;
     e.preventDefault();
+    this._cancelReturnAnimation();
+    if (typeof this.onStart === 'function') this.onStart(this.value);
     const dir = e.deltaY > 0 ? 1 : -1;
     this.set(this.value + dir * this.step, { animate: true });
     if (typeof this.onCommit === 'function') this.onCommit(this.value);
@@ -252,18 +287,34 @@ export class PowerSlider {
 
   _keyDown(e) {
     if (this.locked) return;
+    let started = false;
     let handled = false;
     let inc = e.shiftKey ? this.step * 5 : this.step;
     if (e.key === 'ArrowDown') {
+      started = true;
       this.set(this.value + inc);
       handled = true;
     } else if (e.key === 'ArrowUp') {
+      started = true;
       this.set(this.value - inc);
       handled = true;
     } else if (e.key === 'Enter') {
       if (typeof this.onCommit === 'function') this.onCommit(this.value);
       handled = true;
     }
-    if (handled) e.preventDefault();
+    if (handled) {
+      if (started) {
+        this._cancelReturnAnimation();
+        if (typeof this.onStart === 'function') this.onStart(this.value);
+      }
+      e.preventDefault();
+    }
+  }
+
+  _cancelReturnAnimation() {
+    if (this._returnAnimFrame != null) {
+      cancelAnimationFrame(this._returnAnimFrame);
+      this._returnAnimFrame = null;
+    }
   }
 }

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -32441,12 +32441,11 @@ const powerRef = useRef(hud.power);
       onStart: () => {
         captureCueStickAnchor();
       },
-      onCommit: () => {
+      onCommit: (committedValue = 0) => {
         fireRef.current?.();
-        requestAnimationFrame(() => {
-          slider.set(slider.min, { animate: true });
-          applyPower(0);
-        });
+        const powerRatio = THREE.MathUtils.clamp((committedValue ?? 0) / 100, 0, 1);
+        const resetDurationMs = THREE.MathUtils.lerp(190, 105, powerRatio);
+        slider.animateToMin({ duration: resetDurationMs });
       }
     });
     sliderInstanceRef.current = slider;


### PR DESCRIPTION
### Motivation
- After a shot is triggered the pull label and visual cue should return to their idle positions rhythmically to match the cue strike, without changing the shooting mechanism which must fire immediately on release.

### Description
- Add `onStart` callback and wire it for pointer, wheel and keyboard interactions so the UI can capture the cue anchor when the user begins pulling, and cancel any pending return animation on new input.
- Implement `animateTo` / `animateToMin` on `PowerSlider` with an eased requestAnimationFrame loop and `_cancelReturnAnimation` to support smooth timed returns and to clear in-flight animations on destroy or new input.
- Update Pool Royale slider `onCommit` to call `fire()` immediately and then animate the slider back to `0%` using `animateToMin` with a duration scaled by the committed power (faster for stronger shots).
- Ensure `PowerSlider.destroy()` cancels animations and cleanup remains unchanged.

### Testing
- Ran `node --check webapp/public/power-slider.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df5dac796c832993c2150572318413)