### PR TITLE
Adjust Ludo firearm rack placement and alignment

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -231,8 +231,8 @@ const FIREARM_RACK_DISPLAY_TUNING = Object.freeze({
   }),
   large: Object.freeze({
     targetSizeMultiplier: 1.9,
-    position: [0.08, 0, -0.014],
-    rotation: [-Math.PI * 0.5, Math.PI * 0.04, 0]
+    position: [0.092, 0, -0.014],
+    rotation: [-Math.PI * 0.5, Math.PI * 0.02, 0]
   })
 });
 const FIREARM_RACK_PARKING_TUNING = Object.freeze({
@@ -244,9 +244,9 @@ const FIREARM_RACK_PARKING_TUNING = Object.freeze({
   }),
   // Long guns stay on the wider octagon rail zones (red long markings in reference shots).
   large: Object.freeze({
-    side: 0.258,
-    inward: -0.012,
-    outward: 0.096
+    side: 0.272,
+    inward: -0.006,
+    outward: 0.112
   })
 });
 const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({


### PR DESCRIPTION
### Motivation
- Improve visual placement of long-gun models on the Ludo Battle Royal board so they sit slightly farther from the board and appear more straight in the hand/rack pose.

### Description
- Tweaked large firearm rack display transform in `webapp/src/pages/Games/LudoBattleRoyal.jsx` by nudging `FIREARM_RACK_DISPLAY_TUNING.large.position` to the right and reducing the yaw in `rotation` so the models look straighter on-screen.
- Tuned `FIREARM_RACK_PARKING_TUNING.large` values (`side`, `inward`, `outward`) so parked long guns sit a touch farther from the board while preserving seat-relative placement logic.
- Changes are confined to the capture/weapon rack tuning constants and do not alter the positioning algorithm itself.

### Testing
- Ran the production build with `npm -C webapp run -s build` which completed successfully (build produced with standard warnings about chunk sizes and duplicate package key).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f05e2b93cc8329bb7bc5f7162e5b9b)