### PR TITLE
Tune Chess Battle Royal air-unit lift, camera, parking, and missile launch anchors

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -127,7 +127,7 @@ const CAPTURE_AIR_STRIKE_PATH_EDGE_MARGIN_TILES = 3.85; // keep turns inboard so
 const CAPTURE_AIR_STRIKE_BOTTOM_PLAYER_BIAS_TILES = 0.02; // reduce portrait bottom bias so aircraft stay nearer center
 const CAPTURE_DRONE_ORBIT_RADIUS_MUL = 0.18; // slightly longer drone route before descent
 const CAPTURE_DRONE_ORBIT_HEIGHT_MUL = 0.2; // keep drone orbit visibly higher than piece heads
-const CAPTURE_AIR_STRIKE_ORBIT_HEIGHT_MUL = 0.92; // raise jet/helicopter board loop
+const CAPTURE_AIR_STRIKE_ORBIT_HEIGHT_MUL = 0.65; // keep jet/helicopter max lift aligned to pawn short-missile peak altitude
 const CAPTURE_DRONE_ORBIT_CYCLES = 0.22; // extend visible loop around board
 const CAPTURE_DRONE_ORBIT_SPLIT = 0.72;
 const CAPTURE_DRONE_RETURN_SPLIT = 0.72;
@@ -407,8 +407,8 @@ const FALLBACK_SEAT_POSITIONS = [
 ];
 const CAMERA_WHEEL_FACTOR = ARENA_CAMERA_DEFAULTS.wheelDeltaFactor;
 const CAMERA_PULL_FORWARD_MIN = THREE.MathUtils.degToRad(15);
-const CAMERA_CAPTURE_VIEW_UPWARD_BIAS = THREE.MathUtils.degToRad(8); // push forced 3D animation camera higher for clearer portrait framing
-const CAMERA_CAPTURE_VIEW_RADIUS_SCALE = 1.08; // pull the camera back slightly during forced 3D animation to widen board visibility
+const CAMERA_CAPTURE_VIEW_UPWARD_BIAS = THREE.MathUtils.degToRad(11); // raise forced 3D animation camera so portrait view looks more top-down
+const CAMERA_CAPTURE_VIEW_RADIUS_SCALE = 0.96; // move forced 3D animation camera slightly closer
 const CAMERA_CAPTURE_BOTTOM_AVATAR_SCREEN_OFFSET = 6; // keep local player's avatar lower so chair/animation view stays clear
 const SAND_TIMER_RADIUS_FACTOR = 0.68;
 const SAND_TIMER_SURFACE_OFFSET = 0.2;
@@ -2008,9 +2008,9 @@ const BOARD_SURFACE_OFFSETS_BY_SHAPE = Object.freeze({
 const LOWER_PROFILE_TABLE_SHAPE_IDS = new Set(['classicOctagon', 'hexagonTable', 'grandOval', 'diamondEdge']);
 const LOWER_PROFILE_TABLE_HEIGHT_DELTA = 0.12;
 const SIDE_PARKED_AIRCRAFT_SCALE_MULTIPLIER = 27; // make parked units/markers a bit larger
-const SIDE_PARKED_AIR_UNITS_INWARD_OFFSET = -0.5; // push parked vehicles farther to the sides
+const SIDE_PARKED_AIR_UNITS_INWARD_OFFSET = -0.66; // push parked vehicles farther to the sides
 const SIDE_PARKED_AIR_UNITS_BOARD_LEVEL_LIFT = 0.26; // lift pad markers/parked units from floor to board/table level
-const SIDE_PARKED_AIR_UNITS_LANE_SPREAD = 1.72; // increase spacing between parking slots
+const SIDE_PARKED_AIR_UNITS_LANE_SPREAD = 1.92; // increase spacing between parking slots
 const SIDE_PARKED_TRUCK_SCALE_MULTIPLIER = 1.28; // increase parked truck size just a bit more
 
 function getTableHeightForShape(shapeId) {
@@ -3183,11 +3183,11 @@ function applyMilitaryJetLook(model, toneSeed = null, skin = null) {
     materials.forEach((mat) => {
       if (!mat?.color) return;
       if (/cockpit|canopy|window|glass/.test(name)) {
-        mat.color.set('#06080c');
+        mat.color.set('#000000');
         if ('metalness' in mat) mat.metalness = 0.55;
-        if ('roughness' in mat) mat.roughness = 0.16;
-        if ('transparent' in mat) mat.transparent = true;
-        if ('opacity' in mat) mat.opacity = 0.94;
+        if ('roughness' in mat) mat.roughness = 0.08;
+        if ('transparent' in mat) mat.transparent = false;
+        if ('opacity' in mat) mat.opacity = 1;
       } else if (/missile|rocket|store|pod/.test(name)) {
         mat.color.set('#d8dde3');
         if ('metalness' in mat) mat.metalness = 0.88;
@@ -9046,8 +9046,9 @@ function Chess3D({
       });
       return best;
     };
-    const findJetExhaustAnchor = (model) => {
-      if (!model) return new THREE.Vector3(-1.9, 0, 0);
+    const findJetExhaustAnchors = (model) => {
+      const fallback = [new THREE.Vector3(-1.95, -0.02, -0.18), new THREE.Vector3(-1.95, -0.02, 0.18)];
+      if (!model) return fallback;
       const candidates = [];
       model.traverse((node) => {
         if (!node?.isMesh) return;
@@ -9055,34 +9056,75 @@ function Chess3D({
         if (!/engine|exhaust|nozzle|thruster|afterburn|jet/.test(name)) return;
         const box = new THREE.Box3().setFromObject(node);
         if (box.isEmpty()) return;
-        const center = new THREE.Vector3();
-        box.getCenter(center);
-        const size = new THREE.Vector3();
-        box.getSize(size);
-        const score = (box.min.x * -1) + Math.max(size.y, size.z) * 0.2;
+        const center = box.getCenter(new THREE.Vector3());
+        const size = box.getSize(new THREE.Vector3());
+        const score = box.min.x * -1 + Math.max(size.y, size.z) * 0.2 + Math.abs(center.z) * 0.08;
         candidates.push({ center, score });
       });
-      if (!candidates.length) return new THREE.Vector3(-1.9, 0, 0);
+      if (candidates.length < 2) return fallback;
       candidates.sort((a, b) => b.score - a.score);
-      const anchor = candidates[0].center.clone();
-      model.worldToLocal(anchor);
+      const usable = candidates.slice(0, 6).map((item) => item.center.clone());
+      let bestPair = null;
+      for (let i = 0; i < usable.length; i += 1) {
+        for (let j = i + 1; j < usable.length; j += 1) {
+          const spread = Math.abs(usable[i].z - usable[j].z);
+          const rearBias = Math.min(usable[i].x, usable[j].x);
+          const pairScore = spread * 1.4 - rearBias;
+          if (!bestPair || pairScore > bestPair.score) {
+            bestPair = { score: pairScore, a: usable[i], b: usable[j] };
+          }
+        }
+      }
+      if (!bestPair) return fallback;
+      const anchors = [bestPair.a.clone(), bestPair.b.clone()].sort((a, b) => a.z - b.z);
+      anchors.forEach((anchor) => model.worldToLocal(anchor));
+      return anchors;
+    };
+    const createLocalLaunchAnchor = (root, fallback = [0, 0, 0]) => {
+      const anchor = new THREE.Object3D();
+      anchor.position.set(fallback[0], fallback[1], fallback[2]);
+      root.add(anchor);
       return anchor;
+    };
+    const findMissileLaunchAnchors = (model, fallbackAnchors = [[0, 0, -0.18], [0, 0, 0.18]]) => {
+      if (!model) {
+        return fallbackAnchors.map((offset) => offset.slice(0, 3));
+      }
+      const candidates = [];
+      model.traverse((node) => {
+        if (!node?.isMesh) return;
+        const name = `${node.name || ''}`.toLowerCase();
+        if (!/missile|rocket|store|pod|pylon|weapon|wing/.test(name)) return;
+        const bounds = new THREE.Box3().setFromObject(node);
+        if (bounds.isEmpty()) return;
+        const center = bounds.getCenter(new THREE.Vector3());
+        const size = bounds.getSize(new THREE.Vector3());
+        const score = Math.abs(center.z) * 1.1 + Math.max(size.x, size.y, size.z) * 0.3 - center.x * 0.15;
+        candidates.push({ center, score });
+      });
+      if (candidates.length < 2) {
+        return fallbackAnchors.map((offset) => offset.slice(0, 3));
+      }
+      candidates.sort((a, b) => b.score - a.score);
+      const pair = [candidates[0].center.clone(), candidates[1].center.clone()].sort((a, b) => a.z - b.z);
+      pair.forEach((pt) => model.worldToLocal(pt));
+      return pair.map((pt) => [pt.x, pt.y, pt.z]);
     };
     const createJetExhaustClouds = (root, count = 6, start = [-1.95, 0, 0], stepX = 0.2) => {
       const clouds = [];
       for (let i = 0; i < count; i += 1) {
-        clouds.push(
-          addFxSphere(
-            root,
-            0.12 + i * 0.035,
-            [start[0] - i * stepX, start[1], start[2]],
-            i < 2 ? '#f7a94b' : '#8b949b',
-            i < 2 ? 0.22 : 1,
-            0,
-            true,
-            i < 2 ? 0.85 - i * 0.18 : 0.28 - (i - 2) * 0.045
-          )
+        const puff = addFxSphere(
+          root,
+          0.12 + i * 0.035,
+          [start[0] - i * stepX, start[1], start[2]],
+          i < 2 ? '#f7a94b' : '#8b949b',
+          i < 2 ? 0.22 : 1,
+          0,
+          true,
+          i < 2 ? 0.85 - i * 0.18 : 0.28 - (i - 2) * 0.045
         );
+        puff.visible = false;
+        clouds.push(puff);
       }
       return clouds;
     };
@@ -9274,7 +9316,12 @@ function Chess3D({
         applyMilitaryHelicopterLook(model, topRotor, tailRotor, getCaptureToneSeed('helicopter'));
         const topRotorAxis = new THREE.Vector3(0, 1, 0);
         const tailRotorAxis = inferRotorSpinAxis(tailRotor, 'x');
-        return { root, topRotor, tailRotor, rotorNodes, topRotorAxis, tailRotorAxis, exhaustClouds: [] };
+        const missileAnchorOffsets = findMissileLaunchAnchors(model, [
+          [0.28, -0.08, -0.28],
+          [0.28, -0.08, 0.28]
+        ]);
+        const missileAnchors = missileAnchorOffsets.map((offset) => createLocalLaunchAnchor(root, offset));
+        return { root, topRotor, tailRotor, rotorNodes, topRotorAxis, tailRotorAxis, exhaustClouds: [], missileAnchors };
       }
       const root = new THREE.Group();
       addFxCylinder(root, 0.2, 0.24, 2.5, [0.05, 0, 0], [0, 0, Math.PI / 2], '#96a0a8', 20);
@@ -9296,6 +9343,10 @@ function Chess3D({
       addFxBox(tailRotor, [0.03, 0.38, 0.03], [0, 0, 0], '#21272d', 0.55, 0.08);
       addFxBox(tailRotor, [0.03, 0.03, 0.38], [0, 0, 0], '#21272d', 0.55, 0.08);
       root.add(tailRotor);
+      const missileAnchors = [
+        createLocalLaunchAnchor(root, [0.26, -0.1, -0.28]),
+        createLocalLaunchAnchor(root, [0.26, -0.1, 0.28])
+      ];
       const exhaustClouds = [];
       for (let i = 0; i < 6; i += 1) {
         exhaustClouds.push(
@@ -9308,7 +9359,8 @@ function Chess3D({
         tailRotor,
         topRotorAxis: new THREE.Vector3(0, 1, 0),
         tailRotorAxis: new THREE.Vector3(1, 0, 0),
-        exhaustClouds
+        exhaustClouds,
+        missileAnchors
       };
     };
     const createFxJet = () => {
@@ -9321,15 +9373,22 @@ function Chess3D({
           model.getObjectByName('cockpit') ||
           model.getObjectByName('Cockpit') ||
           model;
-        const detectedExhaustAnchor = findJetExhaustAnchor(model);
-        const exhaustAnchor = detectedExhaustAnchor.lerp(new THREE.Vector3(-1.95, 0, 0), 0.9);
+        const exhaustAnchors = findJetExhaustAnchors(model);
+        const averagedAnchor = exhaustAnchors
+          .reduce((acc, anchor) => acc.add(anchor.clone()), new THREE.Vector3())
+          .multiplyScalar(1 / Math.max(1, exhaustAnchors.length));
         const exhaustClouds = createJetExhaustClouds(
           root,
           6,
-          [exhaustAnchor.x, exhaustAnchor.y, exhaustAnchor.z],
+          [averagedAnchor.x, averagedAnchor.y, averagedAnchor.z],
           0.22
         );
-        return { root, cockpit, leftStore: null, rightStore: null, exhaustClouds, exhaustAnchor };
+        const missileAnchorOffsets = findMissileLaunchAnchors(model, [
+          [0.2, -0.1, -0.3],
+          [0.2, -0.1, 0.3]
+        ]);
+        const missileAnchors = missileAnchorOffsets.map((offset) => createLocalLaunchAnchor(root, offset));
+        return { root, cockpit, leftStore: null, rightStore: null, exhaustClouds, exhaustAnchors, missileAnchors };
       }
       const root = new THREE.Group();
       addFxCylinder(root, 0.16, 0.22, 3.1, [0, 0, 0], [0, 0, Math.PI / 2], '#b8bec5', 24);
@@ -9371,9 +9430,13 @@ function Chess3D({
       const rightStore = leftStore.clone();
       rightStore.position.z = 1.15;
       root.add(rightStore);
-      const exhaustAnchor = new THREE.Vector3(-1.95, 0, 0);
-      const exhaustClouds = createJetExhaustClouds(root, 8, [exhaustAnchor.x, exhaustAnchor.y, exhaustAnchor.z], 0.26);
-      return { root, cockpit, leftStore, rightStore, exhaustClouds, exhaustAnchor };
+      const exhaustAnchors = [new THREE.Vector3(-1.95, -0.02, -0.18), new THREE.Vector3(-1.95, -0.02, 0.18)];
+      const exhaustClouds = createJetExhaustClouds(root, 8, [-1.95, -0.02, 0], 0.26);
+      const missileAnchors = [
+        createLocalLaunchAnchor(root, [0.24, -0.12, -0.35]),
+        createLocalLaunchAnchor(root, [0.24, -0.12, 0.35])
+      ];
+      return { root, cockpit, leftStore, rightStore, exhaustClouds, exhaustAnchors, missileAnchors };
     };
     const createFxSupportTruck = () => {
       const root = new THREE.Group();
@@ -9982,6 +10045,16 @@ function Chess3D({
     }) => {
       const u = clamp01(progress);
       const cruiseY = Math.max(launchPos.y + strikeAltitude, targetPos.y + CAPTURE_VERTICAL_STRIKE_TOP_OFFSET);
+      const liftRatio = 0.24;
+      if (u <= liftRatio) {
+        const lu = smoothEase(u / Math.max(0.001, liftRatio));
+        const liftTop = launchPos.clone();
+        liftTop.y = cruiseY;
+        const pos = launchPos.clone().lerp(liftTop, lu);
+        const next = launchPos.clone().lerp(liftTop, clamp01(lu + 0.06));
+        return { pos: constrainInsideBoardPerimeter(pos), next: constrainInsideBoardPerimeter(next) };
+      }
+      const orbitUProgress = (u - liftRatio) / Math.max(0.001, 1 - liftRatio);
       const orbitCenter = new THREE.Vector3(
         THREE.MathUtils.lerp(launchPos.x, 0, 0.72),
         cruiseY,
@@ -10001,8 +10074,8 @@ function Chess3D({
       const spinSign = launchPos.x <= 0 ? 1 : -1;
       const endAngle = startAngle + spinSign * (Math.PI * 2 * CAPTURE_DRONE_CIRCLE_RATIO);
       const orbitSplit = CAPTURE_DRONE_CIRCLE_RATIO;
-      if (u <= orbitSplit) {
-        const ou = smoothEase(u / Math.max(0.001, orbitSplit));
+      if (orbitUProgress <= orbitSplit) {
+        const ou = smoothEase(orbitUProgress / Math.max(0.001, orbitSplit));
         const angle = THREE.MathUtils.lerp(startAngle, endAngle, ou);
         const nextAngle = THREE.MathUtils.lerp(startAngle, endAngle, clamp01(ou + 0.03));
         const radiusPulse = 1 + Math.sin(ou * Math.PI * 2) * 0.03;
@@ -10018,7 +10091,7 @@ function Chess3D({
         );
         return { pos: constrainInsideBoardPerimeter(pos), next: constrainInsideBoardPerimeter(next) };
       }
-      const du = smoothEase((u - orbitSplit) / Math.max(0.001, 1 - orbitSplit));
+      const du = smoothEase((orbitUProgress - orbitSplit) / Math.max(0.001, 1 - orbitSplit));
       const topStrike = targetPos.clone();
       topStrike.y = cruiseY;
       const descentAim = targetPos.clone();
@@ -12250,14 +12323,22 @@ function Chess3D({
             captureDir.copy(jetNext).sub(jetPos).normalize();
             const jetForward = captureDir.clone();
             orientForwardKeepingUp(fx.jetFx.root, captureDir);
-            const jetExhaustAnchor = fx.jetFx.exhaustAnchor || new THREE.Vector3(-1.95, 0, 0);
+            const jetExhaustAnchors =
+              Array.isArray(fx.jetFx.exhaustAnchors) && fx.jetFx.exhaustAnchors.length
+                ? fx.jetFx.exhaustAnchors
+                : [new THREE.Vector3(-1.95, -0.02, -0.18), new THREE.Vector3(-1.95, -0.02, 0.18)];
+            const engineIgnition = clamp01(jetTimelineU / 0.28);
+            const engineScaleBoost = 1 + (1 - smoothEase(engineIgnition)) * 0.46;
             fx.jetFx.exhaustClouds?.forEach((puff, idx) => {
+              const anchor = jetExhaustAnchors[idx % jetExhaustAnchors.length];
+              const trailDepth = Math.floor(idx / Math.max(1, jetExhaustAnchors.length));
+              puff.visible = jetTimelineU > 0.02;
               puff.position.set(
-                jetExhaustAnchor.x - idx * 0.2,
-                jetExhaustAnchor.y + Math.sin(fx.t * 8.4 + idx * 0.4) * 0.02,
-                jetExhaustAnchor.z + Math.sin(fx.t * 5.8 + idx * 0.3) * 0.008
+                anchor.x - trailDepth * 0.2,
+                anchor.y + Math.sin(fx.t * 8.4 + idx * 0.4) * 0.02,
+                anchor.z + Math.sin(fx.t * 5.8 + idx * 0.3) * 0.008
               );
-              const s = 0.84 + idx * 0.12 + ((fx.t * 1.65 + idx * 0.11) % 1) * 0.52;
+              const s = (0.84 + trailDepth * 0.12 + ((fx.t * 1.65 + idx * 0.11) % 1) * 0.52) * engineScaleBoost;
               puff.scale.setScalar(s);
             });
 
@@ -12280,14 +12361,19 @@ function Chess3D({
                 return;
               }
               if (!missile.launchPos) {
-                const sideOffset = idx === 0 ? -CAPTURE_AIR_MISSILE_SIDE_OFFSET : CAPTURE_AIR_MISSILE_SIDE_OFFSET;
-                const right = jetForward.clone().cross(WORLD_UP);
-                if (right.lengthSq() < 1e-6) {
-                  right.set(0, 0, idx === 0 ? -1 : 1);
+                const anchor = fx.jetFx.missileAnchors?.[idx] || fx.jetFx.missileAnchors?.[0];
+                if (anchor) {
+                  missile.launchPos = anchor.getWorldPosition(new THREE.Vector3());
                 } else {
-                  right.normalize();
+                  const sideOffset = idx === 0 ? -CAPTURE_AIR_MISSILE_SIDE_OFFSET : CAPTURE_AIR_MISSILE_SIDE_OFFSET;
+                  const right = jetForward.clone().cross(WORLD_UP);
+                  if (right.lengthSq() < 1e-6) {
+                    right.set(0, 0, idx === 0 ? -1 : 1);
+                  } else {
+                    right.normalize();
+                  }
+                  missile.launchPos = jetPos.clone().add(right.multiplyScalar(sideOffset));
                 }
-                missile.launchPos = jetPos.clone().add(right.multiplyScalar(sideOffset));
               }
               const missileU = clamp01((fx.t - releaseTime) / missileTravel);
               if (missileU <= 0 || missileU >= 1) {
@@ -12330,6 +12416,9 @@ function Chess3D({
             }
 
             if (jetTimelineU >= 1) {
+              fx.jetFx.exhaustClouds?.forEach((puff) => {
+                puff.visible = false;
+              });
               if (fx.sourceUnit) {
                 returnParkedAirUnit(fx.sourceUnit);
               }
@@ -12396,14 +12485,19 @@ function Chess3D({
                 return;
               }
               if (!missile.launchPos) {
-                const sideOffset = idx === 0 ? -CAPTURE_AIR_MISSILE_SIDE_OFFSET : CAPTURE_AIR_MISSILE_SIDE_OFFSET;
-                const right = heliForward.clone().cross(WORLD_UP);
-                if (right.lengthSq() < 1e-6) {
-                  right.set(0, 0, idx === 0 ? -1 : 1);
+                const anchor = fx.helicopterFx.missileAnchors?.[idx] || fx.helicopterFx.missileAnchors?.[0];
+                if (anchor) {
+                  missile.launchPos = anchor.getWorldPosition(new THREE.Vector3());
                 } else {
-                  right.normalize();
+                  const sideOffset = idx === 0 ? -CAPTURE_AIR_MISSILE_SIDE_OFFSET : CAPTURE_AIR_MISSILE_SIDE_OFFSET;
+                  const right = heliForward.clone().cross(WORLD_UP);
+                  if (right.lengthSq() < 1e-6) {
+                    right.set(0, 0, idx === 0 ? -1 : 1);
+                  } else {
+                    right.normalize();
+                  }
+                  missile.launchPos = heliPos.clone().add(right.multiplyScalar(sideOffset));
                 }
-                missile.launchPos = heliPos.clone().add(right.multiplyScalar(sideOffset));
               }
               const missileU = clamp01((fx.t - releaseTime) / missileTravel);
               if (missileU <= 0 || missileU >= 1) {


### PR DESCRIPTION
### Motivation
- Make air-unit capture animations visually consistent and precise by aligning jet/helicopter altitude to pawn short-missile peak and ensuring the drone lifts exactly from its parked position.
- Improve portrait framing during forced 3D capture animations so the camera looks slightly more top-down and a bit closer to the board.
- Prevent visual errors where exhaust and missiles appear in the wrong places by using model-aware anchors and more robust FX handling.
- Space side parking slots outward to avoid overlap and improve visual clarity of parked vehicles.

### Description
- Tuned flight / camera / parking constants: updated `CAPTURE_AIR_STRIKE_ORBIT_HEIGHT_MUL`, `CAMERA_CAPTURE_VIEW_UPWARD_BIAS`, `CAMERA_CAPTURE_VIEW_RADIUS_SCALE`, `SIDE_PARKED_AIR_UNITS_INWARD_OFFSET`, and `SIDE_PARKED_AIR_UNITS_LANE_SPREAD` to change lift altitudes, forced-3D framing, and parking layout in `ChessBattleRoyal.jsx`.
- Improved drone takeoff path by adding an initial strict vertical lift phase in `getCaptureDroneStrikePose` so the drone now lifts precisely from its launch/parked position before orbiting.
- Jet visuals: changed cockpit/window material to render fully black and opaque (tighter cockpit appearance) in `applyMilitaryJetLook`.
- Exhaust placement and missile launch anchors: added `findJetExhaustAnchors`, `findMissileLaunchAnchors`, and `createLocalLaunchAnchor` helpers to detect model exhaust/nozzles and weapon hardpoints (with robust fallbacks), changed `createFxJet`/`createFxHelicopter` to produce anchor objects, adjusted `createJetExhaustClouds` to default exhaust puffs hidden, and made runtime FX use these anchors so exhaust originates from rear nozzles and missiles spawn from vehicle-mounted anchors.
- Runtime FX behavior: made jet exhaust hidden while parked, enlarged ignition plume at takeoff and decay it over time, and updated missile launch logic to read `missileAnchors` (fallback to side-offset math when anchors not found).
- Single file changed: `webapp/src/pages/Games/ChessBattleRoyal.jsx` (multiple related helpers, FX builders, and the main capture update loop were modified).

### Testing
- Ran repo lint (`npm run -s lint`) which executed a broad lint run and failed due to existing, pre-existing repository lint issues unrelated to this change; the change itself was kept consistent with surrounding code style.
- Ran `npx eslint` targeting the modified file; the file is excluded by repository ignore rules so direct lint validation for it is not available in the current project configuration.
- Performed local static checks (search/preview of diffs) and validated the updated code paths for exhaust/missile anchors and drone lift logic; no runtime integration or UI screenshot was available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eafaf611e083299969bd8e9be4455e)