### PR TITLE
Reduce Murlan Royale card texture memory usage on mobile WebView

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -2710,15 +2710,25 @@ function resolveHdriResolutionFromGraphics(frameOption) {
 }
 
 function resolveCardTextureSize(frameOption) {
+  const ua = typeof navigator !== 'undefined' ? navigator.userAgent ?? '' : '';
+  const isAndroidWebView =
+    /Android/i.test(ua) && (/\bwv\b/i.test(ua) || /Version\/\d+\.\d+ Chrome\//i.test(ua));
+  const deviceMemory = typeof navigator !== 'undefined' && typeof navigator.deviceMemory === 'number'
+    ? navigator.deviceMemory
+    : null;
+  const memoryScaleCap = deviceMemory != null && deviceMemory <= 4 ? 0.72 : 1;
+  const webViewScaleCap = isAndroidWebView ? 0.7 : 1;
+  const runtimeScaleCap = Math.min(memoryScaleCap, webViewScaleCap);
   const scale = Number.isFinite(frameOption?.cardTextureScale)
     ? THREE.MathUtils.clamp(frameOption.cardTextureScale, 1, 1.5)
     : 1;
+  const effectiveScale = Math.max(0.62, scale * runtimeScaleCap);
   return {
-    w: Math.round(768 * scale),
-    h: Math.round(1080 * scale),
-    heldW: Math.round(256 * scale),
-    heldH: Math.round(360 * scale),
-    id: `${frameOption?.id || DEFAULT_FRAME_RATE_ID}-${scale.toFixed(2)}`
+    w: Math.round(768 * effectiveScale),
+    h: Math.round(1080 * effectiveScale),
+    heldW: Math.round(256 * effectiveScale),
+    heldH: Math.round(360 * effectiveScale),
+    id: `${frameOption?.id || DEFAULT_FRAME_RATE_ID}-${effectiveScale.toFixed(2)}`
   };
 }
 
@@ -7252,7 +7262,9 @@ function recolorBlackJokerFigure(ctx, width, height) {
 }
 
 function makeCardBackTexture(theme, textureQuality = null) {
-  const safeQualityScale = Number.isFinite(textureQuality?.w) ? THREE.MathUtils.clamp(textureQuality.w / 768, 1, 1.5) : 1;
+  const safeQualityScale = Number.isFinite(textureQuality?.w)
+    ? THREE.MathUtils.clamp(textureQuality.w / 768, 0.62, 1.5)
+    : 1;
   const width = Math.round(1024 * safeQualityScale);
   const height = Math.round(1536 * safeQualityScale);
   return makeTonplaygramCardBackTexture(theme, width, height);

--- a/webapp/src/utils/cards3d.js
+++ b/webapp/src/utils/cards3d.js
@@ -209,8 +209,8 @@ function makeCardFace(rank, suit, theme, w = 512, h = 720) {
 }
 
 export function makeTonplaygramCardBackTexture(theme, w = 3072, h = 4320) {
-  const safeWidth = Math.max(1024, Math.round(Math.min(w, 3072)));
-  const safeHeight = Math.max(1440, Math.round(Math.min(h, 4320)));
+  const safeWidth = Math.max(640, Math.round(Math.min(w, 2048)));
+  const safeHeight = Math.max(960, Math.round(Math.min(h, 3072)));
   const cacheKey = `${theme?.id || 'default'}:${safeWidth}x${safeHeight}`;
   const cachedTexture = cardBackTextureCache.get(cacheKey);
   if (cachedTexture) return cachedTexture;
@@ -234,7 +234,7 @@ export function makeTonplaygramCardBackTexture(theme, w = 3072, h = 4320) {
   texture.minFilter = THREE.LinearMipmapLinearFilter;
   texture.magFilter = THREE.LinearFilter;
   texture.generateMipmaps = true;
-  texture.anisotropy = 16;
+  texture.anisotropy = 8;
   texture.flipY = false;
 
   const logoImage = getTonplaygramLogoImage();


### PR DESCRIPTION
### Motivation
- Android WebView clients were crashing with "Aw, Snap!" due to GPU/texture memory pressure from high-resolution card textures in Murlan Royale. 

### Description
- Detect Android WebView and low-memory devices in `resolveCardTextureSize` and apply a runtime scaling cap so generated card texture sizes are reduced for constrained clients (`webapp/src/pages/Games/MurlanRoyaleArena.jsx`).
- Allow card-back generation to scale down to `0.62` of nominal size in `makeCardBackTexture` so back canvases can be smaller on constrained runtimes (`webapp/src/pages/Games/MurlanRoyaleArena.jsx`).
- Lower the minimum/maximum canvas dimensions used to generate the Tonplaygram card-back texture and reduce `anisotropy` from `16` to `8` to cut GPU memory pressure while retaining visual quality (`webapp/src/utils/cards3d.js`).

### Testing
- Ran unit tests with `npm run test -- test/murlan.test.js`, and the suite passed (`1` suite, `12` tests passed).
- Ran linting with `npx eslint webapp/src/pages/Games/MurlanRoyaleArena.jsx webapp/src/utils/cards3d.js`; ESLint reported ignore warnings for those files but no lint errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb1285c70883299d74726e4dc32540)