### PR TITLE
Tune Ludo Battle Royal: weapon scales, store filters, avatar & dice contact fixes

### DIFF
--- a/webapp/src/config/ludoBattleInventoryConfig.js
+++ b/webapp/src/config/ludoBattleInventoryConfig.js
@@ -148,7 +148,9 @@ export const LUDO_BATTLE_STORE_ITEMS = uniqueStoreItemsByName([
     price: 950 + idx * 120,
     description: option.description,
     thumbnail: option.thumbnail || swatchThumbnail(['#0f172a', '#1d4ed8', '#f97316'])
-  })),
+  })).filter((item) =>
+    !['mrtkGunAttack', 'pistolHolsterAttack', 'pistolSidearmAttack'].includes(item.optionId)
+  ),
   ...HUMAN_CHARACTER_OPTIONS.slice(1).map((option, idx) => ({
     id: `ludo-human-character-${option.id}`,
     type: 'humanCharacter',

--- a/webapp/src/config/ludoBattleOptions.js
+++ b/webapp/src/config/ludoBattleOptions.js
@@ -321,22 +321,6 @@ export const HUMAN_CHARACTER_OPTIONS = Object.freeze([
     license: 'Check repository license'
   },
   {
-    id: 'webgl-human-body-a',
-    label: 'Human Body A',
-    description: 'Open WebGL GLB body variant using the same seated character animation logic.',
-    modelUrls: ['https://raw.githubusercontent.com/msorkhpar/3d-human-model-vite/main/body.glb'],
-    source: 'msorkhpar/3d-human-model-vite GitHub',
-    license: 'Check repository license'
-  },
-  {
-    id: 'webgl-human-body-b',
-    label: 'Human Body B',
-    description: 'Open WebGL GLB body variant matched to default seated sizing/orientation.',
-    modelUrls: ['https://raw.githubusercontent.com/bddicken/humanbody/main/body.glb'],
-    source: 'bddicken/humanbody GitHub',
-    license: 'Check repository license'
-  },
-  {
     id: 'webgl-ai-teacher',
     label: 'AI Teacher',
     description: 'Open-source AI Teacher avatar adapted to the default seated pose pipeline.',

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -224,7 +224,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://cdn.jsdelivr.net/gh/lando19/Guns-for-BJS-FPS-Game@master/main/scene.gltf',
       'https://raw.githubusercontent.com/lando19/Guns-for-BJS-FPS-Game/master/main/scene.gltf'
     ],
-    scale: 0.142
+    scale: 0.284
   },
   glockSidearmAttack: {
     label: 'Glock',
@@ -232,7 +232,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://cdn.jsdelivr.net/gh/webaverse/pistol@master/glock.glb',
       'https://raw.githubusercontent.com/webaverse/pistol/master/glock.glb'
     ],
-    scale: 0.125
+    scale: 0.165
   },
   pistolSidearmAttack: {
     label: 'Pistol Sidearm',
@@ -246,9 +246,9 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   assaultRifleAttack: {
     label: 'Assault Rifle',
     urls: [
-      'https://cdn.jsdelivr.net/gh/webaverse/pistol@master/military.glb',
-      'https://raw.githubusercontent.com/webaverse/pistol/master/military.glb',
-      'https://cdn.statically.io/gh/webaverse/pistol/master/military.glb'
+      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/AK47/scene.gltf',
+      'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/AK47/scene.gltf',
+      'https://cdn.statically.io/gh/KrishBharadwaj5678/Gunify/main/models/AK47/scene.gltf'
     ],
     scale: 0.145
   },
@@ -258,7 +258,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models2/Uzi/scene.gltf',
       'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models2/Uzi/scene.gltf'
     ],
-    scale: 0.14
+    scale: 0.218
   },
   ak47VolleyAttack: {
     label: 'AK-47',
@@ -266,7 +266,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/AK47/scene.gltf',
       'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/AK47/scene.gltf'
     ],
-    scale: 0.16
+    scale: 0.24
   },
   krsvBurstAttack: {
     label: 'KRSV',
@@ -274,7 +274,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/KRSV/scene.gltf',
       'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/KRSV/scene.gltf'
     ],
-    scale: 0.148
+    scale: 0.24
   },
   smithSidearmAttack: {
     label: 'Smith',
@@ -282,7 +282,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/Smith/scene.gltf',
       'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/Smith/scene.gltf'
     ],
-    scale: 0.122
+    scale: 0.165
   },
   mosinMarksmanAttack: {
     label: 'Mosin',
@@ -290,24 +290,27 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models2/Mosin/scene.gltf',
       'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models2/Mosin/scene.gltf'
     ],
-    scale: 0.205
+    scale: 0.5125
   },
   sigsauerTacticalAttack: {
     label: 'SigSauer Tactical',
     urls: [
       'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models3/SigSauer/scene.gltf',
-      'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models3/SigSauer/scene.gltf'
+      'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models3/SigSauer/scene.gltf',
+      'https://cdn.statically.io/gh/KrishBharadwaj5678/Gunify/main/models3/SigSauer/scene.gltf'
     ],
     scale: 0.13
   },
   grenadeBlastAttack: {
     label: 'Grenade Blast',
     urls: [
+      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models3/Grenade/scene.gltf',
+      'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models3/Grenade/scene.gltf',
+      'https://cdn.statically.io/gh/KrishBharadwaj5678/Gunify/main/models3/Grenade/scene.gltf',
       'https://cdn.jsdelivr.net/gh/friuns2/bingextension@main/grenade.glb',
-      'https://raw.githubusercontent.com/friuns2/bingextension/main/grenade.glb',
-      'https://cdn.statically.io/gh/friuns2/bingextension/main/grenade.glb'
+      'https://raw.githubusercontent.com/friuns2/bingextension/main/grenade.glb'
     ],
-    scale: 0.19
+    scale: 0.13
   },
   shotgunBlastAttack: {
     label: 'Shotgun Blast',
@@ -325,7 +328,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models2/Mosin/scene.gltf',
       'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models2/Mosin/scene.gltf'
     ],
-    scale: 0.252
+    scale: 0.504
   },
   smgBurstAttack: {
     label: 'SMG',
@@ -338,8 +341,9 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   compactCarbineAttack: {
     label: 'Compact Carbine',
     urls: [
-      'https://cdn.jsdelivr.net/gh/webaverse/uzi@main/uzi.glb',
-      'https://cdn.jsdelivr.net/gh/webaverse/pistol@master/military.glb'
+      'https://cdn.jsdelivr.net/gh/webaverse/pistol@master/military.glb',
+      'https://raw.githubusercontent.com/webaverse/pistol/master/military.glb',
+      'https://cdn.statically.io/gh/webaverse/pistol/master/military.glb'
     ],
     scale: 0.21
   },
@@ -506,22 +510,22 @@ const FIREARM_ATTACH_SCALE_MULTIPLIER = Object.freeze({
   // seated humans keep a consistent hand fit around the trigger/handle zone.
   mrtkGunAttack: 1.16,
   pistolHolsterAttack: 1.14,
-  fpsGunAttack: 1.72,
-  glockSidearmAttack: 0.98,
+  fpsGunAttack: 2,
+  glockSidearmAttack: 1.18,
   pistolSidearmAttack: 1.16,
-  uziSprayAttack: 1.2,
+  uziSprayAttack: 1.22,
   smgBurstAttack: 1.22,
   compactCarbineAttack: 1.34,
   assaultRifleAttack: 1.56,
-  ak47VolleyAttack: 1.64,
-  krsvBurstAttack: 1.58,
-  smithSidearmAttack: 1.15,
-  mosinMarksmanAttack: 1.72,
+  ak47VolleyAttack: 1.5,
+  krsvBurstAttack: 1.5,
+  smithSidearmAttack: 1.18,
+  mosinMarksmanAttack: 2.5,
   sigsauerTacticalAttack: 1.2,
   shotgunBlastAttack: 1.7,
   marksmanDmrAttack: 1.48,
-  sniperShotAttack: 1.76,
-  grenadeBlastAttack: 1.12
+  sniperShotAttack: 2,
+  grenadeBlastAttack: 0.78
 });
 const FIREARM_VOLLEY_SLOW_FACTOR = 1.72;
 const FIREARM_CAMERA_FOCUS_BLEND = 0.58;
@@ -2754,8 +2758,8 @@ const CHAIR_MODEL_URLS = [
 const SEATED_HUMAN_MODEL_URL = 'https://threejs.org/examples/models/gltf/readyplayer.me.glb';
 const SEATED_HUMAN_BASE_HEIGHT = 1.74;
 const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.42;
-// Slightly upscale seated humans so they read better on portrait/mobile gameplay.
-const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 4.55;
+// Keep seated humans slightly smaller so board interactions stay readable on portrait/mobile gameplay.
+const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 3.7;
 // Push seated humans dramatically lower so they sit much deeper on portrait/mobile camera framing.
 const SEATED_HUMAN_SEAT_Y_OFFSET = -6.2 * MODEL_SCALE * STOOL_SCALE;
 // Shift humans farther back on the chair so they appear more outward from the table in portrait gameplay.
@@ -2792,14 +2796,14 @@ const SEATED_HUMAN_DOWNWARD_CONTACT_MODE_SET = new Set([
   'carryToken',
   'placeToken'
 ]);
-const SEATED_HELPER_FORWARD_DICE_PICKUP = 0.084 * MODEL_SCALE;
+const SEATED_HELPER_FORWARD_DICE_PICKUP = 0.066 * MODEL_SCALE;
 const SEATED_HELPER_FORWARD_DICE_RELEASE = 0.154 * MODEL_SCALE;
-const SEATED_HELPER_RIGHT_DICE = 0.0032 * MODEL_SCALE;
-const SEATED_HELPER_UP_DICE_PICKUP = 0.011 * MODEL_SCALE;
+const SEATED_HELPER_RIGHT_DICE = -0.001 * MODEL_SCALE;
+const SEATED_HELPER_UP_DICE_PICKUP = 0.004 * MODEL_SCALE;
 const SEATED_HELPER_UP_DICE_RELEASE = 0.024 * MODEL_SCALE;
-const SEATED_HELPER_FORWARD_DICE_HOLD = 0.088 * MODEL_SCALE;
-const SEATED_HELPER_UP_DICE_HOLD = 0.013 * MODEL_SCALE;
-const SEATED_DICE_HOLD_VERTICAL_NUDGE = 0.035;
+const SEATED_HELPER_FORWARD_DICE_HOLD = 0.063 * MODEL_SCALE;
+const SEATED_HELPER_UP_DICE_HOLD = 0.004 * MODEL_SCALE;
+const SEATED_DICE_HOLD_VERTICAL_NUDGE = 0.006;
 const SEATED_DICE_THROW_VERTICAL_NUDGE = 0.008;
 const SEATED_HELPER_FORWARD_TOKEN_PICKUP = 0.076 * MODEL_SCALE;
 const SEATED_HELPER_FORWARD_TOKEN_PLACE = 0.114 * MODEL_SCALE;


### PR DESCRIPTION
### Motivation
- Align in-game weapon visuals and in-hand attachment sizes to a requested balance pass so pickups and animations read correctly in portrait/mobile play.
- Remove redundant/unwanted weapon store items and skeleton-like human avatars from the Ludo inventory.
- Fix texture/load reliability and model fallbacks for several weapon GLTF sources.
- Improve the hand/dice contact so grabbed dice sit visually in the center of the palm for better UX.

### Description
- Scaled weapon capture models in `LudoBattleRoyal.jsx` (table and attach sizes): `fpsGunAttack` 2x, `sniperShotAttack` 2x, `ak47VolleyAttack` 1.5x, `krsvBurstAttack` matched to AK-47, `mosinMarksmanAttack` 2.5x, increased `glockSidearmAttack` and `smithSidearmAttack` to match, made `uziSprayAttack` match SMG sizing, and reduced `grenadeBlastAttack` scale. (See updated `CAPTURE_WEAPON_MODEL_CONFIG` and `FIREARM_ATTACH_SCALE_MULTIPLIER`.)
- Changed several model URL sources and fallback ordering to improve texture reliability and correct model identity for `assaultRifleAttack`, `sigsauerTacticalAttack`, `grenadeBlastAttack`, and `compactCarbineAttack`.
- Removed three capture animations from the Ludo store list by filtering `CAPTURE_ANIMATION_OPTIONS` when building `LUDO_BATTLE_STORE_ITEMS`: `mrtkGunAttack`, `pistolHolsterAttack`, and `pistolSidearmAttack`.
- Removed two skeleton-style human options from `HUMAN_CHARACTER_OPTIONS` (`webgl-human-body-a`, `webgl-human-body-b`) and reduced seated avatar visual scale via `SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER` to make avatars appear smaller on the table.
- Tuned seated hand/dice helper constants (`SEATED_HELPER_*` and `SEATED_DICE_HOLD_VERTICAL_NUDGE`) to shift dice contact toward the palm and reduce vertical hold nudge for tighter visual alignment during `gripDice`/`holdDice` phases.

### Testing
- Ran a production build with `npm -C webapp run -s build` and the build completed successfully; Vite emitted non-blocking warnings about chunking/dynamic imports and large chunk sizes but the build artifacts were produced. 
- No automated unit tests were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef8cdf5af883299ee64703a8e7ee20)