### PR TITLE
Enlarge Pool Royale human rig and replace chess pieces with a scaled center pawn

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1947,7 +1947,7 @@ const CUE_FOLLOW_THROUGH_MAX = BALL_R * 8.4; // extend top-end follow-through so
 const MIN_SHOT_POWER_TO_FIRE = BILARDO_MIN_RELEASE_POWER; // keep Pool Royale release gate identical to Bilardo Shqip
 const HUMAN_PLAYER_TARGET_HEIGHT_METERS = 1.8; // keep avatar visually human-sized (~1.8m) in portrait view
 const BILARDO_SHQIP_HUMAN_URL = 'https://threejs.org/examples/models/gltf/readyplayer.me.glb';
-const POOL_ROYALE_HUMAN_SCALE_MULTIPLIER = 1.0; // keep fallback hand helpers at real-world scale
+const POOL_ROYALE_HUMAN_SCALE_MULTIPLIER = 3.5; // enlarge the in-scene player rig 3.5× to match requested portrait-screen readability
 const HUMAN_PLAYER_IDLE_SWAY_SPEED = 1.2;
 const HUMAN_PLAYER_IDLE_SWAY_ANGLE = 0.04;
 const HUMAN_PLAYER_AIM_LEAN = 0.2;
@@ -19448,19 +19448,9 @@ const shotPowerRef = useRef(0);
           return piece;
         };
         const piecesGroup = new THREE.Group();
-        const origin = -boardSize / 2 + tile / 2;
-        const rows = [
-          { zIndex: 1, material: lightMaterial },
-          { zIndex: 6, material: darkMaterial }
-        ];
-        rows.forEach(({ zIndex, material }) => {
-          for (let c = 0; c < 8; c += 1) {
-            const x = origin + c * tile;
-            const z = origin + zIndex * tile;
-            const pawn = placePiece(material, x, z);
-            piecesGroup.add(pawn);
-          }
-        });
+        const centerPawn = placePiece(lightMaterial, 0, 0);
+        centerPawn.scale.setScalar(3.5);
+        piecesGroup.add(centerPawn);
         piecesGroup.position.y = boardThickness * 0.5;
         boardGroup.add(piecesGroup);
       };


### PR DESCRIPTION
### Motivation
- Improve portrait-screen readability by increasing the in-scene human/player rig scale used by Pool Royale. 
- Make the human/avatar visually prominent in cue/portrait views so hand/cue alignment and aiming are easier to read. 
- Simplify the chess board prop to a single, larger focal piece that matches the new scene scale and visual intent. 

### Description
- Updated `POOL_ROYALE_HUMAN_SCALE_MULTIPLIER` from `1.0` to `3.5` in `webapp/src/pages/Games/PoolRoyale.jsx` to enlarge the player rig by 3.5×. 
- Replaced the previous multi-piece chess placement loop with a single centered pawn created via `placePiece(lightMaterial, 0, 0)` and scaled it up with `centerPawn.scale.setScalar(3.5)`. 
- Kept materials, transforms, and existing group placements intact while removing the multi-row pawn layout for a simplified prop. 

### Testing
- Ran unit tests with `yarn test` and they completed successfully. 
- Built the app with `yarn build` to validate bundling and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2da98f1c4832988d8aed4b5323acb)