### PR TITLE
Fix Domino Royal black screen and align seated humans with Ludo layout

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -979,12 +979,15 @@ const CHAIR_GAP = 0.152 * MODEL_SCALE; // mirrors Snake & Ladder AI chair gap
 const CHAIR_OUTWARD_OFFSET = 0;
 const CHAIR_RADIUS =
   TABLE_RADIUS + SEAT_DEPTH * 0.5 + CHAIR_GAP + CHAIR_OUTWARD_OFFSET;
+const CHAIR_GLOBAL_PUSHBACK = 0.68 * MODEL_SCALE;
+const SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK = 0.82 * MODEL_SCALE;
 const CHAIR_VISUAL_SCALE = 1.3;
 const SEATED_HUMAN_BASE_HEIGHT = 1.74;
 const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.42;
 const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 4.55;
-const SEATED_HUMAN_SEAT_Y_OFFSET = -5.85 * MODEL_SCALE * STOOL_SCALE;
+const SEATED_HUMAN_SEAT_Y_OFFSET = -6.45 * MODEL_SCALE * STOOL_SCALE;
 const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.42;
+const SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET = -SEAT_DEPTH * 0.2;
 const SEATED_HUMAN_FACING_Y = 0;
 const SEATED_HUMAN_FOOT_GROUND_CLEARANCE = -1.55 * MODEL_SCALE * STOOL_SCALE;
 const SEATED_HELPER_FORWARD_DICE_PICKUP = 0.092 * MODEL_SCALE;
@@ -1017,10 +1020,10 @@ const CHAIR_SEAT_ANGLES = Object.freeze([
   THREE.MathUtils.degToRad(180)
 ]);
 const CHAIR_SEAT_RADII = Object.freeze([
-  CHAIR_RADIUS,
-  CHAIR_RADIUS,
-  CHAIR_RADIUS,
-  CHAIR_RADIUS
+  CHAIR_RADIUS + CHAIR_GLOBAL_PUSHBACK + SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK,
+  CHAIR_RADIUS + CHAIR_GLOBAL_PUSHBACK,
+  CHAIR_RADIUS + CHAIR_GLOBAL_PUSHBACK,
+  CHAIR_RADIUS + CHAIR_GLOBAL_PUSHBACK
 ]);
 const DOMINO_HUMAN_CHARACTER_OPTIONS = Object.freeze([
   {
@@ -1054,31 +1057,6 @@ const DOMINO_HUMAN_CHARACTER_OPTIONS = Object.freeze([
       'https://api.readyplayer.me/v1/avatars/67e1b51ae11c93725e4395c9.glb',
       'https://avatars.readyplayer.me/67e1b51ae11c93725e4395c9.glb'
     ]
-  },
-  {
-    id: 'webgl-vietnam-human',
-    label: 'Vietnam Human',
-    modelUrls: ['https://raw.githubusercontent.com/hmthanh/3d-human-model/main/TranThiNgocTham.glb']
-  },
-  {
-    id: 'webgl-human-body-a',
-    label: 'Human Body A',
-    modelUrls: ['https://raw.githubusercontent.com/msorkhpar/3d-human-model-vite/main/body.glb']
-  },
-  {
-    id: 'webgl-human-body-b',
-    label: 'Human Body B',
-    modelUrls: ['https://raw.githubusercontent.com/bddicken/humanbody/main/body.glb']
-  },
-  {
-    id: 'webgl-ai-teacher',
-    label: 'AI Teacher',
-    modelUrls: ['https://raw.githubusercontent.com/Surbh77/AI-teacher/main/avatar.glb']
-  },
-  {
-    id: 'webgl-ai-teacher-1',
-    label: 'AI Teacher 1',
-    modelUrls: ['https://raw.githubusercontent.com/Surbh77/AI-teacher/main/avatar1.glb']
   }
 ]);
 const ARENA_WALL_HEIGHT = 3.6 * 1.3;
@@ -8152,7 +8130,10 @@ async function attachSeatedHumanActors(token) {
       const actorScale =
         template.userData?.seatedHumanScale ?? computeSeatedHumanScale(template);
       actor.scale.setScalar(actorScale);
-      actor.position.set(0, SEATED_HUMAN_SEAT_Y_OFFSET, SEATED_HUMAN_SEAT_Z_OFFSET);
+      const seatZOffset =
+        SEATED_HUMAN_SEAT_Z_OFFSET +
+        (index === HUMAN_SEAT_INDEX ? SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET : 0);
+      actor.position.set(0, SEATED_HUMAN_SEAT_Y_OFFSET, seatZOffset);
       actor.rotation.set(0, SEATED_HUMAN_FACING_Y, 0);
       const rig = saveBoneRig(actor);
       applySeatedHumanPose(rig);

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -90,6 +90,7 @@ export default function DominoRoyalArena() {
           left: auto !important;
           top: calc(8.15rem + env(safe-area-inset-top, 0px)) !important;
           margin: 0 !important;
+          z-index: 60 !important;
         }
         #configButton {
           top: calc(4.55rem + env(safe-area-inset-top, 0px)) !important;
@@ -99,6 +100,7 @@ export default function DominoRoyalArena() {
           display: flex !important;
           align-items: center;
           gap: 0.5rem;
+          z-index: 60 !important;
         }
         #configButton span:first-child { font-size: 1.05rem; line-height: 1; }
         #configButton span:last-child { font-size: 0.72rem; letter-spacing: 0.24em; text-transform: uppercase; }
@@ -107,6 +109,7 @@ export default function DominoRoyalArena() {
           right: calc(0.38rem + env(safe-area-inset-right, 0px)) !important;
           left: auto !important;
           bottom: auto !important;
+          z-index: 60 !important;
         }
         #railControls {
           left: calc(0.75rem + env(safe-area-inset-left, 0px)) !important;
@@ -121,6 +124,7 @@ export default function DominoRoyalArena() {
           box-shadow: none !important;
           padding: 0 !important;
           backdrop-filter: none !important;
+          z-index: 55 !important;
         }
         #railControls button {
           min-width: clamp(5.5rem, 26vw, 7.2rem) !important;
@@ -135,6 +139,7 @@ export default function DominoRoyalArena() {
         #quickActions .quick-action {
           position: fixed !important;
           bottom: calc(env(safe-area-inset-bottom, 0px) + clamp(1.2rem, 7vh, 2.2rem) + clamp(2.8rem, 8vh, 3.4rem)) !important;
+          z-index: 60 !important;
         }
         #quickActions .quick-action[data-action="gift"] {
           right: calc(0.75rem + env(safe-area-inset-right, 0px)) !important;


### PR DESCRIPTION
### Motivation
- Users saw a black/interactable Domino Royal game screen on portrait devices when seated humans or UI controls overlapped or caused camera/mesh occlusion. This change matches Domino seating to the Ludo Battle Royal calibration to avoid occlusion and unstable external GLB variants. 
- Ensure local-player (bottom) avatar sits visibly and actions remain clickable by adjusting chair/human offsets and control stacking.

### Description
- Added `CHAIR_GLOBAL_PUSHBACK` and `SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK` and applied them to `CHAIR_SEAT_RADII` so all chairs (and the bottom seat extra) are pushed away from the table to reduce camera occlusion in portrait view. (`webapp/public/domino-royal-game.js`).
- Lowered seated-human vertical offset to match Ludo (`SEATED_HUMAN_SEAT_Y_OFFSET = -6.45 * MODEL_SCALE * STOOL_SCALE`) and added `SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET` to nudge the local player's model rearwards; applied when positioning cloned human actors so the bottom player sits correctly. (`webapp/public/domino-royal-game.js`).
- Restrained `DOMINO_HUMAN_CHARACTER_OPTIONS` to the stable Ready Player Me entries used by Ludo to avoid loading unpredictable external GLB variants that can trigger rendering issues. (`webapp/public/domino-royal-game.js`).
- Raised z-index for in-game controls and quick actions inside the React arena wrapper so `#viewToggle`, `#configButton`, `#muteButton`, `#railControls`, and `#quickActions` stay above the WebGL canvas and remain interactable. (`webapp/src/pages/Games/DominoRoyalArena.jsx`).

### Testing
- Built the frontend with `npm --prefix webapp run build` and the production build completed successfully (Vite build completed).  
- Attempted an automated Playwright screenshot/test run to capture the UI, but the environment lacks downloaded Playwright browser binaries so the headless Chromium launch failed (Playwright requires `npx playwright install`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eee562d9308329957836ca5cffd97d)