### PR TITLE
Stabilize cue/camera behavior on menu/chair changes and lower dice grab reach

### DIFF
--- a/Assets/Scripts/Gameplay/CueController.cs
+++ b/Assets/Scripts/Gameplay/CueController.cs
@@ -202,17 +202,6 @@ namespace Aiming
         public void SetCameraLowered(bool lowered)
         {
             _cameraLowered = lowered;
-
-            if (_cameraLowered && _shotState == ShotState.Idle)
-            {
-                BeginCharge();
-                return;
-            }
-
-            if (!_cameraLowered && _shotState == ShotState.Dragging && _power < releaseTriggerThresholdNormalized)
-            {
-                CancelCharge();
-            }
         }
 
         public void CancelCharge()

--- a/Assets/Scripts/Gameplay/Weapons/LudoDicePalmAlignment.cs
+++ b/Assets/Scripts/Gameplay/Weapons/LudoDicePalmAlignment.cs
@@ -13,6 +13,8 @@ namespace TonPlaygram.Gameplay.Weapons
         [SerializeField] private bool alignEveryFrame = true;
         [SerializeField] private Vector3 palmOffset = new Vector3(0f, -0.012f, 0.016f);
         [SerializeField] private Vector3 palmEulerOffset = new Vector3(5f, 0f, 90f);
+        [Tooltip("Extra downward reach in palm local space so the right hand physically goes lower toward the dice.")]
+        [SerializeField] private float extraDownwardReach = 0.018f;
 
         private Quaternion _localRotationOffset;
 
@@ -41,7 +43,8 @@ namespace TonPlaygram.Gameplay.Weapons
             if (diceTransform == null || palmAnchor == null)
                 return;
 
-            diceTransform.position = palmAnchor.TransformPoint(palmOffset);
+            Vector3 adjustedOffset = palmOffset + (Vector3.down * Mathf.Max(0f, extraDownwardReach));
+            diceTransform.position = palmAnchor.TransformPoint(adjustedOffset);
             diceTransform.rotation = palmAnchor.rotation * _localRotationOffset;
         }
     }


### PR DESCRIPTION
### Motivation
- Prevent camera/menu/chair option toggles from unintentionally starting or cancelling cue charge so the camera remains stable when users change chairs or settings.
- Improve tactile feel when grabbing dice by letting the right hand reach lower toward the dice during grab/hold poses.

### Description
- Decoupled camera state from shot charge by removing the auto `BeginCharge`/`CancelCharge` logic from `SetCameraLowered` in `CueController.cs`, so `SetCameraLowered` only sets the `_cameraLowered` flag.
- Added a configurable `extraDownwardReach` (`float`, default `0.018`) to `LudoDicePalmAlignment.cs` and apply it to the palm snap offset so the dice sits lower in the palm and the hand appears to reach down more when grabbing.

### Testing
- No automated unit or CI tests for these gameplay scripts were executed as part of this change; file-level checks (`git diff` / `git commit`) completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f332c640c0832984965bf0e1118309)