### PR TITLE
Tune parked capture vehicle anchors for Ludo Battle Royal

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -102,12 +102,12 @@ const CAPTURE_AIRCRAFT_ALTITUDE_FACTOR = 0.76;
 const CAPTURE_VEHICLE_HEIGHT_TO_KING = 1.35;
 const CAPTURE_PARK_BOX_TARGET_SIZE = 0.17;
 const CAPTURE_PARK_TRUCK_BOX_TARGET_SIZE = 0.21;
-const CAPTURE_PARK_SIDE_OFFSET = 0.19;
+const CAPTURE_PARK_SIDE_OFFSET = 0.26;
 const CAPTURE_PARK_SIDE_OFFSET_BY_PLAYER = Object.freeze({
-  0: -0.34,
-  1: 0.28,
-  2: -0.32,
-  3: 0.34
+  0: -0.52,
+  1: 0.5,
+  2: -0.5,
+  3: 0.52
 });
 const CAPTURE_PARK_SIDE_OFFSET_BY_TYPE = Object.freeze({
   fighter: 0,
@@ -115,12 +115,12 @@ const CAPTURE_PARK_SIDE_OFFSET_BY_TYPE = Object.freeze({
   drone: 0,
   missile: 0
 });
-const CAPTURE_PARK_OUTWARD_OFFSET = 0.03;
+const CAPTURE_PARK_OUTWARD_OFFSET = 0.05;
 const CAPTURE_PARK_OUTWARD_OFFSET_BY_PLAYER = Object.freeze({
-  0: 0.35,
-  1: 0.33,
-  2: 0.33,
-  3: 0.35
+  0: 0.56,
+  1: 0.55,
+  2: 0.55,
+  3: 0.56
 });
 const CAPTURE_PARK_OUTWARD_OFFSET_BY_TYPE = Object.freeze({
   fighter: 0,


### PR DESCRIPTION
### Motivation
- Parked capture-weapon visuals needed to match the reference parking boxes at the board corners so the parked animation weapons sit precisely where marked. 
- Small placement-only tuning keeps capture animations and timing unchanged while improving visual alignment with the board.

### Description
- Updated placement constants in `webapp/src/pages/Games/LudoBattleRoyal.jsx` to move parked vehicles toward the board corners by increasing the global side offset (`CAPTURE_PARK_SIDE_OFFSET`) and per-player side offsets (`CAPTURE_PARK_SIDE_OFFSET_BY_PLAYER`).
- Increased the global outward offset (`CAPTURE_PARK_OUTWARD_OFFSET`) and per-player outward offsets (`CAPTURE_PARK_OUTWARD_OFFSET_BY_PLAYER`) so parked units sit farther from the board center and align with the marked boxes.
- Change scope is limited to positioning constants used by the existing `resolveCaptureParkingAnchors` / `rebuildParkedCaptureVehicles` flow and does not modify capture animation logic or timings.

### Testing
- Ran linter checks with `npx eslint webapp/src/pages/Games/LudoBattleRoyal.jsx` and `npx eslint --no-ignore webapp/src/pages/Games/LudoBattleRoyal.jsx`; both runs completed and reported the file is ignored by project lint config but produced no lint errors for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1280aa79483298f541d0f22200dde)