### PR TITLE
Improve seated dice hold helpers and hand-sync for Ludo 3D

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -2187,8 +2187,10 @@ const SEATED_HUMAN_DOWNWARD_CONTACT_MODE_SET = new Set([
 const SEATED_HELPER_FORWARD_DICE_PICKUP = 0.092 * MODEL_SCALE;
 const SEATED_HELPER_FORWARD_DICE_RELEASE = 0.148 * MODEL_SCALE;
 const SEATED_HELPER_RIGHT_DICE = -0.013 * MODEL_SCALE;
-const SEATED_HELPER_UP_DICE_PICKUP = -0.014 * MODEL_SCALE;
+const SEATED_HELPER_UP_DICE_PICKUP = -0.024 * MODEL_SCALE;
 const SEATED_HELPER_UP_DICE_RELEASE = 0.01 * MODEL_SCALE;
+const SEATED_HELPER_FORWARD_DICE_HOLD = 0.104 * MODEL_SCALE;
+const SEATED_HELPER_UP_DICE_HOLD = -0.03 * MODEL_SCALE;
 const SEATED_HELPER_FORWARD_TOKEN_PICKUP = 0.076 * MODEL_SCALE;
 const SEATED_HELPER_FORWARD_TOKEN_PLACE = 0.114 * MODEL_SCALE;
 const SEATED_HELPER_RIGHT_TOKEN = -0.012 * MODEL_SCALE;
@@ -4795,6 +4797,12 @@ function createSeatedHumanActionHelpers(actor, rig) {
       SEATED_HELPER_UP_DICE_RELEASE,
       SEATED_HELPER_FORWARD_DICE_RELEASE
     ),
+    diceHold: createHelper(
+      'diceHoldHelper',
+      SEATED_HELPER_RIGHT_DICE,
+      SEATED_HELPER_UP_DICE_HOLD,
+      SEATED_HELPER_FORWARD_DICE_HOLD
+    ),
     tokenPickup: createHelper(
       'tokenPickupHelper',
       SEATED_HELPER_RIGHT_TOKEN,
@@ -6923,12 +6931,35 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     requestAnimationFrame(step);
   };
 
+  const resolveDiceHoldContactTarget = (player, fallbackTarget = null) => {
+    const dice = diceRef.current;
+    if (!dice?.isObject3D) return fallbackTarget ?? null;
+    const actorEntry = seatedHumanActorsRef.current?.find((entry) => entry?.playerIndex === player);
+    if (!actorEntry) return fallbackTarget ?? null;
+    const helperWorld = new THREE.Vector3();
+    const sampled =
+      sampleSeatedActionHelper(actorEntry, 'diceHold', helperWorld) ||
+      sampleSeatedActionHelper(actorEntry, 'dicePickup', helperWorld);
+    if (!sampled) return fallbackTarget ?? null;
+    const parent = dice.parent;
+    const local = helperWorld.clone();
+    if (parent?.worldToLocal) {
+      parent.worldToLocal(local);
+    }
+    // Keep the dice slightly under the fingertip so the grasp appears like physical contact.
+    local.y -= DICE_SIZE * 0.08;
+    return local;
+  };
+
   const moveDiceToRail = (player, immediate = false) => {
     const dice = diceRef.current;
     if (!dice) return;
     const rails = dice.userData?.railPositions;
     if (!rails || !rails[player]) return;
-    const target = rails[player].clone ? rails[player].clone() : new THREE.Vector3().copy(rails[player]);
+    const railTarget = rails[player].clone ? rails[player].clone() : new THREE.Vector3().copy(rails[player]);
+    // Keep the local human player dice at the visible board rail before roll (tap-to-roll expectation on portrait).
+    // AI turns can still use the hand-rest contact helper.
+    const target = player === 0 ? railTarget : resolveDiceHoldContactTarget(player, railTarget) ?? railTarget;
     if (immediate) {
       stopDiceTransition();
       dice.position.copy(target);
@@ -10436,14 +10467,24 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
   const syncDiceToThrowHand = useCallback((player, dice, { duration = 28 } = {}) => {
     if (!dice?.isObject3D || !dice.parent?.isObject3D) return Promise.resolve();
     const parent = dice.parent;
-    const worldTarget = new THREE.Vector3();
+    const worldTargetPickup = new THREE.Vector3();
+    const worldTargetRelease = new THREE.Vector3();
     const localTarget = new THREE.Vector3();
     const start = performance.now();
 
-    const snapToHand = (blend = 1) => {
-      if (!sampleSeatedContactEffectorPosition(player, worldTarget)) return false;
-      worldTarget.y -= DICE_SIZE * 0.1;
-      localTarget.copy(worldTarget);
+    const snapToHand = (blend = 1, phase = 1) => {
+      const hasPickup =
+        sampleHumanActionHelperPosition(player, 'dicePickup', worldTargetPickup) ||
+        sampleSeatedContactEffectorPosition(player, worldTargetPickup);
+      if (!hasPickup) return false;
+      const hasRelease = sampleHumanActionHelperPosition(player, 'diceRelease', worldTargetRelease);
+      const useRelease = hasRelease && phase > 0.52;
+      const targetWorld = useRelease
+        ? worldTargetPickup.clone().lerp(worldTargetRelease, smoother01((phase - 0.52) / 0.48))
+        : worldTargetPickup;
+      // Small portrait-calibrated downward nudge so fingers visibly touch the die (not hanging below hand).
+      targetWorld.y -= DICE_SIZE * 0.038;
+      localTarget.copy(targetWorld);
       parent.worldToLocal(localTarget);
       if (blend >= 1) {
         dice.position.copy(localTarget);
@@ -10465,7 +10506,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         const elapsed = performance.now() - start;
         const phase = clamp(elapsed / Math.max(1, duration), 0, 1);
         const blend = 0.92 + (1 - Math.pow(1 - phase, 2)) * 0.08;
-        snapToHand(blend);
+        snapToHand(blend, phase);
         if (phase < 1) {
           requestAnimationFrame(step);
         } else {


### PR DESCRIPTION
### Motivation
- Improve the visual contact and positioning of dice when held by seated actors so grasps look physically plausible. 
- Keep the local player's dice at a visible board rail in portrait mode while allowing AI/other players to use hand-contact helpers.
- Reduce visible pickup lag and make the throw-hand sync smoothly interpolate between pickup and release positions.

### Description
- Adjusted dice pickup vertical offset `SEATED_HELPER_UP_DICE_PICKUP` to better align fingertips with the die and added new hold offsets `SEATED_HELPER_FORWARD_DICE_HOLD` and `SEATED_HELPER_UP_DICE_HOLD`.
- Added a `diceHold` helper in `createSeatedHumanActionHelpers` so seated actors expose a dedicated hold target in world space.
- Introduced `resolveDiceHoldContactTarget` to prefer the `diceHold` helper (falling back to `dicePickup`) and return a local-space target slightly under the fingertip.
- Modified `moveDiceToRail` so the local player (player 0) stays at the visible rail while other players use the contact-target computed by `resolveDiceHoldContactTarget`.
- Enhanced `syncDiceToThrowHand` to sample both pickup and release helper positions, interpolate between them across the throw phase, apply a calibrated downward nudge, and immediately snap the die into the hand to remove visible pickup lag.

### Testing
- Ran the existing automated test suite with `yarn test` and linters with `yarn lint`, and they completed successfully with no failures.
- No new automated tests were added for these visual/behavior changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee4d17494c8329add4ae052b79c603)