### PR TITLE
Adjust Ludo battle weapon/button placement and quick-swap UI

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -109,7 +109,7 @@ const CAPTURE_PARK_SIDE_SIGN_BY_TYPE = Object.freeze({
   helicopter: -1,
   drone: -1,
   missile: 1,
-  firearmRack: -1
+  firearmRack: 1
 });
 const CAPTURE_PARK_OUTWARD_OFFSET = 0.03;
 const CAPTURE_PARK_FORWARD_OFFSET_BY_TYPE = {
@@ -225,14 +225,14 @@ const FIREARM_RACK_SIZE_MULTIPLIER_BY_ID = Object.freeze({
 
 const FIREARM_RACK_DISPLAY_TUNING = Object.freeze({
   default: Object.freeze({
-    targetSizeMultiplier: 1.06,
-    position: [0, 0, -0.004],
-    rotation: [-Math.PI * 0.5, Math.PI * 0.5, 0]
+    targetSizeMultiplier: 1.14,
+    position: [0.018, 0.001, -0.01],
+    rotation: [-Math.PI * 0.5, Math.PI * 0.08, 0]
   }),
   large: Object.freeze({
-    targetSizeMultiplier: 1.9,
-    position: [0.08, 0, -0.014],
-    rotation: [-Math.PI * 0.5, Math.PI * 0.04, 0]
+    targetSizeMultiplier: 1.74,
+    position: [0.066, 0.001, -0.016],
+    rotation: [-Math.PI * 0.5, Math.PI * 0.08, 0]
   })
 });
 const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
@@ -696,34 +696,34 @@ const HELICOPTER_TOP_ROTOR_SPIN_SPEED = 26;
 const HELICOPTER_TAIL_ROTOR_SPIN_SPEED = 30;
 const HELICOPTER_AUX_ROTOR_SPIN_SPEED = 24;
 const QUICK_SWAP_WEAPON_SHAPE_BY_ID = Object.freeze({
-  missileJavelin: '▸',
-  droneAttack: '◈',
-  fighterJetAttack: '◁',
-  helicopterAttack: '◎',
-  fpsGunAttack: '▬',
-  glockSidearmAttack: '▮',
-  assaultRifleAttack: '▰',
-  uziSprayAttack: '▯',
-  ak47VolleyAttack: '▰',
-  krsvBurstAttack: '▰',
-  smithSidearmAttack: '▮',
-  mosinMarksmanAttack: '▤',
-  sigsauerTacticalAttack: '▮',
-  grenadeBlastAttack: '⬢',
-  shotgunBlastAttack: '▭',
-  sniperShotAttack: '▤',
-  smgBurstAttack: '▯',
-  compactCarbineAttack: '▰',
-  marksmanDmrAttack: '▤',
-  polyShotgun01Attack: '▬',
-  polyAssaultRifle01Attack: '▰',
-  polyPistol01Attack: '▮',
-  polyRevolver01Attack: '◖',
-  polySawedOff01Attack: '▭',
-  polyRevolver02Attack: '◗',
-  polyShotgun02Attack: '▤',
-  polyShotgun03Attack: '▥',
-  polySmg01Attack: '▯'
+  missileJavelin: '🚀',
+  droneAttack: '🛸',
+  fighterJetAttack: '✈️',
+  helicopterAttack: '🚁',
+  fpsGunAttack: '🔫',
+  glockSidearmAttack: '🔫',
+  assaultRifleAttack: '🪖',
+  uziSprayAttack: '🔫',
+  ak47VolleyAttack: '🪖',
+  krsvBurstAttack: '🪖',
+  smithSidearmAttack: '🔫',
+  mosinMarksmanAttack: '🎯',
+  sigsauerTacticalAttack: '🔫',
+  grenadeBlastAttack: '💣',
+  shotgunBlastAttack: '🧨',
+  sniperShotAttack: '🎯',
+  smgBurstAttack: '🔫',
+  compactCarbineAttack: '🪖',
+  marksmanDmrAttack: '🎯',
+  polyShotgun01Attack: '🧨',
+  polyAssaultRifle01Attack: '🪖',
+  polyPistol01Attack: '🔫',
+  polyRevolver01Attack: '🔫',
+  polySawedOff01Attack: '🧨',
+  polyRevolver02Attack: '🔫',
+  polyShotgun02Attack: '🧨',
+  polyShotgun03Attack: '🧨',
+  polySmg01Attack: '🔫'
 });
 
 function orientCaptureVehicleTowardBoardCenter(root, target) {
@@ -1021,23 +1021,16 @@ async function attachFirearmToRightHand(attackerEntry, captureAnimationId) {
 async function createCaptureWeaponRackFx() {
   const root = new THREE.Group();
   const weaponHolder = new THREE.Group();
-  weaponHolder.position.set(0.04, 0.032, -0.018);
+  weaponHolder.position.set(0.064, 0.021, -0.03);
   weaponHolder.rotation.set(0, 0, 0);
   root.add(weaponHolder);
-
-  const buttonBase = new THREE.Mesh(
-    new THREE.CylinderGeometry(0.03, 0.035, 0.02, 24),
-    createCaptureVehicleMaterial('truck', { color: '#0f172a', roughness: 0.4, metalness: 0.34 })
-  );
-  buttonBase.position.set(0.074, 0.016, -0.022);
-  root.add(buttonBase);
 
   const actionButton = new THREE.Mesh(
     new THREE.CylinderGeometry(0.024, 0.026, 0.015, 28),
     createCaptureVehicleMaterial('truck', { color: '#ef4444', roughness: 0.22, metalness: 0.15, emissive: '#5f0a0a' })
   );
   actionButton.name = 'captureActionButton';
-  actionButton.position.set(0.074, 0.03, -0.022);
+  actionButton.position.set(0.064, 0.012, -0.046);
   root.add(actionButton);
 
   const actionButtonHit = new THREE.Mesh(
@@ -1053,7 +1046,7 @@ async function createCaptureWeaponRackFx() {
     new THREE.MeshBasicMaterial({ transparent: true, opacity: 0 })
   );
   weaponRackHit.name = 'captureWeaponRackHit';
-  weaponRackHit.position.set(0.04, 0.032, -0.018);
+  weaponRackHit.position.set(0.064, 0.02, -0.03);
   root.add(weaponRackHit);
 
   return {
@@ -6936,12 +6929,12 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       const basePosition = isLargeFirearm
         ? seatPos
             .clone()
-            .addScaledVector(rightSide, CAPTURE_PARK_SIDE_OFFSET * 0.95)
-            .addScaledVector(inward, 0.02)
+            .addScaledVector(rightSide, CAPTURE_PARK_SIDE_OFFSET * 1.08)
+            .addScaledVector(inward, 0.012)
         : oppositeToPlayer
             .clone()
-            .addScaledVector(rightSide, CAPTURE_PARK_SIDE_OFFSET * 0.35)
-            .addScaledVector(inward, 0.01);
+            .addScaledVector(rightSide, CAPTURE_PARK_SIDE_OFFSET * 0.94)
+            .addScaledVector(inward, 0.004);
       entry.weaponRack.position.copy(basePosition);
       alignObjectBottomToY(entry.weaponRack, arena.tableInfo?.surfaceY);
       entry.weaponRack.position.y += CAPTURE_PARKED_LIFT_OFFSET_Y;
@@ -6953,8 +6946,8 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         CAPTURE_ANIMATION_OPTIONS[optionIndex]?.id ?? CAPTURE_ANIMATION_OPTIONS[0]?.id ?? 'missileJavelin';
       if (entry?.jet) entry.jet.visible = selectedCaptureAnimationId === 'fighterJetAttack';
       if (entry?.helicopter) entry.helicopter.visible = selectedCaptureAnimationId === 'helicopterAttack';
-      if (entry?.drone) entry.drone.visible = false;
-      if (entry?.droneTruck) entry.droneTruck.visible = selectedCaptureAnimationId === 'droneAttack';
+      if (entry?.drone) entry.drone.visible = selectedCaptureAnimationId === 'droneAttack';
+      if (entry?.droneTruck) entry.droneTruck.visible = false;
       if (entry?.missile) entry.missile.visible = selectedCaptureAnimationId === 'missileJavelin';
       if (entry?.weaponRack) {
         const showFirearm = FIREARM_CAPTURE_ANIMATION_IDS.has(selectedCaptureAnimationId);
@@ -6966,9 +6959,9 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         if (entry.actionButton?.isObject3D) {
           entry.actionButton.visible = showActionButton;
           if (showActionButton) {
-            entry.actionButton.position.set(0.082, 0.033, -0.024);
+            entry.actionButton.position.set(0.064, 0.012, -0.046);
           } else {
-            entry.actionButton.position.set(0.074, 0.02, -0.022);
+            entry.actionButton.position.set(0.064, 0.012, -0.046);
           }
         }
         if (entry.actionButtonHit?.isObject3D) {
@@ -9907,7 +9900,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             : isHelicopterAttack
             ? parkedEntry?.helicopterPark?.clone?.()
             : isDroneAttack
-            ? parkedEntry?.droneTruckPark?.clone?.() ?? parkedEntry?.dronePark?.clone?.()
+            ? parkedEntry?.dronePark?.clone?.()
             : isMissileTruckAttack
             ? parkedEntry?.missilePark?.clone?.()
             : null;
@@ -9917,7 +9910,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             : resolvedCaptureAnimationId === 'helicopterAttack'
             ? parkedEntry?.helicopter
             : resolvedCaptureAnimationId === 'droneAttack'
-            ? parkedEntry?.droneTruck ?? parkedEntry?.drone
+            ? parkedEntry?.drone
             : resolvedCaptureAnimationId === 'missileJavelin'
             ? parkedEntry?.missile
             : null;
@@ -11722,10 +11715,10 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       <div className="absolute inset-0 pointer-events-none">
         {weaponSwapPopup && (
           <div
-            className="pointer-events-auto absolute z-30 w-[min(96vw,25rem)] max-h-[68vh] overflow-hidden rounded-2xl border border-white/20 bg-black/88 p-2.5 shadow-2xl backdrop-blur"
+            className="pointer-events-auto absolute z-30 w-[min(90vw,18rem)] max-h-[56vh] overflow-hidden rounded-2xl border border-white/20 bg-black/88 p-2 shadow-2xl backdrop-blur"
             style={{
-              left: clamp(weaponSwapPopup.x - 140, 8, (typeof window !== 'undefined' ? window.innerWidth : 360) - 336),
-              top: clamp(weaponSwapPopup.y - 8, 88, (typeof window !== 'undefined' ? window.innerHeight : 640) - 420)
+              left: clamp(weaponSwapPopup.x - 120, 8, (typeof window !== 'undefined' ? window.innerWidth : 360) - 296),
+              top: clamp(weaponSwapPopup.y - 8, 88, (typeof window !== 'undefined' ? window.innerHeight : 640) - 360)
             }}
           >
             <div className="mb-2 flex items-center justify-between gap-2 px-1">
@@ -11738,7 +11731,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
                 Close
               </button>
             </div>
-            <div className="grid max-h-[54vh] grid-cols-3 gap-1.5 overflow-y-auto pr-1 touch-pan-y overscroll-contain">
+            <div className="grid max-h-[46vh] grid-cols-3 gap-1 overflow-y-auto pr-1 touch-pan-y overscroll-contain">
               {weaponSwapPopup.options.map((option) => {
                 const optionIndex = CAPTURE_ANIMATION_OPTIONS.findIndex((entry) => entry.id === option.id);
                 const selected = appearance.captureAnimation === optionIndex;
@@ -11747,14 +11740,14 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
                   <button
                     key={option.id}
                     type="button"
-                    className={`overflow-hidden rounded-xl border p-1 text-[8px] font-semibold ${
+                    className={`overflow-hidden rounded-lg border p-1 text-[7px] font-semibold ${
                       selected ? 'border-sky-300 bg-sky-400/25 text-white' : 'border-white/20 bg-white/5 text-white/80'
                     }`}
                     onClick={() => {
                       if (optionIndex >= 0) setAppearance((prev) => ({ ...prev, captureAnimation: optionIndex }));
                     }}
                   >
-                    <div className="mx-auto mb-1 flex h-6 w-6 items-center justify-center rounded border border-white/20 bg-slate-900/70 text-[13px] leading-none text-slate-100">
+                    <div className="mx-auto mb-1 flex h-5 w-5 items-center justify-center rounded border border-white/20 bg-slate-900/70 text-[11px] leading-none text-slate-100">
                       {shape}
                     </div>
                     <div className="px-0.5 pb-0.5 leading-tight">{option.label}</div>
@@ -11764,7 +11757,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             </div>
           </div>
         )}
-        <div className="absolute top-[5.35rem] left-2 z-20 flex flex-col items-start gap-3">
+        <div className="absolute bottom-[10.75rem] left-2 z-20 flex flex-col items-start gap-3">
           <div className="pointer-events-auto">
             <button
               type="button"


### PR DESCRIPTION
### Motivation
- Move and retune capture-weapon visuals so weapons sit closer to the human's right-hand grab area, lay flatter on the table, and face the board center for clearer pickup affordance.
- Remove the dark rounded holder under weapons and reposition the red action button to sit lower and nearer the right-hand area so it is visually aligned with the weapon.
- Ensure drone selection displays/launches the drone itself (not the truck) and make the red action button visible only for air strikes (jet/helicopter/drone).
- Align and shrink the quick-swap UI so it sits in the same horizontal zone as the red button on the left-hand side and reads better on portrait mobile screens.

### Description
- Updated parking side sign for firearm racks by changing `CAPTURE_PARK_SIDE_SIGN_BY_TYPE.firearmRack` so racks are positioned toward the right-hand side for the local player.
- Adjusted weapon display tuning in `FIREARM_RACK_DISPLAY_TUNING` to increase `targetSizeMultiplier`, change `position` and `rotation` so weapons lay flatter and are smaller/closer to the hand.
- Removed the dark rounded base mesh under the action area (deleted `buttonBase`) and repositioned `weaponHolder`, `actionButton`, and `weaponRackHit` coordinates to the new right-hand placement inside `createCaptureWeaponRackFx`.
- Changed visibility and parking logic so `drone` is used/shown for `droneAttack` (and `droneTruck` is no longer shown), and switched the parked launch anchor for drones to use the drone park point (replaced `droneTruckPark` with `dronePark`).
- Retuned base positioning in `refreshWeaponRackPose` to nudge weapon racks and large firearms toward the right side and slightly inward so they appear next to the right hand.
- Moved quick-swap trigger to a lower-left screen position, reduced the quick-swap popup/card size and item sizes, replaced abstract glyphs with clearer emoji-like icons in `QUICK_SWAP_WEAPON_SHAPE_BY_ID`, and tightened grid spacing for a more compact quick-swap menu.
- All changes are contained in `webapp/src/pages/Games/LudoBattleRoyal.jsx`.

### Testing
- Ran `npx eslint webapp/src/pages/Games/LudoBattleRoyal.jsx`; result: no lint errors (file is ignored by project eslint patterns and produced a warning only).
- No other automated tests were modified or executed for this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f03414a2fc8329af9f51da29e53828)