### PR TITLE
Restore Pool Royale to Apr 29 16:00 baseline

### DIFF
--- a/Assets/Scripts/Gameplay/Weapons/BattleRoyaleWeaponDirector.cs
+++ b/Assets/Scripts/Gameplay/Weapons/BattleRoyaleWeaponDirector.cs
@@ -68,8 +68,6 @@ namespace TonPlaygram.Gameplay.Weapons
         [SerializeField] private Transform attackerCameraAnchor;
         [SerializeField] private Transform liveTargetTransform;
         [SerializeField] private Transform weaponRoot;
-        [SerializeField] private Transform tableWeaponAnchor;
-        [SerializeField] private Transform weaponSwapIcon;
         [SerializeField] private Transform rightHandGrip;
         [SerializeField] private Transform leftHandGrip;
 
@@ -84,12 +82,10 @@ namespace TonPlaygram.Gameplay.Weapons
         [SerializeField] private Vector3 firstPersonAimOffset = new Vector3(0.08f, -0.04f, 0.18f);
         [SerializeField] private float aimPositionLerp = 20f;
         [SerializeField] private bool followAllBullets = true;
-        [SerializeField] private bool forceAttackerAimAnchor = true;
         [SerializeField] private float bulletFollowDistance = 0.4f;
         [SerializeField] private float bulletFollowHeight = 0.14f;
         [SerializeField] private float cameraLookLerp = 18f;
         [SerializeField] private float cameraTrackLerp = 15f;
-        [SerializeField] private Vector3 swapIconWorldOffset = new Vector3(0f, 0.11f, 0f);
 
         private readonly Dictionary<LudoWeaponType, WeaponBallisticsProfile> _profiles = new Dictionary<LudoWeaponType, WeaponBallisticsProfile>();
         private readonly List<TokenPieceHealth> _tokenPieces = new List<TokenPieceHealth>();
@@ -103,10 +99,6 @@ namespace TonPlaygram.Gameplay.Weapons
         private Vector3 _baseCameraLocalPos;
         private Transform _baseCameraParent;
         private Quaternion _baseCameraLocalRot;
-        private Vector3 _weaponRootLocalPos;
-        private Quaternion _weaponRootLocalRot;
-        private Vector3 _swapIconWorldPos;
-        private Quaternion _swapIconWorldRot;
 
         private void Awake()
         {
@@ -130,7 +122,6 @@ namespace TonPlaygram.Gameplay.Weapons
 
             BuildProfileMap();
             CacheTokenPieces();
-            CacheStaticAnchors();
             _eventListeners = GetComponentsInParent<ILudoWeaponEvents>(true);
             _projectileListeners = GetComponentsInParent<ILudoProjectileBroadcastEvents>(true);
             Equip(startingWeapon);
@@ -222,7 +213,7 @@ namespace TonPlaygram.Gameplay.Weapons
                 }
 
                 bool isLeadPellet = pelletIndex == 0;
-                bool shouldFollowBullet = isLeadPellet && (followAllBullets || isLastBullet || weapon.usesPellets);
+                bool shouldFollowBullet = isLeadPellet && (followAllBullets || isLastBullet);
                 bullet.Initialize(pelletDirection * weapon.muzzleVelocity, this, weapon.weaponType, shotIndex, pelletIndex, isLastBullet, shouldFollowBullet, weapon.impactFollowSeconds);
                 BroadcastProjectileSpawned(weapon.weaponType, shotIndex, pelletIndex, muzzle.position, pelletDirection * weapon.muzzleVelocity);
                 if (shouldFollowBullet)
@@ -350,8 +341,8 @@ namespace TonPlaygram.Gameplay.Weapons
         {
             if (weaponRoot != null)
             {
-                weaponRoot.localPosition = _weaponRootLocalPos;
-                weaponRoot.localRotation = _weaponRootLocalRot;
+                weaponRoot.position = muzzle.position;
+                weaponRoot.rotation = Quaternion.LookRotation(shotDirection, Vector3.up);
             }
 
             if (rightHandGrip != null)
@@ -370,11 +361,6 @@ namespace TonPlaygram.Gameplay.Weapons
 
         private IEnumerator AimViewRoutine(WeaponBallisticsProfile weapon)
         {
-            if (forceAttackerAimAnchor && attackerCameraAnchor != null && playerCamera.transform.parent != attackerCameraAnchor)
-            {
-                playerCamera.transform.SetParent(attackerCameraAnchor, true);
-            }
-
             float elapsed = 0f;
             float duration = Mathf.Max(0.01f, weapon.aimTransitionSeconds);
             float startFov = playerCamera.fieldOfView;
@@ -393,6 +379,11 @@ namespace TonPlaygram.Gameplay.Weapons
                 }
 
                 playerCamera.fieldOfView = Mathf.Lerp(startFov, weapon.aimFov, t);
+                if (attackerCameraAnchor != null && playerCamera.transform.parent != attackerCameraAnchor)
+                {
+                    playerCamera.transform.SetParent(attackerCameraAnchor, true);
+                }
+
                 playerCamera.transform.localPosition = Vector3.Lerp(startPos, targetLocalPos, Mathf.Clamp01(Time.deltaTime * aimPositionLerp));
                 Quaternion toTarget = Quaternion.LookRotation((targetWorld - playerCamera.transform.position).normalized, Vector3.up);
                 playerCamera.transform.rotation = Quaternion.Slerp(playerCamera.transform.rotation, toTarget, Mathf.Clamp01(Time.deltaTime * cameraLookLerp));
@@ -460,11 +451,6 @@ namespace TonPlaygram.Gameplay.Weapons
 
         private IEnumerator ReturnCameraToDefault()
         {
-            if (forceAttackerAimAnchor && attackerCameraAnchor != null && playerCamera.transform.parent != attackerCameraAnchor)
-            {
-                playerCamera.transform.SetParent(attackerCameraAnchor, true);
-            }
-
             float elapsed = 0f;
             const float duration = 0.2f;
             float fromFov = playerCamera.fieldOfView;
@@ -506,51 +492,6 @@ namespace TonPlaygram.Gameplay.Weapons
                     continue;
 
                 _profiles[profile.weaponType] = profile;
-            }
-        }
-
-        private void LateUpdate()
-        {
-            MaintainStaticPresentationAnchors();
-        }
-
-        private void CacheStaticAnchors()
-        {
-            if (weaponRoot != null)
-            {
-                _weaponRootLocalPos = weaponRoot.localPosition;
-                _weaponRootLocalRot = weaponRoot.localRotation;
-            }
-
-            if (weaponSwapIcon != null)
-            {
-                Transform iconAnchor = tableWeaponAnchor != null ? tableWeaponAnchor : weaponRoot;
-                if (iconAnchor != null)
-                {
-                    _swapIconWorldPos = iconAnchor.position + swapIconWorldOffset;
-                    _swapIconWorldRot = weaponSwapIcon.rotation;
-                    weaponSwapIcon.position = _swapIconWorldPos;
-                }
-                else
-                {
-                    _swapIconWorldPos = weaponSwapIcon.position;
-                    _swapIconWorldRot = weaponSwapIcon.rotation;
-                }
-            }
-        }
-
-        private void MaintainStaticPresentationAnchors()
-        {
-            if (weaponRoot != null)
-            {
-                weaponRoot.localPosition = _weaponRootLocalPos;
-                weaponRoot.localRotation = _weaponRootLocalRot;
-            }
-
-            if (weaponSwapIcon != null)
-            {
-                weaponSwapIcon.position = _swapIconWorldPos;
-                weaponSwapIcon.rotation = _swapIconWorldRot;
             }
         }
 

--- a/webapp/src/pages/Games/BilardoShqipGame.tsx
+++ b/webapp/src/pages/Games/BilardoShqipGame.tsx
@@ -93,6 +93,7 @@ const CFG = {
   holdTime: 0.05,
   cueLength: 1.46,
   bridgeDist: 0.24,
+  gripRatio: 0.76,
   edgeMargin: 0.62,
   desiredShootDistance: 1.06,
   poseLambda: 9,
@@ -105,15 +106,7 @@ const CFG = {
   bridgeCueLift: 0.026,
   bridgeHandBackFromBall: 0.245,
   bridgeHandSide: -0.008,
-  idleRightHandY: 0.8,
-  idleRightHandX: 0.31,
-  idleRightHandZ: -0.015,
-  idleCueGripFromBack: 0.24,
-  shootCueGripFromBack: 0.86,
-  idleCueDir: new THREE.Vector3(0.055, 0.965, -0.13),
-  rightHandRollIdle: -2.2,
-  rightHandRollShoot: -1.05,
-  rightHandCueSocketLocal: new THREE.Vector3(-0.004, -0.014, 0.092),
+  gripHandBackOnCue: 0.78,
   chinToCueHeight: 0.11,
   cueArmElbowRise: 0.43,
 };
@@ -606,11 +599,6 @@ function setHandBasis(bone: THREE.Bone | undefined, side: THREE.Vector3, up: THR
   if (Math.abs(roll) > 1e-4) q.multiply(new THREE.Quaternion().setFromAxisAngle(forward.clone().normalize(), roll));
   setBoneWorldQuaternion(bone, bone.getWorldQuaternion(new THREE.Quaternion()).slerp(q, clamp01(strength)));
 }
-function cueSocketOffsetWorld(side: THREE.Vector3, up: THREE.Vector3, forward: THREE.Vector3, roll: number, socketLocal = CFG.rightHandCueSocketLocal) {
-  const q = makeBasisQuaternion(side, up, forward);
-  if (Math.abs(roll) > 1e-5) q.multiply(new THREE.Quaternion().setFromAxisAngle(forward.clone().normalize(), roll));
-  return socketLocal.clone().applyQuaternion(q);
-}
 function poseFingers(fingers: THREE.Bone[], mode: "idle" | "bridge" | "grip", weight: number) {
   const w = clamp01(weight);
   fingers.forEach((finger, i) => {
@@ -692,16 +680,13 @@ function driveHuman(human: HumanRig, frame: HumanFrame) {
     if (b.hips) b.hips.rotation.z -= c * 0.018 * w;
   }
 
-  const rightGrip = frame.rightHandWorld.clone();
+  const rightGrip = frame.rightHandWorld.clone().addScaledVector(cueDir, -0.028 * (0.25 + 0.75 * ik)).addScaledVector(UP, 0.006 * ik);
   const rightIdleElbow = rightGrip.clone().addScaledVector(UP, 0.24 + 0.19 * ik).addScaledVector(frame.side, 0.09).addScaledVector(frame.forward, -0.03 * idle);
   const rightElbow = frame.rightElbow.clone().lerp(rightIdleElbow, idle * 0.68);
   const rightHold = 0.56 + 0.4 * ik;
-  aimTwoBone(b.rightUpperArm, b.rightLowerArm, rightElbow, rightGrip, frame.side.clone().multiplyScalar(-1).addScaledVector(UP, 0.18).normalize(), rightHold, rightHold);
-  const gripSide = frame.side.clone().multiplyScalar(-1).addScaledVector(UP, lerp(-0.55, -0.24, ik)).addScaledVector(frame.forward, lerp(0.16, 0.05, ik)).normalize();
-  const gripUp = UP.clone().multiplyScalar(lerp(-1.0, 0.6, ik)).addScaledVector(frame.side, lerp(-0.64, -0.28, ik)).addScaledVector(frame.forward, lerp(0.2, -0.1, ik)).normalize();
-  const gripRoll = lerp(CFG.rightHandRollIdle, CFG.rightHandRollShoot, ik) + 0.05 * frame.stroke;
-  setHandBasis(b.rightHand, gripSide, gripUp, cueDir, gripRoll, 1.0);
-  poseFingers(human.rightFingers, "grip", 0.95);
+  aimTwoBone(b.rightUpperArm, b.rightLowerArm, rightElbow, rightGrip, frame.side.clone().addScaledVector(UP, 0.22).normalize(), rightHold, rightHold);
+  setHandBasis(b.rightHand, frame.side.clone().addScaledVector(UP, -0.08).normalize(), UP.clone().multiplyScalar(0.76).addScaledVector(frame.side, 0.18).addScaledVector(frame.forward, -0.1).normalize(), cueDir, 0.08 * idle + 0.2 * ik + 0.03 * frame.stroke, 0.78 + 0.18 * ik);
+  poseFingers(human.rightFingers, "grip", 0.58 + 0.28 * ik);
 
   if (ik < 0.025) {
     poseFingers(human.leftFingers, "idle", 1);
@@ -771,18 +756,8 @@ function updateHumanPose(human: HumanRig, dt: number, state: ShotState, rootTarg
   const rightHip = local(new THREE.Vector3(0.13, 0.92, 0.02));
   const leftFoot = local(new THREE.Vector3(-0.13, 0.035, 0.03 + walk * 0.03).lerp(new THREE.Vector3(-CFG.stanceWidth * 0.42, 0.035, -0.36), t));
   const rightFoot = local(new THREE.Vector3(0.13, 0.035, -0.03 - walk * 0.03).lerp(new THREE.Vector3(CFG.stanceWidth * 0.5, 0.035, 0.36), t));
-  const leftHand = idleLeft.clone().lerp(bridgeTarget.clone().addScaledVector(forward, -0.006 * t).addScaledVector(side, -0.012 * t).setY(CFG.tableTopY + CFG.bridgePalmTableLift).addScaledVector(UP, -0.01 * human.settleT), t);
-  const cueDirForHand = cueTip.clone().sub(cueBack).normalize();
-  const handIk = easeInOut(clamp01(t));
-  const idleGripSide = side.clone().multiplyScalar(-1).addScaledVector(UP, -0.55).addScaledVector(forward, 0.16).normalize();
-  const idleGripUp = UP.clone().multiplyScalar(-1).addScaledVector(side, -0.64).addScaledVector(forward, 0.2).normalize();
-  const liveGripSide = side.clone().multiplyScalar(-1).addScaledVector(UP, lerp(-0.55, -0.24, handIk)).addScaledVector(forward, lerp(0.16, 0.05, handIk)).normalize();
-  const liveGripUp = UP.clone().multiplyScalar(lerp(-1.0, 0.6, handIk)).addScaledVector(side, lerp(-0.64, -0.28, handIk)).addScaledVector(forward, lerp(0.2, -0.1, handIk)).normalize();
-  const idleCueGripPoint = idleRight.clone();
-  const liveCueGripPoint = gripTarget.clone().addScaledVector(forward, 0.046 * stroke * t + 0.065 * follow * power);
-  const idleWristTarget = idleCueGripPoint.clone().sub(cueSocketOffsetWorld(idleGripSide, idleGripUp, cueDirForHand, CFG.rightHandRollIdle));
-  const liveWristTarget = liveCueGripPoint.clone().sub(cueSocketOffsetWorld(liveGripSide, liveGripUp, cueDirForHand, lerp(CFG.rightHandRollIdle, CFG.rightHandRollShoot, handIk)));
-  const rightHand = idleWristTarget.clone().lerp(liveWristTarget, t);
+  const leftHand = idleLeft.clone().lerp(bridgeTarget.clone().addScaledVector(forward, -0.026 * t).addScaledVector(side, -0.018 * t).setY(CFG.tableTopY + CFG.bridgePalmTableLift).addScaledVector(UP, -0.006 * human.settleT), t);
+  const rightHand = idleRight.clone().lerp(gripTarget.clone().addScaledVector(forward, 0.032 * stroke * t + 0.052 * follow * power).addScaledVector(UP, -0.007 * follow), t);
   const leftElbow = leftShoulder.clone().lerp(leftHand, 0.57).addScaledVector(UP, 0.02 * t).addScaledVector(side, -0.03 * t).addScaledVector(forward, 0.035 * t);
   const rightElbow = rightHand.clone().addScaledVector(UP, lerp(0.18, CFG.cueArmElbowRise, t)).addScaledVector(side, lerp(0.03, 0.07, t)).addScaledVector(forward, lerp(-0.03, 0, t));
   const leftKnee = leftHip.clone().lerp(leftFoot, 0.53).addScaledVector(UP, lerp(0.18, 0.105, t)).addScaledVector(forward, 0.052 * t).addScaledVector(side, -0.016 * t);
@@ -1142,19 +1117,18 @@ export default function BilardoShqipGame() {
       if (state === "striking") gap = lerp(CFG.idleGap + pull, CFG.contactGap, easeOutCubic(strikeNorm));
       const cueTipShoot = cueBallWorld.clone().addScaledVector(aimForward, -(CFG.ballR + gap));
       const cueBackShoot = bridgeCuePoint.clone().addScaledVector(aimForward, -(CFG.cueLength - CFG.bridgeDist - CFG.ballR - gap)).add(new THREE.Vector3(0, 0.028, 0));
+      const gripHandTarget = cueTipShoot.clone().lerp(cueBackShoot, CFG.gripRatio);
       const standingYaw = yawFromForward(aimForward);
-      const idleRightHandTarget = humanRootTarget.clone().add(new THREE.Vector3(CFG.idleRightHandX, CFG.idleRightHandY, CFG.idleRightHandZ).applyAxisAngle(Y_AXIS, standingYaw));
+      const idleRightHandTarget = humanRootTarget.clone().add(new THREE.Vector3(0.24, 1.12, 0.02).applyAxisAngle(Y_AXIS, standingYaw));
       const idleLeftHandTarget = humanRootTarget.clone().add(new THREE.Vector3(-0.18, 1.08, 0.03).applyAxisAngle(Y_AXIS, standingYaw));
-      const idleDir = CFG.idleCueDir.clone().applyAxisAngle(Y_AXIS, standingYaw).normalize();
-      const idleCue = cuePoseFromGrip(idleRightHandTarget, idleDir, CFG.idleCueGripFromBack, CFG.cueLength);
-      const shootCueDir = cueTipShoot.clone().sub(cueBackShoot).normalize();
-      const gripHandTarget = cueBackShoot.clone().addScaledVector(shootCueDir, CFG.shootCueGripFromBack);
-      let cueBackVisual = state === "idle" ? idleCue.back : cueBackShoot.clone();
-      let cueTipVisual = state === "idle" ? idleCue.tip : cueTipShoot.clone();
+      let cueBackVisual = cueBackShoot.clone(), cueTipVisual = cueTipShoot.clone();
 
       if (state === "idle") {
         strikeT = 0;
         didHit = false;
+        const idleDir = new THREE.Vector3(0.16, 0.74, -0.22).applyAxisAngle(Y_AXIS, standingYaw).normalize();
+        cueBackVisual = idleRightHandTarget.clone().addScaledVector(idleDir, -0.22);
+        cueTipVisual = idleRightHandTarget.clone().addScaledVector(idleDir, 0.96);
       } else if (state === "dragging") {
         strikeT = 0;
         didHit = false;

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -117,28 +117,12 @@ import { sampleCueStrokeTimeline } from './poolRoyaleCueStrokeTimeline.js';
 import { resolvePocketMouthAimPoint } from './poolRoyalePocketAim.js';
 import { resolveAiPotGhostAim } from './poolRoyaleAiAimCompensation.js';
 import { computeCueDriveBoost } from './cueShotImpact.js';
+import {
+  chooseHumanEdgePosition as chooseBilardoHumanEdgePosition,
+  createBilardoHumanRig,
+  updateBilardoHumanPose
+} from './shared/bilardoHumanRig.js';
 import { polyHavenThumb } from '../../config/storeThumbnails.js';
-
-
-const BILARDO_HUMAN_CFG = {
-  edgeMargin: 0.58,
-  desiredShootDistance: 1.06,
-};
-
-function chooseBilardoHumanEdgePosition(cueBallWorld, aimForward, opts = {}) {
-  const desired = cueBallWorld
-    .clone()
-    .addScaledVector(aimForward, -(opts.desiredShootDistance ?? BILARDO_HUMAN_CFG.desiredShootDistance));
-  const xEdge = (opts.tableW ?? 2.0) / 2 + (opts.edgeMargin ?? BILARDO_HUMAN_CFG.edgeMargin);
-  const zEdge = (opts.tableL ?? 3.6) / 2 + (opts.edgeMargin ?? BILARDO_HUMAN_CFG.edgeMargin);
-  const candidates = [
-    new THREE.Vector3(-xEdge, 0, clamp(desired.z, -zEdge, zEdge)),
-    new THREE.Vector3(xEdge, 0, clamp(desired.z, -zEdge, zEdge)),
-    new THREE.Vector3(clamp(desired.x, -xEdge, xEdge), 0, -zEdge),
-    new THREE.Vector3(clamp(desired.x, -xEdge, xEdge), 0, zEdge),
-  ];
-  return candidates.sort((a, b) => a.distanceToSquared(desired) - b.distanceToSquared(desired))[0].clone();
-}
 
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/v1/decoders/';
 const BASIS_TRANSCODER_PATH =
@@ -1965,19 +1949,12 @@ const HUMAN_EYE_CAMERA_FORWARD_OFFSET = BALL_R * 3.2; // move camera forward fro
 const HUMAN_EYE_CAMERA_SIDE_OFFSET = -BALL_R * 0.34; // keep a subtle right-eye bias for right-handed stance without exposing the avatar back
 const HUMAN_EYE_CAMERA_MIN_BLEND = 0.06; // only engage eye camera when cue view is noticeably lowered
 const HUMAN_EYE_CAMERA_SMOOTH = 0.48; // smooth eye-camera blending into the cue camera for portrait stability
-const HUMAN_BRIDGE_HAND_BACK_FROM_BALL = 0.235; // PoolPreview-tuned bridge hand offset from cue ball
-const HUMAN_BRIDGE_HAND_SIDE = -0.012; // PoolPreview-tuned lateral bridge hand offset
-const HUMAN_BRIDGE_CUE_LIFT = 0.018; // PoolPreview-tuned cue elevation above bridge hand
-const HUMAN_GRIP_RATIO = 0.86; // align right-hand grip location with PoolPreview working cue socket placement
+const HUMAN_BRIDGE_HAND_BACK_FROM_BALL = 0.245; // match Bilardo Shqip bridge hand offset from cue ball
+const HUMAN_BRIDGE_HAND_SIDE = -0.008; // match Bilardo Shqip bridge hand lateral placement
+const HUMAN_BRIDGE_CUE_LIFT = 0.026; // match Bilardo Shqip cue elevation above bridge hand
+const HUMAN_GRIP_RATIO = 0.9; // shift right-hand grip toward the cue butt while keeping the same aiming direction
 const HUMAN_CUE_LENGTH = 1.46; // match Bilardo Shqip cue length used for hand/cue alignment
 const HUMAN_BRIDGE_DIST = 0.24; // match Bilardo Shqip bridge-to-tip section used by cue placement
-const HUMAN_IDLE_RIGHT_HAND_X = 0.31;
-const HUMAN_IDLE_RIGHT_HAND_Y = 0.8;
-const HUMAN_IDLE_RIGHT_HAND_Z = -0.015;
-const HUMAN_IDLE_CUE_GRIP_FROM_BACK = 0.24;
-const HUMAN_SHOOT_CUE_GRIP_FROM_BACK = 0.86;
-const HUMAN_RIGHT_HAND_ROLL_IDLE = -2.2;
-const HUMAN_RIGHT_HAND_ROLL_SHOOT = -1.05;
 const HUMAN_WALK_PERIMETER_SPEED = Math.max(TABLE.W * 0.95, TABLE.H * 0.7); // world units per second when traversing the walk ring
 const HUMAN_WALK_EPS = 1e-5;
 const CUE_STRIKE_DURATION_MS = 260;
@@ -24685,65 +24662,76 @@ const shotPowerRef = useRef(0);
 
       const spawnPlayerCharacters = async () => {
         disposePlayerCharacters();
-        const template = await ensureSeatedHumanTemplate();
-        const rig = createPlayerCharacterRig({
-          seat: 'A',
-          x: 0,
-          z: PLAY_H * 0.48,
-          facingY: Math.PI,
-          template
+        const seatConfigs = [
+          { seat: 'A', x: 0, z: 0, facingY: 0 },
+          { seat: 'B', x: 0, z: 0, facingY: Math.PI }
+        ];
+        const loader = new GLTFLoader().setCrossOrigin('anonymous');
+        seatConfigs.forEach((cfg) => {
+          const human = createBilardoHumanRig(scene, {
+            loader,
+            modelUrl: BILARDO_SHQIP_HUMAN_URL,
+            humanScale: 1.18,
+            humanVisualYawFix: Math.PI,
+            tableTopY: TABLE_Y + TABLE.THICK,
+            edgeMargin: HUMAN_EDGE_MARGIN,
+            desiredShootDistance: HUMAN_DESIRED_SHOOT_DISTANCE,
+            bridgePalmTableLift: 0.001
+          });
+          human.root.position.set(cfg.x, floorY, cfg.z);
+          human.yaw = cfg.facingY;
+          const rig = { seat: cfg.seat, human, group: human.root };
+          playerCharacterRigsRef.current.push(rig);
         });
-        playerCharacterRigsRef.current = [rig];
-        world.add(rig);
       };
 
       const updatePlayerCharacters = (nowMs, dtSeconds) => {
         void nowMs;
-        const rig = playerCharacterRigsRef.current[0];
-        const anim = rig?.userData?.anim;
-        if (!rig || !anim || !cue?.active) return;
-        const dir2 = aimDirRef.current?.clone?.() ?? new THREE.Vector2(0, 1);
-        if (dir2.lengthSq() < 1e-6) dir2.set(0, 1);
-        dir2.normalize();
-        const forward = new THREE.Vector3(dir2.x, 0, dir2.y).normalize();
-        const side = new THREE.Vector3(forward.z, 0, -forward.x).normalize();
-        const rootTarget = new THREE.Vector3(
-          cue.pos.x - forward.x * (TABLE.W * 0.38),
-          floorY,
-          cue.pos.y - forward.z * (TABLE.H * 0.38)
-        );
-        anim.rootTarget = anim.rootTarget || rootTarget.clone();
-        anim.rootTarget.lerp(rootTarget, 1 - Math.exp(-4.6 * Math.max(0.001, dtSeconds)));
-        rig.position.copy(anim.rootTarget);
-        const targetYaw = Math.atan2(-forward.x, -forward.z);
-        anim.yaw = Number.isFinite(anim.yaw) ? anim.yaw : rig.rotation.y;
-        anim.yaw = THREE.MathUtils.lerp(anim.yaw, targetYaw, 1 - Math.exp(-7.2 * Math.max(0.001, dtSeconds)));
-        rig.rotation.y = anim.yaw;
+        const cueBall = ballsRef.current?.find((b) => b?.id === 'cue' && b?.active !== false);
+        if (!cueBall || !Number.isFinite(dtSeconds) || dtSeconds <= 0) return;
+        const aimForward = new THREE.Vector3(aimDirRef.current.x, 0, aimDirRef.current.y).normalize();
+        if (aimForward.lengthSq() < 1e-6) aimForward.set(0, 0, -1);
+        const aimSide = new THREE.Vector3(aimForward.z, 0, -aimForward.x).normalize();
+        const cueBallWorld = new THREE.Vector3(cueBall.pos.x, TABLE_Y + TABLE.THICK + BALL_R, cueBall.pos.y);
 
-        const grip = anim.gripHand;
-        const bridge = anim.bridgeHand;
-        if (!grip || !bridge) return;
-        const gripIdle = new THREE.Vector3(0.31, 0.8, -0.015);
-        const gripLocal = gripIdle.clone().addScaledVector(forward, -0.06);
-        grip.position.copy(gripLocal);
-        const cueDir = new THREE.Vector3(-forward.x, 0.45, -forward.z).normalize();
-        grip.quaternion.copy(makeHumanoidBasis(side.clone().multiplyScalar(-1), cueDir));
+        const bridgeTarget = cueBallWorld
+          .clone()
+          .addScaledVector(aimForward, -HUMAN_BRIDGE_HAND_BACK_FROM_BALL)
+          .addScaledVector(aimSide, HUMAN_BRIDGE_HAND_SIDE)
+          .setY(TABLE_Y + TABLE.THICK + 0.001);
+        const cueTip = cueBallWorld.clone().addScaledVector(aimForward, -CUE_TIP_GAP);
+        const gripTarget = cueTip
+          .clone()
+          .addScaledVector(aimForward, -HUMAN_CUE_LENGTH * HUMAN_GRIP_RATIO)
+          .addScaledVector(aimSide, 0.018)
+          .addScaledVector(new THREE.Vector3(0, 1, 0), -0.008);
 
-        const bridgeWorld = new THREE.Vector3(
-          cue.pos.x - forward.x * (BALL_R * 4.2),
-          floorY + TABLE.THICK + 0.015,
-          cue.pos.y - forward.z * (BALL_R * 4.2)
-        );
-        const bridgeLocal = rig.worldToLocal(bridgeWorld.clone());
-        bridge.position.copy(bridgeLocal);
-        bridge.quaternion.copy(makeHumanoidBasis(side.clone().multiplyScalar(-1), cueDir));
-
-        if (anim.model) {
-          anim.poseT = THREE.MathUtils.lerp(anim.poseT || 0, shooting ? 1 : 0, 1 - Math.exp(-6.8 * Math.max(0.001, dtSeconds)));
-          const t = anim.poseT;
-          anim.model.position.y = -0.03 * t;
-          anim.model.rotation.x = -0.15 * t;
-        }
+        const standingYaw = Math.atan2(-aimForward.x, -aimForward.z);
+        const humanRootTarget = chooseBilardoHumanEdgePosition(cueBallWorld, aimForward, {
+          tableW: PLAY_W,
+          tableL: PLAY_H,
+          edgeMargin: HUMAN_EDGE_MARGIN,
+          desiredShootDistance: HUMAN_DESIRED_SHOOT_DISTANCE
+        }).setY(floorY);
+        const idleLeft = humanRootTarget.clone().add(new THREE.Vector3(-0.18, 1.08, 0.03).applyAxisAngle(new THREE.Vector3(0, 1, 0), standingYaw));
+        const idleRight = humanRootTarget.clone().add(new THREE.Vector3(0.18, 1.08, 0.03).applyAxisAngle(new THREE.Vector3(0, 1, 0), standingYaw));
+        const state = shooting ? 'striking' : isDragging ? 'dragging' : 'idle';
+        playerCharacterRigsRef.current.forEach((rig) => {
+          const human = rig?.human;
+          if (!human) return;
+          updateBilardoHumanPose(human, dtSeconds, {
+            state,
+            power: clamp(powerRef.current || 0, 0, 1),
+            rootTarget: humanRootTarget,
+            aimForward,
+            bridgeTarget,
+            gripTarget,
+            idleRight,
+            idleLeft,
+            cueBack: gripTarget,
+            cueTip
+          });
+        });
       };
 
       void spawnPlayerCharacters();


### PR DESCRIPTION
### Motivation
- Restore the Pool Royale experience to the exact gameplay, human-rig, and weapon-camera behavior that existed yesterday at ~16:00 so players see the same code-driven behavior as before recent changes.
- Re-align shared human-rig and weapon director logic used across Bilardo/Pool features so animations, grip/pose, and projectile/camera follow behavior match the Bilardo baseline.

### Description
- Restored Pool Royale page and gameplay wiring by reverting `webapp/src/pages/Games/PoolRoyale.jsx` to the Apr 29 16:00 snapshot, reintroducing the Bilardo-compatible human rig integration and per-frame pose/arm-hand logic. 
- Reverted `webapp/src/pages/Games/BilardoShqipGame.tsx` to restore the previous human-rig constants and pose-driving adjustments (grip/bridge offsets, cue/back visual handling, and updated hand/arm IK tuning). 
- Reverted `Assets/Scripts/Gameplay/Weapons/BattleRoyaleWeaponDirector.cs` to restore the previous weapon presentation and camera routines, including projectile follow conditions, camera parenting/aim routine ordering, and simplified weapon-root pose handling. 
- Limited the scope of the change to only Pool Royale / Bilardo-adjacent client code and the shared weapon director to keep gameplay behavior consistent across affected scenes.

### Testing
- No automated unit or integration test suite was executed for this restore. 
- Performed repository-level validations including file diff/stat inspection and direct file content previews to confirm the three target files match the intended Apr 29 16:00 snapshot and that the in-repo changes are limited to the Pool Royale/Bilardo weapon and page code. 
- Verified repository status shows unrelated untracked/modified files outside the restored scope and that only the intended Pool Royale-related files were modified by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2c943aaf883299b07c67ae993b1d1)