### PR TITLE
Adjust Snake seated human scale to 6am proportions

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -81,10 +81,10 @@ const CHAIR_MODEL_URLS = [
 ];
 const HUMAN_MODEL_URL = 'https://threejs.org/examples/models/gltf/readyplayer.me.glb';
 const HUMAN_MODEL_CACHE = { promise: null, template: null };
-// Keep Snake seated humans aligned with Ludo/Chess Battle Royal chair anchoring and 7am scale baseline.
+// Keep Snake seated humans in Ludo Battle Royal seating layout, but with the smaller 6am-scale proportion.
 const SEATED_HUMAN_BASE_HEIGHT = 1.74;
-const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.42;
-const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 4.55;
+const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.22;
+const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 3.24;
 const SEATED_HUMAN_SEAT_Y_OFFSET = -5.85 * MODEL_SCALE * STOOL_SCALE;
 const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.42;
 // Mirror Ludo Battle Royal's deeper bottom-seat pushback so the local player sits


### PR DESCRIPTION
### Motivation
- Restore the smaller seated-human proportions so Snake & Ladder human characters match the chair proportions and the Ludo/Chess Battle Royal seating layout used previously (~6am baseline). 

### Description
- Updated `webapp/src/components/SnakeBoard3D.jsx` to reduce `SEATED_HUMAN_TARGET_HEIGHT` from `BACK_HEIGHT * 2.42` to `BACK_HEIGHT * 2.22` and `SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER` from `4.55` to `3.24`, and clarified the surrounding comment while keeping chair angles/placement unchanged. 

### Testing
- Ran `npx eslint webapp/src/components/SnakeBoard3D.jsx`, which completed with only an existing ignore-pattern warning and no lint errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ede61d282c832993d94d581c9a6611)