### PR TITLE
Fix parked weapon switching and seat holder resolution for Snake & Ladder capture VFX

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -5199,6 +5199,19 @@ function updateSeatWeaponDisplays(board, players = []) {
   });
 }
 
+function getSeatWeaponHolderForPlayer(board, players = [], playerIndex = null) {
+  if (!board?.weaponDisplayGroup?.userData?.byPlayer || !Number.isInteger(playerIndex) || playerIndex < 0) return null;
+  const player = Array.isArray(players) ? players[playerIndex] : null;
+  const rawSeatIndex = Number.isFinite(player?.seatIndex) ? Number(player.seatIndex) : playerIndex;
+  const seatIndex = Number.isFinite(rawSeatIndex) ? Math.trunc(rawSeatIndex) : playerIndex;
+  const seatKey = `seat-${seatIndex}`;
+  return (
+    board.weaponDisplayGroup.userData.byPlayer.get(seatKey) ||
+    board.weaponDisplayGroup.userData.byPlayer.get(playerIndex) ||
+    null
+  );
+}
+
 export default function SnakeBoard3D({
   players = [],
   highlight,
@@ -6388,7 +6401,7 @@ export default function SnakeBoard3D({
     const startPos = (board.indexToPosition.get(captureEvent.fromCell) || board.serpentineIndexToXZ(captureEvent.fromCell)).clone();
     const targetPos = (board.indexToPosition.get(captureEvent.targetCell) || board.serpentineIndexToXZ(captureEvent.targetCell)).clone();
     startPos.y = targetPos.y = board.baseLevelTop + TOKEN_HEIGHT * 0.85;
-    const parkedHolder = board.weaponDisplayGroup?.userData?.byPlayer?.get(captureEvent.attackerIndex) || null;
+    const parkedHolder = getSeatWeaponHolderForPlayer(board, players, captureEvent.attackerIndex);
     const parkedPos = parkedHolder ? parkedHolder.position.clone() : null;
     const launchOrigin = parkedPos || startPos;
     const launch = launchOrigin.clone().add(new THREE.Vector3(0, TOKEN_HEIGHT * 1.6, 0));
@@ -6401,7 +6414,7 @@ export default function SnakeBoard3D({
     const impact = targetPos.clone().add(new THREE.Vector3(0, TOKEN_HEIGHT * 1.2, 0));
     const impactTop = impact.clone().add(new THREE.Vector3(0, CAPTURE_VERTICAL_STRIKE_LIFT, 0));
     const parkedTop = launch.clone().add(new THREE.Vector3(0, TOKEN_HEIGHT * 0.4, 0));
-    const attackerHolder = board.weaponDisplayGroup?.userData?.byPlayer?.get(captureEvent.attackerIndex) || null;
+    const attackerHolder = parkedHolder;
     if (attackerHolder) attackerHolder.visible = false;
 
     attacker.position.copy(startPos);
@@ -6682,7 +6695,7 @@ export default function SnakeBoard3D({
         return false;
       }
     });
-  }, [captureEvent, onCaptureAnimationComplete]);
+  }, [captureEvent, onCaptureAnimationComplete, players]);
 
   useEffect(() => {
     const handle = () => fitRef.current();

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -3266,7 +3266,20 @@ export default function SnakeAndLadder() {
         type: 'normal',
         color: playerColors[i] || '#fff',
         seatIndex: seatAssignments.get(i),
-        weaponType: CAPTURE_WEAPON_OPTIONS[(i + 1) % CAPTURE_WEAPON_OPTIONS.length]?.id || 'drone'
+        weaponType:
+          p.id === accountId
+            ? selectedCaptureWeaponId
+            : CAPTURE_WEAPON_OPTIONS.some(
+                (option) =>
+                  option.id ===
+                  normalizeCaptureWeaponId(
+                    p?.captureWeapon || p?.appearance?.captureWeapon || p?.selectedCaptureWeapon
+                  )
+              )
+            ? normalizeCaptureWeaponId(
+                p?.captureWeapon || p?.appearance?.captureWeapon || p?.selectedCaptureWeapon
+              )
+            : CAPTURE_WEAPON_OPTIONS[(i + 1) % CAPTURE_WEAPON_OPTIONS.length]?.id || 'drone'
       }))
     : [
         {


### PR DESCRIPTION
### Motivation
- Players who switched capture weapons in Snake & Ladder could not see the new weapon parked at their seat or use it as the capture animation source, because parked holders were keyed by seat (e.g. `seat-0`) while capture logic looked up by numeric player index.
- The goal is to match Ludo Battle Royal behaviour: seated humans show parked weapons and switching should immediately reflect in capture animations.

### Description
- Added a helper `getSeatWeaponHolderForPlayer(board, players, playerIndex)` that resolves a player -> parked weapon holder by seat key (`seat-{index}`) with a numeric-key fallback. (`webapp/src/components/SnakeBoard3D.jsx`).
- Rewired capture animation code to use the resolved parked holder for launch origin and hide/restore visibility (`attackerHolder`), so switched weapons appear from the parked slot instead of token origin. (`webapp/src/components/SnakeBoard3D.jsx`).
- Included `players` in the capture `useEffect` dependency list so UI changes to player loadout reflect immediately in running capture effects. (`webapp/src/components/SnakeBoard3D.jsx`).
- Updated multiplayer player construction in `SnakeAndLadder.jsx` so the local player uses their selected capture weapon (`selectedCaptureWeaponId`) and remote players read normalized capture weapon metadata when available, with a safe fallback to existing options. (`webapp/src/pages/Games/SnakeAndLadder.jsx`).

### Testing
- Ran the production build with `npm -C webapp run build` and it completed successfully (Vite build succeeded; only non-blocking warnings about chunk sizing and an existing duplicate `package.json` key were emitted).
- Confirmed no compile-time errors during the build and that the modified components were included in the built output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f07ae4c8a48329bac56957dbc074bc)