### PR TITLE
Tune Murlan Royale card layout, back logos, and camera framing

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2332,7 +2332,7 @@ const HUMAN_HAND_CLOSER_OFFSET = 0.042 * MODEL_SCALE;
 const HUMAN_HAND_BOTTOM_SHIFT_Y = 0.0 * MODEL_SCALE;
 const AI_HAND_BOTTOM_SHIFT_Y = -0.02 * MODEL_SCALE;
 const AI_HAND_CLOSER_OFFSET = 0.02 * MODEL_SCALE;
-const HUMAN_HAND_LEFT_SHIFT = 0.18 * MODEL_SCALE; // Positive value shifts the bottom human hand visually left on portrait camera.
+const HUMAN_HAND_LEFT_SHIFT = 0.205 * MODEL_SCALE; // Positive value shifts the bottom human hand visually left on portrait camera.
 const AI_HAND_LEFT_SHIFT = 0;
 const HUMAN_HAND_UP_SHIFT_Y = 0.092 * MODEL_SCALE;
 const HUMAN_HAND_DIRECTIONAL_LIFT = 0;
@@ -2409,13 +2409,13 @@ const CAMERA_PLAY_FOLLOW_HOLD_MS = 420;
 const CAMERA_PLAY_NEXT_TURN_DELAY_MS = 520;
 const CAMERA_PLAY_TURN_DURATION_MS = 300;
 const CAMERA_TARGET_TURN_SNAP_DISTANCE = 0.018 * MODEL_SCALE;
-const CAMERA_PLAYER_TARGET_WEIGHT = 0.52;
+const CAMERA_PLAYER_TARGET_WEIGHT = 0.6;
 const HDRI_GROUND_FLOOR_Y = -0.015 * MODEL_SCALE;
 const ARENA_GROUND_Y = HDRI_GROUND_FLOOR_Y;
 const HDRI_GROUND_FLOOR_RADIUS_MULTIPLIER = 1.52;
 const HDRI_GROUND_FLOOR_OPACITY = 0.22;
 const HDRI_BACKGROUND_PITCH = THREE.MathUtils.degToRad(-2.4);
-const CAMERA_SIDE_LOOK_EXTRA = 0.34 * MODEL_SCALE;
+const CAMERA_SIDE_LOOK_EXTRA = 0.44 * MODEL_SCALE;
 const CAMERA_INWARD_RADIUS_FACTOR = 1;
 const CAMERA_UP_TILT_FORWARD_BLEND = 0.34 * MODEL_SCALE;
 const CAMERA_UP_TILT_FORWARD_LERP = 0.14;
@@ -5022,7 +5022,7 @@ export default function MurlanRoyaleArena({ search }) {
       const safeHorizontalReach = Math.max(2.6 * MODEL_SCALE, cameraBoundRadius);
       const maxOrbitRadius = Math.max(3.6 * MODEL_SCALE, safeHorizontalReach / Math.sin(ARENA_CAMERA_DEFAULTS.phiMax));
       const minOrbitRadius = Math.max(2.4 * MODEL_SCALE, maxOrbitRadius * 0.58);
-      const desiredRadius = Math.min(maxOrbitRadius, minOrbitRadius * 1.1) * CAMERA_INWARD_RADIUS_FACTOR * 0.84;
+      const desiredRadius = Math.min(maxOrbitRadius, minOrbitRadius * 1.1) * CAMERA_INWARD_RADIUS_FACTOR * 0.88;
       spherical.radius = desiredRadius;
       spherical.phi = THREE.MathUtils.clamp(
         spherical.phi,
@@ -6396,9 +6396,8 @@ function updateCardFace(mesh, mode) {
   if (!frontMaterial || !backMaterial) return;
   if (mode === cardFace) return;
   if (mode === 'back') {
-    const mat = hiddenMaterial ?? backMaterial;
-    mesh.material[4] = mat;
-    mesh.material[5] = mat;
+    mesh.material[4] = backMaterial;
+    mesh.material[5] = backMaterial;
     mesh.userData.cardFace = 'back';
     return;
   }
@@ -6528,21 +6527,42 @@ function makeCardFace(rank, suit, theme, w = 768, h = 1080) {
   const color = SUIT_COLORS[suit] || '#0f172a';
   const label = rank === 'JB' ? 'JB' : rank === 'JR' ? 'JR' : String(rank);
 
-  // Keep rank/suit indicators visually at the top for portrait gameplay readability.
+  const drawCornerIndicator = ({
+    x,
+    y,
+    angleDeg = 0,
+    align = 'left',
+    baseline = 'top'
+  }) => {
+    g.save();
+    g.translate(x, y);
+    g.rotate(THREE.MathUtils.degToRad(angleDeg));
+    g.fillStyle = color;
+    g.textAlign = align;
+    g.textBaseline = baseline;
+    g.font = `900 ${Math.round(w * 0.19)}px "Inter", "Segoe UI", sans-serif`;
+    g.fillText(label, 0, 0);
+    g.font = `${Math.round(w * 0.18)}px "Inter", "Segoe UI", sans-serif`;
+    g.fillText(suit, 0, Math.round(h * 0.105));
+    g.restore();
+  };
+
+  // Move rank/suit indicators to the left side and tilt them diagonally for portrait readability.
   g.fillStyle = color;
-  g.textAlign = 'left';
-  g.textBaseline = 'top';
-  g.font = `900 ${Math.round(w * 0.19)}px "Inter", "Segoe UI", sans-serif`;
-  g.fillText(label, Math.round(w * 0.095), Math.round(h * 0.04));
-
-  g.font = `${Math.round(w * 0.18)}px "Inter", "Segoe UI", sans-serif`;
-  g.fillText(suit, Math.round(w * 0.12), Math.round(h * 0.145));
-
-  g.textAlign = 'right';
-  g.font = `900 ${Math.round(w * 0.19)}px "Inter", "Segoe UI", sans-serif`;
-  g.fillText(label, Math.round(w * 0.905), Math.round(h * 0.04));
-  g.font = `${Math.round(w * 0.18)}px "Inter", "Segoe UI", sans-serif`;
-  g.fillText(suit, Math.round(w * 0.88), Math.round(h * 0.145));
+  drawCornerIndicator({
+    x: Math.round(w * 0.12),
+    y: Math.round(h * 0.08),
+    angleDeg: -17,
+    align: 'left',
+    baseline: 'top'
+  });
+  drawCornerIndicator({
+    x: Math.round(w * 0.11),
+    y: Math.round(h * 0.93),
+    angleDeg: -17,
+    align: 'left',
+    baseline: 'alphabetic'
+  });
 
   g.textAlign = 'center';
   g.textBaseline = 'middle';


### PR DESCRIPTION
### Motivation
- Align the bottom (human) player hand slightly left for portrait screens, render corner rank/suit indicators diagonally at the left edge, ensure card backs show the Tonplaygram logo/pattern, and give the camera a slightly wider view and stronger left/right focus when switching active players.

### Description
- Increased the bottom-hand lateral offset by updating `HUMAN_HAND_LEFT_SHIFT` to shift the human hand further left in `webapp/src/pages/Games/MurlanRoyaleArena.jsx`.
- Reworked card face corner rendering by adding a `drawCornerIndicator` routine and drawing the rank/suit rotated/diagonal on the left side in `makeCardFace` in `MurlanRoyaleArena.jsx` so numbers/letters match the requested diagonal placement.
- Forced hidden/back face rendering to use the themed back material (so the Tonplaygram logo/pattern is visible) by changing `updateCardFace` to assign `backMaterial` when showing the back in `MurlanRoyaleArena.jsx`.
- Tuned camera framing by increasing `CAMERA_PLAYER_TARGET_WEIGHT`, `CAMERA_SIDE_LOOK_EXTRA`, and slightly increasing the orbit `desiredRadius` multiplier to give a bit more zoom-out and stronger left/right look bias in `MurlanRoyaleArena.jsx`.

### Testing
- Ran the production frontend build with `npm -C webapp run -s build`, which completed successfully (build artifacts produced, minor chunk-size warnings only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e79a5764ec83299808e1edc95a4e9f)