### PR TITLE
Adjust capture vehicle scaling, parking placement, and orientation for jets

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -64,6 +64,7 @@ import { socket } from '../../utils/socket.js';
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
 const FRAME_TIME_CATCH_UP_MULTIPLIER = 3;
 const MISSILE_FORWARD = new THREE.Vector3(1, 0, 0);
+const JET_FORWARD = new THREE.Vector3(-1, 0, 0);
 const MISSILE_WORLD_UP = new THREE.Vector3(0, 1, 0);
 const CAPTURE_VEHICLE_TEXTURE_CACHE = new Map();
 const CAPTURE_POLYHAVEN_TEXTURE_CACHE = new Map();
@@ -91,10 +92,11 @@ const GLB_MAGIC = 0x46546c67;
 const GLB_VERSION = 2;
 const GLB_JSON_CHUNK = 0x4e4f534a;
 const GLB_BIN_CHUNK = 0x004e4942;
-const CAPTURE_JET_SIZE_MULTIPLIER = 1.26 * 1.15;
-const CAPTURE_DRONE_SIZE_MULTIPLIER = 0.74 * 1.15;
-const CAPTURE_HELICOPTER_SIZE_MULTIPLIER = 1.104 * 1.15;
-const CAPTURE_MISSILE_SIZE_MULTIPLIER = 0.9;
+const CAPTURE_VEHICLE_UPSCALE_FACTOR = 1.2;
+const CAPTURE_JET_SIZE_MULTIPLIER = 1.26 * 1.15 * CAPTURE_VEHICLE_UPSCALE_FACTOR;
+const CAPTURE_DRONE_SIZE_MULTIPLIER = 0.74 * 1.15 * CAPTURE_VEHICLE_UPSCALE_FACTOR;
+const CAPTURE_HELICOPTER_SIZE_MULTIPLIER = 1.104 * 1.15 * CAPTURE_VEHICLE_UPSCALE_FACTOR;
+const CAPTURE_MISSILE_SIZE_MULTIPLIER = 0.9 * CAPTURE_VEHICLE_UPSCALE_FACTOR;
 const CAPTURE_AIRCRAFT_SLOW_FACTOR = 1.4;
 const CAPTURE_AIRCRAFT_ORBIT_INWARD_FACTOR = 0.68;
 const CAPTURE_AIRCRAFT_ALTITUDE_FACTOR = 0.76;
@@ -102,24 +104,37 @@ const CAPTURE_VEHICLE_HEIGHT_TO_KING = 1.35;
 const CAPTURE_PARK_BOX_TARGET_SIZE = 0.17;
 const CAPTURE_PARK_TRUCK_BOX_TARGET_SIZE = 0.21;
 const CAPTURE_PARK_SIDE_OFFSET = 0.19;
+const CAPTURE_PARK_SIDE_OFFSET_BY_TYPE = Object.freeze({
+  fighter: 0.25,
+  helicopter: 0.2,
+  drone: 0.13,
+  missile: 0.31
+});
+const CAPTURE_PARK_PLAYER_SIDE_SIGN = Object.freeze([1, -1, -1, 1]);
 const CAPTURE_PARK_OUTWARD_OFFSET = 0.03;
-const CAPTURE_PARK_FORWARD_OFFSET_BY_TYPE = {
-  fighter: 0.03,
-  helicopter: 0.03,
+const CAPTURE_PARK_OUTWARD_OFFSET_BY_TYPE = Object.freeze({
+  fighter: 0.06,
+  helicopter: 0.045,
   drone: 0.03,
-  missile: 0.08
+  missile: 0.1
+});
+const CAPTURE_PARK_FORWARD_OFFSET_BY_TYPE = {
+  fighter: 0.038,
+  helicopter: 0.028,
+  drone: 0.02,
+  missile: 0.09
 };
 const CAPTURE_PARK_SCALE_BY_TYPE = Object.freeze({
-  fighter: 1.4 * 1.15,
-  helicopter: 1.2 * 1.15,
-  missile: 1.15,
-  drone: 1.15
+  fighter: 1.4 * 1.15 * CAPTURE_VEHICLE_UPSCALE_FACTOR,
+  helicopter: 1.2 * 1.15 * CAPTURE_VEHICLE_UPSCALE_FACTOR,
+  missile: 1.15 * CAPTURE_VEHICLE_UPSCALE_FACTOR,
+  drone: 1.15 * CAPTURE_VEHICLE_UPSCALE_FACTOR
 });
 const CAPTURE_AIR_ATTACK_ID_SET = new Set(['fighterJetAttack', 'helicopterAttack', 'droneAttack', 'missileJavelin']);
 const CAPTURE_ATTACK_TUNING = Object.freeze({
   fighterJetAttack: { speed: 1.2, height: 0.92, inward: 0.94, takeoff: 0.2, landing: 0.24 },
   helicopterAttack: { speed: 1.26, height: 0.84, inward: 0.88, takeoff: 0.24, landing: 0.28 },
-  droneAttack: { speed: 1.14, height: 0.9, inward: 0.94, takeoff: 0.22, landing: 0.26 },
+  droneAttack: { speed: 1.04, height: 0.9, inward: 0.94, takeoff: 0.22, landing: 0.26 },
   missileJavelin: { speed: 1.12, height: 0.88, inward: 0.92, takeoff: 0.18, landing: 0.24 }
 });
 const CAPTURE_CAMERA_ZOOM_OUT_FACTOR = 1.08;
@@ -131,7 +146,9 @@ function orientCaptureVehicleTowardBoardCenter(root, target) {
   if (!root?.isObject3D || !target?.isVector3) return;
   const forward = target.clone().sub(root.position).setY(0);
   if (forward.lengthSq() < 1e-6) return;
-  root.quaternion.setFromUnitVectors(MISSILE_FORWARD, forward.normalize());
+  const vehicleType = root.userData?.captureVehicleType || 'missile';
+  const modelForward = vehicleType === 'fighter' ? JET_FORWARD : MISSILE_FORWARD;
+  root.quaternion.setFromUnitVectors(modelForward, forward.normalize());
 }
 
 function getCaptureVehicleTexture(kind = 'generic', toneSeed = null) {
@@ -556,7 +573,7 @@ function applyMilitaryJetLook(root) {
         /window|glass/.test(materialName) ||
         mat.transparent
       ) {
-        mat.color.set('#020304');
+        mat.color.set('#000000');
         if ('metalness' in mat) mat.metalness = 0.48;
         if ('roughness' in mat) mat.roughness = 0.24;
         if ('transparent' in mat) mat.transparent = true;
@@ -1031,7 +1048,7 @@ async function createCaptureMissileTruckFx() {
   });
 
   root.add(launcher);
-  root.scale.setScalar(1.15 * 1.15);
+  root.scale.setScalar(1.15 * 1.15 * CAPTURE_VEHICLE_UPSCALE_FACTOR);
   root.visible = true;
   return {
     root,
@@ -4598,11 +4615,15 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     if (inward.lengthSq() < 1e-6) return null;
     const leftSide = new THREE.Vector3().crossVectors(MISSILE_WORLD_UP, inward).normalize();
     const forwardOffset = CAPTURE_PARK_FORWARD_OFFSET_BY_TYPE[vehicleType] ?? 0.03;
+    const sideOffsetBase = CAPTURE_PARK_SIDE_OFFSET_BY_TYPE[vehicleType] ?? CAPTURE_PARK_SIDE_OFFSET;
+    const playerSideSign = CAPTURE_PARK_PLAYER_SIDE_SIGN[playerIndex] ?? 1;
+    const sideOffset = sideOffsetBase * playerSideSign;
+    const outwardOffset = CAPTURE_PARK_OUTWARD_OFFSET_BY_TYPE[vehicleType] ?? CAPTURE_PARK_OUTWARD_OFFSET;
     const park = kingPos
       .clone()
-      .addScaledVector(leftSide, CAPTURE_PARK_SIDE_OFFSET)
+      .addScaledVector(leftSide, sideOffset)
       .addScaledVector(inward, forwardOffset)
-      .addScaledVector(inward, -CAPTURE_PARK_OUTWARD_OFFSET);
+      .addScaledVector(inward, -outwardOffset);
     park.y = (arena.tableInfo?.surfaceY ?? park.y) + 0.002;
     return park;
   }, [getKingTokenPositionForPlayer]);
@@ -4661,6 +4682,11 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       fitObjectToTargetSize(droneFx.root, CAPTURE_PARK_BOX_TARGET_SIZE);
       fitObjectToTargetSize(missileFx.root, CAPTURE_PARK_TRUCK_BOX_TARGET_SIZE);
       fitObjectToTargetSize(droneTruckFx.root, CAPTURE_PARK_TRUCK_BOX_TARGET_SIZE);
+      jetFx.root.userData.captureVehicleType = 'fighter';
+      helicopterFx.root.userData.captureVehicleType = 'helicopter';
+      droneFx.root.userData.captureVehicleType = 'drone';
+      missileFx.root.userData.captureVehicleType = 'missile';
+      droneTruckFx.root.userData.captureVehicleType = 'missile';
       jetFx.root.scale.multiplyScalar(CAPTURE_PARK_SCALE_BY_TYPE.fighter);
       helicopterFx.root.scale.multiplyScalar(CAPTURE_PARK_SCALE_BY_TYPE.helicopter);
       missileFx.root.scale.multiplyScalar(CAPTURE_PARK_SCALE_BY_TYPE.missile);


### PR DESCRIPTION
### Motivation
- Improve the visual scale and parking placement of capture vehicles so models align better with the board and player positions.
- Ensure fighter jets orient correctly relative to their model forward direction and apply a consistent upscale factor to vehicle assets.
- Tweak a few visual/material details and attack tuning for better appearance and motion balance.

### Description
- Introduce `CAPTURE_VEHICLE_UPSCALE_FACTOR` and apply it to vehicle size multipliers and `CAPTURE_PARK_SCALE_BY_TYPE` so all capture vehicles are uniformly upscaled.
- Add `JET_FORWARD` vector and update `orientCaptureVehicleTowardBoardCenter` to respect `root.userData.captureVehicleType`, using `JET_FORWARD` for fighters and `MISSILE_FORWARD` otherwise.
- Add per-type and per-player parking offset configuration via `CAPTURE_PARK_SIDE_OFFSET_BY_TYPE`, `CAPTURE_PARK_PLAYER_SIDE_SIGN`, `CAPTURE_PARK_OUTWARD_OFFSET_BY_TYPE`, and `CAPTURE_PARK_FORWARD_OFFSET_BY_TYPE`, and update `resolveCaptureParkingAnchors` to use these values.
- Set `userData.captureVehicleType` for parked vehicle roots (`fighter`, `helicopter`, `drone`, `missile`) when creating parked capture vehicles.
- Apply the upscale factor when creating the missile truck FX scale and adjust cockpit material color for jets from `#020304` to `#000000`.
- Reduce `droneAttack` speed tuning from `1.14` to `1.04` for smoother drone attack motion.

### Testing
- Ran project build with `yarn build` which completed successfully.
- Executed test suite with `yarn test` and all automated tests passed.
- Ran `yarn lint` and no new linting errors were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0a8ad918c83299410b169cf79a112)