### PR TITLE
Ludo: use source thumbnails and improve weapon rack presentation

### DIFF
--- a/webapp/src/config/ludoBattleOptions.js
+++ b/webapp/src/config/ludoBattleOptions.js
@@ -115,6 +115,8 @@ const captureWeaponThumb = (icon = '⚔️', accent = '#0ea5e9') =>
       <text x="160" y="112" text-anchor="middle" font-size="72">${icon}</text>
     </svg>`
   )}`;
+const githubRepoThumb = (repo, cacheKey = 'ludo-capture') =>
+  `https://opengraph.githubassets.com/${encodeURIComponent(cacheKey)}/${repo}`;
 
 export const CAPTURE_ANIMATION_OPTIONS = Object.freeze([
   {
@@ -163,19 +165,19 @@ export const CAPTURE_ANIMATION_OPTIONS = Object.freeze([
     id: 'glockSidearmAttack',
     label: 'Glock Sidearm',
     description: 'Pick the Glock from the table, aim, and fire before taking the tile.',
-    thumbnail: captureWeaponThumb('🔫', '#2563eb')
+    thumbnail: githubRepoThumb('webaverse/pistol', 'glock-sidearm')
   },
   {
     id: 'pistolSidearmAttack',
     label: 'Pistol Sidearm',
     description: 'Classic pistol takedown with right-hand pickup using original GLB textures.',
-    thumbnail: captureWeaponThumb('🔫', '#0284c7')
+    thumbnail: githubRepoThumb('webaverse/pistol', 'pistol-sidearm')
   },
   {
     id: 'assaultRifleAttack',
     label: 'Assault Rifle',
     description: 'AR burst capture with short aim hold and original GLB texture materials.',
-    thumbnail: captureWeaponThumb('🪖', '#334155')
+    thumbnail: githubRepoThumb('webaverse/pistol', 'assault-rifle')
   },
   {
     id: 'uziSprayAttack',
@@ -187,7 +189,7 @@ export const CAPTURE_ANIMATION_OPTIONS = Object.freeze([
     id: 'ak47VolleyAttack',
     label: 'AK-47 Volley',
     description: 'Heavy AK volley using Gunify AK47 GLTF textures with original material maps preserved.',
-    thumbnail: captureWeaponThumb('🪖', '#7f1d1d')
+    thumbnail: githubRepoThumb('KrishBharadwaj5678/Gunify', 'ak47-volley')
   },
   {
     id: 'krsvBurstAttack',
@@ -199,7 +201,7 @@ export const CAPTURE_ANIMATION_OPTIONS = Object.freeze([
     id: 'smithSidearmAttack',
     label: 'Smith Sidearm',
     description: 'Smith sidearm takedown with original Gunify texture maps.',
-    thumbnail: captureWeaponThumb('🔫', '#155e75')
+    thumbnail: githubRepoThumb('KrishBharadwaj5678/Gunify', 'smith-sidearm')
   },
   {
     id: 'mosinMarksmanAttack',
@@ -223,13 +225,13 @@ export const CAPTURE_ANIMATION_OPTIONS = Object.freeze([
     id: 'shotgunBlastAttack',
     label: 'Shotgun Blast',
     description: 'Short-range tactical shotgun blast with fast pickup timing.',
-    thumbnail: captureWeaponThumb('🧨', '#92400e')
+    thumbnail: githubRepoThumb('webaverse/pistol', 'shotgun-blast')
   },
   {
     id: 'sniperShotAttack',
     label: 'Sniper Shot',
     description: 'Precision long-barrel sniper takedown sequence.',
-    thumbnail: captureWeaponThumb('🎯', '#312e81')
+    thumbnail: githubRepoThumb('LazerMaker/gun-models-ak47-and-supprest-pistol-', 'sniper-shot')
   },
   {
     id: 'smgBurstAttack',

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -109,7 +109,7 @@ const CAPTURE_PARK_SIDE_SIGN_BY_TYPE = Object.freeze({
   helicopter: -1,
   drone: -1,
   missile: 1,
-  firearmRack: -1
+  firearmRack: 1
 });
 const CAPTURE_PARK_OUTWARD_OFFSET = 0.03;
 const CAPTURE_PARK_FORWARD_OFFSET_BY_TYPE = {
@@ -154,6 +154,23 @@ const FIREARM_CAPTURE_ANIMATION_IDS = new Set([
   'smgBurstAttack',
   'compactCarbineAttack',
   'marksmanDmrAttack'
+]);
+const LARGE_FIREARM_CAPTURE_ANIMATION_IDS = new Set([
+  'assaultRifleAttack',
+  'ak47VolleyAttack',
+  'mosinMarksmanAttack',
+  'shotgunBlastAttack',
+  'sniperShotAttack',
+  'marksmanDmrAttack',
+  'compactCarbineAttack',
+  'krsvBurstAttack'
+]);
+const SIDEARM_CAPTURE_ANIMATION_IDS = new Set([
+  'glockSidearmAttack',
+  'pistolSidearmAttack',
+  'smithSidearmAttack',
+  'pistolHolsterAttack',
+  'sigsauerTacticalAttack'
 ]);
 const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   mrtkGunAttack: {
@@ -699,9 +716,26 @@ async function applyCaptureWeaponDisplay(entry, captureAnimationId) {
   entry.selectedCaptureAnimationId = captureAnimationId;
   entry.weaponHolder.clear();
   const clone = weaponModel.clone(true);
-  fitObjectToTargetSize(clone, CAPTURE_PARK_BOX_TARGET_SIZE * 1.06);
-  clone.rotation.y = Math.PI * 0.5;
-  clone.position.set(0, 0, -0.004);
+  const isLargeWeapon = LARGE_FIREARM_CAPTURE_ANIMATION_IDS.has(captureAnimationId);
+  const isSidearm = SIDEARM_CAPTURE_ANIMATION_IDS.has(captureAnimationId);
+  clone.traverse((node) => {
+    if (!node?.isMesh) return;
+    const nodeName = String(node.name || '').toLowerCase();
+    if (isSidearm && /(support|stand|holder|pedestal|round)/i.test(nodeName)) {
+      node.parent?.remove?.(node);
+    }
+  });
+  fitObjectToTargetSize(clone, CAPTURE_PARK_BOX_TARGET_SIZE * (isLargeWeapon ? 1.95 : isSidearm ? 1.25 : 1.45));
+  if (isSidearm) {
+    clone.rotation.set(-Math.PI * 0.5, Math.PI * 0.52, 0);
+    clone.position.set(0.012, 0.001, -0.008);
+  } else if (isLargeWeapon) {
+    clone.rotation.set(0, Math.PI * 0.5, 0);
+    clone.position.set(0.012, 0, -0.008);
+  } else {
+    clone.rotation.set(-Math.PI * 0.12, Math.PI * 0.5, 0);
+    clone.position.set(0.01, 0, -0.006);
+  }
   entry.weaponHolder.add(clone);
 }
 
@@ -11231,7 +11265,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
                       <img
                         src={option.thumbnail}
                         alt={`${option.label} thumbnail`}
-                        className="h-16 w-full object-cover"
+                        className="h-16 w-full bg-slate-950/60 object-contain p-1"
                         loading="lazy"
                       />
                     ) : (

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -3223,7 +3223,7 @@ export default function Store() {
                   <img
                     src={detailMedia.zoom}
                     alt={`${detailMedia.alt} zoom preview`}
-                    className="h-56 w-full object-cover transition duration-300 ease-out group-hover:scale-[1.02]"
+                    className="h-56 w-full bg-black/50 object-contain p-2 transition duration-300 ease-out group-hover:scale-[1.02]"
                     loading="lazy"
                   />
                   <div className="absolute inset-0 bg-gradient-to-br from-black/20 via-transparent to-black/70" />


### PR DESCRIPTION
### Motivation
- Ensure quick-swap and store thumbnails show original source imagery instead of generated emoji cards for clearer UI readability.
- Make parked weapons visually correct for portrait mobile: large long guns should appear bigger and standing at the player’s right, while small sidearms should lie flat on the table with their support stands removed.

### Description
- Replaced several capture option thumbnails to pull repo-based source images by adding `githubRepoThumb` and updating entries in `webapp/src/config/ludoBattleOptions.js` for Glock/Pistol/AR/AK47/Shotgun/Sniper/Smith variants.
- Changed quick-swap popup thumbnail rendering in `webapp/src/pages/Games/LudoBattleRoyal.jsx` to preserve original aspect using `object-contain` and added subtle background/padding for consistent framing.
- Updated store detail zoom preview in `webapp/src/pages/Store.jsx` to use `object-contain` so source images retain original composition.
- Reworked weapon display logic in `webapp/src/pages/Games/LudoBattleRoyal.jsx` by adding `LARGE_FIREARM_CAPTURE_ANIMATION_IDS` and `SIDEARM_CAPTURE_ANIMATION_IDS`, moving firearm rack anchoring to the player right side, scaling large weapons up, laying sidearms flat, and removing support/stand/round meshes when rendering sidearms.

### Testing
- Built the web client with `npm --prefix webapp run build` and the production build completed successfully.
- No automated unit tests were run against these UI/display changes in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef2e40770c8329900126d8c340731e)