### PR TITLE
Align Snake seated avatars with Ludo Battle Royal seating and texture pipeline

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -79,17 +79,18 @@ const CHAIR_MODEL_URLS = [
 ];
 const HUMAN_MODEL_URL = 'https://threejs.org/examples/models/gltf/readyplayer.me.glb';
 const HUMAN_MODEL_CACHE = { promise: null, template: null };
-// Portrait calibration for seated humans:
-// - keep the back close to the chair back-rest
-// - keep hips centered on the seat pan
-// - keep feet grounded for a clear ~90° seated posture
-const HUMAN_SEAT_LOCAL_POSITION = new THREE.Vector3(0.22, -0.76, -0.4);
-const HUMAN_SEAT_SCALE = 1.75;
+// Keep Snake seated humans aligned with Ludo Battle Royal chair anchoring and scale technique.
+const SEATED_HUMAN_BASE_HEIGHT = 1.74;
+const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.22;
+const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 3.24;
+const SEATED_HUMAN_SEAT_Y_OFFSET = -0.38 * MODEL_SCALE * STOOL_SCALE;
+const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.2;
+const SEATED_HUMAN_FACING_Y = 0;
 const HUMAN_FRONT_SIDE_Z = 1;
-const HUMAN_LEG_FRONT_OFFSET = 0.31;
-const HUMAN_TORSO_FACE_BOARD_YAW = 0.24;
-const HUMAN_NECK_FACE_BOARD_YAW = 0.18;
-const HUMAN_HEAD_FACE_BOARD_YAW = 0.12;
+const HUMAN_LEG_FRONT_OFFSET = 0;
+const HUMAN_TORSO_FACE_BOARD_YAW = 0;
+const HUMAN_NECK_FACE_BOARD_YAW = 0;
+const HUMAN_HEAD_FACE_BOARD_YAW = 0;
 const SNAKE_TOKEN_MODEL_URLS = [
   'https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Models@master/2.0/ABeautifulGame/glTF-Binary/ABeautifulGame.glb',
   'https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Models@master/2.0/ABeautifulGame/glTF/ABeautifulGame.gltf'
@@ -1506,6 +1507,58 @@ function applyOriginalTextureMapping(root) {
   });
 }
 
+function normalizeMaterialTextures(material, maxAnisotropy = 8, { preserveGltfTextureMapping = false } = {}) {
+  if (!material) return;
+  const maps = ['map', 'emissiveMap', 'normalMap', 'roughnessMap', 'metalnessMap', 'aoMap', 'alphaMap'];
+  maps.forEach((key) => {
+    const tex = material[key];
+    if (!tex) return;
+    applySRGBColorSpace(tex);
+    if (!preserveGltfTextureMapping) {
+      tex.flipY = false;
+      tex.wrapS = THREE.RepeatWrapping;
+      tex.wrapT = THREE.RepeatWrapping;
+    }
+    tex.anisotropy = Math.max(tex.anisotropy || 1, maxAnisotropy);
+    tex.needsUpdate = true;
+  });
+}
+
+function createSeatedHumanFallbackTexture(primary = '#cdb8a0', secondary = '#8a6a4e') {
+  const size = 256;
+  const canvas = document.createElement('canvas');
+  canvas.width = size;
+  canvas.height = size;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return new THREE.CanvasTexture(canvas);
+
+  const grad = ctx.createLinearGradient(0, 0, size, size);
+  grad.addColorStop(0, primary);
+  grad.addColorStop(1, secondary);
+  ctx.fillStyle = grad;
+  ctx.fillRect(0, 0, size, size);
+
+  for (let i = 0; i < 180; i += 1) {
+    const x = (i * 53) % size;
+    const y = (i * 79) % size;
+    const w = 8 + ((i * 11) % 22);
+    const h = 4 + ((i * 7) % 14);
+    ctx.globalAlpha = 0.09 + (i % 4) * 0.06;
+    ctx.fillStyle = i % 2 ? 'rgba(255,255,255,0.75)' : 'rgba(0,0,0,0.55)';
+    ctx.fillRect(x, y, w, h);
+  }
+
+  ctx.globalAlpha = 1;
+  const tex = new THREE.CanvasTexture(canvas);
+  applySRGBColorSpace(tex);
+  tex.flipY = false;
+  tex.wrapS = THREE.RepeatWrapping;
+  tex.wrapT = THREE.RepeatWrapping;
+  tex.anisotropy = 8;
+  tex.needsUpdate = true;
+  return tex;
+}
+
 function normalizeHumanBoneName(value = '') {
   return String(value).toLowerCase().replace(/[^a-z0-9]/g, '');
 }
@@ -1659,7 +1712,27 @@ async function loadSeatedHumanTemplate(renderer) {
       if (!scene) {
         throw new Error('Failed to load seated human template');
       }
-      applyOriginalTextureMapping(scene);
+      const skinTex = createSeatedHumanFallbackTexture('#d8c0a6', '#b48d6b');
+      const clothTex = createSeatedHumanFallbackTexture('#55739a', '#2c3f54');
+      const hairTex = createSeatedHumanFallbackTexture('#7b5d3f', '#3f2f20');
+      scene.traverse((obj) => {
+        if (!obj?.isMesh) return;
+        obj.castShadow = true;
+        obj.receiveShadow = true;
+        obj.frustumCulled = false;
+        const meshName = `${obj.name || ''}`.toLowerCase();
+        const useSkin = /head|face|neck|ear|hand/.test(meshName);
+        const useHair = /hair|beard|mustache|moustache|eyebrow/.test(meshName);
+        const fallbackTex = useHair ? hairTex : useSkin ? skinTex : clothTex;
+        const materials = Array.isArray(obj.material) ? obj.material : obj.material ? [obj.material] : [];
+        materials.forEach((mat) => {
+          if (!mat?.map) mat.map = fallbackTex;
+          if (mat?.color?.setHex) mat.color.setHex(0xffffff);
+          normalizeMaterialTextures(mat, 8, { preserveGltfTextureMapping: true });
+          if (mat?.emissiveMap) mat.emissiveMap.needsUpdate = true;
+          mat.needsUpdate = true;
+        });
+      });
       HUMAN_MODEL_CACHE.template = scene;
       return scene;
     })();
@@ -3328,8 +3401,8 @@ function buildArena(scene, renderer, host, cameraRef, disposeHandlers, appearanc
     group.add(avatarAnchor);
 
     const humanAnchor = new THREE.Object3D();
-    humanAnchor.position.copy(HUMAN_SEAT_LOCAL_POSITION);
-    humanAnchor.rotation.set(0, Math.PI, 0);
+    humanAnchor.position.set(0, SEATED_HUMAN_SEAT_Y_OFFSET, SEATED_HUMAN_SEAT_Z_OFFSET);
+    humanAnchor.rotation.set(0, SEATED_HUMAN_FACING_Y, 0);
     group.add(humanAnchor);
 
     const chairModel = chairTemplate ? chairTemplate.clone(true) : null;
@@ -3360,13 +3433,15 @@ function buildArena(scene, renderer, host, cameraRef, disposeHandlers, appearanc
         const instance = cloneSkeleton(humanTemplate);
         applyOriginalTextureMapping(instance);
         instance.name = `SnakeSeatHuman_${seatIndex}`;
-        instance.scale.setScalar(HUMAN_SEAT_SCALE);
+        const baseScale =
+          (SEATED_HUMAN_TARGET_HEIGHT / Math.max(SEATED_HUMAN_BASE_HEIGHT, 0.01)) * SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER;
+        instance.scale.setScalar(baseScale);
         chair.humanAnchor.add(instance);
         seatedHumans[seatIndex] = {
           root: instance,
           bones: buildHumanBoneMap(instance),
           rest: captureModelRestPose(instance),
-          baseScale: HUMAN_SEAT_SCALE
+          baseScale
         };
         applySeatedHumanPose(seatedHumans[seatIndex], 0, 0);
       });


### PR DESCRIPTION
### Motivation
- Make Snake & Ladder seated human actors match the same placement, facing and visual scale technique used by Ludo Battle Royal so characters look identical in position and pose across games.
- Ensure WebGL textures and fallback behavior for seated humans match the Ludo pipeline so models render consistently even when GLTF textures are missing or mapped differently.

### Description
- Replaced Snake seated-human anchoring/scale constants with the same seat offsets, facing direction and scale formula used by Ludo (`SEATED_HUMAN_*` constants) and applied them to the human anchor placement and instance scaling in `SnakeBoard3D.jsx`.
- Zeroed the extra torso/head/leg yaw offsets used previously so resting seated pose orientation matches the Ludo-style facing behavior, and preserved the existing seated pose composition logic.
- Added `normalizeMaterialTextures` and `createSeatedHumanFallbackTexture` utilities and applied a fallback-texture + material normalization pass when loading the ReadyPlayer GLTF so skin/cloth/hair maps, sRGB conversion, flip/wrap and anisotropy are handled consistently.
- Updated template loading to apply the new fallback textures and normalization, and adjusted clone/scale logic when instancing seated humans so they use the Ludo visual scale multiplier.

### Testing
- Ran `npx eslint webapp/src/components/SnakeBoard3D.jsx` to validate file parsing (repo ESLint ignore rules mark the file ignored; no syntax issues surfaced).
- Built the web app with `npm --prefix webapp run build` and the production build completed successfully (Vite emitted non-blocking warnings about chunking and dynamic imports which are unrelated to this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec378a57408329ad3de39b1d232e45)