### PR TITLE
Fix Murlan Royale card visuals and raise results frame

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -4850,7 +4850,8 @@ export default function MurlanRoyaleArena({ search }) {
         const scoreboardHeight = scoreboardWidth * 0.39;
         const scoreboardGeometry = new THREE.PlaneGeometry(scoreboardWidth, scoreboardHeight);
         const scoreboardMesh = new THREE.Mesh(scoreboardGeometry, scoreboardMaterial);
-        const scoreboardY = TABLE_HEIGHT + 1.02 * MODEL_SCALE;
+        // Lift results frame higher on portrait/mobile so it matches requested visual placement.
+        const scoreboardY = TABLE_HEIGHT + 1.24 * MODEL_SCALE;
         const scoreboardZ = -Math.max(TABLE_RADIUS * 2.2, floorRadius * 0.72);
         scoreboardMesh.position.set(0, scoreboardY, scoreboardZ);
         scoreboardMesh.lookAt(new THREE.Vector3(0, scoreboardMesh.position.y, 0));
@@ -6549,8 +6550,13 @@ function setTopSeatBackLogoAdjustments(mesh, enabled) {
 
   if (!mesh.userData.topSeatBackTexture) {
     const tunedTexture = baseTexture.clone();
-    tunedTexture.repeat.set(1, 0.92);
-    tunedTexture.offset.set(0, 0.04);
+    // Keep the top opponent card-back logo visually face-up on portrait screens.
+    // Flip UVs on both axes for this seat-specific clone so the badge no longer
+    // appears upside-down / mirrored to the local player camera.
+    tunedTexture.repeat.set(-1, -0.92);
+    tunedTexture.offset.set(1, 0.96);
+    tunedTexture.center.set(0.5, 0.5);
+    tunedTexture.rotation = 0;
     tunedTexture.needsUpdate = true;
     mesh.userData.topSeatBackTexture = tunedTexture;
     mesh.userData.topSeatBackTextureSource = baseTexture;
@@ -6583,8 +6589,8 @@ function makeCardFace(rank, suit, theme, w = 768, h = 1080) {
   const cornerRightX = Math.round(w * 0.895);
   const topRankY = Math.round(h * 0.1);
   const topSuitY = Math.round(h * 0.2);
-  const bottomRankY = Math.round(h * 0.76);
-  const bottomSuitY = Math.round(h * 0.86);
+  const bottomSuitY = Math.round(h * 0.91);
+  const bottomRankY = Math.round(h * 0.81);
 
   g.fillStyle = color;
   g.textAlign = 'left';
@@ -6594,6 +6600,7 @@ function makeCardFace(rank, suit, theme, w = 768, h = 1080) {
   g.font = `${cornerSuitSize}px "Inter", "Segoe UI", sans-serif`;
   g.fillText(suit, cornerLeftX, topSuitY);
 
+  g.textBaseline = 'alphabetic';
   g.font = `900 ${cornerRankSize}px "Inter", "Segoe UI", sans-serif`;
   g.fillText(label, cornerLeftX, bottomRankY);
   g.font = `${cornerSuitSize}px "Inter", "Segoe UI", sans-serif`;
@@ -6605,6 +6612,13 @@ function makeCardFace(rank, suit, theme, w = 768, h = 1080) {
   g.fillText(label, cornerRightX, topRankY);
   g.font = `${cornerSuitSize}px "Inter", "Segoe UI", sans-serif`;
   g.fillText(suit, cornerRightX, topSuitY);
+
+  g.textAlign = 'right';
+  g.textBaseline = 'alphabetic';
+  g.font = `900 ${cornerRankSize}px "Inter", "Segoe UI", sans-serif`;
+  g.fillText(label, cornerRightX, bottomRankY);
+  g.font = `${cornerSuitSize}px "Inter", "Segoe UI", sans-serif`;
+  g.fillText(suit, cornerRightX, bottomSuitY);
 
   g.textAlign = 'center';
   g.textBaseline = 'middle';


### PR DESCRIPTION
### Motivation
- Cards seen from the top opponent seat displayed the back logo upside-down / mirrored for portrait view and card corner indices were missing or misaligned, reducing readability. 
- The in-scene Results frame sat too low on portrait/mobile and needed to be visually lifted to match the provided mock/photo.

### Description
- Adjusted seat-specific back texture mapping in `setTopSeatBackLogoAdjustments` so the top-opponent card-back logo is oriented face-up for the local portrait camera by cloning and flipping the UVs and tuning center/offset (`tunedTexture.repeat`, `tunedTexture.offset`, `tunedTexture.center`).
- Updated `makeCardFace` to draw all four corner rank/suit markers and tightened bottom-corner alignment by changing baseline handling and bottom Y offsets so each card shows four properly aligned indices.
- Raised the Results/scoreboard plane by increasing its Y position calculation so the results frame appears higher on portrait/mobile (`scoreboardY = TABLE_HEIGHT + 1.24 * MODEL_SCALE`).
- All changes are contained in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` and touch texture/UV handling, canvas face drawing, and scoreboard placement.

### Testing
- Ran `npm run -s test -- test/murlan.test.js` and the suite passed (`12 tests, 0 failures`).
- No other automated UI tests were executed in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e850ca6e548329b3636ac6afb400f1)