### PR TITLE
Fix Murlan Royale mobile stability, card-back orientation and layout

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyale.jsx
+++ b/webapp/src/pages/Games/MurlanRoyale.jsx
@@ -10,7 +10,7 @@ export default function MurlanRoyale() {
   useOnlineRoomSync(search, 'Murlan Player');
 
   return (
-    <div className="relative w-full h-screen bg-[#050812]">
+    <div className="fixed inset-0 w-full h-[100dvh] overflow-hidden bg-[#050812]">
       <MurlanRoyaleArena search={search} />
     </div>
   );

--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -286,6 +286,11 @@ function detectPreferredFrameRateId() {
   const lowRefresh = detectLowRefreshDisplay();
   const refreshTier = detectDisplayRefreshTier();
   const rendererTier = classifyRendererTier(readGraphicsRendererString());
+  const isAndroidWebView = /Android/i.test(ua) && (/\bwv\b/i.test(ua) || /Version\/[\d.]+/i.test(ua));
+
+  if (isAndroidWebView) {
+    return 'fhd60';
+  }
 
   if (lowRefresh) {
     return 'fhd60';
@@ -2317,8 +2322,8 @@ const CAMERA_SEATED_ELEVATION_OFFSETS = Object.freeze({
   portrait: 1.7,
   landscape: 0.82
 });
-const CAMERA_TARGET_LIFT = 0.08 * MODEL_SCALE;
-const CAMERA_FOCUS_CENTER_LIFT = 0.1 * MODEL_SCALE;
+const CAMERA_TARGET_LIFT = 0.16 * MODEL_SCALE;
+const CAMERA_FOCUS_CENTER_LIFT = 0.14 * MODEL_SCALE;
 const CAMERA_TARGET_TOP_PLAYER_BIAS = 0.5 * MODEL_SCALE;
 const HUMAN_HAND_CARD_SCALE = 1.06;
 const HUMAN_HAND_CARD_SPACING = CARD_W * HUMAN_HAND_CARD_SCALE * 0.27;
@@ -6509,7 +6514,7 @@ function applyHandCardLayering(mesh, isHumanCard, stackOrder = 0) {
   });
 }
 
-function makeCardFace(rank, suit, theme, w = 768, h = 1080) {
+function makeCardFace(rank, suit, theme, w = 512, h = 720) {
   const canvas = document.createElement('canvas');
   canvas.width = w;
   canvas.height = h;
@@ -6560,7 +6565,7 @@ function makeCardFace(rank, suit, theme, w = 768, h = 1080) {
 
   const tex = new THREE.CanvasTexture(canvas);
   applySRGBColorSpace(tex);
-  tex.anisotropy = 12;
+  tex.anisotropy = 6;
   tex.magFilter = THREE.LinearFilter;
   tex.minFilter = THREE.LinearMipmapLinearFilter;
   tex.generateMipmaps = true;

--- a/webapp/src/utils/cards3d.js
+++ b/webapp/src/utils/cards3d.js
@@ -154,17 +154,34 @@ function makeCardFace(rank, suit, theme, w = 512, h = 720) {
   return texture;
 }
 
-export function makeTonplaygramCardBackTexture(theme, w = 3072, h = 4320) {
+function resolveSafeCardBackTextureSize() {
+  if (typeof navigator === 'undefined') {
+    return { width: 1536, height: 2160 };
+  }
+  const ua = navigator.userAgent ?? '';
+  const isAndroid = /Android/i.test(ua);
+  const isWebView = /\bwv\b|Version\/[\d.]+\s+Chrome\/[\d.]+\s+Mobile/i.test(ua);
+  const memory = typeof navigator.deviceMemory === 'number' ? navigator.deviceMemory : null;
+  if (isAndroid || isWebView || (memory !== null && memory <= 4)) {
+    return { width: 1024, height: 1440 };
+  }
+  return { width: 1536, height: 2160 };
+}
+
+export function makeTonplaygramCardBackTexture(theme, w, h) {
+  const safeSize = resolveSafeCardBackTextureSize();
+  const resolvedWidth = Number.isFinite(w) ? Math.max(512, Math.round(w)) : safeSize.width;
+  const resolvedHeight = Number.isFinite(h) ? Math.max(720, Math.round(h)) : safeSize.height;
   const canvas = document.createElement('canvas');
-  canvas.width = w;
-  canvas.height = h;
+  canvas.width = resolvedWidth;
+  canvas.height = resolvedHeight;
   const ctx = canvas.getContext('2d');
   const drawBack = () => {
     const cardBackPattern = ctx.createPattern(makeLuckyCardBackPatternCanvas(), 'repeat');
     ctx.fillStyle = cardBackPattern || '#112233';
-    ctx.fillRect(0, 0, w, h);
+    ctx.fillRect(0, 0, resolvedWidth, resolvedHeight);
 
-    drawLogoFrame(ctx, w, h, theme);
+    drawLogoFrame(ctx, resolvedWidth, resolvedHeight, theme);
   };
 
   drawBack();
@@ -174,7 +191,7 @@ export function makeTonplaygramCardBackTexture(theme, w = 3072, h = 4320) {
   texture.minFilter = THREE.LinearMipmapLinearFilter;
   texture.magFilter = THREE.LinearFilter;
   texture.generateMipmaps = true;
-  texture.anisotropy = 16;
+  texture.anisotropy = 8;
 
   const logoImage = getTonplaygramLogoImage();
   if (logoImage && !(logoImage.complete && logoImage.naturalWidth > 0)) {
@@ -369,8 +386,8 @@ function drawLogoFrame(ctx, w, h, theme) {
   ctx.restore();
 
   ctx.save();
-  const plateWidth = w * 0.88;
-  const plateHeight = h * 0.34;
+  const plateWidth = w * 0.92;
+  const plateHeight = h * 0.4;
   const plateX = (w - plateWidth) / 2;
   const plateY = (h - plateHeight) / 2;
   const plateGradient = ctx.createLinearGradient(plateX, plateY, plateX, plateY + plateHeight);
@@ -386,19 +403,27 @@ function drawLogoFrame(ctx, w, h, theme) {
 
   if (logoImage?.complete && logoImage.naturalWidth > 0) {
     const ratio = logoImage.naturalWidth / Math.max(logoImage.naturalHeight, 1);
-    const logoBoxWidth = w * 0.82;
-    const logoBoxHeight = h * 0.3;
+    const logoBoxWidth = w * 0.88;
+    const logoBoxHeight = h * 0.36;
     const drawWidth = Math.min(logoBoxWidth, logoBoxHeight * ratio);
     const drawHeight = drawWidth / ratio;
     const logoX = w / 2 - drawWidth / 2;
     const logoY = h / 2 - drawHeight / 2;
-    ctx.drawImage(logoImage, logoX, logoY, drawWidth, drawHeight);
+    ctx.save();
+    ctx.translate(w / 2, h / 2);
+    ctx.rotate(Math.PI);
+    ctx.drawImage(logoImage, -drawWidth / 2, -drawHeight / 2, drawWidth, drawHeight);
+    ctx.restore();
   } else {
     ctx.fillStyle = theme.backAccent || 'rgba(255,255,255,0.85)';
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
     ctx.font = '700 48px "Inter", system-ui, sans-serif';
-    ctx.fillText('TonPlaygram', w / 2, h / 2);
+    ctx.save();
+    ctx.translate(w / 2, h / 2);
+    ctx.rotate(Math.PI);
+    ctx.fillText('TonPlaygram', 0, 0);
+    ctx.restore();
   }
 
   ctx.restore();


### PR DESCRIPTION
### Motivation
- Prevent runtime crashes and high-memory pressure observed on mobile/WebView when rendering card textures. 
- Make the card-back logo larger and render right-side-up. 
- Remove the unwanted bottom gap by ensuring the game fills the mobile viewport and slightly lower the gameplay framing for portrait screens.

### Description
- Added a safe card-back sizing strategy and conservative defaults in `webapp/src/utils/cards3d.js` to cap canvas size on constrained devices and lowered card-back anisotropy to reduce GPU/memory pressure. 
- Enlarged the logo plate and rotated the card-back logo drawing (and fallback text) by `Math.PI` in `webapp/src/utils/cards3d.js` to correct upside-down rendering and increase visible logo size. 
- Reduced in-scene card face texture resolution and anisotropy (`768x1080` -> `512x720`, anisotropy lowered) by changing `makeCardFace` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to reduce memory usage. 
- Detect Android WebView in `detectPreferredFrameRateId` and force a safer graphics preset (`fhd60`) to avoid aggressive auto-promotions that can trigger instability. 
- Increased camera look/target lift constants (`CAMERA_TARGET_LIFT`, `CAMERA_FOCUS_CENTER_LIFT`) in `MurlanRoyaleArena.jsx` to nudge the scene visually downward in portrait. 
- Made the Murlan game wrapper fill the viewport reliably by switching the page shell to `fixed inset-0 w-full h-[100dvh] overflow-hidden` in `webapp/src/pages/Games/MurlanRoyale.jsx` to eliminate the bottom gap on phones.

### Testing
- Built the web app with `npm -C webapp run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7beb6197883299df64f004cc66d0e)