### PR TITLE
Fix Texas Hold'em table orientation for hexagon and octagon

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -852,8 +852,8 @@ function getEffectiveShapeConfig(shapeIndex, playerCount) {
   const option = forcedOption ?? requested ?? fallback;
   const forced = option?.id !== requested?.id;
   let rotationY = 0;
-  if (option?.id === HEXAGON_SHAPE_ID) rotationY = Math.PI / 6;
-  if (option?.id === OCTAGON_SHAPE_ID) rotationY = Math.PI / 8;
+  // Keep Texas Hold'em table orientation aligned to its prior baseline.
+  // Hexagon and octagon auto-rotation remains enabled for other games only.
   if (option?.id === DIAMOND_SHAPE_ID && playerCount <= 4) rotationY = Math.PI / 4;
   return { option, rotationY, forced };
 }


### PR DESCRIPTION
### Motivation
- Restore the prior visual orientation for Texas Hold'em tables by preventing Texas-specific auto-rotation for hexagon and octagon shapes while keeping other games' orientations unchanged.

### Description
- Removed the hexagon/octagon rotation assignments in `webapp/src/pages/Games/TexasHoldemArena.jsx` so only the diamond-table rotation rule (for <= 4 players) remains active for Texas Hold'em.

### Testing
- Built the web app with `npm run build` from the `webapp/` directory and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e89336d228832987ea0f3c2dc80329)