### PR TITLE
Adjust Ludo seated avatar leg alignment on chairs

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1763,7 +1763,7 @@ const SEATED_HUMAN_MODEL_URL = 'https://threejs.org/examples/models/gltf/readypl
 const SEATED_HUMAN_BASE_HEIGHT = 1.74;
 const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.22;
 const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 3.24;
-const SEATED_HUMAN_SEAT_Y_OFFSET = -0.092 * MODEL_SCALE * STOOL_SCALE;
+const SEATED_HUMAN_SEAT_Y_OFFSET = -0.125 * MODEL_SCALE * STOOL_SCALE;
 const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.2;
 const SEATED_HUMAN_FACING_Y = 0;
 const SEATED_HUMAN_ROLL_MS = 1680;
@@ -4093,20 +4093,20 @@ function applySeatedHumanPose(rig, mode = 'idle', intensity = 1, handGrip = 0) {
   const t = smooth01(intensity);
   const breathe = Math.sin(performance.now() * 0.002) * 0.012;
 
-  addBonePos(rig, rig.hips, 0, -0.31, -0.105, 1);
-  addBoneRot(rig, rig.hips, -0.11, 0, 0, 1);
+  addBonePos(rig, rig.hips, 0, -0.345, -0.078, 1);
+  addBoneRot(rig, rig.hips, -0.06, 0, 0, 1);
   addBoneRot(rig, rig.spine, 0.15 + breathe, 0, 0, 1);
   addBoneRot(rig, rig.chest, 0.12, 0, 0, 1);
   addBoneRot(rig, rig.neck, -0.05, 0, 0, 1);
   addBoneRot(rig, rig.head, -0.06, 0, 0, 1);
 
-  // Force a more natural seated pose: thighs forward + shins down + feet touching floor.
-  addBoneRot(rig, rig.leftUpperLeg, 1.54, -0.04, -0.05, 1);
-  addBoneRot(rig, rig.leftLowerLeg, -1.28, 0.02, 0.02, 1);
-  addBoneRot(rig, rig.leftFoot, -0.12, 0.03, 0.01, 1);
-  addBoneRot(rig, rig.rightUpperLeg, 1.54, 0.04, 0.05, 1);
-  addBoneRot(rig, rig.rightLowerLeg, -1.28, -0.02, -0.02, 1);
-  addBoneRot(rig, rig.rightFoot, -0.12, -0.03, -0.01, 1);
+  // Force a natural chair-sit pose: thighs forward, knees bending down, feet resting near the floor.
+  addBoneRot(rig, rig.leftUpperLeg, 1.45, -0.03, -0.04, 1);
+  addBoneRot(rig, rig.leftLowerLeg, 1.12, 0.03, 0.02, 1);
+  addBoneRot(rig, rig.leftFoot, -0.05, 0.02, 0.01, 1);
+  addBoneRot(rig, rig.rightUpperLeg, 1.45, 0.03, 0.04, 1);
+  addBoneRot(rig, rig.rightLowerLeg, 1.12, -0.03, -0.02, 1);
+  addBoneRot(rig, rig.rightFoot, -0.05, -0.02, -0.01, 1);
 
   addBoneRot(rig, rig.leftUpperArm, -0.28, 0.12, 0.96, 1);
   addBoneRot(rig, rig.leftForeArm, -0.62, 0.05, -0.24, 1);


### PR DESCRIPTION
### Motivation
- Seated human actors were positioned and posed such that legs appeared on the wrong side and avatars looked too high above the chair, so their feet did not visually contact the seat/floor.

### Description
- Lowered the seated actor anchor by changing `SEATED_HUMAN_SEAT_Y_OFFSET` from `-0.092 * MODEL_SCALE * STOOL_SCALE` to `-0.125 * MODEL_SCALE * STOOL_SCALE` so avatars sit deeper in the chair.
- Adjusted pelvis/hip transform via `addBonePos(rig, rig.hips, ...)` and `addBoneRot(rig, rig.hips, ...)` to move the pelvis lower and better centered on the seat.
- Reworked leg chain rotations to correct knee/shin orientation and keep feet near the floor by updating `leftUpperLeg`, `leftLowerLeg`, `leftFoot`, and symmetrical `right*` bones in `applySeatedHumanPose`.
- Left arm, chest and head animation parameters unchanged to preserve existing reach/roll behavior.

### Testing
- Ran `npx eslint webapp/src/pages/Games/LudoBattleRoyal.jsx` which reported the file is ignored by the lint configuration and produced a warning but no errors.
- Ran `npx eslint --no-ignore webapp/src/pages/Games/LudoBattleRoyal.jsx` which produced the same ignore warning and no errors.
- Changes were committed to the repository with the message `Fix seated avatar leg pose for Ludo chairs`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebaa2862888329b9b80b0e2d249f30)