### PR TITLE
Adjust Ludo seated avatars and chairs for lower/outward portrait framing

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1729,9 +1729,9 @@ const AI_CHAIR_RADIUS =
   TABLE_EDGE_INSET -
   CHAIR_INWARD_PULL;
 // Pull all chairs (with seated humans) farther away from the table edge for clearer portrait spacing.
-const CHAIR_GLOBAL_PUSHBACK = 0.31 * MODEL_SCALE;
+const CHAIR_GLOBAL_PUSHBACK = 0.48 * MODEL_SCALE;
 // Keep the bottom/local-player seat distinctly farther out than the rest.
-const SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK = 0.48 * MODEL_SCALE;
+const SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK = 0.62 * MODEL_SCALE;
 
 const DEFAULT_PLAYER_COUNT = 4;
 const clampPlayerCount = (value) =>
@@ -1767,10 +1767,10 @@ const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.42;
 // Slightly upscale seated humans so they read better on portrait/mobile gameplay.
 const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 4.98;
 // Push seated humans further downward so hips are clearly seated and feet stay grounded on portrait gameplay.
-const SEATED_HUMAN_SEAT_Y_OFFSET = -2.08 * MODEL_SCALE * STOOL_SCALE;
-// Shift humans slightly farther back on the chair so they stay aligned after outward chair spacing changes.
-const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.26;
-const SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET = -SEAT_DEPTH * 0.1;
+const SEATED_HUMAN_SEAT_Y_OFFSET = -2.3 * MODEL_SCALE * STOOL_SCALE;
+// Shift humans farther back on the chair so they appear more outward from the table in portrait gameplay.
+const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.34;
+const SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET = -SEAT_DEPTH * 0.14;
 const SEATED_HUMAN_FACING_Y = 0;
 // Keep feet slightly below the strict grounding plane to reinforce the lower seated posture.
 const SEATED_HUMAN_FOOT_GROUND_CLEARANCE = -0.76 * MODEL_SCALE * STOOL_SCALE;


### PR DESCRIPTION
### Motivation
- Improve portrait/mobile framing for the Ludo Battle Royal scene by moving chairs outward and making seated avatars appear lower and further back so hips/feet read correctly on small screens.

### Description
- Increased global chair pushback by updating `CHAIR_GLOBAL_PUSHBACK` from `0.31 * MODEL_SCALE` to `0.48 * MODEL_SCALE` to place all chairs farther from the table edge.
- Increased bottom/local-player chair offset by updating `SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK` from `0.48 * MODEL_SCALE` to `0.62 * MODEL_SCALE` to keep the local seat visibly outward.
- Lowered seated avatars by changing `SEATED_HUMAN_SEAT_Y_OFFSET` from `-2.08 * MODEL_SCALE * STOOL_SCALE` to `-2.3 * MODEL_SCALE * STOOL_SCALE` so characters sit visually lower.
- Moved seated avatars further back by changing `SEATED_HUMAN_SEAT_Z_OFFSET` from `-SEAT_DEPTH * 0.26` to `-SEAT_DEPTH * 0.34` and `SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET` from `-SEAT_DEPTH * 0.1` to `-SEAT_DEPTH * 0.14` so characters read as more outward from the table.

### Testing
- Ran the production build with `npm -C webapp run build`, which completed successfully; Vite emitted non-blocking warnings about a duplicate `package.json` key and large chunk sizes but the build finished without errors.
- No additional automated unit or integration tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eca983374883299c0aff5da5500b05)