### PR TITLE
Improve Snooker human cue alignment and GLTF material compatibility

### DIFF
--- a/Assets/Scripts/Gameplay/CueController.cs
+++ b/Assets/Scripts/Gameplay/CueController.cs
@@ -26,6 +26,12 @@ namespace Aiming
         public float contactTipGap = 0.001f;
         public float baseCueOffset = 0.12f;
         public float pullRange = 0.34f;
+        [Tooltip("Optional world-space anchor (usually grip hand) that keeps cue stick seated inside the player's hand.")]
+        public Transform externalGripAnchor;
+        [Tooltip("Distance from cue root to hand grip point used when locking cue to hand.")]
+        [Range(0.05f, 1.2f)] public float externalGripDistanceFromCueRoot = 0.36f;
+        [Tooltip("Small world-space offset to fine-tune cue seating in palm/fingers when hand lock is enabled.")]
+        public Vector3 externalGripWorldOffset = new Vector3(0f, 0.012f, 0f);
 
         [Header("Aiming feel")]
         [Range(1f, 30f)] public float rotationDamping = 14f;
@@ -360,7 +366,8 @@ namespace Aiming
 
             Vector3 anchor = _cueAnchorPosition + spinOffset;
             float cueDistance = baseCueOffset + _currentCueDepth;
-            transform.position = anchor - (_aimDirection * cueDistance);
+            Vector3 defaultCueRoot = anchor - (_aimDirection * cueDistance);
+            transform.position = ResolveCueRootFromGripAnchor(defaultCueRoot, _aimDirection);
 
             Quaternion baseRotation = Quaternion.LookRotation(_aimDirection, Vector3.up);
             Quaternion wobbleRotation = Quaternion.AngleAxis(_dynamicWobble * Mathf.Rad2Deg, Vector3.up);
@@ -372,6 +379,18 @@ namespace Aiming
             }
 
             SyncCueCameraStroke();
+        }
+
+        Vector3 ResolveCueRootFromGripAnchor(Vector3 fallbackRoot, Vector3 aimDirection)
+        {
+            if (externalGripAnchor == null)
+            {
+                return fallbackRoot;
+            }
+
+            float gripDistance = Mathf.Max(0.05f, externalGripDistanceFromCueRoot);
+            Vector3 gripWorld = externalGripAnchor.position + externalGripWorldOffset;
+            return gripWorld - (aimDirection * gripDistance);
         }
 
         void SyncCueCameraStroke()

--- a/Assets/Scripts/Gameplay/PoolHumanPoseDriver.cs
+++ b/Assets/Scripts/Gameplay/PoolHumanPoseDriver.cs
@@ -37,7 +37,7 @@ namespace Aiming
         [Tooltip("Reference table width from source implementation.")]
         public float sourceTableWidth = 2f;
         public float edgeMargin = 0.21f;
-        public float desiredShootDistance = 0.74f;
+        public float desiredShootDistance = 0.65f;
         [Tooltip("Optional helper waypoints around table sides (left, right, bottom, top) for Bilardo-style perimeter walking.")]
         public Transform[] sideWalkHelpers;
         [Tooltip("Uniform character size multiplier. Values above 1 make the player visually bigger and heavier.")]
@@ -56,7 +56,7 @@ namespace Aiming
         public float gripRatio = 0.76f;
         public float stanceHeight = 0f;
         [Tooltip("How much closer to the table edge the chest/head moves while aiming.")]
-        [Range(0f, 0.2f)] public float tableLeanDepth = 0.08f;
+        [Range(0f, 0.2f)] public float tableLeanDepth = 0.11f;
         [Tooltip("Extra right-hand pull distance, matching the live power slider pullback.")]
         [Range(0f, 0.4f)] public float gripPullRange = 0.24f;
         [Tooltip("Right hand grip point from cue root towards cue tip (meters).")]
@@ -67,6 +67,8 @@ namespace Aiming
         [Range(0f, 0.18f)] public float chinToCueForwardBias = 0.085f;
         [Tooltip("Makes lead shoulder slightly lower for realistic bridge alignment.")]
         [Range(0f, 0.16f)] public float shoulderDrop = 0.055f;
+        [Tooltip("When enabled, cue root follows grip hand so stick always stays in palm/fingers (Bilardo-style).")]
+        public bool lockCueToGripHand = true;
 
         [Header("Visual fidelity")]
         [Tooltip("Renderers that should keep their original shared materials/textures (prevents accidental runtime overrides).")]
@@ -127,6 +129,13 @@ namespace Aiming
 
             float handPull = cueController.CurrentPullNormalized * gripPullRange * s;
             Vector3 gripHandTarget = ResolveRightHandGripTarget(aimForward, aimSide, bridgeHandTarget, handPull, s);
+
+            if (lockCueToGripHand && cueController != null)
+            {
+                cueController.externalGripAnchor = gripHand;
+                cueController.externalGripDistanceFromCueRoot = Mathf.Max(0.05f, rightHandGripFromCueRoot * s);
+                cueController.externalGripWorldOffset = (Vector3.up * (rightHandVerticalOffset * s)) + (aimSide * (0.012f * s));
+            }
 
             float standingYaw = YawFromForward(aimForward);
             Vector3 idleRightHandTarget = rootTarget + RotateAroundY(new Vector3(0.22f, 1.18f, 0.04f) * s, standingYaw);
@@ -516,7 +525,7 @@ namespace Aiming
                     Vector3 grip = cueRootPos + (cueDir * gripDistance);
                     grip += (cueDir * -handPull);
                     grip += (Vector3.up * (rightHandVerticalOffset * s));
-                    grip += (aimSide * (0.018f * s));
+                    grip += (aimSide * (0.012f * s));
                     return grip;
                 }
             }
@@ -524,7 +533,7 @@ namespace Aiming
             return fallbackTarget +
                    (aimForward * (-handPull)) +
                    (Vector3.up * (rightHandVerticalOffset * s)) +
-                   (aimSide * (0.022f * s));
+                   (aimSide * (0.012f * s));
         }
 
         void CacheRailHelpers()

--- a/Assets/Scripts/Gameplay/Rendering/GltfMaterialCompatibilityAdapter.cs
+++ b/Assets/Scripts/Gameplay/Rendering/GltfMaterialCompatibilityAdapter.cs
@@ -10,22 +10,41 @@ namespace Aiming.Gameplay.Rendering
     {
         [SerializeField] private Renderer[] targetRenderers;
         [SerializeField] private bool runOnAwake = true;
+        [SerializeField] private bool runOnEnable = true;
         [SerializeField] private bool forceUrpLitShader = true;
+        [SerializeField] private bool forceSupportedShaderSwap = true;
+        [SerializeField] private bool keepOpaqueByDefault = true;
         [SerializeField] private Shader urpLitShader;
         [SerializeField] private Shader standardShader;
 
         private static readonly int BaseMapId = Shader.PropertyToID("_BaseMap");
+        private static readonly int BaseColorMapId = Shader.PropertyToID("_BaseColorMap");
         private static readonly int MainTexId = Shader.PropertyToID("_MainTex");
         private static readonly int BaseColorId = Shader.PropertyToID("_BaseColor");
         private static readonly int ColorId = Shader.PropertyToID("_Color");
         private static readonly int BumpMapId = Shader.PropertyToID("_BumpMap");
+        private static readonly int NormalMapId = Shader.PropertyToID("_NormalMap");
         private static readonly int MetallicGlossMapId = Shader.PropertyToID("_MetallicGlossMap");
+        private static readonly int MetallicMapId = Shader.PropertyToID("_MetallicMap");
         private static readonly int OcclusionMapId = Shader.PropertyToID("_OcclusionMap");
         private static readonly int EmissionMapId = Shader.PropertyToID("_EmissionMap");
+        private static readonly int SurfaceId = Shader.PropertyToID("_Surface");
+        private static readonly int SrcBlendId = Shader.PropertyToID("_SrcBlend");
+        private static readonly int DstBlendId = Shader.PropertyToID("_DstBlend");
+        private static readonly int ZWriteId = Shader.PropertyToID("_ZWrite");
+        private static readonly int AlphaClipId = Shader.PropertyToID("_AlphaClip");
 
         void Awake()
         {
             if (runOnAwake)
+            {
+                ApplyCompatibilityPass();
+            }
+        }
+
+        void OnEnable()
+        {
+            if (runOnEnable)
             {
                 ApplyCompatibilityPass();
             }
@@ -70,7 +89,7 @@ namespace Aiming.Gameplay.Rendering
 
         private void EnsureSupportedShader(Material material)
         {
-            if (material.shader != null && material.shader.isSupported)
+            if (!forceSupportedShaderSwap && material.shader != null && material.shader.isSupported)
             {
                 return;
             }
@@ -107,10 +126,11 @@ namespace Aiming.Gameplay.Rendering
 
         private static void CopyPbrMaps(Material material)
         {
-            Texture baseTexture = FirstTexture(material, BaseMapId, MainTexId);
+            Texture baseTexture = FirstTexture(material, BaseMapId, BaseColorMapId, MainTexId);
             if (baseTexture != null)
             {
                 TrySetTexture(material, BaseMapId, baseTexture);
+                TrySetTexture(material, BaseColorMapId, baseTexture);
                 TrySetTexture(material, MainTexId, baseTexture);
             }
 
@@ -125,17 +145,19 @@ namespace Aiming.Gameplay.Rendering
                 material.SetColor(BaseColorId, mainColor);
             }
 
-            Texture normal = FirstTexture(material, BumpMapId);
+            Texture normal = FirstTexture(material, BumpMapId, NormalMapId);
             if (normal != null)
             {
                 TrySetTexture(material, BumpMapId, normal);
+                TrySetTexture(material, NormalMapId, normal);
                 material.EnableKeyword("_NORMALMAP");
             }
 
-            Texture metallic = FirstTexture(material, MetallicGlossMapId);
+            Texture metallic = FirstTexture(material, MetallicGlossMapId, MetallicMapId);
             if (metallic != null)
             {
                 TrySetTexture(material, MetallicGlossMapId, metallic);
+                TrySetTexture(material, MetallicMapId, metallic);
             }
 
             Texture occlusion = FirstTexture(material, OcclusionMapId);
@@ -150,6 +172,69 @@ namespace Aiming.Gameplay.Rendering
                 TrySetTexture(material, EmissionMapId, emission);
                 material.EnableKeyword("_EMISSION");
             }
+        }
+
+        void LateUpdate()
+        {
+            if (!keepOpaqueByDefault)
+            {
+                return;
+            }
+
+            Renderer[] renderers = ResolveRenderers();
+            for (int r = 0; r < renderers.Length; r++)
+            {
+                Renderer renderer = renderers[r];
+                if (renderer == null)
+                {
+                    continue;
+                }
+
+                Material[] materials = renderer.sharedMaterials;
+                for (int i = 0; i < materials.Length; i++)
+                {
+                    Material mat = materials[i];
+                    if (mat == null)
+                    {
+                        continue;
+                    }
+
+                    ForceOpaque(mat);
+                }
+            }
+        }
+
+        private static void ForceOpaque(Material material)
+        {
+            if (material.HasProperty(SurfaceId))
+            {
+                material.SetFloat(SurfaceId, 0f);
+            }
+
+            if (material.HasProperty(SrcBlendId))
+            {
+                material.SetFloat(SrcBlendId, (int)UnityEngine.Rendering.BlendMode.One);
+            }
+
+            if (material.HasProperty(DstBlendId))
+            {
+                material.SetFloat(DstBlendId, (int)UnityEngine.Rendering.BlendMode.Zero);
+            }
+
+            if (material.HasProperty(ZWriteId))
+            {
+                material.SetFloat(ZWriteId, 1f);
+            }
+
+            if (material.HasProperty(AlphaClipId))
+            {
+                material.SetFloat(AlphaClipId, 0f);
+            }
+
+            material.renderQueue = -1;
+            material.DisableKeyword("_ALPHATEST_ON");
+            material.DisableKeyword("_ALPHABLEND_ON");
+            material.DisableKeyword("_ALPHAPREMULTIPLY_ON");
         }
 
         private static Texture FirstTexture(Material material, params int[] texturePropertyIds)


### PR DESCRIPTION
### Motivation
- Make the Snooker Royal human pose and cue handling match Bilardo-style behavior so the player stands closer to the table and the cue remains seated in the hand. 
- Fix cases where imported GLTF/GLB character textures were not visible by adapting materials/shaders and remapping common PBR texture properties.

### Description
- PoolHumanPoseDriver: reduced `desiredShootDistance`, increased `tableLeanDepth`, tightened right-hand lateral offsets, and added `lockCueToGripHand` to drive grip anchor data into the cue system. (file: `Assets/Scripts/Gameplay/PoolHumanPoseDriver.cs`).
- CueController: added `externalGripAnchor`, `externalGripDistanceFromCueRoot`, and `externalGripWorldOffset` plus `ResolveCueRootFromGripAnchor(...)` to position the cue root from the grip hand when an external anchor is supplied (file: `Assets/Scripts/Gameplay/CueController.cs`).
- GltfMaterialCompatibilityAdapter: added `OnEnable` pass, broader PBR texture property mapping (BaseColor/BaseMap/MainTex, Normal/Bump, Metallic variants), optional forced shader swap, and a runtime opaque-enforcement pass to help keep imported textures visible across render pipelines (file: `Assets/Scripts/Gameplay/Rendering/GltfMaterialCompatibilityAdapter.cs`).

### Testing
- Ran a repository code check using `git diff --check -- Assets/Scripts/Gameplay/CueController.cs Assets/Scripts/Gameplay/PoolHumanPoseDriver.cs Assets/Scripts/Gameplay/Rendering/GltfMaterialCompatibilityAdapter.cs` which reported no whitespace/merge issues. 
- Verified file diffs and applied patches locally using the workspace CLI tools without errors. 
- No Unity editor/playmode or runtime graphics tests were executed in this environment, so visual verification and playmode smoke tests should be run in-editor before merging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef34beeb94832986eca10588ae67f7)