### PR TITLE
Pool Royale: add cue-eye player camera, tighten human-table collision, and prefer textured GLBs

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1942,10 +1942,14 @@ const HUMAN_ROT_LAMBDA = 8.5;
 const HUMAN_EDGE_MARGIN = 0.58;
 const HUMAN_DESIRED_SHOOT_DISTANCE = 1.06;
 const HUMAN_SHOOT_BLEND_THRESHOLD = 0.72; // enter shooting pose earlier when the cue camera starts getting lowered
-const HUMAN_WALK_RING_MARGIN = TABLE.WALL * 3.1; // keep player roots on a perimeter ring outside the table footprint
-const HUMAN_TABLE_BLOCKER_MARGIN = TABLE.WALL * 1.95; // collision helper margin so characters never cut through the table body
+const HUMAN_WALK_RING_MARGIN = TABLE.WALL * 3.9; // push walk ring farther from rails so the character never drifts through the table body
+const HUMAN_TABLE_BLOCKER_MARGIN = TABLE.WALL * 2.35; // expand collision blocker around the table shell to keep feet/body clear
 const HUMAN_WALK_PERIMETER_SPEED = Math.max(TABLE.W * 0.95, TABLE.H * 0.7); // world units per second when traversing the walk ring
 const HUMAN_WALK_EPS = 1e-5;
+const HUMAN_EYE_CAMERA_HEIGHT_OFFSET = 0.02;
+const HUMAN_EYE_CAMERA_FORWARD_OFFSET = 0.05;
+const HUMAN_EYE_CAMERA_LOOK_AHEAD = 1.55;
+const HUMAN_EYE_CAMERA_SIDE_OFFSET = 0.032;
 const CUE_STRIKE_DURATION_MS = 260;
 const PLAYER_CUE_STRIKE_MIN_MS = 120;
 const PLAYER_CUE_STRIKE_MAX_MS = 1400;
@@ -20383,6 +20387,48 @@ const shotPowerRef = useRef(0);
           return vec;
         };
 
+        const resolveCueEyeCamera = (focusTargetWorld) => {
+          if (!focusTargetWorld || shooting || topViewRef.current || replayPlaybackRef.current) return null;
+          const blend = THREE.MathUtils.clamp(cameraBlendRef.current ?? 1, 0, 1);
+          if (blend > HUMAN_SHOOT_BLEND_THRESHOLD) return null;
+          const activeSeat = hudRef.current?.turn === 1 ? 'B' : 'A';
+          const rigs = Array.isArray(playerCharacterRigsRef.current)
+            ? playerCharacterRigsRef.current
+            : [];
+          const activeRig = rigs.find((entry) => entry?.seat === activeSeat && entry?.human);
+          const human = activeRig?.human;
+          if (!human?.loaded) return null;
+          const headBone = human.bones?.head ?? null;
+          const sourceNode = headBone || human.modelRoot || human.root;
+          if (!sourceNode) return null;
+          const eyePos = sourceNode.getWorldPosition(new THREE.Vector3());
+          const cue = cueRef.current;
+          const aimDir = aimDirRef.current;
+          const forward2 =
+            cue?.active && aimDir?.lengthSq?.() > 1e-6
+              ? aimDir.clone().normalize()
+              : null;
+          const cameraForward = forward2
+            ? new THREE.Vector3(forward2.x, 0, forward2.y).normalize()
+            : focusTargetWorld.clone().sub(eyePos).setY(0).normalize();
+          if (cameraForward.lengthSq() < 1e-6) return null;
+          const side = new THREE.Vector3(cameraForward.z, 0, -cameraForward.x).normalize();
+          const lookTarget = focusTargetWorld
+            .clone()
+            .addScaledVector(cameraForward, HUMAN_EYE_CAMERA_LOOK_AHEAD);
+          const cameraPos = eyePos
+            .clone()
+            .addScaledVector(side, HUMAN_EYE_CAMERA_SIDE_OFFSET)
+            .addScaledVector(cameraForward, HUMAN_EYE_CAMERA_FORWARD_OFFSET)
+            .setY(eyePos.y + HUMAN_EYE_CAMERA_HEIGHT_OFFSET);
+          const scaleFactor = Number.isFinite(worldScaleFactor) ? worldScaleFactor : WORLD_SCALE;
+          const tableTopClearance = (TABLE_Y + TABLE.THICK + BALL_R * 3.4) * scaleFactor;
+          if (cameraPos.y < tableTopClearance) {
+            cameraPos.y = tableTopClearance;
+          }
+          return { position: cameraPos, target: lookTarget };
+        };
+
 
         const updateBroadcastCameras = ({
           railDir = 1,
@@ -21609,6 +21655,12 @@ const shotPowerRef = useRef(0);
             }
           }
           camera.lookAt(lookTarget);
+          const eyeCamera = resolveCueEyeCamera(lookTarget);
+          if (eyeCamera?.position && eyeCamera?.target) {
+            camera.position.copy(eyeCamera.position);
+            camera.lookAt(eyeCamera.target);
+            lookTarget = eyeCamera.target;
+          }
           renderCamera = camera;
           broadcastArgs.focusWorld =
             broadcastCamerasRef.current?.defaultFocusWorld ?? lookTarget;

--- a/webapp/src/pages/Games/shared/bilardoHumanRig.js
+++ b/webapp/src/pages/Games/shared/bilardoHumanRig.js
@@ -63,6 +63,22 @@ function buildAvatarBones(model) {
   };
 }
 
+function hasRenderableTexture(model) {
+  let textured = false;
+  model?.traverse?.((obj) => {
+    if (textured || !obj?.isMesh) return;
+    const mats = Array.isArray(obj.material)
+      ? obj.material
+      : obj.material
+        ? [obj.material]
+        : [];
+    if (mats.some((m) => m?.map || m?.emissiveMap || m?.normalMap)) {
+      textured = true;
+    }
+  });
+  return textured;
+}
+
 function collectFingerBones(hand) {
   const out = [];
   hand?.traverse((obj) => {
@@ -200,19 +216,16 @@ export function createBilardoHumanRig(scene, opts = {}) {
         if (bone) human.restQuats.set(bone, bone.quaternion.clone());
       });
       human.activeGlb = Boolean(
-        human.bones.hips &&
-          human.bones.spine &&
-          human.bones.head &&
-          human.bones.leftUpperArm &&
-          human.bones.leftLowerArm &&
-          human.bones.leftHand &&
-          human.bones.rightUpperArm &&
-          human.bones.rightLowerArm &&
-          human.bones.rightHand &&
-          human.bones.leftUpperLeg &&
-          human.bones.leftLowerLeg &&
-          human.bones.rightUpperLeg &&
-          human.bones.rightLowerLeg
+        hasRenderableTexture(model) ||
+          (human.bones.hips &&
+            human.bones.spine &&
+            human.bones.head &&
+            human.bones.leftUpperArm &&
+            human.bones.leftLowerArm &&
+            human.bones.leftHand &&
+            human.bones.rightUpperArm &&
+            human.bones.rightLowerArm &&
+            human.bones.rightHand)
       );
       human.model = model;
       human.modelRoot.add(model);


### PR DESCRIPTION
### Motivation
- Provide a cue-mode player camera anchored to the shooter's head so the cue view reads as a player-first (eye) view while aiming. 
- Prevent human rigs from drifting through or clipping the table by increasing walk/blocker margins around the table. 
- Ensure textured GLB avatars render when they include visible texture maps even if some expected rig bones are missing, avoiding fallback proxy visuals.

### Description
- Added a texture-detection helper `hasRenderableTexture(model)` and updated rig activation logic to keep textured GLB avatars active even if some bones are absent, in `webapp/src/pages/Games/shared/bilardoHumanRig.js`.
- Increased human perimeter margins (`HUMAN_WALK_RING_MARGIN`, `HUMAN_TABLE_BLOCKER_MARGIN`) and added small constants controlling an eye-style cue camera offset in `webapp/src/pages/Games/PoolRoyale.jsx` to keep characters clear of the table shell.
- Implemented `resolveCueEyeCamera(...)` and integrated it into the camera update path to attach the render camera to the shooter's head position (with safety clamps and table-top clearance), in `webapp/src/pages/Games/PoolRoyale.jsx`.

### Testing
- Ran `npm test -- --runInBand test/poolRoyaleShotState.test.js`, which completed successfully (test suite passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f077ebb1108329a357860321b6d695)