### PR TITLE
Four in Row: remove 144Hz preset, UI tweaks, add LT table finishes & PolyHaven cloths, add branding plate

### DIFF
--- a/test/fourInRowInventoryConfig.test.js
+++ b/test/fourInRowInventoryConfig.test.js
@@ -1,0 +1,32 @@
+import {
+  FOUR_IN_ROW_BATTLE_DEFAULT_UNLOCKS,
+  FOUR_IN_ROW_BATTLE_OPTION_LABELS,
+  FOUR_IN_ROW_BATTLE_STORE_ITEMS,
+  FOUR_IN_ROW_TABLE_CLOTH_OPTIONS,
+  FOUR_IN_ROW_TABLE_FINISH_OPTIONS
+} from '../webapp/src/config/fourInRowInventoryConfig.js';
+
+describe('fourInRowInventoryConfig', () => {
+  test('includes LT table finishes in selectable options', () => {
+    const finishIds = new Set(FOUR_IN_ROW_TABLE_FINISH_OPTIONS.map((option) => option.id));
+    expect(finishIds.has('carbonFiberChalk')).toBe(true);
+    expect(finishIds.has('carbonFiberAlligatorNight')).toBe(true);
+  });
+
+  test('adds polyhaven cloth options to defaults and labels', () => {
+    const defaultCloth = FOUR_IN_ROW_BATTLE_DEFAULT_UNLOCKS.tableCloth?.[0];
+    expect(defaultCloth).toBe(FOUR_IN_ROW_TABLE_CLOTH_OPTIONS[0]?.id);
+    expect(FOUR_IN_ROW_BATTLE_OPTION_LABELS.tableCloth?.[defaultCloth]).toBeTruthy();
+  });
+
+  test('store includes table cloth and LT finish purchasables', () => {
+    const storeByType = FOUR_IN_ROW_BATTLE_STORE_ITEMS.reduce((acc, item) => {
+      if (!acc[item.type]) acc[item.type] = [];
+      acc[item.type].push(item.optionId);
+      return acc;
+    }, {});
+
+    expect(storeByType.tableCloth?.length).toBeGreaterThan(0);
+    expect(storeByType.tableFinish).toContain('carbonFiberChalk');
+  });
+});

--- a/webapp/src/config/fourInRowInventoryConfig.js
+++ b/webapp/src/config/fourInRowInventoryConfig.js
@@ -2,10 +2,12 @@ import { MURLAN_TABLE_THEMES } from './murlanThemes.js'
 import { MURLAN_TABLE_FINISHES } from './murlanTableFinishes.js'
 import {
   POOL_ROYALE_DEFAULT_HDRI_ID,
-  POOL_ROYALE_HDRI_VARIANTS
+  POOL_ROYALE_HDRI_VARIANTS,
+  POOL_ROYALE_STORE_ITEMS
 } from './poolRoyaleInventoryConfig.js'
 import { swatchThumbnail } from './storeThumbnails.js'
 import { MURLAN_STOOL_THEMES } from './murlanThemes.js'
+import { MURLAN_TABLE_CLOTHS } from './murlanTableCloths.js'
 
 const DEFAULT_HDRI_ID = POOL_ROYALE_DEFAULT_HDRI_ID || POOL_ROYALE_HDRI_VARIANTS[0]?.id
 
@@ -32,6 +34,55 @@ export const FOUR_IN_ROW_BOARD_THEMES = Object.freeze([
 
 export const FOUR_IN_ROW_BOARD_FINISH_OPTIONS = Object.freeze([...MURLAN_TABLE_FINISHES])
 export const FOUR_IN_ROW_BOARD_FRAME_FINISH_OPTIONS = Object.freeze([...MURLAN_TABLE_FINISHES])
+export const FOUR_IN_ROW_TABLE_CLOTH_OPTIONS = Object.freeze([...MURLAN_TABLE_CLOTHS])
+
+const POOL_ROYALE_LT_TABLE_FINISH_IDS = new Set([
+  'carbonFiberChalk',
+  'carbonFiberChalkGrey',
+  'carbonFiberChalkBeige',
+  'carbonFiberChalkDarkBlue',
+  'carbonFiberChalkWhite',
+  'carbonFiberChalkDarkGreen',
+  'carbonFiberChalkDarkYellow',
+  'carbonFiberChalkDarkBrown',
+  'carbonFiberChalkDarkRed',
+  'carbonFiberSnakeChalk',
+  'carbonFiberSnakeChalkGrey',
+  'carbonFiberSnakeChalkBeige',
+  'carbonFiberSnakeChalkDarkBlue',
+  'carbonFiberSnakeChalkWhite',
+  'carbonFiberSnakeChalkDarkGreen',
+  'carbonFiberAlligatorOlive',
+  'carbonFiberAlligatorSwamp',
+  'carbonFiberAlligatorClay',
+  'carbonFiberAlligatorSand',
+  'carbonFiberAlligatorMoss',
+  'carbonFiberAlligatorNight'
+])
+
+const FOUR_IN_ROW_LT_TABLE_FINISHES = Object.freeze(
+  POOL_ROYALE_STORE_ITEMS.filter(
+    (item) => item.type === 'tableFinish' && POOL_ROYALE_LT_TABLE_FINISH_IDS.has(item.optionId)
+  ).map((item) => ({
+    id: item.optionId,
+    label: item.name.replace(/\s*Finish$/i, ''),
+    description: item.description,
+    price: item.price,
+    swatches: item.swatches,
+    thumbnail: item.thumbnail,
+    woodOption: Object.freeze({
+      id: item.optionId,
+      label: item.name.replace(/\s*Finish$/i, ''),
+      presetId: 'smokedOak',
+      grainId: 'dark_wood'
+    })
+  }))
+)
+
+export const FOUR_IN_ROW_TABLE_FINISH_OPTIONS = Object.freeze([
+  ...MURLAN_TABLE_FINISHES,
+  ...FOUR_IN_ROW_LT_TABLE_FINISHES
+])
 
 export const FOUR_IN_ROW_RING_FINISH_OPTIONS = Object.freeze([
   {
@@ -87,7 +138,8 @@ export const FOUR_IN_ROW_STONE_STYLES = Object.freeze([
 export const FOUR_IN_ROW_BATTLE_DEFAULT_UNLOCKS = Object.freeze({
   chairColor: [FOUR_IN_ROW_CHAIR_OPTIONS[0]?.id],
   tables: [FOUR_IN_ROW_TABLE_OPTIONS[0]?.id],
-  tableFinish: [MURLAN_TABLE_FINISHES[0]?.id],
+  tableFinish: [FOUR_IN_ROW_TABLE_FINISH_OPTIONS[0]?.id],
+  tableCloth: [FOUR_IN_ROW_TABLE_CLOTH_OPTIONS[0]?.id],
   boardFinish: [FOUR_IN_ROW_BOARD_FINISH_OPTIONS[0]?.id],
   boardFrameFinish: [FOUR_IN_ROW_BOARD_FRAME_FINISH_OPTIONS[0]?.id],
   ringFinish: [FOUR_IN_ROW_RING_FINISH_OPTIONS[0]?.id],
@@ -100,7 +152,8 @@ export const FOUR_IN_ROW_BATTLE_DEFAULT_UNLOCKS = Object.freeze({
 export const FOUR_IN_ROW_BATTLE_OPTION_LABELS = Object.freeze({
   chairColor: Object.freeze(FOUR_IN_ROW_CHAIR_OPTIONS.reduce((acc, option) => ({ ...acc, [option.id]: option.label }), {})),
   tables: Object.freeze(FOUR_IN_ROW_TABLE_OPTIONS.reduce((acc, option) => ({ ...acc, [option.id]: option.label }), {})),
-  tableFinish: Object.freeze(MURLAN_TABLE_FINISHES.reduce((acc, option) => ({ ...acc, [option.id]: option.label }), {})),
+  tableFinish: Object.freeze(FOUR_IN_ROW_TABLE_FINISH_OPTIONS.reduce((acc, option) => ({ ...acc, [option.id]: option.label }), {})),
+  tableCloth: Object.freeze(FOUR_IN_ROW_TABLE_CLOTH_OPTIONS.reduce((acc, option) => ({ ...acc, [option.id]: option.label }), {})),
   boardFinish: Object.freeze(FOUR_IN_ROW_BOARD_FINISH_OPTIONS.reduce((acc, option) => ({ ...acc, [option.id]: option.label }), {})),
   boardFrameFinish: Object.freeze(FOUR_IN_ROW_BOARD_FRAME_FINISH_OPTIONS.reduce((acc, option) => ({ ...acc, [option.id]: option.label }), {})),
   ringFinish: Object.freeze(FOUR_IN_ROW_RING_FINISH_OPTIONS.reduce((acc, option) => ({ ...acc, [option.id]: option.label }), {})),
@@ -113,7 +166,7 @@ export const FOUR_IN_ROW_BATTLE_OPTION_LABELS = Object.freeze({
 export const FOUR_IN_ROW_BATTLE_DEFAULT_LOADOUT = FOUR_IN_ROW_BATTLE_DEFAULT_UNLOCKS
 
 export const FOUR_IN_ROW_BATTLE_STORE_ITEMS = [
-  ...MURLAN_TABLE_FINISHES.map((finish, idx) => ({
+  ...FOUR_IN_ROW_TABLE_FINISH_OPTIONS.map((finish, idx) => ({
     id: `fourinrow-table-finish-${finish.id}`,
     type: 'tableFinish',
     optionId: finish.id,
@@ -122,6 +175,17 @@ export const FOUR_IN_ROW_BATTLE_STORE_ITEMS = [
     description: finish.description,
     swatches: finish.swatches,
     thumbnail: finish.thumbnail,
+    previewShape: 'table'
+  })),
+  ...FOUR_IN_ROW_TABLE_CLOTH_OPTIONS.slice(1).map((cloth, idx) => ({
+    id: `fourinrow-table-cloth-${cloth.id}`,
+    type: 'tableCloth',
+    optionId: cloth.id,
+    name: cloth.label,
+    price: cloth.price ?? 620 + idx * 20,
+    description: cloth.description || `Poly Haven ${cloth.label} table cloth.`,
+    swatches: cloth.swatches,
+    thumbnail: cloth.thumbnail,
     previewShape: 'table'
   })),
   ...FOUR_IN_ROW_BOARD_FINISH_OPTIONS.slice(1).map((finish, idx) => ({

--- a/webapp/src/pages/Games/FourInRowRoyal.jsx
+++ b/webapp/src/pages/Games/FourInRowRoyal.jsx
@@ -25,14 +25,15 @@ import {
   FOUR_IN_ROW_TABLE_OPTIONS,
   FOUR_IN_ROW_BATTLE_DEFAULT_LOADOUT,
   FOUR_IN_ROW_BOARD_LAYOUTS,
-  FOUR_IN_ROW_BATTLE_OPTION_LABELS
+  FOUR_IN_ROW_BATTLE_OPTION_LABELS,
+  FOUR_IN_ROW_TABLE_FINISH_OPTIONS,
+  FOUR_IN_ROW_TABLE_CLOTH_OPTIONS
 } from '../../config/fourInRowInventoryConfig.js';
 import {
   POOL_ROYALE_DEFAULT_HDRI_ID,
   POOL_ROYALE_HDRI_VARIANTS,
   POOL_ROYALE_HDRI_VARIANT_MAP
 } from '../../config/poolRoyaleInventoryConfig.js';
-import { MURLAN_TABLE_FINISHES } from '../../config/murlanTableFinishes.js';
 import {
   applyWoodTextures,
   DEFAULT_WOOD_GRAIN_ID,
@@ -180,16 +181,6 @@ const GRAPHICS_PRESETS = Object.freeze([
     shadowMapSize: 2048,
     preferredHdriResolutions: ['8k', '4k', '2k'],
     description: 'High-fidelity preset for flagship mobile GPUs.'
-  },
-  {
-    id: 'ultra144',
-    label: 'Ultra HD+ (144 Hz)',
-    fps: 144,
-    pixelRatioScale: 1.35,
-    pixelRatioCap: 2.2,
-    shadowMapSize: 2048,
-    preferredHdriResolutions: ['8k', '4k'],
-    description: 'Maximum smoothness preset where thermals allow.'
   }
 ]);
 let sharedKtx2Loader = null;
@@ -744,6 +735,44 @@ const safeThumbnail = (value) => {
 const getGraphicsPreset = (graphicsId) =>
   GRAPHICS_PRESETS.find((g) => g.id === graphicsId) || GRAPHICS_PRESETS[1] || GRAPHICS_PRESETS[0];
 
+const createTonplaygramBrandingPlate = (tableRadius) => {
+  const width = Math.max(0.18, tableRadius * 0.24);
+  const height = Math.max(0.065, tableRadius * 0.082);
+  const plate = new THREE.Mesh(
+    new THREE.PlaneGeometry(width, height),
+    new THREE.MeshStandardMaterial({
+      color: '#10161f',
+      metalness: 0.78,
+      roughness: 0.28,
+      emissive: '#06090f',
+      emissiveIntensity: 0.32
+    })
+  );
+  const canvas = document.createElement('canvas');
+  canvas.width = 512;
+  canvas.height = 192;
+  const ctx = canvas.getContext('2d');
+  if (ctx) {
+    ctx.fillStyle = '#0f172a';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    ctx.strokeStyle = '#1f2937';
+    ctx.lineWidth = 8;
+    ctx.strokeRect(4, 4, canvas.width - 8, canvas.height - 8);
+    ctx.fillStyle = '#e5edf8';
+    ctx.font = '700 72px Inter, system-ui, sans-serif';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText('TonPlaygram', canvas.width / 2, canvas.height / 2);
+  }
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.colorSpace = THREE.SRGBColorSpace;
+  texture.needsUpdate = true;
+  plate.material.map = texture;
+  plate.material.needsUpdate = true;
+  plate.castShadow = true;
+  return plate;
+};
+
 const getArenaYOffsetForHdri = (hdriId) => {
   const variant =
     POOL_ROYALE_HDRI_VARIANT_MAP[hdriId] ||
@@ -828,7 +857,10 @@ export default function FourInRowRoyal() {
   const yStep = boardHeight / rows;
 
   const [appearance, setAppearance] = useState(() => ({
-    tableFinish: inventory.tableFinish?.[0] || MURLAN_TABLE_FINISHES[0]?.id,
+    tableFinish:
+      inventory.tableFinish?.[0] || FOUR_IN_ROW_TABLE_FINISH_OPTIONS[0]?.id,
+    tableCloth:
+      inventory.tableCloth?.[0] || FOUR_IN_ROW_TABLE_CLOTH_OPTIONS[0]?.id,
     tableId:
       inventory.tables?.[0] ||
       FOUR_IN_ROW_BATTLE_DEFAULT_LOADOUT.tables?.[0] ||
@@ -1147,19 +1179,42 @@ export default function FourInRowRoyal() {
     keyLightRef.current = key;
     scene.add(key);
 
+    const tableClothOption =
+      FOUR_IN_ROW_TABLE_CLOTH_OPTIONS.find(
+        (item) => item.id === appearance.tableCloth
+      ) || FOUR_IN_ROW_TABLE_CLOTH_OPTIONS[0];
+    const tableFinishOption =
+      FOUR_IN_ROW_TABLE_FINISH_OPTIONS.find(
+        (f) => f.id === appearance.tableFinish
+      ) || FOUR_IN_ROW_TABLE_FINISH_OPTIONS[0];
     const table = createMurlanStyleTable({
       arena: arenaRoot,
       renderer,
       tableRadius: TABLE_RADIUS,
       tableHeight: TABLE_HEIGHT,
-      tableThemeId: appearance.tableId
+      clothOption: {
+        ...tableClothOption,
+        preferredTextureResolutions: getGraphicsPreset(appearance.graphics)
+          .preferredHdriResolutions
+      }
     });
     tablePartsRef.current = table.parts;
     applyTableMaterials(
       table.parts,
-      MURLAN_TABLE_FINISHES.find((f) => f.id === appearance.tableFinish) ||
-        MURLAN_TABLE_FINISHES[0]
+      {
+        woodOption: tableFinishOption,
+        clothOption: {
+          ...tableClothOption,
+          preferredTextureResolutions: getGraphicsPreset(appearance.graphics)
+            .preferredHdriResolutions
+        }
+      },
+      renderer
     );
+    const brandingPlate = createTonplaygramBrandingPlate(TABLE_RADIUS);
+    brandingPlate.position.set(0, TABLE_HEIGHT - 0.1, TABLE_RADIUS * 0.88);
+    brandingPlate.rotation.y = Math.PI;
+    table.group.add(brandingPlate);
 
     const chairTheme =
       FOUR_IN_ROW_CHAIR_OPTIONS.find(
@@ -1896,10 +1951,24 @@ export default function FourInRowRoyal() {
   useEffect(() => {
     if (!tablePartsRef.current) return;
     const finish =
-      MURLAN_TABLE_FINISHES.find((f) => f.id === appearance.tableFinish) ||
-      MURLAN_TABLE_FINISHES[0];
-    applyTableMaterials(tablePartsRef.current, finish);
-  }, [appearance.tableFinish]);
+      FOUR_IN_ROW_TABLE_FINISH_OPTIONS.find((f) => f.id === appearance.tableFinish) ||
+      FOUR_IN_ROW_TABLE_FINISH_OPTIONS[0];
+    const cloth =
+      FOUR_IN_ROW_TABLE_CLOTH_OPTIONS.find((item) => item.id === appearance.tableCloth) ||
+      FOUR_IN_ROW_TABLE_CLOTH_OPTIONS[0];
+    applyTableMaterials(
+      tablePartsRef.current,
+      {
+        woodOption: finish,
+        clothOption: {
+          ...cloth,
+          preferredTextureResolutions: getGraphicsPreset(appearance.graphics)
+            .preferredHdriResolutions
+        }
+      },
+      rendererRef.current
+    );
+  }, [appearance.tableFinish, appearance.tableCloth, appearance.graphics]);
 
   useEffect(() => {
     const chairTheme =
@@ -1997,8 +2066,17 @@ export default function FourInRowRoyal() {
     },
     {
       key: 'tableFinish',
+      label: 'Table Finish',
+      options: FOUR_IN_ROW_TABLE_FINISH_OPTIONS.map((item) => ({
+        id: item.id,
+        label: item.label,
+        thumbnail: item.thumbnail
+      }))
+    },
+    {
+      key: 'tableCloth',
       label: 'Table Cloth',
-      options: MURLAN_TABLE_FINISHES.map((item) => ({
+      options: FOUR_IN_ROW_TABLE_CLOTH_OPTIONS.map((item) => ({
         id: item.id,
         label: item.label,
         thumbnail: item.thumbnail
@@ -2087,9 +2165,6 @@ export default function FourInRowRoyal() {
             </span>
             <span className="leading-none">Menu</span>
           </button>
-          <h1 className="pointer-events-none rounded-2xl border border-white/15 bg-black/60 px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em]">
-            4 in a Row
-          </h1>
         </div>
 
         <div className="absolute top-20 right-4 flex flex-col items-end gap-3 pointer-events-none">
@@ -2110,7 +2185,7 @@ export default function FourInRowRoyal() {
           {configOpen && (
             <div className="pointer-events-auto mt-2 w-[min(90vw,32rem)] max-h-[72vh] overflow-y-auto rounded-2xl border border-white/15 bg-black/80 p-4 text-xs text-white shadow-2xl backdrop-blur">
               <p className="text-[10px] uppercase tracking-[0.4em] text-sky-200/80">
-                4 in a Row Customization
+                Customization
               </p>
               <p className="mt-2 text-white/70">
                 Layout:{' '}
@@ -2155,7 +2230,7 @@ export default function FourInRowRoyal() {
       </div>
 
       <div className="pointer-events-none absolute inset-0 z-20">
-        <div className="absolute left-1/2 top-[11%] -translate-x-1/2">
+        <div className="absolute left-1/2 top-[22%] -translate-x-1/2">
           <AvatarTimer
             photoUrl="🤖"
             name="AI Rival"
@@ -2166,7 +2241,7 @@ export default function FourInRowRoyal() {
         </div>
         <div
           data-self-player="true"
-          className="absolute left-1/2 top-[91.5%] -translate-x-1/2"
+          className="absolute left-1/2 top-[79%] -translate-x-1/2"
         >
           <AvatarTimer
             photoUrl={avatar}

--- a/webapp/src/utils/murlanTable.js
+++ b/webapp/src/utils/murlanTable.js
@@ -91,9 +91,14 @@ function pickBestTextureUrls(apiJson, preferredSizes = POLYHAVEN_PREFERRED_SIZES
   };
 }
 
-async function loadPolyhavenTextureSet(assetId, textureLoader, maxAnisotropy = 1) {
+async function loadPolyhavenTextureSet(
+  assetId,
+  textureLoader,
+  maxAnisotropy = 1,
+  preferredSizes = POLYHAVEN_PREFERRED_SIZES
+) {
   if (!assetId || !textureLoader) return null;
-  const key = `${assetId.toLowerCase()}|${maxAnisotropy}`;
+  const key = `${assetId.toLowerCase()}|${maxAnisotropy}|${preferredSizes.join(',')}`;
   if (CLOTH_TEXTURE_CACHE.has(key)) {
     return CLOTH_TEXTURE_CACHE.get(key);
   }
@@ -103,7 +108,7 @@ async function loadPolyhavenTextureSet(assetId, textureLoader, maxAnisotropy = 1
       const response = await fetch(`https://api.polyhaven.com/files/${encodeURIComponent(assetId)}`);
       if (!response.ok) return null;
       const json = await response.json();
-      const urls = pickBestTextureUrls(json, POLYHAVEN_PREFERRED_SIZES);
+      const urls = pickBestTextureUrls(json, preferredSizes);
       if (!urls.diffuse) return null;
       const load = (url, isColor) =>
         new Promise((resolve, reject) => {
@@ -150,13 +155,19 @@ async function applyPolyhavenClothTexture(parts, clothOption, renderer) {
   const clothMat = parts?.surfaceMat;
   if (!clothMat || !clothOption?.sourceId) return;
   const maxAnisotropy = renderer?.capabilities?.getMaxAnisotropy?.() ?? 8;
+  const preferredResolutions =
+    Array.isArray(clothOption?.preferredTextureResolutions) &&
+    clothOption.preferredTextureResolutions.length
+      ? clothOption.preferredTextureResolutions
+      : POLYHAVEN_PREFERRED_SIZES;
   const requestId = `${clothOption.sourceId}-${Date.now()}`;
   clothMat.userData = { ...(clothMat.userData || {}), polyhavenRequestId: requestId, sourceId: clothOption.sourceId };
 
   const textures = await loadPolyhavenTextureSet(
     clothOption.sourceId,
     SHARED_TEXTURE_LOADER,
-    maxAnisotropy
+    maxAnisotropy,
+    preferredResolutions
   );
   if (!textures) return;
   if (clothMat.userData?.polyhavenRequestId !== requestId) return;


### PR DESCRIPTION
### Motivation
- Remove the 144 Hz graphics preset and tidy up the in-game menu text to match design decisions and target device support. 
- Seat the player avatar visually nearer the chair and align the AI avatar so avatars read as seated in the scene. 
- Reuse Pool Royale LT table finishes and Poly Haven cloths so players can buy and apply the same high-quality table finishes/cloths to Four in a Row tables. 
- Add in-scene branding (TonPlaygram plate) and ensure cloth textures follow the selected graphics preset for appropriate resolution.

### Description
- Removed the `ultra144` graphics preset from `webapp/src/pages/Games/FourInRowRoyal.jsx` so highest preset is now `uhd120` (120 Hz). 
- Cleaned the menu UI by removing the explicit "4 in a Row" chip and simplified the customization heading to `Customization`, and repositioned avatar overlays to better match chair placement in `FourInRowRoyal.jsx`. 
- Added a small TonPlaygram branding plate mesh via `createTonplaygramBrandingPlate` and attach it to the table group at a proportional location/size inside `FourInRowRoyal.jsx`. 
- Extended the Four in Row inventory/config to include table cloths and LT finishes by importing `MURLAN_TABLE_CLOTHS` and Pool Royale store items, exposing `FOUR_IN_ROW_TABLE_CLOTH_OPTIONS` and `FOUR_IN_ROW_TABLE_FINISH_OPTIONS`, updating defaults/labels/store entries in `webapp/src/config/fourInRowInventoryConfig.js`. 
- Updated runtime table creation and material application in `FourInRowRoyal.jsx` to pass both `woodOption` (finish) and `clothOption` into `createMurlanStyleTable`/`applyTableMaterials`, and added preferred-resolution wiring so cloth texture fetches match the selected graphics preset. 
- Enhanced `webapp/src/utils/murlanTable.js` to let `loadPolyhavenTextureSet` accept `preferredSizes` and to make `applyPolyhavenClothTexture` respect a `preferredTextureResolutions` hint, ensuring PolyHaven cloth textures are chosen appropriately for the graphics profile. 
- Added unit tests `test/fourInRowInventoryConfig.test.js` that assert LT finishes and table cloth options are present in Four in Row options and store entries.

### Testing
- Ran the targeted unit tests with `npm test -- --runInBand test/fourInRowInventoryConfig.test.js`, and all tests passed. 
- Verified module loads with `node -e "import('./webapp/src/config/fourInRowInventoryConfig.js').then(()=>console.log('ok'))"`, which printed `ok`. 
- Ran `npm run -s lint` scoped attempt which reported many unrelated repo lint errors (baseline), so lint did not provide a clean pass signal for these changes but the functional tests above passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e770ae431883299709806a68d8722e)