### PR TITLE
Tune Snooker human cue stance and harden GLTF texture visibility

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -109,8 +109,8 @@ const BILARDO_REFERENCE_TABLE_TOP_Y = 0.84;
 const BILARDO_REFERENCE_HUMAN_HEIGHT = BILARDO_REFERENCE_TABLE_TOP_Y * 2;
 const SNOOKER_HUMAN_BASE_SCALE = 1.32;
 const SNOOKER_HUMAN_VISUAL_SCALE_BOOST = 2.22;
-const SNOOKER_HUMAN_EDGE_MARGIN_FACTOR = 6.9;
-const SNOOKER_HUMAN_DESIRED_SHOOT_DISTANCE_FACTOR = 16.6;
+const SNOOKER_HUMAN_EDGE_MARGIN_FACTOR = 4.9;
+const SNOOKER_HUMAN_DESIRED_SHOOT_DISTANCE_FACTOR = 18.8;
 
 function safePolygonUnion(...parts) {
   const valid = parts.filter(Boolean);
@@ -20790,7 +20790,7 @@ const powerRef = useRef(hud.power);
       const bilardoSharedPose = {
         bridgeHandBackFromBall: 0.245,
         bridgeHandSide: -0.008,
-        gripRatio: 0.76,
+        gripRatio: 0.78,
         idleRightOffset: new THREE.Vector3(0.24, 1.12, 0.02),
         idleLeftOffset: new THREE.Vector3(-0.18, 1.08, 0.03)
       };
@@ -25316,8 +25316,8 @@ const powerRef = useRef(hud.power);
           const rootTarget = chooseHumanEdgePosition(cueBallWorld, aimForward, {
             tableW: PLAY_W,
             tableL: PLAY_H,
-            edgeMargin: Math.max(BALL_R * SNOOKER_HUMAN_EDGE_MARGIN_FACTOR, SIDE_RAIL_INNER_THICKNESS * 1.65),
-            desiredShootDistance: Math.max(cueLen * 0.54, BALL_R * SNOOKER_HUMAN_DESIRED_SHOOT_DISTANCE_FACTOR)
+            edgeMargin: Math.max(BALL_R * SNOOKER_HUMAN_EDGE_MARGIN_FACTOR, SIDE_RAIL_INNER_THICKNESS * 1.2),
+            desiredShootDistance: Math.max(cueLen * 0.56, BALL_R * SNOOKER_HUMAN_DESIRED_SHOOT_DISTANCE_FACTOR)
           });
           rootTarget.y = FLOOR_Y + Math.max(BALL_R * 0.08, 0.03);
           const aimSide = new THREE.Vector3(aimForward.z, 0, -aimForward.x).normalize();
@@ -25328,7 +25328,8 @@ const powerRef = useRef(hud.power);
             .setY(BALL_CENTER_Y - BALL_R + BALL_R * 0.24);
           const gripTarget = humanPoseContext.cueTip
             .clone()
-            .lerp(humanPoseContext.cueBack.clone(), bilardoSharedPose.gripRatio);
+            .lerp(humanPoseContext.cueBack.clone(), bilardoSharedPose.gripRatio)
+            .addScaledVector(aimForward, -0.016);
           const standingYaw = Math.atan2(-aimForward.x, -aimForward.z);
           const upAxis = new THREE.Vector3(0, 1, 0);
           const idleRight = rootTarget

--- a/webapp/src/pages/Games/shared/bilardoHumanRig.js
+++ b/webapp/src/pages/Games/shared/bilardoHumanRig.js
@@ -13,6 +13,28 @@ const dampScalar = (current, target, lambda, dt) =>
 const yawFromForward = (forward) => Math.atan2(-forward.x, -forward.z);
 
 const cleanName = (name) => String(name || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+let fallbackHumanAlbedoTexture = null;
+
+function getFallbackHumanAlbedoTexture() {
+  if (fallbackHumanAlbedoTexture) return fallbackHumanAlbedoTexture;
+  const canvas = globalThis?.document?.createElement?.('canvas');
+  if (!canvas) return null;
+  canvas.width = 4;
+  canvas.height = 4;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return null;
+  ctx.fillStyle = '#c7a88d';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  ctx.fillStyle = '#8b6c54';
+  ctx.fillRect(0, 0, 2, 2);
+  ctx.fillRect(2, 2, 2, 2);
+  const tex = new THREE.CanvasTexture(canvas);
+  tex.colorSpace = THREE.SRGBColorSpace;
+  tex.flipY = false;
+  tex.needsUpdate = true;
+  fallbackHumanAlbedoTexture = tex;
+  return fallbackHumanAlbedoTexture;
+}
 
 function makeBasisQuaternion(side, up, forward) {
   BASIS_MAT.makeBasis(
@@ -187,12 +209,27 @@ export function createBilardoHumanRig(scene, opts = {}) {
             ? [obj.material]
             : [];
         mats.forEach((m) => {
-          if (m?.map) {
-            m.map.colorSpace = THREE.SRGBColorSpace;
-            m.map.anisotropy = Math.max(m.map.anisotropy || 1, opts?.textureAnisotropy ?? 8);
-            m.map.needsUpdate = true;
+          if (!m) return;
+          const ensureTexture = (tex, isColor = false) => {
+            if (!tex) return;
+            if (isColor) tex.colorSpace = THREE.SRGBColorSpace;
+            tex.flipY = false;
+            tex.anisotropy = Math.max(tex.anisotropy || 1, opts?.textureAnisotropy ?? 8);
+            tex.needsUpdate = true;
+          };
+          if (!m.map) {
+            m.map = getFallbackHumanAlbedoTexture();
           }
-          if (m) m.needsUpdate = true;
+          ensureTexture(m.map, true);
+          ensureTexture(m.emissiveMap, true);
+          ensureTexture(m.normalMap, false);
+          ensureTexture(m.roughnessMap, false);
+          ensureTexture(m.metalnessMap, false);
+          ensureTexture(m.aoMap, false);
+          if (m.color?.setHex) m.color.setHex(0xffffff);
+          if (typeof m.opacity === 'number' && m.opacity < 1) m.opacity = 1;
+          if (m.transparent) m.transparent = false;
+          m.needsUpdate = true;
         });
       });
       human.bones = buildAvatarBones(model);


### PR DESCRIPTION
### Motivation
- Align the Snooker Royal human actor and cue so the player sits closer to the table and holds the cue like the Bilardo Shqip reference. 
- Make imported GLTF human materials more robust so characters are visible when assets lack expected texture maps or when texture flags (KTX2/DRACO/meshopt) vary across platforms. 

### Description
- Adjusted Snooker human placement and aiming parameters by changing `SNOOKER_HUMAN_EDGE_MARGIN_FACTOR` and `SNOOKER_HUMAN_DESIRED_SHOOT_DISTANCE_FACTOR` in `SnookerRoyal.jsx`. 
- Tightened right-hand cue grip by increasing `gripRatio` from `0.76` to `0.78` and added a small forward offset to the computed `gripTarget` so the cue sits more consistently in the hand. 
- When computing the human `rootTarget` for Snooker, reduced the rail margin clamp and slightly increased the cue distance fallback so the character moves closer to the table edge. 
- Hardened GLTF material handling in `shared/bilardoHumanRig.js` by adding `getFallbackHumanAlbedoTexture()` (a small canvas texture) and normalizing texture/material properties (set `colorSpace`, `flipY`, `anisotropy`, `needsUpdate`, force white base color, enforce non-transparent/opaque) across `map`, `emissiveMap`, `normalMap`, `roughnessMap`, `metalnessMap`, and `aoMap` to avoid invisible/flat human renders when maps are missing or metadata differs. 

### Testing
- Ran ESLint on the changed files with `npx eslint webapp/src/pages/Games/SnookerRoyal.jsx webapp/src/pages/Games/shared/bilardoHumanRig.js`, which produced warnings only due to repository ignore patterns and no lint errors. 
- No automated runtime/visual tests were available in this environment; visual verification should be performed in-browser to confirm hand/cue alignment and character texture visibility.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef2fc243dc832991abcee58ece4d3b)