### PR TITLE
Improve seated dice pickup posture and battle-royale camera dynamics

### DIFF
--- a/Assets/Scripts/Gameplay/Weapons/BattleRoyaleWeaponDirector.cs
+++ b/Assets/Scripts/Gameplay/Weapons/BattleRoyaleWeaponDirector.cs
@@ -84,6 +84,7 @@ namespace TonPlaygram.Gameplay.Weapons
         [SerializeField] private Vector3 firstPersonAimOffset = new Vector3(0.08f, -0.04f, 0.18f);
         [SerializeField] private float aimPositionLerp = 20f;
         [SerializeField] private bool followAllBullets = true;
+        [SerializeField] private bool forceAttackerAimAnchor = true;
         [SerializeField] private float bulletFollowDistance = 0.4f;
         [SerializeField] private float bulletFollowHeight = 0.14f;
         [SerializeField] private float cameraLookLerp = 18f;
@@ -221,7 +222,7 @@ namespace TonPlaygram.Gameplay.Weapons
                 }
 
                 bool isLeadPellet = pelletIndex == 0;
-                bool shouldFollowBullet = isLeadPellet && (followAllBullets || isLastBullet);
+                bool shouldFollowBullet = isLeadPellet && (followAllBullets || isLastBullet || weapon.usesPellets);
                 bullet.Initialize(pelletDirection * weapon.muzzleVelocity, this, weapon.weaponType, shotIndex, pelletIndex, isLastBullet, shouldFollowBullet, weapon.impactFollowSeconds);
                 BroadcastProjectileSpawned(weapon.weaponType, shotIndex, pelletIndex, muzzle.position, pelletDirection * weapon.muzzleVelocity);
                 if (shouldFollowBullet)
@@ -369,6 +370,11 @@ namespace TonPlaygram.Gameplay.Weapons
 
         private IEnumerator AimViewRoutine(WeaponBallisticsProfile weapon)
         {
+            if (forceAttackerAimAnchor && attackerCameraAnchor != null && playerCamera.transform.parent != attackerCameraAnchor)
+            {
+                playerCamera.transform.SetParent(attackerCameraAnchor, true);
+            }
+
             float elapsed = 0f;
             float duration = Mathf.Max(0.01f, weapon.aimTransitionSeconds);
             float startFov = playerCamera.fieldOfView;
@@ -387,11 +393,6 @@ namespace TonPlaygram.Gameplay.Weapons
                 }
 
                 playerCamera.fieldOfView = Mathf.Lerp(startFov, weapon.aimFov, t);
-                if (attackerCameraAnchor != null && playerCamera.transform.parent != attackerCameraAnchor)
-                {
-                    playerCamera.transform.SetParent(attackerCameraAnchor, true);
-                }
-
                 playerCamera.transform.localPosition = Vector3.Lerp(startPos, targetLocalPos, Mathf.Clamp01(Time.deltaTime * aimPositionLerp));
                 Quaternion toTarget = Quaternion.LookRotation((targetWorld - playerCamera.transform.position).normalized, Vector3.up);
                 playerCamera.transform.rotation = Quaternion.Slerp(playerCamera.transform.rotation, toTarget, Mathf.Clamp01(Time.deltaTime * cameraLookLerp));
@@ -459,6 +460,11 @@ namespace TonPlaygram.Gameplay.Weapons
 
         private IEnumerator ReturnCameraToDefault()
         {
+            if (forceAttackerAimAnchor && attackerCameraAnchor != null && playerCamera.transform.parent != attackerCameraAnchor)
+            {
+                playerCamera.transform.SetParent(attackerCameraAnchor, true);
+            }
+
             float elapsed = 0f;
             const float duration = 0.2f;
             float fromFov = playerCamera.fieldOfView;

--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -5696,6 +5696,7 @@ function applySeatedHumanPose(
   let headX = -0.06;
   let headY = 0;
   const bodyLockedMode = mode !== 'idle';
+  const isDiceReachMode = mode === 'reachDice' || mode === 'gripDice';
 
   if (mode === 'firearmAim') {
     shoulderX = THREE.MathUtils.lerp(shoulderX, -0.96, t);
@@ -5755,25 +5756,29 @@ function applySeatedHumanPose(
     chestX = THREE.MathUtils.lerp(chestX, 0.24, t);
     headX = THREE.MathUtils.lerp(headX, -0.18, t);
   } else if (mode === 'reachDice') {
-    shoulderX = THREE.MathUtils.lerp(shoulderX, -0.78, t);
-    shoulderY = THREE.MathUtils.lerp(shoulderY, -0.08, t);
-    shoulderZ = THREE.MathUtils.lerp(shoulderZ, -1.06, t);
-    forearmX = THREE.MathUtils.lerp(forearmX, -1.02, t);
-    forearmY = THREE.MathUtils.lerp(forearmY, -0.18, t);
-    forearmZ = THREE.MathUtils.lerp(forearmZ, -0.34, t);
-    wristX = THREE.MathUtils.lerp(wristX, -0.5, t);
-    wristY = THREE.MathUtils.lerp(wristY, 0.1, t);
-    wristZ = THREE.MathUtils.lerp(wristZ, -0.34, t);
+    shoulderX = THREE.MathUtils.lerp(shoulderX, -0.86, t);
+    shoulderY = THREE.MathUtils.lerp(shoulderY, -0.16, t);
+    shoulderZ = THREE.MathUtils.lerp(shoulderZ, -1.14, t);
+    forearmX = THREE.MathUtils.lerp(forearmX, -1.18, t);
+    forearmY = THREE.MathUtils.lerp(forearmY, -0.26, t);
+    forearmZ = THREE.MathUtils.lerp(forearmZ, -0.44, t);
+    wristX = THREE.MathUtils.lerp(wristX, -0.58, t);
+    wristY = THREE.MathUtils.lerp(wristY, 0.14, t);
+    wristZ = THREE.MathUtils.lerp(wristZ, -0.42, t);
+    chestX = THREE.MathUtils.lerp(chestX, 0.34, t);
+    headX = THREE.MathUtils.lerp(headX, -0.2, t);
   } else if (mode === 'gripDice') {
-    shoulderX = THREE.MathUtils.lerp(shoulderX, -0.76, t);
-    shoulderY = THREE.MathUtils.lerp(shoulderY, -0.10, t);
-    shoulderZ = THREE.MathUtils.lerp(shoulderZ, -0.92, t);
-    forearmX = THREE.MathUtils.lerp(forearmX, -0.98, t);
-    forearmY = THREE.MathUtils.lerp(forearmY, -0.22, t);
-    forearmZ = THREE.MathUtils.lerp(forearmZ, -0.12, t);
-    wristX = THREE.MathUtils.lerp(wristX, -0.54, t);
-    wristY = THREE.MathUtils.lerp(wristY, 0.08, t);
-    wristZ = THREE.MathUtils.lerp(wristZ, -0.2, t);
+    shoulderX = THREE.MathUtils.lerp(shoulderX, -0.84, t);
+    shoulderY = THREE.MathUtils.lerp(shoulderY, -0.18, t);
+    shoulderZ = THREE.MathUtils.lerp(shoulderZ, -1.02, t);
+    forearmX = THREE.MathUtils.lerp(forearmX, -1.12, t);
+    forearmY = THREE.MathUtils.lerp(forearmY, -0.28, t);
+    forearmZ = THREE.MathUtils.lerp(forearmZ, -0.2, t);
+    wristX = THREE.MathUtils.lerp(wristX, -0.62, t);
+    wristY = THREE.MathUtils.lerp(wristY, 0.12, t);
+    wristZ = THREE.MathUtils.lerp(wristZ, -0.28, t);
+    chestX = THREE.MathUtils.lerp(chestX, 0.3, t);
+    headX = THREE.MathUtils.lerp(headX, -0.18, t);
   } else if (mode === 'holdDice') {
     shoulderX = THREE.MathUtils.lerp(shoulderX, -0.5, t);
     shoulderY = THREE.MathUtils.lerp(shoulderY, -0.18, t);
@@ -5875,7 +5880,7 @@ function applySeatedHumanPose(
     forearmZ = THREE.MathUtils.lerp(forearmZ, 0.28, t);
   }
 
-  if (bodyLockedMode) {
+  if (bodyLockedMode && !isDiceReachMode) {
     chestX = 0.12;
     chestY = 0;
     headX = -0.06;


### PR DESCRIPTION
### Motivation
- Characters reaching for dice needed a slightly more forward upper-body bend and stronger right-arm extension while remaining seated and grounded to match the reference photo. 
- Cinematic attack playback should reliably present the attacker’s aim and follow projectiles (including pellets) so bullet/shotgun attacks produce more cinematic, player-focused camera coverage. 
- Provide a simple inspector toggle to control attacker-anchor enforcement so designers can tune broadcasted attack camera behavior without code changes.

### Description
- Tuned seated human pose values for `reachDice` and `gripDice` in `webapp/src/pages/Games/LudoBattleRoyal.jsx` and added `isDiceReachMode` to avoid forcing chest/head neutral during those dice reach/grip modes so the upper body remains slightly leaned forward. 
- Extended dice reach/grip pose adjustments to increase forearm/hand extension and added modest chest/head forward offsets to produce a more natural seated reach. 
- In `Assets/Scripts/Gameplay/Weapons/BattleRoyaleWeaponDirector.cs` added a serialized `forceAttackerAimAnchor` toggle and ensured the `playerCamera` is parented to the `attackerCameraAnchor` at the start of aim transitions and on return-to-default to snap the view to the attacker. 
- Ensured pellet-based weapons set the lead pellet to be followed by the camera by changing projectile follow logic so shotgun-style attacks can trigger the bullet-follow camera for cinematic tracking.

### Testing
- Inspected modified file ranges and verified code changes in `webapp/src/pages/Games/LudoBattleRoyal.jsx` and `Assets/Scripts/Gameplay/Weapons/BattleRoyaleWeaponDirector.cs` using `nl`/`sed` and pattern searches, and confirmed the updated pose and camera-anchor lines are present. 
- Ran automated repository text searches with `rg` to validate the animation and ballistics code paths were updated as intended. 
- All verification commands completed successfully (diff/inspection/search outputs matched expected edits).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2531a23dc8329b0d609c374bb671f)