### PR TITLE
Adjust reserve token and weapon parking for bottom/side seats in Snake board

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -242,24 +242,24 @@ const WEAPON_REST_RAIL_INSET_BY_SEAT = Object.freeze(new Array(DEFAULT_PLAYER_CO
 const TOKEN_REST_MIN_RADIUS = BOARD_RADIUS + TILE_SIZE * 2.08;
 const TOKEN_REST_LATERAL_BY_SEAT = Object.freeze(new Array(DEFAULT_PLAYER_COUNT).fill(0));
 // Seat order: 0=bottom, 1=right, 2=top, 3=left (portrait screen orientation).
-// Pull bottom/right reserve tokens inwards and push top token outwards slightly.
+// Pull bottom/side reserve tokens inwards so they sit on the wooden rim near each seat.
 const TOKEN_REST_EXTRA_RADIAL_BY_SEAT = Object.freeze([
-  -TILE_SIZE * 0.78,
-  -TILE_SIZE * 0.74,
+  -TILE_SIZE * 1.18,
+  -TILE_SIZE * 0.98,
   TILE_SIZE * 0.68,
-  0
+  -TILE_SIZE * 0.98
 ]);
 const SEAT_RAIL_DICE_GAP = Math.max(DICE_SIZE * 0.95, TOKEN_RADIUS * 2.75);
 const SEAT_RAIL_SLOT_OFFSET = SEAT_RAIL_DICE_GAP * 0.5;
 const SEAT_RAIL_FORWARD_BIAS = TILE_SIZE * 0.08;
 const WEAPON_DISPLAY_SIZE_MULTIPLIER = 1.4;
 const WEAPON_PARKING_OUTWARD_OFFSET = TILE_SIZE * 0.14;
-// Pull bottom/right parked weapons closer so they match the top seat distance.
+// Pull parked weapons for bottom/side seats inward so they align with each player edge position.
 const WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT = Object.freeze([
-  -TILE_SIZE * 0.84,
-  -TILE_SIZE * 0.82,
+  -TILE_SIZE * 1.02,
+  -TILE_SIZE * 0.9,
   0,
-  0
+  -TILE_SIZE * 0.9
 ]);
 const WEAPON_PARKED_Y_DROP_BY_KIND = Object.freeze({
   fighter: TOKEN_HEIGHT * 1.74,


### PR DESCRIPTION
### Motivation
- Tokens and parked weapons for players seated at the bottom/left/right edges did not visually match the provided photos; the change moves those reserve tokens/weapons inward so they sit on the table rim near each player in portrait orientation.

### Description
- Tuned radial offsets in `TOKEN_REST_EXTRA_RADIAL_BY_SEAT` to pull bottom/side reserve tokens inward and updated the array for seats [bottom, right, top, left].
- Tuned `WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT` so parked weapon displays for bottom/side seats align with the updated token locations.
- Updated inline comments to clarify seat ordering and the intent for bottom/side seat positioning.
- File modified: `webapp/src/components/SnakeBoard3D.jsx`.

### Testing
- Ran the production build with `npm --prefix webapp run -s build`, which completed successfully (Vite emitted non-blocking chunk-size and dynamic-import warnings). 
- Ran lint with `npm --prefix webapp run -s lint -- src/components/SnakeBoard3D.jsx`, which returned a non-zero exit (lint did not pass in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0ab98902083299a6c3eeee4a7de22)