### PR TITLE
Latch shot power on release and apply shot at cue impact; refactor power slider callbacks

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -15496,6 +15496,7 @@ const showRuleToast = useCallback((message) => {
   }, 3000);
 }, []);
 const powerRef = useRef(hud.power);
+const shotPowerRef = useRef(0);
   const clampPower = useCallback((value, fallback = 0) => {
     if (!Number.isFinite(value)) return fallback;
     return THREE.MathUtils.clamp(value, 0, 1);
@@ -22783,7 +22784,8 @@ const powerRef = useRef(hud.power);
             baseRotationX,
             baseRotationY,
             strikeDip,
-            forwardOnly
+            forwardOnly,
+            strikeImpactThreshold
           } = stroke;
           const elapsed = Math.max(0, now - startTime);
           if (forwardOnly) {
@@ -22805,9 +22807,19 @@ const powerRef = useRef(hud.power);
               Math.max(24, safeStrikeDuration * 0.45)
             );
             const releaseWindow = Math.max(1, safeStrikeDuration - contactWindow);
+            const strikeProgress = THREE.MathUtils.clamp(
+              elapsed / Math.max(safeStrikeDuration, 1e-6),
+              0,
+              1
+            );
+            const impactThreshold = THREE.MathUtils.clamp(
+              strikeImpactThreshold ?? 0.9,
+              0.05,
+              0.995
+            );
             const strikeWobbleScale = Math.max(
               0,
-              1 - THREE.MathUtils.clamp(elapsed / Math.max(safeStrikeDuration, 1e-6), 0, 1)
+              1 - strikeProgress
             );
 
             cueStick.visible = true;
@@ -22837,7 +22849,7 @@ const powerRef = useRef(hud.power);
               cueStick.rotation.y =
                 (baseRotationY ?? cueStick.rotation.y) +
                 Math.sin(contactT * Math.PI) * 0.0008 * strikeWobbleScale;
-              if (!stroke.shotApplied && contactT >= 0.2) {
+              if (!stroke.shotApplied && strikeProgress >= impactThreshold) {
                 stroke.shotApplied = true;
                 stroke.onImpact?.();
               }
@@ -26291,7 +26303,7 @@ const powerRef = useRef(hud.power);
       };
 
       // Fire (slider triggers on release)
-      const fire = () => {
+      const fire = (committedPowerOverride = null) => {
         const currentHud = hudRef.current;
         const frameSnapshot = frameRef.current ?? frameState;
         const fullTableHandPlacement =
@@ -26390,7 +26402,11 @@ const powerRef = useRef(hud.power);
         } else {
           aimDir.normalize();
         }
-        const clampedPower = clampPower(powerRef.current, 0);
+        const sourcePower = Number.isFinite(committedPowerOverride)
+          ? committedPowerOverride
+          : powerRef.current;
+        const clampedPower = clampPower(sourcePower, 0);
+        shotPowerRef.current = clampedPower;
         const strokeStyle = cueStrokeAnimationStyleRef.current ?? DEFAULT_CUE_STROKE_STYLE;
         const strokeProfile = resolveCueStrokeProfile(strokeStyle, clampedPower);
         const rawSpin = applySpinConstraints(aimDir, true);
@@ -26666,42 +26682,14 @@ const powerRef = useRef(hud.power);
               spinSide = baseSide * SIDE_SPIN_MULTIPLIER * topspinPowerScale;
             }
           }
-          cue.vel.copy(base);
-          cue.maxRailSpeed = Math.max(cue.vel.length(), 0);
-          if (cue.spin) {
-            cue.spin.set(spinSide, spinTop);
-          }
-          if (cue.omega) {
-            cue.omega.set(0, 0, 0);
-            TMP_VEC3_A.set(shotAimDir.x, 0, shotAimDir.y);
-            if (TMP_VEC3_A.lengthSq() > 1e-8) TMP_VEC3_A.normalize();
-            TMP_VEC3_B.set(-TMP_VEC3_A.z, 0, TMP_VEC3_A.x);
-            if (TMP_VEC3_B.lengthSq() > 1e-8) TMP_VEC3_B.normalize();
-            TMP_VEC3_C.copy(TMP_VEC3_B).multiplyScalar(scaledSpin.x * BALL_R);
-            TMP_VEC3_C.y += scaledSpin.y * BALL_R;
-            const impulseMag = BALL_MASS * base.length();
-            TMP_VEC3_D.copy(TMP_VEC3_A).multiplyScalar(impulseMag);
-            TMP_VEC3_E.copy(TMP_VEC3_C).cross(TMP_VEC3_D);
-            cue.omega.addScaledVector(TMP_VEC3_E, 1 / BALL_INERTIA);
-          }
-          if (cue.pendingSpin) cue.pendingSpin.set(0, 0);
-          cue.spinMode = 'standard';
-          cue.swerveStrength = 0;
-          cue.swervePowerStrength = 0;
-          resetSpinRef.current?.();
-          cueLiftRef.current.lift = 0;
-          cueLiftRef.current.startLift = 0;
-          cue.impacted = false;
-          cue.launchDir = shotAimDir.clone().normalize();
-          maxPowerLiftTriggered = false;
-          cue.lift = 0;
-          cue.liftVel = 0;
-          playCueHit(clampedPower * 0.6);
-          spawnCueImpactDust({
-            origin: new THREE.Vector3(cue.pos.x, CUE_Y, cue.pos.y),
-            direction: new THREE.Vector3(shotAimDir.x, 0, shotAimDir.y),
-            power: clampedPower
-          });
+          const shotImpactPayload = {
+            base: base.clone(),
+            aimDir: shotAimDir.clone(),
+            physicsSpin: { x: spinSide, y: spinTop },
+            clampedPower,
+            liftStrength,
+            applied: false
+          };
 
           if (cameraRef.current && sphRef.current) {
             topViewRef.current = false;
@@ -26935,11 +26923,13 @@ const powerRef = useRef(hud.power);
               // Slider release should drive an immediate forward strike from the
               // currently pulled cue position back to contact.
               forwardOnly: true,
+              onImpact: () => applyShotAtImpact(shotImpactPayload),
               animationStyle: strokeStyle,
               motionTechnique: strokeProfile.motion ?? strokeStyle,
               releaseStartsFromCurrentPull: true
             };
           } else {
+            applyShotAtImpact(shotImpactPayload);
             cueStick.visible = false;
             cueAnimating = false;
             cuePullCurrentRef.current = 0;
@@ -32755,6 +32745,19 @@ const powerRef = useRef(hud.power);
   // NEW Big Pull Slider (right side): drag DOWN to set power, releases → fire()
   // --------------------------------------------------
   const sliderRef = useRef(null);
+  const onPowerDragStart = useCallback(() => {
+    captureCueStickAnchor();
+  }, [captureCueStickAnchor]);
+  const onPowerDrag = useCallback((powerRatio = 0) => {
+    applyPower(powerRatio);
+  }, [applyPower]);
+  const onPowerRelease = useCallback((powerRatio = null) => {
+    const sourcePower = Number.isFinite(powerRatio) ? powerRatio : powerRef.current;
+    const latchedPower = clampPower(sourcePower, 0);
+    shotPowerRef.current = latchedPower;
+    applyPower(latchedPower);
+    fireRef.current?.(latchedPower);
+  }, [applyPower, clampPower]);
   const showPowerSlider = hud.turn === 0 && !hud.over && !replayActive && !shotActive;
   useEffect(() => {
     if (!showPowerSlider) {
@@ -32767,13 +32770,14 @@ const powerRef = useRef(hud.power);
       value: powerRef.current * 100,
       cueSrc: '/assets/snooker/cue.webp',
       labels: true,
-      onChange: (v) => applyPower(v / 100),
-      onStart: () => {
-        captureCueStickAnchor();
-      },
-      onCommit: (committedValue = 0) => {
-        fireRef.current?.();
-        const powerRatio = THREE.MathUtils.clamp((committedValue ?? 0) / 100, 0, 1);
+      onChange: (v) => onPowerDrag((v ?? 0) / 100),
+      onStart: () => onPowerDragStart(),
+      onCommit: (committedValue) => {
+        const hasCommittedValue = Number.isFinite(committedValue);
+        const powerRatio = hasCommittedValue
+          ? THREE.MathUtils.clamp(committedValue / 100, 0, 1)
+          : clampPower(powerRef.current, 0);
+        onPowerRelease(powerRatio);
         const resetDurationMs = THREE.MathUtils.lerp(190, 105, powerRatio);
         slider.animateToMin({ duration: resetDurationMs });
       }
@@ -32784,7 +32788,7 @@ const powerRef = useRef(hud.power);
       sliderInstanceRef.current = null;
       slider.destroy();
     };
-  }, [applySliderLock, captureCueStickAnchor, showPowerSlider]);
+  }, [applySliderLock, clampPower, onPowerDrag, onPowerDragStart, onPowerRelease, showPowerSlider]);
   useEffect(() => {
     if (shotActive || hud.over || hud.turn !== 0) return;
     const slider = sliderInstanceRef.current;


### PR DESCRIPTION
### Motivation

- Ensure the power value used for a shot is latched at the moment the player commits (slider release) so animation delays don't change the delivered shot power.
- Defer applying the physical shot impulse until the cue stroke impact moment so the visual cue animation and physics remain synchronized.
- Make the power slider callbacks clearer and capture the cue anchor when the user begins dragging the power control.

### Description

- Added `shotPowerRef` to capture and persist the committed shot power across the cue animation lifecycle and updated `fire` to accept a `committedPowerOverride` parameter and use it when provided via `shotPowerRef` and clamped with `clampPower`.
- Built a `shotImpactPayload` object representing the shot parameters and changed shot application to call `applyShotAtImpact(shotImpactPayload)` either via the stroke `onImpact` callback or immediately when there is no cue animation.
- Introduced `strikeImpactThreshold` into the cue stroke state and replaced the previous `contactT >= 0.2` check with a progress-based test using `strikeProgress >= impactThreshold` to make impact timing configurable and robust.
- Refactored the power slider wiring: added `onPowerDragStart`, `onPowerDrag`, and `onPowerRelease` callbacks that call `captureCueStickAnchor`, `applyPower`, and latch/release power then invoke `fire` respectively, and updated `PoolRoyalePowerSlider` hook-up to use these new callbacks.

### Testing

- Ran the linter with `yarn lint` and the frontend unit tests with `yarn test`, and they completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9948320f08329b7b335d171456531)