### PR TITLE
Adjust card face layout and back art sizing; tweak hand offset and render ordering logic

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2332,7 +2332,7 @@ const HUMAN_HAND_CLOSER_OFFSET = 0.042 * MODEL_SCALE;
 const HUMAN_HAND_BOTTOM_SHIFT_Y = 0.0 * MODEL_SCALE;
 const AI_HAND_BOTTOM_SHIFT_Y = -0.02 * MODEL_SCALE;
 const AI_HAND_CLOSER_OFFSET = 0.02 * MODEL_SCALE;
-const HUMAN_HAND_LEFT_SHIFT = 0.2 * MODEL_SCALE; // Positive value shifts the bottom human hand visually left on portrait camera.
+const HUMAN_HAND_LEFT_SHIFT = 0.14 * MODEL_SCALE; // Positive value shifts the bottom human hand visually left on portrait camera.
 const AI_HAND_LEFT_SHIFT = 0;
 const HUMAN_HAND_UP_SHIFT_Y = 0.092 * MODEL_SCALE;
 const HUMAN_HAND_DIRECTIONAL_LIFT = 0;
@@ -6497,9 +6497,7 @@ function applyHandCardLayering(mesh, isHumanCard, stackOrder = 0) {
   mesh.renderOrder = orderBase + stackOrder;
 
   const shouldForceRenderOrder = Boolean(isHumanCard);
-  if (mesh.userData?.forceHandRenderOrder === shouldForceRenderOrder) {
-    return;
-  }
+  if (mesh.userData?.forceHandRenderOrder === shouldForceRenderOrder) return;
   mesh.userData.forceHandRenderOrder = shouldForceRenderOrder;
 
   const allMaterials = Array.isArray(mesh.material) ? mesh.material : [mesh.material];
@@ -6528,37 +6526,32 @@ function makeCardFace(rank, suit, theme, w = 768, h = 1080) {
   const label = rank === 'JB' ? 'JB' : rank === 'JR' ? 'JR' : String(rank);
   const cornerRankSize = Math.round(w * 0.18);
   const cornerSuitSize = Math.round(w * 0.16);
-  const diagonalTilt = THREE.MathUtils.degToRad(-13);
+  const cornerLeftX = Math.round(w * 0.115);
+  const cornerRightX = Math.round(w * 0.895);
+  const topRankY = Math.round(h * 0.1);
+  const topSuitY = Math.round(h * 0.2);
+  const bottomRankY = Math.round(h * 0.76);
+  const bottomSuitY = Math.round(h * 0.86);
 
   g.fillStyle = color;
-  g.save();
-  g.translate(Math.round(w * 0.14), Math.round(h * 0.115));
-  g.rotate(diagonalTilt);
-  g.textAlign = 'center';
-  g.textBaseline = 'middle';
+  g.textAlign = 'left';
+  g.textBaseline = 'top';
   g.font = `900 ${cornerRankSize}px "Inter", "Segoe UI", sans-serif`;
-  g.fillText(label, 0, -Math.round(h * 0.03));
+  g.fillText(label, cornerLeftX, topRankY);
   g.font = `${cornerSuitSize}px "Inter", "Segoe UI", sans-serif`;
-  g.fillText(suit, 0, Math.round(h * 0.035));
-  g.restore();
+  g.fillText(suit, cornerLeftX, topSuitY);
 
-  g.save();
-  g.translate(Math.round(w * 0.14), Math.round(h * 0.87));
-  g.rotate(diagonalTilt);
-  g.textAlign = 'center';
-  g.textBaseline = 'middle';
   g.font = `900 ${cornerRankSize}px "Inter", "Segoe UI", sans-serif`;
-  g.fillText(label, 0, -Math.round(h * 0.03));
+  g.fillText(label, cornerLeftX, bottomRankY);
   g.font = `${cornerSuitSize}px "Inter", "Segoe UI", sans-serif`;
-  g.fillText(suit, 0, Math.round(h * 0.035));
-  g.restore();
+  g.fillText(suit, cornerLeftX, bottomSuitY);
 
   g.textAlign = 'right';
   g.textBaseline = 'top';
-  g.font = `900 ${Math.round(w * 0.19)}px "Inter", "Segoe UI", sans-serif`;
-  g.fillText(label, Math.round(w * 0.905), Math.round(h * 0.04));
-  g.font = `${Math.round(w * 0.18)}px "Inter", "Segoe UI", sans-serif`;
-  g.fillText(suit, Math.round(w * 0.88), Math.round(h * 0.145));
+  g.font = `900 ${cornerRankSize}px "Inter", "Segoe UI", sans-serif`;
+  g.fillText(label, cornerRightX, topRankY);
+  g.font = `${cornerSuitSize}px "Inter", "Segoe UI", sans-serif`;
+  g.fillText(suit, cornerRightX, topSuitY);
 
   g.textAlign = 'center';
   g.textBaseline = 'middle';

--- a/webapp/src/utils/cards3d.js
+++ b/webapp/src/utils/cards3d.js
@@ -369,8 +369,8 @@ function drawLogoFrame(ctx, w, h, theme) {
   ctx.restore();
 
   ctx.save();
-  const plateWidth = w * 0.8;
-  const plateHeight = h * 0.28;
+  const plateWidth = w * 0.88;
+  const plateHeight = h * 0.34;
   const plateX = (w - plateWidth) / 2;
   const plateY = (h - plateHeight) / 2;
   const plateGradient = ctx.createLinearGradient(plateX, plateY, plateX, plateY + plateHeight);
@@ -386,8 +386,8 @@ function drawLogoFrame(ctx, w, h, theme) {
 
   if (logoImage?.complete && logoImage.naturalWidth > 0) {
     const ratio = logoImage.naturalWidth / Math.max(logoImage.naturalHeight, 1);
-    const logoBoxWidth = w * 0.72;
-    const logoBoxHeight = h * 0.24;
+    const logoBoxWidth = w * 0.82;
+    const logoBoxHeight = h * 0.3;
     const drawWidth = Math.min(logoBoxWidth, logoBoxHeight * ratio);
     const drawHeight = drawWidth / ratio;
     const logoX = w / 2 - drawWidth / 2;


### PR DESCRIPTION
### Motivation

- Improve card face readability and alignment by replacing rotated corner labels with consistent, explicitly positioned rank/suit coordinates. 
- Make the logo/plate on card backs larger so it occupies more of the back surface. 
- Fine-tune the visual placement of the bottom human hand and ensure hand layering render flags are applied consistently.

### Description

- Reduced `HUMAN_HAND_LEFT_SHIFT` from `0.2 * MODEL_SCALE` to `0.14 * MODEL_SCALE` to shift the bottom human hand less on portrait camera. 
- Simplified `applyHandCardLayering` conditional early-return and ensure material `depthTest`/`depthWrite` toggles are applied when `forceHandRenderOrder` changes. 
- Reworked `makeCardFace` to remove the diagonal tilt and use explicit corner coordinates (`cornerLeftX`, `cornerRightX`, `topRankY`, `topSuitY`, `bottomRankY`, `bottomSuitY`) and consistent corner font sizes for rank and suit placement. 
- Increased artwork area in `drawLogoFrame` by adjusting `plateWidth`/`plateHeight` and `logoBoxWidth`/`logoBoxHeight` so the logo/plate fills more of the card back canvas.

### Testing

- Ran unit tests with `yarn test` and all tests passed. 
- Ran linter with `yarn lint` and it returned no issues. 
- Built the webapp with `yarn build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7b03d797c8329914abe9578dbe739)