### PR TITLE
Adjust SnakeBoard3D token and weapon parking for portrait view

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -276,7 +276,7 @@ const WEAPON_SLOT_LATERAL_NUDGE_BY_SEAT = Object.freeze([
   0
 ]);
 const WEAPON_DISPLAY_SIZE_MULTIPLIER = 1.72;
-const WEAPON_PARKING_OUTWARD_OFFSET = -TILE_SIZE * 0.2;
+const WEAPON_PARKING_OUTWARD_OFFSET = TILE_SIZE * 0.34;
 const WEAPON_FROM_TOKEN_CENTER_OFFSET = TOKEN_RADIUS * 0.58;
 const WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT = Object.freeze([
   0,
@@ -286,12 +286,12 @@ const WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT = Object.freeze([
 ]);
 const WEAPON_TOKEN_GAP = TILE_SIZE * 0.004;
 const WEAPON_PARKED_Y_DROP_BY_KIND = Object.freeze({
-  // Keep parked weapons lifted to bishop-like token height (portrait calibration).
-  fighter: TOKEN_HEIGHT * 0.22,
-  helicopter: TOKEN_HEIGHT * 0.28,
-  drone: TOKEN_HEIGHT * 0.18,
-  supportTruck: TOKEN_HEIGHT * 0.24,
-  javelin: TOKEN_HEIGHT * 0.2
+  // Lift parked weapons higher so they sit at bishop-token visual height on portrait screens.
+  fighter: TOKEN_HEIGHT * 0.06,
+  helicopter: TOKEN_HEIGHT * 0.08,
+  drone: TOKEN_HEIGHT * 0.05,
+  supportTruck: TOKEN_HEIGHT * 0.07,
+  javelin: TOKEN_HEIGHT * 0.06
 });
 const WEAPON_REST_HEIGHT_OFFSET = -TOKEN_HEIGHT * 0.72;
 const WEAPON_SLOT_CLUSTER_SCALE = 0.3;
@@ -305,19 +305,19 @@ const WEAPON_REST_HEIGHT_OFFSET_BY_SEAT = Object.freeze([
 // Positive radial moves items visually toward each chair/edge on screen.
 const TOKEN_PORTRAIT_SCREEN_SHIFT_BY_SEAT = Object.freeze([
   // Bottom seat: push reserve token visually upward toward top player.
-  Object.freeze({ radial: -TILE_SIZE * 0.64, lateral: 0, y: 0 }),
+  Object.freeze({ radial: -TILE_SIZE * 0.92, lateral: 0, y: 0 }),
   Object.freeze({ radial: 0, lateral: 0, y: 0 }),
   // Top seat: push reserve token further upward on portrait screens.
-  Object.freeze({ radial: TILE_SIZE * 0.64, lateral: 0, y: 0 }),
+  Object.freeze({ radial: TILE_SIZE * 0.92, lateral: 0, y: 0 }),
   Object.freeze({ radial: 0, lateral: 0, y: 0 })
 ]);
 const WEAPON_PORTRAIT_SCREEN_SHIFT_BY_SEAT = Object.freeze([
-  Object.freeze({ radial: -TILE_SIZE * 0.46, lateral: 0, y: TILE_SIZE * 0.14 }),
-  Object.freeze({ radial: -TILE_SIZE * 0.22, lateral: -TILE_SIZE * 0.16, y: TILE_SIZE * 0.14 }),
-  Object.freeze({ radial: TILE_SIZE * 0.36, lateral: 0, y: TILE_SIZE * 0.14 }),
-  Object.freeze({ radial: -TILE_SIZE * 0.22, lateral: TILE_SIZE * 0.16, y: TILE_SIZE * 0.14 })
+  Object.freeze({ radial: -TILE_SIZE * 0.72, lateral: 0, y: TILE_SIZE * 0.2 }),
+  Object.freeze({ radial: -TILE_SIZE * 0.28, lateral: -TILE_SIZE * 0.18, y: TILE_SIZE * 0.2 }),
+  Object.freeze({ radial: TILE_SIZE * 0.62, lateral: 0, y: TILE_SIZE * 0.2 }),
+  Object.freeze({ radial: -TILE_SIZE * 0.28, lateral: TILE_SIZE * 0.18, y: TILE_SIZE * 0.2 })
 ]);
-const WEAPON_TABLE_SURFACE_Y_OFFSET = TILE_SIZE * 0.42;
+const WEAPON_TABLE_SURFACE_Y_OFFSET = TILE_SIZE * 0.52;
 const WEAPON_PARKING_SIDE_EXTRA_RADIUS = TILE_SIZE * 0.2;
 const WEAPON_PARKING_Y_FROM_GROUND_FLOOR = TOKEN_HEIGHT * 0.9;
 


### PR DESCRIPTION
### Motivation
- Improve visual layout on portrait phones by pushing bottom/top reserve tokens further toward the top-player direction so the four-token center aligns with the board center. 
- Prevent parked weapon rigs from appearing under the table by raising their resting height to be visually similar to the bishop token height. 
- Reduce crowding near the board center by moving parked weapons farther outward and increasing seat-specific portrait offsets. 

### Description
- Updated `WEAPON_PARKING_OUTWARD_OFFSET` from `-TILE_SIZE * 0.2` to `TILE_SIZE * 0.34` to move parked weapons outward from the board center in `webapp/src/components/SnakeBoard3D.jsx`. 
- Reduced the downward drop values in `WEAPON_PARKED_Y_DROP_BY_KIND` so parked weapons are lifted (new values use smaller multipliers of `TOKEN_HEIGHT`). 
- Increased radial shifts in `TOKEN_PORTRAIT_SCREEN_SHIFT_BY_SEAT` (bottom and top seats now use `0.92 * TILE_SIZE`) to push reserve tokens upward on portrait screens. 
- Expanded `WEAPON_PORTRAIT_SCREEN_SHIFT_BY_SEAT` radial/lateral/y offsets and raised `WEAPON_TABLE_SURFACE_Y_OFFSET` from `TILE_SIZE * 0.42` to `TILE_SIZE * 0.52` so parked weapon positions and their animations render higher and less crowded. 

### Testing
- Ran the production build with `npm --prefix webapp run build`, which completed successfully. 
- The build produced unrelated non-blocking Vite warnings (dynamic import/chunk-size and a duplicate key notice in `package.json`) but no errors from the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea50d5c7508329ac31ac068c92770d)