### PR TITLE
Preserve piece styles when changing customization in Chess Battle Royal

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -2750,10 +2750,17 @@ function normalizeAppearance(value = {}) {
     const clamped = Math.min(Math.max(0, Math.round(source)), max - 1);
     normalized[key] = clamped;
   });
-  normalized.boardColor = DEFAULT_APPEARANCE.boardColor;
-  normalized.whitePieceStyle = DEFAULT_APPEARANCE.whitePieceStyle;
-  normalized.blackPieceStyle = DEFAULT_APPEARANCE.blackPieceStyle;
-  normalized.headStyle = DEFAULT_APPEARANCE.headStyle;
+  const detailEntries = [
+    ['boardColor', BEAUTIFUL_GAME_BOARD_OPTIONS.length],
+    ['whitePieceStyle', PIECE_STYLE_OPTIONS.length],
+    ['blackPieceStyle', PIECE_STYLE_OPTIONS.length],
+    ['headStyle', HEAD_PRESET_OPTIONS.length]
+  ];
+  detailEntries.forEach(([key, max]) => {
+    const raw = Number(value?.[key]);
+    if (!Number.isFinite(raw)) return;
+    normalized[key] = Math.min(Math.max(0, Math.round(raw)), max - 1);
+  });
   if (!Number.isFinite(normalized.captureAnimation)) normalized.captureAnimation = DEFAULT_APPEARANCE.captureAnimation;
   if (!Number.isFinite(normalized.humanCharacter)) normalized.humanCharacter = DEFAULT_APPEARANCE.humanCharacter;
   return normalized;


### PR DESCRIPTION
### Motivation
- Changing unrelated customization (weapons/tables/chairs) caused chess pieces and presets to reset because `normalizeAppearance` forcibly set piece/board/head fields to defaults, which broke user expectations.

### Description
- Update `normalizeAppearance` in `webapp/src/pages/Games/ChessBattleRoyal.jsx` to clamp and preserve `boardColor`, `whitePieceStyle`, `blackPieceStyle`, and `headStyle` using the corresponding option list lengths instead of overriding them with defaults.

### Testing
- Inspected the diff with `git diff` and repository status with `git status`, then committed the change with `git commit`, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f18f1c64b48329a0941c15483273e7)