### PR TITLE
Four in Row: remove 144Hz, add LT finishes & cloths, and add TonPlaygram branding plate

### DIFF
--- a/webapp/src/config/fourInRowInventoryConfig.js
+++ b/webapp/src/config/fourInRowInventoryConfig.js
@@ -1,5 +1,6 @@
 import { MURLAN_TABLE_THEMES } from './murlanThemes.js'
 import { MURLAN_TABLE_FINISHES } from './murlanTableFinishes.js'
+import { MURLAN_TABLE_CLOTHS } from './murlanTableCloths.js'
 import {
   POOL_ROYALE_DEFAULT_HDRI_ID,
   POOL_ROYALE_HDRI_VARIANTS
@@ -88,6 +89,7 @@ export const FOUR_IN_ROW_BATTLE_DEFAULT_UNLOCKS = Object.freeze({
   chairColor: [FOUR_IN_ROW_CHAIR_OPTIONS[0]?.id],
   tables: [FOUR_IN_ROW_TABLE_OPTIONS[0]?.id],
   tableFinish: [MURLAN_TABLE_FINISHES[0]?.id],
+  clothColor: [MURLAN_TABLE_CLOTHS[0]?.id],
   boardFinish: [FOUR_IN_ROW_BOARD_FINISH_OPTIONS[0]?.id],
   boardFrameFinish: [FOUR_IN_ROW_BOARD_FRAME_FINISH_OPTIONS[0]?.id],
   ringFinish: [FOUR_IN_ROW_RING_FINISH_OPTIONS[0]?.id],
@@ -101,6 +103,7 @@ export const FOUR_IN_ROW_BATTLE_OPTION_LABELS = Object.freeze({
   chairColor: Object.freeze(FOUR_IN_ROW_CHAIR_OPTIONS.reduce((acc, option) => ({ ...acc, [option.id]: option.label }), {})),
   tables: Object.freeze(FOUR_IN_ROW_TABLE_OPTIONS.reduce((acc, option) => ({ ...acc, [option.id]: option.label }), {})),
   tableFinish: Object.freeze(MURLAN_TABLE_FINISHES.reduce((acc, option) => ({ ...acc, [option.id]: option.label }), {})),
+  clothColor: Object.freeze(MURLAN_TABLE_CLOTHS.reduce((acc, option) => ({ ...acc, [option.id]: option.label }), {})),
   boardFinish: Object.freeze(FOUR_IN_ROW_BOARD_FINISH_OPTIONS.reduce((acc, option) => ({ ...acc, [option.id]: option.label }), {})),
   boardFrameFinish: Object.freeze(FOUR_IN_ROW_BOARD_FRAME_FINISH_OPTIONS.reduce((acc, option) => ({ ...acc, [option.id]: option.label }), {})),
   ringFinish: Object.freeze(FOUR_IN_ROW_RING_FINISH_OPTIONS.reduce((acc, option) => ({ ...acc, [option.id]: option.label }), {})),
@@ -122,6 +125,17 @@ export const FOUR_IN_ROW_BATTLE_STORE_ITEMS = [
     description: finish.description,
     swatches: finish.swatches,
     thumbnail: finish.thumbnail,
+    previewShape: 'table'
+  })),
+  ...MURLAN_TABLE_CLOTHS.slice(1).map((cloth, idx) => ({
+    id: `fourinrow-cloth-${cloth.id}`,
+    type: 'clothColor',
+    optionId: cloth.id,
+    name: cloth.label,
+    price: cloth.price ?? 620 + idx * 20,
+    description: cloth.description,
+    swatches: cloth.swatches,
+    thumbnail: cloth.thumbnail,
     previewShape: 'table'
   })),
   ...FOUR_IN_ROW_BOARD_FINISH_OPTIONS.slice(1).map((finish, idx) => ({

--- a/webapp/src/config/murlanTableFinishes.js
+++ b/webapp/src/config/murlanTableFinishes.js
@@ -1,5 +1,5 @@
 import { POOL_ROYALE_OPTION_LABELS } from './poolRoyaleInventoryConfig.js';
-import { polyHavenThumb } from './storeThumbnails.js';
+import { polyHavenThumb, swatchThumbnail } from './storeThumbnails.js';
 
 export const MURLAN_TABLE_FINISHES = Object.freeze([
   Object.freeze({
@@ -70,6 +70,216 @@ export const MURLAN_TABLE_FINISHES = Object.freeze([
       label: POOL_ROYALE_OPTION_LABELS.tableFinish.rosewoodVeneer01,
       presetId: 'cherry',
       grainId: 'rosewood_veneer_01'
+    })
+  }),
+  Object.freeze({
+    id: 'carbonFiberChalk',
+    label: POOL_ROYALE_OPTION_LABELS.tableFinish.carbonFiberChalk,
+    description: 'Black LT carbon-fiber weave finish with a brighter charcoal tone.',
+    price: 1160,
+    swatches: ['#1f242b', '#4f5a68'],
+    thumbnail: swatchThumbnail(['#1f242b', '#4f5a68']),
+    woodOption: Object.freeze({
+      id: 'carbonFiberChalk',
+      label: POOL_ROYALE_OPTION_LABELS.tableFinish.carbonFiberChalk,
+      presetId: 'carbonFiberChalk',
+      grainId: 'plastic_monoblock_lt_black'
+    })
+  }),
+  Object.freeze({
+    id: 'carbonFiberChalkGrey',
+    label: POOL_ROYALE_OPTION_LABELS.tableFinish.carbonFiberChalkGrey,
+    description: 'Grey LT carbon-fiber weave finish tuned a touch brighter for clarity.',
+    price: 1170,
+    swatches: ['#727d8b', '#a4adbb'],
+    thumbnail: swatchThumbnail(['#727d8b', '#a4adbb']),
+    woodOption: Object.freeze({
+      id: 'carbonFiberChalkGrey',
+      label: POOL_ROYALE_OPTION_LABELS.tableFinish.carbonFiberChalkGrey,
+      presetId: 'carbonFiberChalkGrey',
+      grainId: 'plastic_monoblock_lt_grey'
+    })
+  }),
+  Object.freeze({
+    id: 'carbonFiberChalkBeige',
+    label: POOL_ROYALE_OPTION_LABELS.tableFinish.carbonFiberChalkBeige,
+    description: 'Dark-grey LT carbon-fiber weave finish with a slightly brighter lift.',
+    price: 1180,
+    swatches: ['#3f4956', '#6a7788'],
+    thumbnail: swatchThumbnail(['#3f4956', '#6a7788']),
+    woodOption: Object.freeze({
+      id: 'carbonFiberChalkBeige',
+      label: POOL_ROYALE_OPTION_LABELS.tableFinish.carbonFiberChalkBeige,
+      presetId: 'carbonFiberChalkBeige',
+      grainId: 'plastic_monoblock_lt_dark_grey'
+    })
+  }),
+  Object.freeze({
+    id: 'carbonFiberChalkDarkBlue',
+    label: POOL_ROYALE_OPTION_LABELS.tableFinish.carbonFiberChalkDarkBlue,
+    description: 'Burgundy LT finish shifted to rosewood-brown warmth.',
+    price: 1190,
+    swatches: ['#6a3233', '#a55c5d'],
+    thumbnail: swatchThumbnail(['#6a3233', '#a55c5d']),
+    woodOption: Object.freeze({
+      id: 'carbonFiberChalkDarkBlue',
+      label: POOL_ROYALE_OPTION_LABELS.tableFinish.carbonFiberChalkDarkBlue,
+      presetId: 'carbonFiberChalkDarkBlue',
+      grainId: 'plastic_monoblock_lt_burgundy'
+    })
+  }),
+  Object.freeze({
+    id: 'carbonFiberChalkWhite',
+    label: POOL_ROYALE_OPTION_LABELS.tableFinish.carbonFiberChalkWhite,
+    description: 'Milk-cream LT carbon-fiber weave finish with a deeper cream tone.',
+    price: 1200,
+    swatches: ['#d8ccb9', '#ece3d3'],
+    thumbnail: swatchThumbnail(['#d8ccb9', '#ece3d3']),
+    woodOption: Object.freeze({
+      id: 'carbonFiberChalkWhite',
+      label: POOL_ROYALE_OPTION_LABELS.tableFinish.carbonFiberChalkWhite,
+      presetId: 'carbonFiberChalkWhite',
+      grainId: 'plastic_monoblock_lt_milk_cream'
+    })
+  }),
+  Object.freeze({
+    id: 'carbonFiberChalkDarkGreen',
+    label: POOL_ROYALE_OPTION_LABELS.tableFinish.carbonFiberChalkDarkGreen,
+    description: 'Dark-green LT carbon-fiber weave finish with rich forest depth.',
+    price: 1210,
+    swatches: ['#314d39', '#588365'],
+    thumbnail: swatchThumbnail(['#314d39', '#588365']),
+    woodOption: Object.freeze({
+      id: 'carbonFiberChalkDarkGreen',
+      label: POOL_ROYALE_OPTION_LABELS.tableFinish.carbonFiberChalkDarkGreen,
+      presetId: 'carbonFiberChalkDarkGreen',
+      grainId: 'plastic_monoblock_lt_dark_green'
+    })
+  }),
+  Object.freeze({
+    id: 'carbonFiberChalkDarkYellow',
+    label: POOL_ROYALE_OPTION_LABELS.tableFinish.carbonFiberChalkDarkYellow,
+    description: 'Dark-yellow LT carbon-fiber weave finish with mustard-gold warmth.',
+    price: 1220,
+    swatches: ['#8d6b2c', '#c79d52'],
+    thumbnail: swatchThumbnail(['#8d6b2c', '#c79d52']),
+    woodOption: Object.freeze({
+      id: 'carbonFiberChalkDarkYellow',
+      label: POOL_ROYALE_OPTION_LABELS.tableFinish.carbonFiberChalkDarkYellow,
+      presetId: 'carbonFiberChalkDarkYellow',
+      grainId: 'plastic_monoblock_lt_dark_yellow'
+    })
+  }),
+  Object.freeze({
+    id: 'carbonFiberChalkDarkBrown',
+    label: POOL_ROYALE_OPTION_LABELS.tableFinish.carbonFiberChalkDarkBrown,
+    description: 'Dark-brown LT carbon-fiber weave finish with earthy depth.',
+    price: 1230,
+    swatches: ['#5f3f30', '#95664f'],
+    thumbnail: swatchThumbnail(['#5f3f30', '#95664f']),
+    woodOption: Object.freeze({
+      id: 'carbonFiberChalkDarkBrown',
+      label: POOL_ROYALE_OPTION_LABELS.tableFinish.carbonFiberChalkDarkBrown,
+      presetId: 'carbonFiberChalkDarkBrown',
+      grainId: 'plastic_monoblock_lt_dark_brown'
+    })
+  }),
+  Object.freeze({
+    id: 'carbonFiberChalkDarkRed',
+    label: POOL_ROYALE_OPTION_LABELS.tableFinish.carbonFiberChalkDarkRed,
+    description: 'Dark-red LT carbon-fiber weave finish with deep crimson character.',
+    price: 1240,
+    swatches: ['#803a36', '#bd615e'],
+    thumbnail: swatchThumbnail(['#803a36', '#bd615e']),
+    woodOption: Object.freeze({
+      id: 'carbonFiberChalkDarkRed',
+      label: POOL_ROYALE_OPTION_LABELS.tableFinish.carbonFiberChalkDarkRed,
+      presetId: 'carbonFiberChalkDarkRed',
+      grainId: 'plastic_monoblock_lt_dark_red'
+    })
+  }),
+  Object.freeze({
+    id: 'carbonFiberAlligatorOlive',
+    label: POOL_ROYALE_OPTION_LABELS.tableFinish.carbonFiberAlligatorOlive,
+    description: 'Olive LT alligator-scale texture with natural reptile tone transitions.',
+    price: 1310,
+    swatches: ['#4c5d3f', '#6d7d58'],
+    thumbnail: swatchThumbnail(['#4c5d3f', '#6d7d58']),
+    woodOption: Object.freeze({
+      id: 'carbonFiberAlligatorOlive',
+      label: POOL_ROYALE_OPTION_LABELS.tableFinish.carbonFiberAlligatorOlive,
+      presetId: 'carbonFiberAlligatorOlive',
+      grainId: 'plastic_monoblock_lt_olive_alligator'
+    })
+  }),
+  Object.freeze({
+    id: 'carbonFiberAlligatorSwamp',
+    label: POOL_ROYALE_OPTION_LABELS.tableFinish.carbonFiberAlligatorSwamp,
+    description: 'Swamp-green LT alligator texture tuned to deep marsh tones.',
+    price: 1320,
+    swatches: ['#304b36', '#48624d'],
+    thumbnail: swatchThumbnail(['#304b36', '#48624d']),
+    woodOption: Object.freeze({
+      id: 'carbonFiberAlligatorSwamp',
+      label: POOL_ROYALE_OPTION_LABELS.tableFinish.carbonFiberAlligatorSwamp,
+      presetId: 'carbonFiberAlligatorSwamp',
+      grainId: 'plastic_monoblock_lt_swamp_alligator'
+    })
+  }),
+  Object.freeze({
+    id: 'carbonFiberAlligatorClay',
+    label: POOL_ROYALE_OPTION_LABELS.tableFinish.carbonFiberAlligatorClay,
+    description: 'Clay-brown LT alligator pattern with warm hide-inspired contrast.',
+    price: 1330,
+    swatches: ['#5f4c3c', '#816a56'],
+    thumbnail: swatchThumbnail(['#5f4c3c', '#816a56']),
+    woodOption: Object.freeze({
+      id: 'carbonFiberAlligatorClay',
+      label: POOL_ROYALE_OPTION_LABELS.tableFinish.carbonFiberAlligatorClay,
+      presetId: 'carbonFiberAlligatorClay',
+      grainId: 'plastic_monoblock_lt_clay_alligator'
+    })
+  }),
+  Object.freeze({
+    id: 'carbonFiberAlligatorSand',
+    label: POOL_ROYALE_OPTION_LABELS.tableFinish.carbonFiberAlligatorSand,
+    description: 'Sand LT alligator scales with brighter khaki highlights.',
+    price: 1340,
+    swatches: ['#7e6e56', '#a49277'],
+    thumbnail: swatchThumbnail(['#7e6e56', '#a49277']),
+    woodOption: Object.freeze({
+      id: 'carbonFiberAlligatorSand',
+      label: POOL_ROYALE_OPTION_LABELS.tableFinish.carbonFiberAlligatorSand,
+      presetId: 'carbonFiberAlligatorSand',
+      grainId: 'plastic_monoblock_lt_sand_alligator'
+    })
+  }),
+  Object.freeze({
+    id: 'carbonFiberAlligatorMoss',
+    label: POOL_ROYALE_OPTION_LABELS.tableFinish.carbonFiberAlligatorMoss,
+    description: 'Moss LT alligator texture balancing olive and slate greens.',
+    price: 1350,
+    swatches: ['#435340', '#60715c'],
+    thumbnail: swatchThumbnail(['#435340', '#60715c']),
+    woodOption: Object.freeze({
+      id: 'carbonFiberAlligatorMoss',
+      label: POOL_ROYALE_OPTION_LABELS.tableFinish.carbonFiberAlligatorMoss,
+      presetId: 'carbonFiberAlligatorMoss',
+      grainId: 'plastic_monoblock_lt_moss_alligator'
+    })
+  }),
+  Object.freeze({
+    id: 'carbonFiberAlligatorNight',
+    label: POOL_ROYALE_OPTION_LABELS.tableFinish.carbonFiberAlligatorNight,
+    description: 'Night LT alligator scales with muted charcoal-green depth.',
+    price: 1360,
+    swatches: ['#263129', '#3a453c'],
+    thumbnail: swatchThumbnail(['#263129', '#3a453c']),
+    woodOption: Object.freeze({
+      id: 'carbonFiberAlligatorNight',
+      label: POOL_ROYALE_OPTION_LABELS.tableFinish.carbonFiberAlligatorNight,
+      presetId: 'carbonFiberAlligatorNight',
+      grainId: 'plastic_monoblock_lt_night_alligator'
     })
   })
 ]);

--- a/webapp/src/pages/Games/FourInRowRoyal.jsx
+++ b/webapp/src/pages/Games/FourInRowRoyal.jsx
@@ -33,6 +33,7 @@ import {
   POOL_ROYALE_HDRI_VARIANT_MAP
 } from '../../config/poolRoyaleInventoryConfig.js';
 import { MURLAN_TABLE_FINISHES } from '../../config/murlanTableFinishes.js';
+import { MURLAN_TABLE_CLOTHS } from '../../config/murlanTableCloths.js';
 import {
   applyWoodTextures,
   DEFAULT_WOOD_GRAIN_ID,
@@ -181,16 +182,6 @@ const GRAPHICS_PRESETS = Object.freeze([
     preferredHdriResolutions: ['8k', '4k', '2k'],
     description: 'High-fidelity preset for flagship mobile GPUs.'
   },
-  {
-    id: 'ultra144',
-    label: 'Ultra HD+ (144 Hz)',
-    fps: 144,
-    pixelRatioScale: 1.35,
-    pixelRatioCap: 2.2,
-    shadowMapSize: 2048,
-    preferredHdriResolutions: ['8k', '4k'],
-    description: 'Maximum smoothness preset where thermals allow.'
-  }
 ]);
 let sharedKtx2Loader = null;
 const polyhavenModelUrlCache = new Map();
@@ -829,6 +820,7 @@ export default function FourInRowRoyal() {
 
   const [appearance, setAppearance] = useState(() => ({
     tableFinish: inventory.tableFinish?.[0] || MURLAN_TABLE_FINISHES[0]?.id,
+    clothColor: inventory.clothColor?.[0] || MURLAN_TABLE_CLOTHS[0]?.id,
     tableId:
       inventory.tables?.[0] ||
       FOUR_IN_ROW_BATTLE_DEFAULT_LOADOUT.tables?.[0] ||
@@ -1157,8 +1149,15 @@ export default function FourInRowRoyal() {
     tablePartsRef.current = table.parts;
     applyTableMaterials(
       table.parts,
-      MURLAN_TABLE_FINISHES.find((f) => f.id === appearance.tableFinish) ||
-        MURLAN_TABLE_FINISHES[0]
+      {
+        woodOption:
+          MURLAN_TABLE_FINISHES.find((f) => f.id === appearance.tableFinish)
+            ?.woodOption || MURLAN_TABLE_FINISHES[0]?.woodOption,
+        clothOption:
+          MURLAN_TABLE_CLOTHS.find((c) => c.id === appearance.clothColor) ||
+          MURLAN_TABLE_CLOTHS[0]
+      },
+      renderer
     );
 
     const chairTheme =
@@ -1895,11 +1894,19 @@ export default function FourInRowRoyal() {
 
   useEffect(() => {
     if (!tablePartsRef.current) return;
-    const finish =
-      MURLAN_TABLE_FINISHES.find((f) => f.id === appearance.tableFinish) ||
-      MURLAN_TABLE_FINISHES[0];
-    applyTableMaterials(tablePartsRef.current, finish);
-  }, [appearance.tableFinish]);
+    applyTableMaterials(
+      tablePartsRef.current,
+      {
+        woodOption:
+          MURLAN_TABLE_FINISHES.find((f) => f.id === appearance.tableFinish)
+            ?.woodOption || MURLAN_TABLE_FINISHES[0]?.woodOption,
+        clothOption:
+          MURLAN_TABLE_CLOTHS.find((c) => c.id === appearance.clothColor) ||
+          MURLAN_TABLE_CLOTHS[0]
+      },
+      rendererRef.current
+    );
+  }, [appearance.tableFinish, appearance.clothColor]);
 
   useEffect(() => {
     const chairTheme =
@@ -1997,8 +2004,17 @@ export default function FourInRowRoyal() {
     },
     {
       key: 'tableFinish',
-      label: 'Table Cloth',
+      label: 'Table Finish',
       options: MURLAN_TABLE_FINISHES.map((item) => ({
+        id: item.id,
+        label: item.label,
+        thumbnail: item.thumbnail
+      }))
+    },
+    {
+      key: 'clothColor',
+      label: 'Table Cloth',
+      options: MURLAN_TABLE_CLOTHS.map((item) => ({
         id: item.id,
         label: item.label,
         thumbnail: item.thumbnail
@@ -2087,9 +2103,6 @@ export default function FourInRowRoyal() {
             </span>
             <span className="leading-none">Menu</span>
           </button>
-          <h1 className="pointer-events-none rounded-2xl border border-white/15 bg-black/60 px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em]">
-            4 in a Row
-          </h1>
         </div>
 
         <div className="absolute top-20 right-4 flex flex-col items-end gap-3 pointer-events-none">
@@ -2155,7 +2168,7 @@ export default function FourInRowRoyal() {
       </div>
 
       <div className="pointer-events-none absolute inset-0 z-20">
-        <div className="absolute left-1/2 top-[11%] -translate-x-1/2">
+        <div className="absolute left-1/2 top-[18%] -translate-x-1/2">
           <AvatarTimer
             photoUrl="🤖"
             name="AI Rival"

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -262,7 +262,11 @@ const TAVULL_TYPE_LABELS = {
 const FOUR_IN_ROW_TYPE_LABELS = {
   tables: 'Table Models',
   tableFinish: 'Table Finish',
+  clothColor: 'Table Cloth',
   chairColor: 'Chairs',
+  boardFinish: 'Board Finish',
+  boardFrameFinish: 'Board Frame',
+  ringFinish: 'Ring Finish',
   boardTheme: 'Board Skins',
   boardLayout: 'Board Sizes',
   stoneStyle: 'Stone Sets',

--- a/webapp/src/utils/murlanTable.js
+++ b/webapp/src/utils/murlanTable.js
@@ -423,6 +423,34 @@ export function makeRoughClothTexture(size, topHex, bottomHex, anisotropy = 8) {
   return texture;
 }
 
+function createTonPlaygramBrandingTexture(ThreeNamespace = THREE) {
+  const canvas = document.createElement('canvas');
+  canvas.width = 1024;
+  canvas.height = 256;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return null;
+
+  const grad = ctx.createLinearGradient(0, 0, canvas.width, 0);
+  grad.addColorStop(0, '#0f172a');
+  grad.addColorStop(0.5, '#1e293b');
+  grad.addColorStop(1, '#0f172a');
+  ctx.fillStyle = grad;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  ctx.strokeStyle = 'rgba(148,163,184,0.75)';
+  ctx.lineWidth = 10;
+  ctx.strokeRect(8, 8, canvas.width - 16, canvas.height - 16);
+  ctx.fillStyle = '#f8fafc';
+  ctx.font = '700 120px Inter, system-ui, sans-serif';
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText('TonPlaygram', canvas.width / 2, canvas.height / 2);
+
+  const texture = new ThreeNamespace.CanvasTexture(canvas);
+  applySRGBColorSpace(texture);
+  texture.needsUpdate = true;
+  return texture;
+}
+
 function resolveWoodComponents(option) {
   const fallbackPreset = WOOD_FINISH_PRESETS.find((preset) => preset.id === 'walnut') || WOOD_FINISH_PRESETS[0];
   const preset = (option?.presetId && WOOD_FINISH_PRESETS.find((p) => p.id === option.presetId)) || fallbackPreset;
@@ -675,6 +703,26 @@ export function createMurlanStyleTable({
   rimMesh.receiveShadow = true;
   tableGroup.add(rimMesh);
 
+  const brandingTexture = createTonPlaygramBrandingTexture(ThreeNamespace);
+  const brandingPlateMat = new ThreeNamespace.MeshStandardMaterial({
+    color: new ThreeNamespace.Color('#dbe1ea'),
+    metalness: 0.72,
+    roughness: 0.34,
+    map: brandingTexture
+  });
+  const brandingPlate = new ThreeNamespace.Mesh(
+    new ThreeNamespace.BoxGeometry(
+      tableRadius * 0.42,
+      tableRadius * 0.082,
+      Math.max(0.018 * scaleFactor, 0.01)
+    ),
+    brandingPlateMat
+  );
+  brandingPlate.position.set(0, tableY + clothRise * 0.22, tableRadius * 0.84);
+  brandingPlate.castShadow = true;
+  brandingPlate.receiveShadow = true;
+  tableGroup.add(brandingPlate);
+
   if (includeBase) {
     const baseGeometry = new ThreeNamespace.CylinderGeometry(
       0.62 * scaleFactor,
@@ -742,6 +790,8 @@ export function createMurlanStyleTable({
     velvetTexture: null,
     topWoodMat,
     rimWoodMat,
+    brandingPlateMat,
+    brandingTexture,
     group: tableGroup
   };
 
@@ -755,6 +805,9 @@ export function createMurlanStyleTable({
     tableParts.trimMat?.dispose?.();
     tableParts.surfaceMat?.map?.dispose?.();
     tableParts.surfaceMat?.dispose?.();
+    tableParts.brandingPlateMat?.map?.dispose?.();
+    tableParts.brandingPlateMat?.dispose?.();
+    tableParts.brandingTexture?.dispose?.();
     if (tableGroup.parent) {
       tableGroup.parent.remove(tableGroup);
     }


### PR DESCRIPTION
### Motivation
- Reduce an unsupported/max graphics preset surface (remove 144 Hz) to match platform targets and avoid an extreme option in the menu. 
- Improve player presentation by aligning the top avatar visually with the chair area in portrait layout. 
- Expose the LT table finish family (same finishes used by Pool Royale) and Poly Haven cloths to Four in Row so players can buy/use the same table finishes and cloths as other games. 
- Add a small TonPlaygram branding plate on Murlan-style tables to match Pool Royale branding and make branding available on Octagon/Oval/Diamond/Hexagon table models. 

### Description
- Trimmed `GRAPHICS_PRESETS` in `webapp/src/pages/Games/FourInRowRoyal.jsx` to remove the `144 Hz` preset and keep the top preset at `120 Hz`. 
- Moved the top `AvatarTimer` down (from `top-[11%]` to `top-[18%]`) in `FourInRowRoyal.jsx` so the avatar visually sits with the chair; also removed the separate `4 in a Row` header that appeared under the menu. 
- Added Poly Haven cloth support to Four in Row by importing `MURLAN_TABLE_CLOTHS`, adding `clothColor` to the `appearance` state, adding a `Table Cloth` option group in the in-game menu, and wiring `clothOption` into `applyTableMaterials` calls in `FourInRowRoyal.jsx`. 
- Expanded shared table finishes with LT/carbon and LT-alligator variants in `webapp/src/config/murlanTableFinishes.js` so the same LT finishes used by Pool Royale are available for table/frame/board finishes and store items. 
- Added a TonPlaygram branding plate rendering pipeline into the shared table builder in `webapp/src/utils/murlanTable.js` including `createTonPlaygramBrandingTexture`, a proportional plate mesh placed on the table rim, material setup, and proper disposal in the table `dispose` routine. 
- Updated inventory/store wiring: `webapp/src/config/fourInRowInventoryConfig.js` now includes `clothColor` defaults and store items for cloths, and `webapp/src/pages/Store.jsx` was updated to expose the new `clothColor` and related type labels for Four in Row. 

### Testing
- Built the web app with `npm -C webapp run -s build`, and the production build completed successfully (Vite build finished without blocking errors). 
- The build produced normal warnings about some chunk sizes during minification but completed successfully and the modified game bundle (`FourInRowRoyal`) was included in the produced `dist` artifacts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e770ae431883299709806a68d8722e)