### PR TITLE
Fix Chess Battle Royal capture weapon GLTF textures

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -3661,16 +3661,28 @@ function normalizeModel(object, targetSize) {
 }
 
 function prepareCaptureModel(root) {
+  const maxAnisotropy = 8;
+  const normalizeTexture = (texture, isColor = false) => {
+    if (!texture) return;
+    if (isColor) applySRGBColorSpace(texture);
+    // Keep GLTF-authored UV transforms/wrap modes so original baked textures render as authored.
+    texture.flipY = false;
+    texture.anisotropy = Math.max(texture.anisotropy ?? 1, maxAnisotropy);
+    texture.needsUpdate = true;
+  };
+
   root.traverse((child) => {
     if (!child?.isMesh) return;
     child.castShadow = true;
     child.receiveShadow = true;
     const materials = Array.isArray(child.material) ? child.material : [child.material];
     materials.forEach((material) => {
-      if (material?.map) applySRGBColorSpace(material.map);
-      if (material?.emissiveMap) {
-        applySRGBColorSpace(material.emissiveMap);
-      }
+      normalizeTexture(material?.map, true);
+      normalizeTexture(material?.emissiveMap, true);
+      normalizeTexture(material?.normalMap, false);
+      normalizeTexture(material?.roughnessMap, false);
+      normalizeTexture(material?.metalnessMap, false);
+      normalizeTexture(material?.aoMap, false);
       if (material && 'envMapIntensity' in material) {
         material.envMapIntensity = 1.1;
         material.needsUpdate = true;


### PR DESCRIPTION
### Motivation
- Capture weapon models in Chess Battle Royal were not reliably displaying their authored GLTF textures and needed the same texture-preparation behavior used by other Battle Royal games so weapons render as authored.

### Description
- Updated `prepareCaptureModel` in `webapp/src/pages/Games/ChessBattleRoyal.jsx` to add a shared `normalizeTexture` helper and a `maxAnisotropy` value to improve texture clarity.
- The new flow applies sRGB only to color maps (`map`, `emissiveMap`), preserves GLTF texture orientation/UV wrap by setting `flipY = false`, boosts `anisotropy`, and calls `texture.needsUpdate` so original baked textures render correctly.
- Extended normalization to all key PBR slots (`normalMap`, `roughnessMap`, `metalnessMap`, `aoMap`) while retaining the existing `envMapIntensity` tuning and ensuring materials are marked for update.

### Testing
- Ran lint for the updated file with `npm -s run -s lint -- webapp/src/pages/Games/ChessBattleRoyal.jsx`, which completed but emitted an ESLint environment warning about React auto-detection (no blocking errors reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f18828ab90832991dd490aa38da4dc)