### PR TITLE
Murlan: reverse bottom-hand card layering to favor low-card side

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -3736,7 +3736,8 @@ export default function MurlanRoyaleArena({ search }) {
         if (!entry) return;
         const mesh = entry.mesh;
         const isHumanCard = player.isHuman;
-        applyHandCardLayering(mesh, isHumanCard, cardIdx);
+        const layerIndex = isHumanCard ? cards.length - 1 - cardIdx : cardIdx;
+        applyHandCardLayering(mesh, isHumanCard, layerIndex);
         const backLogoVariant = !isHumanCard
           ? idx === topNonHumanSeatIndex
             ? 'top'


### PR DESCRIPTION
### Motivation
- Make the human player's bottom-hand cards display their full visible edge on the low-card side (near the `3`) instead of the joker side so cards are easier to read in portrait/mobile view.

### Description
- For human hands, reverse the render-layer index passed to `applyHandCardLayering` so the last card in the array is rendered on top; AI card layering is unchanged (file: `webapp/src/pages/Games/MurlanRoyaleArena.jsx`).

### Testing
- Ran `npm test -- --runInBand test/murlan.test.js` which executed the Murlan tests and resulted in all tests passing (`12 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e863927cc4832993206c799678024a)