### PR TITLE
Adjust Snake & Ladder token and weapon parking for portrait alignment

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -253,10 +253,10 @@ const TOKEN_REST_LATERAL_BY_SEAT = Object.freeze(new Array(DEFAULT_PLAYER_COUNT)
 // Seat order: 0=bottom, 1=right, 2=top, 3=left (portrait screen orientation).
 // Pull bottom/side reserve tokens inwards so they sit on the wooden rim near each seat.
 const TOKEN_REST_EXTRA_RADIAL_BY_SEAT = Object.freeze([
-  -TILE_SIZE * 0.08,
-  -TILE_SIZE * 0.06,
+  -TILE_SIZE * 0.14,
   -TILE_SIZE * 0.12,
-  -TILE_SIZE * 0.06
+  -TILE_SIZE * 0.2,
+  -TILE_SIZE * 0.12
 ]);
 const SEAT_RAIL_DICE_GAP = Math.max(DICE_SIZE * 0.95, TOKEN_RADIUS * 2.75);
 const SEAT_RAIL_SLOT_OFFSET = SEAT_RAIL_DICE_GAP * 0.16;
@@ -306,28 +306,28 @@ const WEAPON_REST_HEIGHT_OFFSET_BY_SEAT = Object.freeze([
 // Positive radial moves items visually toward each chair/edge on screen.
 const TOKEN_PORTRAIT_SCREEN_SHIFT_BY_SEAT = Object.freeze([
   // Bottom seat (yellow): bottom-left marker near logo plate.
-  Object.freeze({ radial: TILE_SIZE * 0.72, lateral: TILE_SIZE * 0.72, y: TILE_SIZE * 0.18 }),
+  Object.freeze({ radial: TILE_SIZE * 0.52, lateral: TILE_SIZE * 0.64, y: TILE_SIZE * 0.22 }),
   // Right seat (yellow): upper marker above side-center.
-  Object.freeze({ radial: TILE_SIZE * 0.5, lateral: -TILE_SIZE * 0.78, y: TILE_SIZE * 0.18 }),
+  Object.freeze({ radial: TILE_SIZE * 0.34, lateral: -TILE_SIZE * 0.7, y: TILE_SIZE * 0.22 }),
   // Top seat (yellow): push toward top player while nudging inward toward board center.
-  Object.freeze({ radial: TILE_SIZE * 1.04, lateral: -TILE_SIZE * 0.48, y: TILE_SIZE * 0.22 }),
+  Object.freeze({ radial: TILE_SIZE * 0.86, lateral: -TILE_SIZE * 0.42, y: TILE_SIZE * 0.26 }),
   // Left seat (yellow): upper marker above side-center.
-  Object.freeze({ radial: TILE_SIZE * 0.5, lateral: TILE_SIZE * 0.78, y: TILE_SIZE * 0.18 })
+  Object.freeze({ radial: TILE_SIZE * 0.34, lateral: TILE_SIZE * 0.7, y: TILE_SIZE * 0.22 })
 ]);
 const WEAPON_PORTRAIT_SCREEN_SHIFT_BY_SEAT = Object.freeze([
   // Bottom seat (red): bottom-right marker.
-  Object.freeze({ radial: TILE_SIZE * 1.02, lateral: -TILE_SIZE * 0.86, y: TILE_SIZE * 1.34 }),
+  Object.freeze({ radial: TILE_SIZE * 0.8, lateral: -TILE_SIZE * 0.78, y: TILE_SIZE * 1.42 }),
   // Right seat (red): lower side marker.
-  Object.freeze({ radial: TILE_SIZE * 0.76, lateral: TILE_SIZE * 0.76, y: TILE_SIZE * 1.34 }),
+  Object.freeze({ radial: TILE_SIZE * 0.58, lateral: TILE_SIZE * 0.68, y: TILE_SIZE * 1.42 }),
   // Top seat (red): push toward top player while nudging inward toward board center.
-  Object.freeze({ radial: TILE_SIZE * 1.3, lateral: TILE_SIZE * 0.56, y: TILE_SIZE * 1.42 }),
+  Object.freeze({ radial: TILE_SIZE * 1.06, lateral: TILE_SIZE * 0.48, y: TILE_SIZE * 1.5 }),
   // Left seat (red): lower side marker.
-  Object.freeze({ radial: TILE_SIZE * 0.76, lateral: -TILE_SIZE * 0.76, y: TILE_SIZE * 1.34 })
+  Object.freeze({ radial: TILE_SIZE * 0.58, lateral: -TILE_SIZE * 0.68, y: TILE_SIZE * 1.42 })
 ]);
 const WEAPON_TABLE_SURFACE_Y_OFFSET = TILE_SIZE * 0.52;
 const WEAPON_PARKING_SIDE_EXTRA_RADIUS = TILE_SIZE * 0.2;
 const WEAPON_PARKING_Y_FROM_GROUND_FLOOR = TOKEN_HEIGHT * 1.02;
-const PARKING_TOP_SCREEN_WORLD_SHIFT = TILE_SIZE * 0.92;
+const PARKING_TOP_SCREEN_WORLD_SHIFT = TILE_SIZE * 1.08;
 const PARKING_VERTICAL_LIFT = TILE_SIZE * 0.2;
 
 const PAVEMENT_EXTRA_SCALE = 1.18;


### PR DESCRIPTION
### Motivation
- Improve visual layout on portrait phones by moving parked weapons and token anchors higher on the screen and pulling idle player tokens more inward toward the board center.
- Address UX requests to make weapons/parking and tokens appear closer to the top-center area so they match the mobile portrait composition.

### Description
- Tuned reserve token radial offsets in `webapp/src/components/SnakeBoard3D.jsx` (`TOKEN_REST_EXTRA_RADIAL_BY_SEAT`) to pull idle tokens slightly more inward toward the board center.
- Adjusted portrait token parking presets (`TOKEN_PORTRAIT_SCREEN_SHIFT_BY_SEAT`) to move token markers visually higher and slightly more centered for each seat.
- Updated weapon parking presets (`WEAPON_PORTRAIT_SCREEN_SHIFT_BY_SEAT`) and increased the global `PARKING_TOP_SCREEN_WORLD_SHIFT` so parked weapons render higher and less outward on portrait screens.
- Changes are confined to layout constants and screen-shift math in `SnakeBoard3D.jsx` and do not modify runtime logic.

### Testing
- Built the web app with `npm --prefix webapp run build` and the production build completed successfully (warnings only, no errors).
- Verified the modified file `webapp/src/components/SnakeBoard3D.jsx` compiles as part of the build and the bundle was produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb3af6b4b0832989bb6868f34c63d0)