### PR TITLE
Align Pool Royal human stance and cue pullback with slider-driven shot logic

### DIFF
--- a/Assets/Scripts/Gameplay/CueController.cs
+++ b/Assets/Scripts/Gameplay/CueController.cs
@@ -64,6 +64,7 @@ namespace Aiming
         Vector3 _cueAnchorPosition;
         float _currentCueDepth;
         float _chargedCueDepth;
+        float _latchedPullDistance;
         float _power;
         float _latchedShotPower;
         Vector2 _liveSpinInput;
@@ -79,6 +80,19 @@ namespace Aiming
 
         public ShotState CurrentShotState => _shotState;
         public Vector3 CurrentAimDirection => _aimDirection;
+        public float CurrentPullNormalized
+        {
+            get
+            {
+                if (pullRange <= 0.0001f)
+                {
+                    return 0f;
+                }
+
+                float pulled = Mathf.Max(0f, _currentCueDepth - idleTipGap);
+                return Mathf.Clamp01(pulled / pullRange);
+            }
+        }
 
         void Awake()
         {
@@ -119,7 +133,7 @@ namespace Aiming
 
             if (_shotState == ShotState.Dragging)
             {
-                float pull = pullRange * EaseOutCubic(_power);
+                float pull = PullDistanceFromPower(_power);
                 _chargedCueDepth = idleTipGap + pull;
                 _currentCueDepth = _chargedCueDepth;
                 UpdateCuePose();
@@ -138,7 +152,8 @@ namespace Aiming
             _shotState = ShotState.Dragging;
             _power = Mathf.Max(_power, RecoverPowerFromCueDepth(_currentCueDepth));
             _latchedShotPower = 0f;
-            _chargedCueDepth = idleTipGap + (pullRange * EaseOutCubic(_power));
+            _latchedPullDistance = 0f;
+            _chargedCueDepth = idleTipGap + PullDistanceFromPower(_power);
             _currentCueDepth = _chargedCueDepth;
             _dynamicLift = 0f;
             _dynamicWobble = 0f;
@@ -162,6 +177,7 @@ namespace Aiming
             _shotState = ShotState.Idle;
             _power = 0f;
             _latchedShotPower = 0f;
+            _latchedPullDistance = 0f;
             _latchedShotSpin = _liveSpinInput;
             _chargedCueDepth = idleTipGap;
             _currentCueDepth = idleTipGap;
@@ -178,8 +194,9 @@ namespace Aiming
                 return;
             }
 
+            _latchedPullDistance = Mathf.Max(0f, _chargedCueDepth - idleTipGap);
             float recoveredPower = RecoverPowerFromCueDepth(_chargedCueDepth);
-            _latchedShotPower = ResolveReleasedShotPower(_power, recoveredPower);
+            _latchedShotPower = ResolveReleasedShotPower(_power, recoveredPower, _latchedPullDistance);
             if (_latchedShotPower <= 0f)
             {
                 _shotState = ShotState.Idle;
@@ -237,7 +254,7 @@ namespace Aiming
         {
             float hitT = Mathf.Clamp01(hitProgress);
             float activePower = _shotState == ShotState.Dragging ? _power : _latchedShotPower;
-            float pull = pullRange * EaseOutCubic(activePower);
+            float pull = _shotState == ShotState.Striking ? _latchedPullDistance : PullDistanceFromPower(activePower);
 
             if (_shotState == ShotState.Idle)
             {
@@ -410,6 +427,7 @@ namespace Aiming
             _shotState = ShotState.Idle;
             _power = 0f;
             _latchedShotPower = 0f;
+            _latchedPullDistance = 0f;
             _latchedShotSpin = _liveSpinInput;
             _chargedCueDepth = idleTipGap;
             _currentCueDepth = idleTipGap;
@@ -418,9 +436,10 @@ namespace Aiming
             ResetTipScale();
         }
 
-        float ResolveReleasedShotPower(float sliderPower, float recoveredPower)
+        float ResolveReleasedShotPower(float sliderPower, float recoveredPower, float pullDistance)
         {
-            float raw = Mathf.Clamp01(Mathf.Max(sliderPower, recoveredPower));
+            float pullNorm = pullRange > 0.0001f ? Mathf.Clamp01(pullDistance / pullRange) : 0f;
+            float raw = Mathf.Clamp01(Mathf.Max(Mathf.Max(sliderPower, recoveredPower), pullNorm));
             if (raw <= 0f)
             {
                 return 0f;
@@ -479,6 +498,16 @@ namespace Aiming
             }
 
             cueTip.localScale = _tipBaseScale;
+        }
+
+        float PullDistanceFromPower(float normalizedPower)
+        {
+            if (pullRange <= 0.0001f)
+            {
+                return 0f;
+            }
+
+            return pullRange * EaseOutCubic(normalizedPower);
         }
 
         static float EaseOutCubic(float t)

--- a/Assets/Scripts/Gameplay/PoolHumanPoseDriver.cs
+++ b/Assets/Scripts/Gameplay/PoolHumanPoseDriver.cs
@@ -36,8 +36,8 @@ namespace Aiming
         public float sourceTableLength = 3.6f;
         [Tooltip("Reference table width from source implementation.")]
         public float sourceTableWidth = 2f;
-        public float edgeMargin = 0.58f;
-        public float desiredShootDistance = 1.06f;
+        public float edgeMargin = 0.34f;
+        public float desiredShootDistance = 0.9f;
         [Tooltip("Uniform character size multiplier. Values above 1 make the player visually bigger and heavier.")]
         [Min(0.6f)] public float bodyScaleMultiplier = 1.12f;
 
@@ -49,11 +49,13 @@ namespace Aiming
         [Range(0.05f, 1f)] public float lateralResponse = 0.42f;
 
         [Header("Cue relation")]
-        public float bridgeDist = 0.24f;
+        public float bridgeDist = 0.2f;
         public float gripRatio = 0.76f;
         public float stanceHeight = 0f;
         [Tooltip("How much closer to the table edge the chest/head moves while aiming.")]
         [Range(0f, 0.2f)] public float tableLeanDepth = 0.08f;
+        [Tooltip("Extra right-hand pull distance, matching the live power slider pullback.")]
+        [Range(0f, 0.4f)] public float gripPullRange = 0.24f;
 
         [Header("Visual fidelity")]
         [Tooltip("Renderers that should keep their original shared materials/textures (prevents accidental runtime overrides).")]
@@ -107,9 +109,12 @@ namespace Aiming
             Vector3 bridgeHandTarget = cueBall + (aimForward * -bridgeDistance) + (aimSide * (-0.018f * s));
             bridgeHandTarget.y = ResolveTableY(cueBall.y) + ResolveBridgeHeightOffset(bridgeMode, s);
 
-            Vector3 cueTip = cueController.cueTip != null ? cueController.cueTip.position : cueBall;
-            Vector3 cueBase = cueController.transform.position;
-            Vector3 gripHandTarget = Vector3.Lerp(cueTip, cueBase, gripRatio);
+            float handPull = cueController.CurrentPullNormalized * gripPullRange * s;
+            Vector3 gripHandTarget =
+                bridgeHandTarget +
+                (aimForward * (-(0.44f * s + handPull))) +
+                (Vector3.up * (0.03f * s)) +
+                (aimSide * (0.022f * s));
 
             float standingYaw = YawFromForward(aimForward);
             Vector3 idleRightHandTarget = rootTarget + RotateAroundY(new Vector3(0.22f, 1.18f, 0.04f) * s, standingYaw);
@@ -309,9 +314,9 @@ namespace Aiming
                                 (side * (-0.025f * t * s));
 
             Vector3 rightElbow = rightHandWorld +
-                                 (Vector3.up * Lerp(0.19f, 0.43f, t) * s) +
-                                 (side * Lerp(0.03f, 0.06f, t) * s) +
-                                 (forward * Lerp(-0.03f, 0.02f, t) * s);
+                                 (Vector3.up * Lerp(0.19f, 0.4f, t) * s) +
+                                 (side * Lerp(0.03f, 0.07f, t) * s) +
+                                 (forward * Lerp(-0.03f, 0.01f, t) * s);
 
             Vector3 leftKnee = Vector3.Lerp(leftHipWorld, leftFootWorld, 0.53f) +
                                (Vector3.up * Lerp(0.18f, 0.11f, t) * s) +


### PR DESCRIPTION
### Motivation
- Make the Pool Royal human pose and cue animation match the existing snooker-style shooting behavior and the live power slider so the character visibly holds and pulls the cue in sync with shot power. 
- Move the right-hand grip to follow the slider-driven pull while keeping the left (bridge) hand near the cue ball for a realistic pool stance next to side/short rails. 

### Description
- Exposed live pull state via `CueController.CurrentPullNormalized` and added latched pull distance (`_latchedPullDistance`) so the pull amount is recorded on release and reused during the strike animation/physics. 
- Replaced inline pull math with `PullDistanceFromPower` and updated release logic to compute `_latchedPullDistance` and feed it into `ResolveReleasedShotPower` to keep animation and impulse consistent. 
- Adjusted human pose defaults in `PoolHumanPoseDriver` (`edgeMargin`, `desiredShootDistance`, `bridgeDist`) to move the character closer to rails and added `gripPullRange` so the right hand target uses `CurrentPullNormalized` to translate the cue grip back with slider pull. 
- Kept original material/texture restore logic in `PoolHumanPoseDriver` (`CacheOriginalMaterials` / `EnsureOriginalMaterials`) to avoid runtime texture overrides. 

### Testing
- Reviewed changes with `git diff` and confirmed modified files are `Assets/Scripts/Gameplay/CueController.cs` and `Assets/Scripts/Gameplay/PoolHumanPoseDriver.cs`. 
- Performed repository status checks (`git status --short`) and committed the change; no automated Unity Editor or Play Mode tests were executed in this CLI-only environment. 
- No runtime/playmode validation was run here, so in-Editor testing on device/Unity is required to verify hand alignment, cue-tip contact timing, and texture preservation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eef9a0a0b4832982961e2f83787531)