### PR TITLE
Fix Ludo BR table weapon stability and dice palm contact precision

### DIFF
--- a/Assets/Scripts/Gameplay/Weapons/BattleRoyaleWeaponDirector.cs
+++ b/Assets/Scripts/Gameplay/Weapons/BattleRoyaleWeaponDirector.cs
@@ -68,6 +68,8 @@ namespace TonPlaygram.Gameplay.Weapons
         [SerializeField] private Transform attackerCameraAnchor;
         [SerializeField] private Transform liveTargetTransform;
         [SerializeField] private Transform weaponRoot;
+        [SerializeField] private Transform tableWeaponAnchor;
+        [SerializeField] private Transform weaponSwapIcon;
         [SerializeField] private Transform rightHandGrip;
         [SerializeField] private Transform leftHandGrip;
 
@@ -86,6 +88,7 @@ namespace TonPlaygram.Gameplay.Weapons
         [SerializeField] private float bulletFollowHeight = 0.14f;
         [SerializeField] private float cameraLookLerp = 18f;
         [SerializeField] private float cameraTrackLerp = 15f;
+        [SerializeField] private Vector3 swapIconWorldOffset = new Vector3(0f, 0.11f, 0f);
 
         private readonly Dictionary<LudoWeaponType, WeaponBallisticsProfile> _profiles = new Dictionary<LudoWeaponType, WeaponBallisticsProfile>();
         private readonly List<TokenPieceHealth> _tokenPieces = new List<TokenPieceHealth>();
@@ -99,6 +102,10 @@ namespace TonPlaygram.Gameplay.Weapons
         private Vector3 _baseCameraLocalPos;
         private Transform _baseCameraParent;
         private Quaternion _baseCameraLocalRot;
+        private Vector3 _weaponRootLocalPos;
+        private Quaternion _weaponRootLocalRot;
+        private Vector3 _swapIconWorldPos;
+        private Quaternion _swapIconWorldRot;
 
         private void Awake()
         {
@@ -122,6 +129,7 @@ namespace TonPlaygram.Gameplay.Weapons
 
             BuildProfileMap();
             CacheTokenPieces();
+            CacheStaticAnchors();
             _eventListeners = GetComponentsInParent<ILudoWeaponEvents>(true);
             _projectileListeners = GetComponentsInParent<ILudoProjectileBroadcastEvents>(true);
             Equip(startingWeapon);
@@ -341,8 +349,8 @@ namespace TonPlaygram.Gameplay.Weapons
         {
             if (weaponRoot != null)
             {
-                weaponRoot.position = muzzle.position;
-                weaponRoot.rotation = Quaternion.LookRotation(shotDirection, Vector3.up);
+                weaponRoot.localPosition = _weaponRootLocalPos;
+                weaponRoot.localRotation = _weaponRootLocalRot;
             }
 
             if (rightHandGrip != null)
@@ -492,6 +500,51 @@ namespace TonPlaygram.Gameplay.Weapons
                     continue;
 
                 _profiles[profile.weaponType] = profile;
+            }
+        }
+
+        private void LateUpdate()
+        {
+            MaintainStaticPresentationAnchors();
+        }
+
+        private void CacheStaticAnchors()
+        {
+            if (weaponRoot != null)
+            {
+                _weaponRootLocalPos = weaponRoot.localPosition;
+                _weaponRootLocalRot = weaponRoot.localRotation;
+            }
+
+            if (weaponSwapIcon != null)
+            {
+                Transform iconAnchor = tableWeaponAnchor != null ? tableWeaponAnchor : weaponRoot;
+                if (iconAnchor != null)
+                {
+                    _swapIconWorldPos = iconAnchor.position + swapIconWorldOffset;
+                    _swapIconWorldRot = weaponSwapIcon.rotation;
+                    weaponSwapIcon.position = _swapIconWorldPos;
+                }
+                else
+                {
+                    _swapIconWorldPos = weaponSwapIcon.position;
+                    _swapIconWorldRot = weaponSwapIcon.rotation;
+                }
+            }
+        }
+
+        private void MaintainStaticPresentationAnchors()
+        {
+            if (weaponRoot != null)
+            {
+                weaponRoot.localPosition = _weaponRootLocalPos;
+                weaponRoot.localRotation = _weaponRootLocalRot;
+            }
+
+            if (weaponSwapIcon != null)
+            {
+                weaponSwapIcon.position = _swapIconWorldPos;
+                weaponSwapIcon.rotation = _swapIconWorldRot;
             }
         }
 

--- a/Assets/Scripts/Gameplay/Weapons/LudoDicePalmAlignment.cs
+++ b/Assets/Scripts/Gameplay/Weapons/LudoDicePalmAlignment.cs
@@ -1,0 +1,48 @@
+using UnityEngine;
+
+namespace TonPlaygram.Gameplay.Weapons
+{
+    /// <summary>
+    /// Keeps the dice precisely seated inside the player's palm during grab/hold poses.
+    /// Attach this to the dice object or any controller object and assign refs in inspector.
+    /// </summary>
+    public sealed class LudoDicePalmAlignment : MonoBehaviour
+    {
+        [SerializeField] private Transform diceTransform;
+        [SerializeField] private Transform palmAnchor;
+        [SerializeField] private bool alignEveryFrame = true;
+        [SerializeField] private Vector3 palmOffset = new Vector3(0f, -0.012f, 0.016f);
+        [SerializeField] private Vector3 palmEulerOffset = new Vector3(5f, 0f, 90f);
+
+        private Quaternion _localRotationOffset;
+
+        private void Awake()
+        {
+            if (diceTransform == null)
+            {
+                diceTransform = transform;
+            }
+
+            _localRotationOffset = Quaternion.Euler(palmEulerOffset);
+            SnapToPalm();
+        }
+
+        private void LateUpdate()
+        {
+            if (!alignEveryFrame)
+                return;
+
+            SnapToPalm();
+        }
+
+        [ContextMenu("Snap Dice To Palm")]
+        public void SnapToPalm()
+        {
+            if (diceTransform == null || palmAnchor == null)
+                return;
+
+            diceTransform.position = palmAnchor.TransformPoint(palmOffset);
+            diceTransform.rotation = palmAnchor.rotation * _localRotationOffset;
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Prevent table weapons and the swap icon from drifting when the player swaps weapons or the camera rotates to keep table presentation stable.
- Ensure dice visibly and physically contact the player hand by precisely aligning dice into the palm during grab/hold poses.

### Description
- Added caching and re-application of the initial `weaponRoot` local transform in `BattleRoyaleWeaponDirector` so the table weapon keeps its startup pose (`Assets/Scripts/Gameplay/Weapons/BattleRoyaleWeaponDirector.cs`).
- Added `tableWeaponAnchor`, `weaponSwapIcon` and `swapIconWorldOffset` to `BattleRoyaleWeaponDirector` and implemented `CacheStaticAnchors`/`MaintainStaticPresentationAnchors` to lock the swap icon to a stable world position above the table weapon.
- Replaced previous runtime weapon-root updates in `RefreshWeaponPose` with restoring the cached local pose and kept precise hand grips behavior unchanged while maintaining the table presentation in `LateUpdate`.
- Introduced a new `LudoDicePalmAlignment` MonoBehaviour that snaps a dice `Transform` into a configurable palm anchor using `TransformPoint` plus an Euler offset and supports per-frame LateUpdate alignment and a context-menu snap (`Assets/Scripts/Gameplay/Weapons/LudoDicePalmAlignment.cs`).

### Testing
- No automated unit or integration tests were run for these changes; changes are limited to presentation components and were committed after local edits (`Assets/Scripts/Gameplay/Weapons/BattleRoyaleWeaponDirector.cs` and `Assets/Scripts/Gameplay/Weapons/LudoDicePalmAlignment.cs`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20f2cee148329a932d39658e1fbab)