### PR TITLE
Align Snooker Royal human cue pose behavior with Bilardo Shqip

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -109,10 +109,8 @@ const BILARDO_REFERENCE_TABLE_TOP_Y = 0.84;
 const BILARDO_REFERENCE_HUMAN_HEIGHT = BILARDO_REFERENCE_TABLE_TOP_Y * 2;
 const SNOOKER_HUMAN_BASE_SCALE = 1.18;
 const SNOOKER_HUMAN_VISUAL_SCALE_BOOST = 2.22;
-const SNOOKER_HUMAN_EDGE_MARGIN_FACTOR = 4.1;
-const SNOOKER_HUMAN_DESIRED_SHOOT_DISTANCE_FACTOR = 13.8;
-const SNOOKER_HUMAN_CAMERA_LOWERED_BLEND_THRESHOLD = 0.42;
-const SNOOKER_HUMAN_PULL_TO_POSE_THRESHOLD = 0.035;
+const SNOOKER_HUMAN_EDGE_MARGIN = 0.62;
+const SNOOKER_HUMAN_DESIRED_SHOOT_DISTANCE = 1.06;
 const SNOOKER_HUMAN_CUE_HAND_GRIP_RATIO = 0.76;
 const SNOOKER_HUMAN_CUE_GRIP_BACK_OFFSET = 0;
 
@@ -20794,6 +20792,7 @@ const powerRef = useRef(hud.power);
       const bilardoSharedPose = {
         bridgeHandBackFromBall: 0.245,
         bridgeHandSide: -0.008,
+        bridgePalmTableLift: 0.012,
         gripRatio: SNOOKER_HUMAN_CUE_HAND_GRIP_RATIO,
         idleRightOffset: new THREE.Vector3(0.24, 1.12, 0.02),
         idleLeftOffset: new THREE.Vector3(-0.18, 1.08, 0.03)
@@ -20821,22 +20820,12 @@ const powerRef = useRef(hud.power);
       };
       const resolveSnookerHumanPoseState = (
         preferredState,
-        powerValue,
+        _powerValue,
         { forcePose = false } = {}
       ) => {
         if (preferredState === 'striking') return 'striking';
-        if (forcePose) return 'dragging';
-        const cameraBlend = THREE.MathUtils.clamp(
-          cameraBlendRef.current ?? 1,
-          0,
-          1
-        );
-        const cameraLowered =
-          cameraBlend <= SNOOKER_HUMAN_CAMERA_LOWERED_BLEND_THRESHOLD;
-        const hasPull =
-          THREE.MathUtils.clamp(powerValue ?? 0, 0, 1) >=
-          SNOOKER_HUMAN_PULL_TO_POSE_THRESHOLD;
-        return cameraLowered || hasPull ? 'dragging' : 'idle';
+        if (forcePose || preferredState === 'dragging') return 'dragging';
+        return 'idle';
       };
 
       const closeCueGallery = () => {
@@ -25343,11 +25332,8 @@ const powerRef = useRef(hud.power);
           const rootTarget = chooseHumanEdgePosition(cueBallWorld, aimForward, {
             tableW: PLAY_W,
             tableL: PLAY_H,
-            edgeMargin: Math.max(BALL_R * SNOOKER_HUMAN_EDGE_MARGIN_FACTOR, SIDE_RAIL_INNER_THICKNESS * 1.2),
-            desiredShootDistance: Math.max(
-              cueLen * 0.36,
-              BALL_R * SNOOKER_HUMAN_DESIRED_SHOOT_DISTANCE_FACTOR
-            )
+            edgeMargin: SNOOKER_HUMAN_EDGE_MARGIN,
+            desiredShootDistance: SNOOKER_HUMAN_DESIRED_SHOOT_DISTANCE
           });
           rootTarget.y = FLOOR_Y + Math.max(BALL_R * 0.08, 0.03);
           const aimSide = new THREE.Vector3(aimForward.z, 0, -aimForward.x).normalize();
@@ -25355,7 +25341,7 @@ const powerRef = useRef(hud.power);
             .clone()
             .addScaledVector(aimForward, -bilardoSharedPose.bridgeHandBackFromBall)
             .addScaledVector(aimSide, bilardoSharedPose.bridgeHandSide)
-            .setY(BALL_CENTER_Y - BALL_R + BALL_R * 0.24);
+            .setY(BALL_CENTER_Y - BALL_R + bilardoSharedPose.bridgePalmTableLift);
           const gripTarget = humanPoseContext.cueTip
             .clone()
             .lerp(humanPoseContext.cueBack.clone(), bilardoSharedPose.gripRatio)


### PR DESCRIPTION
### Motivation
- Make the Snooker Royal human actor bend, grip and position the cue identically to the Bilardo Shqip reference so the player looks and behaves the same and stands closer to the table while aiming.

### Description
- Replaced Snooker-specific tuning with Bilardo-style constants: introduced `SNOOKER_HUMAN_EDGE_MARGIN = 0.62` and `SNOOKER_HUMAN_DESIRED_SHOOT_DISTANCE = 1.06` and used them when computing the human `rootTarget` placement. (`webapp/src/pages/Games/SnookerRoyal.jsx`).
- Added `bridgePalmTableLift` to the shared pose (`bilardoSharedPose`) and applied it to the bridge-hand Y placement so the support hand sits at the same table height as Bilardo Shqip. (`webapp/src/pages/Games/SnookerRoyal.jsx`).
- Simplified pose state logic in `resolveSnookerHumanPoseState` to Bilardo-style behavior so the human enters `dragging` when aiming, stays `striking` during the strike, and `idle` otherwise (removed camera/power gating that previously prevented the full bend/grip pose). (`webapp/src/pages/Games/SnookerRoyal.jsx`).

### Testing
- Ran the production build with `npm --prefix webapp run build`, which completed successfully. 
- Build emitted existing Vite warnings about large chunks and a duplicate `package.json` key, but the build finished without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef52cdc89883299cfbf824512680b0)