### PR TITLE
Rotate camera toward played card without dolly (Murlan Royale)

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -3607,31 +3607,48 @@ export default function MurlanRoyaleArena({ search }) {
       if (!controls || !camera || !basis?.targetDistance) return;
 
       const fallbackTarget = cameraDefaultTargetRef.current;
+      const lockedPosition = cameraLockedPositionRef.current;
       const desiredPoint = targetPoint?.clone?.() ?? fallbackTarget.clone();
-      const aimDirection = desiredPoint.sub(camera.position);
-      if (aimDirection.lengthSq() <= 1e-6) return;
-      aimDirection.normalize();
-      const desiredTarget = camera.position.clone().addScaledVector(aimDirection, basis.targetDistance);
-      const snapDistance = controls.target.distanceTo(desiredTarget);
+      const desiredDirection = desiredPoint.sub(lockedPosition);
+      if (desiredDirection.lengthSq() <= 1e-6) return;
+      desiredDirection.normalize();
+
+      const applyDirection = (direction) => {
+        camera.position.copy(lockedPosition);
+        controls.target.copy(lockedPosition).addScaledVector(direction, basis.targetDistance);
+        camera.lookAt(controls.target);
+        updateSeatAnchors();
+      };
+
+      const currentDirection = cameraForwardScratchRef.current;
+      camera.getWorldDirection(currentDirection);
+      if (currentDirection.lengthSq() <= 1e-8) {
+        applyDirection(desiredDirection);
+        return;
+      }
+      currentDirection.normalize();
+      const snapDistance = currentDirection.distanceTo(desiredDirection);
 
       if (snapDistance <= CAMERA_TARGET_TURN_SNAP_DISTANCE || options.animate === false) {
         stopCameraTurnAnimation();
-        controls.target.copy(desiredTarget);
-        controls.update();
-        updateSeatAnchors();
+        applyDirection(desiredDirection);
         return;
       }
 
       stopCameraTurnAnimation();
       const durationMs = options.durationMs ?? CAMERA_TURN_DURATION_MS;
       const startTime = performance.now();
-      const startTarget = controls.target.clone();
+      const startQuat = new THREE.Quaternion().setFromUnitVectors(new THREE.Vector3(0, 0, -1), currentDirection);
+      const endQuat = new THREE.Quaternion().setFromUnitVectors(new THREE.Vector3(0, 0, -1), desiredDirection);
+      const tmpQuat = new THREE.Quaternion();
+      const tmpDirection = new THREE.Vector3();
+
       const animateStep = (now) => {
         const t = Math.min(1, (now - startTime) / Math.max(1, durationMs));
         const eased = t * (2 - t);
-        controls.target.lerpVectors(startTarget, desiredTarget, eased);
-        controls.update();
-        updateSeatAnchors();
+        tmpQuat.slerpQuaternions(startQuat, endQuat, eased);
+        tmpDirection.set(0, 0, -1).applyQuaternion(tmpQuat).normalize();
+        applyDirection(tmpDirection);
         if (t < 1) {
           cameraTurnAnimationRef.current = requestAnimationFrame(animateStep);
         } else {


### PR DESCRIPTION
### Motivation
- Prevent the camera from translating/zooming (dolly) when auto-focusing on a card being placed and instead only rotate the view to look at the card while keeping the same camera distance.

### Description
- Reworked `turnCameraTowardTarget` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to compute a direction from a locked camera anchor (`cameraLockedPositionRef`) and steer the camera by rotating its forward direction rather than lerping the orbit target.
- Replaced controls.target position lerp with direction interpolation using `Quaternion.slerp` to smoothly rotate the view while preserving camera position and `basis.targetDistance`.
- Added an `applyDirection` helper that writes the rotated `controls.target`, calls `camera.lookAt`, and refreshes HUD anchors via `updateSeatAnchors` to keep UI aligned.
- Preserved smoothing/duration behavior and the existing snap/animation flags (`CAMERA_TARGET_TURN_SNAP_DISTANCE`, `CAMERA_TURN_DURATION_MS`) so transitions remain smooth.

### Testing
- Ran unit tests: `npm test -- test/murlan.test.js --runInBand` and all tests passed (1 suite, 12 tests). 
- Ran linter: `npx eslint webapp/src/pages/Games/MurlanRoyaleArena.jsx` (file is ignored by repo eslint config; reported as ignored/warning, no actionable lint errors reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9f2b8d5708329998c9c91d468a8e3)