### PR TITLE
Adjust top-seat token and weapon placement (portrait)

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -310,7 +310,7 @@ const TOKEN_PORTRAIT_SCREEN_SHIFT_BY_SEAT = Object.freeze([
   // Right seat (yellow): upper marker above side-center.
   Object.freeze({ radial: TILE_SIZE * 1.08, lateral: -TILE_SIZE * 1.1, y: TILE_SIZE * 0.08 }),
   // Top seat (yellow): push toward top player while nudging inward toward board center.
-  Object.freeze({ radial: TILE_SIZE * 1.72, lateral: -TILE_SIZE * 0.9, y: TILE_SIZE * 0.1 }),
+  Object.freeze({ radial: TILE_SIZE * 1.86, lateral: -TILE_SIZE * 0.72, y: TILE_SIZE * 0.1 }),
   // Left seat (yellow): upper marker above side-center.
   Object.freeze({ radial: TILE_SIZE * 1.08, lateral: TILE_SIZE * 1.1, y: TILE_SIZE * 0.08 })
 ]);
@@ -320,7 +320,7 @@ const WEAPON_PORTRAIT_SCREEN_SHIFT_BY_SEAT = Object.freeze([
   // Right seat (red): lower side marker.
   Object.freeze({ radial: TILE_SIZE * 1.34, lateral: TILE_SIZE * 0.96, y: TILE_SIZE * 1.1 }),
   // Top seat (red): push toward top player while nudging inward toward board center.
-  Object.freeze({ radial: TILE_SIZE * 2.02, lateral: TILE_SIZE * 0.88, y: TILE_SIZE * 1.16 }),
+  Object.freeze({ radial: TILE_SIZE * 2.16, lateral: TILE_SIZE * 0.72, y: TILE_SIZE * 1.16 }),
   // Left seat (red): lower side marker.
   Object.freeze({ radial: TILE_SIZE * 1.34, lateral: -TILE_SIZE * 0.96, y: TILE_SIZE * 1.1 })
 ]);


### PR DESCRIPTION
### Motivation
- Move reserve tokens and parked weapons for the top (seat index 2) player slightly inward and visually closer to the top player on portrait phones so they appear nearer the player and centered on-screen.

### Description
- Tuned portrait calibration constants in `webapp/src/components/SnakeBoard3D.jsx` for seat index `2`.
- Updated `TOKEN_PORTRAIT_SCREEN_SHIFT_BY_SEAT[2]` to `{ radial: TILE_SIZE * 1.86, lateral: -TILE_SIZE * 0.72, y: TILE_SIZE * 0.1 }`.
- Updated `WEAPON_PORTRAIT_SCREEN_SHIFT_BY_SEAT[2]` to `{ radial: TILE_SIZE * 2.16, lateral: TILE_SIZE * 0.72, y: TILE_SIZE * 1.16 }`.

### Testing
- No automated tests were run for this tweak; change is a visual/layout calibration and should be validated with a portrait-device UI check.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb29b9f93083299d16c8d6c31a4989)