### PR TITLE
Adjust top-seat token and weapon placement for portrait Snake & Ladder board

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -309,8 +309,8 @@ const TOKEN_PORTRAIT_SCREEN_SHIFT_BY_SEAT = Object.freeze([
   Object.freeze({ radial: TILE_SIZE * 1.46, lateral: TILE_SIZE * 1.06, y: TILE_SIZE * 0.08 }),
   // Right seat (yellow): upper marker above side-center.
   Object.freeze({ radial: TILE_SIZE * 1.08, lateral: -TILE_SIZE * 1.1, y: TILE_SIZE * 0.08 }),
-  // Top seat (yellow): upper-left marker near top edge.
-  Object.freeze({ radial: TILE_SIZE * 1.58, lateral: -TILE_SIZE * 1.04, y: TILE_SIZE * 0.1 }),
+  // Top seat (yellow): push toward top player while nudging inward toward board center.
+  Object.freeze({ radial: TILE_SIZE * 1.72, lateral: -TILE_SIZE * 0.9, y: TILE_SIZE * 0.1 }),
   // Left seat (yellow): upper marker above side-center.
   Object.freeze({ radial: TILE_SIZE * 1.08, lateral: TILE_SIZE * 1.1, y: TILE_SIZE * 0.08 })
 ]);
@@ -319,8 +319,8 @@ const WEAPON_PORTRAIT_SCREEN_SHIFT_BY_SEAT = Object.freeze([
   Object.freeze({ radial: TILE_SIZE * 1.72, lateral: -TILE_SIZE * 1.08, y: TILE_SIZE * 1.1 }),
   // Right seat (red): lower side marker.
   Object.freeze({ radial: TILE_SIZE * 1.34, lateral: TILE_SIZE * 0.96, y: TILE_SIZE * 1.1 }),
-  // Top seat (red): upper-right marker.
-  Object.freeze({ radial: TILE_SIZE * 1.86, lateral: TILE_SIZE * 1.02, y: TILE_SIZE * 1.16 }),
+  // Top seat (red): push toward top player while nudging inward toward board center.
+  Object.freeze({ radial: TILE_SIZE * 2.02, lateral: TILE_SIZE * 0.88, y: TILE_SIZE * 1.16 }),
   // Left seat (red): lower side marker.
   Object.freeze({ radial: TILE_SIZE * 1.34, lateral: -TILE_SIZE * 0.96, y: TILE_SIZE * 1.1 })
 ]);


### PR DESCRIPTION
### Motivation
- Improve mobile portrait UX by moving the top player's parked token and parked weapon slightly further toward the top player and a bit inward toward the board center to match the requested visual alignment.

### Description
- Tuned portrait calibration constants in `webapp/src/components/SnakeBoard3D.jsx` for seat index `2` (top seat) by increasing the `radial` offsets and reducing the `lateral` offsets so items appear closer to the top player and nudged inward. 
- Changed `TOKEN_PORTRAIT_SCREEN_SHIFT_BY_SEAT[2]` to `radial: TILE_SIZE * 1.72` and `lateral: -TILE_SIZE * 0.9` and updated the accompanying inline comment to describe the inward nudge. 
- Changed `WEAPON_PORTRAIT_SCREEN_SHIFT_BY_SEAT[2]` to `radial: TILE_SIZE * 2.02` and `lateral: TILE_SIZE * 0.88` and updated the comment to match the placement intent.

### Testing
- Ran the production build with `npm -C webapp run build`, which completed successfully. 
- Build emitted pre-existing non-blocking warnings (chunk-size and a duplicate `package.json` key) that are unrelated to these constant changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb240f8ef883298c9846203791fa95)