### PR TITLE
Murlan Royale: camera/HDRI orientation, card stacking and card-back fixes

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2310,8 +2310,8 @@ const DISCARD_PILE_OFFSET = Object.freeze({
   y: CARD_H * 1.14,
   z: -TABLE_RADIUS * 0.18
 });
-const DISCARD_PILE_FORWARD_SHIFT = -CARD_H * 0.18;
-const DISCARD_PILE_RIGHT_SHIFT = -CARD_W * 0.28;
+const DISCARD_PILE_FORWARD_SHIFT = -CARD_H * 0.34;
+const DISCARD_PILE_RIGHT_SHIFT = -CARD_W * 0.42;
 const SEAT_WIDTH = 0.9 * MODEL_SCALE * STOOL_SCALE;
 const SEAT_DEPTH = 0.95 * MODEL_SCALE * STOOL_SCALE;
 const SEAT_THICKNESS = 0.09 * MODEL_SCALE * STOOL_SCALE;
@@ -2345,7 +2345,7 @@ const CAMERA_TARGET_LIFT = 0.08 * MODEL_SCALE;
 const CAMERA_FOCUS_CENTER_LIFT = 0.1 * MODEL_SCALE;
 const CAMERA_TARGET_TOP_PLAYER_BIAS = 0.36 * MODEL_SCALE;
 const CAMERA_SCREEN_DOWN_SHIFT = Object.freeze({
-  portrait: 0.14 * MODEL_SCALE,
+  portrait: 0.19 * MODEL_SCALE,
   landscape: 0.05 * MODEL_SCALE
 });
 const HUMAN_HAND_CARD_SCALE = 1.06;
@@ -2379,7 +2379,7 @@ const AI_HAND_TABLE_EDGE_MARGIN = CARD_H * 0.2;
 const HAND_CARDS_INWARD_BIAS = 0.18 * MODEL_SCALE;
 const COMMUNITY_CARD_TOP_TILT = THREE.MathUtils.degToRad(12);
 const COMMUNITY_CARD_SCALE = 1.08;
-const COMMUNITY_CARD_SPACING = CARD_W * 1.08;
+const COMMUNITY_CARD_SPACING = HUMAN_HAND_CARD_SPACING * 0.2;
 const COMMUNITY_CARD_MAX_SPREAD = COMMUNITY_CARD_SPACING * 12;
 const COMMUNITY_CARD_BOTTOM_LOCK_Y_OFFSET = Math.sin(COMMUNITY_CARD_TOP_TILT) * CARD_H * 0.5;
 const COMMUNITY_CARD_FAN_ARC_LIFT = 0;
@@ -3928,6 +3928,8 @@ export default function MurlanRoyaleArena({ search }) {
       if (!entry) return;
       const mesh = entry.mesh;
       mesh.visible = true;
+      const tableLayerIndex = tableCount - 1 - idx;
+      applyTableCardLayering(mesh, tableLayerIndex, 8);
       mesh.scale.setScalar(COMMUNITY_CARD_SCALE);
       updateCardFace(mesh, 'front');
       setCommunityCardLegibility(mesh, true);
@@ -3977,6 +3979,7 @@ export default function MurlanRoyaleArena({ search }) {
       if (!entry) return;
       const mesh = entry.mesh;
       mesh.visible = true;
+      applyTableCardLayering(mesh, idx, 6);
       mesh.scale.setScalar(1);
       updateCardFace(mesh, 'front');
       setCommunityCardLegibility(mesh, true);
@@ -3986,7 +3989,6 @@ export default function MurlanRoyaleArena({ search }) {
       target.addScaledVector(pileRightAxis, scatterX);
       target.addScaledVector(pileForwardAxis, scatterZ);
       target.y += idx * 0.0022;
-      mesh.renderOrder = 1800 + idx;
       const discardYaw = (cardIdNoise(card.id, 13) - 0.5) * THREE.MathUtils.degToRad(14);
       const discardTilt = (cardIdNoise(card.id, 17) - 0.5) * THREE.MathUtils.degToRad(3.2);
       setMeshPosition(
@@ -4244,12 +4246,13 @@ export default function MurlanRoyaleArena({ search }) {
         : hdriSource === 'polyhaven'
           ? -Math.PI / 12
           : 0;
+      const invertedRotationY = rotationY + Math.PI;
       const rotationX = Number.isFinite(activeVariant?.rotationX) ? activeVariant.rotationX : 0;
       if ('backgroundRotation' in three.scene) {
-        three.scene.backgroundRotation.set(rotationX, rotationY, 0);
+        three.scene.backgroundRotation.set(rotationX, invertedRotationY, 0);
       }
       if ('environmentRotation' in three.scene) {
-        three.scene.environmentRotation.set(rotationX, rotationY, 0);
+        three.scene.environmentRotation.set(rotationX, invertedRotationY, 0);
       }
       if ('backgroundIntensity' in three.scene && typeof activeVariant?.backgroundIntensity === 'number') {
         three.scene.backgroundIntensity = activeVariant.backgroundIntensity;
@@ -6810,6 +6813,23 @@ function applyHandCardLayering(mesh, isHumanCard, stackOrder = 0) {
   });
 }
 
+function applyTableCardLayering(mesh, stackOrder = 0, orderBase = 8) {
+  if (!mesh?.isMesh) return;
+  mesh.renderOrder = orderBase + stackOrder;
+
+  const shouldForceRenderOrder = true;
+  if (mesh.userData?.forceTableRenderOrder === shouldForceRenderOrder) return;
+  mesh.userData.forceTableRenderOrder = shouldForceRenderOrder;
+
+  const allMaterials = Array.isArray(mesh.material) ? mesh.material : [mesh.material];
+  allMaterials.forEach((material) => {
+    if (!material) return;
+    material.depthTest = !shouldForceRenderOrder;
+    material.depthWrite = !shouldForceRenderOrder;
+    material.needsUpdate = true;
+  });
+}
+
 function setBackLogoOrientation(mesh, variant = 'default') {
   const backMaterial = mesh?.userData?.backMaterial;
   const baseTexture = mesh?.userData?.backTexture;
@@ -6844,9 +6864,10 @@ function setBackLogoOrientation(mesh, variant = 'default') {
   if (!mesh.userData.backLogoOrientedTexture) {
     const tunedTexture = baseTexture.clone();
     if (desiredVariant === 'top') {
-      tunedTexture.repeat.set(-1, 1);
-      tunedTexture.offset.set(1, 0);
-      tunedTexture.rotation = 0;
+      tunedTexture.repeat.set(1, 1);
+      tunedTexture.offset.set(0, 0);
+      tunedTexture.rotation = Math.PI;
+      tunedTexture.center.set(0.5, 0.5);
     } else if (desiredVariant === 'side') {
       tunedTexture.repeat.set(1, 1);
       tunedTexture.offset.set(0, 0);

--- a/webapp/src/utils/cards3d.js
+++ b/webapp/src/utils/cards3d.js
@@ -209,8 +209,8 @@ function makeCardFace(rank, suit, theme, w = 512, h = 720) {
 }
 
 export function makeTonplaygramCardBackTexture(theme, w = 3072, h = 4320) {
-  const safeWidth = Math.max(512, Math.round(Math.min(w, 1536)));
-  const safeHeight = Math.max(768, Math.round(Math.min(h, 2304)));
+  const safeWidth = Math.max(1024, Math.round(Math.min(w, 3072)));
+  const safeHeight = Math.max(1440, Math.round(Math.min(h, 4320)));
   const cacheKey = `${theme?.id || 'default'}:${safeWidth}x${safeHeight}`;
   const cachedTexture = cardBackTextureCache.get(cacheKey);
   if (cachedTexture) return cachedTexture;
@@ -448,8 +448,8 @@ function drawLogoFrame(ctx, w, h, theme) {
 
   if (logoImage?.complete && logoImage.naturalWidth > 0) {
     const ratio = logoImage.naturalWidth / Math.max(logoImage.naturalHeight, 1);
-    const logoBoxWidth = w * 0.94;
-    const logoBoxHeight = h * 0.4;
+    const logoBoxWidth = w * 0.98;
+    const logoBoxHeight = h * 0.46;
     const drawWidth = Math.min(logoBoxWidth, logoBoxHeight * ratio);
     const drawHeight = drawWidth / ratio;
     const logoX = w / 2 - drawWidth / 2;


### PR DESCRIPTION
### Motivation
- Align the Murlan Royale scene to the requested composition: camera moved visually lower, HDRI/environment facing the opposite direction, and discard pile positioned to match reference photo.  
- Make played/community cards stack like the bottom player's hand with a small gap and ensure bottom-player cards render on top of community/discard cards.  
- Fix card-back logo orientation and increase back-logo size/resolution to avoid mirrored/upside-down and low-res renderings.

### Description
- Lowered portrait framing by increasing `CAMERA_SCREEN_DOWN_SHIFT.portrait` to push the table visually down on-screen.  
- Inverted HDRI/environment orientation by applying `rotationY + Math.PI` when setting `backgroundRotation` / `environmentRotation` so the arena faces the opposite HDRI direction.  
- Moved the used-card pile by updating `DISCARD_PILE_FORWARD_SHIFT` and `DISCARD_PILE_RIGHT_SHIFT` to reposition the discard anchor.  
- Tightened community layout by changing `COMMUNITY_CARD_SPACING` to a smaller value and applied a new `applyTableCardLayering` helper that forces `renderOrder` and disables depth test/write for table/discard cards so hand cards (higher order base) stay visually on top.  
- Fixed back-logo orientation in `setBackLogoOrientation` to avoid mirrored/upside-down variants by adjusting `tunedTexture.repeat`, `offset`, `rotation`, and `center` for the `top` variant.  
- Increased card-back texture resolution and logo draw area in `makeTonplaygramCardBackTexture` (`safeWidth`/`safeHeight` and logo box sizing) for sharper, larger logos.

### Testing
- Ran `npm -C webapp run build` and the production build completed successfully.  
- Build output included non-blocking Vite warnings about dynamic/static imports and chunk sizes, and an existing `package.json` duplicate key warning, none of which broke the build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea28028fe48329bbba39b3a204797f)