### PR TITLE
Adjust Snake & Ladder weapon parking placement and dice roll/SFX timing

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -135,7 +135,7 @@ const TILE_GAP = 0.015;
 const TILE_SIZE = RAW_BOARD_SIZE / BASE_LEVEL_TILES;
 const PYRAMID_HEIGHT_MULTIPLIER = 1.52; // make pyramid tiers taller
 const MAX_DICE = 1;
-const DICE_SIZE = TILE_SIZE * 0.61 * 0.86;
+const DICE_SIZE = TILE_SIZE * 0.61 * 0.8;
 const DICE_CORNER_RADIUS = DICE_SIZE * 0.18;
 const DICE_PIP_RADIUS = DICE_SIZE * 0.093;
 const DICE_PIP_DEPTH = DICE_SIZE * 0.018;
@@ -146,7 +146,7 @@ const DICE_PIP_SPREAD = DICE_SIZE * 0.3;
 const DICE_FACE_INSET = DICE_SIZE * 0.064;
 // Keep Snake dice pacing aligned with Ludo Battle Royale dice rhythm.
 const DICE_ROLL_DURATION = 900;
-const DICE_SETTLE_DURATION = 220;
+const DICE_SETTLE_DURATION = 120;
 const DICE_BOUNCE_HEIGHT = DICE_SIZE * 0.44;
 const DICE_THROW_LANDING_MARGIN = TILE_SIZE * 1.8;
 const DICE_THROW_START_EXTRA = TILE_SIZE * 3.6;
@@ -276,13 +276,13 @@ const WEAPON_SLOT_LATERAL_NUDGE_BY_SEAT = Object.freeze([
   0
 ]);
 const WEAPON_DISPLAY_SIZE_MULTIPLIER = 1.72;
-const WEAPON_PARKING_OUTWARD_OFFSET = TILE_SIZE * 0.9;
+const WEAPON_PARKING_OUTWARD_OFFSET = TILE_SIZE * 0.98;
 const WEAPON_FROM_TOKEN_CENTER_OFFSET = TOKEN_RADIUS * 0.58;
 const WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT = Object.freeze([
-  TILE_SIZE * 0.52,
-  TILE_SIZE * 0.52,
-  TILE_SIZE * 0.58,
-  TILE_SIZE * 0.52
+  TILE_SIZE * 0.62,
+  TILE_SIZE * 0.62,
+  TILE_SIZE * 0.72,
+  TILE_SIZE * 0.62
 ]);
 const WEAPON_TOKEN_GAP = TILE_SIZE * 0.004;
 const WEAPON_PARKED_Y_DROP_BY_KIND = Object.freeze({
@@ -296,10 +296,10 @@ const WEAPON_PARKED_Y_DROP_BY_KIND = Object.freeze({
 const WEAPON_REST_HEIGHT_OFFSET = -TOKEN_HEIGHT * 0.72;
 const WEAPON_SLOT_CLUSTER_SCALE = 0.3;
 const WEAPON_REST_HEIGHT_OFFSET_BY_SEAT = Object.freeze([
-  TILE_SIZE * 0.09,
-  TILE_SIZE * 0.08,
-  TILE_SIZE * 0.1,
-  TILE_SIZE * 0.08
+  TILE_SIZE * 0.12,
+  TILE_SIZE * 0.11,
+  TILE_SIZE * 0.14,
+  TILE_SIZE * 0.11
 ]);
 // Portrait phone calibration (seat order: 0=bottom, 1=right, 2=top, 3=left).
 // Positive radial moves items visually toward each chair/edge on screen.
@@ -312,10 +312,10 @@ const TOKEN_PORTRAIT_SCREEN_SHIFT_BY_SEAT = Object.freeze([
   Object.freeze({ radial: 0, lateral: 0, y: 0 })
 ]);
 const WEAPON_PORTRAIT_SCREEN_SHIFT_BY_SEAT = Object.freeze([
-  Object.freeze({ radial: -TILE_SIZE * 1.96, lateral: 0, y: TILE_SIZE * 1.02 }),
-  Object.freeze({ radial: -TILE_SIZE * 1.26, lateral: -TILE_SIZE * 0.76, y: TILE_SIZE * 1.0 }),
-  Object.freeze({ radial: TILE_SIZE * 1.98, lateral: 0, y: TILE_SIZE * 1.06 }),
-  Object.freeze({ radial: -TILE_SIZE * 1.26, lateral: TILE_SIZE * 0.76, y: TILE_SIZE * 1.0 })
+  Object.freeze({ radial: -TILE_SIZE * 2.12, lateral: 0, y: TILE_SIZE * 1.12 }),
+  Object.freeze({ radial: -TILE_SIZE * 1.42, lateral: -TILE_SIZE * 0.84, y: TILE_SIZE * 1.08 }),
+  Object.freeze({ radial: TILE_SIZE * 2.18, lateral: 0, y: TILE_SIZE * 1.2 }),
+  Object.freeze({ radial: -TILE_SIZE * 1.42, lateral: TILE_SIZE * 0.84, y: TILE_SIZE * 1.08 })
 ]);
 const WEAPON_TABLE_SURFACE_Y_OFFSET = TILE_SIZE * 0.52;
 const WEAPON_PARKING_SIDE_EXTRA_RADIUS = TILE_SIZE * 0.2;

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -186,6 +186,7 @@ const AI_ROLL_DELAY_MS = 1300;
 const AI_EXTRA_ROLL_DELAY_MS = 850;
 const TURN_ADVANCE_AFTER_DICE_MS = 0;
 const DICE_RESULT_HOLD_MS = 2000;
+const DICE_SFX_MIN_INTERVAL_MS = 850;
 const DEFAULT_CAPACITY = 4;
 const COMMENTARY_PRESET_STORAGE_KEY = 'snakeCommentaryPreset';
 const COMMENTARY_MUTE_STORAGE_KEY = 'snakeCommentaryMute';
@@ -1824,7 +1825,7 @@ export default function SnakeAndLadder() {
   const playDiceRollSound = useCallback(() => {
     if (muted) return;
     const now = Date.now();
-    if (now - lastDiceRollSfxAtRef.current < 180) return;
+    if (now - lastDiceRollSfxAtRef.current < DICE_SFX_MIN_INTERVAL_MS) return;
     lastDiceRollSfxAtRef.current = now;
     playLudoDiceRollSfx({
       volume: getGameVolume(),


### PR DESCRIPTION
### Motivation

- Parked capture weapons should sit slightly higher, be pushed visually toward the top in portrait, and placed farther outward from the board center for better on-screen composition. 
- The dice animation should match the Ludo Battle Royale cadence and feel (same rolling speed/technique/fps) while being a bit smaller on portrait screens. 
- Dice roll SFX must not play twice for a single roll and should be debounced to a single playback per roll window.

### Description

- Reduced the in-scene dice size by changing `DICE_SIZE` multiplier and shortened the settle phase by changing `DICE_SETTLE_DURATION` to tighten roll cadence while keeping `DICE_ROLL_DURATION` (file `webapp/src/components/SnakeBoard3D.jsx`).
- Moved parked weapons farther out and slightly higher by increasing `WEAPON_PARKING_OUTWARD_OFFSET`, per-seat outward offsets (`WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT`), rest-height offsets (`WEAPON_REST_HEIGHT_OFFSET_BY_SEAT`), and portrait screen radial/vertical shifts (`WEAPON_PORTRAIT_SCREEN_SHIFT_BY_SEAT`) (file `webapp/src/components/SnakeBoard3D.jsx`).
- Added a dedicated SFX debounce constant `DICE_SFX_MIN_INTERVAL_MS = 850` and applied it in `playDiceRollSound` so the dice roll sound can only trigger once per roll window instead of the previous short 180ms gate (file `webapp/src/pages/Games/SnakeAndLadder.jsx`).
- Files changed: `webapp/src/components/SnakeBoard3D.jsx`, `webapp/src/pages/Games/SnakeAndLadder.jsx`.

### Testing

- Ran `npx eslint webapp/src/components/SnakeBoard3D.jsx webapp/src/pages/Games/SnakeAndLadder.jsx`, which completed with warnings only due to ignore patterns (no lint errors).
- Ran `git diff --check` which reported no whitespace or diff errors.
- Changes were committed locally with message `Tune Snake board weapon parking and dice roll behavior` (commit succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaf040a8388329babf381952b0d02d)