### PR TITLE
Align Snooker Royal human cue stance with Bilardo behavior

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -109,10 +109,8 @@ const BILARDO_REFERENCE_TABLE_TOP_Y = 0.84;
 const BILARDO_REFERENCE_HUMAN_HEIGHT = BILARDO_REFERENCE_TABLE_TOP_Y * 2;
 const SNOOKER_HUMAN_BASE_SCALE = 1.18;
 const SNOOKER_HUMAN_VISUAL_SCALE_BOOST = 2.22;
-const SNOOKER_HUMAN_EDGE_MARGIN_FACTOR = 4.1;
-const SNOOKER_HUMAN_DESIRED_SHOOT_DISTANCE_FACTOR = 13.8;
-const SNOOKER_HUMAN_CAMERA_LOWERED_BLEND_THRESHOLD = 0.42;
-const SNOOKER_HUMAN_PULL_TO_POSE_THRESHOLD = 0.035;
+const SNOOKER_HUMAN_EDGE_MARGIN = 0.62;
+const SNOOKER_HUMAN_DESIRED_SHOOT_DISTANCE = 1.06;
 const SNOOKER_HUMAN_CUE_HAND_GRIP_RATIO = 0.76;
 const SNOOKER_HUMAN_CUE_GRIP_BACK_OFFSET = 0;
 
@@ -20826,17 +20824,7 @@ const powerRef = useRef(hud.power);
       ) => {
         if (preferredState === 'striking') return 'striking';
         if (forcePose) return 'dragging';
-        const cameraBlend = THREE.MathUtils.clamp(
-          cameraBlendRef.current ?? 1,
-          0,
-          1
-        );
-        const cameraLowered =
-          cameraBlend <= SNOOKER_HUMAN_CAMERA_LOWERED_BLEND_THRESHOLD;
-        const hasPull =
-          THREE.MathUtils.clamp(powerValue ?? 0, 0, 1) >=
-          SNOOKER_HUMAN_PULL_TO_POSE_THRESHOLD;
-        return cameraLowered || hasPull ? 'dragging' : 'idle';
+        return preferredState === 'idle' ? 'idle' : 'dragging';
       };
 
       const closeCueGallery = () => {
@@ -25343,10 +25331,10 @@ const powerRef = useRef(hud.power);
           const rootTarget = chooseHumanEdgePosition(cueBallWorld, aimForward, {
             tableW: PLAY_W,
             tableL: PLAY_H,
-            edgeMargin: Math.max(BALL_R * SNOOKER_HUMAN_EDGE_MARGIN_FACTOR, SIDE_RAIL_INNER_THICKNESS * 1.2),
+            edgeMargin: SNOOKER_HUMAN_EDGE_MARGIN,
             desiredShootDistance: Math.max(
               cueLen * 0.36,
-              BALL_R * SNOOKER_HUMAN_DESIRED_SHOOT_DISTANCE_FACTOR
+              SNOOKER_HUMAN_DESIRED_SHOOT_DISTANCE
             )
           });
           rootTarget.y = FLOOR_Y + Math.max(BALL_R * 0.08, 0.03);


### PR DESCRIPTION
### Motivation
- The Snooker Royal human rig should hold and bend around the cue identically to the Bilardo Shqip implementation and appear closer to the table while aiming. 
- Make pose-state selection and spacing deterministic so the character reliably transitions into the active aiming/dragging pose instead of remaining idle due to camera/pull heuristics.

### Description
- Replaced Snooker-specific spacing constants with Bilardo-like values by adding `SNOOKER_HUMAN_EDGE_MARGIN = 0.62` and `SNOOKER_HUMAN_DESIRED_SHOOT_DISTANCE = 1.06` and using them in root positioning logic. (`webapp/src/pages/Games/SnookerRoyal.jsx`)
- Simplified `resolveSnookerHumanPoseState` to drive non-idle preferred states into `dragging` (preserving `striking` and `forcePose`) so aiming/pull always produces an active pose similar to Bilardo. (`webapp/src/pages/Games/SnookerRoyal.jsx`)
- Updated the `chooseHumanEdgePosition` call site to use the new fixed `edgeMargin` and `desiredShootDistance` values so the human root target and cue-hand/grip calculations pull the character closer to the table for better cue alignment. (`webapp/src/pages/Games/SnookerRoyal.jsx`)

### Testing
- No automated tests were executed for this change; it is a front-end pose/positioning logic update and requires visual/manual validation in the running app.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef52cdc89883299cfbf824512680b0)