### PR TITLE
Fix Checkers table mapping and preserve GLTF chair textures on swaps

### DIFF
--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -315,7 +315,7 @@ const CHECKERS_PROCEDURAL_TABLE_IDS = new Set([
 ]);
 const CHECKERS_TABLE_SHAPE_BY_ID = Object.freeze({
   'murlan-default': 'classicOctagon',
-  ovalTable: 'grandOval',
+  grandOval: 'grandOval',
   diamondEdge: 'diamondEdge',
   hexagonTable: 'hexagonTable'
 });
@@ -510,11 +510,15 @@ const animateSmokePuff = (group, tile, position, activeAnimationsRef) => {
   }
 };
 
-const disposeGroupMeshes = (group) => {
+const disposeGroupMeshes = (
+  group,
+  { disposeGeometry = true, disposeMaterials = true } = {}
+) => {
   if (!group) return;
   group.traverse((child) => {
     if (!child?.isMesh) return;
-    child.geometry?.dispose?.();
+    if (disposeGeometry) child.geometry?.dispose?.();
+    if (!disposeMaterials) return;
     if (Array.isArray(child.material)) {
       child.material.forEach((mat) => mat?.dispose?.());
       return;
@@ -1888,7 +1892,10 @@ export default function CheckersBattleRoyal() {
 
       chairsRef.current.forEach((chair) => {
         chair?.parent?.remove?.(chair);
-        disposeGroupMeshes(chair);
+        disposeGroupMeshes(chair, {
+          disposeGeometry: false,
+          disposeMaterials: false
+        });
       });
       chairsRef.current = [];
 


### PR DESCRIPTION
### Motivation
- Selecting the Oval table option did not always rebuild to the intended procedural shape due to a table-id mapping mismatch. 
- Repeated chair swaps could break GLTF PBR textures because previously-added chair instances were fully disposed, including shared geometry/materials. 

### Description
- Corrected the table shape lookup by changing the `CHECKERS_TABLE_SHAPE_BY_ID` entry so `grandOval` maps to `'grandOval'` (fixes the Oval table selection). 
- Added optional disposal flags to `disposeGroupMeshes` as `({ disposeGeometry = true, disposeMaterials = true } = {})` to allow selective cleanup. 
- Updated the chair rebuild flow to remove previous chair instances without disposing shared GLTF geometry/material resources by calling `disposeGroupMeshes(chair, { disposeGeometry: false, disposeMaterials: false })`. 
- Changes are limited to `webapp/src/pages/Games/CheckersBattleRoyal.jsx` and adjust GLTF reuse and table-shape mapping logic. 

### Testing
- Ran `npx eslint webapp/src/pages/Games/CheckersBattleRoyal.jsx`, which reported the file was ignored by repo ignore rules and produced no lint errors for the edited file. 
- No other automated tests were executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6fe1f82448329bdaf3cbecd43f39e)