### PR TITLE
Murlan: shrink table/cards, round card edges, and improve card-back logo

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2262,7 +2262,7 @@ async function buildChairTemplate(theme, renderer = null, textureOptions = {}) {
 }
 
 const STOOL_SCALE = 1.5 * 1.3 * CHAIR_SIZE_SCALE * ARENA_PROP_SCALE;
-const CARD_SCALE = ARENA_PROP_SCALE * 0.8 * TABLE_AND_CHAIR_VISUAL_SHRINK; // Match cards to the same 30% visual shrink as table/chairs.
+const CARD_SCALE = ARENA_PROP_SCALE * 0.75 * TABLE_AND_CHAIR_VISUAL_SHRINK; // Keep cards a bit smaller than table/chairs for cleaner portrait readability.
 const CARD_W = 0.4 * MODEL_SCALE * CARD_SCALE;
 const CARD_H = 0.56 * MODEL_SCALE * CARD_SCALE;
 const CARD_D = 0.012 * MODEL_SCALE * CARD_SCALE; // Slimmer card thickness.
@@ -4813,8 +4813,8 @@ export default function MurlanRoyaleArena({ search }) {
 
       cardGeometry = createCardGeometry(CARD_W, CARD_H, CARD_D, {
         rounded: true,
-        cornerRadiusRatio: 0.14,
-        segments: 6
+        cornerRadiusRatio: 0.2,
+        segments: 8
       });
 
       const seatConfigs = [];

--- a/webapp/src/utils/cards3d.js
+++ b/webapp/src/utils/cards3d.js
@@ -369,22 +369,55 @@ function drawLogoFrame(ctx, w, h, theme) {
   ctx.restore();
 
   ctx.save();
+  const logoPanelWidth = w * 0.9;
+  const logoPanelHeight = h * 0.42;
+  const logoPanelX = (w - logoPanelWidth) / 2;
+  const logoPanelY = (h - logoPanelHeight) / 2;
+  const logoPanelRadius = Math.min(logoPanelWidth, logoPanelHeight) * 0.14;
+  const panelGradient = ctx.createLinearGradient(0, logoPanelY, 0, logoPanelY + logoPanelHeight);
+  panelGradient.addColorStop(0, 'rgba(10,18,34,0.72)');
+  panelGradient.addColorStop(1, 'rgba(15,28,52,0.86)');
+  ctx.fillStyle = panelGradient;
+  roundRect(ctx, logoPanelX, logoPanelY, logoPanelWidth, logoPanelHeight, logoPanelRadius);
+  ctx.fill();
+
+  ctx.strokeStyle = 'rgba(255,255,255,0.42)';
+  ctx.lineWidth = Math.max(6, Math.round(w * 0.0028));
+  roundRect(
+    ctx,
+    logoPanelX + w * 0.01,
+    logoPanelY + w * 0.01,
+    logoPanelWidth - w * 0.02,
+    logoPanelHeight - w * 0.02,
+    logoPanelRadius * 0.92
+  );
+  ctx.stroke();
+
   if (logoImage?.complete && logoImage.naturalWidth > 0) {
     const ratio = logoImage.naturalWidth / Math.max(logoImage.naturalHeight, 1);
-    const logoBoxWidth = w * 0.94;
-    const logoBoxHeight = h * 0.56;
+    const logoBoxWidth = w * 0.82;
+    const logoBoxHeight = h * 0.28;
     const drawWidth = Math.min(logoBoxWidth, logoBoxHeight * ratio);
     const drawHeight = drawWidth / ratio;
     const logoX = w / 2 - drawWidth / 2;
-    const logoY = h / 2 - drawHeight / 2;
+    const logoY = h / 2 - drawHeight / 2 - h * 0.02;
+    ctx.shadowColor = 'rgba(255,255,255,0.35)';
+    ctx.shadowBlur = Math.max(18, Math.round(w * 0.014));
     ctx.drawImage(logoImage, logoX, logoY, drawWidth, drawHeight);
+    ctx.shadowBlur = 0;
   } else {
     ctx.fillStyle = theme.backAccent || 'rgba(255,255,255,0.85)';
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
     ctx.font = '700 48px "Inter", system-ui, sans-serif';
-    ctx.fillText('TonPlaygram', w / 2, h / 2);
+    ctx.fillText('TonPlaygram', w / 2, h / 2 - h * 0.02);
   }
+
+  ctx.fillStyle = 'rgba(255,255,255,0.95)';
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.font = `700 ${Math.max(42, Math.round(w * 0.04))}px "Inter", system-ui, sans-serif`;
+  ctx.fillText('TonPlaygram', w / 2, h / 2 + h * 0.12);
 
   ctx.restore();
 }


### PR DESCRIPTION
### Motivation
- Follow the design request to make the table/chairs/cards visually smaller while keeping the same portrait composition and camera framing.  
- Make card edges rounded instead of sharp so cards read softer on mobile in portrait.  
- Ensure the TonPlaygram logo/branding is visible on the back of cards (same approach used for Lucky/Texas back textures) so backs are clearly branded.

### Description
- Reduced the per-card visual scale by adjusting `CARD_SCALE` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to make cards read smaller relative to the already-applied table/chair shrink.  
- Increased card geometry rounding by changing `createCardGeometry` parameters in `MurlanRoyaleArena.jsx` (`cornerRadiusRatio: 0.14 -> 0.2`, `segments: 6 -> 8`) so card edges are visibly rounder.  
- Strengthened card-back rendering in `webapp/src/utils/cards3d.js` by adding a dedicated logo panel and frame, tightening the logo drawing box, applying a subtle glow/shadow to the image, and always drawing a readable `TonPlaygram` wordmark fallback; the implementation uses the existing `getTonplaygramLogoImage()` and `drawLogoFrame()` pipeline.  
- Kept existing composition behavior and constants such as `TABLE_AND_CHAIR_VISUAL_SHRINK` and camera logic unchanged so the scene layout and avatar positioning remain consistent.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully (build output produced, packaging warnings about some large chunks were reported but did not fail the build).  
- No additional automated unit tests were changed or required; visual verification (screenshots/manual QA) is recommended on a portrait mobile viewport to confirm final composition and logo legibility.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5324ef8d08329b6d1e15b56f04207)