### PR TITLE
Adjust Pool Royal human pose distance and GLTF texture compatibility

### DIFF
--- a/Assets/Scripts/Gameplay/CueController.cs
+++ b/Assets/Scripts/Gameplay/CueController.cs
@@ -86,6 +86,7 @@ namespace Aiming
 
         public ShotState CurrentShotState => _shotState;
         public Vector3 CurrentAimDirection => _aimDirection;
+        public bool IsCameraLowered => _cameraLowered;
         public float CurrentPullNormalized
         {
             get

--- a/Assets/Scripts/Gameplay/PoolHumanPoseDriver.cs
+++ b/Assets/Scripts/Gameplay/PoolHumanPoseDriver.cs
@@ -36,8 +36,8 @@ namespace Aiming
         public float sourceTableLength = 3.6f;
         [Tooltip("Reference table width from source implementation.")]
         public float sourceTableWidth = 2f;
-        public float edgeMargin = 0.21f;
-        public float desiredShootDistance = 0.74f;
+        public float edgeMargin = 0.3f;
+        public float desiredShootDistance = 0.88f;
         [Tooltip("Optional helper waypoints around table sides (left, right, bottom, top) for Bilardo-style perimeter walking.")]
         public Transform[] sideWalkHelpers;
         [Tooltip("Uniform character size multiplier. Values above 1 make the player visually bigger and heavier.")]
@@ -56,9 +56,9 @@ namespace Aiming
         public float gripRatio = 0.76f;
         public float stanceHeight = 0f;
         [Tooltip("How much closer to the table edge the chest/head moves while aiming.")]
-        [Range(0f, 0.2f)] public float tableLeanDepth = 0.08f;
+        [Range(0f, 0.2f)] public float tableLeanDepth = 0.055f;
         [Tooltip("Extra right-hand pull distance, matching the live power slider pullback.")]
-        [Range(0f, 0.4f)] public float gripPullRange = 0.24f;
+        [Range(0f, 0.4f)] public float gripPullRange = 0.3f;
         [Tooltip("Right hand grip point from cue root towards cue tip (meters).")]
         [Range(0.05f, 0.9f)] public float rightHandGripFromCueRoot = 0.18f;
         [Tooltip("Primary right hand grip distance measured backward from cue tip (meters). Keeps the hand behind the bridge like Bilardo stance.")]
@@ -68,7 +68,7 @@ namespace Aiming
         [Tooltip("Small right-hand vertical offset so fingers wrap the cue instead of intersecting it.")]
         [Range(-0.1f, 0.15f)] public float rightHandVerticalOffset = 0.025f;
         [Tooltip("Moves chest/head closer to cue line to mimic real snooker stance.")]
-        [Range(0f, 0.18f)] public float chinToCueForwardBias = 0.085f;
+        [Range(0f, 0.18f)] public float chinToCueForwardBias = 0.1f;
         [Tooltip("Makes lead shoulder slightly lower for realistic bridge alignment.")]
         [Range(0f, 0.16f)] public float shoulderDrop = 0.055f;
 
@@ -153,9 +153,16 @@ namespace Aiming
                 aimForward = _lockedStrikeAimForward;
             }
 
+            bool shouldUseShootPose = cueController.CurrentShotState != CueController.ShotState.Idle ||
+                                      cueController.IsCameraLowered ||
+                                      cueController.CurrentPullNormalized > 0.001f;
+            CueController.ShotState visualShotState = shouldUseShootPose
+                ? CueController.ShotState.Dragging
+                : CueController.ShotState.Idle;
+
             UpdateHumanPose(
                 dt,
-                cueController.CurrentShotState,
+                visualShotState,
                 navigatedRootTarget,
                 aimForward,
                 bridgeHandTarget,

--- a/Assets/Scripts/Gameplay/Rendering/GltfMaterialCompatibilityAdapter.cs
+++ b/Assets/Scripts/Gameplay/Rendering/GltfMaterialCompatibilityAdapter.cs
@@ -22,6 +22,8 @@ namespace Aiming.Gameplay.Rendering
         private static readonly int MetallicGlossMapId = Shader.PropertyToID("_MetallicGlossMap");
         private static readonly int OcclusionMapId = Shader.PropertyToID("_OcclusionMap");
         private static readonly int EmissionMapId = Shader.PropertyToID("_EmissionMap");
+        private static readonly int BaseMapStId = Shader.PropertyToID("_BaseMap_ST");
+        private static readonly int MainTexStId = Shader.PropertyToID("_MainTex_ST");
 
         void Awake()
         {
@@ -112,6 +114,7 @@ namespace Aiming.Gameplay.Rendering
             {
                 TrySetTexture(material, BaseMapId, baseTexture);
                 TrySetTexture(material, MainTexId, baseTexture);
+                SyncTextureTransform(material);
             }
 
             if (material.HasProperty(BaseColorId) && material.HasProperty(ColorId))
@@ -177,6 +180,35 @@ namespace Aiming.Gameplay.Rendering
             if (material.HasProperty(propertyId))
             {
                 material.SetTexture(propertyId, texture);
+            }
+        }
+
+        private static void SyncTextureTransform(Material material)
+        {
+            bool hasBase = material.HasProperty(BaseMapId);
+            bool hasMain = material.HasProperty(MainTexId);
+            if (!hasBase || !hasMain)
+            {
+                return;
+            }
+
+            Vector2 scale = material.GetTextureScale(BaseMapId);
+            Vector2 offset = material.GetTextureOffset(BaseMapId);
+            if (scale == Vector2.zero)
+            {
+                scale = material.GetTextureScale(MainTexId);
+            }
+
+            material.SetTextureScale(MainTexId, scale);
+            material.SetTextureOffset(MainTexId, offset);
+            material.SetTextureScale(BaseMapId, scale);
+            material.SetTextureOffset(BaseMapId, offset);
+
+            if (material.HasProperty(BaseMapStId) && material.HasProperty(MainTexStId))
+            {
+                Vector4 st = new Vector4(scale.x, scale.y, offset.x, offset.y);
+                material.SetVector(BaseMapStId, st);
+                material.SetVector(MainTexStId, st);
             }
         }
     }


### PR DESCRIPTION
### Motivation
- The Pool Royal human was visually too close to the table and did not reliably enter the aiming stance when the cue camera was lowered or when the power slider started pulling. 
- Imported GLTF/GLB character materials could lose their original texture mapping when switched to the active render pipeline, making character textures appear incorrect.

### Description
- Increased `edgeMargin` and `desiredShootDistance` defaults in `Assets/Scripts/Gameplay/PoolHumanPoseDriver.cs` to move the human root farther away from the table edge. 
- Tuned stance-related parameters (`tableLeanDepth`, `gripPullRange`, `chinToCueForwardBias`) to improve cue alignment and pull-back body behavior in `PoolHumanPoseDriver.cs`. 
- Updated pose activation logic in `PoolHumanPoseDriver.cs` so the driver uses a visual shooting pose when the shot state is active, when the cue camera is lowered, or when the pull slider begins (`CurrentPullNormalized > 0`), by computing `shouldUseShootPose` and passing `visualShotState` into `UpdateHumanPose`. 
- Exposed `IsCameraLowered` on `Assets/Scripts/Gameplay/CueController.cs` so the pose driver can query the lowered-camera state consistently. 
- Improved GLTF material handling in `Assets/Scripts/Gameplay/Rendering/GltfMaterialCompatibilityAdapter.cs` by syncing base/main texture scale/offset and setting `_BaseMap_ST`/`_MainTex_ST` when present to preserve original texture tiling and offsets across shader fallbacks.

### Testing
- Ran `git status --short` to verify working tree changes and the check succeeded. 
- Committed the patch with `git commit -m "Adjust pool human shooting stance and GLTF texture mapping"` and the commit operation succeeded. 
- No Unity Editor or PlayMode runtime tests were executed in this environment (Unity runtime not available).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f182ccbecc8329ad46b47050d4d527)