### PR TITLE
Fix seated avatar height and leg orientation in Ludo Battle Royal

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1763,7 +1763,7 @@ const SEATED_HUMAN_MODEL_URL = 'https://threejs.org/examples/models/gltf/readypl
 const SEATED_HUMAN_BASE_HEIGHT = 1.74;
 const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.22;
 const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 3.24;
-const SEATED_HUMAN_SEAT_Y_OFFSET = -0.092 * MODEL_SCALE * STOOL_SCALE;
+const SEATED_HUMAN_SEAT_Y_OFFSET = -0.168 * MODEL_SCALE * STOOL_SCALE;
 const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.2;
 const SEATED_HUMAN_FACING_Y = 0;
 const SEATED_HUMAN_ROLL_MS = 1680;
@@ -4100,13 +4100,13 @@ function applySeatedHumanPose(rig, mode = 'idle', intensity = 1, handGrip = 0) {
   addBoneRot(rig, rig.neck, -0.05, 0, 0, 1);
   addBoneRot(rig, rig.head, -0.06, 0, 0, 1);
 
-  // Force a more natural seated pose: thighs forward + shins down + feet touching floor.
-  addBoneRot(rig, rig.leftUpperLeg, 1.54, -0.04, -0.05, 1);
-  addBoneRot(rig, rig.leftLowerLeg, -1.28, 0.02, 0.02, 1);
-  addBoneRot(rig, rig.leftFoot, -0.12, 0.03, 0.01, 1);
-  addBoneRot(rig, rig.rightUpperLeg, 1.54, 0.04, 0.05, 1);
-  addBoneRot(rig, rig.rightLowerLeg, -1.28, -0.02, -0.02, 1);
-  addBoneRot(rig, rig.rightFoot, -0.12, -0.03, -0.01, 1);
+  // Keep legs seated naturally on this rig: thighs slightly raised, knees bent downward, feet angled to floor.
+  addBoneRot(rig, rig.leftUpperLeg, 1.02, -0.05, -0.08, 1);
+  addBoneRot(rig, rig.leftLowerLeg, 1.18, 0.02, 0.02, 1);
+  addBoneRot(rig, rig.leftFoot, 0.16, 0.03, 0.01, 1);
+  addBoneRot(rig, rig.rightUpperLeg, 1.02, 0.05, 0.08, 1);
+  addBoneRot(rig, rig.rightLowerLeg, 1.18, -0.02, -0.02, 1);
+  addBoneRot(rig, rig.rightFoot, 0.16, -0.03, -0.01, 1);
 
   addBoneRot(rig, rig.leftUpperArm, -0.28, 0.12, 0.96, 1);
   addBoneRot(rig, rig.leftForeArm, -0.62, 0.05, -0.24, 1);


### PR DESCRIPTION
### Motivation
- Players reported the human seated avatar looked too high/floaty in portrait view and leg joints pointed in an unnatural direction. 
- The change aims to visually lower the character on the chair and correct bone rotations so legs sit naturally on the stool.

### Description
- Lowered the seated avatar placement by changing `SEATED_HUMAN_SEAT_Y_OFFSET` from `-0.092 * MODEL_SCALE * STOOL_SCALE` to `-0.168 * MODEL_SCALE * STOOL_SCALE` in `webapp/src/pages/Games/LudoBattleRoyal.jsx`.
- Replaced the previous leg rotation values with new rotations for left/right upper/lower legs and feet to produce a natural seated orientation (updated calls to `addBoneRot` in `applySeatedHumanPose`).
- Kept changes localized to tuning constants and pose application logic for Ludo Battle Royal seated-human rigs.

### Testing
- Ran `npm run -s test -- test/lobbyWait.test.js` and the test suite passed (1 test, 1 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb9e70f4ac8329bb7ff1c584907a79)