### PR TITLE
Tune Snake & Ladder weapon parking and decouple snake caches

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -76,7 +76,7 @@ const CHAIR_MODEL_URLS = [
   'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/SheenChair/glTF-Binary/SheenChair.glb',
   'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/AntiqueChair/glTF-Binary/AntiqueChair.glb'
 ];
-const LUDO_BATTLE_ROYAL_TOKEN_URLS = [
+const SNAKE_TOKEN_MODEL_URLS = [
   'https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Models@master/2.0/ABeautifulGame/glTF-Binary/ABeautifulGame.glb',
   'https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Models@master/2.0/ABeautifulGame/glTF/ABeautifulGame.gltf'
 ];
@@ -86,23 +86,23 @@ const TARGET_CHAIR_SIZE = new THREE.Vector3(1.3162499970197679, 1.91737499003112
 const TARGET_CHAIR_MIN_Y = -0.8570624993294478 * CHAIR_SIZE_SCALE;
 
 const POLYHAVEN_TEXTURE_CACHE = new Map();
-const CHESS_PIECE_CACHE = { promise: null, pieces: null };
-const CAPTURE_VEHICLE_MODEL_CACHE = new Map();
-const CAPTURE_VEHICLE_TEXTURE_MATERIAL_CACHE = new Map();
-const CAPTURE_POLYHAVEN_TEXTURE_SETS = new Map();
-const CAPTURE_VEHICLE_MODEL_HOSTS = [
+const SNAKE_TOKEN_PROTOTYPE_CACHE = { promise: null, pieces: null };
+const SNAKE_CAPTURE_VEHICLE_MODEL_CACHE = new Map();
+const SNAKE_CAPTURE_VEHICLE_TEXTURE_MATERIAL_CACHE = new Map();
+const SNAKE_CAPTURE_POLYHAVEN_TEXTURE_SETS = new Map();
+const SNAKE_CAPTURE_VEHICLE_MODEL_HOSTS = [
   'https://cdn.jsdelivr.net/gh/srcejon/sdrangel-3d-models@main',
   'https://raw.githubusercontent.com/srcejon/sdrangel-3d-models/main',
   'https://cdn.statically.io/gh/srcejon/sdrangel-3d-models/main'
 ];
-const CAPTURE_VEHICLE_MODEL_FILES = Object.freeze({
+const SNAKE_CAPTURE_VEHICLE_MODEL_FILES = Object.freeze({
   drone: ['drone.glb'],
   helicopter: ['helicopter.glb'],
   fighter: ['f15.glb'],
   supportTruck: ['fire_truck.glb'],
   javelin: ['javelin_missile.glb', 'javelin.glb', 'missile_javelin.glb', 'missile.glb']
 });
-const CAPTURE_POLYHAVEN_TEXTURE_ASSETS = Object.freeze({
+const SNAKE_CAPTURE_POLYHAVEN_TEXTURE_ASSETS = Object.freeze({
   drone: 'rusty_metal_sheet',
   fighter: 'green_metal_rust',
   helicopter: 'green_metal_rust',
@@ -238,7 +238,7 @@ const DICE_PLAYER_EXTRA_OFFSET = TILE_SIZE * 1.8;
 const TOP_TILE_EXTRA_LEVELS = 1;
 const TOP_SEAT_TOKEN_REST_RAIL_INSET = TILE_SIZE * 0.02;
 // Keep parked weapons on the same front rail as player tokens (table edge near each seat).
-const TOP_SEAT_WEAPON_REST_RAIL_INSET = TILE_SIZE * 0.32;
+const TOP_SEAT_WEAPON_REST_RAIL_INSET = TILE_SIZE * 0.2;
 const TOKEN_REST_RAIL_INSET_BY_SEAT = Object.freeze(new Array(DEFAULT_PLAYER_COUNT).fill(TOP_SEAT_TOKEN_REST_RAIL_INSET));
 const WEAPON_REST_RAIL_INSET_BY_SEAT = Object.freeze([
   TOP_SEAT_WEAPON_REST_RAIL_INSET,
@@ -269,19 +269,19 @@ const TOKEN_SLOT_LATERAL_NUDGE_BY_SEAT = Object.freeze([
   TILE_SIZE * 0.08
 ]);
 const WEAPON_SLOT_LATERAL_NUDGE_BY_SEAT = Object.freeze([
-  -TILE_SIZE * 0.02,
-  -TILE_SIZE * 0.02,
-  -TILE_SIZE * 0.02,
-  -TILE_SIZE * 0.02
+  -TILE_SIZE * 0.01,
+  -TILE_SIZE * 0.01,
+  -TILE_SIZE * 0.01,
+  -TILE_SIZE * 0.01
 ]);
 const WEAPON_DISPLAY_SIZE_MULTIPLIER = 1.4;
 const WEAPON_PARKING_OUTWARD_OFFSET = -TILE_SIZE * 0.22;
 const WEAPON_FROM_TOKEN_CENTER_OFFSET = TOKEN_RADIUS * 0.58;
 const WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT = Object.freeze([
-  0,
-  0,
-  0,
-  0
+  TILE_SIZE * 0.05,
+  TILE_SIZE * 0.04,
+  TILE_SIZE * 0.12,
+  TILE_SIZE * 0.04
 ]);
 const WEAPON_TOKEN_GAP = TILE_SIZE * 0.004;
 const WEAPON_PARKED_Y_DROP_BY_KIND = Object.freeze({
@@ -291,8 +291,8 @@ const WEAPON_PARKED_Y_DROP_BY_KIND = Object.freeze({
   supportTruck: TOKEN_HEIGHT * 2.32,
   javelin: TOKEN_HEIGHT * 2.26
 });
-const WEAPON_REST_HEIGHT_OFFSET = -TOKEN_HEIGHT * 1.34;
-const WEAPON_SLOT_CLUSTER_SCALE = 0.34;
+const WEAPON_REST_HEIGHT_OFFSET = -TOKEN_HEIGHT * 1.52;
+const WEAPON_SLOT_CLUSTER_SCALE = 0.24;
 const WEAPON_REST_HEIGHT_OFFSET_BY_SEAT = Object.freeze([
   0,
   0,
@@ -720,8 +720,8 @@ function applyTextureSetToMaterial(material, textureSet, repeat = 1) {
 }
 
 function createCaptureVehicleTexture(kind = 'fighter') {
-  if (CAPTURE_VEHICLE_TEXTURE_MATERIAL_CACHE.has(kind)) {
-    return CAPTURE_VEHICLE_TEXTURE_MATERIAL_CACHE.get(kind);
+  if (SNAKE_CAPTURE_VEHICLE_TEXTURE_MATERIAL_CACHE.has(kind)) {
+    return SNAKE_CAPTURE_VEHICLE_TEXTURE_MATERIAL_CACHE.get(kind);
   }
   const canvas = document.createElement('canvas');
   canvas.width = 256;
@@ -729,7 +729,7 @@ function createCaptureVehicleTexture(kind = 'fighter') {
   const ctx = canvas.getContext('2d');
   if (!ctx) {
     const fallback = new THREE.CanvasTexture(canvas);
-    CAPTURE_VEHICLE_TEXTURE_MATERIAL_CACHE.set(kind, fallback);
+    SNAKE_CAPTURE_VEHICLE_TEXTURE_MATERIAL_CACHE.set(kind, fallback);
     return fallback;
   }
   const palettes = {
@@ -766,12 +766,12 @@ function createCaptureVehicleTexture(kind = 'fighter') {
   texture.wrapT = THREE.RepeatWrapping;
   texture.repeat.set(2.4, 2.4);
   texture.anisotropy = 4;
-  CAPTURE_VEHICLE_TEXTURE_MATERIAL_CACHE.set(kind, texture);
+  SNAKE_CAPTURE_VEHICLE_TEXTURE_MATERIAL_CACHE.set(kind, texture);
   return texture;
 }
 
 function createCaptureVehicleMaterial(kind = 'fighter') {
-  const textureSet = CAPTURE_POLYHAVEN_TEXTURE_SETS.get(kind) || null;
+  const textureSet = SNAKE_CAPTURE_POLYHAVEN_TEXTURE_SETS.get(kind) || null;
   return new THREE.MeshStandardMaterial({
     map: textureSet?.map || createCaptureVehicleTexture(kind),
     normalMap: textureSet?.normalMap || null,
@@ -783,16 +783,16 @@ function createCaptureVehicleMaterial(kind = 'fighter') {
 
 async function primeCaptureVehicleTextureSets(renderer = null) {
   const maxAnisotropy = renderer?.capabilities?.getMaxAnisotropy?.() ?? 6;
-  const entries = Object.entries(CAPTURE_POLYHAVEN_TEXTURE_ASSETS);
+  const entries = Object.entries(SNAKE_CAPTURE_POLYHAVEN_TEXTURE_ASSETS);
   await Promise.all(
     entries.map(async ([kind, assetId]) => {
-      if (!assetId || CAPTURE_POLYHAVEN_TEXTURE_SETS.has(kind)) return;
+      if (!assetId || SNAKE_CAPTURE_POLYHAVEN_TEXTURE_SETS.has(kind)) return;
       const set = await loadPolyhavenTextureSet(assetId, renderer);
       if (!set) return;
       if (set.map) set.map.anisotropy = maxAnisotropy;
       if (set.roughnessMap) set.roughnessMap.anisotropy = maxAnisotropy;
       if (set.normalMap) set.normalMap.anisotropy = maxAnisotropy;
-      CAPTURE_POLYHAVEN_TEXTURE_SETS.set(kind, set);
+      SNAKE_CAPTURE_POLYHAVEN_TEXTURE_SETS.set(kind, set);
     })
   );
 }
@@ -923,12 +923,12 @@ function buildChessPiecePrototypes(scene) {
 }
 
 async function loadChessPiecePrototypes(renderer = null) {
-  if (CHESS_PIECE_CACHE.pieces) return CHESS_PIECE_CACHE.pieces;
-  if (!CHESS_PIECE_CACHE.promise) {
+  if (SNAKE_TOKEN_PROTOTYPE_CACHE.pieces) return SNAKE_TOKEN_PROTOTYPE_CACHE.pieces;
+  if (!SNAKE_TOKEN_PROTOTYPE_CACHE.promise) {
     const loader = createConfiguredGLTFLoader(renderer);
-    CHESS_PIECE_CACHE.promise = (async () => {
+    SNAKE_TOKEN_PROTOTYPE_CACHE.promise = (async () => {
       let gltf = null;
-      for (const url of LUDO_BATTLE_ROYAL_TOKEN_URLS) {
+      for (const url of SNAKE_TOKEN_MODEL_URLS) {
         try {
           gltf = await loader.loadAsync(url);
           break;
@@ -942,8 +942,8 @@ async function loadChessPiecePrototypes(renderer = null) {
       return prototypes;
     })();
   }
-  CHESS_PIECE_CACHE.pieces = await CHESS_PIECE_CACHE.promise;
-  return CHESS_PIECE_CACHE.pieces;
+  SNAKE_TOKEN_PROTOTYPE_CACHE.pieces = await SNAKE_TOKEN_PROTOTYPE_CACHE.promise;
+  return SNAKE_TOKEN_PROTOTYPE_CACHE.pieces;
 }
 
 function scaleChessPieceToToken(piece, targetHeight) {
@@ -4456,18 +4456,18 @@ async function patchGlbImagesToDataUris(buffer, kind, sourceUrl, modelUrls, cach
 }
 
 async function loadCaptureVehicleModel(kind = 'fighter') {
-  const files = CAPTURE_VEHICLE_MODEL_FILES[kind] || CAPTURE_VEHICLE_MODEL_FILES.fighter;
+  const files = SNAKE_CAPTURE_VEHICLE_MODEL_FILES[kind] || SNAKE_CAPTURE_VEHICLE_MODEL_FILES.fighter;
   const fileList = Array.isArray(files) ? files : [files];
   const cacheKey = `${kind}:${fileList.join('|')}`;
-  if (!CAPTURE_VEHICLE_MODEL_CACHE.has(cacheKey)) {
-    CAPTURE_VEHICLE_MODEL_CACHE.set(
+  if (!SNAKE_CAPTURE_VEHICLE_MODEL_CACHE.has(cacheKey)) {
+    SNAKE_CAPTURE_VEHICLE_MODEL_CACHE.set(
       cacheKey,
       (async () => {
         const loader = createConfiguredGLTFLoader();
         const imageCache = new Map();
 
         for (const file of fileList) {
-          const urls = CAPTURE_VEHICLE_MODEL_HOSTS.map((host) => `${host}/${file}`);
+          const urls = SNAKE_CAPTURE_VEHICLE_MODEL_HOSTS.map((host) => `${host}/${file}`);
           for (const url of urls) {
             try {
               // eslint-disable-next-line no-await-in-loop
@@ -4502,7 +4502,7 @@ async function loadCaptureVehicleModel(kind = 'fighter') {
       })()
     );
   }
-  const model = await CAPTURE_VEHICLE_MODEL_CACHE.get(cacheKey);
+  const model = await SNAKE_CAPTURE_VEHICLE_MODEL_CACHE.get(cacheKey);
   return model?.clone?.(true) ?? null;
 }
 


### PR DESCRIPTION
### Motivation
- Parked weapons on the Snake & Ladder table must sit visually higher toward the top rail, be pulled closer together inward toward each other, and rest at the same altitude as tokens and the board for portrait phones.
- Weapon/token handling and asset caches for the Snake game should be scoped to the Snake implementation to avoid accidental sharing with other games.

### Description
- Tuned parked-weapon layout constants in `webapp/src/components/SnakeBoard3D.jsx` including `TOP_SEAT_WEAPON_REST_RAIL_INSET`, `WEAPON_SLOT_LATERAL_NUDGE_BY_SEAT`, `WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT`, `WEAPON_REST_HEIGHT_OFFSET`, and `WEAPON_SLOT_CLUSTER_SCALE` to move weapons visually higher, closer together, and lower their resting altitude to align with tokens/board.
- Renamed and scoped model/texture/cache constants and maps to snake-specific identifiers (for example `LUDO_BATTLE_ROYAL_TOKEN_URLS` → `SNAKE_TOKEN_MODEL_URLS`, `CHESS_PIECE_CACHE` → `SNAKE_TOKEN_PROTOTYPE_CACHE`, and capture vehicle/model caches to `SNAKE_CAPTURE_*`) to isolate Snake asset/animation handling inside `SnakeBoard3D`.
- Updated all usages in the same file so runtime behavior continues to reference the snake-scoped variables.

### Testing
- Ran the production build with `npm --prefix webapp run build`, which completed successfully; Vite emitted the expected existing chunk-size/dynamic-import warnings but no compile or runtime errors introduced by these changes.
- No additional automated tests were modified or required for these constant and renaming changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e87a8bf5cc8329a53bd03b498b10ba)