### PR TITLE
Adjust checkers table brand plate thickness and octagon rail alignment

### DIFF
--- a/webapp/src/utils/murlanTable.js
+++ b/webapp/src/utils/murlanTable.js
@@ -726,7 +726,7 @@ export function createMurlanStyleTable({
   const brandPlateSize = {
     width: rimSize.width * 0.9,
     depth: rimSize.depth * 0.86,
-    thickness: 0.013 * scaleFactor
+    thickness: 0.0075 * scaleFactor
   };
   const brandPlateGeometry = new ThreeNamespace.BoxGeometry(
     brandPlateSize.width,
@@ -752,13 +752,27 @@ export function createMurlanStyleTable({
     brandPlateMaterialSide,
     brandPlateMaterialSide
   ]);
-  const frontRadius = outerRadiusSampler(new ThreeNamespace.Vector2(0, 1));
-  brandPlate.position.set(
-    0,
-    tableY + clothRise * 0.84,
-    frontRadius - brandPlateSize.depth * 1.08
-  );
-  brandPlate.rotation.x = THREE.MathUtils.degToRad(-2.2);
+  const isClassicOctagon = shapeOption?.id === 'classicOctagon';
+  const brandLiftY = tableY + clothRise * 0.93;
+  if (isClassicOctagon) {
+    const octagonRailDirection = new ThreeNamespace.Vector2(0.46, 1).normalize();
+    const octagonRailRadius = outerRadiusSampler(octagonRailDirection);
+    brandPlate.position.set(
+      octagonRailDirection.x * (octagonRailRadius - brandPlateSize.depth * 0.62),
+      brandLiftY,
+      octagonRailDirection.y * (octagonRailRadius - brandPlateSize.depth * 0.62)
+    );
+    brandPlate.rotation.y =
+      Math.atan2(octagonRailDirection.x, octagonRailDirection.y) + Math.PI / 2;
+  } else {
+    const frontRadius = outerRadiusSampler(new ThreeNamespace.Vector2(0, 1));
+    brandPlate.position.set(
+      0,
+      brandLiftY,
+      frontRadius - brandPlateSize.depth * 1.08
+    );
+  }
+  brandPlate.rotation.x = THREE.MathUtils.degToRad(-1.2);
   brandPlate.castShadow = true;
   brandPlate.receiveShadow = true;
   tableGroup.add(brandPlate);


### PR DESCRIPTION
### Motivation
- Make the table branding plate visually thinner and sit higher on the wooden rail top so it reads like the reference photo. 
- For the octagon table shape, align the plate to follow the rail direction instead of the default front-centered placement. 

### Description
- Reduced brand plate thickness from `0.013 * scaleFactor` to `0.0075 * scaleFactor` in `createMurlanStyleTable` inside `webapp/src/utils/murlanTable.js` to produce a slimmer plate. 
- Raised the plate vertical placement by using `brandLiftY = tableY + clothRise * 0.93` so the plate sits more on the rail top surface. 
- Added a `classicOctagon` branch that positions the plate along an octagon rail direction vector and sets `rotation.y` to follow the rail using `outerRadiusSampler` and a normalized `Vector2`. 
- Kept non-octagon tables using the existing front-centered logic while applying the new vertical lift and a slightly reduced `rotation.x`. 

### Testing
- Ran `node --check webapp/src/utils/murlanTable.js` which completed successfully. 
- No further automated tests were executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e851e08958832991099a59426da649)