### PR TITLE
Align Snake seated-human placement with Ludo Battle Royal baseline

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -87,6 +87,9 @@ const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.42;
 const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 4.55;
 const SEATED_HUMAN_SEAT_Y_OFFSET = -5.85 * MODEL_SCALE * STOOL_SCALE;
 const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.42;
+// Mirror Ludo Battle Royal's deeper bottom-seat pushback so the local player sits
+// with the same portrait-facing posture/orientation while preserving Snake table scale.
+const SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET = -SEAT_DEPTH * 0.2;
 const SEATED_HUMAN_FACING_Y = 0;
 const SEATED_HUMAN_FOOT_GROUND_Y = -1.55 * MODEL_SCALE * STOOL_SCALE;
 const HUMAN_FRONT_SIDE_Z = 1;
@@ -3424,7 +3427,8 @@ function buildArena(scene, renderer, host, cameraRef, disposeHandlers, appearanc
     group.add(avatarAnchor);
 
     const humanAnchor = new THREE.Object3D();
-    humanAnchor.position.set(0, SEATED_HUMAN_SEAT_Y_OFFSET, SEATED_HUMAN_SEAT_Z_OFFSET);
+    const humanSeatZOffset = SEATED_HUMAN_SEAT_Z_OFFSET + (i === 0 ? SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET : 0);
+    humanAnchor.position.set(0, SEATED_HUMAN_SEAT_Y_OFFSET, humanSeatZOffset);
     humanAnchor.rotation.set(0, SEATED_HUMAN_FACING_Y, 0);
     group.add(humanAnchor);
 


### PR DESCRIPTION
### Motivation
- Ensure Snake & Ladder seated human characters match the layout, position and portrait-facing posture used by the Ludo Battle Royal seating so the local player reads and orients identically across games.

### Description
- Added `SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET` and applied it when creating human anchors so seat `0` (local/bottom) receives the same rear Z pushback used by Ludo while preserving Snake table/chair scale in `webapp/src/components/SnakeBoard3D.jsx`.
- Updated the human anchor positioning to use `humanSeatZOffset = SEATED_HUMAN_SEAT_Z_OFFSET + (i === 0 ? SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET : 0)` during chair setup.

### Testing
- Ran `cd webapp && npm run build` and the production build completed successfully.
- Build emitted existing, non-blocking warnings (duplicate dependency key in `webapp/package.json` and Vite chunk-size/dynamic-import notices) but finished without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed1aa0ddf48329ab2aebe0f3c3dff3)