### PR TITLE
Fix Ludo seated human alignment, leg orientation, and texture fallback

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1762,8 +1762,8 @@ const CHAIR_MODEL_URLS = [
 const SEATED_HUMAN_MODEL_URL = 'https://threejs.org/examples/models/gltf/readyplayer.me.glb';
 const SEATED_HUMAN_BASE_HEIGHT = 1.74;
 const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.22;
-const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 3;
-const SEATED_HUMAN_SEAT_Y_OFFSET = -0.015 * MODEL_SCALE * STOOL_SCALE;
+const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 3.24;
+const SEATED_HUMAN_SEAT_Y_OFFSET = -0.092 * MODEL_SCALE * STOOL_SCALE;
 const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.2;
 const SEATED_HUMAN_FACING_Y = 0;
 const SEATED_HUMAN_ROLL_MS = 1680;
@@ -4051,6 +4051,42 @@ function applyRightHandGrip(rig, gripAmount = 0) {
   });
 }
 
+function createSeatedHumanFallbackTexture(primary = '#cdb8a0', secondary = '#8a6a4e') {
+  const size = 256;
+  const canvas = document.createElement('canvas');
+  canvas.width = size;
+  canvas.height = size;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) {
+    return new THREE.CanvasTexture(canvas);
+  }
+
+  const grad = ctx.createLinearGradient(0, 0, size, size);
+  grad.addColorStop(0, primary);
+  grad.addColorStop(1, secondary);
+  ctx.fillStyle = grad;
+  ctx.fillRect(0, 0, size, size);
+
+  for (let i = 0; i < 180; i += 1) {
+    const x = (i * 53) % size;
+    const y = (i * 79) % size;
+    const w = 8 + ((i * 11) % 22);
+    const h = 4 + ((i * 7) % 14);
+    ctx.globalAlpha = 0.09 + (i % 4) * 0.06;
+    ctx.fillStyle = i % 2 ? 'rgba(255,255,255,0.75)' : 'rgba(0,0,0,0.55)';
+    ctx.fillRect(x, y, w, h);
+  }
+  ctx.globalAlpha = 1;
+  const tex = new THREE.CanvasTexture(canvas);
+  applySRGBColorSpace(tex);
+  tex.flipY = false;
+  tex.wrapS = THREE.RepeatWrapping;
+  tex.wrapT = THREE.RepeatWrapping;
+  tex.anisotropy = 8;
+  tex.needsUpdate = true;
+  return tex;
+}
+
 function applySeatedHumanPose(rig, mode = 'idle', intensity = 1, handGrip = 0) {
   if (!rig) return;
   resetBoneRig(rig);
@@ -4064,13 +4100,13 @@ function applySeatedHumanPose(rig, mode = 'idle', intensity = 1, handGrip = 0) {
   addBoneRot(rig, rig.neck, -0.05, 0, 0, 1);
   addBoneRot(rig, rig.head, -0.06, 0, 0, 1);
 
-  // Keep legs seated downward so feet do not point up/out from the chair in portrait views.
-  addBoneRot(rig, rig.leftUpperLeg, 1.36, -0.05, -0.08, 1);
-  addBoneRot(rig, rig.leftLowerLeg, -0.34, 0, 0, 1);
-  addBoneRot(rig, rig.leftFoot, -0.22, 0.04, 0.02, 1);
-  addBoneRot(rig, rig.rightUpperLeg, 1.36, 0.05, 0.08, 1);
-  addBoneRot(rig, rig.rightLowerLeg, -0.34, 0, 0, 1);
-  addBoneRot(rig, rig.rightFoot, -0.22, -0.04, -0.02, 1);
+  // Force a more natural seated pose: thighs forward + shins down + feet touching floor.
+  addBoneRot(rig, rig.leftUpperLeg, 1.54, -0.04, -0.05, 1);
+  addBoneRot(rig, rig.leftLowerLeg, -1.28, 0.02, 0.02, 1);
+  addBoneRot(rig, rig.leftFoot, -0.12, 0.03, 0.01, 1);
+  addBoneRot(rig, rig.rightUpperLeg, 1.54, 0.04, 0.05, 1);
+  addBoneRot(rig, rig.rightLowerLeg, -1.28, -0.02, -0.02, 1);
+  addBoneRot(rig, rig.rightFoot, -0.12, -0.03, -0.01, 1);
 
   addBoneRot(rig, rig.leftUpperArm, -0.28, 0.12, 0.96, 1);
   addBoneRot(rig, rig.leftForeArm, -0.62, 0.05, -0.24, 1);
@@ -4229,13 +4265,26 @@ async function loadSeatedHumanTemplate(renderer = null) {
     const gltf = await loader.loadAsync(SEATED_HUMAN_MODEL_URL);
     const root = gltf?.scene || gltf?.scenes?.[0];
     if (!root) throw new Error('Missing seated human scene');
+    const skinTex = createSeatedHumanFallbackTexture('#d8c0a6', '#b48d6b');
+    const clothTex = createSeatedHumanFallbackTexture('#55739a', '#2c3f54');
+    const hairTex = createSeatedHumanFallbackTexture('#7b5d3f', '#3f2f20');
     root.traverse((obj) => {
       if (obj?.isMesh) {
         obj.castShadow = true;
         obj.receiveShadow = true;
         obj.frustumCulled = false;
+        const meshName = `${obj.name || ''}`.toLowerCase();
+        const useSkin = /head|face|neck|ear|hand/.test(meshName);
+        const useHair = /hair|beard|mustache|moustache|eyebrow/.test(meshName);
+        const fallbackTex = useHair ? hairTex : useSkin ? skinTex : clothTex;
         const materials = Array.isArray(obj.material) ? obj.material : obj.material ? [obj.material] : [];
         materials.forEach((mat) => {
+          if (!mat?.map) {
+            mat.map = fallbackTex;
+          }
+          if (mat?.color?.setHex) {
+            mat.color.setHex(0xffffff);
+          }
           normalizeMaterialTextures(mat, 8, { preserveGltfTextureMapping: true });
           if (mat?.emissiveMap) mat.emissiveMap.needsUpdate = true;
           mat.needsUpdate = true;


### PR DESCRIPTION
### Motivation
- Players reported seated human avatars were floating too high, legs were oriented upward, and GLTF textures were not visible; avatars also needed to read slightly larger on portrait screens.

### Description
- Lowered the seated avatar anchor and increased visual scale by updating `SEATED_HUMAN_SEAT_Y_OFFSET` and `SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER` in `webapp/src/pages/Games/LudoBattleRoyal.jsx`.
- Reworked leg bone rotations in `applySeatedHumanPose` so thighs/shins/feet rotate to a natural seated posture with feet pointing toward the floor.
- Added `createSeatedHumanFallbackTexture` and applied generated `skin/cloth/hair` fallback textures in `loadSeatedHumanTemplate` when a GLTF mesh material lacks a `map`, and reset material color to avoid all-white meshes.
- Kept existing texture normalization by calling `normalizeMaterialTextures(...)` so fallback textures are prepared consistently with other assets.

### Testing
- Ran `git status --short` to confirm changes are staged and committed successfully (succeeded).
- Ran `npm --prefix webapp run lint` which failed in this environment because the `webapp` package has no `lint` script (automated lint step not available here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb978f3a4c8329ab42f0f7788b2cff)