### PR TITLE
Adjust SnakeBoard3D: lift parked weapons and tweak portrait seat token offsets

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -285,13 +285,13 @@ const WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT = Object.freeze([
 ]);
 const WEAPON_TOKEN_GAP = TILE_SIZE * 0.004;
 const WEAPON_PARKED_Y_DROP_BY_KIND = Object.freeze({
-  fighter: TOKEN_HEIGHT * 2.04,
-  helicopter: TOKEN_HEIGHT * 2.12,
-  drone: TOKEN_HEIGHT * 1.96,
-  supportTruck: TOKEN_HEIGHT * 2.08,
-  javelin: TOKEN_HEIGHT * 2.02
+  fighter: TOKEN_HEIGHT * 1.72,
+  helicopter: TOKEN_HEIGHT * 1.8,
+  drone: TOKEN_HEIGHT * 1.68,
+  supportTruck: TOKEN_HEIGHT * 1.76,
+  javelin: TOKEN_HEIGHT * 1.7
 });
-const WEAPON_REST_HEIGHT_OFFSET = -TOKEN_HEIGHT * 1.92;
+const WEAPON_REST_HEIGHT_OFFSET = -TOKEN_HEIGHT * 1.52;
 const WEAPON_SLOT_CLUSTER_SCALE = 0.3;
 const WEAPON_REST_HEIGHT_OFFSET_BY_SEAT = Object.freeze([
   0,
@@ -303,21 +303,21 @@ const WEAPON_REST_HEIGHT_OFFSET_BY_SEAT = Object.freeze([
 // Positive radial moves items visually toward each chair/edge on screen.
 const TOKEN_PORTRAIT_SCREEN_SHIFT_BY_SEAT = Object.freeze([
   // Bottom seat: pull token closer to the table rail on portrait screens.
-  Object.freeze({ radial: -TILE_SIZE * 0.12, lateral: 0, y: 0 }),
+  Object.freeze({ radial: -TILE_SIZE * 0.24, lateral: 0, y: 0 }),
   Object.freeze({ radial: 0, lateral: 0, y: 0 }),
   // Top seat: push token farther from the table edge (visually away from table).
-  Object.freeze({ radial: TILE_SIZE * 0.12, lateral: 0, y: 0 }),
+  Object.freeze({ radial: TILE_SIZE * 0.24, lateral: 0, y: 0 }),
   Object.freeze({ radial: 0, lateral: 0, y: 0 })
 ]);
 const WEAPON_PORTRAIT_SCREEN_SHIFT_BY_SEAT = Object.freeze([
-  Object.freeze({ radial: -TILE_SIZE * 0.24, lateral: 0, y: 0 }),
-  Object.freeze({ radial: -TILE_SIZE * 0.16, lateral: 0, y: 0 }),
-  Object.freeze({ radial: -TILE_SIZE * 0.14, lateral: 0, y: 0 }),
-  Object.freeze({ radial: -TILE_SIZE * 0.16, lateral: 0, y: 0 })
+  Object.freeze({ radial: -TILE_SIZE * 0.24, lateral: 0, y: TILE_SIZE * 0.08 }),
+  Object.freeze({ radial: -TILE_SIZE * 0.16, lateral: 0, y: TILE_SIZE * 0.08 }),
+  Object.freeze({ radial: -TILE_SIZE * 0.14, lateral: 0, y: TILE_SIZE * 0.08 }),
+  Object.freeze({ radial: -TILE_SIZE * 0.16, lateral: 0, y: TILE_SIZE * 0.08 })
 ]);
-const WEAPON_TABLE_SURFACE_Y_OFFSET = TILE_SIZE * 0.08;
+const WEAPON_TABLE_SURFACE_Y_OFFSET = TILE_SIZE * 0.14;
 const WEAPON_PARKING_SIDE_EXTRA_RADIUS = TILE_SIZE * 0.2;
-const WEAPON_PARKING_Y_FROM_GROUND_FLOOR = TOKEN_HEIGHT * 0.65;
+const WEAPON_PARKING_Y_FROM_GROUND_FLOOR = TOKEN_HEIGHT * 0.9;
 
 const PAVEMENT_EXTRA_SCALE = 1.18;
 const PAVEMENT_THICKNESS = TILE_SIZE * 0.4;


### PR DESCRIPTION
### Motivation
- Improve visual alignment on portrait phones by making parked weapon models sit visibly higher above the board and table surface. 
- Adjust reserve token placement so the top-seat token is pushed visually away from the table toward the top chair and the bottom-seat token is pulled visually closer to the table, matching the requested portrait calibration. 
- Add a small vertical offset for parked weapon portrait positions to keep animated weapons appearing lifted relative to the board.

### Description
- Updated constants in `webapp/src/components/SnakeBoard3D.jsx` to reduce Y drop for parked vehicles by changing `WEAPON_PARKED_Y_DROP_BY_KIND` multipliers for each vehicle kind. 
- Raised the weapon rest/table offsets by changing `WEAPON_REST_HEIGHT_OFFSET`, `WEAPON_TABLE_SURFACE_Y_OFFSET`, and `WEAPON_PARKING_Y_FROM_GROUND_FLOOR` to make parked weapons sit higher. 
- Increased portrait radial calibration in `TOKEN_PORTRAIT_SCREEN_SHIFT_BY_SEAT` so bottom seat tokens are pulled more inward and top seat tokens are pushed further outward. 
- Added a small positive `y` shift in `WEAPON_PORTRAIT_SCREEN_SHIFT_BY_SEAT` to lift parked weapon slots on portrait screens.

### Testing
- Ran the scoped linter with `npm run -s lint -- webapp/src/components/SnakeBoard3D.jsx`, which produced an ESLint React-version warning and timed out in this environment (`EXIT:124`), so no successful lint pass was recorded. 
- No additional automated unit or integration tests were executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1f85d62c8329a80dd8ecaf751c8a)