### PR TITLE
Align parked weapons next to player tokens on Snake & Ladder board

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -270,7 +270,8 @@ const WEAPON_SLOT_LATERAL_NUDGE_BY_SEAT = Object.freeze([
 ]);
 const WEAPON_DISPLAY_SIZE_MULTIPLIER = 1.4;
 const WEAPON_PARKING_OUTWARD_OFFSET = 0;
-const WEAPON_FROM_TOKEN_CENTER_OFFSET = TOKEN_RADIUS * 1.18;
+// Keep parked weapons visually paired with each reserve token (tight side-by-side spacing).
+const WEAPON_FROM_TOKEN_CENTER_OFFSET = TOKEN_RADIUS * 0.82;
 // Keep parked weapons anchored next to the player token with only a small visual gap.
 const WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT = Object.freeze([
   0,
@@ -278,15 +279,15 @@ const WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT = Object.freeze([
   0,
   0
 ]);
-const WEAPON_TOKEN_GAP = TILE_SIZE * 0.03;
+const WEAPON_TOKEN_GAP = TILE_SIZE * 0.01;
 const WEAPON_PARKED_Y_DROP_BY_KIND = Object.freeze({
-  fighter: TOKEN_HEIGHT * 0.2,
-  helicopter: TOKEN_HEIGHT * 0.2,
-  drone: TOKEN_HEIGHT * 0.18,
-  supportTruck: TOKEN_HEIGHT * 0.22,
-  javelin: TOKEN_HEIGHT * 0.2
+  fighter: TOKEN_HEIGHT * 0.44,
+  helicopter: TOKEN_HEIGHT * 0.42,
+  drone: TOKEN_HEIGHT * 0.4,
+  supportTruck: TOKEN_HEIGHT * 0.46,
+  javelin: TOKEN_HEIGHT * 0.44
 });
-const WEAPON_REST_HEIGHT_OFFSET = 0;
+const WEAPON_REST_HEIGHT_OFFSET = -TOKEN_HEIGHT * 0.02;
 const WEAPON_REST_HEIGHT_OFFSET_BY_SEAT = Object.freeze([
   0,
   0,


### PR DESCRIPTION
### Motivation
- Parked weapon models on the Snake & Ladder board appeared visually detached from player tokens and slightly floating above the table, so their resting positions were tightened and lowered to sit next to tokens at matching height.

### Description
- Reduced horizontal offset by updating `WEAPON_FROM_TOKEN_CENTER_OFFSET` from `TOKEN_RADIUS * 1.18` to `TOKEN_RADIUS * 0.82` in `webapp/src/components/SnakeBoard3D.jsx` so weapons sit side-by-side with reserve tokens.
- Tightened spacing by changing `WEAPON_TOKEN_GAP` from `TILE_SIZE * 0.03` to `TILE_SIZE * 0.01` to remove the excessive visual gap between token and weapon.
- Lowered parked weapon rests by increasing per-kind drop values in `WEAPON_PARKED_Y_DROP_BY_KIND` so each weapon model aligns closer to token/table height (updated fighter/helicopter/drone/supportTruck/javelin multipliers).
- Applied a small global vertical adjustment by setting `WEAPON_REST_HEIGHT_OFFSET` to `-TOKEN_HEIGHT * 0.02` to reduce floating and improve table contact.

### Testing
- Built the web app with `npm --prefix webapp run build` and the production build completed successfully.
- No automated unit tests were modified or run; manual runtime screenshot could not be captured in this environment so visual verification should be performed in the client to confirm weapons are next to tokens.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4bd0b7264832996371a349dacc87e)