### PR TITLE
Improve human rail movement, cue stroke realism, and GLTF texture preservation

### DIFF
--- a/Assets/Scripts/Gameplay/CueController.cs
+++ b/Assets/Scripts/Gameplay/CueController.cs
@@ -83,6 +83,8 @@ namespace Aiming
         Vector3 _strikeDirection;
         Vector3 _tipBaseScale = Vector3.one;
         bool _cameraLowered;
+        float _strokeVelocityNormalized;
+        float _previousCueDepth;
 
         public ShotState CurrentShotState => _shotState;
         public Vector3 CurrentAimDirection => _aimDirection;
@@ -99,6 +101,21 @@ namespace Aiming
                 return Mathf.Clamp01(pulled / pullRange);
             }
         }
+        public float CurrentCueStrokeNormalized
+        {
+            get
+            {
+                float delta = _currentCueDepth - idleTipGap;
+                if (delta >= 0f)
+                {
+                    return Mathf.Clamp01(pullRange > 0.0001f ? delta / pullRange : 0f);
+                }
+
+                float pushRange = Mathf.Max(0.0001f, idleTipGap - contactTipGap);
+                return Mathf.Clamp(delta / pushRange, -1f, 0f);
+            }
+        }
+        public float CurrentStrokeVelocityNormalized => _strokeVelocityNormalized;
 
         void Awake()
         {
@@ -106,6 +123,8 @@ namespace Aiming
             {
                 _tipBaseScale = cueTip.localScale;
             }
+
+            _previousCueDepth = _currentCueDepth;
         }
 
         void Update()
@@ -309,6 +328,7 @@ namespace Aiming
 
         void UpdateCueDepth()
         {
+            float previousDepth = _currentCueDepth;
             float hitT = Mathf.Clamp01(hitProgress);
             float activePower = _shotState == ShotState.Dragging ? _power : _latchedShotPower;
             float pull = _shotState == ShotState.Striking ? _latchedPullDistance : PullDistanceFromPower(activePower);
@@ -321,6 +341,7 @@ namespace Aiming
                 _dynamicLift = 0f;
                 _dynamicWobble = 0f;
                 _currentCueDepth = idleTipGap + (Mathf.Sin(Time.time * 1.5f) * 0.001f);
+                UpdateStrokeVelocity(previousDepth);
                 return;
             }
 
@@ -333,6 +354,7 @@ namespace Aiming
                 _dynamicWobble = 0f;
                 _chargedCueDepth = idleTipGap + pull;
                 _currentCueDepth = _chargedCueDepth;
+                UpdateStrokeVelocity(previousDepth);
                 return;
             }
 
@@ -370,6 +392,8 @@ namespace Aiming
             {
                 FinishStrike();
             }
+
+            UpdateStrokeVelocity(previousDepth);
         }
 
         void UpdateCuePose()
@@ -491,7 +515,17 @@ namespace Aiming
             _previousSliderPower = 0f;
             _dynamicLift = 0f;
             _dynamicWobble = 0f;
+            _strokeVelocityNormalized = 0f;
             ResetTipScale();
+        }
+
+        void UpdateStrokeVelocity(float previousDepth)
+        {
+            float dt = Mathf.Max(0.0001f, Time.deltaTime);
+            float cueDepthDelta = _currentCueDepth - previousDepth;
+            float range = Mathf.Max(0.0001f, pullRange);
+            _strokeVelocityNormalized = Mathf.Clamp(cueDepthDelta / range / dt, -1f, 1f);
+            _previousCueDepth = _currentCueDepth;
         }
 
         float ResolveReleasedShotPower(float sliderPower, float recoveredPower, float pullDistance)

--- a/Assets/Scripts/Gameplay/HumanRailGuide.cs
+++ b/Assets/Scripts/Gameplay/HumanRailGuide.cs
@@ -11,9 +11,11 @@ namespace Aiming.Gameplay
         [SerializeField] private CueController cueController;
         [SerializeField] private Transform humanRoot;
         [SerializeField, Min(0f)] private float outsidePadding = 0.03f;
+        [SerializeField, Min(0f)] private float railWalkOffset = 0.18f;
+        [SerializeField, Range(0f, 1f)] private float cornerSnapBias = 0.18f;
         [SerializeField] private bool drawHelpers = true;
 
-        private readonly Vector3[] railHelpers = new Vector3[4];
+        private readonly Vector3[] railHelpers = new Vector3[8];
 
         void LateUpdate()
         {
@@ -31,10 +33,17 @@ namespace Aiming.Gameplay
             Bounds bounds = cueController.tableBounds;
             Vector3 c = bounds.center;
             Vector3 e = bounds.extents;
-            railHelpers[0] = new Vector3(c.x, humanRoot.position.y, c.z - e.z); // short near
-            railHelpers[1] = new Vector3(c.x, humanRoot.position.y, c.z + e.z); // short far
-            railHelpers[2] = new Vector3(c.x - e.x, humanRoot.position.y, c.z); // long left
-            railHelpers[3] = new Vector3(c.x + e.x, humanRoot.position.y, c.z); // long right
+            float y = humanRoot.position.y;
+            float xOuter = e.x + railWalkOffset;
+            float zOuter = e.z + railWalkOffset;
+            railHelpers[0] = new Vector3(c.x, y, c.z - zOuter); // short near
+            railHelpers[1] = new Vector3(c.x, y, c.z + zOuter); // short far
+            railHelpers[2] = new Vector3(c.x - xOuter, y, c.z); // long left
+            railHelpers[3] = new Vector3(c.x + xOuter, y, c.z); // long right
+            railHelpers[4] = new Vector3(c.x - xOuter, y, c.z - zOuter); // corner near-left
+            railHelpers[5] = new Vector3(c.x + xOuter, y, c.z - zOuter); // corner near-right
+            railHelpers[6] = new Vector3(c.x - xOuter, y, c.z + zOuter); // corner far-left
+            railHelpers[7] = new Vector3(c.x + xOuter, y, c.z + zOuter); // corner far-right
         }
 
         private void ConstrainOutsideTable()
@@ -48,6 +57,8 @@ namespace Aiming.Gameplay
 
             float minX = b.extents.x + outsidePadding;
             float minZ = b.extents.z + outsidePadding;
+            float railX = b.extents.x + railWalkOffset;
+            float railZ = b.extents.z + railWalkOffset;
 
             if (absX < minX && absZ < minZ)
             {
@@ -61,7 +72,28 @@ namespace Aiming.Gameplay
                 }
 
                 humanRoot.position = pos;
+                return;
             }
+
+            bool currentlyOnLongRail = absX > absZ;
+            if (currentlyOnLongRail)
+            {
+                pos.x = b.center.x + (Mathf.Sign(dx == 0f ? 1f : dx) * railX);
+                pos.z = Mathf.Clamp(pos.z, b.center.z - railZ, b.center.z + railZ);
+            }
+            else
+            {
+                pos.z = b.center.z + (Mathf.Sign(dz == 0f ? 1f : dz) * railZ);
+                pos.x = Mathf.Clamp(pos.x, b.center.x - railX, b.center.x + railX);
+            }
+
+            if (Mathf.Abs(absX - absZ) < cornerSnapBias)
+            {
+                pos.x = b.center.x + (Mathf.Sign(dx == 0f ? 1f : dx) * railX);
+                pos.z = b.center.z + (Mathf.Sign(dz == 0f ? 1f : dz) * railZ);
+            }
+
+            humanRoot.position = pos;
         }
 
         void OnDrawGizmosSelected()

--- a/Assets/Scripts/Gameplay/PoolHumanPoseDriver.cs
+++ b/Assets/Scripts/Gameplay/PoolHumanPoseDriver.cs
@@ -67,6 +67,14 @@ namespace Aiming
         [Range(0f, 0.18f)] public float chinToCueForwardBias = 0.085f;
         [Tooltip("Makes lead shoulder slightly lower for realistic bridge alignment.")]
         [Range(0f, 0.16f)] public float shoulderDrop = 0.055f;
+        [Tooltip("Keeps the body behind the cue stick line (positive pushes player farther behind cue butt).")]
+        [Range(0f, 0.35f)] public float bodyBehindCueOffset = 0.12f;
+        [Tooltip("How far from cue butt end the right hand grips (meters). Real players are commonly near the butt cap.")]
+        [Range(0.03f, 0.25f)] public float rightHandFromCueButt = 0.1f;
+        [Tooltip("Small pause at end of backswing before forward stroke to mimic set-pause-finish rhythm.")]
+        [Range(0f, 0.2f)] public float backswingPauseSeconds = 0.06f;
+        [Tooltip("How much left bridge hand moves inward toward cue ball at high pull values.")]
+        [Range(0f, 0.1f)] public float bridgeCompressionAtMaxPull = 0.028f;
 
         [Header("Visual fidelity")]
         [Tooltip("Renderers that should keep their original shared materials/textures (prevents accidental runtime overrides).")]
@@ -84,6 +92,7 @@ namespace Aiming
         Vector3 _lockedStrikeRootTarget;
         Vector3 _lockedStrikeBridgeTarget;
         Vector3 _lockedStrikeAimForward;
+        float _strokePauseTimer;
 
         void Awake()
         {
@@ -113,6 +122,7 @@ namespace Aiming
 
             Vector3 aimSide = new Vector3(aimForward.z, 0f, -aimForward.x).normalized;
             Vector3 rootTarget = ChooseHumanEdgePosition(cueBall, aimForward, s, cueController.CurrentShotState);
+            rootTarget += aimForward * (-bodyBehindCueOffset * s);
             Vector3 navigatedRootTarget = NavigateAlongTablePerimeter(rootTarget, s, dt);
             CacheRailHelpers();
 
@@ -126,11 +136,12 @@ namespace Aiming
             {
                 bridgeDistance *= 1.07f;
             }
-            Vector3 bridgeHandTarget = cueBall + (aimForward * -bridgeDistance) + (aimSide * (-0.018f * s));
+            float pull01 = cueController.CurrentPullNormalized;
+            Vector3 bridgeHandTarget = cueBall + (aimForward * -(bridgeDistance - (pull01 * bridgeCompressionAtMaxPull * s))) + (aimSide * (-0.018f * s));
             bridgeHandTarget.y = ResolveTableY(cueBall.y) + ResolveBridgeHeightOffset(bridgeMode, s);
             bridgeHandTarget += aimSide * ResolveBridgeSideOffset(bridgeMode, s);
 
-            float handPull = cueController.CurrentPullNormalized * gripPullRange * s;
+            float handPull = ApplyBackswingPause(cueController.CurrentShotState, cueController.CurrentPullNormalized, dt) * gripPullRange * s;
             Vector3 gripHandTarget = ResolveRightHandGripTarget(aimForward, aimSide, bridgeHandTarget, handPull, s);
 
             float standingYaw = YawFromForward(aimForward);
@@ -529,7 +540,7 @@ namespace Aiming
                 {
                     Vector3 cueDir = cueVector.normalized;
                     float cueLength = cueVector.magnitude;
-                    float gripDistance = Mathf.Clamp(rightHandGripFromCueRoot, 0.05f, cueLength - 0.03f);
+                    float gripDistance = Mathf.Clamp(cueLength - rightHandFromCueButt, 0.05f, cueLength - 0.03f);
                     Vector3 grip = cueRootPos + (cueDir * gripDistance);
                     grip += (cueDir * -handPull);
                     grip += (Vector3.up * (rightHandVerticalOffset * s));
@@ -542,6 +553,30 @@ namespace Aiming
                    (aimForward * (-handPull)) +
                    (Vector3.up * (rightHandVerticalOffset * s)) +
                    (aimSide * (0.022f * s));
+        }
+
+        float ApplyBackswingPause(CueController.ShotState shotState, float pullNormalized, float dt)
+        {
+            if (shotState == CueController.ShotState.Dragging)
+            {
+                float strokeVelocity = cueController != null ? cueController.CurrentStrokeVelocityNormalized : 0f;
+                if (strokeVelocity < -0.25f && pullNormalized > 0.2f)
+                {
+                    _strokePauseTimer = backswingPauseSeconds;
+                }
+            }
+            else if (shotState != CueController.ShotState.Striking)
+            {
+                _strokePauseTimer = 0f;
+            }
+
+            if (_strokePauseTimer > 0f)
+            {
+                _strokePauseTimer = Mathf.Max(0f, _strokePauseTimer - dt);
+                return pullNormalized * 0.98f;
+            }
+
+            return pullNormalized;
         }
 
         void CacheRailHelpers()

--- a/Assets/Scripts/Gameplay/Rendering/GltfMaterialCompatibilityAdapter.cs
+++ b/Assets/Scripts/Gameplay/Rendering/GltfMaterialCompatibilityAdapter.cs
@@ -13,6 +13,9 @@ namespace Aiming.Gameplay.Rendering
         [SerializeField] private bool forceUrpLitShader = true;
         [SerializeField] private Shader urpLitShader;
         [SerializeField] private Shader standardShader;
+        [SerializeField] private bool preserveSourceTextureTransforms = true;
+        [Tooltip("Keeps UV orientation from imported GLTF source. Enable only if your importer flipped textures vertically.")]
+        [SerializeField] private bool invertMainTextureY = false;
 
         private static readonly int BaseMapId = Shader.PropertyToID("_BaseMap");
         private static readonly int MainTexId = Shader.PropertyToID("_MainTex");
@@ -105,13 +108,22 @@ namespace Aiming.Gameplay.Rendering
             return standardShader;
         }
 
-        private static void CopyPbrMaps(Material material)
+        private void CopyPbrMaps(Material material)
         {
             Texture baseTexture = FirstTexture(material, BaseMapId, MainTexId);
             if (baseTexture != null)
             {
                 TrySetTexture(material, BaseMapId, baseTexture);
                 TrySetTexture(material, MainTexId, baseTexture);
+                if (preserveSourceTextureTransforms)
+                {
+                    CopyTextureTransform(material, BaseMapId, MainTexId);
+                    if (invertMainTextureY)
+                    {
+                        FlipTextureY(material, BaseMapId);
+                        FlipTextureY(material, MainTexId);
+                    }
+                }
             }
 
             if (material.HasProperty(BaseColorId) && material.HasProperty(ColorId))
@@ -130,18 +142,30 @@ namespace Aiming.Gameplay.Rendering
             {
                 TrySetTexture(material, BumpMapId, normal);
                 material.EnableKeyword("_NORMALMAP");
+                if (preserveSourceTextureTransforms)
+                {
+                    CopyTextureTransform(material, BumpMapId, BaseMapId);
+                }
             }
 
             Texture metallic = FirstTexture(material, MetallicGlossMapId);
             if (metallic != null)
             {
                 TrySetTexture(material, MetallicGlossMapId, metallic);
+                if (preserveSourceTextureTransforms)
+                {
+                    CopyTextureTransform(material, MetallicGlossMapId, BaseMapId);
+                }
             }
 
             Texture occlusion = FirstTexture(material, OcclusionMapId);
             if (occlusion != null)
             {
                 TrySetTexture(material, OcclusionMapId, occlusion);
+                if (preserveSourceTextureTransforms)
+                {
+                    CopyTextureTransform(material, OcclusionMapId, BaseMapId);
+                }
             }
 
             Texture emission = FirstTexture(material, EmissionMapId);
@@ -149,6 +173,10 @@ namespace Aiming.Gameplay.Rendering
             {
                 TrySetTexture(material, EmissionMapId, emission);
                 material.EnableKeyword("_EMISSION");
+                if (preserveSourceTextureTransforms)
+                {
+                    CopyTextureTransform(material, EmissionMapId, BaseMapId);
+                }
             }
         }
 
@@ -178,6 +206,34 @@ namespace Aiming.Gameplay.Rendering
             {
                 material.SetTexture(propertyId, texture);
             }
+        }
+
+        private static void CopyTextureTransform(Material material, int destinationPropertyId, int sourcePropertyId)
+        {
+            if (!material.HasProperty(destinationPropertyId) || !material.HasProperty(sourcePropertyId))
+            {
+                return;
+            }
+
+            Vector2 srcScale = material.GetTextureScale(sourcePropertyId);
+            Vector2 srcOffset = material.GetTextureOffset(sourcePropertyId);
+            material.SetTextureScale(destinationPropertyId, srcScale);
+            material.SetTextureOffset(destinationPropertyId, srcOffset);
+        }
+
+        private static void FlipTextureY(Material material, int propertyId)
+        {
+            if (!material.HasProperty(propertyId))
+            {
+                return;
+            }
+
+            Vector2 scale = material.GetTextureScale(propertyId);
+            Vector2 offset = material.GetTextureOffset(propertyId);
+            scale.y *= -1f;
+            offset.y = 1f - offset.y;
+            material.SetTextureScale(propertyId, scale);
+            material.SetTextureOffset(propertyId, offset);
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent the human character from walking through the table and make perimeter walking feel natural by adding explicit rail helpers and stronger constraints. 
- Make the player visually hold the cue more realistically (right hand near butt, left bridge near cue ball, behind-cue stance and backswing rhythm) so strikes align with UI pull/push behavior. 
- Preserve original GLTF/GLB textures and UV orientation when importing characters so materials look like the source.

### Description
- `Assets/Scripts/Gameplay/HumanRailGuide.cs`: expanded helper anchors from 4 to 8 (rails + corners), added `railWalkOffset` and `cornerSnapBias`, and tightened perimeter constraint logic so `humanRoot` is forced to walk on table sides and corners rather than inside the table. 
- `Assets/Scripts/Gameplay/PoolHumanPoseDriver.cs`: added `bodyBehindCueOffset`, `rightHandFromCueButt`, `backswingPauseSeconds`, and `bridgeCompressionAtMaxPull` and integrated them into pose calculation so the body stands behind the cue line, the right hand grips nearer the butt end, the bridge compresses with pull, and a short backswing pause smooths the set-pause-finish stroke rhythm. 
- `Assets/Scripts/Gameplay/CueController.cs`: added runtime telemetry fields and read-only properties `CurrentCueStrokeNormalized` and `CurrentStrokeVelocityNormalized`, tracked cue depth changes and computed `_strokeVelocityNormalized` via `UpdateStrokeVelocity` so animation/pose code can react to pullback/forward velocity. 
- `Assets/Scripts/Gameplay/Rendering/GltfMaterialCompatibilityAdapter.cs`: added `preserveSourceTextureTransforms` and `invertMainTextureY` options, propagate texture scale/offset from base/main map to normal/metallic/occlusion/emission, and added Y-flip helper to fix common GLTF UV inversion issues; adjusted `CopyPbrMaps` to use the instance flags. 

### Testing
- Ran `git diff --check` to ensure no whitespace/format errors and it succeeded. 
- Searched project references with `rg` to verify new API/flags (`CopyPbrMaps`, `preserveSourceTextureTransforms`, `invertMainTextureY`, `CurrentStrokeVelocityNormalized`, `ApplyBackswingPause`) and confirmed usages. 
- No additional automated unit or playtests were executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0620df3648329934d03c6f7f24d50)