### PR TITLE
Fix Domino seated humans and sync human-character catalog with Ludo

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -7,6 +7,7 @@ import { RGBELoader } from '/vendor/three/examples/jsm/loaders/RGBELoader.js';
 import { DRACOLoader } from '/vendor/three/examples/jsm/loaders/DRACOLoader.js';
 import { KTX2Loader } from '/vendor/three/examples/jsm/loaders/KTX2Loader.js';
 import { MeshoptDecoder } from '/vendor/three/examples/jsm/libs/meshopt_decoder.module.js';
+import { SkeletonUtils } from '/vendor/three/examples/jsm/utils/SkeletonUtils.js';
 import './flag-emojis.js';
 
 const urlParams = new URLSearchParams(window.location.search);
@@ -8149,7 +8150,7 @@ async function attachSeatedHumanActors(token) {
         template = await loadSeatedHumanTemplate(DOMINO_HUMAN_CHARACTER_OPTIONS[0]);
       }
       if (!template || token !== chairBuildToken) return;
-      const actor = template.clone(true);
+      const actor = SkeletonUtils.clone(template);
       const actorScale =
         template.userData?.seatedHumanScale ?? computeSeatedHumanScale(template);
       actor.scale.setScalar(actorScale);

--- a/webapp/src/config/dominoRoyalInventoryConfig.js
+++ b/webapp/src/config/dominoRoyalInventoryConfig.js
@@ -1,6 +1,7 @@
 import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from './murlanThemes.js';
 import { POOL_ROYALE_DEFAULT_HDRI_ID } from './poolRoyaleInventoryConfig.js';
 import { swatchThumbnail } from './storeThumbnails.js';
+import { HUMAN_CHARACTER_OPTIONS as LUDO_HUMAN_CHARACTER_OPTIONS } from './ludoBattleOptions.js';
 import {
   BATTLE_ROYALE_SHARED_CHAIR_THEME_OPTIONS,
   BATTLE_ROYALE_SHARED_HDRI_VARIANTS,
@@ -9,17 +10,13 @@ import {
   BATTLE_ROYALE_SHARED_TABLE_THEME_OPTIONS
 } from './battleRoyaleSharedInventory.js';
 
-const DOMINO_HUMAN_CHARACTER_OPTIONS = Object.freeze([
-  { id: 'rpm-current', label: 'Current Avatar', description: 'Default Chess Battle Royal human avatar.' },
-  { id: 'rpm-67d411', label: 'RPM 67d411', description: 'Ready Player Me seated avatar variant.' },
-  { id: 'rpm-67f433', label: 'RPM 67f433', description: 'Ready Player Me seated avatar variant.' },
-  { id: 'rpm-67e1b5', label: 'RPM 67e1b5', description: 'Ready Player Me seated avatar variant.' },
-  { id: 'webgl-vietnam-human', label: 'Vietnam Human', description: 'Imported seated human model from Chess roster.' },
-  { id: 'webgl-human-body-a', label: 'Human Body A', description: 'Imported seated human model from Chess roster.' },
-  { id: 'webgl-human-body-b', label: 'Human Body B', description: 'Imported seated human model from Chess roster.' },
-  { id: 'webgl-ai-teacher', label: 'AI Teacher', description: 'Imported seated human model from Chess roster.' },
-  { id: 'webgl-ai-teacher-1', label: 'AI Teacher 1', description: 'Imported seated human model from Chess roster.' }
-]);
+const DOMINO_HUMAN_CHARACTER_OPTIONS = Object.freeze(
+  LUDO_HUMAN_CHARACTER_OPTIONS.map(({ id, label, description }) => ({
+    id,
+    label,
+    description
+  }))
+);
 
 export const DOMINO_ROYAL_OPTION_SETS = Object.freeze({
   tableWood: BATTLE_ROYALE_SHARED_TABLE_FINISH_OPTIONS.map(({ id, label, price = 0, description, thumbnail, woodOption }) => ({

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-04-27-domino-human-seating-v37';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-04-27-domino-human-seating-v38';
 
 export default function DominoRoyalArena() {
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- Domino Battle Royal showed only one correct human avatar per match because skinned GLTF avatars were cloned with a generic `Object3D.clone(true)` which shares skeletons and breaks per-seat skinning.
- The Domino human-character list was maintained separately and could drift from the Ludo roster, so it should reuse the existing Ludo character catalog.

### Description
- Replace generic GLTF cloning with skeleton-safe cloning by importing `SkeletonUtils` and using `SkeletonUtils.clone(template)` when instantiating seated human actors in `webapp/public/domino-royal-game.js`.
- Source Domino human-character options from the Ludo catalog by importing `HUMAN_CHARACTER_OPTIONS` from `ludoBattleOptions.js` and building `DOMINO_HUMAN_CHARACTER_OPTIONS` from it in `webapp/src/config/dominoRoyalInventoryConfig.js`.
- Bump the Domino arena script version key in `webapp/src/pages/Games/DominoRoyalArena.jsx` (`DOMINO_ROYAL_SCRIPT_VERSION`) so clients will fetch the updated script immediately.

### Testing
- Ran the production build with `npm -C webapp run build`, which completed successfully and produced optimized `dist/` assets (warnings shown are pre-existing bundle/size warnings and a duplicate package key warning). 
- Attempted `npm -C webapp run lint` for the changed files but it failed because this repository does not expose a `lint` npm script (no in-repo linter script to run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eefb2525788329a369d0cf8e975280)