### PR TITLE
Fix Murlan card-back logo visibility and black joker figure fill

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -6753,7 +6753,7 @@ function easeInOutCubic(t) {
 }
 
 const CARD_FRONT_BASE_COLOR = '#e9eef5';
-const CARD_BACK_BASE_COLOR = '#dce5f0';
+const CARD_BACK_BASE_COLOR = '#ffffff';
 
 function createCardMesh(card, geometry, cache, theme, textureQuality = null) {
   const textureKey = textureQuality?.id || 'default';
@@ -7126,7 +7126,7 @@ function createFallbackOpenSourceCardSvg(cardKey) {
 
 function toOpenSourceDeckKey(rank, suit) {
   if (rank === 'JR') return 'J1';
-  if (rank === 'JB') return 'J2';
+  if (rank === 'JB') return 'J1';
   const suitCode = OPEN_SOURCE_SUIT_CODES[suit];
   if (!suitCode) return null;
   const rankCode = OPEN_SOURCE_RANK_CODES[rank] || String(rank).toLowerCase();
@@ -7139,18 +7139,7 @@ function svgMarkupFromOpenSourceDeck(rank, suit) {
   const CardComponent = OpenSourceDeck?.[cardKey];
   if (!CardComponent) return createFallbackOpenSourceCardSvg(cardKey);
   const svg = renderToStaticMarkup(<CardComponent width={1000} height={1400} />);
-  if (rank !== 'JB') {
-    return svg;
-  }
-  return svg
-    .replace(/#ff[0-9a-f]{4}/gi, '#111111')
-    .replace(/#f0[0-9a-f]{4}/gi, '#111111')
-    .replace(/#e0[0-9a-f]{4}/gi, '#111111')
-    .replace(/#d0[0-9a-f]{4}/gi, '#111111')
-    .replace(/#d[0-9a-f]{2,2}[0-9a-f]{2,2}/gi, '#111111')
-    .replace(/#e[0-9a-f]{2,2}[0-9a-f]{2,2}/gi, '#111111')
-    .replace(/#f[0-9a-f]{2,2}[0-9a-f]{2,2}/gi, '#111111')
-    .replace(/rgb\(\s*2(?:0[0-9]|1[0-9]|2[0-5])\s*,\s*[0-9]{1,3}\s*,\s*[0-9]{1,3}\s*\)/gi, 'rgb(17,17,17)');
+  return svg;
 }
 
 
@@ -7198,6 +7187,9 @@ function makeCardFace(rank, suit, theme, w = 768, h = 1080) {
     roundRect(ctx, 0, 0, canvas.width, canvas.height, cornerRadius);
     ctx.clip();
     ctx.drawImage(image, offsetX, offsetY, zoomedWidth, zoomedHeight);
+    if (rank === 'JB') {
+      recolorBlackJokerFigure(ctx, canvas.width, canvas.height);
+    }
 
     // Slightly thicken rank/suit glyph edges for better mobile readability.
     ctx.globalCompositeOperation = 'multiply';
@@ -7222,6 +7214,35 @@ function makeCardFace(rank, suit, theme, w = 768, h = 1080) {
   image.src = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
   tex.needsUpdate = true;
   return tex;
+}
+
+function recolorBlackJokerFigure(ctx, width, height) {
+  if (!ctx || width <= 0 || height <= 0) return;
+  const figureBounds = {
+    left: Math.floor(width * 0.18),
+    right: Math.ceil(width * 0.82),
+    top: Math.floor(height * 0.12),
+    bottom: Math.ceil(height * 0.9)
+  };
+  const imageData = ctx.getImageData(0, 0, width, height);
+  const data = imageData.data;
+  for (let i = 0; i < data.length; i += 4) {
+    const pixelIndex = i / 4;
+    const x = pixelIndex % width;
+    const y = Math.floor(pixelIndex / width);
+    if (x < figureBounds.left || x > figureBounds.right || y < figureBounds.top || y > figureBounds.bottom) continue;
+    const r = data[i];
+    const g = data[i + 1];
+    const b = data[i + 2];
+    const a = data[i + 3];
+    if (a < 12) continue;
+    const dominantRed = r > 96 && r > g + 18 && r > b + 18;
+    if (!dominantRed) continue;
+    data[i] = 17;
+    data[i + 1] = 17;
+    data[i + 2] = 17;
+  }
+  ctx.putImageData(imageData, 0, 0);
 }
 
 function makeCardBackTexture(theme, textureQuality = null) {


### PR DESCRIPTION
### Motivation
- Restore the card-back appearance so the Murlan logo and pattern render with the same visibility as before.  
- Ensure the black joker uses the original joker asset and that only the joker figure is recolored to black (not the whole card).  

### Description
- Set `CARD_BACK_BASE_COLOR` to `#ffffff` so the back texture/logo is not muted and matches the prior appearance.  
- Use the original open-source mapping for the black joker by mapping `JB` to the original `J1` key instead of a separate replacement path.  
- Remove the broad SVG-wide color-replacement logic and add a bounded pixel-recolor pass (`recolorBlackJokerFigure`) that only targets red-dominant pixels inside the joker figure area, turning those pixels to near-black while leaving the card background and non-figure areas intact.  
- Call the bounded recolor pass when rendering `rank === 'JB'` so only the black-joker face is affected at texture generation time.  

### Testing
- Ran `git diff --check` and it produced no blocking problems.  
- Ran `npm run -s lint -- webapp/src/pages/Games/MurlanRoyaleArena.jsx`, which surfaced pre-existing repository-wide lint issues; the project linter also reports this file is ignored in the current lint config so no new lint failures were introduced for the changed file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea4c7ee8988329a3f3b8d75e6a7bb5)