### PR TITLE
Align firearm rack models: facing, grip anchoring, and orientation toward board center

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -246,6 +246,12 @@ const UNIFORM_FIREARM_RACK_DISPLAY_TUNING = Object.freeze({
   position: [...FIREARM_RACK_DISPLAY_TUNING_BY_ID.ak47VolleyAttack.position],
   rotation: [...FIREARM_RACK_DISPLAY_TUNING_BY_ID.ak47VolleyAttack.rotation]
 });
+const UNIFORM_FIREARM_RACK_GRIP_ANCHOR = Object.freeze({
+  // Keep every firearm's trigger/grip region in the same local slot so right-hand pickup
+  // alignment stays consistent when transitioning from rack -> hand attachment.
+  position: [0.086, 0.008, -0.02],
+  minSurfaceY: 0
+});
 const FIREARM_RACK_PARKING_TUNING = Object.freeze({
   // Small sidearms sit tight next to the token on its right-hand side.
   small: Object.freeze({
@@ -771,6 +777,19 @@ function orientFirearmRackFlat(root) {
   root.rotation.set(0, 0, 0);
 }
 
+function orientFirearmRackTowardBoardCenter(root, target) {
+  if (!root?.isObject3D || !target?.isVector3) {
+    orientFirearmRackFlat(root);
+    return;
+  }
+  const lookTarget = target.clone();
+  lookTarget.y = root.position.y;
+  root.lookAt(lookTarget);
+  // Keep the rack physically flat on table; only yaw may change.
+  root.rotation.x = 0;
+  root.rotation.z = 0;
+}
+
 function playCaptureWeaponSourceSound(captureAnimationId, { volume = 1, muted = false } = {}) {
   if (muted) return false;
   const config = CAPTURE_WEAPON_MODEL_CONFIG[captureAnimationId];
@@ -994,6 +1013,73 @@ function findObjectByNeedles(root, needles = []) {
   return match;
 }
 
+function alignFirearmRackGripAnchor(root) {
+  if (!root?.isObject3D) return;
+  root.updateMatrixWorld?.(true);
+  const gripNode =
+    findObjectByNeedles(root, [
+      'trigger',
+      'grip',
+      'handle',
+      'r_wrist',
+      'right_wrist',
+      'hand_r',
+      'r_hand'
+    ]) || null;
+  if (gripNode?.isObject3D) {
+    gripNode.updateMatrixWorld?.(true);
+    const gripLocal = root.worldToLocal(gripNode.getWorldPosition(new THREE.Vector3()));
+    const anchor = new THREE.Vector3(...UNIFORM_FIREARM_RACK_GRIP_ANCHOR.position);
+    root.position.add(anchor.sub(gripLocal));
+  }
+  root.updateMatrixWorld?.(true);
+  const bounds = new THREE.Box3().setFromObject(root);
+  if (Number.isFinite(bounds.min.y) && bounds.min.y < UNIFORM_FIREARM_RACK_GRIP_ANCHOR.minSurfaceY) {
+    root.position.y += UNIFORM_FIREARM_RACK_GRIP_ANCHOR.minSurfaceY - bounds.min.y;
+  }
+}
+
+function alignFirearmRackFacing(root) {
+  if (!root?.isObject3D) return;
+  root.updateMatrixWorld?.(true);
+  const gripNode =
+    findObjectByNeedles(root, ['trigger', 'grip', 'handle', 'r_wrist', 'right_wrist', 'hand_r', 'r_hand']) || null;
+  const muzzleNode =
+    findObjectByNeedles(root, ['muzzle', 'barrel', 'flash', 'tip', 'front', 'sight']) || null;
+  if (!gripNode?.isObject3D || !muzzleNode?.isObject3D) return;
+  const gripLocal = root.worldToLocal(gripNode.getWorldPosition(new THREE.Vector3()));
+  const muzzleLocal = root.worldToLocal(muzzleNode.getWorldPosition(new THREE.Vector3()));
+  const dir = muzzleLocal.sub(gripLocal);
+  if (dir.lengthSq() < 1e-6) return;
+  const yaw = Math.atan2(dir.x, dir.z);
+  // Flip 180° after muzzle alignment so weapon fronts point to the requested opposite direction.
+  root.rotation.y = root.rotation.y - yaw + Math.PI;
+}
+
+function alignFirearmRackFlatByBounds(root, baseRotation = [0, 0, 0]) {
+  if (!root?.isObject3D) return;
+  const xOffsets = [0, Math.PI * 0.5, -Math.PI * 0.5, Math.PI];
+  const zOffsets = [0, Math.PI * 0.5, -Math.PI * 0.5, Math.PI];
+  let bestRotation = null;
+  let bestHeight = Number.POSITIVE_INFINITY;
+  const box = new THREE.Box3();
+  const size = new THREE.Vector3();
+  xOffsets.forEach((xOffset) => {
+    zOffsets.forEach((zOffset) => {
+      root.rotation.set(baseRotation[0] + xOffset, baseRotation[1], baseRotation[2] + zOffset);
+      root.updateMatrixWorld?.(true);
+      box.setFromObject(root);
+      box.getSize(size);
+      const height = size.y;
+      if (height < bestHeight) {
+        bestHeight = height;
+        bestRotation = [root.rotation.x, root.rotation.y, root.rotation.z];
+      }
+    });
+  });
+  if (bestRotation) root.rotation.set(bestRotation[0], bestRotation[1], bestRotation[2]);
+}
+
 async function attachFirearmToRightHand(attackerEntry, captureAnimationId) {
   const rightHand = attackerEntry?.rig?.rightHand;
   if (!rightHand?.isBone) return null;
@@ -1147,7 +1233,9 @@ async function applyCaptureWeaponDisplay(entry, captureAnimationId) {
   clone.position.x += displayPosition[0];
   clone.position.y += displayPosition[1];
   clone.position.z += displayPosition[2];
-  clone.rotation.set(...displayRotation);
+  alignFirearmRackFlatByBounds(clone, displayRotation);
+  alignFirearmRackFacing(clone);
+  alignFirearmRackGripAnchor(clone);
   entry.weaponHolder.add(clone);
 }
 
@@ -7107,7 +7195,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       orientCaptureVehicleTowardBoardCenter(droneFx.root, arena.boardLookTarget);
       orientCaptureVehicleTowardBoardCenter(missileFx.root, arena.boardLookTarget);
       orientCaptureVehicleTowardBoardCenter(droneTruckFx.root, arena.boardLookTarget);
-      orientFirearmRackFlat(weaponRackFx.root);
+      orientFirearmRackTowardBoardCenter(weaponRackFx.root, arena.boardLookTarget);
       arena.scene.add(jetFx.root);
       arena.scene.add(helicopterFx.root);
       arena.scene.add(droneFx.root);


### PR DESCRIPTION
### Motivation
- Improve consistency of firearm displays so weapons present with predictable facing and pickup alignment in racks and when attaching to hands.
- Make rack orientation responsive to the board center so parked racks visually face the play area.

### Description
- Add a global `UNIFORM_FIREARM_RACK_GRIP_ANCHOR` and three new alignment helpers: `alignFirearmRackGripAnchor`, `alignFirearmRackFacing`, and `alignFirearmRackFlatByBounds` to standardize grip location, muzzle-facing direction, and optimal flat rotation respectively.
- Add `orientFirearmRackTowardBoardCenter` to yaw racks toward the board look target while keeping racks flat, and replace the previous flat-only orientation call with this function when placing parked racks.
- Update `applyCaptureWeaponDisplay` to use `alignFirearmRackFlatByBounds`, `alignFirearmRackFacing`, and `alignFirearmRackGripAnchor` in sequence after fitting and positioning the cloned weapon model so displays are consistently sized, oriented, and aligned for pickup.
- Minor helpers and traversal logic (`findObjectByNeedles`) are reused to locate grip/muzzle nodes and adjust model transforms accordingly.

### Testing
- Ran `yarn test` and unit tests completed successfully with no failures.
- Ran `yarn build` and the production build finished without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0b8ade1c483299d869a4839d57981)