### PR TITLE
Add missing Ludo weapons, thumbnails, dedupe store items, and improve Quick Weapon Swap UI

### DIFF
--- a/webapp/src/config/ludoBattleInventoryConfig.js
+++ b/webapp/src/config/ludoBattleInventoryConfig.js
@@ -53,7 +53,17 @@ export const LUDO_BATTLE_OPTION_LABELS = Object.freeze({
   headStyle: Object.freeze(CHESS_BATTLE_OPTION_LABELS.headStyle)
 });
 
-export const LUDO_BATTLE_STORE_ITEMS = [
+const uniqueStoreItemsByName = (items) => {
+  const seen = new Set();
+  return items.filter((item) => {
+    const key = `${item?.type || ''}:${String(item?.name || '').trim().toLowerCase()}`;
+    if (!key || seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+};
+
+export const LUDO_BATTLE_STORE_ITEMS = uniqueStoreItemsByName([
   ...MURLAN_TABLE_FINISHES.map((finish, idx) => ({
     id: `ludo-table-finish-${finish.id}`,
     type: 'tableFinish',
@@ -137,7 +147,7 @@ export const LUDO_BATTLE_STORE_ITEMS = [
     name: option.label,
     price: 950 + idx * 120,
     description: option.description,
-    thumbnail: swatchThumbnail(['#0f172a', '#1d4ed8', '#f97316'])
+    thumbnail: option.thumbnail || swatchThumbnail(['#0f172a', '#1d4ed8', '#f97316'])
   })),
   ...HUMAN_CHARACTER_OPTIONS.slice(1).map((option, idx) => ({
     id: `ludo-human-character-${option.id}`,
@@ -150,7 +160,7 @@ export const LUDO_BATTLE_STORE_ITEMS = [
     thumbnail: swatchThumbnail(['#334155', '#64748b', '#f59e0b'])
   })),
   ...CHESS_BATTLE_STORE_ITEMS.filter((item) => ['sideColor', 'headStyle'].includes(item.type))
-];
+]);
 
 export const LUDO_BATTLE_DEFAULT_LOADOUT = [
   { type: 'tables', optionId: MURLAN_TABLE_THEMES[0]?.id, label: MURLAN_TABLE_THEMES[0]?.label },

--- a/webapp/src/config/ludoBattleOptions.js
+++ b/webapp/src/config/ludoBattleOptions.js
@@ -101,101 +101,153 @@ export const TOKEN_PIECE_OPTIONS = Object.freeze([
   { id: 'pieceKing', label: 'Play as King', type: 'k', symbol: '♔' }
 ]);
 
+const captureWeaponThumb = (icon = '⚔️', accent = '#0ea5e9') =>
+  `data:image/svg+xml;utf8,${encodeURIComponent(
+    `<svg xmlns="http://www.w3.org/2000/svg" width="320" height="180" viewBox="0 0 320 180">
+      <defs>
+        <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0%" stop-color="#0f172a" />
+          <stop offset="100%" stop-color="${accent}" />
+        </linearGradient>
+      </defs>
+      <rect width="320" height="180" rx="18" fill="url(#bg)" />
+      <rect x="14" y="14" width="292" height="152" rx="14" fill="rgba(255,255,255,0.08)" />
+      <text x="160" y="112" text-anchor="middle" font-size="72">${icon}</text>
+    </svg>`
+  )}`;
+
 export const CAPTURE_ANIMATION_OPTIONS = Object.freeze([
   {
     id: 'missileJavelin',
     label: 'Javelin Missile',
-    description: 'Perimeter missile orbit with a spear-like terminal strike.'
+    description: 'Perimeter missile orbit with a spear-like terminal strike.',
+    thumbnail: captureWeaponThumb('🚀', '#1d4ed8')
   },
   {
     id: 'droneAttack',
     label: 'Drone Attack',
-    description: 'Attack drone sweep adapted from Chess Battle Royal scale.'
+    description: 'Attack drone sweep adapted from Chess Battle Royal scale.',
+    thumbnail: captureWeaponThumb('🛸', '#0ea5e9')
   },
   {
     id: 'fighterJetAttack',
     label: 'Fighter Jet Attack',
-    description: 'Fast fighter jet strike with right-hand red launch button trigger.'
+    description: 'Fast fighter jet strike with right-hand red launch button trigger.',
+    thumbnail: captureWeaponThumb('✈️', '#2563eb')
   },
   {
     id: 'helicopterAttack',
     label: 'Helicopter Strike',
-    description: 'Attack helicopter run that launches twin missiles after button press.'
+    description: 'Attack helicopter run that launches twin missiles after button press.',
+    thumbnail: captureWeaponThumb('🚁', '#0f766e')
+  },
+  {
+    id: 'mrtkGunAttack',
+    label: 'MRTK Gun',
+    description: 'Mixed Reality Toolkit Gun.glb pickup and burst attack.',
+    thumbnail: captureWeaponThumb('🔫', '#075985')
+  },
+  {
+    id: 'pistolHolsterAttack',
+    label: 'Pistol Holster',
+    description: 'Holstered pistol model from SAM_ASSET-PISTOL-IN-HOLSTER.glb.',
+    thumbnail: captureWeaponThumb('🧰', '#0f766e')
+  },
+  {
+    id: 'fpsGunAttack',
+    label: 'FPS Gun',
+    description: 'FPS Gun scene.gltf pickup with preserved mesh/material shape.',
+    thumbnail: captureWeaponThumb('🎯', '#7c3aed')
   },
   {
     id: 'glockSidearmAttack',
     label: 'Glock Sidearm',
-    description: 'Pick the Glock from the table, aim, and fire before taking the tile.'
+    description: 'Pick the Glock from the table, aim, and fire before taking the tile.',
+    thumbnail: captureWeaponThumb('🔫', '#2563eb')
   },
   {
     id: 'pistolSidearmAttack',
     label: 'Pistol Sidearm',
-    description: 'Classic pistol takedown with right-hand pickup using original GLB textures.'
+    description: 'Classic pistol takedown with right-hand pickup using original GLB textures.',
+    thumbnail: captureWeaponThumb('🔫', '#0284c7')
   },
   {
     id: 'assaultRifleAttack',
     label: 'Assault Rifle',
-    description: 'AR burst capture with short aim hold and original GLB texture materials.'
+    description: 'AR burst capture with short aim hold and original GLB texture materials.',
+    thumbnail: captureWeaponThumb('🪖', '#334155')
   },
   {
     id: 'uziSprayAttack',
     label: 'Uzi Spray',
-    description: 'Fast SMG capture variation inspired by Tirana 2040 Uzi loadout.'
+    description: 'Fast SMG capture variation inspired by Tirana 2040 Uzi loadout.',
+    thumbnail: captureWeaponThumb('🔫', '#1e293b')
   },
   {
     id: 'ak47VolleyAttack',
     label: 'AK-47 Volley',
-    description: 'Heavy AK volley using Gunify AK47 GLTF textures with original material maps preserved.'
+    description: 'Heavy AK volley using Gunify AK47 GLTF textures with original material maps preserved.',
+    thumbnail: captureWeaponThumb('🪖', '#7f1d1d')
   },
   {
     id: 'krsvBurstAttack',
     label: 'KRSV Burst',
-    description: 'KRSV firearm burst using Gunify GLTF textures/material mapping.'
+    description: 'KRSV firearm burst using Gunify GLTF textures/material mapping.',
+    thumbnail: captureWeaponThumb('🎖️', '#6d28d9')
   },
   {
     id: 'smithSidearmAttack',
     label: 'Smith Sidearm',
-    description: 'Smith sidearm takedown with original Gunify texture maps.'
+    description: 'Smith sidearm takedown with original Gunify texture maps.',
+    thumbnail: captureWeaponThumb('🔫', '#155e75')
   },
   {
     id: 'mosinMarksmanAttack',
     label: 'Mosin Marksman',
-    description: 'Mosin long-range strike using Gunify GLTF textures and preserved materials.'
+    description: 'Mosin long-range strike using Gunify GLTF textures and preserved materials.',
+    thumbnail: captureWeaponThumb('🎯', '#0f172a')
   },
   {
     id: 'sigsauerTacticalAttack',
     label: 'SigSauer Tactical',
-    description: 'SigSauer tactical burst using Gunify GLTF texture/material files.'
+    description: 'SigSauer tactical burst using Gunify GLTF texture/material files.',
+    thumbnail: captureWeaponThumb('🔫', '#1d4ed8')
   },
   {
     id: 'grenadeBlastAttack',
     label: 'Grenade Blast',
-    description: 'Grenade capture with preserved GLB textures and quick throw/pickup pacing.'
+    description: 'Grenade capture with preserved GLB textures and quick throw/pickup pacing.',
+    thumbnail: captureWeaponThumb('💣', '#9a3412')
   },
   {
     id: 'shotgunBlastAttack',
     label: 'Shotgun Blast',
-    description: 'Short-range tactical shotgun blast with fast pickup timing.'
+    description: 'Short-range tactical shotgun blast with fast pickup timing.',
+    thumbnail: captureWeaponThumb('🧨', '#92400e')
   },
   {
     id: 'sniperShotAttack',
     label: 'Sniper Shot',
-    description: 'Precision long-barrel sniper takedown sequence.'
+    description: 'Precision long-barrel sniper takedown sequence.',
+    thumbnail: captureWeaponThumb('🎯', '#312e81')
   },
   {
     id: 'smgBurstAttack',
     label: 'SMG Burst',
-    description: 'Compact SMG burst animation with controlled recoil.'
+    description: 'Compact SMG burst animation with controlled recoil.',
+    thumbnail: captureWeaponThumb('🔫', '#0f172a')
   },
   {
     id: 'compactCarbineAttack',
     label: 'Compact Carbine',
-    description: 'Open-source compact carbine-style pickup and burst capture animation.'
+    description: 'Open-source compact carbine-style pickup and burst capture animation.',
+    thumbnail: captureWeaponThumb('🪖', '#1f2937')
   },
   {
     id: 'marksmanDmrAttack',
     label: 'Marksman DMR',
-    description: 'Open-source designated marksman rifle attack with controlled right-hand aim.'
+    description: 'Open-source designated marksman rifle attack with controlled right-hand aim.',
+    thumbnail: captureWeaponThumb('🎯', '#334155')
   }
 
 ]);

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -136,6 +136,9 @@ const CAPTURE_PARK_SCALE_BY_TYPE = Object.freeze({
 });
 const CAPTURE_AIR_ATTACK_ID_SET = new Set(['fighterJetAttack', 'helicopterAttack', 'droneAttack', 'missileJavelin']);
 const FIREARM_CAPTURE_ANIMATION_IDS = new Set([
+  'mrtkGunAttack',
+  'pistolHolsterAttack',
+  'fpsGunAttack',
   'glockSidearmAttack',
   'pistolSidearmAttack',
   'assaultRifleAttack',
@@ -153,6 +156,34 @@ const FIREARM_CAPTURE_ANIMATION_IDS = new Set([
   'marksmanDmrAttack'
 ]);
 const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
+  mrtkGunAttack: {
+    label: 'MRTK Gun',
+    urls: [
+      'https://raw.githubusercontent.com/microsoft/MixedRealityToolkit/main/SpatialInput/Samples/DemoRoom/Media/Models/Gun.glb',
+      'https://cdn.jsdelivr.net/gh/microsoft/MixedRealityToolkit@main/SpatialInput/Samples/DemoRoom/Media/Models/Gun.glb',
+      'https://raw.githubusercontent.com/Microsoft/MixedRealityToolkit/master/SpatialInput/Samples/DemoRoom/Media/Models/Gun.glb',
+      'https://cdn.jsdelivr.net/gh/Microsoft/MixedRealityToolkit@master/SpatialInput/Samples/DemoRoom/Media/Models/Gun.glb'
+    ],
+    scale: 0.132
+  },
+  pistolHolsterAttack: {
+    label: 'Pistol Holster',
+    urls: [
+      'https://raw.githubusercontent.com/SAAAM-LLC/3D_model_bundle/main/SAM_ASSET-PISTOL-IN-HOLSTER.glb',
+      'https://cdn.jsdelivr.net/gh/SAAAM-LLC/3D_model_bundle@main/SAM_ASSET-PISTOL-IN-HOLSTER.glb'
+    ],
+    scale: 0.138
+  },
+  fpsGunAttack: {
+    label: 'FPS Gun',
+    urls: [
+      'https://cdn.jsdelivr.net/gh/lando19/Guns-for-BJS-FPS-Game@main/main/scene.gltf',
+      'https://raw.githubusercontent.com/lando19/Guns-for-BJS-FPS-Game/main/main/scene.gltf',
+      'https://cdn.jsdelivr.net/gh/lando19/Guns-for-BJS-FPS-Game@master/main/scene.gltf',
+      'https://raw.githubusercontent.com/lando19/Guns-for-BJS-FPS-Game/master/main/scene.gltf'
+    ],
+    scale: 0.142
+  },
   glockSidearmAttack: {
     label: 'Glock',
     urls: [
@@ -312,6 +343,9 @@ function applyModelQualityToObject(root) {
 }
 
 const FIREARM_MAGAZINE_SHOTS = Object.freeze({
+  mrtkGunAttack: 22,
+  pistolHolsterAttack: 14,
+  fpsGunAttack: 24,
   glockSidearmAttack: 17,
   pistolSidearmAttack: 16,
   assaultRifleAttack: 30,
@@ -333,6 +367,21 @@ const FIREARM_HAND_ATTACH_TUNING = Object.freeze({
     position: [0.018, -0.002, 0.086],
     rotation: [-1.5, -0.02, -1.56],
     muzzleOffset: [0.0, 0.012, 0.2]
+  },
+  mrtkGunAttack: {
+    position: [0.02, -0.002, 0.092],
+    rotation: [-1.49, -0.04, -1.56],
+    muzzleOffset: [0, 0.013, 0.22]
+  },
+  pistolHolsterAttack: {
+    position: [0.018, -0.002, 0.086],
+    rotation: [-1.5, -0.03, -1.57],
+    muzzleOffset: [0, 0.012, 0.2]
+  },
+  fpsGunAttack: {
+    position: [0.022, -0.003, 0.098],
+    rotation: [-1.46, -0.04, -1.56],
+    muzzleOffset: [0, 0.014, 0.224]
   },
   glockSidearmAttack: {
     position: [0.018, 0.0, 0.082],
@@ -407,6 +456,9 @@ const FIREARM_HAND_ATTACH_TUNING = Object.freeze({
 });
 const FIREARM_ATTACH_WORLD_SCALE_BOOST = 1.18;
 const FIREARM_ATTACH_SCALE_MULTIPLIER = Object.freeze({
+  mrtkGunAttack: 1.04,
+  pistolHolsterAttack: 1.0,
+  fpsGunAttack: 1.08,
   glockSidearmAttack: 0.98,
   pistolSidearmAttack: 1.0,
   uziSprayAttack: 1.06,
@@ -7259,9 +7311,17 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         );
       case 'captureAnimation':
         return (
-          <div className="relative flex h-14 w-full items-center justify-center overflow-hidden rounded-xl border border-white/10 bg-slate-950/40 px-3 text-center text-[0.65rem] leading-tight text-slate-100">
-            <div className="absolute inset-0 bg-gradient-to-tr from-white/5 via-transparent to-black/40" />
-            <div className="relative flex flex-col items-center gap-0.5">
+          <div className="relative flex h-16 w-full items-center justify-center overflow-hidden rounded-xl border border-white/10 bg-slate-950/40 px-3 text-center text-[0.65rem] leading-tight text-slate-100">
+            {option?.thumbnail ? (
+              <img
+                src={option.thumbnail}
+                alt={`${option?.label || 'Weapon'} thumbnail`}
+                className="absolute inset-0 h-full w-full object-cover"
+                loading="lazy"
+              />
+            ) : null}
+            <div className="absolute inset-0 bg-gradient-to-tr from-black/45 via-transparent to-black/55" />
+            <div className="relative flex flex-col items-center gap-0.5 px-1">
               <span className="font-semibold">{option.label}</span>
               {option.description ? <span className="text-[0.56rem] text-slate-200/80">{option.description}</span> : null}
             </div>
@@ -11135,14 +11195,23 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       <div className="absolute inset-0 pointer-events-none">
         {weaponSwapPopup && (
           <div
-            className="pointer-events-auto absolute z-30 w-48 rounded-xl border border-white/20 bg-black/85 p-2 shadow-2xl backdrop-blur"
+            className="pointer-events-auto absolute z-30 w-[min(96vw,25rem)] max-h-[68vh] overflow-hidden rounded-2xl border border-white/20 bg-black/88 p-2.5 shadow-2xl backdrop-blur"
             style={{
-              left: clamp(weaponSwapPopup.x - 80, 8, (typeof window !== 'undefined' ? window.innerWidth : 360) - 200),
-              top: clamp(weaponSwapPopup.y - 12, 96, (typeof window !== 'undefined' ? window.innerHeight : 640) - 170)
+              left: clamp(weaponSwapPopup.x - 140, 8, (typeof window !== 'undefined' ? window.innerWidth : 360) - 336),
+              top: clamp(weaponSwapPopup.y - 16, 88, (typeof window !== 'undefined' ? window.innerHeight : 640) - 420)
             }}
           >
-            <p className="px-1 pb-1 text-[10px] uppercase tracking-[0.28em] text-sky-200/80">Quick Weapon Swap</p>
-            <div className="grid grid-cols-2 gap-1">
+            <div className="mb-2 flex items-center justify-between gap-2 px-1">
+              <p className="text-[10px] uppercase tracking-[0.28em] text-sky-200/80">Quick Weapon Swap</p>
+              <button
+                type="button"
+                onClick={() => setWeaponSwapPopup(null)}
+                className="rounded-md border border-white/20 bg-white/10 px-2 py-0.5 text-xs font-semibold text-white/90 hover:bg-white/20"
+              >
+                Close
+              </button>
+            </div>
+            <div className="grid max-h-[54vh] grid-cols-2 gap-2 overflow-y-auto pr-1 touch-pan-y overscroll-contain">
               {weaponSwapPopup.options.map((option) => {
                 const optionIndex = CAPTURE_ANIMATION_OPTIONS.findIndex((entry) => entry.id === option.id);
                 const selected = appearance.captureAnimation === optionIndex;
@@ -11150,7 +11219,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
                   <button
                     key={option.id}
                     type="button"
-                    className={`rounded-md border px-1.5 py-1 text-[10px] font-semibold ${
+                    className={`overflow-hidden rounded-xl border text-[10px] font-semibold ${
                       selected ? 'border-sky-300 bg-sky-400/25 text-white' : 'border-white/20 bg-white/5 text-white/80'
                     }`}
                     onClick={() => {
@@ -11158,7 +11227,17 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
                       setWeaponSwapPopup(null);
                     }}
                   >
-                    {option.label}
+                    {option.thumbnail ? (
+                      <img
+                        src={option.thumbnail}
+                        alt={`${option.label} thumbnail`}
+                        className="h-16 w-full object-cover"
+                        loading="lazy"
+                      />
+                    ) : (
+                      <div className="h-16 w-full bg-slate-900/60" />
+                    )}
+                    <div className="px-1.5 py-1">{option.label}</div>
                   </button>
                 );
               })}


### PR DESCRIPTION
### Motivation
- The Ludo Battle Royal flow needed missing firearm/capture options added so players can purchase and use them in-game. 
- Weapon selection was text-only and the quick-swap popup was cramped on portrait/mobile, making shape recognition and selection difficult. 
- Prevent duplicate store entries with identical names so the store list stays clean.

### Description
- Added three new capture/capture-weapon entries (`mrtkGunAttack`, `pistolHolsterAttack`, `fpsGunAttack`) to the runtime config and capture animation list so they can be selected and loaded at runtime (`webapp/src/pages/Games/LudoBattleRoyal.jsx` and `webapp/src/config/ludoBattleOptions.js`).
- Added simple data-URI SVG thumbnails for every `CAPTURE_ANIMATION_OPTIONS` entry and surfaced thumbnails into preview cards so users see a visual mini-thumbnail instead of text-only entries (`webapp/src/config/ludoBattleOptions.js`).
- Wired the new weapon IDs into the runtime weapon model config, including fallback URLs, per-weapon `scale`, `FIREARM_HAND_ATTACH_TUNING`, `FIREARM_ATTACH_SCALE_MULTIPLIER`, and `FIREARM_MAGAZINE_SHOTS` so the new weapons behave like existing firearms (`webapp/src/pages/Games/LudoBattleRoyal.jsx`).
- Upgraded the Quick Weapon Swap popup UX: larger responsive frame, explicit `Close` button, vertical scrolling with `overflow-y-auto`, and thumbnail+label cards for each weapon to make selection faster on portrait/mobile screens (`webapp/src/pages/Games/LudoBattleRoyal.jsx`).
- Prevent duplicate store items by name+type when building `LUDO_BATTLE_STORE_ITEMS` and prefer weapon thumbnails from `CAPTURE_ANIMATION_OPTIONS` when available (`webapp/src/config/ludoBattleInventoryConfig.js`).

### Testing
- Ran the production build with `npm --prefix webapp run build` and the build completed successfully (assets compiled and `dist` produced). 
- Build output emitted existing non-blocking project warnings (duplicate dependency key and chunk-size/dynamic-import notices) but no errors from the changes introduced. 
- Verified that modified code paths referencing the new capture IDs, thumbnails, and store generation compile without type/runtime errors during the build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef25760c6c8329af827b7651ed775e)