### PR TITLE
Align Snake & Ladder parked weapons on all four board sides

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -278,10 +278,10 @@ const WEAPON_DISPLAY_SIZE_MULTIPLIER = 1.4;
 const WEAPON_PARKING_OUTWARD_OFFSET = TILE_SIZE * 0.06;
 const WEAPON_FROM_TOKEN_CENTER_OFFSET = TOKEN_RADIUS * 0.58;
 const WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT = Object.freeze([
-  TILE_SIZE * 0.08,
-  TILE_SIZE * 0.1,
-  TILE_SIZE * 0.24,
-  TILE_SIZE * 0.1
+  0,
+  0,
+  0,
+  0
 ]);
 const WEAPON_TOKEN_GAP = TILE_SIZE * 0.004;
 const WEAPON_PARKED_Y_DROP_BY_KIND = Object.freeze({
@@ -310,15 +310,12 @@ const TOKEN_PORTRAIT_SCREEN_SHIFT_BY_SEAT = Object.freeze([
   Object.freeze({ radial: 0, lateral: 0, y: 0 })
 ]);
 const WEAPON_PORTRAIT_SCREEN_SHIFT_BY_SEAT = Object.freeze([
-  // Bottom seat: pull weapon farther inward than token so it sits next to it.
-  Object.freeze({ radial: -TILE_SIZE * 0.24, lateral: 0, y: 0 }),
-  // Right seat: move weapon closer to table edge where the token rests.
-  Object.freeze({ radial: -TILE_SIZE * 0.14, lateral: 0, y: 0 }),
-  // Top seat: lower weapon so it rests on/touches the table surface like token.
-  Object.freeze({ radial: 0, lateral: 0, y: -TOKEN_HEIGHT * 0.28 }),
-  // Left seat: move weapon closer to table edge where the token rests.
-  Object.freeze({ radial: -TILE_SIZE * 0.14, lateral: 0, y: 0 })
+  Object.freeze({ radial: -TILE_SIZE * 0.08, lateral: 0, y: 0 }),
+  Object.freeze({ radial: -TILE_SIZE * 0.08, lateral: 0, y: 0 }),
+  Object.freeze({ radial: -TILE_SIZE * 0.08, lateral: 0, y: 0 }),
+  Object.freeze({ radial: -TILE_SIZE * 0.08, lateral: 0, y: 0 })
 ]);
+const WEAPON_TABLE_SURFACE_Y_OFFSET = 0;
 
 const PAVEMENT_EXTRA_SCALE = 1.18;
 const PAVEMENT_THICKNESS = TILE_SIZE * 0.4;
@@ -4694,21 +4691,29 @@ function updateSeatWeaponDisplays(board, players = []) {
   const keep = new Set();
   const fallbackOrder = ['drone', 'fighter', 'helicopter', 'supportTruck', 'javelin'];
   const tableY = Number.isFinite(board?.tableInfo?.surfaceY) ? board.tableInfo.surfaceY : boardLookTarget.y;
-
+  const playersBySeat = new Map();
   players.forEach((player, index) => {
     const seatIndex = Number.isFinite(player?.seatIndex) ? player.seatIndex : index;
+    if (!Number.isFinite(seatIndex)) return;
+    if (seatIndex < 0 || seatIndex >= anchors.length) return;
+    if (!playersBySeat.has(seatIndex)) playersBySeat.set(seatIndex, player);
+  });
+
+  for (let seatIndex = 0; seatIndex < anchors.length; seatIndex += 1) {
+    const player = playersBySeat.get(seatIndex) ?? null;
     const anchor = anchors[seatIndex];
-    if (!anchor) return;
-    keep.add(index);
-    let holder = board.weaponDisplayGroup.userData.byPlayer?.get(index);
+    if (!anchor) continue;
+    const holderKey = `seat-${seatIndex}`;
+    keep.add(holderKey);
+    let holder = board.weaponDisplayGroup.userData.byPlayer?.get(holderKey);
     if (!holder) {
       holder = new THREE.Group();
       holder.userData.weaponType = null;
       board.weaponDisplayGroup.add(holder);
       if (!board.weaponDisplayGroup.userData.byPlayer) board.weaponDisplayGroup.userData.byPlayer = new Map();
-      board.weaponDisplayGroup.userData.byPlayer.set(index, holder);
+      board.weaponDisplayGroup.userData.byPlayer.set(holderKey, holder);
     }
-    const weaponType = player?.weaponType || fallbackOrder[index % fallbackOrder.length];
+    const weaponType = player?.weaponType || fallbackOrder[seatIndex % fallbackOrder.length];
     if (holder.userData.weaponType !== weaponType) {
       while (holder.children.length) {
         const child = holder.children.pop();
@@ -4743,16 +4748,12 @@ function updateSeatWeaponDisplays(board, players = []) {
           .addScaledVector(railLayout.seatDirection, portraitShift.radial ?? 0)
           .addScaledVector(railLayout.lateral, portraitShift.lateral ?? 0);
       }
-      holder.position.y =
-        railLayout.railHeightY +
-        WEAPON_REST_HEIGHT_OFFSET +
-        (WEAPON_REST_HEIGHT_OFFSET_BY_SEAT[seatIndex] ?? 0) +
-        (portraitShift?.y ?? 0);
+      holder.position.y = tableY + WEAPON_TABLE_SURFACE_Y_OFFSET;
     } else {
       const seatWorld = new THREE.Vector3();
       anchor.getWorldPosition(seatWorld);
       const seatDirection = seatWorld.clone().sub(boardLookTarget).setY(0);
-      if (seatDirection.lengthSq() < 1e-6) return;
+      if (seatDirection.lengthSq() < 1e-6) continue;
       seatDirection.normalize();
       const lateral = new THREE.Vector3(-seatDirection.z, 0, seatDirection.x);
       const radius = TOKEN_REST_MIN_RADIUS + TILE_SIZE * 0.16;
@@ -4761,19 +4762,19 @@ function updateSeatWeaponDisplays(board, players = []) {
         .addScaledVector(seatDirection, radius)
         .addScaledVector(lateral, (seatIndex % 2 === 0 ? 1 : -1) * TOKEN_RADIUS * 0.22);
       holder.position.copy(markerPos);
-      holder.position.y = tableY + TOKEN_HEIGHT * 0.18;
+      holder.position.y = tableY + WEAPON_TABLE_SURFACE_Y_OFFSET;
     }
     holder.lookAt(boardLookTarget.x, holder.position.y, boardLookTarget.z);
     holder.rotation.x = 0;
     holder.rotation.z = 0;
-  });
+  }
 
   const byPlayer = board.weaponDisplayGroup.userData.byPlayer;
   if (!(byPlayer instanceof Map)) return;
-  byPlayer.forEach((group, index) => {
-    if (!keep.has(index)) {
+  byPlayer.forEach((group, key) => {
+    if (!keep.has(key)) {
       group.parent?.remove(group);
-      byPlayer.delete(index);
+      byPlayer.delete(key);
     }
   });
 }


### PR DESCRIPTION
### Motivation
- Ensure parked weapon models are visible next to the Snake & Ladder board on all four sides and sit at the same height as the table surface for a consistent portrait-screen presentation.
- Make weapon placement independent of number of active players so each seat/side can show a parked weapon holder with a sensible fallback.

### Description
- Normalized per-seat parking offsets by setting `WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT` to zeros and unified `WEAPON_PORTRAIT_SCREEN_SHIFT_BY_SEAT` so weapons stay pulled in consistently around the board.
- Added `WEAPON_TABLE_SURFACE_Y_OFFSET` and force-set parked weapon Y to `tableY + WEAPON_TABLE_SURFACE_Y_OFFSET` so holders rest at table surface height for both rail and fallback paths.
- Reworked `updateSeatWeaponDisplays` to iterate by seat index and build a `playersBySeat` map so a holder is created for every board side using seat keys (`seat-<index>`), plus using seat-based cleanup keys instead of player indexes.
- Fixed control flow and cleanup edge-cases by replacing early `return` with `continue` in seat loops and adjusting stale-holder deletion to compare seat keys.

### Testing
- Ran `npx eslint webapp/src/components/SnakeBoard3D.jsx`, which completed with a repository ignore warning but no errors.
- Ran `npx eslint --no-ignore webapp/src/components/SnakeBoard3D.jsx`, which completed with the same ignore warning and no reported errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9adfefe688329832a8664ed6b0178)