### PR TITLE
Pool Royale: switch to Bilardo Shqip GLB character and restore cue-ball power curve

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -115,7 +115,6 @@ import {
 import { sampleCueStrokeTimeline } from './poolRoyaleCueStrokeTimeline.js';
 import { resolvePocketMouthAimPoint } from './poolRoyalePocketAim.js';
 import { resolveAiPotGhostAim } from './poolRoyaleAiAimCompensation.js';
-import { computeCueDriveBoost } from './cueShotImpact.js';
 import { polyHavenThumb } from '../../config/storeThumbnails.js';
 
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/v1/decoders/';
@@ -24505,6 +24504,29 @@ const shotPowerRef = useRef(0);
         rigGroup.add(bridgeHand);
         rigGroup.add(gripHand);
 
+        const proceduralParts = [
+          pelvis,
+          torso,
+          chest,
+          neck,
+          head,
+          leftUpperArm,
+          leftLowerArm,
+          rightUpperArm,
+          rightLowerArm,
+          leftUpperLeg,
+          leftLowerLeg,
+          rightUpperLeg,
+          rightLowerLeg,
+          leftFoot,
+          rightFoot,
+          bridgeHand,
+          gripHand
+        ];
+        const modelRoot = new THREE.Group();
+        modelRoot.visible = false;
+        rigGroup.add(modelRoot);
+
         rigGroup.userData.anim = {
           seat,
           mode: 'idle',
@@ -24532,8 +24554,44 @@ const shotPowerRef = useRef(0);
           walkT: 0,
           yaw: facingY,
           rootTarget: new THREE.Vector3(x, floorY, z),
-          usesFallbackRig: false
+          usesFallbackRig: true,
+          modelRoot,
+          activeGlb: false
         };
+        void loadFirstAvailableGltf([BILARDO_SHQIP_HUMAN_URL])
+          .then((gltf) => {
+            const model =
+              gltf?.scene?.clone?.(true) ??
+              gltf?.scene ??
+              gltf?.scenes?.[0] ??
+              null;
+            if (!model) return;
+            const bbox = new THREE.Box3().setFromObject(model);
+            const modelHeight = Math.max(
+              1e-5,
+              (bbox.max?.y ?? 0) - (bbox.min?.y ?? 0)
+            );
+            const targetScale = (humanHeight / modelHeight) * POOL_ROYALE_HUMAN_SCALE_MULTIPLIER;
+            model.scale.setScalar(targetScale);
+            model.position.y = -(bbox.min?.y ?? 0) * targetScale;
+            model.rotation.y = Math.PI;
+            model.traverse((child) => {
+              if (!child?.isMesh) return;
+              child.castShadow = true;
+              child.receiveShadow = true;
+            });
+            modelRoot.add(model);
+            modelRoot.visible = true;
+            proceduralParts.forEach((part) => {
+              if (part) part.visible = false;
+            });
+            rigGroup.userData.anim.activeGlb = true;
+            rigGroup.userData.anim.usesFallbackRig = false;
+          })
+          .catch(() => {
+            rigGroup.userData.anim.activeGlb = false;
+            rigGroup.userData.anim.usesFallbackRig = true;
+          });
         return rigGroup;
       };
 
@@ -26735,17 +26793,10 @@ const shotPowerRef = useRef(0);
         const shotDir3 = TMP_VEC3_C.set(aimDir.x, 0, aimDir.y);
         if (shotDir3.lengthSq() > 1e-8) shotDir3.normalize();
         else shotDir3.set(0, 0, 1);
-        const cueDriveBoost = computeCueDriveBoost({
-          pullDistance,
-          contactAdvance,
-          strikeDurationMs: strikeDuration,
-          clampedPower
-        });
         const referenceSpeed =
           REFERENCE_CUE_SPEED_BASE +
           REFERENCE_CUE_SPEED_RANGE *
-            Math.pow(THREE.MathUtils.clamp(clampedPower, 0, 1), REFERENCE_CUE_SPEED_GAMMA) *
-            cueDriveBoost;
+            Math.pow(THREE.MathUtils.clamp(clampedPower, 0, 1), REFERENCE_CUE_SPEED_GAMMA);
         cue.vel.copy(shotDir3).multiplyScalar(referenceSpeed);
         if (cue.spin) {
           cue.spin.set(offsetScaled.x, offsetScaled.y);


### PR DESCRIPTION
### Motivation
- Replace the procedural Pool Royale player visual with the same GLB human used in Bilardo Shqip so character shape/animation matches across games while preserving Pool Royale gameplay sizing and placement.
- Fix underpowered cue-ball launches by aligning Pool Royale’s shot-to-speed mapping to the Bilardo Shqip technique so the cue ball receives the same power for equivalent input.

### Description
- Load the shared GLB (`BILARDO_SHQIP_HUMAN_URL`) per player rig, add a `modelRoot`, scale and position the loaded model to the existing `humanHeight`, and hide the procedural body parts once the GLB is ready so footprint/size remain unchanged.
- Add `usesFallbackRig`/`activeGlb` flags to the rig `userData` so the code falls back to the procedural rig if the GLB fails to load.
- Remove the `computeCueDriveBoost` multiplier and compute `referenceSpeed` directly as `REFERENCE_CUE_SPEED_BASE + REFERENCE_CUE_SPEED_RANGE * Math.pow(clampedPower, REFERENCE_CUE_SPEED_GAMMA)` to restore the Bilardo Shqip power curve mapping to shot speed.
- Remove the unused import of `computeCueDriveBoost` and keep all existing movement/aim/pose logic intact so only the visual and power mapping behavior change.

### Testing
- Ran the focused test suites with `npm test -- --runInBand test/poolRoyaleShotState.test.js test/poolRoyaleCueStrokeTimeline.test.js` and both suites passed.
- Test summary: `test/poolRoyaleCueStrokeTimeline.test.js` — PASS and `test/poolRoyaleShotState.test.js` — PASS.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edad54ada083298804965e8eef7e36)