### PR TITLE
Improve portrait framing and human rig robustness (camera, offsets, grip)

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -1939,8 +1939,8 @@ const HUMAN_PLAYER_REACT_LEAN = 0.12;
 const HUMAN_POSE_LAMBDA = 9.0;
 const HUMAN_MOVE_LAMBDA = 5.6;
 const HUMAN_ROT_LAMBDA = 8.5;
-const HUMAN_EDGE_MARGIN = 1.22; // push the shooter farther outward so the body stays clearly on the table perimeter
-const HUMAN_DESIRED_SHOOT_DISTANCE = 1.06; // keep the shooter farther back on the cue butt side instead of drifting over the shaft
+const HUMAN_EDGE_MARGIN = 1.58; // push the shooter farther outward so the avatar stays behind the cue butt on portrait screens
+const HUMAN_DESIRED_SHOOT_DISTANCE = 1.58; // move the shooter clearly to the cue-butt side so camera no longer sits behind the head
 const HUMAN_SHOOT_BLEND_THRESHOLD = 0.72; // enter shooting pose earlier when the cue camera starts getting lowered
 const HUMAN_WALK_RING_MARGIN = TABLE.WALL * 4.55; // widen the perimeter walk ring so feet never step onto the table mesh
 const HUMAN_TABLE_BLOCKER_MARGIN = TABLE.WALL * 1.95; // collision helper margin so characters never cut through the table body
@@ -6038,7 +6038,7 @@ const CAMERA_LOWEST_PHI = CUE_SHOT_PHI - 0.1; // let the standing view dip a lit
 const CAMERA_MIN_PHI = Math.max(CAMERA_ABS_MIN_PHI, STANDING_VIEW_PHI - 0.54);
 const CAMERA_MAX_PHI = CAMERA_LOWEST_PHI; // halt the downward sweep right above the cue while still enabling the lower AI cue height for players
 // Bring the cue camera in closer so the player view sits right against the rail on portrait screens.
-const PLAYER_CAMERA_DISTANCE_FACTOR = 0.0154; // pull the player orbit nearer to the cloth while keeping the frame airy
+const PLAYER_CAMERA_DISTANCE_FACTOR = 0.0126; // pull the player orbit nearer to the cloth while keeping the frame airy
 const BROADCAST_RADIUS_LIMIT_MULTIPLIER = 1.14;
 // Bring the standing/broadcast framing closer to the cloth so the table feels less distant while matching the rail proximity of the pocket cams
 const BROADCAST_DISTANCE_MULTIPLIER = 0.06;
@@ -6053,8 +6053,8 @@ const CAMERA_ZOOM_PROFILES = Object.freeze({
   default: Object.freeze({ cue: 0.86, broadcast: 0.9, margin: 0.97 }),
   nearLandscape: Object.freeze({ cue: 0.84, broadcast: 0.88, margin: 0.97 }),
   landscape: Object.freeze({ cue: 0.82, broadcast: 0.86, margin: 0.965 }),
-  portrait: Object.freeze({ cue: 0.82, broadcast: 1, margin: 0.96 }),
-  ultraPortrait: Object.freeze({ cue: 0.8, broadcast: 1, margin: 0.955 })
+  portrait: Object.freeze({ cue: 0.76, broadcast: 1, margin: 0.93 }),
+  ultraPortrait: Object.freeze({ cue: 0.74, broadcast: 1, margin: 0.92 })
 });
 const resolveCameraZoomProfile = (aspect) => {
   if (!Number.isFinite(aspect)) {

--- a/webapp/src/pages/Games/shared/bilardoHumanRig.js
+++ b/webapp/src/pages/Games/shared/bilardoHumanRig.js
@@ -146,6 +146,13 @@ export function createBilardoHumanRig(scene, opts = {}) {
   loader.setCrossOrigin?.('anonymous');
   loader.load(modelUrl, (gltf) => {
     const model = gltf?.scene;
+    if (!model) {
+      human.loaded = true;
+      human.activeGlb = false;
+      human.modelRoot.visible = false;
+      human.fallback.visible = true;
+      return;
+    }
     normalizeHuman(model, opts);
     model.traverse((obj) => {
       if (!obj?.isMesh) return;
@@ -191,7 +198,7 @@ function rotateBoneToward(bone, target, strength = 1, fallbackDir = UP) {
   setBoneWorldQuaternion(bone, delta.multiply(bone.getWorldQuaternion(new THREE.Quaternion())));
 }
 function twistBone(bone, axis, amount) { if (!bone || Math.abs(amount) < 1e-5) return; setBoneWorldQuaternion(bone, new THREE.Quaternion().setFromAxisAngle(axis.clone().normalize(), amount).multiply(bone.getWorldQuaternion(new THREE.Quaternion()))); }
-function aimTwoBone(upper, lower, elbow, hand, pole, upperStrength = 0.96, lowerStrength = 0.98) { for (let i = 0; i < 4; i += 1) { rotateBoneToward(upper, elbow, upperStrength, pole); rotateBoneToward(lower, hand, lowerStrength, pole); twistBone(upper, pole, 0.025 * upperStrength); } }
+function aimTwoBone(upper, lower, elbow, hand, pole, upperStrength = 0.96, lowerStrength = 0.98) { for (let i = 0; i < 4; i += 1) { rotateBoneToward(upper, elbow, upperStrength, pole); rotateBoneToward(lower, hand, lowerStrength, pole); } }
 function setHandBasis(bone, side, up, forward, roll = 0, strength = 1) { if (!bone || strength <= 0) return; const q = makeBasisQuaternion(side, up, forward); if (Math.abs(roll) > 1e-4) q.multiply(new THREE.Quaternion().setFromAxisAngle(forward.clone().normalize(), roll)); setBoneWorldQuaternion(bone, bone.getWorldQuaternion(new THREE.Quaternion()).slerp(q, clamp01(strength))); }
 
 function cueSocketOffsetWorld(side, up, forward, roll, socketLocal = CFG.rightHandCueSocketLocal) {
@@ -207,9 +214,9 @@ function poseFingers(fingers, mode, weight) {
     const base = !(n.includes('2') || n.includes('3') || n.includes('intermediate') || n.includes('distal')); const mid = n.includes('2') || n.includes('intermediate');
     if (mode === 'idle') { finger.rotation.x += 0.018 * w; finger.rotation.z += 0.01 * w * (i % 2 ? -1 : 1); return; }
     if (mode === 'grip') {
-      if (thumb) { finger.rotation.x += 0.34 * w; finger.rotation.y += -0.68 * w; finger.rotation.z += 0.36 * w; return; }
-      const curl = index ? (base ? 0.44 : mid ? 0.72 : 0.52) : middle ? (base ? 0.62 : mid ? 0.9 : 0.62) : ring ? (base ? 0.58 : mid ? 0.76 : 0.56) : pinky ? (base ? 0.5 : mid ? 0.68 : 0.5) : 0;
-      finger.rotation.x += curl * w; finger.rotation.y += (index ? -0.08 : middle ? -0.02 : ring ? 0.03 : pinky ? 0.06 : 0) * w; finger.rotation.z += (index ? -0.06 : middle ? -0.01 : ring ? 0.05 : pinky ? 0.1 : 0) * w; return;
+      if (thumb) { finger.rotation.x += 0.48 * w; finger.rotation.y += -0.82 * w; finger.rotation.z += 0.54 * w; return; }
+      const curl = index ? (base ? 0.58 : mid ? 0.9 : 0.68) : middle ? (base ? 0.76 : mid ? 1.02 : 0.76) : ring ? (base ? 0.72 : mid ? 0.92 : 0.7) : pinky ? (base ? 0.62 : mid ? 0.82 : 0.62) : 0;
+      finger.rotation.x += curl * w; finger.rotation.y += (index ? -0.12 : middle ? -0.03 : ring ? 0.04 : pinky ? 0.08 : 0) * w; finger.rotation.z += (index ? -0.08 : middle ? -0.02 : ring ? 0.06 : pinky ? 0.12 : 0) * w; return;
     }
     if (thumb) { finger.rotation.x += -0.18 * w; finger.rotation.y += 0.95 * w; finger.rotation.z += -0.95 * w; }
     else if (index) { finger.rotation.x += (base ? 0.26 : mid ? 0.42 : 0.28) * w; finger.rotation.y += -0.46 * w; finger.rotation.z += -0.42 * w; }


### PR DESCRIPTION
### Motivation
- Improve portrait/phone framing so the avatar and cue remain properly positioned behind the cue butt and the camera does not end up behind the avatar head.
- Tighten cue/standing camera framing for portrait aspects so the table and balls feel closer without clipping.
- Make the human rig more robust to missing GLB scenes and refine arm/hand animation to produce a more stable, natural cue grip.

### Description
- Increased `HUMAN_EDGE_MARGIN` and `HUMAN_DESIRED_SHOOT_DISTANCE` to move the shooter outward and clearly toward the cue-butt side on portrait screens.
- Reduced `PLAYER_CAMERA_DISTANCE_FACTOR` and adjusted `CAMERA_ZOOM_PROFILES` for `portrait` and `ultraPortrait` to bring the player/cue view closer to the cloth and tighten margins.
- Added a guard in the GLTF loader callback to handle missing `gltf.scene` by falling back to the placeholder human and marking the rig as unloaded.
- Tweaked the human rig IK/pose logic by removing an aggressive twist in `aimTwoBone` and updating finger `grip` rotation parameters to produce a firmer, more natural hold.

### Testing
- Ran unit tests with `yarn test` and the suite completed successfully.
- Ran linting with `yarn lint` and no new issues were reported.
- Built the webapp with `yarn build` to verify bundling and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f360ecb224832994b055bbb2b77eb7)