### PR TITLE
Integrate Bilardo Shqiptar rules and human rig into Snooker Royal

### DIFF
--- a/src/rules/SnookerRoyalRules.ts
+++ b/src/rules/SnookerRoyalRules.ts
@@ -1,4 +1,5 @@
 import { Ball, BallColor, FrameState, Player, ShotContext, ShotEvent } from '../types';
+import { BilardoShqipRules } from './BilardoShqipRules';
 
 type HudInfo = {
   next: string;
@@ -133,9 +134,48 @@ function isBallState(value: unknown): value is Ball {
 }
 
 export class SnookerRoyalRules {
-  constructor(_variant?: string | null) {}
+  private readonly variantMode: 'snooker' | 'bilardo-shqip';
+
+  private bilardoEngine: BilardoShqipRules | null = null;
+
+  constructor(variant?: string | null) {
+    this.variantMode =
+      typeof variant === 'string' && variant.toLowerCase() === 'bilardo-shqip'
+        ? 'bilardo-shqip'
+        : 'snooker';
+  }
 
   getInitialFrame(playerA: string, playerB: string): FrameState {
+    if (this.variantMode === 'bilardo-shqip') {
+      this.bilardoEngine = new BilardoShqipRules(61);
+      const snapshot = this.bilardoEngine.getSnapshot();
+      return {
+        balls: buildInitialBalls(),
+        activePlayer: snapshot.currentPlayer,
+        players: {
+          A: { id: 'A', name: playerA, score: snapshot.scores.A },
+          B: { id: 'B', name: playerB, score: snapshot.scores.B }
+        },
+        currentBreak: 0,
+        phase: 'REDS_AND_COLORS',
+        redsRemaining: snapshot.ballsRemaining,
+        ballOn: [String(snapshot.nextRequiredBall ?? '-')],
+        frameOver: false,
+        colorOnAfterRed: false,
+        freeBall: false,
+        meta: {
+          variant: 'bilardo-shqip',
+          hud: {
+            next: snapshot.nextRequiredBall != null ? `ball ${snapshot.nextRequiredBall}` : 'race complete',
+            phase: 'bilardo shqip',
+            scores: snapshot.scores
+          },
+          state: {
+            ballInHand: snapshot.cueBallInHand
+          }
+        }
+      };
+    }
     const base: FrameState = {
       balls: buildInitialBalls(),
       activePlayer: 'A',
@@ -162,6 +202,87 @@ export class SnookerRoyalRules {
   }
 
   applyShot(state: FrameState, events: ShotEvent[], context: ShotContext = {}): FrameState {
+    if (this.variantMode === 'bilardo-shqip') {
+      if (!this.bilardoEngine) {
+        this.bilardoEngine = new BilardoShqipRules(61);
+      }
+      const normalizeBallNumber = (value: unknown): number | null => {
+        if (typeof value === 'number' && Number.isFinite(value)) {
+          const rounded = Math.round(value);
+          return rounded >= 1 && rounded <= 15 ? rounded : null;
+        }
+        if (typeof value === 'string') {
+          const lower = value.toLowerCase();
+          if (lower === 'cue' || lower === 'cue_ball') return null;
+          const match = lower.match(/\d+/);
+          if (!match) return null;
+          const parsed = Number.parseInt(match[0], 10);
+          return parsed >= 1 && parsed <= 15 ? parsed : null;
+        }
+        return null;
+      };
+      const hitEvent = events.find((event) => event.type === 'HIT') as
+        | { type: 'HIT'; firstContact?: unknown; ballId?: unknown }
+        | undefined;
+      const firstContact = normalizeBallNumber(hitEvent?.firstContact ?? hitEvent?.ballId);
+      const pottedBallNumbers = events
+        .filter((event) => event.type === 'POTTED')
+        .map((event) => {
+          const potted = event as { type: 'POTTED'; ball?: unknown; ballId?: unknown };
+          return normalizeBallNumber(potted.ballId ?? potted.ball);
+        })
+        .filter((value): value is number => value != null);
+      const cueBallPotted =
+        Boolean(context.cueBallPotted) ||
+        events.some((event) => {
+          if (event.type !== 'POTTED') return false;
+          const potted = event as { type: 'POTTED'; ball?: unknown; ballId?: unknown };
+          const raw = potted.ballId ?? potted.ball;
+          if (typeof raw !== 'string') return false;
+          const normalized = raw.toLowerCase();
+          return normalized === 'cue' || normalized === 'cue_ball';
+        });
+      const resolved = this.bilardoEngine.resolveShot({
+        firstContact,
+        potted: pottedBallNumbers,
+        cueBallPotted
+      });
+      const snapshot = this.bilardoEngine.getSnapshot();
+      const nextRequiredBall = snapshot.nextRequiredBall;
+      return {
+        ...state,
+        activePlayer: resolved.nextPlayer,
+        players: {
+          A: { ...state.players.A, score: resolved.scores.A },
+          B: { ...state.players.B, score: resolved.scores.B }
+        },
+        currentBreak: resolved.keepTurn ? resolved.scored : 0,
+        phase: 'REDS_AND_COLORS',
+        redsRemaining: snapshot.ballsRemaining,
+        colorOnAfterRed: false,
+        freeBall: false,
+        ballOn: [String(nextRequiredBall ?? '-')],
+        frameOver: Boolean(resolved.winner),
+        winner: resolved.winner ?? undefined,
+        foul: resolved.foul
+          ? {
+              points: 4,
+              reason: resolved.reason ?? 'foul'
+            }
+          : undefined,
+        meta: {
+          variant: 'bilardo-shqip',
+          hud: {
+            next: nextRequiredBall != null ? `ball ${nextRequiredBall}` : 'race complete',
+            phase: 'bilardo shqip',
+            scores: resolved.scores
+          },
+          state: {
+            ballInHand: resolved.cueBallInHand
+          }
+        }
+      };
+    }
     const meta = state.meta as SnookerMeta | undefined;
     const colorsRemaining = Array.isArray(meta?.colorsRemaining)
       ? [...meta.colorsRemaining]

--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -94,7 +94,10 @@ import {
   SPIN_STUN_RADIUS
 } from './snookerRoyalSpinUtils.js';
 import { sampleCueStrokeTimeline } from './poolRoyaleCueStrokeTimeline.js';
-import { BILARDO_STRIKE_TIME_MS } from './shared/bilardoShotModel';
+import {
+  BILARDO_MIN_RELEASE_POWER,
+  BILARDO_STRIKE_TIME_MS
+} from './shared/bilardoShotModel';
 import {
   createBilardoHumanRig,
   chooseHumanEdgePosition,
@@ -108,11 +111,11 @@ const BILARDO_SHARED_HUMAN_GLTF_URL = 'https://threejs.org/examples/models/gltf/
 const BILARDO_REFERENCE_TABLE_TOP_Y = 0.84;
 const BILARDO_REFERENCE_HUMAN_HEIGHT = BILARDO_REFERENCE_TABLE_TOP_Y * 2;
 const SNOOKER_HUMAN_BASE_SCALE = 1.18;
-const SNOOKER_HUMAN_VISUAL_SCALE_BOOST = 2.22;
-const SNOOKER_HUMAN_EDGE_MARGIN_FACTOR = 4.1;
-const SNOOKER_HUMAN_DESIRED_SHOOT_DISTANCE_FACTOR = 13.8;
+const SNOOKER_HUMAN_VISUAL_SCALE_BOOST = 1;
+const SNOOKER_HUMAN_EDGE_MARGIN_FACTOR = 11.2;
+const SNOOKER_HUMAN_DESIRED_SHOOT_DISTANCE_FACTOR = 19.3;
 const SNOOKER_HUMAN_CAMERA_LOWERED_BLEND_THRESHOLD = 0.42;
-const SNOOKER_HUMAN_PULL_TO_POSE_THRESHOLD = 0.035;
+const SNOOKER_HUMAN_PULL_TO_POSE_THRESHOLD = BILARDO_MIN_RELEASE_POWER;
 const SNOOKER_HUMAN_CUE_HAND_GRIP_RATIO = 0.76;
 const SNOOKER_HUMAN_CUE_GRIP_BACK_OFFSET = 0;
 
@@ -11189,7 +11192,7 @@ function SnookerRoyalGame({
   const mountRef = useRef(null);
   const rafRef = useRef(null);
   const worldRef = useRef(null);
-  const rules = useMemo(() => new SnookerRoyalRules(variantKey), [variantKey]);
+  const rules = useMemo(() => new SnookerRoyalRules('bilardo-shqip'), []);
   const tournamentMode = playType === 'tournament';
   const tournamentPlayers = useMemo(() => {
     const params = new URLSearchParams(location.search);


### PR DESCRIPTION
### Motivation
- Reuse the Bilardo Shqiptar player character rig and shot/rules logic in the Snooker Royal scene so the human character behavior and rule adjudication match the BilardoShqip game.
- Keep Snooker Royal’s existing table/ball/cue assets while delegating shot legality/scoring and player-state to the Bilardo engine for parity with the other game.
- Align human pose/interaction thresholds to Bilardo defaults so cue motion and pose feel identical between games.

### Description
- Added an adapter mode to `SnookerRoyalRules` which detects `bilardo-shqip`, imports `BilardoShqipRules`, bootstraps a `bilardoEngine`, and delegates shot resolution and scoring to it while preserving the Snooker frame-state shape (`src/rules/SnookerRoyalRules.ts`).
- Implemented normalization and mapping for hit/potted events to translate Snooker shot events into the `BilardoShqipRules.resolveShot` input and reflect the resolved state back into the Snooker frame (next player, scores, ball-in-hand, HUD info).
- Switched the Snooker Royal scene to use the Bilardo mode by constructing `new SnookerRoyalRules('bilardo-shqip')` and adjusted human rig tuning constants to match the shared Bilardo rig, including importing `BILARDO_MIN_RELEASE_POWER` and using it as the pull-to-pose threshold, reducing the visual scale boost and updating edge/distance factors (`webapp/src/pages/Games/SnookerRoyal.jsx`).

### Testing
- Ran a TypeScript build with `npm run build` which completed successfully.
- Executed unit tests with `npm test -- test/poolRoyaleRules.test.ts --runInBand` and the test suite passed (`5 passed`).
- No UI screenshot/test was produced in this environment; changes were validated via build and rule unit tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef611f23848329ae5dce54d59b6671)