### PR TITLE
Fix Pool Royale manual strike to always transfer cue-ball impact

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -27463,7 +27463,8 @@ useEffect(() => {
             applyShotAtImpact(shotImpactPayload);
           };
           const useBilardoImmediateImpact =
-            manualShotStateRef.current === 'striking';
+            manualShotStateRef.current === 'striking' ||
+            Number.isFinite(committedPowerOverride);
           if (ENABLE_CUE_STROKE_ANIMATION && shotRecording) {
             const strokeStartOffset = REPLAY_CUE_START_HOLD_MS;
             shotRecording.cueStroke = {
@@ -33343,6 +33344,7 @@ useEffect(() => {
   const onPowerDragStart = useCallback(() => {
     captureCueStickAnchor();
     manualStrikeDidHitRef.current = false;
+    manualShotStateRef.current = 'dragging';
     setManualShotState('dragging');
   }, [captureCueStickAnchor]);
   const onPowerDrag = useCallback((powerRatio = 0) => {
@@ -33363,10 +33365,10 @@ useEffect(() => {
     manualStrikeDidHitRef.current = false;
     manualStrikeStartedAtRef.current = performance.now();
     const shouldStrike = latchedPower > BILARDO_MIN_RELEASE_POWER;
+    manualShotStateRef.current = shouldStrike ? 'striking' : 'idle';
     setManualShotState(shouldStrike ? 'striking' : 'idle');
     if (shouldStrike) {
-      // Immediate fire on release guarantees cue-ball power transfer even if
-      // strike timeline callbacks are delayed on some devices.
+      // Bilardo Shqip behavior: release should immediately commit the shot.
       fireRef.current?.(latchedPower);
     }
   }, [applyPower, clampPower]);
@@ -33384,17 +33386,9 @@ useEffect(() => {
       );
       if (!manualStrikeDidHitRef.current && strikeNorm > MANUAL_STRIKE_THRESHOLD) {
         manualStrikeDidHitRef.current = true;
-        fireRef.current?.(
-          manualStrikePowerRef.current ??
-            shotPowerRef.current ??
-            powerRef.current ??
-            0
-        );
       }
       if (strikeNorm >= 1) {
-        if (!shootingRef.current && manualStrikePowerRef.current > BILARDO_MIN_RELEASE_POWER) {
-          fireRef.current?.(manualStrikePowerRef.current);
-        }
+        manualShotStateRef.current = 'idle';
         setManualShotState('idle');
         manualStrikeStartedAtRef.current = 0;
         manualStrikePowerRef.current = 0;


### PR DESCRIPTION
### Motivation
- Cue-ball could remain stationary after slider release because the manual strike flow relied on async state and fallback re-fires, causing missed immediate impulse. 
- Align slider-release behaviour with the Bilardo Shqip mechanic where release commits the shot immediately and preserves the original strike timing.
- Avoid redundant re-fire attempts from the RAF tick that could create non-deterministic or conflicting strike timing.

### Description
- Synchronously update `manualShotStateRef.current` in `onPowerDragStart` and `onPowerRelease` so ref-state matches UI state immediately. (modified `webapp/src/pages/Games/PoolRoyale.jsx`).
- Immediately commit slider-shot by calling `fireRef.current(latchedPower)` on release when `shouldStrike` is true, ensuring cue-ball receives impulse at release time. (modified `onPowerRelease`).
- Remove fallback `fire()` calls from the manual strike RAF loop so the RAF tick only tracks animation progress and resets the slider, preventing duplicate/late firing. (removed redundant `fireRef` calls in RAF loop).
- Treat `committedPowerOverride` as an immediate-impact trigger by expanding the `useBilardoImmediateImpact` condition, ensuring programmatic/slider-committed fires apply impact right away. (updated impact conditional logic).

### Testing
- Ran `npm test -- --runInBand test/poolRoyaleShotState.test.js test/cueShotImpact.test.js` and both test suites passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee52fd01048329b00939224be320d5)