### PR TITLE
Fix Pool Royale slider commit to use committed slider value for shot power

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -33747,8 +33747,9 @@ useEffect(() => {
       labels: true,
       onChange: (v) => onPowerDrag((v ?? 0) / 100),
       onStart: () => onPowerDragStart(),
-      onCommit: () => {
-        onPowerRelease(clampPower(powerRef.current, 0));
+      onCommit: (value) => {
+        const committedRatio = Number.isFinite(value) ? value / 100 : powerRef.current;
+        onPowerRelease(clampPower(committedRatio, 0));
       }
     });
     sliderInstanceRef.current = slider;


### PR DESCRIPTION
### Motivation
- The Pool Royale release path could read a stale `powerRef` on slider commit, causing cue shots to fire with no or incorrect power, so the behavior must match the working Snooker/Bilardo release flow and reliably use the slider's committed value.

### Description
- Updated `webapp/src/pages/Games/PoolRoyale.jsx` so the `PowerSlider` `onCommit` handler receives the committed `value` and calls `onPowerRelease` with `Number(value) / 100` (clamped via `clampPower`) instead of relying solely on `powerRef.current`.

### Testing
- Ran `npm test -- test/poolRoyaleShotState.test.js --runInBand` and the suite passed (`4 tests, 4 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef1f2f2c648329b121d5d61ec18f83)