### PR TITLE
Lower Murlan Royale camera framing (portrait & landscape offsets)

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2344,7 +2344,10 @@ const CAMERA_LOOK_VERTICAL_ALLOWANCE = Object.freeze({
 const CAMERA_TARGET_LIFT = 0.08 * MODEL_SCALE;
 const CAMERA_FOCUS_CENTER_LIFT = 0.1 * MODEL_SCALE;
 const CAMERA_TARGET_TOP_PLAYER_BIAS = 0.36 * MODEL_SCALE;
-const CAMERA_SCREEN_DOWN_SHIFT = 0;
+const CAMERA_SCREEN_DOWN_SHIFT = Object.freeze({
+  portrait: 0.12 * MODEL_SCALE,
+  landscape: 0.04 * MODEL_SCALE
+});
 const HUMAN_HAND_CARD_SCALE = 1.06;
 const HUMAN_HAND_CARD_SPACING = CARD_W * HUMAN_HAND_CARD_SCALE * 0.25;
 const HUMAN_HAND_CARD_MAX_SPREAD = HUMAN_HAND_CARD_SPACING * 10;
@@ -5171,7 +5174,10 @@ export default function MurlanRoyaleArena({ search }) {
         camConfig.near,
         camConfig.far
       );
-      const targetHeightOffset = CAMERA_TARGET_LIFT + 0.03 * MODEL_SCALE + CAMERA_SCREEN_DOWN_SHIFT;
+      const targetScreenDownShift = isPortrait
+        ? CAMERA_SCREEN_DOWN_SHIFT.portrait
+        : CAMERA_SCREEN_DOWN_SHIFT.landscape;
+      const targetHeightOffset = CAMERA_TARGET_LIFT + 0.03 * MODEL_SCALE + targetScreenDownShift;
       let target = new THREE.Vector3(0, TABLE_HEIGHT + targetHeightOffset, 0);
       let initialCameraPosition;
       if (humanSeatConfig) {


### PR DESCRIPTION
### Motivation
- Adjust the Murlan Royale arena camera so the visible scene is shifted lower on the player's screen, especially in portrait orientation, to improve framing and UX on phones in portrait mode.

### Description
- Replace the scalar `CAMERA_SCREEN_DOWN_SHIFT` with an orientation-aware frozen object providing `portrait` and `landscape` offsets (`portrait: 0.12 * MODEL_SCALE`, `landscape: 0.04 * MODEL_SCALE`).
- Apply the appropriate `targetScreenDownShift` depending on `isPortrait` and add it into the computed `targetHeightOffset` used when building the initial camera `target` and position.
- Changes are implemented in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` and only affect initial camera target framing.

### Testing
- Ran the production build with `npm --prefix webapp run build` and the build completed successfully (Vite warnings about duplicate package key and large chunks appeared but did not fail the build).
- No automated unit tests were modified or required for this framing adjustment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea16058758832997123006317ee7ab)