### PR TITLE
Fix Murlan Royale card-back logo seat orientation and size

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -3824,7 +3824,13 @@ export default function MurlanRoyaleArena({ search }) {
         const layerIndex = isHumanCard ? cards.length - 1 - cardIdx : cardIdx;
         applyHandCardLayering(mesh, isHumanCard, layerIndex);
         const isGiftSideSeat = seat?.handVariant === 'giftSide';
-        const backLogoVariant = !isHumanCard ? 'top' : 'default';
+        const backLogoVariant = !isHumanCard
+          ? (seat?.handVariant === 'top'
+            ? 'top'
+            : seat?.handVariant === 'giftSide'
+              ? 'sideGift'
+              : 'side')
+          : 'default';
         setBackLogoOrientation(mesh, backLogoVariant);
         mesh.visible = true;
         updateCardFace(mesh, isHumanCard ? 'front' : 'back');
@@ -6882,10 +6888,10 @@ function setBackLogoOrientation(mesh, variant = 'default') {
     tunedTexture.rotation = 0;
     tunedTexture.center.set(0.5, 0.5);
     if (desiredVariant === 'top') {
-      // Keep top seat logo fully visible and upright.
+      // Top seat is opposite the camera, so rotate 180° to keep logo upright on screen.
       tunedTexture.repeat.set(1, 1);
       tunedTexture.offset.set(0, 0);
-      tunedTexture.rotation = 0;
+      tunedTexture.rotation = Math.PI;
     } else if (desiredVariant === 'side') {
       // Left side seat: mirror horizontally so branding reads naturally from camera.
       tunedTexture.repeat.set(-1, 1);

--- a/webapp/src/utils/cards3d.js
+++ b/webapp/src/utils/cards3d.js
@@ -448,9 +448,9 @@ function drawLogoFrame(ctx, w, h, theme) {
 
   if (logoImage?.complete && logoImage.naturalWidth > 0) {
     const ratio = logoImage.naturalWidth / Math.max(logoImage.naturalHeight, 1);
-    const logoBoxWidth = w * 1.02;
-    // Restore larger back logo sizing for clearer visibility on mobile portrait screens.
-    const logoBoxHeight = h * 1.02;
+    const logoBoxWidth = w * 0.95;
+    // Slightly reduce logo size to improve card-back framing.
+    const logoBoxHeight = h * 0.95;
     const drawWidth = Math.min(logoBoxWidth, logoBoxHeight * ratio);
     const drawHeight = drawWidth / ratio;
     const logoX = w / 2 - drawWidth / 2;


### PR DESCRIPTION
### Motivation
- Fix card-back branding that appeared upside-down for the top seat and mirrored incorrectly for left/right AI seats, and slightly reduce logo size for better framing on mobile portrait screens.

### Description
- Map non-human seat hand variants to distinct orientation variants (`'top'`, `'side'`, `'sideGift'`) and pass the correct variant to `setBackLogoOrientation` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` instead of forcing every AI card to `'top'`.
- Rotate the top-seat tuned back-texture by `Math.PI` so the logo appears upright from the player camera by adjusting `setBackLogoOrientation` behavior in `webapp/src/pages/Games/MurlanRoyaleArena.jsx`.
- Reduce the card-back logo sizing from `1.02` to `0.95` for improved card-back framing in `webapp/src/utils/cards3d.js`.

### Testing
- Ran the production build with `npm --prefix webapp run build`, which completed successfully and produced the production bundles.
- The build produced non-blocking Vite warnings (duplicate `package.json` key and chunk-size/import warnings) but no build failure occurred.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea5dded7f48329903a2472e4de6803)