### PR TITLE
Pool Royale: attach larger GLB player avatar and add GLB pose driver

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1927,7 +1927,11 @@ const REFERENCE_CUE_SPEED_GAMMA = 1.08; // reference implementation: power curve
 const MIN_SHOT_POWER_TO_FIRE = 0.015; // ignore accidental micro drags/releases that should not launch the cue ball
 const HUMAN_PLAYER_HEIGHT_RATIO_TO_TABLE = 0.8; // larger character relative to table/balls on portrait screens
 const LUDO_BATTLE_ROYAL_SEATED_HUMAN_URL = 'https://threejs.org/examples/models/gltf/readyplayer.me.glb';
-const POOL_ROYALE_HUMAN_SCALE_MULTIPLIER = 1.2; // make Pool Royale humans slightly bigger than the old procedural rig
+const POOL_ROYALE_HUMAN_GLTF_URLS = [
+  '/assets/models/pool-royale-human.glb',
+  LUDO_BATTLE_ROYAL_SEATED_HUMAN_URL
+];
+const POOL_ROYALE_HUMAN_SCALE_MULTIPLIER = 1.35; // make Pool Royale humans visibly bigger on portrait view
 const HUMAN_PLAYER_IDLE_SWAY_SPEED = 1.2;
 const HUMAN_PLAYER_IDLE_SWAY_ANGLE = 0.04;
 const HUMAN_PLAYER_AIM_LEAN = 0.2;
@@ -19673,7 +19677,7 @@ const shotPowerRef = useRef(0);
         if (seatedHumanLoadRef.current) {
           return seatedHumanLoadRef.current;
         }
-        seatedHumanLoadRef.current = loadFirstAvailableGltf([LUDO_BATTLE_ROYAL_SEATED_HUMAN_URL])
+        seatedHumanLoadRef.current = loadFirstAvailableGltf(POOL_ROYALE_HUMAN_GLTF_URLS)
           .then((gltf) => {
             const model = gltf?.scene?.clone?.(true) ?? gltf?.scene ?? gltf?.scenes?.[0] ?? null;
             if (!model) {
@@ -24393,6 +24397,87 @@ const shotPowerRef = useRef(0);
         return new THREE.Quaternion().setFromRotationMatrix(basis);
       };
 
+      const cleanBoneName = (name = '') => String(name).toLowerCase().replace(/[^a-z0-9]/g, '');
+
+      const findBoneByAliases = (bones, aliases = []) => {
+        if (!Array.isArray(bones) || !bones.length) return null;
+        const normalized = bones.map((bone) => ({ bone, name: cleanBoneName(bone?.name) }));
+        const wanted = aliases.map((alias) => cleanBoneName(alias));
+        for (const alias of wanted) {
+          const exact = normalized.find((entry) => entry.name === alias || entry.name.endsWith(alias));
+          if (exact?.bone) return exact.bone;
+        }
+        for (const alias of wanted) {
+          const loose = normalized.find((entry) => entry.name.includes(alias));
+          if (loose?.bone) return loose.bone;
+        }
+        return null;
+      };
+
+      const buildPlayerAvatarBones = (model) => {
+        const bones = [];
+        model?.traverse?.((child) => {
+          if (child?.isBone) bones.push(child);
+        });
+        return {
+          hips: findBoneByAliases(bones, ['hips', 'pelvis', 'mixamorigHips']),
+          spine: findBoneByAliases(bones, ['spine', 'spine1', 'mixamorigSpine']),
+          chest: findBoneByAliases(bones, ['spine2', 'chest', 'upperchest', 'mixamorigSpine2']),
+          head: findBoneByAliases(bones, ['head', 'mixamorigHead']),
+          leftUpperArm: findBoneByAliases(bones, ['leftupperarm', 'leftarm', 'mixamorigLeftArm']),
+          leftLowerArm: findBoneByAliases(bones, ['leftforearm', 'leftlowerarm', 'mixamorigLeftForeArm']),
+          rightUpperArm: findBoneByAliases(bones, ['rightupperarm', 'rightarm', 'mixamorigRightArm']),
+          rightLowerArm: findBoneByAliases(bones, ['rightforearm', 'rightlowerarm', 'mixamorigRightForeArm']),
+          leftUpperLeg: findBoneByAliases(bones, ['leftupleg', 'leftthigh', 'mixamorigLeftUpLeg']),
+          leftLowerLeg: findBoneByAliases(bones, ['leftleg', 'leftlowerleg', 'mixamorigLeftLeg']),
+          rightUpperLeg: findBoneByAliases(bones, ['rightupleg', 'rightthigh', 'mixamorigRightUpLeg']),
+          rightLowerLeg: findBoneByAliases(bones, ['rightleg', 'rightlowerleg', 'mixamorigRightLeg'])
+        };
+      };
+
+      const driveGltfPlayerPose = (anim, mode, poseT, power) => {
+        if (!anim?.gltfBones || !anim?.gltfRestPose) return;
+        const t = THREE.MathUtils.clamp(poseT, 0, 1);
+        anim.gltfRestPose.forEach((restQ, bone) => {
+          bone.quaternion.copy(restQ);
+        });
+        const aimWeight = mode === 'aim' || mode === 'strike' ? t : 0;
+        const strikeWeight = mode === 'strike' ? 1 : 0;
+        const powerWeight = THREE.MathUtils.clamp(power ?? 0, 0, 1);
+        const {
+          hips,
+          spine,
+          chest,
+          head,
+          leftUpperArm,
+          leftLowerArm,
+          rightUpperArm,
+          rightLowerArm,
+          leftUpperLeg,
+          leftLowerLeg,
+          rightUpperLeg,
+          rightLowerLeg
+        } = anim.gltfBones;
+        if (hips) hips.rotation.x += -0.12 * aimWeight;
+        if (spine) spine.rotation.x += -0.25 * aimWeight;
+        if (chest) chest.rotation.x += -0.34 * aimWeight - 0.05 * powerWeight;
+        if (head) head.rotation.x += -0.1 * aimWeight;
+        if (leftUpperArm) {
+          leftUpperArm.rotation.x += -0.68 * aimWeight;
+          leftUpperArm.rotation.z += -0.32 * aimWeight;
+        }
+        if (leftLowerArm) leftLowerArm.rotation.x += -0.42 * aimWeight;
+        if (rightUpperArm) {
+          rightUpperArm.rotation.x += -0.48 * aimWeight - 0.2 * strikeWeight;
+          rightUpperArm.rotation.z += 0.18 * aimWeight;
+        }
+        if (rightLowerArm) rightLowerArm.rotation.x += -0.32 * aimWeight - 0.22 * strikeWeight;
+        if (leftUpperLeg) leftUpperLeg.rotation.x += 0.14 * aimWeight;
+        if (leftLowerLeg) leftLowerLeg.rotation.x += -0.2 * aimWeight;
+        if (rightUpperLeg) rightUpperLeg.rotation.x += -0.08 * aimWeight;
+        if (rightLowerLeg) rightLowerLeg.rotation.x += -0.12 * aimWeight;
+      };
+
       const createBridgeHandGroup = (skinMat) => {
         const group = new THREE.Group();
         const palm = new THREE.Mesh(new THREE.BoxGeometry(0.165, 0.022, 0.115), skinMat);
@@ -24441,8 +24526,12 @@ const shotPowerRef = useRef(0);
 
       const createPlayerCharacterRig = ({ seat = 'A', x = 0, z = 0, facingY = 0 } = {}) => {
         const rigGroup = new THREE.Group();
+        const proceduralRoot = new THREE.Group();
+        const gltfRoot = new THREE.Group();
         rigGroup.position.set(x, floorY, z);
         rigGroup.rotation.y = facingY;
+        rigGroup.add(proceduralRoot);
+        rigGroup.add(gltfRoot);
 
         const humanHeight = TABLE.H * HUMAN_PLAYER_HEIGHT_RATIO_TO_TABLE;
         const scale = humanHeight / 1.82;
@@ -24494,11 +24583,11 @@ const shotPowerRef = useRef(0);
         ].forEach((mesh) => {
           mesh.castShadow = true;
           mesh.receiveShadow = true;
-          rigGroup.add(mesh);
+          proceduralRoot.add(mesh);
         });
 
-        rigGroup.add(bridgeHand);
-        rigGroup.add(gripHand);
+        proceduralRoot.add(bridgeHand);
+        proceduralRoot.add(gripHand);
 
         rigGroup.userData.anim = {
           seat,
@@ -24527,8 +24616,52 @@ const shotPowerRef = useRef(0);
           walkT: 0,
           yaw: facingY,
           rootTarget: new THREE.Vector3(x, floorY, z),
-          usesFallbackRig: false
+          usesFallbackRig: false,
+          proceduralRoot,
+          gltfRoot,
+          gltfModel: null,
+          gltfBones: null,
+          gltfRestPose: null
         };
+
+        void ensureSeatedHumanTemplate()
+          .then((template) => {
+            if (!template || !rigGroup.userData?.anim) return;
+            const model = template.clone(true);
+            model.traverse((child) => {
+              if (!child?.isMesh) return;
+              child.castShadow = true;
+              child.receiveShadow = true;
+              child.frustumCulled = false;
+            });
+            const anim = rigGroup.userData.anim;
+            gltfRoot.clear();
+            gltfRoot.add(model);
+            const gltfScale = Math.max(0.0001, scale * POOL_ROYALE_HUMAN_SCALE_MULTIPLIER);
+            gltfRoot.scale.setScalar(gltfScale);
+            gltfRoot.rotation.y = Math.PI;
+
+            model.updateMatrixWorld(true);
+            const box = new THREE.Box3().setFromObject(model);
+            const center = box.getCenter(new THREE.Vector3());
+            model.position.x -= center.x;
+            model.position.y -= box.min.y;
+            model.position.z -= center.z;
+
+            const bones = buildPlayerAvatarBones(model);
+            const restPose = new Map();
+            Object.values(bones).forEach((bone) => {
+              if (bone) restPose.set(bone, bone.quaternion.clone());
+            });
+            anim.gltfModel = model;
+            anim.gltfBones = bones;
+            anim.gltfRestPose = restPose;
+            proceduralRoot.visible = false;
+          })
+          .catch((error) => {
+            console.warn('Failed to attach Pool Royale player GLB', error);
+          });
+
         return rigGroup;
       };
 
@@ -24606,6 +24739,14 @@ const shotPowerRef = useRef(0);
           else if (isShotActive) mode = 'react';
           else if (isShooter && (loweredCueCamera || draggingSlider || sliderPowerActive)) mode = 'aim';
           anim.mode = mode;
+
+          if (anim.gltfModel) {
+            anim.proceduralRoot.visible = false;
+            anim.gltfRoot.visible = true;
+          } else {
+            anim.proceduralRoot.visible = true;
+            anim.gltfRoot.visible = false;
+          }
 
           const targetPose = mode === 'idle' ? 0 : 1;
           anim.poseT = THREE.MathUtils.lerp(anim.poseT ?? 0, targetPose, 1 - Math.exp(-HUMAN_POSE_LAMBDA * dtSeconds));
@@ -24741,6 +24882,13 @@ const shotPowerRef = useRef(0);
           anim.rightFoot.quaternion.copy(bodyQ);
           anim.leftFoot.rotation.y += -0.24 * t;
           anim.rightFoot.rotation.y += 0.16 * t;
+
+          if (anim.gltfModel) {
+            anim.gltfRoot.position.copy(hipCenterWorld);
+            anim.gltfRoot.position.y -= 0.95 * scale;
+            anim.gltfRoot.rotation.y = anim.yaw + Math.PI;
+            driveGltfPlayerPose(anim, mode, t, activePower);
+          }
 
         });
       };


### PR DESCRIPTION
### Motivation
- Make the player character visually larger and replace the procedural visual with a dedicated GLB avatar when available while keeping the existing cue/shot mechanics identical.
- Ensure the human model adopts the same aiming/striking pose when the power slider is pulled or the cue camera is lowered so visual behavior matches the reference code.

### Description
- Added a prioritized GLB URL list `POOL_ROYALE_HUMAN_GLTF_URLS` (local `/assets/models/pool-royale-human.glb` then Ready Player Me) and updated the seated-human loader to use it so the game prefers the new local model but falls back safely. (`webapp/src/pages/Games/PoolRoyale.jsx`)
- Increased the human scale multiplier to `1.35` for a bigger on-screen character in portrait view and applied the scale when attaching the GLB model. (`POOL_ROYALE_HUMAN_SCALE_MULTIPLIER`) 
- Implemented lightweight GLB bone utilities (`cleanBoneName`, `findBoneByAliases`, `buildPlayerAvatarBones`) and a simple pose driver `driveGltfPlayerPose` that nudges hips/spine/chest/arms/legs based on shot state and power so the GLB mimics existing aiming/striking posture.
- Refactored player rig creation to keep the procedural fallback and add `proceduralRoot` + `gltfRoot` visual roots, load/center/scale the GLB, cache rest-quaternions, and switch visuals at runtime; wired the GLB pose driver into the existing per-frame `updatePlayerCharacters` flow so cue slider/camera lowering and shot state still drive animations without changing cue/shot force logic.

### Testing
- Built the web client: ran `cd webapp && npm run -s build` and the production build completed successfully (warnings present from bundling but build succeeded).
- No automated unit tests were modified; the change was validated by a successful app build and static inspection of the updated `PoolRoyale.jsx` logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecf4aa115c8329a686e2bae38b96ae)