### PR TITLE
Ludo: isolate player loadout changes, remove some capture weapons, and retune firearm scales

### DIFF
--- a/webapp/src/config/ludoBattleOptions.js
+++ b/webapp/src/config/ludoBattleOptions.js
@@ -156,18 +156,6 @@ export const CAPTURE_ANIMATION_OPTIONS = Object.freeze([
     thumbnail: captureWeaponThumb('🚁', '#0f766e')
   },
   {
-    id: 'mrtkGunAttack',
-    label: 'MRTK Gun',
-    description: 'Mixed Reality Toolkit Gun.glb pickup and burst attack.',
-    thumbnail: captureWeaponThumb('🔫', '#075985')
-  },
-  {
-    id: 'pistolHolsterAttack',
-    label: 'Pistol Holster',
-    description: 'Holstered pistol model from SAM_ASSET-PISTOL-IN-HOLSTER.glb.',
-    thumbnail: captureWeaponThumb('🧰', '#0f766e')
-  },
-  {
     id: 'fpsGunAttack',
     label: 'FPS Gun',
     description: 'FPS Gun scene.gltf pickup with preserved mesh/material shape.',
@@ -178,12 +166,6 @@ export const CAPTURE_ANIMATION_OPTIONS = Object.freeze([
     label: 'Glock Sidearm',
     description: 'Pick the Glock from the table, aim, and fire before taking the tile.',
     thumbnail: CAPTURE_WEAPON_SOURCE_THUMBNAILS.glockSidearmAttack
-  },
-  {
-    id: 'pistolSidearmAttack',
-    label: 'Pistol Sidearm',
-    description: 'Classic pistol takedown with right-hand pickup using original GLB textures.',
-    thumbnail: CAPTURE_WEAPON_SOURCE_THUMBNAILS.pistolSidearmAttack
   },
   {
     id: 'assaultRifleAttack',

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -186,13 +186,15 @@ const FIREARM_SINGLE_HAND_ONLY_IDS = new Set([
   'grenadeBlastAttack'
 ]);
 const FIREARM_RACK_SIZE_MULTIPLIER_BY_ID = Object.freeze({
-  fpsGunAttack: 3.2,
-  glockSidearmAttack: 2.2,
-  uziSprayAttack: 1.8,
-  smgBurstAttack: 1.8,
+  fpsGunAttack: 2.2,
+  glockSidearmAttack: 1,
+  assaultRifleAttack: 1,
+  uziSprayAttack: 1.6,
+  smgBurstAttack: 1.6,
   ak47VolleyAttack: 2.2,
   krsvBurstAttack: 2.2,
-  smithSidearmAttack: 2.2,
+  shotgunBlastAttack: 2.2,
+  smithSidearmAttack: 1,
   mosinMarksmanAttack: 3.5,
   sniperShotAttack: 2.8,
   grenadeBlastAttack: 0.45
@@ -528,19 +530,19 @@ const FIREARM_ATTACH_SCALE_MULTIPLIER = Object.freeze({
   // seated humans keep a consistent hand fit around the trigger/handle zone.
   mrtkGunAttack: 1.16,
   pistolHolsterAttack: 1.14,
-  fpsGunAttack: 5.5,
-  glockSidearmAttack: 2.2,
+  fpsGunAttack: 3.2,
+  glockSidearmAttack: 1.2,
   pistolSidearmAttack: 1.16,
-  uziSprayAttack: 2,
-  smgBurstAttack: 2,
+  uziSprayAttack: 1.8,
+  smgBurstAttack: 1.8,
   compactCarbineAttack: 1.34,
-  assaultRifleAttack: 1.56,
+  assaultRifleAttack: 1.2,
   ak47VolleyAttack: 3.2,
   krsvBurstAttack: 3.2,
-  smithSidearmAttack: 2.2,
+  smithSidearmAttack: 1.2,
   mosinMarksmanAttack: 6,
   sigsauerTacticalAttack: 1.2,
-  shotgunBlastAttack: 1.7,
+  shotgunBlastAttack: 3.2,
   marksmanDmrAttack: 1.48,
   sniperShotAttack: 5.2,
   grenadeBlastAttack: 0.55
@@ -3002,7 +3004,7 @@ const DEFAULT_CLOTH_OPTION = TABLE_CLOTH_OPTIONS[0];
 const DEFAULT_BASE_OPTION = TABLE_BASE_OPTIONS[0];
 const TABLE_MODEL_TARGET_DIAMETER = TABLE_RADIUS * 2 * TABLE_VISUAL_SCALE;
 
-function createAiUniqueLoadout(activePlayerCount, appearance = DEFAULT_APPEARANCE) {
+function createAiUniqueLoadout(activePlayerCount) {
   const totalPlayers = Math.max(1, Number(activePlayerCount) || 1);
   const byPlayer = Array.from({ length: totalPlayers }, () => ({
     tokenPieceIndex: 0,
@@ -3021,25 +3023,9 @@ function createAiUniqueLoadout(activePlayerCount, appearance = DEFAULT_APPEARANC
     return copy;
   };
 
-  const playerTokenPieceIndex = Math.max(0, Math.min(TOKEN_PIECE_OPTIONS.length - 1, Number(appearance?.tokenPiece) || 0));
-  const playerCaptureIndex = Math.max(
-    0,
-    Math.min(CAPTURE_ANIMATION_OPTIONS.length - 1, Number(appearance?.captureAnimation) || 0)
-  );
-  const playerHumanIndex = Math.max(
-    0,
-    Math.min(HUMAN_CHARACTER_OPTIONS.length - 1, Number(appearance?.humanCharacter) || 0)
-  );
-
-  const piecePool = shuffle(
-    Array.from({ length: TOKEN_PIECE_OPTIONS.length }, (_, idx) => idx).filter((idx) => idx !== playerTokenPieceIndex)
-  );
-  const capturePool = shuffle(
-    Array.from({ length: CAPTURE_ANIMATION_OPTIONS.length }, (_, idx) => idx).filter((idx) => idx !== playerCaptureIndex)
-  );
-  const humanPool = shuffle(
-    Array.from({ length: HUMAN_CHARACTER_OPTIONS.length }, (_, idx) => idx).filter((idx) => idx !== playerHumanIndex)
-  );
+  const piecePool = shuffle(Array.from({ length: TOKEN_PIECE_OPTIONS.length }, (_, idx) => idx));
+  const capturePool = shuffle(Array.from({ length: CAPTURE_ANIMATION_OPTIONS.length }, (_, idx) => idx));
+  const humanPool = shuffle(Array.from({ length: HUMAN_CHARACTER_OPTIONS.length }, (_, idx) => idx));
 
   aiIndexes.forEach((playerIndex, aiIndex) => {
     byPlayer[playerIndex] = {
@@ -6580,10 +6566,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     }
     return pool.slice(0, aiOpponentCount);
   }, [aiFlagOverrides, aiOpponentCount]);
-  const aiLoadoutByPlayer = useMemo(
-    () => createAiUniqueLoadout(activePlayerCount, appearance),
-    [activePlayerCount, appearance]
-  );
+  const aiLoadoutByPlayer = useMemo(() => createAiUniqueLoadout(activePlayerCount), [activePlayerCount]);
 
   const userPhotoUrl = avatar || '/assets/icons/profile.svg';
 


### PR DESCRIPTION
### Motivation

- Prevent local player appearance swaps (weapon/human) from changing other players' loadouts so a user change only affects their own seated character and weapon visuals. 
- Remove unwanted capture animation options (`mrtkGun`, `pistolHolster`, `pistolSidearm`) from the selectable Ludo capture weapons list.
- Adjust weapon rack and hand-attach scale multipliers so requested weapons visually match target sizes (SigSauer baseline / AK-47 baseline / slight Uzi/SMG shrink).

### Description

- Stop regenerating AI loadouts when the local player changes appearance by removing the `appearance` input from `createAiUniqueLoadout` and memoizing `aiLoadoutByPlayer` only by player count; this ensures local swaps do not replace AI player weapons/humans (`webapp/src/pages/Games/LudoBattleRoyal.jsx`).
- Remove the MRTK Gun, Pistol Holster, and Pistol Sidearm entries from `CAPTURE_ANIMATION_OPTIONS` so they are no longer selectable (`webapp/src/config/ludoBattleOptions.js`).
- Retune firearm sizing constants used for rack display and hand attachment by updating `FIREARM_RACK_SIZE_MULTIPLIER_BY_ID` and `FIREARM_ATTACH_SCALE_MULTIPLIER` to align sizes as requested: Glock/Smith/AssaultRifle → SigSauer scale; Uzi/SMG Burst slightly smaller; KRSV/FPS/Shotgun → AK-47 scale, and adjust related entries (`webapp/src/pages/Games/LudoBattleRoyal.jsx`).

### Testing

- Ran unit test command `npm test -- --runInBand test/inventoryCrossGameConfig.test.js`, which failed due to the environment's Jest/ESM parsing problem with `three` addon imports (syntax error from ESM `import` in `three/examples/jsm`), not related to the Ludo code changes.
- Ran linting with `npx eslint` which reported file-ignore warnings and localized rule errors when forcing `--no-ignore`; lint output flagged several `semi` and formatting issues in the edited files, not runtime failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efa3d5e6748329965a3f231ca71c15)