### PR TITLE
Adjust Snake & Ladder parking slots upward and inward

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -277,13 +277,13 @@ const WEAPON_SLOT_LATERAL_NUDGE_BY_SEAT = Object.freeze([
   0
 ]);
 const WEAPON_DISPLAY_SIZE_MULTIPLIER = 1.72;
-const WEAPON_PARKING_OUTWARD_OFFSET = TILE_SIZE * 0.86;
+const WEAPON_PARKING_OUTWARD_OFFSET = TILE_SIZE * 0.72;
 const WEAPON_FROM_TOKEN_CENTER_OFFSET = TOKEN_RADIUS * 0.58;
 const WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT = Object.freeze([
-  TILE_SIZE * 0.52,
+  TILE_SIZE * 0.44,
+  TILE_SIZE * 0.42,
   TILE_SIZE * 0.5,
-  TILE_SIZE * 0.62,
-  TILE_SIZE * 0.5
+  TILE_SIZE * 0.42
 ]);
 const WEAPON_TOKEN_GAP = TILE_SIZE * 0.004;
 const WEAPON_PARKED_Y_DROP_BY_KIND = Object.freeze({
@@ -306,28 +306,28 @@ const WEAPON_REST_HEIGHT_OFFSET_BY_SEAT = Object.freeze([
 // Positive radial moves items visually toward each chair/edge on screen.
 const TOKEN_PORTRAIT_SCREEN_SHIFT_BY_SEAT = Object.freeze([
   // Bottom seat (yellow): bottom-left marker near logo plate.
-  Object.freeze({ radial: TILE_SIZE * 1.22, lateral: TILE_SIZE * 1.06, y: TILE_SIZE * 0.12 }),
+  Object.freeze({ radial: TILE_SIZE * 1.02, lateral: TILE_SIZE * 1.06, y: TILE_SIZE * 0.12 }),
   // Right seat (yellow): upper marker above side-center.
-  Object.freeze({ radial: TILE_SIZE * 0.86, lateral: -TILE_SIZE * 1.1, y: TILE_SIZE * 0.12 }),
+  Object.freeze({ radial: TILE_SIZE * 0.72, lateral: -TILE_SIZE * 1.1, y: TILE_SIZE * 0.12 }),
   // Top seat (yellow): push toward top player while nudging inward toward board center.
-  Object.freeze({ radial: TILE_SIZE * 1.56, lateral: -TILE_SIZE * 0.72, y: TILE_SIZE * 0.14 }),
+  Object.freeze({ radial: TILE_SIZE * 1.3, lateral: -TILE_SIZE * 0.72, y: TILE_SIZE * 0.14 }),
   // Left seat (yellow): upper marker above side-center.
-  Object.freeze({ radial: TILE_SIZE * 0.86, lateral: TILE_SIZE * 1.1, y: TILE_SIZE * 0.12 })
+  Object.freeze({ radial: TILE_SIZE * 0.72, lateral: TILE_SIZE * 1.1, y: TILE_SIZE * 0.12 })
 ]);
 const WEAPON_PORTRAIT_SCREEN_SHIFT_BY_SEAT = Object.freeze([
   // Bottom seat (red): bottom-right marker.
-  Object.freeze({ radial: TILE_SIZE * 1.46, lateral: -TILE_SIZE * 1.08, y: TILE_SIZE * 1.2 }),
+  Object.freeze({ radial: TILE_SIZE * 1.18, lateral: -TILE_SIZE * 1.08, y: TILE_SIZE * 1.2 }),
   // Right seat (red): lower side marker.
-  Object.freeze({ radial: TILE_SIZE * 1.1, lateral: TILE_SIZE * 0.96, y: TILE_SIZE * 1.2 }),
+  Object.freeze({ radial: TILE_SIZE * 0.88, lateral: TILE_SIZE * 0.96, y: TILE_SIZE * 1.2 }),
   // Top seat (red): push toward top player while nudging inward toward board center.
-  Object.freeze({ radial: TILE_SIZE * 1.8, lateral: TILE_SIZE * 0.72, y: TILE_SIZE * 1.28 }),
+  Object.freeze({ radial: TILE_SIZE * 1.46, lateral: TILE_SIZE * 0.72, y: TILE_SIZE * 1.28 }),
   // Left seat (red): lower side marker.
-  Object.freeze({ radial: TILE_SIZE * 1.1, lateral: -TILE_SIZE * 0.96, y: TILE_SIZE * 1.2 })
+  Object.freeze({ radial: TILE_SIZE * 0.88, lateral: -TILE_SIZE * 0.96, y: TILE_SIZE * 1.2 })
 ]);
 const WEAPON_TABLE_SURFACE_Y_OFFSET = TILE_SIZE * 0.52;
 const WEAPON_PARKING_SIDE_EXTRA_RADIUS = TILE_SIZE * 0.2;
 const WEAPON_PARKING_Y_FROM_GROUND_FLOOR = TOKEN_HEIGHT * 1.02;
-const PARKING_TOP_SCREEN_WORLD_SHIFT = TILE_SIZE * 0.58;
+const PARKING_TOP_SCREEN_WORLD_SHIFT = TILE_SIZE * 0.78;
 const PARKING_VERTICAL_LIFT = TILE_SIZE * 0.14;
 
 const PAVEMENT_EXTRA_SCALE = 1.18;


### PR DESCRIPTION
### Motivation
- Move parked weapons and reserve tokens on portrait phones visually higher on the screen and pull them closer to the board center to match the requested UI adjustments.
- Keep seat-aware layout and lateral separation intact while tuning radial offsets and global parking shift for better on-screen composition.

### Description
- Updated layout constants in `webapp/src/components/SnakeBoard3D.jsx` to reposition items for portrait screens by increasing `PARKING_TOP_SCREEN_WORLD_SHIFT` and `PARKING_VERTICAL_LIFT` usage. 
- Reduced global weapon outward offset by changing `WEAPON_PARKING_OUTWARD_OFFSET` and tightened per-seat outward offsets in `WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT` to pull weapon holders inward. 
- Pulled token and weapon portrait placement inward by reducing radial values in `TOKEN_PORTRAIT_SCREEN_SHIFT_BY_SEAT` and `WEAPON_PORTRAIT_SCREEN_SHIFT_BY_SEAT` respectively. 
- Minor numeric tweaks only; no behavior or rendering logic branches were changed, only constants used by the positioning math.

### Testing
- Attempted a lint run with `npm run -s lint -- webapp/src/components/SnakeBoard3D.jsx`, which produced a React-version warning and did not complete to a full result in this environment. 
- Confirmed the modified file with `git diff --name-only HEAD~1 HEAD` and committed the change; no unit or integration tests were run for visual adjustments.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb3317c4848329bf96d73c3f8986c2)