### PR TITLE
Fix Murlan card-back logo size and seat-specific orientation

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -6882,19 +6882,19 @@ function setBackLogoOrientation(mesh, variant = 'default') {
     tunedTexture.rotation = 0;
     tunedTexture.center.set(0.5, 0.5);
     if (desiredVariant === 'top') {
-      // Keep top seat logo fully visible and upright.
+      // Top player cards face opposite direction from camera, so rotate logo 180° to read upright on screen.
+      tunedTexture.repeat.set(1, 1);
+      tunedTexture.offset.set(0, 0);
+      tunedTexture.rotation = Math.PI;
+    } else if (desiredVariant === 'side') {
+      // Left side player: keep logo upright without horizontal mirroring.
       tunedTexture.repeat.set(1, 1);
       tunedTexture.offset.set(0, 0);
       tunedTexture.rotation = 0;
-    } else if (desiredVariant === 'side') {
-      // Left side seat: mirror horizontally so branding reads naturally from camera.
-      tunedTexture.repeat.set(-1, 1);
-      tunedTexture.offset.set(1, 0);
-      tunedTexture.rotation = 0;
     } else if (desiredVariant === 'sideGift') {
-      // Right side seat: avoid 180° rotation that made the logo upside down.
-      tunedTexture.repeat.set(-1, 1);
-      tunedTexture.offset.set(1, 0);
+      // Right side player: same as left, upright and not mirrored.
+      tunedTexture.repeat.set(1, 1);
+      tunedTexture.offset.set(0, 0);
       tunedTexture.rotation = 0;
     }
     tunedTexture.needsUpdate = true;

--- a/webapp/src/utils/cards3d.js
+++ b/webapp/src/utils/cards3d.js
@@ -448,9 +448,9 @@ function drawLogoFrame(ctx, w, h, theme) {
 
   if (logoImage?.complete && logoImage.naturalWidth > 0) {
     const ratio = logoImage.naturalWidth / Math.max(logoImage.naturalHeight, 1);
-    const logoBoxWidth = w * 1.02;
-    // Restore larger back logo sizing for clearer visibility on mobile portrait screens.
-    const logoBoxHeight = h * 1.02;
+    const logoBoxWidth = w * 0.94;
+    // Keep the back logo slightly smaller so it stays clear without crowding the card edges.
+    const logoBoxHeight = h * 0.94;
     const drawWidth = Math.min(logoBoxWidth, logoBoxHeight * ratio);
     const drawHeight = drawWidth / ratio;
     const logoX = w / 2 - drawWidth / 2;


### PR DESCRIPTION
### Motivation
- The Murlan/TonPlaygram logo on card backs was crowding the card edges on portrait screens and appeared upside-down or mirrored for players at different seats, reducing readability.

### Description
- Reduce the logo draw box in `webapp/src/utils/cards3d.js` (changed logo box scaling from `1.02` to `0.94`) so the back logo is slightly smaller and no longer crowds the card edges. 
- Update seat-specific back-logo handling in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` so the `top` variant rotates the texture by `Math.PI` (180°) to appear upright on-screen, and the `side` / `sideGift` variants stop using horizontal mirroring (use normal orientation).

### Testing
- Ran the unit tests with `npm test -- --runInBand test/murlan.test.js` and the test suite passed (all tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea5dded7f48329903a2472e4de6803)