### PR TITLE
Prefer board look target for Ludo seat camera while preserving position

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -4383,11 +4383,11 @@ function resolveSeatedFaceCameraPose(actorEntry, fallbackTarget = null) {
   const target = new THREE.Vector3();
   faceHelper.updateMatrixWorld?.(true);
   faceHelper.getWorldPosition(position);
-  if (actorEntry?.rig?.head?.isBone) {
+  if (fallbackTarget?.isVector3) {
+    target.copy(fallbackTarget);
+  } else if (actorEntry?.rig?.head?.isBone) {
     actorEntry.rig.head.updateMatrixWorld?.(true);
     actorEntry.rig.head.getWorldPosition(target);
-  } else if (fallbackTarget?.isVector3) {
-    target.copy(fallbackTarget);
   } else {
     target.copy(position).add(new THREE.Vector3(0, -0.005, 0.08 * MODEL_SCALE));
   }


### PR DESCRIPTION
### Motivation
- Ensure the seated-player camera keeps its existing position but looks toward the table/board so portrait framing keeps the table in view rather than the avatar head.

### Description
- Updated `resolveSeatedFaceCameraPose` in `webapp/src/pages/Games/LudoBattleRoyal.jsx` to prioritize the provided `fallbackTarget` (board/table look target) for the camera target when available.
- The change preserves the computed camera `position` while switching `target` selection order so the view direction points at the board when `fallbackTarget` is supplied.
- No other camera pipelines were changed; `applyBottomSeatFaceCameraView` and OrbitControls usage remain unchanged.

### Testing
- Ran `npm run -s test -- test/lobbyUtils.test.js` and the suite passed (6 tests, all green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecfed3e4ac8329b73c26690f60f9aa)