### PR TITLE
Add Gunify weapons to Ludo Battle store and switch AK47/Uzi to Gunify GLTFs

### DIFF
--- a/webapp/src/config/ludoBattleOptions.js
+++ b/webapp/src/config/ludoBattleOptions.js
@@ -145,7 +145,27 @@ export const CAPTURE_ANIMATION_OPTIONS = Object.freeze([
   {
     id: 'ak47VolleyAttack',
     label: 'AK-47 Volley',
-    description: 'Heavy AK volley using GLB texture maps while preserving vehicle attacks.'
+    description: 'Heavy AK volley using Gunify AK47 GLTF textures with original material maps preserved.'
+  },
+  {
+    id: 'krsvBurstAttack',
+    label: 'KRSV Burst',
+    description: 'KRSV firearm burst using Gunify GLTF textures/material mapping.'
+  },
+  {
+    id: 'smithSidearmAttack',
+    label: 'Smith Sidearm',
+    description: 'Smith sidearm takedown with original Gunify texture maps.'
+  },
+  {
+    id: 'mosinMarksmanAttack',
+    label: 'Mosin Marksman',
+    description: 'Mosin long-range strike using Gunify GLTF textures and preserved materials.'
+  },
+  {
+    id: 'sigsauerTacticalAttack',
+    label: 'SigSauer Tactical',
+    description: 'SigSauer tactical burst using Gunify GLTF texture/material files.'
   },
   {
     id: 'grenadeBlastAttack',

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -141,6 +141,10 @@ const FIREARM_CAPTURE_ANIMATION_IDS = new Set([
   'assaultRifleAttack',
   'uziSprayAttack',
   'ak47VolleyAttack',
+  'krsvBurstAttack',
+  'smithSidearmAttack',
+  'mosinMarksmanAttack',
+  'sigsauerTacticalAttack',
   'grenadeBlastAttack',
   'shotgunBlastAttack',
   'sniperShotAttack',
@@ -177,18 +181,51 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   },
   uziSprayAttack: {
     label: 'Uzi',
-    url: 'https://cdn.jsdelivr.net/gh/webaverse/uzi@main/uzi.glb',
+    urls: [
+      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models2/Uzi/scene.gltf',
+      'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models2/Uzi/scene.gltf'
+    ],
     scale: 0.14
   },
   ak47VolleyAttack: {
     label: 'AK-47',
     urls: [
-      'https://cdn.jsdelivr.net/gh/LazerMaker/gun-models-ak47-and-supprest-pistol-@master/ak47.glb',
-      'https://cdn.jsdelivr.net/gh/webaverse/pistol@master/military.glb',
-      'https://raw.githubusercontent.com/LazerMaker/gun-models-ak47-and-supprest-pistol-/master/ak47.glb',
-      'https://cdn.statically.io/gh/LazerMaker/gun-models-ak47-and-supprest-pistol-/master/ak47.glb'
+      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/AK47/scene.gltf',
+      'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/AK47/scene.gltf'
     ],
     scale: 0.16
+  },
+  krsvBurstAttack: {
+    label: 'KRSV',
+    urls: [
+      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/KRSV/scene.gltf',
+      'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/KRSV/scene.gltf'
+    ],
+    scale: 0.148
+  },
+  smithSidearmAttack: {
+    label: 'Smith',
+    urls: [
+      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/Smith/scene.gltf',
+      'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/Smith/scene.gltf'
+    ],
+    scale: 0.122
+  },
+  mosinMarksmanAttack: {
+    label: 'Mosin',
+    urls: [
+      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models2/Mosin/scene.gltf',
+      'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models2/Mosin/scene.gltf'
+    ],
+    scale: 0.205
+  },
+  sigsauerTacticalAttack: {
+    label: 'SigSauer',
+    urls: [
+      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models3/SigSauer/scene.gltf',
+      'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models3/SigSauer/scene.gltf'
+    ],
+    scale: 0.13
   },
   grenadeBlastAttack: {
     label: 'Grenade',
@@ -280,6 +317,10 @@ const FIREARM_MAGAZINE_SHOTS = Object.freeze({
   assaultRifleAttack: 30,
   uziSprayAttack: 32,
   ak47VolleyAttack: 30,
+  krsvBurstAttack: 30,
+  smithSidearmAttack: 16,
+  mosinMarksmanAttack: 10,
+  sigsauerTacticalAttack: 20,
   grenadeBlastAttack: 1,
   shotgunBlastAttack: 8,
   sniperShotAttack: 10,
@@ -323,6 +364,26 @@ const FIREARM_HAND_ATTACH_TUNING = Object.freeze({
     rotation: [-1.42, -0.04, -1.55],
     muzzleOffset: [0, 0.014, 0.245]
   },
+  krsvBurstAttack: {
+    position: [0.026, -0.004, 0.111],
+    rotation: [-1.43, -0.04, -1.55],
+    muzzleOffset: [0, 0.014, 0.238]
+  },
+  smithSidearmAttack: {
+    position: [0.019, -0.001, 0.084],
+    rotation: [-1.51, -0.03, -1.58],
+    muzzleOffset: [0, 0.012, 0.194]
+  },
+  mosinMarksmanAttack: {
+    position: [0.029, -0.005, 0.131],
+    rotation: [-1.38, -0.04, -1.58],
+    muzzleOffset: [0, 0.015, 0.262]
+  },
+  sigsauerTacticalAttack: {
+    position: [0.021, -0.002, 0.09],
+    rotation: [-1.49, -0.04, -1.57],
+    muzzleOffset: [0, 0.013, 0.208]
+  },
   compactCarbineAttack: {
     position: [0.024, -0.003, 0.105],
     rotation: [-1.44, -0.04, -1.55],
@@ -353,6 +414,10 @@ const FIREARM_ATTACH_SCALE_MULTIPLIER = Object.freeze({
   compactCarbineAttack: 1.14,
   assaultRifleAttack: 1.18,
   ak47VolleyAttack: 1.22,
+  krsvBurstAttack: 1.2,
+  smithSidearmAttack: 1.0,
+  mosinMarksmanAttack: 1.28,
+  sigsauerTacticalAttack: 1.08,
   shotgunBlastAttack: 1.2,
   marksmanDmrAttack: 1.26,
   sniperShotAttack: 1.3,
@@ -406,8 +471,22 @@ async function loadCaptureWeaponModel(captureAnimationId) {
     loader.setCrossOrigin?.('anonymous');
     const imageCache = new Map();
     let loadedRoot = null;
+    const isGltfAssetUrl = (url = '') => {
+      const normalized = `${url}`.split('?')[0].split('#')[0].toLowerCase();
+      return normalized.endsWith('.gltf');
+    };
     for (let i = 0; i < candidateUrls.length; i += 1) {
       try {
+        if (isGltfAssetUrl(candidateUrls[i])) {
+          // eslint-disable-next-line no-await-in-loop
+          const gltf = await withLoadTimeout(loader.loadAsync(candidateUrls[i]));
+          const root = gltf?.scene || gltf?.scenes?.[0] || null;
+          if (root) {
+            loadedRoot = root;
+            break;
+          }
+          continue;
+        }
         // eslint-disable-next-line no-await-in-loop
         const rawBuffer = await withLoadTimeout(fetchBuffer(candidateUrls[i]));
         if (!rawBuffer) continue;


### PR DESCRIPTION
### Motivation
- Provide new purchasable firearm capture animations and ensure the in-game AK‑47 uses the supplied Gunify GLTF and its original textures/material mapping.
- Keep capture weapon visuals faithful to the source GLTFs so models load with their referenced texture files preserved.

### Description
- Added new capture animation entries and store-friendly labels to `webapp/src/config/ludoBattleOptions.js` for the Gunify assets (`krsvBurstAttack`, `smithSidearmAttack`, `mosinMarksmanAttack`, `sigsauerTacticalAttack`) and updated the AK-47 description to reference Gunify textures.
- Replaced existing AK‑47 and Uzi model sources in `webapp/src/pages/Games/LudoBattleRoyal.jsx` with Gunify `scene.gltf` URLs (raw.githubusercontent + jsDelivr fallback) and added model configs for KRSV, Smith, Mosin and SigSauer.
- Extended runtime firearm support in `LudoBattleRoyal.jsx` by adding the new capture IDs to `FIREARM_CAPTURE_ANIMATION_IDS` and updating `CAPTURE_WEAPON_MODEL_CONFIG`, `FIREARM_MAGAZINE_SHOTS`, `FIREARM_HAND_ATTACH_TUNING`, and `FIREARM_ATTACH_SCALE_MULTIPLIER` so new weapons behave correctly in animations and hand attachments.
- Improved capture weapon loader to handle `.gltf` URLs directly via `loader.loadAsync(...)` before the GLB patch/parse flow so Gunify `scene.gltf` assets can resolve their external texture references unchanged.

### Testing
- Ran the production build with `npm --prefix webapp run build` and the build completed successfully.
- The build emitted pre-existing warnings about duplicate package keys and some large chunks, but these are unrelated to the changes and did not block the build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef1c2de8788329a5eac11cb5b121c6)