### PR TITLE
Add quick weapon swap rail with curated 18-weapon list and reposition swap button

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -7655,6 +7655,37 @@ function Chess3D({
         .filter(Boolean),
     [chessInventory]
   );
+  const QUICK_SWAP_WEAPON_IDS = useMemo(
+    () =>
+      [
+        'polyShotgun01Attack',
+        'polyAssaultRifle01Attack',
+        'polyPistol01Attack',
+        'polyRevolver01Attack',
+        'polySawedOff01Attack',
+        'polyRevolver02Attack',
+        'polyShotgun02Attack',
+        'polyShotgun03Attack',
+        'polySmg01Attack',
+        'ak47VolleyAttack',
+        'krsvBurstAttack',
+        'smithSidearmAttack',
+        'mosinMarksmanAttack',
+        'uziSprayAttack',
+        'sigsauerTacticalAttack',
+        'sniperShotAttack',
+        'compactCarbineAttack',
+        'fpsGunAttack'
+      ],
+    []
+  );
+  const quickSwapWeapons = useMemo(() => {
+    const ownedIds = new Set((ownedCaptureAnimations || []).map((option) => option.id));
+    return QUICK_SWAP_WEAPON_IDS
+      .filter((id) => ownedIds.has(id))
+      .map((id) => CAPTURE_ANIMATION_OPTIONS.find((option) => option.id === id))
+      .filter(Boolean);
+  }, [ownedCaptureAnimations, QUICK_SWAP_WEAPON_IDS]);
   const [weaponSwapOpen, setWeaponSwapOpen] = useState(false);
   const handleCaptureAnimationSwap = useCallback(
     (optionId) => {
@@ -13862,14 +13893,14 @@ function Chess3D({
             </div>
           )}
         </div>
-        <div className="absolute top-1/2 left-3 z-30 -translate-y-1/2 pointer-events-none">
+        <div className="fixed right-3 bottom-[10.4rem] z-50 pointer-events-none">
           <div className="pointer-events-auto flex flex-col items-start gap-2">
             <button
               type="button"
               onClick={() => setWeaponSwapOpen((open) => !open)}
               aria-expanded={weaponSwapOpen}
               aria-label={weaponSwapOpen ? 'Close quick weapon swap' : 'Open quick weapon swap'}
-              className="flex h-11 w-11 items-center justify-center rounded-full border border-amber-300/60 bg-black/65 text-lg shadow-[0_6px_16px_rgba(0,0,0,0.42)] transition hover:border-amber-200 hover:text-amber-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300/80"
+              className="flex h-10 w-10 items-center justify-center rounded-full border border-amber-300/60 bg-black/65 text-base shadow-[0_6px_16px_rgba(0,0,0,0.42)] transition hover:border-amber-200 hover:text-amber-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300/80"
             >
               🔄
             </button>
@@ -13879,7 +13910,7 @@ function Chess3D({
                   Quick Weapon Swap
                 </p>
                 <div className="space-y-2">
-                  {ownedCaptureAnimations.map((option) => {
+                  {(quickSwapWeapons.length ? quickSwapWeapons : ownedCaptureAnimations).map((option) => {
                     const isSelected = option.id === selectedCaptureAnimationId;
                     return (
                       <button
@@ -13896,7 +13927,7 @@ function Chess3D({
                           <img
                             src={option.thumbnail}
                             alt={option.label}
-                            className="h-9 w-9 rounded-md object-cover"
+                            className="h-9 w-9 rounded-md border border-white/20 bg-black/30 object-cover p-[1px]"
                             loading="lazy"
                           />
                         ) : (


### PR DESCRIPTION
### Motivation
- Provide a quick weapon-swap UI that prioritizes the requested Quaternius + Extra weapons so players can quickly swap capture animations/GLTF weapons for in-game animations. 
- Place the swap control in the same vertical lane as other portrait controls (gift/controls) and add spacing so the swap button does not obscure those icons. 
- Keep the existing `captureAnimation` inventory/equip flow and GLTF configuration intact while surfacing a curated, easy-to-reach picker. 

### Description
- Added a curated list `QUICK_SWAP_WEAPON_IDS` and derived `quickSwapWeapons` memo so the quick-swap menu prioritizes the requested 18 weapon animation ids when they are owned. 
- Repositioned the swap control container from left-center to a right-side fixed rail and adjusted the button sizing/placement to `className="fixed right-3 bottom-[10.4rem] ..."` and `h-10 w-10` for portrait-friendly spacing. 
- Updated the quick-swap menu to prefer the curated `quickSwapWeapons` (falling back to `ownedCaptureAnimations`) and to render thumbnails with a framed style by changing the image class to `h-9 w-9 rounded-md border border-white/20 bg-black/30 object-cover p-[1px]`. 
- All changes are contained in `webapp/src/pages/Games/ChessBattleRoyal.jsx` and continue to call `setChessBattleEquippedOption('captureAnimation', ...)` to apply swaps. 

### Testing
- Ran the unit test `npm test -- --runInBand test/chessBattleInventoryConfig.test.js`. 
- The test run failed with an existing inventory finish expectation mismatch (`carbonFiberChalk`, `carbonFiberSnakeChalk`, `carbonFiberAlligatorNight` missing), which is unrelated to the UI/quick-swap changes and indicates a pre-existing config expectation difference.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f212f53d2c832986ff19298381f9ec)