### PR TITLE
Add manual strike timing for power slider and retune cue speed calculation

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -15523,6 +15523,15 @@ const showRuleToast = useCallback((message) => {
 }, []);
 const powerRef = useRef(hud.power);
 const shotPowerRef = useRef(0);
+const MANUAL_STRIKE_TIME_MS = 170;
+const MANUAL_STRIKE_THRESHOLD = 0.88;
+const [manualShotState, setManualShotState] = useState('idle'); // idle | dragging | striking
+const manualShotStateRef = useRef('idle');
+const manualStrikeStartedAtRef = useRef(0);
+const manualStrikeDidHitRef = useRef(false);
+useEffect(() => {
+  manualShotStateRef.current = manualShotState;
+}, [manualShotState]);
   const clampPower = useCallback((value, fallback = 0) => {
     if (!Number.isFinite(value)) return fallback;
     return THREE.MathUtils.clamp(value, 0, 1);
@@ -26798,10 +26807,8 @@ const shotPowerRef = useRef(0);
           clampedPower
         });
         const referenceSpeed =
-          REFERENCE_CUE_SPEED_BASE +
-          REFERENCE_CUE_SPEED_RANGE *
-            Math.pow(THREE.MathUtils.clamp(clampedPower, 0, 1), REFERENCE_CUE_SPEED_GAMMA) *
-            cueDriveBoost;
+          (1.9 + 8.2 * Math.pow(THREE.MathUtils.clamp(clampedPower, 0, 1), 1.08)) *
+          cueDriveBoost;
         cue.vel.copy(shotDir3).multiplyScalar(referenceSpeed);
         if (cue.spin) {
           cue.spin.set(offsetScaled.x, offsetScaled.y);
@@ -33310,6 +33317,8 @@ const shotPowerRef = useRef(0);
   const sliderRef = useRef(null);
   const onPowerDragStart = useCallback(() => {
     captureCueStickAnchor();
+    manualStrikeDidHitRef.current = false;
+    setManualShotState('dragging');
   }, [captureCueStickAnchor]);
   const onPowerDrag = useCallback((powerRatio = 0) => {
     const clamped = clampPower(powerRatio, 0);
@@ -33325,8 +33334,41 @@ const shotPowerRef = useRef(0);
     const latchedPower = clampPower(sourcePower, 0);
     shotPowerRef.current = latchedPower;
     applyPower(latchedPower);
-    fireRef.current?.(latchedPower);
+    manualStrikeDidHitRef.current = false;
+    manualStrikeStartedAtRef.current = performance.now();
+    setManualShotState(latchedPower > 0.02 ? 'striking' : 'idle');
   }, [applyPower, clampPower]);
+  useEffect(() => {
+    let raf = 0;
+    const tick = () => {
+      raf = requestAnimationFrame(tick);
+      if (manualShotStateRef.current !== 'striking') return;
+      const start = manualStrikeStartedAtRef.current || 0;
+      if (start <= 0) return;
+      const strikeNorm = THREE.MathUtils.clamp(
+        (performance.now() - start) / MANUAL_STRIKE_TIME_MS,
+        0,
+        1
+      );
+      if (!manualStrikeDidHitRef.current && strikeNorm > MANUAL_STRIKE_THRESHOLD) {
+        manualStrikeDidHitRef.current = true;
+        fireRef.current?.(shotPowerRef.current ?? powerRef.current ?? 0);
+      }
+      if (strikeNorm >= 1) {
+        setManualShotState('idle');
+        manualStrikeStartedAtRef.current = 0;
+        requestAnimationFrame(() => {
+          const slider = sliderInstanceRef.current;
+          if (slider) slider.set(slider.min, { animate: true });
+          applyPower(0);
+        });
+      }
+    };
+    raf = requestAnimationFrame(tick);
+    return () => {
+      if (raf) cancelAnimationFrame(raf);
+    };
+  }, [applyPower]);
   const showPowerSlider = hud.turn === 0 && !hud.over && !replayActive && !shotActive;
   useEffect(() => {
     if (!showPowerSlider) {
@@ -33344,10 +33386,6 @@ const shotPowerRef = useRef(0);
       onStart: () => onPowerDragStart(),
       onCommit: () => {
         onPowerRelease(clampPower(powerRef.current, 0));
-        requestAnimationFrame(() => {
-          slider.set(slider.min, { animate: true });
-          applyPower(0);
-        });
       }
     });
     sliderInstanceRef.current = slider;


### PR DESCRIPTION
### Motivation
- Implement a more realistic manual strike behavior for the big pull power slider so firing occurs after a short strike animation instead of immediately on release.
- Prevent duplicate/early fires from the slider by tracking strike progress and ensuring a single `fire` call when the strike reaches a threshold.
- Adjust the cue reference speed formula to new tuning for more consistent shot velocity across power values.

### Description
- Added manual strike state and refs (`manualShotState`, `manualShotStateRef`, `manualStrikeStartedAtRef`, `manualStrikeDidHitRef`) and constants (`MANUAL_STRIKE_TIME_MS`, `MANUAL_STRIKE_THRESHOLD`) to manage a timed strike workflow for the power slider.
- Reworked power slider handlers to enter `dragging`/`striking` states on start/release and removed the immediate `fire` call from `onPowerRelease`, deferring firing to a RAF loop.
- Added a RAF-based effect that tracks strike progress, triggers `fireRef.current` once when the normalized strike passes the threshold, and resets the slider and power when the strike completes.
- Replaced the previous reference speed expression with a new tuned formula `(1.9 + 8.2 * Math.pow(clampedPower, 1.08)) * cueDriveBoost` to change cue velocity computation.

### Testing
- Ran unit tests with `yarn test` and the suite completed successfully.
- Performed a production build with `yarn build` which succeeded without errors.
- Ran linting (`yarn lint`) which reported no new issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ede4d14b088329845ca0c7d8244238)