### PR TITLE
Adjust checkers table brand plate alignment and lift

### DIFF
--- a/webapp/src/utils/murlanTable.js
+++ b/webapp/src/utils/murlanTable.js
@@ -723,10 +723,12 @@ export function createMurlanStyleTable({
   tableGroup.add(rimMesh);
 
   const rimSize = shapeOption?.id === 'grandOval' ? { width: tableRadius * 0.7, depth: tableRadius * 0.16 } : { width: tableRadius * 0.62, depth: tableRadius * 0.14 };
+  const isClassicOctagon = shapeOption?.id === 'classicOctagon';
   const brandPlateSize = {
     width: rimSize.width * 0.9,
     depth: rimSize.depth * 0.86,
-    thickness: 0.013 * scaleFactor
+    // Keep the brand plate slimmer so it sits cleaner on the top rail across all table shapes.
+    thickness: 0.0095 * scaleFactor
   };
   const brandPlateGeometry = new ThreeNamespace.BoxGeometry(
     brandPlateSize.width,
@@ -755,10 +757,14 @@ export function createMurlanStyleTable({
   const frontRadius = outerRadiusSampler(new ThreeNamespace.Vector2(0, 1));
   brandPlate.position.set(
     0,
-    tableY + clothRise * 0.84,
+    tableY + clothRise * (isClassicOctagon ? 1.01 : 0.92),
     frontRadius - brandPlateSize.depth * 1.08
   );
   brandPlate.rotation.x = THREE.MathUtils.degToRad(-2.2);
+  if (isClassicOctagon) {
+    // Match the front rail direction on the octagon variant so the branding follows the same slant.
+    brandPlate.rotation.y = THREE.MathUtils.degToRad(22.5);
+  }
   brandPlate.castShadow = true;
   brandPlate.receiveShadow = true;
   tableGroup.add(brandPlate);


### PR DESCRIPTION
### Motivation
- The brand plate on Murlan-style tables appeared too thick and sat slightly below the wooden rail on the octagon variant, so it needed to be thinner, lifted, and oriented to match the rail direction for the classic octagon table. 

### Description
- Slimmed the brand plate thickness from `0.013 * scaleFactor` to `0.0095 * scaleFactor` in `webapp/src/utils/murlanTable.js` so the plate reads less bulky across all table shapes. 
- Added a shape check via `isClassicOctagon` and adjusted vertical placement to `tableY + clothRise * (isClassicOctagon ? 1.01 : 0.92)` so octagon plates sit on the top rail and others are slightly lifted. 
- For the classic octagon, applied `brandPlate.rotation.y = THREE.MathUtils.degToRad(22.5)` so the brand plate follows the octagon rail direction. 

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully with Vite non-blocking chunk warnings. 
- No automated unit tests were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e851e08958832991099a59426da649)