### PR TITLE
Fix Snake & Ladder parked weapon displays and multiplayer weapon switching

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -5114,6 +5114,7 @@ function updateSeatWeaponDisplays(board, players = []) {
   const boardLookTarget = board.boardLookTarget;
   if (!boardLookTarget) return;
   const keep = new Set();
+  const holderByPlayerIndex = new Map();
   const fallbackOrder = ['drone', 'fighter', 'helicopter', 'supportTruck', 'javelin'];
   const playersBySeat = new Map();
   players.forEach((player, index) => {
@@ -5138,6 +5139,9 @@ function updateSeatWeaponDisplays(board, players = []) {
       board.weaponDisplayGroup.userData.byPlayer.set(holderKey, holder);
     }
     const weaponType = normalizeSnakeCaptureWeaponKind(player?.weaponType || fallbackOrder[seatIndex % fallbackOrder.length]);
+    if (player && Number.isFinite(player.index)) {
+      holderByPlayerIndex.set(Number(player.index), holder);
+    }
     if (holder.userData.weaponType !== weaponType) {
       while (holder.children.length) {
         const child = holder.children.pop();
@@ -5190,6 +5194,7 @@ function updateSeatWeaponDisplays(board, players = []) {
   }
 
   const byPlayer = board.weaponDisplayGroup.userData.byPlayer;
+  board.weaponDisplayGroup.userData.holderByPlayerIndex = holderByPlayerIndex;
   if (!(byPlayer instanceof Map)) return;
   byPlayer.forEach((group, key) => {
     if (!keep.has(key)) {
@@ -6388,7 +6393,10 @@ export default function SnakeBoard3D({
     const startPos = (board.indexToPosition.get(captureEvent.fromCell) || board.serpentineIndexToXZ(captureEvent.fromCell)).clone();
     const targetPos = (board.indexToPosition.get(captureEvent.targetCell) || board.serpentineIndexToXZ(captureEvent.targetCell)).clone();
     startPos.y = targetPos.y = board.baseLevelTop + TOKEN_HEIGHT * 0.85;
-    const parkedHolder = board.weaponDisplayGroup?.userData?.byPlayer?.get(captureEvent.attackerIndex) || null;
+    const parkedHolder =
+      board.weaponDisplayGroup?.userData?.holderByPlayerIndex?.get?.(captureEvent.attackerIndex) ||
+      board.weaponDisplayGroup?.userData?.byPlayer?.get?.(`seat-${captureEvent.attackerIndex}`) ||
+      null;
     const parkedPos = parkedHolder ? parkedHolder.position.clone() : null;
     const launchOrigin = parkedPos || startPos;
     const launch = launchOrigin.clone().add(new THREE.Vector3(0, TOKEN_HEIGHT * 1.6, 0));
@@ -6401,7 +6409,10 @@ export default function SnakeBoard3D({
     const impact = targetPos.clone().add(new THREE.Vector3(0, TOKEN_HEIGHT * 1.2, 0));
     const impactTop = impact.clone().add(new THREE.Vector3(0, CAPTURE_VERTICAL_STRIKE_LIFT, 0));
     const parkedTop = launch.clone().add(new THREE.Vector3(0, TOKEN_HEIGHT * 0.4, 0));
-    const attackerHolder = board.weaponDisplayGroup?.userData?.byPlayer?.get(captureEvent.attackerIndex) || null;
+    const attackerHolder =
+      board.weaponDisplayGroup?.userData?.holderByPlayerIndex?.get?.(captureEvent.attackerIndex) ||
+      board.weaponDisplayGroup?.userData?.byPlayer?.get?.(`seat-${captureEvent.attackerIndex}`) ||
+      null;
     if (attackerHolder) attackerHolder.visible = false;
 
     attacker.position.copy(startPos);

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -3266,7 +3266,10 @@ export default function SnakeAndLadder() {
         type: 'normal',
         color: playerColors[i] || '#fff',
         seatIndex: seatAssignments.get(i),
-        weaponType: CAPTURE_WEAPON_OPTIONS[(i + 1) % CAPTURE_WEAPON_OPTIONS.length]?.id || 'drone'
+        weaponType:
+          p.id === accountId
+            ? selectedCaptureWeaponId
+            : p.weaponType || CAPTURE_WEAPON_OPTIONS[(i + 1) % CAPTURE_WEAPON_OPTIONS.length]?.id || 'drone'
       }))
     : [
         {


### PR DESCRIPTION
### Motivation
- Players could not see or switch their parked capture weapons reliably during Snake & Ladder capture animations, causing inconsistent visuals compared to Ludo Battle Royal seated humans.
- The capture FX resolved parked weapons only by seat key which broke lookups when player indexing or multiplayer state diverged.

### Description
- Added a `holderByPlayerIndex` map in `updateSeatWeaponDisplays` and stored it on `board.weaponDisplayGroup.userData` so holders are addressable by `player.index` as well as by seat key in `byPlayer` (file: `webapp/src/components/SnakeBoard3D.jsx`).
- Updated capture animation logic to prefer the new player-index holder lookup and fall back to seat-key lookup when resolving `parkedHolder` and `attackerHolder` so launch/hide/restore target the correct parked object (file: `webapp/src/components/SnakeBoard3D.jsx`).
- Updated multiplayer player mapping so the local player’s selected capture weapon is used for the seated/parked weapon model (`selectedCaptureWeaponId` is applied to the local player entry) enabling visible switching in multiplayer (file: `webapp/src/pages/Games/SnakeAndLadder.jsx`).

### Testing
- Ran ESLint on the modified files with `npx eslint webapp/src/components/SnakeBoard3D.jsx webapp/src/pages/Games/SnakeAndLadder.jsx`, which completed but the files are ignored by the repo’s current ESLint patterns (warnings only).
- Ran the focused unit test `npm test -- snakeLobbyRoute.test.js --runInBand` and the suite passed: 1 test suite, 2 tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f07ae4c8a48329bac56957dbc074bc)