### PR TITLE
Adjust seated human lower-body pose and restore parked weapons parking order

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -1762,12 +1762,12 @@ function applySeatedHumanPose(seatHuman, timeSeconds = 0, activeLean = 0) {
   composeModelBone(rest, bones.head, new THREE.Euler(-0.06, 0, 0, 'XYZ'));
 
   // Match Ludo Battle Royal seated lower-body orientation for identical portrait posture.
-  composeModelBone(rest, bones.leftUpLeg, new THREE.Euler(-1.58, 0.16, 0.05, 'XYZ'));
-  composeModelBone(rest, bones.rightUpLeg, new THREE.Euler(-1.58, 0.03, -0.02, 'XYZ'));
-  composeModelBone(rest, bones.leftLeg, new THREE.Euler(-1.66, 0.02, 0.01, 'XYZ'));
-  composeModelBone(rest, bones.rightLeg, new THREE.Euler(-1.66, -0.02, -0.01, 'XYZ'));
-  composeModelBone(rest, bones.leftFoot, new THREE.Euler(0.26, 0.03, 0.02, 'XYZ'));
-  composeModelBone(rest, bones.rightFoot, new THREE.Euler(0.26, -0.02, -0.01, 'XYZ'));
+  composeModelBone(rest, bones.leftUpLeg, new THREE.Euler(-1.58, -0.16, 0.05, 'XYZ'));
+  composeModelBone(rest, bones.rightUpLeg, new THREE.Euler(-1.58, -0.03, -0.02, 'XYZ'));
+  composeModelBone(rest, bones.leftLeg, new THREE.Euler(-1.66, -0.02, 0.01, 'XYZ'));
+  composeModelBone(rest, bones.rightLeg, new THREE.Euler(-1.66, 0.02, -0.01, 'XYZ'));
+  composeModelBone(rest, bones.leftFoot, new THREE.Euler(0.26, -0.03, 0.02, 'XYZ'));
+  composeModelBone(rest, bones.rightFoot, new THREE.Euler(0.26, 0.02, -0.01, 'XYZ'));
 
   composeModelBone(rest, bones.leftArm, new THREE.Euler(-0.28, 0.12, 0.96, 'XYZ'));
   composeModelBone(rest, bones.rightArm, new THREE.Euler(-0.2, -0.02, -0.72, 'XYZ'));
@@ -5224,7 +5224,7 @@ function updateSeatWeaponDisplays(board, players = []) {
   const boardLookTarget = board.boardLookTarget;
   if (!boardLookTarget) return;
   const keep = new Set();
-  const fallbackOrder = ['drone', 'fighter', 'helicopter', 'supportTruck', 'javelin'];
+  const fallbackOrder = ['helicopter', 'fighter', 'drone', 'supportTruck'];
   const playersBySeat = new Map();
   players.forEach((player, index) => {
     const seatIndex = Number.isFinite(player?.seatIndex) ? player.seatIndex : index;


### PR DESCRIPTION
### Motivation
- Ensure Snake & Ladder seated humans keep the same seat placement and upper-body pose while making the lower-body (thighs/legs/feet) angle inward toward the table to match the portrait seating used in Ludo Battle Royal. 
- Restore the pre-change parked weapon lineup so the visible firearms/vehicles appear in the same parking spots (helicopter, fighter/jet, drone, support truck) as before the previous PR.

### Description
- Adjusted lower-body bone rotations in `applySeatedHumanPose` to change thigh/leg/foot Euler angles for inward-facing legs in `webapp/src/components/SnakeBoard3D.jsx`. 
- Restored the parked-weapon fallback order by changing `fallbackOrder` in `updateSeatWeaponDisplays` to `['helicopter','fighter','drone','supportTruck']` in `webapp/src/components/SnakeBoard3D.jsx`. 
- Preserved existing seat anchors, human anchor offsets, and upper-body pose math so seating technique and framing remain identical to Ludo Battle Royal. 
- Change is limited to `webapp/src/components/SnakeBoard3D.jsx` (seated pose + weapon display logic).

### Testing
- Verified the source diff and inspected the modified lines with `git diff` and file excerpts, confirming the updated Euler values and the `fallbackOrder` change; these inspections succeeded. 
- Ran file listing and grep-based searches to confirm no other files were unintentionally modified; these checks succeeded. 
- No build, runtime, or visual regression tests were executed in this pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2dcec5188832989cc9c7de8a72e55)