### PR TITLE
Lay down and seat-align weapon racks for Ludo Battle Royal

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -195,13 +195,13 @@ const FIREARM_RACK_SIZE_MULTIPLIER_BY_ID = Object.freeze({
 const FIREARM_RACK_DISPLAY_TUNING = Object.freeze({
   default: Object.freeze({
     targetSizeMultiplier: 1.06,
-    position: [0, 0, -0.004],
-    rotation: [0, Math.PI * 0.5, 0]
+    position: [0, 0.004, 0],
+    rotation: [-Math.PI * 0.5, 0, 0]
   }),
   large: Object.freeze({
     targetSizeMultiplier: 1.9,
-    position: [0.08, 0, -0.014],
-    rotation: [0, Math.PI * 0.04, Math.PI * 0.02]
+    position: [0.01, 0.004, 0.004],
+    rotation: [-Math.PI * 0.5, 0, 0]
   })
 });
 const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
@@ -6734,6 +6734,34 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     [players]
   );
 
+  const placeWeaponRackForPlayer = useCallback((entry, playerIndex, selectedCaptureAnimationId) => {
+    const arena = arenaRef.current;
+    const rack = entry?.weaponRack;
+    const chairGroup = arena?.chairs?.[playerIndex]?.group;
+    if (!arena?.tableInfo || !rack?.isObject3D || !chairGroup?.isObject3D) return;
+    const boardCenter = arena.boardLookTarget?.isVector3
+      ? arena.boardLookTarget.clone()
+      : new THREE.Vector3(0, arena.tableInfo.surfaceY ?? 0, 0);
+    const chairWorld = chairGroup.getWorldPosition(new THREE.Vector3());
+    const toCenter = boardCenter.clone().sub(chairWorld).setY(0);
+    if (toCenter.lengthSq() < 1e-6) return;
+    toCenter.normalize();
+    const playerRight = toCenter.clone().cross(new THREE.Vector3(0, 1, 0)).normalize();
+    const isLargeFirearm = LARGE_RACK_FIREARM_IDS.has(selectedCaptureAnimationId);
+    const baseForward = isLargeFirearm ? 0.08 : 0.34;
+    const baseSide = isLargeFirearm ? 0.22 : 0.02;
+    const sideSign = isLargeFirearm ? 1 : 0;
+    const target = chairWorld
+      .clone()
+      .addScaledVector(toCenter, baseForward)
+      .addScaledVector(playerRight, baseSide * sideSign);
+    target.y = (arena.tableInfo.surfaceY ?? target.y) + 0.002;
+    rack.position.copy(target);
+    alignObjectBottomToY(rack, arena.tableInfo.surfaceY);
+    rack.position.y += CAPTURE_PARKED_LIFT_OFFSET_Y;
+    orientCaptureVehicleTowardBoardCenter(rack, boardCenter);
+  }, []);
+
   const updateParkedCaptureVehicleVisibility = useCallback((humanCaptureAnimationIndex = null) => {
     const humanOptionIndex =
       Number.isFinite(humanCaptureAnimationIndex) && humanCaptureAnimationIndex >= 0
@@ -6748,13 +6776,14 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       if (entry?.drone) entry.drone.visible = false;
       if (entry?.droneTruck) entry.droneTruck.visible = selectedCaptureAnimationId === 'droneAttack';
       if (entry?.missile) entry.missile.visible = selectedCaptureAnimationId === 'missileJavelin';
-      if (entry?.weaponRack) {
-        const showFirearm = FIREARM_CAPTURE_ANIMATION_IDS.has(selectedCaptureAnimationId);
-        const showActionButton =
-          selectedCaptureAnimationId === 'fighterJetAttack' ||
-          selectedCaptureAnimationId === 'helicopterAttack' ||
-          selectedCaptureAnimationId === 'droneAttack';
-        entry.weaponRack.visible = showFirearm || showActionButton;
+        if (entry?.weaponRack) {
+          const showFirearm = FIREARM_CAPTURE_ANIMATION_IDS.has(selectedCaptureAnimationId);
+          const showActionButton =
+            selectedCaptureAnimationId === 'fighterJetAttack' ||
+            selectedCaptureAnimationId === 'helicopterAttack' ||
+            selectedCaptureAnimationId === 'droneAttack';
+          placeWeaponRackForPlayer(entry, playerIndex, selectedCaptureAnimationId);
+          entry.weaponRack.visible = showFirearm || showActionButton;
         if (entry.actionButton?.isObject3D) {
           entry.actionButton.visible = showActionButton;
           if (showActionButton) {
@@ -6781,7 +6810,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         }
       }
     });
-  }, [aiLoadoutByPlayer]);
+  }, [aiLoadoutByPlayer, placeWeaponRackForPlayer]);
 
   const rebuildParkedCaptureVehicles = useCallback(async () => {
     const arena = arenaRef.current;
@@ -6853,7 +6882,11 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       orientCaptureVehicleTowardBoardCenter(droneFx.root, arena.boardLookTarget);
       orientCaptureVehicleTowardBoardCenter(missileFx.root, arena.boardLookTarget);
       orientCaptureVehicleTowardBoardCenter(droneTruckFx.root, arena.boardLookTarget);
-      orientCaptureVehicleTowardBoardCenter(weaponRackFx.root, arena.boardLookTarget);
+      placeWeaponRackForPlayer(
+        { weaponRack: weaponRackFx.root },
+        playerIndex,
+        CAPTURE_ANIMATION_OPTIONS[0]?.id ?? ''
+      );
       arena.scene.add(jetFx.root);
       arena.scene.add(helicopterFx.root);
       arena.scene.add(droneFx.root);


### PR DESCRIPTION
### Motivation
- Improve the visual placement of capture weapons on the Ludo Battle Royal table so weapons lie flat on the table and face the board center instead of standing upright.
- Make large weapons (rifle/sniper class) appear at the player’s right-hand side while keeping standard firearms opposite the player for clearer portrait/mobile framing.
- Keep placement consistent both at spawn/build time and when the active loadout changes during gameplay.

### Description
- Rotated and re-tuned `FIREARM_RACK_DISPLAY_TUNING` so default and large weapon racks are laid flat on the table (changed `position`/`rotation`).
- Added a new `placeWeaponRackForPlayer` helper to compute per-seat rack positions that point toward the board center and place large firearms on the player’s right-hand side.
- Wired `placeWeaponRackForPlayer` into runtime visibility updates (`updateParkedCaptureVehicleVisibility`) so racks reposition when a player’s capture animation/loadout changes.
- Applied the same placement during parked vehicle rebuild (`rebuildParkedCaptureVehicles`) so initial spawned racks match the seat-aware layout; changes are contained to `webapp/src/pages/Games/LudoBattleRoyal.jsx`.

### Testing
- Ran the production build with `npm --prefix webapp run build`, which completed successfully.
- Attempted a visual verification with Playwright screenshot (`npx playwright screenshot ...`) but it failed because Playwright browser binaries are not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f02158e23483298fe730fafe8ac7c1)