### PR TITLE
Human rig: perimeter walking, GLTF texture fidelity, and cue grip adjustments

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -24611,7 +24611,7 @@ const shotPowerRef = useRef(0);
         const sideOffset = TABLE.W * 0.19;
         const makeRig = (seat, x, z, yaw) => {
           const human = createBilardoHumanRig(world, {
-            loader: new GLTFLoader(),
+            loader: createConfiguredGLTFLoader(renderer),
             modelUrl: BILARDO_SHQIP_HUMAN_URL,
             humanScale: POOL_ROYALE_HUMAN_SCALE_MULTIPLIER,
             humanVisualYawFix: Math.PI,
@@ -24625,7 +24625,8 @@ const shotPowerRef = useRef(0);
             chinToCueHeight: 0.11,
             cueArmElbowRise: 0.43,
             tableTopY: TABLE_Y + TABLE.THICK,
-            textureAnisotropy: renderer?.capabilities?.getMaxAnisotropy?.() ?? 8
+            textureAnisotropy: renderer?.capabilities?.getMaxAnisotropy?.() ?? 8,
+            walkPerimeterSpeed: HUMAN_WALK_PERIMETER_SPEED
           });
           human.root.position.set(x, floorY, z);
           human.yaw = yaw;
@@ -24798,7 +24799,7 @@ const shotPowerRef = useRef(0);
               .clone()
               .addScaledVector(aimForward, -(1.46 - 0.24 - BALL_R - cueBallGap))
               .add(new THREE.Vector3(0, 0.024, 0));
-            const gripTarget = cueTip.clone().lerp(cueBack, 0.82);
+            const gripTarget = cueTip.clone().lerp(cueBack, 0.88);
             const standingYaw = Math.atan2(-aimForward.x, -aimForward.z);
             const idleRight = desiredRoot
               .clone()
@@ -24816,7 +24817,9 @@ const shotPowerRef = useRef(0);
               idleLeft,
               cueBack,
               cueTip,
-              power: activePower
+              power: activePower,
+              walkHalfX: blockerHalfX,
+              walkHalfZ: blockerHalfZ
             });
             return;
           }

--- a/webapp/src/pages/Games/shared/bilardoHumanRig.js
+++ b/webapp/src/pages/Games/shared/bilardoHumanRig.js
@@ -11,6 +11,7 @@ const easeInOut = (t) => t * t * (3 - 2 * t);
 const dampScalar = (current, target, lambda, dt) =>
   THREE.MathUtils.lerp(current, target, 1 - Math.exp(-lambda * dt));
 const yawFromForward = (forward) => Math.atan2(-forward.x, -forward.z);
+const euclideanModulo = (n, m) => ((n % m) + m) % m;
 
 const cleanName = (name) => String(name || '').toLowerCase().replace(/[^a-z0-9]/g, '');
 
@@ -136,6 +137,7 @@ export function createBilardoHumanRig(scene, opts = {}) {
     strikeRoot: new THREE.Vector3(),
     strikeYaw: 0,
     strikeClock: 0,
+    walkPerimeterT: 0,
     cfg: {
       poseLambda: opts.poseLambda ?? 9,
       moveLambda: opts.moveLambda ?? 5.6,
@@ -146,7 +148,8 @@ export function createBilardoHumanRig(scene, opts = {}) {
       bridgePalmTableLift: opts.bridgePalmTableLift ?? 0.012,
       chinToCueHeight: opts.chinToCueHeight ?? 0.11,
       cueArmElbowRise: opts.cueArmElbowRise ?? 0.43,
-      tableTopY: opts.tableTopY ?? 0.84
+      tableTopY: opts.tableTopY ?? 0.84,
+      walkPerimeterSpeed: opts.walkPerimeterSpeed ?? 2.7
     }
   };
 
@@ -185,11 +188,38 @@ export function createBilardoHumanRig(scene, opts = {}) {
             : [];
         mats.forEach((m) => {
           if (!m) return;
-          if (m.map) {
-            m.map.colorSpace = THREE.SRGBColorSpace;
-            if (textureAnisotropy != null) m.map.anisotropy = textureAnisotropy;
-            m.map.needsUpdate = true;
-          }
+          const colorSlots = ['map', 'emissiveMap', 'sheenColorMap', 'specularColorMap'];
+          const textureSlots = [
+            'map',
+            'emissiveMap',
+            'normalMap',
+            'roughnessMap',
+            'metalnessMap',
+            'aoMap',
+            'alphaMap',
+            'bumpMap',
+            'clearcoatMap',
+            'clearcoatNormalMap',
+            'clearcoatRoughnessMap',
+            'displacementMap',
+            'iridescenceMap',
+            'iridescenceThicknessMap',
+            'sheenColorMap',
+            'sheenRoughnessMap',
+            'specularMap',
+            'specularIntensityMap',
+            'specularColorMap',
+            'thicknessMap',
+            'transmissionMap'
+          ];
+          textureSlots.forEach((slot) => {
+            const tex = m[slot];
+            if (!tex) return;
+            tex.flipY = false;
+            if (colorSlots.includes(slot)) tex.colorSpace = THREE.SRGBColorSpace;
+            if (textureAnisotropy != null) tex.anisotropy = textureAnisotropy;
+            tex.needsUpdate = true;
+          });
           m.needsUpdate = true;
         });
       });
@@ -510,13 +540,58 @@ export function chooseHumanEdgePosition(cueBallWorld, aimForward, opts = {}) {
   const desired = cueBallWorld.clone().addScaledVector(aimForward, -desiredShootDistance);
   const xEdge = tableW / 2 + edgeMargin;
   const zEdge = tableL / 2 + edgeMargin;
+  const clampPerimeter = (point) => {
+    const x = clamp(point.x, -xEdge, xEdge);
+    const z = clamp(point.z, -zEdge, zEdge);
+    const dx = Math.min(Math.abs(x + xEdge), Math.abs(xEdge - x));
+    const dz = Math.min(Math.abs(z + zEdge), Math.abs(zEdge - z));
+    if (dx < dz) {
+      return new THREE.Vector3(x < 0 ? -xEdge : xEdge, 0, z);
+    }
+    return new THREE.Vector3(x, 0, z < 0 ? -zEdge : zEdge);
+  };
   const candidates = [
     new THREE.Vector3(-xEdge, 0, clamp(desired.z, -zEdge, zEdge)),
     new THREE.Vector3(xEdge, 0, clamp(desired.z, -zEdge, zEdge)),
     new THREE.Vector3(clamp(desired.x, -xEdge, xEdge), 0, -zEdge),
     new THREE.Vector3(clamp(desired.x, -xEdge, xEdge), 0, zEdge)
   ];
+  candidates.push(clampPerimeter(desired));
   return candidates.sort((a, b) => a.distanceToSquared(desired) - b.distanceToSquared(desired))[0].clone();
+}
+
+function perimeterTToPoint(t, halfX, halfZ, y = 0) {
+  const perim = 4 * (halfX + halfZ);
+  let dist = euclideanModulo(t, 1) * perim;
+  if (dist <= 2 * halfZ) return new THREE.Vector3(-halfX, y, -halfZ + dist);
+  dist -= 2 * halfZ;
+  if (dist <= 2 * halfX) return new THREE.Vector3(-halfX + dist, y, halfZ);
+  dist -= 2 * halfX;
+  if (dist <= 2 * halfZ) return new THREE.Vector3(halfX, y, halfZ - dist);
+  dist -= 2 * halfZ;
+  return new THREE.Vector3(halfX - dist, y, -halfZ);
+}
+
+function pointToPerimeterT(point, halfX, halfZ) {
+  const x = clamp(point.x, -halfX, halfX);
+  const z = clamp(point.z, -halfZ, halfZ);
+  const distToSide = Math.min(
+    Math.abs(x + halfX),
+    Math.abs(halfX - x),
+    Math.abs(z + halfZ),
+    Math.abs(halfZ - z)
+  );
+  let side = 'left';
+  if (distToSide === Math.abs(halfX - x)) side = 'right';
+  else if (distToSide === Math.abs(z + halfZ)) side = 'bottom';
+  else if (distToSide === Math.abs(halfZ - z)) side = 'top';
+  const perim = 4 * (halfX + halfZ);
+  let dist = 0;
+  if (side === 'left') dist = z + halfZ;
+  else if (side === 'top') dist = 2 * halfZ + (x + halfX);
+  else if (side === 'right') dist = 2 * halfZ + 2 * halfX + (halfZ - z);
+  else dist = 2 * halfZ + 2 * halfX + 2 * halfZ + (halfX - x);
+  return euclideanModulo(dist / Math.max(perim, 1e-6), 1);
 }
 
 export function updateBilardoHumanPose(human, dt, frameData) {
@@ -541,7 +616,22 @@ export function updateBilardoHumanPose(human, dt, frameData) {
   }
 
   const rootGoal = state === 'striking' ? human.strikeRoot : frameData.rootTarget;
-  human.root.position.lerp(rootGoal, 1 - Math.exp(-(state === 'striking' ? 12 : cfg.moveLambda) * dt));
+  const halfX = Math.max(0.1, Number(frameData.walkHalfX ?? 1));
+  const halfZ = Math.max(0.1, Number(frameData.walkHalfZ ?? 1));
+  const perimeterGoalT = pointToPerimeterT(rootGoal, halfX, halfZ);
+  if (!Number.isFinite(human.walkPerimeterT)) {
+    human.walkPerimeterT = perimeterGoalT;
+  }
+  const loopDelta = euclideanModulo(perimeterGoalT - human.walkPerimeterT + 0.5, 1) - 0.5;
+  const perimeter = 4 * (halfX + halfZ);
+  const maxStepT =
+    (cfg.walkPerimeterSpeed * Math.max(dt, 1 / 240)) /
+    Math.max(perimeter, 0.001);
+  const stepT = clamp(loopDelta, -maxStepT, maxStepT);
+  human.walkPerimeterT = euclideanModulo(human.walkPerimeterT + stepT, 1);
+  const perimeterPoint = perimeterTToPoint(human.walkPerimeterT, halfX, halfZ, rootGoal.y);
+  const moveLerp = 1 - Math.exp(-(state === 'striking' ? 12 : cfg.moveLambda) * dt);
+  human.root.position.lerp(perimeterPoint, moveLerp);
   const moveAmountRaw = human.root.position.distanceTo(rootGoal);
   human.walkT += dt * (2 + Math.min(7, moveAmountRaw * 10));
   human.yaw = dampScalar(


### PR DESCRIPTION
### Motivation
- Prevent characters from walking through the table by constraining human locomotion to the table perimeter and make shot posture/hand placement more realistic.  
- Preserve original GLTF/GLB texture orientation and color-space so imported avatars display intended materials.  
- Improve cue-hold and stroke behavior so the model grips the butt end with the right hand and positions the left hand near the cue ball while following slider-driven pull/push dynamics.

### Description
- Added perimeter locomotion helpers and state to `bilardoHumanRig.js` including `pointToPerimeterT`, `perimeterTToPoint`, `euclideanModulo`, perimeter clamping and a `walkPerimeterT` timeliner so characters move along side/short-rail lanes instead of cutting through the table.  
- Snapped/expanded edge selection by pushing an additional candidate perimeter point via `clampPerimeter` in `chooseHumanEdgePosition` so standing positions prefer valid rail edges.  
- Wire walk bounds into the rig update path by passing `walkHalfX`/`walkHalfZ` (blocker extents) from `PoolRoyale.jsx` into `updateBilardoHumanPose` and added configurable `walkPerimeterSpeed`.  
- Improved GLTF texture/material handling in `createBilardoHumanRig` by iterating texture slots, setting `tex.flipY = false`, applying `THREE.SRGBColorSpace` for color maps, and applying the configured anisotropy so source mapping and orientation are preserved.  
- Use the configured GLTF loader pipeline (`DRACO`/`KTX2`/`Meshopt`) when spawning player humans by calling `createConfiguredGLTFLoader(renderer)`.  
- Adjusted shooter grip placement by lerping the right-hand `gripTarget` slightly toward the cue butt (`lerp(..., 0.88)`), keeping cueBack/cueTip math and slider-driven pull/push intact so backswing/follow-through remain physically driven.

### Testing
- Ran unit tests: `npm test -- --runTestsByPath test/poolRoyaleCueStrokeTimeline.test.js test/poolRoyaleShotState.test.js` and both suites passed.  
- Ran project linter on the modified files with `npx eslint webapp/src/pages/Games/shared/bilardoHumanRig.js webapp/src/pages/Games/PoolRoyale.jsx`, which reported repository ignore warnings for those paths (files are ignored by repo eslint patterns) rather than code errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0620df3648329934d03c6f7f24d50)