### PR TITLE
Align seated human models' feet to ground and lower seat offset on portrait screens

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1763,10 +1763,12 @@ const SEATED_HUMAN_MODEL_URL = 'https://threejs.org/examples/models/gltf/readypl
 const SEATED_HUMAN_BASE_HEIGHT = 1.74;
 const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.42;
 const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 3.92;
-// Lower seated humans so feet visually rest on the HDRI floor while preserving pose/orientation.
-const SEATED_HUMAN_SEAT_Y_OFFSET = -0.43 * MODEL_SCALE * STOOL_SCALE;
+// Push seated humans further down on portrait screens to remove any visible hovering.
+const SEATED_HUMAN_SEAT_Y_OFFSET = -0.64 * MODEL_SCALE * STOOL_SCALE;
 const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.2;
 const SEATED_HUMAN_FACING_Y = 0;
+const SEATED_HUMAN_FOOT_GROUND_CLEARANCE = 0.002;
+const SEATED_HUMAN_ANKLE_TO_SOLE_DROP = 0.028;
 const SEATED_HUMAN_ROLL_MS = 1680;
 const SEATED_HUMAN_RECOVER_MS = 420;
 let seatedHumanTemplatePromise = null;
@@ -4268,6 +4270,21 @@ function applySeatedHumanPose(rig, mode = 'idle', intensity = 1, handGrip = 0) {
   applyRightHandGrip(rig, handGrip);
 }
 
+function alignSeatedHumanFeetToGroundPlane(actor, rig, clearance = SEATED_HUMAN_FOOT_GROUND_CLEARANCE) {
+  if (!actor?.isObject3D) return;
+  actor.updateMatrixWorld(true);
+  const footBones = [rig?.leftFoot, rig?.rightFoot].filter((bone) => bone?.isBone);
+  if (!footBones.length) return;
+  let minFootY = Infinity;
+  footBones.forEach((bone) => {
+    const worldPos = bone.getWorldPosition(new THREE.Vector3());
+    if (Number.isFinite(worldPos.y)) minFootY = Math.min(minFootY, worldPos.y);
+  });
+  if (!Number.isFinite(minFootY)) return;
+  actor.position.y -= minFootY - clearance + SEATED_HUMAN_ANKLE_TO_SOLE_DROP;
+  actor.updateMatrixWorld(true);
+}
+
 async function loadSeatedHumanTemplate(renderer = null) {
   if (seatedHumanTemplatePromise) return seatedHumanTemplatePromise;
   seatedHumanTemplatePromise = (async () => {
@@ -6745,6 +6762,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         chair.group.add(actor);
         const rig = saveBoneRig(actor);
         applySeatedHumanPose(rig, 'idle', 1);
+        alignSeatedHumanFeetToGroundPlane(actor, rig);
         seatedHumanActorsRef.current.push({ playerIndex, actor, rig });
       });
     } catch (error) {


### PR DESCRIPTION
### Motivation

- Prevent seated human avatars from appearing to hover above the HDRI floor on portrait/compact layouts by lowering their seat offset and ensuring feet rest on the ground plane.

### Description

- Reduced `SEATED_HUMAN_SEAT_Y_OFFSET` from `-0.43 * MODEL_SCALE * STOOL_SCALE` to `-0.64 * MODEL_SCALE * STOOL_SCALE` to push seated humans further down on portrait screens.  
- Added `SEATED_HUMAN_FOOT_GROUND_CLEARANCE` and `SEATED_HUMAN_ANKLE_TO_SOLE_DROP` constants to control foot clearance and ankle-to-sole correction.  
- Implemented `alignSeatedHumanFeetToGroundPlane(actor, rig, clearance)` which computes world-space foot positions from the skeleton and adjusts the actor `position.y` so feet sit at the target clearance above the ground.  
- Invoke `alignSeatedHumanFeetToGroundPlane` after applying the seated pose when cloning the seated human template so instantiated actors are corrected at creation time.

### Testing

- Ran a production build with `yarn build` which completed successfully.  
- Executed the existing automated test suite with `yarn test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec4eafc57483298cbd4a6d591f40b7)