### PR TITLE
Adjust parked capture-weapon anchors to move vehicles into board-corner parking zones

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -104,10 +104,10 @@ const CAPTURE_PARK_BOX_TARGET_SIZE = 0.17;
 const CAPTURE_PARK_TRUCK_BOX_TARGET_SIZE = 0.21;
 const CAPTURE_PARK_SIDE_OFFSET = 0.19;
 const CAPTURE_PARK_SIDE_OFFSET_BY_PLAYER = Object.freeze({
-  0: -0.34,
-  1: 0.28,
-  2: -0.32,
-  3: 0.34
+  0: -0.48,
+  1: 0.46,
+  2: -0.5,
+  3: 0.5
 });
 const CAPTURE_PARK_SIDE_OFFSET_BY_TYPE = Object.freeze({
   fighter: 0,
@@ -117,10 +117,10 @@ const CAPTURE_PARK_SIDE_OFFSET_BY_TYPE = Object.freeze({
 });
 const CAPTURE_PARK_OUTWARD_OFFSET = 0.03;
 const CAPTURE_PARK_OUTWARD_OFFSET_BY_PLAYER = Object.freeze({
-  0: 0.35,
-  1: 0.33,
-  2: 0.33,
-  3: 0.35
+  0: 0.52,
+  1: 0.5,
+  2: 0.52,
+  3: 0.5
 });
 const CAPTURE_PARK_OUTWARD_OFFSET_BY_TYPE = Object.freeze({
   fighter: 0,
@@ -129,10 +129,10 @@ const CAPTURE_PARK_OUTWARD_OFFSET_BY_TYPE = Object.freeze({
   missile: 0
 });
 const CAPTURE_PARK_FORWARD_OFFSET_BY_TYPE = {
-  fighter: 0.012,
-  helicopter: 0.01,
-  drone: 0.008,
-  missile: 0.016
+  fighter: -0.008,
+  helicopter: -0.01,
+  drone: -0.012,
+  missile: -0.004
 };
 const CAPTURE_PARK_SCALE_BY_TYPE = Object.freeze({
   fighter: 1.4 * 1.15 * CAPTURE_VEHICLE_UPSCALE_FACTOR,


### PR DESCRIPTION
### Motivation
- Parked capture-weapon models were visually sitting near board edge midpoints instead of the corner parking zones marked in the reference photo, so the anchors needed tuning to place parked vehicles precisely against the board guide. 
- The intent is to keep attack animation paths unchanged while only moving the idle/parked positions to better match the indicated red-box "P" placements.

### Description
- Increased per-player lateral offsets by updating `CAPTURE_PARK_SIDE_OFFSET_BY_PLAYER` in `webapp/src/pages/Games/LudoBattleRoyal.jsx` so parked vehicles shift toward each player’s board corner. 
- Increased per-player outward offsets by updating `CAPTURE_PARK_OUTWARD_OFFSET_BY_PLAYER` so parked vehicles move farther from edge midpoints into corner zones. 
- Adjusted `CAPTURE_PARK_FORWARD_OFFSET_BY_TYPE` (fighter/helicopter/drone/missile) to fine-tune forward/back placement relative to the board surface guide. 
- These constants are consumed by `resolveCaptureParkingAnchors` and the parked vehicle rebuild flow, so parked models will reposition without changing attack animation logic.

### Testing
- Ran `npx eslint webapp/src/pages/Games/LudoBattleRoyal.jsx` which is ignored by the repo ESLint ignore pattern and produced only an ignore warning and no lint errors. 
- Ran `npx eslint --no-ignore webapp/src/pages/Games/LudoBattleRoyal.jsx` which likewise returned the ignore warning and no lint errors. 
- No unit tests or build steps were changed as part of this tweak and no automated test failures were observed from the lint checks above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1280aa79483298f541d0f22200dde)