### PR TITLE
Adjust Snake & Ladder seated pose and parked firearm display mapping

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -89,9 +89,8 @@ const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.24;
 const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 2.21;
 const SEATED_HUMAN_SEAT_Y_OFFSET = -6.75 * MODEL_SCALE * STOOL_SCALE;
 const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.46;
-// Mirror Ludo Battle Royal's deeper bottom-seat pushback so the local player sits
-// with the same portrait-facing posture/orientation while preserving Snake table scale.
-const SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET = -SEAT_DEPTH * 0.2;
+// Pull lower-body seating inward toward the table while preserving the same seat anchors.
+const SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET = SEAT_DEPTH * 0.2;
 const SEATED_HUMAN_FACING_Y = 0;
 const SEATED_HUMAN_FOOT_GROUND_Y = -1.26 * MODEL_SCALE * STOOL_SCALE;
 const HUMAN_FRONT_SIDE_Z = 1;
@@ -586,21 +585,21 @@ const SNAKE_CAPTURE_WEAPON_KIND_MAP = Object.freeze({
   droneAttack: 'drone',
   fighterJetAttack: 'fighter',
   helicopterAttack: 'helicopter',
-  fpsGunAttack: 'supportTruck',
-  glockSidearmAttack: 'supportTruck',
-  assaultRifleAttack: 'supportTruck',
-  uziSprayAttack: 'supportTruck',
-  ak47VolleyAttack: 'supportTruck',
-  krsvBurstAttack: 'supportTruck',
-  smithSidearmAttack: 'supportTruck',
-  mosinMarksmanAttack: 'supportTruck',
-  sigsauerTacticalAttack: 'supportTruck',
-  grenadeBlastAttack: 'supportTruck',
-  shotgunBlastAttack: 'supportTruck',
-  sniperShotAttack: 'supportTruck',
-  smgBurstAttack: 'supportTruck',
-  compactCarbineAttack: 'supportTruck',
-  marksmanDmrAttack: 'supportTruck',
+  fpsGunAttack: 'fpsGunAttack',
+  glockSidearmAttack: 'glockSidearmAttack',
+  assaultRifleAttack: 'assaultRifleAttack',
+  uziSprayAttack: 'uziSprayAttack',
+  ak47VolleyAttack: 'ak47VolleyAttack',
+  krsvBurstAttack: 'krsvBurstAttack',
+  smithSidearmAttack: 'smithSidearmAttack',
+  mosinMarksmanAttack: 'mosinMarksmanAttack',
+  sigsauerTacticalAttack: 'sigsauerTacticalAttack',
+  grenadeBlastAttack: 'grenadeBlastAttack',
+  shotgunBlastAttack: 'shotgunBlastAttack',
+  sniperShotAttack: 'sniperShotAttack',
+  smgBurstAttack: 'smgBurstAttack',
+  compactCarbineAttack: 'compactCarbineAttack',
+  marksmanDmrAttack: 'marksmanDmrAttack',
   polyShotgun01Attack: 'polyShotgun01Attack',
   polyAssaultRifle01Attack: 'polyAssaultRifle01Attack',
   polyPistol01Attack: 'polyPistol01Attack',


### PR DESCRIPTION
### Motivation
- Align the bottom-half human seating pose in Snake & Ladder with the Ludo Battle Royal portrait seating so the lower-body appears inward toward the table while keeping existing seat anchors/positions unchanged.
- Ensure firearms selected for capture attacks resolve to firearm-specific parked display types so they appear in the same parking spots previously used for helicopter/jet/drone/truck.

### Description
- Flipped the local bottom-seat lower-body offset by changing `SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET` in `webapp/src/components/SnakeBoard3D.jsx` so the seated model pulls inward toward the table instead of outward.
- Updated `SNAKE_CAPTURE_WEAPON_KIND_MAP` in `webapp/src/components/SnakeBoard3D.jsx` to map firearm attack keys (e.g. `fpsGunAttack`, `glockSidearmAttack`, `assaultRifleAttack`, etc.) to distinct firearm-kind identifiers instead of collapsing them to `supportTruck`.
- Preserved existing seat anchors and anchoring logic so seating positions remain identical to the previous PR while only adjusting lower-body placement.

### Testing
- Verified changes by inspecting the modified file with `nl -ba webapp/src/components/SnakeBoard3D.jsx | sed -n '86,100p;582,615p'` and checked repository status with `git status --short`.
- Committed the update with `git commit webapp/src/components/SnakeBoard3D.jsx -m "Adjust snake seating posture and parked firearm display mapping"`; no unit or integration tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2dcec5188832989cc9c7de8a72e55)