### PR TITLE
Normalize firearm rack orientation and add grip-anchor alignment

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -246,6 +246,12 @@ const UNIFORM_FIREARM_RACK_DISPLAY_TUNING = Object.freeze({
   position: [...FIREARM_RACK_DISPLAY_TUNING_BY_ID.ak47VolleyAttack.position],
   rotation: [...FIREARM_RACK_DISPLAY_TUNING_BY_ID.ak47VolleyAttack.rotation]
 });
+const UNIFORM_FIREARM_RACK_GRIP_ANCHOR = Object.freeze({
+  // Keep every firearm's trigger/grip region in the same local slot so right-hand pickup
+  // alignment stays consistent when transitioning from rack -> hand attachment.
+  position: [0.086, 0.008, -0.02],
+  minSurfaceY: 0
+});
 const FIREARM_RACK_PARKING_TUNING = Object.freeze({
   // Small sidearms sit tight next to the token on its right-hand side.
   small: Object.freeze({
@@ -766,9 +772,11 @@ function orientCaptureVehicleTowardBoardCenter(root, target) {
   root.quaternion.setFromUnitVectors(MISSILE_FORWARD, forward.normalize());
 }
 
-function orientFirearmRackFlat(root) {
-  if (!root?.isObject3D) return;
-  root.rotation.set(0, 0, 0);
+function orientFirearmRackTowardBoardCenter(root, origin, target) {
+  if (!root?.isObject3D || !origin?.isVector3 || !target?.isVector3) return;
+  const forward = target.clone().sub(origin).setY(0);
+  if (forward.lengthSq() < 1e-6) return;
+  root.quaternion.setFromUnitVectors(MISSILE_FORWARD, forward.normalize());
 }
 
 function playCaptureWeaponSourceSound(captureAnimationId, { volume = 1, muted = false } = {}) {
@@ -994,6 +1002,56 @@ function findObjectByNeedles(root, needles = []) {
   return match;
 }
 
+function alignFirearmRackGripAnchor(root) {
+  if (!root?.isObject3D) return;
+  root.updateMatrixWorld?.(true);
+  const gripNode =
+    findObjectByNeedles(root, [
+      'trigger',
+      'grip',
+      'handle',
+      'r_wrist',
+      'right_wrist',
+      'hand_r',
+      'r_hand'
+    ]) || null;
+  if (gripNode?.isObject3D) {
+    gripNode.updateMatrixWorld?.(true);
+    const gripLocal = root.worldToLocal(gripNode.getWorldPosition(new THREE.Vector3()));
+    const anchor = new THREE.Vector3(...UNIFORM_FIREARM_RACK_GRIP_ANCHOR.position);
+    root.position.add(anchor.sub(gripLocal));
+  }
+  root.updateMatrixWorld?.(true);
+  const bounds = new THREE.Box3().setFromObject(root);
+  if (Number.isFinite(bounds.min.y) && bounds.min.y < UNIFORM_FIREARM_RACK_GRIP_ANCHOR.minSurfaceY) {
+    root.position.y += UNIFORM_FIREARM_RACK_GRIP_ANCHOR.minSurfaceY - bounds.min.y;
+  }
+}
+
+function applyFlattestFirearmOrientation(root, baseRotation) {
+  if (!root?.isObject3D || !Array.isArray(baseRotation)) return;
+  const candidates = [
+    [0, 0, 0],
+    [Math.PI * 0.5, 0, 0],
+    [-Math.PI * 0.5, 0, 0],
+    [0, 0, Math.PI * 0.5],
+    [0, 0, -Math.PI * 0.5]
+  ];
+  let bestRotation = [baseRotation[0], baseRotation[1], baseRotation[2]];
+  let bestHeight = Number.POSITIVE_INFINITY;
+  candidates.forEach((extra) => {
+    root.rotation.set(baseRotation[0] + extra[0], baseRotation[1] + extra[1], baseRotation[2] + extra[2]);
+    root.updateMatrixWorld?.(true);
+    const bounds = new THREE.Box3().setFromObject(root);
+    const height = bounds.getSize(new THREE.Vector3()).y;
+    if (height < bestHeight) {
+      bestHeight = height;
+      bestRotation = [baseRotation[0] + extra[0], baseRotation[1] + extra[1], baseRotation[2] + extra[2]];
+    }
+  });
+  root.rotation.set(bestRotation[0], bestRotation[1], bestRotation[2]);
+}
+
 async function attachFirearmToRightHand(attackerEntry, captureAnimationId) {
   const rightHand = attackerEntry?.rig?.rightHand;
   if (!rightHand?.isBone) return null;
@@ -1147,7 +1205,8 @@ async function applyCaptureWeaponDisplay(entry, captureAnimationId) {
   clone.position.x += displayPosition[0];
   clone.position.y += displayPosition[1];
   clone.position.z += displayPosition[2];
-  clone.rotation.set(...displayRotation);
+  applyFlattestFirearmOrientation(clone, displayRotation);
+  alignFirearmRackGripAnchor(clone);
   entry.weaponHolder.add(clone);
 }
 
@@ -6988,7 +7047,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       entry.weaponRack.position.copy(basePosition);
       alignObjectBottomToY(entry.weaponRack, arena.tableInfo?.surfaceY);
       entry.weaponRack.position.y += CAPTURE_PARKED_LIFT_OFFSET_Y;
-      orientFirearmRackFlat(entry.weaponRack);
+      orientFirearmRackTowardBoardCenter(entry.weaponRack, kingPos, arena.boardLookTarget);
     };
     parkedCaptureVehiclesRef.current.forEach((entry, playerIndex) => {
       const optionIndex = playerIndex > 0 ? aiLoadoutByPlayer[playerIndex]?.captureAnimationIndex ?? 0 : humanOptionIndex;
@@ -7107,7 +7166,11 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       orientCaptureVehicleTowardBoardCenter(droneFx.root, arena.boardLookTarget);
       orientCaptureVehicleTowardBoardCenter(missileFx.root, arena.boardLookTarget);
       orientCaptureVehicleTowardBoardCenter(droneTruckFx.root, arena.boardLookTarget);
-      orientFirearmRackFlat(weaponRackFx.root);
+      orientFirearmRackTowardBoardCenter(
+        weaponRackFx.root,
+        getKingTokenPositionForPlayer(playerIndex) ?? weaponRackFx.root.position,
+        arena.boardLookTarget
+      );
       arena.scene.add(jetFx.root);
       arena.scene.add(helicopterFx.root);
       arena.scene.add(droneFx.root);


### PR DESCRIPTION
### Motivation

- Ensure firearms displayed on player racks present a consistent, low-profile orientation and that the trigger/grip area aligns to a uniform pickup slot so right-hand attachments transition cleanly.
- Make parked weapon racks face the board center so visuals and interactions are oriented toward the play area.

### Description

- Introduce `UNIFORM_FIREARM_RACK_GRIP_ANCHOR` to define a common grip/trigger anchor and minimum surface Y for firearm models.  
- Replace `orientFirearmRackFlat` with `orientFirearmRackTowardBoardCenter(root, origin, target)` to orient racks toward the board center using an origin and target.  
- Add `alignFirearmRackGripAnchor` to translate weapon models so a detected grip/trigger node lands at the uniform anchor and to enforce `minSurfaceY`.  
- Add `applyFlattestFirearmOrientation` which trials several canonical rotations and selects the one that minimizes model height, and apply it plus `alignFirearmRackGripAnchor` when placing weapons in racks; update parked rack placement and refresh logic to call the new orientation function.

### Testing

- Ran the existing automated test suite via `yarn test` and the linter via `yarn lint`, and both completed successfully.  
- No new automated tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0b8ade1c483299d869a4839d57981)