### PR TITLE
Fix seated avatars: chair alignment, rotation and leg/spine pose (SnakeBoard3D)

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -79,7 +79,7 @@ const CHAIR_MODEL_URLS = [
 ];
 const HUMAN_MODEL_URL = 'https://threejs.org/examples/models/gltf/readyplayer.me.glb';
 const HUMAN_MODEL_CACHE = { promise: null, template: null };
-const HUMAN_SEAT_LOCAL_POSITION = new THREE.Vector3(0, -0.2, 0.04);
+const HUMAN_SEAT_LOCAL_POSITION = new THREE.Vector3(0.18, -0.44, -0.2);
 const HUMAN_SEAT_SCALE = 1.75;
 const SNAKE_TOKEN_MODEL_URLS = [
   'https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Models@master/2.0/ABeautifulGame/glTF-Binary/ABeautifulGame.glb',
@@ -1581,19 +1581,19 @@ function applySeatedHumanPose(seatHuman, timeSeconds = 0, activeLean = 0) {
   const breathe = Math.sin(timeSeconds * 1.05) * 0.016;
   const dynamicLean = activeLean * 0.06;
 
-  composeModelBone(rest, bones.hips, new THREE.Euler(-0.18 - dynamicLean, 0, 0, 'XYZ'));
-  composeModelBone(rest, bones.spine, new THREE.Euler(0.36 + breathe - dynamicLean * 0.32, 0, 0, 'XYZ'));
-  composeModelBone(rest, bones.spine1, new THREE.Euler(0.2, 0, 0, 'XYZ'));
-  composeModelBone(rest, bones.spine2, new THREE.Euler(0.1, 0, 0, 'XYZ'));
+  composeModelBone(rest, bones.hips, new THREE.Euler(-0.24 - dynamicLean, 0.02, 0, 'XYZ'));
+  composeModelBone(rest, bones.spine, new THREE.Euler(0.3 + breathe - dynamicLean * 0.32, 0, 0, 'XYZ'));
+  composeModelBone(rest, bones.spine1, new THREE.Euler(0.18, 0, 0, 'XYZ'));
+  composeModelBone(rest, bones.spine2, new THREE.Euler(0.12, 0, 0, 'XYZ'));
   composeModelBone(rest, bones.neck, new THREE.Euler(-0.14, 0, 0, 'XYZ'));
   composeModelBone(rest, bones.head, new THREE.Euler(-0.08, Math.sin(timeSeconds * 0.27) * 0.03, 0, 'XYZ'));
 
-  composeModelBone(rest, bones.leftUpLeg, new THREE.Euler(-1.46, 0.15, 0.08, 'XYZ'));
-  composeModelBone(rest, bones.rightUpLeg, new THREE.Euler(-1.46, -0.15, -0.08, 'XYZ'));
-  composeModelBone(rest, bones.leftLeg, new THREE.Euler(1.56, 0, 0, 'XYZ'));
-  composeModelBone(rest, bones.rightLeg, new THREE.Euler(1.56, 0, 0, 'XYZ'));
-  composeModelBone(rest, bones.leftFoot, new THREE.Euler(-0.08, 0.06, 0.05, 'XYZ'));
-  composeModelBone(rest, bones.rightFoot, new THREE.Euler(-0.08, -0.06, -0.05, 'XYZ'));
+  composeModelBone(rest, bones.leftUpLeg, new THREE.Euler(-1.3, 0.1, 0.06, 'XYZ'));
+  composeModelBone(rest, bones.rightUpLeg, new THREE.Euler(-1.3, -0.1, -0.06, 'XYZ'));
+  composeModelBone(rest, bones.leftLeg, new THREE.Euler(1.24, 0, 0, 'XYZ'));
+  composeModelBone(rest, bones.rightLeg, new THREE.Euler(1.24, 0, 0, 'XYZ'));
+  composeModelBone(rest, bones.leftFoot, new THREE.Euler(-0.2, 0.04, 0.03, 'XYZ'));
+  composeModelBone(rest, bones.rightFoot, new THREE.Euler(-0.2, -0.04, -0.03, 'XYZ'));
 
   composeModelBone(rest, bones.leftShoulder, new THREE.Euler(-0.14, 0.06, -0.3, 'XYZ'));
   composeModelBone(rest, bones.rightShoulder, new THREE.Euler(-0.14, -0.06, 0.3, 'XYZ'));
@@ -3286,7 +3286,7 @@ function buildArena(scene, renderer, host, cameraRef, disposeHandlers, appearanc
 
     const humanAnchor = new THREE.Object3D();
     humanAnchor.position.copy(HUMAN_SEAT_LOCAL_POSITION);
-    humanAnchor.rotation.set(0, 0, 0);
+    humanAnchor.rotation.set(0, Math.PI, 0);
     group.add(humanAnchor);
 
     const chairModel = chairTemplate ? chairTemplate.clone(true) : null;


### PR DESCRIPTION
### Motivation
- Avatars were visually misaligned on procedural chairs with legs appearing on the wrong side and feet not meeting the floor, so the seated pose needed repositioning and bone tuning. 
- The goal is to place hips on the seat, lower feet to touch the ground, and have the backrest support the torso for a natural seated posture. 
- Changes target the Snake & Ladder 3D arena seating so characters match chair orientation and look grounded in portrait view.

### Description
- Updated the avatar local seat anchor in `webapp/src/components/SnakeBoard3D.jsx` by changing `HUMAN_SEAT_LOCAL_POSITION` from `new THREE.Vector3(0, -0.2, 0.04)` to `new THREE.Vector3(0.18, -0.44, -0.2)` to move avatars lower, farther back, and toward the chair side. 
- Rotated the per-seat `humanAnchor` by setting `humanAnchor.rotation.set(0, Math.PI, 0)` so the body faces the correct direction relative to the chair and fixes wrong-side leg placement. 
- Tuned seated pose bone Euler angles inside `applySeatedHumanPose` (adjusted `hips`, `spine`, `spine1`, `spine2`, `leftUpLeg`, `rightUpLeg`, `leftLeg`, `rightLeg`, `leftFoot`, and `rightFoot`) to produce a more grounded seated pose (hips lowered, spine leaned, feet rotated down). 
- Changes are limited to `SnakeBoard3D.jsx` and preserve existing scale and template-loading flows for cloned skeleton instances.

### Testing
- Ran file-level lint with `npx eslint webapp/src/components/SnakeBoard3D.jsx` which produced only ignore/warning messages and no new errors for the modified file. 
- Ran `npx eslint --no-ignore webapp/src/components/SnakeBoard3D.jsx` which again reported only warnings for this file and no new syntax errors introduced by the changes. 
- Ran repository lint via `npm run lint` which failed due to large pre-existing repo-wide lint issues in generated/legacy files, and the failure is unrelated to the edits in `SnakeBoard3D.jsx`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb932b723c83299ad994a1edb78787)