### PR TITLE
Align bottom-player weapons; shrink/move avatars and lower seated humans in LudoBattleRoyal

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -241,6 +241,11 @@ const FIREARM_RACK_DISPLAY_TUNING_BY_ID = Object.freeze({
     rotation: [-Math.PI * 0.5, -Math.PI * 0.02, 0]
   })
 });
+const BOTTOM_PLAYER_FIREARM_RACK_DISPLAY_TUNING = Object.freeze({
+  // Keep the local/bottom user's parked firearm perfectly flat on the table.
+  position: [0.078, 0, -0.014],
+  rotation: [-Math.PI * 0.5, Math.PI * 0.02, 0]
+});
 const FIREARM_RACK_PARKING_TUNING = Object.freeze({
   // Small sidearms sit tight next to the token on its right-hand side.
   small: Object.freeze({
@@ -1128,8 +1133,9 @@ async function applyCaptureWeaponDisplay(entry, captureAnimationId) {
     ? FIREARM_RACK_DISPLAY_TUNING.large
     : FIREARM_RACK_DISPLAY_TUNING.default;
   const weaponSpecificDisplayTuning = FIREARM_RACK_DISPLAY_TUNING_BY_ID[captureAnimationId] ?? null;
-  const displayPosition = weaponSpecificDisplayTuning?.position ?? displayTuning.position;
-  const displayRotation = weaponSpecificDisplayTuning?.rotation ?? displayTuning.rotation;
+  const bottomPlayerDisplayTuning = entry?.playerIndex === 0 ? BOTTOM_PLAYER_FIREARM_RACK_DISPLAY_TUNING : null;
+  const displayPosition = bottomPlayerDisplayTuning?.position ?? weaponSpecificDisplayTuning?.position ?? displayTuning.position;
+  const displayRotation = bottomPlayerDisplayTuning?.rotation ?? weaponSpecificDisplayTuning?.rotation ?? displayTuning.rotation;
   const weaponRackScaleMultiplier = FIREARM_RACK_SIZE_MULTIPLIER_BY_ID[captureAnimationId] ?? 1;
   fitObjectToTargetSize(
     clone,
@@ -2997,7 +3003,7 @@ const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.42;
 // Slightly upscale seated humans so they read better on portrait/mobile gameplay.
 const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 4.2;
 // Push seated humans dramatically lower so they sit much deeper on portrait/mobile camera framing.
-const SEATED_HUMAN_SEAT_Y_OFFSET = -6.2 * MODEL_SCALE * STOOL_SCALE;
+const SEATED_HUMAN_SEAT_Y_OFFSET = -6.75 * MODEL_SCALE * STOOL_SCALE;
 // Shift humans farther back on the chair so they appear more outward from the table in portrait gameplay.
 const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.42;
 const SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET = -SEAT_DEPTH * 0.2;
@@ -3083,7 +3089,7 @@ const FALLBACK_SEAT_POSITIONS = [
   { left: '52%', top: '24%' },
   { left: '20%', top: '56%' }
 ];
-const SELF_AVATAR_BOTTOM_OFFSET_PERCENT = 8;
+const SELF_AVATAR_BOTTOM_OFFSET_PERCENT = 10.5;
 
 const colorNumberToHex = (value) => `#${value.toString(16).padStart(6, '0')}`;
 
@@ -11943,7 +11949,13 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             </div>
           )}
         </div>
-        <div className="pointer-events-auto absolute bottom-[11.75rem] left-1/2 z-20 -translate-x-1/2">
+        <div
+          className="pointer-events-auto absolute z-20 -translate-x-1/2"
+          style={{
+            left: `${seatAnchorMap.get(0)?.x ?? 50}%`,
+            top: `${clamp((seatAnchorMap.get(0)?.y ?? 82) - 10.5, 58, 92)}%`
+          }}
+        >
           <button
             type="button"
             onClick={(event) => {
@@ -12038,7 +12050,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
                   transform: 'translate(-50%, -50%)'
                 };
             const depth = anchor?.depth ?? 3;
-            const avatarSize = anchor ? clamp(1.32 - (depth - 2.6) * 0.22, 0.86, 1.2) : 1;
+            const avatarSize = anchor ? clamp(1.08 - (depth - 2.6) * 0.18, 0.72, 0.94) : 0.78;
             const isTurn = ui.turn === player.index;
             return (
               <div


### PR DESCRIPTION
### Motivation
- Ensure the local (bottom) player's weapons appear flat on the table and share a consistent placement/orientation (shotgun baseline) regardless of selected firearm. 
- Improve portrait/mobile composition by reducing avatar visual size and moving human characters lower so the bottom player reads clearly on the screen. 
- Make the quick weapon switch control appear directly over the bottom player's weapon area.

### Description
- Added `BOTTOM_PLAYER_FIREARM_RACK_DISPLAY_TUNING` and applied it in `applyCaptureWeaponDisplay` so `entry.playerIndex === 0` uses a dedicated flat/consistent display transform for parked weapons. (modified `webapp/src/pages/Games/LudoBattleRoyal.jsx`).
- Repositioned the quick weapon swap button to follow the bottom seat anchor by using `seatAnchorMap.get(0)` and a clamped `top` value so the switch icon sits over the bottom player weapon zone. (modified UI placement code in `LudoBattleRoyal.jsx`).
- Reduced avatar rendering scale and tightened avatar size clamp formula to make avatars smaller on-screen, and increased `SELF_AVATAR_BOTTOM_OFFSET_PERCENT` so the human avatar shifts further downward. (updated avatar size and offset in `LudoBattleRoyal.jsx`).
- Lowered seated human models by increasing `SEATED_HUMAN_SEAT_Y_OFFSET` to push characters deeper toward the bottom of the screen. (tweak in `LudoBattleRoyal.jsx`).

### Testing
- Ran the production build with `npm --prefix webapp run build` and the Vite build completed successfully; output included non-blocking code-splitting warnings but no build failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f09cc76ac8832985fc3d65abb163fa)