### PR TITLE
Murlan Royale: nudge bottom hand toward gift icon and restore side-seat card-back logo

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2335,7 +2335,7 @@ const HUMAN_HAND_CLOSER_OFFSET = 0.042 * MODEL_SCALE;
 const HUMAN_HAND_BOTTOM_SHIFT_Y = -0.018 * MODEL_SCALE;
 const AI_HAND_BOTTOM_SHIFT_Y = -0.02 * MODEL_SCALE;
 const AI_HAND_CLOSER_OFFSET = 0.02 * MODEL_SCALE;
-const HUMAN_HAND_LEFT_SHIFT = -0.015 * MODEL_SCALE; // Negative value nudges the bottom human hand toward the right-side gift icon in portrait.
+const HUMAN_HAND_LEFT_SHIFT = -0.018 * MODEL_SCALE; // Negative value nudges the bottom human hand toward the right-side gift icon in portrait.
 const AI_HAND_LEFT_SHIFT = 0;
 const HUMAN_HAND_UP_SHIFT_Y = 0.108 * MODEL_SCALE;
 const HUMAN_HAND_DIRECTIONAL_LIFT = 0;
@@ -3759,10 +3759,9 @@ export default function MurlanRoyaleArena({ search }) {
         const isHumanCard = player.isHuman;
         const layerIndex = isHumanCard ? cards.length - 1 - cardIdx : cardIdx;
         applyHandCardLayering(mesh, isHumanCard, layerIndex);
-        const isGiftSideSeat = seat?.handVariant === 'giftSide';
         const isSideSeatOnScreen = Math.abs(forward?.x ?? 0) > 0.45;
         const backLogoVariant = !isHumanCard
-          ? (isGiftSideSeat ? 'sideGift' : isSideSeatOnScreen ? 'side' : 'top')
+          ? (isSideSeatOnScreen ? 'side' : 'top')
           : 'default';
         setBackLogoOrientation(mesh, backLogoVariant);
         mesh.visible = true;
@@ -6628,11 +6627,6 @@ function setBackLogoOrientation(mesh, variant = 'default') {
     } else if (desiredVariant === 'side') {
       tunedTexture.repeat.set(1, 1);
       tunedTexture.offset.set(0, 0);
-      tunedTexture.rotation = Math.PI;
-      tunedTexture.center.set(0.5, 0.5);
-    } else if (desiredVariant === 'sideGift') {
-      tunedTexture.repeat.set(-1, 1);
-      tunedTexture.offset.set(1, 0);
       tunedTexture.rotation = Math.PI;
       tunedTexture.center.set(0.5, 0.5);
     }


### PR DESCRIPTION
### Motivation
- Visually nudge the bottom (human) player’s cards a tiny bit toward the gift icon in portrait and undo an unintended change that altered the card-back logo orientation for side-seat opponents.

### Description
- Increased `HUMAN_HAND_LEFT_SHIFT` from `-0.015 * MODEL_SCALE` to `-0.018 * MODEL_SCALE` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to shift the bottom hand slightly toward the gift icon.
- Restored prior side-seat card-back behavior by removing the `isGiftSideSeat` branch so side-seat cards use the `side`/`top` selection again in the hand layout logic in `MurlanRoyaleArena.jsx`.
- Removed the `sideGift` variant handling from `setBackLogoOrientation` and simplified the tuned texture logic so back textures use the previous `top`/`side` orientations only.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully with only non-blocking Vite warnings about chunk sizes/dynamic imports.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8943404e88329a2ca42a1fffd343e)