### PR TITLE
chess: align weapon quick-switch panel with 18-weapon set

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -205,6 +205,26 @@ const GLOBAL_CAPTURE_KIND_BY_ANIMATION_ID = Object.freeze({
 const FIREARM_CAPTURE_ANIMATION_IDS = new Set(
   CAPTURE_ANIMATION_OPTIONS.map((option) => option.id).filter((id) => !GLOBAL_CAPTURE_KIND_BY_ANIMATION_ID[id])
 );
+const CHESS_WEAPON_PANEL_ORDER = Object.freeze([
+  'polyShotgun01Attack',
+  'polyAssaultRifle01Attack',
+  'polyPistol01Attack',
+  'polyRevolver01Attack',
+  'polySawedOff01Attack',
+  'polyRevolver02Attack',
+  'polyShotgun02Attack',
+  'polyShotgun03Attack',
+  'polySmg01Attack',
+  'ak47VolleyAttack',
+  'krsvBurstAttack',
+  'smithSidearmAttack',
+  'mosinMarksmanAttack',
+  'uziSprayAttack',
+  'sigsauerTacticalAttack',
+  'sniperShotAttack',
+  'fpsGunAttack',
+  'marksmanDmrAttack'
+]);
 const VEHICLE_CAPTURE_KINDS = new Set(['truck', 'drone', 'jet', 'helicopter']);
 const FIREARM_CAPTURE_KIND = 'firearm';
 
@@ -7752,6 +7772,9 @@ function Chess3D({
     return CAPTURE_ANIMATION_OPTIONS[0] ? [CAPTURE_ANIMATION_OPTIONS[0]] : [];
   }, [chessInventory]);
   const quickSwapCaptureOptions = useMemo(() => {
+    const byId = new Map(ownedCaptureAnimations.map((option) => [option.id, option]));
+    const ordered = CHESS_WEAPON_PANEL_ORDER.map((id) => byId.get(id)).filter(Boolean);
+    if (ordered.length) return ordered;
     const firearm = [];
     const other = [];
     ownedCaptureAnimations.forEach((option) => {
@@ -7811,7 +7834,7 @@ function Chess3D({
   useEffect(() => {
     aiCaptureAnimationIdRef.current = randomCaptureAnimationId(ownedCaptureAnimations);
   }, [ownedCaptureAnimations, randomCaptureAnimationId]);
-  const [weaponSwapOpen, setWeaponSwapOpen] = useState(false);
+  const [weaponSwapOpen, setWeaponSwapOpen] = useState(true);
   useEffect(() => {
     const selectedIdx = quickSwapCaptureOptions.findIndex((option) => option.id === selectedCaptureAnimationId);
     if (selectedIdx < 0) return;
@@ -14164,7 +14187,7 @@ function Chess3D({
             {weaponSwapOpen && (
               <div className="max-h-[52vh] w-[14rem] overflow-y-auto rounded-2xl border border-white/20 bg-[#060a14]/95 p-2 text-xs shadow-2xl backdrop-blur">
                 <p className="px-2 pb-2 text-[10px] uppercase tracking-[0.3em] text-sky-200/80">
-                  Quick Weapon Swap
+                  Board-side Weapon Switch
                 </p>
                 <div className="space-y-2">
                   {quickSwapCaptureOptions.map((option) => {


### PR DESCRIPTION
### Motivation
- Surface and prioritize the full 18-weapon lineup (9 Quaternius + 9 extra firearm options) so players can immediately see and switch capture/weapon animations from the board side.
- Preserve existing fallback grouping and inventory-driven behavior while making the intended weapon order and visibility explicit in the UI.

### Description
- Added a `CHESS_WEAPON_PANEL_ORDER` constant listing the 18 weapon animation IDs to represent the requested panel order in `ChessBattleRoyal.jsx`.
- Updated `quickSwapCaptureOptions` derivation to prefer owned options in the `CHESS_WEAPON_PANEL_ORDER` sequence, falling back to the previous firearm/other grouping when no ordered matches exist.
- Changed the side-panel weapon control default to open by default via `useState(true)` so the weapon switcher is visible on board load.
- Replaced the panel heading text from “Quick Weapon Swap” to `Board-side Weapon Switch` for clearer UX intent.

### Testing
- Built the webapp with `npm -C webapp run -s build` and the Vite production build completed successfully with non-blocking warnings reported.
- Ran the single test `npm -C webapp run -s test -- test/chessBattleInventoryConfig.test.js`, which exited with code 1 and produced no output in this environment (test run failed here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1e210de948329ac06ca04f20981e0)