### PR TITLE
Murlan Royale: increase bottom hand spacing and fix side-seat card orientation

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2322,7 +2322,7 @@ const CAMERA_FOCUS_CENTER_LIFT = 0.1 * MODEL_SCALE;
 const CAMERA_TARGET_TOP_PLAYER_BIAS = 0.5 * MODEL_SCALE;
 const CAMERA_SCREEN_DOWN_SHIFT = 0.12 * MODEL_SCALE;
 const HUMAN_HAND_CARD_SCALE = 1.06;
-const HUMAN_HAND_CARD_SPACING = CARD_W * HUMAN_HAND_CARD_SCALE * 0.2;
+const HUMAN_HAND_CARD_SPACING = CARD_W * HUMAN_HAND_CARD_SCALE * 0.23;
 const HUMAN_HAND_CARD_MAX_SPREAD = HUMAN_HAND_CARD_SPACING * 10;
 const HUMAN_HAND_EXTRA_LIFT = 0.068 * MODEL_SCALE;
 const HUMAN_HAND_FAN_MAX_YAW = THREE.MathUtils.degToRad(15);
@@ -3729,8 +3729,9 @@ export default function MurlanRoyaleArena({ search }) {
         const isHumanCard = player.isHuman;
         const layerIndex = isHumanCard ? cards.length - 1 - cardIdx : cardIdx;
         applyHandCardLayering(mesh, isHumanCard, layerIndex);
+        const isSideSeatOnScreen = Math.abs(forward?.x ?? 0) > 0.45;
         const backLogoVariant = !isHumanCard
-          ? 'top'
+          ? (isSideSeatOnScreen ? 'side' : 'top')
           : 'default';
         setBackLogoOrientation(mesh, backLogoVariant);
         mesh.visible = true;
@@ -3743,7 +3744,11 @@ export default function MurlanRoyaleArena({ search }) {
         const lateral = humanLineOffset;
         const radial = player.isHuman ? radius : radius + AI_CARD_OUTWARD;
         const fanArcLift = isHumanCard ? HUMAN_HAND_FAN_ARC_LIFT : AI_HAND_FAN_ARC_LIFT;
-        const fanDirection = HUMAN_HAND_FAN_DIRECTION;
+        const fanDirection = isHumanCard
+          ? HUMAN_HAND_FAN_DIRECTION
+          : (forward?.x ?? 0) < -0.45
+            ? -HUMAN_HAND_FAN_DIRECTION
+            : HUMAN_HAND_FAN_DIRECTION;
         const fanYaw = HUMAN_HAND_UNIFORM_YAW_FROM_LEFT
           ? HUMAN_HAND_FAN_MAX_YAW
           : normalizedOffset * (isHumanCard ? HUMAN_HAND_FAN_MAX_YAW : AI_HAND_FAN_MAX_YAW) * fanDirection;


### PR DESCRIPTION
### Motivation
- Improve card legibility on portrait/mobile by slightly widening the spacing between cards in the bottom (human) hand.
- Ensure left/right (side) opponent hands present consistently (not visually upside-down) and share the same arched/top layout style as the bottom hand.

### Description
- Increased the bottom hand spacing by updating `HUMAN_HAND_CARD_SPACING` from `CARD_W * HUMAN_HAND_CARD_SCALE * 0.2` to `CARD_W * HUMAN_HAND_CARD_SCALE * 0.23` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx`.
- Detect side seats with `isSideSeatOnScreen = Math.abs(forward?.x ?? 0) > 0.45` and use a side-specific back-logo variant (`'side'`) for non-human seats so back texture orientation matches left/right seating instead of always using `'top'`.
- Mirror the fan yaw for side AI seats by adjusting `fanDirection` for non-human players based on `forward.x`, keeping the visual arch consistent with the bottom hand.

### Testing
- Ran unit tests with `npm test -- test/murlan.test.js --runInBand`, and the suite passed (`1` test suite, `12` tests all passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8854ad6dc8329b7d7369a82cb6e73)