### PR TITLE
Adjust Murlan Royale hand gaps for top and bottom players

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2322,8 +2322,8 @@ const CAMERA_FOCUS_CENTER_LIFT = 0.1 * MODEL_SCALE;
 const CAMERA_TARGET_TOP_PLAYER_BIAS = 0.5 * MODEL_SCALE;
 const CAMERA_SCREEN_DOWN_SHIFT = 0.12 * MODEL_SCALE;
 const HUMAN_HAND_CARD_SCALE = 1.06;
-const HUMAN_HAND_CARD_SPACING = CARD_W * HUMAN_HAND_CARD_SCALE * 0.17;
-const HUMAN_HAND_CARD_MAX_SPREAD = HUMAN_HAND_CARD_SPACING * 10;
+const HUMAN_HAND_CARD_SPACING = CARD_W * HUMAN_HAND_CARD_SCALE * 0.245;
+const HUMAN_HAND_CARD_MAX_SPREAD = HUMAN_HAND_CARD_SPACING * 11;
 const HUMAN_HAND_EXTRA_LIFT = 0.068 * MODEL_SCALE;
 const HUMAN_HAND_FAN_MAX_YAW = THREE.MathUtils.degToRad(11);
 const HUMAN_HAND_FAN_ARC_LIFT = 0.022 * MODEL_SCALE;
@@ -2340,8 +2340,6 @@ const HUMAN_HAND_DIRECTIONAL_LIFT = 0;
 const HUMAN_HAND_BOTTOM_INWARD_TILT_X = 0;
 const AI_HAND_CARD_SPACING = CARD_W * HUMAN_HAND_CARD_SCALE * 0.3;
 const AI_HAND_CARD_MAX_SPREAD = AI_HAND_CARD_SPACING * 11;
-const TOP_AI_HAND_CARD_SPACING_MULTIPLIER = 1.28;
-const TOP_AI_HAND_CARD_MAX_SPREAD_MULTIPLIER = 1.28;
 const AI_HAND_FAN_MAX_YAW = THREE.MathUtils.degToRad(6.5);
 const AI_HAND_FAN_ARC_LIFT = 0.012 * MODEL_SCALE;
 const HUMAN_HAND_TABLE_EDGE_MARGIN = CARD_H * 0.04;
@@ -4934,9 +4932,6 @@ export default function MurlanRoyaleArena({ search }) {
 
         const forward = new THREE.Vector3(x, 0, z).normalize();
         const right = new THREE.Vector3(-forward.z, 0, forward.x).normalize();
-        const isTopSeatOnScreen = forward.z < -0.45;
-        const aiSeatSpacingMultiplier = isTopSeatOnScreen ? TOP_AI_HAND_CARD_SPACING_MULTIPLIER : 1;
-        const aiSeatMaxSpreadMultiplier = isTopSeatOnScreen ? TOP_AI_HAND_CARD_MAX_SPREAD_MULTIPLIER : 1;
         const focus = forward
           .clone()
           .multiplyScalar(seatRadius - (isHumanSeat ? 1.05 * MODEL_SCALE : 0.65 * MODEL_SCALE));
@@ -4951,8 +4946,8 @@ export default function MurlanRoyaleArena({ search }) {
           right,
           focus,
           radius: resolveSeatHandRadius(activeTableRadius, isHumanSeat),
-          spacing: isHumanSeat ? HUMAN_HAND_CARD_SPACING : AI_HAND_CARD_SPACING * aiSeatSpacingMultiplier,
-          maxSpread: isHumanSeat ? HUMAN_HAND_CARD_MAX_SPREAD : AI_HAND_CARD_MAX_SPREAD * aiSeatMaxSpreadMultiplier,
+          spacing: isHumanSeat ? HUMAN_HAND_CARD_SPACING : AI_HAND_CARD_SPACING,
+          maxSpread: isHumanSeat ? HUMAN_HAND_CARD_MAX_SPREAD : AI_HAND_CARD_MAX_SPREAD,
           stoolPosition,
           stoolHeight
         });

--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2322,7 +2322,7 @@ const CAMERA_FOCUS_CENTER_LIFT = 0.1 * MODEL_SCALE;
 const CAMERA_TARGET_TOP_PLAYER_BIAS = 0.5 * MODEL_SCALE;
 const CAMERA_SCREEN_DOWN_SHIFT = 0.12 * MODEL_SCALE;
 const HUMAN_HAND_CARD_SCALE = 1.06;
-const HUMAN_HAND_CARD_SPACING = CARD_W * HUMAN_HAND_CARD_SCALE * 0.21;
+const HUMAN_HAND_CARD_SPACING = CARD_W * HUMAN_HAND_CARD_SCALE * 0.17;
 const HUMAN_HAND_CARD_MAX_SPREAD = HUMAN_HAND_CARD_SPACING * 10;
 const HUMAN_HAND_EXTRA_LIFT = 0.068 * MODEL_SCALE;
 const HUMAN_HAND_FAN_MAX_YAW = THREE.MathUtils.degToRad(11);
@@ -2340,6 +2340,8 @@ const HUMAN_HAND_DIRECTIONAL_LIFT = 0;
 const HUMAN_HAND_BOTTOM_INWARD_TILT_X = 0;
 const AI_HAND_CARD_SPACING = CARD_W * HUMAN_HAND_CARD_SCALE * 0.3;
 const AI_HAND_CARD_MAX_SPREAD = AI_HAND_CARD_SPACING * 11;
+const TOP_AI_HAND_CARD_SPACING_MULTIPLIER = 1.28;
+const TOP_AI_HAND_CARD_MAX_SPREAD_MULTIPLIER = 1.28;
 const AI_HAND_FAN_MAX_YAW = THREE.MathUtils.degToRad(6.5);
 const AI_HAND_FAN_ARC_LIFT = 0.012 * MODEL_SCALE;
 const HUMAN_HAND_TABLE_EDGE_MARGIN = CARD_H * 0.04;
@@ -4932,6 +4934,9 @@ export default function MurlanRoyaleArena({ search }) {
 
         const forward = new THREE.Vector3(x, 0, z).normalize();
         const right = new THREE.Vector3(-forward.z, 0, forward.x).normalize();
+        const isTopSeatOnScreen = forward.z < -0.45;
+        const aiSeatSpacingMultiplier = isTopSeatOnScreen ? TOP_AI_HAND_CARD_SPACING_MULTIPLIER : 1;
+        const aiSeatMaxSpreadMultiplier = isTopSeatOnScreen ? TOP_AI_HAND_CARD_MAX_SPREAD_MULTIPLIER : 1;
         const focus = forward
           .clone()
           .multiplyScalar(seatRadius - (isHumanSeat ? 1.05 * MODEL_SCALE : 0.65 * MODEL_SCALE));
@@ -4946,8 +4951,8 @@ export default function MurlanRoyaleArena({ search }) {
           right,
           focus,
           radius: resolveSeatHandRadius(activeTableRadius, isHumanSeat),
-          spacing: isHumanSeat ? HUMAN_HAND_CARD_SPACING : AI_HAND_CARD_SPACING,
-          maxSpread: isHumanSeat ? HUMAN_HAND_CARD_MAX_SPREAD : AI_HAND_CARD_MAX_SPREAD,
+          spacing: isHumanSeat ? HUMAN_HAND_CARD_SPACING : AI_HAND_CARD_SPACING * aiSeatSpacingMultiplier,
+          maxSpread: isHumanSeat ? HUMAN_HAND_CARD_MAX_SPREAD : AI_HAND_CARD_MAX_SPREAD * aiSeatMaxSpreadMultiplier,
           stoolPosition,
           stoolHeight
         });


### PR DESCRIPTION
### Motivation
- Players on portrait phones reported bottom (human) hand cards appear too spread and hard to read while top-seat AI cards are too close together to distinguish.
- The change aims to improve card legibility by tightening the bottom hand fan and widening the top hand fan where it appears at the top of the screen.

### Description
- Reduced bottom human hand spacing by lowering `HUMAN_HAND_CARD_SPACING` from `* 0.21` to `* 0.17` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` so bottom cards overlap more and are easier to read.
- Added `TOP_AI_HAND_CARD_SPACING_MULTIPLIER` and `TOP_AI_HAND_CARD_MAX_SPREAD_MULTIPLIER` constants and apply them to AI seats that are visually at the top (`forward.z < -0.45`) so top-seat cards fan out more.
- Updated seat configuration assignment to multiply `spacing` and `maxSpread` for top AI seats while preserving side-seat and human-seat behavior.

### Testing
- Built the web app with `npm --prefix webapp run build` and the build completed successfully.
- No unit tests were modified or run; only the production build was validated and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e87992b77483299d5dff9e154d18af)