### PR TITLE
Adjust snake board seat weapon parking for mobile portrait

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -271,10 +271,10 @@ const WEAPON_DISPLAY_SIZE_MULTIPLIER = 1.4;
 const WEAPON_PARKING_OUTWARD_OFFSET = 0;
 // Keep parked weapons anchored next to the player token with only a small visual gap.
 const WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT = Object.freeze([
+  -TILE_SIZE * 0.26,
+  -TILE_SIZE * 0.2,
   0,
-  0,
-  0,
-  0
+  -TILE_SIZE * 0.2
 ]);
 const WEAPON_TOKEN_GAP = TILE_SIZE * 0.06;
 const WEAPON_PARKED_Y_DROP_BY_KIND = Object.freeze({
@@ -285,6 +285,12 @@ const WEAPON_PARKED_Y_DROP_BY_KIND = Object.freeze({
   javelin: TOKEN_HEIGHT * 1.72
 });
 const WEAPON_REST_HEIGHT_OFFSET = 0;
+const WEAPON_REST_HEIGHT_OFFSET_BY_SEAT = Object.freeze([
+  -TOKEN_HEIGHT * 0.34,
+  -TOKEN_HEIGHT * 0.3,
+  0,
+  -TOKEN_HEIGHT * 0.3
+]);
 
 const PAVEMENT_EXTRA_SCALE = 1.18;
 const PAVEMENT_THICKNESS = TILE_SIZE * 0.4;
@@ -4672,7 +4678,10 @@ function updateSeatWeaponDisplays(board, players = []) {
           railLayout.seatDirection,
           WEAPON_PARKING_OUTWARD_OFFSET + (WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT[seatIndex] ?? 0)
         );
-      holder.position.y = railLayout.railHeightY + WEAPON_REST_HEIGHT_OFFSET;
+      holder.position.y =
+        railLayout.railHeightY +
+        WEAPON_REST_HEIGHT_OFFSET +
+        (WEAPON_REST_HEIGHT_OFFSET_BY_SEAT[seatIndex] ?? 0);
     } else {
       const seatWorld = new THREE.Vector3();
       anchor.getWorldPosition(seatWorld);


### PR DESCRIPTION
### Motivation
- Make the parked vehicle/weapon models (fighter/jet, helicopter, javelin/missile, support truck, drone) sit visually closer to each player token and lower to the table surface for bottom/right/left seats in portrait mobile view while leaving the top seat unchanged.
- Improve token/weapon layout and visual clarity on small portrait screens so vehicles no longer appear out by the chairs.

### Description
- Added per-seat inward offsets via `WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT` to pull parked vehicles toward the table center for seats 0 (bottom), 1 (right) and 3 (left) while keeping seat 2 (top) unchanged.
- Added per-seat vertical offsets via `WEAPON_REST_HEIGHT_OFFSET_BY_SEAT` to lower parked vehicles for the same seats so they rest closer to the table surface.
- Applied the new per-seat offsets in `updateSeatWeaponDisplays` when computing `holder.position` (y and rail lateral placement) so the placement logic uses the new arrays.
- Changes are implemented in `webapp/src/components/SnakeBoard3D.jsx` and committed on the working branch.

### Testing
- Ran the webapp production build with `npm --prefix webapp run build`, which completed successfully (`✓ built in 34.13s`) although Vite emitted chunk-size and dynamic-import warnings; the build artifacts were produced.
- No other automated unit tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e28594782c832991597a79fe57040d)