### PR TITLE
Reduce Murlan card glare under HDRI lighting

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1674,19 +1674,19 @@ function createCharacterCards({ handLift = 0.96, handCardsInput = [], cardTheme 
     managedTextures.push(faceTexture);
     const frontMaterial = new THREE.MeshStandardMaterial({
       map: faceTexture,
-      color: new THREE.Color('#ffffff'),
-      roughness: 0.96,
+      color: new THREE.Color(CARD_FRONT_BASE_COLOR),
+      roughness: 1,
       metalness: 0,
       envMapIntensity: 0
     });
     const backMaterial = new THREE.MeshStandardMaterial({
       map: backTexture,
-      color: new THREE.Color('#ffffff'),
-      roughness: 0.98,
+      color: new THREE.Color(CARD_BACK_BASE_COLOR),
+      roughness: 1,
       metalness: 0,
       envMapIntensity: 0,
       emissive: new THREE.Color('#0f172a'),
-      emissiveIntensity: 0.05
+      emissiveIntensity: 0
     });
     managedMaterials.push(frontMaterial, backMaterial);
     const sideMaterials = [edgeMaterial, edgeMaterial, edgeMaterial, edgeMaterial, frontMaterial, backMaterial];
@@ -6547,6 +6547,9 @@ function easeInOutCubic(t) {
   return t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
 }
 
+const CARD_FRONT_BASE_COLOR = '#e9eef5';
+const CARD_BACK_BASE_COLOR = '#dce5f0';
+
 function createCardMesh(card, geometry, cache, theme, textureQuality = null) {
   const textureKey = textureQuality?.id || 'default';
   const faceKey = `${theme.id}-${card.rank}-${card.suit}-${textureKey}`;
@@ -6567,17 +6570,17 @@ function createCardMesh(card, geometry, cache, theme, textureQuality = null) {
     roughness: 1,
     metalness: 0,
     envMapIntensity: 0,
-    color: new THREE.Color('#ffffff')
+    color: new THREE.Color(CARD_FRONT_BASE_COLOR)
   });
   const backTexture = makeCardBackTexture(theme, textureQuality);
   const backMat = new THREE.MeshStandardMaterial({
     map: backTexture,
-    color: new THREE.Color('#ffffff'),
+    color: new THREE.Color(CARD_BACK_BASE_COLOR),
     roughness: 1,
     metalness: 0,
     envMapIntensity: 0,
     emissive: new THREE.Color('#0f172a'),
-    emissiveIntensity: 0.01
+    emissiveIntensity: 0
   });
   const hiddenMat = new THREE.MeshStandardMaterial({
     color: new THREE.Color(theme.hiddenColor || theme.backColor),
@@ -6998,7 +7001,7 @@ function makeCardFace(rank, suit, theme, w = 768, h = 1080) {
 
     // Slightly darker front-face matte layer for less glare and reduced overall brightness.
     ctx.globalAlpha = 1;
-    ctx.fillStyle = 'rgba(15, 23, 42, 0.12)';
+    ctx.fillStyle = 'rgba(15, 23, 42, 0.2)';
     ctx.fillRect(0, 0, canvas.width, canvas.height);
     ctx.restore();
 
@@ -7087,12 +7090,12 @@ function applyCardThemeMaterials(three, theme, force = false, textureQuality = n
       three.faceTextureCache.set(faceKey, faceTexture);
     }
     frontMaterial.map = faceTexture;
-    frontMaterial.color?.set?.('#ffffff');
+    frontMaterial.color?.set?.(CARD_FRONT_BASE_COLOR);
     frontMaterial.needsUpdate = true;
     const backTexture = makeCardBackTexture(theme, textureQuality);
     mesh.userData.backTexture = backTexture;
     backMaterial.map = backTexture;
-    backMaterial.color?.set?.('#ffffff');
+    backMaterial.color?.set?.(CARD_BACK_BASE_COLOR);
     backMaterial.roughness = 1;
     backMaterial.metalness = 0;
     backMaterial.envMapIntensity = 0;


### PR DESCRIPTION
### Motivation
- Community (table) and held cards were overly bright and showed strong HDRI reflections that made exposed community cards hard to read under bright environments.
- Goal is to make cards less reflective and slightly darker so ranks/pips remain legible when HDRIs/light probes are strong.

### Description
- Toned down card base albedo by introducing `CARD_FRONT_BASE_COLOR` and `CARD_BACK_BASE_COLOR` and using them for front/back materials instead of pure white. (`webapp/src/pages/Games/MurlanRoyaleArena.jsx`)
- Forced card materials to fully matte configuration by setting `roughness: 1`, `metalness: 0`, and `envMapIntensity: 0` for board, hand, hidden and back materials so they no longer pick up strong HDRI highlights. (`createCardMesh`, held-card creation and theme re-apply paths)
- Removed residual self-lit appearance by setting card back `emissiveIntensity` to `0` where previously a small emissive lift existed for back materials.
- Increased the dark matte overlay in card texture generation from `rgba(15, 23, 42, 0.12)` to `rgba(15, 23, 42, 0.2)` to reduce overall face brightness and improve readability under HDRI lighting. (`makeCardFace`)

### Testing
- Built the webapp to validate changes with `npm --prefix webapp run build`, which completed successfully. 
- Build produced the same pre-existing Vite warnings about chunk sizes and mixed static/dynamic imports; no new build errors were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9af20d9d88329b3c1add3e9b727f2)