### PR TITLE
Adjust capture vehicle scaling, parking layout and visual/attack tuning

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -91,10 +91,11 @@ const GLB_MAGIC = 0x46546c67;
 const GLB_VERSION = 2;
 const GLB_JSON_CHUNK = 0x4e4f534a;
 const GLB_BIN_CHUNK = 0x004e4942;
-const CAPTURE_JET_SIZE_MULTIPLIER = 1.26 * 1.15;
-const CAPTURE_DRONE_SIZE_MULTIPLIER = 0.74 * 1.15;
-const CAPTURE_HELICOPTER_SIZE_MULTIPLIER = 1.104 * 1.15;
-const CAPTURE_MISSILE_SIZE_MULTIPLIER = 0.9;
+const CAPTURE_VEHICLE_UPSCALE_FACTOR = 1.2;
+const CAPTURE_JET_SIZE_MULTIPLIER = 1.26 * 1.15 * CAPTURE_VEHICLE_UPSCALE_FACTOR;
+const CAPTURE_DRONE_SIZE_MULTIPLIER = 0.74 * 1.15 * CAPTURE_VEHICLE_UPSCALE_FACTOR;
+const CAPTURE_HELICOPTER_SIZE_MULTIPLIER = 1.104 * 1.15 * CAPTURE_VEHICLE_UPSCALE_FACTOR;
+const CAPTURE_MISSILE_SIZE_MULTIPLIER = 0.9 * CAPTURE_VEHICLE_UPSCALE_FACTOR;
 const CAPTURE_AIRCRAFT_SLOW_FACTOR = 1.4;
 const CAPTURE_AIRCRAFT_ORBIT_INWARD_FACTOR = 0.68;
 const CAPTURE_AIRCRAFT_ALTITUDE_FACTOR = 0.76;
@@ -102,24 +103,30 @@ const CAPTURE_VEHICLE_HEIGHT_TO_KING = 1.35;
 const CAPTURE_PARK_BOX_TARGET_SIZE = 0.17;
 const CAPTURE_PARK_TRUCK_BOX_TARGET_SIZE = 0.21;
 const CAPTURE_PARK_SIDE_OFFSET = 0.19;
+const CAPTURE_PARK_LAYOUT_BY_TYPE = Object.freeze({
+  fighter: { side: 0.34, depth: -0.27 },
+  helicopter: { side: -0.34, depth: -0.24 },
+  drone: { side: 0.34, depth: 0.25 },
+  missile: { side: -0.34, depth: 0.26 }
+});
 const CAPTURE_PARK_OUTWARD_OFFSET = 0.03;
 const CAPTURE_PARK_FORWARD_OFFSET_BY_TYPE = {
-  fighter: 0.03,
-  helicopter: 0.03,
-  drone: 0.03,
-  missile: 0.08
+  fighter: 0.038,
+  helicopter: 0.028,
+  drone: 0.02,
+  missile: 0.09
 };
 const CAPTURE_PARK_SCALE_BY_TYPE = Object.freeze({
-  fighter: 1.4 * 1.15,
-  helicopter: 1.2 * 1.15,
-  missile: 1.15,
-  drone: 1.15
+  fighter: 1.4 * 1.15 * CAPTURE_VEHICLE_UPSCALE_FACTOR,
+  helicopter: 1.2 * 1.15 * CAPTURE_VEHICLE_UPSCALE_FACTOR,
+  missile: 1.15 * CAPTURE_VEHICLE_UPSCALE_FACTOR,
+  drone: 1.15 * CAPTURE_VEHICLE_UPSCALE_FACTOR
 });
 const CAPTURE_AIR_ATTACK_ID_SET = new Set(['fighterJetAttack', 'helicopterAttack', 'droneAttack', 'missileJavelin']);
 const CAPTURE_ATTACK_TUNING = Object.freeze({
   fighterJetAttack: { speed: 1.2, height: 0.92, inward: 0.94, takeoff: 0.2, landing: 0.24 },
   helicopterAttack: { speed: 1.26, height: 0.84, inward: 0.88, takeoff: 0.24, landing: 0.28 },
-  droneAttack: { speed: 1.14, height: 0.9, inward: 0.94, takeoff: 0.22, landing: 0.26 },
+  droneAttack: { speed: 1.22, height: 0.9, inward: 0.94, takeoff: 0.22, landing: 0.26 },
   missileJavelin: { speed: 1.12, height: 0.88, inward: 0.92, takeoff: 0.18, landing: 0.24 }
 });
 const CAPTURE_CAMERA_ZOOM_OUT_FACTOR = 1.08;
@@ -556,7 +563,7 @@ function applyMilitaryJetLook(root) {
         /window|glass/.test(materialName) ||
         mat.transparent
       ) {
-        mat.color.set('#020304');
+        mat.color.set('#000000');
         if ('metalness' in mat) mat.metalness = 0.48;
         if ('roughness' in mat) mat.roughness = 0.24;
         if ('transparent' in mat) mat.transparent = true;
@@ -1031,7 +1038,7 @@ async function createCaptureMissileTruckFx() {
   });
 
   root.add(launcher);
-  root.scale.setScalar(1.15 * 1.15);
+  root.scale.setScalar(1.15 * 1.15 * CAPTURE_VEHICLE_UPSCALE_FACTOR);
   root.visible = true;
   return {
     root,
@@ -4598,11 +4605,13 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     if (inward.lengthSq() < 1e-6) return null;
     const leftSide = new THREE.Vector3().crossVectors(MISSILE_WORLD_UP, inward).normalize();
     const forwardOffset = CAPTURE_PARK_FORWARD_OFFSET_BY_TYPE[vehicleType] ?? 0.03;
+    const vehicleLayout = CAPTURE_PARK_LAYOUT_BY_TYPE[vehicleType] ?? null;
+    const sideOffset = vehicleLayout?.side ?? CAPTURE_PARK_SIDE_OFFSET;
+    const depthOffset = vehicleLayout?.depth ?? forwardOffset - CAPTURE_PARK_OUTWARD_OFFSET;
     const park = kingPos
       .clone()
-      .addScaledVector(leftSide, CAPTURE_PARK_SIDE_OFFSET)
-      .addScaledVector(inward, forwardOffset)
-      .addScaledVector(inward, -CAPTURE_PARK_OUTWARD_OFFSET);
+      .addScaledVector(leftSide, sideOffset)
+      .addScaledVector(inward, depthOffset);
     park.y = (arena.tableInfo?.surfaceY ?? park.y) + 0.002;
     return park;
   }, [getKingTokenPositionForPlayer]);


### PR DESCRIPTION
### Motivation
- Introduce a single upscale factor to be able to uniformly change capture vehicle sizes and make parking layouts more consistent.
- Improve parking placement per-vehicle to reduce overlap and better position assets relative to the king token and board center.
- Tweak visual material and attack tuning for captured aircraft to improve appearance and motion consistency.

### Description
- Add `CAPTURE_VEHICLE_UPSCALE_FACTOR` and apply it to existing size/scale constants (`CAPTURE_*_SIZE_MULTIPLIER`, `CAPTURE_PARK_SCALE_BY_TYPE`, and truck root scaling in `createCaptureMissileTruckFx`).
- Introduce `CAPTURE_PARK_LAYOUT_BY_TYPE` for per-vehicle `side` and `depth` offsets and use it in `resolveCaptureParkingAnchors`, replacing the previous fixed side/depth calculations.
- Adjust `CAPTURE_PARK_FORWARD_OFFSET_BY_TYPE` numeric values for finer forward placement per vehicle type.
- Change cockpit/window material color in `applyMilitaryJetLook` from `#020304` to `#000000` and adjust drone attack tuning speed from `1.14` to `1.22`.

### Testing
- Ran the project test suite with `yarn test` and the tests completed without failures.
- Ran linting with `yarn lint` and no lint errors were reported.
- Performed a local build with `yarn build` to validate bundling and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0a8ad918c83299410b169cf79a112)