### PR TITLE
Adjust Snake board weapon & token parking for portrait layout

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -276,7 +276,7 @@ const WEAPON_SLOT_LATERAL_NUDGE_BY_SEAT = Object.freeze([
   0
 ]);
 const WEAPON_DISPLAY_SIZE_MULTIPLIER = 1.72;
-const WEAPON_PARKING_OUTWARD_OFFSET = -TILE_SIZE * 0.14;
+const WEAPON_PARKING_OUTWARD_OFFSET = -TILE_SIZE * 0.2;
 const WEAPON_FROM_TOKEN_CENTER_OFFSET = TOKEN_RADIUS * 0.58;
 const WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT = Object.freeze([
   0,
@@ -287,11 +287,11 @@ const WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT = Object.freeze([
 const WEAPON_TOKEN_GAP = TILE_SIZE * 0.004;
 const WEAPON_PARKED_Y_DROP_BY_KIND = Object.freeze({
   // Keep parked weapons lifted to bishop-like token height (portrait calibration).
-  fighter: TOKEN_HEIGHT * 0.22,
-  helicopter: TOKEN_HEIGHT * 0.28,
-  drone: TOKEN_HEIGHT * 0.18,
-  supportTruck: TOKEN_HEIGHT * 0.24,
-  javelin: TOKEN_HEIGHT * 0.2
+  fighter: TOKEN_HEIGHT * 0.42,
+  helicopter: TOKEN_HEIGHT * 0.5,
+  drone: TOKEN_HEIGHT * 0.38,
+  supportTruck: TOKEN_HEIGHT * 0.46,
+  javelin: TOKEN_HEIGHT * 0.4
 });
 const WEAPON_REST_HEIGHT_OFFSET = -TOKEN_HEIGHT * 1.52;
 const WEAPON_SLOT_CLUSTER_SCALE = 0.3;
@@ -305,21 +305,21 @@ const WEAPON_REST_HEIGHT_OFFSET_BY_SEAT = Object.freeze([
 // Positive radial moves items visually toward each chair/edge on screen.
 const TOKEN_PORTRAIT_SCREEN_SHIFT_BY_SEAT = Object.freeze([
   // Bottom seat: push reserve token visually upward toward top player.
-  Object.freeze({ radial: -TILE_SIZE * 0.48, lateral: 0, y: 0 }),
+  Object.freeze({ radial: -TILE_SIZE * 0.7, lateral: 0, y: 0 }),
   Object.freeze({ radial: 0, lateral: 0, y: 0 }),
   // Top seat: push reserve token further upward on portrait screens.
-  Object.freeze({ radial: TILE_SIZE * 0.48, lateral: 0, y: 0 }),
+  Object.freeze({ radial: TILE_SIZE * 0.7, lateral: 0, y: 0 }),
   Object.freeze({ radial: 0, lateral: 0, y: 0 })
 ]);
 const WEAPON_PORTRAIT_SCREEN_SHIFT_BY_SEAT = Object.freeze([
-  Object.freeze({ radial: -TILE_SIZE * 0.3, lateral: 0, y: TILE_SIZE * 0.08 }),
-  Object.freeze({ radial: -TILE_SIZE * 0.16, lateral: -TILE_SIZE * 0.12, y: TILE_SIZE * 0.08 }),
-  Object.freeze({ radial: TILE_SIZE * 0.18, lateral: 0, y: TILE_SIZE * 0.08 }),
-  Object.freeze({ radial: -TILE_SIZE * 0.16, lateral: TILE_SIZE * 0.12, y: TILE_SIZE * 0.08 })
+  Object.freeze({ radial: -TILE_SIZE * 0.52, lateral: 0, y: TILE_SIZE * 0.16 }),
+  Object.freeze({ radial: -TILE_SIZE * 0.28, lateral: -TILE_SIZE * 0.14, y: TILE_SIZE * 0.16 }),
+  Object.freeze({ radial: TILE_SIZE * 0.38, lateral: 0, y: TILE_SIZE * 0.16 }),
+  Object.freeze({ radial: -TILE_SIZE * 0.28, lateral: TILE_SIZE * 0.14, y: TILE_SIZE * 0.16 })
 ]);
-const WEAPON_TABLE_SURFACE_Y_OFFSET = TILE_SIZE * 0.42;
+const WEAPON_TABLE_SURFACE_Y_OFFSET = TILE_SIZE * 0.54;
 const WEAPON_PARKING_SIDE_EXTRA_RADIUS = TILE_SIZE * 0.2;
-const WEAPON_PARKING_Y_FROM_GROUND_FLOOR = TOKEN_HEIGHT * 0.9;
+const WEAPON_PARKING_Y_FROM_GROUND_FLOOR = TOKEN_HEIGHT * 1.22;
 
 const PAVEMENT_EXTRA_SCALE = 1.18;
 const PAVEMENT_THICKNESS = TILE_SIZE * 0.4;


### PR DESCRIPTION
### Motivation
- Improve visual alignment on portrait phones by lifting parked capture weapons so they appear closer to the bishop token height and above the table.
- Move parked weapons and reserve tokens toward the top of the portrait screen and slightly outward from center for clearer composition and less table overlap.
- Nudge the bottom and top player reserve tokens upward so the tokens visually sit closer to the top-player area on portrait screens.

### Description
- Updated `webapp/src/components/SnakeBoard3D.jsx` constants controlling weapon/token parking and portrait shifts so parked weapons sit higher, farther toward the top of the screen, and slightly outward from center.
- Increased per-weapon parked lift in `WEAPON_PARKED_Y_DROP_BY_KIND` for `fighter`, `helicopter`, `drone`, `supportTruck`, and `javelin` to better match bishop-like token height.
- Increased outward radial offset via `WEAPON_PARKING_OUTWARD_OFFSET` and raised table-surface and parking Y offsets via `WEAPON_TABLE_SURFACE_Y_OFFSET` and `WEAPON_PARKING_Y_FROM_GROUND_FLOOR`.
- Amplified portrait radial pushes for reserve tokens in `TOKEN_PORTRAIT_SCREEN_SHIFT_BY_SEAT` (bottom and top seats) and adjusted `WEAPON_PORTRAIT_SCREEN_SHIFT_BY_SEAT` lateral/radial/y values to move weapon clusters toward the top and slightly outward.

### Testing
- Executed `cd webapp && npm run -s build` and the build completed successfully.
- The build emitted the same non-blocking Vite warnings (duplicate package key and dynamic/static import notices) which are unchanged and did not block the build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea4a4950a483298c1a9fd10929932a)