### PR TITLE
Adjust capture vehicle sizing, parking offsets, orientation and materials

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -65,6 +65,7 @@ const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
 const FRAME_TIME_CATCH_UP_MULTIPLIER = 3;
 const MISSILE_FORWARD = new THREE.Vector3(1, 0, 0);
 const MISSILE_WORLD_UP = new THREE.Vector3(0, 1, 0);
+const CAPTURE_VEHICLE_PARK_YAW_CORRECTION = Math.PI;
 const CAPTURE_VEHICLE_TEXTURE_CACHE = new Map();
 const CAPTURE_POLYHAVEN_TEXTURE_CACHE = new Map();
 const CAPTURE_POLYHAVEN_TEXTURE_SETS = new Map();
@@ -91,10 +92,11 @@ const GLB_MAGIC = 0x46546c67;
 const GLB_VERSION = 2;
 const GLB_JSON_CHUNK = 0x4e4f534a;
 const GLB_BIN_CHUNK = 0x004e4942;
-const CAPTURE_JET_SIZE_MULTIPLIER = 1.26 * 1.15;
-const CAPTURE_DRONE_SIZE_MULTIPLIER = 0.74 * 1.15;
-const CAPTURE_HELICOPTER_SIZE_MULTIPLIER = 1.104 * 1.15;
-const CAPTURE_MISSILE_SIZE_MULTIPLIER = 0.9;
+const CAPTURE_VEHICLE_UPSCALE_FACTOR = 1.2;
+const CAPTURE_JET_SIZE_MULTIPLIER = 1.26 * 1.15 * CAPTURE_VEHICLE_UPSCALE_FACTOR;
+const CAPTURE_DRONE_SIZE_MULTIPLIER = 0.74 * 1.15 * CAPTURE_VEHICLE_UPSCALE_FACTOR;
+const CAPTURE_HELICOPTER_SIZE_MULTIPLIER = 1.104 * 1.15 * CAPTURE_VEHICLE_UPSCALE_FACTOR;
+const CAPTURE_MISSILE_SIZE_MULTIPLIER = 0.9 * CAPTURE_VEHICLE_UPSCALE_FACTOR;
 const CAPTURE_AIRCRAFT_SLOW_FACTOR = 1.4;
 const CAPTURE_AIRCRAFT_ORBIT_INWARD_FACTOR = 0.68;
 const CAPTURE_AIRCRAFT_ALTITUDE_FACTOR = 0.76;
@@ -102,24 +104,36 @@ const CAPTURE_VEHICLE_HEIGHT_TO_KING = 1.35;
 const CAPTURE_PARK_BOX_TARGET_SIZE = 0.17;
 const CAPTURE_PARK_TRUCK_BOX_TARGET_SIZE = 0.21;
 const CAPTURE_PARK_SIDE_OFFSET = 0.19;
+const CAPTURE_PARK_SIDE_OFFSET_BY_TYPE = Object.freeze({
+  fighter: 0.25,
+  helicopter: 0.2,
+  drone: 0.13,
+  missile: 0.31
+});
 const CAPTURE_PARK_OUTWARD_OFFSET = 0.03;
-const CAPTURE_PARK_FORWARD_OFFSET_BY_TYPE = {
-  fighter: 0.03,
-  helicopter: 0.03,
+const CAPTURE_PARK_OUTWARD_OFFSET_BY_TYPE = Object.freeze({
+  fighter: 0.06,
+  helicopter: 0.045,
   drone: 0.03,
-  missile: 0.08
+  missile: 0.1
+});
+const CAPTURE_PARK_FORWARD_OFFSET_BY_TYPE = {
+  fighter: 0.038,
+  helicopter: 0.028,
+  drone: 0.02,
+  missile: 0.09
 };
 const CAPTURE_PARK_SCALE_BY_TYPE = Object.freeze({
-  fighter: 1.4 * 1.15,
-  helicopter: 1.2 * 1.15,
-  missile: 1.15,
-  drone: 1.15
+  fighter: 1.4 * 1.15 * CAPTURE_VEHICLE_UPSCALE_FACTOR,
+  helicopter: 1.2 * 1.15 * CAPTURE_VEHICLE_UPSCALE_FACTOR,
+  missile: 1.15 * CAPTURE_VEHICLE_UPSCALE_FACTOR,
+  drone: 1.15 * CAPTURE_VEHICLE_UPSCALE_FACTOR
 });
 const CAPTURE_AIR_ATTACK_ID_SET = new Set(['fighterJetAttack', 'helicopterAttack', 'droneAttack', 'missileJavelin']);
 const CAPTURE_ATTACK_TUNING = Object.freeze({
   fighterJetAttack: { speed: 1.2, height: 0.92, inward: 0.94, takeoff: 0.2, landing: 0.24 },
   helicopterAttack: { speed: 1.26, height: 0.84, inward: 0.88, takeoff: 0.24, landing: 0.28 },
-  droneAttack: { speed: 1.14, height: 0.9, inward: 0.94, takeoff: 0.22, landing: 0.26 },
+  droneAttack: { speed: 1.02, height: 0.9, inward: 0.94, takeoff: 0.22, landing: 0.26 },
   missileJavelin: { speed: 1.12, height: 0.88, inward: 0.92, takeoff: 0.18, landing: 0.24 }
 });
 const CAPTURE_CAMERA_ZOOM_OUT_FACTOR = 1.08;
@@ -132,6 +146,7 @@ function orientCaptureVehicleTowardBoardCenter(root, target) {
   const forward = target.clone().sub(root.position).setY(0);
   if (forward.lengthSq() < 1e-6) return;
   root.quaternion.setFromUnitVectors(MISSILE_FORWARD, forward.normalize());
+  root.rotateY(CAPTURE_VEHICLE_PARK_YAW_CORRECTION);
 }
 
 function getCaptureVehicleTexture(kind = 'generic', toneSeed = null) {
@@ -556,8 +571,8 @@ function applyMilitaryJetLook(root) {
         /window|glass/.test(materialName) ||
         mat.transparent
       ) {
-        mat.color.set('#020304');
-        if ('metalness' in mat) mat.metalness = 0.48;
+        mat.color.set('#000000');
+        if ('metalness' in mat) mat.metalness = 0.52;
         if ('roughness' in mat) mat.roughness = 0.24;
         if ('transparent' in mat) mat.transparent = true;
         if ('opacity' in mat) mat.opacity = 0.98;
@@ -1031,7 +1046,7 @@ async function createCaptureMissileTruckFx() {
   });
 
   root.add(launcher);
-  root.scale.setScalar(1.15 * 1.15);
+  root.scale.setScalar(1.15 * 1.15 * CAPTURE_VEHICLE_UPSCALE_FACTOR);
   root.visible = true;
   return {
     root,
@@ -4593,16 +4608,22 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     const anchor = arena.seatAnchors[playerIndex];
     if (!anchor) return null;
     const seatPos = anchor.getWorldPosition(new THREE.Vector3());
+    const boardCenter = arena.boardLookTarget.clone();
     const kingPos = getKingTokenPositionForPlayer(playerIndex) ?? seatPos;
-    const inward = arena.boardLookTarget.clone().sub(kingPos).setY(0).normalize();
+    const inward = boardCenter.clone().sub(kingPos).setY(0).normalize();
     if (inward.lengthSq() < 1e-6) return null;
+    const outward = inward.clone().multiplyScalar(-1);
     const leftSide = new THREE.Vector3().crossVectors(MISSILE_WORLD_UP, inward).normalize();
+    const seatDirection = seatPos.clone().sub(boardCenter).setY(0);
+    const sideDirection = leftSide.dot(seatDirection) >= 0 ? 1 : -1;
     const forwardOffset = CAPTURE_PARK_FORWARD_OFFSET_BY_TYPE[vehicleType] ?? 0.03;
+    const sideOffset = CAPTURE_PARK_SIDE_OFFSET_BY_TYPE[vehicleType] ?? CAPTURE_PARK_SIDE_OFFSET;
+    const outwardOffset = CAPTURE_PARK_OUTWARD_OFFSET_BY_TYPE[vehicleType] ?? CAPTURE_PARK_OUTWARD_OFFSET;
     const park = kingPos
       .clone()
-      .addScaledVector(leftSide, CAPTURE_PARK_SIDE_OFFSET)
-      .addScaledVector(inward, forwardOffset)
-      .addScaledVector(inward, -CAPTURE_PARK_OUTWARD_OFFSET);
+      .addScaledVector(outward, 0.2 + outwardOffset)
+      .addScaledVector(leftSide, sideOffset * sideDirection)
+      .addScaledVector(inward, forwardOffset);
     park.y = (arena.tableInfo?.surfaceY ?? park.y) + 0.002;
     return park;
   }, [getKingTokenPositionForPlayer]);


### PR DESCRIPTION
### Motivation

- Improve visual consistency and placement of capture vehicles by introducing a unified upscale factor, per-type parking offsets, and a yaw correction so models face the board correctly.  
- Fine-tune vehicle appearance and attack behavior values to better match intended visuals and animation timing.  

### Description

- Add `CAPTURE_VEHICLE_UPSCALE_FACTOR` and apply it to size multipliers (`CAPTURE_*_SIZE_MULTIPLIER`), `CAPTURE_PARK_SCALE_BY_TYPE`, and truck FX scaling.  
- Add `CAPTURE_VEHICLE_PARK_YAW_CORRECTION` and apply a `root.rotateY(...)` correction in `orientCaptureVehicleTowardBoardCenter`.  
- Introduce per-type parking offsets: `CAPTURE_PARK_SIDE_OFFSET_BY_TYPE`, `CAPTURE_PARK_OUTWARD_OFFSET_BY_TYPE`, and `CAPTURE_PARK_FORWARD_OFFSET_BY_TYPE`, and use them in `resolveCaptureParkingAnchors`.  
- Update parking anchor computation to reference `boardCenter`, compute `outward` and `sideDirection`, and position parks using outward/side/inward offsets; also set park height from `arena.tableInfo.surfaceY`.  
- Adjust material tuning in `applyMilitaryJetLook` (cockpit color changed to `#000000` and metalness nudged to `0.52`).  
- Change drone attack tuning speed and other minor numeric refinements across capture-related constants.  

### Testing

- Ran linting with `yarn lint` and a local unit test run with `yarn test`, and encountered no failures.  
- Performed a local dev build with `yarn build` to verify assets and bundling completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0a8ad918c83299410b169cf79a112)