### PR TITLE
Restore Murlan Royale 120Hz graphics profile to 4K to fix loading

### DIFF
--- a/Assets/Scripts/Gameplay/Rendering/HdriQualityGuard.cs
+++ b/Assets/Scripts/Gameplay/Rendering/HdriQualityGuard.cs
@@ -20,7 +20,6 @@ namespace Aiming.Gameplay.Rendering
         [Header("Mobile HDRI Maps")]
         [SerializeField] private Cubemap mobileHdri2K;
         [SerializeField] private Cubemap mobileHdri4K;
-        [SerializeField] private Cubemap mobileHdri8K;
 
         [SerializeField] private Material[] skyboxTargets;
 
@@ -60,9 +59,7 @@ namespace Aiming.Gameplay.Rendering
             {
                 if (isMobileDevice)
                 {
-                    Cubemap mobilePrimary = mobileHdri8K != null ? mobileHdri8K : mobileHdri4K;
-                    Cubemap mobileFallback = mobileHdri4K != null ? mobileHdri4K : mobileHdri2K;
-                    return new HdriProfile(mobilePrimary, mobileFallback, 8192, 4096);
+                    return new HdriProfile(mobileHdri4K, mobileHdri2K, 4096, 2048);
                 }
 
                 return new HdriProfile(desktopHdri8K, desktopHdri4K, 8192, 4096);

--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2618,16 +2618,16 @@ const FRAME_RATE_OPTIONS = Object.freeze([
     fps: 120,
     renderScale: 1.22,
     pixelRatioCap: 1.72,
-    resolution: '8K texture pack • 120 FPS',
-    hdriResolution: '8k',
-    preferredTextureSizes: ['8k', '4k', '2k', '1k'],
-    cardTextureScale: 1.36,
-    description: 'Poly Haven 8K HDRI target with fallback to 4K.'
+    resolution: '4K texture pack • 120 FPS',
+    hdriResolution: '4k',
+    preferredTextureSizes: ['4k', '2k', '1k'],
+    cardTextureScale: 1.18,
+    description: 'Poly Haven 4K HDRI target with fallback to 2K.'
   }
 ]);
 
 const HDRI_RESOLUTION_POLICY_BY_FPS = Object.freeze([
-  { minFps: 120, preferredResolutions: Object.freeze(['8k', '4k', '2k']), fallbackResolution: '4k' },
+  { minFps: 120, preferredResolutions: Object.freeze(['4k', '2k']), fallbackResolution: '2k' },
   { minFps: 90, preferredResolutions: Object.freeze(['4k', '2k']), fallbackResolution: '2k' },
   { minFps: 0, preferredResolutions: Object.freeze(['2k', '1k']), fallbackResolution: '1k' }
 ]);


### PR DESCRIPTION
### Motivation
- Recent changes promoted 8K HDRI/texture selection for the 120 Hz profile which increased startup texture pressure and caused loading problems on some devices.
- The goal is to restore the stable, lower-memory graphics profile used earlier while preserving higher-refresh UX where feasible.

### Description
- Reverted the Unity mobile HDRI selection for 120 Hz in `Assets/Scripts/Gameplay/Rendering/HdriQualityGuard.cs` to use 4K primary with 2K fallback and removed the serialized `mobileHdri8K` usage.
- Updated the web UI Murlan Royale `Ultra (120 Hz)` frame option in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` from 8K→4K→2K to the lighter 4K→2K chain and adjusted `cardTextureScale` back to the safer value.
- Changed the HDRI policy mapping so `minFps: 120` prefers `4k`→`2k` fallback instead of `8k`→`4k`, and updated preferred texture size lists accordingly.

### Testing
- Ran `git diff --check` to ensure no whitespace/errors and the check passed.
- Committed the targeted changes with `git commit` which completed successfully and updated the two files without unrelated modifications.
- No automated play-mode or build tests were executed in this environment (only repo checks and commit verification were run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8b0fa99688329aced57764bf14d91)