### PR TITLE
Fix Ludo GLB weapon loading, hand grip direction, and graphics quality scaling

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -184,6 +184,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
     label: 'AK-47',
     urls: [
       'https://cdn.jsdelivr.net/gh/LazerMaker/gun-models-ak47-and-supprest-pistol-@master/ak47.glb',
+      'https://cdn.jsdelivr.net/gh/webaverse/pistol@master/military.glb',
       'https://raw.githubusercontent.com/LazerMaker/gun-models-ak47-and-supprest-pistol-/master/ak47.glb',
       'https://cdn.statically.io/gh/LazerMaker/gun-models-ak47-and-supprest-pistol-/master/ak47.glb'
     ],
@@ -200,31 +201,75 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   },
   shotgunBlastAttack: {
     label: 'Shotgun',
-    url: 'https://raw.githubusercontent.com/pmndrs/drei-assets/master/shotgun.glb',
+    urls: [
+      'https://cdn.jsdelivr.net/gh/webaverse/pistol@master/military.glb',
+      'https://cdn.jsdelivr.net/gh/webaverse/pistol@master/pistol.glb'
+    ],
     scale: 0.228
   },
   sniperShotAttack: {
     label: 'Sniper Rifle',
-    url: 'https://raw.githubusercontent.com/pmndrs/drei-assets/master/sniper.glb',
+    urls: [
+      'https://cdn.jsdelivr.net/gh/webaverse/pistol@master/military.glb',
+      'https://cdn.jsdelivr.net/gh/LazerMaker/gun-models-ak47-and-supprest-pistol-@master/ak47.glb'
+    ],
     scale: 0.248
   },
   smgBurstAttack: {
     label: 'SMG',
-    url: 'https://raw.githubusercontent.com/pmndrs/drei-assets/master/smg.glb',
+    urls: [
+      'https://cdn.jsdelivr.net/gh/webaverse/uzi@main/uzi.glb',
+      'https://cdn.jsdelivr.net/gh/webaverse/pistol@master/pistol.glb'
+    ],
     scale: 0.218
   },
   compactCarbineAttack: {
     label: 'Compact Carbine',
-    urls: ['https://raw.githubusercontent.com/pmndrs/drei-assets/master/smg.glb'],
+    urls: [
+      'https://cdn.jsdelivr.net/gh/webaverse/uzi@main/uzi.glb',
+      'https://cdn.jsdelivr.net/gh/webaverse/pistol@master/military.glb'
+    ],
     scale: 0.21
   },
   marksmanDmrAttack: {
     label: 'Marksman DMR',
-    urls: ['https://raw.githubusercontent.com/pmndrs/drei-assets/master/sniper.glb'],
+    urls: [
+      'https://cdn.jsdelivr.net/gh/webaverse/pistol@master/military.glb',
+      'https://cdn.jsdelivr.net/gh/LazerMaker/gun-models-ak47-and-supprest-pistol-@master/ak47.glb'
+    ],
     scale: 0.23
   }
 });
 const CAPTURE_WEAPON_MODEL_CACHE = new Map();
+let activeModelTextureAnisotropy = 8;
+
+function resolveModelTextureAnisotropy(profile = null) {
+  const id = `${profile?.id || ''}`.toLowerCase();
+  if (id.includes('hd50')) return 3;
+  if (id.includes('fhd60')) return 6;
+  if (id.includes('qhd90')) return 8;
+  if (id.includes('uhd120')) return 12;
+  if (id.includes('uhd144')) return 16;
+  return 8;
+}
+
+function setModelTextureQualityProfile(profile = null) {
+  activeModelTextureAnisotropy = resolveModelTextureAnisotropy(profile);
+}
+
+function applyModelQualityToObject(root) {
+  if (!root?.isObject3D) return;
+  root.traverse((node) => {
+    if (!node?.isMesh) return;
+    const materials = Array.isArray(node.material) ? node.material : [node.material];
+    materials.forEach((material) => {
+      if (!material) return;
+      normalizeMaterialTextures(material, activeModelTextureAnisotropy, { preserveGltfTextureMapping: true });
+      material.needsUpdate = true;
+    });
+  });
+}
+
 const FIREARM_MAGAZINE_SHOTS = Object.freeze({
   glockSidearmAttack: 17,
   pistolSidearmAttack: 16,
@@ -332,6 +377,7 @@ async function loadCaptureWeaponModel(captureAnimationId) {
           material.needsUpdate = true;
         });
       });
+      applyModelQualityToObject(root);
       fitObjectToTargetSize(root, config.scale ?? 0.12);
       return root;
     } catch (error) {
@@ -4460,7 +4506,7 @@ function normalizedPhase(nowMs, startMs, durationMs) {
 function curlFingerChain(rig, chain = [], amount = 0, sideSpread = 0) {
   const grip = clamp(amount, 0, 1);
   chain.forEach((bone, index) => {
-    const curl = index === 0 ? -0.38 : -0.72;
+    const curl = index === 0 ? 0.38 : 0.72;
     const side = index === 0 ? sideSpread : sideSpread * 0.25;
     addBoneRot(rig, bone, curl * grip, 0.03 * grip, side * grip, 1);
   });
@@ -4478,7 +4524,7 @@ function applyRightHandGrip(rig, gripAmount = 0) {
   curlFingerChain(rig, rig.rightPinky, grip * squeeze, 0.105 - 0.04 * open);
 
   (rig.rightThumb || []).forEach((bone, index) => {
-    const fold = index === 0 ? -0.38 : -0.62;
+    const fold = index === 0 ? 0.38 : 0.62;
     addBoneRot(rig, bone, fold * grip, -0.36 * grip, 0.27 * grip, 1);
   });
 }
@@ -5187,12 +5233,13 @@ async function loadSeatedHumanTemplate(renderer = null, humanOption = HUMAN_CHAR
             materials.forEach((mat) => {
               if (!mat?.map) mat.map = fallbackTex;
               if (mat?.color?.setHex) mat.color.setHex(0xffffff);
-              normalizeMaterialTextures(mat, 8, { preserveGltfTextureMapping: true });
+              normalizeMaterialTextures(mat, activeModelTextureAnisotropy, { preserveGltfTextureMapping: true });
               if (mat?.emissiveMap) mat.emissiveMap.needsUpdate = true;
               mat.needsUpdate = true;
             });
           }
         });
+        applyModelQualityToObject(root);
         return root;
       })()
     );
@@ -5610,6 +5657,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
   }, [activeFrameRateOption]);
   useEffect(() => {
     frameQualityRef.current = frameQualityProfile;
+    setModelTextureQualityProfile(frameQualityProfile);
   }, [frameQualityProfile]);
   const resolvedFrameTiming = useMemo(() => {
     const fallbackFps =
@@ -7366,6 +7414,14 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       if (hdriChanged) {
         await applyHdriEnvironment(envVariant);
         arena.hdriResolutionKey = hdriResolutionProfile.key;
+      }
+
+      if (qualityChanged) {
+        seatedHumanActorsRef.current?.forEach((entry) => applyModelQualityToObject(entry?.actor));
+        parkedCaptureVehiclesRef.current?.forEach((entry) => {
+          applyModelQualityToObject(entry?.weaponRack);
+          applyModelQualityToObject(entry?.weaponHolder);
+        });
       }
 
       if (paletteChanged || tokenStyleChanged || tokenPieceChanged || tableChanged || qualityChanged) {


### PR DESCRIPTION
### Motivation
- Resolve missing/white firearm models caused by dead/404 GLB URLs and provide stronger AK‑47 fallbacks so weapons reliably render in the Ludo Battle Royal scene.
- Correct the seated human right-hand finger/thumb curling so the hand closes downwards to properly catch tokens/dice.
- Ensure loaded GLB human and weapon models respect the selected graphics/quality profile (texture anisotropy) so visuals match the chosen settings.

### Description
- Replaced several unreliable `pmndrs/drei-assets` GLB endpoints and added reachable CDN fallbacks for `ak47`, `shotgun`, `sniper`, `smg`, `compactCarbine`, and `marksmanDmr` in `CAPTURE_WEAPON_MODEL_CONFIG`.
- Added a small model-quality pipeline: `resolveModelTextureAnisotropy`, `setModelTextureQualityProfile`, and `applyModelQualityToObject` to map frame/graphics profile to a texture anisotropy value and reapply normalized texture settings to GLB materials.
- Applied the model-quality pass when capture weapons are prepared (`loadCaptureWeaponModel`) and when seated human templates are loaded (`loadSeatedHumanTemplate`), and hooked `setModelTextureQualityProfile` into frame-profile updates.
- Triggered a reapplication of model-quality to seated human actors and parked weapon-rack/holder objects when the renderer texture/quality profile changes.
- Fixed finger curl/thumb fold sign in `curlFingerChain` and `applyRightHandGrip` so fingers bend downward toward dice/tokens during pickup/grip.

### Testing
- Verified remote GLB endpoints with HTTP checks: replacement CDN GLB URLs (webaverse/jsdelivr, LazerMaker jsdelivr) responded 200 while several original `pmndrs/drei-assets` links returned 404, validating the need for replacements (URL checks succeeded for chosen fallbacks).
- Ran ESLint parsing (`npx eslint`) on the modified file; linter reported a repository ignore warning but no syntax errors for the touched file.
- No unit/integration tests were modified or executed; changes are front-end visual/asset/animation fixes limited to `webapp/src/pages/Games/LudoBattleRoyal.jsx` and validated by the network and lint checks above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee4607f240832989934314f7e2a2fe)