### PR TITLE
Human dice pickup animation before advancing turn

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -8200,10 +8200,6 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
   const resolveDiceHoldContactTarget = (player, fallbackTarget = null) => {
     const dice = diceRef.current;
     if (!dice?.isObject3D) return fallbackTarget ?? null;
-    if (player === 0) {
-      // Keep local/human turn start anchored on the board rail so users see exactly where to tap to roll.
-      return fallbackTarget ?? null;
-    }
     const actorEntry = seatedHumanActorsRef.current?.find((entry) => entry?.playerIndex === player);
     if (!actorEntry) return fallbackTarget ?? null;
     const helperWorld = new THREE.Vector3();
@@ -8239,6 +8235,28 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       duration: 260,
       lift: 0.03,
       onComplete: () => beginDiceHoldPose(player)
+    });
+  };
+
+  const animateHumanDicePickupBeforeTurnAdvance = async () => {
+    const state = stateRef.current;
+    const dice = diceRef.current;
+    if (!state || !dice?.isObject3D || dice.userData?.isRolling) return;
+    if (state.turn !== 0 || state.winner || state.animation) return;
+
+    const handTarget = resolveDiceHoldContactTarget(0, null);
+    if (!handTarget?.isVector3) return;
+
+    beginDiceHoldPose(0);
+    await new Promise((resolve) => {
+      animateDicePosition(dice, handTarget, {
+        duration: 300,
+        lift: 0.028,
+        onComplete: resolve
+      });
+    });
+    await new Promise((resolve) => {
+      window.setTimeout(resolve, 170);
     });
   };
 
@@ -11766,7 +11784,8 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     }, 2000 + DICE_RESULT_EXTRA_HOLD_MS);
   }, [setUi]);
 
-  const advanceTurn = (extraTurn) => {
+  const advanceTurn = async (extraTurn) => {
+    await animateHumanDicePickupBeforeTurnAdvance();
     clearTurnAdvanceTimeout();
     clearHumanSelection();
     cancelCameraFocusAnimation();


### PR DESCRIPTION
### Motivation
- Improve the visual handoff when the human player finishes a dice roll so the seated character visibly reaches, grasps, and holds the dice before the next player's turn begins. 

### Description
- Remove the hard early-return for `player === 0` in `resolveDiceHoldContactTarget` so the human seat action helpers (`diceHold` / `dicePickup`) are sampled for player 0 rather than always snapping to the rail fallback. 
- Add `animateHumanDicePickupBeforeTurnAdvance` which uses `beginDiceHoldPose` and `animateDicePosition` to move the dice into the human hand while keeping the character seated and briefly hold it for readability. 
- Make `advanceTurn` asynchronous and `await` the new pickup sequence so the dice pickup is completed before the turn state and camera are updated. 
- File changed: `webapp/src/pages/Games/LudoBattleRoyal.jsx` (dice target resolution + pickup animation + `advanceTurn` update). 

### Testing
- Ran a repository validation diff check showing the updated `webapp/src/pages/Games/LudoBattleRoyal.jsx` (succeeded). 
- Attempted to run lint with `npm -C webapp run -s eslint -- src/pages/Games/LudoBattleRoyal.jsx`, which failed because the `webapp/package.json` does not expose an `eslint` script in `scripts` (no lint run performed). 
- Queried `webapp/package.json` scripts via `node -e` to confirm available scripts (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f248218a8c832990eee4e4d28bb86f)