### PR TITLE
Increase human scale and refine shooting posture (grounded feet, upper-body bend)

### DIFF
--- a/Assets/Scripts/Gameplay/CueController.cs
+++ b/Assets/Scripts/Gameplay/CueController.cs
@@ -86,6 +86,7 @@ namespace Aiming
 
         public ShotState CurrentShotState => _shotState;
         public Vector3 CurrentAimDirection => _aimDirection;
+        public bool IsCameraLowered => _cameraLowered;
         public float CurrentPullNormalized
         {
             get

--- a/Assets/Scripts/Gameplay/PoolHumanPoseDriver.cs
+++ b/Assets/Scripts/Gameplay/PoolHumanPoseDriver.cs
@@ -41,7 +41,7 @@ namespace Aiming
         [Tooltip("Optional helper waypoints around table sides (left, right, bottom, top) for Bilardo-style perimeter walking.")]
         public Transform[] sideWalkHelpers;
         [Tooltip("Uniform character size multiplier. Values above 1 make the player visually bigger and heavier.")]
-        [Min(0.6f)] public float bodyScaleMultiplier = 1.12f;
+        [Min(0.6f)] public float bodyScaleMultiplier = 1.75f;
 
         [Header("Smoothing")]
         public float poseLambda = 9f;
@@ -67,6 +67,10 @@ namespace Aiming
         [Range(0f, 0.18f)] public float chinToCueForwardBias = 0.085f;
         [Tooltip("Makes lead shoulder slightly lower for realistic bridge alignment.")]
         [Range(0f, 0.16f)] public float shoulderDrop = 0.055f;
+        [Tooltip("Keeps feet planted on the ground while aiming; increase if shoes appear to float.")]
+        [Range(0f, 0.06f)] public float footGroundedOffset = 0.008f;
+        [Tooltip("How much the hips are allowed to bend while aiming. Lower values keep bend mostly in upper body.")]
+        [Range(0f, 0.2f)] public float hipBendLimit = 0.03f;
 
         [Header("Visual fidelity")]
         [Tooltip("Renderers that should keep their original shared materials/textures (prevents accidental runtime overrides).")]
@@ -152,6 +156,7 @@ namespace Aiming
             UpdateHumanPose(
                 dt,
                 cueController.CurrentShotState,
+                cueController.IsCameraLowered,
                 navigatedRootTarget,
                 aimForward,
                 bridgeHandTarget,
@@ -160,8 +165,6 @@ namespace Aiming
                 idleLeftHandTarget,
                 bridgeMode,
                 s);
-
-            cueController.SetCameraLowered(cueController.CurrentShotState != CueController.ShotState.Idle);
         }
 
         float ComputeScaleFactor()
@@ -420,6 +423,7 @@ namespace Aiming
         void UpdateHumanPose(
             float dt,
             CueController.ShotState shotState,
+            bool cameraLowered,
             Vector3 rootTarget,
             Vector3 aimForward,
             Vector3 bridgeHandTarget,
@@ -429,7 +433,8 @@ namespace Aiming
             BridgeMode bridgeMode,
             float s)
         {
-            float targetPose = shotState == CueController.ShotState.Idle ? 0f : 1f;
+            bool shootingPoseRequested = cameraLowered || shotState != CueController.ShotState.Idle;
+            float targetPose = shootingPoseRequested ? 1f : 0f;
             _poseT = DampScalar(_poseT, targetPose, poseLambda, dt);
             root.position = DampVector(root.position, rootTarget, moveLambda, dt);
 
@@ -493,7 +498,7 @@ namespace Aiming
                 leftElbow += side * (-0.015f * s);
             }
 
-            SetNodePose(pelvis, hipCenterWorld, side, forward, new Vector3(Lerp(0f, -0.08f, t), 0f, 0f));
+            SetNodePose(pelvis, hipCenterWorld, side, forward, new Vector3(Lerp(0f, -hipBendLimit, t), 0f, 0f));
             SetNodePose(torso, torsoCenterWorld, side, forward, new Vector3(Lerp(0f, -0.28f, t), 0f, 0f));
             SetNodePose(chest, chestCenterWorld, side, forward, new Vector3(Lerp(0f, -0.62f, t), 0f, 0f));
 
@@ -513,8 +518,8 @@ namespace Aiming
             OrientFlatObject(bridgeHand, leftHandWorld, aimForward, side, Vector3.zero);
             OrientFlatObject(gripHand, rightHandWorld, aimForward, side, new Vector3(Lerp(0.3f, 1.2f, t), 0f, 0f));
 
-            SetNodePose(leftFoot, leftFootWorld + new Vector3(0f, -0.02f * s, 0f), side, forward, new Vector3(0f, -0.24f * t, 0f));
-            SetNodePose(rightFoot, rightFootWorld + new Vector3(0f, -0.02f * s, 0f), side, forward, new Vector3(0f, 0.16f * t, 0f));
+            SetNodePose(leftFoot, leftFootWorld + new Vector3(0f, -(footGroundedOffset * s), 0f), side, forward, new Vector3(0f, -0.24f * t, 0f));
+            SetNodePose(rightFoot, rightFootWorld + new Vector3(0f, -(footGroundedOffset * s), 0f), side, forward, new Vector3(0f, 0.16f * t, 0f));
         }
 
         Vector3 ResolveRightHandGripTarget(Vector3 aimForward, Vector3 aimSide, Vector3 fallbackTarget, float handPull, float s)


### PR DESCRIPTION
### Motivation
- Make the Pool Royale human character visually larger to match reference photos by increasing the default body scale. 
- Prevent the whole body from folding when taking a shooting stance by limiting hip bend and keeping feet grounded. 
- Ensure the character enters the shooting pose when the cue camera is lowered (user lowers cue camera) as well as during dragging/striking.

### Description
- Increased default size by bumping `bodyScaleMultiplier` from `1.12` to `1.75` in `PoolHumanPoseDriver`. 
- Added two tunable pose parameters to `PoolHumanPoseDriver`: `footGroundedOffset` and `hipBendLimit` and applied them to foot placement and pelvis bend respectively. 
- Changed pose activation to consider camera-lowered state by passing `cueController.IsCameraLowered` into `UpdateHumanPose` and using `cameraLowered || shotState != Idle` to request the shooting pose. 
- Stopped the pose driver from overriding cue-camera state each frame by removing the `SetCameraLowered(...)` call from the pose driver. 
- Exposed camera-lowered state by adding `public bool IsCameraLowered => _cameraLowered;` to `CueController` so pose logic can react to the camera state reliably.

### Testing
- Ran repository checks and diffs: `rg "UpdateHumanPose\\(" -n Assets/Scripts/Gameplay/PoolHumanPoseDriver.cs`, `git diff -- Assets/Scripts/Gameplay/CueController.cs Assets/Scripts/Gameplay/PoolHumanPoseDriver.cs`, and `git status --short`, all completed successfully. 
- Committed changes with message `Adjust Pool Royal human scale and shooting posture behavior` successfully. 
- No Unity Editor Play Mode or automated runtime tests were run in this environment; please validate visually in the Unity Editor / target device (play-mode) to confirm scale, feet grounding, and camera-lowered-triggered pose behave as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f04ccf6de083298d5106ea78be1ec0)