### PR TITLE
Murlan Royale: enlarge card-back logo, preserve joker face tone, lower chairs

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2396,7 +2396,7 @@ const DEAL_SHUFFLE_LEAD_IN_MS = 220;
 const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 1.1;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
 const CHAIR_GROUND_DROP = 0;
-const CHAIR_SCREEN_LOWER_OFFSET = 0;
+const CHAIR_SCREEN_LOWER_OFFSET = 0.1 * MODEL_SCALE;
 const HUMAN_CHAIR_EXTRA_INWARD_OFFSET = 0; // Align human chair distance with AI seats.
 const TABLE_HEIGHT_LIFT = 0.025 * MODEL_SCALE;
 const TABLE_HEIGHT = STOOL_HEIGHT + TABLE_HEIGHT_LIFT;
@@ -7224,6 +7224,10 @@ function recolorBlackJokerFigure(ctx, width, height) {
     top: Math.floor(height * 0.12),
     bottom: Math.ceil(height * 0.9)
   };
+  const faceCenterX = width * 0.5;
+  const faceCenterY = height * 0.39;
+  const faceRadiusX = width * 0.12;
+  const faceRadiusY = height * 0.09;
   const imageData = ctx.getImageData(0, 0, width, height);
   const data = imageData.data;
   for (let i = 0; i < data.length; i += 4) {
@@ -7236,6 +7240,18 @@ function recolorBlackJokerFigure(ctx, width, height) {
     const b = data[i + 2];
     const a = data[i + 3];
     if (a < 12) continue;
+    const dx = (x - faceCenterX) / Math.max(faceRadiusX, 1);
+    const dy = (y - faceCenterY) / Math.max(faceRadiusY, 1);
+    const isInsideFace = dx * dx + dy * dy <= 1;
+    if (isInsideFace) {
+      // Keep the joker's rounded face area aligned with the yellow/red joker tone.
+      if (r > 140 && g > 95 && b < 130) {
+        data[i] = 246;
+        data[i + 1] = 206;
+        data[i + 2] = 126;
+      }
+      continue;
+    }
     const dominantRed = r > 96 && r > g + 18 && r > b + 18;
     if (!dominantRed) continue;
     data[i] = 17;

--- a/webapp/src/utils/cards3d.js
+++ b/webapp/src/utils/cards3d.js
@@ -448,8 +448,9 @@ function drawLogoFrame(ctx, w, h, theme) {
 
   if (logoImage?.complete && logoImage.naturalWidth > 0) {
     const ratio = logoImage.naturalWidth / Math.max(logoImage.naturalHeight, 1);
-    const logoBoxWidth = w * 0.98;
-    const logoBoxHeight = h * 0.46;
+    // Make the logo on the card back visually ~2x larger as requested.
+    const logoBoxWidth = w * 1.96;
+    const logoBoxHeight = h * 0.92;
     const drawWidth = Math.min(logoBoxWidth, logoBoxHeight * ratio);
     const drawHeight = drawWidth / ratio;
     const logoX = w / 2 - drawWidth / 2;


### PR DESCRIPTION
### Motivation
- Implement the requested visual updates for Murlan Royale: make the card-back logo larger, make the black joker's rounded face match the other joker's rounded face tone, and lower chairs on-screen for better visual alignment.

### Description
- Increased the TonPlaygram logo render bounds used by the card-back drawing routine in `webapp/src/utils/cards3d.js` so the logo appears roughly 2x larger on card backs (`drawLogoFrame` logo box sizes adjusted).
- Updated the black joker recoloring logic in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` by computing a rounded face region and preserving a yellow/skin-tone fill inside that ellipse while keeping the rest of red-dominant pixels mapped to dark (changes in `recolorBlackJokerFigure`).
- Lowered chair placement by introducing a small screen-offset for chairs via `CHAIR_SCREEN_LOWER_OFFSET = 0.1 * MODEL_SCALE` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` so chairs render slightly lower on-screen.

### Testing
- Built the webapp successfully using `npm -C webapp run build`, and the production build completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea50265db88329a4033264b972e0b6)