### PR TITLE
Add resilient fallback URLs for Ludo weapon models

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -294,6 +294,10 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   fpsGunAttack: {
     label: 'FPS Gun',
     urls: [
+      // Primary source occasionally goes unavailable/rate-limited; keep resilient mirrors first.
+      'https://static.poly.pizza/b3e6be61-0299-4866-a227-58f5f3fe610b.glb',
+      'https://cdn.jsdelivr.net/gh/webaverse/pistol@master/military.glb',
+      'https://raw.githubusercontent.com/webaverse/pistol/master/military.glb',
       'https://cdn.jsdelivr.net/gh/lando19/Guns-for-BJS-FPS-Game@main/main/scene.gltf',
       'https://raw.githubusercontent.com/lando19/Guns-for-BJS-FPS-Game/main/main/scene.gltf',
       'https://cdn.jsdelivr.net/gh/lando19/Guns-for-BJS-FPS-Game@master/main/scene.gltf',
@@ -341,6 +345,8 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   ak47VolleyAttack: {
     label: 'AK-47',
     urls: [
+      'https://static.poly.pizza/b3e6be61-0299-4866-a227-58f5f3fe610b.glb',
+      'https://cdn.jsdelivr.net/gh/LazerMaker/gun-models-ak47-and-supprest-pistol-@master/ak47.glb',
       'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models/AK47/scene.gltf',
       'https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models/AK47/scene.gltf'
     ],
@@ -396,6 +402,8 @@ const CAPTURE_WEAPON_MODEL_CONFIG = Object.freeze({
   shotgunBlastAttack: {
     label: 'Shotgun Blast',
     urls: [
+      'https://static.poly.pizza/08f27141-8e64-425a-9161-1bbd6956dfca.glb',
+      'https://static.poly.pizza/f71d6771-f512-4374-bd23-ba00b564db68.glb',
       'https://raw.githubusercontent.com/lando19/Guns-for-BJS-FPS-Game/main/main/scene.gltf',
       'https://cdn.jsdelivr.net/gh/lando19/Guns-for-BJS-FPS-Game@main/main/scene.gltf',
       'https://raw.githubusercontent.com/lando19/Guns-for-BJS-FPS-Game/master/main/scene.gltf',


### PR DESCRIPTION
### Motivation
- Several Ludo Battle Royal weapons (FPS Gun, AK-47, Shotgun Blast) were intermittently missing because their model entries relied on a small set of external GLTF hosts that can be rate-limited or temporarily unavailable. 
- The change aims to make model loading more resilient by preferring stable GLB mirrors and additional CDNs so the game still shows weapons when a primary host fails.

### Description
- Added additional fallback GLB/CDN URLs and moved them earlier in the candidate list for `fpsGunAttack`, `ak47VolleyAttack`, and `shotgunBlastAttack` in `webapp/src/pages/Games/LudoBattleRoyal.jsx`. 
- Prioritized more resilient mirrors (static.poly.pizza, jsDelivr, webaverse GLB) before the original GitHub-hosted GLTF sources to reduce load failures. 
- No runtime logic changes were made; only the `CAPTURE_WEAPON_MODEL_CONFIG` URL lists were updated.

### Testing
- Ran the production build with `npm run -s build` in the `webapp` directory and the Vite build completed successfully with bundles emitted. 
- The build output contained non-blocking warnings about chunking size and a duplicate key in `package.json`, but the build finished and artifacts were produced. 
- No automated unit tests were modified or run as part of this change beyond the production build step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f175fbd7208329824a64a68978c7f8)