### PR TITLE
Air Hockey: play hit SFX when puck rebounds off side rails

### DIFF
--- a/webapp/src/components/AirHockey3D.jsx
+++ b/webapp/src/components/AirHockey3D.jsx
@@ -2194,7 +2194,7 @@ export default function AirHockey3D({
             -PLAYFIELD.h / 2 + PUCK_RADIUS,
             PLAYFIELD.h / 2 - PUCK_RADIUS
           );
-          playPost();
+          playHit();
         }
       }
 


### PR DESCRIPTION
### Motivation
- Make rail rebounds (when the puck hits the top/bottom non-goal edges) use the same sound feedback as player mallet hits so collisions feel consistent.

### Description
- Replaced `playPost()` with `playHit()` for non-goal top/bottom field rebounds in `webapp/src/components/AirHockey3D.jsx` so rail impacts use the existing hit SFX.

### Testing
- Built the web client with `npm -C webapp run build` and the build completed successfully (Vite warnings about chunking remain, unrelated to this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9ad4556908329aa466283930c8bdc)