### PR TITLE
Rename BILARDO_SHQIP_HUMAN_URL to BILARDO_SHQIP_HUMAN_GLB_URL and update usage

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1946,7 +1946,7 @@ const CUE_FOLLOW_THROUGH_MIN = BALL_R * 3.9; // keep low-power shots visibly pus
 const CUE_FOLLOW_THROUGH_MAX = BALL_R * 8.4; // extend top-end follow-through so powerful shots visibly punch forward
 const MIN_SHOT_POWER_TO_FIRE = BILARDO_MIN_RELEASE_POWER; // keep Pool Royale release gate identical to Bilardo Shqip
 const HUMAN_PLAYER_HEIGHT_RATIO_TO_TABLE = 0.96; // increase player size so body/table proportions match Bilardo-like framing
-const BILARDO_SHQIP_HUMAN_URL = 'https://threejs.org/examples/models/gltf/readyplayer.me.glb';
+const BILARDO_SHQIP_HUMAN_GLB_URL = 'https://threejs.org/examples/models/gltf/readyplayer.me.glb';
 const POOL_ROYALE_HUMAN_SCALE_MULTIPLIER = 42.0; // make the shooter ~4x larger than the previous size for portrait-phone readability
 const HUMAN_PLAYER_IDLE_SWAY_SPEED = 1.2;
 const HUMAN_PLAYER_IDLE_SWAY_ANGLE = 0.04;
@@ -19716,7 +19716,7 @@ const shotPowerRef = useRef(0);
         if (seatedHumanLoadRef.current) {
           return seatedHumanLoadRef.current;
         }
-        seatedHumanLoadRef.current = loadFirstAvailableGltf([BILARDO_SHQIP_HUMAN_URL])
+        seatedHumanLoadRef.current = loadFirstAvailableGltf([BILARDO_SHQIP_HUMAN_GLB_URL])
           .then((gltf) => {
             const model = gltf?.scene?.clone?.(true) ?? gltf?.scene ?? gltf?.scenes?.[0] ?? null;
             if (!model) {


### PR DESCRIPTION
### Motivation
- Clarify the constant name to indicate the asset is a GLB model file and make the identifier more explicit.

### Description
- Renamed `BILARDO_SHQIP_HUMAN_URL` to `BILARDO_SHQIP_HUMAN_GLB_URL` and updated the `loadFirstAvailableGltf` call in `PoolRoyale.jsx` to use the new constant.

### Testing
- No automated tests were run for this trivial rename; change is limited to a constant rename and its single usage in the webapp source.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f24ae512608329aaea4f564d232173)