### PR TITLE
Four in Row: remove 144Hz option, add LT table finishes, cloths and branding plate

### DIFF
--- a/webapp/src/config/fourInRowInventoryConfig.js
+++ b/webapp/src/config/fourInRowInventoryConfig.js
@@ -1,11 +1,12 @@
-import { MURLAN_TABLE_THEMES } from './murlanThemes.js'
+import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from './murlanThemes.js'
 import { MURLAN_TABLE_FINISHES } from './murlanTableFinishes.js'
 import {
   POOL_ROYALE_DEFAULT_HDRI_ID,
-  POOL_ROYALE_HDRI_VARIANTS
+  POOL_ROYALE_HDRI_VARIANTS,
+  POOL_ROYALE_CLOTH_VARIANTS,
+  POOL_ROYALE_OPTION_LABELS
 } from './poolRoyaleInventoryConfig.js'
 import { swatchThumbnail } from './storeThumbnails.js'
-import { MURLAN_STOOL_THEMES } from './murlanThemes.js'
 
 const DEFAULT_HDRI_ID = POOL_ROYALE_DEFAULT_HDRI_ID || POOL_ROYALE_HDRI_VARIANTS[0]?.id
 
@@ -32,6 +33,94 @@ export const FOUR_IN_ROW_BOARD_THEMES = Object.freeze([
 
 export const FOUR_IN_ROW_BOARD_FINISH_OPTIONS = Object.freeze([...MURLAN_TABLE_FINISHES])
 export const FOUR_IN_ROW_BOARD_FRAME_FINISH_OPTIONS = Object.freeze([...MURLAN_TABLE_FINISHES])
+const LT_TABLE_FINISH_OPTIONS = Object.freeze([
+  {
+    id: 'carbonFiberChalk',
+    label: POOL_ROYALE_OPTION_LABELS.tableFinish.carbonFiberChalk,
+    description: 'Black LT carbon-fiber weave finish with a brighter charcoal tone.',
+    price: 1160,
+    swatches: ['#1f242b', '#4f5a68'],
+    thumbnail: swatchThumbnail(['#1f242b', '#4f5a68']),
+    woodOption: { id: 'carbonFiberChalk', label: POOL_ROYALE_OPTION_LABELS.tableFinish.carbonFiberChalk, presetId: 'oak', grainId: 'plastic_monoblock_lt_black' }
+  },
+  {
+    id: 'carbonFiberChalkGrey',
+    label: POOL_ROYALE_OPTION_LABELS.tableFinish.carbonFiberChalkGrey,
+    description: 'Grey LT carbon-fiber weave finish tuned a touch brighter for clarity.',
+    price: 1170,
+    swatches: ['#727d8b', '#a4adbb'],
+    thumbnail: swatchThumbnail(['#727d8b', '#a4adbb']),
+    woodOption: { id: 'carbonFiberChalkGrey', label: POOL_ROYALE_OPTION_LABELS.tableFinish.carbonFiberChalkGrey, presetId: 'oak', grainId: 'plastic_monoblock_lt_grey' }
+  },
+  {
+    id: 'carbonFiberChalkBeige',
+    label: POOL_ROYALE_OPTION_LABELS.tableFinish.carbonFiberChalkBeige,
+    description: 'Dark-grey LT carbon-fiber weave finish with a slightly brighter lift.',
+    price: 1180,
+    swatches: ['#3f4956', '#6a7788'],
+    thumbnail: swatchThumbnail(['#3f4956', '#6a7788']),
+    woodOption: { id: 'carbonFiberChalkBeige', label: POOL_ROYALE_OPTION_LABELS.tableFinish.carbonFiberChalkBeige, presetId: 'oak', grainId: 'plastic_monoblock_lt_dark_grey' }
+  },
+  {
+    id: 'carbonFiberChalkDarkBlue',
+    label: POOL_ROYALE_OPTION_LABELS.tableFinish.carbonFiberChalkDarkBlue,
+    description: 'Burgundy LT finish shifted to rosewood-brown warmth.',
+    price: 1190,
+    swatches: ['#6a3233', '#a55c5d'],
+    thumbnail: swatchThumbnail(['#6a3233', '#a55c5d']),
+    woodOption: { id: 'carbonFiberChalkDarkBlue', label: POOL_ROYALE_OPTION_LABELS.tableFinish.carbonFiberChalkDarkBlue, presetId: 'oak', grainId: 'plastic_monoblock_lt_burgundy' }
+  },
+  {
+    id: 'carbonFiberChalkWhite',
+    label: POOL_ROYALE_OPTION_LABELS.tableFinish.carbonFiberChalkWhite,
+    description: 'Milk-cream LT carbon-fiber weave finish with a deeper cream tone.',
+    price: 1200,
+    swatches: ['#d8ccb9', '#ece3d3'],
+    thumbnail: swatchThumbnail(['#d8ccb9', '#ece3d3']),
+    woodOption: { id: 'carbonFiberChalkWhite', label: POOL_ROYALE_OPTION_LABELS.tableFinish.carbonFiberChalkWhite, presetId: 'oak', grainId: 'plastic_monoblock_lt_milk_cream' }
+  },
+  {
+    id: 'carbonFiberChalkDarkGreen',
+    label: POOL_ROYALE_OPTION_LABELS.tableFinish.carbonFiberChalkDarkGreen,
+    description: 'Dark-green LT carbon-fiber weave finish with rich forest depth.',
+    price: 1210,
+    swatches: ['#314d39', '#588365'],
+    thumbnail: swatchThumbnail(['#314d39', '#588365']),
+    woodOption: { id: 'carbonFiberChalkDarkGreen', label: POOL_ROYALE_OPTION_LABELS.tableFinish.carbonFiberChalkDarkGreen, presetId: 'oak', grainId: 'plastic_monoblock_lt_dark_green' }
+  },
+  {
+    id: 'carbonFiberChalkDarkYellow',
+    label: POOL_ROYALE_OPTION_LABELS.tableFinish.carbonFiberChalkDarkYellow,
+    description: 'Dark-yellow LT carbon-fiber weave finish with mustard-gold warmth.',
+    price: 1220,
+    swatches: ['#8d6b2c', '#c79d52'],
+    thumbnail: swatchThumbnail(['#8d6b2c', '#c79d52']),
+    woodOption: { id: 'carbonFiberChalkDarkYellow', label: POOL_ROYALE_OPTION_LABELS.tableFinish.carbonFiberChalkDarkYellow, presetId: 'oak', grainId: 'plastic_monoblock_lt_dark_yellow' }
+  },
+  {
+    id: 'carbonFiberChalkDarkBrown',
+    label: POOL_ROYALE_OPTION_LABELS.tableFinish.carbonFiberChalkDarkBrown,
+    description: 'Dark-brown LT carbon-fiber weave finish with earthy depth.',
+    price: 1230,
+    swatches: ['#5f3f30', '#95664f'],
+    thumbnail: swatchThumbnail(['#5f3f30', '#95664f']),
+    woodOption: { id: 'carbonFiberChalkDarkBrown', label: POOL_ROYALE_OPTION_LABELS.tableFinish.carbonFiberChalkDarkBrown, presetId: 'oak', grainId: 'plastic_monoblock_lt_dark_brown' }
+  },
+  {
+    id: 'carbonFiberChalkDarkRed',
+    label: POOL_ROYALE_OPTION_LABELS.tableFinish.carbonFiberChalkDarkRed,
+    description: 'Dark-red LT carbon-fiber weave finish with deep crimson character.',
+    price: 1240,
+    swatches: ['#803a36', '#bd615e'],
+    thumbnail: swatchThumbnail(['#803a36', '#bd615e']),
+    woodOption: { id: 'carbonFiberChalkDarkRed', label: POOL_ROYALE_OPTION_LABELS.tableFinish.carbonFiberChalkDarkRed, presetId: 'oak', grainId: 'plastic_monoblock_lt_dark_red' }
+  }
+])
+export const FOUR_IN_ROW_TABLE_FINISH_OPTIONS = Object.freeze([
+  ...MURLAN_TABLE_FINISHES,
+  ...LT_TABLE_FINISH_OPTIONS
+])
+export const FOUR_IN_ROW_CLOTH_OPTIONS = Object.freeze([...POOL_ROYALE_CLOTH_VARIANTS])
 
 export const FOUR_IN_ROW_RING_FINISH_OPTIONS = Object.freeze([
   {
@@ -94,26 +183,28 @@ export const FOUR_IN_ROW_BATTLE_DEFAULT_UNLOCKS = Object.freeze({
   boardTheme: [FOUR_IN_ROW_BOARD_THEMES[0]?.id],
   boardLayout: [FOUR_IN_ROW_BOARD_LAYOUTS[0]?.id],
   stoneStyle: [FOUR_IN_ROW_STONE_STYLES[0]?.id],
+  clothColor: [FOUR_IN_ROW_CLOTH_OPTIONS[0]?.id],
   environmentHdri: [DEFAULT_HDRI_ID]
 })
 
 export const FOUR_IN_ROW_BATTLE_OPTION_LABELS = Object.freeze({
   chairColor: Object.freeze(FOUR_IN_ROW_CHAIR_OPTIONS.reduce((acc, option) => ({ ...acc, [option.id]: option.label }), {})),
   tables: Object.freeze(FOUR_IN_ROW_TABLE_OPTIONS.reduce((acc, option) => ({ ...acc, [option.id]: option.label }), {})),
-  tableFinish: Object.freeze(MURLAN_TABLE_FINISHES.reduce((acc, option) => ({ ...acc, [option.id]: option.label }), {})),
+  tableFinish: Object.freeze(FOUR_IN_ROW_TABLE_FINISH_OPTIONS.reduce((acc, option) => ({ ...acc, [option.id]: option.label }), {})),
   boardFinish: Object.freeze(FOUR_IN_ROW_BOARD_FINISH_OPTIONS.reduce((acc, option) => ({ ...acc, [option.id]: option.label }), {})),
   boardFrameFinish: Object.freeze(FOUR_IN_ROW_BOARD_FRAME_FINISH_OPTIONS.reduce((acc, option) => ({ ...acc, [option.id]: option.label }), {})),
   ringFinish: Object.freeze(FOUR_IN_ROW_RING_FINISH_OPTIONS.reduce((acc, option) => ({ ...acc, [option.id]: option.label }), {})),
   boardTheme: Object.freeze(FOUR_IN_ROW_BOARD_THEMES.reduce((acc, option) => ({ ...acc, [option.id]: option.label }), {})),
   boardLayout: Object.freeze(FOUR_IN_ROW_BOARD_LAYOUTS.reduce((acc, option) => ({ ...acc, [option.id]: option.label }), {})),
   stoneStyle: Object.freeze(FOUR_IN_ROW_STONE_STYLES.reduce((acc, option) => ({ ...acc, [option.id]: option.label }), {})),
+  clothColor: Object.freeze(FOUR_IN_ROW_CLOTH_OPTIONS.reduce((acc, option) => ({ ...acc, [option.id]: option.name }), {})),
   environmentHdri: Object.freeze(POOL_ROYALE_HDRI_VARIANTS.reduce((acc, variant) => ({ ...acc, [variant.id]: `${variant.name} HDRI` }), {}))
 })
 
 export const FOUR_IN_ROW_BATTLE_DEFAULT_LOADOUT = FOUR_IN_ROW_BATTLE_DEFAULT_UNLOCKS
 
 export const FOUR_IN_ROW_BATTLE_STORE_ITEMS = [
-  ...MURLAN_TABLE_FINISHES.map((finish, idx) => ({
+  ...FOUR_IN_ROW_TABLE_FINISH_OPTIONS.map((finish, idx) => ({
     id: `fourinrow-table-finish-${finish.id}`,
     type: 'tableFinish',
     optionId: finish.id,
@@ -208,6 +299,16 @@ export const FOUR_IN_ROW_BATTLE_STORE_ITEMS = [
     thumbnail: style.thumbnail,
     swatches: [style.black, style.white],
     previewShape: 'piece'
+  })),
+  ...FOUR_IN_ROW_CLOTH_OPTIONS.slice(1).map((variant, idx) => ({
+    id: `fourinrow-cloth-${variant.id}`,
+    type: 'clothColor',
+    optionId: variant.id,
+    name: `${variant.name} Cloth`,
+    price: 620 + idx * 45,
+    description: `Poly Haven ${variant.name} cloth finish for all 4 in a Row board tables.`,
+    thumbnail: variant.thumbnail || swatchThumbnail(variant.swatches || ['#1f2937', '#0f172a']),
+    swatches: variant.swatches
   })),
   ...POOL_ROYALE_HDRI_VARIANTS.slice(1).map((variant, idx) => ({
     id: `fourinrow-hdri-${variant.id}`,

--- a/webapp/src/pages/Games/FourInRowRoyal.jsx
+++ b/webapp/src/pages/Games/FourInRowRoyal.jsx
@@ -18,10 +18,12 @@ import {
 import {
   FOUR_IN_ROW_CHAIR_OPTIONS,
   FOUR_IN_ROW_BOARD_THEMES,
+  FOUR_IN_ROW_CLOTH_OPTIONS,
   FOUR_IN_ROW_BOARD_FINISH_OPTIONS,
   FOUR_IN_ROW_BOARD_FRAME_FINISH_OPTIONS,
   FOUR_IN_ROW_RING_FINISH_OPTIONS,
   FOUR_IN_ROW_STONE_STYLES,
+  FOUR_IN_ROW_TABLE_FINISH_OPTIONS,
   FOUR_IN_ROW_TABLE_OPTIONS,
   FOUR_IN_ROW_BATTLE_DEFAULT_LOADOUT,
   FOUR_IN_ROW_BOARD_LAYOUTS,
@@ -32,7 +34,6 @@ import {
   POOL_ROYALE_HDRI_VARIANTS,
   POOL_ROYALE_HDRI_VARIANT_MAP
 } from '../../config/poolRoyaleInventoryConfig.js';
-import { MURLAN_TABLE_FINISHES } from '../../config/murlanTableFinishes.js';
 import {
   applyWoodTextures,
   DEFAULT_WOOD_GRAIN_ID,
@@ -180,16 +181,6 @@ const GRAPHICS_PRESETS = Object.freeze([
     shadowMapSize: 2048,
     preferredHdriResolutions: ['8k', '4k', '2k'],
     description: 'High-fidelity preset for flagship mobile GPUs.'
-  },
-  {
-    id: 'ultra144',
-    label: 'Ultra HD+ (144 Hz)',
-    fps: 144,
-    pixelRatioScale: 1.35,
-    pixelRatioCap: 2.2,
-    shadowMapSize: 2048,
-    preferredHdriResolutions: ['8k', '4k'],
-    description: 'Maximum smoothness preset where thermals allow.'
   }
 ]);
 let sharedKtx2Loader = null;
@@ -789,6 +780,7 @@ export default function FourInRowRoyal() {
     trimMat: null,
     holeRimMat: null
   });
+  const tableBrandPlateRef = useRef(null);
   const keyLightRef = useRef(null);
   const graphicsPresetRef = useRef(getGraphicsPreset(GRAPHICS_PRESETS[1]?.id || GRAPHICS_PRESETS[0].id));
   const audioCtxRef = useRef(null);
@@ -828,7 +820,8 @@ export default function FourInRowRoyal() {
   const yStep = boardHeight / rows;
 
   const [appearance, setAppearance] = useState(() => ({
-    tableFinish: inventory.tableFinish?.[0] || MURLAN_TABLE_FINISHES[0]?.id,
+    tableFinish:
+      inventory.tableFinish?.[0] || FOUR_IN_ROW_TABLE_FINISH_OPTIONS[0]?.id,
     tableId:
       inventory.tables?.[0] ||
       FOUR_IN_ROW_BATTLE_DEFAULT_LOADOUT.tables?.[0] ||
@@ -857,6 +850,10 @@ export default function FourInRowRoyal() {
       inventory.stoneStyle?.[0] ||
       FOUR_IN_ROW_BATTLE_DEFAULT_LOADOUT.stoneStyle?.[0] ||
       FOUR_IN_ROW_STONE_STYLES[0]?.id,
+    clothColor:
+      inventory.clothColor?.[0] ||
+      FOUR_IN_ROW_BATTLE_DEFAULT_LOADOUT.clothColor?.[0] ||
+      FOUR_IN_ROW_CLOTH_OPTIONS[0]?.id,
     hdriId:
       inventory.environmentHdri?.[0] ||
       FOUR_IN_ROW_BATTLE_DEFAULT_LOADOUT.environmentHdri?.[0] ||
@@ -1155,11 +1152,56 @@ export default function FourInRowRoyal() {
       tableThemeId: appearance.tableId
     });
     tablePartsRef.current = table.parts;
-    applyTableMaterials(
-      table.parts,
-      MURLAN_TABLE_FINISHES.find((f) => f.id === appearance.tableFinish) ||
-        MURLAN_TABLE_FINISHES[0]
+    const selectedTableFinish =
+      FOUR_IN_ROW_TABLE_FINISH_OPTIONS.find((f) => f.id === appearance.tableFinish) ||
+      FOUR_IN_ROW_TABLE_FINISH_OPTIONS[0];
+    const selectedCloth =
+      FOUR_IN_ROW_CLOTH_OPTIONS.find((item) => item.id === appearance.clothColor) ||
+      FOUR_IN_ROW_CLOTH_OPTIONS[0];
+    applyTableMaterials(table.parts, {
+      woodOption: selectedTableFinish?.woodOption,
+      clothOption: selectedCloth
+    });
+    const plateGeometry = new THREE.BoxGeometry(
+      TABLE_RADIUS * 0.34,
+      TABLE_HEIGHT * 0.065,
+      TABLE_RADIUS * 0.024
     );
+    const plateMaterial = new THREE.MeshStandardMaterial({
+      color: '#1f2937',
+      metalness: 0.88,
+      roughness: 0.24,
+      emissive: '#020617',
+      emissiveIntensity: 0.2
+    });
+    const brandPlate = new THREE.Mesh(plateGeometry, plateMaterial);
+    brandPlate.position.set(0, TABLE_HEIGHT * 0.79, TABLE_RADIUS * 0.89);
+    brandPlate.castShadow = true;
+    brandPlate.receiveShadow = true;
+    const brandTextCanvas = document.createElement('canvas');
+    brandTextCanvas.width = 1024;
+    brandTextCanvas.height = 256;
+    const brandTextCtx = brandTextCanvas.getContext('2d');
+    if (brandTextCtx) {
+      brandTextCtx.clearRect(0, 0, brandTextCanvas.width, brandTextCanvas.height);
+      brandTextCtx.fillStyle = '#e2e8f0';
+      brandTextCtx.font = '700 124px Inter, Arial, sans-serif';
+      brandTextCtx.textAlign = 'center';
+      brandTextCtx.textBaseline = 'middle';
+      brandTextCtx.fillText('TonPlaygram', brandTextCanvas.width / 2, brandTextCanvas.height / 2);
+    }
+    const brandTextTexture = new THREE.CanvasTexture(brandTextCanvas);
+    brandTextTexture.needsUpdate = true;
+    const brandText = new THREE.Sprite(
+      new THREE.SpriteMaterial({
+        map: brandTextTexture,
+        transparent: true
+      })
+    );
+    brandText.scale.set(TABLE_RADIUS * 0.3, TABLE_HEIGHT * 0.14, 1);
+    brandText.position.set(0, TABLE_HEIGHT * 0.83, TABLE_RADIUS * 0.904);
+    table.group.add(brandPlate, brandText);
+    tableBrandPlateRef.current = { brandPlate, brandText, brandTextTexture };
 
     const chairTheme =
       FOUR_IN_ROW_CHAIR_OPTIONS.find(
@@ -1639,6 +1681,10 @@ export default function FourInRowRoyal() {
     return () => {
       cancelAnimationFrame(raf);
       window.removeEventListener('resize', onResize);
+      tableBrandPlateRef.current?.brandTextTexture?.dispose?.();
+      tableBrandPlateRef.current?.brandText?.material?.dispose?.();
+      tableBrandPlateRef.current?.brandPlate?.geometry?.dispose?.();
+      tableBrandPlateRef.current?.brandPlate?.material?.dispose?.();
       renderer.dispose();
       mount.removeChild(renderer.domElement);
     };
@@ -1896,10 +1942,16 @@ export default function FourInRowRoyal() {
   useEffect(() => {
     if (!tablePartsRef.current) return;
     const finish =
-      MURLAN_TABLE_FINISHES.find((f) => f.id === appearance.tableFinish) ||
-      MURLAN_TABLE_FINISHES[0];
-    applyTableMaterials(tablePartsRef.current, finish);
-  }, [appearance.tableFinish]);
+      FOUR_IN_ROW_TABLE_FINISH_OPTIONS.find((f) => f.id === appearance.tableFinish) ||
+      FOUR_IN_ROW_TABLE_FINISH_OPTIONS[0];
+    const clothOption =
+      FOUR_IN_ROW_CLOTH_OPTIONS.find((item) => item.id === appearance.clothColor) ||
+      FOUR_IN_ROW_CLOTH_OPTIONS[0];
+    applyTableMaterials(tablePartsRef.current, {
+      woodOption: finish?.woodOption,
+      clothOption
+    });
+  }, [appearance.tableFinish, appearance.clothColor]);
 
   useEffect(() => {
     const chairTheme =
@@ -1998,9 +2050,18 @@ export default function FourInRowRoyal() {
     {
       key: 'tableFinish',
       label: 'Table Cloth',
-      options: MURLAN_TABLE_FINISHES.map((item) => ({
+      options: FOUR_IN_ROW_TABLE_FINISH_OPTIONS.map((item) => ({
         id: item.id,
         label: item.label,
+        thumbnail: item.thumbnail
+      }))
+    },
+    {
+      key: 'clothColor',
+      label: 'Table Felt',
+      options: FOUR_IN_ROW_CLOTH_OPTIONS.map((item) => ({
+        id: item.id,
+        label: item.name,
         thumbnail: item.thumbnail
       }))
     },
@@ -2087,9 +2148,6 @@ export default function FourInRowRoyal() {
             </span>
             <span className="leading-none">Menu</span>
           </button>
-          <h1 className="pointer-events-none rounded-2xl border border-white/15 bg-black/60 px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em]">
-            4 in a Row
-          </h1>
         </div>
 
         <div className="absolute top-20 right-4 flex flex-col items-end gap-3 pointer-events-none">
@@ -2155,7 +2213,7 @@ export default function FourInRowRoyal() {
       </div>
 
       <div className="pointer-events-none absolute inset-0 z-20">
-        <div className="absolute left-1/2 top-[11%] -translate-x-1/2">
+        <div className="absolute left-1/2 top-[16%] -translate-x-1/2">
           <AvatarTimer
             photoUrl="🤖"
             name="AI Rival"


### PR DESCRIPTION
### Motivation
- Reduce an unsupported / undesirable graphics preset by removing the 144 Hz option and keep presets aligned with device profiles. 
- Expose the same LT table finish family and cloth (PolyHaven) options that exist in Pool Royale so users can buy and apply them to Four in a Row tables. 
- Improve HUD alignment so the top avatar visually sits in the chair and add TonPlaygram branding on each table for consistency with other games.

### Description
- Removed the `ultra144` graphics preset from the Four in a Row `GRAPHICS_PRESETS` list so the top preset is now `uhd120` (`webapp/src/pages/Games/FourInRowRoyal.jsx`).
- Removed the standalone “4 in a Row” text chip shown under the menu and shifted the top avatar HUD lower to appear seated (`webapp/src/pages/Games/FourInRowRoyal.jsx`).
- Added a carbon-fiber style TonPlaygram branding plate and a text sprite to the table mesh with proportional size/placement and cleanup logic (`webapp/src/pages/Games/FourInRowRoyal.jsx`).
- Added LT table finish options (mirroring Pool Royale LT finishes) and merged them into the Four in a Row table finish set (`webapp/src/config/fourInRowInventoryConfig.js`).
- Added table cloth/felt variants by reusing `POOL_ROYALE_CLOTH_VARIANTS`, added `clothColor` to default loadout and labels, added a new “Table Felt” option group in the in-game customization menu, and added purchasable cloth store entries (`webapp/src/config/fourInRowInventoryConfig.js`, `webapp/src/pages/Games/FourInRowRoyal.jsx`).
- Wired runtime application so `applyTableMaterials` receives both `woodOption` (table finish) and `clothOption` (cloth/felt) and updates the table visuals when selections change (`webapp/src/pages/Games/FourInRowRoyal.jsx`).

### Testing
- Ran linter on the modified config file with `npx eslint --no-ignore webapp/src/config/fourInRowInventoryConfig.js`, which succeeded.
- Ran `npx eslint` for the changed files in repo mode which surfaced repo ignore-pattern warnings for these source files; those warnings are due to repository eslint ignore configuration and do not block the changes.
- No unit tests or runtime integration tests were executed in this change; basic file-level linting and local code checks were performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e770ae431883299709806a68d8722e)