### PR TITLE
Reduce Murlan Royale card-back memory, fix back-logo orientation/size, and nudge camera down

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2320,6 +2320,7 @@ const CAMERA_SEATED_ELEVATION_OFFSETS = Object.freeze({
 const CAMERA_TARGET_LIFT = 0.08 * MODEL_SCALE;
 const CAMERA_FOCUS_CENTER_LIFT = 0.1 * MODEL_SCALE;
 const CAMERA_TARGET_TOP_PLAYER_BIAS = 0.5 * MODEL_SCALE;
+const CAMERA_SCREEN_DOWN_SHIFT = 0.12 * MODEL_SCALE;
 const HUMAN_HAND_CARD_SCALE = 1.06;
 const HUMAN_HAND_CARD_SPACING = CARD_W * HUMAN_HAND_CARD_SCALE * 0.27;
 const HUMAN_HAND_CARD_MAX_SPREAD = HUMAN_HAND_CARD_SPACING * 12;
@@ -4979,7 +4980,7 @@ export default function MurlanRoyaleArena({ search }) {
         camConfig.near,
         camConfig.far
       );
-      const targetHeightOffset = CAMERA_TARGET_LIFT + 0.03 * MODEL_SCALE;
+      const targetHeightOffset = CAMERA_TARGET_LIFT + 0.03 * MODEL_SCALE + CAMERA_SCREEN_DOWN_SHIFT;
       let target = new THREE.Vector3(0, TABLE_HEIGHT + targetHeightOffset, 0);
       let initialCameraPosition;
       if (humanSeatConfig) {

--- a/webapp/src/utils/cards3d.js
+++ b/webapp/src/utils/cards3d.js
@@ -7,6 +7,7 @@ export { CARD_THEMES, DEFAULT_CARD_THEME } from './cardThemes.js';
 
 const TONPLAYGRAM_LOGO_SRC = '/assets/icons/file_00000000bc2862439eecffff3730bbe4.webp';
 let tonplaygramLogoImage = null;
+const cardBackTextureCache = new Map();
 
 function getTonplaygramLogoImage() {
   if (!tonplaygramLogoImage && typeof Image !== 'undefined') {
@@ -155,16 +156,22 @@ function makeCardFace(rank, suit, theme, w = 512, h = 720) {
 }
 
 export function makeTonplaygramCardBackTexture(theme, w = 3072, h = 4320) {
+  const safeWidth = Math.max(512, Math.round(Math.min(w, 1024)));
+  const safeHeight = Math.max(768, Math.round(Math.min(h, 1536)));
+  const cacheKey = `${theme?.id || 'default'}:${safeWidth}x${safeHeight}`;
+  const cachedTexture = cardBackTextureCache.get(cacheKey);
+  if (cachedTexture) return cachedTexture;
+
   const canvas = document.createElement('canvas');
-  canvas.width = w;
-  canvas.height = h;
+  canvas.width = safeWidth;
+  canvas.height = safeHeight;
   const ctx = canvas.getContext('2d');
   const drawBack = () => {
     const cardBackPattern = ctx.createPattern(makeLuckyCardBackPatternCanvas(), 'repeat');
     ctx.fillStyle = cardBackPattern || '#112233';
-    ctx.fillRect(0, 0, w, h);
+    ctx.fillRect(0, 0, safeWidth, safeHeight);
 
-    drawLogoFrame(ctx, w, h, theme);
+    drawLogoFrame(ctx, safeWidth, safeHeight, theme);
   };
 
   drawBack();
@@ -175,6 +182,9 @@ export function makeTonplaygramCardBackTexture(theme, w = 3072, h = 4320) {
   texture.magFilter = THREE.LinearFilter;
   texture.generateMipmaps = true;
   texture.anisotropy = 16;
+  texture.center.set(0.5, 0.5);
+  texture.rotation = Math.PI;
+  texture.flipY = false;
 
   const logoImage = getTonplaygramLogoImage();
   if (logoImage && !(logoImage.complete && logoImage.naturalWidth > 0)) {
@@ -188,6 +198,7 @@ export function makeTonplaygramCardBackTexture(theme, w = 3072, h = 4320) {
     );
   }
 
+  cardBackTextureCache.set(cacheKey, texture);
   return texture;
 }
 
@@ -369,8 +380,8 @@ function drawLogoFrame(ctx, w, h, theme) {
   ctx.restore();
 
   ctx.save();
-  const plateWidth = w * 0.88;
-  const plateHeight = h * 0.34;
+  const plateWidth = w * 0.92;
+  const plateHeight = h * 0.38;
   const plateX = (w - plateWidth) / 2;
   const plateY = (h - plateHeight) / 2;
   const plateGradient = ctx.createLinearGradient(plateX, plateY, plateX, plateY + plateHeight);
@@ -386,8 +397,8 @@ function drawLogoFrame(ctx, w, h, theme) {
 
   if (logoImage?.complete && logoImage.naturalWidth > 0) {
     const ratio = logoImage.naturalWidth / Math.max(logoImage.naturalHeight, 1);
-    const logoBoxWidth = w * 0.82;
-    const logoBoxHeight = h * 0.3;
+    const logoBoxWidth = w * 0.88;
+    const logoBoxHeight = h * 0.34;
     const drawWidth = Math.min(logoBoxWidth, logoBoxHeight * ratio);
     const drawHeight = drawWidth / ratio;
     const logoX = w / 2 - drawWidth / 2;


### PR DESCRIPTION
### Motivation
- Reduce runtime memory and crash risk caused by allocating large per-card canvas textures for the card backs. 
- Ensure the card-back logo renders upright and larger so the back art matches the provided photo.
- Shift the gameplay view slightly downward to remove the unwanted gap at the bottom of portrait screens.

### Description
- Added a `cardBackTextureCache` and clamp-generated card-back canvas to a safer resolution (clamped `safeWidth`/`safeHeight`) to avoid creating a 3072×4320 canvas per card and reuse textures per theme/size. (`webapp/src/utils/cards3d.js`)
- Rotated the generated back texture (`texture.rotation = Math.PI`) and disabled `flipY` so the logo is upright on the card back. (`webapp/src/utils/cards3d.js`)
- Increased the card-back plate and logo drawing area (`plateWidth`, `plateHeight`, `logoBoxWidth`, `logoBoxHeight`) so the logo appears larger on the card back. (`webapp/src/utils/cards3d.js`)
- Introduced `CAMERA_SCREEN_DOWN_SHIFT` and added it to the initial camera target height so the arena view is visually pushed a bit lower (toward the bottom of portrait screens). (`webapp/src/pages/Games/MurlanRoyaleArena.jsx`)

### Testing
- Ran the Murlan unit tests with `npm test -- test/murlan.test.js --runInBand`, and the suite passed (12 tests, all passed).
- No other automated UI or rendering tests were available in CI for the visual changes; changes were restricted to texture generation, caching, and camera target math.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7beb6197883299df64f004cc66d0e)