### PR TITLE
Fix Ludo seated human scale, orientation, and texture mapping

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1761,9 +1761,10 @@ const CHAIR_MODEL_URLS = [
 ];
 const SEATED_HUMAN_MODEL_URL = 'https://threejs.org/examples/models/gltf/readyplayer.me.glb';
 const SEATED_HUMAN_BASE_HEIGHT = 1.74;
-const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 1.62;
-const SEATED_HUMAN_SEAT_Y_OFFSET = -0.07 * MODEL_SCALE * STOOL_SCALE;
-const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.07;
+const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.22;
+const SEATED_HUMAN_SEAT_Y_OFFSET = -0.015 * MODEL_SCALE * STOOL_SCALE;
+const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.2;
+const SEATED_HUMAN_FACING_Y = 0;
 const SEATED_HUMAN_ROLL_MS = 1680;
 const SEATED_HUMAN_RECOVER_MS = 420;
 let seatedHumanTemplatePromise = null;
@@ -4221,7 +4222,7 @@ function applySeatedHumanPose(rig, mode = 'idle', intensity = 1, handGrip = 0) {
 async function loadSeatedHumanTemplate() {
   if (seatedHumanTemplatePromise) return seatedHumanTemplatePromise;
   seatedHumanTemplatePromise = (async () => {
-    const loader = new GLTFLoader();
+    const loader = createConfiguredGLTFLoader();
     loader.setCrossOrigin('anonymous');
     const gltf = await loader.loadAsync(SEATED_HUMAN_MODEL_URL);
     const root = gltf?.scene || gltf?.scenes?.[0];
@@ -4233,10 +4234,8 @@ async function loadSeatedHumanTemplate() {
         obj.frustumCulled = false;
         const materials = Array.isArray(obj.material) ? obj.material : obj.material ? [obj.material] : [];
         materials.forEach((mat) => {
-          if (mat?.map) {
-            applySRGBColorSpace(mat.map);
-            mat.map.needsUpdate = true;
-          }
+          normalizeMaterialTextures(mat, 8, { preserveGltfTextureMapping: true });
+          if (mat?.emissiveMap) mat.emissiveMap.needsUpdate = true;
           mat.needsUpdate = true;
         });
       }
@@ -6679,7 +6678,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         const actor = cloneSkeleton(humanTemplate);
         actor.scale.setScalar(baseScale);
         actor.position.set(0, SEATED_HUMAN_SEAT_Y_OFFSET, SEATED_HUMAN_SEAT_Z_OFFSET);
-        actor.rotation.set(0, Math.PI, 0);
+        actor.rotation.set(0, SEATED_HUMAN_FACING_Y, 0);
         chair.group.add(actor);
         const rig = saveBoneRig(actor);
         applySeatedHumanPose(rig, 'idle', 1);


### PR DESCRIPTION
### Motivation
- Seated human characters on Ludo chairs were visually too small, facing the wrong way, and their legs/pose did not align with chair geometry, so adjust placement and pose to match chair proportions.  
- Preserve original model textures from the glTF source so avatars look like the original Ready Player Me assets rather than losing texture mapping when cloned.

### Description
- Increased `SEATED_HUMAN_TARGET_HEIGHT` and adjusted `SEATED_HUMAN_SEAT_Y_OFFSET` and `SEATED_HUMAN_SEAT_Z_OFFSET` to make the human models larger and reposition them to sit correctly in the chairs.  
- Replaced the hard 180° rotation with a `SEATED_HUMAN_FACING_Y` constant and applied it to actor rotation so characters face the correct direction relative to chairs.  
- Switched seated human loading to `createConfiguredGLTFLoader()` and used `normalizeMaterialTextures(..., { preserveGltfTextureMapping: true })` to keep original texture mapping (including emissive maps) instead of reassigning or blanking textures.  
- Modified `loadSeatedHumanTemplate()` and the human placement loop to apply the new loader, texture normalization, offsets and facing; changes are contained in `webapp/src/pages/Games/LudoBattleRoyal.jsx`.

### Testing
- Attempted to run lint with `npm -C webapp run lint`, but the package has no `lint` script so the lint step could not be executed (automated lint not available).  
- Verified repository changes with `git status --short` and `git diff` which reported the updated `webapp/src/pages/Games/LudoBattleRoyal.jsx`.  
- Committed the change (`git commit`) successfully; runtime visual verification is recommended in a browser/preview since this is a front-end model/pose adjustment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb8d53b1f483299af6e092b28fd1b8)