### PR TITLE
Fix Chess Battle Royal weapon swap selection desync

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -7809,14 +7809,13 @@ function Chess3D({
   const handleCaptureAnimationSwap = useCallback(
     (optionId) => {
       if (!optionId || optionId === selectedCaptureAnimationId) return;
-      const nextIdx = quickSwapCaptureOptions.findIndex((option) => option.id === optionId);
-      if (nextIdx >= 0) {
-        setAppearance((prev) => normalizeAppearance({ ...prev, captureAnimation: nextIdx }));
-      }
+      // Keep captureAnimation pinned to index 0 because inventory reorder puts the equipped
+      // weapon at the front; storing a stale index can point at a different weapon after sync.
+      setAppearance((prev) => normalizeAppearance({ ...prev, captureAnimation: 0 }));
       setChessBattleEquippedOption('captureAnimation', optionId, resolvedAccountId);
       setWeaponSwapOpen(false);
     },
-    [quickSwapCaptureOptions, resolvedAccountId, selectedCaptureAnimationId]
+    [resolvedAccountId, selectedCaptureAnimationId]
   );
   useEffect(() => {
     const handler = (event) => {


### PR DESCRIPTION
### Motivation
- Prevent quick-swap selection from becoming incorrect after inventory reorder moves the equipped weapon to the front.

### Description
- Update `handleCaptureAnimationSwap` in `webapp/src/pages/Games/ChessBattleRoyal.jsx` to pin `appearance.captureAnimation` to `0` instead of storing a computed index, and remove the now-unused `quickSwapCaptureOptions` dependency from the callback.

### Testing
- No automated tests were run for this small UI logic change; the fix was validated via code inspection and a local commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1a85dbfa88329ad3ca19c44248b55)