### PR TITLE
Align Snake & Ladder seated human orientation with Ludo Battle Royal

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -81,14 +81,15 @@ const CHAIR_MODEL_URLS = [
 ];
 const HUMAN_MODEL_URL = 'https://threejs.org/examples/models/gltf/readyplayer.me.glb';
 const HUMAN_MODEL_CACHE = { promise: null, template: null };
-// Keep Snake seated humans aligned with Ludo/Chess Battle Royal chair anchoring and 7am scale baseline.
+// Keep Snake seated humans aligned with Ludo Battle Royal chair anchoring, pose depth, and portrait framing.
 const SEATED_HUMAN_BASE_HEIGHT = 1.74;
 const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.42;
-const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 2.0;
-const SEATED_HUMAN_SEAT_Y_OFFSET = -1.55 * MODEL_SCALE * STOOL_SCALE;
-const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.2;
+const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 4.55;
+const SEATED_HUMAN_SEAT_Y_OFFSET = -5.85 * MODEL_SCALE * STOOL_SCALE;
+const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.42;
+const SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET = -SEAT_DEPTH * 0.2;
 const SEATED_HUMAN_FACING_Y = 0;
-const SEATED_HUMAN_FOOT_GROUND_Y = -0.76 * MODEL_SCALE * STOOL_SCALE;
+const SEATED_HUMAN_FOOT_GROUND_Y = -1.55 * MODEL_SCALE * STOOL_SCALE;
 const HUMAN_FRONT_SIDE_Z = 1;
 const HUMAN_LEG_FRONT_OFFSET = 0;
 const SNAKE_TOKEN_MODEL_URLS = [
@@ -1674,7 +1675,7 @@ function applySeatedHumanPose(seatHuman, timeSeconds = 0, activeLean = 0) {
   const breathe = Math.sin(timeSeconds * 1.05) * 0.012;
   const dynamicLean = activeLean * 0.04;
   moveHumanLegRootsToFront(bones, rest, HUMAN_LEG_FRONT_OFFSET);
-  offsetModelBone(rest, bones.hips, 0, -0.345, -0.078);
+  offsetModelBone(rest, bones.hips, 0, -0.62, -0.078);
 
   composeModelBone(
     rest,
@@ -1682,17 +1683,17 @@ function applySeatedHumanPose(seatHuman, timeSeconds = 0, activeLean = 0) {
     new THREE.Euler(-0.16 - dynamicLean * 0.4, 0, 0, 'XYZ')
   );
   composeModelBone(rest, bones.spine, new THREE.Euler(0.26 + breathe - dynamicLean * 0.2, 0, 0, 'XYZ'));
-  composeModelBone(rest, bones.spine1, new THREE.Euler(0.28, 0, 0, 'XYZ'));
+  composeModelBone(rest, bones.spine1, new THREE.Euler(0.16, 0, 0, 'XYZ'));
   composeModelBone(rest, bones.spine2, new THREE.Euler(0, 0, 0, 'XYZ'));
   composeModelBone(rest, bones.neck, new THREE.Euler(-0.04, 0, 0, 'XYZ'));
   composeModelBone(rest, bones.head, new THREE.Euler(-0.06, 0, 0, 'XYZ'));
 
-  composeModelBone(rest, bones.leftUpLeg, new THREE.Euler(-1.32, 0.16, 0.05, 'XYZ'));
-  composeModelBone(rest, bones.rightUpLeg, new THREE.Euler(-1.32, 0.03, -0.02, 'XYZ'));
-  composeModelBone(rest, bones.leftLeg, new THREE.Euler(-1.28, 0.02, 0.01, 'XYZ'));
-  composeModelBone(rest, bones.rightLeg, new THREE.Euler(-1.28, -0.02, -0.01, 'XYZ'));
-  composeModelBone(rest, bones.leftFoot, new THREE.Euler(0.16, 0.03, 0.02, 'XYZ'));
-  composeModelBone(rest, bones.rightFoot, new THREE.Euler(0.16, -0.02, -0.01, 'XYZ'));
+  composeModelBone(rest, bones.leftUpLeg, new THREE.Euler(-1.58, 0.16, 0.05, 'XYZ'));
+  composeModelBone(rest, bones.rightUpLeg, new THREE.Euler(-1.58, 0.03, -0.02, 'XYZ'));
+  composeModelBone(rest, bones.leftLeg, new THREE.Euler(-1.66, 0.02, 0.01, 'XYZ'));
+  composeModelBone(rest, bones.rightLeg, new THREE.Euler(-1.66, -0.02, -0.01, 'XYZ'));
+  composeModelBone(rest, bones.leftFoot, new THREE.Euler(0.26, 0.03, 0.02, 'XYZ'));
+  composeModelBone(rest, bones.rightFoot, new THREE.Euler(0.26, -0.02, -0.01, 'XYZ'));
 
   composeModelBone(rest, bones.leftArm, new THREE.Euler(-0.28, 0.12, 0.96, 'XYZ'));
   composeModelBone(rest, bones.rightArm, new THREE.Euler(-0.2, -0.02, -0.72, 'XYZ'));
@@ -3424,7 +3425,7 @@ function buildArena(scene, renderer, host, cameraRef, disposeHandlers, appearanc
     group.add(avatarAnchor);
 
     const humanAnchor = new THREE.Object3D();
-    humanAnchor.position.set(0, SEATED_HUMAN_SEAT_Y_OFFSET, SEATED_HUMAN_SEAT_Z_OFFSET);
+    humanAnchor.position.set(0, 0, 0);
     humanAnchor.rotation.set(0, SEATED_HUMAN_FACING_Y, 0);
     group.add(humanAnchor);
 
@@ -3459,6 +3460,9 @@ function buildArena(scene, renderer, host, cameraRef, disposeHandlers, appearanc
         const baseScale =
           (SEATED_HUMAN_TARGET_HEIGHT / Math.max(SEATED_HUMAN_BASE_HEIGHT, 0.01)) * SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER;
         instance.scale.setScalar(baseScale);
+        const seatZOffset = SEATED_HUMAN_SEAT_Z_OFFSET + (seatIndex === 0 ? SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET : 0);
+        instance.position.set(0, SEATED_HUMAN_SEAT_Y_OFFSET, seatZOffset);
+        instance.rotation.set(0, SEATED_HUMAN_FACING_Y, 0);
         chair.humanAnchor.add(instance);
         seatedHumans[seatIndex] = {
           root: instance,


### PR DESCRIPTION
### Motivation

- Make Snake & Ladder seated human actors visually identical to the Ludo Battle Royal seated characters so portrait/mobile framing and body orientation match across games.
- Ensure the seated silhouette, limb orientation and seat depth behave the same (local player pushback for bottom seat included).

### Description

- Updated seated-human tuning constants in `webapp/src/components/SnakeBoard3D.jsx` including `SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER`, `SEATED_HUMAN_SEAT_Y_OFFSET`, `SEATED_HUMAN_SEAT_Z_OFFSET`, `SEATED_HUMAN_FOOT_GROUND_Y` and added `SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET` to match Ludo baselines.
- Modified `applySeatedHumanPose` to match Ludo idle pose mappings by adjusting hip offset, `spine1` rotation and the thigh/calf/foot Euler angles so hips/spine/legs/feet match Ludo layout.
- Changed actor placement so `humanAnchor` is neutral at creation and each human instance gets per-seat `position`/`rotation` (including the seat-0 extra rear offset) when attaching the cloned skeleton.

### Testing

- Ran the production build with `npm -C webapp run build` and the build completed successfully (Vite reported only existing chunking and package.json duplicate-key warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed10e69e60832983f0f34ac063b75b)