### PR TITLE
Add capture-weapon badges, dedupe inventory and safer capture selection

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -7662,19 +7662,32 @@ function Chess3D({
   useEffect(() => {
     setSelectedCaptureAnimationId(inventoryCaptureAnimationId);
   }, [inventoryCaptureAnimationId]);
-  const ownedCaptureAnimations = useMemo(
-    () =>
-      (chessInventory?.captureAnimation || [])
-        .map((optionId) => CAPTURE_ANIMATION_OPTIONS.find((option) => option.id === optionId))
-        .filter(Boolean),
-    [chessInventory]
-  );
+  const ownedCaptureAnimations = useMemo(() => {
+    const ownedIds = Array.isArray(chessInventory?.captureAnimation) ? chessInventory.captureAnimation : [];
+    const uniqueIds = Array.from(new Set(ownedIds.filter(Boolean)));
+    const ownedOptions = uniqueIds
+      .map((optionId) => CAPTURE_ANIMATION_OPTIONS.find((option) => option.id === optionId))
+      .filter(Boolean);
+    if (ownedOptions.length > 0) return ownedOptions;
+    const fallback =
+      CAPTURE_ANIMATION_OPTIONS.find((option) => option.id === selectedCaptureAnimationId) ||
+      CAPTURE_ANIMATION_OPTIONS[0];
+    return fallback ? [fallback] : [];
+  }, [chessInventory, selectedCaptureAnimationId]);
   const selectedCaptureKind = useMemo(() => {
     const vehicleKind = resolveVehicleCaptureKind(selectedCaptureAnimationId);
     if (vehicleKind) return vehicleKind;
     if (FIREARM_CAPTURE_ANIMATION_IDS.has(selectedCaptureAnimationId)) return 'firearm';
     return 'truck';
   }, [selectedCaptureAnimationId]);
+  const selectedCaptureAnimationIdRef = useRef(selectedCaptureAnimationId);
+  useEffect(() => {
+    selectedCaptureAnimationIdRef.current = selectedCaptureAnimationId;
+  }, [selectedCaptureAnimationId]);
+  const selectedCaptureKindRef = useRef(selectedCaptureKind);
+  useEffect(() => {
+    selectedCaptureKindRef.current = selectedCaptureKind;
+  }, [selectedCaptureKind]);
   const ownedVehicleCaptureKind = useMemo(() => {
     for (const option of ownedCaptureAnimations) {
       const kind = resolveVehicleCaptureKind(option?.id);
@@ -11166,7 +11179,7 @@ function Chess3D({
         }
         return timing;
       };
-      const captureKind = selectedCaptureKind;
+      const captureKind = selectedCaptureKindRef.current || 'truck';
       if (captureKind === 'truck') {
         suppressTimerBeepUntilRef.current = performance.now() + CAPTURE_GROUND_TOTAL * 1000;
         const missileFx = createFxGroundMissile();
@@ -11498,10 +11511,67 @@ function Chess3D({
       button.scale.y = 0.66;
       button.castShadow = true;
       root.add(button);
+      const badgeCanvas = document.createElement('canvas');
+      badgeCanvas.width = 128;
+      badgeCanvas.height = 128;
+      const badgeTexture = new THREE.CanvasTexture(badgeCanvas);
+      applySRGBColorSpace(badgeTexture);
+      const badge = new THREE.Sprite(
+        new THREE.SpriteMaterial({ map: badgeTexture, transparent: true, depthWrite: false })
+      );
+      badge.scale.set(tile * 0.62, tile * 0.62, 1);
+      badge.position.set(0, tile * 0.2, 0);
+      root.add(badge);
+      root.userData.captureBadge = { canvas: badgeCanvas, texture: badgeTexture };
       airPadGroup.add(root);
+      return root;
     };
-    addAttackButtonMarker(true);
-    addAttackButtonMarker(false);
+    const resolveCaptureWeaponBadgeLabel = (captureAnimationId) => {
+      const option = CAPTURE_ANIMATION_OPTIONS.find((entry) => entry.id === captureAnimationId);
+      if (option?.label) {
+        const tokens = option.label.split(/\s+/).filter(Boolean);
+        const initials = tokens
+          .slice(0, 2)
+          .map((token) => token[0])
+          .join('');
+        if (initials) return initials.toUpperCase();
+      }
+      const kind = resolveVehicleCaptureKind(captureAnimationId, selectedParkedWeaponKindRef.current) || 'truck';
+      if (kind === 'drone') return 'DR';
+      if (kind === 'helicopter') return 'HE';
+      if (kind === 'jet') return 'JT';
+      if (kind === 'firearm') return 'AR';
+      return 'TR';
+    };
+    const paintAttackButtonBadge = (buttonRoot, captureAnimationId) => {
+      const badgeData = buttonRoot?.userData?.captureBadge;
+      const canvas = badgeData?.canvas;
+      const texture = badgeData?.texture;
+      const ctx = canvas?.getContext?.('2d');
+      if (!ctx || !texture) return;
+      const label = resolveCaptureWeaponBadgeLabel(captureAnimationId);
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      ctx.fillStyle = '#facc15';
+      ctx.font = '900 66px "JetBrains Mono","Arial Black",sans-serif';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(label, canvas.width / 2, canvas.height / 2 + 4);
+      texture.needsUpdate = true;
+    };
+    const whiteAttackButton = addAttackButtonMarker(true);
+    const blackAttackButton = addAttackButtonMarker(false);
+    let lastBadgeCaptureAnimationId = '';
+    const updateAttackButtonBadges = () => {
+      const captureAnimationId =
+        selectedCaptureAnimationIdRef.current ||
+        CAPTURE_ANIMATION_OPTIONS[0]?.id ||
+        'missileJavelin';
+      if (captureAnimationId === lastBadgeCaptureAnimationId) return;
+      lastBadgeCaptureAnimationId = captureAnimationId;
+      paintAttackButtonBadge(whiteAttackButton, captureAnimationId);
+      paintAttackButtonBadge(blackAttackButton, captureAnimationId);
+    };
+    updateAttackButtonBadges();
 
     // Tiles
     const tiles = [];
@@ -13807,6 +13877,7 @@ function Chess3D({
       }
 
 
+      updateAttackButtonBadges();
       const fpState = firstPersonViewRef.current;
       const fpvEnabled = viewModeRef.current === 'fpv';
       const localActorEntry = Array.isArray(seatedActors)
@@ -14030,6 +14101,11 @@ function Chess3D({
                       </button>
                     );
                   })}
+                  {ownedCaptureAnimations.length === 0 && (
+                    <p className="rounded-lg border border-white/10 bg-white/5 px-2 py-2 text-[0.62rem] text-white/65">
+                      No weapons found in inventory yet.
+                    </p>
+                  )}
                 </div>
               </div>
             )}
@@ -14192,6 +14268,53 @@ function Chess3D({
                         </div>
                       </div>
                     )}
+                  </div>
+                </div>
+                <div className="rounded-xl border border-white/10 bg-white/5 p-3">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="text-[10px] uppercase tracking-[0.35em] text-white/70">Capture Weapon</p>
+                      <p className="mt-1 text-[0.7rem] text-white/60">
+                        Pick any weapon you own from inventory.
+                      </p>
+                    </div>
+                    <span className="rounded-lg border border-white/15 px-2 py-1 text-[0.6rem] font-semibold uppercase tracking-[0.12em] text-white/70">
+                      {ownedCaptureAnimations.length} owned
+                    </span>
+                  </div>
+                  <div className="mt-3 grid gap-2">
+                    {ownedCaptureAnimations.map((option) => {
+                      const isSelected = option.id === selectedCaptureAnimationId;
+                      return (
+                        <button
+                          key={`menu-weapon-${option.id}`}
+                          type="button"
+                          onClick={() => handleCaptureAnimationSwap(option.id)}
+                          className={`flex items-center gap-2 rounded-xl border p-2 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 ${
+                            isSelected
+                              ? 'border-emerald-300/80 bg-emerald-300/15'
+                              : 'border-white/10 bg-white/5 hover:border-white/30'
+                          }`}
+                        >
+                          {option.thumbnail ? (
+                            <img
+                              src={option.thumbnail}
+                              alt={option.label}
+                              className="h-9 w-9 rounded-md object-cover"
+                              loading="lazy"
+                            />
+                          ) : (
+                            <span className="flex h-9 w-9 items-center justify-center rounded-md border border-white/20 bg-white/10 text-base">
+                              🧰
+                            </span>
+                          )}
+                          <span className="min-w-0 flex-1">
+                            <span className="block truncate text-[0.68rem] font-semibold text-white">{option.label}</span>
+                            <span className="block truncate text-[0.58rem] text-white/60">{option.description}</span>
+                          </span>
+                        </button>
+                      );
+                    })}
                   </div>
                 </div>
                 <div className="mt-3 space-y-3 rounded-xl border border-white/10 bg-white/5 p-3">


### PR DESCRIPTION
### Motivation

- Prevent empty/duplicate entries and stale selections when rendering and choosing capture animations from inventory.  
- Surface a concise badge on the attack buttons to indicate the currently selected capture weapon.  
- Provide a simple UI for picking equipped capture weapons and communicate when the inventory is empty.  

### Description

- Deduplicate and sanitize `chessInventory.captureAnimation` into `ownedCaptureAnimations` and provide a fallback option based on the currently selected animation or the first available option.  
- Introduce refs `selectedCaptureAnimationIdRef` and `selectedCaptureKindRef` and use them in `playCaptureAnimation` to avoid stale closure issues when resolving capture kind at runtime.  
- Extend `addAttackButtonMarker` to create a canvas-backed sprite badge and store it in `root.userData.captureBadge`, and make the function return the created root.  
- Add `resolveCaptureWeaponBadgeLabel`, `paintAttackButtonBadge`, and `updateAttackButtonBadges` to render initials/kind labels onto the badge canvas and update the white/black attack buttons when the selection changes.  
- Wire badge updates into the render/update loop so badges refresh as the selected capture animation changes.  
- Add a small UI card displaying the count of owned capture animations and a selector panel for equipping a capture weapon, and show a message when no weapons are found in inventory.  

### Testing

- Ran the build with `yarn build` which completed successfully.  
- Ran the unit test suite with `yarn test` and all tests passed.  
- Ran linting with `yarn lint` and no new linter errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0983cec9c8329b8409c38971182bd)