### PR TITLE
Use external weapon thumbnails and refine firearm rack display in Ludo Battle

### DIFF
--- a/webapp/src/config/ludoBattleInventoryConfig.js
+++ b/webapp/src/config/ludoBattleInventoryConfig.js
@@ -147,7 +147,7 @@ export const LUDO_BATTLE_STORE_ITEMS = uniqueStoreItemsByName([
     name: option.label,
     price: 950 + idx * 120,
     description: option.description,
-    thumbnail: option.thumbnail || swatchThumbnail(['#0f172a', '#1d4ed8', '#f97316'])
+    thumbnail: option.thumbnail || ''
   })),
   ...HUMAN_CHARACTER_OPTIONS.slice(1).map((option, idx) => ({
     id: `ludo-human-character-${option.id}`,

--- a/webapp/src/config/ludoBattleOptions.js
+++ b/webapp/src/config/ludoBattleOptions.js
@@ -116,6 +116,25 @@ const captureWeaponThumb = (icon = '⚔️', accent = '#0ea5e9') =>
     </svg>`
   )}`;
 
+const CAPTURE_WEAPON_SOURCE_THUMBNAILS = Object.freeze({
+  uziSprayAttack:
+    'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models2/Uzi/textures/Material__90_baseColor.png',
+  ak47VolleyAttack:
+    'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/AK47/textures/Material.001_baseColor.png',
+  krsvBurstAttack:
+    'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/KRSV/textures/Steel_baseColor.png',
+  smithSidearmAttack:
+    'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/Smith/textures/Wood_baseColor.jpeg',
+  mosinMarksmanAttack:
+    'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models2/Mosin/textures/Mosin_baseColor.png',
+  sigsauerTacticalAttack:
+    'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models3/SigSauer/textures/Material.003_diffuse.png',
+  shotgunBlastAttack:
+    'https://raw.githubusercontent.com/lando19/Guns-for-BJS-FPS-Game/main/main/textures/shotgun_baseColor.png',
+  sniperShotAttack:
+    'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models2/Mosin/textures/Mosin_baseColor.png'
+});
+
 export const CAPTURE_ANIMATION_OPTIONS = Object.freeze([
   {
     id: 'missileJavelin',
@@ -163,55 +182,55 @@ export const CAPTURE_ANIMATION_OPTIONS = Object.freeze([
     id: 'glockSidearmAttack',
     label: 'Glock Sidearm',
     description: 'Pick the Glock from the table, aim, and fire before taking the tile.',
-    thumbnail: captureWeaponThumb('🔫', '#2563eb')
+    thumbnail: CAPTURE_WEAPON_SOURCE_THUMBNAILS.glockSidearmAttack
   },
   {
     id: 'pistolSidearmAttack',
     label: 'Pistol Sidearm',
     description: 'Classic pistol takedown with right-hand pickup using original GLB textures.',
-    thumbnail: captureWeaponThumb('🔫', '#0284c7')
+    thumbnail: CAPTURE_WEAPON_SOURCE_THUMBNAILS.pistolSidearmAttack
   },
   {
     id: 'assaultRifleAttack',
     label: 'Assault Rifle',
     description: 'AR burst capture with short aim hold and original GLB texture materials.',
-    thumbnail: captureWeaponThumb('🪖', '#334155')
+    thumbnail: CAPTURE_WEAPON_SOURCE_THUMBNAILS.assaultRifleAttack
   },
   {
     id: 'uziSprayAttack',
     label: 'Uzi Spray',
     description: 'Fast SMG capture variation inspired by Tirana 2040 Uzi loadout.',
-    thumbnail: captureWeaponThumb('🔫', '#1e293b')
+    thumbnail: CAPTURE_WEAPON_SOURCE_THUMBNAILS.uziSprayAttack
   },
   {
     id: 'ak47VolleyAttack',
     label: 'AK-47 Volley',
     description: 'Heavy AK volley using Gunify AK47 GLTF textures with original material maps preserved.',
-    thumbnail: captureWeaponThumb('🪖', '#7f1d1d')
+    thumbnail: CAPTURE_WEAPON_SOURCE_THUMBNAILS.ak47VolleyAttack
   },
   {
     id: 'krsvBurstAttack',
     label: 'KRSV Burst',
     description: 'KRSV firearm burst using Gunify GLTF textures/material mapping.',
-    thumbnail: captureWeaponThumb('🎖️', '#6d28d9')
+    thumbnail: CAPTURE_WEAPON_SOURCE_THUMBNAILS.krsvBurstAttack
   },
   {
     id: 'smithSidearmAttack',
     label: 'Smith Sidearm',
     description: 'Smith sidearm takedown with original Gunify texture maps.',
-    thumbnail: captureWeaponThumb('🔫', '#155e75')
+    thumbnail: CAPTURE_WEAPON_SOURCE_THUMBNAILS.smithSidearmAttack
   },
   {
     id: 'mosinMarksmanAttack',
     label: 'Mosin Marksman',
     description: 'Mosin long-range strike using Gunify GLTF textures and preserved materials.',
-    thumbnail: captureWeaponThumb('🎯', '#0f172a')
+    thumbnail: CAPTURE_WEAPON_SOURCE_THUMBNAILS.mosinMarksmanAttack
   },
   {
     id: 'sigsauerTacticalAttack',
     label: 'SigSauer Tactical',
     description: 'SigSauer tactical burst using Gunify GLTF texture/material files.',
-    thumbnail: captureWeaponThumb('🔫', '#1d4ed8')
+    thumbnail: CAPTURE_WEAPON_SOURCE_THUMBNAILS.sigsauerTacticalAttack
   },
   {
     id: 'grenadeBlastAttack',
@@ -223,13 +242,13 @@ export const CAPTURE_ANIMATION_OPTIONS = Object.freeze([
     id: 'shotgunBlastAttack',
     label: 'Shotgun Blast',
     description: 'Short-range tactical shotgun blast with fast pickup timing.',
-    thumbnail: captureWeaponThumb('🧨', '#92400e')
+    thumbnail: CAPTURE_WEAPON_SOURCE_THUMBNAILS.shotgunBlastAttack
   },
   {
     id: 'sniperShotAttack',
     label: 'Sniper Shot',
     description: 'Precision long-barrel sniper takedown sequence.',
-    thumbnail: captureWeaponThumb('🎯', '#312e81')
+    thumbnail: CAPTURE_WEAPON_SOURCE_THUMBNAILS.sniperShotAttack
   },
   {
     id: 'smgBurstAttack',

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -155,6 +155,27 @@ const FIREARM_CAPTURE_ANIMATION_IDS = new Set([
   'compactCarbineAttack',
   'marksmanDmrAttack'
 ]);
+const LARGE_RACK_FIREARM_IDS = new Set([
+  'assaultRifleAttack',
+  'ak47VolleyAttack',
+  'mosinMarksmanAttack',
+  'shotgunBlastAttack',
+  'sniperShotAttack',
+  'marksmanDmrAttack',
+  'compactCarbineAttack'
+]);
+const FIREARM_RACK_DISPLAY_TUNING = Object.freeze({
+  default: Object.freeze({
+    targetSizeMultiplier: 1.06,
+    position: [0, 0, -0.004],
+    rotation: [0, Math.PI * 0.5, 0]
+  }),
+  large: Object.freeze({
+    targetHeight: 0.42,
+    position: [0.078, 0, -0.018],
+    rotation: [0, Math.PI * 0.5, 0]
+  })
+});
 const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   mrtkGunAttack: {
     label: 'MRTK Gun',
@@ -637,16 +658,9 @@ async function attachFirearmToRightHand(attackerEntry, captureAnimationId) {
 async function createCaptureWeaponRackFx() {
   const root = new THREE.Group();
   const weaponHolder = new THREE.Group();
-  weaponHolder.position.set(0.04, 0.032, -0.018);
-  weaponHolder.rotation.z = -0.08;
+  weaponHolder.position.set(0.078, 0.026, -0.024);
+  weaponHolder.rotation.z = -0.03;
   root.add(weaponHolder);
-
-  const buttonBase = new THREE.Mesh(
-    new THREE.CylinderGeometry(0.03, 0.035, 0.02, 24),
-    createCaptureVehicleMaterial('truck', { color: '#0f172a', roughness: 0.4, metalness: 0.34 })
-  );
-  buttonBase.position.set(0.074, 0.016, -0.022);
-  root.add(buttonBase);
 
   const actionButton = new THREE.Mesh(
     new THREE.CylinderGeometry(0.024, 0.026, 0.015, 28),
@@ -669,7 +683,7 @@ async function createCaptureWeaponRackFx() {
     new THREE.MeshBasicMaterial({ transparent: true, opacity: 0 })
   );
   weaponRackHit.name = 'captureWeaponRackHit';
-  weaponRackHit.position.set(0.04, 0.032, -0.018);
+  weaponRackHit.position.set(0.078, 0.026, -0.024);
   root.add(weaponRackHit);
 
   return {
@@ -699,9 +713,18 @@ async function applyCaptureWeaponDisplay(entry, captureAnimationId) {
   entry.selectedCaptureAnimationId = captureAnimationId;
   entry.weaponHolder.clear();
   const clone = weaponModel.clone(true);
-  fitObjectToTargetSize(clone, CAPTURE_PARK_BOX_TARGET_SIZE * 1.06);
-  clone.rotation.y = Math.PI * 0.5;
-  clone.position.set(0, 0, -0.004);
+  const isLargeRackFirearm = LARGE_RACK_FIREARM_IDS.has(captureAnimationId);
+  const displayTuning = isLargeRackFirearm
+    ? FIREARM_RACK_DISPLAY_TUNING.large
+    : FIREARM_RACK_DISPLAY_TUNING.default;
+  if (isLargeRackFirearm) {
+    fitObjectToTargetHeight(clone, displayTuning.targetHeight);
+    alignObjectBottomToY(clone, 0);
+  } else {
+    fitObjectToTargetSize(clone, CAPTURE_PARK_BOX_TARGET_SIZE * displayTuning.targetSizeMultiplier);
+  }
+  clone.position.set(...displayTuning.position);
+  clone.rotation.set(...displayTuning.rotation);
   entry.weaponHolder.add(clone);
 }
 


### PR DESCRIPTION
### Motivation
- Improve visual fidelity by using real source thumbnails for firearm capture animations instead of generated swatches. 
- Adjust weapon rack positioning and sizing to better accommodate large firearm models so displays look consistent. 

### Description
- Added `CAPTURE_WEAPON_SOURCE_THUMBNAILS` mapping and switched several `CAPTURE_ANIMATION_OPTIONS` entries to use those external thumbnail URLs. 
- Changed default capture animation thumbnail fallback to an empty string in `ludoBattleInventoryConfig.js` (`thumbnail: option.thumbnail || ''`). 
- Introduced `LARGE_RACK_FIREARM_IDS` and `FIREARM_RACK_DISPLAY_TUNING` and updated `applyCaptureWeaponDisplay` to select a large or default tuning, use `fitObjectToTargetHeight` + `alignObjectBottomToY` for large guns, and apply tuned position/rotation. 
- Tuned weapon rack placement in `createCaptureWeaponRackFx` by updating `weaponHolder` and `weaponRackHit` positions/rotation and removed the previous `buttonBase` mesh. 

### Testing
- Ran unit tests with `yarn test` and they passed. 
- Performed a production build with `yarn build` which completed successfully. 
- Ran linter with `yarn lint` and no issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef2e40770c8329900126d8c340731e)