### PR TITLE
Align Snooker Royal human rig behavior with Bilardo Shqip style

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -108,9 +108,9 @@ const BILARDO_SHARED_HUMAN_GLTF_URL = 'https://threejs.org/examples/models/gltf/
 const BILARDO_REFERENCE_TABLE_TOP_Y = 0.84;
 const BILARDO_REFERENCE_HUMAN_HEIGHT = BILARDO_REFERENCE_TABLE_TOP_Y * 2;
 const SNOOKER_HUMAN_BASE_SCALE = 1.32;
-const SNOOKER_HUMAN_VISUAL_SCALE_BOOST = 2.42;
-const SNOOKER_HUMAN_EDGE_MARGIN_FACTOR = 6.9;
-const SNOOKER_HUMAN_DESIRED_SHOOT_DISTANCE_FACTOR = 16.6;
+const SNOOKER_HUMAN_VISUAL_SCALE_BOOST = 2.3;
+const SNOOKER_HUMAN_EDGE_MARGIN = 0.62;
+const SNOOKER_HUMAN_DESIRED_SHOOT_DISTANCE = 1.06;
 
 function safePolygonUnion(...parts) {
   const valid = parts.filter(Boolean);
@@ -20764,12 +20764,12 @@ const powerRef = useRef(hud.power);
         textureAnisotropy: Math.min(renderer.capabilities?.getMaxAnisotropy?.() || 8, 16),
         humanVisualYawFix: Math.PI,
         strikeTime: BILARDO_STRIKE_TIME_MS / 1000,
-        moveLambda: 3.15,
-        rotLambda: 7.35,
-        stanceWidth: 0.56,
-        bridgePalmTableLift: 0.009,
-        chinToCueHeight: 0.122,
-        cueArmElbowRise: 0.47
+        moveLambda: 5.6,
+        rotLambda: 8.5,
+        stanceWidth: 0.52,
+        bridgePalmTableLift: 0.012,
+        chinToCueHeight: 0.11,
+        cueArmElbowRise: 0.43
       });
       humanActor.root.visible = true;
       const snookerTableTopFromGround = Math.max(
@@ -20788,8 +20788,8 @@ const powerRef = useRef(hud.power);
       humanActor.fallback.scale.setScalar(snookerFinalHumanScale);
 
       const bilardoSharedPose = {
-        bridgeHandBackFromBall: 0.218,
-        bridgeHandSide: -0.014,
+        bridgeHandBackFromBall: 0.245,
+        bridgeHandSide: -0.008,
         gripRatio: 0.76,
         idleRightOffset: new THREE.Vector3(0.24, 1.12, 0.02),
         idleLeftOffset: new THREE.Vector3(-0.18, 1.08, 0.03)
@@ -25316,8 +25316,8 @@ const powerRef = useRef(hud.power);
           const rootTarget = chooseHumanEdgePosition(cueBallWorld, aimForward, {
             tableW: PLAY_W,
             tableL: PLAY_H,
-            edgeMargin: Math.max(BALL_R * SNOOKER_HUMAN_EDGE_MARGIN_FACTOR, SIDE_RAIL_INNER_THICKNESS * 1.65),
-            desiredShootDistance: Math.max(cueLen * 0.54, BALL_R * SNOOKER_HUMAN_DESIRED_SHOOT_DISTANCE_FACTOR)
+            edgeMargin: SNOOKER_HUMAN_EDGE_MARGIN,
+            desiredShootDistance: SNOOKER_HUMAN_DESIRED_SHOOT_DISTANCE
           });
           rootTarget.y = FLOOR_Y + Math.max(BALL_R * 0.08, 0.03);
           const aimSide = new THREE.Vector3(aimForward.z, 0, -aimForward.x).normalize();


### PR DESCRIPTION
### Motivation
- The Snooker Royal human actor did not match the cue-holding and striking logic used by the Bilardo Shqip implementation, causing inconsistent pose/aim behavior and scale differences.
- The goal is to make Snooker Royal use the same human-placement, bridge/grip and strike tuning so the on-screen character holds the cue and shoots like Bilardo while appearing slightly smaller.

### Description
- Updated tuning and creation options passed to `createBilardoHumanRig` in `webapp/src/pages/Games/SnookerRoyal.jsx` to Bilardo-equivalent values by changing `moveLambda`, `rotLambda`, `stanceWidth`, `bridgePalmTableLift`, `chinToCueHeight`, and `cueArmElbowRise` to `5.6`, `8.5`, `0.52`, `0.012`, `0.11`, and `0.43` respectively.
- Replaced Snooker-specific scaling factors with fixed Bilardo-style placement constants by changing `SNOOKER_HUMAN_VISUAL_SCALE_BOOST` from `2.42` to `2.3` and introducing `SNOOKER_HUMAN_EDGE_MARGIN = 0.62` and `SNOOKER_HUMAN_DESIRED_SHOOT_DISTANCE = 1.06`, then using them in the `chooseHumanEdgePosition` call.
- Aligned bridge/grip pose targets to Bilardo values by updating `bilardoSharedPose.bridgeHandBackFromBall` from `0.218` to `0.245` and `bridgeHandSide` from `-0.014` to `-0.008` to improve cue-holding consistency.

### Testing
- Ran `npx eslint webapp/src/pages/Games/SnookerRoyal.jsx` which completed but reported the file is ignored by repository lint rules, so no effective lint errors were produced.
- Ran `npx eslint --no-ignore webapp/src/pages/Games/SnookerRoyal.jsx` which similarly emitted the ignore warning in this environment and did not surface lint errors for the changed lines.
- No other automated tests were executed within this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef1388ad7c83299116362acf679398)