### PR TITLE
Lower seated humans and align feet to ground in LudoBattleRoyal

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1763,10 +1763,12 @@ const SEATED_HUMAN_MODEL_URL = 'https://threejs.org/examples/models/gltf/readypl
 const SEATED_HUMAN_BASE_HEIGHT = 1.74;
 const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.42;
 const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 3.92;
-// Lower seated humans so feet visually rest on the HDRI floor while preserving pose/orientation.
-const SEATED_HUMAN_SEAT_Y_OFFSET = -0.43 * MODEL_SCALE * STOOL_SCALE;
+// Push seated humans noticeably lower on portrait screens so they do not appear to hover above chairs.
+const SEATED_HUMAN_SEAT_Y_OFFSET = -0.95 * MODEL_SCALE * STOOL_SCALE;
 const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.2;
 const SEATED_HUMAN_FACING_Y = 0;
+// Keep feet slightly below the strict grounding plane for a clearly lower seated look on portrait screens.
+const SEATED_HUMAN_FOOT_GROUND_CLEARANCE = -0.04 * MODEL_SCALE;
 const SEATED_HUMAN_ROLL_MS = 1680;
 const SEATED_HUMAN_RECOVER_MS = 420;
 let seatedHumanTemplatePromise = null;
@@ -4268,6 +4270,25 @@ function applySeatedHumanPose(rig, mode = 'idle', intensity = 1, handGrip = 0) {
   applyRightHandGrip(rig, handGrip);
 }
 
+function alignSeatedHumanFeetToGroundPlane(actor, rig, clearance = SEATED_HUMAN_FOOT_GROUND_CLEARANCE) {
+  if (!actor?.isObject3D) return;
+  actor.updateMatrixWorld(true);
+  const actorBox = new THREE.Box3().setFromObject(actor);
+  const minMeshY = Number.isFinite(actorBox.min.y) ? actorBox.min.y : Infinity;
+
+  const footBones = [rig?.leftFoot, rig?.rightFoot].filter((bone) => bone?.isBone);
+  let minFootY = Infinity;
+  footBones.forEach((bone) => {
+    const worldPos = bone.getWorldPosition(new THREE.Vector3());
+    if (Number.isFinite(worldPos.y)) minFootY = Math.min(minFootY, worldPos.y);
+  });
+
+  const contactY = Math.min(minMeshY, minFootY);
+  if (!Number.isFinite(contactY)) return;
+  actor.position.y -= contactY - clearance;
+  actor.updateMatrixWorld(true);
+}
+
 async function loadSeatedHumanTemplate(renderer = null) {
   if (seatedHumanTemplatePromise) return seatedHumanTemplatePromise;
   seatedHumanTemplatePromise = (async () => {
@@ -6745,6 +6766,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         chair.group.add(actor);
         const rig = saveBoneRig(actor);
         applySeatedHumanPose(rig, 'idle', 1);
+        alignSeatedHumanFeetToGroundPlane(actor, rig);
         seatedHumanActorsRef.current.push({ playerIndex, actor, rig });
       });
     } catch (error) {


### PR DESCRIPTION
### Motivation
- Prevent seated avatar models from appearing to hover above chairs on portrait/smaller screens by lowering them and ensuring feet visually contact the ground.

### Description
- Reduced the seated human seat Y offset from `-0.43 * MODEL_SCALE * STOOL_SCALE` to `-0.95 * MODEL_SCALE * STOOL_SCALE` to push models lower on portrait screens.
- Added a new `SEATED_HUMAN_FOOT_GROUND_CLEARANCE` constant to keep feet slightly below the grounding plane for a visually lower seated look.
- Introduced `alignSeatedHumanFeetToGroundPlane(actor, rig, clearance)` which computes the actor mesh bounding box and foot bone world positions and adjusts the actor Y position so feet contact the ground with the configured clearance.
- Invoke `alignSeatedHumanFeetToGroundPlane` after applying the seated pose when instantiating seated human actors.

### Testing
- Ran the front-end build with `yarn build` which completed successfully.
- Executed the test suite with `yarn test` and linting with `yarn lint`, and they passed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec4eafc57483298cbd4a6d591f40b7)