### PR TITLE
Snake: show parked weapons, keep swap open, and tune seated human pose

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -85,8 +85,8 @@ const HUMAN_MODEL_CACHE = { promise: null, template: null };
 // Keep Snake seated humans aligned with Ludo/Chess Battle Royal chair anchoring and 7am scale baseline.
 const SEATED_HUMAN_BASE_HEIGHT = 1.74;
 const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.24;
-const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 3.75;
-const SEATED_HUMAN_SEAT_Y_OFFSET = -5.65 * MODEL_SCALE * STOOL_SCALE;
+const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 3.25;
+const SEATED_HUMAN_SEAT_Y_OFFSET = -5.1 * MODEL_SCALE * STOOL_SCALE;
 const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.42;
 // Mirror Ludo Battle Royal's deeper bottom-seat pushback so the local player sits
 // with the same portrait-facing posture/orientation while preserving Snake table scale.
@@ -94,7 +94,7 @@ const SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET = -SEAT_DEPTH * 0.2;
 const SEATED_HUMAN_FACING_Y = 0;
 const SEATED_HUMAN_FOOT_GROUND_Y = -1.26 * MODEL_SCALE * STOOL_SCALE;
 const HUMAN_FRONT_SIDE_Z = 1;
-const HUMAN_LEG_FRONT_OFFSET = 0;
+const HUMAN_LEG_FRONT_OFFSET = -0.05;
 const SNAKE_TOKEN_MODEL_URLS = [
   'https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Models@master/2.0/ABeautifulGame/glTF-Binary/ABeautifulGame.glb',
   'https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Models@master/2.0/ABeautifulGame/glTF/ABeautifulGame.gltf'
@@ -1741,8 +1741,8 @@ function applySeatedHumanPose(seatHuman, timeSeconds = 0, activeLean = 0) {
   composeModelBone(rest, bones.neck, new THREE.Euler(-0.04, 0, 0, 'XYZ'));
   composeModelBone(rest, bones.head, new THREE.Euler(-0.06, 0, 0, 'XYZ'));
 
-  composeModelBone(rest, bones.leftUpLeg, new THREE.Euler(-1.58, 0.16, 0.05, 'XYZ'));
-  composeModelBone(rest, bones.rightUpLeg, new THREE.Euler(-1.58, 0.03, -0.02, 'XYZ'));
+  composeModelBone(rest, bones.leftUpLeg, new THREE.Euler(-1.56, 0.28, 0.08, 'XYZ'));
+  composeModelBone(rest, bones.rightUpLeg, new THREE.Euler(-1.56, -0.28, -0.08, 'XYZ'));
   composeModelBone(rest, bones.leftLeg, new THREE.Euler(-1.66, 0.02, 0.01, 'XYZ'));
   composeModelBone(rest, bones.rightLeg, new THREE.Euler(-1.66, -0.02, -0.01, 'XYZ'));
   composeModelBone(rest, bones.leftFoot, new THREE.Euler(0.26, 0.03, 0.02, 'XYZ'));

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -3827,11 +3827,30 @@ export default function SnakeAndLadder() {
             onClick={() => setWeaponSwapOpen((prev) => !prev)}
             className="rounded-full border border-rose-300/70 bg-black/70 px-3 py-2 text-xs font-semibold uppercase tracking-[0.24em] text-rose-100 shadow-[0_10px_25px_rgba(244,63,94,0.35)] transition hover:border-rose-200 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-200"
           >
-            🔫 Swap
+            🔫 Swap · {resolvedAppearance?.captureWeapon?.label || 'Weapon'}
           </button>
           {weaponSwapOpen && (
             <div className="absolute bottom-12 right-0 w-[min(19rem,84vw)] max-h-[52vh] overflow-y-auto rounded-2xl border border-white/15 bg-black/90 p-3 shadow-[0_22px_55px_rgba(2,6,23,0.65)] backdrop-blur-xl">
               <p className="text-[10px] uppercase tracking-[0.3em] text-white/70">Quick weapon swap</p>
+
+              <p className="mt-2 text-[10px] uppercase tracking-[0.24em] text-rose-200/85">Parked weapons by seat</p>
+              <div className="mt-2 grid grid-cols-2 gap-2">
+                {(players || []).slice(0, 4).map((player, idx) => {
+                  const seatIndex = Number.isFinite(player?.seatIndex) ? player.seatIndex : idx;
+                  const weapon = normalizeCaptureWeaponId(player?.weaponType || selectedCaptureWeaponId);
+                  const weaponLabel = CAPTURE_WEAPON_OPTIONS.find((item) => item.id === weapon)?.label || weapon;
+                  return (
+                    <div
+                      key={`parked-weapon-${seatIndex}`}
+                      className="rounded-lg border border-white/10 bg-white/5 px-2 py-1 text-[10px] text-white/80"
+                    >
+                      <span className="mr-1 font-semibold uppercase tracking-[0.2em] text-rose-100">S{seatIndex + 1}</span>
+                      <span className="uppercase tracking-[0.1em]">{weaponLabel}</span>
+                    </div>
+                  );
+                })}
+              </div>
+
               <div className="mt-2 space-y-2">
                 {CAPTURE_WEAPON_OPTIONS.map((option) => {
                   const selected = selectedCaptureWeaponId === option.id;
@@ -3842,7 +3861,6 @@ export default function SnakeAndLadder() {
                       type="button"
                       onClick={() => {
                         setAppearance((prev) => normalizeAppearance({ ...prev, captureWeapon: optionIndex }));
-                        setWeaponSwapOpen(false);
                       }}
                       className={`flex w-full items-center gap-3 rounded-xl border px-2 py-2 text-left transition ${
                         selected


### PR DESCRIPTION
### Motivation
- Improve quick-weapon-swap discoverability by showing the currently selected weapon and the parked weapons for each seat so players can see loadouts at a glance.
- Make rapid swapping on mobile easier by keeping the swap panel open after selecting an option.
- Match Snake seated avatar presentation to Ludo-style framing by making the human visually smaller, lifting the seated anchor, and orienting the legs more to the side-of-center.

### Description
- Updated `webapp/src/pages/Games/SnakeAndLadder.jsx` to show the active capture weapon on the `Swap` button, add a “Parked weapons by seat” grid that lists each seat's parked weapon label, and remove the code that closed the swap panel on selection to keep it open for rapid switching.
- Tuned seated human parameters in `webapp/src/components/SnakeBoard3D.jsx` by reducing `SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER` from `3.75` to `3.25`, raising `SEATED_HUMAN_SEAT_Y_OFFSET` (less negative), and setting `HUMAN_LEG_FRONT_OFFSET` to `-0.05` to move leg roots forward/sidewards.
- Adjusted procedural pose values for `leftUpLeg` and `rightUpLeg` in the seated pose driver to push the thighs outward for a side-of-center seating posture similar to Ludo.
- The parked weapons panel derives weapon names via `normalizeCaptureWeaponId` and `CAPTURE_WEAPON_OPTIONS` to keep labels consistent with existing options and player state.

### Testing
- Ran the production build with `npm run -s build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f190aee24883299a7effb426d4871c)