### PR TITLE
Tune Checkers Battle Royal table pedestal grounding and branding plate sizing

### DIFF
--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -101,7 +101,7 @@ const MIN_HDRI_RADIUS = 28;
 const DEFAULT_HDRI_RADIUS_MULTIPLIER = 6;
 const DEFAULT_HDRI_GROUNDED_RESOLUTION = 256;
 const CHECKERS_ROOM_HALF_SPAN = CHAIR_DISTANCE + SEAT_DEPTH;
-const CHECKERS_TABLE_BASE_HEIGHT_SCALE = 0.5;
+const CHECKERS_TABLE_BASE_HEIGHT_SCALE = 0.72;
 const CHECKERS_TABLE_BASE_RADIUS_SCALE = 0.56;
 const CHECKERS_TABLE_TRIM_HEIGHT_SCALE = 0.66;
 const CHECKERS_TABLE_TRIM_RADIUS_SCALE = 0.74;
@@ -289,6 +289,7 @@ const TARGET_CHAIR_SIZE = new THREE.Vector3(
 const TARGET_CHAIR_MIN_Y = -CHAIR_BASE_HEIGHT;
 const TARGET_CHAIR_CENTER_Z = -0.1553906416893005;
 const CHAIR_GROUNDING_EPSILON = 0.012 * MODEL_SCALE;
+const CHECKERS_TABLE_BASE_FLOOR_Y = -CHAIR_GROUND_SINK - CHAIR_GROUNDING_EPSILON;
 const SHADOW_CATCHER_SIZE = CHECKERS_ROOM_HALF_SPAN * 2.9;
 const SHADOW_CATCHER_OPACITY = 0.26;
 const SHADOW_CATCHER_ELEVATION = 0.004;
@@ -1536,6 +1537,15 @@ function alignArenaGroundArtifacts({ shadowCatcher, skybox, table, board, chairs
 
 function reduceCheckersTableBase(tableGroup) {
   if (!tableGroup) return;
+  const supportedShapeIds = new Set([
+    'murlan-default',
+    'ovalTable',
+    'grandOval',
+    'diamondEdge',
+    'hexagonTable'
+  ]);
+  const selectedTableId = tableGroup?.userData?.selectedTableId;
+  if (selectedTableId && !supportedShapeIds.has(selectedTableId)) return;
   tableGroup.traverse((node) => {
     if (!node?.isMesh || node.geometry?.type !== 'CylinderGeometry') return;
     const isBelowTop = node.position.y < TABLE_HEIGHT - 0.06;
@@ -1584,6 +1594,28 @@ function reduceCheckersTableBase(tableGroup) {
           Number.isFinite(beforeBox.min.y)
         ) {
           node.position.y += beforeBox.min.y - realignedBox.min.y;
+          node.updateMatrixWorld(true);
+        }
+      }
+      const groundedBox = new THREE.Box3().setFromObject(node);
+      if (
+        Number.isFinite(groundedBox.min.y) &&
+        Number.isFinite(groundedBox.max.y) &&
+        groundedBox.max.y - groundedBox.min.y > 1e-5 &&
+        groundedBox.min.y > CHECKERS_TABLE_BASE_FLOOR_Y
+      ) {
+        const currentHeight = groundedBox.max.y - groundedBox.min.y;
+        const targetHeight = groundedBox.max.y - CHECKERS_TABLE_BASE_FLOOR_Y;
+        const floorReachScale = THREE.MathUtils.clamp(
+          targetHeight / currentHeight,
+          1,
+          2.2
+        );
+        node.scale.y *= floorReachScale;
+        node.updateMatrixWorld(true);
+        const floorAlignedBox = new THREE.Box3().setFromObject(node);
+        if (Number.isFinite(floorAlignedBox.max.y)) {
+          node.position.y += groundedBox.max.y - floorAlignedBox.max.y;
           node.updateMatrixWorld(true);
         }
       }

--- a/webapp/src/utils/murlanTable.js
+++ b/webapp/src/utils/murlanTable.js
@@ -787,10 +787,11 @@ export function createMurlanStyleTable({
 
   const rimSize = shapeOption?.id === 'grandOval' ? { width: tableRadius * 0.7, depth: tableRadius * 0.16 } : { width: tableRadius * 0.62, depth: tableRadius * 0.14 };
   const brandPlateSize = {
-    width: rimSize.width * 0.9,
-    depth: rimSize.depth * 0.86,
-    // Keep the brand plate slimmer so it sits cleaner on the top rail across all table shapes.
-    thickness: 0.0095 * scaleFactor
+    // Slightly smaller footprint for a cleaner front rail read on portrait screens.
+    width: rimSize.width * 0.86,
+    depth: rimSize.depth * 0.82,
+    // Make the branding plate a bit thinner.
+    thickness: 0.0072 * scaleFactor
   };
   const brandPlateGeometry = new ThreeNamespace.BoxGeometry(
     brandPlateSize.width,
@@ -819,7 +820,7 @@ export function createMurlanStyleTable({
   const frontRadius = outerRadiusSampler(new ThreeNamespace.Vector2(0, 1));
   brandPlate.position.set(
     0,
-    tableY + clothRise * 1.14,
+    tableY + clothRise * 1.28,
     frontRadius - brandPlateSize.depth * 1.08
   );
   brandPlate.rotation.x = THREE.MathUtils.degToRad(-2.2);


### PR DESCRIPTION
### Motivation
- Visual feedback requested: procedural octagon/oval/diamond/hexagon tables should read taller and physically reach the same HDRI ground as chairs so they no longer appear to float. 
- The branding plate needs to sit slightly higher, slimmer, and a bit smaller so it reads cleaner on portrait/mobile framing.

### Description
- Increased table pedestal scale by changing `CHECKERS_TABLE_BASE_HEIGHT_SCALE` from `0.5` to `0.72` to make procedural table bases appear taller. (`webapp/src/pages/Games/CheckersBattleRoyal.jsx`)
- Added `CHECKERS_TABLE_BASE_FLOOR_Y` and shape-scoped grounding logic in `reduceCheckersTableBase` so supported procedural shapes (`murlan-default`, `ovalTable`, `grandOval`, `diamondEdge`, `hexagonTable`) expand downward to meet the chair/arena floor plane. (`webapp/src/pages/Games/CheckersBattleRoyal.jsx`)
- Adjusted branding plate footprint and placement to be slightly smaller, thinner, and raised on the rail by updating `brandPlateSize` and its `position.y`. (`webapp/src/utils/murlanTable.js`)

### Testing
- Ran `npx jest test/checkersBattleHdriCatalog.test.js --runInBand` and the test suite passed.
- Ran `npx eslint webapp/src/pages/Games/CheckersBattleRoyal.jsx webapp/src/utils/murlanTable.js` which reported the files were ignored by the repo eslint config (warnings), so no lint errors were produced for the changed files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8644dd41c83298eb213263a9f16e5)