### PR TITLE
Fix Murlan WebView stability, card-back orientation/size and bottom gap

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -197,6 +197,18 @@ function detectDisplayRefreshTier() {
   return '60';
 }
 
+function detectAndroidWebView() {
+  if (typeof navigator === 'undefined') {
+    return false;
+  }
+  const ua = navigator.userAgent ?? '';
+  const isAndroid = /Android/i.test(ua);
+  if (!isAndroid) {
+    return false;
+  }
+  return /;\s*wv\)/i.test(ua) || /Version\/[\d.]+/i.test(ua);
+}
+
 let cachedRendererString = null;
 let rendererLookupAttempted = false;
 
@@ -275,6 +287,9 @@ function resolveDefaultPixelRatioCap() {
 function detectPreferredFrameRateId() {
   if (typeof window === 'undefined' || typeof navigator === 'undefined') {
     return DEFAULT_FRAME_RATE_ID;
+  }
+  if (detectAndroidWebView()) {
+    return 'fhd60';
   }
   const coarsePointer = detectCoarsePointer();
   const ua = navigator.userAgent ?? '';
@@ -2419,6 +2434,7 @@ const CAMERA_SIDE_LOOK_EXTRA = 0.42 * MODEL_SCALE;
 const CAMERA_INWARD_RADIUS_FACTOR = 1;
 const CAMERA_UP_TILT_FORWARD_BLEND = 0.34 * MODEL_SCALE;
 const CAMERA_UP_TILT_FORWARD_LERP = 0.14;
+const ARENA_SCREEN_DOWN_SHIFT = '2.2vh';
 
 const PLAYER_COLORS = ['#f97316', '#38bdf8', '#a78bfa', '#22c55e'];
 const FALLBACK_SEAT_POSITIONS = [
@@ -2658,6 +2674,7 @@ const START_CARD = { rank: '3', suit: '♠' };
 export default function MurlanRoyaleArena({ search }) {
   const mountRef = useRef(null);
   const players = useMemo(() => buildPlayers(search), [search]);
+  const androidWebView = useMemo(() => detectAndroidWebView(), []);
 
   const [murlanInventory, setMurlanInventory] = useState(() => getMurlanInventory(murlanAccountId()));
 
@@ -2776,6 +2793,10 @@ export default function MurlanRoyaleArena({ search }) {
   const activeFrameRateOption = useMemo(
     () => FRAME_RATE_OPTIONS.find((opt) => opt.id === frameRateId) ?? DEFAULT_FRAME_RATE_OPTION,
     [frameRateId]
+  );
+  const frameRateOptions = useMemo(
+    () => (androidWebView ? FRAME_RATE_OPTIONS.filter((option) => option.id === 'fhd60') : FRAME_RATE_OPTIONS),
+    [androidWebView]
   );
   const frameQualityProfile = useMemo(() => {
     const option = activeFrameRateOption ?? DEFAULT_FRAME_RATE_OPTION;
@@ -3299,6 +3320,12 @@ export default function MurlanRoyaleArena({ search }) {
   ]);
 
   useEffect(() => {
+    if (!androidWebView) return;
+    if (frameRateId === 'fhd60') return;
+    setFrameRateId('fhd60');
+  }, [androidWebView, frameRateId]);
+
+  useEffect(() => {
     if (typeof window === 'undefined') return;
     try {
       window.localStorage?.setItem(FRAME_RATE_STORAGE_KEY, frameRateId);
@@ -3585,15 +3612,17 @@ export default function MurlanRoyaleArena({ search }) {
     const pixelRatioCap =
       quality?.pixelRatioCap ??
       (typeof window !== 'undefined' ? resolveDefaultPixelRatioCap() : 2);
+    const safePixelRatioCap = androidWebView ? Math.min(pixelRatioCap, 1.1) : pixelRatioCap;
     const renderScale =
       typeof quality?.renderScale === 'number' && Number.isFinite(quality.renderScale)
         ? THREE.MathUtils.clamp(quality.renderScale, 1, 1.6)
         : 1;
-    renderer.setPixelRatio(Math.min(pixelRatioCap, dpr));
-    renderer.setSize(host.clientWidth * renderScale, host.clientHeight * renderScale, false);
+    const safeRenderScale = androidWebView ? Math.min(renderScale, 1) : renderScale;
+    renderer.setPixelRatio(Math.min(safePixelRatioCap, dpr));
+    renderer.setSize(host.clientWidth * safeRenderScale, host.clientHeight * safeRenderScale, false);
     renderer.domElement.style.width = '100%';
     renderer.domElement.style.height = '100%';
-  }, []);
+  }, [androidWebView]);
 
   useEffect(() => {
     applyRendererQuality();
@@ -5420,7 +5449,7 @@ export default function MurlanRoyaleArena({ search }) {
   }, [humanPlayerIndex, players, seatAnchorMap]);
 
   return (
-    <div className="absolute inset-0">
+    <div className="absolute inset-0" style={{ top: ARENA_SCREEN_DOWN_SHIFT, bottom: `calc(-1 * ${ARENA_SCREEN_DOWN_SHIFT})` }}>
       <div ref={mountRef} className="absolute inset-0" />
       <div className="absolute inset-0 pointer-events-none flex h-full flex-col">
         {uiState.scoreboard?.length ? (
@@ -5586,7 +5615,7 @@ export default function MurlanRoyaleArena({ search }) {
                       </p>
                     </div>
                     <div className="grid gap-2">
-                      {FRAME_RATE_OPTIONS.map((option) => {
+                      {frameRateOptions.map((option) => {
                         const active = option.id === frameRateId;
                         return (
                           <button

--- a/webapp/src/utils/cards3d.js
+++ b/webapp/src/utils/cards3d.js
@@ -386,13 +386,16 @@ function drawLogoFrame(ctx, w, h, theme) {
 
   if (logoImage?.complete && logoImage.naturalWidth > 0) {
     const ratio = logoImage.naturalWidth / Math.max(logoImage.naturalHeight, 1);
-    const logoBoxWidth = w * 0.82;
-    const logoBoxHeight = h * 0.3;
+    const logoBoxWidth = w * 0.9;
+    const logoBoxHeight = h * 0.36;
     const drawWidth = Math.min(logoBoxWidth, logoBoxHeight * ratio);
     const drawHeight = drawWidth / ratio;
-    const logoX = w / 2 - drawWidth / 2;
-    const logoY = h / 2 - drawHeight / 2;
-    ctx.drawImage(logoImage, logoX, logoY, drawWidth, drawHeight);
+    ctx.save();
+    ctx.translate(w / 2, h / 2);
+    // Back-face UVs are mirrored in gameplay, so rotate here to keep logo upright on-screen.
+    ctx.rotate(Math.PI);
+    ctx.drawImage(logoImage, -drawWidth / 2, -drawHeight / 2, drawWidth, drawHeight);
+    ctx.restore();
   } else {
     ctx.fillStyle = theme.backAccent || 'rgba(255,255,255,0.85)';
     ctx.textAlign = 'center';


### PR DESCRIPTION
### Motivation
- Prevent crashes and rendering issues observed on Android WebView by limiting heavy graphics profiles and reducing renderer pressure. 
- Make the card back logo appear upright and slightly larger because it was drawn upside-down and too small. 
- Eliminate the visible bottom gap on portrait phones by nudging the arena viewport downward.

### Description
- Added `detectAndroidWebView()` and used it to force the safe frame-rate profile `fhd60` for WebView environments and to restrict the graphics menu to the safe option; changes in `webapp/src/pages/Games/MurlanRoyaleArena.jsx`. 
- Added runtime guardrails for WebView rendering by capping pixel ratio and render scale when `androidWebView` is true (safe caps applied in `applyRendererQuality`). 
- Auto-corrects selected frame mode back to `fhd60` when running inside an Android WebView to avoid user selecting crash-prone modes. 
- Shifted the main Murlan arena container down by `ARENA_SCREEN_DOWN_SHIFT = '2.2vh'` to remove the bottom gap (applied to the root `<div>` style). 
- Increased card-back logo drawing area and rotated the canvas draw by 180° so the back logo is larger and upright; change in `webapp/src/utils/cards3d.js` (`drawLogoFrame`).

### Testing
- Ran `npx eslint webapp/src/pages/Games/MurlanRoyaleArena.jsx webapp/src/utils/cards3d.js`; linter reported repository ignore warnings for these files but no blocking errors. 
- Built the web app with `npm --prefix webapp run build`; the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7beb6197883299df64f004cc66d0e)