### PR TITLE
Fix Pool Royale cue-stick impact power transfer

### DIFF
--- a/test/cueShotImpact.test.js
+++ b/test/cueShotImpact.test.js
@@ -1,5 +1,6 @@
 import {
   applyShotImpact,
+  computeCueDriveBoost,
   createShotImpactFallback,
   createShotImpactPayload,
   shouldResolveShot
@@ -38,5 +39,24 @@ describe('cue shot impact orchestration', () => {
     expect(shouldResolveShot({ hasAnyMotion: false, shotApplied: false })).toBe(false);
     expect(shouldResolveShot({ hasAnyMotion: true, shotApplied: true })).toBe(false);
     expect(shouldResolveShot({ hasAnyMotion: false, shotApplied: true })).toBe(true);
+  });
+
+  test('boosts impact speed more for longer and stronger cue drives', () => {
+    const soft = computeCueDriveBoost({
+      pullDistance: 0.04,
+      contactAdvance: 0.01,
+      strikeDurationMs: 150,
+      clampedPower: 0.2
+    });
+    const strong = computeCueDriveBoost({
+      pullDistance: 0.18,
+      contactAdvance: 0.05,
+      strikeDurationMs: 90,
+      clampedPower: 1
+    });
+
+    expect(soft).toBeGreaterThanOrEqual(0.85);
+    expect(strong).toBeLessThanOrEqual(1.35);
+    expect(strong).toBeGreaterThan(soft);
   });
 });

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -115,6 +115,7 @@ import {
 import { sampleCueStrokeTimeline } from './poolRoyaleCueStrokeTimeline.js';
 import { resolvePocketMouthAimPoint } from './poolRoyalePocketAim.js';
 import { resolveAiPotGhostAim } from './poolRoyaleAiAimCompensation.js';
+import { computeCueDriveBoost } from './cueShotImpact.js';
 import { polyHavenThumb } from '../../config/storeThumbnails.js';
 
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/v1/decoders/';
@@ -26205,7 +26206,7 @@ const shotPowerRef = useRef(0);
       const applyShotAtImpact = (payload) => {
         if (!payload || payload.applied) return;
         payload.applied = true;
-        const { base, aimDir, physicsSpin, clampedPower, liftStrength } = payload;
+        const { base, aimDir, physicsSpin, clampedPower, liftStrength, cueDriveBoost = 1 } = payload;
         const offsetScaled = {
           x: physicsSpin?.x ?? 0,
           y: physicsSpin?.y ?? 0
@@ -26215,7 +26216,7 @@ const shotPowerRef = useRef(0);
         else shotDir3.set(0, 0, 1);
         const sideDir3 = TMP_VEC3_D.set(shotDir3.z, 0, -shotDir3.x);
         if (sideDir3.lengthSq() > 1e-8) sideDir3.normalize();
-        const baseSpeed = Math.max(0, base.length());
+        const baseSpeed = Math.max(0, base.length()) * THREE.MathUtils.clamp(cueDriveBoost, 0.8, 1.5);
         const topspin = Math.max(0, offsetScaled.y);
         const backspin = Math.max(0, -offsetScaled.y);
         const squirt = offsetScaled.x * clampedPower * 0.24;
@@ -26649,6 +26650,7 @@ const shotPowerRef = useRef(0);
             physicsSpin: { x: spinSide, y: spinTop },
             clampedPower,
             liftStrength,
+            cueDriveBoost: 1,
             applied: false
           };
 
@@ -26759,6 +26761,12 @@ const shotPowerRef = useRef(0);
           const contactPos = impactPos
             .clone()
             .addScaledVector(dir, contactAdvance);
+          shotImpactPayload.cueDriveBoost = computeCueDriveBoost({
+            pullDistance: releaseStartPos.distanceTo(impactPos),
+            contactAdvance,
+            strikeDurationMs: strikeDuration,
+            clampedPower
+          });
           const followDistance = THREE.MathUtils.lerp(
             CUE_FOLLOW_THROUGH_MIN,
             CUE_FOLLOW_THROUGH_MAX,

--- a/webapp/src/pages/Games/cueShotImpact.js
+++ b/webapp/src/pages/Games/cueShotImpact.js
@@ -20,6 +20,25 @@ export function createShotImpactFallback(payload, impactAtMs) {
   };
 }
 
+export function computeCueDriveBoost({
+  pullDistance = 0,
+  contactAdvance = 0,
+  strikeDurationMs = 120,
+  clampedPower = 0
+} = {}) {
+  const safePower = Number.isFinite(clampedPower) ? Math.max(0, Math.min(1, clampedPower)) : 0;
+  const strokeDistance = Math.max(
+    0,
+    (Number.isFinite(pullDistance) ? pullDistance : 0) +
+      (Number.isFinite(contactAdvance) ? contactAdvance : 0)
+  );
+  const strokeSeconds = Math.max(0.05, (Number.isFinite(strikeDurationMs) ? strikeDurationMs : 120) / 1000);
+  const strokeSpeed = strokeDistance / strokeSeconds;
+  const driveFromSpeed = Math.max(0, Math.min(1, strokeSpeed / 3.25));
+  const driveFromPower = Math.max(0, Math.min(1, safePower));
+  return Math.max(0.85, Math.min(1.35, 0.9 + driveFromSpeed * 0.34 + driveFromPower * 0.11));
+}
+
 
 export function shouldResolveShot({ hasAnyMotion, shotApplied }) {
   return Boolean(shotApplied) && !Boolean(hasAnyMotion);


### PR DESCRIPTION
### Motivation
- The Pool Royale cue ball felt underpowered because the visible cue-stick push (pullback + forward punch) wasn't contributing to the launch impulse at impact.   
- Improve realism by transferring visible stroke energy into cue-ball speed so stronger/longer pushes produce noticeably stronger launches.

### Description
- Added a helper `computeCueDriveBoost` in `webapp/src/pages/Games/cueShotImpact.js` that computes a bounded multiplier from `pullDistance`, `contactAdvance`, `strikeDurationMs`, and `clampedPower`.
- Wired the boost into the shot creation flow in `webapp/src/pages/Games/PoolRoyale.jsx` by computing `cueDriveBoost` from the release start position, contact advance and strike timing, attaching it to the `shotImpactPayload`, and applying it to the base launch speed inside the impact application.
- Kept the multiplier clamped to safe bounds so physics remain stable and tuned coefficients to blend stroke speed and power influence.
- Added a unit test in `test/cueShotImpact.test.js` asserting that longer/faster/stronger strokes produce larger boost values and that values remain within the expected range.

### Testing
- Ran the unit tests for the modified behaviour with `npm test -- --runInBand test/cueShotImpact.test.js` which passed.  
- Test results: 1 test suite passed, 4 tests passed (`cue shot impact orchestration` — 4/4 passing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb1a5a8bf083299f4d1bacef7e4995)