### PR TITLE
Add toggle to disable dynamic camera for Ludo turn/dice/token flows

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -3305,6 +3305,7 @@ const LUDO_CAMERA_AUTO_LOOK_ENABLED = true;
 const LUDO_CAMERA_BROADCAST_LOCKED_POSITION = false;
 const LUDO_CAMERA_SEAT_LOCK_ENABLED = true;
 const LUDO_CAMERA_ANIMATION_BOTTOM_TURN_VIEW = false;
+const LUDO_CAMERA_DYNAMIC_TURN_DICE_TOKEN = false;
 const CAPTURE_ATTACK_CAMERA_FRAME = Object.freeze({
   fighterJetAttack: { focusWeight: 0.52, targetLift: 0.014, followPullback: 0.082, followLift: 0.022 },
   helicopterAttack: { focusWeight: 0.56, targetLift: 0.02, followPullback: 0.068, followLift: 0.026 },
@@ -11813,20 +11814,22 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       const shouldLockHumanCamera = nextTurn === 0;
       preserveUserTurnCameraRef.current = shouldLockHumanCamera;
       lockUserTurnSeatViewRef.current = shouldLockHumanCamera;
-      if (!shouldLockHumanCamera) {
-        setCameraViewForTurn(nextTurn);
-        setCameraFocus({ target: resolveTurnLookTarget(nextTurn), priority: 1, force: true });
-      } else {
-        setCameraViewForTurn(0, CAMERA_TURN_VIEW_DURATION_MS, { force: true });
-      }
-      if (diceRef.current && !shouldLockHumanCamera) {
-        setCameraFocus({
-          object: diceRef.current,
-          follow: true,
-          priority: 4,
-          force: true,
-          offset: CAMERA_TARGET_LIFT + 0.022
-        });
+      if (LUDO_CAMERA_DYNAMIC_TURN_DICE_TOKEN) {
+        if (!shouldLockHumanCamera) {
+          setCameraViewForTurn(nextTurn);
+          setCameraFocus({ target: resolveTurnLookTarget(nextTurn), priority: 1, force: true });
+        } else {
+          setCameraViewForTurn(0, CAMERA_TURN_VIEW_DURATION_MS, { force: true });
+        }
+        if (diceRef.current && !shouldLockHumanCamera) {
+          setCameraFocus({
+            object: diceRef.current,
+            follow: true,
+            priority: 4,
+            force: true,
+            offset: CAMERA_TARGET_LIFT + 0.022
+          });
+        }
       }
       updated = true;
       const status =
@@ -11937,7 +11940,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       const seatSideTarget = getWorldForProgress(player, 0, tokenIndex);
       const isSideSeat = player === 1 || player === 3;
       const enteringOffset = isSideSeat ? CAMERA_TARGET_LIFT + 0.035 : CAMERA_TARGET_LIFT + 0.02;
-      if (player !== 0) {
+      if (player !== 0 && LUDO_CAMERA_DYNAMIC_TURN_DICE_TOKEN) {
         setCameraViewForTurn(player, CAMERA_TURN_VIEW_DURATION_MS, { force: true });
         setCameraFocus({
           target: seatSideTarget,
@@ -12110,7 +12113,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     baseTarget.y = baseHeight;
     stopDiceTransition();
     dice.userData.isRolling = true;
-    if (!isHumanTurn) {
+    if (!isHumanTurn && LUDO_CAMERA_DYNAMIC_TURN_DICE_TOKEN) {
       setCameraViewForTurn(player, CAMERA_TURN_VIEW_DURATION_MS, { force: true });
       setCameraFocus({
         object: dice,
@@ -12163,24 +12166,26 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     const hasBoardMoveOption = options.some((option) => !option.entering);
     const keepTurnCameraFraming = !hasBoardTokenBeforeRoll || !options.length || !hasBoardMoveOption;
     scheduleDiceClear();
-    if (!keepTurnCameraFraming) {
-      if (!(isHumanTurn && lockUserTurnSeatViewRef.current)) {
-        setCameraFocus({
-          target: landingFocus,
-          follow: false,
-          ttl: 0.88,
-          priority: 2,
-          offset: CAMERA_TARGET_LIFT + 0.03,
-          force: true
-        });
+    if (LUDO_CAMERA_DYNAMIC_TURN_DICE_TOKEN) {
+      if (!keepTurnCameraFraming) {
+        if (!(isHumanTurn && lockUserTurnSeatViewRef.current)) {
+          setCameraFocus({
+            target: landingFocus,
+            follow: false,
+            ttl: 0.88,
+            priority: 2,
+            offset: CAMERA_TARGET_LIFT + 0.03,
+            force: true
+          });
+        }
+      } else if (!isHumanTurn) {
+        setCameraViewForTurn(player, CAMERA_TURN_VIEW_DURATION_MS, { force: true });
       }
-    } else if (!isHumanTurn) {
-      setCameraViewForTurn(player, CAMERA_TURN_VIEW_DURATION_MS, { force: true });
     }
     if (!options.length) {
       const playerCycle = Math.max(1, activePlayerCount);
       const upcomingTurn = value === 6 ? player : (player + playerCycle - 1) % playerCycle;
-      if (upcomingTurn !== 0) {
+      if (upcomingTurn !== 0 && LUDO_CAMERA_DYNAMIC_TURN_DICE_TOKEN) {
         setCameraViewForTurn(upcomingTurn, CAMERA_TURN_VIEW_DURATION_MS, { force: true });
         setCameraFocus({ target: resolveTurnLookTarget(upcomingTurn), priority: 1, force: true });
       } else {
@@ -12203,8 +12208,10 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     if (!choice) {
       const playerCycle = Math.max(1, activePlayerCount);
       const upcomingTurn = value === 6 ? player : (player + playerCycle - 1) % playerCycle;
-      setCameraViewForTurn(upcomingTurn, CAMERA_TURN_VIEW_DURATION_MS, { force: true });
-      setCameraFocus({ target: resolveTurnLookTarget(upcomingTurn), priority: 1, force: true });
+      if (LUDO_CAMERA_DYNAMIC_TURN_DICE_TOKEN) {
+        setCameraViewForTurn(upcomingTurn, CAMERA_TURN_VIEW_DURATION_MS, { force: true });
+        setCameraFocus({ target: resolveTurnLookTarget(upcomingTurn), priority: 1, force: true });
+      }
       clearTurnAdvanceTimeout();
       turnAdvanceTimeoutRef.current = window.setTimeout(() => {
         turnAdvanceTimeoutRef.current = null;


### PR DESCRIPTION
### Motivation
- The gameplay camera was reframing for player turns, dice throws and token movements, making non-animation gameplay feel dynamic instead of staying statically framed. 
- We want only cinematic/animation sequences (capture/attack FX) to move the camera while normal turn/dice/token flows keep the camera stable.

### Description
- Added a new flag `LUDO_CAMERA_DYNAMIC_TURN_DICE_TOKEN = false` to `webapp/src/pages/Games/LudoBattleRoyal.jsx` near the other camera tuning constants. 
- Wrapped the per-turn reframing logic in `advanceTurn` with a check for `LUDO_CAMERA_DYNAMIC_TURN_DICE_TOKEN` so the camera is not moved on normal turn changes when the flag is disabled. 
- Guarded token-entry framing inside `moveToken` so non-human side-seat token entry no longer forces a dynamic camera change unless the flag is enabled. 
- Guarded dice-roll and post-roll camera focus/upcoming-turn camera behavior inside `rollDice` so dice throws and follow-up framing remain static unless the flag is turned on.

### Testing
- Inspected the resulting changes in `webapp/src/pages/Games/LudoBattleRoyal.jsx` to confirm the conditional guards and the new flag are present and applied at the intended code paths. 
- Ran `npm --prefix webapp run -s lint`, which exited with a non-zero status in this environment and did not produce passing lint results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2fe5ba93c83298b85b223f5fa1b3d)