### PR TITLE
Pool Royale: release shot power at actual cue-ball contact

### DIFF
--- a/test/poolRoyaleCueStrokeTimeline.test.js
+++ b/test/poolRoyaleCueStrokeTimeline.test.js
@@ -13,16 +13,19 @@ describe('Pool Royale cue stroke timeline', () => {
     expect(sample.t).toBeCloseTo(0.2, 2);
   });
 
-  it('arms impact during the dedicated strike window before hold begins', () => {
+  it('arms impact only when strike reaches cue-ball contact', () => {
     const preStrike = sampleCueStrokeTimeline({ elapsed: 277, ...options });
     const strikeStart = sampleCueStrokeTimeline({ elapsed: 278, ...options });
-    const armedStrike = sampleCueStrokeTimeline({ elapsed: 282, ...options });
+    const nearContact = sampleCueStrokeTimeline({ elapsed: 299, ...options });
+    const atContact = sampleCueStrokeTimeline({ elapsed: 300, ...options });
     expect(preStrike.phase).toBe('release');
     expect(preStrike.hitArmed).toBe(false);
     expect(strikeStart.phase).toBe('strike');
     expect(strikeStart.hitArmed).toBe(false);
-    expect(armedStrike.phase).toBe('strike');
-    expect(armedStrike.hitArmed).toBe(true);
+    expect(nearContact.phase).toBe('strike');
+    expect(nearContact.hitArmed).toBe(false);
+    expect(atContact.phase).toBe('strike');
+    expect(atContact.hitArmed).toBe(true);
   });
 
   it('keeps spring release monotonic so cue does not snap backward mid-push', () => {

--- a/webapp/src/pages/Games/poolRoyaleCueStrokeTimeline.js
+++ b/webapp/src/pages/Games/poolRoyaleCueStrokeTimeline.js
@@ -60,10 +60,14 @@ export const sampleCueStrokeTimeline = ({
       }
     }
     const strikeT = THREE.MathUtils.clamp((baseT - strikeStartT) / Math.max(strikeShare, 1e-6), 0, 1)
+    const cueAtContact = strikeT >= 0.999
     return {
       phase: 'strike',
       t: Math.max(styleT, strikeT),
-      hitArmed: baseT >= hitT,
+      // Fire physics only when the cue has fully reached cue-ball contact.
+      // Slider power still controls pull amount + strike speed, but release
+      // should happen from cue impact, not early in the forward motion.
+      hitArmed: cueAtContact && baseT >= hitT,
       done: false
     }
   }


### PR DESCRIPTION
### Motivation
- Make the in-game shooting behavior match a real cue: the slider only sets pull/power while the cue stick itself must reach the cue ball to release the shot, preventing early physics launches during forward travel.

### Description
- Modified `sampleCueStrokeTimeline` so `hitArmed` becomes true only when the strike has actually reached cue-ball contact (introduces a `cueAtContact` check based on `strikeT`).
- Kept animation/easing behavior intact while gating physics release to the contact moment so slider semantics remain pull/power-only.
- Updated the timeline unit test `test/poolRoyaleCueStrokeTimeline.test.js` to assert that near-contact frames remain unarmed and that the contact frame arms impact.
- Files changed: `webapp/src/pages/Games/poolRoyaleCueStrokeTimeline.js` and `test/poolRoyaleCueStrokeTimeline.test.js`.

### Testing
- Ran the timeline unit tests with `npm test -- test/poolRoyaleCueStrokeTimeline.test.js --runInBand` and the suite passed (4 tests passing).
- The updated test validates the new gating behavior and succeeded without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed11e4f2308329860e0b45d0256681)