### PR TITLE
Keep Snooker human stance grounded while aiming

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -25344,7 +25344,9 @@ const powerRef = useRef(hud.power);
               BILARDO_DESIRED_SHOOT_DISTANCE
             )
           });
-          rootTarget.y = FLOOR_Y + Math.max(BALL_R * 0.08, 0.03);
+          // Keep the avatar root on the same floor plane used by Bilardo Shqip so
+          // the stance stays grounded while bending to shoot.
+          rootTarget.y = FLOOR_Y;
           const aimSide = new THREE.Vector3(aimForward.z, 0, -aimForward.x).normalize();
           const bridgeTarget = cueBallWorld
             .clone()


### PR DESCRIPTION
### Motivation
- Ensure the Snooker Royal avatar's bending/aiming pose keeps the feet on the same floor plane used by Bilardo-style poses so the character remains grounded while leaning to shoot.
- Match Bilardo Shqip orientation/stance behavior to provide consistent visual pose across billiards modes.

### Description
- Changed the computed human root Y position in `webapp/src/pages/Games/SnookerRoyal.jsx` to place the avatar root on `FLOOR_Y` instead of adding an extra vertical offset during aim/drag updates.
- Added an inline comment explaining the floor-plane alignment for Bilardo-style pose consistency.

### Testing
- Ran `npx eslint webapp/src/pages/Games/SnookerRoyal.jsx`, which reported the file is ignored by the repo lint pattern and emitted a warning but no lint errors.
- Ran `npx eslint --no-ignore webapp/src/pages/Games/SnookerRoyal.jsx` and `npm run -s lint`, both completed with warnings only and no lint errors detected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef8fda2a288329b10945b5b3352113)