### PR TITLE
Tweak Murlan Royale camera, avatar, and card positioning

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -107,7 +107,7 @@ const ENABLE_3D_HUMAN_CHARACTERS = false;
 const ARENA_GROWTH = 1.45; // expanded arena footprint for wider walkways
 const CHAIR_SIZE_SCALE = 1;
 const ARENA_PROP_SCALE = 1;
-const TOP_SEAT_AVATAR_UP_LIFT = 1.45;
+const TOP_SEAT_AVATAR_UP_LIFT = 2.25;
 const TABLE_AND_CHAIR_VISUAL_SHRINK = 1;
 const CARD_VISUAL_TRIM = 1;
 
@@ -2306,16 +2306,16 @@ const CHAIR_SEAT_INWARD_FACTOR = 0.965;
 const CHAIR_VISUAL_SCALE = 1.3;
 const CAMERA_SEATED_LATERAL_OFFSETS = Object.freeze({ portrait: 0, landscape: 0 });
 const CAMERA_SEATED_RETREAT_OFFSETS = Object.freeze({
-  portrait: 0.84,
-  landscape: 0.68
+  portrait: 0.8,
+  landscape: 0.64
 });
 const CAMERA_SEATED_ELEVATION_OFFSETS = Object.freeze({
-  portrait: 1.9,
-  landscape: 0.9
+  portrait: 1.7,
+  landscape: 0.82
 });
 const CAMERA_TARGET_LIFT = 0.08 * MODEL_SCALE;
 const CAMERA_FOCUS_CENTER_LIFT = 0.1 * MODEL_SCALE;
-const CAMERA_TARGET_TOP_PLAYER_BIAS = 0.36 * MODEL_SCALE;
+const CAMERA_TARGET_TOP_PLAYER_BIAS = 0.5 * MODEL_SCALE;
 const HUMAN_HAND_CARD_SCALE = 1.1;
 const HUMAN_HAND_CARD_SPACING = CARD_W * HUMAN_HAND_CARD_SCALE * 0.29;
 const HUMAN_HAND_CARD_MAX_SPREAD = HUMAN_HAND_CARD_SPACING * 12;
@@ -2325,12 +2325,12 @@ const HUMAN_HAND_FAN_ARC_LIFT = 0;
 const HUMAN_HAND_FAN_DIRECTION = 1;
 const HUMAN_HAND_UNIFORM_YAW_FROM_LEFT = true;
 const HUMAN_HAND_CLOSER_OFFSET = 0.042 * MODEL_SCALE;
-const HUMAN_HAND_BOTTOM_SHIFT_Y = -0.19 * MODEL_SCALE;
-const AI_HAND_BOTTOM_SHIFT_Y = -0.012 * MODEL_SCALE;
+const HUMAN_HAND_BOTTOM_SHIFT_Y = 0.0 * MODEL_SCALE;
+const AI_HAND_BOTTOM_SHIFT_Y = -0.02 * MODEL_SCALE;
 const AI_HAND_CLOSER_OFFSET = 0.02 * MODEL_SCALE;
 const HUMAN_HAND_LEFT_SHIFT = 0;
 const AI_HAND_LEFT_SHIFT = 0;
-const HUMAN_HAND_UP_SHIFT_Y = 0.052 * MODEL_SCALE;
+const HUMAN_HAND_UP_SHIFT_Y = 0.078 * MODEL_SCALE;
 const HUMAN_HAND_DIRECTIONAL_LIFT = 0;
 const HUMAN_HAND_BOTTOM_INWARD_TILT_X = 0;
 const AI_HAND_CARD_SPACING = HUMAN_HAND_CARD_SPACING;
@@ -2338,9 +2338,9 @@ const AI_HAND_CARD_MAX_SPREAD = HUMAN_HAND_CARD_MAX_SPREAD;
 const AI_HAND_FAN_MAX_YAW = HUMAN_HAND_FAN_MAX_YAW;
 const AI_HAND_FAN_ARC_LIFT = HUMAN_HAND_FAN_ARC_LIFT;
 const HUMAN_HAND_TABLE_EDGE_MARGIN = CARD_H * 0.04;
-const HUMAN_HAND_EXTRA_INWARD_PULL = 0.34 * MODEL_SCALE;
+const HUMAN_HAND_EXTRA_INWARD_PULL = 0.4 * MODEL_SCALE;
 const AI_HAND_TABLE_EDGE_MARGIN = CARD_H * 0.2;
-const HAND_CARDS_INWARD_BIAS = 0.14 * MODEL_SCALE;
+const HAND_CARDS_INWARD_BIAS = 0.18 * MODEL_SCALE;
 const COMMUNITY_CARD_TOP_TILT = THREE.MathUtils.degToRad(12);
 const COMMUNITY_CARD_SCALE = 1.08;
 const COMMUNITY_CARD_SPACING = CARD_W * 1.08;
@@ -2367,7 +2367,7 @@ const TABLE_MODEL_TARGET_DIAMETER = TABLE_RADIUS * 2.04;
 const TABLE_MODEL_TARGET_HEIGHT = TABLE_HEIGHT;
 const TABLE_HEIGHT_RAISE = TABLE_HEIGHT - BASE_TABLE_HEIGHT;
 const HUMAN_SELECTION_OFFSET = 0.14 * MODEL_SCALE;
-const AI_CARD_LIFT = 0.056 * MODEL_SCALE;
+const AI_CARD_LIFT = 0.076 * MODEL_SCALE;
 const AI_CARD_OUTWARD = 0;
 
 function resolveSeatHandRadius(tableRadius, isHumanSeat) {
@@ -5411,7 +5411,7 @@ export default function MurlanRoyaleArena({ search }) {
             const anchor = seatAnchorMap.get(idx);
             const fallback = FALLBACK_SEAT_POSITIONS[idx % FALLBACK_SEAT_POSITIONS.length];
             const isSideSeat = idx !== humanPlayerIndex && idx !== topSeatIndex;
-            const sideSeatTopLift = isSideSeat ? 4.2 : 2.9;
+            const sideSeatTopLift = isSideSeat ? 6.0 : 4.2;
             const topSeatLift = idx === topSeatIndex ? TOP_SEAT_AVATAR_UP_LIFT : 0;
             const positionStyle = idx === humanPlayerIndex
               ? {
@@ -5431,7 +5431,7 @@ export default function MurlanRoyaleArena({ search }) {
                 : {
                     position: 'absolute',
                     left: fallback.left,
-                    top: `${clampValue(Number.parseFloat(fallback.top) - topSeatLift, -10, 110)}%`,
+                    top: `${clampValue(Number.parseFloat(fallback.top) - sideSeatTopLift - topSeatLift, -10, 110)}%`,
                     transform: 'translate(-50%, -50%)'
                   };
             const avatarSize = anchor ? clampValue(1.25 - (anchor.depth - 2.4) * 0.12, 0.85, 1.25) : 1;


### PR DESCRIPTION
### Motivation
- Improve portrait framing so the camera sits slightly lower and looks more toward the top player, matching the requested visual directions. 
- Make player hand cards sit higher on screen, pulled slightly inward, and ensure the bottom (human) player's cards are higher than other players'.
- Raise non-bottom avatars higher while keeping the bottom avatar position unchanged and apply the same vertical-lift logic to fallback avatar positions.

### Description
- Adjusted camera seating constants: updated `CAMERA_SEATED_RETREAT_OFFSETS`, `CAMERA_SEATED_ELEVATION_OFFSETS`, and increased `CAMERA_TARGET_TOP_PLAYER_BIAS` to bias the look target toward the top player. 
- Raised top-seat avatar lift by changing `TOP_SEAT_AVATAR_UP_LIFT` and applied larger `sideSeatTopLift` used when computing avatar styles so non-bottom avatars appear higher.
- Tuned hand/card layout constants: changed `HUMAN_HAND_BOTTOM_SHIFT_Y`, `HUMAN_HAND_UP_SHIFT_Y`, `HUMAN_HAND_EXTRA_INWARD_PULL`, `HAND_CARDS_INWARD_BIAS`, and `AI_CARD_LIFT` to lift and pull cards inward and to make bottom player cards appear higher than AI cards.
- Ensured avatar fallback positioning uses the same vertical offset by subtracting `sideSeatTopLift` from fallback `top` values in the avatar rendering branch of `MurlanRoyaleArena.jsx`.
- Files modified: `webapp/src/pages/Games/MurlanRoyaleArena.jsx`.

### Testing
- Ran the focused unit test: `npm test -- --runInBand test/murlan.test.js` and it passed (all tests in that file succeeded).
- No automated visual regression was available in this environment, so changes were validated via unit tests only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e763531f2c8329ac431a6f73f1444a)