### PR TITLE
Fix Domino Royal seated avatar chair placement

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -983,13 +983,13 @@ const CHAIR_GLOBAL_PUSHBACK = 0.68 * MODEL_SCALE;
 const SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK = 0.82 * MODEL_SCALE;
 const CHAIR_VISUAL_SCALE = 1.3;
 const SEATED_HUMAN_BASE_HEIGHT = 1.74;
-const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.42;
-const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 4.7;
-const SEATED_HUMAN_SEAT_Y_OFFSET = -6.2 * MODEL_SCALE * STOOL_SCALE;
-const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.42;
-const SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET = -SEAT_DEPTH * 0.2;
+const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 1.08;
+const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 1.05;
+const SEATED_HUMAN_SEAT_Y_OFFSET = CHAIR_BASE_HEIGHT - SEAT_THICKNESS * 0.48;
+const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.28;
+const SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET = -SEAT_DEPTH * 0.08;
 const SEATED_HUMAN_FACING_Y = 0;
-const SEATED_HUMAN_FOOT_GROUND_CLEARANCE = -1.55 * MODEL_SCALE * STOOL_SCALE;
+const SEATED_HUMAN_FOOT_GROUND_CLEARANCE = 0.03 * MODEL_SCALE;
 const SEATED_HELPER_FORWARD_DICE_PICKUP = 0.092 * MODEL_SCALE;
 const SEATED_HELPER_FORWARD_DICE_RELEASE = 0.148 * MODEL_SCALE;
 const SEATED_HELPER_RIGHT_DICE = -0.013 * MODEL_SCALE;
@@ -8094,7 +8094,14 @@ function placeChairsWithOption(option, chairData, token) {
 
   const seatAvatarSources = buildSeatAvatarSources(N);
 
-  CHAIR_SEAT_ANGLES.forEach((angle, index) => {
+  const seatCount = THREE.MathUtils.clamp(
+    Number.isFinite(N) ? Math.round(N) : CHAIR_SEAT_ANGLES.length,
+    1,
+    CHAIR_SEAT_ANGLES.length
+  );
+
+  for (let index = 0; index < seatCount; index += 1) {
+    const angle = CHAIR_SEAT_ANGLES[index];
     const radius = CHAIR_SEAT_RADII[index] ?? CHAIR_RADIUS;
     const basis = seatBasisForAngle(angle, radius);
     const wrapper = new THREE.Group();
@@ -8120,7 +8127,7 @@ function placeChairsWithOption(option, chairData, token) {
       seatLabelMesh.rotation.x = -Math.PI / 16;
       wrapper.add(seatLabelMesh);
     }
-  });
+  }
 
   refreshSeatBadges(seatAvatarSources, buildSeatNames(N));
   void attachSeatedHumanActors(token);

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-04-27-domino-human-seating-v37';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-04-28-domino-human-seat-fix-v38';
 
 export default function DominoRoyalArena() {
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- Players reported the human avatar appearing in the middle of the table and not seated on the chair; the goal is to ensure every active player seat has a seated human avatar correctly anchored to the chair.

### Description
- Adjusted seated-human tuning constants so avatars are scaled and anchored to chair geometry by changing `SEATED_HUMAN_TARGET_HEIGHT`, `SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER`, `SEATED_HUMAN_SEAT_Y_OFFSET`, `SEATED_HUMAN_SEAT_Z_OFFSET`, `SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET`, and `SEATED_HUMAN_FOOT_GROUND_CLEARANCE` in `webapp/public/domino-royal-game.js`.
- Limit chair (and avatar) spawning to the active player count `N` by computing a `seatCount` with `THREE.MathUtils.clamp(Number.isFinite(N) ? Math.round(N) : CHAIR_SEAT_ANGLES.length, 1, CHAIR_SEAT_ANGLES.length)` and iterating a deterministic `for` loop instead of spawning chairs for every defined angle.
- Keep existing seated actor attachment flow (`attachSeatedHumanActors`) so each created chair receives a cloned, posed, and aligned human actor instance placed on the chair.
- Bumped the Domino Royal script version string in `webapp/src/pages/Games/DominoRoyalArena.jsx` to `2026-04-28-domino-human-seat-fix-v38` so clients will fetch the updated game script.

### Testing
- Ran the automated test `npm test -- test/dominoRoyalHdriCatalog.test.js`, which passed (1 test, 1 suite).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f06ab3e7608329939e59aeb75c7a29)