### PR TITLE
Restore Pool Royale pull-slider commit power behavior

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -33747,9 +33747,8 @@ useEffect(() => {
       labels: true,
       onChange: (v) => onPowerDrag((v ?? 0) / 100),
       onStart: () => onPowerDragStart(),
-      onCommit: (value) => {
-        const committedRatio = Number.isFinite(value) ? value / 100 : powerRef.current;
-        onPowerRelease(clampPower(committedRatio, 0));
+      onCommit: () => {
+        onPowerRelease(clampPower(powerRef.current, 0));
       }
     });
     sliderInstanceRef.current = slider;


### PR DESCRIPTION
### Motivation
- The pull-style power slider was committing shot power from a potentially stale callback argument instead of the latched pull value, causing incorrect cue-ball power on release; the intent is to restore the previous behavior where the release uses the current latched `powerRef.current` value.

### Description
- Change in `webapp/src/pages/Games/PoolRoyale.jsx`: the slider `onCommit` now calls `onPowerRelease(clampPower(powerRef.current, 0))` instead of using the `value` callback argument so the shot uses the latched pull power.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully (Vite emitted non-blocking warnings about chunk sizing and a duplicate `package.json` key).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef450c21348329b9d09b45357cd687)