### PR TITLE
Fine-tune Ludo parked weapon corner offsets for portrait reference

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -106,10 +106,12 @@ const CAPTURE_PARK_SIDE_OFFSET = 0.19;
 // Seat order is fixed to portrait view (0=bottom, 1=right, 2=top, 3=left).
 // Keep parked capture weapons at board-corner parking pads (as marked in the mobile UI reference).
 const CAPTURE_PARK_SIDE_OFFSET_BY_PLAYER = Object.freeze({
-  0: -0.5,
-  1: -0.5,
-  2: -0.5,
-  3: 0.5
+  // Portrait camera calibration (from mobile 2D reference):
+  // 0=bottom seat, 1=right seat, 2=top seat, 3=left seat.
+  0: -0.54,
+  1: -0.46,
+  2: -0.42,
+  3: 0.54
 });
 const CAPTURE_PARK_SIDE_OFFSET_BY_TYPE = Object.freeze({
   fighter: 0,
@@ -119,10 +121,10 @@ const CAPTURE_PARK_SIDE_OFFSET_BY_TYPE = Object.freeze({
 });
 const CAPTURE_PARK_OUTWARD_OFFSET = 0.03;
 const CAPTURE_PARK_OUTWARD_OFFSET_BY_PLAYER = Object.freeze({
-  0: 0.58,
-  1: 0.58,
-  2: 0.58,
-  3: 0.58
+  0: 0.56,
+  1: 0.52,
+  2: 0.5,
+  3: 0.56
 });
 const CAPTURE_PARK_OUTWARD_OFFSET_BY_TYPE = Object.freeze({
   fighter: 0,


### PR DESCRIPTION
### Motivation
- Parked capture vehicles (helicopter/jet/drone/missile) need to match the mobile portrait photo reference precisely when placed at table corner pads. The existing per-seat offsets produced small visual misalignments in the portrait camera framing.

### Description
- Tuned per-seat side offsets in `CAPTURE_PARK_SIDE_OFFSET_BY_PLAYER` to better match the marked corner pads for portrait orientation in `webapp/src/pages/Games/LudoBattleRoyal.jsx` by updating the numeric values and adding a short calibration comment. The values changed from `{-0.5, -0.5, -0.5, 0.5}` to `{-0.54, -0.46, -0.42, 0.54}`.
- Tuned per-seat outward offsets in `CAPTURE_PARK_OUTWARD_OFFSET_BY_PLAYER` so parked vehicles are inset consistently from table edges, changing values from uniform `0.58` to `{0.56, 0.52, 0.5, 0.56}`.
- Kept the parking computation logic unchanged; the patch only adjusts the configuration used by `resolveCaptureParkingAnchors` so vehicles are positioned visually where the mobile portrait reference marks them.

### Testing
- Ran the production build with `npm --prefix webapp run build`, which completed successfully (Vite build finished; warnings about chunk sizes/dynamic-import are informational and non-blocking).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1c1f810208329b2d6bd70f665f157)