### PR TITLE
Adjust Snake & Ladder 3D staging, camera framing, roll UX, and avatar touch priority

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -160,7 +160,7 @@ const CAMERA_NEAR = ARENA_CAMERA_DEFAULTS.near;
 const CAMERA_FAR = ARENA_CAMERA_DEFAULTS.far;
 const CAMERA_TARGET_LIFT = 0.08 * MODEL_SCALE;
 const CAMERA_TARGET_EXTRA = 0.12 * MODEL_SCALE;
-const CAMERA_SIDE_LOOK_EXTRA = 0.46 * MODEL_SCALE;
+const CAMERA_SIDE_LOOK_EXTRA = 0.6 * MODEL_SCALE;
 const CAMERA_TURN_PLAYER_LERP = 0.44;
 const CAMERA_BROADCAST_TARGET_BLEND = 0.5;
 const CAMERA_BASE_RADIUS = Math.max(TABLE_RADIUS, BOARD_RADIUS);
@@ -241,13 +241,26 @@ const TOKEN_REST_RAIL_INSET_BY_SEAT = Object.freeze(new Array(DEFAULT_PLAYER_COU
 const WEAPON_REST_RAIL_INSET_BY_SEAT = Object.freeze(new Array(DEFAULT_PLAYER_COUNT).fill(TOP_SEAT_WEAPON_REST_RAIL_INSET));
 const TOKEN_REST_MIN_RADIUS = BOARD_RADIUS + TILE_SIZE * 2.08;
 const TOKEN_REST_LATERAL_BY_SEAT = Object.freeze(new Array(DEFAULT_PLAYER_COUNT).fill(0));
-const TOKEN_REST_EXTRA_RADIAL_BY_SEAT = Object.freeze(new Array(DEFAULT_PLAYER_COUNT).fill(0));
+// Seat order: 0=bottom, 1=right, 2=top, 3=left (portrait screen orientation).
+// Pull bottom/right reserve tokens inwards and push top token outwards slightly.
+const TOKEN_REST_EXTRA_RADIAL_BY_SEAT = Object.freeze([
+  -TILE_SIZE * 0.78,
+  -TILE_SIZE * 0.74,
+  TILE_SIZE * 0.68,
+  0
+]);
 const SEAT_RAIL_DICE_GAP = Math.max(DICE_SIZE * 0.95, TOKEN_RADIUS * 2.75);
 const SEAT_RAIL_SLOT_OFFSET = SEAT_RAIL_DICE_GAP * 0.5;
 const SEAT_RAIL_FORWARD_BIAS = TILE_SIZE * 0.08;
 const WEAPON_DISPLAY_SIZE_MULTIPLIER = 1.4;
 const WEAPON_PARKING_OUTWARD_OFFSET = TILE_SIZE * 0.14;
-const WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT = Object.freeze(new Array(DEFAULT_PLAYER_COUNT).fill(0));
+// Pull bottom/right parked weapons closer so they match the top seat distance.
+const WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT = Object.freeze([
+  -TILE_SIZE * 0.84,
+  -TILE_SIZE * 0.82,
+  0,
+  0
+]);
 const WEAPON_PARKED_Y_DROP_BY_KIND = Object.freeze({
   fighter: TOKEN_HEIGHT * 1.74,
   helicopter: TOKEN_HEIGHT * 1.82,
@@ -255,7 +268,7 @@ const WEAPON_PARKED_Y_DROP_BY_KIND = Object.freeze({
   supportTruck: TOKEN_HEIGHT * 1.78,
   javelin: TOKEN_HEIGHT * 1.72
 });
-const WEAPON_REST_HEIGHT_OFFSET = -TOKEN_HEIGHT * 1.62;
+const WEAPON_REST_HEIGHT_OFFSET = -TOKEN_HEIGHT * 2.02;
 
 const PAVEMENT_EXTRA_SCALE = 1.18;
 const PAVEMENT_THICKNESS = TILE_SIZE * 0.4;
@@ -295,20 +308,20 @@ const CAMERA_LOOK_YAW_DRAG_FACTOR = 0.0055;
 const CAMERA_LOOK_PITCH_LIMIT = THREE.MathUtils.degToRad(16);
 const CAMERA_LOOK_PITCH_DRAG_FACTOR = -0.0038;
 const CAMERA_EXTRA_LIFT = 0.2;
-const PORTRAIT_INITIAL_CAMERA_DISTANCE_FACTOR = 0.72;
-const LANDSCAPE_INITIAL_CAMERA_DISTANCE_FACTOR = 0.62;
+const PORTRAIT_INITIAL_CAMERA_DISTANCE_FACTOR = 0.76;
+const LANDSCAPE_INITIAL_CAMERA_DISTANCE_FACTOR = 0.65;
 const POINTER_TAP_MAX_DISTANCE = 14;
 const POINTER_TAP_MAX_DURATION_MS = 420;
 const PORTRAIT_CAMERA_TUNING = Object.freeze({
-  backOffset: 2.02,
+  backOffset: 2.14,
   forwardOffset: 0,
-  heightOffset: 3.82,
+  heightOffset: 3.96,
   targetLift: 0.016 * MODEL_SCALE
 });
 const LANDSCAPE_CAMERA_TUNING = Object.freeze({
-  backOffset: 0.78,
+  backOffset: 0.9,
   forwardOffset: 0,
-  heightOffset: 1.32,
+  heightOffset: 1.4,
   targetLift: 0.06 * MODEL_SCALE
 });
 const SHOW_BOARD_RAILS = false;
@@ -1900,11 +1913,11 @@ function computeTurnCameraFocusState(board, camera, turnIndex, players = []) {
   }
   if (seatIndex === 1) {
     target.x += CAMERA_SIDE_LOOK_EXTRA;
-    target.z += TILE_SIZE * 0.12;
+    target.z += TILE_SIZE * 0.18;
   }
   if (seatIndex === 3) {
     target.x -= CAMERA_SIDE_LOOK_EXTRA;
-    target.z += TILE_SIZE * 0.12;
+    target.z += TILE_SIZE * 0.18;
   }
   const boardToCamera = camera.position.clone().sub(boardLookTarget).setY(0);
   if (boardToCamera.lengthSq() > 1e-6) {

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -3860,7 +3860,7 @@ export default function SnakeAndLadder() {
             return (
               <div
                 key={`player-${p.index}`}
-                className="absolute pointer-events-auto flex flex-col items-center"
+                className={`absolute flex flex-col items-center ${showConfig ? 'pointer-events-none' : 'pointer-events-auto'}`}
                 style={positionStyle}
               >
                 <AvatarTimer
@@ -4092,7 +4092,7 @@ export default function SnakeAndLadder() {
             numDice={diceCount}
             trigger={aiRollingIndex != null ? aiRollTrigger : playerAutoRolling ? playerRollTrigger : undefined}
             showButton={false}
-            muted={muted}
+            muted
             fixedSoundVolume={1}
           />
         </div>
@@ -4103,7 +4103,7 @@ export default function SnakeAndLadder() {
             <DiceRoller
               clickable
               showButton={false}
-              muted={muted}
+              muted
               fixedSoundVolume={1}
               emitRollEvent
               divRef={diceRollerDivRef}
@@ -4142,7 +4142,6 @@ export default function SnakeAndLadder() {
                 <button
                   type="button"
                   onClick={handleRollButtonClick}
-                  onTouchStart={handleRollButtonClick}
                   className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-[rgba(255,215,0,0.5)] bg-[rgba(255,215,0,0.14)] text-base leading-none text-[#f7e7a4] shadow-[0_0_10px_rgba(250,204,21,0.28)]"
                   aria-label="Roll dice"
                 >
@@ -4151,23 +4150,12 @@ export default function SnakeAndLadder() {
               ) : null}
             </div>
           )}
-          {canRoll && (
-            <button
-              type="button"
-              onClick={handleRollButtonClick}
-              onTouchStart={handleRollButtonClick}
-              className="pointer-events-auto px-6 py-3 rounded-full font-semibold text-sm text-[#f7e7a4] shadow-lg bg-gradient-to-b from-[#2b2b2b] to-[#121212] border border-[rgba(255,215,0,0.45)]"
-            >
-              ROLL
-            </button>
-          )}
         </div>
       )}
       {canRoll && diceAnchor ? (
         <button
           type="button"
           onClick={handleRollButtonClick}
-          onTouchStart={handleRollButtonClick}
           className="fixed z-30 pointer-events-auto rounded-full flex items-center justify-center text-2xl text-[#f7e7a4]"
           style={{
             left: `${diceAnchor.x}%`,


### PR DESCRIPTION
### Motivation
- Align on-screen 3D staging and UI so parked weapons and reserve tokens visually match the top player's spacing and appear parked on the table surface.  
- Improve camera framing for portrait/mobile so the view is slightly higher and a bit farther back and broadcast cameras give clearer left/right turn focus.  
- Eliminate duplicate dice roll triggers and simplify the roll UI to a single icon-based control and ensure dice SFX plays once per roll.  
- Make avatar taps respect open menus so menu controls have pointer priority over live-avatar activation.

### Description
- Adjusted camera tuning and framing constants in `webapp/src/components/SnakeBoard3D.jsx`, including `CAMERA_SIDE_LOOK_EXTRA`, portrait/landscape initial distance factors, `PORTRAIT_CAMERA_TUNING`/`LANDSCAPE_CAMERA_TUNING` `backOffset` and `heightOffset`, and increased side-seat `target.z` offset for turn-focus cues.  
- Reworked token and weapon staging in `webapp/src/components/SnakeBoard3D.jsx` by adding `TOKEN_REST_EXTRA_RADIAL_BY_SEAT` to pull bottom/right reserve tokens inward and push the top token outward, changing `WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT` to bring bottom/right parked weapons closer, and lowering parked weapons with a larger `WEAPON_REST_HEIGHT_OFFSET`.  
- Simplified roll UX in `webapp/src/pages/Games/SnakeAndLadder.jsx` by removing the duplicate text `ROLL` button, keeping the icon roll buttons, and removing redundant `onTouchStart` handlers to reduce double-trigger risk on mobile.  
- Muted hidden `DiceRoller` instances by passing `muted` to ensure the centralized roll SFX is the single source of audio playback per roll.  
- Made avatar hit targets non-interactive while the settings menu is open by toggling `pointer-events` on avatar container elements (`pointer-events-none` when `showConfig` is true) so menu overlays keep touch priority.

### Testing
- Ran ESLint on the modified files with `npx eslint --no-ignore webapp/src/components/SnakeBoard3D.jsx webapp/src/pages/Games/SnakeAndLadder.jsx`, which completed and reported only repository-ignore warnings and no errors.  
- Changes were committed locally (`Tune Snake 3D staging, camera, roll UI, and avatar hit targets`) and are ready for functional QA and visual verification on device builds.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e08bcad5fc83298994467b848278e1)