### PR TITLE
Fix Murlan card-play camera to rotate without moving closer

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -3453,6 +3453,7 @@ export default function MurlanRoyaleArena({ search }) {
   const cameraTurnSuppressUntilRef = useRef(0);
   const cameraPlayFollowTimeoutRef = useRef(null);
   const cameraPlayTrackAnimationRef = useRef(null);
+  const cameraDisableForwardDriftUntilRef = useRef(0);
 
   const enforceRotationOnlyCamera = useCallback(() => {
     const { camera, controls } = threeStateRef.current;
@@ -3466,8 +3467,15 @@ export default function MurlanRoyaleArena({ search }) {
     const phiMin = Number.isFinite(orbit.phiMin) ? orbit.phiMin : controls.minPolarAngle;
     const phiMax = Number.isFinite(orbit.phiMax) ? orbit.phiMax : controls.maxPolarAngle;
     const basePhi = Number.isFinite(orbit.phi) ? orbit.phi : currentSpherical.phi;
+    const now =
+      typeof performance !== 'undefined' && typeof performance.now === 'function'
+        ? performance.now()
+        : Date.now();
+    const disableForwardDrift = now < cameraDisableForwardDriftUntilRef.current;
     const upTiltRange = Math.max(1e-4, basePhi - phiMin);
-    const upTiltRatio = THREE.MathUtils.clamp((basePhi - currentSpherical.phi) / upTiltRange, 0, 1);
+    const upTiltRatio = disableForwardDrift
+      ? 0
+      : THREE.MathUtils.clamp((basePhi - currentSpherical.phi) / upTiltRange, 0, 1);
     const forwardOffset = cameraForwardOffsetScratchRef.current
       .copy(defaultTarget)
       .sub(basePosition)
@@ -4746,6 +4754,8 @@ export default function MurlanRoyaleArena({ search }) {
     };
     cameraPlayTrackAnimationRef.current = requestAnimationFrame(trackCardDuringFlight);
     cameraTurnSuppressUntilRef.current = start + CAMERA_PLAY_FOLLOW_HOLD_MS + CAMERA_PLAY_NEXT_TURN_DELAY_MS;
+    cameraDisableForwardDriftUntilRef.current =
+      start + CAMERA_PLAY_FOLLOW_HOLD_MS + CAMERA_PLAY_NEXT_TURN_DELAY_MS;
 
     cameraPlayFollowTimeoutRef.current = setTimeout(() => {
       const liveState = gameStateRef.current;


### PR DESCRIPTION
### Motivation
- Players need the camera to look toward a card being placed without the view appearing to zoom in or move closer during the play-follow window.
- Current auto-focus tracking applied a forward-drift positional blend which made the camera feel like it was moving inwards instead of only rotating.

### Description
- Added a `cameraDisableForwardDriftUntilRef` and wired it into `enforceRotationOnlyCamera` so the forward-drift blend is suppressed while the play-follow tracking is active.
- When a `PLAY` action is tracked the code now sets `cameraDisableForwardDriftUntilRef.current` for the same window used to suppress turn updates (`CAMERA_PLAY_FOLLOW_HOLD_MS + CAMERA_PLAY_NEXT_TURN_DELAY_MS`).
- The suppression forces the `upTiltRatio` to `0` while active so the camera rotates to face the played card without changing its position.
- Change is isolated to `webapp/src/pages/Games/MurlanRoyaleArena.jsx` and does not modify gameplay rules or APIs.

### Testing
- Ran `npm -C webapp run -s lint` which returned a non-zero exit (lint step failed in this environment).
- Ran `npm -C webapp run -s build` which completed successfully in this environment with non-blocking Vite warnings about duplicate dependency keys and chunk sizes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9f2b8d5708329998c9c91d468a8e3)