### PR TITLE
Adjust snake seat token/weapon alignment for portrait table view

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -302,16 +302,22 @@ const WEAPON_REST_HEIGHT_OFFSET_BY_SEAT = Object.freeze([
 // Portrait phone calibration (seat order: 0=bottom, 1=right, 2=top, 3=left).
 // Positive radial moves items visually toward each chair/edge on screen.
 const TOKEN_PORTRAIT_SCREEN_SHIFT_BY_SEAT = Object.freeze([
+  // Bottom seat: pull token closer to the table rail on portrait screens.
+  Object.freeze({ radial: -TILE_SIZE * 0.12, lateral: 0, y: 0 }),
   Object.freeze({ radial: 0, lateral: 0, y: 0 }),
-  Object.freeze({ radial: 0, lateral: 0, y: 0 }),
-  Object.freeze({ radial: 0, lateral: 0, y: 0 }),
+  // Top seat: push token farther from the table edge (visually away from table).
+  Object.freeze({ radial: TILE_SIZE * 0.12, lateral: 0, y: 0 }),
   Object.freeze({ radial: 0, lateral: 0, y: 0 })
 ]);
 const WEAPON_PORTRAIT_SCREEN_SHIFT_BY_SEAT = Object.freeze([
-  Object.freeze({ radial: 0, lateral: 0, y: 0 }),
-  Object.freeze({ radial: 0, lateral: 0, y: 0 }),
-  Object.freeze({ radial: 0, lateral: 0, y: 0 }),
-  Object.freeze({ radial: 0, lateral: 0, y: 0 })
+  // Bottom seat: pull weapon farther inward than token so it sits next to it.
+  Object.freeze({ radial: -TILE_SIZE * 0.24, lateral: 0, y: 0 }),
+  // Right seat: move weapon closer to table edge where the token rests.
+  Object.freeze({ radial: -TILE_SIZE * 0.14, lateral: 0, y: 0 }),
+  // Top seat: lower weapon so it rests on/touches the table surface like token.
+  Object.freeze({ radial: 0, lateral: 0, y: -TOKEN_HEIGHT * 0.28 }),
+  // Left seat: move weapon closer to table edge where the token rests.
+  Object.freeze({ radial: -TILE_SIZE * 0.14, lateral: 0, y: 0 })
 ]);
 
 const PAVEMENT_EXTRA_SCALE = 1.18;


### PR DESCRIPTION
### Motivation
- Improve visual alignment of reserve tokens and parked weapons for the Snake & Ladder portrait layout so pieces sit naturally near the table edge and each other.
- Bring the bottom player's token and weapon closer to the table rim (weapon pulled farther than token) because they were too far from the table and behind the chair.
- Ensure left/right player weapons sit nearer the same rail where tokens are parked and make the top player's token/weapon pair visually consistent by moving the token outward and lowering the weapon to touch the table surface.

### Description
- Tuned portrait-seat calibration constants in `webapp/src/components/SnakeBoard3D.jsx` by updating `TOKEN_PORTRAIT_SCREEN_SHIFT_BY_SEAT` and `WEAPON_PORTRAIT_SCREEN_SHIFT_BY_SEAT`.
- Specific adjustments: bottom token radial `-TILE_SIZE * 0.12`; bottom weapon radial `-TILE_SIZE * 0.24`; left/right weapon radials `-TILE_SIZE * 0.14`; top token radial `TILE_SIZE * 0.12`; top weapon Y offset `-TOKEN_HEIGHT * 0.28` to better rest on the table.
- Changes are limited to seat-space/portrait calibration values used by the seat rail layout and weapon/token placement logic.

### Testing
- Ran the production web build with `npm --prefix webapp run build`, and the build completed successfully (with normal bundle-size warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e89e801ddc8329a1a57d01627a07f1)