### PR TITLE
Fix Chess Battle Royal parked weapon visibility and add firearm parked display

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -206,6 +206,7 @@ const FIREARM_CAPTURE_ANIMATION_IDS = new Set(
   CAPTURE_ANIMATION_OPTIONS.map((option) => option.id).filter((id) => !GLOBAL_CAPTURE_KIND_BY_ANIMATION_ID[id])
 );
 const VEHICLE_CAPTURE_KINDS = new Set(['truck', 'drone', 'jet', 'helicopter']);
+const FIREARM_CAPTURE_KIND = 'firearm';
 
 function resolveVehicleCaptureKind(optionId, fallbackKind = null) {
   const mapped = GLOBAL_CAPTURE_KIND_BY_ANIMATION_ID[optionId];
@@ -2661,6 +2662,58 @@ const SIDE_PARKED_TRUCK_SCALE_MULTIPLIER = 1.06; // keep truck close to true-siz
 const SHOW_SIDE_PARKING_MARKINGS = false;
 const SHOW_BOARD_SIDE_MARKINGS = false;
 const VEHICLE_BUTTON_CAPTURE_KINDS = new Set(['truck', 'drone', 'helicopter', 'jet']);
+
+function createParkedFirearmDisplay(optionLabel = 'Weapon') {
+  const root = new THREE.Group();
+  const stand = new THREE.Mesh(
+    new THREE.CylinderGeometry(0.18, 0.26, 0.3, 20),
+    new THREE.MeshStandardMaterial({
+      color: '#111827',
+      metalness: 0.42,
+      roughness: 0.58
+    })
+  );
+  stand.position.y = 0.15;
+  root.add(stand);
+
+  const weaponBar = new THREE.Mesh(
+    new THREE.BoxGeometry(0.86, 0.1, 0.14),
+    new THREE.MeshStandardMaterial({
+      color: '#dbeafe',
+      metalness: 0.3,
+      roughness: 0.38
+    })
+  );
+  weaponBar.position.set(0.08, 0.34, 0);
+  root.add(weaponBar);
+
+  const grip = new THREE.Mesh(
+    new THREE.BoxGeometry(0.15, 0.24, 0.12),
+    new THREE.MeshStandardMaterial({
+      color: '#f59e0b',
+      metalness: 0.12,
+      roughness: 0.84
+    })
+  );
+  grip.position.set(-0.2, 0.16, 0.02);
+  grip.rotation.z = THREE.MathUtils.degToRad(18);
+  root.add(grip);
+
+  const muzzle = new THREE.Mesh(
+    new THREE.CylinderGeometry(0.03, 0.03, 0.24, 12),
+    new THREE.MeshStandardMaterial({
+      color: '#93c5fd',
+      metalness: 0.68,
+      roughness: 0.24
+    })
+  );
+  muzzle.rotation.z = Math.PI / 2;
+  muzzle.position.set(0.52, 0.34, 0);
+  root.add(muzzle);
+
+  root.userData.weaponLabel = optionLabel;
+  return { root };
+}
 
 function getTableHeightForShape(shapeId) {
   if (LOWER_PROFILE_TABLE_SHAPE_IDS.has(shapeId)) {
@@ -7707,7 +7760,9 @@ function Chess3D({
     return 'truck';
   }, [ownedCaptureAnimations]);
   const selectedParkedWeaponKind = useMemo(
-    () => resolveVehicleCaptureKind(selectedCaptureAnimationId, ownedVehicleCaptureKind) || 'truck',
+    () =>
+      resolveVehicleCaptureKind(selectedCaptureAnimationId, ownedVehicleCaptureKind) ||
+      (FIREARM_CAPTURE_ANIMATION_IDS.has(selectedCaptureAnimationId) ? FIREARM_CAPTURE_KIND : 'truck'),
     [ownedVehicleCaptureKind, selectedCaptureAnimationId]
   );
   const selectedParkedWeaponKindRef = useRef(selectedParkedWeaponKind);
@@ -11988,6 +12043,31 @@ function Chess3D({
           homeRotation: truckHomeRotation,
           ...supportTruck,
           root: supportTruck.root
+        });
+
+        const firearmDisplay = createParkedFirearmDisplay(
+          CAPTURE_ANIMATION_OPTIONS.find((option) => option.id === selectedCaptureAnimationId)?.label || 'Weapon'
+        );
+        firearmDisplay.root.scale.setScalar(
+          CAPTURE_HELICOPTER_SCALE * 1.15 * SIDE_PARKED_AIRCRAFT_SCALE_MULTIPLIER * 0.44
+        );
+        const firearmPad = getAirPadAnchor(isWhite, 'truck', 0);
+        placeParkedUnitOnPad(
+          firearmDisplay.root,
+          firearmPad.clone().add(new THREE.Vector3(0, CAPTURE_TILE_HEIGHT * 0.36, 0)),
+          isWhite ? -Math.PI * 0.18 : Math.PI * 1.18
+        );
+        airPadGroup.add(firearmDisplay.root);
+        parkedAirUnits.push({
+          kind: FIREARM_CAPTURE_KIND,
+          isWhite,
+          slot: 0,
+          busy: false,
+          rotorsActive: false,
+          homePosition: firearmPad.clone(),
+          homeRotation: firearmDisplay.root.rotation.clone(),
+          ...firearmDisplay,
+          root: firearmDisplay.root
         });
       });
       const currentCaptureKind = selectedParkedWeaponKindRef.current;


### PR DESCRIPTION
### Motivation
- Parked weapons for non-vehicle capture animations (firearm-family animations) were not shown in side parking lanes and quick-swap only selected vehicle assets, so players could not visibly pick/use firearm animations from inventory.

### Description
- Added `FIREARM_CAPTURE_KIND` and updated parked-weapon resolution so `selectedParkedWeaponKind` maps firearm animation IDs to a dedicated `firearm` kind instead of falling back to vehicle kinds. 
- Implemented a lightweight `createParkedFirearmDisplay` helper that builds a small mesh group to represent firearms in side parking lanes. 
- Integrated the firearm display creation into the side parking rebuild flow so firearm displays are added to `parkedAirUnits` and participate in the same visibility logic as `truck`, `drone`, `jet`, and `helicopter` units. 

### Testing
- Ran `npm test -- test/chessBattleInventoryConfig.test.js --runInBand` and the suite executed 4 tests with `3 passed, 1 failed`. 
- The single failing assertion is unrelated to the modified code and corresponds to an existing table-finish expectation in `test/chessBattleInventoryConfig.test.js`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f17c2b792083298784c1a9de5d9091)