### PR TITLE
Add quick weapon swap control for Snake & Ladder

### DIFF
--- a/webapp/src/components/BottomLeftIcons.jsx
+++ b/webapp/src/components/BottomLeftIcons.jsx
@@ -25,7 +25,8 @@ export default function BottomLeftIcons({
   cameraIcon,
   cameraLabel = '2D',
   order = ['chat', 'gift', 'info', 'mute'],
-  actionOffsets = {}
+  actionOffsets = {},
+  extraActions = []
 }) {
   const [muted, setMuted] = useState(isGameMuted());
 
@@ -92,6 +93,23 @@ export default function BottomLeftIcons({
         )
       : null
   };
+
+  if (Array.isArray(extraActions)) {
+    extraActions.forEach((action) => {
+      if (!action?.key || typeof action.onClick !== 'function' || action.show === false) return;
+      actions[action.key] = (
+        <button
+          type="button"
+          onClick={action.onClick}
+          className={action.buttonClassName || buttonClassName}
+          aria-label={action.ariaLabel || action.label}
+        >
+          <span className={action.iconClassName || iconClassName}>{action.icon ?? '⚡'}</span>
+          <span className={action.labelClassName || labelClassName}>{action.label || action.key}</span>
+        </button>
+      );
+    });
+  }
 
   return (
     <div className={className} style={style}>

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -1266,6 +1266,7 @@ export default function SnakeAndLadder() {
   const [aiAvatars, setAiAvatars] = useState([]);
   const [burning, setBurning] = useState([]); // indices of tokens burning
   const [refreshTick, setRefreshTick] = useState(0);
+  const [showWeaponSwapMenu, setShowWeaponSwapMenu] = useState(false);
   const [rollCooldown, setRollCooldown] = useState(0);
   const [moving, setMoving] = useState(false);
   const [pendingExtraRoll, setPendingExtraRoll] = useState(false);
@@ -1277,6 +1278,13 @@ export default function SnakeAndLadder() {
   const normalizedAppearance = useMemo(() => normalizeAppearance(appearance), [appearance]);
   const appearanceKey = useMemo(() => buildAppearanceKey(appearance), [appearance]);
   const resolvedAppearance = useMemo(() => resolveAppearance(appearance), [appearance]);
+  const ownedCaptureWeapons = useMemo(
+    () =>
+      CAPTURE_WEAPON_OPTIONS.filter((option) =>
+        isSnakeOptionUnlocked('captureWeapon', option.id, snakeInventory)
+      ),
+    [snakeInventory]
+  );
   const activeFrameRateOption = useMemo(
     () => FRAME_RATE_OPTIONS.find((option) => option.id === frameRateId) ?? DEFAULT_FRAME_RATE_OPTION,
     [frameRateId]
@@ -3828,12 +3836,61 @@ export default function SnakeAndLadder() {
             showMute={false}
             showGift
             showCamera2d={false}
-            order={['gift']}
+            order={['swapWeapon', 'gift']}
+            extraActions={[
+              {
+                key: 'swapWeapon',
+                label: 'Swap',
+                icon: '🔁',
+                onClick: () => setShowWeaponSwapMenu((prev) => !prev),
+                ariaLabel: 'Swap capture weapon'
+              }
+            ]}
             buttonClassName="flex flex-col items-center bg-transparent p-0 text-white/90 shadow-none transition hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
             iconClassName="text-2xl leading-none"
             labelClassName="sr-only"
           />
         </div>
+        {showWeaponSwapMenu ? (
+          <div
+            className="pointer-events-auto fixed z-30 right-3 rounded-2xl border border-white/15 bg-slate-900/95 p-2 shadow-2xl backdrop-blur-md"
+            style={{
+              bottom: 'calc(env(safe-area-inset-bottom, 0px) + 7.3rem)',
+              maxWidth: '18rem',
+              width: 'min(72vw, 18rem)'
+            }}
+          >
+            <div className="px-2 pb-2 text-[10px] font-bold uppercase tracking-[0.16em] text-yellow-200/90">
+              Weapon Swap
+            </div>
+            <div className="max-h-64 space-y-1 overflow-y-auto pr-1">
+              {ownedCaptureWeapons.map((weapon) => {
+                const active = resolvedAppearance?.captureWeapon?.id === weapon.id;
+                return (
+                  <button
+                    key={`swap-${weapon.id}`}
+                    type="button"
+                    onClick={() => {
+                      const idx = CAPTURE_WEAPON_OPTIONS.findIndex((option) => option.id === weapon.id);
+                      if (idx >= 0) {
+                        setAppearance((prev) => normalizeAppearance({ ...prev, captureWeapon: idx }));
+                      }
+                      setShowWeaponSwapMenu(false);
+                    }}
+                    className={`flex w-full items-center gap-2 rounded-xl border px-2 py-2 text-left text-[11px] font-semibold ${
+                      active
+                        ? 'border-yellow-300/70 bg-yellow-400/90 text-slate-950'
+                        : 'border-white/15 bg-white/5 text-slate-100 hover:bg-white/10'
+                    }`}
+                  >
+                    <img src={weapon.thumbnail} alt={weapon.label} className="h-8 w-8 rounded-md border border-white/20 object-cover" />
+                    <span className="truncate">{weapon.label}</span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        ) : null}
         {/* Player photos stacked vertically */}
         <div className="absolute inset-0 z-20 pointer-events-none">
           {players.map((player, seat) => {


### PR DESCRIPTION
### Motivation
- Provide a quick, mobile-friendly control so players can open their owned weapon inventory and swap the capture weapon used in Snake & Ladder animations without leaving the game UI. 
- Reuse the existing GLTF/GLB fallback chain and configuration already defined for capture weapons so swapped items keep the same visual behaviour.

### Description
- Extended `BottomLeftIcons` with an `extraActions` prop so pages can inject stacked vertical actions into the existing rail UI while preserving ordering and styles (`webapp/src/components/BottomLeftIcons.jsx`).
- Added a right-side `Swap` action to the Snake & Ladder screen that appears in the same vertical rail as other quick actions (`webapp/src/pages/Games/SnakeAndLadder.jsx`).
- Implemented a compact weapon inventory popup that lists owned capture weapons with thumbnail + name and allows one-tap swap; selection updates the existing `appearance.captureWeapon` flow so the same `CAPTURE_WEAPON_OPTIONS` GLTF/GLB configuration and fallback chain are used. (`webapp/src/pages/Games/SnakeAndLadder.jsx`).
- Small UI/UX details: the swap button uses an icon and opens a menu positioned above the gift button with a gap to match portrait vertical layout; owned weapons are filtered via `isSnakeOptionUnlocked` and displayed using their configured thumbnails.

### Testing
- Ran the production build with `npm --prefix webapp run build` and the build completed successfully; only non-blocking pre-existing warnings (chunk size/dynamic import and a duplicate package key) were reported. 
- Manual smoke-checked the new UI components in the Snake & Ladder page to confirm the swap button appears in the BottomLeftIcons rail and the popup lists owned weapons and triggers `appearance.captureWeapon` updates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2121ed7048329b2c2ce5b160f1d6b)