### PR TITLE
Fix Texas Hold'em hexagon/octagon table orientation

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -852,8 +852,10 @@ function getEffectiveShapeConfig(shapeIndex, playerCount) {
   const option = forcedOption ?? requested ?? fallback;
   const forced = option?.id !== requested?.id;
   let rotationY = 0;
-  if (option?.id === HEXAGON_SHAPE_ID) rotationY = Math.PI / 6;
-  if (option?.id === OCTAGON_SHAPE_ID) rotationY = Math.PI / 8;
+  // Keep Texas Hold'em on its legacy visual orientation after shared Murlan
+  // shape adjustments for hexagon/octagon tables.
+  if (option?.id === HEXAGON_SHAPE_ID) rotationY = 0;
+  if (option?.id === OCTAGON_SHAPE_ID) rotationY = 0;
   if (option?.id === DIAMOND_SHAPE_ID && playerCount <= 4) rotationY = Math.PI / 4;
   return { option, rotationY, forced };
 }


### PR DESCRIPTION
### Motivation
- Preserve the legacy visual orientation for Texas Hold'em after shared Murlan table shape adjustments caused hexagon/octagon tables to rotate differently.

### Description
- Modified `getEffectiveShapeConfig` in `webapp/src/pages/Games/TexasHoldemArena.jsx` so `HEXAGON` and `OCTAGON` shape branches set `rotationY = 0`, keeping Texas Hold'em's previous orientation while leaving other games and the diamond short-handed rotation behavior unchanged.

### Testing
- Ran `npm --prefix webapp run build` and succeeded (Vite production build completed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e89336d228832987ea0f3c2dc80329)