### PR TITLE
fix(ludo): lower seated human avatar so feet touch ground

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1763,7 +1763,8 @@ const SEATED_HUMAN_MODEL_URL = 'https://threejs.org/examples/models/gltf/readypl
 const SEATED_HUMAN_BASE_HEIGHT = 1.74;
 const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.22;
 const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 3.24;
-const SEATED_HUMAN_SEAT_Y_OFFSET = -0.125 * MODEL_SCALE * STOOL_SCALE;
+// Lower seated avatars so feet visually touch the floor/chair base in portrait gameplay.
+const SEATED_HUMAN_SEAT_Y_OFFSET = -0.38 * MODEL_SCALE * STOOL_SCALE;
 const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.2;
 const SEATED_HUMAN_FACING_Y = 0;
 const SEATED_HUMAN_ROLL_MS = 1680;


### PR DESCRIPTION
### Motivation

- Seated human avatars in the Ludo Battle Royal scene were rendering too high and their feet did not visually contact the chair/floor in portrait gameplay, so the seat offset was tuned to ground the character visually.

### Description

- Lowered the vertical seat offset constant in `webapp/src/pages/Games/LudoBattleRoyal.jsx` by changing `SEATED_HUMAN_SEAT_Y_OFFSET` from `-0.125 * MODEL_SCALE * STOOL_SCALE` to `-0.38 * MODEL_SCALE * STOOL_SCALE` and added an inline comment explaining the portrait visual intent.

### Testing

- Located the Ludo page and confirmed the changed constant via repository search (`rg`) and inspected the updated file with `nl -ba`, which showed the new value and comment; these checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec35e0a0988329aa0d638a846eede6)