### PR TITLE
Lower Murlan Royale table and chairs for tighter portrait framing

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2280,8 +2280,8 @@ const BACK_THICKNESS = 0.08 * MODEL_SCALE * STOOL_SCALE;
 const ARM_THICKNESS = 0.125 * MODEL_SCALE * STOOL_SCALE;
 const ARM_HEIGHT = 0.3 * MODEL_SCALE * STOOL_SCALE;
 const ARM_DEPTH = SEAT_DEPTH * 0.75;
-const BASE_COLUMN_HEIGHT = 0.5 * MODEL_SCALE * STOOL_SCALE;
-const TABLE_HEIGHT_SHORTEN_FACTOR = 0.58; // Shorten table profile further while preserving readability in portrait.
+const BASE_COLUMN_HEIGHT = 0.42 * MODEL_SCALE * STOOL_SCALE; // Trim chair legs so seating reads shorter/lower.
+const TABLE_HEIGHT_SHORTEN_FACTOR = 0.52; // Further shorten table profile while preserving portrait readability.
 const BASE_TABLE_HEIGHT = 0.96 * MODEL_SCALE * TABLE_HEIGHT_SHORTEN_FACTOR;
 const BASE_HUMAN_CHAIR_RADIUS = 5.6 * MODEL_SCALE * ARENA_GROWTH * 0.85;
 const HUMAN_CHAIR_PULLBACK = 0.08 * MODEL_SCALE;
@@ -2339,9 +2339,9 @@ const DEAL_CARD_STEP_DELAY_MS = 60;
 const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 0.85 - 0.06 * MODEL_SCALE;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
 const CHAIR_GROUND_DROP = 0.018 * MODEL_SCALE;
-const CHAIR_SCREEN_LOWER_OFFSET = 0.052 * MODEL_SCALE; // Lower chairs so feet visually sit on the HDRI floor.
+const CHAIR_SCREEN_LOWER_OFFSET = 0.072 * MODEL_SCALE; // Lower chairs a bit more so feet visually touch the HDRI floor.
 const HUMAN_CHAIR_EXTRA_INWARD_OFFSET = 0.26 * MODEL_SCALE; // Pull only the bottom player's chair slightly closer to the table.
-const TABLE_HEIGHT_LIFT = 0.012 * MODEL_SCALE;
+const TABLE_HEIGHT_LIFT = 0.008 * MODEL_SCALE;
 const TABLE_HEIGHT = STOOL_HEIGHT + TABLE_HEIGHT_LIFT;
 const TABLE_SIDE_TRIM_SCALE = 0.86;
 const TABLE_MODEL_TARGET_DIAMETER = TABLE_RADIUS * 2 * 1.06 * TABLE_SIDE_TRIM_SCALE;
@@ -3888,6 +3888,7 @@ export default function MurlanRoyaleArena({ search }) {
           renderer: three.renderer,
           tableRadius: TABLE_RADIUS * TABLE_SIDE_TRIM_SCALE,
           tableHeight: TABLE_HEIGHT,
+          pedestalHeightScale: 0.82,
           includeBase: true,
           shapeOption,
           woodOption: finish?.woodOption || undefined,

--- a/webapp/src/utils/murlanTable.js
+++ b/webapp/src/utils/murlanTable.js
@@ -546,6 +546,7 @@ export function createMurlanStyleTable({
   renderer,
   tableRadius = 2.55,
   tableHeight = 0.81,
+  pedestalHeightScale = 1.08,
   woodOption = DEFAULT_TABLE_WOOD_OPTION,
   clothOption = DEFAULT_TABLE_CLOTH_OPTION,
   baseOption = DEFAULT_TABLE_BASE_OPTION,
@@ -567,7 +568,10 @@ export function createMurlanStyleTable({
   const minBaseHeight = 0.2 * scaleFactor;
   const maxBaseHeight = Math.max(minBaseHeight, tableY + baseLift);
   // Keep table-top height unchanged while trimming the pedestal so the table reads shorter overall.
-  baseHeight = maxBaseHeight * 1.08;
+  const safePedestalScale = Number.isFinite(pedestalHeightScale)
+    ? Math.max(0.55, Math.min(1.25, pedestalHeightScale))
+    : 1.08;
+  baseHeight = maxBaseHeight * safePedestalScale;
 
   const baseMat = includeBase
     ? new ThreeNamespace.MeshPhysicalMaterial({


### PR DESCRIPTION
### Motivation
- Reduce the perceived vertical height of the Murlan Royale table/chairs so the scene fits better in portrait orientation while preserving current camera/card composition.
- Trim chair legs and table pedestal so chairs visually touch the HDRI floor and the table reads shorter without breaking gameplay anchors.

### Description
- Added a new `pedestalHeightScale` parameter (with clamped safety bounds) to `createMurlanStyleTable` and used it to scale the table pedestal height when building procedural tables in Murlan Royale (`webapp/src/utils/murlanTable.js`).
- Applied `pedestalHeightScale: 0.82` when creating the Murlan Royale procedural table so the table base is visually shorter (`webapp/src/pages/Games/MurlanRoyaleArena.jsx`).
- Reduced `BASE_COLUMN_HEIGHT` and `TABLE_HEIGHT_SHORTEN_FACTOR`, and slightly lowered `TABLE_HEIGHT_LIFT` to shorten the overall table/chair profile while keeping table-top anchors intact (`webapp/src/pages/Games/MurlanRoyaleArena.jsx`).
- Increased `CHAIR_SCREEN_LOWER_OFFSET` so chairs are positioned a bit lower and their feet align with the HDRI floor, keeping camera and card anchors unchanged so framing remains consistent (`webapp/src/pages/Games/MurlanRoyaleArena.jsx`).

### Testing
- Ran `npm -C webapp run build` and the production build completed successfully; the build emitted non-blocking Vite chunk-size/dynamic-import warnings but finished without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e51dc086b483298a75a734504ae40d)