### PR TITLE
Tune LT Pool Royale table finishes to matte tinted GLTF wood

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -3128,7 +3128,8 @@ const createStandardWoodFinish = ({
   woodRepeatScale,
   disableWoodPattern = false,
   surfaceStyle = 'standard',
-  useBrandCarbonTexture = false
+  useBrandCarbonTexture = false,
+  preserveWoodTint = false
 }) => ({
   id,
   label,
@@ -3142,6 +3143,7 @@ const createStandardWoodFinish = ({
   woodRepeatScale,
   disableWoodPattern,
   useBrandCarbonTexture,
+  preserveWoodTint,
   surfaceStyle,
   createMaterials: () => {
     const useMatteSurface = surfaceStyle === 'matte';
@@ -3272,8 +3274,9 @@ const TABLE_FINISHES = Object.freeze({
     woodTextureId: LT_TABLE_WOOD_TEXTURE_ID,
     woodRepeatScale: LT_TABLE_WOOD_REPEAT_SCALE,
     disableWoodPattern: false,
-    surfaceStyle: 'standard',
-    useBrandCarbonTexture: false
+    surfaceStyle: 'matte',
+    useBrandCarbonTexture: false,
+    preserveWoodTint: true
   }),
   carbonFiberChalkGrey: createStandardWoodFinish({
     id: 'carbonFiberChalkGrey',
@@ -3284,8 +3287,9 @@ const TABLE_FINISHES = Object.freeze({
     woodTextureId: LT_TABLE_WOOD_TEXTURE_ID,
     woodRepeatScale: LT_TABLE_WOOD_REPEAT_SCALE,
     disableWoodPattern: false,
-    surfaceStyle: 'standard',
-    useBrandCarbonTexture: false
+    surfaceStyle: 'matte',
+    useBrandCarbonTexture: false,
+    preserveWoodTint: true
   }),
   carbonFiberChalkBeige: createStandardWoodFinish({
     id: 'carbonFiberChalkBeige',
@@ -3296,8 +3300,9 @@ const TABLE_FINISHES = Object.freeze({
     woodTextureId: LT_TABLE_WOOD_TEXTURE_ID,
     woodRepeatScale: LT_TABLE_WOOD_REPEAT_SCALE,
     disableWoodPattern: false,
-    surfaceStyle: 'standard',
-    useBrandCarbonTexture: false
+    surfaceStyle: 'matte',
+    useBrandCarbonTexture: false,
+    preserveWoodTint: true
   }),
   carbonFiberChalkDarkBlue: createStandardWoodFinish({
     id: 'carbonFiberChalkDarkBlue',
@@ -3308,8 +3313,9 @@ const TABLE_FINISHES = Object.freeze({
     woodTextureId: LT_TABLE_WOOD_TEXTURE_ID,
     woodRepeatScale: LT_TABLE_WOOD_REPEAT_SCALE,
     disableWoodPattern: false,
-    surfaceStyle: 'standard',
-    useBrandCarbonTexture: false
+    surfaceStyle: 'matte',
+    useBrandCarbonTexture: false,
+    preserveWoodTint: true
   }),
   carbonFiberChalkWhite: createStandardWoodFinish({
     id: 'carbonFiberChalkWhite',
@@ -3320,8 +3326,9 @@ const TABLE_FINISHES = Object.freeze({
     woodTextureId: LT_TABLE_WOOD_TEXTURE_ID,
     woodRepeatScale: LT_TABLE_WOOD_REPEAT_SCALE,
     disableWoodPattern: false,
-    surfaceStyle: 'standard',
-    useBrandCarbonTexture: false
+    surfaceStyle: 'matte',
+    useBrandCarbonTexture: false,
+    preserveWoodTint: true
   }),
   carbonFiberChalkDarkGreen: createStandardWoodFinish({
     id: 'carbonFiberChalkDarkGreen',
@@ -3332,8 +3339,9 @@ const TABLE_FINISHES = Object.freeze({
     woodTextureId: LT_TABLE_WOOD_TEXTURE_ID,
     woodRepeatScale: LT_TABLE_WOOD_REPEAT_SCALE,
     disableWoodPattern: false,
-    surfaceStyle: 'standard',
-    useBrandCarbonTexture: false
+    surfaceStyle: 'matte',
+    useBrandCarbonTexture: false,
+    preserveWoodTint: true
   }),
   carbonFiberChalkDarkYellow: createStandardWoodFinish({
     id: 'carbonFiberChalkDarkYellow',
@@ -3344,8 +3352,9 @@ const TABLE_FINISHES = Object.freeze({
     woodTextureId: LT_TABLE_WOOD_TEXTURE_ID,
     woodRepeatScale: LT_TABLE_WOOD_REPEAT_SCALE,
     disableWoodPattern: false,
-    surfaceStyle: 'standard',
-    useBrandCarbonTexture: false
+    surfaceStyle: 'matte',
+    useBrandCarbonTexture: false,
+    preserveWoodTint: true
   }),
   carbonFiberChalkDarkBrown: createStandardWoodFinish({
     id: 'carbonFiberChalkDarkBrown',
@@ -3356,8 +3365,9 @@ const TABLE_FINISHES = Object.freeze({
     woodTextureId: LT_TABLE_WOOD_TEXTURE_ID,
     woodRepeatScale: LT_TABLE_WOOD_REPEAT_SCALE,
     disableWoodPattern: false,
-    surfaceStyle: 'standard',
-    useBrandCarbonTexture: false
+    surfaceStyle: 'matte',
+    useBrandCarbonTexture: false,
+    preserveWoodTint: true
   }),
   carbonFiberChalkDarkRed: createStandardWoodFinish({
     id: 'carbonFiberChalkDarkRed',
@@ -3368,8 +3378,9 @@ const TABLE_FINISHES = Object.freeze({
     woodTextureId: LT_TABLE_WOOD_TEXTURE_ID,
     woodRepeatScale: LT_TABLE_WOOD_REPEAT_SCALE,
     disableWoodPattern: false,
-    surfaceStyle: 'standard',
-    useBrandCarbonTexture: false
+    surfaceStyle: 'matte',
+    useBrandCarbonTexture: false,
+    preserveWoodTint: true
   }),
   carbonFiberSnakeChalk: createStandardWoodFinish({
     id: 'carbonFiberSnakeChalk',
@@ -3452,8 +3463,9 @@ const TABLE_FINISHES = Object.freeze({
     woodTextureId: LT_TABLE_WOOD_TEXTURE_ID,
     woodRepeatScale: LT_TABLE_WOOD_REPEAT_SCALE,
     disableWoodPattern: false,
-    surfaceStyle: 'standard',
-    useBrandCarbonTexture: false
+    surfaceStyle: 'matte',
+    useBrandCarbonTexture: false,
+    preserveWoodTint: true
   }),
   carbonFiberAlligatorSwamp: createStandardWoodFinish({
     id: 'carbonFiberAlligatorSwamp',
@@ -3464,8 +3476,9 @@ const TABLE_FINISHES = Object.freeze({
     woodTextureId: LT_TABLE_WOOD_TEXTURE_ID,
     woodRepeatScale: LT_TABLE_WOOD_REPEAT_SCALE,
     disableWoodPattern: false,
-    surfaceStyle: 'standard',
-    useBrandCarbonTexture: false
+    surfaceStyle: 'matte',
+    useBrandCarbonTexture: false,
+    preserveWoodTint: true
   }),
   carbonFiberAlligatorClay: createStandardWoodFinish({
     id: 'carbonFiberAlligatorClay',
@@ -3476,8 +3489,9 @@ const TABLE_FINISHES = Object.freeze({
     woodTextureId: LT_TABLE_WOOD_TEXTURE_ID,
     woodRepeatScale: LT_TABLE_WOOD_REPEAT_SCALE,
     disableWoodPattern: false,
-    surfaceStyle: 'standard',
-    useBrandCarbonTexture: false
+    surfaceStyle: 'matte',
+    useBrandCarbonTexture: false,
+    preserveWoodTint: true
   }),
   carbonFiberAlligatorSand: createStandardWoodFinish({
     id: 'carbonFiberAlligatorSand',
@@ -3488,8 +3502,9 @@ const TABLE_FINISHES = Object.freeze({
     woodTextureId: LT_TABLE_WOOD_TEXTURE_ID,
     woodRepeatScale: LT_TABLE_WOOD_REPEAT_SCALE,
     disableWoodPattern: false,
-    surfaceStyle: 'standard',
-    useBrandCarbonTexture: false
+    surfaceStyle: 'matte',
+    useBrandCarbonTexture: false,
+    preserveWoodTint: true
   }),
   carbonFiberAlligatorMoss: createStandardWoodFinish({
     id: 'carbonFiberAlligatorMoss',
@@ -3500,8 +3515,9 @@ const TABLE_FINISHES = Object.freeze({
     woodTextureId: LT_TABLE_WOOD_TEXTURE_ID,
     woodRepeatScale: LT_TABLE_WOOD_REPEAT_SCALE,
     disableWoodPattern: false,
-    surfaceStyle: 'standard',
-    useBrandCarbonTexture: false
+    surfaceStyle: 'matte',
+    useBrandCarbonTexture: false,
+    preserveWoodTint: true
   }),
   carbonFiberAlligatorNight: createStandardWoodFinish({
     id: 'carbonFiberAlligatorNight',
@@ -3512,8 +3528,9 @@ const TABLE_FINISHES = Object.freeze({
     woodTextureId: LT_TABLE_WOOD_TEXTURE_ID,
     woodRepeatScale: LT_TABLE_WOOD_REPEAT_SCALE,
     disableWoodPattern: false,
-    surfaceStyle: 'standard',
-    useBrandCarbonTexture: false
+    surfaceStyle: 'matte',
+    useBrandCarbonTexture: false,
+    preserveWoodTint: true
   })
 });
 
@@ -4982,6 +4999,7 @@ function ensureMaterialWoodOptions(material, targetSettings) {
     targetSettings.normalMapUrl.trim().length > 0
       ? targetSettings.normalMapUrl.trim()
       : undefined;
+  const preserveBaseColor = Boolean(targetSettings?.preserveBaseColor);
   applyWoodTextures(material, {
     hue: preset.hue,
     sat: preset.sat,
@@ -4994,6 +5012,7 @@ function ensureMaterialWoodOptions(material, targetSettings) {
     roughnessMapUrl,
     normalMapUrl,
     sharedKey: `pool-wood-${preset.id}`,
+    preserveBaseColor,
     ...SHARED_WOOD_SURFACE_PROPS
   });
   applySharedWoodSurfaceProps(material);
@@ -5002,6 +5021,7 @@ function ensureMaterialWoodOptions(material, targetSettings) {
 
 function applyWoodTextureToMaterial(material, repeat) {
   if (!material) return;
+  const preserveBaseColor = Boolean(repeat?.preserveBaseColor);
   const repeatVec = resolveRepeatVector(repeat, material);
   const rotation = resolveRotation(repeat, material);
   const textureSize = resolveTextureSize(repeat, material);
@@ -5026,7 +5046,8 @@ function applyWoodTextureToMaterial(material, repeat) {
     textureSize,
     mapUrl,
     roughnessMapUrl,
-    normalMapUrl
+    normalMapUrl,
+    preserveBaseColor
   });
   if (options) {
     const repeatChanged =
@@ -5049,7 +5070,8 @@ function applyWoodTextureToMaterial(material, repeat) {
         textureSize: textureSize ?? options.textureSize,
         mapUrl: mapUrl ?? options.mapUrl,
         roughnessMapUrl: roughnessMapUrl ?? options.roughnessMapUrl,
-        normalMapUrl: normalMapUrl ?? options.normalMapUrl
+        normalMapUrl: normalMapUrl ?? options.normalMapUrl,
+        preserveBaseColor
       });
     }
   } else {
@@ -8547,7 +8569,8 @@ export function Table3D(
     mapUrl: initialFrameSurface.mapUrl,
     roughnessMapUrl: initialFrameSurface.roughnessMapUrl,
     normalMapUrl: initialFrameSurface.normalMapUrl,
-    woodRepeatScale
+    woodRepeatScale,
+    preserveBaseColor: Boolean(resolvedFinish?.preserveWoodTint)
   };
   const synchronizedFrameSurface = {
     repeat: new THREE.Vector2(
@@ -8559,7 +8582,8 @@ export function Table3D(
     mapUrl: initialFrameSurface.mapUrl,
     roughnessMapUrl: initialFrameSurface.roughnessMapUrl,
     normalMapUrl: initialFrameSurface.normalMapUrl,
-    woodRepeatScale
+    woodRepeatScale,
+    preserveBaseColor: Boolean(resolvedFinish?.preserveWoodTint)
   };
 
   if (resolvedFinish?.disableWoodPattern) {
@@ -12767,7 +12791,8 @@ function applyTableFinishToTable(table, finish) {
       mapUrl: nextFrameSurface.mapUrl,
       roughnessMapUrl: nextFrameSurface.roughnessMapUrl,
       normalMapUrl: nextFrameSurface.normalMapUrl,
-      woodRepeatScale
+      woodRepeatScale,
+      preserveBaseColor: Boolean(resolvedFinish?.preserveWoodTint)
     };
     const usesGltfWoodMaps =
       typeof synchronizedFrameSurface.mapUrl === 'string' &&
@@ -12784,7 +12809,8 @@ function applyTableFinishToTable(table, finish) {
       mapUrl: synchronizedFrameSurface.mapUrl,
       roughnessMapUrl: synchronizedFrameSurface.roughnessMapUrl,
       normalMapUrl: synchronizedFrameSurface.normalMapUrl,
-      woodRepeatScale
+      woodRepeatScale,
+      preserveBaseColor: Boolean(resolvedFinish?.preserveWoodTint)
     };
 
     if (resolvedFinish?.disableWoodPattern) {

--- a/webapp/src/utils/woodMaterials.js
+++ b/webapp/src/utils/woodMaterials.js
@@ -1426,10 +1426,12 @@ export const applyWoodTextures = (
     roughnessSize = DEFAULT_WOOD_ROUGHNESS_SIZE,
     roughnessBase = 0.18,
     roughnessVariance = 0.25,
-    sharedKey = null
+    sharedKey = null,
+    preserveBaseColor = false
   } = {}
 ) => {
   if (!material) return null;
+  const baseColor = preserveBaseColor && material.color?.isColor ? material.color.clone() : null;
   disposeWoodTextures(material);
   const fallbackTextures = {
     map: makeSlabTexture(textureSize, textureSize, hue, sat, light, contrast),
@@ -1487,7 +1489,11 @@ export const applyWoodTextures = (
   material.map = map;
   material.roughnessMap = roughnessMap;
   material.normalMap = normalMap;
-  material.color.setHex(0xffffff);
+  if (baseColor && material.color?.isColor) {
+    material.color.copy(baseColor);
+  } else {
+    material.color.setHex(0xffffff);
+  }
   material.needsUpdate = true;
   if (material.map) material.map.needsUpdate = true;
   if (material.roughnessMap) material.roughnessMap.needsUpdate = true;
@@ -1508,7 +1514,8 @@ export const applyWoodTextures = (
     roughnessSize,
     roughnessBase,
     roughnessVariance,
-    sharedKey
+    sharedKey,
+    preserveBaseColor
   };
   material.userData.woodRepeat = new THREE.Vector2(repeatVec.x, repeatVec.y);
   return { map, roughnessMap };


### PR DESCRIPTION
### Motivation
- LT table finishes were using the rosewood veneer appearance and losing each finish's named color tint, so LT options must show the rosewood grain but retain their distinct, non-reflective (matte) colors. 

### Description
- Add a `preserveBaseColor` flag to `applyWoodTextures` (in `webapp/src/utils/woodMaterials.js`) so wood maps can keep a material tint instead of forcing white. 
- Expose `preserveWoodTint` on finish definitions and thread it into wood-surface application in `PoolRoyale.jsx` so finishes can opt into tint-preservation. 
- Update LT finishes (chalk + alligator variants) in `webapp/src/pages/Games/PoolRoyale.jsx` to use the rosewood GLTF grain while switching to a matte/non-reflective surface and `preserveWoodTint: true`. 
- Ensure `applyWoodTextureToMaterial` / `ensureMaterialWoodOptions` propagate the `preserveBaseColor` option so cloned/applied textures preserve the configured tint when required. 

### Testing
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx webapp/src/utils/woodMaterials.js` (files are ignored by repo lint settings; no blocking lint errors reported). 
- Ran `npm test -- --runInBand test/poolRoyaleRules.test.ts` and it passed. 
- Ran `npm test -- --runInBand test/chessBattleInventoryConfig.test.js` which failed; failure is an existing inventory expectation mismatch (missing LT finish IDs) not introduced by these rendering/material changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e09fa394b48329a0f11a9d9ae9c642)