### PR TITLE
Normalize Extra GLTF weapon sizes to Quaternius proportions

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -317,10 +317,18 @@ const WEAPON_SLOT_LATERAL_NUDGE_BY_SEAT = Object.freeze([
 const WEAPON_DISPLAY_SIZE_MULTIPLIER = 1.72;
 const FIREARM_DISPLAY_SIZE_MULTIPLIER = 0.78;
 const FIREARM_MODEL_SCALE_BY_ID = Object.freeze({
-  // Match Gunify AK47 GLTF visual size with the in-game AK baseline.
+  // Normalize Extra GLTF weapons against the Quaternius catalog proportions.
+  // Rifles/snipers keep longer silhouettes; sidearms stay compact in portrait view.
   'slot-10-ak47-gltf': 0.32,
-  // Match SigSauer GLTF visual size with Glock-sized sidearms.
-  'slot-15-sigsauer-gltf': 0.3
+  'slot-11-krsv-gltf': 0.31,
+  'slot-12-smith-gltf': 0.24,
+  'slot-13-mosin-gltf': 0.33,
+  'slot-14-uzi-gltf': 0.27,
+  'slot-15-sigsauer-gltf': 0.24,
+  'slot-16-awp-gltf': 0.35,
+  'slot-17-mrtk-gun-gltf': 0.29,
+  // Shotgun blast GLTF tuned to Quaternius shotgun footprint.
+  'slot-18-fps-gun-gltf': 0.28
 });
 const WEAPON_PARKING_OUTWARD_OFFSET = TILE_SIZE * 0.88;
 const WEAPON_FROM_TOKEN_CENTER_OFFSET = TOKEN_RADIUS * 0.58;


### PR DESCRIPTION
### Motivation
- Visual inconsistency: several Extra GLTF weapons (AK47 and the shotgun blast among others) appeared out of proportion compared with the Quaternius catalog when displayed in the Snake & Ladder portrait view.
- Ensure consistent weapon silhouettes so parked/capture weapons match the Quaternius baseline proportions across seats and UI scales.

### Description
- Updated the `FIREARM_MODEL_SCALE_BY_ID` map in `webapp/src/components/SnakeBoard3D.jsx` to include explicit per-weapon scale factors for slots `10`–`18` so Extra GLTF weapons normalize to Quaternius proportions.
- Added scale entries for `slot-10-ak47-gltf`, `slot-11-krsv-gltf`, `slot-12-smith-gltf`, `slot-13-mosin-gltf`, `slot-14-uzi-gltf`, `slot-15-sigsauer-gltf`, `slot-16-awp-gltf`, `slot-17-mrtk-gun-gltf`, and tuned `slot-18-fps-gun-gltf` for the shotgun footprint.
- The change is limited to the weapon display scaling constants and preserves existing placement/parking logic and other visual offsets in the same file (`SnakeBoard3D.jsx`).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f32564396483299867e390d43adfe7)