### PR TITLE
Adjust Ludo Battle Royal weapon/table controls placement

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -226,13 +226,13 @@ const FIREARM_RACK_SIZE_MULTIPLIER_BY_ID = Object.freeze({
 const FIREARM_RACK_DISPLAY_TUNING = Object.freeze({
   default: Object.freeze({
     targetSizeMultiplier: 1.06,
-    position: [0, 0, -0.004],
-    rotation: [-Math.PI * 0.5, Math.PI * 0.5, 0]
+    position: [0.004, 0, -0.002],
+    rotation: [-Math.PI * 0.5, 0, 0]
   }),
   large: Object.freeze({
     targetSizeMultiplier: 1.9,
-    position: [0.08, 0, -0.014],
-    rotation: [-Math.PI * 0.5, Math.PI * 0.04, 0]
+    position: [0.034, 0, -0.01],
+    rotation: [-Math.PI * 0.5, 0, 0]
   })
 });
 const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
@@ -696,34 +696,34 @@ const HELICOPTER_TOP_ROTOR_SPIN_SPEED = 26;
 const HELICOPTER_TAIL_ROTOR_SPIN_SPEED = 30;
 const HELICOPTER_AUX_ROTOR_SPIN_SPEED = 24;
 const QUICK_SWAP_WEAPON_SHAPE_BY_ID = Object.freeze({
-  missileJavelin: '▸',
-  droneAttack: '◈',
-  fighterJetAttack: '◁',
-  helicopterAttack: '◎',
-  fpsGunAttack: '▬',
-  glockSidearmAttack: '▮',
-  assaultRifleAttack: '▰',
-  uziSprayAttack: '▯',
-  ak47VolleyAttack: '▰',
-  krsvBurstAttack: '▰',
-  smithSidearmAttack: '▮',
-  mosinMarksmanAttack: '▤',
-  sigsauerTacticalAttack: '▮',
-  grenadeBlastAttack: '⬢',
-  shotgunBlastAttack: '▭',
-  sniperShotAttack: '▤',
-  smgBurstAttack: '▯',
-  compactCarbineAttack: '▰',
-  marksmanDmrAttack: '▤',
-  polyShotgun01Attack: '▬',
-  polyAssaultRifle01Attack: '▰',
-  polyPistol01Attack: '▮',
-  polyRevolver01Attack: '◖',
-  polySawedOff01Attack: '▭',
-  polyRevolver02Attack: '◗',
-  polyShotgun02Attack: '▤',
-  polyShotgun03Attack: '▥',
-  polySmg01Attack: '▯'
+  missileJavelin: '🚀',
+  droneAttack: '🛸',
+  fighterJetAttack: '✈️',
+  helicopterAttack: '🚁',
+  fpsGunAttack: '🔫',
+  glockSidearmAttack: '🔫',
+  assaultRifleAttack: '🪖',
+  uziSprayAttack: '🔫',
+  ak47VolleyAttack: '🪖',
+  krsvBurstAttack: '🪖',
+  smithSidearmAttack: '🔫',
+  mosinMarksmanAttack: '🎯',
+  sigsauerTacticalAttack: '🔫',
+  grenadeBlastAttack: '💣',
+  shotgunBlastAttack: '💥',
+  sniperShotAttack: '🎯',
+  smgBurstAttack: '🔫',
+  compactCarbineAttack: '🪖',
+  marksmanDmrAttack: '🎯',
+  polyShotgun01Attack: '💥',
+  polyAssaultRifle01Attack: '🪖',
+  polyPistol01Attack: '🔫',
+  polyRevolver01Attack: '🔫',
+  polySawedOff01Attack: '💥',
+  polyRevolver02Attack: '🔫',
+  polyShotgun02Attack: '💥',
+  polyShotgun03Attack: '💥',
+  polySmg01Attack: '🔫'
 });
 
 function orientCaptureVehicleTowardBoardCenter(root, target) {
@@ -1021,23 +1021,16 @@ async function attachFirearmToRightHand(attackerEntry, captureAnimationId) {
 async function createCaptureWeaponRackFx() {
   const root = new THREE.Group();
   const weaponHolder = new THREE.Group();
-  weaponHolder.position.set(0.04, 0.032, -0.018);
+  weaponHolder.position.set(0.098, 0.012, -0.034);
   weaponHolder.rotation.set(0, 0, 0);
   root.add(weaponHolder);
-
-  const buttonBase = new THREE.Mesh(
-    new THREE.CylinderGeometry(0.03, 0.035, 0.02, 24),
-    createCaptureVehicleMaterial('truck', { color: '#0f172a', roughness: 0.4, metalness: 0.34 })
-  );
-  buttonBase.position.set(0.074, 0.016, -0.022);
-  root.add(buttonBase);
 
   const actionButton = new THREE.Mesh(
     new THREE.CylinderGeometry(0.024, 0.026, 0.015, 28),
     createCaptureVehicleMaterial('truck', { color: '#ef4444', roughness: 0.22, metalness: 0.15, emissive: '#5f0a0a' })
   );
   actionButton.name = 'captureActionButton';
-  actionButton.position.set(0.074, 0.03, -0.022);
+  actionButton.position.set(0.11, 0.011, -0.036);
   root.add(actionButton);
 
   const actionButtonHit = new THREE.Mesh(
@@ -1053,7 +1046,7 @@ async function createCaptureWeaponRackFx() {
     new THREE.MeshBasicMaterial({ transparent: true, opacity: 0 })
   );
   weaponRackHit.name = 'captureWeaponRackHit';
-  weaponRackHit.position.set(0.04, 0.032, -0.018);
+  weaponRackHit.position.set(0.098, 0.012, -0.034);
   root.add(weaponRackHit);
 
   return {
@@ -6931,17 +6924,10 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       if (inward.lengthSq() < 1e-6) return;
       inward.normalize();
       const rightSide = new THREE.Vector3().crossVectors(inward, MISSILE_WORLD_UP).normalize();
-      const oppositeToPlayer = arena.boardLookTarget.clone().multiplyScalar(2).sub(kingPos).setY(0);
       const isLargeFirearm = LARGE_RACK_FIREARM_IDS.has(captureAnimationId);
-      const basePosition = isLargeFirearm
-        ? seatPos
-            .clone()
-            .addScaledVector(rightSide, CAPTURE_PARK_SIDE_OFFSET * 0.95)
-            .addScaledVector(inward, 0.02)
-        : oppositeToPlayer
-            .clone()
-            .addScaledVector(rightSide, CAPTURE_PARK_SIDE_OFFSET * 0.35)
-            .addScaledVector(inward, 0.01);
+      const sideOffset = isLargeFirearm ? CAPTURE_PARK_SIDE_OFFSET * 0.72 : CAPTURE_PARK_SIDE_OFFSET * 0.62;
+      const inwardOffset = isLargeFirearm ? 0.032 : 0.024;
+      const basePosition = seatPos.clone().addScaledVector(rightSide, sideOffset).addScaledVector(inward, inwardOffset);
       entry.weaponRack.position.copy(basePosition);
       alignObjectBottomToY(entry.weaponRack, arena.tableInfo?.surfaceY);
       entry.weaponRack.position.y += CAPTURE_PARKED_LIFT_OFFSET_Y;
@@ -6953,8 +6939,8 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         CAPTURE_ANIMATION_OPTIONS[optionIndex]?.id ?? CAPTURE_ANIMATION_OPTIONS[0]?.id ?? 'missileJavelin';
       if (entry?.jet) entry.jet.visible = selectedCaptureAnimationId === 'fighterJetAttack';
       if (entry?.helicopter) entry.helicopter.visible = selectedCaptureAnimationId === 'helicopterAttack';
-      if (entry?.drone) entry.drone.visible = false;
-      if (entry?.droneTruck) entry.droneTruck.visible = selectedCaptureAnimationId === 'droneAttack';
+      if (entry?.drone) entry.drone.visible = selectedCaptureAnimationId === 'droneAttack';
+      if (entry?.droneTruck) entry.droneTruck.visible = false;
       if (entry?.missile) entry.missile.visible = selectedCaptureAnimationId === 'missileJavelin';
       if (entry?.weaponRack) {
         const showFirearm = FIREARM_CAPTURE_ANIMATION_IDS.has(selectedCaptureAnimationId);
@@ -6966,9 +6952,9 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         if (entry.actionButton?.isObject3D) {
           entry.actionButton.visible = showActionButton;
           if (showActionButton) {
-            entry.actionButton.position.set(0.082, 0.033, -0.024);
+            entry.actionButton.position.set(0.11, 0.011, -0.036);
           } else {
-            entry.actionButton.position.set(0.074, 0.02, -0.022);
+            entry.actionButton.position.set(0.11, 0.011, -0.036);
           }
         }
         if (entry.actionButtonHit?.isObject3D) {
@@ -9907,7 +9893,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             : isHelicopterAttack
             ? parkedEntry?.helicopterPark?.clone?.()
             : isDroneAttack
-            ? parkedEntry?.droneTruckPark?.clone?.() ?? parkedEntry?.dronePark?.clone?.()
+            ? parkedEntry?.dronePark?.clone?.() ?? parkedEntry?.droneTruckPark?.clone?.()
             : isMissileTruckAttack
             ? parkedEntry?.missilePark?.clone?.()
             : null;
@@ -9917,23 +9903,14 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             : resolvedCaptureAnimationId === 'helicopterAttack'
             ? parkedEntry?.helicopter
             : resolvedCaptureAnimationId === 'droneAttack'
-            ? parkedEntry?.droneTruck ?? parkedEntry?.drone
+            ? parkedEntry?.drone ?? parkedEntry?.droneTruck
             : resolvedCaptureAnimationId === 'missileJavelin'
             ? parkedEntry?.missile
             : null;
         parkedReloadMissile = parkedEntry?.reloadMissile ?? null;
         parkedReloadMissileLocalPosition = parkedEntry?.reloadMissileLocalPosition ?? null;
         parkedReloadMissileLocalRotation = parkedEntry?.reloadMissileLocalRotation ?? null;
-        if (isDroneAttack) {
-          const parkedPayloads = Array.isArray(parkedEntry?.droneTruckPayloads) ? parkedEntry.droneTruckPayloads : [];
-          if (parkedPayloads.length > 0) {
-            const nextPayloadIndex = Number.isFinite(parkedEntry?.nextDronePayloadIndex)
-              ? parkedEntry.nextDronePayloadIndex
-              : 0;
-            parkedDronePayload = parkedPayloads[((nextPayloadIndex % parkedPayloads.length) + parkedPayloads.length) % parkedPayloads.length];
-            parkedEntry.nextDronePayloadIndex = (nextPayloadIndex + 1) % parkedPayloads.length;
-          }
-        }
+        if (isDroneAttack) parkedDronePayload = null;
         stopCaptureVehicleSounds();
         if (isHelicopterAttack) {
           stopFighterJetSound();
@@ -11722,10 +11699,10 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       <div className="absolute inset-0 pointer-events-none">
         {weaponSwapPopup && (
           <div
-            className="pointer-events-auto absolute z-30 w-[min(96vw,25rem)] max-h-[68vh] overflow-hidden rounded-2xl border border-white/20 bg-black/88 p-2.5 shadow-2xl backdrop-blur"
+            className="pointer-events-auto absolute z-30 w-[min(80vw,17rem)] max-h-[48vh] overflow-hidden rounded-2xl border border-white/20 bg-black/88 p-2 shadow-2xl backdrop-blur"
             style={{
-              left: clamp(weaponSwapPopup.x - 140, 8, (typeof window !== 'undefined' ? window.innerWidth : 360) - 336),
-              top: clamp(weaponSwapPopup.y - 8, 88, (typeof window !== 'undefined' ? window.innerHeight : 640) - 420)
+              left: clamp(weaponSwapPopup.x - 100, 8, (typeof window !== 'undefined' ? window.innerWidth : 360) - 272),
+              top: clamp(weaponSwapPopup.y - 12, 88, (typeof window !== 'undefined' ? window.innerHeight : 640) - 320)
             }}
           >
             <div className="mb-2 flex items-center justify-between gap-2 px-1">
@@ -11738,7 +11715,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
                 Close
               </button>
             </div>
-            <div className="grid max-h-[54vh] grid-cols-3 gap-1.5 overflow-y-auto pr-1 touch-pan-y overscroll-contain">
+            <div className="grid max-h-[40vh] grid-cols-3 gap-1 overflow-y-auto pr-1 touch-pan-y overscroll-contain">
               {weaponSwapPopup.options.map((option) => {
                 const optionIndex = CAPTURE_ANIMATION_OPTIONS.findIndex((entry) => entry.id === option.id);
                 const selected = appearance.captureAnimation === optionIndex;
@@ -11747,14 +11724,14 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
                   <button
                     key={option.id}
                     type="button"
-                    className={`overflow-hidden rounded-xl border p-1 text-[8px] font-semibold ${
+                    className={`overflow-hidden rounded-xl border p-1 text-[7px] font-semibold ${
                       selected ? 'border-sky-300 bg-sky-400/25 text-white' : 'border-white/20 bg-white/5 text-white/80'
                     }`}
                     onClick={() => {
                       if (optionIndex >= 0) setAppearance((prev) => ({ ...prev, captureAnimation: optionIndex }));
                     }}
                   >
-                    <div className="mx-auto mb-1 flex h-6 w-6 items-center justify-center rounded border border-white/20 bg-slate-900/70 text-[13px] leading-none text-slate-100">
+                    <div className="mx-auto mb-1 flex h-5 w-5 items-center justify-center rounded border border-white/20 bg-slate-900/70 text-[11px] leading-none text-slate-100">
                       {shape}
                     </div>
                     <div className="px-0.5 pb-0.5 leading-tight">{option.label}</div>
@@ -11765,15 +11742,15 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           </div>
         )}
         <div className="absolute top-[5.35rem] left-2 z-20 flex flex-col items-start gap-3">
-          <div className="pointer-events-auto">
+          <div className="pointer-events-auto fixed bottom-[7.45rem] left-2 z-20">
             <button
               type="button"
               onClick={(event) => {
                 const rect = event.currentTarget.getBoundingClientRect();
-                openWeaponSwapPopup(rect.right - 6, rect.bottom + 8);
+                openWeaponSwapPopup(rect.right - 8, rect.top - 12);
               }}
               aria-label="Open quick weapon swap"
-              className="flex h-8 w-8 items-center justify-center rounded-full border border-white/20 bg-black/60 text-sm text-white shadow-[0_6px_18px_rgba(2,6,23,0.45)] transition hover:border-white/35 hover:bg-black/75"
+              className="flex h-7 w-7 items-center justify-center rounded-full border border-white/20 bg-black/60 text-xs text-white shadow-[0_6px_18px_rgba(2,6,23,0.45)] transition hover:border-white/35 hover:bg-black/75"
             >
               ⇄
             </button>


### PR DESCRIPTION
### Motivation
- Improve Ludo Battle Royal UX by placing rack weapons closer to the seated human’s right hand so they can be grabbed naturally, remove distracting rack base under weapons, and align the red action button and quick-swap control with the player’s hand band in portrait view.
- Ensure vehicle/aircraft behaviors match selection intent (show standalone drone when drone is selected and launch it directly), and make the quick-swap menu smaller and iconography clearer for faster selection.

### Description
- Tuned firearm rack display pose by updating `FIREARM_RACK_DISPLAY_TUNING` to use flatter rotation and adjusted `position` offsets so weapons lie flatter and face the board center (changes in `webapp/src/pages/Games/LudoBattleRoyal.jsx`).
- Repositioned the rack content and hit targets by moving `weaponHolder`, `weaponRackHit` and the red `actionButton` coordinates to sit to the right/near the seated human right-hand area and removed the black rounded `buttonBase` under the red action button.
- Reworked parked-vehicle pose logic to compute rack anchors relative to the seat (`rightSide` + inward offsets) instead of the previous opposite anchor, and adjusted offsets for large vs default firearms so placement reads correctly across sizes.
- Changed capture-vehicle visibility/launch source for drones so selecting `droneAttack` shows the standalone `drone` (hides `droneTruck`) and uses the drone parking anchor for launch/restore; updated parkedLaunch / parkedVehicleToRestore logic accordingly and cleared previous parked payload handling.
- Reduced the quick-swap popup footprint and item sizing, moved the quick-swap trigger button into the lower-left band (aligned with action-button row), and made the trigger smaller; updated popup layout values (width, max height, grid sizing, item sizes and font sizes) to better fit portrait screens.
- Replaced the simple glyphs with more descriptive icons in `QUICK_SWAP_WEAPON_SHAPE_BY_ID` to make weapon shapes clearer in the compact quick-swap menu.

### Testing
- Ran `npx eslint webapp/src/pages/Games/LudoBattleRoyal.jsx` which completed and reported the file is ignored by repo ignore rules (no lint errors reported); status: warning about ignore pattern only.
- Performed local code inspection of changed layout/visibility logic and ensured the updated coordinate values, visibility branches and quick-swap UI sizing are syntactically valid (no runtime test suite was executed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f03414a2fc8329af9f51da29e53828)