### PR TITLE
Adjust Ludo weapon rack placement and firearm tuning

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -203,6 +203,7 @@ const FIREARM_SINGLE_HAND_ONLY_IDS = new Set([
 const FIREARM_RACK_SIZE_MULTIPLIER_BY_ID = Object.freeze({
   fpsGunAttack: 2.2,
   glockSidearmAttack: 1,
+  assaultRifleAttack: 0.72,
   uziSprayAttack: 1.65,
   smgBurstAttack: 1.65,
   ak47VolleyAttack: 2.2,
@@ -235,20 +236,40 @@ const FIREARM_RACK_DISPLAY_TUNING = Object.freeze({
     rotation: [-Math.PI * 0.5, Math.PI * 0.02, 0]
   })
 });
+const FIREARM_RACK_DISPLAY_TUNING_BY_ID = Object.freeze({
+  ak47VolleyAttack: Object.freeze({
+    targetSizeMultiplier: 1.9,
+    position: [0.09, 0, -0.014],
+    rotation: [-Math.PI * 0.5, Math.PI * 0.02, 0]
+  }),
+  shotgunBlastAttack: Object.freeze({
+    // Keep shotgun parked as flat as AK-47 reference.
+    targetSizeMultiplier: 1.9,
+    position: [0.09, 0, -0.014],
+    rotation: [-Math.PI * 0.5, Math.PI * 0.02, 0]
+  }),
+  assaultRifleAttack: Object.freeze({
+    // Keep assault rifle at glock-sized footprint.
+    targetSizeMultiplier: 1.02,
+    position: [0.012, 0, -0.004],
+    rotation: [-Math.PI * 0.5, Math.PI * 0.5, 0]
+  })
+});
 const FIREARM_RACK_PARKING_TUNING = Object.freeze({
   // Small sidearms sit tight next to the token on its right-hand side.
   small: Object.freeze({
-    side: 0.118,
+    side: 0.146,
     inward: 0.004,
     outward: 0.018
   }),
   // Long guns stay on the wider octagon rail zones (red long markings in reference shots).
   large: Object.freeze({
-    side: 0.266,
+    side: 0.304,
     inward: -0.01,
     outward: 0.108
   })
 });
+const FIREARM_RACK_WORLD_YAW_OFFSET = -Math.PI * 0.12;
 const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   mrtkGunAttack: {
     label: 'MRTK Gun',
@@ -1113,9 +1134,10 @@ async function applyCaptureWeaponDisplay(entry, captureAnimationId) {
   const clone = weaponModel.clone(true);
   const baseAlignPositionY = clone.position.y;
   alignObjectBottomToY(clone, 0);
-  const displayTuning = LARGE_RACK_FIREARM_IDS.has(captureAnimationId)
+  const displayTuningDefault = LARGE_RACK_FIREARM_IDS.has(captureAnimationId)
     ? FIREARM_RACK_DISPLAY_TUNING.large
     : FIREARM_RACK_DISPLAY_TUNING.default;
+  const displayTuning = FIREARM_RACK_DISPLAY_TUNING_BY_ID[captureAnimationId] ?? displayTuningDefault;
   const weaponRackScaleMultiplier = FIREARM_RACK_SIZE_MULTIPLIER_BY_ID[captureAnimationId] ?? 1;
   fitObjectToTargetSize(
     clone,
@@ -6962,6 +6984,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       alignObjectBottomToY(entry.weaponRack, arena.tableInfo?.surfaceY);
       entry.weaponRack.position.y += CAPTURE_PARKED_LIFT_OFFSET_Y;
       orientCaptureVehicleTowardBoardCenter(entry.weaponRack, arena.boardLookTarget);
+      entry.weaponRack.rotateY(FIREARM_RACK_WORLD_YAW_OFFSET);
     };
     parkedCaptureVehiclesRef.current.forEach((entry, playerIndex) => {
       const optionIndex = playerIndex > 0 ? aiLoadoutByPlayer[playerIndex]?.captureAnimationIndex ?? 0 : humanOptionIndex;


### PR DESCRIPTION
### Motivation
- Make parked weapons sit further to the right on the table and present in a straighter, less intrusive orientation so they match the reference photo (AK47 flat laid pose). 
- Ensure the shotgun appears laid down like the AK-47 and make the assault rifle's parked footprint match the Glock-sized expectation.

### Description
- Added per-weapon rack display overrides via `FIREARM_RACK_DISPLAY_TUNING_BY_ID` to expose custom `targetSizeMultiplier`, `position`, and `rotation` for `ak47VolleyAttack`, `shotgunBlastAttack`, and `assaultRifleAttack`.
- Reduced the parked size footprint for `assaultRifleAttack` by setting `FIREARM_RACK_SIZE_MULTIPLIER_BY_ID.assaultRifleAttack = 0.72` so it visually aligns with glock scale.
- Shifted parked weapon slots outward by increasing `FIREARM_RACK_PARKING_TUNING.small.side` and `FIREARM_RACK_PARKING_TUNING.large.side` so weapons sit more to the right of the player lane.
- Added a global yaw correction (`FIREARM_RACK_WORLD_YAW_OFFSET`) and apply `entry.weaponRack.rotateY(...)` after orienting racks so long guns appear straighter across the table.
- Updated the display pipeline in `applyCaptureWeaponDisplay` to prefer the per-ID `displayTuning` when present and otherwise fall back to existing default/large tuning.
- File changed: `webapp/src/pages/Games/LudoBattleRoyal.jsx`.

### Testing
- Ran the production build with `cd webapp && npm run build`, which completed successfully (build warnings about duplicate package keys and chunk size were present but did not fail the build).
- No automated unit tests were added or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f06cf42e108329aa35bd4427c032d6)