### PR TITLE
Inline Pool Royale human edge positioning helper

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -117,10 +117,28 @@ import { sampleCueStrokeTimeline } from './poolRoyaleCueStrokeTimeline.js';
 import { resolvePocketMouthAimPoint } from './poolRoyalePocketAim.js';
 import { resolveAiPotGhostAim } from './poolRoyaleAiAimCompensation.js';
 import { computeCueDriveBoost } from './cueShotImpact.js';
-import {
-  chooseHumanEdgePosition as chooseBilardoHumanEdgePosition,
-} from './shared/bilardoHumanRig.js';
 import { polyHavenThumb } from '../../config/storeThumbnails.js';
+
+
+const BILARDO_HUMAN_CFG = {
+  edgeMargin: 0.58,
+  desiredShootDistance: 1.06,
+};
+
+function chooseBilardoHumanEdgePosition(cueBallWorld, aimForward, opts = {}) {
+  const desired = cueBallWorld
+    .clone()
+    .addScaledVector(aimForward, -(opts.desiredShootDistance ?? BILARDO_HUMAN_CFG.desiredShootDistance));
+  const xEdge = (opts.tableW ?? 2.0) / 2 + (opts.edgeMargin ?? BILARDO_HUMAN_CFG.edgeMargin);
+  const zEdge = (opts.tableL ?? 3.6) / 2 + (opts.edgeMargin ?? BILARDO_HUMAN_CFG.edgeMargin);
+  const candidates = [
+    new THREE.Vector3(-xEdge, 0, clamp(desired.z, -zEdge, zEdge)),
+    new THREE.Vector3(xEdge, 0, clamp(desired.z, -zEdge, zEdge)),
+    new THREE.Vector3(clamp(desired.x, -xEdge, xEdge), 0, -zEdge),
+    new THREE.Vector3(clamp(desired.x, -xEdge, xEdge), 0, zEdge),
+  ];
+  return candidates.sort((a, b) => a.distanceToSquared(desired) - b.distanceToSquared(desired))[0].clone();
+}
 
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/v1/decoders/';
 const BASIS_TRANSCODER_PATH =


### PR DESCRIPTION
### Motivation
- Localize human edge-positioning logic so `PoolRoyale.jsx` no longer depends on the external helper in `shared/bilardoHumanRig.js` and the behavior can be tailored/maintained inside the game file.

### Description
- Removed the `chooseHumanEdgePosition` import and inlined a `BILARDO_HUMAN_CFG` and `chooseBilardoHumanEdgePosition(cueBallWorld, aimForward, opts = {})` helper directly into `webapp/src/pages/Games/PoolRoyale.jsx`, preserving the same edge-candidate generation and nearest-distance selection logic.
- Kept all call sites unchanged so runtime behavior remains equivalent to the previous helper and configuration values (`desiredShootDistance`, `edgeMargin`) are preserved.

### Testing
- No automated tests were executed for this change and the commit was recorded (`git commit` completed successfully). 
- This is a logic-only refactor; recommend running the app smoke test and the Pool Royale related unit tests (for example the `test/poolRoyale*` suite) before merging to validate runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2215fb2d08329953d0fb8bdfb9623)