### PR TITLE
Prevent micro-shot launches and simplify reference speed calculation

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1925,7 +1925,7 @@ const CUE_FOLLOW_THROUGH_MAX = BALL_R * 8.4; // extend top-end follow-through so
 const REFERENCE_CUE_SPEED_BASE = 1.9; // align baseline launch speed with Bilardo Shqip shot feel
 const REFERENCE_CUE_SPEED_RANGE = 8.2; // align high-end launch speed with Bilardo Shqip shot feel
 const REFERENCE_CUE_SPEED_GAMMA = 1.08; // reference implementation: power curve
-const MIN_SHOT_POWER_TO_FIRE = 0.015; // ignore accidental micro drags/releases that should not launch the cue ball
+const MIN_SHOT_POWER_TO_FIRE = 0.02; // Bilardo Shqip parity: only release above 0.02 starts striking
 const HUMAN_PLAYER_HEIGHT_RATIO_TO_TABLE = 0.88; // make player humans visibly bigger relative to table/balls
 const BILARDO_SHQIP_HUMAN_URL = 'https://threejs.org/examples/models/gltf/readyplayer.me.glb';
 const POOL_ROYALE_HUMAN_SCALE_MULTIPLIER = 1.4; // slight size bump while keeping the same base proportions
@@ -26791,17 +26791,10 @@ const shotPowerRef = useRef(0);
         const shotDir3 = TMP_VEC3_C.set(aimDir.x, 0, aimDir.y);
         if (shotDir3.lengthSq() > 1e-8) shotDir3.normalize();
         else shotDir3.set(0, 0, 1);
-        const cueDriveBoost = computeCueDriveBoost({
-          pullDistance,
-          contactAdvance,
-          strikeDurationMs: strikeDuration,
-          clampedPower
-        });
         const referenceSpeed =
           REFERENCE_CUE_SPEED_BASE +
           REFERENCE_CUE_SPEED_RANGE *
-            Math.pow(THREE.MathUtils.clamp(clampedPower, 0, 1), REFERENCE_CUE_SPEED_GAMMA) *
-            cueDriveBoost;
+            Math.pow(THREE.MathUtils.clamp(clampedPower, 0, 1), REFERENCE_CUE_SPEED_GAMMA);
         cue.vel.copy(shotDir3).multiplyScalar(referenceSpeed);
         if (cue.spin) {
           cue.spin.set(offsetScaled.x, offsetScaled.y);
@@ -33325,7 +33318,9 @@ const shotPowerRef = useRef(0);
     const latchedPower = clampPower(sourcePower, 0);
     shotPowerRef.current = latchedPower;
     applyPower(latchedPower);
-    fireRef.current?.(latchedPower);
+    if (latchedPower > MIN_SHOT_POWER_TO_FIRE) {
+      fireRef.current?.(latchedPower);
+    }
   }, [applyPower, clampPower]);
   const showPowerSlider = hud.turn === 0 && !hud.over && !replayActive && !shotActive;
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- Prevent accidental micro drags from launching the cue ball by raising the minimum release threshold to match Bilardo Shqip behavior.
- Simplify and align reference speed calculation with the intended power-only curve, removing extra drive-time boosts.
- Make shot firing behavior more predictable and prevent tiny power values from producing unintended shots.

### Description
- Increased `MIN_SHOT_POWER_TO_FIRE` from `0.015` to `0.02` and updated the inline comment for Bilardo Shqip parity.
- Added a guard in `onPowerRelease` so `fireRef.current` is only invoked when the latched power is greater than `MIN_SHOT_POWER_TO_FIRE`.
- Removed the `computeCueDriveBoost` multiplier from the `referenceSpeed` calculation so `referenceSpeed` is driven solely by the power curve.

### Testing
- Ran the automated unit test suite via `yarn test`, which passed.
- Performed an automated production build via `yarn build`, which completed successfully.
- Verified that firing behavior respects the new threshold in automated integration checks and that reference speed matches the power-only curve.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ede4d14b088329845ca0c7d8244238)