### PR TITLE
Improve cue pull-release shot behavior and scale up pool human character

### DIFF
--- a/Assets/Scripts/Gameplay/CueController.cs
+++ b/Assets/Scripts/Gameplay/CueController.cs
@@ -34,6 +34,8 @@ namespace Aiming
         [Header("Strike feel")]
         public float strikeDuration = 0.11f;
         public float strikeHoldDuration = 0.045f;
+        [Tooltip("How strongly the pull slider ramps into shot power (1 = linear, >1 softer low-end).")]
+        [Range(0.5f, 3f)] public float pullToPowerExponent = 1.35f;
         [Tooltip("Minimum impulse used whenever a valid shot is released.")]
         [Min(0f)] public float minStrikeImpulse = 0.25f;
         [Tooltip("Smallest normalized power that still produces cue-ball movement when charge/release was valid.")]
@@ -41,6 +43,8 @@ namespace Aiming
         public float maxStrikeImpulse = 6.5f;
         [Tooltip("Normalized strike progress where the hit is fired once.")]
         [Range(0.75f, 0.99f)] public float hitProgress = 0.88f;
+        [Tooltip("Guarantees cue-ball exits contact with at least this linear speed after a valid strike.")]
+        [Min(0f)] public float minimumCueBallSpeedAfterStrike = 0.09f;
 
         [Header("Motion settle")]
         [Tooltip("Linear velocity threshold used to decide whether a ball is still moving.")]
@@ -64,6 +68,7 @@ namespace Aiming
         Vector3 _cueAnchorPosition;
         float _currentCueDepth;
         float _chargedCueDepth;
+        float _releaseStartDepth;
         float _power;
         float _latchedShotPower;
         Vector2 _liveSpinInput;
@@ -140,6 +145,7 @@ namespace Aiming
             _latchedShotPower = 0f;
             _chargedCueDepth = idleTipGap + (pullRange * EaseOutCubic(_power));
             _currentCueDepth = _chargedCueDepth;
+            _releaseStartDepth = _chargedCueDepth;
             _dynamicLift = 0f;
             _dynamicWobble = 0f;
             gameObject.SetActive(true);
@@ -196,6 +202,7 @@ namespace Aiming
             _strikeDirection = _aimDirection;
             _strikeElapsed = 0f;
             _didStrike = false;
+            _releaseStartDepth = Mathf.Max(idleTipGap, _chargedCueDepth);
             _shotState = ShotState.Striking;
             TriggerShotBroadcastCamera();
         }
@@ -235,7 +242,6 @@ namespace Aiming
 
         void UpdateCueDepth()
         {
-            float hitT = Mathf.Clamp01(hitProgress);
             float activePower = _shotState == ShotState.Dragging ? _power : _latchedShotPower;
             float pull = pullRange * EaseOutCubic(activePower);
 
@@ -259,6 +265,7 @@ namespace Aiming
                 _dynamicWobble = 0f;
                 _chargedCueDepth = idleTipGap + pull;
                 _currentCueDepth = _chargedCueDepth;
+                _releaseStartDepth = _chargedCueDepth;
                 return;
             }
 
@@ -270,22 +277,19 @@ namespace Aiming
             float follow = Mathf.Min(0.018f, topspin * 0.018f);
             float dynamicFollow = follow * (0.55f + (0.45f * Mathf.Sin(t * Mathf.PI)));
 
-            float pulledDepth = Mathf.Max(idleTipGap, _chargedCueDepth);
+            float pulledDepth = Mathf.Max(idleTipGap, _releaseStartDepth);
             float releaseTargetDepth = idleTipGap;
-            float contactDepth = Mathf.Min(contactTipGap - dynamicFollow, releaseTargetDepth);
+            float releaseDistance = Mathf.Max(0.0001f, pulledDepth - releaseTargetDepth);
 
             _dynamicLift = -0.0035f * strikeEase;
             _dynamicWobble = Mathf.Sin(t * Mathf.PI) * 0.0014f;
             _currentCueDepth = Mathf.Lerp(pulledDepth, releaseTargetDepth, strikeEase);
 
-            if (!_didStrike && _currentCueDepth <= contactDepth)
-            {
-                _didStrike = true;
-                SquashTip();
-                ApplyStrikeImpulse(_strikeDirection, _latchedShotPower);
-            }
-
-            if (!_didStrike && t >= hitT)
+            float travel01 = Mathf.Clamp01((pulledDepth - _currentCueDepth) / releaseDistance);
+            float contactDepth = Mathf.Min(contactTipGap - dynamicFollow, releaseTargetDepth);
+            bool crossedContactDepth = _currentCueDepth <= contactDepth;
+            bool crossedHitProgress = travel01 >= Mathf.Clamp01(hitProgress);
+            if (!_didStrike && (crossedContactDepth || crossedHitProgress))
             {
                 _didStrike = true;
                 SquashTip();
@@ -420,7 +424,10 @@ namespace Aiming
 
         float ResolveReleasedShotPower(float sliderPower, float recoveredPower)
         {
-            float raw = Mathf.Clamp01(Mathf.Max(sliderPower, recoveredPower));
+            float slider = Mathf.Clamp01(sliderPower);
+            float pulled = Mathf.Clamp01(recoveredPower);
+            float pullWeighted = Mathf.Pow(pulled, Mathf.Max(0.5f, pullToPowerExponent));
+            float raw = Mathf.Clamp01(Mathf.Max(slider, pullWeighted));
             if (raw <= 0f)
             {
                 return 0f;
@@ -457,6 +464,28 @@ namespace Aiming
             float impulseMagnitude = Mathf.Lerp(minStrikeImpulse, maxStrikeImpulse, normalizedPower);
             Vector2 appliedSpin = _shotState == ShotState.Striking ? _latchedShotSpin : _liveSpinInput;
             strikePhysics.Apply(cueBallBody, strikeDirection, impulseMagnitude, appliedSpin, ballRadius);
+
+            float minSpeed = Mathf.Max(0f, minimumCueBallSpeedAfterStrike);
+            if (minSpeed > 0f)
+            {
+                Vector3 velocity = cueBallBody.velocity;
+                float planarSpeed = Vector3.ProjectOnPlane(velocity, Vector3.up).magnitude;
+                if (planarSpeed < minSpeed)
+                {
+                    Vector3 planarDirection = Vector3.ProjectOnPlane(strikeDirection, Vector3.up);
+                    if (planarDirection.sqrMagnitude < 1e-6f)
+                    {
+                        planarDirection = velocity.sqrMagnitude > 1e-6f ? velocity.normalized : _aimDirection;
+                    }
+                    planarDirection.y = 0f;
+                    if (planarDirection.sqrMagnitude < 1e-6f)
+                    {
+                        planarDirection = Vector3.forward;
+                    }
+                    planarDirection.Normalize();
+                    cueBallBody.velocity = (planarDirection * minSpeed) + (Vector3.up * velocity.y);
+                }
+            }
         }
 
         void SquashTip()

--- a/Assets/Scripts/Gameplay/PoolHumanPoseDriver.cs
+++ b/Assets/Scripts/Gameplay/PoolHumanPoseDriver.cs
@@ -38,6 +38,8 @@ namespace Aiming
         public float sourceTableWidth = 2f;
         public float edgeMargin = 0.58f;
         public float desiredShootDistance = 1.06f;
+        [Tooltip("Scales the full procedural human rig up/down after table-based scaling.")]
+        [Min(0.1f)] public float humanScaleMultiplier = 1.2f;
 
         [Header("Smoothing")]
         public float poseLambda = 9f;
@@ -112,7 +114,8 @@ namespace Aiming
             float lengthScale = cueController.tableBounds.size.z > 0.0001f
                 ? cueController.tableBounds.size.z / Mathf.Max(0.0001f, sourceTableLength)
                 : 1f;
-            return (widthScale + lengthScale) * 0.5f;
+            float tableScale = (widthScale + lengthScale) * 0.5f;
+            return tableScale * Mathf.Max(0.1f, humanScaleMultiplier);
         }
 
         float ResolveTableY(float cueBallY)


### PR DESCRIPTION
### Motivation
- Players requested larger human characters and a realistic cue pull→release shooting flow where pulling back charges the cue and releasing pushes the cue forward to the original position to transfer power into the cue ball. 
- Existing behavior sometimes failed to deliver power to the cue ball and did not reflect real-life pull/push sequencing, so the shot charging/triggering and safety behavior needed tightening.

### Description
- Added a configurable `humanScaleMultiplier` to `Assets/Scripts/Gameplay/PoolHumanPoseDriver.cs` and apply it on top of table-relative scaling so humans appear larger without breaking table adaptation.
- Tracked the exact pulled-back depth via `_releaseStartDepth` in `Assets/Scripts/Gameplay/CueController.cs` and drive strike travel from that pulled position back to idle so release motion is simulated from the pulled spot to the original tip gap.
- Reworked impact trigger logic to fire the strike when either the cue crosses the computed contact depth or the normalized travel progress reaches `hitProgress`, and preserved existing easing-based stroke timing.
- Improved power resolution by combining slider power with recovered pull depth using a tunable exponent `pullToPowerExponent` in `CueController`, and added `minimumCueBallSpeedAfterStrike` to guarantee a minimum planar speed after a valid strike when physics would otherwise leave the cue ball nearly stationary.

### Testing
- Ran `git diff --check -- Assets/Scripts/Gameplay/CueController.cs Assets/Scripts/Gameplay/PoolHumanPoseDriver.cs` and the check completed with no issues.
- Performed manual code-path review of `BeginCharge -> SetChargePower -> ReleaseAndStrike -> UpdateCueDepth -> ApplyStrikeImpulse` to validate sequencing and new paths (no automated unit tests were modified or run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed88c9e91c832983104ea221e1e819)