### PR TITLE
Lower seated chess human actors toward HDRI ground

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -425,6 +425,7 @@ const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 4.05;
 const SEATED_HUMAN_SEAT_Y_OFFSET = -0.36 * MODEL_SCALE * STOOL_SCALE;
 const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.2;
 const SEATED_HUMAN_FACING_Y = 0;
+const SEATED_HUMAN_FOOT_GROUND_DROP = 0.12;
 const SEATED_HUMAN_PICK_LIFT_HEIGHT = 0.3;
 const SEATED_HUMAN_HAND_PIECE_LIFT = 0.075;
 const SEATED_HUMAN_HAND_PIECE_FORWARD = 0.07;
@@ -2183,7 +2184,7 @@ function alignActorFeetToFloorY(actor, floorY = 0) {
   actor.updateMatrixWorld(true);
   const box = new THREE.Box3().setFromObject(actor);
   if (!Number.isFinite(box.min.y)) return 0;
-  const offset = floorY - box.min.y;
+  const offset = floorY - box.min.y - SEATED_HUMAN_FOOT_GROUND_DROP;
   if (Math.abs(offset) > 1e-4) {
     actor.position.y += offset;
     actor.updateMatrixWorld(true);


### PR DESCRIPTION
### Motivation
- Lower seated human characters so their feet visually contact the HDRI ground plane in the Chess Battle Royal scene.

### Description
- Added `SEATED_HUMAN_FOOT_GROUND_DROP = 0.12` and applied it in `alignActorFeetToFloorY` to push seated actors down when aligning their feet to `floorY` in `webapp/src/pages/Games/ChessBattleRoyal.jsx`.

### Testing
- Ran `npm --prefix webapp run build` and the build completed successfully (Vite emitted non-blocking warnings about duplicate package key and chunk sizing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec4779a2548329b7922d069060894f)