### PR TITLE
Restore Domino Battle Royal pre-human-character behavior

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -7671,43 +7671,10 @@ const CHAIR_TEXTURE_PROPS = Object.freeze([
   'sheenColorMap',
   'sheenRoughnessMap'
 ]);
-const HUMAN_CHARACTER_DISABLED = false;
-const SEATED_HUMAN_MODEL_URL = 'https://threejs.org/examples/models/gltf/readyplayer.me.glb';
-// Keep Domino seated humans aligned to the same seated baseline used in Ludo Battle Royal.
-const SEATED_HUMAN_SEAT_Y_OFFSET = -1.42 * MODEL_SCALE * STOOL_SCALE;
-const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.2;
-const SEATED_HUMAN_FACING_Y = 0;
+const HUMAN_CHARACTER_DISABLED = true;
 const seatedHumans = [];
 const seatFaceAnchors = [];
 const seatCharacterHelpers = [];
-let seatedHumanTemplatePromise = null;
-
-function cloneSkinned(source) {
-  if (!source?.isObject3D) return source?.clone?.(true) ?? null;
-  const clone = source.clone(true);
-  const sourceSkinnedMeshes = [];
-  const cloneBonesByName = new Map();
-  const cloneSkinnedMeshes = [];
-
-  source.traverse((obj) => {
-    if (obj?.isSkinnedMesh) sourceSkinnedMeshes.push(obj);
-  });
-  clone.traverse((obj) => {
-    if (obj?.isBone && obj.name) cloneBonesByName.set(obj.name, obj);
-    if (obj?.isSkinnedMesh) cloneSkinnedMeshes.push(obj);
-  });
-
-  cloneSkinnedMeshes.forEach((mesh, index) => {
-    const sourceMesh = sourceSkinnedMeshes[index];
-    if (!sourceMesh?.skeleton) return;
-    const sourceBones = sourceMesh.skeleton.bones || [];
-    const cloneBones = sourceBones.map((bone) => cloneBonesByName.get(bone.name) || bone);
-    if (!cloneBones.length) return;
-    mesh.bind(new THREE.Skeleton(cloneBones, sourceMesh.skeleton.boneInverses), mesh.bindMatrix);
-  });
-
-  return clone;
-}
 
 function normalizeHumanBoneName(value = '') {
   return String(value).toLowerCase().replace(/[^a-z0-9]/g, '');
@@ -7787,72 +7754,42 @@ function applyLoadedHumanPose(seatHuman, timeSeconds, actionStrength = 0, knockS
   const breathe = Math.sin(timeSeconds * 1.1) * 0.018;
   root.scale.setScalar(baseScale);
 
-  const actionType = seatHuman?.action?.type ?? 'idle';
-  const isPlaceAction = actionType === 'place';
-  const isKnockAction = actionType === 'knock';
-  const actionTarget = seatHuman?.action?.targetWorld;
-  let targetBiasY = -0.04;
-  let targetBiasZ = 0.18;
-  let forwardReach = 0;
-  if (actionTarget && seatHuman?.root?.parent?.worldToLocal) {
-    const targetLocal = seatHuman.root.parent.worldToLocal(actionTarget.clone());
-    const horizontal = Math.hypot(targetLocal.x, targetLocal.z) || 1;
-    targetBiasY = THREE.MathUtils.clamp(targetLocal.x / horizontal, -0.32, 0.32);
-    targetBiasZ = THREE.MathUtils.clamp(-targetLocal.z / horizontal, -0.34, 0.34);
-    const seatLocal = seatHuman.root.parent.worldToLocal(seatHuman.root.getWorldPosition(new THREE.Vector3()));
-    const dist = Math.hypot(targetLocal.x - seatLocal.x, targetLocal.z - seatLocal.z);
-    forwardReach = THREE.MathUtils.clamp((dist - 0.55) / 1.25, 0, 1);
-  }
-
-  const placeReach = THREE.MathUtils.clamp(actionStrength * (0.64 + forwardReach * 0.36), 0, 1);
-  const pickPhase = Math.sin(placeReach * Math.PI * 0.72);
-  const placePhase = Math.sin(placeReach * Math.PI);
-
-  composeModelBone(
-    rest,
-    bones.hips,
-    new THREE.Euler(-0.14 - knockStrength * 0.08 + forwardReach * 0.08 * placePhase, 0, 0, 'XYZ')
-  );
-  composeModelBone(
-    rest,
-    bones.spine,
-    new THREE.Euler(0.34 + breathe - knockStrength * 0.15 + forwardReach * 0.24 * placePhase, 0, 0, 'XYZ')
-  );
+  composeModelBone(rest, bones.hips, new THREE.Euler(-0.12 - knockStrength * 0.08, 0, 0, 'XYZ'));
+  composeModelBone(rest, bones.spine, new THREE.Euler(0.34 + breathe - knockStrength * 0.15, 0, 0, 'XYZ'));
   composeModelBone(rest, bones.spine1, new THREE.Euler(0.22 - knockStrength * 0.08, 0, 0, 'XYZ'));
   composeModelBone(rest, bones.spine2, new THREE.Euler(0.12 - knockStrength * 0.03, 0, 0, 'XYZ'));
   composeModelBone(rest, bones.neck, new THREE.Euler(-0.08, 0, 0, 'XYZ'));
-  composeModelBone(
-    rest,
-    bones.head,
-    new THREE.Euler(-0.08 + placePhase * 0.08, Math.sin(timeSeconds * 0.33) * 0.03, 0, 'XYZ')
-  );
+  composeModelBone(rest, bones.head, new THREE.Euler(-0.08, Math.sin(timeSeconds * 0.33) * 0.03, 0, 'XYZ'));
 
   composeModelBone(rest, bones.leftUpLeg, new THREE.Euler(-1.5, 0.13, 0.1, 'XYZ'));
   composeModelBone(rest, bones.rightUpLeg, new THREE.Euler(-1.5, -0.13, -0.1, 'XYZ'));
   composeModelBone(rest, bones.leftLeg, new THREE.Euler(1.56, 0, 0, 'XYZ'));
   composeModelBone(rest, bones.rightLeg, new THREE.Euler(1.56, 0, 0, 'XYZ'));
 
-  const rightReach = isPlaceAction ? placePhase : 0;
+  const rightReach = actionStrength;
   const rightKnock = knockStrength;
-  // Baseline: both hands hold dominos from both side edges while seated.
-  composeModelBone(
-    rest,
-    bones.leftShoulder,
-    new THREE.Euler(-0.14 + pickPhase * 0.08, 0.04 + targetBiasY * 0.12, -0.34 + targetBiasZ * 0.1, 'XYZ')
-  );
-  composeModelBone(
-    rest,
-    bones.leftArm,
-    new THREE.Euler(-0.88 + pickPhase * 0.14, 0.16 + targetBiasY * 0.1, -0.38 + targetBiasZ * 0.08, 'XYZ')
-  );
-  composeModelBone(rest, bones.leftForeArm, new THREE.Euler(-1.14 + pickPhase * 0.1, 0.12, -0.16, 'XYZ'));
-  composeModelBone(rest, bones.leftHand, new THREE.Euler(-0.22 + pickPhase * 0.08, 0.08, -0.06, 'XYZ'));
+  // Baseline: both arms stay in a stable "holding dominos" seated pose.
+  composeModelBone(rest, bones.leftShoulder, new THREE.Euler(-0.14, 0.04, -0.34, 'XYZ'));
+  composeModelBone(rest, bones.leftArm, new THREE.Euler(-0.84, 0.18, -0.36, 'XYZ'));
+  composeModelBone(rest, bones.leftForeArm, new THREE.Euler(-1.1, 0.16, -0.14, 'XYZ'));
+  composeModelBone(rest, bones.leftHand, new THREE.Euler(-0.2, 0.08, -0.04, 'XYZ'));
+
+  let targetBiasY = -0.04;
+  let targetBiasZ = 0.18;
+  if (seatHuman?.action?.targetWorld && seatHuman?.root?.parent?.worldToLocal) {
+    const targetLocal = seatHuman.root.parent.worldToLocal(
+      seatHuman.action.targetWorld.clone()
+    );
+    const horizontal = Math.hypot(targetLocal.x, targetLocal.z) || 1;
+    targetBiasY = THREE.MathUtils.clamp(targetLocal.x / horizontal, -0.32, 0.32);
+    targetBiasZ = THREE.MathUtils.clamp(-targetLocal.z / horizontal, -0.34, 0.34);
+  }
 
   composeModelBone(
     rest,
     bones.rightShoulder,
     new THREE.Euler(
-      -0.18 + rightReach * 0.58 - rightKnock * 0.2 + pickPhase * 0.12,
+      -0.18 + rightReach * 0.58 - rightKnock * 0.2,
       -0.18 + targetBiasY * 0.52,
       0.28 + targetBiasZ * 0.36,
       'XYZ'
@@ -7862,7 +7799,7 @@ function applyLoadedHumanPose(seatHuman, timeSeconds, actionStrength = 0, knockS
     rest,
     bones.rightArm,
     new THREE.Euler(
-      -0.86 + rightReach * 1.78 + rightKnock * 1.06 + pickPhase * 0.3,
+      -0.86 + rightReach * 1.78 + rightKnock * 1.06,
       -0.2 - rightReach * 0.24 + targetBiasY * 0.4,
       0.24 + targetBiasZ * 0.34,
       'XYZ'
@@ -7872,7 +7809,7 @@ function applyLoadedHumanPose(seatHuman, timeSeconds, actionStrength = 0, knockS
     rest,
     bones.rightForeArm,
     new THREE.Euler(
-      -1.22 + rightReach * 1.4 + rightKnock * 1.65 + pickPhase * 0.12,
+      -1.22 + rightReach * 1.4 + rightKnock * 1.65,
       -0.12 + targetBiasY * 0.35,
       0.14 + targetBiasZ * 0.2,
       'XYZ'
@@ -7881,80 +7818,12 @@ function applyLoadedHumanPose(seatHuman, timeSeconds, actionStrength = 0, knockS
   composeModelBone(
     rest,
     bones.rightHand,
-    new THREE.Euler(-0.24 + rightReach * 0.7 + pickPhase * 0.12, 0.06 + targetBiasY * 0.22, -0.06, 'XYZ')
+    new THREE.Euler(-0.24 + rightReach * 0.7, 0.06 + targetBiasY * 0.22, -0.06, 'XYZ')
   );
-  if (isKnockAction) {
-    composeModelBone(rest, bones.leftShoulder, new THREE.Euler(-0.18, 0.02, -0.2, 'XYZ'));
-    composeModelBone(rest, bones.leftArm, new THREE.Euler(-0.72, 0.08, -0.18, 'XYZ'));
-    composeModelBone(rest, bones.leftForeArm, new THREE.Euler(-0.92, 0.04, -0.1, 'XYZ'));
-  }
-}
-
-function createSeatedHumanFallbackTexture(primary = '#cdb8a0', secondary = '#8a6a4e') {
-  const size = 256;
-  const canvas = document.createElement('canvas');
-  canvas.width = size;
-  canvas.height = size;
-  const ctx = canvas.getContext('2d');
-  if (!ctx) return new THREE.CanvasTexture(canvas);
-  const grad = ctx.createLinearGradient(0, 0, size, size);
-  grad.addColorStop(0, primary);
-  grad.addColorStop(1, secondary);
-  ctx.fillStyle = grad;
-  ctx.fillRect(0, 0, size, size);
-  for (let i = 0; i < 180; i += 1) {
-    const x = (i * 53) % size;
-    const y = (i * 79) % size;
-    const w = 8 + ((i * 11) % 22);
-    const h = 4 + ((i * 7) % 14);
-    ctx.globalAlpha = 0.09 + (i % 4) * 0.06;
-    ctx.fillStyle = i % 2 ? 'rgba(255,255,255,0.75)' : 'rgba(0,0,0,0.55)';
-    ctx.fillRect(x, y, w, h);
-  }
-  ctx.globalAlpha = 1;
-  const tex = new THREE.CanvasTexture(canvas);
-  applySRGBColorSpace(tex);
-  tex.flipY = false;
-  tex.wrapS = THREE.RepeatWrapping;
-  tex.wrapT = THREE.RepeatWrapping;
-  tex.anisotropy = 8;
-  tex.needsUpdate = true;
-  return tex;
 }
 
 async function ensureHumanTemplate() {
-  if (seatedHumanTemplatePromise) return seatedHumanTemplatePromise;
-  seatedHumanTemplatePromise = (async () => {
-    const loader = createConfiguredGltfLoader();
-    loader.setCrossOrigin('anonymous');
-    const gltf = await loader.loadAsync(SEATED_HUMAN_MODEL_URL);
-    const root = gltf?.scene || gltf?.scenes?.[0];
-    if (!root) throw new Error('Missing seated human scene');
-    const skinTex = createSeatedHumanFallbackTexture('#d8c0a6', '#b48d6b');
-    const clothTex = createSeatedHumanFallbackTexture('#55739a', '#2c3f54');
-    const hairTex = createSeatedHumanFallbackTexture('#7b5d3f', '#3f2f20');
-    root.traverse((obj) => {
-      if (!obj?.isMesh) return;
-      obj.castShadow = true;
-      obj.receiveShadow = true;
-      obj.frustumCulled = false;
-      const meshName = `${obj.name || ''}`.toLowerCase();
-      const useSkin = /head|face|neck|ear|hand/.test(meshName);
-      const useHair = /hair|beard|mustache|moustache|eyebrow/.test(meshName);
-      const fallbackTex = useHair ? hairTex : useSkin ? skinTex : clothTex;
-      const mats = Array.isArray(obj.material) ? obj.material : obj.material ? [obj.material] : [];
-      mats.forEach((mat) => {
-        // Preserve original GLB texture set whenever it exists; only fill missing maps.
-        if (!mat?.map) mat.map = fallbackTex;
-        if (mat?.color?.setHex) mat.color.setHex(0xffffff);
-        if (mat?.map) applySRGBColorSpace(mat.map);
-        if (mat?.emissiveMap) applySRGBColorSpace(mat.emissiveMap);
-        mat.needsUpdate = true;
-      });
-    });
-    return { template: root };
-  })();
-  return seatedHumanTemplatePromise;
+  throw new Error('Domino Royal seated human character is disabled');
 }
 
 function clearSeatedHumans() {
@@ -7974,8 +7843,8 @@ function clearSeatedHumans() {
 function createSeatCharacterHelper({ chairSize, seatBottomOffset }) {
   const helper = new THREE.Object3D();
   const seatY = chairSize.y - seatBottomOffset;
-  const seatDepth = SEATED_HUMAN_SEAT_Z_OFFSET;
-  helper.position.set(0, seatY + SEATED_HUMAN_SEAT_Y_OFFSET, seatDepth);
+  const seatDepth = chairSize.z * -0.2;
+  helper.position.set(0, seatY + -0.125 * MODEL_SCALE * STOOL_SCALE, seatDepth);
   helper.userData = {
     seatBottomOffset,
     chairSize: chairSize.clone(),
@@ -7988,9 +7857,17 @@ function createSeatCharacterHelper({ chairSize, seatBottomOffset }) {
 function fitHumanToSeat(root, seatHelper, chairSize) {
   const bounds = new THREE.Box3().setFromObject(root);
   const size = bounds.getSize(new THREE.Vector3());
-  const baseHeight = Math.max(0.1, size.y, 1.74);
-  // Keep seated humans proportional to each chair so all seats match the Ludo-like layout.
-  const targetHeight = THREE.MathUtils.clamp(chairSize.y * 2.18, 1.5, 2.1);
+  const baseHeight = Math.max(
+    0.1,
+    size.y,
+    1.74
+  );
+  const targetHeightFromChair = Math.max(
+    0.9,
+    chairSize.y * 2.7 * 1.02
+  );
+  const targetHeightFromLudo = 1.74 * 3.24;
+  const targetHeight = Math.max(targetHeightFromChair, targetHeightFromLudo);
   const scaleFix = targetHeight / baseHeight;
   root.scale.multiplyScalar(scaleFix);
   root.position.copy(seatHelper.position);
@@ -8014,7 +7891,7 @@ function triggerSeatHumanAction(seatIndex, action = 'place', targetWorld = null)
   seatHuman.action = {
     type: 'place',
     startMs: now,
-    durationMs: 1050,
+    durationMs: 950,
     targetWorld: actionTarget
   };
 }
@@ -8033,10 +7910,7 @@ function syncSeatHumans(nowMs = performance.now()) {
         Math.max(0, (nowMs - seatHuman.action.startMs) / Math.max(1, seatHuman.action.durationMs))
       );
       if (seatHuman.action.type === 'place') {
-        const pickupPhase = THREE.MathUtils.smoothstep(progress, 0.04, 0.42);
-        const carryPhase = THREE.MathUtils.smoothstep(progress, 0.28, 0.78);
-        const placePhase = THREE.MathUtils.smoothstep(progress, 0.56, 1);
-        placeStrength = Math.max(0, pickupPhase * 0.62 + carryPhase * 0.55 + placePhase);
+        placeStrength = Math.sin(progress * Math.PI);
       } else if (seatHuman.action.type === 'knock') {
         knockStrength = Math.sin(progress * Math.PI * 3.4) * (1 - progress * 0.55);
       }
@@ -8067,8 +7941,8 @@ async function placeSeatedHumans(seatBottomOffset, chairSize) {
     const seatHelper = createSeatCharacterHelper({ chairSize, seatBottomOffset });
     wrapper.add(seatHelper);
     seatCharacterHelpers[index] = seatHelper;
-    const root = cloneSkinned(humanTemplateData.template);
-    root.rotation.y = SEATED_HUMAN_FACING_Y;
+    const root = humanTemplateData.template.clone(true);
+    root.rotation.y = Math.PI;
     fitHumanToSeat(root, seatHelper, chairSize);
     root.position.y += 0.045;
     wrapper.add(root);


### PR DESCRIPTION
### Motivation
- Revert the recent seated-human character additions so the Domino Battle Royal game behaves the same as before the human character was introduced.

### Description
- Re-disabled Domino seated humans by setting `HUMAN_CHARACTER_DISABLED = true` in `webapp/public/domino-royal-game.js`.
- Removed live human-model loading and helper code paths by making `ensureHumanTemplate` throw and deleting the `cloneSkinned`/fallback texture/template logic from the Domino flow.
- Reverted pose and seat-helper changes so Domino seat offsets, pose baseline and placement logic match the pre-human-character implementation in `placeSeatedHumans` and related functions.
- Kept all changes scoped to `webapp/public/domino-royal-game.js` to avoid impacting other games.

### Testing
- No automated test suite was executed for this targeted revert.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edbc97b4c08329a865a77d9cbfce57)