### PR TITLE
Refine firearm capture FX, GLTF texture loading, and dice pickup timing in LudoBattleRoyal

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -155,7 +155,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://cdn.jsdelivr.net/gh/webaverse/pistol@master/glock.glb',
       'https://raw.githubusercontent.com/webaverse/pistol/master/glock.glb'
     ],
-    scale: 0.11
+    scale: 0.125
   },
   pistolSidearmAttack: {
     label: 'Pistol',
@@ -164,7 +164,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://raw.githubusercontent.com/webaverse/pistol/master/pistol.glb',
       'https://cdn.statically.io/gh/webaverse/pistol/master/pistol.glb'
     ],
-    scale: 0.1
+    scale: 0.115
   },
   assaultRifleAttack: {
     label: 'Assault Rifle',
@@ -173,12 +173,12 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://raw.githubusercontent.com/webaverse/pistol/master/military.glb',
       'https://cdn.statically.io/gh/webaverse/pistol/master/military.glb'
     ],
-    scale: 0.12
+    scale: 0.145
   },
   uziSprayAttack: {
     label: 'Uzi',
     url: 'https://cdn.jsdelivr.net/gh/webaverse/uzi@main/uzi.glb',
-    scale: 0.12
+    scale: 0.14
   },
   ak47VolleyAttack: {
     label: 'AK-47',
@@ -187,7 +187,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://raw.githubusercontent.com/LazerMaker/gun-models-ak47-and-supprest-pistol-/master/ak47.glb',
       'https://cdn.statically.io/gh/LazerMaker/gun-models-ak47-and-supprest-pistol-/master/ak47.glb'
     ],
-    scale: 0.13
+    scale: 0.16
   },
   grenadeBlastAttack: {
     label: 'Grenade',
@@ -196,32 +196,32 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://raw.githubusercontent.com/friuns2/bingextension/main/grenade.glb',
       'https://cdn.statically.io/gh/friuns2/bingextension/main/grenade.glb'
     ],
-    scale: 0.16
+    scale: 0.19
   },
   shotgunBlastAttack: {
     label: 'Shotgun',
     url: 'https://raw.githubusercontent.com/pmndrs/drei-assets/master/shotgun.glb',
-    scale: 0.2
+    scale: 0.228
   },
   sniperShotAttack: {
     label: 'Sniper Rifle',
     url: 'https://raw.githubusercontent.com/pmndrs/drei-assets/master/sniper.glb',
-    scale: 0.22
+    scale: 0.248
   },
   smgBurstAttack: {
     label: 'SMG',
     url: 'https://raw.githubusercontent.com/pmndrs/drei-assets/master/smg.glb',
-    scale: 0.19
+    scale: 0.218
   },
   compactCarbineAttack: {
     label: 'Compact Carbine',
     urls: ['https://raw.githubusercontent.com/pmndrs/drei-assets/master/smg.glb'],
-    scale: 0.18
+    scale: 0.21
   },
   marksmanDmrAttack: {
     label: 'Marksman DMR',
     urls: ['https://raw.githubusercontent.com/pmndrs/drei-assets/master/sniper.glb'],
-    scale: 0.2
+    scale: 0.23
   }
 });
 const CAPTURE_WEAPON_MODEL_CACHE = new Map();
@@ -257,8 +257,26 @@ async function loadCaptureWeaponModel(captureAnimationId) {
   const promise = (async () => {
     const loader = new GLTFLoader();
     loader.setCrossOrigin('anonymous');
+    const imageCache = new Map();
     let loadedRoot = null;
     for (let i = 0; i < candidateUrls.length; i += 1) {
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        const rawBuffer = await fetchBuffer(candidateUrls[i]);
+        // eslint-disable-next-line no-await-in-loop
+        const patchedBuffer = await patchGlbImagesToDataUris(
+          rawBuffer,
+          'fighter',
+          candidateUrls[i],
+          candidateUrls,
+          imageCache
+        );
+        // eslint-disable-next-line no-await-in-loop
+        loadedRoot = await parseObjectFromBuffer(loader, patchedBuffer);
+      } catch (error) {
+        // ignore patched path and try direct loader fallback below
+      }
+      if (loadedRoot) break;
       try {
         // eslint-disable-next-line no-await-in-loop
         const gltf = await loader.loadAsync(candidateUrls[i]);
@@ -360,7 +378,7 @@ async function applyCaptureWeaponDisplay(entry, captureAnimationId) {
   entry.selectedCaptureAnimationId = captureAnimationId;
   entry.weaponHolder.clear();
   const clone = weaponModel.clone(true);
-  fitObjectToTargetSize(clone, CAPTURE_PARK_BOX_TARGET_SIZE * 0.92);
+  fitObjectToTargetSize(clone, CAPTURE_PARK_BOX_TARGET_SIZE * 1.06);
   clone.rotation.y = Math.PI * 0.5;
   clone.position.set(0, 0, -0.004);
   entry.weaponHolder.add(clone);
@@ -1657,6 +1675,42 @@ function createCaptureExplosionFx() {
   return { root, flash, fire, smoke };
 }
 
+function createCaptureBulletTracerFx(color = '#ffe8a3') {
+  const root = new THREE.Group();
+  const core = new THREE.Mesh(
+    new THREE.CylinderGeometry(0.0048, 0.0048, 0.12, 8),
+    new THREE.MeshBasicMaterial({
+      color,
+      transparent: true,
+      opacity: 0.9,
+      depthWrite: false
+    })
+  );
+  core.rotation.z = Math.PI / 2;
+  root.add(core);
+  root.visible = false;
+  return { root, core };
+}
+
+function createCaptureShellCasingFx() {
+  const root = new THREE.Mesh(
+    new THREE.CylinderGeometry(0.004, 0.004, 0.016, 10),
+    new THREE.MeshStandardMaterial({ color: '#d4a64a', metalness: 0.88, roughness: 0.22 })
+  );
+  root.castShadow = true;
+  root.receiveShadow = true;
+  root.visible = false;
+  return root;
+}
+
+function createCaptureMuzzleFx() {
+  const root = new THREE.Group();
+  const flash = addFxSphere(root, 0.06, [0, 0, 0], '#ffd78a', 0.05, 0, true, 0.95);
+  const smoke = addFxSphere(root, 0.075, [0.03, 0, 0], '#8b929b', 0.95, 0, true, 0.42);
+  root.visible = false;
+  return { root, flash, smoke };
+}
+
 function detectCoarsePointer() {
   if (typeof window === 'undefined') {
     return false;
@@ -1977,7 +2031,7 @@ const CUSTOM_CHAIR_ANGLES = [
 ];
 const AI_ROLL_DELAY_MS = 2000;
 const AI_EXTRA_TURN_DELAY_MS = 1600;
-const HUMAN_ROLL_DELAY_MS = 2600;
+const HUMAN_ROLL_DELAY_MS = 1880;
 const AUTO_ROLL_DURATION_MS = 1100;
 const DICE_RESULT_EXTRA_HOLD_MS = 3000;
 const ANIMATION_BASE_FPS = 60;
@@ -2004,8 +2058,8 @@ const SEATED_HUMAN_FACING_Y = 0;
 // Keep feet lower to preserve the deeper seat grounding after the stronger vertical drop.
 const SEATED_HUMAN_FOOT_GROUND_CLEARANCE = -1.55 * MODEL_SCALE * STOOL_SCALE;
 const SEATED_HUMAN_DICE_PHASES = Object.freeze({
-  reachMs: 380,
-  gripMs: 300,
+  reachMs: 250,
+  gripMs: 180,
   holdMs: 220,
   windupMs: 300,
   releaseMs: 260,
@@ -2022,10 +2076,10 @@ const SEATED_HUMAN_MOTION_TUNING = Object.freeze({
   throwPrecision: 1.08,
   tokenPrecision: 1.14
 });
-const SEATED_HELPER_FORWARD_DICE_PICKUP = 0.079 * MODEL_SCALE;
+const SEATED_HELPER_FORWARD_DICE_PICKUP = 0.092 * MODEL_SCALE;
 const SEATED_HELPER_FORWARD_DICE_RELEASE = 0.148 * MODEL_SCALE;
 const SEATED_HELPER_RIGHT_DICE = -0.013 * MODEL_SCALE;
-const SEATED_HELPER_UP_DICE_PICKUP = -0.004 * MODEL_SCALE;
+const SEATED_HELPER_UP_DICE_PICKUP = -0.008 * MODEL_SCALE;
 const SEATED_HELPER_UP_DICE_RELEASE = 0.01 * MODEL_SCALE;
 const SEATED_HELPER_FORWARD_TOKEN_PICKUP = 0.076 * MODEL_SCALE;
 const SEATED_HELPER_FORWARD_TOKEN_PLACE = 0.114 * MODEL_SCALE;
@@ -3566,6 +3620,9 @@ const TOKEN_MOVE_SPEED = 2.45;
 const TOKEN_STEP_DURATION_SECONDS = 0.34;
 const LUDO_CAPTURE_MISSILE_LAUNCH_SOUND_URL = '/assets/sounds/launch-85216.mp3';
 const LUDO_CAPTURE_MISSILE_IMPACT_SOUND_URL = '/assets/sounds/080998_bullet-hit-39870.mp3';
+const LUDO_CAPTURE_FIREARM_SHOT_SOUND_URL = '/assets/sounds/launch-85216.mp3';
+const LUDO_CAPTURE_FIREARM_SHELL_SOUND_URL = '/assets/sounds/metal-whistle-6121.mp3';
+const LUDO_CAPTURE_GLASS_SHATTER_SOUND_URL = '/assets/sounds/glass-bottle-breaking-351297.mp3';
 const LUDO_CAPTURE_DRONE_SOUND_URL =
   '/assets/sounds/kimsa-kimsa-big-motorcycle-sound-394700.mp3';
 const LUDO_CAPTURE_FIGHTER_SOUND_URL = '/assets/sounds/race-care-151963.mp3';
@@ -4863,7 +4920,7 @@ function resolveSeatedHumanActionPose(actorState, gameState, playerIndex, nowMs)
       ...basePose,
       mode: 'holdDice',
       intensity: 1,
-      handGrip: 0.92,
+      handGrip: playerIndex === 0 ? 0.2 : 0.92,
       motionTuning: { idleBreathAmp: 0.008, precision: 1.08 }
     };
   }
@@ -4978,7 +5035,24 @@ async function loadSeatedHumanTemplate(renderer = null, humanOption = HUMAN_CHAR
           : ['https://threejs.org/examples/models/gltf/readyplayer.me.glb'];
         let gltf = null;
         let lastError = null;
+        const patchedLoader = createConfiguredGLTFLoader(renderer);
+        patchedLoader.setCrossOrigin('anonymous');
+        const imageCache = new Map();
         for (const url of urls) {
+          try {
+            // eslint-disable-next-line no-await-in-loop
+            const rawBuffer = await fetchBuffer(url);
+            // eslint-disable-next-line no-await-in-loop
+            const patchedBuffer = await patchGlbImagesToDataUris(rawBuffer, 'fighter', url, urls, imageCache);
+            // eslint-disable-next-line no-await-in-loop
+            const patchedRoot = await parseObjectFromBuffer(patchedLoader, patchedBuffer);
+            if (patchedRoot) {
+              gltf = { scene: patchedRoot };
+            }
+            if (gltf) break;
+          } catch (error) {
+            // ignore patched path and retry with default loader
+          }
           try {
             // eslint-disable-next-line no-await-in-loop
             gltf = await loader.loadAsync(url);
@@ -5262,6 +5336,9 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
   const captureSoundRef = useRef(null);
   const missileLaunchSoundRef = useRef(null);
   const missileImpactSoundRef = useRef(null);
+  const firearmShotSoundRef = useRef(null);
+  const firearmShellSoundRef = useRef(null);
+  const firearmGlassSoundRef = useRef(null);
   const droneSoundRef = useRef(null);
   const fighterJetSoundRef = useRef(null);
   const helicopterSoundRef = useRef(null);
@@ -6978,7 +7055,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
   useEffect(() => {
     const applyVolume = (baseVolume) => {
       const level = settingsRef.current.soundEnabled ? baseVolume : 0;
-      [moveSoundRef, captureSoundRef, missileLaunchSoundRef, missileImpactSoundRef, droneSoundRef, fighterJetSoundRef, helicopterSoundRef, cheerSoundRef, diceSoundRef, diceRewardSoundRef, sixRollSoundRef, hahaSoundRef, giftBombSoundRef].forEach((ref) => {
+      [moveSoundRef, captureSoundRef, missileLaunchSoundRef, missileImpactSoundRef, firearmShotSoundRef, firearmShellSoundRef, firearmGlassSoundRef, droneSoundRef, fighterJetSoundRef, helicopterSoundRef, cheerSoundRef, diceSoundRef, diceRewardSoundRef, sixRollSoundRef, hahaSoundRef, giftBombSoundRef].forEach((ref) => {
         if (ref.current) {
           ref.current.volume = level;
           if (!settingsRef.current.soundEnabled) {
@@ -6995,6 +7072,9 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     captureSoundRef.current = new Audio(bombSound);
     missileLaunchSoundRef.current = new Audio(LUDO_CAPTURE_MISSILE_LAUNCH_SOUND_URL);
     missileImpactSoundRef.current = new Audio(LUDO_CAPTURE_MISSILE_IMPACT_SOUND_URL);
+    firearmShotSoundRef.current = new Audio(LUDO_CAPTURE_FIREARM_SHOT_SOUND_URL);
+    firearmShellSoundRef.current = new Audio(LUDO_CAPTURE_FIREARM_SHELL_SOUND_URL);
+    firearmGlassSoundRef.current = new Audio(LUDO_CAPTURE_GLASS_SHATTER_SOUND_URL);
     droneSoundRef.current = new Audio(LUDO_CAPTURE_DRONE_SOUND_URL);
     droneSoundRef.current.loop = true;
     droneSoundRef.current.volume = 0.42;
@@ -8282,6 +8362,21 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     missileImpactSoundRef.current.currentTime = 0;
     missileImpactSoundRef.current.play().catch(() => {});
   };
+  const playFirearmShotSound = () => {
+    if (!settingsRef.current.soundEnabled || !firearmShotSoundRef.current) return;
+    firearmShotSoundRef.current.currentTime = 0;
+    firearmShotSoundRef.current.play().catch(() => {});
+  };
+  const playFirearmShellSound = () => {
+    if (!settingsRef.current.soundEnabled || !firearmShellSoundRef.current) return;
+    firearmShellSoundRef.current.currentTime = 0;
+    firearmShellSoundRef.current.play().catch(() => {});
+  };
+  const playGlassShatterSound = () => {
+    if (!settingsRef.current.soundEnabled || !firearmGlassSoundRef.current) return;
+    firearmGlassSoundRef.current.currentTime = 0;
+    firearmGlassSoundRef.current.play().catch(() => {});
+  };
 
   const playHelicopterSound = () => {
     if (!settingsRef.current.soundEnabled || !helicopterSoundRef.current) return;
@@ -8411,6 +8506,140 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         const isHelicopterAttack = resolvedCaptureAnimationId === 'helicopterAttack';
         const isDroneAttack = resolvedCaptureAnimationId === 'droneAttack';
         const isFighterJetAttack = resolvedCaptureAnimationId === 'fighterJetAttack';
+        const isFirearmAttack = FIREARM_CAPTURE_ANIMATION_IDS.has(resolvedCaptureAnimationId);
+        if (isFirearmAttack) {
+          const attackerEntry = seatedHumanActorsRef.current?.find((entry) => entry?.playerIndex === attackerPlayer);
+          const muzzleOrigin = new THREE.Vector3();
+          const muzzleTarget = new THREE.Vector3();
+          const shellBase = new THREE.Vector3();
+          const shooterRoot = attackerEntry?.actorRoot;
+          if (shooterRoot?.isObject3D) {
+            shooterRoot.updateMatrixWorld?.(true);
+            shooterRoot.getWorldPosition(muzzleOrigin);
+            muzzleOrigin.y += 0.09;
+            muzzleOrigin.add(new THREE.Vector3(0.02, 0.01, 0.02));
+          } else {
+            muzzleOrigin.copy(startPosition).add(new THREE.Vector3(0, 0.08, 0));
+          }
+          muzzleTarget.copy(targetPosition).add(new THREE.Vector3(0, 0.03, 0));
+          const shots = resolvedCaptureAnimationId === 'shotgunBlastAttack' ? 10 : 18;
+          const cadenceMs = resolvedCaptureAnimationId === 'sniperShotAttack' ? 85 : 42;
+          const volleyStart = performance.now();
+          const durationMs = shots * cadenceMs + 420;
+          const muzzleFx = createCaptureMuzzleFx();
+          const tracers = Array.from({ length: 10 }, () => createCaptureBulletTracerFx('#ffe39a'));
+          const shells = Array.from({ length: 14 }, () => createCaptureShellCasingFx());
+          scene.add(muzzleFx.root);
+          tracers.forEach((entry) => scene.add(entry.root));
+          shells.forEach((entry) => scene.add(entry));
+          const tokenGlassShards = [];
+          let shatterDone = false;
+          const hideTarget = targetToken?.isObject3D ? targetToken : null;
+          const tickFirearm = () => {
+            const elapsed = performance.now() - volleyStart;
+            const shotIdx = Math.floor(elapsed / cadenceMs);
+            muzzleFx.root.position.copy(muzzleOrigin);
+            muzzleFx.root.visible = elapsed < shots * cadenceMs;
+            if (elapsed < shots * cadenceMs) {
+              if (elapsed % cadenceMs < 16) {
+                playFirearmShotSound();
+                playFirearmShellSound();
+              }
+              const pulse = 1 - ((elapsed % cadenceMs) / Math.max(1, cadenceMs));
+              muzzleFx.flash.scale.setScalar(0.8 + pulse * 0.8);
+              muzzleFx.flash.material.opacity = clamp(0.15 + pulse * 0.9, 0, 1);
+              muzzleFx.smoke.scale.setScalar(0.75 + pulse * 0.3);
+              muzzleFx.smoke.material.opacity = clamp(0.06 + pulse * 0.2, 0, 0.35);
+            } else {
+              muzzleFx.root.visible = false;
+            }
+            tracers.forEach((entry, idx) => {
+              const active = idx <= shotIdx && idx > shotIdx - 2;
+              entry.root.visible = active;
+              if (!active) return;
+              const spread = new THREE.Vector3((Math.random() - 0.5) * 0.018, (Math.random() - 0.5) * 0.016, (Math.random() - 0.5) * 0.018);
+              const from = muzzleOrigin.clone().add(spread);
+              const to = muzzleTarget.clone().add(spread.multiplyScalar(0.3));
+              const mid = from.clone().lerp(to, 0.5);
+              const dir = to.clone().sub(from).normalize();
+              entry.root.position.copy(mid);
+              entry.root.quaternion.setFromUnitVectors(MISSILE_FORWARD, dir);
+            });
+            shells.forEach((shell, idx) => {
+              const launchAt = idx * (cadenceMs * 0.7);
+              const shellLife = elapsed - launchAt;
+              if (shellLife < 0 || shellLife > 620) {
+                shell.visible = false;
+                return;
+              }
+              shell.visible = true;
+              if (shellLife < 18) shellBase.copy(muzzleOrigin);
+              shell.position.set(
+                shellBase.x + shellLife * 0.00022,
+                shellBase.y + 0.02 + Math.sin((shellLife / 620) * Math.PI) * 0.04 - shellLife * 0.00008,
+                shellBase.z - shellLife * 0.00018
+              );
+              shell.rotation.x += 0.28;
+              shell.rotation.y += 0.19;
+              shell.rotation.z += 0.22;
+            });
+            const impactPhase = clamp((elapsed - shots * cadenceMs * 0.72) / Math.max(140, shots * cadenceMs * 0.28), 0, 1);
+            if (!shatterDone && impactPhase >= 0.92) {
+              shatterDone = true;
+              playGlassShatterSound();
+              if (hideTarget) hideTarget.visible = false;
+              for (let i = 0; i < 14; i += 1) {
+                const shard = new THREE.Mesh(
+                  new THREE.BoxGeometry(0.007 + Math.random() * 0.012, 0.005 + Math.random() * 0.01, 0.004 + Math.random() * 0.009),
+                  new THREE.MeshStandardMaterial({
+                    color: '#a9e8ff',
+                    emissive: '#b7dfff',
+                    emissiveIntensity: 0.22,
+                    transparent: true,
+                    opacity: 0.76,
+                    metalness: 0.15,
+                    roughness: 0.32
+                  })
+                );
+                shard.position.copy(muzzleTarget);
+                shard.userData.velocity = new THREE.Vector3(
+                  (Math.random() - 0.5) * 0.012,
+                  0.012 + Math.random() * 0.01,
+                  (Math.random() - 0.5) * 0.012
+                );
+                tokenGlassShards.push(shard);
+                scene.add(shard);
+              }
+            }
+            tokenGlassShards.forEach((shard) => {
+              const v = shard.userData.velocity;
+              shard.position.add(v);
+              v.y -= 0.0012;
+              shard.rotation.x += 0.18;
+              shard.rotation.y += 0.22;
+              shard.material.opacity = Math.max(0, shard.material.opacity - 0.016);
+            });
+            if (elapsed < durationMs) {
+              requestAnimationFrame(tickFirearm);
+              return;
+            }
+            if (hideTarget) hideTarget.visible = true;
+            [muzzleFx.root, ...tracers.map((entry) => entry.root), ...shells, ...tokenGlassShards].forEach((obj) => {
+              obj?.parent?.remove?.(obj);
+            });
+            playCapture();
+            seatedHumanActionRef.current = {
+              ...seatedHumanActionRef.current,
+              capturePlayer: null,
+              captureStartMs: 0,
+              captureEndMs: 0,
+              captureAnimationId: null
+            };
+            resolve();
+          };
+          requestAnimationFrame(tickFirearm);
+          return;
+        }
         const parkedEntry = parkedCaptureVehiclesRef.current.get(attackerPlayer);
         isMissileTruckAttack = resolvedCaptureAnimationId === 'missileJavelin';
         parkedLaunch =
@@ -10023,7 +10252,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     return true;
   }, []);
 
-  const syncDiceToThrowHand = useCallback((player, dice, { duration = 220 } = {}) => {
+  const syncDiceToThrowHand = useCallback((player, dice, { duration = 150 } = {}) => {
     if (!dice?.isObject3D || !dice.parent?.isObject3D) return Promise.resolve();
     const parent = dice.parent;
     const worldTarget = new THREE.Vector3();
@@ -10038,10 +10267,10 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         const elapsed = performance.now() - start;
         const phase = clamp(elapsed / Math.max(1, duration), 0, 1);
         if (sampleSeatedContactEffectorPosition(player, worldTarget)) {
-          worldTarget.y -= DICE_SIZE * 0.14;
+          worldTarget.y -= DICE_SIZE * 0.08;
           localTarget.copy(worldTarget);
           parent.worldToLocal(localTarget);
-          const blend = 0.24 + (1 - Math.pow(1 - phase, 2)) * 0.58;
+          const blend = 0.38 + (1 - Math.pow(1 - phase, 2)) * 0.58;
           dice.position.lerp(localTarget, blend);
         }
         if (phase < 1) {
@@ -10102,7 +10331,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       throwForward = clamp(-localDir.z * 1.4, -1, 1);
     }
     beginDiceThrowPose(player, { lateral: throwLateral, forward: throwForward });
-    await syncDiceToThrowHand(player, dice, { duration: 230 });
+    await syncDiceToThrowHand(player, dice, { duration: 150 });
     const landingFocus = baseTarget.clone();
     const value = await spinDice(dice, {
       duration: resolveFrameSyncedDuration(AUTO_ROLL_DURATION_MS, { min: 620, max: 1800 }),


### PR DESCRIPTION
### Motivation
- Make small firearms behave and read like real guns during capture animations with bullet tracers, ejected shells, muzzle flash/smoke and per-shot audio instead of reusing missile flight logic.
- Ensure weapon and human GLTFs preserve their original textures when external image URIs exist, and make sidearms/rifles visually larger so they read better on portrait devices.
- Improve feel and responsiveness of seated human dice pickup/hold behavior so picks happen sooner and the bottom (local) player's hand stays more open until throw.

### Description
- Added a dedicated firearm capture flow that runs a rapid bullet-volley sequence (tracers, muzzle flash/smoke, shell ejection, token glass-shatter impact) for IDs in `FIREARM_CAPTURE_ANIMATION_IDS` and leaves air/missile vehicle logic unchanged; implemented in `playCaptureMissileSequence` handling in `LudoBattleRoyal.jsx`.
- Implemented new FX helpers: `createCaptureBulletTracerFx`, `createCaptureShellCasingFx`, and `createCaptureMuzzleFx` and wired them into the firearm sequence; added glass-shatter token debris on impact.
- Added and wired firearm-specific audio URLs/refs and playback helpers (`LUDO_CAPTURE_FIREARM_SHOT_SOUND_URL`, `LUDO_CAPTURE_FIREARM_SHELL_SOUND_URL`, `LUDO_CAPTURE_GLASS_SHATTER_SOUND_URL`, `playFirearmShotSound`, `playFirearmShellSound`, `playGlassShatterSound`) so shots, shell ejection and shatter events produce sound.
- Increased weapon presentation size: bumped model `scale` values in `CAPTURE_WEAPON_MODEL_CONFIG` for sidearms and rifles and adjusted weapon rack display `fitObjectToTargetSize(clone, CAPTURE_PARK_BOX_TARGET_SIZE * 1.06)` so firearms read larger while leaving jet/helicopter/drone/truck scales untouched.
- Improved GLTF image handling for capture weapons and seated human templates by attempting to `fetchBuffer` + `patchGlbImagesToDataUris` (resolve external image URIs into data-URIs) and parse the patched buffer before falling back to `loader.loadAsync`; this helps preserve original GLTF textures when assets reference external images.
- Tightened human dice pickup and throw timing: reduced `SEATED_HUMAN_DICE_PHASES.reachMs` and `gripMs`, adjusted helper pickup offsets (`SEATED_HELPER_FORWARD_DICE_PICKUP`, `SEATED_HELPER_UP_DICE_PICKUP`), reduced `HUMAN_ROLL_DELAY_MS`, shortened `syncDiceToThrowHand` duration and adjusted `blend`/Y offsets so the dice moves earlier and closer to the hand, and set the bottom player's `handGrip` while holding to a more open value until throw.
- Minor change: enlarged weapon fit on the parked rack and adjusted `fitObjectToTargetSize` usage so displayed firearms appear a bit bigger in the weapon rack.
- All changes are contained in `webapp/src/pages/Games/LudoBattleRoyal.jsx`.

### Testing
- Ran `npx eslint webapp/src/pages/Games/LudoBattleRoyal.jsx`; the command completed and reported the file is ignored by the repository ESLint ignore pattern (no lint errors were produced for the changed file in this run).
- No other automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee15433c2083298dd82d1326266e46)