### PR TITLE
Pool Royale: push human outward, bring cue camera closer, and stabilize GLTF human rig

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1939,7 +1939,7 @@ const HUMAN_PLAYER_REACT_LEAN = 0.12;
 const HUMAN_POSE_LAMBDA = 9.0;
 const HUMAN_MOVE_LAMBDA = 5.6;
 const HUMAN_ROT_LAMBDA = 8.5;
-const HUMAN_EDGE_MARGIN = 0.58;
+const HUMAN_EDGE_MARGIN = 0.72; // push the shooter farther outward so the body stays clearly on the table perimeter
 const HUMAN_DESIRED_SHOOT_DISTANCE = 1.42; // keep the shooter farther back on the cue butt side instead of drifting over the shaft
 const HUMAN_SHOOT_BLEND_THRESHOLD = 0.72; // enter shooting pose earlier when the cue camera starts getting lowered
 const HUMAN_WALK_RING_MARGIN = TABLE.WALL * 3.1; // keep player roots on a perimeter ring outside the table footprint
@@ -6165,7 +6165,7 @@ const RAIL_OVERHEAD_DISTANCE_BIAS = 0.94; // pull broadcast rail camera inward f
 const SHORT_RAIL_CAMERA_DISTANCE =
   computeTopViewBroadcastDistance() * RAIL_OVERHEAD_DISTANCE_BIAS; // match the 2D top view framing distance for overhead rail cuts while keeping a touch of breathing room
 const SIDE_RAIL_CAMERA_DISTANCE = SHORT_RAIL_CAMERA_DISTANCE; // keep side-rail framing aligned with the top view scale
-const CUE_VIEW_RADIUS_RATIO = 0.0205; // tighten cue camera distance so the cue ball and object ball appear larger
+const CUE_VIEW_RADIUS_RATIO = 0.0178; // move cue camera closer for a tighter portrait aiming view
 const CUE_VIEW_MIN_RADIUS = CAMERA.minR * 0.08;
 const CUE_VIEW_MIN_PHI = Math.min(
   CAMERA.maxPhi - CAMERA_RAIL_SAFETY,

--- a/webapp/src/pages/Games/shared/bilardoHumanRig.js
+++ b/webapp/src/pages/Games/shared/bilardoHumanRig.js
@@ -113,6 +113,18 @@ function normalizeHuman(model, opts) {
   model.position.set(-center.x, -box.min.y, -center.z);
 }
 
+function applyOriginalGltfTextureSettings(texture, { isColor = false, anisotropy = null } = {}) {
+  if (!texture) return;
+  if (isColor) {
+    texture.colorSpace = THREE.SRGBColorSpace;
+  }
+  texture.flipY = false;
+  if (Number.isFinite(anisotropy)) {
+    texture.anisotropy = Math.max(1, anisotropy);
+  }
+  texture.needsUpdate = true;
+}
+
 export function createBilardoHumanRig(scene, opts = {}) {
   const textureAnisotropy = Number.isFinite(opts?.textureAnisotropy)
     ? Math.max(1, opts.textureAnisotropy)
@@ -178,46 +190,36 @@ export function createBilardoHumanRig(scene, opts = {}) {
         obj.castShadow = true;
         obj.receiveShadow = true;
         obj.frustumCulled = false;
-        const mats = Array.isArray(obj.material)
+        const sourceMats = Array.isArray(obj.material)
           ? obj.material
           : obj.material
             ? [obj.material]
             : [];
+        const mats = sourceMats.map((material) => (material?.clone ? material.clone() : material));
+        if (Array.isArray(obj.material)) obj.material = mats;
+        else obj.material = mats[0] ?? obj.material;
         mats.forEach((m) => {
           if (!m) return;
-          if (m.color) {
-            const hsl = { h: 0, s: 0, l: 0 };
-            m.color.getHSL(hsl);
-            hsl.l = Math.max(hsl.l, 0.36);
-            hsl.s = Math.max(hsl.s, 0.16);
-            m.color.setHSL(hsl.h, hsl.s, hsl.l);
-          }
-          if (m.map) {
-            m.map.colorSpace = THREE.SRGBColorSpace;
-            if (textureAnisotropy != null) m.map.anisotropy = textureAnisotropy;
-            m.map.needsUpdate = true;
-          }
-          if (m.emissiveMap) {
-            m.emissiveMap.colorSpace = THREE.SRGBColorSpace;
-            if (textureAnisotropy != null) m.emissiveMap.anisotropy = textureAnisotropy;
-            m.emissiveMap.needsUpdate = true;
-          }
-          if (m.normalMap && textureAnisotropy != null) {
-            m.normalMap.anisotropy = textureAnisotropy;
-            m.normalMap.needsUpdate = true;
-          }
-          if (m.roughnessMap && textureAnisotropy != null) {
-            m.roughnessMap.anisotropy = textureAnisotropy;
-            m.roughnessMap.needsUpdate = true;
-          }
-          if (m.metalnessMap && textureAnisotropy != null) {
-            m.metalnessMap.anisotropy = textureAnisotropy;
-            m.metalnessMap.needsUpdate = true;
-          }
-          if (m.alphaMap) {
-            if (textureAnisotropy != null) m.alphaMap.anisotropy = textureAnisotropy;
-            m.alphaMap.needsUpdate = true;
-          }
+          applyOriginalGltfTextureSettings(m.map, {
+            isColor: true,
+            anisotropy: textureAnisotropy
+          });
+          applyOriginalGltfTextureSettings(m.emissiveMap, {
+            isColor: true,
+            anisotropy: textureAnisotropy
+          });
+          applyOriginalGltfTextureSettings(m.normalMap, {
+            anisotropy: textureAnisotropy
+          });
+          applyOriginalGltfTextureSettings(m.roughnessMap, {
+            anisotropy: textureAnisotropy
+          });
+          applyOriginalGltfTextureSettings(m.metalnessMap, {
+            anisotropy: textureAnisotropy
+          });
+          applyOriginalGltfTextureSettings(m.alphaMap, {
+            anisotropy: textureAnisotropy
+          });
           m.opacity = Math.max(0.96, Number.isFinite(m.opacity) ? m.opacity : 1);
           if (m.roughness != null) m.roughness = Math.min(m.roughness, 0.95);
           if (m.metalness != null) m.metalness = Math.min(m.metalness, 0.25);
@@ -552,7 +554,9 @@ export function chooseHumanEdgePosition(cueBallWorld, aimForward, opts = {}) {
 }
 
 export function updateBilardoHumanPose(human, dt, frameData) {
-  if (!human) return;
+  if (!human || !frameData) return;
+  if (!Number.isFinite(dt) || dt < 0) return;
+  if (!frameData.rootTarget || !frameData.aimForward) return;
   const cfg = human.cfg;
   const state = frameData.state || 'idle';
 
@@ -573,6 +577,9 @@ export function updateBilardoHumanPose(human, dt, frameData) {
   }
 
   const rootGoal = state === 'striking' ? human.strikeRoot : frameData.rootTarget;
+  if (!Number.isFinite(rootGoal?.x) || !Number.isFinite(rootGoal?.y) || !Number.isFinite(rootGoal?.z)) {
+    return;
+  }
   human.root.position.lerp(rootGoal, 1 - Math.exp(-(state === 'striking' ? 12 : cfg.moveLambda) * dt));
   const moveAmountRaw = human.root.position.distanceTo(rootGoal);
   human.walkT += dt * (2 + Math.min(7, moveAmountRaw * 10));
@@ -693,7 +700,7 @@ export function updateBilardoHumanPose(human, dt, frameData) {
     rightKnee,
     leftFootWorld: leftFoot,
     rightFootWorld: rightFoot,
-    cueBackWorld: frameData.cueBack,
-    cueTipWorld: frameData.cueTip
+    cueBackWorld: frameData.cueBack || frameData.bridgeTarget || frameData.rootTarget,
+    cueTipWorld: frameData.cueTip || frameData.gripTarget || frameData.rootTarget
   });
 }


### PR DESCRIPTION
### Motivation
- Make the human shooter sit visibly outside the table perimeter and make the cue aiming camera feel closer on portrait screens to match the requested visual changes. 
- Prevent crashes and visual regressions caused by GLTF material/texture handling for the human character by restoring original texture mapping semantics used across other games. 

### Description
- Move shooter outward by increasing `HUMAN_EDGE_MARGIN` from `0.58` to `0.72` in `PoolRoyale.jsx`. 
- Bring cue camera visually closer by reducing `CUE_VIEW_RADIUS_RATIO` from `0.0205` to `0.0178` in `PoolRoyale.jsx`. 
- Add `applyOriginalGltfTextureSettings` in `webapp/src/pages/Games/shared/bilardoHumanRig.js` to preserve GLTF texture orientation (`flipY = false`), apply SRGB color space for color maps, set anisotropy, and call `needsUpdate`. 
- Clone mesh materials per-instance before runtime tuning (avoid editing shared materials) and remove the runtime HSL recolor so original GLTF texture mapping/appearance is preserved. 
- Harden `updateBilardoHumanPose` with early guards for invalid inputs (`human`, `frameData`, `dt`, required vectors) and finite-coordinate checks, and add fallbacks for missing `cueBack`/`cueTip` values to reduce crash surface. 

### Testing
- Ran ESLint on the modified files with repository ignore rules (`npx eslint webapp/src/pages/Games/shared/bilardoHumanRig.js webapp/src/pages/Games/PoolRoyale.jsx`) which completed with warnings about ignored files. 
- Ran ESLint forcing lint of the shared file (`npx eslint --no-ignore webapp/src/pages/Games/shared/bilardoHumanRig.js webapp/src/pages/Games/PoolRoyale.jsx`) which reported many pre-existing style rule violations (semicolons/spacing) unrelated to the functional changes; these are lint-style issues present in the repo rather than runtime defects introduced by this patch. 
- No unit tests were modified or added; changes are focused on runtime safety and asset handling for the Pool Royale human rig.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0b33663ec83299792911723c5c527)