### PR TITLE
Fix Pool Royale slider power handoff on release

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -15539,6 +15539,7 @@ const manualShotStateRef = useRef('idle');
 const manualStrikeStartedAtRef = useRef(0);
 const manualStrikeDidHitRef = useRef(false);
 const manualStrikePowerRef = useRef(0);
+const lastSliderDragPowerRef = useRef(0);
 useEffect(() => {
   manualShotStateRef.current = manualShotState;
 }, [manualShotState]);
@@ -27290,6 +27291,7 @@ useEffect(() => {
         }
         const sourcePower = Math.max(
           Number.isFinite(committedPowerOverride) ? committedPowerOverride : 0,
+          Number.isFinite(lastSliderDragPowerRef.current) ? lastSliderDragPowerRef.current : 0,
           Number.isFinite(shotPowerRef.current) ? shotPowerRef.current : 0,
           Number.isFinite(powerRef.current) ? powerRef.current : 0
         );
@@ -33674,12 +33676,14 @@ useEffect(() => {
   }, [captureCueStickAnchor]);
   const onPowerDrag = useCallback((powerRatio = 0) => {
     const clamped = clampPower(powerRatio, 0);
+    lastSliderDragPowerRef.current = clamped;
     shotPowerRef.current = clamped;
     applyPower(clamped);
   }, [applyPower, clampPower]);
   const onPowerRelease = useCallback((powerRatio = null) => {
     const sourcePower = Math.max(
       Number.isFinite(powerRatio) ? powerRatio : 0,
+      Number.isFinite(lastSliderDragPowerRef.current) ? lastSliderDragPowerRef.current : 0,
       Number.isFinite(shotPowerRef.current) ? shotPowerRef.current : 0,
       Number.isFinite(powerRef.current) ? powerRef.current : 0
     );
@@ -33748,7 +33752,11 @@ useEffect(() => {
       onChange: (v) => onPowerDrag((v ?? 0) / 100),
       onStart: () => onPowerDragStart(),
       onCommit: (value) => {
-        const committedRatio = Number.isFinite(value) ? value / 100 : powerRef.current;
+        const sliderCommittedValue =
+          Number.isFinite(value) ? value : sliderInstanceRef.current?.get?.();
+        const committedRatio = Number.isFinite(sliderCommittedValue)
+          ? sliderCommittedValue / 100
+          : powerRef.current;
         onPowerRelease(clampPower(committedRatio, 0));
       }
     });


### PR DESCRIPTION
### Motivation
- Players reported the pull-slider sometimes failed to deliver the intended power to the cue-ball when releasing the slider, typically when the commit payload was missing or stale.
- The goal is to preserve the live dragged power through release and into the `fire()` resolution so pull → release → shot behaves predictably.

### Description
- Added `lastSliderDragPowerRef` to record the latest live drag value during slider interaction in `webapp/src/pages/Games/PoolRoyale.jsx`.
- Use `lastSliderDragPowerRef` as an additional fallback when computing source power for both the manual release path and the final `fire()` shot resolution so the most-recent drag value is honored.
- Hardened slider `onCommit` handling to fall back to the slider instance current value (`sliderInstanceRef.current?.get?.()`) when the `onCommit` argument is not a finite number, then normalize it to a ratio before calling the release handler.

### Testing
- Ran the project linter: `npx eslint webapp/src/pages/Games/PoolRoyale.jsx` and `npx eslint --no-ignore webapp/src/pages/Games/PoolRoyale.jsx`; ESLint reported the file is ignored by project ignore rules but produced no lint errors.
- Verified the modified code compiles locally (no runtime build/test suite executed in this rollout).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef450c21348329b9d09b45357cd687)