### PR TITLE
Fix Checkers chair GLTF/KTX2 loading and king promotion ring alignment

### DIFF
--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -458,21 +458,22 @@ const createCheckerMesh = ({
   if (king) {
     const ring = new THREE.Mesh(
       new THREE.TorusGeometry(
-        tile * 0.16 * CHECKER_PIECE_SCALE,
-        tile * 0.038 * CHECKER_PIECE_SCALE,
-        12,
-        32
+        tile * 0.188 * CHECKER_PIECE_SCALE,
+        tile * 0.026 * CHECKER_PIECE_SCALE,
+        18,
+        48
       ),
       new THREE.MeshStandardMaterial({
         color: '#facc15',
         metalness: 0.94,
-        roughness: 0.14,
+        roughness: 0.18,
         emissive: '#9a6c00',
-        emissiveIntensity: 0.2
+        emissiveIntensity: 0.24
       })
     );
     ring.rotation.x = Math.PI / 2;
-    ring.position.y = tile * 0.13 * CHECKER_PIECE_SCALE;
+    ring.position.y = tile * 0.198 * CHECKER_PIECE_SCALE;
+    ring.renderOrder = 6;
     pieceGroup.add(ring);
   }
 
@@ -1117,10 +1118,7 @@ function fitChairModelToFootprint(model) {
 }
 
 async function buildChessMappedChairTemplate() {
-  const loader = new GLTFLoader();
-  const draco = new DRACOLoader();
-  draco.setDecoderPath(DRACO_DECODER_PATH);
-  loader.setDRACOLoader(draco);
+  const loader = createConfiguredGLTFLoader();
   let gltf = null;
   let lastError = null;
   for (const url of CHAIR_MODEL_URLS) {
@@ -1155,10 +1153,13 @@ async function buildPolyhavenChairTemplate(assetId, renderer = null) {
     return CHAIR_TEMPLATE_CACHE.get(cacheKey).clone(true);
   }
   const urls = [
+    `https://dl.polyhaven.org/file/ph-assets/Models/gltf/4k/${assetId}/${assetId}_4k.gltf`,
     `https://dl.polyhaven.org/file/ph-assets/Models/gltf/2k/${assetId}/${assetId}_2k.gltf`,
     `https://dl.polyhaven.org/file/ph-assets/Models/gltf/1k/${assetId}/${assetId}_1k.gltf`,
     `https://dl.polyhaven.org/file/ph-assets/Models/GLB/${assetId}/${assetId}.glb`,
-    `https://dl.polyhaven.org/file/ph-assets/Models/GLB/${assetId}.glb`
+    `https://dl.polyhaven.org/file/ph-assets/Models/GLB/${assetId}.glb`,
+    `https://dl.polyhaven.org/file/ph-assets/Models/glb/${assetId}/${assetId}.glb`,
+    `https://dl.polyhaven.org/file/ph-assets/Models/glb/${assetId}.glb`
   ];
   const loader = createConfiguredGLTFLoader(renderer);
   let gltf = null;
@@ -1176,12 +1177,23 @@ async function buildPolyhavenChairTemplate(assetId, renderer = null) {
   if (!model) throw new Error(`Missing PolyHaven chair scene for ${assetId}`);
   model.traverse((obj) => {
     if (!obj.isMesh) return;
+    obj.userData = {
+      ...(obj.userData || {}),
+      preserveGltfTextureMapping: true
+    };
     obj.castShadow = true;
     obj.receiveShadow = true;
     const mats = Array.isArray(obj.material) ? obj.material : [obj.material];
     mats.forEach((mat) => {
-      if (mat?.map) applySRGBColorSpace(mat.map);
-      if (mat?.emissiveMap) applySRGBColorSpace(mat.emissiveMap);
+      if (mat?.map) {
+        applySRGBColorSpace(mat.map);
+        mat.map.needsUpdate = true;
+      }
+      if (mat?.emissiveMap) {
+        applySRGBColorSpace(mat.emissiveMap);
+        mat.emissiveMap.needsUpdate = true;
+      }
+      mat.needsUpdate = true;
     });
   });
   fitChairModelToFootprint(model);


### PR DESCRIPTION
### Motivation

- Ensure PolyHaven chair GLTFs load with the full decoder/transcoder stack so original texture mappings are preserved and high‑resolution sources are used when available.
- Make the gold promotion ring sit visually on top of promoted pieces and scale correctly with the updated piece proportions.

### Description

- Use the existing loader stack by switching `buildChessMappedChairTemplate` to call `createConfiguredGLTFLoader()` so DRACO/KTX2/Meshopt support is available for mapped chairs.
- Add additional PolyHaven URL fallbacks (including `4k` GLTF and alternate GLB path/case variants) in `buildPolyhavenChairTemplate` to improve reliability of fetched resources.
- Mark loaded chair meshes with `userData.preserveGltfTextureMapping = true` and force updates to `map`, `emissiveMap` and material `needsUpdate` after applying `applySRGBColorSpace` so original PolyHaven texture mappings and colors are preserved.
- Retune the promoted piece gold ring by changing the torus geometry, increasing segment/detail and adjusting `roughness`, `emissiveIntensity`, `position.y` and `renderOrder` so the ring appears on top of the piece and matches new piece sizing.

### Testing

- Ran `npm test -- --runInBand test/checkersAuthoritativeEngine.test.js` and the suite passed (4 tests, 0 failures).
- Ran `npx eslint webapp/src/pages/Games/CheckersBattleRoyal.jsx` which emitted an ignore-warning due to repo lint settings and produced no lint errors for the file itself.
- Verified the modified file compiles in the repo environment and no unit tests were negatively impacted by the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4e7ab65ec8329ade5bde948618298)