### PR TITLE
Refine Ludo avatar name arc and standardize rack weapon orientation

### DIFF
--- a/webapp/src/components/AvatarTimer.jsx
+++ b/webapp/src/components/AvatarTimer.jsx
@@ -21,7 +21,8 @@ export default function AvatarTimer({
   frameScale = 1,
   scoreStyle = {},
   rollHistoryStyle = {},
-  nameCurveRadius = 45,
+  nameCurveRadius = 52,
+  nameCurveGapRem = 0.16,
 }) {
   const angle = (1 - timerPct) * 360;
   const gradient = `conic-gradient(#facc15 ${angle}deg, #16a34a 0deg)`;
@@ -71,15 +72,15 @@ export default function AvatarTimer({
       {name && (
         <svg
           className="rank-name curved-name"
-          viewBox="0 0 100 50"
-          style={{ color: color || '#fde047' }}
+          viewBox="0 0 100 60"
+          style={{ color: color || '#fde047', '--name-curve-gap': `${nameCurveGapRem}rem` }}
         >
           <defs>
             {(() => {
               const r = nameCurveRadius;
               const start = 50 - r;
               const end = 50 + r;
-              const path = `M${start},50 A${r},${r} 0 0 1 ${end},50`;
+              const path = `M${start},54 A${r},${r} 0 0 1 ${end},54`;
               return <path id={`name-path-${index}`} d={path} />;
             })()}
           </defs>

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1037,15 +1037,14 @@ input:focus {
   position: absolute;
   bottom: 100%;
   left: 50%;
-  /* Move the curved name closer to the avatar */
-  transform: translate(-50%, 0.6rem);
+  transform: translate(-50%, var(--name-curve-gap, 0.16rem));
   font-size: 1.2rem;
   color: inherit;
   white-space: nowrap;
 }
 .curved-name {
-  width: 110%;
-  height: 1.2rem;
+  width: 126%;
+  height: 1.45rem;
   pointer-events: none;
   overflow: visible;
 }

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -242,9 +242,9 @@ const FIREARM_RACK_DISPLAY_TUNING_BY_ID = Object.freeze({
   })
 });
 const UNIFORM_FIREARM_RACK_DISPLAY_TUNING = Object.freeze({
-  // Use AK-47 rack pose as the global baseline so every firearm sits in the exact same slot/angle.
+  // Lock every rack weapon to the Smith sidearm visual direction without moving parking locations.
   position: [...FIREARM_RACK_DISPLAY_TUNING_BY_ID.ak47VolleyAttack.position],
-  rotation: [...FIREARM_RACK_DISPLAY_TUNING_BY_ID.ak47VolleyAttack.rotation]
+  rotation: [...FIREARM_RACK_DISPLAY_TUNING.default.rotation]
 });
 const UNIFORM_FIREARM_RACK_GRIP_ANCHOR = Object.freeze({
   // Keep every firearm's trigger/grip region in the same local slot so right-hand pickup
@@ -1039,23 +1039,6 @@ function alignFirearmRackGripAnchor(root) {
   }
 }
 
-function alignFirearmRackFacing(root) {
-  if (!root?.isObject3D) return;
-  root.updateMatrixWorld?.(true);
-  const gripNode =
-    findObjectByNeedles(root, ['trigger', 'grip', 'handle', 'r_wrist', 'right_wrist', 'hand_r', 'r_hand']) || null;
-  const muzzleNode =
-    findObjectByNeedles(root, ['muzzle', 'barrel', 'flash', 'tip', 'front', 'sight']) || null;
-  if (!gripNode?.isObject3D || !muzzleNode?.isObject3D) return;
-  const gripLocal = root.worldToLocal(gripNode.getWorldPosition(new THREE.Vector3()));
-  const muzzleLocal = root.worldToLocal(muzzleNode.getWorldPosition(new THREE.Vector3()));
-  const dir = muzzleLocal.sub(gripLocal);
-  if (dir.lengthSq() < 1e-6) return;
-  const yaw = Math.atan2(dir.x, dir.z);
-  // Flip 180° after muzzle alignment so weapon fronts point to the requested opposite direction.
-  root.rotation.y = root.rotation.y - yaw + Math.PI;
-}
-
 function alignFirearmRackFlatByBounds(root, baseRotation = [0, 0, 0]) {
   if (!root?.isObject3D) return;
   const xOffsets = [0, Math.PI * 0.5, -Math.PI * 0.5, Math.PI];
@@ -1234,7 +1217,6 @@ async function applyCaptureWeaponDisplay(entry, captureAnimationId) {
   clone.position.y += displayPosition[1];
   clone.position.z += displayPosition[2];
   alignFirearmRackFlatByBounds(clone, displayRotation);
-  alignFirearmRackFacing(clone);
   alignFirearmRackGripAnchor(clone);
   entry.weaponHolder.add(clone);
 }
@@ -12159,9 +12141,6 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
                   color={player.color}
                   size={avatarSize}
                 />
-                <span className="mt-1 text-[0.65rem] font-semibold text-white drop-shadow-[0_2px_6px_rgba(0,0,0,0.6)]">
-                  {player.name}
-                </span>
               </div>
             );
           })}


### PR DESCRIPTION
### Motivation
- Improve avatar label layout so player names appear only above avatars with a consistent curved arc and a small gap from the avatar circle. 
- Ensure all parked capture weapons on the Ludo board share a single, consistent visual direction (match the Smith sidearm baseline) to avoid mixed-facing racks while keeping their positions unchanged.

### Description
- Removed the duplicate inline username rendered below each avatar in `LudoBattleRoyal` and rely on the curved SVG name in `AvatarTimer` for name display. (`webapp/src/pages/Games/LudoBattleRoyal.jsx`)
- Expanded and parameterized the curved name rendering in `AvatarTimer` by increasing `nameCurveRadius`, adding `nameCurveGapRem`, updating the SVG `viewBox` and path baseline, and exposing the gap via a CSS variable. (`webapp/src/components/AvatarTimer.jsx`, `webapp/src/index.css`)
- Tuned curved-name CSS (width/height and translation) to make the arch sit slightly larger than the avatar circle with a consistent small gap. (`webapp/src/index.css`)
- Standardized rack weapon orientation by setting `UNIFORM_FIREARM_RACK_DISPLAY_TUNING.rotation` to the default display rotation and removing the per-model auto-yaw alignment call (`alignFirearmRackFacing`) from the capture-weapon display flow so all weapons keep the same facing while parking locations remain unchanged. (`webapp/src/pages/Games/LudoBattleRoyal.jsx`)

### Testing
- Ran `npx eslint` against the edited files; lint run completed and reported repository ignore warnings but no blocking errors. 
- Started the local dev server (`npm --prefix webapp run dev`) and attempted a UI screenshot via Playwright to validate visual changes, but the headless Chromium launch failed in this environment due to a missing system library (`libatk-1.0.so.0`). 
- No unit tests were added or changed; existing test suite was not executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0e4e351ec8329809cd510744bfa55)