### PR TITLE
Adjust Ludo avatar name arc and unify weapon facing direction

### DIFF
--- a/webapp/src/components/AvatarTimer.jsx
+++ b/webapp/src/components/AvatarTimer.jsx
@@ -22,6 +22,7 @@ export default function AvatarTimer({
   scoreStyle = {},
   rollHistoryStyle = {},
   nameCurveRadius = 45,
+  nameCurveBaselineY = 54,
 }) {
   const angle = (1 - timerPct) * 360;
   const gradient = `conic-gradient(#facc15 ${angle}deg, #16a34a 0deg)`;
@@ -79,7 +80,7 @@ export default function AvatarTimer({
               const r = nameCurveRadius;
               const start = 50 - r;
               const end = 50 + r;
-              const path = `M${start},50 A${r},${r} 0 0 1 ${end},50`;
+              const path = `M${start},${nameCurveBaselineY} A${r},${r} 0 0 1 ${end},${nameCurveBaselineY}`;
               return <path id={`name-path-${index}`} d={path} />;
             })()}
           </defs>

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1037,15 +1037,15 @@ input:focus {
   position: absolute;
   bottom: 100%;
   left: 50%;
-  /* Move the curved name closer to the avatar */
-  transform: translate(-50%, 0.6rem);
+  /* Keep the curved name just above the avatar with a small visual gap */
+  transform: translate(-50%, 0.32rem);
   font-size: 1.2rem;
   color: inherit;
   white-space: nowrap;
 }
 .curved-name {
-  width: 110%;
-  height: 1.2rem;
+  width: 124%;
+  height: 1.35rem;
   pointer-events: none;
   overflow: visible;
 }

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -683,6 +683,9 @@ const FIREARM_HAND_ATTACH_TUNING = Object.freeze({
     muzzleOffset: [0, 0.015, 0.278]
   }
 });
+const FIREARM_UNIFIED_DIRECTION_ROTATION =
+  FIREARM_HAND_ATTACH_TUNING.smithSidearmAttack?.rotation ||
+  FIREARM_HAND_ATTACH_TUNING.default.rotation;
 const FIREARM_ATTACH_WORLD_SCALE_BOOST = 1.18;
 const FIREARM_ATTACH_SCALE_MULTIPLIER = Object.freeze({
   // Keep glock as the grip-size baseline and upscale all other firearms so
@@ -1088,7 +1091,7 @@ async function attachFirearmToRightHand(attackerEntry, captureAnimationId) {
   const tuning = FIREARM_HAND_ATTACH_TUNING[captureAnimationId] || FIREARM_HAND_ATTACH_TUNING.default;
   const weapon = modelTemplate.clone(true);
   weapon.position.set(...(tuning.position || FIREARM_HAND_ATTACH_TUNING.default.position));
-  weapon.rotation.set(...(tuning.rotation || FIREARM_HAND_ATTACH_TUNING.default.rotation));
+  weapon.rotation.set(...FIREARM_UNIFIED_DIRECTION_ROTATION);
   const attachScaleMultiplier = captureAnimationId === 'fpsGunAttack'
     ? SHOTGUN_HAND_SCALE
     : (FIREARM_ATTACH_SCALE_MULTIPLIER[captureAnimationId] ?? 1);
@@ -12158,10 +12161,8 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
                   name={player.name}
                   color={player.color}
                   size={avatarSize}
+                  nameCurveRadius={52}
                 />
-                <span className="mt-1 text-[0.65rem] font-semibold text-white drop-shadow-[0_2px_6px_rgba(0,0,0,0.6)]">
-                  {player.name}
-                </span>
               </div>
             );
           })}


### PR DESCRIPTION
### Motivation
- Clean up the Ludo Battle Royal HUD so player names are rendered only in the curved label above the avatar and visually match the avatar circle, improving spacing and legibility.
- Make weapon visuals consistent by unifying the in-hand facing direction to a single canonical orientation so all weapons point the same way while keeping their positional offsets.
- No external skill was used for these edits.

### Description
- Removed the duplicate username text rendered under each seat avatar and rely on the curved SVG label in `AvatarTimer` for the player name (changed in `webapp/src/pages/Games/LudoBattleRoyal.jsx`).
- Increased and tuned the curved name arc by adding `nameCurveRadius` and `nameCurveBaselineY` props to `AvatarTimer` and updating the path baseline, and adjusted CSS sizing to widen and raise the arc (`webapp/src/components/AvatarTimer.jsx`, `webapp/src/index.css`).
- Introduced `FIREARM_UNIFIED_DIRECTION_ROTATION` and apply it when attaching weapons so all firearms use the same facing rotation as `smithSidearmAttack` while preserving per-weapon positions and scale multipliers (`webapp/src/pages/Games/LudoBattleRoyal.jsx`).
- Minor layout/CSS tweaks to keep a small visual gap between the curved name and the avatar circle (`webapp/src/index.css`).

### Testing
- Ran the production web build with `npm -C webapp run build`, which completed successfully (build artifacts produced); warnings from the bundler were informational only and did not block the build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0e4e351ec8329809cd510744bfa55)