### PR TITLE
Pool Royale: prefer GLTF human model and preserve 10am character size

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1946,7 +1946,8 @@ const CUE_FOLLOW_THROUGH_MIN = BALL_R * 3.9; // keep low-power shots visibly pus
 const CUE_FOLLOW_THROUGH_MAX = BALL_R * 8.4; // extend top-end follow-through so powerful shots visibly punch forward
 const MIN_SHOT_POWER_TO_FIRE = BILARDO_MIN_RELEASE_POWER; // keep Pool Royale release gate identical to Bilardo Shqip
 const HUMAN_PLAYER_HEIGHT_RATIO_TO_TABLE = 0.96; // increase player size so body/table proportions match Bilardo-like framing
-const BILARDO_SHQIP_HUMAN_URL = 'https://threejs.org/examples/models/gltf/readyplayer.me.glb';
+const BILARDO_SHQIP_HUMAN_GLTF_URL = 'https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/models/gltf/readyplayer.me/scene.gltf';
+const BILARDO_SHQIP_HUMAN_GLB_URL = 'https://threejs.org/examples/models/gltf/readyplayer.me.glb';
 const POOL_ROYALE_HUMAN_SCALE_MULTIPLIER = 42.0; // make the shooter ~4x larger than the previous size for portrait-phone readability
 const HUMAN_PLAYER_IDLE_SWAY_SPEED = 1.2;
 const HUMAN_PLAYER_IDLE_SWAY_ANGLE = 0.04;
@@ -19716,7 +19717,10 @@ const shotPowerRef = useRef(0);
         if (seatedHumanLoadRef.current) {
           return seatedHumanLoadRef.current;
         }
-        seatedHumanLoadRef.current = loadFirstAvailableGltf([BILARDO_SHQIP_HUMAN_URL])
+        seatedHumanLoadRef.current = loadFirstAvailableGltf([
+          BILARDO_SHQIP_HUMAN_GLTF_URL,
+          BILARDO_SHQIP_HUMAN_GLB_URL
+        ])
           .then((gltf) => {
             const model = gltf?.scene?.clone?.(true) ?? gltf?.scene ?? gltf?.scenes?.[0] ?? null;
             if (!model) {


### PR DESCRIPTION
### Motivation
- Use a GLTF human character source as requested while keeping the in-game human size exactly as it was this morning for visual parity.

### Description
- Introduces `BILARDO_SHQIP_HUMAN_GLTF_URL` and `BILARDO_SHQIP_HUMAN_GLB_URL` and prefers the GLTF URL first when loading the seated human asset.
- Updates the `ensureSeatedHumanTemplate` loader to call `loadFirstAvailableGltf` with the GLTF URL first and the GLB URL as a fallback.
- Leaves `HUMAN_PLAYER_HEIGHT_RATIO_TO_TABLE` and `POOL_ROYALE_HUMAN_SCALE_MULTIPLIER` unchanged so the character size remains identical to the earlier calibration.

### Testing
- Verified the file diff for `webapp/src/pages/Games/PoolRoyale.jsx` contains the new constants and the reordered loader call.
- Ran a symbol search (`rg -n`) to confirm the new constant names and the updated loader invocation are present.
- Inspected the modified lines for syntax consistency to ensure no obvious JS/JSX errors were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f24ae512608329aaea4f564d232173)