### PR TITLE
Normalize and resolve snake capture weapon IDs; add aliases and merge inventory with catalog

### DIFF
--- a/webapp/src/config/snakeWeaponCatalog.js
+++ b/webapp/src/config/snakeWeaponCatalog.js
@@ -34,3 +34,20 @@ export const SNAKE_CAPTURE_WEAPON_OPTIONS = Object.freeze([
   { id: 'slot-17-mrtk-gun-glb', label: 'MRTK Gun GLB', thumbnail: swatchThumbnail(['#0369a1','#0f172a','#e0f2fe']), urls: [SNAKE_KNOWN_WORKING_GLB.mrtk, SNAKE_KNOWN_WORKING_GLB.mrtkRaw, SNAKE_KNOWN_WORKING_GLB.mrtkMaster] },
   { id: 'slot-18-fps-gun-gltf', label: 'FPS Shotgun', thumbnail: swatchThumbnail(['#f59e0b','#111827','#fde68a']), urls: [SNAKE_KNOWN_WORKING_GLB.fps, SNAKE_KNOWN_WORKING_GLB.fpsRaw, SNAKE_KNOWN_WORKING_GLB.awp, SNAKE_KNOWN_WORKING_GLB.awpRaw] }
 ]);
+
+
+export const SNAKE_CAPTURE_WEAPON_ALIAS_MAP = Object.freeze({
+  fighter: 'poly-assault-rifle-01',
+  helicopter: 'poly-shotgun-02',
+  supporttruck: 'poly-smg-01',
+  drone: 'poly-shotgun-01'
+});
+
+export const normalizeSnakeWeaponId = (value) =>
+  typeof value === 'string' ? value.trim().toLowerCase() : '';
+
+export const resolveSnakeCaptureWeaponId = (weaponId) => {
+  const normalized = normalizeSnakeWeaponId(weaponId);
+  if (!normalized) return '';
+  return SNAKE_CAPTURE_WEAPON_ALIAS_MAP[normalized] || normalized;
+};

--- a/webapp/src/pages/Games/SnakeAndLadder.jsx
+++ b/webapp/src/pages/Games/SnakeAndLadder.jsx
@@ -36,7 +36,10 @@ import {
   SNAKE_PAWN_HEAD_OPTIONS,
   SNAKE_TOKEN_COLOR_OPTIONS
 } from "../../config/snakeInventoryConfig.js";
-import { SNAKE_CAPTURE_WEAPON_OPTIONS } from "../../config/snakeWeaponCatalog.js";
+import {
+  SNAKE_CAPTURE_WEAPON_OPTIONS,
+  resolveSnakeCaptureWeaponId
+} from "../../config/snakeWeaponCatalog.js";
 // Developer accounts that receive shares of each pot
 const DEV_ACCOUNT = import.meta.env.VITE_DEV_ACCOUNT_ID;
 const DEV_ACCOUNT_1 = import.meta.env.VITE_DEV_ACCOUNT_ID_1;
@@ -817,9 +820,16 @@ const TOKEN_SHAPE_OPTIONS = Object.freeze([
 const CAPTURE_WEAPON_OPTIONS = Object.freeze(
   SNAKE_CAPTURE_WEAPON_OPTIONS.map((option) => ({
     id: option.id,
-    label: option.label
+    label: option.label,
+    thumbnail: option.thumbnail
   }))
 );
+
+const resolveCaptureWeaponOptionById = (weaponId) => {
+  const resolvedId = resolveSnakeCaptureWeaponId(weaponId);
+  if (!resolvedId) return null;
+  return CAPTURE_WEAPON_OPTIONS.find((option) => option.id === resolvedId) || null;
+};
 
 const SNAKE_SKIN_OPTIONS = Object.freeze([
   {
@@ -1278,13 +1288,25 @@ export default function SnakeAndLadder() {
   const normalizedAppearance = useMemo(() => normalizeAppearance(appearance), [appearance]);
   const appearanceKey = useMemo(() => buildAppearanceKey(appearance), [appearance]);
   const resolvedAppearance = useMemo(() => resolveAppearance(appearance), [appearance]);
-  const ownedCaptureWeapons = useMemo(
-    () =>
-      CAPTURE_WEAPON_OPTIONS.filter((option) =>
-        isSnakeOptionUnlocked('captureWeapon', option.id, snakeInventory)
-      ),
-    [snakeInventory]
-  );
+  const ownedCaptureWeapons = useMemo(() => {
+    const inventoryWeaponIds = Array.isArray(snakeInventory?.captureWeapon)
+      ? snakeInventory.captureWeapon
+      : [];
+    const resolvedInventoryWeapons = inventoryWeaponIds
+      .map((weaponId) => resolveCaptureWeaponOptionById(weaponId))
+      .filter(Boolean);
+    const unlockedCatalogWeapons = CAPTURE_WEAPON_OPTIONS.filter((option) =>
+      isSnakeOptionUnlocked('captureWeapon', option.id, snakeInventory)
+    );
+    const merged = new Map();
+    [...resolvedInventoryWeapons, ...unlockedCatalogWeapons].forEach((weapon) => {
+      merged.set(weapon.id, weapon);
+    });
+    if (!merged.size && CAPTURE_WEAPON_OPTIONS[0]) {
+      merged.set(CAPTURE_WEAPON_OPTIONS[0].id, CAPTURE_WEAPON_OPTIONS[0]);
+    }
+    return Array.from(merged.values());
+  }, [snakeInventory]);
   const activeFrameRateOption = useMemo(
     () => FRAME_RATE_OPTIONS.find((option) => option.id === frameRateId) ?? DEFAULT_FRAME_RATE_OPTION,
     [frameRateId]

--- a/webapp/src/utils/snakeInventory.js
+++ b/webapp/src/utils/snakeInventory.js
@@ -3,6 +3,10 @@ import {
   SNAKE_DEFAULT_UNLOCKS,
   SNAKE_OPTION_LABELS
 } from '../config/snakeInventoryConfig.js';
+import {
+  resolveSnakeCaptureWeaponId,
+  SNAKE_CAPTURE_WEAPON_OPTIONS
+} from '../config/snakeWeaponCatalog.js';
 
 const STORAGE_KEY = 'snakeInventoryByAccount';
 
@@ -37,13 +41,28 @@ const writeAllInventories = (payload) => {
   window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
 };
 
+const KNOWN_CAPTURE_WEAPON_IDS = new Set(
+  SNAKE_CAPTURE_WEAPON_OPTIONS.map((option) => resolveSnakeCaptureWeaponId(option.id)).filter(Boolean)
+);
+
+const normalizeInventoryValues = (key, values = []) => {
+  if (key !== 'captureWeapon') return Array.from(new Set(values));
+  return Array.from(
+    new Set(
+      values
+        .map((value) => resolveSnakeCaptureWeaponId(value))
+        .filter((value) => value && KNOWN_CAPTURE_WEAPON_IDS.has(value))
+    )
+  );
+};
+
 const normalizeInventory = (rawInventory) => {
   const base = copyDefaults();
   if (!rawInventory || typeof rawInventory !== 'object') return base;
   const merged = { ...base };
   Object.entries(rawInventory).forEach(([key, value]) => {
     if (!Array.isArray(value)) return;
-    merged[key] = Array.from(new Set([...(merged[key] || []), ...value]));
+    merged[key] = normalizeInventoryValues(key, [...(merged[key] || []), ...value]);
   });
   return merged;
 };
@@ -67,7 +86,8 @@ export const isSnakeOptionUnlocked = (type, optionId, inventoryOrAccountId) => {
     typeof inventoryOrAccountId === 'string' || !inventoryOrAccountId
       ? getSnakeInventory(inventoryOrAccountId)
       : inventoryOrAccountId;
-  return Array.isArray(inventory?.[type]) && inventory[type].includes(optionId);
+  const resolvedOptionId = type === 'captureWeapon' ? resolveSnakeCaptureWeaponId(optionId) : optionId;
+  return Array.isArray(inventory?.[type]) && inventory[type].includes(resolvedOptionId);
 };
 
 export const addSnakeUnlock = (type, optionId, accountId) => {
@@ -75,7 +95,7 @@ export const addSnakeUnlock = (type, optionId, accountId) => {
   const inventories = readAllInventories();
   const current = normalizeInventory(inventories[resolvedAccountId]);
   const existing = new Set(current[type] || []);
-  existing.add(optionId);
+  existing.add(type === 'captureWeapon' ? resolveSnakeCaptureWeaponId(optionId) : optionId);
   const nextInventory = {
     ...current,
     [type]: Array.from(existing)


### PR DESCRIPTION
### Motivation
- Ensure capture weapon IDs are normalized and aliasable so inventory and catalog entries match reliably across different ID formats.
- Prevent invalid or unknown capture weapon IDs from polluting local storage and fix inconsistent UI behavior when inventory IDs don't match catalog IDs.
- Merge owned inventory weapons with unlocked catalog options so the UI shows a unified, deduplicated list of available capture weapons.

### Description
- Added `SNAKE_CAPTURE_WEAPON_ALIAS_MAP`, `normalizeSnakeWeaponId`, and `resolveSnakeCaptureWeaponId` to `snakeWeaponCatalog.js` to support aliases and normalization of weapon IDs.
- Introduced `resolveCaptureWeaponOptionById` and updated the `ownedCaptureWeapons` `useMemo` in `SnakeAndLadder.jsx` to resolve inventory IDs, merge them with unlocked catalog items, deduplicate by `id`, and fall back to the first catalog item when empty.
- Updated `snakeInventory.js` to normalize stored capture weapon IDs via `normalizeInventoryValues`, maintain a `KNOWN_CAPTURE_WEAPON_IDS` set, and ensure `getSnakeInventory`, `isSnakeOptionUnlocked`, and `addSnakeUnlock` resolve and store canonical IDs for `captureWeapon` values.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f23dc44358832997999336e845f9b4)