### PR TITLE
Use source weapon thumbnails and improve Ludo weapon rack display

### DIFF
--- a/webapp/src/config/ludoBattleOptions.js
+++ b/webapp/src/config/ludoBattleOptions.js
@@ -116,6 +116,20 @@ const captureWeaponThumb = (icon = '⚔️', accent = '#0ea5e9') =>
     </svg>`
   )}`;
 
+const CAPTURE_WEAPON_SOURCE_THUMBNAILS = Object.freeze({
+  glockSidearmAttack: 'https://raw.githubusercontent.com/webaverse/pistol/master/homer.png',
+  pistolSidearmAttack: 'https://raw.githubusercontent.com/webaverse/pistol/master/homer.png',
+  assaultRifleAttack: 'https://raw.githubusercontent.com/webaverse/pistol/master/homer.png',
+  ak47VolleyAttack:
+    'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/AK47/textures/Material.001_baseColor.png',
+  smithSidearmAttack:
+    'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/Smith/textures/Wood_baseColor.jpeg',
+  shotgunBlastAttack:
+    'https://raw.githubusercontent.com/lando19/Guns-for-BJS-FPS-Game/main/main/textures/shotgun_baseColor.png',
+  sniperShotAttack:
+    'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models2/Mosin/textures/Mosin_baseColor.png'
+});
+
 export const CAPTURE_ANIMATION_OPTIONS = Object.freeze([
   {
     id: 'missileJavelin',
@@ -163,19 +177,19 @@ export const CAPTURE_ANIMATION_OPTIONS = Object.freeze([
     id: 'glockSidearmAttack',
     label: 'Glock Sidearm',
     description: 'Pick the Glock from the table, aim, and fire before taking the tile.',
-    thumbnail: captureWeaponThumb('🔫', '#2563eb')
+    thumbnail: CAPTURE_WEAPON_SOURCE_THUMBNAILS.glockSidearmAttack
   },
   {
     id: 'pistolSidearmAttack',
     label: 'Pistol Sidearm',
     description: 'Classic pistol takedown with right-hand pickup using original GLB textures.',
-    thumbnail: captureWeaponThumb('🔫', '#0284c7')
+    thumbnail: CAPTURE_WEAPON_SOURCE_THUMBNAILS.pistolSidearmAttack
   },
   {
     id: 'assaultRifleAttack',
     label: 'Assault Rifle',
     description: 'AR burst capture with short aim hold and original GLB texture materials.',
-    thumbnail: captureWeaponThumb('🪖', '#334155')
+    thumbnail: CAPTURE_WEAPON_SOURCE_THUMBNAILS.assaultRifleAttack
   },
   {
     id: 'uziSprayAttack',
@@ -187,7 +201,7 @@ export const CAPTURE_ANIMATION_OPTIONS = Object.freeze([
     id: 'ak47VolleyAttack',
     label: 'AK-47 Volley',
     description: 'Heavy AK volley using Gunify AK47 GLTF textures with original material maps preserved.',
-    thumbnail: captureWeaponThumb('🪖', '#7f1d1d')
+    thumbnail: CAPTURE_WEAPON_SOURCE_THUMBNAILS.ak47VolleyAttack
   },
   {
     id: 'krsvBurstAttack',
@@ -199,7 +213,7 @@ export const CAPTURE_ANIMATION_OPTIONS = Object.freeze([
     id: 'smithSidearmAttack',
     label: 'Smith Sidearm',
     description: 'Smith sidearm takedown with original Gunify texture maps.',
-    thumbnail: captureWeaponThumb('🔫', '#155e75')
+    thumbnail: CAPTURE_WEAPON_SOURCE_THUMBNAILS.smithSidearmAttack
   },
   {
     id: 'mosinMarksmanAttack',
@@ -223,13 +237,13 @@ export const CAPTURE_ANIMATION_OPTIONS = Object.freeze([
     id: 'shotgunBlastAttack',
     label: 'Shotgun Blast',
     description: 'Short-range tactical shotgun blast with fast pickup timing.',
-    thumbnail: captureWeaponThumb('🧨', '#92400e')
+    thumbnail: CAPTURE_WEAPON_SOURCE_THUMBNAILS.shotgunBlastAttack
   },
   {
     id: 'sniperShotAttack',
     label: 'Sniper Shot',
     description: 'Precision long-barrel sniper takedown sequence.',
-    thumbnail: captureWeaponThumb('🎯', '#312e81')
+    thumbnail: CAPTURE_WEAPON_SOURCE_THUMBNAILS.sniperShotAttack
   },
   {
     id: 'smgBurstAttack',

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -155,6 +155,39 @@ const FIREARM_CAPTURE_ANIMATION_IDS = new Set([
   'compactCarbineAttack',
   'marksmanDmrAttack'
 ]);
+const LARGE_RACK_FIREARM_IDS = new Set([
+  'assaultRifleAttack',
+  'ak47VolleyAttack',
+  'mosinMarksmanAttack',
+  'shotgunBlastAttack',
+  'sniperShotAttack',
+  'marksmanDmrAttack',
+  'compactCarbineAttack'
+]);
+const SIDEARM_RACK_FIREARM_IDS = new Set([
+  'glockSidearmAttack',
+  'pistolSidearmAttack',
+  'smithSidearmAttack',
+  'sigsauerTacticalAttack',
+  'pistolHolsterAttack'
+]);
+const FIREARM_RACK_DISPLAY_TUNING = Object.freeze({
+  default: Object.freeze({
+    targetSizeMultiplier: 1.06,
+    position: [0.01, 0, -0.004],
+    rotation: [0, Math.PI * 0.5, 0]
+  }),
+  large: Object.freeze({
+    targetSizeMultiplier: 1.42,
+    position: [0.05, 0.012, -0.012],
+    rotation: [Math.PI * -0.03, Math.PI * 0.16, Math.PI * 0.08]
+  }),
+  sidearm: Object.freeze({
+    targetSizeMultiplier: 0.96,
+    position: [0.026, -0.01, -0.006],
+    rotation: [Math.PI * -0.48, Math.PI * 0.32, Math.PI * 0.02]
+  })
+});
 const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   mrtkGunAttack: {
     label: 'MRTK Gun',
@@ -637,16 +670,9 @@ async function attachFirearmToRightHand(attackerEntry, captureAnimationId) {
 async function createCaptureWeaponRackFx() {
   const root = new THREE.Group();
   const weaponHolder = new THREE.Group();
-  weaponHolder.position.set(0.04, 0.032, -0.018);
-  weaponHolder.rotation.z = -0.08;
+  weaponHolder.position.set(0.078, 0.026, -0.024);
+  weaponHolder.rotation.z = -0.03;
   root.add(weaponHolder);
-
-  const buttonBase = new THREE.Mesh(
-    new THREE.CylinderGeometry(0.03, 0.035, 0.02, 24),
-    createCaptureVehicleMaterial('truck', { color: '#0f172a', roughness: 0.4, metalness: 0.34 })
-  );
-  buttonBase.position.set(0.074, 0.016, -0.022);
-  root.add(buttonBase);
 
   const actionButton = new THREE.Mesh(
     new THREE.CylinderGeometry(0.024, 0.026, 0.015, 28),
@@ -669,7 +695,7 @@ async function createCaptureWeaponRackFx() {
     new THREE.MeshBasicMaterial({ transparent: true, opacity: 0 })
   );
   weaponRackHit.name = 'captureWeaponRackHit';
-  weaponRackHit.position.set(0.04, 0.032, -0.018);
+  weaponRackHit.position.set(0.078, 0.026, -0.024);
   root.add(weaponRackHit);
 
   return {
@@ -699,9 +725,14 @@ async function applyCaptureWeaponDisplay(entry, captureAnimationId) {
   entry.selectedCaptureAnimationId = captureAnimationId;
   entry.weaponHolder.clear();
   const clone = weaponModel.clone(true);
-  fitObjectToTargetSize(clone, CAPTURE_PARK_BOX_TARGET_SIZE * 1.06);
-  clone.rotation.y = Math.PI * 0.5;
-  clone.position.set(0, 0, -0.004);
+  const displayTuning = LARGE_RACK_FIREARM_IDS.has(captureAnimationId)
+    ? FIREARM_RACK_DISPLAY_TUNING.large
+    : SIDEARM_RACK_FIREARM_IDS.has(captureAnimationId)
+    ? FIREARM_RACK_DISPLAY_TUNING.sidearm
+    : FIREARM_RACK_DISPLAY_TUNING.default;
+  fitObjectToTargetSize(clone, CAPTURE_PARK_BOX_TARGET_SIZE * displayTuning.targetSizeMultiplier);
+  clone.position.set(...displayTuning.position);
+  clone.rotation.set(...displayTuning.rotation);
   entry.weaponHolder.add(clone);
 }
 


### PR DESCRIPTION
### Motivation
- Replace generated emoji-style thumbnails with original source imagery so quick-swap and store cards show the real weapon art. 
- Make large firearms (rifles/snipers/shotguns/AK) visually bigger and visually positioned to the player-right so they match human scale. 
- Present small sidearms laid flatter on the table and remove the rounded support base under the rack to match requested visuals.

### Description
- Added `CAPTURE_WEAPON_SOURCE_THUMBNAILS` and switched key capture options (Glock, Pistol, Assault Rifle, AK-47, Smith, Shotgun, Sniper) to use the source-hosted image URLs for thumbnails in `webapp/src/config/ludoBattleOptions.js`. 
- Introduced `LARGE_RACK_FIREARM_IDS`, `SIDEARM_RACK_FIREARM_IDS` and `FIREARM_RACK_DISPLAY_TUNING` and used these buckets in `applyCaptureWeaponDisplay` so each weapon group uses a tuned `targetSizeMultiplier`, `position`, and `rotation` when rendered in the rack in `webapp/src/pages/Games/LudoBattleRoyal.jsx`. 
- Shifted the weapon rack anchor (`weaponHolder` / `weaponRackHit`) toward the player-right area and removed the rounded `buttonBase` support mesh under the action button to simplify the under-weapon support visual. 
- Updated the rack display flow to call `fitObjectToTargetSize` with the tuned multipliers and to set per-weapon rotation/position so large weapons stand more upright and sidearms lie flatter.

### Testing
- Ran `npx eslint webapp/src/config/ludoBattleOptions.js webapp/src/pages/Games/LudoBattleRoyal.jsx` which produced no lint errors (repository ignore rules produced warnings but no blocking errors). 
- No automated visual/UI snapshot tests were run in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef2e40770c8329900126d8c340731e)