### PR TITLE
Fix Snake/Ladder seated body orientation and parked firearm previews

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -87,7 +87,7 @@ const HUMAN_MODEL_CACHE = { promise: null, template: null };
 const SEATED_HUMAN_BASE_HEIGHT = 1.74;
 const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.24;
 const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 2.21;
-const SEATED_HUMAN_SEAT_Y_OFFSET = -4.78 * MODEL_SCALE * STOOL_SCALE;
+const SEATED_HUMAN_SEAT_Y_OFFSET = -6.75 * MODEL_SCALE * STOOL_SCALE;
 const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.46;
 // Mirror Ludo Battle Royal's deeper bottom-seat pushback so the local player sits
 // with the same portrait-facing posture/orientation while preserving Snake table scale.
@@ -1761,12 +1761,13 @@ function applySeatedHumanPose(seatHuman, timeSeconds = 0, activeLean = 0) {
   composeModelBone(rest, bones.neck, new THREE.Euler(-0.04, 0, 0, 'XYZ'));
   composeModelBone(rest, bones.head, new THREE.Euler(-0.06, 0, 0, 'XYZ'));
 
-  composeModelBone(rest, bones.leftUpLeg, new THREE.Euler(-1.18, 0.06, 0.02, 'XYZ'));
-  composeModelBone(rest, bones.rightUpLeg, new THREE.Euler(-1.18, -0.06, -0.02, 'XYZ'));
-  composeModelBone(rest, bones.leftLeg, new THREE.Euler(1.26, 0.01, 0, 'XYZ'));
-  composeModelBone(rest, bones.rightLeg, new THREE.Euler(1.26, -0.01, 0, 'XYZ'));
-  composeModelBone(rest, bones.leftFoot, new THREE.Euler(-0.18, 0.01, 0.01, 'XYZ'));
-  composeModelBone(rest, bones.rightFoot, new THREE.Euler(-0.18, -0.01, -0.01, 'XYZ'));
+  // Match Ludo Battle Royal seated lower-body orientation for identical portrait posture.
+  composeModelBone(rest, bones.leftUpLeg, new THREE.Euler(-1.58, 0.16, 0.05, 'XYZ'));
+  composeModelBone(rest, bones.rightUpLeg, new THREE.Euler(-1.58, 0.03, -0.02, 'XYZ'));
+  composeModelBone(rest, bones.leftLeg, new THREE.Euler(-1.66, 0.02, 0.01, 'XYZ'));
+  composeModelBone(rest, bones.rightLeg, new THREE.Euler(-1.66, -0.02, -0.01, 'XYZ'));
+  composeModelBone(rest, bones.leftFoot, new THREE.Euler(0.26, 0.03, 0.02, 'XYZ'));
+  composeModelBone(rest, bones.rightFoot, new THREE.Euler(0.26, -0.02, -0.01, 'XYZ'));
 
   composeModelBone(rest, bones.leftArm, new THREE.Euler(-0.28, 0.12, 0.96, 'XYZ'));
   composeModelBone(rest, bones.rightArm, new THREE.Euler(-0.2, -0.02, -0.72, 'XYZ'));
@@ -5169,12 +5170,14 @@ function createPolySeatWeaponMesh(weaponType) {
   return group;
 }
 function createSeatWeaponMesh(weaponType = 'fighter') {
-  const normalizedWeaponType = normalizeSnakeCaptureWeaponKind(weaponType);
-  if (SNAKE_CAPTURE_WEAPON_OPTION_BY_ID[weaponType]) {
+  const rawWeaponType = typeof weaponType === 'string' ? weaponType.trim() : '';
+  const catalogWeaponType = SNAKE_CAPTURE_WEAPON_OPTION_BY_ID[rawWeaponType] ? rawWeaponType : null;
+  const normalizedWeaponType = normalizeSnakeCaptureWeaponKind(rawWeaponType || weaponType);
+  if (catalogWeaponType) {
     const holder = new THREE.Group();
     const fallback = createPolySeatWeaponMesh(normalizedWeaponType);
     holder.add(fallback);
-    loadCaptureWeaponCatalogModel(weaponType)
+    loadCaptureWeaponCatalogModel(catalogWeaponType)
       .then((model) => {
         if (!model || !holder.parent) return;
         while (holder.children.length) holder.remove(holder.children[0]);
@@ -5244,14 +5247,15 @@ function updateSeatWeaponDisplays(board, players = []) {
       if (!board.weaponDisplayGroup.userData.byPlayer) board.weaponDisplayGroup.userData.byPlayer = new Map();
       board.weaponDisplayGroup.userData.byPlayer.set(holderKey, holder);
     }
-    const weaponType = normalizeSnakeCaptureWeaponKind(player?.weaponType || fallbackOrder[seatIndex % fallbackOrder.length]);
-    if (holder.userData.weaponType !== weaponType) {
+    const configuredWeaponType = typeof player?.weaponType === 'string' ? player.weaponType.trim() : '';
+    const parkedWeaponType = configuredWeaponType || fallbackOrder[seatIndex % fallbackOrder.length];
+    if (holder.userData.weaponType !== parkedWeaponType) {
       while (holder.children.length) {
         const child = holder.children.pop();
         if (child) holder.remove(child);
       }
-      holder.add(createSeatWeaponMesh(weaponType));
-      holder.userData.weaponType = weaponType;
+      holder.add(createSeatWeaponMesh(parkedWeaponType));
+      holder.userData.weaponType = parkedWeaponType;
     }
     const railLayout = getSeatSideParkingLayout(board, seatIndex, board.weaponDisplayGroup);
     if (railLayout) {


### PR DESCRIPTION
### Motivation
- Make the bottom-player seated body orientation in Snake match the portrait framing and lower-body pose used by Ludo Battle Royal so characters look identical in portrait view. 
- Ensure selected GLTF firearms appear parked on the board the same way vehicles (drone/jet/helicopter/truck) do so users see the chosen weapon model and its thumbnail. 

### Description
- Adjusted the seated human baseline vertical offset by changing `SEATED_HUMAN_SEAT_Y_OFFSET` in `webapp/src/components/SnakeBoard3D.jsx` to match Ludo Battle Royal seating depth. 
- Replaced the lower-body bone rotations in `applySeatedHumanPose` to mirror Ludo-style Euler values so upper/lower legs and feet orientation is identical. 
- Updated weapon parking/rendering logic to preserve the original selected catalog weapon ID when creating parked previews by passing the raw catalog ID into `createSeatWeaponMesh` and calling `loadCaptureWeaponCatalogModel` with that ID, while keeping the original fallback mesh behavior. 

### Testing
- Ran `npm -s test -- test/snakeGame.test.js` which executed the snake test suite and finished with 4 failed, 6 passed (10 total) and the run returned non-zero; failures are pre-existing backend test expectation mismatches and not caused by the UI/3D changes in `SnakeBoard3D.jsx`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2d4c55e248329b3e96adf9f8ede6a)