### PR TITLE
Chess Battle Royal: add 5 purchasable WebGL humans and keep current avatar free

### DIFF
--- a/test/chessBattleInventoryConfig.test.js
+++ b/test/chessBattleInventoryConfig.test.js
@@ -1,5 +1,7 @@
 import {
+  CHESS_BATTLE_DEFAULT_UNLOCKS,
   CHESS_BATTLE_ROYAL_DEFAULT_UNLOCKS,
+  CHESS_HUMAN_CHARACTER_OPTIONS,
   CHESS_BATTLE_ROYAL_STORE_ITEMS,
   CHESS_BATTLE_TABLE_OPTIONS,
   CHESS_TABLE_FINISH_OPTIONS
@@ -30,5 +32,26 @@ describe('chess battle inventory config', () => {
       expect(finishIds.has(id)).toBe(true);
       expect(storeFinishIds.has(id)).toBe(true);
     });
+  });
+
+  test('keeps current avatar free by default and sells exactly the 5 requested WebGL humans', () => {
+    expect(CHESS_HUMAN_CHARACTER_OPTIONS[0]?.id).toBe('rpm-current');
+    expect(CHESS_BATTLE_DEFAULT_UNLOCKS.humanCharacter[0]).toBe('rpm-current');
+    expect(CHESS_BATTLE_ROYAL_DEFAULT_UNLOCKS.humanCharacter[0]).toBe('rpm-current');
+
+    const storeHumanIds = CHESS_BATTLE_ROYAL_STORE_ITEMS
+      .filter((item) => item.type === 'humanCharacter')
+      .map((item) => item.optionId)
+      .sort();
+
+    expect(storeHumanIds).toEqual(
+      [
+        'webgl-ai-teacher',
+        'webgl-ai-teacher-1',
+        'webgl-human-body-a',
+        'webgl-human-body-b',
+        'webgl-vietnam-human'
+      ].sort()
+    );
   });
 });

--- a/webapp/src/config/chessBattleInventoryConfig.js
+++ b/webapp/src/config/chessBattleInventoryConfig.js
@@ -175,6 +175,14 @@ export const CHESS_HUMAN_CHARACTER_OPTIONS = Object.freeze([
   }
 ]);
 
+const CHESS_STORE_HUMAN_CHARACTER_IDS = Object.freeze([
+  'webgl-vietnam-human',
+  'webgl-human-body-a',
+  'webgl-human-body-b',
+  'webgl-ai-teacher',
+  'webgl-ai-teacher-1'
+]);
+
 const BASE_CHAIR_OPTIONS = [
   {
     id: 'crimsonVelvet',
@@ -679,7 +687,9 @@ export const CHESS_BATTLE_STORE_ITEMS = [
     description: 'Unlocks an additional pawn head glass preset.',
     thumbnail: CHESS_BATTLE_OPTION_THUMBNAILS.headStyle.headGold
   },
-  ...CHESS_HUMAN_CHARACTER_OPTIONS.slice(1).map((option, idx) => ({
+  ...CHESS_HUMAN_CHARACTER_OPTIONS.filter((option) =>
+    CHESS_STORE_HUMAN_CHARACTER_IDS.includes(option.id)
+  ).map((option, idx) => ({
     id: `chess-human-${option.id}`,
     type: 'humanCharacter',
     optionId: option.id,


### PR DESCRIPTION
### Motivation
- Ship five explicit WebGL human characters as purchasable store items for Chess Battle Royal while keeping the existing in-game “current” avatar free by default. 
- Ensure only those five external GLB-based humans appear in the store (no extra/cloned humans), matching the requested assets and preserving seated orientation/pose logic. 

### Description
- Added an allowlist `CHESS_STORE_HUMAN_CHARACTER_IDS` and limited store generation to that list so only the five requested WebGL humans are exposed for purchase in `webapp/src/config/chessBattleInventoryConfig.js`.
- Replaced the previous `CHESS_HUMAN_CHARACTER_OPTIONS.slice(1)` mapping with a filter that includes only the allowlisted IDs when creating `humanCharacter` store items.
- Kept the existing `rpm-current` option as the default/free human and left runtime seated-pose/loading logic unchanged so models still use the same loading/pose pipeline in the game.
- Added a test in `test/chessBattleInventoryConfig.test.js` that verifies the default free avatar is `rpm-current` and that store `humanCharacter` entries are exactly the five requested IDs.

### Testing
- Ran the full test file with `npm test -- test/chessBattleInventoryConfig.test.js --runInBand` which shows one pre-existing unrelated failure in LT table finish expectations (not caused by these changes).
- Ran the focused test with `npm test -- test/chessBattleInventoryConfig.test.js --runInBand -t "keeps current avatar free"` which passed and verifies the default avatar and the five store human IDs.
- Modified files: `webapp/src/config/chessBattleInventoryConfig.js` and `test/chessBattleInventoryConfig.test.js`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee2d0cf3348329a4519ff65cb31ab4)