### PR TITLE
Improve Pool Royale cue release power transfer and enlarge human characters

### DIFF
--- a/power-slider.js
+++ b/power-slider.js
@@ -105,7 +105,7 @@ export class PowerSlider {
     return this.value;
   }
 
-  set(v, { animate = false } = {}) {
+  set(v, { animate = false, emitChange = true } = {}) {
     const value = this._clamp(this._step(v));
     this.value = value;
     if (!animate) this.el.classList.add('ps-no-animate');
@@ -113,22 +113,22 @@ export class PowerSlider {
     this._update(animate);
     if (!animate)
       requestAnimationFrame(() => this.el.classList.remove('ps-no-animate'));
-    if (typeof this.onChange === 'function') this.onChange(value);
+    if (emitChange && typeof this.onChange === 'function') this.onChange(value);
   }
 
-  animateTo(v, { duration = 160 } = {}) {
+  animateTo(v, { duration = 160, emitChange = true } = {}) {
     this._cancelReturnAnimation();
     const target = this._clamp(this._step(v));
     const start = this.value;
     if (!Number.isFinite(duration) || duration <= 0 || Math.abs(target - start) < 1e-6) {
-      this.set(target, { animate: true });
+      this.set(target, { animate: true, emitChange });
       return;
     }
     const startedAt = performance.now();
     const step = (now) => {
       const t = Math.min(1, Math.max(0, (now - startedAt) / duration));
       const eased = 1 - Math.pow(1 - t, 3);
-      this.set(start + (target - start) * eased, { animate: true });
+      this.set(start + (target - start) * eased, { animate: true, emitChange });
       if (t >= 1) {
         this._returnAnimFrame = null;
         return;
@@ -138,8 +138,8 @@ export class PowerSlider {
     this._returnAnimFrame = requestAnimationFrame(step);
   }
 
-  animateToMin({ duration = 160 } = {}) {
-    this.animateTo(this.min, { duration });
+  animateToMin({ duration = 160, emitChange = true } = {}) {
+    this.animateTo(this.min, { duration, emitChange });
   }
 
   lock() {

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1925,9 +1925,9 @@ const REFERENCE_CUE_SPEED_BASE = 1.9; // reference implementation: base cue-ball
 const REFERENCE_CUE_SPEED_RANGE = 8.2; // reference implementation: extra speed from power
 const REFERENCE_CUE_SPEED_GAMMA = 1.08; // reference implementation: power curve
 const MIN_SHOT_POWER_TO_FIRE = 0.015; // ignore accidental micro drags/releases that should not launch the cue ball
-const HUMAN_PLAYER_HEIGHT_RATIO_TO_TABLE = 0.8; // larger character relative to table/balls on portrait screens
+const HUMAN_PLAYER_HEIGHT_RATIO_TO_TABLE = 0.9; // make human players visibly bigger relative to the table on portrait screens
 const LUDO_BATTLE_ROYAL_SEATED_HUMAN_URL = 'https://threejs.org/examples/models/gltf/readyplayer.me.glb';
-const POOL_ROYALE_HUMAN_SCALE_MULTIPLIER = 1.2; // make Pool Royale humans slightly bigger than the old procedural rig
+const POOL_ROYALE_HUMAN_SCALE_MULTIPLIER = 1.28; // extra global scale bump so both fallback and GLTF humans read larger on phone screens
 const HUMAN_PLAYER_IDLE_SWAY_SPEED = 1.2;
 const HUMAN_PLAYER_IDLE_SWAY_ANGLE = 0.04;
 const HUMAN_PLAYER_AIM_LEAN = 0.2;
@@ -24445,7 +24445,7 @@ const shotPowerRef = useRef(0);
         rigGroup.rotation.y = facingY;
 
         const humanHeight = TABLE.H * HUMAN_PLAYER_HEIGHT_RATIO_TO_TABLE;
-        const scale = humanHeight / 1.82;
+        const scale = (humanHeight / 1.82) * POOL_ROYALE_HUMAN_SCALE_MULTIPLIER;
         const bodyMat = new THREE.MeshStandardMaterial({ color: 0x374151, roughness: 0.78 });
         const vestMat = new THREE.MeshStandardMaterial({ color: seat === 'A' ? 0x1f2d5a : 0x111827, roughness: 0.7 });
         const skinMat = new THREE.MeshStandardMaterial({ color: 0xe4bf9d, roughness: 0.82 });
@@ -27185,8 +27185,8 @@ const shotPowerRef = useRef(0);
           const startTime = performance.now();
           const impactPos = idlePos.clone();
           const contactAdvance = THREE.MathUtils.lerp(
-            BALL_R * 0.28,
-            BALL_R * 0.62,
+            BALL_R * 0.02,
+            BALL_R * 0.14,
             clampedPower
           );
           const contactPos = impactPos
@@ -27316,7 +27316,7 @@ const shotPowerRef = useRef(0);
               baseRotationY: cueStick.rotation.y,
               strikeDip: THREE.MathUtils.lerp(0.0028, 0.0054, clampedPower),
               wobbleAmount: THREE.MathUtils.lerp(0.0014, 0.0036, clampedPower),
-              strikeImpactThreshold: 0.9,
+              strikeImpactThreshold: 0.72,
               strikeExtraFollow: Math.min(0.018, Math.max(0, (rawSpin?.y ?? 0) * clampedPower) * 0.016),
               // Slider release should drive an immediate forward strike from the
               // currently pulled cue position back to contact.
@@ -33184,7 +33184,7 @@ const shotPowerRef = useRef(0);
 	          : clampPower(powerRef.current, 0);
 	        onPowerRelease(powerRatio);
 	        const resetDurationMs = 180;
-	        slider.animateToMin({ duration: resetDurationMs });
+	        slider.animateToMin({ duration: resetDurationMs, emitChange: false });
 	      }
 	    });
     sliderInstanceRef.current = slider;


### PR DESCRIPTION
### Motivation
- Make player characters more prominent on portrait/mobile so humans read larger relative to the table and balls. 
- Fix the pull/release shooting flow so the pull slider charges the cue, the cue visibly returns from the pulled position and delivers the generated power only when the cue tip contacts the cue ball (real-life feel). 
- Prevent the UI slider reset from overwriting the latched shot power when the player releases to shoot.

### Description
- Add an `emitChange` flag to `PowerSlider.set`, `animateTo` and `animateToMin` so animations can reset the UI without emitting `onChange` callbacks (`power-slider.js`).
- Use the silent reset on commit (`slider.animateToMin({ emitChange: false })`) so the slider returns visually but the latched shot power remains in `shotPowerRef` (`PoolRoyale.jsx`).
- Increase base human sizing constants and apply the global `POOL_ROYALE_HUMAN_SCALE_MULTIPLIER` to the fallback rig scale so seated/standing rigs are visibly larger on phones (`HUMAN_PLAYER_HEIGHT_RATIO_TO_TABLE` and `POOL_ROYALE_HUMAN_SCALE_MULTIPLIER` in `PoolRoyale.jsx`).
- Reduce forward contact overshoot and earlier-impact behavior by tightening `contactAdvance` lerp bounds and lowering `strikeImpactThreshold` so impact is triggered closer to cue-tip contact (`PoolRoyale.jsx`).

### Testing
- Ran the web client build with `npm --prefix webapp run build` and the build completed successfully (Vite produced its usual chunk-size and import warnings that are pre-existing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed88c9e91c832983104ea221e1e819)