### PR TITLE
Improve Pool Royale cue stroke and power slider animation reliability

### DIFF
--- a/power-slider.js
+++ b/power-slider.js
@@ -24,6 +24,7 @@ export class PowerSlider {
     this.onStart = onStart;
     this.onCommit = onCommit;
     this.locked = false;
+    this._returnAnimFrame = null;
 
     this.el = document.createElement('div');
     this.el.className = `ps ps-theme-${theme}`;
@@ -115,6 +116,33 @@ export class PowerSlider {
     if (typeof this.onChange === 'function') this.onChange(value);
   }
 
+  animateTo(v, { duration = 160 } = {}) {
+    this._cancelReturnAnimation();
+    const target = this._clamp(this._step(v));
+    const start = this.value;
+    if (!Number.isFinite(duration) || duration <= 0 || Math.abs(target - start) < 1e-6) {
+      this.set(target, { animate: true });
+      return;
+    }
+    const startedAt = performance.now();
+    const step = (now) => {
+      const t = Math.min(1, Math.max(0, (now - startedAt) / duration));
+      const eased = 1 - (1 - t) * (1 - t);
+      const next = start + (target - start) * eased;
+      this.set(next, { animate: true });
+      if (t >= 1) {
+        this._returnAnimFrame = null;
+        return;
+      }
+      this._returnAnimFrame = requestAnimationFrame(step);
+    };
+    this._returnAnimFrame = requestAnimationFrame(step);
+  }
+
+  animateToMin({ duration = 160 } = {}) {
+    this.animateTo(this.min, { duration });
+  }
+
   lock() {
     this.locked = true;
     this.el.classList.add('ps-locked');
@@ -130,6 +158,7 @@ export class PowerSlider {
   }
 
   destroy() {
+    this._cancelReturnAnimation();
     this.el.removeEventListener('pointerdown', this._onPointerDown);
     this.el.removeEventListener('wheel', this._onWheel);
     this.el.removeEventListener('keydown', this._onKeyDown);
@@ -205,6 +234,7 @@ export class PowerSlider {
   _pointerDown(e) {
     if (this.locked) return;
     e.preventDefault();
+    this._cancelReturnAnimation();
     this.dragging = true;
     this.el.classList.add('ps-no-animate');
     this.el.setPointerCapture(e.pointerId);
@@ -238,6 +268,8 @@ export class PowerSlider {
   _wheel(e) {
     if (this.locked) return;
     e.preventDefault();
+    this._cancelReturnAnimation();
+    if (typeof this.onStart === 'function') this.onStart(this.value);
     const dir = e.deltaY > 0 ? 1 : -1;
     this.set(this.value + dir * this.step, { animate: true });
     if (typeof this.onCommit === 'function') this.onCommit(this.value);
@@ -245,18 +277,34 @@ export class PowerSlider {
 
   _keyDown(e) {
     if (this.locked) return;
+    let started = false;
     let handled = false;
     let inc = e.shiftKey ? this.step * 5 : this.step;
     if (e.key === 'ArrowDown') {
+      started = true;
       this.set(this.value + inc);
       handled = true;
     } else if (e.key === 'ArrowUp') {
+      started = true;
       this.set(this.value - inc);
       handled = true;
     } else if (e.key === 'Enter') {
       if (typeof this.onCommit === 'function') this.onCommit(this.value);
       handled = true;
     }
-    if (handled) e.preventDefault();
+    if (handled) {
+      if (started) {
+        this._cancelReturnAnimation();
+        if (typeof this.onStart === 'function') this.onStart(this.value);
+      }
+      e.preventDefault();
+    }
+  }
+
+  _cancelReturnAnimation() {
+    if (this._returnAnimFrame != null) {
+      cancelAnimationFrame(this._returnAnimFrame);
+      this._returnAnimFrame = null;
+    }
   }
 }

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -25987,18 +25987,20 @@ const shotPowerRef = useRef(0);
 
       const resolveCueStrokeProfile = (_styleId, powerRatio = 0) => {
         const p = THREE.MathUtils.clamp(powerRatio ?? 0, 0, 1);
-        const pullbackDuration = THREE.MathUtils.lerp(90, 170, p);
+        const strikeDuration = THREE.MathUtils.lerp(88, 124, p);
+        const holdDuration = THREE.MathUtils.lerp(28, 54, p);
+        const recoverDuration = THREE.MathUtils.lerp(72, 118, p);
         return {
           // Match the reference cue workflow exactly:
           // drag = pull back, release = immediate forward strike.
           motion: 'classic',
           pullRatio: easeOutCubic(p),
           pullSmoothing: 1,
-          strikeDuration: 110,
-          holdDuration: 45,
-          pullbackDuration,
-          recoverDuration: 0,
-          impactThreshold: 0.9,
+          strikeDuration,
+          holdDuration,
+          pullbackDuration: 0,
+          recoverDuration,
+          impactThreshold: THREE.MathUtils.lerp(0.7, 0.82, p),
           forwardOnly: false,
           cameraExtraHoldMs: 240,
           spinScale: 0.22
@@ -32738,7 +32740,11 @@ const shotPowerRef = useRef(0);
           : clampPower(powerRef.current, 0);
         onPowerRelease(powerRatio);
         const resetDurationMs = 160;
-        slider.animateToMin({ duration: resetDurationMs });
+        if (typeof slider.animateToMin === 'function') {
+          slider.animateToMin({ duration: resetDurationMs });
+        } else {
+          slider.set(slider.min, { animate: true });
+        }
       }
     });
     sliderInstanceRef.current = slider;


### PR DESCRIPTION
### Motivation
- Stabilize the cue pull → release → shoot workflow by making the shared power slider robust and ensuring the cue stroke animation is driven by the slider state and timed by power.
- Prevent runtime breakage when the slider resets after commit and make cue impact timing more realistic and power-sensitive.

### Description
- Added smooth return animation helpers to `PowerSlider` (`animateTo`, `animateToMin`) and an internal cancel path (`_cancelReturnAnimation`) to avoid overlapping return animations and to allow safe programmatic reset (file: `power-slider.js`).
- Hardened input lifecycle handling in `PowerSlider` by cancelling return animation on drag/wheel/keyboard start and invoking `onStart` for wheel/key interactions so external code sees consistent start/drag/commit events (file: `power-slider.js`).
- Tuned Pool Royale stroke profile so strike/hold/recover durations scale with power, removed synthetic pullback at release so the slider pull is the source of pullback, and made impact timing power-aware via `resolveCueStrokeProfile` (file: `webapp/src/pages/Games/PoolRoyale.jsx`).
- Added a defensive fallback in Pool Royale when resetting the slider after commit to call `slider.set(slider.min, { animate: true })` if `animateToMin` is not present, preventing shot flow failures (file: `webapp/src/pages/Games/PoolRoyale.jsx`).

### Testing
- Built the web app with `npm --prefix webapp run build` and the production build completed successfully (warnings from Vite unrelated to these changes were observed). 
- No other automated unit/integration tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaff364a688329a8b123610663938e)