### PR TITLE
Nudge bottom hand toward gift icon and restore side-seat card-back logo

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2335,7 +2335,7 @@ const HUMAN_HAND_CLOSER_OFFSET = 0.042 * MODEL_SCALE;
 const HUMAN_HAND_BOTTOM_SHIFT_Y = -0.018 * MODEL_SCALE;
 const AI_HAND_BOTTOM_SHIFT_Y = -0.02 * MODEL_SCALE;
 const AI_HAND_CLOSER_OFFSET = 0.02 * MODEL_SCALE;
-const HUMAN_HAND_LEFT_SHIFT = -0.015 * MODEL_SCALE; // Negative value nudges the bottom human hand toward the right-side gift icon in portrait.
+const HUMAN_HAND_LEFT_SHIFT = -0.017 * MODEL_SCALE; // Negative value nudges the bottom human hand toward the right-side gift icon in portrait.
 const AI_HAND_LEFT_SHIFT = 0;
 const HUMAN_HAND_UP_SHIFT_Y = 0.108 * MODEL_SCALE;
 const HUMAN_HAND_DIRECTIONAL_LIFT = 0;
@@ -3762,7 +3762,7 @@ export default function MurlanRoyaleArena({ search }) {
         const isGiftSideSeat = seat?.handVariant === 'giftSide';
         const isSideSeatOnScreen = Math.abs(forward?.x ?? 0) > 0.45;
         const backLogoVariant = !isHumanCard
-          ? (isGiftSideSeat ? 'sideGift' : isSideSeatOnScreen ? 'side' : 'top')
+          ? (isSideSeatOnScreen ? 'side' : 'top')
           : 'default';
         setBackLogoOrientation(mesh, backLogoVariant);
         mesh.visible = true;


### PR DESCRIPTION
### Motivation
- Small visual polish to shift the bottom (human) player's cards slightly toward the gift icon and to revert an unintended card-back logo orientation change introduced in the previous change.

### Description
- Tuned `HUMAN_HAND_LEFT_SHIFT` from `-0.015 * MODEL_SCALE` to `-0.017 * MODEL_SCALE` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to nudge the bottom hand toward the right-side gift icon. 
- Restored non-human side-seat card-back logo orientation by removing the `sideGift` override and using the original side/top orientation rule in the same file.

### Testing
- Ran `npm test -- --runInBand test/murlan.test.js`, which passed (12 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8943404e88329a2ca42a1fffd343e)