### PR TITLE
Fix Chess Battle Royal camera restore and board surface clearance

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -356,6 +356,7 @@ const BOARD_GROUP_Y_OFFSET = 0.05;
 const BOARD_MODEL_Y_OFFSET = -0.12;
 const BOARD_VISUAL_Y_OFFSET = -0.03;
 const BOARD_SURFACE_DROP = 0.05;
+const BOARD_SURFACE_CLEARANCE = 0.035; // Keep board visibly above every table surface to avoid clipping.
 
 const RAW_BOARD_SIZE = BOARD.N * BOARD.tile + BOARD.rim * 2;
 const BOARD_SCALE = 0.0359 * LAYOUT_SCALE_FACTOR * TABLE_LAYOUT_SCALE_FACTOR;
@@ -2270,7 +2271,10 @@ function alignBoardGroupToTableSurface(boardGroup, tableInfo) {
     BOARD_SURFACE_OFFSETS_BY_SHAPE[tableInfo?.shapeId] ??
     BOARD_SURFACE_OFFSETS_BY_SHAPE[tableInfo?.themeId] ??
     0;
-  return alignGroupToFloorY(boardGroup, surfaceY + BOARD_GROUP_Y_OFFSET + surfaceOffset);
+  return alignGroupToFloorY(
+    boardGroup,
+    surfaceY + BOARD_GROUP_Y_OFFSET + surfaceOffset + BOARD_SURFACE_CLEARANCE
+  );
 }
 
 function alignArenaContentsToRoom(groups = [], roomHalfWidth, roomHalfDepth, preferredShiftZ = 0) {
@@ -9295,7 +9299,7 @@ function Chess3D({
       const theta = Number.isFinite(current.theta) ? current.theta : PLAYER_VIEW_SEAT_THETA;
       const isForcedCapture3dView = mode === '3d' && restoreAutoViewTo2dRef.current;
 
-      const initialRadius = CAMERA_3D_MAX_RADIUS;
+      const initialRadius = clamp(cameraRadius, CAMERA_3D_MIN_RADIUS, CAMERA_3D_MAX_RADIUS);
       const default3d = new THREE.Spherical(initialRadius, CAMERA_DEFAULT_PHI, theta);
 
       if (mode === '2d') {
@@ -9340,7 +9344,8 @@ function Chess3D({
           CAM.phiMax
         );
         const targetRadius = clamp(
-          CAMERA_3D_MAX_RADIUS * (isForcedCapture3dView ? CAMERA_CAPTURE_VIEW_RADIUS_SCALE : 1),
+          (Number.isFinite(restore.radius) ? restore.radius : default3d.radius) *
+            (isForcedCapture3dView ? CAMERA_CAPTURE_VIEW_RADIUS_SCALE : 1),
           CAMERA_3D_MIN_RADIUS,
           CAMERA_3D_MAX_RADIUS
         );


### PR DESCRIPTION
### Motivation
- Ensure the gameplay camera restores to the player-facing startup distance and does not jump to an unrelated far/max-radius when views change or when a forced 3D capture runs.  
- Prevent the board mesh from visually clipping into some table models by guaranteeing a small clearance above any table surface.

### Description
- Added a new constant `BOARD_SURFACE_CLEARANCE` and applied it in `alignBoardGroupToTableSurface` so the board is positioned slightly above the table surface.  
- Adjusted 3D camera restore logic to use the actual `cameraRadius` (clamped into allowed ranges) for the default 3D radius instead of always using `CAMERA_3D_MAX_RADIUS`.  
- When restoring from 2D/FPV modes the code uses the previously saved orbit radius (`cameraMemory.last3d`) or the computed default radius, preserving user/previous 3D orbit distance and avoiding abrupt jumps.

### Testing
- Ran `npm run build` in the `webapp` package and the build completed successfully.  
- Build emitted a few non-fatal warnings (duplicate package key and chunk-size notices) but finished with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eca37489408329a2e743ade1146bcf)