### PR TITLE
Fix Chess Battle Royal weapon swap coverage and side-weapon visibility scale

### DIFF
--- a/webapp/src/config/chessBattleInventoryConfig.js
+++ b/webapp/src/config/chessBattleInventoryConfig.js
@@ -380,7 +380,7 @@ export const CHESS_BATTLE_DEFAULT_UNLOCKS = Object.freeze({
   headStyle: ['current'],
   humanCharacter: [CHESS_HUMAN_CHARACTER_OPTIONS[0]?.id],
   environmentHdri: [DEFAULT_HDRI_ID],
-  captureAnimation: [CAPTURE_ANIMATION_OPTIONS[0]?.id]
+  captureAnimation: CAPTURE_ANIMATION_OPTIONS.map((option) => option.id).filter(Boolean)
 });
 
 export const CHESS_BATTLE_OPTION_LABELS = Object.freeze({

--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -195,6 +195,17 @@ const CAPTURE_MODEL_URLS = Object.freeze({
     'https://cdn.statically.io/gh/srcejon/sdrangel-3d-models/main/fire_truck.glb'
   ]
 });
+const CAPTURE_VEHICLE_MODEL_HOSTS = Object.freeze([
+  'https://cdn.jsdelivr.net/gh/srcejon/sdrangel-3d-models@main',
+  'https://raw.githubusercontent.com/srcejon/sdrangel-3d-models/main',
+  'https://cdn.statically.io/gh/srcejon/sdrangel-3d-models/main'
+]);
+const CAPTURE_VEHICLE_MODEL_FILES = Object.freeze({
+  drone: 'drone.glb',
+  helicopter: 'helicopter.glb',
+  fighter: 'f15.glb',
+  truck: 'fire_truck.glb'
+});
 
 const GLOBAL_CAPTURE_KIND_BY_ANIMATION_ID = Object.freeze({
   missileJavelin: 'truck',
@@ -2645,11 +2656,11 @@ const BOARD_SURFACE_OFFSETS_BY_SHAPE = Object.freeze({
 });
 const LOWER_PROFILE_TABLE_SHAPE_IDS = new Set(['classicOctagon', 'hexagonTable', 'grandOval', 'diamondEdge']);
 const LOWER_PROFILE_TABLE_HEIGHT_DELTA = 0;
-const SIDE_PARKED_AIRCRAFT_SCALE_MULTIPLIER = 17.5; // keep side parking weapons realistic beside seated humans
+const SIDE_PARKED_AIRCRAFT_SCALE_MULTIPLIER = 35; // double side weapon scale so vehicles stay readable on portrait phones
 const SIDE_PARKED_AIR_UNITS_INWARD_OFFSET = -2.2; // push parked vehicles much farther to the sides
 const SIDE_PARKED_AIR_UNITS_BOARD_LEVEL_LIFT = 0.26; // lift pad markers/parked units from floor to board/table level
 const SIDE_PARKED_AIR_UNITS_LANE_SPREAD = 1.92; // increase spacing between parking slots
-const SIDE_PARKED_TRUCK_SCALE_MULTIPLIER = 1.06; // keep truck close to true-size relative to helicopter shell
+const SIDE_PARKED_TRUCK_SCALE_MULTIPLIER = 2.12; // keep truck at same 2x boost as jet/helicopter/drone
 const SHOW_SIDE_PARKING_MARKINGS = false;
 const SHOW_BOARD_SIDE_MARKINGS = false;
 const VEHICLE_BUTTON_CAPTURE_KINDS = new Set(['truck', 'drone', 'helicopter', 'jet']);
@@ -9796,7 +9807,10 @@ function Chess3D({
     const loadCaptureUnitTemplate = async (key, targetSize) => {
       if (captureUnitTemplates[key]) return captureUnitTemplates[key];
       if (captureUnitLoads[key]) return captureUnitLoads[key];
-      const urls = CAPTURE_MODEL_URLS[key] || [];
+      const hostFileUrls = (CAPTURE_VEHICLE_MODEL_FILES[key]
+        ? CAPTURE_VEHICLE_MODEL_HOSTS.map((host) => `${host}/${CAPTURE_VEHICLE_MODEL_FILES[key]}`)
+        : []);
+      const urls = Array.from(new Set([...(CAPTURE_MODEL_URLS[key] || []), ...hostFileUrls]));
       const loader = createConfiguredGLTFLoader(renderer);
       const imageCache = new Map();
       const task = (async () => {


### PR DESCRIPTION
### Motivation
- Players could only swap a very small set of capture weapons and parked side weapons were too small to read on portrait/mobile screens.
- Capture model loading should be more resilient and reuse the same GLB host/file fallback approach used elsewhere to reduce missing-model cases.
- Ensure the quick-weapon-swap UI exposes all owned capture animations so selected weapons appear in the side-of-board display and are usable for capture animations.

### Description
- Default `captureAnimation` unlocks to every available animation ID by changing `captureAnimation` in `webapp/src/config/chessBattleInventoryConfig.js` to `CAPTURE_ANIMATION_OPTIONS.map(...).filter(Boolean)` so the quick-swap list includes the full set of weapons.
- Increased parked side-weapon visibility by doubling `SIDE_PARKED_AIRCRAFT_SCALE_MULTIPLIER` and applying the same 2x boost to trucks by updating `SIDE_PARKED_TRUCK_SCALE_MULTIPLIER` in `webapp/src/pages/Games/ChessBattleRoyal.jsx` so side models are substantially larger on portrait phones.
- Added `CAPTURE_VEHICLE_MODEL_HOSTS` and `CAPTURE_VEHICLE_MODEL_FILES` and merged host/file fallbacks into the `loadCaptureUnitTemplate` URL candidates in `webapp/src/pages/Games/ChessBattleRoyal.jsx` to align Chess GLB load behavior with Ludo and improve GLB/GLTF load resilience.

### Testing
- Ran targeted Jest suites with `npm test -- --runInBand test/chessBattleInventoryConfig.test.js test/inventoryCrossGameConfig.test.js`, which failed due to an existing repository-level ESM/Jest transform issue in `three/examples` and an unrelated inventory expectation mismatch; tests did not fully pass.
- Ran `npx eslint` against the edited files which reported repository ignore warnings (paths are ignored), so no lint errors were emitted for the changed code.
- Manual runtime changes limited to model URL merging and scale constants; visual verification is recommended in a local browser/device to confirm side-weapon visibility and quick-swap coverage after deploying these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f05f29ac7083299bcaac1b775911fa)