### PR TITLE
Ground seated Ludo avatars to chair/floor in LudoBattleRoyal

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1763,10 +1763,11 @@ const SEATED_HUMAN_MODEL_URL = 'https://threejs.org/examples/models/gltf/readypl
 const SEATED_HUMAN_BASE_HEIGHT = 1.74;
 const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.42;
 const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 3.92;
-// Lower seated humans so feet visually rest on the HDRI floor while preserving pose/orientation.
-const SEATED_HUMAN_SEAT_Y_OFFSET = -0.43 * MODEL_SCALE * STOOL_SCALE;
+// Keep seated humans lower so their feet can be grounded against the chair/floor contact plane.
+const SEATED_HUMAN_SEAT_Y_OFFSET = -0.52 * MODEL_SCALE * STOOL_SCALE;
 const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.2;
 const SEATED_HUMAN_FACING_Y = 0;
+const SEATED_HUMAN_FOOT_GROUND_CLEARANCE = 0.002;
 const SEATED_HUMAN_ROLL_MS = 1680;
 const SEATED_HUMAN_RECOVER_MS = 420;
 let seatedHumanTemplatePromise = null;
@@ -4268,6 +4269,21 @@ function applySeatedHumanPose(rig, mode = 'idle', intensity = 1, handGrip = 0) {
   applyRightHandGrip(rig, handGrip);
 }
 
+function alignSeatedHumanFeetToGroundPlane(actor, rig, clearance = SEATED_HUMAN_FOOT_GROUND_CLEARANCE) {
+  if (!actor?.isObject3D) return;
+  actor.updateMatrixWorld(true);
+  const footBones = [rig?.leftFoot, rig?.rightFoot].filter((bone) => bone?.isBone);
+  if (!footBones.length) return;
+  let minFootY = Infinity;
+  footBones.forEach((bone) => {
+    const worldPos = bone.getWorldPosition(new THREE.Vector3());
+    if (Number.isFinite(worldPos.y)) minFootY = Math.min(minFootY, worldPos.y);
+  });
+  if (!Number.isFinite(minFootY)) return;
+  actor.position.y -= minFootY - clearance;
+  actor.updateMatrixWorld(true);
+}
+
 async function loadSeatedHumanTemplate(renderer = null) {
   if (seatedHumanTemplatePromise) return seatedHumanTemplatePromise;
   seatedHumanTemplatePromise = (async () => {
@@ -6745,6 +6761,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         chair.group.add(actor);
         const rig = saveBoneRig(actor);
         applySeatedHumanPose(rig, 'idle', 1);
+        alignSeatedHumanFeetToGroundPlane(actor, rig);
         seatedHumanActorsRef.current.push({ playerIndex, actor, rig });
       });
     } catch (error) {


### PR DESCRIPTION
### Motivation
- Seated human avatars in the Ludo scene appeared to float above chairs/ground in portrait view, so their feet needed to visually contact the HDRI ground to improve realism.
- Provide a robust per-avatar correction that preserves pose while ensuring the bottom of the feet meet the local contact plane.

### Description
- Lowered the seated avatar baseline by changing `SEATED_HUMAN_SEAT_Y_OFFSET` from `-0.43 * MODEL_SCALE * STOOL_SCALE` to `-0.52 * MODEL_SCALE * STOOL_SCALE` in `webapp/src/pages/Games/LudoBattleRoyal.jsx`.
- Added a small constant `SEATED_HUMAN_FOOT_GROUND_CLEARANCE = 0.002` to control minimal foot clearance from the ground plane.
- Implemented `alignSeatedHumanFeetToGroundPlane(actor, rig, clearance)` which measures left/right foot bone world Y positions and shifts the actor down so feet meet the target plane.
- Applied the grounding pass immediately after `applySeatedHumanPose(...)` when instantiating and attaching seated actors so each spawned avatar is corrected automatically.

### Testing
- Ran `npx eslint webapp/src/pages/Games/LudoBattleRoyal.jsx` which executed (repo ignore rules flagged the file as ignored) and reported only an ignore warning and no lint errors.
- Ran `npx eslint --no-ignore webapp/src/pages/Games/LudoBattleRoyal.jsx` which produced the same ignore warning in this environment and no lint errors.
- The change was committed (`git commit`) successfully and the modified file is `webapp/src/pages/Games/LudoBattleRoyal.jsx`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec4eafc57483298cbd4a6d591f40b7)