### PR TITLE
Restore Snake seated human scale/orientation and lower feet to floor

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -79,13 +79,15 @@ const CHAIR_MODEL_URLS = [
 ];
 const HUMAN_MODEL_URL = 'https://threejs.org/examples/models/gltf/readyplayer.me.glb';
 const HUMAN_MODEL_CACHE = { promise: null, template: null };
-// Keep Snake seated humans aligned with Ludo Battle Royal chair anchoring and scale technique.
-const SEATED_HUMAN_BASE_HEIGHT = 1.74;
-const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.22;
-const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 3.24;
-const SEATED_HUMAN_SEAT_Y_OFFSET = -0.38 * MODEL_SCALE * STOOL_SCALE;
-const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.2;
-const SEATED_HUMAN_FACING_Y = 0;
+// Portrait-screen tuning for Snake seated humans:
+// - restore the compact pre-PR seated scale
+// - keep the previous seat-facing orientation
+// - lower the avatar so the feet meet the HDRI floor plane visually
+const SEATED_HUMAN_SCALE = 1.75;
+const SEATED_HUMAN_SEAT_X_OFFSET = 0.22;
+const SEATED_HUMAN_SEAT_Y_OFFSET = -0.84;
+const SEATED_HUMAN_SEAT_Z_OFFSET = -0.4;
+const SEATED_HUMAN_FACING_Y = Math.PI;
 const HUMAN_FRONT_SIDE_Z = 1;
 const HUMAN_LEG_FRONT_OFFSET = 0;
 const HUMAN_TORSO_FACE_BOARD_YAW = 0;
@@ -3401,7 +3403,11 @@ function buildArena(scene, renderer, host, cameraRef, disposeHandlers, appearanc
     group.add(avatarAnchor);
 
     const humanAnchor = new THREE.Object3D();
-    humanAnchor.position.set(0, SEATED_HUMAN_SEAT_Y_OFFSET, SEATED_HUMAN_SEAT_Z_OFFSET);
+    humanAnchor.position.set(
+      SEATED_HUMAN_SEAT_X_OFFSET,
+      SEATED_HUMAN_SEAT_Y_OFFSET,
+      SEATED_HUMAN_SEAT_Z_OFFSET
+    );
     humanAnchor.rotation.set(0, SEATED_HUMAN_FACING_Y, 0);
     group.add(humanAnchor);
 
@@ -3433,8 +3439,7 @@ function buildArena(scene, renderer, host, cameraRef, disposeHandlers, appearanc
         const instance = cloneSkeleton(humanTemplate);
         applyOriginalTextureMapping(instance);
         instance.name = `SnakeSeatHuman_${seatIndex}`;
-        const baseScale =
-          (SEATED_HUMAN_TARGET_HEIGHT / Math.max(SEATED_HUMAN_BASE_HEIGHT, 0.01)) * SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER;
+        const baseScale = SEATED_HUMAN_SCALE;
         instance.scale.setScalar(baseScale);
         chair.humanAnchor.add(instance);
         seatedHumans[seatIndex] = {


### PR DESCRIPTION
### Motivation
- Restore the Snake & Ladder seated human appearance to the compact sizing and facing orientation from before the previous PR and visually lower avatars so feet meet the HDRI ground plane on portrait screens.

### Description
- Replaced the previous Ludo-aligned sizing constants with portrait-focused tuning constants (`SEATED_HUMAN_SCALE`, `SEATED_HUMAN_SEAT_X_OFFSET`, `SEATED_HUMAN_SEAT_Y_OFFSET`, `SEATED_HUMAN_SEAT_Z_OFFSET`, `SEATED_HUMAN_FACING_Y`) in `webapp/src/components/SnakeBoard3D.jsx`.
- Updated seat anchor placement to set `humanAnchor.position` with explicit X/Y/Z offsets and kept the intended facing rotation via `humanAnchor.rotation.set(0, SEATED_HUMAN_FACING_Y, 0)`.
- Use the restored fixed `SEATED_HUMAN_SCALE` when creating seated human instances (`instance.scale.setScalar(baseScale)`), replacing the previous derived scale math.
- Kept other seated-human texture/fallback handling and pose application intact so runtime behavior remains consistent.

### Testing
- Ran `npm run build` from the `webapp/` directory and the production build completed successfully (Vite produced non-blocking warnings about duplicate package keys and chunk sizes, but the build finished without errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec3b5c0b6483299995f8d7d5097f0a)