### PR TITLE
Fix Murlan Royale card-back logo orientation and slightly reduce logo size

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -3823,9 +3823,16 @@ export default function MurlanRoyaleArena({ search }) {
         const isHumanCard = player.isHuman;
         const layerIndex = isHumanCard ? cards.length - 1 - cardIdx : cardIdx;
         applyHandCardLayering(mesh, isHumanCard, layerIndex);
-        const isGiftSideSeat = seat?.handVariant === 'giftSide';
-        const backLogoVariant = !isHumanCard ? 'top' : 'default';
+        const seatHandVariant = seat?.handVariant;
+        const backLogoVariant = !isHumanCard
+          ? (seatHandVariant === 'top'
+            ? 'top'
+            : seatHandVariant === 'giftSide'
+              ? 'sideGift'
+              : 'side')
+          : 'default';
         setBackLogoOrientation(mesh, backLogoVariant);
+        const isGiftSideSeat = seatHandVariant === 'giftSide';
         mesh.visible = true;
         updateCardFace(mesh, isHumanCard ? 'front' : 'back');
         handsVisible.add(card.id);
@@ -6880,19 +6887,19 @@ function setBackLogoOrientation(mesh, variant = 'default') {
     tunedTexture.rotation = 0;
     tunedTexture.center.set(0.5, 0.5);
     if (desiredVariant === 'top') {
-      // Keep top seat logo fully visible and upright.
+      // Top seat cards are physically rotated toward the center, so counter-rotate the texture.
+      tunedTexture.repeat.set(1, 1);
+      tunedTexture.offset.set(0, 0);
+      tunedTexture.rotation = Math.PI;
+    } else if (desiredVariant === 'side') {
+      // Left side seat should keep the logo readable without horizontal mirroring.
       tunedTexture.repeat.set(1, 1);
       tunedTexture.offset.set(0, 0);
       tunedTexture.rotation = 0;
-    } else if (desiredVariant === 'side') {
-      // Left side seat: mirror horizontally so branding reads naturally from camera.
-      tunedTexture.repeat.set(-1, 1);
-      tunedTexture.offset.set(1, 0);
-      tunedTexture.rotation = 0;
     } else if (desiredVariant === 'sideGift') {
-      // Right side seat: avoid 180° rotation that made the logo upside down.
-      tunedTexture.repeat.set(-1, 1);
-      tunedTexture.offset.set(1, 0);
+      // Right side seat should also stay unmirrored and upright.
+      tunedTexture.repeat.set(1, 1);
+      tunedTexture.offset.set(0, 0);
       tunedTexture.rotation = 0;
     }
     tunedTexture.needsUpdate = true;

--- a/webapp/src/utils/cards3d.js
+++ b/webapp/src/utils/cards3d.js
@@ -448,9 +448,9 @@ function drawLogoFrame(ctx, w, h, theme) {
 
   if (logoImage?.complete && logoImage.naturalWidth > 0) {
     const ratio = logoImage.naturalWidth / Math.max(logoImage.naturalHeight, 1);
-    const logoBoxWidth = w * 0.98;
-    // Make the back logo appear ~2x larger while still fitting inside the frame.
-    const logoBoxHeight = h * 0.92;
+    const logoBoxWidth = w * 0.9;
+    // Slightly reduce the logo footprint for cleaner spacing around the card back frame.
+    const logoBoxHeight = h * 0.84;
     const drawWidth = Math.min(logoBoxWidth, logoBoxHeight * ratio);
     const drawHeight = drawWidth / ratio;
     const logoX = w / 2 - drawWidth / 2;


### PR DESCRIPTION
### Motivation
- User-reported issues showed the card-back logo was upside-down for the top player and mirrored for left/right players, and requested the logo be slightly smaller on Murlan Royale cards. 
- The change aims to make card-back branding readable from each seat and reduce the logo footprint for cleaner visuals.

### Description
- Use seat-specific back-logo variants in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` so non-human seats select `top`, `side`, or `sideGift` instead of forcing all AI cards to `top` and ensure `isGiftSideSeat` is computed from the seat variant. 
- Update `setBackLogoOrientation` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to counter-rotate the `top` variant (`Math.PI`) and remove the previous horizontal mirroring for side variants so logos render upright and unmirrored. 
- Reduce the card-back logo draw footprint in `webapp/src/utils/cards3d.js` by shrinking the logo box from near-full size to a tighter area (`logoBoxWidth` from `w * 0.98` to `w * 0.9` and `logoBoxHeight` from `h * 0.92` to `h * 0.84`). 
- Files changed: `webapp/src/pages/Games/MurlanRoyaleArena.jsx` and `webapp/src/utils/cards3d.js`.

### Testing
- Ran the production build with `npm run build` inside `webapp/` and the Vite build completed successfully. 
- The build emitted pre-existing non-blocking warnings (duplicate dependency key in `package.json` and large chunk warnings) but no errors occurred and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea6a6c4e748329906eaf1d1f3dddda)