### PR TITLE
Fix Murlan deck shuffle scatter and enlarge card-back logo

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -3872,9 +3872,11 @@ export default function MurlanRoyaleArena({ search }) {
         const isNewHandCard = Boolean(card && !previousPlayer?.hand?.some((prevCard) => prevCard.id === card.id));
         let handDealDelay = isNewHandCard ? (cardIdx * state.players.length + idx) * DEAL_CARD_STEP_DELAY_MS : 0;
         if (isNewHandCard && !immediate && three.deckAnchor) {
-          const shuffleSpreadX = (cardIdNoise(card.id, 11) - 0.5) * CARD_W * 0.22;
-          const shuffleSpreadZ = (cardIdNoise(card.id, 29) - 0.5) * CARD_H * 0.22;
+          const shuffleSpreadX = (Math.random() - 0.5) * CARD_W * 0.34;
+          const shuffleSpreadZ = (Math.random() - 0.5) * CARD_H * 0.34;
+          const shuffleYaw = (Math.random() - 0.5) * THREE.MathUtils.degToRad(8);
           mesh.position.copy(three.deckAnchor).add(new THREE.Vector3(shuffleSpreadX, 0, shuffleSpreadZ));
+          mesh.rotation.y = shuffleYaw;
           if (isInitialDealAnimation) {
             handDealDelay += DEAL_SHUFFLE_LEAD_IN_MS;
           }

--- a/webapp/src/utils/cards3d.js
+++ b/webapp/src/utils/cards3d.js
@@ -431,8 +431,8 @@ function drawLogoFrame(ctx, w, h, theme) {
   ctx.restore();
 
   ctx.save();
-  const plateWidth = w * 0.92;
-  const plateHeight = h * 0.38;
+  const plateWidth = w * 0.96;
+  const plateHeight = h * 0.48;
   const plateX = (w - plateWidth) / 2;
   const plateY = (h - plateHeight) / 2;
   const plateGradient = ctx.createLinearGradient(plateX, plateY, plateX, plateY + plateHeight);
@@ -448,9 +448,9 @@ function drawLogoFrame(ctx, w, h, theme) {
 
   if (logoImage?.complete && logoImage.naturalWidth > 0) {
     const ratio = logoImage.naturalWidth / Math.max(logoImage.naturalHeight, 1);
-    const logoBoxWidth = w * 0.98;
-    // Make the back logo appear ~2x larger while still fitting inside the frame.
-    const logoBoxHeight = h * 0.92;
+    const logoBoxWidth = w * 1.02;
+    // Restore larger back logo sizing for clearer visibility on mobile portrait screens.
+    const logoBoxHeight = h * 1.02;
     const drawWidth = Math.min(logoBoxWidth, logoBoxHeight * ratio);
     const drawHeight = drawWidth / ratio;
     const logoX = w / 2 - drawWidth / 2;


### PR DESCRIPTION
### Motivation
- Players reported the dealt pile looked too ordered and the card-back logo was smaller than before, reducing visual clarity on portrait/mobile screens.
- Changes aim to keep the deck anchor location the same while restoring a messy shuffled appearance and increasing the back-logo visibility.

### Description
- Randomized initial deal spawn by replacing deterministic `cardIdNoise` offsets with stronger `Math.random()` X/Z scatter and a small random yaw so new cards appear messily placed while still originating from the same `deckAnchor` (`webapp/src/pages/Games/MurlanRoyaleArena.jsx`).
- Increased the card-back center plate and logo draw bounds in `drawLogoFrame` so the TonPlaygram logo is drawn larger and more legible on card backs (`webapp/src/utils/cards3d.js`).
- Kept existing material/texture pipeline intact and used the same deck anchor so layout and camera logic remain unchanged.

### Testing
- Ran unit tests: `npm test -- --runTestsByPath test/murlan.test.js --runInBand` which passed (`1` test suite, `12` tests passed).
- Ran lint checks: `npx eslint webapp/src/pages/Games/MurlanRoyaleArena.jsx webapp/src/utils/cards3d.js` which reported ignored-file warnings under the current lint ignore settings, and `npx eslint --no-ignore` flagged linting errors in `cards3d.js` (lint failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea571e05f08329a210b493f6b27469)