### PR TITLE
Murlan Royale: enlarge card-back logo, style black joker face, and lower chairs

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2396,7 +2396,7 @@ const DEAL_SHUFFLE_LEAD_IN_MS = 220;
 const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 1.1;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
 const CHAIR_GROUND_DROP = 0;
-const CHAIR_SCREEN_LOWER_OFFSET = 0;
+const CHAIR_SCREEN_LOWER_OFFSET = 0.11 * MODEL_SCALE;
 const HUMAN_CHAIR_EXTRA_INWARD_OFFSET = 0; // Align human chair distance with AI seats.
 const TABLE_HEIGHT_LIFT = 0.025 * MODEL_SCALE;
 const TABLE_HEIGHT = STOOL_HEIGHT + TABLE_HEIGHT_LIFT;
@@ -7242,6 +7242,27 @@ function recolorBlackJokerFigure(ctx, width, height) {
     data[i + 1] = 17;
     data[i + 2] = 17;
   }
+
+  // Keep the rounded joker face in the same yellow tone as the red/yellow joker.
+  const faceCenterX = width * 0.5;
+  const faceCenterY = height * 0.385;
+  const faceRadiusX = width * 0.105;
+  const faceRadiusY = height * 0.09;
+  const faceColor = { r: 246, g: 214, b: 132 };
+  for (let i = 0; i < data.length; i += 4) {
+    const pixelIndex = i / 4;
+    const x = pixelIndex % width;
+    const y = Math.floor(pixelIndex / width);
+    const dx = (x - faceCenterX) / faceRadiusX;
+    const dy = (y - faceCenterY) / faceRadiusY;
+    if (dx * dx + dy * dy > 1) continue;
+    const a = data[i + 3];
+    if (a < 12) continue;
+    data[i] = faceColor.r;
+    data[i + 1] = faceColor.g;
+    data[i + 2] = faceColor.b;
+  }
+
   ctx.putImageData(imageData, 0, 0);
 }
 

--- a/webapp/src/utils/cards3d.js
+++ b/webapp/src/utils/cards3d.js
@@ -448,8 +448,8 @@ function drawLogoFrame(ctx, w, h, theme) {
 
   if (logoImage?.complete && logoImage.naturalWidth > 0) {
     const ratio = logoImage.naturalWidth / Math.max(logoImage.naturalHeight, 1);
-    const logoBoxWidth = w * 0.98;
-    const logoBoxHeight = h * 0.46;
+    const logoBoxWidth = w * 1.96;
+    const logoBoxHeight = h * 0.92;
     const drawWidth = Math.min(logoBoxWidth, logoBoxHeight * ratio);
     const drawHeight = drawWidth / ratio;
     const logoX = w / 2 - drawWidth / 2;


### PR DESCRIPTION
### Motivation
- Implement visual updates requested for the Murlan Royale game: make card back logo ~2x larger, harmonize the black joker rounded-face color with the yellow joker face, and move chairs visually lower on screen to match portrait layout expectations.

### Description
- Increased the logo drawing box inside `drawLogoFrame` so the TonPlaygram logo occupies a much larger area on card backs by changing `logoBoxWidth`/`logoBoxHeight` scale factors in `webapp/src/utils/cards3d.js`.
- Modified `recolorBlackJokerFigure` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to keep the joker figure dark while forcing a rounded-face ellipse region to a yellow skin tone so the black joker’s face matches the other joker tone.
- Lowered chair placement by increasing the `CHAIR_SCREEN_LOWER_OFFSET` constant (`0` → `0.11 * MODEL_SCALE`) in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` so seats render visually lower.
- Files changed: `webapp/src/utils/cards3d.js` and `webapp/src/pages/Games/MurlanRoyaleArena.jsx`.

### Testing
- Ran `npm run -s lint`, which completed but produced linter warnings in this environment; no runtime unit tests were executed.
- Ran `npx eslint webapp/src/pages/Games/MurlanRoyaleArena.jsx webapp/src/utils/cards3d.js`, which completed but reported that the files are ignored by repo eslint ignore rules and produced ignore warnings only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea50265db88329a4033264b972e0b6)