### PR TITLE
Domino Royal: always use 8K HDRIs for 120Hz profile (mobile)

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -452,7 +452,7 @@ function resolveInitialFrameRateId() {
 function resolveGraphicsHdriResolutionId(qualityId = DEFAULT_FRAME_RATE_ID) {
   switch (qualityId) {
     case 'uhd120':
-      return IS_HIGH_REFRESH_MOBILE ? '4k' : '8k';
+      return '8k';
     case 'qhd90':
       return '8k';
     case 'fhd60':
@@ -4246,9 +4246,7 @@ function getUnlockedOptions(key, inventory = dominoInventory) {
 function resolveHdriPolicyForFrameRate(qualityId = DEFAULT_FRAME_RATE_ID, fps = 60) {
   if (qualityId === 'uhd120') {
     return Object.freeze({
-      preferredResolutions: Object.freeze(
-        IS_HIGH_REFRESH_MOBILE ? ['4k', '2k'] : ['8k', '6k', '4k']
-      )
+      preferredResolutions: Object.freeze(['8k', '6k', '4k'])
     });
   }
   if (qualityId === 'qhd90' || fps >= 90) {

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-04-13-domino-camera-hand-gap-v34';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-04-22-domino-uhd120-mobile-hdri-v35';
 
 export default function DominoRoyalArena() {
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- Ensure the 120 Hz graphics profile (`uhd120`) uses the highest-quality HDRI on mobile so players selecting 120 Hz see 8K environments like on desktop. 
- Provide a consistent HDRI fallback ordering for the 120 Hz profile across devices to avoid mobile-specific downscaling.
- Invalidate cached client script so existing users pick up the HDRI behavior change promptly.

### Description
- Changed HDRI resolution resolver so `uhd120` always resolves to `8k` by default in `webapp/public/domino-royal-game.js` via `resolveGraphicsHdriResolutionId` returning `'8k'` for `uhd120` instead of switching to `4k` on mobile. 
- Updated the `uhd120` HDRI policy fallback chain to `['8k','6k','4k']` in `resolveHdriPolicyForFrameRate` so high-quality fallbacks are preferred uniformly. 
- Bumped the domino script version string in `webapp/src/pages/Games/DominoRoyalArena.jsx` (`DOMINO_ROYAL_SCRIPT_VERSION`) to force clients to load the updated `domino-royal-game.js`.

### Testing
- Ran the automated catalog unit test: `node --test test/dominoRoyalHdriCatalog.test.js` and it passed (`ok 1 - Domino Royal public HDRI catalog includes every shared Pool Royale HDRI id`).
- No other automated tests were run in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e87d7662008329a702de4277a961ae)