### PR TITLE
Adjust Snake & Ladder seat token/weapon placement for bottom/side players

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -252,6 +252,23 @@ const TOKEN_REST_EXTRA_RADIAL_BY_SEAT = Object.freeze([
 const SEAT_RAIL_DICE_GAP = Math.max(DICE_SIZE * 0.95, TOKEN_RADIUS * 2.75);
 const SEAT_RAIL_SLOT_OFFSET = SEAT_RAIL_DICE_GAP * 0.5;
 const SEAT_RAIL_FORWARD_BIAS = TILE_SIZE * 0.08;
+// Seat-aware slot signs (portrait): 0=bottom, 1=right, 2=top, 3=left.
+// Keep reserve token placement stable and tune weapon to sit on the opposite side
+// for bottom/side seats so both props are clearly separated.
+const TOKEN_SLOT_SIDE_SIGN_BY_SEAT = Object.freeze([-1, 1, -1, 1]);
+const WEAPON_SLOT_SIDE_SIGN_BY_SEAT = Object.freeze([1, -1, -1, -1]);
+const TOKEN_SLOT_LATERAL_NUDGE_BY_SEAT = Object.freeze([
+  TILE_SIZE * 0.06,
+  0,
+  0,
+  0
+]);
+const WEAPON_SLOT_LATERAL_NUDGE_BY_SEAT = Object.freeze([
+  -TILE_SIZE * 0.22,
+  -TILE_SIZE * 0.12,
+  0,
+  TILE_SIZE * 0.12
+]);
 const WEAPON_DISPLAY_SIZE_MULTIPLIER = 1.4;
 const WEAPON_PARKING_OUTWARD_OFFSET = TILE_SIZE * 0.14;
 // Pull parked weapons for bottom/side seats inward so they align with each player edge position.
@@ -3781,10 +3798,11 @@ function updateTokens(
           seatIndex
         );
         if (railLayout) {
-          const sideSign = seatIndex % 2 === 0 ? -1 : 1;
+          const sideSign = TOKEN_SLOT_SIDE_SIGN_BY_SEAT[seatIndex] ?? (seatIndex % 2 === 0 ? -1 : 1);
+          const lateralNudge = TOKEN_SLOT_LATERAL_NUDGE_BY_SEAT[seatIndex] ?? 0;
           worldPos = railLayout.railLocal
             .clone()
-            .addScaledVector(railLayout.lateral, sideSign * SEAT_RAIL_SLOT_OFFSET);
+            .addScaledVector(railLayout.lateral, sideSign * SEAT_RAIL_SLOT_OFFSET + lateralNudge);
           worldPos.y = railLayout.railHeightY;
         }
       }
@@ -4641,10 +4659,11 @@ function updateSeatWeaponDisplays(board, players = []) {
       Number.isFinite(weaponInset) ? weaponInset : null
     );
     if (railLayout) {
-      const sideSign = seatIndex % 2 === 0 ? -1 : 1;
+      const sideSign = WEAPON_SLOT_SIDE_SIGN_BY_SEAT[seatIndex] ?? (seatIndex % 2 === 0 ? -1 : 1);
+      const lateralNudge = WEAPON_SLOT_LATERAL_NUDGE_BY_SEAT[seatIndex] ?? 0;
       holder.position
         .copy(railLayout.railLocal)
-        .addScaledVector(railLayout.lateral, sideSign * SEAT_RAIL_SLOT_OFFSET)
+        .addScaledVector(railLayout.lateral, sideSign * SEAT_RAIL_SLOT_OFFSET + lateralNudge)
         .addScaledVector(
           railLayout.seatDirection,
           WEAPON_PARKING_OUTWARD_OFFSET + (WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT[seatIndex] ?? 0)


### PR DESCRIPTION
### Motivation
- Align reserve tokens and parked weapons for players seated at the bottom/left/right of the portrait screen to match reference photos and improve visual separation between token and weapon props. 
- Make seat placement deterministic per-seat (bottom/right/top/left) so portrait-oriented layouts render consistently.

### Description
- Added seat-aware placement constants: `TOKEN_SLOT_SIDE_SIGN_BY_SEAT`, `WEAPON_SLOT_SIDE_SIGN_BY_SEAT`, `TOKEN_SLOT_LATERAL_NUDGE_BY_SEAT`, and `WEAPON_SLOT_LATERAL_NUDGE_BY_SEAT` in `webapp/src/components/SnakeBoard3D.jsx` to express per-seat side/sign and lateral nudges. 
- Wired these new constants into `updateTokens` so reserve tokens use the explicit per-seat side sign and lateral nudge when computing rail slot positions. 
- Wired the weapon-side constants into `updateSeatWeaponDisplays` so parked weapon holders position independently from tokens and sit on the tuned side for bottom/side seats. 
- Changes are constrained to seat-aware offsets and preserve the existing rail/radius/railLayout logic to minimize side effects.

### Testing
- Ran the production build with `npm -C webapp run -s build` which completed successfully. 
- No automated unit tests were added or modified for this visual tweak; visual verification is recommended in the running app to confirm photo-matching positions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e129bb3e6483299f03b4f9f7813730)