### PR TITLE
Add player human rigs, animation, and human-eye camera pose for Pool Royale

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -20358,7 +20358,38 @@ const shotPowerRef = useRef(0);
           return vec;
         };
 
-        const resolveActiveHumanEyePose = () => null;
+        const resolveActiveHumanEyePose = () => {
+          const rigs = Array.isArray(playerCharacterRigsRef.current)
+            ? playerCharacterRigsRef.current
+            : [];
+          if (!rigs.length) return null;
+          const cueBall = cueRef.current;
+          const cuePos = cueBall?.pos ?? null;
+          if (!cuePos) return null;
+          const aim = aimDirRef.current;
+          if (!aim || aim.lengthSq() <= 1e-8) return null;
+          const activeRig = rigs.find((entry) => entry?.seat === activePlayerRef.current) ?? rigs[0];
+          const anim = activeRig?.group?.userData?.anim ?? null;
+          if (!anim) return null;
+          const poseT = THREE.MathUtils.clamp(anim.poseT ?? 0, 0, 1);
+          if (poseT <= HUMAN_EYE_CAMERA_MIN_BLEND) return null;
+          const right = new THREE.Vector3(aim.y, 0, -aim.x).normalize();
+          const eyePos = new THREE.Vector3(
+            anim.root.x + right.x * HUMAN_EYE_CAMERA_SIDE_OFFSET + aim.x * HUMAN_EYE_CAMERA_FORWARD_OFFSET,
+            floorY + anim.humanHeight * 0.935 + HUMAN_EYE_CAMERA_HEIGHT_OFFSET,
+            anim.root.z + right.z * HUMAN_EYE_CAMERA_SIDE_OFFSET + aim.y * HUMAN_EYE_CAMERA_FORWARD_OFFSET
+          );
+          const target = new THREE.Vector3(
+            cuePos.x + aim.x * BALL_R * 10,
+            CUE_Y + BALL_R * 0.2,
+            cuePos.y + aim.y * BALL_R * 10
+          );
+          return {
+            blend: poseT,
+            position: eyePos,
+            target
+          };
+        };
 
 
         const updateBroadcastCameras = ({
@@ -24589,7 +24620,9 @@ const shotPowerRef = useRef(0);
           scale,
           poseT: 0,
           walkT: 0,
+          breathT: 0,
           yaw: facingY,
+          root: { x, z },
           rootTarget: new THREE.Vector3(x, floorY, z),
           usesFallbackRig: false
         };
@@ -24598,11 +24631,145 @@ const shotPowerRef = useRef(0);
 
       const spawnPlayerCharacters = async () => {
         disposePlayerCharacters();
+        const seats = ['A', 'B'];
+        const loader = new GLTFLoader();
+        let template = null;
+        try {
+          const gltf = await new Promise((resolve, reject) => {
+            loader.load(BILARDO_SHQIP_HUMAN_URL, resolve, undefined, reject);
+          });
+          template = gltf?.scene ?? null;
+        } catch (err) {
+          console.warn('Pool Royale human avatar load failed, using fallback rig.', err);
+        }
+        seats.forEach((seat) => {
+          const rigGroup = createPlayerCharacterRig({
+            seat,
+            x: 0,
+            z: 0,
+            facingY: seat === 'A' ? Math.PI : 0,
+            template
+          });
+          world.add(rigGroup);
+          playerCharacterRigsRef.current.push({ seat, group: rigGroup });
+        });
       };
 
       const updatePlayerCharacters = (nowMs, dtSeconds) => {
         void nowMs;
-        void dtSeconds;
+        const cueBall = cueRef.current;
+        if (!cueBall?.pos) return;
+        const aim = aimDirRef.current;
+        if (!aim || aim.lengthSq() <= 1e-8) return;
+        const perimeterPadding = BALL_R * 7.5;
+        const railOuter = TABLE.WALL * 2.5;
+        const halfWOuter = TABLE.W / 2 + railOuter + perimeterPadding;
+        const halfHOuter = TABLE.H / 2 + railOuter + perimeterPadding;
+        const minX = -halfWOuter;
+        const maxX = halfWOuter;
+        const minZ = -halfHOuter;
+        const maxZ = halfHOuter;
+        playerCharacterRigsRef.current.forEach((entry) => {
+          const anim = entry?.group?.userData?.anim;
+          if (!anim) return;
+          const cuePos = cueBall.pos;
+          const desired = new THREE.Vector2(
+            cuePos.x - aim.x * PLAYER_CAMERA_DISTANCE * 3.2,
+            cuePos.y - aim.y * PLAYER_CAMERA_DISTANCE * 3.2
+          );
+          const perimeter = [
+            new THREE.Vector2(THREE.MathUtils.clamp(desired.x, minX, maxX), minZ),
+            new THREE.Vector2(THREE.MathUtils.clamp(desired.x, minX, maxX), maxZ),
+            new THREE.Vector2(minX, THREE.MathUtils.clamp(desired.y, minZ, maxZ)),
+            new THREE.Vector2(maxX, THREE.MathUtils.clamp(desired.y, minZ, maxZ))
+          ];
+          perimeter.sort((a, b) => a.distanceToSquared(desired) - b.distanceToSquared(desired));
+          const best = perimeter[0];
+          anim.root = anim.root || { x: best.x, z: best.y };
+          const blendTarget = cameraPhi <= CUE_SHOT_PHI + 0.045 ? 1 : 0;
+          anim.poseT = THREE.MathUtils.lerp(anim.poseT ?? 0, blendTarget, 1 - Math.exp(-dtSeconds * 8));
+          anim.breathT = (anim.breathT ?? 0) + dtSeconds * (anim.poseT > 0.5 ? 0.6 : 1.05);
+          anim.root.x = THREE.MathUtils.lerp(anim.root.x ?? best.x, best.x, 1 - Math.exp(-dtSeconds * 7));
+          anim.root.z = THREE.MathUtils.lerp(anim.root.z ?? best.y, best.y, 1 - Math.exp(-dtSeconds * 7));
+          const yaw = Math.atan2(-aim.x, -aim.y);
+          anim.yaw = THREE.MathUtils.lerp(anim.yaw ?? yaw, yaw, 1 - Math.exp(-dtSeconds * 10));
+          entry.group.position.set(anim.root.x, floorY, anim.root.z);
+          entry.group.rotation.y = anim.yaw;
+          const forward = new THREE.Vector3(aim.x, 0, aim.y).normalize();
+          const side = new THREE.Vector3(forward.z, 0, -forward.x).normalize();
+          const rootPos = entry.group.position.clone();
+          const t = THREE.MathUtils.clamp(anim.poseT, 0, 1);
+          const idle = 1 - t;
+          const breath = Math.sin(anim.breathT * Math.PI * 2) * 0.014;
+          const local = (xOff, yOff, zOff) =>
+            rootPos
+              .clone()
+              .addScaledVector(side, xOff)
+              .addScaledVector(new THREE.Vector3(0, 1, 0), yOff)
+              .addScaledVector(forward, zOff);
+
+          const bridgeTarget = new THREE.Vector3(
+            cuePos.x - aim.x * (BALL_R * 4.6),
+            CUE_Y + BALL_R * 0.42,
+            cuePos.y - aim.y * (BALL_R * 4.6)
+          );
+          const gripTarget = new THREE.Vector3(
+            cuePos.x - aim.x * (BALL_R * 10.5),
+            CUE_Y + BALL_R * 0.9,
+            cuePos.y - aim.y * (BALL_R * 10.5)
+          );
+          const torso = local(0, anim.humanHeight * (0.63 - t * 0.08), -BALL_R * (0.4 + t * 2.8));
+          const chest = local(0, anim.humanHeight * (0.78 - t * 0.11), -BALL_R * (0.6 + t * 4.2));
+          const neck = local(0, anim.humanHeight * (0.86 - t * 0.14), -BALL_R * (0.8 + t * 5.6));
+          const head = local(0, anim.humanHeight * (0.94 - t * 0.18) + breath, -BALL_R * (0.9 + t * 6.5));
+          const leftShoulder = chest.clone().addScaledVector(side, -0.22 * anim.scale);
+          const rightShoulder = chest.clone().addScaledVector(side, 0.22 * anim.scale);
+          const leftElbow = leftShoulder.clone().lerp(bridgeTarget, 0.58).addScaledVector(side, -0.04 * anim.scale).addScaledVector(new THREE.Vector3(0, 1, 0), 0.03 * anim.scale * t);
+          const rightElbow = rightShoulder.clone().lerp(gripTarget, 0.56).addScaledVector(side, -0.24 * anim.scale).addScaledVector(new THREE.Vector3(0, 1, 0), 0.34 * anim.scale * t);
+          const leftHip = local(-0.12 * anim.scale, anim.humanHeight * 0.5, -BALL_R * 0.25);
+          const rightHip = local(0.12 * anim.scale, anim.humanHeight * 0.5, -BALL_R * 0.25);
+          const leftKnee = leftHip.clone().addScaledVector(new THREE.Vector3(0, 1, 0), -0.36 * anim.scale).addScaledVector(forward, -0.04 * anim.scale * t);
+          const rightKnee = rightHip.clone().addScaledVector(new THREE.Vector3(0, 1, 0), -0.36 * anim.scale).addScaledVector(forward, 0.03 * anim.scale * t);
+          const leftFoot = local(-0.18 * anim.scale, 0.035 * anim.scale, BALL_R * 1.2).lerp(local(-0.28 * anim.scale, 0.035 * anim.scale, -BALL_R * 3.2), t);
+          const rightFoot = local(0.2 * anim.scale, 0.035 * anim.scale, -BALL_R * 0.8).lerp(local(0.3 * anim.scale, 0.035 * anim.scale, BALL_R * 3.0), t);
+
+          if (anim.model) {
+            anim.model.visible = true;
+          } else if (anim.pelvis) {
+            anim.pelvis.position.copy(local(0, anim.humanHeight * 0.54, -BALL_R * 0.5));
+            anim.torso.position.copy(torso);
+            anim.chest.position.copy(chest);
+            anim.neck.position.copy(neck);
+            anim.neck.scale.set(0.03 * anim.scale, 0.08 * anim.scale, 0.03 * anim.scale);
+            anim.head.position.copy(head);
+            setHumanoidSegment(anim.leftUpperArm, leftShoulder, leftElbow, 0.03 * anim.scale);
+            setHumanoidSegment(anim.leftLowerArm, leftElbow, bridgeTarget, 0.026 * anim.scale);
+            setHumanoidSegment(anim.rightUpperArm, rightShoulder, rightElbow, 0.032 * anim.scale);
+            setHumanoidSegment(anim.rightLowerArm, rightElbow, gripTarget, 0.027 * anim.scale);
+            setHumanoidSegment(anim.leftUpperLeg, leftHip, leftKnee, 0.046 * anim.scale);
+            setHumanoidSegment(anim.leftLowerLeg, leftKnee, leftFoot, 0.041 * anim.scale);
+            setHumanoidSegment(anim.rightUpperLeg, rightHip, rightKnee, 0.046 * anim.scale);
+            setHumanoidSegment(anim.rightLowerLeg, rightKnee, rightFoot, 0.041 * anim.scale);
+            anim.leftFoot.position.copy(leftFoot);
+            anim.rightFoot.position.copy(rightFoot);
+          }
+          if (anim.model) {
+            anim.model.visible = true;
+          }
+          if (anim.bridgeHand) {
+            anim.bridgeHand.visible = anim.poseT > 0.02;
+            anim.bridgeHand.position.copy(bridgeTarget.clone().addScaledVector(side, -0.01 * anim.scale));
+            const bridgeQ = makeHumanoidBasis(side.clone().multiplyScalar(-1), forward.clone());
+            anim.bridgeHand.quaternion.slerp(bridgeQ, 0.72);
+          }
+          if (anim.gripHand) {
+            anim.gripHand.visible = true;
+            const gripDir = bridgeTarget.clone().sub(gripTarget).normalize();
+            anim.gripHand.position.copy(gripTarget);
+            const gripQ = makeHumanoidBasis(side.clone().multiplyScalar(-1), gripDir);
+            anim.gripHand.quaternion.slerp(gripQ, 0.76);
+          }
+        });
       };
 
       void spawnPlayerCharacters();


### PR DESCRIPTION
### Motivation
- Add visible player avatars and a human-eye camera pose to improve immersion and broadcast framing in the Pool Royale scene.
- Provide physically positioned/animated rigs so broadcast cameras can blend to a player’s eye when appropriate.

### Description
- Implement `resolveActiveHumanEyePose` to compute a blended human-eye camera `position`, `target`, and `blend` from the active character rig and cue/aim state.
- Create and initialize player character rigs with additional animation state (`poseT`, `breathT`, `root`, `yaw`, etc.) and support loading an external GLTF template with a fallback rig in `spawnPlayerCharacters`.
- Add `updatePlayerCharacters` to place rigs around the table perimeter, update blend/pose/breath animations, compute limb target positions, and update visible hand/bridge/grip transforms and model visibility.
- Small data and state wiring changes to store rig `root` and `breathT` in `userData.anim` and to integrate rigs into the world scene graph.

### Testing
- Ran the project build and linting as part of local verification with no build errors reported. 
- Executed the existing automated test suite and static checks; all tests and checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2fdc06ef48329af129eebef664b4f)