### PR TITLE
Limit dynamic camera to weapon animation sequence

### DIFF
--- a/Assets/Scripts/Gameplay/Weapons/BattleRoyaleWeaponDirector.cs
+++ b/Assets/Scripts/Gameplay/Weapons/BattleRoyaleWeaponDirector.cs
@@ -97,6 +97,7 @@ namespace TonPlaygram.Gameplay.Weapons
         private WeaponBallisticsProfile _activeWeapon;
         private Coroutine _fireRoutine;
         private Coroutine _cameraRoutine;
+        private bool _isWeaponAnimationSequenceActive;
         private ILudoWeaponEvents[] _eventListeners = Array.Empty<ILudoWeaponEvents>();
         private ILudoProjectileBroadcastEvents[] _projectileListeners = Array.Empty<ILudoProjectileBroadcastEvents>();
         private float _baseFov = 60f;
@@ -169,6 +170,7 @@ namespace TonPlaygram.Gameplay.Weapons
             int shots = weapon.fireMode == WeaponFireMode.Single ? 1 : Mathf.Max(1, weapon.magazineSize);
             float shotDelay = weapon.roundsPerSecond <= 0.001f ? 0f : 1f / weapon.roundsPerSecond;
 
+            _isWeaponAnimationSequenceActive = true;
             BeginAimCamera(weapon);
 
             for (int i = 0; i < shots; i++)
@@ -180,6 +182,9 @@ namespace TonPlaygram.Gameplay.Weapons
                     yield return new WaitForSeconds(shotDelay);
                 }
             }
+
+            yield return StartCoroutine(ReturnCameraToDefault());
+            _isWeaponAnimationSequenceActive = false;
         }
 
         private void FireSingleRound(WeaponBallisticsProfile weapon, int shotIndex, int totalShots, bool isLastBullet)
@@ -280,7 +285,10 @@ namespace TonPlaygram.Gameplay.Weapons
             ApplyProgressiveDamage(isLastBullet);
             if (isLastBullet)
             {
-                StartFinalImpactCamera(point);
+                if (_isWeaponAnimationSequenceActive)
+                {
+                    StartFinalImpactCamera(point);
+                }
                 for (int i = 0; i < _eventListeners.Length; i++)
                 {
                     _eventListeners[i].OnFinalImpact(_activeWeapon.weaponType, point);
@@ -335,7 +343,7 @@ namespace TonPlaygram.Gameplay.Weapons
 
         private void BeginAimCamera(WeaponBallisticsProfile weapon)
         {
-            if (playerCamera == null)
+            if (playerCamera == null || !_isWeaponAnimationSequenceActive)
                 return;
 
             if (_cameraRoutine != null)
@@ -402,7 +410,7 @@ namespace TonPlaygram.Gameplay.Weapons
 
         private void StartBulletFollowCamera(Transform bulletTransform, float seconds)
         {
-            if (playerCamera == null || bulletTransform == null)
+            if (playerCamera == null || bulletTransform == null || !_isWeaponAnimationSequenceActive)
                 return;
 
             if (_cameraRoutine != null)
@@ -429,7 +437,7 @@ namespace TonPlaygram.Gameplay.Weapons
 
         private void StartFinalImpactCamera(Vector3 point)
         {
-            if (playerCamera == null)
+            if (playerCamera == null || !_isWeaponAnimationSequenceActive)
                 return;
 
             if (_cameraRoutine != null)
@@ -455,7 +463,6 @@ namespace TonPlaygram.Gameplay.Weapons
                 yield return null;
             }
 
-            yield return StartCoroutine(ReturnCameraToDefault());
         }
 
         private IEnumerator ReturnCameraToDefault()


### PR DESCRIPTION
### Motivation
- Prevent dynamic camera routines from interfering with normal gameplay (player turns, dice, and token movement) by restricting cinematic camera behavior to weapon animation sequences.

### Description
- Introduced a boolean `_isWeaponAnimationSequenceActive` in `BattleRoyaleWeaponDirector` to mark the active weapon animation/fire sequence.
- Set `_isWeaponAnimationSequenceActive` at the start and end of `FireRoutine` and centralized camera reset to the fire-sequence flow by calling `ReturnCameraToDefault()` there.
- Guarded camera entry points (`BeginAimCamera`, bullet follow camera, and final impact camera) so they return early unless the weapon animation sequence is active.
- Removed the automatic camera reset call from `FinalImpactRoutine` and other scattered locations to keep camera changes confined to the animation lifecycle.

### Testing
- No automated unit or integration tests were executed for this change; review and CI builds are recommended to validate runtime behavior and ensure there are no regressions in camera ownership and presentation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2fe5ba93c83298b85b223f5fa1b3d)