### PR TITLE
Adjust seated human transforms and weapon scale constants in SnakeBoard3D

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -86,13 +86,13 @@ const HUMAN_MODEL_CACHE = { promise: null, template: null };
 // Keep Snake seated humans aligned with Ludo/Chess Battle Royal chair anchoring and 7am scale baseline.
 const SEATED_HUMAN_BASE_HEIGHT = 1.74;
 const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.55;
-const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 4.32;
+const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 2.86;
 // Mirror Chess Battle Royal seated-body anchoring so bottom-half pose/placement is identical.
-const SEATED_HUMAN_SEAT_Y_OFFSET = -0.78 * MODEL_SCALE * STOOL_SCALE;
-const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.05;
+const SEATED_HUMAN_SEAT_Y_OFFSET = -0.46 * MODEL_SCALE * STOOL_SCALE;
+const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.2;
 // Mirror Ludo Battle Royal's deeper bottom-seat pushback so the local player sits
 // with the same portrait-facing posture/orientation while preserving Snake table scale.
-const SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET = -SEAT_DEPTH * 0.2;
+const SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET = -SEAT_DEPTH * 0.44;
 const SEATED_HUMAN_FACING_Y = 0;
 const SEATED_HUMAN_FOOT_GROUND_Y = -1.26 * MODEL_SCALE * STOOL_SCALE;
 const HUMAN_FRONT_SIDE_Z = 1;
@@ -320,23 +320,23 @@ const FIREARM_MODEL_SCALE_BY_ID = Object.freeze({
   // Keep third-party GLTF/GLB weapons visually aligned with Quaternius catalog proportions.
   // Quaternius models are treated as baseline (multiplier 1).
   // Match Gunify AK47 GLTF visual size with Quaternius assault-rifle baseline.
-  'slot-10-ak47-gltf': 0.32,
+  'slot-10-ak47-gltf': 0.11,
   // Match Gunify KRSV GLTF with Quaternius SMG/compact rifle baseline.
-  'slot-11-krsv-gltf': 0.34,
+  'slot-11-krsv-gltf': 0.12,
   // Match Gunify Smith GLTF with Quaternius pistol baseline.
-  'slot-12-smith-gltf': 0.31,
+  'slot-12-smith-gltf': 0.1,
   // Match Gunify Mosin GLTF with Quaternius long-gun baseline.
-  'slot-13-mosin-gltf': 0.29,
+  'slot-13-mosin-gltf': 0.1,
   // Match Gunify Uzi GLTF with Quaternius SMG baseline.
-  'slot-14-uzi-gltf': 0.33,
+  'slot-14-uzi-gltf': 0.11,
   // Match SigSauer GLTF visual size with Glock-sized sidearms.
-  'slot-15-sigsauer-gltf': 0.3,
+  'slot-15-sigsauer-gltf': 0.1,
   // Match external AWP GLB with Quaternius long-rifle/sniper visual footprint.
-  'slot-16-awp-glb': 0.28,
+  'slot-16-awp-glb': 0.09,
   // Match MRTK gun GLB with Quaternius assault-rifle baseline.
-  'slot-17-mrtk-gun-glb': 0.3,
+  'slot-17-mrtk-gun-glb': 0.1,
   // Match FPS shotgun blast model with Quaternius shotgun baseline.
-  'slot-18-fps-gun-gltf': 0.24
+  'slot-18-fps-gun-gltf': 0.08
 });
 const WEAPON_PARKING_OUTWARD_OFFSET = TILE_SIZE * 0.88;
 const WEAPON_FROM_TOKEN_CENTER_OFFSET = TOKEN_RADIUS * 0.58;


### PR DESCRIPTION
### Motivation
- Correct visual alignment of seated humans with other board variants by changing scale and seat offsets to match anchoring and portrait-facing posture.
- Make third-party weapon GLTF/GLB models visually consistent with the Quaternius catalog baseline by reducing per-model scale multipliers. 
- Reduce discrepancies in local-player bottom-seat placement so portrait orientation and foot grounding are preserved at current table scale.

### Description
- Reduced `SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER` from `4.32` to `2.86` and adjusted seating offsets `SEATED_HUMAN_SEAT_Y_OFFSET` and `SEATED_HUMAN_SEAT_Z_OFFSET` to `-0.46 * MODEL_SCALE * STOOL_SCALE` and `-SEAT_DEPTH * 0.2` respectively. 
- Increased `SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET` from `-SEAT_DEPTH * 0.2` to `-SEAT_DEPTH * 0.44` to move the local player slightly further back. 
- Updated `FIREARM_MODEL_SCALE_BY_ID` values to much smaller multipliers for third-party weapons (slots `slot-10` through `slot-18`) to better match Quaternius visual footprints. 

### Testing
- Ran unit tests with `yarn test` and all tests passed. 
- Ran the linter with `yarn lint` and there were no linting errors. 
- Built the webapp with `yarn build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f33100385883299a96da66ca099916)