### PR TITLE
Tighten Pool Royale camera framing and harden human rig loading; align hand IK/grip

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -6038,7 +6038,7 @@ const CAMERA_LOWEST_PHI = CUE_SHOT_PHI - 0.1; // let the standing view dip a lit
 const CAMERA_MIN_PHI = Math.max(CAMERA_ABS_MIN_PHI, STANDING_VIEW_PHI - 0.54);
 const CAMERA_MAX_PHI = CAMERA_LOWEST_PHI; // halt the downward sweep right above the cue while still enabling the lower AI cue height for players
 // Bring the cue camera in closer so the player view sits right against the rail on portrait screens.
-const PLAYER_CAMERA_DISTANCE_FACTOR = 0.0154; // pull the player orbit nearer to the cloth while keeping the frame airy
+const PLAYER_CAMERA_DISTANCE_FACTOR = 0.0126; // pull the player orbit nearer to the cloth while keeping the frame airy
 const BROADCAST_RADIUS_LIMIT_MULTIPLIER = 1.14;
 // Bring the standing/broadcast framing closer to the cloth so the table feels less distant while matching the rail proximity of the pocket cams
 const BROADCAST_DISTANCE_MULTIPLIER = 0.06;
@@ -6053,8 +6053,8 @@ const CAMERA_ZOOM_PROFILES = Object.freeze({
   default: Object.freeze({ cue: 0.86, broadcast: 0.9, margin: 0.97 }),
   nearLandscape: Object.freeze({ cue: 0.84, broadcast: 0.88, margin: 0.97 }),
   landscape: Object.freeze({ cue: 0.82, broadcast: 0.86, margin: 0.965 }),
-  portrait: Object.freeze({ cue: 0.82, broadcast: 1, margin: 0.96 }),
-  ultraPortrait: Object.freeze({ cue: 0.8, broadcast: 1, margin: 0.955 })
+  portrait: Object.freeze({ cue: 0.76, broadcast: 1, margin: 0.93 }),
+  ultraPortrait: Object.freeze({ cue: 0.74, broadcast: 1, margin: 0.92 })
 });
 const resolveCameraZoomProfile = (aspect) => {
   if (!Number.isFinite(aspect)) {

--- a/webapp/src/pages/Games/shared/bilardoHumanRig.js
+++ b/webapp/src/pages/Games/shared/bilardoHumanRig.js
@@ -146,6 +146,13 @@ export function createBilardoHumanRig(scene, opts = {}) {
   loader.setCrossOrigin?.('anonymous');
   loader.load(modelUrl, (gltf) => {
     const model = gltf?.scene;
+    if (!model) {
+      human.loaded = true;
+      human.activeGlb = false;
+      human.modelRoot.visible = false;
+      human.fallback.visible = true;
+      return;
+    }
     normalizeHuman(model, opts);
     model.traverse((obj) => {
       if (!obj?.isMesh) return;
@@ -191,7 +198,7 @@ function rotateBoneToward(bone, target, strength = 1, fallbackDir = UP) {
   setBoneWorldQuaternion(bone, delta.multiply(bone.getWorldQuaternion(new THREE.Quaternion())));
 }
 function twistBone(bone, axis, amount) { if (!bone || Math.abs(amount) < 1e-5) return; setBoneWorldQuaternion(bone, new THREE.Quaternion().setFromAxisAngle(axis.clone().normalize(), amount).multiply(bone.getWorldQuaternion(new THREE.Quaternion()))); }
-function aimTwoBone(upper, lower, elbow, hand, pole, upperStrength = 0.96, lowerStrength = 0.98) { for (let i = 0; i < 4; i += 1) { rotateBoneToward(upper, elbow, upperStrength, pole); rotateBoneToward(lower, hand, lowerStrength, pole); twistBone(upper, pole, 0.025 * upperStrength); } }
+function aimTwoBone(upper, lower, elbow, hand, pole, upperStrength = 0.96, lowerStrength = 0.98) { for (let i = 0; i < 4; i += 1) { rotateBoneToward(upper, elbow, upperStrength, pole); rotateBoneToward(lower, hand, lowerStrength, pole); } }
 function setHandBasis(bone, side, up, forward, roll = 0, strength = 1) { if (!bone || strength <= 0) return; const q = makeBasisQuaternion(side, up, forward); if (Math.abs(roll) > 1e-4) q.multiply(new THREE.Quaternion().setFromAxisAngle(forward.clone().normalize(), roll)); setBoneWorldQuaternion(bone, bone.getWorldQuaternion(new THREE.Quaternion()).slerp(q, clamp01(strength))); }
 
 function cueSocketOffsetWorld(side, up, forward, roll, socketLocal = CFG.rightHandCueSocketLocal) {
@@ -207,9 +214,9 @@ function poseFingers(fingers, mode, weight) {
     const base = !(n.includes('2') || n.includes('3') || n.includes('intermediate') || n.includes('distal')); const mid = n.includes('2') || n.includes('intermediate');
     if (mode === 'idle') { finger.rotation.x += 0.018 * w; finger.rotation.z += 0.01 * w * (i % 2 ? -1 : 1); return; }
     if (mode === 'grip') {
-      if (thumb) { finger.rotation.x += 0.34 * w; finger.rotation.y += -0.68 * w; finger.rotation.z += 0.36 * w; return; }
-      const curl = index ? (base ? 0.44 : mid ? 0.72 : 0.52) : middle ? (base ? 0.62 : mid ? 0.9 : 0.62) : ring ? (base ? 0.58 : mid ? 0.76 : 0.56) : pinky ? (base ? 0.5 : mid ? 0.68 : 0.5) : 0;
-      finger.rotation.x += curl * w; finger.rotation.y += (index ? -0.08 : middle ? -0.02 : ring ? 0.03 : pinky ? 0.06 : 0) * w; finger.rotation.z += (index ? -0.06 : middle ? -0.01 : ring ? 0.05 : pinky ? 0.1 : 0) * w; return;
+      if (thumb) { finger.rotation.x += 0.48 * w; finger.rotation.y += -0.82 * w; finger.rotation.z += 0.54 * w; return; }
+      const curl = index ? (base ? 0.58 : mid ? 0.9 : 0.68) : middle ? (base ? 0.76 : mid ? 1.02 : 0.76) : ring ? (base ? 0.72 : mid ? 0.92 : 0.7) : pinky ? (base ? 0.62 : mid ? 0.82 : 0.62) : 0;
+      finger.rotation.x += curl * w; finger.rotation.y += (index ? -0.12 : middle ? -0.03 : ring ? 0.04 : pinky ? 0.08 : 0) * w; finger.rotation.z += (index ? -0.08 : middle ? -0.02 : ring ? 0.06 : pinky ? 0.12 : 0) * w; return;
     }
     if (thumb) { finger.rotation.x += -0.18 * w; finger.rotation.y += 0.95 * w; finger.rotation.z += -0.95 * w; }
     else if (index) { finger.rotation.x += (base ? 0.26 : mid ? 0.42 : 0.28) * w; finger.rotation.y += -0.46 * w; finger.rotation.z += -0.42 * w; }


### PR DESCRIPTION
### Motivation
- Pull the Pool Royale player/cue camera closer for portrait/phone screens so the table and cue feel visually nearer and the cue view is more usable on mobile. 
- Prevent runtime crashes when a remote GLTF payload resolves without a usable `scene` by making the human rig loader defensive and falling back to the primitive rig. 
- Make the avatar’s right-hand grip and arm IK match the Bilardo-style reference so the cue sits reliably in the player’s hand and finger poses look correct.

### Description
- Tighter camera/cue framing: reduced `PLAYER_CAMERA_DISTANCE_FACTOR` and tightened portrait/ultra-portrait entries in `CAMERA_ZOOM_PROFILES` to bring the orbit/cue camera visually closer to the table on narrow/aspect-ratio screens (`webapp/src/pages/Games/PoolRoyale.jsx`).
- GLTF loader hardening: added an explicit null/`scene` guard in the GLTF success callback so invalid/missing payloads set `human.loaded = true`, keep the fallback rig visible, and avoid throwing during model setup (`webapp/src/pages/Games/shared/bilardoHumanRig.js`).
- Human rig IK/finger tuning: removed an extra twist injection in `aimTwoBone` and updated `poseFingers` grip coefficients (thumb + finger curl/rotations) to better match the provided Bilardo reference behavior so the cue grip and hand animation align more closely with the reference implementation (`webapp/src/pages/Games/shared/bilardoHumanRig.js`).
- Minor safety/visibility adjustments: ensure `modelRoot`/`fallback` visibility is set consistently after load success/failure to keep gameplay stable when the glTF is absent or incomplete (`webapp/src/pages/Games/shared/bilardoHumanRig.js`).

### Testing
- Ran `npx eslint webapp/src/pages/Games/PoolRoyale.jsx webapp/src/pages/Games/shared/bilardoHumanRig.js`; linter returned only ignore warnings for these paths and reported no lint errors (automated check: success).
- Verified repository diffs locally and committed the changes (no automated unit tests were executed as part of this PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f360ecb224832994b055bbb2b77eb7)