### PR TITLE
Faster dice pickup + downward hand pose; refresh Ludo human store avatars

### DIFF
--- a/webapp/src/config/ludoBattleOptions.js
+++ b/webapp/src/config/ludoBattleOptions.js
@@ -191,44 +191,40 @@ export const HUMAN_CHARACTER_OPTIONS = Object.freeze([
     license: 'MIT examples bundle'
   },
   {
-    id: 'mixamo-aj',
-    label: 'AJ',
-    description: 'Mixamo AJ humanoid rig that can be fully re-targeted for seated gameplay.',
-    modelUrls: ['https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/models/gltf/Aj.glb'],
-    source: 'three.js examples / Mixamo',
-    license: 'Mixamo sample terms'
+    id: 'rpm-67d411',
+    label: 'RPM 67d411',
+    description: 'Ready Player Me public avatar seated with the same Ludo rig logic and motion set.',
+    modelUrls: [
+      'https://models.readyplayer.me/67d411b30787acbf58ce58ac.glb',
+      'https://api.readyplayer.me/v1/avatars/67d411b30787acbf58ce58ac.glb',
+      'https://avatars.readyplayer.me/67d411b30787acbf58ce58ac.glb'
+    ],
+    source: 'Ready Player Me public GLB',
+    license: 'Check Ready Player Me terms'
   },
   {
-    id: 'mixamo-jane',
-    label: 'Jane',
-    description: 'Mixamo Jane with preserved GLB material textures and humanoid skeleton.',
-    modelUrls: ['https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/models/gltf/Jane.glb'],
-    source: 'three.js examples / Mixamo',
-    license: 'Mixamo sample terms'
+    id: 'rpm-67f433',
+    label: 'RPM 67f433',
+    description: 'Ready Player Me public avatar aligned to default seated scale/orientation for Ludo.',
+    modelUrls: [
+      'https://models.readyplayer.me/67f433b69dc08cf26d2cf585.glb',
+      'https://api.readyplayer.me/v1/avatars/67f433b69dc08cf26d2cf585.glb',
+      'https://avatars.readyplayer.me/67f433b69dc08cf26d2cf585.glb'
+    ],
+    source: 'Ready Player Me public GLB',
+    license: 'Check Ready Player Me terms'
   },
   {
-    id: 'mixamo-eva',
-    label: 'Eva',
-    description: 'Mixamo Eva realistic female rig ready for seated pose overrides.',
-    modelUrls: ['https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/models/gltf/Eva.glb'],
-    source: 'three.js examples / Mixamo',
-    license: 'Mixamo sample terms'
-  },
-  {
-    id: 'mixamo-joe',
-    label: 'Joe',
-    description: 'Mixamo Joe humanoid compatible with existing Ludo seated animation helpers.',
-    modelUrls: ['https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/models/gltf/Joe.glb'],
-    source: 'three.js examples / Mixamo',
-    license: 'Mixamo sample terms'
-  },
-  {
-    id: 'mixamo-remy',
-    label: 'Remy',
-    description: 'Mixamo Remy character tuned to the same target seated height in-game.',
-    modelUrls: ['https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/models/gltf/Remy.glb'],
-    source: 'three.js examples / Mixamo',
-    license: 'Mixamo sample terms'
+    id: 'rpm-67e1b5',
+    label: 'RPM 67e1b5',
+    description: 'Ready Player Me public avatar using the same seated helper offsets and animation logic.',
+    modelUrls: [
+      'https://models.readyplayer.me/67e1b51ae11c93725e4395c9.glb',
+      'https://api.readyplayer.me/v1/avatars/67e1b51ae11c93725e4395c9.glb',
+      'https://avatars.readyplayer.me/67e1b51ae11c93725e4395c9.glb'
+    ],
+    source: 'Ready Player Me public GLB',
+    license: 'Check Ready Player Me terms'
   }
 ]);
 

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -2058,9 +2058,9 @@ const SEATED_HUMAN_FACING_Y = 0;
 // Keep feet lower to preserve the deeper seat grounding after the stronger vertical drop.
 const SEATED_HUMAN_FOOT_GROUND_CLEARANCE = -1.55 * MODEL_SCALE * STOOL_SCALE;
 const SEATED_HUMAN_DICE_PHASES = Object.freeze({
-  reachMs: 250,
-  gripMs: 180,
-  holdMs: 220,
+  reachMs: 170,
+  gripMs: 120,
+  holdMs: 130,
   windupMs: 300,
   releaseMs: 260,
   followMs: 520
@@ -2076,6 +2076,15 @@ const SEATED_HUMAN_MOTION_TUNING = Object.freeze({
   throwPrecision: 1.08,
   tokenPrecision: 1.14
 });
+const SEATED_HUMAN_DOWNWARD_CONTACT_MODE_SET = new Set([
+  'reachDice',
+  'gripDice',
+  'holdDice',
+  'reachToken',
+  'gripToken',
+  'carryToken',
+  'placeToken'
+]);
 const SEATED_HELPER_FORWARD_DICE_PICKUP = 0.092 * MODEL_SCALE;
 const SEATED_HELPER_FORWARD_DICE_RELEASE = 0.148 * MODEL_SCALE;
 const SEATED_HELPER_RIGHT_DICE = -0.013 * MODEL_SCALE;
@@ -4623,6 +4632,12 @@ function applySeatedHumanPose(rig, mode = 'idle', intensity = 1, handGrip = 0, t
     wristZ = THREE.MathUtils.lerp(wristZ, -0.2, t);
   }
 
+  if (SEATED_HUMAN_DOWNWARD_CONTACT_MODE_SET.has(mode)) {
+    wristX -= 0.22 * t;
+    wristZ += 0.28 * t;
+    forearmZ += 0.09 * t;
+  }
+
   if (bodyLockedMode) {
     chestX = 0.12;
     chestY = 0;
@@ -6782,8 +6797,8 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     }
     beginDiceHoldPose(player, { startMs: performance.now() - 220 });
     animateDicePosition(dice, target, {
-      duration: 520,
-      lift: 0.05,
+      duration: 260,
+      lift: 0.03,
       onComplete: () => beginDiceHoldPose(player)
     });
   };
@@ -10243,7 +10258,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     return true;
   }, []);
 
-  const syncDiceToThrowHand = useCallback((player, dice, { duration = 90 } = {}) => {
+  const syncDiceToThrowHand = useCallback((player, dice, { duration = 28 } = {}) => {
     if (!dice?.isObject3D || !dice.parent?.isObject3D) return Promise.resolve();
     const parent = dice.parent;
     const worldTarget = new THREE.Vector3();
@@ -10274,7 +10289,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         }
         const elapsed = performance.now() - start;
         const phase = clamp(elapsed / Math.max(1, duration), 0, 1);
-        const blend = 0.7 + (1 - Math.pow(1 - phase, 2)) * 0.3;
+        const blend = 0.92 + (1 - Math.pow(1 - phase, 2)) * 0.08;
         snapToHand(blend);
         if (phase < 1) {
           requestAnimationFrame(step);


### PR DESCRIPTION
### Motivation
- Fix visual pickup: fingers/wrist should angle downward toward the dice/token during pickup so the hand looks like it actually grasps the object. 
- Reduce visible pickup lag so dice move into the hand faster and achieve proper contact timing with the human hand. 
- Keep the existing default human avatar but simplify the store roster by replacing alternate human options with three provided Ready Player Me characters, ensuring they use the same seating/scale/animation logic.

### Description
- Tuned seated hand/dice timing by reducing `SEATED_HUMAN_DICE_PHASES` (`reachMs`, `gripMs`, `holdMs`) to speed up the pickup cadence in `webapp/src/pages/Games/LudoBattleRoyal.jsx`.
- Added `SEATED_HUMAN_DOWNWARD_CONTACT_MODE_SET` and applied a downward wrist/forearm bias during pickup/carry/place modes so fingers and wrist angle toward the dice (changes inside `applySeatedHumanPose` in `LudoBattleRoyal.jsx`).
- Accelerated dice movement by shortening `animateDicePosition` rail transition `duration` and `lift`, and tightened the throw-hand snap timing/blend inside `syncDiceToThrowHand` so the dice snaps into the hand more quickly (in `LudoBattleRoyal.jsx`).
- Updated store human options in `webapp/src/config/ludoBattleOptions.js` to keep `rpm-current` as the default and replace the other store entries with the first three Ready Player Me characters (`rpm-67d411`, `rpm-67f433`, `rpm-67e1b5`) using the provided GLB URLs and the same seating/orientation/motion pipeline.

### Testing
- Ran `npx eslint webapp/src/pages/Games/LudoBattleRoyal.jsx webapp/src/config/ludoBattleOptions.js` which completed but the project eslint ignore rules skipped these files and produced ignore warnings. 
- Ran `npx eslint --no-ignore webapp/src/pages/Games/LudoBattleRoyal.jsx webapp/src/config/ludoBattleOptions.js` which reported repository style errors (9 errors, 1 warning) related to project lint rules in the config file; these are style issues and not runtime failures.
- No unit tests were executed as part of this change; manual runtime visual verification is recommended to confirm finger orientation and dice-hand contact timing on mobile portrait view.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee29dc1f3c8329942f87605a1e1853)