### PR TITLE
MurlanRoyaleArena: visual tuning for cards, HDRI defaults and camera/chair layout

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -67,7 +67,7 @@ import {
   resolveMurlanLanguageKey
 } from '../../utils/murlanRoyaleCommentary.js';
 
-const DEFAULT_HDRI_RESOLUTIONS = Object.freeze(['2k']);
+const DEFAULT_HDRI_RESOLUTIONS = Object.freeze(['4k', '2k']);
 const HDRI_RESOLUTION_LADDER = Object.freeze(['8k', '4k', '2k', '1k']);
 const DEFAULT_HDRI_ID = 'neon_photostudio';
 const DEFAULT_HDRI_INDEX = Math.max(
@@ -2337,7 +2337,7 @@ const CAMERA_SEATED_ELEVATION_OFFSETS = Object.freeze({
 });
 const CAMERA_TARGET_LIFT = 0.08 * MODEL_SCALE;
 const CAMERA_FOCUS_CENTER_LIFT = 0.1 * MODEL_SCALE;
-const CAMERA_TARGET_TOP_PLAYER_BIAS = 0.5 * MODEL_SCALE;
+const CAMERA_TARGET_TOP_PLAYER_BIAS = 0.36 * MODEL_SCALE;
 const CAMERA_SCREEN_DOWN_SHIFT = 0.12 * MODEL_SCALE;
 const HUMAN_HAND_CARD_SCALE = 1.06;
 const HUMAN_HAND_CARD_SPACING = CARD_W * HUMAN_HAND_CARD_SCALE * 0.28;
@@ -2348,7 +2348,7 @@ const HUMAN_HAND_FAN_ARC_LIFT = 0.036 * MODEL_SCALE;
 const HUMAN_HAND_FAN_DIRECTION = 1;
 const HUMAN_HAND_UNIFORM_YAW_FROM_LEFT = false;
 const HUMAN_HAND_CLOSER_OFFSET = 0.042 * MODEL_SCALE;
-const HUMAN_HAND_BOTTOM_SHIFT_Y = -0.018 * MODEL_SCALE;
+const HUMAN_HAND_BOTTOM_SHIFT_Y = -0.04 * MODEL_SCALE;
 const AI_HAND_BOTTOM_SHIFT_Y = -0.02 * MODEL_SCALE;
 const AI_HAND_CLOSER_OFFSET = 0.02 * MODEL_SCALE;
 const HUMAN_HAND_LEFT_SHIFT = -0.022 * MODEL_SCALE; // Negative value nudges the bottom human hand toward the right-side gift icon in portrait.
@@ -2386,7 +2386,7 @@ const DEAL_CARD_STEP_DELAY_MS = 60;
 const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 1.1;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
 const CHAIR_GROUND_DROP = 0;
-const CHAIR_SCREEN_LOWER_OFFSET = 0.03 * MODEL_SCALE;
+const CHAIR_SCREEN_LOWER_OFFSET = 0.085 * MODEL_SCALE;
 const HUMAN_CHAIR_EXTRA_INWARD_OFFSET = 0; // Align human chair distance with AI seats.
 const TABLE_HEIGHT_LIFT = 0.025 * MODEL_SCALE;
 const TABLE_HEIGHT = STOOL_HEIGHT + TABLE_HEIGHT_LIFT;
@@ -2436,11 +2436,11 @@ const CAMERA_TARGET_TURN_SNAP_DISTANCE = 0.018 * MODEL_SCALE;
 const CAMERA_PLAYER_TARGET_WEIGHT = 0.6;
 const HDRI_GROUND_FLOOR_Y = -0.015 * MODEL_SCALE;
 const ARENA_GROUND_Y = HDRI_GROUND_FLOOR_Y;
-const HDRI_GROUND_FLOOR_RADIUS_MULTIPLIER = 1.52;
+const HDRI_GROUND_FLOOR_RADIUS_MULTIPLIER = 1.76;
 const HDRI_GROUND_FLOOR_OPACITY = 0.22;
 const HDRI_BACKGROUND_PITCH = THREE.MathUtils.degToRad(-2.4);
 const CAMERA_SIDE_LOOK_EXTRA = 0.42 * MODEL_SCALE;
-const CAMERA_INWARD_RADIUS_FACTOR = 1;
+const CAMERA_INWARD_RADIUS_FACTOR = 0.97;
 const CAMERA_UP_TILT_FORWARD_BLEND = 0.34 * MODEL_SCALE;
 const CAMERA_UP_TILT_FORWARD_LERP = 0.14;
 
@@ -4957,7 +4957,7 @@ export default function MurlanRoyaleArena({ search }) {
 
       cardGeometry = createCardGeometry(CARD_W, CARD_H, CARD_D, {
         rounded: true,
-        cornerRadiusRatio: 0.24,
+        cornerRadiusRatio: 0.31,
         segments: 14
       });
 
@@ -6971,7 +6971,12 @@ function makeCardFace(rank, suit, theme, w = 768, h = 1080) {
   image.crossOrigin = 'anonymous';
   image.onload = () => {
     ctx.clearRect(0, 0, canvas.width, canvas.height);
-    ctx.drawImage(image, 0, 0, canvas.width, canvas.height);
+    const faceZoom = 1.045;
+    const zoomedWidth = canvas.width * faceZoom;
+    const zoomedHeight = canvas.height * faceZoom;
+    const offsetX = (canvas.width - zoomedWidth) * 0.5;
+    const offsetY = (canvas.height - zoomedHeight) * 0.5;
+    ctx.drawImage(image, offsetX, offsetY, zoomedWidth, zoomedHeight);
 
     // Slightly thicken rank/suit glyph edges for better mobile readability.
     ctx.save();
@@ -6987,15 +6992,15 @@ function makeCardFace(rank, suit, theme, w = 768, h = 1080) {
     ctx.drawImage(canvas, 0.65, -0.65, canvas.width, canvas.height);
     ctx.restore();
 
-    // Slight front-face matte layer to reduce glare on community cards.
+    // Slightly darker front-face matte layer for less glare and reduced overall brightness.
     ctx.save();
     ctx.globalCompositeOperation = 'multiply';
-    ctx.fillStyle = 'rgba(15, 23, 42, 0.06)';
+    ctx.fillStyle = 'rgba(15, 23, 42, 0.12)';
     ctx.fillRect(0, 0, canvas.width, canvas.height);
     ctx.restore();
 
     // Clip all card faces with stronger rounded corners to hide dark corner wedges/triangles.
-    const cornerRadius = Math.round(Math.min(canvas.width, canvas.height) * 0.07);
+    const cornerRadius = Math.round(Math.min(canvas.width, canvas.height) * 0.092);
     ctx.save();
     ctx.globalCompositeOperation = 'destination-in';
     roundRect(ctx, 0, 0, canvas.width, canvas.height, cornerRadius);


### PR DESCRIPTION
### Motivation
- Improve visual fidelity and readability of card faces and reduce glare on community cards. 
- Provide higher-resolution HDRI defaults and subtly refine camera and seat layout to better frame players across viewports. 

### Description
- Add `4k` to `DEFAULT_HDRI_RESOLUTIONS` to prefer higher-resolution environment maps by default. 
- Adjust camera and seating metrics by changing `CAMERA_TARGET_TOP_PLAYER_BIAS`, `CAMERA_INWARD_RADIUS_FACTOR`, `CHAIR_SCREEN_LOWER_OFFSET`, and `HDRI_GROUND_FLOOR_RADIUS_MULTIPLIER` to refine framing and ground coverage. 
- Modify hand layout values by updating `HUMAN_HAND_BOTTOM_SHIFT_Y` to improve hand positioning relative to the table. 
- Increase card geometry corner rounding by changing `cornerRadiusRatio` for `createCardGeometry` and strengthen face rendering in `makeCardFace` by applying a slight zoom (`faceZoom = 1.045`), increasing the front matte darkness (`rgba(..., 0.12)`), and enlarging rounded corner clipping (`cornerRadius` multiplier). 

### Testing
- Ran unit tests with `yarn test` and they passed. 
- Ran linter via `yarn lint` with no new warnings. 
- Verified a production build with `yarn build` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a2c01b54832992b61f51c08693ac)