### PR TITLE
Adjust Murlan Royale layout: shrink table/chairs/cards, tighten hands, slope community cards, remove bottom commentary overlay

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -105,7 +105,7 @@ const CHARACTER_PROPORTION_SCALE = 2.0;
 const ENABLE_3D_HUMAN_CHARACTERS = false;
 const ARENA_GROWTH = 1.45; // expanded arena footprint for wider walkways
 const CHAIR_SIZE_SCALE = 1;
-const ARENA_PROP_SCALE = 0.72; // Rebalanced prop sizing so table/chairs/cards better match HDRI room scale in portrait.
+const ARENA_PROP_SCALE = 0.576; // Scale table/chairs/cards down by ~20% for tighter portrait composition.
 const TOP_SEAT_AVATAR_UP_LIFT = 2.4; // Keep top avatar slightly closer to table center in portrait.
 
 const TABLE_RADIUS = 3.08 * MODEL_SCALE * ARENA_PROP_SCALE;
@@ -2299,14 +2299,14 @@ const HUMAN_HAND_CARD_SPACING = CARD_W * HUMAN_HAND_CARD_SCALE * 0.25;
 const HUMAN_HAND_CARD_MAX_SPREAD = HUMAN_HAND_CARD_SPACING * 12;
 const HUMAN_HAND_EXTRA_LIFT = 0.07 * MODEL_SCALE;
 const HUMAN_HAND_FAN_MAX_YAW = THREE.MathUtils.degToRad(22);
-const HUMAN_HAND_FAN_ARC_LIFT = 0.06 * MODEL_SCALE;
+const HUMAN_HAND_FAN_ARC_LIFT = 0;
 const HUMAN_HAND_FAN_DIRECTION = 1;
 const HUMAN_HAND_UNIFORM_YAW_FROM_LEFT = true;
-const HUMAN_HAND_CLOSER_OFFSET = -0.34 * MODEL_SCALE; // Pull player cards closer toward table center.
+const HUMAN_HAND_CLOSER_OFFSET = -0.44 * MODEL_SCALE; // Pull every player hand a bit closer toward table center.
 const HUMAN_HAND_BOTTOM_SHIFT_Y = -0.105 * MODEL_SCALE;
 const HUMAN_HAND_LEFT_SHIFT = 0;
 const HUMAN_HAND_UP_SHIFT_Y = 0.03 * MODEL_SCALE;
-const HUMAN_HAND_DIRECTIONAL_LIFT = 0.05 * MODEL_SCALE;
+const HUMAN_HAND_DIRECTIONAL_LIFT = 0;
 const HUMAN_HAND_BOTTOM_INWARD_TILT_X = THREE.MathUtils.degToRad(5);
 const AI_HAND_CARD_SPACING = HUMAN_HAND_CARD_SPACING;
 const AI_HAND_CARD_MAX_SPREAD = HUMAN_HAND_CARD_MAX_SPREAD;
@@ -2323,6 +2323,7 @@ const COMMUNITY_CARD_BOTTOM_SHIFT_Y = 0.012 * MODEL_SCALE;
 const COMMUNITY_CARD_LEFT_SHIFT = 0;
 const COMMUNITY_CARD_DIRECTIONAL_LIFT = 0;
 const COMMUNITY_CARD_SIDE_ORIENTATION_YAW = 0;
+const COMMUNITY_CARD_STRAIGHT_FLUSH_RIGHT_DROP = 0.035 * MODEL_SCALE;
 const TABLE_CARD_AREA_FORWARD_SHIFT = 0.72 * MODEL_SCALE;
 const DEAL_CARD_STEP_DELAY_MS = 60;
 const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 0.85 - 0.06 * MODEL_SCALE;
@@ -3737,6 +3738,11 @@ export default function MurlanRoyaleArena({ search }) {
     }
     const communityLookTarget = humanSeat?.focus?.clone().addScaledVector(humanSeat.forward, 2.4 * MODEL_SCALE)
       ?? tableLookBase.clone();
+    const comboType = state.tableCombo?.type ?? null;
+    const shouldSlopeCommunityCards =
+      comboType === ComboType.STRAIGHT ||
+      comboType === ComboType.FLUSH ||
+      comboType === ComboType.STRAIGHT_FLUSH;
     state.tableCards.forEach((card, idx) => {
       const entry = cardMap.get(card.id);
       if (!entry) return;
@@ -3754,6 +3760,11 @@ export default function MurlanRoyaleArena({ search }) {
       } else {
         target.x += lateralOffset + COMMUNITY_CARD_LEFT_SHIFT;
       }
+      if (shouldSlopeCommunityCards && tableSpread > 0) {
+        const normalizedAcrossRow = lateralOffset / (tableSpread / 2);
+        const rightDrop = THREE.MathUtils.clamp(normalizedAcrossRow, -1, 1) * COMMUNITY_CARD_STRAIGHT_FLUSH_RIGHT_DROP;
+        target.y -= rightDrop;
+      }
       target.y += 0.075 * MODEL_SCALE + COMMUNITY_CARD_BOTTOM_LOCK_Y_OFFSET + COMMUNITY_CARD_FAN_ARC_LIFT + COMMUNITY_CARD_BOTTOM_SHIFT_Y + COMMUNITY_CARD_DIRECTIONAL_LIFT;
       setMeshPosition(
         mesh,
@@ -3769,7 +3780,7 @@ export default function MurlanRoyaleArena({ search }) {
     const pileForwardAxis = humanSeat?.forward?.clone()?.normalize?.() ?? new THREE.Vector3(0, 0, 1);
     const discardAnchor = tableAnchor
       .clone()
-      .addScaledVector(pileForwardAxis, CARD_H * 1.36)
+      .addScaledVector(pileForwardAxis, CARD_H * 1.12)
       .addScaledVector(pileRightAxis, CARD_W * 1.62)
       .add(new THREE.Vector3(0, DISCARD_PILE_OFFSET.y, 0));
     state.discardPile.forEach((card, idx) => {
@@ -5555,14 +5566,6 @@ export default function MurlanRoyaleArena({ search }) {
             onGift={() => setShowGift(true)}
           />
         </div>
-        {!isLandscapeViewport && (
-          <div className="pointer-events-none fixed bottom-[8.6rem] left-1/2 z-20 w-[min(88vw,26rem)] -translate-x-1/2 text-center">
-            <div className="rounded-2xl border border-sky-200/55 bg-[radial-gradient(circle_at_top,rgba(56,189,248,0.24),rgba(12,23,42,0.92)_60%)] px-3.5 py-2.5 shadow-[0_12px_34px_rgba(2,132,199,0.36),inset_0_1px_0_rgba(255,255,255,0.32)] backdrop-blur-[3px]">
-              <p className="text-sm font-semibold tracking-wide text-white drop-shadow-[0_2px_8px_rgba(0,0,0,0.85)]">{uiState.message}</p>
-              {actionError && <p className="mt-1.5 text-[11px] font-semibold text-red-300 drop-shadow-[0_2px_6px_rgba(0,0,0,0.8)]">{actionError}</p>}
-            </div>
-          </div>
-        )}
         <div className="mt-auto px-3 pb-2 pointer-events-none">
           <div className="mx-auto w-full max-w-2xl pointer-events-auto">
             <div className="fixed bottom-[4.8rem] left-1/2 z-20 flex -translate-x-1/2 flex-nowrap items-center justify-center gap-2 pointer-events-auto">


### PR DESCRIPTION
### Motivation
- Improve portrait framing by making the table/chairs/cards smaller and visually tighter around the player. 
- Pull player cards closer to the table and remove vertical drift for left/right players so their cards line up in a single row. 
- Make the community cards visually indicate straights/flushes by sloping the right side lower, and move the discard pile slightly closer to the top player. 
- Remove the persistent bottom commentary/status banner to declutter the HUD on mobile portrait.

### Description
- Reduced arena prop scale by ~20% via `ARENA_PROP_SCALE` changed to `0.576` so table/chairs/cards render smaller. (file: `webapp/src/pages/Games/MurlanRoyaleArena.jsx`).
- Tightened player-hand layout by increasing `HUMAN_HAND_CLOSER_OFFSET` to `-0.44 * MODEL_SCALE`, set `HUMAN_HAND_FAN_ARC_LIFT` to `0`, and set `HUMAN_HAND_DIRECTIONAL_LIFT` to `0` so left/right hands sit in one line like top/bottom hands. (same file)
- Added conditional community-card slope for straight/flush/straight-flush combos using `COMMUNITY_CARD_STRAIGHT_FLUSH_RIGHT_DROP` and applying a small downward offset across the community row when appropriate. (same file)
- Nudged the discard pile toward the top player by reducing the forward placement from `CARD_H * 1.36` to `CARD_H * 1.12`. (same file)
- Removed the bottom center commentary/status banner block from the HUD so `uiState.message` is no longer shown in that fixed overlay. (same file)

### Testing
- Ran a production build with `npm -C webapp run build`, which completed successfully; Vite produced only non-blocking chunking/dynamic-import warnings. 
- No other automated test suites were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e323ac8e988329a63f0e1461947318)