### PR TITLE
Refactor airstrike/capture FX: new flight profiles, pathing, and parked-unit handling

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -144,18 +144,22 @@ const CAPTURE_DIRECT_STRIKE_INWARD_DISTANCE = 0.1; // straighter launch line tow
 const CAPTURE_DIRECT_STRIKE_TAKEOFF_RATIO = 0.34; // quicker lift for cleaner direct strike
 const CAPTURE_DIRECT_STRIKE_RETURN_RATIO = 0.54; // return earlier so fly-bys stay close to board
 const CAPTURE_VERTICAL_STRIKE_INWARD_DISTANCE = 0; // pawn/drone/truck missile rises straight up from launch point
-const CAPTURE_VERTICAL_STRIKE_ALTITUDE = 0.07; // even lower pawn/drone strike profile
+const CAPTURE_VERTICAL_STRIKE_ALTITUDE = 0.054; // lower short-missile cruise lane so it sits visibly lower on portrait screens
 const CAPTURE_VERTICAL_STRIKE_TOP_OFFSET = 0.05; // shorter top point before vertical drop
 const CAPTURE_VERTICAL_STRIKE_HORIZONTAL_RATIO = 0.22; // shorter top-flight pass before vertical crash
 const CAPTURE_PRECISION_STRIKE_LIFT_RATIO = 0.28; // strict vertical launch segment for short missiles
 const CAPTURE_PRECISION_STRIKE_DROP_RATIO = 0.24; // strict vertical terminal drop for short missiles
-const CAPTURE_LOOP_TAKEOFF_RATIO = 0.18; // show aircraft lifting from pad before starting loop
+const CAPTURE_SHORT_STRIKE_ALTITUDE = CAPTURE_DRONE_REFERENCE_BOARD_ALTITUDE * 0.62; // shared pawn/drone/truck short-strike altitude
+const CAPTURE_LOOP_TAKEOFF_RATIO = 0.3; // longer visible lift so side-pad takeoff is clearly readable on portrait screens
 const CAPTURE_AIR_APPROACH_RATIO = 0.58; // jet/heli approach target, fire, then return
 const CAPTURE_RELOAD_SHOW_TIME = 0.58;
 const CAPTURE_MISSILE_SCALE = 0.068;
 const CAPTURE_JAVELIN_MISSILE_SCALE = CAPTURE_MISSILE_SCALE * 1.48; // make javelin missile bigger
 const CAPTURE_PAWN_JAVELIN_SCALE = CAPTURE_JAVELIN_MISSILE_SCALE * 0.72;
 const CAPTURE_ROOK_JAVELIN_SCALE = CAPTURE_JAVELIN_MISSILE_SCALE * 1.04; // make rook javelin read as a heavy drone-sized strike
+const CAPTURE_JET_ATTACK_PROFILE = Object.freeze({ inward: 0.92, takeoff: 0.2, landing: 0.24, phaseSplit: 0.84, apexHeightMul: 0.52 });
+const CAPTURE_HELI_ATTACK_PROFILE = Object.freeze({ inward: 0.9, takeoff: 0.22, landing: 0.26, phaseSplit: 0.84, apexHeightMul: 0.62 });
+const CAPTURE_DRONE_ATTACK_PROFILE = Object.freeze({ inward: 0.88, takeoff: 0.24, landing: 0.2, phaseSplit: 0.78, apexHeightMul: 0.56 });
 const CAPTURE_EXPLOSION_SCALE = 0.132; // smaller capture explosion
 const CAPTURE_EDGE_PATH_FACTOR = 0.52;
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
@@ -9427,10 +9431,6 @@ function Chess3D({
       if (!preferred?.root) return null;
       preferred.busy = true;
       preferred.root.visible = true;
-      if (preferred.root.parent !== captureFxGroup) {
-        preferred.root.parent?.remove(preferred.root);
-        captureFxGroup.add(preferred.root);
-      }
       return preferred;
     };
     const returnParkedAirUnit = (unit) => {
@@ -9813,43 +9813,83 @@ function Chess3D({
       }
       return { pos: clampIfNeeded(pos), next: clampIfNeeded(next) };
     };
+    const remapTakeoffLandingProgress = (progress, takeoff = 0.2, landing = 0.24) => {
+      const u = clamp01(progress);
+      const activeSpan = Math.max(0.001, 1 - takeoff - landing);
+      if (u <= takeoff) return smoothEase((u / Math.max(0.001, takeoff)) * 0.16);
+      if (u >= 1 - landing) {
+        const landU = smoothEase((u - (1 - landing)) / Math.max(0.001, landing));
+        return clamp01(0.84 + landU * 0.16);
+      }
+      const cruiseU = (u - takeoff) / activeSpan;
+      return clamp01(0.16 + cruiseU * 0.68);
+    };
     const getCaptureAirRunPose = ({
       from,
       to,
       progress,
-      launchHeight = 0.08,
+      launchHeight = 0.06,
       cruiseHeight = CAPTURE_FLIGHT_ALTITUDE * CAPTURE_AIR_STRIKE_ORBIT_HEIGHT_MUL,
-      returnToOrigin = true
+      returnToOrigin = true,
+      constrainToBoard = true,
+      profile = CAPTURE_JET_ATTACK_PROFILE
     }) => {
-      const launchPos = from.clone().add(new THREE.Vector3(0, launchHeight, 0));
+      const clampIfNeeded = (value) => (constrainToBoard ? constrainInsideBoardPerimeter(value) : value);
+      const launchPos = from.clone();
+      const liftTop = from.clone().add(new THREE.Vector3(0, launchHeight, 0));
       const toVec = to.clone();
-      const approachPoint = launchPos.clone().lerp(toVec, 0.42);
-      approachPoint.y = Math.max(launchPos.y + tile * 0.04, toVec.y + cruiseHeight);
-      const nearTargetPoint = toVec.clone();
-      nearTargetPoint.y = Math.max(toVec.y + cruiseHeight * 0.9, launchPos.y + tile * 0.03);
-      const u = clamp01(progress);
-      const takeoffSplit = Math.min(CAPTURE_LOOP_TAKEOFF_RATIO, CAPTURE_AIR_APPROACH_RATIO * 0.4);
-      if (u < takeoffSplit) {
-        const su = smoothEase(u / Math.max(0.001, takeoffSplit));
-        const liftPoint = launchPos.clone();
-        liftPoint.y = approachPoint.y;
-        const pos = launchPos.clone().lerp(liftPoint, su);
-        const next = launchPos.clone().lerp(liftPoint, clamp01(su + 0.05));
-        return { pos: constrainInsideBoardPerimeter(pos), next: constrainInsideBoardPerimeter(next) };
+      const arenaCenter = new THREE.Vector3(0, liftTop.y, 0);
+      const fromOffset = liftTop.clone().sub(arenaCenter).setY(0);
+      const toOffset = toVec.clone().sub(arenaCenter).setY(0);
+      const fallbackRadius = Math.max(tile * 2.75, Math.max(fromOffset.length(), toOffset.length(), 0.001));
+      const orbitalRadius = fallbackRadius * (profile?.inward ?? 0.92);
+      const fromAngle = Math.atan2(fromOffset.z || 0.001, fromOffset.x || Math.sign(liftTop.x || 1));
+      const toAngle = Math.atan2(toOffset.z || 0.001, toOffset.x || Math.sign(toVec.x || 1));
+      let angularDelta = toAngle - fromAngle;
+      if (angularDelta <= 0) angularDelta += Math.PI * 2;
+      if (angularDelta < Math.PI / 3) angularDelta += Math.PI * 2;
+      const cruiseAngle = fromAngle + angularDelta * 0.7;
+      const apexHeight = Math.max(
+        liftTop.y + cruiseHeight * 0.8,
+        toVec.y + Math.max(tile * (profile?.apexHeightMul ?? 0.52), cruiseHeight * 1.6)
+      );
+      const apex = new THREE.Vector3(
+        arenaCenter.x + Math.cos(cruiseAngle) * orbitalRadius,
+        apexHeight,
+        arenaCenter.z + Math.sin(cruiseAngle) * orbitalRadius
+      );
+      const phaseSplit = clamp01(profile?.phaseSplit ?? 0.84);
+      const mappedU = remapTakeoffLandingProgress(
+        progress,
+        Math.max(CAPTURE_LOOP_TAKEOFF_RATIO, profile?.takeoff ?? 0.2),
+        profile?.landing ?? 0.24
+      );
+      const pathAt = (v) => {
+        const u = clamp01(v);
+        if (u < phaseSplit) {
+          const a = smoothEase(u / Math.max(0.001, phaseSplit));
+          const orbitAngle = fromAngle + angularDelta * a;
+          const ring = new THREE.Vector3(
+            arenaCenter.x + Math.cos(orbitAngle) * orbitalRadius,
+            THREE.MathUtils.lerp(liftTop.y, apex.y, a),
+            arenaCenter.z + Math.sin(orbitAngle) * orbitalRadius
+          );
+          return liftTop.clone().lerp(ring, 0.76 + a * 0.24);
+        }
+        const d = smoothEase((u - phaseSplit) / Math.max(0.001, 1 - phaseSplit));
+        const flyByEnd = toVec
+          .clone()
+          .add(toVec.clone().sub(arenaCenter).setY(0).normalize().multiplyScalar(orbitalRadius * 0.66))
+          .add(new THREE.Vector3(0, tile * 0.22, 0));
+        return qBezier(apex, apex.clone().lerp(flyByEnd, 0.5), flyByEnd, d);
+      };
+      const pos = pathAt(mappedU);
+      const next = pathAt(clamp01(mappedU + 0.03));
+      if (returnToOrigin && progress >= 1) {
+        const landPos = liftTop.clone();
+        return { pos: clampIfNeeded(landPos), next: clampIfNeeded(landPos.clone().add(new THREE.Vector3(0.02, 0, 0))) };
       }
-      if (u < CAPTURE_AIR_APPROACH_RATIO) {
-        const su = smoothEase((u - takeoffSplit) / Math.max(0.001, CAPTURE_AIR_APPROACH_RATIO - takeoffSplit));
-        const pos = launchPos.clone().lerp(approachPoint, su);
-        const next = launchPos.clone().lerp(approachPoint, clamp01(su + 0.05));
-        return { pos: constrainInsideBoardPerimeter(pos), next: constrainInsideBoardPerimeter(next) };
-      }
-      if (returnToOrigin) {
-        const ru = smoothEase((u - CAPTURE_AIR_APPROACH_RATIO) / Math.max(0.001, 1 - CAPTURE_AIR_APPROACH_RATIO));
-        const pos = nearTargetPoint.clone().lerp(launchPos, ru);
-        const next = nearTargetPoint.clone().lerp(launchPos, clamp01(ru + 0.05));
-        return { pos: constrainInsideBoardPerimeter(pos), next: constrainInsideBoardPerimeter(next) };
-      }
-      return { pos: nearTargetPoint, next: toVec.clone() };
+      return { pos: clampIfNeeded(pos), next: clampIfNeeded(next) };
     };
     const getCaptureDirectStrikePose = ({
       launchPos,
@@ -9944,10 +9984,10 @@ function Chess3D({
         return { pos, next };
       }
       const cu = smoothEase((u - CAPTURE_PRECISION_STRIKE_LIFT_RATIO) / travelSpan);
-      const pos = liftEnd.clone().lerp(strikeTop, cu);
-      const next = liftEnd.clone().lerp(strikeTop, clamp01(cu + 0.05));
-      pos.y = liftEnd.y;
-      next.y = liftEnd.y;
+      const naturalDropControl = liftEnd.clone().lerp(strikeTop, 0.5);
+      naturalDropControl.y = Math.max(targetPos.y + CAPTURE_VERTICAL_STRIKE_TOP_OFFSET * 1.25, liftEnd.y * 0.9);
+      const pos = qBezier(liftEnd, naturalDropControl, targetPos, cu);
+      const next = qBezier(liftEnd, naturalDropControl, targetPos, clamp01(cu + 0.06));
       return { pos, next };
     };
 
@@ -9966,9 +10006,10 @@ function Chess3D({
         suppressTimerBeepUntilRef.current = performance.now() + CAPTURE_GROUND_TOTAL * 1000;
         const missileFx = createFxGroundMissile();
         missileFx.root.scale.setScalar(CAPTURE_ROOK_JAVELIN_SCALE);
-        const parkedTruck = acquireParkedSupportUnit(Boolean(movingMesh?.userData?.w));
-        const launchBase = getLiveLaunchPosition(fromPos.clone(), movingMesh, 0.11);
-        missileFx.root.position.copy(launchBase.clone().add(new THREE.Vector3(0, 0.14, 0)));
+        const isWhiteSide = Boolean(movingMesh?.userData?.w);
+        const parkedTruck = acquireParkedSupportUnit(isWhiteSide);
+        const launchBase = parkedTruck?.homePosition?.clone?.() || getAirPadAnchor(isWhiteSide, 'truck', 0);
+        missileFx.root.position.copy(launchBase.clone());
         captureFxGroup.add(missileFx.root);
         playAudio(missileLaunchSoundRef);
         activeCaptureFx.push({
@@ -9977,10 +10018,10 @@ function Chess3D({
           duration: CAPTURE_GROUND_TOTAL,
           from: fromPos.clone(),
           to: targetPos.clone(),
-          launchPos: launchBase.add(new THREE.Vector3(0, 0.03, 0)),
+          launchPos: launchBase.clone(),
           movingMesh,
           targetMesh,
-          launchFromLivePiece: true,
+          launchFromLivePiece: false,
           sourceUnit: parkedTruck,
           missileFx,
           directPath: false,
@@ -9997,14 +10038,11 @@ function Chess3D({
           suppressTimerBeepUntilRef.current = performance.now() + CAPTURE_GROUND_TOTAL * 1000;
           const isWhiteSide = Boolean(movingMesh?.userData?.w);
           const parkedDrone = acquireParkedAirUnit(isWhiteSide, 'drone');
-          const droneFx = parkedDrone || createFxDrone({ forceProcedural: true });
+          const droneFx = createFxDrone({ forceProcedural: !parkedDrone });
           droneFx.root.scale.setScalar(CAPTURE_DRONE_SCALE);
-          if (!parkedDrone) {
-            const launchBase = getAirPadAnchor(isWhiteSide, 'drone', 0);
-            droneFx.root.position.copy(launchBase.clone().add(new THREE.Vector3(0, 0.08, 0)));
-            captureFxGroup.add(droneFx.root);
-          }
           const launchBase = parkedDrone?.homePosition?.clone?.() || getAirPadAnchor(isWhiteSide, 'drone', 0);
+          droneFx.root.position.copy(launchBase.clone());
+          captureFxGroup.add(droneFx.root);
           playAudio(droneSoundRef, { maxDurationMs: CAPTURE_GROUND_TOTAL * 1000 });
           activeCaptureFx.push({
             type: 'drone',
@@ -10012,7 +10050,7 @@ function Chess3D({
             duration: CAPTURE_GROUND_TOTAL,
             from: fromPos.clone(),
             to: targetPos.clone(),
-            launchPos: launchBase.add(new THREE.Vector3(0, 0.08, 0)),
+            launchPos: launchBase.clone(),
             movingMesh,
             targetMesh,
             returnToOrigin: true,
@@ -10056,23 +10094,20 @@ function Chess3D({
         suppressTimerBeepUntilRef.current = performance.now() + CAPTURE_JET_TOTAL * 1000;
         const isWhiteSide = Boolean(movingMesh?.userData?.w);
         const parkedUnit = acquireParkedAirUnit(isWhiteSide, 'jet');
-        const jetFx = parkedUnit || createFxJet();
-        if (!parkedUnit) {
-          jetFx.root.scale.setScalar(CAPTURE_JET_SCALE);
-          const launchBase = getAirPadAnchor(isWhiteSide, 'jet', 0);
-          const sideSkin = resolveSideVehicleSkin(isWhiteSide);
-          if (sideSkin) applyVehicleSkinToModel(jetFx.root, sideSkin);
-          attachVehicleAvatarBadge(
-            jetFx.root,
-            isWhiteSide
-              ? avatar || username || playerFlag || '🙂'
-              : (onlineRef.current.enabled ? opponent?.avatar || opponent?.name : null) || opponent?.name || aiFlag || '🤖',
-            isWhiteSide ? 1 : -1
-          );
-          jetFx.root.position.copy(launchBase.clone().add(new THREE.Vector3(0, 0.08, 0)));
-          captureFxGroup.add(jetFx.root);
-        }
+        const jetFx = createFxJet();
+        jetFx.root.scale.setScalar(CAPTURE_JET_SCALE);
         const launchBase = parkedUnit?.homePosition?.clone?.() || getAirPadAnchor(isWhiteSide, 'jet', 0);
+        const sideSkin = resolveSideVehicleSkin(isWhiteSide);
+        if (sideSkin) applyVehicleSkinToModel(jetFx.root, sideSkin);
+        attachVehicleAvatarBadge(
+          jetFx.root,
+          isWhiteSide
+            ? avatar || username || playerFlag || '🙂'
+            : (onlineRef.current.enabled ? opponent?.avatar || opponent?.name : null) || opponent?.name || aiFlag || '🤖',
+          isWhiteSide ? 1 : -1
+        );
+        jetFx.root.position.copy(launchBase.clone());
+        captureFxGroup.add(jetFx.root);
         const missileFx = [createFxGroundMissile(), createFxGroundMissile()];
         missileFx.forEach((missile) => {
           missile.root.scale.setScalar(CAPTURE_MISSILE_SCALE);
@@ -10105,27 +10140,24 @@ function Chess3D({
         suppressTimerBeepUntilRef.current = performance.now() + CAPTURE_HELICOPTER_TOTAL * 1000;
         const isWhiteSide = Boolean(movingMesh?.userData?.w);
         const parkedUnit = acquireParkedAirUnit(isWhiteSide, 'helicopter');
-        const helicopterFx = parkedUnit || createFxHelicopter();
-        if (!parkedUnit) {
-          helicopterFx.root.scale.setScalar(CAPTURE_HELICOPTER_SCALE);
-          const launchBase = getAirPadAnchor(isWhiteSide, 'helicopter', 0);
-          const sideSkin = resolveSideVehicleSkin(isWhiteSide);
-          if (sideSkin) {
-            applyVehicleSkinToModel(helicopterFx.root, sideSkin, (node) =>
-              /rotor|propell|blade|fan|window|cockpit|glass|canopy/.test(`${node.name || ''}`.toLowerCase())
-            );
-          }
-          attachVehicleAvatarBadge(
-            helicopterFx.root,
-            isWhiteSide
-              ? avatar || username || playerFlag || '🙂'
-              : (onlineRef.current.enabled ? opponent?.avatar || opponent?.name : null) || opponent?.name || aiFlag || '🤖',
-            isWhiteSide ? 1 : -1
-          );
-          helicopterFx.root.position.copy(launchBase.clone().add(new THREE.Vector3(0, 0.08, 0)));
-          captureFxGroup.add(helicopterFx.root);
-        }
+        const helicopterFx = createFxHelicopter();
+        helicopterFx.root.scale.setScalar(CAPTURE_HELICOPTER_SCALE);
         const launchBase = parkedUnit?.homePosition?.clone?.() || getAirPadAnchor(isWhiteSide, 'helicopter', 0);
+        const sideSkin = resolveSideVehicleSkin(isWhiteSide);
+        if (sideSkin) {
+          applyVehicleSkinToModel(helicopterFx.root, sideSkin, (node) =>
+            /rotor|propell|blade|fan|window|cockpit|glass|canopy/.test(`${node.name || ''}`.toLowerCase())
+          );
+        }
+        attachVehicleAvatarBadge(
+          helicopterFx.root,
+          isWhiteSide
+            ? avatar || username || playerFlag || '🙂'
+            : (onlineRef.current.enabled ? opponent?.avatar || opponent?.name : null) || opponent?.name || aiFlag || '🤖',
+          isWhiteSide ? 1 : -1
+        );
+        helicopterFx.root.position.copy(launchBase.clone());
+        captureFxGroup.add(helicopterFx.root);
         const missileFx = [createFxGroundMissile(), createFxGroundMissile()];
         missileFx.forEach((missile) => {
           missile.root.scale.setScalar(CAPTURE_MISSILE_SCALE);
@@ -10159,23 +10191,20 @@ function Chess3D({
         suppressTimerBeepUntilRef.current = performance.now() + CAPTURE_JET_TOTAL * 1000;
         const isWhiteSide = Boolean(movingMesh?.userData?.w);
         const parkedUnit = acquireParkedAirUnit(isWhiteSide, 'jet');
-        const jetFx = parkedUnit || createFxJet();
-        if (!parkedUnit) {
-          jetFx.root.scale.setScalar(CAPTURE_JET_SCALE);
-          const launchBase = getAirPadAnchor(isWhiteSide, 'jet', 1);
-          const sideSkin = resolveSideVehicleSkin(isWhiteSide);
-          if (sideSkin) applyVehicleSkinToModel(jetFx.root, sideSkin);
-          attachVehicleAvatarBadge(
-            jetFx.root,
-            isWhiteSide
-              ? avatar || username || playerFlag || '🙂'
-              : (onlineRef.current.enabled ? opponent?.avatar || opponent?.name : null) || opponent?.name || aiFlag || '🤖',
-            isWhiteSide ? 1 : -1
-          );
-          jetFx.root.position.copy(launchBase.clone().add(new THREE.Vector3(0, 0.08, 0)));
-          captureFxGroup.add(jetFx.root);
-        }
+        const jetFx = createFxJet();
+        jetFx.root.scale.setScalar(CAPTURE_JET_SCALE);
         const launchBase = parkedUnit?.homePosition?.clone?.() || getAirPadAnchor(isWhiteSide, 'jet', 1);
+        const sideSkin = resolveSideVehicleSkin(isWhiteSide);
+        if (sideSkin) applyVehicleSkinToModel(jetFx.root, sideSkin);
+        attachVehicleAvatarBadge(
+          jetFx.root,
+          isWhiteSide
+            ? avatar || username || playerFlag || '🙂'
+            : (onlineRef.current.enabled ? opponent?.avatar || opponent?.name : null) || opponent?.name || aiFlag || '🤖',
+          isWhiteSide ? 1 : -1
+        );
+        jetFx.root.position.copy(launchBase.clone());
+        captureFxGroup.add(jetFx.root);
         const missileFx = [createFxGroundMissile(), createFxGroundMissile()];
         missileFx.forEach((missile) => {
           missile.root.scale.setScalar(CAPTURE_MISSILE_SCALE);
@@ -11968,27 +11997,60 @@ function Chess3D({
             const launchPos = fx.returnToOrigin
               ? fx.launchPos.clone()
               : getLiveLaunchPosition(fx.launchPos, fx.movingMesh, 0);
+            const liveTargetPos = getLiveTargetPosition(fx.to, fx.targetMesh, 0);
+            fx.to.copy(liveTargetPos);
             if (!fx.returnToOrigin) fx.launchPos.copy(launchPos);
             fx.droneFx.root.scale.setScalar(CAPTURE_DRONE_SCALE);
             let pose = null;
             if (fx.t < CAPTURE_GROUND_FIRE_TIME) {
-              pose = { pos: launchPos.clone(), next: launchPos.clone().add(new THREE.Vector3(0.05, 0, 0)) };
+              const liftTop = launchPos.clone().add(new THREE.Vector3(0, 0.06, 0));
+              const holdU = smoothEase(fx.t / Math.max(0.001, CAPTURE_GROUND_FIRE_TIME));
+              const pos = launchPos.clone().lerp(liftTop, holdU);
+              const next = launchPos.clone().lerp(liftTop, clamp01(holdU + 0.05));
+              pose = { pos, next };
             } else if (fx.t < impactTime) {
-              const mu = smoothEase((fx.t - CAPTURE_GROUND_FIRE_TIME) / CAPTURE_GROUND_TRAVEL_TIME);
-              pose = getCaptureDirectStrikePose({
-                launchPos,
-                targetPos: fx.to,
-                progress: mu,
-                altitude: CAPTURE_VERTICAL_STRIKE_ALTITUDE,
-                verticalCrash: true
-              });
+              const mu = clamp01((fx.t - CAPTURE_GROUND_FIRE_TIME) / CAPTURE_GROUND_TRAVEL_TIME);
+              const dropStart = 0.74;
+              if (mu < dropStart) {
+                pose = getCaptureAirRunPose({
+                  from: launchPos,
+                  to: liveTargetPos,
+                  progress: mu / dropStart,
+                  launchHeight: 0.06,
+                  cruiseHeight: CAPTURE_SHORT_STRIKE_ALTITUDE,
+                  returnToOrigin: false,
+                  constrainToBoard: false,
+                  profile: CAPTURE_DRONE_ATTACK_PROFILE
+                });
+              } else {
+                const cruisePose = getCaptureAirRunPose({
+                  from: launchPos,
+                  to: liveTargetPos,
+                  progress: 1,
+                  launchHeight: 0.06,
+                  cruiseHeight: CAPTURE_SHORT_STRIKE_ALTITUDE,
+                  returnToOrigin: false,
+                  constrainToBoard: false,
+                  profile: CAPTURE_DRONE_ATTACK_PROFILE
+                });
+                const strikeTop = cruisePose.pos.clone();
+                strikeTop.x = liveTargetPos.x;
+                strikeTop.z = liveTargetPos.z;
+                strikeTop.y = Math.max(strikeTop.y, liveTargetPos.y + CAPTURE_VERTICAL_STRIKE_TOP_OFFSET * 1.1);
+                const du = smoothEase((mu - dropStart) / Math.max(0.001, 1 - dropStart));
+                const pos = strikeTop.clone().lerp(liveTargetPos, du);
+                const next = strikeTop.clone().lerp(liveTargetPos, clamp01(du + 0.08));
+                next.x = pos.x;
+                next.z = pos.z;
+                pose = { pos, next };
+              }
             }
             if (!pose) {
               fx.droneFx.root.visible = false;
             } else {
               fx.droneFx.root.visible = true;
               const { pos, next } = pose;
-              fx.droneFx.root.position.copy(constrainInsideBoardPerimeter(pos));
+              fx.droneFx.root.position.copy(pos);
               captureDir.copy(next).sub(pos).normalize();
               fx.droneFx.root.quaternion.setFromUnitVectors(FORWARD, captureDir);
             }
@@ -12001,16 +12063,21 @@ function Chess3D({
             if (fx.t >= impactTime) {
               if (!fx.hasExploded) {
                 fx.hasExploded = true;
-                launchExplosion(fx.to);
+                launchExplosion(liveTargetPos);
                 fx.reloading = true;
                 fx.reloadEndsAt = fx.t + CAPTURE_RELOAD_SHOW_TIME;
                 fx.droneFx.root.position.copy(launchPos);
-              } else if (fx.reloading && fx.t >= fx.reloadEndsAt) {
                 if (fx.sourceUnit) {
                   returnParkedAirUnit(fx.sourceUnit);
-                } else {
-                  captureFxGroup.remove(fx.droneFx.root);
+                  fx.returnedToPad = true;
                 }
+              } else if (fx.reloading && fx.t >= fx.reloadEndsAt) {
+                if (!fx.returnedToPad) {
+                  if (fx.sourceUnit) {
+                    returnParkedAirUnit(fx.sourceUnit);
+                  }
+                }
+                captureFxGroup.remove(fx.droneFx.root);
                 activeCaptureFx.splice(i, 1);
               }
             }
@@ -12027,9 +12094,11 @@ function Chess3D({
               to: fx.flightTarget || fx.to,
               progress: jetU,
               cruiseHeight: CAPTURE_FLIGHT_ALTITUDE * CAPTURE_AIR_STRIKE_ORBIT_HEIGHT_MUL,
-              returnToOrigin: true
+              returnToOrigin: true,
+              constrainToBoard: false,
+              profile: CAPTURE_JET_ATTACK_PROFILE
             });
-            fx.jetFx.root.position.copy(constrainInsideBoardPerimeter(jetPos));
+            fx.jetFx.root.position.copy(jetPos);
             captureDir.copy(jetNext).sub(jetPos).normalize();
             const jetForward = captureDir.clone();
             fx.jetFx.root.quaternion.setFromUnitVectors(FORWARD, captureDir);
@@ -12119,9 +12188,8 @@ function Chess3D({
             if (jetTimelineU >= 1) {
               if (fx.sourceUnit) {
                 returnParkedAirUnit(fx.sourceUnit);
-              } else {
-                captureFxGroup.remove(fx.jetFx.root);
               }
+              captureFxGroup.remove(fx.jetFx.root);
               jetMissiles.forEach((missile) => {
                 captureFxGroup.remove(missile.root);
               });
@@ -12140,9 +12208,11 @@ function Chess3D({
               to: fx.flightTarget || fx.to,
               progress: heliU,
               cruiseHeight: CAPTURE_FLIGHT_ALTITUDE * CAPTURE_AIR_STRIKE_ORBIT_HEIGHT_MUL,
-              returnToOrigin: true
+              returnToOrigin: true,
+              constrainToBoard: false,
+              profile: CAPTURE_HELI_ATTACK_PROFILE
             });
-            fx.helicopterFx.root.position.copy(constrainInsideBoardPerimeter(heliPos));
+            fx.helicopterFx.root.position.copy(heliPos);
             captureDir.copy(heliNext).sub(heliPos).normalize();
             const heliForward = captureDir.clone();
             fx.helicopterFx.root.quaternion.setFromUnitVectors(FORWARD, captureDir);
@@ -12234,9 +12304,8 @@ function Chess3D({
             if (heliTimelineU >= 1) {
               if (fx.sourceUnit) {
                 returnParkedAirUnit(fx.sourceUnit);
-              } else {
-                captureFxGroup.remove(fx.helicopterFx.root);
               }
+              captureFxGroup.remove(fx.helicopterFx.root);
               heliMissiles.forEach((missile) => {
                 captureFxGroup.remove(missile.root);
               });
@@ -12270,7 +12339,7 @@ function Chess3D({
                     launchPos: strikeFrom,
                     targetPos: strikeTo,
                     progress: mu,
-                    strikeAltitude: CAPTURE_DRONE_REFERENCE_BOARD_ALTITUDE * 0.84
+                    strikeAltitude: CAPTURE_SHORT_STRIKE_ALTITUDE
                   })
                 : getCaptureDirectStrikePose({
                     launchPos: strikeFrom,


### PR DESCRIPTION
### Motivation
- Improve visual readability of air/short strikes on portrait screens by lowering short-missile cruise lanes and extending takeoff visibility. 
- Make flight motion more natural and configurable via attack profiles and a remapped takeoff/landing progression. 
- Simplify and correct parked-unit handling so FX use canonical home positions and are returned cleanly to pads. 

### Description
- Tweaked tuning constants: reduced `CAPTURE_VERTICAL_STRIKE_ALTITUDE`, introduced `CAPTURE_SHORT_STRIKE_ALTITUDE`, and increased `CAPTURE_LOOP_TAKEOFF_RATIO` to make takeoffs/strikes more legible. 
- Added new immutable attack profile objects (`CAPTURE_JET_ATTACK_PROFILE`, `CAPTURE_HELI_ATTACK_PROFILE`, `CAPTURE_DRONE_ATTACK_PROFILE`) and a `remapTakeoffLandingProgress` helper to map progress through takeoff/cruise/landing. 
- Rewrote `getCaptureAirRunPose` to use an orbital/cruise apex path with configurable phase splits and optional perimeter clamping, and improved precision vertical strike interpolation using a quadratic bezier for more natural drop arcs. 
- Changed parked-unit handling and FX instantiation so FX roots are positioned from `homePosition` clones, FX models are created when needed (with `forceProcedural` when appropriate), and parked units are returned to `airPadGroup` reliably; many launch position calculations now use cloned home anchors. 
- Updated drone and short-strike flows to use the new orbital approach for cruise then switch to vertical drop for impact, and replaced several uses of `constrainInsideBoardPerimeter` with an optional `constrainToBoard` flag for flight poses. 

### Testing
- Ran lint and unit test suite (`yarn lint`, `yarn test`) locally and they completed without failures. 
- Performed a local development build (`yarn build`) to ensure no build-time regressions. 
- Observed FX paths in the dev build and verified that jets, helis, drones and ground javelins use the updated paths and parked units are returned to pads (visual smoke tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9fe1cbfd08329ad4430161e44fce5)