### PR TITLE
Restore Snooker-style cue pull/release & power slider in Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -18,7 +18,7 @@ import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader.js';
 import { GroundedSkybox } from 'three/examples/jsm/objects/GroundedSkybox.js';
 import { RoundedBoxGeometry } from 'three/examples/jsm/geometries/RoundedBoxGeometry.js';
 import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.js';
-import { PowerSlider } from '../../../../power-slider.js';
+import { PoolRoyalePowerSlider } from '../../../../pool-royale-power-slider.js';
 import '../../../../pool-royale-power-slider.css';
 import { useLocation, useNavigate } from 'react-router-dom';
 import {
@@ -81,8 +81,6 @@ import {
 } from '../../config/poolRoyaleInventoryConfig.js';
 import {
   BILARDO_MIN_RELEASE_POWER,
-  BILARDO_STRIKE_CONTACT_THRESHOLD,
-  BILARDO_STRIKE_TIME_MS,
   bilardoCueSpeed
 } from './shared/bilardoShotModel';
 import { POOL_ROYALE_CLOTH_VARIANTS } from '../../config/poolRoyaleClothPresets.js';
@@ -15532,13 +15530,8 @@ const showRuleToast = useCallback((message) => {
 }, []);
 const powerRef = useRef(hud.power);
 const shotPowerRef = useRef(0);
-const MANUAL_STRIKE_TIME_MS = BILARDO_STRIKE_TIME_MS;
-const MANUAL_STRIKE_THRESHOLD = BILARDO_STRIKE_CONTACT_THRESHOLD;
-const [manualShotState, setManualShotState] = useState('idle'); // idle | dragging | striking
+const [manualShotState, setManualShotState] = useState('idle'); // idle | dragging
 const manualShotStateRef = useRef('idle');
-const manualStrikeStartedAtRef = useRef(0);
-const manualStrikeDidHitRef = useRef(false);
-const manualStrikePowerRef = useRef(0);
 useEffect(() => {
   manualShotStateRef.current = manualShotState;
 }, [manualShotState]);
@@ -24964,8 +24957,7 @@ useEffect(() => {
           let mode = 'idle';
           if (isReplay) mode = 'idle';
           else if (
-            (isShotActive && anim.seat === shotSeat && shotAge < 420) ||
-            (isShooter && manualShotStateRef.current === 'striking')
+            (isShotActive && anim.seat === shotSeat && shotAge < 420)
           )
             mode = 'strike';
           else if (isShotActive) mode = 'react';
@@ -26907,23 +26899,20 @@ useEffect(() => {
 
       const resolveCueStrokeProfile = (_styleId, powerRatio = 0) => {
         const p = THREE.MathUtils.clamp(powerRatio ?? 0, 0, 1);
-        const pullbackDuration = THREE.MathUtils.lerp(110, 190, p);
-        const strikeDuration = THREE.MathUtils.lerp(128, 92, p);
-        const holdDuration = THREE.MathUtils.lerp(40, 68, p);
         return {
-          // Rebuilt cue stroke: slider pull maps directly to cue pullback,
-          // then release performs a single forward punch through the cue ball.
+          // Match Snooker Royal stroke timing: pull stays on the slider, and
+          // release drives an immediate forward punch.
           motion: 'classic',
           pullRatio: p,
           pullSmoothing: 1,
-          strikeDuration,
-          holdDuration,
-          pullbackDuration,
+          strikeDuration: 110,
+          holdDuration: 45,
+          pullbackDuration: 0,
           recoverDuration: 0,
-          impactThreshold: 0.86,
+          impactThreshold: 0.88,
           forwardOnly: false,
           cameraExtraHoldMs: 240,
-          spinScale: 0.22
+          spinScale: 0.4
         };
       };
 
@@ -27622,16 +27611,13 @@ useEffect(() => {
           );
           const rawMaxPull = Math.max(0, backInfo.tHit - cueLen - CUE_TIP_GAP);
           const maxPull = Number.isFinite(rawMaxPull) ? rawMaxPull : CUE_PULL_BASE;
-          // Rebuilt stroke pullback: tie visible pull directly to slider power
-          // and the currently available room behind the cue ball.
-          const pullRange = THREE.MathUtils.clamp(
-            maxPull * 0.92,
-            CUE_PULL_MIN_VISUAL,
-            Math.max(CUE_PULL_MIN_VISUAL, maxPull)
-          );
-          const pullTarget = pullRange * strokeProfile.pullRatio;
+          const pullTarget = computePullTargetFromPower(clampedPower, maxPull);
           const pulledNow = cuePullCurrentRef.current ?? pullTarget;
-          const startPull = THREE.MathUtils.clamp(pulledNow, 0, Math.max(maxPull, 0));
+          const startPull = THREE.MathUtils.clamp(
+            Math.max(pulledNow, pullTarget),
+            0,
+            Math.max(maxPull, 0)
+          );
           const visualPull = applyVisualPullCompensation(startPull, dir);
           shotImpactPayload.pullDistance = visualPull;
           cuePullCurrentRef.current = startPull;
@@ -27789,8 +27775,6 @@ useEffect(() => {
             shotImpactApplied = true;
             applyShotAtImpact(shotImpactPayload);
           };
-          const useBilardoImmediateImpact =
-            manualShotStateRef.current === 'striking';
           if (ENABLE_CUE_STROKE_ANIMATION && shotRecording) {
             const strokeStartOffset = REPLAY_CUE_START_HOLD_MS;
             shotRecording.cueStroke = {
@@ -27808,11 +27792,6 @@ useEffect(() => {
             };
           }
           if (ENABLE_CUE_STROKE_ANIMATION) {
-            if (useBilardoImmediateImpact) {
-              // Bilardo Shqip behavior: impact happens at strike trigger time, not
-              // later inside the cue animation timeline.
-              applyShotImpactOnce();
-            }
             cueStick.visible = true;
             cueAnimating = true;
             lastCueIdlePoseRef.current = {
@@ -33669,7 +33648,6 @@ useEffect(() => {
   const sliderRef = useRef(null);
   const onPowerDragStart = useCallback(() => {
     captureCueStickAnchor();
-    manualStrikeDidHitRef.current = false;
     setManualShotState('dragging');
   }, [captureCueStickAnchor]);
   const onPowerDrag = useCallback((powerRatio = 0) => {
@@ -33685,53 +33663,17 @@ useEffect(() => {
     );
     const latchedPower = clampPower(sourcePower, 0);
     shotPowerRef.current = latchedPower;
-    manualStrikePowerRef.current = latchedPower;
     applyPower(latchedPower);
-    manualStrikeDidHitRef.current = false;
-    manualStrikeStartedAtRef.current = performance.now();
-    const shouldStrike = latchedPower > BILARDO_MIN_RELEASE_POWER;
-    setManualShotState(shouldStrike ? 'striking' : 'idle');
+    setManualShotState('idle');
+    if (latchedPower > BILARDO_MIN_RELEASE_POWER) {
+      fireRef.current?.(latchedPower);
+    }
+    requestAnimationFrame(() => {
+      const slider = sliderInstanceRef.current;
+      if (slider) slider.set(slider.min, { animate: true });
+      applyPower(0);
+    });
   }, [applyPower, clampPower]);
-  useEffect(() => {
-    let raf = 0;
-    const tick = () => {
-      raf = requestAnimationFrame(tick);
-      if (manualShotStateRef.current !== 'striking') return;
-      const start = manualStrikeStartedAtRef.current || 0;
-      if (start <= 0) return;
-      const strikeNorm = THREE.MathUtils.clamp(
-        (performance.now() - start) / MANUAL_STRIKE_TIME_MS,
-        0,
-        1
-      );
-      if (!manualStrikeDidHitRef.current && strikeNorm > MANUAL_STRIKE_THRESHOLD) {
-        manualStrikeDidHitRef.current = true;
-        fireRef.current?.(
-          manualStrikePowerRef.current ??
-            shotPowerRef.current ??
-            powerRef.current ??
-            0
-        );
-      }
-      if (strikeNorm >= 1) {
-        if (!shootingRef.current && manualStrikePowerRef.current > BILARDO_MIN_RELEASE_POWER) {
-          fireRef.current?.(manualStrikePowerRef.current);
-        }
-        setManualShotState('idle');
-        manualStrikeStartedAtRef.current = 0;
-        manualStrikePowerRef.current = 0;
-        requestAnimationFrame(() => {
-          const slider = sliderInstanceRef.current;
-          if (slider) slider.set(slider.min, { animate: true });
-          applyPower(0);
-        });
-      }
-    };
-    raf = requestAnimationFrame(tick);
-    return () => {
-      if (raf) cancelAnimationFrame(raf);
-    };
-  }, [applyPower]);
   const showPowerSlider = hud.turn === 0 && !hud.over && !replayActive && !shotActive;
   useEffect(() => {
     if (!showPowerSlider) {
@@ -33739,7 +33681,7 @@ useEffect(() => {
     }
     const mount = sliderRef.current;
     if (!mount) return undefined;
-    const slider = new PowerSlider({
+    const slider = new PoolRoyalePowerSlider({
       mount,
       value: powerRef.current * 100,
       cueSrc: '',


### PR DESCRIPTION
### Motivation
- Make Pool Royale cue interaction match the Snooker Royal pull-and-release feel so the cue animation and power control behave consistently across games.

### Description
- Swapped the generic slider for the dedicated `PoolRoyalePowerSlider` and wired Pool Royale to use it for pull-and-release power control (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Removed the intermediate manual-strike timing/state path and related refs so the slider release now immediately commits the shot when latched power exceeds `BILARDO_MIN_RELEASE_POWER` instead of driving a separate "striking" loop.
- Aligned the cue stroke profile to Snooker-style timing by setting `strikeDuration`, `holdDuration`, and `pullbackDuration` to the snooker-like values and increased `spinScale`; restored pull target computation to use `computePullTargetFromPower` and preserved the pulled distance into the release.
- Removed the special-case immediate-impact path tied to the old manual striking state and simplified cue-animation start/reset logic and slider reset after release.

### Testing
- Ran `npm test -- poolRoyaleCueStrokeTimeline.test.js --runInBand` and all tests passed (4 tests, 1 suite): the cue stroke timeline behavior assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef536dd6488329b93af936e8239c6d)