### PR TITLE
Pool Royale: remove American mode, enforce 9‑ball break rules, brighten cloth & switch LT finish, and refine broadcast rail cuts

### DIFF
--- a/lib/nineBall.js
+++ b/lib/nineBall.js
@@ -26,6 +26,7 @@ export class NineBall {
     const opp = opponent(current);
     const lowest = s.ballsOnTable.size ? Math.min(...s.ballsOnTable) : null;
     const wasBreakShot = Boolean(s.breakInProgress);
+    const railContactsAfterFirstHit = Math.max(0, Number(shot.railContactsAfterFirstHit) || 0);
     let foul = false;
     let reason = '';
 
@@ -49,6 +50,13 @@ export class NineBall {
     if (!foul && shot.noCushionAfterContact && pottedBalls.length === 0) {
       foul = true;
       reason = 'no cushion';
+    }
+    if (!foul && wasBreakShot) {
+      const legalBreak = pottedBalls.length > 0 || railContactsAfterFirstHit >= 4;
+      if (!legalBreak) {
+        foul = true;
+        reason = 'illegal break';
+      }
     }
 
     let nextPlayer = current;

--- a/src/rules/PoolRoyaleRules.ts
+++ b/src/rules/PoolRoyaleRules.ts
@@ -1,10 +1,9 @@
 import { FrameState, Player, ShotContext, ShotEvent } from '../types';
 import { UkPool } from '../../lib/poolUk8Ball.js';
-import { AmericanBilliards } from '../../lib/americanBilliards.js';
 import { NineBall } from '../../lib/nineBall.js';
 import { BcaEightBall } from '../../lib/bcaEightBall.js';
 
-type PoolVariantId = 'american' | '8ball' | 'uk' | '9ball';
+type PoolVariantId = '8ball' | 'uk' | '9ball';
 
 type UkColour = 'blue' | 'red' | 'black' | 'cue';
 
@@ -41,19 +40,6 @@ type EightBallSerializedState = {
   breakInProgress: boolean;
 };
 
-type Race61SerializedState = {
-  ballsOnTable: number[];
-  currentPlayer: 'A' | 'B';
-  scores: { A: number; B: number };
-  assignments: { A: 'SOLID' | 'STRIPE' | null; B: 'SOLID' | 'STRIPE' | null };
-  ballInHand: boolean;
-  foulStreak: { A: number; B: number };
-  frameOver: boolean;
-  winner: 'A' | 'B' | 'TIE' | null;
-  breakInProgress: boolean;
-  targetScore: number;
-};
-
 type NineSerializedState = {
   ballsOnTable: number[];
   currentPlayer: 'A' | 'B';
@@ -74,12 +60,6 @@ type PoolMeta =
   | {
       variant: '8ball';
       state: EightBallSerializedState;
-      hud: HudInfo;
-      breakInProgress?: boolean;
-    }
-  | {
-      variant: 'american';
-      state: Race61SerializedState;
       hud: HudInfo;
       breakInProgress?: boolean;
     }
@@ -175,42 +155,6 @@ function applyEightBallState(game: BcaEightBall, snapshot: EightBallSerializedSt
   };
 }
 
-function serializeRace61State(state: AmericanBilliards['state']): Race61SerializedState {
-  return {
-    ballsOnTable: Array.from(state.ballsOnTable.values()),
-    currentPlayer: state.currentPlayer,
-    scores: { ...state.scores },
-    assignments: {
-      A: state.assignments?.A ?? null,
-      B: state.assignments?.B ?? null
-    },
-    ballInHand: state.ballInHand,
-    foulStreak: { ...state.foulStreak },
-    frameOver: state.frameOver,
-    winner: state.winner,
-    breakInProgress: state.breakInProgress,
-    targetScore: state.targetScore ?? 61
-  };
-}
-
-function applyRace61State(game: AmericanBilliards, snapshot: Race61SerializedState) {
-  game.state = {
-    ballsOnTable: new Set(snapshot.ballsOnTable),
-    currentPlayer: snapshot.currentPlayer,
-    scores: { ...snapshot.scores },
-    assignments: {
-      A: snapshot.assignments?.A ?? null,
-      B: snapshot.assignments?.B ?? null
-    },
-    ballInHand: snapshot.ballInHand,
-    foulStreak: { ...snapshot.foulStreak },
-    frameOver: snapshot.frameOver,
-    winner: snapshot.winner,
-    breakInProgress: snapshot.breakInProgress,
-    targetScore: snapshot.targetScore ?? 61
-  };
-}
-
 function serializeNineState(state: NineBall['state']): NineSerializedState {
   return {
     ballsOnTable: Array.from(state.ballsOnTable.values()),
@@ -296,13 +240,6 @@ export class PoolRoyaleRules {
       normalized === 'bca8ball'
     ) {
       this.variant = '8ball';
-    } else if (
-      normalized === 'race61' ||
-      normalized === 'american' ||
-      normalized === 'americanbilliards' ||
-      normalized === 'rotation61'
-    ) {
-      this.variant = 'american';
     } else if (normalized === '9ball' || normalized === 'nineball' || normalized === '9') {
       this.variant = '9ball';
     } else {
@@ -367,35 +304,6 @@ export class PoolRoyaleRules {
         } satisfies PoolMeta;
         return base;
       }
-      case 'american': {
-        const game = new AmericanBilliards();
-        game.state.ballInHand = true;
-        const snapshot = serializeRace61State(game.state);
-        const ballOn = this.computeRace61BallOn(snapshot);
-        const scores = this.computeRace61Scores(snapshot);
-        const base: FrameState = {
-          balls: [],
-          activePlayer: 'A',
-          players: basePlayers(playerA, playerB),
-          currentBreak: 0,
-          phase: 'REDS_AND_COLORS',
-          redsRemaining: snapshot.ballsOnTable.length,
-          ballOn,
-          frameOver: false
-        };
-        const hud: HudInfo = {
-          next: ballOn.length > 0 ? ballOn.join(' / ').toLowerCase() : 'frame over',
-          phase: 'rotation',
-          scores
-        };
-        base.meta = {
-          variant: 'american',
-          state: snapshot,
-          hud,
-          breakInProgress: true
-        } satisfies PoolMeta;
-        return base;
-      }
       case '8ball':
       default: {
         const game = new BcaEightBall();
@@ -434,8 +342,6 @@ export class PoolRoyaleRules {
         return this.applyUkShot(state, events, context);
       case '9ball':
         return this.applyNineBallShot(state, events, context);
-      case 'american':
-        return this.applyAmericanShot(state, events, context);
       case '8ball':
       default:
         return this.applyEightBallShot(state, events, context);
@@ -662,96 +568,6 @@ export class PoolRoyaleRules {
     return hasStripe ? ['STRIPE'] : state.ballsOnTable.includes(8) ? ['BLACK'] : [];
   }
 
-  private applyAmericanShot(state: FrameState, events: ShotEvent[], context: ShotContext): FrameState {
-    const meta = state.meta as PoolMeta | undefined;
-    const previous = meta && meta.variant === 'american' && meta.state ? meta : null;
-    const game = new AmericanBilliards();
-    if (previous) {
-      applyRace61State(game, previous.state);
-    } else {
-      game.state.ballInHand = true;
-    }
-    const contactOrder: number[] = [];
-    for (const ev of events) {
-      if (ev.type !== 'HIT') continue;
-      const id = parseNumericId(ev.ballId ?? ev.firstContact);
-      if (id != null) contactOrder.push(id);
-    }
-    const potted: number[] = [];
-    for (const ev of events) {
-      if (ev.type !== 'POTTED') continue;
-      if (isCueBallId(ev.ballId ?? ev.ball)) {
-        potted.push(0);
-      } else {
-        const id = parseNumericId(ev.ballId ?? ev.ball);
-        if (id != null) potted.push(id);
-      }
-    }
-    const result = game.shotTaken({
-      contactOrder,
-      potted,
-      cueOffTable: Boolean(context.cueBallPotted),
-      placedFromHand: Boolean(context.placedFromHand),
-      noCushionAfterContact: Boolean(context.noCushionAfterContact)
-    });
-    const pottedCount = potted.filter((id) => id !== 0).length;
-    const snapshot = serializeRace61State(game.state);
-    const ballOn = this.computeRace61BallOn(snapshot);
-    const scores = this.computeRace61Scores(snapshot);
-    const frameOver = snapshot.frameOver;
-    const nextLabel =
-      ballOn.length === 0
-        ? 'frame over'
-        : ballOn.map((entry) => entry.toLowerCase().replace('_', ' ')).join(' / ');
-    const hud: HudInfo = {
-      next: frameOver ? 'frame over' : nextLabel,
-      phase: frameOver ? 'complete' : 'rotation',
-      scores
-    };
-    const breakInProgress = Boolean(snapshot.breakInProgress);
-    return {
-      ...state,
-      activePlayer: game.state.currentPlayer,
-      players: {
-        A: { ...state.players.A, score: scores.A },
-        B: { ...state.players.B, score: scores.B }
-      },
-      currentBreak:
-        !result.foul && game.state.currentPlayer === state.activePlayer && pottedCount > 0
-          ? (state.currentBreak ?? 0) + pottedCount
-          : 0,
-      ballOn: frameOver ? [] : ballOn,
-      frameOver,
-      winner: snapshot.winner ?? undefined,
-      foul: result.foul
-        ? {
-            points: 0,
-            reason: result.reason ?? 'foul'
-          }
-        : undefined,
-      meta: {
-        variant: 'american',
-        state: snapshot,
-        hud,
-        breakInProgress
-      } satisfies PoolMeta
-    };
-  }
-
-  private computeRace61Scores(state: Race61SerializedState): { A: number; B: number } {
-    return {
-      A: state.scores?.A ?? 0,
-      B: state.scores?.B ?? 0
-    };
-  }
-
-  private computeRace61BallOn(state: Race61SerializedState): string[] {
-    if (state.frameOver) return [];
-    const lowest = lowestBall(state.ballsOnTable);
-    if (lowest == null) return [];
-    return [`BALL_${lowest}`];
-  }
-
   private applyNineBallShot(state: FrameState, events: ShotEvent[], context: ShotContext): FrameState {
     const meta = state.meta as PoolMeta | undefined;
     const previous = meta && meta.variant === '9ball' && meta.state ? meta : null;
@@ -782,7 +598,9 @@ export class PoolRoyaleRules {
       potted,
       cueOffTable: Boolean(context.cueBallPotted),
       placedFromHand: Boolean(context.placedFromHand),
-      noCushionAfterContact: Boolean(context.noCushionAfterContact)
+      noCushionAfterContact: Boolean(context.noCushionAfterContact),
+      breakShot: Boolean(previous?.state?.breakInProgress),
+      railContactsAfterFirstHit: Number(context.railContactCountAfterContact ?? 0)
     });
     const pottedCount = potted.filter((id) => id !== 0).length;
     const snapshot = serializeNineState(game.state);

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,6 +44,7 @@ export interface ShotContext {
   cueBallPotted?: boolean;
   contactMade?: boolean;
   cushionAfterContact?: boolean;
+  railContactCountAfterContact?: number;
   noCushionAfterContact?: boolean;
   nominatedBall?: BallColor|string;
   declaredBall?: BallColor|string;

--- a/test/poolRoyaleRules.test.ts
+++ b/test/poolRoyaleRules.test.ts
@@ -44,23 +44,21 @@ describe('PoolRoyaleRules', () => {
     expect(foulState.ballOn).toContain('YELLOW');
   });
 
-  test('American variant uses rotation logic with race to 61 and lowest-ball target', () => {
+  test('Legacy american variant key is remapped to 8-ball rules', () => {
     const rules = new PoolRoyaleRules('american');
     const initialFrame = rules.getInitialFrame('Breaker', 'Opponent');
     const initialMeta = initialFrame.meta as any;
 
-    expect(initialMeta?.variant).toBe('american');
+    expect(initialMeta?.variant).toBe('8ball');
     expect(initialMeta?.breakInProgress).toBe(true);
     expect(initialMeta?.state?.ballInHand).toBe(true);
-    expect(initialMeta?.state?.targetScore).toBe(61);
-    expect(initialMeta?.hud?.next).toBe('ball_1');
-    expect(initialMeta?.hud?.phase).toBe('rotation');
-    expect(initialFrame.ballOn).toEqual(['BALL_1']);
+    expect(initialMeta?.hud?.next).toBe('open table');
+    expect(initialMeta?.hud?.phase).toBe('groups');
+    expect(initialFrame.ballOn).toEqual(['SOLID', 'STRIPE']);
 
     const breakEvents: ShotEvent[] = [
       { type: 'HIT', firstContact: 1, ballId: 1 },
-      { type: 'POTTED', ball: 1, pocket: 'BL', ballId: 1 },
-      { type: 'POTTED', ball: 2, pocket: 'TM', ballId: 2 }
+      { type: 'POTTED', ball: 1, pocket: 'BL', ballId: 1 }
     ];
     const cleared = rules.applyShot(initialFrame, breakEvents, {
       placedFromHand: true,
@@ -71,10 +69,10 @@ describe('PoolRoyaleRules', () => {
 
     expect(clearedMeta?.breakInProgress).toBe(false);
     expect(clearedMeta?.state?.ballInHand).toBe(false);
-    expect(cleared.ballOn).toEqual(['BALL_3']);
-    expect(clearedMeta?.hud?.next).toBe('ball 3');
-    expect(clearedMeta?.hud?.phase).toBe('rotation');
-    expect(cleared.players.A.score).toBe(3);
+    expect(cleared.ballOn).toEqual(['SOLID']);
+    expect(clearedMeta?.hud?.next).toBe('solid');
+    expect(clearedMeta?.hud?.phase).toBe('groups');
+    expect(cleared.players.A.score).toBe(1);
     expect(cleared.activePlayer).toBe('A');
 
     const scratchEvents: ShotEvent[] = [
@@ -89,9 +87,9 @@ describe('PoolRoyaleRules', () => {
     expect(scratchMeta?.state?.ballInHand).toBe(true);
     expect(scratchMeta?.breakInProgress).toBe(false);
     expect(scratch.activePlayer).toBe('B');
-    expect(scratch.ballOn).toEqual(['BALL_3']);
-    expect(scratchMeta?.hud?.next).toBe('ball 3');
-    expect(scratchMeta?.hud?.phase).toBe('rotation');
+    expect(scratch.ballOn).toEqual(['STRIPE']);
+    expect(scratchMeta?.hud?.next).toBe('stripe');
+    expect(scratchMeta?.hud?.phase).toBe('groups');
   });
 
   test('Nine-ball enforces lowest-ball contact and updates HUD after recovery', () => {
@@ -109,7 +107,10 @@ describe('PoolRoyaleRules', () => {
       { type: 'HIT', firstContact: 1, ballId: 1 },
       { type: 'POTTED', ball: 1, pocket: 'TM', ballId: 1 }
     ];
-    const postBreak = rules.applyShot(initialFrame, breakEvents, { contactMade: true });
+    const postBreak = rules.applyShot(initialFrame, breakEvents, {
+      contactMade: true,
+      railContactCountAfterContact: 4
+    });
     const postBreakMeta = postBreak.meta as any;
 
     expect(postBreak.foul).toBeUndefined();
@@ -138,6 +139,18 @@ describe('PoolRoyaleRules', () => {
     expect(recoveryMeta?.state?.ballInHand).toBe(false);
     expect(recoveryState.ballOn).toEqual(['BALL_3']);
     expect(recoveryMeta?.hud?.next).toBe('ball 3');
+  });
+
+  test('9-ball marks an illegal break as foul when no ball is potted and rails are insufficient', () => {
+    const rules = new PoolRoyaleRules('9ball');
+    const initialFrame = rules.getInitialFrame('Breaker', 'Opponent');
+    const illegalBreak = rules.applyShot(
+      initialFrame,
+      [{ type: 'HIT', firstContact: 1, ballId: 1 }],
+      { contactMade: true, railContactCountAfterContact: 1 }
+    );
+    expect(illegalBreak.foul?.reason).toBe('illegal break');
+    expect(illegalBreak.activePlayer).toBe('B');
   });
 
   test('8-ball keeps its own rules and allows a legal black-ball finish', () => {

--- a/webapp/src/config/poolRoyaleClothPresets.js
+++ b/webapp/src/config/poolRoyaleClothPresets.js
@@ -63,13 +63,13 @@ const CABAN_TONE_GROUPS = Object.freeze([
     idPrefix: 'cabanBeige',
     label: 'Burgundy',
     tones: ['Ruby', 'Merlot', 'Oxblood'],
-    hex: ['#8a2b3e', '#6b1e30', '#4d1322']
+    hex: ['#933347', '#742739', '#5a1c2c']
   },
   {
     idPrefix: 'cabanDarkGrey',
     label: 'Dark Grey',
     tones: ['Slate', 'Graphite', 'Charcoal'],
-    hex: ['#646a72', '#4c525b', '#333840']
+    hex: ['#6f7680', '#59606b', '#3f454e']
   }
 ])
 

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1994,10 +1994,34 @@ const WOOD_REPEAT_SCALE_MIN = 0.5;
 const WOOD_REPEAT_SCALE_MAX = 2;
 const DEFAULT_WOOD_REPEAT_SCALE = FIXED_WOOD_REPEAT_SCALE;
 const GLTF_RAIL_PATTERN_REPEAT_MULTIPLIER = 2.275; // shrink GLTF rail grain by ~30% (smaller pattern tiles) while keeping leg density aligned.
-const DEFAULT_POOL_VARIANT = 'american';
+const DEFAULT_POOL_VARIANT = 'uk';
 const UK_POOL_RED = 0xd12c2c;
 const UK_POOL_YELLOW = 0xffd700;
 const UK_POOL_BLACK = 0x000000;
+const AMERICAN_BALL_SET = Object.freeze({
+  objectColors: [
+    0xffc52c, 0x0a58ff, 0xd32232, 0x8f32d6, 0xff7c1f, 0x0faa60, 0x651f28,
+    0x111111, 0xffc52c, 0x0a58ff, 0xd32232, 0x8f32d6, 0xff7c1f, 0x0faa60, 0x651f28
+  ],
+  objectNumbers: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+  objectPatterns: [
+    'solid',
+    'solid',
+    'solid',
+    'solid',
+    'solid',
+    'solid',
+    'solid',
+    'solid',
+    'stripe',
+    'stripe',
+    'stripe',
+    'stripe',
+    'stripe',
+    'stripe',
+    'stripe'
+  ]
+});
 const POOL_VARIANT_COLOR_SETS = Object.freeze({
   uk: {
     id: 'uk',
@@ -2040,64 +2064,6 @@ const POOL_VARIANT_COLOR_SETS = Object.freeze({
       null
     ],
     objectPatterns: new Array(15).fill('solid')
-  },
-  american: {
-    id: 'american',
-    label: 'American 8-Ball',
-    cueColor: 0xffffff,
-    rackLayout: 'triangle',
-    disableSnookerMarkings: true,
-    objectColors: [
-      0xffc52c,
-      0x0a58ff,
-      0xd32232,
-      0x8f32d6,
-      0xff7c1f,
-      0x0faa60,
-      0x651f28,
-      0x111111,
-      0xffc52c,
-      0x0a58ff,
-      0xd32232,
-      0x8f32d6,
-      0xff7c1f,
-      0x0faa60,
-      0x651f28
-    ],
-    objectNumbers: [
-      1,
-      2,
-      3,
-      4,
-      5,
-      6,
-      7,
-      8,
-      9,
-      10,
-      11,
-      12,
-      13,
-      14,
-      15
-    ],
-    objectPatterns: [
-      'solid',
-      'solid',
-      'solid',
-      'solid',
-      'solid',
-      'solid',
-      'solid',
-      'solid',
-      'stripe',
-      'stripe',
-      'stripe',
-      'stripe',
-      'stripe',
-      'stripe',
-      'stripe'
-    ]
   },
   '9ball': {
     id: '9ball',
@@ -2160,6 +2126,10 @@ function resolvePoolVariant(variantId, ballSet = null) {
   if (normalized === '9' || normalized === 'nineball') {
     key = '9ball';
   } else if (
+    normalized === 'american' ||
+    normalized === 'americanbilliards' ||
+    normalized === 'rotation61' ||
+    normalized === 'race61' ||
     normalized === '8balluk' ||
     normalized === 'eightballuk' ||
     normalized === '8pooluk' ||
@@ -2171,7 +2141,7 @@ function resolvePoolVariant(variantId, ballSet = null) {
     POOL_VARIANT_COLOR_SETS[key] || POOL_VARIANT_COLOR_SETS[DEFAULT_POOL_VARIANT];
   const ballSetKey = normalizeBallSetKey(ballSet);
   if (base.id === 'uk' && ballSetKey === 'american') {
-    const american = POOL_VARIANT_COLOR_SETS.american;
+    const american = AMERICAN_BALL_SET;
     return {
       ...base,
       ballSet: 'american',
@@ -2186,10 +2156,10 @@ function resolvePoolVariant(variantId, ballSet = null) {
 function deriveInHandFromFrame(frame) {
   const meta = frame && typeof frame === 'object' ? frame.meta : null;
   if (!meta || typeof meta !== 'object') return false;
-  if (meta.variant === 'american' && meta.state) {
+  if (meta.variant === '9ball' && meta.state) {
     return Boolean(meta.state.ballInHand);
   }
-  if (meta.variant === '9ball' && meta.state) {
+  if (meta.variant === '8ball' && meta.state) {
     return Boolean(meta.state.ballInHand);
   }
   if (meta.variant === 'uk' && meta.state) {
@@ -3291,108 +3261,108 @@ const TABLE_FINISHES = Object.freeze({
   carbonFiberChalk: createStandardWoodFinish({
     id: 'carbonFiberChalk',
     label: 'LT Black',
-    rail: 0x242b36,
-    base: 0x242b36,
-    trim: 0x242b36,
-    woodTextureId: 'plastic_monoblock_lt_black',
+    rail: 0x2a313d,
+    base: 0x2a313d,
+    trim: 0x2a313d,
+    woodTextureId: 'rosewood_veneer_01',
     woodRepeatScale: 1,
-    disableWoodPattern: true,
+    disableWoodPattern: false,
     surfaceStyle: 'matte',
     useBrandCarbonTexture: false
   }),
   carbonFiberChalkGrey: createStandardWoodFinish({
     id: 'carbonFiberChalkGrey',
     label: 'LT Grey',
-    rail: 0xb3bcc8,
-    base: 0xb3bcc8,
-    trim: 0xb3bcc8,
-    woodTextureId: 'plastic_monoblock_lt_grey',
+    rail: 0xbdc5cf,
+    base: 0xbdc5cf,
+    trim: 0xbdc5cf,
+    woodTextureId: 'rosewood_veneer_01',
     woodRepeatScale: 1,
-    disableWoodPattern: true,
+    disableWoodPattern: false,
     surfaceStyle: 'matte',
     useBrandCarbonTexture: false
   }),
   carbonFiberChalkBeige: createStandardWoodFinish({
     id: 'carbonFiberChalkBeige',
     label: 'LT Dark Grey',
-    rail: 0x687381,
-    base: 0x687381,
-    trim: 0x687381,
-    woodTextureId: 'plastic_monoblock_lt_dark_grey',
+    rail: 0x727d8b,
+    base: 0x727d8b,
+    trim: 0x727d8b,
+    woodTextureId: 'rosewood_veneer_01',
     woodRepeatScale: 1,
-    disableWoodPattern: true,
+    disableWoodPattern: false,
     surfaceStyle: 'matte',
     useBrandCarbonTexture: false
   }),
   carbonFiberChalkDarkBlue: createStandardWoodFinish({
     id: 'carbonFiberChalkDarkBlue',
     label: 'LT Burgundy',
-    rail: 0xa95b60,
-    base: 0xa95b60,
-    trim: 0xa95b60,
-    woodTextureId: 'plastic_monoblock_lt_burgundy',
+    rail: 0xb66569,
+    base: 0xb66569,
+    trim: 0xb66569,
+    woodTextureId: 'rosewood_veneer_01',
     woodRepeatScale: 1,
-    disableWoodPattern: true,
+    disableWoodPattern: false,
     surfaceStyle: 'matte',
     useBrandCarbonTexture: false
   }),
   carbonFiberChalkWhite: createStandardWoodFinish({
     id: 'carbonFiberChalkWhite',
     label: 'LT Milk Cream',
-    rail: 0xf6ead7,
-    base: 0xf6ead7,
-    trim: 0xf6ead7,
-    woodTextureId: 'plastic_monoblock_lt_milk_cream',
+    rail: 0xf8eedf,
+    base: 0xf8eedf,
+    trim: 0xf8eedf,
+    woodTextureId: 'rosewood_veneer_01',
     woodRepeatScale: 1,
-    disableWoodPattern: true,
+    disableWoodPattern: false,
     surfaceStyle: 'matte',
     useBrandCarbonTexture: false
   }),
   carbonFiberChalkDarkGreen: createStandardWoodFinish({
     id: 'carbonFiberChalkDarkGreen',
     label: 'LT Dark Green',
-    rail: 0x4b7958,
-    base: 0x4b7958,
-    trim: 0x4b7958,
-    woodTextureId: 'plastic_monoblock_lt_dark_green',
+    rail: 0x548460,
+    base: 0x548460,
+    trim: 0x548460,
+    woodTextureId: 'rosewood_veneer_01',
     woodRepeatScale: 1,
-    disableWoodPattern: true,
+    disableWoodPattern: false,
     surfaceStyle: 'matte',
     useBrandCarbonTexture: false
   }),
   carbonFiberChalkDarkYellow: createStandardWoodFinish({
     id: 'carbonFiberChalkDarkYellow',
     label: 'LT Dark Yellow',
-    rail: 0xc59a48,
-    base: 0xc59a48,
-    trim: 0xc59a48,
-    woodTextureId: 'plastic_monoblock_lt_dark_yellow',
+    rail: 0xd1a652,
+    base: 0xd1a652,
+    trim: 0xd1a652,
+    woodTextureId: 'rosewood_veneer_01',
     woodRepeatScale: 1,
-    disableWoodPattern: true,
+    disableWoodPattern: false,
     surfaceStyle: 'matte',
     useBrandCarbonTexture: false
   }),
   carbonFiberChalkDarkBrown: createStandardWoodFinish({
     id: 'carbonFiberChalkDarkBrown',
     label: 'LT Dark Brown',
-    rail: 0x8a6045,
-    base: 0x8a6045,
-    trim: 0x8a6045,
-    woodTextureId: 'plastic_monoblock_lt_dark_brown',
+    rail: 0x956b4f,
+    base: 0x956b4f,
+    trim: 0x956b4f,
+    woodTextureId: 'rosewood_veneer_01',
     woodRepeatScale: 1,
-    disableWoodPattern: true,
+    disableWoodPattern: false,
     surfaceStyle: 'matte',
     useBrandCarbonTexture: false
   }),
   carbonFiberChalkDarkRed: createStandardWoodFinish({
     id: 'carbonFiberChalkDarkRed',
     label: 'LT Dark Red',
-    rail: 0x9e4646,
-    base: 0x9e4646,
-    trim: 0x9e4646,
-    woodTextureId: 'plastic_monoblock_lt_dark_red',
+    rail: 0xaa5151,
+    base: 0xaa5151,
+    trim: 0xaa5151,
+    woodTextureId: 'rosewood_veneer_01',
     woodRepeatScale: 1,
-    disableWoodPattern: true,
+    disableWoodPattern: false,
     surfaceStyle: 'matte',
     useBrandCarbonTexture: false
   }),
@@ -23928,9 +23898,9 @@ const powerRef = useRef(hud.power);
           addCueStick(-PLAY_W * 0.2, rackStartZ + BALL_R * 4.2, -Math.PI * 0.04);
           addCueStick(PLAY_W * 0.22, baulkZ - BALL_R * 1.2, Math.PI * 0.06);
         } else {
-          const rackColors = POOL_VARIANT_COLOR_SETS.american.objectColors || [];
-          const rackNumbers = POOL_VARIANT_COLOR_SETS.american.objectNumbers || [];
-          const rackPatterns = POOL_VARIANT_COLOR_SETS.american.objectPatterns || [];
+          const rackColors = AMERICAN_BALL_SET.objectColors || [];
+          const rackNumbers = AMERICAN_BALL_SET.objectNumbers || [];
+          const rackPatterns = AMERICAN_BALL_SET.objectPatterns || [];
           const rackStartZ = SPOTS.pink[1] + BALL_R * 2 + RACK_VERTICAL_SCREEN_LIFT;
           const rackPositions = generateRackPositions(
             rackColors.length,
@@ -29021,7 +28991,7 @@ const powerRef = useRef(hud.power);
           if (shotRecording) {
             recordReplayFrame(performance.now());
           }
-          const variantId = activeVariantRef.current?.id ?? 'american';
+          const variantId = activeVariantRef.current?.id ?? 'uk';
           const shotEvents = [];
           const firstContactColor = toBallColorId(firstHit);
           const hadObjectPot = potted.some((entry) => entry.id !== 'cue');
@@ -30979,7 +30949,7 @@ const powerRef = useRef(hud.power);
               shotContextRef.current.railContactCountAfterContact =
                 (shotContextRef.current.railContactCountAfterContact ?? 0) + 1;
               if (
-                (shotContextRef.current.railContactCountAfterContact ?? 0) >= 2 &&
+                (shotContextRef.current.railContactCountAfterContact ?? 0) >= 1 &&
                 !shotContextRef.current.doubleBankBroadcastCutApplied
               ) {
                 shotContextRef.current.doubleBankBroadcastCutApplied = true;
@@ -32469,11 +32439,6 @@ const powerRef = useRef(hud.power);
   const isPlayerTurn = hud.turn === 0;
   const isOpponentTurn = hud.turn === 1;
   const shotBroadcastActive = shotActive || pocketCameraActive;
-  useEffect(() => {
-    if (shotBroadcastActive && isTopDownView && !isRailOverheadView) {
-      setIsRailOverheadView(true);
-    }
-  }, [isRailOverheadView, isTopDownView, shotBroadcastActive]);
   const topDownMinimalUi = isTopDownView;
   const hideNonEssentialHud = shotBroadcastActive || topDownMinimalUi;
   const showPlayerControls = isPlayerTurn && !hud.over && !replayActive;
@@ -32816,7 +32781,7 @@ const powerRef = useRef(hud.power);
   }, [showPlayerControls, showSpinController, updateSpinDotPosition]);
 
   const americanBallSwatches = useMemo(() => {
-    const colors = POOL_VARIANT_COLOR_SETS.american.objectColors || [];
+    const colors = AMERICAN_BALL_SET.objectColors || [];
     return colors.reduce((acc, hex, idx) => {
       acc[idx + 1] = `#${hex.toString(16).padStart(6, '0')}`;
       return acc;

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -677,7 +677,7 @@ export default function PoolRoyaleLobby() {
                   Opponents
                 </span>
               </div>
-              <div className="grid grid-cols-3 gap-3">
+              <div className="grid grid-cols-2 gap-3">
                 {[
                   {
                     id: 'ai',
@@ -740,10 +740,9 @@ export default function PoolRoyaleLobby() {
                   Ruleset
                 </span>
               </div>
-              <div className="grid grid-cols-3 gap-3">
+              <div className="grid grid-cols-2 gap-3">
                 {[
                   { id: 'uk', label: '8Ball' },
-                  { id: 'american', label: 'American' },
                   { id: '9ball', label: '9-Ball' }
                 ].map(({ id, label }) => {
                   const active = variant === id;


### PR DESCRIPTION
### Motivation
- Simplify and standardize Pool Royale variants by removing the legacy standalone American/race‑to‑61 mode and avoid exposing multiple incompatible rulesets. 
- Enforce official 9‑ball break semantics (pot or sufficient rail contacts) to reduce ambiguous/illegal breaks. 
- Improve visual clarity by brightening select cloth swatches and updating LT table finishes to a consistent GLTF rosewood veneer pattern. 
- Make broadcast camera switching less aggressive by using rail/cushion context to trigger rail‑overhead cuts only when appropriate.

### Description
- UI: Removed the American variant from the lobby selector and reduced variant grid to `8Ball` and `9-Ball`, remapping legacy `american` inputs to existing supported behavior. (`webapp/src/pages/Games/PoolRoyaleLobby.jsx`, `webapp/src/pages/Games/PoolRoyale.jsx`).
- Rules engine: Simplified `PoolRoyaleRules` by removing the `american`/race‑to‑61 branch and keeping `uk`/`8ball`/`9ball`; legacy `american` keys are remapped into the supported flows. (`src/rules/PoolRoyaleRules.ts`).
- 9‑Ball enforcement: Added a legal‑break check (ball potted OR sufficient rail contacts) and threaded rail‑contact info through shot resolution; updated `NineBall.shotTaken` to mark an illegal break as a foul when criteria are not met. (`lib/nineBall.js`, `src/rules/PoolRoyaleRules.ts`, `src/types.ts`).
- Visuals: Brightened burgundy and dark‑grey cloth swatches in the cloth presets and updated LT table finish entries to use the `rosewood_veneer_01` GLTF texture pattern while preserving LT color identities with small brighten adjustments. (`webapp/src/config/poolRoyaleClothPresets.js`, `webapp/src/pages/Games/PoolRoyale.jsx`).
- Broadcast behavior: Removed the global forced rail‑overhead switch for every shot broadcast and instead trigger the rail‑overhead/top view when cushion/rail contact context indicates a bank/double/rail assist (lowered triggering threshold to activate on cushion-assisted rail contact). (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Tests: Updated and added tests to reflect the American->8‑ball remap and the new 9‑ball illegal‑break behavior. (`test/poolRoyaleRules.test.ts`).

### Testing
- Ran unit tests: `npm test -- --runInBand test/poolRoyaleRules.test.ts test/nineBall.test.js` — all tests passed (2 test suites, 9 tests). 
- Built TypeScript: `npm run build` — compilation succeeded with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfcb5e02b08329ac0db3e579ddfb2c)