### PR TITLE
Ludo: make seated human characters larger and sit lower

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1762,8 +1762,11 @@ const CHAIR_MODEL_URLS = [
 const SEATED_HUMAN_MODEL_URL = 'https://threejs.org/examples/models/gltf/readyplayer.me.glb';
 const SEATED_HUMAN_BASE_HEIGHT = 1.74;
 const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.42;
-const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 3.56;
-const SEATED_HUMAN_SEAT_Y_OFFSET = -0.19 * MODEL_SCALE * STOOL_SCALE;
+// Portrait/mobile visual tuning:
+// - make seated characters larger on screen
+// - place them lower in the chair so they sit deeper
+const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 3.95;
+const SEATED_HUMAN_SEAT_Y_OFFSET = -0.26 * MODEL_SCALE * STOOL_SCALE;
 const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.2;
 const SEATED_HUMAN_FACING_Y = 0;
 const SEATED_HUMAN_ROLL_MS = 1680;


### PR DESCRIPTION
### Motivation
- Improve portrait/mobile visuals for Ludo Battle Royal by making seated human characters appear larger on-screen and sit deeper in the chair.

### Description
- Increase `SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER` from `3.56` to `3.95` in `webapp/src/pages/Games/LudoBattleRoyal.jsx` to render characters bigger.
- Lower `SEATED_HUMAN_SEAT_Y_OFFSET` from `-0.19 * MODEL_SCALE * STOOL_SCALE` to `-0.26 * MODEL_SCALE * STOOL_SCALE` so characters sit deeper/lower in chairs.
- Add an inline comment clarifying these tuning changes target portrait/mobile visual direction.

### Testing
- Ran `cd /workspace/TonPlaygramWebApp/webapp && npm run -s build`, which completed successfully.
- Build emitted existing Vite warnings about a duplicate package key and large chunk sizes, but the production build finished without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec43aa7d8c8329978d41abdc0dfa6b)