### PR TITLE
Align Pool Royale shot release with Snooker (apply impact immediately)

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -27243,6 +27243,10 @@ const shotPowerRef = useRef(0);
             strikeDuration: strokeProfile.strikeDuration ?? LIVE_CUE_FORWARD_DURATION_MS,
             applied: false
           };
+          // Match Snooker Royal shot behavior: apply cue-ball velocity/spin as soon as
+          // the shot is fired so release always transfers power, even if the visual
+          // cue stroke impact callback is delayed or skipped.
+          applyShotAtImpact(shotImpactPayload);
 
           if (cameraRef.current && sphRef.current) {
             topViewRef.current = false;


### PR DESCRIPTION
### Motivation
- Pool Royale sometimes failed to transfer power to the cue ball when the visual cue-stroke impact callback was delayed or skipped, causing different shooting behavior than Snooker Royal.
- Make the Pool Royale firing timing identical to Snooker so a released shot always delivers the intended velocity and spin to the cue ball.

### Description
- Apply `applyShotAtImpact(shotImpactPayload)` immediately after constructing the shot payload in `webapp/src/pages/Games/PoolRoyale.jsx` so cue-ball velocity/spin is set at shot release.
- Preserve the existing cue-stroke animation and later impact callback flow; the payload application is idempotent because the implementation marks `payload.applied`.
- Change is limited to `webapp/src/pages/Games/PoolRoyale.jsx` and keeps other shot logic and camera behavior intact.

### Testing
- Ran the targeted unit test with `npm test -- --runInBand test/poolRoyaleAiAimCompensation.test.js` and it passed.
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx` which reported only a repo ignore warning and no lint errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0203642848329b6aa5633d142f7ff)