### PR TITLE
Adjust seated human scale/offsets and add soft restart + weapon-swap improvements

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -85,9 +85,9 @@ const HUMAN_MODEL_CACHE = { promise: null, template: null };
 // Keep Snake seated humans aligned with Ludo/Chess Battle Royal chair anchoring and 7am scale baseline.
 const SEATED_HUMAN_BASE_HEIGHT = 1.74;
 const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.24;
-const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 3.25;
-const SEATED_HUMAN_SEAT_Y_OFFSET = -5.1 * MODEL_SCALE * STOOL_SCALE;
-const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.42;
+const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 2.95;
+const SEATED_HUMAN_SEAT_Y_OFFSET = -4.78 * MODEL_SCALE * STOOL_SCALE;
+const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.46;
 // Mirror Ludo Battle Royal's deeper bottom-seat pushback so the local player sits
 // with the same portrait-facing posture/orientation while preserving Snake table scale.
 const SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET = -SEAT_DEPTH * 0.2;

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -3267,6 +3267,15 @@ export default function SnakeAndLadder() {
     resolvedAppearance?.captureWeapon?.id
       ? normalizeCaptureWeaponId(resolvedAppearance.captureWeapon.id)
       : fallbackCaptureWeaponId(0);
+  const ownedCaptureWeapons = useMemo(
+    () =>
+      CAPTURE_WEAPON_OPTIONS.filter((option) =>
+        isSnakeOptionUnlocked('captureWeapon', option.id, snakeInventory)
+      ),
+    [snakeInventory]
+  );
+  const selectableCaptureWeapons =
+    ownedCaptureWeapons.length > 0 ? ownedCaptureWeapons : [CAPTURE_WEAPON_OPTIONS[0]].filter(Boolean);
   const computedIndex = isMultiplayer
     ? mpPlayers.findIndex((p) => p.id === accountId)
     : 0;
@@ -3311,6 +3320,50 @@ export default function SnakeAndLadder() {
           headPresetId: 'current'
         }))
       ];
+  const handleSoftRestart = useCallback(() => {
+    if (isMultiplayer) return;
+    const aiCount = Math.max(0, ai);
+    const board = generateBoardLocal();
+    const snakesObj = board?.snakes || {};
+    const laddersObj = board?.ladders || {};
+    const diceCellsObj = normalizeDiceCells(board?.diceCells || {});
+    const snk = {};
+    Object.entries(snakesObj).forEach(([s, e]) => {
+      snk[s] = s - e;
+    });
+    const lad = {};
+    Object.entries(laddersObj).forEach(([s, e]) => {
+      const end = typeof e === 'object' ? e.end : e;
+      lad[s] = end - s;
+    });
+    setSnakes(snakesObj);
+    setLadders(laddersObj);
+    setSnakeOffsets(snk);
+    setLadderOffsets(lad);
+    setDiceCells(Object.keys(diceCellsObj).length ? diceCellsObj : generateDiceCellsLocal(snakesObj, laddersObj));
+    setPos(0);
+    setAiPositions(Array(aiCount).fill(0));
+    setRanking([]);
+    setCurrentTurn(0);
+    setSetupPhase(true);
+    setInitialRolls([]);
+    setTurnOrder([]);
+    setGameOver(false);
+    setMoving(false);
+    setPendingExtraRoll(false);
+    setBurning([]);
+    setOffsetPopup(null);
+    setDiceCount(1);
+    setBonusDice(0);
+    setRewardDice(0);
+    setPlayerDiceCounts(Array(aiCount + 1).fill(1));
+    const nextAiWeapons = Array.from({ length: aiCount }, (_, i) => {
+      const randomIndex = Math.floor(Math.random() * CAPTURE_WEAPON_OPTIONS.length);
+      return CAPTURE_WEAPON_OPTIONS[randomIndex]?.id || fallbackCaptureWeaponId(i + 1);
+    });
+    setAiWeaponLoadout(nextAiWeapons);
+    setWeaponSwapOpen(false);
+  }, [ai, fallbackCaptureWeaponId, isMultiplayer]);
 
   const myPlayerIndex = computedIndex >= 0 ? computedIndex : null;
   const hasLocalExtraRoll = pendingExtraRoll;
@@ -3801,7 +3854,7 @@ export default function SnakeAndLadder() {
                   </button>
                   <button
                     type="button"
-                    onClick={() => window.location.reload()}
+                    onClick={handleSoftRestart}
                     className="w-full rounded-lg bg-emerald-500/20 py-2 text-center text-[0.7rem] font-semibold text-emerald-200 transition hover:bg-emerald-500/30"
                   >
                     Restart game
@@ -3833,10 +3886,11 @@ export default function SnakeAndLadder() {
             <div className="absolute bottom-12 right-0 w-[min(19rem,84vw)] max-h-[52vh] overflow-y-auto rounded-2xl border border-white/15 bg-black/90 p-3 shadow-[0_22px_55px_rgba(2,6,23,0.65)] backdrop-blur-xl">
               <p className="text-[10px] uppercase tracking-[0.3em] text-white/70">Quick weapon swap</p>
 
-              <p className="mt-2 text-[10px] uppercase tracking-[0.24em] text-rose-200/85">Parked weapons by seat</p>
+              <p className="mt-2 text-[10px] uppercase tracking-[0.24em] text-rose-200/85">Current seat weapons</p>
               <div className="mt-2 grid grid-cols-2 gap-2">
                 {(players || []).slice(0, 4).map((player, idx) => {
                   const seatIndex = Number.isFinite(player?.seatIndex) ? player.seatIndex : idx;
+                  const isLocalSeat = isMultiplayer ? idx === computedIndex : seatIndex === 0;
                   const weapon = normalizeCaptureWeaponId(player?.weaponType || selectedCaptureWeaponId);
                   const weaponLabel = CAPTURE_WEAPON_OPTIONS.find((item) => item.id === weapon)?.label || weapon;
                   return (
@@ -3845,14 +3899,16 @@ export default function SnakeAndLadder() {
                       className="rounded-lg border border-white/10 bg-white/5 px-2 py-1 text-[10px] text-white/80"
                     >
                       <span className="mr-1 font-semibold uppercase tracking-[0.2em] text-rose-100">S{seatIndex + 1}</span>
-                      <span className="uppercase tracking-[0.1em]">{weaponLabel}</span>
+                      <span className="uppercase tracking-[0.1em]">
+                        {isLocalSeat ? `${weaponLabel} (yours)` : `${weaponLabel} (AI random)`}
+                      </span>
                     </div>
                   );
                 })}
               </div>
 
               <div className="mt-2 space-y-2">
-                {CAPTURE_WEAPON_OPTIONS.map((option) => {
+                {selectableCaptureWeapons.map((option) => {
                   const selected = selectedCaptureWeaponId === option.id;
                   const optionIndex = CAPTURE_WEAPON_OPTIONS.findIndex((item) => item.id === option.id);
                   return (


### PR DESCRIPTION
### Motivation
- Tweak seated human placement and visual scale to better align characters with chair models in the 3D board view.
- Replace a full-page reload restart with an in-app soft restart for local games to preserve application context and reduce load.
- Limit and label quick weapon-swap options to owned/available weapons and clarify parked-weapon labels for local vs AI seats.

### Description
- Updated seated human appearance constants in `SnakeBoard3D.jsx` by changing `SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER` from `3.25` to `2.95`, `SEATED_HUMAN_SEAT_Y_OFFSET` from `-5.1 * MODEL_SCALE * STOOL_SCALE` to `-4.78 * MODEL_SCALE * STOOL_SCALE`, and `SEATED_HUMAN_SEAT_Z_OFFSET` multiplier from `0.42` to `0.46` to adjust positioning and scale.
- Added `ownedCaptureWeapons` and `selectableCaptureWeapons` memoized lists in `SnakeAndLadder.jsx` to filter available capture weapons by unlocks using `isSnakeOptionUnlocked` and `snakeInventory`.
- Implemented `handleSoftRestart` in `SnakeAndLadder.jsx` to reset local-game state (board, snakes/ladders, dice cells, positions, AI loadouts, UI flags, etc.) without reloading the page, and replaced the `window.location.reload()` call with `handleSoftRestart` on the "Restart game" button.
- Improved the quick weapon swap UI by changing the section label to "Current seat weapons", annotating parked weapon entries as `(yours)` or `(AI random)`, and rendering `selectableCaptureWeapons` instead of the full `CAPTURE_WEAPON_OPTIONS` list for selection.

### Testing
- Ran the project's automated linting and unit test suite; all checks completed and passed successfully.
- Performed a production build of the frontend; the build completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f196fe35c88329ba28b523ba2c2b29)