### PR TITLE
Adjust Snake & Ladder arena layout, camera tuning, roll UX, and avatar touch areas

### DIFF
--- a/webapp/src/components/DiceRoller.jsx
+++ b/webapp/src/components/DiceRoller.jsx
@@ -18,6 +18,7 @@ export default function DiceRoller({
   renderVisual = true,
   placeholder = null,
   diceWrapperClassName = 'flex space-x-4 items-center justify-center',
+  soundEnabled = true
 }) {
   const [values, setValues] = useState(Array(numDice).fill(1));
   const [rolling, setRolling] = useState(false);
@@ -55,7 +56,7 @@ export default function DiceRoller({
 
   const rollDice = () => {
     if (rolling) return;
-    if (soundRef.current && !muted) {
+    if (soundEnabled && soundRef.current && !muted) {
       soundRef.current.currentTime = 0;
       soundRef.current.play().catch(() => {});
     }

--- a/webapp/src/components/GameLiveAvatarOverlay.jsx
+++ b/webapp/src/components/GameLiveAvatarOverlay.jsx
@@ -25,8 +25,15 @@ const AVATAR_ANCHOR_SELECTORS = [
   '[aria-label="You"]'
 ];
 
-const FRAME_SCALE = 2;
-const ACTIVATION_TOUCH_PADDING = 8;
+const FRAME_SCALE = 1;
+const ACTIVATION_TOUCH_PADDING = 0;
+const MENU_PRIORITY_SELECTORS = [
+  '[role="dialog"][aria-modal="true"]',
+  '[data-menu-open="true"]',
+  '.modal-open',
+  '.drawer-open',
+  '.menu-open'
+];
 const AVATAR_FRAME_STYLES = Object.freeze({
   borderRadius: '999px',
   border: '2px solid rgba(255,255,255,.32)',
@@ -47,6 +54,7 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
     width: 44,
     height: 44
   });
+  const [menuHasPriority, setMenuHasPriority] = useState(false);
 
   const displayName = useMemo(() => {
     if (typeof window === 'undefined') return 'Player';
@@ -257,6 +265,40 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
     };
   }, [anchorElement, liveMode]);
 
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+
+    const isVisibleElement = (element) => {
+      if (!(element instanceof HTMLElement)) return false;
+      const style = window.getComputedStyle(element);
+      if (style.display === 'none' || style.visibility === 'hidden' || Number(style.opacity) === 0) return false;
+      const rect = element.getBoundingClientRect();
+      return rect.width > 0 && rect.height > 0;
+    };
+
+    const evaluateMenuPriority = () => {
+      const hasOpenMenu = MENU_PRIORITY_SELECTORS.some((selector) =>
+        Array.from(document.querySelectorAll(selector)).some((node) => isVisibleElement(node))
+      );
+      setMenuHasPriority(hasOpenMenu);
+    };
+
+    evaluateMenuPriority();
+    const observer = new MutationObserver(evaluateMenuPriority);
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['class', 'style', 'aria-hidden', 'aria-modal', 'data-menu-open']
+    });
+    window.addEventListener('resize', evaluateMenuPriority);
+
+    return () => {
+      observer.disconnect();
+      window.removeEventListener('resize', evaluateMenuPriority);
+    };
+  }, []);
+
   return (
     <>
       {children}
@@ -264,8 +306,11 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
         <button
           type="button"
           aria-label="Turn on live avatar video"
-          onClick={() => setLiveMode(true)}
-          className="fixed z-[64] rounded-full bg-transparent touch-manipulation"
+          onClick={() => {
+            if (menuHasPriority) return;
+            setLiveMode(true);
+          }}
+          className={`fixed z-[64] rounded-full bg-transparent touch-manipulation ${menuHasPriority ? 'pointer-events-none' : ''}`}
           style={{
             top: `${activationRect.top}px`,
             left: `${activationRect.left}px`,
@@ -278,8 +323,11 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
         <button
           type="button"
           aria-label="Turn off live avatar video"
-          onClick={() => setLiveMode(false)}
-          className="fixed z-[65] overflow-hidden touch-manipulation"
+          onClick={() => {
+            if (menuHasPriority) return;
+            setLiveMode(false);
+          }}
+          className={`fixed z-[65] overflow-hidden touch-manipulation ${menuHasPriority ? 'pointer-events-none' : ''}`}
           style={{
             top: `${overlayRect.top}px`,
             left: `${overlayRect.left}px`,

--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -160,7 +160,7 @@ const CAMERA_NEAR = ARENA_CAMERA_DEFAULTS.near;
 const CAMERA_FAR = ARENA_CAMERA_DEFAULTS.far;
 const CAMERA_TARGET_LIFT = 0.08 * MODEL_SCALE;
 const CAMERA_TARGET_EXTRA = 0.12 * MODEL_SCALE;
-const CAMERA_SIDE_LOOK_EXTRA = 0.46 * MODEL_SCALE;
+const CAMERA_SIDE_LOOK_EXTRA = 0.62 * MODEL_SCALE;
 const CAMERA_TURN_PLAYER_LERP = 0.44;
 const CAMERA_BROADCAST_TARGET_BLEND = 0.5;
 const CAMERA_BASE_RADIUS = Math.max(TABLE_RADIUS, BOARD_RADIUS);
@@ -237,17 +237,37 @@ const DICE_PLAYER_EXTRA_OFFSET = TILE_SIZE * 1.8;
 const TOP_TILE_EXTRA_LEVELS = 1;
 const TOP_SEAT_TOKEN_REST_RAIL_INSET = TILE_SIZE * 0.02;
 const TOP_SEAT_WEAPON_REST_RAIL_INSET = TILE_SIZE * 0.08;
-const TOKEN_REST_RAIL_INSET_BY_SEAT = Object.freeze(new Array(DEFAULT_PLAYER_COUNT).fill(TOP_SEAT_TOKEN_REST_RAIL_INSET));
-const WEAPON_REST_RAIL_INSET_BY_SEAT = Object.freeze(new Array(DEFAULT_PLAYER_COUNT).fill(TOP_SEAT_WEAPON_REST_RAIL_INSET));
+const TOKEN_REST_RAIL_INSET_BY_SEAT = Object.freeze([
+  TOP_SEAT_TOKEN_REST_RAIL_INSET + TILE_SIZE * 0.5, // bottom seat: pull inward
+  TOP_SEAT_TOKEN_REST_RAIL_INSET + TILE_SIZE * 0.44, // right seat: pull inward
+  Math.max(0, TOP_SEAT_TOKEN_REST_RAIL_INSET - TILE_SIZE * 0.22), // top seat: push outward
+  TOP_SEAT_TOKEN_REST_RAIL_INSET
+]);
+const WEAPON_REST_RAIL_INSET_BY_SEAT = Object.freeze([
+  TOP_SEAT_WEAPON_REST_RAIL_INSET + TILE_SIZE * 0.56, // bottom seat: move closer to table
+  TOP_SEAT_WEAPON_REST_RAIL_INSET + TILE_SIZE * 0.56, // right seat: move closer to table
+  TOP_SEAT_WEAPON_REST_RAIL_INSET, // top seat baseline
+  TOP_SEAT_WEAPON_REST_RAIL_INSET // left seat baseline
+]);
 const TOKEN_REST_MIN_RADIUS = BOARD_RADIUS + TILE_SIZE * 2.08;
 const TOKEN_REST_LATERAL_BY_SEAT = Object.freeze(new Array(DEFAULT_PLAYER_COUNT).fill(0));
-const TOKEN_REST_EXTRA_RADIAL_BY_SEAT = Object.freeze(new Array(DEFAULT_PLAYER_COUNT).fill(0));
+const TOKEN_REST_EXTRA_RADIAL_BY_SEAT = Object.freeze([
+  -TILE_SIZE * 0.08,
+  -TILE_SIZE * 0.08,
+  TILE_SIZE * 0.18,
+  0
+]);
 const SEAT_RAIL_DICE_GAP = Math.max(DICE_SIZE * 0.95, TOKEN_RADIUS * 2.75);
 const SEAT_RAIL_SLOT_OFFSET = SEAT_RAIL_DICE_GAP * 0.5;
 const SEAT_RAIL_FORWARD_BIAS = TILE_SIZE * 0.08;
 const WEAPON_DISPLAY_SIZE_MULTIPLIER = 1.4;
 const WEAPON_PARKING_OUTWARD_OFFSET = TILE_SIZE * 0.14;
-const WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT = Object.freeze(new Array(DEFAULT_PLAYER_COUNT).fill(0));
+const WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT = Object.freeze([
+  -TILE_SIZE * 0.08,
+  -TILE_SIZE * 0.08,
+  0,
+  0
+]);
 const WEAPON_PARKED_Y_DROP_BY_KIND = Object.freeze({
   fighter: TOKEN_HEIGHT * 1.74,
   helicopter: TOKEN_HEIGHT * 1.82,
@@ -255,7 +275,7 @@ const WEAPON_PARKED_Y_DROP_BY_KIND = Object.freeze({
   supportTruck: TOKEN_HEIGHT * 1.78,
   javelin: TOKEN_HEIGHT * 1.72
 });
-const WEAPON_REST_HEIGHT_OFFSET = -TOKEN_HEIGHT * 1.62;
+const WEAPON_REST_HEIGHT_OFFSET = -TOKEN_HEIGHT * 1.9;
 
 const PAVEMENT_EXTRA_SCALE = 1.18;
 const PAVEMENT_THICKNESS = TILE_SIZE * 0.4;
@@ -300,15 +320,15 @@ const LANDSCAPE_INITIAL_CAMERA_DISTANCE_FACTOR = 0.62;
 const POINTER_TAP_MAX_DISTANCE = 14;
 const POINTER_TAP_MAX_DURATION_MS = 420;
 const PORTRAIT_CAMERA_TUNING = Object.freeze({
-  backOffset: 2.02,
+  backOffset: 2.2,
   forwardOffset: 0,
-  heightOffset: 3.82,
+  heightOffset: 4,
   targetLift: 0.016 * MODEL_SCALE
 });
 const LANDSCAPE_CAMERA_TUNING = Object.freeze({
-  backOffset: 0.78,
+  backOffset: 0.92,
   forwardOffset: 0,
-  heightOffset: 1.32,
+  heightOffset: 1.42,
   targetLift: 0.06 * MODEL_SCALE
 });
 const SHOW_BOARD_RAILS = false;

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -4094,6 +4094,7 @@ export default function SnakeAndLadder() {
             showButton={false}
             muted={muted}
             fixedSoundVolume={1}
+            soundEnabled={false}
           />
         </div>
       )}
@@ -4105,6 +4106,7 @@ export default function SnakeAndLadder() {
               showButton={false}
               muted={muted}
               fixedSoundVolume={1}
+              soundEnabled={false}
               emitRollEvent
               divRef={diceRollerDivRef}
               onRollStart={() => {
@@ -4152,14 +4154,7 @@ export default function SnakeAndLadder() {
             </div>
           )}
           {canRoll && (
-            <button
-              type="button"
-              onClick={handleRollButtonClick}
-              onTouchStart={handleRollButtonClick}
-              className="pointer-events-auto px-6 py-3 rounded-full font-semibold text-sm text-[#f7e7a4] shadow-lg bg-gradient-to-b from-[#2b2b2b] to-[#121212] border border-[rgba(255,215,0,0.45)]"
-            >
-              ROLL
-            </button>
+            <span className="sr-only">Roll available</span>
           )}
         </div>
       )}


### PR DESCRIPTION
### Motivation
- Improve visual parking and resting positions for tokens and capture-weapon models so they sit naturally against the table and match player-facing orientation.
- Make turn/camera framing clearer by nudging the main camera up/back and biasing broadcast focus toward left/right side seats.
- Eliminate duplicate dice sound effects and simplify roll controls to a single icon-based roll affordance.
- Make live-avatar activation behave predictably by matching touch area to the avatar bounds and ensuring open menus take touch priority.

### Description
- Rebalanced token and weapon resting offsets in `webapp/src/components/SnakeBoard3D.jsx` by adjusting per-seat insets (`TOKEN_REST_RAIL_INSET_BY_SEAT`, `WEAPON_REST_RAIL_INSET_BY_SEAT`, `TOKEN_REST_EXTRA_RADIAL_BY_SEAT`, `WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT`) and lowered parked weapons (`WEAPON_REST_HEIGHT_OFFSET`).
- Tuned arena camera constants in `webapp/src/components/SnakeBoard3D.jsx` (increased `CAMERA_SIDE_LOOK_EXTRA`, raised `PORTRAIT_CAMERA_TUNING.backOffset/heightOffset`, raised `LANDSCAPE_CAMERA_TUNING.backOffset/heightOffset`) so the camera sits slightly higher and farther back and side-seat broadcast look bias is stronger.
- Added a `soundEnabled` prop to `webapp/src/components/DiceRoller.jsx` and disabled embedded dice audio where the game currently plays a single roll SFX to avoid double-playing sounds (`webapp/src/pages/Games/SnakeAndLadder.jsx`).
- Removed the duplicate plain-text `ROLL` CTA in `webapp/src/pages/Games/SnakeAndLadder.jsx` while keeping the icon roll button and dice-anchor icon interaction for accessibility and edge cases.
- Tightened live-avatar activation area and touch behavior in `webapp/src/components/GameLiveAvatarOverlay.jsx` by reducing the frame scale and activation padding (`FRAME_SCALE` and `ACTIVATION_TOUCH_PADDING`) and adding menu-priority detection (`MENU_PRIORITY_SELECTORS` + `menuHasPriority`) so menus/dialogs block avatar touch toggles.

### Testing
- Built the web client with `npm --prefix webapp run build` and the production build completed successfully.
- The build emitted existing Vite chunk-size warnings unrelated to these changes, and no new build errors were produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e08bcad5fc83298994467b848278e1)