### PR TITLE
Adjust Ludo weapon rack placement and firearm sizing

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -109,7 +109,8 @@ const CAPTURE_PARK_SIDE_SIGN_BY_TYPE = Object.freeze({
   helicopter: -1,
   drone: -1,
   missile: 1,
-  firearmRack: -1
+  // Keep firearm parking on the token's visual right-hand side for portrait/table views.
+  firearmRack: 1
 });
 const CAPTURE_PARK_OUTWARD_OFFSET = 0.03;
 const CAPTURE_PARK_FORWARD_OFFSET_BY_TYPE = {
@@ -124,7 +125,19 @@ const CAPTURE_PARK_OUTWARD_OFFSET_BY_TYPE = Object.freeze({
   helicopter: 0.014,
   drone: 0.012,
   missile: 0.032,
-  firearmRack: 0.044
+  firearmRack: 0.086
+});
+const FIREARM_RACK_PARK_TUNING = Object.freeze({
+  small: Object.freeze({
+    sideMultiplier: 0.68,
+    forward: 0.018,
+    outward: 0.082
+  }),
+  large: Object.freeze({
+    sideMultiplier: 1.18,
+    forward: 0.044,
+    outward: 0.122
+  })
 });
 // Lift parked capture vehicles slightly so they read a bit higher on portrait screens.
 const CAPTURE_PARKED_LIFT_OFFSET_Y = 0.008;
@@ -200,8 +213,10 @@ const FIREARM_SINGLE_HAND_ONLY_IDS = new Set([
   'polySawedOff01Attack',
   'polyRevolver02Attack'
 ]);
+const SHOTGUN_BASE_RACK_SCALE = 2.2;
 const FIREARM_RACK_SIZE_MULTIPLIER_BY_ID = Object.freeze({
-  fpsGunAttack: 2.2,
+  // Keep FPS gun parked at the exact same display size as shotgun blast.
+  fpsGunAttack: SHOTGUN_BASE_RACK_SCALE,
   glockSidearmAttack: 1,
   uziSprayAttack: 1.65,
   smgBurstAttack: 1.65,
@@ -210,7 +225,7 @@ const FIREARM_RACK_SIZE_MULTIPLIER_BY_ID = Object.freeze({
   smithSidearmAttack: 1,
   mosinMarksmanAttack: 3.5,
   sniperShotAttack: 2.8,
-  shotgunBlastAttack: 2.2,
+  shotgunBlastAttack: SHOTGUN_BASE_RACK_SCALE,
   grenadeBlastAttack: 0.45,
   polyShotgun01Attack: 2.05,
   polyAssaultRifle01Attack: 2.15,
@@ -6931,17 +6946,13 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       if (inward.lengthSq() < 1e-6) return;
       inward.normalize();
       const rightSide = new THREE.Vector3().crossVectors(inward, MISSILE_WORLD_UP).normalize();
-      const oppositeToPlayer = arena.boardLookTarget.clone().multiplyScalar(2).sub(kingPos).setY(0);
       const isLargeFirearm = LARGE_RACK_FIREARM_IDS.has(captureAnimationId);
-      const basePosition = isLargeFirearm
-        ? seatPos
-            .clone()
-            .addScaledVector(rightSide, CAPTURE_PARK_SIDE_OFFSET * 0.95)
-            .addScaledVector(inward, 0.02)
-        : oppositeToPlayer
-            .clone()
-            .addScaledVector(rightSide, CAPTURE_PARK_SIDE_OFFSET * 0.35)
-            .addScaledVector(inward, 0.01);
+      const rackTuning = isLargeFirearm ? FIREARM_RACK_PARK_TUNING.large : FIREARM_RACK_PARK_TUNING.small;
+      const basePosition = kingPos
+        .clone()
+        .addScaledVector(rightSide, CAPTURE_PARK_SIDE_OFFSET * rackTuning.sideMultiplier)
+        .addScaledVector(inward, rackTuning.forward)
+        .addScaledVector(inward, -rackTuning.outward);
       entry.weaponRack.position.copy(basePosition);
       alignObjectBottomToY(entry.weaponRack, arena.tableInfo?.surfaceY);
       entry.weaponRack.position.y += CAPTURE_PARKED_LIFT_OFFSET_Y;


### PR DESCRIPTION
### Motivation
- Make parked weapons align with the 2D/top portrait placement marks so small weapons sit to the token's visual right while large, long-body firearms sit farther along the table rim. 
- Ensure the FPS gun renders at the same display size as the shotgun so visual scale matches the design mockups.
- Improve rack pose tuning so small vs large firearms get distinct parking offsets for better readability on portrait/mobile.

### Description
- Changed firearm parking side for `firearmRack` so racks are anchored on the token's visual right-hand side by updating `CAPTURE_PARK_SIDE_SIGN_BY_TYPE` in `webapp/src/pages/Games/LudoBattleRoyal.jsx`.
- Increased outward offset for firearm racks and added `FIREARM_RACK_PARK_TUNING` with `small` and `large` presets, then applied those presets when computing parked rack base positions in the rack pose refresh logic.
- Reworked the basePosition calculation to place racks relative to the token/king position using the new tuning instead of the previous opposite-to-player heuristic.
- Introduced `SHOTGUN_BASE_RACK_SCALE` and tied `fpsGunAttack` to the same rack scale as `shotgunBlastAttack` in `FIREARM_RACK_SIZE_MULTIPLIER_BY_ID` so FPS guns and shotguns match visually.

### Testing
- Built the web app with `npm -C webapp run -s build` which completed successfully.
- Ran `npm -C webapp run -s eslint` earlier which exited non-zero, but the production build completed and produced minified assets successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0533547088329a4f1af5158a25284)