### PR TITLE
Fix Domino Royal seated avatars: per-chair skinned clones and position offsets

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -7,6 +7,7 @@ import { RGBELoader } from '/vendor/three/examples/jsm/loaders/RGBELoader.js';
 import { DRACOLoader } from '/vendor/three/examples/jsm/loaders/DRACOLoader.js';
 import { KTX2Loader } from '/vendor/three/examples/jsm/loaders/KTX2Loader.js';
 import { MeshoptDecoder } from '/vendor/three/examples/jsm/libs/meshopt_decoder.module.js';
+import { clone as cloneSkeleton } from '/vendor/three/examples/jsm/utils/SkeletonUtils.js';
 import './flag-emojis.js';
 
 const urlParams = new URLSearchParams(window.location.search);
@@ -986,8 +987,8 @@ const SEATED_HUMAN_BASE_HEIGHT = 1.74;
 const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.42;
 const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 4.7;
 const SEATED_HUMAN_SEAT_Y_OFFSET = -6.2 * MODEL_SCALE * STOOL_SCALE;
-const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.42;
-const SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET = -SEAT_DEPTH * 0.2;
+const SEATED_HUMAN_SEAT_Z_OFFSET = SEAT_DEPTH * 0.06;
+const SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET = SEAT_DEPTH * 0.08;
 const SEATED_HUMAN_FACING_Y = 0;
 const SEATED_HUMAN_FOOT_GROUND_CLEARANCE = -1.55 * MODEL_SCALE * STOOL_SCALE;
 const SEATED_HELPER_FORWARD_DICE_PICKUP = 0.092 * MODEL_SCALE;
@@ -8149,7 +8150,7 @@ async function attachSeatedHumanActors(token) {
         template = await loadSeatedHumanTemplate(DOMINO_HUMAN_CHARACTER_OPTIONS[0]);
       }
       if (!template || token !== chairBuildToken) return;
-      const actor = template.clone(true);
+      const actor = cloneSkeleton(template);
       const actorScale =
         template.userData?.seatedHumanScale ?? computeSeatedHumanScale(template);
       actor.scale.setScalar(actorScale);

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-04-27-domino-human-seating-v37';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-04-28-domino-human-seating-v38';
 
 export default function DominoRoyalArena() {
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- Human avatars were sharing a single skinned mesh instance and were positioned drifting toward the table center instead of sitting on each chair, so each seat needs an independent skinned clone and adjusted offsets to appear seated.

### Description
- Import `SkeletonUtils.clone` and use it to clone seated human templates so each chair receives an independent skinned avatar instance instead of a shared rig (`webapp/public/domino-royal-game.js`).
- Adjusted seated human local Z offsets (`SEATED_HUMAN_SEAT_Z_OFFSET` and `SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET`) so actors anchor onto chair seats instead of drifting inward toward the table center (`webapp/public/domino-royal-game.js`).
- Bumped the Domino Royal script version constant to `2026-04-28-domino-human-seating-v38` to force clients to fetch the updated runtime (`webapp/src/pages/Games/DominoRoyalArena.jsx`).

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` to validate the runtime file syntax and it completed without runtime syntax errors.
- Ran `npx eslint webapp/src/pages/Games/DominoRoyalArena.jsx` and observed the file is ignored by the repo ESLint config so no blocking lint errors were produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f06ab3e7608329939e59aeb75c7a29)