### PR TITLE
Restore Pool Royale to Apr 20 06:00 snapshot (PoolRoyale.jsx)

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1931,9 +1931,8 @@ const CUE_FOLLOW_THROUGH_MAX = BALL_R * 8.4; // extend top-end follow-through so
 const REFERENCE_CUE_SPEED_BASE = 1.9; // align baseline launch speed with Bilardo Shqip shot feel
 const REFERENCE_CUE_SPEED_RANGE = 8.2; // align high-end launch speed with Bilardo Shqip shot feel
 const REFERENCE_CUE_SPEED_GAMMA = 1.08; // reference implementation: power curve
-const POOL_ROYALE_CUE_SPEED_BOOST = 1.35; // raise launch speed so cue-ball movement remains clear on release
 const MIN_SHOT_POWER_TO_FIRE = BILARDO_MIN_RELEASE_POWER; // keep Pool Royale release gate identical to Bilardo Shqip
-const HUMAN_PLAYER_HEIGHT_TO_SURFACE_MULTIPLIER = 2; // keep standing humans at 2x table-surface height
+const HUMAN_PLAYER_HEIGHT_RATIO_TO_TABLE = 0.88; // make player humans visibly bigger relative to table/balls
 const BILARDO_SHQIP_HUMAN_URL = 'https://threejs.org/examples/models/gltf/readyplayer.me.glb';
 const POOL_ROYALE_HUMAN_SCALE_MULTIPLIER = 1.18; // align with Bilardo Shqip human/table size relationship
 const HUMAN_PLAYER_IDLE_SWAY_SPEED = 1.2;
@@ -1945,11 +1944,9 @@ const HUMAN_MOVE_LAMBDA = 5.6;
 const HUMAN_ROT_LAMBDA = 8.5;
 const HUMAN_EDGE_MARGIN = 0.58;
 const HUMAN_DESIRED_SHOOT_DISTANCE = 1.06;
-const HUMAN_BRIDGE_HAND_BACK_FROM_BALL = 0.245;
-const HUMAN_BRIDGE_HAND_SIDE_OFFSET = -0.008;
 const HUMAN_SHOOT_BLEND_THRESHOLD = 0.42; // transition the shooter into cue-address pose once camera is lowered toward cue view
-const HUMAN_WALK_RING_MARGIN = TABLE.WALL * 2.05; // keep players closer to the table so the cue-address pose reaches naturally
-const HUMAN_TABLE_BLOCKER_MARGIN = TABLE.WALL * 1.2; // allow shooters to approach the rail while still preventing table clipping
+const HUMAN_WALK_RING_MARGIN = TABLE.WALL * 3.1; // keep player roots on a perimeter ring outside the table footprint
+const HUMAN_TABLE_BLOCKER_MARGIN = TABLE.WALL * 1.95; // collision helper margin so characters never cut through the table body
 const HUMAN_WALK_PERIMETER_SPEED = Math.max(TABLE.W * 0.95, TABLE.H * 0.7); // world units per second when traversing the walk ring
 const HUMAN_WALK_EPS = 1e-5;
 const CUE_STRIKE_DURATION_MS = 260;
@@ -19527,7 +19524,8 @@ useEffect(() => {
       };
       const loadFirstAvailableGltf = async (urls = []) => {
         if (!hospitalityLoaderRef.current) {
-          hospitalityLoaderRef.current = createConfiguredGLTFLoader(rendererRef.current);
+          hospitalityLoaderRef.current = new GLTFLoader();
+          hospitalityLoaderRef.current.setCrossOrigin('anonymous');
         }
         const loader = hospitalityLoaderRef.current;
         let lastError = null;
@@ -19706,35 +19704,6 @@ useEffect(() => {
               if (!child?.isMesh) return;
               child.castShadow = true;
               child.receiveShadow = true;
-              const materials = Array.isArray(child.material)
-                ? child.material
-                : [child.material];
-              materials.forEach((material) => {
-                if (!material) return;
-                const colorMapKeys = ['map', 'emissiveMap'];
-                const linearMapKeys = [
-                  'normalMap',
-                  'roughnessMap',
-                  'metalnessMap',
-                  'aoMap',
-                  'alphaMap'
-                ];
-                colorMapKeys.forEach((key) => {
-                  const texture = material[key];
-                  if (!texture) return;
-                  applySRGBColorSpace(texture);
-                  texture.flipY = false;
-                  texture.needsUpdate = true;
-                });
-                linearMapKeys.forEach((key) => {
-                  const texture = material[key];
-                  if (!texture) return;
-                  texture.colorSpace = THREE.NoColorSpace;
-                  texture.flipY = false;
-                  texture.needsUpdate = true;
-                });
-                material.needsUpdate = true;
-              });
             });
             seatedHumanTemplateRef.current = model;
             return model;
@@ -24504,183 +24473,13 @@ useEffect(() => {
         model.position.set(-center.x * scale, -box.min.y * scale, -center.z * scale);
         model.updateMatrixWorld(true);
       };
-      const resolvePlayerHumanHeight = () => {
-        const tableSurfaceY = TABLE_Y + TABLE.THICK;
-        const surfaceHeight = Math.max(0.85, tableSurfaceY - floorY);
-        return surfaceHeight * HUMAN_PLAYER_HEIGHT_TO_SURFACE_MULTIPLIER;
-      };
-      const clampHuman01 = (value) => THREE.MathUtils.clamp(value, 0, 1);
-      const cleanHumanBoneName = (value = '') => `${value}`.toLowerCase().replace(/[^a-z0-9]/g, '');
-      const findHumanBone = (allBones, aliases = []) => {
-        const list = allBones.map((bone) => ({ bone, name: cleanHumanBoneName(bone.name) }));
-        const normalizedAliases = aliases.map(cleanHumanBoneName);
-        for (const alias of normalizedAliases) {
-          const exact = list.find((entry) => entry.name === alias || entry.name.endsWith(alias));
-          if (exact) return exact.bone;
-        }
-        for (const alias of normalizedAliases) {
-          const loose = list.find((entry) => entry.name.includes(alias));
-          if (loose) return loose.bone;
-        }
-        return undefined;
-      };
-      const buildPoolHumanBones = (model) => {
-        const all = [];
-        model.traverse((obj) => {
-          if (obj?.isBone) all.push(obj);
-        });
-        const f = (...names) => findHumanBone(all, names);
-        return {
-          hips: f('hips', 'pelvis', 'mixamorigHips'),
-          spine: f('spine', 'spine01', 'mixamorigSpine'),
-          chest: f('spine2', 'chest', 'upperchest', 'mixamorigSpine2', 'mixamorigSpine1'),
-          neck: f('neck', 'mixamorigNeck'),
-          head: f('head', 'mixamorigHead'),
-          leftUpperArm: f('leftupperarm', 'leftarm', 'upperarml', 'mixamorigLeftArm'),
-          leftLowerArm: f('leftforearm', 'leftlowerarm', 'forearml', 'mixamorigLeftForeArm'),
-          leftHand: f('lefthand', 'handl', 'mixamorigLeftHand'),
-          rightUpperArm: f('rightupperarm', 'rightarm', 'upperarmr', 'mixamorigRightArm'),
-          rightLowerArm: f('rightforearm', 'rightlowerarm', 'forearmr', 'mixamorigRightForeArm'),
-          rightHand: f('righthand', 'handr', 'mixamorigRightHand'),
-          leftUpperLeg: f('leftupleg', 'leftupperleg', 'leftthigh', 'mixamorigLeftUpLeg'),
-          leftLowerLeg: f('leftleg', 'leftlowerleg', 'leftcalf', 'mixamorigLeftLeg'),
-          leftFoot: f('leftfoot', 'footl', 'mixamorigLeftFoot'),
-          rightUpperLeg: f('rightupleg', 'rightupperleg', 'rightthigh', 'mixamorigRightUpLeg'),
-          rightLowerLeg: f('rightleg', 'rightlowerleg', 'rightcalf', 'mixamorigRightLeg'),
-          rightFoot: f('rightfoot', 'footr', 'mixamorigRightFoot')
-        };
-      };
-      const collectPoolHumanFingerBones = (hand) => {
-        const out = [];
-        hand?.traverse((obj) => {
-          if (!obj?.isBone || obj === hand) return;
-          const name = cleanHumanBoneName(obj.name);
-          if (
-            ['thumb', 'index', 'middle', 'ring', 'pinky', 'little', 'finger'].some((token) =>
-              name.includes(token)
-            )
-          ) {
-            out.push(obj);
-          }
-        });
-        return out;
-      };
-      const setPoolBoneWorldQuaternion = (bone, q) => {
-        if (!bone || !q) return;
-        const parentQ = new THREE.Quaternion();
-        bone.parent?.getWorldQuaternion(parentQ);
-        bone.quaternion.copy(parentQ.invert().multiply(q));
-        bone.updateMatrixWorld(true);
-      };
-      const rotatePoolBoneToward = (bone, target, strength = 1, fallbackDir = new THREE.Vector3(0, 1, 0)) => {
-        if (!bone || strength <= 0 || !target) return;
-        const bonePos = bone.getWorldPosition(new THREE.Vector3());
-        const childBone = bone.children.find((child) => child?.isBone);
-        const childPos = childBone
-          ? childBone.getWorldPosition(new THREE.Vector3())
-          : bonePos.clone().addScaledVector(fallbackDir.clone().normalize(), 0.25);
-        const current = childPos.sub(bonePos).normalize();
-        const desired = target.clone().sub(bonePos);
-        if (desired.lengthSq() < 1e-6 || current.lengthSq() < 1e-6) return;
-        const delta = new THREE.Quaternion().slerpQuaternions(
-          new THREE.Quaternion(),
-          new THREE.Quaternion().setFromUnitVectors(current, desired.normalize()),
-          clampHuman01(strength)
-        );
-        setPoolBoneWorldQuaternion(
-          bone,
-          delta.multiply(bone.getWorldQuaternion(new THREE.Quaternion()))
-        );
-      };
-      const twistPoolBone = (bone, axis, amount) => {
-        if (!bone || Math.abs(amount) < 1e-5) return;
-        setPoolBoneWorldQuaternion(
-          bone,
-          new THREE.Quaternion()
-            .setFromAxisAngle(axis.clone().normalize(), amount)
-            .multiply(bone.getWorldQuaternion(new THREE.Quaternion()))
-        );
-      };
-      const aimPoolTwoBone = (upper, lower, elbow, hand, pole, upperStrength = 0.96, lowerStrength = 0.98) => {
-        for (let i = 0; i < 2; i += 1) {
-          rotatePoolBoneToward(upper, elbow, upperStrength, pole);
-          rotatePoolBoneToward(lower, hand, lowerStrength, pole);
-          twistPoolBone(upper, pole, 0.025 * upperStrength);
-        }
-      };
-      const setPoolHandBasis = (bone, side, _up, forward, roll = 0, strength = 1) => {
-        if (!bone || strength <= 0) return;
-        const q = makeHumanoidBasis(side, forward);
-        if (Math.abs(roll) > 1e-4) {
-          q.multiply(new THREE.Quaternion().setFromAxisAngle(forward.clone().normalize(), roll));
-        }
-        setPoolBoneWorldQuaternion(
-          bone,
-          bone.getWorldQuaternion(new THREE.Quaternion()).slerp(q, clampHuman01(strength))
-        );
-      };
-      const posePoolHumanFingers = (fingers = [], mode = 'idle', weight = 1) => {
-        const w = clampHuman01(weight);
-        fingers.forEach((finger, i) => {
-          const name = cleanHumanBoneName(finger.name);
-          const thumb = name.includes('thumb');
-          const index = name.includes('index');
-          const middle = name.includes('middle');
-          const ring = name.includes('ring');
-          const pinky = name.includes('pinky') || name.includes('little');
-          const base = !(name.includes('2') || name.includes('3') || name.includes('intermediate') || name.includes('distal'));
-          const tip = name.includes('3') || name.includes('distal');
-          if (mode === 'idle') {
-            finger.rotation.x += 0.02 * w;
-            finger.rotation.z += 0.01 * w * (i % 2 ? -1 : 1);
-            return;
-          }
-          if (mode === 'grip') {
-            if (thumb) {
-              finger.rotation.x += 0.22 * w;
-              finger.rotation.y += -0.42 * w;
-              finger.rotation.z += 0.22 * w;
-              return;
-            }
-            const curl = index
-              ? (base ? 0.42 : tip ? 0.48 : 0.62)
-              : middle
-                ? (base ? 0.54 : tip ? 0.58 : 0.78)
-                : ring
-                  ? (base ? 0.48 : tip ? 0.52 : 0.68)
-                  : pinky
-                    ? (base ? 0.42 : tip ? 0.46 : 0.6)
-                    : 0;
-            finger.rotation.x += curl * w;
-            finger.rotation.z += (index ? -0.03 : ring ? 0.04 : pinky ? 0.07 : 0) * w;
-            return;
-          }
-          if (thumb) {
-            finger.rotation.x += -0.04 * w;
-            finger.rotation.y += 0.62 * w;
-            finger.rotation.z += -0.58 * w;
-          } else if (index) {
-            finger.rotation.x += (base ? 0.12 : tip ? 0.22 : 0.28) * w;
-            finger.rotation.y += -0.26 * w;
-            finger.rotation.z += -0.2 * w;
-          } else if (middle) {
-            finger.rotation.x += (base ? 0.1 : tip ? 0.18 : 0.22) * w;
-            finger.rotation.y += -0.04 * w;
-            finger.rotation.z += -0.04 * w;
-          } else if (ring || pinky) {
-            finger.rotation.x += (base ? (ring ? 0.03 : 0.02) : tip ? (ring ? 0.1 : 0.08) : ring ? 0.12 : 0.1) * w;
-            finger.rotation.y += (ring ? 0.08 : 0.16) * w;
-            finger.rotation.z += (ring ? 0.16 : 0.28) * w;
-          }
-        });
-      };
 
       const createPlayerCharacterRig = ({ seat = 'A', x = 0, z = 0, facingY = 0, template = null } = {}) => {
         const rigGroup = new THREE.Group();
         rigGroup.position.set(x, floorY, z);
         rigGroup.rotation.y = facingY;
 
-        const humanHeight = resolvePlayerHumanHeight();
+        const humanHeight = TABLE.H * HUMAN_PLAYER_HEIGHT_RATIO_TO_TABLE;
         const scale = (humanHeight / 1.82) * POOL_ROYALE_HUMAN_SCALE_MULTIPLIER;
         if (template) {
           const avatar = template.clone(true);
@@ -24691,33 +24490,6 @@ useEffect(() => {
             child.receiveShadow = true;
             child.frustumCulled = false;
           });
-          const bones = buildPoolHumanBones(avatar);
-          const leftFingers = collectPoolHumanFingerBones(bones.leftHand);
-          const rightFingers = collectPoolHumanFingerBones(bones.rightHand);
-          const restQuats = new Map();
-          [
-            ...Object.values(bones),
-            ...leftFingers,
-            ...rightFingers
-          ].forEach((bone) => {
-            if (!bone) return;
-            restQuats.set(bone, bone.quaternion.clone());
-          });
-          const activeGlbRig = Boolean(
-            bones.hips &&
-              bones.spine &&
-              bones.head &&
-              bones.leftUpperArm &&
-              bones.leftLowerArm &&
-              bones.leftHand &&
-              bones.rightUpperArm &&
-              bones.rightLowerArm &&
-              bones.rightHand &&
-              bones.leftUpperLeg &&
-              bones.leftLowerLeg &&
-              bones.rightUpperLeg &&
-              bones.rightLowerLeg
-          );
           rigGroup.add(avatar);
           rigGroup.userData.anim = {
             seat,
@@ -24726,11 +24498,6 @@ useEffect(() => {
             humanHeight,
             scale,
             model: avatar,
-            bones,
-            leftFingers,
-            rightFingers,
-            restQuats,
-            activeGlbRig,
             poseT: 0,
             walkT: 0,
             yaw: facingY,
@@ -24950,6 +24717,8 @@ useEffect(() => {
         const isInsideTableBlocker = (point) =>
           Math.abs(point?.x ?? 0) < blockerHalfX && Math.abs(point?.z ?? 0) < blockerHalfZ;
 
+        const desiredRoot = chooseEdgeTarget(normalizedAim);
+
         rigs.forEach((rig) => {
           const anim = rig?.anim;
           if (!anim) return;
@@ -24975,9 +24744,10 @@ useEffect(() => {
           const targetPose = mode === 'idle' ? 0 : 1;
           anim.poseT = THREE.MathUtils.lerp(anim.poseT ?? 0, targetPose, 1 - Math.exp(-HUMAN_POSE_LAMBDA * dtSeconds));
 
-          const seatAim = isShooter ? normalizedAim : normalizedAim.clone().multiplyScalar(-1);
-          const desiredRoot = chooseEdgeTarget(seatAim);
-          const perimeterTarget = clampToWalkPerimeter(desiredRoot);
+          const seatBiasX = anim.seat === 'A' ? -TABLE.W * 0.19 : TABLE.W * 0.19;
+          const seatBiasZ = anim.seat === 'A' ? -TABLE.H * 0.72 : TABLE.H * 0.72;
+          const seatTarget = desiredRoot.clone().lerp(new THREE.Vector3(seatBiasX, floorY, seatBiasZ), 0.42);
+          const perimeterTarget = clampToWalkPerimeter(seatTarget);
           if (!anim.rootTarget) anim.rootTarget = perimeterTarget.clone();
           anim.rootTarget.copy(perimeterTarget);
           if (!Number.isFinite(anim.walkPerimeterT)) {
@@ -25004,6 +24774,20 @@ useEffect(() => {
           rig.group.rotation.y = anim.yaw;
 
           const side = new THREE.Vector3(aimForward.z, 0, -aimForward.x).normalize();
+          if (anim.model && !anim.pelvis) {
+            const t = anim.poseT * anim.poseT * (3 - 2 * anim.poseT);
+            const idle = 1 - t;
+            const breath = Math.sin(nowMs * 0.0028 + (anim.seat === 'A' ? 0 : Math.PI * 0.5)) * (0.006 + idle * 0.004);
+            const moveAmount = rig.group.position.distanceTo(anim.rootTarget);
+            const walk = Math.sin((anim.walkT ?? 0) * 6.2) * Math.min(1, moveAmount * 12);
+            anim.model.position.set(0, 0.006 * breath - 0.018 * t, 0.01 * walk);
+            anim.model.rotation.set(
+              -0.08 * t - 0.02 * walk,
+              0,
+              (anim.seat === activeSeat ? -1 : 1) * 0.014 * idle
+            );
+            return;
+          }
           const t = anim.poseT * anim.poseT * (3 - 2 * anim.poseT);
           const walk = Math.sin((anim.walkT ?? 0) * 6.2) * Math.min(1, moveAmount * 12);
           const localToWorld = (v) => v.clone().applyAxisAngle(new THREE.Vector3(0, 1, 0), anim.yaw).add(rig.group.position);
@@ -25022,8 +24806,8 @@ useEffect(() => {
 
           const bridgeHandTarget = cueWorld
             .clone()
-            .addScaledVector(aimForward, -HUMAN_BRIDGE_HAND_BACK_FROM_BALL)
-            .addScaledVector(side, HUMAN_BRIDGE_HAND_SIDE_OFFSET)
+            .addScaledVector(aimForward, -(TABLE.W * 0.12))
+            .addScaledVector(side, -0.018 * scale)
             .setY(TABLE_Y + TABLE.THICK + BALL_R * 0.7);
 
           const humanShotState =
@@ -25078,117 +24862,6 @@ useEffect(() => {
 
           const leftKnee = leftHipWorld.clone().lerp(leftFootWorld, 0.53).addScaledVector(new THREE.Vector3(0, 1, 0), THREE.MathUtils.lerp(0.18, 0.11, t) * scale).addScaledVector(aimForward, 0.04 * t * scale);
           const rightKnee = rightHipWorld.clone().lerp(rightFootWorld, 0.52).addScaledVector(new THREE.Vector3(0, 1, 0), THREE.MathUtils.lerp(0.18, 0.08, t) * scale).addScaledVector(aimForward, -0.03 * t * scale);
-
-          if (anim.model && anim.activeGlbRig) {
-            const idle = 1 - t;
-            const breath = Math.sin(nowMs * 0.0028 + (anim.seat === 'A' ? 0 : Math.PI * 0.5)) * (0.006 + idle * 0.004);
-            anim.model.position.set(0, 0.006 * breath - 0.018 * t, 0.01 * walk);
-            anim.model.rotation.set(0, 0, 0);
-            anim.restQuats?.forEach?.((q, bone) => bone?.quaternion?.copy?.(q));
-            anim.model.updateMatrixWorld(true);
-
-            const cueDir = cueTipShoot.clone().sub(cueBackShoot).normalize();
-            const rightGrip = rightHandWorld
-              .clone()
-              .addScaledVector(cueDir, -0.028 * (0.25 + 0.75 * t))
-              .addScaledVector(new THREE.Vector3(0, 1, 0), 0.006 * t);
-            const rightIdleElbow = rightGrip
-              .clone()
-              .addScaledVector(new THREE.Vector3(0, 1, 0), 0.24 + 0.19 * t)
-              .addScaledVector(side, 0.09)
-              .addScaledVector(aimForward, -0.03 * idle);
-            const rightElbowBlend = rightElbow.clone().lerp(rightIdleElbow, idle * 0.68);
-            const rightHold = 0.56 + 0.4 * t;
-            aimPoolTwoBone(
-              anim.bones?.rightUpperArm,
-              anim.bones?.rightLowerArm,
-              rightElbowBlend,
-              rightGrip,
-              side.clone().addScaledVector(new THREE.Vector3(0, 1, 0), 0.22).normalize(),
-              rightHold,
-              rightHold
-            );
-            setPoolHandBasis(
-              anim.bones?.rightHand,
-              side.clone().addScaledVector(new THREE.Vector3(0, 1, 0), -0.08).normalize(),
-              new THREE.Vector3(0, 1, 0)
-                .multiplyScalar(0.76)
-                .addScaledVector(side, 0.18)
-                .addScaledVector(aimForward, -0.1)
-                .normalize(),
-              cueDir,
-              0.08 * idle + 0.2 * t,
-              0.8
-            );
-            posePoolHumanFingers(anim.rightFingers, 'grip', 0.58 + 0.28 * t);
-
-            if (t < 0.025) {
-              posePoolHumanFingers(anim.leftFingers, 'idle', 1);
-              return;
-            }
-
-            rotatePoolBoneToward(anim.bones?.hips, torsoCenterWorld, (0.16 + 0.44 * t) * t, aimForward);
-            twistPoolBone(anim.bones?.hips, side, -0.075 * t);
-            twistPoolBone(anim.bones?.hips, aimForward, -0.04 * t);
-            rotatePoolBoneToward(anim.bones?.spine, chestCenterWorld, (0.38 + 0.36 * t) * t, aimForward);
-            twistPoolBone(anim.bones?.spine, side, -0.23 * t);
-            twistPoolBone(anim.bones?.spine, aimForward, -0.055 * t);
-            rotatePoolBoneToward(anim.bones?.chest, neckWorld, (0.52 + 0.3 * t) * t, aimForward);
-            twistPoolBone(anim.bones?.chest, side, -0.35 * t);
-            twistPoolBone(anim.bones?.chest, aimForward, -0.035 * t);
-            rotatePoolBoneToward(anim.bones?.neck, headCenterWorld, 0.66 * t, aimForward);
-            twistPoolBone(anim.bones?.neck, side, -0.13 * t);
-
-            const leftHandAdjusted = leftHandWorld
-              .clone()
-              .addScaledVector(aimForward, 0.012 * t)
-              .addScaledVector(side, -0.006 * t)
-              .addScaledVector(new THREE.Vector3(0, 1, 0), -0.01 * t);
-            const leftElbowAdjusted = leftElbow
-              .clone()
-              .addScaledVector(aimForward, 0.02 * t)
-              .addScaledVector(side, -0.03 * t)
-              .addScaledVector(new THREE.Vector3(0, 1, 0), -0.005 * t);
-            aimPoolTwoBone(
-              anim.bones?.leftUpperArm,
-              anim.bones?.leftLowerArm,
-              leftElbowAdjusted,
-              leftHandAdjusted,
-              side.clone().multiplyScalar(-1).addScaledVector(new THREE.Vector3(0, 1, 0), 0.14).normalize(),
-              0.95 * t,
-              0.99 * t
-            );
-            twistPoolBone(anim.bones?.leftUpperArm, aimForward, -0.16 * t);
-            twistPoolBone(anim.bones?.leftLowerArm, aimForward, 0.05 * t);
-            setPoolHandBasis(
-              anim.bones?.leftHand,
-              side.clone().multiplyScalar(-1).addScaledVector(aimForward, -0.2).normalize(),
-              new THREE.Vector3(0, 1, 0).multiplyScalar(0.96).addScaledVector(aimForward, -0.08).addScaledVector(side, -0.04).normalize(),
-              cueDir,
-              -0.22 * t,
-              0.98 * t
-            );
-            posePoolHumanFingers(anim.leftFingers, 'bridge', t);
-            aimPoolTwoBone(
-              anim.bones?.leftUpperLeg,
-              anim.bones?.leftLowerLeg,
-              leftKnee,
-              leftFootWorld,
-              aimForward.clone().addScaledVector(new THREE.Vector3(0, 1, 0), 0.12).normalize(),
-              0.68 * t,
-              0.84 * t
-            );
-            aimPoolTwoBone(
-              anim.bones?.rightUpperLeg,
-              anim.bones?.rightLowerLeg,
-              rightKnee,
-              rightFootWorld,
-              aimForward.clone().multiplyScalar(-1).addScaledVector(new THREE.Vector3(0, 1, 0), 0.1).normalize(),
-              0.68 * t,
-              0.84 * t
-            );
-            return;
-          }
 
           const bodyQ = makeHumanoidBasis(side, aimForward);
           anim.pelvis.position.copy(hipCenterWorld);
@@ -27141,7 +26814,7 @@ useEffect(() => {
         const shotDir3 = TMP_VEC3_C.set(aimDir.x, 0, aimDir.y);
         if (shotDir3.lengthSq() > 1e-8) shotDir3.normalize();
         else shotDir3.set(0, 0, 1);
-        const referenceSpeed = bilardoCueSpeed(clampedPower) * POOL_ROYALE_CUE_SPEED_BOOST;
+        const referenceSpeed = bilardoCueSpeed(clampedPower);
         cue.vel.copy(shotDir3).multiplyScalar(referenceSpeed);
         if (cue.spin) {
           cue.spin.set(offsetScaled.x, offsetScaled.y);


### PR DESCRIPTION
### Motivation
- Restore the Pool Royale gameplay code to the precise snapshot corresponding to April 20 06:00 to recover the prior cue/animation/character behavior and table/player sizing while keeping unrelated code untouched.

### Description
- Replaced `webapp/src/pages/Games/PoolRoyale.jsx` with the historical snapshot content, restoring constants, animation and rig logic, and shot/impact calculations to the Apr 20 baseline.
- Reintroduced loader/asset handling changes (instantiating `GLTFLoader` with cross-origin handling) and removed interim transformations to seated human material processing that had been added later.
- Reverted player-human sizing and rig behavior to the previous model by changing sizing constants (e.g., replacing the prior height logic with `HUMAN_PLAYER_HEIGHT_RATIO_TO_TABLE`) and removing the interim GLB-rig conditional complexity and finger/bone handling that had been modified.
- Restored shot speed/power behavior by removing an intermediate `POOL_ROYALE_CUE_SPEED_BOOST` and using the original `bilardoCueSpeed` reference, plus multiple tuning values and walk/perimeter margins reverted to the baseline.

### Testing
- Confirmed the change is limited to the single file `webapp/src/pages/Games/PoolRoyale.jsx` using repo sanity checks `git status`, `git diff --stat`, and `git show` to verify the restoration-only scope and diff.
- No automated unit or integration tests were executed as part of this restoration; this PR is a code snapshot rollback without runtime test coverage in this run.
- Verified file loads in the working tree and committed the restored file so downstream CI can run the project's normal automated test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef8847aa248329a0be197b77eb03bf)