### PR TITLE
Fix Pool Royale slider commit power for cue strike

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -33351,11 +33351,15 @@ useEffect(() => {
     applyPower(clamped);
   }, [applyPower, clampPower]);
   const onPowerRelease = useCallback((powerRatio = null) => {
-    const sourcePower = Math.max(
-      Number.isFinite(powerRatio) ? powerRatio : 0,
-      Number.isFinite(shotPowerRef.current) ? shotPowerRef.current : 0,
-      Number.isFinite(powerRef.current) ? powerRef.current : 0
-    );
+    const providedPower = Number.isFinite(powerRatio)
+      ? clampPower(powerRatio, 0)
+      : null;
+    const sourcePower =
+      providedPower ??
+      Math.max(
+        Number.isFinite(shotPowerRef.current) ? shotPowerRef.current : 0,
+        Number.isFinite(powerRef.current) ? powerRef.current : 0
+      );
     const latchedPower = clampPower(sourcePower, 0);
     shotPowerRef.current = latchedPower;
     manualStrikePowerRef.current = latchedPower;
@@ -33420,8 +33424,11 @@ useEffect(() => {
       labels: true,
       onChange: (v) => onPowerDrag((v ?? 0) / 100),
       onStart: () => onPowerDragStart(),
-      onCommit: () => {
-        onPowerRelease(clampPower(powerRef.current, 0));
+      onCommit: (committedValue) => {
+        const powerRatio = Number.isFinite(committedValue)
+          ? clampPower((committedValue ?? 0) / 100, 0)
+          : clampPower(powerRef.current, 0);
+        onPowerRelease(powerRatio);
       }
     });
     sliderInstanceRef.current = slider;


### PR DESCRIPTION
### Motivation
- The Pool Royale shot release could sometimes fire with zero/low power because the slider commit path relied on mutable refs that could desync with UI timing.
- We need to ensure an explicit committed slider value (the value delivered by the slider `onCommit`) is honored as the source of truth when the player releases the power slider.

### Description
- Prefer an explicit provided power when resolving release power by updating `onPowerRelease` to accept a normalized `powerRatio` and use it before falling back to `shotPowerRef`/`powerRef`.
- Wire the slider `onCommit` to consume the `committedValue` argument, normalize it from `0..100` to `0..1`, clamp it, and pass it into `onPowerRelease`.
- Ensure the resolved `latchedPower` is written to `shotPowerRef` and `manualStrikePowerRef`, and used to enter the `striking` state as before.
- Change is implemented in `webapp/src/pages/Games/PoolRoyale.jsx` (power release / slider wiring).

### Testing
- Ran `npm test -- --runInBand test/poolRoyaleCueStrokeTimeline.test.js test/cueShotImpact.test.js test/poolRoyaleShotState.test.js` and all suites passed.
- Test output: `3 passed, 3 total` (12 tests passed) with no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef8f31a19c8329b0886efd9b101674)