### PR TITLE
Pool Royale: remove American variant, tighten 9‑ball rules, brighten cloths & switch LT finishes, force rail broadcast on pre-contact cushion

### DIFF
--- a/lib/nineBall.js
+++ b/lib/nineBall.js
@@ -2,8 +2,18 @@ function opponent (p) {
   return p === 'A' ? 'B' : 'A';
 }
 
+function toFiniteCount (value) {
+  return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+
 export class NineBall {
-  constructor () {
+  constructor (options = {}) {
+    this.rules = {
+      enforceThreeFoulLoss: options.enforceThreeFoulLoss !== false,
+      legalBreakMinRails: Number.isFinite(options.legalBreakMinRails)
+        ? Math.max(1, Math.floor(options.legalBreakMinRails))
+        : 4
+    };
     this.state = {
       ballsOnTable: new Set([1, 2, 3, 4, 5, 6, 7, 8, 9]),
       currentPlayer: 'A',
@@ -11,7 +21,9 @@ export class NineBall {
       gameOver: false,
       winner: null,
       foulStreak: { A: 0, B: 0 },
-      breakInProgress: true
+      breakInProgress: true,
+      pushOutAvailable: false,
+      pushOutInProgress: false
     };
   }
 
@@ -19,23 +31,27 @@ export class NineBall {
     const s = this.state;
     const contactOrder = Array.isArray(shot.contactOrder) ? shot.contactOrder : [];
     const pottedList = Array.isArray(shot.potted) ? shot.potted : [];
+
     if (s.gameOver) {
       return { legal: false, foul: true, reason: 'game over', potted: [], nextPlayer: s.currentPlayer, ballInHandNext: false, frameOver: true, winner: s.winner };
     }
+
     const current = s.currentPlayer;
     const opp = opponent(current);
     const lowest = s.ballsOnTable.size ? Math.min(...s.ballsOnTable) : null;
     const wasBreakShot = Boolean(s.breakInProgress);
+    const isPushOutShot = Boolean(s.pushOutInProgress && shot.pushOut === true);
+
     let foul = false;
     let reason = '';
 
     const first = contactOrder[0];
-    if (!foul && !first) {
+    if (!first) {
       foul = true;
       reason = 'no contact';
     }
 
-    if (!foul && first !== lowest) {
+    if (!foul && !isPushOutShot && first !== lowest) {
       foul = true;
       reason = 'wrong first contact';
     }
@@ -46,7 +62,21 @@ export class NineBall {
     }
 
     const pottedBalls = pottedList.filter(id => id !== 0);
-    if (!foul && shot.noCushionAfterContact && pottedBalls.length === 0) {
+    const railsAfterContact = toFiniteCount(shot.railsAfterContact);
+    const breakObjectBallsToRail = toFiniteCount(shot.breakObjectBallsToRail);
+
+    if (!foul && wasBreakShot) {
+      const legalBreakByEvent =
+        typeof shot.legalBreak === 'boolean'
+          ? shot.legalBreak
+          : (pottedBalls.length > 0 || breakObjectBallsToRail >= this.rules.legalBreakMinRails);
+      if (!legalBreakByEvent) {
+        foul = true;
+        reason = 'illegal break';
+      }
+    }
+
+    if (!foul && !isPushOutShot && !wasBreakShot && pottedBalls.length === 0 && railsAfterContact === 0 && shot.noCushionAfterContact) {
       foul = true;
       reason = 'no cushion';
     }
@@ -55,48 +85,73 @@ export class NineBall {
     let ballInHandNext = false;
     let frameOver = false;
     let winner = null;
-    const foulLimit = 3;
+
+    const spotNineIfNeeded = () => {
+      if (pottedBalls.includes(9)) {
+        s.ballsOnTable.add(9);
+      }
+    };
 
     if (foul) {
-      // Any object balls potted on a foul stay down except the nine, which is
-      // spotted back on the table. The inning still passes to the opponent.
       for (const id of pottedBalls) {
-        if (id === 9) s.ballsOnTable.add(id);
-        else s.ballsOnTable.delete(id);
+        if (id === 9) continue;
+        s.ballsOnTable.delete(id);
       }
+      spotNineIfNeeded();
       nextPlayer = opp;
       ballInHandNext = true;
       s.currentPlayer = opp;
       s.foulStreak[current] = (s.foulStreak[current] ?? 0) + 1;
       s.foulStreak[opp] = 0;
+      s.pushOutAvailable = false;
+      s.pushOutInProgress = false;
     } else {
       for (const id of pottedBalls) s.ballsOnTable.delete(id);
       s.foulStreak[current] = 0;
       s.foulStreak[opp] = 0;
-      if (pottedBalls.includes(9)) {
+
+      if (wasBreakShot && pottedBalls.includes(9)) {
         frameOver = true;
         winner = current;
-        s.gameOver = true;
-        s.winner = winner;
+      } else if (!isPushOutShot && pottedBalls.includes(9)) {
+        frameOver = true;
+        winner = current;
       }
-      if (frameOver) {
-        nextPlayer = current;
-      } else if (pottedBalls.length === 0) {
-        nextPlayer = opp;
-        s.currentPlayer = opp;
+
+      if (!frameOver) {
+        if (isPushOutShot || pottedBalls.length === 0) {
+          nextPlayer = opp;
+          s.currentPlayer = opp;
+        } else {
+          nextPlayer = current;
+        }
+      }
+
+      if (wasBreakShot) {
+        s.pushOutAvailable = true;
+        s.pushOutInProgress = Boolean(nextPlayer === current && shot.allowPushOut !== false);
+      } else {
+        s.pushOutAvailable = false;
+        s.pushOutInProgress = false;
       }
     }
 
     s.ballInHand = ballInHandNext;
-    if (wasBreakShot || !foul || pottedBalls.length > 0 || shot.breakComplete) {
+    if (wasBreakShot || shot.breakComplete || !s.breakInProgress) {
       s.breakInProgress = false;
+      if (!wasBreakShot) s.pushOutInProgress = false;
     }
 
-    if (!frameOver && s.foulStreak[current] >= foulLimit) {
+    if (!frameOver && this.rules.enforceThreeFoulLoss && s.foulStreak[current] >= 3) {
       frameOver = true;
       winner = opp;
+    }
+
+    if (frameOver) {
       s.gameOver = true;
       s.winner = winner;
+      s.pushOutAvailable = false;
+      s.pushOutInProgress = false;
     }
 
     return {
@@ -107,7 +162,9 @@ export class NineBall {
       nextPlayer,
       ballInHandNext,
       frameOver,
-      winner
+      winner,
+      pushOutAvailable: Boolean(s.pushOutAvailable),
+      pushOutInProgress: Boolean(s.pushOutInProgress)
     };
   }
 }

--- a/rules/9-ball-rules.md
+++ b/rules/9-ball-rules.md
@@ -2,14 +2,32 @@
 title: 9-ball rules
 slug: rules-9-ball
 locale: en
-version: 1.0.0
+version: 1.1.0
 ---
 ## Objective
-Legally pocket the 9-ball. Shots must contact the lowest numbered ball first.
+Legally pocket the 9-ball after first contacting the lowest-numbered object ball on the table.
 
 ## Legal shot
-Hit the lowest-numbered ball first; then either pocket a ball or drive any ball to a rail.
+- The cue ball must first contact the lowest-numbered object ball.
+- After that contact, at least one ball must be pocketed or any ball must contact a rail.
+- Combination shots are legal, including combinations that pocket the 9-ball, as long as the first contact is legal.
+
+## Break shot
+- The cue ball must strike the 1-ball first.
+- A legal break requires at least one pocketed object ball **or** at least four object balls driven to rails.
+- If the 9-ball is pocketed on a legal break, it counts as a win.
+
+## Push-out (after legal break)
+- The incoming player may declare a push-out only on the first shot after a legal break.
+- During a push-out, normal rail/pocket requirements are suspended.
+- The push-out inning always passes to the opponent afterward.
 
 ## Fouls
 - Failing to hit the lowest-numbered ball first.
-- Cue ball scratch.
+- Cue ball scratch or cue ball off the table.
+- No rail or pocket after legal first contact (except on a declared push-out).
+- Illegal break.
+- Pocketing the 9-ball on a foul (the 9-ball is spotted, inning passes with ball-in-hand).
+
+## Penalty
+Most fouls give the opponent ball-in-hand anywhere on the table.

--- a/webapp/src/config/gameAssets.js
+++ b/webapp/src/config/gameAssets.js
@@ -59,7 +59,6 @@ export const lobbyOptionIcons = {
     'mode-ai': 'lobby/pool-royale/mode-ai.webp',
     'mode-online': 'lobby/pool-royale/mode-online.webp',
     'variant-uk': '/assets/icons/8ballrack.png',
-    'variant-american': '/assets/icons/American%20Billiards%20.png',
     'variant-9ball': '/assets/icons/9ballrack.png',
     'ball-uk': '/assets/icons/8ballrack.png',
     'ball-american': '/assets/icons/American%20Billiards%20.png'
@@ -161,7 +160,6 @@ export const lobbyOptionIcons = {
 export const variantThumbnails = {
   poolroyale: {
     uk: '/assets/icons/8ballrack.png',
-    american: '/assets/icons/American%20Billiards%20.png',
     '9ball': '/assets/icons/9ballrack.png'
   }
 };

--- a/webapp/src/config/poolRoyaleClothPresets.js
+++ b/webapp/src/config/poolRoyaleClothPresets.js
@@ -63,13 +63,13 @@ const CABAN_TONE_GROUPS = Object.freeze([
     idPrefix: 'cabanBeige',
     label: 'Burgundy',
     tones: ['Ruby', 'Merlot', 'Oxblood'],
-    hex: ['#8a2b3e', '#6b1e30', '#4d1322']
+    hex: ['#933346', '#742739', '#571c2a']
   },
   {
     idPrefix: 'cabanDarkGrey',
     label: 'Dark Grey',
     tones: ['Slate', 'Graphite', 'Charcoal'],
-    hex: ['#646a72', '#4c525b', '#333840']
+    hex: ['#6d737b', '#575d66', '#3e434b']
   }
 ])
 

--- a/webapp/src/config/poolRoyaleTraining.js
+++ b/webapp/src/config/poolRoyaleTraining.js
@@ -3,7 +3,7 @@ const DIFFICULTY_LABELS = ['Intro', 'Rookie', 'Challenger', 'Advanced', 'Elite']
 const TRAINING_BLUEPRINTS = [
   {
     title: 'Corner tap-in',
-    discipline: 'American Billiards',
+    discipline: '8Ball',
     objective: 'Feather the overhanging ball into the corner without scratching.',
     cue: { x: -0.62, z: -0.68 },
     balls: [{ rackIndex: 1, x: 0.78, z: 0.84 }],
@@ -21,7 +21,7 @@ const TRAINING_BLUEPRINTS = [
   },
   {
     title: 'Long straight stun',
-    discipline: 'American Billiards',
+    discipline: '8Ball',
     objective: 'Drill the down-table ball cleanly and leave the cue ball centred for the next shot.',
     cue: { x: -0.36, z: 0.52 },
     balls: [{ rackIndex: 3, x: 0, z: -0.64 }],
@@ -39,7 +39,7 @@ const TRAINING_BLUEPRINTS = [
   },
   {
     title: 'Two-ball pattern',
-    discipline: 'American Billiards',
+    discipline: '8Ball',
     objective: 'Clear two open balls while floating gently into shape.',
     cue: { x: -0.52, z: -0.28 },
     balls: [
@@ -63,7 +63,7 @@ const TRAINING_BLUEPRINTS = [
   },
   {
     title: 'Bank safety',
-    discipline: 'American Billiards',
+    discipline: '8Ball',
     objective: 'Bank off the long rail, pocket the ball, and hide behind the blocker.',
     cue: { x: -0.62, z: -0.14 },
     balls: [
@@ -100,7 +100,7 @@ const TRAINING_BLUEPRINTS = [
   },
   {
     title: 'Combo finisher',
-    discipline: 'American Billiards',
+    discipline: '8Ball',
     objective: 'Nudge the lead ball to combo the hanger while keeping shape.',
     cue: { x: -0.46, z: -0.22 },
     balls: [
@@ -117,7 +117,6 @@ const clamp = (value) => Math.max(-0.94, Math.min(0.94, value));
 const DISCIPLINE_TO_VARIANT = {
   '8Ball': 'uk',
   '9-Ball': '9ball',
-  'American Billiards': 'american'
 };
 
 const DIFFICULTY_STEPS = [
@@ -156,7 +155,7 @@ export const TRAINING_SCENARIOS = (() => {
       };
 
       const shotLimit = resolveShotLimit(blueprint, tier);
-      const variant = DISCIPLINE_TO_VARIANT[blueprint.discipline] || 'american';
+      const variant = DISCIPLINE_TO_VARIANT[blueprint.discipline] || 'uk';
       const reward = Math.round(60 + level * 10 + (tier.rewardBonus || 0));
       scenarios.push({
         level,

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1994,7 +1994,7 @@ const WOOD_REPEAT_SCALE_MIN = 0.5;
 const WOOD_REPEAT_SCALE_MAX = 2;
 const DEFAULT_WOOD_REPEAT_SCALE = FIXED_WOOD_REPEAT_SCALE;
 const GLTF_RAIL_PATTERN_REPEAT_MULTIPLIER = 2.275; // shrink GLTF rail grain by ~30% (smaller pattern tiles) while keeping leg density aligned.
-const DEFAULT_POOL_VARIANT = 'american';
+const DEFAULT_POOL_VARIANT = 'uk';
 const UK_POOL_RED = 0xd12c2c;
 const UK_POOL_YELLOW = 0xffd700;
 const UK_POOL_BLACK = 0x000000;
@@ -2163,7 +2163,10 @@ function resolvePoolVariant(variantId, ballSet = null) {
     normalized === '8balluk' ||
     normalized === 'eightballuk' ||
     normalized === '8pooluk' ||
-    normalized === 'uk8'
+    normalized === 'uk8' ||
+    normalized === 'american' ||
+    normalized === 'american8ball' ||
+    normalized === 'us8ball'
   ) {
     key = 'uk';
   }
@@ -3294,8 +3297,8 @@ const TABLE_FINISHES = Object.freeze({
     rail: 0x242b36,
     base: 0x242b36,
     trim: 0x242b36,
-    woodTextureId: 'plastic_monoblock_lt_black',
-    woodRepeatScale: 1,
+    woodTextureId: 'rosewood_veneer_01',
+    woodRepeatScale: POLYHAVEN_WOOD_TEXTURE_REPEAT_SCALE.rosewood_veneer_01,
     disableWoodPattern: true,
     surfaceStyle: 'matte',
     useBrandCarbonTexture: false
@@ -3303,11 +3306,11 @@ const TABLE_FINISHES = Object.freeze({
   carbonFiberChalkGrey: createStandardWoodFinish({
     id: 'carbonFiberChalkGrey',
     label: 'LT Grey',
-    rail: 0xb3bcc8,
-    base: 0xb3bcc8,
-    trim: 0xb3bcc8,
-    woodTextureId: 'plastic_monoblock_lt_grey',
-    woodRepeatScale: 1,
+    rail: 0xb8c2ce,
+    base: 0xb8c2ce,
+    trim: 0xb8c2ce,
+    woodTextureId: 'rosewood_veneer_01',
+    woodRepeatScale: POLYHAVEN_WOOD_TEXTURE_REPEAT_SCALE.rosewood_veneer_01,
     disableWoodPattern: true,
     surfaceStyle: 'matte',
     useBrandCarbonTexture: false
@@ -3318,8 +3321,8 @@ const TABLE_FINISHES = Object.freeze({
     rail: 0x687381,
     base: 0x687381,
     trim: 0x687381,
-    woodTextureId: 'plastic_monoblock_lt_dark_grey',
-    woodRepeatScale: 1,
+    woodTextureId: 'rosewood_veneer_01',
+    woodRepeatScale: POLYHAVEN_WOOD_TEXTURE_REPEAT_SCALE.rosewood_veneer_01,
     disableWoodPattern: true,
     surfaceStyle: 'matte',
     useBrandCarbonTexture: false
@@ -3327,11 +3330,11 @@ const TABLE_FINISHES = Object.freeze({
   carbonFiberChalkDarkBlue: createStandardWoodFinish({
     id: 'carbonFiberChalkDarkBlue',
     label: 'LT Burgundy',
-    rail: 0xa95b60,
-    base: 0xa95b60,
-    trim: 0xa95b60,
-    woodTextureId: 'plastic_monoblock_lt_burgundy',
-    woodRepeatScale: 1,
+    rail: 0xad6166,
+    base: 0xad6166,
+    trim: 0xad6166,
+    woodTextureId: 'rosewood_veneer_01',
+    woodRepeatScale: POLYHAVEN_WOOD_TEXTURE_REPEAT_SCALE.rosewood_veneer_01,
     disableWoodPattern: true,
     surfaceStyle: 'matte',
     useBrandCarbonTexture: false
@@ -3342,8 +3345,8 @@ const TABLE_FINISHES = Object.freeze({
     rail: 0xf6ead7,
     base: 0xf6ead7,
     trim: 0xf6ead7,
-    woodTextureId: 'plastic_monoblock_lt_milk_cream',
-    woodRepeatScale: 1,
+    woodTextureId: 'rosewood_veneer_01',
+    woodRepeatScale: POLYHAVEN_WOOD_TEXTURE_REPEAT_SCALE.rosewood_veneer_01,
     disableWoodPattern: true,
     surfaceStyle: 'matte',
     useBrandCarbonTexture: false
@@ -3354,8 +3357,8 @@ const TABLE_FINISHES = Object.freeze({
     rail: 0x4b7958,
     base: 0x4b7958,
     trim: 0x4b7958,
-    woodTextureId: 'plastic_monoblock_lt_dark_green',
-    woodRepeatScale: 1,
+    woodTextureId: 'rosewood_veneer_01',
+    woodRepeatScale: POLYHAVEN_WOOD_TEXTURE_REPEAT_SCALE.rosewood_veneer_01,
     disableWoodPattern: true,
     surfaceStyle: 'matte',
     useBrandCarbonTexture: false
@@ -3366,8 +3369,8 @@ const TABLE_FINISHES = Object.freeze({
     rail: 0xc59a48,
     base: 0xc59a48,
     trim: 0xc59a48,
-    woodTextureId: 'plastic_monoblock_lt_dark_yellow',
-    woodRepeatScale: 1,
+    woodTextureId: 'rosewood_veneer_01',
+    woodRepeatScale: POLYHAVEN_WOOD_TEXTURE_REPEAT_SCALE.rosewood_veneer_01,
     disableWoodPattern: true,
     surfaceStyle: 'matte',
     useBrandCarbonTexture: false
@@ -3378,8 +3381,8 @@ const TABLE_FINISHES = Object.freeze({
     rail: 0x8a6045,
     base: 0x8a6045,
     trim: 0x8a6045,
-    woodTextureId: 'plastic_monoblock_lt_dark_brown',
-    woodRepeatScale: 1,
+    woodTextureId: 'rosewood_veneer_01',
+    woodRepeatScale: POLYHAVEN_WOOD_TEXTURE_REPEAT_SCALE.rosewood_veneer_01,
     disableWoodPattern: true,
     surfaceStyle: 'matte',
     useBrandCarbonTexture: false
@@ -3390,8 +3393,8 @@ const TABLE_FINISHES = Object.freeze({
     rail: 0x9e4646,
     base: 0x9e4646,
     trim: 0x9e4646,
-    woodTextureId: 'plastic_monoblock_lt_dark_red',
-    woodRepeatScale: 1,
+    woodTextureId: 'rosewood_veneer_01',
+    woodRepeatScale: POLYHAVEN_WOOD_TEXTURE_REPEAT_SCALE.rosewood_veneer_01,
     disableWoodPattern: true,
     surfaceStyle: 'matte',
     useBrandCarbonTexture: false
@@ -3402,8 +3405,8 @@ const TABLE_FINISHES = Object.freeze({
     rail: 0x242b36,
     base: 0x242b36,
     trim: 0x242b36,
-    woodTextureId: 'plastic_monoblock_lt_black_snake',
-    woodRepeatScale: 1,
+    woodTextureId: 'rosewood_veneer_01',
+    woodRepeatScale: POLYHAVEN_WOOD_TEXTURE_REPEAT_SCALE.rosewood_veneer_01,
     disableWoodPattern: true,
     surfaceStyle: 'matte',
     useBrandCarbonTexture: false
@@ -3411,11 +3414,11 @@ const TABLE_FINISHES = Object.freeze({
   carbonFiberSnakeChalkGrey: createStandardWoodFinish({
     id: 'carbonFiberSnakeChalkGrey',
     label: 'LT Grey Snake',
-    rail: 0xb3bcc8,
-    base: 0xb3bcc8,
-    trim: 0xb3bcc8,
-    woodTextureId: 'plastic_monoblock_lt_grey_snake',
-    woodRepeatScale: 1,
+    rail: 0xb8c2ce,
+    base: 0xb8c2ce,
+    trim: 0xb8c2ce,
+    woodTextureId: 'rosewood_veneer_01',
+    woodRepeatScale: POLYHAVEN_WOOD_TEXTURE_REPEAT_SCALE.rosewood_veneer_01,
     disableWoodPattern: true,
     surfaceStyle: 'matte',
     useBrandCarbonTexture: false
@@ -3426,8 +3429,8 @@ const TABLE_FINISHES = Object.freeze({
     rail: 0x687381,
     base: 0x687381,
     trim: 0x687381,
-    woodTextureId: 'plastic_monoblock_lt_dark_grey_snake',
-    woodRepeatScale: 1,
+    woodTextureId: 'rosewood_veneer_01',
+    woodRepeatScale: POLYHAVEN_WOOD_TEXTURE_REPEAT_SCALE.rosewood_veneer_01,
     disableWoodPattern: true,
     surfaceStyle: 'matte',
     useBrandCarbonTexture: false
@@ -3435,11 +3438,11 @@ const TABLE_FINISHES = Object.freeze({
   carbonFiberSnakeChalkDarkBlue: createStandardWoodFinish({
     id: 'carbonFiberSnakeChalkDarkBlue',
     label: 'LT Burgundy Snake',
-    rail: 0xa95b60,
-    base: 0xa95b60,
-    trim: 0xa95b60,
-    woodTextureId: 'plastic_monoblock_lt_burgundy_snake',
-    woodRepeatScale: 1,
+    rail: 0xad6166,
+    base: 0xad6166,
+    trim: 0xad6166,
+    woodTextureId: 'rosewood_veneer_01',
+    woodRepeatScale: POLYHAVEN_WOOD_TEXTURE_REPEAT_SCALE.rosewood_veneer_01,
     disableWoodPattern: true,
     surfaceStyle: 'matte',
     useBrandCarbonTexture: false
@@ -3450,8 +3453,8 @@ const TABLE_FINISHES = Object.freeze({
     rail: 0xf6ead7,
     base: 0xf6ead7,
     trim: 0xf6ead7,
-    woodTextureId: 'plastic_monoblock_lt_milk_cream_snake',
-    woodRepeatScale: 1,
+    woodTextureId: 'rosewood_veneer_01',
+    woodRepeatScale: POLYHAVEN_WOOD_TEXTURE_REPEAT_SCALE.rosewood_veneer_01,
     disableWoodPattern: true,
     surfaceStyle: 'matte',
     useBrandCarbonTexture: false
@@ -3462,8 +3465,8 @@ const TABLE_FINISHES = Object.freeze({
     rail: 0x4b7958,
     base: 0x4b7958,
     trim: 0x4b7958,
-    woodTextureId: 'plastic_monoblock_lt_dark_green_snake',
-    woodRepeatScale: 1,
+    woodTextureId: 'rosewood_veneer_01',
+    woodRepeatScale: POLYHAVEN_WOOD_TEXTURE_REPEAT_SCALE.rosewood_veneer_01,
     disableWoodPattern: true,
     surfaceStyle: 'matte',
     useBrandCarbonTexture: false
@@ -3474,8 +3477,8 @@ const TABLE_FINISHES = Object.freeze({
     rail: 0x556b3f,
     base: 0x556b3f,
     trim: 0x556b3f,
-    woodTextureId: 'plastic_monoblock_lt_olive_alligator',
-    woodRepeatScale: 1,
+    woodTextureId: 'rosewood_veneer_01',
+    woodRepeatScale: POLYHAVEN_WOOD_TEXTURE_REPEAT_SCALE.rosewood_veneer_01,
     disableWoodPattern: true,
     surfaceStyle: 'matte',
     useBrandCarbonTexture: false
@@ -3486,8 +3489,8 @@ const TABLE_FINISHES = Object.freeze({
     rail: 0x3f5a3c,
     base: 0x3f5a3c,
     trim: 0x3f5a3c,
-    woodTextureId: 'plastic_monoblock_lt_swamp_alligator',
-    woodRepeatScale: 1,
+    woodTextureId: 'rosewood_veneer_01',
+    woodRepeatScale: POLYHAVEN_WOOD_TEXTURE_REPEAT_SCALE.rosewood_veneer_01,
     disableWoodPattern: true,
     surfaceStyle: 'matte',
     useBrandCarbonTexture: false
@@ -3498,8 +3501,8 @@ const TABLE_FINISHES = Object.freeze({
     rail: 0x6f5b45,
     base: 0x6f5b45,
     trim: 0x6f5b45,
-    woodTextureId: 'plastic_monoblock_lt_clay_alligator',
-    woodRepeatScale: 1,
+    woodTextureId: 'rosewood_veneer_01',
+    woodRepeatScale: POLYHAVEN_WOOD_TEXTURE_REPEAT_SCALE.rosewood_veneer_01,
     disableWoodPattern: true,
     surfaceStyle: 'matte',
     useBrandCarbonTexture: false
@@ -3510,8 +3513,8 @@ const TABLE_FINISHES = Object.freeze({
     rail: 0x8a7b5e,
     base: 0x8a7b5e,
     trim: 0x8a7b5e,
-    woodTextureId: 'plastic_monoblock_lt_sand_alligator',
-    woodRepeatScale: 1,
+    woodTextureId: 'rosewood_veneer_01',
+    woodRepeatScale: POLYHAVEN_WOOD_TEXTURE_REPEAT_SCALE.rosewood_veneer_01,
     disableWoodPattern: true,
     surfaceStyle: 'matte',
     useBrandCarbonTexture: false
@@ -3522,8 +3525,8 @@ const TABLE_FINISHES = Object.freeze({
     rail: 0x4f6048,
     base: 0x4f6048,
     trim: 0x4f6048,
-    woodTextureId: 'plastic_monoblock_lt_moss_alligator',
-    woodRepeatScale: 1,
+    woodTextureId: 'rosewood_veneer_01',
+    woodRepeatScale: POLYHAVEN_WOOD_TEXTURE_REPEAT_SCALE.rosewood_veneer_01,
     disableWoodPattern: true,
     surfaceStyle: 'matte',
     useBrandCarbonTexture: false
@@ -3534,8 +3537,8 @@ const TABLE_FINISHES = Object.freeze({
     rail: 0x2f3c32,
     base: 0x2f3c32,
     trim: 0x2f3c32,
-    woodTextureId: 'plastic_monoblock_lt_night_alligator',
-    woodRepeatScale: 1,
+    woodTextureId: 'rosewood_veneer_01',
+    woodRepeatScale: POLYHAVEN_WOOD_TEXTURE_REPEAT_SCALE.rosewood_veneer_01,
     disableWoodPattern: true,
     surfaceStyle: 'matte',
     useBrandCarbonTexture: false
@@ -15265,6 +15268,7 @@ function PoolRoyaleGame({
     cushionAfterContact: false,
     railContactCountAfterContact: 0,
     doubleBankBroadcastCutApplied: false,
+    railSearchBroadcastCutApplied: false,
     attemptsPenaltyApplied: false
   });
   const shotReplayRef = useRef(null);
@@ -26106,6 +26110,7 @@ const powerRef = useRef(hud.power);
           cushionAfterContact: false,
           railContactCountAfterContact: 0,
           doubleBankBroadcastCutApplied: false,
+          railSearchBroadcastCutApplied: false,
           attemptsPenaltyApplied: false,
           spin: {
             x: appliedSpinSnapshot.x ?? 0,
@@ -29447,6 +29452,7 @@ const powerRef = useRef(hud.power);
           cushionAfterContact: false,
           railContactCountAfterContact: 0,
           doubleBankBroadcastCutApplied: false,
+          railSearchBroadcastCutApplied: false,
           attemptsPenaltyApplied: false,
           spin: { x: 0, y: 0 }
         };
@@ -30974,6 +30980,22 @@ const powerRef = useRef(hud.power);
             }
             const railImpact = reflectRails(b);
             if (railImpact && b.id === 'cue') b.impacted = true;
+            if (
+              railImpact &&
+              b.id === 'cue' &&
+              !shotContextRef.current.contactMade &&
+              !shotContextRef.current.railSearchBroadcastCutApplied
+            ) {
+              shotContextRef.current.railSearchBroadcastCutApplied = true;
+              if (activeShotView?.mode === 'action') {
+                activeShotView.preferRailOverhead = true;
+                activeShotView.pendingActivation = false;
+                activeShotView.activationDelay = null;
+                activeShotView.activationTravel = 0;
+              }
+              queuedPocketView = null;
+              enterTopView(true, { variant: 'rail' });
+            }
             if (railImpact && shotContextRef.current.contactMade) {
               shotContextRef.current.cushionAfterContact = true;
               shotContextRef.current.railContactCountAfterContact =

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -740,10 +740,9 @@ export default function PoolRoyaleLobby() {
                   Ruleset
                 </span>
               </div>
-              <div className="grid grid-cols-3 gap-3">
+              <div className="grid grid-cols-2 gap-3">
                 {[
                   { id: 'uk', label: '8Ball' },
-                  { id: 'american', label: 'American' },
                   { id: '9ball', label: '9-Ball' }
                 ].map(({ id, label }) => {
                   const active = variant === id;


### PR DESCRIPTION
### Motivation
- Simplify Pool Royale by removing the standalone American ruleset while keeping American ball visuals available for 8‑Ball, and ensure 9‑Ball follows official rules (legal break, push‑out, fouls, spotting the 9). 
- Improve visuals by slightly brightening burgundy and dark‑grey cloth presets and update LT finishes to use the real GLTF rosewood veneer pattern with a small brightness lift. 
- Improve broadcast clarity by forcing the rail‑overhead broadcast camera when the cue ball hits a cushion before first object‑ball contact (kick/search situations) while preserving the existing double‑bank cut behavior.

### Description
- Game variants and UI: removed the American variant from the lobby selector and variant thumbnails while retaining the American ball visuals as an 8Ball ball‑set option, and changed the default/resolve logic so ambiguous American ids resolve to UK/8Ball. (files: `webapp/src/pages/Games/PoolRoyaleLobby.jsx`, `webapp/src/config/gameAssets.js`, `webapp/src/pages/Games/PoolRoyale.jsx`).
- 9‑Ball rules and logic: replaced `lib/nineBall.js` with a new implementation adding legal‑break validation (pocket or configurable rails count), push‑out support, illegal‑break detection, 9‑ball spotting on fouls, and configurable three‑foul loss enforcement; updated the public rules doc `rules/9-ball-rules.md` to match. (files: `lib/nineBall.js`, `rules/9-ball-rules.md`).
- Visual updates: brightened the burgundy and dark‑grey cloth tone groups by adjusting hex values in `webapp/src/config/poolRoyaleClothPresets.js`, and changed LT table finishes to use the `rosewood_veneer_01` GLTF wood pattern and slightly brighter LT Grey / LT Burgundy color values in the Pool Royale table finishes registry. (file: `webapp/src/pages/Games/PoolRoyale.jsx`, `webapp/src/config/poolRoyaleClothPresets.js`).
- Broadcast camera: added a short‑lived flag and logic to `PoolRoyale.jsx` that forces a rail‑overhead broadcast cut when the cue ball strikes a cushion before making object‑ball contact (rail search / kick scenarios), and preserved the existing double‑bank trigger that also forces rail overhead. (file: `webapp/src/pages/Games/PoolRoyale.jsx`).
- Training mapping: updated Pool Royale training blueprints to remove American discipline entries and default those drills to 8Ball/UK variant mapping. (file: `webapp/src/config/poolRoyaleTraining.js`).

### Testing
- Ran `node --check lib/nineBall.js` and `node --check` against the modified config modules (`webapp/src/config/poolRoyaleTraining.js`, `webapp/src/config/poolRoyaleClothPresets.js`, `webapp/src/config/gameAssets.js`), and all syntax checks passed. 
- Attempted repository lint with `npm run -s lint` for the changed JSX files, however the repo contains large pre‑existing lint issues in generated/dist files so the lint run surfaced many unrelated errors and cannot be used as a clean signal for these changes. 
- Verified local file modifications and committed the changes; no unit tests were added or modified as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfcb5e02b08329ac0db3e579ddfb2c)