### PR TITLE
Improve Pool Royale human rail pathing and humanoid GLTF material & cue-pose realism

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1942,7 +1942,8 @@ const HUMAN_ROT_LAMBDA = 8.5;
 const HUMAN_EDGE_MARGIN = 0.58;
 const HUMAN_DESIRED_SHOOT_DISTANCE = 1.06;
 const HUMAN_SHOOT_BLEND_THRESHOLD = 0.72; // enter shooting pose earlier when the cue camera starts getting lowered
-const HUMAN_WALK_RING_MARGIN = TABLE.WALL * 3.1; // keep player roots on a perimeter ring outside the table footprint
+const HUMAN_WALK_RING_MARGIN_SIDE_RAIL = TABLE.WALL * 3.22; // helper lane for side rails (long rails): keep humans clearly outside wood/chrome edge
+const HUMAN_WALK_RING_MARGIN_SHORT_RAIL = TABLE.WALL * 3.36; // helper lane for short rails: slightly wider so turns at head/foot rails avoid clipping
 const HUMAN_TABLE_BLOCKER_MARGIN = TABLE.WALL * 1.95; // collision helper margin so characters never cut through the table body
 const HUMAN_WALK_PERIMETER_SPEED = Math.max(TABLE.W * 0.95, TABLE.H * 0.7); // world units per second when traversing the walk ring
 const HUMAN_WALK_EPS = 1e-5;
@@ -24671,8 +24672,8 @@ const shotPowerRef = useRef(0);
             candidate.distanceToSquared(desired) < best.distanceToSquared(desired) ? candidate : best
           );
         };
-        const walkHalfX = TABLE.W / 2 + HUMAN_WALK_RING_MARGIN;
-        const walkHalfZ = TABLE.H / 2 + HUMAN_WALK_RING_MARGIN;
+        const walkHalfX = TABLE.W / 2 + HUMAN_WALK_RING_MARGIN_SIDE_RAIL;
+        const walkHalfZ = TABLE.H / 2 + HUMAN_WALK_RING_MARGIN_SHORT_RAIL;
         const blockerHalfX = TABLE.W / 2 + HUMAN_TABLE_BLOCKER_MARGIN;
         const blockerHalfZ = TABLE.H / 2 + HUMAN_TABLE_BLOCKER_MARGIN;
         const clampToWalkPerimeter = (point) => {

--- a/webapp/src/pages/Games/shared/bilardoHumanRig.js
+++ b/webapp/src/pages/Games/shared/bilardoHumanRig.js
@@ -113,6 +113,31 @@ function normalizeHuman(model, opts) {
   model.position.set(-center.x, -box.min.y, -center.z);
 }
 
+function applyOriginalGltfMaterialConfig(material, textureAnisotropy = null) {
+  if (!material) return;
+  const textureSlots = [
+    { key: 'map', color: true },
+    { key: 'emissiveMap', color: true },
+    { key: 'metalnessMap' },
+    { key: 'roughnessMap' },
+    { key: 'normalMap' },
+    { key: 'aoMap' },
+    { key: 'lightMap' },
+    { key: 'alphaMap' },
+    { key: 'bumpMap' }
+  ];
+  textureSlots.forEach(({ key, color = false }) => {
+    const tex = material[key];
+    if (!tex) return;
+    // Keep glTF UV orientation/mapping conventions when textures are swapped or post-processed.
+    tex.flipY = false;
+    if (color) tex.colorSpace = THREE.SRGBColorSpace;
+    if (textureAnisotropy != null) tex.anisotropy = textureAnisotropy;
+    tex.needsUpdate = true;
+  });
+  material.needsUpdate = true;
+}
+
 export function createBilardoHumanRig(scene, opts = {}) {
   const textureAnisotropy = Number.isFinite(opts?.textureAnisotropy)
     ? Math.max(1, opts.textureAnisotropy)
@@ -185,12 +210,7 @@ export function createBilardoHumanRig(scene, opts = {}) {
             : [];
         mats.forEach((m) => {
           if (!m) return;
-          if (m.map) {
-            m.map.colorSpace = THREE.SRGBColorSpace;
-            if (textureAnisotropy != null) m.map.anisotropy = textureAnisotropy;
-            m.map.needsUpdate = true;
-          }
-          m.needsUpdate = true;
+          applyOriginalGltfMaterialConfig(m, textureAnisotropy);
         });
       });
       human.bones = buildAvatarBones(model);
@@ -598,18 +618,24 @@ export function updateBilardoHumanPose(human, dt, frameData) {
     .lerp(
       frameData.bridgeTarget
         .clone()
-        .addScaledVector(forward, -0.026 * t)
+        .addScaledVector(forward, -0.034 * t)
         .addScaledVector(side, -0.018 * t)
         .setY(cfg.tableTopY + cfg.bridgePalmTableLift)
         .addScaledVector(UP, -0.006 * human.settleT),
       t
     );
+  const pullBack = Math.max(0, frameData.power ?? 0);
+  const pullBackDistance = 0.16 * pullBack * t;
+  const strikeTravel =
+    state === 'striking'
+      ? 0.09 * clamp01(human.strikeClock / Math.max(cfg.strikeTime, 1e-4))
+      : 0;
   const rightHand = frameData.idleRight
     .clone()
     .lerp(
       frameData.gripTarget
         .clone()
-        .addScaledVector(forward, 0.032 * stroke * t + 0.052 * follow * power)
+        .addScaledVector(forward, pullBackDistance + 0.032 * stroke * t - strikeTravel + 0.052 * follow * power)
         .addScaledVector(UP, -0.007 * follow),
       t
     );


### PR DESCRIPTION
### Motivation
- Prevent player avatars from clipping/walking through the table by tightening and separating walk-perimeter lanes for side vs short rails. 
- Preserve original glTF/GLB texture orientation and color-space when loading human models so character textures render as authored. 
- Make the human shoot pose and hand kinematics more realistic by adding explicit pull-back and strike behaviors driven by the power slider.

### Description
- Added separate walk-ring margins `HUMAN_WALK_RING_MARGIN_SIDE_RAIL` and `HUMAN_WALK_RING_MARGIN_SHORT_RAIL` and wired perimeter math to use these values so characters follow an outer lane that avoids rail clipping (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Introduced `applyOriginalGltfMaterialConfig()` to preserve glTF conventions (`flipY=false`) and set color-space/anisotropy for common texture slots when loading humanoid materials (`webapp/src/pages/Games/shared/bilardoHumanRig.js`).
- Adjusted bridge-hand target slightly toward the cue line and implemented a pull-back amount based on the current `power` to move the right hand backward during charge and drive it forward during the `striking` state (limited by strike timing), improving stroke realism (`webapp/src/pages/Games/shared/bilardoHumanRig.js`).
- Minor tuning to hand offsets and cue alignment to reduce arm/rail clipping and produce a more believable grip/bridge posture during aiming and stroke.

### Testing
- Ran the Pool Royale unit tests: `npm test -- test/poolRoyaleCueStrokeTimeline.test.js test/poolRoyaleShotState.test.js` and both suites passed.
- Result: `PASS test/poolRoyaleShotState.test.js` and `PASS test/poolRoyaleCueStrokeTimeline.test.js` (2 suites, 8 tests total).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0620df3648329934d03c6f7f24d50)