### PR TITLE
Refactor token/capture model naming and adjust seat/weapon placement on Snake board

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -76,7 +76,7 @@ const CHAIR_MODEL_URLS = [
   'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/SheenChair/glTF-Binary/SheenChair.glb',
   'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/AntiqueChair/glTF-Binary/AntiqueChair.glb'
 ];
-const LUDO_BATTLE_ROYAL_TOKEN_URLS = [
+const SNAKE_TOKEN_MODEL_URLS = [
   'https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Models@master/2.0/ABeautifulGame/glTF-Binary/ABeautifulGame.glb',
   'https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Models@master/2.0/ABeautifulGame/glTF/ABeautifulGame.gltf'
 ];
@@ -86,23 +86,23 @@ const TARGET_CHAIR_SIZE = new THREE.Vector3(1.3162499970197679, 1.91737499003112
 const TARGET_CHAIR_MIN_Y = -0.8570624993294478 * CHAIR_SIZE_SCALE;
 
 const POLYHAVEN_TEXTURE_CACHE = new Map();
-const CHESS_PIECE_CACHE = { promise: null, pieces: null };
-const CAPTURE_VEHICLE_MODEL_CACHE = new Map();
-const CAPTURE_VEHICLE_TEXTURE_MATERIAL_CACHE = new Map();
-const CAPTURE_POLYHAVEN_TEXTURE_SETS = new Map();
-const CAPTURE_VEHICLE_MODEL_HOSTS = [
+const SNAKE_TOKEN_PROTOTYPE_CACHE = { promise: null, pieces: null };
+const SNAKE_CAPTURE_VEHICLE_MODEL_CACHE = new Map();
+const SNAKE_CAPTURE_VEHICLE_TEXTURE_MATERIAL_CACHE = new Map();
+const SNAKE_CAPTURE_POLYHAVEN_TEXTURE_SETS = new Map();
+const SNAKE_CAPTURE_VEHICLE_MODEL_HOSTS = [
   'https://cdn.jsdelivr.net/gh/srcejon/sdrangel-3d-models@main',
   'https://raw.githubusercontent.com/srcejon/sdrangel-3d-models/main',
   'https://cdn.statically.io/gh/srcejon/sdrangel-3d-models/main'
 ];
-const CAPTURE_VEHICLE_MODEL_FILES = Object.freeze({
+const SNAKE_CAPTURE_VEHICLE_MODEL_FILES = Object.freeze({
   drone: ['drone.glb'],
   helicopter: ['helicopter.glb'],
   fighter: ['f15.glb'],
   supportTruck: ['fire_truck.glb'],
   javelin: ['javelin_missile.glb', 'javelin.glb', 'missile_javelin.glb', 'missile.glb']
 });
-const CAPTURE_POLYHAVEN_TEXTURE_ASSETS = Object.freeze({
+const SNAKE_CAPTURE_POLYHAVEN_TEXTURE_ASSETS = Object.freeze({
   drone: 'rusty_metal_sheet',
   fighter: 'green_metal_rust',
   helicopter: 'green_metal_rust',
@@ -238,7 +238,7 @@ const DICE_PLAYER_EXTRA_OFFSET = TILE_SIZE * 1.8;
 const TOP_TILE_EXTRA_LEVELS = 1;
 const TOP_SEAT_TOKEN_REST_RAIL_INSET = TILE_SIZE * 0.02;
 // Keep parked weapons on the same front rail as player tokens (table edge near each seat).
-const TOP_SEAT_WEAPON_REST_RAIL_INSET = TILE_SIZE * 0.32;
+const TOP_SEAT_WEAPON_REST_RAIL_INSET = -TILE_SIZE * 0.08;
 const TOKEN_REST_RAIL_INSET_BY_SEAT = Object.freeze(new Array(DEFAULT_PLAYER_COUNT).fill(TOP_SEAT_TOKEN_REST_RAIL_INSET));
 const WEAPON_REST_RAIL_INSET_BY_SEAT = Object.freeze([
   TOP_SEAT_WEAPON_REST_RAIL_INSET,
@@ -251,13 +251,13 @@ const TOKEN_REST_LATERAL_BY_SEAT = Object.freeze(new Array(DEFAULT_PLAYER_COUNT)
 // Seat order: 0=bottom, 1=right, 2=top, 3=left (portrait screen orientation).
 // Pull bottom/side reserve tokens inwards so they sit on the wooden rim near each seat.
 const TOKEN_REST_EXTRA_RADIAL_BY_SEAT = Object.freeze([
-  -TILE_SIZE * 0.84,
-  -TILE_SIZE * 0.72,
-  -TILE_SIZE * 0.58,
-  -TILE_SIZE * 0.72
+  TILE_SIZE * 0.02,
+  TILE_SIZE * 0.04,
+  TILE_SIZE * 0.06,
+  TILE_SIZE * 0.04
 ]);
 const SEAT_RAIL_DICE_GAP = Math.max(DICE_SIZE * 0.95, TOKEN_RADIUS * 2.75);
-const SEAT_RAIL_SLOT_OFFSET = SEAT_RAIL_DICE_GAP * 0.5;
+const SEAT_RAIL_SLOT_OFFSET = SEAT_RAIL_DICE_GAP * 0.16;
 const SEAT_RAIL_FORWARD_BIAS = TILE_SIZE * 0.08;
 // Seat-aware slot signs (portrait): 0=bottom, 1=right, 2=top, 3=left.
 const TOKEN_SLOT_SIDE_SIGN_BY_SEAT = Object.freeze([-1, 1, -1, 1]);
@@ -269,19 +269,19 @@ const TOKEN_SLOT_LATERAL_NUDGE_BY_SEAT = Object.freeze([
   TILE_SIZE * 0.08
 ]);
 const WEAPON_SLOT_LATERAL_NUDGE_BY_SEAT = Object.freeze([
-  -TILE_SIZE * 0.02,
-  -TILE_SIZE * 0.02,
-  -TILE_SIZE * 0.02,
-  -TILE_SIZE * 0.02
-]);
-const WEAPON_DISPLAY_SIZE_MULTIPLIER = 1.4;
-const WEAPON_PARKING_OUTWARD_OFFSET = -TILE_SIZE * 0.22;
-const WEAPON_FROM_TOKEN_CENTER_OFFSET = TOKEN_RADIUS * 0.58;
-const WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT = Object.freeze([
   0,
   0,
   0,
   0
+]);
+const WEAPON_DISPLAY_SIZE_MULTIPLIER = 1.4;
+const WEAPON_PARKING_OUTWARD_OFFSET = TILE_SIZE * 0.06;
+const WEAPON_FROM_TOKEN_CENTER_OFFSET = TOKEN_RADIUS * 0.58;
+const WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT = Object.freeze([
+  TILE_SIZE * 0.08,
+  TILE_SIZE * 0.1,
+  TILE_SIZE * 0.24,
+  TILE_SIZE * 0.1
 ]);
 const WEAPON_TOKEN_GAP = TILE_SIZE * 0.004;
 const WEAPON_PARKED_Y_DROP_BY_KIND = Object.freeze({
@@ -291,13 +291,27 @@ const WEAPON_PARKED_Y_DROP_BY_KIND = Object.freeze({
   supportTruck: TOKEN_HEIGHT * 2.32,
   javelin: TOKEN_HEIGHT * 2.26
 });
-const WEAPON_REST_HEIGHT_OFFSET = -TOKEN_HEIGHT * 1.34;
-const WEAPON_SLOT_CLUSTER_SCALE = 0.34;
+const WEAPON_REST_HEIGHT_OFFSET = -TOKEN_HEIGHT * 1.92;
+const WEAPON_SLOT_CLUSTER_SCALE = 0.3;
 const WEAPON_REST_HEIGHT_OFFSET_BY_SEAT = Object.freeze([
   0,
   0,
   0,
   0
+]);
+// Portrait phone calibration (seat order: 0=bottom, 1=right, 2=top, 3=left).
+// Positive radial moves items visually toward each chair/edge on screen.
+const TOKEN_PORTRAIT_SCREEN_SHIFT_BY_SEAT = Object.freeze([
+  Object.freeze({ radial: 0, lateral: 0, y: 0 }),
+  Object.freeze({ radial: 0, lateral: 0, y: 0 }),
+  Object.freeze({ radial: 0, lateral: 0, y: 0 }),
+  Object.freeze({ radial: 0, lateral: 0, y: 0 })
+]);
+const WEAPON_PORTRAIT_SCREEN_SHIFT_BY_SEAT = Object.freeze([
+  Object.freeze({ radial: 0, lateral: 0, y: 0 }),
+  Object.freeze({ radial: 0, lateral: 0, y: 0 }),
+  Object.freeze({ radial: 0, lateral: 0, y: 0 }),
+  Object.freeze({ radial: 0, lateral: 0, y: 0 })
 ]);
 
 const PAVEMENT_EXTRA_SCALE = 1.18;
@@ -720,8 +734,8 @@ function applyTextureSetToMaterial(material, textureSet, repeat = 1) {
 }
 
 function createCaptureVehicleTexture(kind = 'fighter') {
-  if (CAPTURE_VEHICLE_TEXTURE_MATERIAL_CACHE.has(kind)) {
-    return CAPTURE_VEHICLE_TEXTURE_MATERIAL_CACHE.get(kind);
+  if (SNAKE_CAPTURE_VEHICLE_TEXTURE_MATERIAL_CACHE.has(kind)) {
+    return SNAKE_CAPTURE_VEHICLE_TEXTURE_MATERIAL_CACHE.get(kind);
   }
   const canvas = document.createElement('canvas');
   canvas.width = 256;
@@ -729,7 +743,7 @@ function createCaptureVehicleTexture(kind = 'fighter') {
   const ctx = canvas.getContext('2d');
   if (!ctx) {
     const fallback = new THREE.CanvasTexture(canvas);
-    CAPTURE_VEHICLE_TEXTURE_MATERIAL_CACHE.set(kind, fallback);
+    SNAKE_CAPTURE_VEHICLE_TEXTURE_MATERIAL_CACHE.set(kind, fallback);
     return fallback;
   }
   const palettes = {
@@ -766,12 +780,12 @@ function createCaptureVehicleTexture(kind = 'fighter') {
   texture.wrapT = THREE.RepeatWrapping;
   texture.repeat.set(2.4, 2.4);
   texture.anisotropy = 4;
-  CAPTURE_VEHICLE_TEXTURE_MATERIAL_CACHE.set(kind, texture);
+  SNAKE_CAPTURE_VEHICLE_TEXTURE_MATERIAL_CACHE.set(kind, texture);
   return texture;
 }
 
 function createCaptureVehicleMaterial(kind = 'fighter') {
-  const textureSet = CAPTURE_POLYHAVEN_TEXTURE_SETS.get(kind) || null;
+  const textureSet = SNAKE_CAPTURE_POLYHAVEN_TEXTURE_SETS.get(kind) || null;
   return new THREE.MeshStandardMaterial({
     map: textureSet?.map || createCaptureVehicleTexture(kind),
     normalMap: textureSet?.normalMap || null,
@@ -783,16 +797,16 @@ function createCaptureVehicleMaterial(kind = 'fighter') {
 
 async function primeCaptureVehicleTextureSets(renderer = null) {
   const maxAnisotropy = renderer?.capabilities?.getMaxAnisotropy?.() ?? 6;
-  const entries = Object.entries(CAPTURE_POLYHAVEN_TEXTURE_ASSETS);
+  const entries = Object.entries(SNAKE_CAPTURE_POLYHAVEN_TEXTURE_ASSETS);
   await Promise.all(
     entries.map(async ([kind, assetId]) => {
-      if (!assetId || CAPTURE_POLYHAVEN_TEXTURE_SETS.has(kind)) return;
+      if (!assetId || SNAKE_CAPTURE_POLYHAVEN_TEXTURE_SETS.has(kind)) return;
       const set = await loadPolyhavenTextureSet(assetId, renderer);
       if (!set) return;
       if (set.map) set.map.anisotropy = maxAnisotropy;
       if (set.roughnessMap) set.roughnessMap.anisotropy = maxAnisotropy;
       if (set.normalMap) set.normalMap.anisotropy = maxAnisotropy;
-      CAPTURE_POLYHAVEN_TEXTURE_SETS.set(kind, set);
+      SNAKE_CAPTURE_POLYHAVEN_TEXTURE_SETS.set(kind, set);
     })
   );
 }
@@ -923,12 +937,12 @@ function buildChessPiecePrototypes(scene) {
 }
 
 async function loadChessPiecePrototypes(renderer = null) {
-  if (CHESS_PIECE_CACHE.pieces) return CHESS_PIECE_CACHE.pieces;
-  if (!CHESS_PIECE_CACHE.promise) {
+  if (SNAKE_TOKEN_PROTOTYPE_CACHE.pieces) return SNAKE_TOKEN_PROTOTYPE_CACHE.pieces;
+  if (!SNAKE_TOKEN_PROTOTYPE_CACHE.promise) {
     const loader = createConfiguredGLTFLoader(renderer);
-    CHESS_PIECE_CACHE.promise = (async () => {
+    SNAKE_TOKEN_PROTOTYPE_CACHE.promise = (async () => {
       let gltf = null;
-      for (const url of LUDO_BATTLE_ROYAL_TOKEN_URLS) {
+      for (const url of SNAKE_TOKEN_MODEL_URLS) {
         try {
           gltf = await loader.loadAsync(url);
           break;
@@ -942,8 +956,8 @@ async function loadChessPiecePrototypes(renderer = null) {
       return prototypes;
     })();
   }
-  CHESS_PIECE_CACHE.pieces = await CHESS_PIECE_CACHE.promise;
-  return CHESS_PIECE_CACHE.pieces;
+  SNAKE_TOKEN_PROTOTYPE_CACHE.pieces = await SNAKE_TOKEN_PROTOTYPE_CACHE.promise;
+  return SNAKE_TOKEN_PROTOTYPE_CACHE.pieces;
 }
 
 function scaleChessPieceToToken(piece, targetHeight) {
@@ -3494,44 +3508,27 @@ function getSeatRailLayout(board, seatIndex, fallbackRadiusOffset = 0, customIns
   if (seatDirection.lengthSq() < 0.0001) return null;
   seatDirection.normalize();
   const lateral = new THREE.Vector3(-seatDirection.z, 0, seatDirection.x);
-  const seatDistance = seatWorld.distanceTo(boardLookTarget);
-  const inwardInset = Number.isFinite(customInset)
-    ? customInset
-    : TOKEN_REST_RAIL_INSET_BY_SEAT[seatIndex] ?? TILE_SIZE * 1.35;
-  let restRadius = clamp(
-    seatDistance - inwardInset,
-    TOKEN_REST_MIN_RADIUS,
-    Math.max(TOKEN_REST_MIN_RADIUS + TILE_SIZE * 0.4, seatDistance - TOKEN_RADIUS * 0.55)
-  );
-
   const tableInfo = board?.tableInfo;
-  if (tableInfo?.getInnerRadius) {
-    const inner = tableInfo.getInnerRadius(seatDirection);
-    if (Number.isFinite(inner) && inner > 0) {
-      const outer = tableInfo.getOuterRadius?.(seatDirection) ?? inner;
-      const rimInner = Math.min(inner, outer);
-      const rimOuter = Math.max(inner, outer);
-      const rimMid = rimInner + (rimOuter - rimInner) * 0.35;
-      restRadius = Math.max(restRadius, THREE.MathUtils.clamp(rimMid, rimInner + 0.05, rimOuter - 0.08));
-      restRadius = Math.max(restRadius, BOARD_RADIUS + TILE_SIZE * 1.1);
-      if (Number.isFinite(rimOuter)) {
-        restRadius = Math.min(restRadius, rimOuter - 0.12);
-      }
-    }
-  }
-  if (tableInfo?.getOuterRadius) {
-    const outer = tableInfo.getOuterRadius(seatDirection);
-    if (Number.isFinite(outer) && outer > 0) {
-      restRadius = Math.min(restRadius, outer - 0.14);
-    }
-  }
-  if (seatDirection.z < -0.2) {
-    restRadius += TILE_SIZE * 0.74;
-  } else if (seatDirection.z > 0.2) {
-    restRadius -= TILE_SIZE * 0.68;
-  }
+  const outerRadius = tableInfo?.getOuterRadius?.(seatDirection);
+  const innerRadius = tableInfo?.getInnerRadius?.(seatDirection);
+  const fallbackInner = BOARD_RADIUS + TILE_SIZE * 1.05;
+  const fallbackOuter = TOKEN_REST_MIN_RADIUS + TILE_SIZE * 0.95;
+  const rimInner = Number.isFinite(innerRadius) ? innerRadius : fallbackInner;
+  const rimOuter = Number.isFinite(outerRadius) ? outerRadius : fallbackOuter;
+  const rimMin = Math.min(rimInner, rimOuter);
+  const rimMax = Math.max(rimInner, rimOuter);
+
+  // Keep parked items on the wooden rim (not on chairs), centered in portrait.
+  const rimBlendBySeat = [0.58, 0.56, 0.52, 0.56];
+  let restRadius = rimMin + (rimMax - rimMin) * (rimBlendBySeat[seatIndex] ?? 0.56);
   restRadius += TOKEN_REST_EXTRA_RADIAL_BY_SEAT[seatIndex] ?? 0;
-  restRadius = Math.max(restRadius + fallbackRadiusOffset, TOKEN_REST_MIN_RADIUS);
+
+  const inset = Number.isFinite(customInset)
+    ? customInset
+    : TOKEN_REST_RAIL_INSET_BY_SEAT[seatIndex] ?? 0;
+  restRadius -= inset * 0.08;
+  restRadius += fallbackRadiusOffset * 0.25;
+  restRadius = THREE.MathUtils.clamp(restRadius, rimMin + 0.04, rimMax - 0.05);
 
   const railSpread = TOKEN_REST_LATERAL_BY_SEAT[seatIndex] ?? 0;
   const railWorld = boardLookTarget
@@ -3541,7 +3538,7 @@ function getSeatRailLayout(board, seatIndex, fallbackRadiusOffset = 0, customIns
     .addScaledVector(seatDirection, -SEAT_RAIL_FORWARD_BIAS);
   const railLocal = railWorld.clone();
   boardRoot.worldToLocal(railLocal);
-  const railHeightY = TOKEN_HEIGHT * 0.44;
+  const railHeightY = TOKEN_HEIGHT * 0.28;
   railLocal.y = railHeightY;
   return { railLocal, railHeightY, seatDirection, lateral };
 }
@@ -3832,10 +3829,16 @@ function updateTokens(
         if (railLayout) {
           const sideSign = TOKEN_SLOT_SIDE_SIGN_BY_SEAT[seatIndex] ?? (seatIndex % 2 === 0 ? -1 : 1);
           const lateralNudge = TOKEN_SLOT_LATERAL_NUDGE_BY_SEAT[seatIndex] ?? 0;
+          const portraitShift = TOKEN_PORTRAIT_SCREEN_SHIFT_BY_SEAT[seatIndex] ?? null;
           worldPos = railLayout.railLocal
             .clone()
             .addScaledVector(railLayout.lateral, sideSign * SEAT_RAIL_SLOT_OFFSET + lateralNudge);
-          worldPos.y = railLayout.railHeightY;
+          if (portraitShift) {
+            worldPos
+              .addScaledVector(railLayout.seatDirection, portraitShift.radial ?? 0)
+              .addScaledVector(railLayout.lateral, portraitShift.lateral ?? 0);
+          }
+          worldPos.y = railLayout.railHeightY + (portraitShift?.y ?? 0);
         }
       }
       if (!worldPos) {
@@ -4456,18 +4459,18 @@ async function patchGlbImagesToDataUris(buffer, kind, sourceUrl, modelUrls, cach
 }
 
 async function loadCaptureVehicleModel(kind = 'fighter') {
-  const files = CAPTURE_VEHICLE_MODEL_FILES[kind] || CAPTURE_VEHICLE_MODEL_FILES.fighter;
+  const files = SNAKE_CAPTURE_VEHICLE_MODEL_FILES[kind] || SNAKE_CAPTURE_VEHICLE_MODEL_FILES.fighter;
   const fileList = Array.isArray(files) ? files : [files];
   const cacheKey = `${kind}:${fileList.join('|')}`;
-  if (!CAPTURE_VEHICLE_MODEL_CACHE.has(cacheKey)) {
-    CAPTURE_VEHICLE_MODEL_CACHE.set(
+  if (!SNAKE_CAPTURE_VEHICLE_MODEL_CACHE.has(cacheKey)) {
+    SNAKE_CAPTURE_VEHICLE_MODEL_CACHE.set(
       cacheKey,
       (async () => {
         const loader = createConfiguredGLTFLoader();
         const imageCache = new Map();
 
         for (const file of fileList) {
-          const urls = CAPTURE_VEHICLE_MODEL_HOSTS.map((host) => `${host}/${file}`);
+          const urls = SNAKE_CAPTURE_VEHICLE_MODEL_HOSTS.map((host) => `${host}/${file}`);
           for (const url of urls) {
             try {
               // eslint-disable-next-line no-await-in-loop
@@ -4502,7 +4505,7 @@ async function loadCaptureVehicleModel(kind = 'fighter') {
       })()
     );
   }
-  const model = await CAPTURE_VEHICLE_MODEL_CACHE.get(cacheKey);
+  const model = await SNAKE_CAPTURE_VEHICLE_MODEL_CACHE.get(cacheKey);
   return model?.clone?.(true) ?? null;
 }
 
@@ -4718,6 +4721,7 @@ function updateSeatWeaponDisplays(board, players = []) {
     if (railLayout) {
       const sideSign = WEAPON_SLOT_SIDE_SIGN_BY_SEAT[seatIndex] ?? (seatIndex % 2 === 0 ? -1 : 1);
       const lateralNudge = WEAPON_SLOT_LATERAL_NUDGE_BY_SEAT[seatIndex] ?? 0;
+      const portraitShift = WEAPON_PORTRAIT_SCREEN_SHIFT_BY_SEAT[seatIndex] ?? null;
       holder.position
         .copy(railLayout.railLocal)
         .addScaledVector(
@@ -4728,10 +4732,16 @@ function updateSeatWeaponDisplays(board, players = []) {
           railLayout.seatDirection,
           WEAPON_PARKING_OUTWARD_OFFSET + (WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT[seatIndex] ?? 0)
         );
+      if (portraitShift) {
+        holder.position
+          .addScaledVector(railLayout.seatDirection, portraitShift.radial ?? 0)
+          .addScaledVector(railLayout.lateral, portraitShift.lateral ?? 0);
+      }
       holder.position.y =
         railLayout.railHeightY +
         WEAPON_REST_HEIGHT_OFFSET +
-        (WEAPON_REST_HEIGHT_OFFSET_BY_SEAT[seatIndex] ?? 0);
+        (WEAPON_REST_HEIGHT_OFFSET_BY_SEAT[seatIndex] ?? 0) +
+        (portraitShift?.y ?? 0);
     } else {
       const seatWorld = new THREE.Vector3();
       anchor.getWorldPosition(seatWorld);


### PR DESCRIPTION
### Motivation
- Unify naming and caches for the Snake game assets and make layout behavior more suitable for portrait/table edge placement. 
- Improve placement of tokens and parked weapons so they align visually with table rim and seat anchors.
- Prepare for loading different token models by centralizing model URL/caching variables.

### Description
- Renamed and scoped multiple capture/token-related caches and constants from generic names to `SNAKE_*` (for example `CHESS_PIECE_CACHE` -> `SNAKE_TOKEN_PROTOTYPE_CACHE`, `CAPTURE_VEHICLE_MODEL_CACHE` -> `SNAKE_CAPTURE_VEHICLE_MODEL_CACHE`, and `LUDO_BATTLE_ROYAL_TOKEN_URLS` -> `SNAKE_TOKEN_MODEL_URLS`).
- Updated model/host/file lookup to use new `SNAKE_CAPTURE_*` constants in functions that load and cache capture vehicle models and textures (for example in `createCaptureVehicleTexture`, `createCaptureVehicleMaterial`, `primeCaptureVehicleTextureSets`, and `loadCaptureVehicleModel`).
- Reworked seat/rail/slot layout math in `getSeatRailLayout` to compute rim inner/outer radii and blend parking radius by seat instead of older heuristics, clamped results within rim bounds, and adjusted `railHeightY` lower for tokens.
- Tuned numerous placement constants to change token and weapon offsets and clustering: adjusted `TOP_SEAT_WEAPON_REST_RAIL_INSET`, `TOKEN_REST_EXTRA_RADIAL_BY_SEAT`, `SEAT_RAIL_SLOT_OFFSET`, `WEAPON_PARKING_OUTWARD_OFFSET`, `WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT`, `WEAPON_REST_HEIGHT_OFFSET`, and `WEAPON_SLOT_CLUSTER_SCALE`.
- Added placeholder portrait-screen calibration hooks (`TOKEN_PORTRAIT_SCREEN_SHIFT_BY_SEAT` and `WEAPON_PORTRAIT_SCREEN_SHIFT_BY_SEAT`) and applied them in `updateTokens` and `updateSeatWeaponDisplays` so tokens/weapon holders can be shifted per-seat for portrait layouts.
- Rewired prototype-loading code `loadChessPiecePrototypes` to use the new `SNAKE_TOKEN_PROTOTYPE_CACHE` and `SNAKE_TOKEN_MODEL_URLS` while preserving prototype build and scaling logic.

### Testing
- Ran the webapp build with `yarn build` which completed successfully.
- Ran the JavaScript test suite with `yarn test` and `yarn lint`, and reported no failing tests or lint errors.
- Verified asset loading flows by running the dev server and exercising token and capture model load paths (no runtime errors observed during automated load tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e87a8bf5cc8329a53bd03b498b10ba)