### PR TITLE
Lower seated human models and align their feet to the ground in LudoBattleRoyal

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1763,10 +1763,13 @@ const SEATED_HUMAN_MODEL_URL = 'https://threejs.org/examples/models/gltf/readypl
 const SEATED_HUMAN_BASE_HEIGHT = 1.74;
 const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.42;
 const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 3.92;
-// Lower seated humans so feet visually rest on the HDRI floor while preserving pose/orientation.
-const SEATED_HUMAN_SEAT_Y_OFFSET = -0.43 * MODEL_SCALE * STOOL_SCALE;
+// Keep seated humans lower so their feet can be grounded against the chair/floor contact plane.
+const SEATED_HUMAN_SEAT_Y_OFFSET = -0.52 * MODEL_SCALE * STOOL_SCALE;
 const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.2;
 const SEATED_HUMAN_FACING_Y = 0;
+const SEATED_HUMAN_FOOT_GROUND_CLEARANCE = 0.002;
+// Extra portrait-focused drop so seated humans render noticeably lower on-screen.
+const SEATED_HUMAN_EXTRA_DOWN_OFFSET = 0.18 * MODEL_SCALE * STOOL_SCALE;
 const SEATED_HUMAN_ROLL_MS = 1680;
 const SEATED_HUMAN_RECOVER_MS = 420;
 let seatedHumanTemplatePromise = null;
@@ -4268,6 +4271,21 @@ function applySeatedHumanPose(rig, mode = 'idle', intensity = 1, handGrip = 0) {
   applyRightHandGrip(rig, handGrip);
 }
 
+function alignSeatedHumanFeetToGroundPlane(actor, rig, clearance = SEATED_HUMAN_FOOT_GROUND_CLEARANCE) {
+  if (!actor?.isObject3D) return;
+  actor.updateMatrixWorld(true);
+  const footBones = [rig?.leftFoot, rig?.rightFoot].filter((bone) => bone?.isBone);
+  if (!footBones.length) return;
+  let minFootY = Infinity;
+  footBones.forEach((bone) => {
+    const worldPos = bone.getWorldPosition(new THREE.Vector3());
+    if (Number.isFinite(worldPos.y)) minFootY = Math.min(minFootY, worldPos.y);
+  });
+  if (!Number.isFinite(minFootY)) return;
+  actor.position.y -= minFootY - clearance + SEATED_HUMAN_EXTRA_DOWN_OFFSET;
+  actor.updateMatrixWorld(true);
+}
+
 async function loadSeatedHumanTemplate(renderer = null) {
   if (seatedHumanTemplatePromise) return seatedHumanTemplatePromise;
   seatedHumanTemplatePromise = (async () => {
@@ -6745,6 +6763,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         chair.group.add(actor);
         const rig = saveBoneRig(actor);
         applySeatedHumanPose(rig, 'idle', 1);
+        alignSeatedHumanFeetToGroundPlane(actor, rig);
         seatedHumanActorsRef.current.push({ playerIndex, actor, rig });
       });
     } catch (error) {


### PR DESCRIPTION
### Motivation
- Improve visual grounding of seated human avatars so their feet appear to rest naturally against the chair/floor and look correctly positioned in portrait views.
- Provide a small configurable clearance and extra downward offset to avoid visible gaps between feet and the contact plane across HDRI floors and camera crops.

### Description
- Adjusted `SEATED_HUMAN_SEAT_Y_OFFSET` to lower seated human models relative to chairs and updated the inline comment for intent.
- Added `SEATED_HUMAN_FOOT_GROUND_CLEARANCE` and `SEATED_HUMAN_EXTRA_DOWN_OFFSET` constants to control foot grounding and extra portrait drop.
- Implemented `alignSeatedHumanFeetToGroundPlane(actor, rig, clearance)` which computes the lowest foot bone world Y and shifts the actor Y to meet the target clearance and extra down offset.
- Invoke `alignSeatedHumanFeetToGroundPlane` after applying the initial seated pose when instantiating cloned seated human actors.

### Testing
- Ran the frontend unit test suite with `yarn test` and the test run completed successfully.
- Performed a production build with `yarn build` which completed without build-time errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec4eafc57483298cbd4a6d591f40b7)