### PR TITLE
Guard chess piece material updates behind piece/board appearance change

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -9096,11 +9096,11 @@ function Chess3D({
       });
     }
 
-    if (isBeautifulGameSet && arena.piecePrototypes) {
+    if (shouldRefreshBoardPieces && isBeautifulGameSet && arena.piecePrototypes) {
       harmonizeBeautifulGamePieces(arena.piecePrototypes, pieceStyleOption);
     }
 
-    if (arena.allPieceMeshes) {
+    if (shouldRefreshBoardPieces && arena.allPieceMeshes) {
       if (isBeautifulGameSet) {
         applyBeautifulGameStyleToMeshes(arena.allPieceMeshes, pieceStyleOption);
         disposePieceMaterials(arena.pieceMaterials);


### PR DESCRIPTION
### Motivation
- Players reported that chess pieces would change visually after selecting unrelated customization options (weapons, table, chairs), so the intent is to keep piece visuals stable and only reapply piece materials when piece/board-related appearance actually changes.

### Description
- In `webapp/src/pages/Games/ChessBattleRoyal.jsx` the piece/material application is now gated by the existing `shouldRefreshBoardPieces` check so harmonization and material reassignments run only when board/piece appearance fields change.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f18f1c64b48329a0941c15483273e7)