### PR TITLE
Release shot when cue-stick returns to contact (pull slider now only controls pull)

### DIFF
--- a/Assets/Scripts/Gameplay/CueController.cs
+++ b/Assets/Scripts/Gameplay/CueController.cs
@@ -65,7 +65,6 @@ namespace Aiming
         float _currentCueDepth;
         float _chargedCueDepth;
         float _power;
-        float _maxPowerDuringCharge;
         float _latchedShotPower;
         Vector2 _liveSpinInput;
         Vector2 _latchedShotSpin;
@@ -117,9 +116,7 @@ namespace Aiming
 
             if (_shotState == ShotState.Dragging)
             {
-                _maxPowerDuringCharge = Mathf.Max(_maxPowerDuringCharge, _power);
-                float effectivePower = Mathf.Max(_power, _maxPowerDuringCharge);
-                float pull = pullRange * EaseOutCubic(effectivePower);
+                float pull = pullRange * EaseOutCubic(_power);
                 _chargedCueDepth = idleTipGap + pull;
                 _currentCueDepth = _chargedCueDepth;
                 UpdateCuePose();
@@ -137,7 +134,6 @@ namespace Aiming
             _latchedShotSpin = _liveSpinInput;
             _shotState = ShotState.Dragging;
             _power = Mathf.Max(_power, RecoverPowerFromCueDepth(_currentCueDepth));
-            _maxPowerDuringCharge = _power;
             _latchedShotPower = 0f;
             _chargedCueDepth = idleTipGap + (pullRange * EaseOutCubic(_power));
             _currentCueDepth = _chargedCueDepth;
@@ -162,7 +158,6 @@ namespace Aiming
 
             _shotState = ShotState.Idle;
             _power = 0f;
-            _maxPowerDuringCharge = 0f;
             _latchedShotPower = 0f;
             _latchedShotSpin = _liveSpinInput;
             _chargedCueDepth = idleTipGap;
@@ -181,11 +176,10 @@ namespace Aiming
             }
 
             float recoveredPower = RecoverPowerFromCueDepth(_chargedCueDepth);
-            _latchedShotPower = ResolveReleasedShotPower(_power, recoveredPower, _maxPowerDuringCharge);
+            _latchedShotPower = ResolveReleasedShotPower(_power, recoveredPower);
             if (_latchedShotPower <= 0f)
             {
                 _shotState = ShotState.Idle;
-                _maxPowerDuringCharge = 0f;
                 _chargedCueDepth = idleTipGap;
                 _currentCueDepth = idleTipGap;
                 _dynamicLift = 0f;
@@ -273,11 +267,22 @@ namespace Aiming
             float follow = Mathf.Min(0.018f, topspin * 0.018f);
             float dynamicFollow = follow * (0.55f + (0.45f * Mathf.Sin(t * Mathf.PI)));
 
+            float pulledDepth = Mathf.Max(idleTipGap, _chargedCueDepth);
+            float releaseTargetDepth = idleTipGap;
+            float contactDepth = Mathf.Min(contactTipGap - dynamicFollow, releaseTargetDepth);
+
             _dynamicLift = -0.0035f * strikeEase;
             _dynamicWobble = Mathf.Sin(t * Mathf.PI) * 0.0014f;
-            _currentCueDepth = Mathf.Lerp(idleTipGap + pull, contactTipGap - dynamicFollow, strikeEase);
+            _currentCueDepth = Mathf.Lerp(pulledDepth, releaseTargetDepth, strikeEase);
 
-            if (!_didStrike && t > hitT)
+            if (!_didStrike && _currentCueDepth <= contactDepth)
+            {
+                _didStrike = true;
+                SquashTip();
+                ApplyStrikeImpulse(_strikeDirection, _latchedShotPower);
+            }
+
+            if (!_didStrike && t >= hitT)
             {
                 _didStrike = true;
                 SquashTip();
@@ -401,7 +406,6 @@ namespace Aiming
             _didStrike = false;
             _shotState = ShotState.Idle;
             _power = 0f;
-            _maxPowerDuringCharge = 0f;
             _latchedShotPower = 0f;
             _latchedShotSpin = _liveSpinInput;
             _chargedCueDepth = idleTipGap;
@@ -411,9 +415,9 @@ namespace Aiming
             ResetTipScale();
         }
 
-        float ResolveReleasedShotPower(float sliderPower, float recoveredPower, float maxChargePower)
+        float ResolveReleasedShotPower(float sliderPower, float recoveredPower)
         {
-            float raw = Mathf.Clamp01(Mathf.Max(Mathf.Max(sliderPower, recoveredPower), maxChargePower));
+            float raw = Mathf.Clamp01(Mathf.Max(sliderPower, recoveredPower));
             if (raw <= 0f)
             {
                 return 0f;


### PR DESCRIPTION
### Motivation
- Align cue stroke with real-life behavior so the slider only determines how far the cue-stick is pulled and the stick returning to contact is what delivers power to the cue-ball. 
- Remove peak-latching of charge so the cuestick motion, not a separate latched value, dictates shot release and timing.

### Description
- Modified `Assets/Scripts/Gameplay/CueController.cs` to remove the `_maxPowerDuringCharge` peak-latch and make `SetChargePower`/`BeginCharge` use `_power` directly for pull distance. 
- Simplified power resolution by changing `ResolveReleasedShotPower` to accept only the slider and recovered pull (`sliderPower, recoveredPower`).
- Reworked strike-phase motion so the cue now interpolates from the pulled depth back toward `idleTipGap` and fires the impulse when the cue-tip reaches contact depth (with the existing `hitProgress` fallback). 
- Kept existing safety/defaults (`minimumShotPowerNormalized`, contact fallback) and maintained camera sync code path to reflect the new stroke motion.

### Testing
- Ran `git diff --check -- Assets/Scripts/Gameplay/CueController.cs` which produced no whitespace/merge problems and passed locally. 
- Attempted to query the Unity editor via `Unity -version` but the Unity executable is not available in this environment, so PlayMode/runtime physics tests could not be executed here. 
- No automated PlayMode/unit tests were executed in this environment; runtime validation should be run in CI or a local Unity editor to verify strike timing and feel.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed11e4f2308329860e0b45d0256681)