### PR TITLE
Restore Pool Royale pull-release cue stroke behavior to match Snooker Royal

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -18,7 +18,7 @@ import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader.js';
 import { GroundedSkybox } from 'three/examples/jsm/objects/GroundedSkybox.js';
 import { RoundedBoxGeometry } from 'three/examples/jsm/geometries/RoundedBoxGeometry.js';
 import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.js';
-import { PowerSlider } from '../../../../power-slider.js';
+import { PoolRoyalePowerSlider } from '../../../../pool-royale-power-slider.js';
 import '../../../../pool-royale-power-slider.css';
 import { useLocation, useNavigate } from 'react-router-dom';
 import {
@@ -81,8 +81,6 @@ import {
 } from '../../config/poolRoyaleInventoryConfig.js';
 import {
   BILARDO_MIN_RELEASE_POWER,
-  BILARDO_STRIKE_CONTACT_THRESHOLD,
-  BILARDO_STRIKE_TIME_MS,
   bilardoCueSpeed
 } from './shared/bilardoShotModel';
 import { POOL_ROYALE_CLOTH_VARIANTS } from '../../config/poolRoyaleClothPresets.js';
@@ -15532,16 +15530,6 @@ const showRuleToast = useCallback((message) => {
 }, []);
 const powerRef = useRef(hud.power);
 const shotPowerRef = useRef(0);
-const MANUAL_STRIKE_TIME_MS = BILARDO_STRIKE_TIME_MS;
-const MANUAL_STRIKE_THRESHOLD = BILARDO_STRIKE_CONTACT_THRESHOLD;
-const [manualShotState, setManualShotState] = useState('idle'); // idle | dragging | striking
-const manualShotStateRef = useRef('idle');
-const manualStrikeStartedAtRef = useRef(0);
-const manualStrikeDidHitRef = useRef(false);
-const manualStrikePowerRef = useRef(0);
-useEffect(() => {
-  manualShotStateRef.current = manualShotState;
-}, [manualShotState]);
   const clampPower = useCallback((value, fallback = 0) => {
     if (!Number.isFinite(value)) return fallback;
     return THREE.MathUtils.clamp(value, 0, 1);
@@ -24956,17 +24944,11 @@ useEffect(() => {
           const isShooter = anim.seat === activeSeat;
           const cameraBlend = THREE.MathUtils.clamp(cameraBlendRef.current ?? 1, 0, 1);
           const loweredCueCamera = cameraBlend <= HUMAN_SHOOT_BLEND_THRESHOLD;
-          const draggingSlider =
-            manualShotStateRef.current === 'dragging' ||
-            Boolean(sliderInstanceRef.current?.dragging);
-          const sliderPowerActive =
-            manualShotStateRef.current !== 'idle' || (powerRef.current ?? 0) > 0.01;
+          const draggingSlider = Boolean(sliderInstanceRef.current?.dragging);
+          const sliderPowerActive = draggingSlider || (powerRef.current ?? 0) > 0.01;
           let mode = 'idle';
           if (isReplay) mode = 'idle';
-          else if (
-            (isShotActive && anim.seat === shotSeat && shotAge < 420) ||
-            (isShooter && manualShotStateRef.current === 'striking')
-          )
+          else if (isShotActive && anim.seat === shotSeat && shotAge < 420)
             mode = 'strike';
           else if (isShotActive) mode = 'react';
           else if (isShooter && (loweredCueCamera || draggingSlider || sliderPowerActive)) mode = 'aim';
@@ -27789,8 +27771,7 @@ useEffect(() => {
             shotImpactApplied = true;
             applyShotAtImpact(shotImpactPayload);
           };
-          const useBilardoImmediateImpact =
-            manualShotStateRef.current === 'striking';
+          const useBilardoImmediateImpact = false;
           if (ENABLE_CUE_STROKE_ANIMATION && shotRecording) {
             const strokeStartOffset = REPLAY_CUE_START_HOLD_MS;
             shotRecording.cueStroke = {
@@ -33669,8 +33650,6 @@ useEffect(() => {
   const sliderRef = useRef(null);
   const onPowerDragStart = useCallback(() => {
     captureCueStickAnchor();
-    manualStrikeDidHitRef.current = false;
-    setManualShotState('dragging');
   }, [captureCueStickAnchor]);
   const onPowerDrag = useCallback((powerRatio = 0) => {
     const clamped = clampPower(powerRatio, 0);
@@ -33685,53 +33664,16 @@ useEffect(() => {
     );
     const latchedPower = clampPower(sourcePower, 0);
     shotPowerRef.current = latchedPower;
-    manualStrikePowerRef.current = latchedPower;
     applyPower(latchedPower);
-    manualStrikeDidHitRef.current = false;
-    manualStrikeStartedAtRef.current = performance.now();
-    const shouldStrike = latchedPower > BILARDO_MIN_RELEASE_POWER;
-    setManualShotState(shouldStrike ? 'striking' : 'idle');
+    if (latchedPower > BILARDO_MIN_RELEASE_POWER) {
+      fireRef.current?.(latchedPower);
+    }
+    requestAnimationFrame(() => {
+      const slider = sliderInstanceRef.current;
+      if (slider) slider.set(slider.min, { animate: true });
+      applyPower(0);
+    });
   }, [applyPower, clampPower]);
-  useEffect(() => {
-    let raf = 0;
-    const tick = () => {
-      raf = requestAnimationFrame(tick);
-      if (manualShotStateRef.current !== 'striking') return;
-      const start = manualStrikeStartedAtRef.current || 0;
-      if (start <= 0) return;
-      const strikeNorm = THREE.MathUtils.clamp(
-        (performance.now() - start) / MANUAL_STRIKE_TIME_MS,
-        0,
-        1
-      );
-      if (!manualStrikeDidHitRef.current && strikeNorm > MANUAL_STRIKE_THRESHOLD) {
-        manualStrikeDidHitRef.current = true;
-        fireRef.current?.(
-          manualStrikePowerRef.current ??
-            shotPowerRef.current ??
-            powerRef.current ??
-            0
-        );
-      }
-      if (strikeNorm >= 1) {
-        if (!shootingRef.current && manualStrikePowerRef.current > BILARDO_MIN_RELEASE_POWER) {
-          fireRef.current?.(manualStrikePowerRef.current);
-        }
-        setManualShotState('idle');
-        manualStrikeStartedAtRef.current = 0;
-        manualStrikePowerRef.current = 0;
-        requestAnimationFrame(() => {
-          const slider = sliderInstanceRef.current;
-          if (slider) slider.set(slider.min, { animate: true });
-          applyPower(0);
-        });
-      }
-    };
-    raf = requestAnimationFrame(tick);
-    return () => {
-      if (raf) cancelAnimationFrame(raf);
-    };
-  }, [applyPower]);
   const showPowerSlider = hud.turn === 0 && !hud.over && !replayActive && !shotActive;
   useEffect(() => {
     if (!showPowerSlider) {
@@ -33739,7 +33681,7 @@ useEffect(() => {
     }
     const mount = sliderRef.current;
     if (!mount) return undefined;
-    const slider = new PowerSlider({
+    const slider = new PoolRoyalePowerSlider({
       mount,
       value: powerRef.current * 100,
       cueSrc: '',
@@ -33748,7 +33690,7 @@ useEffect(() => {
       onChange: (v) => onPowerDrag((v ?? 0) / 100),
       onStart: () => onPowerDragStart(),
       onCommit: () => {
-        onPowerRelease(clampPower(powerRef.current, 0));
+        onPowerRelease(powerRef.current);
       }
     });
     sliderInstanceRef.current = slider;


### PR DESCRIPTION
### Motivation
- Bring Pool Royale cue interaction and animation in line with the Snooker Royal reference by restoring a pull-and-release slider-driven flow (visual pull → release → immediate shot) instead of the custom delayed manual-strike timing loop.
- Ensure cue animation remains authoritative for replay and visual consistency so the shot seen is the one that produced the physics impulse.
- Simplify input flow to rely on the existing billiards `PowerSlider` family behaviour used by Snooker Royal for more predictable touch/drag ergonomics.

### Description
- Replaced `PowerSlider` with `PoolRoyalePowerSlider` and applied the Pool Royale theme so the slider uses the same pull/release semantics as Snooker Royal (file changed: `webapp/src/pages/Games/PoolRoyale.jsx`).
- Removed the manual strike state machine and timing loop (the `dragging`/`striking` refs, timers and related logic) and simplified the slider handlers so release immediately triggers `fire()` when above the minimum release threshold and then resets the slider.
- Updated shooter pose/animation gating to consult the actual slider drag/power state (and `sliderInstanceRef.current?.dragging`) instead of the removed manual flags, and forced cue impact timing to remain on the cue-stroke timeline (`useBilardoImmediateImpact = false`) so replay/animation remain authoritative.

### Testing
- Ran targeted unit tests with `npm test -- --runInBand test/poolRoyaleOnlineFlow.test.js` and all tests in that suite passed (8 tests passed).
- Ran the project linter with `npm run -s lint -- webapp/src/pages/Games/PoolRoyale.jsx` but the lint run reported pre-existing repo-wide/generated-file lint errors and did not provide a clean pass; the edited file is affected by repository ignore rules and the linter output is unrelated to this change.
- Verified the modified file `webapp/src/pages/Games/PoolRoyale.jsx` builds locally in the dev environment used for these tests and behavior changes are limited to the Pool Royale shot input/slider and cue animation flow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef536dd6488329b93af936e8239c6d)