### PR TITLE
Increase bottom-hand card spacing and make 120Hz HDRI target 8K for Murlan Royale

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2324,7 +2324,7 @@ const CAMERA_FOCUS_CENTER_LIFT = 0.1 * MODEL_SCALE;
 const CAMERA_TARGET_TOP_PLAYER_BIAS = 0.5 * MODEL_SCALE;
 const CAMERA_SCREEN_DOWN_SHIFT = 0.12 * MODEL_SCALE;
 const HUMAN_HAND_CARD_SCALE = 1.06;
-const HUMAN_HAND_CARD_SPACING = CARD_W * HUMAN_HAND_CARD_SCALE * 0.26;
+const HUMAN_HAND_CARD_SPACING = CARD_W * HUMAN_HAND_CARD_SCALE * 0.32;
 const HUMAN_HAND_CARD_MAX_SPREAD = HUMAN_HAND_CARD_SPACING * 10;
 const HUMAN_HAND_EXTRA_LIFT = 0.068 * MODEL_SCALE;
 const HUMAN_HAND_FAN_MAX_YAW = THREE.MathUtils.degToRad(15);
@@ -2627,7 +2627,7 @@ const FRAME_RATE_OPTIONS = Object.freeze([
 ]);
 
 const HDRI_RESOLUTION_POLICY_BY_FPS = Object.freeze([
-  { minFps: 120, preferredResolutions: Object.freeze(['8k', '4k', '2k']), fallbackResolution: '4k' },
+  { minFps: 120, preferredResolutions: Object.freeze(['8k']), fallbackResolution: '8k' },
   { minFps: 90, preferredResolutions: Object.freeze(['4k', '2k']), fallbackResolution: '2k' },
   { minFps: 0, preferredResolutions: Object.freeze(['2k', '1k']), fallbackResolution: '1k' }
 ]);


### PR DESCRIPTION
### Motivation
- Improve readability of the human player's held cards in portrait/mobile by increasing spacing between cards, and ensure Ultra (120 Hz) graphics mode uses the highest HDRI quality (8K) when selected.

### Description
- Increased `HUMAN_HAND_CARD_SPACING` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` from `CARD_W * HUMAN_HAND_CARD_SCALE * 0.26` to `* 0.32` to provide a larger gap between bottom-player cards.
- Updated `HDRI_RESOLUTION_POLICY_BY_FPS` for the 120 FPS tier so `preferredResolutions` is `['8k']` and `fallbackResolution` is `'8k'`, making the Ultra (120 Hz) frame option target 8K HDRIs.

### Testing
- Ran unit tests: `npm test -- --runTestsByPath test/murlan.test.js --runInBand`, and the `test/murlan.test.js` suite passed (12 tests). 
- Ran lint for the file with `npm run -s lint -- webapp/src/pages/Games/MurlanRoyaleArena.jsx`; lint reported repository-wide/ignored-file issues unrelated to this change and did not block the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e88d6616a48329ae042bb5ee11c05e)