### PR TITLE
Snooker Royal: integrate Bilardo Shqip avatar motion & rules adapter and match Bilardo cue power behavior

### DIFF
--- a/src/rules/BilardoShqipRules.ts
+++ b/src/rules/BilardoShqipRules.ts
@@ -61,6 +61,25 @@ export class BilardoShqipRules {
     };
   }
 
+
+  applySnapshot(snapshot?: Partial<ReturnType<BilardoShqipRules["getSnapshot"]>> | null) {
+    if (!snapshot || typeof snapshot !== 'object') return;
+    const scoreA = Number(snapshot.scores?.A);
+    const scoreB = Number(snapshot.scores?.B);
+    this.scores = {
+      A: Number.isFinite(scoreA) ? Math.max(0, Math.floor(scoreA)) : 0,
+      B: Number.isFinite(scoreB) ? Math.max(0, Math.floor(scoreB)) : 0
+    };
+    this.currentPlayer = snapshot.currentPlayer === 'B' ? 'B' : 'A';
+    this.winner = snapshot.winner === 'A' || snapshot.winner === 'B' ? snapshot.winner : null;
+    this.cueBallInHand = Boolean(snapshot.cueBallInHand);
+    const ballsRemainingRaw = Number(snapshot.ballsRemaining);
+    const ballsRemaining = Number.isFinite(ballsRemainingRaw)
+      ? Math.max(0, Math.min(15, Math.floor(ballsRemainingRaw)))
+      : 15;
+    this.ballsOnTable = new Set(Array.from({ length: ballsRemaining }, (_, index) => index + 1));
+  }
+
   resolveShot(summary: BilardoShotSummary): BilardoShotResult {
     const active = this.currentPlayer;
     const opponent: BilardoPlayer = active === 'A' ? 'B' : 'A';

--- a/src/rules/SnookerRoyalBilardoAdapter.ts
+++ b/src/rules/SnookerRoyalBilardoAdapter.ts
@@ -1,0 +1,165 @@
+import { Ball, BallColor, FrameState, Player, ShotContext, ShotEvent } from '../types';
+import { BilardoShqipRules } from './BilardoShqipRules';
+
+type BilardoMeta = {
+  variant: 'bilardo-shqip';
+  hud: {
+    next: string;
+    phase: string;
+    scores: { A: number; B: number };
+  };
+  state: {
+    ballInHand: boolean;
+  };
+  bilardoSnapshot?: ReturnType<BilardoShqipRules['getSnapshot']>;
+};
+
+const COLOR_TO_NUMBER: Partial<Record<BallColor, number>> = {
+  RED: 1,
+  YELLOW: 2,
+  GREEN: 3,
+  BROWN: 4,
+  BLUE: 5,
+  PINK: 6,
+  BLACK: 7
+};
+
+function buildInitialBalls(): Ball[] {
+  const reds = Array.from({ length: 15 }, (_, index) => ({
+    id: `RED_${index + 1}`,
+    color: 'RED' as BallColor,
+    onTable: true,
+    potted: false
+  }));
+  const colors: Ball[] = ['YELLOW', 'GREEN', 'BROWN', 'BLUE', 'PINK', 'BLACK'].map((color) => ({
+    id: color,
+    color: color as BallColor,
+    onTable: true,
+    potted: false
+  }));
+  return [...reds, ...colors, { id: 'CUE', color: 'CUE', onTable: true, potted: false }];
+}
+
+function normalizeNumber(raw: unknown): number | null {
+  if (typeof raw === 'number' && Number.isFinite(raw)) {
+    const rounded = Math.round(raw);
+    return rounded >= 1 && rounded <= 15 ? rounded : null;
+  }
+  if (typeof raw !== 'string') return null;
+  const text = raw.trim().toUpperCase();
+  const idMatch = text.match(/(?:RED_|BALL_)?(\d{1,2})$/);
+  if (idMatch) {
+    const parsed = Number(idMatch[1]);
+    return Number.isFinite(parsed) && parsed >= 1 && parsed <= 15 ? parsed : null;
+  }
+  return (COLOR_TO_NUMBER[text as BallColor] as number | undefined) ?? null;
+}
+
+function basePlayers(playerA: string, playerB: string): { A: Player; B: Player } {
+  return {
+    A: { id: 'A', name: playerA, score: 0 },
+    B: { id: 'B', name: playerB, score: 0 }
+  };
+}
+
+export class SnookerRoyalBilardoAdapter {
+  constructor(private readonly raceTo = 61) {}
+
+  getInitialFrame(playerA: string, playerB: string): FrameState {
+    const rules = new BilardoShqipRules(this.raceTo);
+    const snapshot = rules.getSnapshot();
+    return {
+      balls: buildInitialBalls(),
+      activePlayer: snapshot.currentPlayer,
+      players: basePlayers(playerA, playerB),
+      currentBreak: 0,
+      phase: 'OPENING',
+      redsRemaining: 15,
+      ballOn: [String(snapshot.nextRequiredBall ?? 'open')],
+      freeBall: false,
+      colorOnAfterRed: false,
+      frameOver: false,
+      winner: undefined,
+      meta: {
+        variant: 'bilardo-shqip',
+        hud: {
+          next: `Ball ${snapshot.nextRequiredBall ?? '-'}`,
+          phase: 'bilardo-shqip',
+          scores: snapshot.scores
+        },
+        state: {
+          ballInHand: snapshot.cueBallInHand
+        },
+        bilardoSnapshot: snapshot
+      } satisfies BilardoMeta
+    };
+  }
+
+  applyShot(state: FrameState, events: ShotEvent[], context: ShotContext = {}): FrameState {
+    const meta = (state.meta as BilardoMeta | undefined) ?? undefined;
+    const snapshot = meta?.bilardoSnapshot;
+    const rules = new BilardoShqipRules(snapshot?.raceTo ?? this.raceTo);
+    rules.applySnapshot(snapshot);
+
+    const hitEvent = events.find((event) => event.type === 'HIT') as
+      | { type: 'HIT'; firstContact?: unknown; ballId?: unknown }
+      | undefined;
+    const firstContact = normalizeNumber(hitEvent?.firstContact ?? hitEvent?.ballId);
+
+    const potted = events
+      .filter((event) => event.type === 'POTTED')
+      .map((event) => {
+        const pottedEvent = event as { type: 'POTTED'; ball?: unknown; ballId?: unknown };
+        return normalizeNumber(pottedEvent.ballId ?? pottedEvent.ball);
+      })
+      .filter((value): value is number => Number.isFinite(value));
+
+    const cueBallPotted = Boolean(context.cueBallPotted) || events.some((event) => {
+      if (event.type !== 'POTTED') return false;
+      const pottedEvent = event as { ball?: unknown; ballId?: unknown };
+      return String(pottedEvent.ball ?? pottedEvent.ballId ?? '').toUpperCase() === 'CUE';
+    });
+
+    const result = rules.resolveShot({
+      firstContact,
+      potted,
+      cueBallPotted
+    });
+
+    const nextSnapshot = rules.getSnapshot();
+    const nextPlayers = {
+      A: { ...(state.players?.A ?? { id: 'A', name: 'A', score: 0 }), score: result.scores.A },
+      B: { ...(state.players?.B ?? { id: 'B', name: 'B', score: 0 }), score: result.scores.B }
+    };
+
+    return {
+      ...state,
+      players: nextPlayers,
+      activePlayer: result.nextPlayer,
+      currentBreak: result.keepTurn ? (state.currentBreak ?? 0) + result.scored : 0,
+      ballOn: [String(nextSnapshot.nextRequiredBall ?? 'open')],
+      foul: result.foul
+        ? {
+            points: 4,
+            reason: result.reason || 'foul'
+          }
+        : undefined,
+      frameOver: Boolean(result.winner),
+      winner: result.winner ?? undefined,
+      meta: {
+        variant: 'bilardo-shqip',
+        hud: {
+          next: `Ball ${nextSnapshot.nextRequiredBall ?? '-'}`,
+          phase: 'bilardo-shqip',
+          scores: result.scores
+        },
+        state: {
+          ballInHand: result.cueBallInHand
+        },
+        bilardoSnapshot: nextSnapshot
+      } satisfies BilardoMeta
+    };
+  }
+}
+
+export default SnookerRoyalBilardoAdapter;

--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -28,7 +28,7 @@ import {
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 import { addTransaction, getAccountBalance } from '../../utils/api.js';
 import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
-import { SnookerRoyalRules } from '../../../../src/rules/SnookerRoyalRules.ts';
+import { SnookerRoyalBilardoAdapter } from '../../../../src/rules/SnookerRoyalBilardoAdapter.ts';
 import { useAimCalibration } from '../../hooks/useAimCalibration.js';
 import { resolveTableSize } from '../../config/snookerClubTables.js';
 import { isGameMuted, getGameVolume } from '../../utils/sound.js';
@@ -94,7 +94,7 @@ import {
   SPIN_STUN_RADIUS
 } from './snookerRoyalSpinUtils.js';
 import { sampleCueStrokeTimeline } from './poolRoyaleCueStrokeTimeline.js';
-import { BILARDO_STRIKE_TIME_MS } from './shared/bilardoShotModel';
+import { BILARDO_MIN_RELEASE_POWER, BILARDO_STRIKE_TIME_MS, bilardoCueSpeed } from './shared/bilardoShotModel';
 import {
   createBilardoHumanRig,
   chooseHumanEdgePosition,
@@ -11189,7 +11189,7 @@ function SnookerRoyalGame({
   const mountRef = useRef(null);
   const rafRef = useRef(null);
   const worldRef = useRef(null);
-  const rules = useMemo(() => new SnookerRoyalRules(variantKey), [variantKey]);
+  const rules = useMemo(() => new SnookerRoyalBilardoAdapter(61), []);
   const tournamentMode = playType === 'tournament';
   const tournamentPlayers = useMemo(() => {
     const params = new URLSearchParams(location.search);
@@ -21801,8 +21801,9 @@ const powerRef = useRef(hud.power);
           }
           lastPocketBallRef.current = null;
           const clampedPower = THREE.MathUtils.clamp(powerRef.current, 0, 1);
-          lastShotPower = clampedPower;
-          const isMaxPowerShot = clampedPower >= MAX_POWER_BOUNCE_THRESHOLD;
+          const releasePower = clampedPower < BILARDO_MIN_RELEASE_POWER ? 0 : clampedPower;
+          lastShotPower = releasePower;
+          const isMaxPowerShot = releasePower >= MAX_POWER_BOUNCE_THRESHOLD;
           powerImpactHoldRef.current = isMaxPowerShot
             ? performance.now() + MAX_POWER_CAMERA_HOLD_MS
             : 0;
@@ -21816,7 +21817,7 @@ const powerRef = useRef(hud.power);
             spinRef.current?.x ?? 0,
             spinRef.current?.y ?? 0
           );
-          const isPowerShot = clampedPower >= POWER_REPLAY_THRESHOLD;
+          const isPowerShot = releasePower >= POWER_REPLAY_THRESHOLD;
           if (isPowerShot) replayTags.add('power');
           if (spinMagnitude >= SPIN_REPLAY_THRESHOLD) replayTags.add('spin');
           const shouldRecordReplay = true;
@@ -21824,11 +21825,10 @@ const powerRef = useRef(hud.power);
             replayTags.size > 0 && !replayTags.has('long') && !replayTags.has('bank');
           const frameStateCurrent = frameRef.current ?? null;
           const isBreakShot = (frameStateCurrent?.currentBreak ?? 0) === 0;
-          const powerScale = SHOT_MIN_FACTOR + SHOT_POWER_RANGE * clampedPower;
-          const speedBase = SHOT_BASE_SPEED * (isBreakShot ? SHOT_BREAK_MULTIPLIER : 1);
+          const speedBase = bilardoCueSpeed(releasePower) * (isBreakShot ? SHOT_BREAK_MULTIPLIER : 1);
           const base = aimDir
             .clone()
-            .multiplyScalar(speedBase * powerScale);
+            .multiplyScalar(speedBase);
           const predictedCueSpeed = base.length();
           shotPrediction.speed = predictedCueSpeed;
           if (shouldRecordReplay) {


### PR DESCRIPTION
### Motivation
- Make Snooker Royal use the Bilardo Shqip seated human motion/rig and Bilardo gameplay logic so the human avatar behavior and shot-feel match the BilardoShqip implementation while keeping Snooker visuals (table, balls, pockets) intact.
- Ensure rule state can be persisted/restored between shots so Bilardo logic can be embedded inside Snooker’s frame lifecycle.

### Description
- Added a new adapter `src/rules/SnookerRoyalBilardoAdapter.ts` which maps Snooker frame/shot events to the `BilardoShqipRules` API and returns a `FrameState` compatible snapshot for the Snooker UI. 
- Extended `src/rules/BilardoShqipRules.ts` with `applySnapshot(...)` to hydrate rule state from a saved snapshot so the adapter can restore and continue Bilardo state across shots. 
- Updated `webapp/src/pages/Games/SnookerRoyal.jsx` to instantiate the adapter via `new SnookerRoyalBilardoAdapter(61)`, to import Bilardo motion/power helpers (`BILARDO_MIN_RELEASE_POWER`, `bilardoCueSpeed`), to apply a Bilardo minimum-release cutoff for tiny pulls, and to compute cue launch speed using `bilardoCueSpeed(...)` instead of the previous linear power scaling so the cue motion and shot launch match Bilardo feel. 
- Kept existing Snooker scene, table, cue and ball assets/rendering unchanged and only changed rule-resolution and cue-power/release paths to mirror Bilardo behavior.

### Testing
- Ran the TypeScript build with `npm run -s build`, which completed successfully and validated the new files compile with the project TypeScript configuration. 
- No other automated test suites were run as part of this change (no unit/test changes were required).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef611f23848329ae5dce54d59b6671)