### PR TITLE
Fix Murlan Royale card orientation/corners and raise results frame

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -4850,7 +4850,7 @@ export default function MurlanRoyaleArena({ search }) {
         const scoreboardHeight = scoreboardWidth * 0.39;
         const scoreboardGeometry = new THREE.PlaneGeometry(scoreboardWidth, scoreboardHeight);
         const scoreboardMesh = new THREE.Mesh(scoreboardGeometry, scoreboardMaterial);
-        const scoreboardY = TABLE_HEIGHT + 1.02 * MODEL_SCALE;
+        const scoreboardY = TABLE_HEIGHT + 1.32 * MODEL_SCALE;
         const scoreboardZ = -Math.max(TABLE_RADIUS * 2.2, floorRadius * 0.72);
         scoreboardMesh.position.set(0, scoreboardY, scoreboardZ);
         scoreboardMesh.lookAt(new THREE.Vector3(0, scoreboardMesh.position.y, 0));
@@ -6579,32 +6579,30 @@ function makeCardFace(rank, suit, theme, w = 768, h = 1080) {
   const label = rank === 'JB' ? 'JB' : rank === 'JR' ? 'JR' : String(rank);
   const cornerRankSize = Math.round(w * 0.18);
   const cornerSuitSize = Math.round(w * 0.16);
-  const cornerLeftX = Math.round(w * 0.115);
-  const cornerRightX = Math.round(w * 0.895);
-  const topRankY = Math.round(h * 0.1);
-  const topSuitY = Math.round(h * 0.2);
-  const bottomRankY = Math.round(h * 0.76);
-  const bottomSuitY = Math.round(h * 0.86);
+  const cornerPaddingX = Math.round(w * 0.11);
+  const cornerTopY = Math.round(h * 0.1);
+  const cornerBottomY = Math.round(h * 0.9);
+  const cornerGapY = Math.round(h * 0.1);
+  const drawCorner = (x, y, align = 'left', flipped = false) => {
+    g.save();
+    g.translate(x, y);
+    if (flipped) {
+      g.rotate(Math.PI);
+    }
+    g.textAlign = align;
+    g.textBaseline = 'top';
+    g.font = `900 ${cornerRankSize}px "Inter", "Segoe UI", sans-serif`;
+    g.fillText(label, 0, 0);
+    g.font = `${cornerSuitSize}px "Inter", "Segoe UI", sans-serif`;
+    g.fillText(suit, 0, cornerGapY);
+    g.restore();
+  };
 
   g.fillStyle = color;
-  g.textAlign = 'left';
-  g.textBaseline = 'top';
-  g.font = `900 ${cornerRankSize}px "Inter", "Segoe UI", sans-serif`;
-  g.fillText(label, cornerLeftX, topRankY);
-  g.font = `${cornerSuitSize}px "Inter", "Segoe UI", sans-serif`;
-  g.fillText(suit, cornerLeftX, topSuitY);
-
-  g.font = `900 ${cornerRankSize}px "Inter", "Segoe UI", sans-serif`;
-  g.fillText(label, cornerLeftX, bottomRankY);
-  g.font = `${cornerSuitSize}px "Inter", "Segoe UI", sans-serif`;
-  g.fillText(suit, cornerLeftX, bottomSuitY);
-
-  g.textAlign = 'right';
-  g.textBaseline = 'top';
-  g.font = `900 ${cornerRankSize}px "Inter", "Segoe UI", sans-serif`;
-  g.fillText(label, cornerRightX, topRankY);
-  g.font = `${cornerSuitSize}px "Inter", "Segoe UI", sans-serif`;
-  g.fillText(suit, cornerRightX, topSuitY);
+  drawCorner(cornerPaddingX, cornerTopY, 'left');
+  drawCorner(w - cornerPaddingX, cornerTopY, 'right');
+  drawCorner(cornerPaddingX, cornerBottomY, 'right', true);
+  drawCorner(w - cornerPaddingX, cornerBottomY, 'left', true);
 
   g.textAlign = 'center';
   g.textBaseline = 'middle';

--- a/webapp/src/utils/cards3d.js
+++ b/webapp/src/utils/cards3d.js
@@ -123,22 +123,29 @@ function makeCardFace(rank, suit, theme, w = 512, h = 720) {
   ctx.stroke();
   const suitColor = getSuitColor(suit);
   ctx.fillStyle = suitColor;
-  const label = rank === 'T' ? 'Q' : String(rank);
-  const padding = 36;
-  const topRankY = 104;
-  const topSuitY = topRankY + 76;
-  const bottomSuitY = h - 92;
-  const bottomRankY = bottomSuitY - 76;
-  ctx.textAlign = 'left';
-  ctx.font = 'bold 96px "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI"';
-  ctx.fillText(label, padding, bottomRankY);
-  ctx.font = 'bold 78px "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI"';
-  ctx.fillText(convertSuit(suit), padding, bottomSuitY);
-  ctx.textAlign = 'right';
-  ctx.font = 'bold 96px "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI"';
-  ctx.fillText(label, w - padding, topRankY);
-  ctx.font = 'bold 78px "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI"';
-  ctx.fillText(convertSuit(suit), w - padding, topSuitY);
+  const label = rank === 'T' ? '10' : String(rank);
+  const padding = 34;
+  const rankFontSize = 88;
+  const suitFontSize = 72;
+  const cornerGap = 66;
+  const drawCorner = (x, y, align = 'left', flipped = false) => {
+    ctx.save();
+    ctx.translate(x, y);
+    if (flipped) {
+      ctx.rotate(Math.PI);
+    }
+    ctx.textAlign = align;
+    ctx.textBaseline = 'top';
+    ctx.font = `bold ${rankFontSize}px "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI"`;
+    ctx.fillText(label, 0, 0);
+    ctx.font = `bold ${suitFontSize}px "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI"`;
+    ctx.fillText(convertSuit(suit), 0, cornerGap);
+    ctx.restore();
+  };
+  drawCorner(padding, 48, 'left');
+  drawCorner(w - padding, 48, 'right');
+  drawCorner(padding, h - 48, 'right', true);
+  drawCorner(w - padding, h - 48, 'left', true);
   if (theme.centerAccent) {
     ctx.fillStyle = theme.centerAccent;
     ctx.beginPath();
@@ -182,8 +189,6 @@ export function makeTonplaygramCardBackTexture(theme, w = 3072, h = 4320) {
   texture.magFilter = THREE.LinearFilter;
   texture.generateMipmaps = true;
   texture.anisotropy = 16;
-  texture.center.set(0.5, 0.5);
-  texture.rotation = Math.PI;
   texture.flipY = false;
 
   const logoImage = getTonplaygramLogoImage();


### PR DESCRIPTION
### Motivation
- Card backs were rendered upside-down / mirrored causing the logo to appear wrong on-screen and card corners only had two visible indicators; cards must show rank/suit correctly in all four corners and the results frame should be positioned higher in portrait view.
- Keep rendering logic localized to card texture generation and the arena UI so changes are minimal and safe.

### Description
- Removed the extra canvas texture rotation/centering on the card back to fix upside-down/mirrored logo rendering by deleting `texture.center.set(...)` and `texture.rotation = Math.PI` in `webapp/src/utils/cards3d.js`.
- Reworked corner rendering for card faces to draw rank and suit in all four corners with proper mirrored rotation for bottom corners via a `drawCorner` helper in both `webapp/src/utils/cards3d.js` and `webapp/src/pages/Games/MurlanRoyaleArena.jsx` so each card shows 4 rank/suit markers and they are aligned.
- Standardized some corner sizing/spacing (padding, font sizes) and changed the face label for the Ten to `10` for consistent layout in `webapp/src/utils/cards3d.js`.
- Raised the in-world results/scoreboard plane upward by increasing `scoreboardY` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` so the results frame appears higher on-screen in portrait.
- Files modified: `webapp/src/utils/cards3d.js`, `webapp/src/pages/Games/MurlanRoyaleArena.jsx`.

### Testing
- Ran the production build with `npm --prefix webapp run build`, which completed successfully (Vite emitted non-blocking chunk-size/dynamic-import warnings).
- No automated unit tests were changed or executed in this PR; build is the primary verification and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e850ca6e548329b3636ac6afb400f1)