### PR TITLE
Adjust Ludo Battle Royal weapon scales, store items, avatars and dice handoff

### DIFF
--- a/webapp/src/config/ludoBattleInventoryConfig.js
+++ b/webapp/src/config/ludoBattleInventoryConfig.js
@@ -53,6 +53,12 @@ export const LUDO_BATTLE_OPTION_LABELS = Object.freeze({
   headStyle: Object.freeze(CHESS_BATTLE_OPTION_LABELS.headStyle)
 });
 
+const HIDDEN_LUDO_STORE_CAPTURE_ANIMATION_IDS = new Set([
+  'mrtkGunAttack',
+  'pistolHolsterAttack',
+  'pistolSidearmAttack'
+]);
+
 const uniqueStoreItemsByName = (items) => {
   const seen = new Set();
   return items.filter((item) => {
@@ -140,15 +146,17 @@ export const LUDO_BATTLE_STORE_ITEMS = uniqueStoreItemsByName([
     description: 'Unlock an alternate piece identity for your pawns.',
     thumbnail: swatchThumbnail(['#f8fafc', '#0f172a', '#fbbf24'])
   })),
-  ...CAPTURE_ANIMATION_OPTIONS.slice(1).map((option, idx) => ({
-    id: `ludo-capture-animation-${option.id}`,
-    type: 'captureAnimation',
-    optionId: option.id,
-    name: option.label,
-    price: 950 + idx * 120,
-    description: option.description,
-    thumbnail: option.thumbnail || swatchThumbnail(['#0f172a', '#1d4ed8', '#f97316'])
-  })),
+  ...CAPTURE_ANIMATION_OPTIONS.slice(1)
+    .filter((option) => !HIDDEN_LUDO_STORE_CAPTURE_ANIMATION_IDS.has(option.id))
+    .map((option, idx) => ({
+      id: `ludo-capture-animation-${option.id}`,
+      type: 'captureAnimation',
+      optionId: option.id,
+      name: option.label,
+      price: 950 + idx * 120,
+      description: option.description,
+      thumbnail: option.thumbnail || swatchThumbnail(['#0f172a', '#1d4ed8', '#f97316'])
+    })),
   ...HUMAN_CHARACTER_OPTIONS.slice(1).map((option, idx) => ({
     id: `ludo-human-character-${option.id}`,
     type: 'humanCharacter',

--- a/webapp/src/config/ludoBattleOptions.js
+++ b/webapp/src/config/ludoBattleOptions.js
@@ -321,22 +321,6 @@ export const HUMAN_CHARACTER_OPTIONS = Object.freeze([
     license: 'Check repository license'
   },
   {
-    id: 'webgl-human-body-a',
-    label: 'Human Body A',
-    description: 'Open WebGL GLB body variant using the same seated character animation logic.',
-    modelUrls: ['https://raw.githubusercontent.com/msorkhpar/3d-human-model-vite/main/body.glb'],
-    source: 'msorkhpar/3d-human-model-vite GitHub',
-    license: 'Check repository license'
-  },
-  {
-    id: 'webgl-human-body-b',
-    label: 'Human Body B',
-    description: 'Open WebGL GLB body variant matched to default seated sizing/orientation.',
-    modelUrls: ['https://raw.githubusercontent.com/bddicken/humanbody/main/body.glb'],
-    source: 'bddicken/humanbody GitHub',
-    license: 'Check repository license'
-  },
-  {
     id: 'webgl-ai-teacher',
     label: 'AI Teacher',
     description: 'Open-source AI Teacher avatar adapted to the default seated pose pipeline.',

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -185,6 +185,19 @@ const FIREARM_SINGLE_HAND_ONLY_IDS = new Set([
   'sigsauerTacticalAttack',
   'grenadeBlastAttack'
 ]);
+const FIREARM_RACK_SIZE_MULTIPLIER_BY_ID = Object.freeze({
+  fpsGunAttack: 2,
+  glockSidearmAttack: 1.4,
+  uziSprayAttack: 1.22,
+  smgBurstAttack: 1.22,
+  ak47VolleyAttack: 1.5,
+  krsvBurstAttack: 1.5,
+  smithSidearmAttack: 1.4,
+  mosinMarksmanAttack: 2.5,
+  sniperShotAttack: 2,
+  grenadeBlastAttack: 0.7
+});
+
 const FIREARM_RACK_DISPLAY_TUNING = Object.freeze({
   default: Object.freeze({
     targetSizeMultiplier: 1.06,
@@ -224,7 +237,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://cdn.jsdelivr.net/gh/lando19/Guns-for-BJS-FPS-Game@master/main/scene.gltf',
       'https://raw.githubusercontent.com/lando19/Guns-for-BJS-FPS-Game/master/main/scene.gltf'
     ],
-    scale: 0.142
+    scale: 0.284
   },
   glockSidearmAttack: {
     label: 'Glock',
@@ -232,7 +245,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://cdn.jsdelivr.net/gh/webaverse/pistol@master/glock.glb',
       'https://raw.githubusercontent.com/webaverse/pistol/master/glock.glb'
     ],
-    scale: 0.125
+    scale: 0.2
   },
   pistolSidearmAttack: {
     label: 'Pistol Sidearm',
@@ -250,7 +263,10 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://raw.githubusercontent.com/webaverse/pistol/master/military.glb',
       'https://cdn.statically.io/gh/webaverse/pistol/master/military.glb'
     ],
-    scale: 0.145
+    scale: 0.2175,
+    textureOverrideUrls: [
+      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/images/AK47.jpeg'
+    ]
   },
   uziSprayAttack: {
     label: 'Uzi',
@@ -258,7 +274,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models2/Uzi/scene.gltf',
       'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models2/Uzi/scene.gltf'
     ],
-    scale: 0.14
+    scale: 0.218
   },
   ak47VolleyAttack: {
     label: 'AK-47',
@@ -266,7 +282,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/AK47/scene.gltf',
       'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/AK47/scene.gltf'
     ],
-    scale: 0.16
+    scale: 0.24
   },
   krsvBurstAttack: {
     label: 'KRSV',
@@ -274,7 +290,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/KRSV/scene.gltf',
       'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/KRSV/scene.gltf'
     ],
-    scale: 0.148
+    scale: 0.24
   },
   smithSidearmAttack: {
     label: 'Smith',
@@ -282,7 +298,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/Smith/scene.gltf',
       'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/Smith/scene.gltf'
     ],
-    scale: 0.122
+    scale: 0.2
   },
   mosinMarksmanAttack: {
     label: 'Mosin',
@@ -290,7 +306,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models2/Mosin/scene.gltf',
       'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models2/Mosin/scene.gltf'
     ],
-    scale: 0.205
+    scale: 0.5125
   },
   sigsauerTacticalAttack: {
     label: 'SigSauer Tactical',
@@ -298,7 +314,10 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models3/SigSauer/scene.gltf',
       'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models3/SigSauer/scene.gltf'
     ],
-    scale: 0.13
+    scale: 0.13,
+    textureOverrideUrls: [
+      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/images/SigSauer.jpg'
+    ]
   },
   grenadeBlastAttack: {
     label: 'Grenade Blast',
@@ -307,7 +326,10 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://raw.githubusercontent.com/friuns2/bingextension/main/grenade.glb',
       'https://cdn.statically.io/gh/friuns2/bingextension/main/grenade.glb'
     ],
-    scale: 0.19
+    scale: 0.11,
+    textureOverrideUrls: [
+      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/images/SigSauer.jpg'
+    ]
   },
   shotgunBlastAttack: {
     label: 'Shotgun Blast',
@@ -325,7 +347,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models2/Mosin/scene.gltf',
       'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models2/Mosin/scene.gltf'
     ],
-    scale: 0.252
+    scale: 0.504
   },
   smgBurstAttack: {
     label: 'SMG',
@@ -338,8 +360,8 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   compactCarbineAttack: {
     label: 'Compact Carbine',
     urls: [
-      'https://cdn.jsdelivr.net/gh/webaverse/uzi@main/uzi.glb',
-      'https://cdn.jsdelivr.net/gh/webaverse/pistol@master/military.glb'
+      'https://cdn.jsdelivr.net/gh/webaverse/pistol@master/military.glb',
+      'https://raw.githubusercontent.com/webaverse/pistol/master/military.glb'
     ],
     scale: 0.21
   },
@@ -506,22 +528,22 @@ const FIREARM_ATTACH_SCALE_MULTIPLIER = Object.freeze({
   // seated humans keep a consistent hand fit around the trigger/handle zone.
   mrtkGunAttack: 1.16,
   pistolHolsterAttack: 1.14,
-  fpsGunAttack: 1.72,
-  glockSidearmAttack: 0.98,
+  fpsGunAttack: 3.44,
+  glockSidearmAttack: 1.4,
   pistolSidearmAttack: 1.16,
-  uziSprayAttack: 1.2,
+  uziSprayAttack: 1.22,
   smgBurstAttack: 1.22,
   compactCarbineAttack: 1.34,
   assaultRifleAttack: 1.56,
-  ak47VolleyAttack: 1.64,
-  krsvBurstAttack: 1.58,
-  smithSidearmAttack: 1.15,
-  mosinMarksmanAttack: 1.72,
+  ak47VolleyAttack: 2.46,
+  krsvBurstAttack: 2.46,
+  smithSidearmAttack: 1.4,
+  mosinMarksmanAttack: 4.3,
   sigsauerTacticalAttack: 1.2,
   shotgunBlastAttack: 1.7,
   marksmanDmrAttack: 1.48,
-  sniperShotAttack: 1.76,
-  grenadeBlastAttack: 1.12
+  sniperShotAttack: 3.52,
+  grenadeBlastAttack: 0.78
 });
 const FIREARM_VOLLEY_SLOW_FACTOR = 1.72;
 const FIREARM_CAMERA_FOCUS_BLEND = 0.58;
@@ -645,6 +667,26 @@ async function loadCaptureWeaponModel(captureAnimationId) {
     try {
       const root = loadedRoot;
       if (!root) return null;
+      const textureOverrideUrls = Array.isArray(config?.textureOverrideUrls) ? config.textureOverrideUrls.filter(Boolean) : [];
+      let textureOverride = null;
+      if (textureOverrideUrls.length) {
+        const textureLoader = new THREE.TextureLoader();
+        textureLoader.setCrossOrigin?.('anonymous');
+        for (let t = 0; t < textureOverrideUrls.length; t += 1) {
+          try {
+            // eslint-disable-next-line no-await-in-loop
+            textureOverride = await withLoadTimeout(textureLoader.loadAsync(textureOverrideUrls[t]));
+            if (textureOverride) {
+              textureOverride.flipY = false;
+              applySRGBColorSpace(textureOverride);
+              textureOverride.needsUpdate = true;
+              break;
+            }
+          } catch {
+            // keep trying next override
+          }
+        }
+      }
       root.traverse((node) => {
         if (!node?.isMesh) return;
         if (
@@ -661,6 +703,7 @@ async function loadCaptureWeaponModel(captureAnimationId) {
         const materials = Array.isArray(node.material) ? node.material : [node.material];
         materials.forEach((material) => {
           if (material?.map) applySRGBColorSpace(material.map);
+          if (!material?.map && textureOverride) material.map = textureOverride;
           if (material?.emissiveMap) applySRGBColorSpace(material.emissiveMap);
           material.transparent = false;
           material.opacity = 1;
@@ -891,7 +934,11 @@ async function applyCaptureWeaponDisplay(entry, captureAnimationId) {
   const displayTuning = LARGE_RACK_FIREARM_IDS.has(captureAnimationId)
     ? FIREARM_RACK_DISPLAY_TUNING.large
     : FIREARM_RACK_DISPLAY_TUNING.default;
-  fitObjectToTargetSize(clone, CAPTURE_PARK_BOX_TARGET_SIZE * displayTuning.targetSizeMultiplier);
+  const weaponRackScaleMultiplier = FIREARM_RACK_SIZE_MULTIPLIER_BY_ID[captureAnimationId] ?? 1;
+  fitObjectToTargetSize(
+    clone,
+    CAPTURE_PARK_BOX_TARGET_SIZE * displayTuning.targetSizeMultiplier * weaponRackScaleMultiplier
+  );
   if (!LARGE_RACK_FIREARM_IDS.has(captureAnimationId)) {
     clone.position.y = baseAlignPositionY;
   }
@@ -2755,7 +2802,7 @@ const SEATED_HUMAN_MODEL_URL = 'https://threejs.org/examples/models/gltf/readypl
 const SEATED_HUMAN_BASE_HEIGHT = 1.74;
 const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.42;
 // Slightly upscale seated humans so they read better on portrait/mobile gameplay.
-const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 4.55;
+const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 3.8;
 // Push seated humans dramatically lower so they sit much deeper on portrait/mobile camera framing.
 const SEATED_HUMAN_SEAT_Y_OFFSET = -6.2 * MODEL_SCALE * STOOL_SCALE;
 // Shift humans farther back on the chair so they appear more outward from the table in portrait gameplay.
@@ -2792,15 +2839,15 @@ const SEATED_HUMAN_DOWNWARD_CONTACT_MODE_SET = new Set([
   'carryToken',
   'placeToken'
 ]);
-const SEATED_HELPER_FORWARD_DICE_PICKUP = 0.084 * MODEL_SCALE;
-const SEATED_HELPER_FORWARD_DICE_RELEASE = 0.154 * MODEL_SCALE;
+const SEATED_HELPER_FORWARD_DICE_PICKUP = 0.066 * MODEL_SCALE;
+const SEATED_HELPER_FORWARD_DICE_RELEASE = 0.128 * MODEL_SCALE;
 const SEATED_HELPER_RIGHT_DICE = 0.0032 * MODEL_SCALE;
-const SEATED_HELPER_UP_DICE_PICKUP = 0.011 * MODEL_SCALE;
-const SEATED_HELPER_UP_DICE_RELEASE = 0.024 * MODEL_SCALE;
-const SEATED_HELPER_FORWARD_DICE_HOLD = 0.088 * MODEL_SCALE;
-const SEATED_HELPER_UP_DICE_HOLD = 0.013 * MODEL_SCALE;
+const SEATED_HELPER_UP_DICE_PICKUP = 0.022 * MODEL_SCALE;
+const SEATED_HELPER_UP_DICE_RELEASE = 0.031 * MODEL_SCALE;
+const SEATED_HELPER_FORWARD_DICE_HOLD = 0.064 * MODEL_SCALE;
+const SEATED_HELPER_UP_DICE_HOLD = 0.025 * MODEL_SCALE;
 const SEATED_DICE_HOLD_VERTICAL_NUDGE = 0.035;
-const SEATED_DICE_THROW_VERTICAL_NUDGE = 0.008;
+const SEATED_DICE_THROW_VERTICAL_NUDGE = -0.01;
 const SEATED_HELPER_FORWARD_TOKEN_PICKUP = 0.076 * MODEL_SCALE;
 const SEATED_HELPER_FORWARD_TOKEN_PLACE = 0.114 * MODEL_SCALE;
 const SEATED_HELPER_RIGHT_TOKEN = -0.012 * MODEL_SCALE;


### PR DESCRIPTION
### Motivation
- Make the in-arena weapons and their pickup animations match requested visual sizes and relationships (FPS 2x, Glock larger, Uzi = SMG, Sniper 2x, AK47 1.5x, Smith = Glock, Mosin 2.5x, KRSV = AK47, grenade smaller). 
- Remove unwanted weapons from the in-game store and ensure weapons that fail to provide GLTF texture maps still display a usable texture. 
- Reduce avatar visual prominence and improve dice hand/center contact so dice appear centered in the palm during pickup/throw.

### Description
- Tuned per-weapon model scales and hand-attach multipliers in `webapp/src/pages/Games/LudoBattleRoyal.jsx`, including new `FIREARM_RACK_SIZE_MULTIPLIER_BY_ID`, adjusted `FIREARM_ATTACH_SCALE_MULTIPLIER`, and modified capture model `scale` values to match requested size multipliers. 
- Changed rack display sizing by applying `FIREARM_RACK_SIZE_MULTIPLIER_BY_ID` when calling `fitObjectToTargetSize` so table visuals match the new sizes. 
- Added `textureOverrideUrls` support and a small texture fallback loader to `loadCaptureWeaponModel` so `assaultRifle`, `sigsauerTactical`, and `grenadeBlast` can provide a fallback texture when GLTF textures are missing. 
- Reordered `compactCarbineAttack` model URLs to prefer the military/carbine source and avoid resolving to the Uzi model first. 
- Removed `mrtkGunAttack`, `pistolHolsterAttack`, and `pistolSidearmAttack` from the in-game store list by filtering `CAPTURE_ANIMATION_OPTIONS` in `webapp/src/config/ludoBattleInventoryConfig.js`. 
- Removed two skeletal-style human body avatar options from `webapp/src/config/ludoBattleOptions.js` and reduced `SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER` in `webapp/src/pages/Games/LudoBattleRoyal.jsx` to make avatars smaller. 
- Retuned seated-dice helper constants (`SEATED_HELPER_*` and `SEATED_DICE_THROW_VERTICAL_NUDGE`) to move dice grab/release anchors so dice snap into the palm more centrally during handoff. 
- Files modified: `webapp/src/pages/Games/LudoBattleRoyal.jsx`, `webapp/src/config/ludoBattleOptions.js`, and `webapp/src/config/ludoBattleInventoryConfig.js`.

### Testing
- Built the web frontend with `npm run -s build --prefix webapp` and the production build completed successfully. 
- Ran `npx eslint webapp/src/pages/Games/LudoBattleRoyal.jsx webapp/src/config/ludoBattleOptions.js webapp/src/config/ludoBattleInventoryConfig.js` which produced repository ignore warnings but no fatal errors under normal lint paths. 
- Ran `npx eslint --no-ignore webapp/src/pages/Games/LudoBattleRoyal.jsx webapp/src/config/ludoBattleOptions.js webapp/src/config/ludoBattleInventoryConfig.js` and received style rule errors originating from these modified config files (these are formatting/semicolons/style issues and do not block runtime; they can be fixed with the project's lint autofix or formatter).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef8cdf5af883299ee64703a8e7ee20)