### PR TITLE
Refactor human rig cue/grip IK and spawn/update seated player characters

### DIFF
--- a/webapp/src/pages/Games/BilardoShqipGame.tsx
+++ b/webapp/src/pages/Games/BilardoShqipGame.tsx
@@ -93,7 +93,6 @@ const CFG = {
   holdTime: 0.05,
   cueLength: 1.46,
   bridgeDist: 0.24,
-  gripRatio: 0.76,
   edgeMargin: 0.62,
   desiredShootDistance: 1.06,
   poseLambda: 9,
@@ -106,7 +105,15 @@ const CFG = {
   bridgeCueLift: 0.026,
   bridgeHandBackFromBall: 0.245,
   bridgeHandSide: -0.008,
-  gripHandBackOnCue: 0.78,
+  idleRightHandY: 0.8,
+  idleRightHandX: 0.31,
+  idleRightHandZ: -0.015,
+  idleCueGripFromBack: 0.24,
+  shootCueGripFromBack: 0.86,
+  idleCueDir: new THREE.Vector3(0.055, 0.965, -0.13),
+  rightHandRollIdle: -2.2,
+  rightHandRollShoot: -1.05,
+  rightHandCueSocketLocal: new THREE.Vector3(-0.004, -0.014, 0.092),
   chinToCueHeight: 0.11,
   cueArmElbowRise: 0.43,
 };
@@ -599,6 +606,11 @@ function setHandBasis(bone: THREE.Bone | undefined, side: THREE.Vector3, up: THR
   if (Math.abs(roll) > 1e-4) q.multiply(new THREE.Quaternion().setFromAxisAngle(forward.clone().normalize(), roll));
   setBoneWorldQuaternion(bone, bone.getWorldQuaternion(new THREE.Quaternion()).slerp(q, clamp01(strength)));
 }
+function cueSocketOffsetWorld(side: THREE.Vector3, up: THREE.Vector3, forward: THREE.Vector3, roll: number, socketLocal = CFG.rightHandCueSocketLocal) {
+  const q = makeBasisQuaternion(side, up, forward);
+  if (Math.abs(roll) > 1e-5) q.multiply(new THREE.Quaternion().setFromAxisAngle(forward.clone().normalize(), roll));
+  return socketLocal.clone().applyQuaternion(q);
+}
 function poseFingers(fingers: THREE.Bone[], mode: "idle" | "bridge" | "grip", weight: number) {
   const w = clamp01(weight);
   fingers.forEach((finger, i) => {
@@ -680,13 +692,16 @@ function driveHuman(human: HumanRig, frame: HumanFrame) {
     if (b.hips) b.hips.rotation.z -= c * 0.018 * w;
   }
 
-  const rightGrip = frame.rightHandWorld.clone().addScaledVector(cueDir, -0.028 * (0.25 + 0.75 * ik)).addScaledVector(UP, 0.006 * ik);
+  const rightGrip = frame.rightHandWorld.clone();
   const rightIdleElbow = rightGrip.clone().addScaledVector(UP, 0.24 + 0.19 * ik).addScaledVector(frame.side, 0.09).addScaledVector(frame.forward, -0.03 * idle);
   const rightElbow = frame.rightElbow.clone().lerp(rightIdleElbow, idle * 0.68);
   const rightHold = 0.56 + 0.4 * ik;
-  aimTwoBone(b.rightUpperArm, b.rightLowerArm, rightElbow, rightGrip, frame.side.clone().addScaledVector(UP, 0.22).normalize(), rightHold, rightHold);
-  setHandBasis(b.rightHand, frame.side.clone().addScaledVector(UP, -0.08).normalize(), UP.clone().multiplyScalar(0.76).addScaledVector(frame.side, 0.18).addScaledVector(frame.forward, -0.1).normalize(), cueDir, 0.08 * idle + 0.2 * ik + 0.03 * frame.stroke, 0.78 + 0.18 * ik);
-  poseFingers(human.rightFingers, "grip", 0.58 + 0.28 * ik);
+  aimTwoBone(b.rightUpperArm, b.rightLowerArm, rightElbow, rightGrip, frame.side.clone().multiplyScalar(-1).addScaledVector(UP, 0.18).normalize(), rightHold, rightHold);
+  const gripSide = frame.side.clone().multiplyScalar(-1).addScaledVector(UP, lerp(-0.55, -0.24, ik)).addScaledVector(frame.forward, lerp(0.16, 0.05, ik)).normalize();
+  const gripUp = UP.clone().multiplyScalar(lerp(-1.0, 0.6, ik)).addScaledVector(frame.side, lerp(-0.64, -0.28, ik)).addScaledVector(frame.forward, lerp(0.2, -0.1, ik)).normalize();
+  const gripRoll = lerp(CFG.rightHandRollIdle, CFG.rightHandRollShoot, ik) + 0.05 * frame.stroke;
+  setHandBasis(b.rightHand, gripSide, gripUp, cueDir, gripRoll, 1.0);
+  poseFingers(human.rightFingers, "grip", 0.95);
 
   if (ik < 0.025) {
     poseFingers(human.leftFingers, "idle", 1);
@@ -756,8 +771,18 @@ function updateHumanPose(human: HumanRig, dt: number, state: ShotState, rootTarg
   const rightHip = local(new THREE.Vector3(0.13, 0.92, 0.02));
   const leftFoot = local(new THREE.Vector3(-0.13, 0.035, 0.03 + walk * 0.03).lerp(new THREE.Vector3(-CFG.stanceWidth * 0.42, 0.035, -0.36), t));
   const rightFoot = local(new THREE.Vector3(0.13, 0.035, -0.03 - walk * 0.03).lerp(new THREE.Vector3(CFG.stanceWidth * 0.5, 0.035, 0.36), t));
-  const leftHand = idleLeft.clone().lerp(bridgeTarget.clone().addScaledVector(forward, -0.026 * t).addScaledVector(side, -0.018 * t).setY(CFG.tableTopY + CFG.bridgePalmTableLift).addScaledVector(UP, -0.006 * human.settleT), t);
-  const rightHand = idleRight.clone().lerp(gripTarget.clone().addScaledVector(forward, 0.032 * stroke * t + 0.052 * follow * power).addScaledVector(UP, -0.007 * follow), t);
+  const leftHand = idleLeft.clone().lerp(bridgeTarget.clone().addScaledVector(forward, -0.006 * t).addScaledVector(side, -0.012 * t).setY(CFG.tableTopY + CFG.bridgePalmTableLift).addScaledVector(UP, -0.01 * human.settleT), t);
+  const cueDirForHand = cueTip.clone().sub(cueBack).normalize();
+  const handIk = easeInOut(clamp01(t));
+  const idleGripSide = side.clone().multiplyScalar(-1).addScaledVector(UP, -0.55).addScaledVector(forward, 0.16).normalize();
+  const idleGripUp = UP.clone().multiplyScalar(-1).addScaledVector(side, -0.64).addScaledVector(forward, 0.2).normalize();
+  const liveGripSide = side.clone().multiplyScalar(-1).addScaledVector(UP, lerp(-0.55, -0.24, handIk)).addScaledVector(forward, lerp(0.16, 0.05, handIk)).normalize();
+  const liveGripUp = UP.clone().multiplyScalar(lerp(-1.0, 0.6, handIk)).addScaledVector(side, lerp(-0.64, -0.28, handIk)).addScaledVector(forward, lerp(0.2, -0.1, handIk)).normalize();
+  const idleCueGripPoint = idleRight.clone();
+  const liveCueGripPoint = gripTarget.clone().addScaledVector(forward, 0.046 * stroke * t + 0.065 * follow * power);
+  const idleWristTarget = idleCueGripPoint.clone().sub(cueSocketOffsetWorld(idleGripSide, idleGripUp, cueDirForHand, CFG.rightHandRollIdle));
+  const liveWristTarget = liveCueGripPoint.clone().sub(cueSocketOffsetWorld(liveGripSide, liveGripUp, cueDirForHand, lerp(CFG.rightHandRollIdle, CFG.rightHandRollShoot, handIk)));
+  const rightHand = idleWristTarget.clone().lerp(liveWristTarget, t);
   const leftElbow = leftShoulder.clone().lerp(leftHand, 0.57).addScaledVector(UP, 0.02 * t).addScaledVector(side, -0.03 * t).addScaledVector(forward, 0.035 * t);
   const rightElbow = rightHand.clone().addScaledVector(UP, lerp(0.18, CFG.cueArmElbowRise, t)).addScaledVector(side, lerp(0.03, 0.07, t)).addScaledVector(forward, lerp(-0.03, 0, t));
   const leftKnee = leftHip.clone().lerp(leftFoot, 0.53).addScaledVector(UP, lerp(0.18, 0.105, t)).addScaledVector(forward, 0.052 * t).addScaledVector(side, -0.016 * t);
@@ -1117,18 +1142,19 @@ export default function BilardoShqipGame() {
       if (state === "striking") gap = lerp(CFG.idleGap + pull, CFG.contactGap, easeOutCubic(strikeNorm));
       const cueTipShoot = cueBallWorld.clone().addScaledVector(aimForward, -(CFG.ballR + gap));
       const cueBackShoot = bridgeCuePoint.clone().addScaledVector(aimForward, -(CFG.cueLength - CFG.bridgeDist - CFG.ballR - gap)).add(new THREE.Vector3(0, 0.028, 0));
-      const gripHandTarget = cueTipShoot.clone().lerp(cueBackShoot, CFG.gripRatio);
       const standingYaw = yawFromForward(aimForward);
-      const idleRightHandTarget = humanRootTarget.clone().add(new THREE.Vector3(0.24, 1.12, 0.02).applyAxisAngle(Y_AXIS, standingYaw));
+      const idleRightHandTarget = humanRootTarget.clone().add(new THREE.Vector3(CFG.idleRightHandX, CFG.idleRightHandY, CFG.idleRightHandZ).applyAxisAngle(Y_AXIS, standingYaw));
       const idleLeftHandTarget = humanRootTarget.clone().add(new THREE.Vector3(-0.18, 1.08, 0.03).applyAxisAngle(Y_AXIS, standingYaw));
-      let cueBackVisual = cueBackShoot.clone(), cueTipVisual = cueTipShoot.clone();
+      const idleDir = CFG.idleCueDir.clone().applyAxisAngle(Y_AXIS, standingYaw).normalize();
+      const idleCue = cuePoseFromGrip(idleRightHandTarget, idleDir, CFG.idleCueGripFromBack, CFG.cueLength);
+      const shootCueDir = cueTipShoot.clone().sub(cueBackShoot).normalize();
+      const gripHandTarget = cueBackShoot.clone().addScaledVector(shootCueDir, CFG.shootCueGripFromBack);
+      let cueBackVisual = state === "idle" ? idleCue.back : cueBackShoot.clone();
+      let cueTipVisual = state === "idle" ? idleCue.tip : cueTipShoot.clone();
 
       if (state === "idle") {
         strikeT = 0;
         didHit = false;
-        const idleDir = new THREE.Vector3(0.16, 0.74, -0.22).applyAxisAngle(Y_AXIS, standingYaw).normalize();
-        cueBackVisual = idleRightHandTarget.clone().addScaledVector(idleDir, -0.22);
-        cueTipVisual = idleRightHandTarget.clone().addScaledVector(idleDir, 0.96);
       } else if (state === "dragging") {
         strikeT = 0;
         didHit = false;

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -24685,11 +24685,71 @@ const shotPowerRef = useRef(0);
 
       const spawnPlayerCharacters = async () => {
         disposePlayerCharacters();
+        try {
+          const template = await loadSeatedHumanTemplate();
+          const rig = createPlayerCharacterRig({
+            seat: 'A',
+            x: 0,
+            z: TABLE.H * 0.68,
+            facingY: Math.PI,
+            template
+          });
+          scene.add(rig);
+          playerCharacterRigsRef.current = [rig];
+        } catch (error) {
+          const rig = createPlayerCharacterRig({
+            seat: 'A',
+            x: 0,
+            z: TABLE.H * 0.68,
+            facingY: Math.PI,
+            template: null
+          });
+          scene.add(rig);
+          playerCharacterRigsRef.current = [rig];
+          console.warn('Pool Royale fallback human rig enabled', error);
+        }
       };
 
       const updatePlayerCharacters = (nowMs, dtSeconds) => {
+        const rigs = playerCharacterRigsRef.current;
+        if (!Array.isArray(rigs) || !rigs.length || !cue?.pos) return;
+        const aim = aimDirRef.current?.clone?.() ?? new THREE.Vector2(0, 1);
+        if (aim.lengthSq() < 1e-6) aim.set(0, 1);
+        aim.normalize();
+        const aimForward = new THREE.Vector3(aim.x, 0, aim.y).normalize();
+        const side = new THREE.Vector3(aimForward.z, 0, -aimForward.x).normalize();
+        const cueBallWorld = new THREE.Vector3(cue.pos.x, TABLE_Y + BALL_CENTER_Y, cue.pos.y);
+        const desiredDist = TABLE.H * 0.25;
+        const edgeX = PLAY_W / 2 + BALL_R * 8.4;
+        const edgeZ = PLAY_H / 2 + BALL_R * 8.4;
+        const desired = cueBallWorld.clone().addScaledVector(aimForward, -desiredDist);
+        const candidates = [
+          new THREE.Vector3(-edgeX, floorY, THREE.MathUtils.clamp(desired.z, -edgeZ, edgeZ)),
+          new THREE.Vector3(edgeX, floorY, THREE.MathUtils.clamp(desired.z, -edgeZ, edgeZ)),
+          new THREE.Vector3(THREE.MathUtils.clamp(desired.x, -edgeX, edgeX), floorY, -edgeZ),
+          new THREE.Vector3(THREE.MathUtils.clamp(desired.x, -edgeX, edgeX), floorY, edgeZ)
+        ];
+        const rootTarget = candidates.sort((a, b) => a.distanceToSquared(desired) - b.distanceToSquared(desired))[0];
+        rigs.forEach((rig) => {
+          const anim = rig?.userData?.anim;
+          if (!anim) return;
+          anim.rootTarget = anim.rootTarget || rig.position.clone();
+          const smooth = 1 - Math.exp(-Math.max(0.0001, dtSeconds) * 5.6);
+          anim.rootTarget.lerp(rootTarget, smooth);
+          rig.position.copy(anim.rootTarget);
+          const yawTarget = Math.atan2(-aimForward.x, -aimForward.z);
+          anim.yaw = THREE.MathUtils.lerp(anim.yaw ?? rig.rotation.y, yawTarget, 1 - Math.exp(-Math.max(0.0001, dtSeconds) * 8.5));
+          rig.rotation.y = anim.yaw;
+        });
+        const bridgeTarget = cueBallWorld.clone().addScaledVector(aimForward, -BALL_R * 4.25).addScaledVector(side, -BALL_R * 0.25).setY(TABLE_Y + TABLE.THICK + BALL_R * 0.7);
+        const cueBack = cueBallWorld.clone().addScaledVector(aimForward, -BALL_R * 10.6).addScaledVector(UP, BALL_R * 0.4);
+        activeHumanCueViewRef.current = {
+          cueBack,
+          bridgeTarget,
+          aimForward,
+          side
+        };
         void nowMs;
-        void dtSeconds;
       };
 
       void spawnPlayerCharacters();


### PR DESCRIPTION
### Motivation
- Improve realism and robustness of the human rig by replacing a single `gripRatio` with explicit idle/grip socket transforms and hand-roll parameters to better align the cue in both idle and shooting states.
- Reduce fragile hardcoded idle pose math by introducing reusable helper math for cue socket offsets and clearer grip point computation.
- Add seated player character spawning and smoother positioning for the Pool Royale secondary scene with a fallback when template loading fails.

### Description
- Replace `CFG.gripRatio` with explicit configuration fields (`idleRightHandX/Y/Z`, `idleCueGripFromBack`, `shootCueGripFromBack`, `idleCueDir`, `rightHandRollIdle`, `rightHandRollShoot`, and `rightHandCueSocketLocal`) and remove the old `gripHandBackOnCue` field. 
- Add `cueSocketOffsetWorld` helper to compute socket offsets in world space and use it to compute wrist/hand IK targets, update right-hand basis/roll logic, and increase finger grip weight for a firmer grip pose. 
- Rework `updateHumanPose`/`driveHuman` calculations to compute `idleCue` vs shoot cue, compute `idle` vs `live` grip side/up vectors, and interpolate wrist targets to reduce visual popping between idle/dragging/striking states. 
- Modify main animation `animate` to compute `idleRightHandTarget` using new CFG fields, compute an idle cue pose with `cuePoseFromGrip`, compute `gripHandTarget` from `CFG.shootCueGripFromBack`, and select visual cue tip/back based on state. 
- In `PoolRoyale.jsx` add seated human template loading when spawning player characters with a try/catch fallback to a null-template rig and a console warning on failure. 
- Implement `updatePlayerCharacters` to early-return when no rigs/cue are present, compute desired root target around the table edge based on `aim`, smoothly lerp rig `rootTarget` and yaw for stable positioning, and publish `activeHumanCueViewRef.current` containing `cueBack`, `bridgeTarget`, `aimForward`, and `side` for use by other systems.

### Testing
- Ran TypeScript type-check (`tsc --noEmit`) and the project linting (`yarn lint`) which completed without type or lint errors. 
- Built the webapp (`yarn build`) to validate integration of the changed modules and the build succeeded. 
- Ran the test suite (`yarn test`) and the automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f23b5429e4832998d6a72d7b889b4e)