### PR TITLE
Fix Murlan Royale opponent card-back logo visibility/orientation

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -6876,22 +6876,27 @@ function setBackLogoOrientation(mesh, variant = 'default') {
 
   if (!mesh.userData.backLogoOrientedTexture) {
     const tunedTexture = baseTexture.clone();
+    tunedTexture.wrapS = THREE.RepeatWrapping;
+    tunedTexture.wrapT = THREE.RepeatWrapping;
     tunedTexture.repeat.set(1, 1);
     tunedTexture.offset.set(0, 0);
     tunedTexture.rotation = 0;
     tunedTexture.center.set(0.5, 0.5);
     if (desiredVariant === 'top') {
+      // Keep top seat logo fully visible and upright.
+      tunedTexture.repeat.set(1, 1);
+      tunedTexture.offset.set(0, 0);
+      tunedTexture.rotation = 0;
+    } else if (desiredVariant === 'side') {
+      // Left side seat: mirror horizontally so branding reads naturally from camera.
       tunedTexture.repeat.set(-1, 1);
       tunedTexture.offset.set(1, 0);
       tunedTexture.rotation = 0;
-    } else if (desiredVariant === 'side') {
+    } else if (desiredVariant === 'sideGift') {
+      // Right side seat: avoid 180° rotation that made the logo upside down.
       tunedTexture.repeat.set(-1, 1);
       tunedTexture.offset.set(1, 0);
-      tunedTexture.rotation = Math.PI;
-    } else if (desiredVariant === 'sideGift') {
-      tunedTexture.repeat.set(1, 1);
-      tunedTexture.offset.set(0, 0);
-      tunedTexture.rotation = Math.PI;
+      tunedTexture.rotation = 0;
     }
     tunedTexture.needsUpdate = true;
     mesh.userData.backLogoOrientedTexture = tunedTexture;


### PR DESCRIPTION
### Motivation
- Opponent card backs (top / left / right seats) had incorrect logo placement or were upside down, making branding unreadable and inconsistent during play.
- Ensure the card-back logo is visible and upright for the top seat and mirrored correctly for side seats without introducing clipping or inverted rendering.

### Description
- In `setBackLogoOrientation` (MurlanRoyaleArena) clone of the base back texture now sets `wrapS`/`wrapT` to `THREE.RepeatWrapping` so mirrored `repeat` values do not clip the image. 
- Adjusted per-variant tuning so `top` uses upright/default UV mapping, `side` mirrors horizontally without rotating, and `sideGift` mirrors horizontally instead of applying a 180° rotation that produced an upside-down logo. 
- Kept the existing caching/disposal flow for `mesh.userData.backLogoOrientedTexture` to avoid leaking textures when variants change.

### Testing
- Ran `npm test -- --runInBand test/murlan.test.js` and the suite passed successfully (12 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea3b35840c83299c6e02e471eab8cc)