### PR TITLE
Align Pool Royale cue slider and cue-stick strike behavior with reference mechanics

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -26133,13 +26133,12 @@ const shotPowerRef = useRef(0);
       };
       const computePullTargetFromPower = (power, maxPull = CUE_PULL_BASE) => {
         const ratio = THREE.MathUtils.clamp(power ?? 0, 0, 1);
-        const style = cueStrokeAnimationStyleRef.current ?? DEFAULT_CUE_STROKE_STYLE;
-        const styleRatio = resolveCueStrokeProfile(style, ratio).pullRatio;
+        const easedRatio = 1 - Math.pow(1 - ratio, 3);
         const effectiveMax = Number.isFinite(maxPull) ? Math.max(maxPull, 0) : CUE_PULL_BASE;
         const amplifiedMax = Math.max(effectiveMax, CUE_PULL_MIN_VISUAL);
         const visualMax = effectiveMax + CUE_PULL_VISUAL_FUDGE;
         const target =
-          amplifiedMax * styleRatio * CUE_PULL_VISUAL_MULTIPLIER * CUE_PULL_DISTANCE_SCALE;
+          amplifiedMax * easedRatio * CUE_PULL_VISUAL_MULTIPLIER * CUE_PULL_DISTANCE_SCALE;
         return Math.min(target, visualMax);
       };
       // Easing adapted from easings.net (MIT) for a smoother pull/release cue stroke.
@@ -26727,7 +26726,7 @@ const shotPowerRef = useRef(0);
           // Mirror the reference stroke pullback curve exactly:
           // pull = pullRange * easeOutCubic(power), then push forward on strike.
           const pullRange = 0.24;
-          const pullTarget = pullRange * strokeProfile.pullRatio;
+          const pullTarget = pullRange * easeOutCubic(clampedPower);
           const pulledNow = cuePullCurrentRef.current ?? pullTarget;
           const startPull = THREE.MathUtils.clamp(pulledNow, 0, Math.max(maxPull, 0));
           const visualPull = applyVisualPullCompensation(startPull, dir);
@@ -26781,8 +26780,8 @@ const shotPowerRef = useRef(0);
           if (shotRecording) {
             recordReplayFrame(performance.now());
           }
-          const strikeDuration = strokeProfile.strikeDuration ?? LIVE_CUE_FORWARD_DURATION_MS;
-          const strikeHoldDuration = strokeProfile.holdDuration ?? LIVE_CUE_IMPACT_HOLD_MS;
+          const strikeDuration = 110;
+          const strikeHoldDuration = 45;
           const pullbackDuration = strokeProfile.pullbackDuration ?? 0;
           const startTime = performance.now();
           const impactPos = idlePos.clone();
@@ -26918,7 +26917,7 @@ const shotPowerRef = useRef(0);
               baseRotationY: cueStick.rotation.y,
               strikeDip: THREE.MathUtils.lerp(0.0028, 0.0054, clampedPower),
               wobbleAmount: THREE.MathUtils.lerp(0.0014, 0.0036, clampedPower),
-              strikeImpactThreshold: 0.9,
+              strikeImpactThreshold: 0.88,
               strikeExtraFollow: Math.min(0.018, Math.max(0, (rawSpin?.y ?? 0) * clampedPower) * 0.016),
               // Slider release should drive an immediate forward strike from the
               // currently pulled cue position back to contact.


### PR DESCRIPTION
### Motivation
- The cue pull / slider and cue-stick strike timing needed to match the reference implementation so the cueball receives identical impulse and the UI feedback (pull, release, follow-through) behaves the same while preserving existing power scaling limits.

### Description
- Replaced the previous `pull` mapping that used the cue stroke profile with an eased cubic mapping (`1 - (1 - power)^3`) in `computePullTargetFromPower` to match reference easing and keep the same overall power/pull magnitudes. (modified `webapp/src/pages/Games/PoolRoyale.jsx`)
- When firing, compute the live shot pull target as `pullRange * easeOutCubic(clampedPower)` so the visible pullback and release curve mirror the reference motion. (modified fire/animate stroke code in `PoolRoyale.jsx`)
- Tuned the strike staging timings to match the reference cadence by setting forward strike and hold durations to `110ms` and `45ms` respectively, ensuring the impact occurs at the same phase of the forward stroke. (modified `PoolRoyale.jsx`)
- Adjusted the cue impact trigger threshold from `0.90` to `0.88` so the shot impulse is applied at the matching release fraction of the forward stroke. (modified `PoolRoyale.jsx`)

### Testing
- Ran a production build with `cd webapp && npm run -s build`, which completed successfully and produced the site bundle (warnings about duplicate package key and large chunks were observed but are unrelated to this change). (succeeded)
- Attempted to run lint with `npm run -s lint` but the `lint` script is not defined in `webapp/package.json`, so no lint check was executed. (not applicable)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea7bfd289083298f0f21b83118c6f9)