### PR TITLE
Restore Snake seated human size to 7am baseline

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -84,7 +84,7 @@ const HUMAN_MODEL_CACHE = { promise: null, template: null };
 // Keep Snake seated humans aligned with Ludo/Chess Battle Royal chair anchoring and 7am scale baseline.
 const SEATED_HUMAN_BASE_HEIGHT = 1.74;
 const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.42;
-const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 4.38;
+const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 2.0;
 const SEATED_HUMAN_SEAT_Y_OFFSET = -1.55 * MODEL_SCALE * STOOL_SCALE;
 const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.2;
 const SEATED_HUMAN_FACING_Y = 0;


### PR DESCRIPTION
### Motivation
- Restore the seated human character size in the Snake & Ladder arena to the morning (7am) visual baseline by changing only the visual scale multiplier so the avatar looks as it did at that time without affecting any other behavior or positioning.

### Description
- Updated `SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER` from `4.38` to `2.0` in `webapp/src/components/SnakeBoard3D.jsx` and left all other seating offsets, anchors, and gameplay logic unchanged.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully with the existing non-blocking Vite warnings about duplicate package keys and chunk size/dynamic import notices.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec9cec65f48329a46d4638348e3499)