### PR TITLE
Add weapon rack, firearm capture animations, and quick-swap UI to LudoBattleRoyal

### DIFF
--- a/webapp/src/config/ludoBattleOptions.js
+++ b/webapp/src/config/ludoBattleOptions.js
@@ -121,6 +121,36 @@ export const CAPTURE_ANIMATION_OPTIONS = Object.freeze([
     id: 'helicopterAttack',
     label: 'Helicopter Strike',
     description: 'Attack helicopter run that launches twin missiles on a jet-style path.'
+  },
+  {
+    id: 'glockSidearmAttack',
+    label: 'Glock Sidearm',
+    description: 'Pick the Glock from the table, aim, and fire before taking the tile.'
+  },
+  {
+    id: 'pistolSidearmAttack',
+    label: 'Pistol Sidearm',
+    description: 'Classic pistol takedown sequence with table pickup and close shot.'
+  },
+  {
+    id: 'assaultRifleAttack',
+    label: 'Assault Rifle',
+    description: 'AR burst capture with a short aim hold before advancing to the target tile.'
+  },
+  {
+    id: 'uziSprayAttack',
+    label: 'Uzi Spray',
+    description: 'Fast SMG capture variation inspired by Tirana 2040 Uzi loadout.'
+  },
+  {
+    id: 'ak47VolleyAttack',
+    label: 'AK-47 Volley',
+    description: 'Heavy AK-style capture volley while preserving existing vehicle attacks.'
+  },
+  {
+    id: 'grenadeBlastAttack',
+    label: 'Grenade Blast',
+    description: 'Grenade-style capture with quick throw/pickup pacing from the armory set.'
   }
 ]);
 

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -119,6 +119,35 @@ const CAPTURE_PARK_SCALE_BY_TYPE = Object.freeze({
   drone: 1.15
 });
 const CAPTURE_AIR_ATTACK_ID_SET = new Set(['fighterJetAttack', 'helicopterAttack', 'droneAttack', 'missileJavelin']);
+const FIREARM_CAPTURE_ANIMATION_IDS = new Set([
+  'glockSidearmAttack',
+  'pistolSidearmAttack',
+  'assaultRifleAttack',
+  'uziSprayAttack',
+  'ak47VolleyAttack',
+  'grenadeBlastAttack'
+]);
+const FIREARM_CAPTURE_WEAPON_URLS = Object.freeze({
+  glockSidearmAttack: [
+    'https://cdn.jsdelivr.net/gh/webaverse/pistol@master/glock.glb'
+  ],
+  pistolSidearmAttack: [
+    'https://cdn.jsdelivr.net/gh/webaverse/pistol@master/pistol.glb'
+  ],
+  assaultRifleAttack: [
+    'https://cdn.jsdelivr.net/gh/webaverse/pistol@master/military.glb'
+  ],
+  uziSprayAttack: [
+    'https://cdn.jsdelivr.net/gh/webaverse/uzi@main/uzi.glb'
+  ],
+  ak47VolleyAttack: [
+    'https://cdn.jsdelivr.net/gh/LazerMaker/gun-models-ak47-and-supprest-pistol-@master/ak47.glb'
+  ],
+  grenadeBlastAttack: [
+    'https://cdn.jsdelivr.net/gh/friuns2/bingextension@main/grenade.glb'
+  ]
+});
+const CAPTURE_WEAPON_MODEL_CACHE = new Map();
 const CAPTURE_ATTACK_TUNING = Object.freeze({
   fighterJetAttack: { speed: 1.2, height: 0.92, inward: 0.94, takeoff: 0.2, landing: 0.24 },
   helicopterAttack: { speed: 1.26, height: 0.84, inward: 0.88, takeoff: 0.24, landing: 0.28 },
@@ -135,6 +164,109 @@ function orientCaptureVehicleTowardBoardCenter(root, target) {
   const forward = target.clone().sub(root.position).setY(0);
   if (forward.lengthSq() < 1e-6) return;
   root.quaternion.setFromUnitVectors(MISSILE_FORWARD, forward.normalize());
+}
+
+function normalizeCaptureWeaponModel(model, targetSize = 0.065) {
+  if (!model?.isObject3D) return model;
+  model.updateMatrixWorld?.(true);
+  const box = new THREE.Box3().setFromObject(model);
+  const size = box.getSize(new THREE.Vector3());
+  const maxDim = Math.max(size.x, size.y, size.z, 1e-3);
+  const scale = targetSize / maxDim;
+  model.scale.multiplyScalar(scale);
+  model.updateMatrixWorld?.(true);
+  const nextBox = new THREE.Box3().setFromObject(model);
+  const center = nextBox.getCenter(new THREE.Vector3());
+  model.position.x -= center.x;
+  model.position.y -= nextBox.min.y;
+  model.position.z -= center.z;
+  return model;
+}
+
+async function loadCaptureWeaponModel(captureAnimationId) {
+  if (!captureAnimationId) return null;
+  const cached = CAPTURE_WEAPON_MODEL_CACHE.get(captureAnimationId);
+  if (cached) return cached.clone(true);
+  const urls = FIREARM_CAPTURE_WEAPON_URLS[captureAnimationId];
+  if (!Array.isArray(urls) || !urls.length) return null;
+  const loader = new GLTFLoader();
+  loader.setCrossOrigin('anonymous');
+  for (const url of urls) {
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      const gltf = await loader.loadAsync(url);
+      const scene = gltf?.scene || gltf?.scenes?.[0];
+      if (!scene) continue;
+      const weapon = normalizeCaptureWeaponModel(scene.clone(true), 0.064);
+      weapon.traverse((node) => {
+        if (!node?.isMesh) return;
+        node.castShadow = true;
+        node.receiveShadow = true;
+        const materials = Array.isArray(node.material) ? node.material : [node.material];
+        materials.forEach((material) => {
+          if (!material) return;
+          if (material.map) applySRGBColorSpace(material.map);
+          if (material.emissiveMap) applySRGBColorSpace(material.emissiveMap);
+          material.needsUpdate = true;
+        });
+      });
+      CAPTURE_WEAPON_MODEL_CACHE.set(captureAnimationId, weapon);
+      return weapon.clone(true);
+    } catch (error) {
+      console.warn('Capture weapon model load failed', captureAnimationId, url, error);
+    }
+  }
+  return null;
+}
+
+async function createCaptureWeaponRackFx() {
+  const root = new THREE.Group();
+  const base = new THREE.Mesh(
+    new THREE.BoxGeometry(0.34, 0.03, 0.15),
+    createCaptureVehicleMaterial('truck', { color: '#0f172a', roughness: 0.62, metalness: 0.2 })
+  );
+  base.position.y = 0.015;
+  root.add(base);
+  const post = new THREE.Mesh(
+    new THREE.CylinderGeometry(0.012, 0.012, 0.12, 12),
+    createCaptureVehicleMaterial('truck', { color: '#94a3b8', roughness: 0.44, metalness: 0.32 })
+  );
+  post.position.set(0, 0.075, 0);
+  root.add(post);
+  const tray = new THREE.Mesh(
+    new THREE.BoxGeometry(0.38, 0.018, 0.19),
+    createCaptureVehicleMaterial('truck', { color: '#334155', roughness: 0.55, metalness: 0.22 })
+  );
+  tray.position.y = 0.14;
+  root.add(tray);
+
+  const firearmOptions = CAPTURE_ANIMATION_OPTIONS.filter((option) => FIREARM_CAPTURE_ANIMATION_IDS.has(option.id));
+  for (let idx = 0; idx < firearmOptions.length; idx += 1) {
+    const option = firearmOptions[idx];
+    // eslint-disable-next-line no-await-in-loop
+    let weaponProxy = await loadCaptureWeaponModel(option.id);
+    if (!weaponProxy) {
+      weaponProxy =
+        option.id === 'grenadeBlastAttack'
+          ? new THREE.Mesh(
+              new THREE.SphereGeometry(0.017, 14, 14),
+              createCaptureVehicleMaterial('missile', { color: '#166534', roughness: 0.5, metalness: 0.1 })
+            )
+          : new THREE.Mesh(
+              new THREE.BoxGeometry(0.062, 0.013, 0.018),
+              createCaptureVehicleMaterial('missile', { color: '#e2e8f0', roughness: 0.26, metalness: 0.56 })
+            );
+    }
+    const cols = 3;
+    const row = Math.floor(idx / cols);
+    const col = idx % cols;
+    weaponProxy.position.set(-0.11 + col * 0.11, 0.162, -0.04 + row * 0.08);
+    weaponProxy.rotation.z = -0.24;
+    weaponProxy.userData.captureAnimationId = option.id;
+    weaponProxy.userData.captureWeaponRack = true;
+    root.add(weaponProxy);
+  }
+  return { root };
 }
 
 function getCaptureVehicleTexture(kind = 'generic', toneSeed = null) {
@@ -5276,6 +5408,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     winner: null,
     turnCycle: 0
   });
+  const [weaponSwapPopup, setWeaponSwapPopup] = useState(null);
 
   const playerColors = useMemo(() => resolvePlayerColors(appearance), [appearance]);
 
@@ -5464,6 +5597,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       if (entry?.drone) entry.drone.visible = false;
       if (entry?.droneTruck) entry.droneTruck.visible = selectedCaptureAnimationId === 'droneAttack';
       if (entry?.missile) entry.missile.visible = selectedCaptureAnimationId === 'missileJavelin';
+      if (entry?.weaponRack) entry.weaponRack.visible = true;
     });
   }, [aiLoadoutByPlayer]);
 
@@ -5476,6 +5610,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       entry?.drone?.parent?.remove?.(entry.drone);
       entry?.missile?.parent?.remove?.(entry.missile);
       entry?.droneTruck?.parent?.remove?.(entry.droneTruck);
+      entry?.weaponRack?.parent?.remove?.(entry.weaponRack);
     });
     parkedCaptureVehiclesRef.current.clear();
 
@@ -5490,7 +5625,9 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       const missileFx = await createCaptureMissileTruckFx();
       // eslint-disable-next-line no-await-in-loop
       const droneTruckFx = await createCaptureDroneLauncherTruckFx();
-      if (!jetFx?.root || !helicopterFx?.root || !droneFx?.root || !missileFx?.root || !droneTruckFx?.root) continue;
+      // eslint-disable-next-line no-await-in-loop
+      const weaponRackFx = await createCaptureWeaponRackFx();
+      if (!jetFx?.root || !helicopterFx?.root || !droneFx?.root || !missileFx?.root || !droneTruckFx?.root || !weaponRackFx?.root) continue;
       fitCaptureVehicleToPlayerKing(jetFx.root, playerIndex);
       fitCaptureVehicleToPlayerKing(helicopterFx.root, playerIndex);
       fitCaptureVehicleToPlayerKing(droneFx.root, playerIndex);
@@ -5508,39 +5645,46 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       const dronePark = resolveCaptureParkingAnchors(playerIndex, 'drone');
       const missilePark = resolveCaptureParkingAnchors(playerIndex, 'missile');
       const droneTruckPark = resolveCaptureParkingAnchors(playerIndex, 'missile');
-      if (!jetPark || !helicopterPark || !dronePark || !missilePark || !droneTruckPark) continue;
+      const weaponRackPark = resolveCaptureParkingAnchors(playerIndex, 'missile');
+      if (!jetPark || !helicopterPark || !dronePark || !missilePark || !droneTruckPark || !weaponRackPark) continue;
       jetFx.root.position.copy(jetPark);
       helicopterFx.root.position.copy(helicopterPark);
       droneFx.root.position.copy(dronePark);
       missileFx.root.position.copy(missilePark);
       droneTruckFx.root.position.copy(droneTruckPark);
+      weaponRackFx.root.position.copy(weaponRackPark.clone().add(new THREE.Vector3(0.03, 0, -0.03)));
       const tableSurfaceY = arena.tableInfo?.surfaceY;
       alignObjectBottomToY(jetFx.root, tableSurfaceY);
       alignObjectBottomToY(helicopterFx.root, tableSurfaceY);
       alignObjectBottomToY(droneFx.root, tableSurfaceY);
       alignObjectBottomToY(missileFx.root, tableSurfaceY);
       alignObjectBottomToY(droneTruckFx.root, tableSurfaceY);
+      alignObjectBottomToY(weaponRackFx.root, tableSurfaceY);
       jetFx.root.position.y += CAPTURE_PARKED_LIFT_OFFSET_Y;
       helicopterFx.root.position.y += CAPTURE_PARKED_LIFT_OFFSET_Y;
       droneFx.root.position.y += CAPTURE_PARKED_LIFT_OFFSET_Y;
       missileFx.root.position.y += CAPTURE_PARKED_LIFT_OFFSET_Y;
       droneTruckFx.root.position.y += CAPTURE_PARKED_LIFT_OFFSET_Y;
+      weaponRackFx.root.position.y += CAPTURE_PARKED_LIFT_OFFSET_Y;
       orientCaptureVehicleTowardBoardCenter(jetFx.root, arena.boardLookTarget);
       orientCaptureVehicleTowardBoardCenter(helicopterFx.root, arena.boardLookTarget);
       orientCaptureVehicleTowardBoardCenter(droneFx.root, arena.boardLookTarget);
       orientCaptureVehicleTowardBoardCenter(missileFx.root, arena.boardLookTarget);
       orientCaptureVehicleTowardBoardCenter(droneTruckFx.root, arena.boardLookTarget);
+      orientCaptureVehicleTowardBoardCenter(weaponRackFx.root, arena.boardLookTarget);
       arena.scene.add(jetFx.root);
       arena.scene.add(helicopterFx.root);
       arena.scene.add(droneFx.root);
       arena.scene.add(missileFx.root);
       arena.scene.add(droneTruckFx.root);
+      arena.scene.add(weaponRackFx.root);
       const parkedEntry = {
         jet: jetFx.root,
         helicopter: helicopterFx.root,
         drone: droneFx.root,
         missile: missileFx.root,
         droneTruck: droneTruckFx.root,
+        weaponRack: weaponRackFx.root,
         helicopterRotor: helicopterFx.rotor ?? null,
         helicopterTailRotor: helicopterFx.tailRotor ?? null,
         helicopterRotorNodes: Array.isArray(helicopterFx.rotorNodes) ? helicopterFx.rotorNodes : [],
@@ -5557,7 +5701,8 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         helicopterPark,
         dronePark,
         missilePark,
-        droneTruckPark
+        droneTruckPark,
+        weaponRackPark
       };
       parkedCaptureVehiclesRef.current.set(playerIndex, {
         ...parkedEntry
@@ -7352,23 +7497,69 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         .filter(Boolean);
       if (!tokens.length) return false;
       const hits = raycaster.intersectObjects(tokens, true);
-      if (!hits.length) return false;
-      let targetToken = null;
-      for (const hit of hits) {
-        const group = hit.object?.userData?.tokenGroup;
-        if (group && tokens.includes(group)) {
-          targetToken = group;
-          break;
-        }
+      let option = null;
+      if (!hits.length) {
+        let best = null;
+        let bestDist = Number.POSITIVE_INFINITY;
+        const pointerPx = new THREE.Vector2(clientX, clientY);
+        const projected = new THREE.Vector3();
+        selection.options.forEach((opt) => {
+          const token = state.tokens?.[0]?.[opt.token];
+          if (!token?.isObject3D) return;
+          token.getWorldPosition(projected);
+          projected.project(camera);
+          const sx = ((projected.x + 1) * 0.5) * rect.width + rect.left;
+          const sy = ((-projected.y + 1) * 0.5) * rect.height + rect.top;
+          const dist = pointerPx.distanceTo(new THREE.Vector2(sx, sy));
+          if (dist < bestDist) {
+            bestDist = dist;
+            best = opt;
+          }
+        });
+        if (!best || bestDist > 96) return false;
+        option = best;
       }
-      if (!targetToken) return false;
-      const option = selection.options.find(
-        (opt) => state.tokens?.[0]?.[opt.token] === targetToken
-      );
+      let targetToken = null;
+      if (!option) {
+        for (const hit of hits) {
+          const group = hit.object?.userData?.tokenGroup;
+          if (group && tokens.includes(group)) {
+            targetToken = group;
+            break;
+          }
+        }
+        if (!targetToken) return false;
+        option = selection.options.find(
+          (opt) => state.tokens?.[0]?.[opt.token] === targetToken
+        );
+      }
       if (!option) return false;
       clearHumanSelection();
       moveToken(0, option.token, selection.roll, {
         skipCameraFollow: selection.skipCameraFollow || option.entering
+      });
+      return true;
+    };
+    const attemptWeaponQuickSwap = (clientX, clientY) => {
+      const state = stateRef.current;
+      if (!state || state.turn !== 0 || state.animation || state.winner) return false;
+      const humanEntry = parkedCaptureVehiclesRef.current.get(0);
+      const rack = humanEntry?.weaponRack;
+      if (!rack) return false;
+      const rect = renderer.domElement.getBoundingClientRect();
+      const x = ((clientX - rect.left) / rect.width) * 2 - 1;
+      const y = -((clientY - rect.top) / rect.height) * 2 + 1;
+      pointer.set(x, y);
+      raycaster.setFromCamera(pointer, camera);
+      const hits = raycaster.intersectObject(rack, true);
+      if (!hits.length) return false;
+      const unlockedOptions = CAPTURE_ANIMATION_OPTIONS.filter((option) =>
+        isLudoOptionUnlocked('captureAnimation', option.id, ludoInventory)
+      );
+      setWeaponSwapPopup({
+        x: clientX,
+        y: clientY,
+        options: unlockedOptions.length ? unlockedOptions : CAPTURE_ANIMATION_OPTIONS
       });
       return true;
     };
@@ -7410,7 +7601,10 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     onPointerDown = (event) => {
       const { clientX, clientY } = event;
       if (clientX == null || clientY == null) return;
-      let handled = attemptHumanSelection(clientX, clientY);
+      let handled = attemptWeaponQuickSwap(clientX, clientY);
+      if (!handled) {
+        handled = attemptHumanSelection(clientX, clientY);
+      }
       if (!handled) {
         handled = attemptDiceRoll(clientX, clientY);
       }
@@ -9089,10 +9283,11 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       }
     }
     const token = state.tokens[player][tokenIndex];
+    const isEnteringMove = fromProgress < 0;
     const pickupHelper = new THREE.Vector3();
     const placeHelper = new THREE.Vector3();
-    const hasPickupHelper = sampleHumanActionHelperPosition(player, 'tokenPickup', pickupHelper);
-    const hasPlaceHelper = sampleHumanActionHelperPosition(player, 'tokenPlace', placeHelper);
+    const hasPickupHelper = false;
+    const hasPlaceHelper = isEnteringMove && sampleHumanActionHelperPosition(player, 'tokenPlace', placeHelper);
     const pushPathNode = (collection, position, progress = null, viaHelper = null) => {
       collection.push({
         position,
@@ -9744,6 +9939,18 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     if (player === 0) {
       preserveUserTurnCameraRef.current = true;
       lockUserTurnSeatViewRef.current = true;
+      const enteringOptions = options.filter((option) => option.entering);
+      if (enteringOptions.length) {
+        beginHumanSelection(value, enteringOptions, { skipCameraFollow: !hasBoardTokenBeforeRoll });
+        return;
+      }
+      const choice = chooseMoveOption(state, 0, value, options);
+      if (choice) {
+        moveToken(0, choice.token, value, {
+          skipCameraFollow: !hasBoardTokenBeforeRoll || choice.entering
+        });
+        return;
+      }
       beginHumanSelection(value, options, { skipCameraFollow: !hasBoardTokenBeforeRoll });
       return;
     }
@@ -9792,6 +9999,38 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       className="fixed inset-0 bg-[#0c1020] text-white touch-pan-y select-none"
     >
       <div className="absolute inset-0 pointer-events-none">
+        {weaponSwapPopup && (
+          <div
+            className="pointer-events-auto absolute z-30 w-48 rounded-xl border border-white/20 bg-black/85 p-2 shadow-2xl backdrop-blur"
+            style={{
+              left: clamp(weaponSwapPopup.x - 80, 8, (typeof window !== 'undefined' ? window.innerWidth : 360) - 200),
+              top: clamp(weaponSwapPopup.y - 12, 96, (typeof window !== 'undefined' ? window.innerHeight : 640) - 170)
+            }}
+          >
+            <p className="px-1 pb-1 text-[10px] uppercase tracking-[0.28em] text-sky-200/80">Quick Weapon Swap</p>
+            <div className="grid grid-cols-2 gap-1">
+              {weaponSwapPopup.options.map((option) => {
+                const optionIndex = CAPTURE_ANIMATION_OPTIONS.findIndex((entry) => entry.id === option.id);
+                const selected = appearance.captureAnimation === optionIndex;
+                return (
+                  <button
+                    key={option.id}
+                    type="button"
+                    className={`rounded-md border px-1.5 py-1 text-[10px] font-semibold ${
+                      selected ? 'border-sky-300 bg-sky-400/25 text-white' : 'border-white/20 bg-white/5 text-white/80'
+                    }`}
+                    onClick={() => {
+                      if (optionIndex >= 0) setAppearance((prev) => ({ ...prev, captureAnimation: optionIndex }));
+                      setWeaponSwapPopup(null);
+                    }}
+                  >
+                    {option.label}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        )}
         <div className="absolute top-[5.35rem] left-2 z-20 flex flex-col items-start gap-3">
           <div className="pointer-events-auto">
             <button


### PR DESCRIPTION
### Motivation

- Introduce a set of firearm-style capture animations and in-scene weapon props to expand capture visual variety. 
- Provide a weapon rack parked next to player capture vehicles so humans can preview and quick-swap capture animations during their turn. 
- Improve selection robustness by falling back to nearest token when raycast misses and surface tooling for loading/caching external weapon models.

### Description

- Added new firearm entries to `CAPTURE_ANIMATION_OPTIONS` and wired them with `FIREARM_CAPTURE_ANIMATION_IDS` and `FIREARM_CAPTURE_WEAPON_URLS` for external model loading. 
- Implemented model handling helpers: `normalizeCaptureWeaponModel`, `loadCaptureWeaponModel`, and `CAPTURE_WEAPON_MODEL_CACHE` to load, normalize, cache, and prepare GLTF weapon models. 
- Built a `createCaptureWeaponRackFx` FX that composes a weapon rack and populates it with loaded weapon proxies and integrated it into parked capture vehicles construction and visibility logic. 
- Added a quick-weapon-swap UI: `weaponSwapPopup` state, `attemptWeaponQuickSwap` raycast handler, and an in-scene popup to choose and apply a new `captureAnimation` without opening the full settings menu. 
- Improved token selection by adding a nearest-on-screen fallback when direct raycast hits are empty, and adjusted `scheduleMove` logic to treat entering moves and helper pickup/place behavior more reliably. 

### Testing

- No automated tests were added or executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd38f03f08329be6998e97d0283b4)