### PR TITLE
Align Snake seated humans with Ludo Battle Royal seating layout

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -47,11 +47,23 @@ const BASE_COLUMN_HEIGHT = 0.5 * MODEL_SCALE * STOOL_SCALE;
 const CARD_SCALE = 0.95;
 const CARD_W = 0.4 * MODEL_SCALE * CARD_SCALE;
 const HUMAN_SEAT_ROTATION_OFFSET = Math.PI / 8;
-const AI_CHAIR_GAP = CARD_W * 0.48;
+const AI_CHAIR_GAP = CARD_W * 0.74;
 const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 1.1;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
 const TABLE_HEIGHT_LIFT = -0.045 * MODEL_SCALE;
 const TABLE_HEIGHT = STOOL_HEIGHT + TABLE_HEIGHT_LIFT;
+const CHAIR_OUTWARD_OFFSET = 0.31 * MODEL_SCALE;
+const CHAIR_INWARD_PULL = 0.22 * MODEL_SCALE;
+const CHAIR_GLOBAL_PUSHBACK = 0.146 * MODEL_SCALE;
+const SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK = 0.182 * MODEL_SCALE;
+const AI_CHAIR_RADIUS =
+  TABLE_RADIUS +
+  SEAT_DEPTH / 2 +
+  AI_CHAIR_GAP +
+  0.19 * MODEL_SCALE +
+  CHAIR_OUTWARD_OFFSET -
+  TABLE_EDGE_INSET -
+  CHAIR_INWARD_PULL;
 const TABLE_MODEL_TARGET_DIAMETER = TABLE_RADIUS * 2;
 const TABLE_MODEL_TARGET_HEIGHT = TABLE_HEIGHT;
 
@@ -81,12 +93,12 @@ const HUMAN_MODEL_URL = 'https://threejs.org/examples/models/gltf/readyplayer.me
 const HUMAN_MODEL_CACHE = { promise: null, template: null };
 // Keep Snake seated humans aligned with Ludo/Chess Battle Royal chair anchoring and 7am scale baseline.
 const SEATED_HUMAN_BASE_HEIGHT = 1.74;
-const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.28;
-const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 1.9;
-const SEATED_HUMAN_SEAT_Y_OFFSET = -0.78 * MODEL_SCALE * STOOL_SCALE;
+const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.42;
+const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 4.24;
+const SEATED_HUMAN_SEAT_Y_OFFSET = -1.42 * MODEL_SCALE * STOOL_SCALE;
 const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.2;
 const SEATED_HUMAN_FACING_Y = 0;
-const SEATED_HUMAN_FOOT_GROUND_Y = 0;
+const SEATED_HUMAN_FOOT_GROUND_Y = -0.76 * MODEL_SCALE * STOOL_SCALE;
 const HUMAN_FRONT_SIDE_Z = 1;
 const HUMAN_LEG_FRONT_OFFSET = 0;
 const SNAKE_TOKEN_MODEL_URLS = [
@@ -3308,7 +3320,7 @@ function buildArena(scene, renderer, host, cameraRef, disposeHandlers, appearanc
       .catch(() => {});
   }
 
-  const chairRadius = (tableInfo.radius ?? TABLE_RADIUS) + SEAT_DEPTH / 2 + AI_CHAIR_GAP;
+  const chairRadius = AI_CHAIR_RADIUS + CHAIR_GLOBAL_PUSHBACK;
   const camera = new THREE.PerspectiveCamera(CAM.fov, 1, CAM.near, CAM.far);
   const cameraSeatAngle = Math.PI / 2;
   const cameraBackOffset = cameraTuning.backOffset;
@@ -3407,7 +3419,8 @@ function buildArena(scene, renderer, host, cameraRef, disposeHandlers, appearanc
     const fallbackAngle = Math.PI / 2 - HUMAN_SEAT_ROTATION_OFFSET - (i / DEFAULT_PLAYER_COUNT) * Math.PI * 2;
     const angle = CUSTOM_CHAIR_ANGLES[i] ?? fallbackAngle;
     const forward = new THREE.Vector3(Math.cos(angle), 0, Math.sin(angle));
-    const seatPos = forward.clone().multiplyScalar(chairRadius);
+    const seatRadius = chairRadius + (i === 0 ? SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK : 0);
+    const seatPos = forward.clone().multiplyScalar(seatRadius);
     seatPos.y = CHAIR_BASE_HEIGHT;
     const group = new THREE.Group();
     group.position.copy(seatPos);


### PR DESCRIPTION
### Motivation
- Make Snake seated human actors use the same chair anchoring, distances and visual posture as Ludo Battle Royal so player avatars appear in identical positions and facing directions across the two games.

### Description
- Updated seating/math constants in `webapp/src/components/SnakeBoard3D.jsx` to match Ludo Battle Royal: increased `AI_CHAIR_GAP`, added `CHAIR_OUTWARD_OFFSET`, `CHAIR_INWARD_PULL`, `CHAIR_GLOBAL_PUSHBACK`, `SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK`, and computed `AI_CHAIR_RADIUS` used for seat placement.
- Switched the arena `chairRadius` to use the new `AI_CHAIR_RADIUS + CHAIR_GLOBAL_PUSHBACK` and applied `SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK` for the bottom (self) seat so radial placement/spacing now mirrors Ludo.
- Aligned seated-human transform/profile constants to Ludo values by updating `SEATED_HUMAN_TARGET_HEIGHT`, `SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER`, `SEATED_HUMAN_SEAT_Y_OFFSET`, and `SEATED_HUMAN_FOOT_GROUND_Y` so actors sit at the same scale and depth.

### Testing
- Ran `npx eslint webapp/src/components/SnakeBoard3D.jsx` which returned an ignore-warning (file ignored by repo lint config) and no lint errors.
- Ran `npx eslint --no-ignore webapp/src/components/SnakeBoard3D.jsx` which reported the same ignore-related warning and no lint errors.
- No additional automated tests were run as part of this change in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec8a1e5e148329951c855773bf39dc)