### PR TITLE
Improve seated player dice hold/throw positioning and add diceHold helper

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -2187,8 +2187,12 @@ const SEATED_HUMAN_DOWNWARD_CONTACT_MODE_SET = new Set([
 const SEATED_HELPER_FORWARD_DICE_PICKUP = 0.092 * MODEL_SCALE;
 const SEATED_HELPER_FORWARD_DICE_RELEASE = 0.148 * MODEL_SCALE;
 const SEATED_HELPER_RIGHT_DICE = -0.013 * MODEL_SCALE;
-const SEATED_HELPER_UP_DICE_PICKUP = -0.014 * MODEL_SCALE;
+const SEATED_HELPER_UP_DICE_PICKUP = -0.024 * MODEL_SCALE;
 const SEATED_HELPER_UP_DICE_RELEASE = 0.01 * MODEL_SCALE;
+const SEATED_HELPER_FORWARD_DICE_HOLD = 0.104 * MODEL_SCALE;
+const SEATED_HELPER_UP_DICE_HOLD = -0.03 * MODEL_SCALE;
+const SEATED_DICE_HOLD_VERTICAL_NUDGE = 0.045;
+const SEATED_DICE_THROW_VERTICAL_NUDGE = 0.055;
 const SEATED_HELPER_FORWARD_TOKEN_PICKUP = 0.076 * MODEL_SCALE;
 const SEATED_HELPER_FORWARD_TOKEN_PLACE = 0.114 * MODEL_SCALE;
 const SEATED_HELPER_RIGHT_TOKEN = -0.012 * MODEL_SCALE;
@@ -4795,6 +4799,12 @@ function createSeatedHumanActionHelpers(actor, rig) {
       SEATED_HELPER_UP_DICE_RELEASE,
       SEATED_HELPER_FORWARD_DICE_RELEASE
     ),
+    diceHold: createHelper(
+      'diceHoldHelper',
+      SEATED_HELPER_RIGHT_DICE,
+      SEATED_HELPER_UP_DICE_HOLD,
+      SEATED_HELPER_FORWARD_DICE_HOLD
+    ),
     tokenPickup: createHelper(
       'tokenPickupHelper',
       SEATED_HELPER_RIGHT_TOKEN,
@@ -6923,12 +6933,37 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     requestAnimationFrame(step);
   };
 
+  const resolveDiceHoldContactTarget = (player, fallbackTarget = null) => {
+    const dice = diceRef.current;
+    if (!dice?.isObject3D) return fallbackTarget ?? null;
+    if (player === 0) {
+      // Keep local/human turn start anchored on the board rail so users see exactly where to tap to roll.
+      return fallbackTarget ?? null;
+    }
+    const actorEntry = seatedHumanActorsRef.current?.find((entry) => entry?.playerIndex === player);
+    if (!actorEntry) return fallbackTarget ?? null;
+    const helperWorld = new THREE.Vector3();
+    const sampled =
+      sampleSeatedActionHelper(actorEntry, 'diceHold', helperWorld) ||
+      sampleSeatedActionHelper(actorEntry, 'dicePickup', helperWorld);
+    if (!sampled) return fallbackTarget ?? null;
+    const parent = dice.parent;
+    const local = helperWorld.clone();
+    if (parent?.worldToLocal) {
+      parent.worldToLocal(local);
+    }
+    // Keep the dice slightly under the fingertip so the grasp appears like physical contact.
+    local.y -= DICE_SIZE * SEATED_DICE_HOLD_VERTICAL_NUDGE;
+    return local;
+  };
+
   const moveDiceToRail = (player, immediate = false) => {
     const dice = diceRef.current;
     if (!dice) return;
     const rails = dice.userData?.railPositions;
     if (!rails || !rails[player]) return;
-    const target = rails[player].clone ? rails[player].clone() : new THREE.Vector3().copy(rails[player]);
+    const railTarget = rails[player].clone ? rails[player].clone() : new THREE.Vector3().copy(rails[player]);
+    const target = resolveDiceHoldContactTarget(player, railTarget) ?? railTarget;
     if (immediate) {
       stopDiceTransition();
       dice.position.copy(target);
@@ -10441,8 +10476,11 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     const start = performance.now();
 
     const snapToHand = (blend = 1) => {
-      if (!sampleSeatedContactEffectorPosition(player, worldTarget)) return false;
-      worldTarget.y -= DICE_SIZE * 0.1;
+      const sampledHold =
+        sampleHumanActionHelperPosition(player, 'diceHold', worldTarget) ||
+        sampleHumanActionHelperPosition(player, 'dicePickup', worldTarget);
+      if (!sampledHold && !sampleSeatedContactEffectorPosition(player, worldTarget)) return false;
+      worldTarget.y -= DICE_SIZE * SEATED_DICE_THROW_VERTICAL_NUDGE;
       localTarget.copy(worldTarget);
       parent.worldToLocal(localTarget);
       if (blend >= 1) {
@@ -10474,7 +10512,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       };
       requestAnimationFrame(step);
     });
-  }, [sampleSeatedContactEffectorPosition]);
+  }, [sampleHumanActionHelperPosition, sampleSeatedContactEffectorPosition]);
 
   const rollDice = async () => {
     const state = stateRef.current;


### PR DESCRIPTION
### Motivation
- Improve the visual alignment between seated players' hands and the dice during pickup, hold and throw to make grasps look like physical contact. 
- Ensure the local player's start-of-turn dice remains anchored to the board rail while remote seated players' dice snap to hand/hold helpers for clearer animation.

### Description
- Tuned the pickup vertical offset by changing `SEATED_HELPER_UP_DICE_PICKUP` and added new constants `SEATED_HELPER_FORWARD_DICE_HOLD`, `SEATED_HELPER_UP_DICE_HOLD`, `SEATED_DICE_HOLD_VERTICAL_NUDGE`, and `SEATED_DICE_THROW_VERTICAL_NUDGE` to control hold/throw vertical offsets.
- Added a `diceHold` helper in `createSeatedHumanActionHelpers` so seated actors can expose a distinct hold target separate from pickup/release helpers.
- Implemented `resolveDiceHoldContactTarget` to choose an appropriate world/local target for held dice (keeps player 0 anchored to the rail, samples `diceHold` or falls back to `dicePickup` for others, and applies the hold vertical nudge).
- Updated `moveDiceToRail` to use the resolved hold target, and updated `syncDiceToThrowHand` to sample `diceHold`/`dicePickup` (falling back to the effector) and apply the throw vertical nudge, and added the new dependency to the hook.

### Testing
- Ran unit tests with `yarn test`, which completed successfully.
- Ran lint and build checks with `yarn lint` and `yarn build`, which also passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee4d17494c8329add4ae052b79c603)