### PR TITLE
Tighten pawn missile precision and align jet/helicopter flypaths with Ludo pacing

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -99,7 +99,7 @@ const CAPTURE_DRONE_TOTAL = CAPTURE_DRONE_LIFT_TIME + CAPTURE_DRONE_CRUISE_TIME 
 const CAPTURE_JET_SPEED_FACTOR = 4.9 / CAPTURE_DRONE_TOTAL; // slower than prior tuning for clearer portrait tracking
 const PROFILE_VIEW_ROTATION_TYPES = new Set(['K', 'N']);
 const PROFILE_VIEW_ROTATION_RADIANS = Math.PI / 2;
-const CAPTURE_JET_TOTAL = 4.9; // readable loop: takeoff -> tiny forward move -> fire -> return to same pad
+const CAPTURE_JET_TOTAL = LUDO_CAPTURE_TOTAL; // mirror Ludo loop pacing so takeoff/orbit/return stays readable in portrait
 const CAPTURE_JET_MISSILE_TRAVEL = Math.max(0.28, CAPTURE_JET_TOTAL * (0.96 - 0.56) - 0.1);
 const CAPTURE_HELICOPTER_SPEED_FACTOR = 1; // keep helicopter pacing identical to jet so both share the same visible loop
 const CAPTURE_HELICOPTER_TOTAL = CAPTURE_JET_TOTAL; // helicopter mirrors jet timing and route behavior
@@ -145,17 +145,19 @@ const CAPTURE_AIR_MISSILE_DROP_HEIGHT_MUL = 0.34;
 const CAPTURE_DIRECT_STRIKE_INWARD_DISTANCE = 0.16; // keep launch hop very close to parking position
 const CAPTURE_DIRECT_STRIKE_TAKEOFF_RATIO = 0.42; // spend longer lifting before cruise
 const CAPTURE_DIRECT_STRIKE_RETURN_RATIO = 0.54; // return earlier so fly-bys stay close to board
-const CAPTURE_VERTICAL_STRIKE_INWARD_DISTANCE = 0.025; // pawn missile rises almost vertically from live piece
-const CAPTURE_VERTICAL_STRIKE_ALTITUDE = 0.1; // low vertical arc
-const CAPTURE_VERTICAL_STRIKE_TOP_OFFSET = 0.09; // short top point before vertical drop
+const CAPTURE_VERTICAL_STRIKE_INWARD_DISTANCE = 0.012; // pawn missile stays almost locked to live attacker location
+const CAPTURE_VERTICAL_STRIKE_ALTITUDE = 0.086; // lower pawn/short-missile arc for tighter hit path
+const CAPTURE_VERTICAL_STRIKE_TOP_OFFSET = 0.064; // shorter top crest before final drop for precision hit feel
 const CAPTURE_RELOAD_SHOW_TIME = 0.58;
-const CAPTURE_PAD_STRIKE_ALTITUDE = CAPTURE_VERTICAL_STRIKE_ALTITUDE; // jet/helicopter cruise at same low strike altitude as short pawn missile
-const CAPTURE_PAD_STRIKE_FORWARD_TILES = 0.2; // move only a tiny amount from parking spot before firing
-const CAPTURE_PAD_STRIKE_ASCEND_RATIO = 0.24;
-const CAPTURE_PAD_STRIKE_HOVER_RATIO = 0.54;
-const CAPTURE_PAD_STRIKE_RETURN_RATIO = 0.84;
-const CAPTURE_PAD_MISSILE_RELEASE_RATIO = 0.48; // launch while aircraft is hovering near pad-forward point
-const CAPTURE_PAD_MISSILE_TRAVEL_TIME = CAPTURE_GROUND_TRAVEL_TIME; // same short missile speed as pawn/truck strike
+const CAPTURE_PAD_STRIKE_ALTITUDE = CAPTURE_VERTICAL_STRIKE_ALTITUDE; // keep jet/helicopter route low like pawn short-missile lane
+const CAPTURE_PAD_STRIKE_FORWARD_TILES = 0.22; // short board approach from parking before strike release
+const CAPTURE_PAD_STRIKE_ASCEND_RATIO = 0.22;
+const CAPTURE_PAD_STRIKE_LOOP_RATIO = 0.64;
+const CAPTURE_PAD_STRIKE_RETURN_RATIO = 0.88;
+const CAPTURE_PAD_STRIKE_ORBIT_ARC = 0.18; // compact in-board loop to mimic Ludo fly-around on smaller Chess table
+const CAPTURE_PAD_MISSILE_RELEASE_RATIO = 0.58; // release during loop entry, not at pad pop-up
+const CAPTURE_SHORT_MISSILE_TRAVEL_TIME = 1.96; // slightly shorter, more direct strike timing
+const CAPTURE_PAD_MISSILE_TRAVEL_TIME = CAPTURE_SHORT_MISSILE_TRAVEL_TIME; // air-unit missiles match pawn short missile pacing
 const CAPTURE_SHORT_MISSILE_HIT_THRESHOLD = 0.995; // guarantee explosion when missile reaches target end of path
 const CAPTURE_TRUCK_LAUNCH_SMOKE_BOOST = 1.75;
 const CAPTURE_TRUCK_LAUNCH_SMOKE_BOOST_TIME = 0.32;
@@ -9827,6 +9829,11 @@ function Chess3D({
           next = strikeTop.clone().lerp(targetPos, clamp01(dropU + 0.08));
           next.x = pos.x;
           next.z = pos.z;
+          if (dropU >= 0.985) {
+            pos.copy(targetPos);
+            next.copy(targetPos);
+            next.y = Math.max(targetPos.y - 0.01, 0);
+          }
         }
       }
       constrainInsideBoardPerimeter(pos, CAPTURE_AIR_STRIKE_PATH_EDGE_MARGIN_TILES + 0.2);
@@ -9850,6 +9857,12 @@ function Chess3D({
       const liftTarget = launchPos.clone();
       liftTarget.y = Math.max(launchPos.y + altitude, launchPos.y + 0.06);
       const forwardTarget = liftTarget.clone().addScaledVector(towardTarget, tile * forwardTiles);
+      const toCenter = new THREE.Vector3(-Math.sign(launchPos.x || 1), 0, 0).normalize();
+      const orbitSide = new THREE.Vector3(-towardTarget.z, 0, towardTarget.x).normalize();
+      const loopAnchor = forwardTarget
+        .clone()
+        .addScaledVector(toCenter, tile * CAPTURE_PAD_STRIKE_ORBIT_ARC * 0.86)
+        .addScaledVector(orbitSide, tile * CAPTURE_PAD_STRIKE_ORBIT_ARC * 0.66);
       const u = clamp01(progress);
       let pos = launchPos.clone();
       let next = launchPos.clone().add(new THREE.Vector3(0.04, 0, 0));
@@ -9857,20 +9870,27 @@ function Chess3D({
         const su = smoothEase(u / Math.max(0.001, CAPTURE_PAD_STRIKE_ASCEND_RATIO));
         pos = launchPos.clone().lerp(liftTarget, su);
         next = launchPos.clone().lerp(liftTarget, clamp01(su + 0.06));
-      } else if (u < CAPTURE_PAD_STRIKE_HOVER_RATIO) {
+      } else if (u < CAPTURE_PAD_STRIKE_LOOP_RATIO) {
         const su = smoothEase(
           (u - CAPTURE_PAD_STRIKE_ASCEND_RATIO) /
-            Math.max(0.001, CAPTURE_PAD_STRIKE_HOVER_RATIO - CAPTURE_PAD_STRIKE_ASCEND_RATIO)
+            Math.max(0.001, CAPTURE_PAD_STRIKE_LOOP_RATIO - CAPTURE_PAD_STRIKE_ASCEND_RATIO)
         );
-        pos = liftTarget.clone().lerp(forwardTarget, su);
-        next = liftTarget.clone().lerp(forwardTarget, clamp01(su + 0.06));
+        if (su < 0.52) {
+          const local = smoothEase(su / 0.52);
+          pos = liftTarget.clone().lerp(forwardTarget, local);
+          next = liftTarget.clone().lerp(forwardTarget, clamp01(local + 0.06));
+        } else {
+          const local = smoothEase((su - 0.52) / 0.48);
+          pos = forwardTarget.clone().lerp(loopAnchor, local);
+          next = forwardTarget.clone().lerp(loopAnchor, clamp01(local + 0.06));
+        }
       } else if (u < CAPTURE_PAD_STRIKE_RETURN_RATIO) {
         const su = smoothEase(
-          (u - CAPTURE_PAD_STRIKE_HOVER_RATIO) /
-            Math.max(0.001, CAPTURE_PAD_STRIKE_RETURN_RATIO - CAPTURE_PAD_STRIKE_HOVER_RATIO)
+          (u - CAPTURE_PAD_STRIKE_LOOP_RATIO) /
+            Math.max(0.001, CAPTURE_PAD_STRIKE_RETURN_RATIO - CAPTURE_PAD_STRIKE_LOOP_RATIO)
         );
-        pos = forwardTarget.clone().lerp(liftTarget, su);
-        next = forwardTarget.clone().lerp(liftTarget, clamp01(su + 0.06));
+        pos = loopAnchor.clone().lerp(liftTarget, su);
+        next = loopAnchor.clone().lerp(liftTarget, clamp01(su + 0.06));
       } else {
         const su = smoothEase(
           (u - CAPTURE_PAD_STRIKE_RETURN_RATIO) / Math.max(0.001, 1 - CAPTURE_PAD_STRIKE_RETURN_RATIO)
@@ -9878,7 +9898,12 @@ function Chess3D({
         pos = liftTarget.clone().lerp(launchPos, su);
         next = liftTarget.clone().lerp(launchPos, clamp01(su + 0.06));
       }
-      return { pos, next, forward: towardTarget, strikeAnchor: forwardTarget };
+      return {
+        pos: constrainInsideBoardPerimeter(pos),
+        next: constrainInsideBoardPerimeter(next),
+        forward: towardTarget,
+        strikeAnchor: loopAnchor
+      };
     };
     const getCaptureShortMissilePose = ({ launchPos, targetPos, progress, altitude = CAPTURE_VERTICAL_STRIKE_ALTITUDE }) =>
       getCaptureDirectStrikePose({
@@ -9957,21 +9982,22 @@ function Chess3D({
             captureResolveDelayMs: CAPTURE_GROUND_TOTAL * 1000
           };
         }
-        suppressTimerBeepUntilRef.current = performance.now() + CAPTURE_GROUND_TOTAL * 1000;
+        const pawnCaptureTotal = CAPTURE_GROUND_FIRE_TIME + CAPTURE_SHORT_MISSILE_TRAVEL_TIME;
+        suppressTimerBeepUntilRef.current = performance.now() + pawnCaptureTotal * 1000;
         const missileFx = createFxGroundMissile();
         missileFx.root.scale.setScalar(CAPTURE_PAWN_JAVELIN_SCALE);
-        const liveLaunchPos = getLiveLaunchPosition(fromPos, movingMesh, 0.08);
+        const liveLaunchPos = getLiveLaunchPosition(fromPos, movingMesh, 0.04);
         const launchBase = liveLaunchPos?.clone?.() || fromPos.clone();
-        missileFx.root.position.copy(launchBase.clone().add(new THREE.Vector3(0, 0.03, 0)));
+        missileFx.root.position.copy(launchBase.clone().add(new THREE.Vector3(0, 0.01, 0)));
         captureFxGroup.add(missileFx.root);
         playAudio(missileLaunchSoundRef);
         activeCaptureFx.push({
           type: 'javelin',
           t: 0,
-          duration: CAPTURE_GROUND_TOTAL,
+          duration: pawnCaptureTotal,
           from: fromPos.clone(),
           to: targetPos.clone(),
-          launchPos: launchBase.add(new THREE.Vector3(0, 0.03, 0)),
+          launchPos: launchBase.add(new THREE.Vector3(0, 0.01, 0)),
           movingMesh,
           sourceUnit: null,
           missileFx,
@@ -9979,8 +10005,8 @@ function Chess3D({
           verticalStrike: true
         });
         return {
-          moveDelayMs: CAPTURE_GROUND_TOTAL * 1000,
-          captureResolveDelayMs: CAPTURE_GROUND_TOTAL * 1000
+          moveDelayMs: pawnCaptureTotal * 1000,
+          captureResolveDelayMs: pawnCaptureTotal * 1000
         };
       }
       if (pieceType === 'K') {
@@ -10000,7 +10026,7 @@ function Chess3D({
               : (onlineRef.current.enabled ? opponent?.avatar || opponent?.name : null) || opponent?.name || aiFlag || '🤖',
             isWhiteSide ? 1 : -1
           );
-          jetFx.root.position.copy(launchBase.clone().add(new THREE.Vector3(0, 0.08, 0)));
+          jetFx.root.position.copy(launchBase.clone());
           captureFxGroup.add(jetFx.root);
         }
         const launchBase = parkedUnit?.homePosition?.clone?.() || getAirPadAnchor(isWhiteSide, 'jet', 0);
@@ -10016,7 +10042,7 @@ function Chess3D({
           duration: CAPTURE_JET_TOTAL,
           from: fromPos.clone(),
           to: targetPos.clone(),
-          launchPos: launchBase.add(new THREE.Vector3(0, 0.08, 0)),
+          launchPos: launchBase,
           movingMesh,
           returnToOrigin: true,
           missileReleaseTime: CAPTURE_JET_TOTAL * CAPTURE_JET_MISSILE_ENTRY_RELEASE_RATIO,
@@ -10051,7 +10077,7 @@ function Chess3D({
               : (onlineRef.current.enabled ? opponent?.avatar || opponent?.name : null) || opponent?.name || aiFlag || '🤖',
             isWhiteSide ? 1 : -1
           );
-          helicopterFx.root.position.copy(launchBase.clone().add(new THREE.Vector3(0, 0.08, 0)));
+          helicopterFx.root.position.copy(launchBase.clone());
           captureFxGroup.add(helicopterFx.root);
         }
         const launchBase = parkedUnit?.homePosition?.clone?.() || getAirPadAnchor(isWhiteSide, 'helicopter', 0);
@@ -10068,7 +10094,7 @@ function Chess3D({
           duration: CAPTURE_HELICOPTER_TOTAL,
           from: fromPos.clone(),
           to: targetPos.clone(),
-          launchPos: launchBase.add(new THREE.Vector3(0, 0.08, 0)),
+          launchPos: launchBase,
           movingMesh,
           returnToOrigin: true,
           missileReleaseTime: CAPTURE_HELICOPTER_TOTAL * CAPTURE_JET_MISSILE_ENTRY_RELEASE_RATIO,
@@ -10099,7 +10125,7 @@ function Chess3D({
               : (onlineRef.current.enabled ? opponent?.avatar || opponent?.name : null) || opponent?.name || aiFlag || '🤖',
             isWhiteSide ? 1 : -1
           );
-          jetFx.root.position.copy(launchBase.clone().add(new THREE.Vector3(0, 0.08, 0)));
+          jetFx.root.position.copy(launchBase.clone());
           captureFxGroup.add(jetFx.root);
         }
         const launchBase = parkedUnit?.homePosition?.clone?.() || getAirPadAnchor(isWhiteSide, 'jet', 1);
@@ -10115,7 +10141,7 @@ function Chess3D({
           duration: CAPTURE_JET_TOTAL,
           from: fromPos.clone(),
           to: targetPos.clone(),
-          launchPos: launchBase.add(new THREE.Vector3(0, 0.08, 0)),
+          launchPos: launchBase,
           movingMesh,
           returnToOrigin: true,
           missileReleaseTime: CAPTURE_JET_TOTAL * CAPTURE_JET_MISSILE_ENTRY_RELEASE_RATIO,
@@ -12108,12 +12134,13 @@ function Chess3D({
           } else if (fx.type === 'javelin') {
             const launchPos = fx.sourceUnit?.homePosition?.clone?.() || getLiveLaunchPosition(fx.launchPos, fx.movingMesh, 0);
             fx.launchPos.copy(launchPos);
-            const impactTime = CAPTURE_GROUND_FIRE_TIME + CAPTURE_GROUND_TRAVEL_TIME;
+            const travelTime = fx.verticalStrike ? CAPTURE_SHORT_MISSILE_TRAVEL_TIME : CAPTURE_GROUND_TRAVEL_TIME;
+            const impactTime = CAPTURE_GROUND_FIRE_TIME + travelTime;
             if (fx.t < CAPTURE_GROUND_FIRE_TIME) {
               fx.missileFx.root.visible = true;
               fx.missileFx.root.position.copy(launchPos);
             } else if (fx.t < impactTime) {
-              const mu = smoothEase((fx.t - CAPTURE_GROUND_FIRE_TIME) / CAPTURE_GROUND_TRAVEL_TIME);
+              const mu = smoothEase((fx.t - CAPTURE_GROUND_FIRE_TIME) / travelTime);
               const { pos: missilePos, next: missileNext } = getCaptureDirectStrikePose({
                 launchPos,
                 targetPos: fx.to,
@@ -12149,7 +12176,7 @@ function Chess3D({
               fx.missileFx.root.visible = false;
             }
             if (fx.t >= impactTime) {
-              const strikeProgress = clamp01((fx.t - CAPTURE_GROUND_FIRE_TIME) / CAPTURE_GROUND_TRAVEL_TIME);
+              const strikeProgress = clamp01((fx.t - CAPTURE_GROUND_FIRE_TIME) / travelTime);
               const contactDistance = fx.missileFx.root.position.distanceTo(fx.to);
               if (!fx.hasExploded && (strikeProgress >= CAPTURE_SHORT_MISSILE_HIT_THRESHOLD || contactDistance <= CAPTURE_GROUND_CONTACT_RADIUS)) {
                 fx.hasExploded = true;


### PR DESCRIPTION
### Motivation
- Make pawn short-missile strikes launch from the live attacker location and hit with a tighter, lower arc for more precise visual contact.
- Slow and re-time jet/helicopter takeoff/cruise/return to match the readable Ludo capture loop cadence while keeping flight paths lower and more compact for the smaller Chess board.
- Ensure airborne units visibly lift off from their parking anchors, perform a compact in-board loop to release missiles, then return to pad for consistent UX.

### Description
- Updated capture timing constants so jets/helicopters use `LUDO_CAPTURE_TOTAL` for loop pacing and introduced new pad/loop ratios and orbit arc constants (`CAPTURE_PAD_STRIKE_LOOP_RATIO`, `CAPTURE_PAD_STRIKE_ORBIT_ARC`, `CAPTURE_PAD_MISSILE_RELEASE_RATIO`, `CAPTURE_SHORT_MISSILE_TRAVEL_TIME`, etc.).
- Tightened pawn/short-missile parameters (`CAPTURE_VERTICAL_STRIKE_INWARD_DISTANCE`, `CAPTURE_VERTICAL_STRIKE_ALTITUDE`, `CAPTURE_VERTICAL_STRIKE_TOP_OFFSET`) and shortened pawn travel/duration so pawn strikes are launched closer to the piece and resolve faster.
- Modified `getCapturePadStrikePose` to compute a compact loop anchor and to run a two-phase pad behavior (short ascend → small forward → compact loop → return) so jets/helicopters visibly lift from their pad and release missiles during loop entry.
- Changed live launch offsets so pawn missiles and air units lift from the exact parking/home anchor (reduced Y offsets and removed extra pop-up offsets), and wired missile travel timing per-case (pawn short vs ground truck) via `travelTime` selection.
- Improved terminal vertical-crash precision by snapping the final drop segment to the exact target near impact to avoid overshoot and improve hit feel.
- All changes implemented in `webapp/src/pages/Games/ChessBattleRoyal.jsx` (adjusted constants, pose functions, active fx timeline, and launch origin handling).

### Testing
- Ran `git diff --check` which passed with no whitespace/patch errors.
- Attempted the targeted Jest run `npm run -s test -- chessLobbyPreferredSideMatchmaking.test.js`, but the test run failed in this environment due to a missing dependency (`ERR_MODULE_NOT_FOUND` for `bot/node_modules/mongoose`) and a subsequent timeout, so full automated test verification could not complete here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2711f1d688329a0a9b000151f16ab)