### PR TITLE
Raise parked weapons, adjust token offsets, and align Snake dice to Ludo timing/SFX

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -144,8 +144,9 @@ const DICE_PIP_RIM_OUTER = DICE_PIP_RADIUS * 1.08;
 const DICE_PIP_RIM_OFFSET = DICE_SIZE * 0.0048;
 const DICE_PIP_SPREAD = DICE_SIZE * 0.3;
 const DICE_FACE_INSET = DICE_SIZE * 0.064;
-const DICE_ROLL_DURATION = 520;
-const DICE_SETTLE_DURATION = 180;
+// Keep Snake dice pacing aligned with Ludo Battle Royale dice rhythm.
+const DICE_ROLL_DURATION = 1100;
+const DICE_SETTLE_DURATION = 260;
 const DICE_BOUNCE_HEIGHT = DICE_SIZE * 0.6;
 const DICE_THROW_LANDING_MARGIN = TILE_SIZE * 1.8;
 const DICE_THROW_START_EXTRA = TILE_SIZE * 3.6;
@@ -204,9 +205,9 @@ const CAMERA_FOLLOW_MIN_TILE = Infinity;
 const CAMERA_FOLLOW_BACK_TILES = 5;
 
 const TURN_CAMERA_TURN_IN_DURATION = 620;
-const DICE_CAMERA_LOOK_IN_DURATION = 180;
-const DICE_CAMERA_LOOK_HOLD_DURATION = 380;
-const DICE_CAMERA_LOOK_OUT_DURATION = 180;
+const DICE_CAMERA_LOOK_IN_DURATION = 220;
+const DICE_CAMERA_LOOK_HOLD_DURATION = 460;
+const DICE_CAMERA_LOOK_OUT_DURATION = 220;
 const BOARD_AUTO_ROTATE_IN_DURATION = 520;
 const BOARD_AUTO_ROTATE_HOLD_DURATION = 0;
 const BOARD_AUTO_ROTATE_OUT_DURATION = 520;
@@ -285,11 +286,12 @@ const WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT = Object.freeze([
 ]);
 const WEAPON_TOKEN_GAP = TILE_SIZE * 0.004;
 const WEAPON_PARKED_Y_DROP_BY_KIND = Object.freeze({
-  fighter: TOKEN_HEIGHT * 1.72,
-  helicopter: TOKEN_HEIGHT * 1.8,
-  drone: TOKEN_HEIGHT * 1.68,
-  supportTruck: TOKEN_HEIGHT * 1.76,
-  javelin: TOKEN_HEIGHT * 1.7
+  // Lift parked weapons so they sit around bishop-height instead of under-table.
+  fighter: TOKEN_HEIGHT * 0.96,
+  helicopter: TOKEN_HEIGHT * 1.02,
+  drone: TOKEN_HEIGHT * 0.9,
+  supportTruck: TOKEN_HEIGHT * 0.98,
+  javelin: TOKEN_HEIGHT * 0.94
 });
 const WEAPON_REST_HEIGHT_OFFSET = -TOKEN_HEIGHT * 1.52;
 const WEAPON_SLOT_CLUSTER_SCALE = 0.3;
@@ -303,10 +305,10 @@ const WEAPON_REST_HEIGHT_OFFSET_BY_SEAT = Object.freeze([
 // Positive radial moves items visually toward each chair/edge on screen.
 const TOKEN_PORTRAIT_SCREEN_SHIFT_BY_SEAT = Object.freeze([
   // Bottom seat: pull token closer to the table rail on portrait screens.
-  Object.freeze({ radial: -TILE_SIZE * 0.24, lateral: 0, y: 0 }),
+  Object.freeze({ radial: -TILE_SIZE * 0.34, lateral: 0, y: 0 }),
   Object.freeze({ radial: 0, lateral: 0, y: 0 }),
   // Top seat: push token farther from the table edge (visually away from table).
-  Object.freeze({ radial: TILE_SIZE * 0.24, lateral: 0, y: 0 }),
+  Object.freeze({ radial: TILE_SIZE * 0.34, lateral: 0, y: 0 }),
   Object.freeze({ radial: 0, lateral: 0, y: 0 })
 ]);
 const WEAPON_PORTRAIT_SCREEN_SHIFT_BY_SEAT = Object.freeze([

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -89,7 +89,7 @@ import GiftPopup from "../../components/GiftPopup.jsx";
 import { giftSounds } from "../../utils/giftSounds.js";
 import { moveSeq, flashHighlight, applyEffect as applyEffectHelper } from "../../utils/moveHelpers.js";
 import { getSnakeInventory, isSnakeOptionUnlocked, snakeAccountId } from "../../utils/snakeInventory.js";
-import { createDiceRollAudio } from "../../utils/diceAudio.js";
+import { playLudoDiceRollSfx } from "../../utils/ludoSfx.js";
 import {
   buildSnakeCommentaryLine,
   createSnakeMatchCommentaryScript,
@@ -1813,7 +1813,6 @@ export default function SnakeAndLadder() {
   const badLuckSoundRef = useRef(null);
   const cheerSoundRef = useRef(null);
   const timerSoundRef = useRef(null);
-  const diceRollSoundRef = useRef(null);
   const timerRef = useRef(null);
   const aiRollTimeoutRef = useRef(null);
   const reloadingRef = useRef(false);
@@ -1823,13 +1822,14 @@ export default function SnakeAndLadder() {
   const prevTimeLeftRef = useRef(TURN_TIME);
 
   const playDiceRollSound = useCallback(() => {
-    if (muted || !diceRollSoundRef.current) return;
+    if (muted) return;
     const now = Date.now();
-    if (now - lastDiceRollSfxAtRef.current < 240) return;
+    if (now - lastDiceRollSfxAtRef.current < 180) return;
     lastDiceRollSfxAtRef.current = now;
-    diceRollSoundRef.current.volume = 1;
-    diceRollSoundRef.current.currentTime = 0;
-    diceRollSoundRef.current.play().catch(() => {});
+    playLudoDiceRollSfx({
+      volume: getGameVolume(),
+      muted
+    });
   }, [muted]);
 
   const getPreviousTurn = useCallback(
@@ -1882,8 +1882,6 @@ export default function SnakeAndLadder() {
     cheerSoundRef.current.volume = vol;
     timerSoundRef.current = new Audio(SNAKE_SFX.timer);
     timerSoundRef.current.volume = vol;
-    diceRollSoundRef.current = createDiceRollAudio({ muted });
-    if (diceRollSoundRef.current) diceRollSoundRef.current.volume = 1;
     return () => {
       moveSoundRef.current?.pause();
       snakeSoundRef.current?.pause();
@@ -1897,7 +1895,6 @@ export default function SnakeAndLadder() {
       badLuckSoundRef.current?.pause();
       cheerSoundRef.current?.pause();
       timerSoundRef.current?.pause();
-      diceRollSoundRef.current?.pause();
     };
   }, [accountId, muted]);
 
@@ -1915,7 +1912,6 @@ export default function SnakeAndLadder() {
       badLuckSoundRef,
       cheerSoundRef,
       timerSoundRef,
-      diceRollSoundRef,
     ].forEach((r) => {
       if (r.current) r.current.muted = muted;
     });


### PR DESCRIPTION
### Motivation
- Make the Snake & Ladder arena feel consistent with the Ludo Battle Royale experience by matching dice pacing and using the same dice SFX. 
- Fix parked capture vehicles visually sitting under the table by raising them to a height comparable to the bishop-style token. 
- Improve portrait layout so the top player token reads as pushed away and the bottom player token reads as pulled closer on small/portrait screens.

### Description
- Increased dice animation windows by updating `DICE_ROLL_DURATION`, `DICE_SETTLE_DURATION`, and the dice camera look timings (`DICE_CAMERA_LOOK_*`) in `webapp/src/components/SnakeBoard3D.jsx` to match Ludo roll cadence. 
- Replaced the per-page dice audio usage with the shared Ludo roll SFX by calling `playLudoDiceRollSfx(...)` from `webapp/src/pages/Games/SnakeAndLadder.jsx` and removed the local `createDiceRollAudio` instance. 
- Lifted parked weapons by lowering the Y drop amounts in `WEAPON_PARKED_Y_DROP_BY_KIND` so parked capture vehicles sit visibly higher (around bishop-token height) in `webapp/src/components/SnakeBoard3D.jsx`. 
- Adjusted portrait seat token calibration in `TOKEN_PORTRAIT_SCREEN_SHIFT_BY_SEAT` so the bottom seat radial is more inward and the top seat radial is pushed outward (visually closer/farther on portrait screens) in `webapp/src/components/SnakeBoard3D.jsx`. 
- Minor debounce tweak for dice SFX spacing (reduced interval from 240ms to 180ms) when calling the shared Ludo SFX to better match Ludo timing in `webapp/src/pages/Games/SnakeAndLadder.jsx`.

### Testing
- Ran the production build with `npm -C webapp run build` and the build completed successfully. 
- The build emitted only non-blocking Vite warnings about chunking/size but did not fail the build. 
- No automated unit tests were modified; visual verification is recommended in a device/emulator for portrait layout, weapon parking height, and dice roll feel/sound after deploy.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea33e09d2883298dec041c0f9870db)