### PR TITLE
Adjust Snake seated human scale to match chair proportions

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -81,10 +81,11 @@ const CHAIR_MODEL_URLS = [
 ];
 const HUMAN_MODEL_URL = 'https://threejs.org/examples/models/gltf/readyplayer.me.glb';
 const HUMAN_MODEL_CACHE = { promise: null, template: null };
-// Keep Snake seated humans aligned with Ludo/Chess Battle Royal chair anchoring and 7am scale baseline.
+// Keep Snake seated humans aligned with Ludo Battle Royal chair anchoring/orientation,
+// but restore the smaller portrait footprint so characters stay proportional to Snake chairs.
 const SEATED_HUMAN_BASE_HEIGHT = 1.74;
 const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.42;
-const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 4.55;
+const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 0.65;
 const SEATED_HUMAN_SEAT_Y_OFFSET = -5.85 * MODEL_SCALE * STOOL_SCALE;
 const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.42;
 // Mirror Ludo Battle Royal's deeper bottom-seat pushback so the local player sits


### PR DESCRIPTION
### Motivation
- Reduce oversized seated human visuals in the Snake & Ladder 3D scene so characters appear proportional to their chairs while preserving the Ludo-style seating anchors and orientation.

### Description
- Updated the inline comment and changed `SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER` from `4.55` to `0.65` in `webapp/src/components/SnakeBoard3D.jsx` to restore a smaller portrait-friendly human footprint.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ede61d282c832993d94d581c9a6611)