### PR TITLE
Murlan Royale: make discard pile look messy and enlarge card-back logo

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -3983,13 +3983,15 @@ export default function MurlanRoyaleArena({ search }) {
       updateCardFace(mesh, 'front');
       setCommunityCardLegibility(mesh, true);
       const target = discardAnchor.clone();
-      const scatterX = (cardIdNoise(card.id, 3) - 0.5) * CARD_W * 0.05;
-      const scatterZ = (cardIdNoise(card.id, 7) - 0.5) * CARD_H * 0.04;
+      // Keep the discard pile at the same table location but make card placement look naturally messy.
+      const scatterX = (cardIdNoise(card.id, 3) - 0.5) * CARD_W * 0.34;
+      const scatterZ = (cardIdNoise(card.id, 7) - 0.5) * CARD_H * 0.26;
       target.addScaledVector(pileRightAxis, scatterX);
       target.addScaledVector(pileForwardAxis, scatterZ);
-      target.y += idx * 0.0022;
-      const discardYaw = (cardIdNoise(card.id, 13) - 0.5) * THREE.MathUtils.degToRad(2);
-      const discardTilt = (cardIdNoise(card.id, 17) - 0.5) * THREE.MathUtils.degToRad(0.8);
+      const layerJitter = (cardIdNoise(card.id, 19) - 0.5) * 0.0034;
+      target.y += idx * 0.0014 + layerJitter;
+      const discardYaw = (cardIdNoise(card.id, 13) - 0.5) * THREE.MathUtils.degToRad(20);
+      const discardTilt = (cardIdNoise(card.id, 17) - 0.5) * THREE.MathUtils.degToRad(3.2);
       setMeshPosition(
         mesh,
         target,

--- a/webapp/src/utils/cards3d.js
+++ b/webapp/src/utils/cards3d.js
@@ -448,9 +448,9 @@ function drawLogoFrame(ctx, w, h, theme) {
 
   if (logoImage?.complete && logoImage.naturalWidth > 0) {
     const ratio = logoImage.naturalWidth / Math.max(logoImage.naturalHeight, 1);
-    const logoBoxWidth = w * 0.98;
-    // Make the back logo appear ~2x larger while still fitting inside the frame.
-    const logoBoxHeight = h * 0.92;
+    // Increase logo presence on card backs to match previous larger look.
+    const logoBoxWidth = w * 1.22;
+    const logoBoxHeight = h * 1.04;
     const drawWidth = Math.min(logoBoxWidth, logoBoxHeight * ratio);
     const drawHeight = drawWidth / ratio;
     const logoX = w / 2 - drawWidth / 2;


### PR DESCRIPTION
### Motivation
- The discard pile looked unnaturally ordered and the logo on the back of cards appeared too small compared to the earlier visual; both should be restored to the intended appearance.

### Description
- Changed discard pile placement so cards remain at the same table anchor while getting larger lateral and forward scatter, small per-card height jitter, and wider random yaw/tilt to produce a naturally messy spread (`webapp/src/pages/Games/MurlanRoyaleArena.jsx`).
- Tuned scatter magnitudes to use `CARD_W` / `CARD_H` multipliers and added `layerJitter` so pile cards are not visually stacked in strict order (`scatterX`, `scatterZ`, `discardYaw`, `discardTilt`).
- Increased the card-back logo drawing area inside `drawLogoFrame` to make the TonPlaygram logo noticeably larger on card backs (`webapp/src/utils/cards3d.js` by adjusting `logoBoxWidth` and `logoBoxHeight`).

### Testing
- Ran lint for the modified files with `npm run -s lint -- webapp/src/pages/Games/MurlanRoyaleArena.jsx webapp/src/utils/cards3d.js`, which completed and produced only a non-blocking React version detection warning in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea571e05f08329a210b493f6b27469)