### PR TITLE
Adjust human hand pose & token placement flow in LudoBattleRoyal

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -4513,23 +4513,23 @@ function applySeatedHumanPose(rig, mode = 'idle', intensity = 1, handGrip = 0, t
   if (mode === 'reachDice') {
     shoulderX = THREE.MathUtils.lerp(shoulderX, -0.78, t);
     shoulderY = THREE.MathUtils.lerp(shoulderY, -0.08, t);
-    shoulderZ = THREE.MathUtils.lerp(shoulderZ, -1.06, t);
-    forearmX = THREE.MathUtils.lerp(forearmX, -1.02, t);
-    forearmY = THREE.MathUtils.lerp(forearmY, -0.18, t);
-    forearmZ = THREE.MathUtils.lerp(forearmZ, -0.34, t);
-    wristX = THREE.MathUtils.lerp(wristX, -0.3, t);
-    wristY = THREE.MathUtils.lerp(wristY, 0.24, t);
-    wristZ = THREE.MathUtils.lerp(wristZ, -0.24, t);
+    shoulderZ = THREE.MathUtils.lerp(shoulderZ, -1.18, t);
+    forearmX = THREE.MathUtils.lerp(forearmX, -1.18, t);
+    forearmY = THREE.MathUtils.lerp(forearmY, -0.2, t);
+    forearmZ = THREE.MathUtils.lerp(forearmZ, -0.38, t);
+    wristX = THREE.MathUtils.lerp(wristX, -0.72, t);
+    wristY = THREE.MathUtils.lerp(wristY, 0.08, t);
+    wristZ = THREE.MathUtils.lerp(wristZ, -0.28, t);
   } else if (mode === 'gripDice') {
     shoulderX = THREE.MathUtils.lerp(shoulderX, -0.76, t);
     shoulderY = THREE.MathUtils.lerp(shoulderY, -0.10, t);
-    shoulderZ = THREE.MathUtils.lerp(shoulderZ, -0.92, t);
-    forearmX = THREE.MathUtils.lerp(forearmX, -0.98, t);
-    forearmY = THREE.MathUtils.lerp(forearmY, -0.22, t);
-    forearmZ = THREE.MathUtils.lerp(forearmZ, -0.12, t);
-    wristX = THREE.MathUtils.lerp(wristX, -0.4, t);
-    wristY = THREE.MathUtils.lerp(wristY, 0.18, t);
-    wristZ = THREE.MathUtils.lerp(wristZ, -0.08, t);
+    shoulderZ = THREE.MathUtils.lerp(shoulderZ, -1.04, t);
+    forearmX = THREE.MathUtils.lerp(forearmX, -1.08, t);
+    forearmY = THREE.MathUtils.lerp(forearmY, -0.24, t);
+    forearmZ = THREE.MathUtils.lerp(forearmZ, -0.24, t);
+    wristX = THREE.MathUtils.lerp(wristX, -0.84, t);
+    wristY = THREE.MathUtils.lerp(wristY, 0.04, t);
+    wristZ = THREE.MathUtils.lerp(wristZ, -0.12, t);
   } else if (mode === 'holdDice') {
     shoulderX = THREE.MathUtils.lerp(shoulderX, -0.5, t);
     shoulderY = THREE.MathUtils.lerp(shoulderY, -0.18, t);
@@ -4920,7 +4920,7 @@ function resolveSeatedHumanActionPose(actorState, gameState, playerIndex, nowMs)
       ...basePose,
       mode: 'holdDice',
       intensity: 1,
-      handGrip: playerIndex === 0 ? 0.2 : 0.92,
+      handGrip: 0.94,
       motionTuning: { idleBreathAmp: 0.008, precision: 1.08 }
     };
   }
@@ -9735,12 +9735,9 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       }
     }
     const token = state.tokens[player][tokenIndex];
-    const pickupHelper = new THREE.Vector3();
     const placeHelper = new THREE.Vector3();
-    const hasPickupHelper =
-      enteringMove && sampleHumanActionHelperPosition(player, 'tokenPickup', pickupHelper);
     const hasPlaceHelper =
-      enteringMove && sampleHumanActionHelperPosition(player, 'tokenPlace', placeHelper);
+      !enteringMove && sampleHumanActionHelperPosition(player, 'tokenPlace', placeHelper);
     const pushPathNode = (collection, position, progress = null, viaHelper = null) => {
       collection.push({
         position,
@@ -10331,7 +10328,9 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       throwForward = clamp(-localDir.z * 1.4, -1, 1);
     }
     beginDiceThrowPose(player, { lateral: throwLateral, forward: throwForward });
-    await syncDiceToThrowHand(player, dice, { duration: 150 });
+    await syncDiceToThrowHand(player, dice, {
+      duration: Math.max(80, Math.round(SEATED_HUMAN_DICE_PHASES.gripMs * 0.78))
+    });
     const landingFocus = baseTarget.clone();
     const value = await spinDice(dice, {
       duration: resolveFrameSyncedDuration(AUTO_ROLL_DURATION_MS, { min: 620, max: 1800 }),
@@ -10389,18 +10388,6 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     if (player === 0) {
       preserveUserTurnCameraRef.current = true;
       lockUserTurnSeatViewRef.current = true;
-      const enteringOptions = options.filter((option) => option.entering);
-      if (enteringOptions.length) {
-        beginHumanSelection(value, enteringOptions, { skipCameraFollow: !hasBoardTokenBeforeRoll });
-        return;
-      }
-      const choice = chooseMoveOption(state, 0, value, options);
-      if (choice) {
-        moveToken(0, choice.token, value, {
-          skipCameraFollow: !hasBoardTokenBeforeRoll || choice.entering
-        });
-        return;
-      }
       beginHumanSelection(value, options, { skipCameraFollow: !hasBoardTokenBeforeRoll });
       return;
     }


### PR DESCRIPTION
### Motivation
- Improve the visual fidelity and responsiveness of seated human characters when they pick up and hold dice so the fingers point downward and the die snaps into the fist more quickly. 
- Ensure tokens entering the board go directly to their start tile (no intermediate placement on another tile) and restore explicit user choice when it is the human player's turn.

### Description
- Tweaked seated human right-arm pose interpolation in `reachDice` and `gripDice` to rotate forearm/wrist so the fingers point downwards during dice pickup by adjusting several lerp target values in `applySeatedHumanPose` in `webapp/src/pages/Games/LudoBattleRoyal.jsx`.
- Increased hold-phase closure by setting `handGrip` in the `holdDice` pose to `0.94` to keep the die visibly in a closed fist instead of an open palm.
- Reduced perceived dice-to-hand lag by changing the dice sync timing call to use `Math.max(80, Math.round(SEATED_HUMAN_DICE_PHASES.gripMs * 0.78))` when awaiting `syncDiceToThrowHand` so the dice move into the hand during the grip phase.
- Prevented board-entry token animations from detouring via the place-helper by only sampling the `tokenPlace` helper when `enteringMove` is false (so entering tokens go straight to their start tile) inside `scheduleMove` path construction.
- Restored human selection flow for player 0 by always invoking `beginHumanSelection(value, options, ...)` when move options exist, removing the earlier auto-pick path so the human player explicitly selects which token to move.
- All source edits are contained in `webapp/src/pages/Games/LudoBattleRoyal.jsx`.

### Testing
- Ran the production build with `npm --prefix webapp run build` and it completed successfully.
- The build produced non-blocking Vite warnings about chunk size / dynamic import patterns but no errors and the build artifacts were generated (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee1e9bd8548329bd5a59cebc60bb2e)