### PR TITLE
Add manual strike flow for power slider and tweak player scale; simplify cue speed calc

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1928,7 +1928,7 @@ const REFERENCE_CUE_SPEED_GAMMA = 1.08; // reference implementation: power curve
 const MIN_SHOT_POWER_TO_FIRE = 0.015; // ignore accidental micro drags/releases that should not launch the cue ball
 const HUMAN_PLAYER_HEIGHT_RATIO_TO_TABLE = 0.88; // make player humans visibly bigger relative to table/balls
 const BILARDO_SHQIP_HUMAN_URL = 'https://threejs.org/examples/models/gltf/readyplayer.me.glb';
-const POOL_ROYALE_HUMAN_SCALE_MULTIPLIER = 1.4; // slight size bump while keeping the same base proportions
+const POOL_ROYALE_HUMAN_SCALE_MULTIPLIER = 1.85; // match Bilardo Shqip's stronger player-vs-table size contrast
 const HUMAN_PLAYER_IDLE_SWAY_SPEED = 1.2;
 const HUMAN_PLAYER_IDLE_SWAY_ANGLE = 0.04;
 const HUMAN_PLAYER_AIM_LEAN = 0.2;
@@ -15523,6 +15523,16 @@ const showRuleToast = useCallback((message) => {
 }, []);
 const powerRef = useRef(hud.power);
 const shotPowerRef = useRef(0);
+const MANUAL_STRIKE_TIME_MS = 120;
+const MANUAL_STRIKE_THRESHOLD = 0.88;
+const [manualShotState, setManualShotState] = useState('idle'); // idle | dragging | striking
+const manualShotStateRef = useRef('idle');
+const manualStrikeStartedAtRef = useRef(0);
+const manualStrikeDidHitRef = useRef(false);
+const manualStrikePowerRef = useRef(0);
+useEffect(() => {
+  manualShotStateRef.current = manualShotState;
+}, [manualShotState]);
   const clampPower = useCallback((value, fallback = 0) => {
     if (!Number.isFinite(value)) return fallback;
     return THREE.MathUtils.clamp(value, 0, 1);
@@ -24709,11 +24719,18 @@ const shotPowerRef = useRef(0);
           const isShooter = anim.seat === activeSeat;
           const cameraBlend = THREE.MathUtils.clamp(cameraBlendRef.current ?? 1, 0, 1);
           const loweredCueCamera = cameraBlend <= HUMAN_SHOOT_BLEND_THRESHOLD;
-          const draggingSlider = Boolean(sliderInstanceRef.current?.dragging);
-          const sliderPowerActive = (powerRef.current ?? 0) > 0.01;
+          const draggingSlider =
+            manualShotStateRef.current === 'dragging' ||
+            Boolean(sliderInstanceRef.current?.dragging);
+          const sliderPowerActive =
+            manualShotStateRef.current !== 'idle' || (powerRef.current ?? 0) > 0.01;
           let mode = 'idle';
           if (isReplay) mode = 'idle';
-          else if (isShotActive && anim.seat === shotSeat && shotAge < 420) mode = 'strike';
+          else if (
+            (isShotActive && anim.seat === shotSeat && shotAge < 420) ||
+            (isShooter && manualShotStateRef.current === 'striking')
+          )
+            mode = 'strike';
           else if (isShotActive) mode = 'react';
           else if (isShooter && (loweredCueCamera || draggingSlider || sliderPowerActive)) mode = 'aim';
           anim.mode = mode;
@@ -26791,17 +26808,8 @@ const shotPowerRef = useRef(0);
         const shotDir3 = TMP_VEC3_C.set(aimDir.x, 0, aimDir.y);
         if (shotDir3.lengthSq() > 1e-8) shotDir3.normalize();
         else shotDir3.set(0, 0, 1);
-        const cueDriveBoost = computeCueDriveBoost({
-          pullDistance,
-          contactAdvance,
-          strikeDurationMs: strikeDuration,
-          clampedPower
-        });
         const referenceSpeed =
-          REFERENCE_CUE_SPEED_BASE +
-          REFERENCE_CUE_SPEED_RANGE *
-            Math.pow(THREE.MathUtils.clamp(clampedPower, 0, 1), REFERENCE_CUE_SPEED_GAMMA) *
-            cueDriveBoost;
+          1.9 + 8.2 * Math.pow(THREE.MathUtils.clamp(clampedPower, 0, 1), 1.08);
         cue.vel.copy(shotDir3).multiplyScalar(referenceSpeed);
         if (cue.spin) {
           cue.spin.set(offsetScaled.x, offsetScaled.y);
@@ -33310,6 +33318,8 @@ const shotPowerRef = useRef(0);
   const sliderRef = useRef(null);
   const onPowerDragStart = useCallback(() => {
     captureCueStickAnchor();
+    manualStrikeDidHitRef.current = false;
+    setManualShotState('dragging');
   }, [captureCueStickAnchor]);
   const onPowerDrag = useCallback((powerRatio = 0) => {
     const clamped = clampPower(powerRatio, 0);
@@ -33324,9 +33334,52 @@ const shotPowerRef = useRef(0);
     );
     const latchedPower = clampPower(sourcePower, 0);
     shotPowerRef.current = latchedPower;
+    manualStrikePowerRef.current = latchedPower;
     applyPower(latchedPower);
-    fireRef.current?.(latchedPower);
+    manualStrikeDidHitRef.current = false;
+    manualStrikeStartedAtRef.current = performance.now();
+    setManualShotState(latchedPower > 0.02 ? 'striking' : 'idle');
   }, [applyPower, clampPower]);
+  useEffect(() => {
+    let raf = 0;
+    const tick = () => {
+      raf = requestAnimationFrame(tick);
+      if (manualShotStateRef.current !== 'striking') return;
+      const start = manualStrikeStartedAtRef.current || 0;
+      if (start <= 0) return;
+      const strikeNorm = THREE.MathUtils.clamp(
+        (performance.now() - start) / MANUAL_STRIKE_TIME_MS,
+        0,
+        1
+      );
+      if (!manualStrikeDidHitRef.current && strikeNorm > MANUAL_STRIKE_THRESHOLD) {
+        manualStrikeDidHitRef.current = true;
+        fireRef.current?.(
+          manualStrikePowerRef.current ??
+            shotPowerRef.current ??
+            powerRef.current ??
+            0
+        );
+      }
+      if (strikeNorm >= 1) {
+        if (!shootingRef.current && manualStrikePowerRef.current > 0.02) {
+          fireRef.current?.(manualStrikePowerRef.current);
+        }
+        setManualShotState('idle');
+        manualStrikeStartedAtRef.current = 0;
+        manualStrikePowerRef.current = 0;
+        requestAnimationFrame(() => {
+          const slider = sliderInstanceRef.current;
+          if (slider) slider.set(slider.min, { animate: true });
+          applyPower(0);
+        });
+      }
+    };
+    raf = requestAnimationFrame(tick);
+    return () => {
+      if (raf) cancelAnimationFrame(raf);
+    };
+  }, [applyPower]);
   const showPowerSlider = hud.turn === 0 && !hud.over && !replayActive && !shotActive;
   useEffect(() => {
     if (!showPowerSlider) {
@@ -33344,10 +33397,6 @@ const shotPowerRef = useRef(0);
       onStart: () => onPowerDragStart(),
       onCommit: () => {
         onPowerRelease(clampPower(powerRef.current, 0));
-        requestAnimationFrame(() => {
-          slider.set(slider.min, { animate: true });
-          applyPower(0);
-        });
       }
     });
     sliderInstanceRef.current = slider;


### PR DESCRIPTION
### Motivation
- Improve the feel of the power slider by separating the visual drag from the actual strike timing so releasing the slider triggers a controlled strike animation/timeout rather than firing immediately.
- Make player characters visually larger relative to the table to match a stronger player-vs-table size contrast.
- Simplify the cue launch speed calculation by removing a separate `computeCueDriveBoost` call and inlining the reference-speed formula.

### Description
- Increase `POOL_ROYALE_HUMAN_SCALE_MULTIPLIER` from `1.4` to `1.85` to scale players up relative to the table.
- Add a manual strike state machine with `manualShotState`, refs (`manualShotStateRef`, `manualStrikeStartedAtRef`, `manualStrikeDidHitRef`, `manualStrikePowerRef`) and constants (`MANUAL_STRIKE_TIME_MS`, `MANUAL_STRIKE_THRESHOLD`) to manage `dragging` → `striking` → `idle` transitions.
- Update slider handlers: `onPowerDragStart` marks the manual drag, `onPowerRelease` latches power and starts the manual strike instead of immediately calling `fireRef`, and the slider commit reset is moved into a dedicated RAF loop.
- Add an RAF-based `useEffect` tick to advance the manual strike, call `fireRef.current` when the strike crosses the hit threshold and finalize/reset the slider and power when the strike completes.
- Adjust animation mode detection to consider manual shot state (`dragging`/`striking`) when deciding `anim.mode` and `sliderPowerActive`.
- Replace the previous `computeCueDriveBoost` usage in `applyShotAtImpact` with an inline `referenceSpeed` calculation using the existing constants (previously `REFERENCE_CUE_SPEED_BASE`/`RANGE`/`GAMMA` values).

### Testing
- Ran the automated test suite with `yarn test` and all tests passed.
- Ran the linter with `yarn lint` with no new warnings or errors.
- Built the webapp with `yarn build` to validate bundling, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ede4d14b088329845ca0c7d8244238)