### PR TITLE
Domino Royal: keep 8K HDRI for 120Hz profile on mobile

### DIFF
--- a/test/dominoRoyalHdriCatalog.test.js
+++ b/test/dominoRoyalHdriCatalog.test.js
@@ -26,3 +26,19 @@ test('Domino Royal public HDRI catalog includes every shared Pool Royale HDRI id
     `Domino public catalog is missing shared HDRI ids: ${missingIds.join(', ')}`
   );
 });
+
+test('Domino Royal keeps 8K HDRI for 120 Hz quality profile on mobile and desktop', () => {
+  const script = readFileSync(DOMINO_PUBLIC_SCRIPT, 'utf8');
+
+  assert.match(
+    script,
+    /case\s+'uhd120':\s*\n\s*return\s+'8k';/,
+    'Expected uhd120 HDRI resolution to resolve to 8k'
+  );
+
+  assert.doesNotMatch(
+    script,
+    /IS_HIGH_REFRESH_MOBILE\s*\?\s*\['4k',\s*'2k'\]/,
+    'Expected no mobile-only HDRI downgrade for uhd120'
+  );
+});

--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -452,7 +452,7 @@ function resolveInitialFrameRateId() {
 function resolveGraphicsHdriResolutionId(qualityId = DEFAULT_FRAME_RATE_ID) {
   switch (qualityId) {
     case 'uhd120':
-      return IS_HIGH_REFRESH_MOBILE ? '4k' : '8k';
+      return '8k';
     case 'qhd90':
       return '8k';
     case 'fhd60':
@@ -4247,7 +4247,7 @@ function resolveHdriPolicyForFrameRate(qualityId = DEFAULT_FRAME_RATE_ID, fps = 
   if (qualityId === 'uhd120') {
     return Object.freeze({
       preferredResolutions: Object.freeze(
-        IS_HIGH_REFRESH_MOBILE ? ['4k', '2k'] : ['8k', '6k', '4k']
+        ['8k', '6k', '4k']
       )
     });
   }


### PR DESCRIPTION
### Motivation
- Ensure the Domino Royal 120 Hz graphics profile (`uhd120`) uses the highest-quality HDRI assets (8K) consistently across mobile and desktop so purchased environments and visual fidelity are preserved.
- Remove a mobile-only downgrade branch that forced lower HDRI resolutions for high-refresh mobile devices to avoid unnecessary visual degradation on capable devices.

### Description
- Changed `resolveGraphicsHdriResolutionId` so `uhd120` always returns `'8k'` instead of conditionally returning `'4k'` on high-refresh mobile devices (file `webapp/public/domino-royal-game.js`).
- Removed the `IS_HIGH_REFRESH_MOBILE` conditional fallback in `resolveHdriPolicyForFrameRate` and made the `uhd120` preferred resolution chain `['8k', '6k', '4k']` (file `webapp/public/domino-royal-game.js`).
- Added a regression test that asserts the public Domino script resolves `uhd120` to `8k` and that no mobile-only `['4k','2k']` downgrade branch is present (file `test/dominoRoyalHdriCatalog.test.js`).

### Testing
- Ran `node --test test/dominoRoyalHdriCatalog.test.js` which executed 2 tests and they both passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e87d7662008329a702de4277a961ae)