### PR TITLE
Fix Ludo dice pickup hand pose, speed up dice handoff, and refresh human character store

### DIFF
--- a/webapp/src/config/ludoBattleOptions.js
+++ b/webapp/src/config/ludoBattleOptions.js
@@ -191,44 +191,40 @@ export const HUMAN_CHARACTER_OPTIONS = Object.freeze([
     license: 'MIT examples bundle'
   },
   {
-    id: 'mixamo-aj',
-    label: 'AJ',
-    description: 'Mixamo AJ humanoid rig that can be fully re-targeted for seated gameplay.',
-    modelUrls: ['https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/models/gltf/Aj.glb'],
-    source: 'three.js examples / Mixamo',
-    license: 'Mixamo sample terms'
+    id: 'rpm-67d411',
+    label: 'RPM 67d411',
+    description: 'Public Ready Player Me seated GLB avatar with preserved source textures.',
+    modelUrls: [
+      'https://models.readyplayer.me/67d411b30787acbf58ce58ac.glb',
+      'https://api.readyplayer.me/v1/avatars/67d411b30787acbf58ce58ac.glb',
+      'https://avatars.readyplayer.me/67d411b30787acbf58ce58ac.glb'
+    ],
+    source: 'Ready Player Me public GLB',
+    license: 'Ready Player Me terms'
   },
   {
-    id: 'mixamo-jane',
-    label: 'Jane',
-    description: 'Mixamo Jane with preserved GLB material textures and humanoid skeleton.',
-    modelUrls: ['https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/models/gltf/Jane.glb'],
-    source: 'three.js examples / Mixamo',
-    license: 'Mixamo sample terms'
+    id: 'rpm-67f433',
+    label: 'RPM 67f433',
+    description: 'Public Ready Player Me seated GLB avatar with preserved source textures.',
+    modelUrls: [
+      'https://models.readyplayer.me/67f433b69dc08cf26d2cf585.glb',
+      'https://api.readyplayer.me/v1/avatars/67f433b69dc08cf26d2cf585.glb',
+      'https://avatars.readyplayer.me/67f433b69dc08cf26d2cf585.glb'
+    ],
+    source: 'Ready Player Me public GLB',
+    license: 'Ready Player Me terms'
   },
   {
-    id: 'mixamo-eva',
-    label: 'Eva',
-    description: 'Mixamo Eva realistic female rig ready for seated pose overrides.',
-    modelUrls: ['https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/models/gltf/Eva.glb'],
-    source: 'three.js examples / Mixamo',
-    license: 'Mixamo sample terms'
-  },
-  {
-    id: 'mixamo-joe',
-    label: 'Joe',
-    description: 'Mixamo Joe humanoid compatible with existing Ludo seated animation helpers.',
-    modelUrls: ['https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/models/gltf/Joe.glb'],
-    source: 'three.js examples / Mixamo',
-    license: 'Mixamo sample terms'
-  },
-  {
-    id: 'mixamo-remy',
-    label: 'Remy',
-    description: 'Mixamo Remy character tuned to the same target seated height in-game.',
-    modelUrls: ['https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/models/gltf/Remy.glb'],
-    source: 'three.js examples / Mixamo',
-    license: 'Mixamo sample terms'
+    id: 'rpm-67e1b5',
+    label: 'RPM 67e1b5',
+    description: 'Public Ready Player Me seated GLB avatar with preserved source textures.',
+    modelUrls: [
+      'https://models.readyplayer.me/67e1b51ae11c93725e4395c9.glb',
+      'https://api.readyplayer.me/v1/avatars/67e1b51ae11c93725e4395c9.glb',
+      'https://avatars.readyplayer.me/67e1b51ae11c93725e4395c9.glb'
+    ],
+    source: 'Ready Player Me public GLB',
+    license: 'Ready Player Me terms'
   }
 ]);
 

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -2058,8 +2058,8 @@ const SEATED_HUMAN_FACING_Y = 0;
 // Keep feet lower to preserve the deeper seat grounding after the stronger vertical drop.
 const SEATED_HUMAN_FOOT_GROUND_CLEARANCE = -1.55 * MODEL_SCALE * STOOL_SCALE;
 const SEATED_HUMAN_DICE_PHASES = Object.freeze({
-  reachMs: 250,
-  gripMs: 180,
+  reachMs: 180,
+  gripMs: 130,
   holdMs: 220,
   windupMs: 300,
   releaseMs: 260,
@@ -4516,20 +4516,20 @@ function applySeatedHumanPose(rig, mode = 'idle', intensity = 1, handGrip = 0, t
     shoulderZ = THREE.MathUtils.lerp(shoulderZ, -1.06, t);
     forearmX = THREE.MathUtils.lerp(forearmX, -1.02, t);
     forearmY = THREE.MathUtils.lerp(forearmY, -0.18, t);
-    forearmZ = THREE.MathUtils.lerp(forearmZ, -0.34, t);
-    wristX = THREE.MathUtils.lerp(wristX, -0.5, t);
+    forearmZ = THREE.MathUtils.lerp(forearmZ, -0.16, t);
+    wristX = THREE.MathUtils.lerp(wristX, 0.18, t);
     wristY = THREE.MathUtils.lerp(wristY, 0.1, t);
-    wristZ = THREE.MathUtils.lerp(wristZ, -0.34, t);
+    wristZ = THREE.MathUtils.lerp(wristZ, -0.56, t);
   } else if (mode === 'gripDice') {
     shoulderX = THREE.MathUtils.lerp(shoulderX, -0.76, t);
     shoulderY = THREE.MathUtils.lerp(shoulderY, -0.10, t);
     shoulderZ = THREE.MathUtils.lerp(shoulderZ, -0.92, t);
     forearmX = THREE.MathUtils.lerp(forearmX, -0.98, t);
     forearmY = THREE.MathUtils.lerp(forearmY, -0.22, t);
-    forearmZ = THREE.MathUtils.lerp(forearmZ, -0.12, t);
-    wristX = THREE.MathUtils.lerp(wristX, -0.54, t);
+    forearmZ = THREE.MathUtils.lerp(forearmZ, 0.02, t);
+    wristX = THREE.MathUtils.lerp(wristX, 0.26, t);
     wristY = THREE.MathUtils.lerp(wristY, 0.08, t);
-    wristZ = THREE.MathUtils.lerp(wristZ, -0.2, t);
+    wristZ = THREE.MathUtils.lerp(wristZ, -0.6, t);
   } else if (mode === 'holdDice') {
     shoulderX = THREE.MathUtils.lerp(shoulderX, -0.5, t);
     shoulderY = THREE.MathUtils.lerp(shoulderY, -0.18, t);
@@ -4537,9 +4537,9 @@ function applySeatedHumanPose(rig, mode = 'idle', intensity = 1, handGrip = 0, t
     forearmX = THREE.MathUtils.lerp(forearmX, -1.08, t);
     forearmY = THREE.MathUtils.lerp(forearmY, -0.1, t);
     forearmZ = THREE.MathUtils.lerp(forearmZ, 0.38, t);
-    wristX = THREE.MathUtils.lerp(wristX, -0.56, t);
+    wristX = THREE.MathUtils.lerp(wristX, 0.16, t);
     wristY = THREE.MathUtils.lerp(wristY, 0.06, t);
-    wristZ = THREE.MathUtils.lerp(wristZ, 0.14, t);
+    wristZ = THREE.MathUtils.lerp(wristZ, -0.34, t);
   } else if (mode === 'windUp') {
     shoulderX = THREE.MathUtils.lerp(shoulderX, -0.88, t);
     shoulderY = THREE.MathUtils.lerp(shoulderY, -0.38, t);
@@ -6782,7 +6782,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     }
     beginDiceHoldPose(player, { startMs: performance.now() - 220 });
     animateDicePosition(dice, target, {
-      duration: 520,
+      duration: 320,
       lift: 0.05,
       onComplete: () => beginDiceHoldPose(player)
     });
@@ -10274,7 +10274,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         }
         const elapsed = performance.now() - start;
         const phase = clamp(elapsed / Math.max(1, duration), 0, 1);
-        const blend = 0.7 + (1 - Math.pow(1 - phase, 2)) * 0.3;
+        const blend = 0.92 + (1 - Math.pow(1 - phase, 2)) * 0.08;
         snapToHand(blend);
         if (phase < 1) {
           requestAnimationFrame(step);
@@ -10334,7 +10334,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       throwForward = clamp(-localDir.z * 1.4, -1, 1);
     }
     beginDiceThrowPose(player, { lateral: throwLateral, forward: throwForward });
-    await syncDiceToThrowHand(player, dice, { duration: 70 });
+    await syncDiceToThrowHand(player, dice, { duration: 32 });
     const landingFocus = baseTarget.clone();
     const value = await spinDice(dice, {
       duration: resolveFrameSyncedDuration(AUTO_ROLL_DURATION_MS, { min: 620, max: 1800 }),


### PR DESCRIPTION
### Motivation
- Make the seated human player's right-hand reach/grip/hold look natural by angling the palm/fingers downward toward the dice instead of upward.  
- Remove visible pickup lag by making the dice move into the hand faster and snap with tighter hand-sync so the die is in contact with the hand earlier.  
- Keep the existing default avatar and simplify the store choices by removing the previous extra Mixamo entries and adding the first three Ready Player Me avatars from the provided set so they share the same sizing/orientation/motion pipeline.

### Description
- Adjusted seated dice timing to start pick-up earlier by changing `SEATED_HUMAN_DICE_PHASES` `reachMs` from `250` to `180` and `gripMs` from `180` to `130` in `webapp/src/pages/Games/LudoBattleRoyal.jsx`.  
- Modified the right-arm/forearm/wrist target rotations used during `reachDice`, `gripDice`, and `holdDice` in `applySeatedHumanPose` so the forearm/wrist rotate downward toward the die (updated `forearmZ`, `wristX`, `wristZ` values).  
- Tightened dice-hand synchronization by increasing the immediate snap blend, reducing the progressive blend contribution, and reducing the hand-sync duration used when beginning a throw; also reduced rail-to-player dice move duration from `520`ms to `320`ms (all in `LudoBattleRoyal.jsx`).  
- Replaced the extra Mixamo human options with three Ready Player Me avatars (`67d411`, `67f433`, `67e1b5`) while keeping the original default avatar entry in `webapp/src/config/ludoBattleOptions.js`, so the new options use the same seat anchor/scale/orientation/motion system as the default.

### Testing
- Ran `npx eslint webapp/src/pages/Games/LudoBattleRoyal.jsx webapp/src/config/ludoBattleOptions.js`; the project ignore rules initially hid the files, and a second lint run with `--no-ignore` reported style errors in `ludoBattleOptions.js` (extra semicolons) that should be fixed with an autofix or formatter.  
- Ran `npm test -- test/inventoryCrossGameConfig.test.js --runInBand`; the test run failed in this environment because Jest encountered an ESM parsing error from `three/examples/jsm` imports (an existing environment configuration issue unrelated to the changes).  
- No visual, browser-based runtime screenshots or live integration tests were executed in this environment; playtesting is recommended in the native dev build to confirm finger orientation, dice snap timing, and that the three new avatars load and seat correctly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee29dc1f3c8329942f87605a1e1853)