### PR TITLE
Adjust seated avatar leg pose in Ludo Battle Royal

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -4110,13 +4110,13 @@ function applySeatedHumanPose(rig, mode = 'idle', intensity = 1, handGrip = 0) {
   addBoneRot(rig, rig.neck, -0.04, 0, 0, 1);
   addBoneRot(rig, rig.head, -0.06, 0, 0, 1);
 
-  // Match Snake & Ladder seated leg posture while leaving torso/arm animation unchanged.
-  addBoneRot(rig, rig.leftUpperLeg, -1.48, 0.19, 0.08, 1);
-  addBoneRot(rig, rig.leftLowerLeg, 1.56, 0, 0, 1);
-  addBoneRot(rig, rig.leftFoot, -0.12, 0.05, 0.02, 1);
-  addBoneRot(rig, rig.rightUpperLeg, -1.48, 0.03, -0.04, 1);
-  addBoneRot(rig, rig.rightLowerLeg, 1.56, 0, 0, 1);
-  addBoneRot(rig, rig.rightFoot, -0.12, -0.03, -0.01, 1);
+  // Keep knees visually lower on screen (natural seated 90° posture), not lifted upward.
+  addBoneRot(rig, rig.leftUpperLeg, -1.32, 0.16, 0.05, 1);
+  addBoneRot(rig, rig.leftLowerLeg, -1.28, 0.02, 0.01, 1);
+  addBoneRot(rig, rig.leftFoot, 0.16, 0.03, 0.02, 1);
+  addBoneRot(rig, rig.rightUpperLeg, -1.32, 0.03, -0.02, 1);
+  addBoneRot(rig, rig.rightLowerLeg, -1.28, -0.02, -0.01, 1);
+  addBoneRot(rig, rig.rightFoot, 0.16, -0.02, -0.01, 1);
 
   addBoneRot(rig, rig.leftUpperArm, -0.28, 0.12, 0.96, 1);
   addBoneRot(rig, rig.leftForeArm, -0.62, 0.05, -0.24, 1);


### PR DESCRIPTION
### Motivation
- Fix the seated avatar leg posture so knees and lower legs visually sit lower (a natural seated ~90° posture) instead of appearing lifted on screen, matching the provided photo reference. 
- Improve visual realism for players while preserving existing roll/reach interaction timing. 

### Description
- Updated leg bone rotations in `applySeatedHumanPose` inside `webapp/src/pages/Games/LudoBattleRoyal.jsx` by changing left/right upper leg, lower leg, and foot `addBoneRot` values to lower the knees visually. 
- Replaced the previous Snake & Ladder–aligned leg rotations with new values that keep knees down on screen and flipped the foot rotations to match the new shin orientation. 
- Kept torso and arm bone adjustments unchanged to avoid altering dice-roll/reach animations, and updated the inline comment to reflect the intended visual behavior.

### Testing
- Ran `npm run build` which invokes `tsc -p tsconfig.build.json` and the build completed successfully. 
- Ran `npx eslint webapp/src/pages/Games/LudoBattleRoyal.jsx` and `npx eslint --no-ignore webapp/src/pages/Games/LudoBattleRoyal.jsx`, both produced an ESLint ignore warning for the file path rather than rule errors. 
- No runtime automated animation tests were added; manual visual check is recommended in the running app to confirm the seated posture on portrait mobile view.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec3361c3108329a390da5dfdbe7774)