### PR TITLE
Adjust Murlan seat and hand card positioning for portrait view

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2324,7 +2324,7 @@ const HUMAN_HAND_FAN_ARC_LIFT = 0;
 const HUMAN_HAND_FAN_DIRECTION = 1;
 const HUMAN_HAND_UNIFORM_YAW_FROM_LEFT = true;
 const HUMAN_HAND_CLOSER_OFFSET = 0.42 * MODEL_SCALE; // Pull bottom-seat hand/cards much closer to table center for tighter portrait framing.
-const HUMAN_HAND_BOTTOM_SHIFT_Y = -0.24 * MODEL_SCALE;
+const HUMAN_HAND_BOTTOM_SHIFT_Y = -0.32 * MODEL_SCALE;
 const AI_HAND_BOTTOM_SHIFT_Y = -0.08 * MODEL_SCALE;
 const AI_HAND_CLOSER_OFFSET = 0.12 * MODEL_SCALE;
 const HUMAN_HAND_LEFT_SHIFT = 0.06 * MODEL_SCALE;
@@ -2336,7 +2336,8 @@ const AI_HAND_CARD_SPACING = HUMAN_HAND_CARD_SPACING;
 const AI_HAND_CARD_MAX_SPREAD = HUMAN_HAND_CARD_MAX_SPREAD;
 const AI_HAND_FAN_MAX_YAW = HUMAN_HAND_FAN_MAX_YAW;
 const AI_HAND_FAN_ARC_LIFT = HUMAN_HAND_FAN_ARC_LIFT;
-const HUMAN_HAND_TABLE_EDGE_MARGIN = CARD_H * 0.24;
+const HUMAN_HAND_TABLE_EDGE_MARGIN = CARD_H * 0.04;
+const HUMAN_HAND_EXTRA_INWARD_PULL = 0.36 * MODEL_SCALE;
 const AI_HAND_TABLE_EDGE_MARGIN = CARD_H * 0.38;
 const COMMUNITY_CARD_TOP_TILT = THREE.MathUtils.degToRad(12);
 const COMMUNITY_CARD_SCALE = 1.08;
@@ -2356,7 +2357,7 @@ const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 0.85 - 0.06 * MOD
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
 const CHAIR_GROUND_DROP = 0.018 * MODEL_SCALE;
 const CHAIR_SCREEN_LOWER_OFFSET = 0.092 * MODEL_SCALE; // Extra grounding so chair legs stay visually planted on the HDRI floor.
-const HUMAN_CHAIR_EXTRA_INWARD_OFFSET = 1.52 * MODEL_SCALE; // Pull only the bottom player's chair further inward so it sits closer to the table edge.
+const HUMAN_CHAIR_EXTRA_INWARD_OFFSET = 1.9 * MODEL_SCALE; // Pull only the bottom player's chair further inward so it sits closer to the table edge.
 const TABLE_HEIGHT_LIFT = 0.008 * MODEL_SCALE;
 const TABLE_HEIGHT = STOOL_HEIGHT + TABLE_HEIGHT_LIFT;
 const TABLE_SIDE_TRIM_SCALE = 0.86;
@@ -3708,6 +3709,9 @@ export default function MurlanRoyaleArena({ search }) {
         }
         const target = forward.clone().multiplyScalar(radial).addScaledVector(layoutAxis, lateral);
         target.addScaledVector(forward, isHumanCard ? HUMAN_HAND_CLOSER_OFFSET : AI_HAND_CLOSER_OFFSET);
+        if (isHumanCard) {
+          target.addScaledVector(forward, -HUMAN_HAND_EXTRA_INWARD_PULL);
+        }
         target.addScaledVector(layoutAxis, isHumanCard ? HUMAN_HAND_LEFT_SHIFT : AI_HAND_LEFT_SHIFT);
         target.y =
           baseHeight +


### PR DESCRIPTION
### Motivation
- Improve portrait gameplay framing by moving the human player's held cards visually lower and closer to the table so they render in front of the chair instead of behind/outward.
- Make the bottom (human) chair sit closer to the table edge so its perceived distance matches other seats and keeps a consistent composition.

### Description
- Updated hand vertical offset by changing `HUMAN_HAND_BOTTOM_SHIFT_Y` from `-0.24 * MODEL_SCALE` to `-0.32 * MODEL_SCALE` to lower the human player's cards on screen.
- Reduced inward table edge margin for human hands by changing `HUMAN_HAND_TABLE_EDGE_MARGIN` from `CARD_H * 0.24` to `CARD_H * 0.04` and added `HUMAN_HAND_EXTRA_INWARD_PULL = 0.36 * MODEL_SCALE` to explicitly pull human hand card targets inward.
- Applied the extra inward pull to human hand card target calculation with `target.addScaledVector(forward, -HUMAN_HAND_EXTRA_INWARD_PULL)` so cards sit in front of the chair.
- Increased `HUMAN_CHAIR_EXTRA_INWARD_OFFSET` from `1.52 * MODEL_SCALE` to `1.9 * MODEL_SCALE` so the bottom (human) chair is positioned closer to the table.
- All changes applied in `webapp/src/pages/Games/MurlanRoyaleArena.jsx`.

### Testing
- Ran the unit test matching `murlan.test.js` with `npm run -s test -- murlan.test.js` and the test suite passed (`1` suite, `12` tests all green).
- No automated visual tests were available in this environment, so visual verification should be performed in a device/browser to confirm final layout in portrait mode.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e71b0fff008329b31c75e2cb84ec3d)