### PR TITLE
Ludo: adjust human dice pickup posture, tighten dice-hand sync, and restore manual token selection

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -4511,35 +4511,35 @@ function applySeatedHumanPose(rig, mode = 'idle', intensity = 1, handGrip = 0, t
   const bodyLockedMode = mode !== 'idle';
 
   if (mode === 'reachDice') {
-    shoulderX = THREE.MathUtils.lerp(shoulderX, -0.78, t);
-    shoulderY = THREE.MathUtils.lerp(shoulderY, -0.08, t);
-    shoulderZ = THREE.MathUtils.lerp(shoulderZ, -1.06, t);
-    forearmX = THREE.MathUtils.lerp(forearmX, -1.02, t);
-    forearmY = THREE.MathUtils.lerp(forearmY, -0.18, t);
-    forearmZ = THREE.MathUtils.lerp(forearmZ, -0.34, t);
-    wristX = THREE.MathUtils.lerp(wristX, -0.3, t);
-    wristY = THREE.MathUtils.lerp(wristY, 0.24, t);
-    wristZ = THREE.MathUtils.lerp(wristZ, -0.24, t);
-  } else if (mode === 'gripDice') {
-    shoulderX = THREE.MathUtils.lerp(shoulderX, -0.76, t);
-    shoulderY = THREE.MathUtils.lerp(shoulderY, -0.10, t);
-    shoulderZ = THREE.MathUtils.lerp(shoulderZ, -0.92, t);
-    forearmX = THREE.MathUtils.lerp(forearmX, -0.98, t);
-    forearmY = THREE.MathUtils.lerp(forearmY, -0.22, t);
-    forearmZ = THREE.MathUtils.lerp(forearmZ, -0.12, t);
-    wristX = THREE.MathUtils.lerp(wristX, -0.4, t);
-    wristY = THREE.MathUtils.lerp(wristY, 0.18, t);
-    wristZ = THREE.MathUtils.lerp(wristZ, -0.08, t);
-  } else if (mode === 'holdDice') {
-    shoulderX = THREE.MathUtils.lerp(shoulderX, -0.5, t);
-    shoulderY = THREE.MathUtils.lerp(shoulderY, -0.18, t);
-    shoulderZ = THREE.MathUtils.lerp(shoulderZ, -0.34, t);
+    shoulderX = THREE.MathUtils.lerp(shoulderX, -0.82, t);
+    shoulderY = THREE.MathUtils.lerp(shoulderY, -0.12, t);
+    shoulderZ = THREE.MathUtils.lerp(shoulderZ, -1.04, t);
     forearmX = THREE.MathUtils.lerp(forearmX, -1.08, t);
-    forearmY = THREE.MathUtils.lerp(forearmY, -0.1, t);
-    forearmZ = THREE.MathUtils.lerp(forearmZ, 0.38, t);
-    wristX = THREE.MathUtils.lerp(wristX, -0.56, t);
-    wristY = THREE.MathUtils.lerp(wristY, 0.06, t);
-    wristZ = THREE.MathUtils.lerp(wristZ, 0.14, t);
+    forearmY = THREE.MathUtils.lerp(forearmY, -0.2, t);
+    forearmZ = THREE.MathUtils.lerp(forearmZ, -0.22, t);
+    wristX = THREE.MathUtils.lerp(wristX, -0.74, t);
+    wristY = THREE.MathUtils.lerp(wristY, -0.04, t);
+    wristZ = THREE.MathUtils.lerp(wristZ, 0.22, t);
+  } else if (mode === 'gripDice') {
+    shoulderX = THREE.MathUtils.lerp(shoulderX, -0.8, t);
+    shoulderY = THREE.MathUtils.lerp(shoulderY, -0.14, t);
+    shoulderZ = THREE.MathUtils.lerp(shoulderZ, -0.88, t);
+    forearmX = THREE.MathUtils.lerp(forearmX, -1.02, t);
+    forearmY = THREE.MathUtils.lerp(forearmY, -0.24, t);
+    forearmZ = THREE.MathUtils.lerp(forearmZ, 0.02, t);
+    wristX = THREE.MathUtils.lerp(wristX, -0.84, t);
+    wristY = THREE.MathUtils.lerp(wristY, -0.1, t);
+    wristZ = THREE.MathUtils.lerp(wristZ, 0.18, t);
+  } else if (mode === 'holdDice') {
+    shoulderX = THREE.MathUtils.lerp(shoulderX, -0.52, t);
+    shoulderY = THREE.MathUtils.lerp(shoulderY, -0.2, t);
+    shoulderZ = THREE.MathUtils.lerp(shoulderZ, -0.3, t);
+    forearmX = THREE.MathUtils.lerp(forearmX, -1.1, t);
+    forearmY = THREE.MathUtils.lerp(forearmY, -0.12, t);
+    forearmZ = THREE.MathUtils.lerp(forearmZ, 0.32, t);
+    wristX = THREE.MathUtils.lerp(wristX, -0.92, t);
+    wristY = THREE.MathUtils.lerp(wristY, -0.12, t);
+    wristZ = THREE.MathUtils.lerp(wristZ, 0.12, t);
   } else if (mode === 'windUp') {
     shoulderX = THREE.MathUtils.lerp(shoulderX, -0.88, t);
     shoulderY = THREE.MathUtils.lerp(shoulderY, -0.38, t);
@@ -9735,12 +9735,6 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       }
     }
     const token = state.tokens[player][tokenIndex];
-    const pickupHelper = new THREE.Vector3();
-    const placeHelper = new THREE.Vector3();
-    const hasPickupHelper =
-      enteringMove && sampleHumanActionHelperPosition(player, 'tokenPickup', pickupHelper);
-    const hasPlaceHelper =
-      enteringMove && sampleHumanActionHelperPosition(player, 'tokenPlace', placeHelper);
     const pushPathNode = (collection, position, progress = null, viaHelper = null) => {
       collection.push({
         position,
@@ -9752,9 +9746,6 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     if (path.length) {
       pushPathNode(animatedPath, path[0].position, path[0].progress);
       for (let i = 1; i < path.length; i += 1) {
-        if (hasPlaceHelper && i === path.length - 1 && path[i - 1].position.distanceTo(placeHelper) > 1e-4) {
-          pushPathNode(animatedPath, placeHelper.clone(), null, 'place');
-        }
         pushPathNode(animatedPath, path[i].position, path[i].progress);
       }
     }
@@ -10276,6 +10267,12 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         if (phase < 1) {
           requestAnimationFrame(step);
         } else {
+          if (sampleSeatedContactEffectorPosition(player, worldTarget)) {
+            worldTarget.y -= DICE_SIZE * 0.08;
+            localTarget.copy(worldTarget);
+            parent.worldToLocal(localTarget);
+            dice.position.copy(localTarget);
+          }
           resolve();
         }
       };
@@ -10330,8 +10327,9 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       throwLateral = clamp(localDir.x * 2.1, -1, 1);
       throwForward = clamp(-localDir.z * 1.4, -1, 1);
     }
+    beginDiceHoldPose(player, { startMs: performance.now() - SEATED_HUMAN_DICE_PHASES.reachMs });
+    await syncDiceToThrowHand(player, dice, { duration: 72 });
     beginDiceThrowPose(player, { lateral: throwLateral, forward: throwForward });
-    await syncDiceToThrowHand(player, dice, { duration: 150 });
     const landingFocus = baseTarget.clone();
     const value = await spinDice(dice, {
       duration: resolveFrameSyncedDuration(AUTO_ROLL_DURATION_MS, { min: 620, max: 1800 }),
@@ -10389,18 +10387,6 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     if (player === 0) {
       preserveUserTurnCameraRef.current = true;
       lockUserTurnSeatViewRef.current = true;
-      const enteringOptions = options.filter((option) => option.entering);
-      if (enteringOptions.length) {
-        beginHumanSelection(value, enteringOptions, { skipCameraFollow: !hasBoardTokenBeforeRoll });
-        return;
-      }
-      const choice = chooseMoveOption(state, 0, value, options);
-      if (choice) {
-        moveToken(0, choice.token, value, {
-          skipCameraFollow: !hasBoardTokenBeforeRoll || choice.entering
-        });
-        return;
-      }
       beginHumanSelection(value, options, { skipCameraFollow: !hasBoardTokenBeforeRoll });
       return;
     }


### PR DESCRIPTION
### Motivation
- Fix human character hand orientation when picking up dice so fingers point downwards and the hand looks like it grabs the dice, not palm-up.  
- Eliminate the intermediate placement detour so entering tokens animate directly to the correct start tile.  
- Reduce the perceived delay between hand motion and dice movement so the dice arrive on the fist/hand naturally.  
- Restore explicit human control so the player must choose which token to move on their turn instead of the client auto-picking.

### Description
- Tweaked seated human right-arm pose targets for dice pickup states (`reachDice`, `gripDice`, `holdDice`) to orient the hand downward and adjust forearm/wrist values for a natural grab (file: `webapp/src/pages/Games/LudoBattleRoyal.jsx`).
- Removed the intermediate `tokenPlace` helper insertion from the path builder so entering moves go straight from home pad to board start tile instead of briefly placing on an incorrect tile (file: `webapp/src/pages/Games/LudoBattleRoyal.jsx`).
- Tightened dice-hand synchronization by starting the hand pre-hold earlier, reducing the sync duration, and snapping the dice to the contact effector at the end of `syncDiceToThrowHand` to avoid visible lag (file: `webapp/src/pages/Games/LudoBattleRoyal.jsx`).
- Restored manual human token selection by always invoking `beginHumanSelection` for the player on roll completion instead of auto-applying a chosen move; this forces the user to tap/select which token to move (file: `webapp/src/pages/Games/LudoBattleRoyal.jsx`).

### Testing
- Ran the webapp production build with `cd webapp && npm run build`, which completed successfully and produced build artifacts.  
- Build reported non-blocking Vite warnings about chunking/duplicate keys, but the build finished without errors.  
- No other automated unit tests were run in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee1e9bd8548329bd5a59cebc60bb2e)