### PR TITLE
Align parked Ludo firearms to AK47 baseline and keep racks flat

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -226,13 +226,14 @@ const FIREARM_RACK_SIZE_MULTIPLIER_BY_ID = Object.freeze({
 const FIREARM_RACK_DISPLAY_TUNING = Object.freeze({
   default: Object.freeze({
     targetSizeMultiplier: 1.06,
-    position: [0.078, 0, -0.014],
-    rotation: [-Math.PI * 0.5, Math.PI * 0.02, 0]
+    // Keep every firearm parked in the exact AK47 slot/orientation baseline.
+    position: [0.086, 0, -0.016],
+    rotation: [-Math.PI * 0.5, -Math.PI * 0.02, 0]
   }),
   large: Object.freeze({
     targetSizeMultiplier: 1.9,
     position: [0.086, 0, -0.016],
-    rotation: [-Math.PI * 0.5, Math.PI * 0.02, 0]
+    rotation: [-Math.PI * 0.5, -Math.PI * 0.02, 0]
   })
 });
 const FIREARM_RACK_DISPLAY_TUNING_BY_ID = Object.freeze({
@@ -243,8 +244,8 @@ const FIREARM_RACK_DISPLAY_TUNING_BY_ID = Object.freeze({
 });
 const BOTTOM_PLAYER_FIREARM_RACK_DISPLAY_TUNING = Object.freeze({
   // Keep the local/bottom user's parked firearm perfectly flat on the table.
-  position: [0.078, 0, -0.014],
-  rotation: [-Math.PI * 0.5, Math.PI * 0.02, 0]
+  position: [0.086, 0, -0.016],
+  rotation: [-Math.PI * 0.5, -Math.PI * 0.02, 0]
 });
 const FIREARM_RACK_PARKING_TUNING = Object.freeze({
   // Small sidearms sit tight next to the token on its right-hand side.
@@ -761,6 +762,7 @@ const QUICK_SWAP_WEAPON_SHAPE_BY_ID = Object.freeze({
 
 function orientCaptureVehicleTowardBoardCenter(root, target) {
   if (!root?.isObject3D || !target?.isVector3) return;
+  if (root.userData?.lockFlatTableOrientation) return;
   const forward = target.clone().sub(root.position).setY(0);
   if (forward.lengthSq() < 1e-6) return;
   root.quaternion.setFromUnitVectors(MISSILE_FORWARD, forward.normalize());
@@ -1056,6 +1058,8 @@ async function attachFirearmToRightHand(attackerEntry, captureAnimationId) {
 
 async function createCaptureWeaponRackFx() {
   const root = new THREE.Group();
+  // Firearm rack stays flat/straight instead of aiming toward board center.
+  root.userData.lockFlatTableOrientation = true;
   const weaponHolder = new THREE.Group();
   weaponHolder.position.set(0.04, 0.032, -0.018);
   weaponHolder.rotation.set(0, 0, 0);


### PR DESCRIPTION
### Motivation
- Normalize parked firearm presentation so all weapons appear in the exact same spot and orientation on the Ludo table, matching the AK47 reference.
- Prevent parked firearm racks from auto-rotating toward the board center so the front/back orientation stays visually flat on the table.

### Description
- Changed `FIREARM_RACK_DISPLAY_TUNING.default` and `FIREARM_RACK_DISPLAY_TUNING.large` to use the AK47 baseline `position` and `rotation` values so all weapons park at the same table spot and orientation.
- Updated `BOTTOM_PLAYER_FIREARM_RACK_DISPLAY_TUNING` to the same AK47 baseline so the bottom player's parked weapon matches the global baseline.
- Added a guard to `orientCaptureVehicleTowardBoardCenter` to skip auto-rotation when `root.userData.lockFlatTableOrientation` is set.
- Set `root.userData.lockFlatTableOrientation = true` in `createCaptureWeaponRackFx` so created firearm-rack roots remain flat/straight instead of aiming at the board center.

### Testing
- Ran the production build with `npm --prefix webapp run -s build`, which completed successfully; Vite produced non-blocking warnings about duplicate package key and chunk-size/dynamic-import hints.
- No unit tests were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0b0fd0d988329b958f8382d09c043)