### PR TITLE
Improve human camera/pose handling and material setup for Pool Royale characters

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1944,6 +1944,10 @@ const HUMAN_DESIRED_SHOOT_DISTANCE = 1.06;
 const HUMAN_SHOOT_BLEND_THRESHOLD = 0.72; // enter shooting pose earlier when the cue camera starts getting lowered
 const HUMAN_WALK_RING_MARGIN = TABLE.WALL * 3.1; // keep player roots on a perimeter ring outside the table footprint
 const HUMAN_TABLE_BLOCKER_MARGIN = TABLE.WALL * 1.95; // collision helper margin so characters never cut through the table body
+const HUMAN_EYE_CAMERA_HEIGHT_OFFSET = 0.012; // lift first-person eye camera slightly above the eye joint to avoid brow clipping
+const HUMAN_EYE_CAMERA_FORWARD_OFFSET = 0.065; // nudge first-person eye camera forward so the face mesh stays out of frame
+const HUMAN_EYE_CAMERA_MIN_BLEND = 0.06; // only engage eye camera when cue view is noticeably lowered
+const HUMAN_EYE_CAMERA_SMOOTH = 0.48; // smooth eye-camera blending into the cue camera for portrait stability
 const HUMAN_WALK_PERIMETER_SPEED = Math.max(TABLE.W * 0.95, TABLE.H * 0.7); // world units per second when traversing the walk ring
 const HUMAN_WALK_EPS = 1e-5;
 const CUE_STRIKE_DURATION_MS = 260;
@@ -20383,6 +20387,52 @@ const shotPowerRef = useRef(0);
           return vec;
         };
 
+        const resolveActiveHumanEyePose = () => {
+          if (topViewRef.current || shootingRef.current || replayPlaybackRef.current) return null;
+          const cueBlend = THREE.MathUtils.clamp(cameraBlendRef.current ?? 1, 0, 1);
+          const cueBias = 1 - cueBlend;
+          if (cueBias <= HUMAN_EYE_CAMERA_MIN_BLEND) return null;
+          const hudState = hudRef.current;
+          const activeSeat = hudState?.turn === 1 ? 'B' : 'A';
+          const rigs = playerCharacterRigsRef.current;
+          if (!Array.isArray(rigs) || rigs.length === 0) return null;
+          const activeHuman = rigs.find((rig) => {
+            const seat = rig?.seat ?? rig?.anim?.seat;
+            return seat === activeSeat && rig?.human?.modelRoot;
+          })?.human;
+          if (!activeHuman?.modelRoot) return null;
+
+          activeHuman.modelRoot.updateMatrixWorld(true);
+          const headBone =
+            activeHuman.bones?.head ||
+            activeHuman.bones?.neck ||
+            activeHuman.model?.getObjectByName?.('Head') ||
+            activeHuman.modelRoot;
+          if (!headBone) return null;
+
+          const worldPos = headBone.getWorldPosition(new THREE.Vector3());
+          const worldForward = new THREE.Vector3(0, 0, 1)
+            .applyQuaternion(headBone.getWorldQuaternion(new THREE.Quaternion()))
+            .setY(0);
+          if (worldForward.lengthSq() < 1e-6) {
+            worldForward.set(Math.sin(activeHuman.yaw || 0), 0, Math.cos(activeHuman.yaw || 0));
+          } else {
+            worldForward.normalize();
+          }
+          const eyePos = worldPos
+            .clone()
+            .addScaledVector(UP, HUMAN_EYE_CAMERA_HEIGHT_OFFSET)
+            .addScaledVector(worldForward, HUMAN_EYE_CAMERA_FORWARD_OFFSET);
+          return {
+            blend: THREE.MathUtils.clamp(
+              (cueBias - HUMAN_EYE_CAMERA_MIN_BLEND) / (1 - HUMAN_EYE_CAMERA_MIN_BLEND),
+              0,
+              1
+            ),
+            position: eyePos
+          };
+        };
+
 
         const updateBroadcastCameras = ({
           railDir = 1,
@@ -21606,6 +21656,17 @@ const shotPowerRef = useRef(0);
               TMP_SPH.radius = sph.radius;
               TMP_SPH.phi = sph.phi;
               syncBlendToSpherical();
+            }
+          }
+          const humanEyePose = resolveActiveHumanEyePose();
+          if (humanEyePose) {
+            const lerpT = THREE.MathUtils.clamp(
+              humanEyePose.blend * HUMAN_EYE_CAMERA_SMOOTH,
+              0,
+              1
+            );
+            if (lerpT > 1e-4) {
+              camera.position.lerp(humanEyePose.position, lerpT);
             }
           }
           camera.lookAt(lookTarget);
@@ -24765,6 +24826,33 @@ const shotPowerRef = useRef(0);
               edgeMargin: HUMAN_EDGE_MARGIN,
               desiredShootDistance: HUMAN_DESIRED_SHOOT_DISTANCE
             }).setY(floorY);
+            const perimeterGoal = clampToWalkPerimeter(desiredRoot);
+            if (isInsideTableBlocker(perimeterGoal)) {
+              perimeterGoal.copy(clampToWalkPerimeter(perimeterGoal));
+            }
+            const currentRoot =
+              human.root?.position?.clone?.() ??
+              rig.humanPerimeterPoint?.clone?.() ??
+              perimeterGoal.clone();
+            if (!Number.isFinite(rig.humanWalkPerimeterT)) {
+              rig.humanWalkPerimeterT = pointToPerimeterT(currentRoot);
+            }
+            const targetPerimeterT = pointToPerimeterT(perimeterGoal);
+            const humanLoopDelta =
+              THREE.MathUtils.euclideanModulo(targetPerimeterT - rig.humanWalkPerimeterT + 0.5, 1) - 0.5;
+            const humanMaxStepT =
+              (HUMAN_WALK_PERIMETER_SPEED * Math.max(dtSeconds, 1 / 240)) /
+              (4 * (walkHalfX + walkHalfZ));
+            rig.humanWalkPerimeterT = THREE.MathUtils.euclideanModulo(
+              rig.humanWalkPerimeterT + THREE.MathUtils.clamp(humanLoopDelta, -humanMaxStepT, humanMaxStepT),
+              1
+            );
+            const perimeterRoot = perimeterTToPoint(rig.humanWalkPerimeterT);
+            if (isInsideTableBlocker(perimeterRoot)) {
+              perimeterRoot.copy(clampToWalkPerimeter(perimeterRoot));
+              rig.humanWalkPerimeterT = pointToPerimeterT(perimeterRoot);
+            }
+            rig.humanPerimeterPoint = perimeterRoot.clone();
             const state =
               mode === 'strike' ? 'striking' : mode === 'aim' ? 'dragging' : 'idle';
             const draggingPower = Math.max(0, Math.min(1, powerRef.current ?? 0));
@@ -24800,15 +24888,15 @@ const shotPowerRef = useRef(0);
               .add(new THREE.Vector3(0, 0.024, 0));
             const gripTarget = cueTip.clone().lerp(cueBack, 0.82);
             const standingYaw = Math.atan2(-aimForward.x, -aimForward.z);
-            const idleRight = desiredRoot
+            const idleRight = perimeterRoot
               .clone()
               .add(new THREE.Vector3(0.24, 1.1, 0.02).applyAxisAngle(new THREE.Vector3(0, 1, 0), standingYaw));
-            const idleLeft = desiredRoot
+            const idleLeft = perimeterRoot
               .clone()
               .add(new THREE.Vector3(-0.18, 1.08, 0.03).applyAxisAngle(new THREE.Vector3(0, 1, 0), standingYaw));
             updateBilardoHumanPose(human, dtSeconds, {
               state,
-              rootTarget: desiredRoot,
+              rootTarget: perimeterRoot,
               aimForward,
               bridgeTarget,
               gripTarget,

--- a/webapp/src/pages/Games/shared/bilardoHumanRig.js
+++ b/webapp/src/pages/Games/shared/bilardoHumanRig.js
@@ -185,11 +185,36 @@ export function createBilardoHumanRig(scene, opts = {}) {
             : [];
         mats.forEach((m) => {
           if (!m) return;
+          if (m.color) m.color.setScalar(1);
           if (m.map) {
             m.map.colorSpace = THREE.SRGBColorSpace;
             if (textureAnisotropy != null) m.map.anisotropy = textureAnisotropy;
             m.map.needsUpdate = true;
           }
+          if (m.emissiveMap) {
+            m.emissiveMap.colorSpace = THREE.SRGBColorSpace;
+            if (textureAnisotropy != null) m.emissiveMap.anisotropy = textureAnisotropy;
+            m.emissiveMap.needsUpdate = true;
+          }
+          if (m.normalMap && textureAnisotropy != null) {
+            m.normalMap.anisotropy = textureAnisotropy;
+            m.normalMap.needsUpdate = true;
+          }
+          if (m.roughnessMap && textureAnisotropy != null) {
+            m.roughnessMap.anisotropy = textureAnisotropy;
+            m.roughnessMap.needsUpdate = true;
+          }
+          if (m.metalnessMap && textureAnisotropy != null) {
+            m.metalnessMap.anisotropy = textureAnisotropy;
+            m.metalnessMap.needsUpdate = true;
+          }
+          if (m.emissiveIntensity != null) {
+            m.emissiveIntensity = Math.max(0.35, m.emissiveIntensity);
+          }
+          m.side = THREE.DoubleSide;
+          m.depthWrite = true;
+          if (m.roughness != null) m.roughness = Math.min(m.roughness, 0.9);
+          if (m.metalness != null) m.metalness = Math.min(m.metalness, 0.2);
           m.needsUpdate = true;
         });
       });


### PR DESCRIPTION
### Motivation
- Reduce face/brow clipping and improve portrait stability when the cue camera lowers by blending a lightweight first-person eye camera into the cue camera. 
- Keep human characters routed around the table perimeter and out of table blockers so poses and idle offsets remain stable in Pool Royale. 
- Ensure imported avatar materials render consistently across devices by normalizing texture color spaces, anisotropy, and key material properties.

### Description
- Added first-person eye-camera offsets, minimum blend threshold, and smoothing constants (`HUMAN_EYE_CAMERA_HEIGHT_OFFSET`, `HUMAN_EYE_CAMERA_FORWARD_OFFSET`, `HUMAN_EYE_CAMERA_MIN_BLEND`, `HUMAN_EYE_CAMERA_SMOOTH`) and implemented `resolveActiveHumanEyePose()` to compute an eye pose for the active human rig. 
- Integrated the eye-camera pose into the broadcast/camera update to lerp the camera position toward the computed eye position when the cue view is lowered. 
- Introduced perimeter walking/clamping logic for human rigs: compute `perimeterGoal`, clamp against table blockers, maintain `humanWalkPerimeterT` and step it smoothly toward the target, and use the resulting `perimeterRoot` as the human `rootTarget` and idle offsets. 
- Updated pose/update flow to use `perimeterRoot` for `idleRight`/`idleLeft` offsets and for `rootTarget` so characters stay outside the table footprint while shooting/aiming. 
- Hardened model material setup in `bilardoHumanRig.js` by resetting `m.color` to unity, forcing sRGB for `map` and `emissiveMap`, setting anisotropy for `map`, `emissiveMap`, `normalMap`, `roughnessMap`, and `metalnessMap` when available, enforcing a minimum `emissiveIntensity`, setting `side` to `THREE.DoubleSide` and `depthWrite = true`, and clamping `roughness` and `metalness` to sane ranges.

### Testing
- Ran the frontend automated unit test suite and linter on the modified codebase and they passed. 
- Performed a local development build and launched the app to verify camera transitions and avatar rendering with no runtime errors reported in the console.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f077ebb1108329a357860321b6d695)