### PR TITLE
Place parked weapons next to player tokens on Snake board

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -252,11 +252,7 @@ const TOKEN_REST_EXTRA_RADIAL_BY_SEAT = Object.freeze([
 const SEAT_RAIL_DICE_GAP = Math.max(DICE_SIZE * 0.95, TOKEN_RADIUS * 2.75);
 const SEAT_RAIL_SLOT_OFFSET = SEAT_RAIL_DICE_GAP * 0.5;
 const SEAT_RAIL_FORWARD_BIAS = TILE_SIZE * 0.08;
-// Seat-aware slot signs (portrait): 0=bottom, 1=right, 2=top, 3=left.
-// Keep reserve token placement stable and tune weapon to sit on the opposite side
-// for bottom/side seats so both props are clearly separated.
 const TOKEN_SLOT_SIDE_SIGN_BY_SEAT = Object.freeze([-1, 1, -1, 1]);
-const WEAPON_SLOT_SIDE_SIGN_BY_SEAT = Object.freeze([1, -1, -1, -1]);
 const TOKEN_SLOT_LATERAL_NUDGE_BY_SEAT = Object.freeze([
   TILE_SIZE * 0.06,
   0,
@@ -264,28 +260,30 @@ const TOKEN_SLOT_LATERAL_NUDGE_BY_SEAT = Object.freeze([
   0
 ]);
 const WEAPON_SLOT_LATERAL_NUDGE_BY_SEAT = Object.freeze([
-  -TILE_SIZE * 0.22,
-  -TILE_SIZE * 0.12,
   0,
-  TILE_SIZE * 0.12
+  0,
+  0,
+  0
 ]);
+const WEAPON_TOKEN_GAP = TOKEN_RADIUS * 0.26;
+const WEAPON_TOKEN_CENTER_SPACING = TOKEN_RADIUS * 2 + WEAPON_TOKEN_GAP;
 const WEAPON_DISPLAY_SIZE_MULTIPLIER = 1.4;
-const WEAPON_PARKING_OUTWARD_OFFSET = TILE_SIZE * 0.14;
-// Pull parked weapons for bottom/side seats inward so they align with each player edge position.
+const WEAPON_PARKING_OUTWARD_OFFSET = 0;
+// Keep parked weapons at the same depth as reserve tokens so they read as a tight pair.
 const WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT = Object.freeze([
-  -TILE_SIZE * 1.02,
-  -TILE_SIZE * 0.9,
   0,
-  -TILE_SIZE * 0.9
+  0,
+  0,
+  0
 ]);
 const WEAPON_PARKED_Y_DROP_BY_KIND = Object.freeze({
-  fighter: TOKEN_HEIGHT * 1.74,
-  helicopter: TOKEN_HEIGHT * 1.82,
-  drone: TOKEN_HEIGHT * 1.66,
-  supportTruck: TOKEN_HEIGHT * 1.78,
-  javelin: TOKEN_HEIGHT * 1.72
+  fighter: TOKEN_HEIGHT * 0.92,
+  helicopter: TOKEN_HEIGHT * 0.98,
+  drone: TOKEN_HEIGHT * 0.88,
+  supportTruck: TOKEN_HEIGHT * 0.96,
+  javelin: TOKEN_HEIGHT * 0.94
 });
-const WEAPON_REST_HEIGHT_OFFSET = -TOKEN_HEIGHT * 2.02;
+const WEAPON_REST_HEIGHT_OFFSET = 0;
 
 const PAVEMENT_EXTRA_SCALE = 1.18;
 const PAVEMENT_THICKNESS = TILE_SIZE * 0.4;
@@ -4659,11 +4657,17 @@ function updateSeatWeaponDisplays(board, players = []) {
       Number.isFinite(weaponInset) ? weaponInset : null
     );
     if (railLayout) {
-      const sideSign = WEAPON_SLOT_SIDE_SIGN_BY_SEAT[seatIndex] ?? (seatIndex % 2 === 0 ? -1 : 1);
+      const tokenSideSign = TOKEN_SLOT_SIDE_SIGN_BY_SEAT[seatIndex] ?? (seatIndex % 2 === 0 ? -1 : 1);
+      const sideSign = tokenSideSign;
+      const tokenLateralBase =
+        tokenSideSign * SEAT_RAIL_SLOT_OFFSET + (TOKEN_SLOT_LATERAL_NUDGE_BY_SEAT[seatIndex] ?? 0);
       const lateralNudge = WEAPON_SLOT_LATERAL_NUDGE_BY_SEAT[seatIndex] ?? 0;
       holder.position
         .copy(railLayout.railLocal)
-        .addScaledVector(railLayout.lateral, sideSign * SEAT_RAIL_SLOT_OFFSET + lateralNudge)
+        .addScaledVector(
+          railLayout.lateral,
+          tokenLateralBase + sideSign * WEAPON_TOKEN_CENTER_SPACING + lateralNudge
+        )
         .addScaledVector(
           railLayout.seatDirection,
           WEAPON_PARKING_OUTWARD_OFFSET + (WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT[seatIndex] ?? 0)


### PR DESCRIPTION
### Motivation
- Improve UX by visually grouping parked weapons with their player tokens so each weapon appears immediately beside its token with a small gap and at the same altitude.
- Remove inconsistent per-seat offsets that caused weapons to drift away from the token and appear lower than tokens.

### Description
- Updated `webapp/src/components/SnakeBoard3D.jsx` to compute weapon placement relative to the token lateral slot instead of an independent outward slot.
- Added spacing constants `WEAPON_TOKEN_GAP` and `WEAPON_TOKEN_CENTER_SPACING` and used them to place weapons tightly next to tokens.
- Removed outward seat offsets (`WEAPON_PARKING_OUTWARD_OFFSET` and per-seat outward offsets) and set `WEAPON_REST_HEIGHT_OFFSET = 0` so weapons sit at token height; reduced per-weapon Y drops in `WEAPON_PARKED_Y_DROP_BY_KIND`.
- Adjusted lateral placement math in `updateSeatWeaponDisplays` to use token slot base (`TOKEN_SLOT_SIDE_SIGN_BY_SEAT`, `SEAT_RAIL_SLOT_OFFSET`, `TOKEN_SLOT_LATERAL_NUDGE_BY_SEAT`) plus the new token-centered spacing.

### Testing
- Ran `npx eslint webapp/src/components/SnakeBoard3D.jsx`, which completed (the file is ignored by the current eslint ignore patterns so no actionable lint errors were produced).
- No other automated tests were executed for this change in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1c2a807488329b089bf9891065ccd)