### PR TITLE
Enforce deterministic layering for Murlan hand cards to fix overlap

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -3661,7 +3661,7 @@ export default function MurlanRoyaleArena({ search }) {
         if (!entry) return;
         const mesh = entry.mesh;
         const isHumanCard = player.isHuman;
-        mesh.renderOrder = isHumanCard ? 16 + cardIdx : 4 + cardIdx;
+        applyHandCardLayering(mesh, isHumanCard, cardIdx);
         mesh.visible = true;
         updateCardFace(mesh, isHumanCard ? 'front' : 'back');
         handsVisible.add(card.id);
@@ -6300,6 +6300,26 @@ function createCardMesh(card, geometry, cache, theme) {
   mesh.userData.backTexture = backTexture;
   mesh.userData.cardFace = 'front';
   return mesh;
+}
+
+function applyHandCardLayering(mesh, isHumanCard, stackOrder = 0) {
+  if (!mesh?.isMesh) return;
+  const orderBase = isHumanCard ? 16 : 4;
+  mesh.renderOrder = orderBase + stackOrder;
+
+  const shouldForceRenderOrder = Boolean(isHumanCard);
+  if (mesh.userData?.forceHandRenderOrder === shouldForceRenderOrder) {
+    return;
+  }
+  mesh.userData.forceHandRenderOrder = shouldForceRenderOrder;
+
+  const allMaterials = Array.isArray(mesh.material) ? mesh.material : [mesh.material];
+  allMaterials.forEach((material) => {
+    if (!material) return;
+    material.depthTest = !shouldForceRenderOrder;
+    material.depthWrite = !shouldForceRenderOrder;
+    material.needsUpdate = true;
+  });
 }
 
 function makeCardFace(rank, suit, theme, w = 768, h = 1080) {


### PR DESCRIPTION
### Motivation
- On portrait/mobile views hand cards that are nearly coplanar could visually blend or overlap unpredictably due to depth testing, making card edges hard to read.
- Ensure the human player's hand renders as a clean visible stack (one-above-another) while keeping AI cards' normal depth behavior.

### Description
- Added a helper `applyHandCardLayering(mesh, isHumanCard, stackOrder)` in `MurlanRoyaleArena.jsx` to centralize per-card draw ordering and material adjustments.
- Replaced inline `renderOrder` assignments with calls to `applyHandCardLayering` when applying scene state to player hands.
- For human (bottom) hand cards the helper disables `depthTest` and `depthWrite` on card materials and relies on `renderOrder` for deterministic stacking, and sets `material.needsUpdate`.
- AI cards still receive explicit `renderOrder` via the helper but keep depth test/write enabled so they participate in normal depth buffering.

### Testing
- Ran the unit tests with `npm test -- test/murlan.test.js --runInBand` and the suite passed.
- The `murlan` test file reported all tests passed under Jest (12 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4ba3d60648329a0cc137d1d8e5ede)