### PR TITLE
Domino Royal: per-seat seated human characters and reuse Ludo human catalog

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -1084,6 +1084,32 @@ const DOMINO_HUMAN_CHARACTER_OPTIONS = Object.freeze([
     modelUrls: ['https://raw.githubusercontent.com/Surbh77/AI-teacher/main/avatar1.glb']
   }
 ]);
+
+function createAiUniqueHumanCharacterLoadout(
+  activePlayerCount,
+  selectedHumanIndex = 0
+) {
+  const totalPlayers = Math.max(1, Number(activePlayerCount) || 1);
+  const maxCharacterIndex = Math.max(0, DOMINO_HUMAN_CHARACTER_OPTIONS.length - 1);
+  const humanIndex = THREE.MathUtils.clamp(
+    Number.isFinite(selectedHumanIndex) ? Math.round(selectedHumanIndex) : 0,
+    0,
+    maxCharacterIndex
+  );
+  const byPlayer = Array.from({ length: totalPlayers }, () => humanIndex);
+  if (totalPlayers <= 1 || DOMINO_HUMAN_CHARACTER_OPTIONS.length <= 1) {
+    return byPlayer;
+  }
+  const aiSeatIndexes = Array.from({ length: totalPlayers - 1 }, (_, idx) => idx + 1);
+  const pool = Array.from({ length: DOMINO_HUMAN_CHARACTER_OPTIONS.length }, (_, idx) => idx).filter(
+    (idx) => idx !== humanIndex
+  );
+  const shuffledPool = shuffle([...pool]);
+  aiSeatIndexes.forEach((seatIndex, aiIdx) => {
+    byPlayer[seatIndex] = shuffledPool[aiIdx % shuffledPool.length] ?? humanIndex;
+  });
+  return byPlayer;
+}
 const ARENA_WALL_HEIGHT = 3.6 * 1.3;
 const ARENA_WALL_CENTER_Y = ARENA_WALL_HEIGHT / 2;
 const ARENA_WALL_INNER_RADIUS = TABLE_RADIUS * ARENA_GROWTH * 2.4;
@@ -4236,6 +4262,17 @@ const LEGACY_APPEARANCE_KEYS = ['dominoRoyalArenaAppearanceV2', 'dominoRoyalAren
 const DEFAULT_TABLE_MIGRATION_KEY = 'dominoRoyalMurlanDefaultTableMigrationV3';
 let appearance = { ...DEFAULT_APPEARANCE };
 let dominoInventory = getDominoInventory();
+let seatHumanCharacterLoadout = createAiUniqueHumanCharacterLoadout(
+  N,
+  appearance?.humanCharacter
+);
+
+function refreshSeatHumanCharacterLoadout() {
+  seatHumanCharacterLoadout = createAiUniqueHumanCharacterLoadout(
+    N,
+    appearance?.humanCharacter
+  );
+}
 
 function normalizeAppearance(raw) {
   const normalized = {
@@ -7232,6 +7269,7 @@ function saveAppearance() {
 
 function applyAppearanceChange({ refresh = true } = {}) {
   appearance = sanitizeAppearance(appearance);
+  refreshSeatHumanCharacterLoadout();
   applyEnvironmentHdri(
     ENVIRONMENT_HDRI_OPTIONS[appearance.environmentHdri] ??
       ENVIRONMENT_HDRI_OPTIONS[0]
@@ -8133,9 +8171,11 @@ async function attachSeatedHumanActors(token) {
       if (token !== chairBuildToken) return;
       const chairRoot = chairs[index];
       if (!chairRoot) continue;
-      const selectedHumanIndex = Number.isFinite(appearance?.humanCharacter)
-        ? appearance.humanCharacter
-        : 0;
+      const selectedHumanIndex = Number.isFinite(seatHumanCharacterLoadout[index])
+        ? seatHumanCharacterLoadout[index]
+        : Number.isFinite(appearance?.humanCharacter)
+          ? appearance.humanCharacter
+          : 0;
       const option =
         DOMINO_HUMAN_CHARACTER_OPTIONS[selectedHumanIndex] ??
         DOMINO_HUMAN_CHARACTER_OPTIONS[0];
@@ -8632,6 +8672,7 @@ const isPointsRace =
 if (requestedPlayers >= 2 && requestedPlayers <= 4) {
   N = requestedPlayers;
 }
+refreshSeatHumanCharacterLoadout();
 const stakeAmount = Number.parseInt(urlParams.get('amount') || '', 10);
 const stakeToken = urlParams.get('token') || 'TPC';
 if (Number.isFinite(stakeAmount) && stakeAmount > 0) {

--- a/webapp/src/config/dominoRoyalInventoryConfig.js
+++ b/webapp/src/config/dominoRoyalInventoryConfig.js
@@ -1,6 +1,7 @@
 import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from './murlanThemes.js';
 import { POOL_ROYALE_DEFAULT_HDRI_ID } from './poolRoyaleInventoryConfig.js';
 import { swatchThumbnail } from './storeThumbnails.js';
+import { HUMAN_CHARACTER_OPTIONS } from './ludoBattleOptions.js';
 import {
   BATTLE_ROYALE_SHARED_CHAIR_THEME_OPTIONS,
   BATTLE_ROYALE_SHARED_HDRI_VARIANTS,
@@ -9,17 +10,15 @@ import {
   BATTLE_ROYALE_SHARED_TABLE_THEME_OPTIONS
 } from './battleRoyaleSharedInventory.js';
 
-const DOMINO_HUMAN_CHARACTER_OPTIONS = Object.freeze([
-  { id: 'rpm-current', label: 'Current Avatar', description: 'Default Chess Battle Royal human avatar.' },
-  { id: 'rpm-67d411', label: 'RPM 67d411', description: 'Ready Player Me seated avatar variant.' },
-  { id: 'rpm-67f433', label: 'RPM 67f433', description: 'Ready Player Me seated avatar variant.' },
-  { id: 'rpm-67e1b5', label: 'RPM 67e1b5', description: 'Ready Player Me seated avatar variant.' },
-  { id: 'webgl-vietnam-human', label: 'Vietnam Human', description: 'Imported seated human model from Chess roster.' },
-  { id: 'webgl-human-body-a', label: 'Human Body A', description: 'Imported seated human model from Chess roster.' },
-  { id: 'webgl-human-body-b', label: 'Human Body B', description: 'Imported seated human model from Chess roster.' },
-  { id: 'webgl-ai-teacher', label: 'AI Teacher', description: 'Imported seated human model from Chess roster.' },
-  { id: 'webgl-ai-teacher-1', label: 'AI Teacher 1', description: 'Imported seated human model from Chess roster.' }
-]);
+const DOMINO_HUMAN_CHARACTER_OPTIONS = Object.freeze(
+  HUMAN_CHARACTER_OPTIONS.map(({ id, label, description, source, license }) => ({
+    id,
+    label,
+    description,
+    source,
+    license
+  }))
+);
 
 export const DOMINO_ROYAL_OPTION_SETS = Object.freeze({
   tableWood: BATTLE_ROYALE_SHARED_TABLE_FINISH_OPTIONS.map(({ id, label, price = 0, description, thumbnail, woodOption }) => ({


### PR DESCRIPTION
### Motivation
- Make Domino Battle Royal match Ludo Battle Royal seating: each player seat should have its own seated human character with correct orientation and textures, and use the same character catalog as Ludo for consistent store/purchase behavior.
- Ensure AI seats receive unique human characters (not all seats using the single selected human) so visuals and store unlocks behave consistently across both games.

### Description
- Added `createAiUniqueHumanCharacterLoadout` to `webapp/public/domino-royal-game.js` to produce a per-seat human-character array that assigns the player-selected index to the human seat and distributes unique indices to AI seats (excluding the player's choice).
- Introduced `seatHumanCharacterLoadout` state and `refreshSeatHumanCharacterLoadout()` so the per-seat loadout is recalculated on appearance changes and after player-count initialization, and wired `applyAppearanceChange()` and startup logic to call the refresh.
- Updated `attachSeatedHumanActors()` to pick the seated human model per seat from `seatHumanCharacterLoadout` (falling back to `appearance.humanCharacter` if needed) and kept existing seated-pose, scaling and helper logic intact.
- Replaced the Domino-specific human-character list in `webapp/src/config/dominoRoyalInventoryConfig.js` with a mapped copy of `HUMAN_CHARACTER_OPTIONS` from Ludo (`webapp/src/config/ludoBattleOptions.js`) so Domino reuses Ludo’s human character catalog metadata/IDs for store and inventory definitions.

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` and `node --check webapp/src/config/dominoRoyalInventoryConfig.js`, both checks succeeded (no syntax errors).
- Ran `npx eslint webapp/public/domino-royal-game.js webapp/src/config/dominoRoyalInventoryConfig.js` (repo defaults) which reported files ignored by eslint config (non-blocking warnings).
- Ran `npx eslint --no-ignore webapp/public/domino-royal-game.js webapp/src/config/dominoRoyalInventoryConfig.js` which surfaced many pre-existing style-rule violations across the minified/legacy JS file but did not indicate logical failures introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eefb2525788329a369d0cf8e975280)