### PR TITLE
Adjust Ludo firearm rack display and parking offsets

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -231,8 +231,8 @@ const FIREARM_RACK_DISPLAY_TUNING = Object.freeze({
   }),
   large: Object.freeze({
     targetSizeMultiplier: 1.9,
-    position: [0.08, 0, -0.014],
-    rotation: [-Math.PI * 0.5, Math.PI * 0.04, 0]
+    position: [0.086, 0, -0.016],
+    rotation: [-Math.PI * 0.5, Math.PI * 0.02, 0]
   })
 });
 const FIREARM_RACK_PARKING_TUNING = Object.freeze({
@@ -244,9 +244,9 @@ const FIREARM_RACK_PARKING_TUNING = Object.freeze({
   }),
   // Long guns stay on the wider octagon rail zones (red long markings in reference shots).
   large: Object.freeze({
-    side: 0.258,
-    inward: -0.012,
-    outward: 0.096
+    side: 0.266,
+    inward: -0.01,
+    outward: 0.108
   })
 });
 const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({


### PR DESCRIPTION
### Motivation
- Nudge large/long firearm models (AK-style capture weapons) slightly to the right, a touch farther from the board, and straighten their on-rack facing so the in-scene preview matches the provided reference image.

### Description
- Tuning-only update in `webapp/src/pages/Games/LudoBattleRoyal.jsx` that adjusts `FIREARM_RACK_DISPLAY_TUNING.large.position` to `[0.086, 0, -0.016]` and reduces the yaw in `rotation` to `Math.PI * 0.02`, and updates `FIREARM_RACK_PARKING_TUNING.large` `side`, `inward`, and `outward` to `0.266`, `-0.01`, and `0.108` respectively to move parked long guns slightly farther from the board.

### Testing
- No automated tests were executed for this tuning-only change; visual verification in the running app or local preview is expected to validate the adjustment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f05e2b93cc8329bb7bc5f7162e5b9b)