### PR TITLE
Fix Chess Battle Royal weapon swap list and ownership validation

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -7655,37 +7655,11 @@ function Chess3D({
         .filter(Boolean),
     [chessInventory]
   );
-  const QUICK_SWAP_WEAPON_IDS = useMemo(
-    () =>
-      [
-        'polyShotgun01Attack',
-        'polyAssaultRifle01Attack',
-        'polyPistol01Attack',
-        'polyRevolver01Attack',
-        'polySawedOff01Attack',
-        'polyRevolver02Attack',
-        'polyShotgun02Attack',
-        'polyShotgun03Attack',
-        'polySmg01Attack',
-        'ak47VolleyAttack',
-        'krsvBurstAttack',
-        'smithSidearmAttack',
-        'mosinMarksmanAttack',
-        'uziSprayAttack',
-        'sigsauerTacticalAttack',
-        'sniperShotAttack',
-        'compactCarbineAttack',
-        'fpsGunAttack'
-      ],
-    []
-  );
   const quickSwapWeapons = useMemo(() => {
-    const ownedIds = new Set((ownedCaptureAnimations || []).map((option) => option.id));
-    return QUICK_SWAP_WEAPON_IDS
-      .filter((id) => ownedIds.has(id))
-      .map((id) => CAPTURE_ANIMATION_OPTIONS.find((option) => option.id === id))
-      .filter(Boolean);
-  }, [ownedCaptureAnimations, QUICK_SWAP_WEAPON_IDS]);
+    return (ownedCaptureAnimations || []).filter((option) =>
+      FIREARM_CAPTURE_ANIMATION_IDS.has(option.id)
+    );
+  }, [ownedCaptureAnimations]);
   const [weaponSwapOpen, setWeaponSwapOpen] = useState(false);
   const [weaponSwapTargetKind, setWeaponSwapTargetKind] = useState(null);
   const PIECE_GROUP_BY_PARKED_KIND = useMemo(() => ({
@@ -7711,6 +7685,7 @@ function Chess3D({
   const handleCaptureAnimationSwap = useCallback(
     (optionId) => {
       if (!optionId) return;
+      if (!isChessOptionUnlocked('captureAnimation', optionId, chessInventory)) return;
       const targetKind = weaponSwapTargetKind;
       const targetGroup = targetKind ? PIECE_GROUP_BY_PARKED_KIND[targetKind] : null;
       if (targetGroup) {


### PR DESCRIPTION
### Motivation
- Players reported being unable to quick-swap to weapons they already owned and swaps could result in inconsistent equipped state, so the quick-swap UI must reflect the actual owned inventory and swaps must be validated against ownership.

### Description
- Replaced the hard-coded `QUICK_SWAP_WEAPON_IDS` allowlist and made `quickSwapWeapons` derive from the player's `ownedCaptureAnimations`, filtered for firearm capture IDs using `FIREARM_CAPTURE_ANIMATION_IDS` in `webapp/src/pages/Games/ChessBattleRoyal.jsx`.
- Added an ownership guard call to `handleCaptureAnimationSwap` so the handler returns early if `isChessOptionUnlocked('captureAnimation', optionId, chessInventory)` is false.
- Kept the existing `quickSwapWeaponList` logic that narrows the pool for specific parked targets (jet/drone/helicopter/truck) and did not change table/chair/piece rebuild or full component remount behavior.

### Testing
- Ran a production build with `npm --prefix webapp run -s build` and the build completed successfully (Vite warnings about chunk sizes and a duplicate `package.json` key were non-blocking).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f375e50f7483298495ae82297668a1)