### PR TITLE
Adjust Snake arena token/weapon parking and javelin missile visuals

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -106,6 +106,7 @@ const CAPTURE_POLYHAVEN_TEXTURE_ASSETS = Object.freeze({
   drone: 'rusty_metal_sheet',
   fighter: 'green_metal_rust',
   helicopter: 'green_metal_rust',
+  missile: 'green_metal_rust',
   javelin: 'green_metal_rust',
   supportTruck: 'green_metal_rust'
 });
@@ -244,9 +245,9 @@ const TOKEN_REST_LATERAL_BY_SEAT = Object.freeze(new Array(DEFAULT_PLAYER_COUNT)
 // Seat order: 0=bottom, 1=right, 2=top, 3=left (portrait screen orientation).
 // Pull bottom/side reserve tokens inwards so they sit on the wooden rim near each seat.
 const TOKEN_REST_EXTRA_RADIAL_BY_SEAT = Object.freeze([
-  -TILE_SIZE * 1.34,
-  -TILE_SIZE * 1.12,
-  TILE_SIZE * 1.05,
+  -TILE_SIZE * 1.52,
+  -TILE_SIZE * 1.3,
+  TILE_SIZE * 1.42,
   -TILE_SIZE * 0.98
 ]);
 const SEAT_RAIL_DICE_GAP = Math.max(DICE_SIZE * 0.95, TOKEN_RADIUS * 2.75);
@@ -269,6 +270,7 @@ const WEAPON_SLOT_LATERAL_NUDGE_BY_SEAT = Object.freeze([
 ]);
 const WEAPON_DISPLAY_SIZE_MULTIPLIER = 1.4;
 const WEAPON_PARKING_OUTWARD_OFFSET = 0;
+const WEAPON_FROM_TOKEN_CENTER_OFFSET = TOKEN_RADIUS * 1.18;
 // Keep parked weapons anchored next to the player token with only a small visual gap.
 const WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT = Object.freeze([
   0,
@@ -278,11 +280,11 @@ const WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT = Object.freeze([
 ]);
 const WEAPON_TOKEN_GAP = TILE_SIZE * 0.03;
 const WEAPON_PARKED_Y_DROP_BY_KIND = Object.freeze({
-  fighter: TOKEN_HEIGHT * 1.74,
-  helicopter: TOKEN_HEIGHT * 1.82,
-  drone: TOKEN_HEIGHT * 1.66,
-  supportTruck: TOKEN_HEIGHT * 1.78,
-  javelin: TOKEN_HEIGHT * 1.72
+  fighter: TOKEN_HEIGHT * 0.2,
+  helicopter: TOKEN_HEIGHT * 0.2,
+  drone: TOKEN_HEIGHT * 0.18,
+  supportTruck: TOKEN_HEIGHT * 0.22,
+  javelin: TOKEN_HEIGHT * 0.2
 });
 const WEAPON_REST_HEIGHT_OFFSET = 0;
 const WEAPON_REST_HEIGHT_OFFSET_BY_SEAT = Object.freeze([
@@ -4129,26 +4131,22 @@ function createCaptureVehicleFallbackMesh(kind = 'fighter') {
   } else {
     const isJavelin = kind === 'javelin';
     if (isJavelin) {
-      const javelinBodyMat = createCaptureVehicleMaterial('javelin');
-      const javelinNoseMat = createCaptureVehicleMaterial('javelin');
-      const javelinFinMat = createCaptureVehicleMaterial('javelin');
-      const body = new THREE.Mesh(new THREE.CylinderGeometry(0.092, 0.112, 1.16, 16), javelinBodyMat);
+      const javelinBodyMat = createCaptureVehicleMaterial('missile');
+      const javelinNoseMat = createCaptureVehicleMaterial('missile');
+      const javelinFinMat = createCaptureVehicleMaterial('missile');
+      const body = new THREE.Mesh(new THREE.CylinderGeometry(0.05, 0.06, 0.72, 14), javelinBodyMat);
       body.rotation.z = Math.PI / 2;
-      const nose = new THREE.Mesh(new THREE.ConeGeometry(0.102, 0.28, 16), javelinNoseMat);
-      nose.position.set(0.72, 0, 0);
+      const nose = new THREE.Mesh(new THREE.ConeGeometry(0.055, 0.18, 14), javelinNoseMat);
+      nose.position.set(0.45, 0, 0);
       nose.rotation.z = -Math.PI / 2;
-      const finA = new THREE.Mesh(new THREE.BoxGeometry(0.2, 0.026, 0.38), javelinFinMat);
-      finA.position.set(-0.16, 0, 0);
-      const finB = new THREE.Mesh(new THREE.BoxGeometry(0.2, 0.38, 0.026), javelinFinMat);
-      finB.position.set(-0.16, 0, 0);
-      const finTailA = new THREE.Mesh(new THREE.BoxGeometry(0.14, 0.024, 0.24), javelinFinMat);
-      finTailA.position.set(-0.44, 0, 0);
-      const finTailB = new THREE.Mesh(new THREE.BoxGeometry(0.14, 0.24, 0.024), javelinFinMat);
-      finTailB.position.set(-0.44, 0, 0);
-      const engine = new THREE.Mesh(new THREE.CylinderGeometry(0.088, 0.088, 0.19, 16), finMat);
+      const finA = new THREE.Mesh(new THREE.BoxGeometry(0.1, 0.02, 0.16), javelinFinMat);
+      finA.position.set(-0.18, 0, 0);
+      const finB = new THREE.Mesh(new THREE.BoxGeometry(0.1, 0.16, 0.02), javelinFinMat);
+      finB.position.set(-0.18, 0, 0);
+      const engine = new THREE.Mesh(new THREE.CylinderGeometry(0.055, 0.055, 0.14, 14), javelinFinMat);
       engine.rotation.z = Math.PI / 2;
-      engine.position.set(-0.66, 0, 0);
-      root.add(body, nose, finA, finB, finTailA, finTailB, engine);
+      engine.position.set(-0.42, 0, 0);
+      root.add(body, nose, finA, finB, engine);
     } else {
       const body = new THREE.Mesh(
         new THREE.CylinderGeometry(kind === 'drone' ? 0.06 : 0.08, kind === 'drone' ? 0.06 : 0.09, 1, 16),
@@ -4698,8 +4696,7 @@ function updateSeatWeaponDisplays(board, players = []) {
       const tokenSideSign = TOKEN_SLOT_SIDE_SIGN_BY_SEAT[seatIndex] ?? (seatIndex % 2 === 0 ? -1 : 1);
       const tokenLateralNudge = TOKEN_SLOT_LATERAL_NUDGE_BY_SEAT[seatIndex] ?? 0;
       const tokenSlotOffset = tokenSideSign * SEAT_RAIL_SLOT_OFFSET + tokenLateralNudge;
-      const weaponCenterOffset =
-        tokenSlotOffset + sideSign * (TOKEN_RADIUS * 2 + WEAPON_TOKEN_GAP) + lateralNudge;
+      const weaponCenterOffset = tokenSlotOffset + sideSign * (WEAPON_FROM_TOKEN_CENTER_OFFSET + WEAPON_TOKEN_GAP) + lateralNudge;
       holder.position
         .copy(railLayout.railLocal)
         .addScaledVector(railLayout.lateral, weaponCenterOffset)


### PR DESCRIPTION
### Motivation
- Tokens and parked weapons in the Snake & Ladder arena were visually misaligned: top token sat too close to the table, bottom/right tokens were too far, and weapon models were placed far from their tokens and too low on the table; the javelin fallback missile used a long geometry that didn't match the short pawn-style missiles used elsewhere.

### Description
- Updated `webapp/src/components/SnakeBoard3D.jsx` to change reserve token radial offsets via `TOKEN_REST_EXTRA_RADIAL_BY_SEAT` so top/bottom/right seats sit as requested in portrait layout.
- Anchored parked weapon placements to token positions by adding `WEAPON_FROM_TOKEN_CENTER_OFFSET` and using it in the weapon center offset computation so weapons sit next to tokens with a small gap (`WEAPON_TOKEN_GAP`).
- Lowered parked weapon vertical drop by changing `WEAPON_PARKED_Y_DROP_BY_KIND` so parked weapons appear at token height instead of far below.
- Reworked the javelin fallback mesh to use a `missile` material/texture, shortened the missile body/nose/fins and adjusted engine placement to match the short pawn-style missile geometry and texture family, and added `missile` to `CAPTURE_POLYHAVEN_TEXTURE_ASSETS`.

### Testing
- Ran `npx eslint webapp/src/components/SnakeBoard3D.jsx`, which completed but reported the repo lint ignore warning for this file; no lint errors were produced.
- No automated unit or integration tests were changed or run as part of this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3ac28db008329960f916a20fdaf9c)