### PR TITLE
Unify Ludo firearm rack grip alignment

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -994,6 +994,16 @@ function findObjectByNeedles(root, needles = []) {
   return match;
 }
 
+function normalizeFirearmRackGripAnchor(weaponObject) {
+  if (!weaponObject?.isObject3D) return;
+  weaponObject.updateMatrixWorld?.(true);
+  const sourceRightGrip = findObjectByNeedles(weaponObject, ['r_wrist', 'right_wrist', 'trigger', 'grip', 'handle']);
+  if (!sourceRightGrip?.isObject3D) return;
+  sourceRightGrip.updateMatrixWorld?.(true);
+  const gripLocal = weaponObject.worldToLocal(sourceRightGrip.getWorldPosition(new THREE.Vector3()));
+  weaponObject.position.sub(gripLocal);
+}
+
 async function attachFirearmToRightHand(attackerEntry, captureAnimationId) {
   const rightHand = attackerEntry?.rig?.rightHand;
   if (!rightHand?.isBone) return null;
@@ -1144,6 +1154,8 @@ async function applyCaptureWeaponDisplay(entry, captureAnimationId) {
     clone,
     CAPTURE_PARK_BOX_TARGET_SIZE * displayTuning.targetSizeMultiplier * weaponRackScaleMultiplier
   );
+  // Keep every parked weapon grip/trigger point in one unified pickup slot.
+  normalizeFirearmRackGripAnchor(clone);
   clone.position.x += displayPosition[0];
   clone.position.y += displayPosition[1];
   clone.position.z += displayPosition[2];


### PR DESCRIPTION
### Motivation
- Parked weapons on the Ludo table need a consistent grip/trigger position so the human right-hand pickup, aim and shoot animations line up visually across all weapon models.

### Description
- Added `normalizeFirearmRackGripAnchor(weaponObject)` which searches for grip/trigger bones via `findObjectByNeedles` (needles: `r_wrist`, `right_wrist`, `trigger`, `grip`, `handle`) and recenters the cloned model so its grip sits at the model origin.
- Applied the normalization in `applyCaptureWeaponDisplay` immediately after `fitObjectToTargetSize` so every parked weapon uses a unified AK47-style handle anchor before final positioning and rotation (`webapp/src/pages/Games/LudoBattleRoyal.jsx`).

### Testing
- Ran `npm run build` which completed successfully.
- Ran `npx eslint --no-ignore webapp/src/pages/Games/LudoBattleRoyal.jsx` which reported a repo ignore warning for the file but no new lint errors from the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0b8ade1c483299d869a4839d57981)