### PR TITLE
Chess Battle Royale: fix weapon swapping, add GLTF/GLB fallbacks and avoid full scene reloads

### DIFF
--- a/frontend/src/ChessBattleRoyaleStore.tsx
+++ b/frontend/src/ChessBattleRoyaleStore.tsx
@@ -137,7 +137,16 @@ export default function ChessBattleRoyaleStore() {
 
     const loadOne = async (entry: WeaponEntry, index: number) => {
       try {
-        const gltf = await new Promise<GLTF>((resolve, reject) => makeLoader(entry.urls[0]).load(entry.urls[0], resolve, undefined, reject));
+        let gltf: GLTF | null = null;
+        for (const url of entry.urls) {
+          try {
+            gltf = await new Promise<GLTF>((resolve, reject) => makeLoader(url).load(url, resolve, undefined, reject));
+            break;
+          } catch {
+            // try next candidate URL
+          }
+        }
+        if (!gltf) throw new Error(`All URLs failed for ${entry.name}`);
         const model = gltf.scene;
         normalizeWeapon(model);
         slots[index].add(model);
@@ -206,10 +215,11 @@ export default function ChessBattleRoyaleStore() {
       runtimesRef.current.forEach((runtime, i) => setTimeout(() => fireFromRuntime(runtime), i * 120));
     };
 
-    window.addEventListener('keydown', (e) => {
+    const onKeyDown = (e: KeyboardEvent) => {
       if (e.code === 'Space') fireSelected();
       if (e.key.toLowerCase() === 'f') fireAll();
-    });
+    };
+    window.addEventListener('keydown', onKeyDown);
 
     let raf = 0;
     const animate = () => {
@@ -267,13 +277,14 @@ export default function ChessBattleRoyaleStore() {
 
     return () => {
       cancelAnimationFrame(raf);
+      window.removeEventListener('keydown', onKeyDown);
       renderer.dispose();
       mount.innerHTML = '';
       pelletGeometry.dispose();
       pelletMaterial.dispose();
       trailMaterial.dispose();
     };
-  }, [cameraMode]);
+  }, []);
 
   return (
     <div className='relative h-screen w-full overflow-hidden bg-slate-950 text-white'>
@@ -291,7 +302,11 @@ export default function ChessBattleRoyaleStore() {
           {WEAPON_MANIFEST.map((weapon, index) => (
             <button
               key={weapon.id}
-              onClick={() => setSelectedIndex(index)}
+              onClick={() => {
+                selectedRef.current = index;
+                setSelectedIndex(index);
+                setStatus(`Selected ${index + 1}/${WEAPON_COUNT}: ${weapon.name}`);
+              }}
               className={`rounded-xl border px-2 py-2 text-left text-[11px] font-bold ${selectedIndex === index ? 'border-yellow-300 bg-yellow-400 text-slate-950' : 'border-white/10 bg-white/10 text-slate-100'}`}
             >
               <span className='block text-[10px] opacity-70'>#{index + 1} · {weapon.weaponType}</span>


### PR DESCRIPTION
### Motivation
- Ensure small-weapon selection reliably shows the chosen model in its parking slot and does not require a full scene reload to take effect. 
- Keep the initial table/slot layout stable when users change weapons or camera/options so the game layout remains identical to the start state.
- Avoid duplicated keyboard handlers and unnecessary effect re-runs that teardown/recreate the Three.js scene when camera mode or UI options change.

### Description
- Try all candidate GLTF/GLB URLs for each weapon during load instead of only using the first URL, so fallback sources are used when the primary URL fails (updated loader logic in `frontend/src/ChessBattleRoyaleStore.tsx`).
- Make the Three.js initialization effect run once (removed the `cameraMode` dependency) so changing camera modes or options does not teardown and recreate the entire scene, preserving the original layout and slots (changed the effect dependency array to `[]`).
- Add proper `keydown` listener cleanup by registering a named handler and removing it on unmount to prevent duplicate handlers (listener registration/cleanup in `frontend/src/ChessBattleRoyaleStore.tsx`).
- Update weapon selector click handler to immediately sync `selectedRef` and `selectedIndex` and update status text without rebuilding the scene, ensuring selection swaps happen in-place (button `onClick` in `frontend/src/ChessBattleRoyaleStore.tsx`).

### Testing
- Ran the project build with `npm run build` (TypeScript compile via `tsc`) and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f35664cad8832999d29a22420be179)