### PR TITLE
Pool Royale: cloth pattern & color tweaks, LT finish changes, pocket/chrome refinements, and rail‑overhead bank-shot camera

### DIFF
--- a/webapp/src/config/poolRoyaleClothPresets.js
+++ b/webapp/src/config/poolRoyaleClothPresets.js
@@ -63,13 +63,13 @@ const CABAN_TONE_GROUPS = Object.freeze([
     idPrefix: 'cabanBeige',
     label: 'Burgundy',
     tones: ['Ruby', 'Merlot', 'Oxblood'],
-    hex: ['#933347', '#742739', '#5a1c2c']
+    hex: ['#a43d54', '#853146', '#6a2638']
   },
   {
     idPrefix: 'cabanDarkGrey',
     label: 'Dark Grey',
     tones: ['Slate', 'Graphite', 'Charcoal'],
-    hex: ['#6f7680', '#59606b', '#3f454e']
+    hex: ['#7c848f', '#666f7b', '#4a525c']
   }
 ])
 

--- a/webapp/src/config/poolRoyaleInventoryConfig.js
+++ b/webapp/src/config/poolRoyaleInventoryConfig.js
@@ -658,12 +658,6 @@ export const POOL_ROYALE_OPTION_LABELS = Object.freeze({
     carbonFiberChalkDarkYellow: 'LT Dark Yellow',
     carbonFiberChalkDarkBrown: 'LT Dark Brown',
     carbonFiberChalkDarkRed: 'LT Dark Red',
-    carbonFiberSnakeChalk: 'LT Black Snake',
-    carbonFiberSnakeChalkGrey: 'LT Grey Snake',
-    carbonFiberSnakeChalkBeige: 'LT Dark Grey Snake',
-    carbonFiberSnakeChalkDarkBlue: 'LT Burgundy Snake',
-    carbonFiberSnakeChalkWhite: 'LT Milk Cream Snake',
-    carbonFiberSnakeChalkDarkGreen: 'LT Dark Green Snake',
     carbonFiberAlligatorOlive: 'LT Olive Alligator',
     carbonFiberAlligatorSwamp: 'LT Swamp Alligator',
     carbonFiberAlligatorClay: 'LT Clay Alligator',
@@ -837,60 +831,6 @@ export const POOL_ROYALE_STORE_ITEMS = [
     price: 1240,
     description: 'Dark-red LT carbon-fiber weave finish with deep crimson character.',
     thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberChalkDarkRed
-  },
-  {
-    id: 'finish-carbonFiberSnakeChalk',
-    type: 'tableFinish',
-    optionId: 'carbonFiberSnakeChalk',
-    name: 'LT Black Snake Finish',
-    price: 1250,
-    description: 'Black LT snake-weave finish with the same scale density and a brighter charcoal tone.',
-    thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberSnakeChalk
-  },
-  {
-    id: 'finish-carbonFiberSnakeChalkGrey',
-    type: 'tableFinish',
-    optionId: 'carbonFiberSnakeChalkGrey',
-    name: 'LT Grey Snake Finish',
-    price: 1260,
-    description: 'Grey LT snake-weave finish with the same scale size and a clean brighter lift.',
-    thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberSnakeChalkGrey
-  },
-  {
-    id: 'finish-carbonFiberSnakeChalkBeige',
-    type: 'tableFinish',
-    optionId: 'carbonFiberSnakeChalkBeige',
-    name: 'LT Dark Grey Snake Finish',
-    price: 1270,
-    description: 'Dark-grey LT snake-weave finish keeping identical pattern density.',
-    thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberSnakeChalkBeige
-  },
-  {
-    id: 'finish-carbonFiberSnakeChalkDarkBlue',
-    type: 'tableFinish',
-    optionId: 'carbonFiberSnakeChalkDarkBlue',
-    name: 'LT Burgundy Snake Finish',
-    price: 1280,
-    description: 'Burgundy LT snake-weave finish tuned to match the LT burgundy palette.',
-    thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberSnakeChalkDarkBlue
-  },
-  {
-    id: 'finish-carbonFiberSnakeChalkWhite',
-    type: 'tableFinish',
-    optionId: 'carbonFiberSnakeChalkWhite',
-    name: 'LT Milk Cream Snake Finish',
-    price: 1290,
-    description: 'Milk-cream LT snake-weave finish with the same pattern scale and density.',
-    thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberSnakeChalkWhite
-  },
-  {
-    id: 'finish-carbonFiberSnakeChalkDarkGreen',
-    type: 'tableFinish',
-    optionId: 'carbonFiberSnakeChalkDarkGreen',
-    name: 'LT Dark Green Snake Finish',
-    price: 1300,
-    description: 'Dark-green LT snake-weave finish with matching LT color tone and weave scale.',
-    thumbnail: TABLE_FINISH_THUMBNAILS.carbonFiberSnakeChalkDarkGreen
   },
   {
     id: 'finish-carbonFiberAlligatorOlive',

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -783,9 +783,9 @@ function adjustSideNotchDepth(mp) {
 }
 
 const POCKET_VISUAL_EXPANSION = 1;
-const CORNER_POCKET_INWARD_SCALE = 1; // keep corner cuts identical to middle pocket diameter
-const CORNER_POCKET_SCALE_BOOST = 0.998; // open the corner mouth fractionally to match the inner pocket radius
-const CORNER_POCKET_EXTRA_SCALE = 1.028; // further relax the corner mouth while leaving side pockets unchanged
+const CORNER_POCKET_INWARD_SCALE = 0.986; // tighten only corner-pocket mouth/cut geometry a touch
+const CORNER_POCKET_SCALE_BOOST = 0.994; // keep corner shrink subtle so playability remains unchanged
+const CORNER_POCKET_EXTRA_SCALE = 1.016; // preserve rounded shape while landing at a slightly smaller corner cutout
 const CHROME_CORNER_POCKET_RADIUS_SCALE = 1; // keep the corner chrome arch radius aligned with the middle pockets
 const CHROME_CORNER_NOTCH_CENTER_SCALE = 1.08; // pull the rounded corner cut a touch farther inward while keeping the notch aligned to the cloth
 const CHROME_CORNER_EXPANSION_SCALE = 1.034; // expand the corner chrome farther along the long-rail side so it reaches the marked edge
@@ -833,7 +833,7 @@ const CHROME_SIDE_PLATE_CORNER_LIMIT_SCALE = 0.04;
 const CHROME_SIDE_PLATE_OUTWARD_SHIFT_SCALE = 0.012; // push middle chrome plates slightly outward away from table center while preserving the rounded cut
 const CHROME_OUTER_FLUSH_TRIM_SCALE = 0.022; // trim the outer fascia edge a hair more for a tighter outside finish
 const CHROME_SIDE_OUTER_FLUSH_TRIM_SCALE = 0.078; // trim the middle-pocket outside chrome a touch more so the outer edge ends flush with the wooden rails
-const CHROME_CORNER_POCKET_CUT_SCALE = 1.035; // open only the corner chrome rounded cut a touch so the arc reads slightly larger
+const CHROME_CORNER_POCKET_CUT_SCALE = 1.05; // open only the corner chrome rounded cut a touch more so the arc reads slightly larger
 const CHROME_SIDE_POCKET_CUT_SCALE = 1.02; // open middle-pocket chrome rounded cuts a touch more so the arc reads larger on portrait views
 const CHROME_SIDE_POCKET_CUT_CENTER_PULL_SCALE = 0.04; // reduce inward pull so middle pocket chrome cuts sit a bit farther out
 const WOOD_RAIL_POCKET_RELIEF_SCALE = 1; // match the wooden rail pocket relief to the jaw outside diameter
@@ -3273,9 +3273,9 @@ const TABLE_FINISHES = Object.freeze({
   carbonFiberChalkGrey: createStandardWoodFinish({
     id: 'carbonFiberChalkGrey',
     label: 'LT Grey',
-    rail: 0xbdc5cf,
-    base: 0xbdc5cf,
-    trim: 0xbdc5cf,
+    rail: 0xc7cfd9,
+    base: 0xc7cfd9,
+    trim: 0xc7cfd9,
     woodTextureId: 'rosewood_veneer_01',
     woodRepeatScale: 1,
     disableWoodPattern: false,
@@ -3297,9 +3297,9 @@ const TABLE_FINISHES = Object.freeze({
   carbonFiberChalkDarkBlue: createStandardWoodFinish({
     id: 'carbonFiberChalkDarkBlue',
     label: 'LT Burgundy',
-    rail: 0xb66569,
-    base: 0xb66569,
-    trim: 0xb66569,
+    rail: 0xc37177,
+    base: 0xc37177,
+    trim: 0xc37177,
     woodTextureId: 'rosewood_veneer_01',
     woodRepeatScale: 1,
     disableWoodPattern: false,
@@ -3372,9 +3372,9 @@ const TABLE_FINISHES = Object.freeze({
     rail: 0x242b36,
     base: 0x242b36,
     trim: 0x242b36,
-    woodTextureId: 'plastic_monoblock_lt_black_snake',
+    woodTextureId: 'rosewood_veneer_01',
     woodRepeatScale: 1,
-    disableWoodPattern: true,
+    disableWoodPattern: false,
     surfaceStyle: 'matte',
     useBrandCarbonTexture: false
   }),
@@ -3384,9 +3384,9 @@ const TABLE_FINISHES = Object.freeze({
     rail: 0xb3bcc8,
     base: 0xb3bcc8,
     trim: 0xb3bcc8,
-    woodTextureId: 'plastic_monoblock_lt_grey_snake',
+    woodTextureId: 'rosewood_veneer_01',
     woodRepeatScale: 1,
-    disableWoodPattern: true,
+    disableWoodPattern: false,
     surfaceStyle: 'matte',
     useBrandCarbonTexture: false
   }),
@@ -3396,9 +3396,9 @@ const TABLE_FINISHES = Object.freeze({
     rail: 0x687381,
     base: 0x687381,
     trim: 0x687381,
-    woodTextureId: 'plastic_monoblock_lt_dark_grey_snake',
+    woodTextureId: 'rosewood_veneer_01',
     woodRepeatScale: 1,
-    disableWoodPattern: true,
+    disableWoodPattern: false,
     surfaceStyle: 'matte',
     useBrandCarbonTexture: false
   }),
@@ -3408,9 +3408,9 @@ const TABLE_FINISHES = Object.freeze({
     rail: 0xa95b60,
     base: 0xa95b60,
     trim: 0xa95b60,
-    woodTextureId: 'plastic_monoblock_lt_burgundy_snake',
+    woodTextureId: 'rosewood_veneer_01',
     woodRepeatScale: 1,
-    disableWoodPattern: true,
+    disableWoodPattern: false,
     surfaceStyle: 'matte',
     useBrandCarbonTexture: false
   }),
@@ -3420,9 +3420,9 @@ const TABLE_FINISHES = Object.freeze({
     rail: 0xf6ead7,
     base: 0xf6ead7,
     trim: 0xf6ead7,
-    woodTextureId: 'plastic_monoblock_lt_milk_cream_snake',
+    woodTextureId: 'rosewood_veneer_01',
     woodRepeatScale: 1,
-    disableWoodPattern: true,
+    disableWoodPattern: false,
     surfaceStyle: 'matte',
     useBrandCarbonTexture: false
   }),
@@ -3432,9 +3432,9 @@ const TABLE_FINISHES = Object.freeze({
     rail: 0x4b7958,
     base: 0x4b7958,
     trim: 0x4b7958,
-    woodTextureId: 'plastic_monoblock_lt_dark_green_snake',
+    woodTextureId: 'rosewood_veneer_01',
     woodRepeatScale: 1,
-    disableWoodPattern: true,
+    disableWoodPattern: false,
     surfaceStyle: 'matte',
     useBrandCarbonTexture: false
   }),
@@ -3528,12 +3528,6 @@ const TABLE_FINISH_OPTIONS = Object.freeze(
     TABLE_FINISHES.carbonFiberChalkDarkYellow,
     TABLE_FINISHES.carbonFiberChalkDarkBrown,
     TABLE_FINISHES.carbonFiberChalkDarkRed,
-    TABLE_FINISHES.carbonFiberSnakeChalk,
-    TABLE_FINISHES.carbonFiberSnakeChalkGrey,
-    TABLE_FINISHES.carbonFiberSnakeChalkBeige,
-    TABLE_FINISHES.carbonFiberSnakeChalkDarkBlue,
-    TABLE_FINISHES.carbonFiberSnakeChalkWhite,
-    TABLE_FINISHES.carbonFiberSnakeChalkDarkGreen,
     TABLE_FINISHES.carbonFiberAlligatorOlive,
     TABLE_FINISHES.carbonFiberAlligatorSwamp,
     TABLE_FINISHES.carbonFiberAlligatorClay,
@@ -4042,7 +4036,7 @@ const ORIGINAL_OUTER_HALF_H =
 const CLOTH_TEXTURE_SIZE = CLOTH_QUALITY.textureSize;
 const CLOTH_THREAD_PITCH = 12 * 1.48; // slightly denser thread spacing for a sharper weave
 const CLOTH_THREADS_PER_TILE = CLOTH_TEXTURE_SIZE / CLOTH_THREAD_PITCH;
-const CLOTH_PATTERN_SCALE = 0.76; // match Snooker Royal procedural weave footprint so cloth thread size stays consistent
+const CLOTH_PATTERN_SCALE = 0.7; // slightly denser weave so cloth pattern appears a bit smaller on-screen
 const CLOTH_TEXTURE_REPEAT_HINT = 1.66;
 const POLYHAVEN_PATTERN_REPEAT_SCALE = 1;
 const POLYHAVEN_ANISOTROPY_BOOST = 9;
@@ -20923,6 +20917,12 @@ const powerRef = useRef(hud.power);
                 if (shouldForceRailOverhead) {
                   activeShotView.preferRailOverhead = true;
                 }
+              }
+              const cushionOrBankShotActive =
+                Boolean(shotContextRef.current?.cushionAfterContact) ||
+                (shotContextRef.current?.railContactCountAfterContact ?? 0) >= 1;
+              if (cushionOrBankShotActive) {
+                activeShotView.preferRailOverhead = true;
               }
               const broadcastRailDir =
                 activeShotView.axis === 'short'


### PR DESCRIPTION
### Motivation
- Make the Pool Royale cloth pattern visually finer and brighten key cloth tones (grey & burgundy) for better on-screen clarity. 
- Replace LT snake/weave finishes so LT parts reuse the rosewood veneer pattern (pattern-only) and expose LT finishes with tinting instead of reptile patterns. 
- Slightly tighten corner pocket cloth cutouts while opening the chrome corner rounded cut so the rounded chrome reads larger but cloth mouth is smaller. 
- Ensure doubles/cushion (bank) shots use the rail-overhead broadcast camera exclusively for clearer bank-shot replays.

### Description
- Reduced procedural cloth pattern footprint by changing `CLOTH_PATTERN_SCALE` from `0.76` to `0.7` to make the weave appear smaller on-screen and adjusted cloth palette hexes in `webapp/src/config/poolRoyaleClothPresets.js` to brighten burgundy/dark-grey tones. 
- Tuned corner pocket geometry constants: `CORNER_POCKET_INWARD_SCALE`, `CORNER_POCKET_SCALE_BOOST`, and `CORNER_POCKET_EXTRA_SCALE` were tightened for smaller corner cloth cutouts, and `CHROME_CORNER_POCKET_CUT_SCALE` was increased to `1.05` to slightly enlarge the chrome rounded cut in `webapp/src/pages/Games/PoolRoyale.jsx`. 
- Reworked LT finish entries so LT snake variants now reference the `rosewood_veneer_01` pattern (pattern retained while allowing color tinting) and `disableWoodPattern` set to `false`; removed snake LT finishes from the selectable `TABLE_FINISH_OPTIONS` and pruned their store entries in `webapp/src/config/poolRoyaleInventoryConfig.js`. 
- Enforced rail-overhead preference for cushion/bank/double shots by setting `activeShotView.preferRailOverhead = true` when `shotContextRef.current?.cushionAfterContact` or `railContactCountAfterContact` indicates a bank/cushion interaction, so broadcast cuts prefer rail-overhead for those events in `webapp/src/pages/Games/PoolRoyale.jsx`.

### Testing
- Built the web UI with `npm --prefix webapp run -s build`, which completed successfully (Vite build succeeded; only non-blocking chunk-size warnings were reported). 
- No automated unit tests were changed; no other CI checks were executed in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0707d6e088329b5f83739981d6ab5)