### PR TITLE
Align human cue grip with Bilardo stance and enable eye-level aiming camera

### DIFF
--- a/Assets/Scripts/Gameplay/PoolHumanPoseDriver.cs
+++ b/Assets/Scripts/Gameplay/PoolHumanPoseDriver.cs
@@ -61,6 +61,10 @@ namespace Aiming
         [Range(0f, 0.4f)] public float gripPullRange = 0.24f;
         [Tooltip("Right hand grip point from cue root towards cue tip (meters).")]
         [Range(0.05f, 0.9f)] public float rightHandGripFromCueRoot = 0.18f;
+        [Tooltip("Primary right hand grip distance measured backward from cue tip (meters). Keeps the hand behind the bridge like Bilardo stance.")]
+        [Range(0.12f, 1.2f)] public float rightHandGripFromCueTip = 0.42f;
+        [Tooltip("Minimum spacing between bridge hand and grip hand along cue axis.")]
+        [Range(0.14f, 0.75f)] public float rightHandBackFromBridge = 0.34f;
         [Tooltip("Small right-hand vertical offset so fingers wrap the cue instead of intersecting it.")]
         [Range(-0.1f, 0.15f)] public float rightHandVerticalOffset = 0.025f;
         [Tooltip("Moves chest/head closer to cue line to mimic real snooker stance.")]
@@ -517,7 +521,7 @@ namespace Aiming
             SetNodePose(rightFoot, rightFootWorld + new Vector3(0f, -0.02f * s, 0f), side, forward, new Vector3(0f, 0.16f * t, 0f));
         }
 
-        Vector3 ResolveRightHandGripTarget(Vector3 aimForward, Vector3 aimSide, Vector3 fallbackTarget, float handPull, float s)
+        Vector3 ResolveRightHandGripTarget(Vector3 aimForward, Vector3 aimSide, Vector3 bridgeHandTarget, float handPull, float s)
         {
             if (cueController != null && cueController.cueTip != null)
             {
@@ -529,17 +533,29 @@ namespace Aiming
                 {
                     Vector3 cueDir = cueVector.normalized;
                     float cueLength = cueVector.magnitude;
-                    float gripDistance = Mathf.Clamp(rightHandGripFromCueRoot, 0.05f, cueLength - 0.03f);
-                    Vector3 grip = cueRootPos + (cueDir * gripDistance);
+                    float minBridgeSpacing = Mathf.Clamp(rightHandBackFromBridge, 0.1f, cueLength - 0.03f) * s;
+                    float gripFromTip = Mathf.Clamp(rightHandGripFromCueTip * s, minBridgeSpacing, cueLength - 0.03f);
+                    float gripFromRoot = Mathf.Clamp(rightHandGripFromCueRoot * s, 0.05f, cueLength - 0.03f);
+
+                    Vector3 tipBasedGrip = cueTipPos - (cueDir * gripFromTip);
+                    Vector3 rootBasedGrip = cueRootPos + (cueDir * gripFromRoot);
+                    Vector3 grip = Vector3.Lerp(rootBasedGrip, tipBasedGrip, 0.75f);
                     grip += (cueDir * -handPull);
+
+                    float alongFromBridge = Vector3.Dot(grip - bridgeHandTarget, cueDir);
+                    if (alongFromBridge > -minBridgeSpacing)
+                    {
+                        grip = bridgeHandTarget - (cueDir * minBridgeSpacing);
+                    }
+
                     grip += (Vector3.up * (rightHandVerticalOffset * s));
                     grip += (aimSide * (0.018f * s));
                     return grip;
                 }
             }
 
-            return fallbackTarget +
-                   (aimForward * (-handPull)) +
+            return bridgeHandTarget +
+                   (aimForward * (-(rightHandBackFromBridge * s) - handPull)) +
                    (Vector3.up * (rightHandVerticalOffset * s)) +
                    (aimSide * (0.022f * s));
         }

--- a/billiards.Unity/CueCamera.cs
+++ b/billiards.Unity/CueCamera.cs
@@ -95,6 +95,9 @@ public class CueCamera : MonoBehaviour
     // the cue camera blends into the player's dominant-eye view so the avatar
     // eyes are not visible in frame.
     public Transform playerEyeAnchor;
+    // Keep the cue aiming camera in eye-level first-person while lining up shots
+    // so the avatar body does not block the frame.
+    public bool forceEyeViewDuringCueAim = true;
     // How strongly the lowered cue camera should blend into first-person view.
     [Range(0f, 1f)]
     public float eyeViewBlendStrength = 1f;
@@ -796,10 +799,17 @@ public class CueCamera : MonoBehaviour
         float targetBlend = 0f;
         if (!shotInProgress && playerEyeAnchor != null)
         {
-            float start = Mathf.Clamp01(eyeViewStartLowering);
-            float loweringWindow = Mathf.Max(0.0001f, 1f - start);
-            float loweringT = Mathf.Clamp01((cueLoweringBlend - start) / loweringWindow);
-            targetBlend = loweringT * Mathf.Clamp01(eyeViewBlendStrength);
+            if (forceEyeViewDuringCueAim)
+            {
+                targetBlend = Mathf.Clamp01(eyeViewBlendStrength);
+            }
+            else
+            {
+                float start = Mathf.Clamp01(eyeViewStartLowering);
+                float loweringWindow = Mathf.Max(0.0001f, 1f - start);
+                float loweringT = Mathf.Clamp01((cueLoweringBlend - start) / loweringWindow);
+                targetBlend = loweringT * Mathf.Clamp01(eyeViewBlendStrength);
+            }
         }
 
         float blendLerp = 1f - Mathf.Exp(-Mathf.Max(0f, cueAxisSmoothSpeed) * Mathf.Max(0f, deltaTime));


### PR DESCRIPTION
### Motivation
- Prevent the human avatar's right hand from ending up in front of the cue and reproduce the Bilardo (Bilardo Shqip) holding behaviour so the grip and bridge spacing remain visually correct during pullback and strike.
- Make the aiming camera remain at the player eye level while lining up shots so the avatar's back is not visible and framing matches a player’s viewpoint in portrait play.

### Description
- Added tuning fields `rightHandGripFromCueTip` and `rightHandBackFromBridge` to `PoolHumanPoseDriver` to expose tip-based grip distance and minimum bridge-to-grip spacing for quick visual parity adjustments.
- Reworked `ResolveRightHandGripTarget` in `PoolHumanPoseDriver` to compute a tip-based grip position blended with a root-based estimate, apply pullback offset, and enforce a minimum spacing behind the bridge hand so the right hand cannot move in front of the cue.
- Updated fallback behavior so when cue geometry is unavailable the grip is positioned relative to `bridgeHandTarget` with a safe back offset.
- Added `forceEyeViewDuringCueAim` to `CueCamera` and changed `ApplyEyeViewOverride` so the camera can be forced to blend fully into the `playerEyeAnchor` view during aiming to keep the camera on the avatar’s eyes.
- Files changed: `Assets/Scripts/Gameplay/PoolHumanPoseDriver.cs` and `billiards.Unity/CueCamera.cs`.

### Testing
- Repository sanity/diff checks and working-tree validation completed and reported no immediate code-check issues (sanity checks passed).
- No Unity Editor or PlayMode runtime tests were executed in this CLI environment, so in‑engine verification (pose/camera framing and playmode behavior) remains to be validated in the Unity Editor or CI that runs playmode tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0c386b2e48329b054be581a5215eb)