### PR TITLE
Improve player eye-camera blending, perimeter walk behavior, and GLB material handling

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1944,6 +1944,10 @@ const HUMAN_DESIRED_SHOOT_DISTANCE = 1.06;
 const HUMAN_SHOOT_BLEND_THRESHOLD = 0.72; // enter shooting pose earlier when the cue camera starts getting lowered
 const HUMAN_WALK_RING_MARGIN = TABLE.WALL * 3.1; // keep player roots on a perimeter ring outside the table footprint
 const HUMAN_TABLE_BLOCKER_MARGIN = TABLE.WALL * 1.95; // collision helper margin so characters never cut through the table body
+const HUMAN_EYE_CAMERA_HEIGHT_OFFSET = 0.01; // lift first-person eye camera slightly above the eye joint to avoid brow clipping
+const HUMAN_EYE_CAMERA_FORWARD_OFFSET = 0.038; // nudge first-person eye camera forward so the face mesh stays out of frame
+const HUMAN_EYE_CAMERA_MIN_BLEND = 0.06; // only engage eye camera when cue view is noticeably lowered
+const HUMAN_EYE_CAMERA_SMOOTH = 0.42; // smooth eye-camera blending into the cue camera for portrait stability
 const HUMAN_WALK_PERIMETER_SPEED = Math.max(TABLE.W * 0.95, TABLE.H * 0.7); // world units per second when traversing the walk ring
 const HUMAN_WALK_EPS = 1e-5;
 const CUE_STRIKE_DURATION_MS = 260;
@@ -20383,6 +20387,58 @@ const shotPowerRef = useRef(0);
           return vec;
         };
 
+        const resolveActiveHumanEyePose = (currentLookTarget = null) => {
+          if (topViewRef.current || shootingRef.current || replayPlaybackRef.current) return null;
+          const cueBlend = THREE.MathUtils.clamp(cameraBlendRef.current ?? 1, 0, 1);
+          const cueBias = 1 - cueBlend;
+          if (cueBias <= HUMAN_EYE_CAMERA_MIN_BLEND) return null;
+          const hudState = hudRef.current;
+          const activeSeat = hudState?.turn === 1 ? 'B' : 'A';
+          const rigs = playerCharacterRigsRef.current;
+          if (!Array.isArray(rigs) || rigs.length === 0) return null;
+          const activeHuman = rigs.find((rig) => {
+            const seat = rig?.seat ?? rig?.anim?.seat;
+            return seat === activeSeat && rig?.human?.modelRoot;
+          })?.human;
+          if (!activeHuman?.modelRoot) return null;
+
+          activeHuman.modelRoot.updateMatrixWorld(true);
+          const headBone =
+            activeHuman.bones?.head ||
+            activeHuman.bones?.neck ||
+            activeHuman.model?.getObjectByName?.('Head') ||
+            activeHuman.modelRoot;
+          if (!headBone) return null;
+
+          const worldPos = headBone.getWorldPosition(new THREE.Vector3());
+          const worldForward = new THREE.Vector3();
+          if (currentLookTarget) {
+            worldForward.copy(currentLookTarget).sub(worldPos).setY(0);
+          }
+          if (worldForward.lengthSq() < 1e-6) {
+            worldForward.set(-Math.sin(activeHuman.yaw || 0), 0, -Math.cos(activeHuman.yaw || 0));
+          } else {
+            worldForward.normalize();
+          }
+          const eyePos = worldPos
+            .clone()
+            .addScaledVector(UP, HUMAN_EYE_CAMERA_HEIGHT_OFFSET)
+            .addScaledVector(worldForward, HUMAN_EYE_CAMERA_FORWARD_OFFSET);
+          const eyeTarget = eyePos
+            .clone()
+            .addScaledVector(worldForward, BALL_R * 16)
+            .setY(Math.max(eyePos.y - BALL_R * 0.2, TABLE_Y + TABLE.THICK + BALL_R));
+          return {
+            blend: THREE.MathUtils.clamp(
+              (cueBias - HUMAN_EYE_CAMERA_MIN_BLEND) / (1 - HUMAN_EYE_CAMERA_MIN_BLEND),
+              0,
+              1
+            ),
+            position: eyePos,
+            target: eyeTarget
+          };
+        };
+
 
         const updateBroadcastCameras = ({
           railDir = 1,
@@ -21606,6 +21662,20 @@ const shotPowerRef = useRef(0);
               TMP_SPH.radius = sph.radius;
               TMP_SPH.phi = sph.phi;
               syncBlendToSpherical();
+            }
+          }
+          const humanEyePose = resolveActiveHumanEyePose(lookTarget);
+          if (humanEyePose) {
+            const lerpT = THREE.MathUtils.clamp(
+              humanEyePose.blend * HUMAN_EYE_CAMERA_SMOOTH,
+              0,
+              1
+            );
+            if (lerpT > 1e-4) {
+              camera.position.lerp(humanEyePose.position, lerpT);
+              lookTarget = lookTarget
+                ? lookTarget.clone().lerp(humanEyePose.target, lerpT)
+                : humanEyePose.target.clone();
             }
           }
           camera.lookAt(lookTarget);
@@ -24765,6 +24835,33 @@ const shotPowerRef = useRef(0);
               edgeMargin: HUMAN_EDGE_MARGIN,
               desiredShootDistance: HUMAN_DESIRED_SHOOT_DISTANCE
             }).setY(floorY);
+            const perimeterRoot = clampToWalkPerimeter(desiredRoot);
+            if (isInsideTableBlocker(perimeterRoot)) {
+              perimeterRoot.copy(clampToWalkPerimeter(perimeterRoot));
+            }
+            if (!Number.isFinite(human.walkPerimeterT)) {
+              human.walkPerimeterT = pointToPerimeterT(human.root.position);
+            }
+            const targetPerimeterT = pointToPerimeterT(perimeterRoot);
+            const perimeterDelta =
+              THREE.MathUtils.euclideanModulo(targetPerimeterT - human.walkPerimeterT + 0.5, 1) - 0.5;
+            const perimeterStepMax =
+              (HUMAN_WALK_PERIMETER_SPEED * Math.max(dtSeconds, 1 / 240)) /
+              (4 * (walkHalfX + walkHalfZ));
+            const perimeterStep = THREE.MathUtils.clamp(
+              perimeterDelta,
+              -perimeterStepMax,
+              perimeterStepMax
+            );
+            human.walkPerimeterT = THREE.MathUtils.euclideanModulo(
+              human.walkPerimeterT + perimeterStep,
+              1
+            );
+            const perimeterWalkPos = perimeterTToPoint(human.walkPerimeterT);
+            if (isInsideTableBlocker(perimeterWalkPos)) {
+              perimeterWalkPos.copy(clampToWalkPerimeter(perimeterWalkPos));
+              human.walkPerimeterT = pointToPerimeterT(perimeterWalkPos);
+            }
             const state =
               mode === 'strike' ? 'striking' : mode === 'aim' ? 'dragging' : 'idle';
             const draggingPower = Math.max(0, Math.min(1, powerRef.current ?? 0));
@@ -24800,15 +24897,15 @@ const shotPowerRef = useRef(0);
               .add(new THREE.Vector3(0, 0.024, 0));
             const gripTarget = cueTip.clone().lerp(cueBack, 0.82);
             const standingYaw = Math.atan2(-aimForward.x, -aimForward.z);
-            const idleRight = desiredRoot
+            const idleRight = perimeterWalkPos
               .clone()
               .add(new THREE.Vector3(0.24, 1.1, 0.02).applyAxisAngle(new THREE.Vector3(0, 1, 0), standingYaw));
-            const idleLeft = desiredRoot
+            const idleLeft = perimeterWalkPos
               .clone()
               .add(new THREE.Vector3(-0.18, 1.08, 0.03).applyAxisAngle(new THREE.Vector3(0, 1, 0), standingYaw));
             updateBilardoHumanPose(human, dtSeconds, {
               state,
-              rootTarget: desiredRoot,
+              rootTarget: perimeterWalkPos,
               aimForward,
               bridgeTarget,
               gripTarget,

--- a/webapp/src/pages/Games/shared/bilardoHumanRig.js
+++ b/webapp/src/pages/Games/shared/bilardoHumanRig.js
@@ -189,7 +189,29 @@ export function createBilardoHumanRig(scene, opts = {}) {
             m.map.colorSpace = THREE.SRGBColorSpace;
             if (textureAnisotropy != null) m.map.anisotropy = textureAnisotropy;
             m.map.needsUpdate = true;
+            if (m.color) m.color.setHex(0xffffff);
           }
+          if (m.emissiveMap) {
+            m.emissiveMap.colorSpace = THREE.SRGBColorSpace;
+            if (textureAnisotropy != null) m.emissiveMap.anisotropy = textureAnisotropy;
+            m.emissiveMap.needsUpdate = true;
+          }
+          if (m.roughnessMap) {
+            m.roughnessMap.colorSpace = THREE.NoColorSpace;
+            if (textureAnisotropy != null) m.roughnessMap.anisotropy = textureAnisotropy;
+            m.roughnessMap.needsUpdate = true;
+          }
+          if (m.normalMap) {
+            m.normalMap.colorSpace = THREE.NoColorSpace;
+            if (textureAnisotropy != null) m.normalMap.anisotropy = textureAnisotropy;
+            m.normalMap.needsUpdate = true;
+          }
+          if (m.aoMap) {
+            m.aoMap.colorSpace = THREE.NoColorSpace;
+            if (textureAnisotropy != null) m.aoMap.anisotropy = textureAnisotropy;
+            m.aoMap.needsUpdate = true;
+          }
+          m.side = THREE.FrontSide;
           m.needsUpdate = true;
         });
       });


### PR DESCRIPTION
### Motivation

- Improve first-person/over-the-shoulder cue view stability and avoid face/brow clipping when the cue camera lowers. 
- Make human characters walk smoothly around the table perimeter and respect table blocker margins so characters don't clip through the table. 
- Ensure imported GLB materials and texture maps are configured reliably for rendering (color spaces, anisotropy, normals, AO, emissive, culling, etc.).

### Description

- Added new human eye camera tuning constants: `HUMAN_EYE_CAMERA_HEIGHT_OFFSET`, `HUMAN_EYE_CAMERA_FORWARD_OFFSET`, `HUMAN_EYE_CAMERA_MIN_BLEND`, and `HUMAN_EYE_CAMERA_SMOOTH` to control first-person eye pose blending. 
- Implemented `resolveActiveHumanEyePose` to compute an optional blended eye camera pose from the active shooter head position and integrated it into the broadcast camera update to lerp the camera and look target when applicable. 
- Updated human walking logic to clamp desired positions to a perimeter path, avoid table blocker regions, and sample/advance a perimeter parameter (`walkPerimeterT`) to produce smooth movement around the table. 
- Adjusted pose/root targets so idle/idle-left/right positions use the computed perimeter position instead of the direct desired root. 
- In `bilardoHumanRig` model loading, normalize material handling by setting texture `colorSpace` and `anisotropy` for `map`, `emissiveMap`, `roughnessMap`, `normalMap`, and `aoMap`, enforce `m.side = THREE.FrontSide`, and apply a default `m.color.setHex(0xffffff)` when present to avoid tinting issues.

### Testing

- Ran unit and integration tests with `yarn test`, and the test suite passed. 
- Ran linting with `yarn lint` and there were no lint errors. 
- Performed a production build with `yarn build` to validate bundling and runtime initialization, and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f077ebb1108329a357860321b6d695)