### PR TITLE
Add human eye cue camera, refine human walk/perimeter pose, and harden GLB material handling

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -119,7 +119,6 @@ import { resolveAiPotGhostAim } from './poolRoyaleAiAimCompensation.js';
 import { computeCueDriveBoost } from './cueShotImpact.js';
 import {
   createBilardoHumanRig,
-  chooseHumanEdgePosition as chooseBilardoHumanEdgePosition,
   updateBilardoHumanPose
 } from './shared/bilardoHumanRig.js';
 import { polyHavenThumb } from '../../config/storeThumbnails.js';
@@ -1944,6 +1943,11 @@ const HUMAN_DESIRED_SHOOT_DISTANCE = 1.06;
 const HUMAN_SHOOT_BLEND_THRESHOLD = 0.72; // enter shooting pose earlier when the cue camera starts getting lowered
 const HUMAN_WALK_RING_MARGIN = TABLE.WALL * 3.1; // keep player roots on a perimeter ring outside the table footprint
 const HUMAN_TABLE_BLOCKER_MARGIN = TABLE.WALL * 1.95; // collision helper margin so characters never cut through the table body
+const HUMAN_EYE_CAMERA_MIN_BLEND = 0.06; // only engage eye camera when cue view is noticeably lowered
+const HUMAN_EYE_CAMERA_SMOOTH = 0.48; // smooth eye-camera blending into the cue camera for portrait stability
+const HUMAN_CUE_CAMERA_BACK_OFFSET = 0.19; // keep cue camera behind the cue stick so the player sits at the butt side
+const HUMAN_CUE_CAMERA_SIDE_OFFSET = 0.04; // slight side offset reveals the bridge hand near cue ball in portrait view
+const HUMAN_CUE_CAMERA_HEIGHT = 0.09; // low cue-view height so table remains dominant and hand stays visible
 const HUMAN_WALK_PERIMETER_SPEED = Math.max(TABLE.W * 0.95, TABLE.H * 0.7); // world units per second when traversing the walk ring
 const HUMAN_WALK_EPS = 1e-5;
 const CUE_STRIKE_DURATION_MS = 260;
@@ -15292,6 +15296,7 @@ function PoolRoyaleGame({
   const decorativeTablesRef = useRef([]);
   const hospitalityGroupsRef = useRef([]);
   const playerCharacterRigsRef = useRef([]);
+  const activeHumanCuePoseRef = useRef(null);
   const characterShotStartedAtRef = useRef(0);
   const characterShotShooterRef = useRef('A');
   const hospitalityLayoutRunRef = useRef(null);
@@ -20383,6 +20388,34 @@ const shotPowerRef = useRef(0);
           return vec;
         };
 
+        const resolveActiveHumanEyePose = () => {
+          if (topViewRef.current || shootingRef.current || replayPlaybackRef.current) return null;
+          const cueBlend = THREE.MathUtils.clamp(cameraBlendRef.current ?? 1, 0, 1);
+          const cueBias = 1 - cueBlend;
+          if (cueBias <= HUMAN_EYE_CAMERA_MIN_BLEND) return null;
+          const cuePose = activeHumanCuePoseRef.current;
+          if (!cuePose) return null;
+          const worldForward = cuePose.forward.clone();
+          const eyePos = cuePose.cueBack
+            .clone()
+            .addScaledVector(worldForward, -HUMAN_CUE_CAMERA_BACK_OFFSET)
+            .addScaledVector(cuePose.side, HUMAN_CUE_CAMERA_SIDE_OFFSET)
+            .setY(cuePose.tableY + HUMAN_CUE_CAMERA_HEIGHT);
+          const eyeTarget = cuePose.bridge
+            .clone()
+            .addScaledVector(worldForward, BALL_R * 4.5)
+            .setY(Math.max(cuePose.tableY + BALL_R * 0.8, eyePos.y - BALL_R * 0.18));
+          return {
+            blend: THREE.MathUtils.clamp(
+              (cueBias - HUMAN_EYE_CAMERA_MIN_BLEND) / (1 - HUMAN_EYE_CAMERA_MIN_BLEND),
+              0,
+              1
+            ),
+            position: eyePos,
+            target: eyeTarget
+          };
+        };
+
 
         const updateBroadcastCameras = ({
           railDir = 1,
@@ -21606,6 +21639,20 @@ const shotPowerRef = useRef(0);
               TMP_SPH.radius = sph.radius;
               TMP_SPH.phi = sph.phi;
               syncBlendToSpherical();
+            }
+          }
+          const humanEyePose = resolveActiveHumanEyePose();
+          if (humanEyePose) {
+            const lerpT = THREE.MathUtils.clamp(
+              humanEyePose.blend * HUMAN_EYE_CAMERA_SMOOTH,
+              0,
+              1
+            );
+            if (lerpT > 1e-4) {
+              camera.position.lerp(humanEyePose.position, lerpT);
+              lookTarget = lookTarget
+                ? lookTarget.clone().lerp(humanEyePose.target, lerpT)
+                : humanEyePose.target.clone();
             }
           }
           camera.lookAt(lookTarget);
@@ -24640,6 +24687,7 @@ const shotPowerRef = useRef(0);
       const updatePlayerCharacters = (nowMs, dtSeconds) => {
         const rigs = playerCharacterRigsRef.current;
         if (!Array.isArray(rigs) || rigs.length === 0) return;
+        activeHumanCuePoseRef.current = null;
         const hudState = hudRef.current;
         const isReplay = Boolean(replayPlaybackRef.current);
         const isShotActive = Boolean(shootingRef.current);
@@ -24756,15 +24804,31 @@ const shotPowerRef = useRef(0);
           else if (isHumanShooter && (loweredCueCamera || draggingSlider || sliderPowerActive)) mode = 'aim';
           if (anim) anim.mode = mode;
 
-          if (human) {
+	          if (human) {
             const aimForward = new THREE.Vector3(-normalizedAim.x, 0, -normalizedAim.y).normalize();
             const side = new THREE.Vector3(aimForward.z, 0, -aimForward.x).normalize();
-            const desiredRoot = chooseBilardoHumanEdgePosition(cueWorld, aimForward, {
-              tableW: TABLE.W,
-              tableL: TABLE.H,
-              edgeMargin: HUMAN_EDGE_MARGIN,
-              desiredShootDistance: HUMAN_DESIRED_SHOOT_DISTANCE
-            }).setY(floorY);
+            const desiredRoot = cueWorld
+              .clone()
+              .addScaledVector(aimForward, -HUMAN_DESIRED_SHOOT_DISTANCE)
+              .setY(floorY);
+            const perimeterRoot = clampToWalkPerimeter(desiredRoot);
+            if (isInsideTableBlocker(perimeterRoot)) {
+              perimeterRoot.copy(clampToWalkPerimeter(perimeterRoot));
+            }
+            if (!Number.isFinite(human.walkPerimeterT)) {
+              human.walkPerimeterT = pointToPerimeterT(human.root?.position ?? perimeterRoot);
+            }
+            const humanTargetT = pointToPerimeterT(perimeterRoot);
+            const humanLoopDelta =
+              THREE.MathUtils.euclideanModulo(humanTargetT - human.walkPerimeterT + 0.5, 1) - 0.5;
+            const humanMaxStepT =
+              (HUMAN_WALK_PERIMETER_SPEED * Math.max(dtSeconds, 1 / 240)) /
+              (4 * (walkHalfX + walkHalfZ));
+            human.walkPerimeterT = THREE.MathUtils.euclideanModulo(
+              human.walkPerimeterT + THREE.MathUtils.clamp(humanLoopDelta, -humanMaxStepT, humanMaxStepT),
+              1
+            );
+            const walkRoot = perimeterTToPoint(human.walkPerimeterT);
             const state =
               mode === 'strike' ? 'striking' : mode === 'aim' ? 'dragging' : 'idle';
             const draggingPower = Math.max(0, Math.min(1, powerRef.current ?? 0));
@@ -24798,17 +24862,26 @@ const shotPowerRef = useRef(0);
               .clone()
               .addScaledVector(aimForward, -(1.46 - 0.24 - BALL_R - cueBallGap))
               .add(new THREE.Vector3(0, 0.024, 0));
+            if (isHumanShooter) {
+              activeHumanCuePoseRef.current = {
+                forward: aimForward.clone(),
+                side: side.clone(),
+                cueBack: cueBack.clone(),
+                bridge: bridgeTarget.clone(),
+                tableY: TABLE_Y + TABLE.THICK
+              };
+            }
             const gripTarget = cueTip.clone().lerp(cueBack, 0.82);
             const standingYaw = Math.atan2(-aimForward.x, -aimForward.z);
-            const idleRight = desiredRoot
+            const idleRight = walkRoot
               .clone()
               .add(new THREE.Vector3(0.24, 1.1, 0.02).applyAxisAngle(new THREE.Vector3(0, 1, 0), standingYaw));
-            const idleLeft = desiredRoot
+            const idleLeft = walkRoot
               .clone()
               .add(new THREE.Vector3(-0.18, 1.08, 0.03).applyAxisAngle(new THREE.Vector3(0, 1, 0), standingYaw));
             updateBilardoHumanPose(human, dtSeconds, {
               state,
-              rootTarget: desiredRoot,
+              rootTarget: walkRoot,
               aimForward,
               bridgeTarget,
               gripTarget,

--- a/webapp/src/pages/Games/shared/bilardoHumanRig.js
+++ b/webapp/src/pages/Games/shared/bilardoHumanRig.js
@@ -185,11 +185,43 @@ export function createBilardoHumanRig(scene, opts = {}) {
             : [];
         mats.forEach((m) => {
           if (!m) return;
+          if (m.color) {
+            const hsl = { h: 0, s: 0, l: 0 };
+            m.color.getHSL(hsl);
+            hsl.l = Math.max(hsl.l, 0.36);
+            hsl.s = Math.max(hsl.s, 0.16);
+            m.color.setHSL(hsl.h, hsl.s, hsl.l);
+          }
           if (m.map) {
             m.map.colorSpace = THREE.SRGBColorSpace;
             if (textureAnisotropy != null) m.map.anisotropy = textureAnisotropy;
             m.map.needsUpdate = true;
           }
+          if (m.emissiveMap) {
+            m.emissiveMap.colorSpace = THREE.SRGBColorSpace;
+            if (textureAnisotropy != null) m.emissiveMap.anisotropy = textureAnisotropy;
+            m.emissiveMap.needsUpdate = true;
+          }
+          if (m.normalMap && textureAnisotropy != null) {
+            m.normalMap.anisotropy = textureAnisotropy;
+            m.normalMap.needsUpdate = true;
+          }
+          if (m.roughnessMap && textureAnisotropy != null) {
+            m.roughnessMap.anisotropy = textureAnisotropy;
+            m.roughnessMap.needsUpdate = true;
+          }
+          if (m.metalnessMap && textureAnisotropy != null) {
+            m.metalnessMap.anisotropy = textureAnisotropy;
+            m.metalnessMap.needsUpdate = true;
+          }
+          if (m.alphaMap) {
+            if (textureAnisotropy != null) m.alphaMap.anisotropy = textureAnisotropy;
+            m.alphaMap.needsUpdate = true;
+          }
+          m.opacity = Math.max(0.96, Number.isFinite(m.opacity) ? m.opacity : 1);
+          if (m.roughness != null) m.roughness = Math.min(m.roughness, 0.95);
+          if (m.metalness != null) m.metalness = Math.min(m.metalness, 0.25);
+          if (m.emissiveIntensity != null) m.emissiveIntensity = Math.max(m.emissiveIntensity, 0.12);
           m.needsUpdate = true;
         });
       });


### PR DESCRIPTION
### Motivation
- Improve portrait/close-in cue view by blending an "eye" camera tied to the shooter's cue pose so the player feels more connected during aiming and striking. 
- Make human placement more stable and keep characters on a walk-perimeter that avoids table blockers rather than relying on the previous edge helper. 
- Ensure loaded GLB human materials and textures render consistently by enforcing sRGB color space, anisotropy and safe material property ranges. 

### Description
- Added camera tuning constants (`HUMAN_EYE_CAMERA_MIN_BLEND`, `HUMAN_EYE_CAMERA_SMOOTH`, `HUMAN_CUE_CAMERA_BACK_OFFSET`, `HUMAN_CUE_CAMERA_SIDE_OFFSET`, `HUMAN_CUE_CAMERA_HEIGHT`) and `activeHumanCuePoseRef` to the Pool Royale page. 
- Implemented `resolveActiveHumanEyePose` to compute an eye-camera `position`, `target`, and `blend`, and integrated it into `updateBroadcastCameras` to lerp the main camera toward the human eye pose when appropriate. 
- Reworked shooter human positioning in `updatePlayerCharacters` to compute a `walkRoot` on a perimeter, update `walkPerimeterT`, avoid table blockers, and set `activeHumanCuePoseRef` for the active shooter; removed usage of the old `chooseBilardoHumanEdgePosition` helper. 
- Hardened GLB material handling in `createBilardoHumanRig` by clamping HSL/opacity/roughness/metalness/emissiveIntensity, setting texture `colorSpace` to `THREE.SRGBColorSpace`, and updating anisotropy/`needsUpdate` for `map`, `emissiveMap`, `normalMap`, `roughnessMap`, `metalnessMap`, and `alphaMap`. 

### Testing
- Ran the project build (`yarn build`) to verify compilation and the updated scene integration succeeded. 
- Executed the automated test suite (`yarn test`) including unit/UI tests and snapshot checks, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f077ebb1108329a357860321b6d695)