### PR TITLE
Make seated human characters smaller and lower on chairs

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -82,8 +82,8 @@ const HUMAN_MODEL_CACHE = { promise: null, template: null };
 // Keep Snake seated humans aligned with Ludo Battle Royal chair anchoring and scale technique.
 const SEATED_HUMAN_BASE_HEIGHT = 1.74;
 const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.22;
-const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 2.5;
-const SEATED_HUMAN_SEAT_Y_OFFSET = -0.52 * MODEL_SCALE * STOOL_SCALE;
+const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 2.0;
+const SEATED_HUMAN_SEAT_Y_OFFSET = -0.66 * MODEL_SCALE * STOOL_SCALE;
 const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.2;
 const SEATED_HUMAN_FACING_Y = 0;
 const HUMAN_FRONT_SIDE_Z = 1;


### PR DESCRIPTION
### Motivation
- Seated human characters on the Snake & Ladder 3D board appeared oversized and sat too high on their chairs, impairing visual balance especially on portrait/mobile views.

### Description
- Reduced `SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER` from `2.5` to `2.0` in `webapp/src/components/SnakeBoard3D.jsx` to render seated humans smaller.
- Lowered the seated anchor by changing `SEATED_HUMAN_SEAT_Y_OFFSET` from `-0.52 * MODEL_SCALE * STOOL_SCALE` to `-0.66 * MODEL_SCALE * STOOL_SCALE` in `webapp/src/components/SnakeBoard3D.jsx` so characters sit closer to the bottom of the chair.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully.
- The build reported non-blocking Vite warnings (chunk size and a duplicate `package.json` key) but no errors occurred.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec41ecbca483299b7a5c7ac363ae06)