### PR TITLE
Anchor Ludo parked capture vehicles to seat corner pads

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -4627,8 +4627,9 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     const anchor = arena.seatAnchors[playerIndex];
     if (!anchor) return null;
     const seatPos = anchor.getWorldPosition(new THREE.Vector3());
-    const kingPos = getKingTokenPositionForPlayer(playerIndex) ?? seatPos;
-    const inward = arena.boardLookTarget.clone().sub(kingPos).setY(0).normalize();
+    // Keep parked weapons locked to the player's seat lane (portrait camera reference),
+    // so they stay on the corner parking pads even while kings move around the board.
+    const inward = arena.boardLookTarget.clone().sub(seatPos).setY(0).normalize();
     if (inward.lengthSq() < 1e-6) return null;
     const leftSide = new THREE.Vector3().crossVectors(MISSILE_WORLD_UP, inward).normalize();
     const forwardOffset = CAPTURE_PARK_FORWARD_OFFSET_BY_TYPE[vehicleType] ?? 0.03;
@@ -4638,14 +4639,14 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     const outwardOffsetByPlayer = CAPTURE_PARK_OUTWARD_OFFSET_BY_PLAYER[playerIndex] ?? CAPTURE_PARK_OUTWARD_OFFSET;
     const outwardOffsetByType = CAPTURE_PARK_OUTWARD_OFFSET_BY_TYPE[vehicleType] ?? 0;
     const outwardOffset = outwardOffsetByPlayer + outwardOffsetByType;
-    const park = kingPos
+    const park = seatPos
       .clone()
       .addScaledVector(leftSide, sideOffset)
       .addScaledVector(inward, forwardOffset)
       .addScaledVector(inward, -outwardOffset);
     park.y = (arena.tableInfo?.surfaceY ?? park.y) + 0.002;
     return park;
-  }, [getKingTokenPositionForPlayer]);
+  }, []);
 
   const resolvePlayerLabel = useCallback(
     (playerIndex) => players[playerIndex]?.name || COLOR_NAMES[playerIndex] || `Player ${playerIndex + 1}`,


### PR DESCRIPTION
### Motivation
- Parked capture weapons (helicopters, missiles, jets, drones) should remain fixed to the corner parking pads visible in the portrait mobile UI reference instead of following the moving king token. 
- This preserves the exact layout from the reference photo while allowing only small tuning offsets for each vehicle type. 
- Keep the anchor behavior consistent with the player seat lane so parked items don't drift when tokens move around the board.

### Description
- Changed `resolveCaptureParkingAnchors` in `webapp/src/pages/Games/LudoBattleRoyal.jsx` to compute the inward vector from the player `seat` anchor instead of the (moving) king token, so parked vehicles are anchored to the seat lane. 
- Replaced use of `kingPos` with `seatPos` when building the final `park` position and added a clarifying comment describing the portrait-seat anchoring intent. 
- Simplified the `useCallback` dependency list for `resolveCaptureParkingAnchors` (removed the unused `getKingTokenPositionForPlayer` dependency) to reflect the new stable-seat-based logic.

### Testing
- Ran `npx eslint webapp/src/pages/Games/LudoBattleRoyal.jsx` which executed and reported the file is skipped by repository ignore rules (no lint errors produced). 
- Ran `npx eslint --no-ignore webapp/src/pages/Games/LudoBattleRoyal.jsx` which returned the same ignore-pattern warning and no rule-level errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1c1f810208329b2d6bd70f665f157)