### PR TITLE
Restore slider-driven cue pull/release behavior for Pool Royale

### DIFF
--- a/Assets/Scripts/Gameplay/CueController.cs
+++ b/Assets/Scripts/Gameplay/CueController.cs
@@ -71,6 +71,7 @@ namespace Aiming
         float _latchedPullDistance;
         float _power;
         float _latchedShotPower;
+        float _previousSliderPower;
         Vector2 _liveSpinInput;
         Vector2 _latchedShotSpin;
         ShotState _shotState = ShotState.Idle;
@@ -134,7 +135,16 @@ namespace Aiming
 
         public void SetChargePower(float normalizedPower)
         {
-            _power = Mathf.Clamp01(normalizedPower);
+            float nextPower = Mathf.Clamp01(normalizedPower);
+            float threshold = Mathf.Max(releaseTriggerThresholdNormalized, 0.001f);
+            bool shouldArmCharge = nextPower > threshold;
+
+            if (_shotState == ShotState.Idle && shouldArmCharge)
+            {
+                BeginCharge();
+            }
+
+            _power = nextPower;
 
             if (_shotState == ShotState.Dragging)
             {
@@ -142,7 +152,22 @@ namespace Aiming
                 _chargedCueDepth = idleTipGap + pull;
                 _currentCueDepth = _chargedCueDepth;
                 UpdateCuePose();
+
+                bool sliderDroppedToRelease = _previousSliderPower > threshold && _power <= threshold;
+                if (sliderDroppedToRelease)
+                {
+                    if (HasValidReleaseGesture(_chargedCueDepth - idleTipGap))
+                    {
+                        ReleaseAndStrike();
+                    }
+                    else
+                    {
+                        CancelCharge();
+                    }
+                }
             }
+
+            _previousSliderPower = nextPower;
         }
 
         public void BeginCharge()
@@ -160,6 +185,7 @@ namespace Aiming
             _latchedPullDistance = 0f;
             _chargedCueDepth = idleTipGap + PullDistanceFromPower(_power);
             _currentCueDepth = _chargedCueDepth;
+            _previousSliderPower = Mathf.Max(_previousSliderPower, _power);
             _dynamicLift = 0f;
             _dynamicWobble = 0f;
             gameObject.SetActive(true);
@@ -202,6 +228,7 @@ namespace Aiming
             _latchedShotSpin = _liveSpinInput;
             _chargedCueDepth = idleTipGap;
             _currentCueDepth = idleTipGap;
+            _previousSliderPower = 0f;
             _dynamicLift = 0f;
             _dynamicWobble = 0f;
             ResetTipScale();
@@ -461,6 +488,7 @@ namespace Aiming
             _latchedShotSpin = _liveSpinInput;
             _chargedCueDepth = idleTipGap;
             _currentCueDepth = idleTipGap;
+            _previousSliderPower = 0f;
             _dynamicLift = 0f;
             _dynamicWobble = 0f;
             ResetTipScale();


### PR DESCRIPTION
### Motivation
- Bring Pool Royale cue interaction back in line with Snooker Royal by making the on-screen power slider directly drive the cue pull animation and trigger release on slider drop. 
- Ensure the cue lifecycle remains robust when UI pointer callbacks are missing by allowing the slider to arm/cancel shots.

### Description
- Updated `CueController.SetChargePower` to arm charging from idle when slider power rises above a threshold and to update `_power` from slider input. 
- Detect slider drop from above-threshold to at-or-below-threshold and trigger `ReleaseAndStrike()` or `CancelCharge()` depending on `HasValidReleaseGesture`. 
- Added `_previousSliderPower` tracking and reset it in `BeginCharge`, `CancelCharge`, and `FinishStrike` to keep state consistent across shots. 
- Preserved existing camera-lowered logic and minimum-power fallbacks; behavior change is limited to `Assets/Scripts/Gameplay/CueController.cs`.

### Testing
- Ran `git diff --check -- Assets/Scripts/Gameplay/CueController.cs` to validate no whitespace or diff-check issues and it passed.
- No automated Unity playmode/unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef536dd6488329b93af936e8239c6d)