### PR TITLE
chess: add CHESS_CAPTURE_ANIMATION_OPTIONS and wire Chess to use it

### DIFF
--- a/webapp/src/config/chessBattleInventoryConfig.js
+++ b/webapp/src/config/chessBattleInventoryConfig.js
@@ -1,5 +1,5 @@
 import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from './murlanThemes.js';
-import { CAPTURE_ANIMATION_OPTIONS } from './ludoBattleOptions.js';
+import { CAPTURE_ANIMATION_OPTIONS as LUDO_CAPTURE_ANIMATION_OPTIONS } from './ludoBattleOptions.js';
 import { MURLAN_TABLE_FINISHES } from './murlanTableFinishes.js';
 import {
   POOL_ROYALE_DEFAULT_HDRI_ID,
@@ -197,6 +197,10 @@ export const CHESS_HUMAN_CHARACTER_OPTIONS = Object.freeze([
   }
 ]);
 
+
+export const CHESS_CAPTURE_ANIMATION_OPTIONS = Object.freeze(
+  LUDO_CAPTURE_ANIMATION_OPTIONS.map((option) => ({ ...option }))
+);
 const CHESS_STORE_HUMAN_CHARACTER_IDS = Object.freeze([
   'webgl-vietnam-human',
   'webgl-human-body-a',
@@ -380,7 +384,7 @@ export const CHESS_BATTLE_DEFAULT_UNLOCKS = Object.freeze({
   headStyle: ['current'],
   humanCharacter: [CHESS_HUMAN_CHARACTER_OPTIONS[0]?.id],
   environmentHdri: [DEFAULT_HDRI_ID],
-  captureAnimation: [CAPTURE_ANIMATION_OPTIONS[0]?.id]
+  captureAnimation: [CHESS_CAPTURE_ANIMATION_OPTIONS[0]?.id]
 });
 
 export const CHESS_BATTLE_OPTION_LABELS = Object.freeze({
@@ -446,7 +450,7 @@ export const CHESS_BATTLE_OPTION_LABELS = Object.freeze({
     }, {})
   ),
   captureAnimation: Object.freeze(
-    CAPTURE_ANIMATION_OPTIONS.reduce((acc, option) => {
+    CHESS_CAPTURE_ANIMATION_OPTIONS.reduce((acc, option) => {
       acc[option.id] = option.label;
       return acc;
     }, {})
@@ -492,7 +496,7 @@ export const CHESS_BATTLE_OPTION_THUMBNAILS = Object.freeze({
     }, {})
   ),
   captureAnimation: Object.freeze(
-    CAPTURE_ANIMATION_OPTIONS.reduce((acc, option) => {
+    CHESS_CAPTURE_ANIMATION_OPTIONS.reduce((acc, option) => {
       acc[option.id] = option.thumbnail;
       return acc;
     }, {})
@@ -722,7 +726,7 @@ export const CHESS_BATTLE_STORE_ITEMS = [
     description: 'Unlocks an additional pawn head glass preset.',
     thumbnail: CHESS_BATTLE_OPTION_THUMBNAILS.headStyle.headGold
   },
-  ...CAPTURE_ANIMATION_OPTIONS.slice(1).map((option, idx) => ({
+  ...CHESS_CAPTURE_ANIMATION_OPTIONS.slice(1).map((option, idx) => ({
     id: `chess-capture-animation-${option.id}`,
     type: 'captureAnimation',
     optionId: option.id,
@@ -781,8 +785,8 @@ export const CHESS_BATTLE_DEFAULT_LOADOUT = [
   },
   {
     type: 'captureAnimation',
-    optionId: CAPTURE_ANIMATION_OPTIONS[0]?.id,
-    label: CAPTURE_ANIMATION_OPTIONS[0]?.label
+    optionId: CHESS_CAPTURE_ANIMATION_OPTIONS[0]?.id,
+    label: CHESS_CAPTURE_ANIMATION_OPTIONS[0]?.label
   }
 ];
 

--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -49,7 +49,8 @@ import {
   CHESS_BATTLE_TABLE_OPTIONS,
   CHESS_BATTLE_OPTION_THUMBNAILS,
   CHESS_TABLE_FINISH_OPTIONS,
-  CHESS_HUMAN_CHARACTER_OPTIONS
+  CHESS_HUMAN_CHARACTER_OPTIONS,
+  CHESS_CAPTURE_ANIMATION_OPTIONS
 } from '../../config/chessBattleInventoryConfig.js';
 import {
   chessBattleAccountId,
@@ -68,7 +69,6 @@ import InfoPopup from '../../components/InfoPopup.jsx';
 import QuickMessagePopup from '../../components/QuickMessagePopup.jsx';
 import { socket } from '../../utils/socket.js';
 import { giftSounds } from '../../utils/giftSounds.js';
-import { CAPTURE_ANIMATION_OPTIONS } from '../../config/ludoBattleOptions.js';
 
 /**
  * CHESS 3D — Procedural, Modern Look (no external models)
@@ -203,7 +203,7 @@ const GLOBAL_CAPTURE_KIND_BY_ANIMATION_ID = Object.freeze({
   helicopterAttack: 'helicopter'
 });
 const FIREARM_CAPTURE_ANIMATION_IDS = new Set(
-  CAPTURE_ANIMATION_OPTIONS.map((option) => option.id).filter((id) => !GLOBAL_CAPTURE_KIND_BY_ANIMATION_ID[id])
+  CHESS_CAPTURE_ANIMATION_OPTIONS.map((option) => option.id).filter((id) => !GLOBAL_CAPTURE_KIND_BY_ANIMATION_ID[id])
 );
 const CHESS_WEAPON_PANEL_ORDER = Object.freeze([
   'polyShotgun01Attack',
@@ -2759,7 +2759,7 @@ function normalizeAppearance(value = {}) {
     ['tableCloth', TABLE_CLOTH_OPTIONS.length],
     ['tableFinish', TABLE_FINISH_OPTIONS.length],
     ['chairColor', CHAIR_COLOR_OPTIONS.length],
-    ['captureAnimation', CAPTURE_ANIMATION_OPTIONS.length],
+    ['captureAnimation', CHESS_CAPTURE_ANIMATION_OPTIONS.length],
     ['humanCharacter', HUMAN_CHARACTER_OPTIONS.length],
     ['environmentHdri', CHESS_HDRI_OPTIONS.length]
   ];
@@ -7766,10 +7766,10 @@ function Chess3D({
     const ownedIds = Array.isArray(chessInventory?.captureAnimation) ? chessInventory.captureAnimation : [];
     const uniqueIds = Array.from(new Set(ownedIds.filter(Boolean)));
     const ownedOptions = uniqueIds
-      .map((optionId) => CAPTURE_ANIMATION_OPTIONS.find((option) => option.id === optionId))
+      .map((optionId) => CHESS_CAPTURE_ANIMATION_OPTIONS.find((option) => option.id === optionId))
       .filter(Boolean);
     if (ownedOptions.length > 0) return ownedOptions;
-    return CAPTURE_ANIMATION_OPTIONS[0] ? [CAPTURE_ANIMATION_OPTIONS[0]] : [];
+    return CHESS_CAPTURE_ANIMATION_OPTIONS[0] ? [CHESS_CAPTURE_ANIMATION_OPTIONS[0]] : [];
   }, [chessInventory]);
   const quickSwapCaptureOptions = useMemo(() => {
     const byId = new Map(ownedCaptureAnimations.map((option) => [option.id, option]));
@@ -7792,12 +7792,12 @@ function Chess3D({
     if (equippedId) return equippedId;
     const selectedFromAppearance = quickSwapCaptureOptions[appearance.captureAnimation]?.id;
     if (selectedFromAppearance) return selectedFromAppearance;
-    return quickSwapCaptureOptions[0]?.id || CAPTURE_ANIMATION_OPTIONS[0]?.id || 'missileJavelin';
+    return quickSwapCaptureOptions[0]?.id || CHESS_CAPTURE_ANIMATION_OPTIONS[0]?.id || 'missileJavelin';
   }, [appearance.captureAnimation, chessInventory, quickSwapCaptureOptions]);
-  const randomCaptureAnimationId = useCallback((sourceOptions = CAPTURE_ANIMATION_OPTIONS) => {
+  const randomCaptureAnimationId = useCallback((sourceOptions = CHESS_CAPTURE_ANIMATION_OPTIONS) => {
     const list = Array.isArray(sourceOptions) ? sourceOptions.filter(Boolean) : [];
-    if (!list.length) return CAPTURE_ANIMATION_OPTIONS[0]?.id || 'missileJavelin';
-    return list[Math.floor(Math.random() * list.length)]?.id || CAPTURE_ANIMATION_OPTIONS[0]?.id || 'missileJavelin';
+    if (!list.length) return CHESS_CAPTURE_ANIMATION_OPTIONS[0]?.id || 'missileJavelin';
+    return list[Math.floor(Math.random() * list.length)]?.id || CHESS_CAPTURE_ANIMATION_OPTIONS[0]?.id || 'missileJavelin';
   }, []);
   const aiCaptureAnimationIdRef = useRef(randomCaptureAnimationId());
   const selectedCaptureKind = useMemo(() => {
@@ -12120,7 +12120,7 @@ function Chess3D({
         });
 
         const firearmDisplay = createParkedFirearmDisplay(
-          CAPTURE_ANIMATION_OPTIONS.find((option) => option.id === selectedCaptureAnimationId)?.label || 'Weapon'
+          CHESS_CAPTURE_ANIMATION_OPTIONS.find((option) => option.id === selectedCaptureAnimationId)?.label || 'Weapon'
         );
         firearmDisplay.root.scale.setScalar(
           CAPTURE_HELICOPTER_SCALE * 1.15 * SIDE_PARKED_AIRCRAFT_SCALE_MULTIPLIER * 0.44


### PR DESCRIPTION
### Motivation
- Isolate Chess Battle Royal weapon/capture options so Chess has its own option surface instead of directly sharing the Ludo constant. 
- Keep the same option set and fallback behavior while ensuring store/inventory code paths belong to Chess.
- Make downstream game code (quick-swap, defaults, labels, thumbnails, parked displays) read from a Chess-owned constant to satisfy per-game ownership requirements.

### Description
- Added `CHESS_CAPTURE_ANIMATION_OPTIONS` in `webapp/src/config/chessBattleInventoryConfig.js` which clones the Ludo options with `LUDO_CAPTURE_ANIMATION_OPTIONS.map((option) => ({ ...option }))` so Chess owns its list. 
- Replaced direct uses of the Ludo constant with `CHESS_CAPTURE_ANIMATION_OPTIONS` across the Chess config (defaults, labels, thumbnails, store item generation and loadout) in `webapp/src/config/chessBattleInventoryConfig.js`. 
- Updated `webapp/src/pages/Games/ChessBattleRoyal.jsx` to import and use `CHESS_CAPTURE_ANIMATION_OPTIONS` everywhere capture/weapon lists, selection, and parked-weapon labels are resolved (quick-swap, owned options, random selection, parked display label, firearm sets).

### Testing
- Ran the targeted Jest test: `npm test -- --runInBand test/chessBattleInventoryConfig.test.js` to validate the config wiring. 
- Result: the suite executed; 3 tests passed and 1 pre-existing unrelated assertion failed (`includes LT table finishes in both options and store purchasables`), indicating the refactor fixed the capture-option symbol issues but revealed an existing expectation mismatch unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1f0be14a48329ac28101ba2a61231)