### PR TITLE
Player-face POV camera + raise board and parked weapons in Chess Battle Royal

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -352,7 +352,7 @@ const LAYOUT_SCALE_FACTOR = 0.7225;
 const TABLE_LAYOUT_SCALE_FACTOR = 0.85; // Keep the same table/board/chair proportions, but 15% smaller than current.
 const PIECE_SCALE_FACTOR = 0.79 * LAYOUT_SCALE_FACTOR * 1.5 * 0.85; // Shrink tokens by 15% while preserving the existing style proportions.
 const PIECE_FOOTPRINT_RATIO = 0.86;
-const BOARD_GROUP_Y_OFFSET = 0.035;
+const BOARD_GROUP_Y_OFFSET = 0.115; // Lift board + pieces higher on screen for clearer portrait framing.
 const BOARD_MODEL_Y_OFFSET = -0.12;
 const BOARD_VISUAL_Y_OFFSET = -0.03;
 const BOARD_SURFACE_DROP = 0.05;
@@ -438,6 +438,8 @@ const PLAYER_VIEW_CAMERA_FORWARD_OFFSET_PORTRAIT = 0.96;
 const PLAYER_VIEW_CAMERA_FORWARD_OFFSET_LANDSCAPE = 0.68;
 const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_PORTRAIT = 0.68;
 const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_LANDSCAPE = 0.78;
+const PLAYER_VIEW_FACE_CAMERA_FORWARD_OFFSET = 0.18; // Nudge the camera slightly toward the board from the player's face.
+const PLAYER_VIEW_FACE_CAMERA_HEIGHT_OFFSET = 0.06; // Keep camera at eye/face level of the seated human.
 const PLAYER_VIEW_LOOK_TARGET_FORWARD_BIAS = -BOARD.tile * BOARD_SCALE * 0.55;
 
 function detectCoarsePointer() {
@@ -2437,7 +2439,7 @@ const LOWER_PROFILE_TABLE_SHAPE_IDS = new Set(['classicOctagon', 'hexagonTable',
 const LOWER_PROFILE_TABLE_HEIGHT_DELTA = 0.12;
 const SIDE_PARKED_AIRCRAFT_SCALE_MULTIPLIER = 27; // make parked units/markers a bit larger
 const SIDE_PARKED_AIR_UNITS_INWARD_OFFSET = -0.7; // push parked vehicles farther to the sides
-const SIDE_PARKED_AIR_UNITS_BOARD_LEVEL_LIFT = 0.26; // lift pad markers/parked units from floor to board/table level
+const SIDE_PARKED_AIR_UNITS_BOARD_LEVEL_LIFT = 0.38; // lift parked weapons higher so they track the raised board level
 const SIDE_PARKED_AIR_UNITS_LANE_SPREAD = 1.92; // increase spacing between parking slots
 const SIDE_PARKED_TRUCK_SCALE_MULTIPLIER = 1.28; // increase parked truck size just a bit more
 
@@ -9186,6 +9188,15 @@ function Chess3D({
       tableSurfaceY + cameraHeightOffset,
       Math.sin(cameraSeatAngle) * cameraRadius + tablePlacementOffset.z
     );
+    const bottomPlayerAnchorWorld = chairA.anchor.getWorldPosition(new THREE.Vector3());
+    const faceToBoard = boardLookTarget.clone().sub(bottomPlayerAnchorWorld);
+    faceToBoard.y = 0;
+    if (faceToBoard.lengthSq() > 1e-6) {
+      faceToBoard.normalize();
+      camera.position.copy(bottomPlayerAnchorWorld);
+      camera.position.y += PLAYER_VIEW_FACE_CAMERA_HEIGHT_OFFSET;
+      camera.position.addScaledVector(faceToBoard, PLAYER_VIEW_FACE_CAMERA_FORWARD_OFFSET);
+    }
     camera.lookAt(boardLookTarget);
 
     controls = new OrbitControls(camera, renderer.domElement);


### PR DESCRIPTION
### Motivation
- Provide a player-perspective view by placing the default camera at the bottom human character's face/eye anchor so the opening view reads as the player seated at the bottom. 
- Improve composition on portrait screens by lifting the board, pieces and parked weapons so they appear higher and remain visually aligned with the raised board level.

### Description
- Increased `BOARD_GROUP_Y_OFFSET` to lift the board and pieces higher on screen (`webapp/src/pages/Games/ChessBattleRoyal.jsx`).
- Introduced `PLAYER_VIEW_FACE_CAMERA_FORWARD_OFFSET` and `PLAYER_VIEW_FACE_CAMERA_HEIGHT_OFFSET` and use them to position the default 3D camera at the bottom player's seated-human anchor (camera now copies `chairA.anchor` world position and nudges forward/eye-level toward the board). 
- Raised parked weapon/platform vertical lift by increasing `SIDE_PARKED_AIR_UNITS_BOARD_LEVEL_LIFT` so parked units remain aligned with the raised board. 
- Changes are localized to `webapp/src/pages/Games/ChessBattleRoyal.jsx` and are designed to be small, modular tuning edits to camera and layout constants.

### Testing
- Ran a production build with `cd webapp && npm run build`, which completed successfully.
- Build output contains pre-existing warnings about a duplicate package key and large chunk sizes from Vite, but no new build errors were introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec5cd8d17c8329839d4b1ab81f0d38)