### PR TITLE
Adjust Ludo firearm rack parking and alignment

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -231,22 +231,22 @@ const FIREARM_RACK_DISPLAY_TUNING = Object.freeze({
   }),
   large: Object.freeze({
     targetSizeMultiplier: 1.9,
-    position: [0.08, 0, -0.014],
-    rotation: [-Math.PI * 0.5, Math.PI * 0.04, 0]
+    position: [0.09, 0, -0.012],
+    rotation: [-Math.PI * 0.5, Math.PI * 0.02, 0]
   })
 });
 const FIREARM_RACK_PARKING_TUNING = Object.freeze({
   // Small sidearms sit tight next to the token on its right-hand side.
   small: Object.freeze({
-    side: 0.118,
-    inward: 0.004,
-    outward: 0.018
+    side: 0.126,
+    inward: 0.002,
+    outward: 0.024
   }),
   // Long guns stay on the wider octagon rail zones (red long markings in reference shots).
   large: Object.freeze({
-    side: 0.258,
-    inward: -0.012,
-    outward: 0.096
+    side: 0.272,
+    inward: -0.004,
+    outward: 0.108
   })
 });
 const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({


### PR DESCRIPTION
### Motivation
- Improve parked weapon presentation for the Ludo Battle Royal scene so long guns (e.g. AK47 variants) sit slightly to the right of the board and appear more straight, matching the provided reference images.
- Move parked weapons a bit farther from the board to reduce visual overlap with the play area on portrait/mobile screens.

### Description
- Tuned `FIREARM_RACK_DISPLAY_TUNING.large` by changing `position` to `[0.09, 0, -0.012]` and `rotation` to `[-Math.PI * 0.5, Math.PI * 0.02, 0]` to nudge large racks right and straighten orientation.
- Adjusted `FIREARM_RACK_PARKING_TUNING.small` to `side: 0.126`, `inward: 0.002`, `outward: 0.024` to slightly shift small sidearms outward/right.
- Adjusted `FIREARM_RACK_PARKING_TUNING.large` to `side: 0.272`, `inward: -0.004`, `outward: 0.108` to move long guns farther from the board and reduce inward crowding.
- Changes are contained in `webapp/src/pages/Games/LudoBattleRoyal.jsx` and only affect parked capture/weapon rack positioning and display tuning.

### Testing
- Built the webapp with `npm --prefix webapp run build`, which completed successfully and produced a production bundle.
- The build emitted non-blocking warnings about duplicate `package.json` key and chunk sizes, but no errors occurred and the modified file was included in the build output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f05e2b93cc8329bb7bc5f7162e5b9b)