### PR TITLE
Improve seated human rig and dice throw animation (finger grip, pose refinements, spin overhaul)

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1761,8 +1761,8 @@ const CHAIR_MODEL_URLS = [
 const SEATED_HUMAN_MODEL_URL = 'https://threejs.org/examples/models/gltf/readyplayer.me.glb';
 const SEATED_HUMAN_BASE_HEIGHT = 1.74;
 const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 1.62;
-const SEATED_HUMAN_SEAT_Y_OFFSET = SEAT_THICKNESS * 0.03;
-const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.09;
+const SEATED_HUMAN_SEAT_Y_OFFSET = -SEAT_THICKNESS * 0.22;
+const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.18;
 const SEATED_HUMAN_ROLL_MS = 1680;
 const SEATED_HUMAN_RECOVER_MS = 420;
 let seatedHumanTemplatePromise = null;
@@ -3936,6 +3936,22 @@ function findBoneByNeedle(bones, ...needles) {
   return null;
 }
 
+function findBoneChainByNeedle(bones, ...needles) {
+  const normalized = bones.map((bone) => ({ bone, name: normalizeBoneName(bone.name) }));
+  const result = [];
+  for (const needle of needles) {
+    const clean = normalizeBoneName(needle);
+    const matched = normalized
+      .filter((entry) => entry.name.includes(clean))
+      .sort((a, b) => a.name.localeCompare(b.name, undefined, { numeric: true }));
+    matched.forEach((entry) => {
+      if (!result.includes(entry.bone)) result.push(entry.bone);
+    });
+    if (result.length) break;
+  }
+  return result.slice(0, 4);
+}
+
 function saveBoneRig(modelRoot) {
   const bones = [];
   modelRoot.traverse((obj) => {
@@ -3967,7 +3983,12 @@ function saveBoneRig(modelRoot) {
     leftHand: findBoneByNeedle(bones, 'lefthand'),
     rightUpperArm: findBoneByNeedle(bones, 'rightarm', 'rightupperarm'),
     rightForeArm: findBoneByNeedle(bones, 'rightforearm', 'rightlowerarm'),
-    rightHand: findBoneByNeedle(bones, 'righthand')
+    rightHand: findBoneByNeedle(bones, 'righthand'),
+    rightThumb: findBoneChainByNeedle(bones, 'righthandthumb', 'rightthumb'),
+    rightIndex: findBoneChainByNeedle(bones, 'righthandindex', 'rightindex'),
+    rightMiddle: findBoneChainByNeedle(bones, 'righthandmiddle', 'rightmiddle'),
+    rightRing: findBoneChainByNeedle(bones, 'righthandring', 'rightring'),
+    rightPinky: findBoneChainByNeedle(bones, 'righthandpinky', 'rightpinky')
   };
 }
 
@@ -3979,22 +4000,22 @@ function resetBoneRig(rig) {
   });
 }
 
-function addBoneRot(rig, bone, x = 0, y = 0, z = 0) {
+function addBoneRot(rig, bone, x = 0, y = 0, z = 0, weight = 1) {
   if (!rig || !bone) return;
   const base = rig.saved.get(bone);
   if (!base) return;
-  bone.rotation.x = base.rotation.x + x;
-  bone.rotation.y = base.rotation.y + y;
-  bone.rotation.z = base.rotation.z + z;
+  bone.rotation.x = base.rotation.x + x * weight;
+  bone.rotation.y = base.rotation.y + y * weight;
+  bone.rotation.z = base.rotation.z + z * weight;
 }
 
-function addBonePos(rig, bone, x = 0, y = 0, z = 0) {
+function addBonePos(rig, bone, x = 0, y = 0, z = 0, weight = 1) {
   if (!rig || !bone) return;
   const base = rig.saved.get(bone);
   if (!base) return;
-  bone.position.x = base.position.x + x;
-  bone.position.y = base.position.y + y;
-  bone.position.z = base.position.z + z;
+  bone.position.x = base.position.x + x * weight;
+  bone.position.y = base.position.y + y * weight;
+  bone.position.z = base.position.z + z * weight;
 }
 
 function smooth01(v) {
@@ -4002,90 +4023,198 @@ function smooth01(v) {
   return t * t * (3 - 2 * t);
 }
 
-function applySeatedHumanPose(rig, mode = 'idle', intensity = 1) {
+function curlFingerChain(rig, chain = [], amount = 0, sideSpread = 0) {
+  const grip = clamp(amount, 0, 1);
+  chain.forEach((bone, index) => {
+    const curl = index === 0 ? -0.38 : -0.72;
+    const side = index === 0 ? sideSpread : sideSpread * 0.25;
+    addBoneRot(rig, bone, curl * grip, 0.03 * grip, side * grip, 1);
+  });
+}
+
+function applyRightHandGrip(rig, gripAmount = 0) {
+  if (!rig) return;
+  const grip = clamp(gripAmount, 0, 1);
+  const open = 1 - grip;
+
+  curlFingerChain(rig, rig.rightIndex, grip, -0.08 + 0.08 * open);
+  curlFingerChain(rig, rig.rightMiddle, grip, -0.02);
+  curlFingerChain(rig, rig.rightRing, grip, 0.04 - 0.04 * open);
+  curlFingerChain(rig, rig.rightPinky, grip, 0.09 - 0.06 * open);
+
+  (rig.rightThumb || []).forEach((bone, index) => {
+    const fold = index === 0 ? -0.28 : -0.48;
+    addBoneRot(rig, bone, fold * grip, -0.24 * grip, 0.22 * grip, 1);
+  });
+}
+
+function applySeatedHumanPose(rig, mode = 'idle', intensity = 1, handGrip = 0) {
   if (!rig) return;
   resetBoneRig(rig);
   const t = smooth01(intensity);
-  addBonePos(rig, rig.hips, 0, -0.28, -0.09);
-  addBoneRot(rig, rig.hips, -0.09, 0, 0);
-  addBoneRot(rig, rig.spine, 0.13, 0, 0);
-  addBoneRot(rig, rig.chest, 0.11, 0, 0);
-  addBoneRot(rig, rig.neck, -0.03, 0, 0);
-  addBoneRot(rig, rig.head, -0.05, 0, 0);
-  addBoneRot(rig, rig.leftUpperLeg, 0.92, -0.07, 0.04);
-  addBoneRot(rig, rig.leftLowerLeg, -1.06, 0, 0);
-  addBoneRot(rig, rig.leftFoot, 0.2, 0, 0);
-  addBoneRot(rig, rig.rightUpperLeg, 0.92, 0.07, -0.04);
-  addBoneRot(rig, rig.rightLowerLeg, -1.06, 0, 0);
-  addBoneRot(rig, rig.rightFoot, 0.2, 0, 0);
-  addBoneRot(rig, rig.leftUpperArm, -0.24, 0.12, 0.9);
-  addBoneRot(rig, rig.leftForeArm, -0.56, 0.04, -0.2);
-  addBoneRot(rig, rig.leftHand, -0.12, 0, 0);
+  const breathe = Math.sin(performance.now() * 0.002) * 0.012;
 
-  let shoulderX = -0.22;
-  let shoulderY = -0.03;
+  addBonePos(rig, rig.hips, 0, -0.31, -0.105, 1);
+  addBoneRot(rig, rig.hips, -0.11, 0, 0, 1);
+  addBoneRot(rig, rig.spine, 0.15 + breathe, 0, 0, 1);
+  addBoneRot(rig, rig.chest, 0.12, 0, 0, 1);
+  addBoneRot(rig, rig.neck, -0.05, 0, 0, 1);
+  addBoneRot(rig, rig.head, -0.06, 0, 0, 1);
+
+  addBoneRot(rig, rig.leftUpperLeg, 0.94, -0.08, 0.04, 1);
+  addBoneRot(rig, rig.leftLowerLeg, -1.08, 0, 0, 1);
+  addBoneRot(rig, rig.leftFoot, 0.22, 0, 0, 1);
+  addBoneRot(rig, rig.rightUpperLeg, 0.94, 0.08, -0.04, 1);
+  addBoneRot(rig, rig.rightLowerLeg, -1.08, 0, 0, 1);
+  addBoneRot(rig, rig.rightFoot, 0.22, 0, 0, 1);
+
+  addBoneRot(rig, rig.leftUpperArm, -0.28, 0.12, 0.96, 1);
+  addBoneRot(rig, rig.leftForeArm, -0.62, 0.05, -0.24, 1);
+  addBoneRot(rig, rig.leftHand, -0.16, 0, 0, 1);
+
+  let shoulderX = -0.20;
+  let shoulderY = -0.02;
   let shoulderZ = -0.72;
-  let forearmX = -0.48;
+  let forearmX = -0.50;
   let forearmY = -0.04;
-  let forearmZ = 0.16;
-  let wristX = -0.05;
-  let wristY = 0.02;
-  let wristZ = 0.04;
+  let forearmZ = 0.14;
+  let wristX = -0.08;
+  let wristY = 0;
+  let wristZ = 0.06;
+  let chestX = 0.12;
+  let chestY = 0;
+  let headX = -0.06;
+  let headY = 0;
 
   if (mode === 'reachDice') {
-    shoulderX = THREE.MathUtils.lerp(shoulderX, -0.68, t);
-    shoulderY = THREE.MathUtils.lerp(shoulderY, -0.1, t);
-    shoulderZ = THREE.MathUtils.lerp(shoulderZ, -1.02, t);
-    forearmX = THREE.MathUtils.lerp(forearmX, -0.84, t);
-    forearmY = THREE.MathUtils.lerp(forearmY, -0.16, t);
-    forearmZ = THREE.MathUtils.lerp(forearmZ, -0.24, t);
-    wristX = THREE.MathUtils.lerp(wristX, -0.18, t);
+    shoulderX = THREE.MathUtils.lerp(shoulderX, -0.70, t);
+    shoulderY = THREE.MathUtils.lerp(shoulderY, -0.08, t);
+    shoulderZ = THREE.MathUtils.lerp(shoulderZ, -1.03, t);
+    forearmX = THREE.MathUtils.lerp(forearmX, -0.86, t);
+    forearmY = THREE.MathUtils.lerp(forearmY, -0.18, t);
+    forearmZ = THREE.MathUtils.lerp(forearmZ, -0.26, t);
+    wristX = THREE.MathUtils.lerp(wristX, -0.20, t);
+    wristY = THREE.MathUtils.lerp(wristY, 0.18, t);
+    wristZ = THREE.MathUtils.lerp(wristZ, -0.18, t);
+    chestX = THREE.MathUtils.lerp(chestX, 0.24, t);
+    chestY = THREE.MathUtils.lerp(chestY, -0.08, t);
+    headX = THREE.MathUtils.lerp(headX, 0.03, t);
+    headY = THREE.MathUtils.lerp(headY, -0.08, t);
+  } else if (mode === 'gripDice') {
+    shoulderX = THREE.MathUtils.lerp(shoulderX, -0.76, t);
+    shoulderY = THREE.MathUtils.lerp(shoulderY, -0.10, t);
+    shoulderZ = THREE.MathUtils.lerp(shoulderZ, -0.96, t);
+    forearmX = THREE.MathUtils.lerp(forearmX, -0.82, t);
+    forearmY = THREE.MathUtils.lerp(forearmY, -0.20, t);
+    forearmZ = THREE.MathUtils.lerp(forearmZ, -0.18, t);
+    wristX = THREE.MathUtils.lerp(wristX, -0.30, t);
     wristY = THREE.MathUtils.lerp(wristY, 0.15, t);
-    wristZ = THREE.MathUtils.lerp(wristZ, -0.16, t);
-  } else if (mode === 'windUp') {
-    shoulderX = THREE.MathUtils.lerp(shoulderX, -0.74, t);
-    shoulderY = THREE.MathUtils.lerp(shoulderY, -0.36, t);
-    shoulderZ = THREE.MathUtils.lerp(shoulderZ, -0.32, t);
-    forearmX = THREE.MathUtils.lerp(forearmX, -1.15, t);
-    forearmY = THREE.MathUtils.lerp(forearmY, -0.2, t);
-    forearmZ = THREE.MathUtils.lerp(forearmZ, 0.44, t);
-    wristX = THREE.MathUtils.lerp(wristX, -0.58, t);
-    wristZ = THREE.MathUtils.lerp(wristZ, 0.2, t);
-  } else if (mode === 'release') {
-    shoulderX = THREE.MathUtils.lerp(shoulderX, -1.04, t);
+    wristZ = THREE.MathUtils.lerp(wristZ, -0.12, t);
+    chestX = THREE.MathUtils.lerp(chestX, 0.23, t);
+    chestY = THREE.MathUtils.lerp(chestY, -0.08, t);
+    headX = THREE.MathUtils.lerp(headX, 0.01, t);
+    headY = THREE.MathUtils.lerp(headY, -0.08, t);
+  } else if (mode === 'holdDice') {
+    shoulderX = THREE.MathUtils.lerp(shoulderX, -0.54, t);
     shoulderY = THREE.MathUtils.lerp(shoulderY, -0.16, t);
-    shoulderZ = THREE.MathUtils.lerp(shoulderZ, -0.88, t);
+    shoulderZ = THREE.MathUtils.lerp(shoulderZ, -0.60, t);
+    forearmX = THREE.MathUtils.lerp(forearmX, -1.02, t);
+    forearmY = THREE.MathUtils.lerp(forearmY, -0.10, t);
+    forearmZ = THREE.MathUtils.lerp(forearmZ, 0.30, t);
+    wristX = THREE.MathUtils.lerp(wristX, -0.38, t);
+    wristZ = THREE.MathUtils.lerp(wristZ, 0.18, t);
+  } else if (mode === 'windUp') {
+    shoulderX = THREE.MathUtils.lerp(shoulderX, -0.72, t);
+    shoulderY = THREE.MathUtils.lerp(shoulderY, -0.34, t);
+    shoulderZ = THREE.MathUtils.lerp(shoulderZ, -0.30, t);
+    forearmX = THREE.MathUtils.lerp(forearmX, -1.18, t);
+    forearmY = THREE.MathUtils.lerp(forearmY, -0.18, t);
+    forearmZ = THREE.MathUtils.lerp(forearmZ, 0.46, t);
+    wristX = THREE.MathUtils.lerp(wristX, -0.62, t);
+    wristY = THREE.MathUtils.lerp(wristY, -0.08, t);
+    wristZ = THREE.MathUtils.lerp(wristZ, 0.22, t);
+    chestX = THREE.MathUtils.lerp(chestX, 0.02, t);
+    chestY = THREE.MathUtils.lerp(chestY, -0.06, t);
+    headX = THREE.MathUtils.lerp(headX, -0.02, t);
+  } else if (mode === 'release') {
+    shoulderX = THREE.MathUtils.lerp(shoulderX, -1.08, t);
+    shoulderY = THREE.MathUtils.lerp(shoulderY, -0.18, t);
+    shoulderZ = THREE.MathUtils.lerp(shoulderZ, -0.86, t);
     forearmX = THREE.MathUtils.lerp(forearmX, -0.34, t);
-    forearmY = THREE.MathUtils.lerp(forearmY, -0.08, t);
-    forearmZ = THREE.MathUtils.lerp(forearmZ, 0.03, t);
-    wristX = THREE.MathUtils.lerp(wristX, 0.34, t);
-    wristY = THREE.MathUtils.lerp(wristY, 0.12, t);
+    forearmY = THREE.MathUtils.lerp(forearmY, -0.10, t);
+    forearmZ = THREE.MathUtils.lerp(forearmZ, 0.04, t);
+    wristX = THREE.MathUtils.lerp(wristX, 0.38, t);
+    wristY = THREE.MathUtils.lerp(wristY, 0.14, t);
     wristZ = THREE.MathUtils.lerp(wristZ, -0.08, t);
+    chestX = THREE.MathUtils.lerp(chestX, 0.20, t);
+    chestY = THREE.MathUtils.lerp(chestY, 0.04, t);
+    headX = THREE.MathUtils.lerp(headX, 0.04, t);
+  } else if (mode === 'followThrough') {
+    shoulderX = THREE.MathUtils.lerp(shoulderX, -0.86, t);
+    shoulderY = THREE.MathUtils.lerp(shoulderY, -0.12, t);
+    shoulderZ = THREE.MathUtils.lerp(shoulderZ, -1.02, t);
+    forearmX = THREE.MathUtils.lerp(forearmX, -0.22, t);
+    forearmY = THREE.MathUtils.lerp(forearmY, 0.02, t);
+    forearmZ = THREE.MathUtils.lerp(forearmZ, -0.05, t);
+    wristX = THREE.MathUtils.lerp(wristX, 0.22, t);
+    wristZ = THREE.MathUtils.lerp(wristZ, -0.08, t);
+    chestX = THREE.MathUtils.lerp(chestX, 0.15, t);
   } else if (mode === 'reachToken') {
     shoulderX = THREE.MathUtils.lerp(shoulderX, -0.84, t);
-    shoulderY = THREE.MathUtils.lerp(shoulderY, 0.02, t);
+    shoulderY = THREE.MathUtils.lerp(shoulderY, 0.04, t);
     shoulderZ = THREE.MathUtils.lerp(shoulderZ, -1.02, t);
-    forearmX = THREE.MathUtils.lerp(forearmX, -0.7, t);
-    forearmY = THREE.MathUtils.lerp(forearmY, -0.16, t);
-    forearmZ = THREE.MathUtils.lerp(forearmZ, -0.2, t);
-    wristX = THREE.MathUtils.lerp(wristX, -0.2, t);
+    forearmX = THREE.MathUtils.lerp(forearmX, -0.72, t);
+    forearmY = THREE.MathUtils.lerp(forearmY, -0.18, t);
+    forearmZ = THREE.MathUtils.lerp(forearmZ, -0.22, t);
+    wristX = THREE.MathUtils.lerp(wristX, -0.14, t);
+    wristY = THREE.MathUtils.lerp(wristY, 0.16, t);
+    wristZ = THREE.MathUtils.lerp(wristZ, -0.20, t);
+    chestX = THREE.MathUtils.lerp(chestX, 0.24, t);
+    headX = THREE.MathUtils.lerp(headX, 0.08, t);
+  } else if (mode === 'gripToken') {
+    shoulderX = THREE.MathUtils.lerp(shoulderX, -0.88, t);
+    shoulderY = THREE.MathUtils.lerp(shoulderY, 0.02, t);
+    shoulderZ = THREE.MathUtils.lerp(shoulderZ, -1.00, t);
+    forearmX = THREE.MathUtils.lerp(forearmX, -0.70, t);
+    forearmY = THREE.MathUtils.lerp(forearmY, -0.14, t);
+    forearmZ = THREE.MathUtils.lerp(forearmZ, -0.18, t);
+    wristX = THREE.MathUtils.lerp(wristX, -0.22, t);
     wristY = THREE.MathUtils.lerp(wristY, 0.12, t);
     wristZ = THREE.MathUtils.lerp(wristZ, -0.14, t);
+    chestX = THREE.MathUtils.lerp(chestX, 0.23, t);
+    headX = THREE.MathUtils.lerp(headX, 0.08, t);
   } else if (mode === 'carryToken') {
-    shoulderX = THREE.MathUtils.lerp(shoulderX, -0.9, t);
+    shoulderX = THREE.MathUtils.lerp(shoulderX, -0.94, t);
     shoulderY = THREE.MathUtils.lerp(shoulderY, -0.04, t);
-    shoulderZ = THREE.MathUtils.lerp(shoulderZ, -1.06, t);
-    forearmX = THREE.MathUtils.lerp(forearmX, -0.5, t);
-    forearmY = THREE.MathUtils.lerp(forearmY, -0.1, t);
-    forearmZ = THREE.MathUtils.lerp(forearmZ, -0.1, t);
-    wristX = THREE.MathUtils.lerp(wristX, 0.03, t);
-    wristY = THREE.MathUtils.lerp(wristY, 0.08, t);
-    wristZ = THREE.MathUtils.lerp(wristZ, -0.08, t);
+    shoulderZ = THREE.MathUtils.lerp(shoulderZ, -1.08, t);
+    forearmX = THREE.MathUtils.lerp(forearmX, -0.54, t);
+    forearmY = THREE.MathUtils.lerp(forearmY, -0.12, t);
+    forearmZ = THREE.MathUtils.lerp(forearmZ, -0.12, t);
+    wristX = THREE.MathUtils.lerp(wristX, 0.02, t);
+    wristY = THREE.MathUtils.lerp(wristY, 0.10, t);
+    wristZ = THREE.MathUtils.lerp(wristZ, -0.10, t);
+    chestX = THREE.MathUtils.lerp(chestX, 0.18, t);
+    headX = THREE.MathUtils.lerp(headX, 0.08, t);
+  } else if (mode === 'placeToken') {
+    shoulderX = THREE.MathUtils.lerp(shoulderX, -0.76, t);
+    shoulderY = THREE.MathUtils.lerp(shoulderY, 0.02, t);
+    shoulderZ = THREE.MathUtils.lerp(shoulderZ, -0.92, t);
+    forearmX = THREE.MathUtils.lerp(forearmX, -0.84, t);
+    forearmY = THREE.MathUtils.lerp(forearmY, -0.16, t);
+    forearmZ = THREE.MathUtils.lerp(forearmZ, -0.26, t);
+    wristX = THREE.MathUtils.lerp(wristX, -0.24, t);
+    wristY = THREE.MathUtils.lerp(wristY, 0.12, t);
+    wristZ = THREE.MathUtils.lerp(wristZ, -0.16, t);
+    chestX = THREE.MathUtils.lerp(chestX, 0.22, t);
+    headX = THREE.MathUtils.lerp(headX, 0.10, t);
   }
 
-  addBoneRot(rig, rig.rightUpperArm, shoulderX, shoulderY, shoulderZ);
-  addBoneRot(rig, rig.rightForeArm, forearmX, forearmY, forearmZ);
-  addBoneRot(rig, rig.rightHand, wristX, wristY, wristZ);
+  addBoneRot(rig, rig.chest, chestX, chestY, 0, 1);
+  addBoneRot(rig, rig.head, headX, headY, 0, 1);
+  addBoneRot(rig, rig.rightUpperArm, shoulderX, shoulderY, shoulderZ, 1);
+  addBoneRot(rig, rig.rightForeArm, forearmX, forearmY, forearmZ, 1);
+  addBoneRot(rig, rig.rightHand, wristX, wristY, wristZ, 1);
+  applyRightHandGrip(rig, handGrip);
 }
 
 async function loadSeatedHumanTemplate() {
@@ -4101,6 +4230,14 @@ async function loadSeatedHumanTemplate() {
         obj.castShadow = true;
         obj.receiveShadow = true;
         obj.frustumCulled = false;
+        const materials = Array.isArray(obj.material) ? obj.material : obj.material ? [obj.material] : [];
+        materials.forEach((mat) => {
+          if (mat?.map) {
+            applySRGBColorSpace(mat.map);
+            mat.map.needsUpdate = true;
+          }
+          mat.needsUpdate = true;
+        });
       }
     });
     return root;
@@ -4110,37 +4247,112 @@ async function loadSeatedHumanTemplate() {
 
 function spinDice(
   dice,
-  { duration = 900, targetPosition = new THREE.Vector3(), bounceHeight = 0.06 } = {}
+  { duration = 2550, targetPosition = new THREE.Vector3(), bounceHeight = 0.06 } = {}
 ) {
   return new Promise((resolve) => {
     const start = performance.now();
     const startPos = dice.position.clone();
     const endPos = targetPosition.clone();
-    const spinVec = new THREE.Vector3(
-      1.2 + Math.random() * 0.7,
-      1.35 + Math.random() * 0.65,
-      1.05 + Math.random() * 0.75
-    );
-    const wobble = new THREE.Vector3((Math.random() - 0.5) * 0.16, 0, (Math.random() - 0.5) * 0.16);
+    const throwAxis = endPos.clone().sub(startPos);
+    throwAxis.y = 0;
+    if (throwAxis.lengthSq() < 1e-6) throwAxis.set(1, 0, 0);
+    throwAxis.normalize();
+    const sideAxis = new THREE.Vector3(-throwAxis.z, 0, throwAxis.x);
     const targetValue = 1 + Math.floor(Math.random() * 6);
+    const randomSide = (Math.random() - 0.5) * 0.05;
+
+    const holdStart = startPos
+      .clone()
+      .addScaledVector(throwAxis, 0.06)
+      .addScaledVector(sideAxis, randomSide)
+      .add(new THREE.Vector3(0, 0.11, 0));
+    const holdRelease = startPos
+      .clone()
+      .addScaledVector(throwAxis, 0.24)
+      .addScaledVector(sideAxis, randomSide * 0.7)
+      .add(new THREE.Vector3(0, 0.17, 0));
+    const impact = endPos
+      .clone()
+      .addScaledVector(throwAxis, -0.11)
+      .addScaledVector(sideAxis, randomSide * 0.5);
+
+    const rollAxis = new THREE.Vector3(
+      Math.random() * 0.7 + 0.4,
+      Math.random() * 0.45 + 0.15,
+      Math.random() * 0.8 + 0.4
+    ).normalize();
 
     const step = () => {
       const now = performance.now();
-      const t = Math.min(1, (now - start) / Math.max(1, duration));
-      const eased = easeOutCubic(t);
-      const position = startPos.clone().lerp(endPos, eased);
-      const wobbleStrength = Math.sin(eased * Math.PI);
-      position.addScaledVector(wobble, wobbleStrength * 0.45);
-      const bounce = Math.sin(Math.min(1, eased * 1.25) * Math.PI) * bounceHeight * (1 - eased * 0.45);
-      position.y = THREE.MathUtils.lerp(startPos.y, endPos.y, eased) + bounce;
-      dice.position.copy(position);
+      const seconds = ((now - start) / Math.max(1, duration)) * 2.55;
 
-      const spinFactor = 1 - eased * 0.28;
-      dice.rotation.x += spinVec.x * spinFactor * 0.22;
-      dice.rotation.y += spinVec.y * spinFactor * 0.22;
-      dice.rotation.z += spinVec.z * spinFactor * 0.22;
+      const reachDiceT = clamp(seconds / 0.55, 0, 1);
+      const gripDiceT = clamp((seconds - 0.55) / 0.3, 0, 1);
+      const windT = clamp((seconds - 0.85) / 0.46, 0, 1);
+      const releaseT = clamp((seconds - 1.31) / 0.28, 0, 1);
+      const flightT = clamp((seconds - 1.58) / 0.72, 0, 1);
+      const rollT = clamp((seconds - 2.3) / 0.82, 0, 1);
+      const settleT = clamp((seconds - 2.3) / 0.25, 0, 1);
 
-      if (t < 1) {
+      if (seconds < 0.55) {
+        dice.position.copy(startPos);
+        dice.rotation.x += 0.002;
+        dice.rotation.y += 0.0025;
+      } else if (seconds < 0.85) {
+        const t = smooth01(gripDiceT);
+        const liftArc = Math.sin(t * Math.PI) * 0.06;
+        dice.position.copy(startPos.clone().lerp(holdStart, t));
+        dice.position.y += liftArc;
+        dice.rotation.set(
+          THREE.MathUtils.lerp(dice.rotation.x, 0.55, 0.16),
+          THREE.MathUtils.lerp(dice.rotation.y, 0.35, 0.16),
+          THREE.MathUtils.lerp(dice.rotation.z, 0.18, 0.16)
+        );
+      } else if (seconds < 1.58) {
+        const handT = seconds < 1.31 ? windT * 0.56 : 0.56 + releaseT * 0.44;
+        dice.position.copy(holdStart.clone().lerp(holdRelease, handT));
+        dice.rotation.set(0.55 + handT * 2.4, 0.35 - handT * 1.1, 0.18 + handT * 1.6);
+      } else if (seconds < 2.3) {
+        const t = ease(flightT);
+        const arc = Math.sin(t * Math.PI) * 0.34;
+        dice.position.set(
+          THREE.MathUtils.lerp(holdRelease.x, impact.x, t),
+          THREE.MathUtils.lerp(holdRelease.y, endPos.y + 0.01, t) + arc,
+          THREE.MathUtils.lerp(holdRelease.z, impact.z, t)
+        );
+        dice.rotation.set(10.5 * t + 1.1, 13.2 * t + 0.6, 8.1 * t + 0.4);
+      } else if (seconds < 2.55) {
+        const t = rollT;
+        const eased = easeOutCubic(t);
+        const bounce = Math.abs(Math.sin(t * Math.PI * 6.5)) * Math.pow(1 - t, 1.65) * bounceHeight;
+        const wobble = Math.sin(t * Math.PI * 8) * Math.pow(1 - t, 1.4) * 0.04;
+        dice.position.set(
+          THREE.MathUtils.lerp(impact.x, endPos.x, eased) + wobble,
+          endPos.y + bounce,
+          THREE.MathUtils.lerp(impact.z, endPos.z, eased) + Math.cos(t * Math.PI * 7) * Math.pow(1 - t, 1.4) * 0.032
+        );
+
+        const spin = (1 - Math.pow(t, 1.7)) * 17;
+        dice.rotation.x = 14.5 + rollAxis.x * spin;
+        dice.rotation.y = 10 + rollAxis.y * spin * 1.3;
+        dice.rotation.z = 8.5 + rollAxis.z * spin;
+      } else {
+        const finalRot = {
+          1: new THREE.Euler(0, 0, 0),
+          2: new THREE.Euler(-Math.PI / 2, 0, 0),
+          3: new THREE.Euler(0, 0, Math.PI / 2),
+          4: new THREE.Euler(0, 0, -Math.PI / 2),
+          5: new THREE.Euler(Math.PI / 2, 0, 0),
+          6: new THREE.Euler(Math.PI, 0, 0)
+        }[targetValue] || new THREE.Euler(0, 0, 0);
+        const t = smooth01(settleT);
+        dice.position.lerp(endPos, 0.24);
+        dice.rotation.x = THREE.MathUtils.lerp(dice.rotation.x, finalRot.x, t * 0.22);
+        dice.rotation.y = THREE.MathUtils.lerp(dice.rotation.y, finalRot.y, t * 0.22);
+        dice.rotation.z = THREE.MathUtils.lerp(dice.rotation.z, finalRot.z, t * 0.22);
+      }
+
+      if (seconds < 2.55) {
         requestAnimationFrame(step);
       } else {
         if (typeof dice.userData?.setValue === 'function') {
@@ -4156,6 +4368,7 @@ function spinDice(
     requestAnimationFrame(step);
   });
 }
+
 
 function createTokenCountLabel() {
   if (typeof document === 'undefined') return null;
@@ -6904,6 +7117,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           if (!rig) return;
           let mode = 'idle';
           let intensity = 1;
+          let handGrip = 0;
 
           if (
             Number.isFinite(actorState?.rollStartMs) &&
@@ -6914,18 +7128,32 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             const elapsed = now - actorState.rollStartMs;
             const total = Math.max(1, endMs - actorState.rollStartMs);
             const progress = clamp(elapsed / total, 0, 1.2);
-            if (progress < 0.3) {
+            if (progress < 0.24) {
               mode = 'reachDice';
-              intensity = progress / 0.3;
-            } else if (progress < 0.68) {
+              intensity = progress / 0.24;
+              handGrip = 0.05;
+            } else if (progress < 0.36) {
+              mode = 'gripDice';
+              intensity = clamp((progress - 0.24) / 0.12, 0, 1);
+              handGrip = intensity;
+            } else if (progress < 0.54) {
+              mode = 'holdDice';
+              intensity = clamp((progress - 0.36) / 0.18, 0, 1);
+              handGrip = 1;
+            } else if (progress < 0.76) {
               mode = 'windUp';
-              intensity = (progress - 0.3) / 0.38;
-            } else if (progress < 1.04) {
+              intensity = clamp((progress - 0.54) / 0.22, 0, 1);
+              handGrip = 1;
+            } else if (progress < 0.92) {
               mode = 'release';
-              intensity = clamp((progress - 0.68) / 0.36, 0, 1);
+              intensity = clamp((progress - 0.76) / 0.16, 0, 1);
+              handGrip = 1 - intensity;
+            } else if (progress < 1.08) {
+              mode = 'followThrough';
+              intensity = clamp((progress - 0.92) / 0.16, 0, 1);
             } else {
               mode = 'idle';
-              intensity = clamp(1 - (progress - 1.04) * 2.3, 0, 1);
+              intensity = clamp(1 - (progress - 1.08) * 2.8, 0, 1);
             }
             if (progress > 1.2) {
               actorState.rollPlayer = null;
@@ -6937,20 +7165,30 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             if (anim.segment <= 0) {
               mode = 'reachToken';
               intensity = segProgress;
+              handGrip = 0.05;
+            } else if (anim.segment === 1) {
+              mode = 'gripToken';
+              intensity = segProgress;
+              handGrip = segProgress;
+            } else if (anim.segment >= Math.max((anim.segments?.length || 1) - 1, 2)) {
+              mode = 'placeToken';
+              intensity = segProgress;
+              handGrip = 1 - segProgress * 0.85;
             } else {
               mode = 'carryToken';
               intensity = 0.45 + segProgress * 0.55;
+              handGrip = 1;
             }
           } else if (
             actorState?.rollEndMs &&
             now - actorState.rollEndMs < SEATED_HUMAN_RECOVER_MS &&
             rollingPlayer === playerIndex
           ) {
-            mode = 'release';
+            mode = 'followThrough';
             intensity = clamp(1 - (now - actorState.rollEndMs) / SEATED_HUMAN_RECOVER_MS, 0, 1);
           }
 
-          applySeatedHumanPose(rig, mode, intensity);
+          applySeatedHumanPose(rig, mode, intensity, handGrip);
         });
       }
 
@@ -8843,7 +9081,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     };
     const landingFocus = baseTarget.clone();
     const value = await spinDice(dice, {
-      duration: resolveFrameSyncedDuration(AUTO_ROLL_DURATION_MS, { min: 620, max: 1400 }),
+      duration: resolveFrameSyncedDuration(AUTO_ROLL_DURATION_MS * 2.4, { min: 2400, max: 3200 }),
       targetPosition: baseTarget,
       bounceHeight: dice.userData?.bounceHeight ?? 0.06
     });


### PR DESCRIPTION
### Motivation

- Improve realism and robustness of the seated human/arm rig so hands can grip dice/tokens and poses blend smoothly during roll/animation sequences.
- Replace the simple, short dice spin with a staged throw animation to make throws feel more natural and to produce deterministic final die faces.
- Fix texture color-space issues on the seated human model and adjust seat offsets for better alignment.

### Description

- Added `findBoneChainByNeedle` and updated `saveBoneRig` to capture right-hand finger bone chains (`rightThumb`, `rightIndex`, `rightMiddle`, `rightRing`, `rightPinky`).
- Added `curlFingerChain` and `applyRightHandGrip` utilities and extended `applySeatedHumanPose` to accept a `handGrip` parameter; also converted `addBoneRot`/`addBonePos` to accept a `weight` multiplier for smoother blending.
- Heavily refined seated human pose values (hips, spine, chest, head, limbs) and added breathing, additional animation modes (`gripDice`, `holdDice`, `followThrough`, `gripToken`, `placeToken`, etc.), and applied right-hand grip during relevant modes.
- Updated seated human model loading to ensure material textures are set to sRGB when present (`applySRGBColorSpace` usage) and marked for update.
- Rewrote `spinDice` to a longer, multi-phase throw animation with hold/release/flight/roll/settle phases, a computed throw axis and roll axis, and deterministic final orientation based on the generated `targetValue`.
- Adjusted constants: seat offsets (`SEATED_HUMAN_SEAT_Y_OFFSET`, `SEATED_HUMAN_SEAT_Z_OFFSET`) and increased spin duration when invoked from the roll flow (`resolveFrameSyncedDuration` multiplied by 2.4), plus various numeric tweaks to pose interpolation timings.
- Propagated `handGrip` through the actor update loop and updated progress thresholds so hand animation states align with the new spin timeline.

### Testing

- Ran the project test suite with `yarn test` and linters via `yarn lint`; the automated tests and lint checks completed successfully.
- Executed a local smoke test of the Ludo UI (board, seated avatars, and dice throw sequences) to verify pose transitions, finger grips, and dice animations render without runtime errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb7b6d6804832994acc7ea8732938f)