### PR TITLE
Adjust parked weapon placement on Snake board for top-seat alignment

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -260,7 +260,7 @@ const SEAT_RAIL_SLOT_OFFSET = SEAT_RAIL_DICE_GAP * 0.5;
 const SEAT_RAIL_FORWARD_BIAS = TILE_SIZE * 0.08;
 // Seat-aware slot signs (portrait): 0=bottom, 1=right, 2=top, 3=left.
 const TOKEN_SLOT_SIDE_SIGN_BY_SEAT = Object.freeze([-1, 1, -1, 1]);
-const WEAPON_SLOT_SIDE_SIGN_BY_SEAT = Object.freeze([-1, 1, 0, 1]);
+const WEAPON_SLOT_SIDE_SIGN_BY_SEAT = Object.freeze([-1, 1, -1, 1]);
 const TOKEN_SLOT_LATERAL_NUDGE_BY_SEAT = Object.freeze([
   TILE_SIZE * 0.06,
   0,
@@ -270,17 +270,17 @@ const TOKEN_SLOT_LATERAL_NUDGE_BY_SEAT = Object.freeze([
 const WEAPON_SLOT_LATERAL_NUDGE_BY_SEAT = Object.freeze([
   0,
   0,
-  0,
+  TILE_SIZE * 0.22,
   0
 ]);
 const WEAPON_DISPLAY_SIZE_MULTIPLIER = 1.4;
-const WEAPON_PARKING_OUTWARD_OFFSET = TILE_SIZE * 0.14;
+const WEAPON_PARKING_OUTWARD_OFFSET = TILE_SIZE * 0.06;
 const WEAPON_FROM_TOKEN_CENTER_OFFSET = TOKEN_RADIUS * 0.58;
 const WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT = Object.freeze([
-  0,
-  -TILE_SIZE * 0.34,
-  -TILE_SIZE * 0.42,
-  -TILE_SIZE * 0.48
+  -TILE_SIZE * 0.18,
+  -TILE_SIZE * 0.46,
+  TILE_SIZE * 0.18,
+  -TILE_SIZE * 0.58
 ]);
 const WEAPON_TOKEN_GAP = TILE_SIZE * 0.004;
 const WEAPON_PARKED_Y_DROP_BY_KIND = Object.freeze({
@@ -290,12 +290,12 @@ const WEAPON_PARKED_Y_DROP_BY_KIND = Object.freeze({
   supportTruck: TOKEN_HEIGHT * 1.78,
   javelin: TOKEN_HEIGHT * 1.72
 });
-const WEAPON_REST_HEIGHT_OFFSET = -TOKEN_HEIGHT * 1.34;
+const WEAPON_REST_HEIGHT_OFFSET = -TOKEN_HEIGHT * 1.52;
 const WEAPON_REST_HEIGHT_OFFSET_BY_SEAT = Object.freeze([
-  0,
-  -TOKEN_HEIGHT * 0.22,
-  -TOKEN_HEIGHT * 1.12,
-  -TOKEN_HEIGHT * 0.22
+  -TOKEN_HEIGHT * 0.08,
+  -TOKEN_HEIGHT * 0.3,
+  -TOKEN_HEIGHT * 1.36,
+  -TOKEN_HEIGHT * 0.32
 ]);
 
 const PAVEMENT_EXTRA_SCALE = 1.18;


### PR DESCRIPTION
### Motivation
- Parked weapon props in the Snake arena need to align visually with the portrait top-seat chairs, be pulled inward toward the table rim, and sit lower so they match the chair vertical direction and framing.

### Description
- Tuned seat-aware placement constants in `webapp/src/components/SnakeBoard3D.jsx` so the top-seat weapon now uses a left/right side sign instead of centering (`WEAPON_SLOT_SIDE_SIGN_BY_SEAT`).
- Added a lateral nudge for the top seat and reduced the global outward offset to pull parked weapons inward (`WEAPON_SLOT_LATERAL_NUDGE_BY_SEAT`, `WEAPON_PARKING_OUTWARD_OFFSET`, `WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT`).
- Lowered the resting height globally and retuned per-seat resting offsets so parked rigs sit visibly lower relative to the table/chairs (`WEAPON_REST_HEIGHT_OFFSET`, `WEAPON_REST_HEIGHT_OFFSET_BY_SEAT`).

### Testing
- Ran `npx eslint webapp/src/components/SnakeBoard3D.jsx` which produced no lint errors (file is ignored by project ESLint rules and only returned a file-ignore warning). 
- Ran `npm run -s lint -- webapp/src/components/SnakeBoard3D.jsx` which emitted the environment lint warning but no blocking errors. 
- Ran `npm test -- --runInBand test/snakeGame.test.js` and observed test failures, but those failures are from pre-existing snake game logic assertions unrelated to this visual/positioning change (tests did not indicate new regressions caused by these constant tweaks).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e736a149cc8329a52f17e5422d751d)