### PR TITLE
Stabilize GLTF textures, improve human gait/IK, and adjust Pool Royale avatar placement

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1939,10 +1939,10 @@ const HUMAN_PLAYER_REACT_LEAN = 0.12;
 const HUMAN_POSE_LAMBDA = 9.0;
 const HUMAN_MOVE_LAMBDA = 5.6;
 const HUMAN_ROT_LAMBDA = 8.5;
-const HUMAN_EDGE_MARGIN = 0.88; // push the shooter farther outward so the body stays clearly on the table perimeter
-const HUMAN_DESIRED_SHOOT_DISTANCE = 1.42; // keep the shooter farther back on the cue butt side instead of drifting over the shaft
+const HUMAN_EDGE_MARGIN = TABLE.WALL * 1.35; // keep the shooter tight to the table side perimeter (portrait)
+const HUMAN_DESIRED_SHOOT_DISTANCE = TABLE.H * 0.2; // keep cue-side spacing natural without drifting away from the table
 const HUMAN_SHOOT_BLEND_THRESHOLD = 0.72; // enter shooting pose earlier when the cue camera starts getting lowered
-const HUMAN_WALK_RING_MARGIN = TABLE.WALL * 3.85; // widen the perimeter walk ring so feet never step onto the table mesh
+const HUMAN_WALK_RING_MARGIN = TABLE.WALL * 1.55; // keep walking on the table sides instead of far outside
 const HUMAN_TABLE_BLOCKER_MARGIN = TABLE.WALL * 1.95; // collision helper margin so characters never cut through the table body
 const HUMAN_EYE_CAMERA_HEIGHT_OFFSET = 0.09; // lift camera above cue butt so table stays visible in portrait cue view
 const HUMAN_EYE_CAMERA_FORWARD_OFFSET = BALL_R * 3.2; // move camera forward from the cue butt toward eye line so we keep a true first-person framing
@@ -24680,15 +24680,16 @@ const shotPowerRef = useRef(0);
             chinToCueHeight: 0.11,
             cueArmElbowRise: 0.43,
             tableTopY: TABLE_Y + TABLE.THICK,
-            textureAnisotropy: renderer?.capabilities?.getMaxAnisotropy?.() ?? 8
+            textureAnisotropy: Math.min(2, renderer?.capabilities?.getMaxAnisotropy?.() ?? 2),
+            maxTextureSize: Math.min(1024, renderer?.capabilities?.maxTextureSize ?? 1024),
+            preserveOriginalTextures: true
           });
           human.root.position.set(x, floorY, z);
           human.yaw = yaw;
           return { seat, human };
         };
         playerCharacterRigsRef.current = [
-          makeRig('A', -sideOffset, -zOffset, 0),
-          makeRig('B', sideOffset, zOffset, Math.PI)
+          makeRig('A', -sideOffset, -zOffset, 0)
         ];
       };
 
@@ -24797,7 +24798,10 @@ const shotPowerRef = useRef(0);
         rigs.forEach((rig) => {
           const anim = rig?.anim;
           const human = rig?.human;
-          const seat = anim?.seat ?? rig?.seat;
+          const controlledSeat = isShotActive ? shotSeat : activeSeat;
+          if (rig) rig.seat = controlledSeat;
+          if (anim) anim.seat = controlledSeat;
+          const seat = controlledSeat;
           if (!anim && !human) return;
           const isShooter = anim?.seat === activeSeat;
           const isHumanShooter = seat === activeSeat;

--- a/webapp/src/pages/Games/shared/bilardoHumanRig.js
+++ b/webapp/src/pages/Games/shared/bilardoHumanRig.js
@@ -12,6 +12,30 @@ const dampScalar = (current, target, lambda, dt) =>
   THREE.MathUtils.lerp(current, target, 1 - Math.exp(-lambda * dt));
 const yawFromForward = (forward) => Math.atan2(-forward.x, -forward.z);
 
+const CESIUM_MAN_WALK_KEYFRAMES = [
+  { t: 0, stride: 0.9, lift: 0.08, arm: -0.62, sway: -0.24 },
+  { t: 0.25, stride: -0.72, lift: 0.3, arm: 0.55, sway: 0.2 },
+  { t: 0.5, stride: -0.9, lift: 0.08, arm: 0.62, sway: 0.24 },
+  { t: 0.75, stride: 0.72, lift: 0.3, arm: -0.55, sway: -0.2 },
+  { t: 1, stride: 0.9, lift: 0.08, arm: -0.62, sway: -0.24 }
+];
+
+function sampleCesiumManWalkCurve(phase) {
+  const t = THREE.MathUtils.euclideanModulo(phase, 1);
+  let i = 0;
+  while (i < CESIUM_MAN_WALK_KEYFRAMES.length - 2 && t > CESIUM_MAN_WALK_KEYFRAMES[i + 1].t) i += 1;
+  const a = CESIUM_MAN_WALK_KEYFRAMES[i];
+  const b = CESIUM_MAN_WALK_KEYFRAMES[i + 1];
+  const localT = clamp01((t - a.t) / Math.max(1e-6, b.t - a.t));
+  const smoothT = localT * localT * (3 - 2 * localT);
+  return {
+    stride: lerp(a.stride, b.stride, smoothT),
+    lift: lerp(a.lift, b.lift, smoothT),
+    arm: lerp(a.arm, b.arm, smoothT),
+    sway: lerp(a.sway, b.sway, smoothT)
+  };
+}
+
 const cleanName = (name) => String(name || '').toLowerCase().replace(/[^a-z0-9]/g, '');
 
 function makeBasisQuaternion(side, up, forward) {
@@ -113,22 +137,40 @@ function normalizeHuman(model, opts) {
   model.position.set(-center.x, -box.min.y, -center.z);
 }
 
-function applyOriginalGltfTextureSettings(texture, { isColor = false, anisotropy = null } = {}) {
-  if (!texture) return;
-  if (isColor) {
-    texture.colorSpace = THREE.SRGBColorSpace;
-  }
-  texture.flipY = false;
-  if (Number.isFinite(anisotropy)) {
-    texture.anisotropy = Math.max(1, anisotropy);
-  }
-  texture.needsUpdate = true;
+function stabilizeGltfMaterial(material, textureAnisotropy, maxTextureSize) {
+  if (!material) return;
+  const maps = [
+    material.map,
+    material.emissiveMap,
+    material.normalMap,
+    material.roughnessMap,
+    material.metalnessMap,
+    material.alphaMap
+  ];
+  maps.forEach((texture) => {
+    if (!texture) return;
+    const image = texture.image;
+    const width = Number.isFinite(image?.width) ? image.width : 0;
+    const height = Number.isFinite(image?.height) ? image.height : 0;
+    const oversized = Number.isFinite(maxTextureSize) && maxTextureSize > 0 && (width > maxTextureSize || height > maxTextureSize);
+    if (oversized) {
+      texture.generateMipmaps = false;
+      texture.minFilter = THREE.LinearFilter;
+      texture.magFilter = THREE.LinearFilter;
+      texture.anisotropy = 1;
+    } else if (Number.isFinite(textureAnisotropy)) {
+      texture.anisotropy = Math.max(1, textureAnisotropy);
+    }
+    texture.needsUpdate = true;
+  });
+  material.needsUpdate = true;
 }
 
 export function createBilardoHumanRig(scene, opts = {}) {
   const textureAnisotropy = Number.isFinite(opts?.textureAnisotropy)
     ? Math.max(1, opts.textureAnisotropy)
     : null;
+  const maxTextureSize = Number.isFinite(opts?.maxTextureSize) ? Math.max(256, opts.maxTextureSize) : null;
   const human = {
     root: new THREE.Group(),
     modelRoot: new THREE.Group(),
@@ -148,6 +190,8 @@ export function createBilardoHumanRig(scene, opts = {}) {
     strikeRoot: new THREE.Vector3(),
     strikeYaw: 0,
     strikeClock: 0,
+    walkSpeed: 0,
+    walkPhase: 0,
     cfg: {
       poseLambda: opts.poseLambda ?? 9,
       moveLambda: opts.moveLambda ?? 5.6,
@@ -196,32 +240,7 @@ export function createBilardoHumanRig(scene, opts = {}) {
             ? [obj.material]
             : [];
         mats.forEach((m) => {
-          if (!m) return;
-          applyOriginalGltfTextureSettings(m.map, {
-            isColor: true,
-            anisotropy: textureAnisotropy
-          });
-          applyOriginalGltfTextureSettings(m.emissiveMap, {
-            isColor: true,
-            anisotropy: textureAnisotropy
-          });
-          applyOriginalGltfTextureSettings(m.normalMap, {
-            anisotropy: textureAnisotropy
-          });
-          applyOriginalGltfTextureSettings(m.roughnessMap, {
-            anisotropy: textureAnisotropy
-          });
-          applyOriginalGltfTextureSettings(m.metalnessMap, {
-            anisotropy: textureAnisotropy
-          });
-          applyOriginalGltfTextureSettings(m.alphaMap, {
-            anisotropy: textureAnisotropy
-          });
-          m.opacity = Math.max(0.96, Number.isFinite(m.opacity) ? m.opacity : 1);
-          if (m.roughness != null) m.roughness = Math.min(m.roughness, 0.95);
-          if (m.metalness != null) m.metalness = Math.min(m.metalness, 0.25);
-          if (m.emissiveIntensity != null) m.emissiveIntensity = Math.max(m.emissiveIntensity, 0.12);
-          m.needsUpdate = true;
+          stabilizeGltfMaterial(m, textureAnisotropy, maxTextureSize);
         });
       });
       human.bones = buildAvatarBones(model);
@@ -412,7 +431,7 @@ function driveHuman(human, frame) {
   human.modelRoot.visible = true;
   human.modelRoot.position.copy(frame.rootWorld);
   human.modelRoot.rotation.y = human.yaw;
-  human.modelRoot.position.y += 0.006 * frame.breath - 0.006 * frame.t;
+  human.modelRoot.position.y += 0.006 * frame.breath - 0.018 * frame.t;
   human.modelRoot.updateMatrixWorld(true);
   human.restQuats.forEach((q, bone) => bone.quaternion.copy(q));
   human.modelRoot.updateMatrixWorld(true);
@@ -424,17 +443,19 @@ function driveHuman(human, frame) {
   const shotQ = makeBasisQuaternion(frame.side, UP, frame.forward);
 
   if (frame.walkAmount * idle > 0.001) {
-    const s = Math.sin(human.walkT * 6.2);
-    const c = Math.cos(human.walkT * 6.2);
+    const gait = sampleCesiumManWalkCurve(frame.walkPhase ?? human.walkPhase ?? 0);
     const w = frame.walkAmount * idle;
-    if (b.leftUpperLeg) b.leftUpperLeg.rotation.x += s * 0.34 * w;
-    if (b.rightUpperLeg) b.rightUpperLeg.rotation.x -= s * 0.34 * w;
-    if (b.leftLowerLeg) b.leftLowerLeg.rotation.x += Math.max(0, -s) * 0.28 * w;
-    if (b.rightLowerLeg) b.rightLowerLeg.rotation.x += Math.max(0, s) * 0.28 * w;
-    if (b.leftUpperArm) b.leftUpperArm.rotation.x -= s * 0.23 * w;
-    if (b.rightUpperArm) b.rightUpperArm.rotation.x += s * 0.23 * w;
-    if (b.spine) b.spine.rotation.z += c * 0.025 * w;
-    if (b.hips) b.hips.rotation.z -= c * 0.018 * w;
+    const stride = gait.stride * w;
+    const arm = gait.arm * w;
+    if (b.leftUpperLeg) b.leftUpperLeg.rotation.x += stride * 0.46;
+    if (b.rightUpperLeg) b.rightUpperLeg.rotation.x -= stride * 0.46;
+    if (b.leftLowerLeg) b.leftLowerLeg.rotation.x += Math.max(0, -stride) * 0.34 + gait.lift * 0.06 * w;
+    if (b.rightLowerLeg) b.rightLowerLeg.rotation.x += Math.max(0, stride) * 0.34 + gait.lift * 0.06 * w;
+    if (b.leftUpperArm) b.leftUpperArm.rotation.x += arm * 0.42;
+    if (b.rightUpperArm) b.rightUpperArm.rotation.x -= arm * 0.42;
+    if (b.spine) b.spine.rotation.z += gait.sway * 0.08 * w;
+    if (b.hips) b.hips.rotation.z -= gait.sway * 0.06 * w;
+    if (b.hips) b.hips.position.y += gait.lift * 0.01 * w;
   }
 
   const rightGrip = frame.rightHandWorld
@@ -473,10 +494,9 @@ function driveHuman(human, frame) {
     return;
   }
 
-  const hipIk = ik * 0.35;
-  rotateBoneToward(b.hips, frame.torsoCenterWorld, (0.16 + 0.44 * hipIk) * hipIk, frame.forward);
-  twistBone(b.hips, frame.side, -0.075 * hipIk);
-  twistBone(b.hips, frame.forward, -0.04 * hipIk);
+  rotateBoneToward(b.hips, frame.torsoCenterWorld, (0.16 + 0.44 * ik) * ik, frame.forward);
+  twistBone(b.hips, frame.side, -0.075 * ik);
+  twistBone(b.hips, frame.forward, -0.04 * ik);
   rotateBoneToward(b.spine, frame.chestCenterWorld, (0.38 + 0.36 * ik) * ik, frame.forward);
   twistBone(b.spine, frame.side, -0.23 * ik);
   twistBone(b.spine, frame.forward, -0.055 * ik);
@@ -530,6 +550,29 @@ function driveHuman(human, frame) {
     0.98 * ik
   );
   poseFingers(human.leftFingers, 'bridge', ik);
+
+  aimTwoBone(
+    b.leftUpperLeg,
+    b.leftLowerLeg,
+    frame.leftKnee,
+    frame.leftFootWorld,
+    frame.forward.clone().addScaledVector(UP, 0.12).normalize(),
+    0.68 * ik,
+    0.84 * ik
+  );
+  twistBone(b.leftUpperLeg, frame.forward, -0.07 * ik);
+  setHandBasis(b.leftFoot, frame.side, frame.up, frame.forward, -0.1 * ik, 0.68 * ik);
+  aimTwoBone(
+    b.rightUpperLeg,
+    b.rightLowerLeg,
+    frame.rightKnee,
+    frame.rightFootWorld,
+    frame.forward.clone().multiplyScalar(-1).addScaledVector(UP, 0.1).normalize(),
+    0.68 * ik,
+    0.84 * ik
+  );
+  twistBone(b.rightUpperLeg, frame.forward, 0.06 * ik);
+  setHandBasis(b.rightFoot, frame.side, frame.up, frame.forward, 0.07 * ik, 0.68 * ik);
 }
 
 export function chooseHumanEdgePosition(cueBallWorld, aimForward, opts = {}) {
@@ -580,6 +623,10 @@ export function updateBilardoHumanPose(human, dt, frameData) {
   human.root.position.lerp(rootGoal, 1 - Math.exp(-(state === 'striking' ? 12 : cfg.moveLambda) * dt));
   const moveAmountRaw = human.root.position.distanceTo(rootGoal);
   human.walkT += dt * (2 + Math.min(7, moveAmountRaw * 10));
+  const targetWalkSpeed = clamp01(moveAmountRaw * 22);
+  human.walkSpeed = dampScalar(human.walkSpeed ?? 0, targetWalkSpeed, 8.8, dt);
+  const gaitHz = lerp(1.08, 2.18, human.walkSpeed);
+  human.walkPhase = THREE.MathUtils.euclideanModulo((human.walkPhase ?? 0) + dt * gaitHz, 1);
   human.yaw = dampScalar(
     human.yaw,
     state === 'striking' ? human.strikeYaw : yawFromForward(frameData.aimForward),
@@ -606,7 +653,7 @@ export function updateBilardoHumanPose(human, dt, frameData) {
   const side = new THREE.Vector3(forward.z, 0, -forward.x).normalize();
   const local = (v) => v.clone().applyAxisAngle(Y_AXIS, human.yaw).add(human.root.position);
   const powerLean = power * t;
-  const lowerBodyT = t * 0.35;
+  const lowerBodyT = t;
 
   const rootWorld = human.root.position.clone().addScaledVector(forward, 0.018 * powerLean + 0.026 * follow);
   const torso = local(new THREE.Vector3(0, lerp(1.3, 1.12, t) + breath, lerp(0.02, -0.16, t) - 0.014 * powerLean));
@@ -681,6 +728,7 @@ export function updateBilardoHumanPose(human, dt, frameData) {
     stroke,
     follow,
     walkAmount,
+    walkPhase: human.walkPhase,
     forward,
     side,
     up: UP,


### PR DESCRIPTION
### Motivation
- Reduce texture-driven renderer instability from oversized GLB textures and make avatar visuals more consistent across devices.
- Improve character walk and stance realism by replacing simple sinusoidal gait with a sampled keyframe walk curve and explicit foot IK/basis handling.
- Adjust Pool Royale-specific human placement and camera framing for portrait layouts and simplify player rig spawning/seat control.

### Description
- Add `stabilizeGltfMaterial` to clamp anisotropy, optionally disable mipmaps and switch filtering for textures larger than `maxTextureSize`, and apply it to all common material maps instead of ad-hoc texture tweaks.
- Expose `textureAnisotropy` and new `maxTextureSize` options to `createBilardoHumanRig`, pass safer defaults from `PoolRoyale.jsx` (clamped anisotropy and `maxTextureSize`) and set `preserveOriginalTextures` in the rig call.
- Replace simple leg/arm walk math with a sampled walk curve (`CESIUM_MAN_WALK_KEYFRAMES` + `sampleCesiumManWalkCurve`), add `walkSpeed`/`walkPhase` state, and drive gait frequency from motion in `updateBilardoHumanPose` and `driveHuman` for more natural stride, lift, arm swing and hip movement.
- Improve lower-body IK by driving leg bones and foot basis in `driveHuman`, and adjust hip/spine rotations and model vertical offset for better posture during poses.
- Change several Pool Royale constants to depend on `TABLE` dimensions (`HUMAN_EDGE_MARGIN`, `HUMAN_DESIRED_SHOOT_DISTANCE`, `HUMAN_WALK_RING_MARGIN`) to improve portrait/table-relative placement.
- Adjust player rig spawning in `PoolRoyale.jsx` to only spawn a single rig and unify seat control by setting `controlledSeat` onto rigs/anim when updating so character roles follow the active/shot state.

### Testing
- Ran `yarn test` (frontend unit tests) and all tests passed.
- Ran `yarn lint` and `yarn build` locally to verify no compilation or lint regressions and both completed successfully.
- Verified changes in a local dev build with the Pool Royale scene to confirm human placement, walking and texture behavior under different device capability settings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0d8fcf2fc83298120061d2765d982)