### PR TITLE
Murlan Royale: fix card faces, back logo orientation/scale, hand placement & layering

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2332,7 +2332,7 @@ const HUMAN_HAND_CLOSER_OFFSET = 0.042 * MODEL_SCALE;
 const HUMAN_HAND_BOTTOM_SHIFT_Y = 0.0 * MODEL_SCALE;
 const AI_HAND_BOTTOM_SHIFT_Y = -0.02 * MODEL_SCALE;
 const AI_HAND_CLOSER_OFFSET = 0.02 * MODEL_SCALE;
-const HUMAN_HAND_LEFT_SHIFT = 0.2 * MODEL_SCALE; // Positive value shifts the bottom human hand visually left on portrait camera.
+const HUMAN_HAND_LEFT_SHIFT = -0.08 * MODEL_SCALE; // Negative nudges the bottom hand a bit right (toward the gift icon on portrait).
 const AI_HAND_LEFT_SHIFT = 0;
 const HUMAN_HAND_UP_SHIFT_Y = 0.092 * MODEL_SCALE;
 const HUMAN_HAND_DIRECTIONAL_LIFT = 0;
@@ -6494,9 +6494,10 @@ function createCardMesh(card, geometry, cache, theme) {
 function applyHandCardLayering(mesh, isHumanCard, stackOrder = 0) {
   if (!mesh?.isMesh) return;
   const orderBase = isHumanCard ? 16 : 4;
-  mesh.renderOrder = orderBase + stackOrder;
+  const orderOffset = isHumanCard ? stackOrder : -stackOrder;
+  mesh.renderOrder = orderBase + orderOffset;
 
-  const shouldForceRenderOrder = Boolean(isHumanCard);
+  const shouldForceRenderOrder = true;
   if (mesh.userData?.forceHandRenderOrder === shouldForceRenderOrder) {
     return;
   }
@@ -6553,13 +6554,6 @@ function makeCardFace(rank, suit, theme, w = 768, h = 1080) {
   g.fillText(suit, 0, Math.round(h * 0.035));
   g.restore();
 
-  g.textAlign = 'right';
-  g.textBaseline = 'top';
-  g.font = `900 ${Math.round(w * 0.19)}px "Inter", "Segoe UI", sans-serif`;
-  g.fillText(label, Math.round(w * 0.905), Math.round(h * 0.04));
-  g.font = `${Math.round(w * 0.18)}px "Inter", "Segoe UI", sans-serif`;
-  g.fillText(suit, Math.round(w * 0.88), Math.round(h * 0.145));
-
   g.textAlign = 'center';
   g.textBaseline = 'middle';
   g.font = `700 ${Math.round(w * 0.36)}px "Inter", "Segoe UI", sans-serif`;
@@ -6575,7 +6569,10 @@ function makeCardFace(rank, suit, theme, w = 768, h = 1080) {
 }
 
 function makeCardBackTexture(theme) {
-  return makeTonplaygramCardBackTexture(theme);
+  return makeTonplaygramCardBackTexture(theme, undefined, undefined, {
+    logoScale: 1.16,
+    rotateLogoDegrees: 180
+  });
 }
 
 function applyChairThemeMaterials(three, theme) {

--- a/webapp/src/utils/cards3d.js
+++ b/webapp/src/utils/cards3d.js
@@ -154,7 +154,11 @@ function makeCardFace(rank, suit, theme, w = 512, h = 720) {
   return texture;
 }
 
-export function makeTonplaygramCardBackTexture(theme, w = 3072, h = 4320) {
+export function makeTonplaygramCardBackTexture(theme, w = 3072, h = 4320, options = {}) {
+  const {
+    logoScale = 1,
+    rotateLogoDegrees = 0
+  } = options ?? {};
   const canvas = document.createElement('canvas');
   canvas.width = w;
   canvas.height = h;
@@ -164,7 +168,7 @@ export function makeTonplaygramCardBackTexture(theme, w = 3072, h = 4320) {
     ctx.fillStyle = cardBackPattern || '#112233';
     ctx.fillRect(0, 0, w, h);
 
-    drawLogoFrame(ctx, w, h, theme);
+    drawLogoFrame(ctx, w, h, theme, { logoScale, rotateLogoDegrees });
   };
 
   drawBack();
@@ -350,7 +354,11 @@ function drawBackPattern(ctx, w, h, theme) {
   ctx.restore();
 }
 
-function drawLogoFrame(ctx, w, h, theme) {
+function drawLogoFrame(ctx, w, h, theme, options = {}) {
+  const {
+    logoScale = 1,
+    rotateLogoDegrees = 0
+  } = options ?? {};
   const frameInset = Math.min(w, h) * 0.045;
   const frameRadius = Math.min(w, h) * 0.04;
   const frameWidth = w - frameInset * 2;
@@ -386,13 +394,16 @@ function drawLogoFrame(ctx, w, h, theme) {
 
   if (logoImage?.complete && logoImage.naturalWidth > 0) {
     const ratio = logoImage.naturalWidth / Math.max(logoImage.naturalHeight, 1);
-    const logoBoxWidth = w * 0.72;
-    const logoBoxHeight = h * 0.24;
+    const logoBoxWidth = w * 0.72 * logoScale;
+    const logoBoxHeight = h * 0.24 * logoScale;
     const drawWidth = Math.min(logoBoxWidth, logoBoxHeight * ratio);
     const drawHeight = drawWidth / ratio;
-    const logoX = w / 2 - drawWidth / 2;
-    const logoY = h / 2 - drawHeight / 2;
-    ctx.drawImage(logoImage, logoX, logoY, drawWidth, drawHeight);
+    const rotation = THREE.MathUtils.degToRad(rotateLogoDegrees);
+    ctx.translate(w / 2, h / 2);
+    if (Math.abs(rotation) > 1e-6) {
+      ctx.rotate(rotation);
+    }
+    ctx.drawImage(logoImage, -drawWidth / 2, -drawHeight / 2, drawWidth, drawHeight);
   } else {
     ctx.fillStyle = theme.backAccent || 'rgba(255,255,255,0.85)';
     ctx.textAlign = 'center';


### PR DESCRIPTION
### Motivation
- Remove the non-diagonal rank/suit mark visible on Murlan cards so card faces match the two diagonal corner style shown in the reference. 
- Make the TonPlaygram logo on card backs larger and upright for Murlan-themed decks, and stop logo/back assets overlapping badly. 
- Nudge the bottom (human) player hand toward the gift icon in portrait and stabilize card back overlap by enforcing render ordering.

### Description
- Removed the extra non-diagonal corner label from Murlan card face rendering by deleting the right/top corner `fillText` block in `makeCardFace` (`webapp/src/pages/Games/MurlanRoyaleArena.jsx`).
- Tuned bottom-hand placement by changing `HUMAN_HAND_LEFT_SHIFT` from `0.2 * MODEL_SCALE` to `-0.08 * MODEL_SCALE` so player cards shift slightly toward the gift icon in portrait (`webapp/src/pages/Games/MurlanRoyaleArena.jsx`).
- Improved hand-card layering by computing an `orderOffset` and forcing consistent material `depthTest`/`depthWrite` behavior for hands to reduce visible overlap artifacts (`applyHandCardLayering` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx`).
- Added optional logo controls to the shared card-back generator: `makeTonplaygramCardBackTexture(theme, w, h, options)` and `drawLogoFrame(..., options)` support `logoScale` and `rotateLogoDegrees` and draw the logo using a canvas translate/rotate so it can be scaled and oriented correctly (`webapp/src/utils/cards3d.js`).
- Applied those back-texture options for Murlan card backs (calls `makeTonplaygramCardBackTexture(...)` with `logoScale: 1.16` and `rotateLogoDegrees: 180`) so the logo is larger and upright as viewed in-game (`webapp/src/pages/Games/MurlanRoyaleArena.jsx`).

### Testing
- Ran the production build with `npm --prefix webapp run -s build` and the build completed successfully (Vite build finished; existing chunk-size warnings were emitted but are unrelated to this change). 
- Attempted `npm --prefix webapp run -s lint` but there is no `lint` script in `webapp/package.json` so no lint run was performed.
- No unit tests were modified; no test failures introduced by the build step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7b03d797c8329914abe9578dbe739)