### PR TITLE
Nudge Texas Hold'em player chip stacks inward and upward

### DIFF
--- a/webapp/src/pages/Games/TexasHoldemArena.jsx
+++ b/webapp/src/pages/Games/TexasHoldemArena.jsx
@@ -409,13 +409,14 @@ const PORTRAIT_CAMERA_PLAYER_FOCUS_BLEND = 0.48;
 const PORTRAIT_CAMERA_PLAYER_FOCUS_FORWARD_PULL = CARD_W * -0.02;
 const PORTRAIT_CAMERA_PLAYER_FOCUS_HEIGHT = CARD_SURFACE_OFFSET * 0.69;
 const HUMAN_CARD_INWARD_SHIFT = CARD_W * -2.66;
-const HUMAN_CHIP_INWARD_SHIFT = CARD_W * 0.62;
+const HUMAN_CHIP_INWARD_SHIFT = CARD_W * 0.5;
 const HUMAN_CARD_LATERAL_SHIFT = CARD_W * 0.4;
 const HUMAN_CHIP_LATERAL_SHIFT = CARD_W * 0.34;
 const AI_CARD_INWARD_SHIFT = CARD_W * -2.28;
-const AI_CHIP_INWARD_SHIFT = CARD_W * -0.1;
+const AI_CHIP_INWARD_SHIFT = CARD_W * -0.2;
 const AI_CARD_LATERAL_SHIFT = CARD_W * 0.48;
 const AI_CHIP_LATERAL_SHIFT = CARD_W * -0.22;
+const CHIP_STACK_VERTICAL_LIFT = CARD_H * 0.06;
 const HUMAN_CARD_CHIP_BLEND = 0;
 const HUMAN_CARD_SCALE = 1;
 const COMMUNITY_CARD_SCALE = 1.08;
@@ -2134,7 +2135,7 @@ function createSeatLayout(count, tableInfo = null, options = {}) {
       .clone()
       .addScaledVector(forward, chipInwardShift)
       .addScaledVector(right, chipLateralShift);
-    chipAnchor.y = railSurfaceY - seatLayerDrop;
+    chipAnchor.y = railSurfaceY - seatLayerDrop + CHIP_STACK_VERTICAL_LIFT;
     const cardRailAnchor = cardRailCenter
       .clone()
       .addScaledVector(forward, cardInwardShift)
@@ -2144,7 +2145,7 @@ function createSeatLayout(count, tableInfo = null, options = {}) {
       .clone()
       .addScaledVector(forward, chipInwardShift)
       .addScaledVector(right, chipLateralShift);
-    chipRailAnchor.y = railSurfaceY - seatLayerDrop;
+    chipRailAnchor.y = railSurfaceY - seatLayerDrop + CHIP_STACK_VERTICAL_LIFT;
     const humanBetForwardOffset = isHuman ? HUMAN_BET_FORWARD_OFFSET : BET_FORWARD_OFFSET;
     const betAnchor = forward
       .clone()


### PR DESCRIPTION
### Motivation
- Make the 3x3 chip stacks for players sit slightly closer to the table center and a bit higher on screen to better match the requested visual alignment.

### Description
- Reduced the human chip inward offset from `CARD_W * 0.62` to `CARD_W * 0.5` and increased the AI chip inward offset from `CARD_W * -0.1` to `CARD_W * -0.2` to move stacks slightly inward in `TexasHoldemArena`.
- Added a small vertical lift constant `CHIP_STACK_VERTICAL_LIFT = CARD_H * 0.06` and applied it to both `chipAnchor.y` and `chipRailAnchor.y` so stacks appear slightly higher.
- Changes are localized to `webapp/src/pages/Games/TexasHoldemArena.jsx` and only adjust seat-layout constants and anchor placement logic.

### Testing
- Ran the production build with `npm --prefix webapp run build` and the build completed successfully.
- The build produced the same pre-existing Vite chunk-size/dynamic-import warnings which are unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8b2e5feb483299e3d6f4211507de5)