### PR TITLE
Improve Pool Royale cue strike visibility and timing

### DIFF
--- a/test/poolRoyaleCueStrokeTimeline.test.js
+++ b/test/poolRoyaleCueStrokeTimeline.test.js
@@ -13,13 +13,16 @@ describe('Pool Royale cue stroke timeline', () => {
     expect(sample.t).toBeCloseTo(0.2, 2);
   });
 
-  it('arms impact exactly when release reaches the start contact position', () => {
-    const preHit = sampleCueStrokeTimeline({ elapsed: 299, ...options });
-    const atHit = sampleCueStrokeTimeline({ elapsed: 300, ...options });
-    expect(preHit.phase).toBe('release');
-    expect(preHit.hitArmed).toBe(false);
-    expect(atHit.phase).toBe('release');
-    expect(atHit.hitArmed).toBe(true);
+  it('arms impact during the dedicated strike window before hold begins', () => {
+    const preStrike = sampleCueStrokeTimeline({ elapsed: 277, ...options });
+    const strikeStart = sampleCueStrokeTimeline({ elapsed: 278, ...options });
+    const armedStrike = sampleCueStrokeTimeline({ elapsed: 282, ...options });
+    expect(preStrike.phase).toBe('release');
+    expect(preStrike.hitArmed).toBe(false);
+    expect(strikeStart.phase).toBe('strike');
+    expect(strikeStart.hitArmed).toBe(false);
+    expect(armedStrike.phase).toBe('strike');
+    expect(armedStrike.hitArmed).toBe(true);
   });
 
   it('keeps spring release monotonic so cue does not snap backward mid-push', () => {
@@ -28,7 +31,7 @@ describe('Pool Royale cue stroke timeline', () => {
     const late = sampleCueStrokeTimeline({ elapsed: 295, ...options, animationStyle: 'spring' });
     expect(early.phase).toBe('release');
     expect(middle.phase).toBe('release');
-    expect(late.phase).toBe('release');
+    expect(late.phase).toBe('strike');
     expect(early.t).toBeLessThanOrEqual(middle.t + 1e-9);
     expect(middle.t).toBeLessThanOrEqual(late.t + 1e-9);
   });

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -22946,14 +22946,26 @@ const powerRef = useRef(hud.power);
             })();
             const wobble = Math.sin(sample.t * Math.PI) * (wobbleAmount ?? 0.0018);
             cueStick.position.lerpVectors(pullPos, impactPos, eased);
-            cueStick.position.y -= (strikeDip ?? 0.003) * eased;
+            cueStick.position.y -= (strikeDip ?? 0.003) * eased * 0.72;
             cueStick.rotation.x = baseRotationX ?? cueStick.rotation.x;
             cueStick.rotation.y = (baseRotationY ?? cueStick.rotation.y) + wobble;
             syncCueShadow();
             return true;
           }
+          if (sample.phase === 'strike') {
+            const punchT = 1 - Math.pow(1 - THREE.MathUtils.clamp(sample.t, 0, 1), 4);
+            const contactPos = stroke.contactPos ?? impactPos;
+            cueStick.position.lerpVectors(impactPos, contactPos, punchT);
+            cueStick.position.y -= (strikeDip ?? 0.003) * (0.72 + punchT * 0.38);
+            cueStick.rotation.x = baseRotationX ?? cueStick.rotation.x;
+            cueStick.rotation.y =
+              (baseRotationY ?? cueStick.rotation.y) +
+              Math.sin(punchT * Math.PI) * (wobbleAmount ?? 0.0018) * 0.48;
+            syncCueShadow();
+            return true;
+          }
           if (sample.phase === 'hold') {
-            cueStick.position.copy(followPos ?? impactPos);
+            cueStick.position.copy(followPos ?? stroke.contactPos ?? impactPos);
             cueStick.rotation.x = baseRotationX ?? cueStick.rotation.x;
             cueStick.rotation.y = baseRotationY ?? cueStick.rotation.y;
             syncCueShadow();
@@ -26787,8 +26799,8 @@ const powerRef = useRef(hud.power);
           const startTime = performance.now();
           const impactPos = idlePos.clone();
           const contactAdvance = THREE.MathUtils.lerp(
-            0.0035,
-            0.009,
+            BALL_R * 0.28,
+            BALL_R * 0.62,
             clampedPower
           );
           const contactPos = impactPos

--- a/webapp/src/pages/Games/poolRoyaleCueStrokeTimeline.js
+++ b/webapp/src/pages/Games/poolRoyaleCueStrokeTimeline.js
@@ -6,7 +6,9 @@ export const sampleCueStrokeTimeline = ({
   strikeDuration = 120,
   holdDuration = 50,
   recoverDuration = 0,
-  animationStyle = 'classic'
+  animationStyle = 'classic',
+  strikeWindowRatio = 0.22,
+  hitArmRatio = 0.82
 } = {}) => {
   const pullback = Math.max(0, pullbackDuration ?? 0)
   const release = Math.max(0, strikeDuration ?? 120)
@@ -25,6 +27,9 @@ export const sampleCueStrokeTimeline = ({
   if (safeElapsed <= releaseEnd && release > 0) {
     const releaseElapsed = safeElapsed - pullEnd
     const baseT = THREE.MathUtils.clamp(releaseElapsed / Math.max(release, 1e-6), 0, 1)
+    const strikeShare = THREE.MathUtils.clamp(strikeWindowRatio, 0.05, 0.45)
+    const strikeStartT = 1 - strikeShare
+    const hitT = THREE.MathUtils.clamp(hitArmRatio, strikeStartT, 0.98)
     const styleT = (() => {
       switch (animationStyle) {
         case 'linear':
@@ -44,11 +49,21 @@ export const sampleCueStrokeTimeline = ({
           return 1 - Math.pow(1 - baseT, 3)
       }
     })()
+    if (baseT < strikeStartT) {
+      const releaseT = THREE.MathUtils.clamp(baseT / Math.max(strikeStartT, 1e-6), 0, 1)
+      const easedReleaseT = 1 - Math.pow(1 - releaseT, 2)
+      return {
+        phase: 'release',
+        t: easedReleaseT,
+        hitArmed: false,
+        done: false
+      }
+    }
+    const strikeT = THREE.MathUtils.clamp((baseT - strikeStartT) / Math.max(strikeShare, 1e-6), 0, 1)
     return {
-      phase: 'release',
-      t: styleT,
-      // Cue-ball movement starts only after the cue returns to the start contact point.
-      hitArmed: safeElapsed >= pullEnd + release,
+      phase: 'strike',
+      t: Math.max(styleT, strikeT),
+      hitArmed: baseT >= hitT,
       done: false
     }
   }


### PR DESCRIPTION
### Motivation

- The cue animation felt visually unconvincing because the forward stroke and impact were not explicitly represented, causing the cue tip to appear pulled back instead of visibly striking the cue ball.

### Description

- Add a dedicated `strike` phase and window controls to the cue timeline with new parameters `strikeWindowRatio` and `hitArmRatio` in `webapp/src/pages/Games/poolRoyaleCueStrokeTimeline.js` so forward motion is split into `release -> strike -> hold` and the hit can be armed during visible punch-through.
- Update in-game animation in `webapp/src/pages/Games/PoolRoyale.jsx` to render the `strike` phase (interpolating `impactPos -> contactPos` with punch easing and controlled wobble) and tweak vertical dip scaling so the tip contact reads more clearly.
- Increase the contact advance distance by using `BALL_R` scaling in `PoolRoyale.jsx` so the blue tip impact shows up across camera distances and power levels (replaced small absolute offsets with `THREE.MathUtils.lerp(BALL_R * 0.28, BALL_R * 0.62, clampedPower)`).
- Update tests in `test/poolRoyaleCueStrokeTimeline.test.js` to validate the new `strike` phase timing and hit-arming behavior.

### Testing

- Ran `npm test -- test/poolRoyaleCueStrokeTimeline.test.js test/cueShotImpact.test.js` and both suites passed.
- Unit tests updated to assert `release -> strike -> hold` sequencing and `hitArmed` transitions and reported all tests green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7216f1ec08329840682b2b9960b08)