### PR TITLE
Adjust Snake & Ladder firearm scaling and seated human alignment

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -85,11 +85,11 @@ const HUMAN_MODEL_URL = 'https://threejs.org/examples/models/gltf/readyplayer.me
 const HUMAN_MODEL_CACHE = { promise: null, template: null };
 // Keep Snake seated humans aligned with Ludo/Chess Battle Royal chair anchoring and 7am scale baseline.
 const SEATED_HUMAN_BASE_HEIGHT = 1.74;
-const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.24;
-const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 2.21;
-// Raise seated humans higher on portrait screens to match earlier approved framing.
-const SEATED_HUMAN_SEAT_Y_OFFSET = -4.95 * MODEL_SCALE * STOOL_SCALE;
-const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.46;
+const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.55;
+const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 4.32;
+// Mirror Chess Battle Royal seated-body anchoring so bottom-half pose/placement is identical.
+const SEATED_HUMAN_SEAT_Y_OFFSET = -0.78 * MODEL_SCALE * STOOL_SCALE;
+const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.05;
 // Mirror Ludo Battle Royal's deeper bottom-seat pushback so the local player sits
 // with the same portrait-facing posture/orientation while preserving Snake table scale.
 const SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET = -SEAT_DEPTH * 0.2;
@@ -317,8 +317,10 @@ const WEAPON_SLOT_LATERAL_NUDGE_BY_SEAT = Object.freeze([
 const WEAPON_DISPLAY_SIZE_MULTIPLIER = 1.72;
 const FIREARM_DISPLAY_SIZE_MULTIPLIER = 0.78;
 const FIREARM_MODEL_SCALE_BY_ID = Object.freeze({
-  'slot-10-ak47-gltf': 0.52,
-  'slot-15-sigsauer-gltf': 0.5
+  // Match Gunify AK47 GLTF visual size with the in-game AK baseline.
+  'slot-10-ak47-gltf': 0.32,
+  // Match SigSauer GLTF visual size with Glock-sized sidearms.
+  'slot-15-sigsauer-gltf': 0.3
 });
 const WEAPON_PARKING_OUTWARD_OFFSET = TILE_SIZE * 0.88;
 const WEAPON_FROM_TOKEN_CENTER_OFFSET = TOKEN_RADIUS * 0.58;


### PR DESCRIPTION
### Motivation
- Imported Gunify GLTF weapons were rendering at visually incorrect sizes compared to in-game baselines, causing the SigSauer to appear much larger than the Glock and the AK47 GLTF to be oversized relative to the other AK model. 
- Seated human characters on the Snake board were positioned and scaled differently than the Chess Battle Royal setup, producing a lower visual placement for the lower body that needed to match the Chess anchoring.

### Description
- Reduced firearm render scales in `FIREARM_MODEL_SCALE_BY_ID` by setting `slot-10-ak47-gltf` to `0.32` and `slot-15-sigsauer-gltf` to `0.3` to match in-game AK and Glock-sized sidearm proportions. 
- Aligned seated human tuning to the Chess Battle Royal baseline by updating `SEATED_HUMAN_TARGET_HEIGHT`, `SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER`, `SEATED_HUMAN_SEAT_Y_OFFSET`, and `SEATED_HUMAN_SEAT_Z_OFFSET` so the bottom-half pose/placement matches Chess. 
- Change is limited to visual/tuning constants and affects `webapp/src/components/SnakeBoard3D.jsx` only, with no game logic flow changes.

### Testing
- No automated unit or integration tests were run for this tuning-only change. 
- Repository verification commands (`git -C /workspace/TonPlaygramWebApp status`, `git -C /workspace/TonPlaygramWebApp diff`, and the local commit) completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f31959bcac832994160dc5e99574f4)