### PR TITLE
Ensure Chess Battle Royal always starts in 3D camera mode

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -9526,7 +9526,11 @@ function Chess3D({
     };
 
     cameraViewRef.current = { setMode: setViewModeInternal };
-    setViewModeInternal(viewModeRef.current);
+    // Always start every new match in cinematic 3D mode before any user toggle.
+    restoreAutoViewTo2dRef.current = false;
+    viewModeRef.current = '3d';
+    setViewMode('3d');
+    setViewModeInternal('3d');
 
     const fit = () => {
       const w = host.clientWidth;


### PR DESCRIPTION
### Motivation
- Ensure every new Chess Battle Royal match launches with the cinematic 3D camera rather than restoring a previous 2D/FPV view.

### Description
- Updated camera bootstrap in `webapp/src/pages/Games/ChessBattleRoyal.jsx` to reset `restoreAutoViewTo2dRef.current = false`, set `viewModeRef.current = '3d'`, and call `setViewMode('3d')` and `setViewModeInternal('3d')` during initialization so the scene always begins in 3D.

### Testing
- Ran `npm --prefix webapp run build`, which completed successfully; Vite emitted non-blocking warnings about chunk sizes and a duplicate `package.json` key but the production build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed013281b8832985fff8cbc43604a8)