### PR TITLE
Lift parked Ludo capture vehicles and slightly shrink table sides

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -109,6 +109,8 @@ const CAPTURE_PARK_FORWARD_OFFSET_BY_TYPE = {
   drone: 0.03,
   missile: 0.08
 };
+// Lift parked capture vehicles slightly so they read a bit higher on portrait screens.
+const CAPTURE_PARKED_LIFT_OFFSET_Y = 0.008;
 const CAPTURE_PARK_SCALE_BY_TYPE = Object.freeze({
   fighter: 1.4 * 1.15,
   helicopter: 1.2 * 1.15,
@@ -2705,7 +2707,7 @@ function getTableWidthScale(tableThemeId) {
   const id = String(tableThemeId || '').toLowerCase();
   if (!id) return 1;
   if (id.includes('octagon')) return 1;
-  return 1.06;
+  return 1.03;
 }
 
 function applyBoardGroupScale(boardGroup, tableInfo) {
@@ -4682,6 +4684,11 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       alignObjectBottomToY(droneFx.root, tableSurfaceY);
       alignObjectBottomToY(missileFx.root, tableSurfaceY);
       alignObjectBottomToY(droneTruckFx.root, tableSurfaceY);
+      jetFx.root.position.y += CAPTURE_PARKED_LIFT_OFFSET_Y;
+      helicopterFx.root.position.y += CAPTURE_PARKED_LIFT_OFFSET_Y;
+      droneFx.root.position.y += CAPTURE_PARKED_LIFT_OFFSET_Y;
+      missileFx.root.position.y += CAPTURE_PARKED_LIFT_OFFSET_Y;
+      droneTruckFx.root.position.y += CAPTURE_PARKED_LIFT_OFFSET_Y;
       orientCaptureVehicleTowardBoardCenter(jetFx.root, arena.boardLookTarget);
       orientCaptureVehicleTowardBoardCenter(helicopterFx.root, arena.boardLookTarget);
       orientCaptureVehicleTowardBoardCenter(droneFx.root, arena.boardLookTarget);
@@ -7562,7 +7569,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             if (shouldLandAtPark && parkedLaunch) {
               const landingBlend = clamp((flyAwayT - 0.72) / 0.28, 0, 1);
               const landed = parkedLaunch.clone();
-              landed.y = tableSurfaceY + 0.002;
+              landed.y = tableSurfaceY + 0.002 + CAPTURE_PARKED_LIFT_OFFSET_Y;
               primaryFx.root.position.lerp(landed, easeSmooth(landingBlend));
             }
           } else {
@@ -7600,7 +7607,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           if (parkedVehicleToRestore?.isObject3D && parkedLaunch?.isVector3) {
             parkedVehicleToRestore.visible = true;
             parkedVehicleToRestore.position.copy(parkedLaunch);
-            parkedVehicleToRestore.position.y = tableSurfaceY + 0.002;
+            parkedVehicleToRestore.position.y = tableSurfaceY + 0.002 + CAPTURE_PARKED_LIFT_OFFSET_Y;
             orientCaptureVehicleTowardBoardCenter(parkedVehicleToRestore, boardLookTargetRef.current ?? new THREE.Vector3());
           }
           if (isDroneAttack && parkedDronePayload?.isObject3D) {


### PR DESCRIPTION
### Motivation
- Parked capture weapons (jets, helicopters, drones, missiles, truck) should read a bit higher on portrait screens so they don't visually sit too low next to tokens. 
- Table sides should appear slightly narrower while preserving table height so the overall board looks a bit slimmer on mobile layout.

### Description
- Added a small vertical offset constant `CAPTURE_PARKED_LIFT_OFFSET_Y = 0.008` and applied it to parked capture vehicle roots after surface alignment so parked vehicles are lifted visually.
- Applied the same parked lift offset to landing/restore code paths (`landed.y` and `parkedVehicleToRestore.position.y`) to avoid snapping when attack animations finish.
- Reduced non-octagon table width scaling in `getTableWidthScale` from `1.06` to `1.03` so table sides render slightly smaller while height logic remains unchanged.
- All changes are in `webapp/src/pages/Games/LudoBattleRoyal.jsx`.

### Testing
- Ran the production build with `npm --prefix webapp run build`, which completed successfully (Vite build finished; non-blocking chunk-size/dynamic-import warnings were emitted). 
- No automated unit tests were added or modified for this visual tweak.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5d54c48dc83298bf688ba3f2440b3)