### PR TITLE
Restore Pool Royale cue/power-slider behavior and add two 3D human players

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -120,6 +120,7 @@ import { polyHavenThumb } from '../../config/storeThumbnails.js';
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/v1/decoders/';
 const BASIS_TRANSCODER_PATH =
   'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/';
+const POOL_ROYALE_HUMAN_URL = 'https://threejs.org/examples/models/gltf/readyplayer.me.glb';
 
 
 const TRAINING_MISS_ATTEMPT_COST = 1;
@@ -15496,7 +15497,6 @@ const showRuleToast = useCallback((message) => {
   }, 3000);
 }, []);
 const powerRef = useRef(hud.power);
-const shotPowerRef = useRef(0);
   const clampPower = useCallback((value, fallback = 0) => {
     if (!Number.isFinite(value)) return fallback;
     return THREE.MathUtils.clamp(value, 0, 1);
@@ -18211,6 +18211,166 @@ const shotPowerRef = useRef(0);
       const world = new THREE.Group();
       scene.add(world);
       worldRef.current = world;
+      const humanActors = [];
+      const humanTemplateRef = { current: null };
+      const humanLoadRef = { current: null };
+      const getActorBone = (actor, pattern) =>
+        actor?.bones?.find((entry) => pattern.test(entry.name || ''))?.bone ?? null;
+      const toSidewalkPosition = (x, z) => {
+        const padding = BALL_R * 7.6;
+        return new THREE.Vector3(
+          THREE.MathUtils.clamp(x, -PLAY_W * 0.5 - padding, PLAY_W * 0.5 + padding),
+          0,
+          THREE.MathUtils.clamp(z, -PLAY_H * 0.5 - padding, PLAY_H * 0.5 + padding)
+        );
+      };
+      const setActorPose = (actor, mode, aimTarget = null) => {
+        if (!actor) return;
+        const spine = getActorBone(actor, /(spine|chest|upperchest)/i);
+        const head = getActorBone(actor, /head/i);
+        const rightUpperArm = getActorBone(actor, /(rightarm|rightupperarm)/i);
+        const rightForeArm = getActorBone(actor, /(rightforearm|rightlowerarm)/i);
+        const leftUpperArm = getActorBone(actor, /(leftarm|leftupperarm)/i);
+        const leftForeArm = getActorBone(actor, /(leftforearm|leftlowerarm)/i);
+        const applyBone = (bone, key, euler) => {
+          if (!bone || !actor.restPose?.[key]) return;
+          bone.quaternion.copy(actor.restPose[key]).multiply(
+            new THREE.Quaternion().setFromEuler(euler)
+          );
+        };
+        if (mode === 'aim') {
+          applyBone(spine, 'spine', new THREE.Euler(-0.62, 0, -0.1));
+          applyBone(head, 'head', new THREE.Euler(0.2, 0, 0));
+          applyBone(rightUpperArm, 'rightUpperArm', new THREE.Euler(-1.2, 0.4, -0.2));
+          applyBone(rightForeArm, 'rightForeArm', new THREE.Euler(-0.62, 0.12, 0.2));
+          applyBone(leftUpperArm, 'leftUpperArm', new THREE.Euler(-1.32, -0.3, 0.12));
+          applyBone(leftForeArm, 'leftForeArm', new THREE.Euler(-0.78, -0.1, -0.22));
+          if (aimTarget) {
+            actor.group.lookAt(aimTarget.x, actor.group.position.y + 1.16, aimTarget.z);
+          }
+          actor.group.position.y = 0;
+          return;
+        }
+        applyBone(spine, 'spine', new THREE.Euler(0, 0, 0));
+        applyBone(head, 'head', new THREE.Euler(0, 0, 0));
+        applyBone(rightUpperArm, 'rightUpperArm', new THREE.Euler(-0.2, 0, 0));
+        applyBone(rightForeArm, 'rightForeArm', new THREE.Euler(-0.08, 0, 0));
+        applyBone(leftUpperArm, 'leftUpperArm', new THREE.Euler(-0.12, 0, 0));
+        applyBone(leftForeArm, 'leftForeArm', new THREE.Euler(-0.08, 0, 0));
+        if (mode === 'walk') {
+          const swing = Math.sin((performance.now() + actor.phaseOffset * 1000) * 0.008) * 0.16;
+          applyBone(rightUpperArm, 'rightUpperArm', new THREE.Euler(-0.2 - swing, 0, 0));
+          applyBone(leftUpperArm, 'leftUpperArm', new THREE.Euler(-0.1 + swing, 0, 0));
+        }
+      };
+      const buildHumanActor = (template, index) => {
+        const group = template.clone(true);
+        group.scale.setScalar(1.18);
+        group.traverse((obj) => {
+          if (obj.isMesh) {
+            obj.castShadow = true;
+            obj.receiveShadow = true;
+          }
+        });
+        const cueMesh = new THREE.Mesh(
+          new THREE.CylinderGeometry(BALL_R * 0.09, BALL_R * 0.12, BALL_R * 15.8, 14),
+          new THREE.MeshStandardMaterial({ color: 0xc8a976, roughness: 0.55, metalness: 0.08 })
+        );
+        cueMesh.rotation.z = Math.PI / 2;
+        cueMesh.position.set(0.58, 0.95, -0.1);
+        cueMesh.castShadow = true;
+        cueMesh.receiveShadow = true;
+        const bones = [];
+        group.traverse((obj) => {
+          if (obj.isBone) bones.push({ name: obj.name, bone: obj });
+        });
+        const rightHand = bones.find((entry) => /(righthand|hand_r|mixamorigRightHand)/i.test(entry.name || ''))?.bone;
+        if (rightHand) {
+          rightHand.add(cueMesh);
+          cueMesh.position.set(0.22, -0.03, 0.05);
+          cueMesh.rotation.set(-Math.PI * 0.5, 0, Math.PI * 0.12);
+        } else {
+          group.add(cueMesh);
+        }
+        const actor = {
+          index,
+          group,
+          cueMesh,
+          bones,
+          phaseOffset: Math.random(),
+          walkAngle: index === 0 ? Math.PI * 0.2 : Math.PI * 1.2,
+          restPose: {}
+        };
+        const captureRest = (key, pattern) => {
+          const bone = getActorBone(actor, pattern);
+          if (bone) actor.restPose[key] = bone.quaternion.clone();
+        };
+        captureRest('spine', /(spine|chest|upperchest)/i);
+        captureRest('head', /head/i);
+        captureRest('rightUpperArm', /(rightarm|rightupperarm)/i);
+        captureRest('rightForeArm', /(rightforearm|rightlowerarm)/i);
+        captureRest('leftUpperArm', /(leftarm|leftupperarm)/i);
+        captureRest('leftForeArm', /(leftforearm|leftlowerarm)/i);
+        actor.group.position.copy(
+          toSidewalkPosition(
+            index === 0 ? -PLAY_W * 0.65 : PLAY_W * 0.65,
+            index === 0 ? -PLAY_H * 0.62 : PLAY_H * 0.62
+          )
+        );
+        world.add(group);
+        return actor;
+      };
+      const ensureHumanActors = async () => {
+        if (humanActors.length >= 2) return;
+        if (humanLoadRef.current) return humanLoadRef.current;
+        const loader = new GLTFLoader();
+        loader.setCrossOrigin('anonymous');
+        humanLoadRef.current = loader
+          .loadAsync(POOL_ROYALE_HUMAN_URL)
+          .then((gltf) => {
+            humanTemplateRef.current = gltf?.scene ?? null;
+            if (!humanTemplateRef.current) return;
+            for (let i = 0; i < 2; i += 1) {
+              humanActors.push(buildHumanActor(humanTemplateRef.current, i));
+            }
+          })
+          .catch((error) => {
+            console.warn('Pool Royale human players failed to load', error);
+          })
+          .finally(() => {
+            humanLoadRef.current = null;
+          });
+        return humanLoadRef.current;
+      };
+      const updateHumanActors = ({ cueBall, turn, shotActive, ballsState }) => {
+        if (!humanActors.length) return;
+        const allStoppedNow = allStopped(ballsState || []);
+        const activeShooter = turn === 1 ? 1 : 0;
+        humanActors.forEach((actor, index) => {
+          const targetAim = cueBall?.pos
+            ? new THREE.Vector3(cueBall.pos.x, 0, cueBall.pos.y)
+            : new THREE.Vector3();
+          if (!allStoppedNow || shotActive) {
+            actor.walkAngle += (index === activeShooter ? 1 : -1) * 0.0028;
+            const walkRadiusX = PLAY_W * 0.67;
+            const walkRadiusZ = PLAY_H * 0.72;
+            const tx = Math.cos(actor.walkAngle) * walkRadiusX;
+            const tz = Math.sin(actor.walkAngle) * walkRadiusZ;
+            actor.group.position.lerp(toSidewalkPosition(tx, tz), 0.05);
+            actor.group.lookAt(targetAim.x, actor.group.position.y + 1.15, targetAim.z);
+            setActorPose(actor, 'walk');
+            return;
+          }
+          const sideSign = index === 0 ? -1 : 1;
+          const aimPos = toSidewalkPosition(
+            targetAim.x + sideSign * (PLAY_W * 0.53),
+            targetAim.z - PLAY_H * 0.08
+          );
+          actor.group.position.lerp(aimPos, 0.06);
+          setActorPose(actor, index === activeShooter ? 'aim' : 'idle', targetAim);
+        });
+      };
+      void ensureHumanActors();
       const applyHdriEnvironment = async (variantConfig = activeEnvironmentVariantRef.current) => {
         const sceneInstance = sceneRef.current;
         if (!renderer || !sceneInstance) return;
@@ -22784,13 +22944,12 @@ const shotPowerRef = useRef(0);
             baseRotationX,
             baseRotationY,
             strikeDip,
-            forwardOnly,
-            strikeImpactThreshold
+            forwardOnly
           } = stroke;
           const elapsed = Math.max(0, now - startTime);
           if (forwardOnly) {
-            const safeStrikeDuration = Math.max(1, strikeDuration ?? 110);
-            const safeHoldDuration = Math.max(0, holdDuration ?? 45);
+            const safeStrikeDuration = Math.max(1, strikeDuration ?? 120);
+            const safeHoldDuration = Math.max(0, holdDuration ?? 50);
             const safeRecoverDuration = Math.max(0, recoverDuration ?? 0);
             const normalizedStroke = ensureCueStrokeForwardMotion({
               pullPos: pullPos ?? impactPos,
@@ -22798,43 +22957,86 @@ const shotPowerRef = useRef(0);
               fallbackDirection: tmpCueStrokeB.set(Math.sin(baseRotationY ?? 0), 0, Math.cos(baseRotationY ?? 0))
             });
             const resolvedPullPos = normalizedStroke.pullPos ?? pullPos ?? impactPos;
-            const resolvedContactPos = stroke.contactPos ?? impactPos ?? pullPos;
-            const strikeProgress = THREE.MathUtils.clamp(
-              elapsed / Math.max(safeStrikeDuration, 1e-6),
-              0,
-              1
+            const resolvedImpactPos = normalizedStroke.impactPos ?? impactPos ?? pullPos;
+            const resolvedContactPos = stroke.contactPos ?? resolvedImpactPos;
+            const resolvedFollowPos = followPos ?? resolvedContactPos ?? resolvedImpactPos;
+            const contactWindow = THREE.MathUtils.clamp(
+              safeStrikeDuration * 0.24,
+              24,
+              Math.max(24, safeStrikeDuration * 0.45)
             );
-            const strikeEase = easeOutCubic(strikeProgress);
+            const releaseWindow = Math.max(1, safeStrikeDuration - contactWindow);
+            const strikeWobbleScale = Math.max(
+              0,
+              1 - THREE.MathUtils.clamp(elapsed / Math.max(safeStrikeDuration, 1e-6), 0, 1)
+            );
+
             cueStick.visible = true;
-            cueStick.position.lerpVectors(resolvedPullPos, resolvedContactPos, strikeEase);
-            cueStick.position.y -= (strikeDip ?? 0.0035) * strikeEase;
-            cueStick.rotation.x = baseRotationX ?? cueStick.rotation.x;
-            cueStick.rotation.y =
-              (baseRotationY ?? cueStick.rotation.y) +
-              Math.sin(strikeProgress * Math.PI) * 0.0014;
-
-            const impactThreshold = THREE.MathUtils.clamp(strikeImpactThreshold ?? 0.88, 0.05, 0.995);
-            if (!stroke.shotApplied && strikeProgress >= impactThreshold) {
-              stroke.shotApplied = true;
-              stroke.onImpact?.();
-            }
-
-            if (elapsed < safeStrikeDuration + safeHoldDuration) {
+            if (elapsed < releaseWindow) {
+              const releaseT = THREE.MathUtils.clamp(elapsed / Math.max(releaseWindow, 1e-6), 0, 1);
+              const easedRelease = easeOutCubic(releaseT);
+              cueStick.position.lerpVectors(resolvedPullPos, resolvedImpactPos, easedRelease);
+              cueStick.position.y -= (strikeDip ?? 0.003) * easedRelease * 0.75;
+              cueStick.rotation.x = baseRotationX ?? cueStick.rotation.x;
+              cueStick.rotation.y =
+                (baseRotationY ?? cueStick.rotation.y) +
+                Math.sin(releaseT * Math.PI) * 0.0012 * strikeWobbleScale;
               cueAnimating = true;
               syncCueShadow();
               return true;
             }
-            const recoverT = THREE.MathUtils.clamp(
-              (elapsed - (safeStrikeDuration + safeHoldDuration)) / Math.max(safeRecoverDuration || 1, 1),
-              0,
-              1
-            );
-            if (recoverT < 1) {
-              cueStick.position.lerpVectors(
-                resolvedContactPos,
-                idlePos ?? impactPos ?? pullPos,
-                easeInOutCubic(recoverT)
+            if (elapsed < safeStrikeDuration) {
+              const contactT = THREE.MathUtils.clamp(
+                (elapsed - releaseWindow) / Math.max(contactWindow, 1e-6),
+                0,
+                1
               );
+              const punchT = 1 - Math.pow(1 - contactT, 4);
+              cueStick.position.lerpVectors(resolvedImpactPos, resolvedContactPos, punchT);
+              cueStick.position.y -= (strikeDip ?? 0.003) * (0.7 + punchT * 0.45);
+              cueStick.rotation.x = baseRotationX ?? cueStick.rotation.x;
+              cueStick.rotation.y =
+                (baseRotationY ?? cueStick.rotation.y) +
+                Math.sin(contactT * Math.PI) * 0.0008 * strikeWobbleScale;
+              if (!stroke.shotApplied && contactT >= 0.2) {
+                stroke.shotApplied = true;
+                stroke.onImpact?.();
+              }
+              cueAnimating = true;
+              syncCueShadow();
+              return true;
+            }
+            if (elapsed < safeStrikeDuration + safeHoldDuration) {
+              const followT = THREE.MathUtils.clamp(
+                (elapsed - safeStrikeDuration) / Math.max(safeHoldDuration, 1e-6),
+                0,
+                1
+              );
+              const easedFollow = easeOutCubic(followT);
+              cueStick.position.lerpVectors(resolvedContactPos, resolvedFollowPos, easedFollow);
+              cueStick.rotation.x = baseRotationX ?? cueStick.rotation.x;
+              cueStick.rotation.y = baseRotationY ?? cueStick.rotation.y;
+              cueAnimating = true;
+              syncCueShadow();
+              return true;
+            }
+            const recoverStart = safeStrikeDuration + safeHoldDuration;
+            const recoverEnd = recoverStart + safeRecoverDuration;
+            if (elapsed <= recoverEnd) {
+              const t = THREE.MathUtils.clamp(
+                (elapsed - recoverStart) / Math.max(safeRecoverDuration, 1e-6),
+                0,
+                1
+              );
+              const eased = easeInOutCubic(t);
+              cueStick.visible = true;
+              cueStick.position.lerpVectors(
+                resolvedFollowPos,
+                idlePos ?? impactPos ?? pullPos,
+                eased
+              );
+              cueStick.rotation.x = baseRotationX ?? cueStick.rotation.x;
+              cueStick.rotation.y = baseRotationY ?? cueStick.rotation.y;
               cueAnimating = true;
               syncCueShadow();
               return true;
@@ -25987,20 +26189,18 @@ const shotPowerRef = useRef(0);
 
       const resolveCueStrokeProfile = (_styleId, powerRatio = 0) => {
         const p = THREE.MathUtils.clamp(powerRatio ?? 0, 0, 1);
-        const pullbackDuration = THREE.MathUtils.lerp(110, 190, p);
-        const strikeDuration = THREE.MathUtils.lerp(128, 92, p);
-        const holdDuration = THREE.MathUtils.lerp(40, 68, p);
+        const pullbackDuration = THREE.MathUtils.lerp(90, 170, p);
         return {
-          // Rebuilt cue stroke: slider pull maps directly to cue pullback,
-          // then release performs a single forward punch through the cue ball.
+          // Match the reference cue workflow exactly:
+          // drag = pull back, release = immediate forward strike.
           motion: 'classic',
-          pullRatio: p,
+          pullRatio: easeOutCubic(p),
           pullSmoothing: 1,
-          strikeDuration,
-          holdDuration,
+          strikeDuration: 120,
+          holdDuration: 50,
           pullbackDuration,
           recoverDuration: 0,
-          impactThreshold: 0.86,
+          impactThreshold: 0.9,
           forwardOnly: false,
           cameraExtraHoldMs: 240,
           spinScale: 0.22
@@ -26210,20 +26410,7 @@ const shotPowerRef = useRef(0);
           x: physicsSpin?.x ?? 0,
           y: physicsSpin?.y ?? 0
         };
-        const shotDir3 = TMP_VEC3_C.set(aimDir.x, 0, aimDir.y);
-        if (shotDir3.lengthSq() > 1e-8) shotDir3.normalize();
-        else shotDir3.set(0, 0, 1);
-        const sideDir3 = TMP_VEC3_D.set(shotDir3.z, 0, -shotDir3.x);
-        if (sideDir3.lengthSq() > 1e-8) sideDir3.normalize();
-        const baseSpeed = Math.max(0, base.length());
-        const topspin = Math.max(0, offsetScaled.y);
-        const backspin = Math.max(0, -offsetScaled.y);
-        const squirt = offsetScaled.x * clampedPower * 0.24;
-        cue.vel
-          .copy(shotDir3)
-          .multiplyScalar(baseSpeed + topspin * clampedPower * 0.9)
-          .addScaledVector(sideDir3, squirt)
-          .addScaledVector(shotDir3, -backspin * clampedPower * 0.65);
+        cue.vel.copy(base);
         if (cue.spin) {
           cue.spin.set(offsetScaled.x, offsetScaled.y);
         }
@@ -26234,8 +26421,9 @@ const shotPowerRef = useRef(0);
         cue.spinMode = 'standard';
         cue.swerveStrength = 0;
         cue.swervePowerStrength = 0;
-        const shotDir = shotDir3;
-        const sideAxis = TMP_VEC3_E.set(-shotDir.z, 0, shotDir.x);
+        const shotDir = TMP_VEC3_C.set(aimDir.x, 0, aimDir.y);
+        if (shotDir.lengthSq() > 1e-8) shotDir.normalize();
+        const sideAxis = TMP_VEC3_D.set(-shotDir.z, 0, shotDir.x);
         if (sideAxis.lengthSq() > 1e-8) sideAxis.normalize();
         const rOffset = TMP_VEC3_E
           .copy(sideAxis)
@@ -26264,7 +26452,7 @@ const shotPowerRef = useRef(0);
       };
 
       // Fire (slider triggers on release)
-      const fire = (committedPowerOverride = null) => {
+      const fire = () => {
         const currentHud = hudRef.current;
         const frameSnapshot = frameRef.current ?? frameState;
         const fullTableHandPlacement =
@@ -26363,11 +26551,7 @@ const shotPowerRef = useRef(0);
         } else {
           aimDir.normalize();
         }
-        const sourcePower = Number.isFinite(committedPowerOverride)
-          ? committedPowerOverride
-          : powerRef.current;
-        const clampedPower = clampPower(sourcePower, 0);
-        shotPowerRef.current = clampedPower;
+        const clampedPower = clampPower(powerRef.current, 0);
         const strokeStyle = cueStrokeAnimationStyleRef.current ?? DEFAULT_CUE_STROKE_STYLE;
         const strokeProfile = resolveCueStrokeProfile(strokeStyle, clampedPower);
         const rawSpin = applySpinConstraints(aimDir, true);
@@ -26643,14 +26827,42 @@ const shotPowerRef = useRef(0);
               spinSide = baseSide * SIDE_SPIN_MULTIPLIER * topspinPowerScale;
             }
           }
-          const shotImpactPayload = {
-            base: base.clone(),
-            aimDir: shotAimDir.clone(),
-            physicsSpin: { x: spinSide, y: spinTop },
-            clampedPower,
-            liftStrength,
-            applied: false
-          };
+          cue.vel.copy(base);
+          cue.maxRailSpeed = Math.max(cue.vel.length(), 0);
+          if (cue.spin) {
+            cue.spin.set(spinSide, spinTop);
+          }
+          if (cue.omega) {
+            cue.omega.set(0, 0, 0);
+            TMP_VEC3_A.set(shotAimDir.x, 0, shotAimDir.y);
+            if (TMP_VEC3_A.lengthSq() > 1e-8) TMP_VEC3_A.normalize();
+            TMP_VEC3_B.set(-TMP_VEC3_A.z, 0, TMP_VEC3_A.x);
+            if (TMP_VEC3_B.lengthSq() > 1e-8) TMP_VEC3_B.normalize();
+            TMP_VEC3_C.copy(TMP_VEC3_B).multiplyScalar(scaledSpin.x * BALL_R);
+            TMP_VEC3_C.y += scaledSpin.y * BALL_R;
+            const impulseMag = BALL_MASS * base.length();
+            TMP_VEC3_D.copy(TMP_VEC3_A).multiplyScalar(impulseMag);
+            TMP_VEC3_E.copy(TMP_VEC3_C).cross(TMP_VEC3_D);
+            cue.omega.addScaledVector(TMP_VEC3_E, 1 / BALL_INERTIA);
+          }
+          if (cue.pendingSpin) cue.pendingSpin.set(0, 0);
+          cue.spinMode = 'standard';
+          cue.swerveStrength = 0;
+          cue.swervePowerStrength = 0;
+          resetSpinRef.current?.();
+          cueLiftRef.current.lift = 0;
+          cueLiftRef.current.startLift = 0;
+          cue.impacted = false;
+          cue.launchDir = shotAimDir.clone().normalize();
+          maxPowerLiftTriggered = false;
+          cue.lift = 0;
+          cue.liftVel = 0;
+          playCueHit(clampedPower * 0.6);
+          spawnCueImpactDust({
+            origin: new THREE.Vector3(cue.pos.x, CUE_Y, cue.pos.y),
+            direction: new THREE.Vector3(shotAimDir.x, 0, shotAimDir.y),
+            power: clampedPower
+          });
 
           if (cameraRef.current && sphRef.current) {
             topViewRef.current = false;
@@ -26685,13 +26897,9 @@ const shotPowerRef = useRef(0);
           );
           const rawMaxPull = Math.max(0, backInfo.tHit - cueLen - CUE_TIP_GAP);
           const maxPull = Number.isFinite(rawMaxPull) ? rawMaxPull : CUE_PULL_BASE;
-          // Rebuilt stroke pullback: tie visible pull directly to slider power
-          // and the currently available room behind the cue ball.
-          const pullRange = THREE.MathUtils.clamp(
-            maxPull * 0.92,
-            CUE_PULL_MIN_VISUAL,
-            Math.max(CUE_PULL_MIN_VISUAL, maxPull)
-          );
+          // Mirror the reference stroke pullback curve exactly:
+          // pull = pullRange * easeOutCubic(power), then push forward on strike.
+          const pullRange = 0.24;
           const pullTarget = pullRange * strokeProfile.pullRatio;
           const pulledNow = cuePullCurrentRef.current ?? pullTarget;
           const startPull = THREE.MathUtils.clamp(pulledNow, 0, Math.max(maxPull, 0));
@@ -26736,9 +26944,9 @@ const shotPowerRef = useRef(0);
               .sub(TMP_VEC3_CUE_TIP_OFFSET);
           };
           const idlePos = buildCuePosition(0);
-          // Start the release exactly from the computed pull position so the
-          // cue always pushes forward from the same pulled depth the player set.
-          const releaseStartPos = buildCuePosition(visualPull);
+          // Start the release from the *currently visible* pulled cue position
+          // so slider release always pushes forward from what the player sees.
+          const releaseStartPos = cueStick.position.clone();
           cueStick.position.copy(releaseStartPos);
           TMP_VEC3_BUTT.copy(cueStick.position).add(TMP_VEC3_CUE_BUTT_OFFSET);
           cueAnimating = true;
@@ -26888,13 +27096,11 @@ const shotPowerRef = useRef(0);
               // Slider release should drive an immediate forward strike from the
               // currently pulled cue position back to contact.
               forwardOnly: true,
-              onImpact: () => applyShotAtImpact(shotImpactPayload),
               animationStyle: strokeStyle,
               motionTechnique: strokeProfile.motion ?? strokeStyle,
               releaseStartsFromCurrentPull: true
             };
           } else {
-            applyShotAtImpact(shotImpactPayload);
             cueStick.visible = false;
             cueAnimating = false;
             cuePullCurrentRef.current = 0;
@@ -30009,6 +30215,12 @@ const shotPowerRef = useRef(0);
             if (cueStick?.visible) {
               cueStick.position.y = Math.max(cueStick.position.y, CUE_Y + BALL_R * 0.06);
             }
+            updateHumanActors({
+              cueBall: cue,
+              turn: hudRef.current?.turn ?? 0,
+              shotActive: shooting,
+              ballsState: balls
+            });
             renderer.render(scene, frameCamera ?? camera);
             const finished = elapsed >= duration || elapsed - duration >= REPLAY_TIMEOUT_GRACE_MS;
             if (finished) {
@@ -30219,6 +30431,12 @@ const shotPowerRef = useRef(0);
           (!(currentHud?.inHand) || cueBallPlacedFromHandRef.current) &&
           !remoteShotActive &&
           (isPlayerTurn || previewingAiShot || aiCueViewActive);
+        updateHumanActors({
+          cueBall: cue,
+          turn: currentHud?.turn ?? 0,
+          shotActive: shooting,
+          ballsState: balls
+        });
         if (
           cue?.pos &&
           !sliderInstanceRef.current?.dragging &&
@@ -32538,6 +32756,12 @@ const shotPowerRef = useRef(0);
         activeRenderCameraRef.current = null;
         cueBodyRef.current = null;
         tipGroupRef.current = null;
+        humanActors.forEach((actor) => {
+          actor?.group?.parent?.remove?.(actor.group);
+        });
+        humanActors.length = 0;
+        humanTemplateRef.current = null;
+        humanLoadRef.current = null;
         try {
           host.removeChild(renderer.domElement);
         } catch {}
@@ -32710,19 +32934,6 @@ const shotPowerRef = useRef(0);
   // NEW Big Pull Slider (right side): drag DOWN to set power, releases → fire()
   // --------------------------------------------------
   const sliderRef = useRef(null);
-  const onPowerDragStart = useCallback(() => {
-    captureCueStickAnchor();
-  }, [captureCueStickAnchor]);
-  const onPowerDrag = useCallback((powerRatio = 0) => {
-    applyPower(powerRatio);
-  }, [applyPower]);
-  const onPowerRelease = useCallback((powerRatio = null) => {
-    const sourcePower = Number.isFinite(powerRatio) ? powerRatio : powerRef.current;
-    const latchedPower = clampPower(sourcePower, 0);
-    shotPowerRef.current = latchedPower;
-    applyPower(latchedPower);
-    fireRef.current?.(latchedPower);
-  }, [applyPower, clampPower]);
   const showPowerSlider = hud.turn === 0 && !hud.over && !replayActive && !shotActive;
   useEffect(() => {
     if (!showPowerSlider) {
@@ -32735,15 +32946,14 @@ const shotPowerRef = useRef(0);
       value: powerRef.current * 100,
       cueSrc: '/assets/snooker/cue.webp',
       labels: true,
-      onChange: (v) => onPowerDrag((v ?? 0) / 100),
-      onStart: () => onPowerDragStart(),
-      onCommit: (committedValue) => {
-        const hasCommittedValue = Number.isFinite(committedValue);
-        const powerRatio = hasCommittedValue
-          ? THREE.MathUtils.clamp(committedValue / 100, 0, 1)
-          : clampPower(powerRef.current, 0);
-        onPowerRelease(powerRatio);
-        const resetDurationMs = 160;
+      onChange: (v) => applyPower(v / 100),
+      onStart: () => {
+        captureCueStickAnchor();
+      },
+      onCommit: (committedValue = 0) => {
+        fireRef.current?.();
+        const powerRatio = THREE.MathUtils.clamp((committedValue ?? 0) / 100, 0, 1);
+        const resetDurationMs = THREE.MathUtils.lerp(190, 105, powerRatio);
         slider.animateToMin({ duration: resetDurationMs });
       }
     });
@@ -32753,7 +32963,7 @@ const shotPowerRef = useRef(0);
       sliderInstanceRef.current = null;
       slider.destroy();
     };
-  }, [applySliderLock, clampPower, onPowerDrag, onPowerDragStart, onPowerRelease, showPowerSlider]);
+  }, [applySliderLock, captureCueStickAnchor, showPowerSlider]);
   useEffect(() => {
     if (shotActive || hud.over || hud.turn !== 0) return;
     const slider = sliderInstanceRef.current;


### PR DESCRIPTION
### Motivation
- Restore the Pool Royale cue-stick animation and power-slider behavior to the previous (four days ago) flow so slider maps directly to visible cue pull and release triggers an immediate forward strike. 
- Add two 3D human actors that visually behave like pool players around the table (walk outside the table while balls move, move into aiming positions when table is settled, and take a right-hand cue-hold shooting pose). 

### Description
- Restored cue/power behavior in `PoolRoyale.jsx` by reintroducing the previous cue stroke timing/profile and by mapping slider input directly to the visible cue pull and immediate forward strike on release. 
- Reworked the power-slider hookup so the slider updates `hud.power` directly and commit triggers the in-game `fire()` call while the slider reset animation duration is scaled by power. 
- Added a Ready Player Me human model constant and loader (`POOL_ROYALE_HUMAN_URL` + `GLTFLoader`), plus `buildHumanActor`, `ensureHumanActors`, and `updateHumanActors` routines to spawn two cloned actors, attach a cue prop to the right hand, capture rest poses and apply lightweight bone offsets for walking/aim/idle poses. 
- Integrated actor updates into both live render and replay loops and added cleanup to remove actor groups and clear load state when the scene is disposed. 

### Testing
- Ran unit tests for cue stroke timeline: `npm test -- --runInBand test/poolRoyaleCueStrokeTimeline.test.js` and the suite passed (4 tests passed). 
- Ran linter on the file with `npx eslint webapp/src/pages/Games/PoolRoyale.jsx`, which reported the file is ignored by repo lint settings (no lint errors surfaced for project-run lint).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb8bb823fc832997f65471fd505c74)