### PR TITLE
Adjust Snake & Ladder weapon sizing and seated human placement

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -85,14 +85,14 @@ const HUMAN_MODEL_URL = 'https://threejs.org/examples/models/gltf/readyplayer.me
 const HUMAN_MODEL_CACHE = { promise: null, template: null };
 // Keep Snake seated humans aligned with Ludo/Chess Battle Royal chair anchoring and 7am scale baseline.
 const SEATED_HUMAN_BASE_HEIGHT = 1.74;
-const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.55;
+const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.2;
 const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 4.32;
 // Mirror Chess Battle Royal seated-body anchoring so bottom-half pose/placement is identical.
-const SEATED_HUMAN_SEAT_Y_OFFSET = -0.78 * MODEL_SCALE * STOOL_SCALE;
-const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.05;
+const SEATED_HUMAN_SEAT_Y_OFFSET = -0.6 * MODEL_SCALE * STOOL_SCALE;
+const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.28;
 // Mirror Ludo Battle Royal's deeper bottom-seat pushback so the local player sits
 // with the same portrait-facing posture/orientation while preserving Snake table scale.
-const SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET = -SEAT_DEPTH * 0.2;
+const SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET = -SEAT_DEPTH * 0.34;
 const SEATED_HUMAN_FACING_Y = 0;
 const SEATED_HUMAN_FOOT_GROUND_Y = -1.26 * MODEL_SCALE * STOOL_SCALE;
 const HUMAN_FRONT_SIDE_Z = 1;
@@ -318,9 +318,14 @@ const WEAPON_DISPLAY_SIZE_MULTIPLIER = 1.72;
 const FIREARM_DISPLAY_SIZE_MULTIPLIER = 0.78;
 const FIREARM_MODEL_SCALE_BY_ID = Object.freeze({
   // Match Gunify AK47 GLTF visual size with the in-game AK baseline.
-  'slot-10-ak47-gltf': 0.32,
+  'slot-10-ak47-gltf': 0.128,
   // Match SigSauer GLTF visual size with Glock-sized sidearms.
-  'slot-15-sigsauer-gltf': 0.3
+  'slot-15-sigsauer-gltf': 0.12,
+  // Shrink FPS shotgun by 60% to reduce table obstruction on portrait phones.
+  'slot-18-fps-gun-gltf': 0.312,
+  // Expand long-rifle silhouettes 3× for better readability from the player camera.
+  'slot-13-mosin-gltf': 2.34,
+  'slot-16-awp-glb': 2.34
 });
 const WEAPON_PARKING_OUTWARD_OFFSET = TILE_SIZE * 0.88;
 const WEAPON_FROM_TOKEN_CENTER_OFFSET = TOKEN_RADIUS * 0.58;

--- a/webapp/src/config/snakeWeaponCatalog.js
+++ b/webapp/src/config/snakeWeaponCatalog.js
@@ -31,7 +31,6 @@ export const SNAKE_CAPTURE_WEAPON_OPTIONS = Object.freeze([
   { id: 'slot-14-uzi-gltf', label: 'Uzi GLTF', thumbnail: weaponSilhouetteThumbnail(['#0f766e','#111827','#99f6e4']), urls: ['https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models2/Uzi/scene.gltf', 'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models2/Uzi/scene.gltf', SNAKE_KNOWN_WORKING_GLB.mrtk, SNAKE_KNOWN_WORKING_GLB.mrtkMaster] },
   { id: 'slot-15-sigsauer-gltf', label: 'SigSauer GLTF', thumbnail: weaponSilhouetteThumbnail(['#334155','#020617','#f1f5f9']), urls: ['https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models3/SigSauer/scene.gltf', 'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models3/SigSauer/scene.gltf', SNAKE_KNOWN_WORKING_GLB.pistolHolster, SNAKE_KNOWN_WORKING_GLB.pistolHolsterRaw] },
   { id: 'slot-16-awp-glb', label: 'AWP Sniper GLB', thumbnail: weaponSilhouetteThumbnail(['#1e293b','#0f172a','#f8fafc']), urls: [SNAKE_KNOWN_WORKING_GLB.awp, SNAKE_KNOWN_WORKING_GLB.awpRaw] },
-  { id: 'slot-17-mrtk-gun-glb', label: 'MRTK Gun GLB', thumbnail: weaponSilhouetteThumbnail(['#0369a1','#0f172a','#e0f2fe']), urls: [SNAKE_KNOWN_WORKING_GLB.mrtk, SNAKE_KNOWN_WORKING_GLB.mrtkRaw, SNAKE_KNOWN_WORKING_GLB.mrtkMaster] },
   { id: 'slot-18-fps-gun-gltf', label: 'FPS Shotgun', thumbnail: weaponSilhouetteThumbnail(['#f59e0b','#111827','#fde68a']), urls: [SNAKE_KNOWN_WORKING_GLB.fps, SNAKE_KNOWN_WORKING_GLB.fpsRaw, SNAKE_KNOWN_WORKING_GLB.awp, SNAKE_KNOWN_WORKING_GLB.awpRaw] }
 ]);
 


### PR DESCRIPTION
### Motivation
- Make specific capture-weapon visuals read better on portrait phones by shrinking some sidearms and expanding long rifles for clarity. 
- Remove an unused store weapon entry that should no longer appear in the catalog. 
- Improve seated human framing so characters appear smaller, higher, and visually further from the table in portrait camera framing.

### Description
- Updated per-weapon scale overrides in `webapp/src/components/SnakeBoard3D.jsx` by changing `FIREARM_MODEL_SCALE_BY_ID` to set `slot-10-ak47-gltf` to `0.128`, `slot-15-sigsauer-gltf` to `0.12`, `slot-18-fps-gun-gltf` to `0.312`, and expand `slot-13-mosin-gltf` and `slot-16-awp-glb` to `2.34` each. 
- Tuned seated human placement constants in `webapp/src/components/SnakeBoard3D.jsx` by setting `SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.2`, `SEATED_HUMAN_SEAT_Y_OFFSET = -0.6 * MODEL_SCALE * STOOL_SCALE`, `SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.28`, and `SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET = -SEAT_DEPTH * 0.34` to make characters appear smaller, higher, and farther from the table. 
- Removed the `slot-17-mrtk-gun-glb` entry from the capture weapon catalog in `webapp/src/config/snakeWeaponCatalog.js` so the MRTK gun no longer shows in the store/catalog. 
- All changes are runtime/config adjustments (no asset files replaced) and are scoped to the Snake & Ladder UI/3D layout code.

### Testing
- Ran `npm test -- test/inventoryCrossGameConfig.test.js --runInBand` which failed to start due to Jest parsing an ESM import from `three/addons` (a separate ESM transform/config issue) and not because of these edits. 
- No other automated test failures attributable to the modified code were observed during the local rollout steps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f34a1c2c8c8329bb420edfca3a21dd)