### PR TITLE
Adjust ChessBattleRoyal weapon-swap UI: reposition button, widen panel, and preserve thumbnails

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -13862,21 +13862,21 @@ function Chess3D({
             </div>
           )}
         </div>
-        <div className="absolute top-1/2 left-3 z-30 -translate-y-1/2 pointer-events-none">
+        <div className="absolute top-36 right-4 z-30 pointer-events-none">
           <div className="pointer-events-auto flex flex-col items-start gap-2">
             <button
               type="button"
               onClick={() => setWeaponSwapOpen((open) => !open)}
               aria-expanded={weaponSwapOpen}
-              aria-label={weaponSwapOpen ? 'Close quick weapon swap' : 'Open quick weapon swap'}
+              aria-label={weaponSwapOpen ? 'Close weapon inventory swap' : 'Open weapon inventory swap'}
               className="flex h-11 w-11 items-center justify-center rounded-full border border-amber-300/60 bg-black/65 text-lg shadow-[0_6px_16px_rgba(0,0,0,0.42)] transition hover:border-amber-200 hover:text-amber-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300/80"
             >
               🔄
             </button>
             {weaponSwapOpen && (
-              <div className="max-h-[52vh] w-[14rem] overflow-y-auto rounded-2xl border border-white/20 bg-[#060a14]/95 p-2 text-xs shadow-2xl backdrop-blur">
+              <div className="max-h-[52vh] w-[15rem] overflow-y-auto rounded-2xl border border-white/20 bg-[#060a14]/95 p-2 text-xs shadow-2xl backdrop-blur">
                 <p className="px-2 pb-2 text-[10px] uppercase tracking-[0.3em] text-sky-200/80">
-                  Quick Weapon Swap
+                  Weapon Inventory Swap
                 </p>
                 <div className="space-y-2">
                   {ownedCaptureAnimations.map((option) => {
@@ -13896,7 +13896,7 @@ function Chess3D({
                           <img
                             src={option.thumbnail}
                             alt={option.label}
-                            className="h-9 w-9 rounded-md object-cover"
+                            className="h-9 w-9 rounded-md object-contain bg-white/5 p-0.5"
                             loading="lazy"
                           />
                         ) : (


### PR DESCRIPTION
### Motivation
- Make the quick weapon swap control clearer and more consistent with other action controls by moving it into the main action rail and improving spacing and labeling.
- Ensure weapon inventory thumbnails preserve original silhouettes and remain legible in the quick-swap menu.

### Description
- Moved the weapon swap action button from the mid-left edge to the upper-right action rail in `webapp/src/pages/Games/ChessBattleRoyal.jsx` by updating the container position to `top-36 right-4`.
- Updated the button `aria-label` text from the generic quick-swap wording to explicit inventory wording (`'Open weapon inventory swap'` / `'Close weapon inventory swap'`).
- Increased the quick-swap panel width from `w-[14rem]` to `w-[15rem]` and renamed the panel heading from `Quick Weapon Swap` to `Weapon Inventory Swap`.
- Changed thumbnail rendering for inventory items to `object-contain` with a subtle `bg-white/5` and `p-0.5` so weapon shapes remain visible (replaced prior `object-cover`).

### Testing
- Verified the file diff for `webapp/src/pages/Games/ChessBattleRoyal.jsx` with `git diff` to confirm only intended changes were made, which succeeded.
- Inspected the updated lines with `nl -ba` / `sed` to confirm markup and class changes, which succeeded.
- Created a commit with the message `Adjust chess weapon swap control placement and inventory panel`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f212f53d2c832986ff19298381f9ec)