### PR TITLE
Adjust SnakeBoard3D portrait token and parked-weapon positioning

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -303,19 +303,19 @@ const WEAPON_REST_HEIGHT_OFFSET_BY_SEAT = Object.freeze([
 // Positive radial moves items visually toward each chair/edge on screen.
 const TOKEN_PORTRAIT_SCREEN_SHIFT_BY_SEAT = Object.freeze([
   // Bottom seat: pull token closer to the table rail on portrait screens.
-  Object.freeze({ radial: -TILE_SIZE * 0.12, lateral: 0, y: 0 }),
+  Object.freeze({ radial: -TILE_SIZE * 0.2, lateral: 0, y: 0 }),
   Object.freeze({ radial: 0, lateral: 0, y: 0 }),
   // Top seat: push token farther from the table edge (visually away from table).
-  Object.freeze({ radial: TILE_SIZE * 0.12, lateral: 0, y: 0 }),
+  Object.freeze({ radial: TILE_SIZE * 0.22, lateral: 0, y: 0 }),
   Object.freeze({ radial: 0, lateral: 0, y: 0 })
 ]);
 const WEAPON_PORTRAIT_SCREEN_SHIFT_BY_SEAT = Object.freeze([
-  Object.freeze({ radial: -TILE_SIZE * 0.24, lateral: 0, y: 0 }),
-  Object.freeze({ radial: -TILE_SIZE * 0.16, lateral: 0, y: 0 }),
-  Object.freeze({ radial: -TILE_SIZE * 0.14, lateral: 0, y: 0 }),
-  Object.freeze({ radial: -TILE_SIZE * 0.16, lateral: 0, y: 0 })
+  Object.freeze({ radial: -TILE_SIZE * 0.24, lateral: 0, y: TILE_SIZE * 0.1 }),
+  Object.freeze({ radial: -TILE_SIZE * 0.16, lateral: 0, y: TILE_SIZE * 0.1 }),
+  Object.freeze({ radial: -TILE_SIZE * 0.14, lateral: 0, y: TILE_SIZE * 0.1 }),
+  Object.freeze({ radial: -TILE_SIZE * 0.16, lateral: 0, y: TILE_SIZE * 0.1 })
 ]);
-const WEAPON_TABLE_SURFACE_Y_OFFSET = TILE_SIZE * 0.08;
+const WEAPON_TABLE_SURFACE_Y_OFFSET = TILE_SIZE * 0.2;
 const WEAPON_PARKING_SIDE_EXTRA_RADIUS = TILE_SIZE * 0.2;
 const WEAPON_PARKING_Y_FROM_GROUND_FLOOR = TOKEN_HEIGHT * 0.65;
 
@@ -4769,6 +4769,7 @@ function updateSeatWeaponDisplays(board, players = []) {
         holder.position
           .addScaledVector(railLayout.seatDirection, portraitShift.radial ?? 0)
           .addScaledVector(railLayout.lateral, portraitShift.lateral ?? 0);
+        holder.position.y += portraitShift.y ?? 0;
       }
     } else {
       const seatWorld = new THREE.Vector3();


### PR DESCRIPTION
### Motivation
- Improve visual layout on portrait phones by moving seat tokens to better match user expectations: bottom seat tokens should sit closer to the table rail and top-seat tokens should appear pushed away toward the top chair.
- Raise parked weapon display positions so weapon props sit visibly higher on the table rim and do not clip against the board surface.
- Ensure portrait-oriented vertical offsets are applied to weapon holders so per-seat Y shifts affect final placement.

### Description
- Increased the radial portrait calibration for tokens in `TOKEN_PORTRAIT_SCREEN_SHIFT_BY_SEAT` so seat 0 (bottom) is pulled further inward and seat 2 (top) is pushed further outward. (file: `webapp/src/components/SnakeBoard3D.jsx`)
- Added a small per-seat Y lift value to `WEAPON_PORTRAIT_SCREEN_SHIFT_BY_SEAT` and applied that Y offset when positioning parked weapon holders so vertical lift affects rendered placement. (file: `webapp/src/components/SnakeBoard3D.jsx`)
- Raised `WEAPON_TABLE_SURFACE_Y_OFFSET` to lift parked weapons higher above the table surface. (file: `webapp/src/components/SnakeBoard3D.jsx`)

### Testing
- Attempted to run the repository lint step with `npm run lint -- src/components/SnakeBoard3D.jsx` inside `webapp`, but the project does not define a `lint` script so the lint run failed with an npm error. 
- Verified the patch applied cleanly to `webapp/src/components/SnakeBoard3D.jsx` and inspected affected placement code paths with static searches (`rg`/`sed`) to confirm the new constants are referenced where tokens and weapon holders are positioned.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1f85d62c8329a80dd8ecaf751c8a)