### PR TITLE
Fix Murlan Royale card-back logo orientation and size

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -3824,7 +3824,13 @@ export default function MurlanRoyaleArena({ search }) {
         const layerIndex = isHumanCard ? cards.length - 1 - cardIdx : cardIdx;
         applyHandCardLayering(mesh, isHumanCard, layerIndex);
         const isGiftSideSeat = seat?.handVariant === 'giftSide';
-        const backLogoVariant = !isHumanCard ? 'top' : 'default';
+        const backLogoVariant = isHumanCard
+          ? 'default'
+          : seat?.handVariant === 'top'
+            ? 'top'
+            : seat?.handVariant === 'giftSide'
+              ? 'sideGift'
+              : 'side';
         setBackLogoOrientation(mesh, backLogoVariant);
         mesh.visible = true;
         updateCardFace(mesh, isHumanCard ? 'front' : 'back');
@@ -6880,19 +6886,19 @@ function setBackLogoOrientation(mesh, variant = 'default') {
     tunedTexture.rotation = 0;
     tunedTexture.center.set(0.5, 0.5);
     if (desiredVariant === 'top') {
-      // Keep top seat logo fully visible and upright.
+      // Top seat cards need a 180° turn so the logo reads upright from the camera.
+      tunedTexture.repeat.set(1, 1);
+      tunedTexture.offset.set(0, 0);
+      tunedTexture.rotation = Math.PI;
+    } else if (desiredVariant === 'side') {
+      // Left side seat: keep the logo un-mirrored.
       tunedTexture.repeat.set(1, 1);
       tunedTexture.offset.set(0, 0);
       tunedTexture.rotation = 0;
-    } else if (desiredVariant === 'side') {
-      // Left side seat: mirror horizontally so branding reads naturally from camera.
-      tunedTexture.repeat.set(-1, 1);
-      tunedTexture.offset.set(1, 0);
-      tunedTexture.rotation = 0;
     } else if (desiredVariant === 'sideGift') {
-      // Right side seat: avoid 180° rotation that made the logo upside down.
-      tunedTexture.repeat.set(-1, 1);
-      tunedTexture.offset.set(1, 0);
+      // Right side seat: keep the logo un-mirrored.
+      tunedTexture.repeat.set(1, 1);
+      tunedTexture.offset.set(0, 0);
       tunedTexture.rotation = 0;
     }
     tunedTexture.needsUpdate = true;

--- a/webapp/src/utils/cards3d.js
+++ b/webapp/src/utils/cards3d.js
@@ -448,9 +448,9 @@ function drawLogoFrame(ctx, w, h, theme) {
 
   if (logoImage?.complete && logoImage.naturalWidth > 0) {
     const ratio = logoImage.naturalWidth / Math.max(logoImage.naturalHeight, 1);
-    const logoBoxWidth = w * 0.98;
-    // Make the back logo appear ~2x larger while still fitting inside the frame.
-    const logoBoxHeight = h * 0.92;
+    const logoBoxWidth = w * 0.92;
+    // Keep logo prominent but slightly smaller for better balance on card backs.
+    const logoBoxHeight = h * 0.86;
     const drawWidth = Math.min(logoBoxWidth, logoBoxHeight * ratio);
     const drawHeight = drawWidth / ratio;
     const logoX = w / 2 - drawWidth / 2;


### PR DESCRIPTION
### Motivation
- Player card backs showed incorrect logo orientation (top-seat logos upside-down and side-seat logos mirrored) and the logo was slightly too large on the card back. 
- Make card-back appearance seat-aware so logos read correctly from the player camera and improve visual balance.

### Description
- Choose `backLogoVariant` per seat (`default`, `top`, `side`, `sideGift`) instead of forcing a single variant for all non-human seats by mapping to `seat.handVariant` in `MurlanRoyaleArena.jsx`.
- For the `top` variant rotate the back texture by 180° (`Math.PI`) so the logo appears upright from the camera in `setBackLogoOrientation`.
- Remove horizontal mirroring for `side` and `sideGift` variants so left/right side-seat logos are not mirrored and read naturally.
- Reduce the drawn logo bounds in `makeTonplaygramCardBackTexture` (smaller logo box width/height) so the logo is slightly smaller and better balanced on the card back.

### Testing
- Ran a production build of the web app with `npm --prefix webapp run build`, which completed successfully (build artifacts produced).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea6a6c4e748329906eaf1d1f3dddda)