### PR TITLE
Adjust Snake&Ladder capture weapon scales and seated human placement

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -86,13 +86,13 @@ const HUMAN_MODEL_CACHE = { promise: null, template: null };
 // Keep Snake seated humans aligned with Ludo/Chess Battle Royal chair anchoring and 7am scale baseline.
 const SEATED_HUMAN_BASE_HEIGHT = 1.74;
 const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.55;
-const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 4.32;
+const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 3.75;
 // Mirror Chess Battle Royal seated-body anchoring so bottom-half pose/placement is identical.
-const SEATED_HUMAN_SEAT_Y_OFFSET = -0.78 * MODEL_SCALE * STOOL_SCALE;
-const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.05;
+const SEATED_HUMAN_SEAT_Y_OFFSET = -0.64 * MODEL_SCALE * STOOL_SCALE;
+const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.24;
 // Mirror Ludo Battle Royal's deeper bottom-seat pushback so the local player sits
 // with the same portrait-facing posture/orientation while preserving Snake table scale.
-const SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET = -SEAT_DEPTH * 0.2;
+const SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET = -SEAT_DEPTH * 0.3;
 const SEATED_HUMAN_FACING_Y = 0;
 const SEATED_HUMAN_FOOT_GROUND_Y = -1.26 * MODEL_SCALE * STOOL_SCALE;
 const HUMAN_FRONT_SIDE_Z = 1;
@@ -318,9 +318,14 @@ const WEAPON_DISPLAY_SIZE_MULTIPLIER = 1.72;
 const FIREARM_DISPLAY_SIZE_MULTIPLIER = 0.78;
 const FIREARM_MODEL_SCALE_BY_ID = Object.freeze({
   // Match Gunify AK47 GLTF visual size with the in-game AK baseline.
-  'slot-10-ak47-gltf': 0.32,
+  'slot-10-ak47-gltf': 0.128,
   // Match SigSauer GLTF visual size with Glock-sized sidearms.
-  'slot-15-sigsauer-gltf': 0.3
+  'slot-15-sigsauer-gltf': 0.12,
+  // Reduce FPS shotgun footprint to 40% (60% smaller) for table readability.
+  'slot-18-fps-gun-gltf': 0.4,
+  // Enlarge long rifles for clearer sniper identity in portrait view.
+  'slot-16-awp-glb': 3,
+  'slot-13-mosin-gltf': 3
 });
 const WEAPON_PARKING_OUTWARD_OFFSET = TILE_SIZE * 0.88;
 const WEAPON_FROM_TOKEN_CENTER_OFFSET = TOKEN_RADIUS * 0.58;

--- a/webapp/src/config/snakeWeaponCatalog.js
+++ b/webapp/src/config/snakeWeaponCatalog.js
@@ -31,7 +31,6 @@ export const SNAKE_CAPTURE_WEAPON_OPTIONS = Object.freeze([
   { id: 'slot-14-uzi-gltf', label: 'Uzi GLTF', thumbnail: weaponSilhouetteThumbnail(['#0f766e','#111827','#99f6e4']), urls: ['https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models2/Uzi/scene.gltf', 'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models2/Uzi/scene.gltf', SNAKE_KNOWN_WORKING_GLB.mrtk, SNAKE_KNOWN_WORKING_GLB.mrtkMaster] },
   { id: 'slot-15-sigsauer-gltf', label: 'SigSauer GLTF', thumbnail: weaponSilhouetteThumbnail(['#334155','#020617','#f1f5f9']), urls: ['https://cdn.jsdelivr.net/gh/KrishBharadwaj5678/Gunify@main/models3/SigSauer/scene.gltf', 'https://raw.githubusercontent.com/KrishBharadwaj5678/Gunify/main/models3/SigSauer/scene.gltf', SNAKE_KNOWN_WORKING_GLB.pistolHolster, SNAKE_KNOWN_WORKING_GLB.pistolHolsterRaw] },
   { id: 'slot-16-awp-glb', label: 'AWP Sniper GLB', thumbnail: weaponSilhouetteThumbnail(['#1e293b','#0f172a','#f8fafc']), urls: [SNAKE_KNOWN_WORKING_GLB.awp, SNAKE_KNOWN_WORKING_GLB.awpRaw] },
-  { id: 'slot-17-mrtk-gun-glb', label: 'MRTK Gun GLB', thumbnail: weaponSilhouetteThumbnail(['#0369a1','#0f172a','#e0f2fe']), urls: [SNAKE_KNOWN_WORKING_GLB.mrtk, SNAKE_KNOWN_WORKING_GLB.mrtkRaw, SNAKE_KNOWN_WORKING_GLB.mrtkMaster] },
   { id: 'slot-18-fps-gun-gltf', label: 'FPS Shotgun', thumbnail: weaponSilhouetteThumbnail(['#f59e0b','#111827','#fde68a']), urls: [SNAKE_KNOWN_WORKING_GLB.fps, SNAKE_KNOWN_WORKING_GLB.fpsRaw, SNAKE_KNOWN_WORKING_GLB.awp, SNAKE_KNOWN_WORKING_GLB.awpRaw] }
 ]);
 


### PR DESCRIPTION
### Motivation
- Reduce visually oversized weapon models and remove an unused store item so the board and UI read clearly on portrait phones.
- Emphasize sniper-style weapons by enlarging long rifles so they remain legible on the board.
- Move and scale seated human characters so players appear smaller, slightly higher on-screen and visually farther from the table to match the provided layout intent.

### Description
- Updated firearm model scale overrides in `webapp/src/components/SnakeBoard3D.jsx` by changing `FIREARM_MODEL_SCALE_BY_ID` so `slot-10-ak47-gltf` and `slot-15-sigsauer-gltf` are 40% of their previous size and adding entries for `slot-18-fps-gun-gltf` (0.4), `slot-16-awp-glb` (3) and `slot-13-mosin-gltf` (3). 
- Adjusted seated human presentation constants in `webapp/src/components/SnakeBoard3D.jsx` by lowering `SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER`, changing `SEATED_HUMAN_SEAT_Y_OFFSET` and increasing `SEATED_HUMAN_SEAT_Z_OFFSET` and `SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET` to make characters smaller, higher and farther from the table.
- Removed the `slot-17-mrtk-gun-glb` entry from the Snake store catalog in `webapp/src/config/snakeWeaponCatalog.js` so the MRTK gun is no longer available in the store.
- Changes are focused on portrait-screen visual tuning and affect the in-scene model scaling and seat anchors used by `SnakeBoard3D` and the store catalog.

### Testing
- Verified code changes with `git diff` for `webapp/src/components/SnakeBoard3D.jsx` and `webapp/src/config/snakeWeaponCatalog.js`, and committed the updates successfully (commit created: "Adjust snake capture weapon scales and seat human placement").
- Ran repository searches to confirm the modified weapon IDs and seat constants are referenced where expected and no obvious remaining catalog entry for `slot-17-mrtk-gun-glb` exists; these checks succeeded.
- No unit or integration tests were added for visual changes; recommend a quick visual smoke check on a portrait mobile viewport to confirm the in-game result.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f34a1c2c8c8329bb420edfca3a21dd)