### PR TITLE
Adjust Snake & Ladder seated avatar torso to face board

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -87,6 +87,9 @@ const HUMAN_SEAT_LOCAL_POSITION = new THREE.Vector3(0.24, -0.72, -0.34);
 const HUMAN_SEAT_SCALE = 1.75;
 const HUMAN_FRONT_SIDE_Z = 1;
 const HUMAN_LEG_FRONT_OFFSET = 0.34;
+const HUMAN_TORSO_FACE_BOARD_YAW = 0.32;
+const HUMAN_NECK_FACE_BOARD_YAW = 0.22;
+const HUMAN_HEAD_FACE_BOARD_YAW = 0.14;
 const SNAKE_TOKEN_MODEL_URLS = [
   'https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Models@master/2.0/ABeautifulGame/glTF-Binary/ABeautifulGame.glb',
   'https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Models@master/2.0/ABeautifulGame/glTF/ABeautifulGame.gltf'
@@ -1609,12 +1612,24 @@ function applySeatedHumanPose(seatHuman, timeSeconds = 0, activeLean = 0) {
   const dynamicLean = activeLean * 0.06;
   moveHumanLegRootsToFront(bones, rest, HUMAN_LEG_FRONT_OFFSET);
 
-  composeModelBone(rest, bones.hips, new THREE.Euler(-0.1 - dynamicLean * 0.55, 0.03, 0.02, 'XYZ'));
-  composeModelBone(rest, bones.spine, new THREE.Euler(0.2 + breathe - dynamicLean * 0.22, 0, 0, 'XYZ'));
-  composeModelBone(rest, bones.spine1, new THREE.Euler(0.11, 0, 0, 'XYZ'));
-  composeModelBone(rest, bones.spine2, new THREE.Euler(0.08, 0, 0, 'XYZ'));
-  composeModelBone(rest, bones.neck, new THREE.Euler(-0.09, 0, 0, 'XYZ'));
-  composeModelBone(rest, bones.head, new THREE.Euler(-0.08, Math.sin(timeSeconds * 0.27) * 0.03, 0, 'XYZ'));
+  composeModelBone(
+    rest,
+    bones.hips,
+    new THREE.Euler(-0.1 - dynamicLean * 0.55, 0.03 + HUMAN_TORSO_FACE_BOARD_YAW * 0.38, 0.02, 'XYZ')
+  );
+  composeModelBone(
+    rest,
+    bones.spine,
+    new THREE.Euler(0.2 + breathe - dynamicLean * 0.22, HUMAN_TORSO_FACE_BOARD_YAW, 0, 'XYZ')
+  );
+  composeModelBone(rest, bones.spine1, new THREE.Euler(0.11, HUMAN_TORSO_FACE_BOARD_YAW * 0.72, 0, 'XYZ'));
+  composeModelBone(rest, bones.spine2, new THREE.Euler(0.08, HUMAN_TORSO_FACE_BOARD_YAW * 0.56, 0, 'XYZ'));
+  composeModelBone(rest, bones.neck, new THREE.Euler(-0.09, HUMAN_NECK_FACE_BOARD_YAW, 0, 'XYZ'));
+  composeModelBone(
+    rest,
+    bones.head,
+    new THREE.Euler(-0.08, HUMAN_HEAD_FACE_BOARD_YAW + Math.sin(timeSeconds * 0.27) * 0.03, 0, 'XYZ')
+  );
 
   composeModelBone(rest, bones.leftUpLeg, new THREE.Euler(-1.48, 0.19, 0.08, 'XYZ'));
   composeModelBone(rest, bones.rightUpLeg, new THREE.Euler(-1.48, 0.03, -0.04, 'XYZ'));


### PR DESCRIPTION
### Motivation
- Players requested the seated character upper body to face the board (matching the Ludo Battle Royale orientation) while keeping the existing leg pose unchanged.
- The change aims to re-orient the torso/neck/head so the character visually looks toward the board on portrait/mobile views without touching leg transforms.

### Description
- Added three tuning constants: `HUMAN_TORSO_FACE_BOARD_YAW`, `HUMAN_NECK_FACE_BOARD_YAW`, and `HUMAN_HEAD_FACE_BOARD_YAW` in `webapp/src/components/SnakeBoard3D.jsx` to parameterize upper-body yaw offsets.
- Updated `applySeatedHumanPose` in `webapp/src/components/SnakeBoard3D.jsx` to apply yaw offsets to `hips`, `spine`, `spine1`, `spine2`, `neck`, and `head` while preserving existing breathing/head micro-motion.
- Left all leg-related transforms and the leg-front offset logic untouched so leg appearance/placement remains exactly as before.

### Testing
- Ran `npx eslint webapp/src/components/SnakeBoard3D.jsx` and it completed without lint errors; the command produced a single warning that the file is ignored by current ESLint ignore settings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebb42038c483298b314cfddb8ddd0b)