### PR TITLE
Adjust card artwork layout, hand positioning, and hand-layer rendering

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2332,7 +2332,7 @@ const HUMAN_HAND_CLOSER_OFFSET = 0.042 * MODEL_SCALE;
 const HUMAN_HAND_BOTTOM_SHIFT_Y = 0.0 * MODEL_SCALE;
 const AI_HAND_BOTTOM_SHIFT_Y = -0.02 * MODEL_SCALE;
 const AI_HAND_CLOSER_OFFSET = 0.02 * MODEL_SCALE;
-const HUMAN_HAND_LEFT_SHIFT = 0.2 * MODEL_SCALE; // Positive value shifts the bottom human hand visually left on portrait camera.
+const HUMAN_HAND_LEFT_SHIFT = 0.14 * MODEL_SCALE; // Positive value shifts the bottom human hand visually left on portrait camera.
 const AI_HAND_LEFT_SHIFT = 0;
 const HUMAN_HAND_UP_SHIFT_Y = 0.092 * MODEL_SCALE;
 const HUMAN_HAND_DIRECTIONAL_LIFT = 0;
@@ -6507,6 +6507,9 @@ function applyHandCardLayering(mesh, isHumanCard, stackOrder = 0) {
     if (!material) return;
     material.depthTest = !shouldForceRenderOrder;
     material.depthWrite = !shouldForceRenderOrder;
+    material.polygonOffset = false;
+    material.polygonOffsetFactor = 0;
+    material.polygonOffsetUnits = 0;
     material.needsUpdate = true;
   });
 }
@@ -6528,37 +6531,26 @@ function makeCardFace(rank, suit, theme, w = 768, h = 1080) {
   const label = rank === 'JB' ? 'JB' : rank === 'JR' ? 'JR' : String(rank);
   const cornerRankSize = Math.round(w * 0.18);
   const cornerSuitSize = Math.round(w * 0.16);
-  const diagonalTilt = THREE.MathUtils.degToRad(-13);
+  const cornerInsetX = Math.round(w * 0.1);
+  const cornerTopY = Math.round(h * 0.09);
+  const cornerBottomY = Math.round(h * 0.91);
+  const cornerGapY = Math.round(h * 0.105);
+  const rightInsetX = Math.round(w * 0.9);
 
   g.fillStyle = color;
-  g.save();
-  g.translate(Math.round(w * 0.14), Math.round(h * 0.115));
-  g.rotate(diagonalTilt);
-  g.textAlign = 'center';
-  g.textBaseline = 'middle';
+  g.textAlign = 'left';
+  g.textBaseline = 'top';
   g.font = `900 ${cornerRankSize}px "Inter", "Segoe UI", sans-serif`;
-  g.fillText(label, 0, -Math.round(h * 0.03));
+  g.fillText(label, cornerInsetX, cornerBottomY - cornerGapY);
   g.font = `${cornerSuitSize}px "Inter", "Segoe UI", sans-serif`;
-  g.fillText(suit, 0, Math.round(h * 0.035));
-  g.restore();
-
-  g.save();
-  g.translate(Math.round(w * 0.14), Math.round(h * 0.87));
-  g.rotate(diagonalTilt);
-  g.textAlign = 'center';
-  g.textBaseline = 'middle';
-  g.font = `900 ${cornerRankSize}px "Inter", "Segoe UI", sans-serif`;
-  g.fillText(label, 0, -Math.round(h * 0.03));
-  g.font = `${cornerSuitSize}px "Inter", "Segoe UI", sans-serif`;
-  g.fillText(suit, 0, Math.round(h * 0.035));
-  g.restore();
+  g.fillText(suit, cornerInsetX, cornerBottomY);
 
   g.textAlign = 'right';
   g.textBaseline = 'top';
-  g.font = `900 ${Math.round(w * 0.19)}px "Inter", "Segoe UI", sans-serif`;
-  g.fillText(label, Math.round(w * 0.905), Math.round(h * 0.04));
-  g.font = `${Math.round(w * 0.18)}px "Inter", "Segoe UI", sans-serif`;
-  g.fillText(suit, Math.round(w * 0.88), Math.round(h * 0.145));
+  g.font = `900 ${cornerRankSize}px "Inter", "Segoe UI", sans-serif`;
+  g.fillText(label, rightInsetX, cornerTopY);
+  g.font = `${cornerSuitSize}px "Inter", "Segoe UI", sans-serif`;
+  g.fillText(suit, rightInsetX, cornerTopY + cornerGapY);
 
   g.textAlign = 'center';
   g.textBaseline = 'middle';

--- a/webapp/src/utils/cards3d.js
+++ b/webapp/src/utils/cards3d.js
@@ -369,8 +369,8 @@ function drawLogoFrame(ctx, w, h, theme) {
   ctx.restore();
 
   ctx.save();
-  const plateWidth = w * 0.8;
-  const plateHeight = h * 0.28;
+  const plateWidth = w * 0.88;
+  const plateHeight = h * 0.34;
   const plateX = (w - plateWidth) / 2;
   const plateY = (h - plateHeight) / 2;
   const plateGradient = ctx.createLinearGradient(plateX, plateY, plateX, plateY + plateHeight);
@@ -386,8 +386,8 @@ function drawLogoFrame(ctx, w, h, theme) {
 
   if (logoImage?.complete && logoImage.naturalWidth > 0) {
     const ratio = logoImage.naturalWidth / Math.max(logoImage.naturalHeight, 1);
-    const logoBoxWidth = w * 0.72;
-    const logoBoxHeight = h * 0.24;
+    const logoBoxWidth = w * 0.82;
+    const logoBoxHeight = h * 0.3;
     const drawWidth = Math.min(logoBoxWidth, logoBoxHeight * ratio);
     const drawHeight = drawWidth / ratio;
     const logoX = w / 2 - drawWidth / 2;


### PR DESCRIPTION
### Motivation
- Improve the visual layout and alignment of generated card faces and backs for consistent corner placement and logo framing. 
- Reduce the visual offset of the bottom human hand on portrait camera to better center the hand. 
- Ensure consistent rendering of hand card meshes to avoid depth ordering artifacts.

### Description
- Tweaked the bottom human hand visual offset by changing `HUMAN_HAND_LEFT_SHIFT` from `0.2 * MODEL_SCALE` to `0.14 * MODEL_SCALE`.
- Updated `applyHandCardLayering` to explicitly disable `polygonOffset` and zero its factors, while preserving `depthTest`/`depthWrite` changes for forced hand render ordering.
- Reworked the card face rendering math in `makeCardFace` to remove the diagonal tilt, compute corner insets and vertical gaps (`cornerInsetX`, `cornerTopY`, `cornerBottomY`, `cornerGapY`, `rightInsetX`) and align corner ranks/suits using those values and consistent font sizing.
- Enlarged the logo plate and logo drawing area in `drawLogoFrame` by increasing `plateWidth`/`plateHeight` and `logoBoxWidth`/`logoBoxHeight` to give the logo more room on card backs.

### Testing
- Ran the frontend test suite with `yarn test`, and all tests completed successfully.
- Built the webapp with `yarn build` and the production bundle completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7b03d797c8329914abe9578dbe739)