### PR TITLE
Refine seated human pose and add domino hand helpers; preserve GLB textures

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -7674,12 +7674,24 @@ const CHAIR_TEXTURE_PROPS = Object.freeze([
 ]);
 const HUMAN_CHARACTER_DISABLED = false;
 const SEATED_HUMAN_MODEL_URL = 'https://threejs.org/examples/models/gltf/readyplayer.me.glb';
-const SEATED_HUMAN_SEAT_Y_OFFSET = -0.78 * MODEL_SCALE * STOOL_SCALE;
+// Keep Domino seated humans aligned to the same seated baseline used in Ludo Battle Royal.
+const SEATED_HUMAN_SEAT_Y_OFFSET = -1.42 * MODEL_SCALE * STOOL_SCALE;
 const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.2;
 const SEATED_HUMAN_FACING_Y = 0;
+const SEATED_DOMINO_HOLD_SIDE_OFFSET = 0.048 * MODEL_SCALE;
+const SEATED_DOMINO_HOLD_FORWARD_OFFSET = 0.11 * MODEL_SCALE;
+const SEATED_DOMINO_HOLD_HEIGHT_OFFSET = 0.018 * MODEL_SCALE;
+const SEATED_DOMINO_PICKUP_RIGHT_OFFSET = -0.028 * MODEL_SCALE;
+const SEATED_DOMINO_PICKUP_FORWARD_OFFSET = 0.08 * MODEL_SCALE;
+const SEATED_DOMINO_PICKUP_HEIGHT_OFFSET = 0.014 * MODEL_SCALE;
+const SEATED_DOMINO_PLACE_RIGHT_OFFSET = -0.02 * MODEL_SCALE;
+const SEATED_DOMINO_PLACE_FORWARD_OFFSET = 0.12 * MODEL_SCALE;
+const SEATED_DOMINO_PLACE_HEIGHT_OFFSET = 0.02 * MODEL_SCALE;
 const seatedHumans = [];
 const seatFaceAnchors = [];
 const seatCharacterHelpers = [];
+const tmpSeatTargetLocal = new THREE.Vector3();
+const tmpSeatRootWorld = new THREE.Vector3();
 let seatedHumanTemplatePromise = null;
 
 function normalizeHumanBoneName(value = '') {
@@ -7760,36 +7772,57 @@ function applyLoadedHumanPose(seatHuman, timeSeconds, actionStrength = 0, knockS
   const breathe = Math.sin(timeSeconds * 1.1) * 0.018;
   root.scale.setScalar(baseScale);
 
-  composeModelBone(rest, bones.hips, new THREE.Euler(-0.12 - knockStrength * 0.08, 0, 0, 'XYZ'));
-  composeModelBone(rest, bones.spine, new THREE.Euler(0.34 + breathe - knockStrength * 0.15, 0, 0, 'XYZ'));
+  const actionType = seatHuman?.action?.type ?? 'idle';
+  const isPlaceAction = actionType === 'place';
+  const isKnockAction = actionType === 'knock';
+  const actionTarget = seatHuman?.action?.targetWorld;
+  let targetBiasY = -0.04;
+  let targetBiasZ = 0.18;
+  let forwardReach = 0;
+  if (actionTarget && seatHuman?.root?.parent?.worldToLocal) {
+    const targetLocal = tmpSeatTargetLocal.copy(actionTarget);
+    seatHuman.root.parent.worldToLocal(targetLocal);
+    const horizontal = Math.hypot(targetLocal.x, targetLocal.z) || 1;
+    targetBiasY = THREE.MathUtils.clamp(targetLocal.x / horizontal, -0.32, 0.32);
+    targetBiasZ = THREE.MathUtils.clamp(-targetLocal.z / horizontal, -0.34, 0.34);
+    const seatLocal = tmpSeatRootWorld;
+    seatHuman.root.getWorldPosition(seatLocal);
+    seatHuman.root.parent.worldToLocal(seatLocal);
+    const dist = Math.hypot(targetLocal.x - seatLocal.x, targetLocal.z - seatLocal.z);
+    forwardReach = THREE.MathUtils.clamp((dist - 0.55) / 1.25, 0, 1);
+  }
+
+  composeModelBone(
+    rest,
+    bones.hips,
+    new THREE.Euler(-0.14 - knockStrength * 0.08 + forwardReach * 0.08 * actionStrength, 0, 0, 'XYZ')
+  );
+  composeModelBone(
+    rest,
+    bones.spine,
+    new THREE.Euler(0.34 + breathe - knockStrength * 0.15 + forwardReach * 0.24 * actionStrength, 0, 0, 'XYZ')
+  );
   composeModelBone(rest, bones.spine1, new THREE.Euler(0.22 - knockStrength * 0.08, 0, 0, 'XYZ'));
   composeModelBone(rest, bones.spine2, new THREE.Euler(0.12 - knockStrength * 0.03, 0, 0, 'XYZ'));
   composeModelBone(rest, bones.neck, new THREE.Euler(-0.08, 0, 0, 'XYZ'));
-  composeModelBone(rest, bones.head, new THREE.Euler(-0.08, Math.sin(timeSeconds * 0.33) * 0.03, 0, 'XYZ'));
+  composeModelBone(
+    rest,
+    bones.head,
+    new THREE.Euler(-0.08 + actionStrength * 0.08, Math.sin(timeSeconds * 0.33) * 0.03, 0, 'XYZ')
+  );
 
   composeModelBone(rest, bones.leftUpLeg, new THREE.Euler(-1.5, 0.13, 0.1, 'XYZ'));
   composeModelBone(rest, bones.rightUpLeg, new THREE.Euler(-1.5, -0.13, -0.1, 'XYZ'));
   composeModelBone(rest, bones.leftLeg, new THREE.Euler(1.56, 0, 0, 'XYZ'));
   composeModelBone(rest, bones.rightLeg, new THREE.Euler(1.56, 0, 0, 'XYZ'));
 
-  const rightReach = actionStrength;
+  const rightReach = isPlaceAction ? actionStrength : 0;
   const rightKnock = knockStrength;
-  // Baseline: both arms stay in a stable "holding dominos" seated pose.
-  composeModelBone(rest, bones.leftShoulder, new THREE.Euler(-0.14, 0.04, -0.34, 'XYZ'));
-  composeModelBone(rest, bones.leftArm, new THREE.Euler(-0.84, 0.18, -0.36, 'XYZ'));
-  composeModelBone(rest, bones.leftForeArm, new THREE.Euler(-1.1, 0.16, -0.14, 'XYZ'));
-  composeModelBone(rest, bones.leftHand, new THREE.Euler(-0.2, 0.08, -0.04, 'XYZ'));
-
-  let targetBiasY = -0.04;
-  let targetBiasZ = 0.18;
-  if (seatHuman?.action?.targetWorld && seatHuman?.root?.parent?.worldToLocal) {
-    const targetLocal = seatHuman.root.parent.worldToLocal(
-      seatHuman.action.targetWorld.clone()
-    );
-    const horizontal = Math.hypot(targetLocal.x, targetLocal.z) || 1;
-    targetBiasY = THREE.MathUtils.clamp(targetLocal.x / horizontal, -0.32, 0.32);
-    targetBiasZ = THREE.MathUtils.clamp(-targetLocal.z / horizontal, -0.34, 0.34);
-  }
+  // Baseline: both hands hold dominos from both side edges while seated.
+  composeModelBone(rest, bones.leftShoulder, new THREE.Euler(-0.12, 0.04, -0.32, 'XYZ'));
+  composeModelBone(rest, bones.leftArm, new THREE.Euler(-0.92, 0.14, -0.4, 'XYZ'));
+  composeModelBone(rest, bones.leftForeArm, new THREE.Euler(-1.18, 0.1, -0.2, 'XYZ'));
+  composeModelBone(rest, bones.leftHand, new THREE.Euler(-0.26, 0.08, -0.08, 'XYZ'));
 
   composeModelBone(
     rest,
@@ -7826,6 +7859,11 @@ function applyLoadedHumanPose(seatHuman, timeSeconds, actionStrength = 0, knockS
     bones.rightHand,
     new THREE.Euler(-0.24 + rightReach * 0.7, 0.06 + targetBiasY * 0.22, -0.06, 'XYZ')
   );
+  if (isKnockAction) {
+    composeModelBone(rest, bones.leftShoulder, new THREE.Euler(-0.18, 0.02, -0.2, 'XYZ'));
+    composeModelBone(rest, bones.leftArm, new THREE.Euler(-0.72, 0.08, -0.18, 'XYZ'));
+    composeModelBone(rest, bones.leftForeArm, new THREE.Euler(-0.92, 0.04, -0.1, 'XYZ'));
+  }
 }
 
 function createSeatedHumanFallbackTexture(primary = '#cdb8a0', secondary = '#8a6a4e') {
@@ -7882,10 +7920,15 @@ async function ensureHumanTemplate() {
       const fallbackTex = useHair ? hairTex : useSkin ? skinTex : clothTex;
       const mats = Array.isArray(obj.material) ? obj.material : obj.material ? [obj.material] : [];
       mats.forEach((mat) => {
+        // Preserve original GLB texture set whenever it exists; only fill missing maps.
         if (!mat?.map) mat.map = fallbackTex;
         if (mat?.color?.setHex) mat.color.setHex(0xffffff);
-        if (mat?.map) applySRGBColorSpace(mat.map);
-        if (mat?.emissiveMap) applySRGBColorSpace(mat.emissiveMap);
+        if (typeof normalizeMaterialTextures === 'function') {
+          normalizeMaterialTextures(mat, 8, { preserveGltfTextureMapping: true });
+        } else {
+          if (mat?.map) applySRGBColorSpace(mat.map);
+          if (mat?.emissiveMap) applySRGBColorSpace(mat.emissiveMap);
+        }
         mat.needsUpdate = true;
       });
     });
@@ -7941,6 +7984,58 @@ function fitHumanToSeat(root, seatHelper, chairSize) {
   root.position.copy(seatHelper.position);
 }
 
+function createHandHelper(root, name, x, y, z) {
+  const helper = new THREE.Object3D();
+  helper.name = name;
+  helper.position.set(x, y, z);
+  root.add(helper);
+  return helper;
+}
+
+function createDominoHandHelpers(bones) {
+  const leftRoot = bones?.leftHand?.isObject3D ? bones.leftHand : bones?.leftForeArm;
+  const rightRoot = bones?.rightHand?.isObject3D ? bones.rightHand : bones?.rightForeArm;
+  if (!leftRoot && !rightRoot) return null;
+  return {
+    leftHoldOuter: leftRoot
+      ? createHandHelper(
+          leftRoot,
+          'dominoLeftHoldOuter',
+          SEATED_DOMINO_HOLD_SIDE_OFFSET,
+          SEATED_DOMINO_HOLD_HEIGHT_OFFSET,
+          SEATED_DOMINO_HOLD_FORWARD_OFFSET
+        )
+      : null,
+    rightHoldOuter: rightRoot
+      ? createHandHelper(
+          rightRoot,
+          'dominoRightHoldOuter',
+          -SEATED_DOMINO_HOLD_SIDE_OFFSET,
+          SEATED_DOMINO_HOLD_HEIGHT_OFFSET,
+          SEATED_DOMINO_HOLD_FORWARD_OFFSET
+        )
+      : null,
+    rightPickup: rightRoot
+      ? createHandHelper(
+          rightRoot,
+          'dominoRightPickup',
+          SEATED_DOMINO_PICKUP_RIGHT_OFFSET,
+          SEATED_DOMINO_PICKUP_HEIGHT_OFFSET,
+          SEATED_DOMINO_PICKUP_FORWARD_OFFSET
+        )
+      : null,
+    rightPlace: rightRoot
+      ? createHandHelper(
+          rightRoot,
+          'dominoRightPlace',
+          SEATED_DOMINO_PLACE_RIGHT_OFFSET,
+          SEATED_DOMINO_PLACE_HEIGHT_OFFSET,
+          SEATED_DOMINO_PLACE_FORWARD_OFFSET
+        )
+      : null
+  };
+}
+
 function triggerSeatHumanAction(seatIndex, action = 'place', targetWorld = null) {
   if (HUMAN_CHARACTER_DISABLED) return;
   const seatHuman = seatedHumans[seatIndex];
@@ -7959,7 +8054,7 @@ function triggerSeatHumanAction(seatIndex, action = 'place', targetWorld = null)
   seatHuman.action = {
     type: 'place',
     startMs: now,
-    durationMs: 950,
+    durationMs: 1050,
     targetWorld: actionTarget
   };
 }
@@ -8025,6 +8120,7 @@ async function placeSeatedHumans(seatBottomOffset, chairSize) {
 
     const bones = buildHumanBoneMap(root);
     seatHuman.bones = bones;
+    seatHuman.handHelpers = createDominoHandHelpers(bones);
     seatHuman.rest = captureModelRestPose(root);
     seatHuman.baseScale = 1;
 


### PR DESCRIPTION
### Motivation
- Align seated human models to the same seated baseline used in Ludo and make seated character poses respond to place/knock actions and world targets. 
- Provide explicit hand helper anchors for domino pickup/place interactions so objects can be positioned reliably relative to hands. 
- Preserve original GLB texture mappings while normalizing textures for rendering and fallback generation when maps are missing.

### Description
- Updated seat vertical offset to use Ludo baseline (`SEATED_HUMAN_SEAT_Y_OFFSET`) and added a set of domino hand offset constants (`SEATED_DOMINO_*`) plus temporary `THREE.Vector3` helpers. 
- Enhanced `applyLoadedHumanPose` to detect action type (`place`/`knock`), compute a local target bias and forward reach from a world target, and blend bone rotations (hips, spine, head, shoulders, arms, hands) based on `actionStrength` and `knockStrength`, including a special left-arm adjustment for knock actions. 
- Limited `rightReach` to `place` actions and increased place action duration from 950ms to 1050ms in `triggerSeatHumanAction`. 
- Preserve GLB-provided textures by preferring existing maps and call `normalizeMaterialTextures` when available with `preserveGltfTextureMapping: true`, otherwise fall back to existing `applySRGBColorSpace` behavior for maps and emissive maps. 
- Added `createHandHelper` and `createDominoHandHelpers` to attach named helper objects to hand/forearm bones, and wire up `seatHuman.handHelpers` when creating seated humans. 

### Testing
- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec8b6f50308329b898a5ea98ed2c0a)