### PR TITLE
Reduce seated human size and lower placement in SnakeBoard3D

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -82,8 +82,8 @@ const HUMAN_MODEL_CACHE = { promise: null, template: null };
 // Keep Snake seated humans aligned with Ludo Battle Royal chair anchoring and scale technique.
 const SEATED_HUMAN_BASE_HEIGHT = 1.74;
 const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.22;
-const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 3.24;
-const SEATED_HUMAN_SEAT_Y_OFFSET = -0.38 * MODEL_SCALE * STOOL_SCALE;
+const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 2.5;
+const SEATED_HUMAN_SEAT_Y_OFFSET = -0.52 * MODEL_SCALE * STOOL_SCALE;
 const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.2;
 const SEATED_HUMAN_FACING_Y = 0;
 const HUMAN_FRONT_SIDE_Z = 1;


### PR DESCRIPTION
### Motivation
- Make the Snake & Ladder human characters visually smaller while keeping their existing orientation and facing behavior. 
- Lower the characters so their feet appear closer to the HDRI ground plane.

### Description
- Reduced `SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER` from `3.24` to `2.5` in `webapp/src/components/SnakeBoard3D.jsx` so seated humans render smaller.
- Lowered `SEATED_HUMAN_SEAT_Y_OFFSET` from `-0.38 * MODEL_SCALE * STOOL_SCALE` to `-0.52 * MODEL_SCALE * STOOL_SCALE` to move the models downward toward the ground.
- Preserved orientation-related constants (e.g. `SEATED_HUMAN_FACING_Y`, torso/neck/head yaw values) so facing/orientation behavior is unchanged.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully with no new runtime errors.
- The build produced the same Vite warnings about dynamic/static imports and chunk size but these were pre-existing and did not cause the build to fail.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec3b5c0b6483299995f8d7d5097f0a)