### PR TITLE
Align Pool Royal human walk-around and shot trigger with Bilardo behavior

### DIFF
--- a/Assets/Scripts/Gameplay/CueController.cs
+++ b/Assets/Scripts/Gameplay/CueController.cs
@@ -38,6 +38,8 @@ namespace Aiming
         [Min(0f)] public float minStrikeImpulse = 0.25f;
         [Tooltip("Smallest normalized power that still produces cue-ball movement when charge/release was valid.")]
         [Range(0f, 0.5f)] public float minimumShotPowerNormalized = 0.06f;
+        [Tooltip("Minimum pull/slider amount required to arm a release trigger (Bilardo Shqip parity).")]
+        [Range(0f, 0.25f)] public float releaseTriggerThresholdNormalized = 0.02f;
         public float maxStrikeImpulse = 6.5f;
         [Tooltip("Normalized strike progress where the hit is fired once.")]
         [Range(0.75f, 0.99f)] public float hitProgress = 0.88f;
@@ -76,6 +78,7 @@ namespace Aiming
         float _dynamicWobble;
         Vector3 _strikeDirection;
         Vector3 _tipBaseScale = Vector3.one;
+        bool _cameraLowered;
 
         public ShotState CurrentShotState => _shotState;
         public Vector3 CurrentAimDirection => _aimDirection;
@@ -146,6 +149,22 @@ namespace Aiming
             UpdateCuePose();
         }
 
+        public void SetCameraLowered(bool lowered)
+        {
+            _cameraLowered = lowered;
+
+            if (_cameraLowered && _shotState == ShotState.Idle)
+            {
+                BeginCharge();
+                return;
+            }
+
+            if (!_cameraLowered && _shotState == ShotState.Dragging && _power < releaseTriggerThresholdNormalized)
+            {
+                CancelCharge();
+            }
+        }
+
         public void SetSpinInput(Vector2 normalizedSpin)
         {
             _liveSpinInput = Vector2.ClampMagnitude(normalizedSpin, 1f);
@@ -197,6 +216,7 @@ namespace Aiming
             _strikeElapsed = 0f;
             _didStrike = false;
             _shotState = ShotState.Striking;
+            _cameraLowered = false;
             TriggerShotBroadcastCamera();
         }
 
@@ -421,6 +441,12 @@ namespace Aiming
         float ResolveReleasedShotPower(float sliderPower, float recoveredPower)
         {
             float raw = Mathf.Clamp01(Mathf.Max(sliderPower, recoveredPower));
+            bool pulledEnough = raw > releaseTriggerThresholdNormalized;
+            if (!pulledEnough && !_cameraLowered)
+            {
+                return 0f;
+            }
+
             if (raw <= 0f)
             {
                 return 0f;

--- a/Assets/Scripts/Gameplay/PoolHumanPoseDriver.cs
+++ b/Assets/Scripts/Gameplay/PoolHumanPoseDriver.cs
@@ -38,11 +38,14 @@ namespace Aiming
         public float sourceTableWidth = 2f;
         public float edgeMargin = 0.58f;
         public float desiredShootDistance = 1.06f;
+        [Tooltip("Optional helper waypoints around table sides (left, right, bottom, top).")]
+        public Transform[] sideWalkHelpers;
 
         [Header("Smoothing")]
         public float poseLambda = 9f;
         public float moveLambda = 5.6f;
         public float rotLambda = 8.5f;
+        [Min(0.1f)] public float walkPerimeterSpeed = 2.7f;
 
         [Header("Cue relation")]
         public float bridgeDist = 0.24f;
@@ -52,6 +55,8 @@ namespace Aiming
         float _poseT;
         float _walkT;
         float _yaw;
+        Vector3 _perimeterRootTarget;
+        bool _hasPerimeterTarget;
 
         void LateUpdate()
         {
@@ -74,6 +79,7 @@ namespace Aiming
 
             Vector3 aimSide = new Vector3(aimForward.z, 0f, -aimForward.x).normalized;
             Vector3 rootTarget = ChooseHumanEdgePosition(cueBall, aimForward, s);
+            Vector3 navigatedRootTarget = NavigateAlongTablePerimeter(rootTarget, s, dt);
 
             float bridgeDistance = bridgeDist * s;
             Vector3 bridgeHandTarget = cueBall + (aimForward * -bridgeDistance) + (aimSide * (-0.018f * s));
@@ -90,7 +96,7 @@ namespace Aiming
             UpdateHumanPose(
                 dt,
                 cueController.CurrentShotState,
-                rootTarget,
+                navigatedRootTarget,
                 aimForward,
                 bridgeHandTarget,
                 gripHandTarget,
@@ -151,6 +157,132 @@ namespace Aiming
 
             best.y = stanceHeight;
             return best;
+        }
+
+        Vector3 NavigateAlongTablePerimeter(Vector3 desiredTarget, float s, float dt)
+        {
+            if (!_hasPerimeterTarget)
+            {
+                _perimeterRootTarget = root.position;
+                _hasPerimeterTarget = true;
+            }
+
+            Vector3 currentPerimeter = ClosestPerimeterPoint(_perimeterRootTarget, s);
+            Vector3 targetPerimeter = ClosestPerimeterPoint(desiredTarget, s);
+            _perimeterRootTarget = MovePerimeterPoint(currentPerimeter, targetPerimeter, walkPerimeterSpeed * Mathf.Max(0f, dt), s);
+            _perimeterRootTarget.y = stanceHeight;
+            return _perimeterRootTarget;
+        }
+
+        Vector3 ClosestPerimeterPoint(Vector3 point, float s)
+        {
+            Vector3[] helpers = sideWalkHelpers;
+            if (helpers != null && helpers.Length > 0)
+            {
+                Vector3 best = helpers[0] != null ? helpers[0].position : point;
+                float bestDist = (best - point).sqrMagnitude;
+                for (int i = 1; i < helpers.Length; i++)
+                {
+                    if (helpers[i] == null)
+                    {
+                        continue;
+                    }
+
+                    float d = (helpers[i].position - point).sqrMagnitude;
+                    if (d < bestDist)
+                    {
+                        best = helpers[i].position;
+                        bestDist = d;
+                    }
+                }
+
+                best.y = stanceHeight;
+                return best;
+            }
+
+            float halfW = cueController.tableBounds.size.x * 0.5f;
+            float halfL = cueController.tableBounds.size.z * 0.5f;
+            float xEdge = halfW + (edgeMargin * s);
+            float zEdge = halfL + (edgeMargin * s);
+            return new Vector3(
+                Mathf.Clamp(point.x, -xEdge, xEdge),
+                stanceHeight,
+                Mathf.Clamp(point.z, -zEdge, zEdge));
+        }
+
+        Vector3 MovePerimeterPoint(Vector3 current, Vector3 target, float step, float s)
+        {
+            if (step <= 0f)
+            {
+                return current;
+            }
+
+            float halfW = cueController.tableBounds.size.x * 0.5f;
+            float halfL = cueController.tableBounds.size.z * 0.5f;
+            float xEdge = halfW + (edgeMargin * s);
+            float zEdge = halfL + (edgeMargin * s);
+            float perimeter = (xEdge + zEdge) * 4f;
+            if (perimeter < 0.0001f)
+            {
+                return target;
+            }
+
+            float uCurrent = PointToPerimeterU(current, xEdge, zEdge);
+            float uTarget = PointToPerimeterU(target, xEdge, zEdge);
+
+            float cw = Mathf.Repeat(uTarget - uCurrent, perimeter);
+            float ccw = cw - perimeter;
+            float delta = Mathf.Abs(cw) <= Mathf.Abs(ccw) ? cw : ccw;
+            float travel = Mathf.Clamp(delta, -step, step);
+            float uNext = Mathf.Repeat(uCurrent + travel, perimeter);
+            return PerimeterUToPoint(uNext, xEdge, zEdge);
+        }
+
+        static float PointToPerimeterU(Vector3 p, float xEdge, float zEdge)
+        {
+            float width = xEdge * 2f;
+            float length = zEdge * 2f;
+            float perimeter = (xEdge + zEdge) * 4f;
+            float px = Mathf.Clamp(p.x, -xEdge, xEdge);
+            float pz = Mathf.Clamp(p.z, -zEdge, zEdge);
+
+            float dx = Mathf.Min(Mathf.Abs(px + xEdge), Mathf.Abs(px - xEdge));
+            float dz = Mathf.Min(Mathf.Abs(pz + zEdge), Mathf.Abs(pz - zEdge));
+
+            if (dz <= dx)
+            {
+                return pz < 0f ? (px + xEdge) : (width + length + (xEdge - px));
+            }
+
+            return px > 0f ? (width + (pz + zEdge)) : (width + length + width + (zEdge - pz));
+        }
+
+        static Vector3 PerimeterUToPoint(float u, float xEdge, float zEdge)
+        {
+            float width = xEdge * 2f;
+            float length = zEdge * 2f;
+            float perimeter = (xEdge + zEdge) * 4f;
+            u = Mathf.Repeat(u, perimeter);
+
+            if (u < width)
+            {
+                return new Vector3(-xEdge + u, 0f, -zEdge);
+            }
+
+            u -= width;
+            if (u < length)
+            {
+                return new Vector3(xEdge, 0f, -zEdge + u);
+            }
+
+            u -= length;
+            if (u < width)
+            {
+                return new Vector3(xEdge - u, 0f, zEdge);
+            }
+
+            u -= width;
+            return new Vector3(-xEdge, 0f, zEdge - u);
         }
 
         void UpdateHumanPose(

--- a/Assets/Tests/PlayMode/CueControllerTriggerTests.cs
+++ b/Assets/Tests/PlayMode/CueControllerTriggerTests.cs
@@ -1,0 +1,60 @@
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Aiming.Tests
+{
+    public class CueControllerTriggerTests
+    {
+        [Test]
+        public void ReleaseAndStrike_WithLowPullAndCameraUp_StaysIdle()
+        {
+            var go = new GameObject("cue-controller-low-pull");
+            var cueBall = new GameObject("cue-ball").transform;
+
+            try
+            {
+                var controller = go.AddComponent<CueController>();
+                controller.cueBall = cueBall;
+                controller.releaseTriggerThresholdNormalized = 0.02f;
+                controller.minimumShotPowerNormalized = 0.06f;
+
+                controller.BeginCharge();
+                controller.SetChargePower(0.01f);
+                controller.ReleaseAndStrike();
+
+                Assert.That(controller.CurrentShotState, Is.EqualTo(CueController.ShotState.Idle));
+            }
+            finally
+            {
+                Object.DestroyImmediate(cueBall.gameObject);
+                Object.DestroyImmediate(go);
+            }
+        }
+
+        [Test]
+        public void ReleaseAndStrike_WithLowPullAndCameraLowered_TriggersStrike()
+        {
+            var go = new GameObject("cue-controller-camera-lowered");
+            var cueBall = new GameObject("cue-ball").transform;
+
+            try
+            {
+                var controller = go.AddComponent<CueController>();
+                controller.cueBall = cueBall;
+                controller.releaseTriggerThresholdNormalized = 0.02f;
+                controller.minimumShotPowerNormalized = 0.06f;
+
+                controller.SetCameraLowered(true);
+                controller.SetChargePower(0.01f);
+                controller.ReleaseAndStrike();
+
+                Assert.That(controller.CurrentShotState, Is.EqualTo(CueController.ShotState.Striking));
+            }
+            finally
+            {
+                Object.DestroyImmediate(cueBall.gameObject);
+                Object.DestroyImmediate(go);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Match Pool Royale player interaction to Bilardo Shqip: human walks around table edges (not through the table) and the shot trigger is armed when the camera is lowered or when the player pulls the slider sufficiently. 
- Preserve existing power slider scale, impulse mapping and human model while improving movement routing and parity in release arming logic.

### Description
- Added a configurable release gating parameter and camera-backed arming API to `CueController` so very-small slider pulls no longer fire unless camera-lowered mode is active; new API: `SetCameraLowered(bool)` and new field `releaseTriggerThresholdNormalized` (see `Assets/Scripts/Gameplay/CueController.cs`).
- Changed released-power resolution so a shot is ignored unless the slider pull exceeds the threshold or the camera-lowered flag is set, and camera-lowered is cleared when a strike begins (see `ResolveReleasedShotPower` and `ReleaseAndStrike`).
- Updated `PoolHumanPoseDriver` to route the human along the table perimeter instead of cutting through the table, added optional `sideWalkHelpers` for authored waypoints, and implemented perimeter navigation utilities (`NavigateAlongTablePerimeter`, `MovePerimeterPoint`, `ClosestPerimeterPoint`, etc.) (see `Assets/Scripts/Gameplay/PoolHumanPoseDriver.cs`).
- Added PlayMode tests exercising the new trigger logic in `Assets/Tests/PlayMode/CueControllerTriggerTests.cs` (two tests covering low-pull with camera up vs camera lowered).

### Testing
- Added automated PlayMode tests: `CueControllerTriggerTests` with two cases (low pull + camera up => stays Idle, low pull + camera lowered => triggers Striking). These tests were created but not executed in this environment because the Unity test runner/CLI is not available here. 
- No changes were made to the power → impulse mapping or strike physics code paths, and existing non-Unity checks in the environment completed successfully. 
- Manual/CI Unity PlayMode run is recommended to validate the new tests and verify runtime integration with the scene (ensure `sideWalkHelpers` and `cueCamera` are wired in scene prefabs).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed9e337f4c8329b986092fba251dc6)