### PR TITLE
Fix Ludo camera stability, turn focus timing, and dice reach pose

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -3224,10 +3224,10 @@ const SEATED_HUMAN_DOWNWARD_CONTACT_MODE_SET = new Set([
 const SEATED_HELPER_FORWARD_DICE_PICKUP = 0.057 * MODEL_SCALE;
 const SEATED_HELPER_FORWARD_DICE_RELEASE = 0.112 * MODEL_SCALE;
 const SEATED_HELPER_RIGHT_DICE = -0.003 * MODEL_SCALE;
-const SEATED_HELPER_UP_DICE_PICKUP = 0.012 * MODEL_SCALE;
+const SEATED_HELPER_UP_DICE_PICKUP = -0.008 * MODEL_SCALE;
 const SEATED_HELPER_UP_DICE_RELEASE = 0.019 * MODEL_SCALE;
 const SEATED_HELPER_FORWARD_DICE_HOLD = 0.056 * MODEL_SCALE;
-const SEATED_HELPER_UP_DICE_HOLD = 0.011 * MODEL_SCALE;
+const SEATED_HELPER_UP_DICE_HOLD = -0.006 * MODEL_SCALE;
 const SEATED_DICE_HOLD_VERTICAL_NUDGE = 0.012;
 const SEATED_DICE_THROW_VERTICAL_NUDGE = -0.01;
 const SEATED_HELPER_FORWARD_TOKEN_PICKUP = 0.076 * MODEL_SCALE;
@@ -3304,7 +3304,7 @@ const USER_TURN_CAMERA_LIFT = 0;
 const LUDO_CAMERA_AUTO_LOOK_ENABLED = true;
 const LUDO_CAMERA_BROADCAST_LOCKED_POSITION = false;
 const LUDO_CAMERA_SEAT_LOCK_ENABLED = true;
-const LUDO_CAMERA_ANIMATION_BOTTOM_TURN_VIEW = false;
+const LUDO_CAMERA_ANIMATION_BOTTOM_TURN_VIEW = true;
 const CAPTURE_ATTACK_CAMERA_FRAME = Object.freeze({
   fighterJetAttack: { focusWeight: 0.52, targetLift: 0.014, followPullback: 0.082, followLift: 0.022 },
   helicopterAttack: { focusWeight: 0.56, targetLift: 0.02, followPullback: 0.068, followLift: 0.026 },
@@ -7768,6 +7768,12 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         preferredTextureSizes: textureResolutionStack
       };
       const token = ++chairBuildTokenRef.current;
+      const camera = cameraRef.current;
+      const controls = controlsRef.current;
+      const savedCameraPose =
+        camera && controls
+          ? { position: camera.position.clone(), target: controls.target.clone() }
+          : null;
       const chairBuild = await buildChairTemplate(stoolTheme, renderer, textureOptions);
       if (chairBuildTokenRef.current !== token || !chairBuild) return;
 
@@ -7802,6 +7808,11 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       });
       groundArenaToHdriFloor({ preserveView: true });
       updateEnvironmentFloor();
+      if (savedCameraPose && cameraRef.current && controlsRef.current) {
+        cameraRef.current.position.copy(savedCameraPose.position);
+        controlsRef.current.target.copy(savedCameraPose.target);
+        controlsRef.current.update();
+      }
     },
     [groundArenaToHdriFloor, textureResolutionStack, updateEnvironmentFloor]
   );
@@ -8249,6 +8260,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       return;
     }
     beginDiceHoldPose(player, { startMs: performance.now() - 220 });
+    setCameraViewForTurn(player, 240, { force: true });
     animateDicePosition(dice, target, {
       duration: 260,
       lift: 0.03,


### PR DESCRIPTION
### Motivation
- Prevent the camera from jumping or dropping when the player changes chair/stool options in the UI so the visual framing remains stable.
- Make the camera move to the active player's view at the same time the dice move so the turn-focus timing feels synchronized.
- Improve the seated human's dice grab so the right hand actually reaches lower and appears to touch the dice.
- Enable camera side/aiming framing during capture/attack animations only, so weapon aiming views play when animations are active.

### Description
- Adjusted seated helper offsets by lowering `SEATED_HELPER_UP_DICE_PICKUP` and `SEATED_HELPER_UP_DICE_HOLD` so the avatar's right hand reaches further down for dice grabs (constants changed in `LudoBattleRoyal.jsx`).
- Enabled bottom-turn animation camera mode (`LUDO_CAMERA_ANIMATION_BOTTOM_TURN_VIEW = true`) to allow side/aiming framing during capture attack sequences (in `LudoBattleRoyal.jsx`).
- Snapshot and restore the current camera `position` and `controls.target` around chair/stool rebuilds inside `rebuildChairs` so changing a chair theme does not alter the camera pose (save/restore logic added to `LudoBattleRoyal.jsx`).
- Force camera alignment to the active player at the start of the dice move-to-rail animation by calling `setCameraViewForTurn(player, 240, { force: true })` before `animateDicePosition`, synchronizing camera motion with dice animation (change in `moveDiceToRail` / dice animation flow in `LudoBattleRoyal.jsx`).

### Testing
- Ran the production build with `npm --prefix webapp run -s build` and it completed successfully (no compile errors).
- Build emitted existing Vite warnings about a duplicate package key and large chunk size/dynamic import recommendations, but these are non-blocking and unrelated to the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f332c640c0832984965bf0e1118309)