### PR TITLE
Tune Snooker Royal human pose realism and movement

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -20756,9 +20756,15 @@ const powerRef = useRef(hud.power);
         loader: humanLoader,
         modelUrl: BILARDO_SHARED_HUMAN_GLTF_URL,
         tableTopY: BALL_CENTER_Y - BALL_R,
-        humanScale: 1.18,
+        humanScale: 1.24,
         humanVisualYawFix: Math.PI,
-        strikeTime: BILARDO_STRIKE_TIME_MS / 1000
+        strikeTime: BILARDO_STRIKE_TIME_MS / 1000,
+        moveLambda: 3.15,
+        rotLambda: 7.35,
+        stanceWidth: 0.56,
+        bridgePalmTableLift: 0.009,
+        chinToCueHeight: 0.122,
+        cueArmElbowRise: 0.47
       });
       humanActor.root.visible = true;
       const snookerTableTopFromGround = Math.max(
@@ -20771,14 +20777,14 @@ const powerRef = useRef(hud.power);
         0.9,
         14
       );
-      const snookerHumanScaleBoost = 2;
+      const snookerHumanScaleBoost = 2.18;
       const snookerFinalHumanScale = snookerHumanScaleFactor * snookerHumanScaleBoost;
       humanActor.modelRoot.scale.setScalar(snookerFinalHumanScale);
       humanActor.fallback.scale.setScalar(snookerFinalHumanScale);
 
       const bilardoSharedPose = {
-        bridgeHandBackFromBall: 0.245,
-        bridgeHandSide: -0.008,
+        bridgeHandBackFromBall: 0.218,
+        bridgeHandSide: -0.014,
         gripRatio: 0.76,
         idleRightOffset: new THREE.Vector3(0.24, 1.12, 0.02),
         idleLeftOffset: new THREE.Vector3(-0.18, 1.08, 0.03)
@@ -25306,7 +25312,7 @@ const powerRef = useRef(hud.power);
             tableW: PLAY_W,
             tableL: PLAY_H,
             edgeMargin: Math.max(BALL_R * 8.4, SIDE_RAIL_INNER_THICKNESS * 2.2),
-            desiredShootDistance: Math.max(cueLen * 0.72, BALL_R * 22)
+            desiredShootDistance: Math.max(cueLen * 0.64, BALL_R * 18.8)
           });
           rootTarget.y = FLOOR_Y + Math.max(BALL_R * 0.08, 0.03);
           const aimSide = new THREE.Vector3(aimForward.z, 0, -aimForward.x).normalize();


### PR DESCRIPTION
### Motivation
- Make the Snooker Royal seated human avatar read larger on-screen and adopt a more realistic snooker stance that matches the Bilardo Shqip cue-holding posture and reference photos.
- Slow lateral/root repositioning so edge-placement and rail movement feel heavier and more natural for a human player.
- Move the body/bridge/grip slightly closer to the cue line so head/torso align better with the table during aiming.

### Description
- Increased runtime human scale by updating `humanScale` and boosting `snookerHumanScaleBoost` so the actor appears larger in-frame (`humanScale: 1.24`, `snookerHumanScaleBoost: 2.18`).
- Tuned IK/pose config passed to `createBilardoHumanRig` to slow and refine motion with new values: `moveLambda: 3.15`, `rotLambda: 7.35`, `stanceWidth: 0.56`, `bridgePalmTableLift: 0.009`, `chinToCueHeight: 0.122`, and `cueArmElbowRise: 0.47` (file edited: `webapp/src/pages/Games/SnookerRoyal.jsx`).
- Adjusted bridge/grip constants in `bilardoSharedPose` for a more authentic bridge (`bridgeHandBackFromBall: 0.218`, `bridgeHandSide: -0.014`).
- Reduced the `desiredShootDistance` used to place the human edge target so the torso/head come closer to the table while aiming (`desiredShootDistance: Math.max(cueLen * 0.64, BALL_R * 18.8)`).

### Testing
- Ran `npm run build` and the TypeScript build completed successfully.
- Ran `npx eslint webapp/src/pages/Games/SnookerRoyal.jsx` and `npx eslint --no-ignore webapp/src/pages/Games/SnookerRoyal.jsx`, which produced a repository ignore warning for the file path but no blocking errors in this environment.
- Visual validation is recommended in-editor/playtest to confirm pose, scale, and timing changes under gameplay conditions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eef27f07a48329b6d0103fc1a51b55)