### PR TITLE
Fix Pool Royale slider release to immediately fire shot with latched power

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -33688,9 +33688,12 @@ useEffect(() => {
     manualStrikePowerRef.current = latchedPower;
     applyPower(latchedPower);
     manualStrikeDidHitRef.current = false;
-    manualStrikeStartedAtRef.current = performance.now();
+    manualStrikeStartedAtRef.current = 0;
     const shouldStrike = latchedPower > BILARDO_MIN_RELEASE_POWER;
-    setManualShotState(shouldStrike ? 'striking' : 'idle');
+    if (shouldStrike) {
+      fireRef.current?.(latchedPower);
+    }
+    setManualShotState('idle');
   }, [applyPower, clampPower]);
   useEffect(() => {
     let raf = 0;
@@ -33748,7 +33751,7 @@ useEffect(() => {
       onChange: (v) => onPowerDrag((v ?? 0) / 100),
       onStart: () => onPowerDragStart(),
       onCommit: () => {
-        onPowerRelease(clampPower(powerRef.current, 0));
+        onPowerRelease(slider.get() / 100);
       }
     });
     sliderInstanceRef.current = slider;


### PR DESCRIPTION
### Motivation
- The Pool Royale shot release could leave the cue ball with no power because the slider commit flow did not reliably pass the committed value to the shot trigger, causing releases to feel like they didn’t fire. 
- The behavior should match the working Snooker/Bilardo samples where the committed slider value immediately drives the `fire` logic and launches the cue ball.

### Description
- Updated the slider release flow in `webapp/src/pages/Games/PoolRoyale.jsx` so `onPowerRelease` immediately calls `fireRef.current(latchedPower)` when the latched power exceeds `BILARDO_MIN_RELEASE_POWER` instead of waiting on the delayed manual-strike gate. 
- Reset `manualStrikeStartedAtRef` to `0` and force `setManualShotState('idle')` after release to avoid stuck or non-firing manual states. 
- Changed the slider commit handler to read the slider value directly via `slider.get() / 100` when committing to avoid stale reads from `powerRef.current`.

### Testing
- Ran the targeted unit test suite `npm test -- --runTestsByPath test/poolRoyaleOnlineFlow.test.js --runInBand`, and all tests in that file passed. 
- Ran `npx eslint` on the file producing a repository ignore warning (file is excluded by repo ignore pattern), but no blocking lint errors were introduced. 
- Modified file: `webapp/src/pages/Games/PoolRoyale.jsx`, and behavior aligns with existing Snooker/Bilardo shot release semantics.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef1f2f2c648329b121d5d61ec18f83)