### PR TITLE
Adjust Ludo Battle Royal weapon rack layout, action button and drone launch behavior

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -225,14 +225,14 @@ const FIREARM_RACK_SIZE_MULTIPLIER_BY_ID = Object.freeze({
 
 const FIREARM_RACK_DISPLAY_TUNING = Object.freeze({
   default: Object.freeze({
-    targetSizeMultiplier: 1.06,
-    position: [0, 0, -0.004],
-    rotation: [-Math.PI * 0.5, Math.PI * 0.5, 0]
+    targetSizeMultiplier: 1.12,
+    position: [0, 0, -0.006],
+    rotation: [-Math.PI * 0.5, Math.PI * 0.98, 0]
   }),
   large: Object.freeze({
-    targetSizeMultiplier: 1.9,
-    position: [0.08, 0, -0.014],
-    rotation: [-Math.PI * 0.5, Math.PI * 0.04, 0]
+    targetSizeMultiplier: 2.02,
+    position: [0.02, 0, -0.016],
+    rotation: [-Math.PI * 0.5, Math.PI * 0.98, 0]
   })
 });
 const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
@@ -696,34 +696,34 @@ const HELICOPTER_TOP_ROTOR_SPIN_SPEED = 26;
 const HELICOPTER_TAIL_ROTOR_SPIN_SPEED = 30;
 const HELICOPTER_AUX_ROTOR_SPIN_SPEED = 24;
 const QUICK_SWAP_WEAPON_SHAPE_BY_ID = Object.freeze({
-  missileJavelin: '▸',
-  droneAttack: '◈',
-  fighterJetAttack: '◁',
-  helicopterAttack: '◎',
-  fpsGunAttack: '▬',
-  glockSidearmAttack: '▮',
-  assaultRifleAttack: '▰',
-  uziSprayAttack: '▯',
-  ak47VolleyAttack: '▰',
-  krsvBurstAttack: '▰',
-  smithSidearmAttack: '▮',
-  mosinMarksmanAttack: '▤',
-  sigsauerTacticalAttack: '▮',
+  missileJavelin: '🛻',
+  droneAttack: '🚀',
+  fighterJetAttack: '🛩',
+  helicopterAttack: '🚁',
+  fpsGunAttack: '┥↣',
+  glockSidearmAttack: '⌐↣',
+  assaultRifleAttack: '⌁↣',
+  uziSprayAttack: '≣↣',
+  ak47VolleyAttack: '≋↣',
+  krsvBurstAttack: '⫯↣',
+  smithSidearmAttack: '⌐↣',
+  mosinMarksmanAttack: '╾↣',
+  sigsauerTacticalAttack: '⌐↣',
   grenadeBlastAttack: '⬢',
-  shotgunBlastAttack: '▭',
-  sniperShotAttack: '▤',
-  smgBurstAttack: '▯',
-  compactCarbineAttack: '▰',
-  marksmanDmrAttack: '▤',
-  polyShotgun01Attack: '▬',
-  polyAssaultRifle01Attack: '▰',
-  polyPistol01Attack: '▮',
-  polyRevolver01Attack: '◖',
-  polySawedOff01Attack: '▭',
-  polyRevolver02Attack: '◗',
-  polyShotgun02Attack: '▤',
-  polyShotgun03Attack: '▥',
-  polySmg01Attack: '▯'
+  shotgunBlastAttack: '⟍↣',
+  sniperShotAttack: '╼↣',
+  smgBurstAttack: '≣↣',
+  compactCarbineAttack: '≍↣',
+  marksmanDmrAttack: '╾↣',
+  polyShotgun01Attack: '⟍↣',
+  polyAssaultRifle01Attack: '≋↣',
+  polyPistol01Attack: '⌐↣',
+  polyRevolver01Attack: '◔↣',
+  polySawedOff01Attack: '⟋↣',
+  polyRevolver02Attack: '◕↣',
+  polyShotgun02Attack: '⟍↣',
+  polyShotgun03Attack: '⟍↣',
+  polySmg01Attack: '≣↣'
 });
 
 function orientCaptureVehicleTowardBoardCenter(root, target) {
@@ -1021,23 +1021,16 @@ async function attachFirearmToRightHand(attackerEntry, captureAnimationId) {
 async function createCaptureWeaponRackFx() {
   const root = new THREE.Group();
   const weaponHolder = new THREE.Group();
-  weaponHolder.position.set(0.04, 0.032, -0.018);
+  weaponHolder.position.set(0.054, 0.018, -0.028);
   weaponHolder.rotation.set(0, 0, 0);
   root.add(weaponHolder);
-
-  const buttonBase = new THREE.Mesh(
-    new THREE.CylinderGeometry(0.03, 0.035, 0.02, 24),
-    createCaptureVehicleMaterial('truck', { color: '#0f172a', roughness: 0.4, metalness: 0.34 })
-  );
-  buttonBase.position.set(0.074, 0.016, -0.022);
-  root.add(buttonBase);
 
   const actionButton = new THREE.Mesh(
     new THREE.CylinderGeometry(0.024, 0.026, 0.015, 28),
     createCaptureVehicleMaterial('truck', { color: '#ef4444', roughness: 0.22, metalness: 0.15, emissive: '#5f0a0a' })
   );
   actionButton.name = 'captureActionButton';
-  actionButton.position.set(0.074, 0.03, -0.022);
+  actionButton.position.set(0.068, 0.016, -0.052);
   root.add(actionButton);
 
   const actionButtonHit = new THREE.Mesh(
@@ -1053,7 +1046,7 @@ async function createCaptureWeaponRackFx() {
     new THREE.MeshBasicMaterial({ transparent: true, opacity: 0 })
   );
   weaponRackHit.name = 'captureWeaponRackHit';
-  weaponRackHit.position.set(0.04, 0.032, -0.018);
+  weaponRackHit.position.set(0.054, 0.018, -0.028);
   root.add(weaponRackHit);
 
   return {
@@ -6936,12 +6929,12 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       const basePosition = isLargeFirearm
         ? seatPos
             .clone()
-            .addScaledVector(rightSide, CAPTURE_PARK_SIDE_OFFSET * 0.95)
-            .addScaledVector(inward, 0.02)
+            .addScaledVector(rightSide, CAPTURE_PARK_SIDE_OFFSET * 0.84)
+            .addScaledVector(inward, -0.012)
         : oppositeToPlayer
             .clone()
-            .addScaledVector(rightSide, CAPTURE_PARK_SIDE_OFFSET * 0.35)
-            .addScaledVector(inward, 0.01);
+            .addScaledVector(rightSide, CAPTURE_PARK_SIDE_OFFSET * 0.62)
+            .addScaledVector(inward, -0.012);
       entry.weaponRack.position.copy(basePosition);
       alignObjectBottomToY(entry.weaponRack, arena.tableInfo?.surfaceY);
       entry.weaponRack.position.y += CAPTURE_PARKED_LIFT_OFFSET_Y;
@@ -6953,22 +6946,23 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         CAPTURE_ANIMATION_OPTIONS[optionIndex]?.id ?? CAPTURE_ANIMATION_OPTIONS[0]?.id ?? 'missileJavelin';
       if (entry?.jet) entry.jet.visible = selectedCaptureAnimationId === 'fighterJetAttack';
       if (entry?.helicopter) entry.helicopter.visible = selectedCaptureAnimationId === 'helicopterAttack';
-      if (entry?.drone) entry.drone.visible = false;
-      if (entry?.droneTruck) entry.droneTruck.visible = selectedCaptureAnimationId === 'droneAttack';
+      if (entry?.drone) entry.drone.visible = selectedCaptureAnimationId === 'droneAttack';
+      if (entry?.droneTruck) entry.droneTruck.visible = false;
       if (entry?.missile) entry.missile.visible = selectedCaptureAnimationId === 'missileJavelin';
       if (entry?.weaponRack) {
         const showFirearm = FIREARM_CAPTURE_ANIMATION_IDS.has(selectedCaptureAnimationId);
         const showActionButton =
           selectedCaptureAnimationId === 'fighterJetAttack' ||
           selectedCaptureAnimationId === 'helicopterAttack' ||
-          selectedCaptureAnimationId === 'droneAttack';
+          selectedCaptureAnimationId === 'droneAttack' ||
+          selectedCaptureAnimationId === 'missileJavelin';
         entry.weaponRack.visible = showFirearm || showActionButton;
         if (entry.actionButton?.isObject3D) {
           entry.actionButton.visible = showActionButton;
           if (showActionButton) {
-            entry.actionButton.position.set(0.082, 0.033, -0.024);
+            entry.actionButton.position.set(0.068, 0.016, -0.052);
           } else {
-            entry.actionButton.position.set(0.074, 0.02, -0.022);
+            entry.actionButton.position.set(0.068, 0.016, -0.052);
           }
         }
         if (entry.actionButtonHit?.isObject3D) {
@@ -8990,7 +8984,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         humanEntry?.weaponRackHit,
         humanEntry?.jet,
         humanEntry?.helicopter,
-        humanEntry?.droneTruck,
+        humanEntry?.drone,
         humanEntry?.missile
       ].filter(Boolean);
       if (!interactiveTargets.length) return false;
@@ -9907,7 +9901,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             : isHelicopterAttack
             ? parkedEntry?.helicopterPark?.clone?.()
             : isDroneAttack
-            ? parkedEntry?.droneTruckPark?.clone?.() ?? parkedEntry?.dronePark?.clone?.()
+            ? parkedEntry?.dronePark?.clone?.()
             : isMissileTruckAttack
             ? parkedEntry?.missilePark?.clone?.()
             : null;
@@ -9917,23 +9911,14 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             : resolvedCaptureAnimationId === 'helicopterAttack'
             ? parkedEntry?.helicopter
             : resolvedCaptureAnimationId === 'droneAttack'
-            ? parkedEntry?.droneTruck ?? parkedEntry?.drone
+            ? parkedEntry?.drone
             : resolvedCaptureAnimationId === 'missileJavelin'
             ? parkedEntry?.missile
             : null;
         parkedReloadMissile = parkedEntry?.reloadMissile ?? null;
         parkedReloadMissileLocalPosition = parkedEntry?.reloadMissileLocalPosition ?? null;
         parkedReloadMissileLocalRotation = parkedEntry?.reloadMissileLocalRotation ?? null;
-        if (isDroneAttack) {
-          const parkedPayloads = Array.isArray(parkedEntry?.droneTruckPayloads) ? parkedEntry.droneTruckPayloads : [];
-          if (parkedPayloads.length > 0) {
-            const nextPayloadIndex = Number.isFinite(parkedEntry?.nextDronePayloadIndex)
-              ? parkedEntry.nextDronePayloadIndex
-              : 0;
-            parkedDronePayload = parkedPayloads[((nextPayloadIndex % parkedPayloads.length) + parkedPayloads.length) % parkedPayloads.length];
-            parkedEntry.nextDronePayloadIndex = (nextPayloadIndex + 1) % parkedPayloads.length;
-          }
-        }
+        if (isDroneAttack) parkedDronePayload = null;
         stopCaptureVehicleSounds();
         if (isHelicopterAttack) {
           stopFighterJetSound();
@@ -11722,10 +11707,10 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       <div className="absolute inset-0 pointer-events-none">
         {weaponSwapPopup && (
           <div
-            className="pointer-events-auto absolute z-30 w-[min(96vw,25rem)] max-h-[68vh] overflow-hidden rounded-2xl border border-white/20 bg-black/88 p-2.5 shadow-2xl backdrop-blur"
+            className="pointer-events-auto absolute z-30 w-[min(92vw,19rem)] max-h-[54vh] overflow-hidden rounded-2xl border border-white/20 bg-black/88 p-2 shadow-2xl backdrop-blur"
             style={{
-              left: clamp(weaponSwapPopup.x - 140, 8, (typeof window !== 'undefined' ? window.innerWidth : 360) - 336),
-              top: clamp(weaponSwapPopup.y - 8, 88, (typeof window !== 'undefined' ? window.innerHeight : 640) - 420)
+              left: clamp(weaponSwapPopup.x - 112, 8, (typeof window !== 'undefined' ? window.innerWidth : 360) - 292),
+              top: clamp(weaponSwapPopup.y - 10, 88, (typeof window !== 'undefined' ? window.innerHeight : 640) - 360)
             }}
           >
             <div className="mb-2 flex items-center justify-between gap-2 px-1">
@@ -11738,7 +11723,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
                 Close
               </button>
             </div>
-            <div className="grid max-h-[54vh] grid-cols-3 gap-1.5 overflow-y-auto pr-1 touch-pan-y overscroll-contain">
+            <div className="grid max-h-[42vh] grid-cols-3 gap-1 overflow-y-auto pr-1 touch-pan-y overscroll-contain">
               {weaponSwapPopup.options.map((option) => {
                 const optionIndex = CAPTURE_ANIMATION_OPTIONS.findIndex((entry) => entry.id === option.id);
                 const selected = appearance.captureAnimation === optionIndex;
@@ -11747,14 +11732,14 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
                   <button
                     key={option.id}
                     type="button"
-                    className={`overflow-hidden rounded-xl border p-1 text-[8px] font-semibold ${
+                    className={`overflow-hidden rounded-xl border p-1 text-[7px] font-semibold ${
                       selected ? 'border-sky-300 bg-sky-400/25 text-white' : 'border-white/20 bg-white/5 text-white/80'
                     }`}
                     onClick={() => {
                       if (optionIndex >= 0) setAppearance((prev) => ({ ...prev, captureAnimation: optionIndex }));
                     }}
                   >
-                    <div className="mx-auto mb-1 flex h-6 w-6 items-center justify-center rounded border border-white/20 bg-slate-900/70 text-[13px] leading-none text-slate-100">
+                    <div className="mx-auto mb-1 flex h-5 w-5 items-center justify-center rounded border border-white/20 bg-slate-900/70 text-[10px] leading-none text-slate-100">
                       {shape}
                     </div>
                     <div className="px-0.5 pb-0.5 leading-tight">{option.label}</div>
@@ -11764,16 +11749,16 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             </div>
           </div>
         )}
-        <div className="absolute top-[5.35rem] left-2 z-20 flex flex-col items-start gap-3">
+        <div className="absolute bottom-[8.7rem] left-3 z-20 flex flex-col items-start gap-2">
           <div className="pointer-events-auto">
             <button
               type="button"
               onClick={(event) => {
                 const rect = event.currentTarget.getBoundingClientRect();
-                openWeaponSwapPopup(rect.right - 6, rect.bottom + 8);
+                openWeaponSwapPopup(rect.right + 2, rect.top - 8);
               }}
               aria-label="Open quick weapon swap"
-              className="flex h-8 w-8 items-center justify-center rounded-full border border-white/20 bg-black/60 text-sm text-white shadow-[0_6px_18px_rgba(2,6,23,0.45)] transition hover:border-white/35 hover:bg-black/75"
+              className="flex h-7 w-7 items-center justify-center rounded-full border border-white/20 bg-black/60 text-[11px] text-white shadow-[0_6px_18px_rgba(2,6,23,0.45)] transition hover:border-white/35 hover:bg-black/75"
             >
               ⇄
             </button>


### PR DESCRIPTION
### Motivation
- Improve weapon placement and interaction so table weapons lie flat near the local human actor's right hand and are easier to grab and read. 
- Remove the unnecessary black rounded base under weapons and reposition the red action/strike button to align visually with the player's right hand and show only for vehicle/air strikes. 
- Make drone strikes use the standalone drone model (launch from drone) instead of the truck payload and align the quick-swap control horizontally with the action button in the portrait UI. 

### Description
- Tuned firearm display and rack pose constants in `webapp/src/pages/Games/LudoBattleRoyal.jsx` (`FIREARM_RACK_DISPLAY_TUNING`, rack position adjustments) so weapons sit flatter, shifted to the right side of the seated player and point inward. 
- Removed the extra black cylinder base from the weapon rack FX and moved/retuned the red action button (`createCaptureWeaponRackFx`) by changing `weaponHolder`, `actionButton`, `actionButtonHit`, and `weaponRackHit` positions. 
- Updated parked-capture visibility and launch selection logic so selecting a drone shows/uses the standalone `drone` object (not `droneTruck`) and drone payload launch code now references the drone park/object directly. 
- Adjusted rack placement offsets used by `refreshWeaponRackPose` to move the rack closer to the player's right-hand side and update inward offsets. 
- Moved quick-swap trigger to the lower-left UI band, reduced the quick-swap popup/button size and list cell sizes, and replaced simple glyphs with more detailed weapon glyphs in `QUICK_SWAP_WEAPON_SHAPE_BY_ID`. 
- Updated raycast/interaction targets for quick-swap (use `humanEntry?.drone` instead of `droneTruck`) so input taps hit the standalone drone and action button area correctly. 

### Testing
- Built the web app with `npm --prefix webapp run build` and the production build completed successfully. 
- The build produced pre-existing bundler warnings about chunking and a duplicate package key in `package.json`, but no build errors occurred.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f03414a2fc8329af9f51da29e53828)