### PR TITLE
Adjust Snake seated human offsets and weapon GLTF scale overrides

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -87,9 +87,9 @@ const HUMAN_MODEL_CACHE = { promise: null, template: null };
 const SEATED_HUMAN_BASE_HEIGHT = 1.74;
 const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.24;
 const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 2.21;
-// Raise seated humans higher on portrait screens to match earlier approved framing.
-const SEATED_HUMAN_SEAT_Y_OFFSET = -4.95 * MODEL_SCALE * STOOL_SCALE;
-const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.46;
+// Lift seated humans to match Chess Battle Royal lower-body seat anchoring on portrait screens.
+const SEATED_HUMAN_SEAT_Y_OFFSET = -0.78 * MODEL_SCALE * STOOL_SCALE;
+const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.05;
 // Mirror Ludo Battle Royal's deeper bottom-seat pushback so the local player sits
 // with the same portrait-facing posture/orientation while preserving Snake table scale.
 const SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET = -SEAT_DEPTH * 0.2;
@@ -317,8 +317,10 @@ const WEAPON_SLOT_LATERAL_NUDGE_BY_SEAT = Object.freeze([
 const WEAPON_DISPLAY_SIZE_MULTIPLIER = 1.72;
 const FIREARM_DISPLAY_SIZE_MULTIPLIER = 0.78;
 const FIREARM_MODEL_SCALE_BY_ID = Object.freeze({
-  'slot-10-ak47-gltf': 0.52,
-  'slot-15-sigsauer-gltf': 0.5
+  // Keep imported firearm GLTFs aligned with in-game fallback weapon proportions.
+  'slot-10-ak47-gltf': 0.34,
+  // Match SigSauer GLTF visual size to Glock sidearm profile.
+  'slot-15-sigsauer-gltf': 0.28
 });
 const WEAPON_PARKING_OUTWARD_OFFSET = TILE_SIZE * 0.88;
 const WEAPON_FROM_TOKEN_CENTER_OFFSET = TOKEN_RADIUS * 0.58;


### PR DESCRIPTION
### Motivation
- Align Snake & Ladder visual framing with Chess Battle Royal so seated humans are higher on portrait screens and imported GLTF weapons no longer appear oversized.

### Description
- Updated `SEATED_HUMAN_SEAT_Y_OFFSET` and `SEATED_HUMAN_SEAT_Z_OFFSET` in `webapp/src/components/SnakeBoard3D.jsx` to lift seated characters and match Chess Battle Royal lower-body seat anchoring.
- Rebalanced `FIREARM_MODEL_SCALE_BY_ID` in `webapp/src/components/SnakeBoard3D.jsx` by reducing `slot-10-ak47-gltf` to `0.34` and `slot-15-sigsauer-gltf` to `0.28` so the SigSauer visually matches the Glock sidearm profile and the AK47 GLTF matches the in-game AK47 proportions.
- Changes are isolated to `SnakeBoard3D.jsx` and preserve existing fallback weapon sizing and seating logic.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f31959bcac832994160dc5e99574f4)