### PR TITLE
Snooker Royal: double human scale and align cue pose with Bilardo Shqip behavior

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -20771,8 +20771,18 @@ const powerRef = useRef(hud.power);
         0.9,
         14
       );
-      humanActor.modelRoot.scale.setScalar(snookerHumanScaleFactor);
-      humanActor.fallback.scale.setScalar(snookerHumanScaleFactor);
+      const snookerHumanScaleBoost = 2;
+      const snookerFinalHumanScale = snookerHumanScaleFactor * snookerHumanScaleBoost;
+      humanActor.modelRoot.scale.setScalar(snookerFinalHumanScale);
+      humanActor.fallback.scale.setScalar(snookerFinalHumanScale);
+
+      const bilardoSharedPose = {
+        bridgeHandBackFromBall: 0.245,
+        bridgeHandSide: -0.008,
+        gripRatio: 0.76,
+        idleRightOffset: new THREE.Vector3(0.24, 1.12, 0.02),
+        idleLeftOffset: new THREE.Vector3(-0.18, 1.08, 0.03)
+      };
 
       const humanPoseContext = {
         aimDir: new THREE.Vector2(0, 1),
@@ -25302,20 +25312,28 @@ const powerRef = useRef(hud.power);
           const aimSide = new THREE.Vector3(aimForward.z, 0, -aimForward.x).normalize();
           const bridgeTarget = cueBallWorld
             .clone()
-            .addScaledVector(aimForward, -Math.max(BALL_R * 5.6, cueLen * 0.16))
-            .addScaledVector(aimSide, -BALL_R * 0.18)
+            .addScaledVector(aimForward, -bilardoSharedPose.bridgeHandBackFromBall)
+            .addScaledVector(aimSide, bilardoSharedPose.bridgeHandSide)
             .setY(BALL_CENTER_Y - BALL_R + BALL_R * 0.24);
           const gripTarget = humanPoseContext.cueTip
             .clone()
-            .lerp(humanPoseContext.cueBack.clone(), 0.76);
+            .lerp(humanPoseContext.cueBack.clone(), bilardoSharedPose.gripRatio);
           const standingYaw = Math.atan2(-aimForward.x, -aimForward.z);
           const upAxis = new THREE.Vector3(0, 1, 0);
           const idleRight = rootTarget
             .clone()
-            .add(new THREE.Vector3(0.24, 1.12, 0.02).applyAxisAngle(upAxis, standingYaw));
+            .add(
+              bilardoSharedPose.idleRightOffset
+                .clone()
+                .applyAxisAngle(upAxis, standingYaw)
+            );
           const idleLeft = rootTarget
             .clone()
-            .add(new THREE.Vector3(-0.18, 1.08, 0.03).applyAxisAngle(upAxis, standingYaw));
+            .add(
+              bilardoSharedPose.idleLeftOffset
+                .clone()
+                .applyAxisAngle(upAxis, standingYaw)
+            );
           updateBilardoHumanPose(humanActor, deltaSeconds, {
             state: humanPoseContext.state,
             rootTarget,


### PR DESCRIPTION
### Motivation
- Players reported the Snooker Royal human avatar was too small and held the cue differently from Bilardo Shqip, causing inconsistent shooting visuals; the change aims to match size and right-hand cue handling to the Bilardo motion model.
- Keep one source of truth for character animation by reusing the existing `bilardoHumanRig` pipeline and feeding it Bilardo-consistent pose targets.

### Description
- Increase the effective Snooker human actor scale by applying a `snookerHumanScaleBoost = 2` on top of the existing table-relative normalization so the avatar appears larger in-scene via `humanActor.modelRoot.scale` and `humanActor.fallback.scale` in `webapp/src/pages/Games/SnookerRoyal.jsx`.
- Introduce a `bilardoSharedPose` set of tuning constants (`bridgeHandBackFromBall`, `bridgeHandSide`, `gripRatio`, `idleRightOffset`, `idleLeftOffset`) and use them to compute `bridgeTarget`, `gripTarget`, and idle hand offsets before calling `updateBilardoHumanPose` so right-hand grip and shooting posture mirror Bilardo Shqip behavior.
- Preserve the existing shared rig and animation functions (`createBilardoHumanRig`, `updateBilardoHumanPose`); only the pose input targets and scale are adjusted so motion/animation logic remains centralized and unchanged.

### Testing
- Ran the targeted Jest suite: `npm test -- --runInBand test/snookerRoyalInventoryRoutes.test.js`, which passed (1 test, 1 suite).
- No other automated tests were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eeec2523648329b515438f11de223e)