### PR TITLE
Tune Snake & Ladder seat parking and synchronize dice handoff with turn camera

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -135,7 +135,7 @@ const TILE_GAP = 0.015;
 const TILE_SIZE = RAW_BOARD_SIZE / BASE_LEVEL_TILES;
 const PYRAMID_HEIGHT_MULTIPLIER = 1.52; // make pyramid tiers taller
 const MAX_DICE = 1;
-const DICE_SIZE = TILE_SIZE * 0.675 * 1.16;
+const DICE_SIZE = TILE_SIZE * 0.675 * 1.04;
 const DICE_CORNER_RADIUS = DICE_SIZE * 0.18;
 const DICE_PIP_RADIUS = DICE_SIZE * 0.093;
 const DICE_PIP_DEPTH = DICE_SIZE * 0.018;
@@ -276,13 +276,13 @@ const WEAPON_SLOT_LATERAL_NUDGE_BY_SEAT = Object.freeze([
   0
 ]);
 const WEAPON_DISPLAY_SIZE_MULTIPLIER = 1.72;
-const WEAPON_PARKING_OUTWARD_OFFSET = TILE_SIZE * 0.64;
+const WEAPON_PARKING_OUTWARD_OFFSET = TILE_SIZE * 0.84;
 const WEAPON_FROM_TOKEN_CENTER_OFFSET = TOKEN_RADIUS * 0.58;
 const WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT = Object.freeze([
-  TILE_SIZE * 0.22,
-  TILE_SIZE * 0.2,
-  TILE_SIZE * 0.26,
-  TILE_SIZE * 0.2
+  TILE_SIZE * 0.3,
+  TILE_SIZE * 0.28,
+  TILE_SIZE * 0.34,
+  TILE_SIZE * 0.28
 ]);
 const WEAPON_TOKEN_GAP = TILE_SIZE * 0.004;
 const WEAPON_PARKED_Y_DROP_BY_KIND = Object.freeze({
@@ -305,17 +305,17 @@ const WEAPON_REST_HEIGHT_OFFSET_BY_SEAT = Object.freeze([
 // Positive radial moves items visually toward each chair/edge on screen.
 const TOKEN_PORTRAIT_SCREEN_SHIFT_BY_SEAT = Object.freeze([
   // Bottom seat: push reserve token visually upward toward top player.
-  Object.freeze({ radial: -TILE_SIZE * 1.46, lateral: 0, y: TILE_SIZE * 0.04 }),
+  Object.freeze({ radial: -TILE_SIZE * 1.7, lateral: 0, y: TILE_SIZE * 0.08 }),
   Object.freeze({ radial: 0, lateral: 0, y: 0 }),
   // Top seat: push reserve token further upward on portrait screens.
-  Object.freeze({ radial: TILE_SIZE * 1.46, lateral: 0, y: TILE_SIZE * 0.05 }),
+  Object.freeze({ radial: TILE_SIZE * 1.7, lateral: 0, y: TILE_SIZE * 0.08 }),
   Object.freeze({ radial: 0, lateral: 0, y: 0 })
 ]);
 const WEAPON_PORTRAIT_SCREEN_SHIFT_BY_SEAT = Object.freeze([
-  Object.freeze({ radial: -TILE_SIZE * 1.18, lateral: 0, y: TILE_SIZE * 0.44 }),
-  Object.freeze({ radial: -TILE_SIZE * 0.66, lateral: -TILE_SIZE * 0.28, y: TILE_SIZE * 0.44 }),
-  Object.freeze({ radial: TILE_SIZE * 1.14, lateral: 0, y: TILE_SIZE * 0.46 }),
-  Object.freeze({ radial: -TILE_SIZE * 0.66, lateral: TILE_SIZE * 0.28, y: TILE_SIZE * 0.44 })
+  Object.freeze({ radial: -TILE_SIZE * 1.34, lateral: 0, y: TILE_SIZE * 0.56 }),
+  Object.freeze({ radial: -TILE_SIZE * 0.84, lateral: -TILE_SIZE * 0.36, y: TILE_SIZE * 0.56 }),
+  Object.freeze({ radial: TILE_SIZE * 1.32, lateral: 0, y: TILE_SIZE * 0.58 }),
+  Object.freeze({ radial: -TILE_SIZE * 0.84, lateral: TILE_SIZE * 0.36, y: TILE_SIZE * 0.56 })
 ]);
 const WEAPON_TABLE_SURFACE_Y_OFFSET = TILE_SIZE * 0.52;
 const WEAPON_PARKING_SIDE_EXTRA_RADIUS = TILE_SIZE * 0.2;
@@ -5774,6 +5774,36 @@ export default function SnakeBoard3D({
     };
   }, [currentTurn]);
 
+  const moveDiceToTurnSeat = useCallback((seatIndexOverride = null) => {
+    const board = boardRef.current;
+    if (!board) return;
+    if (diceStateRef.current?.currentId != null) return;
+    const seatCount = Array.isArray(board.seatAnchors) ? board.seatAnchors.length : 0;
+    if (seatCount <= 0) return;
+    const targetSeat =
+      Number.isInteger(seatIndexOverride) && seatIndexOverride >= 0
+        ? seatIndexOverride
+        : Number.isInteger(currentTurn)
+        ? currentTurn
+        : 0;
+    const seatIndex = Math.max(0, Math.min(seatCount - 1, targetSeat));
+    const visibleDice = Array.isArray(board.diceSet) ? board.diceSet.filter((die) => die?.visible) : [];
+    if (!visibleDice.length) return;
+    const layout = computeDiceThrowLayout(board, seatIndex, visibleDice.length);
+    const basePositions = Array.isArray(layout.basePositions) ? layout.basePositions : [];
+    if (!basePositions.length) return;
+    removeAnimationsByType(animationsRef.current, 'diceHandoff');
+    const handoffAnimation = createDiceHandoffAnimation(visibleDice, {
+      basePositions,
+      baseY: board.diceBaseY ?? 0
+    });
+    if (handoffAnimation) animationsRef.current.push(handoffAnimation);
+    diceStateRef.current = {
+      ...(diceStateRef.current || {}),
+      lastSeatIndex: seatIndex
+    };
+  }, [currentTurn]);
+
   useEffect(() => {
     if (!diceEvent || !boardRef.current) return;
     const board = boardRef.current;
@@ -5907,8 +5937,9 @@ export default function SnakeBoard3D({
         count: 0,
         lastSeatIndex
       };
+      moveDiceToTurnSeat(Number.isInteger(currentTurn) ? currentTurn : lastSeatIndex);
     }
-  }, [diceEvent, cameraViewMode]);
+  }, [diceEvent, cameraViewMode, currentTurn, moveDiceToTurnSeat]);
 
   useEffect(() => {
     if (!captureEvent || !boardRef.current) return;


### PR DESCRIPTION
### Motivation
- Improve portrait phone visual layout by lifting and shifting parked capture weapons so they read higher and farther from the board center.
- Push bottom and top reserve tokens visually toward the top-player direction on portrait screens for clearer composition.
- Make dice slightly smaller so they fit better on portrait screens and ensure dice reposition to the next player's seat in sync with the camera/turn flow.

### Description
- Reduced dice scale by updating `DICE_SIZE` to `TILE_SIZE * 0.675 * 1.04` so dice render slightly smaller.
- Increased weapon parking radius by changing `WEAPON_PARKING_OUTWARD_OFFSET` and strengthened per-seat outward offsets in `WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT` to push parked weapons farther outward.
- Raised portrait offsets for tokens and weapons by updating `TOKEN_PORTRAIT_SCREEN_SHIFT_BY_SEAT` and `WEAPON_PORTRAIT_SCREEN_SHIFT_BY_SEAT` so bottom/top reserve tokens and parked weapons appear shifted upward on mobile portrait.
- Added a `moveDiceToTurnSeat` `useCallback` helper and call it after a dice roll settles (on `diceEvent.phase === 'end'`) so dice handoff animation repositions to the next turn seat in sync with turn-camera changes.

### Testing
- Ran `npm run build` in `webapp/` and the production build completed successfully with non-blocking Vite warnings about chunking and dynamic/static imports.
- No unit tests were modified; changes validated by a successful build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea6c01b6408329b5a822c3c9979a51)