### PR TITLE
Adjust bottom Murlan hand cards closer to table

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2308,6 +2308,7 @@ const HUMAN_HAND_LEFT_SHIFT = 0;
 const HUMAN_HAND_UP_SHIFT_Y = 0.03 * MODEL_SCALE;
 const HUMAN_HAND_DIRECTIONAL_LIFT = 0;
 const HUMAN_HAND_BOTTOM_INWARD_TILT_X = 0;
+const HUMAN_HAND_BOTTOM_EXTRA_INWARD_OFFSET = -0.34 * MODEL_SCALE; // Keep the bottom player's hand clearly between chair and table on portrait screens.
 const AI_HAND_CARD_SPACING = HUMAN_HAND_CARD_SPACING;
 const AI_HAND_CARD_MAX_SPREAD = HUMAN_HAND_CARD_MAX_SPREAD;
 const AI_HAND_FAN_MAX_YAW = HUMAN_HAND_FAN_MAX_YAW;
@@ -3676,6 +3677,9 @@ export default function MurlanRoyaleArena({ search }) {
         }
         const target = forward.clone().multiplyScalar(radial).addScaledVector(layoutAxis, lateral);
         target.addScaledVector(forward, HUMAN_HAND_CLOSER_OFFSET);
+        if (isHumanCard) {
+          target.addScaledVector(forward, HUMAN_HAND_BOTTOM_EXTRA_INWARD_OFFSET);
+        }
         target.addScaledVector(layoutAxis, HUMAN_HAND_LEFT_SHIFT);
         target.y = baseHeight + centerWeight * fanArcLift + HUMAN_HAND_BOTTOM_SHIFT_Y + HUMAN_HAND_UP_SHIFT_Y + leftWeight * HUMAN_HAND_DIRECTIONAL_LIFT;
         if (isHumanCard && selectionSet.has(card.id)) target.y += HUMAN_SELECTION_OFFSET;


### PR DESCRIPTION
### Motivation
- On portrait mobile the bottom (human) player's hand cards were visually too far from the table and partially obscured, so they need to be pulled visibly inward between the chair and the table for clarity.

### Description
- Add a new constant `HUMAN_HAND_BOTTOM_EXTRA_INWARD_OFFSET` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` and apply it only when positioning human (bottom) hand cards so the bottom player's cards are pulled further toward the table while leaving AI seat spacing unchanged.

### Testing
- Built the web app with `npm --prefix webapp run build` and the production build completed successfully (Vite chunk-size warnings remain unchanged).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e34ce491a88329aeccaf403071cff5)