### PR TITLE
Refine Chess Battle Royal capture flight choreography

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -99,10 +99,10 @@ const CAPTURE_DRONE_TOTAL = CAPTURE_DRONE_LIFT_TIME + CAPTURE_DRONE_CRUISE_TIME 
 const CAPTURE_JET_SPEED_FACTOR = 4.9 / CAPTURE_DRONE_TOTAL; // slower than prior tuning for clearer portrait tracking
 const PROFILE_VIEW_ROTATION_TYPES = new Set(['K', 'N']);
 const PROFILE_VIEW_ROTATION_RADIANS = Math.PI / 2;
-const CAPTURE_JET_TOTAL = 4.2; // balanced pacing: readable impact without feeling slow
+const CAPTURE_JET_TOTAL = 6.2; // slower sortie so launch, strike, and return are clearly visible on portrait screens
 const CAPTURE_JET_MISSILE_TRAVEL = Math.max(0.28, CAPTURE_JET_TOTAL * (0.96 - 0.56) - 0.1);
 const CAPTURE_HELICOPTER_SPEED_FACTOR = 1; // keep helicopter pacing identical to jet so both share the same visible loop
-const CAPTURE_HELICOPTER_TOTAL = CAPTURE_JET_TOTAL; // helicopter mirrors jet timing and route behavior
+const CAPTURE_HELICOPTER_TOTAL = CAPTURE_JET_TOTAL; // helicopter mirrors jet timing so both units remain readable
 const CAPTURE_HELICOPTER_MISSILE_TRAVEL = Math.max(0.28, CAPTURE_HELICOPTER_TOTAL * (0.96 - 0.56) - 0.1);
 const CAPTURE_JET_MISSILE_RELEASE_RATIO = 0.62;
 const CAPTURE_JET_MISSILE_ENTRY_RELEASE_RATIO = 0.56; // release while entering the enemy-side U-turn
@@ -150,6 +150,8 @@ const CAPTURE_VERTICAL_STRIKE_INWARD_DISTANCE = 0.01; // pawn missile rises almo
 const CAPTURE_VERTICAL_STRIKE_ALTITUDE = 0.064; // slightly taller short strike arc so lift-and-drop is more visible
 const CAPTURE_VERTICAL_STRIKE_TOP_OFFSET = 0.062; // emphasize upside-down U before vertical drop
 const CAPTURE_VERTICAL_STRIKE_FINAL_LOCK_RATIO = 0.995; // keep final segment locked longer for pinpoint impacts
+const CAPTURE_VERTICAL_STRIKE_ASCEND_RATIO = 0.34;
+const CAPTURE_VERTICAL_STRIKE_CRUISE_RATIO = 0.72;
 const CAPTURE_RELOAD_SHOW_TIME = 0.58;
 const CAPTURE_PAD_STRIKE_ALTITUDE = CAPTURE_VERTICAL_STRIKE_ALTITUDE; // keep jet/helicopter as low as short-pawn strike
 const CAPTURE_PAD_STRIKE_FORWARD_TILES = 0.09; // keep aircraft path tighter and closer to parking slot
@@ -10016,13 +10018,66 @@ function Chess3D({
       }
       return { pos, next, forward: towardTarget, strikeAnchor: forwardTarget };
     };
+    const getCaptureUShapeStrikePose = ({
+      launchPos,
+      targetPos,
+      progress,
+      altitude = CAPTURE_VERTICAL_STRIKE_ALTITUDE
+    }) => {
+      const toTarget = targetPos.clone().sub(launchPos);
+      toTarget.y = 0;
+      if (toTarget.lengthSq() < 1e-5) {
+        toTarget.set(-Math.sign(launchPos.x || 1), 0, 0);
+      } else {
+        toTarget.normalize();
+      }
+      const liftTop = launchPos.clone();
+      liftTop.y = launchPos.y + altitude;
+      const strikeTop = targetPos.clone();
+      strikeTop.y = Math.max(targetPos.y + CAPTURE_VERTICAL_STRIKE_TOP_OFFSET, launchPos.y + altitude);
+      const travelPlanar = targetPos.clone().sub(launchPos);
+      travelPlanar.y = 0;
+      const cruiseTarget = liftTop.clone().addScaledVector(toTarget, travelPlanar.length());
+      cruiseTarget.x = targetPos.x;
+      cruiseTarget.z = targetPos.z;
+      const u = clamp01(progress);
+      let pos = launchPos.clone();
+      let next = launchPos.clone().add(new THREE.Vector3(0.05, 0, 0));
+      if (u < CAPTURE_VERTICAL_STRIKE_ASCEND_RATIO) {
+        const su = smoothEase(u / Math.max(0.001, CAPTURE_VERTICAL_STRIKE_ASCEND_RATIO));
+        pos = launchPos.clone().lerp(liftTop, su);
+        next = launchPos.clone().lerp(liftTop, clamp01(su + 0.06));
+      } else if (u < CAPTURE_VERTICAL_STRIKE_CRUISE_RATIO) {
+        const su = smoothEase(
+          (u - CAPTURE_VERTICAL_STRIKE_ASCEND_RATIO) /
+            Math.max(0.001, CAPTURE_VERTICAL_STRIKE_CRUISE_RATIO - CAPTURE_VERTICAL_STRIKE_ASCEND_RATIO)
+        );
+        pos = liftTop.clone().lerp(cruiseTarget, su);
+        next = liftTop.clone().lerp(cruiseTarget, clamp01(su + 0.05));
+      } else {
+        const su = smoothEase(
+          (u - CAPTURE_VERTICAL_STRIKE_CRUISE_RATIO) / Math.max(0.001, 1 - CAPTURE_VERTICAL_STRIKE_CRUISE_RATIO)
+        );
+        if (su >= CAPTURE_VERTICAL_STRIKE_FINAL_LOCK_RATIO) {
+          pos = targetPos.clone();
+          next = targetPos.clone();
+        } else {
+          pos = strikeTop.clone().lerp(targetPos, su);
+          next = strikeTop.clone().lerp(targetPos, clamp01(su + 0.06));
+        }
+        next.x = pos.x;
+        next.z = pos.z;
+      }
+      constrainInsideBoardPerimeter(pos, CAPTURE_AIR_STRIKE_PATH_EDGE_MARGIN_TILES + 0.2);
+      constrainInsideBoardPerimeter(next, CAPTURE_AIR_STRIKE_PATH_EDGE_MARGIN_TILES + 0.2);
+      return { pos, next };
+    };
     const getCaptureShortMissilePose = ({ launchPos, targetPos, progress, altitude = CAPTURE_VERTICAL_STRIKE_ALTITUDE }) =>
-      getCaptureDirectStrikePose({
+      getCaptureUShapeStrikePose({
         launchPos,
         targetPos,
         progress,
-        altitude,
-        verticalCrash: true
+        altitude
       });
     const getCaptureAirStrikePose = ({ launchPos, targetPos, progress, returnToOrigin = false }) =>
       getCaptureLoopPose({
@@ -10119,10 +10174,8 @@ function Chess3D({
           const parkedDrone = acquireParkedAirUnit(isWhiteSide, 'drone');
           const droneFx = parkedDrone || createFxDrone({ forceProcedural: true });
           droneFx.root.scale.setScalar(CAPTURE_DRONE_SCALE);
-          const liveLaunchPos = getLiveLaunchPosition(fromPos, movingMesh, 0);
-          const launchBase =
-            parkedDrone?.homePosition?.clone?.() ||
-            getAirPadAnchor(isWhiteSide, 'drone', 0, liveLaunchPos).clone();
+          const liveLaunchPos = getLiveLaunchPosition(fromPos, movingMesh, 0.02);
+          const launchBase = liveLaunchPos.clone();
           if (!parkedDrone) {
             droneFx.root.position.copy(launchBase.clone());
             captureFxGroup.add(droneFx.root);
@@ -10141,7 +10194,7 @@ function Chess3D({
             sourceUnit: parkedDrone,
             droneFx,
             verticalStrike: true,
-            launchFromLivePiece: false
+            launchFromLivePiece: true
           });
           return waitForExplosion(CAPTURE_GROUND_TOTAL * 1000);
         }
@@ -11480,6 +11533,7 @@ function Chess3D({
         if (captureResolveDelayMs > 0) {
           moveDelayMs = Math.max(moveDelayMs, captureResolveDelayMs);
         }
+        moveDelayMs = Math.max(moveDelayMs, captureResolveDelayMs + 60);
         const moveCapturedPieceToZone = () => {
           const capturingWhite = board[rr][cc]?.w ?? board[sel.r][sel.c].w;
           const zone = capturingWhite ? capturedByWhite : capturedByBlack;
@@ -12144,12 +12198,11 @@ function Chess3D({
               pose = { pos: launchPos.clone(), next: launchPos.clone().add(new THREE.Vector3(0.05, 0, 0)) };
             } else if (fx.t < impactTime) {
               const mu = smoothEase((fx.t - CAPTURE_GROUND_FIRE_TIME) / CAPTURE_GROUND_TRAVEL_TIME);
-              pose = getCaptureDirectStrikePose({
+              pose = getCaptureShortMissilePose({
                 launchPos,
                 targetPos: fx.to,
                 progress: mu,
-                altitude: CAPTURE_DRONE_STRIKE_ALTITUDE,
-                verticalCrash: Boolean(fx.verticalStrike)
+                altitude: CAPTURE_DRONE_STRIKE_ALTITUDE
               });
             }
             if (!pose) {
@@ -12202,12 +12255,12 @@ function Chess3D({
               ? fx.launchPos.clone()
               : getLiveLaunchPosition(fx.launchPos, fx.movingMesh, 0);
             if (!fx.returnToOrigin || fx.launchFromLivePiece) fx.launchPos.copy(launchPos);
-            const { pos: jetPos, next: jetNext } = getCaptureAirStrikePose({
+            const { pos: jetPos, next: jetNext } = getCapturePadStrikePose({
               launchPos,
               targetPos: fx.to,
               progress: jetTimelineU,
-              returnToOrigin: true,
-              sideSign: fx.sideSign ?? 1
+              altitude: CAPTURE_PAD_STRIKE_ALTITUDE,
+              forwardTiles: CAPTURE_PAD_STRIKE_FORWARD_TILES
             });
             fx.jetFx.root.position.copy(constrainInsideBoardPerimeter(jetPos));
             captureDir.copy(jetNext).sub(jetPos).normalize();
@@ -12295,12 +12348,12 @@ function Chess3D({
               ? fx.launchPos.clone()
               : getLiveLaunchPosition(fx.launchPos, fx.movingMesh, 0);
             if (!fx.returnToOrigin || fx.launchFromLivePiece) fx.launchPos.copy(launchPos);
-            const { pos: heliPos, next: heliNext } = getCaptureAirStrikePose({
+            const { pos: heliPos, next: heliNext } = getCapturePadStrikePose({
               launchPos,
               targetPos: fx.to,
               progress: heliTimelineU,
-              returnToOrigin: true,
-              sideSign: fx.sideSign ?? 1
+              altitude: CAPTURE_PAD_STRIKE_ALTITUDE,
+              forwardTiles: CAPTURE_PAD_STRIKE_FORWARD_TILES
             });
             fx.helicopterFx.root.position.copy(constrainInsideBoardPerimeter(heliPos));
             captureDir.copy(heliNext).sub(heliPos).normalize();
@@ -12407,12 +12460,11 @@ function Chess3D({
               });
             } else if (fx.t < impactTime) {
               const mu = smoothEase((fx.t - CAPTURE_GROUND_FIRE_TIME) / CAPTURE_GROUND_TRAVEL_TIME);
-              const { pos: missilePos, next: missileNext } = getCaptureDirectStrikePose({
+              const { pos: missilePos, next: missileNext } = getCaptureShortMissilePose({
                 launchPos,
                 targetPos: fx.to,
                 progress: mu,
-                altitude: CAPTURE_DRONE_STRIKE_ALTITUDE,
-                verticalCrash: Boolean(fx.verticalStrike)
+                altitude: CAPTURE_DRONE_STRIKE_ALTITUDE
               });
 
               fx.missileFx.root.visible = true;


### PR DESCRIPTION
### Motivation
- Fix several capture animation issues so attackers move after explosions complete and targets are removed before attacker advance. 
- Make drone launches originate from the attacker’s live piece position and fly a readable upside-down U-shaped path (lift → cruise → vertical crash). 
- Unify short/long missile trajectories so pawn/truck missiles and drone strikes share the same flight profile and timing. 
- Slow and anchor jet/helicopter sorties so their launch, strike, and return are visible and they land back on their parked pads.

### Description
- Increased `CAPTURE_JET_TOTAL` to slow sortie pacing and added vertical-strike timing constants `CAPTURE_VERTICAL_STRIKE_ASCEND_RATIO` and `CAPTURE_VERTICAL_STRIKE_CRUISE_RATIO` to control U-shaped strike phases. 
- Implemented `getCaptureUShapeStrikePose` and routed short/precision strikes through it by replacing direct vertical-strike calls with `getCaptureShortMissilePose` that uses the U-shaped solver. 
- Changed drone launch mapping to use the live attacker position (`getLiveLaunchPosition(..., 0.02)`) as the immediate launch base and set `launchFromLivePiece: true` so drones lift from the piece then cruise to the target. 
- Switched jet/helicopter flight to pad-based strike poses (`getCapturePadStrikePose`) so they visibly launch from and return to their parked origin, and adjusted missile launch/pose code accordingly. 
- Enforced capture ordering by extending `moveDelayMs` (added a small offset) so captured target is moved off-board before the attacker mesh advances.

### Testing
- Ran `git diff --check` which returned no problems. 
- Ran `npx eslint --no-ignore webapp/src/pages/Games/ChessBattleRoyal.jsx` and received an ignore warning for the file path but no syntax errors from the runner. 
- Committed changes to `webapp/src/pages/Games/ChessBattleRoyal.jsx` and validated the diff and commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e71775107883299a02aa0ec4311fbd)