### PR TITLE
Shift bottom player hand left in Murlan/Domino table view

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -6608,6 +6608,7 @@ const HUMAN_HAND_VERTICAL_OFFSET = DOMINO_WIDTH * 0.065;
 const HUMAN_BOTTOM_EXTRA_OUTWARD = DOMINO_WIDTH * 0.04;
 const HUMAN_BOTTOM_EXTRA_RAISE = DOMINO_WIDTH * 0.145;
 const HUMAN_BOTTOM_HAND_GAP_SCALE = 0.88;
+const HUMAN_BOTTOM_HAND_LEFT_SHIFT = -DOMINO_WIDTH * 0.42;
 const DOMINO_DOUBLE_NEIGHBOR_EXTRA_GAP = 0;
 const DOMINO_OPENING_DOUBLE_SIDE_GAP = DOMINO_LENGTH * 0.11;
 const TILE_UP_H = 0.2 * DOMINO_WORLD_SCALE * DOMINO_HEIGHT_ADJUST;
@@ -8290,7 +8291,7 @@ function computeHandSlotPosition(
     const humanExtraOutwardX = (x0 / seatLength) * HUMAN_BOTTOM_EXTRA_OUTWARD;
     const humanExtraOutwardZ = (z0 / seatLength) * HUMAN_BOTTOM_EXTRA_OUTWARD;
     return new THREE.Vector3(
-      x0 + outwardX + humanExtraOutwardX + offset,
+      x0 + outwardX + humanExtraOutwardX + offset + HUMAN_BOTTOM_HAND_LEFT_SHIFT,
       handY - HUMAN_HAND_VERTICAL_OFFSET + HUMAN_BOTTOM_EXTRA_RAISE,
       handAnchorZ + outwardZ + humanExtraOutwardZ
     );
@@ -8298,7 +8299,8 @@ function computeHandSlotPosition(
   if (isSide) {
     return new THREE.Vector3(x0 + outwardX, handY, z0 + outwardZ + offset);
   }
-  return new THREE.Vector3(x0 + outwardX + offset, handY, z0 + outwardZ);
+  const humanLeftShift = isHuman ? HUMAN_BOTTOM_HAND_LEFT_SHIFT : 0;
+  return new THREE.Vector3(x0 + outwardX + offset + humanLeftShift, handY, z0 + outwardZ);
 }
 
 function renderHands() {


### PR DESCRIPTION
### Motivation
- Fix the visual alignment where the bottom (human) player's cards/hands were rendered too far to the right and should be moved left a bit on-screen for the Murlan/Domino table view.

### Description
- Added a new constant `HUMAN_BOTTOM_HAND_LEFT_SHIFT = -DOMINO_WIDTH * 0.42` to control a horizontal left shift for the human bottom hand.
- Applied `HUMAN_BOTTOM_HAND_LEFT_SHIFT` to the human bottom hand return path in `computeHandSlotPosition` so the bottom player's tiles/cards render further left in the non-flat view.
- Applied the same left shift for the shared return path so the bottom player's hand is consistently left-shifted for the other placement branch as well.
- Changes are confined to `webapp/public/domino-royal-game.js` and only affect hand positioning math.

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e78b0b1e0483299ff53ddc50c5a5eb)