### PR TITLE
Bias human grip toward cue root in PoolHumanPoseDriver

### DIFF
--- a/Assets/Scripts/Gameplay/PoolHumanPoseDriver.cs
+++ b/Assets/Scripts/Gameplay/PoolHumanPoseDriver.cs
@@ -546,7 +546,7 @@ namespace Aiming
 
                     Vector3 tipBasedGrip = cueTipPos - (cueDir * gripFromTip);
                     Vector3 rootBasedGrip = cueRootPos + (cueDir * gripFromRoot);
-                    Vector3 grip = Vector3.Lerp(rootBasedGrip, tipBasedGrip, 0.75f);
+                    Vector3 grip = Vector3.Lerp(rootBasedGrip, tipBasedGrip, 0.35f);
                     grip += (cueDir * -handPull);
 
                     float alongFromBridge = Vector3.Dot(grip - bridgeHandTarget, cueDir);


### PR DESCRIPTION
### Motivation
- Move the human character's right-hand grip farther back along the cue (closer to the middle/back butt) while preserving the aiming direction.

### Description
- Changed the grip blend in `ResolveRightHandGripTarget` in `Assets/Scripts/Gameplay/PoolHumanPoseDriver.cs` from `0.75f` to `0.35f` so the computed grip is more root-weighted and places the character further back on the cue.

### Testing
- No automated tests were run; this is an isolated one-line adjustment committed to the repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1d0cc675c8329aa1691c48eb49b2d)