### PR TITLE
Murlan Royale: fix card-back logo, recolor black joker accents, and align discard pile

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2310,8 +2310,8 @@ const DISCARD_PILE_OFFSET = Object.freeze({
   y: CARD_H * 1.14,
   z: -TABLE_RADIUS * 0.18
 });
-const DISCARD_PILE_FORWARD_SHIFT = -CARD_H * 0.34;
-const DISCARD_PILE_RIGHT_SHIFT = -CARD_W * 0.42;
+const DISCARD_PILE_FORWARD_SHIFT = -CARD_H * 0.2;
+const DISCARD_PILE_RIGHT_SHIFT = 0;
 const SEAT_WIDTH = 0.9 * MODEL_SCALE * STOOL_SCALE;
 const SEAT_DEPTH = 0.95 * MODEL_SCALE * STOOL_SCALE;
 const SEAT_THICKNESS = 0.09 * MODEL_SCALE * STOOL_SCALE;
@@ -3823,11 +3823,7 @@ export default function MurlanRoyaleArena({ search }) {
         const isHumanCard = player.isHuman;
         const layerIndex = isHumanCard ? cards.length - 1 - cardIdx : cardIdx;
         applyHandCardLayering(mesh, isHumanCard, layerIndex);
-        const isGiftSideSeat = seat?.handVariant === 'giftSide';
-        const isSideSeatOnScreen = Math.abs(forward?.x ?? 0) > 0.45;
-        const backLogoVariant = !isHumanCard
-          ? (isGiftSideSeat ? 'sideGift' : isSideSeatOnScreen ? 'side' : 'top')
-          : 'default';
+        const backLogoVariant = !isHumanCard ? 'top' : 'default';
         setBackLogoOrientation(mesh, backLogoVariant);
         mesh.visible = true;
         updateCardFace(mesh, isHumanCard ? 'front' : 'back');
@@ -3841,11 +3837,9 @@ export default function MurlanRoyaleArena({ search }) {
         const fanArcLift = isHumanCard ? HUMAN_HAND_FAN_ARC_LIFT : AI_HAND_FAN_ARC_LIFT;
         const fanDirection = isHumanCard
           ? HUMAN_HAND_FAN_DIRECTION
-          : isGiftSideSeat
+          : (forward?.x ?? 0) < -0.45
             ? -HUMAN_HAND_FAN_DIRECTION
-            : (forward?.x ?? 0) < -0.45
-              ? -HUMAN_HAND_FAN_DIRECTION
-              : HUMAN_HAND_FAN_DIRECTION;
+            : HUMAN_HAND_FAN_DIRECTION;
         const fanYaw = HUMAN_HAND_UNIFORM_YAW_FROM_LEFT
           ? HUMAN_HAND_FAN_MAX_YAW
           : normalizedOffset * (isHumanCard ? HUMAN_HAND_FAN_MAX_YAW : AI_HAND_FAN_MAX_YAW) * fanDirection;
@@ -3986,13 +3980,13 @@ export default function MurlanRoyaleArena({ search }) {
       updateCardFace(mesh, 'front');
       setCommunityCardLegibility(mesh, true);
       const target = discardAnchor.clone();
-      const scatterX = (cardIdNoise(card.id, 3) - 0.5) * CARD_W * 0.34;
-      const scatterZ = (cardIdNoise(card.id, 7) - 0.5) * CARD_H * 0.3;
+      const scatterX = (cardIdNoise(card.id, 3) - 0.5) * CARD_W * 0.08;
+      const scatterZ = (cardIdNoise(card.id, 7) - 0.5) * CARD_H * 0.08;
       target.addScaledVector(pileRightAxis, scatterX);
       target.addScaledVector(pileForwardAxis, scatterZ);
       target.y += idx * 0.0022;
-      const discardYaw = (cardIdNoise(card.id, 13) - 0.5) * THREE.MathUtils.degToRad(14);
-      const discardTilt = (cardIdNoise(card.id, 17) - 0.5) * THREE.MathUtils.degToRad(3.2);
+      const discardYaw = (cardIdNoise(card.id, 13) - 0.5) * THREE.MathUtils.degToRad(5);
+      const discardTilt = (cardIdNoise(card.id, 17) - 0.5) * THREE.MathUtils.degToRad(1.2);
       setMeshPosition(
         mesh,
         target,
@@ -7197,6 +7191,9 @@ function makeCardFace(rank, suit, theme, w = 768, h = 1080) {
     roundRect(ctx, 0, 0, canvas.width, canvas.height, cornerRadius);
     ctx.clip();
     ctx.drawImage(image, offsetX, offsetY, zoomedWidth, zoomedHeight);
+    if (rank === 'JB') {
+      recolorBlackJokerRedAccents(ctx, canvas.width, canvas.height);
+    }
 
     // Slightly thicken rank/suit glyph edges for better mobile readability.
     ctx.globalCompositeOperation = 'multiply';
@@ -7221,6 +7218,25 @@ function makeCardFace(rank, suit, theme, w = 768, h = 1080) {
   image.src = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
   tex.needsUpdate = true;
   return tex;
+}
+
+function recolorBlackJokerRedAccents(ctx, width, height) {
+  if (!ctx || width <= 0 || height <= 0) return;
+  const imageData = ctx.getImageData(0, 0, width, height);
+  const data = imageData.data;
+  for (let i = 0; i < data.length; i += 4) {
+    const r = data[i];
+    const g = data[i + 1];
+    const b = data[i + 2];
+    const a = data[i + 3];
+    if (a < 12) continue;
+    const dominantRed = r > 105 && r > g + 20 && r > b + 20;
+    if (!dominantRed) continue;
+    data[i] = 17;
+    data[i + 1] = 17;
+    data[i + 2] = 17;
+  }
+  ctx.putImageData(imageData, 0, 0);
 }
 
 function makeCardBackTexture(theme, textureQuality = null) {


### PR DESCRIPTION
### Motivation
- Restore the previous visual layout and branding on cards so opponent cards show the upright logo like before. 
- Ensure the black joker appears fully black (no leftover red accents) to match the provided reference. 
- Move the used/discard pile directly under the community cards and tighten its scatter so played cards stack above the pile clearly.

### Description
- Set non-human hand card back logo orientation to the upright `top` variant by changing the computed `backLogoVariant` to `!isHumanCard ? 'top' : 'default'` in `MurlanRoyaleArena.jsx` so opponent cards show the previous logo placement. 
- Reposition the discard pile anchor by changing `DISCARD_PILE_FORWARD_SHIFT` from `-CARD_H * 0.34` to `-CARD_H * 0.2` and `DISCARD_PILE_RIGHT_SHIFT` to `0` so the pile sits closer beneath the community cards. 
- Reduce discard pile card spread and rotation by decreasing scatter and tilt values: scatter multipliers changed from `0.34/0.3` to `0.08/0.08` and rotation/tilt ranges reduced from `14°/3.2°` to `5°/1.2°`. 
- Add a canvas-time recolor pass for the black joker face in `makeCardFace` by adding `recolorBlackJokerRedAccents(...)` that scans for red-dominant pixels and forces them to a dark RGB (`17,17,17`) for rank `JB` so the black joker has only black accents. 
- Minor fan-direction simplification for hand layout so non-human fan direction is determined by seat forward vector (keeps human behavior unchanged).

All changes are in `webapp/src/pages/Games/MurlanRoyaleArena.jsx`.

### Testing
- Ran a production build with `npm --prefix webapp run build`, which completed successfully and produced the app bundle; Vite reported non-blocking warnings about chunk size and an existing duplicate dependency key in `package.json`, but the build itself succeeded.
- No additional automated unit tests were modified or required for these visual/renderer changes (visual verification expected in-browser or device preview).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea429260848329b1515c52463f6c9f)