### PR TITLE
Tune Murlan Royale camera/hand framing and add 1v1/1v2 lobby choice

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2345,7 +2345,7 @@ const CAMERA_FOCUS_CENTER_LIFT = 0.1 * MODEL_SCALE;
 const CAMERA_TARGET_TOP_PLAYER_BIAS = 0.36 * MODEL_SCALE;
 const CAMERA_SCREEN_DOWN_SHIFT = 0.12 * MODEL_SCALE;
 const HUMAN_HAND_CARD_SCALE = 1.06;
-const HUMAN_HAND_CARD_SPACING = CARD_W * HUMAN_HAND_CARD_SCALE * 0.28;
+const HUMAN_HAND_CARD_SPACING = CARD_W * HUMAN_HAND_CARD_SCALE * 0.25;
 const HUMAN_HAND_CARD_MAX_SPREAD = HUMAN_HAND_CARD_SPACING * 10;
 const HUMAN_HAND_EXTRA_LIFT = 0.068 * MODEL_SCALE;
 const HUMAN_HAND_FAN_MAX_YAW = THREE.MathUtils.degToRad(15);
@@ -2353,7 +2353,7 @@ const HUMAN_HAND_FAN_ARC_LIFT = 0.036 * MODEL_SCALE;
 const HUMAN_HAND_FAN_DIRECTION = 1;
 const HUMAN_HAND_UNIFORM_YAW_FROM_LEFT = false;
 const HUMAN_HAND_CLOSER_OFFSET = 0.042 * MODEL_SCALE;
-const HUMAN_HAND_BOTTOM_SHIFT_Y = -0.066 * MODEL_SCALE;
+const HUMAN_HAND_BOTTOM_SHIFT_Y = -0.078 * MODEL_SCALE;
 const AI_HAND_BOTTOM_SHIFT_Y = -0.02 * MODEL_SCALE;
 const AI_HAND_CLOSER_OFFSET = 0.02 * MODEL_SCALE;
 const HUMAN_HAND_LEFT_SHIFT = -0.032 * MODEL_SCALE; // Negative value nudges the bottom human hand toward the right-side gift icon in portrait.
@@ -2463,7 +2463,7 @@ const CAMERA_INWARD_RADIUS_FACTOR = 0.94;
 const CAMERA_UP_TILT_FORWARD_BLEND = 0.34 * MODEL_SCALE;
 const CAMERA_UP_TILT_FORWARD_LERP = 0.14;
 const CAMERA_AUTO_FOCUS_ON_PLAY_ENABLED = false;
-const CAMERA_AUTO_RECENTER_ON_HUMAN_TURN_ENABLED = false;
+const CAMERA_AUTO_RECENTER_ON_HUMAN_TURN_ENABLED = true;
 
 const PLAYER_COLORS = ['#f97316', '#38bdf8', '#a78bfa', '#22c55e'];
 const FALLBACK_SEAT_POSITIONS = [
@@ -4967,7 +4967,7 @@ export default function MurlanRoyaleArena({ search }) {
         const scoreboardHeight = scoreboardWidth * 0.39;
         const scoreboardGeometry = new THREE.PlaneGeometry(scoreboardWidth, scoreboardHeight);
         const scoreboardMesh = new THREE.Mesh(scoreboardGeometry, scoreboardMaterial);
-        const scoreboardY = TABLE_HEIGHT + 1.32 * MODEL_SCALE;
+        const scoreboardY = TABLE_HEIGHT + 1.56 * MODEL_SCALE;
         const scoreboardZ = -Math.max(TABLE_RADIUS * 2.2, floorRadius * 0.72);
         scoreboardMesh.position.set(0, scoreboardY, scoreboardZ);
         scoreboardMesh.lookAt(new THREE.Vector3(0, scoreboardMesh.position.y, 0));
@@ -6275,6 +6275,11 @@ function buildPlayers(search) {
   const params = new URLSearchParams(search);
   const username = params.get('username') || 'You';
   const avatar = params.get('avatar') || '';
+  const requestedPlayers = Number.parseInt(params.get('players') || '', 10);
+  const totalPlayers = Number.isFinite(requestedPlayers)
+    ? Math.min(Math.max(requestedPlayers, 2), 4)
+    : 4;
+  const aiCount = Math.max(totalPlayers - 1, 1);
   const providedFlags = (params.get('flags') || '')
     .split(',')
     .map((value) => Number.parseInt(value, 10))
@@ -6284,12 +6289,19 @@ function buildPlayers(search) {
   const seedFlags = providedFlags.length
     ? [...providedFlags]
     : [...FLAG_EMOJIS].sort(() => 0.5 - Math.random());
-  const basePlayers = [
-    { name: username, avatar, isHuman: true },
-    seedFlags[0] ? { name: flagName(seedFlags[0]), avatar: seedFlags[0] } : { name: 'Aria', avatar: '🦊' },
-    seedFlags[1] ? { name: flagName(seedFlags[1]), avatar: seedFlags[1] } : { name: 'Milo', avatar: '🐻' },
-    seedFlags[2] ? { name: flagName(seedFlags[2]), avatar: seedFlags[2] } : { name: 'Sora', avatar: '🐱' }
+  const fallbackAiRoster = [
+    { name: 'Aria', avatar: '🦊' },
+    { name: 'Milo', avatar: '🐻' },
+    { name: 'Sora', avatar: '🐱' }
   ];
+  const aiPlayers = Array.from({ length: aiCount }, (_, index) => {
+    const flag = seedFlags[index];
+    if (flag) {
+      return { name: flagName(flag), avatar: flag };
+    }
+    return fallbackAiRoster[index] ?? { name: `Bot ${index + 1}`, avatar: '🤖' };
+  });
+  const basePlayers = [{ name: username, avatar, isHuman: true }, ...aiPlayers];
   return basePlayers.map((player, index) => ({ ...player, color: PLAYER_COLORS[index % PLAYER_COLORS.length] }));
 }
 

--- a/webapp/src/pages/Games/MurlanRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleLobby.jsx
@@ -35,6 +35,7 @@ export default function MurlanRoyaleLobby() {
   const [mode, setMode] = useState('local');
   const [avatar, setAvatar] = useState('');
   const [gameType, setGameType] = useState('single');
+  const [opponentCount, setOpponentCount] = useState(2);
   const [targetPoints, setTargetPoints] = useState(11);
   const [showFlagPicker, setShowFlagPicker] = useState(false);
   const [flags, setFlags] = useState(() => pickRandomFlags(4));
@@ -42,7 +43,8 @@ export default function MurlanRoyaleLobby() {
   const [matchStatus, setMatchStatus] = useState('');
   const [matchError, setMatchError] = useState('');
 
-  const flagPickerCount = mode === 'local' ? 4 : 1;
+  const totalPlayers = opponentCount + 1;
+  const flagPickerCount = mode === 'local' ? opponentCount : 1;
 
   const openAiFlagPicker = () => {
     setShowFlagPicker(true);
@@ -71,7 +73,7 @@ export default function MurlanRoyaleLobby() {
       await runSimpleOnlineFlow({
         gameType: 'murlanroyale',
         stake,
-        maxPlayers: 2,
+        maxPlayers: totalPlayers,
         avatar,
         playerName: getTelegramFirstName() || 'Player',
         state: { setMatching, setMatchStatus, setMatchError },
@@ -82,6 +84,7 @@ export default function MurlanRoyaleLobby() {
           params.set('tableId', tableId);
           params.set('accountId', accountId);
           params.set('game', gameType);
+          params.set('players', String(totalPlayers));
           if (gameType === 'points') params.set('points', String(targetPoints));
           if (stake.token) params.set('token', stake.token);
           if (stake.amount) params.set('amount', String(stake.amount));
@@ -115,6 +118,7 @@ export default function MurlanRoyaleLobby() {
     const params = new URLSearchParams();
     params.set('mode', mode);
     params.set('game', gameType);
+    params.set('players', String(totalPlayers));
     if (gameType === 'points') params.set('points', targetPoints);
     if (mode !== 'local' && stake.token) params.set('token', stake.token);
     if (mode !== 'local' && stake.amount) params.set('amount', stake.amount);
@@ -232,6 +236,46 @@ export default function MurlanRoyaleLobby() {
           <p className="text-xs text-white/60 text-center">
             AI matches stay offline while the arena preloads. Online mode launches when staking is ready.
           </p>
+        </div>
+
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold text-white">Players</h3>
+            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Table size</span>
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            {[
+              { opponents: 1, label: '1v1', desc: 'You vs 1 player', icon: '🆚' },
+              { opponents: 2, label: '1v2', desc: 'You vs 2 players', icon: '👥' }
+            ].map(({ opponents, label, desc, icon }) => {
+              const active = opponentCount === opponents;
+              return (
+                <button
+                  key={label}
+                  type="button"
+                  onClick={() => setOpponentCount(opponents)}
+                  className={`lobby-option-card ${
+                    active ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
+                  }`}
+                >
+                  <div className="lobby-option-thumb bg-gradient-to-br from-cyan-400/30 via-sky-500/10 to-transparent">
+                    <div className="lobby-option-thumb-inner">
+                      <OptionIcon
+                        src={getLobbyIcon('murlanroyale', `players-${opponents}`)}
+                        alt={label}
+                        fallback={icon}
+                        className="lobby-option-icon"
+                      />
+                    </div>
+                  </div>
+                  <div className="text-center">
+                    <p className="lobby-option-label">{label}</p>
+                    <p className="lobby-option-subtitle">{desc}</p>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
         </div>
 
         {mode === 'local' ? (


### PR DESCRIPTION
### Motivation
- Improve portrait UX by returning the camera to the initial (start) framing when control returns to the bottom (human) player, make the human player's cards sit a bit closer and lower for readability, lift the results/leaderboard frame higher on-screen, and give players a simple lobby choice between 1v1 and 1v2.

### Description
- Updated `MurlanRoyaleArena.jsx` to enable auto-recenter on human turn by setting `CAMERA_AUTO_RECENTER_ON_HUMAN_TURN_ENABLED = true` to return the camera to the default start framing when the bottom player gets the turn.
- Reduced bottom-hand spacing and lowered its on-screen position by changing `HUMAN_HAND_CARD_SPACING` (from `* 0.28` to `* 0.25`) and `HUMAN_HAND_BOTTOM_SHIFT_Y` (from `-0.066 * MODEL_SCALE` to `-0.078 * MODEL_SCALE`).
- Moved the in-arena results/leaderboard plane upward by increasing `scoreboardY` (`TABLE_HEIGHT + 1.32 * MODEL_SCALE` → `TABLE_HEIGHT + 1.56 * MODEL_SCALE`).
- Made player roster dynamic by extending `buildPlayers(search)` to read a `players` query parameter (clamped to 2..4) and generate the corresponding number of AI opponents, keeping the human player as the bottom seat.
- Updated `MurlanRoyaleLobby.jsx` to add an opponent count state (`opponentCount`), a small UI card selector for `1v1` and `1v2`, pass `players` in navigation query params, set `maxPlayers` for online flow, and align the local flag picker with the selected opponent count.

### Testing
- Ran `npm run build` (TypeScript build) and it completed successfully.
- Ran `npx eslint webapp/src/pages/Games/MurlanRoyaleArena.jsx webapp/src/pages/Games/MurlanRoyaleLobby.jsx` which returned warnings because the files are ignored by the repository ESLint ignore patterns in this environment (no lint errors reported for the edits themselves).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9e2c489b08329a1bc8dd39995f22f)