### PR TITLE
Adjust seated human anchoring and reduce visual scales for external weapon models

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -86,13 +86,13 @@ const HUMAN_MODEL_CACHE = { promise: null, template: null };
 // Keep Snake seated humans aligned with Ludo/Chess Battle Royal chair anchoring and 7am scale baseline.
 const SEATED_HUMAN_BASE_HEIGHT = 1.74;
 const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.55;
-const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 4.32;
+const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 2.78;
 // Mirror Chess Battle Royal seated-body anchoring so bottom-half pose/placement is identical.
-const SEATED_HUMAN_SEAT_Y_OFFSET = -0.78 * MODEL_SCALE * STOOL_SCALE;
-const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.05;
+const SEATED_HUMAN_SEAT_Y_OFFSET = -0.52 * MODEL_SCALE * STOOL_SCALE;
+const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.16;
 // Mirror Ludo Battle Royal's deeper bottom-seat pushback so the local player sits
 // with the same portrait-facing posture/orientation while preserving Snake table scale.
-const SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET = -SEAT_DEPTH * 0.2;
+const SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET = -SEAT_DEPTH * 0.42;
 const SEATED_HUMAN_FACING_Y = 0;
 const SEATED_HUMAN_FOOT_GROUND_Y = -1.26 * MODEL_SCALE * STOOL_SCALE;
 const HUMAN_FRONT_SIDE_Z = 1;
@@ -320,23 +320,23 @@ const FIREARM_MODEL_SCALE_BY_ID = Object.freeze({
   // Keep third-party GLTF/GLB weapons visually aligned with Quaternius catalog proportions.
   // Quaternius models are treated as baseline (multiplier 1).
   // Match Gunify AK47 GLTF visual size with Quaternius assault-rifle baseline.
-  'slot-10-ak47-gltf': 0.32,
+  'slot-10-ak47-gltf': 0.11,
   // Match Gunify KRSV GLTF with Quaternius SMG/compact rifle baseline.
-  'slot-11-krsv-gltf': 0.34,
+  'slot-11-krsv-gltf': 0.12,
   // Match Gunify Smith GLTF with Quaternius pistol baseline.
-  'slot-12-smith-gltf': 0.31,
+  'slot-12-smith-gltf': 0.1,
   // Match Gunify Mosin GLTF with Quaternius long-gun baseline.
-  'slot-13-mosin-gltf': 0.29,
+  'slot-13-mosin-gltf': 0.095,
   // Match Gunify Uzi GLTF with Quaternius SMG baseline.
-  'slot-14-uzi-gltf': 0.33,
+  'slot-14-uzi-gltf': 0.11,
   // Match SigSauer GLTF visual size with Glock-sized sidearms.
-  'slot-15-sigsauer-gltf': 0.3,
+  'slot-15-sigsauer-gltf': 0.1,
   // Match external AWP GLB with Quaternius long-rifle/sniper visual footprint.
-  'slot-16-awp-glb': 0.28,
+  'slot-16-awp-glb': 0.09,
   // Match MRTK gun GLB with Quaternius assault-rifle baseline.
-  'slot-17-mrtk-gun-glb': 0.3,
+  'slot-17-mrtk-gun-glb': 0.1,
   // Match FPS shotgun blast model with Quaternius shotgun baseline.
-  'slot-18-fps-gun-gltf': 0.24
+  'slot-18-fps-gun-gltf': 0.085
 });
 const WEAPON_PARKING_OUTWARD_OFFSET = TILE_SIZE * 0.88;
 const WEAPON_FROM_TOKEN_CENTER_OFFSET = TOKEN_RADIUS * 0.58;


### PR DESCRIPTION
### Motivation
- Improve seated human placement and visual proportions on the 3D Snake board to match other game boards and portrait-facing posture expectations.
- Normalize third-party weapon model visual sizes to better align with the Quaternius catalog baseline and avoid oversized external assets.

### Description
- Reduced `SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER` from `4.32` to `2.78` to shrink seated human visuals.
- Adjusted seating offsets: `SEATED_HUMAN_SEAT_Y_OFFSET` from `-0.78` to `-0.52` (times scale), `SEATED_HUMAN_SEAT_Z_OFFSET` from `-SEAT_DEPTH * 0.05` to `-SEAT_DEPTH * 0.16`, and `SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET` from `-SEAT_DEPTH * 0.2` to `-SEAT_DEPTH * 0.42` to reposition avatars on chairs.
- Recalibrated multiple entries in `FIREARM_MODEL_SCALE_BY_ID` to much smaller multipliers (e.g. `slot-10-ak47-gltf` from `0.32` to `0.11`, `slot-11-krsv-gltf` from `0.34` to `0.12`, etc.) to bring external weapon models into visual parity with internal baselines.

### Testing
- Ran the project unit test suite with `yarn test`, and all tests passed.
- Performed a headless build with `yarn build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f33100385883299a96da66ca099916)