### PR TITLE
Align Snake & Ladder dice parking/landing with portrait markers

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -153,6 +153,7 @@ const DICE_THROW_START_EXTRA = TILE_SIZE * 3.6;
 const DICE_THROW_HEIGHT = DICE_SIZE * 1.05;
 const BOARD_EDGE_BUFFER = TILE_SIZE * 0.2;
 const DICE_RETREAT_EXTRA = DICE_SIZE * 0.95;
+const DICE_RESULT_HOLD_DURATION = 2000;
 const BOARD_BASE_EXTRA = RAW_BOARD_SIZE * (0.36 / 3.4);
 const BOARD_BASE_HEIGHT = RAW_BOARD_SIZE * (0.24 / 3.4);
 const WORLD_UP = new THREE.Vector3(0, 1, 0);
@@ -420,6 +421,21 @@ const DICE_SEAT_ADJUSTMENTS = [
     }
   }
 ];
+// Dice parking/landing calibration for portrait mobile view:
+// - "blue" parking slots (player turn ready) stay on the wood rail near each seat.
+// - "purple" result slots land near each side of the board before handoff.
+const DICE_BLUE_SLOT_DISTANCE_BY_SEAT = Object.freeze([
+  BOARD_RADIUS + TILE_SIZE * 2.8, // bottom
+  BOARD_RADIUS + TILE_SIZE * 2.72, // right
+  BOARD_RADIUS + TILE_SIZE * 2.86, // top
+  BOARD_RADIUS + TILE_SIZE * 2.72 // left
+]);
+const DICE_PURPLE_SLOT_DISTANCE_BY_SEAT = Object.freeze([
+  BOARD_RADIUS + TILE_SIZE * 1.68, // bottom
+  BOARD_RADIUS + TILE_SIZE * 1.58, // right
+  BOARD_RADIUS + TILE_SIZE * 1.7, // top
+  BOARD_RADIUS + TILE_SIZE * 1.58 // left
+]);
 
 const DEFAULT_COLORS = ['#f97316', '#22d3ee', '#22c55e', '#a855f7'];
 
@@ -2273,9 +2289,10 @@ function computeDiceThrowLayout(board, seatIndex, count) {
 
   const boardHalf = (BASE_LEVEL_TILES * TILE_SIZE) / 2;
   const boardEdgeDistance = boardHalf + BOARD_EDGE_BUFFER;
-  const baseStartDistance = boardHalf + DICE_THROW_START_EXTRA;
+  const baseStartDistance = DICE_BLUE_SLOT_DISTANCE_BY_SEAT[seatIndex] ?? (boardHalf + DICE_THROW_START_EXTRA);
   const settleBaseDistance =
-    boardHalf + DICE_THROW_LANDING_MARGIN * 0.52 + DICE_RETREAT_EXTRA * 0.12;
+    DICE_PURPLE_SLOT_DISTANCE_BY_SEAT[seatIndex] ??
+    (boardHalf + DICE_THROW_LANDING_MARGIN * 0.52 + DICE_RETREAT_EXTRA * 0.12);
 
   const seatAdjust = DICE_SEAT_ADJUSTMENTS[seatIndex] ?? {};
   const forwardAdjust = seatAdjust.forward ?? {};
@@ -2307,16 +2324,14 @@ function computeDiceThrowLayout(board, seatIndex, count) {
 
   for (let i = 0; i < count; i += 1) {
     const offset = (i - centerOffset) * spacing;
-    const lateralJitter = (Math.random() - 0.5) * DICE_SIZE * 0.38;
-    const bounceJitter = (Math.random() - 0.5) * DICE_SIZE * 0.2;
-    const retreatExtra = Math.random() * DICE_SIZE * 0.22;
-    const outwardJitter = Math.random() * DICE_SIZE * 0.18;
+    const lateralJitter = (Math.random() - 0.5) * DICE_SIZE * 0.26;
+    const bounceJitter = (Math.random() - 0.5) * DICE_SIZE * 0.16;
 
-    const startDistance = startBaseDistance + Math.random() * DICE_SIZE * 0.7;
-    const bounceDistance = bounceBaseDistance + (Math.random() - 0.5) * DICE_SIZE * 0.08;
+    const startDistance = startBaseDistance + (Math.random() - 0.5) * DICE_SIZE * 0.2;
+    const bounceDistance = bounceBaseDistance + (Math.random() - 0.5) * DICE_SIZE * 0.06;
     const settleDistance = Math.max(
       bounceDistance + DICE_SIZE * 0.22,
-      settleDistanceBase + (Math.random() - 0.1) * DICE_SIZE * 0.3
+      settleDistanceBase + (Math.random() - 0.5) * DICE_SIZE * 0.06
     );
 
     const start = centerLocal
@@ -2335,9 +2350,8 @@ function computeDiceThrowLayout(board, seatIndex, count) {
 
     const base = centerLocal
       .clone()
-      .addScaledVector(awayFromBoard, settleDistance + retreatExtra)
+      .addScaledVector(awayFromBoard, settleDistance)
       .addScaledVector(lateral, offset + lateralJitter * 0.45);
-    base.addScaledVector(awayFromBoard, outwardJitter);
     base.y = diceBaseY;
     applyAxisOffsets(base, 'base');
 
@@ -4794,6 +4808,7 @@ export default function SnakeBoard3D({
   const snakeTextureRef = useRef(null);
   const animationsRef = useRef([]);
   const diceStateRef = useRef({ currentId: null, basePositions: [], baseY: 0, count: 0 });
+  const diceHandoffTimeoutRef = useRef(null);
   const seatCallbackRef = useRef(null);
   const diceAnchorCallbackRef = useRef(null);
   const diceTapCallbackRef = useRef(null);
@@ -4991,6 +5006,16 @@ export default function SnakeBoard3D({
       diceTapCallbackRef.current = null;
     };
   }, [onDiceTap]);
+
+  useEffect(
+    () => () => {
+      if (diceHandoffTimeoutRef.current) {
+        clearTimeout(diceHandoffTimeoutRef.current);
+        diceHandoffTimeoutRef.current = null;
+      }
+    },
+    []
+  );
 
   useEffect(() => {
     let active = true;
@@ -5726,6 +5751,10 @@ export default function SnakeBoard3D({
     const diceBaseY = board.diceBaseY ?? 0;
     const diceAnchorZ = board.diceAnchorZ ?? 0;
     if (diceEvent.phase === 'start') {
+      if (diceHandoffTimeoutRef.current) {
+        clearTimeout(diceHandoffTimeoutRef.current);
+        diceHandoffTimeoutRef.current = null;
+      }
       removeAnimationsByType(animationsRef.current, 'cameraDiceZoom');
       removeAnimationsByType(animationsRef.current, 'diceRoll');
       removeAnimationsByType(animationsRef.current, 'diceHandoff');
@@ -5845,38 +5874,42 @@ export default function SnakeBoard3D({
         const seatCount = Array.isArray(board.seatAnchors) ? board.seatAnchors.length : 0;
         if (seatCount > 0) {
           const seatIndex = Math.max(0, Math.min(seatCount - 1, currentTurn || 0));
-          const handoffLayout = computeDiceThrowLayout(board, seatIndex, active.length);
-          const handoffBases = Array.isArray(handoffLayout.basePositions) ? handoffLayout.basePositions : [];
-          if (handoffBases.length) {
-            removeAnimationsByType(animationsRef.current, 'diceHandoff');
-            const handoffAnimation = createDiceHandoffAnimation(active, {
-              basePositions: handoffBases,
-              baseY: board.diceBaseY ?? 0,
-              duration: TURN_CAMERA_TURN_IN_DURATION
-            });
-            if (handoffAnimation) animationsRef.current.push(handoffAnimation);
-            const camera = cameraRef.current;
-            const controls = board?.controls;
-            if (camera && controls && cameraViewMode !== '2d') {
-              const focusState = computeTurnCameraFocusState(board, camera, seatIndex, players);
-              if (focusState) {
-                removeAnimationsByType(animationsRef.current, 'cameraTurnFocus');
-                removeAnimationsByType(animationsRef.current, 'cameraDiceZoom');
-                const turnAnimation = createCameraTransitionAnimation(camera, controls, {
-                  toPosition: focusState.position,
-                  toTarget: focusState.target,
-                  durationIn: TURN_CAMERA_TURN_IN_DURATION,
-                  hold: 0,
-                  durationOut: 0,
-                  type: 'cameraTurnFocus',
-                  lockPosition: true,
-                  returnPosition: focusState.position,
-                  returnTarget: focusState.target
-                });
-                if (turnAnimation) animationsRef.current.push(turnAnimation);
+          if (diceHandoffTimeoutRef.current) clearTimeout(diceHandoffTimeoutRef.current);
+          diceHandoffTimeoutRef.current = setTimeout(() => {
+            const handoffLayout = computeDiceThrowLayout(board, seatIndex, active.length);
+            const handoffBases = Array.isArray(handoffLayout.basePositions) ? handoffLayout.basePositions : [];
+            if (handoffBases.length) {
+              removeAnimationsByType(animationsRef.current, 'diceHandoff');
+              const handoffAnimation = createDiceHandoffAnimation(active, {
+                basePositions: handoffBases,
+                baseY: board.diceBaseY ?? 0,
+                duration: TURN_CAMERA_TURN_IN_DURATION
+              });
+              if (handoffAnimation) animationsRef.current.push(handoffAnimation);
+              const camera = cameraRef.current;
+              const controls = board?.controls;
+              if (camera && controls && cameraViewMode !== '2d') {
+                const focusState = computeTurnCameraFocusState(board, camera, seatIndex, players);
+                if (focusState) {
+                  removeAnimationsByType(animationsRef.current, 'cameraTurnFocus');
+                  removeAnimationsByType(animationsRef.current, 'cameraDiceZoom');
+                  const turnAnimation = createCameraTransitionAnimation(camera, controls, {
+                    toPosition: focusState.position,
+                    toTarget: focusState.target,
+                    durationIn: TURN_CAMERA_TURN_IN_DURATION,
+                    hold: 0,
+                    durationOut: 0,
+                    type: 'cameraTurnFocus',
+                    lockPosition: true,
+                    returnPosition: focusState.position,
+                    returnTarget: focusState.target
+                  });
+                  if (turnAnimation) animationsRef.current.push(turnAnimation);
+                }
               }
             }
-          }
+            diceHandoffTimeoutRef.current = null;
+          }, DICE_RESULT_HOLD_DURATION);
         }
       }
       const lastSeatIndex = diceStateRef.current.lastSeatIndex;


### PR DESCRIPTION
### Motivation
- Improve visual fidelity for Snake & Ladder on portrait mobile by placing dice exactly where the photo markers indicate: player "blue" ready slots on the rail and "purple" result slots near the board edge. 
- Make the dice result clearly visible for a fixed duration before automatically handing off to the next player. 
- Use the same dice timing/flow as Ludo/Pool Royale but calibrate positions and jitter so results land consistently in the marked zones.

### Description
- Added a 2s result hold constant `DICE_RESULT_HOLD_DURATION` and seat-specific parking/landing distance arrays `DICE_BLUE_SLOT_DISTANCE_BY_SEAT` and `DICE_PURPLE_SLOT_DISTANCE_BY_SEAT` in `webapp/src/components/SnakeBoard3D.jsx` to map portrait markers to dice start and landing radii. 
- Updated `computeDiceThrowLayout` to use the new seat-specific blue/purple distances and tightened dice jitter/settle random ranges so throws settle more predictably in the purple result zone. 
- Replaced the immediate handoff path with a delayed handoff using a `diceHandoffTimeoutRef` and `setTimeout` for `DICE_RESULT_HOLD_DURATION`, so the rolled value is displayed before the dice move to the next player. 
- Added lifecycle cleanup to clear any pending handoff timer on new rolls and component unmount to avoid stale timers and race conditions.

### Testing
- Ran `npx eslint webapp/src/components/SnakeBoard3D.jsx` which executed successfully but returned a repo ignore warning because this file is excluded by the project's lint ignore; no syntax errors surfaced. 
- Verified through static inspection that `computeDiceThrowLayout`, dice roll/settle and handoff code paths reference the new constants and that a handoff timer is created/cleared on roll start/end and on unmount. 
- No automated runtime integration tests were available in this environment; changes are limited to `webapp/src/components/SnakeBoard3D.jsx` and will require in-app QA on a portrait mobile build to validate visual alignment and timing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaff56cf8c8329ab12166f70ff9768)