### PR TITLE
Add weapon grip helper for battle royale gun hold alignment

### DIFF
--- a/frontend/src/ludoWeaponHelper.ts
+++ b/frontend/src/ludoWeaponHelper.ts
@@ -1,0 +1,41 @@
+import * as THREE from 'three';
+
+export type GripMode = 'one-hand' | 'two-hand';
+
+export type GripConfig = {
+  muzzleLocal: THREE.Vector3;
+  rightHandOffset: THREE.Vector3;
+  leftHandOffset: THREE.Vector3;
+  mode: GripMode;
+};
+
+export class WeaponGripHelper {
+  private tmp = new THREE.Vector3();
+
+  alignWeaponToTarget(weapon: THREE.Object3D, targetWorld: THREE.Vector3) {
+    const origin = weapon.getWorldPosition(this.tmp);
+    const dir = targetWorld.clone().sub(origin).normalize();
+    const q = new THREE.Quaternion().setFromUnitVectors(new THREE.Vector3(0, 0, -1), dir);
+    weapon.quaternion.slerp(q, 0.22);
+  }
+
+  attachHands(
+    weapon: THREE.Object3D,
+    rightHand: THREE.Object3D | null,
+    leftHand: THREE.Object3D | null,
+    cfg: GripConfig
+  ) {
+    if (rightHand) {
+      rightHand.position.copy(cfg.rightHandOffset);
+      rightHand.rotation.set(0, Math.PI, 0);
+      weapon.add(rightHand);
+    }
+
+    if (leftHand) {
+      leftHand.visible = cfg.mode === 'two-hand';
+      leftHand.position.copy(cfg.leftHandOffset);
+      leftHand.rotation.set(0, Math.PI, 0);
+      weapon.add(leftHand);
+    }
+  }
+}


### PR DESCRIPTION
### Motivation
- Fix misaligned character hand grips so weapons front faces the live target direction and support consistent one- vs two-hand holding.
- Provide a small, reusable helper module to be adopted by FPS/shotgun/sniper/rifle rigs before adding camera / impact refinements.

### Description
- Added `frontend/src/ludoWeaponHelper.ts` which exports `WeaponGripHelper`, `GripMode`, and `GripConfig` types.
- Implemented `alignWeaponToTarget(weapon, targetWorld)` that computes a forward-facing quaternion and slerps the weapon toward the target direction.
- Implemented `attachHands(weapon, rightHand, leftHand, cfg)` that positions and orients right/left hand anchors and toggles left-hand visibility for `one-hand` vs `two-hand` modes.
- The module is intentionally self-contained so existing scenes can incrementally adopt the helper without breaking gameplay code. 

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1877dac188329ae0c954990ab8bde)