### PR TITLE
Lower seated avatar and correct leg pose in Ludo Battle Royal

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1763,7 +1763,7 @@ const SEATED_HUMAN_MODEL_URL = 'https://threejs.org/examples/models/gltf/readypl
 const SEATED_HUMAN_BASE_HEIGHT = 1.74;
 const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.22;
 const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 3.24;
-const SEATED_HUMAN_SEAT_Y_OFFSET = -0.092 * MODEL_SCALE * STOOL_SCALE;
+const SEATED_HUMAN_SEAT_Y_OFFSET = -0.168 * MODEL_SCALE * STOOL_SCALE;
 const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.2;
 const SEATED_HUMAN_FACING_Y = 0;
 const SEATED_HUMAN_ROLL_MS = 1680;
@@ -4100,13 +4100,13 @@ function applySeatedHumanPose(rig, mode = 'idle', intensity = 1, handGrip = 0) {
   addBoneRot(rig, rig.neck, -0.05, 0, 0, 1);
   addBoneRot(rig, rig.head, -0.06, 0, 0, 1);
 
-  // Force a more natural seated pose: thighs forward + shins down + feet touching floor.
-  addBoneRot(rig, rig.leftUpperLeg, 1.54, -0.04, -0.05, 1);
-  addBoneRot(rig, rig.leftLowerLeg, -1.28, 0.02, 0.02, 1);
-  addBoneRot(rig, rig.leftFoot, -0.12, 0.03, 0.01, 1);
-  addBoneRot(rig, rig.rightUpperLeg, 1.54, 0.04, 0.05, 1);
-  addBoneRot(rig, rig.rightLowerLeg, -1.28, -0.02, -0.02, 1);
-  addBoneRot(rig, rig.rightFoot, -0.12, -0.03, -0.01, 1);
+  // Keep legs in a grounded seated orientation (thighs down/forward, knees bent naturally, feet toward floor).
+  addBoneRot(rig, rig.leftUpperLeg, -1.20, -0.05, -0.03, 1);
+  addBoneRot(rig, rig.leftLowerLeg, 1.08, 0.01, 0.02, 1);
+  addBoneRot(rig, rig.leftFoot, 0.28, 0.02, 0.01, 1);
+  addBoneRot(rig, rig.rightUpperLeg, -1.20, 0.05, 0.03, 1);
+  addBoneRot(rig, rig.rightLowerLeg, 1.08, -0.01, -0.02, 1);
+  addBoneRot(rig, rig.rightFoot, 0.28, -0.02, -0.01, 1);
 
   addBoneRot(rig, rig.leftUpperArm, -0.28, 0.12, 0.96, 1);
   addBoneRot(rig, rig.leftForeArm, -0.62, 0.05, -0.24, 1);


### PR DESCRIPTION
### Motivation
- The seated human characters in the Ludo Battle Royal scene were rendering too high on the chairs and their leg orientation looked incorrect compared to reference photos, so the visual anchor and bone rotations needed adjustment.

### Description
- Lowered the seated avatar anchor by changing `SEATED_HUMAN_SEAT_Y_OFFSET` from `-0.092 * MODEL_SCALE * STOOL_SCALE` to `-0.168 * MODEL_SCALE * STOOL_SCALE` in `LudoBattleRoyal.jsx` to make characters appear visually lower on the chair.
- Replaced the previous leg rotations in `applySeatedHumanPose` with new values that produce a grounded seated orientation by updating upper-leg, lower-leg, and foot bone rotations for both left and right legs.
- All changes are limited to the Ludo seated human rig and offset logic in `webapp/src/pages/Games/LudoBattleRoyal.jsx`.

### Testing
- Ran `npm --prefix webapp run -s build`, which completed successfully (Vite emitted non-blocking warnings about a duplicate package key and large chunk sizes but the build finished).
- Ran `npm --prefix webapp run lint`, which failed because the project contains no `lint` script (no linting step available).
- No unit tests were modified or required for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb9e70f4ac8329bb7ff1c584907a79)