### PR TITLE
Improve camera follow and offsets for capture/attack animations in Ludo3D

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -10292,10 +10292,12 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
               });
               setCameraFocus({
                 target: muzzleTarget.clone(),
-                follow: false,
+                object: leadBulletMesh?.isObject3D ? leadBulletMesh : handWeaponAttachment?.weapon,
+                follow: true,
                 priority: 11,
                 ttl: 1.4,
                 offset: Math.max(0.018, (CAMERA_TARGET_LIFT + 0.024) * CAPTURE_CAMERA_ZOOM_OUT_FACTOR),
+                followOffset: new THREE.Vector3(0, 0.09, -0.12),
                 force: true
               });
             }
@@ -10452,13 +10454,23 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         if (LUDO_CAMERA_ANIMATION_BOTTOM_TURN_VIEW) {
           setCameraViewForTurn(0, CAMERA_BROADCAST_ANIMATION_MS, { force: true });
         } else {
+          const preLaunchAim = targetPosition.clone().sub(launchAnchor);
+          const preLaunchFollowOffset =
+            preLaunchAim.lengthSq() > 1e-6
+              ? preLaunchAim
+                  .normalize()
+                  .multiplyScalar(-0.12)
+                  .setY(0.1)
+              : new THREE.Vector3(0, 0.1, -0.12);
           moveCameraToHighestAllowedAngle(launchAnchor, Math.max(0.004, CAMERA_TARGET_LIFT - 0.018));
           setCameraFocus({
-            target: launchAnchor,
-            follow: false,
-            priority: 7,
-            ttl: 1.1,
-            offset: Math.max(0.004, CAMERA_TARGET_LIFT - 0.018),
+            object: parkedVehicleToRestore?.isObject3D ? parkedVehicleToRestore : primaryFx.root,
+            target: launchAnchor.clone().lerp(targetPosition, 0.22),
+            follow: true,
+            priority: 8,
+            ttl: 0.9,
+            offset: Math.max(0.008, (CAMERA_TARGET_LIFT - 0.012) * CAPTURE_CAMERA_ZOOM_OUT_FACTOR),
+            followOffset: preLaunchFollowOffset,
             force: true
           });
         }
@@ -10937,11 +10949,13 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
               if (!explosionTriggered) {
                 explosionTriggered = true;
                 setCameraFocus({
+                  object: explosion.root,
                   target: liveTarget.clone(),
-                  follow: false,
+                  follow: true,
                   priority: 11,
                   ttl: 1.8,
                   offset: Math.max(0.02, (CAMERA_TARGET_LIFT + 0.026) * CAPTURE_CAMERA_ZOOM_OUT_FACTOR),
+                  followOffset: new THREE.Vector3(0, 0.1, -0.14),
                   force: true
                 });
                 playMissileImpactSound();


### PR DESCRIPTION
### Motivation
- Make cinematic capture and attack animations feel more dynamic and stable by having the camera follow relevant moving objects and by offsetting the camera relative to those objects.
- Reduce jumpiness when bullets, missiles, explosions, or vehicles move by targeting the actual moving roots instead of only static targets.

### Description
- Pass an `object` to `setCameraFocus` and enable `follow: true` for bullet shatter, pre-launch, and explosion/impact camera focuses so the camera follows the actual moving scene roots instead of a fixed point.
- Add `followOffset` vectors (e.g. `new THREE.Vector3(0, 0.09, -0.12)` and `new THREE.Vector3(0, 0.1, -0.14)`) to position the camera relative to the followed objects, and adjust `offset`, `priority`, and `ttl` values to tune framing.
- Compute a `preLaunchFollowOffset` from the aim vector when moving the camera to the launch anchor and set the camera `object` to `parkedVehicleToRestore` or `primaryFx.root` with the focus `target` lerped toward the `targetPosition` for smoother pre-launch framing.
- Minor numeric tweaks to camera lift/zoom multipliers to better match the new follow behavior.

### Testing
- Ran the project's unit and integration tests with `yarn test`, and the test suite completed successfully. 
- Built the application with `yarn build` to verify typechecks and bundling, and the build succeeded. 
- Ran `yarn lint` to confirm no linting regressions, and linting passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2381adccc8329bb73f9dc7148177d)