### PR TITLE
Snooker Royal: player POV, human rig and bridge-pose refinements

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -113,8 +113,10 @@ const SNOOKER_HUMAN_EDGE_MARGIN_FACTOR = 4.1;
 const SNOOKER_HUMAN_DESIRED_SHOOT_DISTANCE_FACTOR = 13.8;
 const SNOOKER_HUMAN_CAMERA_LOWERED_BLEND_THRESHOLD = 0.42;
 const SNOOKER_HUMAN_PULL_TO_POSE_THRESHOLD = 0.035;
-const SNOOKER_HUMAN_CUE_HAND_GRIP_RATIO = 0.76;
-const SNOOKER_HUMAN_CUE_GRIP_BACK_OFFSET = 0;
+const SNOOKER_HUMAN_CUE_HAND_GRIP_RATIO = 0.9;
+const SNOOKER_HUMAN_CUE_GRIP_BACK_OFFSET = -0.04;
+const SNOOKER_HUMAN_EYE_CAMERA_BLEND_START = 0.33;
+const SNOOKER_HUMAN_EYE_CAMERA_BLEND_END = 0.06;
 
 function safePolygonUnion(...parts) {
   const valid = parts.filter(Boolean);
@@ -13496,6 +13498,7 @@ const powerRef = useRef(hud.power);
   const broadcastCamerasRef = useRef(null);
   const lightingRigRef = useRef(null);
   const activeRenderCameraRef = useRef(null);
+  const humanActorRef = useRef(null);
   const pocketSwitchIntentRef = useRef(null);
   const lastPocketBallRef = useRef(null);
   const cameraBlendRef = useRef(ACTION_CAMERA_START_BLEND);
@@ -17864,6 +17867,43 @@ const powerRef = useRef(hud.power);
             }
           }
           camera.lookAt(lookTarget);
+          const cueViewBlend = THREE.MathUtils.clamp(
+            (SNOOKER_HUMAN_EYE_CAMERA_BLEND_START - (cameraBlendRef.current ?? 1)) /
+              Math.max(
+                SNOOKER_HUMAN_EYE_CAMERA_BLEND_START - SNOOKER_HUMAN_EYE_CAMERA_BLEND_END,
+                1e-4
+              ),
+            0,
+            1
+          );
+          if (cueViewBlend > 1e-4) {
+            const actor = humanActorRef.current;
+            const actorHead = new THREE.Vector3();
+            if (actor?.activeGlb && actor.bones?.head) {
+              actor.bones.head.getWorldPosition(actorHead);
+            } else if (actor?.root) {
+              actorHead.copy(actor.root.position).add(new THREE.Vector3(0, 1.52, 0));
+            }
+            if (actor && actorHead.lengthSq() > 1e-6) {
+              const cueBall = cue?.pos
+                ? new THREE.Vector3(cue.pos.x, BALL_CENTER_Y, cue.pos.y)
+                : lookTarget.clone();
+              const eyeForward = cueBall.clone().sub(actorHead).setY(0);
+              if (eyeForward.lengthSq() < 1e-6) eyeForward.set(0, 0, 1);
+              eyeForward.normalize();
+              const eyePos = actorHead
+                .clone()
+                .addScaledVector(eyeForward, BALL_R * 0.9)
+                .addScaledVector(UP, BALL_R * 0.1);
+              const eyeLook = cueBall
+                .clone()
+                .addScaledVector(eyeForward, BALL_R * 2.2)
+                .setY(BALL_CENTER_Y + BALL_R * 0.16);
+              camera.position.lerp(eyePos, cueViewBlend);
+              lookTarget.lerp(eyeLook, cueViewBlend);
+              camera.lookAt(lookTarget);
+            }
+          }
           renderCamera = camera;
           broadcastArgs.focusWorld =
             broadcastCamerasRef.current?.defaultFocusWorld ?? lookTarget;
@@ -20770,11 +20810,14 @@ const powerRef = useRef(hud.power);
         strikeTime: BILARDO_STRIKE_TIME_MS / 1000,
         moveLambda: 5.6,
         rotLambda: 8.5,
-        stanceWidth: 0.52,
+        stanceWidth: 0.46,
         bridgePalmTableLift: 0.012,
         chinToCueHeight: 0.11,
-        cueArmElbowRise: 0.43
+        cueArmElbowRise: 0.39,
+        upperBodyBend: 1,
+        legBend: 0.25
       });
+      humanActorRef.current = humanActor;
       humanActor.root.visible = true;
       const snookerTableTopFromGround = Math.max(
         0.25,
@@ -20803,6 +20846,8 @@ const powerRef = useRef(hud.power);
         aimDir: new THREE.Vector2(0, 1),
         power: 0,
         state: 'idle',
+        bridgePose: 'open',
+        bridgeHeightOffset: 0,
         cueBack: new THREE.Vector3(),
         cueTip: new THREE.Vector3()
       };
@@ -20816,6 +20861,10 @@ const powerRef = useRef(hud.power);
         }
         humanPoseContext.power = THREE.MathUtils.clamp(power ?? 0, 0, 1);
         humanPoseContext.state = options.state || humanPoseContext.state || 'idle';
+        if (options.bridgePose) humanPoseContext.bridgePose = options.bridgePose;
+        if (Number.isFinite(options.bridgeHeightOffset)) {
+          humanPoseContext.bridgeHeightOffset = options.bridgeHeightOffset;
+        }
         if (options.cueBack) humanPoseContext.cueBack.copy(options.cueBack);
         if (options.cueTip) humanPoseContext.cueTip.copy(options.cueTip);
       };
@@ -25351,11 +25400,28 @@ const powerRef = useRef(hud.power);
           });
           rootTarget.y = FLOOR_Y + Math.max(BALL_R * 0.08, 0.03);
           const aimSide = new THREE.Vector3(aimForward.z, 0, -aimForward.x).normalize();
+          const distToRailX = PLAY_W * 0.5 - Math.abs(cueBallWorld.x);
+          const distToRailZ = PLAY_H * 0.5 - Math.abs(cueBallWorld.z);
+          const railTightThreshold = BALL_R * 2.3;
+          const nearRail = Math.min(distToRailX, distToRailZ) <= railTightThreshold;
+          const requestedLowCamera = (cameraBlendRef.current ?? 1) <= SNOOKER_HUMAN_CAMERA_LOWERED_BLEND_THRESHOLD;
+          const strongPull = (humanPoseContext.power ?? 0) >= 0.7;
+          const bridgePose = nearRail ? 'rail' : strongPull ? 'closed' : requestedLowCamera ? 'low' : 'open';
+          const bridgeHeightOffset =
+            bridgePose === 'low'
+              ? -BALL_R * 0.02
+              : bridgePose === 'rail'
+                ? BALL_R * 0.015
+                : bridgePose === 'closed'
+                  ? BALL_R * 0.006
+                  : 0;
+          humanPoseContext.bridgePose = bridgePose;
+          humanPoseContext.bridgeHeightOffset = bridgeHeightOffset;
           const bridgeTarget = cueBallWorld
             .clone()
             .addScaledVector(aimForward, -bilardoSharedPose.bridgeHandBackFromBall)
             .addScaledVector(aimSide, bilardoSharedPose.bridgeHandSide)
-            .setY(BALL_CENTER_Y - BALL_R + BALL_R * 0.24);
+            .setY(BALL_CENTER_Y - BALL_R + BALL_R * 0.24 + bridgeHeightOffset);
           const gripTarget = humanPoseContext.cueTip
             .clone()
             .lerp(humanPoseContext.cueBack.clone(), bilardoSharedPose.gripRatio)
@@ -25386,7 +25452,9 @@ const powerRef = useRef(hud.power);
             idleLeft,
             cueBack: humanPoseContext.cueBack,
             cueTip: humanPoseContext.cueTip,
-            power: humanPoseContext.power
+            power: humanPoseContext.power,
+            bridgePose: humanPoseContext.bridgePose,
+            bridgeHeightOffset: humanPoseContext.bridgeHeightOffset
           });
         }
 

--- a/webapp/src/pages/Games/shared/bilardoHumanRig.js
+++ b/webapp/src/pages/Games/shared/bilardoHumanRig.js
@@ -181,6 +181,8 @@ export function createBilardoHumanRig(scene, opts = {}) {
       bridgePalmTableLift: opts.bridgePalmTableLift ?? 0.012,
       chinToCueHeight: opts.chinToCueHeight ?? 0.11,
       cueArmElbowRise: opts.cueArmElbowRise ?? 0.43,
+      upperBodyBend: opts.upperBodyBend ?? 1,
+      legBend: opts.legBend ?? 0.38,
       tableTopY: opts.tableTopY ?? 0.84
     }
   };
@@ -401,6 +403,34 @@ function poseFingers(fingers, mode, weight) {
       finger.rotation.z += (index ? -0.03 : ring ? 0.04 : pinky ? 0.07 : 0) * w;
       return;
     }
+    if (mode === 'closedBridge') {
+      if (thumb) {
+        finger.rotation.x += 0.18 * w;
+        finger.rotation.y += -0.56 * w;
+        finger.rotation.z += 0.26 * w;
+      } else if (index) {
+        finger.rotation.x += (base ? 0.38 : tip ? 0.58 : 0.68) * w;
+        finger.rotation.y += -0.12 * w;
+        finger.rotation.z += -0.2 * w;
+      } else if (middle || ring || pinky) {
+        finger.rotation.x += (base ? 0.24 : tip ? 0.4 : 0.5) * w;
+        finger.rotation.y += (ring || pinky ? 0.12 : 0.02) * w;
+        finger.rotation.z += (ring ? 0.08 : pinky ? 0.14 : 0.02) * w;
+      }
+      return;
+    }
+    if (mode === 'railBridge') {
+      if (thumb) {
+        finger.rotation.x += 0.05 * w;
+        finger.rotation.y += 0.35 * w;
+        finger.rotation.z += -0.22 * w;
+      } else {
+        finger.rotation.x += (base ? 0.06 : tip ? 0.1 : 0.14) * w;
+        finger.rotation.y += (ring || pinky ? 0.08 : -0.03) * w;
+        finger.rotation.z += (index ? -0.04 : ring ? 0.04 : pinky ? 0.09 : 0) * w;
+      }
+      return;
+    }
     if (thumb) {
       finger.rotation.x += -0.04 * w;
       finger.rotation.y += 0.62 * w;
@@ -527,7 +557,7 @@ function driveHuman(human, frame) {
     .clone()
     .addScaledVector(frame.forward, 0.012 * ik)
     .addScaledVector(frame.side, -0.006 * ik)
-    .addScaledVector(UP, -0.01 * ik);
+    .addScaledVector(UP, -0.01 * ik + (frame.bridgeHeightOffset ?? 0));
   const leftElbow = frame.leftElbow
     .clone()
     .addScaledVector(frame.forward, 0.02 * ik)
@@ -544,15 +574,32 @@ function driveHuman(human, frame) {
   );
   twistBone(b.leftUpperArm, frame.forward, -0.16 * ik);
   twistBone(b.leftLowerArm, frame.forward, 0.05 * ik);
+  const bridgePose = frame.bridgePose ?? 'open';
+  const bridgeRoll =
+    bridgePose === 'closed'
+      ? -0.1
+      : bridgePose === 'rail'
+        ? -0.3
+        : bridgePose === 'high'
+          ? -0.05
+          : -0.22;
   setHandBasis(
     b.leftHand,
     frame.side.clone().multiplyScalar(-1).addScaledVector(frame.forward, -0.2).normalize(),
     UP.clone().multiplyScalar(0.96).addScaledVector(frame.forward, -0.08).addScaledVector(frame.side, -0.04).normalize(),
     cueDir,
-    -0.22 * ik,
+    bridgeRoll * ik,
     0.98 * ik
   );
-  poseFingers(human.leftFingers, 'bridge', ik);
+  poseFingers(
+    human.leftFingers,
+    bridgePose === 'closed'
+      ? 'closedBridge'
+      : bridgePose === 'rail'
+        ? 'railBridge'
+        : 'bridge',
+    ik
+  );
 }
 
 export function chooseHumanEdgePosition(cueBallWorld, aimForward, opts = {}) {
@@ -678,17 +725,19 @@ export function updateBilardoHumanPose(human, dt, frameData) {
     .addScaledVector(UP, lerp(0.18, cfg.cueArmElbowRise, t))
     .addScaledVector(side, lerp(0.03, 0.07, t))
     .addScaledVector(forward, lerp(-0.03, 0, t));
+  const legBend = clamp01(cfg.legBend);
+  const upperBodyBend = clamp01(cfg.upperBodyBend);
   const leftKnee = leftHip
     .clone()
     .lerp(leftFoot, 0.53)
-    .addScaledVector(UP, lerp(0.18, 0.105, t))
-    .addScaledVector(forward, 0.052 * t)
+    .addScaledVector(UP, lerp(0.18, lerp(0.16, 0.1, legBend), t))
+    .addScaledVector(forward, 0.052 * t * legBend)
     .addScaledVector(side, -0.016 * t);
   const rightKnee = rightHip
     .clone()
     .lerp(rightFoot, 0.52)
-    .addScaledVector(UP, lerp(0.18, 0.08, t))
-    .addScaledVector(forward, -0.032 * t)
+    .addScaledVector(UP, lerp(0.18, lerp(0.16, 0.08, legBend), t))
+    .addScaledVector(forward, -0.032 * t * legBend)
     .addScaledVector(side, 0.018 * t);
 
   human.root.visible = true;
@@ -702,10 +751,10 @@ export function updateBilardoHumanPose(human, dt, frameData) {
     side,
     up: UP,
     rootWorld,
-    torsoCenterWorld: torso,
-    chestCenterWorld: chest,
-    neckWorld: neck,
-    headCenterWorld: head,
+    torsoCenterWorld: torso.clone().addScaledVector(forward, -0.06 * t * upperBodyBend),
+    chestCenterWorld: chest.clone().addScaledVector(forward, -0.12 * t * upperBodyBend),
+    neckWorld: neck.clone().addScaledVector(forward, -0.13 * t * upperBodyBend),
+    headCenterWorld: head.clone().addScaledVector(forward, -0.1 * t * upperBodyBend),
     leftElbow,
     rightElbow,
     leftHandWorld: leftHand,
@@ -715,6 +764,7 @@ export function updateBilardoHumanPose(human, dt, frameData) {
     leftFootWorld: leftFoot,
     rightFootWorld: rightFoot,
     cueBackWorld: frameData.cueBack,
-    cueTipWorld: frameData.cueTip
+    cueTipWorld: frameData.cueTip,
+    bridgePose: frameData.bridgePose ?? 'open'
   });
 }


### PR DESCRIPTION
### Motivation
- Improve player camera and human-shot fidelity so the view is from the character's eyes when the cue camera is lowered and the avatar posture/handing matches photographic references. 
- Make the left-hand bridge, finger poses, stance and upper-body bend behave correctly in different contexts (near-rail, closed bridge for strong pulls, low camera), and move the right-hand grip toward the cue butt for more realistic end-grip control. 

### Description
- Added eye-level POV blending into the cue camera path so when the cue camera is lowered it lerps toward the human head position and looks down the shot vector. 
- Introduced per-human-rig parameters `upperBodyBend` and `legBend` and reduced stance/leg spread to favor an upper-body-only lean, and tuned `cueArmElbowRise` and `stanceWidth` for Snooker Royal. 
- Implemented dynamic bridge selection (open / low / closed / rail) based on cue-ball-to-rail distance, pull strength and camera blend, and passed `bridgePose`/`bridgeHeightOffset` through the pose pipeline. 
- Extended `bilardoHumanRig` with dedicated finger modes (`closedBridge`, `railBridge`), adjusted left-hand basis roll per bridge pose, and applied bridge height offsets to left-hand positioning. 
- Shifted right-hand grip back by a small offset (`SNOOKER_HUMAN_CUE_GRIP_BACK_OFFSET`) so the avatar holds the cue nearer the butt for end-grip behavior used during shots. 
- Hooked the created human actor into a ref so camera blending can sample the avatar head world position and blend smoothly. 

### Testing
- Ran unit tests: `npm test -- --runInBand test/poolRoyaleCueStrokeTimeline.test.js` and the suite passed (4 tests, 1 suite). 
- Ran lint check: `npx eslint webapp/src/pages/Games/SnookerRoyal.jsx webapp/src/pages/Games/shared/bilardoHumanRig.js` which completed but reported the files are ignored by the current ESLint ignore settings (warnings only). 
- No runtime visual regression tests were run in this environment; changes focused on Snooker Royal camera/pose logic and shared human rig code only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef4a2167748329a35a85a0a5633d6f)