### PR TITLE
Stop camera auto-focus for bottom human player and disable auto-follow on card plays (Murlan Royale)

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -4673,7 +4673,15 @@ export default function MurlanRoyaleArena({ search }) {
 
     clearCameraTurnHoldTimeout();
 
-    if (gameState?.status !== 'PLAYING' || activePlayer?.isHuman || !activeSeat?.stoolPosition) {
+    if (gameState?.status !== 'PLAYING') {
+      turnCameraTowardTarget(cameraDefaultTargetRef.current, { animate: true });
+      return;
+    }
+    if (activePlayer?.isHuman) {
+      // Keep the bottom player's current framing stable; only manual user gestures should move closer.
+      return;
+    }
+    if (!activeSeat?.stoolPosition) {
       turnCameraTowardTarget(cameraDefaultTargetRef.current, { animate: true });
       return;
     }
@@ -4704,65 +4712,11 @@ export default function MurlanRoyaleArena({ search }) {
     if (!threeReady) return;
     const action = gameState?.lastAction;
     if (!action || action.type !== 'PLAY') return;
-    clearCameraTurnHoldTimeout();
-    clearCameraPlayFollowTimeout();
-    stopCameraPlayTrackAnimation();
-
-    const store = threeStateRef.current;
-    const playedCardId = action.cards?.[0]?.id;
-    const playedCardMesh = playedCardId ? store.cardMap.get(playedCardId)?.mesh : null;
-    const centerTarget = playedCardMesh?.position?.clone?.() ?? store.tableAnchor?.clone?.() ?? cameraDefaultTargetRef.current.clone();
-    turnCameraTowardTarget(centerTarget, { animate: true, durationMs: CAMERA_PLAY_TURN_DURATION_MS });
-
-    const start =
-      typeof performance !== 'undefined' && typeof performance.now === 'function'
-        ? performance.now()
-        : Date.now();
-    const trackUntil = start + CAMERA_PLAY_FOLLOW_HOLD_MS;
-    const trackCardDuringFlight = (time) => {
-      const cardTarget = playedCardMesh?.position?.clone?.() ?? store.tableAnchor?.clone?.() ?? centerTarget.clone();
-      turnCameraTowardTarget(cardTarget, { animate: false });
-      if (time < trackUntil) {
-        cameraPlayTrackAnimationRef.current = requestAnimationFrame(trackCardDuringFlight);
-      } else {
-        cameraPlayTrackAnimationRef.current = null;
-      }
-    };
-    cameraPlayTrackAnimationRef.current = requestAnimationFrame(trackCardDuringFlight);
-    cameraTurnSuppressUntilRef.current = start + CAMERA_PLAY_FOLLOW_HOLD_MS + CAMERA_PLAY_NEXT_TURN_DELAY_MS;
-
-    cameraPlayFollowTimeoutRef.current = setTimeout(() => {
-      const liveState = gameStateRef.current;
-      const activeIndex = liveState?.activePlayer;
-      const activeSeat = Number.isInteger(activeIndex) ? store.seatConfigs?.[activeIndex] : null;
-      const activePlayer = Number.isInteger(activeIndex) ? liveState?.players?.[activeIndex] : null;
-      if (liveState?.status !== 'PLAYING' || activePlayer?.isHuman || !activeSeat?.stoolPosition) {
-        turnCameraTowardTarget(cameraDefaultTargetRef.current, { animate: true });
-      } else {
-        const blendedFocus = cameraDefaultTargetRef.current
-          .clone()
-          .lerp(activeSeat.focus, CAMERA_PLAYER_TARGET_WEIGHT);
-        const sideSign = Math.sign(activeSeat?.stoolPosition?.x ?? 0);
-        if (sideSign !== 0) {
-          blendedFocus.x += sideSign * CAMERA_SIDE_LOOK_EXTRA;
-        }
-        turnCameraTowardTarget(blendedFocus, { animate: true });
-      }
-      cameraPlayFollowTimeoutRef.current = null;
-    }, CAMERA_PLAY_FOLLOW_HOLD_MS + CAMERA_PLAY_NEXT_TURN_DELAY_MS);
-
-    return () => {
-      clearCameraPlayFollowTimeout();
-      stopCameraPlayTrackAnimation();
-    };
+    // Do not auto-follow played cards; keep zoom/framing under user control.
   }, [
-    clearCameraPlayFollowTimeout,
-    clearCameraTurnHoldTimeout,
     gameState?.lastAction,
     gameState?.lastActionId,
-    stopCameraPlayTrackAnimation,
-    threeReady,
-    turnCameraTowardTarget
+    threeReady
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- Prevent the camera from automatically re-framing/zooming in when the bottom (human) player becomes active or when a card is played, so the user keeps manual control of camera framing and zoom during their turn and play animations.

### Description
- Update `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to stop automatic camera retargeting when the active player is a human, preserving the current user framing unless the player performs manual gestures.
- Disable the automatic camera follow/track behavior that ran on `PLAY` actions by short-circuiting that effect, preventing forced close-in or card-tracking during play animations.
- Adjust effect dependency lists and cleanup to remove the camera-follow logic and keep behavior explicit and stable for human-controlled turns.

### Testing
- Ran the production build with `cd webapp && npm run build`, which completed successfully (Vite emitted non-blocking warnings about a duplicate package key and large chunks but the build passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9df050760832995d48c106ec7ca6d)