### PR TITLE
Lower seated humans, tighten seated pose, and align feet to ground in LudoBattleRoyal

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1763,10 +1763,12 @@ const SEATED_HUMAN_MODEL_URL = 'https://threejs.org/examples/models/gltf/readypl
 const SEATED_HUMAN_BASE_HEIGHT = 1.74;
 const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.42;
 const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 3.92;
-// Lower seated humans so feet visually rest on the HDRI floor while preserving pose/orientation.
-const SEATED_HUMAN_SEAT_Y_OFFSET = -0.43 * MODEL_SCALE * STOOL_SCALE;
+// Push seated humans noticeably lower on portrait screens so they do not appear to hover above chairs.
+const SEATED_HUMAN_SEAT_Y_OFFSET = -0.7 * MODEL_SCALE * STOOL_SCALE;
 const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.2;
 const SEATED_HUMAN_FACING_Y = 0;
+// Keep feet slightly below the strict grounding plane to match the user's requested stronger downward move.
+const SEATED_HUMAN_FOOT_GROUND_CLEARANCE = -0.42 * MODEL_SCALE * STOOL_SCALE;
 const SEATED_HUMAN_ROLL_MS = 1680;
 const SEATED_HUMAN_RECOVER_MS = 420;
 let seatedHumanTemplatePromise = null;
@@ -4103,7 +4105,7 @@ function applySeatedHumanPose(rig, mode = 'idle', intensity = 1, handGrip = 0) {
   const t = smooth01(intensity);
   const breathe = Math.sin(performance.now() * 0.002) * 0.012;
 
-  addBonePos(rig, rig.hips, 0, -0.345, -0.078, 1);
+  addBonePos(rig, rig.hips, 0, -0.62, -0.078, 1);
   moveLegRootsToFront(rig);
   addBoneRot(rig, rig.hips, -0.16, 0, 0, 1);
   addBoneRot(rig, rig.spine, 0.26 + breathe, 0, 0, 1);
@@ -4111,13 +4113,13 @@ function applySeatedHumanPose(rig, mode = 'idle', intensity = 1, handGrip = 0) {
   addBoneRot(rig, rig.neck, -0.04, 0, 0, 1);
   addBoneRot(rig, rig.head, -0.06, 0, 0, 1);
 
-  // Keep knees visually lower on screen (natural seated 90° posture), not lifted upward.
-  addBoneRot(rig, rig.leftUpperLeg, -1.32, 0.16, 0.05, 1);
-  addBoneRot(rig, rig.leftLowerLeg, -1.28, 0.02, 0.01, 1);
-  addBoneRot(rig, rig.leftFoot, 0.16, 0.03, 0.02, 1);
-  addBoneRot(rig, rig.rightUpperLeg, -1.32, 0.03, -0.02, 1);
-  addBoneRot(rig, rig.rightLowerLeg, -1.28, -0.02, -0.01, 1);
-  addBoneRot(rig, rig.rightFoot, 0.16, -0.02, -0.01, 1);
+  // Push seated bodies lower on portrait view by folding legs further and dropping hips.
+  addBoneRot(rig, rig.leftUpperLeg, -1.58, 0.16, 0.05, 1);
+  addBoneRot(rig, rig.leftLowerLeg, -1.66, 0.02, 0.01, 1);
+  addBoneRot(rig, rig.leftFoot, 0.26, 0.03, 0.02, 1);
+  addBoneRot(rig, rig.rightUpperLeg, -1.58, 0.03, -0.02, 1);
+  addBoneRot(rig, rig.rightLowerLeg, -1.66, -0.02, -0.01, 1);
+  addBoneRot(rig, rig.rightFoot, 0.26, -0.02, -0.01, 1);
 
   addBoneRot(rig, rig.leftUpperArm, -0.28, 0.12, 0.96, 1);
   addBoneRot(rig, rig.leftForeArm, -0.62, 0.05, -0.24, 1);
@@ -4266,6 +4268,21 @@ function applySeatedHumanPose(rig, mode = 'idle', intensity = 1, handGrip = 0) {
   addBoneRot(rig, rig.rightForeArm, forearmX, forearmY, forearmZ, 1);
   addBoneRot(rig, rig.rightHand, wristX, wristY, wristZ, 1);
   applyRightHandGrip(rig, handGrip);
+}
+
+function alignSeatedHumanFeetToGroundPlane(actor, rig, clearance = SEATED_HUMAN_FOOT_GROUND_CLEARANCE) {
+  if (!actor?.isObject3D) return;
+  actor.updateMatrixWorld(true);
+  const footBones = [rig?.leftFoot, rig?.rightFoot].filter((bone) => bone?.isBone);
+  if (!footBones.length) return;
+  let minFootY = Infinity;
+  footBones.forEach((bone) => {
+    const worldPos = bone.getWorldPosition(new THREE.Vector3());
+    if (Number.isFinite(worldPos.y)) minFootY = Math.min(minFootY, worldPos.y);
+  });
+  if (!Number.isFinite(minFootY)) return;
+  actor.position.y -= minFootY - clearance;
+  actor.updateMatrixWorld(true);
 }
 
 async function loadSeatedHumanTemplate(renderer = null) {
@@ -6745,6 +6762,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         chair.group.add(actor);
         const rig = saveBoneRig(actor);
         applySeatedHumanPose(rig, 'idle', 1);
+        alignSeatedHumanFeetToGroundPlane(actor, rig);
         seatedHumanActorsRef.current.push({ playerIndex, actor, rig });
       });
     } catch (error) {


### PR DESCRIPTION
### Motivation
- Fix seated human models appearing to float above chairs on portrait screens by moving them down and improving pose. 
- Match a requested stronger downward move so seated actors visually rest on the arena floor. 
- Ensure feet are consistently grounded across models by computing and aligning foot bone positions.

### Description
- Lowered the seat placement by changing `SEATED_HUMAN_SEAT_Y_OFFSET` to `-0.7 * MODEL_SCALE * STOOL_SCALE` and added `SEATED_HUMAN_FOOT_GROUND_CLEARANCE` for explicit foot clearance. 
- Increased hip drop and folded legs by adjusting the hip and leg offsets in `applySeatedHumanPose` (hip Y from `-0.345` to `-0.62` and tightened upper/lower leg and foot rotations). 
- Added `alignSeatedHumanFeetToGroundPlane(actor, rig, clearance)` to compute world-space foot positions and nudge the actor so the lowest foot matches the desired ground clearance. 
- Invoke `alignSeatedHumanFeetToGroundPlane` after `applySeatedHumanPose` when attaching cloned seated actors in `Ludo3D` so feet are grounded at spawn.

### Testing
- Ran the project's unit tests with `yarn test`, which completed successfully. 
- Ran the linter with `yarn lint`, which reported no new issues. 
- Built the app with `yarn build` to verify compile-time correctness, and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec4eafc57483298cbd4a6d591f40b7)