### PR TITLE
Adjust Murlan 120Hz mobile visuals, chair grounding, and card faces

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2335,7 +2335,7 @@ const HUMAN_HAND_CLOSER_OFFSET = 0.042 * MODEL_SCALE;
 const HUMAN_HAND_BOTTOM_SHIFT_Y = -0.018 * MODEL_SCALE;
 const AI_HAND_BOTTOM_SHIFT_Y = -0.02 * MODEL_SCALE;
 const AI_HAND_CLOSER_OFFSET = 0.02 * MODEL_SCALE;
-const HUMAN_HAND_LEFT_SHIFT = -0.018 * MODEL_SCALE; // Negative value nudges the bottom human hand toward the right-side gift icon in portrait.
+const HUMAN_HAND_LEFT_SHIFT = -0.028 * MODEL_SCALE; // Negative value nudges the bottom human hand toward the right-side gift icon in portrait.
 const AI_HAND_LEFT_SHIFT = 0;
 const HUMAN_HAND_UP_SHIFT_Y = 0.108 * MODEL_SCALE;
 const HUMAN_HAND_DIRECTIONAL_LIFT = 0;
@@ -2369,7 +2369,7 @@ const TABLE_CARD_AREA_FORWARD_SHIFT = 0.72 * MODEL_SCALE;
 const DEAL_CARD_STEP_DELAY_MS = 60;
 const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 1.1;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
-const CHAIR_GROUND_DROP = 0;
+const CHAIR_GROUND_DROP = 0.018 * MODEL_SCALE;
 const CHAIR_SCREEN_LOWER_OFFSET = 0;
 const HUMAN_CHAIR_EXTRA_INWARD_OFFSET = 0; // Align human chair distance with AI seats.
 const TABLE_HEIGHT_LIFT = 0.025 * MODEL_SCALE;
@@ -2618,16 +2618,16 @@ const FRAME_RATE_OPTIONS = Object.freeze([
     fps: 120,
     renderScale: 1.22,
     pixelRatioCap: 1.72,
-    resolution: '8K texture pack • 120 FPS',
-    hdriResolution: '8k',
-    preferredTextureSizes: ['8k', '4k', '2k', '1k'],
+    resolution: '4K texture pack • 120 FPS',
+    hdriResolution: '4k',
+    preferredTextureSizes: ['4k', '2k', '1k'],
     cardTextureScale: 1.36,
-    description: 'Poly Haven 8K HDRI target with fallback to 4K.'
+    description: 'Poly Haven 4K HDRI target with fallback to 2K.'
   }
 ]);
 
 const HDRI_RESOLUTION_POLICY_BY_FPS = Object.freeze([
-  { minFps: 120, preferredResolutions: Object.freeze(['8k', '4k', '2k']), fallbackResolution: '4k' },
+  { minFps: 120, preferredResolutions: Object.freeze(['4k', '2k', '1k']), fallbackResolution: '2k' },
   { minFps: 90, preferredResolutions: Object.freeze(['4k', '2k']), fallbackResolution: '2k' },
   { minFps: 0, preferredResolutions: Object.freeze(['2k', '1k']), fallbackResolution: '1k' }
 ]);

--- a/webapp/src/utils/cards3d.js
+++ b/webapp/src/utils/cards3d.js
@@ -150,14 +150,133 @@ function makeCardFace(rank, suit, theme, w = 512, h = 720) {
     ctx.ellipse(w / 2, h / 2, w * 0.18, h * 0.22, 0, 0, Math.PI * 2);
     ctx.fill();
   }
-  ctx.fillStyle = suitColor;
-  ctx.font = 'bold 160px "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI"';
-  ctx.textAlign = 'center';
-  ctx.fillText(convertSuit(suit), w / 2, h / 2 + 56);
+  drawCenterGlyphs(ctx, {
+    rank: label,
+    suit,
+    suitColor,
+    w,
+    h
+  });
   const texture = new THREE.CanvasTexture(canvas);
   applySRGBColorSpace(texture);
   texture.anisotropy = 8;
   return texture;
+}
+
+function drawCenterGlyphs(ctx, { rank, suit, suitColor, w, h }) {
+  const faceRanks = new Set(['J', 'Q', 'K']);
+  if (faceRanks.has(rank)) {
+    drawFaceCardIllustration(ctx, { rank, suit, suitColor, w, h });
+    return;
+  }
+  const pipCount = rank === 'A' ? 1 : Number.parseInt(rank, 10);
+  if (!Number.isFinite(pipCount) || pipCount <= 0) {
+    drawSingleSuitGlyph(ctx, suit, suitColor, w, h, 160);
+    return;
+  }
+  drawPipLayout(ctx, pipCount, suit, suitColor, w, h);
+}
+
+function drawSingleSuitGlyph(ctx, suit, suitColor, w, h, size = 150) {
+  ctx.fillStyle = suitColor;
+  ctx.font = `bold ${size}px "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI"`;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(convertSuit(suit), w / 2, h / 2);
+}
+
+function drawPipLayout(ctx, pipCount, suit, suitColor, w, h) {
+  const layouts = {
+    1: [[0, 0]],
+    2: [[0, -0.34], [0, 0.34]],
+    3: [[0, -0.36], [0, 0], [0, 0.36]],
+    4: [[-0.22, -0.34], [0.22, -0.34], [-0.22, 0.34], [0.22, 0.34]],
+    5: [[-0.22, -0.34], [0.22, -0.34], [0, 0], [-0.22, 0.34], [0.22, 0.34]],
+    6: [[-0.24, -0.36], [0.24, -0.36], [-0.24, 0], [0.24, 0], [-0.24, 0.36], [0.24, 0.36]],
+    7: [[-0.24, -0.36], [0.24, -0.36], [-0.24, -0.06], [0.24, -0.06], [0, 0.16], [-0.24, 0.36], [0.24, 0.36]],
+    8: [[-0.24, -0.38], [0.24, -0.38], [-0.24, -0.12], [0.24, -0.12], [-0.24, 0.12], [0.24, 0.12], [-0.24, 0.38], [0.24, 0.38]],
+    9: [[-0.24, -0.38], [0.24, -0.38], [-0.24, -0.14], [0.24, -0.14], [0, 0], [-0.24, 0.14], [0.24, 0.14], [-0.24, 0.38], [0.24, 0.38]],
+    10: [[-0.24, -0.4], [0.24, -0.4], [-0.24, -0.18], [0.24, -0.18], [-0.24, 0.04], [0.24, 0.04], [-0.24, 0.26], [0.24, 0.26], [-0.24, 0.44], [0.24, 0.44]]
+  };
+  const points = layouts[pipCount] ?? layouts[1];
+  const fontSize = pipCount >= 9 ? 78 : pipCount >= 6 ? 88 : 98;
+  ctx.fillStyle = suitColor;
+  ctx.font = `bold ${fontSize}px "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI"`;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  for (const [dx, dy] of points) {
+    ctx.fillText(convertSuit(suit), w / 2 + dx * w, h / 2 + dy * h);
+  }
+}
+
+function drawFaceCardIllustration(ctx, { rank, suit, suitColor, w, h }) {
+  const centerX = w / 2;
+  const centerY = h / 2;
+  const frameW = w * 0.58;
+  const frameH = h * 0.5;
+  const frameX = centerX - frameW / 2;
+  const frameY = centerY - frameH / 2;
+  const bodyColor = suitColor === '#cc2233' ? '#f5d0d0' : '#d9dde7';
+  const accent = suitColor === '#cc2233' ? '#b91c1c' : '#1f2937';
+
+  ctx.save();
+  ctx.fillStyle = 'rgba(15, 23, 42, 0.08)';
+  roundRect(ctx, frameX + 5, frameY + 8, frameW, frameH, 36);
+  ctx.fill();
+  ctx.fillStyle = '#f8fafc';
+  ctx.strokeStyle = 'rgba(15, 23, 42, 0.18)';
+  ctx.lineWidth = 5;
+  roundRect(ctx, frameX, frameY, frameW, frameH, 36);
+  ctx.fill();
+  ctx.stroke();
+
+  // Head
+  ctx.fillStyle = '#f6d4b8';
+  ctx.beginPath();
+  ctx.arc(centerX, centerY - frameH * 0.22, frameW * 0.11, 0, Math.PI * 2);
+  ctx.fill();
+  // Crown/hat
+  ctx.fillStyle = accent;
+  ctx.beginPath();
+  ctx.moveTo(centerX - frameW * 0.16, centerY - frameH * 0.33);
+  ctx.lineTo(centerX - frameW * 0.08, centerY - frameH * 0.44);
+  ctx.lineTo(centerX, centerY - frameH * 0.35);
+  ctx.lineTo(centerX + frameW * 0.08, centerY - frameH * 0.44);
+  ctx.lineTo(centerX + frameW * 0.16, centerY - frameH * 0.33);
+  ctx.closePath();
+  ctx.fill();
+
+  // Body
+  ctx.fillStyle = bodyColor;
+  roundRect(ctx, centerX - frameW * 0.18, centerY - frameH * 0.09, frameW * 0.36, frameH * 0.36, 30);
+  ctx.fill();
+  ctx.strokeStyle = accent;
+  ctx.lineWidth = 4;
+  ctx.stroke();
+
+  // Scepter / sword cue for face cards
+  ctx.strokeStyle = accent;
+  ctx.lineWidth = rank === 'J' ? 6 : 5;
+  ctx.beginPath();
+  if (rank === 'J') {
+    ctx.moveTo(centerX - frameW * 0.2, centerY + frameH * 0.2);
+    ctx.lineTo(centerX + frameW * 0.2, centerY - frameH * 0.02);
+  } else if (rank === 'Q') {
+    ctx.moveTo(centerX, centerY + frameH * 0.22);
+    ctx.lineTo(centerX, centerY - frameH * 0.04);
+  } else {
+    ctx.moveTo(centerX + frameW * 0.18, centerY + frameH * 0.2);
+    ctx.lineTo(centerX - frameW * 0.18, centerY - frameH * 0.02);
+  }
+  ctx.stroke();
+
+  drawSingleSuitGlyph(ctx, suit, suitColor, w, h, 86);
+  ctx.fillStyle = accent;
+  ctx.font = 'bold 72px "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI"';
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(rank, centerX, frameY + frameH - 42);
+  ctx.restore();
 }
 
 export function makeTonplaygramCardBackTexture(theme, w = 3072, h = 4320) {


### PR DESCRIPTION
### Motivation
- Restore the 120 Hz mobile visual profile to use higher-quality HDRI/texture assets while keeping runtime-friendly fallbacks for mobile hardware. 
- Visually nudge the human player's bottom-hand cards slightly toward the gift icon in portrait so they align better with the UI. 
- Lower chair placement so chair legs visually contact the HDRI ground and improve scene grounding. 
- Make card faces more realistic by rendering correct pip counts for number cards and simple face illustrations for J/Q/K.

### Description
- Updated `FRAME_RATE_OPTIONS` (120 Hz / `uhd120`) to target 4K HDRI/textures instead of 8K and changed the `description`, `resolution`, `hdriResolution`, and `preferredTextureSizes` accordingly in `webapp/src/pages/Games/MurlanRoyaleArena.jsx`.
- Adjusted HDRI policy for 120 FPS in `HDRI_RESOLUTION_POLICY_BY_FPS` so 120fps prefers `['4k','2k','1k']` with a `2k` fallback.
- Nudged bottom human hand lateral offset by changing `HUMAN_HAND_LEFT_SHIFT` from `-0.018 * MODEL_SCALE` to `-0.028 * MODEL_SCALE` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` so the cards sit a bit closer to the gift icon.
- Lowered chairs by setting `CHAIR_GROUND_DROP` to `0.018 * MODEL_SCALE` so the chair base/legs align with the HDRI ground in the arena code path in `webapp/src/pages/Games/MurlanRoyaleArena.jsx`.
- Reworked card face rendering in `webapp/src/utils/cards3d.js` by replacing the single center glyph with `drawCenterGlyphs`, and adding helpers `drawPipLayout`, `drawSingleSuitGlyph`, and `drawFaceCardIllustration` to:
  - render accurate pip layouts for ranks A–10, and
  - draw stylized J/Q/K illustrations for face cards while preserving corner labels and suit colors.

### Testing
- Ran `npm test -- --runInBand test/murlan.test.js` and it passed (`murlan` unit tests succeeded). 
- Ran `npm test -- --runInBand test/murlan.test.js test/inventoryCrossGameConfig.test.js` which failed in this environment due to Jest failing to parse `three/examples/jsm/*` ESM imports (an environment/transform issue), not because of the functional changes made to card rendering or arena constants.
- Verified the updated files compile in the app environment (manual check) and ran project-level `git` status locally to ensure the modified files are staged/committed in the working branch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8bcec419483299a7967f53f9b7b0d)