### PR TITLE
Deduplicate Ludo weapon store entries and orient bottom-seat weapon holder toward table center

### DIFF
--- a/webapp/src/config/ludoBattleInventoryConfig.js
+++ b/webapp/src/config/ludoBattleInventoryConfig.js
@@ -60,6 +60,53 @@ const HIDDEN_LUDO_STORE_CAPTURE_ANIMATION_IDS = new Set([
   'assaultRifleAttack'
 ]);
 
+
+const PREFERRED_CAPTURE_ANIMATION_BY_FAMILY = Object.freeze({
+  pistol: 'sigsauerTacticalAttack',
+  smg: 'polySmg01Attack',
+  assaultRifle: 'ak47VolleyAttack',
+  marksman: 'sniperShotAttack',
+  shotgun: 'shotgunBlastAttack',
+  revolver: 'polyRevolver02Attack',
+  explosive: 'grenadeBlastAttack'
+});
+
+const CAPTURE_ANIMATION_FAMILY_BY_ID = Object.freeze({
+  glockSidearmAttack: 'pistol',
+  pistolSidearmAttack: 'pistol',
+  pistolHolsterAttack: 'pistol',
+  smithSidearmAttack: 'pistol',
+  sigsauerTacticalAttack: 'pistol',
+  polyPistol01Attack: 'pistol',
+  uziSprayAttack: 'smg',
+  smgBurstAttack: 'smg',
+  polySmg01Attack: 'smg',
+  fpsGunAttack: 'assaultRifle',
+  assaultRifleAttack: 'assaultRifle',
+  ak47VolleyAttack: 'assaultRifle',
+  krsvBurstAttack: 'assaultRifle',
+  compactCarbineAttack: 'assaultRifle',
+  polyAssaultRifle01Attack: 'assaultRifle',
+  mosinMarksmanAttack: 'marksman',
+  marksmanDmrAttack: 'marksman',
+  sniperShotAttack: 'marksman',
+  shotgunBlastAttack: 'shotgun',
+  polyShotgun01Attack: 'shotgun',
+  polyShotgun02Attack: 'shotgun',
+  polyShotgun03Attack: 'shotgun',
+  polySawedOff01Attack: 'shotgun',
+  polyRevolver01Attack: 'revolver',
+  polyRevolver02Attack: 'revolver',
+  grenadeBlastAttack: 'explosive'
+});
+
+const shouldShowCaptureAnimationInStore = (optionId) => {
+  if (HIDDEN_LUDO_STORE_CAPTURE_ANIMATION_IDS.has(optionId)) return false;
+  const family = CAPTURE_ANIMATION_FAMILY_BY_ID[optionId];
+  if (!family) return true;
+  return PREFERRED_CAPTURE_ANIMATION_BY_FAMILY[family] === optionId;
+};
+
 const uniqueStoreItemsByName = (items) => {
   const seen = new Set();
   return items.filter((item) => {
@@ -148,7 +195,7 @@ export const LUDO_BATTLE_STORE_ITEMS = uniqueStoreItemsByName([
     thumbnail: swatchThumbnail(['#f8fafc', '#0f172a', '#fbbf24'])
   })),
   ...CAPTURE_ANIMATION_OPTIONS.slice(1)
-    .filter((option) => !HIDDEN_LUDO_STORE_CAPTURE_ANIMATION_IDS.has(option.id))
+    .filter((option) => shouldShowCaptureAnimationInStore(option.id))
     .map((option, idx) => ({
       id: `ludo-capture-animation-${option.id}`,
       type: 'captureAnimation',

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -830,6 +830,21 @@ function orientFirearmRackTowardBoardCenter(root, target) {
   root.rotation.z = 0;
 }
 
+function orientBottomWeaponHolderTowardBoardCenter(entry, boardCenter) {
+  if (!entry?.weaponHolder?.isObject3D || !boardCenter?.isVector3) return;
+  const holderParent = entry.weaponHolder.parent;
+  if (!holderParent?.isObject3D) return;
+  const holderWorld = entry.weaponHolder.getWorldPosition(new THREE.Vector3());
+  const lookTarget = boardCenter.clone();
+  lookTarget.y = holderWorld.y;
+  const inward = lookTarget.sub(holderWorld);
+  if (inward.lengthSq() < 1e-8) return;
+  // Align the local +Z axis (weapon muzzle direction) toward table center.
+  const worldQuat = new THREE.Quaternion().setFromUnitVectors(new THREE.Vector3(0, 0, 1), inward.normalize());
+  const parentQuatInv = holderParent.getWorldQuaternion(new THREE.Quaternion()).invert();
+  entry.weaponHolder.quaternion.copy(parentQuatInv.multiply(worldQuat));
+}
+
 function resolveFirearmBallisticsProfile(captureAnimationId = '') {
   const profileKey = FIREARM_BALLISTICS_PROFILE_BY_ID[captureAnimationId] || 'default';
   return FIREARM_BALLISTICS_PROFILE[profileKey] || FIREARM_BALLISTICS_PROFILE.default;
@@ -7117,6 +7132,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       alignObjectBottomToY(entry.weaponRack, arena.tableInfo?.surfaceY);
       entry.weaponRack.position.y += CAPTURE_PARKED_LIFT_OFFSET_Y;
       orientFirearmRackTowardBoardCenter(entry.weaponRack, arena.boardLookTarget);
+      if (playerIndex === 0) orientBottomWeaponHolderTowardBoardCenter(entry, arena.boardLookTarget);
     };
     parkedCaptureVehiclesRef.current.forEach((entry, playerIndex) => {
       const optionIndex = playerIndex > 0 ? aiLoadoutByPlayer[playerIndex]?.captureAnimationIndex ?? 0 : humanOptionIndex;
@@ -7236,6 +7252,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       orientCaptureVehicleTowardBoardCenter(missileFx.root, arena.boardLookTarget);
       orientCaptureVehicleTowardBoardCenter(droneTruckFx.root, arena.boardLookTarget);
       orientFirearmRackTowardBoardCenter(weaponRackFx.root, arena.boardLookTarget);
+      if (playerIndex === 0) orientBottomWeaponHolderTowardBoardCenter(weaponRackFx, arena.boardLookTarget);
       arena.scene.add(jetFx.root);
       arena.scene.add(helicopterFx.root);
       arena.scene.add(droneFx.root);


### PR DESCRIPTION
### Motivation
- Reduce duplicate weapon items in the Ludo store by preferring a single high-quality GLTF variant per weapon family (pistol/SMG/AR/marksman/shotgun/revolver/explosive) while keeping lower-quality models as runtime fallbacks.
- Improve in-table visual consistency by ensuring the local (bottom) player’s parked weapon display points the weapon muzzle/front toward the board center.

### Description
- Added family-driven store filtering: `PREFERRED_CAPTURE_ANIMATION_BY_FAMILY`, `CAPTURE_ANIMATION_FAMILY_BY_ID`, and `shouldShowCaptureAnimationInStore` and used it to filter `CAPTURE_ANIMATION_OPTIONS` in `LUDO_BATTLE_STORE_ITEMS` so only preferred/high-quality capture animations are shown in the store (`webapp/src/config/ludoBattleInventoryConfig.js`).
- Kept existing hidden-ID logic and routed capture-animation visibility through the new `shouldShowCaptureAnimationInStore` selector so hidden IDs continue to be excluded.
- Added `orientBottomWeaponHolderTowardBoardCenter` helper and invoked it during parked-rack setup and refresh so the bottom/player-0 weapon holder aligns its muzzle/front toward the table center (`webapp/src/pages/Games/LudoBattleRoyal.jsx`).
- Changes are limited to `webapp/src/config/ludoBattleInventoryConfig.js` and `webapp/src/pages/Games/LudoBattleRoyal.jsx` and preserve runtime fallback loading and redirect behavior for capture weapon models.

### Testing
- Ran `npm test -- --runInBand test/inventoryCrossGameConfig.test.js` which failed to start due to a repository Jest ESM transform issue (SyntaxError from `three/examples` imports), which is unrelated to the store/orientation logic and prevented the unit test run from completing.
- No new automated tests were added for UI/orientation; validation performed by running the existing inventory test command (see failure above).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f17bc66e648329846596f549795f3c)