### PR TITLE
Use rosewood GLTF pattern for LT finishes and tighten burgundy/grey cloth tones

### DIFF
--- a/webapp/src/config/poolRoyaleClothPresets.js
+++ b/webapp/src/config/poolRoyaleClothPresets.js
@@ -63,13 +63,13 @@ const CABAN_TONE_GROUPS = Object.freeze([
     idPrefix: 'cabanBeige',
     label: 'Burgundy',
     tones: ['Ruby', 'Merlot', 'Oxblood'],
-    hex: ['#933347', '#742739', '#5a1c2c']
+    hex: ['#8f3a4d', '#7a2f41', '#6d2738']
   },
   {
     idPrefix: 'cabanDarkGrey',
     label: 'Dark Grey',
     tones: ['Slate', 'Graphite', 'Charcoal'],
-    hex: ['#6f7680', '#59606b', '#3f454e']
+    hex: ['#69717b', '#5c646f', '#525a65']
   }
 ])
 

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -3267,7 +3267,7 @@ const TABLE_FINISHES = Object.freeze({
     woodTextureId: 'rosewood_veneer_01',
     woodRepeatScale: 1,
     disableWoodPattern: false,
-    surfaceStyle: 'matte',
+    surfaceStyle: 'standard',
     useBrandCarbonTexture: false
   }),
   carbonFiberChalkGrey: createStandardWoodFinish({
@@ -3279,7 +3279,7 @@ const TABLE_FINISHES = Object.freeze({
     woodTextureId: 'rosewood_veneer_01',
     woodRepeatScale: 1,
     disableWoodPattern: false,
-    surfaceStyle: 'matte',
+    surfaceStyle: 'standard',
     useBrandCarbonTexture: false
   }),
   carbonFiberChalkBeige: createStandardWoodFinish({
@@ -3291,7 +3291,7 @@ const TABLE_FINISHES = Object.freeze({
     woodTextureId: 'rosewood_veneer_01',
     woodRepeatScale: 1,
     disableWoodPattern: false,
-    surfaceStyle: 'matte',
+    surfaceStyle: 'standard',
     useBrandCarbonTexture: false
   }),
   carbonFiberChalkDarkBlue: createStandardWoodFinish({
@@ -3303,7 +3303,7 @@ const TABLE_FINISHES = Object.freeze({
     woodTextureId: 'rosewood_veneer_01',
     woodRepeatScale: 1,
     disableWoodPattern: false,
-    surfaceStyle: 'matte',
+    surfaceStyle: 'standard',
     useBrandCarbonTexture: false
   }),
   carbonFiberChalkWhite: createStandardWoodFinish({
@@ -3315,7 +3315,7 @@ const TABLE_FINISHES = Object.freeze({
     woodTextureId: 'rosewood_veneer_01',
     woodRepeatScale: 1,
     disableWoodPattern: false,
-    surfaceStyle: 'matte',
+    surfaceStyle: 'standard',
     useBrandCarbonTexture: false
   }),
   carbonFiberChalkDarkGreen: createStandardWoodFinish({
@@ -3327,7 +3327,7 @@ const TABLE_FINISHES = Object.freeze({
     woodTextureId: 'rosewood_veneer_01',
     woodRepeatScale: 1,
     disableWoodPattern: false,
-    surfaceStyle: 'matte',
+    surfaceStyle: 'standard',
     useBrandCarbonTexture: false
   }),
   carbonFiberChalkDarkYellow: createStandardWoodFinish({
@@ -3339,7 +3339,7 @@ const TABLE_FINISHES = Object.freeze({
     woodTextureId: 'rosewood_veneer_01',
     woodRepeatScale: 1,
     disableWoodPattern: false,
-    surfaceStyle: 'matte',
+    surfaceStyle: 'standard',
     useBrandCarbonTexture: false
   }),
   carbonFiberChalkDarkBrown: createStandardWoodFinish({
@@ -3351,7 +3351,7 @@ const TABLE_FINISHES = Object.freeze({
     woodTextureId: 'rosewood_veneer_01',
     woodRepeatScale: 1,
     disableWoodPattern: false,
-    surfaceStyle: 'matte',
+    surfaceStyle: 'standard',
     useBrandCarbonTexture: false
   }),
   carbonFiberChalkDarkRed: createStandardWoodFinish({
@@ -3363,7 +3363,7 @@ const TABLE_FINISHES = Object.freeze({
     woodTextureId: 'rosewood_veneer_01',
     woodRepeatScale: 1,
     disableWoodPattern: false,
-    surfaceStyle: 'matte',
+    surfaceStyle: 'standard',
     useBrandCarbonTexture: false
   }),
   carbonFiberSnakeChalk: createStandardWoodFinish({


### PR DESCRIPTION
### Motivation
- Ensure LT table finishes keep the GLTF-compatible rosewood pattern texture while preserving the existing LT color values for Pool Royale finishes. 
- Make the Burgundy and Dark Grey cloth tone families read consistently as a light, a normal, and a slightly darker tone.

### Description
- Changed `surfaceStyle` from `'matte'` to `'standard'` for the core LT finishes (LT Black / LT Grey / LT Dark Grey / LT Burgundy / LT Milk Cream / LT Dark Green / LT Dark Yellow / LT Dark Brown / LT Dark Red) in `webapp/src/pages/Games/PoolRoyale.jsx` so the configured `woodTextureId: 'rosewood_veneer_01'` and GLTF-style pattern are preserved instead of being overridden by the matte procedural surface.
- Kept LT color values and `woodTextureId` unchanged so only surface application behavior is modified.
- Adjusted the hex triplets for the Burgundy (`cabanBeige`) and Dark Grey (`cabanDarkGrey`) tone groups in `webapp/src/config/poolRoyaleClothPresets.js` to `['#8f3a4d','#7a2f41','#6d2738']` and `['#69717b','#5c646f','#525a65']` respectively to produce the requested light/normal/slightly-darker steps.

### Testing
- Ran `npm run build` (TypeScript compile) and it completed successfully.
- Ran `npx eslint` on the touched files; lint reported repository ignore warnings for `PoolRoyale.jsx` in this environment but no blocking errors.
- Verified the edits are syntactically valid in the codebase (no runtime-checked tests executed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfd522adc083298fa6ad65f8970a35)