### PR TITLE
Restore Pool Royale cue-ball launch power on impact

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1931,6 +1931,7 @@ const CUE_FOLLOW_THROUGH_MAX = BALL_R * 8.4; // extend top-end follow-through so
 const REFERENCE_CUE_SPEED_BASE = 1.9; // align baseline launch speed with Bilardo Shqip shot feel
 const REFERENCE_CUE_SPEED_RANGE = 8.2; // align high-end launch speed with Bilardo Shqip shot feel
 const REFERENCE_CUE_SPEED_GAMMA = 1.08; // reference implementation: power curve
+const POOL_ROYALE_CUE_SPEED_BOOST = 1.35; // keep cue-ball launch force strong enough to match expected slider power
 const MIN_SHOT_POWER_TO_FIRE = BILARDO_MIN_RELEASE_POWER; // keep Pool Royale release gate identical to Bilardo Shqip
 const HUMAN_PLAYER_HEIGHT_RATIO_TO_TABLE = 0.88; // make player humans visibly bigger relative to table/balls
 const BILARDO_SHQIP_HUMAN_URL = 'https://threejs.org/examples/models/gltf/readyplayer.me.glb';
@@ -26814,7 +26815,7 @@ useEffect(() => {
         const shotDir3 = TMP_VEC3_C.set(aimDir.x, 0, aimDir.y);
         if (shotDir3.lengthSq() > 1e-8) shotDir3.normalize();
         else shotDir3.set(0, 0, 1);
-        const referenceSpeed = bilardoCueSpeed(clampedPower);
+        const referenceSpeed = bilardoCueSpeed(clampedPower) * POOL_ROYALE_CUE_SPEED_BOOST;
         cue.vel.copy(shotDir3).multiplyScalar(referenceSpeed);
         if (cue.spin) {
           cue.spin.set(offsetScaled.x, offsetScaled.y);


### PR DESCRIPTION
### Motivation
- The Pool Royale shots were feeling weak because the cue-ball launch speed boost was lost during a prior snapshot/restore, so released slider power did not produce the expected cue-ball acceleration.

### Description
- Reintroduced a dedicated constant `POOL_ROYALE_CUE_SPEED_BOOST` and applied it when computing cue launch speed at impact in `webapp/src/pages/Games/PoolRoyale.jsx`.
- The change multiplies the reference cue speed (`bilardoCueSpeed(clampedPower)`) by `POOL_ROYALE_CUE_SPEED_BOOST` so the slider-committed power maps to a clearer cue-ball velocity.

### Testing
- Ran the unit tests `npm test -- --runInBand test/poolRoyaleShotState.test.js test/cueShotImpact.test.js` and both suites passed (`PASS test/cueShotImpact.test.js` and `PASS test/poolRoyaleShotState.test.js`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef8f31a19c8329b0886efd9b101674)