### PR TITLE
Expose full Ludo weapon roster in Snake & Ladder and centralize capture weapon config

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -23,6 +23,7 @@ import {
   DEFAULT_TABLE_CUSTOMIZATION
 } from '../utils/tableCustomizationOptions.js';
 import { applyRendererSRGB, applySRGBColorSpace } from '../utils/colorSpace.js';
+import { LUDO_CAPTURE_ATTACK_TUNING_BY_WEAPON, normalizeSnakeCaptureWeaponKind } from '../config/snakeCaptureWeapons.js';
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
 const clamp01 = (v) => clamp(v, 0, 1);
 
@@ -555,65 +556,6 @@ const CAPTURE_CENTER_STAGE_LIFT = TOKEN_HEIGHT * 7.6;
 const CAPTURE_RETURN_MS = 620;
 const CAPTURE_VERTICAL_STRIKE_LIFT = TOKEN_HEIGHT * 8.8;
 const CAPTURE_MULTI_SHOT_COUNT = 2;
-// Keep Snake & Ladder capture tuning aligned with Ludo Battle Royale flight behaviour,
-// while staying isolated in this file so changes here never alter other games.
-const LUDO_CAPTURE_ATTACK_TUNING_BY_WEAPON = Object.freeze({
-  fighter: Object.freeze({ speed: 0.92, height: 0.92, inward: 0.94, takeoff: 0.22, landing: 0.26 }),
-  helicopter: Object.freeze({ speed: 0.94, height: 0.92, inward: 0.94, takeoff: 0.22, landing: 0.26 }),
-  drone: Object.freeze({ speed: 0.86, height: 0.92, inward: 0.94, takeoff: 0.22, landing: 0.26 }),
-  // Pawn javelin and support-truck rockets intentionally match drone speed/altitude profile.
-  javelin: Object.freeze({ speed: 0.86, height: 0.92, inward: 0.94, takeoff: 0.22, landing: 0.26 }),
-  supportTruck: Object.freeze({ speed: 0.86, height: 0.92, inward: 0.94, takeoff: 0.22, landing: 0.26 })
-});
-const WEAPON_PARKED_PITCH_BY_KIND = Object.freeze({
-  fighter: 0,
-  helicopter: 0,
-  drone: 0,
-  supportTruck: 0,
-  javelin: 0
-});
-const WEAPON_PARKED_ROLL_BY_KIND = Object.freeze({
-  fighter: 0,
-  helicopter: 0,
-  drone: 0,
-  supportTruck: 0,
-  javelin: 0
-});
-const SNAKE_CAPTURE_WEAPON_KIND_MAP = Object.freeze({
-  missileJavelin: 'javelin',
-  droneAttack: 'drone',
-  fighterJetAttack: 'fighter',
-  helicopterAttack: 'helicopter',
-  fpsGunAttack: 'supportTruck',
-  glockSidearmAttack: 'supportTruck',
-  assaultRifleAttack: 'supportTruck',
-  uziSprayAttack: 'supportTruck',
-  ak47VolleyAttack: 'supportTruck',
-  krsvBurstAttack: 'supportTruck',
-  smithSidearmAttack: 'supportTruck',
-  mosinMarksmanAttack: 'supportTruck',
-  sigsauerTacticalAttack: 'supportTruck',
-  grenadeBlastAttack: 'supportTruck',
-  shotgunBlastAttack: 'supportTruck',
-  sniperShotAttack: 'supportTruck',
-  smgBurstAttack: 'supportTruck',
-  compactCarbineAttack: 'supportTruck',
-  marksmanDmrAttack: 'supportTruck',
-  polyShotgun01Attack: 'supportTruck',
-  polyAssaultRifle01Attack: 'supportTruck',
-  polyPistol01Attack: 'supportTruck',
-  polyRevolver01Attack: 'supportTruck',
-  polySawedOff01Attack: 'supportTruck',
-  polyRevolver02Attack: 'supportTruck',
-  polyShotgun02Attack: 'supportTruck',
-  polyShotgun03Attack: 'supportTruck',
-  polySmg01Attack: 'supportTruck'
-});
-
-function normalizeSnakeCaptureWeaponKind(weaponType = 'fighter') {
-  return SNAKE_CAPTURE_WEAPON_KIND_MAP[weaponType] || weaponType || 'fighter';
-}
-
 function pullPointTowardCenter(point, amount = TILE_EDGE_INSET) {
   if (!point) return point;
   const planar = new THREE.Vector3(point.x, 0, point.z);

--- a/webapp/src/config/snakeCaptureWeapons.js
+++ b/webapp/src/config/snakeCaptureWeapons.js
@@ -1,0 +1,53 @@
+import { CAPTURE_ANIMATION_OPTIONS } from './ludoBattleOptions.js';
+
+export const SNAKE_CAPTURE_WEAPON_OPTIONS = Object.freeze(
+  CAPTURE_ANIMATION_OPTIONS.map((option) => ({
+    id: option.id,
+    label: option.label,
+    thumbnail: option.thumbnail
+  }))
+);
+
+export const SNAKE_CAPTURE_WEAPON_KIND_MAP = Object.freeze({
+  missileJavelin: 'javelin',
+  droneAttack: 'drone',
+  fighterJetAttack: 'fighter',
+  helicopterAttack: 'helicopter',
+  fpsGunAttack: 'supportTruck',
+  glockSidearmAttack: 'supportTruck',
+  pistolSidearmAttack: 'supportTruck',
+  assaultRifleAttack: 'supportTruck',
+  uziSprayAttack: 'supportTruck',
+  ak47VolleyAttack: 'supportTruck',
+  krsvBurstAttack: 'supportTruck',
+  smithSidearmAttack: 'supportTruck',
+  mosinMarksmanAttack: 'supportTruck',
+  sigsauerTacticalAttack: 'supportTruck',
+  grenadeBlastAttack: 'supportTruck',
+  shotgunBlastAttack: 'supportTruck',
+  sniperShotAttack: 'supportTruck',
+  smgBurstAttack: 'supportTruck',
+  compactCarbineAttack: 'supportTruck',
+  marksmanDmrAttack: 'supportTruck',
+  polyShotgun01Attack: 'supportTruck',
+  polyAssaultRifle01Attack: 'supportTruck',
+  polyPistol01Attack: 'supportTruck',
+  polyRevolver01Attack: 'supportTruck',
+  polySawedOff01Attack: 'supportTruck',
+  polyRevolver02Attack: 'supportTruck',
+  polyShotgun02Attack: 'supportTruck',
+  polyShotgun03Attack: 'supportTruck',
+  polySmg01Attack: 'supportTruck'
+});
+
+export const LUDO_CAPTURE_ATTACK_TUNING_BY_WEAPON = Object.freeze({
+  fighter: Object.freeze({ speed: 0.92, height: 0.92, inward: 0.94, takeoff: 0.22, landing: 0.26 }),
+  helicopter: Object.freeze({ speed: 0.94, height: 0.92, inward: 0.94, takeoff: 0.22, landing: 0.26 }),
+  drone: Object.freeze({ speed: 0.86, height: 0.92, inward: 0.94, takeoff: 0.22, landing: 0.26 }),
+  javelin: Object.freeze({ speed: 0.86, height: 0.92, inward: 0.94, takeoff: 0.22, landing: 0.26 }),
+  supportTruck: Object.freeze({ speed: 0.86, height: 0.92, inward: 0.94, takeoff: 0.22, landing: 0.26 })
+});
+
+export function normalizeSnakeCaptureWeaponKind(weaponType = 'fighter') {
+  return SNAKE_CAPTURE_WEAPON_KIND_MAP[weaponType] || weaponType || 'fighter';
+}

--- a/webapp/src/config/snakeInventoryConfig.js
+++ b/webapp/src/config/snakeInventoryConfig.js
@@ -1,7 +1,7 @@
 import { POOL_ROYALE_DEFAULT_HDRI_ID, POOL_ROYALE_HDRI_VARIANTS } from './poolRoyaleInventoryConfig.js';
 import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from './murlanThemes.js';
 import { polyHavenThumb, swatchThumbnail } from './storeThumbnails.js';
-import { CAPTURE_ANIMATION_OPTIONS } from './ludoBattleOptions.js';
+import { SNAKE_CAPTURE_WEAPON_OPTIONS } from './snakeCaptureWeapons.js';
 
 const mapLabels = (options) =>
   Object.freeze(
@@ -27,13 +27,6 @@ const SNAKE_TOKEN_SHAPE_OPTIONS = Object.freeze([
   { id: 'queen', label: 'Queen Token' },
   { id: 'king', label: 'King Token' }
 ]);
-const SNAKE_CAPTURE_WEAPON_OPTIONS = Object.freeze(
-  CAPTURE_ANIMATION_OPTIONS.map((option) => ({
-    id: option.id,
-    label: option.label,
-    thumbnail: option.thumbnail
-  }))
-);
 
 export const SNAKE_PAWN_HEAD_OPTIONS = Object.freeze([
   { id: 'current', label: 'Current' },

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -36,7 +36,7 @@ import {
   SNAKE_PAWN_HEAD_OPTIONS,
   SNAKE_TOKEN_COLOR_OPTIONS
 } from "../../config/snakeInventoryConfig.js";
-import { CAPTURE_ANIMATION_OPTIONS } from "../../config/ludoBattleOptions.js";
+import { SNAKE_CAPTURE_WEAPON_OPTIONS } from "../../config/snakeCaptureWeapons.js";
 // Developer accounts that receive shares of each pot
 const DEV_ACCOUNT = import.meta.env.VITE_DEV_ACCOUNT_ID;
 const DEV_ACCOUNT_1 = import.meta.env.VITE_DEV_ACCOUNT_ID_1;
@@ -814,13 +814,7 @@ const TOKEN_SHAPE_OPTIONS = Object.freeze([
   { id: 'queen', label: 'Queen', pieceType: 'queen', source: 'ludoBattleRoyal' },
   { id: 'king', label: 'King', pieceType: 'king', source: 'ludoBattleRoyal' }
 ]);
-const CAPTURE_WEAPON_OPTIONS = Object.freeze(
-  CAPTURE_ANIMATION_OPTIONS.map((option) => ({
-    id: option.id,
-    label: option.label,
-    thumbnail: option.thumbnail
-  }))
-);
+const CAPTURE_WEAPON_OPTIONS = SNAKE_CAPTURE_WEAPON_OPTIONS;
 const LEGACY_CAPTURE_WEAPON_ID_MAP = Object.freeze({
   drone: 'droneAttack',
   fighter: 'fighterJetAttack',
@@ -3267,15 +3261,7 @@ export default function SnakeAndLadder() {
     resolvedAppearance?.captureWeapon?.id
       ? normalizeCaptureWeaponId(resolvedAppearance.captureWeapon.id)
       : fallbackCaptureWeaponId(0);
-  const ownedCaptureWeapons = useMemo(
-    () =>
-      CAPTURE_WEAPON_OPTIONS.filter((option) =>
-        isSnakeOptionUnlocked('captureWeapon', option.id, snakeInventory)
-      ),
-    [snakeInventory]
-  );
-  const selectableCaptureWeapons =
-    ownedCaptureWeapons.length > 0 ? ownedCaptureWeapons : [CAPTURE_WEAPON_OPTIONS[0]].filter(Boolean);
+  const selectableCaptureWeapons = CAPTURE_WEAPON_OPTIONS;
   const computedIndex = isMultiplayer
     ? mpPlayers.findIndex((p) => p.id === accountId)
     : 0;


### PR DESCRIPTION
### Motivation
- Unify Snake & Ladder capture weapons and animation tuning with the Ludo Battle Royal roster so players can swap to the full weapon set (not just the vehicle subset). 
- Reduce duplication by centralizing weapon-kind normalization and per-weapon capture tuning so animation behavior is shared and easier to maintain. 

### Description
- Added a shared config module `webapp/src/config/snakeCaptureWeapons.js` that re-exports the full weapon roster as `SNAKE_CAPTURE_WEAPON_OPTIONS`, provides `SNAKE_CAPTURE_WEAPON_KIND_MAP`, `LUDO_CAPTURE_ATTACK_TUNING_BY_WEAPON`, and `normalizeSnakeCaptureWeaponKind` for shared use. 
- Updated `webapp/src/pages/Games/SnakeAndLadder.jsx` to import `SNAKE_CAPTURE_WEAPON_OPTIONS` and switch the quick-weapon swap UI to expose the full roster (`selectableCaptureWeapons = CAPTURE_WEAPON_OPTIONS`) instead of filtering to unlocked inventory only. 
- Updated `webapp/src/config/snakeInventoryConfig.js` to source weapon store entries from the shared `SNAKE_CAPTURE_WEAPON_OPTIONS` so thumbnails/labels remain consistent with the game picker. 
- Updated `webapp/src/components/SnakeBoard3D.jsx` to import the shared tuning and normalization (`LUDO_CAPTURE_ATTACK_TUNING_BY_WEAPON`, `normalizeSnakeCaptureWeaponKind`) and removed the duplicated local weapon-kind map and tuning constants so Snake animation logic uses the shared values. 

### Testing
- Ran `npm test -- --runInBand test/snakeApi.test.js` locally; the test run completed but a test failed (`turnChanged should indicate player 2`) which appears unrelated to these UI and config changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1aa0b25b483298cb94138a4a8f28f)