### PR TITLE
Fix Ludo portrait camera to front-facing seat with wider framing

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -383,13 +383,15 @@ const CAMERA_LOOK_YAW_DRAG_FACTOR = 0.0055;
 const CAMERA_LOOK_PITCH_LIMIT = THREE.MathUtils.degToRad(16);
 const CAMERA_LOOK_PITCH_DRAG_FACTOR = -0.0038;
 const CAMERA_EXTRA_LIFT = 0.2;
+const PORTRAIT_CAMERA_FOV = 62;
 const PORTRAIT_INITIAL_CAMERA_DISTANCE_FACTOR = 0.62;
 const LANDSCAPE_INITIAL_CAMERA_DISTANCE_FACTOR = 0.65;
 const POINTER_TAP_MAX_DISTANCE = 14;
 const POINTER_TAP_MAX_DURATION_MS = 420;
 const PORTRAIT_CAMERA_TUNING = Object.freeze({
   backOffset: 1.72,
-  forwardOffset: 0.34,
+  // Pull portrait camera inward so the table fills more of the screen.
+  forwardOffset: 0.82,
   heightOffset: 3.05,
   targetLift: 0
 });
@@ -3315,8 +3317,10 @@ function buildArena(scene, renderer, host, cameraRef, disposeHandlers, appearanc
     SEAT_DEPTH / 2 +
     AI_CHAIR_GAP +
     CHAIR_GLOBAL_PUSHBACK;
-  const camera = new THREE.PerspectiveCamera(CAM.fov, 1, CAM.near, CAM.far);
-  const cameraSeatAngle = Math.PI / 2;
+  const cameraFov = isPortrait ? PORTRAIT_CAMERA_FOV : CAM.fov;
+  const camera = new THREE.PerspectiveCamera(cameraFov, 1, CAM.near, CAM.far);
+  // Portrait view should sit in front of the local avatar instead of from behind.
+  const cameraSeatAngle = isPortrait ? -Math.PI / 2 : Math.PI / 2;
   const cameraBackOffset = cameraTuning.backOffset;
   const cameraForwardOffset = cameraTuning.forwardOffset;
   const cameraHeightOffset = cameraTuning.heightOffset + CAMERA_EXTRA_LIFT;


### PR DESCRIPTION
### Motivation
- Players on portrait phones reported the camera sitting behind the avatar head and the field-of-view feeling too narrow for table-focused gameplay.
- The change aims to move the portrait camera in front of the local avatar and provide a wider, closer framing so the table fills more of the screen.

### Description
- Added a dedicated portrait FOV constant `PORTRAIT_CAMERA_FOV = 62` and use it when `isPortrait` so the view is wider on phones (`webapp/src/components/SnakeBoard3D.jsx`).
- Increased portrait `forwardOffset` to `0.82` to pull the camera inward for tighter table framing in portrait mode.
- Spawned the portrait camera from the front side by switching the seat angle to `-Math.PI / 2` when `isPortrait`, so the camera sits in front of the local avatar instead of behind.

### Testing
- Ran the production build: `npm run build` inside `webapp/`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecf54e78e08329be0d8d4161e3f9e8)