### PR TITLE
Keep human dice at landed position so seated actor reaches and picks up before next throw

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -8226,6 +8226,15 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     if (!dice) return;
     const rails = dice.userData?.railPositions;
     if (!rails || !rails[player]) return;
+
+    if (player === 0 && !immediate) {
+      // On human turns keep the dice where it landed so the seated actor can bend from the torso,
+      // reach to that exact table spot, and grab it before the next throw.
+      stopDiceTransition();
+      beginDiceHoldPose(player, { startMs: performance.now() - 220 });
+      return;
+    }
+
     const railTarget = rails[player].clone ? rails[player].clone() : new THREE.Vector3().copy(rails[player]);
     const target = resolveDiceHoldContactTarget(player, railTarget) ?? railTarget;
     if (immediate) {


### PR DESCRIPTION
### Motivation
- Improve the human player's animation flow so the seated human remains grounded and bends the upper body to reach the exact table spot where the dice landed before picking it up and throwing again.
- Avoid snapping the dice back to the rail for the local player so the reach/grab animation aligns with the dice landing position.

### Description
- Modified `moveDiceToRail` in `webapp/src/pages/Games/LudoBattleRoyal.jsx` to early-return when `player === 0 && !immediate`, calling `stopDiceTransition()` and `beginDiceHoldPose(player, { startMs: performance.now() - 220 })` so the dice remains at the landed table position for the human actor.
- Preserved existing behavior for AI turns and immediate placements so non-human flows and initialization still animate to the rail as before.
- No other animation, camera or token logic was changed; the adjustment only affects where the dice is positioned and the seated-human pose state at the start of a human turn.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f248218a8c832990eee4e4d28bb86f)