### PR TITLE
Adjust Murlan hand card placement for smaller tables

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2313,6 +2313,10 @@ const AI_HAND_CARD_SPACING = HUMAN_HAND_CARD_SPACING;
 const AI_HAND_CARD_MAX_SPREAD = HUMAN_HAND_CARD_MAX_SPREAD;
 const AI_HAND_FAN_MAX_YAW = HUMAN_HAND_FAN_MAX_YAW;
 const AI_HAND_FAN_ARC_LIFT = HUMAN_HAND_FAN_ARC_LIFT;
+const HUMAN_HAND_TABLE_EDGE_INSET = 0.2 * MODEL_SCALE;
+const AI_HAND_TABLE_EDGE_INSET = 0.16 * MODEL_SCALE;
+const MIN_HAND_RADIUS = 1.55 * MODEL_SCALE;
+const MAX_HAND_RADIUS = 3.2 * MODEL_SCALE;
 const COMMUNITY_CARD_TOP_TILT = THREE.MathUtils.degToRad(12);
 const COMMUNITY_CARD_SCALE = 1.08;
 const COMMUNITY_CARD_SPACING = CARD_W * 1.08;
@@ -2358,6 +2362,12 @@ function calcFanCardPose(cardCount, cardIdx) {
     centerWeight: 1 - Math.abs(normalizedOffset),
     leftWeight: (1 + normalizedOffset) * 0.5
   };
+}
+
+function resolveHandRadiusFromTable(tableRadius, isHumanSeat) {
+  const safeTableRadius = Number.isFinite(tableRadius) ? tableRadius : TABLE_RADIUS;
+  const inset = isHumanSeat ? HUMAN_HAND_TABLE_EDGE_INSET : AI_HAND_TABLE_EDGE_INSET;
+  return THREE.MathUtils.clamp(safeTableRadius - inset, MIN_HAND_RADIUS, MAX_HAND_RADIUS);
 }
 const CARD_ANIMATION_DURATION = 420;
 const FRAME_TIME_CATCH_UP_MULTIPLIER = 3;
@@ -4783,6 +4793,10 @@ export default function MurlanRoyaleArena({ search }) {
 
       const chairRadius = CHAIR_RADIUS;
       const seatThickness = SEAT_THICKNESS;
+      const currentTableRadius = Math.max(
+        CARD_W * 2.2,
+        threeStateRef.current.tableInfo?.radius ?? TABLE_RADIUS
+      );
 
       cardGeometry = new THREE.BoxGeometry(CARD_W, CARD_H, CARD_D, 1, 1, 1);
 
@@ -4816,9 +4830,14 @@ export default function MurlanRoyaleArena({ search }) {
 
         const forward = new THREE.Vector3(Math.cos(angle), 0, Math.sin(angle));
         const right = new THREE.Vector3(-Math.sin(angle), 0, Math.cos(angle));
+        const handRadius = resolveHandRadiusFromTable(currentTableRadius, isHumanSeat);
+        const focusDistance = Math.max(
+          CARD_W * 2.5,
+          handRadius - (isHumanSeat ? 0.42 * MODEL_SCALE : 0.28 * MODEL_SCALE)
+        );
         const focus = forward
           .clone()
-          .multiplyScalar(seatRadius - (isHumanSeat ? 1.05 * MODEL_SCALE : 0.65 * MODEL_SCALE));
+          .multiplyScalar(focusDistance);
         focus.y = TABLE_HEIGHT + CARD_H * (isHumanSeat ? 0.72 : 0.55);
         const stoolPosition = forward.clone().multiplyScalar(seatRadius);
         stoolPosition.y = chair.position.y + SEAT_THICKNESS / 2;
@@ -4829,7 +4848,7 @@ export default function MurlanRoyaleArena({ search }) {
           forward,
           right,
           focus,
-          radius: (isHumanSeat ? 2.9 : 3.05) * MODEL_SCALE,
+          radius: handRadius,
           spacing: isHumanSeat ? HUMAN_HAND_CARD_SPACING : AI_HAND_CARD_SPACING,
           maxSpread: isHumanSeat ? HUMAN_HAND_CARD_MAX_SPREAD : AI_HAND_CARD_MAX_SPREAD,
           stoolPosition,


### PR DESCRIPTION
### Motivation
- Player hand cards were positioned with fixed radii and could appear misaligned when a newer/smaller table model was used, so hand positions must track the actual table size to keep cards visually in the same place relative to the table edge.

### Description
- Compute a dynamic hand radius from the current table radius by reading `threeStateRef.current.tableInfo?.radius ?? TABLE_RADIUS` and using a new helper `resolveHandRadiusFromTable` to apply an inset and clamp to a safe range.
- Added constants `HUMAN_HAND_TABLE_EDGE_INSET`, `AI_HAND_TABLE_EDGE_INSET`, `MIN_HAND_RADIUS`, and `MAX_HAND_RADIUS` and the helper `resolveHandRadiusFromTable` in `MurlanRoyaleArena.jsx`.
- Replace fixed hand radius values with the computed `handRadius` for seat `radius` and use a `focusDistance` derived from `handRadius` so card aim/orientation follow the new radius.
- All changes are contained in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` and preserve different inset behavior for human vs AI seats.

### Testing
- Ran the unit test for Murlan rules with `npm test -- test/murlan.test.js --runInBand`, which passed: `1 test suite, 12 tests — all passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3b60126988329a9ead23ccb80602b)