### PR TITLE
Tune Snake & Ladder seat parking positions and dice handoff timing

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -279,10 +279,10 @@ const WEAPON_DISPLAY_SIZE_MULTIPLIER = 1.72;
 const WEAPON_PARKING_OUTWARD_OFFSET = TILE_SIZE * 0.46;
 const WEAPON_FROM_TOKEN_CENTER_OFFSET = TOKEN_RADIUS * 0.58;
 const WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT = Object.freeze([
-  TILE_SIZE * 0.05,
-  TILE_SIZE * 0.03,
-  TILE_SIZE * 0.08,
-  TILE_SIZE * 0.03
+  TILE_SIZE * 0.11,
+  TILE_SIZE * 0.09,
+  TILE_SIZE * 0.14,
+  TILE_SIZE * 0.09
 ]);
 const WEAPON_TOKEN_GAP = TILE_SIZE * 0.004;
 const WEAPON_PARKED_Y_DROP_BY_KIND = Object.freeze({
@@ -305,17 +305,17 @@ const WEAPON_REST_HEIGHT_OFFSET_BY_SEAT = Object.freeze([
 // Positive radial moves items visually toward each chair/edge on screen.
 const TOKEN_PORTRAIT_SCREEN_SHIFT_BY_SEAT = Object.freeze([
   // Bottom seat: push reserve token visually upward toward top player.
-  Object.freeze({ radial: -TILE_SIZE * 1.08, lateral: 0, y: TILE_SIZE * 0.02 }),
+  Object.freeze({ radial: -TILE_SIZE * 1.24, lateral: 0, y: TILE_SIZE * 0.03 }),
   Object.freeze({ radial: 0, lateral: 0, y: 0 }),
   // Top seat: push reserve token further upward on portrait screens.
-  Object.freeze({ radial: TILE_SIZE * 1.08, lateral: 0, y: TILE_SIZE * 0.03 }),
+  Object.freeze({ radial: TILE_SIZE * 1.24, lateral: 0, y: TILE_SIZE * 0.04 }),
   Object.freeze({ radial: 0, lateral: 0, y: 0 })
 ]);
 const WEAPON_PORTRAIT_SCREEN_SHIFT_BY_SEAT = Object.freeze([
-  Object.freeze({ radial: -TILE_SIZE * 0.84, lateral: 0, y: TILE_SIZE * 0.28 }),
-  Object.freeze({ radial: -TILE_SIZE * 0.34, lateral: -TILE_SIZE * 0.2, y: TILE_SIZE * 0.28 }),
-  Object.freeze({ radial: TILE_SIZE * 0.78, lateral: 0, y: TILE_SIZE * 0.3 }),
-  Object.freeze({ radial: -TILE_SIZE * 0.34, lateral: TILE_SIZE * 0.2, y: TILE_SIZE * 0.28 })
+  Object.freeze({ radial: -TILE_SIZE * 0.96, lateral: 0, y: TILE_SIZE * 0.34 }),
+  Object.freeze({ radial: -TILE_SIZE * 0.42, lateral: -TILE_SIZE * 0.24, y: TILE_SIZE * 0.34 }),
+  Object.freeze({ radial: TILE_SIZE * 0.92, lateral: 0, y: TILE_SIZE * 0.36 }),
+  Object.freeze({ radial: -TILE_SIZE * 0.42, lateral: TILE_SIZE * 0.24, y: TILE_SIZE * 0.34 })
 ]);
 const WEAPON_TABLE_SURFACE_Y_OFFSET = TILE_SIZE * 0.52;
 const WEAPON_PARKING_SIDE_EXTRA_RADIUS = TILE_SIZE * 0.2;
@@ -2521,12 +2521,11 @@ function createDiceSettleAnimation(diceArray, { basePositions, baseY, startState
   };
 }
 
-function createDiceHandoffAnimation(diceArray, { basePositions, baseY }) {
+function createDiceHandoffAnimation(diceArray, { basePositions, baseY, duration = TURN_CAMERA_TURN_IN_DURATION }) {
   if (!Array.isArray(diceArray) || !diceArray.length || !Array.isArray(basePositions) || !basePositions.length) {
     return null;
   }
   const startPositions = diceArray.map((die) => die.position.clone());
-  const duration = 380;
   return {
     type: 'diceHandoff',
     start: performance.now(),


### PR DESCRIPTION
### Motivation
- Improve portrait-phone UX for Snake & Ladder by nudging reserve player tokens and parked weapons upward and outward so they visually sit closer to the top player and away from the board center, and by aligning dice handoff motion timing with the camera turn-focus to make turns feel synchronized.

### Description
- Updated portrait offsets in `webapp/src/components/SnakeBoard3D.jsx` by changing `TOKEN_PORTRAIT_SCREEN_SHIFT_BY_SEAT` to push bottom/top reserve tokens further toward the top-player area.
- Adjusted `WEAPON_PORTRAIT_SCREEN_SHIFT_BY_SEAT` entries to lift parked weapons higher and bias them toward the top of the screen while increasing lateral spread from center.
- Increased per-seat outward weapon parking radii via `WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT` so side parking slots sit farther from the board center.
- Made the dice handoff animation use a configurable `duration` and default it to `TURN_CAMERA_TURN_IN_DURATION` by changing `createDiceHandoffAnimation` signature so dice handoff timing is aligned with camera turn transitions.

### Testing
- Ran the production build with `npm --prefix webapp run build` and the build completed successfully.
- Build emitted normal Vite warnings about chunk sizes and dynamic imports but the build exit was successful.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea5b64955c83299daa250a387d9226)