### PR TITLE
Fix Chess Battle Royal capture animation piece mapping

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -631,6 +631,57 @@ const CAPTURE_ANIMATION_BY_PIECE = Object.freeze({
   Q: 'queenJetStrike',
   K: 'kingJetStrike'
 });
+const CAPTURE_PIECE_TYPE_ALIASES = Object.freeze({
+  P: 'P',
+  PAWN: 'P',
+  PAWNS: 'P',
+  '♙': 'P',
+  '♟': 'P',
+  N: 'N',
+  KNIGHT: 'N',
+  KNIGHTS: 'N',
+  HORSE: 'N',
+  HORSES: 'N',
+  '♘': 'N',
+  '♞': 'N',
+  B: 'B',
+  BISHOP: 'B',
+  BISHOPS: 'B',
+  '♗': 'B',
+  '♝': 'B',
+  R: 'R',
+  ROOK: 'R',
+  ROOKS: 'R',
+  CASTLE: 'R',
+  CASTLES: 'R',
+  '♖': 'R',
+  '♜': 'R',
+  Q: 'Q',
+  QUEEN: 'Q',
+  QUEENS: 'Q',
+  '♕': 'Q',
+  '♛': 'Q',
+  K: 'K',
+  KING: 'K',
+  KINGS: 'K',
+  '♔': 'K',
+  '♚': 'K'
+});
+const resolveCaptureAnimationPieceType = (...values) => {
+  for (const value of values) {
+    const raw = `${value || ''}`.trim();
+    if (!raw) continue;
+    const normalized = raw.toUpperCase();
+    const alias = CAPTURE_PIECE_TYPE_ALIASES[normalized];
+    if (alias && CAPTURE_ANIMATION_BY_PIECE[alias]) return alias;
+    const compact = normalized.replace(/[^A-Z♔♕♖♗♘♙♚♛♜♝♞♟]/g, '');
+    const compactAlias = CAPTURE_PIECE_TYPE_ALIASES[compact];
+    if (compactAlias && CAPTURE_ANIMATION_BY_PIECE[compactAlias]) return compactAlias;
+    const initial = normalized.charAt(0);
+    if (CAPTURE_ANIMATION_BY_PIECE[initial]) return initial;
+  }
+  return '';
+};
 const FILE_LABELS = 'abcdefgh';
 const resolveChessSquare = (r, c) => `${FILE_LABELS[c] || '?'}${8 - r}`;
 
@@ -9975,20 +10026,13 @@ function Chess3D({
       deltaR = 0,
       deltaC = 0
     }) => {
-      const resolveCapturePieceType = () => {
-        const candidates = [
-          movingType,
-          movingMesh?.userData?.t,
-          movingMesh?.userData?.__pieceType,
-          movingMesh?.userData?.type
-        ];
-        for (const value of candidates) {
-          const key = `${value || ''}`.trim().toUpperCase();
-          if (CAPTURE_ANIMATION_BY_PIECE[key]) return key;
-        }
-        return '';
-      };
-      const pieceType = resolveCapturePieceType();
+      const pieceType = resolveCaptureAnimationPieceType(
+        movingType,
+        movingMesh?.userData?.t,
+        movingMesh?.userData?.__pieceType,
+        movingMesh?.userData?.type,
+        movingMesh?.name
+      );
       const captureAnimationId = CAPTURE_ANIMATION_BY_PIECE[pieceType] || '';
       if (captureAnimationId === 'rookJavelin') {
         suppressTimerBeepUntilRef.current = performance.now() + CAPTURE_GROUND_TOTAL * 1000;


### PR DESCRIPTION
### Motivation
- Capture animations were sometimes misrouted because piece identifiers arrived in different formats (single-letter codes, full names, mesh names, or Unicode chess glyphs). 
- The goal is to make capture FX selection robust and deterministic regardless of how piece metadata is provided.

### Description
- Added a centralized alias map `CAPTURE_PIECE_TYPE_ALIASES` to normalize many variant labels (names, plurals, alternate words and Unicode pieces) to canonical piece keys in `webapp/src/pages/Games/ChessBattleRoyal.jsx`.
- Implemented `resolveCaptureAnimationPieceType(...)` which normalizes and matches incoming values and falls back to compacted glyphs or initial letters before returning an empty string if unmatched.
- Replaced the previous inline resolver with the new function when selecting a capture animation and extended the candidate fields to include `movingMesh?.name` so mesh names are considered.

### Testing
- Ran `npm run -s build` from `webapp/` which completed successfully (build warnings about chunk size were emitted but the build finished). 
- Attempted `npm run -s lint` from `webapp/` which exited non-zero because the repository has no `lint` script configured. 
- Verified that the change is localized to `webapp/src/pages/Games/ChessBattleRoyal.jsx` and the app still builds end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4d5380f788329b0a1ec5dcb4d2678)