### PR TITLE
Preserve chess piece/board/head styles during appearance normalization

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -2750,10 +2750,17 @@ function normalizeAppearance(value = {}) {
     const clamped = Math.min(Math.max(0, Math.round(source)), max - 1);
     normalized[key] = clamped;
   });
-  normalized.boardColor = DEFAULT_APPEARANCE.boardColor;
-  normalized.whitePieceStyle = DEFAULT_APPEARANCE.whitePieceStyle;
-  normalized.blackPieceStyle = DEFAULT_APPEARANCE.blackPieceStyle;
-  normalized.headStyle = DEFAULT_APPEARANCE.headStyle;
+  const styleEntries = [
+    ['boardColor', BEAUTIFUL_GAME_BOARD_OPTIONS.length],
+    ['whitePieceStyle', PIECE_STYLE_OPTIONS.length],
+    ['blackPieceStyle', PIECE_STYLE_OPTIONS.length],
+    ['headStyle', HEAD_PRESET_OPTIONS.length]
+  ];
+  styleEntries.forEach(([key, max]) => {
+    const raw = Number(value?.[key]);
+    if (!Number.isFinite(raw)) return;
+    normalized[key] = Math.min(Math.max(0, Math.round(raw)), max - 1);
+  });
   if (!Number.isFinite(normalized.captureAnimation)) normalized.captureAnimation = DEFAULT_APPEARANCE.captureAnimation;
   if (!Number.isFinite(normalized.humanCharacter)) normalized.humanCharacter = DEFAULT_APPEARANCE.humanCharacter;
   return normalized;


### PR DESCRIPTION
### Motivation
- Changing unrelated customization (table, chairs, weapons/capture animation) was unintentionally resetting chess piece/board/head styles to defaults, causing visual changes the user did not expect.

### Description
- Update `normalizeAppearance` in `webapp/src/pages/Games/ChessBattleRoyal.jsx` to clamp and apply incoming `boardColor`, `whitePieceStyle`, `blackPieceStyle`, and `headStyle` indices (using `BEAUTIFUL_GAME_BOARD_OPTIONS`, `PIECE_STYLE_OPTIONS`, and `HEAD_PRESET_OPTIONS`) instead of force-resetting those fields to `DEFAULT_APPEARANCE`.

### Testing
- No automated test suite was run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f18f1c64b48329a0941c15483273e7)