### PR TITLE
Tune Checkers table pedestal and brand plate; fix diamond-edge board artifact

### DIFF
--- a/webapp/src/pages/Games/CheckersBattleRoyal.jsx
+++ b/webapp/src/pages/Games/CheckersBattleRoyal.jsx
@@ -101,10 +101,10 @@ const MIN_HDRI_RADIUS = 28;
 const DEFAULT_HDRI_RADIUS_MULTIPLIER = 6;
 const DEFAULT_HDRI_GROUNDED_RESOLUTION = 256;
 const CHECKERS_ROOM_HALF_SPAN = CHAIR_DISTANCE + SEAT_DEPTH;
-const CHECKERS_TABLE_BASE_HEIGHT_SCALE = 0.72;
-const CHECKERS_TABLE_BASE_RADIUS_SCALE = 0.56;
-const CHECKERS_TABLE_TRIM_HEIGHT_SCALE = 0.66;
-const CHECKERS_TABLE_TRIM_RADIUS_SCALE = 0.74;
+const CHECKERS_TABLE_BASE_HEIGHT_SCALE = 1.22;
+const CHECKERS_TABLE_BASE_RADIUS_SCALE = 1.08;
+const CHECKERS_TABLE_TRIM_HEIGHT_SCALE = 0.94;
+const CHECKERS_TABLE_TRIM_RADIUS_SCALE = 0.9;
 const CHECKERS_CAMERA_FRAME_COMPENSATION = 1.08;
 // Lower chairs toward the floor for stronger downward screen placement.
 const CHECKERS_GRAPHICS_PROFILE_STORAGE_KEY =
@@ -2843,6 +2843,7 @@ export default function CheckersBattleRoyal() {
             renderer,
             tableRadius: TABLE_RADIUS,
             tableHeight: TABLE_HEIGHT,
+            pedestalHeightScale: 1.24,
             shapeOption: desiredShape
           });
           table.userData = { selectedTableId: appearance.tableId };
@@ -2908,13 +2909,19 @@ export default function CheckersBattleRoyal() {
 
       const proceduralBoard = addVisibleBoardBase();
 
-      try {
-        const boardRoot = await loadCheckersBoardModel(renderer);
-        scene.add(boardRoot);
-        gltfBoardRef.current = boardRoot;
-        applyCheckersBoardTheme(boardRoot, boardThemeRef.current);
-        proceduralBoard.visible = false;
-      } catch {
+      const shouldForceProceduralBoard = appearance.tableId === 'diamondEdge';
+
+      if (!shouldForceProceduralBoard) {
+        try {
+          const boardRoot = await loadCheckersBoardModel(renderer);
+          scene.add(boardRoot);
+          gltfBoardRef.current = boardRoot;
+          applyCheckersBoardTheme(boardRoot, boardThemeRef.current);
+          proceduralBoard.visible = false;
+        } catch {
+          proceduralBoard.visible = true;
+        }
+      } else {
         proceduralBoard.visible = true;
       }
 

--- a/webapp/src/utils/murlanTable.js
+++ b/webapp/src/utils/murlanTable.js
@@ -656,7 +656,7 @@ export function createMurlanStyleTable({
   renderer,
   tableRadius = 2.55,
   tableHeight = 0.81,
-  pedestalHeightScale = 1.08,
+  pedestalHeightScale = 1.14,
   woodOption = DEFAULT_TABLE_WOOD_OPTION,
   clothOption = DEFAULT_TABLE_CLOTH_OPTION,
   baseOption = DEFAULT_TABLE_BASE_OPTION,
@@ -788,10 +788,10 @@ export function createMurlanStyleTable({
   const rimSize = shapeOption?.id === 'grandOval' ? { width: tableRadius * 0.7, depth: tableRadius * 0.16 } : { width: tableRadius * 0.62, depth: tableRadius * 0.14 };
   const brandPlateSize = {
     // Slightly smaller footprint for a cleaner front rail read on portrait screens.
-    width: rimSize.width * 0.86,
-    depth: rimSize.depth * 0.82,
+    width: rimSize.width * 0.8,
+    depth: rimSize.depth * 0.78,
     // Make the branding plate a bit thinner.
-    thickness: 0.0072 * scaleFactor
+    thickness: 0.0054 * scaleFactor
   };
   const brandPlateGeometry = new ThreeNamespace.BoxGeometry(
     brandPlateSize.width,
@@ -820,10 +820,10 @@ export function createMurlanStyleTable({
   const frontRadius = outerRadiusSampler(new ThreeNamespace.Vector2(0, 1));
   brandPlate.position.set(
     0,
-    tableY + clothRise * 1.28,
+    tableY + clothRise * 1.56,
     frontRadius - brandPlateSize.depth * 1.08
   );
-  brandPlate.rotation.x = THREE.MathUtils.degToRad(-2.2);
+  brandPlate.rotation.x = THREE.MathUtils.degToRad(-1.4);
   brandPlate.castShadow = true;
   brandPlate.receiveShadow = true;
   tableGroup.add(brandPlate);


### PR DESCRIPTION
### Motivation
- Procedural checkers table bases (octagon/oval/diamond/hexagon) needed to visually reach the HDRI floor like chairs and other tables. 
- The branding plate should be slightly smaller, thinner and positioned a bit higher for cleaner portrait/mobile presentation. 
- The `diamondEdge` table showed a leftover decorative artifact from the GLTF board that should be avoided by using the procedural board in that case.

### Description
- Increased the checkers table base/trim scaling constants by changing `CHECKERS_TABLE_BASE_HEIGHT_SCALE`, `CHECKERS_TABLE_BASE_RADIUS_SCALE`, `CHECKERS_TABLE_TRIM_HEIGHT_SCALE`, and `CHECKERS_TABLE_TRIM_RADIUS_SCALE` in `webapp/src/pages/Games/CheckersBattleRoyal.jsx` to make pedestals taller. 
- Passed a stronger `pedestalHeightScale: 1.24` when creating procedural tables in the Checkers scene to further extend the base downward. 
- Raised the default `pedestalHeightScale` in the shared table builder `createMurlanStyleTable` to `1.14` and adjusted branding plate geometry/placement in `webapp/src/utils/murlanTable.js` by reducing `width`, `depth`, and `thickness`, moving the plate upward and softening its rotation. 
- Added a `diamondEdge`-specific fallback in the checkers page so the procedural board is used for that table style instead of attempting the GLTF board to avoid the visible edge artifact. 

### Testing
- Ran the production build with `npm --prefix webapp run build`, and the Vite production build completed successfully. 
- No other automated tests were executed in this change; build artifacts were generated and the updated files compiled without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e86954f83c832980e087c669cb1c2e)