### PR TITLE
Align Murlan graphics config with Domino Royal options

### DIFF
--- a/webapp/src/config/murlanInventoryConfig.js
+++ b/webapp/src/config/murlanInventoryConfig.js
@@ -1,13 +1,7 @@
 import { CARD_THEMES } from '../utils/cards3d.js';
+import { DOMINO_ROYAL_OPTION_SETS } from './dominoRoyalInventoryConfig.js';
 import { MURLAN_CHARACTER_THEMES } from './murlanCharacterThemes.js';
 import { MURLAN_OUTFIT_THEMES } from './murlanThemes.js';
-import {
-  BATTLE_ROYALE_SHARED_CHAIR_THEME_OPTIONS as MURLAN_STOOL_THEMES,
-  BATTLE_ROYALE_SHARED_HDRI_VARIANTS as MURLAN_HDRI_OPTIONS,
-  BATTLE_ROYALE_SHARED_TABLE_CLOTH_OPTIONS as MURLAN_TABLE_CLOTH_OPTIONS,
-  BATTLE_ROYALE_SHARED_TABLE_FINISH_OPTIONS as MURLAN_TABLE_FINISH_OPTIONS,
-  BATTLE_ROYALE_SHARED_TABLE_THEME_OPTIONS as MURLAN_TABLE_THEMES
-} from './battleRoyaleSharedInventory.js';
 
 const mapLabels = (options) =>
   Object.freeze(
@@ -16,6 +10,14 @@ const mapLabels = (options) =>
       return acc;
     }, {})
   );
+
+const MURLAN_GRAPHICS_OPTION_SETS = Object.freeze({
+  stools: DOMINO_ROYAL_OPTION_SETS.chairTheme,
+  tables: DOMINO_ROYAL_OPTION_SETS.tableTheme,
+  tableCloth: DOMINO_ROYAL_OPTION_SETS.tableCloth,
+  tableFinish: DOMINO_ROYAL_OPTION_SETS.tableWood,
+  environmentHdri: DOMINO_ROYAL_OPTION_SETS.environmentHdri
+});
 
 const DEFAULT_MURLAN_SHARED_IDS = Object.freeze({
   stool: 'dining_chair_02',
@@ -33,34 +35,28 @@ export const MURLAN_ROYALE_DEFAULT_UNLOCKS = Object.freeze({
   tableCloth: [DEFAULT_MURLAN_SHARED_IDS.tableCloth],
   tableFinish: [DEFAULT_MURLAN_SHARED_IDS.tableFinish],
   characters: [MURLAN_CHARACTER_THEMES[0].id],
-  environmentHdri: MURLAN_HDRI_OPTIONS.map((variant) => variant.id)
+  environmentHdri: MURLAN_GRAPHICS_OPTION_SETS.environmentHdri.map((variant) => variant.id)
 });
 
 export const MURLAN_ROYALE_OPTION_LABELS = Object.freeze({
   outfit: mapLabels(MURLAN_OUTFIT_THEMES),
   cards: mapLabels(CARD_THEMES),
-  stools: mapLabels(MURLAN_STOOL_THEMES),
-  tables: mapLabels(MURLAN_TABLE_THEMES),
-  tableCloth: mapLabels(MURLAN_TABLE_CLOTH_OPTIONS),
-  tableFinish: mapLabels(MURLAN_TABLE_FINISH_OPTIONS),
+  stools: mapLabels(MURLAN_GRAPHICS_OPTION_SETS.stools),
+  tables: mapLabels(MURLAN_GRAPHICS_OPTION_SETS.tables),
+  tableCloth: mapLabels(MURLAN_GRAPHICS_OPTION_SETS.tableCloth),
+  tableFinish: mapLabels(MURLAN_GRAPHICS_OPTION_SETS.tableFinish),
   characters: mapLabels(MURLAN_CHARACTER_THEMES),
-  environmentHdri: mapLabels(
-    MURLAN_HDRI_OPTIONS.map((variant) => ({
-      id: variant.id,
-      label: `${variant.name} HDRI`
-    }))
-  )
+  environmentHdri: mapLabels(MURLAN_GRAPHICS_OPTION_SETS.environmentHdri)
 });
 
 export const MURLAN_ROYALE_STORE_ITEMS = [
-  ...MURLAN_TABLE_FINISH_OPTIONS.map((finish, idx) => ({
+  ...MURLAN_GRAPHICS_OPTION_SETS.tableFinish.map((finish, idx) => ({
     id: `table-finish-${finish.id}`,
     type: 'tableFinish',
     optionId: finish.id,
     name: finish.label,
     price: finish.price ?? 980 + idx * 40,
     description: finish.description,
-    swatches: finish.swatches,
     thumbnail: finish.thumbnail,
     previewShape: 'table'
   })),
@@ -74,7 +70,7 @@ export const MURLAN_ROYALE_STORE_ITEMS = [
     thumbnail: option.thumbnail
   }))
 ].concat(
-  MURLAN_TABLE_CLOTH_OPTIONS.map((cloth, idx) => ({
+  MURLAN_GRAPHICS_OPTION_SETS.tableCloth.map((cloth, idx) => ({
     id: `cloth-${cloth.id}`,
     type: 'tableCloth',
     optionId: cloth.id,
@@ -85,7 +81,7 @@ export const MURLAN_ROYALE_STORE_ITEMS = [
     thumbnail: cloth.thumbnail,
     previewShape: 'table'
   })),
-  MURLAN_TABLE_THEMES.filter((theme, idx) => idx > 0).map((theme, idx) => ({
+  MURLAN_GRAPHICS_OPTION_SETS.tables.filter((theme, idx) => idx > 0).map((theme, idx) => ({
     id: `table-${theme.id}`,
     type: 'tables',
     optionId: theme.id,
@@ -94,7 +90,7 @@ export const MURLAN_ROYALE_STORE_ITEMS = [
     description: theme.description || `${theme.label} table with preserved Poly Haven materials.`,
     thumbnail: theme.thumbnail
   })),
-  MURLAN_STOOL_THEMES.filter((theme, idx) => idx > 0).map((theme, idx) => ({
+  MURLAN_GRAPHICS_OPTION_SETS.stools.filter((theme, idx) => idx > 0).map((theme, idx) => ({
     id: `stool-${theme.id}`,
     type: 'stools',
     optionId: theme.id,
@@ -112,14 +108,13 @@ export const MURLAN_ROYALE_STORE_ITEMS = [
     description: theme.description,
     thumbnail: theme.thumbnail
   })),
-  MURLAN_HDRI_OPTIONS.map((variant, idx) => ({
+  MURLAN_GRAPHICS_OPTION_SETS.environmentHdri.map((variant, idx) => ({
     id: `hdri-${variant.id}`,
     type: 'environmentHdri',
     optionId: variant.id,
-    name: `${variant.name} HDRI`,
+    name: variant.label,
     price: variant.price ?? 1400 + idx * 25,
     description: variant.description || 'Pool Royale HDRI environment tuned for Murlan promos.',
-    swatches: variant.swatches,
     thumbnail: variant.thumbnail,
     previewShape: 'table'
   }))
@@ -130,13 +125,21 @@ export const MURLAN_ROYALE_DEFAULT_LOADOUT = [
   { type: 'cards', optionId: CARD_THEMES[0].id, label: CARD_THEMES[0].label },
   {
     type: 'tables',
-    optionId: MURLAN_TABLE_THEMES.find((option) => option.id === DEFAULT_MURLAN_SHARED_IDS.table)?.id || MURLAN_TABLE_THEMES[0].id,
-    label: (MURLAN_TABLE_THEMES.find((option) => option.id === DEFAULT_MURLAN_SHARED_IDS.table) || MURLAN_TABLE_THEMES[0]).label
+    optionId:
+      MURLAN_GRAPHICS_OPTION_SETS.tables.find((option) => option.id === DEFAULT_MURLAN_SHARED_IDS.table)?.id ||
+      MURLAN_GRAPHICS_OPTION_SETS.tables[0].id,
+    label:
+      (MURLAN_GRAPHICS_OPTION_SETS.tables.find((option) => option.id === DEFAULT_MURLAN_SHARED_IDS.table) ||
+        MURLAN_GRAPHICS_OPTION_SETS.tables[0]).label
   },
   {
     type: 'stools',
-    optionId: MURLAN_STOOL_THEMES.find((option) => option.id === DEFAULT_MURLAN_SHARED_IDS.stool)?.id || MURLAN_STOOL_THEMES[0].id,
-    label: (MURLAN_STOOL_THEMES.find((option) => option.id === DEFAULT_MURLAN_SHARED_IDS.stool) || MURLAN_STOOL_THEMES[0]).label
+    optionId:
+      MURLAN_GRAPHICS_OPTION_SETS.stools.find((option) => option.id === DEFAULT_MURLAN_SHARED_IDS.stool)?.id ||
+      MURLAN_GRAPHICS_OPTION_SETS.stools[0].id,
+    label:
+      (MURLAN_GRAPHICS_OPTION_SETS.stools.find((option) => option.id === DEFAULT_MURLAN_SHARED_IDS.stool) ||
+        MURLAN_GRAPHICS_OPTION_SETS.stools[0]).label
   },
   {
     type: 'characters',
@@ -145,18 +148,25 @@ export const MURLAN_ROYALE_DEFAULT_LOADOUT = [
   },
   {
     type: 'tableCloth',
-    optionId: MURLAN_TABLE_CLOTH_OPTIONS.find((option) => option.id === DEFAULT_MURLAN_SHARED_IDS.tableCloth)?.id || MURLAN_TABLE_CLOTH_OPTIONS[0].id,
-    label: (MURLAN_TABLE_CLOTH_OPTIONS.find((option) => option.id === DEFAULT_MURLAN_SHARED_IDS.tableCloth) || MURLAN_TABLE_CLOTH_OPTIONS[0]).label
+    optionId:
+      MURLAN_GRAPHICS_OPTION_SETS.tableCloth.find((option) => option.id === DEFAULT_MURLAN_SHARED_IDS.tableCloth)
+        ?.id || MURLAN_GRAPHICS_OPTION_SETS.tableCloth[0].id,
+    label:
+      (MURLAN_GRAPHICS_OPTION_SETS.tableCloth.find((option) => option.id === DEFAULT_MURLAN_SHARED_IDS.tableCloth) ||
+        MURLAN_GRAPHICS_OPTION_SETS.tableCloth[0]).label
   },
   {
     type: 'tableFinish',
-    optionId: MURLAN_TABLE_FINISH_OPTIONS.find((option) => option.id === DEFAULT_MURLAN_SHARED_IDS.tableFinish)?.id || MURLAN_TABLE_FINISH_OPTIONS[0].id,
-    label: (MURLAN_TABLE_FINISH_OPTIONS.find((option) => option.id === DEFAULT_MURLAN_SHARED_IDS.tableFinish) || MURLAN_TABLE_FINISH_OPTIONS[0]).label
+    optionId:
+      MURLAN_GRAPHICS_OPTION_SETS.tableFinish.find((option) => option.id === DEFAULT_MURLAN_SHARED_IDS.tableFinish)
+        ?.id || MURLAN_GRAPHICS_OPTION_SETS.tableFinish[0].id,
+    label:
+      (MURLAN_GRAPHICS_OPTION_SETS.tableFinish.find((option) => option.id === DEFAULT_MURLAN_SHARED_IDS.tableFinish) ||
+        MURLAN_GRAPHICS_OPTION_SETS.tableFinish[0]).label
   },
   {
     type: 'environmentHdri',
     optionId: DEFAULT_MURLAN_SHARED_IDS.environmentHdri,
-    label:
-      MURLAN_ROYALE_OPTION_LABELS.environmentHdri[DEFAULT_MURLAN_SHARED_IDS.environmentHdri] || 'HDR Environment'
+    label: MURLAN_ROYALE_OPTION_LABELS.environmentHdri[DEFAULT_MURLAN_SHARED_IDS.environmentHdri] || 'HDR Environment'
   }
 ];


### PR DESCRIPTION
### Motivation
- Ensure Murlan Royale uses the exact same table/chair/cloth/finish/HDRI option sets and thumbnails as Domino Royal so graphics/configuration choices are consistent between the two games.
- Keep Murlan-specific cosmetics (outfits, cards, characters) separate while reusing the shared visual catalog to avoid divergence and duplicated option lists.

### Description
- Replaced local Murlan graphics option sources with a `MURLAN_GRAPHICS_OPTION_SETS` mapping that references `DOMINO_ROYAL_OPTION_SETS` for `stools`, `tables`, `tableCloth`, `tableFinish`, and `environmentHdri` in `webapp/src/config/murlanInventoryConfig.js`.
- Updated `MURLAN_ROYALE_OPTION_LABELS`, `MURLAN_ROYALE_STORE_ITEMS`, and `MURLAN_ROYALE_DEFAULT_LOADOUT` to use the Domino-backed option sets and labels for shared graphics items while leaving outfits/cards/characters unchanged.
- Normalized default unlocks to include the shared HDRI variants from the Domino set and adjusted store item names/labels to use the shared catalog labels.

### Testing
- Ran unit tests with `npm test -- --runInBand test/murlan.test.js test/dominoRoyalHdriCatalog.test.js` and both suites passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8a81c62908329adb854a350c206a9)