### PR TITLE
Lower Ludo Battle Royal seated human floor offset

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1767,7 +1767,7 @@ const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.42;
 // Slightly upscale seated humans so they read better on portrait/mobile gameplay.
 const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 4.55;
 // Push seated humans further downward so hips are clearly seated and feet stay grounded on portrait gameplay.
-const SEATED_HUMAN_SEAT_Y_OFFSET = -2.65 * MODEL_SCALE * STOOL_SCALE;
+const SEATED_HUMAN_SEAT_Y_OFFSET = -2.9 * MODEL_SCALE * STOOL_SCALE;
 // Shift humans farther back on the chair so they appear more outward from the table in portrait gameplay.
 const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.42;
 const SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET = -SEAT_DEPTH * 0.2;


### PR DESCRIPTION
### Motivation
- The seated human appears too high on portrait/mobile screens, so the visual posture should be lowered to make hips/feet sit closer to the floor.

### Description
- Adjusted `SEATED_HUMAN_SEAT_Y_OFFSET` in `webapp/src/pages/Games/LudoBattleRoyal.jsx` from `-2.65 * MODEL_SCALE * STOOL_SCALE` to `-2.9 * MODEL_SCALE * STOOL_SCALE` to move the human character lower.

### Testing
- Ran `npm run -s test -- test/lobbyWait.test.js` and the test suite passed (1 test, 1 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecd9570e008329adc55c6665646c76)