### PR TITLE
Make Pool Royale use Bilardo Shqip human and match its shot behavior; remove slider cue animation

### DIFF
--- a/power-slider.js
+++ b/power-slider.js
@@ -53,9 +53,12 @@ export class PowerSlider {
     this.cueImg = document.createElement('img');
     this.cueImg.className = 'ps-cue-img';
     this.cueImg.alt = '';
-    if (cueSrc) this.cueImg.src = cueSrc;
+    this.hasCueImage = Boolean(cueSrc);
+    if (this.hasCueImage) this.cueImg.src = cueSrc;
+    else this.el.classList.add('ps-no-cue-image');
 
-    this.handle.append(this.cueImg, this.handleText, this.powerBar);
+    if (this.hasCueImage) this.handle.append(this.cueImg, this.handleText, this.powerBar);
+    else this.handle.append(this.handleText, this.powerBar);
     this.el.appendChild(this.handle);
 
     this.tooltip = document.createElement('div');
@@ -94,9 +97,11 @@ export class PowerSlider {
     this.el.addEventListener('wheel', this._onWheel, { passive: false });
     this.el.addEventListener('keydown', this._onKeyDown);
 
-    this.cueImg.addEventListener('load', () => {
-      this._update(false);
-    });
+    if (this.hasCueImage) {
+      this.cueImg.addEventListener('load', () => {
+        this._update(false);
+      });
+    }
 
     this.set(value);
   }
@@ -196,7 +201,7 @@ export class PowerSlider {
     this.el.setAttribute('aria-valuenow', String(Math.round(this.value)));
     if (ratio >= 0.9) this.el.classList.add('ps-hot');
     else this.el.classList.remove('ps-hot');
-    if (this.theme === 'pool-royale' || this.theme === 'snooker-royale') {
+    if (this.hasCueImage && (this.theme === 'pool-royale' || this.theme === 'snooker-royale')) {
       const drop = ratio * 28;
       const tilt = -8 - ratio * 10;
       this.cueImg.style.transform = `translateY(${drop}px) rotate(${tilt}deg)`;

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -18,7 +18,7 @@ import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader.js';
 import { GroundedSkybox } from 'three/examples/jsm/objects/GroundedSkybox.js';
 import { RoundedBoxGeometry } from 'three/examples/jsm/geometries/RoundedBoxGeometry.js';
 import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.js';
-import { PoolRoyalePowerSlider } from '../../../../pool-royale-power-slider.js';
+import { PowerSlider } from '../../../../power-slider.js';
 import '../../../../pool-royale-power-slider.css';
 import { useLocation, useNavigate } from 'react-router-dom';
 import {
@@ -1922,13 +1922,13 @@ const CUE_PULL_GLOBAL_VISIBILITY_BOOST = 0.86; // trim global pullback so charge
 const CUE_PULL_RETURN_PUSH = 1.22; // accelerate the forward cue drive so push-through feels snappier
 const CUE_FOLLOW_THROUGH_MIN = BALL_R * 3.9; // keep low-power shots visibly pushing through the cue ball
 const CUE_FOLLOW_THROUGH_MAX = BALL_R * 8.4; // extend top-end follow-through so powerful shots visibly punch forward
-const REFERENCE_CUE_SPEED_BASE = 2.35; // raise baseline cue-ball launch so light shots still roll with intent
-const REFERENCE_CUE_SPEED_RANGE = 10.6; // wider speed range so slider pull translates to stronger impact
+const REFERENCE_CUE_SPEED_BASE = 1.9; // align baseline launch speed with Bilardo Shqip shot feel
+const REFERENCE_CUE_SPEED_RANGE = 8.2; // align high-end launch speed with Bilardo Shqip shot feel
 const REFERENCE_CUE_SPEED_GAMMA = 1.08; // reference implementation: power curve
 const MIN_SHOT_POWER_TO_FIRE = 0.015; // ignore accidental micro drags/releases that should not launch the cue ball
 const HUMAN_PLAYER_HEIGHT_RATIO_TO_TABLE = 0.88; // make player humans visibly bigger relative to table/balls
-const LUDO_BATTLE_ROYAL_SEATED_HUMAN_URL = 'https://threejs.org/examples/models/gltf/readyplayer.me.glb';
-const POOL_ROYALE_HUMAN_SCALE_MULTIPLIER = 1.34; // stronger character up-scale so humans read larger on mobile portrait
+const BILARDO_SHQIP_HUMAN_URL = 'https://threejs.org/examples/models/gltf/readyplayer.me.glb';
+const POOL_ROYALE_HUMAN_SCALE_MULTIPLIER = 1.4; // slight size bump while keeping the same base proportions
 const HUMAN_PLAYER_IDLE_SWAY_SPEED = 1.2;
 const HUMAN_PLAYER_IDLE_SWAY_ANGLE = 0.04;
 const HUMAN_PLAYER_AIM_LEAN = 0.2;
@@ -19674,7 +19674,7 @@ const shotPowerRef = useRef(0);
         if (seatedHumanLoadRef.current) {
           return seatedHumanLoadRef.current;
         }
-        seatedHumanLoadRef.current = loadFirstAvailableGltf([LUDO_BATTLE_ROYAL_SEATED_HUMAN_URL])
+        seatedHumanLoadRef.current = loadFirstAvailableGltf([BILARDO_SHQIP_HUMAN_URL])
           .then((gltf) => {
             const model = gltf?.scene?.clone?.(true) ?? gltf?.scene ?? gltf?.scenes?.[0] ?? null;
             if (!model) {
@@ -33192,10 +33192,11 @@ const shotPowerRef = useRef(0);
     }
     const mount = sliderRef.current;
     if (!mount) return undefined;
-    const slider = new PoolRoyalePowerSlider({
+    const slider = new PowerSlider({
       mount,
       value: powerRef.current * 100,
-      cueSrc: '/assets/snooker/cue.webp',
+      cueSrc: '',
+      theme: 'pool-royale',
       labels: true,
       onChange: (v) => onPowerDrag((v ?? 0) / 100),
       onStart: () => onPowerDragStart(),


### PR DESCRIPTION
### Motivation
- Make Pool Royale use the same seated human GLB and on-table proportions as Bilardo Shqip so characters look and behave identically.
- Match the shot force/launch feel to Bilardo Shqip so player shots behave the same across both games.
- Remove the visual cue-stick animation on the UI power slider so the human model is the single source of cue animation/pose.

### Description
- Switched Pool Royale to load the same GLB URL used by Bilardo Shqip by introducing `BILARDO_SHQIP_HUMAN_URL` and increasing `POOL_ROYALE_HUMAN_SCALE_MULTIPLIER` to `1.4` to make the human slightly larger (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Tuned shot launch constants by changing `REFERENCE_CUE_SPEED_BASE` to `1.9` and `REFERENCE_CUE_SPEED_RANGE` to `8.2` to align cue-ball launch feel with Bilardo Shqip (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Replaced use of the Pool Royale wrapper slider with the base `PowerSlider` configured with `cueSrc: ''` and `theme: 'pool-royale'` so the slider no longer shows or animates a cue image while preserving pull-and-release firing (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Updated the shared slider implementation to support a cue-less mode by skipping creation/animation of the cue image when `cueSrc` is empty (`power-slider.js`).
- Added an import of `PowerSlider` and removed the previous wrapper usage so the slider behavior is deterministic and the human model drives visible cue animation (`webapp/src/pages/Games/PoolRoyale.jsx`, `power-slider.js`).

### Testing
- Ran `npm run -s test -- test/poolRoyaleCueStrokeTimeline.test.js` and it passed (4 tests).
- Ran `npm run -s test -- test/poolRoyaleShotState.test.js` and it passed (4 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed9555c2648329a455961ea1e37407)