### PR TITLE
Add BattleRoyaleWeaponDirector (Unity) and bullet visuals to LudoBattleRoyal frontend

### DIFF
--- a/Assets/Scripts/Gameplay/Weapons/BattleRoyaleWeaponDirector.cs
+++ b/Assets/Scripts/Gameplay/Weapons/BattleRoyaleWeaponDirector.cs
@@ -1,0 +1,419 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace TonPlaygram.Gameplay.Weapons
+{
+    public enum WeaponFireMode
+    {
+        Single,
+        MagazineAuto
+    }
+
+    public enum LudoWeaponType
+    {
+        Rifle,
+        SMG,
+        Pistol,
+        Shotgun,
+        Sniper,
+        GrenadeLauncher
+    }
+
+    [Serializable]
+    public sealed class WeaponBallisticsProfile
+    {
+        public LudoWeaponType weaponType = LudoWeaponType.Rifle;
+        public WeaponFireMode fireMode = WeaponFireMode.MagazineAuto;
+        public int magazineSize = 30;
+        public float roundsPerSecond = 10f;
+        public float muzzleVelocity = 220f;
+        public float spread = 0.012f;
+        public float bulletScale = 1f;
+        public float shellScale = 1f;
+        public float aimFov = 40f;
+        public float aimTransitionSeconds = 0.08f;
+        public float impactFollowSeconds = 1.15f;
+        public GameObject bulletPrefab;
+        public GameObject shellPrefab;
+        public AudioClip shotSfx;
+    }
+
+    public interface ILudoWeaponEvents
+    {
+        void OnWeaponEquipped(LudoWeaponType weaponType);
+        void OnWeaponShot(LudoWeaponType weaponType, int shotIndex, int totalShots);
+        void OnFinalImpact(LudoWeaponType weaponType, Vector3 impactPoint);
+    }
+
+    public sealed class BattleRoyaleWeaponDirector : MonoBehaviour
+    {
+        [Header("Scene refs")]
+        [SerializeField] private Camera playerCamera;
+        [SerializeField] private Transform muzzle;
+        [SerializeField] private Transform shellEject;
+        [SerializeField] private Transform targetTokenRoot;
+        [SerializeField] private AudioSource sfxSource;
+
+        [Header("Weapon presets")]
+        [SerializeField] private List<WeaponBallisticsProfile> weaponProfiles = new List<WeaponBallisticsProfile>();
+        [SerializeField] private LudoWeaponType startingWeapon = LudoWeaponType.Rifle;
+
+        [Header("Damage progression")]
+        [SerializeField] private int minorPiecesPerNonFinalShot = 3;
+
+        [Header("Camera anchors")]
+        [SerializeField] private Vector3 firstPersonAimOffset = new Vector3(0.08f, -0.04f, 0.18f);
+        [SerializeField] private float aimPositionLerp = 20f;
+
+        private readonly Dictionary<LudoWeaponType, WeaponBallisticsProfile> _profiles = new Dictionary<LudoWeaponType, WeaponBallisticsProfile>();
+        private readonly List<TokenPieceHealth> _tokenPieces = new List<TokenPieceHealth>();
+
+        private WeaponBallisticsProfile _activeWeapon;
+        private Coroutine _fireRoutine;
+        private Coroutine _cameraRoutine;
+        private ILudoWeaponEvents[] _eventListeners = Array.Empty<ILudoWeaponEvents>();
+        private float _baseFov = 60f;
+        private Vector3 _baseCameraLocalPos;
+
+        private void Awake()
+        {
+            if (playerCamera == null)
+            {
+                playerCamera = Camera.main;
+            }
+
+            if (sfxSource == null)
+            {
+                sfxSource = GetComponent<AudioSource>();
+            }
+
+            if (playerCamera != null)
+            {
+                _baseFov = playerCamera.fieldOfView;
+                _baseCameraLocalPos = playerCamera.transform.localPosition;
+            }
+
+            BuildProfileMap();
+            CacheTokenPieces();
+            _eventListeners = GetComponentsInParent<ILudoWeaponEvents>(true);
+            Equip(startingWeapon);
+        }
+
+        public void Equip(LudoWeaponType weaponType)
+        {
+            if (!_profiles.TryGetValue(weaponType, out var profile))
+            {
+                Debug.LogWarning($"Missing profile for weapon {weaponType}");
+                return;
+            }
+
+            _activeWeapon = profile;
+            for (int i = 0; i < _eventListeners.Length; i++)
+            {
+                _eventListeners[i].OnWeaponEquipped(weaponType);
+            }
+        }
+
+        public void FireAtToken()
+        {
+            if (_activeWeapon == null || muzzle == null || targetTokenRoot == null)
+                return;
+
+            if (_fireRoutine != null)
+            {
+                StopCoroutine(_fireRoutine);
+            }
+
+            _fireRoutine = StartCoroutine(FireRoutine(_activeWeapon));
+        }
+
+        private IEnumerator FireRoutine(WeaponBallisticsProfile weapon)
+        {
+            int shots = weapon.fireMode == WeaponFireMode.Single ? 1 : Mathf.Max(1, weapon.magazineSize);
+            float shotDelay = weapon.roundsPerSecond <= 0.001f ? 0f : 1f / weapon.roundsPerSecond;
+
+            BeginAimCamera(weapon);
+
+            for (int i = 0; i < shots; i++)
+            {
+                bool isLastBullet = i == shots - 1;
+                FireSingleRound(weapon, i, shots, isLastBullet);
+                if (shotDelay > 0f)
+                {
+                    yield return new WaitForSeconds(shotDelay);
+                }
+            }
+        }
+
+        private void FireSingleRound(WeaponBallisticsProfile weapon, int shotIndex, int totalShots, bool isLastBullet)
+        {
+            Vector3 directionToTarget = (targetTokenRoot.position - muzzle.position).normalized;
+            Vector3 spreadVec = UnityEngine.Random.insideUnitSphere * weapon.spread;
+            Vector3 shotDirection = (directionToTarget + spreadVec).normalized;
+
+            SpawnBullet(weapon, shotDirection, isLastBullet);
+            SpawnShell(weapon);
+            PlayShotSfx(weapon);
+
+            for (int i = 0; i < _eventListeners.Length; i++)
+            {
+                _eventListeners[i].OnWeaponShot(weapon.weaponType, shotIndex, totalShots);
+            }
+        }
+
+        private void SpawnBullet(WeaponBallisticsProfile weapon, Vector3 direction, bool isLastBullet)
+        {
+            if (weapon.bulletPrefab == null)
+                return;
+
+            GameObject bulletObj = Instantiate(weapon.bulletPrefab, muzzle.position, Quaternion.LookRotation(direction));
+            bulletObj.transform.localScale *= weapon.bulletScale;
+
+            BattleRoyaleBullet bullet = bulletObj.GetComponent<BattleRoyaleBullet>();
+            if (bullet == null)
+            {
+                bullet = bulletObj.AddComponent<BattleRoyaleBullet>();
+            }
+
+            bullet.Initialize(direction * weapon.muzzleVelocity, this, isLastBullet, weapon.impactFollowSeconds);
+        }
+
+        private void SpawnShell(WeaponBallisticsProfile weapon)
+        {
+            if (weapon.shellPrefab == null || shellEject == null)
+                return;
+
+            GameObject shellObj = Instantiate(weapon.shellPrefab, shellEject.position, shellEject.rotation);
+            shellObj.transform.localScale *= weapon.shellScale;
+
+            Rigidbody rb = shellObj.GetComponent<Rigidbody>();
+            if (rb == null)
+            {
+                rb = shellObj.AddComponent<Rigidbody>();
+            }
+
+            rb.mass = 0.02f;
+            rb.velocity = (shellEject.right * UnityEngine.Random.Range(1.8f, 3.1f)) + (Vector3.up * UnityEngine.Random.Range(0.8f, 1.3f));
+            rb.angularVelocity = UnityEngine.Random.insideUnitSphere * 13f;
+            Destroy(shellObj, 5f);
+        }
+
+        private void PlayShotSfx(WeaponBallisticsProfile weapon)
+        {
+            if (sfxSource != null && weapon.shotSfx != null)
+            {
+                sfxSource.PlayOneShot(weapon.shotSfx);
+            }
+        }
+
+        public void OnBulletImpact(Vector3 point, bool isLastBullet)
+        {
+            ApplyProgressiveDamage(isLastBullet);
+            if (isLastBullet)
+            {
+                StartFinalImpactCamera(point);
+                for (int i = 0; i < _eventListeners.Length; i++)
+                {
+                    _eventListeners[i].OnFinalImpact(_activeWeapon.weaponType, point);
+                }
+            }
+        }
+
+        private void ApplyProgressiveDamage(bool isLastBullet)
+        {
+            if (_tokenPieces.Count == 0)
+                return;
+
+            if (isLastBullet)
+            {
+                for (int i = 0; i < _tokenPieces.Count; i++)
+                {
+                    _tokenPieces[i].BreakCompletely();
+                }
+                return;
+            }
+
+            int maxPieces = Mathf.Clamp(minorPiecesPerNonFinalShot, 1, _tokenPieces.Count);
+            for (int i = 0; i < maxPieces; i++)
+            {
+                _tokenPieces[i].DamageMinor();
+            }
+        }
+
+        private void BeginAimCamera(WeaponBallisticsProfile weapon)
+        {
+            if (playerCamera == null)
+                return;
+
+            if (_cameraRoutine != null)
+            {
+                StopCoroutine(_cameraRoutine);
+            }
+
+            _cameraRoutine = StartCoroutine(AimViewRoutine(weapon));
+        }
+
+        private IEnumerator AimViewRoutine(WeaponBallisticsProfile weapon)
+        {
+            float elapsed = 0f;
+            float duration = Mathf.Max(0.01f, weapon.aimTransitionSeconds);
+            float startFov = playerCamera.fieldOfView;
+            Vector3 startPos = playerCamera.transform.localPosition;
+            Vector3 targetLocalPos = _baseCameraLocalPos + firstPersonAimOffset;
+
+            while (elapsed < duration)
+            {
+                elapsed += Time.deltaTime;
+                float t = Mathf.Clamp01(elapsed / duration);
+                playerCamera.fieldOfView = Mathf.Lerp(startFov, weapon.aimFov, t);
+                playerCamera.transform.localPosition = Vector3.Lerp(startPos, targetLocalPos, Mathf.Clamp01(Time.deltaTime * aimPositionLerp));
+                yield return null;
+            }
+        }
+
+        private void StartFinalImpactCamera(Vector3 point)
+        {
+            if (playerCamera == null)
+                return;
+
+            if (_cameraRoutine != null)
+            {
+                StopCoroutine(_cameraRoutine);
+            }
+
+            float seconds = _activeWeapon != null ? _activeWeapon.impactFollowSeconds : 1f;
+            _cameraRoutine = StartCoroutine(FinalImpactRoutine(point, seconds));
+        }
+
+        private IEnumerator FinalImpactRoutine(Vector3 impactPoint, float seconds)
+        {
+            float t = 0f;
+            Quaternion startRot = playerCamera.transform.rotation;
+
+            while (t < seconds)
+            {
+                t += Time.deltaTime;
+                Vector3 towardImpact = (impactPoint - playerCamera.transform.position).normalized;
+                Quaternion impactRot = Quaternion.LookRotation(towardImpact, Vector3.up);
+                playerCamera.transform.rotation = Quaternion.Slerp(startRot, impactRot, Mathf.Clamp01(t / seconds));
+                yield return null;
+            }
+
+            yield return StartCoroutine(ReturnCameraToDefault());
+        }
+
+        private IEnumerator ReturnCameraToDefault()
+        {
+            float elapsed = 0f;
+            const float duration = 0.2f;
+            float fromFov = playerCamera.fieldOfView;
+            Vector3 fromPos = playerCamera.transform.localPosition;
+
+            while (elapsed < duration)
+            {
+                elapsed += Time.deltaTime;
+                float t = Mathf.Clamp01(elapsed / duration);
+                playerCamera.fieldOfView = Mathf.Lerp(fromFov, _baseFov, t);
+                playerCamera.transform.localPosition = Vector3.Lerp(fromPos, _baseCameraLocalPos, t);
+                yield return null;
+            }
+        }
+
+        private void BuildProfileMap()
+        {
+            _profiles.Clear();
+            for (int i = 0; i < weaponProfiles.Count; i++)
+            {
+                WeaponBallisticsProfile profile = weaponProfiles[i];
+                if (profile == null)
+                    continue;
+
+                _profiles[profile.weaponType] = profile;
+            }
+        }
+
+        private void CacheTokenPieces()
+        {
+            _tokenPieces.Clear();
+            if (targetTokenRoot == null)
+                return;
+
+            TokenPieceHealth[] pieces = targetTokenRoot.GetComponentsInChildren<TokenPieceHealth>(true);
+            _tokenPieces.AddRange(pieces);
+        }
+    }
+
+    public sealed class BattleRoyaleBullet : MonoBehaviour
+    {
+        private Vector3 _velocity;
+        private float _life;
+        private bool _isLastBullet;
+        private bool _impactSent;
+        private BattleRoyaleWeaponDirector _director;
+
+        public void Initialize(Vector3 velocity, BattleRoyaleWeaponDirector director, bool isLastBullet, float followSeconds)
+        {
+            _velocity = velocity;
+            _director = director;
+            _isLastBullet = isLastBullet;
+            _life = Mathf.Max(1.2f, followSeconds + 0.55f);
+        }
+
+        private void Update()
+        {
+            transform.position += _velocity * Time.deltaTime;
+            _life -= Time.deltaTime;
+            if (_life <= 0f)
+            {
+                Destroy(gameObject);
+            }
+        }
+
+        private void OnTriggerEnter(Collider other)
+        {
+            if (_impactSent)
+                return;
+
+            _impactSent = true;
+            _director?.OnBulletImpact(transform.position, _isLastBullet);
+            Destroy(gameObject);
+        }
+    }
+
+    public sealed class TokenPieceHealth : MonoBehaviour
+    {
+        [SerializeField] private int minorHitsToDetach = 2;
+        [SerializeField] private Rigidbody rb;
+
+        private int _minorHits;
+
+        private void Awake()
+        {
+            if (rb == null)
+            {
+                rb = GetComponent<Rigidbody>();
+            }
+        }
+
+        public void DamageMinor()
+        {
+            _minorHits++;
+            if (_minorHits >= minorHitsToDetach)
+            {
+                BreakCompletely();
+            }
+        }
+
+        public void BreakCompletely()
+        {
+            if (rb == null)
+                return;
+
+            rb.isKinematic = false;
+            rb.AddExplosionForce(8f, transform.position + Vector3.back, 2f, 0.3f, ForceMode.Impulse);
+            rb.AddTorque(UnityEngine.Random.insideUnitSphere * 5.5f, ForceMode.Impulse);
+        }
+    }
+}

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -545,13 +545,13 @@ const FIREARM_MAGAZINE_SHOTS = Object.freeze({
   polySmg01Attack: 28
 });
 const FIREARM_BALLISTICS_PROFILE = Object.freeze({
-  default: Object.freeze({ tracerSpread: 0.018, shellDriftX: 0.00026, shellDriftZ: -0.00021, shellArc: 0.052 }),
-  pistol: Object.freeze({ tracerSpread: 0.013, shellDriftX: 0.00022, shellDriftZ: -0.00016, shellArc: 0.042 }),
-  smg: Object.freeze({ tracerSpread: 0.022, shellDriftX: 0.00031, shellDriftZ: -0.00025, shellArc: 0.058 }),
-  rifle: Object.freeze({ tracerSpread: 0.016, shellDriftX: 0.00027, shellDriftZ: -0.00022, shellArc: 0.054 }),
-  marksman: Object.freeze({ tracerSpread: 0.01, shellDriftX: 0.0002, shellDriftZ: -0.00014, shellArc: 0.036 }),
-  shotgun: Object.freeze({ tracerSpread: 0.026, shellDriftX: 0.00034, shellDriftZ: -0.00026, shellArc: 0.061 }),
-  explosive: Object.freeze({ tracerSpread: 0.03, shellDriftX: 0.00018, shellDriftZ: -0.00012, shellArc: 0.03 })
+  default: Object.freeze({ tracerSpread: 0.018, shellDriftX: 0.00026, shellDriftZ: -0.00021, shellArc: 0.052, bulletRadius: 0.0036, bulletSpeed: 0.2, shellRadius: 0.0028 }),
+  pistol: Object.freeze({ tracerSpread: 0.013, shellDriftX: 0.00022, shellDriftZ: -0.00016, shellArc: 0.042, bulletRadius: 0.0034, bulletSpeed: 0.21, shellRadius: 0.0026 }),
+  smg: Object.freeze({ tracerSpread: 0.022, shellDriftX: 0.00031, shellDriftZ: -0.00025, shellArc: 0.058, bulletRadius: 0.0033, bulletSpeed: 0.23, shellRadius: 0.0025 }),
+  rifle: Object.freeze({ tracerSpread: 0.016, shellDriftX: 0.00027, shellDriftZ: -0.00022, shellArc: 0.054, bulletRadius: 0.0038, bulletSpeed: 0.26, shellRadius: 0.003 }),
+  marksman: Object.freeze({ tracerSpread: 0.01, shellDriftX: 0.0002, shellDriftZ: -0.00014, shellArc: 0.036, bulletRadius: 0.0042, bulletSpeed: 0.29, shellRadius: 0.0032 }),
+  shotgun: Object.freeze({ tracerSpread: 0.026, shellDriftX: 0.00034, shellDriftZ: -0.00026, shellArc: 0.061, bulletRadius: 0.0048, bulletSpeed: 0.17, shellRadius: 0.004 }),
+  explosive: Object.freeze({ tracerSpread: 0.03, shellDriftX: 0.00018, shellDriftZ: -0.00012, shellArc: 0.03, bulletRadius: 0.0058, bulletSpeed: 0.14, shellRadius: 0.0046 })
 });
 const FIREARM_BALLISTICS_PROFILE_BY_ID = Object.freeze({
   glockSidearmAttack: 'pistol',
@@ -9930,6 +9930,22 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           const muzzleFx = createCaptureMuzzleFx();
           const tracers = Array.from({ length: 10 }, () => createCaptureBulletTracerFx('#ffe39a'));
           const shells = Array.from({ length: Math.max(16, Math.min(42, shots + 6)) }, () => createCaptureShellCasingFx());
+          const bulletGeometry = new THREE.SphereGeometry(ballisticsProfile.bulletRadius, 10, 10);
+          const bulletMaterial = new THREE.MeshStandardMaterial({
+            color: '#d9dde2',
+            metalness: 0.95,
+            roughness: 0.16
+          });
+          const bullets = Array.from({ length: shots }, (_, index) => {
+            const mesh = new THREE.Mesh(bulletGeometry, bulletMaterial.clone());
+            mesh.visible = false;
+            mesh.castShadow = false;
+            mesh.receiveShadow = false;
+            mesh.userData.spawnAt = preFireLeadMs + index * cadenceMs;
+            mesh.userData.completed = false;
+            scene.add(mesh);
+            return mesh;
+          });
           const targetReticle = createCaptureTargetReticleFx();
           const shellStates = shells.map(() => ({ landed: false, settledAt: 0 }));
           scene.add(muzzleFx.root);
@@ -10041,6 +10057,52 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
               entry.root.position.copy(mid);
               entry.root.quaternion.setFromUnitVectors(MISSILE_FORWARD, dir);
             });
+            bullets.forEach((bulletMesh, idx) => {
+              const spawnAt = Number(bulletMesh.userData?.spawnAt ?? 0);
+              const life = elapsed - spawnAt;
+              if (life < 0) {
+                bulletMesh.visible = false;
+                return;
+              }
+              const shotProgress = clamp(life / Math.max(30, cadenceMs), 0, 1);
+              const start = muzzleOrigin.clone();
+              const end = muzzleTarget.clone();
+              const bulletPos = start.lerp(end, shotProgress);
+              bulletMesh.visible = shotProgress < 0.995;
+              bulletMesh.position.copy(bulletPos);
+              if (shotProgress >= 0.995) {
+                bulletMesh.userData.completed = true;
+                bulletMesh.visible = false;
+              }
+              if (idx === shots - 1 && singleShotFirearm) {
+                const aimDirNow = muzzleTarget.clone().sub(muzzleOrigin).normalize();
+                const followOffset = aimDirNow
+                  .clone()
+                  .multiplyScalar(-0.11)
+                  .add(new THREE.Vector3(0, 0.08, 0.03));
+                setCameraFocus({
+                  target: bulletPos,
+                  follow: true,
+                  priority: 10,
+                  ttl: 0,
+                  offset: Math.max(0.02, (CAMERA_TARGET_LIFT + 0.016) * CAPTURE_CAMERA_ZOOM_OUT_FACTOR),
+                  followOffset,
+                  force: true
+                });
+              }
+              if (idx === shots - 1 && !singleShotFirearm && shotProgress > 0.86) {
+                const pullback = muzzleTarget.clone().sub(muzzleOrigin).normalize().multiplyScalar(-0.12);
+                setCameraFocus({
+                  target: bulletPos,
+                  follow: true,
+                  priority: 10,
+                  ttl: 0,
+                  offset: Math.max(0.02, (CAMERA_TARGET_LIFT + 0.02) * CAPTURE_CAMERA_ZOOM_OUT_FACTOR),
+                  followOffset: new THREE.Vector3(pullback.x, 0.09, pullback.z),
+                  force: true
+                });
+              }
+            });
             shells.forEach((shell, idx) => {
               const shellState = shellStates[idx];
               const launchAt = idx * (cadenceMs * 0.7);
@@ -10107,9 +10169,11 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
               return;
             }
             if (hideTarget) hideTarget.visible = true;
-            [muzzleFx.root, targetReticle.root, ...tracers.map((entry) => entry.root), ...shells].forEach((obj) => {
+            [muzzleFx.root, targetReticle.root, ...tracers.map((entry) => entry.root), ...shells, ...bullets].forEach((obj) => {
               obj?.parent?.remove?.(obj);
             });
+            bulletGeometry.dispose();
+            bulletMaterial.dispose();
             handWeaponAttachment?.release?.();
             if (parkedEntry?.weaponHolder) parkedEntry.weaponHolder.visible = true;
             playCapture();


### PR DESCRIPTION
### Motivation

- Implement a local weapon director in Unity to simulate ballistics, firing, shell ejection, progressive token damage, and camera follow for battle-royale-style captures.
- Extend the web frontend's capture animation to render physical bullet meshes and expose more ballistics parameters to better match runtime visuals.

### Description

- Add `Assets/Scripts/Gameplay/Weapons/BattleRoyaleWeaponDirector.cs` which introduces `WeaponBallisticsProfile`, `BattleRoyaleWeaponDirector`, `BattleRoyaleBullet`, `TokenPieceHealth`, `WeaponFireMode`, and `LudoWeaponType`, and implements equip/fire routines, bullet/shell spawning, camera aim/follow, progressive damage, and an `ILudoWeaponEvents` interface for callbacks.
- Implement bullet lifetime, velocity initialization via `BattleRoyaleBullet.Initialize`, impact handling via `OnTriggerEnter`, and piece breaking in `TokenPieceHealth` with configurable minor hit thresholds and explosion forces.
- Update `webapp/src/pages/Games/LudoBattleRoyal.jsx` by extending `FIREARM_BALLISTICS_PROFILE` with `bulletRadius`, `bulletSpeed`, and `shellRadius` per weapon type, and add runtime creation and animation of bullet `THREE.Mesh` objects during capture sequences, including camera focus behavior for final shots and proper disposal of geometry/materials.
- Ensure bullets are hidden/removed from the scene after completion and existing muzzle/tracer/shell workflows are integrated with the new bullet visuals.

### Testing

- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f19533d74c8329854993cbfdc3af1b)