### PR TITLE
Add quick weapon-swap UI and rebalance capture/vehicle scales in Chess Battle Royal

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -54,7 +54,8 @@ import {
 import {
   chessBattleAccountId,
   getChessBattleInventory,
-  isChessOptionUnlocked
+  isChessOptionUnlocked,
+  setChessBattleEquippedOption
 } from '../../utils/chessBattleInventory.js';
 import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
 import { avatarToName } from '../../utils/avatarUtils.js';
@@ -115,7 +116,7 @@ const CAPTURE_DRONE_ATTACK_TOTAL = CAPTURE_GROUND_FIRE_TIME + CAPTURE_DRONE_TRAV
 const CAPTURE_GROUND_TOTAL = CAPTURE_GROUND_FIRE_TIME + CAPTURE_GROUND_TRAVEL_TIME;
 const CAPTURE_PAWN_TRAVEL_TIME = CAPTURE_GROUND_TRAVEL_TIME * 0.78; // make pawn short-missile strike noticeably faster
 const CAPTURE_PAWN_TOTAL = CAPTURE_GROUND_FIRE_TIME + CAPTURE_PAWN_TRAVEL_TIME;
-const CAPTURE_VEHICLE_SCALE_MULTIPLIER = 2.4; // make parked/flying capture vehicles 2x larger
+const CAPTURE_VEHICLE_SCALE_MULTIPLIER = 1.72; // rebalance weapon units closer to human/chess-piece proportions
 const CAPTURE_DRONE_SCALE = 0.0432 * CAPTURE_VEHICLE_SCALE_MULTIPLIER;
 const CAPTURE_JET_SCALE = CAPTURE_DRONE_SCALE * 1.12; // trim jet size slightly so it reads cleaner in portrait view
 const CAPTURE_HELICOPTER_SCALE = CAPTURE_DRONE_SCALE * 1.2; // keep helicopter larger than drone while respecting 20% downsize
@@ -2632,11 +2633,11 @@ const BOARD_SURFACE_OFFSETS_BY_SHAPE = Object.freeze({
 });
 const LOWER_PROFILE_TABLE_SHAPE_IDS = new Set(['classicOctagon', 'hexagonTable', 'grandOval', 'diamondEdge']);
 const LOWER_PROFILE_TABLE_HEIGHT_DELTA = 0;
-const SIDE_PARKED_AIRCRAFT_SCALE_MULTIPLIER = 27; // make parked units/markers a bit larger
+const SIDE_PARKED_AIRCRAFT_SCALE_MULTIPLIER = 17.5; // keep side parking weapons realistic beside seated humans
 const SIDE_PARKED_AIR_UNITS_INWARD_OFFSET = -2.2; // push parked vehicles much farther to the sides
 const SIDE_PARKED_AIR_UNITS_BOARD_LEVEL_LIFT = 0.26; // lift pad markers/parked units from floor to board/table level
 const SIDE_PARKED_AIR_UNITS_LANE_SPREAD = 1.92; // increase spacing between parking slots
-const SIDE_PARKED_TRUCK_SCALE_MULTIPLIER = 1.28; // increase parked truck size just a bit more
+const SIDE_PARKED_TRUCK_SCALE_MULTIPLIER = 1.06; // keep truck close to true-size relative to helicopter shell
 
 function getTableHeightForShape(shapeId) {
   if (LOWER_PROFILE_TABLE_SHAPE_IDS.has(shapeId)) {
@@ -7639,6 +7640,30 @@ function Chess3D({
     if (FIREARM_CAPTURE_ANIMATION_IDS.has(selectedCaptureAnimationId)) return 'firearm';
     return GLOBAL_CAPTURE_KIND_BY_ANIMATION_ID[selectedCaptureAnimationId] || 'truck';
   }, [selectedCaptureAnimationId]);
+  const selectedParkedWeaponKind = useMemo(
+    () => GLOBAL_CAPTURE_KIND_BY_ANIMATION_ID[selectedCaptureAnimationId] || 'truck',
+    [selectedCaptureAnimationId]
+  );
+  const selectedParkedWeaponKindRef = useRef(selectedParkedWeaponKind);
+  useEffect(() => {
+    selectedParkedWeaponKindRef.current = selectedParkedWeaponKind;
+  }, [selectedParkedWeaponKind]);
+  const ownedCaptureAnimations = useMemo(
+    () =>
+      (chessInventory?.captureAnimation || [])
+        .map((optionId) => CAPTURE_ANIMATION_OPTIONS.find((option) => option.id === optionId))
+        .filter(Boolean),
+    [chessInventory]
+  );
+  const [weaponSwapOpen, setWeaponSwapOpen] = useState(false);
+  const handleCaptureAnimationSwap = useCallback(
+    (optionId) => {
+      if (!optionId || optionId === selectedCaptureAnimationId) return;
+      setChessBattleEquippedOption('captureAnimation', optionId, resolvedAccountId);
+      setWeaponSwapOpen(false);
+    },
+    [resolvedAccountId, selectedCaptureAnimationId]
+  );
   useEffect(() => {
     const handler = (event) => {
       if (!event?.detail?.accountId || event.detail.accountId === resolvedAccountId) {
@@ -11840,6 +11865,11 @@ function Chess3D({
           root: supportTruck.root
         });
       });
+      const currentCaptureKind = selectedParkedWeaponKindRef.current;
+      parkedAirUnits.forEach((unit) => {
+        if (!unit?.root) return;
+        unit.root.visible = unit.busy || unit.kind === currentCaptureKind;
+      });
     };
 
     const syncBoardFromState = (payload = {}) => {
@@ -13046,6 +13076,8 @@ function Chess3D({
 
       parkedAirUnits.forEach((unit) => {
         if (!unit?.root) return;
+        unit.root.visible =
+          unit.busy || unit.kind === selectedParkedWeaponKindRef.current;
         if (unit.rotorsActive && unit.topRotor && unit.topRotorAxis) {
           unit.topRotor.rotateOnAxis(unit.topRotorAxis, dt * 22);
         }
@@ -13829,6 +13861,60 @@ function Chess3D({
               )}
             </div>
           )}
+        </div>
+        <div className="absolute top-1/2 left-3 z-30 -translate-y-1/2 pointer-events-none">
+          <div className="pointer-events-auto flex flex-col items-start gap-2">
+            <button
+              type="button"
+              onClick={() => setWeaponSwapOpen((open) => !open)}
+              aria-expanded={weaponSwapOpen}
+              aria-label={weaponSwapOpen ? 'Close quick weapon swap' : 'Open quick weapon swap'}
+              className="flex h-11 w-11 items-center justify-center rounded-full border border-amber-300/60 bg-black/65 text-lg shadow-[0_6px_16px_rgba(0,0,0,0.42)] transition hover:border-amber-200 hover:text-amber-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300/80"
+            >
+              🔄
+            </button>
+            {weaponSwapOpen && (
+              <div className="max-h-[52vh] w-[14rem] overflow-y-auto rounded-2xl border border-white/20 bg-[#060a14]/95 p-2 text-xs shadow-2xl backdrop-blur">
+                <p className="px-2 pb-2 text-[10px] uppercase tracking-[0.3em] text-sky-200/80">
+                  Quick Weapon Swap
+                </p>
+                <div className="space-y-2">
+                  {ownedCaptureAnimations.map((option) => {
+                    const isSelected = option.id === selectedCaptureAnimationId;
+                    return (
+                      <button
+                        key={option.id}
+                        type="button"
+                        onClick={() => handleCaptureAnimationSwap(option.id)}
+                        className={`flex w-full items-center gap-2 rounded-xl border p-2 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
+                          isSelected
+                            ? 'border-emerald-300/80 bg-emerald-300/15'
+                            : 'border-white/10 bg-white/5 hover:border-white/30'
+                        }`}
+                      >
+                        {option.thumbnail ? (
+                          <img
+                            src={option.thumbnail}
+                            alt={option.label}
+                            className="h-9 w-9 rounded-md object-cover"
+                            loading="lazy"
+                          />
+                        ) : (
+                          <span className="flex h-9 w-9 items-center justify-center rounded-md border border-white/20 bg-white/10 text-base">
+                            🧰
+                          </span>
+                        )}
+                        <span className="min-w-0 flex-1">
+                          <span className="block truncate text-[0.68rem] font-semibold text-white">{option.label}</span>
+                          <span className="block truncate text-[0.58rem] text-white/60">{option.description}</span>
+                        </span>
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+          </div>
         </div>
         <div className="absolute top-20 right-4 z-20 flex flex-col items-end gap-3 pointer-events-none">
           <div className="pointer-events-auto flex flex-col items-end gap-3">


### PR DESCRIPTION
### Motivation

- Provide a quick in-game control to swap capture animation/weapon cosmetics and keep parked/side weapon visuals consistent with the equipped animation. 
- Rebalance vehicle and parked-unit scales so capture/vehicle visuals better match human/chess-piece proportions and seating context. 

### Description

- Import `setChessBattleEquippedOption` and add a handler `handleCaptureAnimationSwap` that equips a new `captureAnimation` for the resolved account by calling `setChessBattleEquippedOption`. 
- Add state, memo and ref for `selectedParkedWeaponKind`, `selectedParkedWeaponKindRef`, `ownedCaptureAnimations`, and `weaponSwapOpen` to drive the quick-swap UI and visibility logic. 
- Add a left-side quick weapon swap UI that lists owned capture animations with thumbnails and descriptions and calls `handleCaptureAnimationSwap` when an option is selected. 
- Update parked air/truck unit visibility logic to only show parked units that match the currently selected parked weapon kind or are `busy`, and reduce several scale multipliers: `CAPTURE_VEHICLE_SCALE_MULTIPLIER` changed from `2.4` to `1.72`, `SIDE_PARKED_AIRCRAFT_SCALE_MULTIPLIER` from `27` to `17.5`, and `SIDE_PARKED_TRUCK_SCALE_MULTIPLIER` from `1.28` to `1.06` to rebalance proportions. 

### Testing

- Ran the application build (`yarn build`) locally and verified the bundle completed without errors. 
- Executed the test suite (`yarn test`) and confirmed existing automated tests passed. 
- Performed a development run and manually exercised the new quick-swap UI to confirm selections call `setChessBattleEquippedOption` and parked unit visibility updates as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f04152e7e0832983eba447f08d0b44)