### PR TITLE
Fix Ludo camera flow when swapping table/chair cosmetics

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -8761,7 +8761,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         });
       }
 
-      if (paletteChanged || tokenStyleChanged || tokenPieceChanged || tableChanged || qualityChanged) {
+      if (paletteChanged || tokenStyleChanged || tokenPieceChanged) {
         await refreshBoardTokens();
       }
     })();


### PR DESCRIPTION
### Motivation
- Prevent cosmetic changes to table/chairs/quality from disrupting the running Ludo game flow and forcing dynamic camera behavior that should be reserved for animations.

### Description
- Limit invocation of `refreshBoardTokens()` in `webapp/src/pages/Games/LudoBattleRoyal.jsx` so it runs only when token visuals change (`palette`, `tokenStyle`, `tokenPiece`) and not for `table`/`chairs`/`quality` updates.

### Testing
- No automated tests were executed for this change; change is a single-line conditional update and was verified locally via `git diff` and commit to ensure the edit is isolated and syntactically valid.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f31b19fe10832985fd0efbb3c18d3f)