### PR TITLE
Re-anchor chess table/chairs when swapping customization to prevent layout drift

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -8792,6 +8792,11 @@ function Chess3D({
           nextTable.group.add(boardGroup);
           alignBoardGroupToTableSurface(boardGroup, nextTable);
         }
+        const placementOffset = arena.tablePlacementOffset ?? new THREE.Vector3();
+        if (nextTable?.group) {
+          nextTable.group.position.x = placementOffset.x;
+          nextTable.group.position.z = placementOffset.z;
+        }
         arena.tableInfo?.dispose?.();
         arena.tableInfo = nextTable;
         arena.tableShapeId = nextTable?.shapeId;
@@ -8804,7 +8809,6 @@ function Chess3D({
         }
         (arena.chairs || []).forEach((chair) => alignGroupToFloorY(chair.group, arenaFloorY));
         // Preserve original room layout when table/chair options change so gameplay framing stays stable.
-        const placementOffset = arena.tablePlacementOffset ?? new THREE.Vector3();
         arena.tablePlacementOffset = placementOffset.clone();
         if (arena.boardLookTarget) {
           arena.boardLookTarget.x = placementOffset.x;


### PR DESCRIPTION
### Motivation
- Prevent the table/chair/board/human layout from drifting when the player swaps table or chair options so visual framing remains stable without reloading the match.

### Description
- Re-apply the stored arena placement offset (`arena.tablePlacementOffset.x` / `z`) to the freshly built table group before attaching the board so the rebuilt table is anchored to the existing room layout (change in `webapp/src/pages/Games/ChessBattleRoyal.jsx`).
- Preserve the existing placement cloning logic so camera look-target, grounded groups, and controls continue to reference the same placement after customization swaps.

### Testing
- Ran: `npm test -- --runInBand test/chessBattleInventoryConfig.test.js`.
- Result: the suite ran but failed due to a pre-existing, unrelated inventory config assertion (`includes LT table finishes in both options and store purchasables`), not caused by this layout change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f362abf00c83299ae3fd75c1b6d9a1)