### PR TITLE
Adjust Snake & Ladder weapon parking for side seats

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -273,9 +273,9 @@ const WEAPON_PARKING_OUTWARD_OFFSET = TILE_SIZE * 0.14;
 const WEAPON_FROM_TOKEN_CENTER_OFFSET = TOKEN_RADIUS * 0.58;
 const WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT = Object.freeze([
   0,
-  -TILE_SIZE * 0.12,
+  -TILE_SIZE * 0.34,
   0,
-  -TILE_SIZE * 0.34
+  -TILE_SIZE * 0.48
 ]);
 const WEAPON_TOKEN_GAP = TILE_SIZE * 0.004;
 const WEAPON_PARKED_Y_DROP_BY_KIND = Object.freeze({
@@ -288,9 +288,9 @@ const WEAPON_PARKED_Y_DROP_BY_KIND = Object.freeze({
 const WEAPON_REST_HEIGHT_OFFSET = -TOKEN_HEIGHT * 1.34;
 const WEAPON_REST_HEIGHT_OFFSET_BY_SEAT = Object.freeze([
   0,
+  -TOKEN_HEIGHT * 0.22,
   0,
-  0,
-  0
+  -TOKEN_HEIGHT * 0.22
 ]);
 
 const PAVEMENT_EXTRA_SCALE = 1.18;
@@ -4709,10 +4709,11 @@ function updateSeatWeaponDisplays(board, players = []) {
       Number.isFinite(weaponInset) ? weaponInset : null
     );
     if (railLayout) {
-      const sideSign = seatIndex % 2 === 0 ? -1 : 1;
+      const sideSign = WEAPON_SLOT_SIDE_SIGN_BY_SEAT[seatIndex] ?? (seatIndex % 2 === 0 ? -1 : 1);
+      const lateralNudge = WEAPON_SLOT_LATERAL_NUDGE_BY_SEAT[seatIndex] ?? 0;
       holder.position
         .copy(railLayout.railLocal)
-        .addScaledVector(railLayout.lateral, sideSign * SEAT_RAIL_SLOT_OFFSET)
+        .addScaledVector(railLayout.lateral, sideSign * SEAT_RAIL_SLOT_OFFSET + lateralNudge)
         .addScaledVector(
           railLayout.seatDirection,
           WEAPON_PARKING_OUTWARD_OFFSET + (WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT[seatIndex] ?? 0)


### PR DESCRIPTION
### Motivation
- Side-seat parked capture weapons needed to sit visually lower and closer to the board center on portrait screens so they appear better aligned with the table edges.
- Keep seat positioning logic consistent with token-slot rules so tuning is straightforward per-seat.

### Description
- Updated per-seat radial offsets in `WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT` to move side seats (indices 1 and 3) inward toward the board center.
- Lowered parked resting height for side seats by setting `WEAPON_REST_HEIGHT_OFFSET_BY_SEAT` for seats 1 and 3 to `-TOKEN_HEIGHT * 0.22` so parked weapons sit lower on screen.
- Reworked seat placement math in `updateSeatWeaponDisplays` to use `WEAPON_SLOT_SIDE_SIGN_BY_SEAT` and `WEAPON_SLOT_LATERAL_NUDGE_BY_SEAT` (replacing ad-hoc side-sign logic) and apply the lateral nudge when computing holder positions.
- Modified file: `webapp/src/components/SnakeBoard3D.jsx`.

### Testing
- Ran the production build with `npm --prefix webapp run -s build` and the build completed successfully in this environment.
- The build produced existing non-blocking Vite warnings about large chunks / dynamic imports which are unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e707ef841c83298c9ece7b3759e6dd)