### PR TITLE
Adjust SnakeBoard3D seat-edge placement for tokens and weapons

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -260,27 +260,27 @@ const SEAT_RAIL_SLOT_OFFSET = SEAT_RAIL_DICE_GAP * 0.5;
 const SEAT_RAIL_FORWARD_BIAS = TILE_SIZE * 0.08;
 // Seat-aware slot signs (portrait): 0=bottom, 1=right, 2=top, 3=left.
 const TOKEN_SLOT_SIDE_SIGN_BY_SEAT = Object.freeze([-1, 1, -1, 1]);
-const WEAPON_SLOT_SIDE_SIGN_BY_SEAT = Object.freeze([-1, 1, -1, 1]);
+const WEAPON_SLOT_SIDE_SIGN_BY_SEAT = Object.freeze([1, -1, 1, -1]);
 const TOKEN_SLOT_LATERAL_NUDGE_BY_SEAT = Object.freeze([
-  TILE_SIZE * 0.06,
-  0,
-  0,
-  0
+  TILE_SIZE * 0.22,
+  TILE_SIZE * 0.12,
+  TILE_SIZE * 0.2,
+  TILE_SIZE * 0.12
 ]);
 const WEAPON_SLOT_LATERAL_NUDGE_BY_SEAT = Object.freeze([
-  0,
-  0,
-  TILE_SIZE * 0.22,
-  0
+  -TILE_SIZE * 0.2,
+  -TILE_SIZE * 0.12,
+  -TILE_SIZE * 0.24,
+  -TILE_SIZE * 0.12
 ]);
 const WEAPON_DISPLAY_SIZE_MULTIPLIER = 1.4;
 const WEAPON_PARKING_OUTWARD_OFFSET = TILE_SIZE * 0.06;
 const WEAPON_FROM_TOKEN_CENTER_OFFSET = TOKEN_RADIUS * 0.58;
 const WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT = Object.freeze([
-  -TILE_SIZE * 0.18,
-  -TILE_SIZE * 0.46,
-  TILE_SIZE * 0.18,
-  -TILE_SIZE * 0.58
+  -TILE_SIZE * 0.08,
+  -TILE_SIZE * 0.34,
+  TILE_SIZE * 0.24,
+  -TILE_SIZE * 0.34
 ]);
 const WEAPON_TOKEN_GAP = TILE_SIZE * 0.004;
 const WEAPON_PARKED_Y_DROP_BY_KIND = Object.freeze({
@@ -292,10 +292,10 @@ const WEAPON_PARKED_Y_DROP_BY_KIND = Object.freeze({
 });
 const WEAPON_REST_HEIGHT_OFFSET = -TOKEN_HEIGHT * 1.52;
 const WEAPON_REST_HEIGHT_OFFSET_BY_SEAT = Object.freeze([
-  -TOKEN_HEIGHT * 0.08,
-  -TOKEN_HEIGHT * 0.3,
-  -TOKEN_HEIGHT * 1.36,
-  -TOKEN_HEIGHT * 0.32
+  -TOKEN_HEIGHT * 0.12,
+  -TOKEN_HEIGHT * 0.36,
+  -TOKEN_HEIGHT * 1.32,
+  -TOKEN_HEIGHT * 0.36
 ]);
 
 const PAVEMENT_EXTRA_SCALE = 1.18;


### PR DESCRIPTION
### Motivation
- Reserve tokens and parked weapons should render visibly in front of each player at the board edge to match portrait-screen placement targets (the red-circle positions). 
- Small per-seat offsets are required so tokens and weapons appear on opposite sides and line up correctly with seat anchors on mobile portrait screens. 

### Description
- Tuned seat-slot constants in `webapp/src/components/SnakeBoard3D.jsx` to flip weapon side signs so weapons render opposite the token side for each seat. 
- Increased per-seat lateral nudges for token slots (`TOKEN_SLOT_LATERAL_NUDGE_BY_SEAT`) to better align reserve tokens with the edge targets. 
- Increased per-seat lateral nudges for weapon slots (`WEAPON_SLOT_LATERAL_NUDGE_BY_SEAT`) and changed their sign so weapons are offset to the intended side. 
- Adjusted `WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT` and `WEAPON_REST_HEIGHT_OFFSET_BY_SEAT` to improve outward/vertical placement of parked vehicles so they sit correctly on the table rim. 

### Testing
- Ran the snake unit test: `npm run -s test -- test/snakeGame.test.js`. 
- Result: the test run failed with 4 assertion failures in `test/snakeGame.test.js`, which are unrelated to the visual placement constants and reflect pre-existing game-logic expectations; no rendering/runtime errors were produced by the change. 
- Change is isolated to `webapp/src/components/SnakeBoard3D.jsx` and does not modify network/API or core gameplay logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e742e05f6c83298c43bde093aa18f5)