### PR TITLE
Adjust Ludo Battle Royal firearm size multipliers

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -502,25 +502,25 @@ const FIREARM_HAND_ATTACH_TUNING = Object.freeze({
 });
 const FIREARM_ATTACH_WORLD_SCALE_BOOST = 1.18;
 const FIREARM_ATTACH_SCALE_MULTIPLIER = Object.freeze({
-  // Keep glock as the grip-size baseline and upscale all other firearms so
-  // seated humans keep a consistent hand fit around the trigger/handle zone.
+  // Per-weapon overrides tuned for in-game readability on portrait mobile screens.
+  // Values intentionally diverge (e.g. FPS vs Glock) based on requested visual balance.
   mrtkGunAttack: 1.16,
   pistolHolsterAttack: 1.14,
-  fpsGunAttack: 1.72,
-  glockSidearmAttack: 0.98,
+  fpsGunAttack: 3.44,
+  glockSidearmAttack: 1.36,
   pistolSidearmAttack: 1.16,
-  uziSprayAttack: 1.2,
+  uziSprayAttack: 1.22,
   smgBurstAttack: 1.22,
   compactCarbineAttack: 1.34,
   assaultRifleAttack: 1.56,
-  ak47VolleyAttack: 1.64,
+  ak47VolleyAttack: 2.46,
   krsvBurstAttack: 1.58,
   smithSidearmAttack: 1.15,
   mosinMarksmanAttack: 1.72,
   sigsauerTacticalAttack: 1.2,
   shotgunBlastAttack: 1.7,
   marksmanDmrAttack: 1.48,
-  sniperShotAttack: 1.76,
+  sniperShotAttack: 3.52,
   grenadeBlastAttack: 1.12
 });
 const FIREARM_VOLLEY_SLOW_FACTOR = 1.72;


### PR DESCRIPTION
### Motivation
- Align on-screen firearm visuals with requested balance for portrait/mobile play by making FPS and sniper weapons larger, increasing AK47 size, enlarging Glock from its previous baseline, and matching Uzi to SMG burst sizing.

### Description
- Updated `FIREARM_ATTACH_SCALE_MULTIPLIER` in `webapp/src/pages/Games/LudoBattleRoyal.jsx` to apply the new per-weapon scale values. 
- Specific value changes: `fpsGunAttack` from `1.72` to `3.44`, `sniperShotAttack` from `1.76` to `3.52`, `ak47VolleyAttack` from `1.64` to `2.46`, `glockSidearmAttack` from `0.98` to `1.36`, and `uziSprayAttack` from `1.20` to `1.22` (matching `smgBurstAttack`).
- Adjusted the nearby comment to clarify that these are per-weapon portrait-screen tuning overrides. 
- No other gameplay logic, assets, or files were modified.

### Testing
- Ran `git diff --check -- webapp/src/pages/Games/LudoBattleRoyal.jsx` and it returned clean with no whitespace errors. 
- Verified the modified file is syntactically intact and the multiplier map is parseable; no automated unit or integration tests were run for this visual tuning change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef87c316508329b29c3d68136e8512)