### PR TITLE
Improve firearm capture animation and weapon swap behavior for parked vehicles

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -7700,9 +7700,20 @@ function Chess3D({
   const quickSwapWeaponList = useMemo(() => {
     const pool = quickSwapWeapons.length ? quickSwapWeapons : ownedCaptureAnimations;
     if (!weaponSwapTargetKind) return pool;
-    const filtered = pool.filter(
-      (option) => GLOBAL_CAPTURE_KIND_BY_ANIMATION_ID[option.id] === weaponSwapTargetKind
-    );
+
+    // Parked pads (jet / drone / helicopter / truck) can now be swapped with any owned firearm.
+    // Keep full firearm inventory visible when player taps one of those parked vehicles.
+    if (['jet', 'drone', 'helicopter', 'truck'].includes(weaponSwapTargetKind)) {
+      const firearmOnly = pool.filter((option) =>
+        FIREARM_CAPTURE_ANIMATION_IDS.has(option.id)
+      );
+      if (firearmOnly.length) return firearmOnly;
+    }
+
+    const filtered = pool.filter((option) => {
+      if (FIREARM_CAPTURE_ANIMATION_IDS.has(option.id)) return true;
+      return GLOBAL_CAPTURE_KIND_BY_ANIMATION_ID[option.id] === weaponSwapTargetKind;
+    });
     if (filtered.length) return filtered;
     return pool;
   }, [ownedCaptureAnimations, quickSwapWeapons, weaponSwapTargetKind]);
@@ -11117,6 +11128,25 @@ function Chess3D({
       return { pos, next };
     };
 
+    const SINGLE_SHOT_FIREARM_IDS = new Set([
+      'polyShotgun01Attack',
+      'polyShotgun02Attack',
+      'polyShotgun03Attack',
+      'sniperShotAttack',
+      'mosinMarksmanAttack',
+      'compactCarbineAttack'
+    ]);
+
+    const resolveFirearmCaptureProfile = () => {
+      const singleShot = SINGLE_SHOT_FIREARM_IDS.has(selectedCaptureAnimationId);
+      return {
+        bulletCount: singleShot ? 1 : 7,
+        duration: singleShot ? 0.62 : 1.15,
+        impactAt: singleShot ? 1 : 0.92,
+        singleShot
+      };
+    };
+
     const playCaptureAnimation = ({
       fromPos,
       targetPos,
@@ -11306,20 +11336,31 @@ function Chess3D({
         });
       }
       if (captureKind === 'firearm') {
+        const firearmProfile = resolveFirearmCaptureProfile();
         playAudio(missileLaunchSoundRef);
         const missileFx = createFxMissile();
-        missileFx.root.scale.setScalar(CAPTURE_MISSILE_SCALE * 1.25);
+        missileFx.root.scale.setScalar(CAPTURE_MISSILE_SCALE * 0.52);
+        missileFx.root.visible = false;
         captureFxGroup.add(missileFx.root);
         activeCaptureFx.push({
-          type: 'missile',
+          type: 'firearm',
           t: 0,
-          duration: LUDO_CAPTURE_MISSILE_TRAVEL_TIME,
+          duration: firearmProfile.duration,
           from: fromPos.clone(),
           to: targetPos.clone(),
           targetMesh,
-          missileFx
+          missileFx,
+          bulletCount: firearmProfile.bulletCount,
+          impactAt: firearmProfile.impactAt,
+          singleShot: firearmProfile.singleShot,
+          firedBullets: 0,
+          hitTriggered: false,
+          muzzleOffset: new THREE.Vector3(0.24, 0.14, 0)
         });
-        return withAuto3d({ moveDelayMs: LUDO_CAPTURE_TOTAL_TIME * 1000 });
+        return withAuto3d({
+          moveDelayMs: firearmProfile.duration * 1000,
+          captureResolveDelayMs: firearmProfile.duration * 1000
+        });
       }
       if (distance <= 1.5) {
         playAudio(swordSoundRef);
@@ -13531,6 +13572,43 @@ function Chess3D({
                 fx.hasExploded = true;
                 launchExplosion(targetPos);
               }
+              fx.missileFx.root.visible = false;
+              captureFxGroup.remove(fx.missileFx.root);
+              activeCaptureFx.splice(i, 1);
+            }
+          } else if (fx.type === 'firearm') {
+            const targetPos = getLiveTargetPosition(fx.to, fx.targetMesh, 0);
+            fx.to.copy(targetPos);
+            const shooterPos = fx.from.clone().lerp(targetPos, 0.24);
+            shooterPos.y += 0.24;
+            const aimDir = targetPos.clone().sub(shooterPos).normalize();
+            fx.missileFx.root.visible = true;
+            fx.missileFx.root.position.copy(shooterPos).addScaledVector(aimDir, 0.08);
+            orientForwardKeepingUp(fx.missileFx.root, aimDir);
+
+            const bulletsToFire = Math.max(1, fx.bulletCount || 1);
+            const fireStep = 1 / bulletsToFire;
+            const shouldFireCount = Math.min(
+              bulletsToFire,
+              Math.floor((u + 0.0001) / fireStep) + (u > 0.04 ? 1 : 0)
+            );
+            while (fx.firedBullets < shouldFireCount) {
+              fx.firedBullets += 1;
+              const shotProgress = clamp01(fx.firedBullets / bulletsToFire);
+              const shotPos = shooterPos.clone().lerp(targetPos, shotProgress);
+              launchExplosion(shotPos);
+              if (!fx.singleShot && fx.firedBullets < bulletsToFire) {
+                playAudio(missileImpactSoundRef, { volume: 0.25 });
+              }
+            }
+
+            if (!fx.hitTriggered && u >= fx.impactAt) {
+              fx.hitTriggered = true;
+              playAudio(missileImpactSoundRef, { volume: fx.singleShot ? 0.9 : 0.65 });
+              launchExplosion(targetPos);
+            }
+
+            if (u >= 1) {
               fx.missileFx.root.visible = false;
               captureFxGroup.remove(fx.missileFx.root);
               activeCaptureFx.splice(i, 1);


### PR DESCRIPTION
### Motivation
- Allow parked support vehicles (jet/drone/helicopter/truck) to swap into firearms inventory and make firearm captures behave more realistic for single-shot vs multi-shot weapons.
- Replace the generic missile capture behavior with a dedicated firearm path to support multi-bullet firing, hit timing and tailored audio/visuals.

### Description
- Update `quickSwapWeaponList` logic to expose firearms when the swap target kind is one of `jet`, `drone`, `helicopter`, or `truck`, and ensure firearm animations are always considered when filtering by kind.
- Add `SINGLE_SHOT_FIREARM_IDS` and `resolveFirearmCaptureProfile()` to determine per-weapon `bulletCount`, `duration`, `impactAt`, and `singleShot` behavior.
- Implement a new `firearm` active FX flow: create a smaller, initially hidden missile FX, push a `firearm` FX entry to `activeCaptureFx` with firearm-specific metadata, and return the proper `withAuto3d` delays based on the firearm profile.
- Implement update logic for `fx.type === 'firearm'` to position the shooter, step through firing bullets over progress, trigger explosions per shot, play impact audio with different volumes, and clean up the FX after completion.

### Testing
- Ran `yarn test` unit test suite and all tests passed.
- Built the frontend with `yarn build` and the build completed successfully.
- Ran `eslint` and code style checks with no reported errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f31d28b15c8329b14d762ce6386b15)