### PR TITLE
Push human outward, trigger pre-shot on pull, and improve GLTF shader compatibility

### DIFF
--- a/Assets/Scripts/Gameplay/HumanRailGuide.cs
+++ b/Assets/Scripts/Gameplay/HumanRailGuide.cs
@@ -10,7 +10,7 @@ namespace Aiming.Gameplay
     {
         [SerializeField] private CueController cueController;
         [SerializeField] private Transform humanRoot;
-        [SerializeField, Min(0f)] private float outsidePadding = 0.03f;
+        [SerializeField, Min(0f)] private float outsidePadding = 0.14f;
         [SerializeField] private bool drawHelpers = true;
 
         private readonly Vector3[] railHelpers = new Vector3[4];

--- a/Assets/Scripts/Gameplay/PoolHumanPoseDriver.cs
+++ b/Assets/Scripts/Gameplay/PoolHumanPoseDriver.cs
@@ -36,8 +36,9 @@ namespace Aiming
         public float sourceTableLength = 3.6f;
         [Tooltip("Reference table width from source implementation.")]
         public float sourceTableWidth = 2f;
-        public float edgeMargin = 0.21f;
-        public float desiredShootDistance = 0.74f;
+        [Tooltip("How far outside the rail the human must stay. Increase to push the character visually outward on screen.")]
+        public float edgeMargin = 0.32f;
+        public float desiredShootDistance = 0.88f;
         [Tooltip("Optional helper waypoints around table sides (left, right, bottom, top) for Bilardo-style perimeter walking.")]
         public Transform[] sideWalkHelpers;
         [Tooltip("Uniform character size multiplier. Values above 1 make the player visually bigger and heavier.")]
@@ -116,7 +117,8 @@ namespace Aiming
             aimForward.Normalize();
 
             Vector3 aimSide = new Vector3(aimForward.z, 0f, -aimForward.x).normalized;
-            Vector3 rootTarget = ChooseHumanEdgePosition(cueBall, aimForward, s, cueController.CurrentShotState);
+            bool prepareToShoot = cueController.CurrentShotState != CueController.ShotState.Idle || cueController.CurrentPullNormalized > 0.015f;
+            Vector3 rootTarget = ChooseHumanEdgePosition(cueBall, aimForward, s, prepareToShoot);
             Vector3 navigatedRootTarget = NavigateAlongTablePerimeter(rootTarget, s, dt);
             CacheRailHelpers();
 
@@ -141,7 +143,7 @@ namespace Aiming
             Vector3 idleRightHandTarget = rootTarget + RotateAroundY(new Vector3(0.22f, 1.18f, 0.04f) * s, standingYaw);
             Vector3 idleLeftHandTarget = rootTarget + RotateAroundY(new Vector3(-0.16f, 1.1f, -0.02f) * s, standingYaw);
             ResolveStrikePoseLock(
-                cueController.CurrentShotState,
+                prepareToShoot,
                 navigatedRootTarget,
                 bridgeHandTarget,
                 aimForward);
@@ -155,7 +157,7 @@ namespace Aiming
 
             UpdateHumanPose(
                 dt,
-                cueController.CurrentShotState,
+                prepareToShoot,
                 navigatedRootTarget,
                 aimForward,
                 bridgeHandTarget,
@@ -165,7 +167,7 @@ namespace Aiming
                 bridgeMode,
                 s);
 
-            cueController.SetCameraLowered(cueController.CurrentShotState != CueController.ShotState.Idle);
+            cueController.SetCameraLowered(prepareToShoot);
         }
 
         float ComputeScaleFactor()
@@ -242,10 +244,10 @@ namespace Aiming
             return cueBallY - cueController.ballRadius + stanceHeight;
         }
 
-        Vector3 ChooseHumanEdgePosition(Vector3 cueBallWorld, Vector3 aimForward, float s, CueController.ShotState shotState)
+        Vector3 ChooseHumanEdgePosition(Vector3 cueBallWorld, Vector3 aimForward, float s, bool prepareToShoot)
         {
             float approachDistance = desiredShootDistance * s;
-            if (shotState != CueController.ShotState.Idle)
+            if (prepareToShoot)
             {
                 approachDistance = Mathf.Max(0.08f, approachDistance - (tableLeanDepth * s));
             }
@@ -423,7 +425,7 @@ namespace Aiming
 
         void UpdateHumanPose(
             float dt,
-            CueController.ShotState shotState,
+            bool prepareToShoot,
             Vector3 rootTarget,
             Vector3 aimForward,
             Vector3 bridgeHandTarget,
@@ -433,7 +435,7 @@ namespace Aiming
             BridgeMode bridgeMode,
             float s)
         {
-            float targetPose = shotState == CueController.ShotState.Idle ? 0f : 1f;
+            float targetPose = prepareToShoot ? 1f : 0f;
             _poseT = DampScalar(_poseT, targetPose, poseLambda, dt);
             root.position = DampVector(root.position, rootTarget, moveLambda, dt);
 
@@ -668,12 +670,12 @@ namespace Aiming
         }
 
         void ResolveStrikePoseLock(
-            CueController.ShotState shotState,
+            bool prepareToShoot,
             Vector3 rootTarget,
             Vector3 bridgeTarget,
             Vector3 aimForward)
         {
-            if (shotState == CueController.ShotState.Striking)
+            if (cueController != null && cueController.CurrentShotState == CueController.ShotState.Striking)
             {
                 if (!_strikePoseLocked)
                 {

--- a/Assets/Scripts/Gameplay/Rendering/GltfMaterialCompatibilityAdapter.cs
+++ b/Assets/Scripts/Gameplay/Rendering/GltfMaterialCompatibilityAdapter.cs
@@ -70,13 +70,16 @@ namespace Aiming.Gameplay.Rendering
 
         private void EnsureSupportedShader(Material material)
         {
-            if (material.shader != null && material.shader.isSupported)
+            Shader selected = ResolveFallbackShader();
+
+            if (selected == null)
             {
                 return;
             }
 
-            Shader selected = ResolveFallbackShader();
-            if (selected != null)
+            bool unsupported = material.shader == null || !material.shader.isSupported;
+            bool forcePipelineMatch = forceUrpLitShader && material.shader != selected;
+            if (unsupported || forcePipelineMatch)
             {
                 material.shader = selected;
             }


### PR DESCRIPTION
### Motivation
- Players reported the human avatar sits too close to the table and pre-shot pose/orientation doesn't reliably activate when lowering the cue camera or pulling the power slider, and imported GLTF character textures sometimes become invisible due to shader mismatches.
- The change aims to match the Bilardo-style human stance/pose activation and restore visible GLTF textures without touching unrelated subsystems.

### Description
- Increase default rail/perimeter spacing to move the human visually farther from the table by raising `outsidePadding`, `edgeMargin`, and `desiredShootDistance` in `HumanRailGuide.cs` and `PoolHumanPoseDriver.cs`.
- Trigger the human pre-shot pose and cue-camera lowering when either the shot state is non-idle or the player begins pulling power by checking `cueController.CurrentPullNormalized > 0.015f`, and thread that `prepareToShoot` flag through `ChooseHumanEdgePosition`, `ResolveStrikePoseLock`, `UpdateHumanPose`, and camera lowering in `PoolHumanPoseDriver.cs`.
- Preserve strike-lock behavior by ensuring the locked strike pose still keys off the actual `Striking` state (`cueController.CurrentShotState == CueController.ShotState.Striking`).
- Make GLTF material handling more robust in `GltfMaterialCompatibilityAdapter.cs` by resolving a fallback shader early and assigning it when the material shader is unsupported or when forcing pipeline alignment (URP Lit/Standard fallback); keep the existing PBR map copy logic intact.

### Testing
- No unit/CI tests were executed as part of this change; please run the repository's test suite / CI to validate runtime, animation, and rendering on target platforms.
- Repository sanity checks and diffs were inspected and show the intended three files were modified and the strike-lock safety adjustment was applied to avoid a runtime mismatch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f182ccbecc8329ad46b47050d4d527)