### PR TITLE
Sync Chess Battle Royal quick-weapon selection with equipped inventory

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -7761,10 +7761,16 @@ function Chess3D({
     return [...firearm, ...other];
   }, [ownedCaptureAnimations]);
   const selectedCaptureAnimationId = useMemo(() => {
+    const equippedId = Array.isArray(chessInventory?.captureAnimation)
+      ? chessInventory.captureAnimation.find((optionId) =>
+          quickSwapCaptureOptions.some((option) => option.id === optionId)
+        )
+      : null;
+    if (equippedId) return equippedId;
     const selectedFromAppearance = quickSwapCaptureOptions[appearance.captureAnimation]?.id;
     if (selectedFromAppearance) return selectedFromAppearance;
     return quickSwapCaptureOptions[0]?.id || CAPTURE_ANIMATION_OPTIONS[0]?.id || 'missileJavelin';
-  }, [appearance.captureAnimation, quickSwapCaptureOptions]);
+  }, [appearance.captureAnimation, chessInventory, quickSwapCaptureOptions]);
   const randomCaptureAnimationId = useCallback((sourceOptions = CAPTURE_ANIMATION_OPTIONS) => {
     const list = Array.isArray(sourceOptions) ? sourceOptions.filter(Boolean) : [];
     if (!list.length) return CAPTURE_ANIMATION_OPTIONS[0]?.id || 'missileJavelin';
@@ -7806,6 +7812,12 @@ function Chess3D({
     aiCaptureAnimationIdRef.current = randomCaptureAnimationId(ownedCaptureAnimations);
   }, [ownedCaptureAnimations, randomCaptureAnimationId]);
   const [weaponSwapOpen, setWeaponSwapOpen] = useState(false);
+  useEffect(() => {
+    const selectedIdx = quickSwapCaptureOptions.findIndex((option) => option.id === selectedCaptureAnimationId);
+    if (selectedIdx < 0) return;
+    if (appearance.captureAnimation === selectedIdx) return;
+    setAppearance((prev) => normalizeAppearance({ ...prev, captureAnimation: selectedIdx }));
+  }, [appearance.captureAnimation, quickSwapCaptureOptions, selectedCaptureAnimationId]);
   const handleCaptureAnimationSwap = useCallback(
     (optionId) => {
       if (!optionId || optionId === selectedCaptureAnimationId) return;


### PR DESCRIPTION
### Motivation
- Players reported weapons not showing or not switching in Chess Battle Royal when the quick-swap list was filtered or reordered, caused by the UI relying only on a numeric `appearance.captureAnimation` index that could drift from the actual equipped item.

### Description
- Prefer the equipped capture animation stored in inventory when resolving the active weapon by reading `chessInventory.captureAnimation` in `selectedCaptureAnimationId` in `webapp/src/pages/Games/ChessBattleRoyal.jsx`.
- Add an effect that keeps `appearance.captureAnimation` synchronized to the index of the resolved/equipped quick-swap option so the UI index and equipped item remain consistent.
- Include `chessInventory` in the `useMemo` dependencies for selection resolution; no changes to inventory schema or backend contracts.

### Testing
- Ran: `npm test -- --runInBand test/chessBattleInventoryConfig.test.js`; result: failed due to a pre-existing unrelated assertion about LT table finishes in `test/chessBattleInventoryConfig.test.js` and not introduced by this change.
- No other automated tests were modified; the change is scoped to `webapp/src/pages/Games/ChessBattleRoyal.jsx` and restores consistent quick-swap visibility/selection behavior in the UI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1a85dbfa88329ad3ca19c44248b55)