### PR TITLE
Refine Chess 3D capture animations: timing, flight profiles, and eject synchronization

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -99,16 +99,16 @@ const CAPTURE_DRONE_TOTAL = CAPTURE_DRONE_LIFT_TIME + CAPTURE_DRONE_CRUISE_TIME 
 const CAPTURE_JET_SPEED_FACTOR = 4.9 / CAPTURE_DRONE_TOTAL; // slower than prior tuning for clearer portrait tracking
 const PROFILE_VIEW_ROTATION_TYPES = new Set(['K', 'N']);
 const PROFILE_VIEW_ROTATION_RADIANS = Math.PI / 2;
-const CAPTURE_JET_TOTAL = 4.2; // balanced pacing: readable impact without feeling slow
+const CAPTURE_JET_TOTAL = 8.2; // extra-long sortie so jet launch/fly/return remains clearly visible on mobile portrait
 const CAPTURE_JET_MISSILE_TRAVEL = Math.max(0.28, CAPTURE_JET_TOTAL * (0.96 - 0.56) - 0.1);
 const CAPTURE_HELICOPTER_SPEED_FACTOR = 1; // keep helicopter pacing identical to jet so both share the same visible loop
-const CAPTURE_HELICOPTER_TOTAL = CAPTURE_JET_TOTAL; // helicopter mirrors jet timing and route behavior
+const CAPTURE_HELICOPTER_TOTAL = 8.8; // helicopter is slightly slower than jet for easier visual tracking
 const CAPTURE_HELICOPTER_MISSILE_TRAVEL = Math.max(0.28, CAPTURE_HELICOPTER_TOTAL * (0.96 - 0.56) - 0.1);
 const CAPTURE_JET_MISSILE_RELEASE_RATIO = 0.62;
 const CAPTURE_JET_MISSILE_ENTRY_RELEASE_RATIO = 0.56; // release while entering the enemy-side U-turn
 const CAPTURE_JET_TRIMMED_START_RATIO = 0; // keep takeoff visible from the live piece location
-const CAPTURE_GROUND_FIRE_TIME = 0.22; // quick ignition before short vertical strike
-const CAPTURE_DRONE_STRIKE_TRAVEL_TIME = 1.24; // normal-speed strike pacing for readable but snappy impacts
+const CAPTURE_GROUND_FIRE_TIME = 0.34; // longer ignition so launch point is readable
+const CAPTURE_DRONE_STRIKE_TRAVEL_TIME = 1.82; // slower precision strike for clear upside-down U motion
 const CAPTURE_GROUND_TRAVEL_TIME = CAPTURE_DRONE_STRIKE_TRAVEL_TIME; // keep pawn javelin/truck missiles in sync with drone strike timing
 const CAPTURE_GROUND_TOTAL = CAPTURE_GROUND_FIRE_TIME + CAPTURE_GROUND_TRAVEL_TIME;
 const CAPTURE_GROUND_CONTACT_RADIUS = 0.004; // ultra-tight contact radius so missiles lock onto target precisely
@@ -150,13 +150,18 @@ const CAPTURE_VERTICAL_STRIKE_INWARD_DISTANCE = 0.01; // pawn missile rises almo
 const CAPTURE_VERTICAL_STRIKE_ALTITUDE = 0.064; // slightly taller short strike arc so lift-and-drop is more visible
 const CAPTURE_VERTICAL_STRIKE_TOP_OFFSET = 0.062; // emphasize upside-down U before vertical drop
 const CAPTURE_VERTICAL_STRIKE_FINAL_LOCK_RATIO = 0.995; // keep final segment locked longer for pinpoint impacts
+const CAPTURE_VERTICAL_STRIKE_ASCEND_RATIO = 0.34;
+const CAPTURE_VERTICAL_STRIKE_CRUISE_RATIO = 0.72;
+const CHESS_CAPTURE_EXPLOSION_DURATION_MS = LUDO_CAPTURE_EXPLOSION_TIME * 1000;
+const CHESS_CAPTURE_EJECT_BUFFER_MS = 24;
+const CHESS_CAPTURE_ATTACKER_BUFFER_MS = 34;
 const CAPTURE_RELOAD_SHOW_TIME = 0.58;
-const CAPTURE_PAD_STRIKE_ALTITUDE = CAPTURE_VERTICAL_STRIKE_ALTITUDE; // keep jet/helicopter as low as short-pawn strike
-const CAPTURE_PAD_STRIKE_FORWARD_TILES = 0.09; // keep aircraft path tighter and closer to parking slot
-const CAPTURE_PAD_STRIKE_ASCEND_RATIO = 0.84; // much slower liftoff so aircraft visibly rise from parking spot
-const CAPTURE_PAD_STRIKE_HOVER_RATIO = 0.9;
-const CAPTURE_PAD_STRIKE_RETURN_RATIO = 0.95;
-const CAPTURE_PAD_MISSILE_RELEASE_RATIO = 0.64; // fire near shared strike latitude, then return to parking side instead of dive-crashing
+const CAPTURE_PAD_STRIKE_ALTITUDE = 0.22; // aircraft fly lower than drone but still clearly above board
+const CAPTURE_PAD_STRIKE_FORWARD_TILES = 3.05; // make jet/helicopter visibly cross the board before firing
+const CAPTURE_PAD_STRIKE_ASCEND_RATIO = 0.32;
+const CAPTURE_PAD_STRIKE_HOVER_RATIO = 0.62;
+const CAPTURE_PAD_STRIKE_RETURN_RATIO = 0.9;
+const CAPTURE_PAD_MISSILE_RELEASE_RATIO = 0.56; // release while aircraft are clearly over board path
 const CAPTURE_PAD_MISSILE_TRAVEL_TIME = 1.2; // normal-speed travel synced with fly-by
 const CAPTURE_PAD_MISSILE_FORWARD_OFFSET = 0.03; // fire a bit ahead of aircraft center
 const CAPTURE_PAD_MISSILE_LIFT_OFFSET = 0.003; // keep launch altitude low and close to aircraft body
@@ -9689,6 +9694,18 @@ function Chess3D({
       const bc = new THREE.Vector3().copy(b).lerp(c, t);
       return ab.lerp(bc, t);
     };
+    const CHESS_CAPTURE_FLIGHT_PROFILE = Object.freeze({
+      shortStrikeAltitude: CAPTURE_DRONE_STRIKE_ALTITUDE,
+      shortStrikeAscendRatio: CAPTURE_VERTICAL_STRIKE_ASCEND_RATIO,
+      shortStrikeCruiseRatio: CAPTURE_VERTICAL_STRIKE_CRUISE_RATIO,
+      shortStrikeTopOffset: CAPTURE_VERTICAL_STRIKE_TOP_OFFSET,
+      shortStrikeFinalLockRatio: CAPTURE_VERTICAL_STRIKE_FINAL_LOCK_RATIO,
+      airPadAltitude: CAPTURE_PAD_STRIKE_ALTITUDE,
+      airPadForwardTiles: CAPTURE_PAD_STRIKE_FORWARD_TILES,
+      airPadAscendRatio: CAPTURE_PAD_STRIKE_ASCEND_RATIO,
+      airPadHoverRatio: CAPTURE_PAD_STRIKE_HOVER_RATIO,
+      airPadReturnRatio: CAPTURE_PAD_STRIKE_RETURN_RATIO
+    });
     const constrainInsideBoardPerimeter = (vector, marginTiles = 0.62) => {
       const margin = BOARD.tile * marginTiles;
       const boardHalf = (BOARD.N * BOARD.tile) / 2 - margin;
@@ -9986,43 +10003,109 @@ function Chess3D({
       const liftTarget = launchPos.clone();
       liftTarget.y = launchPos.y + altitude;
       const forwardTarget = liftTarget.clone().addScaledVector(towardTarget, tile * forwardTiles);
+      const targetLane = targetPos.clone();
+      targetLane.y = liftTarget.y;
+      const strikeLane = forwardTarget.clone().lerp(targetLane, 0.76);
+      strikeLane.y = liftTarget.y;
       const u = clamp01(progress);
       let pos = launchPos.clone();
       let next = launchPos.clone().add(new THREE.Vector3(0.04, 0, 0));
       if (u < CAPTURE_PAD_STRIKE_ASCEND_RATIO) {
-        const su = smoothEase(u / Math.max(0.001, CAPTURE_PAD_STRIKE_ASCEND_RATIO));
+        const su = smoothEase(u / Math.max(0.001, CHESS_CAPTURE_FLIGHT_PROFILE.airPadAscendRatio));
         pos = launchPos.clone().lerp(liftTarget, su);
         next = launchPos.clone().lerp(liftTarget, clamp01(su + 0.06));
-      } else if (u < CAPTURE_PAD_STRIKE_HOVER_RATIO) {
+      } else if (u < CHESS_CAPTURE_FLIGHT_PROFILE.airPadHoverRatio) {
         const su = smoothEase(
-          (u - CAPTURE_PAD_STRIKE_ASCEND_RATIO) /
-            Math.max(0.001, CAPTURE_PAD_STRIKE_HOVER_RATIO - CAPTURE_PAD_STRIKE_ASCEND_RATIO)
+          (u - CHESS_CAPTURE_FLIGHT_PROFILE.airPadAscendRatio) /
+            Math.max(0.001, CHESS_CAPTURE_FLIGHT_PROFILE.airPadHoverRatio - CHESS_CAPTURE_FLIGHT_PROFILE.airPadAscendRatio)
         );
-        pos = liftTarget.clone().lerp(forwardTarget, su);
-        next = liftTarget.clone().lerp(forwardTarget, clamp01(su + 0.06));
-      } else if (u < CAPTURE_PAD_STRIKE_RETURN_RATIO) {
+        pos = liftTarget.clone().lerp(strikeLane, su);
+        next = liftTarget.clone().lerp(strikeLane, clamp01(su + 0.06));
+      } else if (u < CHESS_CAPTURE_FLIGHT_PROFILE.airPadReturnRatio) {
         const su = smoothEase(
-          (u - CAPTURE_PAD_STRIKE_HOVER_RATIO) /
-            Math.max(0.001, CAPTURE_PAD_STRIKE_RETURN_RATIO - CAPTURE_PAD_STRIKE_HOVER_RATIO)
+          (u - CHESS_CAPTURE_FLIGHT_PROFILE.airPadHoverRatio) /
+            Math.max(0.001, CHESS_CAPTURE_FLIGHT_PROFILE.airPadReturnRatio - CHESS_CAPTURE_FLIGHT_PROFILE.airPadHoverRatio)
         );
-        pos = forwardTarget.clone().lerp(liftTarget, su);
-        next = forwardTarget.clone().lerp(liftTarget, clamp01(su + 0.06));
+        pos = strikeLane.clone().lerp(liftTarget, su);
+        next = strikeLane.clone().lerp(liftTarget, clamp01(su + 0.06));
       } else {
         const su = smoothEase(
-          (u - CAPTURE_PAD_STRIKE_RETURN_RATIO) / Math.max(0.001, 1 - CAPTURE_PAD_STRIKE_RETURN_RATIO)
+          (u - CHESS_CAPTURE_FLIGHT_PROFILE.airPadReturnRatio) / Math.max(0.001, 1 - CHESS_CAPTURE_FLIGHT_PROFILE.airPadReturnRatio)
         );
         pos = liftTarget.clone().lerp(launchPos, su);
         next = liftTarget.clone().lerp(launchPos, clamp01(su + 0.06));
       }
-      return { pos, next, forward: towardTarget, strikeAnchor: forwardTarget };
+      return { pos, next, forward: towardTarget, strikeAnchor: strikeLane };
     };
-    const getCaptureShortMissilePose = ({ launchPos, targetPos, progress, altitude = CAPTURE_VERTICAL_STRIKE_ALTITUDE }) =>
-      getCaptureDirectStrikePose({
+    const getCaptureUShapeStrikePose = ({
+      launchPos,
+      targetPos,
+      progress,
+      altitude = CHESS_CAPTURE_FLIGHT_PROFILE.shortStrikeAltitude
+    }) => {
+      const toTarget = targetPos.clone().sub(launchPos);
+      toTarget.y = 0;
+      if (toTarget.lengthSq() < 1e-5) {
+        toTarget.set(-Math.sign(launchPos.x || 1), 0, 0);
+      } else {
+        toTarget.normalize();
+      }
+      const liftTop = launchPos.clone();
+      liftTop.y = launchPos.y + altitude;
+      const strikeTop = targetPos.clone();
+      strikeTop.y = Math.max(targetPos.y + CHESS_CAPTURE_FLIGHT_PROFILE.shortStrikeTopOffset, launchPos.y + altitude);
+      const travelPlanar = targetPos.clone().sub(launchPos);
+      travelPlanar.y = 0;
+      const cruiseTarget = liftTop.clone().addScaledVector(toTarget, travelPlanar.length());
+      cruiseTarget.x = targetPos.x;
+      cruiseTarget.z = targetPos.z;
+      const u = clamp01(progress);
+      let pos = launchPos.clone();
+      let next = launchPos.clone().add(new THREE.Vector3(0.05, 0, 0));
+      if (u < CHESS_CAPTURE_FLIGHT_PROFILE.shortStrikeAscendRatio) {
+        const su = smoothEase(u / Math.max(0.001, CHESS_CAPTURE_FLIGHT_PROFILE.shortStrikeAscendRatio));
+        pos = launchPos.clone().lerp(liftTop, su);
+        next = launchPos.clone().lerp(liftTop, clamp01(su + 0.06));
+      } else if (u < CHESS_CAPTURE_FLIGHT_PROFILE.shortStrikeCruiseRatio) {
+        const su = smoothEase(
+          (u - CHESS_CAPTURE_FLIGHT_PROFILE.shortStrikeAscendRatio) /
+            Math.max(
+              0.001,
+              CHESS_CAPTURE_FLIGHT_PROFILE.shortStrikeCruiseRatio - CHESS_CAPTURE_FLIGHT_PROFILE.shortStrikeAscendRatio
+            )
+        );
+        pos = liftTop.clone().lerp(cruiseTarget, su);
+        next = liftTop.clone().lerp(cruiseTarget, clamp01(su + 0.05));
+      } else {
+        const su = smoothEase(
+          (u - CHESS_CAPTURE_FLIGHT_PROFILE.shortStrikeCruiseRatio) /
+            Math.max(0.001, 1 - CHESS_CAPTURE_FLIGHT_PROFILE.shortStrikeCruiseRatio)
+        );
+        if (su >= CHESS_CAPTURE_FLIGHT_PROFILE.shortStrikeFinalLockRatio) {
+          pos = targetPos.clone();
+          next = targetPos.clone();
+        } else {
+          pos = strikeTop.clone().lerp(targetPos, su);
+          next = strikeTop.clone().lerp(targetPos, clamp01(su + 0.06));
+        }
+        next.x = pos.x;
+        next.z = pos.z;
+      }
+      constrainInsideBoardPerimeter(pos, CAPTURE_AIR_STRIKE_PATH_EDGE_MARGIN_TILES + 0.2);
+      constrainInsideBoardPerimeter(next, CAPTURE_AIR_STRIKE_PATH_EDGE_MARGIN_TILES + 0.2);
+      return { pos, next };
+    };
+    const getCaptureShortMissilePose = ({
+      launchPos,
+      targetPos,
+      progress,
+      altitude = CHESS_CAPTURE_FLIGHT_PROFILE.shortStrikeAltitude
+    }) =>
+      getCaptureUShapeStrikePose({
         launchPos,
         targetPos,
         progress,
-        altitude,
-        verticalCrash: true
+        altitude
       });
     const getCaptureAirStrikePose = ({ launchPos, targetPos, progress, returnToOrigin = false }) =>
       getCaptureLoopPose({
@@ -10067,12 +10150,20 @@ function Chess3D({
       deltaR = 0,
       deltaC = 0
     }) => {
-      const afterExplosionDelayMs = LUDO_CAPTURE_EXPLOSION_TIME * 1000;
-      const waitForExplosion = (impactDelayMs) => {
-        const totalDelay = Math.max(0, impactDelayMs) + afterExplosionDelayMs;
+      const waitForExplosion = ({
+        impactDelayMs,
+        targetEjectDelayMs = impactDelayMs,
+        animationDoneDelayMs = impactDelayMs
+      }) => {
+        const impactDelay = Math.max(0, impactDelayMs);
+        const ejectDelay = Math.max(0, targetEjectDelayMs) + CHESS_CAPTURE_EJECT_BUFFER_MS;
+        const postExplosionDelay = impactDelay + CHESS_CAPTURE_EXPLOSION_DURATION_MS + CHESS_CAPTURE_ATTACKER_BUFFER_MS;
+        const attackerDelay = Math.max(postExplosionDelay, Math.max(0, animationDoneDelayMs));
         return {
-          moveDelayMs: totalDelay,
-          captureResolveDelayMs: totalDelay
+          moveDelayMs: attackerDelay,
+          captureResolveDelayMs: ejectDelay,
+          targetEjectDelayMs: ejectDelay,
+          attackerAdvanceDelayMs: attackerDelay
         };
       };
       const pieceType = resolveCaptureAnimationPieceType(
@@ -10110,7 +10201,11 @@ function Chess3D({
           verticalStrike: true,
           launchFromLivePiece: false
         });
-        return waitForExplosion(CAPTURE_GROUND_TOTAL * 1000);
+        return waitForExplosion({
+          impactDelayMs: CAPTURE_GROUND_TOTAL * 1000,
+          targetEjectDelayMs: CAPTURE_GROUND_TOTAL * 1000,
+          animationDoneDelayMs: CAPTURE_GROUND_TOTAL * 1000
+        });
       }
       if (captureAnimationId === 'droneStrike' || captureAnimationId === 'pawnJavelin') {
         if (captureAnimationId === 'droneStrike') {
@@ -10119,10 +10214,8 @@ function Chess3D({
           const parkedDrone = acquireParkedAirUnit(isWhiteSide, 'drone');
           const droneFx = parkedDrone || createFxDrone({ forceProcedural: true });
           droneFx.root.scale.setScalar(CAPTURE_DRONE_SCALE);
-          const liveLaunchPos = getLiveLaunchPosition(fromPos, movingMesh, 0);
-          const launchBase =
-            parkedDrone?.homePosition?.clone?.() ||
-            getAirPadAnchor(isWhiteSide, 'drone', 0, liveLaunchPos).clone();
+          const liveLaunchPos = getLiveLaunchPosition(fromPos, movingMesh, 0.02);
+          const launchBase = liveLaunchPos.clone();
           if (!parkedDrone) {
             droneFx.root.position.copy(launchBase.clone());
             captureFxGroup.add(droneFx.root);
@@ -10141,9 +10234,13 @@ function Chess3D({
             sourceUnit: parkedDrone,
             droneFx,
             verticalStrike: true,
-            launchFromLivePiece: false
+            launchFromLivePiece: true
           });
-          return waitForExplosion(CAPTURE_GROUND_TOTAL * 1000);
+          return waitForExplosion({
+            impactDelayMs: CAPTURE_GROUND_TOTAL * 1000,
+            targetEjectDelayMs: CAPTURE_GROUND_TOTAL * 1000,
+            animationDoneDelayMs: CAPTURE_GROUND_TOTAL * 1000
+          });
         }
         suppressTimerBeepUntilRef.current = performance.now() + CAPTURE_GROUND_TOTAL * 1000;
         const missileFx = createFxGroundMissile();
@@ -10168,7 +10265,11 @@ function Chess3D({
           verticalStrike: true,
           launchFromLivePiece: true
         });
-        return waitForExplosion(CAPTURE_GROUND_TOTAL * 1000);
+        return waitForExplosion({
+          impactDelayMs: CAPTURE_GROUND_TOTAL * 1000,
+          targetEjectDelayMs: CAPTURE_GROUND_TOTAL * 1000,
+          animationDoneDelayMs: CAPTURE_GROUND_TOTAL * 1000
+        });
       }
       if (captureAnimationId === 'kingJetStrike') {
         suppressTimerBeepUntilRef.current = performance.now() + CAPTURE_JET_TOTAL * 1000;
@@ -10216,7 +10317,11 @@ function Chess3D({
           missileFx
         });
         const jetImpactDelayMs = CAPTURE_JET_TOTAL * 0.96 * 1000;
-        return waitForExplosion(jetImpactDelayMs);
+        return waitForExplosion({
+          impactDelayMs: jetImpactDelayMs,
+          targetEjectDelayMs: jetImpactDelayMs,
+          animationDoneDelayMs: CAPTURE_JET_TOTAL * 1000
+        });
       }
       if (captureAnimationId === 'helicopterStrike') {
         suppressTimerBeepUntilRef.current = performance.now() + CAPTURE_HELICOPTER_TOTAL * 1000;
@@ -10269,7 +10374,11 @@ function Chess3D({
           missileFx
         });
         const helicopterImpactDelayMs = CAPTURE_HELICOPTER_TOTAL * 0.96 * 1000;
-        return waitForExplosion(helicopterImpactDelayMs);
+        return waitForExplosion({
+          impactDelayMs: helicopterImpactDelayMs,
+          targetEjectDelayMs: helicopterImpactDelayMs,
+          animationDoneDelayMs: CAPTURE_HELICOPTER_TOTAL * 1000
+        });
       }
       if (captureAnimationId === 'queenJetStrike') {
         suppressTimerBeepUntilRef.current = performance.now() + CAPTURE_JET_TOTAL * 1000;
@@ -10317,7 +10426,11 @@ function Chess3D({
           missileFx
         });
         const jetImpactDelayMs = CAPTURE_JET_TOTAL * 0.96 * 1000;
-        return waitForExplosion(jetImpactDelayMs);
+        return waitForExplosion({
+          impactDelayMs: jetImpactDelayMs,
+          targetEjectDelayMs: jetImpactDelayMs,
+          animationDoneDelayMs: CAPTURE_JET_TOTAL * 1000
+        });
       }
       if (distance <= 1.5) {
         playAudio(swordSoundRef);
@@ -10331,7 +10444,11 @@ function Chess3D({
         missileFx.root.scale.setScalar(CAPTURE_MISSILE_SCALE);
         captureFxGroup.add(missileFx.root);
         activeCaptureFx.push({ type: 'missile', t: 0, duration: LUDO_CAPTURE_MISSILE_TRAVEL_TIME, from: fromPos.clone(), to: targetPos.clone(), missileFx });
-        return waitForExplosion(LUDO_CAPTURE_MISSILE_TRAVEL_TIME * 1000);
+        return waitForExplosion({
+          impactDelayMs: LUDO_CAPTURE_MISSILE_TRAVEL_TIME * 1000,
+          targetEjectDelayMs: LUDO_CAPTURE_MISSILE_TRAVEL_TIME * 1000,
+          animationDoneDelayMs: LUDO_CAPTURE_MISSILE_TRAVEL_TIME * 1000
+        });
       }
       launchExplosion(targetPos.clone());
       return { moveDelayMs: 280 };
@@ -11457,6 +11574,8 @@ function Chess3D({
       const toWorldPos = piecePosition(rr, cc, currentPieceYOffset);
       let moveDelayMs = 0;
       let captureResolveDelayMs = 0;
+      let targetEjectDelayMs = 0;
+      let attackerAdvanceDelayMs = 0;
       // capture mesh if any
       const targetMesh = pieceMeshes[rr][cc];
       if (targetMesh) {
@@ -11474,11 +11593,16 @@ function Chess3D({
         });
         moveDelayMs = Math.max(0, captureFx?.moveDelayMs ?? 0);
         captureResolveDelayMs = Math.max(0, captureFx?.captureResolveDelayMs ?? 0);
+        targetEjectDelayMs = Math.max(0, captureFx?.targetEjectDelayMs ?? captureResolveDelayMs);
+        attackerAdvanceDelayMs = Math.max(0, captureFx?.attackerAdvanceDelayMs ?? moveDelayMs);
         if (moveDelayMs > 0 && captureResolveDelayMs <= 0) {
           captureResolveDelayMs = moveDelayMs;
         }
         if (captureResolveDelayMs > 0) {
           moveDelayMs = Math.max(moveDelayMs, captureResolveDelayMs);
+        }
+        if (attackerAdvanceDelayMs > 0) {
+          moveDelayMs = Math.max(moveDelayMs, attackerAdvanceDelayMs);
         }
         const moveCapturedPieceToZone = () => {
           const capturingWhite = board[rr][cc]?.w ?? board[sel.r][sel.c].w;
@@ -11501,8 +11625,9 @@ function Chess3D({
             forceSway: 0.003
           });
         };
-        if (captureResolveDelayMs > 0) {
-          setTimeout(() => moveCapturedPieceToZone(), captureResolveDelayMs);
+        const ejectDelay = Math.max(targetEjectDelayMs, captureResolveDelayMs);
+        if (ejectDelay > 0) {
+          setTimeout(() => moveCapturedPieceToZone(), ejectDelay);
         } else {
           moveCapturedPieceToZone();
         }
@@ -12144,12 +12269,11 @@ function Chess3D({
               pose = { pos: launchPos.clone(), next: launchPos.clone().add(new THREE.Vector3(0.05, 0, 0)) };
             } else if (fx.t < impactTime) {
               const mu = smoothEase((fx.t - CAPTURE_GROUND_FIRE_TIME) / CAPTURE_GROUND_TRAVEL_TIME);
-              pose = getCaptureDirectStrikePose({
+              pose = getCaptureShortMissilePose({
                 launchPos,
                 targetPos: fx.to,
                 progress: mu,
-                altitude: CAPTURE_DRONE_STRIKE_ALTITUDE,
-                verticalCrash: Boolean(fx.verticalStrike)
+                altitude: CAPTURE_DRONE_STRIKE_ALTITUDE
               });
             }
             if (!pose) {
@@ -12202,12 +12326,12 @@ function Chess3D({
               ? fx.launchPos.clone()
               : getLiveLaunchPosition(fx.launchPos, fx.movingMesh, 0);
             if (!fx.returnToOrigin || fx.launchFromLivePiece) fx.launchPos.copy(launchPos);
-            const { pos: jetPos, next: jetNext } = getCaptureAirStrikePose({
+            const { pos: jetPos, next: jetNext } = getCapturePadStrikePose({
               launchPos,
               targetPos: fx.to,
               progress: jetTimelineU,
-              returnToOrigin: true,
-              sideSign: fx.sideSign ?? 1
+              altitude: CAPTURE_PAD_STRIKE_ALTITUDE,
+              forwardTiles: CAPTURE_PAD_STRIKE_FORWARD_TILES
             });
             fx.jetFx.root.position.copy(constrainInsideBoardPerimeter(jetPos));
             captureDir.copy(jetNext).sub(jetPos).normalize();
@@ -12295,12 +12419,12 @@ function Chess3D({
               ? fx.launchPos.clone()
               : getLiveLaunchPosition(fx.launchPos, fx.movingMesh, 0);
             if (!fx.returnToOrigin || fx.launchFromLivePiece) fx.launchPos.copy(launchPos);
-            const { pos: heliPos, next: heliNext } = getCaptureAirStrikePose({
+            const { pos: heliPos, next: heliNext } = getCapturePadStrikePose({
               launchPos,
               targetPos: fx.to,
               progress: heliTimelineU,
-              returnToOrigin: true,
-              sideSign: fx.sideSign ?? 1
+              altitude: CAPTURE_PAD_STRIKE_ALTITUDE,
+              forwardTiles: CAPTURE_PAD_STRIKE_FORWARD_TILES
             });
             fx.helicopterFx.root.position.copy(constrainInsideBoardPerimeter(heliPos));
             captureDir.copy(heliNext).sub(heliPos).normalize();
@@ -12407,12 +12531,11 @@ function Chess3D({
               });
             } else if (fx.t < impactTime) {
               const mu = smoothEase((fx.t - CAPTURE_GROUND_FIRE_TIME) / CAPTURE_GROUND_TRAVEL_TIME);
-              const { pos: missilePos, next: missileNext } = getCaptureDirectStrikePose({
+              const { pos: missilePos, next: missileNext } = getCaptureShortMissilePose({
                 launchPos,
                 targetPos: fx.to,
                 progress: mu,
-                altitude: CAPTURE_DRONE_STRIKE_ALTITUDE,
-                verticalCrash: Boolean(fx.verticalStrike)
+                altitude: CAPTURE_DRONE_STRIKE_ALTITUDE
               });
 
               fx.missileFx.root.visible = true;


### PR DESCRIPTION
### Motivation

- Improve readability of capture animations (especially on mobile/portrait) by slowing and lengthening flight paths and making strike motions clearer.
- Replace scattered magic timing values with a small, shareable flight profile and explicit eject/attacker buffers to avoid visual and state desyncs during captures.
- Make short strikes use a smoother U-shaped ascent/cruise/lock profile for more readable impacts.

### Description

- Increased and retuned core timing constants such as `CAPTURE_JET_TOTAL`, `CAPTURE_HELICOPTER_TOTAL`, `CAPTURE_GROUND_FIRE_TIME`, and `CAPTURE_DRONE_STRIKE_TRAVEL_TIME` for clearer pacing.  
- Introduced new constants `CAPTURE_VERTICAL_STRIKE_ASCEND_RATIO`, `CAPTURE_VERTICAL_STRIKE_CRUISE_RATIO`, `CHESS_CAPTURE_EXPLOSION_DURATION_MS`, `CHESS_CAPTURE_EJECT_BUFFER_MS`, and `CHESS_CAPTURE_ATTACKER_BUFFER_MS` to control explosion/eject/attacker timing.  
- Added a frozen `CHESS_CAPTURE_FLIGHT_PROFILE` object and migrated pad/short strike pose calculations to reference it; refactored `getCapturePadStrikePose` and implemented a new `getCaptureUShapeStrikePose` (used by `getCaptureShortMissilePose`) for U-shaped ascend/cruise/descent strikes.  
- Reworked `playCaptureAnimation`/`waitForExplosion` to return structured timing information (`moveDelayMs`, `captureResolveDelayMs`, `targetEjectDelayMs`, `attackerAdvanceDelayMs`) and updated callers to respect eject and attacker-advance buffers.  
- Adjusted drone/jet/helicopter behavior to prefer live launch positions (`launchFromLivePiece`), updated missile release math and flight pose usage for jets/helicopters to use pad strike logic, and cleaned up several pose/strike lane computations.  

### Testing

- Ran unit tests with `yarn test`, and all tests passed.  
- Built the production bundle with `yarn build`, and the build completed successfully.  
- Ran the linter with `yarn lint`, and no new lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e71775107883299a02aa0ec4311fbd)