### PR TITLE
Tune dice contact offsets and firearm right-hand attach poses

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -289,9 +289,49 @@ const FIREARM_MAGAZINE_SHOTS = Object.freeze({
 });
 const FIREARM_HAND_ATTACH_TUNING = Object.freeze({
   default: {
-    position: [0.02, -0.014, 0.082],
-    rotation: [-1.46, -0.06, -1.52],
+    position: [0.017, -0.01, 0.078],
+    rotation: [-1.5, -0.02, -1.56],
     muzzleOffset: [0.0, 0.012, 0.2]
+  },
+  glockSidearmAttack: {
+    position: [0.016, -0.009, 0.074],
+    rotation: [-1.52, -0.03, -1.58],
+    muzzleOffset: [0, 0.012, 0.19]
+  },
+  pistolSidearmAttack: {
+    position: [0.017, -0.01, 0.076],
+    rotation: [-1.51, -0.03, -1.58],
+    muzzleOffset: [0, 0.012, 0.195]
+  },
+  uziSprayAttack: {
+    position: [0.02, -0.012, 0.088],
+    rotation: [-1.47, -0.04, -1.56],
+    muzzleOffset: [0, 0.014, 0.215]
+  },
+  smgBurstAttack: {
+    position: [0.021, -0.012, 0.09],
+    rotation: [-1.46, -0.04, -1.56],
+    muzzleOffset: [0, 0.014, 0.22]
+  },
+  assaultRifleAttack: {
+    position: [0.023, -0.013, 0.098],
+    rotation: [-1.43, -0.04, -1.55],
+    muzzleOffset: [0, 0.014, 0.235]
+  },
+  ak47VolleyAttack: {
+    position: [0.024, -0.013, 0.102],
+    rotation: [-1.42, -0.04, -1.55],
+    muzzleOffset: [0, 0.014, 0.245]
+  },
+  compactCarbineAttack: {
+    position: [0.022, -0.012, 0.095],
+    rotation: [-1.44, -0.04, -1.55],
+    muzzleOffset: [0, 0.014, 0.228]
+  },
+  marksmanDmrAttack: {
+    position: [0.024, -0.013, 0.108],
+    rotation: [-1.4, -0.04, -1.56],
+    muzzleOffset: [0, 0.015, 0.25]
   },
   shotgunBlastAttack: {
     position: [0.024, -0.016, 0.102],
@@ -2318,13 +2358,13 @@ const SEATED_HUMAN_DOWNWARD_CONTACT_MODE_SET = new Set([
   'carryToken',
   'placeToken'
 ]);
-const SEATED_HELPER_FORWARD_DICE_PICKUP = 0.064 * MODEL_SCALE;
+const SEATED_HELPER_FORWARD_DICE_PICKUP = 0.059 * MODEL_SCALE;
 const SEATED_HELPER_FORWARD_DICE_RELEASE = 0.148 * MODEL_SCALE;
-const SEATED_HELPER_RIGHT_DICE = -0.006 * MODEL_SCALE;
-const SEATED_HELPER_UP_DICE_PICKUP = -0.024 * MODEL_SCALE;
+const SEATED_HELPER_RIGHT_DICE = -0.012 * MODEL_SCALE;
+const SEATED_HELPER_UP_DICE_PICKUP = -0.018 * MODEL_SCALE;
 const SEATED_HELPER_UP_DICE_RELEASE = 0.01 * MODEL_SCALE;
-const SEATED_HELPER_FORWARD_DICE_HOLD = 0.072 * MODEL_SCALE;
-const SEATED_HELPER_UP_DICE_HOLD = -0.032 * MODEL_SCALE;
+const SEATED_HELPER_FORWARD_DICE_HOLD = 0.067 * MODEL_SCALE;
+const SEATED_HELPER_UP_DICE_HOLD = -0.026 * MODEL_SCALE;
 const SEATED_DICE_HOLD_VERTICAL_NUDGE = 0.12;
 const SEATED_DICE_THROW_VERTICAL_NUDGE = 0.055;
 const SEATED_HELPER_FORWARD_TOKEN_PICKUP = 0.076 * MODEL_SCALE;


### PR DESCRIPTION
### Motivation
- Fix visual gap so the seated right hand properly contacts and holds the dice during pickup/hold phases for portrait gameplay.
- Improve how the human character holds firearms so different weapon models align the barrel and grip naturally with the right hand.
- Provide per-weapon tuning to account for model variance (sidearms, SMGs, rifles) instead of one-size defaults.

### Description
- Updated `FIREARM_HAND_ATTACH_TUNING.default` position/rotation/muzzle values in `webapp/src/pages/Games/LudoBattleRoyal.jsx` to a tighter one-hand grip pose.
- Added per-weapon attach tuning entries for `glockSidearmAttack`, `pistolSidearmAttack`, `uziSprayAttack`, `smgBurstAttack`, `assaultRifleAttack`, `ak47VolleyAttack`, `compactCarbineAttack`, and `marksmanDmrAttack` in the same `FIREARM_HAND_ATTACH_TUNING` table so models align better by class while keeping existing `shotgunBlastAttack` and `sniperShotAttack` values.
- Tightened seated dice helper offsets by changing `SEATED_HELPER_FORWARD_DICE_PICKUP`, `SEATED_HELPER_RIGHT_DICE`, `SEATED_HELPER_UP_DICE_PICKUP`, `SEATED_HELPER_FORWARD_DICE_HOLD`, and `SEATED_HELPER_UP_DICE_HOLD` (constants in the same file) to reduce floating gaps and improve visual contact.

### Testing
- Ran the production build with `cd webapp && npm run -s build` which completed successfully and emitted non-blocking Vite warnings about duplicate package key and large chunk sizes.
- No automated unit test changes were executed as part of this PR; only the app build was validated and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eef133eb348329bad17e32cf01438f)