### PR TITLE
Restore original parked weapon locations in Snake & Ladder

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -269,29 +269,28 @@ const WEAPON_SLOT_LATERAL_NUDGE_BY_SEAT = Object.freeze([
   0
 ]);
 const WEAPON_DISPLAY_SIZE_MULTIPLIER = 1.4;
-const WEAPON_PARKING_OUTWARD_OFFSET = -TILE_SIZE * 0.18;
+const WEAPON_PARKING_OUTWARD_OFFSET = TILE_SIZE * 0.14;
 const WEAPON_FROM_TOKEN_CENTER_OFFSET = TOKEN_RADIUS * 0.58;
-// Keep parked weapons anchored immediately next to the player token.
 const WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT = Object.freeze([
-  -TILE_SIZE * 0.08,
-  -TILE_SIZE * 0.07,
-  -TILE_SIZE * 0.1,
-  -TILE_SIZE * 0.07
+  0,
+  -TILE_SIZE * 0.12,
+  0,
+  -TILE_SIZE * 0.34
 ]);
 const WEAPON_TOKEN_GAP = TILE_SIZE * 0.004;
 const WEAPON_PARKED_Y_DROP_BY_KIND = Object.freeze({
-  fighter: TOKEN_HEIGHT * 1.3,
-  helicopter: TOKEN_HEIGHT * 1.26,
-  drone: TOKEN_HEIGHT * 1.2,
-  supportTruck: TOKEN_HEIGHT * 1.34,
-  javelin: TOKEN_HEIGHT * 1.28
+  fighter: TOKEN_HEIGHT * 1.74,
+  helicopter: TOKEN_HEIGHT * 1.82,
+  drone: TOKEN_HEIGHT * 1.66,
+  supportTruck: TOKEN_HEIGHT * 1.78,
+  javelin: TOKEN_HEIGHT * 1.72
 });
-const WEAPON_REST_HEIGHT_OFFSET = -TOKEN_HEIGHT * 0.22;
+const WEAPON_REST_HEIGHT_OFFSET = -TOKEN_HEIGHT * 1.34;
 const WEAPON_REST_HEIGHT_OFFSET_BY_SEAT = Object.freeze([
-  -TOKEN_HEIGHT * 0.03,
-  -TOKEN_HEIGHT * 0.01,
-  -TOKEN_HEIGHT * 0.04,
-  -TOKEN_HEIGHT * 0.01
+  0,
+  0,
+  0,
+  0
 ]);
 
 const PAVEMENT_EXTRA_SCALE = 1.18;
@@ -4705,19 +4704,14 @@ function updateSeatWeaponDisplays(board, players = []) {
     const railLayout = getSeatRailLayout(
       board,
       seatIndex,
-      -TILE_SIZE * 0.12,
+      TILE_SIZE * 0.08,
       Number.isFinite(weaponInset) ? weaponInset : null
     );
     if (railLayout) {
-      const sideSign = WEAPON_SLOT_SIDE_SIGN_BY_SEAT[seatIndex] ?? (seatIndex % 2 === 0 ? -1 : 1);
-      const lateralNudge = WEAPON_SLOT_LATERAL_NUDGE_BY_SEAT[seatIndex] ?? 0;
-      const tokenSideSign = TOKEN_SLOT_SIDE_SIGN_BY_SEAT[seatIndex] ?? (seatIndex % 2 === 0 ? -1 : 1);
-      const tokenLateralNudge = TOKEN_SLOT_LATERAL_NUDGE_BY_SEAT[seatIndex] ?? 0;
-      const tokenSlotOffset = tokenSideSign * SEAT_RAIL_SLOT_OFFSET + tokenLateralNudge;
-      const weaponCenterOffset = tokenSlotOffset + sideSign * (WEAPON_FROM_TOKEN_CENTER_OFFSET + WEAPON_TOKEN_GAP) + lateralNudge;
+      const sideSign = seatIndex % 2 === 0 ? -1 : 1;
       holder.position
         .copy(railLayout.railLocal)
-        .addScaledVector(railLayout.lateral, weaponCenterOffset)
+        .addScaledVector(railLayout.lateral, sideSign * SEAT_RAIL_SLOT_OFFSET)
         .addScaledVector(
           railLayout.seatDirection,
           WEAPON_PARKING_OUTWARD_OFFSET + (WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT[seatIndex] ?? 0)


### PR DESCRIPTION
### Motivation
- Parked capture-weapon props on the Snake & Ladder board had been moved; this change restores them to their original seat-edge locations so parked animations appear where they were when first introduced.

### Description
- Reverted placement constants and per-seat offsets in `webapp/src/components/SnakeBoard3D.jsx`, including `WEAPON_PARKING_OUTWARD_OFFSET`, `WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT`, `WEAPON_PARKED_Y_DROP_BY_KIND`, `WEAPON_REST_HEIGHT_OFFSET`, and `WEAPON_REST_HEIGHT_OFFSET_BY_SEAT` to the baseline values used originally.
- Restored rail placement math for parked weapons by returning to the parity-based lateral slot calculation (using `sideSign = seatIndex % 2 === 0 ? -1 : 1`) and using `SEAT_RAIL_SLOT_OFFSET` instead of deriving a `weaponCenterOffset` from token offsets and nudges.
- Adjusted the `getSeatRailLayout` call parameter from `-TILE_SIZE * 0.12` back to the original `TILE_SIZE * 0.08` to match the original forward bias for parked weapons.
- All changes are contained in `webapp/src/components/SnakeBoard3D.jsx` and affect only visual positioning of parked weapon models and their rest heights.

### Testing
- Ran the production build with `npm --prefix webapp run build` and the build completed successfully (Vite output shown). 
- The build produced pre-existing Vite chunk-size/dynamic-import warnings only; no new warnings or build errors were introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e618979bc4832980c64a64764cc758)