### PR TITLE
Make Murlan Royale cards matte and tie card-back resolution to graphics quality

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -6550,27 +6550,35 @@ function createCardMesh(card, geometry, cache, theme, textureQuality = null) {
     faceTexture = makeCardFace(card.rank, card.suit, theme, textureQuality?.w, textureQuality?.h);
     cache.set(faceKey, faceTexture);
   }
-  const edgeMat = new THREE.MeshStandardMaterial({ color: new THREE.Color(theme.edgeColor), roughness: 0.55, metalness: 0.1 });
+  const edgeMat = new THREE.MeshStandardMaterial({
+    color: new THREE.Color(theme.edgeColor),
+    roughness: 0.82,
+    metalness: 0,
+    envMapIntensity: 0
+  });
   const edgeMats = [edgeMat, edgeMat.clone(), edgeMat.clone(), edgeMat.clone()];
   const frontMat = new THREE.MeshStandardMaterial({
     map: faceTexture,
-    roughness: 0.35,
-    metalness: 0.08,
+    roughness: 0.96,
+    metalness: 0,
+    envMapIntensity: 0,
     color: new THREE.Color('#ffffff')
   });
-  const backTexture = makeCardBackTexture(theme);
+  const backTexture = makeCardBackTexture(theme, textureQuality);
   const backMat = new THREE.MeshStandardMaterial({
     map: backTexture,
     color: new THREE.Color('#ffffff'),
-    roughness: 0.6,
-    metalness: 0.15,
+    roughness: 0.98,
+    metalness: 0,
+    envMapIntensity: 0,
     emissive: new THREE.Color('#0f172a'),
-    emissiveIntensity: 0.08
+    emissiveIntensity: 0.02
   });
   const hiddenMat = new THREE.MeshStandardMaterial({
     color: new THREE.Color(theme.hiddenColor || theme.backColor),
-    roughness: 0.7,
-    metalness: 0.12
+    roughness: 0.95,
+    metalness: 0,
+    envMapIntensity: 0
   });
   const mesh = new THREE.Mesh(geometry, [...edgeMats, frontMat, backMat]);
   mesh.userData.cardId = card.id;
@@ -6908,8 +6916,11 @@ function makeCardFace(rank, suit, theme, w = 768, h = 1080) {
   return tex;
 }
 
-function makeCardBackTexture(theme) {
-  return makeTonplaygramCardBackTexture(theme);
+function makeCardBackTexture(theme, textureQuality = null) {
+  const safeQualityScale = Number.isFinite(textureQuality?.w) ? THREE.MathUtils.clamp(textureQuality.w / 768, 1, 1.5) : 1;
+  const width = Math.round(1024 * safeQualityScale);
+  const height = Math.round(1536 * safeQualityScale);
+  return makeTonplaygramCardBackTexture(theme, width, height);
 }
 
 function applyChairThemeMaterials(three, theme) {
@@ -6985,17 +6996,29 @@ function applyCardThemeMaterials(three, theme, force = false, textureQuality = n
     frontMaterial.map = faceTexture;
     frontMaterial.color?.set?.('#ffffff');
     frontMaterial.needsUpdate = true;
-    const backTexture = makeCardBackTexture(theme);
+    const backTexture = makeCardBackTexture(theme, textureQuality);
     mesh.userData.backTexture = backTexture;
     backMaterial.map = backTexture;
     backMaterial.color?.set?.('#ffffff');
+    backMaterial.roughness = 0.98;
+    backMaterial.metalness = 0;
+    backMaterial.envMapIntensity = 0;
     backMaterial.needsUpdate = true;
+    frontMaterial.roughness = 0.96;
+    frontMaterial.metalness = 0;
+    frontMaterial.envMapIntensity = 0;
     if (hiddenMaterial?.color) {
       hiddenMaterial.color.set(theme.hiddenColor || theme.backColor);
+      hiddenMaterial.roughness = 0.95;
+      hiddenMaterial.metalness = 0;
+      hiddenMaterial.envMapIntensity = 0;
       hiddenMaterial.needsUpdate = true;
     }
     edgeMaterials.forEach((mat) => {
       mat.color?.set?.(theme.edgeColor);
+      mat.roughness = 0.82;
+      mat.metalness = 0;
+      mat.envMapIntensity = 0;
       mat.needsUpdate = true;
     });
   });

--- a/webapp/src/utils/cards3d.js
+++ b/webapp/src/utils/cards3d.js
@@ -209,8 +209,8 @@ function makeCardFace(rank, suit, theme, w = 512, h = 720) {
 }
 
 export function makeTonplaygramCardBackTexture(theme, w = 3072, h = 4320) {
-  const safeWidth = Math.max(512, Math.round(Math.min(w, 1024)));
-  const safeHeight = Math.max(768, Math.round(Math.min(h, 1536)));
+  const safeWidth = Math.max(512, Math.round(Math.min(w, 1536)));
+  const safeHeight = Math.max(768, Math.round(Math.min(h, 2304)));
   const cacheKey = `${theme?.id || 'default'}:${safeWidth}x${safeHeight}`;
   const cachedTexture = cardBackTextureCache.get(cacheKey);
   if (cachedTexture) return cachedTexture;


### PR DESCRIPTION
### Motivation
- Cards were showing scene reflections and highlights which conflicted with the requested non-reflective appearance for Murlan Royale cards. 
- Card backs and front textures did not scale with the selected graphics quality, so premium graphics presets didn't produce higher-detail card visuals.

### Description
- Force matte PBR on all card materials by setting high `roughness`, zero `metalness`, and `envMapIntensity: 0` for front/back/edge/hidden materials in `webapp/src/pages/Games/MurlanRoyaleArena.jsx`. 
- Thread the active graphics `textureQuality` into card-back texture creation so back textures are generated at a size that matches the chosen graphics preset (use `makeCardBackTexture(theme, textureQuality)` and propagate when applying themes). 
- Increase allowed max canvas size used by `makeTonplaygramCardBackTexture` in `webapp/src/utils/cards3d.js` so higher graphics presets can produce higher-resolution back textures.

### Testing
- Ran `npm test -- test/murlan.test.js test/inventoryCrossGameConfig.test.js --runInBand`; `test/murlan.test.js` passed. 
- `test/inventoryCrossGameConfig.test.js` failed to run in this environment due to Jest parsing an ESM `three/addons/...` import (Jest environment limitation), not due to the card-material logic change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8fa1f9880832986abbe80e4a253cd)