### PR TITLE
Add Unity BattleRoyaleWeaponDirector and enrich web ballistics, calibers, and SFX fallbacks

### DIFF
--- a/Assets/Scripts/Gameplay/Weapons/BattleRoyaleWeaponDirector.cs
+++ b/Assets/Scripts/Gameplay/Weapons/BattleRoyaleWeaponDirector.cs
@@ -1,0 +1,419 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace TonPlaygram.Gameplay.Weapons
+{
+    public enum WeaponFireMode
+    {
+        Single,
+        MagazineAuto
+    }
+
+    public enum LudoWeaponType
+    {
+        Rifle,
+        SMG,
+        Pistol,
+        Shotgun,
+        Sniper,
+        GrenadeLauncher
+    }
+
+    [Serializable]
+    public sealed class WeaponBallisticsProfile
+    {
+        public LudoWeaponType weaponType = LudoWeaponType.Rifle;
+        public WeaponFireMode fireMode = WeaponFireMode.MagazineAuto;
+        public int magazineSize = 30;
+        public float roundsPerSecond = 10f;
+        public float muzzleVelocity = 220f;
+        public float spread = 0.012f;
+        public float bulletScale = 1f;
+        public float shellScale = 1f;
+        public float aimFov = 40f;
+        public float aimTransitionSeconds = 0.08f;
+        public float impactFollowSeconds = 1.15f;
+        public GameObject bulletPrefab;
+        public GameObject shellPrefab;
+        public AudioClip shotSfx;
+    }
+
+    public interface ILudoWeaponEvents
+    {
+        void OnWeaponEquipped(LudoWeaponType weaponType);
+        void OnWeaponShot(LudoWeaponType weaponType, int shotIndex, int totalShots);
+        void OnFinalImpact(LudoWeaponType weaponType, Vector3 impactPoint);
+    }
+
+    public sealed class BattleRoyaleWeaponDirector : MonoBehaviour
+    {
+        [Header("Scene refs")]
+        [SerializeField] private Camera playerCamera;
+        [SerializeField] private Transform muzzle;
+        [SerializeField] private Transform shellEject;
+        [SerializeField] private Transform targetTokenRoot;
+        [SerializeField] private AudioSource sfxSource;
+
+        [Header("Weapon presets")]
+        [SerializeField] private List<WeaponBallisticsProfile> weaponProfiles = new List<WeaponBallisticsProfile>();
+        [SerializeField] private LudoWeaponType startingWeapon = LudoWeaponType.Rifle;
+
+        [Header("Damage progression")]
+        [SerializeField] private int minorPiecesPerNonFinalShot = 3;
+
+        [Header("Camera anchors")]
+        [SerializeField] private Vector3 firstPersonAimOffset = new Vector3(0.08f, -0.04f, 0.18f);
+        [SerializeField] private float aimPositionLerp = 20f;
+
+        private readonly Dictionary<LudoWeaponType, WeaponBallisticsProfile> _profiles = new Dictionary<LudoWeaponType, WeaponBallisticsProfile>();
+        private readonly List<TokenPieceHealth> _tokenPieces = new List<TokenPieceHealth>();
+
+        private WeaponBallisticsProfile _activeWeapon;
+        private Coroutine _fireRoutine;
+        private Coroutine _cameraRoutine;
+        private ILudoWeaponEvents[] _eventListeners = Array.Empty<ILudoWeaponEvents>();
+        private float _baseFov = 60f;
+        private Vector3 _baseCameraLocalPos;
+
+        private void Awake()
+        {
+            if (playerCamera == null)
+            {
+                playerCamera = Camera.main;
+            }
+
+            if (sfxSource == null)
+            {
+                sfxSource = GetComponent<AudioSource>();
+            }
+
+            if (playerCamera != null)
+            {
+                _baseFov = playerCamera.fieldOfView;
+                _baseCameraLocalPos = playerCamera.transform.localPosition;
+            }
+
+            BuildProfileMap();
+            CacheTokenPieces();
+            _eventListeners = GetComponentsInParent<ILudoWeaponEvents>(true);
+            Equip(startingWeapon);
+        }
+
+        public void Equip(LudoWeaponType weaponType)
+        {
+            if (!_profiles.TryGetValue(weaponType, out var profile))
+            {
+                Debug.LogWarning($"Missing profile for weapon {weaponType}");
+                return;
+            }
+
+            _activeWeapon = profile;
+            for (int i = 0; i < _eventListeners.Length; i++)
+            {
+                _eventListeners[i].OnWeaponEquipped(weaponType);
+            }
+        }
+
+        public void FireAtToken()
+        {
+            if (_activeWeapon == null || muzzle == null || targetTokenRoot == null)
+                return;
+
+            if (_fireRoutine != null)
+            {
+                StopCoroutine(_fireRoutine);
+            }
+
+            _fireRoutine = StartCoroutine(FireRoutine(_activeWeapon));
+        }
+
+        private IEnumerator FireRoutine(WeaponBallisticsProfile weapon)
+        {
+            int shots = weapon.fireMode == WeaponFireMode.Single ? 1 : Mathf.Max(1, weapon.magazineSize);
+            float shotDelay = weapon.roundsPerSecond <= 0.001f ? 0f : 1f / weapon.roundsPerSecond;
+
+            BeginAimCamera(weapon);
+
+            for (int i = 0; i < shots; i++)
+            {
+                bool isLastBullet = i == shots - 1;
+                FireSingleRound(weapon, i, shots, isLastBullet);
+                if (shotDelay > 0f)
+                {
+                    yield return new WaitForSeconds(shotDelay);
+                }
+            }
+        }
+
+        private void FireSingleRound(WeaponBallisticsProfile weapon, int shotIndex, int totalShots, bool isLastBullet)
+        {
+            Vector3 directionToTarget = (targetTokenRoot.position - muzzle.position).normalized;
+            Vector3 spreadVec = UnityEngine.Random.insideUnitSphere * weapon.spread;
+            Vector3 shotDirection = (directionToTarget + spreadVec).normalized;
+
+            SpawnBullet(weapon, shotDirection, isLastBullet);
+            SpawnShell(weapon);
+            PlayShotSfx(weapon);
+
+            for (int i = 0; i < _eventListeners.Length; i++)
+            {
+                _eventListeners[i].OnWeaponShot(weapon.weaponType, shotIndex, totalShots);
+            }
+        }
+
+        private void SpawnBullet(WeaponBallisticsProfile weapon, Vector3 direction, bool isLastBullet)
+        {
+            if (weapon.bulletPrefab == null)
+                return;
+
+            GameObject bulletObj = Instantiate(weapon.bulletPrefab, muzzle.position, Quaternion.LookRotation(direction));
+            bulletObj.transform.localScale *= weapon.bulletScale;
+
+            BattleRoyaleBullet bullet = bulletObj.GetComponent<BattleRoyaleBullet>();
+            if (bullet == null)
+            {
+                bullet = bulletObj.AddComponent<BattleRoyaleBullet>();
+            }
+
+            bullet.Initialize(direction * weapon.muzzleVelocity, this, isLastBullet, weapon.impactFollowSeconds);
+        }
+
+        private void SpawnShell(WeaponBallisticsProfile weapon)
+        {
+            if (weapon.shellPrefab == null || shellEject == null)
+                return;
+
+            GameObject shellObj = Instantiate(weapon.shellPrefab, shellEject.position, shellEject.rotation);
+            shellObj.transform.localScale *= weapon.shellScale;
+
+            Rigidbody rb = shellObj.GetComponent<Rigidbody>();
+            if (rb == null)
+            {
+                rb = shellObj.AddComponent<Rigidbody>();
+            }
+
+            rb.mass = 0.02f;
+            rb.velocity = (shellEject.right * UnityEngine.Random.Range(1.8f, 3.1f)) + (Vector3.up * UnityEngine.Random.Range(0.8f, 1.3f));
+            rb.angularVelocity = UnityEngine.Random.insideUnitSphere * 13f;
+            Destroy(shellObj, 5f);
+        }
+
+        private void PlayShotSfx(WeaponBallisticsProfile weapon)
+        {
+            if (sfxSource != null && weapon.shotSfx != null)
+            {
+                sfxSource.PlayOneShot(weapon.shotSfx);
+            }
+        }
+
+        public void OnBulletImpact(Vector3 point, bool isLastBullet)
+        {
+            ApplyProgressiveDamage(isLastBullet);
+            if (isLastBullet)
+            {
+                StartFinalImpactCamera(point);
+                for (int i = 0; i < _eventListeners.Length; i++)
+                {
+                    _eventListeners[i].OnFinalImpact(_activeWeapon.weaponType, point);
+                }
+            }
+        }
+
+        private void ApplyProgressiveDamage(bool isLastBullet)
+        {
+            if (_tokenPieces.Count == 0)
+                return;
+
+            if (isLastBullet)
+            {
+                for (int i = 0; i < _tokenPieces.Count; i++)
+                {
+                    _tokenPieces[i].BreakCompletely();
+                }
+                return;
+            }
+
+            int maxPieces = Mathf.Clamp(minorPiecesPerNonFinalShot, 1, _tokenPieces.Count);
+            for (int i = 0; i < maxPieces; i++)
+            {
+                _tokenPieces[i].DamageMinor();
+            }
+        }
+
+        private void BeginAimCamera(WeaponBallisticsProfile weapon)
+        {
+            if (playerCamera == null)
+                return;
+
+            if (_cameraRoutine != null)
+            {
+                StopCoroutine(_cameraRoutine);
+            }
+
+            _cameraRoutine = StartCoroutine(AimViewRoutine(weapon));
+        }
+
+        private IEnumerator AimViewRoutine(WeaponBallisticsProfile weapon)
+        {
+            float elapsed = 0f;
+            float duration = Mathf.Max(0.01f, weapon.aimTransitionSeconds);
+            float startFov = playerCamera.fieldOfView;
+            Vector3 startPos = playerCamera.transform.localPosition;
+            Vector3 targetLocalPos = _baseCameraLocalPos + firstPersonAimOffset;
+
+            while (elapsed < duration)
+            {
+                elapsed += Time.deltaTime;
+                float t = Mathf.Clamp01(elapsed / duration);
+                playerCamera.fieldOfView = Mathf.Lerp(startFov, weapon.aimFov, t);
+                playerCamera.transform.localPosition = Vector3.Lerp(startPos, targetLocalPos, Mathf.Clamp01(Time.deltaTime * aimPositionLerp));
+                yield return null;
+            }
+        }
+
+        private void StartFinalImpactCamera(Vector3 point)
+        {
+            if (playerCamera == null)
+                return;
+
+            if (_cameraRoutine != null)
+            {
+                StopCoroutine(_cameraRoutine);
+            }
+
+            float seconds = _activeWeapon != null ? _activeWeapon.impactFollowSeconds : 1f;
+            _cameraRoutine = StartCoroutine(FinalImpactRoutine(point, seconds));
+        }
+
+        private IEnumerator FinalImpactRoutine(Vector3 impactPoint, float seconds)
+        {
+            float t = 0f;
+            Quaternion startRot = playerCamera.transform.rotation;
+
+            while (t < seconds)
+            {
+                t += Time.deltaTime;
+                Vector3 towardImpact = (impactPoint - playerCamera.transform.position).normalized;
+                Quaternion impactRot = Quaternion.LookRotation(towardImpact, Vector3.up);
+                playerCamera.transform.rotation = Quaternion.Slerp(startRot, impactRot, Mathf.Clamp01(t / seconds));
+                yield return null;
+            }
+
+            yield return StartCoroutine(ReturnCameraToDefault());
+        }
+
+        private IEnumerator ReturnCameraToDefault()
+        {
+            float elapsed = 0f;
+            const float duration = 0.2f;
+            float fromFov = playerCamera.fieldOfView;
+            Vector3 fromPos = playerCamera.transform.localPosition;
+
+            while (elapsed < duration)
+            {
+                elapsed += Time.deltaTime;
+                float t = Mathf.Clamp01(elapsed / duration);
+                playerCamera.fieldOfView = Mathf.Lerp(fromFov, _baseFov, t);
+                playerCamera.transform.localPosition = Vector3.Lerp(fromPos, _baseCameraLocalPos, t);
+                yield return null;
+            }
+        }
+
+        private void BuildProfileMap()
+        {
+            _profiles.Clear();
+            for (int i = 0; i < weaponProfiles.Count; i++)
+            {
+                WeaponBallisticsProfile profile = weaponProfiles[i];
+                if (profile == null)
+                    continue;
+
+                _profiles[profile.weaponType] = profile;
+            }
+        }
+
+        private void CacheTokenPieces()
+        {
+            _tokenPieces.Clear();
+            if (targetTokenRoot == null)
+                return;
+
+            TokenPieceHealth[] pieces = targetTokenRoot.GetComponentsInChildren<TokenPieceHealth>(true);
+            _tokenPieces.AddRange(pieces);
+        }
+    }
+
+    public sealed class BattleRoyaleBullet : MonoBehaviour
+    {
+        private Vector3 _velocity;
+        private float _life;
+        private bool _isLastBullet;
+        private bool _impactSent;
+        private BattleRoyaleWeaponDirector _director;
+
+        public void Initialize(Vector3 velocity, BattleRoyaleWeaponDirector director, bool isLastBullet, float followSeconds)
+        {
+            _velocity = velocity;
+            _director = director;
+            _isLastBullet = isLastBullet;
+            _life = Mathf.Max(1.2f, followSeconds + 0.55f);
+        }
+
+        private void Update()
+        {
+            transform.position += _velocity * Time.deltaTime;
+            _life -= Time.deltaTime;
+            if (_life <= 0f)
+            {
+                Destroy(gameObject);
+            }
+        }
+
+        private void OnTriggerEnter(Collider other)
+        {
+            if (_impactSent)
+                return;
+
+            _impactSent = true;
+            _director?.OnBulletImpact(transform.position, _isLastBullet);
+            Destroy(gameObject);
+        }
+    }
+
+    public sealed class TokenPieceHealth : MonoBehaviour
+    {
+        [SerializeField] private int minorHitsToDetach = 2;
+        [SerializeField] private Rigidbody rb;
+
+        private int _minorHits;
+
+        private void Awake()
+        {
+            if (rb == null)
+            {
+                rb = GetComponent<Rigidbody>();
+            }
+        }
+
+        public void DamageMinor()
+        {
+            _minorHits++;
+            if (_minorHits >= minorHitsToDetach)
+            {
+                BreakCompletely();
+            }
+        }
+
+        public void BreakCompletely()
+        {
+            if (rb == null)
+                return;
+
+            rb.isKinematic = false;
+            rb.AddExplosionForce(8f, transform.position + Vector3.back, 2f, 0.3f, ForceMode.Impulse);
+            rb.AddTorque(UnityEngine.Random.insideUnitSphere * 5.5f, ForceMode.Impulse);
+        }
+    }
+}

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -545,13 +545,13 @@ const FIREARM_MAGAZINE_SHOTS = Object.freeze({
   polySmg01Attack: 28
 });
 const FIREARM_BALLISTICS_PROFILE = Object.freeze({
-  default: Object.freeze({ tracerSpread: 0.018, shellDriftX: 0.00026, shellDriftZ: -0.00021, shellArc: 0.052 }),
-  pistol: Object.freeze({ tracerSpread: 0.013, shellDriftX: 0.00022, shellDriftZ: -0.00016, shellArc: 0.042 }),
-  smg: Object.freeze({ tracerSpread: 0.022, shellDriftX: 0.00031, shellDriftZ: -0.00025, shellArc: 0.058 }),
-  rifle: Object.freeze({ tracerSpread: 0.016, shellDriftX: 0.00027, shellDriftZ: -0.00022, shellArc: 0.054 }),
-  marksman: Object.freeze({ tracerSpread: 0.01, shellDriftX: 0.0002, shellDriftZ: -0.00014, shellArc: 0.036 }),
-  shotgun: Object.freeze({ tracerSpread: 0.026, shellDriftX: 0.00034, shellDriftZ: -0.00026, shellArc: 0.061 }),
-  explosive: Object.freeze({ tracerSpread: 0.03, shellDriftX: 0.00018, shellDriftZ: -0.00012, shellArc: 0.03 })
+  default: Object.freeze({ tracerSpread: 0.018, shellDriftX: 0.00026, shellDriftZ: -0.00021, shellArc: 0.052, bulletRadius: 0.0036, bulletSpeed: 0.2, shellRadius: 0.0028 }),
+  pistol: Object.freeze({ tracerSpread: 0.013, shellDriftX: 0.00022, shellDriftZ: -0.00016, shellArc: 0.042, bulletRadius: 0.0034, bulletSpeed: 0.21, shellRadius: 0.0026 }),
+  smg: Object.freeze({ tracerSpread: 0.022, shellDriftX: 0.00031, shellDriftZ: -0.00025, shellArc: 0.058, bulletRadius: 0.0033, bulletSpeed: 0.23, shellRadius: 0.0025 }),
+  rifle: Object.freeze({ tracerSpread: 0.016, shellDriftX: 0.00027, shellDriftZ: -0.00022, shellArc: 0.054, bulletRadius: 0.0038, bulletSpeed: 0.26, shellRadius: 0.003 }),
+  marksman: Object.freeze({ tracerSpread: 0.01, shellDriftX: 0.0002, shellDriftZ: -0.00014, shellArc: 0.036, bulletRadius: 0.0042, bulletSpeed: 0.29, shellRadius: 0.0032 }),
+  shotgun: Object.freeze({ tracerSpread: 0.026, shellDriftX: 0.00034, shellDriftZ: -0.00026, shellArc: 0.061, bulletRadius: 0.0048, bulletSpeed: 0.17, shellRadius: 0.004 }),
+  explosive: Object.freeze({ tracerSpread: 0.03, shellDriftX: 0.00018, shellDriftZ: -0.00012, shellArc: 0.03, bulletRadius: 0.0058, bulletSpeed: 0.14, shellRadius: 0.0046 })
 });
 const FIREARM_BALLISTICS_PROFILE_BY_ID = Object.freeze({
   glockSidearmAttack: 'pistol',
@@ -580,6 +580,30 @@ const FIREARM_BALLISTICS_PROFILE_BY_ID = Object.freeze({
   polyShotgun03Attack: 'shotgun',
   polySawedOff01Attack: 'shotgun',
   grenadeBlastAttack: 'explosive'
+});
+const FIREARM_CALIBER_BY_ID = Object.freeze({
+  glockSidearmAttack: { bulletRadius: 0.0032, bulletSpeed: 0.22, shellRadius: 0.0024 },
+  pistolSidearmAttack: { bulletRadius: 0.0032, bulletSpeed: 0.22, shellRadius: 0.0024 },
+  pistolHolsterAttack: { bulletRadius: 0.0032, bulletSpeed: 0.22, shellRadius: 0.0024 },
+  smithSidearmAttack: { bulletRadius: 0.0033, bulletSpeed: 0.23, shellRadius: 0.0024 },
+  sigsauerTacticalAttack: { bulletRadius: 0.0033, bulletSpeed: 0.23, shellRadius: 0.0025 },
+  uziSprayAttack: { bulletRadius: 0.0031, bulletSpeed: 0.24, shellRadius: 0.0023 },
+  smgBurstAttack: { bulletRadius: 0.0031, bulletSpeed: 0.24, shellRadius: 0.0023 },
+  polySmg01Attack: { bulletRadius: 0.0031, bulletSpeed: 0.24, shellRadius: 0.0023 },
+  fpsGunAttack: { bulletRadius: 0.0038, bulletSpeed: 0.27, shellRadius: 0.003 },
+  assaultRifleAttack: { bulletRadius: 0.0039, bulletSpeed: 0.27, shellRadius: 0.003 },
+  ak47VolleyAttack: { bulletRadius: 0.004, bulletSpeed: 0.27, shellRadius: 0.0031 },
+  krsvBurstAttack: { bulletRadius: 0.004, bulletSpeed: 0.27, shellRadius: 0.0031 },
+  compactCarbineAttack: { bulletRadius: 0.0039, bulletSpeed: 0.27, shellRadius: 0.003 },
+  sniperShotAttack: { bulletRadius: 0.0044, bulletSpeed: 0.3, shellRadius: 0.0033 },
+  mosinMarksmanAttack: { bulletRadius: 0.0044, bulletSpeed: 0.3, shellRadius: 0.0033 },
+  marksmanDmrAttack: { bulletRadius: 0.0041, bulletSpeed: 0.28, shellRadius: 0.0032 },
+  shotgunBlastAttack: { bulletRadius: 0.005, bulletSpeed: 0.18, shellRadius: 0.0041 },
+  polyShotgun01Attack: { bulletRadius: 0.0049, bulletSpeed: 0.18, shellRadius: 0.004 },
+  polyShotgun02Attack: { bulletRadius: 0.005, bulletSpeed: 0.18, shellRadius: 0.0041 },
+  polyShotgun03Attack: { bulletRadius: 0.005, bulletSpeed: 0.18, shellRadius: 0.0041 },
+  polySawedOff01Attack: { bulletRadius: 0.0048, bulletSpeed: 0.17, shellRadius: 0.0039 },
+  grenadeBlastAttack: { bulletRadius: 0.0062, bulletSpeed: 0.145, shellRadius: 0.0048 }
 });
 const FIREARM_HAND_ATTACH_TUNING = Object.freeze({
   default: {
@@ -804,6 +828,15 @@ const QUICK_SWAP_WEAPON_SHAPE_BY_ID = Object.freeze({
   polyShotgun03Attack: '🧨',
   polySmg01Attack: '🔫'
 });
+const FIREARM_OPEN_SOURCE_SFX_FALLBACK = Object.freeze({
+  default: 'https://cdn.pixabay.com/audio/2022/03/10/audio_c3a4a4b2f0.mp3',
+  pistol: 'https://cdn.pixabay.com/audio/2022/03/15/audio_c8c8a73467.mp3',
+  smg: 'https://cdn.pixabay.com/audio/2022/03/15/audio_12b0c7443f.mp3',
+  rifle: 'https://cdn.pixabay.com/audio/2022/03/10/audio_788f8c2f7f.mp3',
+  marksman: 'https://cdn.pixabay.com/audio/2022/10/16/audio_5ea36ec6ca.mp3',
+  shotgun: 'https://cdn.pixabay.com/audio/2022/03/09/audio_7279d2f31f.mp3',
+  explosive: 'https://cdn.pixabay.com/audio/2023/03/14/audio_64671f5f62.mp3'
+});
 
 function orientCaptureVehicleTowardBoardCenter(root, target) {
   if (!root?.isObject3D || !target?.isVector3) return;
@@ -853,7 +886,9 @@ function resolveFirearmBallisticsProfile(captureAnimationId = '') {
 function playCaptureWeaponSourceSound(captureAnimationId, { volume = 1, muted = false } = {}) {
   if (muted) return false;
   const config = CAPTURE_WEAPON_MODEL_CONFIG[captureAnimationId];
-  const sourceUrl = Array.isArray(config?.soundUrls) ? config.soundUrls.find(Boolean) : null;
+  const sourceUrlFromModel = Array.isArray(config?.soundUrls) ? config.soundUrls.find(Boolean) : null;
+  const profileKey = FIREARM_BALLISTICS_PROFILE_BY_ID[captureAnimationId] || 'default';
+  const sourceUrl = sourceUrlFromModel || FIREARM_OPEN_SOURCE_SFX_FALLBACK[profileKey] || FIREARM_OPEN_SOURCE_SFX_FALLBACK.default;
   if (!sourceUrl) return false;
   let audio = FIREARM_SOURCE_AUDIO_CACHE.get(sourceUrl);
   if (!audio) {
@@ -9922,7 +9957,12 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           }
           muzzleTarget.copy(targetPosition).add(new THREE.Vector3(0, 0.03, 0));
           const shots = FIREARM_MAGAZINE_SHOTS[resolvedCaptureAnimationId] ?? 18;
-          const ballisticsProfile = resolveFirearmBallisticsProfile(resolvedCaptureAnimationId);
+          const baseBallisticsProfile = resolveFirearmBallisticsProfile(resolvedCaptureAnimationId);
+          const caliberProfile = FIREARM_CALIBER_BY_ID[resolvedCaptureAnimationId] || {};
+          const ballisticsProfile = {
+            ...baseBallisticsProfile,
+            ...caliberProfile
+          };
           const cadenceMs = (resolvedCaptureAnimationId === 'sniperShotAttack' ? 125 : 56) * FIREARM_VOLLEY_SLOW_FACTOR;
           const volleyStart = performance.now();
           const preFireLeadMs = pickupLeadMs + reloadLeadMs + aimLeadMs;
@@ -9930,6 +9970,22 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           const muzzleFx = createCaptureMuzzleFx();
           const tracers = Array.from({ length: 10 }, () => createCaptureBulletTracerFx('#ffe39a'));
           const shells = Array.from({ length: Math.max(16, Math.min(42, shots + 6)) }, () => createCaptureShellCasingFx());
+          const bulletGeometry = new THREE.SphereGeometry(ballisticsProfile.bulletRadius, 10, 10);
+          const bulletMaterial = new THREE.MeshStandardMaterial({
+            color: '#d9dde2',
+            metalness: 0.95,
+            roughness: 0.16
+          });
+          const bullets = Array.from({ length: shots }, (_, index) => {
+            const mesh = new THREE.Mesh(bulletGeometry, bulletMaterial.clone());
+            mesh.visible = false;
+            mesh.castShadow = false;
+            mesh.receiveShadow = false;
+            mesh.userData.spawnAt = preFireLeadMs + index * cadenceMs;
+            mesh.userData.completed = false;
+            scene.add(mesh);
+            return mesh;
+          });
           const targetReticle = createCaptureTargetReticleFx();
           const shellStates = shells.map(() => ({ landed: false, settledAt: 0 }));
           scene.add(muzzleFx.root);
@@ -9970,6 +10026,15 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
               if (elapsed >= pickupLeadMs + reloadLeadMs) {
                 handWeaponAttachment.weapon.lookAt(targetLocal);
                 handWeaponAttachment.weapon.rotateY(Math.PI);
+                if (handWeaponAttachment?.muzzle?.isObject3D) {
+                  handWeaponAttachment.muzzle.updateMatrixWorld?.(true);
+                  const muzzleForward = handWeaponAttachment.muzzle.getWorldDirection(new THREE.Vector3()).normalize();
+                  const desiredForward = muzzleTarget.clone().sub(muzzleOrigin).normalize();
+                  if (muzzleForward.lengthSq() > 1e-7 && desiredForward.lengthSq() > 1e-7) {
+                    const alignQuat = new THREE.Quaternion().setFromUnitVectors(muzzleForward, desiredForward);
+                    handWeaponAttachment.weapon.quaternion.premultiply(alignQuat);
+                  }
+                }
               } else {
                 handWeaponAttachment.weapon.rotation.x += Math.sin(elapsed * 0.02) * 0.006;
               }
@@ -10041,6 +10106,52 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
               entry.root.position.copy(mid);
               entry.root.quaternion.setFromUnitVectors(MISSILE_FORWARD, dir);
             });
+            bullets.forEach((bulletMesh, idx) => {
+              const spawnAt = Number(bulletMesh.userData?.spawnAt ?? 0);
+              const life = elapsed - spawnAt;
+              if (life < 0) {
+                bulletMesh.visible = false;
+                return;
+              }
+              const shotProgress = clamp(life / Math.max(30, cadenceMs), 0, 1);
+              const start = muzzleOrigin.clone();
+              const end = muzzleTarget.clone();
+              const bulletPos = start.lerp(end, shotProgress);
+              bulletMesh.visible = shotProgress < 0.995;
+              bulletMesh.position.copy(bulletPos);
+              if (shotProgress >= 0.995) {
+                bulletMesh.userData.completed = true;
+                bulletMesh.visible = false;
+              }
+              if (idx === shots - 1 && singleShotFirearm) {
+                const aimDirNow = muzzleTarget.clone().sub(muzzleOrigin).normalize();
+                const followOffset = aimDirNow
+                  .clone()
+                  .multiplyScalar(-0.11)
+                  .add(new THREE.Vector3(0, 0.08, 0.03));
+                setCameraFocus({
+                  target: bulletPos,
+                  follow: true,
+                  priority: 10,
+                  ttl: 0,
+                  offset: Math.max(0.02, (CAMERA_TARGET_LIFT + 0.016) * CAPTURE_CAMERA_ZOOM_OUT_FACTOR),
+                  followOffset,
+                  force: true
+                });
+              }
+              if (idx === shots - 1 && !singleShotFirearm && shotProgress > 0.86) {
+                const pullback = muzzleTarget.clone().sub(muzzleOrigin).normalize().multiplyScalar(-0.12);
+                setCameraFocus({
+                  target: bulletPos,
+                  follow: true,
+                  priority: 10,
+                  ttl: 0,
+                  offset: Math.max(0.02, (CAMERA_TARGET_LIFT + 0.02) * CAPTURE_CAMERA_ZOOM_OUT_FACTOR),
+                  followOffset: new THREE.Vector3(pullback.x, 0.09, pullback.z),
+                  force: true
+                });
+              }
+            });
             shells.forEach((shell, idx) => {
               const shellState = shellStates[idx];
               const launchAt = idx * (cadenceMs * 0.7);
@@ -10107,9 +10218,11 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
               return;
             }
             if (hideTarget) hideTarget.visible = true;
-            [muzzleFx.root, targetReticle.root, ...tracers.map((entry) => entry.root), ...shells].forEach((obj) => {
+            [muzzleFx.root, targetReticle.root, ...tracers.map((entry) => entry.root), ...shells, ...bullets].forEach((obj) => {
               obj?.parent?.remove?.(obj);
             });
+            bulletGeometry.dispose();
+            bulletMaterial.dispose();
             handWeaponAttachment?.release?.();
             if (parkedEntry?.weaponHolder) parkedEntry.weaponHolder.visible = true;
             playCapture();


### PR DESCRIPTION
### Motivation
- Provide a unified weapon director for the Battle Royale capture flow in the Unity client to handle firing, bullets/shells, camera aim/follow, and progressive token damage. 
- Extend the web capture UI ballistics model to include per-caliber tuning (bullet radius, speed, shell radius) and supply open-source SFX fallbacks when model assets lack sounds.

### Description
- Add `BattleRoyaleWeaponDirector.cs` implementing weapon profiles (`WeaponBallisticsProfile`), firing routines, shell and bullet spawning (`BattleRoyaleBullet`), camera aim/follow routines, and token piece health progression (`TokenPieceHealth`).
- Expand `FIREARM_BALLISTICS_PROFILE` with `bulletRadius`, `bulletSpeed`, and `shellRadius` and add `FIREARM_CALIBER_BY_ID` to override per-weapon-caliber values.
- Add `FIREARM_OPEN_SOURCE_SFX_FALLBACK` and update `playCaptureWeaponSourceSound` to prefer model-provided sounds and fall back to profile-based open-source URLs.
- Integrate caliber data into the firing visualization path (merge base profile and caliber overrides), spawn per-shot bullet meshes with lifetime/visibility handling, improve muzzle alignment logic, update camera focus to follow bullets for final shots, and dispose generated geometries/materials after the sequence.

### Testing
- No automated tests were added or executed for the Unity changes in this PR.
- No modifications were made to existing automated webapp tests as part of this change.
- Visual/functional changes should be validated in a playtest or local webapp preview to confirm firing visuals, SFX fallbacks, and camera behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f19533d74c8329854993cbfdc3af1b)