### PR TITLE
Adjust Murlan Royale camera framing, avatar positions and card layout

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -107,7 +107,7 @@ const ENABLE_3D_HUMAN_CHARACTERS = false;
 const ARENA_GROWTH = 1.45; // expanded arena footprint for wider walkways
 const CHAIR_SIZE_SCALE = 1;
 const ARENA_PROP_SCALE = 1;
-const TOP_SEAT_AVATAR_UP_LIFT = 1.1;
+const TOP_SEAT_AVATAR_UP_LIFT = 1.45;
 const TABLE_AND_CHAIR_VISUAL_SHRINK = 1;
 const CARD_VISUAL_TRIM = 1;
 
@@ -2310,12 +2310,12 @@ const CAMERA_SEATED_RETREAT_OFFSETS = Object.freeze({
   landscape: 0.68
 });
 const CAMERA_SEATED_ELEVATION_OFFSETS = Object.freeze({
-  portrait: 2.12,
-  landscape: 0.98
+  portrait: 1.9,
+  landscape: 0.9
 });
 const CAMERA_TARGET_LIFT = 0.08 * MODEL_SCALE;
 const CAMERA_FOCUS_CENTER_LIFT = 0.1 * MODEL_SCALE;
-const CAMERA_TARGET_TOP_PLAYER_BIAS = 0.24 * MODEL_SCALE;
+const CAMERA_TARGET_TOP_PLAYER_BIAS = 0.36 * MODEL_SCALE;
 const HUMAN_HAND_CARD_SCALE = 1.1;
 const HUMAN_HAND_CARD_SPACING = CARD_W * HUMAN_HAND_CARD_SCALE * 0.29;
 const HUMAN_HAND_CARD_MAX_SPREAD = HUMAN_HAND_CARD_SPACING * 12;
@@ -2325,12 +2325,12 @@ const HUMAN_HAND_FAN_ARC_LIFT = 0;
 const HUMAN_HAND_FAN_DIRECTION = 1;
 const HUMAN_HAND_UNIFORM_YAW_FROM_LEFT = true;
 const HUMAN_HAND_CLOSER_OFFSET = 0.042 * MODEL_SCALE;
-const HUMAN_HAND_BOTTOM_SHIFT_Y = -0.235 * MODEL_SCALE;
-const AI_HAND_BOTTOM_SHIFT_Y = -0.056 * MODEL_SCALE;
-const AI_HAND_CLOSER_OFFSET = -0.014 * MODEL_SCALE;
+const HUMAN_HAND_BOTTOM_SHIFT_Y = -0.19 * MODEL_SCALE;
+const AI_HAND_BOTTOM_SHIFT_Y = -0.012 * MODEL_SCALE;
+const AI_HAND_CLOSER_OFFSET = 0.02 * MODEL_SCALE;
 const HUMAN_HAND_LEFT_SHIFT = 0;
 const AI_HAND_LEFT_SHIFT = 0;
-const HUMAN_HAND_UP_SHIFT_Y = 0.038 * MODEL_SCALE;
+const HUMAN_HAND_UP_SHIFT_Y = 0.052 * MODEL_SCALE;
 const HUMAN_HAND_DIRECTIONAL_LIFT = 0;
 const HUMAN_HAND_BOTTOM_INWARD_TILT_X = 0;
 const AI_HAND_CARD_SPACING = HUMAN_HAND_CARD_SPACING;
@@ -2338,9 +2338,9 @@ const AI_HAND_CARD_MAX_SPREAD = HUMAN_HAND_CARD_MAX_SPREAD;
 const AI_HAND_FAN_MAX_YAW = HUMAN_HAND_FAN_MAX_YAW;
 const AI_HAND_FAN_ARC_LIFT = HUMAN_HAND_FAN_ARC_LIFT;
 const HUMAN_HAND_TABLE_EDGE_MARGIN = CARD_H * 0.04;
-const HUMAN_HAND_EXTRA_INWARD_PULL = 0.315 * MODEL_SCALE;
+const HUMAN_HAND_EXTRA_INWARD_PULL = 0.34 * MODEL_SCALE;
 const AI_HAND_TABLE_EDGE_MARGIN = CARD_H * 0.2;
-const HAND_CARDS_INWARD_BIAS = 0.118 * MODEL_SCALE;
+const HAND_CARDS_INWARD_BIAS = 0.14 * MODEL_SCALE;
 const COMMUNITY_CARD_TOP_TILT = THREE.MathUtils.degToRad(12);
 const COMMUNITY_CARD_SCALE = 1.08;
 const COMMUNITY_CARD_SPACING = CARD_W * 1.08;
@@ -5411,7 +5411,7 @@ export default function MurlanRoyaleArena({ search }) {
             const anchor = seatAnchorMap.get(idx);
             const fallback = FALLBACK_SEAT_POSITIONS[idx % FALLBACK_SEAT_POSITIONS.length];
             const isSideSeat = idx !== humanPlayerIndex && idx !== topSeatIndex;
-            const sideSeatTopLift = isSideSeat ? 3.05 : 2.1;
+            const sideSeatTopLift = isSideSeat ? 4.2 : 2.9;
             const topSeatLift = idx === topSeatIndex ? TOP_SEAT_AVATAR_UP_LIFT : 0;
             const positionStyle = idx === humanPlayerIndex
               ? {


### PR DESCRIPTION
### Motivation
- Improve portrait framing so the camera sits lower and visually looks more toward the player at the top.  
- Raise player hand cards and pull them slightly inward, with the bottom (human) hand kept higher than other hands for better legibility.  
- Move non-bottom avatars upward on the UI while keeping the bottom avatar anchored in its current fixed position.

### Description
- Tuned camera/target constants in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to lower seated camera elevation and bias the look target toward the top player by updating `CAMERA_SEATED_ELEVATION_OFFSETS` and `CAMERA_TARGET_TOP_PLAYER_BIAS`.  
- Increased `TOP_SEAT_AVATAR_UP_LIFT` and raised side/top avatar placement by increasing `sideSeatTopLift` to make non-bottom avatars appear higher.  
- Adjusted hand/card layout constants to raise and pull cards inward: `HUMAN_HAND_BOTTOM_SHIFT_Y`, `AI_HAND_BOTTOM_SHIFT_Y`, `AI_HAND_CLOSER_OFFSET`, `HUMAN_HAND_UP_SHIFT_Y`, `HUMAN_HAND_EXTRA_INWARD_PULL`, and `HAND_CARDS_INWARD_BIAS` were updated to give the bottom (human) hand additional vertical emphasis and to nudge all hands slightly inward.  
- Single file changed: `webapp/src/pages/Games/MurlanRoyaleArena.jsx` (layout constants only, no structural logic changes).

### Testing
- Ran linter targeting the modified file with `npm run -s lint -- webapp/src/pages/Games/MurlanRoyaleArena.jsx`; the command completed but repository-wide ESLint issues in generated/dist files caused many errors unrelated to this change.  
- No runtime code paths were added; changes are limited to layout constants and were committed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e75ff8b9f48329989131adb42bb8f3)