### PR TITLE
Snake & Ladder: sync capture weapons with Ludo, add quick weapon swap, adjust seated humans

### DIFF
--- a/test/inventoryCrossGameConfig.test.js
+++ b/test/inventoryCrossGameConfig.test.js
@@ -33,6 +33,11 @@ import {
 } from '../webapp/src/config/tavullBattleInventoryConfig.js';
 import { MURLAN_TABLE_FINISHES } from '../webapp/src/config/murlanTableFinishes.js';
 import { POOL_ROYALE_HDRI_VARIANTS } from '../webapp/src/config/poolRoyaleInventoryConfig.js';
+import {
+  SNAKE_DEFAULT_UNLOCKS,
+  SNAKE_STORE_ITEMS
+} from '../webapp/src/config/snakeInventoryConfig.js';
+import { CAPTURE_ANIMATION_OPTIONS } from '../webapp/src/config/ludoBattleOptions.js';
 
 describe('cross-game inventory alignment', () => {
   test('domino default table follows chess default murlan table', () => {
@@ -128,5 +133,15 @@ describe('cross-game inventory alignment', () => {
       expect(source).toBeTruthy();
       expect(item.thumbnail).toBe(source.thumbnail);
     });
+  });
+
+  test('snake store mirrors ludo battle royal capture weapons', () => {
+    const snakeCaptureStoreIds = new Set(
+      SNAKE_STORE_ITEMS.filter((item) => item.type === 'captureWeapon').map((item) => item.optionId)
+    );
+    const ludoCaptureIds = new Set(CAPTURE_ANIMATION_OPTIONS.slice(1).map((option) => option.id));
+
+    expect(snakeCaptureStoreIds).toEqual(ludoCaptureIds);
+    expect(new Set(SNAKE_DEFAULT_UNLOCKS.captureWeapon)).toEqual(new Set([CAPTURE_ANIMATION_OPTIONS[0]?.id]));
   });
 });

--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -84,15 +84,15 @@ const HUMAN_MODEL_URL = 'https://threejs.org/examples/models/gltf/readyplayer.me
 const HUMAN_MODEL_CACHE = { promise: null, template: null };
 // Keep Snake seated humans aligned with Ludo/Chess Battle Royal chair anchoring and 7am scale baseline.
 const SEATED_HUMAN_BASE_HEIGHT = 1.74;
-const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.42;
-const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 4.2;
-const SEATED_HUMAN_SEAT_Y_OFFSET = -6.2 * MODEL_SCALE * STOOL_SCALE;
+const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.24;
+const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 3.75;
+const SEATED_HUMAN_SEAT_Y_OFFSET = -5.65 * MODEL_SCALE * STOOL_SCALE;
 const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.42;
 // Mirror Ludo Battle Royal's deeper bottom-seat pushback so the local player sits
 // with the same portrait-facing posture/orientation while preserving Snake table scale.
 const SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET = -SEAT_DEPTH * 0.2;
 const SEATED_HUMAN_FACING_Y = 0;
-const SEATED_HUMAN_FOOT_GROUND_Y = -1.55 * MODEL_SCALE * STOOL_SCALE;
+const SEATED_HUMAN_FOOT_GROUND_Y = -1.26 * MODEL_SCALE * STOOL_SCALE;
 const HUMAN_FRONT_SIDE_Z = 1;
 const HUMAN_LEG_FRONT_OFFSET = 0;
 const SNAKE_TOKEN_MODEL_URLS = [
@@ -579,6 +579,40 @@ const WEAPON_PARKED_ROLL_BY_KIND = Object.freeze({
   supportTruck: 0,
   javelin: 0
 });
+const SNAKE_CAPTURE_WEAPON_KIND_MAP = Object.freeze({
+  missileJavelin: 'javelin',
+  droneAttack: 'drone',
+  fighterJetAttack: 'fighter',
+  helicopterAttack: 'helicopter',
+  fpsGunAttack: 'supportTruck',
+  glockSidearmAttack: 'supportTruck',
+  assaultRifleAttack: 'supportTruck',
+  uziSprayAttack: 'supportTruck',
+  ak47VolleyAttack: 'supportTruck',
+  krsvBurstAttack: 'supportTruck',
+  smithSidearmAttack: 'supportTruck',
+  mosinMarksmanAttack: 'supportTruck',
+  sigsauerTacticalAttack: 'supportTruck',
+  grenadeBlastAttack: 'supportTruck',
+  shotgunBlastAttack: 'supportTruck',
+  sniperShotAttack: 'supportTruck',
+  smgBurstAttack: 'supportTruck',
+  compactCarbineAttack: 'supportTruck',
+  marksmanDmrAttack: 'supportTruck',
+  polyShotgun01Attack: 'supportTruck',
+  polyAssaultRifle01Attack: 'supportTruck',
+  polyPistol01Attack: 'supportTruck',
+  polyRevolver01Attack: 'supportTruck',
+  polySawedOff01Attack: 'supportTruck',
+  polyRevolver02Attack: 'supportTruck',
+  polyShotgun02Attack: 'supportTruck',
+  polyShotgun03Attack: 'supportTruck',
+  polySmg01Attack: 'supportTruck'
+});
+
+function normalizeSnakeCaptureWeaponKind(weaponType = 'fighter') {
+  return SNAKE_CAPTURE_WEAPON_KIND_MAP[weaponType] || weaponType || 'fighter';
+}
 
 function pullPointTowardCenter(point, amount = TILE_EDGE_INSET) {
   if (!point) return point;
@@ -5047,19 +5081,20 @@ function updateCaptureExplosionRig(rig, elapsedSinceImpact) {
 }
 
 function createSeatWeaponMesh(weaponType = 'fighter') {
-  const rig = createCaptureVehicleRig(weaponType);
+  const normalizedWeaponType = normalizeSnakeCaptureWeaponKind(weaponType);
+  const rig = createCaptureVehicleRig(normalizedWeaponType);
   const group = rig.root;
   group.visible = true;
   const displayScale =
-    weaponType === 'supportTruck'
+    normalizedWeaponType === 'supportTruck'
       ? TOKEN_HEIGHT * 0.8
-      : weaponType === 'drone'
+      : normalizedWeaponType === 'drone'
       ? TOKEN_HEIGHT * 0.75
       : TOKEN_HEIGHT * 0.85;
   group.scale.setScalar(displayScale * 1.5 * WEAPON_DISPLAY_SIZE_MULTIPLIER);
-  group.position.y -= WEAPON_PARKED_Y_DROP_BY_KIND[weaponType] ?? TOKEN_HEIGHT * 1.48;
-  group.rotation.x = WEAPON_PARKED_PITCH_BY_KIND[weaponType] ?? 0;
-  group.rotation.z = WEAPON_PARKED_ROLL_BY_KIND[weaponType] ?? 0;
+  group.position.y -= WEAPON_PARKED_Y_DROP_BY_KIND[normalizedWeaponType] ?? TOKEN_HEIGHT * 1.48;
+  group.rotation.x = WEAPON_PARKED_PITCH_BY_KIND[normalizedWeaponType] ?? 0;
+  group.rotation.z = WEAPON_PARKED_ROLL_BY_KIND[normalizedWeaponType] ?? 0;
   rig.trail?.forEach((puff) => {
     if (!puff?.material) return;
     puff.visible = false;
@@ -5102,7 +5137,7 @@ function updateSeatWeaponDisplays(board, players = []) {
       if (!board.weaponDisplayGroup.userData.byPlayer) board.weaponDisplayGroup.userData.byPlayer = new Map();
       board.weaponDisplayGroup.userData.byPlayer.set(holderKey, holder);
     }
-    const weaponType = player?.weaponType || fallbackOrder[seatIndex % fallbackOrder.length];
+    const weaponType = normalizeSnakeCaptureWeaponKind(player?.weaponType || fallbackOrder[seatIndex % fallbackOrder.length]);
     if (holder.userData.weaponType !== weaponType) {
       while (holder.children.length) {
         const child = holder.children.pop();
@@ -6334,7 +6369,7 @@ export default function SnakeBoard3D({
     if (captureFxIdRef.current === captureEvent.id) return;
     captureFxIdRef.current = captureEvent.id;
     const board = boardRef.current;
-    const vehicleKind = captureEvent.weaponType || 'fighter';
+    const vehicleKind = normalizeSnakeCaptureWeaponKind(captureEvent.weaponType || 'fighter');
     const vehicleMap = board.captureFx?.vehicles || {};
     const primaryVehicle = vehicleMap[vehicleKind] || vehicleMap.fighter || Object.values(vehicleMap)[0];
     const missileProjectile = vehicleMap.javelin || vehicleMap.fighter || Object.values(vehicleMap)[0];

--- a/webapp/src/config/snakeInventoryConfig.js
+++ b/webapp/src/config/snakeInventoryConfig.js
@@ -1,6 +1,7 @@
 import { POOL_ROYALE_DEFAULT_HDRI_ID, POOL_ROYALE_HDRI_VARIANTS } from './poolRoyaleInventoryConfig.js';
 import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from './murlanThemes.js';
 import { polyHavenThumb, swatchThumbnail } from './storeThumbnails.js';
+import { CAPTURE_ANIMATION_OPTIONS } from './ludoBattleOptions.js';
 
 const mapLabels = (options) =>
   Object.freeze(
@@ -26,12 +27,13 @@ const SNAKE_TOKEN_SHAPE_OPTIONS = Object.freeze([
   { id: 'queen', label: 'Queen Token' },
   { id: 'king', label: 'King Token' }
 ]);
-const SNAKE_CAPTURE_WEAPON_OPTIONS = Object.freeze([
-  { id: 'drone', label: 'Drone' },
-  { id: 'fighter', label: 'Fighter Jet' },
-  { id: 'helicopter', label: 'Military Helicopter' },
-  { id: 'supportTruck', label: 'Support Truck' }
-]);
+const SNAKE_CAPTURE_WEAPON_OPTIONS = Object.freeze(
+  CAPTURE_ANIMATION_OPTIONS.map((option) => ({
+    id: option.id,
+    label: option.label,
+    thumbnail: option.thumbnail
+  }))
+);
 
 export const SNAKE_PAWN_HEAD_OPTIONS = Object.freeze([
   { id: 'current', label: 'Current' },
@@ -162,33 +164,18 @@ export const SNAKE_OPTION_LABELS = Object.freeze({
 });
 
 export const SNAKE_STORE_ITEMS = [
-  {
-    id: 'capture-fighter',
+  ...SNAKE_CAPTURE_WEAPON_OPTIONS.filter((option, idx) => idx > 0).map((option, idx) => ({
+    id: `capture-${option.id}`,
     type: 'captureWeapon',
-    optionId: 'fighter',
-    name: 'F-15 Fighter Jet',
-    price: 520,
-    description: 'Capture eliminations use a fighter jet flypath and strike animation.',
-    thumbnail: SNAKE_THEME_THUMBNAILS.captureWeapon.fighter
-  },
-  {
-    id: 'capture-helicopter',
-    type: 'captureWeapon',
-    optionId: 'helicopter',
-    name: 'Military Helicopter',
-    price: 420,
-    description: 'Capture eliminations use a helicopter flypath and strike animation.',
-    thumbnail: SNAKE_THEME_THUMBNAILS.captureWeapon.helicopter
-  },
-  {
-    id: 'capture-supportTruck',
-    type: 'captureWeapon',
-    optionId: 'supportTruck',
-    name: 'Support Truck',
-    price: 390,
-    description: 'Capture eliminations use an armored truck flypath animation.',
-    thumbnail: SNAKE_THEME_THUMBNAILS.captureWeapon.supportTruck
-  },
+    optionId: option.id,
+    name: option.label,
+    price: 390 + idx * 30,
+    description: 'Use this Ludo Battle Royal weapon set for Snake & Ladder capture animations.',
+    thumbnail:
+      option.thumbnail ||
+      SNAKE_THEME_THUMBNAILS.captureWeapon.fighter ||
+      SNAKE_THEME_THUMBNAILS.captureWeapon.drone
+  })),
   {
     id: 'arena-crystalLagoon',
     type: 'arenaTheme',

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -36,6 +36,7 @@ import {
   SNAKE_PAWN_HEAD_OPTIONS,
   SNAKE_TOKEN_COLOR_OPTIONS
 } from "../../config/snakeInventoryConfig.js";
+import { CAPTURE_ANIMATION_OPTIONS } from "../../config/ludoBattleOptions.js";
 // Developer accounts that receive shares of each pot
 const DEV_ACCOUNT = import.meta.env.VITE_DEV_ACCOUNT_ID;
 const DEV_ACCOUNT_1 = import.meta.env.VITE_DEV_ACCOUNT_ID_1;
@@ -813,13 +814,20 @@ const TOKEN_SHAPE_OPTIONS = Object.freeze([
   { id: 'queen', label: 'Queen', pieceType: 'queen', source: 'ludoBattleRoyal' },
   { id: 'king', label: 'King', pieceType: 'king', source: 'ludoBattleRoyal' }
 ]);
-const CAPTURE_WEAPON_OPTIONS = Object.freeze([
-  { id: 'drone', label: 'Drone' },
-  { id: 'fighter', label: 'Fighter Jet' },
-  { id: 'helicopter', label: 'Military Helicopter' },
-  { id: 'supportTruck', label: 'Support Truck' },
-  { id: 'javelin', label: 'Javelin Missile' }
-]);
+const CAPTURE_WEAPON_OPTIONS = Object.freeze(
+  CAPTURE_ANIMATION_OPTIONS.map((option) => ({
+    id: option.id,
+    label: option.label,
+    thumbnail: option.thumbnail
+  }))
+);
+const LEGACY_CAPTURE_WEAPON_ID_MAP = Object.freeze({
+  drone: 'droneAttack',
+  fighter: 'fighterJetAttack',
+  helicopter: 'helicopterAttack',
+  supportTruck: 'grenadeBlastAttack',
+  javelin: 'missileJavelin'
+});
 
 const SNAKE_SKIN_OPTIONS = Object.freeze([
   {
@@ -939,6 +947,13 @@ const DEFAULT_FRAME_RATE_ID = 'fast120';
 const DEFAULT_FRAME_RATE_OPTION =
   FRAME_RATE_OPTIONS.find((option) => option.id === DEFAULT_FRAME_RATE_ID) ?? FRAME_RATE_OPTIONS[0];
 
+function normalizeCaptureWeaponId(rawId) {
+  if (!rawId) return CAPTURE_WEAPON_OPTIONS[0]?.id || 'missileJavelin';
+  const normalized = LEGACY_CAPTURE_WEAPON_ID_MAP[rawId] || rawId;
+  if (CAPTURE_WEAPON_OPTIONS.some((option) => option.id === normalized)) return normalized;
+  return CAPTURE_WEAPON_OPTIONS[0]?.id || 'missileJavelin';
+}
+
 function normalizeAppearance(value = {}) {
   const normalized = { ...DEFAULT_APPEARANCE };
   const entries = [
@@ -959,6 +974,11 @@ function normalizeAppearance(value = {}) {
       normalized[key] = Math.min(Math.max(0, Math.round(raw)), Math.max(0, max - 1));
     }
   });
+  if (typeof value?.captureWeapon === 'string') {
+    const captureId = normalizeCaptureWeaponId(value.captureWeapon);
+    const idx = CAPTURE_WEAPON_OPTIONS.findIndex((option) => option.id === captureId);
+    if (idx >= 0) normalized.captureWeapon = idx;
+  }
   normalized.snakeSkin = 0;
   normalized.tokenFinish = 0;
   return normalized;
@@ -1208,6 +1228,7 @@ export default function SnakeAndLadder() {
     return false;
   });
   const [showConfig, setShowConfig] = useState(false);
+  const [weaponSwapOpen, setWeaponSwapOpen] = useState(false);
   const [showTrailEnabled, setShowTrailEnabled] = useState(true);
   const [appearance, setAppearance] = useState(() => {
     try {
@@ -3232,9 +3253,10 @@ export default function SnakeAndLadder() {
   const playerHeadPreset = resolvedAppearance?.pawnHead?.preset ?? null;
   const playerHeadPresetId = resolvedAppearance?.pawnHead?.id ?? 'current';
   const selectedCaptureWeaponId =
-    resolvedAppearance?.captureWeapon?.id && isSnakeOptionUnlocked('captureWeapon', resolvedAppearance.captureWeapon.id, snakeInventory)
-      ? resolvedAppearance.captureWeapon.id
-      : 'drone';
+    resolvedAppearance?.captureWeapon?.id &&
+    isSnakeOptionUnlocked('captureWeapon', normalizeCaptureWeaponId(resolvedAppearance.captureWeapon.id), snakeInventory)
+      ? normalizeCaptureWeaponId(resolvedAppearance.captureWeapon.id)
+      : CAPTURE_WEAPON_OPTIONS[0]?.id || 'missileJavelin';
 
   const players = isMultiplayer
     ? mpPlayers.map((p, i) => ({
@@ -3769,6 +3791,62 @@ export default function SnakeAndLadder() {
                     Restart game
                   </button>
                 </div>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+      <div
+        className="absolute z-30 pointer-events-auto"
+        style={{
+          right: 'calc(0.9rem + env(safe-area-inset-right, 0px))',
+          bottom: 'calc(env(safe-area-inset-bottom, 0px) + 9.8rem)'
+        }}
+      >
+        <div className="relative">
+          <button
+            type="button"
+            aria-expanded={weaponSwapOpen}
+            aria-label={weaponSwapOpen ? 'Close quick weapon swap' : 'Open quick weapon swap'}
+            onClick={() => setWeaponSwapOpen((prev) => !prev)}
+            className="rounded-full border border-rose-300/70 bg-black/70 px-3 py-2 text-xs font-semibold uppercase tracking-[0.24em] text-rose-100 shadow-[0_10px_25px_rgba(244,63,94,0.35)] transition hover:border-rose-200 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-200"
+          >
+            🔫 Swap
+          </button>
+          {weaponSwapOpen && (
+            <div className="absolute bottom-12 right-0 w-[min(19rem,84vw)] max-h-[52vh] overflow-y-auto rounded-2xl border border-white/15 bg-black/90 p-3 shadow-[0_22px_55px_rgba(2,6,23,0.65)] backdrop-blur-xl">
+              <p className="text-[10px] uppercase tracking-[0.3em] text-white/70">Quick weapon swap</p>
+              <div className="mt-2 space-y-2">
+                {CAPTURE_WEAPON_OPTIONS.filter((option) =>
+                  isSnakeOptionUnlocked('captureWeapon', option.id, snakeInventory)
+                ).map((option) => {
+                  const selected = selectedCaptureWeaponId === option.id;
+                  const optionIndex = CAPTURE_WEAPON_OPTIONS.findIndex((item) => item.id === option.id);
+                  return (
+                    <button
+                      key={option.id}
+                      type="button"
+                      onClick={() => {
+                        setAppearance((prev) => normalizeAppearance({ ...prev, captureWeapon: optionIndex }));
+                        setWeaponSwapOpen(false);
+                      }}
+                      className={`flex w-full items-center gap-3 rounded-xl border px-2 py-2 text-left transition ${
+                        selected
+                          ? 'border-rose-300/80 bg-rose-400/15'
+                          : 'border-white/10 bg-white/5 hover:border-white/20'
+                      }`}
+                    >
+                      <img
+                        src={option.thumbnail || '/assets/icons/gift.svg'}
+                        alt={option.label}
+                        className="h-9 w-14 rounded-md border border-white/10 object-cover"
+                      />
+                      <span className="text-[11px] font-semibold uppercase tracking-[0.16em] text-white/90">
+                        {option.label}
+                      </span>
+                    </button>
+                  );
+                })}
               </div>
             </div>
           )}


### PR DESCRIPTION
### Motivation
- Ensure Snake & Ladder uses the same capture weapon catalog as Ludo Battle Royal so weapons, labels and thumbnails are shared across games.
- Provide a fast in-game way for players to swap their parked/capture weapon without opening deep menus.
- Match seated human visual scale/placement and weapon parking orientation to the other battle-royal games for consistent portrait framing.

### Description
- Replace Snake local capture list with `CAPTURE_ANIMATION_OPTIONS` from `ludoBattleOptions.js` and generate store entries from it in `webapp/src/config/snakeInventoryConfig.js` so Snake store mirrors Ludo options.
- Add legacy ID normalization and `normalizeCaptureWeaponId` in `webapp/src/pages/Games/SnakeAndLadder.jsx` so older saved selections (e.g. `drone`, `fighter`) map to the new Ludo IDs, and resolve selected weapon using the normalized ID before unlock checks.
- Add a portrait-friendly quick weapon swap UI (`🔫 Swap`) in `webapp/src/pages/Games/SnakeAndLadder.jsx` that lists unlocked capture weapons (thumbnails + labels) and applies selection immediately to appearance state.
- Tune seated human constants in `webapp/src/components/SnakeBoard3D.jsx` (`SEATED_HUMAN_TARGET_HEIGHT`, `SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER`, `SEATED_HUMAN_SEAT_Y_OFFSET`, `SEATED_HUMAN_FOOT_GROUND_Y`) to make characters smaller and lifted to better match Ludo/Chess orientation.
- Add `SNAKE_CAPTURE_WEAPON_KIND_MAP` + `normalizeSnakeCaptureWeaponKind` and use it when creating parked weapon meshes and during capture FX so Ludo capture IDs map to Snake vehicle/rig kinds consistently.
- Add a cross-game test in `test/inventoryCrossGameConfig.test.js` asserting Snake capture store entries equal Ludo capture IDs and that the Snake default unlock matches the Ludo default.

### Testing
- Ran a quick node import check that compares `SNAKE_STORE_ITEMS` vs `CAPTURE_ANIMATION_OPTIONS` and confirmed store IDs match and default resolves to `missileJavelin` (success).
- Ran `npx eslint` on the changed files which executed, returning only repo ignore-pattern warnings (no rule errors in changed code).
- Ran `npm test -- test/inventoryCrossGameConfig.test.js --runInBand`, which failed in this environment due to an existing Jest ESM parsing issue with `three/addons` imports unrelated to these changes (failure upstream of the new assertions in the CI environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f069f7ec548329bea57cd8c577b24c)