### PR TITLE
Fix first-person seat camera to follow avatar eye orientation

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -5983,14 +5983,38 @@ function resolveSeatedFaceCameraPose(actorEntry, fallbackTarget = null) {
   const target = new THREE.Vector3();
   faceHelper.updateMatrixWorld?.(true);
   faceHelper.getWorldPosition(position);
-  if (fallbackTarget?.isVector3) {
-    target.copy(fallbackTarget);
-  } else if (actorEntry?.rig?.head?.isBone) {
-    actorEntry.rig.head.updateMatrixWorld?.(true);
-    actorEntry.rig.head.getWorldPosition(target);
-  } else {
-    target.copy(position).add(new THREE.Vector3(0, -0.005, 0.08 * MODEL_SCALE));
+
+  const headBone = actorEntry?.rig?.head;
+  const headQuaternion = new THREE.Quaternion();
+  const headForward = new THREE.Vector3(0, 0, 1);
+  if (headBone?.isBone) {
+    headBone.updateMatrixWorld?.(true);
+    headBone.getWorldQuaternion?.(headQuaternion);
+    headForward.applyQuaternion(headQuaternion).normalize();
   }
+
+  if (headForward.lengthSq() < 1e-6) {
+    headForward.set(0, 0, 1);
+  }
+
+  const lookDistance = 1.45 * MODEL_SCALE;
+  target.copy(position).addScaledVector(headForward, lookDistance);
+
+  // Keep a stable horizon-level gaze for first-person eye view and avoid vertical jumps.
+  target.y = position.y;
+
+  if (fallbackTarget?.isVector3) {
+    const boardForwardTarget = fallbackTarget.clone();
+    boardForwardTarget.y = position.y;
+    const toBoard = boardForwardTarget.sub(position);
+    if (toBoard.lengthSq() > 1e-6) {
+      toBoard.normalize();
+      const blendedForward = headForward.clone().lerp(toBoard, 0.12).normalize();
+      target.copy(position).addScaledVector(blendedForward, lookDistance);
+      target.y = position.y;
+    }
+  }
+
   return {
     position,
     target


### PR DESCRIPTION
### Motivation
- Ensure the first-person (bottom/player) camera is precisely aligned to the human avatar's eye direction and remove vertical jumps when the seat camera is reapplied so the player perspective feels stable and accurate.

### Description
- Change `resolveSeatedFaceCameraPose` in `webapp/src/pages/Games/LudoBattleRoyal.jsx` to derive the look target from the avatar head bone forward vector, place the target at an eye-forward distance, lock the target to the avatar eye height, and blend a small fraction toward the board `fallbackTarget` so gameplay focus is preserved.

### Testing
- No automated tests were executed for this change; the updated `resolveSeatedFaceCameraPose` implementation was inspected in the diff and committed to the repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f343d700dc8329a4f2da8b50985aed)