### PR TITLE
Lower seated human models and align feet to ground in LudoBattleRoyal

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1763,10 +1763,12 @@ const SEATED_HUMAN_MODEL_URL = 'https://threejs.org/examples/models/gltf/readypl
 const SEATED_HUMAN_BASE_HEIGHT = 1.74;
 const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.42;
 const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 3.92;
-// Lower seated humans so feet visually rest on the HDRI floor while preserving pose/orientation.
-const SEATED_HUMAN_SEAT_Y_OFFSET = -0.43 * MODEL_SCALE * STOOL_SCALE;
+// Push seated humans noticeably lower on portrait screens so they do not appear to hover above chairs.
+const SEATED_HUMAN_SEAT_Y_OFFSET = -0.7 * MODEL_SCALE * STOOL_SCALE;
 const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.2;
 const SEATED_HUMAN_FACING_Y = 0;
+// Keep feet slightly below the strict grounding plane to match the user's requested stronger downward move.
+const SEATED_HUMAN_FOOT_GROUND_CLEARANCE = -0.18 * MODEL_SCALE * STOOL_SCALE;
 const SEATED_HUMAN_ROLL_MS = 1680;
 const SEATED_HUMAN_RECOVER_MS = 420;
 let seatedHumanTemplatePromise = null;
@@ -4268,6 +4270,21 @@ function applySeatedHumanPose(rig, mode = 'idle', intensity = 1, handGrip = 0) {
   applyRightHandGrip(rig, handGrip);
 }
 
+function alignSeatedHumanFeetToGroundPlane(actor, rig, clearance = SEATED_HUMAN_FOOT_GROUND_CLEARANCE) {
+  if (!actor?.isObject3D) return;
+  actor.updateMatrixWorld(true);
+  const footBones = [rig?.leftFoot, rig?.rightFoot].filter((bone) => bone?.isBone);
+  if (!footBones.length) return;
+  let minFootY = Infinity;
+  footBones.forEach((bone) => {
+    const worldPos = bone.getWorldPosition(new THREE.Vector3());
+    if (Number.isFinite(worldPos.y)) minFootY = Math.min(minFootY, worldPos.y);
+  });
+  if (!Number.isFinite(minFootY)) return;
+  actor.position.y -= minFootY - clearance;
+  actor.updateMatrixWorld(true);
+}
+
 async function loadSeatedHumanTemplate(renderer = null) {
   if (seatedHumanTemplatePromise) return seatedHumanTemplatePromise;
   seatedHumanTemplatePromise = (async () => {
@@ -6745,6 +6762,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         chair.group.add(actor);
         const rig = saveBoneRig(actor);
         applySeatedHumanPose(rig, 'idle', 1);
+        alignSeatedHumanFeetToGroundPlane(actor, rig);
         seatedHumanActorsRef.current.push({ playerIndex, actor, rig });
       });
     } catch (error) {


### PR DESCRIPTION
### Motivation
- Prevent seated human models from appearing to hover above chairs on portrait screens by lowering their anchor position.
- Ensure the actors' feet are visually grounded (slightly below the strict plane) to match a requested stronger downward adjustment.

### Description
- Reduce `SEATED_HUMAN_SEAT_Y_OFFSET` from `-0.43 * MODEL_SCALE * STOOL_SCALE` to `-0.7 * MODEL_SCALE * STOOL_SCALE` and adjust the explanatory comment to reflect portrait-screen intent.
- Add `SEATED_HUMAN_FOOT_GROUND_CLEARANCE` constant to control how far feet sit relative to the grounding plane.
- Implement `alignSeatedHumanFeetToGroundPlane(actor, rig, clearance)` to compute foot world positions and shift the actor so the lowest foot matches the clearance value.
- Invoke `alignSeatedHumanFeetToGroundPlane` when attaching cloned seated human actors to chairs so feet are aligned at runtime.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec4eafc57483298cbd4a6d591f40b7)