### PR TITLE
Adjust Ludo Battle Royal portrait camera framing and widen FOV

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1771,7 +1771,7 @@ const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 4.55;
 const SEATED_HUMAN_SEAT_Y_OFFSET = -5.85 * MODEL_SCALE * STOOL_SCALE;
 // Shift humans farther back on the chair so they appear more outward from the table in portrait gameplay.
 const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.42;
-const SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET = -SEAT_DEPTH * 0.2;
+const SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET = -SEAT_DEPTH * 0.05;
 const SEATED_HUMAN_FACING_Y = 0;
 // Keep feet lower to preserve the deeper seat grounding after the stronger vertical drop.
 const SEATED_HUMAN_FOOT_GROUND_CLEARANCE = -1.55 * MODEL_SCALE * STOOL_SCALE;
@@ -1836,6 +1836,7 @@ const CAMERA_FOV = ARENA_CAMERA_DEFAULTS.fov;
 const CAMERA_NEAR = ARENA_CAMERA_DEFAULTS.near;
 const CAMERA_FAR = ARENA_CAMERA_DEFAULTS.far;
 const CAMERA_DOLLY_FACTOR = ARENA_CAMERA_DEFAULTS.wheelDeltaFactor;
+const CAMERA_FOV_PORTRAIT = 58;
 const CAMERA_TARGET_LIFT = 0.028 * MODEL_SCALE;
 const CAMERA_SIDE_LOOK_EXTRA = 0.21;
 const CAMERA_TURN_PLAYER_LERP = 0.58;
@@ -1863,11 +1864,11 @@ const LUDO_CAMERA_PHI_MAX = 1.22;
 const PLAYER_VIEW_SEAT_THETA = Math.PI / 2;
 const PLAYER_VIEW_CAMERA_BACK_OFFSET_PORTRAIT = 1.62;
 const PLAYER_VIEW_CAMERA_BACK_OFFSET_LANDSCAPE = 1.26;
-const PLAYER_VIEW_CAMERA_FORWARD_OFFSET_PORTRAIT = 1.26;
+const PLAYER_VIEW_CAMERA_FORWARD_OFFSET_PORTRAIT = 1.48;
 const PLAYER_VIEW_CAMERA_FORWARD_OFFSET_LANDSCAPE = 0.86;
 const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_PORTRAIT = 0.62;
 const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_LANDSCAPE = 0.72;
-const PLAYER_VIEW_FIRST_PERSON_EYE_FORWARD_PORTRAIT = 0.32 * MODEL_SCALE;
+const PLAYER_VIEW_FIRST_PERSON_EYE_FORWARD_PORTRAIT = 0.48 * MODEL_SCALE;
 const PLAYER_VIEW_FIRST_PERSON_EYE_FORWARD_LANDSCAPE = 0.12 * MODEL_SCALE;
 const PLAYER_VIEW_LOOK_TARGET_FORWARD_BIAS = -0.02 * 3.22 * ARENA_SCALE;
 const LANDSCAPE_CAMERA_TUNING = Object.freeze({
@@ -6712,9 +6713,10 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       rimLight.position.set(-2.4, 5.4, -4.8);
       scene.add(rimLight);
 
-      camera = new THREE.PerspectiveCamera(CAM.fov, 1, CAM.near, CAM.far);
-      cameraRef.current = camera;
       const isPortrait = host.clientHeight > host.clientWidth;
+      const initialFov = isPortrait ? CAMERA_FOV_PORTRAIT : CAM.fov;
+      camera = new THREE.PerspectiveCamera(initialFov, 1, CAM.near, CAM.far);
+      cameraRef.current = camera;
       const cameraSeatAngle = PLAYER_VIEW_SEAT_THETA;
       const cameraBackOffset = isPortrait ? PORTRAIT_CAMERA_TUNING.backOffset : LANDSCAPE_CAMERA_TUNING.backOffset;
       const cameraForwardOffset = isPortrait ? PORTRAIT_CAMERA_TUNING.forwardOffset : LANDSCAPE_CAMERA_TUNING.forwardOffset;


### PR DESCRIPTION
### Motivation
- Portrait players reported the camera sitting too far back (showing the back of the local avatar's head) and having a narrow view of the board, so the portrait camera needs to move visually closer to the table and present a wider field of view.

### Description
- Added a portrait-specific FOV constant `CAMERA_FOV_PORTRAIT = 58` and use it when creating the `THREE.PerspectiveCamera` for portrait view. 
- Increased forward camera offsets for portrait by updating `PLAYER_VIEW_CAMERA_FORWARD_OFFSET_PORTRAIT` to `1.48` and `PLAYER_VIEW_FIRST_PERSON_EYE_FORWARD_PORTRAIT` to `0.48 * MODEL_SCALE` so the camera sits visually more in front of the player. 
- Reduced the local-player backward offset `SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET` from `-SEAT_DEPTH * 0.2` to `-SEAT_DEPTH * 0.05` to avoid the avatar blocking the table. 
- Changes applied in `webapp/src/pages/Games/LudoBattleRoyal.jsx` and the new portrait FOV is applied at camera creation.

### Testing
- Ran `npm run -s build` and the build completed successfully. 
- Ran `npx eslint webapp/src/pages/Games/LudoBattleRoyal.jsx` which produced a lint warning only because the file is ignored by the repo eslint ignore pattern, not a hard error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecf54e78e08329be0d8d4161e3f9e8)