### PR TITLE
Fix Chess Battle Royal weapon swaps from owned inventory

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -7662,13 +7662,18 @@ function Chess3D({
   useEffect(() => {
     setSelectedCaptureAnimationId(inventoryCaptureAnimationId);
   }, [inventoryCaptureAnimationId]);
-  const ownedCaptureAnimations = useMemo(
-    () =>
-      (chessInventory?.captureAnimation || [])
-        .map((optionId) => CAPTURE_ANIMATION_OPTIONS.find((option) => option.id === optionId))
-        .filter(Boolean),
-    [chessInventory]
-  );
+  const ownedCaptureAnimations = useMemo(() => {
+    const ownedIds = Array.isArray(chessInventory?.captureAnimation) ? chessInventory.captureAnimation : [];
+    const uniqueIds = Array.from(new Set(ownedIds.filter(Boolean)));
+    const ownedOptions = uniqueIds
+      .map((optionId) => CAPTURE_ANIMATION_OPTIONS.find((option) => option.id === optionId))
+      .filter(Boolean);
+    if (ownedOptions.length > 0) return ownedOptions;
+    const fallback =
+      CAPTURE_ANIMATION_OPTIONS.find((option) => option.id === selectedCaptureAnimationId) ||
+      CAPTURE_ANIMATION_OPTIONS[0];
+    return fallback ? [fallback] : [];
+  }, [chessInventory, selectedCaptureAnimationId]);
   const selectedCaptureKind = useMemo(() => {
     const vehicleKind = resolveVehicleCaptureKind(selectedCaptureAnimationId);
     if (vehicleKind) return vehicleKind;
@@ -14030,6 +14035,11 @@ function Chess3D({
                       </button>
                     );
                   })}
+                  {ownedCaptureAnimations.length === 0 && (
+                    <p className="rounded-lg border border-white/10 bg-white/5 px-2 py-2 text-[0.62rem] text-white/65">
+                      No weapons found in inventory yet.
+                    </p>
+                  )}
                 </div>
               </div>
             )}
@@ -14192,6 +14202,53 @@ function Chess3D({
                         </div>
                       </div>
                     )}
+                  </div>
+                </div>
+                <div className="rounded-xl border border-white/10 bg-white/5 p-3">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="text-[10px] uppercase tracking-[0.35em] text-white/70">Capture Weapon</p>
+                      <p className="mt-1 text-[0.7rem] text-white/60">
+                        Pick any weapon you own from inventory.
+                      </p>
+                    </div>
+                    <span className="rounded-lg border border-white/15 px-2 py-1 text-[0.6rem] font-semibold uppercase tracking-[0.12em] text-white/70">
+                      {ownedCaptureAnimations.length} owned
+                    </span>
+                  </div>
+                  <div className="mt-3 grid gap-2">
+                    {ownedCaptureAnimations.map((option) => {
+                      const isSelected = option.id === selectedCaptureAnimationId;
+                      return (
+                        <button
+                          key={`menu-weapon-${option.id}`}
+                          type="button"
+                          onClick={() => handleCaptureAnimationSwap(option.id)}
+                          className={`flex items-center gap-2 rounded-xl border p-2 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
+                            isSelected
+                              ? 'border-emerald-300/80 bg-emerald-300/15'
+                              : 'border-white/10 bg-white/5 hover:border-white/30'
+                          }`}
+                        >
+                          {option.thumbnail ? (
+                            <img
+                              src={option.thumbnail}
+                              alt={option.label}
+                              className="h-9 w-9 rounded-md object-cover"
+                              loading="lazy"
+                            />
+                          ) : (
+                            <span className="flex h-9 w-9 items-center justify-center rounded-md border border-white/20 bg-white/10 text-base">
+                              🧰
+                            </span>
+                          )}
+                          <span className="min-w-0 flex-1">
+                            <span className="block truncate text-[0.68rem] font-semibold text-white">{option.label}</span>
+                            <span className="block truncate text-[0.58rem] text-white/60">{option.description}</span>
+                          </span>
+                        </button>
+                      );
+                    })}
                   </div>
                 </div>
                 <div className="mt-3 space-y-3 rounded-xl border border-white/10 bg-white/5 p-3">


### PR DESCRIPTION
### Motivation
- Players could not reliably change capture weapons even when items existed in their inventory due to sparse/duplicated inventory data and lack of fallbacks in the UI.
- The quick-swap drawer and in-menu weapon selection needed to be driven from the same owned-inventory source so both entry points behave predictably.

### Description
- Hardened the owned-weapon resolution in `ChessBattleRoyal` by replacing the simple mapping with a `useMemo` that dedupes owned IDs, resolves them to option objects, and falls back to the currently selected or default capture animation when inventory is empty or malformed.
- Kept quick-swap behavior synchronized with the owned inventory and added a small fallback message when no weapons are available in the quick-swap drawer.
- Added a new “Capture Weapon” section inside the in-game settings menu so users can pick any owned weapon from the full menu (not only via the side quick-swap control).
- Changed file: `webapp/src/pages/Games/ChessBattleRoyal.jsx` (UI + inventory resolution logic updates).

### Testing
- Ran a production build with `cd webapp && npm run -s build`, which completed successfully (build artifacts updated); existing non-blocking warnings about duplicate package key and chunk sizing remained and are unchanged by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0983cec9c8329b8409c38971182bd)