### PR TITLE
Reduce seated human visual scale in Snake & Ladder 3D board

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -82,7 +82,7 @@ const HUMAN_MODEL_CACHE = { promise: null, template: null };
 // Keep Snake seated humans aligned with Ludo Battle Royal chair anchoring and scale technique.
 const SEATED_HUMAN_BASE_HEIGHT = 1.74;
 const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.42;
-const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 2.3;
+const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 2.15;
 const SEATED_HUMAN_SEAT_Y_OFFSET = -0.8 * MODEL_SCALE * STOOL_SCALE;
 const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.2;
 const SEATED_HUMAN_FACING_Y = 0;


### PR DESCRIPTION
### Motivation
- Make the seated human characters on the Snake & Ladder 3D board slightly smaller for improved visual proportion on the board while preserving anchoring and placement logic.

### Description
- Reduced `SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER` from `2.3` to `2.15` in `webapp/src/components/SnakeBoard3D.jsx` to scale down seated human models without changing positioning or gameplay logic.

### Testing
- Ran `npx eslint webapp/src/components/SnakeBoard3D.jsx`, which completed with a warning due to current eslint ignore settings and reported no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec59c158648329b2bef3b96e2734d8)