### PR TITLE
Add external weapon thumbnails and rack display tuning for firearm capture animations

### DIFF
--- a/webapp/src/config/ludoBattleOptions.js
+++ b/webapp/src/config/ludoBattleOptions.js
@@ -116,6 +116,20 @@ const captureWeaponThumb = (icon = '⚔️', accent = '#0ea5e9') =>
     </svg>`
   )}`;
 
+const CAPTURE_WEAPON_SOURCE_THUMBNAILS = Object.freeze({
+  glockSidearmAttack: 'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/images/SigSauer.jpg',
+  pistolSidearmAttack: 'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/images/Smith.jpeg',
+  assaultRifleAttack: 'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/images/AK47.jpeg',
+  ak47VolleyAttack:
+    'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/images/AK47.jpeg',
+  smithSidearmAttack:
+    'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/images/Smith.jpeg',
+  shotgunBlastAttack:
+    'https://raw.githubusercontent.com/lando19/Guns-for-BJS-FPS-Game/main/main/textures/shotgun_baseColor.png',
+  sniperShotAttack:
+    'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/images/Mosin.png'
+});
+
 export const CAPTURE_ANIMATION_OPTIONS = Object.freeze([
   {
     id: 'missileJavelin',
@@ -163,19 +177,19 @@ export const CAPTURE_ANIMATION_OPTIONS = Object.freeze([
     id: 'glockSidearmAttack',
     label: 'Glock Sidearm',
     description: 'Pick the Glock from the table, aim, and fire before taking the tile.',
-    thumbnail: captureWeaponThumb('🔫', '#2563eb')
+    thumbnail: CAPTURE_WEAPON_SOURCE_THUMBNAILS.glockSidearmAttack
   },
   {
     id: 'pistolSidearmAttack',
     label: 'Pistol Sidearm',
     description: 'Classic pistol takedown with right-hand pickup using original GLB textures.',
-    thumbnail: captureWeaponThumb('🔫', '#0284c7')
+    thumbnail: CAPTURE_WEAPON_SOURCE_THUMBNAILS.pistolSidearmAttack
   },
   {
     id: 'assaultRifleAttack',
     label: 'Assault Rifle',
     description: 'AR burst capture with short aim hold and original GLB texture materials.',
-    thumbnail: captureWeaponThumb('🪖', '#334155')
+    thumbnail: CAPTURE_WEAPON_SOURCE_THUMBNAILS.assaultRifleAttack
   },
   {
     id: 'uziSprayAttack',
@@ -187,7 +201,7 @@ export const CAPTURE_ANIMATION_OPTIONS = Object.freeze([
     id: 'ak47VolleyAttack',
     label: 'AK-47 Volley',
     description: 'Heavy AK volley using Gunify AK47 GLTF textures with original material maps preserved.',
-    thumbnail: captureWeaponThumb('🪖', '#7f1d1d')
+    thumbnail: CAPTURE_WEAPON_SOURCE_THUMBNAILS.ak47VolleyAttack
   },
   {
     id: 'krsvBurstAttack',
@@ -199,7 +213,7 @@ export const CAPTURE_ANIMATION_OPTIONS = Object.freeze([
     id: 'smithSidearmAttack',
     label: 'Smith Sidearm',
     description: 'Smith sidearm takedown with original Gunify texture maps.',
-    thumbnail: captureWeaponThumb('🔫', '#155e75')
+    thumbnail: CAPTURE_WEAPON_SOURCE_THUMBNAILS.smithSidearmAttack
   },
   {
     id: 'mosinMarksmanAttack',
@@ -223,13 +237,13 @@ export const CAPTURE_ANIMATION_OPTIONS = Object.freeze([
     id: 'shotgunBlastAttack',
     label: 'Shotgun Blast',
     description: 'Short-range tactical shotgun blast with fast pickup timing.',
-    thumbnail: captureWeaponThumb('🧨', '#92400e')
+    thumbnail: CAPTURE_WEAPON_SOURCE_THUMBNAILS.shotgunBlastAttack
   },
   {
     id: 'sniperShotAttack',
     label: 'Sniper Shot',
     description: 'Precision long-barrel sniper takedown sequence.',
-    thumbnail: captureWeaponThumb('🎯', '#312e81')
+    thumbnail: CAPTURE_WEAPON_SOURCE_THUMBNAILS.sniperShotAttack
   },
   {
     id: 'smgBurstAttack',

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -155,6 +155,27 @@ const FIREARM_CAPTURE_ANIMATION_IDS = new Set([
   'compactCarbineAttack',
   'marksmanDmrAttack'
 ]);
+const LARGE_RACK_FIREARM_IDS = new Set([
+  'assaultRifleAttack',
+  'ak47VolleyAttack',
+  'mosinMarksmanAttack',
+  'shotgunBlastAttack',
+  'sniperShotAttack',
+  'marksmanDmrAttack',
+  'compactCarbineAttack'
+]);
+const FIREARM_RACK_DISPLAY_TUNING = Object.freeze({
+  default: Object.freeze({
+    targetSizeMultiplier: 1.06,
+    position: [0, 0, -0.004],
+    rotation: [0, Math.PI * 0.5, 0]
+  }),
+  large: Object.freeze({
+    targetSizeMultiplier: 1.9,
+    position: [0.08, 0, -0.014],
+    rotation: [0, Math.PI * 0.04, Math.PI * 0.02]
+  })
+});
 const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   mrtkGunAttack: {
     label: 'MRTK Gun',
@@ -699,9 +720,19 @@ async function applyCaptureWeaponDisplay(entry, captureAnimationId) {
   entry.selectedCaptureAnimationId = captureAnimationId;
   entry.weaponHolder.clear();
   const clone = weaponModel.clone(true);
-  fitObjectToTargetSize(clone, CAPTURE_PARK_BOX_TARGET_SIZE * 1.06);
-  clone.rotation.y = Math.PI * 0.5;
-  clone.position.set(0, 0, -0.004);
+  const baseAlignPositionY = clone.position.y;
+  alignObjectBottomToY(clone, 0);
+  const displayTuning = LARGE_RACK_FIREARM_IDS.has(captureAnimationId)
+    ? FIREARM_RACK_DISPLAY_TUNING.large
+    : FIREARM_RACK_DISPLAY_TUNING.default;
+  fitObjectToTargetSize(clone, CAPTURE_PARK_BOX_TARGET_SIZE * displayTuning.targetSizeMultiplier);
+  if (!LARGE_RACK_FIREARM_IDS.has(captureAnimationId)) {
+    clone.position.y = baseAlignPositionY;
+  }
+  clone.position.x += displayTuning.position[0];
+  clone.position.y += displayTuning.position[1];
+  clone.position.z += displayTuning.position[2];
+  clone.rotation.set(...displayTuning.rotation);
   entry.weaponHolder.add(clone);
 }
 


### PR DESCRIPTION
### Motivation
- Provide realistic thumbnails for firearm capture animations by referencing external images instead of generated SVG placeholders.
- Improve visual presentation of weapon racks by adjusting scale, position, and rotation for larger firearm models so they display naturally in the capture park.

### Description
- Added `CAPTURE_WEAPON_SOURCE_THUMBNAILS` mapping with external image URLs and replaced SVG thumbnails for several firearm capture animation entries in `webapp/src/config/ludoBattleOptions.js` to use those images. 
- Introduced `LARGE_RACK_FIREARM_IDS` and `FIREARM_RACK_DISPLAY_TUNING` in `webapp/src/pages/Games/LudoBattleRoyal.jsx` to categorize large weapons and provide distinct `default` and `large` display tuning values. 
- Updated `applyCaptureWeaponDisplay` to align object bottoms, pick the appropriate `displayTuning` based on the weapon id, apply a `targetSizeMultiplier` when calling `fitObjectToTargetSize`, and adjust the clone's position and rotation from the selected tuning before adding to the `weaponHolder`.

### Testing
- No new automated tests were added for these UI/tuning changes. If available, run the frontend test suite and visual/manual checks to verify thumbnails and rack layouts render as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef2e40770c8329900126d8c340731e)