### PR TITLE
Pool Royal: human perimeter offset, tighter cue camera, and GLTF texture handling

### DIFF
--- a/Assets/Scripts/Gameplay/PoolHumanPoseDriver.cs
+++ b/Assets/Scripts/Gameplay/PoolHumanPoseDriver.cs
@@ -36,7 +36,7 @@ namespace Aiming
         public float sourceTableLength = 3.6f;
         [Tooltip("Reference table width from source implementation.")]
         public float sourceTableWidth = 2f;
-        public float edgeMargin = 0.21f;
+        public float edgeMargin = 0.3f;
         public float desiredShootDistance = 0.74f;
         [Tooltip("Optional helper waypoints around table sides (left, right, bottom, top) for Bilardo-style perimeter walking.")]
         public Transform[] sideWalkHelpers;

--- a/Assets/Scripts/Gameplay/Rendering/GltfMaterialCompatibilityAdapter.cs
+++ b/Assets/Scripts/Gameplay/Rendering/GltfMaterialCompatibilityAdapter.cs
@@ -22,6 +22,11 @@ namespace Aiming.Gameplay.Rendering
         private static readonly int MetallicGlossMapId = Shader.PropertyToID("_MetallicGlossMap");
         private static readonly int OcclusionMapId = Shader.PropertyToID("_OcclusionMap");
         private static readonly int EmissionMapId = Shader.PropertyToID("_EmissionMap");
+        private static readonly int BaseColorTextureId = Shader.PropertyToID("_BaseColorTexture");
+        private static readonly int MetallicRoughnessMapId = Shader.PropertyToID("_MetallicRoughnessMap");
+        private static readonly int NormalTextureId = Shader.PropertyToID("_NormalTexture");
+        private static readonly int EmissiveTextureId = Shader.PropertyToID("_EmissiveTexture");
+        private static readonly int OcclusionTextureId = Shader.PropertyToID("_OcclusionTexture");
 
         void Awake()
         {
@@ -107,11 +112,9 @@ namespace Aiming.Gameplay.Rendering
 
         private static void CopyPbrMaps(Material material)
         {
-            Texture baseTexture = FirstTexture(material, BaseMapId, MainTexId);
-            if (baseTexture != null)
+            if (TryCopyTexture(material, BaseMapId, BaseColorTextureId, MainTexId))
             {
-                TrySetTexture(material, BaseMapId, baseTexture);
-                TrySetTexture(material, MainTexId, baseTexture);
+                CopyTextureTransform(material, BaseMapId, MainTexId);
             }
 
             if (material.HasProperty(BaseColorId) && material.HasProperty(ColorId))
@@ -125,31 +128,50 @@ namespace Aiming.Gameplay.Rendering
                 material.SetColor(BaseColorId, mainColor);
             }
 
-            Texture normal = FirstTexture(material, BumpMapId);
-            if (normal != null)
+            if (TryCopyTexture(material, BumpMapId, NormalTextureId))
             {
-                TrySetTexture(material, BumpMapId, normal);
+                CopyTextureTransform(material, BumpMapId, NormalTextureId);
                 material.EnableKeyword("_NORMALMAP");
             }
 
-            Texture metallic = FirstTexture(material, MetallicGlossMapId);
-            if (metallic != null)
+            if (TryCopyTexture(material, MetallicGlossMapId, MetallicRoughnessMapId))
             {
-                TrySetTexture(material, MetallicGlossMapId, metallic);
+                CopyTextureTransform(material, MetallicGlossMapId, MetallicRoughnessMapId);
             }
 
-            Texture occlusion = FirstTexture(material, OcclusionMapId);
-            if (occlusion != null)
+            if (TryCopyTexture(material, OcclusionMapId, OcclusionTextureId))
             {
-                TrySetTexture(material, OcclusionMapId, occlusion);
+                CopyTextureTransform(material, OcclusionMapId, OcclusionTextureId);
             }
 
-            Texture emission = FirstTexture(material, EmissionMapId);
-            if (emission != null)
+            if (TryCopyTexture(material, EmissionMapId, EmissiveTextureId))
             {
-                TrySetTexture(material, EmissionMapId, emission);
+                CopyTextureTransform(material, EmissionMapId, EmissiveTextureId);
                 material.EnableKeyword("_EMISSION");
             }
+        }
+
+        private static bool TryCopyTexture(Material material, int destinationProperty, params int[] sourceProperties)
+        {
+            int sourceProperty;
+            Texture texture = FirstTextureWithProperty(material, sourceProperties, out sourceProperty);
+            if (texture == null)
+            {
+                return false;
+            }
+
+            TrySetTexture(material, destinationProperty, texture);
+            if (material.HasProperty(MainTexId) && destinationProperty == BaseMapId)
+            {
+                TrySetTexture(material, MainTexId, texture);
+            }
+
+            if (sourceProperty >= 0)
+            {
+                CopyTextureTransform(material, sourceProperty, destinationProperty);
+            }
+
+            return true;
         }
 
         private static Texture FirstTexture(Material material, params int[] texturePropertyIds)
@@ -172,12 +194,45 @@ namespace Aiming.Gameplay.Rendering
             return null;
         }
 
+        private static Texture FirstTextureWithProperty(Material material, int[] texturePropertyIds, out int selectedPropertyId)
+        {
+            selectedPropertyId = -1;
+            for (int i = 0; i < texturePropertyIds.Length; i++)
+            {
+                int propertyId = texturePropertyIds[i];
+                if (!material.HasProperty(propertyId))
+                {
+                    continue;
+                }
+
+                Texture tex = material.GetTexture(propertyId);
+                if (tex != null)
+                {
+                    selectedPropertyId = propertyId;
+                    return tex;
+                }
+            }
+
+            return null;
+        }
+
         private static void TrySetTexture(Material material, int propertyId, Texture texture)
         {
             if (material.HasProperty(propertyId))
             {
                 material.SetTexture(propertyId, texture);
             }
+        }
+
+        private static void CopyTextureTransform(Material material, int sourcePropertyId, int destinationPropertyId)
+        {
+            if (!material.HasProperty(sourcePropertyId) || !material.HasProperty(destinationPropertyId))
+            {
+                return;
+            }
+
+            material.SetTextureScale(destinationPropertyId, material.GetTextureScale(sourcePropertyId));
+            material.SetTextureOffset(destinationPropertyId, material.GetTextureOffset(sourcePropertyId));
         }
     }
 }

--- a/billiards.Unity/CueCamera.cs
+++ b/billiards.Unity/CueCamera.cs
@@ -29,7 +29,7 @@ public class CueCamera : MonoBehaviour
     // Distance from the cue ball used for the lowest aiming view.  This keeps the
     // camera hovering over the mid–upper portion of the cue rather than slipping
     // all the way back to the plastic end.
-    public float cueLoweredDistanceFromBall = 0.04f;
+    public float cueLoweredDistanceFromBall = 0.025f;
     // Additional pull-in applied to the cue camera so the portrait framing hugs
     // the cloth like a player leaning over the shot.
     public float cueDistancePullIn = 0.55f;
@@ -48,7 +48,7 @@ public class CueCamera : MonoBehaviour
     public float cueLoweredHeight = 0.25f;
     // Extra forward push applied as the player lowers the camera so the framing
     // stays tight on the cue ball and shaft instead of drifting backward.
-    public float cueLoweredForwardPush = 0.08f;
+    public float cueLoweredForwardPush = 0.11f;
     // Keep a small safety buffer from the butt of the cue so the camera never
     // retreats past the stick and always looks down the shaft.
     public float cueButtClearance = 0.12f;
@@ -114,7 +114,7 @@ public class CueCamera : MonoBehaviour
     // Scale applied once the camera is fully lowered toward the cue. Lower
     // values bring the framing tighter to the cue ball and aiming line.
     [Range(0.1f, 1f)]
-    public float cueLoweredDistanceScale = 0.38f;
+    public float cueLoweredDistanceScale = 0.3f;
     // Bias used when lowering the camera to keep it hovering just above the cue
     // instead of drifting upward toward the player's face.
     [Range(0.1f, 1f)]


### PR DESCRIPTION
### Motivation
- Move the human avatar visually farther outside the table perimeter so the character sits on the rail edge instead of overlapping the play area.  
- Bring the cue camera closer/tighter in the lowered aiming state to match the requested portrait framing that hugs the cue.  
- Preserve original GLTF texture mappings when converting materials so imported human character textures keep their UV tiling/offset and appear as intended.

### Description
- Increased the human perimeter offset by changing `edgeMargin` from `0.21` to `0.3` in `Assets/Scripts/Gameplay/PoolHumanPoseDriver.cs` so the avatar positions farther outside the table.  
- Tightened cue-camera aiming framing in `billiards.Unity/CueCamera.cs` by adjusting `cueLoweredDistanceFromBall`, `cueLoweredForwardPush`, and `cueLoweredDistanceScale` for a closer portrait view.  
- Extended `Assets/Scripts/Gameplay/Rendering/GltfMaterialCompatibilityAdapter.cs` to recognize common GLTF texture properties (`_BaseColorTexture`, `_NormalTexture`, `_MetallicRoughnessMap`, `_OcclusionTexture`, `_EmissiveTexture`) and added `TryCopyTexture`, `FirstTextureWithProperty`, and `CopyTextureTransform` helpers to copy texture references and preserve texture scale/offset between source and destination shader properties.  
- Kept existing behavior such as fallback shader selection and enabling `_NORMALMAP`/`_EMISSION` keywords when appropriate.

### Testing
- Ran `git diff --check` on the modified files which reported no whitespace or diff-check errors.  
- Attempted to run `dotnet test` for the C# test project but it could not be executed in this environment because `dotnet` is not installed.  
- No Unity editor/PlayMode build was executed in this environment, so runtime/graphics validation should be performed locally in the Unity editor or CI build to confirm camera framing and GLTF texture results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0b33663ec83299792911723c5c527)