### PR TITLE
Increase Pool Royale human scale and align pose/textures with Bilardo Shqip

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1931,7 +1931,7 @@ const CUE_FOLLOW_THROUGH_MAX = BALL_R * 8.4; // extend top-end follow-through so
 const MIN_SHOT_POWER_TO_FIRE = BILARDO_MIN_RELEASE_POWER; // keep Pool Royale release gate identical to Bilardo Shqip
 const HUMAN_PLAYER_HEIGHT_RATIO_TO_TABLE = 0.96; // increase player size so body/table proportions match Bilardo-like framing
 const BILARDO_SHQIP_HUMAN_URL = 'https://threejs.org/examples/models/gltf/readyplayer.me.glb';
-const POOL_ROYALE_HUMAN_SCALE_MULTIPLIER = 1.18; // align with Bilardo Shqip human/table size relationship
+const POOL_ROYALE_HUMAN_SCALE_MULTIPLIER = 5.9; // make humans 5x larger while keeping the Bilardo Shqip base proportions
 const HUMAN_PLAYER_IDLE_SWAY_SPEED = 1.2;
 const HUMAN_PLAYER_IDLE_SWAY_ANGLE = 0.04;
 const HUMAN_PLAYER_AIM_LEAN = 0.2;
@@ -24618,13 +24618,14 @@ const shotPowerRef = useRef(0);
             poseLambda: HUMAN_POSE_LAMBDA,
             moveLambda: HUMAN_MOVE_LAMBDA,
             rotLambda: HUMAN_ROT_LAMBDA,
-            strikeTime: 0.12,
+            strikeTime: 0.11,
             holdTime: 0.05,
             stanceWidth: 0.52,
-            bridgePalmTableLift: 0.009,
+            bridgePalmTableLift: 0.012,
             chinToCueHeight: 0.11,
             cueArmElbowRise: 0.43,
-            tableTopY: TABLE_Y + TABLE.THICK + BALL_R * 0.08
+            tableTopY: TABLE_Y + TABLE.THICK,
+            textureAnisotropy: renderer?.capabilities?.getMaxAnisotropy?.() ?? 8
           });
           human.root.position.set(x, floorY, z);
           human.yaw = yaw;

--- a/webapp/src/pages/Games/shared/bilardoHumanRig.js
+++ b/webapp/src/pages/Games/shared/bilardoHumanRig.js
@@ -114,6 +114,9 @@ function normalizeHuman(model, opts) {
 }
 
 export function createBilardoHumanRig(scene, opts = {}) {
+  const textureAnisotropy = Number.isFinite(opts?.textureAnisotropy)
+    ? Math.max(1, opts.textureAnisotropy)
+    : null;
   const human = {
     root: new THREE.Group(),
     modelRoot: new THREE.Group(),
@@ -184,6 +187,7 @@ export function createBilardoHumanRig(scene, opts = {}) {
           if (!m) return;
           if (m.map) {
             m.map.colorSpace = THREE.SRGBColorSpace;
+            if (textureAnisotropy != null) m.map.anisotropy = textureAnisotropy;
             m.map.needsUpdate = true;
           }
           m.needsUpdate = true;


### PR DESCRIPTION
### Motivation
- Make the Pool Royale human character visually 5× larger to match the requested scale and screen framing.
- Correct the character bending/orientation so Pool Royale stance and shot pose match the Bilardo Shqip behavior.
- Improve texture clarity for the enlarged characters so materials remain sharp at steeper view angles.

### Description
- Raised `POOL_ROYALE_HUMAN_SCALE_MULTIPLIER` from `1.18` to `5.9` to achieve the ~5× visual size increase. (`webapp/src/pages/Games/PoolRoyale.jsx`)
- Aligned pose tuning to Bilardo defaults by adjusting `strikeTime` to `0.11`, increasing `bridgePalmTableLift` to `0.012`, and using `tableTopY: TABLE_Y + TABLE.THICK` to remove the previous extra offset. (`webapp/src/pages/Games/PoolRoyale.jsx`)
- Added optional `textureAnisotropy` support to the shared human rig loader and applied it to mesh texture maps when provided. (`webapp/src/pages/Games/shared/bilardoHumanRig.js`)
- Enabled the new `textureAnisotropy` for Pool Royale using the renderer cap so enlarged GLB textures remain sharper. (`webapp/src/pages/Games/PoolRoyale.jsx`)

### Testing
- Ran `npm --prefix webapp run -s build` and the production build completed successfully with non-blocking warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f042911c9c8329a540e27f7d7be945)