### PR TITLE
Isolate player weapon/character swaps; remove MRTK/Pistol Holster/Sidearm; rebalance firearm sizes

### DIFF
--- a/webapp/src/config/ludoBattleInventoryConfig.js
+++ b/webapp/src/config/ludoBattleInventoryConfig.js
@@ -53,11 +53,7 @@ export const LUDO_BATTLE_OPTION_LABELS = Object.freeze({
   headStyle: Object.freeze(CHESS_BATTLE_OPTION_LABELS.headStyle)
 });
 
-const HIDDEN_LUDO_STORE_CAPTURE_ANIMATION_IDS = new Set([
-  'mrtkGunAttack',
-  'pistolHolsterAttack',
-  'pistolSidearmAttack'
-]);
+const HIDDEN_LUDO_STORE_CAPTURE_ANIMATION_IDS = new Set();
 
 const uniqueStoreItemsByName = (items) => {
   const seen = new Set();

--- a/webapp/src/config/ludoBattleOptions.js
+++ b/webapp/src/config/ludoBattleOptions.js
@@ -156,18 +156,6 @@ export const CAPTURE_ANIMATION_OPTIONS = Object.freeze([
     thumbnail: captureWeaponThumb('🚁', '#0f766e')
   },
   {
-    id: 'mrtkGunAttack',
-    label: 'MRTK Gun',
-    description: 'Mixed Reality Toolkit Gun.glb pickup and burst attack.',
-    thumbnail: captureWeaponThumb('🔫', '#075985')
-  },
-  {
-    id: 'pistolHolsterAttack',
-    label: 'Pistol Holster',
-    description: 'Holstered pistol model from SAM_ASSET-PISTOL-IN-HOLSTER.glb.',
-    thumbnail: captureWeaponThumb('🧰', '#0f766e')
-  },
-  {
     id: 'fpsGunAttack',
     label: 'FPS Gun',
     description: 'FPS Gun scene.gltf pickup with preserved mesh/material shape.',
@@ -178,12 +166,6 @@ export const CAPTURE_ANIMATION_OPTIONS = Object.freeze([
     label: 'Glock Sidearm',
     description: 'Pick the Glock from the table, aim, and fire before taking the tile.',
     thumbnail: CAPTURE_WEAPON_SOURCE_THUMBNAILS.glockSidearmAttack
-  },
-  {
-    id: 'pistolSidearmAttack',
-    label: 'Pistol Sidearm',
-    description: 'Classic pistol takedown with right-hand pickup using original GLB textures.',
-    thumbnail: CAPTURE_WEAPON_SOURCE_THUMBNAILS.pistolSidearmAttack
   },
   {
     id: 'assaultRifleAttack',

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -186,13 +186,13 @@ const FIREARM_SINGLE_HAND_ONLY_IDS = new Set([
   'grenadeBlastAttack'
 ]);
 const FIREARM_RACK_SIZE_MULTIPLIER_BY_ID = Object.freeze({
-  fpsGunAttack: 3.2,
-  glockSidearmAttack: 2.2,
-  uziSprayAttack: 1.8,
-  smgBurstAttack: 1.8,
+  fpsGunAttack: 2.2,
+  glockSidearmAttack: 1,
+  uziSprayAttack: 1.6,
+  smgBurstAttack: 1.6,
   ak47VolleyAttack: 2.2,
   krsvBurstAttack: 2.2,
-  smithSidearmAttack: 2.2,
+  smithSidearmAttack: 1,
   mosinMarksmanAttack: 3.5,
   sniperShotAttack: 2.8,
   grenadeBlastAttack: 0.45
@@ -237,7 +237,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://cdn.jsdelivr.net/gh/lando19/Guns-for-BJS-FPS-Game@master/main/scene.gltf',
       'https://raw.githubusercontent.com/lando19/Guns-for-BJS-FPS-Game/master/main/scene.gltf'
     ],
-    scale: 0.284
+    scale: 0.24
   },
   glockSidearmAttack: {
     label: 'Glock',
@@ -245,7 +245,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://cdn.jsdelivr.net/gh/webaverse/pistol@master/glock.glb',
       'https://raw.githubusercontent.com/webaverse/pistol/master/glock.glb'
     ],
-    scale: 0.2
+    scale: 0.13
   },
   pistolSidearmAttack: {
     label: 'Pistol Sidearm',
@@ -263,7 +263,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://raw.githubusercontent.com/webaverse/pistol/master/military.glb',
       'https://cdn.statically.io/gh/webaverse/pistol/master/military.glb'
     ],
-    scale: 0.2175,
+    scale: 0.13,
     textureOverrideUrls: [
       'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/images/AK47.jpeg'
     ]
@@ -274,7 +274,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models2/Uzi/scene.gltf',
       'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models2/Uzi/scene.gltf'
     ],
-    scale: 0.218
+    scale: 0.19
   },
   ak47VolleyAttack: {
     label: 'AK-47',
@@ -298,7 +298,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/Smith/scene.gltf',
       'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/Smith/scene.gltf'
     ],
-    scale: 0.2
+    scale: 0.13
   },
   mosinMarksmanAttack: {
     label: 'Mosin',
@@ -339,7 +339,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://raw.githubusercontent.com/lando19/Guns-for-BJS-FPS-Game/master/main/scene.gltf',
       'https://cdn.jsdelivr.net/gh/lando19/Guns-for-BJS-FPS-Game@master/main/scene.gltf'
     ],
-    scale: 0.238
+    scale: 0.24
   },
   sniperShotAttack: {
     label: 'Sniper Shot',
@@ -355,7 +355,7 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
       'https://cdn.jsdelivr.net/gh/webaverse/uzi@main/uzi.glb',
       'https://cdn.jsdelivr.net/gh/webaverse/pistol@master/pistol.glb'
     ],
-    scale: 0.218
+    scale: 0.19
   },
   compactCarbineAttack: {
     label: 'Compact Carbine',
@@ -528,19 +528,19 @@ const FIREARM_ATTACH_SCALE_MULTIPLIER = Object.freeze({
   // seated humans keep a consistent hand fit around the trigger/handle zone.
   mrtkGunAttack: 1.16,
   pistolHolsterAttack: 1.14,
-  fpsGunAttack: 5.5,
-  glockSidearmAttack: 2.2,
+  fpsGunAttack: 3.2,
+  glockSidearmAttack: 1.2,
   pistolSidearmAttack: 1.16,
-  uziSprayAttack: 2,
-  smgBurstAttack: 2,
+  uziSprayAttack: 1.85,
+  smgBurstAttack: 1.85,
   compactCarbineAttack: 1.34,
-  assaultRifleAttack: 1.56,
+  assaultRifleAttack: 1.2,
   ak47VolleyAttack: 3.2,
   krsvBurstAttack: 3.2,
-  smithSidearmAttack: 2.2,
+  smithSidearmAttack: 1.2,
   mosinMarksmanAttack: 6,
   sigsauerTacticalAttack: 1.2,
-  shotgunBlastAttack: 1.7,
+  shotgunBlastAttack: 3.2,
   marksmanDmrAttack: 1.48,
   sniperShotAttack: 5.2,
   grenadeBlastAttack: 0.55
@@ -3002,7 +3002,7 @@ const DEFAULT_CLOTH_OPTION = TABLE_CLOTH_OPTIONS[0];
 const DEFAULT_BASE_OPTION = TABLE_BASE_OPTIONS[0];
 const TABLE_MODEL_TARGET_DIAMETER = TABLE_RADIUS * 2 * TABLE_VISUAL_SCALE;
 
-function createAiUniqueLoadout(activePlayerCount, appearance = DEFAULT_APPEARANCE) {
+function createAiUniqueLoadout(activePlayerCount) {
   const totalPlayers = Math.max(1, Number(activePlayerCount) || 1);
   const byPlayer = Array.from({ length: totalPlayers }, () => ({
     tokenPieceIndex: 0,
@@ -3021,25 +3021,9 @@ function createAiUniqueLoadout(activePlayerCount, appearance = DEFAULT_APPEARANC
     return copy;
   };
 
-  const playerTokenPieceIndex = Math.max(0, Math.min(TOKEN_PIECE_OPTIONS.length - 1, Number(appearance?.tokenPiece) || 0));
-  const playerCaptureIndex = Math.max(
-    0,
-    Math.min(CAPTURE_ANIMATION_OPTIONS.length - 1, Number(appearance?.captureAnimation) || 0)
-  );
-  const playerHumanIndex = Math.max(
-    0,
-    Math.min(HUMAN_CHARACTER_OPTIONS.length - 1, Number(appearance?.humanCharacter) || 0)
-  );
-
-  const piecePool = shuffle(
-    Array.from({ length: TOKEN_PIECE_OPTIONS.length }, (_, idx) => idx).filter((idx) => idx !== playerTokenPieceIndex)
-  );
-  const capturePool = shuffle(
-    Array.from({ length: CAPTURE_ANIMATION_OPTIONS.length }, (_, idx) => idx).filter((idx) => idx !== playerCaptureIndex)
-  );
-  const humanPool = shuffle(
-    Array.from({ length: HUMAN_CHARACTER_OPTIONS.length }, (_, idx) => idx).filter((idx) => idx !== playerHumanIndex)
-  );
+  const piecePool = shuffle(Array.from({ length: TOKEN_PIECE_OPTIONS.length }, (_, idx) => idx));
+  const capturePool = shuffle(Array.from({ length: CAPTURE_ANIMATION_OPTIONS.length }, (_, idx) => idx));
+  const humanPool = shuffle(Array.from({ length: HUMAN_CHARACTER_OPTIONS.length }, (_, idx) => idx));
 
   aiIndexes.forEach((playerIndex, aiIndex) => {
     byPlayer[playerIndex] = {
@@ -6580,10 +6564,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     }
     return pool.slice(0, aiOpponentCount);
   }, [aiFlagOverrides, aiOpponentCount]);
-  const aiLoadoutByPlayer = useMemo(
-    () => createAiUniqueLoadout(activePlayerCount, appearance),
-    [activePlayerCount, appearance]
-  );
+  const aiLoadoutByPlayer = useMemo(() => createAiUniqueLoadout(activePlayerCount), [activePlayerCount]);
 
   const userPhotoUrl = avatar || '/assets/icons/profile.svg';
 


### PR DESCRIPTION
### Motivation
- Prevent user changes to capture weapon or human character from affecting other players by making AI loadouts independent from live `appearance` changes. 
- Remove `mrtkGun`, `pistolHolster` and `pistolSidearm` capture options from the game and store UI. 
- Align weapon visuals so selected weapons present consistent in-hand and rack sizing and match requested size baselines (SigSauer / AK-47 / slightly smaller SMGs). 

### Description
- Make AI loadouts stable: changed `createAiUniqueLoadout` to no longer read the live `appearance` object and updated the `useMemo` that builds `aiLoadoutByPlayer` to remove `appearance` from dependencies so AI choices aren't regenerated when the human player adjusts appearance; this scope-limits swaps to the local user. (file: `webapp/src/pages/Games/LudoBattleRoyal.jsx`).
- Remove three capture animation options: deleted `mrtkGunAttack`, `pistolHolsterAttack`, and `pistolSidearmAttack` from `CAPTURE_ANIMATION_OPTIONS` so they are no longer selectable. (file: `webapp/src/config/ludoBattleOptions.js`).
- Adjust store visibility bookkeeping: cleared the previous hidden-ID set so the store logic stays aligned with the updated capture option list. (file: `webapp/src/config/ludoBattleInventoryConfig.js`).
- Rebalanced model and attach/rack scales: updated entries in `CAPTURE_WEAPON_MODEL_CONFIG`, `FIREARM_ATTACH_SCALE_MULTIPLIER` and `FIREARM_RACK_SIZE_MULTIPLIER_BY_ID` to make `glock`, `smith`, and `assaultRifle` match `sigsauerTactical` sizing, make `uzi` and `smgBurst` slightly smaller, and make `krsvBurst`, `fpsGun`, and `shotgunBlast` match `ak47` sizing; also adjusted the `fpsGun`/`assaultRifle` attach multipliers so in-hand animations remain believable. (file: `webapp/src/pages/Games/LudoBattleRoyal.jsx`).
- Minor tuning: updated a few `scale` numeric values and rack/attach multipliers to maintain consistent hand grip and rack visuals across affected weapons. (file: `webapp/src/pages/Games/LudoBattleRoyal.jsx`).

### Testing
- Ran `npm test -- --runInBand test/lobbyUtils.test.js` which passed (6 tests, all succeeded). 
- Ran `npm test -- --runInBand test/inventoryCrossGameConfig.test.js test/chessBattleInventoryConfig.test.js` which did not fully pass: one suite failed to run due to a Jest ESM/`three/examples` parsing error (`Cannot use import statement outside a module`), and the `chessBattleInventoryConfig` test failed an expectation about pre-existing inventory entries (this failure appears unrelated to the Ludo-specific changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efa3d5e6748329965a3f231ca71c15)