### PR TITLE
Adjust Checkers Battle Royal branding plate proportions and placement

### DIFF
--- a/webapp/src/utils/murlanTable.js
+++ b/webapp/src/utils/murlanTable.js
@@ -723,7 +723,16 @@ export function createMurlanStyleTable({
   tableGroup.add(rimMesh);
 
   const rimSize = shapeOption?.id === 'grandOval' ? { width: tableRadius * 0.7, depth: tableRadius * 0.16 } : { width: tableRadius * 0.62, depth: tableRadius * 0.14 };
-  const brandPlateGeometry = new ThreeNamespace.BoxGeometry(rimSize.width, 0.018 * scaleFactor, rimSize.depth);
+  const brandPlateSize = {
+    width: rimSize.width * 0.9,
+    depth: rimSize.depth * 0.86,
+    thickness: 0.013 * scaleFactor
+  };
+  const brandPlateGeometry = new ThreeNamespace.BoxGeometry(
+    brandPlateSize.width,
+    brandPlateSize.thickness,
+    brandPlateSize.depth
+  );
   const brandPlateMaterialTop = new ThreeNamespace.MeshStandardMaterial({
     map: makeBrandPlateTexture(),
     color: '#ffffff',
@@ -744,7 +753,11 @@ export function createMurlanStyleTable({
     brandPlateMaterialSide
   ]);
   const frontRadius = outerRadiusSampler(new ThreeNamespace.Vector2(0, 1));
-  brandPlate.position.set(0, tableY + clothRise * 0.63, frontRadius - rimSize.depth * 0.65);
+  brandPlate.position.set(
+    0,
+    tableY + clothRise * 0.84,
+    frontRadius - brandPlateSize.depth * 1.08
+  );
   brandPlate.rotation.x = THREE.MathUtils.degToRad(-2.2);
   brandPlate.castShadow = true;
   brandPlate.receiveShadow = true;


### PR DESCRIPTION
### Motivation
- Make the table branding plate visually smaller and thinner so it doesn't dominate the wooden rail. 
- Move and raise the plate so it sits on the rail surface and appears slightly inset for better composition.

### Description
- Introduced `brandPlateSize` and replaced the previous geometry with a smaller, thinner `BoxGeometry` using `brandPlateSize.width`, `brandPlateSize.thickness`, and `brandPlateSize.depth` in `webapp/src/utils/murlanTable.js`.
- Raised the plate vertically by changing its Y position to `tableY + clothRise * 0.84` so it sits higher on the rail surface.
- Shifted the plate inward from the rail edge by setting Z to `frontRadius - brandPlateSize.depth * 1.08` for a subtly inset placement.
- Kept materials and rotation intact so appearance and shading remain consistent.

### Testing
- Ran `npm run -s test -- test/checkersBattleHdriCatalog.test.js` and the test suite passed (2 tests, 1 suite).
- Verified repository status to confirm the modified file `webapp/src/utils/murlanTable.js` was updated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e84ec173d08329a61b5a54138237b6)