### PR TITLE
Align Snooker Royal human pose behavior with Bilardo rig defaults

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -109,11 +109,10 @@ const BILARDO_REFERENCE_TABLE_TOP_Y = 0.84;
 const BILARDO_REFERENCE_HUMAN_HEIGHT = BILARDO_REFERENCE_TABLE_TOP_Y * 2;
 const SNOOKER_HUMAN_BASE_SCALE = 1.18;
 const SNOOKER_HUMAN_VISUAL_SCALE_BOOST = 2.22;
-const SNOOKER_HUMAN_EDGE_MARGIN_FACTOR = 4.1;
-const SNOOKER_HUMAN_DESIRED_SHOOT_DISTANCE_FACTOR = 13.8;
-const SNOOKER_HUMAN_CAMERA_LOWERED_BLEND_THRESHOLD = 0.42;
-const SNOOKER_HUMAN_PULL_TO_POSE_THRESHOLD = 0.035;
-const SNOOKER_HUMAN_CUE_HAND_GRIP_RATIO = 0.76;
+const BILARDO_EDGE_MARGIN_BALL_MULTIPLIER = 0.62 / 0.055;
+const BILARDO_DESIRED_SHOOT_DISTANCE_BALL_MULTIPLIER = 1.06 / 0.055;
+const BILARDO_PULL_TO_POSE_THRESHOLD = 0.035;
+const BILARDO_CUE_HAND_GRIP_RATIO = 0.76;
 const SNOOKER_HUMAN_CUE_GRIP_BACK_OFFSET = 0;
 
 function safePolygonUnion(...parts) {
@@ -20794,7 +20793,7 @@ const powerRef = useRef(hud.power);
       const bilardoSharedPose = {
         bridgeHandBackFromBall: 0.245,
         bridgeHandSide: -0.008,
-        gripRatio: SNOOKER_HUMAN_CUE_HAND_GRIP_RATIO,
+        gripRatio: BILARDO_CUE_HAND_GRIP_RATIO,
         idleRightOffset: new THREE.Vector3(0.24, 1.12, 0.02),
         idleLeftOffset: new THREE.Vector3(-0.18, 1.08, 0.03)
       };
@@ -20826,17 +20825,10 @@ const powerRef = useRef(hud.power);
       ) => {
         if (preferredState === 'striking') return 'striking';
         if (forcePose) return 'dragging';
-        const cameraBlend = THREE.MathUtils.clamp(
-          cameraBlendRef.current ?? 1,
-          0,
-          1
-        );
-        const cameraLowered =
-          cameraBlend <= SNOOKER_HUMAN_CAMERA_LOWERED_BLEND_THRESHOLD;
         const hasPull =
           THREE.MathUtils.clamp(powerValue ?? 0, 0, 1) >=
-          SNOOKER_HUMAN_PULL_TO_POSE_THRESHOLD;
-        return cameraLowered || hasPull ? 'dragging' : 'idle';
+          BILARDO_PULL_TO_POSE_THRESHOLD;
+        return hasPull ? 'dragging' : 'idle';
       };
 
       const closeCueGallery = () => {
@@ -25343,10 +25335,13 @@ const powerRef = useRef(hud.power);
           const rootTarget = chooseHumanEdgePosition(cueBallWorld, aimForward, {
             tableW: PLAY_W,
             tableL: PLAY_H,
-            edgeMargin: Math.max(BALL_R * SNOOKER_HUMAN_EDGE_MARGIN_FACTOR, SIDE_RAIL_INNER_THICKNESS * 1.2),
+            edgeMargin: Math.max(
+              BALL_R * BILARDO_EDGE_MARGIN_BALL_MULTIPLIER,
+              SIDE_RAIL_INNER_THICKNESS * 1.2
+            ),
             desiredShootDistance: Math.max(
               cueLen * 0.36,
-              BALL_R * SNOOKER_HUMAN_DESIRED_SHOOT_DISTANCE_FACTOR
+              BALL_R * BILARDO_DESIRED_SHOOT_DISTANCE_BALL_MULTIPLIER
             )
           });
           rootTarget.y = FLOOR_Y + Math.max(BALL_R * 0.08, 0.03);


### PR DESCRIPTION
### Motivation
- Make the Snooker human actor and cue motion match the Bilardo Shqip behavior so pose transitions and grip/bridge positioning are consistent between games while preserving on-screen size.

### Description
- Updated `webapp/src/pages/Games/SnookerRoyal.jsx` to reuse Bilardo pose constants by adding `BILARDO_EDGE_MARGIN_BALL_MULTIPLIER`, `BILARDO_DESIRED_SHOOT_DISTANCE_BALL_MULTIPLIER`, `BILARDO_PULL_TO_POSE_THRESHOLD`, and `BILARDO_CUE_HAND_GRIP_RATIO` and applying them where the Snooker code computed edge margin, desired shoot distance, and grip ratio.
- Removed Snooker-specific camera-blend gating from the pose-state decision so pose switching follows Bilardo-style pull-driven logic (drag when pull threshold met).
- Kept the existing Snooker human scale path intact so the visible character size and scale calculation remain unchanged.

### Testing
- Ran the webapp production build with `npm -C webapp run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef611f23848329ae5dce54d59b6671)