### PR TITLE
Tune Air Hockey puck speed slightly slower

### DIFF
--- a/webapp/src/components/AirHockey3D.jsx
+++ b/webapp/src/components/AirHockey3D.jsx
@@ -1932,9 +1932,10 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
     renderer.domElement.addEventListener('mousemove', onMove);
 
     const SPEED_BOOST = 1.25;
-    const HIT_FORCE = 0.5 * SPEED_SCALE * SPEED_BOOST;
-    const MAX_SPEED = 0.095 * SPEED_SCALE * SPEED_BOOST;
-    const SERVE_SPEED = 0.055 * SPEED_SCALE * SPEED_BOOST;
+    const PUCK_SPEED_TUNING = 0.9;
+    const HIT_FORCE = 0.5 * SPEED_SCALE * SPEED_BOOST * PUCK_SPEED_TUNING;
+    const MAX_SPEED = 0.095 * SPEED_SCALE * SPEED_BOOST * PUCK_SPEED_TUNING;
+    const SERVE_SPEED = 0.055 * SPEED_SCALE * SPEED_BOOST * PUCK_SPEED_TUNING;
     const GOAL_RESET_DELAY = 1500;
 
     const servePuck = (towardTop = false) => {


### PR DESCRIPTION
### Motivation
- Players reported the puck feels too fast, so introduce a small global tuning factor to slow puck motion slightly while keeping behavior consistent.

### Description
- Added `PUCK_SPEED_TUNING = 0.9` in `webapp/src/components/AirHockey3D.jsx` and applied it to `HIT_FORCE`, `MAX_SPEED`, and `SERVE_SPEED` so all puck-related velocities scale uniformly.

### Testing
- Built the web app with `cd webapp && npm run -s build`, and the production build completed successfully (Vite emitted non-blocking chunk-size warnings that are unrelated to this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e496fd02d883298407cb4698ce8ec2)