### PR TITLE
Domino Royal: seat all chairs with larger Ludo-aligned human avatars

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -984,8 +984,8 @@ const SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK = 0.82 * MODEL_SCALE;
 const CHAIR_VISUAL_SCALE = 1.3;
 const SEATED_HUMAN_BASE_HEIGHT = 1.74;
 const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.42;
-const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 4.55;
-const SEATED_HUMAN_SEAT_Y_OFFSET = -6.45 * MODEL_SCALE * STOOL_SCALE;
+const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 4.9;
+const SEATED_HUMAN_SEAT_Y_OFFSET = -6.2 * MODEL_SCALE * STOOL_SCALE;
 const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.42;
 const SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET = -SEAT_DEPTH * 0.2;
 const SEATED_HUMAN_FACING_Y = 0;
@@ -8129,18 +8129,23 @@ function placeChairsWithOption(option, chairData, token) {
 
 async function attachSeatedHumanActors(token) {
   try {
+    const sharedHumanIndex = Math.max(
+      0,
+      Math.min(
+        DOMINO_HUMAN_CHARACTER_OPTIONS.length - 1,
+        Number.isFinite(Number(appearance.humanCharacter))
+          ? Number(appearance.humanCharacter)
+          : 0
+      )
+    );
+    const sharedHumanOption =
+      DOMINO_HUMAN_CHARACTER_OPTIONS[sharedHumanIndex] ??
+      DOMINO_HUMAN_CHARACTER_OPTIONS[0];
     for (let index = 0; index < chairs.length; index += 1) {
       if (token !== chairBuildToken) return;
       const chairRoot = chairs[index];
       if (!chairRoot) continue;
-      const humanIndex =
-        index === HUMAN_SEAT_INDEX
-          ? appearance.humanCharacter
-          : (index - 1 + DOMINO_HUMAN_CHARACTER_OPTIONS.length) %
-            DOMINO_HUMAN_CHARACTER_OPTIONS.length;
-      const option =
-        DOMINO_HUMAN_CHARACTER_OPTIONS[humanIndex] ??
-        DOMINO_HUMAN_CHARACTER_OPTIONS[0];
+      const option = sharedHumanOption;
       let template;
       try {
         // eslint-disable-next-line no-await-in-loop

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-04-27-domino-human-seating-v37';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-04-27-domino-human-seating-v38';
 
 export default function DominoRoyalArena() {
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- Make the Domino Battle Royal seating match the Ludo Battle Royal presentation by ensuring every chair has a seated human character and the avatar appears slightly larger and better aligned to the seat so original GLTF textures/readability are preserved.

### Description
- Increase seated avatar sizing and adjust vertical placement by changing `SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER` (4.55 → 4.9) and `SEATED_HUMAN_SEAT_Y_OFFSET` (-6.45 → -6.2) in `webapp/public/domino-royal-game.js` so the model sits deeper and reads larger on the chair. 
- Populate every chair with the same selected human character by computing a clamped `sharedHumanOption` from `appearance.humanCharacter` and using it for all seats in `attachSeatedHumanActors` instead of per-seat option rotation. 
- Bump the Domino runtime script version in `webapp/src/pages/Games/DominoRoyalArena.jsx` (script version → `2026-04-27-domino-human-seating-v38`) so clients load the updated game script.
- Build artifacts updated by the production build (updated `webapp/public/*` build outputs and `webapp/src/config/buildInfo.js`).

### Testing
- Ran the production build with `npm --prefix webapp run -s build`, which completed successfully.  No other automated tests were added or executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eeed82ba1483298ac217f1de8db358)