### PR TITLE
Extract Bilardo shot model and add manual strike flow to PoolRoyale

### DIFF
--- a/webapp/src/pages/Games/BilardoShqipGame.tsx
+++ b/webapp/src/pages/Games/BilardoShqipGame.tsx
@@ -4,6 +4,11 @@ import React, { useEffect, useRef, useState } from "react";
 import * as THREE from "three";
 import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js";
 import { BilardoShqipRules } from "../../../../src/rules/BilardoShqipRules.ts";
+import {
+  BILARDO_MIN_RELEASE_POWER,
+  BILARDO_STRIKE_TIME_MS,
+  bilardoCueSpeed
+} from "./shared/bilardoShotModel";
 
 type ShotState = "idle" | "dragging" | "striking";
 type BallState = { mesh: THREE.Mesh; pos: THREE.Vector3; vel: THREE.Vector3; number: number; isCue: boolean };
@@ -83,7 +88,7 @@ const CFG = {
   idleGap: 0.012,
   contactGap: 0.0012,
   pullRange: 0.42,
-  strikeTime: 0.12,
+  strikeTime: BILARDO_STRIKE_TIME_MS / 1000,
   holdTime: 0.05,
   cueLength: 1.46,
   bridgeDist: 0.24,
@@ -669,7 +674,7 @@ function updateHumanPose(human: HumanRig, dt: number, state: ShotState, rootTarg
 }
 
 function applyCueShot(cueBall: BallState, power: number, yaw: number, tmp: THREE.Vector3) {
-  cueBall.vel.copy(tmp.set(0, 0, -1).applyAxisAngle(Y_AXIS, yaw).normalize()).multiplyScalar(1.9 + 8.2 * Math.pow(power, 1.08));
+  cueBall.vel.copy(tmp.set(0, 0, -1).applyAxisAngle(Y_AXIS, yaw).normalize()).multiplyScalar(bilardoCueSpeed(power));
 }
 function updateBalls(
   balls: BallState[],
@@ -860,7 +865,7 @@ export default function BilardoShqipGame() {
     if (scoreboardRef.current.winner || scoreboardRef.current.currentPlayer !== "A") return;
     try { e.currentTarget.releasePointerCapture(e.pointerId); } catch {}
     draggingSliderRef.current = false;
-    setShotState(shotPowerRef.current > 0.02 ? "striking" : "idle");
+    setShotState(shotPowerRef.current > BILARDO_MIN_RELEASE_POWER ? "striking" : "idle");
     animatePowerToZero(powerRef.current, 180);
   };
 

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -79,6 +79,12 @@ import {
   POOL_ROYALE_BASE_VARIANTS,
   POOL_ROYALE_OPTION_LABELS
 } from '../../config/poolRoyaleInventoryConfig.js';
+import {
+  BILARDO_MIN_RELEASE_POWER,
+  BILARDO_STRIKE_CONTACT_THRESHOLD,
+  BILARDO_STRIKE_TIME_MS,
+  bilardoCueSpeed
+} from './shared/bilardoShotModel';
 import { POOL_ROYALE_CLOTH_VARIANTS } from '../../config/poolRoyaleClothPresets.js';
 import {
   getCachedPoolRoyalInventory,
@@ -1928,7 +1934,7 @@ const REFERENCE_CUE_SPEED_GAMMA = 1.08; // reference implementation: power curve
 const MIN_SHOT_POWER_TO_FIRE = 0.015; // ignore accidental micro drags/releases that should not launch the cue ball
 const HUMAN_PLAYER_HEIGHT_RATIO_TO_TABLE = 0.88; // make player humans visibly bigger relative to table/balls
 const BILARDO_SHQIP_HUMAN_URL = 'https://threejs.org/examples/models/gltf/readyplayer.me.glb';
-const POOL_ROYALE_HUMAN_SCALE_MULTIPLIER = 1.4; // slight size bump while keeping the same base proportions
+const POOL_ROYALE_HUMAN_SCALE_MULTIPLIER = 1.18; // align with Bilardo Shqip human/table size relationship
 const HUMAN_PLAYER_IDLE_SWAY_SPEED = 1.2;
 const HUMAN_PLAYER_IDLE_SWAY_ANGLE = 0.04;
 const HUMAN_PLAYER_AIM_LEAN = 0.2;
@@ -15523,6 +15529,16 @@ const showRuleToast = useCallback((message) => {
 }, []);
 const powerRef = useRef(hud.power);
 const shotPowerRef = useRef(0);
+const MANUAL_STRIKE_TIME_MS = BILARDO_STRIKE_TIME_MS;
+const MANUAL_STRIKE_THRESHOLD = BILARDO_STRIKE_CONTACT_THRESHOLD;
+const [manualShotState, setManualShotState] = useState('idle'); // idle | dragging | striking
+const manualShotStateRef = useRef('idle');
+const manualStrikeStartedAtRef = useRef(0);
+const manualStrikeDidHitRef = useRef(false);
+const manualStrikePowerRef = useRef(0);
+useEffect(() => {
+  manualShotStateRef.current = manualShotState;
+}, [manualShotState]);
   const clampPower = useCallback((value, fallback = 0) => {
     if (!Number.isFinite(value)) return fallback;
     return THREE.MathUtils.clamp(value, 0, 1);
@@ -24709,11 +24725,18 @@ const shotPowerRef = useRef(0);
           const isShooter = anim.seat === activeSeat;
           const cameraBlend = THREE.MathUtils.clamp(cameraBlendRef.current ?? 1, 0, 1);
           const loweredCueCamera = cameraBlend <= HUMAN_SHOOT_BLEND_THRESHOLD;
-          const draggingSlider = Boolean(sliderInstanceRef.current?.dragging);
-          const sliderPowerActive = (powerRef.current ?? 0) > 0.01;
+          const draggingSlider =
+            manualShotStateRef.current === 'dragging' ||
+            Boolean(sliderInstanceRef.current?.dragging);
+          const sliderPowerActive =
+            manualShotStateRef.current !== 'idle' || (powerRef.current ?? 0) > 0.01;
           let mode = 'idle';
           if (isReplay) mode = 'idle';
-          else if (isShotActive && anim.seat === shotSeat && shotAge < 420) mode = 'strike';
+          else if (
+            (isShotActive && anim.seat === shotSeat && shotAge < 420) ||
+            (isShooter && manualShotStateRef.current === 'striking')
+          )
+            mode = 'strike';
           else if (isShotActive) mode = 'react';
           else if (isShooter && (loweredCueCamera || draggingSlider || sliderPowerActive)) mode = 'aim';
           anim.mode = mode;
@@ -26791,17 +26814,7 @@ const shotPowerRef = useRef(0);
         const shotDir3 = TMP_VEC3_C.set(aimDir.x, 0, aimDir.y);
         if (shotDir3.lengthSq() > 1e-8) shotDir3.normalize();
         else shotDir3.set(0, 0, 1);
-        const cueDriveBoost = computeCueDriveBoost({
-          pullDistance,
-          contactAdvance,
-          strikeDurationMs: strikeDuration,
-          clampedPower
-        });
-        const referenceSpeed =
-          REFERENCE_CUE_SPEED_BASE +
-          REFERENCE_CUE_SPEED_RANGE *
-            Math.pow(THREE.MathUtils.clamp(clampedPower, 0, 1), REFERENCE_CUE_SPEED_GAMMA) *
-            cueDriveBoost;
+        const referenceSpeed = bilardoCueSpeed(clampedPower);
         cue.vel.copy(shotDir3).multiplyScalar(referenceSpeed);
         if (cue.spin) {
           cue.spin.set(offsetScaled.x, offsetScaled.y);
@@ -27437,6 +27450,14 @@ const shotPowerRef = useRef(0);
             }
           }
           openingShotViewSuppressedRef.current = false;
+          let shotImpactApplied = false;
+          const applyShotImpactOnce = () => {
+            if (shotImpactApplied) return;
+            shotImpactApplied = true;
+            applyShotAtImpact(shotImpactPayload);
+          };
+          const useBilardoImmediateImpact =
+            manualShotStateRef.current === 'striking';
           if (ENABLE_CUE_STROKE_ANIMATION && shotRecording) {
             const strokeStartOffset = REPLAY_CUE_START_HOLD_MS;
             shotRecording.cueStroke = {
@@ -27454,6 +27475,11 @@ const shotPowerRef = useRef(0);
             };
           }
           if (ENABLE_CUE_STROKE_ANIMATION) {
+            if (useBilardoImmediateImpact) {
+              // Bilardo Shqip behavior: impact happens at strike trigger time, not
+              // later inside the cue animation timeline.
+              applyShotImpactOnce();
+            }
             cueStick.visible = true;
             cueAnimating = true;
             lastCueIdlePoseRef.current = {
@@ -27481,13 +27507,13 @@ const shotPowerRef = useRef(0);
               // Slider release should drive an immediate forward strike from the
               // currently pulled cue position back to contact.
               forwardOnly: true,
-              onImpact: () => applyShotAtImpact(shotImpactPayload),
+              onImpact: () => applyShotImpactOnce(),
               animationStyle: strokeStyle,
               motionTechnique: strokeProfile.motion ?? strokeStyle,
               releaseStartsFromCurrentPull: true
             };
           } else {
-            applyShotAtImpact(shotImpactPayload);
+            applyShotImpactOnce();
             cueStick.visible = false;
             cueAnimating = false;
             cuePullCurrentRef.current = 0;
@@ -33310,6 +33336,8 @@ const shotPowerRef = useRef(0);
   const sliderRef = useRef(null);
   const onPowerDragStart = useCallback(() => {
     captureCueStickAnchor();
+    manualStrikeDidHitRef.current = false;
+    setManualShotState('dragging');
   }, [captureCueStickAnchor]);
   const onPowerDrag = useCallback((powerRatio = 0) => {
     const clamped = clampPower(powerRatio, 0);
@@ -33324,9 +33352,58 @@ const shotPowerRef = useRef(0);
     );
     const latchedPower = clampPower(sourcePower, 0);
     shotPowerRef.current = latchedPower;
+    manualStrikePowerRef.current = latchedPower;
     applyPower(latchedPower);
-    fireRef.current?.(latchedPower);
+    manualStrikeDidHitRef.current = false;
+    manualStrikeStartedAtRef.current = performance.now();
+    const shouldStrike = latchedPower > BILARDO_MIN_RELEASE_POWER;
+    setManualShotState(shouldStrike ? 'striking' : 'idle');
+    if (shouldStrike) {
+      // Immediate fire on release guarantees cue-ball power transfer even if
+      // strike timeline callbacks are delayed on some devices.
+      fireRef.current?.(latchedPower);
+    }
   }, [applyPower, clampPower]);
+  useEffect(() => {
+    let raf = 0;
+    const tick = () => {
+      raf = requestAnimationFrame(tick);
+      if (manualShotStateRef.current !== 'striking') return;
+      const start = manualStrikeStartedAtRef.current || 0;
+      if (start <= 0) return;
+      const strikeNorm = THREE.MathUtils.clamp(
+        (performance.now() - start) / MANUAL_STRIKE_TIME_MS,
+        0,
+        1
+      );
+      if (!manualStrikeDidHitRef.current && strikeNorm > MANUAL_STRIKE_THRESHOLD) {
+        manualStrikeDidHitRef.current = true;
+        fireRef.current?.(
+          manualStrikePowerRef.current ??
+            shotPowerRef.current ??
+            powerRef.current ??
+            0
+        );
+      }
+      if (strikeNorm >= 1) {
+        if (!shootingRef.current && manualStrikePowerRef.current > BILARDO_MIN_RELEASE_POWER) {
+          fireRef.current?.(manualStrikePowerRef.current);
+        }
+        setManualShotState('idle');
+        manualStrikeStartedAtRef.current = 0;
+        manualStrikePowerRef.current = 0;
+        requestAnimationFrame(() => {
+          const slider = sliderInstanceRef.current;
+          if (slider) slider.set(slider.min, { animate: true });
+          applyPower(0);
+        });
+      }
+    };
+    raf = requestAnimationFrame(tick);
+    return () => {
+      if (raf) cancelAnimationFrame(raf);
+    };
+  }, [applyPower]);
   const showPowerSlider = hud.turn === 0 && !hud.over && !replayActive && !shotActive;
   useEffect(() => {
     if (!showPowerSlider) {
@@ -33344,10 +33421,6 @@ const shotPowerRef = useRef(0);
       onStart: () => onPowerDragStart(),
       onCommit: () => {
         onPowerRelease(clampPower(powerRef.current, 0));
-        requestAnimationFrame(() => {
-          slider.set(slider.min, { animate: true });
-          applyPower(0);
-        });
       }
     });
     sliderInstanceRef.current = slider;

--- a/webapp/src/pages/Games/shared/bilardoShotModel.ts
+++ b/webapp/src/pages/Games/shared/bilardoShotModel.ts
@@ -1,0 +1,15 @@
+export const BILARDO_MIN_RELEASE_POWER = 0.02;
+export const BILARDO_STRIKE_TIME_MS = 120;
+export const BILARDO_STRIKE_CONTACT_THRESHOLD = 0.88;
+
+export function clampBilardoPower(value: number, fallback = 0): number {
+  if (!Number.isFinite(value)) return fallback;
+  if (value <= 0) return 0;
+  if (value >= 1) return 1;
+  return value;
+}
+
+export function bilardoCueSpeed(power: number): number {
+  const p = clampBilardoPower(power, 0);
+  return 1.9 + 8.2 * Math.pow(p, 1.08);
+}


### PR DESCRIPTION
### Motivation
- Share Bilardo-specific shot constants and power→speed curve across BilardoShqip and PoolRoyale to keep shot feel consistent.
- Replace hard-coded magic numbers with named constants for strike timing, contact threshold and minimum release power.
- Implement a manual strike lifecycle in PoolRoyale so slider-driven releases and in-flight strike timing reproduce Bilardo Shqip immediate-impact behavior.

### Description
- Introduce `webapp/src/pages/Games/shared/bilardoShotModel.ts` exporting `BILARDO_MIN_RELEASE_POWER`, `BILARDO_STRIKE_TIME_MS`, `BILARDO_STRIKE_CONTACT_THRESHOLD`, `clampBilardoPower`, and `bilardoCueSpeed` for reuse.
- Update `BilardoShqipGame.tsx` to import the shared module, use `BILARDO_STRIKE_TIME_MS` for `CFG.strikeTime`, use `bilardoCueSpeed` to compute cue launch velocity, and use `BILARDO_MIN_RELEASE_POWER` for slider release threshold logic.
- Update `PoolRoyale.jsx` to import the shared shot model and replace the inline speed computation with `bilardoCueSpeed`, align human scale (`POOL_ROYALE_HUMAN_SCALE_MULTIPLIER = 1.18`) with Bilardo, and add manual strike state and timing logic (`manualShotState`, refs, RAF loop) to support immediate-impact strikes and thresholded contacts when the player releases the power slider.
- Wire manual strike behavior into animation and shot application so impacts can be applied immediately on release or when the strike timeline reaches the contact threshold, and ensure the slider and HUD power are reset after strike completion.

### Testing
- Ran type checking and project build with `yarn build` which completed successfully.
- Ran the test suite with `yarn test` and relevant frontend tests passed.
- Performed a local smoke check of the shooter interactions in development to verify slider release, immediate impact firing and cue-ball speed changes matched the Bilardo behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ede4d14b088329845ca0c7d8244238)