### PR TITLE
Align Ludo seated human legs with Snake & Ladder posture

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -4088,7 +4088,7 @@ function createSeatedHumanFallbackTexture(primary = '#cdb8a0', secondary = '#8a6
 }
 
 const FRONT_SIDE_Z = 1;
-const LEG_FRONT_OFFSET_MIXAMO = 0.3;
+const LEG_FRONT_OFFSET_MIXAMO = 0;
 
 function moveLegRootsToFront(rig, amount = LEG_FRONT_OFFSET_MIXAMO) {
   if (!rig) return;
@@ -4110,13 +4110,13 @@ function applySeatedHumanPose(rig, mode = 'idle', intensity = 1, handGrip = 0) {
   addBoneRot(rig, rig.neck, -0.04, 0, 0, 1);
   addBoneRot(rig, rig.head, -0.06, 0, 0, 1);
 
-  // Match the seated-bone technique: leg roots shifted to visual front + Mixamo-like seated joint angles.
-  addBoneRot(rig, rig.leftUpperLeg, -1.42, 0.14, 0.1, 1);
-  addBoneRot(rig, rig.leftLowerLeg, 1.52, 0.02, 0.02, 1);
-  addBoneRot(rig, rig.leftFoot, -0.16, 0.03, 0.03, 1);
-  addBoneRot(rig, rig.rightUpperLeg, -1.42, -0.14, -0.1, 1);
-  addBoneRot(rig, rig.rightLowerLeg, 1.52, -0.02, -0.02, 1);
-  addBoneRot(rig, rig.rightFoot, -0.16, -0.03, -0.03, 1);
+  // Match Snake & Ladder seated leg posture while leaving torso/arm animation unchanged.
+  addBoneRot(rig, rig.leftUpperLeg, 1.45, -0.03, -0.04, 1);
+  addBoneRot(rig, rig.leftLowerLeg, 1.12, 0.03, 0.02, 1);
+  addBoneRot(rig, rig.leftFoot, -0.05, 0.02, 0.01, 1);
+  addBoneRot(rig, rig.rightUpperLeg, 1.45, 0.03, 0.04, 1);
+  addBoneRot(rig, rig.rightLowerLeg, 1.12, -0.03, -0.02, 1);
+  addBoneRot(rig, rig.rightFoot, -0.05, -0.02, -0.01, 1);
 
   addBoneRot(rig, rig.leftUpperArm, -0.28, 0.12, 0.96, 1);
   addBoneRot(rig, rig.leftForeArm, -0.62, 0.05, -0.24, 1);


### PR DESCRIPTION
### Motivation
- Make the Ludo Battle Royal seated human legs match the Snake & Ladder seated-leg posture while leaving torso, arms and other animations unchanged, per art/UX request.

### Description
- Updated `webapp/src/pages/Games/LudoBattleRoyal.jsx` to set `LEG_FRONT_OFFSET_MIXAMO` to `0` so leg roots remain aligned with the Snake setup and avoid moving the roots forward.
- Replaced only the leg joint rotations in `applySeatedHumanPose` (left/right upper leg, lower leg, and foot) with the Snake-matching rotation values while keeping all torso and arm rotations intact.
- Kept the change localized to `moveLegRootsToFront` / `applySeatedHumanPose` so other gameplay systems and animations are unaffected.

### Testing
- Ran `npx eslint webapp/src/pages/Games/LudoBattleRoyal.jsx` and `npx eslint --no-ignore webapp/src/pages/Games/LudoBattleRoyal.jsx`, which reported the file is ignored by the repo lint pattern but produced no lint errors for the changes.
- Verified the diff and committed the change (no runtime tests were executed as part of this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebb3b325188329bb0442fcbf0c29d8)