### PR TITLE
Restore Pool Royale cue trigger parity and Bilardo-style human perimeter behavior

### DIFF
--- a/Assets/Scripts/Gameplay/CueController.cs
+++ b/Assets/Scripts/Gameplay/CueController.cs
@@ -38,6 +38,8 @@ namespace Aiming
         [Min(0f)] public float minStrikeImpulse = 0.25f;
         [Tooltip("Smallest normalized power that still produces cue-ball movement when charge/release was valid.")]
         [Range(0f, 0.5f)] public float minimumShotPowerNormalized = 0.06f;
+        [Tooltip("Minimum pull/slider amount required to arm release when camera is not lowered (Bilardo parity).")]
+        [Range(0f, 0.25f)] public float releaseTriggerThresholdNormalized = 0.02f;
         public float maxStrikeImpulse = 6.5f;
         [Tooltip("Normalized strike progress where the hit is fired once.")]
         [Range(0.75f, 0.99f)] public float hitProgress = 0.88f;
@@ -77,6 +79,7 @@ namespace Aiming
         float _dynamicWobble;
         Vector3 _strikeDirection;
         Vector3 _tipBaseScale = Vector3.one;
+        bool _cameraLowered;
 
         public ShotState CurrentShotState => _shotState;
         public Vector3 CurrentAimDirection => _aimDirection;
@@ -167,6 +170,22 @@ namespace Aiming
             spinInput = _liveSpinInput;
         }
 
+        public void SetCameraLowered(bool lowered)
+        {
+            _cameraLowered = lowered;
+
+            if (_cameraLowered && _shotState == ShotState.Idle)
+            {
+                BeginCharge();
+                return;
+            }
+
+            if (!_cameraLowered && _shotState == ShotState.Dragging && _power < releaseTriggerThresholdNormalized)
+            {
+                CancelCharge();
+            }
+        }
+
         public void CancelCharge()
         {
             if (_shotState == ShotState.Striking)
@@ -214,6 +233,7 @@ namespace Aiming
             _strikeElapsed = 0f;
             _didStrike = false;
             _shotState = ShotState.Striking;
+            _cameraLowered = false;
             TriggerShotBroadcastCamera();
         }
 
@@ -440,6 +460,12 @@ namespace Aiming
         {
             float pullNorm = pullRange > 0.0001f ? Mathf.Clamp01(pullDistance / pullRange) : 0f;
             float raw = Mathf.Clamp01(Mathf.Max(Mathf.Max(sliderPower, recoveredPower), pullNorm));
+            bool pulledEnough = raw > releaseTriggerThresholdNormalized;
+            if (!pulledEnough && !_cameraLowered)
+            {
+                return 0f;
+            }
+
             if (raw <= 0f)
             {
                 return 0f;

--- a/Assets/Scripts/Gameplay/PoolHumanPoseDriver.cs
+++ b/Assets/Scripts/Gameplay/PoolHumanPoseDriver.cs
@@ -38,6 +38,8 @@ namespace Aiming
         public float sourceTableWidth = 2f;
         public float edgeMargin = 0.21f;
         public float desiredShootDistance = 0.74f;
+        [Tooltip("Optional helper waypoints around table sides (left, right, bottom, top) for Bilardo-style perimeter walking.")]
+        public Transform[] sideWalkHelpers;
         [Tooltip("Uniform character size multiplier. Values above 1 make the player visually bigger and heavier.")]
         [Min(0.6f)] public float bodyScaleMultiplier = 1.12f;
 
@@ -47,6 +49,7 @@ namespace Aiming
         public float rotLambda = 8.5f;
         [Tooltip("Lower values slow rail-to-rail side movement to feel heavier and more realistic.")]
         [Range(0.05f, 1f)] public float lateralResponse = 0.42f;
+        [Min(0.1f)] public float walkPerimeterSpeed = 2.7f;
 
         [Header("Cue relation")]
         public float bridgeDist = 0.2f;
@@ -75,6 +78,8 @@ namespace Aiming
         float _yaw;
         float _lateralEdgeCoord;
         Vector3[] _railHelpers = new Vector3[4];
+        Vector3 _perimeterRootTarget;
+        bool _hasPerimeterTarget;
 
         void Awake()
         {
@@ -104,6 +109,7 @@ namespace Aiming
 
             Vector3 aimSide = new Vector3(aimForward.z, 0f, -aimForward.x).normalized;
             Vector3 rootTarget = ChooseHumanEdgePosition(cueBall, aimForward, s, cueController.CurrentShotState);
+            Vector3 navigatedRootTarget = NavigateAlongTablePerimeter(rootTarget, s, dt);
             CacheRailHelpers();
 
             BridgeMode bridgeMode = ResolveBridgeMode(cueBall);
@@ -129,7 +135,7 @@ namespace Aiming
             UpdateHumanPose(
                 dt,
                 cueController.CurrentShotState,
-                rootTarget,
+                navigatedRootTarget,
                 aimForward,
                 bridgeHandTarget,
                 gripHandTarget,
@@ -137,6 +143,8 @@ namespace Aiming
                 idleLeftHandTarget,
                 bridgeMode,
                 s);
+
+            cueController.SetCameraLowered(cueController.CurrentShotState != CueController.ShotState.Idle);
         }
 
         float ComputeScaleFactor()
@@ -263,6 +271,133 @@ namespace Aiming
 
             best.y = stanceHeight;
             return best;
+        }
+
+        Vector3 NavigateAlongTablePerimeter(Vector3 desiredTarget, float s, float dt)
+        {
+            if (!_hasPerimeterTarget)
+            {
+                _perimeterRootTarget = root != null ? root.position : desiredTarget;
+                _hasPerimeterTarget = true;
+            }
+
+            Vector3 currentPerimeter = ClosestPerimeterPoint(_perimeterRootTarget, s);
+            Vector3 targetPerimeter = ClosestPerimeterPoint(desiredTarget, s);
+            _perimeterRootTarget = MovePerimeterPoint(
+                currentPerimeter,
+                targetPerimeter,
+                walkPerimeterSpeed * Mathf.Max(0f, dt),
+                s);
+            _perimeterRootTarget.y = stanceHeight;
+            return _perimeterRootTarget;
+        }
+
+        Vector3 ClosestPerimeterPoint(Vector3 point, float s)
+        {
+            if (sideWalkHelpers != null && sideWalkHelpers.Length > 0)
+            {
+                Vector3 best = point;
+                float bestDist = float.PositiveInfinity;
+                for (int i = 0; i < sideWalkHelpers.Length; i++)
+                {
+                    if (sideWalkHelpers[i] == null)
+                    {
+                        continue;
+                    }
+
+                    Vector3 helperPoint = sideWalkHelpers[i].position;
+                    float d = (helperPoint - point).sqrMagnitude;
+                    if (d < bestDist)
+                    {
+                        best = helperPoint;
+                        bestDist = d;
+                    }
+                }
+
+                best.y = stanceHeight;
+                return best;
+            }
+
+            float halfW = cueController.tableBounds.size.x * 0.5f;
+            float halfL = cueController.tableBounds.size.z * 0.5f;
+            float xEdge = halfW + (edgeMargin * s);
+            float zEdge = halfL + (edgeMargin * s);
+            return new Vector3(
+                Mathf.Clamp(point.x, -xEdge, xEdge),
+                stanceHeight,
+                Mathf.Clamp(point.z, -zEdge, zEdge));
+        }
+
+        Vector3 MovePerimeterPoint(Vector3 current, Vector3 target, float step, float s)
+        {
+            if (step <= 0f)
+            {
+                return current;
+            }
+
+            float halfW = cueController.tableBounds.size.x * 0.5f;
+            float halfL = cueController.tableBounds.size.z * 0.5f;
+            float xEdge = halfW + (edgeMargin * s);
+            float zEdge = halfL + (edgeMargin * s);
+            float perimeter = (xEdge + zEdge) * 4f;
+            if (perimeter < 0.0001f)
+            {
+                return target;
+            }
+
+            float uCurrent = PointToPerimeterU(current, xEdge, zEdge);
+            float uTarget = PointToPerimeterU(target, xEdge, zEdge);
+            float cw = Mathf.Repeat(uTarget - uCurrent, perimeter);
+            float ccw = cw - perimeter;
+            float delta = Mathf.Abs(cw) <= Mathf.Abs(ccw) ? cw : ccw;
+            float travel = Mathf.Clamp(delta, -step, step);
+            float uNext = Mathf.Repeat(uCurrent + travel, perimeter);
+            return PerimeterUToPoint(uNext, xEdge, zEdge);
+        }
+
+        static float PointToPerimeterU(Vector3 p, float xEdge, float zEdge)
+        {
+            float width = xEdge * 2f;
+            float length = zEdge * 2f;
+            float px = Mathf.Clamp(p.x, -xEdge, xEdge);
+            float pz = Mathf.Clamp(p.z, -zEdge, zEdge);
+            float dx = Mathf.Min(Mathf.Abs(px + xEdge), Mathf.Abs(px - xEdge));
+            float dz = Mathf.Min(Mathf.Abs(pz + zEdge), Mathf.Abs(pz - zEdge));
+
+            if (dz <= dx)
+            {
+                return pz < 0f ? (px + xEdge) : (width + length + (xEdge - px));
+            }
+
+            return px > 0f ? (width + (pz + zEdge)) : (width + length + width + (zEdge - pz));
+        }
+
+        static Vector3 PerimeterUToPoint(float u, float xEdge, float zEdge)
+        {
+            float width = xEdge * 2f;
+            float length = zEdge * 2f;
+            float perimeter = (xEdge + zEdge) * 4f;
+            u = Mathf.Repeat(u, perimeter);
+
+            if (u < width)
+            {
+                return new Vector3(-xEdge + u, 0f, -zEdge);
+            }
+
+            u -= width;
+            if (u < length)
+            {
+                return new Vector3(xEdge, 0f, -zEdge + u);
+            }
+
+            u -= length;
+            if (u < width)
+            {
+                return new Vector3(xEdge - u, 0f, zEdge);
+            }
+
+            u -= width;
+            return new Vector3(-xEdge, 0f, zEdge - u);
         }
 
         void UpdateHumanPose(


### PR DESCRIPTION
### Motivation
- Restore Pool Royale cue release behavior to match the Bilardo (Bilardo Shqip) parity so low slider pulls do not fire unless the cue view is lowered, while keeping the existing pull/slider mapping unchanged.
- Make the human character behave like the Bilardo game when preparing and taking a shot: keep the current GLTF human and visual scale, but move/position the rig so the right hand properly grips the cue and the character approaches the table edge naturally.

### Description
- Added a `releaseTriggerThresholdNormalized` field and `_cameraLowered` state to `CueController`, plus a `SetCameraLowered(bool)` API that arms/cancels charge based on camera-lowered state and small pulls.
- Gate shot release in `CueController.ResolveReleasedShotPower(...)` with the new threshold and camera-lowered logic so low `raw` power does not trigger unless camera was lowered; reset `_cameraLowered` when striking begins.
- Left existing pull-to-depth mapping intact by using `PullDistanceFromPower(...)` and preserved tip/camera stroke syncing and strike impulse flow.
- Extended `PoolHumanPoseDriver` with Bilardo-style perimeter navigation: added `sideWalkHelpers`, `walkPerimeterSpeed`, and perimeter traversal helpers (`NavigateAlongTablePerimeter`, `ClosestPerimeterPoint`, `MovePerimeterPoint`, `PointToPerimeterU`, `PerimeterUToPoint`) and wired the computed perimeter target into the existing pose update.
- Synced human aiming state to cue arming by calling `cueController.SetCameraLowered(...)` (non-idle => lowered) so the human pose and cue trigger behavior remain coordinated.
- Changes are scoped to `Assets/Scripts/Gameplay/CueController.cs` and `Assets/Scripts/Gameplay/PoolHumanPoseDriver.cs` only and preserve current character scale and cue-grip math.

### Testing
- Reviewed the existing playmode test file `Assets/Tests/PlayMode/CueControllerTriggerTests.cs` which asserts the camera-lowered arming behavior and confirmed the implementation matches the expected assertions.
- Ran repository verification commands: `git diff` (for the effected files), `git show --stat --oneline HEAD`, and `git status --short`, and committed the changes successfully.
- No full automated playmode/unit test suite was executed in this edit; further CI/Unity PlayMode runs are recommended to validate runtime animation/pose and strike behavior on device.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef0d127b0c832995a9a90b48c670ef)