### PR TITLE
Preserve game state and camera when swapping Ludo chairs

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -8729,9 +8729,18 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       }
 
       if (stoolChanged) {
+        const lockedSeatCameraBeforeSwap = cameraSeatLockPositionRef.current?.isVector3
+          ? cameraSeatLockPositionRef.current.clone()
+          : null;
+        const preservedTurn = stateRef.current?.turn ?? 0;
         await rebuildChairs(stoolTheme);
         arena.textureResolutionKey = textureResolutionKey;
         configureDiceAnchors({ tableInfo: arena.tableInfo, boardGroup: arena.boardGroup, chairs: arena.chairs });
+        moveDiceToRail(preservedTurn, true);
+        updateTurnIndicator(preservedTurn, true);
+        if (LUDO_CAMERA_SEAT_LOCK_ENABLED) {
+          cameraSeatLockPositionRef.current = lockedSeatCameraBeforeSwap || cameraRef.current?.position?.clone?.() || null;
+        }
 
       } else if (!shouldPreserveChairMaterials(stoolTheme) && arena.chairMaterials) {
         applyChairThemeMaterials(


### PR DESCRIPTION
### Motivation
- Swapping chair themes could unintentionally reframe or appear to reset the active Ludo gameplay because the chair rebuild logic didn't re-apply the current turn or preserve the seat-locked camera position. 
- The change ensures chair updates only replace chair assets and anchors without forcing a visible game reload or causing the camera to drop.

### Description
- In `webapp/src/pages/Games/LudoBattleRoyal.jsx` the chair-swap path now captures the current seat-locked camera position into `lockedSeatCameraBeforeSwap` and the current turn into `preservedTurn` before rebuilding chairs. 
- After `await rebuildChairs(stoolTheme)` the code re-configures dice anchors and then calls `moveDiceToRail(preservedTurn, true)` and `updateTurnIndicator(preservedTurn, true)` so the visible board/turn state is preserved. 
- The seat-lock camera is restored after the swap by reassigning `cameraSeatLockPositionRef.current` to the preserved camera position (falling back to the active camera position when necessary) so the camera does not drop or reframe unexpectedly.

### Testing
- Built the webapp with `npm -C webapp run -s build` and the build completed successfully. 
- The production build emitted existing warnings (duplicate dependency key and chunk size warnings) but the bundling finished without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3647dbf148329b0339835a4a55897)