### PR TITLE
Improve Murlan Royale card touch hit-testing precision

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -6145,20 +6145,13 @@ function pickMostPreciseCardAtPointer({
   event,
   rect,
   camera,
-  selectionTargets,
-  raycaster
+  selectionTargets
 }) {
-  if (!event || !rect || !camera || !Array.isArray(selectionTargets) || !selectionTargets.length || !raycaster) {
+  if (!event || !rect || !camera || !Array.isArray(selectionTargets) || !selectionTargets.length) {
     return null;
   }
   const pointerX = event.clientX - rect.left;
   const pointerY = event.clientY - rect.top;
-  const pointer = new THREE.Vector2((pointerX / rect.width) * 2 - 1, -(pointerY / rect.height) * 2 + 1);
-  raycaster.setFromCamera(pointer, camera);
-  const intersects = raycaster.intersectObjects(selectionTargets, false);
-  if (!intersects.length) {
-    return null;
-  }
 
   const screenCorners = [];
   const cardPlaneZ = CARD_D * 0.5;
@@ -6185,25 +6178,20 @@ function pickMostPreciseCardAtPointer({
     }
     return true;
   };
-  const pointToSegmentDistance = (px, py, a, b) => {
-    const abx = b.x - a.x;
-    const aby = b.y - a.y;
-    const lengthSq = abx * abx + aby * aby;
-    if (lengthSq < 1e-6) return Math.hypot(px - a.x, py - a.y);
-    const t = Math.max(0, Math.min(1, ((px - a.x) * abx + (py - a.y) * aby) / lengthSq));
-    const cx = a.x + abx * t;
-    const cy = a.y + aby * t;
+  const pointDistanceToQuadCentroid = (px, py, quad) => {
+    if (!quad?.length) return Number.POSITIVE_INFINITY;
+    const cx = quad.reduce((sum, point) => sum + point.x, 0) / quad.length;
+    const cy = quad.reduce((sum, point) => sum + point.y, 0) / quad.length;
     return Math.hypot(px - cx, py - cy);
   };
 
-  let bestInsideCardId = null;
-  let bestInsideDistance = Number.POSITIVE_INFINITY;
-  let bestEdgeCardId = null;
-  let bestEdgeDistance = Number.POSITIVE_INFINITY;
-  const maxEdgeDistance = detectCoarsePointer() ? 6 : 4;
+  let bestCardId = null;
+  let bestRenderOrder = Number.NEGATIVE_INFINITY;
+  let bestDistanceToCamera = Number.POSITIVE_INFINITY;
+  let bestCentroidDistance = Number.POSITIVE_INFINITY;
+  const meshWorldPosition = new THREE.Vector3();
 
-  intersects.forEach((hit) => {
-    const mesh = hit?.object;
+  selectionTargets.forEach((mesh) => {
     if (!mesh) return;
     const cardId = mesh.userData.cardId || mesh.parent?.userData.cardId;
     if (!cardId) return;
@@ -6218,31 +6206,34 @@ function pickMostPreciseCardAtPointer({
       });
     }
     const inside = isPointInsideQuad(pointerX, pointerY, screenCorners);
-    if (inside) {
-      if (hit.distance < bestInsideDistance) {
-        bestInsideDistance = hit.distance;
-        bestInsideCardId = cardId;
-      }
+    if (!inside) {
       return;
     }
-    let edgeDistance = Number.POSITIVE_INFINITY;
-    for (let i = 0; i < screenCorners.length; i++) {
-      const a = screenCorners[i];
-      const b = screenCorners[(i + 1) % screenCorners.length];
-      const segDistance = pointToSegmentDistance(pointerX, pointerY, a, b);
-      if (segDistance < edgeDistance) {
-        edgeDistance = segDistance;
-      }
-    }
-    if (edgeDistance < bestEdgeDistance) {
-      bestEdgeDistance = edgeDistance;
-      bestEdgeCardId = cardId;
+
+    const meshRenderOrder = Number.isFinite(mesh.renderOrder) ? mesh.renderOrder : 0;
+    mesh.getWorldPosition(meshWorldPosition);
+    const distanceToCamera = meshWorldPosition.distanceTo(camera.position);
+    const centroidDistance = pointDistanceToQuadCentroid(pointerX, pointerY, screenCorners);
+
+    const isBetterRenderOrder = meshRenderOrder > bestRenderOrder;
+    const isTieRenderOrder = meshRenderOrder === bestRenderOrder;
+    const isBetterDepth = distanceToCamera < bestDistanceToCamera - 1e-4;
+    const isTieDepth = Math.abs(distanceToCamera - bestDistanceToCamera) <= 1e-4;
+    const isBetterCentroid = centroidDistance < bestCentroidDistance;
+
+    if (
+      isBetterRenderOrder ||
+      (isTieRenderOrder && isBetterDepth) ||
+      (isTieRenderOrder && isTieDepth && isBetterCentroid)
+    ) {
+      bestRenderOrder = meshRenderOrder;
+      bestDistanceToCamera = distanceToCamera;
+      bestCentroidDistance = centroidDistance;
+      bestCardId = cardId;
     }
   });
 
-  if (bestInsideCardId) return bestInsideCardId;
-  if (bestEdgeDistance <= maxEdgeDistance) return bestEdgeCardId;
-  return null;
+  return bestCardId;
 }
 
 function setMeshPosition(mesh, target, lookTarget, orientation, immediate, animations, delayMs = 0) {


### PR DESCRIPTION
### Motivation
- Touch/card selection on the Murlan Royale table was not matching the visible card bounds, causing inaccurate taps on mobile portrait screens. 
- The goal is to make selection match the actual rendered card footprint precisely and deterministically when cards overlap.

### Description
- Rewrote `pickMostPreciseCardAtPointer` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to project each card's four corner world positions to screen space and perform a point-in-quad test against the pointer. 
- Removed the earlier dependency on raycast hit ordering and the coarse pointer edge-snap behavior, replacing it with strict inside-quad selection. 
- When multiple cards contain the pointer the selection chooses the visually top card by `renderOrder`, using camera distance and centroid distance as deterministic tie-breakers. 
- Kept the API minimal by no longer requiring a `raycaster` parameter when calling `pickMostPreciseCardAtPointer`.

### Testing
- Ran the unit tests with `npm test -- test/murlan.test.js --runInBand`, and the suite passed (1 test suite, 12 tests all passed). 
- No additional automated UI/end-to-end tests were available in this environment; manual visual verification on device is recommended after deployment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4e859c8a08329b10e59c6ee9b0f3e)