### PR TITLE
Tune Goal Rush puck physics for faster, bouncier, lower-spin play

### DIFF
--- a/webapp/public/goal-rush.html
+++ b/webapp/public/goal-rush.html
@@ -1911,9 +1911,9 @@
   }
   function getCSS(v){ return getComputedStyle(document.documentElement).getPropertyValue(v).trim(); }
 
-  const friction = 0.996;
-  const wallBounce = 1.19;
-  const minWallSpeed = 6.2;
+  const friction = 0.9972;
+  const wallBounce = 1.24;
+  const minWallSpeed = 6.6;
   function constrainPaddle(p, bottom){
     const margin=12;
     const minX = rink.x + margin + p.r;
@@ -2022,9 +2022,9 @@
         const relVY = puck.vy - p.vy;
         const relAlongNormal = relVX*nx + relVY*ny;
         const tangential = relVX*(-ny) + relVY*nx;
-        puck.spin += tangential * 0.008;
+        puck.spin += tangential * 0.005;
         if (relAlongNormal <= 0){
-          const restitution = 1.22;
+          const restitution = 1.26;
           const impulse = -(1+restitution) * relAlongNormal;
           puck.vx += impulse * nx;
           puck.vy += impulse * ny;
@@ -2184,7 +2184,7 @@
     if (shouldRunPhysics()) {
       puck.x += puck.vx * dt * 60;
       puck.y += puck.vy * dt * 60;
-      const mag = puck.spin * dt * 0.6;
+      const mag = puck.spin * dt * 0.35;
       const magVx = -puck.vy * mag;
       const magVy = puck.vx * mag;
       puck.vx += magVx;
@@ -2193,7 +2193,7 @@
       puck.vy *= Math.pow(friction, dt*60);
       puck.angle += Math.hypot(puck.vx, puck.vy) * dt * 0.1;
       puck.angle += puck.spin * dt * 10;
-      puck.spin *= Math.pow(0.985, dt*60);
+      puck.spin *= Math.pow(0.97, dt*60);
 
       handleCollisions();
       emitStateIfNeeded();


### PR DESCRIPTION
### Motivation
- Make the puck feel slightly faster with livelier rebounds and reduce curving spin so shots are more responsive and predictable.

### Description
- Updated physics constants in `webapp/public/goal-rush.html` by adjusting `friction` from `0.996` to `0.9972`, `wallBounce` from `1.19` to `1.24`, and `minWallSpeed` from `6.2` to `6.6`.
- Reduced spin added on paddle impact by changing `puck.spin += tangential * 0.008` to `puck.spin += tangential * 0.005` and raised collision `restitution` from `1.22` to `1.26`.
- Reduced Magnus/curve influence and increased spin damping by changing the Magnus multiplier `mag` from `0.6` to `0.35` and spin decay from `Math.pow(0.985, dt*60)` to `Math.pow(0.97, dt*60)`.

### Testing
- Ran `git diff --check webapp/public/goal-rush.html`, which completed with no issues.
- Committed the change to the repository (one file modified) as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e496820d988329bf223bf9fba9d245)