### PR TITLE
Anchor first‑person camera to seated character eyes and stabilize chair swaps

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -5981,16 +5981,32 @@ function resolveSeatedFaceCameraPose(actorEntry, fallbackTarget = null) {
   if (!faceHelper?.isObject3D) return null;
   const position = new THREE.Vector3();
   const target = new THREE.Vector3();
+  const forward = new THREE.Vector3();
   faceHelper.updateMatrixWorld?.(true);
   faceHelper.getWorldPosition(position);
-  if (fallbackTarget?.isVector3) {
-    target.copy(fallbackTarget);
-  } else if (actorEntry?.rig?.head?.isBone) {
-    actorEntry.rig.head.updateMatrixWorld?.(true);
-    actorEntry.rig.head.getWorldPosition(target);
-  } else {
-    target.copy(position).add(new THREE.Vector3(0, -0.005, 0.08 * MODEL_SCALE));
+
+  // Keep the camera exactly on the player eye helper, and aim along the human's own face orientation.
+  faceHelper.getWorldDirection(forward);
+  if (forward.lengthSq() < 1e-8) {
+    forward.set(0, -0.02, 1);
   }
+  forward.normalize();
+  target.copy(position).addScaledVector(forward, 0.26 * MODEL_SCALE);
+
+  // If we have a board target, softly bias only horizontal yaw so first-person view still faces gameplay.
+  if (fallbackTarget?.isVector3) {
+    const boardDirection = fallbackTarget.clone().sub(position).setY(0);
+    const forwardFlat = forward.clone().setY(0);
+    if (boardDirection.lengthSq() > 1e-8 && forwardFlat.lengthSq() > 1e-8) {
+      boardDirection.normalize();
+      forwardFlat.normalize();
+      const blendedFlat = forwardFlat.lerp(boardDirection, 0.22).normalize();
+      target.copy(position)
+        .addScaledVector(blendedFlat, 0.26 * MODEL_SCALE)
+        .add(new THREE.Vector3(0, forward.y * 0.26 * MODEL_SCALE, 0));
+    }
+  }
+
   return {
     position,
     target
@@ -8727,6 +8743,21 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         await rebuildChairs(stoolTheme);
         arena.textureResolutionKey = textureResolutionKey;
         configureDiceAnchors({ tableInfo: arena.tableInfo, boardGroup: arena.boardGroup, chairs: arena.chairs });
+
+        // Keep chair swap lightweight: do not move camera now, only refresh the next first-person lock pose.
+        const bottomActorEntry = seatedHumanActorsRef.current?.find((entry) => entry?.playerIndex === 0);
+        const refreshedFacePose = resolveSeatedFaceCameraPose(bottomActorEntry, boardLookTargetRef.current);
+        if (refreshedFacePose?.position?.isVector3 && refreshedFacePose?.target?.isVector3) {
+          initialBottomCameraViewRef.current = {
+            position: refreshedFacePose.position.clone(),
+            target: refreshedFacePose.target.clone()
+          };
+          cameraTurnStateRef.current.baseTurnView = {
+            position: refreshedFacePose.position.clone(),
+            target: refreshedFacePose.target.clone()
+          };
+          cameraSeatLockPositionRef.current = refreshedFacePose.position.clone();
+        }
       } else if (!shouldPreserveChairMaterials(stoolTheme) && arena.chairMaterials) {
         applyChairThemeMaterials(
           { chairMaterials: arena.chairMaterials },


### PR DESCRIPTION
### Motivation
- The player camera must sit exactly at the local seated human’s eyes and preserve that orientation to provide a true first‑person player perspective. 
- Changing chair themes or options currently caused disruptive camera jumps and low/high offsets because cached first‑person pose data became stale. 
- Chair/option swaps should be lightweight and must not reload or reorient the entire scene or camera immediately. 

### Description
- Updated `resolveSeatedFaceCameraPose` to anchor the camera at the seated human’s `faceCamera` helper and compute the look target from the character’s world forward direction to produce an eye‑level first‑person pose (file: `webapp/src/pages/Games/LudoBattleRoyal.jsx`).
- Added a small horizontal blend toward the board look target so the first‑person view remains gameplay‑focused while keeping the character’s face orientation as priority.
- When rebuilding chairs (`rebuildChairs` path), refreshed the cached bottom‑seat first‑person lock/initial view (`initialBottomCameraViewRef`, `cameraTurnStateRef.current.baseTurnView`, `cameraSeatLockPositionRef`) without moving the active camera immediately to avoid disruptive jumps.
- Left existing camera preservation logic intact so changing other appearance options does not force a full camera reset.

### Testing
- Ran lint on the modified file with `cd webapp && npx eslint src/pages/Games/LudoBattleRoyal.jsx`, which produced no lint errors for the checked scope (file is ignored by repo eslint ignore settings, reported as ignored).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f343d700dc8329a4f2da8b50985aed)