### PR TITLE
Improve Snooker Royal human alignment, rail constraints, and GLTF texture fidelity

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -109,8 +109,9 @@ const BILARDO_REFERENCE_TABLE_TOP_Y = 0.84;
 const BILARDO_REFERENCE_HUMAN_HEIGHT = BILARDO_REFERENCE_TABLE_TOP_Y * 2;
 const SNOOKER_HUMAN_BASE_SCALE = 1.32;
 const SNOOKER_HUMAN_VISUAL_SCALE_BOOST = 2.42;
-const SNOOKER_HUMAN_EDGE_MARGIN_FACTOR = 6.9;
-const SNOOKER_HUMAN_DESIRED_SHOOT_DISTANCE_FACTOR = 16.6;
+const SNOOKER_HUMAN_EDGE_MARGIN_FACTOR = 4.8;
+const SNOOKER_HUMAN_DESIRED_SHOOT_DISTANCE_FACTOR = 13.4;
+const SNOOKER_HUMAN_RAIL_CLEARANCE_FACTOR = 2.5;
 
 function safePolygonUnion(...parts) {
   const valid = parts.filter(Boolean);
@@ -20802,6 +20803,41 @@ const powerRef = useRef(hud.power);
         cueBack: new THREE.Vector3(),
         cueTip: new THREE.Vector3()
       };
+      const humanRailHelperRoot = new THREE.Group();
+      humanRailHelperRoot.name = 'SnookerHumanRailHelpers';
+      table.add(humanRailHelperRoot);
+      const humanRootHelper = new THREE.Mesh(
+        new THREE.SphereGeometry(BALL_R * 0.22, 18, 12),
+        new THREE.MeshBasicMaterial({ color: 0xff6f3c, transparent: true, opacity: 0.82 })
+      );
+      const humanBridgeHelper = new THREE.Mesh(
+        new THREE.SphereGeometry(BALL_R * 0.17, 16, 10),
+        new THREE.MeshBasicMaterial({ color: 0x5ac8ff, transparent: true, opacity: 0.8 })
+      );
+      const humanGripHelper = new THREE.Mesh(
+        new THREE.SphereGeometry(BALL_R * 0.17, 16, 10),
+        new THREE.MeshBasicMaterial({ color: 0x9dff7a, transparent: true, opacity: 0.8 })
+      );
+      const createRailRectHelper = (halfW, halfL, color) => {
+        const points = [
+          new THREE.Vector3(-halfW, FLOOR_Y + BALL_R * 0.12, -halfL),
+          new THREE.Vector3(halfW, FLOOR_Y + BALL_R * 0.12, -halfL),
+          new THREE.Vector3(halfW, FLOOR_Y + BALL_R * 0.12, halfL),
+          new THREE.Vector3(-halfW, FLOOR_Y + BALL_R * 0.12, halfL),
+          new THREE.Vector3(-halfW, FLOOR_Y + BALL_R * 0.12, -halfL)
+        ];
+        return new THREE.Line(
+          new THREE.BufferGeometry().setFromPoints(points),
+          new THREE.LineBasicMaterial({ color, transparent: true, opacity: 0.72 })
+        );
+      };
+      const humanOuterRailHelper = createRailRectHelper(
+        PLAY_W / 2 + Math.max(BALL_R * SNOOKER_HUMAN_EDGE_MARGIN_FACTOR, SIDE_RAIL_INNER_THICKNESS * 1.65),
+        PLAY_H / 2 + Math.max(BALL_R * SNOOKER_HUMAN_EDGE_MARGIN_FACTOR, SIDE_RAIL_INNER_THICKNESS * 1.65),
+        0xff9d00
+      );
+      const humanInnerRailHelper = createRailRectHelper(PLAY_W / 2, PLAY_H / 2, 0xffffff);
+      humanRailHelperRoot.add(humanOuterRailHelper, humanInnerRailHelper, humanRootHelper, humanBridgeHelper, humanGripHelper);
       const updateSnookerHumanFromAim = (aimDirection, power = 0, options = {}) => {
         if (!humanActor || !cue?.pos) return;
         humanPoseContext.aimDir.set(aimDirection?.x ?? 0, aimDirection?.y ?? 1);
@@ -25317,7 +25353,9 @@ const powerRef = useRef(hud.power);
             tableW: PLAY_W,
             tableL: PLAY_H,
             edgeMargin: Math.max(BALL_R * SNOOKER_HUMAN_EDGE_MARGIN_FACTOR, SIDE_RAIL_INNER_THICKNESS * 1.65),
-            desiredShootDistance: Math.max(cueLen * 0.54, BALL_R * SNOOKER_HUMAN_DESIRED_SHOOT_DISTANCE_FACTOR)
+            desiredShootDistance: Math.max(cueLen * 0.49, BALL_R * SNOOKER_HUMAN_DESIRED_SHOOT_DISTANCE_FACTOR),
+            railClearance: Math.max(BALL_R * SNOOKER_HUMAN_RAIL_CLEARANCE_FACTOR, SIDE_RAIL_INNER_THICKNESS * 0.35),
+            cornerBias: Math.max(BALL_R * 2.05, SIDE_RAIL_INNER_THICKNESS * 0.55)
           });
           rootTarget.y = FLOOR_Y + Math.max(BALL_R * 0.08, 0.03);
           const aimSide = new THREE.Vector3(aimForward.z, 0, -aimForward.x).normalize();
@@ -25328,7 +25366,12 @@ const powerRef = useRef(hud.power);
             .setY(BALL_CENTER_Y - BALL_R + BALL_R * 0.24);
           const gripTarget = humanPoseContext.cueTip
             .clone()
-            .lerp(humanPoseContext.cueBack.clone(), bilardoSharedPose.gripRatio);
+            .lerp(humanPoseContext.cueBack.clone(), bilardoSharedPose.gripRatio)
+            .addScaledVector(aimForward, -BALL_R * 0.34)
+            .addScaledVector(new THREE.Vector3(0, 1, 0), -BALL_R * 0.08);
+          humanRootHelper.position.copy(rootTarget);
+          humanBridgeHelper.position.copy(bridgeTarget);
+          humanGripHelper.position.copy(gripTarget);
           const standingYaw = Math.atan2(-aimForward.x, -aimForward.z);
           const upAxis = new THREE.Vector3(0, 1, 0);
           const idleRight = rootTarget

--- a/webapp/src/pages/Games/shared/bilardoHumanRig.js
+++ b/webapp/src/pages/Games/shared/bilardoHumanRig.js
@@ -187,12 +187,22 @@ export function createBilardoHumanRig(scene, opts = {}) {
             ? [obj.material]
             : [];
         mats.forEach((m) => {
+          ['map', 'emissiveMap'].forEach((colorKey) => {
+            if (!m?.[colorKey]) return;
+            m[colorKey].colorSpace = THREE.SRGBColorSpace;
+          });
+          ['map', 'normalMap', 'roughnessMap', 'metalnessMap', 'aoMap', 'emissiveMap'].forEach((textureKey) => {
+            if (!m?.[textureKey]) return;
+            m[textureKey].anisotropy = Math.max(m[textureKey].anisotropy || 1, opts?.textureAnisotropy ?? 8);
+            m[textureKey].needsUpdate = true;
+          });
           if (m?.map) {
-            m.map.colorSpace = THREE.SRGBColorSpace;
-            m.map.anisotropy = Math.max(m.map.anisotropy || 1, opts?.textureAnisotropy ?? 8);
-            m.map.needsUpdate = true;
+            m.map.flipY = false;
           }
-          if (m) m.needsUpdate = true;
+          if (m) {
+            m.envMapIntensity = Math.max(0.9, m.envMapIntensity ?? 1);
+            m.needsUpdate = true;
+          }
         });
       });
       human.bones = buildAvatarBones(model);
@@ -507,17 +517,39 @@ export function chooseHumanEdgePosition(cueBallWorld, aimForward, opts = {}) {
   const tableL = opts.tableL ?? 3.6;
   const edgeMargin = opts.edgeMargin ?? 0.58;
   const desiredShootDistance = opts.desiredShootDistance ?? 1.06;
+  const railClearance = opts.railClearance ?? Math.max(0.08, edgeMargin * 0.18);
+  const cornerBias = opts.cornerBias ?? Math.max(0.12, edgeMargin * 0.34);
 
   const desired = cueBallWorld.clone().addScaledVector(aimForward, -desiredShootDistance);
   const xEdge = tableW / 2 + edgeMargin;
   const zEdge = tableL / 2 + edgeMargin;
+  const xMin = -xEdge + railClearance;
+  const xMax = xEdge - railClearance;
+  const zMin = -zEdge + railClearance;
+  const zMax = zEdge - railClearance;
+  const clampRail = (value, min, max) =>
+    min <= max ? clamp(value, min, max) : (min + max) / 2;
   const candidates = [
-    new THREE.Vector3(-xEdge, 0, clamp(desired.z, -zEdge, zEdge)),
-    new THREE.Vector3(xEdge, 0, clamp(desired.z, -zEdge, zEdge)),
-    new THREE.Vector3(clamp(desired.x, -xEdge, xEdge), 0, -zEdge),
-    new THREE.Vector3(clamp(desired.x, -xEdge, xEdge), 0, zEdge)
+    new THREE.Vector3(-xEdge, 0, clampRail(desired.z, zMin + cornerBias, zMax - cornerBias)),
+    new THREE.Vector3(xEdge, 0, clampRail(desired.z, zMin + cornerBias, zMax - cornerBias)),
+    new THREE.Vector3(clampRail(desired.x, xMin + cornerBias, xMax - cornerBias), 0, -zEdge),
+    new THREE.Vector3(clampRail(desired.x, xMin + cornerBias, xMax - cornerBias), 0, zEdge),
+    new THREE.Vector3(-xEdge, 0, clampRail(desired.z, zMin, zMax)),
+    new THREE.Vector3(xEdge, 0, clampRail(desired.z, zMin, zMax)),
+    new THREE.Vector3(clampRail(desired.x, xMin, xMax), 0, -zEdge),
+    new THREE.Vector3(clampRail(desired.x, xMin, xMax), 0, zEdge)
   ];
-  return candidates.sort((a, b) => a.distanceToSquared(desired) - b.distanceToSquared(desired))[0].clone();
+  return candidates
+    .sort((a, b) => {
+      const aRailInset = Math.min(Math.abs(Math.abs(a.x) - xEdge), Math.abs(Math.abs(a.z) - zEdge));
+      const bRailInset = Math.min(Math.abs(Math.abs(b.x) - xEdge), Math.abs(Math.abs(b.z) - zEdge));
+      const aCorner = Math.min(xEdge - Math.abs(a.x), zEdge - Math.abs(a.z));
+      const bCorner = Math.min(xEdge - Math.abs(b.x), zEdge - Math.abs(b.z));
+      const aScore = a.distanceToSquared(desired) + aRailInset * 0.35 - aCorner * 0.18;
+      const bScore = b.distanceToSquared(desired) + bRailInset * 0.35 - bCorner * 0.18;
+      return aScore - bScore;
+    })[0]
+    .clone();
 }
 
 export function updateBilardoHumanPose(human, dt, frameData) {


### PR DESCRIPTION
### Motivation
- Make the player avatar appear closer to the snooker table and align the right-hand grip with the cue so the human visually holds the cue correctly.  
- Prevent the avatar from clipping through outside short/long rails andCorners by improving edge-position selection and adding visible helpers to validate paths.  
- Preserve original GLTF/GLB textures and improve material setup so readyplayer.me / other glTF avatars render with correct color space and sharper textures.

### Description
- Tuned human placement and spacing constants by changing `SNOOKER_HUMAN_EDGE_MARGIN_FACTOR` and `SNOOKER_HUMAN_DESIRED_SHOOT_DISTANCE_FACTOR` and adding `SNOOKER_HUMAN_RAIL_CLEARANCE_FACTOR` in `webapp/src/pages/Games/SnookerRoyal.jsx`.  
- Added on-table visual helpers (root/bridge/grip markers and inner/outer rail guides) in `SnookerRoyal.jsx` to validate stance targets and walking bounds at runtime.  
- Adjusted grip target logic so the computed `gripTarget` is offset along the aim direction and slightly vertically to better match the cue hold position in `SnookerRoyal.jsx`.  
- Reworked edge-position selection in `webapp/src/pages/Games/shared/bilardoHumanRig.js` (`chooseHumanEdgePosition`) to include `railClearance` and `cornerBias`, expanded candidate positions, and added an inset/corner-aware scoring function to reduce rail/corner clipping.  
- Improved GLTF material handling in `createBilardoHumanRig` (same `bilardoHumanRig.js`) by assigning sRGB color space to color maps, applying anisotropy to relevant texture maps (map, normalMap, roughnessMap, metalnessMap, aoMap, emissiveMap), setting `map.flipY = false`, clamping `envMapIntensity`, and forcing `needsUpdate` so original avatar textures appear correctly.

### Testing
- Ran ESLint on the modified files with `npx eslint webapp/src/pages/Games/SnookerRoyal.jsx webapp/src/pages/Games/shared/bilardoHumanRig.js` which completed successfully; warnings were reported because these files are currently ignored by repo ignore patterns.  
- No other automated unit/integration tests were run in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eefebb9c5083299c7074ded502ccdb)