### PR TITLE
Fix Murlan card-back logo orientation and reduce logo size

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -3824,7 +3824,14 @@ export default function MurlanRoyaleArena({ search }) {
         const layerIndex = isHumanCard ? cards.length - 1 - cardIdx : cardIdx;
         applyHandCardLayering(mesh, isHumanCard, layerIndex);
         const isGiftSideSeat = seat?.handVariant === 'giftSide';
-        const backLogoVariant = !isHumanCard ? 'top' : 'default';
+        const isTopSeat = seat?.handVariant === 'top';
+        const backLogoVariant = isHumanCard
+          ? 'default'
+          : isTopSeat
+            ? 'top'
+            : isGiftSideSeat
+              ? 'sideGift'
+              : 'side';
         setBackLogoOrientation(mesh, backLogoVariant);
         mesh.visible = true;
         updateCardFace(mesh, isHumanCard ? 'front' : 'back');
@@ -6880,12 +6887,12 @@ function setBackLogoOrientation(mesh, variant = 'default') {
     tunedTexture.rotation = 0;
     tunedTexture.center.set(0.5, 0.5);
     if (desiredVariant === 'top') {
-      // Keep top seat logo fully visible and upright.
+      // Top seat cards face the opposite direction, so rotate logo 180° for an upright read on screen.
       tunedTexture.repeat.set(1, 1);
       tunedTexture.offset.set(0, 0);
-      tunedTexture.rotation = 0;
+      tunedTexture.rotation = Math.PI;
     } else if (desiredVariant === 'side') {
-      // Left side seat: mirror horizontally so branding reads naturally from camera.
+      // Left side seat: mirror horizontally so branding reads naturally from portrait camera view.
       tunedTexture.repeat.set(-1, 1);
       tunedTexture.offset.set(1, 0);
       tunedTexture.rotation = 0;

--- a/webapp/src/utils/cards3d.js
+++ b/webapp/src/utils/cards3d.js
@@ -448,9 +448,9 @@ function drawLogoFrame(ctx, w, h, theme) {
 
   if (logoImage?.complete && logoImage.naturalWidth > 0) {
     const ratio = logoImage.naturalWidth / Math.max(logoImage.naturalHeight, 1);
-    const logoBoxWidth = w * 0.98;
-    // Make the back logo appear ~2x larger while still fitting inside the frame.
-    const logoBoxHeight = h * 0.92;
+    // Keep branding slightly smaller to avoid crowding the frame in portrait gameplay.
+    const logoBoxWidth = w * 0.88;
+    const logoBoxHeight = h * 0.8;
     const drawWidth = Math.min(logoBoxWidth, logoBoxHeight * ratio);
     const drawHeight = drawWidth / ratio;
     const logoX = w / 2 - drawWidth / 2;


### PR DESCRIPTION
### Motivation
- Fix incorrect card-back branding orientation seen for different opponent seats (top/upside-down, left/right mirrored) and make the logo slightly smaller so it doesn't crowd the card frame in portrait gameplay.

### Description
- Update seat-specific logo variant selection in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to pick `default`, `top`, `sideGift`, or `side` based on `player.isHuman` and `seat.handVariant` before calling `setBackLogoOrientation`.
- Rotate the top-seat tuned texture by 180° (`Math.PI`) so the top player's card-back logo reads upright on screen, and keep mirrored side rules for side seats in `setBackLogoOrientation` (same file).
- Reduce the logo draw area inside the card back frame in `webapp/src/utils/cards3d.js` by changing the logo box to `w * 0.88` x `h * 0.8` so branding appears a bit smaller.

### Testing
- Ran the production build with `npm -C webapp run -s build` which completed successfully (build finished); the build produced warnings but no errors and output artifacts were written.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea6a6c4e748329906eaf1d1f3dddda)