### PR TITLE
Preserve GLTF weapon textures in Chess Battle Royal models

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -3660,21 +3660,49 @@ function normalizeModel(object, targetSize) {
   object.position.y -= normalized.min.y;
 }
 
-function prepareCaptureModel(root) {
+function prepareCaptureModel(root, maxAnisotropy = 1) {
   root.traverse((child) => {
     if (!child?.isMesh) return;
     child.castShadow = true;
     child.receiveShadow = true;
+    child.frustumCulled = false;
+    child.visible = true;
     const materials = Array.isArray(child.material) ? child.material : [child.material];
     materials.forEach((material) => {
-      if (material?.map) applySRGBColorSpace(material.map);
-      if (material?.emissiveMap) {
+      if (!material) return;
+      if (material.map) {
+        applySRGBColorSpace(material.map);
+        material.map.flipY = false;
+        material.map.anisotropy = Math.max(material.map.anisotropy ?? 1, maxAnisotropy);
+        material.map.needsUpdate = true;
+      }
+      if (material.emissiveMap) {
         applySRGBColorSpace(material.emissiveMap);
+        material.emissiveMap.flipY = false;
+        material.emissiveMap.anisotropy = Math.max(material.emissiveMap.anisotropy ?? 1, maxAnisotropy);
+        material.emissiveMap.needsUpdate = true;
       }
-      if (material && 'envMapIntensity' in material) {
+      if (material.normalMap) {
+        material.normalMap.flipY = false;
+        material.normalMap.anisotropy = Math.max(material.normalMap.anisotropy ?? 1, maxAnisotropy);
+        material.normalMap.needsUpdate = true;
+      }
+      if (material.roughnessMap) {
+        material.roughnessMap.flipY = false;
+        material.roughnessMap.anisotropy = Math.max(material.roughnessMap.anisotropy ?? 1, maxAnisotropy);
+        material.roughnessMap.needsUpdate = true;
+      }
+      if (material.metalnessMap) {
+        material.metalnessMap.flipY = false;
+        material.metalnessMap.anisotropy = Math.max(material.metalnessMap.anisotropy ?? 1, maxAnisotropy);
+        material.metalnessMap.needsUpdate = true;
+      }
+      material.transparent = false;
+      material.opacity = 1;
+      if ('envMapIntensity' in material) {
         material.envMapIntensity = 1.1;
-        material.needsUpdate = true;
       }
+      material.needsUpdate = true;
     });
   });
 }
@@ -9953,7 +9981,7 @@ function Chess3D({
             }
             if (!model) continue;
             model = model.clone?.(true) ?? model;
-            prepareCaptureModel(model);
+            prepareCaptureModel(model, renderer?.capabilities?.getMaxAnisotropy?.() || 1);
             normalizeModel(model, targetSize);
             captureUnitTemplates[key] = model;
             return model;
@@ -9971,7 +9999,7 @@ function Chess3D({
       const template = captureUnitTemplates[key];
       if (!template) return null;
       const clone = cloneSkinned(template);
-      prepareCaptureModel(clone);
+      prepareCaptureModel(clone, renderer?.capabilities?.getMaxAnisotropy?.() || 1);
       return clone;
     };
 


### PR DESCRIPTION
### Motivation
- Capture-weapon GLTFs in the Chess Battle Royal scene were rendering without their original texture maps or with incorrect configuration, causing visual mismatch compared to the Ludo Battle Royal assets.

### Description
- Updated `prepareCaptureModel` in `webapp/src/pages/Games/ChessBattleRoyal.jsx` to accept a `maxAnisotropy` parameter and to preserve/configure original material maps by applying sRGB color space, setting `flipY = false`, boosting `anisotropy`, and calling `needsUpdate` on maps.
- Ensured meshes are visible and stable by setting `frustumCulled = false`, `visible = true`, `transparent = false`, and `opacity = 1` for prepared materials.
- Propagated renderer anisotropy into both template loading and cloning paths by passing `renderer?.capabilities?.getMaxAnisotropy?.() || 1` to `prepareCaptureModel` when loading capture unit templates and when cloning templates.
- Change is confined to `webapp/src/pages/Games/ChessBattleRoyal.jsx` and aligns texture handling with existing Ludo behavior.

### Testing
- Ran the targeted Jest test command `npm test -- --runInBand test/chessBattleInventoryConfig.test.js` which executed but reported 3 passed and 1 failed, with the failing assertion related to an unrelated inventory fixture mismatch and not to the texture handling changes.
- No runtime rendering tests were automated in this run; the code was committed after the change succeeded locally in applying the new texture configuration logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f18828ab90832991dd490aa38da4dc)