### PR TITLE
Add human eye-camera blending, walk-perimeter movement, and avatar material hardening

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1944,6 +1944,10 @@ const HUMAN_DESIRED_SHOOT_DISTANCE = 1.06;
 const HUMAN_SHOOT_BLEND_THRESHOLD = 0.72; // enter shooting pose earlier when the cue camera starts getting lowered
 const HUMAN_WALK_RING_MARGIN = TABLE.WALL * 3.1; // keep player roots on a perimeter ring outside the table footprint
 const HUMAN_TABLE_BLOCKER_MARGIN = TABLE.WALL * 1.95; // collision helper margin so characters never cut through the table body
+const HUMAN_EYE_CAMERA_HEIGHT_OFFSET = 0.012; // lift first-person eye camera slightly above the eye joint to avoid brow clipping
+const HUMAN_EYE_CAMERA_FORWARD_OFFSET = 0.065; // nudge first-person eye camera forward so the face mesh stays out of frame
+const HUMAN_EYE_CAMERA_MIN_BLEND = 0.06; // only engage eye camera when cue view is noticeably lowered
+const HUMAN_EYE_CAMERA_SMOOTH = 0.48; // smooth eye-camera blending into the cue camera for portrait stability
 const HUMAN_WALK_PERIMETER_SPEED = Math.max(TABLE.W * 0.95, TABLE.H * 0.7); // world units per second when traversing the walk ring
 const HUMAN_WALK_EPS = 1e-5;
 const CUE_STRIKE_DURATION_MS = 260;
@@ -20383,6 +20387,69 @@ const shotPowerRef = useRef(0);
           return vec;
         };
 
+        const resolveActiveHumanEyePose = () => {
+          if (topViewRef.current || shootingRef.current || replayPlaybackRef.current) return null;
+          const cueBlend = THREE.MathUtils.clamp(cameraBlendRef.current ?? 1, 0, 1);
+          const cueBias = 1 - cueBlend;
+          if (cueBias <= HUMAN_EYE_CAMERA_MIN_BLEND) return null;
+          const hudState = hudRef.current;
+          const activeSeat = hudState?.turn === 1 ? 'B' : 'A';
+          const rigs = playerCharacterRigsRef.current;
+          if (!Array.isArray(rigs) || rigs.length === 0) return null;
+          const activeHuman = rigs.find((rig) => {
+            const seat = rig?.seat ?? rig?.anim?.seat;
+            return seat === activeSeat && rig?.human?.modelRoot;
+          })?.human;
+          if (!activeHuman?.modelRoot) return null;
+
+          activeHuman.modelRoot.updateMatrixWorld(true);
+          const headBone =
+            activeHuman.bones?.head ||
+            activeHuman.bones?.neck ||
+            activeHuman.model?.getObjectByName?.('Head') ||
+            activeHuman.modelRoot;
+          if (!headBone) return null;
+
+          const worldPos = headBone.getWorldPosition(new THREE.Vector3());
+          const cueBall = cueRef.current;
+          const aim2 = aimDirRef.current;
+          const hasAim2 =
+            cueBall?.pos &&
+            aim2 &&
+            Number.isFinite(aim2.x) &&
+            Number.isFinite(aim2.y) &&
+            aim2.lengthSq?.() > 1e-6;
+          const cueWorld = hasAim2
+            ? new THREE.Vector3(cueBall.pos.x, worldPos.y, cueBall.pos.y)
+            : null;
+          const worldForward = hasAim2
+            ? new THREE.Vector3(aim2.x, 0, aim2.y).normalize()
+            : cueWorld
+              ? cueWorld.clone().sub(worldPos).setY(0).normalize()
+              : new THREE.Vector3(Math.sin(activeHuman.yaw || 0), 0, Math.cos(activeHuman.yaw || 0));
+          if (!Number.isFinite(worldForward.x) || !Number.isFinite(worldForward.z) || worldForward.lengthSq() < 1e-6) {
+            worldForward.set(Math.sin(activeHuman.yaw || 0), 0, Math.cos(activeHuman.yaw || 0));
+          }
+          worldForward.normalize();
+          const eyePos = worldPos
+            .clone()
+            .addScaledVector(UP, HUMAN_EYE_CAMERA_HEIGHT_OFFSET)
+            .addScaledVector(worldForward, HUMAN_EYE_CAMERA_FORWARD_OFFSET);
+          const eyeTarget = cueWorld
+            ? cueWorld.clone().addScaledVector(worldForward, BALL_R * 6)
+            : eyePos.clone().addScaledVector(worldForward, BALL_R * 16);
+          eyeTarget.y = Math.max(TABLE_Y + TABLE.THICK + BALL_R, eyePos.y - BALL_R * 0.2);
+          return {
+            blend: THREE.MathUtils.clamp(
+              (cueBias - HUMAN_EYE_CAMERA_MIN_BLEND) / (1 - HUMAN_EYE_CAMERA_MIN_BLEND),
+              0,
+              1
+            ),
+            position: eyePos,
+            target: eyeTarget
+          };
+        };
+
 
         const updateBroadcastCameras = ({
           railDir = 1,
@@ -21606,6 +21673,20 @@ const shotPowerRef = useRef(0);
               TMP_SPH.radius = sph.radius;
               TMP_SPH.phi = sph.phi;
               syncBlendToSpherical();
+            }
+          }
+          const humanEyePose = resolveActiveHumanEyePose();
+          if (humanEyePose) {
+            const lerpT = THREE.MathUtils.clamp(
+              humanEyePose.blend * HUMAN_EYE_CAMERA_SMOOTH,
+              0,
+              1
+            );
+            if (lerpT > 1e-4) {
+              camera.position.lerp(humanEyePose.position, lerpT);
+              lookTarget = lookTarget
+                ? lookTarget.clone().lerp(humanEyePose.target, lerpT)
+                : humanEyePose.target.clone();
             }
           }
           camera.lookAt(lookTarget);
@@ -24765,6 +24846,21 @@ const shotPowerRef = useRef(0);
               edgeMargin: HUMAN_EDGE_MARGIN,
               desiredShootDistance: HUMAN_DESIRED_SHOOT_DISTANCE
             }).setY(floorY);
+            const perimeterRoot = clampToWalkPerimeter(desiredRoot);
+            if (isInsideTableBlocker(perimeterRoot)) {
+              perimeterRoot.copy(clampToWalkPerimeter(perimeterRoot));
+            }
+            if (!Number.isFinite(rig.walkPerimeterT)) {
+              rig.walkPerimeterT = pointToPerimeterT(human.root.position);
+            }
+            const targetT = pointToPerimeterT(perimeterRoot);
+            const loopDelta = THREE.MathUtils.euclideanModulo(targetT - rig.walkPerimeterT + 0.5, 1) - 0.5;
+            const maxStepT =
+              (HUMAN_WALK_PERIMETER_SPEED * Math.max(dtSeconds, 1 / 240)) /
+              (4 * (walkHalfX + walkHalfZ));
+            const stepT = THREE.MathUtils.clamp(loopDelta, -maxStepT, maxStepT);
+            rig.walkPerimeterT = THREE.MathUtils.euclideanModulo(rig.walkPerimeterT + stepT, 1);
+            const walkPerimeterRoot = perimeterTToPoint(rig.walkPerimeterT);
             const state =
               mode === 'strike' ? 'striking' : mode === 'aim' ? 'dragging' : 'idle';
             const draggingPower = Math.max(0, Math.min(1, powerRef.current ?? 0));
@@ -24800,15 +24896,15 @@ const shotPowerRef = useRef(0);
               .add(new THREE.Vector3(0, 0.024, 0));
             const gripTarget = cueTip.clone().lerp(cueBack, 0.82);
             const standingYaw = Math.atan2(-aimForward.x, -aimForward.z);
-            const idleRight = desiredRoot
+            const idleRight = walkPerimeterRoot
               .clone()
               .add(new THREE.Vector3(0.24, 1.1, 0.02).applyAxisAngle(new THREE.Vector3(0, 1, 0), standingYaw));
-            const idleLeft = desiredRoot
+            const idleLeft = walkPerimeterRoot
               .clone()
               .add(new THREE.Vector3(-0.18, 1.08, 0.03).applyAxisAngle(new THREE.Vector3(0, 1, 0), standingYaw));
             updateBilardoHumanPose(human, dtSeconds, {
               state,
-              rootTarget: desiredRoot,
+              rootTarget: walkPerimeterRoot,
               aimForward,
               bridgeTarget,
               gripTarget,

--- a/webapp/src/pages/Games/shared/bilardoHumanRig.js
+++ b/webapp/src/pages/Games/shared/bilardoHumanRig.js
@@ -185,11 +185,22 @@ export function createBilardoHumanRig(scene, opts = {}) {
             : [];
         mats.forEach((m) => {
           if (!m) return;
+          if (m.color) m.color.setRGB(1, 1, 1);
           if (m.map) {
             m.map.colorSpace = THREE.SRGBColorSpace;
             if (textureAnisotropy != null) m.map.anisotropy = textureAnisotropy;
             m.map.needsUpdate = true;
           }
+          if (m.emissiveMap) {
+            m.emissiveMap.colorSpace = THREE.SRGBColorSpace;
+            if (textureAnisotropy != null) m.emissiveMap.anisotropy = textureAnisotropy;
+            m.emissiveMap.needsUpdate = true;
+          }
+          if (m.side !== THREE.DoubleSide) m.side = THREE.DoubleSide;
+          if (typeof m.depthWrite === 'boolean') m.depthWrite = true;
+          if (typeof m.alphaTest === 'number' && m.alphaTest > 0.08) m.alphaTest = 0.08;
+          if (m.roughness != null) m.roughness = Math.min(m.roughness, 0.95);
+          if (m.metalness != null) m.metalness = Math.min(m.metalness, 0.25);
           m.needsUpdate = true;
         });
       });


### PR DESCRIPTION
### Motivation
- Improve first-person cue view stability by slightly offsetting and blending an eye-centered camera to avoid face clipping during lowered cue camera states.
- Make NPC/player placement around the table more stable by clamping and smoothly moving characters along a walk-perimeter instead of snapping to desired table edges.
- Harden loaded avatar materials to produce more predictable visuals across models and platforms.

### Description
- Introduce new constants for eye-camera offsets and blending (`HUMAN_EYE_CAMERA_HEIGHT_OFFSET`, `HUMAN_EYE_CAMERA_FORWARD_OFFSET`, `HUMAN_EYE_CAMERA_MIN_BLEND`, `HUMAN_EYE_CAMERA_SMOOTH`) and use them to compute a blended first-person eye pose.
- Add `resolveActiveHumanEyePose()` to compute an eye position and target from the active human’s head bone and cue/aim direction, and blend it into `updateBroadcastCameras()` to nudge the camera and look target when appropriate.
- Implement walk-perimeter logic for human rigs by clamping desired roots to the perimeter, initializing and advancing `rig.walkPerimeterT` using `pointToPerimeterT`/`perimeterTToPoint`, and using the computed `walkPerimeterRoot` as the pose `rootTarget` for pose updates.
- Update idle offsets to use the perimeter root and ensure characters respect a table-blocker margin.
- Harden avatar materials in `bilardoHumanRig.js` by forcing neutral/albedo color, setting texture color spaces and anisotropy, marking double-sided geometry, enforcing `depthWrite`, clamping `alphaTest`, and limiting `roughness`/`metalness`, plus ensuring `needsUpdate` on modified materials.

### Testing
- Ran the project linter via `yarn lint` with no new lint errors reported.
- Executed the test suite via `yarn test`, and unit tests passed on the modified modules.
- Verified a development build started successfully and the camera/character behavior changes do not produce runtime errors in local smoke tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f077ebb1108329a357860321b6d695)