### PR TITLE
Introduce dedicated Goal Rush component and store inventory (separate from Air Hockey)

### DIFF
--- a/webapp/src/components/GoalRush3D.jsx
+++ b/webapp/src/components/GoalRush3D.jsx
@@ -1,0 +1,3205 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import * as THREE from 'three';
+import { EXRLoader } from 'three/examples/jsm/loaders/EXRLoader.js';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader.js';
+import { KTX2Loader } from 'three/examples/jsm/loaders/KTX2Loader.js';
+import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.js';
+import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader.js';
+import { bombSound, chatBeep } from '../assets/soundData.js';
+import GiftPopup from './GiftPopup.jsx';
+import QuickMessagePopup from './QuickMessagePopup.jsx';
+import { giftSounds } from '../utils/giftSounds.js';
+import LiveVideoChatPanel from './LiveVideoChatPanel.jsx';
+import useLiveVideoChat from '../hooks/useLiveVideoChat.js';
+import { getGameVolume, isGameMuted, toggleGameMuted } from '../utils/sound.js';
+import { getAvatarUrl } from '../utils/avatarUtils.js';
+import { buildAirHockeyCommentaryLine, AIR_HOCKEY_SPEAKERS } from '../utils/airHockeyCommentary.js';
+import {
+  getSpeechSupport,
+  getSpeechSynthesis,
+  onSpeechSupportChange,
+  primeSpeechSynthesis,
+  speakCommentaryLines
+} from '../utils/textToSpeech.js';
+import { applyWoodTextures, WOOD_GRAIN_OPTIONS_BY_ID } from '../utils/woodMaterials.js';
+import { GOAL_RUSH_CUSTOMIZATION } from '../config/goalRushInventoryConfig.js';
+import {
+  Table3D as PoolRoyaleTable3D,
+  POOL_ROYALE_TABLE_DIMENSIONS
+} from '../pages/Games/PoolRoyale.jsx';
+import {
+  goalRushAccountId,
+  getGoalRushInventory,
+  isGoalRushOptionUnlocked
+} from '../utils/goalRushInventory.js';
+
+const CUSTOMIZATION_KEYS = Object.freeze([
+  'field',
+  'cushionCloth',
+  'table',
+  'tableBase',
+  'environmentHdri',
+  'puck',
+  'mallet',
+  'goals'
+]);
+
+const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
+const resolveNumber = (...values) => values.find((value) => typeof value === 'number' && !Number.isNaN(value));
+
+const DEFAULT_RENDER_PIXEL_RATIO_CAP = 1.25;
+const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
+const BASIS_TRANSCODER_PATH = 'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/';
+const RENDER_PIXEL_RATIO_SCALE = 1.0;
+const MIN_RENDER_PIXEL_RATIO = 0.85;
+const GRAPHICS_STORAGE_KEY = 'goalRushGraphics';
+const COMMENTARY_PRESET_STORAGE_KEY = 'goalRushCommentaryPreset';
+const COMMENTARY_MUTE_STORAGE_KEY = 'goalRushCommentaryMute';
+const COMMENTARY_QUEUE_LIMIT = 4;
+const COMMENTARY_MIN_INTERVAL_MS = 1200;
+const GRAPHICS_OPTIONS = Object.freeze([
+  {
+    id: 'hd50',
+    label: 'HD Performance (50 Hz)',
+    fps: 50,
+    renderScale: 1,
+    pixelRatioCap: 1.4,
+    pixelRatioScale: 1,
+    resolution: 'HD render • DPR 1.4 cap',
+    description: 'Minimum HD output for battery saver and 50–60 Hz displays.'
+  },
+  {
+    id: 'fhd60',
+    label: 'Full HD (60 Hz)',
+    fps: 60,
+    renderScale: 1.1,
+    pixelRatioCap: 1.5,
+    pixelRatioScale: 1,
+    resolution: 'Full HD render • DPR 1.5 cap',
+    description: '1080p-focused profile that mirrors the Snooker frame pacing.'
+  },
+  {
+    id: 'qhd90',
+    label: 'Quad HD (90 Hz)',
+    fps: 90,
+    renderScale: 1.25,
+    pixelRatioCap: 1.7,
+    pixelRatioScale: 1,
+    resolution: 'QHD render • DPR 1.7 cap',
+    description: 'Sharper 1440p render for capable 90 Hz mobile and desktop GPUs.'
+  },
+  {
+    id: 'uhd120',
+    label: 'Ultra HD (120 Hz)',
+    fps: 120,
+    renderScale: 1.35,
+    pixelRatioCap: 2,
+    pixelRatioScale: 1,
+    resolution: 'Ultra HD render • DPR 2.0 cap',
+    description: '4K-oriented profile for 120 Hz flagships and desktops.'
+  },
+  {
+    id: 'ultra144',
+    label: 'Ultra HD+ (144 Hz)',
+    fps: 144,
+    renderScale: 1.5,
+    pixelRatioCap: 2.2,
+    pixelRatioScale: 1,
+    resolution: 'Ultra HD+ render • DPR 2.2 cap',
+    description: 'Maximum clarity preset that prioritizes UHD detail at 144 Hz.'
+  }
+]);
+const DEFAULT_GRAPHICS_ID = 'fhd60';
+const DEFAULT_CAMERA_LIFT = 1;
+const AIR_HOCKEY_COMMENTARY_PRESETS = Object.freeze([
+  {
+    id: 'english',
+    label: 'English',
+    description: 'Mixed voices, classic English',
+    language: 'en',
+    voiceHints: {
+      [AIR_HOCKEY_SPEAKERS.lead]: ['en-US', 'English', 'male', 'David', 'Guy', 'Daniel', 'Alex'],
+      [AIR_HOCKEY_SPEAKERS.analyst]: ['en-GB', 'English', 'female', 'Sonia', 'Hazel', 'Kate', 'Emma']
+    },
+    speakerSettings: {
+      [AIR_HOCKEY_SPEAKERS.lead]: { rate: 1, pitch: 0.96, volume: 1 },
+      [AIR_HOCKEY_SPEAKERS.analyst]: { rate: 1.04, pitch: 1.06, volume: 1 }
+    }
+  },
+  {
+    id: 'saffron-table',
+    label: 'Indian Table',
+    description: 'Hindi commentary with lively pacing',
+    language: 'hi',
+    voiceHints: {
+      [AIR_HOCKEY_SPEAKERS.lead]: ['hi-IN', 'hi', 'Hindi', 'male', 'Raj', 'Amit', 'Arjun'],
+      [AIR_HOCKEY_SPEAKERS.analyst]: ['hi-IN', 'hi', 'Hindi', 'female', 'Asha', 'Priya', 'Neha']
+    },
+    speakerSettings: {
+      [AIR_HOCKEY_SPEAKERS.lead]: { rate: 1.06, pitch: 1.02, volume: 1 },
+      [AIR_HOCKEY_SPEAKERS.analyst]: { rate: 1.08, pitch: 1.08, volume: 1 }
+    }
+  },
+  {
+    id: 'moscow-mics',
+    label: 'Russian Booth',
+    description: 'Russian commentary with steady cadence',
+    language: 'ru',
+    voiceHints: {
+      [AIR_HOCKEY_SPEAKERS.lead]: ['ru-RU', 'ru', 'Russian', 'male', 'Dmitri', 'Ivan', 'Sergey', 'Alexey'],
+      [AIR_HOCKEY_SPEAKERS.analyst]: ['ru-RU', 'ru', 'Russian', 'female', 'Anna', 'Svetlana', 'Irina', 'Olga']
+    },
+    speakerSettings: {
+      [AIR_HOCKEY_SPEAKERS.lead]: { rate: 1, pitch: 0.95, volume: 1 },
+      [AIR_HOCKEY_SPEAKERS.analyst]: { rate: 1.03, pitch: 1.02, volume: 1 }
+    }
+  },
+  {
+    id: 'latin-pulse',
+    label: 'Latin Pulse',
+    description: 'Spanish play-by-play with lively color',
+    language: 'es',
+    voiceHints: {
+      [AIR_HOCKEY_SPEAKERS.lead]: ['es-ES', 'es-MX', 'Spanish', 'male', 'Jorge', 'Carlos', 'Miguel'],
+      [AIR_HOCKEY_SPEAKERS.analyst]: ['es-ES', 'es-MX', 'Spanish', 'female', 'Isabella', 'Lucia', 'Camila']
+    },
+    speakerSettings: {
+      [AIR_HOCKEY_SPEAKERS.lead]: { rate: 1.05, pitch: 1, volume: 1 },
+      [AIR_HOCKEY_SPEAKERS.analyst]: { rate: 1.08, pitch: 1.1, volume: 1 }
+    }
+  },
+  {
+    id: 'francophone-booth',
+    label: 'Francophone Booth',
+    description: 'French broadcast pairing',
+    language: 'fr',
+    voiceHints: {
+      [AIR_HOCKEY_SPEAKERS.lead]: ['fr-FR', 'French', 'male', 'Henri', 'Louis', 'Paul'],
+      [AIR_HOCKEY_SPEAKERS.analyst]: ['fr-FR', 'French', 'female', 'Amelie', 'Marie', 'Charlotte']
+    },
+    speakerSettings: {
+      [AIR_HOCKEY_SPEAKERS.lead]: { rate: 0.98, pitch: 0.96, volume: 1 },
+      [AIR_HOCKEY_SPEAKERS.analyst]: { rate: 1.04, pitch: 1.06, volume: 1 }
+    }
+  }
+]);
+const DEFAULT_COMMENTARY_PRESET_ID = AIR_HOCKEY_COMMENTARY_PRESETS[0]?.id || 'english';
+const HUD_VERTICAL_SHIFT_REM = 9;
+const HUD_TOP_ROW_LIFT_REM = 2.5;
+const HUD_ICON_ROW_TOP_REM = 0.9;
+const HUD_MENU_LEFT_REM = 0.5;
+const AIR_HOCKEY_MENU_TOP_TWEAK_REM = -1.05;
+const AIR_HOCKEY_TARGET_CENTER_TOP_TWEAK_REM = -0.25;
+const AIR_HOCKEY_RIGHT_ICON_STACK_DOWN_REM = 0.6;
+const AIR_HOCKEY_TOP_VIEW_CAMERA_DISTANCE_SCALE = 0.9;
+const CAMERA_LIFT_STEP = 0.2;
+const CAMERA_LIFT_MIN = 0.45;
+const CAMERA_LIFT_MAX = 1.85;
+const GAME_VARIANTS = Object.freeze({
+  airhockey: {
+    id: 'airhockey',
+    roomPrefix: 'air-hockey',
+    lobbyPath: '/games/airhockey/lobby',
+    lobbyLabel: 'Goal Rush',
+    arenaLabel: 'Goal Rush arena',
+    optionLabels: {
+      puck: 'Puck',
+      mallet: 'Mallets'
+    }
+  },
+  goalrush: {
+    id: 'goalrush',
+    roomPrefix: 'goal-rush',
+    lobbyPath: '/games/goalrush/lobby',
+    lobbyLabel: 'Goal Rush',
+    arenaLabel: 'Goal Rush arena',
+    optionLabels: {
+      puck: 'Football',
+      mallet: 'Strikers'
+    }
+  }
+});
+
+function detectRefreshRateHint() {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return null;
+  const queries = [
+    { query: '(min-refresh-rate: 143hz)', fps: 144 },
+    { query: '(min-refresh-rate: 119hz)', fps: 120 },
+    { query: '(min-refresh-rate: 89hz)', fps: 90 },
+    { query: '(max-refresh-rate: 59hz)', fps: 60 },
+    { query: '(max-refresh-rate: 50hz)', fps: 50 },
+    { query: '(prefers-reduced-motion: reduce)', fps: 50 }
+  ];
+  for (const { query, fps } of queries) {
+    try {
+      if (window.matchMedia(query).matches) {
+        return fps;
+      }
+    } catch {}
+  }
+  return null;
+}
+
+function resolveDefaultGraphicsId() {
+  const hint = detectRefreshRateHint();
+  if (hint >= 144) return 'ultra144';
+  if (hint >= 120) return 'uhd120';
+  if (hint >= 90) return 'qhd90';
+  if (hint && hint <= 50) return 'hd50';
+  return DEFAULT_GRAPHICS_ID;
+}
+
+function selectPerformanceProfile(option = null) {
+  const targetFps = clamp(option?.fps ?? detectRefreshRateHint() ?? 60, 45, 144);
+  return {
+    targetFps,
+    renderScale: option?.renderScale ?? 1,
+    pixelRatioCap: option?.pixelRatioCap ?? DEFAULT_RENDER_PIXEL_RATIO_CAP,
+    pixelRatioScale: option?.pixelRatioScale ?? RENDER_PIXEL_RATIO_SCALE
+  };
+}
+
+const DEFAULT_HDRI_RESOLUTIONS = ['4k'];
+const LOCK_POOL_ROYALE_TABLE_STYLE = false;
+const PREFERRED_MARBLE_TEXTURE_SIZES = ['2k', '1k'];
+const MARBLE_TEXTURE_CACHE = new Map();
+const GLTF_MATERIAL_CACHE = new Map();
+let sharedKtx2Loader = null;
+const POOL_BALL_MARBLE_FINISH = Object.freeze({
+  clearcoat: 1,
+  clearcoatRoughness: 0.03,
+  metalness: 0.24,
+  roughness: 0.08,
+  reflectivity: 0.9,
+  sheen: 0.14,
+  sheenColor: new THREE.Color(0xf8f9ff),
+  envMapIntensity: 1.05
+});
+
+const pickBestTextureUrls = (apiJson, preferredSizes = PREFERRED_MARBLE_TEXTURE_SIZES) => {
+  const urls = [];
+  const walk = (value) => {
+    if (!value) return;
+    if (typeof value === 'string') {
+      const lower = value.toLowerCase();
+      if (value.startsWith('http') && (lower.includes('.jpg') || lower.includes('.png'))) {
+        urls.push(value);
+      }
+      return;
+    }
+    if (Array.isArray(value)) {
+      value.forEach(walk);
+      return;
+    }
+    if (typeof value === 'object') {
+      Object.values(value).forEach(walk);
+    }
+  };
+  walk(apiJson);
+  const pick = (keywords) => {
+    const scored = urls
+      .filter((url) => keywords.some((kw) => url.toLowerCase().includes(kw)))
+      .map((url) => {
+        const lower = url.toLowerCase();
+        let score = 0;
+        preferredSizes.forEach((size, index) => {
+          if (lower.includes(size)) {
+            score += (preferredSizes.length - index) * 10;
+          }
+        });
+        if (lower.includes('jpg')) score += 6;
+        if (lower.includes('png')) score += 3;
+        if (lower.includes('preview') || lower.includes('thumb')) score -= 50;
+        if (lower.includes('.exr')) score -= 100;
+        return { url, score };
+      })
+      .sort((a, b) => b.score - a.score);
+    return scored[0]?.url;
+  };
+  return {
+    diffuse: pick(['diff', 'diffuse', 'albedo', 'basecolor']),
+    normal: pick(['nor_gl', 'normal_gl', 'nor', 'normal']),
+    roughness: pick(['rough', 'roughness'])
+  };
+};
+
+const loadTexture = (loader, url, isColor) =>
+  new Promise((resolve) => {
+    loader.load(
+      url,
+      (texture) => {
+        if (isColor) {
+          texture.colorSpace = THREE.SRGBColorSpace;
+        }
+        resolve(texture);
+      },
+      undefined,
+      () => resolve(null)
+    );
+  });
+
+const createFallbackTexture = (color) => {
+  const canvas = document.createElement('canvas');
+  canvas.width = 8;
+  canvas.height = 8;
+  const ctx = canvas.getContext('2d');
+  ctx.fillStyle = color;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.colorSpace = THREE.SRGBColorSpace;
+  return texture;
+};
+
+const loadMarbleTextureSet = (fieldOption) => {
+  const assetId = fieldOption?.assetId;
+  const textureUrls = fieldOption?.textureUrls;
+  const cacheKey = fieldOption?.id || assetId || textureUrls?.diffuse;
+  if (!cacheKey) return Promise.resolve(null);
+  if (MARBLE_TEXTURE_CACHE.has(cacheKey)) return MARBLE_TEXTURE_CACHE.get(cacheKey);
+  const promise = (async () => {
+    try {
+      let urls = textureUrls;
+      if (!urls?.diffuse && assetId) {
+        const response = await fetch(`https://api.polyhaven.com/files/${encodeURIComponent(assetId)}`);
+        if (!response.ok) return null;
+        const json = await response.json();
+        urls = pickBestTextureUrls(json, PREFERRED_MARBLE_TEXTURE_SIZES);
+      }
+      if (!urls?.diffuse) return null;
+      const loader = new THREE.TextureLoader();
+      loader.setCrossOrigin('anonymous');
+      const [map, normal, roughness] = await Promise.all([
+        loadTexture(loader, urls.diffuse, true),
+        urls.normal ? loadTexture(loader, urls.normal, false) : Promise.resolve(null),
+        urls.roughness ? loadTexture(loader, urls.roughness, false) : Promise.resolve(null)
+      ]);
+      return { map, normal, roughness };
+    } catch (error) {
+      console.warn('Failed to load marble texture set', error);
+      return null;
+    }
+  })();
+  MARBLE_TEXTURE_CACHE.set(cacheKey, promise);
+  return promise;
+};
+
+const createConfiguredGltfLoader = (renderer = null) => {
+  const loader = new GLTFLoader();
+  loader.setCrossOrigin('anonymous');
+  const draco = new DRACOLoader();
+  draco.setDecoderPath(DRACO_DECODER_PATH);
+  loader.setDRACOLoader(draco);
+  loader.setMeshoptDecoder(MeshoptDecoder);
+
+  if (!sharedKtx2Loader) {
+    sharedKtx2Loader = new KTX2Loader();
+    sharedKtx2Loader.setTranscoderPath(BASIS_TRANSCODER_PATH);
+  }
+  if (renderer) {
+    try {
+      sharedKtx2Loader.detectSupport(renderer);
+    } catch (error) {
+      console.warn('Goal Rush KTX2 support detection failed', error);
+    }
+  }
+
+  loader.setKTX2Loader(sharedKtx2Loader);
+  return loader;
+};
+
+const loadGltfMaterialSet = (fieldOption) => {
+  const urls = fieldOption?.gltfUrls;
+  const cacheKey = fieldOption?.id || urls?.[0];
+  if (!Array.isArray(urls) || !urls.length) return Promise.resolve(null);
+  if (GLTF_MATERIAL_CACHE.has(cacheKey)) return GLTF_MATERIAL_CACHE.get(cacheKey);
+
+  const promise = (async () => {
+    const loader = createConfiguredGltfLoader();
+    let gltf = null;
+    for (const url of urls) {
+      try {
+        gltf = await loader.loadAsync(url);
+        if (gltf) break;
+      } catch (error) {
+        console.warn('Failed to load field GLTF material', url, error);
+      }
+    }
+    if (!gltf) return null;
+    const root = gltf.scene || gltf.scenes?.[0] || gltf;
+    let pickedMaterial = null;
+    root?.traverse?.((child) => {
+      if (pickedMaterial || !child?.isMesh) return;
+      if (child.material) {
+        pickedMaterial = Array.isArray(child.material) ? child.material[0] : child.material;
+      }
+    });
+    if (!pickedMaterial) return null;
+    const textures = {
+      map: pickedMaterial.map ?? null,
+      normal: pickedMaterial.normalMap ?? null,
+      roughness: pickedMaterial.roughnessMap ?? null,
+      metalness: pickedMaterial.metalnessMap ?? null,
+      emissive: pickedMaterial.emissiveMap ?? null
+    };
+    if (textures.map) {
+      textures.map.colorSpace = THREE.SRGBColorSpace;
+    }
+    if (textures.emissive) {
+      textures.emissive.colorSpace = THREE.SRGBColorSpace;
+    }
+    return {
+      textures,
+      materialProps: {
+        color: pickedMaterial.color?.clone?.(),
+        roughness: pickedMaterial.roughness,
+        metalness: pickedMaterial.metalness,
+        clearcoat: pickedMaterial.clearcoat,
+        clearcoatRoughness: pickedMaterial.clearcoatRoughness,
+        sheen: pickedMaterial.sheen,
+        sheenColor: pickedMaterial.sheenColor?.clone?.(),
+        envMapIntensity: pickedMaterial.envMapIntensity
+      }
+    };
+  })();
+
+  GLTF_MATERIAL_CACHE.set(cacheKey, promise);
+  return promise;
+};
+
+const loadFieldSurface = async (fieldOption) => {
+  if (Array.isArray(fieldOption?.gltfUrls) && fieldOption.gltfUrls.length) {
+    return loadGltfMaterialSet(fieldOption);
+  }
+  const textures = await loadMarbleTextureSet(fieldOption);
+  return textures ? { textures } : null;
+};
+
+const pickPolyHavenHdriUrl = (json, preferred = DEFAULT_HDRI_RESOLUTIONS) => {
+  if (!json || typeof json !== 'object') return null;
+  const resolutions = Array.isArray(preferred) && preferred.length ? preferred : DEFAULT_HDRI_RESOLUTIONS;
+  for (const res of resolutions) {
+    const entry = json[res];
+    if (entry?.hdr) return entry.hdr;
+    if (entry?.exr) return entry.exr;
+  }
+  const fallback = Object.values(json).find((value) => value?.hdr || value?.exr);
+  if (!fallback) return null;
+  return fallback.hdr || fallback.exr || null;
+};
+
+async function resolvePolyHavenHdriUrl(config = {}) {
+  const forcedResolution =
+    typeof config?.forceResolution === 'string' && config.forceResolution.length
+      ? config.forceResolution
+      : null;
+  const preferred = forcedResolution
+    ? [forcedResolution]
+    : Array.isArray(config?.preferredResolutions) && config.preferredResolutions.length
+      ? config.preferredResolutions
+      : DEFAULT_HDRI_RESOLUTIONS;
+  const fallbackRes = forcedResolution || config?.fallbackResolution || preferred[0] || '4k';
+  const fallbackUrl =
+    config?.fallbackUrl ||
+    `https://dl.polyhaven.org/file/ph-assets/HDRIs/hdr/${fallbackRes}/${config?.assetId ?? 'neon_photostudio'}_${fallbackRes}.hdr`;
+  if (config?.assetUrls && typeof config.assetUrls === 'object') {
+    for (const res of preferred) {
+      if (config.assetUrls[res]) return config.assetUrls[res];
+    }
+    const manual = Object.values(config.assetUrls).find((value) => typeof value === 'string' && value.length);
+    if (manual) return manual;
+  }
+  if (typeof config?.assetUrl === 'string' && config.assetUrl.length) return config.assetUrl;
+  if (!config?.assetId || typeof fetch !== 'function') return fallbackUrl;
+  try {
+    const response = await fetch(`https://api.polyhaven.com/files/${encodeURIComponent(config.assetId)}`);
+    if (!response?.ok) return fallbackUrl;
+    const json = await response.json();
+    const picked = pickPolyHavenHdriUrl(json, preferred);
+    return picked || fallbackUrl;
+  } catch (error) {
+    console.warn('Failed to resolve Poly Haven HDRI url', error);
+    return fallbackUrl;
+  }
+}
+
+async function loadPolyHavenHdriEnvironment(renderer, config = {}) {
+  if (!renderer) return null;
+  const url = await resolvePolyHavenHdriUrl(config);
+  const lowerUrl = `${url ?? ''}`.toLowerCase();
+  const useExr = lowerUrl.endsWith('.exr');
+  const loader = useExr ? new EXRLoader() : null;
+  const rgbeLoader = new RGBELoader();
+  const activeLoader = useExr && loader ? loader : rgbeLoader;
+  if (!activeLoader) return null;
+  activeLoader.setCrossOrigin?.('anonymous');
+  return new Promise((resolve) => {
+    activeLoader.load(
+      url,
+      (texture) => {
+        const pmrem = new THREE.PMREMGenerator(renderer);
+        pmrem.compileEquirectangularShader();
+        const envMap = pmrem.fromEquirectangular(texture).texture;
+        envMap.name = `${config?.assetId ?? 'polyhaven'}-env`;
+        texture.dispose();
+        pmrem.dispose();
+        resolve({ envMap, url });
+      },
+      undefined,
+      (error) => {
+        console.warn('Failed to load Poly Haven HDRI', error);
+        resolve(null);
+      }
+    );
+  });
+}
+
+/**
+ * AIR HOCKEY 3D — Mobile Portrait
+ * -------------------------------
+ * • HDRI-lit Goal Rush arena with Murlan Royale environments (no walls or carpet)
+ * • Player-edge camera for an at-table perspective suited to portrait play
+ * • Controls: drag bottom half to move mallet
+ * • AI opponent on top half with simple tracking logic
+ * • Scoreboard with avatars
+ */
+
+export default function AirHockey3D({
+  player,
+  ai,
+  target = 11,
+  playType = 'regular',
+  accountId,
+  variant = 'goalrush'
+}) {
+  const gameVariant = GAME_VARIANTS.goalrush;
+  const isGoalRushVariant = gameVariant.id === 'goalrush';
+  const targetValue = Number(target) || 11;
+  const hostRef = useRef(null);
+  const raf = useRef(0);
+  const [ui, setUi] = useState({ left: 0, right: 0 });
+  const [gameOver, setGameOver] = useState(false);
+  const [winner, setWinner] = useState('');
+  const [goalPopup, setGoalPopup] = useState(null);
+  const [postPopup, setPostPopup] = useState(false);
+  const [redirecting, setRedirecting] = useState(false);
+  const resolvedAccountId = useMemo(() => goalRushAccountId(accountId), [accountId]);
+  const [airInventory, setAirInventory] = useState(() => getGoalRushInventory(resolvedAccountId));
+  const defaultSelections = useMemo(
+    () =>
+      CUSTOMIZATION_KEYS.reduce((acc, key) => {
+        acc[key] = GOAL_RUSH_CUSTOMIZATION[key]?.[0]?.id;
+        return acc;
+      }, {}),
+    []
+  );
+  const [selections, setSelections] = useState({
+    ...defaultSelections
+  });
+  const [showCustomizer, setShowCustomizer] = useState(false);
+  const [isTopDownView, setIsTopDownView] = useState(false);
+  const [showChat, setShowChat] = useState(false);
+  const [showGift, setShowGift] = useState(false);
+  const [cameraLiftUi, setCameraLiftUi] = useState(DEFAULT_CAMERA_LIFT);
+  const [chatBubbles, setChatBubbles] = useState([]);
+  const [liveMode, setLiveMode] = useState(false);
+  const [showLivePanel, setShowLivePanel] = useState(false);
+  const [muted, setMuted] = useState(isGameMuted());
+  const [commentaryPresetId, setCommentaryPresetId] = useState(() => {
+    if (typeof window !== 'undefined') {
+      const stored = window.localStorage.getItem(COMMENTARY_PRESET_STORAGE_KEY);
+      if (stored && AIR_HOCKEY_COMMENTARY_PRESETS.some((preset) => preset.id === stored)) {
+        return stored;
+      }
+    }
+    return DEFAULT_COMMENTARY_PRESET_ID;
+  });
+  const [commentaryMuted, setCommentaryMuted] = useState(() => {
+    if (typeof window !== 'undefined') {
+      const stored = window.localStorage.getItem(COMMENTARY_MUTE_STORAGE_KEY);
+      if (stored === '1') return true;
+      if (stored === '0') return false;
+    }
+    return false;
+  });
+  const [graphicsId, setGraphicsId] = useState(() => {
+    const fallback = resolveDefaultGraphicsId();
+    if (typeof window === 'undefined') return fallback;
+    try {
+      const stored = window.localStorage?.getItem(GRAPHICS_STORAGE_KEY);
+      if (stored && GRAPHICS_OPTIONS.some((opt) => opt.id === stored)) return stored;
+    } catch {}
+    return fallback;
+  });
+  const activeGraphicsOption = useMemo(
+    () =>
+      GRAPHICS_OPTIONS.find((opt) => opt.id === graphicsId) ||
+      GRAPHICS_OPTIONS.find((opt) => opt.id === DEFAULT_GRAPHICS_ID) ||
+      GRAPHICS_OPTIONS[0],
+    [graphicsId]
+  );
+  const activeCommentaryPreset = useMemo(
+    () =>
+      AIR_HOCKEY_COMMENTARY_PRESETS.find((preset) => preset.id === commentaryPresetId) ??
+      AIR_HOCKEY_COMMENTARY_PRESETS[0],
+    [commentaryPresetId]
+  );
+  const [commentarySupported, setCommentarySupported] = useState(() => getSpeechSupport());
+  const initialProfile = useMemo(() => selectPerformanceProfile(activeGraphicsOption), [activeGraphicsOption]);
+  const targetRef = useRef(Number(target) || 3);
+  const gameOverRef = useRef(false);
+  const audioRef = useRef({
+    hit: null,
+    goal: null,
+    whistle: null,
+    post: null
+  });
+  const audioStartedRef = useRef(false);
+  const hahaSoundRef = useRef(null);
+  const bombSoundRef = useRef(null);
+  const scoreRef = useRef({ left: 0, right: 0 });
+  const commentaryMutedRef = useRef(commentaryMuted);
+  const commentaryReadyRef = useRef(false);
+  const commentaryQueueRef = useRef([]);
+  const commentarySpeakingRef = useRef(false);
+  const commentaryLastEventAtRef = useRef(0);
+  const pendingCommentaryLinesRef = useRef(null);
+  const commentaryIntroPlayedRef = useRef(false);
+  const commentarySpeakerIndexRef = useRef(0);
+  const goalTimeoutRef = useRef(null);
+  const postTimeoutRef = useRef(null);
+  const restartTimeoutRef = useRef(null);
+  const redirectTimeoutRef = useRef(null);
+  const lastTouchRef = useRef(null);
+  const topLiveVideoRef = useRef(null);
+  const materialsRef = useRef({
+    tableSurface: null,
+    cushion: null,
+    frame: null,
+    trim: null,
+    base: null,
+    baseAccent: null,
+    rail: null,
+    line: null,
+    rings: [],
+    goal: null,
+    playerMallet: null,
+    aiMallet: null,
+    playerKnob: null,
+    aiKnob: null,
+    puck: null
+  });
+  const sceneRef = useRef(null);
+  const environmentRef = useRef({ envMap: null });
+  const tableBaseRef = useRef({ rebuild: () => {}, clear: () => {} });
+  const malletRefs = useRef({ player: null, ai: null });
+  const malletDimensionsRef = useRef({
+    radius: 0,
+    knobRadius: 0,
+    height: 0,
+    knobHeight: 0
+  });
+  const rendererRef = useRef(null);
+  const cameraRef = useRef(null);
+  const cameraViewRef = useRef({ applyCurrent: () => {} });
+  const cameraLiftRef = useRef(DEFAULT_CAMERA_LIFT);
+  const isTopDownViewRef = useRef(false);
+  const renderSettingsRef = useRef({
+    targetFrameIntervalMs: 1000 / initialProfile.targetFps,
+    renderResolutionScale: initialProfile.renderScale ?? 1,
+    pixelRatioCap: initialProfile.pixelRatioCap ?? DEFAULT_RENDER_PIXEL_RATIO_CAP,
+    pixelRatioScale: initialProfile.pixelRatioScale ?? RENDER_PIXEL_RATIO_SCALE
+  });
+  const lastFrameTimeRef = useRef(0);
+  const frameAccumulatorRef = useRef(0);
+  const selectionsRef = useRef(selections);
+  const chatAvatar = useMemo(() => getAvatarUrl(player.avatar), [player.avatar]);
+  const liveChatRoomId = useMemo(() => {
+    const params = new URLSearchParams(window.location.search || '');
+    return (
+      params.get('tableId') ||
+      params.get('table') ||
+      `${gameVariant.roomPrefix}-${playType || 'regular'}`
+    );
+  }, [gameVariant.roomPrefix, playType]);
+  const liveChat = useLiveVideoChat({
+    roomId: liveChatRoomId,
+    displayName: player?.name || 'Player',
+    enabled: liveMode
+  });
+  useEffect(() => {
+    if (liveMode) {
+      liveChat.startLiveChat();
+      return;
+    }
+    liveChat.stopLiveChat();
+  }, [liveMode, liveChat.startLiveChat, liveChat.stopLiveChat]);
+  const giftPlayers = useMemo(() => {
+    const playerAvatar = getAvatarUrl(player.avatar);
+    const aiAvatar = getAvatarUrl(ai.avatar);
+    const safeId = resolvedAccountId || accountId || 'guest';
+    return [
+      {
+        ...player,
+        id: safeId,
+        index: 0,
+        photoUrl: playerAvatar,
+        name: player.name || 'Player'
+      },
+      {
+        ...ai,
+        id: safeId,
+        index: 1,
+        photoUrl: aiAvatar,
+        name: ai.name || 'Opponent'
+      }
+    ];
+  }, [ai, accountId, player, resolvedAccountId]);
+  useEffect(() => {
+    if (!topLiveVideoRef.current) return;
+    topLiveVideoRef.current.srcObject = liveChat.localStream || null;
+  }, [liveChat.localStream]);
+  const toggleLiveFromAvatar = useCallback(() => {
+    setLiveMode((prev) => {
+      const nextLiveMode = !prev;
+      setShowLivePanel((panelOpen) => (nextLiveMode ? true : panelOpen));
+      return nextLiveMode;
+    });
+  }, []);
+  const updateRendererSettings = useCallback(() => {
+    const renderer = rendererRef.current;
+    const host = hostRef.current;
+    if (!renderer || !host || typeof window === 'undefined') return;
+
+    const { renderResolutionScale, pixelRatioCap, pixelRatioScale } = renderSettingsRef.current;
+    const devicePixelRatio = window.devicePixelRatio || 1;
+    const scaledPixelRatio = devicePixelRatio * pixelRatioScale;
+    const pixelRatio = Math.max(
+      MIN_RENDER_PIXEL_RATIO,
+      Math.min(pixelRatioCap, scaledPixelRatio)
+    );
+
+    renderer.setPixelRatio(pixelRatio);
+    const targetWidth = host.clientWidth * renderResolutionScale;
+    const targetHeight = host.clientHeight * renderResolutionScale;
+    renderer.setSize(targetWidth, targetHeight, false);
+    renderer.domElement.style.width = `${host.clientWidth}px`;
+    renderer.domElement.style.height = `${host.clientHeight}px`;
+  }, []);
+  const tableGroupRef = useRef(null);
+  const tableMarkingsRef = useRef({ line: null, circle: null });
+  const avatarSpritesRef = useRef({ player: null, ai: null });
+  const getOption = (key, optionId) => {
+    const options = GOAL_RUSH_CUSTOMIZATION[key] || [];
+    return options.find((option) => option.id === optionId) || options[0];
+  };
+
+  useEffect(() => {
+    const updateSupport = () => setCommentarySupported(getSpeechSupport());
+    updateSupport();
+    const unsubscribe = onSpeechSupportChange((supported) => setCommentarySupported(Boolean(supported)));
+    return () => {
+      unsubscribe();
+    };
+  }, []);
+
+  useEffect(() => {
+    setAirInventory(getGoalRushInventory(resolvedAccountId));
+  }, [resolvedAccountId]);
+
+  useEffect(() => {
+    selectionsRef.current = selections;
+  }, [selections]);
+
+  useEffect(() => {
+    tableBaseRef.current?.rebuild?.(selections.tableBase);
+  }, [selections.tableBase]);
+
+  useEffect(() => {
+    const handler = (event) => {
+      if (!event?.detail?.accountId || event.detail.accountId === resolvedAccountId) {
+        setAirInventory(getGoalRushInventory(resolvedAccountId));
+      }
+    };
+    window.addEventListener('goalRushInventoryUpdate', handler);
+    return () => window.removeEventListener('goalRushInventoryUpdate', handler);
+  }, [resolvedAccountId]);
+
+  useEffect(() => {
+    setSelections((prev) => {
+      let changed = false;
+      const next = { ...prev };
+      CUSTOMIZATION_KEYS.forEach((key) => {
+        const currentId = prev[key];
+        if (!isGoalRushOptionUnlocked(key, currentId, airInventory)) {
+          const fallback = (GOAL_RUSH_CUSTOMIZATION[key] || []).find((option) =>
+            isGoalRushOptionUnlocked(key, option.id, airInventory)
+          );
+          if (fallback && fallback.id !== currentId) {
+            next[key] = fallback.id;
+            changed = true;
+          }
+        }
+      });
+      return changed ? next : prev;
+    });
+  }, [airInventory]);
+
+  useEffect(() => {
+    if (!gameOver) return undefined;
+
+    setRedirecting(true);
+    redirectTimeoutRef.current = setTimeout(() => {
+      window.location.href = gameVariant.lobbyPath;
+    }, 2000);
+
+    return () => {
+      clearTimeout(redirectTimeoutRef.current);
+    };
+  }, [gameOver, gameVariant.lobbyPath]);
+
+  useEffect(() => () => {
+    clearTimeout(goalTimeoutRef.current);
+    clearTimeout(postTimeoutRef.current);
+    clearTimeout(restartTimeoutRef.current);
+    clearTimeout(redirectTimeoutRef.current);
+  }, []);
+
+  useEffect(() => {
+    targetRef.current = Number(target) || 3;
+  }, [target]);
+
+  useEffect(() => {
+    try {
+      window.localStorage?.setItem(GRAPHICS_STORAGE_KEY, graphicsId);
+    } catch {}
+  }, [graphicsId]);
+
+  useEffect(() => {
+    const profile = selectPerformanceProfile(activeGraphicsOption);
+    renderSettingsRef.current = {
+      targetFrameIntervalMs: 1000 / profile.targetFps,
+      renderResolutionScale: profile.renderScale ?? 1,
+      pixelRatioCap: profile.pixelRatioCap ?? DEFAULT_RENDER_PIXEL_RATIO_CAP,
+      pixelRatioScale: profile.pixelRatioScale ?? RENDER_PIXEL_RATIO_SCALE
+    };
+    lastFrameTimeRef.current = 0;
+    frameAccumulatorRef.current = 0;
+    updateRendererSettings();
+  }, [activeGraphicsOption, updateRendererSettings]);
+
+  useEffect(() => {
+    isTopDownViewRef.current = isTopDownView;
+    cameraLiftRef.current = DEFAULT_CAMERA_LIFT;
+    cameraViewRef.current.applyCurrent?.(isTopDownView, DEFAULT_CAMERA_LIFT);
+  }, [isTopDownView]);
+
+  useEffect(() => {
+    commentaryMutedRef.current = commentaryMuted;
+    if (commentaryMuted) {
+      const synth = getSpeechSynthesis();
+      synth?.cancel();
+      commentaryQueueRef.current = [];
+      commentarySpeakingRef.current = false;
+      pendingCommentaryLinesRef.current = null;
+    }
+  }, [commentaryMuted]);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(COMMENTARY_PRESET_STORAGE_KEY, commentaryPresetId);
+    }
+  }, [commentaryPresetId]);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(COMMENTARY_MUTE_STORAGE_KEY, commentaryMuted ? '1' : '0');
+    }
+  }, [commentaryMuted]);
+
+  const playerNameRef = useRef(player.name || 'Player');
+  const aiNameRef = useRef(ai.name || 'Opponent');
+  useEffect(() => {
+    playerNameRef.current = player.name || 'Player';
+    aiNameRef.current = ai.name || 'Opponent';
+  }, [ai.name, player.name]);
+
+  const resolveScoreline = useCallback((left, right) => {
+    if (left === right) return `level at ${left}-${right}`;
+    const leader = left > right ? playerNameRef.current : aiNameRef.current;
+    const leaderScore = left > right ? left : right;
+    const trailerScore = left > right ? right : left;
+    return `${leader} leads ${leaderScore}-${trailerScore}`;
+  }, []);
+
+  const pickCommentarySpeaker = useCallback(() => {
+    const speakers = [AIR_HOCKEY_SPEAKERS.lead, AIR_HOCKEY_SPEAKERS.analyst];
+    const index = commentarySpeakerIndexRef.current;
+    commentarySpeakerIndexRef.current = index + 1;
+    return speakers[index % speakers.length] || AIR_HOCKEY_SPEAKERS.lead;
+  }, []);
+
+  const playNextCommentary = useCallback(async () => {
+    if (commentarySpeakingRef.current) return;
+    const next = commentaryQueueRef.current.shift();
+    if (!next) return;
+    const synth = getSpeechSynthesis();
+    if (!synth) return;
+    commentarySpeakingRef.current = true;
+    try {
+      synth.cancel();
+    } catch {}
+    await speakCommentaryLines(next.lines, {
+      speakerSettings: next.preset?.speakerSettings,
+      voiceHints: next.preset?.voiceHints
+    });
+    commentarySpeakingRef.current = false;
+    if (commentaryQueueRef.current.length) {
+      playNextCommentary();
+    }
+  }, []);
+
+  const enqueueAirHockeyCommentary = useCallback(
+    (lines, { priority = false, preset = activeCommentaryPreset } = {}) => {
+      if (!Array.isArray(lines) || lines.length === 0) return;
+      if (commentaryMutedRef.current || isGameMuted()) return;
+      if (!commentaryReadyRef.current) {
+        pendingCommentaryLinesRef.current = { lines, priority, preset };
+        return;
+      }
+      const now = performance.now();
+      if (!priority && now - commentaryLastEventAtRef.current < COMMENTARY_MIN_INTERVAL_MS) return;
+      if (!priority && commentaryQueueRef.current.length >= COMMENTARY_QUEUE_LIMIT) return;
+      if (priority) {
+        commentaryQueueRef.current.unshift({ lines, preset });
+      } else {
+        commentaryQueueRef.current.push({ lines, preset });
+      }
+      if (!commentarySpeakingRef.current) {
+        playNextCommentary();
+      }
+      commentaryLastEventAtRef.current = now;
+    },
+    [activeCommentaryPreset, playNextCommentary]
+  );
+
+  const enqueueAirHockeyCommentaryEventRef = useRef(() => {});
+  useEffect(() => {
+    enqueueAirHockeyCommentaryEventRef.current = (event, context = {}, options = {}) => {
+      const speaker = options.speaker ?? pickCommentarySpeaker();
+      const text = buildAirHockeyCommentaryLine({
+        event,
+        speaker,
+        language: activeCommentaryPreset?.language ?? commentaryPresetId,
+        context: {
+          arena: gameVariant.arenaLabel,
+          targetScore: targetRef.current ?? targetValue,
+          ...context
+        }
+      });
+      enqueueAirHockeyCommentary([{ speaker, text }], options);
+    };
+  }, [
+    activeCommentaryPreset?.language,
+    commentaryPresetId,
+    enqueueAirHockeyCommentary,
+    pickCommentarySpeaker,
+    targetValue
+  ]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+    const unlockCommentary = () => {
+      if (commentaryReadyRef.current) return;
+      primeSpeechSynthesis();
+      const synth = getSpeechSynthesis();
+      synth?.getVoices?.();
+      commentaryReadyRef.current = true;
+      const pending = pendingCommentaryLinesRef.current;
+      if (pending) {
+        pendingCommentaryLinesRef.current = null;
+        enqueueAirHockeyCommentary(pending.lines, pending);
+      }
+    };
+    window.addEventListener('pointerdown', unlockCommentary);
+    window.addEventListener('click', unlockCommentary);
+    window.addEventListener('touchstart', unlockCommentary);
+    window.addEventListener('keydown', unlockCommentary);
+    return () => {
+      window.removeEventListener('pointerdown', unlockCommentary);
+      window.removeEventListener('click', unlockCommentary);
+      window.removeEventListener('touchstart', unlockCommentary);
+      window.removeEventListener('keydown', unlockCommentary);
+    };
+  }, [enqueueAirHockeyCommentary]);
+
+  useEffect(() => {
+    if (commentaryIntroPlayedRef.current) return;
+    commentaryIntroPlayedRef.current = true;
+    const lead = AIR_HOCKEY_SPEAKERS.lead;
+    const analyst = AIR_HOCKEY_SPEAKERS.analyst;
+    const baseContext = {
+      player: playerNameRef.current,
+      opponent: aiNameRef.current,
+      playerScore: scoreRef.current.left,
+      opponentScore: scoreRef.current.right,
+      scoreline: resolveScoreline(scoreRef.current.left, scoreRef.current.right)
+    };
+    enqueueAirHockeyCommentary(
+      [
+        {
+          speaker: lead,
+          text: buildAirHockeyCommentaryLine({
+            event: 'intro',
+            speaker: lead,
+            language: activeCommentaryPreset?.language ?? commentaryPresetId,
+            context: baseContext
+          })
+        },
+        {
+          speaker: analyst,
+          text: buildAirHockeyCommentaryLine({
+            event: 'introReply',
+            speaker: analyst,
+            language: activeCommentaryPreset?.language ?? commentaryPresetId,
+            context: baseContext
+          })
+        }
+      ],
+      { priority: true }
+    );
+  }, [activeCommentaryPreset?.language, commentaryPresetId, enqueueAirHockeyCommentary, resolveScoreline]);
+
+  useEffect(() => {
+    const handler = () => setMuted(isGameMuted());
+    window.addEventListener('gameMuteChanged', handler);
+    return () => window.removeEventListener('gameMuteChanged', handler);
+  }, []);
+
+  useEffect(() => {
+    const handleMute = () => {
+      if (!isGameMuted()) return;
+      const synth = getSpeechSynthesis();
+      synth?.cancel();
+      commentaryQueueRef.current = [];
+      commentarySpeakingRef.current = false;
+      pendingCommentaryLinesRef.current = null;
+    };
+    window.addEventListener('gameMuteChanged', handleMute);
+    return () => window.removeEventListener('gameMuteChanged', handleMute);
+  }, []);
+
+  useEffect(() => {
+    const vol = getGameVolume();
+    hahaSoundRef.current = new Audio('/assets/sounds/Haha.mp3');
+    hahaSoundRef.current.volume = vol;
+    bombSoundRef.current = new Audio(bombSound);
+    bombSoundRef.current.volume = vol;
+    return () => {
+      hahaSoundRef.current?.pause();
+      bombSoundRef.current?.pause();
+    };
+  }, []);
+
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host) return;
+
+    audioRef.current.hit = new Audio('/assets/sounds/football-game-sound-effects-359284.mp3');
+    audioRef.current.goal = new Audio('/assets/sounds/a-football-hits-the-net-goal-313216.mp3');
+    audioRef.current.whistle = new Audio('/assets/sounds/metal-whistle-6121.mp3');
+    audioRef.current.post = new Audio('/assets/sounds/frying-pan-over-the-head-89303.mp3');
+
+    const primeAudio = () => {
+      const audios = Object.values(audioRef.current).filter(Boolean);
+      if (!audios.length || audioStartedRef.current) return;
+
+      let unlocked = false;
+      let pending = audios.length;
+
+      audios.forEach((audio) => {
+        const originalVolume = audio.volume;
+        audio.volume = Math.max(0.0001, originalVolume * 0.0001);
+        audio.currentTime = 0;
+
+        const finalize = (wasUnlocked) => {
+          unlocked = unlocked || wasUnlocked;
+          audio.volume = originalVolume;
+          pending -= 1;
+          if (pending === 0) {
+            audioStartedRef.current = unlocked;
+          }
+        };
+
+        const playPromise = audio.play();
+        if (playPromise && playPromise.then) {
+          playPromise
+            .then(() => {
+              audio.pause();
+              audio.currentTime = 0;
+              finalize(true);
+            })
+            .catch(() => finalize(false));
+        } else {
+          audio.pause();
+          audio.currentTime = 0;
+          finalize(true);
+        }
+      });
+    };
+
+    const playWhistle = () => {
+      if (isGameMuted()) return;
+      const whistle = audioRef.current.whistle;
+      if (!whistle || !audioStartedRef.current) return;
+      whistle.volume = getGameVolume();
+      whistle.currentTime = 0;
+      whistle.play().catch(() => {});
+      setTimeout(() => {
+        whistle.pause();
+        whistle.currentTime = 0;
+      }, 2000);
+    };
+
+    const playHit = () => {
+      if (isGameMuted()) return;
+      const hit = audioRef.current.hit;
+      if (!hit || !audioStartedRef.current) return;
+      hit.volume = getGameVolume();
+      hit.currentTime = 0;
+      hit.play().catch(() => {});
+      setTimeout(() => {
+        hit.pause();
+      }, 700);
+    };
+
+    const playPost = () => {
+      if (isGameMuted()) return;
+      const post = audioRef.current.post;
+      if (!post || !audioStartedRef.current) return;
+      post.volume = Math.min(1, getGameVolume() * 0.7);
+      post.currentTime = 0.15;
+      post.play().catch(() => {});
+      setTimeout(() => {
+        post.pause();
+        post.currentTime = 0.15;
+      }, 1000);
+      setPostPopup(true);
+      clearTimeout(postTimeoutRef.current);
+      postTimeoutRef.current = setTimeout(() => setPostPopup(false), 900);
+      const lastTouch = lastTouchRef.current;
+      const playerWasLast = lastTouch === 'player';
+      const scorerName = playerWasLast ? playerNameRef.current : aiNameRef.current;
+      const opponentName = playerWasLast ? aiNameRef.current : playerNameRef.current;
+      enqueueAirHockeyCommentaryEventRef.current('post', {
+        player: scorerName,
+        opponent: opponentName,
+        playerScore: playerWasLast ? scoreRef.current.left : scoreRef.current.right,
+        opponentScore: playerWasLast ? scoreRef.current.right : scoreRef.current.left,
+        scoreline: resolveScoreline(scoreRef.current.left, scoreRef.current.right)
+      });
+    };
+
+    const playGoal = () => {
+      if (isGameMuted()) return;
+      const goal = audioRef.current.goal;
+      if (!goal || !audioStartedRef.current) return;
+      goal.volume = getGameVolume();
+      goal.currentTime = 0;
+      goal.play().catch(() => {});
+      setTimeout(() => {
+        goal.pause();
+        goal.currentTime = 0;
+      }, 2000);
+    };
+
+    const recordGoal = (playerScored) => {
+      const prevLeft = scoreRef.current.left;
+      const prevRight = scoreRef.current.right;
+      const prevLeader =
+        prevLeft === prevRight ? 'tie' : prevLeft > prevRight ? 'left' : 'right';
+      scoreRef.current = {
+        left: scoreRef.current.left + (playerScored ? 1 : 0),
+        right: scoreRef.current.right + (playerScored ? 0 : 1)
+      };
+      setUi({ ...scoreRef.current });
+      setGoalPopup({
+        scorer: playerScored ? player.name : ai.name,
+        scoreLine: `${scoreRef.current.left} - ${scoreRef.current.right}`,
+        isPlayer: playerScored
+      });
+      clearTimeout(goalTimeoutRef.current);
+      goalTimeoutRef.current = setTimeout(() => setGoalPopup(null), 1500);
+      const targetScore = targetRef.current;
+      const scoreline = resolveScoreline(scoreRef.current.left, scoreRef.current.right);
+      const scorerName = playerScored ? playerNameRef.current : aiNameRef.current;
+      const opponentName = playerScored ? aiNameRef.current : playerNameRef.current;
+      const playerScore = playerScored ? scoreRef.current.left : scoreRef.current.right;
+      const opponentScore = playerScored ? scoreRef.current.right : scoreRef.current.left;
+      const newLeader =
+        scoreRef.current.left === scoreRef.current.right
+          ? 'tie'
+          : scoreRef.current.left > scoreRef.current.right
+            ? 'left'
+            : 'right';
+      const leadChanged = newLeader !== prevLeader && newLeader !== 'tie';
+      if (
+        targetScore &&
+        (scoreRef.current.left >= targetScore || scoreRef.current.right >= targetScore)
+      ) {
+        gameOverRef.current = true;
+        setGameOver(true);
+        setWinner(playerScored ? player.name : ai.name);
+        enqueueAirHockeyCommentaryEventRef.current(
+          'matchWin',
+          {
+            player: scorerName,
+            opponent: opponentName,
+            playerScore,
+            opponentScore,
+            scoreline
+          },
+          { priority: true }
+        );
+        return true;
+      }
+      if (scoreRef.current.left === scoreRef.current.right) {
+        enqueueAirHockeyCommentaryEventRef.current('equalizer', {
+          player: scorerName,
+          opponent: opponentName,
+          playerScore,
+          opponentScore,
+          scoreline
+        });
+      } else if (leadChanged) {
+        enqueueAirHockeyCommentaryEventRef.current('leadChange', {
+          player: scorerName,
+          opponent: opponentName,
+          playerScore,
+          opponentScore,
+          scoreline
+        });
+      } else {
+        enqueueAirHockeyCommentaryEventRef.current('goal', {
+          player: scorerName,
+          opponent: opponentName,
+          playerScore,
+          opponentScore,
+          scoreline
+        });
+      }
+      if (targetScore && playerScore === targetScore - 1) {
+        enqueueAirHockeyCommentaryEventRef.current('matchPoint', {
+          player: scorerName,
+          opponent: opponentName,
+          playerScore,
+          opponentScore,
+          scoreline
+        });
+      }
+      return false;
+    };
+
+    const renderer = new THREE.WebGLRenderer({
+      antialias: true,
+      powerPreference: 'high-performance'
+    });
+    renderer.toneMapping = THREE.ACESFilmicToneMapping;
+    renderer.toneMappingExposure = 1.85;
+    renderer.outputColorSpace = THREE.SRGBColorSpace;
+    host.appendChild(renderer.domElement);
+    rendererRef.current = renderer;
+    updateRendererSettings();
+
+    const createPuckTexture = () => {
+      const size = 512;
+      const canvas = document.createElement('canvas');
+      canvas.width = size;
+      canvas.height = size;
+      const ctx = canvas.getContext('2d');
+      const cx = size / 2;
+      const cy = size / 2;
+      if (isGoalRushVariant) {
+        ctx.fillStyle = '#f8fafc';
+        ctx.fillRect(0, 0, size, size);
+        ctx.strokeStyle = '#0f172a';
+        ctx.lineWidth = size * 0.03;
+        ctx.beginPath();
+        ctx.arc(cx, cy, size * 0.42, 0, Math.PI * 2);
+        ctx.stroke();
+        ctx.fillStyle = '#0f172a';
+        ctx.beginPath();
+        ctx.moveTo(cx, cy - size * 0.14);
+        ctx.lineTo(cx + size * 0.11, cy - size * 0.03);
+        ctx.lineTo(cx + size * 0.07, cy + size * 0.12);
+        ctx.lineTo(cx - size * 0.07, cy + size * 0.12);
+        ctx.lineTo(cx - size * 0.11, cy - size * 0.03);
+        ctx.closePath();
+        ctx.fill();
+        const patchPositions = [
+          [-0.19, -0.18],
+          [0.19, -0.18],
+          [-0.26, 0.12],
+          [0.26, 0.12]
+        ];
+        patchPositions.forEach(([x, y]) => {
+          ctx.beginPath();
+          ctx.arc(cx + size * x, cy + size * y, size * 0.06, 0, Math.PI * 2);
+          ctx.fill();
+        });
+        const texture = new THREE.CanvasTexture(canvas);
+        texture.colorSpace = THREE.SRGBColorSpace;
+        texture.anisotropy = renderer.capabilities.getMaxAnisotropy();
+        texture.needsUpdate = true;
+        return texture;
+      }
+
+      ctx.fillStyle = '#0b0c0f';
+      ctx.fillRect(0, 0, size, size);
+
+      const outerRim = ctx.createRadialGradient(cx, cy, size * 0.1, cx, cy, size * 0.48);
+      outerRim.addColorStop(0, '#1b1f23');
+      outerRim.addColorStop(0.55, '#0f1114');
+      outerRim.addColorStop(1, '#040506');
+      ctx.fillStyle = outerRim;
+      ctx.beginPath();
+      ctx.arc(cx, cy, size * 0.48, 0, Math.PI * 2);
+      ctx.fill();
+
+      const rimCut = ctx.createRadialGradient(cx, cy, size * 0.14, cx, cy, size * 0.42);
+      rimCut.addColorStop(0, 'rgba(255,255,255,0.08)');
+      rimCut.addColorStop(0.42, 'rgba(60,60,60,0.2)');
+      rimCut.addColorStop(1, 'rgba(0,0,0,0.55)');
+      ctx.strokeStyle = rimCut;
+      ctx.lineWidth = size * 0.05;
+      ctx.beginPath();
+      ctx.arc(cx, cy, size * 0.36, 0, Math.PI * 2);
+      ctx.stroke();
+
+      const top = ctx.createRadialGradient(cx, cy * 0.98, size * 0.06, cx, cy, size * 0.33);
+      top.addColorStop(0, 'rgba(240,240,240,0.28)');
+      top.addColorStop(0.6, 'rgba(80,85,90,0.18)');
+      top.addColorStop(1, 'rgba(10,10,10,0.55)');
+      ctx.fillStyle = top;
+      ctx.beginPath();
+      ctx.arc(cx, cy, size * 0.34, 0, Math.PI * 2);
+      ctx.fill();
+
+      ctx.save();
+      ctx.translate(cx, cy);
+      ctx.rotate(-0.4);
+      const sheen = ctx.createLinearGradient(-size * 0.2, -size * 0.18, size * 0.12, size * 0.26);
+      sheen.addColorStop(0, 'rgba(255,255,255,0.12)');
+      sheen.addColorStop(0.55, 'rgba(255,255,255,0.25)');
+      sheen.addColorStop(1, 'rgba(255,255,255,0.06)');
+      ctx.fillStyle = sheen;
+      ctx.beginPath();
+      ctx.ellipse(0, size * 0.02, size * 0.32, size * 0.21, -0.2, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.restore();
+
+      ctx.globalCompositeOperation = 'lighter';
+      ctx.fillStyle = 'rgba(255,255,255,0.08)';
+      for (let i = 0; i < 8; i += 1) {
+        const angle = (i / 8) * Math.PI * 2;
+        const radius = size * 0.36;
+        const x = cx + Math.cos(angle) * radius;
+        const y = cy + Math.sin(angle) * radius;
+        ctx.beginPath();
+        ctx.arc(x, y, size * 0.01, 0, Math.PI * 2);
+        ctx.fill();
+      }
+      ctx.globalCompositeOperation = 'source-over';
+
+      const texture = new THREE.CanvasTexture(canvas);
+      texture.colorSpace = THREE.SRGBColorSpace;
+      texture.anisotropy = renderer.capabilities.getMaxAnisotropy();
+      texture.needsUpdate = true;
+      return texture;
+    };
+
+    const createMalletTexture = (color) => {
+      const size = 512;
+      const canvas = document.createElement('canvas');
+      canvas.width = size;
+      canvas.height = size;
+      const ctx = canvas.getContext('2d');
+      const cx = size / 2;
+      const cy = size / 2;
+
+      const base = ctx.createRadialGradient(cx, cy, size * 0.08, cx, cy, size * 0.5);
+      base.addColorStop(0, '#fafafc');
+      base.addColorStop(0.08, '#ffffff');
+      base.addColorStop(0.26, color);
+      base.addColorStop(1, '#0a0a0c');
+      ctx.fillStyle = base;
+      ctx.beginPath();
+      ctx.arc(cx, cy, size * 0.48, 0, Math.PI * 2);
+      ctx.fill();
+
+      const gloss = ctx.createLinearGradient(cx - size * 0.18, cy - size * 0.25, cx + size * 0.22, cy + size * 0.26);
+      gloss.addColorStop(0, 'rgba(255,255,255,0.18)');
+      gloss.addColorStop(0.55, 'rgba(255,255,255,0.34)');
+      gloss.addColorStop(1, 'rgba(255,255,255,0.08)');
+      ctx.fillStyle = gloss;
+      ctx.beginPath();
+      ctx.ellipse(cx - size * 0.06, cy, size * 0.32, size * 0.18, -0.3, 0, Math.PI * 2);
+      ctx.fill();
+
+      ctx.strokeStyle = 'rgba(0,0,0,0.45)';
+      ctx.lineWidth = size * 0.018;
+      ctx.beginPath();
+      ctx.arc(cx, cy, size * 0.34, 0, Math.PI * 2);
+      ctx.stroke();
+
+      const texture = new THREE.CanvasTexture(canvas);
+      texture.colorSpace = THREE.SRGBColorSpace;
+      texture.anisotropy = renderer.capabilities.getMaxAnisotropy();
+      texture.needsUpdate = true;
+      return texture;
+    };
+
+    const scene = new THREE.Scene();
+    scene.background = new THREE.Color(0x050505);
+    sceneRef.current = scene;
+
+    const TABLE_SCALE = 1;
+    const TABLE = {
+      w: POOL_ROYALE_TABLE_DIMENSIONS.tableWidth * TABLE_SCALE,
+      h: POOL_ROYALE_TABLE_DIMENSIONS.tableLength * TABLE_SCALE,
+      thickness: POOL_ROYALE_TABLE_DIMENSIONS.tableThickness * TABLE_SCALE,
+      topExtension: 0
+    };
+    const TABLE_WALL = POOL_ROYALE_TABLE_DIMENSIONS.tableWall * TABLE_SCALE;
+    const PLAYFIELD = {
+      w: POOL_ROYALE_TABLE_DIMENSIONS.playfieldWidth * TABLE_SCALE,
+      h: POOL_ROYALE_TABLE_DIMENSIONS.playfieldHeight * TABLE_SCALE,
+      goalW: POOL_ROYALE_TABLE_DIMENSIONS.playfieldWidth * 0.45454545454545453,
+      inset: 0
+    };
+    const SCALE_WIDTH = PLAYFIELD.w / 2.2;
+    const SCALE_LENGTH = PLAYFIELD.h / (4.8 * 1.2);
+    const SPEED_SCALE = (SCALE_WIDTH + SCALE_LENGTH) / 2;
+    const MALLET_RADIUS = PLAYFIELD.w * 0.072;
+    const MALLET_HEIGHT = MALLET_RADIUS * (0.05 / 0.12);
+    const MALLET_KNOB_RADIUS = MALLET_RADIUS * (0.065 / 0.12);
+    const MALLET_KNOB_HEIGHT = MALLET_RADIUS * (0.1 / 0.12);
+    malletDimensionsRef.current = {
+      radius: MALLET_RADIUS,
+      knobRadius: MALLET_KNOB_RADIUS,
+      height: MALLET_HEIGHT,
+      knobHeight: MALLET_KNOB_HEIGHT
+    };
+    const PUCK_RADIUS = PLAYFIELD.w * 0.0285;
+    const PUCK_HEIGHT = isGoalRushVariant ? PUCK_RADIUS * 2 : PUCK_RADIUS * 1.05;
+    const CORNER_POCKET_RADIUS = Math.max(PUCK_RADIUS * 2.3, PLAYFIELD.w * 0.055);
+    const CORNER_POCKET_CAPTURE = Math.max(PUCK_RADIUS * 0.6, CORNER_POCKET_RADIUS - PUCK_RADIUS * 0.25);
+    const cornerPocketCenters = [
+      new THREE.Vector2(-PLAYFIELD.w / 2, -PLAYFIELD.h / 2),
+      new THREE.Vector2(PLAYFIELD.w / 2, -PLAYFIELD.h / 2),
+      new THREE.Vector2(-PLAYFIELD.w / 2, PLAYFIELD.h / 2),
+      new THREE.Vector2(PLAYFIELD.w / 2, PLAYFIELD.h / 2)
+    ];
+
+    const camera = new THREE.PerspectiveCamera(
+      56,
+      host.clientWidth / host.clientHeight,
+      0.1,
+      1200
+    );
+    cameraRef.current = camera;
+
+    const world = new THREE.Group();
+    scene.add(world);
+
+    const poolTableEntry = PoolRoyaleTable3D(
+      world,
+      null,
+      null,
+      null,
+      selectionsRef.current.tableBase,
+      renderer,
+      { enableSidePockets: false, mergeSideCushions: true }
+    );
+    const poolTable = poolTableEntry?.group ?? new THREE.Group();
+    const poolMarkings = poolTable?.userData?.markings;
+    if (poolMarkings?.group) {
+      poolMarkings.group.traverse((child) => {
+        if (!child?.isMesh) return;
+        child.geometry?.dispose?.();
+        if (Array.isArray(child.material)) {
+          child.material.forEach((mat) => mat?.dispose?.());
+        } else {
+          child.material?.dispose?.();
+        }
+      });
+      poolTable.remove(poolMarkings.group);
+      delete poolTable.userData.markings;
+    }
+    const clothPlaneLocal =
+      poolTable?.userData?.clothPlaneLocal ?? -TABLE.thickness + 0.01;
+    const elevatedTableSurfaceY = (poolTable?.position?.y ?? 0) + clothPlaneLocal;
+
+    const tableGroup = new THREE.Group();
+    tableGroup.position.y = elevatedTableSurfaceY;
+    tableGroup.position.z = -TABLE.topExtension / 2;
+    const tableCenterZ = tableGroup.position.z;
+    world.add(tableGroup);
+    tableGroupRef.current = tableGroup;
+
+    const finishMaterials = poolTable?.userData?.finish?.materials ?? {};
+    materialsRef.current.tableSurface = poolTableEntry?.clothMat ?? null;
+    materialsRef.current.cushion = poolTableEntry?.cushionMat ?? null;
+    materialsRef.current.frame = finishMaterials.frame ?? null;
+    materialsRef.current.trim = finishMaterials.trim ?? null;
+    materialsRef.current.rail = finishMaterials.rail ?? null;
+    materialsRef.current.base = finishMaterials.leg ?? finishMaterials.frame ?? null;
+    materialsRef.current.baseAccent = finishMaterials.trim ?? finishMaterials.rail ?? null;
+
+    const railThickness = TABLE_WALL * 0.6;
+
+    tableBaseRef.current = {
+      rebuild: (variantId) => poolTableEntry?.setBaseVariant?.(variantId),
+      clear: () => {}
+    };
+
+    const goalGeometry = new THREE.BoxGeometry(
+      PLAYFIELD.goalW,
+      0.11 * SCALE_WIDTH,
+      railThickness * 0.6
+    );
+    const goalMaterial = new THREE.MeshStandardMaterial({
+      color: 0x99ffd6,
+      emissive: 0x003322,
+      emissiveIntensity: 0.6
+    });
+    materialsRef.current.goal = goalMaterial;
+    const goalInsetTowardCenter = railThickness * 0.44;
+    const northGoal = new THREE.Mesh(goalGeometry, goalMaterial);
+    northGoal.position.set(0, 0.055 * SCALE_WIDTH, -PLAYFIELD.h / 2 - railThickness * 0.7 + goalInsetTowardCenter);
+    tableGroup.add(northGoal);
+    const southGoal = new THREE.Mesh(goalGeometry, goalMaterial);
+    southGoal.position.set(0, 0.055 * SCALE_WIDTH, PLAYFIELD.h / 2 + railThickness * 0.7 - goalInsetTowardCenter);
+    tableGroup.add(southGoal);
+
+    const goalOpeningWidth = PLAYFIELD.goalW * 0.74;
+    const goalSideCushionWidth = Math.max(
+      PLAYFIELD.goalW * 0.09,
+      (PLAYFIELD.goalW - goalOpeningWidth) / 2
+    );
+    const goalCutoutGeometry = new THREE.BoxGeometry(
+      goalOpeningWidth,
+      0.13 * SCALE_WIDTH,
+      railThickness * 1.05
+    );
+    const goalCutoutMaterial = new THREE.MeshStandardMaterial({
+      color: 0x09121d,
+      roughness: 0.82,
+      metalness: 0.08,
+      emissive: new THREE.Color(0x02060b),
+      emissiveIntensity: 0.35
+    });
+    const pocketNetReference =
+      poolTable?.userData?.finish?.parts?.pocketNetMeshes?.[0]?.material ?? null;
+    const goalNetMaterial = pocketNetReference
+      ? pocketNetReference.clone()
+      : new THREE.MeshStandardMaterial({
+          color: 0xc8f3ff,
+          emissive: new THREE.Color(0x0e3446),
+          emissiveIntensity: 0.45,
+          roughness: 0.78,
+          metalness: 0.1,
+          transparent: true,
+          opacity: 0.7
+        });
+    goalNetMaterial.wireframe = true;
+    goalNetMaterial.transparent = true;
+    goalNetMaterial.opacity = typeof goalNetMaterial.opacity === 'number' ? goalNetMaterial.opacity : 0.68;
+    goalNetMaterial.needsUpdate = true;
+
+    const goalPocketCavityMaterial = new THREE.MeshStandardMaterial({
+      color: 0x04070b,
+      roughness: 0.92,
+      metalness: 0.04,
+      emissive: new THREE.Color(0x010205),
+      emissiveIntensity: 0.3
+    });
+    const goalSideCushionMaterial =
+      materialsRef.current.cushion?.clone?.() ?? goalCutoutMaterial.clone();
+    if (goalSideCushionMaterial?.color) {
+      goalSideCushionMaterial.color.offsetHSL(0, 0, -0.04);
+    }
+    const createGoalMouth = (direction) => {
+      const mouth = new THREE.Mesh(goalCutoutGeometry, goalCutoutMaterial);
+      mouth.position.set(
+        0,
+        0.048 * SCALE_WIDTH,
+        direction * (PLAYFIELD.h / 2 + railThickness * 0.08 - goalInsetTowardCenter)
+      );
+      tableGroup.add(mouth);
+
+      const cavity = new THREE.Mesh(
+        new THREE.BoxGeometry(goalOpeningWidth * 0.94, 0.125 * SCALE_WIDTH, railThickness * 1.8),
+        goalPocketCavityMaterial
+      );
+      cavity.position.set(
+        0,
+        0.04 * SCALE_WIDTH,
+        direction * (PLAYFIELD.h / 2 + railThickness * 0.92 - goalInsetTowardCenter)
+      );
+      tableGroup.add(cavity);
+
+      const sideOffsetX = goalOpeningWidth / 2 + goalSideCushionWidth / 2;
+      [-1, 1].forEach((xDirection) => {
+        const sideCushion = new THREE.Mesh(
+          new THREE.BoxGeometry(goalSideCushionWidth, 0.16 * SCALE_WIDTH, railThickness * 0.68),
+          goalSideCushionMaterial
+        );
+        sideCushion.position.set(
+          xDirection * sideOffsetX,
+          0.07 * SCALE_WIDTH,
+          direction * (PLAYFIELD.h / 2 + railThickness * 0.26 - goalInsetTowardCenter)
+        );
+        tableGroup.add(sideCushion);
+      });
+
+      const net = new THREE.Mesh(
+        new THREE.BoxGeometry(goalOpeningWidth * 0.96, 0.165 * SCALE_WIDTH, railThickness * 1.15),
+        goalNetMaterial
+      );
+      net.position.set(
+        0,
+        0.062 * SCALE_WIDTH,
+        direction * (PLAYFIELD.h / 2 + railThickness * 0.95 - goalInsetTowardCenter)
+      );
+      tableGroup.add(net);
+    };
+    createGoalMouth(-1);
+    createGoalMouth(1);
+
+    const goalTrimMaterial = new THREE.MeshStandardMaterial({
+      color: 0x09121d,
+      roughness: 0.82,
+      metalness: 0.08,
+      emissive: new THREE.Color(0x02060b),
+      emissiveIntensity: 0.24
+    });
+    const goalCushionTrimGeometry = new THREE.BoxGeometry(
+      PLAYFIELD.goalW * 0.92,
+      0.2 * SCALE_WIDTH,
+      railThickness * 0.5
+    );
+    const addGoalCushionTrim = (direction) => {
+      const trim = new THREE.Mesh(goalCushionTrimGeometry, goalTrimMaterial);
+      trim.position.set(
+        0,
+        0.072 * SCALE_WIDTH,
+        direction * (PLAYFIELD.h / 2 + railThickness * 0.22 - goalInsetTowardCenter)
+      );
+      tableGroup.add(trim);
+    };
+    addGoalCushionTrim(-1);
+    addGoalCushionTrim(1);
+
+    const createGoalLabel = (text, accent) => {
+      const width = 1024;
+      const height = 300;
+      const canvas = document.createElement('canvas');
+      canvas.width = width;
+      canvas.height = height;
+      const ctx = canvas.getContext('2d');
+      const gradient = ctx.createLinearGradient(0, 0, 0, height);
+      gradient.addColorStop(0, 'rgba(0,0,0,0.82)');
+      gradient.addColorStop(1, 'rgba(0,0,0,0.55)');
+      ctx.fillStyle = gradient;
+      const radius = 36;
+      ctx.beginPath();
+      ctx.moveTo(radius, 0);
+      ctx.lineTo(width - radius, 0);
+      ctx.quadraticCurveTo(width, 0, width, radius);
+      ctx.lineTo(width, height - radius);
+      ctx.quadraticCurveTo(width, height, width - radius, height);
+      ctx.lineTo(radius, height);
+      ctx.quadraticCurveTo(0, height, 0, height - radius);
+      ctx.lineTo(0, radius);
+      ctx.quadraticCurveTo(0, 0, radius, 0);
+      ctx.closePath();
+      ctx.fill();
+
+      ctx.strokeStyle = `${accent}80`;
+      ctx.lineWidth = 14;
+      ctx.stroke();
+
+      ctx.font = '700 150px "Inter", "Helvetica", sans-serif';
+      ctx.fillStyle = accent;
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.shadowColor = 'rgba(0,0,0,0.45)';
+      ctx.shadowBlur = 24;
+      ctx.fillText(text, width / 2, height / 2 + 8);
+
+      const map = new THREE.CanvasTexture(canvas);
+      map.colorSpace = THREE.SRGBColorSpace;
+      map.needsUpdate = true;
+      const material = new THREE.SpriteMaterial({
+        map,
+        transparent: true,
+        depthTest: false,
+        depthWrite: false
+      });
+      const sprite = new THREE.Sprite(material);
+      const labelWidth = PLAYFIELD.goalW * 0.72;
+      const labelHeight = labelWidth * (height / width) * 0.6;
+      sprite.scale.set(labelWidth, labelHeight, 1);
+      sprite.renderOrder = 15;
+      return sprite;
+    };
+
+    const goalLabels = [];
+
+    const northLabel = createGoalLabel(ai?.name || 'Opponent', '#22d3ee');
+    northLabel.position.set(0, northGoal.position.y + SCALE_WIDTH * 0.12, northGoal.position.z);
+    tableGroup.add(northLabel);
+    goalLabels.push(northLabel);
+
+    const southLabel = createGoalLabel(player?.name || 'You', '#ff5577');
+    southLabel.position.set(0, southGoal.position.y + SCALE_WIDTH * 0.12, southGoal.position.z);
+    tableGroup.add(southLabel);
+    goalLabels.push(southLabel);
+
+    const markingLift = PLAYFIELD.h * 0.002;
+    const markingThickness = PLAYFIELD.h * 0.01;
+    const lineMaterial = new THREE.MeshStandardMaterial({
+      color: 0xf8fafc,
+      roughness: 0.28,
+      metalness: 0.05,
+      transparent: true,
+      opacity: 0.9
+    });
+    const lineMesh = new THREE.Mesh(
+      new THREE.PlaneGeometry(PLAYFIELD.w * 0.92, markingThickness),
+      lineMaterial
+    );
+    lineMesh.rotation.x = -Math.PI / 2;
+    lineMesh.position.set(0, markingLift, 0);
+    tableGroup.add(lineMesh);
+
+    const circleRadius = PLAYFIELD.w * 0.18;
+    const circleMaterial = lineMaterial.clone();
+    const circleMesh = new THREE.Mesh(
+      new THREE.RingGeometry(
+        Math.max(0.01, circleRadius - markingThickness * 0.5),
+        circleRadius + markingThickness * 0.5,
+        96
+      ),
+      circleMaterial
+    );
+    circleMesh.rotation.x = -Math.PI / 2;
+    circleMesh.position.set(0, markingLift, 0);
+    tableGroup.add(circleMesh);
+    if (isGoalRushVariant) {
+      const boxDepth = PLAYFIELD.h * 0.165;
+      const boxThickness = markingThickness;
+      const boxWidth = PLAYFIELD.w * 0.52;
+      const addBoxMarking = (direction) => {
+        const baseZ = direction * (PLAYFIELD.h / 2 - boxDepth / 2);
+        const longA = new THREE.Mesh(
+          new THREE.PlaneGeometry(boxWidth, boxThickness),
+          lineMaterial.clone()
+        );
+        longA.rotation.x = -Math.PI / 2;
+        longA.position.set(0, markingLift, baseZ + direction * boxDepth * 0.5);
+        tableGroup.add(longA);
+        const longB = new THREE.Mesh(
+          new THREE.PlaneGeometry(boxWidth, boxThickness),
+          lineMaterial.clone()
+        );
+        longB.rotation.x = -Math.PI / 2;
+        longB.position.set(0, markingLift, baseZ - direction * boxDepth * 0.5);
+        tableGroup.add(longB);
+        [-1, 1].forEach((xDirection) => {
+          const side = new THREE.Mesh(
+            new THREE.PlaneGeometry(boxThickness, boxDepth),
+            lineMaterial.clone()
+          );
+          side.rotation.x = -Math.PI / 2;
+          side.position.set(xDirection * boxWidth * 0.5, markingLift, baseZ);
+          tableGroup.add(side);
+        });
+      };
+      addBoxMarking(1);
+      addBoxMarking(-1);
+    }
+
+    materialsRef.current.line = lineMaterial;
+    materialsRef.current.rings = [circleMaterial];
+    tableMarkingsRef.current = { line: lineMesh, circle: circleMesh };
+
+    const makeMallet = (color) => {
+      const mallet = new THREE.Group();
+      const baseTexture = createMalletTexture(new THREE.Color(color).getStyle());
+      const baseMaterial = new THREE.MeshStandardMaterial({
+        color,
+        map: baseTexture,
+        roughness: 0.32,
+        metalness: 0.28
+      });
+      const base = new THREE.Mesh(
+        new THREE.CylinderGeometry(MALLET_RADIUS, MALLET_RADIUS, MALLET_HEIGHT, 32),
+        baseMaterial
+      );
+      base.position.y = MALLET_HEIGHT / 2;
+      const knobMaterial = new THREE.MeshStandardMaterial({
+        color: 0x222222,
+        roughness: 0.26,
+        metalness: 0.22
+      });
+      const knob = new THREE.Mesh(
+        new THREE.CylinderGeometry(
+          MALLET_KNOB_RADIUS,
+          MALLET_KNOB_RADIUS,
+          MALLET_KNOB_HEIGHT,
+          32
+        ),
+        knobMaterial
+      );
+      knob.position.y = MALLET_HEIGHT + MALLET_KNOB_HEIGHT / 2;
+      mallet.add(base, knob);
+      return { mallet, baseMaterial, knobMaterial };
+    };
+
+    const youData = makeMallet(0xff5577);
+    const you = youData.mallet;
+    you.position.set(0, 0, PLAYFIELD.h * 0.42);
+    tableGroup.add(you);
+    materialsRef.current.playerMallet = youData.baseMaterial;
+    materialsRef.current.playerKnob = youData.knobMaterial;
+    malletRefs.current.player = you;
+
+    const aiData = makeMallet(0x66ddff);
+    const aiMallet = aiData.mallet;
+    aiMallet.position.set(0, 0, -PLAYFIELD.h * 0.36);
+    tableGroup.add(aiMallet);
+    materialsRef.current.aiMallet = aiData.baseMaterial;
+    materialsRef.current.aiKnob = aiData.knobMaterial;
+    malletRefs.current.ai = aiMallet;
+
+    const puckTexture = createPuckTexture();
+    const puck = new THREE.Mesh(
+      isGoalRushVariant
+        ? new THREE.SphereGeometry(PUCK_RADIUS, 48, 48)
+        : new THREE.CylinderGeometry(PUCK_RADIUS, PUCK_RADIUS, PUCK_HEIGHT, 32),
+      new THREE.MeshStandardMaterial({
+        color: isGoalRushVariant ? 0xfafafa : 0x111111,
+        map: puckTexture,
+        roughness: isGoalRushVariant ? 0.26 : 0.34,
+        metalness: 0.22,
+        clearcoat: isGoalRushVariant ? 0.55 : 0.35,
+        clearcoatRoughness: isGoalRushVariant ? 0.16 : 0.28
+      })
+    );
+    puck.position.y = isGoalRushVariant ? PUCK_RADIUS : PUCK_HEIGHT / 2;
+    tableGroup.add(puck);
+    materialsRef.current.puck = puck.material;
+
+    const playerRailZ = PLAYFIELD.h / 2 + railThickness / 2;
+    const cameraFocus = new THREE.Vector3(
+      0,
+      elevatedTableSurfaceY + TABLE.thickness * 0.06,
+      tableCenterZ
+    );
+    const standingCameraAnchor = new THREE.Vector3(
+      0,
+      elevatedTableSurfaceY + TABLE.h * 0.31,
+      tableCenterZ + playerRailZ + TABLE.w * 0.12
+    );
+    const resolveCameraAnchor = () => {
+      const anchor = standingCameraAnchor.clone();
+      anchor.y += (cameraLiftRef.current - DEFAULT_CAMERA_LIFT) * SCALE_WIDTH * 0.38;
+      return anchor;
+    };
+    const getCameraDirection = (anchor) =>
+      new THREE.Vector3().subVectors(anchor, cameraFocus).normalize();
+    const TOP_VIEW_MARGIN = 1.12;
+    const defaultCameraUp = new THREE.Vector3(0, 1, 0);
+    const topViewUp = new THREE.Vector3(0, 0, -1);
+    const topViewTarget = cameraFocus.clone();
+
+    const updateTopViewCamera = () => {
+      camera.aspect = host.clientWidth / host.clientHeight;
+      const verticalFov = THREE.MathUtils.degToRad(camera.fov);
+      const verticalTan = Math.tan(Math.max(verticalFov / 2, 1e-3));
+      const horizontalTan = Math.max(verticalTan * camera.aspect, 1e-3);
+      const halfWidth = (TABLE.w * TOP_VIEW_MARGIN) / 2;
+      const halfLength = (TABLE.h * TOP_VIEW_MARGIN) / 2;
+      const distance =
+        Math.max(halfLength / verticalTan, halfWidth / horizontalTan) *
+        AIR_HOCKEY_TOP_VIEW_CAMERA_DISTANCE_SCALE;
+      camera.up.copy(topViewUp);
+      camera.position.set(0, topViewTarget.y + distance, tableCenterZ);
+      camera.lookAt(topViewTarget);
+      camera.updateProjectionMatrix();
+      updateRendererSettings();
+    };
+
+    const tableCorners = [
+      new THREE.Vector3(-TABLE.w / 2, elevatedTableSurfaceY, -TABLE.h / 2 + tableCenterZ),
+      new THREE.Vector3(TABLE.w / 2, elevatedTableSurfaceY, -TABLE.h / 2 + tableCenterZ),
+      new THREE.Vector3(-TABLE.w / 2, elevatedTableSurfaceY, TABLE.h / 2 + tableCenterZ),
+      new THREE.Vector3(TABLE.w / 2, elevatedTableSurfaceY, TABLE.h / 2 + tableCenterZ)
+    ];
+
+    const fitCameraToTable = () => {
+      if (isTopDownViewRef.current) {
+        updateTopViewCamera();
+        return;
+      }
+      const anchor = resolveCameraAnchor();
+      const direction = getCameraDirection(anchor);
+      camera.aspect = host.clientWidth / host.clientHeight;
+      camera.up.copy(defaultCameraUp);
+      camera.position.copy(anchor);
+      camera.lookAt(cameraFocus);
+      camera.updateProjectionMatrix();
+      updateRendererSettings();
+      for (let i = 0; i < 20; i++) {
+        const needsRetreat = tableCorners.some((corner) => {
+          const sample = corner.clone();
+          const ndc = sample.project(camera);
+          return Math.abs(ndc.x) > 0.95 || ndc.y < -1.05 || ndc.y > 1.05;
+        });
+        if (!needsRetreat) break;
+        camera.position.addScaledVector(direction, 2.4);
+        camera.lookAt(cameraFocus);
+        camera.updateProjectionMatrix();
+      }
+    };
+
+    cameraViewRef.current = {
+      applyCurrent: (useTopView, lift = cameraLiftRef.current) => {
+        cameraLiftRef.current = clamp(lift, CAMERA_LIFT_MIN, CAMERA_LIFT_MAX);
+        if (useTopView) {
+          updateTopViewCamera();
+        } else {
+          fitCameraToTable();
+        }
+      }
+    };
+
+    const S = {
+      vel: new THREE.Vector3(0, 0, 0),
+      friction: 0.994
+    };
+
+    const ray = new THREE.Raycaster();
+    const ndc = new THREE.Vector2();
+    const plane = new THREE.Plane(
+      new THREE.Vector3(0, 1, 0),
+      -elevatedTableSurfaceY
+    );
+    const hit = new THREE.Vector3();
+
+    const isLowerHalfTouch = (clientY) => {
+      const r = renderer.domElement.getBoundingClientRect();
+      return clientY >= r.top + r.height * 0.5;
+    };
+
+    const touchToXZ = (clientX, clientY) => {
+      const r = renderer.domElement.getBoundingClientRect();
+      ndc.x = ((clientX - r.left) / r.width) * 2 - 1;
+      ndc.y = -((clientY - r.top) / r.height) * 2 + 1;
+      ray.setFromCamera(ndc, camera);
+      if (!ray.ray.intersectPlane(plane, hit)) {
+        return { x: you.position.x, z: you.position.z };
+      }
+      return {
+        x: clamp(hit.x, -PLAYFIELD.w / 2 + MALLET_RADIUS, PLAYFIELD.w / 2 - MALLET_RADIUS),
+        z: clamp(hit.z, 0, PLAYFIELD.h / 2 - MALLET_RADIUS)
+      };
+    };
+
+    const onMove = (e) => {
+      primeAudio();
+      const t = e.touches ? e.touches[0] : e;
+      if (e.cancelable) {
+        e.preventDefault();
+      }
+      if (!isLowerHalfTouch(t.clientY)) return;
+      const { x, z } = touchToXZ(t.clientX, t.clientY);
+      you.position.set(x, 0, z);
+    };
+
+    renderer.domElement.addEventListener('touchstart', onMove, {
+      passive: false
+    });
+    renderer.domElement.addEventListener('touchmove', onMove, {
+      passive: false
+    });
+    renderer.domElement.addEventListener('mousemove', onMove);
+
+    const SPEED_BOOST = 1.25;
+    const PUCK_SPEED_TUNING = 0.76;
+    const HIT_FORCE = 0.5 * SPEED_SCALE * SPEED_BOOST * PUCK_SPEED_TUNING;
+    const MAX_SPEED = 0.095 * SPEED_SCALE * SPEED_BOOST * PUCK_SPEED_TUNING;
+    const SERVE_SPEED = 0.055 * SPEED_SCALE * SPEED_BOOST * PUCK_SPEED_TUNING;
+    const GOAL_RESET_DELAY = 1500;
+
+    const servePuck = (towardTop = false) => {
+      S.vel.set(0, 0, towardTop ? -SERVE_SPEED : SERVE_SPEED);
+      playWhistle();
+    };
+
+    const handleCollision = (mallet, isPlayer = false) => {
+      const dx = puck.position.x - mallet.position.x;
+      const dz = puck.position.z - mallet.position.z;
+      const d2 = dx * dx + dz * dz;
+      const collideRadius = MALLET_RADIUS + PUCK_RADIUS * 0.8;
+      if (d2 < collideRadius * collideRadius) {
+        lastTouchRef.current = isPlayer ? 'player' : 'ai';
+        const distance = Math.max(Math.sqrt(d2), 1e-6);
+        const overlap = collideRadius - distance;
+        const normal = new THREE.Vector3(dx / distance, 0, dz / distance);
+
+        puck.position.x += normal.x * overlap;
+        puck.position.z += normal.z * overlap;
+
+        const directionalForce = HIT_FORCE * (isPlayer ? 1.2 : 1);
+        S.vel.addScaledVector(normal, directionalForce);
+
+        if (isPlayer) {
+          const guardOffset = MALLET_RADIUS + PUCK_RADIUS * 0.2;
+          puck.position.z = Math.min(puck.position.z, mallet.position.z - guardOffset);
+          if (S.vel.z > 0) {
+            S.vel.z = -Math.abs(S.vel.z);
+          }
+        }
+
+        const alongNormal = S.vel.dot(normal);
+        if (alongNormal < SERVE_SPEED * 0.4) {
+          S.vel.addScaledVector(normal, SERVE_SPEED * 0.4 - alongNormal);
+        }
+
+        playHit();
+      }
+    };
+
+    const aiUpdate = (dt) => {
+      const guardLine = -MALLET_RADIUS;
+      const defensiveZ = -PLAYFIELD.h * 0.36;
+      const targetZ =
+        puck.position.z < guardLine
+          ? clamp(
+              puck.position.z + MALLET_RADIUS * 0.8,
+              -PLAYFIELD.h / 2 + MALLET_RADIUS,
+              guardLine - MALLET_RADIUS
+            )
+          : defensiveZ;
+      const targetX = clamp(
+        puck.position.x,
+        -PLAYFIELD.w / 2 + MALLET_RADIUS,
+        PLAYFIELD.w / 2 - MALLET_RADIUS
+      );
+      const chaseSpeed = 3.4;
+      aiMallet.position.x += (targetX - aiMallet.position.x) * chaseSpeed * dt;
+      aiMallet.position.z += (targetZ - aiMallet.position.z) * chaseSpeed * dt;
+    };
+
+    const reset = (towardTop = false, shouldServe = true, spawnZ = 0) => {
+      puck.position.set(0, isGoalRushVariant ? PUCK_RADIUS : PUCK_HEIGHT / 2, spawnZ);
+      S.vel.set(0, 0, 0);
+      you.position.set(0, 0, PLAYFIELD.h * 0.42);
+      aiMallet.position.set(0, 0, -PLAYFIELD.h * 0.36);
+      lastTouchRef.current = null;
+      if (shouldServe) {
+        servePuck(towardTop);
+      }
+    };
+
+    // loop
+    reset();
+    fitCameraToTable();
+
+    const tick = (timestamp = performance.now()) => {
+      if (lastFrameTimeRef.current === 0) {
+        lastFrameTimeRef.current = timestamp;
+        frameAccumulatorRef.current = 0;
+      }
+
+      const elapsedMs = Math.min(1000, timestamp - lastFrameTimeRef.current);
+      frameAccumulatorRef.current += elapsedMs;
+      const targetInterval = renderSettingsRef.current.targetFrameIntervalMs || 16.67;
+      if (frameAccumulatorRef.current < targetInterval * 0.92) {
+        raf.current = requestAnimationFrame(tick);
+        return;
+      }
+
+      const dt = Math.min(0.033, frameAccumulatorRef.current / 1000);
+      frameAccumulatorRef.current = Math.max(0, frameAccumulatorRef.current - targetInterval);
+      lastFrameTimeRef.current = timestamp;
+
+      puck.position.x += S.vel.x;
+      puck.position.z += S.vel.z;
+      S.vel.multiplyScalar(Math.pow(S.friction, dt * 60));
+      // keep puck speed manageable
+      S.vel.clampLength(0, MAX_SPEED);
+
+      const cornerPocketed = cornerPocketCenters.some((center) => {
+        const dx = puck.position.x - center.x;
+        const dz = puck.position.z - center.y;
+        return dx * dx + dz * dz <= CORNER_POCKET_CAPTURE * CORNER_POCKET_CAPTURE;
+      });
+
+      if (cornerPocketed) {
+        const playerGetsPuck = lastTouchRef.current !== 'player';
+        const spawnZ = playerGetsPuck ? PLAYFIELD.h * 0.24 : -PLAYFIELD.h * 0.24;
+        reset(playerGetsPuck, true, spawnZ);
+        playPost();
+        renderer.render(scene, camera);
+        if (!gameOverRef.current) {
+          raf.current = requestAnimationFrame(tick);
+        }
+        return;
+      }
+
+      if (Math.abs(puck.position.x) > PLAYFIELD.w / 2 - PUCK_RADIUS) {
+        puck.position.x = clamp(
+          puck.position.x,
+          -PLAYFIELD.w / 2 + PUCK_RADIUS,
+          PLAYFIELD.w / 2 - PUCK_RADIUS
+        );
+        S.vel.x = -S.vel.x;
+        playHit();
+      }
+
+      const goalHalf = PLAYFIELD.goalW / 2;
+      const atTop = puck.position.z < -PLAYFIELD.h / 2 + PUCK_RADIUS;
+      const atBot = puck.position.z > PLAYFIELD.h / 2 - PUCK_RADIUS;
+      if (atTop || atBot) {
+        if (Math.abs(puck.position.x) <= goalHalf) {
+          const playerScored = atTop;
+          const ended = recordGoal(playerScored);
+          playGoal();
+          S.vel.set(0, 0, 0);
+          clearTimeout(restartTimeoutRef.current);
+          if (!ended) {
+            reset(!atBot, false);
+            restartTimeoutRef.current = setTimeout(() => {
+              servePuck(!atBot);
+            }, GOAL_RESET_DELAY);
+          }
+        } else {
+          S.vel.z = -S.vel.z;
+          puck.position.z = clamp(
+            puck.position.z,
+            -PLAYFIELD.h / 2 + PUCK_RADIUS,
+            PLAYFIELD.h / 2 - PUCK_RADIUS
+          );
+          playPost();
+        }
+      }
+
+      aiUpdate(dt);
+      handleCollision(you, true);
+      handleCollision(aiMallet);
+      renderer.render(scene, camera);
+      if (!gameOverRef.current) {
+        raf.current = requestAnimationFrame(tick);
+      }
+    };
+
+    tick();
+
+    const onResize = () => {
+      fitCameraToTable();
+    };
+    window.addEventListener('resize', onResize);
+
+    return () => {
+      cancelAnimationFrame(raf.current);
+      window.removeEventListener('resize', onResize);
+      renderer.domElement.removeEventListener('touchstart', onMove);
+      renderer.domElement.removeEventListener('touchmove', onMove);
+      renderer.domElement.removeEventListener('mousemove', onMove);
+      rendererRef.current = null;
+      lastFrameTimeRef.current = 0;
+      frameAccumulatorRef.current = 0;
+      Object.keys(audioRef.current).forEach((key) => {
+        const audio = audioRef.current[key];
+        if (audio) {
+          audio.pause();
+          audioRef.current[key] = null;
+        }
+      });
+      goalLabels.forEach((label) => {
+        label.parent?.remove(label);
+        label.material.map?.dispose();
+        label.material.dispose();
+      });
+      if (tableMarkingsRef.current.line) {
+        tableMarkingsRef.current.line.parent?.remove(tableMarkingsRef.current.line);
+        tableMarkingsRef.current.line.geometry?.dispose();
+        tableMarkingsRef.current.line.material?.dispose();
+      }
+      if (tableMarkingsRef.current.circle) {
+        tableMarkingsRef.current.circle.parent?.remove(tableMarkingsRef.current.circle);
+        tableMarkingsRef.current.circle.geometry?.dispose();
+        tableMarkingsRef.current.circle.material?.dispose();
+      }
+      try {
+        host.removeChild(renderer.domElement);
+      } catch {}
+      if (environmentRef.current.envMap) {
+        environmentRef.current.envMap.dispose?.();
+        environmentRef.current.envMap = null;
+      }
+      renderer.dispose();
+    };
+  }, []);
+
+  useEffect(() => {
+    const renderer = rendererRef.current;
+    const scene = sceneRef.current;
+    if (!renderer || !scene) return undefined;
+    const hdriOption = getOption('environmentHdri', selections.environmentHdri);
+    if (!hdriOption) return undefined;
+    let cancelled = false;
+    loadPolyHavenHdriEnvironment(renderer, hdriOption).then((result) => {
+      if (cancelled || !result?.envMap) {
+        result?.envMap?.dispose?.();
+        return;
+      }
+      const prevEnv = environmentRef.current.envMap;
+      if (prevEnv && prevEnv !== result.envMap) {
+        prevEnv.dispose?.();
+      }
+      environmentRef.current.envMap = result.envMap;
+      scene.environment = result.envMap;
+      scene.background = result.envMap;
+      const rotationY = Number.isFinite(hdriOption.rotationY) ? hdriOption.rotationY : 0;
+      if ('backgroundRotation' in scene) {
+        scene.backgroundRotation = new THREE.Euler(0, rotationY, 0);
+      }
+      if ('environmentRotation' in scene) {
+        scene.environmentRotation = new THREE.Euler(0, rotationY, 0);
+      }
+      if ('backgroundIntensity' in scene && typeof hdriOption.backgroundIntensity === 'number') {
+        scene.backgroundIntensity = hdriOption.backgroundIntensity;
+      }
+      if ('environmentIntensity' in scene && typeof hdriOption.environmentIntensity === 'number') {
+        scene.environmentIntensity = hdriOption.environmentIntensity;
+      }
+      if (typeof hdriOption.exposure === 'number') {
+        renderer.toneMappingExposure = hdriOption.exposure;
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [selections.environmentHdri]);
+
+  useEffect(() => {
+    const mats = materialsRef.current;
+    const fieldOption = getOption('field', selections.field);
+    if (!mats?.tableSurface || !fieldOption) return undefined;
+    let cancelled = false;
+
+    const applyTextureRepeat = (texture, repeat) => {
+      if (!texture) return;
+      texture.wrapS = THREE.RepeatWrapping;
+      texture.wrapT = THREE.RepeatWrapping;
+      texture.repeat.set(repeat, repeat);
+      texture.anisotropy = rendererRef.current?.capabilities.getMaxAnisotropy() ?? 1;
+      texture.needsUpdate = true;
+    };
+
+    const applyFieldMaterial = (surface) => {
+      if (cancelled || !mats.tableSurface) return;
+      const mat = mats.tableSurface;
+      const fallbackColor = fieldOption.color || fieldOption.swatches?.[0] || '#f8fafc';
+      const repeat = fieldOption.repeat ?? 1;
+      const textures = surface?.textures ?? surface;
+      const materialProps = surface?.materialProps;
+      const hasTextures = Boolean(textures?.map);
+      const baseColor = materialProps?.color || (fieldOption.color ? new THREE.Color(fieldOption.color) : null);
+
+      if (hasTextures) {
+        applyTextureRepeat(textures.map, repeat);
+        applyTextureRepeat(textures.normal, repeat);
+        applyTextureRepeat(textures.roughness, repeat);
+        applyTextureRepeat(textures.metalness, repeat);
+        mat.map = textures.map;
+        mat.normalMap = textures.normal ?? null;
+        mat.roughnessMap = textures.roughness ?? null;
+        mat.metalnessMap = textures.metalness ?? null;
+        mat.color.set(0xffffff);
+        if (baseColor) {
+          mat.color.copy(baseColor);
+        }
+      } else {
+        mat.map = createFallbackTexture(fallbackColor);
+        mat.normalMap = null;
+        mat.roughnessMap = null;
+        mat.metalnessMap = null;
+        mat.color.set(fallbackColor);
+      }
+
+      mat.bumpMap = null;
+      const roughness = resolveNumber(fieldOption.roughness, materialProps?.roughness, POOL_BALL_MARBLE_FINISH.roughness);
+      const metalness = resolveNumber(fieldOption.metalness, materialProps?.metalness, POOL_BALL_MARBLE_FINISH.metalness);
+      const clearcoat = resolveNumber(fieldOption.clearcoat, materialProps?.clearcoat, POOL_BALL_MARBLE_FINISH.clearcoat);
+      const clearcoatRoughness = resolveNumber(
+        fieldOption.clearcoatRoughness,
+        materialProps?.clearcoatRoughness,
+        POOL_BALL_MARBLE_FINISH.clearcoatRoughness
+      );
+      const reflectivity = resolveNumber(fieldOption.reflectivity, POOL_BALL_MARBLE_FINISH.reflectivity);
+      const sheen = resolveNumber(fieldOption.sheen, materialProps?.sheen, 0);
+      const envMapIntensity = resolveNumber(
+        fieldOption.envMapIntensity,
+        materialProps?.envMapIntensity,
+        POOL_BALL_MARBLE_FINISH.envMapIntensity
+      );
+      if ('sheenRoughness' in mat) {
+        mat.sheenRoughness = 1;
+      }
+      if (typeof metalness === 'number') mat.metalness = metalness;
+      if (typeof roughness === 'number') mat.roughness = roughness;
+      if (typeof clearcoat === 'number') mat.clearcoat = clearcoat;
+      if (typeof clearcoatRoughness === 'number') mat.clearcoatRoughness = clearcoatRoughness;
+      if (typeof reflectivity === 'number') mat.reflectivity = reflectivity;
+      if ('sheen' in mat) {
+        mat.sheen = sheen ?? 0;
+      }
+      if ('sheenColor' in mat) {
+        mat.sheenColor = materialProps?.sheenColor || POOL_BALL_MARBLE_FINISH.sheenColor;
+      }
+      if ('envMapIntensity' in mat && typeof envMapIntensity === 'number') {
+        mat.envMapIntensity = envMapIntensity;
+      }
+      mat.needsUpdate = true;
+    };
+
+    loadFieldSurface(fieldOption).then((surface) => {
+      if (cancelled) return;
+      applyFieldMaterial(surface);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selections.field]);
+
+  useEffect(() => {
+    const playerMallet = malletRefs.current.player;
+    const aiMallet = malletRefs.current.ai;
+    const dims = malletDimensionsRef.current;
+    if (!playerMallet || !aiMallet || !dims.knobRadius || !dims.knobHeight) {
+      return undefined;
+    }
+
+    const createCircleTexture = (image, fallbackLabel = '?') => {
+      const size = 512;
+      const canvas = document.createElement('canvas');
+      canvas.width = size;
+      canvas.height = size;
+      const ctx = canvas.getContext('2d');
+      ctx.clearRect(0, 0, size, size);
+      ctx.save();
+      const maskRadius = size / 2 - 10;
+      ctx.beginPath();
+      ctx.arc(size / 2, size / 2, maskRadius, 0, Math.PI * 2);
+      ctx.closePath();
+      const gradient = ctx.createLinearGradient(0, 0, 0, size);
+      gradient.addColorStop(0, '#0b1224');
+      gradient.addColorStop(1, '#111827');
+      ctx.fillStyle = gradient;
+      ctx.fill();
+      ctx.clip();
+      if (image && image.width && image.height) {
+        const cropSize = Math.min(image.width, image.height);
+        const sx = (image.width - cropSize) / 2;
+        const sy = (image.height - cropSize) / 2;
+        const inset = size * 0.12;
+        ctx.drawImage(
+          image,
+          sx,
+          sy,
+          cropSize,
+          cropSize,
+          inset,
+          inset,
+          size - inset * 2,
+          size - inset * 2
+        );
+      } else {
+        ctx.fillStyle = '#0f172a';
+        ctx.fillRect(0, 0, size, size);
+        ctx.fillStyle = '#e5e7eb';
+        ctx.font = 'bold 220px Inter, sans-serif';
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.fillText(fallbackLabel, size / 2, size / 2 + 20);
+      }
+      ctx.restore();
+      ctx.beginPath();
+      ctx.arc(size / 2, size / 2, maskRadius - 4, 0, Math.PI * 2);
+      ctx.strokeStyle = 'rgba(255, 255, 255, 0.55)';
+      ctx.lineWidth = 10;
+      ctx.stroke();
+      const texture = new THREE.CanvasTexture(canvas);
+      texture.colorSpace = THREE.SRGBColorSpace;
+      texture.needsUpdate = true;
+      return texture;
+    };
+
+    const loadAvatarImage = (key, avatar, onReady) => {
+      const url = getAvatarUrl(avatar) || '/assets/icons/profile.svg';
+      const img = new Image();
+      img.crossOrigin = 'anonymous';
+      img.onload = () => onReady(img, url);
+      img.onerror = () => {
+        if (url !== '/assets/icons/profile.svg') {
+          loadAvatarImage(key, '/assets/icons/profile.svg', onReady);
+          return;
+        }
+        onReady(null, url);
+      };
+      img.src = url;
+    };
+
+    const setAvatar = (key, avatar) => {
+      const existing = avatarSpritesRef.current[key];
+      if (existing) {
+        existing.parent?.remove(existing);
+        existing.material.map?.dispose();
+        existing.material.dispose();
+        existing.geometry?.dispose();
+      }
+      loadAvatarImage(key, avatar, (image, url) => {
+        const label = typeof avatar === 'string' ? avatar.slice(0, 2) : '?';
+        const texture = createCircleTexture(image, label);
+        const material = new THREE.MeshBasicMaterial({
+          map: texture,
+          transparent: true,
+          depthWrite: false,
+          depthTest: false,
+          side: THREE.DoubleSide
+        });
+        const geometry = new THREE.CircleGeometry(dims.knobRadius, 64);
+        const badge = new THREE.Mesh(geometry, material);
+        badge.position.set(0, dims.height + dims.knobHeight + 0.0005, 0);
+        badge.rotation.x = -Math.PI / 2;
+        badge.renderOrder = 20;
+        const targetMallet = key === 'player' ? playerMallet : aiMallet;
+        targetMallet.add(badge);
+        avatarSpritesRef.current[key] = badge;
+      });
+    };
+
+    setAvatar('player', player.avatar);
+    setAvatar('ai', ai.avatar);
+
+    return () => {
+      ['player', 'ai'].forEach((key) => {
+        const sprite = avatarSpritesRef.current[key];
+        if (sprite) {
+          sprite.parent?.remove(sprite);
+          sprite.material.map?.dispose();
+          sprite.material.dispose();
+          sprite.geometry?.dispose();
+          avatarSpritesRef.current[key] = null;
+        }
+      });
+    };
+  }, [player.avatar, ai.avatar]);
+
+  useEffect(() => {
+    const mats = materialsRef.current;
+    if (!mats) return;
+
+    const fieldTheme = getOption('field', selections.field);
+    const cushionTheme = getOption('cushionCloth', selections.cushionCloth);
+    const puckTheme = getOption('puck', selections.puck);
+    const malletTheme = getOption('mallet', selections.mallet);
+    const goalTheme = getOption('goals', selections.goals);
+
+    if (!LOCK_POOL_ROYALE_TABLE_STYLE) {
+      const tableTheme = getOption('table', selections.table);
+      const baseTheme = getOption('tableBase', selections.tableBase);
+      const tableGrain =
+        tableTheme?.woodTextureId && WOOD_GRAIN_OPTIONS_BY_ID[tableTheme.woodTextureId]
+          ? WOOD_GRAIN_OPTIONS_BY_ID[tableTheme.woodTextureId]
+          : null;
+      const fallbackHsl = tableTheme?.wood
+        ? new THREE.Color(tableTheme.wood).getHSL({})
+        : { h: 0.08, s: 0.35, l: 0.5 };
+      const baseHsl = baseTheme?.base ? new THREE.Color(baseTheme.base).getHSL({}) : fallbackHsl;
+      const accentHsl = baseTheme?.accent ? new THREE.Color(baseTheme.accent).getHSL({}) : baseHsl;
+
+      const applyTableTexture = (material, surfaceKey) => {
+        if (!material || !tableGrain) return;
+        const surface = tableGrain[surfaceKey] || tableGrain.frame || tableGrain.rail;
+        if (!surface) return;
+        applyWoodTextures(material, {
+          mapUrl: surface.mapUrl,
+          roughnessMapUrl: surface.roughnessMapUrl,
+          normalMapUrl: surface.normalMapUrl,
+          repeat: surface.repeat,
+          rotation: surface.rotation,
+          textureSize: surface.textureSize,
+          hue: fallbackHsl.h * 360,
+          sat: fallbackHsl.s,
+          light: fallbackHsl.l,
+          contrast: 0.55
+        });
+      };
+      const applyBaseTexture = (material, surfaceKey, tint) => {
+        if (!material || !tableGrain) return;
+        const surface = tableGrain[surfaceKey] || tableGrain.frame || tableGrain.rail;
+        if (!surface) return;
+        applyWoodTextures(material, {
+          mapUrl: surface.mapUrl,
+          roughnessMapUrl: surface.roughnessMapUrl,
+          normalMapUrl: surface.normalMapUrl,
+          repeat: surface.repeat,
+          rotation: surface.rotation,
+          textureSize: surface.textureSize,
+          hue: tint.h * 360,
+          sat: tint.s,
+          light: tint.l,
+          contrast: 0.55
+        });
+      };
+
+      if (tableGrain) {
+        applyTableTexture(mats.frame, 'frame');
+        applyTableTexture(mats.rail, 'rail');
+        applyTableTexture(mats.trim, 'rail');
+        applyBaseTexture(mats.base, 'frame', baseHsl);
+        applyBaseTexture(mats.baseAccent, 'rail', accentHsl);
+      } else {
+        if (mats.frame) mats.frame.color.set(tableTheme.wood);
+        if (mats.rail) mats.rail.color.set(tableTheme.wood);
+        if (mats.trim) mats.trim.color.set(tableTheme.trim);
+      }
+      if (mats.base) mats.base.color.set(baseTheme.base);
+      if (mats.baseAccent) mats.baseAccent.color.set(baseTheme.accent);
+    }
+    if (mats.line && fieldTheme?.lineColor) {
+      mats.line.color.set(fieldTheme.lineColor);
+    }
+    if (Array.isArray(mats.rings) && fieldTheme?.lineColor) {
+      mats.rings.forEach((ring) => ring?.color?.set?.(fieldTheme.lineColor));
+    }
+    if (mats.cushion && cushionTheme) {
+      const palette = cushionTheme.palette || {};
+      const base = palette.base ?? cushionTheme.baseColor ?? 0x2d7f4b;
+      const baseColor = new THREE.Color(base);
+      mats.cushion.color.copy(baseColor);
+      if (mats.cushion.emissive) {
+        mats.cushion.emissive.copy(baseColor.clone().multiplyScalar(0.06));
+      }
+      if (typeof cushionTheme.detail?.emissiveIntensity === 'number') {
+        mats.cushion.emissiveIntensity = cushionTheme.detail.emissiveIntensity;
+      }
+      if (typeof cushionTheme.detail?.sheen === 'number' && 'sheen' in mats.cushion) {
+        mats.cushion.sheen = cushionTheme.detail.sheen;
+      }
+      if (
+        typeof cushionTheme.detail?.sheenRoughness === 'number' &&
+        'sheenRoughness' in mats.cushion
+      ) {
+        mats.cushion.sheenRoughness = cushionTheme.detail.sheenRoughness;
+      }
+      if (typeof cushionTheme.detail?.envMapIntensity === 'number') {
+        mats.cushion.envMapIntensity = cushionTheme.detail.envMapIntensity;
+      }
+      if (typeof cushionTheme.detail?.bumpMultiplier === 'number') {
+        const baseBumpScale =
+          mats.cushion.userData?.baseBumpScale ?? mats.cushion.bumpScale ?? 1;
+        mats.cushion.bumpScale = baseBumpScale * cushionTheme.detail.bumpMultiplier;
+      }
+      mats.cushion.needsUpdate = true;
+    }
+    if (mats.puck) {
+      mats.puck.color.set(puckTheme.color);
+      mats.puck.emissive.set(puckTheme.emissive);
+      mats.puck.needsUpdate = true;
+    }
+    if (mats.playerMallet) mats.playerMallet.color.set(malletTheme.color);
+    if (mats.aiMallet) mats.aiMallet.color.set(malletTheme.color);
+    if (mats.playerKnob) mats.playerKnob.color.set(malletTheme.knob);
+    if (mats.aiKnob) mats.aiKnob.color.set(malletTheme.knob);
+    if (mats.goal) {
+      mats.goal.color.set(goalTheme.color);
+      mats.goal.emissive.set(goalTheme.emissive);
+    }
+  }, [selections]);
+
+  const renderOptionRow = (label, key) => {
+    const options = (GOAL_RUSH_CUSTOMIZATION[key] || []).filter((option) =>
+      isGoalRushOptionUnlocked(key, option.id, airInventory)
+    );
+    if (!options.length) return null;
+    return (
+      <div className="space-y-1">
+        <div className="text-[11px] uppercase tracking-wide text-white/70">{label}</div>
+        <div className="grid grid-cols-2 gap-2">
+          {options.map((option, idx) => {
+            const swatch =
+              option.surface ||
+              option.wood ||
+              option.color ||
+              option.base ||
+              option.swatches?.[0];
+            const active = selections[key] === option.id;
+            return (
+              <button
+                key={`${key}-${option.name}`}
+                onClick={() =>
+                  setSelections((prev) => ({
+                    ...prev,
+                    [key]: option.id
+                  }))
+                }
+                className={`flex items-center justify-between rounded px-2 py-1 text-left text-[11px] font-semibold transition ${
+                  active ? 'bg-white/20 text-white' : 'bg-white/5 text-white/80 hover:bg-white/10'
+                }`}
+              >
+                <span className="truncate">{option.name}</span>
+                <span
+                  className="ml-2 w-5 h-5 rounded-full border border-white/30"
+                  style={{ background: swatch }}
+                />
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <div
+      ref={hostRef}
+      className="w-full h-[100dvh] bg-black relative overflow-hidden select-none"
+      style={{ touchAction: 'none', overscrollBehavior: 'none' }}
+    >
+      <div
+        className={`absolute left-2 right-2 z-30 grid grid-cols-2 items-center gap-2 text-white ${
+          isTopDownView ? 'bottom-12' : ''
+        }`}
+        style={isTopDownView ? undefined : { top: `${2.35 + HUD_VERTICAL_SHIFT_REM - HUD_TOP_ROW_LIFT_REM}rem` }}
+      >
+        <div
+          className="flex items-center gap-2 rounded bg-white/10 px-2 py-1 text-xs cursor-pointer"
+          data-player-index="0"
+          data-self-player="true"
+          role="button"
+          tabIndex={0}
+          aria-label={liveMode ? 'Turn off live avatar video' : 'Turn on live avatar video'}
+          onClick={toggleLiveFromAvatar}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault();
+              toggleLiveFromAvatar();
+            }
+          }}
+        >
+          {liveMode ? (
+            <video
+              ref={topLiveVideoRef}
+              autoPlay
+              playsInline
+              muted
+              className="h-10 w-10 rounded-full border border-emerald-300/70 object-cover bg-black scale-x-[-1]"
+            />
+          ) : (
+            <img
+              src={getAvatarUrl(player.avatar)}
+              alt=""
+              className="h-5 w-5 rounded-full object-cover"
+            />
+          )}
+          <span className="truncate">
+            {player.name}: {ui.left}
+            {liveMode ? <span className="ml-1 text-emerald-200">• Live</span> : null}
+          </span>
+        </div>
+        <div
+          className="flex items-center justify-end gap-2 rounded bg-white/10 px-2 py-1 text-xs"
+          data-player-index="1"
+        >
+          <span className="truncate text-right">
+            {ui.right}: {ai.name}
+          </span>
+          <img
+            src={getAvatarUrl(ai.avatar)}
+            alt=""
+            className="h-5 w-5 rounded-full object-cover"
+          />
+        </div>
+      </div>
+      <div
+        className={`absolute z-40 text-white text-[10px] bg-white/10 rounded px-3 py-1 backdrop-blur ${
+          isTopDownView ? 'left-1/2 -translate-x-1/2 bottom-4' : 'left-1/2 -translate-x-1/2'
+        }`}
+        style={
+          isTopDownView
+            ? undefined
+            : {
+                top: `${HUD_ICON_ROW_TOP_REM + HUD_VERTICAL_SHIFT_REM - HUD_TOP_ROW_LIFT_REM + AIR_HOCKEY_TARGET_CENTER_TOP_TWEAK_REM}rem`
+              }
+        }
+      >
+        <span className="uppercase tracking-wide">{playType}</span>
+        <span className="mx-2">•</span>
+        <span>Target: {targetValue}</span>
+      </div>
+      <button
+        type="button"
+        onClick={() => setShowCustomizer((prev) => !prev)}
+        className={`absolute z-40 pointer-events-auto flex items-center gap-2 rounded-full border border-white/15 bg-black/60 px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-gray-100 shadow-[0_6px_18px_rgba(2,6,23,0.45)] transition hover:border-white/30 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 ${
+          showCustomizer ? 'bg-black/60' : 'hover:bg-black/60'
+        }`}
+        style={
+          isTopDownView
+            ? {
+                left: '50%',
+                top: `${HUD_ICON_ROW_TOP_REM + HUD_VERTICAL_SHIFT_REM - HUD_TOP_ROW_LIFT_REM - 0.35 + AIR_HOCKEY_MENU_TOP_TWEAK_REM}rem`,
+                transform: 'translateX(-50%)'
+              }
+            : {
+                left: `${HUD_MENU_LEFT_REM}rem`,
+                top: `${HUD_ICON_ROW_TOP_REM + HUD_VERTICAL_SHIFT_REM - HUD_TOP_ROW_LIFT_REM - 0.35 + AIR_HOCKEY_MENU_TOP_TWEAK_REM}rem`
+              }
+        }
+        aria-label={showCustomizer ? 'Close menu' : 'Open menu'}
+      >
+        <span className="text-lg leading-none" aria-hidden="true">☰</span>
+        <span className="leading-none">Menu</span>
+      </button>
+      <div
+        className={`absolute z-20 flex flex-col gap-3 pointer-events-auto ${
+          isTopDownView
+            ? 'left-3 top-[45%] -translate-y-1/2 items-center'
+            : 'bottom-2 left-2 items-start'
+        }`}
+      >
+        <button
+          type="button"
+          onClick={() => setShowChat(true)}
+          className="flex flex-col items-center rounded bg-transparent px-2 py-1 text-[10px] font-semibold text-white hover:bg-white/10"
+        >
+          <span className="text-xl">💬</span>
+          <span>Chat</span>
+        </button>
+        {isTopDownView ? (
+          <>
+            <button
+              type="button"
+              onClick={() => {
+                toggleGameMuted();
+                setMuted(isGameMuted());
+              }}
+              className="flex items-center justify-center rounded bg-transparent px-2 py-1 text-[10px] font-semibold text-white hover:bg-white/10"
+              aria-label={muted ? 'Unmute' : 'Mute'}
+            >
+              <span className="text-xl">{muted ? '🔇' : '🔊'}</span>
+            </button>
+            <button
+              type="button"
+              onClick={() => setShowGift(true)}
+              className="flex flex-col items-center rounded bg-transparent px-2 py-1 text-[10px] font-semibold text-white hover:bg-white/10"
+            >
+              <span className="text-xl">🎁</span>
+              <span>Gift</span>
+            </button>
+          </>
+        ) : null}
+      </div>
+      {!isTopDownView && (
+        <>
+          <div
+            className="absolute right-3 z-40 flex flex-col items-center gap-1"
+            style={{
+              top: `${3.7 + HUD_VERTICAL_SHIFT_REM - HUD_TOP_ROW_LIFT_REM + AIR_HOCKEY_RIGHT_ICON_STACK_DOWN_REM}rem`
+            }}
+          >
+            <button
+              type="button"
+              onClick={() => {
+                toggleGameMuted();
+                setMuted(isGameMuted());
+              }}
+              className="flex items-center justify-center rounded bg-transparent px-2 py-1 text-[10px] font-semibold text-white hover:bg-white/10"
+              aria-label={muted ? 'Unmute' : 'Mute'}
+            >
+              <span className="text-xl">{muted ? '🔇' : '🔊'}</span>
+            </button>
+            <button
+              type="button"
+              aria-pressed={isTopDownView}
+              onClick={() => setIsTopDownView((prev) => !prev)}
+              className={`rounded px-3 py-2 text-xs font-semibold backdrop-blur border transition ${
+                isTopDownView
+                  ? 'border-emerald-300 bg-emerald-300/20 text-emerald-100'
+                  : 'border-white/15 bg-white/10 text-white hover:bg-white/20'
+              }`}
+            >
+              <span className="inline-flex items-center gap-1">
+                <span aria-hidden>🧭</span>
+                <span>{isTopDownView ? '3D' : '2D'}</span>
+              </span>
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                const nextLift = clamp(cameraLiftUi + CAMERA_LIFT_STEP, CAMERA_LIFT_MIN, CAMERA_LIFT_MAX);
+                setCameraLiftUi(nextLift);
+                cameraViewRef.current.applyCurrent?.(false, nextLift);
+              }}
+              className="rounded border border-white/15 bg-white/10 px-2 py-1 text-lg leading-none text-white transition hover:bg-white/20"
+              aria-label="Lift camera angle up"
+              title="Camera up"
+            >
+              ▲
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                const nextLift = clamp(cameraLiftUi - CAMERA_LIFT_STEP, CAMERA_LIFT_MIN, CAMERA_LIFT_MAX);
+                setCameraLiftUi(nextLift);
+                cameraViewRef.current.applyCurrent?.(false, nextLift);
+              }}
+              className="rounded border border-white/15 bg-white/10 px-2 py-1 text-lg leading-none text-white transition hover:bg-white/20"
+              aria-label="Lower camera angle down"
+              title="Camera down"
+            >
+              ▼
+            </button>
+          </div>
+        </>
+      )}
+      <div className="absolute bottom-2 right-2 flex flex-col items-end space-y-2 z-20">
+        {!isTopDownView && (
+          <button
+            type="button"
+            onClick={() => setShowGift(true)}
+            className="flex flex-col items-center rounded bg-transparent px-2 py-1 text-[10px] font-semibold text-white hover:bg-white/10"
+          >
+            <span className="text-xl">🎁</span>
+            <span>Gift</span>
+          </button>
+        )}
+        {isTopDownView && (
+          <button
+            type="button"
+            aria-pressed={isTopDownView}
+            onClick={() => setIsTopDownView((prev) => !prev)}
+            className="rounded px-3 py-2 text-xs font-semibold backdrop-blur border transition border-emerald-300 bg-emerald-300/20 text-emerald-100"
+          >
+            <span className="inline-flex items-center gap-1">
+              <span aria-hidden>🧭</span>
+              <span>3D</span>
+            </span>
+          </button>
+        )}
+        {showCustomizer && (
+          <div className="w-72 max-h-[70vh] overflow-y-auto bg-black/70 border border-white/15 rounded-lg p-3 space-y-3 backdrop-blur">
+            <div className="rounded-xl border border-white/10 bg-white/5 p-3">
+              <div>
+                <p className="text-[10px] uppercase tracking-[0.35em] text-white/70">Graphics</p>
+                <p className="mt-1 text-[0.7rem] text-white/60">Match the Murlan Royale quality presets.</p>
+              </div>
+              <div className="mt-2 grid gap-2">
+                {GRAPHICS_OPTIONS.map((option) => {
+                  const active = option.id === graphicsId;
+                  return (
+                    <button
+                      key={option.id}
+                      type="button"
+                      onClick={() => setGraphicsId(option.id)}
+                      aria-pressed={active}
+                      className={`w-full rounded-2xl border px-3 py-2 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
+                        active
+                          ? 'border-sky-300 bg-sky-300/15 shadow-[0_0_12px_rgba(125,211,252,0.35)]'
+                          : 'border-white/10 bg-white/5 hover:border-white/20 text-white/80'
+                      }`}
+                    >
+                      <span className="flex items-center justify-between gap-2">
+                        <span className="text-[11px] font-semibold uppercase tracking-[0.26em] text-white">
+                          {option.label}
+                        </span>
+                        <span className="text-[11px] font-semibold tracking-wide text-sky-100">
+                          {option.resolution ? `${option.resolution} • ${option.fps} FPS` : `${option.fps} FPS`}
+                        </span>
+                      </span>
+                      {option.description ? (
+                        <span className="mt-1 block text-[10px] uppercase tracking-[0.2em] text-white/60">
+                          {option.description}
+                        </span>
+                      ) : null}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+            <div className="rounded-xl border border-white/10 bg-white/5 p-3">
+              <div>
+                <p className="text-[10px] uppercase tracking-[0.35em] text-white/70">Commentary</p>
+              </div>
+              <div className="mt-2 grid gap-2">
+                {AIR_HOCKEY_COMMENTARY_PRESETS.map((preset) => {
+                  const active = preset.id === commentaryPresetId;
+                  return (
+                    <button
+                      key={preset.id}
+                      type="button"
+                      onClick={() => setCommentaryPresetId(preset.id)}
+                      aria-pressed={active}
+                      disabled={!commentarySupported}
+                      className={`w-full rounded-2xl border px-3 py-2 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
+                        active
+                          ? 'border-sky-300 bg-sky-300/15 shadow-[0_0_12px_rgba(125,211,252,0.35)]'
+                          : 'border-white/10 bg-white/5 hover:border-white/20 text-white/80'
+                      } ${commentarySupported ? '' : 'cursor-not-allowed opacity-60'}`}
+                    >
+                      <span className="flex items-center justify-between gap-2">
+                        <span className="text-[11px] font-semibold uppercase tracking-[0.26em] text-white">{preset.label}</span>
+                        {active && (
+                          <span className="rounded-full border border-sky-200/70 px-2 py-0.5 text-[9px] tracking-[0.3em] text-sky-100">
+                            Active
+                          </span>
+                        )}
+                      </span>
+                      <span className="mt-1 block text-[10px] uppercase tracking-[0.2em] text-white/60">
+                        {preset.description}
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+              <button
+                type="button"
+                onClick={() => setCommentaryMuted((prev) => !prev)}
+                aria-pressed={commentaryMuted}
+                disabled={!commentarySupported}
+                className={`mt-2 flex w-full items-center justify-between gap-3 rounded-full px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.24em] transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
+                  commentaryMuted
+                    ? 'bg-sky-300 text-slate-900 shadow-[0_0_12px_rgba(125,211,252,0.35)]'
+                    : 'bg-white/10 text-white/80 hover:bg-white/20'
+                } ${commentarySupported ? '' : 'cursor-not-allowed opacity-60'}`}
+              >
+                <span>Mute commentary</span>
+                <span
+                  className={`rounded-full border px-2 py-0.5 text-[10px] tracking-[0.3em] ${
+                    commentaryMuted ? 'border-black/30 text-black/70' : 'border-white/30 text-white/70'
+                  }`}
+                >
+                  {commentaryMuted ? 'On' : 'Off'}
+                </span>
+              </button>
+              {!commentarySupported && (
+                <p className="mt-2 text-[0.65rem] text-white/60">
+                  Voice commentary needs Web Speech support.
+                </p>
+              )}
+            </div>
+            {renderOptionRow('Field Surface', 'field')}
+            {renderOptionRow('Cushion Cloth', 'cushionCloth')}
+            {renderOptionRow('Table Finish', 'table')}
+            {renderOptionRow('Table Base', 'tableBase')}
+            {renderOptionRow('HDRI Environment', 'environmentHdri')}
+            {renderOptionRow(gameVariant.optionLabels.puck, 'puck')}
+            {renderOptionRow(gameVariant.optionLabels.mallet, 'mallet')}
+            {renderOptionRow('Goals', 'goals')}
+          </div>
+        )}
+      </div>
+      {goalPopup && (
+        <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+          <div
+            className={`text-center drop-shadow-[0_0_12px_rgba(0,0,0,0.9)] px-4 py-3 rounded-lg bg-black/50 border border-white/10 ${goalPopup.isPlayer ? 'text-emerald-200' : 'text-amber-200'}`}
+          >
+            <div className="text-4xl font-extrabold tracking-[0.2em] uppercase">Goal!</div>
+            <div className="text-lg font-semibold mt-1">{goalPopup.scorer}</div>
+            <div className="text-sm font-semibold mt-1">Score: {goalPopup.scoreLine}</div>
+          </div>
+        </div>
+      )}
+      {postPopup && !goalPopup && (
+        <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+          <div className="text-center text-amber-200 text-3xl font-extrabold uppercase tracking-[0.15em] drop-shadow-[0_0_12px_rgba(0,0,0,0.9)] bg-black/50 border border-white/10 rounded-lg px-4 py-2">
+            Post!
+          </div>
+        </div>
+      )}
+      {chatBubbles.map((bubble) => (
+        <div key={bubble.id} className="chat-bubble">
+          <span>{bubble.text}</span>
+          <img src={bubble.photoUrl} alt="avatar" className="w-5 h-5 rounded-full" />
+        </div>
+      ))}
+      <div className="pointer-events-auto">
+        <QuickMessagePopup
+          open={showChat}
+          onClose={() => setShowChat(false)}
+          onSend={(text) => {
+            const id = Date.now();
+            setChatBubbles((bubbles) => [...bubbles, { id, text, photoUrl: chatAvatar }]);
+            if (!muted) {
+              const audio = new Audio(chatBeep);
+              audio.volume = getGameVolume();
+              audio.play().catch(() => {});
+            }
+            setTimeout(
+              () => setChatBubbles((bubbles) => bubbles.filter((bubble) => bubble.id !== id)),
+              3000
+            );
+          }}
+        />
+      </div>
+      <LiveVideoChatPanel
+        open={showLivePanel && liveMode}
+        onClose={() => {
+          setShowLivePanel(false);
+        }}
+        roomId={liveChatRoomId}
+        localStream={liveChat.localStream}
+        localMediaState={liveChat.mediaState}
+        remotePeers={liveChat.remotePeers}
+        isConnected={liveChat.isConnected}
+        error={liveChat.error}
+        onStart={() => {
+          setLiveMode(true);
+          liveChat.startLiveChat();
+        }}
+        onStop={() => {
+          liveChat.stopLiveChat();
+          setLiveMode(false);
+          setShowLivePanel(false);
+        }}
+        onToggleMicrophone={liveChat.toggleMicrophone}
+        onToggleCamera={liveChat.toggleCamera}
+      />
+      <div className="pointer-events-auto">
+        <GiftPopup
+          open={showGift}
+          onClose={() => setShowGift(false)}
+          players={giftPlayers}
+          senderIndex={0}
+          onGiftSent={({ from, to, gift }) => {
+            const start = document.querySelector(`[data-player-index="${from}"]`);
+            const end = document.querySelector(`[data-player-index="${to}"]`);
+            if (start && end) {
+              const s = start.getBoundingClientRect();
+              const e = end.getBoundingClientRect();
+              const cx = window.innerWidth / 2;
+              const cy = window.innerHeight / 2;
+              let icon;
+              if (typeof gift.icon === 'string' && gift.icon.match(/\.(png|jpg|jpeg|webp|svg)$/)) {
+                icon = document.createElement('img');
+                icon.src = gift.icon;
+                icon.className = 'w-5 h-5';
+              } else {
+                icon = document.createElement('div');
+                icon.textContent = gift.icon;
+                icon.style.fontSize = '24px';
+              }
+              icon.style.position = 'fixed';
+              icon.style.left = '0px';
+              icon.style.top = '0px';
+              icon.style.pointerEvents = 'none';
+              icon.style.transform = `translate(${s.left + s.width / 2}px, ${s.top + s.height / 2}px) scale(1)`;
+              icon.style.zIndex = '9999';
+              document.body.appendChild(icon);
+              const giftSound = giftSounds[gift.id];
+              if (gift.id === 'laugh_bomb' && !muted) {
+                bombSoundRef.current.currentTime = 0;
+                bombSoundRef.current.play().catch(() => {});
+                hahaSoundRef.current.currentTime = 0;
+                hahaSoundRef.current.play().catch(() => {});
+                setTimeout(() => {
+                  hahaSoundRef.current.pause();
+                }, 5000);
+              } else if (gift.id === 'coffee_boost' && !muted) {
+                const audio = new Audio(giftSound);
+                audio.volume = getGameVolume();
+                audio.currentTime = 4;
+                audio.play().catch(() => {});
+                setTimeout(() => {
+                  audio.pause();
+                }, 4000);
+              } else if (gift.id === 'baby_chick' && !muted) {
+                const audio = new Audio(giftSound);
+                audio.volume = getGameVolume();
+                audio.play().catch(() => {});
+              } else if (gift.id === 'magic_trick' && !muted) {
+                const audio = new Audio(giftSound);
+                audio.volume = getGameVolume();
+                audio.play().catch(() => {});
+                setTimeout(() => {
+                  audio.pause();
+                }, 4000);
+              } else if (gift.id === 'fireworks' && !muted) {
+                const audio = new Audio(giftSound);
+                audio.volume = getGameVolume();
+                audio.play().catch(() => {});
+                setTimeout(() => {
+                  audio.pause();
+                }, 6000);
+              } else if (gift.id === 'surprise_box' && !muted) {
+                const audio = new Audio(giftSound);
+                audio.volume = getGameVolume();
+                audio.play().catch(() => {});
+                setTimeout(() => {
+                  audio.pause();
+                }, 5000);
+              } else if (gift.id === 'bullseye' && !muted) {
+                const audio = new Audio(giftSound);
+                audio.volume = getGameVolume();
+                setTimeout(() => {
+                  audio.play().catch(() => {});
+                }, 2500);
+              } else if (giftSound && !muted) {
+                const audio = new Audio(giftSound);
+                audio.volume = getGameVolume();
+                audio.play().catch(() => {});
+              }
+              const animation = icon.animate(
+                [
+                  { transform: `translate(${s.left + s.width / 2}px, ${s.top + s.height / 2}px) scale(1)` },
+                  { transform: `translate(${cx}px, ${cy}px) scale(3)`, offset: 0.5 },
+                  { transform: `translate(${e.left + e.width / 2}px, ${e.top + e.height / 2}px) scale(1)` }
+                ],
+                { duration: 3500, easing: 'linear' }
+              );
+              animation.onfinish = () => icon.remove();
+            }
+          }}
+        />
+      </div>
+      {gameOver && (
+        <div className="absolute inset-0 flex items-center justify-center bg-black/70 text-white text-center px-4">
+          <div className="rounded-lg border border-white/10 bg-white/5 px-5 py-4 space-y-2 max-w-sm w-full">
+            <div className="text-lg font-semibold">Game Over</div>
+            <div className="text-sm font-medium">Winner: {winner}</div>
+            <div className="text-xs text-white/80">Final Score: {scoreRef.current.left} - {scoreRef.current.right}</div>
+            <div className="text-[11px] text-white/70">
+              {redirecting ? `Redirecting to the ${gameVariant.lobbyLabel} lobby...` : 'Preparing lobby return...'}
+            </div>
+            <div className="pt-2">
+              <button
+                onClick={() => (window.location.href = gameVariant.lobbyPath)}
+                className="w-full rounded bg-emerald-500/90 hover:bg-emerald-500 text-black font-semibold py-2 text-sm"
+              >
+                Go to Lobby
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/webapp/src/config/goalRushInventoryConfig.js
+++ b/webapp/src/config/goalRushInventoryConfig.js
@@ -1,0 +1,734 @@
+import { POOL_ROYALE_CLOTH_VARIANTS } from './poolRoyaleClothPresets.js';
+import { khronosThumb, polyHavenThumb, swatchThumbnail } from './storeThumbnails.js';
+
+const GOAL_RUSH_HDRI_PLACEMENTS = Object.freeze({
+  neonPhotostudio: {
+    cameraHeightM: 1.52,
+    groundRadiusMultiplier: 3.8,
+    groundResolution: 120,
+    arenaScale: 1.1
+  },
+  colorfulStudio: {
+    cameraHeightM: 1.5,
+    groundRadiusMultiplier: 4,
+    groundResolution: 120,
+    arenaScale: 1.15,
+    rotationY: Math.PI / 2
+  },
+  dancingHall: {
+    cameraHeightM: 1.58,
+    groundRadiusMultiplier: 5,
+    groundResolution: 112,
+    arenaScale: 1.3
+  },
+  abandonedHall: {
+    cameraHeightM: 1.6,
+    groundRadiusMultiplier: 5.2,
+    groundResolution: 112,
+    arenaScale: 1.25
+  },
+  mirroredHall: {
+    cameraHeightM: 1.58,
+    groundRadiusMultiplier: 5,
+    groundResolution: 112,
+    arenaScale: 1.25
+  },
+  musicHall02: {
+    cameraHeightM: 1.6,
+    groundRadiusMultiplier: 5.2,
+    groundResolution: 112,
+    arenaScale: 1.3
+  },
+  oldHall: {
+    cameraHeightM: 1.58,
+    groundRadiusMultiplier: 5,
+    groundResolution: 112,
+    arenaScale: 1.22
+  },
+  blockyPhotoStudio: {
+    cameraHeightM: 1.5,
+    groundRadiusMultiplier: 3.9,
+    groundResolution: 120,
+    arenaScale: 1.14,
+    rotationY: -Math.PI / 2
+  },
+  cycloramaHardLight: {
+    cameraHeightM: 1.5,
+    groundRadiusMultiplier: 3.8,
+    groundResolution: 120,
+    arenaScale: 1.15
+  },
+  abandonedGarage: {
+    cameraHeightM: 1.6,
+    groundRadiusMultiplier: 5.1,
+    groundResolution: 112,
+    arenaScale: 1.26,
+    rotationY: Math.PI / 2
+  },
+  vestibule: {
+    cameraHeightM: 1.56,
+    groundRadiusMultiplier: 4.7,
+    groundResolution: 112,
+    arenaScale: 1.2,
+    rotationY: 0
+  },
+  countryClub: {
+    cameraHeightM: 1.58,
+    groundRadiusMultiplier: 4.9,
+    groundResolution: 112,
+    arenaScale: 1.24,
+    rotationY: Math.PI
+  },
+  sepulchralChapelRotunda: {
+    cameraHeightM: 1.62,
+    groundRadiusMultiplier: 5.6,
+    groundResolution: 112,
+    arenaScale: 1.32
+  },
+  squashCourt: {
+    cameraHeightM: 1.5,
+    groundRadiusMultiplier: 4.1,
+    groundResolution: 120,
+    arenaScale: 1.18,
+    rotationY: Math.PI / 2
+  }
+});
+
+const RAW_GOAL_RUSH_HDRI_VARIANTS = [
+  {
+    id: 'neonPhotostudio',
+    name: 'Neon Photo Studio',
+    assetId: 'neon_photostudio',
+    preferredResolutions: ['4k'],
+    fallbackResolution: '4k',
+    price: 1420,
+    exposure: 1.18,
+    environmentIntensity: 1.12,
+    backgroundIntensity: 1.06,
+    swatches: ['#0ea5e9', '#8b5cf6'],
+    description: 'Vibrant cyber studio wrap with strong rim accents.'
+  },
+  {
+    id: 'colorfulStudio',
+    name: 'Colorful Studio',
+    assetId: 'colorful_studio',
+    preferredResolutions: ['4k'],
+    fallbackResolution: '4k',
+    price: 0,
+    exposure: 1.02,
+    environmentIntensity: 0.92,
+    backgroundIntensity: 0.92,
+    swatches: ['#ec4899', '#a855f7'],
+    description: 'Playful multi-hue studio for glossy highlight variety.'
+  },
+  {
+    id: 'dancingHall',
+    name: 'Dancing Hall',
+    assetId: 'dancing_hall',
+    preferredResolutions: ['4k'],
+    fallbackResolution: '4k',
+    price: 1840,
+    exposure: 1.12,
+    environmentIntensity: 1.08,
+    backgroundIntensity: 1.04,
+    swatches: ['#22c55e', '#f97316'],
+    description: 'Spacious dance hall bounce light for soft, even sheen.'
+  },
+  {
+    id: 'abandonedHall',
+    name: 'Abandoned Hall',
+    assetId: 'abandoned_hall_01',
+    preferredResolutions: ['4k'],
+    fallbackResolution: '4k',
+    price: 1860,
+    exposure: 1.08,
+    environmentIntensity: 1.05,
+    backgroundIntensity: 0.98,
+    swatches: ['#64748b', '#0f172a'],
+    description: 'Moody derelict hall with soft overhead spill and cool shadows.'
+  },
+  {
+    id: 'mirroredHall',
+    name: 'Mirrored Hall',
+    assetId: 'mirrored_hall',
+    preferredResolutions: ['4k'],
+    fallbackResolution: '4k',
+    price: 2020,
+    exposure: 1.15,
+    environmentIntensity: 1.12,
+    backgroundIntensity: 1.06,
+    swatches: ['#22c55e', '#10b981'],
+    description: 'Reflective hall with bright symmetrical highlights for chrome polish.'
+  },
+  {
+    id: 'musicHall02',
+    name: 'Music Hall 02',
+    assetId: 'music_hall_02',
+    preferredResolutions: ['4k'],
+    fallbackResolution: '4k',
+    price: 2060,
+    exposure: 1.11,
+    environmentIntensity: 1.08,
+    backgroundIntensity: 1.04,
+    swatches: ['#a855f7', '#2563eb'],
+    description: 'Alternate music hall mood with richer purple-blue spill and soft roof glow.'
+  },
+  {
+    id: 'oldHall',
+    name: 'Old Hall',
+    assetId: 'old_hall',
+    preferredResolutions: ['4k'],
+    fallbackResolution: '4k',
+    price: 2080,
+    exposure: 1.08,
+    environmentIntensity: 1.05,
+    backgroundIntensity: 0.99,
+    swatches: ['#78350f', '#fbbf24'],
+    description: 'Vintage hall ambience with warm wood bounce and subtle window fill.'
+  },
+  {
+    id: 'blockyPhotoStudio',
+    name: 'Blocky Photo Studio',
+    assetId: 'blocky_photo_studio',
+    preferredResolutions: ['4k'],
+    fallbackResolution: '4k',
+    price: 2200,
+    exposure: 1.12,
+    environmentIntensity: 1.1,
+    backgroundIntensity: 1.05,
+    swatches: ['#60a5fa', '#a855f7'],
+    description: 'Graphic studio blocks with crisp edges and balanced bounce.'
+  },
+  {
+    id: 'cycloramaHardLight',
+    name: 'Cyclorama Hard Light',
+    assetId: 'cyclorama_hard_light',
+    preferredResolutions: ['4k'],
+    fallbackResolution: '4k',
+    price: 2260,
+    exposure: 1.16,
+    environmentIntensity: 1.12,
+    backgroundIntensity: 1.08,
+    swatches: ['#f8fafc', '#94a3b8'],
+    description: 'Studio cyc with punchy hard light and sharp specular falloff.'
+  },
+  {
+    id: 'abandonedGarage',
+    name: 'Abandoned Garage',
+    assetId: 'abandoned_garage',
+    preferredResolutions: ['4k'],
+    fallbackResolution: '4k',
+    price: 2340,
+    exposure: 1.07,
+    environmentIntensity: 1.04,
+    backgroundIntensity: 0.98,
+    swatches: ['#334155', '#94a3b8'],
+    description: 'Gritty garage mood with diffused skylight and cool steel reflections.'
+  },
+  {
+    id: 'vestibule',
+    name: 'Vestibule',
+    assetId: 'vestibule',
+    preferredResolutions: ['4k'],
+    fallbackResolution: '4k',
+    price: 2360,
+    exposure: 1.1,
+    environmentIntensity: 1.06,
+    backgroundIntensity: 1.02,
+    swatches: ['#e2e8f0', '#64748b'],
+    description: 'Elegant entry lighting with neutral stone bounce and soft fill.'
+  },
+  {
+    id: 'countryClub',
+    name: 'Country Club',
+    assetId: 'country_club',
+    preferredResolutions: ['4k'],
+    fallbackResolution: '4k',
+    price: 2380,
+    exposure: 1.11,
+    environmentIntensity: 1.08,
+    backgroundIntensity: 1.03,
+    swatches: ['#f8fafc', '#22c55e'],
+    description: 'Upscale lounge ambience with bright daylight and warm interiors.'
+  },
+  {
+    id: 'sepulchralChapelRotunda',
+    name: 'Sepulchral Chapel Rotunda',
+    assetId: 'sepulchral_chapel_rotunda',
+    preferredResolutions: ['4k'],
+    fallbackResolution: '4k',
+    price: 2480,
+    exposure: 1.06,
+    environmentIntensity: 1.03,
+    backgroundIntensity: 0.98,
+    swatches: ['#1f2937', '#6b7280'],
+    description: 'Stone rotunda with dramatic overhead light and deep shadows.'
+  },
+  {
+    id: 'squashCourt',
+    name: 'Squash Court',
+    assetId: 'squash_court',
+    preferredResolutions: ['4k'],
+    fallbackResolution: '4k',
+    price: 2440,
+    exposure: 1.1,
+    environmentIntensity: 1.06,
+    backgroundIntensity: 1.02,
+    swatches: ['#f8fafc', '#f97316'],
+    description: 'Bright court lighting with clean white walls and strong bounce.'
+  }
+];
+
+const HDRI_RESOLUTION_STACK = Object.freeze(['4k']);
+
+const GOAL_RUSH_HDRI_VARIANTS = Object.freeze(
+  RAW_GOAL_RUSH_HDRI_VARIANTS.map((variant) => ({
+    ...variant,
+    preferredResolutions: HDRI_RESOLUTION_STACK,
+    thumbnail: polyHavenThumb(variant.assetId),
+    ...(GOAL_RUSH_HDRI_PLACEMENTS[variant.id] || {})
+  }))
+);
+
+const TABLE_FINISH_THUMBNAILS = Object.freeze({
+  peelingPaintWeathered: polyHavenThumb('wood_peeling_paint_weathered'),
+  oakVeneer01: polyHavenThumb('oak_veneer_01'),
+  woodTable001: polyHavenThumb('wood_table_001'),
+  darkWood: polyHavenThumb('dark_wood'),
+  rosewoodVeneer01: polyHavenThumb('rosewood_veneer_01')
+});
+
+const TABLE_BASE_THUMBNAILS = Object.freeze({
+  classicCylinders: swatchThumbnail(['#8f6243', '#6f3a2f', '#fef3c7']),
+  openPortal: swatchThumbnail(['#f8fafc', '#e5e7eb', '#93c5fd']),
+  coffeeTableRound01: polyHavenThumb('coffee_table_round_01'),
+  gothicCoffeeTable: polyHavenThumb('gothic_coffee_table'),
+  woodenTable02Alt: polyHavenThumb('wooden_table_02')
+});
+
+const FIELD_THUMBNAILS = Object.freeze({
+  'bust-marble': polyHavenThumb('marble_bust_01'),
+  'bust-onyx': polyHavenThumb('marble_bust_01'),
+  'clearcoat-ruby': khronosThumb('ClearCoatCarPaint'),
+  'clearcoat-azure': khronosThumb('ClearCoatCarPaint')
+});
+
+const GOAL_RUSH_TABLE_FINISHES = Object.freeze([
+  Object.freeze({
+    id: 'peelingPaintWeathered',
+    name: 'Wood Peeling Paint Weathered',
+    wood: '#b8b3aa',
+    trim: '#d6d0c7',
+    woodTextureId: 'wood_peeling_paint_weathered',
+    swatches: ['#a89f95', '#b8b3aa'],
+    price: 980,
+    description: 'Weathered peeling paint wood rails with a reclaimed finish.'
+  }),
+  Object.freeze({
+    id: 'oakVeneer01',
+    name: 'Oak Veneer 01',
+    wood: '#c89a64',
+    trim: '#e0bb7a',
+    woodTextureId: 'oak_veneer_01',
+    swatches: ['#b9854e', '#c89a64'],
+    price: 990,
+    description: 'Warm oak veneer rails with smooth satin polish.'
+  }),
+  Object.freeze({
+    id: 'woodTable001',
+    name: 'Wood Table 001',
+    wood: '#a4724f',
+    trim: '#c89a64',
+    woodTextureId: 'wood_table_001',
+    swatches: ['#8f6243', '#a4724f'],
+    price: 1000,
+    description: 'Balanced walnut-brown rails inspired by classic table slabs.'
+  }),
+  Object.freeze({
+    id: 'darkWood',
+    name: 'Dark Wood',
+    wood: '#3d2f2a',
+    trim: '#6a5a52',
+    woodTextureId: 'dark_wood',
+    swatches: ['#2f241f', '#3d2f2a'],
+    price: 1010,
+    description: 'Deep espresso rails with strong grain contrast.'
+  }),
+  Object.freeze({
+    id: 'rosewoodVeneer01',
+    name: 'Rosewood Veneer 01',
+    wood: '#6f3a2f',
+    trim: '#9b5a44',
+    woodTextureId: 'rosewood_veneer_01',
+    swatches: ['#5b2f26', '#6f3a2f'],
+    price: 1020,
+    description: 'Rosewood veneer rails with rich, reddish undertones.'
+  })
+]);
+
+const GOAL_RUSH_TABLE_BASES = Object.freeze([
+  Object.freeze({
+    id: 'classicCylinders',
+    name: 'Classic Cylinders',
+    description: 'Rounded skirt with six cylinder legs and subtle foot pads.',
+    base: '#8f6243',
+    accent: '#6f3a2f',
+    swatches: ['#8f6243', '#6f3a2f']
+  }),
+  Object.freeze({
+    id: 'openPortal',
+    name: 'Open Portal',
+    description: 'Twin portal legs with angled sides and negative space.',
+    base: '#f8fafc',
+    accent: '#e5e7eb',
+    swatches: ['#f8fafc', '#e5e7eb']
+  }),
+  Object.freeze({
+    id: 'coffeeTableRound01',
+    name: 'Coffee Table Round 01 Base',
+    description: 'Rounded Poly Haven coffee table legs tucked beneath the pool table.',
+    base: '#c5a47e',
+    accent: '#7a5534',
+    swatches: ['#c5a47e', '#7a5534']
+  }),
+  Object.freeze({
+    id: 'gothicCoffeeTable',
+    name: 'Gothic Coffee Table Base',
+    description: 'Gothic coffee table from Murlan Royale re-used as a sculpted support base.',
+    base: '#8f4a2b',
+    accent: '#3b2a1f',
+    swatches: ['#8f4a2b', '#3b2a1f']
+  }),
+  Object.freeze({
+    id: 'woodenTable02Alt',
+    name: 'Wooden Table 02 Alt Base',
+    description: 'Alternate Wooden Table 02 variant resized to cradle the pool playfield.',
+    base: '#6f5140',
+    accent: '#caa07a',
+    swatches: ['#6f5140', '#caa07a']
+  })
+].map((variant) => ({
+  ...variant,
+  thumbnail: TABLE_BASE_THUMBNAILS[variant.id]
+})));
+
+const createPolyHavenGltfUrls = (assetId, size = '2k') =>
+  Object.freeze([
+    `https://dl.polyhaven.org/file/ph-assets/Models/gltf/${size}/${assetId}/${assetId}_${size}.gltf`,
+    `https://dl.polyhaven.org/file/ph-assets/Models/gltf/1k/${assetId}/${assetId}_1k.gltf`
+  ]);
+
+const createKhronosGltfUrls = (assetId) =>
+  Object.freeze([
+    `https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/${assetId}/glTF-Binary/${assetId}.glb`,
+    `https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Assets@main/Models/${assetId}/glTF-Binary/${assetId}.glb`
+  ]);
+
+const GOAL_RUSH_MARBLE_FIELDS = Object.freeze([
+  Object.freeze({
+    id: 'poolRoyalGreenCloth',
+    name: 'Pool Royal Green Cloth',
+    color: '#47a35d',
+    swatches: ['#47a35d', '#66ce78', '#347b4b'],
+    lineColor: '#d1fae5',
+    roughness: 0.86,
+    metalness: 0.04,
+    clearcoat: 0.1,
+    clearcoatRoughness: 0.72,
+    description: 'Goal Rush field cloth aligned to the Pool Royal green cloth finish.'
+  }),
+  Object.freeze({
+    id: 'bust-marble',
+    name: 'Marble Bust',
+    gltfUrls: createPolyHavenGltfUrls('marble_bust_01'),
+    swatches: ['#f5f5f4', '#d6d3d1'],
+    repeat: 1,
+    lineColor: '#f8fafc',
+    roughness: 0.26,
+    clearcoat: 0.28,
+    clearcoatRoughness: 0.2,
+    description: 'CC0 Poly Haven marble bust model re-used as a surface material with authentic stone textures.'
+  }),
+  Object.freeze({
+    id: 'bust-onyx',
+    name: 'Onyx Bust',
+    gltfUrls: createPolyHavenGltfUrls('marble_bust_01'),
+    swatches: ['#111827', '#374151'],
+    color: '#0f172a',
+    repeat: 1,
+    lineColor: '#e5e7eb',
+    roughness: 0.3,
+    clearcoat: 0.26,
+    clearcoatRoughness: 0.22,
+    description: 'Deep onyx tint based on the open-source Poly Haven marble bust materials.'
+  }),
+  Object.freeze({
+    id: 'clearcoat-ruby',
+    name: 'Clearcoat Ruby',
+    gltfUrls: createKhronosGltfUrls('ClearCoatCarPaint'),
+    swatches: ['#7f1d1d', '#dc2626'],
+    color: '#7f1d1d',
+    repeat: 1,
+    lineColor: '#fee2e2',
+    metalness: 0.9,
+    roughness: 0.18,
+    clearcoat: 1,
+    clearcoatRoughness: 0.08,
+    description: 'Open-source Khronos clearcoat car paint material with metallic sparkle.'
+  }),
+  Object.freeze({
+    id: 'clearcoat-azure',
+    name: 'Clearcoat Azure',
+    gltfUrls: createKhronosGltfUrls('ClearCoatCarPaint'),
+    swatches: ['#0ea5e9', '#38bdf8'],
+    color: '#0284c7',
+    repeat: 1,
+    lineColor: '#bae6fd',
+    metalness: 0.9,
+    roughness: 0.2,
+    clearcoat: 1,
+    clearcoatRoughness: 0.09,
+    description: 'Metallic blue clearcoat paint inspired by Khronos glTF Sample Assets.'
+  })
+]);
+
+const GOAL_RUSH_CUSHION_CLOTH_OPTIONS = Object.freeze(
+  POOL_ROYALE_CLOTH_VARIANTS.map((variant) =>
+    Object.freeze({
+      id: variant.id,
+      name: variant.name,
+      palette: variant.palette,
+      detail: variant.detail,
+      swatches: variant.swatches,
+      thumbnail: variant.thumbnail,
+      price: variant.price,
+      sourceId: variant.sourceId,
+      description: variant.description
+    })
+  )
+);
+
+export const GOAL_RUSH_CUSTOMIZATION = Object.freeze({
+  field: GOAL_RUSH_MARBLE_FIELDS,
+  cushionCloth: GOAL_RUSH_CUSHION_CLOTH_OPTIONS,
+  table: GOAL_RUSH_TABLE_FINISHES,
+  tableBase: GOAL_RUSH_TABLE_BASES,
+  environmentHdri: GOAL_RUSH_HDRI_VARIANTS,
+  puck: Object.freeze([
+    Object.freeze({ id: 'classicBall', name: 'Classic WebGL Ball', color: '#f8fafc', emissive: '#1e293b' }),
+    Object.freeze({ id: 'plasmaBall', name: 'Plasma WebGL Ball', color: '#38bdf8', emissive: '#0369a1' }),
+    Object.freeze({ id: 'emeraldBall', name: 'Emerald WebGL Ball', color: '#22c55e', emissive: '#166534' }),
+    Object.freeze({ id: 'lavaBall', name: 'Lava WebGL Ball', color: '#fb7185', emissive: '#9f1239' }),
+    Object.freeze({ id: 'chromeBall', name: 'Chrome WebGL Ball', color: '#e5e7eb', emissive: '#6b7280' })
+  ]),
+  mallet: Object.freeze([
+    Object.freeze({ id: 'crimson', name: 'Crimson', color: '#ff5577', knob: '#1f2937' }),
+    Object.freeze({ id: 'cyan', name: 'Cyan', color: '#22d3ee', knob: '#0f172a' }),
+    Object.freeze({ id: 'amber', name: 'Amber', color: '#f59e0b', knob: '#451a03' }),
+    Object.freeze({ id: 'violet', name: 'Violet', color: '#a855f7', knob: '#312e81' }),
+    Object.freeze({ id: 'lime', name: 'Lime', color: '#84cc16', knob: '#1a2e05' })
+  ]),
+  goals: Object.freeze([
+    Object.freeze({ id: 'mintNet', name: 'Mint Net', color: '#99ffd6', emissive: '#1aaf80' }),
+    Object.freeze({ id: 'crimsonNet', name: 'Crimson Net', color: '#ef4444', emissive: '#7f1d1d' }),
+    Object.freeze({ id: 'cobaltNet', name: 'Cobalt Net', color: '#60a5fa', emissive: '#1d4ed8' }),
+    Object.freeze({ id: 'amberNet', name: 'Amber Net', color: '#f59e0b', emissive: '#92400e' }),
+    Object.freeze({ id: 'ghostNet', name: 'Ghost Net', color: '#e5e7eb', emissive: '#6b7280' })
+  ])
+});
+
+const firstIds = Object.fromEntries(
+  Object.entries(GOAL_RUSH_CUSTOMIZATION).map(([key, options]) => [key, options?.[0]?.id])
+);
+
+export const GOAL_RUSH_DEFAULT_UNLOCKS = Object.freeze(
+  Object.entries(firstIds).reduce((acc, [key, id]) => {
+    acc[key] = id ? [id] : [];
+    return acc;
+  }, {})
+);
+
+export const GOAL_RUSH_OPTION_LABELS = Object.freeze(
+  Object.entries(GOAL_RUSH_CUSTOMIZATION).reduce((acc, [key, options]) => {
+    acc[key] = Object.freeze(
+      options.reduce((map, option) => {
+        map[option.id] = option.name;
+        return map;
+      }, {})
+    );
+    return acc;
+  }, {})
+);
+
+export const GOAL_RUSH_STORE_ITEMS = [
+  ...GOAL_RUSH_MARBLE_FIELDS.map((field, idx) => ({
+    id: `field-${field.id}`,
+    type: 'field',
+    optionId: field.id,
+    name: `${field.name} Surface`,
+    price: 520 + idx * 20,
+    description: field.description,
+    swatches: field.swatches,
+    thumbnail: FIELD_THUMBNAILS[field.id] || swatchThumbnail(field.swatches)
+  })),
+  ...GOAL_RUSH_TABLE_FINISHES.map((finish) => ({
+    id: `finish-${finish.id}`,
+    type: 'table',
+    optionId: finish.id,
+    name: `${finish.name} Finish`,
+    price: finish.price,
+    description: finish.description,
+    thumbnail: TABLE_FINISH_THUMBNAILS[finish.id]
+  })),
+  {
+    id: 'ball-plasma',
+    type: 'puck',
+    optionId: 'plasmaBall',
+    name: 'Plasma WebGL Ball',
+    price: 220,
+    description: 'High-voltage yellow puck glow.',
+    thumbnail: swatchThumbnail(['#eab308', '#854d0e', '#fef08a'])
+  },
+  {
+    id: 'ball-emerald',
+    type: 'puck',
+    optionId: 'emeraldBall',
+    name: 'Emerald WebGL Ball',
+    price: 240,
+    description: 'Magenta puck with vivid emissive edge.',
+    thumbnail: swatchThumbnail(['#be185d', '#9f1239', '#fda4af'])
+  },
+  {
+    id: 'ball-lava',
+    type: 'puck',
+    optionId: 'lavaBall',
+    name: 'Lava WebGL Ball',
+    price: 260,
+    description: 'Frost-white puck with cyan glow.',
+    thumbnail: swatchThumbnail(['#e0f2fe', '#0ea5e9', '#bae6fd'])
+  },
+  {
+    id: 'ball-chrome',
+    type: 'puck',
+    optionId: 'chromeBall',
+    name: 'Chrome WebGL Ball',
+    price: 280,
+    description: 'Deep jade puck with emerald shine.',
+    thumbnail: swatchThumbnail(['#064e3b', '#10b981', '#6ee7b7'])
+  },
+  {
+    id: 'mallet-cyan',
+    type: 'mallet',
+    optionId: 'cyan',
+    name: 'Cyan Mallets',
+    price: 260,
+    description: 'Cyan mallets with midnight knobs.',
+    thumbnail: swatchThumbnail(['#22d3ee', '#0f172a', '#cffafe'])
+  },
+  {
+    id: 'mallet-amber',
+    type: 'mallet',
+    optionId: 'amber',
+    name: 'Amber Mallets',
+    price: 280,
+    description: 'Amber mallets with dark wood knobs.',
+    thumbnail: swatchThumbnail(['#f59e0b', '#451a03', '#fde68a'])
+  },
+  {
+    id: 'mallet-violet',
+    type: 'mallet',
+    optionId: 'violet',
+    name: 'Violet Mallets',
+    price: 300,
+    description: 'Violet mallets with indigo knobs.',
+    thumbnail: swatchThumbnail(['#a855f7', '#312e81', '#e9d5ff'])
+  },
+  {
+    id: 'mallet-lime',
+    type: 'mallet',
+    optionId: 'lime',
+    name: 'Lime Mallets',
+    price: 320,
+    description: 'Lime mallets with forest knobs.',
+    thumbnail: swatchThumbnail(['#84cc16', '#1a2e05', '#ecfccb'])
+  },
+  {
+    id: 'goal-crimson',
+    type: 'goals',
+    optionId: 'crimsonNet',
+    name: 'Crimson Net Goals',
+    price: 330,
+    description: 'Crimson goal nets with deep ember glow.',
+    thumbnail: swatchThumbnail(['#ef4444', '#7f1d1d', '#fecaca'])
+  },
+  {
+    id: 'goal-cobalt',
+    type: 'goals',
+    optionId: 'cobaltNet',
+    name: 'Cobalt Net Goals',
+    price: 360,
+    description: 'Cobalt nets with electric blue emissive.',
+    thumbnail: swatchThumbnail(['#60a5fa', '#1d4ed8', '#bfdbfe'])
+  },
+  {
+    id: 'goal-amber',
+    type: 'goals',
+    optionId: 'amberNet',
+    name: 'Amber Net Goals',
+    price: 390,
+    description: 'Amber nets with warm metallic shine.',
+    thumbnail: swatchThumbnail(['#f59e0b', '#92400e', '#fde68a'])
+  },
+  {
+    id: 'goal-ghost',
+    type: 'goals',
+    optionId: 'ghostNet',
+    name: 'Ghost Net Goals',
+    price: 420,
+    description: 'Ghostly pale nets with steel glow.',
+    thumbnail: swatchThumbnail(['#e5e7eb', '#6b7280', '#f8fafc'])
+  },
+  ...GOAL_RUSH_CUSHION_CLOTH_OPTIONS.map((variant, idx) => ({
+    id: `cushion-cloth-${variant.id}`,
+    type: 'cushionCloth',
+    optionId: variant.id,
+    name: variant.name,
+    price: variant.price ?? 680 + idx * 8,
+    description: variant.description,
+    swatches: variant.swatches,
+    thumbnail: variant.thumbnail
+  })),
+  ...GOAL_RUSH_TABLE_BASES.map((variant) => ({
+    id: `base-${variant.id}`,
+    type: 'tableBase',
+    optionId: variant.id,
+    name: `${variant.name} Base`,
+    price: 0,
+    description: variant.description,
+    thumbnail: TABLE_BASE_THUMBNAILS[variant.id]
+  })),
+  ...GOAL_RUSH_HDRI_VARIANTS.map((variant) => ({
+    id: `hdri-${variant.id}`,
+    type: 'environmentHdri',
+    optionId: variant.id,
+    name: `${variant.name} HDRI`,
+    price: variant.price,
+    description: variant.description,
+    thumbnail: variant.thumbnail
+  }))
+];
+
+export const GOAL_RUSH_DEFAULT_LOADOUT = [
+  { type: 'field', optionId: GOAL_RUSH_CUSTOMIZATION.field[0].id, label: GOAL_RUSH_CUSTOMIZATION.field[0].name },
+  {
+    type: 'cushionCloth',
+    optionId: GOAL_RUSH_CUSTOMIZATION.cushionCloth[0].id,
+    label: GOAL_RUSH_CUSTOMIZATION.cushionCloth[0].name
+  },
+  { type: 'table', optionId: GOAL_RUSH_CUSTOMIZATION.table[0].id, label: GOAL_RUSH_CUSTOMIZATION.table[0].name },
+  { type: 'tableBase', optionId: GOAL_RUSH_CUSTOMIZATION.tableBase[0].id, label: GOAL_RUSH_CUSTOMIZATION.tableBase[0].name },
+  { type: 'environmentHdri', optionId: GOAL_RUSH_CUSTOMIZATION.environmentHdri[0].id, label: GOAL_RUSH_CUSTOMIZATION.environmentHdri[0].name },
+  { type: 'puck', optionId: GOAL_RUSH_CUSTOMIZATION.puck[0].id, label: GOAL_RUSH_CUSTOMIZATION.puck[0].name },
+  { type: 'mallet', optionId: GOAL_RUSH_CUSTOMIZATION.mallet[0].id, label: GOAL_RUSH_CUSTOMIZATION.mallet[0].name },
+  { type: 'goals', optionId: GOAL_RUSH_CUSTOMIZATION.goals[0].id, label: GOAL_RUSH_CUSTOMIZATION.goals[0].name }
+];

--- a/webapp/src/pages/Games/GoalRush.jsx
+++ b/webapp/src/pages/Games/GoalRush.jsx
@@ -1,6 +1,6 @@
 import { useLocation } from 'react-router-dom';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
-import AirHockey3D from '../../components/AirHockey3D.jsx';
+import GoalRush3D from '../../components/GoalRush3D.jsx';
 import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
 import { avatarToName } from '../../utils/avatarUtils.js';
 import useOnlineRoomSync from '../../hooks/useOnlineRoomSync.js';
@@ -26,7 +26,7 @@ export default function GoalRush() {
   const chosenAiFlag = aiFlag || randomAiFlag;
   const ai = { name: avatarToName(chosenAiFlag) || 'AI', avatar: chosenAiFlag };
   return (
-    <AirHockey3D
+    <GoalRush3D
       player={player}
       ai={ai}
       target={target}

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -24,6 +24,11 @@ import {
   AIR_HOCKEY_STORE_ITEMS
 } from '../config/airHockeyInventoryConfig.js';
 import {
+  GOAL_RUSH_DEFAULT_LOADOUT,
+  GOAL_RUSH_OPTION_LABELS,
+  GOAL_RUSH_STORE_ITEMS
+} from '../config/goalRushInventoryConfig.js';
+import {
   addPoolRoyalUnlock,
   getCachedPoolRoyalInventory,
   getPoolRoyalInventory,
@@ -46,6 +51,13 @@ import {
   isAirHockeyOptionUnlocked,
   listOwnedAirHockeyOptions
 } from '../utils/airHockeyInventory.js';
+import {
+  addGoalRushUnlock,
+  goalRushAccountId,
+  getGoalRushInventory,
+  isGoalRushOptionUnlocked,
+  listOwnedGoalRushOptions
+} from '../utils/goalRushInventory.js';
 import {
   CHESS_BATTLE_DEFAULT_LOADOUT,
   CHESS_BATTLE_OPTION_LABELS,
@@ -179,6 +191,18 @@ const AIR_HOCKEY_TYPE_LABELS = {
   mallet: 'Mallets',
   rails: 'Rails',
   goals: 'Goals'
+};
+
+const GOAL_RUSH_TYPE_LABELS = {
+  field: 'Pitch Surface',
+  cushionCloth: 'Cushion Cloth',
+  table: 'Table Finish',
+  tableBase: 'Table Bases',
+  environmentHdri: 'HDR Environments',
+  puck: 'WebGL Balls',
+  mallet: 'Strikers',
+  rails: 'Rails',
+  goals: 'Goal Nets'
 };
 
 const CHESS_TYPE_LABELS = {
@@ -353,6 +377,8 @@ const SNOOKER_STORE_ACCOUNT_ID =
   import.meta.env.VITE_SNOOKER_ROYALE_STORE_ACCOUNT_ID || DEV_INFO.account;
 const AIR_HOCKEY_STORE_ACCOUNT_ID =
   import.meta.env.VITE_AIR_HOCKEY_STORE_ACCOUNT_ID || DEV_INFO.account;
+const GOAL_RUSH_STORE_ACCOUNT_ID =
+  import.meta.env.VITE_GOAL_RUSH_STORE_ACCOUNT_ID || DEV_INFO.account;
 const CHESS_STORE_ACCOUNT_ID =
   import.meta.env.VITE_CHESS_BATTLE_STORE_ACCOUNT_ID || DEV_INFO.account;
 const TAVULL_STORE_ACCOUNT_ID =
@@ -1052,6 +1078,14 @@ const storeMeta = {
     typeLabels: AIR_HOCKEY_TYPE_LABELS,
     accountId: AIR_HOCKEY_STORE_ACCOUNT_ID
   },
+  goalrush: {
+    name: 'Goal Rush',
+    items: GOAL_RUSH_STORE_ITEMS,
+    defaults: GOAL_RUSH_DEFAULT_LOADOUT,
+    labels: GOAL_RUSH_OPTION_LABELS,
+    typeLabels: GOAL_RUSH_TYPE_LABELS,
+    accountId: GOAL_RUSH_STORE_ACCOUNT_ID
+  },
   chessbattleroyal: {
     name: 'Chess Battle Royal',
     items: CHESS_BATTLE_ROYAL_STORE_ITEMS,
@@ -1139,6 +1173,9 @@ export default function Store() {
   );
   const [airOwned, setAirOwned] = useState(() =>
     getAirHockeyInventory(airHockeyAccountId(accountId))
+  );
+  const [goalRushOwned, setGoalRushOwned] = useState(() =>
+    getGoalRushInventory(goalRushAccountId(accountId))
   );
   const [chessOwned, setChessOwned] = useState(() =>
     getChessBattleInventory(chessBattleAccountId(accountId))
@@ -1282,6 +1319,7 @@ export default function Store() {
     setPoolOwned(getCachedPoolRoyalInventory(accountId));
     setSnookerOwned(getCachedSnookerRoyalInventory(accountId));
     setAirOwned(getAirHockeyInventory(airHockeyAccountId(accountId)));
+    setGoalRushOwned(getGoalRushInventory(goalRushAccountId(accountId)));
     setChessOwned(getChessBattleInventory(chessBattleAccountId(accountId)));
     setFourInRowOwned(getFourInRowInventory(fourInRowAccountId(accountId)));
     setLudoOwned(getLudoBattleInventory(ludoBattleAccountId(accountId)));
@@ -1595,6 +1633,7 @@ export default function Store() {
           if (slug === 'poolroyale') return addPoolRoyalUnlock('environmentHdri', optionId, accountId);
           if (slug === 'snookerroyale') return addSnookerRoyalUnlock('environmentHdri', optionId, accountId);
           if (slug === 'airhockey') return addAirHockeyUnlock('environmentHdri', optionId, accountId);
+          if (slug === 'goalrush') return addGoalRushUnlock('environmentHdri', optionId, accountId);
           if (slug === 'chessbattleroyal' || slug === 'checkersbattleroyal') {
             return addChessBattleUnlock('environmentHdri', optionId, accountId);
           }
@@ -1673,6 +1712,11 @@ export default function Store() {
         key: createItemKey(item.type, item.optionId),
         slug: 'airhockey'
       })),
+      goalrush: GOAL_RUSH_STORE_ITEMS.map((item) => ({
+        ...item,
+        key: createItemKey(item.type, item.optionId),
+        slug: 'goalrush'
+      })),
       chessbattleroyal: CHESS_BATTLE_ROYAL_STORE_ITEMS.map((item) => ({
         ...item,
         key: createItemKey(item.type, item.optionId),
@@ -1730,6 +1774,8 @@ export default function Store() {
         isSnookerOptionUnlocked(type, optionId, snookerOwned),
       airhockey: (type, optionId) =>
         isAirHockeyOptionUnlocked(type, optionId, airOwned),
+      goalrush: (type, optionId) =>
+        isGoalRushOptionUnlocked(type, optionId, goalRushOwned),
       chessbattleroyal: (type, optionId) =>
         isChessOptionUnlocked(type, optionId, chessOwned),
       checkersbattleroyal: (type, optionId) =>
@@ -1751,6 +1797,7 @@ export default function Store() {
     }),
     [
       airOwned,
+      goalRushOwned,
       poolOwned,
       snookerOwned,
       chessOwned,
@@ -1772,6 +1819,8 @@ export default function Store() {
         SNOOKER_ROYALE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
       airhockey: (item) =>
         AIR_HOCKEY_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
+      goalrush: (item) =>
+        GOAL_RUSH_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
       chessbattleroyal: (item) =>
         CHESS_BATTLE_ROYAL_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
       checkersbattleroyal: (item) =>
@@ -1799,6 +1848,7 @@ export default function Store() {
     () => ({
       poolroyale: TYPE_LABELS,
       airhockey: AIR_HOCKEY_TYPE_LABELS,
+      goalrush: GOAL_RUSH_TYPE_LABELS,
       chessbattleroyal: CHESS_TYPE_LABELS,
       checkersbattleroyal: CHECKERS_BATTLE_TYPE_LABELS,
       fourinrowroyale: FOUR_IN_ROW_TYPE_LABELS,

--- a/webapp/src/utils/goalRushInventory.js
+++ b/webapp/src/utils/goalRushInventory.js
@@ -1,0 +1,112 @@
+import {
+  GOAL_RUSH_DEFAULT_LOADOUT,
+  GOAL_RUSH_DEFAULT_UNLOCKS,
+  GOAL_RUSH_OPTION_LABELS
+} from '../config/goalRushInventoryConfig.js';
+
+const STORAGE_KEY = 'goalRushInventoryByAccount';
+
+const copyDefaults = () =>
+  Object.entries(GOAL_RUSH_DEFAULT_UNLOCKS).reduce((acc, [key, values]) => {
+    acc[key] = Array.isArray(values) ? [...values] : [];
+    return acc;
+  }, {});
+
+const resolveAccountId = (accountId) => {
+  if (accountId) return accountId;
+  if (typeof window !== 'undefined') {
+    const stored = window.localStorage.getItem('accountId');
+    if (stored) return stored;
+  }
+  return 'guest';
+};
+
+const readAllInventories = () => {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch (err) {
+    console.warn('Failed to read goal rush inventory, resetting', err);
+    return {};
+  }
+};
+
+const writeAllInventories = (payload) => {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+};
+
+const normalizeInventory = (rawInventory) => {
+  const base = copyDefaults();
+  if (!rawInventory || typeof rawInventory !== 'object') return base;
+  const merged = { ...base };
+  Object.entries(rawInventory).forEach(([key, value]) => {
+    if (!Array.isArray(value)) return;
+    merged[key] = Array.from(new Set([...(merged[key] || []), ...value]));
+  });
+  return merged;
+};
+
+export const getGoalRushInventory = (accountId) => {
+  const resolvedAccountId = resolveAccountId(accountId);
+  const inventories = readAllInventories();
+  const normalized = normalizeInventory(inventories[resolvedAccountId]);
+  if (typeof window !== 'undefined') {
+    writeAllInventories({
+      ...inventories,
+      [resolvedAccountId]: normalized
+    });
+  }
+  return normalized;
+};
+
+export const isGoalRushOptionUnlocked = (type, optionId, inventoryOrAccountId) => {
+  if (!type || !optionId) return false;
+  const inventory =
+    typeof inventoryOrAccountId === 'string' || !inventoryOrAccountId
+      ? getGoalRushInventory(inventoryOrAccountId)
+      : inventoryOrAccountId;
+  return Array.isArray(inventory?.[type]) && inventory[type].includes(optionId);
+};
+
+export const addGoalRushUnlock = (type, optionId, accountId) => {
+  const resolvedAccountId = resolveAccountId(accountId);
+  const inventories = readAllInventories();
+  const current = normalizeInventory(inventories[resolvedAccountId]);
+  const existing = new Set(current[type] || []);
+  existing.add(optionId);
+  const nextInventory = {
+    ...current,
+    [type]: Array.from(existing)
+  };
+  writeAllInventories({
+    ...inventories,
+    [resolvedAccountId]: nextInventory
+  });
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(
+      new CustomEvent('goalRushInventoryUpdate', {
+        detail: { accountId: resolvedAccountId, inventory: nextInventory }
+      })
+    );
+  }
+  return nextInventory;
+};
+
+export const listOwnedGoalRushOptions = (accountId) => {
+  const inventory = getGoalRushInventory(accountId);
+  return Object.entries(inventory).flatMap(([type, values]) => {
+    if (!Array.isArray(values)) return [];
+    const labels = GOAL_RUSH_OPTION_LABELS[type] || {};
+    return values.map((optionId) => ({
+      type,
+      optionId,
+      label: labels[optionId] || optionId
+    }));
+  });
+};
+
+export const getDefaultGoalRushLoadout = () => [...GOAL_RUSH_DEFAULT_LOADOUT];
+
+export const goalRushAccountId = resolveAccountId;


### PR DESCRIPTION
### Motivation
- Keep Goal Rush implementation separate from Air Hockey so each game has its own code path and customization state.
- Provide a Goal Rush store with distinct WebGL ball variants and independent unlocks so items are not shared with Air Hockey.
- Use the Pool Royale green cloth as the default field look for Goal Rush to match existing visuals.
- Tune gameplay feel by slightly reducing ball speed for Goal Rush.

### Description
- Added a new `GoalRush3D` component and wired `webapp/src/pages/Games/GoalRush.jsx` to render it instead of `AirHockey3D`, creating an independent game runtime path (`webapp/src/components/GoalRush3D.jsx`).
- Introduced a dedicated Goal Rush inventory config and store catalog in `webapp/src/config/goalRushInventoryConfig.js` that includes multiple `puck` entries rebranded as WebGL balls and a `poolRoyalGreenCloth` field option.
- Implemented inventory persistence and helpers for Goal Rush in `webapp/src/utils/goalRushInventory.js` with its own storage key and event (`goalRushInventoryUpdate`) so unlocks are not shared with Air Hockey.
- Extended the Store UI and logic (`webapp/src/pages/Store.jsx`) to include Goal Rush metadata, store items, ownership checks, unlock delivery handlers, label/type resolvers and catalog entries.
- Tuned Goal Rush physics parameters inside the new component: reduced `PUCK_SPEED_TUNING` and adjusted `friction` for a slightly slower ball, and ensured the puck spawn/height logic matches the spherical WebGL ball variant.

### Testing
- Built the web client with `npm --prefix webapp run build` and the production build completed successfully (bundle warnings unrelated to these changes were shown but build finished).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a4f3f4188329afbc392ebe917486)