### PR TITLE
Adjust seated human vertical offset and foot clearance for deeper portrait seating

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1766,14 +1766,14 @@ const SEATED_HUMAN_BASE_HEIGHT = 1.74;
 const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.42;
 // Slightly upscale seated humans so they read better on portrait/mobile gameplay.
 const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 4.55;
-// Push seated humans noticeably lower so the local player reads much closer to the floor on portrait gameplay.
-const SEATED_HUMAN_SEAT_Y_OFFSET = -3.65 * MODEL_SCALE * STOOL_SCALE;
+// Push seated humans dramatically lower so they sit much deeper on portrait/mobile camera framing.
+const SEATED_HUMAN_SEAT_Y_OFFSET = -5.85 * MODEL_SCALE * STOOL_SCALE;
 // Shift humans farther back on the chair so they appear more outward from the table in portrait gameplay.
 const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.42;
 const SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET = -SEAT_DEPTH * 0.2;
 const SEATED_HUMAN_FACING_Y = 0;
-// Keep feet slightly below the strict grounding plane to reinforce the lower seated posture.
-const SEATED_HUMAN_FOOT_GROUND_CLEARANCE = -0.82 * MODEL_SCALE * STOOL_SCALE;
+// Keep feet lower to preserve the deeper seat grounding after the stronger vertical drop.
+const SEATED_HUMAN_FOOT_GROUND_CLEARANCE = -1.55 * MODEL_SCALE * STOOL_SCALE;
 const SEATED_HUMAN_ROLL_MS = 1680;
 const SEATED_HUMAN_RECOVER_MS = 420;
 const SEATED_HELPER_FORWARD_DICE_PICKUP = 0.052 * MODEL_SCALE;


### PR DESCRIPTION
### Motivation
- Improve the visual framing of seated player avatars on portrait/mobile by seating them deeper and preserving foot grounding after a stronger vertical drop.

### Description
- Increase `SEATED_HUMAN_SEAT_Y_OFFSET` from `-3.65 * MODEL_SCALE * STOOL_SCALE` to `-5.85 * MODEL_SCALE * STOOL_SCALE` and update its comment to reflect the deeper seating intent.
- Lower `SEATED_HUMAN_FOOT_GROUND_CLEARANCE` from `-0.82 * MODEL_SCALE * STOOL_SCALE` to `-1.55 * MODEL_SCALE * STOOL_SCALE` and adjust the comment to note the preserved grounding.

### Testing
- Ran the project automated test and lint suite via `yarn test` and `yarn lint`, and no tests failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ece3c0d4e883299f60dff954365c61)