### PR TITLE
Tweak Murlan Royale portrait layout: discard pile, camera, chairs, hands, avatars

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -106,7 +106,7 @@ const ENABLE_3D_HUMAN_CHARACTERS = false;
 const ARENA_GROWTH = 1.45; // expanded arena footprint for wider walkways
 const CHAIR_SIZE_SCALE = 1;
 const ARENA_PROP_SCALE = 0.4896; // Keep table/chairs/cards another 15% smaller while preserving portrait composition.
-const TOP_SEAT_AVATAR_UP_LIFT = 2.4; // Keep top avatar slightly closer to table center in portrait.
+const TOP_SEAT_AVATAR_UP_LIFT = 2.9; // Lift top avatar a bit higher in portrait so it clears card overlays better.
 
 const TABLE_RADIUS = 3.08 * MODEL_SCALE * ARENA_PROP_SCALE;
 const CHAIR_COUNT = 4;
@@ -2264,9 +2264,11 @@ const CARD_D = 0.02 * MODEL_SCALE * CARD_SCALE;
 const CARD_SURFACE_OFFSET = CARD_D * 4;
 const DISCARD_PILE_OFFSET = Object.freeze({
   x: 0,
-  y: CARD_H * 0.96,
+  y: CARD_H * 1.14,
   z: -TABLE_RADIUS * 0.18
 });
+const DISCARD_PILE_FORWARD_SHIFT = CARD_H * 1.74;
+const DISCARD_PILE_RIGHT_SHIFT = CARD_W * 1.48;
 const SEAT_WIDTH = 0.9 * MODEL_SCALE * STOOL_SCALE;
 const SEAT_DEPTH = 0.95 * MODEL_SCALE * STOOL_SCALE;
 const SEAT_THICKNESS = 0.09 * MODEL_SCALE * STOOL_SCALE;
@@ -2285,15 +2287,15 @@ const CHAIR_RADIUS = BASE_HUMAN_CHAIR_RADIUS + HUMAN_CHAIR_PULLBACK - CHAIR_INWA
 const AI_CHAIR_GAP = CARD_W * 0.2;
 const AI_CHAIR_RADIUS = TABLE_RADIUS + SEAT_DEPTH / 2 + AI_CHAIR_GAP - CHAIR_INWARD_OFFSET * 0.45;
 const CHAIR_SEAT_INWARD_FACTOR = 0.92;
-const CHAIR_VISUAL_SCALE = 1.08 * 1.1 * ARENA_PROP_SCALE;
+const CHAIR_VISUAL_SCALE = 1.08 * 1.16 * ARENA_PROP_SCALE;
 const CAMERA_SEATED_LATERAL_OFFSETS = Object.freeze({ portrait: 0.12 * ARENA_PROP_SCALE, landscape: 0.56 * ARENA_PROP_SCALE });
 const CAMERA_SEATED_RETREAT_OFFSETS = Object.freeze({ portrait: 0.54 * ARENA_PROP_SCALE, landscape: 0.56 * ARENA_PROP_SCALE });
 const CAMERA_SEATED_ELEVATION_OFFSETS = Object.freeze({
-  portrait: 1.24 * ARENA_PROP_SCALE,
-  landscape: 0.94 * ARENA_PROP_SCALE
+  portrait: 1.3 * ARENA_PROP_SCALE,
+  landscape: 0.98 * ARENA_PROP_SCALE
 });
 const CAMERA_TARGET_LIFT = 0.05 * MODEL_SCALE;
-const CAMERA_FOCUS_CENTER_LIFT = -0.2 * MODEL_SCALE;
+const CAMERA_FOCUS_CENTER_LIFT = -0.24 * MODEL_SCALE;
 const HUMAN_HAND_CARD_SCALE = 1.1;
 const HUMAN_HAND_CARD_SPACING = CARD_W * HUMAN_HAND_CARD_SCALE * 0.25;
 const HUMAN_HAND_CARD_MAX_SPREAD = HUMAN_HAND_CARD_SPACING * 12;
@@ -2303,10 +2305,10 @@ const HUMAN_HAND_FAN_ARC_LIFT = 0;
 const HUMAN_HAND_FAN_DIRECTION = 1;
 const HUMAN_HAND_UNIFORM_YAW_FROM_LEFT = true;
 const HUMAN_HAND_CLOSER_OFFSET = -0.92 * MODEL_SCALE; // Move the bottom player's hand inward so cards sit between chair and table.
-const HUMAN_HAND_BOTTOM_SHIFT_Y = -0.04 * MODEL_SCALE;
+const HUMAN_HAND_BOTTOM_SHIFT_Y = -0.055 * MODEL_SCALE;
 const AI_HAND_CLOSER_OFFSET = 0;
 const HUMAN_HAND_LEFT_SHIFT = 0;
-const HUMAN_HAND_UP_SHIFT_Y = 0.03 * MODEL_SCALE;
+const HUMAN_HAND_UP_SHIFT_Y = 0.012 * MODEL_SCALE;
 const HUMAN_HAND_DIRECTIONAL_LIFT = 0;
 const HUMAN_HAND_BOTTOM_INWARD_TILT_X = 0;
 const AI_HAND_CARD_SPACING = HUMAN_HAND_CARD_SPACING;
@@ -3771,8 +3773,8 @@ export default function MurlanRoyaleArena({ search }) {
     const pileForwardAxis = humanSeat?.forward?.clone()?.normalize?.() ?? new THREE.Vector3(0, 0, 1);
     const discardAnchor = tableAnchor
       .clone()
-      .addScaledVector(pileForwardAxis, CARD_H * 1.44)
-      .addScaledVector(pileRightAxis, CARD_W * 1.62)
+      .addScaledVector(pileForwardAxis, DISCARD_PILE_FORWARD_SHIFT)
+      .addScaledVector(pileRightAxis, DISCARD_PILE_RIGHT_SHIFT)
       .add(new THREE.Vector3(0, DISCARD_PILE_OFFSET.y, 0));
     state.discardPile.forEach((card, idx) => {
       const entry = cardMap.get(card.id);
@@ -5351,7 +5353,7 @@ export default function MurlanRoyaleArena({ search }) {
             const activePlayer = gameState.players?.[idx] ?? player;
             const anchor = seatAnchorMap.get(idx);
             const fallback = FALLBACK_SEAT_POSITIONS[idx % FALLBACK_SEAT_POSITIONS.length];
-            const sideSeatTopLift = 0;
+            const sideSeatTopLift = 1.05;
             const topSeatLift = idx === topSeatIndex ? TOP_SEAT_AVATAR_UP_LIFT : 0;
             const positionStyle = idx === humanPlayerIndex
               ? {


### PR DESCRIPTION
### Motivation
- Improve portrait composition so the used/discard pile no longer overlaps community cards and player UI elements.
- Nudge the gameplay camera slightly higher and more downward to better frame table + community cards in portrait.
- Make chairs a bit more prominent and adjust player hand / avatar placement to avoid visual overlap with cards.

### Description
- Increased top-seat avatar lift by updating `TOP_SEAT_AVATAR_UP_LIFT` to `2.9` to raise the top avatar in portrait view in `webapp/src/pages/Games/MurlanRoyaleArena.jsx`.
- Moved the discard pile away from the community cards by raising `DISCARD_PILE_OFFSET.y` and adding explicit `DISCARD_PILE_FORWARD_SHIFT` and `DISCARD_PILE_RIGHT_SHIFT`, and used these when computing the `discardAnchor`.
- Slightly enlarged chairs by increasing `CHAIR_VISUAL_SCALE`, and raised the seated camera by increasing `CAMERA_SEATED_ELEVATION_OFFSETS` and adjusting `CAMERA_FOCUS_CENTER_LIFT` to look more downward.
- Tuned player hand vertical offsets (`HUMAN_HAND_BOTTOM_SHIFT_Y`, `HUMAN_HAND_UP_SHIFT_Y`) and lifted side-seat avatars (`sideSeatTopLift`) to reduce card/avatar overlap.

### Testing
- Ran `npx eslint webapp/src/pages/Games/MurlanRoyaleArena.jsx`, which executed successfully but reported that the file is ignored by the repo lint config (no blocking errors).
- No unit tests were run as part of this tweak; changes are layout/tuning only and were committed to the repository (`webapp/src/pages/Games/MurlanRoyaleArena.jsx`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4c83177988329bb8a3d25c57ac21e)