### PR TITLE
Tune Murlan Royale portrait layout: shorter table, lower chairs, tighter card framing

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -107,7 +107,7 @@ const ENABLE_3D_HUMAN_CHARACTERS = false;
 const ARENA_GROWTH = 1.45; // expanded arena footprint for wider walkways
 const CHAIR_SIZE_SCALE = 1;
 const ARENA_PROP_SCALE = 0.4896; // Keep table/chairs/cards another 15% smaller while preserving portrait composition.
-const TOP_SEAT_AVATAR_UP_LIFT = 2.9; // Lift top avatar a bit higher in portrait so it clears card overlays better.
+const TOP_SEAT_AVATAR_UP_LIFT = 3.2; // Lift top avatar a bit higher in portrait so it clears card overlays better.
 
 const TABLE_RADIUS = 3.08 * MODEL_SCALE * ARENA_PROP_SCALE;
 const TABLE_HORIZONTAL_SHRINK = 0.94; // Trim only visual left/right footprint while keeping top/bottom depth.
@@ -1648,7 +1648,7 @@ function createCharacterCards({ handLift = 0.96, handCardsInput = [], cardTheme 
     });
     const backMaterial = new THREE.MeshStandardMaterial({
       map: backTexture,
-      color: new THREE.Color(idx === safeCount - 1 ? playerColor : cardTheme?.backColor || '#1d4ed8'),
+      color: new THREE.Color('#ffffff'),
       roughness: 0.6,
       metalness: 0.15
     });
@@ -2260,7 +2260,7 @@ async function buildChairTemplate(theme, renderer = null, textureOptions = {}) {
 }
 
 const STOOL_SCALE = 1.5 * 1.3 * CHAIR_SIZE_SCALE * ARENA_PROP_SCALE;
-const CARD_SCALE = ARENA_PROP_SCALE * 0.84; // Slightly smaller cards for cleaner mobile portrait framing.
+const CARD_SCALE = ARENA_PROP_SCALE * 0.8; // Make cards a bit smaller for cleaner mobile portrait framing.
 const CARD_W = 0.4 * MODEL_SCALE * CARD_SCALE;
 const CARD_H = 0.56 * MODEL_SCALE * CARD_SCALE;
 const CARD_D = 0.012 * MODEL_SCALE * CARD_SCALE; // Slimmer card thickness.
@@ -2281,7 +2281,7 @@ const ARM_THICKNESS = 0.125 * MODEL_SCALE * STOOL_SCALE;
 const ARM_HEIGHT = 0.3 * MODEL_SCALE * STOOL_SCALE;
 const ARM_DEPTH = SEAT_DEPTH * 0.75;
 const BASE_COLUMN_HEIGHT = 0.5 * MODEL_SCALE * STOOL_SCALE;
-const TABLE_HEIGHT_SHORTEN_FACTOR = 0.7; // Keep the table ~30% shorter than the previous baseline height.
+const TABLE_HEIGHT_SHORTEN_FACTOR = 0.66; // Keep the table shorter for portrait readability.
 const BASE_TABLE_HEIGHT = 0.96 * MODEL_SCALE * TABLE_HEIGHT_SHORTEN_FACTOR;
 const BASE_HUMAN_CHAIR_RADIUS = 5.6 * MODEL_SCALE * ARENA_GROWTH * 0.85;
 const HUMAN_CHAIR_PULLBACK = 0.08 * MODEL_SCALE;
@@ -2302,7 +2302,7 @@ const CAMERA_FOCUS_CENTER_LIFT = -0.28 * MODEL_SCALE;
 const HUMAN_HAND_CARD_SCALE = 1.1;
 const HUMAN_HAND_CARD_SPACING = CARD_W * HUMAN_HAND_CARD_SCALE * 0.29;
 const HUMAN_HAND_CARD_MAX_SPREAD = HUMAN_HAND_CARD_SPACING * 12;
-const HUMAN_HAND_EXTRA_LIFT = 0.07 * MODEL_SCALE;
+const HUMAN_HAND_EXTRA_LIFT = 0.05 * MODEL_SCALE;
 const HUMAN_HAND_FAN_MAX_YAW = 0; // Keep hands in a single line, including left/right seats.
 const HUMAN_HAND_FAN_ARC_LIFT = 0;
 const HUMAN_HAND_FAN_DIRECTION = 1;
@@ -2339,7 +2339,7 @@ const DEAL_CARD_STEP_DELAY_MS = 60;
 const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 0.85 - 0.06 * MODEL_SCALE;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
 const CHAIR_GROUND_DROP = 0.018 * MODEL_SCALE;
-const CHAIR_SCREEN_LOWER_OFFSET = 0.02 * MODEL_SCALE; // Push chairs lower so they visually touch the floor plane in portrait.
+const CHAIR_SCREEN_LOWER_OFFSET = 0.032 * MODEL_SCALE; // Push chairs a little lower so they visually touch the floor plane in portrait.
 const HUMAN_CHAIR_EXTRA_INWARD_OFFSET = 0.26 * MODEL_SCALE; // Pull only the bottom player's chair slightly closer to the table.
 const TABLE_HEIGHT_LIFT = 0.02 * MODEL_SCALE;
 const TABLE_HEIGHT = STOOL_HEIGHT + TABLE_HEIGHT_LIFT;
@@ -2348,7 +2348,7 @@ const TABLE_MODEL_TARGET_DIAMETER = TABLE_RADIUS * 2 * 1.06 * TABLE_SIDE_TRIM_SC
 const TABLE_MODEL_TARGET_HEIGHT = TABLE_HEIGHT;
 const TABLE_HEIGHT_RAISE = TABLE_HEIGHT - BASE_TABLE_HEIGHT;
 const HUMAN_SELECTION_OFFSET = 0.14 * MODEL_SCALE;
-const AI_CARD_LIFT = 0.05 * MODEL_SCALE;
+const AI_CARD_LIFT = 0.036 * MODEL_SCALE;
 const AI_CARD_OUTWARD = 0;
 
 function resolveSeatHandRadius(tableRadius, isHumanSeat) {
@@ -4760,11 +4760,11 @@ export default function MurlanRoyaleArena({ search }) {
           toneMapped: false,
           depthWrite: false
         });
-        const scoreboardWidth = Math.min(innerHalfWidth * 0.84, 4.08 * MODEL_SCALE);
-        const scoreboardHeight = scoreboardWidth * 0.42;
+        const scoreboardWidth = Math.min(innerHalfWidth * 0.78, 3.78 * MODEL_SCALE);
+        const scoreboardHeight = scoreboardWidth * 0.39;
         const scoreboardGeometry = new THREE.PlaneGeometry(scoreboardWidth, scoreboardHeight);
         const scoreboardMesh = new THREE.Mesh(scoreboardGeometry, scoreboardMaterial);
-        const scoreboardY = TABLE_HEIGHT + 1.34 * MODEL_SCALE;
+        const scoreboardY = TABLE_HEIGHT + 1.2 * MODEL_SCALE;
         const scoreboardZ = -Math.max(TABLE_RADIUS * 2.2, floorRadius * 0.72);
         scoreboardMesh.position.set(0, scoreboardY, scoreboardZ);
         scoreboardMesh.lookAt(new THREE.Vector3(0, scoreboardMesh.position.y, 0));
@@ -5370,7 +5370,7 @@ export default function MurlanRoyaleArena({ search }) {
             const anchor = seatAnchorMap.get(idx);
             const fallback = FALLBACK_SEAT_POSITIONS[idx % FALLBACK_SEAT_POSITIONS.length];
             const isSideSeat = idx !== humanPlayerIndex && idx !== topSeatIndex;
-            const sideSeatTopLift = isSideSeat ? 2.05 : 1.35;
+            const sideSeatTopLift = isSideSeat ? 2.25 : 1.45;
             const topSeatLift = idx === topSeatIndex ? TOP_SEAT_AVATAR_UP_LIFT : 0;
             const positionStyle = idx === humanPlayerIndex
               ? {


### PR DESCRIPTION
### Motivation
- Improve portrait mobile composition for Murlan Royale by making the table visually shorter and chairs sit slightly lower so elements fit better on small/portrait screens.
- Raise non-bottom avatars (top and side seats) to clear card overlays while keeping the bottom (user) avatar placement unchanged.
- Make player cards slightly smaller and ensure the back logo is visible without per-card tinting, and scale/position the results frame to match the new layout.

### Description
- Adjusted portrait layout constants in `webapp/src/pages/Games/MurlanRoyaleArena.jsx`: `TOP_SEAT_AVATAR_UP_LIFT` increased to `3.2`, `CARD_SCALE` reduced to `ARENA_PROP_SCALE * 0.8`, and `TABLE_HEIGHT_SHORTEN_FACTOR` reduced to `0.66` to shorten the table height.
- Brought player hands/cards closer to the table by reducing `HUMAN_HAND_EXTRA_LIFT` and `AI_CARD_LIFT`, and pushed chairs visually lower via `CHAIR_SCREEN_LOWER_OFFSET` to make chairs appear lowered.
- Ensured card backs are rendered without per-card tinting by setting the hand back material color to `'#ffffff'` so the Tonplaygram logo/pattern from the back texture remains visible.
- Reduced and lowered the in-scene results/scoreboard plane by shrinking its geometry (`scoreboardWidth/scoreboardHeight`) and moving it down (`scoreboardY`), and increased `sideSeatTopLift` so side avatars lift more visibly.

### Testing
- Ran the Murlan game unit tests with `npm -s test -- test/murlan.test.js` and all tests passed (12 tests, 1 suite).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e50dccc8c083298fa7332baa10dbbd)