### PR TITLE
Add seated humanoid models and idle/place/knock animations; align seat badges to head bone

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -6248,23 +6248,27 @@ function updateSeatBadgePositions() {
   chairs.forEach((wrapper, idx) => {
     const badge = seatBadges[idx];
     if (!badge) return;
-    const world = wrapper.getWorldPosition(projectedSeatTarget);
-    world.y +=
-      CHAIR_DIMENSIONS.seatThickness + CHAIR_DIMENSIONS.backHeight * 0.62;
+    const seatHuman = seatedHumans[idx];
+    let world = null;
+    if (seatHuman?.headBone) {
+      world = seatHuman.headBone.getWorldPosition(projectedSeatTarget);
+      world.y += 0.08;
+    } else {
+      world = wrapper.getWorldPosition(projectedSeatTarget);
+      world.y +=
+        CHAIR_DIMENSIONS.seatThickness + CHAIR_DIMENSIONS.backHeight * 0.62;
+    }
     world.project(camera);
     const projectedX = (world.x * 0.5 + 0.5) * rect.width + rect.left;
     const projectedY = (1 - (world.y * 0.5 + 0.5)) * rect.height + rect.top;
-    let x = projectedX;
-    let y = projectedY;
+    const x = projectedX;
+    const y = projectedY;
     if (idx === human) {
-      const anchorX =
-        rect.left + rect.width * 0.5 + HUMAN_SEAT_BADGE_LEFT_OFFSET;
-      const anchorY = rect.top + rect.height - HUMAN_SEAT_BADGE_BOTTOM_OFFSET;
+      const anchorX = projectedX;
+      const anchorY = projectedY;
       if (!humanSeatBadgeAnchor) humanSeatBadgeAnchor = { x: anchorX, y: anchorY };
       humanSeatBadgeAnchor.x = anchorX;
       humanSeatBadgeAnchor.y = anchorY;
-      x = humanSeatBadgeAnchor.x;
-      y = humanSeatBadgeAnchor.y;
     }
     badge.style.left = `${x}px`;
     badge.style.top = `${y}px`;
@@ -6356,12 +6360,11 @@ function createSeatBadge({ avatar = '🎯', name = '', isSelf = false } = {}) {
   applyBadgeAvatar(core, avatar);
   avatarWrap.appendChild(core);
 
-  wrap.appendChild(avatarWrap);
-
   const label = document.createElement('span');
   label.className = 'seat-badge-name';
   label.textContent = name || '';
   wrap.appendChild(label);
+  wrap.appendChild(avatarWrap);
 
   seatOverlay.appendChild(wrap);
   return wrap;
@@ -7673,6 +7676,262 @@ const CHAIR_TEXTURE_PROPS = Object.freeze([
   'sheenColorMap',
   'sheenRoughnessMap'
 ]);
+const HUMAN_MODEL_SOURCE = Object.freeze({
+  label: 'Xbot Mixamo humanoid',
+  url: 'https://threejs.org/examples/models/gltf/Xbot.glb',
+  scale: 1.16
+});
+const HUMAN_PROFILE_ROTATION_Y = -Math.PI / 2;
+const HUMAN_SEAT_TUNE = Object.freeze({
+  chairHeightRatio: 0.98,
+  chairDepthRatio: 0.24,
+  scaleBoost: 1.42
+});
+let humanTemplatePromise = null;
+const seatedHumans = [];
+
+function normalizeHumanBoneName(value = '') {
+  return String(value).toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+function getModelBones(root) {
+  const bones = [];
+  root.traverse((obj) => {
+    if (obj?.isBone) bones.push(obj);
+  });
+  return bones;
+}
+
+function findModelBone(bones, aliases = []) {
+  const normalizedAliases = aliases.map((alias) => normalizeHumanBoneName(alias));
+  for (const alias of normalizedAliases) {
+    const exact = bones.find((bone) => normalizeHumanBoneName(bone.name) === alias);
+    if (exact) return exact;
+  }
+  for (const alias of normalizedAliases) {
+    const partial = bones.find((bone) => normalizeHumanBoneName(bone.name).includes(alias));
+    if (partial) return partial;
+  }
+  return null;
+}
+
+function captureModelRestPose(root) {
+  const rest = new Map();
+  getModelBones(root).forEach((bone) => rest.set(bone, bone.quaternion.clone()));
+  return rest;
+}
+
+function composeModelBone(rest, bone, euler) {
+  if (!bone) return;
+  const base = rest.get(bone);
+  if (!base) return;
+  bone.quaternion.copy(base).multiply(new THREE.Quaternion().setFromEuler(euler));
+}
+
+function buildHumanBoneMap(root) {
+  const bones = getModelBones(root);
+  const map = {
+    hips: findModelBone(bones, ['hips', 'mixamorighips', 'pelvis', 'wolf3dhips']),
+    spine: findModelBone(bones, ['spine', 'mixamorigspine', 'wolf3dspine']),
+    spine1: findModelBone(bones, ['spine1', 'spine01', 'mixamorigspine1', 'chest']),
+    spine2: findModelBone(bones, ['spine2', 'spine02', 'mixamorigspine2', 'upperchest']),
+    neck: findModelBone(bones, ['neck', 'mixamorigneck', 'wolf3dneck']),
+    head: findModelBone(bones, ['head', 'mixamorighead', 'wolf3dhead']),
+    leftShoulder: findModelBone(bones, ['leftshoulder', 'mixamorigleftshoulder']),
+    leftArm: findModelBone(bones, ['leftarm', 'mixamorigleftarm', 'leftupperarm']),
+    leftForeArm: findModelBone(bones, ['leftforearm', 'mixamorigleftforearm', 'leftlowerarm']),
+    rightShoulder: findModelBone(bones, ['rightshoulder', 'mixamorigrightshoulder']),
+    rightArm: findModelBone(bones, ['rightarm', 'mixamorigrightarm', 'rightupperarm']),
+    rightForeArm: findModelBone(bones, ['rightforearm', 'mixamorigrightforearm', 'rightlowerarm']),
+    leftUpLeg: findModelBone(bones, ['leftupleg', 'mixamorigleftupleg', 'leftthigh']),
+    leftLeg: findModelBone(bones, ['leftleg', 'mixamorigleftleg', 'leftcalf']),
+    rightUpLeg: findModelBone(bones, ['rightupleg', 'mixamorigrightupleg', 'rightthigh']),
+    rightLeg: findModelBone(bones, ['rightleg', 'mixamorigrightleg', 'rightcalf'])
+  };
+  map.spine ??= map.spine1 ?? map.spine2 ?? map.hips;
+  map.spine1 ??= map.spine2 ?? map.spine;
+  map.spine2 ??= map.spine1 ?? map.spine;
+  map.leftArm ??= map.leftShoulder;
+  map.rightArm ??= map.rightShoulder;
+  map.leftForeArm ??= map.leftArm;
+  map.rightForeArm ??= map.rightArm;
+  map.leftLeg ??= map.leftUpLeg;
+  map.rightLeg ??= map.rightUpLeg;
+  return map;
+}
+
+function settleHumanHips(root, hips, targetHipY, targetHipZ, tmp = new THREE.Vector3()) {
+  if (!hips) return;
+  root.updateMatrixWorld(true);
+  hips.getWorldPosition(tmp);
+  root.position.x += -tmp.x;
+  root.position.y += targetHipY - tmp.y;
+  root.position.z += targetHipZ - tmp.z;
+  root.updateMatrixWorld(true);
+}
+
+function applyLoadedHumanPose(seatHuman, timeSeconds, actionStrength = 0, knockStrength = 0) {
+  const { root, bones, rest, baseScale = 1, targetHipY = 0.76, targetHipZ = -0.2 } = seatHuman;
+  rest.forEach((quat, bone) => bone.quaternion.copy(quat));
+  const breathe = Math.sin(timeSeconds * 1.1) * 0.018;
+  root.scale.setScalar(baseScale);
+  root.rotation.y = HUMAN_PROFILE_ROTATION_Y;
+  root.position.set(0, 0, 0);
+
+  composeModelBone(rest, bones.hips, new THREE.Euler(-0.08 - knockStrength * 0.05, 0, 0, 'XYZ'));
+  composeModelBone(rest, bones.spine, new THREE.Euler(0.34 + breathe - knockStrength * 0.08, 0, 0, 'XYZ'));
+  composeModelBone(rest, bones.spine1, new THREE.Euler(0.22, 0, 0, 'XYZ'));
+  composeModelBone(rest, bones.spine2, new THREE.Euler(0.12, 0, 0, 'XYZ'));
+  composeModelBone(rest, bones.neck, new THREE.Euler(-0.08, 0, 0, 'XYZ'));
+  composeModelBone(
+    rest,
+    bones.head,
+    new THREE.Euler(-0.1 - knockStrength * 0.02, Math.sin(timeSeconds * 0.33) * 0.03, 0, 'XYZ')
+  );
+
+  composeModelBone(rest, bones.leftUpLeg, new THREE.Euler(-1.52, 0.09, 0.06, 'XYZ'));
+  composeModelBone(rest, bones.rightUpLeg, new THREE.Euler(-1.52, -0.09, -0.06, 'XYZ'));
+  composeModelBone(rest, bones.leftLeg, new THREE.Euler(1.57, 0, 0, 'XYZ'));
+  composeModelBone(rest, bones.rightLeg, new THREE.Euler(1.57, 0, 0, 'XYZ'));
+
+  const rightReach = actionStrength;
+  const rightKnock = knockStrength;
+  composeModelBone(rest, bones.leftShoulder, new THREE.Euler(-0.04, 0.06, -0.12, 'XYZ'));
+  composeModelBone(rest, bones.leftArm, new THREE.Euler(-0.65, 0.22, -0.18, 'XYZ'));
+  composeModelBone(rest, bones.leftForeArm, new THREE.Euler(-0.95, 0.08, -0.04, 'XYZ'));
+
+  composeModelBone(
+    rest,
+    bones.rightShoulder,
+    new THREE.Euler(-0.04 + rightReach * 0.4 - rightKnock * 0.22, -0.08 - rightReach * 0.08, 0.12, 'XYZ')
+  );
+  composeModelBone(
+    rest,
+    bones.rightArm,
+    new THREE.Euler(-0.65 + rightReach * 1.95 + rightKnock * 1.1, -0.22 - rightReach * 0.32, 0.18, 'XYZ')
+  );
+  composeModelBone(
+    rest,
+    bones.rightForeArm,
+    new THREE.Euler(-0.95 + rightReach * 1.72 + rightKnock * 1.7, -0.08, 0.04, 'XYZ')
+  );
+}
+
+async function ensureHumanTemplate() {
+  if (humanTemplatePromise) return humanTemplatePromise;
+  humanTemplatePromise = (async () => {
+    try {
+      const loader = new GLTFLoader();
+      loader.setCrossOrigin('anonymous');
+      const gltf = await new Promise((resolve, reject) => {
+        loader.load(HUMAN_MODEL_SOURCE.url, resolve, undefined, reject);
+      });
+      const root = gltf?.scene;
+      if (!root) throw new Error('scene missing');
+      root.traverse((obj) => {
+        if (!obj?.isMesh) return;
+        obj.castShadow = true;
+        obj.receiveShadow = true;
+      });
+      root.scale.setScalar(HUMAN_MODEL_SOURCE.scale);
+      return { source: HUMAN_MODEL_SOURCE, template: root };
+    } catch (error) {
+      console.error('Failed to load Xbot seated model', error);
+      return null;
+    }
+  })();
+  return humanTemplatePromise;
+}
+
+function clearSeatedHumans() {
+  while (seatedHumans.length) {
+    const seatHuman = seatedHumans.pop();
+    seatHuman?.root?.parent?.remove(seatHuman.root);
+    seatHuman?.root?.traverse?.((obj) => {
+      if (obj?.isMesh && obj.geometry?.dispose) obj.geometry.dispose();
+      const materials = Array.isArray(obj?.material) ? obj.material : [obj?.material];
+      materials.forEach((material) => material?.dispose?.());
+    });
+  }
+}
+
+function triggerSeatHumanAction(seatIndex, action = 'place') {
+  const seatHuman = seatedHumans[seatIndex];
+  if (!seatHuman) return;
+  const now = performance.now();
+  if (action === 'knock') {
+    seatHuman.action = { type: 'knock', startMs: now, durationMs: 760 };
+    return;
+  }
+  seatHuman.action = { type: 'place', startMs: now, durationMs: 980 };
+}
+
+function syncSeatHumans(nowMs = performance.now()) {
+  if (!seatedHumans.length) return;
+  const nowSeconds = nowMs / 1000;
+  seatedHumans.forEach((seatHuman) => {
+    if (!seatHuman?.root) return;
+    let placeStrength = 0;
+    let knockStrength = 0;
+    if (seatHuman.action) {
+      const progress = Math.min(
+        1,
+        Math.max(0, (nowMs - seatHuman.action.startMs) / Math.max(1, seatHuman.action.durationMs))
+      );
+      if (seatHuman.action.type === 'place') {
+        placeStrength = Math.pow(Math.sin(progress * Math.PI), 0.72);
+      } else if (seatHuman.action.type === 'knock') {
+        knockStrength = Math.sin(progress * Math.PI * 3.1) * (1 - progress * 0.85);
+      }
+      if (progress >= 1) {
+        seatHuman.action = null;
+      }
+    }
+    applyLoadedHumanPose(seatHuman, nowSeconds, placeStrength, knockStrength);
+    settleHumanHips(
+      seatHuman.root,
+      seatHuman.bones?.hips,
+      seatHuman.targetHipY,
+      seatHuman.targetHipZ,
+      projectedSeatTarget
+    );
+  });
+}
+
+async function placeSeatedHumans(seatBottomOffset, chairSize) {
+  clearSeatedHumans();
+  const humanTemplateData = await ensureHumanTemplate();
+  if (!humanTemplateData?.template) return;
+  const seatTopY = chairSize.y - seatBottomOffset;
+  const targetHipY = seatTopY + seatBottomOffset - chairSize.y * 0.08;
+  const targetHipZ = -chairSize.z * HUMAN_SEAT_TUNE.chairDepthRatio;
+  CHAIR_SEAT_ANGLES.forEach((angle, index) => {
+    const wrapper = chairs[index];
+    if (!wrapper) return;
+    const root = humanTemplateData.template.clone(true);
+    root.position.set(0, 0, 0);
+    wrapper.add(root);
+    const bounds = new THREE.Box3().setFromObject(root);
+    const size = bounds.getSize(new THREE.Vector3());
+    const height = Math.max(0.2, size.y);
+    const targetHeight = Math.max(0.75, chairSize.y * 2.55 * HUMAN_SEAT_TUNE.chairHeightRatio);
+    const scaleFix = (targetHeight / height) * HUMAN_SEAT_TUNE.scaleBoost;
+    root.scale.multiplyScalar(scaleFix);
+    const bones = buildHumanBoneMap(root);
+    const seatHuman = {
+      root,
+      action: null,
+      bones,
+      rest: captureModelRestPose(root),
+      baseScale: 1,
+      targetHipY,
+      targetHipZ,
+      headBone: bones.head
+    };
+    seatedHumans[index] = seatHuman;
+    triggerSeatHumanAction(index, 'place');
+  });
+}
 
 function disposeChairResources(root) {
   root.traverse((child) => {
@@ -7715,8 +7974,9 @@ function placeChairsWithOption(option, chairData, token) {
   }
 
   const seatBottomOffset = -chairTemplateBounds.min.y;
+  const chairSize = chairTemplateBounds.getSize(new THREE.Vector3());
   const labelHeight = seatBottomOffset + chairTemplateBounds.max.y + 0.12;
-  const labelDepth = -chairTemplateBounds.getSize(new THREE.Vector3()).z * 0.35;
+  const labelDepth = -chairSize.z * 0.35;
 
   const seatAvatarSources = buildSeatAvatarSources(N);
 
@@ -7749,6 +8009,9 @@ function placeChairsWithOption(option, chairData, token) {
   });
 
   refreshSeatBadges(seatAvatarSources, buildSeatNames(N));
+  placeSeatedHumans(seatBottomOffset, chairSize).catch((error) => {
+    console.warn('Failed to place seated humans', error);
+  });
   syncArenaGroundToFurniture();
 }
 
@@ -9230,6 +9493,7 @@ function placeOnBoard(tile, side, options = {}) {
   } else {
     renderChain();
   }
+  triggerSeatHumanAction(current, 'place');
   SFX.place();
   return { success: true, segment, end: updatedEnd };
 }
@@ -10302,6 +10566,7 @@ function schedulePassTurnAdvance(
   playerIndex = current,
   delayMs = PASS_TURN_ADVANCE_DELAY_MS
 ) {
+  triggerSeatHumanAction(playerIndex, 'knock');
   showPassBubble(playerIndex);
   if (pendingTurnAdvanceTimeout) {
     clearTimeout(pendingTurnAdvanceTimeout);
@@ -10744,6 +11009,7 @@ function shutdownDominoRoyal(reason = 'unknown') {
     anchoredSelfVideoElement = null;
     controls.enabled = false;
     scene.visible = false;
+    clearSeatedHumans();
     if (seatOverlay?.parentNode) {
       seatOverlay.parentNode.removeChild(seatOverlay);
     }
@@ -10786,6 +11052,7 @@ function tick(now) {
     updateEntrySequence(current);
     updateDrawAnimations(current);
     updatePlacementAnimations(current);
+    syncSeatHumans(current);
     updateWinnerHighlight(current);
     updateSeatBadgePositions();
     updateCameraLookRecentering();


### PR DESCRIPTION
### Motivation
- Introduce seated humanoid models to chairs to make player seats more lifelike and to animate interactions like placing a tile and knocking when passing.
- Improve seat badge positioning by anchoring badges to the model head when available so overlays track the avatar more accurately.
- Provide robust bone mapping and pose application for different GLTF humanoid rigs.

### Description
- Added a human model pipeline including `HUMAN_MODEL_SOURCE`, `ensureHumanTemplate`, `placeSeatedHumans`, `clearSeatedHumans`, `buildHumanBoneMap`, `captureModelRestPose`, `applyLoadedHumanPose`, and `settleHumanHips` to load, clone, scale, place and animate seated humanoid models in chairs.
- Implemented bone utilities `getModelBones`, `findModelBone`, `normalizeHumanBoneName`, and `composeModelBone` to robustly map and manipulate bones across varying model naming conventions.
- Integrated seated humans into the chair placement flow by calling `placeSeatedHumans` from `placeChairsWithOption` and added `seatedHumans` state tracking; added `syncSeatHumans` into the main `tick` loop to update poses each frame.
- Added interaction triggers `triggerSeatHumanAction` and invoked it on tile placement (`placeOnBoard`) and on scheduled pass advance (`schedulePassTurnAdvance`) to play `place` and `knock` animations respectively.
- Updated seat badge positioning in `updateSeatBadgePositions` to prefer each seat model's `head` bone world position when present and adjusted anchor logic for the human seat; moved avatar DOM insertion order in `createSeatBadge` to ensure label placement is consistent.
- Added resource cleanup by clearing seated humans in `shutdownDominoRoyal` and disposing meshes/materials in `clearSeatedHumans` and `disposeChairResources`.

### Testing
- Ran the development build and visually verified that humanoid models load onto chairs, animate on tile placement and pass (place/knock), and that seat badges follow model heads; visual checks succeeded.
- Ran existing automated test suite and linter locally (`npm test` / `npm run lint`) with no regressions reported.  No new automated unit tests were added for the 3D model behaviors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb52e635248329bfd67ccd8ee3a039)