### PR TITLE
Tune Chess Battle Royal strike paths and impact sync

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -92,9 +92,9 @@ const WORLD_UP = new THREE.Vector3(0, 1, 0);
 const LUDO_CAPTURE_MISSILE_TRAVEL_TIME = 2.52;
 const LUDO_CAPTURE_EXPLOSION_TIME = 2.6;
 const LUDO_CAPTURE_TOTAL_TIME = LUDO_CAPTURE_MISSILE_TRAVEL_TIME + LUDO_CAPTURE_EXPLOSION_TIME;
-const CAPTURE_DRONE_LIFT_TIME = 1.52; // slower lift-off so takeoff remains readable in portrait
-const CAPTURE_DRONE_CRUISE_TIME = 5.36; // slower cruise to keep aircraft readable on-frame
-const CAPTURE_DRONE_DIVE_TIME = 2.08;
+const CAPTURE_DRONE_LIFT_TIME = 1.08; // shorter launch while still clearly visible from the parking pad
+const CAPTURE_DRONE_CRUISE_TIME = 4.3; // trim path duration so the strike stays close to the board action
+const CAPTURE_DRONE_DIVE_TIME = 1.84;
 const CAPTURE_DRONE_TOTAL = CAPTURE_DRONE_LIFT_TIME + CAPTURE_DRONE_CRUISE_TIME + CAPTURE_DRONE_DIVE_TIME;
 const CAPTURE_JET_SPEED_FACTOR = 4.9 / CAPTURE_DRONE_TOTAL; // slower than prior tuning for clearer portrait tracking
 const PROFILE_VIEW_ROTATION_TYPES = new Set(['K', 'N']);
@@ -121,32 +121,32 @@ const CAPTURE_AIR_STRIKE_BOARD_CLEARANCE = 0; // measure air-strike altitude str
 const CAPTURE_AIR_STRIKE_ALTITUDE_MULTIPLIER = 1; // align jet/helicopter flight height with drone altitude
 const CAPTURE_JET_ALTITUDE = CAPTURE_DRONE_REFERENCE_BOARD_ALTITUDE * CAPTURE_AIR_STRIKE_ALTITUDE_MULTIPLIER;
 const CAPTURE_HELICOPTER_ALTITUDE_BOOST = 0; // keep helicopter and jet at the same flight altitude
-const CAPTURE_AIR_STRIKE_PATH_RADIUS_FACTOR = 0.045; // tighter and shorter loop near board center
+const CAPTURE_AIR_STRIKE_PATH_RADIUS_FACTOR = 0.03; // much shorter inboard loop so jet/heli stay visible in portrait
 const CAPTURE_AIR_STRIKE_PATH_EDGE_MARGIN_TILES = 3.85; // keep turns inboard so aircraft never drift away from center
 const CAPTURE_AIR_STRIKE_BOTTOM_PLAYER_BIAS_TILES = 0.02; // reduce portrait bottom bias so aircraft stay nearer center
-const CAPTURE_DRONE_ORBIT_RADIUS_MUL = 0.2; // keep drone loop tighter so it hugs the board area
-const CAPTURE_DRONE_ORBIT_HEIGHT_MUL = 0.14; // lower drone route to keep it close to board surface
-const CAPTURE_AIR_STRIKE_ORBIT_HEIGHT_MUL = 0.09; // lower jet/helicopter route so aircraft feel closer to board
-const CAPTURE_DRONE_ORBIT_CYCLES = 0.18; // shorter loop cadence shared by drone/jet/helicopter
-const CAPTURE_DRONE_ORBIT_SPLIT = 0.84;
+const CAPTURE_DRONE_ORBIT_RADIUS_MUL = 0.14; // shorten drone route further
+const CAPTURE_DRONE_ORBIT_HEIGHT_MUL = 0.09; // lower drone route further to sit near pieces
+const CAPTURE_AIR_STRIKE_ORBIT_HEIGHT_MUL = 0.06; // lower jet/helicopter route so takeoff + approach stay readable
+const CAPTURE_DRONE_ORBIT_CYCLES = 0.12; // shorter loop cadence shared by drone/jet/helicopter
+const CAPTURE_DRONE_ORBIT_SPLIT = 0.72;
 const CAPTURE_DRONE_RETURN_SPLIT = 0.72;
-const CAPTURE_AIR_MISSILE_RELEASE_START_RATIO = 0.4;
-const CAPTURE_AIR_MISSILE_RELEASE_END_RATIO = 0.68;
+const CAPTURE_AIR_MISSILE_RELEASE_START_RATIO = 0.34;
+const CAPTURE_AIR_MISSILE_RELEASE_END_RATIO = 0.54;
 const CAPTURE_AIR_MISSILE_ARC_SPLIT = 0.84;
 const CAPTURE_AIR_MISSILE_DROP_PORTION = 0.16;
 const CAPTURE_AIR_MISSILE_SIDE_OFFSET = 0.022;
-const CAPTURE_AIR_MISSILE_TOP_HEIGHT_TILE_MUL = 0.82;
-const CAPTURE_AIR_MISSILE_TOP_HEIGHT_MIN = 0.11;
-const CAPTURE_AIR_MISSILE_TOP_BLEND = 0.34;
-const CAPTURE_AIR_MISSILE_TOP_EXTRA_LIFT = 0.015;
-const CAPTURE_AIR_MISSILE_DROP_HEIGHT_MUL = 0.34;
+const CAPTURE_AIR_MISSILE_TOP_HEIGHT_TILE_MUL = 0.44;
+const CAPTURE_AIR_MISSILE_TOP_HEIGHT_MIN = 0.05;
+const CAPTURE_AIR_MISSILE_TOP_BLEND = 0.22;
+const CAPTURE_AIR_MISSILE_TOP_EXTRA_LIFT = 0.004;
+const CAPTURE_AIR_MISSILE_DROP_HEIGHT_MUL = 0.2;
 const CAPTURE_DIRECT_STRIKE_INWARD_DISTANCE = 0.16; // keep launch hop very close to parking position
 const CAPTURE_DIRECT_STRIKE_TAKEOFF_RATIO = 0.42; // spend longer lifting before cruise
 const CAPTURE_DIRECT_STRIKE_RETURN_RATIO = 0.54; // return earlier so fly-bys stay close to board
 const CAPTURE_VERTICAL_STRIKE_INWARD_DISTANCE = 0; // pawn/drone/truck missile rises straight up from launch point
-const CAPTURE_VERTICAL_STRIKE_ALTITUDE = 0.1; // low vertical arc
-const CAPTURE_VERTICAL_STRIKE_TOP_OFFSET = 0.09; // short top point before vertical drop
-const CAPTURE_VERTICAL_STRIKE_HORIZONTAL_RATIO = 0.36; // after liftoff, keep a clear top-flight pass before vertical crash
+const CAPTURE_VERTICAL_STRIKE_ALTITUDE = 0.07; // even lower pawn/drone strike profile
+const CAPTURE_VERTICAL_STRIKE_TOP_OFFSET = 0.05; // shorter top point before vertical drop
+const CAPTURE_VERTICAL_STRIKE_HORIZONTAL_RATIO = 0.22; // shorter top-flight pass before vertical crash
 const CAPTURE_LOOP_TAKEOFF_RATIO = 0.18; // show aircraft lifting from pad before starting loop
 const CAPTURE_RELOAD_SHOW_TIME = 0.58;
 const CAPTURE_MISSILE_SCALE = 0.068;
@@ -9563,6 +9563,13 @@ function Chess3D({
       const bc = new THREE.Vector3().copy(b).lerp(c, t);
       return ab.lerp(bc, t);
     };
+    const getAirMissileImpactTime = (totalDuration) => {
+      const releaseStart = totalDuration * CAPTURE_AIR_MISSILE_RELEASE_START_RATIO;
+      const releaseWindow = totalDuration * (CAPTURE_AIR_MISSILE_RELEASE_END_RATIO - CAPTURE_AIR_MISSILE_RELEASE_START_RATIO);
+      const missileTravel = Math.max(0.28, releaseWindow - 0.1);
+      const secondMissileOffset = 0.14;
+      return releaseStart + secondMissileOffset + missileTravel;
+    };
     const constrainInsideBoardPerimeter = (vector, marginTiles = 0.62) => {
       const margin = BOARD.tile * marginTiles;
       const boardHalf = (BOARD.N * BOARD.tile) / 2 - margin;
@@ -9917,7 +9924,7 @@ function Chess3D({
         suppressTimerBeepUntilRef.current = performance.now() + CAPTURE_GROUND_TOTAL * 1000;
         const missileFx = createFxGroundMissile();
         missileFx.root.scale.setScalar(CAPTURE_PAWN_JAVELIN_SCALE);
-        const launchBase = fromPos.clone().add(new THREE.Vector3(0, 0.11, 0));
+        const launchBase = getLiveLaunchPosition(fromPos.clone(), movingMesh, 0.11);
         missileFx.root.position.copy(launchBase.clone().add(new THREE.Vector3(0, 0.03, 0)));
         captureFxGroup.add(missileFx.root);
         playAudio(missileLaunchSoundRef);
@@ -9932,8 +9939,7 @@ function Chess3D({
           sourceUnit: null,
           missileFx,
           directPath: false,
-          verticalStrike: true,
-          fixedLaunch: true
+          verticalStrike: true
         });
         return {
           moveDelayMs: CAPTURE_GROUND_TOTAL * 1000,
@@ -9982,7 +9988,7 @@ function Chess3D({
           jetFx,
           missileFx
         });
-        const jetImpactDelayMs = CAPTURE_JET_TOTAL * 0.96 * 1000;
+        const jetImpactDelayMs = getAirMissileImpactTime(CAPTURE_JET_TOTAL) * 1000;
         return {
           moveDelayMs: jetImpactDelayMs,
           captureResolveDelayMs: jetImpactDelayMs
@@ -10035,7 +10041,7 @@ function Chess3D({
           helicopterFx,
           missileFx
         });
-        const helicopterImpactDelayMs = CAPTURE_HELICOPTER_TOTAL * 0.96 * 1000;
+        const helicopterImpactDelayMs = getAirMissileImpactTime(CAPTURE_HELICOPTER_TOTAL) * 1000;
         return {
           moveDelayMs: helicopterImpactDelayMs,
           captureResolveDelayMs: helicopterImpactDelayMs
@@ -10083,7 +10089,7 @@ function Chess3D({
           jetFx,
           missileFx
         });
-        const jetImpactDelayMs = CAPTURE_JET_TOTAL * 0.96 * 1000;
+        const jetImpactDelayMs = getAirMissileImpactTime(CAPTURE_JET_TOTAL) * 1000;
         return {
           moveDelayMs: jetImpactDelayMs,
           captureResolveDelayMs: jetImpactDelayMs
@@ -11902,7 +11908,7 @@ function Chess3D({
               from: launchPos,
               to: fx.flightTarget || fx.to,
               progress: jetU,
-              orbitHeight: CAPTURE_FLIGHT_ALTITUDE * 0.72,
+              orbitHeight: CAPTURE_FLIGHT_ALTITUDE * CAPTURE_AIR_STRIKE_ORBIT_HEIGHT_MUL,
               orbitRadiusMul: CAPTURE_AIR_STRIKE_PATH_RADIUS_FACTOR,
               minOrbitCycles: CAPTURE_DRONE_ORBIT_CYCLES,
               orbitSplit: CAPTURE_DRONE_ORBIT_SPLIT,
@@ -11928,6 +11934,7 @@ function Chess3D({
             const releaseStart = CAPTURE_JET_TOTAL * CAPTURE_AIR_MISSILE_RELEASE_START_RATIO;
             const releaseEnd = CAPTURE_JET_TOTAL * CAPTURE_AIR_MISSILE_RELEASE_END_RATIO;
             const missileTravel = Math.max(0.28, releaseEnd - releaseStart - 0.1);
+            const missileImpactTime = getAirMissileImpactTime(CAPTURE_JET_TOTAL);
             const topStrikeHeight = Math.max(tile * CAPTURE_AIR_MISSILE_TOP_HEIGHT_TILE_MUL, CAPTURE_AIR_MISSILE_TOP_HEIGHT_MIN);
             const hitTop = fx.to
               .clone()
@@ -11985,7 +11992,7 @@ function Chess3D({
               missile.root.position.copy(constrainInsideBoardPerimeter(missilePos));
               missile.root.quaternion.setFromUnitVectors(FORWARD, captureDir);
             });
-            if (!anyMissileVisible && fx.t > releaseEnd + missileTravel) {
+            if (!anyMissileVisible && fx.t >= missileImpactTime) {
               jetMissiles.forEach((missile) => {
                 missile.root.visible = false;
               });
@@ -12018,7 +12025,7 @@ function Chess3D({
               from: launchPos,
               to: fx.flightTarget || fx.to,
               progress: heliU,
-              orbitHeight: CAPTURE_FLIGHT_ALTITUDE * 0.72,
+              orbitHeight: CAPTURE_FLIGHT_ALTITUDE * CAPTURE_AIR_STRIKE_ORBIT_HEIGHT_MUL,
               orbitRadiusMul: CAPTURE_AIR_STRIKE_PATH_RADIUS_FACTOR,
               minOrbitCycles: CAPTURE_DRONE_ORBIT_CYCLES,
               orbitSplit: CAPTURE_DRONE_ORBIT_SPLIT,
@@ -12047,6 +12054,7 @@ function Chess3D({
             const releaseStart = CAPTURE_HELICOPTER_TOTAL * CAPTURE_AIR_MISSILE_RELEASE_START_RATIO;
             const releaseEnd = CAPTURE_HELICOPTER_TOTAL * CAPTURE_AIR_MISSILE_RELEASE_END_RATIO;
             const missileTravel = Math.max(0.28, releaseEnd - releaseStart - 0.1);
+            const missileImpactTime = getAirMissileImpactTime(CAPTURE_HELICOPTER_TOTAL);
             const topStrikeHeight = Math.max(tile * CAPTURE_AIR_MISSILE_TOP_HEIGHT_TILE_MUL, CAPTURE_AIR_MISSILE_TOP_HEIGHT_MIN);
             const hitTop = fx.to
               .clone()
@@ -12104,7 +12112,7 @@ function Chess3D({
               missile.root.position.copy(constrainInsideBoardPerimeter(missilePos));
               missile.root.quaternion.setFromUnitVectors(FORWARD, captureDir);
             });
-            if (!anyMissileVisible && fx.t > releaseEnd + missileTravel) {
+            if (!anyMissileVisible && fx.t >= missileImpactTime) {
               heliMissiles.forEach((missile) => {
                 missile.root.visible = false;
               });
@@ -12126,8 +12134,8 @@ function Chess3D({
             }
           } else if (fx.type === 'javelin') {
             const launchPos = fx.sourceUnit?.homePosition?.clone?.()
-              || (fx.fixedLaunch ? fx.launchPos.clone() : getLiveLaunchPosition(fx.launchPos, fx.movingMesh, 0));
-            if (!fx.fixedLaunch) fx.launchPos.copy(launchPos);
+              || getLiveLaunchPosition(fx.launchPos, fx.movingMesh, 0);
+            fx.launchPos.copy(launchPos);
             const impactTime = CAPTURE_GROUND_FIRE_TIME + CAPTURE_GROUND_TRAVEL_TIME;
             if (fx.t < CAPTURE_GROUND_FIRE_TIME) {
               fx.missileFx.root.visible = true;


### PR DESCRIPTION
### Motivation
- Improve visual clarity in portrait mode by keeping capture vehicles and missiles closer to the board and making the launch/orbit motion shorter and lower. 
- Make pawn javelin strikes originate from the actual live piece position so launches look correct and synchronized with the piece performing the attack. 
- Eliminate delayed explosion timing by driving impact/explosion with missile flight timing instead of a fixed post-flight delay.

### Description
- Tuned capture timing and trajectory constants (`CAPTURE_DRONE_*`, `CAPTURE_AIR_STRIKE_PATH_RADIUS_FACTOR`, orbit height/radius multipliers, missile arc/height constants, and related ratios) to shorten and lower drone/jet/helicopter paths and missile arcs in `webapp/src/pages/Games/ChessBattleRoyal.jsx`.
- Switched pawn javelin launch origin to use `getLiveLaunchPosition()` so ground missiles launch from the moving piece world position at fire-time.
- Added `getAirMissileImpactTime(totalDuration)` and wired jet/helicopter impact/delay logic and explosion triggers to this computed missile contact time instead of a fixed multiplier, and updated runtime missile visibility checks to use the new impact time.
- Adjusted runtime updates so javelin/air unit `launchPos` is refreshed from live sources during update ticks and aircraft loop orbit height now uses the lowered `CAPTURE_AIR_STRIKE_ORBIT_HEIGHT_MUL`.

### Testing
- Ran `npm --prefix webapp run build` and the Vite production build completed successfully.
- Verified the modified file `webapp/src/pages/Games/ChessBattleRoyal.jsx` compiles as part of the app bundle with no build-time errors.
- No automated visual tests were run; visual validation should be performed in-app to confirm launch origins, lower flight paths, and explosion synchronization.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7b8103fc883298707ebd98ed13ec6)