### PR TITLE
Add firearm-specific seated aim poses and player capture animation resolution

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -5697,7 +5697,64 @@ function applySeatedHumanPose(
   let headY = 0;
   const bodyLockedMode = mode !== 'idle';
 
-  if (mode === 'reachDice') {
+  if (mode === 'firearmAim') {
+    shoulderX = THREE.MathUtils.lerp(shoulderX, -0.96, t);
+    shoulderY = THREE.MathUtils.lerp(shoulderY, -0.09, t);
+    shoulderZ = THREE.MathUtils.lerp(shoulderZ, -1.02, t);
+    forearmX = THREE.MathUtils.lerp(forearmX, -0.22, t);
+    forearmY = THREE.MathUtils.lerp(forearmY, -0.06, t);
+    forearmZ = THREE.MathUtils.lerp(forearmZ, 0.1, t);
+    wristX = THREE.MathUtils.lerp(wristX, 0.1, t);
+    wristY = THREE.MathUtils.lerp(wristY, -0.05, t);
+    wristZ = THREE.MathUtils.lerp(wristZ, -0.18, t);
+    chestX = THREE.MathUtils.lerp(chestX, 0.2, t);
+    headX = THREE.MathUtils.lerp(headX, -0.14, t);
+
+  } else if (mode === 'firearmAimPistol') {
+    shoulderX = THREE.MathUtils.lerp(shoulderX, -0.94, t);
+    shoulderY = THREE.MathUtils.lerp(shoulderY, -0.04, t);
+    shoulderZ = THREE.MathUtils.lerp(shoulderZ, -0.96, t);
+    forearmX = THREE.MathUtils.lerp(forearmX, -0.18, t);
+    forearmY = THREE.MathUtils.lerp(forearmY, -0.04, t);
+    forearmZ = THREE.MathUtils.lerp(forearmZ, 0.07, t);
+    wristX = THREE.MathUtils.lerp(wristX, 0.06, t);
+    wristY = THREE.MathUtils.lerp(wristY, -0.03, t);
+    wristZ = THREE.MathUtils.lerp(wristZ, -0.12, t);
+  } else if (mode === 'firearmAimSmg') {
+    shoulderX = THREE.MathUtils.lerp(shoulderX, -0.98, t);
+    shoulderY = THREE.MathUtils.lerp(shoulderY, -0.1, t);
+    shoulderZ = THREE.MathUtils.lerp(shoulderZ, -1.06, t);
+    forearmX = THREE.MathUtils.lerp(forearmX, -0.26, t);
+    forearmY = THREE.MathUtils.lerp(forearmY, -0.08, t);
+    forearmZ = THREE.MathUtils.lerp(forearmZ, 0.12, t);
+    wristX = THREE.MathUtils.lerp(wristX, 0.12, t);
+    wristY = THREE.MathUtils.lerp(wristY, -0.06, t);
+    wristZ = THREE.MathUtils.lerp(wristZ, -0.2, t);
+  } else if (mode === 'firearmAimRifle') {
+    shoulderX = THREE.MathUtils.lerp(shoulderX, -1.02, t);
+    shoulderY = THREE.MathUtils.lerp(shoulderY, -0.11, t);
+    shoulderZ = THREE.MathUtils.lerp(shoulderZ, -1.12, t);
+    forearmX = THREE.MathUtils.lerp(forearmX, -0.28, t);
+    forearmY = THREE.MathUtils.lerp(forearmY, -0.07, t);
+    forearmZ = THREE.MathUtils.lerp(forearmZ, 0.14, t);
+    wristX = THREE.MathUtils.lerp(wristX, 0.14, t);
+    wristY = THREE.MathUtils.lerp(wristY, -0.07, t);
+    wristZ = THREE.MathUtils.lerp(wristZ, -0.22, t);
+    chestX = THREE.MathUtils.lerp(chestX, 0.22, t);
+    headX = THREE.MathUtils.lerp(headX, -0.16, t);
+  } else if (mode === 'firearmAimShotgun') {
+    shoulderX = THREE.MathUtils.lerp(shoulderX, -1.06, t);
+    shoulderY = THREE.MathUtils.lerp(shoulderY, -0.13, t);
+    shoulderZ = THREE.MathUtils.lerp(shoulderZ, -1.16, t);
+    forearmX = THREE.MathUtils.lerp(forearmX, -0.32, t);
+    forearmY = THREE.MathUtils.lerp(forearmY, -0.1, t);
+    forearmZ = THREE.MathUtils.lerp(forearmZ, 0.16, t);
+    wristX = THREE.MathUtils.lerp(wristX, 0.18, t);
+    wristY = THREE.MathUtils.lerp(wristY, -0.08, t);
+    wristZ = THREE.MathUtils.lerp(wristZ, -0.24, t);
+    chestX = THREE.MathUtils.lerp(chestX, 0.24, t);
+    headX = THREE.MathUtils.lerp(headX, -0.18, t);
+  } else if (mode === 'reachDice') {
     shoulderX = THREE.MathUtils.lerp(shoulderX, -0.78, t);
     shoulderY = THREE.MathUtils.lerp(shoulderY, -0.08, t);
     shoulderZ = THREE.MathUtils.lerp(shoulderZ, -1.06, t);
@@ -6197,39 +6254,36 @@ function resolveSeatedHumanActionPose(actorState, gameState, playerIndex, nowMs)
       };
     }
     if (isFirearmAttack) {
-      if (phase < 0.22) {
-        return {
-          ...basePose,
-          mode: 'reachDice',
-          intensity: easeInOutSine01(phase / 0.22),
-          handGrip: 0.08 + phase * 2.2,
-          motionTuning: { idleBreathAmp: 0.008, precision: 1.14 }
-        };
-      }
-      if (phase < 0.46) {
-        return {
-          ...basePose,
-          mode: 'gripDice',
-          intensity: smoother01((phase - 0.22) / 0.24),
-          handGrip: 0.7 + smoother01((phase - 0.22) / 0.24) * 0.22,
-          motionTuning: { idleBreathAmp: 0.008, precision: 1.16 }
-        };
-      }
-      if (phase < 0.82) {
-        return {
-          ...basePose,
-          mode: 'release',
-          intensity: 0.78 + smoother01((phase - 0.46) / 0.36) * 0.22,
-          handGrip: 0.96,
-          motionTuning: { idleBreathAmp: 0.007, precision: 1.22 }
-        };
-      }
+      const profileKey = FIREARM_BALLISTICS_PROFILE_BY_ID[attackId] || 'default';
+      const modeByProfile = {
+        pistol: 'firearmAimPistol',
+        smg: 'firearmAimSmg',
+        rifle: 'firearmAimRifle',
+        marksman: 'firearmAimRifle',
+        shotgun: 'firearmAimShotgun',
+        explosive: 'firearmAimShotgun',
+        default: 'firearmAim'
+      };
+      const selectedMode = modeByProfile[profileKey] || modeByProfile.default;
+      const gripByProfile = {
+        pistol: 0.88,
+        smg: 0.92,
+        rifle: 0.94,
+        marksman: 0.95,
+        shotgun: 0.96,
+        explosive: 0.94,
+        default: 0.92
+      };
+      const enterWindow = profileKey === 'shotgun' || profileKey === 'explosive' ? 0.24 : 0.2;
+      const settleWindow = profileKey === 'pistol' ? 0.9 : 0.86;
+      const holdBlend = phase < enterWindow ? easeInOutSine01(phase / enterWindow) : 1;
+      const settleBlend = phase > settleWindow ? 1 - smoother01((phase - settleWindow) / (1 - settleWindow)) : 1;
       return {
         ...basePose,
-        mode: 'followThrough',
-        intensity: 1 - smoother01((phase - 0.82) / 0.18),
-        handGrip: 0.58,
-        motionTuning: { idleBreathAmp: 0.008, precision: 1.12 }
+        mode: selectedMode,
+        intensity: clamp(holdBlend * settleBlend, 0, 1),
+        handGrip: gripByProfile[profileKey] ?? gripByProfile.default,
+        motionTuning: { idleBreathAmp: 0.007, precision: profileKey === 'marksman' ? 1.28 : 1.22 }
       };
     }
     return {
@@ -9891,6 +9945,16 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     [resolveTokenAnchorPoint]
   );
 
+  const resolvePlayerCaptureAnimationId = useCallback((playerIndex, fallbackActorState = null) => {
+    const actorCaptureId = fallbackActorState?.captureAnimationId;
+    if (typeof actorCaptureId === 'string' && actorCaptureId.length > 0) return actorCaptureId;
+    if (playerIndex > 0) {
+      return CAPTURE_ANIMATION_OPTIONS[aiLoadoutByPlayer[playerIndex]?.captureAnimationIndex ?? 0]?.id ?? CAPTURE_ANIMATION_OPTIONS[0]?.id;
+    }
+    const humanIndex = appearanceRef.current?.captureAnimation ?? appearance.captureAnimation ?? 0;
+    return CAPTURE_ANIMATION_OPTIONS[humanIndex]?.id ?? CAPTURE_ANIMATION_OPTIONS[0]?.id;
+  }, [aiLoadoutByPlayer, appearance.captureAnimation]);
+
   const playCaptureMissileSequence = ({
     attackerToken,
     attackerPlayer,
@@ -9920,13 +9984,8 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             return;
           }
 
-        const selectedCaptureAnimationId =
-          attackerPlayer > 0
-            ? CAPTURE_ANIMATION_OPTIONS[aiLoadoutByPlayer[attackerPlayer]?.captureAnimationIndex ?? 0]?.id
-            : CAPTURE_ANIMATION_OPTIONS[appearance.captureAnimation]?.id ??
-              CAPTURE_ANIMATION_OPTIONS[appearanceRef.current?.captureAnimation ?? 0]?.id;
-        const resolvedCaptureAnimationId =
-          selectedCaptureAnimationId ?? CAPTURE_ANIMATION_OPTIONS[0]?.id ?? 'missileJavelin';
+        const selectedCaptureAnimationId = resolvePlayerCaptureAnimationId(attackerPlayer, seatedHumanActionRef.current);
+        const resolvedCaptureAnimationId = selectedCaptureAnimationId ?? CAPTURE_ANIMATION_OPTIONS[0]?.id ?? 'missileJavelin';
         seatedHumanActionRef.current = {
           ...seatedHumanActionRef.current,
           capturePlayer: attackerPlayer,
@@ -10149,6 +10208,17 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
                 ttl: 0,
                 offset: Math.max(0.02, (CAMERA_TARGET_LIFT + (singleShotFirearm ? 0.016 : 0.02)) * CAPTURE_CAMERA_ZOOM_OUT_FACTOR),
                 followOffset: new THREE.Vector3(pullback.x, singleShotFirearm ? 0.08 : 0.09, pullback.z),
+                force: true
+              });
+            } else if (tracers[0]?.root?.visible) {
+              const tracerFocus = tracers[0].root.getWorldPosition(new THREE.Vector3());
+              setCameraFocus({
+                target: tracerFocus,
+                follow: true,
+                priority: 9,
+                ttl: 0,
+                offset: Math.max(0.02, (CAMERA_TARGET_LIFT + 0.015) * CAPTURE_CAMERA_ZOOM_OUT_FACTOR),
+                followOffset: new THREE.Vector3(0, 0.08, -0.11),
                 force: true
               });
             }


### PR DESCRIPTION
### Motivation
- Improve seated actor pose fidelity during capture/firearm attacks by introducing weapon-specific aiming postures and grips. 
- Centralize selection of a player's capture animation so AI/human choices resolve consistently across sequences. 
- Improve camera focus behavior when firearm tracers are present to better follow projectiles.

### Description
- Added multiple firearm aim modes in `applySeatedHumanPose` (`firearmAim`, `firearmAimPistol`, `firearmAimSmg`, `firearmAimRifle`, `firearmAimShotgun`) with interpolated bone rotations for shoulder/forearm/wrist/chest/head to represent different weapons. 
- Reworked capture animation handling in `resolveSeatedHumanActionPose` to detect a firearm profile via `FIREARM_BALLISTICS_PROFILE_BY_ID`, map profiles to aim modes and per-profile grip/precision tuning, and compute blended `intensity` based on profile-specific timing windows. 
- Introduced `resolvePlayerCaptureAnimationId` (a `useCallback`) to centralize resolving an attacker player's capture animation id and used it in `playCaptureMissileSequence` instead of duplicating selection logic. 
- Adjusted capture missile sequence behavior to set camera focus on tracers when no lead bullet is available, and updated some motion tuning values for firearm poses. 

### Testing
- Ran the project test suite with `yarn test` and project lint checks with `yarn lint`, both completed successfully. 
- Performed a local build with `yarn build` which succeeded and allowed manual smoke validation of capture/firearm sequences (aim poses, grips and camera focus) in the demo scene.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1ec85ed0c832985cf75d7dbfba0d4)