### PR TITLE
Closer cue camera and improved human bridge/stance behavior for Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1945,11 +1945,14 @@ const HUMAN_SHOOT_BLEND_THRESHOLD = 0.72; // enter shooting pose earlier when th
 const HUMAN_WALK_RING_MARGIN = TABLE.WALL * 3.1; // keep player roots on a perimeter ring outside the table footprint
 const HUMAN_TABLE_BLOCKER_MARGIN = TABLE.WALL * 1.95; // collision helper margin so characters never cut through the table body
 const HUMAN_EYE_CAMERA_HEIGHT_OFFSET = 0.09; // lift camera above cue butt so table stays visible in portrait cue view
-const HUMAN_EYE_CAMERA_FORWARD_OFFSET = 0.1; // pull camera slightly backward along cue axis before looking down-table
+const HUMAN_EYE_CAMERA_FORWARD_OFFSET = 0.135; // pull camera slightly further backward along cue axis for tighter over-shoulder player view
 const HUMAN_EYE_CAMERA_MIN_BLEND = 0.06; // only engage eye camera when cue view is noticeably lowered
 const HUMAN_EYE_CAMERA_SMOOTH = 0.48; // smooth eye-camera blending into the cue camera for portrait stability
 const HUMAN_WALK_PERIMETER_SPEED = Math.max(TABLE.W * 0.95, TABLE.H * 0.7); // world units per second when traversing the walk ring
 const HUMAN_WALK_EPS = 1e-5;
+const HUMAN_BRIDGE_RAIL_THRESHOLD = BALL_R * 1.9; // switch to rail bridge when cue ball is close to cushion
+const HUMAN_CLOSED_BRIDGE_POWER_THRESHOLD = 0.58; // use closed bridge on stronger strokes
+const HUMAN_HIGH_BRIDGE_TOPSPIN_THRESHOLD = 0.42; // lift bridge/grip for elevated top-spin hits
 const CUE_STRIKE_DURATION_MS = 260;
 const PLAYER_CUE_STRIKE_MIN_MS = 120;
 const PLAYER_CUE_STRIKE_MAX_MS = 1400;
@@ -6165,13 +6168,13 @@ const RAIL_OVERHEAD_DISTANCE_BIAS = 0.94; // pull broadcast rail camera inward f
 const SHORT_RAIL_CAMERA_DISTANCE =
   computeTopViewBroadcastDistance() * RAIL_OVERHEAD_DISTANCE_BIAS; // match the 2D top view framing distance for overhead rail cuts while keeping a touch of breathing room
 const SIDE_RAIL_CAMERA_DISTANCE = SHORT_RAIL_CAMERA_DISTANCE; // keep side-rail framing aligned with the top view scale
-const CUE_VIEW_RADIUS_RATIO = 0.0205; // tighten cue camera distance so the cue ball and object ball appear larger
+const CUE_VIEW_RADIUS_RATIO = 0.0168; // tighten cue camera distance further for stronger player-perspective framing
 const CUE_VIEW_MIN_RADIUS = CAMERA.minR * 0.08;
 const CUE_VIEW_MIN_PHI = Math.min(
   CAMERA.maxPhi - CAMERA_RAIL_SAFETY,
   STANDING_VIEW_PHI + 0.26
 );
-const CUE_VIEW_PHI_LIFT = 0.06; // keep the cue camera slightly higher before it bottoms out
+const CUE_VIEW_PHI_LIFT = 0.055; // keep cue camera low enough for player-eye perspective while clearing rails
 const CUE_VIEW_TARGET_PHI = CUE_VIEW_MIN_PHI + CUE_VIEW_PHI_LIFT * 0.5;
 const CAMERA_RAIL_APPROACH_PHI = Math.min(
   STANDING_VIEW_PHI + 0.32,
@@ -24673,6 +24676,9 @@ const shotPowerRef = useRef(0);
             chinToCueHeight: 0.11,
             cueArmElbowRise: 0.43,
             tableTopY: TABLE_Y + TABLE.THICK,
+            bridgeDistance: 0.255,
+            railBridgeThreshold: HUMAN_BRIDGE_RAIL_THRESHOLD,
+            openBridgeMaxPower: HUMAN_CLOSED_BRIDGE_POWER_THRESHOLD,
             textureAnisotropy: renderer?.capabilities?.getMaxAnisotropy?.() ?? 8
           });
           human.root.position.set(x, floorY, z);
@@ -24881,6 +24887,19 @@ const shotPowerRef = useRef(0);
             const idleLeft = walkRoot
               .clone()
               .add(new THREE.Vector3(-0.18, 1.08, 0.03).applyAxisAngle(new THREE.Vector3(0, 1, 0), standingYaw));
+            const railDistance = Math.min(
+              TABLE.W / 2 - Math.abs(cueBall.pos.x),
+              TABLE.H / 2 - Math.abs(cueBall.pos.y)
+            );
+            const spinY = Number.isFinite(spinRef.current?.y) ? spinRef.current.y : 0;
+            const bridgeMode =
+              railDistance <= HUMAN_BRIDGE_RAIL_THRESHOLD
+                ? 'rail'
+                : state === 'striking' && spinY > HUMAN_HIGH_BRIDGE_TOPSPIN_THRESHOLD
+                  ? 'high'
+                  : activePower > HUMAN_CLOSED_BRIDGE_POWER_THRESHOLD
+                    ? 'closed'
+                    : 'open';
             updateBilardoHumanPose(human, dtSeconds, {
               state,
               rootTarget: walkRoot,
@@ -24891,7 +24910,11 @@ const shotPowerRef = useRef(0);
               idleLeft,
               cueBack,
               cueTip,
-              power: activePower
+              power: activePower,
+              spinY,
+              railDistance,
+              bridgeMode,
+              cueCameraLowered: loweredCueCamera
             });
             return;
           }

--- a/webapp/src/pages/Games/shared/bilardoHumanRig.js
+++ b/webapp/src/pages/Games/shared/bilardoHumanRig.js
@@ -146,7 +146,10 @@ export function createBilardoHumanRig(scene, opts = {}) {
       bridgePalmTableLift: opts.bridgePalmTableLift ?? 0.012,
       chinToCueHeight: opts.chinToCueHeight ?? 0.11,
       cueArmElbowRise: opts.cueArmElbowRise ?? 0.43,
-      tableTopY: opts.tableTopY ?? 0.84
+      tableTopY: opts.tableTopY ?? 0.84,
+      bridgeDistance: opts.bridgeDistance ?? 0.255,
+      railBridgeThreshold: opts.railBridgeThreshold ?? 0.08,
+      openBridgeMaxPower: opts.openBridgeMaxPower ?? 0.55
     }
   };
 
@@ -185,13 +188,6 @@ export function createBilardoHumanRig(scene, opts = {}) {
             : [];
         mats.forEach((m) => {
           if (!m) return;
-          if (m.color) {
-            const hsl = { h: 0, s: 0, l: 0 };
-            m.color.getHSL(hsl);
-            hsl.l = Math.max(hsl.l, 0.36);
-            hsl.s = Math.max(hsl.s, 0.16);
-            m.color.setHSL(hsl.h, hsl.s, hsl.l);
-          }
           if (m.map) {
             m.map.colorSpace = THREE.SRGBColorSpace;
             if (textureAnisotropy != null) m.map.anisotropy = textureAnisotropy;
@@ -218,10 +214,6 @@ export function createBilardoHumanRig(scene, opts = {}) {
             if (textureAnisotropy != null) m.alphaMap.anisotropy = textureAnisotropy;
             m.alphaMap.needsUpdate = true;
           }
-          m.opacity = Math.max(0.96, Number.isFinite(m.opacity) ? m.opacity : 1);
-          if (m.roughness != null) m.roughness = Math.min(m.roughness, 0.95);
-          if (m.metalness != null) m.metalness = Math.min(m.metalness, 0.25);
-          if (m.emissiveIntensity != null) m.emissiveIntensity = Math.max(m.emissiveIntensity, 0.12);
           m.needsUpdate = true;
         });
       });
@@ -551,6 +543,18 @@ export function chooseHumanEdgePosition(cueBallWorld, aimForward, opts = {}) {
   return candidates.sort((a, b) => a.distanceToSquared(desired) - b.distanceToSquared(desired))[0].clone();
 }
 
+
+function resolveBridgeMode(frameData, cfg) {
+  if (frameData?.bridgeMode) return frameData.bridgeMode;
+  const state = frameData?.state ?? 'idle';
+  const power = clamp01(frameData?.power ?? 0);
+  const railDistance = Number.isFinite(frameData?.railDistance) ? frameData.railDistance : Infinity;
+  if (railDistance <= (cfg?.railBridgeThreshold ?? 0.08)) return 'rail';
+  if (state === 'striking' && (frameData?.spinY ?? 0) > 0.42) return 'high';
+  if (state === 'dragging' && power > (cfg?.openBridgeMaxPower ?? 0.55)) return 'closed';
+  return 'open';
+}
+
 export function updateBilardoHumanPose(human, dt, frameData) {
   if (!human) return;
   const cfg = human.cfg;
@@ -589,6 +593,8 @@ export function updateBilardoHumanPose(human, dt, frameData) {
   const walk = Math.sin(human.walkT * 6.2) * Math.min(1, moveAmountRaw * 12);
   const walkAmount = clamp01(moveAmountRaw * 18) * idle;
   const power = frameData.power ?? 0;
+  const bridgeMode = resolveBridgeMode(frameData, cfg);
+  const bridgeModeT = bridgeMode === 'open' ? 0 : bridgeMode === 'closed' ? 0.5 : bridgeMode === 'rail' ? 0.85 : 1;
   const stroke =
     state === 'dragging'
       ? Math.sin(performance.now() * 0.011) * (0.25 + power * 0.75)
@@ -602,7 +608,7 @@ export function updateBilardoHumanPose(human, dt, frameData) {
   const side = new THREE.Vector3(forward.z, 0, -forward.x).normalize();
   const local = (v) => v.clone().applyAxisAngle(Y_AXIS, human.yaw).add(human.root.position);
   const powerLean = power * t;
-  const lowerBodyT = t * 0.35;
+  const lowerBodyT = t * (0.35 + bridgeModeT * 0.15);
 
   const rootWorld = human.root.position.clone().addScaledVector(forward, 0.018 * powerLean + 0.026 * follow);
   const torso = local(new THREE.Vector3(0, lerp(1.3, 1.12, t) + breath, lerp(0.02, -0.16, t) - 0.014 * powerLean));
@@ -614,35 +620,41 @@ export function updateBilardoHumanPose(human, dt, frameData) {
   const rightHip = local(new THREE.Vector3(0.13, 0.92, 0.02));
   const leftFoot = local(
     new THREE.Vector3(-0.13, 0.035, 0.03 + walk * 0.03).lerp(
-      new THREE.Vector3(-cfg.stanceWidth * 0.42, 0.035, -0.36),
+      new THREE.Vector3(-cfg.stanceWidth * (0.42 + bridgeModeT * 0.06), 0.035, -0.36 - bridgeModeT * 0.04),
       lowerBodyT
     )
   );
   const rightFoot = local(
     new THREE.Vector3(0.13, 0.035, -0.03 - walk * 0.03).lerp(
-      new THREE.Vector3(cfg.stanceWidth * 0.5, 0.035, 0.36),
+      new THREE.Vector3(cfg.stanceWidth * (0.5 + bridgeModeT * 0.05), 0.035, 0.36 + bridgeModeT * 0.05),
       lowerBodyT
     )
   );
 
+  const bridgeForwardBias = bridgeMode === 'rail' ? -0.015 : bridgeMode === 'high' ? -0.004 : -0.026;
+  const bridgeSideBias = bridgeMode === 'rail' ? -0.028 : bridgeMode === 'high' ? -0.01 : -0.018;
+  const bridgeLift = bridgeMode === 'rail' ? 0.015 : bridgeMode === 'high' ? 0.026 : bridgeMode === 'closed' ? 0.01 : 0;
   const leftHand = frameData.idleLeft
     .clone()
     .lerp(
       frameData.bridgeTarget
         .clone()
-        .addScaledVector(forward, -0.026 * t)
-        .addScaledVector(side, -0.018 * t)
-        .setY(cfg.tableTopY + cfg.bridgePalmTableLift)
+        .addScaledVector(forward, bridgeForwardBias * t)
+        .addScaledVector(side, bridgeSideBias * t)
+        .setY(cfg.tableTopY + cfg.bridgePalmTableLift + bridgeLift)
         .addScaledVector(UP, -0.006 * human.settleT),
       t
     );
+  const gripVerticalBias = bridgeMode === 'high' ? 0.016 : bridgeMode === 'rail' ? 0.006 : 0;
+  const gripSideBias = bridgeMode === 'closed' ? 0.012 : bridgeMode === 'rail' ? 0.009 : 0.005;
   const rightHand = frameData.idleRight
     .clone()
     .lerp(
       frameData.gripTarget
         .clone()
         .addScaledVector(forward, 0.032 * stroke * t + 0.052 * follow * power)
-        .addScaledVector(UP, -0.007 * follow),
+        .addScaledVector(side, gripSideBias * t)
+        .addScaledVector(UP, -0.007 * follow + gripVerticalBias * t),
       t
     );
 
@@ -652,11 +664,12 @@ export function updateBilardoHumanPose(human, dt, frameData) {
     .addScaledVector(UP, 0.02 * t)
     .addScaledVector(side, -0.03 * t)
     .addScaledVector(forward, 0.035 * t);
+  const rightElbowRise = bridgeMode === 'high' ? cfg.cueArmElbowRise + 0.08 : cfg.cueArmElbowRise;
   const rightElbow = rightHand
     .clone()
-    .addScaledVector(UP, lerp(0.18, cfg.cueArmElbowRise, t))
-    .addScaledVector(side, lerp(0.03, 0.07, t))
-    .addScaledVector(forward, lerp(-0.03, 0, t));
+    .addScaledVector(UP, lerp(0.18, rightElbowRise, t))
+    .addScaledVector(side, lerp(0.03, bridgeMode === 'closed' ? 0.08 : 0.07, t))
+    .addScaledVector(forward, lerp(-0.03, bridgeMode === 'rail' ? 0.02 : 0, t));
   const leftKnee = leftHip
     .clone()
     .lerp(leftFoot, 0.53)


### PR DESCRIPTION
### Motivation
- Improve portrait/phone player perspective by bringing the cue camera closer and tightening over-shoulder framing so the view reads more like a real player standing at the rail. 
- Make the human avatar behave and hold the cue like a real pool player across common bridge modes (open/closed/rail/high) so hand placement, elbow rise and stance react to shot context. 
- Preserve original character texture mapping and authored GLB appearance while adding enough pose context (rail distance, power, spin) to drive precise hand/bridge alignment. 

### Description
- Tuned cue/eye camera constants in `webapp/src/pages/Games/PoolRoyale.jsx` by reducing `CUE_VIEW_RADIUS_RATIO`, slightly lowering `CUE_VIEW_PHI_LIFT`, and increasing `HUMAN_EYE_CAMERA_FORWARD_OFFSET` to produce a tighter player-perspective framing. 
- Added explicit bridge heuristics and constants (`HUMAN_BRIDGE_RAIL_THRESHOLD`, `HUMAN_CLOSED_BRIDGE_POWER_THRESHOLD`, `HUMAN_HIGH_BRIDGE_TOPSPIN_THRESHOLD`) and pass `bridgeMode`, `railDistance`, and `spinY` into the human pose driver so the rig knows shot context each frame. 
- Extended the shared rig in `webapp/src/pages/Games/shared/bilardoHumanRig.js` with a `resolveBridgeMode` helper and mode-aware pose adjustments that adapt stance width/depth, bridge hand forward/side/lift biases, grip side/vertical offsets, and right-elbow rise/forward bias to better match open/closed/rail/high bridge behavior. 
- Restored GLB material fidelity by removing runtime color/roughness/metalness/emissive overrides while keeping SRGB map handling and optional anisotropy adjustments so original texture mapping remains visible and unchanged at runtime. 

### Testing
- Ran focused unit tests with `npm test -- --runInBand test/poolRoyaleShotState.test.js test/poolRoyaleCueStrokeTimeline.test.js` and both suites passed. 
- Attempted an automated portrait screenshot of the running webapp via Playwright to visually validate camera/pose changes, but the run failed in this environment due to a missing system shared library required by headless Chromium (`libatk-1.0.so.0`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0a52978688329b246e79c5669dd18)