### PR TITLE
Adjust Snake & Ladder GLTF weapon scales and raise seated humans with seat helper

### DIFF
--- a/webapp/src/components/SnakeBoard3D.jsx
+++ b/webapp/src/components/SnakeBoard3D.jsx
@@ -88,7 +88,7 @@ const SEATED_HUMAN_BASE_HEIGHT = 1.74;
 const SEATED_HUMAN_TARGET_HEIGHT = BACK_HEIGHT * 2.42;
 const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 4.2;
 // Mirror Chess Battle Royal seated-body anchoring so bottom-half pose/placement is identical.
-const SEATED_HUMAN_SEAT_Y_OFFSET = -6.75 * MODEL_SCALE * STOOL_SCALE;
+const SEATED_HUMAN_SEAT_Y_OFFSET = -5.95 * MODEL_SCALE * STOOL_SCALE;
 const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.42;
 // Mirror Ludo Battle Royal's deeper bottom-seat pushback so the local player sits
 // with the same portrait-facing posture/orientation while preserving Snake table scale.
@@ -243,6 +243,19 @@ function getSeatHumanOffsets(seatIndex) {
   };
 }
 
+function applyChessBattleRoyalSeatHelper(humanAnchor, seatIndex) {
+  if (!humanAnchor) return;
+  const offsets = getSeatHumanOffsets(seatIndex);
+  humanAnchor.position.set(0, offsets.y, offsets.z);
+  humanAnchor.rotation.set(0, SEATED_HUMAN_FACING_Y, 0);
+  humanAnchor.userData.seatHelper = Object.freeze({
+    source: 'ChessBattleRoyal',
+    seatIndex,
+    y: offsets.y,
+    z: offsets.z
+  });
+}
+
 const TURN_CAMERA_TURN_IN_DURATION = 620;
 const DICE_CAMERA_LOOK_IN_DURATION = 220;
 const DICE_CAMERA_LOOK_HOLD_DURATION = 460;
@@ -318,11 +331,11 @@ const WEAPON_DISPLAY_SIZE_MULTIPLIER = 1.72;
 const FIREARM_DISPLAY_SIZE_MULTIPLIER = 0.78;
 const FIREARM_MODEL_SCALE_BY_ID = Object.freeze({
   // Match AK47 GLTF visual size to Quaternius Assault Rifle baseline.
-  'slot-10-ak47-gltf': 0.1,
+  'slot-10-ak47-gltf': 0.04,
   // Match SigSauer GLTF visual size with Glock-sized sidearms.
   'slot-15-sigsauer-gltf': 0.12,
   // Match FPS Gun GLTF visual size to Quaternius Shotgun baseline.
-  'slot-18-fps-gun-gltf': 0.1,
+  'slot-18-fps-gun-gltf': 0.07,
   // Enlarge long rifles for clearer sniper identity in portrait view.
   'slot-16-awp-glb': 3,
   'slot-13-mosin-gltf': 3
@@ -3511,9 +3524,7 @@ function buildArena(scene, renderer, host, cameraRef, disposeHandlers, appearanc
     group.add(avatarAnchor);
 
     const humanAnchor = new THREE.Object3D();
-    const humanSeatOffset = getSeatHumanOffsets(i);
-    humanAnchor.position.set(0, humanSeatOffset.y, humanSeatOffset.z);
-    humanAnchor.rotation.set(0, SEATED_HUMAN_FACING_Y, 0);
+    applyChessBattleRoyalSeatHelper(humanAnchor, i);
     group.add(humanAnchor);
 
     const chairModel = chairTemplate ? chairTemplate.clone(true) : null;


### PR DESCRIPTION
### Motivation
- Reduce visual size of imported AK47 and FPSGun GLTFs so parked weapons match portrait scaling and other weapon baselines. 
- Correct seated human placement because a prior change made characters sit lower instead of higher on-screen. 
- Keep Snake & Ladder seated-human pose/placement consistent with the Chess Battle Royal seating system for visual parity across games.

### Description
- Updated `webapp/src/components/SnakeBoard3D.jsx` to change `FIREARM_MODEL_SCALE_BY_ID` for `'slot-10-ak47-gltf'` from `0.1` to `0.04` (≈60% smaller) and for `'slot-18-fps-gun-gltf'` from `0.1` to `0.07` (≈30% smaller). 
- Raised seated human anchor by adjusting `SEATED_HUMAN_SEAT_Y_OFFSET` from `-6.75 * MODEL_SCALE * STOOL_SCALE` to `-5.95 * MODEL_SCALE * STOOL_SCALE`. 
- Added a new helper `applyChessBattleRoyalSeatHelper(humanAnchor, seatIndex)` that applies seat offsets/rotation and writes `humanAnchor.userData.seatHelper`, and replaced per-seat manual anchor setup with a call to this helper.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f358fb0e5083298932a7b2c3ed2ea6)