### PR TITLE
Align human cue grip to cue butt and refine shooting IK for Pool Royale

### DIFF
--- a/webapp/src/pages/Games/shared/bilardoHumanRig.js
+++ b/webapp/src/pages/Games/shared/bilardoHumanRig.js
@@ -11,10 +11,19 @@ const CFG = {
   edgeMargin: 0.58,
   desiredShootDistance: 1.06,
   chinToCueHeight: 0.11,
-  cueArmElbowRise: 0.43,
+  cueArmElbowRise: 0.84,
   strikeTime: 0.12,
   holdTime: 0.05,
   tableTopY: 0.84
+  ,
+  shootCueGripFromBack: 0.58,
+  rightHandShotExtraBack: 0.18,
+  rightHandShotLift: 0.055,
+  rightHandForwardClamp: -0.08,
+  rightHandOutward: 0.14,
+  rightHandRollIdle: -2.2,
+  rightHandRollShoot: -2.05,
+  rightHandCueSocketLocal: new THREE.Vector3(-0.004, -0.014, 0.092)
 };
 
 const Y_AXIS = new THREE.Vector3(0, 1, 0);
@@ -171,6 +180,11 @@ function rotateBoneToward(bone, target, strength = 1, fallbackDir = UP) {
 function twistBone(bone, axis, amount) { if (!bone || Math.abs(amount) < 1e-5) return; setBoneWorldQuaternion(bone, new THREE.Quaternion().setFromAxisAngle(axis.clone().normalize(), amount).multiply(bone.getWorldQuaternion(new THREE.Quaternion()))); }
 function aimTwoBone(upper, lower, elbow, hand, pole, upperStrength = 0.96, lowerStrength = 0.98) { for (let i = 0; i < 2; i += 1) { rotateBoneToward(upper, elbow, upperStrength, pole); rotateBoneToward(lower, hand, lowerStrength, pole); twistBone(upper, pole, 0.025 * upperStrength); } }
 function setHandBasis(bone, side, up, forward, roll = 0, strength = 1) { if (!bone || strength <= 0) return; const q = makeBasisQuaternion(side, up, forward); if (Math.abs(roll) > 1e-4) q.multiply(new THREE.Quaternion().setFromAxisAngle(forward.clone().normalize(), roll)); setBoneWorldQuaternion(bone, bone.getWorldQuaternion(new THREE.Quaternion()).slerp(q, clamp01(strength))); }
+function cueSocketOffsetWorld(side, up, forward, roll, socketLocal) {
+  const q = makeBasisQuaternion(side, up, forward);
+  if (Math.abs(roll) > 1e-5) q.multiply(new THREE.Quaternion().setFromAxisAngle(forward.clone().normalize(), roll));
+  return socketLocal.clone().applyQuaternion(q);
+}
 
 function poseFingers(fingers, mode, weight) {
   const w = clamp01(weight);
@@ -233,9 +247,29 @@ export function updateBilardoHumanPose(human, dt, frameData) {
   const rightFoot = local(new THREE.Vector3(0.13, 0.035, -0.03 - walk * 0.03).lerp(new THREE.Vector3(cfg.stanceWidth * 0.5, 0.035, 0.36), t));
   const bridgePalmTarget = frameData.bridgeTarget.clone().addScaledVector(forward, -0.006 * t).addScaledVector(side, -0.012 * t).setY(cfg.tableTopY + cfg.bridgePalmTableLift).addScaledVector(UP, -0.01 * human.settleT);
   const leftHand = frameData.idleLeft.clone().lerp(bridgePalmTarget, t);
-  const rightHand = frameData.idleRight.clone().lerp(frameData.gripTarget.clone().addScaledVector(forward, 0.046 * stroke * t + 0.065 * follow * power).addScaledVector(UP, -0.004 * follow), t);
+  const cueDirForHand = frameData.cueTip.clone().sub(frameData.cueBack).normalize();
+  const handIk = easeInOut(clamp01(t));
+  const idleGripSide = side.clone().multiplyScalar(-1).addScaledVector(UP, -0.55).addScaledVector(forward, 0.16).normalize();
+  const idleGripUp = UP.clone().multiplyScalar(-1.0).addScaledVector(side, -0.64).addScaledVector(forward, 0.2).normalize();
+  const liveGripSide = side.clone().multiplyScalar(-1).addScaledVector(UP, lerp(-0.55, -0.2, handIk)).addScaledVector(side, 0.18 * handIk).addScaledVector(forward, lerp(0.16, -0.02, handIk)).normalize();
+  const liveGripUp = UP.clone().multiplyScalar(lerp(-1.0, 0.74, handIk)).addScaledVector(side, lerp(-0.64, -0.22, handIk)).addScaledVector(forward, lerp(0.2, -0.22, handIk)).normalize();
+  const backLockedGripPoint = frameData.cueBack.clone()
+    .addScaledVector(cueDirForHand, cfg.shootCueGripFromBack)
+    .addScaledVector(forward, cfg.rightHandForwardClamp - cfg.rightHandShotExtraBack * t)
+    .addScaledVector(UP, cfg.rightHandShotLift * t)
+    .addScaledVector(side, cfg.rightHandOutward * t);
+  const liveCueGripPoint = backLockedGripPoint
+    .addScaledVector(forward, 0.012 * stroke * t + 0.012 * follow * power)
+    .addScaledVector(side, cfg.rightHandOutward * 0.25 * t);
+  const idleWristTarget = frameData.idleRight.clone().sub(
+    cueSocketOffsetWorld(idleGripSide, idleGripUp, cueDirForHand, cfg.rightHandRollIdle, cfg.rightHandCueSocketLocal)
+  );
+  const liveWristTarget = liveCueGripPoint.clone().sub(
+    cueSocketOffsetWorld(liveGripSide, liveGripUp, cueDirForHand, lerp(cfg.rightHandRollIdle, cfg.rightHandRollShoot, handIk), cfg.rightHandCueSocketLocal)
+  );
+  const rightHand = idleWristTarget.clone().lerp(liveWristTarget, t);
   const leftElbow = leftShoulder.clone().lerp(leftHand, 0.62).addScaledVector(UP, 0.006 * t).addScaledVector(side, -0.044 * t).addScaledVector(forward, 0.065 * t);
-  const rightElbow = rightHand.clone().addScaledVector(UP, lerp(0.18, cfg.cueArmElbowRise, t)).addScaledVector(side, lerp(0.03, 0.07, t)).addScaledVector(forward, lerp(-0.03, 0, t));
+  const rightElbow = rightHand.clone().addScaledVector(UP, lerp(0.12, cfg.cueArmElbowRise, t)).addScaledVector(side, lerp(-0.18, -0.34, t)).addScaledVector(forward, lerp(-0.04, -0.82, t));
   const leftKnee = leftHip.clone().lerp(leftFoot, 0.53).addScaledVector(UP, lerp(0.18, 0.105, t)).addScaledVector(forward, 0.052 * t).addScaledVector(side, -0.016 * t);
   const rightKnee = rightHip.clone().lerp(rightFoot, 0.52).addScaledVector(UP, lerp(0.18, 0.08, t)).addScaledVector(forward, -0.032 * t).addScaledVector(side, 0.018 * t);
   human.root.visible = true;


### PR DESCRIPTION
### Motivation
- Make the player avatar hold the cue from the rear (butt) side and stop the right hand drifting toward the shaft, matching the provided reference behavior.
- Improve shot posture so elbow trajectory, wrist placement and cue seating look natural across idle/aim/strike blends.

### Description
- Added tuning constants and socket offset data to `webapp/src/pages/Games/shared/bilardoHumanRig.js` to support rear-grip behavior (`shootCueGripFromBack`, hand offsets, roll values, `rightHandCueSocketLocal`).
- Added `cueSocketOffsetWorld` helper to compute the cue-to-wrist offset in world space and keep the cue visually seated inside the right hand during blends.
- Reworked right-hand IK in `updateBilardoHumanPose` to compute idle vs live wrist targets from the cue back/tip direction and lerp between them so the grip locks toward the cue butt.
- Adjusted elbow / cue-arm tuning (`cueArmElbowRise` and right-elbow placement) so pull/strike posture matches the new rear-grip stance.

### Testing
- No automated tests were executed for this patch; only the rig file was modified and committed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f33a8b38f48329a824a3a2eccc39fb)