### PR TITLE
Improve Murlan card-back logo visibility

### DIFF
--- a/webapp/src/utils/cards3d.js
+++ b/webapp/src/utils/cards3d.js
@@ -432,30 +432,41 @@ function drawLogoFrame(ctx, w, h, theme) {
 
   ctx.save();
   const plateWidth = w * 0.92;
-  const plateHeight = h * 0.38;
+  const plateHeight = h * 0.42;
   const plateX = (w - plateWidth) / 2;
   const plateY = (h - plateHeight) / 2;
+  const glow = ctx.createRadialGradient(w / 2, h / 2, w * 0.08, w / 2, h / 2, w * 0.5);
+  glow.addColorStop(0, 'rgba(255,255,255,0.24)');
+  glow.addColorStop(1, 'rgba(255,255,255,0)');
+  ctx.fillStyle = glow;
+  ctx.fillRect(0, 0, w, h);
   const plateGradient = ctx.createLinearGradient(plateX, plateY, plateX, plateY + plateHeight);
-  plateGradient.addColorStop(0, 'rgba(8, 15, 35, 0.82)');
-  plateGradient.addColorStop(1, 'rgba(15, 23, 42, 0.7)');
+  plateGradient.addColorStop(0, 'rgba(5, 10, 26, 0.9)');
+  plateGradient.addColorStop(1, 'rgba(15, 23, 42, 0.82)');
   ctx.fillStyle = plateGradient;
   roundRect(ctx, plateX, plateY, plateWidth, plateHeight, Math.min(w, h) * 0.04);
   ctx.fill();
-  ctx.strokeStyle = 'rgba(255,255,255,0.36)';
+  ctx.strokeStyle = 'rgba(255,255,255,0.52)';
   ctx.lineWidth = Math.max(4, Math.round(w * 0.0028));
   roundRect(ctx, plateX + 8, plateY + 8, plateWidth - 16, plateHeight - 16, Math.min(w, h) * 0.032);
   ctx.stroke();
 
   if (logoImage?.complete && logoImage.naturalWidth > 0) {
     const ratio = logoImage.naturalWidth / Math.max(logoImage.naturalHeight, 1);
-    const logoBoxWidth = w * 0.92;
-    // Keep logo prominent but slightly smaller for better balance on card backs.
-    const logoBoxHeight = h * 0.86;
+    const logoBoxWidth = w * 0.86;
+    // Keep logo clear on mobile with extra margin from card edges.
+    const logoBoxHeight = h * 0.76;
     const drawWidth = Math.min(logoBoxWidth, logoBoxHeight * ratio);
     const drawHeight = drawWidth / ratio;
     const logoX = w / 2 - drawWidth / 2;
     const logoY = h / 2 - drawHeight / 2;
+    ctx.shadowColor = 'rgba(255,255,255,0.42)';
+    ctx.shadowBlur = Math.max(18, Math.round(w * 0.022));
+    ctx.shadowOffsetX = 0;
+    ctx.shadowOffsetY = 0;
     ctx.drawImage(logoImage, logoX, logoY, drawWidth, drawHeight);
+    ctx.shadowColor = 'transparent';
+    ctx.shadowBlur = 0;
   } else {
     ctx.fillStyle = theme.backAccent || 'rgba(255,255,255,0.85)';
     ctx.textAlign = 'center';


### PR DESCRIPTION
### Motivation
- The Murlan Royale card-back logo was not sufficiently visible against patterned backs, especially on mobile portrait screens. 
- Increase contrast and add subtle lighting so the logo reads clearly from typical camera/view angles. 
- Make a conservative visual change limited to the card-back rendering to avoid side effects in other systems.

### Description
- Increased the logo plate height and adjusted plate gradient stops in `drawLogoFrame` to provide stronger contrast (`webapp/src/utils/cards3d.js`).
- Added a soft radial glow behind the plate and increased the plate stroke alpha to help the logo stand out from repeating patterns.
- Reduced the logo box size to add safe margins for mobile portrait and added a subtle shadow (`ctx.shadow*`) when drawing the logo image to improve perceived contrast.
- All changes are confined to the `drawLogoFrame` canvas drawing logic in `webapp/src/utils/cards3d.js`.

### Testing
- Ran the unit test target `npm test -- test/murlan.test.js --runInBand` and it passed.
- No other automated tests were modified or required for this visual tweak.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb016886ac8329866e9ceb65cd9b85)