### PR TITLE
Align parked capture vehicles to portrait corner parking pads

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -103,11 +103,13 @@ const CAPTURE_VEHICLE_HEIGHT_TO_KING = 1.35;
 const CAPTURE_PARK_BOX_TARGET_SIZE = 0.17;
 const CAPTURE_PARK_TRUCK_BOX_TARGET_SIZE = 0.21;
 const CAPTURE_PARK_SIDE_OFFSET = 0.19;
+// Seat order is fixed to portrait view (0=bottom, 1=right, 2=top, 3=left).
+// Keep parked capture weapons at board-corner parking pads (as marked in the mobile UI reference).
 const CAPTURE_PARK_SIDE_OFFSET_BY_PLAYER = Object.freeze({
-  0: -0.34,
-  1: 0.28,
-  2: -0.32,
-  3: 0.34
+  0: -0.5,
+  1: -0.5,
+  2: -0.5,
+  3: 0.5
 });
 const CAPTURE_PARK_SIDE_OFFSET_BY_TYPE = Object.freeze({
   fighter: 0,
@@ -117,10 +119,10 @@ const CAPTURE_PARK_SIDE_OFFSET_BY_TYPE = Object.freeze({
 });
 const CAPTURE_PARK_OUTWARD_OFFSET = 0.03;
 const CAPTURE_PARK_OUTWARD_OFFSET_BY_PLAYER = Object.freeze({
-  0: 0.35,
-  1: 0.33,
-  2: 0.33,
-  3: 0.35
+  0: 0.58,
+  1: 0.58,
+  2: 0.58,
+  3: 0.58
 });
 const CAPTURE_PARK_OUTWARD_OFFSET_BY_TYPE = Object.freeze({
   fighter: 0,


### PR DESCRIPTION
### Motivation
- Parked capture-vehicle visuals (fighter/helicopter/drone/missile) need to sit precisely on the corner parking pads shown in the mobile portrait reference so the parked animation matches the red-box P markers.

### Description
- Tuned per-player lateral offsets by changing `CAPTURE_PARK_SIDE_OFFSET_BY_PLAYER` in `webapp/src/pages/Games/LudoBattleRoyal.jsx` so parked vehicles align with the board corners in portrait orientation.
- Increased per-player outward offsets by changing `CAPTURE_PARK_OUTWARD_OFFSET_BY_PLAYER` in the same file so parked vehicles sit farther from the board center and match the marked parking zones.
- Added a short inline comment describing the seat order (portrait orientation) and the intended corner parking layout used as the visual guide.

### Testing
- Ran `npx eslint webapp/src/pages/Games/LudoBattleRoyal.jsx` which returned a lint warning that the file is ignored by the repo ignore settings and produced no errors.
- Ran `npx eslint --no-ignore webapp/src/pages/Games/LudoBattleRoyal.jsx` which executed and reported the same ignore-related warning with no lint errors.
- Invoked `npm run lint -- --no-ignore webapp/src/pages/Games/LudoBattleRoyal.jsx` which started the repo lint task and produced the same warnings; no automated unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1280aa79483298f541d0f22200dde)