### PR TITLE
Snake‑Ladder: in-session options + inventory‑aware weapon swap (server + client)

### DIFF
--- a/examples/snake-ladder/ReactClient.jsx
+++ b/examples/snake-ladder/ReactClient.jsx
@@ -59,10 +59,14 @@ export default function ReactClient({
   }, [roomId, playerName, socket]);
 
   const rollDice = () => socket.emit('rollDice', { roomId });
+  const updateOption = (key, value) =>
+    socket.emit('setOption', { roomId, key, value });
+  const swapWeapon = (weapon) => socket.emit('swapWeapon', { roomId, weapon });
 
   if (!state) return <div style={{ color: '#fff' }}>Loading...</div>;
 
   const current = state.players[state.currentPlayer]?.id;
+  const me = state.players.find((p) => p.id === socket.id);
 
   return (
     <div
@@ -111,6 +115,48 @@ export default function ReactClient({
         {state.winner && (
           <p style={{ margin: '12px 0 0' }}>Winner: {state.winner}</p>
         )}
+        <div style={{ marginTop: 12, display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+          <label>
+            Theme:{' '}
+            <select
+              value={state.options?.boardTheme || 'classic'}
+              onChange={(e) => updateOption('boardTheme', e.target.value)}
+            >
+              <option value="classic">Classic</option>
+              <option value="night">Night</option>
+            </select>
+          </label>
+          <label>
+            Speed:{' '}
+            <select
+              value={state.options?.moveSpeed || 'normal'}
+              onChange={(e) => updateOption('moveSpeed', e.target.value)}
+            >
+              <option value="slow">Slow</option>
+              <option value="normal">Normal</option>
+              <option value="fast">Fast</option>
+            </select>
+          </label>
+          {me && (
+            <label>
+              Weapon:{' '}
+              <select
+                value={me.equippedWeapon}
+                onChange={(e) => swapWeapon(e.target.value)}
+              >
+                {me.inventory.map((weapon) => (
+                  <option key={weapon} value={weapon}>
+                    {weapon}
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
+        </div>
+        {me && <p style={{ margin: '8px 0 0' }}>My weapon: {me.equippedWeapon}</p>}
+        <p style={{ margin: '4px 0 0' }}>
+          AI weapon this game: {state.ai?.equippedWeapon}
+        </p>
       </div>
 
       <div style={{ margin: '0 auto', maxWidth: 900 }}>

--- a/examples/snake-ladder/gameLogic.js
+++ b/examples/snake-ladder/gameLogic.js
@@ -1,4 +1,9 @@
 export const BOARD_SIZE = 100;
+export const DEFAULT_OPTIONS = {
+  boardTheme: 'classic',
+  moveSpeed: 'normal'
+};
+export const WEAPONS = ['Pistol', 'Shotgun', 'Rifle', 'SMG'];
 
 export const DEFAULT_SNAKES = {
   16: 6,
@@ -28,19 +33,37 @@ export const DEFAULT_LADDERS = {
 export class Game {
   constructor(roomId) {
     this.roomId = roomId;
+    this.options = { ...DEFAULT_OPTIONS };
+    this.resetBoard();
+  }
+
+  resetBoard() {
     this.players = [];
     this.currentPlayer = 0;
     this.diceRoll = null;
     this.snakes = { ...DEFAULT_SNAKES };
     this.ladders = { ...DEFAULT_LADDERS };
     this.winner = null;
+    this.ai = {
+      id: 'AI_BOT',
+      name: 'AI Bot',
+      position: 0,
+      inventory: [...WEAPONS],
+      equippedWeapon: WEAPONS[Math.floor(Math.random() * WEAPONS.length)]
+    };
   }
 
   addPlayer(id, name) {
     if (this.players.length >= 4) return null;
     const existing = this.players.find((p) => p.id === id);
     if (existing) return existing;
-    const player = { id, name, position: 0 };
+    const player = {
+      id,
+      name,
+      position: 0,
+      inventory: ['Pistol'],
+      equippedWeapon: 'Pistol'
+    };
     this.players.push(player);
     return player;
   }
@@ -80,15 +103,32 @@ export class Game {
     }
   }
 
+  setOption(key, value) {
+    if (!(key in this.options)) return false;
+    this.options[key] = value;
+    return true;
+  }
+
+  swapWeapon(playerId, weapon) {
+    const player = this.players.find((p) => p.id === playerId);
+    if (!player) return false;
+    if (!player.inventory.includes(weapon)) return false;
+    player.equippedWeapon = weapon;
+    return true;
+  }
+
   getState() {
     return {
       roomId: this.roomId,
       players: this.players,
+      ai: this.ai,
       currentPlayer: this.currentPlayer,
       diceRoll: this.diceRoll,
       snakes: this.snakes,
       ladders: this.ladders,
-      winner: this.winner
+      winner: this.winner,
+      options: this.options,
+      weapons: WEAPONS
     };
   }
 }

--- a/examples/snake-ladder/server.js
+++ b/examples/snake-ladder/server.js
@@ -31,6 +31,20 @@ io.on('connection', (socket) => {
     io.to(roomId).emit('gameStateUpdate', game.getState());
   });
 
+  socket.on('setOption', ({ roomId, key, value }) => {
+    const game = games.get(roomId);
+    if (!game) return;
+    game.setOption(key, value);
+    io.to(roomId).emit('gameStateUpdate', game.getState());
+  });
+
+  socket.on('swapWeapon', ({ roomId, weapon }) => {
+    const game = games.get(roomId);
+    if (!game) return;
+    game.swapWeapon(socket.id, weapon);
+    io.to(roomId).emit('gameStateUpdate', game.getState());
+  });
+
   socket.on('disconnect', () => {
     games.forEach((game, id) => {
       if (game.removePlayer(socket.id)) {


### PR DESCRIPTION
### Motivation
- Preserve in‑game progress when a player changes UI options so a single option update does not reset the whole board. 
- Enforce weapon swap rules so human players can only equip weapons they actually own while giving AI a randomized loadout each game. 
- Expose small server/client APIs to apply these partial updates live from the UI without a full reload, and surface the new state to clients for rendering and debugging.

### Description
- Added `DEFAULT_OPTIONS` and `WEAPONS` plus an `options` object to the `Game` class so options are stored on the game instance and returned in `getState` (`examples/snake-ladder/gameLogic.js`).
- Introduced `resetBoard()` to initialize board, `ai` payload with randomized `equippedWeapon`, and per-player `inventory` + `equippedWeapon` fields so inventory/weapon state is tracked per player (`examples/snake-ladder/gameLogic.js`).
- Implemented `setOption(key, value)` and `swapWeapon(playerId, weapon)` on the `Game` class and included the `ai`, `options`, and `weapons` in the returned game state (`examples/snake-ladder/gameLogic.js`).
- Added Socket.IO handlers for `setOption` and `swapWeapon` so clients can request option changes and weapon swaps without resetting the game, and updated the React client with `updateOption` + `swapWeapon` calls and corresponding UI selects bound to the live state (`examples/snake-ladder/server.js`, `examples/snake-ladder/ReactClient.jsx`).

### Testing
- Ran an automated module smoke test that imports the updated game class and exercises option and weapon swap APIs: `node -e "import('./examples/snake-ladder/gameLogic.js').then(m=>{const g=new m.Game('r');g.addPlayer('p','P');g.setOption('boardTheme','night');g.swapWeapon('p','Pistol');console.log('ok',g.getState().options.boardTheme,g.getState().ai.equippedWeapon);})"` which printed expected output and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f196fe35c88329ba28b523ba2c2b29)