### PR TITLE
Refine Murlan Royale table spacing and live-avatar touch priority

### DIFF
--- a/webapp/src/components/GameLiveAvatarOverlay.jsx
+++ b/webapp/src/components/GameLiveAvatarOverlay.jsx
@@ -26,7 +26,15 @@ const AVATAR_ANCHOR_SELECTORS = [
 ];
 
 const FRAME_SCALE = 2;
-const ACTIVATION_TOUCH_PADDING = 8;
+const BLOCKING_OVERLAY_SELECTORS = [
+  '#configPanel.active',
+  '#chatModal.active',
+  '#giftModal.active',
+  '.modal-overlay.active',
+  '[role="dialog"][aria-hidden="false"]',
+  '#rules[style*="display: flex"]',
+  '#rules[style*="display:flex"]'
+];
 const AVATAR_FRAME_STYLES = Object.freeze({
   borderRadius: '999px',
   border: '2px solid rgba(255,255,255,.32)',
@@ -47,6 +55,13 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
     width: 44,
     height: 44
   });
+  const [activationRect, setActivationRect] = useState({
+    top: 96,
+    left: 12,
+    width: 44,
+    height: 44
+  });
+  const [hasBlockingOverlay, setHasBlockingOverlay] = useState(false);
 
   const displayName = useMemo(() => {
     if (typeof window === 'undefined') return 'Player';
@@ -178,6 +193,15 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
         Math.round(rect.top - (height - rect.height) / 2),
         0
       );
+      const activationSize = Math.max(Math.round(avatarDiameter), 20);
+      const activationLeft = Math.max(
+        Math.round(rect.left + rect.width / 2 - activationSize / 2),
+        0
+      );
+      const activationTop = Math.max(
+        Math.round(rect.top + rect.height / 2 - activationSize / 2),
+        0
+      );
       setAnchorElement(node);
       setOverlayRect((prev) => {
         if (
@@ -189,6 +213,22 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
           return prev;
         }
         return { top, left, width, height };
+      });
+      setActivationRect((prev) => {
+        if (
+          Math.abs(prev.top - activationTop) <= 1 &&
+          Math.abs(prev.left - activationLeft) <= 1 &&
+          Math.abs(prev.width - activationSize) <= 1 &&
+          Math.abs(prev.height - activationSize) <= 1
+        ) {
+          return prev;
+        }
+        return {
+          top: activationTop,
+          left: activationLeft,
+          width: activationSize,
+          height: activationSize
+        };
       });
     };
 
@@ -239,13 +279,35 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
     };
   }, [gameSlug, search]);
 
-  const activationRect = useMemo(() => {
-    const width = overlayRect.width + ACTIVATION_TOUCH_PADDING * 2;
-    const height = overlayRect.height + ACTIVATION_TOUCH_PADDING * 2;
-    const left = Math.max(overlayRect.left - ACTIVATION_TOUCH_PADDING, 0);
-    const top = Math.max(overlayRect.top - ACTIVATION_TOUCH_PADDING, 0);
-    return { top, left, width, height };
-  }, [overlayRect]);
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+    const hasOpenOverlay = () =>
+      BLOCKING_OVERLAY_SELECTORS.some((selector) => {
+        const node = document.querySelector(selector);
+        if (!node) return false;
+        if (node.id === 'rules') {
+          const display = window.getComputedStyle(node).display;
+          return display !== 'none';
+        }
+        return true;
+      });
+    const syncOverlayState = () => setHasBlockingOverlay(hasOpenOverlay());
+    const observer = new MutationObserver(syncOverlayState);
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['class', 'style', 'aria-hidden']
+    });
+    syncOverlayState();
+    window.addEventListener('resize', syncOverlayState);
+    window.addEventListener('orientationchange', syncOverlayState);
+    return () => {
+      observer.disconnect();
+      window.removeEventListener('resize', syncOverlayState);
+      window.removeEventListener('orientationchange', syncOverlayState);
+    };
+  }, []);
 
   useEffect(() => {
     if (!anchorElement) return undefined;
@@ -265,12 +327,13 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
           type="button"
           aria-label="Turn on live avatar video"
           onClick={() => setLiveMode(true)}
-          className="fixed z-[64] rounded-full bg-transparent touch-manipulation"
+          className="fixed z-[18] rounded-full bg-transparent touch-manipulation"
           style={{
             top: `${activationRect.top}px`,
             left: `${activationRect.left}px`,
             width: `${activationRect.width}px`,
-            height: `${activationRect.height}px`
+            height: `${activationRect.height}px`,
+            pointerEvents: hasBlockingOverlay ? 'none' : 'auto'
           }}
         />
       ) : null}
@@ -279,12 +342,13 @@ export default function GameLiveAvatarOverlay({ gameSlug, children }) {
           type="button"
           aria-label="Turn off live avatar video"
           onClick={() => setLiveMode(false)}
-          className="fixed z-[65] overflow-hidden touch-manipulation"
+          className="fixed z-[18] overflow-hidden touch-manipulation"
           style={{
             top: `${overlayRect.top}px`,
             left: `${overlayRect.left}px`,
             width: `${overlayRect.width}px`,
             height: `${overlayRect.height}px`,
+            pointerEvents: hasBlockingOverlay ? 'none' : 'auto',
             ...(gameSlug === 'domino-royal' ? AVATAR_FRAME_STYLES : {}),
             ...(gameSlug !== 'domino-royal'
               ? {

--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -106,9 +106,9 @@ const ENABLE_3D_HUMAN_CHARACTERS = false;
 const ARENA_GROWTH = 1.45; // expanded arena footprint for wider walkways
 const CHAIR_SIZE_SCALE = 1;
 const ARENA_PROP_SCALE = 0.78; // Slightly smaller arena props so table/chairs/cards better match HDRI scale in portrait.
-const TOP_SEAT_AVATAR_UP_LIFT = 3.8; // Portrait-space lift for the visual top player's avatar badge.
+const TOP_SEAT_AVATAR_UP_LIFT = 2.4; // Keep top avatar slightly closer to table center in portrait.
 
-const TABLE_RADIUS = 3.22 * MODEL_SCALE * ARENA_PROP_SCALE;
+const TABLE_RADIUS = 3.08 * MODEL_SCALE * ARENA_PROP_SCALE;
 const CHAIR_COUNT = 4;
 const CUSTOM_SEAT_ANGLES = [
   THREE.MathUtils.degToRad(90),
@@ -2280,7 +2280,7 @@ const TABLE_HEIGHT_SHORTEN_FACTOR = 0.7; // Keep the table ~30% shorter than the
 const BASE_TABLE_HEIGHT = 0.96 * MODEL_SCALE * TABLE_HEIGHT_SHORTEN_FACTOR;
 const BASE_HUMAN_CHAIR_RADIUS = 5.6 * MODEL_SCALE * ARENA_GROWTH * 0.85;
 const HUMAN_CHAIR_PULLBACK = 0.08 * MODEL_SCALE;
-const CHAIR_INWARD_OFFSET = 0.18 * MODEL_SCALE;
+const CHAIR_INWARD_OFFSET = 0.24 * MODEL_SCALE;
 const CHAIR_RADIUS = BASE_HUMAN_CHAIR_RADIUS + HUMAN_CHAIR_PULLBACK - CHAIR_INWARD_OFFSET;
 const AI_CHAIR_GAP = CARD_W * 0.2;
 const AI_CHAIR_RADIUS = TABLE_RADIUS + SEAT_DEPTH / 2 + AI_CHAIR_GAP - CHAIR_INWARD_OFFSET * 0.45;
@@ -2302,8 +2302,8 @@ const HUMAN_HAND_FAN_MAX_YAW = THREE.MathUtils.degToRad(22);
 const HUMAN_HAND_FAN_ARC_LIFT = 0.06 * MODEL_SCALE;
 const HUMAN_HAND_FAN_DIRECTION = 1;
 const HUMAN_HAND_UNIFORM_YAW_FROM_LEFT = true;
-const HUMAN_HAND_CLOSER_OFFSET = -0.35 * MODEL_SCALE;
-const HUMAN_HAND_BOTTOM_SHIFT_Y = -0.145 * MODEL_SCALE;
+const HUMAN_HAND_CLOSER_OFFSET = -0.23 * MODEL_SCALE;
+const HUMAN_HAND_BOTTOM_SHIFT_Y = -0.105 * MODEL_SCALE;
 const HUMAN_HAND_LEFT_SHIFT = 0;
 const HUMAN_HAND_UP_SHIFT_Y = 0.03 * MODEL_SCALE;
 const HUMAN_HAND_DIRECTIONAL_LIFT = 0.05 * MODEL_SCALE;
@@ -5348,13 +5348,13 @@ export default function MurlanRoyaleArena({ search }) {
             const anchor = seatAnchorMap.get(idx);
             const fallback = FALLBACK_SEAT_POSITIONS[idx % FALLBACK_SEAT_POSITIONS.length];
             const isSideSeat = Boolean(anchor) && (anchor.x <= 35 || anchor.x >= 65);
-            const sideSeatTopLift = isSideSeat ? 12 : 0;
+            const sideSeatTopLift = isSideSeat ? 8 : 0;
             const topSeatLift = idx === topSeatIndex ? TOP_SEAT_AVATAR_UP_LIFT : 0;
             const positionStyle = idx === humanPlayerIndex
               ? {
                   position: 'fixed',
                   left: '50%',
-                  bottom: 'calc(12rem + env(safe-area-inset-bottom, 0px))',
+                  bottom: 'calc(12.8rem + env(safe-area-inset-bottom, 0px))',
                   transform: 'translateX(-50%)',
                   zIndex: 24
                 }
@@ -5558,9 +5558,6 @@ export default function MurlanRoyaleArena({ search }) {
           <div className="pointer-events-none fixed bottom-[8.6rem] left-1/2 z-20 w-[min(88vw,26rem)] -translate-x-1/2 text-center">
             <div className="rounded-2xl border border-sky-200/55 bg-[radial-gradient(circle_at_top,rgba(56,189,248,0.24),rgba(12,23,42,0.92)_60%)] px-3.5 py-2.5 shadow-[0_12px_34px_rgba(2,132,199,0.36),inset_0_1px_0_rgba(255,255,255,0.32)] backdrop-blur-[3px]">
               <p className="text-sm font-semibold tracking-wide text-white drop-shadow-[0_2px_8px_rgba(0,0,0,0.85)]">{uiState.message}</p>
-              {uiState.tableSummary && (
-                <p className="mt-1 text-xs font-medium tracking-wide text-sky-100 drop-shadow-[0_2px_6px_rgba(0,0,0,0.8)]">{uiState.tableSummary}</p>
-              )}
               {actionError && <p className="mt-1.5 text-[11px] font-semibold text-red-300 drop-shadow-[0_2px_6px_rgba(0,0,0,0.8)]">{actionError}</p>}
             </div>
           </div>


### PR DESCRIPTION
### Motivation
- Improve portrait UX by bringing player cards, chairs and avatars visually closer to the table and tightening table footprint. 
- Remove the extra commentary/status line from the central HUD to reduce clutter. 
- Make live-avatar activation touch behave like a small avatar hit area (not the larger video frame) and ensure menus/modals take touch priority when open.

### Description
- Tuned Murlan arena geometry in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` by reducing `TABLE_RADIUS`, increasing `CHAIR_INWARD_OFFSET`, lowering `TOP_SEAT_AVATAR_UP_LIFT`, and reducing `HUMAN_HAND_*` offsets so the human hand/cards and chair avatars appear closer to the table; adjusted side-seat/top lifts and human seat bottom placement for portrait. 
- Removed the secondary `uiState.tableSummary` line from the center HUD card so only the main message and error remain. 
- Updated live-avatar overlay in `webapp/src/components/GameLiveAvatarOverlay.jsx` to: use a separate `activationRect` sized to the avatar (activation touch = avatar diameter), keep the live video frame size unchanged when active, add `BLOCKING_OVERLAY_SELECTORS` and a `hasBlockingOverlay` state to detect menus/modals/rules/dialogs, and disable the avatar activation button (`pointer-events:none`) while those overlays are open so menu interactions get priority; also lowered the overlay z-index so menus can take precedence. 
- Kept live-video sizing/visuals intact; only the touch/activation area and touch-priority behavior were changed.

### Testing
- Built the web app with `npm run build` (run from `webapp/`), and the build completed successfully with the usual chunking warnings but no fatal errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e30b01f4308329a8a7a7b4db0a9906)