### PR TITLE
Adjust Ludo avatar name arc and unify weapon facing

### DIFF
--- a/webapp/src/components/AvatarTimer.jsx
+++ b/webapp/src/components/AvatarTimer.jsx
@@ -26,6 +26,7 @@ export default function AvatarTimer({
   const angle = (1 - timerPct) * 360;
   const gradient = `conic-gradient(#facc15 ${angle}deg, #16a34a 0deg)`;
   const sizeRem = 3.25 * size;
+  const normalizedNameRadius = Math.max(nameCurveRadius, 54);
   return (
     <div
       className="relative"
@@ -76,7 +77,7 @@ export default function AvatarTimer({
         >
           <defs>
             {(() => {
-              const r = nameCurveRadius;
+              const r = normalizedNameRadius;
               const start = 50 - r;
               const end = 50 + r;
               const path = `M${start},50 A${r},${r} 0 0 1 ${end},50`;

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1037,15 +1037,14 @@ input:focus {
   position: absolute;
   bottom: 100%;
   left: 50%;
-  /* Move the curved name closer to the avatar */
-  transform: translate(-50%, 0.6rem);
+  transform: translate(-50%, 0.18rem);
   font-size: 1.2rem;
   color: inherit;
   white-space: nowrap;
 }
 .curved-name {
-  width: 110%;
-  height: 1.2rem;
+  width: 124%;
+  height: 1.45rem;
   pointer-events: none;
   overflow: visible;
 }

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -242,9 +242,10 @@ const FIREARM_RACK_DISPLAY_TUNING_BY_ID = Object.freeze({
   })
 });
 const UNIFORM_FIREARM_RACK_DISPLAY_TUNING = Object.freeze({
-  // Use AK-47 rack pose as the global baseline so every firearm sits in the exact same slot/angle.
+  // Use Smith sidearm rack pose as the global baseline so every firearm points
+  // in the same direction while staying on the same parking slot.
   position: [...FIREARM_RACK_DISPLAY_TUNING_BY_ID.ak47VolleyAttack.position],
-  rotation: [...FIREARM_RACK_DISPLAY_TUNING_BY_ID.ak47VolleyAttack.rotation]
+  rotation: [-Math.PI * 0.5, Math.PI * 0.02, 0]
 });
 const UNIFORM_FIREARM_RACK_GRIP_ANCHOR = Object.freeze({
   // Keep every firearm's trigger/grip region in the same local slot so right-hand pickup
@@ -683,6 +684,9 @@ const FIREARM_HAND_ATTACH_TUNING = Object.freeze({
     muzzleOffset: [0, 0.015, 0.278]
   }
 });
+const UNIFORM_FIREARM_HAND_ROTATION = Object.freeze(
+  [...(FIREARM_HAND_ATTACH_TUNING.smithSidearmAttack.rotation || FIREARM_HAND_ATTACH_TUNING.default.rotation)]
+);
 const FIREARM_ATTACH_WORLD_SCALE_BOOST = 1.18;
 const FIREARM_ATTACH_SCALE_MULTIPLIER = Object.freeze({
   // Keep glock as the grip-size baseline and upscale all other firearms so
@@ -1088,7 +1092,7 @@ async function attachFirearmToRightHand(attackerEntry, captureAnimationId) {
   const tuning = FIREARM_HAND_ATTACH_TUNING[captureAnimationId] || FIREARM_HAND_ATTACH_TUNING.default;
   const weapon = modelTemplate.clone(true);
   weapon.position.set(...(tuning.position || FIREARM_HAND_ATTACH_TUNING.default.position));
-  weapon.rotation.set(...(tuning.rotation || FIREARM_HAND_ATTACH_TUNING.default.rotation));
+  weapon.rotation.set(...UNIFORM_FIREARM_HAND_ROTATION);
   const attachScaleMultiplier = captureAnimationId === 'fpsGunAttack'
     ? SHOTGUN_HAND_SCALE
     : (FIREARM_ATTACH_SCALE_MULTIPLIER[captureAnimationId] ?? 1);
@@ -12159,9 +12163,6 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
                   color={player.color}
                   size={avatarSize}
                 />
-                <span className="mt-1 text-[0.65rem] font-semibold text-white drop-shadow-[0_2px_6px_rgba(0,0,0,0.6)]">
-                  {player.name}
-                </span>
               </div>
             );
           })}


### PR DESCRIPTION
### Motivation
- Improve avatar label alignment so player names appear clearly above avatar rings with a consistent arc and small gap. 
- Ensure all displayed weapons use a consistent facing direction (match the Smith sidearm) while keeping their current parking/positioning.

### Description
- Removed the duplicated username rendered below each avatar in the Ludo Battle Royal overlay so names are shown only in the curved label above the avatar (`webapp/src/pages/Games/LudoBattleRoyal.jsx`).
- Increased the curved-name footprint and tightened spacing to the avatar by changing CSS (`.rank-name` transform and `.curved-name` width/height) in `webapp/src/index.css` so the arc sits slightly outside the avatar circle.
- Raised the minimum name arc radius in `AvatarTimer` so short radii produce a larger, cleaner arc (`webapp/src/components/AvatarTimer.jsx`).
- Normalized firearm facing by introducing a uniform weapon hand rotation based on the Smith sidearm and applying it when attaching weapons to the right hand, and set a uniform rack-facing rotation so all parked weapons point the same direction while preserving their positions (`webapp/src/pages/Games/LudoBattleRoyal.jsx`).

### Testing
- Ran ESLint on the modified files: `npx eslint webapp/src/components/AvatarTimer.jsx webapp/src/pages/Games/LudoBattleRoyal.jsx webapp/src/index.css`, which returned warnings due to repo ignore settings but no errors.
- Built the frontend: `cd webapp && npm run build`, which completed successfully (build warnings about duplicate package key and chunk size remain unrelated).
- Attempted an automated visual capture with Playwright, but browser runtime dependencies are missing in the environment so the screenshot step failed; Playwright install reported missing host libraries.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0e4e351ec8329809cd510744bfa55)