### PR TITLE
Adjust seated human pose and anchor for Snake & Ladder chairs

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -79,7 +79,11 @@ const CHAIR_MODEL_URLS = [
 ];
 const HUMAN_MODEL_URL = 'https://threejs.org/examples/models/gltf/readyplayer.me.glb';
 const HUMAN_MODEL_CACHE = { promise: null, template: null };
-const HUMAN_SEAT_LOCAL_POSITION = new THREE.Vector3(0.18, -0.44, -0.2);
+// Portrait calibration for seated humans:
+// - move slightly to screen-right
+// - lower the whole body so shoes touch the floor
+// - push backward so hips/back rest into the chair
+const HUMAN_SEAT_LOCAL_POSITION = new THREE.Vector3(0.24, -0.72, -0.34);
 const HUMAN_SEAT_SCALE = 1.75;
 const SNAKE_TOKEN_MODEL_URLS = [
   'https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Models@master/2.0/ABeautifulGame/glTF-Binary/ABeautifulGame.glb',
@@ -1581,19 +1585,19 @@ function applySeatedHumanPose(seatHuman, timeSeconds = 0, activeLean = 0) {
   const breathe = Math.sin(timeSeconds * 1.05) * 0.016;
   const dynamicLean = activeLean * 0.06;
 
-  composeModelBone(rest, bones.hips, new THREE.Euler(-0.24 - dynamicLean, 0.02, 0, 'XYZ'));
-  composeModelBone(rest, bones.spine, new THREE.Euler(0.3 + breathe - dynamicLean * 0.32, 0, 0, 'XYZ'));
-  composeModelBone(rest, bones.spine1, new THREE.Euler(0.18, 0, 0, 'XYZ'));
-  composeModelBone(rest, bones.spine2, new THREE.Euler(0.12, 0, 0, 'XYZ'));
-  composeModelBone(rest, bones.neck, new THREE.Euler(-0.14, 0, 0, 'XYZ'));
+  composeModelBone(rest, bones.hips, new THREE.Euler(-0.1 - dynamicLean * 0.55, 0.03, 0.02, 'XYZ'));
+  composeModelBone(rest, bones.spine, new THREE.Euler(0.2 + breathe - dynamicLean * 0.22, 0, 0, 'XYZ'));
+  composeModelBone(rest, bones.spine1, new THREE.Euler(0.11, 0, 0, 'XYZ'));
+  composeModelBone(rest, bones.spine2, new THREE.Euler(0.08, 0, 0, 'XYZ'));
+  composeModelBone(rest, bones.neck, new THREE.Euler(-0.09, 0, 0, 'XYZ'));
   composeModelBone(rest, bones.head, new THREE.Euler(-0.08, Math.sin(timeSeconds * 0.27) * 0.03, 0, 'XYZ'));
 
-  composeModelBone(rest, bones.leftUpLeg, new THREE.Euler(-1.3, 0.1, 0.06, 'XYZ'));
-  composeModelBone(rest, bones.rightUpLeg, new THREE.Euler(-1.3, -0.1, -0.06, 'XYZ'));
-  composeModelBone(rest, bones.leftLeg, new THREE.Euler(1.24, 0, 0, 'XYZ'));
-  composeModelBone(rest, bones.rightLeg, new THREE.Euler(1.24, 0, 0, 'XYZ'));
-  composeModelBone(rest, bones.leftFoot, new THREE.Euler(-0.2, 0.04, 0.03, 'XYZ'));
-  composeModelBone(rest, bones.rightFoot, new THREE.Euler(-0.2, -0.04, -0.03, 'XYZ'));
+  composeModelBone(rest, bones.leftUpLeg, new THREE.Euler(-1.48, 0.19, 0.08, 'XYZ'));
+  composeModelBone(rest, bones.rightUpLeg, new THREE.Euler(-1.48, 0.03, -0.04, 'XYZ'));
+  composeModelBone(rest, bones.leftLeg, new THREE.Euler(1.56, 0, 0, 'XYZ'));
+  composeModelBone(rest, bones.rightLeg, new THREE.Euler(1.56, 0, 0, 'XYZ'));
+  composeModelBone(rest, bones.leftFoot, new THREE.Euler(-0.12, 0.05, 0.02, 'XYZ'));
+  composeModelBone(rest, bones.rightFoot, new THREE.Euler(-0.12, -0.03, -0.01, 'XYZ'));
 
   composeModelBone(rest, bones.leftShoulder, new THREE.Euler(-0.14, 0.06, -0.3, 'XYZ'));
   composeModelBone(rest, bones.rightShoulder, new THREE.Euler(-0.14, -0.06, 0.3, 'XYZ'));


### PR DESCRIPTION
### Motivation

- Fix seated human placement and pose in the Snake & Ladder arena so characters sit lower, further back and slightly to the right in portrait framing, with feet touching the ground and the back resting on the chair backrest.

### Description

- Update `HUMAN_SEAT_LOCAL_POSITION` in `webapp/src/components/SnakeBoard3D.jsx` to shift the human anchor right, lower, and rearward for portrait calibration.
- Tweak seated rig bone rotations in `applySeatedHumanPose` (hips, spine, spine1, spine2, neck, upper/lower legs, feet) to place hips on the seat, lean the torso into the backrest, and bring feet closer to the floor.
- Changes are purely calibration/pose adjustments and do not alter model loading, animation flow, or other scene logic.

### Testing

- Ran a production build with `cd webapp && npm run -s build`, which completed successfully (build warnings unrelated to this change were reported but did not block the build).
- Attempted `npm run -s lint -- src/components/SnakeBoard3D.jsx` but the project has no lint script configured so the lint step was not executed.
- Verified the repository compiled and generated build artifacts (`dist/` output) without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb9817627483298bba60b2d0c3724d)