### PR TITLE
Scale up seated Ludo avatars, fix leg pose, and stabilize GLTF loading/texture mapping

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1762,6 +1762,7 @@ const CHAIR_MODEL_URLS = [
 const SEATED_HUMAN_MODEL_URL = 'https://threejs.org/examples/models/gltf/readyplayer.me.glb';
 const SEATED_HUMAN_BASE_HEIGHT = 1.74;
 const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.22;
+const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 3;
 const SEATED_HUMAN_SEAT_Y_OFFSET = -0.015 * MODEL_SCALE * STOOL_SCALE;
 const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.2;
 const SEATED_HUMAN_FACING_Y = 0;
@@ -4063,12 +4064,13 @@ function applySeatedHumanPose(rig, mode = 'idle', intensity = 1, handGrip = 0) {
   addBoneRot(rig, rig.neck, -0.05, 0, 0, 1);
   addBoneRot(rig, rig.head, -0.06, 0, 0, 1);
 
-  addBoneRot(rig, rig.leftUpperLeg, 0.94, -0.08, 0.04, 1);
-  addBoneRot(rig, rig.leftLowerLeg, -1.08, 0, 0, 1);
-  addBoneRot(rig, rig.leftFoot, 0.22, 0, 0, 1);
-  addBoneRot(rig, rig.rightUpperLeg, 0.94, 0.08, -0.04, 1);
-  addBoneRot(rig, rig.rightLowerLeg, -1.08, 0, 0, 1);
-  addBoneRot(rig, rig.rightFoot, 0.22, 0, 0, 1);
+  // Keep legs seated downward so feet do not point up/out from the chair in portrait views.
+  addBoneRot(rig, rig.leftUpperLeg, 1.36, -0.05, -0.08, 1);
+  addBoneRot(rig, rig.leftLowerLeg, -0.34, 0, 0, 1);
+  addBoneRot(rig, rig.leftFoot, -0.22, 0.04, 0.02, 1);
+  addBoneRot(rig, rig.rightUpperLeg, 1.36, 0.05, 0.08, 1);
+  addBoneRot(rig, rig.rightLowerLeg, -0.34, 0, 0, 1);
+  addBoneRot(rig, rig.rightFoot, -0.22, -0.04, -0.02, 1);
 
   addBoneRot(rig, rig.leftUpperArm, -0.28, 0.12, 0.96, 1);
   addBoneRot(rig, rig.leftForeArm, -0.62, 0.05, -0.24, 1);
@@ -4219,10 +4221,10 @@ function applySeatedHumanPose(rig, mode = 'idle', intensity = 1, handGrip = 0) {
   applyRightHandGrip(rig, handGrip);
 }
 
-async function loadSeatedHumanTemplate() {
+async function loadSeatedHumanTemplate(renderer = null) {
   if (seatedHumanTemplatePromise) return seatedHumanTemplatePromise;
   seatedHumanTemplatePromise = (async () => {
-    const loader = createConfiguredGLTFLoader();
+    const loader = createConfiguredGLTFLoader(renderer);
     loader.setCrossOrigin('anonymous');
     const gltf = await loader.loadAsync(SEATED_HUMAN_MODEL_URL);
     const root = gltf?.scene || gltf?.scenes?.[0];
@@ -6672,8 +6674,9 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     }
     seatedHumanActorsRef.current = [];
     try {
-      const humanTemplate = await loadSeatedHumanTemplate();
-      const baseScale = SEATED_HUMAN_TARGET_HEIGHT / Math.max(SEATED_HUMAN_BASE_HEIGHT, 0.01);
+      const humanTemplate = await loadSeatedHumanTemplate(renderer);
+      const baseScale =
+        (SEATED_HUMAN_TARGET_HEIGHT / Math.max(SEATED_HUMAN_BASE_HEIGHT, 0.01)) * SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER;
       chairs.forEach((chair, playerIndex) => {
         const actor = cloneSkeleton(humanTemplate);
         actor.scale.setScalar(baseScale);


### PR DESCRIPTION
### Motivation
- Players reported seated human characters are too small and legs point the wrong way in portrait view, and the GLTF/KTX2 pipeline must use the real renderer so original texture mapping and converters (KTX2/Basis) work correctly.

### Description
- Add `SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 3` and apply it when instantiating seated human actors so avatars render approximately 3x larger on chairs in the Ludo scene (`webapp/src/pages/Games/LudoBattleRoyal.jsx`).
- Rework seated leg/foot bone rotations inside `applySeatedHumanPose` so legs sit downward naturally in portrait views instead of pointing up/outwards.
- Change `loadSeatedHumanTemplate` to accept an optional `renderer` and pass it into `createConfiguredGLTFLoader(renderer)` so KTX2/Basis support detection runs against the active renderer; keep `preserveGltfTextureMapping: true` when normalizing seated human materials.

### Testing
- Ran `npm test -- --runInBand test/lobbyUtils.test.js`, which passed (1 test suite, 6 tests passed). 
- Ran ESLint on the modified file `./node_modules/.bin/eslint webapp/src/pages/Games/LudoBattleRoyal.jsx`, which completed with only an ignore-pattern warning and no lint errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb9262767483299ddc2366b5e18c8e)