### PR TITLE
Lower seated Ludo Battle Royale avatars on chairs

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1764,11 +1764,11 @@ const SEATED_HUMAN_BASE_HEIGHT = 1.74;
 const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.42;
 const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 3.92;
 // Push seated humans noticeably lower on portrait screens so they do not appear to hover above chairs.
-const SEATED_HUMAN_SEAT_Y_OFFSET = -0.7 * MODEL_SCALE * STOOL_SCALE;
+const SEATED_HUMAN_SEAT_Y_OFFSET = -0.92 * MODEL_SCALE * STOOL_SCALE;
 const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.2;
 const SEATED_HUMAN_FACING_Y = 0;
 // Keep feet slightly below the strict grounding plane to match the user's requested stronger downward move.
-const SEATED_HUMAN_FOOT_GROUND_CLEARANCE = -0.42 * MODEL_SCALE * STOOL_SCALE;
+const SEATED_HUMAN_FOOT_GROUND_CLEARANCE = -0.5 * MODEL_SCALE * STOOL_SCALE;
 const SEATED_HUMAN_ROLL_MS = 1680;
 const SEATED_HUMAN_RECOVER_MS = 420;
 let seatedHumanTemplatePromise = null;


### PR DESCRIPTION
### Motivation
- On portrait/mobile framing seated human characters appeared to hover above chairs, so they need to be pushed visually lower to match prior visual tuning.

### Description
- In `webapp/src/pages/Games/LudoBattleRoyal.jsx` I increased the downward seat offset and foot grounding clearance by changing `SEATED_HUMAN_SEAT_Y_OFFSET` from `-0.7 * MODEL_SCALE * STOOL_SCALE` to `-0.92 * MODEL_SCALE * STOOL_SCALE` and `SEATED_HUMAN_FOOT_GROUND_CLEARANCE` from `-0.42 * MODEL_SCALE * STOOL_SCALE` to `-0.5 * MODEL_SCALE * STOOL_SCALE` so avatars sit visibly lower and feet remain naturally planted.

### Testing
- Ran the production build with `npm -C webapp run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec62b7c1e883299a9b492ab559d83d)