### PR TITLE
Refactor capture FX paths and parked-unit handling in ChessBattleRoyal

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -144,13 +144,16 @@ const CAPTURE_DIRECT_STRIKE_INWARD_DISTANCE = 0.1; // straighter launch line tow
 const CAPTURE_DIRECT_STRIKE_TAKEOFF_RATIO = 0.34; // quicker lift for cleaner direct strike
 const CAPTURE_DIRECT_STRIKE_RETURN_RATIO = 0.54; // return earlier so fly-bys stay close to board
 const CAPTURE_VERTICAL_STRIKE_INWARD_DISTANCE = 0; // pawn/drone/truck missile rises straight up from launch point
-const CAPTURE_VERTICAL_STRIKE_ALTITUDE = 0.07; // even lower pawn/drone strike profile
+const CAPTURE_VERTICAL_STRIKE_ALTITUDE = 0.054; // lower short-missile cruise lane so it sits visibly lower on portrait screens
 const CAPTURE_VERTICAL_STRIKE_TOP_OFFSET = 0.05; // shorter top point before vertical drop
 const CAPTURE_VERTICAL_STRIKE_HORIZONTAL_RATIO = 0.22; // shorter top-flight pass before vertical crash
 const CAPTURE_PRECISION_STRIKE_LIFT_RATIO = 0.28; // strict vertical launch segment for short missiles
 const CAPTURE_PRECISION_STRIKE_DROP_RATIO = 0.24; // strict vertical terminal drop for short missiles
-const CAPTURE_LOOP_TAKEOFF_RATIO = 0.18; // show aircraft lifting from pad before starting loop
+const CAPTURE_SHORT_STRIKE_ALTITUDE = CAPTURE_DRONE_REFERENCE_BOARD_ALTITUDE * 0.62; // shared pawn/drone/truck short-strike altitude
+const CAPTURE_LOOP_TAKEOFF_RATIO = 0.3; // longer visible lift so side-pad takeoff is clearly readable on portrait screens
 const CAPTURE_AIR_APPROACH_RATIO = 0.58; // jet/heli approach target, fire, then return
+const CAPTURE_AIR_CENTER_PULL_RATIO = 0.34; // keep jet/heli paths tighter around board center like Ludo's air routes
+const CAPTURE_AIR_LANDING_RATIO = 0.86; // reserve tail segment for visible descent back to parking altitude
 const CAPTURE_RELOAD_SHOW_TIME = 0.58;
 const CAPTURE_MISSILE_SCALE = 0.068;
 const CAPTURE_JAVELIN_MISSILE_SCALE = CAPTURE_MISSILE_SCALE * 1.48; // make javelin missile bigger
@@ -9427,10 +9430,6 @@ function Chess3D({
       if (!preferred?.root) return null;
       preferred.busy = true;
       preferred.root.visible = true;
-      if (preferred.root.parent !== captureFxGroup) {
-        preferred.root.parent?.remove(preferred.root);
-        captureFxGroup.add(preferred.root);
-      }
       return preferred;
     };
     const returnParkedAirUnit = (unit) => {
@@ -9817,37 +9816,50 @@ function Chess3D({
       from,
       to,
       progress,
-      launchHeight = 0.08,
+      launchHeight = 0.06,
       cruiseHeight = CAPTURE_FLIGHT_ALTITUDE * CAPTURE_AIR_STRIKE_ORBIT_HEIGHT_MUL,
-      returnToOrigin = true
+      returnToOrigin = true,
+      constrainToBoard = true
     }) => {
-      const launchPos = from.clone().add(new THREE.Vector3(0, launchHeight, 0));
+      const clampIfNeeded = (value) => (constrainToBoard ? constrainInsideBoardPerimeter(value) : value);
+      const launchPos = from.clone();
+      const liftTop = from.clone().add(new THREE.Vector3(0, launchHeight, 0));
+      const centerPoint = boardLookTargetRef.current?.clone?.() || new THREE.Vector3(0, liftTop.y, 0);
+      centerPoint.y = liftTop.y;
       const toVec = to.clone();
-      const approachPoint = launchPos.clone().lerp(toVec, 0.42);
-      approachPoint.y = Math.max(launchPos.y + tile * 0.04, toVec.y + cruiseHeight);
+      const approachPoint = liftTop.clone().lerp(toVec, 0.42);
+      approachPoint.lerp(centerPoint, CAPTURE_AIR_CENTER_PULL_RATIO);
+      approachPoint.y = Math.max(liftTop.y + tile * 0.02, toVec.y + cruiseHeight);
       const nearTargetPoint = toVec.clone();
-      nearTargetPoint.y = Math.max(toVec.y + cruiseHeight * 0.9, launchPos.y + tile * 0.03);
+      nearTargetPoint.y = Math.max(toVec.y + cruiseHeight * 0.9, liftTop.y + tile * 0.015);
       const u = clamp01(progress);
       const takeoffSplit = Math.min(CAPTURE_LOOP_TAKEOFF_RATIO, CAPTURE_AIR_APPROACH_RATIO * 0.4);
       if (u < takeoffSplit) {
         const su = smoothEase(u / Math.max(0.001, takeoffSplit));
-        const liftPoint = launchPos.clone();
-        liftPoint.y = approachPoint.y;
-        const pos = launchPos.clone().lerp(liftPoint, su);
-        const next = launchPos.clone().lerp(liftPoint, clamp01(su + 0.05));
-        return { pos: constrainInsideBoardPerimeter(pos), next: constrainInsideBoardPerimeter(next) };
+        const pos = launchPos.clone().lerp(liftTop, su);
+        const next = launchPos.clone().lerp(liftTop, clamp01(su + 0.05));
+        return { pos: clampIfNeeded(pos), next: clampIfNeeded(next) };
       }
       if (u < CAPTURE_AIR_APPROACH_RATIO) {
         const su = smoothEase((u - takeoffSplit) / Math.max(0.001, CAPTURE_AIR_APPROACH_RATIO - takeoffSplit));
-        const pos = launchPos.clone().lerp(approachPoint, su);
-        const next = launchPos.clone().lerp(approachPoint, clamp01(su + 0.05));
-        return { pos: constrainInsideBoardPerimeter(pos), next: constrainInsideBoardPerimeter(next) };
+        const pos = liftTop.clone().lerp(approachPoint, su);
+        const next = liftTop.clone().lerp(approachPoint, clamp01(su + 0.05));
+        return { pos: clampIfNeeded(pos), next: clampIfNeeded(next) };
       }
       if (returnToOrigin) {
-        const ru = smoothEase((u - CAPTURE_AIR_APPROACH_RATIO) / Math.max(0.001, 1 - CAPTURE_AIR_APPROACH_RATIO));
-        const pos = nearTargetPoint.clone().lerp(launchPos, ru);
-        const next = nearTargetPoint.clone().lerp(launchPos, clamp01(ru + 0.05));
-        return { pos: constrainInsideBoardPerimeter(pos), next: constrainInsideBoardPerimeter(next) };
+        if (u < CAPTURE_AIR_LANDING_RATIO) {
+          const ru = smoothEase(
+            (u - CAPTURE_AIR_APPROACH_RATIO) / Math.max(0.001, CAPTURE_AIR_LANDING_RATIO - CAPTURE_AIR_APPROACH_RATIO)
+          );
+          const returnEntry = liftTop.clone();
+          const pos = nearTargetPoint.clone().lerp(returnEntry, ru);
+          const next = nearTargetPoint.clone().lerp(returnEntry, clamp01(ru + 0.05));
+          return { pos: clampIfNeeded(pos), next: clampIfNeeded(next) };
+        }
+        const lu = smoothEase((u - CAPTURE_AIR_LANDING_RATIO) / Math.max(0.001, 1 - CAPTURE_AIR_LANDING_RATIO));
+        const pos = liftTop.clone().lerp(launchPos, lu);
+        const next = liftTop.clone().lerp(launchPos, clamp01(lu + 0.05));
+        return { pos: clampIfNeeded(pos), next: clampIfNeeded(next) };
       }
       return { pos: nearTargetPoint, next: toVec.clone() };
     };
@@ -9924,30 +9936,18 @@ function Chess3D({
       const u = clamp01(progress);
       const liftEnd = launchPos.clone();
       liftEnd.y = Math.max(launchPos.y + strikeAltitude, targetPos.y + CAPTURE_VERTICAL_STRIKE_TOP_OFFSET);
-      const strikeTop = targetPos.clone();
-      strikeTop.y = liftEnd.y;
-      const travelSpan = Math.max(0.001, 1 - CAPTURE_PRECISION_STRIKE_LIFT_RATIO - CAPTURE_PRECISION_STRIKE_DROP_RATIO);
+      const travelSpan = Math.max(0.001, 1 - CAPTURE_PRECISION_STRIKE_LIFT_RATIO);
       if (u <= CAPTURE_PRECISION_STRIKE_LIFT_RATIO) {
         const lu = smoothEase(u / Math.max(0.001, CAPTURE_PRECISION_STRIKE_LIFT_RATIO));
         const pos = launchPos.clone().lerp(liftEnd, lu);
         const next = launchPos.clone().lerp(liftEnd, clamp01(lu + 0.05));
         return { pos, next };
       }
-      if (u >= 1 - CAPTURE_PRECISION_STRIKE_DROP_RATIO) {
-        const du = smoothEase(
-          (u - (1 - CAPTURE_PRECISION_STRIKE_DROP_RATIO)) / Math.max(0.001, CAPTURE_PRECISION_STRIKE_DROP_RATIO)
-        );
-        const pos = strikeTop.clone().lerp(targetPos, du);
-        const next = strikeTop.clone().lerp(targetPos, clamp01(du + 0.08));
-        next.x = pos.x;
-        next.z = pos.z;
-        return { pos, next };
-      }
       const cu = smoothEase((u - CAPTURE_PRECISION_STRIKE_LIFT_RATIO) / travelSpan);
-      const pos = liftEnd.clone().lerp(strikeTop, cu);
-      const next = liftEnd.clone().lerp(strikeTop, clamp01(cu + 0.05));
-      pos.y = liftEnd.y;
-      next.y = liftEnd.y;
+      const naturalDropControl = liftEnd.clone().lerp(targetPos, 0.62);
+      naturalDropControl.y = Math.max(targetPos.y + CAPTURE_VERTICAL_STRIKE_TOP_OFFSET * 1.1, liftEnd.y * 0.82);
+      const pos = qBezier(liftEnd, naturalDropControl, targetPos, cu);
+      const next = qBezier(liftEnd, naturalDropControl, targetPos, clamp01(cu + 0.06));
       return { pos, next };
     };
 
@@ -9966,9 +9966,10 @@ function Chess3D({
         suppressTimerBeepUntilRef.current = performance.now() + CAPTURE_GROUND_TOTAL * 1000;
         const missileFx = createFxGroundMissile();
         missileFx.root.scale.setScalar(CAPTURE_ROOK_JAVELIN_SCALE);
-        const parkedTruck = acquireParkedSupportUnit(Boolean(movingMesh?.userData?.w));
-        const launchBase = getLiveLaunchPosition(fromPos.clone(), movingMesh, 0.11);
-        missileFx.root.position.copy(launchBase.clone().add(new THREE.Vector3(0, 0.14, 0)));
+        const isWhiteSide = Boolean(movingMesh?.userData?.w);
+        const parkedTruck = acquireParkedSupportUnit(isWhiteSide);
+        const launchBase = parkedTruck?.homePosition?.clone?.() || getAirPadAnchor(isWhiteSide, 'truck', 0);
+        missileFx.root.position.copy(launchBase.clone());
         captureFxGroup.add(missileFx.root);
         playAudio(missileLaunchSoundRef);
         activeCaptureFx.push({
@@ -9977,10 +9978,10 @@ function Chess3D({
           duration: CAPTURE_GROUND_TOTAL,
           from: fromPos.clone(),
           to: targetPos.clone(),
-          launchPos: launchBase.add(new THREE.Vector3(0, 0.03, 0)),
+          launchPos: launchBase.clone(),
           movingMesh,
           targetMesh,
-          launchFromLivePiece: true,
+          launchFromLivePiece: false,
           sourceUnit: parkedTruck,
           missileFx,
           directPath: false,
@@ -9997,14 +9998,11 @@ function Chess3D({
           suppressTimerBeepUntilRef.current = performance.now() + CAPTURE_GROUND_TOTAL * 1000;
           const isWhiteSide = Boolean(movingMesh?.userData?.w);
           const parkedDrone = acquireParkedAirUnit(isWhiteSide, 'drone');
-          const droneFx = parkedDrone || createFxDrone({ forceProcedural: true });
+          const droneFx = createFxDrone({ forceProcedural: !parkedDrone });
           droneFx.root.scale.setScalar(CAPTURE_DRONE_SCALE);
-          if (!parkedDrone) {
-            const launchBase = getAirPadAnchor(isWhiteSide, 'drone', 0);
-            droneFx.root.position.copy(launchBase.clone().add(new THREE.Vector3(0, 0.08, 0)));
-            captureFxGroup.add(droneFx.root);
-          }
           const launchBase = parkedDrone?.homePosition?.clone?.() || getAirPadAnchor(isWhiteSide, 'drone', 0);
+          droneFx.root.position.copy(launchBase.clone());
+          captureFxGroup.add(droneFx.root);
           playAudio(droneSoundRef, { maxDurationMs: CAPTURE_GROUND_TOTAL * 1000 });
           activeCaptureFx.push({
             type: 'drone',
@@ -10012,7 +10010,7 @@ function Chess3D({
             duration: CAPTURE_GROUND_TOTAL,
             from: fromPos.clone(),
             to: targetPos.clone(),
-            launchPos: launchBase.add(new THREE.Vector3(0, 0.08, 0)),
+            launchPos: launchBase.clone(),
             movingMesh,
             targetMesh,
             returnToOrigin: true,
@@ -10056,23 +10054,20 @@ function Chess3D({
         suppressTimerBeepUntilRef.current = performance.now() + CAPTURE_JET_TOTAL * 1000;
         const isWhiteSide = Boolean(movingMesh?.userData?.w);
         const parkedUnit = acquireParkedAirUnit(isWhiteSide, 'jet');
-        const jetFx = parkedUnit || createFxJet();
-        if (!parkedUnit) {
-          jetFx.root.scale.setScalar(CAPTURE_JET_SCALE);
-          const launchBase = getAirPadAnchor(isWhiteSide, 'jet', 0);
-          const sideSkin = resolveSideVehicleSkin(isWhiteSide);
-          if (sideSkin) applyVehicleSkinToModel(jetFx.root, sideSkin);
-          attachVehicleAvatarBadge(
-            jetFx.root,
-            isWhiteSide
-              ? avatar || username || playerFlag || '🙂'
-              : (onlineRef.current.enabled ? opponent?.avatar || opponent?.name : null) || opponent?.name || aiFlag || '🤖',
-            isWhiteSide ? 1 : -1
-          );
-          jetFx.root.position.copy(launchBase.clone().add(new THREE.Vector3(0, 0.08, 0)));
-          captureFxGroup.add(jetFx.root);
-        }
+        const jetFx = createFxJet();
+        jetFx.root.scale.setScalar(CAPTURE_JET_SCALE);
         const launchBase = parkedUnit?.homePosition?.clone?.() || getAirPadAnchor(isWhiteSide, 'jet', 0);
+        const sideSkin = resolveSideVehicleSkin(isWhiteSide);
+        if (sideSkin) applyVehicleSkinToModel(jetFx.root, sideSkin);
+        attachVehicleAvatarBadge(
+          jetFx.root,
+          isWhiteSide
+            ? avatar || username || playerFlag || '🙂'
+            : (onlineRef.current.enabled ? opponent?.avatar || opponent?.name : null) || opponent?.name || aiFlag || '🤖',
+          isWhiteSide ? 1 : -1
+        );
+        jetFx.root.position.copy(launchBase.clone());
+        captureFxGroup.add(jetFx.root);
         const missileFx = [createFxGroundMissile(), createFxGroundMissile()];
         missileFx.forEach((missile) => {
           missile.root.scale.setScalar(CAPTURE_MISSILE_SCALE);
@@ -10085,7 +10080,7 @@ function Chess3D({
           duration: CAPTURE_JET_TOTAL,
           from: fromPos.clone(),
           to: targetPos.clone(),
-          launchPos: launchBase.add(new THREE.Vector3(0, 0.08, 0)),
+          launchPos: launchBase.clone(),
           movingMesh,
           targetMesh,
           returnToOrigin: true,
@@ -10105,27 +10100,24 @@ function Chess3D({
         suppressTimerBeepUntilRef.current = performance.now() + CAPTURE_HELICOPTER_TOTAL * 1000;
         const isWhiteSide = Boolean(movingMesh?.userData?.w);
         const parkedUnit = acquireParkedAirUnit(isWhiteSide, 'helicopter');
-        const helicopterFx = parkedUnit || createFxHelicopter();
-        if (!parkedUnit) {
-          helicopterFx.root.scale.setScalar(CAPTURE_HELICOPTER_SCALE);
-          const launchBase = getAirPadAnchor(isWhiteSide, 'helicopter', 0);
-          const sideSkin = resolveSideVehicleSkin(isWhiteSide);
-          if (sideSkin) {
-            applyVehicleSkinToModel(helicopterFx.root, sideSkin, (node) =>
-              /rotor|propell|blade|fan|window|cockpit|glass|canopy/.test(`${node.name || ''}`.toLowerCase())
-            );
-          }
-          attachVehicleAvatarBadge(
-            helicopterFx.root,
-            isWhiteSide
-              ? avatar || username || playerFlag || '🙂'
-              : (onlineRef.current.enabled ? opponent?.avatar || opponent?.name : null) || opponent?.name || aiFlag || '🤖',
-            isWhiteSide ? 1 : -1
-          );
-          helicopterFx.root.position.copy(launchBase.clone().add(new THREE.Vector3(0, 0.08, 0)));
-          captureFxGroup.add(helicopterFx.root);
-        }
+        const helicopterFx = createFxHelicopter();
+        helicopterFx.root.scale.setScalar(CAPTURE_HELICOPTER_SCALE);
         const launchBase = parkedUnit?.homePosition?.clone?.() || getAirPadAnchor(isWhiteSide, 'helicopter', 0);
+        const sideSkin = resolveSideVehicleSkin(isWhiteSide);
+        if (sideSkin) {
+          applyVehicleSkinToModel(helicopterFx.root, sideSkin, (node) =>
+            /rotor|propell|blade|fan|window|cockpit|glass|canopy/.test(`${node.name || ''}`.toLowerCase())
+          );
+        }
+        attachVehicleAvatarBadge(
+          helicopterFx.root,
+          isWhiteSide
+            ? avatar || username || playerFlag || '🙂'
+            : (onlineRef.current.enabled ? opponent?.avatar || opponent?.name : null) || opponent?.name || aiFlag || '🤖',
+          isWhiteSide ? 1 : -1
+        );
+        helicopterFx.root.position.copy(launchBase.clone());
+        captureFxGroup.add(helicopterFx.root);
         const missileFx = [createFxGroundMissile(), createFxGroundMissile()];
         missileFx.forEach((missile) => {
           missile.root.scale.setScalar(CAPTURE_MISSILE_SCALE);
@@ -10139,7 +10131,7 @@ function Chess3D({
           duration: CAPTURE_HELICOPTER_TOTAL,
           from: fromPos.clone(),
           to: targetPos.clone(),
-          launchPos: launchBase.add(new THREE.Vector3(0, 0.08, 0)),
+          launchPos: launchBase.clone(),
           movingMesh,
           targetMesh,
           returnToOrigin: true,
@@ -10159,23 +10151,20 @@ function Chess3D({
         suppressTimerBeepUntilRef.current = performance.now() + CAPTURE_JET_TOTAL * 1000;
         const isWhiteSide = Boolean(movingMesh?.userData?.w);
         const parkedUnit = acquireParkedAirUnit(isWhiteSide, 'jet');
-        const jetFx = parkedUnit || createFxJet();
-        if (!parkedUnit) {
-          jetFx.root.scale.setScalar(CAPTURE_JET_SCALE);
-          const launchBase = getAirPadAnchor(isWhiteSide, 'jet', 1);
-          const sideSkin = resolveSideVehicleSkin(isWhiteSide);
-          if (sideSkin) applyVehicleSkinToModel(jetFx.root, sideSkin);
-          attachVehicleAvatarBadge(
-            jetFx.root,
-            isWhiteSide
-              ? avatar || username || playerFlag || '🙂'
-              : (onlineRef.current.enabled ? opponent?.avatar || opponent?.name : null) || opponent?.name || aiFlag || '🤖',
-            isWhiteSide ? 1 : -1
-          );
-          jetFx.root.position.copy(launchBase.clone().add(new THREE.Vector3(0, 0.08, 0)));
-          captureFxGroup.add(jetFx.root);
-        }
+        const jetFx = createFxJet();
+        jetFx.root.scale.setScalar(CAPTURE_JET_SCALE);
         const launchBase = parkedUnit?.homePosition?.clone?.() || getAirPadAnchor(isWhiteSide, 'jet', 1);
+        const sideSkin = resolveSideVehicleSkin(isWhiteSide);
+        if (sideSkin) applyVehicleSkinToModel(jetFx.root, sideSkin);
+        attachVehicleAvatarBadge(
+          jetFx.root,
+          isWhiteSide
+            ? avatar || username || playerFlag || '🙂'
+            : (onlineRef.current.enabled ? opponent?.avatar || opponent?.name : null) || opponent?.name || aiFlag || '🤖',
+          isWhiteSide ? 1 : -1
+        );
+        jetFx.root.position.copy(launchBase.clone());
+        captureFxGroup.add(jetFx.root);
         const missileFx = [createFxGroundMissile(), createFxGroundMissile()];
         missileFx.forEach((missile) => {
           missile.root.scale.setScalar(CAPTURE_MISSILE_SCALE);
@@ -10188,7 +10177,7 @@ function Chess3D({
           duration: CAPTURE_JET_TOTAL,
           from: fromPos.clone(),
           to: targetPos.clone(),
-          launchPos: launchBase.add(new THREE.Vector3(0, 0.08, 0)),
+          launchPos: launchBase.clone(),
           movingMesh,
           targetMesh,
           returnToOrigin: true,
@@ -11968,6 +11957,8 @@ function Chess3D({
             const launchPos = fx.returnToOrigin
               ? fx.launchPos.clone()
               : getLiveLaunchPosition(fx.launchPos, fx.movingMesh, 0);
+            const liveTargetPos = getLiveTargetPosition(fx.to, fx.targetMesh, 0);
+            fx.to.copy(liveTargetPos);
             if (!fx.returnToOrigin) fx.launchPos.copy(launchPos);
             fx.droneFx.root.scale.setScalar(CAPTURE_DRONE_SCALE);
             let pose = null;
@@ -11975,12 +11966,11 @@ function Chess3D({
               pose = { pos: launchPos.clone(), next: launchPos.clone().add(new THREE.Vector3(0.05, 0, 0)) };
             } else if (fx.t < impactTime) {
               const mu = smoothEase((fx.t - CAPTURE_GROUND_FIRE_TIME) / CAPTURE_GROUND_TRAVEL_TIME);
-              pose = getCaptureDirectStrikePose({
+              pose = getCapturePrecisionVerticalStrikePose({
                 launchPos,
-                targetPos: fx.to,
+                targetPos: liveTargetPos,
                 progress: mu,
-                altitude: CAPTURE_VERTICAL_STRIKE_ALTITUDE,
-                verticalCrash: true
+                strikeAltitude: CAPTURE_SHORT_STRIKE_ALTITUDE
               });
             }
             if (!pose) {
@@ -11988,7 +11978,7 @@ function Chess3D({
             } else {
               fx.droneFx.root.visible = true;
               const { pos, next } = pose;
-              fx.droneFx.root.position.copy(constrainInsideBoardPerimeter(pos));
+              fx.droneFx.root.position.copy(pos);
               captureDir.copy(next).sub(pos).normalize();
               fx.droneFx.root.quaternion.setFromUnitVectors(FORWARD, captureDir);
             }
@@ -12001,16 +11991,21 @@ function Chess3D({
             if (fx.t >= impactTime) {
               if (!fx.hasExploded) {
                 fx.hasExploded = true;
-                launchExplosion(fx.to);
+                launchExplosion(liveTargetPos);
                 fx.reloading = true;
                 fx.reloadEndsAt = fx.t + CAPTURE_RELOAD_SHOW_TIME;
                 fx.droneFx.root.position.copy(launchPos);
-              } else if (fx.reloading && fx.t >= fx.reloadEndsAt) {
                 if (fx.sourceUnit) {
                   returnParkedAirUnit(fx.sourceUnit);
-                } else {
-                  captureFxGroup.remove(fx.droneFx.root);
+                  fx.returnedToPad = true;
                 }
+              } else if (fx.reloading && fx.t >= fx.reloadEndsAt) {
+                if (!fx.returnedToPad) {
+                  if (fx.sourceUnit) {
+                    returnParkedAirUnit(fx.sourceUnit);
+                  }
+                }
+                captureFxGroup.remove(fx.droneFx.root);
                 activeCaptureFx.splice(i, 1);
               }
             }
@@ -12027,9 +12022,10 @@ function Chess3D({
               to: fx.flightTarget || fx.to,
               progress: jetU,
               cruiseHeight: CAPTURE_FLIGHT_ALTITUDE * CAPTURE_AIR_STRIKE_ORBIT_HEIGHT_MUL,
-              returnToOrigin: true
+              returnToOrigin: true,
+              constrainToBoard: false
             });
-            fx.jetFx.root.position.copy(constrainInsideBoardPerimeter(jetPos));
+            fx.jetFx.root.position.copy(jetPos);
             captureDir.copy(jetNext).sub(jetPos).normalize();
             const jetForward = captureDir.clone();
             fx.jetFx.root.quaternion.setFromUnitVectors(FORWARD, captureDir);
@@ -12119,9 +12115,8 @@ function Chess3D({
             if (jetTimelineU >= 1) {
               if (fx.sourceUnit) {
                 returnParkedAirUnit(fx.sourceUnit);
-              } else {
-                captureFxGroup.remove(fx.jetFx.root);
               }
+              captureFxGroup.remove(fx.jetFx.root);
               jetMissiles.forEach((missile) => {
                 captureFxGroup.remove(missile.root);
               });
@@ -12140,9 +12135,10 @@ function Chess3D({
               to: fx.flightTarget || fx.to,
               progress: heliU,
               cruiseHeight: CAPTURE_FLIGHT_ALTITUDE * CAPTURE_AIR_STRIKE_ORBIT_HEIGHT_MUL,
-              returnToOrigin: true
+              returnToOrigin: true,
+              constrainToBoard: false
             });
-            fx.helicopterFx.root.position.copy(constrainInsideBoardPerimeter(heliPos));
+            fx.helicopterFx.root.position.copy(heliPos);
             captureDir.copy(heliNext).sub(heliPos).normalize();
             const heliForward = captureDir.clone();
             fx.helicopterFx.root.quaternion.setFromUnitVectors(FORWARD, captureDir);
@@ -12234,9 +12230,8 @@ function Chess3D({
             if (heliTimelineU >= 1) {
               if (fx.sourceUnit) {
                 returnParkedAirUnit(fx.sourceUnit);
-              } else {
-                captureFxGroup.remove(fx.helicopterFx.root);
               }
+              captureFxGroup.remove(fx.helicopterFx.root);
               heliMissiles.forEach((missile) => {
                 captureFxGroup.remove(missile.root);
               });
@@ -12270,7 +12265,7 @@ function Chess3D({
                     launchPos: strikeFrom,
                     targetPos: strikeTo,
                     progress: mu,
-                    strikeAltitude: CAPTURE_DRONE_REFERENCE_BOARD_ALTITUDE * 0.84
+                    strikeAltitude: CAPTURE_SHORT_STRIKE_ALTITUDE
                   })
                 : getCaptureDirectStrikePose({
                     launchPos: strikeFrom,


### PR DESCRIPTION
### Motivation
- Improve readability and visual placement of air/short-strike FX on portrait and center-focused boards by adjusting altitudes, approach curves, and landing segments. 
- Simplify parked-unit pooling and FX lifecycle so models use a consistent positioning source and avoid visual glitches from on-the-fly reparenting and offset errors.

### Description
- Tweaked constants for strike altitudes and timing, including lowering `CAPTURE_VERTICAL_STRIKE_ALTITUDE`, adding `CAPTURE_SHORT_STRIKE_ALTITUDE`, increasing takeoff visibility via `CAPTURE_LOOP_TAKEOFF_RATIO`, and adding `CAPTURE_AIR_CENTER_PULL_RATIO` and `CAPTURE_AIR_LANDING_RATIO` to tighten center-focused air paths. 
- Reworked `getCaptureAirRunPose` to use a lifted `liftTop` point, pull approaches toward board center, expose `constrainToBoard` option, and add explicit landing-phase interpolation for clearer returns. 
- Replaced several direct-perimeter clamps for air units and missiles with configurable clamping and stricter control points, converted precision vertical strikes to a quadratic Bezier (`qBezier`) path in `getCapturePrecisionVerticalStrikePose`, and adjusted travel/span math for smoother arcs. 
- Changed parked-unit / FX creation flow: parked units provide `homePosition` but FX instances are created/initialized consistently (`createFxJet`, `createFxHelicopter`, `createFxDrone`, etc.), launch positions now use parked `homePosition` clones or `getAirPadAnchor` fallbacks, and removed fragile parent-reparent logic; added clearer handling when returning units to pads and removing FX from `captureFxGroup`. 

### Testing
- Ran the repository test suite with `yarn test` and static checks with `yarn lint`, and the existing automated tests completed without failures. 
- Exercised capture FX via the app's capture flows during local dev smoke tests to validate visual trajectories and lifecycle (no automated visual tests were added).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9fe1cbfd08329ad4430161e44fce5)