### PR TITLE
Normalize external GLTF/GLB capture-weapon scales to Quaternius proportions

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -317,10 +317,26 @@ const WEAPON_SLOT_LATERAL_NUDGE_BY_SEAT = Object.freeze([
 const WEAPON_DISPLAY_SIZE_MULTIPLIER = 1.72;
 const FIREARM_DISPLAY_SIZE_MULTIPLIER = 0.78;
 const FIREARM_MODEL_SCALE_BY_ID = Object.freeze({
-  // Match Gunify AK47 GLTF visual size with the in-game AK baseline.
+  // Keep third-party GLTF/GLB weapons visually aligned with Quaternius catalog proportions.
+  // Quaternius models are treated as baseline (multiplier 1).
+  // Match Gunify AK47 GLTF visual size with Quaternius assault-rifle baseline.
   'slot-10-ak47-gltf': 0.32,
+  // Match Gunify KRSV GLTF with Quaternius SMG/compact rifle baseline.
+  'slot-11-krsv-gltf': 0.34,
+  // Match Gunify Smith GLTF with Quaternius pistol baseline.
+  'slot-12-smith-gltf': 0.31,
+  // Match Gunify Mosin GLTF with Quaternius long-gun baseline.
+  'slot-13-mosin-gltf': 0.29,
+  // Match Gunify Uzi GLTF with Quaternius SMG baseline.
+  'slot-14-uzi-gltf': 0.33,
   // Match SigSauer GLTF visual size with Glock-sized sidearms.
-  'slot-15-sigsauer-gltf': 0.3
+  'slot-15-sigsauer-gltf': 0.3,
+  // Match external AWP GLB with Quaternius long-rifle/sniper visual footprint.
+  'slot-16-awp-glb': 0.28,
+  // Match MRTK gun GLB with Quaternius assault-rifle baseline.
+  'slot-17-mrtk-gun-glb': 0.3,
+  // Match FPS shotgun blast model with Quaternius shotgun baseline.
+  'slot-18-fps-gun-gltf': 0.24
 });
 const WEAPON_PARKING_OUTWARD_OFFSET = TILE_SIZE * 0.88;
 const WEAPON_FROM_TOKEN_CENTER_OFFSET = TOKEN_RADIUS * 0.58;


### PR DESCRIPTION
### Motivation
- External GLTF/GLB weapons (notably the AK47 and FPS shotgun) appeared visually mismatched against Quaternius catalog weapons when displayed on tokens.  
- The intent is to treat Quaternius models as the visual baseline and scale third-party imports to match those proportions for consistent in-game framing.  
- This improves swap/parking visuals and ensures capture-weapon icons read correctly at mobile portrait sizes.

### Description
- Updated `FIREARM_MODEL_SCALE_BY_ID` in `webapp/src/components/SnakeBoard3D.jsx` to include explicit per-weapon scale multipliers for external GLTF/GLB capture weapons.  
- Added scale mappings for AK47 (`slot-10-ak47-gltf`), KRSV, Smith, Mosin, Uzi, SigSauer, AWP, MRTK gun and FPS shotgun so third-party models align with Quaternius baselines.  
- Added inline comments documenting that Quaternius models are treated as the baseline (multiplier 1) and the rationale for each mapping.

### Testing
- Ran `npm run -s eslint -- src/components/SnakeBoard3D.jsx` which exited with non-zero status in this environment and produced no diagnostic output, so linting needs re-checking in CI or a local dev environment.  
- No other automated tests were executed as part of this change in the current rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f32564396483299867e390d43adfe7)