### PR TITLE
Adjust Ludo parked weapon spacing and firearm orientations

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -244,9 +244,33 @@ const FIREARM_RACK_PARKING_TUNING = Object.freeze({
   }),
   // Long guns stay on the wider octagon rail zones (red long markings in reference shots).
   large: Object.freeze({
-    side: 0.308,
-    inward: -0.022,
-    outward: 0.162
+    side: 0.326,
+    inward: -0.03,
+    outward: 0.184
+  })
+});
+const FIREARM_RACK_DISPLAY_TUNING_BY_ID = Object.freeze({
+  ak47VolleyAttack: Object.freeze({
+    // Keep AK flatter and aimed more straight across the rail (not into board center).
+    position: [0.086, 0, -0.016],
+    rotation: [-Math.PI * 0.5, Math.PI * 0.54, 0]
+  }),
+  shotgunBlastAttack: Object.freeze({
+    // Keep shotgun laid flat with the same rack height profile as AK.
+    position: [0.086, 0, -0.016],
+    rotation: [-Math.PI * 0.5, Math.PI * 0.1, 0]
+  }),
+  polyShotgun01Attack: Object.freeze({
+    position: [0.086, 0, -0.016],
+    rotation: [-Math.PI * 0.5, Math.PI * 0.12, 0]
+  }),
+  polyShotgun02Attack: Object.freeze({
+    position: [0.086, 0, -0.016],
+    rotation: [-Math.PI * 0.5, Math.PI * 0.12, 0]
+  }),
+  polyShotgun03Attack: Object.freeze({
+    position: [0.086, 0, -0.016],
+    rotation: [-Math.PI * 0.5, Math.PI * 0.12, 0]
   })
 });
 const FIREARM_RACK_PARKING_SEAT_ADJUSTMENTS = Object.freeze([
@@ -1122,6 +1146,9 @@ async function applyCaptureWeaponDisplay(entry, captureAnimationId) {
   const displayTuning = LARGE_RACK_FIREARM_IDS.has(captureAnimationId)
     ? FIREARM_RACK_DISPLAY_TUNING.large
     : FIREARM_RACK_DISPLAY_TUNING.default;
+  const perWeaponDisplayTuning = FIREARM_RACK_DISPLAY_TUNING_BY_ID[captureAnimationId] || null;
+  const rackPosition = perWeaponDisplayTuning?.position ?? displayTuning.position;
+  const rackRotation = perWeaponDisplayTuning?.rotation ?? displayTuning.rotation;
   const weaponRackScaleMultiplier = FIREARM_RACK_SIZE_MULTIPLIER_BY_ID[captureAnimationId] ?? 1;
   fitObjectToTargetSize(
     clone,
@@ -1130,10 +1157,10 @@ async function applyCaptureWeaponDisplay(entry, captureAnimationId) {
   if (!LARGE_RACK_FIREARM_IDS.has(captureAnimationId)) {
     clone.position.y = baseAlignPositionY;
   }
-  clone.position.x += displayTuning.position[0];
-  clone.position.y += displayTuning.position[1];
-  clone.position.z += displayTuning.position[2];
-  clone.rotation.set(...displayTuning.rotation);
+  clone.position.x += rackPosition[0];
+  clone.position.y += rackPosition[1];
+  clone.position.z += rackPosition[2];
+  clone.rotation.set(...rackRotation);
   entry.weaponHolder.add(clone);
 }
 


### PR DESCRIPTION
### Motivation
- Parked weapons on the Ludo table need to sit slightly farther from player tokens and the board edge so they read clearer on portrait screens.
- AK-47 and shotgun-family captures should present laid-flat and aligned similarly (AK as reference) so visuals are consistent and the AK no longer points into the board center.

### Description
- Tweaked `FIREARM_RACK_PARKING_TUNING.large` values to move long-gun racks a bit farther from the token and outward from the board in `webapp/src/pages/Games/LudoBattleRoyal.jsx`.
- Added `FIREARM_RACK_DISPLAY_TUNING_BY_ID` with per-weapon `position`/`rotation` overrides for `ak47VolleyAttack`, `shotgunBlastAttack` and `polyShotgun0[1-3]Attack` to force flat/table-aligned poses and make AK point more straight across the rail.
- Wired the per-weapon override into `applyCaptureWeaponDisplay` by selecting `rackPosition`/`rackRotation` (falling back to existing display tuning) before placing the cloned weapon model.

### Testing
- Ran `npx eslint webapp/src/pages/Games/LudoBattleRoyal.jsx`, which executed but reported the file is ignored by workspace lint ignore rules in this environment (no errors from the change).
- Ran `npm test -- --runInBand test/inventoryCrossGameConfig.test.js`, which failed in the current CI-like environment due to an existing Jest/ESM parsing issue with `three` addon imports unrelated to this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f09407b32483298c6264cfeee5c6a0)