### PR TITLE
Sync Snake weapon swap with parked seat displays

### DIFF
--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -3252,22 +3252,40 @@ export default function SnakeAndLadder() {
 
   const playerHeadPreset = resolvedAppearance?.pawnHead?.preset ?? null;
   const playerHeadPresetId = resolvedAppearance?.pawnHead?.id ?? 'current';
+  const fallbackCaptureWeaponId = useCallback(
+    (orderIndex = 0) => {
+      if (!CAPTURE_WEAPON_OPTIONS.length) return 'drone';
+      const normalizedIndex = ((Math.trunc(orderIndex) % CAPTURE_WEAPON_OPTIONS.length) + CAPTURE_WEAPON_OPTIONS.length) %
+        CAPTURE_WEAPON_OPTIONS.length;
+      return CAPTURE_WEAPON_OPTIONS[normalizedIndex]?.id || 'drone';
+    },
+    []
+  );
   const selectedCaptureWeaponId =
     resolvedAppearance?.captureWeapon?.id &&
     isSnakeOptionUnlocked('captureWeapon', normalizeCaptureWeaponId(resolvedAppearance.captureWeapon.id), snakeInventory)
       ? normalizeCaptureWeaponId(resolvedAppearance.captureWeapon.id)
-      : CAPTURE_WEAPON_OPTIONS[0]?.id || 'missileJavelin';
+      : fallbackCaptureWeaponId(0);
 
   const players = isMultiplayer
-    ? mpPlayers.map((p, i) => ({
-        id: p.id,
-        position: p.position,
-        photoUrl: p.photoUrl || '/assets/icons/profile.svg',
-        type: 'normal',
-        color: playerColors[i] || '#fff',
-        seatIndex: seatAssignments.get(i),
-        weaponType: CAPTURE_WEAPON_OPTIONS[(i + 1) % CAPTURE_WEAPON_OPTIONS.length]?.id || 'drone'
-      }))
+    ? mpPlayers.map((p, i) => {
+        const seatIndex = seatAssignments.get(i);
+        const orderIndex = Number.isFinite(seatIndex) ? seatIndex + 1 : i + 1;
+        const isLocalPlayer =
+          accountId != null &&
+          p?.id != null &&
+          String(p.id) === String(accountId);
+        return {
+          id: p.id,
+          position: p.position,
+          photoUrl: p.photoUrl || '/assets/icons/profile.svg',
+          type: 'normal',
+          color: playerColors[i] || '#fff',
+          seatIndex,
+          // Keep local quick-swap weapon synced to parked display (same as Ludo-style behaviour).
+          weaponType: isLocalPlayer ? selectedCaptureWeaponId : fallbackCaptureWeaponId(orderIndex)
+        };
+      })
     : [
         {
           position: pos,
@@ -3286,7 +3304,7 @@ export default function SnakeAndLadder() {
           type: 'normal',
           color: playerColors[i + 1],
           seatIndex: i + 1,
-          weaponType: aiWeaponLoadout[i] || CAPTURE_WEAPON_OPTIONS[(i + 1) % CAPTURE_WEAPON_OPTIONS.length]?.id || 'drone',
+          weaponType: aiWeaponLoadout[i] || fallbackCaptureWeaponId(i + 1),
           tokenShape: aiTokenShapes[i] || TOKEN_SHAPE_OPTIONS[i % TOKEN_SHAPE_OPTIONS.length],
           headPreset: null,
           headPresetId: 'current'


### PR DESCRIPTION
### Motivation
- Players could not see their selected weapon in parked seat positions when switching in Snake & Ladder multiplayer, causing visual mismatch with Ludo Battle Royal behavior. 
- The goal is to make local quick-swap selection drive the in-scene `weaponType` used by parked/seat rendering so animations and parked weapons remain consistent with Ludo logic.

### Description
- Added a stable helper `fallbackCaptureWeaponId(orderIndex)` (React `useCallback`) to deterministically resolve seat/order-based fallback weapon ids and avoid out-of-range indexing. 
- Made the local multiplayer player's `weaponType` use the UI-selected `selectedCaptureWeaponId` so quick-swap updates are reflected in the parked weapon display. 
- Reused `fallbackCaptureWeaponId` for AI fallback assignment to keep consistent seat-based weapon selection. 
- Changed the player mapping logic in `webapp/src/pages/Games/SnakeAndLadder.jsx` to apply the above behavior for multiplayer and single-player cases.

### Testing
- Ran a production build with `npm --prefix webapp run build` and the build completed successfully with non-blocking warnings about duplicate package key and large chunk notices.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f07ae4c8a48329bac56957dbc074bc)