### PR TITLE
Improve seated human animations and IK; refine dice/token timing and easing

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -1774,8 +1774,25 @@ const SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET = -SEAT_DEPTH * 0.2;
 const SEATED_HUMAN_FACING_Y = 0;
 // Keep feet lower to preserve the deeper seat grounding after the stronger vertical drop.
 const SEATED_HUMAN_FOOT_GROUND_CLEARANCE = -1.55 * MODEL_SCALE * STOOL_SCALE;
-const SEATED_HUMAN_ROLL_MS = 1680;
-const SEATED_HUMAN_RECOVER_MS = 420;
+const SEATED_HUMAN_DICE_PHASES = Object.freeze({
+  reachMs: 280,
+  gripMs: 220,
+  holdMs: 180,
+  windupMs: 180,
+  releaseMs: 210,
+  followMs: 520
+});
+const SEATED_HUMAN_TOKEN_PHASES = Object.freeze({
+  pickupMs: 180,
+  gripMs: 140,
+  carryMs: 240,
+  placeMs: 200
+});
+const SEATED_HUMAN_MOTION_TUNING = Object.freeze({
+  idleBreathAmp: 0.012,
+  throwPrecision: 1.08,
+  tokenPrecision: 1.14
+});
 const SEATED_HELPER_FORWARD_DICE_PICKUP = 0.066 * MODEL_SCALE;
 const SEATED_HELPER_FORWARD_DICE_RELEASE = 0.124 * MODEL_SCALE;
 const SEATED_HELPER_RIGHT_DICE = -0.023 * MODEL_SCALE;
@@ -1790,6 +1807,8 @@ const SEATED_HELPER_FACE_CAMERA_RIGHT = 0;
 const SEATED_HELPER_FACE_CAMERA_UP = 0.016 * MODEL_SCALE;
 // Move camera anchor to the face-front side so the local player's head stays out of portrait framing.
 const SEATED_HELPER_FACE_CAMERA_FORWARD = -0.14 * MODEL_SCALE;
+const SEATED_CONTACT_IK_ITERATIONS = 4;
+const SEATED_CONTACT_IK_MAX_STEP_RAD = 0.22;
 let seatedHumanTemplatePromise = null;
 const TARGET_CHAIR_SIZE = new THREE.Vector3(1.3162499970197679, 1.9173749900311232, 1.7001562547683715).multiplyScalar(
   CHAIR_SIZE_SCALE
@@ -4058,6 +4077,26 @@ function smooth01(v) {
   return t * t * (3 - 2 * t);
 }
 
+function smoother01(v) {
+  const t = clamp(v, 0, 1);
+  return t * t * t * (t * (t * 6 - 15) + 10);
+}
+
+function easeInOutSine01(v) {
+  const t = clamp(v, 0, 1);
+  return 0.5 - Math.cos(Math.PI * t) * 0.5;
+}
+
+function easeOutBack01(v, overshoot = 1.6) {
+  const t = clamp(v, 0, 1) - 1;
+  return 1 + (overshoot + 1) * t * t * t + overshoot * t * t;
+}
+
+function normalizedPhase(nowMs, startMs, durationMs) {
+  const safeDuration = Math.max(1, durationMs || 0);
+  return clamp((nowMs - startMs) / safeDuration, 0, 1);
+}
+
 function curlFingerChain(rig, chain = [], amount = 0, sideSpread = 0) {
   const grip = clamp(amount, 0, 1);
   chain.forEach((bone, index) => {
@@ -4128,11 +4167,12 @@ function moveLegRootsToFront(rig, amount = LEG_FRONT_OFFSET_MIXAMO) {
   addBonePos(rig, rig.rightUpperLeg, 0, 0, FRONT_SIDE_Z * amount, 1);
 }
 
-function applySeatedHumanPose(rig, mode = 'idle', intensity = 1, handGrip = 0, throwBias = {}) {
+function applySeatedHumanPose(rig, mode = 'idle', intensity = 1, handGrip = 0, throwBias = {}, motionTuning = {}) {
   if (!rig) return;
   resetBoneRig(rig);
-  const t = smooth01(intensity);
-  const breathe = Math.sin(performance.now() * 0.002) * 0.012;
+  const t = smoother01(intensity);
+  const breathe = Math.sin(performance.now() * 0.002) * (motionTuning.idleBreathAmp ?? SEATED_HUMAN_MOTION_TUNING.idleBreathAmp);
+  const precision = clamp(motionTuning?.precision ?? 1, 0.8, 1.35);
   const throwLateral = clamp(throwBias?.lateral ?? 0, -1, 1);
   const throwForward = clamp(throwBias?.forward ?? 1, -1, 1);
 
@@ -4220,10 +4260,10 @@ function applySeatedHumanPose(rig, mode = 'idle', intensity = 1, handGrip = 0, t
     chestX = THREE.MathUtils.lerp(chestX, 0.02, t);
     chestY = THREE.MathUtils.lerp(chestY, -0.06, t);
     headX = THREE.MathUtils.lerp(headX, -0.02, t);
-    shoulderY += throwLateral * 0.24 * t;
-    forearmY += throwLateral * 0.14 * t;
-    wristY += throwLateral * 0.08 * t;
-    shoulderZ += (1 - throwForward) * 0.14 * t;
+    shoulderY += throwLateral * 0.24 * t * precision;
+    forearmY += throwLateral * 0.14 * t * precision;
+    wristY += throwLateral * 0.08 * t * precision;
+    shoulderZ += (1 - throwForward) * 0.14 * t * precision;
   } else if (mode === 'release') {
     shoulderX = THREE.MathUtils.lerp(shoulderX, -1.18, t);
     shoulderY = THREE.MathUtils.lerp(shoulderY, -0.14, t);
@@ -4237,10 +4277,10 @@ function applySeatedHumanPose(rig, mode = 'idle', intensity = 1, handGrip = 0, t
     chestX = THREE.MathUtils.lerp(chestX, 0.20, t);
     chestY = THREE.MathUtils.lerp(chestY, 0.04, t);
     headX = THREE.MathUtils.lerp(headX, 0.04, t);
-    shoulderY += throwLateral * 0.34 * t;
-    forearmY += throwLateral * 0.24 * t;
-    wristY += throwLateral * 0.2 * t;
-    shoulderZ += (1 - throwForward) * 0.2 * t;
+    shoulderY += throwLateral * 0.34 * t * precision;
+    forearmY += throwLateral * 0.24 * t * precision;
+    wristY += throwLateral * 0.2 * t * precision;
+    shoulderZ += (1 - throwForward) * 0.2 * t * precision;
   } else if (mode === 'followThrough') {
     shoulderX = THREE.MathUtils.lerp(shoulderX, -0.86, t);
     shoulderY = THREE.MathUtils.lerp(shoulderY, -0.12, t);
@@ -4251,10 +4291,12 @@ function applySeatedHumanPose(rig, mode = 'idle', intensity = 1, handGrip = 0, t
     wristX = THREE.MathUtils.lerp(wristX, 0.22, t);
     wristZ = THREE.MathUtils.lerp(wristZ, -0.08, t);
     chestX = THREE.MathUtils.lerp(chestX, 0.15, t);
-    shoulderY += throwLateral * 0.24 * t;
-    forearmY += throwLateral * 0.14 * t;
-    wristY += throwLateral * 0.1 * t;
+    shoulderY += throwLateral * 0.24 * t * precision;
+    forearmY += throwLateral * 0.14 * t * precision;
+    wristY += throwLateral * 0.1 * t * precision;
   } else if (mode === 'reachToken') {
+    addBonePos(rig, rig.hips, 0, 0, -0.03 * t, 1);
+    addBoneRot(rig, rig.spine, 0.08 * t, 0, 0, 1);
     shoulderX = THREE.MathUtils.lerp(shoulderX, -0.84, t);
     shoulderY = THREE.MathUtils.lerp(shoulderY, 0.04, t);
     shoulderZ = THREE.MathUtils.lerp(shoulderZ, -1.02, t);
@@ -4267,6 +4309,8 @@ function applySeatedHumanPose(rig, mode = 'idle', intensity = 1, handGrip = 0, t
     chestX = THREE.MathUtils.lerp(chestX, 0.24, t);
     headX = THREE.MathUtils.lerp(headX, 0.08, t);
   } else if (mode === 'gripToken') {
+    addBonePos(rig, rig.hips, 0, 0, -0.036 * t, 1);
+    addBoneRot(rig, rig.spine, 0.1 * t, 0, 0, 1);
     shoulderX = THREE.MathUtils.lerp(shoulderX, -0.9, t);
     shoulderY = THREE.MathUtils.lerp(shoulderY, 0.02, t);
     shoulderZ = THREE.MathUtils.lerp(shoulderZ, -1.00, t);
@@ -4279,6 +4323,8 @@ function applySeatedHumanPose(rig, mode = 'idle', intensity = 1, handGrip = 0, t
     chestX = THREE.MathUtils.lerp(chestX, 0.23, t);
     headX = THREE.MathUtils.lerp(headX, 0.08, t);
   } else if (mode === 'carryToken') {
+    addBonePos(rig, rig.hips, 0, 0, -0.022 * t, 1);
+    addBoneRot(rig, rig.spine, 0.08 * t, 0, 0, 1);
     shoulderX = THREE.MathUtils.lerp(shoulderX, -0.94, t);
     shoulderY = THREE.MathUtils.lerp(shoulderY, -0.04, t);
     shoulderZ = THREE.MathUtils.lerp(shoulderZ, -1.08, t);
@@ -4291,6 +4337,8 @@ function applySeatedHumanPose(rig, mode = 'idle', intensity = 1, handGrip = 0, t
     chestX = THREE.MathUtils.lerp(chestX, 0.18, t);
     headX = THREE.MathUtils.lerp(headX, 0.08, t);
   } else if (mode === 'placeToken') {
+    addBonePos(rig, rig.hips, 0, 0, -0.04 * t, 1);
+    addBoneRot(rig, rig.spine, 0.12 * t, 0, 0, 1);
     shoulderX = THREE.MathUtils.lerp(shoulderX, -0.82, t);
     shoulderY = THREE.MathUtils.lerp(shoulderY, 0.02, t);
     shoulderZ = THREE.MathUtils.lerp(shoulderZ, -0.92, t);
@@ -4409,6 +4457,195 @@ function sampleSeatedActionHelper(entry, helperKey, out) {
   helper.updateMatrixWorld?.(true);
   helper.getWorldPosition(out);
   return true;
+}
+
+function applyWorldRotationDeltaToBone(bone, worldDeltaQ) {
+  if (!bone?.isBone || !worldDeltaQ?.isQuaternion) return;
+  const parentWorldQ = new THREE.Quaternion();
+  bone.parent?.getWorldQuaternion?.(parentWorldQ);
+  const parentWorldInv = parentWorldQ.clone().invert();
+  const localDeltaQ = parentWorldInv.multiply(worldDeltaQ).multiply(parentWorldQ);
+  bone.quaternion.premultiply(localDeltaQ);
+}
+
+function solveSeatedRightArmContactIK(entry, targetWorld, weight = 1) {
+  const rig = entry?.rig;
+  const actor = entry?.actor;
+  if (!rig || !actor?.isObject3D || !targetWorld?.isVector3) return;
+  const upper = rig.rightUpperArm;
+  const lower = rig.rightForeArm;
+  const hand = rig.rightHand;
+  if (!upper?.isBone || !lower?.isBone || !hand?.isBone) return;
+
+  const blend = clamp(weight, 0, 1);
+  if (blend <= 1e-4) return;
+  const shoulderPos = new THREE.Vector3();
+  const endPos = new THREE.Vector3();
+  const jointPos = new THREE.Vector3();
+  const toEnd = new THREE.Vector3();
+  const toTarget = new THREE.Vector3();
+  const axis = new THREE.Vector3();
+  const worldDeltaQ = new THREE.Quaternion();
+
+  const applyBoneStep = (bone) => {
+    bone.updateMatrixWorld?.(true);
+    hand.updateMatrixWorld?.(true);
+    bone.getWorldPosition(jointPos);
+    hand.getWorldPosition(endPos);
+    toEnd.copy(endPos).sub(jointPos);
+    toTarget.copy(targetWorld).sub(jointPos);
+    const endLen = toEnd.length();
+    const targetLen = toTarget.length();
+    if (endLen < 1e-6 || targetLen < 1e-6) return;
+    toEnd.multiplyScalar(1 / endLen);
+    toTarget.multiplyScalar(1 / targetLen);
+    const cosTheta = clamp(toEnd.dot(toTarget), -1, 1);
+    const angle = Math.acos(cosTheta);
+    if (!Number.isFinite(angle) || angle < 1e-5) return;
+    axis.crossVectors(toEnd, toTarget);
+    if (axis.lengthSq() < 1e-8) return;
+    axis.normalize();
+    const limited = Math.min(angle, SEATED_CONTACT_IK_MAX_STEP_RAD) * blend;
+    worldDeltaQ.setFromAxisAngle(axis, limited);
+    applyWorldRotationDeltaToBone(bone, worldDeltaQ);
+    bone.updateMatrixWorld?.(true);
+    hand.updateMatrixWorld?.(true);
+  };
+
+  actor.updateMatrixWorld(true);
+  upper.getWorldPosition(shoulderPos);
+  for (let i = 0; i < SEATED_CONTACT_IK_ITERATIONS; i += 1) {
+    applyBoneStep(lower);
+    applyBoneStep(upper);
+  }
+}
+
+function resolveSeatedHumanActionPose(actorState, gameState, playerIndex, nowMs) {
+  const basePose = {
+    mode: 'idle',
+    intensity: 1,
+    handGrip: 0,
+    motionTuning: {
+      idleBreathAmp: SEATED_HUMAN_MOTION_TUNING.idleBreathAmp,
+      precision: 1
+    }
+  };
+  if (!actorState) return basePose;
+
+  const throwingPlayer = actorState.throwPlayer;
+  if (throwingPlayer === playerIndex && Number.isFinite(actorState.throwStartMs) && actorState.throwStartMs > 0) {
+    const { windupMs, releaseMs, followMs } = SEATED_HUMAN_DICE_PHASES;
+    const windupStart = actorState.throwStartMs;
+    const releaseStart = windupStart + windupMs;
+    const followStart = releaseStart + releaseMs;
+    const endMs = followStart + followMs;
+
+    if (nowMs < releaseStart) {
+      return {
+        ...basePose,
+        mode: 'windUp',
+        intensity: easeInOutSine01(normalizedPhase(nowMs, windupStart, windupMs)),
+        handGrip: 0.56,
+        motionTuning: { idleBreathAmp: 0.008, precision: SEATED_HUMAN_MOTION_TUNING.throwPrecision }
+      };
+    }
+    if (nowMs < followStart) {
+      const phase = normalizedPhase(nowMs, releaseStart, releaseMs);
+      return {
+        ...basePose,
+        mode: 'release',
+        intensity: easeOutBack01(phase, 1.45),
+        handGrip: 1 - phase,
+        motionTuning: { idleBreathAmp: 0.006, precision: SEATED_HUMAN_MOTION_TUNING.throwPrecision }
+      };
+    }
+    if (nowMs < endMs) {
+      return {
+        ...basePose,
+        mode: 'followThrough',
+        intensity: 1 - normalizedPhase(nowMs, followStart, followMs),
+        handGrip: 0,
+        motionTuning: { idleBreathAmp: 0.01, precision: 1.04 }
+      };
+    }
+    return basePose;
+  }
+
+  const holdPlayer = actorState.holdPlayer;
+  if (holdPlayer === playerIndex && Number.isFinite(actorState.holdStartMs) && actorState.holdStartMs > 0) {
+    const { reachMs, gripMs } = SEATED_HUMAN_DICE_PHASES;
+    const reachEnd = actorState.holdStartMs + reachMs;
+    const gripEnd = reachEnd + gripMs;
+    if (nowMs < reachEnd) {
+      return {
+        ...basePose,
+        mode: 'reachDice',
+        intensity: easeInOutSine01(normalizedPhase(nowMs, actorState.holdStartMs, reachMs)),
+        handGrip: 0.04,
+        motionTuning: { idleBreathAmp: 0.01, precision: 1.05 }
+      };
+    }
+    if (nowMs < gripEnd) {
+      const phase = normalizedPhase(nowMs, reachEnd, gripMs);
+      return {
+        ...basePose,
+        mode: 'gripDice',
+        intensity: smoother01(phase),
+        handGrip: 0.28 + phase * 0.28,
+        motionTuning: { idleBreathAmp: 0.009, precision: 1.08 }
+      };
+    }
+    return {
+      ...basePose,
+      mode: 'holdDice',
+      intensity: 1,
+      handGrip: 0.56,
+      motionTuning: { idleBreathAmp: 0.008, precision: 1.08 }
+    };
+  }
+
+  const activeAnim = gameState?.animation;
+  if (activeAnim?.active && activeAnim.player === playerIndex) {
+    const seg = activeAnim.segments?.[activeAnim.segment];
+    const segProgress = seg ? normalizedPhase(activeAnim.elapsed, 0, seg.duration) : 1;
+    const helperPhase = seg?.viaHelper || null;
+    if (helperPhase === 'pickup') {
+      return {
+        ...basePose,
+        mode: 'reachToken',
+        intensity: easeInOutSine01(segProgress),
+        handGrip: 0.08,
+        motionTuning: { idleBreathAmp: 0.009, precision: SEATED_HUMAN_MOTION_TUNING.tokenPrecision }
+      };
+    }
+    if (activeAnim.segment > 0 && activeAnim.segments?.[activeAnim.segment - 1]?.viaHelper === 'pickup') {
+      return {
+        ...basePose,
+        mode: 'gripToken',
+        intensity: smoother01(segProgress),
+        handGrip: segProgress,
+        motionTuning: { idleBreathAmp: 0.009, precision: SEATED_HUMAN_MOTION_TUNING.tokenPrecision }
+      };
+    }
+    if (helperPhase === 'place' || activeAnim.segments?.[activeAnim.segment + 1]?.viaHelper === 'place') {
+      return {
+        ...basePose,
+        mode: 'placeToken',
+        intensity: easeInOutSine01(segProgress),
+        handGrip: 1 - segProgress * 0.86,
+        motionTuning: { idleBreathAmp: 0.01, precision: SEATED_HUMAN_MOTION_TUNING.tokenPrecision }
+      };
+    }
+    return {
+      ...basePose,
+      mode: 'carryToken',
+      intensity: 0.48 + segProgress * 0.52,
+      handGrip: 1,
+      motionTuning: { idleBreathAmp: 0.01, precision: 1.1 }
+    };
+  }
+
+  return basePose;
 }
 
 function applyBottomSeatFaceCameraView({
@@ -6072,10 +6309,10 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       if (state.cancelled) return;
       const now = performance.now();
       const t = Math.min(1, (now - started) / Math.max(1, duration));
-      const eased = easeOutCubic(t);
+      const eased = t < 0.82 ? easeInOutSine01(t / 0.82) * 0.92 : 0.92 + easeOutBack01((t - 0.82) / 0.18, 1.3) * 0.08;
       const pos = startPos.clone().lerp(target, eased);
       if (lift > 0) {
-        const arc = Math.sin(Math.PI * eased) * lift * (1 - eased * 0.35);
+        const arc = Math.sin(Math.PI * eased) * lift * (1 - eased * 0.25);
         pos.y = THREE.MathUtils.lerp(startPos.y, target.y, eased) + arc;
       }
       dice.position.copy(pos);
@@ -7221,6 +7458,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     const seatWorld = new THREE.Vector3();
     const seatNdc = new THREE.Vector3();
     const faceWorld = new THREE.Vector3();
+    const handContactTarget = new THREE.Vector3();
 
     const step = () => {
       const now = performance.now();
@@ -7301,102 +7539,56 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       }
 
       const actorState = seatedHumanActionRef.current;
-      const holdPlayer = actorState?.holdPlayer;
-      const throwingPlayer = actorState?.throwPlayer;
+      if (
+        actorState?.throwStartMs > 0 &&
+        now - actorState.throwStartMs >
+          SEATED_HUMAN_DICE_PHASES.windupMs +
+            SEATED_HUMAN_DICE_PHASES.releaseMs +
+            SEATED_HUMAN_DICE_PHASES.followMs +
+            40
+      ) {
+        actorState.throwPlayer = null;
+        actorState.throwStartMs = 0;
+      }
       const actors = seatedHumanActorsRef.current;
       if (Array.isArray(actors) && actors.length) {
         actors.forEach((entry) => {
           const { rig, playerIndex } = entry;
           if (!rig) return;
-          let mode = 'idle';
-          let intensity = 1;
-          let handGrip = 0;
+          const pose = resolveSeatedHumanActionPose(actorState, state, playerIndex, now);
           const throwBias = {
             lateral: actorState?.throwLateral ?? 0,
             forward: actorState?.throwForward ?? 1
           };
-
-          if (
-            Number.isFinite(actorState?.throwStartMs) &&
-            throwingPlayer === playerIndex &&
-            actorState.throwStartMs > 0
-          ) {
-            const elapsedSec = Math.max(0, (now - actorState.throwStartMs) / 1000);
-            if (elapsedSec < 0.18) {
-              mode = 'holdDice';
-              intensity = 1;
-              handGrip = 0.52;
-            } else if (elapsedSec < 0.38) {
-              mode = 'windUp';
-              intensity = clamp((elapsedSec - 0.18) / 0.2, 0, 1);
-              handGrip = 0.56;
-            } else if (elapsedSec < 0.66) {
-              mode = 'release';
-              intensity = clamp((elapsedSec - 0.38) / 0.28, 0, 1);
-              handGrip = 1 - intensity;
-            } else if (elapsedSec < 1.45) {
-              mode = 'followThrough';
-              intensity = 1;
-              handGrip = 0;
-            } else {
-              mode = 'idle';
-              intensity = 1;
-              handGrip = 0;
-            }
-            if (elapsedSec > 1.62) {
-              actorState.throwPlayer = null;
-            }
+          applySeatedHumanPose(
+            rig,
+            pose.mode,
+            pose.intensity,
+            pose.handGrip,
+            throwBias,
+            pose.motionTuning
+          );
+          let hasContactTarget = false;
+          const movingToken =
+            state?.animation?.active && state.animation.player === playerIndex
+              ? state.animation.token
+              : null;
+          if (movingToken?.isObject3D) {
+            movingToken.getWorldPosition(handContactTarget);
+            handContactTarget.y += 0.012;
+            hasContactTarget = true;
           } else if (
-            Number.isFinite(actorState?.holdStartMs) &&
-            holdPlayer === playerIndex &&
-            actorState.holdStartMs > 0
+            diceRef.current?.isObject3D &&
+            (actorState?.holdPlayer === playerIndex || actorState?.throwPlayer === playerIndex)
           ) {
-            const elapsedSec = Math.max(0, (now - actorState.holdStartMs) / 1000);
-            if (elapsedSec < 0.36) {
-              mode = 'reachDice';
-              intensity = clamp(elapsedSec / 0.36, 0, 1);
-              handGrip = 0.02;
-            } else if (elapsedSec < 0.68) {
-              mode = 'gripDice';
-              intensity = clamp((elapsedSec - 0.36) / 0.32, 0, 1);
-              handGrip = 0.42;
-            } else {
-              mode = 'holdDice';
-              intensity = 1;
-              handGrip = 0.52;
-            }
-          } else if (state?.animation?.active && state.animation.player === playerIndex) {
-            const anim = state.animation;
-            const seg = anim.segments?.[anim.segment];
-            const segProgress = seg ? clamp(anim.elapsed / Math.max(seg.duration, 1e-4), 0, 1) : 1;
-            const helperPhase = seg?.viaHelper || null;
-            if (helperPhase === 'pickup') {
-              mode = 'reachToken';
-              intensity = segProgress;
-              handGrip = 0.05;
-            } else if (anim.segment > 0 && anim.segments?.[anim.segment - 1]?.viaHelper === 'pickup') {
-              mode = 'gripToken';
-              intensity = segProgress;
-              handGrip = segProgress;
-            } else if (helperPhase === 'place' || anim.segments?.[anim.segment + 1]?.viaHelper === 'place') {
-              mode = 'placeToken';
-              intensity = segProgress;
-              handGrip = 1 - segProgress * 0.85;
-            } else {
-              mode = 'carryToken';
-              intensity = 0.45 + segProgress * 0.55;
-              handGrip = 1;
-            }
-          } else if (
-            actorState?.rollEndMs &&
-            now - actorState.rollEndMs < SEATED_HUMAN_RECOVER_MS &&
-            throwingPlayer === playerIndex
-          ) {
-            mode = 'followThrough';
-            intensity = clamp(1 - (now - actorState.rollEndMs) / SEATED_HUMAN_RECOVER_MS, 0, 1);
+            diceRef.current.getWorldPosition(handContactTarget);
+            handContactTarget.y += 0.009;
+            hasContactTarget = true;
           }
-
-          applySeatedHumanPose(rig, mode, intensity, handGrip, throwBias);
+          if (hasContactTarget) {
+            const contactWeight = pose.mode === 'carryToken' ? 0.65 : 1;
+            solveSeatedRightArmContactIK(entry, handContactTarget, contactWeight);
+          }
         });
       }
 
@@ -8872,7 +9064,20 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       const from = fromNode.position;
       const to = toNode.position;
       const distance = from.distanceTo(to);
-      const duration = Math.max(TOKEN_STEP_DURATION_SECONDS, distance / TOKEN_MOVE_SPEED);
+      const baseDuration = Math.max(TOKEN_STEP_DURATION_SECONDS, distance / TOKEN_MOVE_SPEED);
+      const helperDurationScale =
+        toNode.viaHelper === 'pickup'
+          ? 0.78
+          : toNode.viaHelper === 'place'
+          ? 0.74
+          : 1;
+      const minDuration =
+        toNode.viaHelper === 'pickup'
+          ? SEATED_HUMAN_TOKEN_PHASES.pickupMs / 1000
+          : toNode.viaHelper === 'place'
+          ? SEATED_HUMAN_TOKEN_PHASES.placeMs / 1000
+          : 0.16;
+      const duration = Math.max(minDuration, baseDuration * helperDurationScale);
       segments.push({
         from,
         to,


### PR DESCRIPTION
### Motivation
- Make seated avatar interactions (dice throws and token pickups) look more natural and robust by introducing phase-based timings, better easing, and contact IK for the right arm.
- Centralize motion tuning and precise timing constants for dice and token actions to allow consistent, tweakable animation behavior.
- Improve perceived motion of dice movement with new easing and a slightly adjusted arc for more pleasing visuals.

### Description
- Replace ad-hoc timing variables with frozen phase config objects `SEATED_HUMAN_DICE_PHASES`, `SEATED_HUMAN_TOKEN_PHASES`, and `SEATED_HUMAN_MOTION_TUNING`, and add IK parameters `SEATED_CONTACT_IK_ITERATIONS` and `SEATED_CONTACT_IK_MAX_STEP_RAD`.
- Add utility easing and phase helpers (`smoother01`, `easeInOutSine01`, `easeOutBack01`, `normalizedPhase`) and switch `applySeatedHumanPose` to accept a `motionTuning` argument and use a refined precision multiplier.
- Implement arm contact IK via `applyWorldRotationDeltaToBone` and `solveSeatedRightArmContactIK`, and add `resolveSeatedHumanActionPose` to compute pose mode/intensity/handGrip/motionTuning from actor and game state.
- Integrate pose resolution and IK into the render loop: apply poses via `applySeatedHumanPose`, compute a `handContactTarget` from moving tokens or dice, and run the IK solver; also auto-clear throw state after complete phases.
- Tweak dice animation easing/arc calculation inside `animateDicePosition`, and alter token move segment duration to account for helper phases and minimum phase durations.

### Testing
- Ran unit tests with `yarn test` and the test suite completed successfully.
- Performed a production build with `yarn build` which completed without errors.
- Ran lint/static checks with `yarn lint` and found no new lint violations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed1cf976b88329b48104e5e7e26570)