### PR TITLE
Adjust Snake & Ladder seated lower-body orientation and weapon parking placement

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -352,14 +352,11 @@ const TOKEN_PORTRAIT_SCREEN_SHIFT_BY_SEAT = Object.freeze([
   Object.freeze({ radial: TILE_SIZE * 0.08, lateral: TILE_SIZE * 0.7, y: TILE_SIZE * 0.5 })
 ]);
 const WEAPON_PORTRAIT_SCREEN_SHIFT_BY_SEAT = Object.freeze([
-  // Bottom seat (red): bottom-right marker.
-  Object.freeze({ radial: TILE_SIZE * 0.72, lateral: -TILE_SIZE * 0.78, y: TILE_SIZE * 1.72 }),
-  // Right seat (red): lower side marker.
-  Object.freeze({ radial: TILE_SIZE * 0.5, lateral: TILE_SIZE * 0.68, y: TILE_SIZE * 1.72 }),
-  // Top seat (red): push toward top player while nudging inward toward board center.
-  Object.freeze({ radial: TILE_SIZE * 0.96, lateral: TILE_SIZE * 0.48, y: TILE_SIZE * 1.8 }),
-  // Left seat (red): lower side marker.
-  Object.freeze({ radial: TILE_SIZE * 0.5, lateral: -TILE_SIZE * 0.68, y: TILE_SIZE * 1.72 })
+  // Keep weapons parked on dedicated parking slots (helicopter/jet/drone/truck pads).
+  Object.freeze({ radial: 0, lateral: 0, y: 0 }),
+  Object.freeze({ radial: 0, lateral: 0, y: 0 }),
+  Object.freeze({ radial: 0, lateral: 0, y: 0 }),
+  Object.freeze({ radial: 0, lateral: 0, y: 0 })
 ]);
 const WEAPON_TABLE_SURFACE_Y_OFFSET = TILE_SIZE * 0.52;
 const WEAPON_PARKING_SIDE_EXTRA_RADIUS = TILE_SIZE * 0.2;
@@ -1762,8 +1759,9 @@ function applySeatedHumanPose(seatHuman, timeSeconds = 0, activeLean = 0) {
   composeModelBone(rest, bones.head, new THREE.Euler(-0.06, 0, 0, 'XYZ'));
 
   // Match Ludo Battle Royal seated lower-body orientation for identical portrait posture.
-  composeModelBone(rest, bones.leftUpLeg, new THREE.Euler(-1.58, 0.16, 0.05, 'XYZ'));
-  composeModelBone(rest, bones.rightUpLeg, new THREE.Euler(-1.58, 0.03, -0.02, 'XYZ'));
+  // Mirror lower-body spread inward toward the table while preserving seated location.
+  composeModelBone(rest, bones.leftUpLeg, new THREE.Euler(-1.58, -0.12, 0.05, 'XYZ'));
+  composeModelBone(rest, bones.rightUpLeg, new THREE.Euler(-1.58, 0.12, -0.02, 'XYZ'));
   composeModelBone(rest, bones.leftLeg, new THREE.Euler(-1.66, 0.02, 0.01, 'XYZ'));
   composeModelBone(rest, bones.rightLeg, new THREE.Euler(-1.66, -0.02, -0.01, 'XYZ'));
   composeModelBone(rest, bones.leftFoot, new THREE.Euler(0.26, 0.03, 0.02, 'XYZ'));


### PR DESCRIPTION
### Motivation
- Ensure seated human characters keep their original seat/world positions while correcting the lower-body so thighs/legs angle inward toward the table to match the Ludo Battle Royal seated posture. 
- Restore parked weapons to the dedicated vehicle/parking pads (helicopter/jet/drone/truck) so firearms appear on the same parking spots that existed before the prior PR.

### Description
- Updated `WEAPON_PORTRAIT_SCREEN_SHIFT_BY_SEAT` to zeroed offsets so weapon displays use the dedicated parking slots instead of portrait-screen lateral overrides in `webapp/src/components/SnakeBoard3D.jsx`.
- Modified the seated pose bone transforms by changing the `composeModelBone` Euler angles for `bones.leftUpLeg` and `bones.rightUpLeg` to angle the lower body inward while preserving the rest of the seated pose in `webapp/src/components/SnakeBoard3D.jsx`.
- Change is limited to `webapp/src/components/SnakeBoard3D.jsx` and only affects visual transform/placement logic.

### Testing
- No automated tests were executed for this visual transform change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2dcec5188832989cc9c7de8a72e55)