### PR TITLE
Restore Domino Battle Royal to pre-human-character implementation

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -6028,6 +6028,8 @@ const seatAvatars = [];
 const seatNameTags = [];
 const seatBadges = [];
 let humanSeatBadgeAnchor = null;
+const HUMAN_SEAT_BADGE_BOTTOM_OFFSET = 82;
+const HUMAN_SEAT_BADGE_LEFT_OFFSET = -6;
 const seatOverlay = document.createElement('div');
 seatOverlay.id = 'seatOverlay';
 document.body.appendChild(seatOverlay);
@@ -6246,28 +6248,28 @@ function updateSeatBadgePositions() {
   chairs.forEach((wrapper, idx) => {
     const badge = seatBadges[idx];
     if (!badge) return;
-    const faceAnchor = seatFaceAnchors[idx];
-    const world = faceAnchor
-      ? faceAnchor.getWorldPosition(projectedSeatTarget)
-      : wrapper.getWorldPosition(projectedSeatTarget);
-    if (!faceAnchor) {
-      world.y +=
-        CHAIR_DIMENSIONS.seatThickness + CHAIR_DIMENSIONS.backHeight * 0.62;
-    }
+    const world = wrapper.getWorldPosition(projectedSeatTarget);
+    world.y +=
+      CHAIR_DIMENSIONS.seatThickness + CHAIR_DIMENSIONS.backHeight * 0.62;
     world.project(camera);
     const projectedX = (world.x * 0.5 + 0.5) * rect.width + rect.left;
     const projectedY = (1 - (world.y * 0.5 + 0.5)) * rect.height + rect.top;
-    badge.style.left = `${projectedX}px`;
-    badge.style.top = `${projectedY}px`;
+    let x = projectedX;
+    let y = projectedY;
+    if (idx === human) {
+      const anchorX =
+        rect.left + rect.width * 0.5 + HUMAN_SEAT_BADGE_LEFT_OFFSET;
+      const anchorY = rect.top + rect.height - HUMAN_SEAT_BADGE_BOTTOM_OFFSET;
+      if (!humanSeatBadgeAnchor) humanSeatBadgeAnchor = { x: anchorX, y: anchorY };
+      humanSeatBadgeAnchor.x = anchorX;
+      humanSeatBadgeAnchor.y = anchorY;
+      x = humanSeatBadgeAnchor.x;
+      y = humanSeatBadgeAnchor.y;
+    }
+    badge.style.left = `${x}px`;
+    badge.style.top = `${y}px`;
     badge.style.opacity =
       idx === human ? '1' : world.z > 1 || world.z < -1 ? '0' : '1';
-    if (idx === human) {
-      if (!humanSeatBadgeAnchor) {
-        humanSeatBadgeAnchor = { x: projectedX, y: projectedY };
-      }
-      humanSeatBadgeAnchor.x = projectedX;
-      humanSeatBadgeAnchor.y = projectedY;
-    }
   });
   anchorSelfVideoToBottomSeat();
 }
@@ -7671,425 +7673,6 @@ const CHAIR_TEXTURE_PROPS = Object.freeze([
   'sheenColorMap',
   'sheenRoughnessMap'
 ]);
-const HUMAN_CHARACTER_DISABLED = false;
-const SEATED_HUMAN_MODEL_URL = 'https://threejs.org/examples/models/gltf/readyplayer.me.glb';
-// Keep Domino seated humans aligned to the same seated baseline used in Ludo Battle Royal.
-const SEATED_HUMAN_SEAT_Y_OFFSET = -1.42 * MODEL_SCALE * STOOL_SCALE;
-const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.2;
-const SEATED_HUMAN_FACING_Y = 0;
-const seatedHumans = [];
-const seatFaceAnchors = [];
-const seatCharacterHelpers = [];
-let seatedHumanTemplatePromise = null;
-
-function cloneSkinned(source) {
-  if (!source?.isObject3D) return source?.clone?.(true) ?? null;
-  const clone = source.clone(true);
-  const sourceSkinnedMeshes = [];
-  const cloneBonesByName = new Map();
-  const cloneSkinnedMeshes = [];
-
-  source.traverse((obj) => {
-    if (obj?.isSkinnedMesh) sourceSkinnedMeshes.push(obj);
-  });
-  clone.traverse((obj) => {
-    if (obj?.isBone && obj.name) cloneBonesByName.set(obj.name, obj);
-    if (obj?.isSkinnedMesh) cloneSkinnedMeshes.push(obj);
-  });
-
-  cloneSkinnedMeshes.forEach((mesh, index) => {
-    const sourceMesh = sourceSkinnedMeshes[index];
-    if (!sourceMesh?.skeleton) return;
-    const sourceBones = sourceMesh.skeleton.bones || [];
-    const cloneBones = sourceBones.map((bone) => cloneBonesByName.get(bone.name) || bone);
-    if (!cloneBones.length) return;
-    mesh.bind(new THREE.Skeleton(cloneBones, sourceMesh.skeleton.boneInverses), mesh.bindMatrix);
-  });
-
-  return clone;
-}
-
-function normalizeHumanBoneName(value = '') {
-  return String(value).toLowerCase().replace(/[^a-z0-9]/g, '');
-}
-
-function getModelBones(root) {
-  const bones = [];
-  root.traverse((obj) => {
-    if (obj?.isBone) bones.push(obj);
-  });
-  return bones;
-}
-
-function findModelBone(bones, aliases = []) {
-  const normalizedAliases = aliases.map((alias) => normalizeHumanBoneName(alias));
-  for (const alias of normalizedAliases) {
-    const exact = bones.find((bone) => normalizeHumanBoneName(bone.name) === alias);
-    if (exact) return exact;
-  }
-  for (const alias of normalizedAliases) {
-    const partial = bones.find((bone) => normalizeHumanBoneName(bone.name).includes(alias));
-    if (partial) return partial;
-  }
-  return null;
-}
-
-function captureModelRestPose(root) {
-  const rest = new Map();
-  getModelBones(root).forEach((bone) => rest.set(bone, bone.quaternion.clone()));
-  return rest;
-}
-
-function composeModelBone(rest, bone, euler) {
-  if (!bone) return;
-  const base = rest.get(bone);
-  if (!base) return;
-  bone.quaternion.copy(base).multiply(new THREE.Quaternion().setFromEuler(euler));
-}
-
-function buildHumanBoneMap(root) {
-  const bones = getModelBones(root);
-  const map = {
-    hips: findModelBone(bones, ['hips', 'mixamorighips', 'pelvis', 'wolf3dhips']),
-    spine: findModelBone(bones, ['spine', 'mixamorigspine', 'wolf3dspine']),
-    spine1: findModelBone(bones, ['spine1', 'spine01', 'mixamorigspine1', 'chest']),
-    spine2: findModelBone(bones, ['spine2', 'spine02', 'mixamorigspine2', 'upperchest']),
-    neck: findModelBone(bones, ['neck', 'mixamorigneck', 'wolf3dneck']),
-    head: findModelBone(bones, ['head', 'mixamorighead', 'wolf3dhead']),
-    leftShoulder: findModelBone(bones, ['leftshoulder', 'mixamorigleftshoulder']),
-    leftArm: findModelBone(bones, ['leftarm', 'mixamorigleftarm', 'leftupperarm']),
-    leftForeArm: findModelBone(bones, ['leftforearm', 'mixamorigleftforearm', 'leftlowerarm']),
-    rightShoulder: findModelBone(bones, ['rightshoulder', 'mixamorigrightshoulder']),
-    rightArm: findModelBone(bones, ['rightarm', 'mixamorigrightarm', 'rightupperarm']),
-    rightForeArm: findModelBone(bones, ['rightforearm', 'mixamorigrightforearm', 'rightlowerarm']),
-    leftHand: findModelBone(bones, ['lefthand', 'mixamoriglefthand']),
-    rightHand: findModelBone(bones, ['righthand', 'mixamorigrighthand']),
-    leftUpLeg: findModelBone(bones, ['leftupleg', 'mixamorigleftupleg', 'leftthigh']),
-    leftLeg: findModelBone(bones, ['leftleg', 'mixamorigleftleg', 'leftcalf']),
-    rightUpLeg: findModelBone(bones, ['rightupleg', 'mixamorigrightupleg', 'rightthigh']),
-    rightLeg: findModelBone(bones, ['rightleg', 'mixamorigrightleg', 'rightcalf'])
-  };
-  map.spine ??= map.spine1 ?? map.spine2 ?? map.hips;
-  map.spine1 ??= map.spine2 ?? map.spine;
-  map.spine2 ??= map.spine1 ?? map.spine;
-  map.leftArm ??= map.leftShoulder;
-  map.rightArm ??= map.rightShoulder;
-  map.leftForeArm ??= map.leftArm;
-  map.rightForeArm ??= map.rightArm;
-  map.leftLeg ??= map.leftUpLeg;
-  map.rightLeg ??= map.rightUpLeg;
-  return map;
-}
-
-function applyLoadedHumanPose(seatHuman, timeSeconds, actionStrength = 0, knockStrength = 0) {
-  const { root, bones, rest, baseScale = 1 } = seatHuman;
-  rest.forEach((quat, bone) => bone.quaternion.copy(quat));
-  const breathe = Math.sin(timeSeconds * 1.1) * 0.018;
-  root.scale.setScalar(baseScale);
-
-  const actionType = seatHuman?.action?.type ?? 'idle';
-  const isPlaceAction = actionType === 'place';
-  const isKnockAction = actionType === 'knock';
-  const actionTarget = seatHuman?.action?.targetWorld;
-  let targetBiasY = -0.04;
-  let targetBiasZ = 0.18;
-  let forwardReach = 0;
-  if (actionTarget && seatHuman?.root?.parent?.worldToLocal) {
-    const targetLocal = seatHuman.root.parent.worldToLocal(actionTarget.clone());
-    const horizontal = Math.hypot(targetLocal.x, targetLocal.z) || 1;
-    targetBiasY = THREE.MathUtils.clamp(targetLocal.x / horizontal, -0.32, 0.32);
-    targetBiasZ = THREE.MathUtils.clamp(-targetLocal.z / horizontal, -0.34, 0.34);
-    const seatLocal = seatHuman.root.parent.worldToLocal(seatHuman.root.getWorldPosition(new THREE.Vector3()));
-    const dist = Math.hypot(targetLocal.x - seatLocal.x, targetLocal.z - seatLocal.z);
-    forwardReach = THREE.MathUtils.clamp((dist - 0.55) / 1.25, 0, 1);
-  }
-
-  const placeReach = THREE.MathUtils.clamp(actionStrength * (0.64 + forwardReach * 0.36), 0, 1);
-  const pickPhase = Math.sin(placeReach * Math.PI * 0.72);
-  const placePhase = Math.sin(placeReach * Math.PI);
-
-  composeModelBone(
-    rest,
-    bones.hips,
-    new THREE.Euler(-0.14 - knockStrength * 0.08 + forwardReach * 0.08 * placePhase, 0, 0, 'XYZ')
-  );
-  composeModelBone(
-    rest,
-    bones.spine,
-    new THREE.Euler(0.34 + breathe - knockStrength * 0.15 + forwardReach * 0.24 * placePhase, 0, 0, 'XYZ')
-  );
-  composeModelBone(rest, bones.spine1, new THREE.Euler(0.22 - knockStrength * 0.08, 0, 0, 'XYZ'));
-  composeModelBone(rest, bones.spine2, new THREE.Euler(0.12 - knockStrength * 0.03, 0, 0, 'XYZ'));
-  composeModelBone(rest, bones.neck, new THREE.Euler(-0.08, 0, 0, 'XYZ'));
-  composeModelBone(
-    rest,
-    bones.head,
-    new THREE.Euler(-0.08 + placePhase * 0.08, Math.sin(timeSeconds * 0.33) * 0.03, 0, 'XYZ')
-  );
-
-  composeModelBone(rest, bones.leftUpLeg, new THREE.Euler(-1.5, 0.13, 0.1, 'XYZ'));
-  composeModelBone(rest, bones.rightUpLeg, new THREE.Euler(-1.5, -0.13, -0.1, 'XYZ'));
-  composeModelBone(rest, bones.leftLeg, new THREE.Euler(1.56, 0, 0, 'XYZ'));
-  composeModelBone(rest, bones.rightLeg, new THREE.Euler(1.56, 0, 0, 'XYZ'));
-
-  const rightReach = isPlaceAction ? placePhase : 0;
-  const rightKnock = knockStrength;
-  // Baseline: both hands hold dominos from both side edges while seated.
-  composeModelBone(
-    rest,
-    bones.leftShoulder,
-    new THREE.Euler(-0.14 + pickPhase * 0.08, 0.04 + targetBiasY * 0.12, -0.34 + targetBiasZ * 0.1, 'XYZ')
-  );
-  composeModelBone(
-    rest,
-    bones.leftArm,
-    new THREE.Euler(-0.88 + pickPhase * 0.14, 0.16 + targetBiasY * 0.1, -0.38 + targetBiasZ * 0.08, 'XYZ')
-  );
-  composeModelBone(rest, bones.leftForeArm, new THREE.Euler(-1.14 + pickPhase * 0.1, 0.12, -0.16, 'XYZ'));
-  composeModelBone(rest, bones.leftHand, new THREE.Euler(-0.22 + pickPhase * 0.08, 0.08, -0.06, 'XYZ'));
-
-  composeModelBone(
-    rest,
-    bones.rightShoulder,
-    new THREE.Euler(
-      -0.18 + rightReach * 0.58 - rightKnock * 0.2 + pickPhase * 0.12,
-      -0.18 + targetBiasY * 0.52,
-      0.28 + targetBiasZ * 0.36,
-      'XYZ'
-    )
-  );
-  composeModelBone(
-    rest,
-    bones.rightArm,
-    new THREE.Euler(
-      -0.86 + rightReach * 1.78 + rightKnock * 1.06 + pickPhase * 0.3,
-      -0.2 - rightReach * 0.24 + targetBiasY * 0.4,
-      0.24 + targetBiasZ * 0.34,
-      'XYZ'
-    )
-  );
-  composeModelBone(
-    rest,
-    bones.rightForeArm,
-    new THREE.Euler(
-      -1.22 + rightReach * 1.4 + rightKnock * 1.65 + pickPhase * 0.12,
-      -0.12 + targetBiasY * 0.35,
-      0.14 + targetBiasZ * 0.2,
-      'XYZ'
-    )
-  );
-  composeModelBone(
-    rest,
-    bones.rightHand,
-    new THREE.Euler(-0.24 + rightReach * 0.7 + pickPhase * 0.12, 0.06 + targetBiasY * 0.22, -0.06, 'XYZ')
-  );
-  if (isKnockAction) {
-    composeModelBone(rest, bones.leftShoulder, new THREE.Euler(-0.18, 0.02, -0.2, 'XYZ'));
-    composeModelBone(rest, bones.leftArm, new THREE.Euler(-0.72, 0.08, -0.18, 'XYZ'));
-    composeModelBone(rest, bones.leftForeArm, new THREE.Euler(-0.92, 0.04, -0.1, 'XYZ'));
-  }
-}
-
-function createSeatedHumanFallbackTexture(primary = '#cdb8a0', secondary = '#8a6a4e') {
-  const size = 256;
-  const canvas = document.createElement('canvas');
-  canvas.width = size;
-  canvas.height = size;
-  const ctx = canvas.getContext('2d');
-  if (!ctx) return new THREE.CanvasTexture(canvas);
-  const grad = ctx.createLinearGradient(0, 0, size, size);
-  grad.addColorStop(0, primary);
-  grad.addColorStop(1, secondary);
-  ctx.fillStyle = grad;
-  ctx.fillRect(0, 0, size, size);
-  for (let i = 0; i < 180; i += 1) {
-    const x = (i * 53) % size;
-    const y = (i * 79) % size;
-    const w = 8 + ((i * 11) % 22);
-    const h = 4 + ((i * 7) % 14);
-    ctx.globalAlpha = 0.09 + (i % 4) * 0.06;
-    ctx.fillStyle = i % 2 ? 'rgba(255,255,255,0.75)' : 'rgba(0,0,0,0.55)';
-    ctx.fillRect(x, y, w, h);
-  }
-  ctx.globalAlpha = 1;
-  const tex = new THREE.CanvasTexture(canvas);
-  applySRGBColorSpace(tex);
-  tex.flipY = false;
-  tex.wrapS = THREE.RepeatWrapping;
-  tex.wrapT = THREE.RepeatWrapping;
-  tex.anisotropy = 8;
-  tex.needsUpdate = true;
-  return tex;
-}
-
-async function ensureHumanTemplate() {
-  if (seatedHumanTemplatePromise) return seatedHumanTemplatePromise;
-  seatedHumanTemplatePromise = (async () => {
-    const loader = createConfiguredGltfLoader();
-    loader.setCrossOrigin('anonymous');
-    const gltf = await loader.loadAsync(SEATED_HUMAN_MODEL_URL);
-    const root = gltf?.scene || gltf?.scenes?.[0];
-    if (!root) throw new Error('Missing seated human scene');
-    const skinTex = createSeatedHumanFallbackTexture('#d8c0a6', '#b48d6b');
-    const clothTex = createSeatedHumanFallbackTexture('#55739a', '#2c3f54');
-    const hairTex = createSeatedHumanFallbackTexture('#7b5d3f', '#3f2f20');
-    root.traverse((obj) => {
-      if (!obj?.isMesh) return;
-      obj.castShadow = true;
-      obj.receiveShadow = true;
-      obj.frustumCulled = false;
-      const meshName = `${obj.name || ''}`.toLowerCase();
-      const useSkin = /head|face|neck|ear|hand/.test(meshName);
-      const useHair = /hair|beard|mustache|moustache|eyebrow/.test(meshName);
-      const fallbackTex = useHair ? hairTex : useSkin ? skinTex : clothTex;
-      const mats = Array.isArray(obj.material) ? obj.material : obj.material ? [obj.material] : [];
-      mats.forEach((mat) => {
-        // Preserve original GLB texture set whenever it exists; only fill missing maps.
-        if (!mat?.map) mat.map = fallbackTex;
-        if (mat?.color?.setHex) mat.color.setHex(0xffffff);
-        if (mat?.map) applySRGBColorSpace(mat.map);
-        if (mat?.emissiveMap) applySRGBColorSpace(mat.emissiveMap);
-        mat.needsUpdate = true;
-      });
-    });
-    return { template: root };
-  })();
-  return seatedHumanTemplatePromise;
-}
-
-function clearSeatedHumans() {
-  while (seatedHumans.length) {
-    const seatHuman = seatedHumans.pop();
-    seatHuman?.root?.parent?.remove(seatHuman.root);
-    seatHuman?.root?.traverse?.((obj) => {
-      if (obj?.isMesh && obj.geometry?.dispose) obj.geometry.dispose();
-      const materials = Array.isArray(obj?.material) ? obj.material : [obj?.material];
-      materials.forEach((material) => material?.dispose?.());
-    });
-  }
-  seatFaceAnchors.length = 0;
-  seatCharacterHelpers.length = 0;
-}
-
-function createSeatCharacterHelper({ chairSize, seatBottomOffset }) {
-  const helper = new THREE.Object3D();
-  const seatY = chairSize.y - seatBottomOffset;
-  const seatDepth = SEATED_HUMAN_SEAT_Z_OFFSET;
-  helper.position.set(0, seatY + SEATED_HUMAN_SEAT_Y_OFFSET, seatDepth);
-  helper.userData = {
-    seatBottomOffset,
-    chairSize: chairSize.clone(),
-    seatY,
-    seatDepth
-  };
-  return helper;
-}
-
-function fitHumanToSeat(root, seatHelper, chairSize) {
-  const bounds = new THREE.Box3().setFromObject(root);
-  const size = bounds.getSize(new THREE.Vector3());
-  const baseHeight = Math.max(0.1, size.y, 1.74);
-  // Keep seated humans proportional to each chair so all seats match the Ludo-like layout.
-  const targetHeight = THREE.MathUtils.clamp(chairSize.y * 2.18, 1.5, 2.1);
-  const scaleFix = targetHeight / baseHeight;
-  root.scale.multiplyScalar(scaleFix);
-  root.position.copy(seatHelper.position);
-}
-
-function triggerSeatHumanAction(seatIndex, action = 'place', targetWorld = null) {
-  if (HUMAN_CHARACTER_DISABLED) return;
-  const seatHuman = seatedHumans[seatIndex];
-  if (!seatHuman) return;
-  const now = performance.now();
-  const actionTarget = targetWorld instanceof THREE.Vector3 ? targetWorld.clone() : null;
-  if (action === 'knock') {
-    seatHuman.action = {
-      type: 'knock',
-      startMs: now,
-      durationMs: 720,
-      targetWorld: actionTarget
-    };
-    return;
-  }
-  seatHuman.action = {
-    type: 'place',
-    startMs: now,
-    durationMs: 1050,
-    targetWorld: actionTarget
-  };
-}
-
-function syncSeatHumans(nowMs = performance.now()) {
-  if (HUMAN_CHARACTER_DISABLED) return;
-  if (!seatedHumans.length) return;
-  const nowSeconds = nowMs / 1000;
-  seatedHumans.forEach((seatHuman) => {
-    if (!seatHuman?.root) return;
-    let placeStrength = 0;
-    let knockStrength = 0;
-    if (seatHuman.action) {
-      const progress = Math.min(
-        1,
-        Math.max(0, (nowMs - seatHuman.action.startMs) / Math.max(1, seatHuman.action.durationMs))
-      );
-      if (seatHuman.action.type === 'place') {
-        const pickupPhase = THREE.MathUtils.smoothstep(progress, 0.04, 0.42);
-        const carryPhase = THREE.MathUtils.smoothstep(progress, 0.28, 0.78);
-        const placePhase = THREE.MathUtils.smoothstep(progress, 0.56, 1);
-        placeStrength = Math.max(0, pickupPhase * 0.62 + carryPhase * 0.55 + placePhase);
-      } else if (seatHuman.action.type === 'knock') {
-        knockStrength = Math.sin(progress * Math.PI * 3.4) * (1 - progress * 0.55);
-      }
-      if (progress >= 1) {
-        seatHuman.action = null;
-      }
-    }
-    applyLoadedHumanPose(seatHuman, nowSeconds, placeStrength, knockStrength);
-  });
-}
-
-async function placeSeatedHumans(seatBottomOffset, chairSize) {
-  if (HUMAN_CHARACTER_DISABLED) {
-    clearSeatedHumans();
-    return;
-  }
-  clearSeatedHumans();
-  let humanTemplateData = null;
-  try {
-    humanTemplateData = await ensureHumanTemplate();
-  } catch (error) {
-    console.warn('Ludo seated human model failed to load for Domino seats', error);
-    return;
-  }
-  CHAIR_SEAT_ANGLES.forEach((_angle, index) => {
-    const wrapper = chairs[index];
-    if (!wrapper) return;
-    const seatHelper = createSeatCharacterHelper({ chairSize, seatBottomOffset });
-    wrapper.add(seatHelper);
-    seatCharacterHelpers[index] = seatHelper;
-    const root = cloneSkinned(humanTemplateData.template);
-    root.rotation.y = SEATED_HUMAN_FACING_Y;
-    fitHumanToSeat(root, seatHelper, chairSize);
-    root.position.y += 0.045;
-    wrapper.add(root);
-    const faceAnchor = new THREE.Object3D();
-    faceAnchor.position.set(0, 0.62, 0.08);
-    root.add(faceAnchor);
-    seatFaceAnchors[index] = faceAnchor;
-    const seatHuman = {
-      root,
-      action: null
-    };
-
-    const bones = buildHumanBoneMap(root);
-    seatHuman.bones = bones;
-    seatHuman.rest = captureModelRestPose(root);
-    seatHuman.baseScale = 1;
-
-    seatedHumans[index] = seatHuman;
-    triggerSeatHumanAction(index, 'place');
-  });
-}
 
 function disposeChairResources(root) {
   root.traverse((child) => {
@@ -8132,9 +7715,8 @@ function placeChairsWithOption(option, chairData, token) {
   }
 
   const seatBottomOffset = -chairTemplateBounds.min.y;
-  const chairSize = chairTemplateBounds.getSize(new THREE.Vector3());
   const labelHeight = seatBottomOffset + chairTemplateBounds.max.y + 0.12;
-  const labelDepth = -chairSize.z * 0.35;
+  const labelDepth = -chairTemplateBounds.getSize(new THREE.Vector3()).z * 0.35;
 
   const seatAvatarSources = buildSeatAvatarSources(N);
 
@@ -8167,9 +7749,6 @@ function placeChairsWithOption(option, chairData, token) {
   });
 
   refreshSeatBadges(seatAvatarSources, buildSeatNames(N));
-  placeSeatedHumans(seatBottomOffset, chairSize).catch((error) => {
-    console.warn('Failed to place seated humans', error);
-  });
   syncArenaGroundToFurniture();
 }
 
@@ -9651,11 +9230,6 @@ function placeOnBoard(tile, side, options = {}) {
   } else {
     renderChain();
   }
-  triggerSeatHumanAction(
-    current,
-    'place',
-    new THREE.Vector3(segment.x, CHAIN_TILE_Y, segment.z)
-  );
   SFX.place();
   return { success: true, segment, end: updatedEnd };
 }
@@ -10728,7 +10302,6 @@ function schedulePassTurnAdvance(
   playerIndex = current,
   delayMs = PASS_TURN_ADVANCE_DELAY_MS
 ) {
-  triggerSeatHumanAction(playerIndex, 'knock');
   showPassBubble(playerIndex);
   if (pendingTurnAdvanceTimeout) {
     clearTimeout(pendingTurnAdvanceTimeout);
@@ -11171,7 +10744,6 @@ function shutdownDominoRoyal(reason = 'unknown') {
     anchoredSelfVideoElement = null;
     controls.enabled = false;
     scene.visible = false;
-    clearSeatedHumans();
     if (seatOverlay?.parentNode) {
       seatOverlay.parentNode.removeChild(seatOverlay);
     }
@@ -11214,7 +10786,6 @@ function tick(now) {
     updateEntrySequence(current);
     updateDrawAnimations(current);
     updatePlacementAnimations(current);
-    syncSeatHumans(current);
     updateWinnerHighlight(current);
     updateSeatBadgePositions();
     updateCameraLookRecentering();


### PR DESCRIPTION
### Motivation

- Restore the Domino Battle Royal experience to the state from two days ago by removing the recently added seated-human avatar pipeline so the game is Domino-only again.
- Eliminate the human-seat rendering/crash surface and keep seating, badges and chair theming working without the extra GLTF/rig/IK complexity.

### Description

- Restored the Domino runtime by reverting changes in `webapp/public/domino-royal-game.js` so the seated-human loader, skinned-clone, bone-map, pose application, IK and related helpers are removed. 
- Removed runtime calls and flows that placed or animated seated humans, including `placeSeatedHumans`, `syncSeatHumans`, `triggerSeatHumanAction` and their usage sites. 
- Kept and adjusted chair, badge and seat overlay code (including a small refactor to `labelDepth` calculation and seat-badge anchoring constants `HUMAN_SEAT_BADGE_BOTTOM_OFFSET`/`HUMAN_SEAT_BADGE_LEFT_OFFSET`) so UI anchors remain stable without human models. 
- Cleaned up disposal and shutdown paths to avoid referencing cleared human resources during `shutdownDominoRoyal` and render loop.

### Testing

- Ran syntax validation with `node --check webapp/public/domino-royal-game.js`, which completed successfully. 
- No additional automated unit or integration tests were executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edbc97b4c08329a865a77d9cbfce57)