### PR TITLE
Murlan: Fix card-back logo orientation, corner labels, and tighten AI hand spacing

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2338,7 +2338,7 @@ const AI_HAND_LEFT_SHIFT = 0;
 const HUMAN_HAND_UP_SHIFT_Y = 0.092 * MODEL_SCALE;
 const HUMAN_HAND_DIRECTIONAL_LIFT = 0;
 const HUMAN_HAND_BOTTOM_INWARD_TILT_X = 0;
-const AI_HAND_CARD_SPACING = CARD_W * HUMAN_HAND_CARD_SCALE * 0.5;
+const AI_HAND_CARD_SPACING = CARD_W * HUMAN_HAND_CARD_SCALE * 0.38;
 const AI_HAND_CARD_MAX_SPREAD = AI_HAND_CARD_SPACING * 14;
 const AI_HAND_FAN_MAX_YAW = HUMAN_HAND_FAN_MAX_YAW;
 const AI_HAND_FAN_ARC_LIFT = HUMAN_HAND_FAN_ARC_LIFT;
@@ -3740,7 +3740,11 @@ export default function MurlanRoyaleArena({ search }) {
         const backLogoVariant = !isHumanCard
           ? idx === topNonHumanSeatIndex
             ? 'top'
-            : 'side'
+            : (seat?.forward?.x ?? 0) > 0.01
+              ? 'sideRight'
+              : (seat?.forward?.x ?? 0) < -0.01
+                ? 'sideLeft'
+                : 'side'
           : 'default';
         setBackLogoOrientation(mesh, backLogoVariant);
         mesh.visible = true;
@@ -3870,7 +3874,7 @@ export default function MurlanRoyaleArena({ search }) {
       mesh.visible = true;
       mesh.scale.setScalar(1);
       updateCardFace(mesh, 'back');
-      setBackLogoOrientation(mesh, 'top');
+      setBackLogoOrientation(mesh, 'discard');
       setCommunityCardLegibility(mesh, false);
       const target = discardAnchor.clone();
       target.y += idx * 0.0015;
@@ -6571,6 +6575,21 @@ function setBackLogoOrientation(mesh, variant = 'default') {
       tunedTexture.offset.set(0, 0);
       tunedTexture.rotation = Math.PI;
       tunedTexture.center.set(0.5, 0.5);
+    } else if (desiredVariant === 'sideLeft') {
+      tunedTexture.repeat.set(1, 1);
+      tunedTexture.offset.set(0, 0);
+      tunedTexture.rotation = Math.PI / 2;
+      tunedTexture.center.set(0.5, 0.5);
+    } else if (desiredVariant === 'sideRight') {
+      tunedTexture.repeat.set(1, 1);
+      tunedTexture.offset.set(0, 0);
+      tunedTexture.rotation = -Math.PI / 2;
+      tunedTexture.center.set(0.5, 0.5);
+    } else if (desiredVariant === 'discard') {
+      tunedTexture.repeat.set(1, 1);
+      tunedTexture.offset.set(0, 0);
+      tunedTexture.rotation = 0;
+      tunedTexture.center.set(0.5, 0.5);
     }
     tunedTexture.needsUpdate = true;
     mesh.userData.backLogoOrientedTexture = tunedTexture;
@@ -6621,8 +6640,8 @@ function makeCardFace(rank, suit, theme, w = 768, h = 1080) {
   };
 
   g.fillStyle = color;
-  drawCorner(cornerPaddingX, cornerTopY, 'left');
-  drawCorner(w - cornerPaddingX, cornerBottomY, 'left', true);
+  drawCorner(w - cornerPaddingX, cornerTopY, 'right');
+  drawCorner(cornerPaddingX, cornerBottomY, 'right', true);
 
   g.textAlign = 'center';
   g.textBaseline = 'middle';


### PR DESCRIPTION
### Motivation
- Align card visuals with the reference photo by ensuring opponent card logos are mirrored correctly, the discard pile logo is upright, corner rank/suit marks are on the opposite diagonal, and AI hands appear visually closer together while leaving the top and bottom players' cards unchanged.

### Description
- Updated `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to compute opponent back-logo variants per-seat and emit `sideLeft` / `sideRight` based on `seat.forward.x` while preserving the top-player `top` behavior and human `default` behavior.
- Added new texture-orientation branches in `setBackLogoOrientation` for `sideLeft`, `sideRight`, and `discard` and configured their `rotation`/`center`/`repeat`/`offset` so side opponents are mirrored correctly and the discard pile renders upright (non-mirrored).
- Moved the corner rank/suit drawing positions inside `makeCardFace` to the opposite diagonal by swapping the calls so labels render on the requested diagonal.
- Reduced non-human hand spacing by changing `AI_HAND_CARD_SPACING` from `CARD_W * HUMAN_HAND_CARD_SCALE * 0.5` to `CARD_W * HUMAN_HAND_CARD_SCALE * 0.38` so opponent cards sit closer together without changing human (bottom) spacing.

### Testing
- Ran the Murlan unit test file with `npm -s test -- test/murlan.test.js` and all tests passed (`12 passed`).
- No other automated visual/browser tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8597a0490832992642ff5c0770b9a)