### PR TITLE
Fix Murlan Royale card-back logo orientation and slightly reduce logo size

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -3824,7 +3824,13 @@ export default function MurlanRoyaleArena({ search }) {
         const layerIndex = isHumanCard ? cards.length - 1 - cardIdx : cardIdx;
         applyHandCardLayering(mesh, isHumanCard, layerIndex);
         const isGiftSideSeat = seat?.handVariant === 'giftSide';
-        const backLogoVariant = !isHumanCard ? 'top' : 'default';
+        const backLogoVariant = !isHumanCard
+          ? seat?.handVariant === 'giftSide'
+            ? 'sideGift'
+            : seat?.handVariant === 'top'
+              ? 'top'
+              : 'side'
+          : 'default';
         setBackLogoOrientation(mesh, backLogoVariant);
         mesh.visible = true;
         updateCardFace(mesh, isHumanCard ? 'front' : 'back');
@@ -6882,19 +6888,19 @@ function setBackLogoOrientation(mesh, variant = 'default') {
     tunedTexture.rotation = 0;
     tunedTexture.center.set(0.5, 0.5);
     if (desiredVariant === 'top') {
-      // Keep top seat logo fully visible and upright.
+      // Top seat cards face opposite direction on screen, so rotate logo to keep it upright.
+      tunedTexture.repeat.set(1, 1);
+      tunedTexture.offset.set(0, 0);
+      tunedTexture.rotation = Math.PI;
+    } else if (desiredVariant === 'side') {
+      // Left side seat: avoid mirroring so branding reads normally.
       tunedTexture.repeat.set(1, 1);
       tunedTexture.offset.set(0, 0);
       tunedTexture.rotation = 0;
-    } else if (desiredVariant === 'side') {
-      // Left side seat: mirror horizontally so branding reads naturally from camera.
-      tunedTexture.repeat.set(-1, 1);
-      tunedTexture.offset.set(1, 0);
-      tunedTexture.rotation = 0;
     } else if (desiredVariant === 'sideGift') {
-      // Right side seat: avoid 180° rotation that made the logo upside down.
-      tunedTexture.repeat.set(-1, 1);
-      tunedTexture.offset.set(1, 0);
+      // Right side seat: avoid mirroring so branding reads normally.
+      tunedTexture.repeat.set(1, 1);
+      tunedTexture.offset.set(0, 0);
       tunedTexture.rotation = 0;
     }
     tunedTexture.needsUpdate = true;

--- a/webapp/src/utils/cards3d.js
+++ b/webapp/src/utils/cards3d.js
@@ -448,9 +448,9 @@ function drawLogoFrame(ctx, w, h, theme) {
 
   if (logoImage?.complete && logoImage.naturalWidth > 0) {
     const ratio = logoImage.naturalWidth / Math.max(logoImage.naturalHeight, 1);
-    const logoBoxWidth = w * 1.02;
-    // Restore larger back logo sizing for clearer visibility on mobile portrait screens.
-    const logoBoxHeight = h * 1.02;
+    // Keep logo large but slightly reduced so it breathes better inside the frame.
+    const logoBoxWidth = w * 0.96;
+    const logoBoxHeight = h * 0.96;
     const drawWidth = Math.min(logoBoxWidth, logoBoxHeight * ratio);
     const drawHeight = drawWidth / ratio;
     const logoX = w / 2 - drawWidth / 2;


### PR DESCRIPTION
### Motivation
- Cards' back logo was too large for the frame on mobile and needed a slight size reduction to breathe visually.
- AI players' card-back logos displayed with inconsistent orientation (top upside-down, side seats mirrored), causing branding to appear flipped or mirrored.
- Ensure card-back branding reads naturally from each seat's camera/view without affecting human player's front-face cards.

### Description
- Reduced the card-back logo draw box from `1.02` to `0.96` in `drawLogoFrame` to slightly shrink the logo on card backs (`webapp/src/utils/cards3d.js`).
- Added per-seat back-logo variant selection when rendering hands so non-human seats use `top`, `side`, or `sideGift` variants instead of forcing everything to `top` (`webapp/src/pages/Games/MurlanRoyaleArena.jsx`).
- Updated `setBackLogoOrientation` behavior to rotate the `top` variant by `Math.PI` so the top-seat logo is upright, and to avoid mirroring for `side`/`sideGift` so left/right logos read normally (`webapp/src/pages/Games/MurlanRoyaleArena.jsx`).

### Testing
- Ran the production web build with `npm --prefix webapp run -s build` and the build completed successfully.
- Build emitted existing non-blocking warnings (duplicate dependency key and Vite chunk-size warnings) but no errors, so the change passed the automated build step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea5dded7f48329903a2472e4de6803)