### PR TITLE
Lower seated Ludo avatar and correct leg pose

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1763,7 +1763,7 @@ const SEATED_HUMAN_MODEL_URL = 'https://threejs.org/examples/models/gltf/readypl
 const SEATED_HUMAN_BASE_HEIGHT = 1.74;
 const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.22;
 const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 3.24;
-const SEATED_HUMAN_SEAT_Y_OFFSET = -0.092 * MODEL_SCALE * STOOL_SCALE;
+const SEATED_HUMAN_SEAT_Y_OFFSET = -0.148 * MODEL_SCALE * STOOL_SCALE;
 const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.2;
 const SEATED_HUMAN_FACING_Y = 0;
 const SEATED_HUMAN_ROLL_MS = 1680;
@@ -4100,13 +4100,13 @@ function applySeatedHumanPose(rig, mode = 'idle', intensity = 1, handGrip = 0) {
   addBoneRot(rig, rig.neck, -0.05, 0, 0, 1);
   addBoneRot(rig, rig.head, -0.06, 0, 0, 1);
 
-  // Force a more natural seated pose: thighs forward + shins down + feet touching floor.
-  addBoneRot(rig, rig.leftUpperLeg, 1.54, -0.04, -0.05, 1);
-  addBoneRot(rig, rig.leftLowerLeg, -1.28, 0.02, 0.02, 1);
-  addBoneRot(rig, rig.leftFoot, -0.12, 0.03, 0.01, 1);
-  addBoneRot(rig, rig.rightUpperLeg, 1.54, 0.04, 0.05, 1);
-  addBoneRot(rig, rig.rightLowerLeg, -1.28, -0.02, -0.02, 1);
-  addBoneRot(rig, rig.rightFoot, -0.12, -0.03, -0.01, 1);
+  // Keep a stable seated profile: thighs angled forward and shins dropping toward the floor.
+  addBoneRot(rig, rig.leftUpperLeg, 1.12, -0.05, -0.06, 1);
+  addBoneRot(rig, rig.leftLowerLeg, -2.18, 0.02, 0.02, 1);
+  addBoneRot(rig, rig.leftFoot, 0.34, 0.03, 0.01, 1);
+  addBoneRot(rig, rig.rightUpperLeg, 1.12, 0.05, 0.06, 1);
+  addBoneRot(rig, rig.rightLowerLeg, -2.18, -0.02, -0.02, 1);
+  addBoneRot(rig, rig.rightFoot, 0.34, -0.03, -0.01, 1);
 
   addBoneRot(rig, rig.leftUpperArm, -0.28, 0.12, 0.96, 1);
   addBoneRot(rig, rig.leftForeArm, -0.62, 0.05, -0.24, 1);


### PR DESCRIPTION
### Motivation
- Players reported seated humanoid avatars appear too high on Ludo chairs and the leg orientation looks incorrect, so the seated anchor and bone rotations were tuned to match the intended visual pose in portrait/mobile view.

### Description
- Lowered the avatar anchor by changing the `SEATED_HUMAN_SEAT_Y_OFFSET` constant so seated actors sit visually lower in chairs in `webapp/src/pages/Games/LudoBattleRoyal.jsx`.
- Reworked the seated leg pose inside `applySeatedHumanPose` by adjusting the upper/lower leg and foot rotation calls so thighs angle forward and shins drop toward the floor instead of flipping upward.
- Kept the change localized to the Ludo scene and the seated-human pose codepath only.

### Testing
- Ran `npx eslint webapp/src/pages/Games/LudoBattleRoyal.jsx` and `npx eslint --no-ignore webapp/src/pages/Games/LudoBattleRoyal.jsx`, both runs reported the repository lint ignore warning for the file and produced no lint errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb9e70f4ac8329bb7ff1c584907a79)