### PR TITLE
Add bilardo human rig and integrate animated player into SnookerRoyal

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -94,10 +94,17 @@ import {
   SPIN_STUN_RADIUS
 } from './snookerRoyalSpinUtils.js';
 import { sampleCueStrokeTimeline } from './poolRoyaleCueStrokeTimeline.js';
+import { BILARDO_STRIKE_TIME_MS } from './shared/bilardoShotModel';
+import {
+  createBilardoHumanRig,
+  chooseHumanEdgePosition,
+  updateBilardoHumanPose
+} from './shared/bilardoHumanRig.js';
 
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
 const BASIS_TRANSCODER_PATH =
   'https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/libs/basis/';
+const BILARDO_SHARED_HUMAN_GLTF_URL = 'https://threejs.org/examples/models/gltf/readyplayer.me.glb';
 
 function safePolygonUnion(...parts) {
   const valid = parts.filter(Boolean);
@@ -20723,6 +20730,38 @@ const powerRef = useRef(hud.power);
       table.add(cueStick);
       applySelectedCueStyle(cueStyleIndexRef.current ?? cueStyleIndex);
 
+      const humanLoader = createConfiguredGLTFLoader(renderer);
+      const humanActor = createBilardoHumanRig(scene, {
+        loader: humanLoader,
+        modelUrl: BILARDO_SHARED_HUMAN_GLTF_URL,
+        tableTopY: BALL_CENTER_Y - BALL_R,
+        humanScale: 1.18,
+        humanVisualYawFix: Math.PI,
+        strikeTime: BILARDO_STRIKE_TIME_MS / 1000
+      });
+      humanActor.root.visible = true;
+
+      const humanPoseContext = {
+        aimDir: new THREE.Vector2(0, 1),
+        power: 0,
+        state: 'idle',
+        cueBack: new THREE.Vector3(),
+        cueTip: new THREE.Vector3()
+      };
+      const updateSnookerHumanFromAim = (aimDirection, power = 0, options = {}) => {
+        if (!humanActor || !cue?.pos) return;
+        humanPoseContext.aimDir.set(aimDirection?.x ?? 0, aimDirection?.y ?? 1);
+        if (humanPoseContext.aimDir.lengthSq() < 1e-6) {
+          humanPoseContext.aimDir.set(0, 1);
+        } else {
+          humanPoseContext.aimDir.normalize();
+        }
+        humanPoseContext.power = THREE.MathUtils.clamp(power ?? 0, 0, 1);
+        humanPoseContext.state = options.state || humanPoseContext.state || 'idle';
+        if (options.cueBack) humanPoseContext.cueBack.copy(options.cueBack);
+        if (options.cueTip) humanPoseContext.cueTip.copy(options.cueTip);
+      };
+
       const closeCueGallery = () => {
         if (!ENABLE_CUE_GALLERY) return;
         const state = cueGalleryStateRef.current;
@@ -22141,6 +22180,11 @@ const powerRef = useRef(hud.power);
               }
               return;
             }
+            updateSnookerHumanFromAim(aimDir, clampedPower, {
+              state: 'striking',
+              cueBack: TMP_VEC3_BUTT.copy(cueStick.position).add(TMP_VEC3_CUE_BUTT_OFFSET),
+              cueTip: cueStick.position.clone().add(TMP_VEC3_CUE_TIP_OFFSET)
+            });
             requestAnimationFrame(animateStroke);
           };
           requestAnimationFrame(animateStroke);
@@ -24913,6 +24957,11 @@ const powerRef = useRef(hud.power);
           }
           updateChalkVisibility(visibleChalkIndex);
           cueStick.visible = true;
+          updateSnookerHumanFromAim(aimDir2D, powerStrength, {
+            state: 'dragging',
+            cueBack: TMP_VEC3_BUTT,
+            cueTip: tipTarget
+          });
           if (targetDir && targetBall) {
             const travelScale = BALL_R * (14 + powerStrength * 22);
             const tDir = new THREE.Vector3(targetDir.x, 0, targetDir.y);
@@ -25067,6 +25116,11 @@ const powerRef = useRef(hud.power);
           applyCueStickTransform(tipTarget);
           clampCueButtAboveCushion(tipTarget);
           cueStick.visible = true;
+          updateSnookerHumanFromAim(remoteAimDir, powerStrength, {
+            state: 'dragging',
+            cueBack: TMP_VEC3_BUTT,
+            cueTip: tipTarget
+          });
           updateChalkVisibility(null);
           if (targetDir && targetBall) {
             const travelScale = BALL_R * (14 + powerStrength * 22);
@@ -25167,6 +25221,11 @@ const powerRef = useRef(hud.power);
           applyCueStickTransform(tipTarget);
           clampCueButtAboveCushion(tipTarget);
           cueStick.visible = true;
+          updateSnookerHumanFromAim(planDir, powerTarget, {
+            state: 'dragging',
+            cueBack: TMP_VEC3_BUTT,
+            cueTip: tipTarget
+          });
         } else {
           aimFocusRef.current = null;
           aim.visible = false;
@@ -25179,6 +25238,11 @@ const powerRef = useRef(hud.power);
             tipGroupRef.current.position.set(0, 0, -cueLen / 2);
           }
           if (!cueAnimating) cueStick.visible = false;
+          updateSnookerHumanFromAim(aimDirRef.current, powerRef.current ?? 0, {
+            state: cueAnimating ? 'striking' : 'idle',
+            cueBack: TMP_VEC3_BUTT,
+            cueTip: cueStick.position.clone().add(TMP_VEC3_CUE_TIP_OFFSET)
+          });
           updateChalkVisibility(null);
         }
 
@@ -25187,6 +25251,51 @@ const powerRef = useRef(hud.power);
           if (precisionArea) precisionArea.visible = false;
         }
         chalkAssistTargetRef.current = shouldSlowAim;
+
+        if (humanActor && cue?.pos) {
+          const aimForward = new THREE.Vector3(
+            humanPoseContext.aimDir.x,
+            0,
+            humanPoseContext.aimDir.y
+          ).normalize();
+          const cueBallWorld = new THREE.Vector3(cue.pos.x, BALL_CENTER_Y, cue.pos.y);
+          const rootTarget = chooseHumanEdgePosition(cueBallWorld, aimForward, {
+            tableW: PLAY_W,
+            tableL: PLAY_H,
+            edgeMargin: Math.max(BALL_R * 8.4, SIDE_RAIL_INNER_THICKNESS * 2.2),
+            desiredShootDistance: Math.max(cueLen * 0.72, BALL_R * 22)
+          });
+          rootTarget.y = BALL_CENTER_Y - BALL_R * 2;
+          const aimSide = new THREE.Vector3(aimForward.z, 0, -aimForward.x).normalize();
+          const bridgeTarget = cueBallWorld
+            .clone()
+            .addScaledVector(aimForward, -Math.max(BALL_R * 5.6, cueLen * 0.16))
+            .addScaledVector(aimSide, -BALL_R * 0.18)
+            .setY(BALL_CENTER_Y - BALL_R + BALL_R * 0.24);
+          const gripTarget = humanPoseContext.cueTip
+            .clone()
+            .lerp(humanPoseContext.cueBack.clone(), 0.76);
+          const standingYaw = Math.atan2(-aimForward.x, -aimForward.z);
+          const upAxis = new THREE.Vector3(0, 1, 0);
+          const idleRight = rootTarget
+            .clone()
+            .add(new THREE.Vector3(0.24, 1.12, 0.02).applyAxisAngle(upAxis, standingYaw));
+          const idleLeft = rootTarget
+            .clone()
+            .add(new THREE.Vector3(-0.18, 1.08, 0.03).applyAxisAngle(upAxis, standingYaw));
+          updateBilardoHumanPose(humanActor, deltaSeconds, {
+            state: humanPoseContext.state,
+            rootTarget,
+            aimForward,
+            bridgeTarget,
+            gripTarget,
+            idleRight,
+            idleLeft,
+            cueBack: humanPoseContext.cueBack,
+            cueTip: humanPoseContext.cueTip,
+            power: humanPoseContext.power
+          });
+        }
 
         // Fizika
         balls.forEach((ball) => {

--- a/webapp/src/pages/Games/shared/bilardoHumanRig.js
+++ b/webapp/src/pages/Games/shared/bilardoHumanRig.js
@@ -1,0 +1,666 @@
+import * as THREE from 'three';
+
+const UP = new THREE.Vector3(0, 1, 0);
+const Y_AXIS = UP;
+const BASIS_MAT = new THREE.Matrix4();
+
+const clamp = (v, lo, hi) => Math.max(lo, Math.min(hi, v));
+const clamp01 = (v) => clamp(v, 0, 1);
+const lerp = (a, b, t) => a + (b - a) * t;
+const easeInOut = (t) => t * t * (3 - 2 * t);
+const dampScalar = (current, target, lambda, dt) =>
+  THREE.MathUtils.lerp(current, target, 1 - Math.exp(-lambda * dt));
+const yawFromForward = (forward) => Math.atan2(-forward.x, -forward.z);
+
+const cleanName = (name) => String(name || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+
+function makeBasisQuaternion(side, up, forward) {
+  BASIS_MAT.makeBasis(
+    side.clone().normalize(),
+    up.clone().normalize(),
+    forward.clone().normalize()
+  );
+  return new THREE.Quaternion().setFromRotationMatrix(BASIS_MAT);
+}
+
+function findBone(bones, names) {
+  const list = bones.map((bone) => ({ bone, name: cleanName(bone.name) }));
+  for (const alias of names) {
+    const exact = list.find((x) => x.name === alias || x.name.endsWith(alias));
+    if (exact) return exact.bone;
+  }
+  for (const alias of names) {
+    const loose = list.find((x) => x.name.includes(alias));
+    if (loose) return loose.bone;
+  }
+  return undefined;
+}
+
+function buildAvatarBones(model) {
+  const all = [];
+  model.traverse((obj) => {
+    if (obj?.isBone) all.push(obj);
+  });
+  const f = (...names) => findBone(all, names);
+  return {
+    hips: f('hips', 'pelvis', 'mixamorigHips'),
+    spine: f('spine', 'spine01', 'mixamorigSpine'),
+    chest: f('spine2', 'chest', 'upperchest', 'mixamorigSpine2', 'mixamorigSpine1'),
+    neck: f('neck', 'mixamorigNeck'),
+    head: f('head', 'mixamorigHead'),
+    leftUpperArm: f('leftupperarm', 'leftarm', 'upperarml', 'mixamorigLeftArm'),
+    leftLowerArm: f('leftforearm', 'leftlowerarm', 'forearml', 'mixamorigLeftForeArm'),
+    leftHand: f('lefthand', 'handl', 'mixamorigLeftHand'),
+    rightUpperArm: f('rightupperarm', 'rightarm', 'upperarmr', 'mixamorigRightArm'),
+    rightLowerArm: f('rightforearm', 'rightlowerarm', 'forearmr', 'mixamorigRightForeArm'),
+    rightHand: f('righthand', 'handr', 'mixamorigRightHand'),
+    leftUpperLeg: f('leftupleg', 'leftupperleg', 'leftthigh', 'mixamorigLeftUpLeg'),
+    leftLowerLeg: f('leftleg', 'leftlowerleg', 'leftcalf', 'mixamorigLeftLeg'),
+    leftFoot: f('leftfoot', 'footl', 'mixamorigLeftFoot'),
+    rightUpperLeg: f('rightupleg', 'rightupperleg', 'rightthigh', 'mixamorigRightUpLeg'),
+    rightLowerLeg: f('rightleg', 'rightlowerleg', 'rightcalf', 'mixamorigRightLeg'),
+    rightFoot: f('rightfoot', 'footr', 'mixamorigRightFoot')
+  };
+}
+
+function collectFingerBones(hand) {
+  const out = [];
+  hand?.traverse((obj) => {
+    if (!obj?.isBone || obj === hand) return;
+    const n = cleanName(obj.name);
+    if (['thumb', 'index', 'middle', 'ring', 'pinky', 'little', 'finger'].some((s) => n.includes(s))) {
+      out.push(obj);
+    }
+  });
+  return out;
+}
+
+function createFallbackHuman() {
+  const group = new THREE.Group();
+  const bodyMat = new THREE.MeshStandardMaterial({ color: 0x5d7286, roughness: 0.75, metalness: 0.02 });
+  const skinMat = new THREE.MeshStandardMaterial({ color: 0xffd3b0, roughness: 0.9, metalness: 0.0 });
+
+  const torso = new THREE.Mesh(new THREE.CapsuleGeometry(0.18, 0.62, 6, 12), bodyMat);
+  torso.position.set(0, 1.25, 0);
+  const hips = new THREE.Mesh(new THREE.CapsuleGeometry(0.16, 0.28, 6, 10), bodyMat);
+  hips.position.set(0, 0.86, 0);
+  const head = new THREE.Mesh(new THREE.SphereGeometry(0.16, 20, 16), skinMat);
+  head.position.set(0, 1.8, 0.04);
+  const lLeg = new THREE.Mesh(new THREE.CapsuleGeometry(0.08, 0.64, 6, 10), bodyMat);
+  lLeg.position.set(-0.11, 0.36, 0);
+  const rLeg = lLeg.clone();
+  rLeg.position.x = 0.11;
+  const lArm = new THREE.Mesh(new THREE.CapsuleGeometry(0.06, 0.52, 6, 10), bodyMat);
+  lArm.position.set(-0.3, 1.25, -0.04);
+  lArm.rotation.z = 0.25;
+  const rArm = lArm.clone();
+  rArm.position.x = 0.3;
+  rArm.rotation.z = -0.35;
+
+  group.add(torso, hips, head, lLeg, rLeg, lArm, rArm);
+  group.traverse((child) => {
+    if (child.isMesh) {
+      child.castShadow = true;
+      child.receiveShadow = true;
+    }
+  });
+  return group;
+}
+
+function normalizeHuman(model, opts) {
+  const scale = opts?.humanScale ?? 1.18;
+  const yawFix = opts?.humanVisualYawFix ?? Math.PI;
+  model.scale.setScalar(scale);
+  model.rotation.set(0, yawFix, 0);
+  model.position.set(0, 0, 0);
+  model.updateMatrixWorld(true);
+  const box = new THREE.Box3().setFromObject(model);
+  const center = box.getCenter(new THREE.Vector3());
+  model.position.set(-center.x, -box.min.y, -center.z);
+}
+
+export function createBilardoHumanRig(scene, opts = {}) {
+  const human = {
+    root: new THREE.Group(),
+    modelRoot: new THREE.Group(),
+    model: null,
+    fallback: createFallbackHuman(),
+    bones: {},
+    leftFingers: [],
+    rightFingers: [],
+    restQuats: new Map(),
+    loaded: false,
+    activeGlb: false,
+    poseT: 0,
+    walkT: 0,
+    yaw: 0,
+    breathT: 0,
+    settleT: 0,
+    strikeRoot: new THREE.Vector3(),
+    strikeYaw: 0,
+    strikeClock: 0,
+    cfg: {
+      poseLambda: opts.poseLambda ?? 9,
+      moveLambda: opts.moveLambda ?? 5.6,
+      rotLambda: opts.rotLambda ?? 8.5,
+      strikeTime: opts.strikeTime ?? 0.11,
+      holdTime: opts.holdTime ?? 0.05,
+      stanceWidth: opts.stanceWidth ?? 0.52,
+      bridgePalmTableLift: opts.bridgePalmTableLift ?? 0.012,
+      chinToCueHeight: opts.chinToCueHeight ?? 0.11,
+      cueArmElbowRise: opts.cueArmElbowRise ?? 0.43,
+      tableTopY: opts.tableTopY ?? 0.84
+    }
+  };
+
+  human.root.visible = false;
+  human.modelRoot.visible = false;
+  scene.add(human.root, human.modelRoot, human.fallback);
+
+  const loader = opts.loader;
+  const modelUrl = opts.modelUrl;
+  if (!loader || !modelUrl) {
+    human.loaded = true;
+    human.fallback.visible = true;
+    return human;
+  }
+
+  loader.setCrossOrigin?.('anonymous');
+  loader.load(
+    modelUrl,
+    (gltf) => {
+      const model = gltf?.scene || gltf?.scenes?.[0];
+      if (!model) {
+        human.loaded = true;
+        human.fallback.visible = true;
+        return;
+      }
+      normalizeHuman(model, opts);
+      model.traverse((obj) => {
+        if (!obj?.isMesh) return;
+        obj.castShadow = true;
+        obj.receiveShadow = true;
+        obj.frustumCulled = false;
+        const mats = Array.isArray(obj.material)
+          ? obj.material
+          : obj.material
+            ? [obj.material]
+            : [];
+        mats.forEach((m) => {
+          if (m?.map) {
+            m.map.colorSpace = THREE.SRGBColorSpace;
+            m.map.needsUpdate = true;
+          }
+          if (m) m.needsUpdate = true;
+        });
+      });
+      human.bones = buildAvatarBones(model);
+      human.leftFingers = collectFingerBones(human.bones.leftHand);
+      human.rightFingers = collectFingerBones(human.bones.rightHand);
+      [...Object.values(human.bones), ...human.leftFingers, ...human.rightFingers].forEach((bone) => {
+        if (bone) human.restQuats.set(bone, bone.quaternion.clone());
+      });
+      human.activeGlb = Boolean(
+        human.bones.hips &&
+          human.bones.spine &&
+          human.bones.head &&
+          human.bones.leftUpperArm &&
+          human.bones.leftLowerArm &&
+          human.bones.leftHand &&
+          human.bones.rightUpperArm &&
+          human.bones.rightLowerArm &&
+          human.bones.rightHand &&
+          human.bones.leftUpperLeg &&
+          human.bones.leftLowerLeg &&
+          human.bones.rightUpperLeg &&
+          human.bones.rightLowerLeg
+      );
+      human.model = model;
+      human.modelRoot.add(model);
+      human.modelRoot.visible = human.activeGlb;
+      human.fallback.visible = !human.activeGlb;
+      human.loaded = true;
+    },
+    undefined,
+    () => {
+      human.loaded = true;
+      human.activeGlb = false;
+      human.modelRoot.visible = false;
+      human.fallback.visible = true;
+    }
+  );
+
+  return human;
+}
+
+function setBoneWorldQuaternion(bone, q) {
+  if (!bone || !q) return;
+  const parentQ = new THREE.Quaternion();
+  bone.parent?.getWorldQuaternion(parentQ);
+  bone.quaternion.copy(parentQ.invert().multiply(q));
+  bone.updateMatrixWorld(true);
+}
+
+function firstBoneChild(bone) {
+  return bone?.children.find((child) => child?.isBone);
+}
+
+function rotateBoneToward(bone, target, strength = 1, fallbackDir = UP) {
+  if (!bone || strength <= 0) return;
+  const bonePos = bone.getWorldPosition(new THREE.Vector3());
+  const childPos =
+    firstBoneChild(bone)?.getWorldPosition(new THREE.Vector3()) ||
+    bonePos.clone().addScaledVector(fallbackDir.clone().normalize(), 0.25);
+  const current = childPos.sub(bonePos).normalize();
+  const desired = target.clone().sub(bonePos);
+  if (desired.lengthSq() < 1e-6 || current.lengthSq() < 1e-6) return;
+  const delta = new THREE.Quaternion().slerpQuaternions(
+    new THREE.Quaternion(),
+    new THREE.Quaternion().setFromUnitVectors(current, desired.normalize()),
+    clamp01(strength)
+  );
+  setBoneWorldQuaternion(
+    bone,
+    delta.multiply(bone.getWorldQuaternion(new THREE.Quaternion()))
+  );
+}
+
+function twistBone(bone, axis, amount) {
+  if (!bone || Math.abs(amount) < 1e-5) return;
+  setBoneWorldQuaternion(
+    bone,
+    new THREE.Quaternion()
+      .setFromAxisAngle(axis.clone().normalize(), amount)
+      .multiply(bone.getWorldQuaternion(new THREE.Quaternion()))
+  );
+}
+
+function aimTwoBone(upper, lower, elbow, hand, pole, upperStrength = 0.96, lowerStrength = 0.98) {
+  for (let i = 0; i < 2; i += 1) {
+    rotateBoneToward(upper, elbow, upperStrength, pole);
+    rotateBoneToward(lower, hand, lowerStrength, pole);
+    twistBone(upper, pole, 0.025 * upperStrength);
+  }
+}
+
+function setHandBasis(bone, side, up, forward, roll = 0, strength = 1) {
+  if (!bone || strength <= 0) return;
+  const q = makeBasisQuaternion(side, up, forward);
+  if (Math.abs(roll) > 1e-4) {
+    q.multiply(new THREE.Quaternion().setFromAxisAngle(forward.clone().normalize(), roll));
+  }
+  setBoneWorldQuaternion(
+    bone,
+    bone.getWorldQuaternion(new THREE.Quaternion()).slerp(q, clamp01(strength))
+  );
+}
+
+function poseFingers(fingers, mode, weight) {
+  const w = clamp01(weight);
+  fingers.forEach((finger, i) => {
+    const n = cleanName(finger.name);
+    const thumb = n.includes('thumb');
+    const index = n.includes('index');
+    const middle = n.includes('middle');
+    const ring = n.includes('ring');
+    const pinky = n.includes('pinky') || n.includes('little');
+    const base = !(n.includes('2') || n.includes('3') || n.includes('intermediate') || n.includes('distal'));
+    const tip = n.includes('3') || n.includes('distal');
+    if (mode === 'idle') {
+      finger.rotation.x += 0.02 * w;
+      finger.rotation.z += 0.01 * w * (i % 2 ? -1 : 1);
+      return;
+    }
+    if (mode === 'grip') {
+      if (thumb) {
+        finger.rotation.x += 0.22 * w;
+        finger.rotation.y += -0.42 * w;
+        finger.rotation.z += 0.22 * w;
+        return;
+      }
+      const curl = index
+        ? base
+          ? 0.42
+          : tip
+            ? 0.48
+            : 0.62
+        : middle
+          ? base
+            ? 0.54
+            : tip
+              ? 0.58
+              : 0.78
+          : ring
+            ? base
+              ? 0.48
+              : tip
+                ? 0.52
+                : 0.68
+            : pinky
+              ? base
+                ? 0.42
+                : tip
+                  ? 0.46
+                  : 0.6
+              : 0;
+      finger.rotation.x += curl * w;
+      finger.rotation.z += (index ? -0.03 : ring ? 0.04 : pinky ? 0.07 : 0) * w;
+      return;
+    }
+    if (thumb) {
+      finger.rotation.x += -0.04 * w;
+      finger.rotation.y += 0.62 * w;
+      finger.rotation.z += -0.58 * w;
+    } else if (index) {
+      finger.rotation.x += (base ? 0.12 : tip ? 0.22 : 0.28) * w;
+      finger.rotation.y += -0.26 * w;
+      finger.rotation.z += -0.2 * w;
+    } else if (middle) {
+      finger.rotation.x += (base ? 0.1 : tip ? 0.18 : 0.22) * w;
+      finger.rotation.y += -0.04 * w;
+      finger.rotation.z += -0.04 * w;
+    } else if (ring || pinky) {
+      finger.rotation.x +=
+        (base ? (ring ? 0.03 : 0.02) : tip ? (ring ? 0.1 : 0.08) : ring ? 0.12 : 0.1) * w;
+      finger.rotation.y += (ring ? 0.08 : 0.16) * w;
+      finger.rotation.z += (ring ? 0.16 : 0.28) * w;
+    }
+  });
+}
+
+function driveHuman(human, frame) {
+  if (!human.activeGlb || !human.model) {
+    human.fallback.visible = true;
+    human.fallback.position.copy(frame.rootWorld);
+    human.fallback.rotation.y = human.yaw;
+    human.fallback.rotation.x = -0.16 * frame.t;
+    human.fallback.position.y -= 0.035 * frame.t;
+    return;
+  }
+
+  human.fallback.visible = false;
+  human.modelRoot.visible = true;
+  human.modelRoot.position.copy(frame.rootWorld);
+  human.modelRoot.rotation.y = human.yaw;
+  human.modelRoot.position.y += 0.006 * frame.breath - 0.018 * frame.t;
+  human.modelRoot.updateMatrixWorld(true);
+  human.restQuats.forEach((q, bone) => bone.quaternion.copy(q));
+  human.modelRoot.updateMatrixWorld(true);
+
+  const b = human.bones;
+  const ik = easeInOut(clamp01(frame.t));
+  const idle = 1 - ik;
+  const cueDir = frame.cueTipWorld.clone().sub(frame.cueBackWorld).normalize();
+  const shotQ = makeBasisQuaternion(frame.side, UP, frame.forward);
+
+  if (frame.walkAmount * idle > 0.001) {
+    const s = Math.sin(human.walkT * 6.2);
+    const c = Math.cos(human.walkT * 6.2);
+    const w = frame.walkAmount * idle;
+    if (b.leftUpperLeg) b.leftUpperLeg.rotation.x += s * 0.34 * w;
+    if (b.rightUpperLeg) b.rightUpperLeg.rotation.x -= s * 0.34 * w;
+    if (b.leftLowerLeg) b.leftLowerLeg.rotation.x += Math.max(0, -s) * 0.28 * w;
+    if (b.rightLowerLeg) b.rightLowerLeg.rotation.x += Math.max(0, s) * 0.28 * w;
+    if (b.leftUpperArm) b.leftUpperArm.rotation.x -= s * 0.23 * w;
+    if (b.rightUpperArm) b.rightUpperArm.rotation.x += s * 0.23 * w;
+    if (b.spine) b.spine.rotation.z += c * 0.025 * w;
+    if (b.hips) b.hips.rotation.z -= c * 0.018 * w;
+  }
+
+  const rightGrip = frame.rightHandWorld
+    .clone()
+    .addScaledVector(cueDir, -0.028 * (0.25 + 0.75 * ik))
+    .addScaledVector(UP, 0.006 * ik);
+  const rightIdleElbow = rightGrip
+    .clone()
+    .addScaledVector(UP, 0.24 + 0.19 * ik)
+    .addScaledVector(frame.side, 0.09)
+    .addScaledVector(frame.forward, -0.03 * idle);
+  const rightElbow = frame.rightElbow.clone().lerp(rightIdleElbow, idle * 0.68);
+  const rightHold = 0.56 + 0.4 * ik;
+
+  aimTwoBone(
+    b.rightUpperArm,
+    b.rightLowerArm,
+    rightElbow,
+    rightGrip,
+    frame.side.clone().addScaledVector(UP, 0.22).normalize(),
+    rightHold,
+    rightHold
+  );
+  setHandBasis(
+    b.rightHand,
+    frame.side.clone().addScaledVector(UP, -0.08).normalize(),
+    UP.clone().multiplyScalar(0.76).addScaledVector(frame.side, 0.18).addScaledVector(frame.forward, -0.1).normalize(),
+    cueDir,
+    0.08 * idle + 0.2 * ik + 0.03 * frame.stroke,
+    0.78 + 0.18 * ik
+  );
+  poseFingers(human.rightFingers, 'grip', 0.58 + 0.28 * ik);
+
+  if (ik < 0.025) {
+    poseFingers(human.leftFingers, 'idle', 1);
+    return;
+  }
+
+  rotateBoneToward(b.hips, frame.torsoCenterWorld, (0.16 + 0.44 * ik) * ik, frame.forward);
+  twistBone(b.hips, frame.side, -0.075 * ik);
+  twistBone(b.hips, frame.forward, -0.04 * ik);
+  rotateBoneToward(b.spine, frame.chestCenterWorld, (0.38 + 0.36 * ik) * ik, frame.forward);
+  twistBone(b.spine, frame.side, -0.23 * ik);
+  twistBone(b.spine, frame.forward, -0.055 * ik);
+  rotateBoneToward(b.chest, frame.neckWorld, (0.52 + 0.3 * ik) * ik, frame.forward);
+  twistBone(b.chest, frame.side, -0.35 * ik);
+  twistBone(b.chest, frame.forward, -0.035 * ik);
+  rotateBoneToward(b.neck, frame.headCenterWorld, 0.66 * ik, frame.forward);
+  twistBone(b.neck, frame.side, -0.13 * ik);
+  setBoneWorldQuaternion(
+    b.head,
+    b.head
+      ? b.head
+          .getWorldQuaternion(new THREE.Quaternion())
+          .slerp(
+            shotQ
+              .clone()
+              .multiply(new THREE.Quaternion().setFromAxisAngle(frame.side, -0.12 * ik))
+              .multiply(new THREE.Quaternion().setFromAxisAngle(frame.forward, -0.025 * ik)),
+            0.74 * ik
+          )
+      : shotQ
+  );
+
+  const leftHand = frame.leftHandWorld
+    .clone()
+    .addScaledVector(frame.forward, 0.012 * ik)
+    .addScaledVector(frame.side, -0.006 * ik)
+    .addScaledVector(UP, -0.01 * ik);
+  const leftElbow = frame.leftElbow
+    .clone()
+    .addScaledVector(frame.forward, 0.02 * ik)
+    .addScaledVector(frame.side, -0.03 * ik)
+    .addScaledVector(UP, -0.005 * ik);
+  aimTwoBone(
+    b.leftUpperArm,
+    b.leftLowerArm,
+    leftElbow,
+    leftHand,
+    frame.side.clone().multiplyScalar(-1).addScaledVector(UP, 0.14).normalize(),
+    0.95 * ik,
+    0.99 * ik
+  );
+  twistBone(b.leftUpperArm, frame.forward, -0.16 * ik);
+  twistBone(b.leftLowerArm, frame.forward, 0.05 * ik);
+  setHandBasis(
+    b.leftHand,
+    frame.side.clone().multiplyScalar(-1).addScaledVector(frame.forward, -0.2).normalize(),
+    UP.clone().multiplyScalar(0.96).addScaledVector(frame.forward, -0.08).addScaledVector(frame.side, -0.04).normalize(),
+    cueDir,
+    -0.22 * ik,
+    0.98 * ik
+  );
+  poseFingers(human.leftFingers, 'bridge', ik);
+}
+
+export function chooseHumanEdgePosition(cueBallWorld, aimForward, opts = {}) {
+  const tableW = opts.tableW ?? 2.0;
+  const tableL = opts.tableL ?? 3.6;
+  const edgeMargin = opts.edgeMargin ?? 0.58;
+  const desiredShootDistance = opts.desiredShootDistance ?? 1.06;
+
+  const desired = cueBallWorld.clone().addScaledVector(aimForward, -desiredShootDistance);
+  const xEdge = tableW / 2 + edgeMargin;
+  const zEdge = tableL / 2 + edgeMargin;
+  const candidates = [
+    new THREE.Vector3(-xEdge, 0, clamp(desired.z, -zEdge, zEdge)),
+    new THREE.Vector3(xEdge, 0, clamp(desired.z, -zEdge, zEdge)),
+    new THREE.Vector3(clamp(desired.x, -xEdge, xEdge), 0, -zEdge),
+    new THREE.Vector3(clamp(desired.x, -xEdge, xEdge), 0, zEdge)
+  ];
+  return candidates.sort((a, b) => a.distanceToSquared(desired) - b.distanceToSquared(desired))[0].clone();
+}
+
+export function updateBilardoHumanPose(human, dt, frameData) {
+  if (!human) return;
+  const cfg = human.cfg;
+  const state = frameData.state || 'idle';
+
+  human.poseT = dampScalar(human.poseT, state === 'idle' ? 0 : 1, cfg.poseLambda, dt);
+  human.breathT += dt * (state === 'idle' ? 1.05 : 0.5);
+  human.settleT = dampScalar(human.settleT, state === 'dragging' ? 1 : 0, 5.5, dt);
+
+  if (state === 'striking') {
+    if (human.strikeClock === 0) {
+      human.strikeRoot.copy(
+        human.root.position.lengthSq() > 0.001 ? human.root.position : frameData.rootTarget
+      );
+      human.strikeYaw = human.yaw;
+    }
+    human.strikeClock += dt;
+  } else {
+    human.strikeClock = 0;
+  }
+
+  const rootGoal = state === 'striking' ? human.strikeRoot : frameData.rootTarget;
+  human.root.position.lerp(rootGoal, 1 - Math.exp(-(state === 'striking' ? 12 : cfg.moveLambda) * dt));
+  const moveAmountRaw = human.root.position.distanceTo(rootGoal);
+  human.walkT += dt * (2 + Math.min(7, moveAmountRaw * 10));
+  human.yaw = dampScalar(
+    human.yaw,
+    state === 'striking' ? human.strikeYaw : yawFromForward(frameData.aimForward),
+    cfg.rotLambda,
+    dt
+  );
+
+  const t = easeInOut(human.poseT);
+  const idle = 1 - t;
+  const breath = Math.sin(human.breathT * Math.PI * 2) * (0.006 + idle * 0.004);
+  const walk = Math.sin(human.walkT * 6.2) * Math.min(1, moveAmountRaw * 12);
+  const walkAmount = clamp01(moveAmountRaw * 18) * idle;
+  const power = frameData.power ?? 0;
+  const stroke =
+    state === 'dragging'
+      ? Math.sin(performance.now() * 0.011) * (0.25 + power * 0.75)
+      : 0;
+  const follow =
+    state === 'striking'
+      ? Math.sin(clamp01(human.strikeClock / (cfg.strikeTime + cfg.holdTime)) * Math.PI)
+      : 0;
+
+  const forward = new THREE.Vector3(0, 0, -1).applyAxisAngle(Y_AXIS, human.yaw).normalize();
+  const side = new THREE.Vector3(forward.z, 0, -forward.x).normalize();
+  const local = (v) => v.clone().applyAxisAngle(Y_AXIS, human.yaw).add(human.root.position);
+  const powerLean = power * t;
+
+  const rootWorld = human.root.position.clone().addScaledVector(forward, 0.018 * powerLean + 0.026 * follow);
+  const torso = local(new THREE.Vector3(0, lerp(1.3, 1.12, t) + breath, lerp(0.02, -0.16, t) - 0.014 * powerLean));
+  const chest = local(new THREE.Vector3(0, lerp(1.52, 1.22, t) + breath, lerp(0.02, -0.42, t) - 0.024 * powerLean));
+  const neck = local(new THREE.Vector3(0, lerp(1.68, 1.25, t) + breath, lerp(0.02, -0.61, t) - 0.028 * powerLean));
+  const head = local(new THREE.Vector3(0, lerp(1.84, 1.34, t) + breath - cfg.chinToCueHeight * 0.16 * t, lerp(0.04, -0.72, t) - 0.028 * powerLean));
+  const leftShoulder = local(new THREE.Vector3(-0.23, lerp(1.58, 1.36, t) + breath, lerp(0, -0.46, t) - 0.018 * human.settleT));
+  const leftHip = local(new THREE.Vector3(-0.13, 0.92, 0.02));
+  const rightHip = local(new THREE.Vector3(0.13, 0.92, 0.02));
+  const leftFoot = local(
+    new THREE.Vector3(-0.13, 0.035, 0.03 + walk * 0.03).lerp(
+      new THREE.Vector3(-cfg.stanceWidth * 0.42, 0.035, -0.36),
+      t
+    )
+  );
+  const rightFoot = local(
+    new THREE.Vector3(0.13, 0.035, -0.03 - walk * 0.03).lerp(
+      new THREE.Vector3(cfg.stanceWidth * 0.5, 0.035, 0.36),
+      t
+    )
+  );
+
+  const leftHand = frameData.idleLeft
+    .clone()
+    .lerp(
+      frameData.bridgeTarget
+        .clone()
+        .addScaledVector(forward, -0.026 * t)
+        .addScaledVector(side, -0.018 * t)
+        .setY(cfg.tableTopY + cfg.bridgePalmTableLift)
+        .addScaledVector(UP, -0.006 * human.settleT),
+      t
+    );
+  const rightHand = frameData.idleRight
+    .clone()
+    .lerp(
+      frameData.gripTarget
+        .clone()
+        .addScaledVector(forward, 0.032 * stroke * t + 0.052 * follow * power)
+        .addScaledVector(UP, -0.007 * follow),
+      t
+    );
+
+  const leftElbow = leftShoulder
+    .clone()
+    .lerp(leftHand, 0.57)
+    .addScaledVector(UP, 0.02 * t)
+    .addScaledVector(side, -0.03 * t)
+    .addScaledVector(forward, 0.035 * t);
+  const rightElbow = rightHand
+    .clone()
+    .addScaledVector(UP, lerp(0.18, cfg.cueArmElbowRise, t))
+    .addScaledVector(side, lerp(0.03, 0.07, t))
+    .addScaledVector(forward, lerp(-0.03, 0, t));
+  const leftKnee = leftHip
+    .clone()
+    .lerp(leftFoot, 0.53)
+    .addScaledVector(UP, lerp(0.18, 0.105, t))
+    .addScaledVector(forward, 0.052 * t)
+    .addScaledVector(side, -0.016 * t);
+  const rightKnee = rightHip
+    .clone()
+    .lerp(rightFoot, 0.52)
+    .addScaledVector(UP, lerp(0.18, 0.08, t))
+    .addScaledVector(forward, -0.032 * t)
+    .addScaledVector(side, 0.018 * t);
+
+  human.root.visible = true;
+  driveHuman(human, {
+    t,
+    breath,
+    stroke,
+    follow,
+    walkAmount,
+    forward,
+    side,
+    up: UP,
+    rootWorld,
+    torsoCenterWorld: torso,
+    chestCenterWorld: chest,
+    neckWorld: neck,
+    headCenterWorld: head,
+    leftElbow,
+    rightElbow,
+    leftHandWorld: leftHand,
+    rightHandWorld: rightHand,
+    leftKnee,
+    rightKnee,
+    leftFootWorld: leftFoot,
+    rightFootWorld: rightFoot,
+    cueBackWorld: frameData.cueBack,
+    cueTipWorld: frameData.cueTip
+  });
+}


### PR DESCRIPTION
### Motivation
- Provide a reusable human avatar rig to visually represent the player during aim/drag/strike in Snooker Royal and improve immersion and feedback. 
- Share bilardo shot timing and human rig logic across games by moving the implementation into a shared module. 

### Description
- Added a new shared module `webapp/src/pages/Games/shared/bilardoHumanRig.js` that implements a fallback mesh, GLTF loading, bone mapping, IK-like posing, finger posing, and exported helpers `createBilardoHumanRig`, `chooseHumanEdgePosition`, and `updateBilardoHumanPose`.
- Integrated the new rig into `SnookerRoyal.jsx`: imported `createBilardoHumanRig`, `chooseHumanEdgePosition`, `updateBilardoHumanPose`, `BILARDO_STRIKE_TIME_MS`, and a shared GLTF URL constant, then created and configured a `humanActor` instance when initializing the cue and table visuals.
- Wired pose updates into existing input/animation flows by calling `updateSnookerHumanFromAim` during dragging/preview/strike actions and by computing a root target with `chooseHumanEdgePosition` each frame, then invoking `updateBilardoHumanPose` with assembled pose context.
- Ensured model normalization and SRGB handling for loaded textures and provided a visible fallback human when GLTF loading or bone mapping fails.

### Testing
- Ran the project test suite with `npm test` locally against the modified files and observed the test run completed successfully.
- Launched a local development build and exercised aim/drag/strike flows to verify the human rig loads (fallback on failure), follows the cue position, and animates during dragging and striking.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eed47c1b28832984a240e90dfb4896)