### PR TITLE
Add 1v3 table-size option in Murlan Royale lobby

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleLobby.jsx
@@ -243,10 +243,11 @@ export default function MurlanRoyaleLobby() {
             <h3 className="font-semibold text-white">Players</h3>
             <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Table size</span>
           </div>
-          <div className="grid grid-cols-2 gap-3">
+          <div className="grid grid-cols-3 gap-3">
             {[
               { opponents: 1, label: '1v1', desc: 'You vs 1 player', icon: '🆚' },
-              { opponents: 2, label: '1v2', desc: 'You vs 2 players', icon: '👥' }
+              { opponents: 2, label: '1v2', desc: 'You vs 2 players', icon: '👥' },
+              { opponents: 3, label: '1v3', desc: 'You vs 3 players', icon: '🧩' }
             ].map(({ opponents, label, desc, icon }) => {
               const active = opponentCount === opponents;
               return (


### PR DESCRIPTION
### Motivation
- Restore a third table-size choice so players can select `1v3` (you vs 3 players) from the Murlan Royale lobby and ensure all options are visible at once.

### Description
- Updated the players selector in `webapp/src/pages/Games/MurlanRoyaleLobby.jsx` to add `{ opponents: 3, label: '1v3', ... }` and changed the layout from `grid-cols-2` to `grid-cols-3` so `1v1`, `1v2` and `1v3` display together.

### Testing
- Ran the unit test command `npm test -- test/lobbyUtils.test.js --runInBand` and the suite passed (all tests green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9e670f39483298d8e1862b4e82eae)