### PR TITLE
Fix Pool Royal cue strike to always apply minimum shot power

### DIFF
--- a/Assets/Scripts/Gameplay/CueController.cs
+++ b/Assets/Scripts/Gameplay/CueController.cs
@@ -180,17 +180,6 @@ namespace Aiming
 
             float recoveredPower = RecoverPowerFromCueDepth(_chargedCueDepth);
             _latchedShotPower = ResolveReleasedShotPower(_power, recoveredPower);
-            if (_latchedShotPower <= 0f)
-            {
-                _shotState = ShotState.Idle;
-                _chargedCueDepth = idleTipGap;
-                _currentCueDepth = idleTipGap;
-                _dynamicLift = 0f;
-                _dynamicWobble = 0f;
-                ResetTipScale();
-                UpdateCuePose();
-                return;
-            }
 
             _latchedShotSpin = _liveSpinInput;
             _strikeDirection = _aimDirection;
@@ -421,12 +410,7 @@ namespace Aiming
         float ResolveReleasedShotPower(float sliderPower, float recoveredPower)
         {
             float raw = Mathf.Clamp01(Mathf.Max(sliderPower, recoveredPower));
-            if (raw <= 0f)
-            {
-                return 0f;
-            }
-
-            return Mathf.Max(minimumShotPowerNormalized, raw);
+            return raw <= 0f ? minimumShotPowerNormalized : Mathf.Max(minimumShotPowerNormalized, raw);
         }
 
         void ApplyStrikeImpulse(Vector3 strikeDirection, float shotPower)


### PR DESCRIPTION
### Motivation
- A valid release could be cancelled by an early-exit path leaving the cue ball stationary, breaking the intended Pool Royal shooting feel and diverging from the Bilardo Shqip behavior.
- The change ensures a released shot always results in a fired strike with at least the configured minimum power to keep controls responsive and consistent.

### Description
- Removed the early-return in `ReleaseAndStrike` that reset `_shotState` to `Idle` when resolved power was zero so a valid release no longer gets silently cancelled.
- Updated `ResolveReleasedShotPower` to return `minimumShotPowerNormalized` when the computed raw power is `<= 0`, ensuring a guaranteed minimum strike magnitude.
- Left `ApplyStrikeImpulse` and `CueStrikePhysics` logic intact so spin and impulse application remain unchanged.

### Testing
- Attempted to run `dotnet test billiards.Tests/Billiards.Tests.csproj`, but it failed in this environment because `dotnet` is not installed (`/bin/bash: dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee52fd01048329b00939224be320d5)