### PR TITLE
Tune Ludo dice pickup contact and replace store human roster

### DIFF
--- a/webapp/src/config/ludoBattleOptions.js
+++ b/webapp/src/config/ludoBattleOptions.js
@@ -191,44 +191,28 @@ export const HUMAN_CHARACTER_OPTIONS = Object.freeze([
     license: 'MIT examples bundle'
   },
   {
-    id: 'mixamo-aj',
-    label: 'AJ',
-    description: 'Mixamo AJ humanoid rig that can be fully re-targeted for seated gameplay.',
-    modelUrls: ['https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/models/gltf/Aj.glb'],
-    source: 'three.js examples / Mixamo',
-    license: 'Mixamo sample terms'
+    id: 'rpm-67d411',
+    label: 'RPM 67d411',
+    description: 'Ready Player Me seated avatar variant with full GLB texture maps.',
+    modelUrls: ['https://models.readyplayer.me/67d411b30787acbf58ce58ac.glb'],
+    source: 'Ready Player Me public GLB',
+    license: 'Check RPM terms'
   },
   {
-    id: 'mixamo-jane',
-    label: 'Jane',
-    description: 'Mixamo Jane with preserved GLB material textures and humanoid skeleton.',
-    modelUrls: ['https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/models/gltf/Jane.glb'],
-    source: 'three.js examples / Mixamo',
-    license: 'Mixamo sample terms'
+    id: 'rpm-67f433',
+    label: 'RPM 67f433',
+    description: 'Ready Player Me seated avatar variant with full GLB texture maps.',
+    modelUrls: ['https://models.readyplayer.me/67f433b69dc08cf26d2cf585.glb'],
+    source: 'Ready Player Me public GLB',
+    license: 'Check RPM terms'
   },
   {
-    id: 'mixamo-eva',
-    label: 'Eva',
-    description: 'Mixamo Eva realistic female rig ready for seated pose overrides.',
-    modelUrls: ['https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/models/gltf/Eva.glb'],
-    source: 'three.js examples / Mixamo',
-    license: 'Mixamo sample terms'
-  },
-  {
-    id: 'mixamo-joe',
-    label: 'Joe',
-    description: 'Mixamo Joe humanoid compatible with existing Ludo seated animation helpers.',
-    modelUrls: ['https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/models/gltf/Joe.glb'],
-    source: 'three.js examples / Mixamo',
-    license: 'Mixamo sample terms'
-  },
-  {
-    id: 'mixamo-remy',
-    label: 'Remy',
-    description: 'Mixamo Remy character tuned to the same target seated height in-game.',
-    modelUrls: ['https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/models/gltf/Remy.glb'],
-    source: 'three.js examples / Mixamo',
-    license: 'Mixamo sample terms'
+    id: 'rpm-67e1b5',
+    label: 'RPM 67e1b5',
+    description: 'Ready Player Me seated avatar variant with full GLB texture maps.',
+    modelUrls: ['https://models.readyplayer.me/67e1b51ae11c93725e4395c9.glb'],
+    source: 'Ready Player Me public GLB',
+    license: 'Check RPM terms'
   }
 ]);
 

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -2058,12 +2058,12 @@ const SEATED_HUMAN_FACING_Y = 0;
 // Keep feet lower to preserve the deeper seat grounding after the stronger vertical drop.
 const SEATED_HUMAN_FOOT_GROUND_CLEARANCE = -1.55 * MODEL_SCALE * STOOL_SCALE;
 const SEATED_HUMAN_DICE_PHASES = Object.freeze({
-  reachMs: 250,
-  gripMs: 180,
-  holdMs: 220,
-  windupMs: 300,
-  releaseMs: 260,
-  followMs: 520
+  reachMs: 120,
+  gripMs: 90,
+  holdMs: 140,
+  windupMs: 240,
+  releaseMs: 220,
+  followMs: 420
 });
 const SEATED_HUMAN_TOKEN_PHASES = Object.freeze({
   pickupMs: 220,
@@ -4516,20 +4516,20 @@ function applySeatedHumanPose(rig, mode = 'idle', intensity = 1, handGrip = 0, t
     shoulderZ = THREE.MathUtils.lerp(shoulderZ, -1.06, t);
     forearmX = THREE.MathUtils.lerp(forearmX, -1.02, t);
     forearmY = THREE.MathUtils.lerp(forearmY, -0.18, t);
-    forearmZ = THREE.MathUtils.lerp(forearmZ, -0.34, t);
-    wristX = THREE.MathUtils.lerp(wristX, -0.5, t);
-    wristY = THREE.MathUtils.lerp(wristY, 0.1, t);
-    wristZ = THREE.MathUtils.lerp(wristZ, -0.34, t);
+    forearmZ = THREE.MathUtils.lerp(forearmZ, -0.08, t);
+    wristX = THREE.MathUtils.lerp(wristX, 0.2, t);
+    wristY = THREE.MathUtils.lerp(wristY, -0.05, t);
+    wristZ = THREE.MathUtils.lerp(wristZ, 0.12, t);
   } else if (mode === 'gripDice') {
     shoulderX = THREE.MathUtils.lerp(shoulderX, -0.76, t);
     shoulderY = THREE.MathUtils.lerp(shoulderY, -0.10, t);
     shoulderZ = THREE.MathUtils.lerp(shoulderZ, -0.92, t);
     forearmX = THREE.MathUtils.lerp(forearmX, -0.98, t);
     forearmY = THREE.MathUtils.lerp(forearmY, -0.22, t);
-    forearmZ = THREE.MathUtils.lerp(forearmZ, -0.12, t);
-    wristX = THREE.MathUtils.lerp(wristX, -0.54, t);
-    wristY = THREE.MathUtils.lerp(wristY, 0.08, t);
-    wristZ = THREE.MathUtils.lerp(wristZ, -0.2, t);
+    forearmZ = THREE.MathUtils.lerp(forearmZ, 0.04, t);
+    wristX = THREE.MathUtils.lerp(wristX, 0.1, t);
+    wristY = THREE.MathUtils.lerp(wristY, -0.08, t);
+    wristZ = THREE.MathUtils.lerp(wristZ, 0.16, t);
   } else if (mode === 'holdDice') {
     shoulderX = THREE.MathUtils.lerp(shoulderX, -0.5, t);
     shoulderY = THREE.MathUtils.lerp(shoulderY, -0.18, t);
@@ -4537,9 +4537,9 @@ function applySeatedHumanPose(rig, mode = 'idle', intensity = 1, handGrip = 0, t
     forearmX = THREE.MathUtils.lerp(forearmX, -1.08, t);
     forearmY = THREE.MathUtils.lerp(forearmY, -0.1, t);
     forearmZ = THREE.MathUtils.lerp(forearmZ, 0.38, t);
-    wristX = THREE.MathUtils.lerp(wristX, -0.56, t);
-    wristY = THREE.MathUtils.lerp(wristY, 0.06, t);
-    wristZ = THREE.MathUtils.lerp(wristZ, 0.14, t);
+    wristX = THREE.MathUtils.lerp(wristX, -0.08, t);
+    wristY = THREE.MathUtils.lerp(wristY, -0.02, t);
+    wristZ = THREE.MathUtils.lerp(wristZ, 0.16, t);
   } else if (mode === 'windUp') {
     shoulderX = THREE.MathUtils.lerp(shoulderX, -0.88, t);
     shoulderY = THREE.MathUtils.lerp(shoulderY, -0.38, t);
@@ -6780,9 +6780,9 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       beginDiceHoldPose(player);
       return;
     }
-    beginDiceHoldPose(player, { startMs: performance.now() - 220 });
+    beginDiceHoldPose(player, { startMs: performance.now() - 140 });
     animateDicePosition(dice, target, {
-      duration: 520,
+      duration: 260,
       lift: 0.05,
       onComplete: () => beginDiceHoldPose(player)
     });
@@ -10243,7 +10243,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     return true;
   }, []);
 
-  const syncDiceToThrowHand = useCallback((player, dice, { duration = 90 } = {}) => {
+  const syncDiceToThrowHand = useCallback((player, dice, { duration = 55 } = {}) => {
     if (!dice?.isObject3D || !dice.parent?.isObject3D) return Promise.resolve();
     const parent = dice.parent;
     const worldTarget = new THREE.Vector3();
@@ -10252,7 +10252,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
 
     const snapToHand = (blend = 1) => {
       if (!sampleSeatedContactEffectorPosition(player, worldTarget)) return false;
-      worldTarget.y -= DICE_SIZE * 0.1;
+      worldTarget.y -= DICE_SIZE * 0.16;
       localTarget.copy(worldTarget);
       parent.worldToLocal(localTarget);
       if (blend >= 1) {
@@ -10334,7 +10334,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       throwForward = clamp(-localDir.z * 1.4, -1, 1);
     }
     beginDiceThrowPose(player, { lateral: throwLateral, forward: throwForward });
-    await syncDiceToThrowHand(player, dice, { duration: 70 });
+    await syncDiceToThrowHand(player, dice, { duration: 45 });
     const landingFocus = baseTarget.clone();
     const value = await spinDice(dice, {
       duration: resolveFrameSyncedDuration(AUTO_ROLL_DURATION_MS, { min: 620, max: 1800 }),


### PR DESCRIPTION
### Motivation
- Make the seated human pickup animation read correctly on portrait/mobile by orienting right-hand/fingers downward toward the dice during pickup. 
- Remove lingering visual lag where the dice sits in front of the player instead of quickly moving into the hand and making clear contact. 
- Keep the current default human avatar while replacing the extra Mixamo characters in the Ludo store with the first three Ready Player Me (RPM) characters provided in the candidate list.

### Description
- Adjusted dice pickup timing constants in `LudoBattleRoyal.jsx` by reducing `SEATED_HUMAN_DICE_PHASES` (`reachMs`, `gripMs`, `holdMs`, `windupMs`, `releaseMs`, `followMs`) to speed the reach/grip/throw phases. 
- Re-tuned right-arm pose math in `applySeatedHumanPose` (reach/grip/hold branches) by changing `forearmZ` and `wristX/Y/Z` lerps so the fingers and wrist rotate downwards toward the dice during pickup. 
- Accelerated dice rail transition and hand sync by shortening `moveDiceToRail` pre-hold (`beginDiceHoldPose` start offset) and the rail animation `duration`, and tightened the hand snap by lowering the contact offset and reducing `syncDiceToThrowHand` duration in `LudoBattleRoyal.jsx` so the dice snaps into the fist faster and with deeper contact (`worldTarget.y` adjustment). 
- Replaced the extra Mixamo entries in the Ludo human store with three RPM variants in `webapp/src/config/ludoBattleOptions.js` keeping the default `rpm-current` entry unchanged and adding `rpm-67d411`, `rpm-67f433`, and `rpm-67e1b5` with their GLB URLs. 
- Commit message: `Tune Ludo dice pickup pose/timing and refresh human character options` and built the webapp to validate the front-end bundle.

### Testing
- Ran a production build with `cd webapp && npm run -s build`, which completed successfully (bundle created). 
- The build emitted non-blocking warnings about duplicate package keys and chunk size hints but no errors prevented the build. 
- No automated visual tests were available in this environment, so runtime verification on device/browser is recommended to confirm final hand/dice contact and store UI representation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee29dc1f3c8329942f87605a1e1853)