### PR TITLE
Adjust SnakeBoard3D token & weapon parking for portrait seat layout

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -242,24 +242,32 @@ const WEAPON_REST_RAIL_INSET_BY_SEAT = Object.freeze(new Array(DEFAULT_PLAYER_CO
 const TOKEN_REST_MIN_RADIUS = BOARD_RADIUS + TILE_SIZE * 2.08;
 const TOKEN_REST_LATERAL_BY_SEAT = Object.freeze(new Array(DEFAULT_PLAYER_COUNT).fill(0));
 // Seat order: 0=bottom, 1=right, 2=top, 3=left (portrait screen orientation).
-// Pull bottom/right reserve tokens inwards and push top token outwards slightly.
+// Seat order: 0=bottom, 1=right, 2=top, 3=left (portrait screen orientation).
+// Keep the bottom reserve pair close to the dice lane and push both side seats
+// outward so token/weapon parking sits on the side rails (matching portrait UI).
 const TOKEN_REST_EXTRA_RADIAL_BY_SEAT = Object.freeze([
   -TILE_SIZE * 0.78,
-  -TILE_SIZE * 0.74,
+  TILE_SIZE * 0.22,
   TILE_SIZE * 0.68,
-  0
+  TILE_SIZE * 0.22
 ]);
 const SEAT_RAIL_DICE_GAP = Math.max(DICE_SIZE * 0.95, TOKEN_RADIUS * 2.75);
 const SEAT_RAIL_SLOT_OFFSET = SEAT_RAIL_DICE_GAP * 0.5;
 const SEAT_RAIL_FORWARD_BIAS = TILE_SIZE * 0.08;
 const WEAPON_DISPLAY_SIZE_MULTIPLIER = 1.4;
 const WEAPON_PARKING_OUTWARD_OFFSET = TILE_SIZE * 0.14;
-// Pull bottom/right parked weapons closer so they match the top seat distance.
+// Keep bottom weapon close to the near edge while side-seat weapons stay on the rail.
 const WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT = Object.freeze([
   -TILE_SIZE * 0.84,
-  -TILE_SIZE * 0.82,
+  TILE_SIZE * 0.2,
   0,
-  0
+  TILE_SIZE * 0.2
+]);
+const SEAT_RAIL_SLOT_SIGN_BY_SEAT = Object.freeze([
+  -1, // bottom token/weapon appear to the right of the seat lane
+  -1, // right seat stack appears toward screen-up side
+  -1, // top seat keeps the same slot side as before
+  -1 // left seat stack appears toward screen-down side
 ]);
 const WEAPON_PARKED_Y_DROP_BY_KIND = Object.freeze({
   fighter: TOKEN_HEIGHT * 1.74,
@@ -3781,7 +3789,7 @@ function updateTokens(
           seatIndex
         );
         if (railLayout) {
-          const sideSign = seatIndex % 2 === 0 ? -1 : 1;
+          const sideSign = SEAT_RAIL_SLOT_SIGN_BY_SEAT[seatIndex] ?? -1;
           worldPos = railLayout.railLocal
             .clone()
             .addScaledVector(railLayout.lateral, sideSign * SEAT_RAIL_SLOT_OFFSET);
@@ -4641,7 +4649,7 @@ function updateSeatWeaponDisplays(board, players = []) {
       Number.isFinite(weaponInset) ? weaponInset : null
     );
     if (railLayout) {
-      const sideSign = seatIndex % 2 === 0 ? -1 : 1;
+      const sideSign = SEAT_RAIL_SLOT_SIGN_BY_SEAT[seatIndex] ?? -1;
       holder.position
         .copy(railLayout.railLocal)
         .addScaledVector(railLayout.lateral, sideSign * SEAT_RAIL_SLOT_OFFSET)


### PR DESCRIPTION
### Motivation
- Align reserve token and weapon parking positions so bottom, left and right players render tokens/weapons where the portrait UI expects (bottom near dice lane, side seats on rail).

### Description
- Tuned per-seat radial offsets in `webapp/src/components/SnakeBoard3D.jsx` so side seats are pushed outward and bottom seat stays nearer the board edge. 
- Adjusted per-seat weapon outward offsets to match the new portrait layout.
- Added `SEAT_RAIL_SLOT_SIGN_BY_SEAT` and applied it to both reserve token and weapon placement logic to explicitly control which side of the rail the token/weapon stacks appear on.
- Replaced previous parity-based side calculations with the explicit per-seat slot-sign map in token and weapon placement points.

### Testing
- Ran the production build with `npm --prefix webapp run build` and it completed successfully (Vite build finished; only non-blocking warnings about chunk sizes/dynamic imports).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0ab98902083299a6c3eeee4a7de22)