### PR TITLE
Adjust Ludo portrait seat spacing and bottom player camera alignment

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1728,10 +1728,10 @@ const AI_CHAIR_RADIUS =
   CHAIR_OUTWARD_OFFSET -
   TABLE_EDGE_INSET -
   CHAIR_INWARD_PULL;
-// Pull all chairs (with seated humans) a bit farther away from the table edge for clearer spacing.
-const CHAIR_GLOBAL_PUSHBACK = 0.212 * MODEL_SCALE;
+// Pull all chairs (with seated humans) farther away from the table edge for clearer portrait spacing.
+const CHAIR_GLOBAL_PUSHBACK = 0.236 * MODEL_SCALE;
 // Keep the bottom/local-player seat distinctly farther out than the rest.
-const SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK = 0.332 * MODEL_SCALE;
+const SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK = 0.382 * MODEL_SCALE;
 
 const DEFAULT_PLAYER_COUNT = 4;
 const clampPlayerCount = (value) =>
@@ -1767,8 +1767,9 @@ const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.42;
 // Slightly upscale seated humans so they read better on portrait/mobile gameplay.
 const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 4.62;
 // Push seated humans further downward so hips are clearly seated and feet stay grounded on portrait gameplay.
-const SEATED_HUMAN_SEAT_Y_OFFSET = -1.72 * MODEL_SCALE * STOOL_SCALE;
-const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.2;
+const SEATED_HUMAN_SEAT_Y_OFFSET = -1.88 * MODEL_SCALE * STOOL_SCALE;
+// Shift humans slightly farther back on the chair so they stay aligned after outward chair spacing changes.
+const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.26;
 const SEATED_HUMAN_FACING_Y = 0;
 // Keep feet slightly below the strict grounding plane to reinforce the lower seated posture.
 const SEATED_HUMAN_FOOT_GROUND_CLEARANCE = -0.76 * MODEL_SCALE * STOOL_SCALE;
@@ -1855,15 +1856,15 @@ const CAMERA_ZOOM_MAX_FACTOR = 1;
 const LUDO_CAMERA_PHI_MIN = 0.92;
 const LUDO_CAMERA_PHI_MAX = 1.22;
 const PLAYER_VIEW_SEAT_THETA = Math.PI / 2;
-const PLAYER_VIEW_CAMERA_BACK_OFFSET_PORTRAIT = 1.78;
+const PLAYER_VIEW_CAMERA_BACK_OFFSET_PORTRAIT = 1.68;
 const PLAYER_VIEW_CAMERA_BACK_OFFSET_LANDSCAPE = 1.34;
-const PLAYER_VIEW_CAMERA_FORWARD_OFFSET_PORTRAIT = 1.2;
+const PLAYER_VIEW_CAMERA_FORWARD_OFFSET_PORTRAIT = 1.26;
 const PLAYER_VIEW_CAMERA_FORWARD_OFFSET_LANDSCAPE = 0.82;
-const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_PORTRAIT = 0.58;
+const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_PORTRAIT = 0.5;
 const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_LANDSCAPE = 0.72;
-const PLAYER_VIEW_FIRST_PERSON_EYE_FORWARD_PORTRAIT = 0.18 * MODEL_SCALE;
+const PLAYER_VIEW_FIRST_PERSON_EYE_FORWARD_PORTRAIT = 0.24 * MODEL_SCALE;
 const PLAYER_VIEW_FIRST_PERSON_EYE_FORWARD_LANDSCAPE = 0.12 * MODEL_SCALE;
-const PLAYER_VIEW_LOOK_TARGET_FORWARD_BIAS = -0.075 * 3.22 * ARENA_SCALE * 0.55;
+const PLAYER_VIEW_LOOK_TARGET_FORWARD_BIAS = -0.02 * 3.22 * ARENA_SCALE;
 const LANDSCAPE_CAMERA_TUNING = Object.freeze({
   backOffset: PLAYER_VIEW_CAMERA_BACK_OFFSET_LANDSCAPE,
   forwardOffset: PLAYER_VIEW_CAMERA_FORWARD_OFFSET_LANDSCAPE,


### PR DESCRIPTION
### Motivation
- Improve visual spacing for the Ludo Battle Royal arena in portrait mode so chairs and attached humans don't overlap the table and read better on mobile screens. 
- Lower and re-position seated human models so hips and feet appear more naturally seated and grounded in portrait view. 
- Move the bottom/local-player camera slightly closer and align it more precisely to the bottom human's face for better framing during gameplay.

### Description
- Tuning constants in `webapp/src/pages/Games/LudoBattleRoyal.jsx` to implement the layout and camera adjustments:
  - Increased `CHAIR_GLOBAL_PUSHBACK` from `0.212 * MODEL_SCALE` to `0.236 * MODEL_SCALE` to push all chairs outward. 
  - Increased `SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK` from `0.332 * MODEL_SCALE` to `0.382 * MODEL_SCALE` to push the bottom player chair further out. 
  - Lowered seated human vertical offset by changing `SEATED_HUMAN_SEAT_Y_OFFSET` from `-1.72 * MODEL_SCALE * STOOL_SCALE` to `-1.88 * MODEL_SCALE * STOOL_SCALE` and moved human Z offset from `-SEAT_DEPTH * 0.2` to `-SEAT_DEPTH * 0.26` so characters sit lower and slightly back on the chair. 
  - Adjusted portrait camera tuning values to bring the camera closer and better align with the bottom face by changing `PLAYER_VIEW_CAMERA_BACK_OFFSET_PORTRAIT` to `1.68`, `PLAYER_VIEW_CAMERA_FORWARD_OFFSET_PORTRAIT` to `1.26`, `PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_PORTRAIT` to `0.5`, `PLAYER_VIEW_FIRST_PERSON_EYE_FORWARD_PORTRAIT` to `0.24 * MODEL_SCALE`, and reduced the negative `PLAYER_VIEW_LOOK_TARGET_FORWARD_BIAS` to `-0.02 * 3.22 * ARENA_SCALE`.

### Testing
- Ran the production build with `npm --prefix webapp run build`, which completed successfully.
- The build emitted non-blocking warnings (Vite chunking dynamic/static import notes and a duplicate key warning in `webapp/package.json`), but no build errors occurred.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec9d8417a083299643e9b90fdb90fa)