### PR TITLE
Fix Murlan Royale card-back mirroring and increase HDRI wall spacing

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2462,6 +2462,7 @@ const HDRI_GROUND_FLOOR_Y = 0;
 const ARENA_GROUND_Y = HDRI_GROUND_FLOOR_Y;
 const HDRI_GROUND_FLOOR_RADIUS_MULTIPLIER = 1.76;
 const HDRI_GROUND_FLOOR_OPACITY = 0.22;
+const HDRI_WALL_DISTANCE_MULTIPLIER = 1.22;
 const HDRI_BACKGROUND_PITCH = THREE.MathUtils.degToRad(-2.4);
 const CAMERA_SIDE_LOOK_EXTRA = 0.42 * MODEL_SCALE;
 const CAMERA_INWARD_RADIUS_FACTOR = 0.94;
@@ -4994,7 +4995,8 @@ export default function MurlanRoyaleArena({ search }) {
       const arenaScale = 1.18 * ARENA_GROWTH;
       const boardSize = (TABLE_RADIUS * 2 + 1.2 * MODEL_SCALE) * arenaScale;
       const camConfig = buildArenaCameraConfig(boardSize);
-      const interiorWidth = Math.max(TABLE_RADIUS * ARENA_GROWTH * 3.4, CHAIR_RADIUS * 2 + 4 * MODEL_SCALE);
+      const interiorWidth = Math.max(TABLE_RADIUS * ARENA_GROWTH * 3.4, CHAIR_RADIUS * 2 + 4 * MODEL_SCALE)
+        * HDRI_WALL_DISTANCE_MULTIPLIER;
       const interiorDepth = interiorWidth;
       const innerHalfWidth = interiorWidth / 2;
       const innerHalfDepth = interiorDepth / 2;
@@ -6885,20 +6887,17 @@ function setBackLogoOrientation(mesh, variant = 'default') {
     tunedTexture.offset.set(0, 0);
     tunedTexture.rotation = 0;
     tunedTexture.center.set(0.5, 0.5);
+    // Back-face UVs are mirrored on these seats; flip horizontally so the logo reads correctly.
+    tunedTexture.repeat.x = -1;
+    tunedTexture.offset.x = 1;
     if (desiredVariant === 'top') {
       // Top seat cards need a 180° turn so the logo reads upright from the camera.
-      tunedTexture.repeat.set(1, 1);
-      tunedTexture.offset.set(0, 0);
       tunedTexture.rotation = Math.PI;
     } else if (desiredVariant === 'side') {
-      // Left side seat: keep the logo un-mirrored.
-      tunedTexture.repeat.set(1, 1);
-      tunedTexture.offset.set(0, 0);
+      // Left side seat: keep the logo upright from the mobile portrait camera.
       tunedTexture.rotation = 0;
     } else if (desiredVariant === 'sideGift') {
-      // Right side seat: keep the logo un-mirrored.
-      tunedTexture.repeat.set(1, 1);
-      tunedTexture.offset.set(0, 0);
+      // Right side seat: keep the logo upright from the mobile portrait camera.
       tunedTexture.rotation = 0;
     }
     tunedTexture.needsUpdate = true;


### PR DESCRIPTION
### Motivation
- Card back logos on non-human seats were appearing mirrored and needed to read upright from the player's camera view. 
- The table appeared visually too close to HDRI environment walls and required extra interior margin so it doesn't sit next to HDRI walls.

### Description
- In `webapp/src/pages/Games/MurlanRoyaleArena.jsx` added `HDRI_WALL_DISTANCE_MULTIPLIER` and applied it to the arena `interiorWidth` calculation so HDRI walls sit farther from the table. 
- Updated `setBackLogoOrientation` to clone the base back texture and flip it horizontally with `tunedTexture.repeat.x = -1` and `tunedTexture.offset.x = 1` to correct mirrored logos while preserving per-seat rotations for `top`, `side`, and `sideGift`. 
- Kept existing seat-specific rotation behavior so the logo remains upright for top/side/right seats and added clarifying comments.

### Testing
- Ran the unit tests targeted at the Murlan rules with `npm test -- --runInBand test/murlan.test.js` and the suite passed (`12 passed`).
- No automated visual snapshot was produced in this environment; functionality verification for texture orientation and HDRI spacing should be validated in the running app or with a screenshot capture step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb0b7ac830832991f657b0337d1b38)