### PR TITLE
Tune Murlan visuals: larger card-back logo, refine black joker, lower chairs

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2396,7 +2396,7 @@ const DEAL_SHUFFLE_LEAD_IN_MS = 220;
 const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 1.1;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
 const CHAIR_GROUND_DROP = 0;
-const CHAIR_SCREEN_LOWER_OFFSET = 0;
+const CHAIR_SCREEN_LOWER_OFFSET = 0.14 * MODEL_SCALE;
 const HUMAN_CHAIR_EXTRA_INWARD_OFFSET = 0; // Align human chair distance with AI seats.
 const TABLE_HEIGHT_LIFT = 0.025 * MODEL_SCALE;
 const TABLE_HEIGHT = STOOL_HEIGHT + TABLE_HEIGHT_LIFT;
@@ -7236,8 +7236,9 @@ function recolorBlackJokerFigure(ctx, width, height) {
     const b = data[i + 2];
     const a = data[i + 3];
     if (a < 12) continue;
-    const dominantRed = r > 96 && r > g + 18 && r > b + 18;
-    if (!dominantRed) continue;
+    // Recolor only strong red costume regions. Keep yellow/skin rounded face tones unchanged.
+    const isStrongRedCostume = r >= 120 && g <= 95 && b <= 95 && r >= g + 24 && r >= b + 24;
+    if (!isStrongRedCostume) continue;
     data[i] = 17;
     data[i + 1] = 17;
     data[i + 2] = 17;

--- a/webapp/src/utils/cards3d.js
+++ b/webapp/src/utils/cards3d.js
@@ -449,7 +449,8 @@ function drawLogoFrame(ctx, w, h, theme) {
   if (logoImage?.complete && logoImage.naturalWidth > 0) {
     const ratio = logoImage.naturalWidth / Math.max(logoImage.naturalHeight, 1);
     const logoBoxWidth = w * 0.98;
-    const logoBoxHeight = h * 0.46;
+    // Make the back logo appear ~2x larger while still fitting inside the frame.
+    const logoBoxHeight = h * 0.92;
     const drawWidth = Math.min(logoBoxWidth, logoBoxHeight * ratio);
     const drawHeight = drawWidth / ratio;
     const logoX = w / 2 - drawWidth / 2;


### PR DESCRIPTION
### Motivation
- Visual polish requested for Murlan Royale: make the card-back logo larger, keep the black joker's rounded face tone consistent with the yellow joker, and move chairs visually lower on screen to match design direction.

### Description
- Increase card back logo footprint by changing the logo drawing box in `webapp/src/utils/cards3d.js` (set `logoBoxHeight` to `h * 0.92`).
- Refine black joker recoloring in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to only recolor strong red costume pixels so rounded yellow/skin face tones remain unchanged.
- Lower chair placement by setting `CHAIR_SCREEN_LOWER_OFFSET` to `0.14 * MODEL_SCALE` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` so seats render visually lower on portrait screens.

### Testing
- Ran the targeted Jest suite with `npm test -- --runInBand test/murlan.test.js` and the suite passed: `PASS test/murlan.test.js` (12/12 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea50265db88329a4033264b972e0b6)