### PR TITLE
Lower seated human avatar toward the floor in Ludo Battle Royal

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1766,8 +1766,8 @@ const SEATED_HUMAN_BASE_HEIGHT = 1.74;
 const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.42;
 // Slightly upscale seated humans so they read better on portrait/mobile gameplay.
 const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 4.55;
-// Push seated humans further downward so hips are clearly seated and feet stay grounded on portrait gameplay.
-const SEATED_HUMAN_SEAT_Y_OFFSET = -2.9 * MODEL_SCALE * STOOL_SCALE;
+// Push seated humans noticeably lower so the local player reads much closer to the floor on portrait gameplay.
+const SEATED_HUMAN_SEAT_Y_OFFSET = -3.65 * MODEL_SCALE * STOOL_SCALE;
 // Shift humans farther back on the chair so they appear more outward from the table in portrait gameplay.
 const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.42;
 const SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET = -SEAT_DEPTH * 0.2;


### PR DESCRIPTION
### Motivation
- Make the local human character read closer to the floor on portrait/mobile screens so seated posture and feet look grounded and visually correct.

### Description
- Reduce `SEATED_HUMAN_SEAT_Y_OFFSET` from `-2.9 * MODEL_SCALE * STOOL_SCALE` to `-3.65 * MODEL_SCALE * STOOL_SCALE` and update the inline comment in `webapp/src/pages/Games/LudoBattleRoyal.jsx` to reflect the stronger downward placement.

### Testing
- Ran linting with `npx eslint webapp/src/pages/Games/LudoBattleRoyal.jsx`, which completed successfully (existing ESLint ignore warning reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecdf7c02b483299fc1f44809af1878)