### PR TITLE
Preserve camera when changing Ludo chairs/tables and disable direct weapon click-swap

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -8692,6 +8692,17 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     const baseOption = DEFAULT_BASE_OPTION;
 
     (async () => {
+      const camera = cameraRef.current;
+      const controls = controlsRef.current;
+      const preserveCameraState =
+        camera && controls
+          ? {
+              position: camera.position.clone(),
+              target: controls.target.clone(),
+              up: camera.up.clone()
+            }
+          : null;
+
       if (tableChanged) {
         await rebuildTable(tableTheme, tableFinish, tableCloth);
         arena.textureResolutionKey = textureResolutionKey;
@@ -8703,7 +8714,6 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           arena.defaultLookTarget = arena.boardLookTarget.clone();
           arena.controls?.target.copy(arena.boardLookTarget ?? new THREE.Vector3());
           arena.controls?.update();
-          fitRef.current?.();
           applyBoardGroupScale(arena.boardGroup, arena.tableInfo);
           configureDiceAnchors({ tableInfo: arena.tableInfo, boardGroup: arena.boardGroup, chairs: arena.chairs });
           const currentTurn = stateRef.current?.turn ?? 0;
@@ -8722,6 +8732,20 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           { chairMaterials: arena.chairMaterials },
           { seatColor: stoolTheme.seatColor, legColor: stoolTheme.legColor ?? DEFAULT_STOOL_THEME.legColor }
         );
+      }
+
+      if (preserveCameraState && !isCamera2d) {
+        const activeCamera = cameraRef.current;
+        const activeControls = controlsRef.current;
+        if (activeCamera && activeControls) {
+          activeCamera.position.copy(preserveCameraState.position);
+          activeCamera.up.copy(preserveCameraState.up);
+          activeControls.target.copy(preserveCameraState.target);
+          activeControls.update();
+          if (LUDO_CAMERA_SEAT_LOCK_ENABLED) {
+            cameraSeatLockPositionRef.current = activeCamera.position.clone();
+          }
+        }
       }
 
       if (hdriChanged) {
@@ -9283,14 +9307,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       const state = stateRef.current;
       if (!state || state.turn !== 0 || state.animation || state.winner) return false;
       const humanEntry = parkedCaptureVehiclesRef.current.get(0);
-      const interactiveTargets = [
-        humanEntry?.actionButtonHit,
-        humanEntry?.weaponRackHit,
-        humanEntry?.jet,
-        humanEntry?.helicopter,
-        humanEntry?.droneTruck,
-        humanEntry?.missile
-      ].filter(Boolean);
+      const interactiveTargets = [humanEntry?.actionButtonHit].filter(Boolean);
       if (!interactiveTargets.length) return false;
       const rect = renderer.domElement.getBoundingClientRect();
       const x = ((clientX - rect.left) / rect.width) * 2 - 1;


### PR DESCRIPTION
### Motivation
- Keep the user view/layout intact when changing chairs or table options so only the selected appearance is updated and the camera/layout logic is preserved.
- Ensure all chairs use the shared chair footprint sizing baseline so models render at a consistent size (green chair reference size).
- Disable swapping weapons by clicking parked weapon/vehicle meshes to force use of the dedicated swap UI control only.

### Description
- Capture the current camera pose (`camera.position`, `controls.target`, `camera.up`) before async appearance rebuilds and restore it after table/chair rebuilds so visibility and user camera control are preserved (`LudoBattleRoyal.jsx` appearance update flow). 
- Remove the forced `fitRef.current?.()` camera recenter call during table rebuild inside the appearance-update flow so the view is no longer re-centered automatically. 
- Restrict quick-weapon-swap hit testing to the swap action button only by changing the raycast `interactiveTargets` list to `[humanEntry?.actionButtonHit]`, preventing direct clicks on parked weapon/vehicle meshes from opening the swap popup. 
- Chair sizing is already unified via `TARGET_CHAIR_SIZE` and `fitChairModelToFootprint` so loaded and procedural chairs align to the same footprint; no extra per-theme resizing changes were needed. 

### Testing
- No automated test suite or runtime integration tests were executed in this environment. 
- The modified file (`webapp/src/pages/Games/LudoBattleRoyal.jsx`) was reviewed for reference correctness and the updated JSX/variable references were validated by a code-level inspection (no syntax issues found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2d63a63d883298a3c1319593c3472)