### PR TITLE
Adjust seated human dice pickup pose, speed up dice-to-hand sync, and replace alternate human roster with RPM trio

### DIFF
--- a/webapp/src/config/ludoBattleOptions.js
+++ b/webapp/src/config/ludoBattleOptions.js
@@ -191,44 +191,40 @@ export const HUMAN_CHARACTER_OPTIONS = Object.freeze([
     license: 'MIT examples bundle'
   },
   {
-    id: 'mixamo-aj',
-    label: 'AJ',
-    description: 'Mixamo AJ humanoid rig that can be fully re-targeted for seated gameplay.',
-    modelUrls: ['https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/models/gltf/Aj.glb'],
-    source: 'three.js examples / Mixamo',
-    license: 'Mixamo sample terms'
+    id: 'rpm-67d411',
+    label: 'RPM 67d411',
+    description: 'Ready Player Me seated avatar variant with preserved original texture maps.',
+    modelUrls: [
+      'https://models.readyplayer.me/67d411b30787acbf58ce58ac.glb',
+      'https://api.readyplayer.me/v1/avatars/67d411b30787acbf58ce58ac.glb',
+      'https://avatars.readyplayer.me/67d411b30787acbf58ce58ac.glb'
+    ],
+    source: 'Ready Player Me public GLB',
+    license: 'Check RPM terms'
   },
   {
-    id: 'mixamo-jane',
-    label: 'Jane',
-    description: 'Mixamo Jane with preserved GLB material textures and humanoid skeleton.',
-    modelUrls: ['https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/models/gltf/Jane.glb'],
-    source: 'three.js examples / Mixamo',
-    license: 'Mixamo sample terms'
+    id: 'rpm-67f433',
+    label: 'RPM 67f433',
+    description: 'Ready Player Me seated avatar variant with preserved original texture maps.',
+    modelUrls: [
+      'https://models.readyplayer.me/67f433b69dc08cf26d2cf585.glb',
+      'https://api.readyplayer.me/v1/avatars/67f433b69dc08cf26d2cf585.glb',
+      'https://avatars.readyplayer.me/67f433b69dc08cf26d2cf585.glb'
+    ],
+    source: 'Ready Player Me public GLB',
+    license: 'Check RPM terms'
   },
   {
-    id: 'mixamo-eva',
-    label: 'Eva',
-    description: 'Mixamo Eva realistic female rig ready for seated pose overrides.',
-    modelUrls: ['https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/models/gltf/Eva.glb'],
-    source: 'three.js examples / Mixamo',
-    license: 'Mixamo sample terms'
-  },
-  {
-    id: 'mixamo-joe',
-    label: 'Joe',
-    description: 'Mixamo Joe humanoid compatible with existing Ludo seated animation helpers.',
-    modelUrls: ['https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/models/gltf/Joe.glb'],
-    source: 'three.js examples / Mixamo',
-    license: 'Mixamo sample terms'
-  },
-  {
-    id: 'mixamo-remy',
-    label: 'Remy',
-    description: 'Mixamo Remy character tuned to the same target seated height in-game.',
-    modelUrls: ['https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/models/gltf/Remy.glb'],
-    source: 'three.js examples / Mixamo',
-    license: 'Mixamo sample terms'
+    id: 'rpm-67e1b5',
+    label: 'RPM 67e1b5',
+    description: 'Ready Player Me seated avatar variant with preserved original texture maps.',
+    modelUrls: [
+      'https://models.readyplayer.me/67e1b51ae11c93725e4395c9.glb',
+      'https://api.readyplayer.me/v1/avatars/67e1b51ae11c93725e4395c9.glb',
+      'https://avatars.readyplayer.me/67e1b51ae11c93725e4395c9.glb'
+    ],
+    source: 'Ready Player Me public GLB',
+    license: 'Check RPM terms'
   }
 ]);
 

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -2058,8 +2058,8 @@ const SEATED_HUMAN_FACING_Y = 0;
 // Keep feet lower to preserve the deeper seat grounding after the stronger vertical drop.
 const SEATED_HUMAN_FOOT_GROUND_CLEARANCE = -1.55 * MODEL_SCALE * STOOL_SCALE;
 const SEATED_HUMAN_DICE_PHASES = Object.freeze({
-  reachMs: 250,
-  gripMs: 180,
+  reachMs: 170,
+  gripMs: 120,
   holdMs: 220,
   windupMs: 300,
   releaseMs: 260,
@@ -4517,9 +4517,9 @@ function applySeatedHumanPose(rig, mode = 'idle', intensity = 1, handGrip = 0, t
     forearmX = THREE.MathUtils.lerp(forearmX, -1.02, t);
     forearmY = THREE.MathUtils.lerp(forearmY, -0.18, t);
     forearmZ = THREE.MathUtils.lerp(forearmZ, -0.34, t);
-    wristX = THREE.MathUtils.lerp(wristX, -0.5, t);
-    wristY = THREE.MathUtils.lerp(wristY, 0.1, t);
-    wristZ = THREE.MathUtils.lerp(wristZ, -0.34, t);
+    wristX = THREE.MathUtils.lerp(wristX, -0.64, t);
+    wristY = THREE.MathUtils.lerp(wristY, -0.12, t);
+    wristZ = THREE.MathUtils.lerp(wristZ, -0.08, t);
   } else if (mode === 'gripDice') {
     shoulderX = THREE.MathUtils.lerp(shoulderX, -0.76, t);
     shoulderY = THREE.MathUtils.lerp(shoulderY, -0.10, t);
@@ -4527,9 +4527,9 @@ function applySeatedHumanPose(rig, mode = 'idle', intensity = 1, handGrip = 0, t
     forearmX = THREE.MathUtils.lerp(forearmX, -0.98, t);
     forearmY = THREE.MathUtils.lerp(forearmY, -0.22, t);
     forearmZ = THREE.MathUtils.lerp(forearmZ, -0.12, t);
-    wristX = THREE.MathUtils.lerp(wristX, -0.54, t);
-    wristY = THREE.MathUtils.lerp(wristY, 0.08, t);
-    wristZ = THREE.MathUtils.lerp(wristZ, -0.2, t);
+    wristX = THREE.MathUtils.lerp(wristX, -0.7, t);
+    wristY = THREE.MathUtils.lerp(wristY, -0.14, t);
+    wristZ = THREE.MathUtils.lerp(wristZ, 0.02, t);
   } else if (mode === 'holdDice') {
     shoulderX = THREE.MathUtils.lerp(shoulderX, -0.5, t);
     shoulderY = THREE.MathUtils.lerp(shoulderY, -0.18, t);
@@ -4537,9 +4537,9 @@ function applySeatedHumanPose(rig, mode = 'idle', intensity = 1, handGrip = 0, t
     forearmX = THREE.MathUtils.lerp(forearmX, -1.08, t);
     forearmY = THREE.MathUtils.lerp(forearmY, -0.1, t);
     forearmZ = THREE.MathUtils.lerp(forearmZ, 0.38, t);
-    wristX = THREE.MathUtils.lerp(wristX, -0.56, t);
-    wristY = THREE.MathUtils.lerp(wristY, 0.06, t);
-    wristZ = THREE.MathUtils.lerp(wristZ, 0.14, t);
+    wristX = THREE.MathUtils.lerp(wristX, -0.66, t);
+    wristY = THREE.MathUtils.lerp(wristY, -0.08, t);
+    wristZ = THREE.MathUtils.lerp(wristZ, 0.2, t);
   } else if (mode === 'windUp') {
     shoulderX = THREE.MathUtils.lerp(shoulderX, -0.88, t);
     shoulderY = THREE.MathUtils.lerp(shoulderY, -0.38, t);
@@ -6780,9 +6780,9 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       beginDiceHoldPose(player);
       return;
     }
-    beginDiceHoldPose(player, { startMs: performance.now() - 220 });
+    beginDiceHoldPose(player, { startMs: performance.now() - 320 });
     animateDicePosition(dice, target, {
-      duration: 520,
+      duration: 280,
       lift: 0.05,
       onComplete: () => beginDiceHoldPose(player)
     });
@@ -10243,7 +10243,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     return true;
   }, []);
 
-  const syncDiceToThrowHand = useCallback((player, dice, { duration = 90 } = {}) => {
+  const syncDiceToThrowHand = useCallback((player, dice, { duration = 45 } = {}) => {
     if (!dice?.isObject3D || !dice.parent?.isObject3D) return Promise.resolve();
     const parent = dice.parent;
     const worldTarget = new THREE.Vector3();
@@ -10334,7 +10334,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       throwForward = clamp(-localDir.z * 1.4, -1, 1);
     }
     beginDiceThrowPose(player, { lateral: throwLateral, forward: throwForward });
-    await syncDiceToThrowHand(player, dice, { duration: 70 });
+    await syncDiceToThrowHand(player, dice, { duration: 38 });
     const landingFocus = baseTarget.clone();
     const value = await spinDice(dice, {
       duration: resolveFrameSyncedDuration(AUTO_ROLL_DURATION_MS, { min: 620, max: 1800 }),


### PR DESCRIPTION
### Motivation
- Fix the seated human right-hand/finger orientation so fingers point down toward the dice during pickup instead of up. 
- Remove the visible pickup lag by making the dice snap/move into the hand faster so it does not linger in front of the player. 
- Keep the existing default avatar while simplifying the alternate store roster to the three requested Ready Player Me GLB variants so the store shows precisely the requested characters.

### Description
- Tuned timing constants in `webapp/src/pages/Games/LudoBattleRoyal.jsx` by reducing `SEATED_HUMAN_DICE_PHASES.reachMs` and `gripMs` and shortening rail/transition durations to accelerate dice-to-hand motion. 
- Rotated the right wrist targets used during `reachDice`, `gripDice`, and `holdDice` by adjusting `wristX`, `wristY`, and `wristZ` lerps so the fingers angle downward into the dice. 
- Made dice movement/hand sync faster by reducing the `moveDiceToRail` animation `duration`, increasing the earlier `beginDiceHoldPose` offset, and shortening the default `syncDiceToThrowHand` duration and its call-site; the code now snaps the dice to the contact effector immediately and lerps more quickly. 
- Updated the human roster in `webapp/src/config/ludoBattleOptions.js` to keep the default `rpm-current` entry and replace other alternates with exactly the first three Ready Player Me candidates (`rpm-67d411`, `rpm-67f433`, `rpm-67e1b5`) including URL fallbacks, preserving sizing/seat/orientation/logic via the existing seated-human pipeline.

### Testing
- Ran `npx eslint webapp/src/pages/Games/LudoBattleRoyal.jsx webapp/src/config/ludoBattleOptions.js` which completed but reported the files are ignored by the repository lint ignore patterns (warnings). 
- Ran `npx eslint --no-ignore webapp/src/pages/Games/LudoBattleRoyal.jsx webapp/src/config/ludoBattleOptions.js` which reported style errors (notably in `webapp/src/config/ludoBattleOptions.js` such as semicolon/blank-line rules); these are legacy-style mismatches and pre-existing repository lint constraints rather than runtime failures. 
- No automated visual/unit tests were executed for animation/pose changes in this environment and a browser-based visual check is required to validate the finger orientation and dice contact in-game (could not run here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee29dc1f3c8329942f87605a1e1853)