### PR TITLE
Tune SnakeBoard 3D parking offsets and make dice handoff advance after result

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -276,13 +276,13 @@ const WEAPON_SLOT_LATERAL_NUDGE_BY_SEAT = Object.freeze([
   0
 ]);
 const WEAPON_DISPLAY_SIZE_MULTIPLIER = 1.72;
-const WEAPON_PARKING_OUTWARD_OFFSET = TILE_SIZE * 0.34;
+const WEAPON_PARKING_OUTWARD_OFFSET = TILE_SIZE * 0.46;
 const WEAPON_FROM_TOKEN_CENTER_OFFSET = TOKEN_RADIUS * 0.58;
 const WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT = Object.freeze([
-  0,
-  0,
-  0,
-  0
+  TILE_SIZE * 0.05,
+  TILE_SIZE * 0.03,
+  TILE_SIZE * 0.08,
+  TILE_SIZE * 0.03
 ]);
 const WEAPON_TOKEN_GAP = TILE_SIZE * 0.004;
 const WEAPON_PARKED_Y_DROP_BY_KIND = Object.freeze({
@@ -296,26 +296,26 @@ const WEAPON_PARKED_Y_DROP_BY_KIND = Object.freeze({
 const WEAPON_REST_HEIGHT_OFFSET = -TOKEN_HEIGHT * 0.72;
 const WEAPON_SLOT_CLUSTER_SCALE = 0.3;
 const WEAPON_REST_HEIGHT_OFFSET_BY_SEAT = Object.freeze([
-  0,
-  0,
-  0,
-  0
+  TILE_SIZE * 0.04,
+  TILE_SIZE * 0.03,
+  TILE_SIZE * 0.05,
+  TILE_SIZE * 0.03
 ]);
 // Portrait phone calibration (seat order: 0=bottom, 1=right, 2=top, 3=left).
 // Positive radial moves items visually toward each chair/edge on screen.
 const TOKEN_PORTRAIT_SCREEN_SHIFT_BY_SEAT = Object.freeze([
   // Bottom seat: push reserve token visually upward toward top player.
-  Object.freeze({ radial: -TILE_SIZE * 0.92, lateral: 0, y: 0 }),
+  Object.freeze({ radial: -TILE_SIZE * 1.08, lateral: 0, y: TILE_SIZE * 0.02 }),
   Object.freeze({ radial: 0, lateral: 0, y: 0 }),
   // Top seat: push reserve token further upward on portrait screens.
-  Object.freeze({ radial: TILE_SIZE * 0.92, lateral: 0, y: 0 }),
+  Object.freeze({ radial: TILE_SIZE * 1.08, lateral: 0, y: TILE_SIZE * 0.03 }),
   Object.freeze({ radial: 0, lateral: 0, y: 0 })
 ]);
 const WEAPON_PORTRAIT_SCREEN_SHIFT_BY_SEAT = Object.freeze([
-  Object.freeze({ radial: -TILE_SIZE * 0.72, lateral: 0, y: TILE_SIZE * 0.2 }),
-  Object.freeze({ radial: -TILE_SIZE * 0.28, lateral: -TILE_SIZE * 0.18, y: TILE_SIZE * 0.2 }),
-  Object.freeze({ radial: TILE_SIZE * 0.62, lateral: 0, y: TILE_SIZE * 0.2 }),
-  Object.freeze({ radial: -TILE_SIZE * 0.28, lateral: TILE_SIZE * 0.18, y: TILE_SIZE * 0.2 })
+  Object.freeze({ radial: -TILE_SIZE * 0.84, lateral: 0, y: TILE_SIZE * 0.28 }),
+  Object.freeze({ radial: -TILE_SIZE * 0.34, lateral: -TILE_SIZE * 0.2, y: TILE_SIZE * 0.28 }),
+  Object.freeze({ radial: TILE_SIZE * 0.78, lateral: 0, y: TILE_SIZE * 0.3 }),
+  Object.freeze({ radial: -TILE_SIZE * 0.34, lateral: TILE_SIZE * 0.2, y: TILE_SIZE * 0.28 })
 ]);
 const WEAPON_TABLE_SURFACE_Y_OFFSET = TILE_SIZE * 0.52;
 const WEAPON_PARKING_SIDE_EXTRA_RADIUS = TILE_SIZE * 0.2;

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -2717,6 +2717,10 @@ export default function SnakeAndLadder() {
       }
       const extraPred = diceCells[predicted] || rolledSix;
       const nextPlayer = extraPred ? currentTurn : getPreviousTurn(currentTurn);
+      if (!gameOver) {
+        setCurrentTurn(nextPlayer);
+        setDiceCount(playerDiceCounts[nextPlayer] ?? 1);
+      }
 
       const steps = [];
       for (let i = current + 1; i <= target; i++) steps.push(i);
@@ -2843,12 +2847,6 @@ export default function SnakeAndLadder() {
             setCurrentTurn(next);
             setDiceCount(playerDiceCounts[next] ?? 1);
             if (next === 0) setRollCooldown(0);
-          } else {
-            const next = getPreviousTurn(currentTurn);
-            setTimeout(() => {
-              setCurrentTurn(next);
-              setDiceCount(playerDiceCounts[next] ?? 1);
-            }, TURN_ADVANCE_AFTER_DICE_MS);
           }
         }
       };
@@ -2941,6 +2939,8 @@ export default function SnakeAndLadder() {
     }
     const extraPred = diceCells[predicted] || rolledSix;
     const nextPlayer = extraPred ? index : getPreviousTurn(index);
+    setCurrentTurn(nextPlayer);
+    setDiceCount(playerDiceCounts[nextPlayer] ?? 1);
 
     const steps = [];
     for (let i = current + 1; i <= target; i++) steps.push(i);
@@ -3046,11 +3046,6 @@ export default function SnakeAndLadder() {
       if (extraTurn) {
         setCurrentTurn(next);
         setDiceCount(playerDiceCounts[next] ?? 1);
-      } else {
-        setTimeout(() => {
-          setCurrentTurn(next);
-          setDiceCount(playerDiceCounts[next] ?? 1);
-        }, TURN_ADVANCE_AFTER_DICE_MS);
       }
       setDiceVisible(true);
       setMoving(false);


### PR DESCRIPTION
### Motivation
- Improve visual placement of parked weapons and reserve tokens on portrait mobile so items appear slightly higher, more outward from board center, and shifted toward the top player for better UX in portrait orientation.
- Make dice/turn behavior feel snappier by moving the dice handoff to the next player immediately after the dice result hold, reducing perceived idle time.
- Keep changes limited to presentation/layout and local turn flow so multiplayer/server logic remains unchanged.

### Description
- Increased the weapon parking outward radius and added per-seat outward offsets and per-seat Y offsets to lift parked weapons visually in `webapp/src/components/SnakeBoard3D.jsx`.
- Adjusted `TOKEN_PORTRAIT_SCREEN_SHIFT_BY_SEAT` and `WEAPON_PORTRAIT_SCREEN_SHIFT_BY_SEAT` to push bottom/top reserve tokens and parked weapons further toward the top of portrait screens in `webapp/src/components/SnakeBoard3D.jsx`.
- Updated local turn flow in `webapp/src/pages/Games/SnakeAndLadder.jsx` so after showing the dice result for `DICE_RESULT_HOLD_MS` the code calls `setCurrentTurn`/`setDiceCount` immediately for both player and AI paths, instead of waiting for full movement resolution.
- Changes are scoped to the two files above and affect visual/layout constants and local UI turn sequencing only.

### Testing
- Ran the production build with `npm -C webapp run -s build` and the build completed successfully (warnings from existing bundle sizes/duplicate package keys only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea550d76148329aae01f6d7259b7c6)