### PR TITLE
Align Snake & Ladder parked weapons next to player tokens

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -270,21 +270,21 @@ const WEAPON_SLOT_LATERAL_NUDGE_BY_SEAT = Object.freeze([
 ]);
 const WEAPON_DISPLAY_SIZE_MULTIPLIER = 1.4;
 const WEAPON_PARKING_OUTWARD_OFFSET = 0;
-const WEAPON_FROM_TOKEN_CENTER_OFFSET = TOKEN_RADIUS * 1.18;
-// Keep parked weapons anchored next to the player token with only a small visual gap.
+const WEAPON_FROM_TOKEN_CENTER_OFFSET = TOKEN_RADIUS * 0.92;
+// Keep parked weapons anchored immediately next to the player token.
 const WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT = Object.freeze([
   0,
   0,
   0,
   0
 ]);
-const WEAPON_TOKEN_GAP = TILE_SIZE * 0.03;
+const WEAPON_TOKEN_GAP = TILE_SIZE * 0.005;
 const WEAPON_PARKED_Y_DROP_BY_KIND = Object.freeze({
-  fighter: TOKEN_HEIGHT * 0.2,
-  helicopter: TOKEN_HEIGHT * 0.2,
-  drone: TOKEN_HEIGHT * 0.18,
-  supportTruck: TOKEN_HEIGHT * 0.22,
-  javelin: TOKEN_HEIGHT * 0.2
+  fighter: TOKEN_HEIGHT * 0.62,
+  helicopter: TOKEN_HEIGHT * 0.6,
+  drone: TOKEN_HEIGHT * 0.56,
+  supportTruck: TOKEN_HEIGHT * 0.64,
+  javelin: TOKEN_HEIGHT * 0.62
 });
 const WEAPON_REST_HEIGHT_OFFSET = 0;
 const WEAPON_REST_HEIGHT_OFFSET_BY_SEAT = Object.freeze([


### PR DESCRIPTION
### Motivation
- Parked weapon models on the Snake & Ladder table were visually separated from their player tokens and floated above the table, so each seat needed its weapon to sit next to and at the same height as the token for clear visual pairing.

### Description
- Reduced `WEAPON_FROM_TOKEN_CENTER_OFFSET` in `webapp/src/components/SnakeBoard3D.jsx` from `TOKEN_RADIUS * 1.18` to `TOKEN_RADIUS * 0.92` so weapons are placed closer to token centers.
- Shrank `WEAPON_TOKEN_GAP` from `TILE_SIZE * 0.03` to `TILE_SIZE * 0.005` to remove the small visual gap between token and weapon.
- Increased per-weapon `WEAPON_PARKED_Y_DROP_BY_KIND` values so parked weapons sit lower (table-contact height) and match token height more closely.

### Testing
- Ran the production build with `cd webapp && npm run build` and it completed successfully.
- The build produced existing Vite chunk-size warnings only and no new build errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4bd0b7264832996371a349dacc87e)