### PR TITLE
Pool Royale: make cue release push forward immediately while preserving pull distance

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -26028,7 +26028,6 @@ const powerRef = useRef(hud.power);
 
       const resolveCueStrokeProfile = (_styleId, powerRatio = 0) => {
         const p = THREE.MathUtils.clamp(powerRatio ?? 0, 0, 1);
-        const pullbackDuration = THREE.MathUtils.lerp(90, 170, p);
         return {
           // Match the reference cue workflow exactly:
           // drag = pull back, release = immediate forward strike.
@@ -26037,10 +26036,13 @@ const powerRef = useRef(hud.power);
           pullSmoothing: 1,
           strikeDuration: 120,
           holdDuration: 50,
-          pullbackDuration,
+          // Keep the full pull distance from power, but remove post-release
+          // pullback time so the cue always pushes forward from the current
+          // pulled position and strikes the cue ball immediately.
+          pullbackDuration: 0,
           recoverDuration: 0,
           impactThreshold: 0.9,
-          forwardOnly: false,
+          forwardOnly: true,
           cameraExtraHoldMs: 240,
           spinScale: 0.22
         };


### PR DESCRIPTION
### Motivation
- Implement the requested cue animation technique so the slider’s drag still controls the visual pull distance while releasing the slider performs an immediate forward push that strikes the cue ball.

### Description
- In `webapp/src/pages/Games/PoolRoyale.jsx` updated `resolveCueStrokeProfile` to preserve the power-driven `pullRatio` while setting `pullbackDuration: 0` so there is no post-release rewind. 
- Enabled `forwardOnly: true` in the same profile so the stroke becomes a forward-only strike from the current pulled position. 
- Added inline comments explaining that drag controls pull amount and release drives the direct forward strike to make the behavior explicit.

### Testing
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx`, which returned only an ESLint ignore warning for that file and reported no lint errors. 
- Re-ran `npx eslint --no-ignore webapp/src/pages/Games/PoolRoyale.jsx` and observed the same ignore/warning behavior with no lint errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9948320f08329b7b335d171456531)