### PR TITLE
Refine seated-human pick/place animations, add contact IK and finger helpers, and adjust portrait framing

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -393,9 +393,9 @@ const CHAIR_SCALE = 0.96 * LAYOUT_SCALE_FACTOR * TABLE_LAYOUT_SCALE_FACTOR;
 const CHAIR_WIDTH_SCALE = 0.9; // Slightly widen/deepen chairs so they read larger in portrait.
 const CHAIR_VERTICAL_OFFSET = -0.065 * MODEL_SCALE;
 const CHAIR_CLEARANCE = AI_CHAIR_GAP;
-const PLAYER_CHAIR_EXTRA_CLEARANCE = 0.08 * MODEL_SCALE; // Pull local seat slightly farther from the table for clearer portrait framing.
-const OPPONENT_CHAIR_EXTRA_CLEARANCE = 0.46 * MODEL_SCALE; // Pull opponent seat a bit farther from the table while preserving top-screen spacing.
-const CHAIR_TABLE_PUSHBACK = 0.12 * MODEL_SCALE;
+const PLAYER_CHAIR_EXTRA_CLEARANCE = 0.01 * MODEL_SCALE; // Keep local chair close so legs visually approach the table edge.
+const OPPONENT_CHAIR_EXTRA_CLEARANCE = 0.08 * MODEL_SCALE; // Keep opponent chair close too, with only a small gap.
+const CHAIR_TABLE_PUSHBACK = 0.04 * MODEL_SCALE;
 const CHAIR_TABLE_GAP_MIN = 0.08 * MODEL_SCALE;
 const CHAIR_TABLE_GAP_MAX = 0.42 * MODEL_SCALE;
 const CHAIR_TABLE_SHAPE_BIAS = 0.18 * MODEL_SCALE;
@@ -419,7 +419,7 @@ const FALLBACK_SEAT_POSITIONS = [
 ];
 const CAMERA_WHEEL_FACTOR = ARENA_CAMERA_DEFAULTS.wheelDeltaFactor;
 const CAMERA_PULL_FORWARD_MIN = THREE.MathUtils.degToRad(15);
-const CAMERA_CAPTURE_VIEW_UPWARD_BIAS = THREE.MathUtils.degToRad(10); // push forced 3D animation camera a bit higher for stronger down-board framing
+const CAMERA_CAPTURE_VIEW_UPWARD_BIAS = THREE.MathUtils.degToRad(15); // raise forced 3D animation camera for a stronger portrait top-down feel.
 const CAMERA_CAPTURE_VIEW_RADIUS_SCALE = 0.95; // move forced 3D animation camera slightly closer during capture
 const CAMERA_CAPTURE_BOTTOM_AVATAR_SCREEN_OFFSET = 6; // keep local player's avatar lower so chair/animation view stays clear
 const SAND_TIMER_RADIUS_FACTOR = 0.68;
@@ -430,19 +430,19 @@ const SEATED_HUMAN_BASE_HEIGHT = 1.74;
 const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.55;
 const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 4.32;
 const SEATED_HUMAN_SEAT_Y_OFFSET = -0.78 * MODEL_SCALE * STOOL_SCALE;
-const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.2;
+const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.05;
 const SEATED_HUMAN_FACING_Y = 0;
 const SEATED_HUMAN_PICK_LIFT_HEIGHT = 0.24;
-const SEATED_HUMAN_HAND_PIECE_FORWARD = 0.018;
+const SEATED_HUMAN_HAND_PIECE_FORWARD = 0.012;
 const PLAYER_VIEW_SEAT_THETA = Math.PI / 2;
-const PLAYER_VIEW_CAMERA_BACK_OFFSET_PORTRAIT = 1.72;
+const PLAYER_VIEW_CAMERA_BACK_OFFSET_PORTRAIT = 1.68;
 const PLAYER_VIEW_CAMERA_BACK_OFFSET_LANDSCAPE = 1.34;
-const PLAYER_VIEW_CAMERA_FORWARD_OFFSET_PORTRAIT = 0.52;
+const PLAYER_VIEW_CAMERA_FORWARD_OFFSET_PORTRAIT = 0.6;
 const PLAYER_VIEW_CAMERA_FORWARD_OFFSET_LANDSCAPE = 0.68;
-const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_PORTRAIT = 1.16;
+const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_PORTRAIT = 1.34;
 const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_LANDSCAPE = 0.78;
 const PLAYER_VIEW_LOOK_TARGET_FORWARD_BIAS = -BOARD.tile * BOARD_SCALE * 0.3;
-const TABLE_BOTTOM_PLAYER_BIAS_Z = BOARD.tile * BOARD_SCALE * 0.64; // Push board/chairs/avatars visually lower on portrait screens.
+const TABLE_BOTTOM_PLAYER_BIAS_Z = BOARD.tile * BOARD_SCALE * 1.02; // Push board/chairs/avatars further downward on portrait screens to match the reference framing.
 const FPV_FACE_FORWARD_OFFSET = 0.08; // keep camera very close and centered in front of the face.
 const FPV_FACE_UP_OFFSET = 0.015; // tiny vertical lift to avoid clipping while staying face-level.
 const FPV_HEAD_FOLLOW_SMOOTHING = 0.78;
@@ -456,6 +456,11 @@ const SEATED_HUMAN_HAND_DROP_CLEARANCE = 0;
 const SEATED_HUMAN_CONTACT_HELPERS_ENABLED = true;
 const SEATED_HUMAN_HAND_HELPER_RADIUS = 0.018;
 const SEATED_HUMAN_PIECE_HELPER_RADIUS = 0.02;
+const SEATED_HUMAN_FINGER_HELPER_RADIUS = 0.012;
+const SEATED_HUMAN_REACH_FORWARD_GAIN = 0.32;
+const SEATED_HUMAN_REACH_SIDE_GAIN = 0.22;
+const SEATED_HUMAN_GRIP_CONTACT_BLEND = 0.68;
+const SEATED_HUMAN_CONTACT_IK_STRENGTH = 0.58;
 
 
 function resolveChairDistanceForDirection(tableInfo, direction, seatDepth = SEAT_DEPTH) {
@@ -496,38 +501,36 @@ function getThreeFingerGripWorldPosition(rig) {
 
 function createSeatedHumanContactHelpers() {
   if (!SEATED_HUMAN_CONTACT_HELPERS_ENABLED) return null;
-  const handHelper = new THREE.Mesh(
-    new THREE.SphereGeometry(SEATED_HUMAN_HAND_HELPER_RADIUS, 16, 16),
-    new THREE.MeshBasicMaterial({
-      color: 0x00d4ff,
-      transparent: true,
-      opacity: 0.95,
-      depthWrite: false
-    })
-  );
-  const pieceHelper = new THREE.Mesh(
-    new THREE.SphereGeometry(SEATED_HUMAN_PIECE_HELPER_RADIUS, 16, 16),
-    new THREE.MeshBasicMaterial({
-      color: 0xffbf00,
-      transparent: true,
-      opacity: 0.95,
-      depthWrite: false
-    })
-  );
-  handHelper.renderOrder = 2500;
-  pieceHelper.renderOrder = 2500;
-  return { handHelper, pieceHelper };
+  const createHelperMesh = (radius, color) =>
+    new THREE.Mesh(
+      new THREE.SphereGeometry(radius, 16, 16),
+      new THREE.MeshBasicMaterial({
+        color,
+        transparent: true,
+        opacity: 0.75,
+        depthWrite: false
+      })
+    );
+  const handHelper = createHelperMesh(SEATED_HUMAN_HAND_HELPER_RADIUS, 0x00d4ff);
+  const pieceHelper = createHelperMesh(SEATED_HUMAN_PIECE_HELPER_RADIUS, 0xffbf00);
+  const thumbHelper = createHelperMesh(SEATED_HUMAN_FINGER_HELPER_RADIUS, 0xff5f8a);
+  const indexHelper = createHelperMesh(SEATED_HUMAN_FINGER_HELPER_RADIUS, 0x7df9ff);
+  const middleHelper = createHelperMesh(SEATED_HUMAN_FINGER_HELPER_RADIUS, 0x66ff88);
+  [handHelper, pieceHelper, thumbHelper, indexHelper, middleHelper].forEach((helper) => {
+    helper.renderOrder = 2500;
+    helper.visible = false;
+  });
+  return { handHelper, pieceHelper, thumbHelper, indexHelper, middleHelper };
 }
 
 function disposeSeatedHumanMoveAction(action) {
   if (!action) return;
-  const { handHelper, pieceHelper } = action;
-  handHelper?.parent?.remove(handHelper);
-  pieceHelper?.parent?.remove(pieceHelper);
-  handHelper?.geometry?.dispose?.();
-  handHelper?.material?.dispose?.();
-  pieceHelper?.geometry?.dispose?.();
-  pieceHelper?.material?.dispose?.();
+  ['handHelper', 'pieceHelper', 'thumbHelper', 'indexHelper', 'middleHelper'].forEach((key) => {
+    const helper = action[key];
+    helper?.parent?.remove(helper);
+    helper?.geometry?.dispose?.();
+    helper?.material?.dispose?.();
+  });
 }
 
 function detectCoarsePointer() {
@@ -687,6 +690,32 @@ function applyRightHandGrip(rig, gripAmount = 0) {
   });
 }
 
+function rotateBoneTowardTarget(rig, bone, endBone, targetWorld, strength = 0.5) {
+  if (!rig || !bone || !endBone || !targetWorld) return;
+  const axisFrom = endBone.getWorldPosition(new THREE.Vector3()).sub(
+    bone.getWorldPosition(new THREE.Vector3())
+  );
+  const axisTo = targetWorld.clone().sub(bone.getWorldPosition(new THREE.Vector3()));
+  if (axisFrom.lengthSq() < 1e-6 || axisTo.lengthSq() < 1e-6) return;
+  axisFrom.normalize();
+  axisTo.normalize();
+  const deltaQuat = new THREE.Quaternion().setFromUnitVectors(axisFrom, axisTo);
+  const blendQuat = new THREE.Quaternion().slerpQuaternions(
+    new THREE.Quaternion(),
+    deltaQuat,
+    THREE.MathUtils.clamp(strength, 0, 1)
+  );
+  bone.quaternion.premultiply(blendQuat);
+  bone.updateMatrixWorld(true);
+}
+
+function applyRightArmContactIK(rig, targetWorld, strength = 0.5) {
+  if (!rig?.rightHand || !targetWorld) return;
+  rotateBoneTowardTarget(rig, rig.rightUpperArm, rig.rightHand, targetWorld, strength * 0.62);
+  rotateBoneTowardTarget(rig, rig.rightForeArm, rig.rightHand, targetWorld, strength * 0.9);
+  rotateBoneTowardTarget(rig, rig.rightHand, rig.rightMiddle?.[rig.rightMiddle.length - 1], targetWorld, strength * 0.4);
+}
+
 function createSeatedHumanFallbackTexture(primary = '#cdb8a0', secondary = '#8a6a4e') {
   const size = 256;
   const canvas = document.createElement('canvas');
@@ -719,7 +748,7 @@ function createSeatedHumanFallbackTexture(primary = '#cdb8a0', secondary = '#8a6
   return tex;
 }
 
-function applySeatedHumanPose(rig, mode = 'idle', intensity = 1, handGrip = 0) {
+function applySeatedHumanPose(rig, mode = 'idle', intensity = 1, handGrip = 0, motionProfile = null) {
   if (!rig) return;
   resetBoneRig(rig);
   const t = smooth01(intensity);
@@ -755,6 +784,8 @@ function applySeatedHumanPose(rig, mode = 'idle', intensity = 1, handGrip = 0) {
   let wristZ = 0.02;
   let chestX = 0.16;
   let headX = -0.03;
+  const forwardReach = clamp01(motionProfile?.forwardReach, 0);
+  const sideReach = THREE.MathUtils.clamp(motionProfile?.sideReach ?? 0, -1, 1);
 
   if (mode === 'reachPiece') {
     shoulderX = THREE.MathUtils.lerp(shoulderX, -0.92, t);
@@ -805,6 +836,19 @@ function applySeatedHumanPose(rig, mode = 'idle', intensity = 1, handGrip = 0) {
     chestX = THREE.MathUtils.lerp(chestX, 0.3, t);
     headX = THREE.MathUtils.lerp(headX, 0.11, t);
   }
+
+  const reachForwardDelta = forwardReach * SEATED_HUMAN_REACH_FORWARD_GAIN;
+  const reachSideDelta = sideReach * SEATED_HUMAN_REACH_SIDE_GAIN;
+  shoulderX = THREE.MathUtils.lerp(shoulderX, shoulderX - reachForwardDelta, t);
+  shoulderY = THREE.MathUtils.lerp(shoulderY, shoulderY + reachSideDelta * 0.32, t);
+  shoulderZ = THREE.MathUtils.lerp(shoulderZ, shoulderZ - reachSideDelta * 0.5, t);
+  forearmX = THREE.MathUtils.lerp(forearmX, forearmX - reachForwardDelta * 0.88, t);
+  forearmY = THREE.MathUtils.lerp(forearmY, forearmY + reachSideDelta * 0.22, t);
+  forearmZ = THREE.MathUtils.lerp(forearmZ, forearmZ - reachSideDelta * 0.36, t);
+  wristY = THREE.MathUtils.lerp(wristY, wristY + reachSideDelta * 0.2, t);
+  wristZ = THREE.MathUtils.lerp(wristZ, wristZ - reachSideDelta * 0.16, t);
+  chestX = THREE.MathUtils.lerp(chestX, chestX + reachForwardDelta * 0.5, t);
+  headX = THREE.MathUtils.lerp(headX, headX + reachForwardDelta * 0.22, t);
 
   addBoneRot(rig, rig.chest, chestX, 0, 0);
   addBoneRot(rig, rig.head, headX, 0, 0);
@@ -12399,6 +12443,10 @@ function Chess3D({
       if (useHumanHandMove) {
         const nowMs = performance.now();
         const liveFrom = m.getWorldPosition(new THREE.Vector3());
+        const normalizedFromForwardReach = moverSeatIndex === 0 ? 1 - sel.r / 7 : sel.r / 7;
+        const normalizedToForwardReach = moverSeatIndex === 0 ? 1 - rr / 7 : rr / 7;
+        const forwardReach = clamp01((normalizedFromForwardReach + normalizedToForwardReach) * 0.5);
+        const sideReach = THREE.MathUtils.clamp(((cc + sel.c) * 0.5 - 3.5) / 3.5, -1, 1);
         const existingAction = seatedHumanMoveActionsRef.current.get(moverSeatIndex);
         if (existingAction) {
           disposeSeatedHumanMoveAction(existingAction);
@@ -12410,6 +12458,9 @@ function Chess3D({
           to: toWorldPos.clone(),
           toSquare: { r: rr, c: cc },
           isCapture: Boolean(capturedPiece),
+          forwardReach,
+          sideReach,
+          gripOffset: null,
           startMs: nowMs + Math.max(0, moveDelayMs),
           durationMs: SEATED_HUMAN_MOVE_DURATION_MS,
           handHelper: null,
@@ -13421,22 +13472,39 @@ function Chess3D({
             intensity = clamp01((u - carryPhaseEnd) / (1 - carryPhaseEnd));
             grip = action.isCapture ? 1 - intensity * 0.2 : 1 - intensity * 0.9;
           }
-          applySeatedHumanPose(entry.rig, mode, intensity, grip);
+          applySeatedHumanPose(entry.rig, mode, intensity, grip, {
+            forwardReach: action.forwardReach,
+            sideReach: action.sideReach
+          });
           if (action?.mesh) {
             if (SEATED_HUMAN_CONTACT_HELPERS_ENABLED && !action.handHelper && !action.pieceHelper) {
               const helpers = createSeatedHumanContactHelpers();
               if (helpers) {
                 action.handHelper = helpers.handHelper;
                 action.pieceHelper = helpers.pieceHelper;
+                action.thumbHelper = helpers.thumbHelper;
+                action.indexHelper = helpers.indexHelper;
+                action.middleHelper = helpers.middleHelper;
                 scene.add(helpers.handHelper);
                 scene.add(helpers.pieceHelper);
+                scene.add(helpers.thumbHelper);
+                scene.add(helpers.indexHelper);
+                scene.add(helpers.middleHelper);
               }
             }
-            const gripWorld =
+            const thumbTip = entry.rig.rightThumb?.[entry.rig.rightThumb.length - 1] ?? null;
+            const indexTip = entry.rig.rightIndex?.[entry.rig.rightIndex.length - 1] ?? null;
+            const middleTip = entry.rig.rightMiddle?.[entry.rig.rightMiddle.length - 1] ?? null;
+            const thumbWorld = thumbTip?.getWorldPosition?.(new THREE.Vector3()) ?? null;
+            const indexWorld = indexTip?.getWorldPosition?.(new THREE.Vector3()) ?? null;
+            const middleWorld = middleTip?.getWorldPosition?.(new THREE.Vector3()) ?? null;
+            const pinchWorld =
+              averageBoneWorldPosition([thumbTip, indexTip, middleTip].filter(Boolean)) ||
               getThreeFingerGripWorldPosition(entry.rig) ||
               (entry.rig.rightHand
                 ? entry.rig.rightHand.getWorldPosition(new THREE.Vector3())
                 : action.from.clone());
+            const gripWorld = pinchWorld.clone();
             const holdWorld = gripWorld.clone();
             holdWorld.y += SEATED_HUMAN_HAND_GRIP_HEIGHT;
             holdWorld.z +=
@@ -13451,30 +13519,45 @@ function Chess3D({
             liftedFrom.y += SEATED_HUMAN_PICK_LIFT_HEIGHT;
             const liftedTo = liveTo.clone();
             liftedTo.y += SEATED_HUMAN_PICK_LIFT_HEIGHT;
+            let handTarget = liveFrom.clone();
             if (u < SEATED_HUMAN_PICKUP_PHASE_END) {
               const pickupT = smoothEase(clamp01(u / SEATED_HUMAN_PICKUP_PHASE_END));
-              action.mesh.position.lerpVectors(liveFrom, liftedFrom, pickupT);
+              handTarget.lerpVectors(liveFrom, liftedFrom, pickupT);
+              action.mesh.position.copy(handTarget);
             } else if (u < 0.44) {
               const gripT = smoothEase(
                 clamp01((u - SEATED_HUMAN_PICKUP_PHASE_END) / (0.44 - SEATED_HUMAN_PICKUP_PHASE_END))
               );
-              action.mesh.position.lerpVectors(liftedFrom, holdWorld, gripT);
+              const blendedGrip = liveFrom.clone().lerp(holdWorld, SEATED_HUMAN_GRIP_CONTACT_BLEND);
+              handTarget.lerpVectors(liftedFrom, blendedGrip, gripT);
+              action.mesh.position.copy(handTarget);
+              if (!action.gripOffset && gripT >= 0.96) {
+                action.gripOffset = action.mesh.position.clone().sub(holdWorld);
+              }
             } else if (u < carryPhaseEnd) {
               const carryT = smoothEase(
                 clamp01((u - 0.44) / (carryPhaseEnd - 0.44))
               );
-              const carryTarget = holdWorld.clone().lerp(liftedTo, carryT);
+              const gripOffset = action.gripOffset || new THREE.Vector3();
+              const gripContact = holdWorld.clone().add(gripOffset);
+              const carryTarget = gripContact.clone().lerp(liftedTo, carryT);
               carryTarget.y = Math.max(carryTarget.y, liftedFrom.y * (1 - carryT) + liftedTo.y * carryT);
+              handTarget.copy(carryTarget);
               action.mesh.position.copy(carryTarget);
             } else {
               const dropT = clamp01((u - carryPhaseEnd) / (1 - carryPhaseEnd));
               const easedDropT = smoothEase(dropT);
               const landing = liveTo.clone();
               landing.y += SEATED_HUMAN_HAND_DROP_CLEARANCE;
-              action.mesh.position.lerpVectors(liftedTo, landing, easedDropT);
+              handTarget.lerpVectors(liftedTo, landing, easedDropT);
+              action.mesh.position.copy(handTarget);
             }
+            applyRightArmContactIK(entry.rig, handTarget, SEATED_HUMAN_CONTACT_IK_STRENGTH);
             if (action.handHelper) action.handHelper.position.copy(holdWorld);
             if (action.pieceHelper) action.pieceHelper.position.copy(action.mesh.position);
+            if (action.thumbHelper && thumbWorld) action.thumbHelper.position.copy(thumbWorld);
+            if (action.indexHelper && indexWorld) action.indexHelper.position.copy(indexWorld);
+            if (action.middleHelper && middleWorld) action.middleHelper.position.copy(middleWorld);
           }
           if (u >= 1) {
             if (action?.mesh) action.mesh.position.copy(action.to);


### PR DESCRIPTION
### Motivation
- Improve portrait-mode framing and chair/table spacing so avatars and boards align better with reference composition.
- Make pick/grab/carry/place animations more physically believable by adding contact helpers, grip blending, and arm IK to guide the hand to the piece.
- Provide small visual debug helpers for fingers to enable more accurate contact placement and to stabilize grips across animations.

### Description
- Tuned several layout and camera constants (chair clearances, camera capture bias, human seat offsets, table bias, and camera offsets) to improve portrait framing and chair proximity.
- Added new configuration constants: `SEATED_HUMAN_FINGER_HELPER_RADIUS`, `SEATED_HUMAN_REACH_FORWARD_GAIN`, `SEATED_HUMAN_REACH_SIDE_GAIN`, `SEATED_HUMAN_GRIP_CONTACT_BLEND`, and `SEATED_HUMAN_CONTACT_IK_STRENGTH` to parameterize reach and contact behavior.
- Reworked contact helper creation in `createSeatedHumanContactHelpers` to produce reusable helper meshes including thumb/index/middle helpers and reduced opacity, and updated `disposeSeatedHumanMoveAction` to generically remove/dispose all helper meshes.
- Implemented `rotateBoneTowardTarget` and `applyRightArmContactIK` to orient upper arm/forearm/hand toward a target world position, and integrated these into the move animation to drive arm IK toward the computed hand target.
- Extended `applySeatedHumanPose` to accept a `motionProfile` and apply forward/side reach deltas to shoulders/forearm/wrist/head, and wired per-move `forwardReach`/`sideReach` into pose application so reach is derived from source/target squares.
- Improved move animation handling to compute pinch/three-finger/grip positions using thumb/index/middle tips, maintain a `gripOffset` once contact is established, blend mesh positions with `SEATED_HUMAN_GRIP_CONTACT_BLEND`, and apply IK each frame to better align the arm to the carried piece while updating helper mesh positions.

### Testing
- Ran the project unit and integration test suites via `yarn test` and no failures were reported.
- Verified linting and type checks with `yarn lint` and `yarn build` which completed successfully and produced a working bundle for manual smoke testing of seated animations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edafac99108329bbafdb1f199f5363)