### PR TITLE
Fix Snake & Ladder seated human leg orientation and position

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -85,6 +85,8 @@ const HUMAN_MODEL_CACHE = { promise: null, template: null };
 // - push backward so hips/back rest into the chair
 const HUMAN_SEAT_LOCAL_POSITION = new THREE.Vector3(0.24, -0.72, -0.34);
 const HUMAN_SEAT_SCALE = 1.75;
+const HUMAN_FRONT_SIDE_Z = 1;
+const HUMAN_LEG_FRONT_OFFSET = 0.34;
 const SNAKE_TOKEN_MODEL_URLS = [
   'https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Models@master/2.0/ABeautifulGame/glTF-Binary/ABeautifulGame.glb',
   'https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Models@master/2.0/ABeautifulGame/glTF/ABeautifulGame.gltf'
@@ -1528,7 +1530,12 @@ function findModelBone(bones, aliases = []) {
 
 function captureModelRestPose(root) {
   const rest = new Map();
-  getModelBones(root).forEach((bone) => rest.set(bone, bone.quaternion.clone()));
+  getModelBones(root).forEach((bone) => {
+    rest.set(bone, {
+      quaternion: bone.quaternion.clone(),
+      position: bone.position.clone()
+    });
+  });
   return rest;
 }
 
@@ -1536,7 +1543,20 @@ function composeModelBone(rest, bone, euler) {
   if (!bone) return;
   const base = rest.get(bone);
   if (!base) return;
-  bone.quaternion.copy(base).multiply(new THREE.Quaternion().setFromEuler(euler));
+  bone.quaternion.copy(base.quaternion).multiply(new THREE.Quaternion().setFromEuler(euler));
+}
+
+function pushModelBoneFront(rest, bone, amount) {
+  if (!bone) return;
+  const base = rest.get(bone);
+  if (!base) return;
+  bone.position.copy(base.position);
+  bone.position.z += HUMAN_FRONT_SIDE_Z * amount;
+}
+
+function moveHumanLegRootsToFront(bones, rest, amount) {
+  pushModelBoneFront(rest, bones.leftUpLeg, amount);
+  pushModelBoneFront(rest, bones.rightUpLeg, amount);
 }
 
 function buildHumanBoneMap(root) {
@@ -1580,10 +1600,14 @@ function buildHumanBoneMap(root) {
 function applySeatedHumanPose(seatHuman, timeSeconds = 0, activeLean = 0) {
   const { root, bones, rest, baseScale = 1 } = seatHuman || {};
   if (!root || !rest || !bones) return;
-  rest.forEach((quat, bone) => bone.quaternion.copy(quat));
+  rest.forEach((pose, bone) => {
+    bone.quaternion.copy(pose.quaternion);
+    bone.position.copy(pose.position);
+  });
   root.scale.setScalar(baseScale);
   const breathe = Math.sin(timeSeconds * 1.05) * 0.016;
   const dynamicLean = activeLean * 0.06;
+  moveHumanLegRootsToFront(bones, rest, HUMAN_LEG_FRONT_OFFSET);
 
   composeModelBone(rest, bones.hips, new THREE.Euler(-0.1 - dynamicLean * 0.55, 0.03, 0.02, 'XYZ'));
   composeModelBone(rest, bones.spine, new THREE.Euler(0.2 + breathe - dynamicLean * 0.22, 0, 0, 'XYZ'));


### PR DESCRIPTION
### Motivation

- The seated avatar legs were visually misaligned when sitting; the goal is to keep the same character model but adjust how it sits so legs point and sit correctly in portrait view.  

### Description

- Updated `webapp/src/components/SnakeBoard3D.jsx` to capture and restore both bone rotation and position in the rest pose by changing `captureModelRestPose` to store `{ quaternion, position }`.  
- Added helpers `pushModelBoneFront` and `moveHumanLegRootsToFront` plus constants `HUMAN_FRONT_SIDE_Z` and `HUMAN_LEG_FRONT_OFFSET` to translate upper leg root bones toward the visual front side before applying seated rotations.  
- Adjusted `composeModelBone` to use the stored quaternion and updated `applySeatedHumanPose` to restore quaternion+position and call the leg-root front-offset before applying the seated bone rotations so the model and pose remain the same but sit correctly.  

### Testing

- Ran lint check: `npx eslint webapp/src/components/SnakeBoard3D.jsx` (ran; file is ignored by repo ESLint config).  
- Built the webapp: `npm --prefix webapp run build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebadcfa3508329bf49bff276121a32)