### PR TITLE
Support two-handed firearm animations, mixers and FPS gun sounds; improve capture weapon handling

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -164,6 +164,16 @@ const LARGE_RACK_FIREARM_IDS = new Set([
   'marksmanDmrAttack',
   'compactCarbineAttack'
 ]);
+const TWO_HAND_FIREARM_IDS = new Set([
+  'assaultRifleAttack',
+  'ak47VolleyAttack',
+  'mosinMarksmanAttack',
+  'shotgunBlastAttack',
+  'sniperShotAttack',
+  'marksmanDmrAttack',
+  'compactCarbineAttack',
+  'krsvBurstAttack'
+]);
 const FIREARM_RACK_DISPLAY_TUNING = Object.freeze({
   default: Object.freeze({
     targetSizeMultiplier: 1.06,
@@ -402,8 +412,8 @@ const FIREARM_HAND_ATTACH_TUNING = Object.freeze({
     muzzleOffset: [0, 0.012, 0.2]
   },
   fpsGunAttack: {
-    position: [0.031, -0.003, 0.114],
-    rotation: [-1.46, -0.04, -1.56],
+    position: [0.04, -0.006, 0.126],
+    rotation: [-1.46, -0.06, -1.56],
     muzzleOffset: [0, 0.014, 0.232]
   },
   glockSidearmAttack: {
@@ -481,7 +491,7 @@ const FIREARM_ATTACH_WORLD_SCALE_BOOST = 1.18;
 const FIREARM_ATTACH_SCALE_MULTIPLIER = Object.freeze({
   mrtkGunAttack: 1.04,
   pistolHolsterAttack: 1.0,
-  fpsGunAttack: 1.28,
+  fpsGunAttack: 1.62,
   glockSidearmAttack: 0.98,
   pistolSidearmAttack: 1.0,
   uziSprayAttack: 1.06,
@@ -557,6 +567,9 @@ async function loadCaptureWeaponModel(captureAnimationId) {
           const gltf = await withLoadTimeout(loader.loadAsync(candidateUrls[i]));
           const root = gltf?.scene || gltf?.scenes?.[0] || null;
           if (root) {
+            if (Array.isArray(gltf?.animations) && gltf.animations.length > 0) {
+              root.userData.animationClips = gltf.animations;
+            }
             loadedRoot = root;
             break;
           }
@@ -583,6 +596,9 @@ async function loadCaptureWeaponModel(captureAnimationId) {
         // eslint-disable-next-line no-await-in-loop
         const gltf = await withLoadTimeout(loader.loadAsync(candidateUrls[i]));
         loadedRoot = gltf?.scene || gltf?.scenes?.[0] || null;
+        if (loadedRoot && Array.isArray(gltf?.animations) && gltf.animations.length > 0) {
+          loadedRoot.userData.animationClips = gltf.animations;
+        }
       } catch (error) {
         if (i === candidateUrls.length - 1) {
           console.warn('Capture weapon model load failed', normalizedCaptureAnimationId, candidateUrls[i], error);
@@ -632,6 +648,78 @@ async function loadCaptureWeaponModel(captureAnimationId) {
   return loadCaptureWeaponModel(fallbackId);
 }
 
+function startCaptureWeaponAnimation({
+  sourceModel,
+  targetModel,
+  mixersStore,
+  loopMode = THREE.LoopRepeat,
+  autoplay = true
+}) {
+  if (!sourceModel?.userData?.animationClips?.length || !targetModel?.isObject3D || !mixersStore) return null;
+  const mixer = new THREE.AnimationMixer(targetModel);
+  const actions = [];
+  sourceModel.userData.animationClips.forEach((clip) => {
+    const action = mixer.clipAction(clip);
+    action.setLoop(loopMode, loopMode === THREE.LoopOnce ? 1 : Infinity);
+    action.clampWhenFinished = false;
+    action.enabled = true;
+    actions.push(action);
+    if (autoplay) action.play();
+  });
+  mixersStore.add(mixer);
+  targetModel.userData.captureWeaponMixer = mixer;
+  return {
+    mixer,
+    play: () => {
+      actions.forEach((action) => action.play());
+    },
+    stop: () => {
+      actions.forEach((action) => action.stop());
+    }
+  };
+}
+
+function stopCaptureWeaponMixersForObjectTree(rootObject, mixersStore) {
+  if (!rootObject?.isObject3D || !mixersStore) return;
+  rootObject.traverse((node) => {
+    const mixer = node?.userData?.captureWeaponMixer;
+    if (!mixer) return;
+    if (mixersStore?.delete) mixersStore.delete(mixer);
+    mixer.stopAllAction?.();
+    mixer.uncacheRoot?.(node);
+    delete node.userData.captureWeaponMixer;
+  });
+}
+
+function findWeaponNodeByNeedles(root, needles = []) {
+  if (!root?.isObject3D || !Array.isArray(needles) || needles.length === 0) return null;
+  const lowerNeedles = needles.map((value) => `${value}`.toLowerCase());
+  let matched = null;
+  root.traverse((node) => {
+    if (matched || !node?.isObject3D) return;
+    const lowerName = `${node.name || ''}`.toLowerCase();
+    if (!lowerName) return;
+    if (lowerNeedles.some((needle) => lowerName.includes(needle))) {
+      matched = node;
+    }
+  });
+  return matched;
+}
+
+function shiftObjectByWorldDelta(object, deltaWorld) {
+  if (!object?.isObject3D || !deltaWorld?.isVector3) return;
+  const parent = object.parent;
+  if (!parent?.isObject3D) {
+    object.position.add(deltaWorld);
+    return;
+  }
+  const currentWorld = object.getWorldPosition(new THREE.Vector3());
+  const nextWorld = currentWorld.clone().add(deltaWorld);
+  const currentLocal = parent.worldToLocal(currentWorld.clone());
+  const nextLocal = parent.worldToLocal(nextWorld);
+  object.position.add(nextLocal.sub(currentLocal));
+}
+
 async function attachFirearmToRightHand(attackerEntry, captureAnimationId) {
   const rightHand = attackerEntry?.rig?.rightHand;
   if (!rightHand?.isBone) return null;
@@ -645,13 +733,51 @@ async function attachFirearmToRightHand(attackerEntry, captureAnimationId) {
     FIREARM_ATTACH_WORLD_SCALE_BOOST * (FIREARM_ATTACH_SCALE_MULTIPLIER[captureAnimationId] ?? 1);
   weapon.scale.multiplyScalar(scaleBoost);
   rightHand.add(weapon);
+  const weaponMixers = attackerEntry?.weaponAnimationMixers;
+  const animationController = startCaptureWeaponAnimation({
+    sourceModel: modelTemplate,
+    targetModel: weapon,
+    mixersStore: weaponMixers,
+    loopMode: THREE.LoopOnce,
+    autoplay: false
+  });
+  const rightGripNode = findWeaponNodeByNeedles(weapon, ['r_wrist', 'right_wrist', 'right hand']);
+  const leftGripNode = findWeaponNodeByNeedles(weapon, ['l_wrist', 'left_wrist', 'left hand']);
+  if (rightGripNode?.isObject3D) {
+    rightGripNode.updateMatrixWorld?.(true);
+    rightHand.updateMatrixWorld?.(true);
+    const gripWorld = rightGripNode.getWorldPosition(new THREE.Vector3());
+    const desiredWorld = rightHand.getWorldPosition(new THREE.Vector3());
+    const correction = desiredWorld.sub(gripWorld);
+    shiftObjectByWorldDelta(weapon, correction);
+  }
   const muzzle = new THREE.Object3D();
   muzzle.position.set(...(tuning.muzzleOffset || FIREARM_HAND_ATTACH_TUNING.default.muzzleOffset));
   weapon.add(muzzle);
+  const leftGrip = new THREE.Object3D();
+  if (leftGripNode?.isObject3D) {
+    leftGripNode.updateMatrixWorld?.(true);
+    const leftGripWorld = leftGripNode.getWorldPosition(new THREE.Vector3());
+    weapon.worldToLocal(leftGripWorld);
+    leftGrip.position.copy(leftGripWorld);
+  } else {
+    leftGrip.position.copy(muzzle.position).add(new THREE.Vector3(-0.08, -0.01, -0.08));
+  }
+  weapon.add(leftGrip);
   return {
     weapon,
     muzzle,
+    leftGrip,
+    playAnimation: () => {
+      animationController?.play?.();
+    },
     release: () => {
+      const mixer = weapon.userData?.captureWeaponMixer;
+      if (mixer && weaponMixers?.delete) {
+        weaponMixers.delete(mixer);
+      }
+      mixer?.stopAllAction?.();
+      mixer?.uncacheRoot?.(weapon);
       weapon.parent?.remove?.(weapon);
     }
   };
@@ -708,11 +834,17 @@ async function createCaptureWeaponRackFx() {
 async function applyCaptureWeaponDisplay(entry, captureAnimationId) {
   if (!entry?.weaponHolder) return;
   if (!FIREARM_CAPTURE_ANIMATION_IDS.has(captureAnimationId)) {
+    entry.weaponHolder.children.forEach((child) => {
+      stopCaptureWeaponMixersForObjectTree(child, entry.weaponAnimationMixers);
+    });
     entry.weaponHolder.clear();
     entry.selectedCaptureAnimationId = null;
     return;
   }
   if (entry.selectedCaptureAnimationId === captureAnimationId && entry.weaponHolder.children.length > 0) return;
+  entry.weaponHolder.children.forEach((child) => {
+    stopCaptureWeaponMixersForObjectTree(child, entry.weaponAnimationMixers);
+  });
   entry.weaponHolder.clear();
   const weaponModel = await loadCaptureWeaponModel(captureAnimationId);
   if (!weaponModel) {
@@ -720,6 +852,9 @@ async function applyCaptureWeaponDisplay(entry, captureAnimationId) {
     return;
   }
   entry.selectedCaptureAnimationId = captureAnimationId;
+  entry.weaponHolder.children.forEach((child) => {
+    stopCaptureWeaponMixersForObjectTree(child, entry.weaponAnimationMixers);
+  });
   entry.weaponHolder.clear();
   const clone = weaponModel.clone(true);
   const baseAlignPositionY = clone.position.y;
@@ -4203,6 +4338,10 @@ const LUDO_CAPTURE_MISSILE_IMPACT_SOUND_URL = '/assets/sounds/080998_bullet-hit-
 const LUDO_CAPTURE_FIREARM_SHOT_SOUND_URL = '/assets/sounds/080998_bullet-hit-39870.mp3';
 const LUDO_CAPTURE_FIREARM_SHELL_SOUND_URL = '/assets/sounds/cueshootsound.mp3';
 const LUDO_CAPTURE_GLASS_SHATTER_SOUND_URL = '/assets/sounds/glass-bottle-breaking-351297.mp3';
+const FPS_GUN_SOURCE_SHOT_SOUND_URL =
+  'https://raw.githubusercontent.com/lando19/Guns-for-BJS-FPS-Game/main/main/12-Gauge-Pump-Action-Shotgun-Close-Gunshot-A-www.fesliyanstudios.com.mp3';
+const FPS_GUN_SOURCE_RELOAD_SOUND_URL =
+  'https://raw.githubusercontent.com/lando19/Guns-for-BJS-FPS-Game/main/main/shotgun-reload-old_school-ra_the_sun_god-580332022.mp3';
 const LUDO_CAPTURE_DRONE_SOUND_URL =
   '/assets/sounds/kimsa-kimsa-big-motorcycle-sound-394700.mp3';
 const LUDO_CAPTURE_FIGHTER_SOUND_URL = '/assets/sounds/race-care-151963.mp3';
@@ -5449,6 +5588,55 @@ function solveSeatedRightArmContactIK(entry, targetWorld, weight = 1, effectorKe
   }
 }
 
+function solveSeatedLeftArmContactIK(entry, targetWorld, weight = 1) {
+  const rig = entry?.rig;
+  const actor = entry?.actor;
+  if (!rig || !actor?.isObject3D || !targetWorld?.isVector3) return;
+  const upper = rig.leftUpperArm;
+  const lower = rig.leftForeArm;
+  const hand = rig.leftHand;
+  if (!upper?.isBone || !lower?.isBone || !hand?.isBone) return;
+  const blend = clamp(weight, 0, 1);
+  if (blend <= 1e-4) return;
+  const endPos = new THREE.Vector3();
+  const jointPos = new THREE.Vector3();
+  const toEnd = new THREE.Vector3();
+  const toTarget = new THREE.Vector3();
+  const axis = new THREE.Vector3();
+  const worldDeltaQ = new THREE.Quaternion();
+
+  const applyBoneStep = (bone) => {
+    bone.updateMatrixWorld?.(true);
+    hand.updateMatrixWorld?.(true);
+    bone.getWorldPosition(jointPos);
+    hand.getWorldPosition(endPos);
+    toEnd.copy(endPos).sub(jointPos);
+    toTarget.copy(targetWorld).sub(jointPos);
+    const endLen = toEnd.length();
+    const targetLen = toTarget.length();
+    if (endLen < 1e-6 || targetLen < 1e-6) return;
+    toEnd.multiplyScalar(1 / endLen);
+    toTarget.multiplyScalar(1 / targetLen);
+    const cosTheta = clamp(toEnd.dot(toTarget), -1, 1);
+    const angle = Math.acos(cosTheta);
+    if (!Number.isFinite(angle) || angle < 1e-5) return;
+    axis.crossVectors(toEnd, toTarget);
+    if (axis.lengthSq() < 1e-8) return;
+    axis.normalize();
+    const limited = Math.min(angle, SEATED_CONTACT_IK_MAX_STEP_RAD) * blend;
+    worldDeltaQ.setFromAxisAngle(axis, limited);
+    applyWorldRotationDeltaToBone(bone, worldDeltaQ);
+    bone.updateMatrixWorld?.(true);
+    hand.updateMatrixWorld?.(true);
+  };
+
+  actor.updateMatrixWorld(true);
+  for (let i = 0; i < SEATED_CONTACT_IK_ITERATIONS; i += 1) {
+    applyBoneStep(lower);
+    applyBoneStep(upper);
+  }
+}
+
 function resolveSeatedHumanActionPose(actorState, gameState, playerIndex, nowMs) {
   const basePose = {
     mode: 'idle',
@@ -5988,6 +6176,8 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
   const firearmShotSoundRef = useRef(null);
   const firearmShellSoundRef = useRef(null);
   const firearmGlassSoundRef = useRef(null);
+  const fpsGunShotSoundRef = useRef(null);
+  const fpsGunReloadSoundRef = useRef(null);
   const droneSoundRef = useRef(null);
   const fighterJetSoundRef = useRef(null);
   const helicopterSoundRef = useRef(null);
@@ -6029,7 +6219,9 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     capturePlayer: null,
     captureStartMs: 0,
     captureEndMs: 0,
-    captureAnimationId: null
+    captureAnimationId: null,
+    captureLeftHandTarget: null,
+    captureTwoHanded: false
   });
   const fitRef = useRef(() => {});
   const cameraRef = useRef(null);
@@ -6037,6 +6229,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
   const saved3dCameraStateRef = useRef(null);
   const captureFxRef = useRef(null);
   const parkedCaptureVehiclesRef = useRef(new Map());
+  const weaponAnimationMixersRef = useRef(new Set());
   const activePlayerCount = useMemo(() => clampPlayerCount(playerCount), [playerCount]);
   const aiSlots = Math.max(0, activePlayerCount - 1);
   const aiOpponentCount = useMemo(
@@ -6523,6 +6716,9 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         if (showFirearm) {
           void applyCaptureWeaponDisplay(entry, selectedCaptureAnimationId);
         } else {
+          entry?.weaponHolder?.children?.forEach?.((child) => {
+            stopCaptureWeaponMixersForObjectTree(child, entry.weaponAnimationMixers);
+          });
           entry.weaponHolder?.clear?.();
           entry.selectedCaptureAnimationId = null;
         }
@@ -6615,6 +6811,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         droneTruck: droneTruckFx.root,
         weaponRack: weaponRackFx.root,
         weaponHolder: weaponRackFx.weaponHolder ?? null,
+        weaponAnimationMixers: weaponAnimationMixersRef.current,
         actionButton: weaponRackFx.actionButton ?? null,
         actionButtonHit: weaponRackFx.actionButtonHit ?? null,
         weaponRackHit: weaponRackFx.weaponRackHit ?? null,
@@ -7759,7 +7956,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
   useEffect(() => {
     const applyVolume = (baseVolume) => {
       const level = settingsRef.current.soundEnabled ? baseVolume : 0;
-      [moveSoundRef, captureSoundRef, missileLaunchSoundRef, missileImpactSoundRef, firearmShotSoundRef, firearmShellSoundRef, firearmGlassSoundRef, droneSoundRef, fighterJetSoundRef, helicopterSoundRef, cheerSoundRef, diceSoundRef, diceRewardSoundRef, sixRollSoundRef, hahaSoundRef, giftBombSoundRef].forEach((ref) => {
+      [moveSoundRef, captureSoundRef, missileLaunchSoundRef, missileImpactSoundRef, firearmShotSoundRef, firearmShellSoundRef, firearmGlassSoundRef, fpsGunShotSoundRef, fpsGunReloadSoundRef, droneSoundRef, fighterJetSoundRef, helicopterSoundRef, cheerSoundRef, diceSoundRef, diceRewardSoundRef, sixRollSoundRef, hahaSoundRef, giftBombSoundRef].forEach((ref) => {
         if (ref.current) {
           ref.current.volume = level;
           if (!settingsRef.current.soundEnabled) {
@@ -7779,6 +7976,8 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     firearmShotSoundRef.current = new Audio(LUDO_CAPTURE_FIREARM_SHOT_SOUND_URL);
     firearmShellSoundRef.current = new Audio(LUDO_CAPTURE_FIREARM_SHELL_SOUND_URL);
     firearmGlassSoundRef.current = new Audio(LUDO_CAPTURE_GLASS_SHATTER_SOUND_URL);
+    fpsGunShotSoundRef.current = new Audio(FPS_GUN_SOURCE_SHOT_SOUND_URL);
+    fpsGunReloadSoundRef.current = new Audio(FPS_GUN_SOURCE_RELOAD_SOUND_URL);
     droneSoundRef.current = new Audio(LUDO_CAPTURE_DRONE_SOUND_URL);
     droneSoundRef.current.loop = true;
     droneSoundRef.current.volume = 0.42;
@@ -8349,7 +8548,8 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           actor,
           rig,
           actionHelpers,
-          chairSupportsArmrest: chair.supportsArmrest !== false
+          chairSupportsArmrest: chair.supportsArmrest !== false,
+          weaponAnimationMixers: weaponAnimationMixersRef.current
         });
       }
     } catch (error) {
@@ -8683,6 +8883,11 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       lastRenderTime = now - Math.max(0, deltaMs - appliedDeltaMs);
       const delta = appliedDeltaMs / 1000;
       // Keep parked aircraft static; rotor/propeller animation only runs during active strikes.
+      if (weaponAnimationMixersRef.current.size > 0) {
+        weaponAnimationMixersRef.current.forEach((mixer) => {
+          mixer?.update?.(delta);
+        });
+      }
 
       const state = stateRef.current;
       if (state?.animation?.active) {
@@ -8758,6 +8963,8 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         actorState.captureStartMs = 0;
         actorState.captureEndMs = 0;
         actorState.captureAnimationId = null;
+        actorState.captureLeftHandTarget = null;
+        actorState.captureTwoHanded = false;
       }
       const actors = seatedHumanActorsRef.current;
       if (Array.isArray(actors) && actors.length) {
@@ -8837,6 +9044,13 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             };
             const contactWeight = contactWeightByMode[pose.mode] ?? 1;
             solveSeatedRightArmContactIK(entry, handContactTarget, contactWeight, 'contactEffector');
+          }
+          if (
+            actorState?.captureTwoHanded &&
+            actorState?.capturePlayer === playerIndex &&
+            actorState?.captureLeftHandTarget?.isVector3
+          ) {
+            solveSeatedLeftArmContactIK(entry, actorState.captureLeftHandTarget, 0.88);
           }
         });
       }
@@ -8961,7 +9175,9 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         capturePlayer: null,
         captureStartMs: 0,
         captureEndMs: 0,
-        captureAnimationId: null
+        captureAnimationId: null,
+        captureLeftHandTarget: null,
+        captureTwoHanded: false
       };
       setSeatAnchors([]);
       stateRef.current = null;
@@ -9028,12 +9244,20 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         captureFxRef.current = null;
       }
       parkedCaptureVehiclesRef.current.forEach((entry) => {
+        entry?.weaponHolder?.children?.forEach?.((child) => {
+          stopCaptureWeaponMixersForObjectTree(child, weaponAnimationMixersRef.current);
+        });
         entry?.jet?.parent?.remove?.(entry.jet);
         entry?.helicopter?.parent?.remove?.(entry.helicopter);
         entry?.drone?.parent?.remove?.(entry.drone);
         entry?.missile?.parent?.remove?.(entry.missile);
         entry?.droneTruck?.parent?.remove?.(entry.droneTruck);
+        entry?.weaponRack?.parent?.remove?.(entry.weaponRack);
       });
+      weaponAnimationMixersRef.current.forEach((mixer) => {
+        mixer?.stopAllAction?.();
+      });
+      weaponAnimationMixersRef.current.clear();
       parkedCaptureVehiclesRef.current.clear();
       arenaRef.current = null;
       rendererRef.current = null;
@@ -9082,10 +9306,22 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     missileImpactSoundRef.current.currentTime = 0;
     missileImpactSoundRef.current.play().catch(() => {});
   };
-  const playFirearmShotSound = () => {
-    if (!settingsRef.current.soundEnabled || !firearmShotSoundRef.current) return;
-    firearmShotSoundRef.current.currentTime = 0;
-    firearmShotSoundRef.current.play().catch(() => {});
+  const playFirearmShotSound = (captureAnimationId = '') => {
+    if (!settingsRef.current.soundEnabled) return;
+    const audio =
+      captureAnimationId === 'fpsGunAttack' && fpsGunShotSoundRef.current
+        ? fpsGunShotSoundRef.current
+        : firearmShotSoundRef.current;
+    if (!audio) return;
+    audio.currentTime = 0;
+    audio.play().catch(() => {});
+  };
+  const playFirearmReloadSound = (captureAnimationId = '') => {
+    if (!settingsRef.current.soundEnabled) return;
+    const audio = captureAnimationId === 'fpsGunAttack' ? fpsGunReloadSoundRef.current : null;
+    if (!audio) return;
+    audio.currentTime = 0;
+    audio.play().catch(() => {});
   };
   const playFirearmShellSound = () => {
     if (!settingsRef.current.soundEnabled || !firearmShellSoundRef.current) return;
@@ -9220,7 +9456,9 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           capturePlayer: attackerPlayer,
           captureStartMs: performance.now(),
           captureEndMs: performance.now() + 3600,
-          captureAnimationId: resolvedCaptureAnimationId
+          captureAnimationId: resolvedCaptureAnimationId,
+          captureLeftHandTarget: null,
+          captureTwoHanded: false
         };
         const captureTuning = resolveCaptureAttackTuning(resolvedCaptureAnimationId);
         const isHelicopterAttack = resolvedCaptureAnimationId === 'helicopterAttack';
@@ -9235,6 +9473,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           const shellBase = new THREE.Vector3();
           const shooterRoot = attackerEntry?.actorRoot;
           const handWeaponAttachment = await attachFirearmToRightHand(attackerEntry, resolvedCaptureAnimationId);
+          const isTwoHandFirearm = TWO_HAND_FIREARM_IDS.has(resolvedCaptureAnimationId);
           const pickupLeadMs = 280;
           const reloadLeadMs = 320;
           const aimLeadMs = 240;
@@ -9260,6 +9499,8 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           const shells = Array.from({ length: Math.max(16, Math.min(42, shots + 6)) }, () => createCaptureShellCasingFx());
           const targetReticle = createCaptureTargetReticleFx();
           const shellStates = shells.map(() => ({ landed: false, settledAt: 0 }));
+          let animationTriggered = false;
+          let reloadTriggered = false;
           scene.add(muzzleFx.root);
           tracers.forEach((entry) => scene.add(entry.root));
           shells.forEach((entry) => scene.add(entry));
@@ -9270,9 +9511,25 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             const elapsed = performance.now() - volleyStart;
             const elapsedShooting = Math.max(0, elapsed - preFireLeadMs);
             const shotIdx = Math.floor(elapsedShooting / cadenceMs);
+            if (!reloadTriggered && elapsed >= pickupLeadMs + 40) {
+              reloadTriggered = true;
+              playFirearmReloadSound(resolvedCaptureAnimationId);
+            }
+            if (!animationTriggered && elapsed >= preFireLeadMs) {
+              animationTriggered = true;
+              handWeaponAttachment?.playAnimation?.();
+            }
             if (handWeaponAttachment?.muzzle?.isObject3D) {
               handWeaponAttachment.muzzle.updateMatrixWorld?.(true);
               handWeaponAttachment.muzzle.getWorldPosition(muzzleOrigin);
+            }
+            if (isTwoHandFirearm && handWeaponAttachment?.leftGrip?.isObject3D) {
+              handWeaponAttachment.leftGrip.updateMatrixWorld?.(true);
+              seatedHumanActionRef.current.captureLeftHandTarget = handWeaponAttachment.leftGrip.getWorldPosition(new THREE.Vector3());
+              seatedHumanActionRef.current.captureTwoHanded = true;
+            } else {
+              seatedHumanActionRef.current.captureLeftHandTarget = null;
+              seatedHumanActionRef.current.captureTwoHanded = false;
             }
             if (elapsed < pickupLeadMs && handWeaponAttachment?.weapon?.isObject3D && rackWorld.isVector3) {
               const blend = easeInOutSine01(elapsed / Math.max(1, pickupLeadMs));
@@ -9326,7 +9583,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             targetReticle.vertical.material.opacity = clamp(0.5 + reticlePulse * 0.4, 0, 1);
             if (elapsed >= preFireLeadMs && elapsedShooting >= 0 && elapsedShooting < shots * cadenceMs) {
               if (elapsedShooting % cadenceMs < 16) {
-                playFirearmShotSound();
+                playFirearmShotSound(resolvedCaptureAnimationId);
                 playFirearmShellSound();
               }
               const pulse = 1 - ((elapsedShooting % cadenceMs) / Math.max(1, cadenceMs));
@@ -9406,7 +9663,9 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
               capturePlayer: null,
               captureStartMs: 0,
               captureEndMs: 0,
-              captureAnimationId: null
+              captureAnimationId: null,
+              captureLeftHandTarget: null,
+              captureTwoHanded: false
             };
             resolve();
           };
@@ -10063,7 +10322,9 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             capturePlayer: null,
             captureStartMs: 0,
             captureEndMs: 0,
-            captureAnimationId: null
+            captureAnimationId: null,
+            captureLeftHandTarget: null,
+            captureTwoHanded: false
           };
           resolve();
         };
@@ -10095,7 +10356,9 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             capturePlayer: null,
             captureStartMs: 0,
             captureEndMs: 0,
-            captureAnimationId: null
+            captureAnimationId: null,
+            captureLeftHandTarget: null,
+            captureTwoHanded: false
           };
           resolve();
         }


### PR DESCRIPTION
### Motivation
- Improve capture weapon visuals by loading and playing glTF animation clips on weapon models and support two-handed firearms so seated actors can hold rifles correctly.
- Add distinct FPS gun shot/reload sounds and better lifecycle for weapon animation mixers to avoid leaked mixers and ensure correct cleanup.

### Description
- Persist glTF animation clips into `root.userData.animationClips` when loading models and add `startCaptureWeaponAnimation` / `stopCaptureWeaponMixersForObjectTree` helpers to create and manage `THREE.AnimationMixer` instances for cloned weapon models.`
- Add helpers `findWeaponNodeByNeedles` and `shiftObjectByWorldDelta` to align grip nodes and shift weapon clones into the attacker hand; update `attachFirearmToRightHand` to start animations, find left/right grip nodes, add a `leftGrip` helper, and expose `playAnimation` and proper `release` cleanup.
- Add `TWO_HAND_FIREARM_IDS` and wire two-handed logic into the capture sequence so the left hand target is sampled and the left-arm IK solver (`solveSeatedLeftArmContactIK`) is invoked while firing.
- Increase `fpsGunAttack` scale and adjust `fpsGunAttack` hand attachment tuning; add FPS shot and reload audio URLs, refs, and play logic (use FPS-specific sounds when `captureAnimationId === 'fpsGunAttack'`) and trigger reload sound before firing.
- Update render loop and teardown to update and clear `weaponAnimationMixersRef`, stop/uncache mixers when clearing weapon displays, and ensure parked weapon racks stop associated mixers on dispose.

### Testing
- Ran the project's automated test suite with `yarn test` and linting with `yarn lint`, which completed without failures. 
- Performed a development build (`yarn build`) and run-time smoke tests exercising capture attacks (firearms, two-handed rifles, and FPS gun) in the local dev environment; no errors observed and audio/animation playback behaved as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef55b547808329b493f56c455a6ec5)