### PR TITLE
Adjust Murlan Royale card layout, reduce card glare and fix black joker art

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2309,8 +2309,8 @@ const DISCARD_PILE_OFFSET = Object.freeze({
   y: CARD_H * 1.14,
   z: -TABLE_RADIUS * 0.18
 });
-const DISCARD_PILE_FORWARD_SHIFT = CARD_H * 0.34;
-const DISCARD_PILE_RIGHT_SHIFT = CARD_W * 1.48;
+const DISCARD_PILE_FORWARD_SHIFT = -CARD_H * 0.12;
+const DISCARD_PILE_RIGHT_SHIFT = -CARD_W * 0.28;
 const SEAT_WIDTH = 0.9 * MODEL_SCALE * STOOL_SCALE;
 const SEAT_DEPTH = 0.95 * MODEL_SCALE * STOOL_SCALE;
 const SEAT_THICKNESS = 0.09 * MODEL_SCALE * STOOL_SCALE;
@@ -2353,10 +2353,10 @@ const HUMAN_HAND_FAN_ARC_LIFT = 0.036 * MODEL_SCALE;
 const HUMAN_HAND_FAN_DIRECTION = 1;
 const HUMAN_HAND_UNIFORM_YAW_FROM_LEFT = false;
 const HUMAN_HAND_CLOSER_OFFSET = 0.042 * MODEL_SCALE;
-const HUMAN_HAND_BOTTOM_SHIFT_Y = -0.052 * MODEL_SCALE;
+const HUMAN_HAND_BOTTOM_SHIFT_Y = -0.066 * MODEL_SCALE;
 const AI_HAND_BOTTOM_SHIFT_Y = -0.02 * MODEL_SCALE;
 const AI_HAND_CLOSER_OFFSET = 0.02 * MODEL_SCALE;
-const HUMAN_HAND_LEFT_SHIFT = -0.022 * MODEL_SCALE; // Negative value nudges the bottom human hand toward the right-side gift icon in portrait.
+const HUMAN_HAND_LEFT_SHIFT = -0.032 * MODEL_SCALE; // Negative value nudges the bottom human hand toward the right-side gift icon in portrait.
 const AI_HAND_LEFT_SHIFT = 0;
 const HUMAN_HAND_UP_SHIFT_Y = 0.108 * MODEL_SCALE;
 const HUMAN_HAND_DIRECTIONAL_LIFT = 0;
@@ -2379,7 +2379,7 @@ const COMMUNITY_CARD_SPACING = CARD_W * 1.08;
 const COMMUNITY_CARD_MAX_SPREAD = COMMUNITY_CARD_SPACING * 12;
 const COMMUNITY_CARD_BOTTOM_LOCK_Y_OFFSET = Math.sin(COMMUNITY_CARD_TOP_TILT) * CARD_H * 0.5;
 const COMMUNITY_CARD_FAN_ARC_LIFT = 0;
-const COMMUNITY_CARD_CLOSER_TO_HUMAN = 0;
+const COMMUNITY_CARD_CLOSER_TO_HUMAN = -0.08 * MODEL_SCALE;
 const COMMUNITY_CARD_BOTTOM_SHIFT_Y = -0.028 * MODEL_SCALE;
 const COMMUNITY_CARD_LEFT_SHIFT = 0;
 const COMMUNITY_CARD_DIRECTIONAL_LIFT = 0;
@@ -6979,11 +6979,19 @@ function toOpenSourceDeckKey(rank, suit) {
 }
 
 function svgMarkupFromOpenSourceDeck(rank, suit) {
-  const cardKey = toOpenSourceDeckKey(rank, suit);
+  const cardKey = rank === 'JB' ? 'J1' : toOpenSourceDeckKey(rank, suit);
   if (!cardKey) return createFallbackOpenSourceCardSvg(`${rank}${suit ?? ''}`);
   const CardComponent = OpenSourceDeck?.[cardKey];
   if (!CardComponent) return createFallbackOpenSourceCardSvg(cardKey);
-  return renderToStaticMarkup(<CardComponent width={1000} height={1400} />);
+  const svg = renderToStaticMarkup(<CardComponent width={1000} height={1400} />);
+  if (rank !== 'JB') {
+    return svg;
+  }
+  return svg
+    .replace(/#d[0-9a-f]{2,2}[0-9a-f]{2,2}/gi, '#111111')
+    .replace(/#e[0-9a-f]{2,2}[0-9a-f]{2,2}/gi, '#111111')
+    .replace(/#f[0-9a-f]{2,2}[0-9a-f]{2,2}/gi, '#111111')
+    .replace(/rgb\(\s*2(?:0[0-9]|1[0-9]|2[0-5])\s*,\s*[0-9]{1,3}\s*,\s*[0-9]{1,3}\s*\)/gi, 'rgb(17,17,17)');
 }
 
 
@@ -7044,9 +7052,9 @@ function makeCardFace(rank, suit, theme, w = 768, h = 1080) {
     ctx.drawImage(canvas, -0.65, 0.65, canvas.width, canvas.height);
     ctx.drawImage(canvas, 0.65, -0.65, canvas.width, canvas.height);
 
-    // Slightly darker front-face matte layer for less glare and reduced overall brightness.
+    // Darker front-face matte layer for less glare and reduced overall brightness on mobile screens.
     ctx.globalAlpha = 1;
-    ctx.fillStyle = 'rgba(15, 23, 42, 0.2)';
+    ctx.fillStyle = 'rgba(15, 23, 42, 0.26)';
     ctx.fillRect(0, 0, canvas.width, canvas.height);
     ctx.restore();
 


### PR DESCRIPTION
### Motivation
- Improve on-screen layout for Murlan Royale so the bottom player's hand sits closer to the gift icon and slightly lower, community cards bias toward the top player, and the used/discard pile shifts toward the top/left player for better visual alignment in portrait mobile. 
- Reduce card face reflectivity to appear less glossy on mobile screens. 
- Make the black joker's interior figure solid black to match the red joker's visual weight.

### Description
- Updated layout constants in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to reposition elements: changed `DISCARD_PILE_FORWARD_SHIFT` to `-CARD_H * 0.12` and `DISCARD_PILE_RIGHT_SHIFT` to `-CARD_W * 0.28` to move the discard pile toward the top/left player; adjusted `HUMAN_HAND_BOTTOM_SHIFT_Y` to `-0.066 * MODEL_SCALE` and `HUMAN_HAND_LEFT_SHIFT` to `-0.032 * MODEL_SCALE` to nudge the bottom player's cards lower and slightly toward the gift icon; set `COMMUNITY_CARD_CLOSER_TO_HUMAN` to `-0.08 * MODEL_SCALE` so community cards bias toward the top player. 
- Reduced front-face brightness/matte glare by increasing the overlay in `makeCardFace` from `rgba(15, 23, 42, 0.2)` to `rgba(15, 23, 42, 0.26)`. 
- Ensured the black joker artwork renders with a solid black interior by altering `svgMarkupFromOpenSourceDeck` to normalize the `JB` (black joker) SVG output: force-use an open-source joker, then rewrite lighter color fills to `#111111` (and rgb variants) so the jockey/figure appears filled black.

### Testing
- Ran the Murlan unit tests with `npm test -- test/murlan.test.js --runInBand`, and the suite passed (Test Suites: 1 passed, Tests: 12 passed). 
- Ran `eslint` on the modified file; linter run completed but reported an ignore-pattern warning for the file (no lint errors reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9d06a21a88329b3de99622bfc2730)