### PR TITLE
Pool Royale: spawn single GLTF human and move it farther from table

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1939,10 +1939,10 @@ const HUMAN_PLAYER_REACT_LEAN = 0.12;
 const HUMAN_POSE_LAMBDA = 9.0;
 const HUMAN_MOVE_LAMBDA = 5.6;
 const HUMAN_ROT_LAMBDA = 8.5;
-const HUMAN_EDGE_MARGIN = 0.88; // push the shooter farther outward so the body stays clearly on the table perimeter
-const HUMAN_DESIRED_SHOOT_DISTANCE = 1.42; // keep the shooter farther back on the cue butt side instead of drifting over the shaft
+const HUMAN_EDGE_MARGIN = 1.22; // push the shooter farther outward so the body stays clearly on the table perimeter
+const HUMAN_DESIRED_SHOOT_DISTANCE = 1.76; // keep the shooter farther back on the cue butt side instead of drifting over the shaft
 const HUMAN_SHOOT_BLEND_THRESHOLD = 0.72; // enter shooting pose earlier when the cue camera starts getting lowered
-const HUMAN_WALK_RING_MARGIN = TABLE.WALL * 3.85; // widen the perimeter walk ring so feet never step onto the table mesh
+const HUMAN_WALK_RING_MARGIN = TABLE.WALL * 4.55; // widen the perimeter walk ring so feet never step onto the table mesh
 const HUMAN_TABLE_BLOCKER_MARGIN = TABLE.WALL * 1.95; // collision helper margin so characters never cut through the table body
 const HUMAN_EYE_CAMERA_HEIGHT_OFFSET = 0.09; // lift camera above cue butt so table stays visible in portrait cue view
 const HUMAN_EYE_CAMERA_FORWARD_OFFSET = BALL_R * 3.2; // move camera forward from the cue butt toward eye line so we keep a true first-person framing
@@ -24687,8 +24687,7 @@ const shotPowerRef = useRef(0);
           return { seat, human };
         };
         playerCharacterRigsRef.current = [
-          makeRig('A', -sideOffset, -zOffset, 0),
-          makeRig('B', sideOffset, zOffset, Math.PI)
+          makeRig('A', -sideOffset, -zOffset, 0)
         ];
       };
 
@@ -24799,15 +24798,16 @@ const shotPowerRef = useRef(0);
           const human = rig?.human;
           const seat = anim?.seat ?? rig?.seat;
           if (!anim && !human) return;
-          const isShooter = anim?.seat === activeSeat;
-          const isHumanShooter = seat === activeSeat;
+          const singleHumanMode = rigs.length === 1;
+          const isShooter = singleHumanMode ? true : anim?.seat === activeSeat;
+          const isHumanShooter = singleHumanMode ? true : seat === activeSeat;
           const cameraBlend = THREE.MathUtils.clamp(cameraBlendRef.current ?? 1, 0, 1);
           const loweredCueCamera = cameraBlend <= HUMAN_SHOOT_BLEND_THRESHOLD;
           const draggingSlider = Boolean(sliderInstanceRef.current?.dragging);
           const sliderPowerActive = (powerRef.current ?? 0) > 0.01;
           let mode = 'idle';
           if (isReplay) mode = 'idle';
-          else if (isShotActive && seat === shotSeat && shotAge < 420) mode = 'strike';
+          else if (isShotActive && (singleHumanMode || seat === shotSeat) && shotAge < 420) mode = 'strike';
           else if (isShotActive) mode = 'react';
           else if (isHumanShooter && (loweredCueCamera || draggingSlider || sliderPowerActive)) mode = 'aim';
           if (anim) anim.mode = mode;


### PR DESCRIPTION
### Motivation
- Fix visual clutter where two human characters were present around the table so only one GLTF-driven human is shown. 
- Prevent the remaining character from appearing too close to the table in portrait view by moving the character outward. 
- Ensure the single human still behaves as the active shooter/reactor so gameplay animation and aim flows remain correct.

### Description
- Increased spacing/tuning for the human perimeter by updating `HUMAN_EDGE_MARGIN` to `1.22`, `HUMAN_DESIRED_SHOOT_DISTANCE` to `1.76`, and `HUMAN_WALK_RING_MARGIN` to `TABLE.WALL * 4.55` in `PoolRoyale.jsx`. 
- Reduced spawned player rigs to a single GLTF human by changing `playerCharacterRigsRef.current` to contain only the `'A'` rig. 
- Added `singleHumanMode` detection and adjusted shooter/seat logic (`isShooter`, `isHumanShooter`) and the strike mode check to keep the lone human active across seat logic changes. 
- Kept existing GLTF human pose/update code paths intact so pose updates and aim/strike math reuse the same `bilardoHumanRig` logic.

### Testing
- No automated test suite was executed for this change. 
- A quick smoke/syntax check of the edited file was performed and the modified section is syntactically valid. 
- Manual runtime QA is recommended to confirm portrait framing, single-character appearance, and aim/strike behavior on device.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f17a024074832992ee81d5777b5a9a)