### PR TITLE
Refactor capture flight/timing for chess captures and improve portrait readability

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -99,16 +99,16 @@ const CAPTURE_DRONE_TOTAL = CAPTURE_DRONE_LIFT_TIME + CAPTURE_DRONE_CRUISE_TIME 
 const CAPTURE_JET_SPEED_FACTOR = 4.9 / CAPTURE_DRONE_TOTAL; // slower than prior tuning for clearer portrait tracking
 const PROFILE_VIEW_ROTATION_TYPES = new Set(['K', 'N']);
 const PROFILE_VIEW_ROTATION_RADIANS = Math.PI / 2;
-const CAPTURE_JET_TOTAL = 4.2; // balanced pacing: readable impact without feeling slow
+const CAPTURE_JET_TOTAL = 8.4; // extra-slow sortie for clear visibility on portrait screens
 const CAPTURE_JET_MISSILE_TRAVEL = Math.max(0.28, CAPTURE_JET_TOTAL * (0.96 - 0.56) - 0.1);
 const CAPTURE_HELICOPTER_SPEED_FACTOR = 1; // keep helicopter pacing identical to jet so both share the same visible loop
-const CAPTURE_HELICOPTER_TOTAL = CAPTURE_JET_TOTAL; // helicopter mirrors jet timing and route behavior
+const CAPTURE_HELICOPTER_TOTAL = CAPTURE_JET_TOTAL; // helicopter mirrors jet timing so both units remain readable
 const CAPTURE_HELICOPTER_MISSILE_TRAVEL = Math.max(0.28, CAPTURE_HELICOPTER_TOTAL * (0.96 - 0.56) - 0.1);
 const CAPTURE_JET_MISSILE_RELEASE_RATIO = 0.62;
 const CAPTURE_JET_MISSILE_ENTRY_RELEASE_RATIO = 0.56; // release while entering the enemy-side U-turn
 const CAPTURE_JET_TRIMMED_START_RATIO = 0; // keep takeoff visible from the live piece location
 const CAPTURE_GROUND_FIRE_TIME = 0.22; // quick ignition before short vertical strike
-const CAPTURE_DRONE_STRIKE_TRAVEL_TIME = 1.24; // normal-speed strike pacing for readable but snappy impacts
+const CAPTURE_DRONE_STRIKE_TRAVEL_TIME = 1.78; // slower precision strike so U-shape is clearly visible
 const CAPTURE_GROUND_TRAVEL_TIME = CAPTURE_DRONE_STRIKE_TRAVEL_TIME; // keep pawn javelin/truck missiles in sync with drone strike timing
 const CAPTURE_GROUND_TOTAL = CAPTURE_GROUND_FIRE_TIME + CAPTURE_GROUND_TRAVEL_TIME;
 const CAPTURE_GROUND_CONTACT_RADIUS = 0.004; // ultra-tight contact radius so missiles lock onto target precisely
@@ -150,14 +150,19 @@ const CAPTURE_VERTICAL_STRIKE_INWARD_DISTANCE = 0.01; // pawn missile rises almo
 const CAPTURE_VERTICAL_STRIKE_ALTITUDE = 0.064; // slightly taller short strike arc so lift-and-drop is more visible
 const CAPTURE_VERTICAL_STRIKE_TOP_OFFSET = 0.062; // emphasize upside-down U before vertical drop
 const CAPTURE_VERTICAL_STRIKE_FINAL_LOCK_RATIO = 0.995; // keep final segment locked longer for pinpoint impacts
+const CAPTURE_VERTICAL_STRIKE_ASCEND_RATIO = 0.36;
+const CAPTURE_VERTICAL_STRIKE_CRUISE_RATIO = 0.76;
+const CHESS_CAPTURE_EXPLOSION_DURATION_MS = LUDO_CAPTURE_EXPLOSION_TIME * 1000;
+const CHESS_CAPTURE_EJECT_BUFFER_MS = 24;
+const CHESS_CAPTURE_ATTACKER_BUFFER_MS = 34;
 const CAPTURE_RELOAD_SHOW_TIME = 0.58;
-const CAPTURE_PAD_STRIKE_ALTITUDE = CAPTURE_VERTICAL_STRIKE_ALTITUDE; // keep jet/helicopter as low as short-pawn strike
-const CAPTURE_PAD_STRIKE_FORWARD_TILES = 0.09; // keep aircraft path tighter and closer to parking slot
-const CAPTURE_PAD_STRIKE_ASCEND_RATIO = 0.84; // much slower liftoff so aircraft visibly rise from parking spot
-const CAPTURE_PAD_STRIKE_HOVER_RATIO = 0.9;
-const CAPTURE_PAD_STRIKE_RETURN_RATIO = 0.95;
+const CAPTURE_PAD_STRIKE_ALTITUDE = 0.14; // visible lift-off for jet/helicopter on phone portrait
+const CAPTURE_PAD_STRIKE_FORWARD_TILES = 1.15; // clear outbound leg before turning back to parked slot
+const CAPTURE_PAD_STRIKE_ASCEND_RATIO = 0.24;
+const CAPTURE_PAD_STRIKE_HOVER_RATIO = 0.58;
+const CAPTURE_PAD_STRIKE_RETURN_RATIO = 0.86;
 const CAPTURE_PAD_MISSILE_RELEASE_RATIO = 0.64; // fire near shared strike latitude, then return to parking side instead of dive-crashing
-const CAPTURE_PAD_MISSILE_TRAVEL_TIME = 1.2; // normal-speed travel synced with fly-by
+const CAPTURE_PAD_MISSILE_TRAVEL_TIME = 1.78; // slower missile travel so trajectory stays visible
 const CAPTURE_PAD_MISSILE_FORWARD_OFFSET = 0.03; // fire a bit ahead of aircraft center
 const CAPTURE_PAD_MISSILE_LIFT_OFFSET = 0.003; // keep launch altitude low and close to aircraft body
 const CAPTURE_SHORT_MISSILE_HIT_THRESHOLD = 0.995; // trigger impact only at the very end of the precision strike
@@ -9689,6 +9694,18 @@ function Chess3D({
       const bc = new THREE.Vector3().copy(b).lerp(c, t);
       return ab.lerp(bc, t);
     };
+    const CHESS_CAPTURE_FLIGHT_PROFILE = Object.freeze({
+      shortStrikeAltitude: CAPTURE_DRONE_STRIKE_ALTITUDE,
+      shortStrikeAscendRatio: CAPTURE_VERTICAL_STRIKE_ASCEND_RATIO,
+      shortStrikeCruiseRatio: CAPTURE_VERTICAL_STRIKE_CRUISE_RATIO,
+      shortStrikeTopOffset: CAPTURE_VERTICAL_STRIKE_TOP_OFFSET,
+      shortStrikeFinalLockRatio: CAPTURE_VERTICAL_STRIKE_FINAL_LOCK_RATIO,
+      airPadAltitude: CAPTURE_PAD_STRIKE_ALTITUDE,
+      airPadForwardTiles: CAPTURE_PAD_STRIKE_FORWARD_TILES,
+      airPadAscendRatio: CAPTURE_PAD_STRIKE_ASCEND_RATIO,
+      airPadHoverRatio: CAPTURE_PAD_STRIKE_HOVER_RATIO,
+      airPadReturnRatio: CAPTURE_PAD_STRIKE_RETURN_RATIO
+    });
     const constrainInsideBoardPerimeter = (vector, marginTiles = 0.62) => {
       const margin = BOARD.tile * marginTiles;
       const boardHalf = (BOARD.N * BOARD.tile) / 2 - margin;
@@ -9983,46 +10000,109 @@ function Chess3D({
       } else {
         towardTarget.normalize();
       }
-      const liftTarget = launchPos.clone();
-      liftTarget.y = launchPos.y + altitude;
-      const forwardTarget = liftTarget.clone().addScaledVector(towardTarget, tile * forwardTiles);
+      const liftTarget = launchPos.clone().setY(launchPos.y + altitude);
+      const outboundTarget = liftTarget.clone().addScaledVector(towardTarget, tile * forwardTiles);
+      const cruiseBackTarget = liftTarget.clone();
       const u = clamp01(progress);
       let pos = launchPos.clone();
       let next = launchPos.clone().add(new THREE.Vector3(0.04, 0, 0));
       if (u < CAPTURE_PAD_STRIKE_ASCEND_RATIO) {
-        const su = smoothEase(u / Math.max(0.001, CAPTURE_PAD_STRIKE_ASCEND_RATIO));
+        const su = smoothEase(u / Math.max(0.001, CHESS_CAPTURE_FLIGHT_PROFILE.airPadAscendRatio));
         pos = launchPos.clone().lerp(liftTarget, su);
         next = launchPos.clone().lerp(liftTarget, clamp01(su + 0.06));
-      } else if (u < CAPTURE_PAD_STRIKE_HOVER_RATIO) {
+      } else if (u < CHESS_CAPTURE_FLIGHT_PROFILE.airPadHoverRatio) {
         const su = smoothEase(
-          (u - CAPTURE_PAD_STRIKE_ASCEND_RATIO) /
-            Math.max(0.001, CAPTURE_PAD_STRIKE_HOVER_RATIO - CAPTURE_PAD_STRIKE_ASCEND_RATIO)
+          (u - CHESS_CAPTURE_FLIGHT_PROFILE.airPadAscendRatio) /
+            Math.max(0.001, CHESS_CAPTURE_FLIGHT_PROFILE.airPadHoverRatio - CHESS_CAPTURE_FLIGHT_PROFILE.airPadAscendRatio)
         );
-        pos = liftTarget.clone().lerp(forwardTarget, su);
-        next = liftTarget.clone().lerp(forwardTarget, clamp01(su + 0.06));
-      } else if (u < CAPTURE_PAD_STRIKE_RETURN_RATIO) {
+        pos = liftTarget.clone().lerp(outboundTarget, su);
+        next = liftTarget.clone().lerp(outboundTarget, clamp01(su + 0.06));
+      } else if (u < CHESS_CAPTURE_FLIGHT_PROFILE.airPadReturnRatio) {
         const su = smoothEase(
-          (u - CAPTURE_PAD_STRIKE_HOVER_RATIO) /
-            Math.max(0.001, CAPTURE_PAD_STRIKE_RETURN_RATIO - CAPTURE_PAD_STRIKE_HOVER_RATIO)
+          (u - CHESS_CAPTURE_FLIGHT_PROFILE.airPadHoverRatio) /
+            Math.max(0.001, CHESS_CAPTURE_FLIGHT_PROFILE.airPadReturnRatio - CHESS_CAPTURE_FLIGHT_PROFILE.airPadHoverRatio)
         );
-        pos = forwardTarget.clone().lerp(liftTarget, su);
-        next = forwardTarget.clone().lerp(liftTarget, clamp01(su + 0.06));
+        pos = outboundTarget.clone().lerp(cruiseBackTarget, su);
+        next = outboundTarget.clone().lerp(cruiseBackTarget, clamp01(su + 0.06));
       } else {
         const su = smoothEase(
-          (u - CAPTURE_PAD_STRIKE_RETURN_RATIO) / Math.max(0.001, 1 - CAPTURE_PAD_STRIKE_RETURN_RATIO)
+          (u - CHESS_CAPTURE_FLIGHT_PROFILE.airPadReturnRatio) / Math.max(0.001, 1 - CHESS_CAPTURE_FLIGHT_PROFILE.airPadReturnRatio)
         );
-        pos = liftTarget.clone().lerp(launchPos, su);
-        next = liftTarget.clone().lerp(launchPos, clamp01(su + 0.06));
+        pos = cruiseBackTarget.clone().lerp(launchPos, su);
+        next = cruiseBackTarget.clone().lerp(launchPos, clamp01(su + 0.06));
       }
-      return { pos, next, forward: towardTarget, strikeAnchor: forwardTarget };
+      return { pos, next, forward: towardTarget, strikeAnchor: outboundTarget };
     };
-    const getCaptureShortMissilePose = ({ launchPos, targetPos, progress, altitude = CAPTURE_VERTICAL_STRIKE_ALTITUDE }) =>
-      getCaptureDirectStrikePose({
+    const getCaptureUShapeStrikePose = ({
+      launchPos,
+      targetPos,
+      progress,
+      altitude = CHESS_CAPTURE_FLIGHT_PROFILE.shortStrikeAltitude
+    }) => {
+      const toTarget = targetPos.clone().sub(launchPos);
+      toTarget.y = 0;
+      if (toTarget.lengthSq() < 1e-5) {
+        toTarget.set(-Math.sign(launchPos.x || 1), 0, 0);
+      } else {
+        toTarget.normalize();
+      }
+      const liftTop = launchPos.clone();
+      liftTop.y = launchPos.y + altitude;
+      const strikeTop = targetPos.clone();
+      strikeTop.y = Math.max(targetPos.y + CHESS_CAPTURE_FLIGHT_PROFILE.shortStrikeTopOffset, launchPos.y + altitude);
+      const travelPlanar = targetPos.clone().sub(launchPos);
+      travelPlanar.y = 0;
+      const cruiseTarget = liftTop.clone().addScaledVector(toTarget, travelPlanar.length());
+      cruiseTarget.x = targetPos.x;
+      cruiseTarget.z = targetPos.z;
+      const u = clamp01(progress);
+      let pos = launchPos.clone();
+      let next = launchPos.clone().add(new THREE.Vector3(0.05, 0, 0));
+      if (u < CHESS_CAPTURE_FLIGHT_PROFILE.shortStrikeAscendRatio) {
+        const su = smoothEase(u / Math.max(0.001, CHESS_CAPTURE_FLIGHT_PROFILE.shortStrikeAscendRatio));
+        pos = launchPos.clone().lerp(liftTop, su);
+        next = launchPos.clone().lerp(liftTop, clamp01(su + 0.06));
+      } else if (u < CHESS_CAPTURE_FLIGHT_PROFILE.shortStrikeCruiseRatio) {
+        const su = smoothEase(
+          (u - CHESS_CAPTURE_FLIGHT_PROFILE.shortStrikeAscendRatio) /
+            Math.max(
+              0.001,
+              CHESS_CAPTURE_FLIGHT_PROFILE.shortStrikeCruiseRatio - CHESS_CAPTURE_FLIGHT_PROFILE.shortStrikeAscendRatio
+            )
+        );
+        pos = liftTop.clone().lerp(cruiseTarget, su);
+        next = liftTop.clone().lerp(cruiseTarget, clamp01(su + 0.05));
+      } else {
+        const su = smoothEase(
+          (u - CHESS_CAPTURE_FLIGHT_PROFILE.shortStrikeCruiseRatio) /
+            Math.max(0.001, 1 - CHESS_CAPTURE_FLIGHT_PROFILE.shortStrikeCruiseRatio)
+        );
+        if (su >= CHESS_CAPTURE_FLIGHT_PROFILE.shortStrikeFinalLockRatio) {
+          pos = targetPos.clone();
+          next = targetPos.clone();
+        } else {
+          const easedDrop = smoothEase(su);
+          pos = strikeTop.clone().lerp(targetPos, easedDrop);
+          next = strikeTop.clone().lerp(targetPos, clamp01(easedDrop + 0.06));
+        }
+        next.x = pos.x;
+        next.z = pos.z;
+      }
+      constrainInsideBoardPerimeter(pos, CAPTURE_AIR_STRIKE_PATH_EDGE_MARGIN_TILES + 0.2);
+      constrainInsideBoardPerimeter(next, CAPTURE_AIR_STRIKE_PATH_EDGE_MARGIN_TILES + 0.2);
+      return { pos, next };
+    };
+    const getCaptureShortMissilePose = ({
+      launchPos,
+      targetPos,
+      progress,
+      altitude = CHESS_CAPTURE_FLIGHT_PROFILE.shortStrikeAltitude
+    }) =>
+      getCaptureUShapeStrikePose({
         launchPos,
         targetPos,
         progress,
-        altitude,
-        verticalCrash: true
+        altitude
       });
     const getCaptureAirStrikePose = ({ launchPos, targetPos, progress, returnToOrigin = false }) =>
       getCaptureLoopPose({
@@ -10067,12 +10147,15 @@ function Chess3D({
       deltaR = 0,
       deltaC = 0
     }) => {
-      const afterExplosionDelayMs = LUDO_CAPTURE_EXPLOSION_TIME * 1000;
-      const waitForExplosion = (impactDelayMs) => {
-        const totalDelay = Math.max(0, impactDelayMs) + afterExplosionDelayMs;
+      const waitForExplosion = (impactDelayMs, targetEjectDelayMs = impactDelayMs) => {
+        const impactDelay = Math.max(0, impactDelayMs);
+        const ejectDelay = Math.max(0, targetEjectDelayMs) + CHESS_CAPTURE_EJECT_BUFFER_MS;
+        const attackerDelay = impactDelay + CHESS_CAPTURE_EXPLOSION_DURATION_MS + CHESS_CAPTURE_ATTACKER_BUFFER_MS;
         return {
-          moveDelayMs: totalDelay,
-          captureResolveDelayMs: totalDelay
+          moveDelayMs: attackerDelay,
+          captureResolveDelayMs: ejectDelay,
+          targetEjectDelayMs: ejectDelay,
+          attackerAdvanceDelayMs: attackerDelay
         };
       };
       const pieceType = resolveCaptureAnimationPieceType(
@@ -10110,7 +10193,7 @@ function Chess3D({
           verticalStrike: true,
           launchFromLivePiece: false
         });
-        return waitForExplosion(CAPTURE_GROUND_TOTAL * 1000);
+        return waitForExplosion(CAPTURE_GROUND_TOTAL * 1000, CAPTURE_GROUND_TOTAL * 1000);
       }
       if (captureAnimationId === 'droneStrike' || captureAnimationId === 'pawnJavelin') {
         if (captureAnimationId === 'droneStrike') {
@@ -10119,10 +10202,8 @@ function Chess3D({
           const parkedDrone = acquireParkedAirUnit(isWhiteSide, 'drone');
           const droneFx = parkedDrone || createFxDrone({ forceProcedural: true });
           droneFx.root.scale.setScalar(CAPTURE_DRONE_SCALE);
-          const liveLaunchPos = getLiveLaunchPosition(fromPos, movingMesh, 0);
-          const launchBase =
-            parkedDrone?.homePosition?.clone?.() ||
-            getAirPadAnchor(isWhiteSide, 'drone', 0, liveLaunchPos).clone();
+          const liveLaunchPos = getLiveLaunchPosition(fromPos, movingMesh, 0.02);
+          const launchBase = liveLaunchPos.clone();
           if (!parkedDrone) {
             droneFx.root.position.copy(launchBase.clone());
             captureFxGroup.add(droneFx.root);
@@ -10141,9 +10222,9 @@ function Chess3D({
             sourceUnit: parkedDrone,
             droneFx,
             verticalStrike: true,
-            launchFromLivePiece: false
+            launchFromLivePiece: true
           });
-          return waitForExplosion(CAPTURE_GROUND_TOTAL * 1000);
+          return waitForExplosion(CAPTURE_GROUND_TOTAL * 1000, CAPTURE_GROUND_TOTAL * 1000);
         }
         suppressTimerBeepUntilRef.current = performance.now() + CAPTURE_GROUND_TOTAL * 1000;
         const missileFx = createFxGroundMissile();
@@ -10168,7 +10249,7 @@ function Chess3D({
           verticalStrike: true,
           launchFromLivePiece: true
         });
-        return waitForExplosion(CAPTURE_GROUND_TOTAL * 1000);
+        return waitForExplosion(CAPTURE_GROUND_TOTAL * 1000, CAPTURE_GROUND_TOTAL * 1000);
       }
       if (captureAnimationId === 'kingJetStrike') {
         suppressTimerBeepUntilRef.current = performance.now() + CAPTURE_JET_TOTAL * 1000;
@@ -10216,7 +10297,7 @@ function Chess3D({
           missileFx
         });
         const jetImpactDelayMs = CAPTURE_JET_TOTAL * 0.96 * 1000;
-        return waitForExplosion(jetImpactDelayMs);
+        return waitForExplosion(jetImpactDelayMs, jetImpactDelayMs);
       }
       if (captureAnimationId === 'helicopterStrike') {
         suppressTimerBeepUntilRef.current = performance.now() + CAPTURE_HELICOPTER_TOTAL * 1000;
@@ -10269,7 +10350,7 @@ function Chess3D({
           missileFx
         });
         const helicopterImpactDelayMs = CAPTURE_HELICOPTER_TOTAL * 0.96 * 1000;
-        return waitForExplosion(helicopterImpactDelayMs);
+        return waitForExplosion(helicopterImpactDelayMs, helicopterImpactDelayMs);
       }
       if (captureAnimationId === 'queenJetStrike') {
         suppressTimerBeepUntilRef.current = performance.now() + CAPTURE_JET_TOTAL * 1000;
@@ -10317,7 +10398,7 @@ function Chess3D({
           missileFx
         });
         const jetImpactDelayMs = CAPTURE_JET_TOTAL * 0.96 * 1000;
-        return waitForExplosion(jetImpactDelayMs);
+        return waitForExplosion(jetImpactDelayMs, jetImpactDelayMs);
       }
       if (distance <= 1.5) {
         playAudio(swordSoundRef);
@@ -10331,7 +10412,7 @@ function Chess3D({
         missileFx.root.scale.setScalar(CAPTURE_MISSILE_SCALE);
         captureFxGroup.add(missileFx.root);
         activeCaptureFx.push({ type: 'missile', t: 0, duration: LUDO_CAPTURE_MISSILE_TRAVEL_TIME, from: fromPos.clone(), to: targetPos.clone(), missileFx });
-        return waitForExplosion(LUDO_CAPTURE_MISSILE_TRAVEL_TIME * 1000);
+        return waitForExplosion(LUDO_CAPTURE_MISSILE_TRAVEL_TIME * 1000, LUDO_CAPTURE_MISSILE_TRAVEL_TIME * 1000);
       }
       launchExplosion(targetPos.clone());
       return { moveDelayMs: 280 };
@@ -11457,6 +11538,8 @@ function Chess3D({
       const toWorldPos = piecePosition(rr, cc, currentPieceYOffset);
       let moveDelayMs = 0;
       let captureResolveDelayMs = 0;
+      let targetEjectDelayMs = 0;
+      let attackerAdvanceDelayMs = 0;
       // capture mesh if any
       const targetMesh = pieceMeshes[rr][cc];
       if (targetMesh) {
@@ -11474,11 +11557,16 @@ function Chess3D({
         });
         moveDelayMs = Math.max(0, captureFx?.moveDelayMs ?? 0);
         captureResolveDelayMs = Math.max(0, captureFx?.captureResolveDelayMs ?? 0);
+        targetEjectDelayMs = Math.max(0, captureFx?.targetEjectDelayMs ?? captureResolveDelayMs);
+        attackerAdvanceDelayMs = Math.max(0, captureFx?.attackerAdvanceDelayMs ?? moveDelayMs);
         if (moveDelayMs > 0 && captureResolveDelayMs <= 0) {
           captureResolveDelayMs = moveDelayMs;
         }
         if (captureResolveDelayMs > 0) {
           moveDelayMs = Math.max(moveDelayMs, captureResolveDelayMs);
+        }
+        if (attackerAdvanceDelayMs > 0) {
+          moveDelayMs = Math.max(moveDelayMs, attackerAdvanceDelayMs);
         }
         const moveCapturedPieceToZone = () => {
           const capturingWhite = board[rr][cc]?.w ?? board[sel.r][sel.c].w;
@@ -11501,8 +11589,9 @@ function Chess3D({
             forceSway: 0.003
           });
         };
-        if (captureResolveDelayMs > 0) {
-          setTimeout(() => moveCapturedPieceToZone(), captureResolveDelayMs);
+        const ejectDelay = Math.max(targetEjectDelayMs, captureResolveDelayMs);
+        if (ejectDelay > 0) {
+          setTimeout(() => moveCapturedPieceToZone(), ejectDelay);
         } else {
           moveCapturedPieceToZone();
         }
@@ -12144,12 +12233,11 @@ function Chess3D({
               pose = { pos: launchPos.clone(), next: launchPos.clone().add(new THREE.Vector3(0.05, 0, 0)) };
             } else if (fx.t < impactTime) {
               const mu = smoothEase((fx.t - CAPTURE_GROUND_FIRE_TIME) / CAPTURE_GROUND_TRAVEL_TIME);
-              pose = getCaptureDirectStrikePose({
+              pose = getCaptureShortMissilePose({
                 launchPos,
                 targetPos: fx.to,
                 progress: mu,
-                altitude: CAPTURE_DRONE_STRIKE_ALTITUDE,
-                verticalCrash: Boolean(fx.verticalStrike)
+                altitude: CAPTURE_DRONE_STRIKE_ALTITUDE
               });
             }
             if (!pose) {
@@ -12202,12 +12290,12 @@ function Chess3D({
               ? fx.launchPos.clone()
               : getLiveLaunchPosition(fx.launchPos, fx.movingMesh, 0);
             if (!fx.returnToOrigin || fx.launchFromLivePiece) fx.launchPos.copy(launchPos);
-            const { pos: jetPos, next: jetNext } = getCaptureAirStrikePose({
+            const { pos: jetPos, next: jetNext } = getCapturePadStrikePose({
               launchPos,
               targetPos: fx.to,
               progress: jetTimelineU,
-              returnToOrigin: true,
-              sideSign: fx.sideSign ?? 1
+              altitude: CAPTURE_PAD_STRIKE_ALTITUDE,
+              forwardTiles: CAPTURE_PAD_STRIKE_FORWARD_TILES
             });
             fx.jetFx.root.position.copy(constrainInsideBoardPerimeter(jetPos));
             captureDir.copy(jetNext).sub(jetPos).normalize();
@@ -12295,12 +12383,12 @@ function Chess3D({
               ? fx.launchPos.clone()
               : getLiveLaunchPosition(fx.launchPos, fx.movingMesh, 0);
             if (!fx.returnToOrigin || fx.launchFromLivePiece) fx.launchPos.copy(launchPos);
-            const { pos: heliPos, next: heliNext } = getCaptureAirStrikePose({
+            const { pos: heliPos, next: heliNext } = getCapturePadStrikePose({
               launchPos,
               targetPos: fx.to,
               progress: heliTimelineU,
-              returnToOrigin: true,
-              sideSign: fx.sideSign ?? 1
+              altitude: CAPTURE_PAD_STRIKE_ALTITUDE,
+              forwardTiles: CAPTURE_PAD_STRIKE_FORWARD_TILES
             });
             fx.helicopterFx.root.position.copy(constrainInsideBoardPerimeter(heliPos));
             captureDir.copy(heliNext).sub(heliPos).normalize();
@@ -12407,12 +12495,11 @@ function Chess3D({
               });
             } else if (fx.t < impactTime) {
               const mu = smoothEase((fx.t - CAPTURE_GROUND_FIRE_TIME) / CAPTURE_GROUND_TRAVEL_TIME);
-              const { pos: missilePos, next: missileNext } = getCaptureDirectStrikePose({
+              const { pos: missilePos, next: missileNext } = getCaptureShortMissilePose({
                 launchPos,
                 targetPos: fx.to,
                 progress: mu,
-                altitude: CAPTURE_DRONE_STRIKE_ALTITUDE,
-                verticalCrash: Boolean(fx.verticalStrike)
+                altitude: CAPTURE_DRONE_STRIKE_ALTITUDE
               });
 
               fx.missileFx.root.visible = true;


### PR DESCRIPTION
### Motivation

- Improve the readability of capture animations on portrait/phone screens by slowing and re-tuning flight paths, missile timings, and pad strike behavior.

### Description

- Introduce new timing/metadata constants (`CHESS_CAPTURE_FLIGHT_PROFILE`, `CHESS_CAPTURE_EXPLOSION_DURATION_MS`, `CHESS_CAPTURE_EJECT_BUFFER_MS`, `CHESS_CAPTURE_ATTACKER_BUFFER_MS`) and adjust existing timing constants such as `CAPTURE_JET_TOTAL`, `CAPTURE_DRONE_STRIKE_TRAVEL_TIME`, and `CAPTURE_PAD_MISSILE_TRAVEL_TIME` to slow and clarify motion on small screens.
- Replace and refactor capture path logic by adding `getCaptureUShapeStrikePose` and `getCapturePadStrikePose`, centralizing pad/short-strike parameters behind the flight profile, and update `getCaptureShortMissilePose` to use the new U-shape routine.
- Extend `playCaptureAnimation`'s internal `waitForExplosion` to return distinct delays (`moveDelayMs`, `captureResolveDelayMs`, `targetEjectDelayMs`, `attackerAdvanceDelayMs`) and wire those into the move/capture scheduling logic so captured piece ejection and attacker advancement are timed precisely.
- Adjust drone/jet/helicopter jettison/launch logic to prefer live-launch positions for better on-board tracking (`launchFromLivePiece` changes) and update various callers to use the new pose functions and profile values.

### Testing

- Built the web app with `yarn build` and the build completed successfully.
- Ran the unit test suite with `yarn test` and all tests passed.
- Ran `yarn lint` to validate formatting and static checks and the linter completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e71775107883299a02aa0ec4311fbd)