### PR TITLE
Disable automatic camera close-ups for Murlan Royale plays and human turns

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2462,6 +2462,8 @@ const CAMERA_SIDE_LOOK_EXTRA = 0.42 * MODEL_SCALE;
 const CAMERA_INWARD_RADIUS_FACTOR = 0.94;
 const CAMERA_UP_TILT_FORWARD_BLEND = 0.34 * MODEL_SCALE;
 const CAMERA_UP_TILT_FORWARD_LERP = 0.14;
+const CAMERA_AUTO_FOCUS_ON_PLAY_ENABLED = false;
+const CAMERA_AUTO_RECENTER_ON_HUMAN_TURN_ENABLED = false;
 
 const PLAYER_COLORS = ['#f97316', '#38bdf8', '#a78bfa', '#22c55e'];
 const FALLBACK_SEAT_POSITIONS = [
@@ -4673,8 +4675,21 @@ export default function MurlanRoyaleArena({ search }) {
 
     clearCameraTurnHoldTimeout();
 
-    if (gameState?.status !== 'PLAYING' || activePlayer?.isHuman || !activeSeat?.stoolPosition) {
-      turnCameraTowardTarget(cameraDefaultTargetRef.current, { animate: true });
+    if (gameState?.status !== 'PLAYING') {
+      if (CAMERA_AUTO_RECENTER_ON_HUMAN_TURN_ENABLED) {
+        turnCameraTowardTarget(cameraDefaultTargetRef.current, { animate: true });
+      }
+      return;
+    }
+
+    if (activePlayer?.isHuman) {
+      if (CAMERA_AUTO_RECENTER_ON_HUMAN_TURN_ENABLED) {
+        turnCameraTowardTarget(cameraDefaultTargetRef.current, { animate: true });
+      }
+      return;
+    }
+
+    if (!activeSeat?.stoolPosition) {
       return;
     }
 
@@ -4702,6 +4717,7 @@ export default function MurlanRoyaleArena({ search }) {
 
   useEffect(() => {
     if (!threeReady) return;
+    if (!CAMERA_AUTO_FOCUS_ON_PLAY_ENABLED) return;
     const action = gameState?.lastAction;
     if (!action || action.type !== 'PLAY') return;
     clearCameraTurnHoldTimeout();


### PR DESCRIPTION
### Motivation
- Prevent forced camera close-ups when a card is placed or when the bottom (human) player’s turn begins so the player retains manual zoom control. 
- Make auto-focus behavior explicit and opt-in via flags to allow easy experimentation and configuration.

### Description
- Added two new camera flags in `MurlanRoyaleArena.jsx`: `CAMERA_AUTO_FOCUS_ON_PLAY_ENABLED` and `CAMERA_AUTO_RECENTER_ON_HUMAN_TURN_ENABLED`, both defaulting to `false`.
- Updated the turn-based camera `useEffect` to skip auto-recenter when the match is not playing or when the active player is human unless `CAMERA_AUTO_RECENTER_ON_HUMAN_TURN_ENABLED` is enabled.
- Updated the play-follow `useEffect` to early-return unless `CAMERA_AUTO_FOCUS_ON_PLAY_ENABLED` is enabled, preventing automatic camera-follow/track when a card is played.
- Kept existing camera APIs and animation helpers intact so manual camera controls remain unchanged.

### Testing
- Ran `npx eslint --no-warn-ignored webapp/src/pages/Games/MurlanRoyaleArena.jsx`, which produced no errors and only an informational warning about file-ignore patterns. (No other automated tests were run.)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9df050760832995d48c106ec7ca6d)