### PR TITLE
Player-eye cue camera + improved human pose and bridge logic for Snooker Royal

### DIFF
--- a/Assets/Scripts/Gameplay/PoolHumanPoseDriver.cs
+++ b/Assets/Scripts/Gameplay/PoolHumanPoseDriver.cs
@@ -60,7 +60,7 @@ namespace Aiming
         [Tooltip("Extra right-hand pull distance, matching the live power slider pullback.")]
         [Range(0f, 0.4f)] public float gripPullRange = 0.24f;
         [Tooltip("Right hand grip point from cue root towards cue tip (meters).")]
-        [Range(0.05f, 0.9f)] public float rightHandGripFromCueRoot = 0.36f;
+        [Range(0.05f, 0.9f)] public float rightHandGripFromCueRoot = 0.18f;
         [Tooltip("Small right-hand vertical offset so fingers wrap the cue instead of intersecting it.")]
         [Range(-0.1f, 0.15f)] public float rightHandVerticalOffset = 0.025f;
         [Tooltip("Moves chest/head closer to cue line to mimic real snooker stance.")]
@@ -80,6 +80,10 @@ namespace Aiming
         Vector3[] _railHelpers = new Vector3[4];
         Vector3 _perimeterRootTarget;
         bool _hasPerimeterTarget;
+        bool _strikePoseLocked;
+        Vector3 _lockedStrikeRootTarget;
+        Vector3 _lockedStrikeBridgeTarget;
+        Vector3 _lockedStrikeAimForward;
 
         void Awake()
         {
@@ -124,6 +128,7 @@ namespace Aiming
             }
             Vector3 bridgeHandTarget = cueBall + (aimForward * -bridgeDistance) + (aimSide * (-0.018f * s));
             bridgeHandTarget.y = ResolveTableY(cueBall.y) + ResolveBridgeHeightOffset(bridgeMode, s);
+            bridgeHandTarget += aimSide * ResolveBridgeSideOffset(bridgeMode, s);
 
             float handPull = cueController.CurrentPullNormalized * gripPullRange * s;
             Vector3 gripHandTarget = ResolveRightHandGripTarget(aimForward, aimSide, bridgeHandTarget, handPull, s);
@@ -131,6 +136,18 @@ namespace Aiming
             float standingYaw = YawFromForward(aimForward);
             Vector3 idleRightHandTarget = rootTarget + RotateAroundY(new Vector3(0.22f, 1.18f, 0.04f) * s, standingYaw);
             Vector3 idleLeftHandTarget = rootTarget + RotateAroundY(new Vector3(-0.16f, 1.1f, -0.02f) * s, standingYaw);
+            ResolveStrikePoseLock(
+                cueController.CurrentShotState,
+                navigatedRootTarget,
+                bridgeHandTarget,
+                aimForward);
+
+            if (_strikePoseLocked)
+            {
+                navigatedRootTarget = _lockedStrikeRootTarget;
+                bridgeHandTarget = _lockedStrikeBridgeTarget;
+                aimForward = _lockedStrikeAimForward;
+            }
 
             UpdateHumanPose(
                 dt,
@@ -429,11 +446,11 @@ namespace Aiming
 
             Vector3 LocalToWorld(Vector3 v) => RotateAroundY(v, _yaw) + root.position;
 
-            Vector3 hipCenterWorld = LocalToWorld(new Vector3(0f, Lerp(1.02f, 0.98f, t), Lerp(0f, 0.02f, t)) * s);
-            Vector3 torsoCenterWorld = LocalToWorld(new Vector3(0f, Lerp(1.28f, 1.13f, t), Lerp(0f, -0.16f, t)) * s);
-            Vector3 chestCenterWorld = LocalToWorld(new Vector3(0f, Lerp(1.5f, 1.22f, t), Lerp(0.01f, -0.38f, t)) * s) + (forward * (chinToCueForwardBias * 0.72f * t * s));
-            Vector3 neckWorld = LocalToWorld(new Vector3(0f, Lerp(1.66f, 1.22f, t), Lerp(0.02f, -0.61f, t)) * s) + (forward * (chinToCueForwardBias * 0.9f * t * s));
-            Vector3 headCenterWorld = LocalToWorld(new Vector3(0f, Lerp(1.82f, 1.27f, t), Lerp(0.04f, -0.71f, t)) * s) + (forward * (chinToCueForwardBias * t * s));
+            Vector3 hipCenterWorld = LocalToWorld(new Vector3(0f, Lerp(1.02f, 1f, t), Lerp(0f, 0.01f, t)) * s);
+            Vector3 torsoCenterWorld = LocalToWorld(new Vector3(0f, Lerp(1.28f, 1.18f, t), Lerp(0f, -0.12f, t)) * s);
+            Vector3 chestCenterWorld = LocalToWorld(new Vector3(0f, Lerp(1.5f, 1.26f, t), Lerp(0.01f, -0.34f, t)) * s) + (forward * (chinToCueForwardBias * 0.72f * t * s));
+            Vector3 neckWorld = LocalToWorld(new Vector3(0f, Lerp(1.66f, 1.3f, t), Lerp(0.02f, -0.53f, t)) * s) + (forward * (chinToCueForwardBias * 0.9f * t * s));
+            Vector3 headCenterWorld = LocalToWorld(new Vector3(0f, Lerp(1.82f, 1.35f, t), Lerp(0.04f, -0.61f, t)) * s) + (forward * (chinToCueForwardBias * t * s));
 
             Vector3 leftShoulderWorld = LocalToWorld(new Vector3(-0.22f, Lerp(1.57f, 1.34f, t), Lerp(0f, -0.42f, t)) * s) + (Vector3.down * (shoulderDrop * t * s));
             Vector3 rightShoulderWorld = LocalToWorld(new Vector3(0.22f, Lerp(1.57f, 1.34f, t), Lerp(0f, -0.35f, t)) * s);
@@ -442,8 +459,8 @@ namespace Aiming
 
             Vector3 leftFootStand = new Vector3(-0.13f, 0.035f, 0.03f + (walk * 0.03f)) * s;
             Vector3 rightFootStand = new Vector3(0.13f, 0.035f, -0.03f - (walk * 0.03f)) * s;
-            Vector3 frontFootShoot = new Vector3(-0.24f, 0.035f, -0.38f) * s;
-            Vector3 rearFootShoot = new Vector3(0.27f, 0.035f, 0.36f) * s;
+            Vector3 frontFootShoot = new Vector3(-0.16f, 0.035f, -0.33f) * s;
+            Vector3 rearFootShoot = new Vector3(0.18f, 0.035f, 0.31f) * s;
             Vector3 leftFootWorld = LocalToWorld(Vector3.Lerp(leftFootStand, frontFootShoot, t));
             Vector3 rightFootWorld = LocalToWorld(Vector3.Lerp(rightFootStand, rearFootShoot, t));
 
@@ -512,7 +529,7 @@ namespace Aiming
                 {
                     Vector3 cueDir = cueVector.normalized;
                     float cueLength = cueVector.magnitude;
-                    float gripDistance = Mathf.Clamp(rightHandGripFromCueRoot * s, 0.05f, cueLength - 0.03f);
+                    float gripDistance = Mathf.Clamp(rightHandGripFromCueRoot, 0.05f, cueLength - 0.03f);
                     Vector3 grip = cueRootPos + (cueDir * gripDistance);
                     grip += (cueDir * -handPull);
                     grip += (Vector3.up * (rightHandVerticalOffset * s));
@@ -576,6 +593,7 @@ namespace Aiming
         enum BridgeMode
         {
             Standard,
+            Closed,
             Rail,
             High
         }
@@ -594,7 +612,13 @@ namespace Aiming
             }
 
             bool elevatedStroke = cueController.CurrentShotState == CueController.ShotState.Striking && cueController.spinInput.y > 0.45f;
-            return elevatedStroke ? BridgeMode.High : BridgeMode.Standard;
+            if (elevatedStroke)
+            {
+                return BridgeMode.High;
+            }
+
+            bool closedBridge = cueController.CurrentPullNormalized > 0.65f || cueController.CurrentShotState == CueController.ShotState.Striking;
+            return closedBridge ? BridgeMode.Closed : BridgeMode.Standard;
         }
 
         float ResolveBridgeHeightOffset(BridgeMode mode, float s)
@@ -605,9 +629,48 @@ namespace Aiming
                     return 0.028f * s;
                 case BridgeMode.High:
                     return 0.04f * s;
+                case BridgeMode.Closed:
+                    return 0.024f * s;
                 default:
                     return 0.02f * s;
             }
+        }
+
+        float ResolveBridgeSideOffset(BridgeMode mode, float s)
+        {
+            switch (mode)
+            {
+                case BridgeMode.Rail:
+                    return -0.012f * s;
+                case BridgeMode.High:
+                    return 0.006f * s;
+                case BridgeMode.Closed:
+                    return -0.006f * s;
+                default:
+                    return 0f;
+            }
+        }
+
+        void ResolveStrikePoseLock(
+            CueController.ShotState shotState,
+            Vector3 rootTarget,
+            Vector3 bridgeTarget,
+            Vector3 aimForward)
+        {
+            if (shotState == CueController.ShotState.Striking)
+            {
+                if (!_strikePoseLocked)
+                {
+                    _strikePoseLocked = true;
+                    _lockedStrikeRootTarget = rootTarget;
+                    _lockedStrikeBridgeTarget = bridgeTarget;
+                    _lockedStrikeAimForward = aimForward;
+                }
+
+                return;
+            }
+
+            _strikePoseLocked = false;
         }
 
         static float DampScalar(float current, float target, float lambda, float dt)

--- a/billiards.Unity/CueCamera.cs
+++ b/billiards.Unity/CueCamera.cs
@@ -91,6 +91,22 @@ public class CueCamera : MonoBehaviour
     public float maxCueAimLowering = 0.7f;
 
     [Header("Cue aim framing")]
+    // Optional first-person eye anchor on the human rig. When assigned, lowering
+    // the cue camera blends into the player's dominant-eye view so the avatar
+    // eyes are not visible in frame.
+    public Transform playerEyeAnchor;
+    // How strongly the lowered cue camera should blend into first-person view.
+    [Range(0f, 1f)]
+    public float eyeViewBlendStrength = 1f;
+    // Lowering amount where first-person blending begins.
+    [Range(0f, 1f)]
+    public float eyeViewStartLowering = 0.45f;
+    // Distance in front of the eye anchor used for the look target.
+    public float eyeViewLookAhead = 1.1f;
+    // Slight inward offset to avoid clipping through eyebrows/face meshes.
+    public float eyeViewForwardOffset = 0.03f;
+    // Vertical offset to center the cue in first-person framing.
+    public float eyeViewHeightOffset = -0.005f;
     // Scale applied to the cue distance when the camera is raised. Values below
     // 1 slide the camera closer to the cloth even before the player lowers it.
     [Range(0.1f, 1f)]
@@ -325,6 +341,7 @@ public class CueCamera : MonoBehaviour
     private float cueStickStrokeVisual;
     private float smoothedCueDistance;
     private bool hasSmoothedCueDistance;
+    private float eyeViewBlend;
     private float cueStrikeHoldUntilTime;
     private bool forceImmediateRailOverheadOnNextShot;
     private bool holdCueAimDuringShot;
@@ -732,6 +749,7 @@ public class CueCamera : MonoBehaviour
 
         ApplyCueAimZoom(blend, deltaTime);
         ApplyCameraAt(focus, cueAimForward, distance, height, minimumHeightOffset, lookTarget);
+        ApplyEyeViewOverride(cueAimForward, blend, deltaTime);
 
         Vector3 flatForward = new Vector3(cueAimForward.x, 0f, cueAimForward.z);
         if (flatForward.sqrMagnitude > 0.0001f)
@@ -771,6 +789,41 @@ public class CueCamera : MonoBehaviour
 
         Quaternion fallback = Quaternion.Euler(0f, GetShortRailYaw(cueAimSideSign), 0f);
         return fallback * Vector3.forward;
+    }
+
+    private void ApplyEyeViewOverride(Vector3 cueForward, float cueLoweringBlend, float deltaTime)
+    {
+        float targetBlend = 0f;
+        if (!shotInProgress && playerEyeAnchor != null)
+        {
+            float start = Mathf.Clamp01(eyeViewStartLowering);
+            float loweringWindow = Mathf.Max(0.0001f, 1f - start);
+            float loweringT = Mathf.Clamp01((cueLoweringBlend - start) / loweringWindow);
+            targetBlend = loweringT * Mathf.Clamp01(eyeViewBlendStrength);
+        }
+
+        float blendLerp = 1f - Mathf.Exp(-Mathf.Max(0f, cueAxisSmoothSpeed) * Mathf.Max(0f, deltaTime));
+        eyeViewBlend = Mathf.Lerp(eyeViewBlend, targetBlend, blendLerp);
+        if (eyeViewBlend <= 0.0001f || playerEyeAnchor == null)
+        {
+            return;
+        }
+
+        Vector3 eyePos = playerEyeAnchor.position +
+                         (cueForward * Mathf.Max(0f, eyeViewForwardOffset)) +
+                         (Vector3.up * eyeViewHeightOffset);
+        Vector3 eyeLookTarget = eyePos +
+                                (cueForward * Mathf.Max(0.1f, eyeViewLookAhead)) +
+                                (Vector3.up * cueBallLookOffset);
+        Vector3 lookDir = eyeLookTarget - eyePos;
+        if (lookDir.sqrMagnitude < 0.0001f)
+        {
+            return;
+        }
+
+        Quaternion eyeRotation = Quaternion.LookRotation(lookDir.normalized, Vector3.up);
+        transform.position = Vector3.Lerp(transform.position, eyePos, eyeViewBlend);
+        transform.rotation = Quaternion.Slerp(transform.rotation, eyeRotation, eyeViewBlend);
     }
 
     private float ResolveCueAimDistance(


### PR DESCRIPTION
### Motivation
- Align player-facing shot presentation to a true first-person/player-eye view when the cue camera is lowered so the camera shows "what the player sees" rather than the avatar eyes.
- Fix unnatural full-body collapse and inconsistent bridge/hand placement by making stance and bridge behavior more precise and varied to match reference photos and realistic snooker posture.
- Ensure the body/bridge remain planted while allowing the right-hand stroke to execute the pull/push independently for reproducible strike animation and physics.

### Description
- Added an optional first-person anchor to `CueCamera` with the fields `playerEyeAnchor`, `eyeViewBlendStrength`, `eyeViewStartLowering`, `eyeViewLookAhead`, `eyeViewForwardOffset`, and `eyeViewHeightOffset`, and implemented `ApplyEyeViewOverride(...)` to blend camera position/rotation into the eye anchor when lowered. (`billiards.Unity/CueCamera.cs`)
- Tuned human stance and upper-body bend targets in `PoolHumanPoseDriver` by adjusting pelvis/torso/chest/neck/head target offsets and reducing extreme foot placements to keep legs grounded and limit bending to upper body only. (`Assets/Scripts/Gameplay/PoolHumanPoseDriver.cs`)
- Introduced a new `BridgeMode` value `Closed` and per-mode bridge height/side offsets via `ResolveBridgeHeightOffset(...)` and `ResolveBridgeSideOffset(...)` to provide more realistic left-hand bridge variations (`Standard`, `Closed`, `Rail`, `High`). (`Assets/Scripts/Gameplay/PoolHumanPoseDriver.cs`)
- Changed right-hand grip logic to hold the cue closer to the butt by reducing `rightHandGripFromCueRoot` default and removing the extra body-scale multiplication from the grip distance calculation so grip sits stably near the cue butt. (`Assets/Scripts/Gameplay/PoolHumanPoseDriver.cs`)
- Added strike-pose locking that captures and holds `root`, `bridgeHand`, and `aimForward` once the `CueController` enters the `Striking` state so only the right-hand stroke motion drives the hit while the rest of the body remains planted. (`Assets/Scripts/Gameplay/PoolHumanPoseDriver.cs`)

### Testing
- Attempted to run the unit test command `dotnet test billiards.Tests/Billiards.Tests.csproj`, but `dotnet` is not available in this environment so automated tests could not be executed.
- Changes were limited to the camera and pose driver scripts and were smoke-verified in this environment by static inspection and local compile-safety checks (no runtime test executed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef4a2167748329a35a85a0a5633d6f)