### PR TITLE
Improve Ludo Battle Royale firearm grip/aim behavior and staged token destruction

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -2671,10 +2671,19 @@ function spawnTokenBreakDebris({
   impactPoint,
   impactDirection = null,
   weaponId = '',
-  tableSurfaceY = 0
+  tableSurfaceY = 0,
+  profileScale = 1
 }) {
   if (!scene || !token?.isObject3D || !impactPoint?.isVector3) return;
-  const profile = resolveTokenBreakProfile(weaponId);
+  const baseProfile = resolveTokenBreakProfile(weaponId);
+  const profile = {
+    ...baseProfile,
+    count: Math.max(3, Math.round(baseProfile.count * clamp(profileScale, 0.12, 2))),
+    sizeMin: baseProfile.sizeMin * clamp(profileScale, 0.35, 1.8),
+    sizeMax: baseProfile.sizeMax * clamp(profileScale, 0.35, 1.8),
+    impulse: baseProfile.impulse * clamp(profileScale, 0.45, 1.9),
+    lingerMs: baseProfile.lingerMs * clamp(profileScale, 0.4, 1.2)
+  };
   const palette = [];
   token.traverse((node) => {
     if (!node?.isMesh) return;
@@ -9928,7 +9937,9 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           shells.forEach((entry) => scene.add(entry));
           scene.add(targetReticle.root);
           let shatterDone = false;
+          let chipDamageDone = false;
           const hideTarget = targetToken?.isObject3D ? targetToken : null;
+          const singleShotFirearm = shots <= 1 || resolvedCaptureAnimationId === 'sniperShotAttack' || resolvedCaptureAnimationId === 'fpsGunAttack';
           const tickFirearm = () => {
             const elapsed = performance.now() - volleyStart;
             const elapsedShooting = Math.max(0, elapsed - preFireLeadMs);
@@ -9958,6 +9969,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
               const targetLocal = parent.worldToLocal(muzzleTarget.clone());
               if (elapsed >= pickupLeadMs + reloadLeadMs) {
                 handWeaponAttachment.weapon.lookAt(targetLocal);
+                handWeaponAttachment.weapon.rotateY(Math.PI);
               } else {
                 handWeaponAttachment.weapon.rotation.x += Math.sin(elapsed * 0.02) * 0.006;
               }
@@ -9968,13 +9980,13 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
               solveSeatedLeftArmContactIK(attackerEntry, offhandWorld, elapsed >= pickupLeadMs ? 0.95 : 0.5);
             }
             const cameraMid = muzzleOrigin.clone().lerp(muzzleTarget, FIREARM_CAMERA_FOCUS_BLEND);
-            const aimDir = muzzleTarget.clone().sub(muzzleOrigin).setY(0);
+            const aimDir = muzzleTarget.clone().sub(muzzleOrigin);
             const followOffset =
               aimDir.lengthSq() > 1e-7
                 ? aimDir
                     .normalize()
-                    .multiplyScalar(FIREARM_CAMERA_SIDE_PULLBACK)
-                    .setY(FIREARM_CAMERA_LIFT)
+                    .multiplyScalar(singleShotFirearm ? FIREARM_CAMERA_SIDE_PULLBACK * 0.62 : FIREARM_CAMERA_SIDE_PULLBACK)
+                    .setY(singleShotFirearm ? FIREARM_CAMERA_LIFT * 1.35 : FIREARM_CAMERA_LIFT)
                 : new THREE.Vector3(0, FIREARM_CAMERA_LIFT, FIREARM_CAMERA_SIDE_PULLBACK);
             setCameraFocus({
               target: cameraMid,
@@ -10063,6 +10075,19 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
               shell.rotation.z += 0.28;
             });
             const impactPhase = clamp((elapsedShooting - shots * cadenceMs * 0.72) / Math.max(140, shots * cadenceMs * 0.28), 0, 1);
+            if (!singleShotFirearm && !chipDamageDone && impactPhase >= 0.36) {
+              chipDamageDone = true;
+              const shotDir = muzzleTarget.clone().sub(muzzleOrigin);
+              spawnTokenBreakDebris({
+                scene,
+                token: hideTarget,
+                impactPoint: muzzleTarget.clone(),
+                impactDirection: shotDir,
+                weaponId: resolvedCaptureAnimationId,
+                tableSurfaceY,
+                profileScale: 0.32
+              });
+            }
             if (!shatterDone && impactPhase >= 0.92) {
               shatterDone = true;
               playGlassShatterSound();


### PR DESCRIPTION
### Motivation
- Make held firearms visually track the live target and present a more cinematic camera for single-shot weapons (sniper / FPS), improving perceived aiming and projectile follow.
- Support staged damage for multi-shot weapons so the token first chips (small debris) while still standing and then fully shatters on final impact.
- Provide a tunable debris system so different weapons (shotgun, rifle, sniper, single-shot FPS) can produce appropriately scaled break effects.

### Description
- Extended `spawnTokenBreakDebris` with a new `profileScale` parameter and applied scaling to `count`, `sizeMin`, `sizeMax`, `impulse`, and `lingerMs` so debris can be produced at chip vs full-break scales (code in `webapp/src/pages/Games/LudoBattleRoyal.jsx`).
- Added staged token-destruction logic in the firearm attack flow so multi-shot weapons spawn a small chip-debris burst early (`profileScale: 0.32`) and the final shatter still runs on terminal impact. This preserves the token-visible-first, full-break-later behavior.
- Classified single-shot firearms (`sniperShotAttack`, `fpsGunAttack`, or `shots <= 1`) as `singleShotFirearm` and tuned the camera follow offsets and lift when focusing on those weapons for a tighter top-of-weapon / bullet-follow framing.
- Adjusted in-hand weapon alignment during the aim phase so the attached weapon `lookAt` the live target and applied a `rotateY(Math.PI)` fix to match model forward orientation while keeping existing offhand IK handling for two-handed weapons.

### Testing
- Built the web client with `npm --prefix webapp run -s build` and the build completed successfully (warnings present but non-blocking).
- Changes were limited to `webapp/src/pages/Games/LudoBattleRoyal.jsx` and validated by a production build; no unit tests were added or modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1877dac188329ae0c954990ab8bde)