### PR TITLE
Scope attack camera to animations, add turn-focus API, and lower dice palm alignment

### DIFF
--- a/Assets/Scripts/Gameplay/Weapons/BattleRoyaleWeaponDirector.cs
+++ b/Assets/Scripts/Gameplay/Weapons/BattleRoyaleWeaponDirector.cs
@@ -90,6 +90,9 @@ namespace TonPlaygram.Gameplay.Weapons
         [SerializeField] private float cameraLookLerp = 18f;
         [SerializeField] private float cameraTrackLerp = 15f;
         [SerializeField] private Vector3 swapIconWorldOffset = new Vector3(0f, 0.11f, 0f);
+        [SerializeField] private bool allowDynamicCameraOnlyDuringAnimation = true;
+        [SerializeField] private float turnFocusDuration = 0.22f;
+
 
         private readonly Dictionary<LudoWeaponType, WeaponBallisticsProfile> _profiles = new Dictionary<LudoWeaponType, WeaponBallisticsProfile>();
         private readonly List<TokenPieceHealth> _tokenPieces = new List<TokenPieceHealth>();
@@ -107,6 +110,7 @@ namespace TonPlaygram.Gameplay.Weapons
         private Quaternion _weaponRootLocalRot;
         private Vector3 _swapIconWorldPos;
         private Quaternion _swapIconWorldRot;
+        private bool _isAnimationCameraActive;
 
         private void Awake()
         {
@@ -169,6 +173,7 @@ namespace TonPlaygram.Gameplay.Weapons
             int shots = weapon.fireMode == WeaponFireMode.Single ? 1 : Mathf.Max(1, weapon.magazineSize);
             float shotDelay = weapon.roundsPerSecond <= 0.001f ? 0f : 1f / weapon.roundsPerSecond;
 
+            _isAnimationCameraActive = true;
             BeginAimCamera(weapon);
 
             for (int i = 0; i < shots; i++)
@@ -179,6 +184,11 @@ namespace TonPlaygram.Gameplay.Weapons
                 {
                     yield return new WaitForSeconds(shotDelay);
                 }
+            }
+
+            if (_cameraRoutine == null)
+            {
+                yield return StartCoroutine(ReturnCameraToDefault());
             }
         }
 
@@ -410,6 +420,11 @@ namespace TonPlaygram.Gameplay.Weapons
                 StopCoroutine(_cameraRoutine);
             }
 
+            if (allowDynamicCameraOnlyDuringAnimation && !_isAnimationCameraActive)
+            {
+                return;
+            }
+
             _cameraRoutine = StartCoroutine(BulletFollowRoutine(bulletTransform, seconds));
         }
 
@@ -482,6 +497,32 @@ namespace TonPlaygram.Gameplay.Weapons
 
                 playerCamera.transform.localPosition = Vector3.Lerp(fromPos, _baseCameraLocalPos, t);
                 playerCamera.transform.localRotation = Quaternion.Slerp(playerCamera.transform.localRotation, _baseCameraLocalRot, t);
+                yield return null;
+            }
+
+            _isAnimationCameraActive = false;
+            _cameraRoutine = null;
+        }
+
+        public void FocusCameraOnTurn(Transform turnAnchor)
+        {
+            if (playerCamera == null || turnAnchor == null || _isAnimationCameraActive)
+                return;
+
+            StartCoroutine(FocusTurnRoutine(turnAnchor));
+        }
+
+        private IEnumerator FocusTurnRoutine(Transform turnAnchor)
+        {
+            Vector3 fromForward = playerCamera.transform.forward;
+            float elapsed = 0f;
+            float duration = Mathf.Max(0.01f, turnFocusDuration);
+            while (elapsed < duration && turnAnchor != null && !_isAnimationCameraActive)
+            {
+                elapsed += Time.deltaTime;
+                Vector3 toTarget = (turnAnchor.position - playerCamera.transform.position).normalized;
+                Vector3 lerped = Vector3.Slerp(fromForward, toTarget, Mathf.Clamp01(elapsed / duration));
+                playerCamera.transform.rotation = Quaternion.LookRotation(lerped, Vector3.up);
                 yield return null;
             }
         }

--- a/Assets/Scripts/Gameplay/Weapons/LudoDicePalmAlignment.cs
+++ b/Assets/Scripts/Gameplay/Weapons/LudoDicePalmAlignment.cs
@@ -11,7 +11,7 @@ namespace TonPlaygram.Gameplay.Weapons
         [SerializeField] private Transform diceTransform;
         [SerializeField] private Transform palmAnchor;
         [SerializeField] private bool alignEveryFrame = true;
-        [SerializeField] private Vector3 palmOffset = new Vector3(0f, -0.012f, 0.016f);
+        [SerializeField] private Vector3 palmOffset = new Vector3(0f, -0.03f, 0.02f);
         [SerializeField] private Vector3 palmEulerOffset = new Vector3(5f, 0f, 90f);
 
         private Quaternion _localRotationOffset;


### PR DESCRIPTION
### Motivation
- Prevent the camera from drifting when menu/chair options change and keep dynamic camera motion limited to attack/animation windows. 
- Ensure attacker-facing aiming view and bullet/pellet follow only run while a firing animation or projectile-follow window is active. 
- Provide a small API for the turn/dice system to smoothly steer the camera toward the active player at dice timing. 
- Improve dice grabbing feel by moving the palm contact point lower and slightly forward so the hand reaches the dice more naturally.

### Description
- Added two serialized inspector knobs `allowDynamicCameraOnlyDuringAnimation` and `turnFocusDuration` plus a private `_isAnimationCameraActive` flag to `BattleRoyaleWeaponDirector` to scope cinematic camera behavior. 
- Mark the animation-camera lifecycle as active inside the firing flow (`FireRoutine`) and return the camera to default when the cinematic finishes, clearing the active flag when done. 
- Gate `StartBulletFollowCamera` so bullets/pellets only trigger camera-follow when `_isAnimationCameraActive` (respecting `allowDynamicCameraOnlyDuringAnimation`), and added `FocusCameraOnTurn(Transform)` with `FocusTurnRoutine` to smoothly orient the camera toward an active player anchor. 
- Tuned `LudoDicePalmAlignment` by lowering and slightly forward-offsetting the `palmOffset` so the right hand reaches lower to touch/grab the dice (`palmOffset` changed to `(0f, -0.03f, 0.02f)`).

### Testing
- Ran repository static checks and searches with `rg` to locate impacted camera and dice code and confirm edits were applied, and inspected the `git diff` for the two modified files; those CLI checks completed successfully. 
- Created the code change and committed it to the branch (commit recorded), and verified the modified files are present in the working tree. 
- No Unity runtime or playmode tests were executed in this environment, so camera timing/animation integration and in-editor feel should be validated in the Unity editor or automated playmode tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f332c640c0832984965bf0e1118309)