### PR TITLE
Fix Chess Battle Royale start camera framing and human character swaps

### DIFF
--- a/webapp/src/config/chessBattleInventoryConfig.js
+++ b/webapp/src/config/chessBattleInventoryConfig.js
@@ -15,6 +15,12 @@ const CHESS_HUMAN_CHARACTER_SOURCE = Object.freeze({
   author: 'Mixamo / Adobe (sample avatars)'
 });
 
+const buildThreeExampleModelUrls = (name) =>
+  Object.freeze([
+    `https://cdn.jsdelivr.net/gh/mrdoob/three.js@dev/examples/models/gltf/${name}.glb`,
+    `https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/models/gltf/${name}.glb`
+  ]);
+
 export const CHESS_HUMAN_CHARACTER_OPTIONS = Object.freeze([
   {
     id: 'rpm-current',
@@ -26,140 +32,140 @@ export const CHESS_HUMAN_CHARACTER_OPTIONS = Object.freeze([
   {
     id: 'mixamo-aj',
     label: 'AJ',
-    modelUrls: ['https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/models/gltf/Aj.glb'],
+    modelUrls: buildThreeExampleModelUrls('Aj'),
     thumbnail: swatchThumbnail(['#2a4365', '#1f2937', '#d4a373']),
     ...CHESS_HUMAN_CHARACTER_SOURCE
   },
   {
     id: 'mixamo-jane',
     label: 'Jane',
-    modelUrls: ['https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/models/gltf/Jane.glb'],
+    modelUrls: buildThreeExampleModelUrls('Jane'),
     thumbnail: swatchThumbnail(['#6b21a8', '#1f2937', '#f5c2a0']),
     ...CHESS_HUMAN_CHARACTER_SOURCE
   },
   {
     id: 'mixamo-eva',
     label: 'Eva',
-    modelUrls: ['https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/models/gltf/Eva.glb'],
+    modelUrls: buildThreeExampleModelUrls('Eva'),
     thumbnail: swatchThumbnail(['#0f766e', '#164e63', '#f2c89b']),
     ...CHESS_HUMAN_CHARACTER_SOURCE
   },
   {
     id: 'mixamo-joe',
     label: 'Joe',
-    modelUrls: ['https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/models/gltf/Joe.glb'],
+    modelUrls: buildThreeExampleModelUrls('Joe'),
     thumbnail: swatchThumbnail(['#6b7280', '#1f2937', '#c58f63']),
     ...CHESS_HUMAN_CHARACTER_SOURCE
   },
   {
     id: 'mixamo-kaya',
     label: 'Kaya',
-    modelUrls: ['https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/models/gltf/Kaya.glb'],
+    modelUrls: buildThreeExampleModelUrls('Kaya'),
     thumbnail: swatchThumbnail(['#1d4ed8', '#111827', '#d8b08c']),
     ...CHESS_HUMAN_CHARACTER_SOURCE
   },
   {
     id: 'mixamo-ybot',
     label: 'Y-Bot',
-    modelUrls: ['https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/models/gltf/YBot.glb'],
+    modelUrls: buildThreeExampleModelUrls('YBot'),
     thumbnail: swatchThumbnail(['#1f2937', '#0f172a', '#9ca3af']),
     ...CHESS_HUMAN_CHARACTER_SOURCE
   },
   {
     id: 'mixamo-xbot',
     label: 'X-Bot',
-    modelUrls: ['https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/models/gltf/Xbot.glb'],
+    modelUrls: buildThreeExampleModelUrls('Xbot'),
     thumbnail: swatchThumbnail(['#334155', '#0f172a', '#94a3b8']),
     ...CHESS_HUMAN_CHARACTER_SOURCE
   },
   {
     id: 'mixamo-soldier',
     label: 'Soldier',
-    modelUrls: ['https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/models/gltf/Soldier.glb'],
+    modelUrls: buildThreeExampleModelUrls('Soldier'),
     thumbnail: swatchThumbnail(['#3f6212', '#1f2937', '#b8a083']),
     ...CHESS_HUMAN_CHARACTER_SOURCE
   },
   {
     id: 'mixamo-remy',
     label: 'Remy',
-    modelUrls: ['https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/models/gltf/Remy.glb'],
+    modelUrls: buildThreeExampleModelUrls('Remy'),
     thumbnail: swatchThumbnail(['#7c2d12', '#111827', '#d6a77b']),
     ...CHESS_HUMAN_CHARACTER_SOURCE
   },
   {
     id: 'mixamo-priya',
     label: 'Priya',
-    modelUrls: ['https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/models/gltf/Priya.glb'],
+    modelUrls: buildThreeExampleModelUrls('Priya'),
     thumbnail: swatchThumbnail(['#c026d3', '#312e81', '#e6b58f']),
     ...CHESS_HUMAN_CHARACTER_SOURCE
   },
   {
     id: 'mixamo-noah',
     label: 'Noah',
-    modelUrls: ['https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/models/gltf/Noah.glb'],
+    modelUrls: buildThreeExampleModelUrls('Noah'),
     thumbnail: swatchThumbnail(['#0891b2', '#0f172a', '#c79b76']),
     ...CHESS_HUMAN_CHARACTER_SOURCE
   },
   {
     id: 'mixamo-martha',
     label: 'Martha',
-    modelUrls: ['https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/models/gltf/Martha.glb'],
+    modelUrls: buildThreeExampleModelUrls('Martha'),
     thumbnail: swatchThumbnail(['#7e22ce', '#1f2937', '#f0c4a3']),
     ...CHESS_HUMAN_CHARACTER_SOURCE
   },
   {
     id: 'mixamo-lewis',
     label: 'Lewis',
-    modelUrls: ['https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/models/gltf/Lewis.glb'],
+    modelUrls: buildThreeExampleModelUrls('Lewis'),
     thumbnail: swatchThumbnail(['#0f766e', '#064e3b', '#cb9d75']),
     ...CHESS_HUMAN_CHARACTER_SOURCE
   },
   {
     id: 'mixamo-kiara',
     label: 'Kiara',
-    modelUrls: ['https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/models/gltf/Kiara.glb'],
+    modelUrls: buildThreeExampleModelUrls('Kiara'),
     thumbnail: swatchThumbnail(['#be123c', '#1f2937', '#e7be98']),
     ...CHESS_HUMAN_CHARACTER_SOURCE
   },
   {
     id: 'mixamo-josh',
     label: 'Josh',
-    modelUrls: ['https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/models/gltf/Josh.glb'],
+    modelUrls: buildThreeExampleModelUrls('Josh'),
     thumbnail: swatchThumbnail(['#1d4ed8', '#1f2937', '#c49368']),
     ...CHESS_HUMAN_CHARACTER_SOURCE
   },
   {
     id: 'mixamo-grace',
     label: 'Grace',
-    modelUrls: ['https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/models/gltf/Grace.glb'],
+    modelUrls: buildThreeExampleModelUrls('Grace'),
     thumbnail: swatchThumbnail(['#7e22ce', '#4c1d95', '#f0c9aa']),
     ...CHESS_HUMAN_CHARACTER_SOURCE
   },
   {
     id: 'mixamo-fred',
     label: 'Fred',
-    modelUrls: ['https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/models/gltf/Fred.glb'],
+    modelUrls: buildThreeExampleModelUrls('Fred'),
     thumbnail: swatchThumbnail(['#78350f', '#1f2937', '#be8f67']),
     ...CHESS_HUMAN_CHARACTER_SOURCE
   },
   {
     id: 'mixamo-ellen',
     label: 'Ellen',
-    modelUrls: ['https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/models/gltf/Ellen.glb'],
+    modelUrls: buildThreeExampleModelUrls('Ellen'),
     thumbnail: swatchThumbnail(['#0369a1', '#1f2937', '#ebc3a2']),
     ...CHESS_HUMAN_CHARACTER_SOURCE
   },
   {
     id: 'mixamo-diego',
     label: 'Diego',
-    modelUrls: ['https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/models/gltf/Diego.glb'],
+    modelUrls: buildThreeExampleModelUrls('Diego'),
     thumbnail: swatchThumbnail(['#166534', '#1f2937', '#bf8a61']),
     ...CHESS_HUMAN_CHARACTER_SOURCE
   },
   {
     id: 'mixamo-carla',
     label: 'Carla',
-    modelUrls: ['https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/models/gltf/Carla.glb'],
+    modelUrls: buildThreeExampleModelUrls('Carla'),
     thumbnail: swatchThumbnail(['#be185d', '#1f2937', '#e5bc96']),
     ...CHESS_HUMAN_CHARACTER_SOURCE
   }

--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -419,8 +419,8 @@ const FALLBACK_SEAT_POSITIONS = [
 ];
 const CAMERA_WHEEL_FACTOR = ARENA_CAMERA_DEFAULTS.wheelDeltaFactor;
 const CAMERA_PULL_FORWARD_MIN = THREE.MathUtils.degToRad(15);
-const CAMERA_CAPTURE_VIEW_UPWARD_BIAS = THREE.MathUtils.degToRad(10); // push forced 3D animation camera a bit higher for stronger down-board framing
-const CAMERA_CAPTURE_VIEW_RADIUS_SCALE = 0.95; // move forced 3D animation camera slightly closer during capture
+const CAMERA_CAPTURE_VIEW_UPWARD_BIAS = THREE.MathUtils.degToRad(3.5); // keep animation framing closer to the game-start camera pose.
+const CAMERA_CAPTURE_VIEW_RADIUS_SCALE = 1.02; // keep animation framing consistent with the game-start camera distance.
 const CAMERA_CAPTURE_BOTTOM_AVATAR_SCREEN_OFFSET = 6; // keep local player's avatar lower so chair/animation view stays clear
 const SAND_TIMER_RADIUS_FACTOR = 0.68;
 const SAND_TIMER_SURFACE_OFFSET = 0.2;
@@ -436,11 +436,11 @@ const SEATED_HUMAN_FOOT_GROUND_DROP = 0.12;
 const SEATED_HUMAN_PICK_LIFT_HEIGHT = 0.24;
 const SEATED_HUMAN_HAND_PIECE_FORWARD = 0.03;
 const PLAYER_VIEW_SEAT_THETA = Math.PI / 2;
-const PLAYER_VIEW_CAMERA_BACK_OFFSET_PORTRAIT = 1.78;
+const PLAYER_VIEW_CAMERA_BACK_OFFSET_PORTRAIT = 1.98;
 const PLAYER_VIEW_CAMERA_BACK_OFFSET_LANDSCAPE = 1.34;
-const PLAYER_VIEW_CAMERA_FORWARD_OFFSET_PORTRAIT = 0.96;
+const PLAYER_VIEW_CAMERA_FORWARD_OFFSET_PORTRAIT = 0.9;
 const PLAYER_VIEW_CAMERA_FORWARD_OFFSET_LANDSCAPE = 0.68;
-const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_PORTRAIT = 0.68;
+const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_PORTRAIT = 0.76;
 const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_LANDSCAPE = 0.78;
 const PLAYER_VIEW_LOOK_TARGET_FORWARD_BIAS = -BOARD.tile * BOARD_SCALE * 0.55;
 const TABLE_BOTTOM_PLAYER_BIAS_Z = BOARD.tile * BOARD_SCALE * 0.62; // pull the whole table noticeably closer to the bottom/local player on portrait screens
@@ -648,38 +648,6 @@ function applyRightHandGrip(rig, gripAmount = 0) {
   });
 }
 
-function createSeatedHumanFallbackTexture(primary = '#cdb8a0', secondary = '#8a6a4e') {
-  const size = 256;
-  const canvas = document.createElement('canvas');
-  canvas.width = size;
-  canvas.height = size;
-  const ctx = canvas.getContext('2d');
-  if (!ctx) return new THREE.CanvasTexture(canvas);
-  const grad = ctx.createLinearGradient(0, 0, size, size);
-  grad.addColorStop(0, primary);
-  grad.addColorStop(1, secondary);
-  ctx.fillStyle = grad;
-  ctx.fillRect(0, 0, size, size);
-  for (let i = 0; i < 180; i += 1) {
-    const x = (i * 53) % size;
-    const y = (i * 79) % size;
-    const w = 8 + ((i * 11) % 22);
-    const h = 4 + ((i * 7) % 14);
-    ctx.globalAlpha = 0.09 + (i % 4) * 0.06;
-    ctx.fillStyle = i % 2 ? 'rgba(255,255,255,0.75)' : 'rgba(0,0,0,0.55)';
-    ctx.fillRect(x, y, w, h);
-  }
-  ctx.globalAlpha = 1;
-  const tex = new THREE.CanvasTexture(canvas);
-  applySRGBColorSpace(tex);
-  tex.flipY = false;
-  tex.wrapS = THREE.RepeatWrapping;
-  tex.wrapT = THREE.RepeatWrapping;
-  tex.anisotropy = 8;
-  tex.needsUpdate = true;
-  return tex;
-}
-
 function applySeatedHumanPose(rig, mode = 'idle', intensity = 1, handGrip = 0) {
   if (!rig) return;
   resetBoneRig(rig);
@@ -800,21 +768,26 @@ async function loadSeatedHumanTemplate(option, renderer = null) {
     if (!root) {
       throw lastError || new Error('Missing seated human scene');
     }
-    const skinTex = createSeatedHumanFallbackTexture('#d8c0a6', '#b48d6b');
-    const clothTex = createSeatedHumanFallbackTexture('#55739a', '#2c3f54');
-    const hairTex = createSeatedHumanFallbackTexture('#7b5d3f', '#3f2f20');
+    root.updateMatrixWorld(true);
+    const preBox = new THREE.Box3().setFromObject(root);
+    const preSize = preBox.getSize(new THREE.Vector3());
+    const sourceHeight = Math.max(preSize.y, 0.01);
+    const normalizeScale = SEATED_HUMAN_BASE_HEIGHT / sourceHeight;
+    root.scale.setScalar(normalizeScale);
+    root.updateMatrixWorld(true);
+    const normalizedBox = new THREE.Box3().setFromObject(root);
+    const normalizedCenter = normalizedBox.getCenter(new THREE.Vector3());
+    root.position.x -= normalizedCenter.x;
+    root.position.z -= normalizedCenter.z;
+    root.position.y -= normalizedBox.min.y;
+    root.updateMatrixWorld(true);
     root.traverse((obj) => {
       if (!obj?.isMesh) return;
       obj.castShadow = true;
       obj.receiveShadow = true;
       obj.frustumCulled = false;
-      const meshName = `${obj.name || ''}`.toLowerCase();
-      const useSkin = /head|face|neck|ear|hand/.test(meshName);
-      const useHair = /hair|beard|mustache|moustache|eyebrow/.test(meshName);
-      const fallbackTex = useHair ? hairTex : useSkin ? skinTex : clothTex;
       const mats = Array.isArray(obj.material) ? obj.material : obj.material ? [obj.material] : [];
       mats.forEach((mat) => {
-        if (!mat?.map) mat.map = fallbackTex;
         if (mat?.color?.setHex) mat.color.setHex(0xffffff);
         if (mat?.map) applySRGBColorSpace(mat.map);
         if (mat?.emissiveMap) applySRGBColorSpace(mat.emissiveMap);
@@ -823,8 +796,12 @@ async function loadSeatedHumanTemplate(option, renderer = null) {
     });
     return root;
   })();
-  seatedHumanTemplatePromiseById.set(cacheKey, promise);
-  return promise;
+  const resilientPromise = promise.catch((error) => {
+    seatedHumanTemplatePromiseById.delete(cacheKey);
+    throw error;
+  });
+  seatedHumanTemplatePromiseById.set(cacheKey, resilientPromise);
+  return resilientPromise;
 }
 
 function getDisplayMetrics() {


### PR DESCRIPTION
### Motivation
- Make the game start/capture camera match the requested reference framing and keep move animations visually consistent with that pose.
- Ensure recently added/purchased human characters actually swap in at runtime, preserve their authored GLB textures, and sit/scale identically to the default avatar.

### Description
- Tweak portrait camera parameters (`PLAYER_VIEW_CAMERA_*` and `CAMERA_CAPTURE_VIEW_*`) to tighten start framing and reduce animation drift during captures in `webapp/src/pages/Games/ChessBattleRoyal.jsx`.
- Make `loadSeatedHumanTemplate` resilient to transient load failures by evicting failed promises from the `seatedHumanTemplatePromiseById` cache so retries can succeed (prevents a bad cached rejection from blocking future swaps).
- Stop forcing fallback canvas textures onto purchased GLBs; instead preserve original material `map` textures while still applying `applySRGBColorSpace` and shadow/frustum flags so materials remain authentic.
- Normalize imported human models by computing a bounding box, scaling to `SEATED_HUMAN_BASE_HEIGHT`, and centering/floor-aligning each model so every character is seated at the same position and apparent size as the default avatar.
- Add `buildThreeExampleModelUrls` helper and update Mixamo entries in `webapp/src/config/chessBattleInventoryConfig.js` to include dual CDN/GitHub fallback URLs for better runtime availability.

### Testing
- Ran ESLint on the modified files with project ignore patterns; lint produced ignore warnings but no blocking errors for the targeted files when using standard invocation (`npx eslint webapp/src/pages/Games/ChessBattleRoyal.jsx webapp/src/config/chessBattleInventoryConfig.js`).
- Built the frontend successfully (`npm run -s build`) with no build-time failures.
- Verified in-code runtime protections: cached GLB promises are removed on failure so re-selecting a character will attempt a fresh load (behavior covered by the added cache-resilience logic).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecbc08f69483299b5b780f11b47f0b)