### PR TITLE
Adjust Murlan Royale card faces, back logos, and hand placement

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2332,7 +2332,7 @@ const HUMAN_HAND_CLOSER_OFFSET = 0.042 * MODEL_SCALE;
 const HUMAN_HAND_BOTTOM_SHIFT_Y = 0.0 * MODEL_SCALE;
 const AI_HAND_BOTTOM_SHIFT_Y = -0.02 * MODEL_SCALE;
 const AI_HAND_CLOSER_OFFSET = 0.02 * MODEL_SCALE;
-const HUMAN_HAND_LEFT_SHIFT = 0.2 * MODEL_SCALE; // Positive value shifts the bottom human hand visually left on portrait camera.
+const HUMAN_HAND_LEFT_SHIFT = 0.14 * MODEL_SCALE; // Positive value shifts the bottom human hand visually left on portrait camera.
 const AI_HAND_LEFT_SHIFT = 0;
 const HUMAN_HAND_UP_SHIFT_Y = 0.092 * MODEL_SCALE;
 const HUMAN_HAND_DIRECTIONAL_LIFT = 0;
@@ -6496,8 +6496,17 @@ function applyHandCardLayering(mesh, isHumanCard, stackOrder = 0) {
   const orderBase = isHumanCard ? 16 : 4;
   mesh.renderOrder = orderBase + stackOrder;
 
-  const shouldForceRenderOrder = Boolean(isHumanCard);
+  const shouldForceRenderOrder = true;
   if (mesh.userData?.forceHandRenderOrder === shouldForceRenderOrder) {
+    if (!isHumanCard) {
+      const allMaterials = Array.isArray(mesh.material) ? mesh.material : [mesh.material];
+      allMaterials.forEach((material) => {
+        if (!material) return;
+        material.polygonOffset = true;
+        material.polygonOffsetFactor = -1 - stackOrder * 0.08;
+        material.polygonOffsetUnits = -1;
+      });
+    }
     return;
   }
   mesh.userData.forceHandRenderOrder = shouldForceRenderOrder;
@@ -6505,8 +6514,11 @@ function applyHandCardLayering(mesh, isHumanCard, stackOrder = 0) {
   const allMaterials = Array.isArray(mesh.material) ? mesh.material : [mesh.material];
   allMaterials.forEach((material) => {
     if (!material) return;
-    material.depthTest = !shouldForceRenderOrder;
+    material.depthTest = isHumanCard ? false : true;
     material.depthWrite = !shouldForceRenderOrder;
+    material.polygonOffset = !isHumanCard;
+    material.polygonOffsetFactor = !isHumanCard ? -1 - stackOrder * 0.08 : 0;
+    material.polygonOffsetUnits = !isHumanCard ? -1 : 0;
     material.needsUpdate = true;
   });
 }
@@ -6531,17 +6543,6 @@ function makeCardFace(rank, suit, theme, w = 768, h = 1080) {
   const diagonalTilt = THREE.MathUtils.degToRad(-13);
 
   g.fillStyle = color;
-  g.save();
-  g.translate(Math.round(w * 0.14), Math.round(h * 0.115));
-  g.rotate(diagonalTilt);
-  g.textAlign = 'center';
-  g.textBaseline = 'middle';
-  g.font = `900 ${cornerRankSize}px "Inter", "Segoe UI", sans-serif`;
-  g.fillText(label, 0, -Math.round(h * 0.03));
-  g.font = `${cornerSuitSize}px "Inter", "Segoe UI", sans-serif`;
-  g.fillText(suit, 0, Math.round(h * 0.035));
-  g.restore();
-
   g.save();
   g.translate(Math.round(w * 0.14), Math.round(h * 0.87));
   g.rotate(diagonalTilt);
@@ -6575,7 +6576,11 @@ function makeCardFace(rank, suit, theme, w = 768, h = 1080) {
 }
 
 function makeCardBackTexture(theme) {
-  return makeTonplaygramCardBackTexture(theme);
+  const texture = makeTonplaygramCardBackTexture(theme);
+  texture.center.set(0.5, 0.5);
+  texture.rotation = Math.PI;
+  texture.needsUpdate = true;
+  return texture;
 }
 
 function applyChairThemeMaterials(three, theme) {

--- a/webapp/src/utils/cards3d.js
+++ b/webapp/src/utils/cards3d.js
@@ -369,8 +369,8 @@ function drawLogoFrame(ctx, w, h, theme) {
   ctx.restore();
 
   ctx.save();
-  const plateWidth = w * 0.8;
-  const plateHeight = h * 0.28;
+  const plateWidth = w * 0.88;
+  const plateHeight = h * 0.34;
   const plateX = (w - plateWidth) / 2;
   const plateY = (h - plateHeight) / 2;
   const plateGradient = ctx.createLinearGradient(plateX, plateY, plateX, plateY + plateHeight);
@@ -386,8 +386,8 @@ function drawLogoFrame(ctx, w, h, theme) {
 
   if (logoImage?.complete && logoImage.naturalWidth > 0) {
     const ratio = logoImage.naturalWidth / Math.max(logoImage.naturalHeight, 1);
-    const logoBoxWidth = w * 0.72;
-    const logoBoxHeight = h * 0.24;
+    const logoBoxWidth = w * 0.82;
+    const logoBoxHeight = h * 0.3;
     const drawWidth = Math.min(logoBoxWidth, logoBoxHeight * ratio);
     const drawHeight = drawWidth / ratio;
     const logoX = w / 2 - drawWidth / 2;


### PR DESCRIPTION
### Motivation
- Align card visuals with the requested art: keep only diagonal corner markers on faces and remove the extra top-left marker. 
- Improve card-back branding so the TonPlaygram logo is larger and oriented correctly in gameplay views. 
- Reduce z-fighting / overlap on stacked back-facing cards and nudge the bottom player hand slightly toward the gift icon for better visual alignment.

### Description
- Removed the top-left rank/suit drawing code in `makeCardFace` so only the two diagonal corner markers remain. 
- Enlarged the card back plate and logo draw box in `drawLogoFrame` to make the back logo more prominent. 
- Rotated the back texture by 180° in `makeCardBackTexture` (`texture.rotation = Math.PI` and set `texture.center`) so the back logo renders upright. 
- Improved layering in `applyHandCardLayering` by forcing a consistent hand renderOrder and adjusting material `depthTest`/`depthWrite` and `polygonOffset` for non-human/back-facing cards to reduce overlap artifacts. 
- Reduced `HUMAN_HAND_LEFT_SHIFT` from `0.2 * MODEL_SCALE` to `0.14 * MODEL_SCALE` to nudge the bottom player cards slightly toward the gift icon.

### Testing
- Ran `npx eslint webapp/src/pages/Games/MurlanRoyaleArena.jsx webapp/src/utils/cards3d.js` which showed repo ignore warnings but no blocking errors in that mode. 
- Ran `npx eslint --no-ignore webapp/src/utils/cards3d.js webapp/src/pages/Games/MurlanRoyaleArena.jsx` which reported lint problems (numerous style issues) and therefore failed the strict lint check. 
- Ran `npm --prefix webapp run build` which completed successfully (production build finished with informational chunk-size warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7b03d797c8329914abe9578dbe739)