### PR TITLE
Fix Murlan Royale player-card positioning relative to resized chairs/table

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2312,6 +2312,9 @@ const AI_HAND_CARD_SPACING = HUMAN_HAND_CARD_SPACING;
 const AI_HAND_CARD_MAX_SPREAD = HUMAN_HAND_CARD_MAX_SPREAD;
 const AI_HAND_FAN_MAX_YAW = HUMAN_HAND_FAN_MAX_YAW;
 const AI_HAND_FAN_ARC_LIFT = HUMAN_HAND_FAN_ARC_LIFT;
+const HUMAN_HAND_RADIUS_RATIO = 0.44; // Keep player cards centered between chair and table after seat/table rescaling.
+const AI_HAND_RADIUS_RATIO = 0.45; // Maintain the same relative gap for AI seats.
+const HAND_RADIUS_TABLE_GAP = CARD_H * 0.72;
 const COMMUNITY_CARD_TOP_TILT = THREE.MathUtils.degToRad(12);
 const COMMUNITY_CARD_SCALE = 1.08;
 const COMMUNITY_CARD_SPACING = CARD_W * 1.08;
@@ -4819,6 +4822,9 @@ export default function MurlanRoyaleArena({ search }) {
           .clone()
           .multiplyScalar(seatRadius - (isHumanSeat ? 1.05 * MODEL_SCALE : 0.65 * MODEL_SCALE));
         focus.y = TABLE_HEIGHT + CARD_H * (isHumanSeat ? 0.72 : 0.55);
+        const nearTableRadius = TABLE_RADIUS + HAND_RADIUS_TABLE_GAP;
+        const handRadiusRatio = isHumanSeat ? HUMAN_HAND_RADIUS_RATIO : AI_HAND_RADIUS_RATIO;
+        const cardHandRadius = THREE.MathUtils.lerp(nearTableRadius, seatRadius, handRadiusRatio);
         const stoolPosition = forward.clone().multiplyScalar(seatRadius);
         stoolPosition.y = chair.position.y + SEAT_THICKNESS / 2;
         const stoolHeight = stoolPosition.y + SEAT_THICKNESS / 2;
@@ -4828,7 +4834,7 @@ export default function MurlanRoyaleArena({ search }) {
           forward,
           right,
           focus,
-          radius: (isHumanSeat ? 2.9 : 3.05) * MODEL_SCALE,
+          radius: cardHandRadius,
           spacing: isHumanSeat ? HUMAN_HAND_CARD_SPACING : AI_HAND_CARD_SPACING,
           maxSpread: isHumanSeat ? HUMAN_HAND_CARD_MAX_SPREAD : AI_HAND_CARD_MAX_SPREAD,
           stoolPosition,


### PR DESCRIPTION
### Motivation
- Player hand cards remained visually detached from the table after we scaled the table/chairs because card radii were hardcoded and not tied to the current table/chair dimensions.
- The intent is to keep cards positioned between each chair and the (resized) table so portrait framing and interaction feel remain consistent.

### Description
- Added three new tuning constants `HUMAN_HAND_RADIUS_RATIO`, `AI_HAND_RADIUS_RATIO` and `HAND_RADIUS_TABLE_GAP` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to control how hand radii interpolate between chair and table.
- Compute `nearTableRadius = TABLE_RADIUS + HAND_RADIUS_TABLE_GAP` and lerp between `nearTableRadius` and `seatRadius` to produce `cardHandRadius` for each seat.
- Replaced the previous hardcoded hand radius (`(isHumanSeat ? 2.9 : 3.05) * MODEL_SCALE`) with the new `cardHandRadius` when building each `seatConfig`, ensuring cards move together with chair/table scale changes.

### Testing
- Built the web app with `npm --prefix webapp run build`, and the production build completed successfully.
- Vite reported non-blocking chunk/dynamic-import warnings but the build finished OK and the change compiled without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e33b8235148329b7bffc3e92894668)