### PR TITLE
Adjust Ludo Battle Royal weapon rack spacing and firearm orientation

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -127,7 +127,7 @@ const CAPTURE_PARK_OUTWARD_OFFSET_BY_TYPE = Object.freeze({
   firearmRack: 0.044
 });
 // Lift parked capture vehicles slightly so they read a bit higher on portrait screens.
-const CAPTURE_PARKED_LIFT_OFFSET_Y = 0.008;
+const CAPTURE_PARKED_LIFT_OFFSET_Y = 0.01;
 const CAPTURE_PARK_SCALE_BY_TYPE = Object.freeze({
   fighter: 1.4 * 1.2,
   helicopter: 1.2 * 1.2,
@@ -232,7 +232,7 @@ const FIREARM_RACK_DISPLAY_TUNING = Object.freeze({
   large: Object.freeze({
     targetSizeMultiplier: 1.9,
     position: [0.086, 0, -0.016],
-    rotation: [-Math.PI * 0.5, Math.PI * 0.02, 0]
+    rotation: [-Math.PI * 0.5, Math.PI * 0.5, 0]
   })
 });
 const FIREARM_RACK_PARKING_TUNING = Object.freeze({
@@ -244,16 +244,16 @@ const FIREARM_RACK_PARKING_TUNING = Object.freeze({
   }),
   // Long guns stay on the wider octagon rail zones (red long markings in reference shots).
   large: Object.freeze({
-    side: 0.308,
-    inward: -0.022,
-    outward: 0.162
+    side: 0.334,
+    inward: -0.03,
+    outward: 0.194
   })
 });
 const FIREARM_RACK_PARKING_SEAT_ADJUSTMENTS = Object.freeze([
-  Object.freeze({ side: 0.012, inward: -0.008 }), // bottom
-  Object.freeze({ side: 0.008, inward: 0.004 }), // right
-  Object.freeze({ side: -0.012, inward: -0.008 }), // top
-  Object.freeze({ side: -0.008, inward: 0.004 }) // left
+  Object.freeze({ side: 0.018, inward: -0.012 }), // bottom
+  Object.freeze({ side: 0.014, inward: 0.002 }), // right
+  Object.freeze({ side: -0.018, inward: -0.012 }), // top
+  Object.freeze({ side: -0.014, inward: 0.002 }) // left
 ]);
 const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   mrtkGunAttack: {


### PR DESCRIPTION
### Motivation
- Parked weapons on the Ludo Battle Royal table needed to be visually farther from player tokens and the board to avoid overlap and improve readability.  
- Long guns and shotguns should lie flat on the table in the same orientation style as the AK47 instead of appearing angled or upright.  
- Parked weapons should sit at a consistent visible height so their tops/readability match the AK47 placement on portrait screens.

### Description
- Increased `CAPTURE_PARKED_LIFT_OFFSET_Y` from `0.008` to `0.01` so parked racks sit slightly higher on the table.  
- Updated `FIREARM_RACK_DISPLAY_TUNING.large.rotation` to align large-rack weapons flat with the AK-style table orientation (`Math.PI * 0.02` → `Math.PI * 0.5`).  
- Moved long-gun parking farther from tokens/board by adjusting `FIREARM_RACK_PARKING_TUNING.large` offsets (`side`, `inward`, `outward` updated).  
- Tuned `FIREARM_RACK_PARKING_SEAT_ADJUSTMENTS` per seat so seat-specific side and inward offsets provide more consistent spacing around all four player positions.

### Testing
- Ran `npm --prefix webapp run build` and the build completed successfully.  
- Vite emitted existing non-blocking warnings (duplicate dependency key and large chunk warnings) which did not block the build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f09407b32483298c6264cfeee5c6a0)