### PR TITLE
Adjust Pool Royale eye camera to preserve cue view direction

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1944,9 +1944,9 @@ const HUMAN_DESIRED_SHOOT_DISTANCE = 1.06; // keep the shooter farther back on t
 const HUMAN_SHOOT_BLEND_THRESHOLD = 0.72; // enter shooting pose earlier when the cue camera starts getting lowered
 const HUMAN_WALK_RING_MARGIN = TABLE.WALL * 4.55; // widen the perimeter walk ring so feet never step onto the table mesh
 const HUMAN_TABLE_BLOCKER_MARGIN = TABLE.WALL * 1.95; // collision helper margin so characters never cut through the table body
-const HUMAN_EYE_CAMERA_HEIGHT_OFFSET = 0.09; // lift camera above cue butt so table stays visible in portrait cue view
-const HUMAN_EYE_CAMERA_FORWARD_OFFSET = BALL_R * 3.2; // keep camera closer to the cue butt so the first-person view matches the rear-hand stance
-const HUMAN_EYE_CAMERA_SIDE_OFFSET = -BALL_R * 0.34; // keep a subtle right-eye bias for right-handed stance without exposing the avatar back
+const HUMAN_EYE_CAMERA_HEIGHT_OFFSET = 0.065; // lock camera nearer to eye line while keeping the cue shaft visible in portrait
+const HUMAN_EYE_CAMERA_FORWARD_OFFSET = BALL_R * 1.15; // keep the eye camera on the rear/butt half of the cue instead of drifting toward the tip
+const HUMAN_EYE_CAMERA_SIDE_OFFSET = -BALL_R * 0.22; // preserve subtle right-eye bias without exposing too much of the avatar body
 const HUMAN_EYE_CAMERA_MIN_BLEND = 0.06; // only engage eye camera when cue view is noticeably lowered
 const HUMAN_EYE_CAMERA_SMOOTH = 0.48; // smooth eye-camera blending into the cue camera for portrait stability
 const HUMAN_BRIDGE_HAND_BACK_FROM_BALL = 0.235; // push bridge hand slightly farther back from the cue ball so the body stays on the butt side
@@ -20409,18 +20409,13 @@ const shotPowerRef = useRef(0);
             .addScaledVector(cuePose.aimForward, HUMAN_EYE_CAMERA_FORWARD_OFFSET)
             .addScaledVector(cuePose.side, HUMAN_EYE_CAMERA_SIDE_OFFSET)
             .addScaledVector(UP, HUMAN_EYE_CAMERA_HEIGHT_OFFSET);
-          const eyeTarget = cuePose.bridgeTarget
-            .clone()
-            .addScaledVector(cuePose.aimForward, BALL_R * 10)
-            .setY(Math.max(TABLE_Y + TABLE.THICK + BALL_R * 0.8, eyePos.y - BALL_R * 0.35));
           return {
             blend: THREE.MathUtils.clamp(
               (cueBias - HUMAN_EYE_CAMERA_MIN_BLEND) / (1 - HUMAN_EYE_CAMERA_MIN_BLEND),
               0,
               1
             ),
-            position: eyePos,
-            target: eyeTarget
+            position: eyePos
           };
         };
 
@@ -21657,10 +21652,13 @@ const shotPowerRef = useRef(0);
               1
             );
             if (lerpT > 1e-4) {
+              const preservedViewDir = lookTarget
+                ? lookTarget.clone().sub(camera.position)
+                : null;
               camera.position.lerp(humanEyePose.position, lerpT);
-              lookTarget = lookTarget
-                ? lookTarget.clone().lerp(humanEyePose.target, lerpT)
-                : humanEyePose.target.clone();
+              if (preservedViewDir && preservedViewDir.lengthSq() > 1e-8) {
+                lookTarget = camera.position.clone().add(preservedViewDir);
+              }
             }
           }
           camera.lookAt(lookTarget);


### PR DESCRIPTION
### Motivation
- Make the human eye camera anchor onto the shooter’s eye position and move with the cue rig while keeping the current aiming direction unchanged for portrait/mobile cue view fidelity.
- Keep the human avatar visually in the lower half of the cue (rear/butt side) and avoid the camera re-aiming toward the avatar face when blending to the eye anchor.

### Description
- Tuned the human eye camera parameters by changing `HUMAN_EYE_CAMERA_HEIGHT_OFFSET`, `HUMAN_EYE_CAMERA_FORWARD_OFFSET`, and `HUMAN_EYE_CAMERA_SIDE_OFFSET` to keep the eye anchor on the rear half of the cue and lower the avatar in-frame in portrait (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Removed the forced eye-target (`eyeTarget`) from `resolveActiveHumanEyePose()` so the eye pose now returns only a `position` and no explicit look-at target (`webapp/src/pages/Games/PoolRoyale.jsx`).
- Preserved the current camera look direction while blending to the human eye position by computing and reapplying a `preservedViewDir` during the position lerp so the camera translates with the human/cue rig without rotating the aim (`webapp/src/pages/Games/PoolRoyale.jsx`).

### Testing
- Ran `npm test -- --runInBand test/poolRoyaleCueStrokeTimeline.test.js` and the suite passed (4 tests, all passing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f351949ea48329bf3fbba966a6a965)