### PR TITLE
Tune Air Hockey puck speed slightly slower

### DIFF
--- a/webapp/src/components/AirHockey3D.jsx
+++ b/webapp/src/components/AirHockey3D.jsx
@@ -1932,7 +1932,7 @@ export default function AirHockey3D({ player, ai, target = 11, playType = 'regul
     renderer.domElement.addEventListener('mousemove', onMove);
 
     const SPEED_BOOST = 1.25;
-    const PUCK_SPEED_TUNING = 0.9;
+    const PUCK_SPEED_TUNING = 0.82;
     const HIT_FORCE = 0.5 * SPEED_SCALE * SPEED_BOOST * PUCK_SPEED_TUNING;
     const MAX_SPEED = 0.095 * SPEED_SCALE * SPEED_BOOST * PUCK_SPEED_TUNING;
     const SERVE_SPEED = 0.055 * SPEED_SCALE * SPEED_BOOST * PUCK_SPEED_TUNING;


### PR DESCRIPTION
### Motivation
- Make the Air Hockey puck feel more controllable by slightly reducing the overall puck speed multiplier so serves, collisions and top speed are marginally slower.

### Description
- Decreased `PUCK_SPEED_TUNING` from `0.9` to `0.82` in `webapp/src/components/AirHockey3D.jsx`, which scales `HIT_FORCE`, `MAX_SPEED`, and `SERVE_SPEED` together for a calmer match pace.

### Testing
- Ran `npm run -s test -- test/storeDelivery.test.js` which completed successfully with the test suite passing (1 suite, 2 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e51e4925dc8329a864f59903df122d)