### PR TITLE
Adjust Snake & Ladder parked token and weapon placement for portrait view

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -277,13 +277,13 @@ const WEAPON_SLOT_LATERAL_NUDGE_BY_SEAT = Object.freeze([
   0
 ]);
 const WEAPON_DISPLAY_SIZE_MULTIPLIER = 1.72;
-const WEAPON_PARKING_OUTWARD_OFFSET = TILE_SIZE * 0.72;
+const WEAPON_PARKING_OUTWARD_OFFSET = TILE_SIZE * 0.8;
 const WEAPON_FROM_TOKEN_CENTER_OFFSET = TOKEN_RADIUS * 0.58;
 const WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT = Object.freeze([
-  TILE_SIZE * 0.3,
-  TILE_SIZE * 0.28,
   TILE_SIZE * 0.36,
-  TILE_SIZE * 0.28
+  TILE_SIZE * 0.34,
+  TILE_SIZE * 0.42,
+  TILE_SIZE * 0.34
 ]);
 const WEAPON_TOKEN_GAP = TILE_SIZE * 0.004;
 const WEAPON_PARKED_Y_DROP_BY_KIND = Object.freeze({
@@ -306,23 +306,23 @@ const WEAPON_REST_HEIGHT_OFFSET_BY_SEAT = Object.freeze([
 // Positive radial moves items visually toward each chair/edge on screen.
 const TOKEN_PORTRAIT_SCREEN_SHIFT_BY_SEAT = Object.freeze([
   // Bottom seat (yellow): bottom-left marker near logo plate.
-  Object.freeze({ radial: TILE_SIZE * 0.3, lateral: TILE_SIZE * 0.64, y: TILE_SIZE * 0.34 }),
+  Object.freeze({ radial: TILE_SIZE * 0.18, lateral: TILE_SIZE * 0.64, y: TILE_SIZE * 0.5 }),
   // Right seat (yellow): upper marker above side-center.
-  Object.freeze({ radial: TILE_SIZE * 0.18, lateral: -TILE_SIZE * 0.7, y: TILE_SIZE * 0.34 }),
+  Object.freeze({ radial: TILE_SIZE * 0.08, lateral: -TILE_SIZE * 0.7, y: TILE_SIZE * 0.5 }),
   // Top seat (yellow): push toward top player while nudging inward toward board center.
-  Object.freeze({ radial: TILE_SIZE * 0.62, lateral: -TILE_SIZE * 0.42, y: TILE_SIZE * 0.38 }),
+  Object.freeze({ radial: TILE_SIZE * 0.52, lateral: -TILE_SIZE * 0.42, y: TILE_SIZE * 0.56 }),
   // Left seat (yellow): upper marker above side-center.
-  Object.freeze({ radial: TILE_SIZE * 0.18, lateral: TILE_SIZE * 0.7, y: TILE_SIZE * 0.34 })
+  Object.freeze({ radial: TILE_SIZE * 0.08, lateral: TILE_SIZE * 0.7, y: TILE_SIZE * 0.5 })
 ]);
 const WEAPON_PORTRAIT_SCREEN_SHIFT_BY_SEAT = Object.freeze([
   // Bottom seat (red): bottom-right marker.
-  Object.freeze({ radial: TILE_SIZE * 0.62, lateral: -TILE_SIZE * 0.78, y: TILE_SIZE * 1.58 }),
+  Object.freeze({ radial: TILE_SIZE * 0.72, lateral: -TILE_SIZE * 0.78, y: TILE_SIZE * 1.72 }),
   // Right seat (red): lower side marker.
-  Object.freeze({ radial: TILE_SIZE * 0.42, lateral: TILE_SIZE * 0.68, y: TILE_SIZE * 1.58 }),
+  Object.freeze({ radial: TILE_SIZE * 0.5, lateral: TILE_SIZE * 0.68, y: TILE_SIZE * 1.72 }),
   // Top seat (red): push toward top player while nudging inward toward board center.
-  Object.freeze({ radial: TILE_SIZE * 0.84, lateral: TILE_SIZE * 0.48, y: TILE_SIZE * 1.66 }),
+  Object.freeze({ radial: TILE_SIZE * 0.96, lateral: TILE_SIZE * 0.48, y: TILE_SIZE * 1.8 }),
   // Left seat (red): lower side marker.
-  Object.freeze({ radial: TILE_SIZE * 0.42, lateral: -TILE_SIZE * 0.68, y: TILE_SIZE * 1.58 })
+  Object.freeze({ radial: TILE_SIZE * 0.5, lateral: -TILE_SIZE * 0.68, y: TILE_SIZE * 1.72 })
 ]);
 const WEAPON_TABLE_SURFACE_Y_OFFSET = TILE_SIZE * 0.52;
 const WEAPON_PARKING_SIDE_EXTRA_RADIUS = TILE_SIZE * 0.2;


### PR DESCRIPTION
### Motivation
- Improve portrait UX by moving parked weapons slightly outward and upward and pulling reserve player tokens visually higher and closer to the board center.

### Description
- Tuned token parking calibration constants in `webapp/src/components/SnakeBoard3D.jsx` by updating `TOKEN_PORTRAIT_SCREEN_SHIFT_BY_SEAT` to reduce radial push and increase vertical offset for portrait seats.
- Tuned weapon parking by increasing `WEAPON_PARKING_OUTWARD_OFFSET` and adjusting `WEAPON_PARKING_OUTWARD_OFFSET_BY_SEAT` to place parked weapons a bit farther from center.
- Increased vertical and radial portrait offsets for weapons by updating `WEAPON_PORTRAIT_SCREEN_SHIFT_BY_SEAT` so weapons render slightly higher on portrait screens.
- Changes are limited to seat/parking calibration constants and do not alter gameplay logic or public APIs.

### Testing
- Ran the production build with `cd webapp && npm run build`, which completed successfully.
- Verified the modified file is `webapp/src/components/SnakeBoard3D.jsx` and the app bundles were rebuilt without build failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb41af8ce08329b5e9e60264c54fd3)