### PR TITLE
Tune Ludo Battle Royale weapon scales, store filtering, and avatar/dice contact

### DIFF
--- a/webapp/src/config/ludoBattleInventoryConfig.js
+++ b/webapp/src/config/ludoBattleInventoryConfig.js
@@ -53,6 +53,12 @@ export const LUDO_BATTLE_OPTION_LABELS = Object.freeze({
   headStyle: Object.freeze(CHESS_BATTLE_OPTION_LABELS.headStyle)
 });
 
+const HIDDEN_LUDO_CAPTURE_STORE_OPTION_IDS = new Set([
+  'mrtkGunAttack',
+  'pistolHolsterAttack',
+  'pistolSidearmAttack'
+]);
+
 const uniqueStoreItemsByName = (items) => {
   const seen = new Set();
   return items.filter((item) => {
@@ -140,15 +146,17 @@ export const LUDO_BATTLE_STORE_ITEMS = uniqueStoreItemsByName([
     description: 'Unlock an alternate piece identity for your pawns.',
     thumbnail: swatchThumbnail(['#f8fafc', '#0f172a', '#fbbf24'])
   })),
-  ...CAPTURE_ANIMATION_OPTIONS.slice(1).map((option, idx) => ({
-    id: `ludo-capture-animation-${option.id}`,
-    type: 'captureAnimation',
-    optionId: option.id,
-    name: option.label,
-    price: 950 + idx * 120,
-    description: option.description,
-    thumbnail: option.thumbnail || swatchThumbnail(['#0f172a', '#1d4ed8', '#f97316'])
-  })),
+  ...CAPTURE_ANIMATION_OPTIONS.slice(1)
+    .filter((option) => !HIDDEN_LUDO_CAPTURE_STORE_OPTION_IDS.has(option.id))
+    .map((option, idx) => ({
+      id: `ludo-capture-animation-${option.id}`,
+      type: 'captureAnimation',
+      optionId: option.id,
+      name: option.label,
+      price: 950 + idx * 120,
+      description: option.description,
+      thumbnail: option.thumbnail || swatchThumbnail(['#0f172a', '#1d4ed8', '#f97316'])
+    })),
   ...HUMAN_CHARACTER_OPTIONS.slice(1).map((option, idx) => ({
     id: `ludo-human-character-${option.id}`,
     type: 'humanCharacter',

--- a/webapp/src/config/ludoBattleOptions.js
+++ b/webapp/src/config/ludoBattleOptions.js
@@ -253,8 +253,8 @@ export const CAPTURE_ANIMATION_OPTIONS = Object.freeze([
   },
   {
     id: 'compactCarbineAttack',
-    label: 'Compact Carbine',
-    description: 'Open-source compact carbine-style pickup and burst capture animation.',
+    label: 'Combat Carbine',
+    description: 'Open-source combat carbine pickup and burst capture animation.',
     thumbnail: captureWeaponThumb('🪖', '#1f2937')
   },
   {
@@ -326,14 +326,6 @@ export const HUMAN_CHARACTER_OPTIONS = Object.freeze([
     description: 'Open WebGL GLB body variant using the same seated character animation logic.',
     modelUrls: ['https://raw.githubusercontent.com/msorkhpar/3d-human-model-vite/main/body.glb'],
     source: 'msorkhpar/3d-human-model-vite GitHub',
-    license: 'Check repository license'
-  },
-  {
-    id: 'webgl-human-body-b',
-    label: 'Human Body B',
-    description: 'Open WebGL GLB body variant matched to default seated sizing/orientation.',
-    modelUrls: ['https://raw.githubusercontent.com/bddicken/humanbody/main/body.glb'],
-    source: 'bddicken/humanbody GitHub',
     license: 'Check repository license'
   },
   {

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -224,7 +224,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://cdn.jsdelivr.net/gh/lando19/Guns-for-BJS-FPS-Game@master/main/scene.gltf',
       'https://raw.githubusercontent.com/lando19/Guns-for-BJS-FPS-Game/master/main/scene.gltf'
     ],
-    scale: 0.142
+    scale: 0.284
   },
   glockSidearmAttack: {
     label: 'Glock',
@@ -232,7 +232,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://cdn.jsdelivr.net/gh/webaverse/pistol@master/glock.glb',
       'https://raw.githubusercontent.com/webaverse/pistol/master/glock.glb'
     ],
-    scale: 0.125
+    scale: 0.2
   },
   pistolSidearmAttack: {
     label: 'Pistol Sidearm',
@@ -246,9 +246,8 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   assaultRifleAttack: {
     label: 'Assault Rifle',
     urls: [
-      'https://cdn.jsdelivr.net/gh/webaverse/pistol@master/military.glb',
-      'https://raw.githubusercontent.com/webaverse/pistol/master/military.glb',
-      'https://cdn.statically.io/gh/webaverse/pistol/master/military.glb'
+      'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/AK47/scene.gltf',
+      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/AK47/scene.gltf'
     ],
     scale: 0.145
   },
@@ -258,7 +257,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models2/Uzi/scene.gltf',
       'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models2/Uzi/scene.gltf'
     ],
-    scale: 0.14
+    scale: 0.218
   },
   ak47VolleyAttack: {
     label: 'AK-47',
@@ -266,7 +265,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/AK47/scene.gltf',
       'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/AK47/scene.gltf'
     ],
-    scale: 0.16
+    scale: 0.24
   },
   krsvBurstAttack: {
     label: 'KRSV',
@@ -274,7 +273,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/KRSV/scene.gltf',
       'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/KRSV/scene.gltf'
     ],
-    scale: 0.148
+    scale: 0.24
   },
   smithSidearmAttack: {
     label: 'Smith',
@@ -282,7 +281,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/Smith/scene.gltf',
       'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/Smith/scene.gltf'
     ],
-    scale: 0.122
+    scale: 0.2
   },
   mosinMarksmanAttack: {
     label: 'Mosin',
@@ -290,13 +289,13 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models2/Mosin/scene.gltf',
       'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models2/Mosin/scene.gltf'
     ],
-    scale: 0.205
+    scale: 0.5125
   },
   sigsauerTacticalAttack: {
     label: 'SigSauer Tactical',
     urls: [
-      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models3/SigSauer/scene.gltf',
-      'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models3/SigSauer/scene.gltf'
+      'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models3/SigSauer/scene.gltf',
+      'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models3/SigSauer/scene.gltf'
     ],
     scale: 0.13
   },
@@ -307,7 +306,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://raw.githubusercontent.com/friuns2/bingextension/main/grenade.glb',
       'https://cdn.statically.io/gh/friuns2/bingextension/main/grenade.glb'
     ],
-    scale: 0.19
+    scale: 0.12
   },
   shotgunBlastAttack: {
     label: 'Shotgun Blast',
@@ -325,7 +324,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models2/Mosin/scene.gltf',
       'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models2/Mosin/scene.gltf'
     ],
-    scale: 0.252
+    scale: 0.504
   },
   smgBurstAttack: {
     label: 'SMG',
@@ -506,22 +505,22 @@ const FIREARM_ATTACH_SCALE_MULTIPLIER = Object.freeze({
   // seated humans keep a consistent hand fit around the trigger/handle zone.
   mrtkGunAttack: 1.16,
   pistolHolsterAttack: 1.14,
-  fpsGunAttack: 1.72,
-  glockSidearmAttack: 0.98,
+  fpsGunAttack: 3.44,
+  glockSidearmAttack: 1.22,
   pistolSidearmAttack: 1.16,
-  uziSprayAttack: 1.2,
+  uziSprayAttack: 1.22,
   smgBurstAttack: 1.22,
   compactCarbineAttack: 1.34,
   assaultRifleAttack: 1.56,
-  ak47VolleyAttack: 1.64,
-  krsvBurstAttack: 1.58,
-  smithSidearmAttack: 1.15,
-  mosinMarksmanAttack: 1.72,
+  ak47VolleyAttack: 2.46,
+  krsvBurstAttack: 2.46,
+  smithSidearmAttack: 1.22,
+  mosinMarksmanAttack: 4.3,
   sigsauerTacticalAttack: 1.2,
   shotgunBlastAttack: 1.7,
   marksmanDmrAttack: 1.48,
-  sniperShotAttack: 1.76,
-  grenadeBlastAttack: 1.12
+  sniperShotAttack: 3.52,
+  grenadeBlastAttack: 0.86
 });
 const FIREARM_VOLLEY_SLOW_FACTOR = 1.72;
 const FIREARM_CAMERA_FOCUS_BLEND = 0.58;
@@ -530,6 +529,11 @@ const FIREARM_CAMERA_LIFT = 0.048;
 const FIREARM_CAMERA_TARGET_OFFSET = 0.036;
 const FIREARM_TARGET_RETICLE_SIZE = 0.04;
 const FIREARM_SOURCE_AUDIO_CACHE = new Map();
+const CAPTURE_WEAPON_TEXTURE_FALLBACK_BY_ID = Object.freeze({
+  assaultRifleAttack: 'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/images/AK47.jpeg',
+  sigsauerTacticalAttack: 'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/images/SigSauer.jpg',
+  grenadeBlastAttack: 'https://raw.githubusercontent.com/twitter/twemoji/master/assets/72x72/1f4a3.png'
+});
 const CAPTURE_ATTACK_TUNING = Object.freeze({
   fighterJetAttack: { speed: 1.2, height: 0.92, inward: 0.94, takeoff: 0.2, landing: 0.24 },
   helicopterAttack: { speed: 1.26, height: 0.84, inward: 0.88, takeoff: 0.24, landing: 0.28 },
@@ -645,6 +649,21 @@ async function loadCaptureWeaponModel(captureAnimationId) {
     try {
       const root = loadedRoot;
       if (!root) return null;
+      const fallbackTextureUrl = CAPTURE_WEAPON_TEXTURE_FALLBACK_BY_ID[normalizedCaptureAnimationId];
+      const fallbackTexturePromise = fallbackTextureUrl
+        ? (async () => {
+            try {
+              const texture = await new THREE.TextureLoader().loadAsync(fallbackTextureUrl);
+              applySRGBColorSpace(texture);
+              texture.wrapS = THREE.RepeatWrapping;
+              texture.wrapT = THREE.RepeatWrapping;
+              return texture;
+            } catch (error) {
+              return null;
+            }
+          })()
+        : Promise.resolve(null);
+      const fallbackTexture = await fallbackTexturePromise;
       root.traverse((node) => {
         if (!node?.isMesh) return;
         if (
@@ -660,6 +679,7 @@ async function loadCaptureWeaponModel(captureAnimationId) {
         node.visible = true;
         const materials = Array.isArray(node.material) ? node.material : [node.material];
         materials.forEach((material) => {
+          if (!material?.map && fallbackTexture) material.map = fallbackTexture;
           if (material?.map) applySRGBColorSpace(material.map);
           if (material?.emissiveMap) applySRGBColorSpace(material.emissiveMap);
           material.transparent = false;
@@ -2755,7 +2775,7 @@ const SEATED_HUMAN_MODEL_URL = 'https://threejs.org/examples/models/gltf/readypl
 const SEATED_HUMAN_BASE_HEIGHT = 1.74;
 const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.42;
 // Slightly upscale seated humans so they read better on portrait/mobile gameplay.
-const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 4.55;
+const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 3.6;
 // Push seated humans dramatically lower so they sit much deeper on portrait/mobile camera framing.
 const SEATED_HUMAN_SEAT_Y_OFFSET = -6.2 * MODEL_SCALE * STOOL_SCALE;
 // Shift humans farther back on the chair so they appear more outward from the table in portrait gameplay.
@@ -2794,13 +2814,13 @@ const SEATED_HUMAN_DOWNWARD_CONTACT_MODE_SET = new Set([
 ]);
 const SEATED_HELPER_FORWARD_DICE_PICKUP = 0.084 * MODEL_SCALE;
 const SEATED_HELPER_FORWARD_DICE_RELEASE = 0.154 * MODEL_SCALE;
-const SEATED_HELPER_RIGHT_DICE = 0.0032 * MODEL_SCALE;
-const SEATED_HELPER_UP_DICE_PICKUP = 0.011 * MODEL_SCALE;
-const SEATED_HELPER_UP_DICE_RELEASE = 0.024 * MODEL_SCALE;
-const SEATED_HELPER_FORWARD_DICE_HOLD = 0.088 * MODEL_SCALE;
-const SEATED_HELPER_UP_DICE_HOLD = 0.013 * MODEL_SCALE;
-const SEATED_DICE_HOLD_VERTICAL_NUDGE = 0.035;
-const SEATED_DICE_THROW_VERTICAL_NUDGE = 0.008;
+const SEATED_HELPER_RIGHT_DICE = 0.0008 * MODEL_SCALE;
+const SEATED_HELPER_UP_DICE_PICKUP = 0.007 * MODEL_SCALE;
+const SEATED_HELPER_UP_DICE_RELEASE = 0.016 * MODEL_SCALE;
+const SEATED_HELPER_FORWARD_DICE_HOLD = 0.081 * MODEL_SCALE;
+const SEATED_HELPER_UP_DICE_HOLD = 0.0072 * MODEL_SCALE;
+const SEATED_DICE_HOLD_VERTICAL_NUDGE = 0.012;
+const SEATED_DICE_THROW_VERTICAL_NUDGE = 0.002;
 const SEATED_HELPER_FORWARD_TOKEN_PICKUP = 0.076 * MODEL_SCALE;
 const SEATED_HELPER_FORWARD_TOKEN_PLACE = 0.114 * MODEL_SCALE;
 const SEATED_HELPER_RIGHT_TOKEN = -0.012 * MODEL_SCALE;
@@ -2815,7 +2835,7 @@ const SEATED_HELPER_FACE_CAMERA_UP = 0.016 * MODEL_SCALE;
 const SEATED_HELPER_FACE_CAMERA_FORWARD = -0.14 * MODEL_SCALE;
 const SEATED_CONTACT_IK_ITERATIONS = 7;
 const SEATED_CONTACT_IK_MAX_STEP_RAD = 0.3;
-const SEATED_CONTACT_DICE_Y_OFFSET = 0.016;
+const SEATED_CONTACT_DICE_Y_OFFSET = 0.005;
 const SEATED_CONTACT_TOKEN_Y_OFFSET = 0.007;
 const SEATED_CONTACT_TOKEN_RADIUS = 0.028;
 const seatedHumanTemplatePromiseById = new Map();


### PR DESCRIPTION
### Motivation
- Align capture-weapon visuals and in-hand animation sizing to requested relative proportions so table display and hand grip look correct. 
- Remove specific weapons from the in-game store while keeping runtime IDs intact to avoid breaking save/compat data. 
- Fix missing GLTF/GLB texture cases for several weapons and improve fallback behavior so models render with visible textures. 
- Make seated avatars smaller and improve dice-hand contact so the die appears centered in the palm during pickup/hold/throw.

### Description
- Adjusted per-weapon model `scale` in `CAPTURE_WEAPON_MODEL_CONFIG` for `fpsGunAttack`, `glockSidearmAttack`, `uziSprayAttack`, `ak47VolleyAttack`, `krsvBurstAttack`, `smithSidearmAttack`, `mosinMarksmanAttack`, `sniperShotAttack`, and `grenadeBlastAttack` in `webapp/src/pages/Games/LudoBattleRoyal.jsx` to match requested sizing. 
- Updated `FIREARM_ATTACH_SCALE_MULTIPLIER` values to keep hand grip/trigger fit consistent with the new model scales in `LudoBattleRoyal.jsx`. 
- Added `CAPTURE_WEAPON_TEXTURE_FALLBACK_BY_ID` and applied a fallback texture loader in `loadCaptureWeaponModel` so `assaultRifleAttack`, `sigsauerTacticalAttack`, and `grenadeBlastAttack` use fallback images when GLTF/GLB materials lack base maps. 
- Swapped `assaultRifleAttack` source URLs to textured Gunify GLTFs and reordered SigSauer URLs to prefer CDN paths in `LudoBattleRoyal.jsx`. 
- Reduced seated avatar visual scale and retuned dice helper/contact constants (`SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER`, `SEATED_HELPER_*`, `SEATED_DICE_*`, `SEATED_CONTACT_DICE_Y_OFFSET`) so the die snaps closer to the palm center and behaves better during handoff in `LudoBattleRoyal.jsx`. 
- Removed the `webgl-human-body-b` skeleton-like avatar from `HUMAN_CHARACTER_OPTIONS` in `webapp/src/config/ludoBattleOptions.js`. 
- Renamed `compactCarbineAttack` display label/description to `Combat Carbine` in `ludoBattleOptions.js`. 
- Added `HIDDEN_LUDO_CAPTURE_STORE_OPTION_IDS` and filtered `CAPTURE_ANIMATION_OPTIONS` in `webapp/src/config/ludoBattleInventoryConfig.js` to hide `mrtkGunAttack`, `pistolHolsterAttack`, and `pistolSidearmAttack` from the store while leaving their IDs available at runtime.

### Testing
- Ran `npm --prefix webapp run build` and the production build completed successfully (Vite emitted normal chunk-size and dynamic-import warnings). 
- Attempting `npm --prefix webapp run lint` failed because the repository does not include a `lint` script. 
- Changes committed and verified in the working tree (`webapp/src/pages/Games/LudoBattleRoyal.jsx`, `webapp/src/config/ludoBattleOptions.js`, and `webapp/src/config/ludoBattleInventoryConfig.js`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef8cdf5af883299ee64703a8e7ee20)