### PR TITLE
Lower Murlan Royale portrait camera elevation

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2334,7 +2334,7 @@ const CAMERA_SEATED_RETREAT_OFFSETS = Object.freeze({
   landscape: 0.68
 });
 const CAMERA_SEATED_ELEVATION_OFFSETS = Object.freeze({
-  portrait: 2.78,
+  portrait: 2.46,
   landscape: 1.12
 });
 const CAMERA_LOOK_VERTICAL_ALLOWANCE = Object.freeze({


### PR DESCRIPTION
### Motivation
- Improve mobile portrait framing by lowering the seated camera elevation so the in-game view appears visually lower on phone portrait screens.

### Description
- Changed `CAMERA_SEATED_ELEVATION_OFFSETS.portrait` from `2.78` to `2.46` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx`.

### Testing
- Ran `npm test -- test/murlan.test.js --runInBand` and the test suite passed (1 suite, 12 tests all passing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1aa2652c8329a10f582f660879c0)