### PR TITLE
Preserve pull→push cue animation by triggering impact at strike progress threshold

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -22783,7 +22783,8 @@ const powerRef = useRef(hud.power);
             baseRotationX,
             baseRotationY,
             strikeDip,
-            forwardOnly
+            forwardOnly,
+            strikeImpactThreshold
           } = stroke;
           const elapsed = Math.max(0, now - startTime);
           if (forwardOnly) {
@@ -22805,9 +22806,19 @@ const powerRef = useRef(hud.power);
               Math.max(24, safeStrikeDuration * 0.45)
             );
             const releaseWindow = Math.max(1, safeStrikeDuration - contactWindow);
+            const strikeProgress = THREE.MathUtils.clamp(
+              elapsed / Math.max(safeStrikeDuration, 1e-6),
+              0,
+              1
+            );
+            const impactThreshold = THREE.MathUtils.clamp(
+              strikeImpactThreshold ?? 0.9,
+              0.05,
+              0.995
+            );
             const strikeWobbleScale = Math.max(
               0,
-              1 - THREE.MathUtils.clamp(elapsed / Math.max(safeStrikeDuration, 1e-6), 0, 1)
+              1 - strikeProgress
             );
 
             cueStick.visible = true;
@@ -22837,7 +22848,7 @@ const powerRef = useRef(hud.power);
               cueStick.rotation.y =
                 (baseRotationY ?? cueStick.rotation.y) +
                 Math.sin(contactT * Math.PI) * 0.0008 * strikeWobbleScale;
-              if (!stroke.shotApplied && contactT >= 0.2) {
+              if (!stroke.shotApplied && strikeProgress >= impactThreshold) {
                 stroke.shotApplied = true;
                 stroke.onImpact?.();
               }


### PR DESCRIPTION
### Motivation
- The cue animation needed to visibly show a pull-back followed by a forward push that contacts the cue ball, instead of applying the shot too early during the forward motion.
- Maintain existing shot power and pull distance behavior while making the visual strike timing deterministic and readable.

### Description
- Added a `strikeProgress` calculation and an `impactThreshold` (`strikeImpactThreshold`) to the cue-stroke state so impact timing is driven by overall strike progress.
- Replaced the previous early-impact condition with a `strikeProgress >= impactThreshold` check that triggers `stroke.onImpact()` near contact.
- Tied `strikeWobbleScale` to `strikeProgress` and clamped `impactThreshold` to a safe range to keep motion stable.
- Change is confined to `webapp/src/pages/Games/PoolRoyale.jsx` inside the `updateCueStroke`/forward-only stroke handling path and does not modify physics constants or power mapping.

### Testing
- Ran `cd webapp && npx eslint --no-ignore src/pages/Games/PoolRoyale.jsx`, which reported the file is ignored by project ESLint settings (warning, no errors).
- Attempted `npm -C webapp run lint`, which failed because the workspace has no `lint` npm script (error).
- No unit tests were added or modified; the change is a localized animation/timing adjustment and should be validated visually in the app (manual playtest recommended).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9948320f08329b7b335d171456531)