### PR TITLE
Improve Pool Royale human pose/camera and tighten avatar material handling

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1940,10 +1940,14 @@ const HUMAN_POSE_LAMBDA = 9.0;
 const HUMAN_MOVE_LAMBDA = 5.6;
 const HUMAN_ROT_LAMBDA = 8.5;
 const HUMAN_EDGE_MARGIN = 0.58;
-const HUMAN_DESIRED_SHOOT_DISTANCE = 1.06;
+const HUMAN_DESIRED_SHOOT_DISTANCE = 1.42; // keep the shooter farther back on the cue butt side instead of drifting over the shaft
 const HUMAN_SHOOT_BLEND_THRESHOLD = 0.72; // enter shooting pose earlier when the cue camera starts getting lowered
 const HUMAN_WALK_RING_MARGIN = TABLE.WALL * 3.1; // keep player roots on a perimeter ring outside the table footprint
 const HUMAN_TABLE_BLOCKER_MARGIN = TABLE.WALL * 1.95; // collision helper margin so characters never cut through the table body
+const HUMAN_EYE_CAMERA_HEIGHT_OFFSET = 0.09; // lift camera above cue butt so table stays visible in portrait cue view
+const HUMAN_EYE_CAMERA_FORWARD_OFFSET = 0.1; // pull camera slightly backward along cue axis before looking down-table
+const HUMAN_EYE_CAMERA_MIN_BLEND = 0.06; // only engage eye camera when cue view is noticeably lowered
+const HUMAN_EYE_CAMERA_SMOOTH = 0.48; // smooth eye-camera blending into the cue camera for portrait stability
 const HUMAN_WALK_PERIMETER_SPEED = Math.max(TABLE.W * 0.95, TABLE.H * 0.7); // world units per second when traversing the walk ring
 const HUMAN_WALK_EPS = 1e-5;
 const CUE_STRIKE_DURATION_MS = 260;
@@ -15292,6 +15296,7 @@ function PoolRoyaleGame({
   const decorativeTablesRef = useRef([]);
   const hospitalityGroupsRef = useRef([]);
   const playerCharacterRigsRef = useRef([]);
+  const activeHumanCueViewRef = useRef(null);
   const characterShotStartedAtRef = useRef(0);
   const characterShotShooterRef = useRef('A');
   const hospitalityLayoutRunRef = useRef(null);
@@ -20383,6 +20388,35 @@ const shotPowerRef = useRef(0);
           return vec;
         };
 
+        const resolveActiveHumanEyePose = () => {
+          if (topViewRef.current || shootingRef.current || replayPlaybackRef.current) return null;
+          const cueBlend = THREE.MathUtils.clamp(cameraBlendRef.current ?? 1, 0, 1);
+          const cueBias = 1 - cueBlend;
+          if (cueBias <= HUMAN_EYE_CAMERA_MIN_BLEND) return null;
+          const cuePose = activeHumanCueViewRef.current;
+          if (!cuePose?.cueBack || !cuePose?.bridgeTarget || !cuePose?.aimForward || !cuePose?.side) {
+            return null;
+          }
+          const eyePos = cuePose.cueBack
+            .clone()
+            .addScaledVector(cuePose.aimForward, -HUMAN_EYE_CAMERA_FORWARD_OFFSET)
+            .addScaledVector(cuePose.side, -BALL_R * 1.45)
+            .addScaledVector(UP, HUMAN_EYE_CAMERA_HEIGHT_OFFSET);
+          const eyeTarget = cuePose.bridgeTarget
+            .clone()
+            .addScaledVector(cuePose.aimForward, BALL_R * 10)
+            .setY(Math.max(TABLE_Y + TABLE.THICK + BALL_R * 0.8, eyePos.y - BALL_R * 0.35));
+          return {
+            blend: THREE.MathUtils.clamp(
+              (cueBias - HUMAN_EYE_CAMERA_MIN_BLEND) / (1 - HUMAN_EYE_CAMERA_MIN_BLEND),
+              0,
+              1
+            ),
+            position: eyePos,
+            target: eyeTarget
+          };
+        };
+
 
         const updateBroadcastCameras = ({
           railDir = 1,
@@ -21606,6 +21640,20 @@ const shotPowerRef = useRef(0);
               TMP_SPH.radius = sph.radius;
               TMP_SPH.phi = sph.phi;
               syncBlendToSpherical();
+            }
+          }
+          const humanEyePose = resolveActiveHumanEyePose();
+          if (humanEyePose) {
+            const lerpT = THREE.MathUtils.clamp(
+              humanEyePose.blend * HUMAN_EYE_CAMERA_SMOOTH,
+              0,
+              1
+            );
+            if (lerpT > 1e-4) {
+              camera.position.lerp(humanEyePose.position, lerpT);
+              lookTarget = lookTarget
+                ? lookTarget.clone().lerp(humanEyePose.target, lerpT)
+                : humanEyePose.target.clone();
             }
           }
           camera.lookAt(lookTarget);
@@ -24639,6 +24687,7 @@ const shotPowerRef = useRef(0);
 
       const updatePlayerCharacters = (nowMs, dtSeconds) => {
         const rigs = playerCharacterRigsRef.current;
+        activeHumanCueViewRef.current = null;
         if (!Array.isArray(rigs) || rigs.length === 0) return;
         const hudState = hudRef.current;
         const isReplay = Boolean(replayPlaybackRef.current);
@@ -24765,6 +24814,24 @@ const shotPowerRef = useRef(0);
               edgeMargin: HUMAN_EDGE_MARGIN,
               desiredShootDistance: HUMAN_DESIRED_SHOOT_DISTANCE
             }).setY(floorY);
+            const perimeterRoot = clampToWalkPerimeter(desiredRoot);
+            if (isInsideTableBlocker(perimeterRoot)) {
+              perimeterRoot.copy(clampToWalkPerimeter(perimeterRoot));
+            }
+            if (!Number.isFinite(human.walkPerimeterT)) {
+              human.walkPerimeterT = pointToPerimeterT(human.root?.position ?? perimeterRoot);
+            }
+            const humanTargetT = pointToPerimeterT(perimeterRoot);
+            const humanLoopDelta =
+              THREE.MathUtils.euclideanModulo(humanTargetT - human.walkPerimeterT + 0.5, 1) - 0.5;
+            const humanMaxStepT =
+              (HUMAN_WALK_PERIMETER_SPEED * Math.max(dtSeconds, 1 / 240)) /
+              (4 * (walkHalfX + walkHalfZ));
+            human.walkPerimeterT = THREE.MathUtils.euclideanModulo(
+              human.walkPerimeterT + THREE.MathUtils.clamp(humanLoopDelta, -humanMaxStepT, humanMaxStepT),
+              1
+            );
+            const walkRoot = perimeterTToPoint(human.walkPerimeterT);
             const state =
               mode === 'strike' ? 'striking' : mode === 'aim' ? 'dragging' : 'idle';
             const draggingPower = Math.max(0, Math.min(1, powerRef.current ?? 0));
@@ -24799,16 +24866,24 @@ const shotPowerRef = useRef(0);
               .addScaledVector(aimForward, -(1.46 - 0.24 - BALL_R - cueBallGap))
               .add(new THREE.Vector3(0, 0.024, 0));
             const gripTarget = cueTip.clone().lerp(cueBack, 0.82);
+            if (isHumanShooter && state === 'dragging') {
+              activeHumanCueViewRef.current = {
+                cueBack: cueBack.clone(),
+                bridgeTarget: bridgeTarget.clone(),
+                aimForward: aimForward.clone(),
+                side: side.clone()
+              };
+            }
             const standingYaw = Math.atan2(-aimForward.x, -aimForward.z);
-            const idleRight = desiredRoot
+            const idleRight = walkRoot
               .clone()
               .add(new THREE.Vector3(0.24, 1.1, 0.02).applyAxisAngle(new THREE.Vector3(0, 1, 0), standingYaw));
-            const idleLeft = desiredRoot
+            const idleLeft = walkRoot
               .clone()
               .add(new THREE.Vector3(-0.18, 1.08, 0.03).applyAxisAngle(new THREE.Vector3(0, 1, 0), standingYaw));
             updateBilardoHumanPose(human, dtSeconds, {
               state,
-              rootTarget: desiredRoot,
+              rootTarget: walkRoot,
               aimForward,
               bridgeTarget,
               gripTarget,

--- a/webapp/src/pages/Games/shared/bilardoHumanRig.js
+++ b/webapp/src/pages/Games/shared/bilardoHumanRig.js
@@ -185,11 +185,43 @@ export function createBilardoHumanRig(scene, opts = {}) {
             : [];
         mats.forEach((m) => {
           if (!m) return;
+          if (m.color) {
+            const hsl = { h: 0, s: 0, l: 0 };
+            m.color.getHSL(hsl);
+            hsl.l = Math.max(hsl.l, 0.36);
+            hsl.s = Math.max(hsl.s, 0.16);
+            m.color.setHSL(hsl.h, hsl.s, hsl.l);
+          }
           if (m.map) {
             m.map.colorSpace = THREE.SRGBColorSpace;
             if (textureAnisotropy != null) m.map.anisotropy = textureAnisotropy;
             m.map.needsUpdate = true;
           }
+          if (m.emissiveMap) {
+            m.emissiveMap.colorSpace = THREE.SRGBColorSpace;
+            if (textureAnisotropy != null) m.emissiveMap.anisotropy = textureAnisotropy;
+            m.emissiveMap.needsUpdate = true;
+          }
+          if (m.normalMap && textureAnisotropy != null) {
+            m.normalMap.anisotropy = textureAnisotropy;
+            m.normalMap.needsUpdate = true;
+          }
+          if (m.roughnessMap && textureAnisotropy != null) {
+            m.roughnessMap.anisotropy = textureAnisotropy;
+            m.roughnessMap.needsUpdate = true;
+          }
+          if (m.metalnessMap && textureAnisotropy != null) {
+            m.metalnessMap.anisotropy = textureAnisotropy;
+            m.metalnessMap.needsUpdate = true;
+          }
+          if (m.alphaMap) {
+            if (textureAnisotropy != null) m.alphaMap.anisotropy = textureAnisotropy;
+            m.alphaMap.needsUpdate = true;
+          }
+          m.opacity = Math.max(0.96, Number.isFinite(m.opacity) ? m.opacity : 1);
+          if (m.roughness != null) m.roughness = Math.min(m.roughness, 0.95);
+          if (m.metalness != null) m.metalness = Math.min(m.metalness, 0.25);
+          if (m.emissiveIntensity != null) m.emissiveIntensity = Math.max(m.emissiveIntensity, 0.12);
           m.needsUpdate = true;
         });
       });


### PR DESCRIPTION
### Motivation
- Keep the shooter properly positioned relative to the cue and table and make the portrait cue view more readable by adding an eye-level camera offset and smoother blending into cue view.
- Prevent characters from drifting over the table by enforcing a walk-perimeter path and clamping roots to table-blocker-safe positions.
- Make loaded avatar materials more robust and visually consistent across devices by ensuring correct color/space, anisotropy, and sane material property bounds.

### Description
- Increased `HUMAN_DESIRED_SHOOT_DISTANCE` and added eye-camera tuning constants (`HUMAN_EYE_CAMERA_HEIGHT_OFFSET`, `HUMAN_EYE_CAMERA_FORWARD_OFFSET`, `HUMAN_EYE_CAMERA_MIN_BLEND`, `HUMAN_EYE_CAMERA_SMOOTH`), plus `activeHumanCueViewRef` to store an active cue pose for the eye-camera.
- Implemented `resolveActiveHumanEyePose()` and applied a smoothed lerp into the main camera update when cue view blending indicates the eye camera should engage.
- Enhanced player-character update logic to compute and clamp a walk-perimeter `walkRoot`, advance the character along the perimeter at a capped step rate, avoid table-blocker positions, and use `walkRoot` as the pedestrian root target; set `activeHumanCueViewRef` while the human shooter is actively dragging the cue.
- Tightened avatar material handling in `bilardoHumanRig.js` by enforcing minimum lightness/saturation, setting texture color spaces to `sRGB`, applying anisotropy to various texture maps, clamping `opacity`, `roughness`, `metalness`, and ensuring a minimum `emissiveIntensity`.

### Testing
- Ran the project build with `yarn build` which completed successfully and produced the production artifacts.
- Ran the automated test suite with `yarn test` and all tests passed.
- Performed a local smoke test of the Pool Royale scene to verify shooter positioning, cue-eye camera blending, and avatar rendering changes (no automated failures detected).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f077ebb1108329a357860321b6d695)