### PR TITLE
Adjust cue eye camera framing and increase human rail padding

### DIFF
--- a/Assets/Scripts/Gameplay/HumanRailGuide.cs
+++ b/Assets/Scripts/Gameplay/HumanRailGuide.cs
@@ -10,7 +10,7 @@ namespace Aiming.Gameplay
     {
         [SerializeField] private CueController cueController;
         [SerializeField] private Transform humanRoot;
-        [SerializeField, Min(0f)] private float outsidePadding = 0.03f;
+        [SerializeField, Min(0f)] private float outsidePadding = 0.12f;
         [SerializeField] private bool drawHelpers = true;
 
         private readonly Vector3[] railHelpers = new Vector3[4];

--- a/billiards.Unity/CueCamera.cs
+++ b/billiards.Unity/CueCamera.cs
@@ -105,11 +105,11 @@ public class CueCamera : MonoBehaviour
     [Range(0f, 1f)]
     public float eyeViewStartLowering = 0.45f;
     // Distance in front of the eye anchor used for the look target.
-    public float eyeViewLookAhead = 1.1f;
+    public float eyeViewLookAhead = 1.4f;
     // Slight inward offset to avoid clipping through eyebrows/face meshes.
-    public float eyeViewForwardOffset = 0.03f;
+    public float eyeViewForwardOffset = 0f;
     // Vertical offset to center the cue in first-person framing.
-    public float eyeViewHeightOffset = -0.005f;
+    public float eyeViewHeightOffset = 0f;
     // Scale applied to the cue distance when the camera is raised. Values below
     // 1 slide the camera closer to the cloth even before the player lowers it.
     [Range(0.1f, 1f)]
@@ -819,11 +819,17 @@ public class CueCamera : MonoBehaviour
             return;
         }
 
+        Vector3 eyeForward = playerEyeAnchor.forward;
+        if (eyeForward.sqrMagnitude < 0.0001f)
+        {
+            eyeForward = cueForward;
+        }
+
         Vector3 eyePos = playerEyeAnchor.position +
-                         (cueForward * Mathf.Max(0f, eyeViewForwardOffset)) +
+                         (eyeForward * Mathf.Max(0f, eyeViewForwardOffset)) +
                          (Vector3.up * eyeViewHeightOffset);
         Vector3 eyeLookTarget = eyePos +
-                                (cueForward * Mathf.Max(0.1f, eyeViewLookAhead)) +
+                                (eyeForward * Mathf.Max(0.1f, eyeViewLookAhead)) +
                                 (Vector3.up * cueBallLookOffset);
         Vector3 lookDir = eyeLookTarget - eyePos;
         if (lookDir.sqrMagnitude < 0.0001f)


### PR DESCRIPTION
### Motivation
- The human rig was visually too close to the table and the cue camera sometimes included the avatar head in first-person aiming; the change aims to move the avatar outward and place the cue camera exactly at eye level and aligned with the face direction so the view shows hands/body only.

### Description
- Increased human rail padding from `0.03f` to `0.12f` in `Assets/Scripts/Gameplay/HumanRailGuide.cs` so the human root is constrained farther outside the table bounds.
- Updated cue-eye defaults in `billiards.Unity/CueCamera.cs`: `eyeViewLookAhead` from `1.1f` to `1.4f`, `eyeViewForwardOffset` from `0.03f` to `0f`, and `eyeViewHeightOffset` from `-0.005f` to `0f` to place the cue camera at eye level and remove forward/vertical bias.
- Changed `ApplyEyeViewOverride` to use `playerEyeAnchor.forward` (with `cueForward` fallback) for both the eye position and look target so the cue camera orientation follows the character face direction.

### Testing
- `git add`/`git commit` completed successfully to record the changes. 
- No automated Unity playmode or editor tests were executed; runtime/in-editor verification is required to validate camera framing and rig spacing (manual playtest recommended).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f18fed2054832984e7de5d47e62c27)