### PR TITLE
Adjust Ludo parked weapon placement and orientation

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -203,6 +203,7 @@ const FIREARM_SINGLE_HAND_ONLY_IDS = new Set([
 const FIREARM_RACK_SIZE_MULTIPLIER_BY_ID = Object.freeze({
   fpsGunAttack: 2.2,
   glockSidearmAttack: 1,
+  assaultRifleAttack: 1,
   uziSprayAttack: 1.65,
   smgBurstAttack: 1.65,
   ak47VolleyAttack: 2.2,
@@ -226,25 +227,25 @@ const FIREARM_RACK_SIZE_MULTIPLIER_BY_ID = Object.freeze({
 const FIREARM_RACK_DISPLAY_TUNING = Object.freeze({
   default: Object.freeze({
     targetSizeMultiplier: 1.06,
-    position: [0, 0, -0.004],
-    rotation: [-Math.PI * 0.5, Math.PI * 0.5, 0]
+    position: [0.01, 0, -0.004],
+    rotation: [-Math.PI * 0.5, Math.PI * 0.42, 0]
   }),
   large: Object.freeze({
     targetSizeMultiplier: 1.9,
-    position: [0.086, 0, -0.016],
-    rotation: [-Math.PI * 0.5, Math.PI * 0.02, 0]
+    position: [0.108, 0, -0.016],
+    rotation: [-Math.PI * 0.5, 0, 0]
   })
 });
 const FIREARM_RACK_PARKING_TUNING = Object.freeze({
   // Small sidearms sit tight next to the token on its right-hand side.
   small: Object.freeze({
-    side: 0.118,
+    side: 0.15,
     inward: 0.004,
     outward: 0.018
   }),
   // Long guns stay on the wider octagon rail zones (red long markings in reference shots).
   large: Object.freeze({
-    side: 0.266,
+    side: 0.31,
     inward: -0.01,
     outward: 0.108
   })


### PR DESCRIPTION
### Motivation
- Make parked capture weapons sit further to the player's right and orient more straight on the table so they don't overlap the board in portrait view, lay the shotgun flat like the AK47, and make the assault rifle use the Glock baseline grip size.

### Description
- Added `assaultRifleAttack: 1` to `FIREARM_RACK_SIZE_MULTIPLIER_BY_ID` to match the Glock baseline sizing in `LudoBattleRoyal.jsx`.
- Adjusted `FIREARM_RACK_DISPLAY_TUNING` default and large entries to shift rack `position` and set `rotation` so racks point straighter and large racks lie flatter.
- Increased right-hand parking offsets in `FIREARM_RACK_PARKING_TUNING` by updating `small.side` and `large.side` so parked weapons move further to the right of each token.
- Changes are in `webapp/src/pages/Games/LudoBattleRoyal.jsx` and only modify visual tuning constants (no gameplay logic changes).

### Testing
- Ran ESLint on the modified file with `npx eslint webapp/src/pages/Games/LudoBattleRoyal.jsx`, which completed with a repository ignore-pattern warning and no code errors reported.
- No unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f06cf42e108329aa35bd4427c032d6)