### PR TITLE
Fix Ludo seated avatar leg direction and seat alignment

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -4087,6 +4087,15 @@ function createSeatedHumanFallbackTexture(primary = '#cdb8a0', secondary = '#8a6
   return tex;
 }
 
+const FRONT_SIDE_Z = 1;
+const LEG_FRONT_OFFSET_MIXAMO = 0.3;
+
+function moveLegRootsToFront(rig, amount = LEG_FRONT_OFFSET_MIXAMO) {
+  if (!rig) return;
+  addBonePos(rig, rig.leftUpperLeg, 0, 0, FRONT_SIDE_Z * amount, 1);
+  addBonePos(rig, rig.rightUpperLeg, 0, 0, FRONT_SIDE_Z * amount, 1);
+}
+
 function applySeatedHumanPose(rig, mode = 'idle', intensity = 1, handGrip = 0) {
   if (!rig) return;
   resetBoneRig(rig);
@@ -4094,19 +4103,20 @@ function applySeatedHumanPose(rig, mode = 'idle', intensity = 1, handGrip = 0) {
   const breathe = Math.sin(performance.now() * 0.002) * 0.012;
 
   addBonePos(rig, rig.hips, 0, -0.345, -0.078, 1);
-  addBoneRot(rig, rig.hips, -0.06, 0, 0, 1);
-  addBoneRot(rig, rig.spine, 0.15 + breathe, 0, 0, 1);
-  addBoneRot(rig, rig.chest, 0.12, 0, 0, 1);
-  addBoneRot(rig, rig.neck, -0.05, 0, 0, 1);
+  moveLegRootsToFront(rig);
+  addBoneRot(rig, rig.hips, -0.16, 0, 0, 1);
+  addBoneRot(rig, rig.spine, 0.26 + breathe, 0, 0, 1);
+  addBoneRot(rig, rig.chest, 0.16, 0, 0, 1);
+  addBoneRot(rig, rig.neck, -0.04, 0, 0, 1);
   addBoneRot(rig, rig.head, -0.06, 0, 0, 1);
 
-  // Force a natural chair-sit pose: thighs forward, knees bending down, feet resting near the floor.
-  addBoneRot(rig, rig.leftUpperLeg, 1.45, -0.03, -0.04, 1);
-  addBoneRot(rig, rig.leftLowerLeg, 1.12, 0.03, 0.02, 1);
-  addBoneRot(rig, rig.leftFoot, -0.05, 0.02, 0.01, 1);
-  addBoneRot(rig, rig.rightUpperLeg, 1.45, 0.03, 0.04, 1);
-  addBoneRot(rig, rig.rightLowerLeg, 1.12, -0.03, -0.02, 1);
-  addBoneRot(rig, rig.rightFoot, -0.05, -0.02, -0.01, 1);
+  // Match the seated-bone technique: leg roots shifted to visual front + Mixamo-like seated joint angles.
+  addBoneRot(rig, rig.leftUpperLeg, -1.42, 0.14, 0.1, 1);
+  addBoneRot(rig, rig.leftLowerLeg, 1.52, 0.02, 0.02, 1);
+  addBoneRot(rig, rig.leftFoot, -0.16, 0.03, 0.03, 1);
+  addBoneRot(rig, rig.rightUpperLeg, -1.42, -0.14, -0.1, 1);
+  addBoneRot(rig, rig.rightLowerLeg, 1.52, -0.02, -0.02, 1);
+  addBoneRot(rig, rig.rightFoot, -0.16, -0.03, -0.03, 1);
 
   addBoneRot(rig, rig.leftUpperArm, -0.28, 0.12, 0.96, 1);
   addBoneRot(rig, rig.leftForeArm, -0.62, 0.05, -0.24, 1);


### PR DESCRIPTION
### Motivation
- Correct the seated Ludo avatar so the thighs/legs face the visual front without changing the character asset, using the same leg-root + Mixamo-style joint technique from the provided reference.

### Description
- Updated `webapp/src/pages/Games/LudoBattleRoyal.jsx` to add constants `FRONT_SIDE_Z` and `LEG_FRONT_OFFSET_MIXAMO` and a new helper `moveLegRootsToFront` that translates upper-leg roots forward. 
- Modified `applySeatedHumanPose` to call `moveLegRootsToFront`, adjusted hip/spine/chest/neck baseline rotations, and replaced the previous leg joint angles with Mixamo-style seated rotations so feet and knees orient correctly while keeping the same model.
- All changes are purely pose/position adjustments (no model or asset replacements) and preserve existing arm/hand pose logic.

### Testing
- Ran the production build with `npm --prefix webapp run build`, which completed successfully (build warnings shown but build finished).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebad97d9788329a8c7a1017b8e9cd9)