### PR TITLE
Disable Domino Royal human avatars to fix startup/loading failures

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -1026,65 +1026,7 @@ const CHAIR_SEAT_RADII = Object.freeze([
   CHAIR_RADIUS + CHAIR_GLOBAL_PUSHBACK,
   CHAIR_RADIUS + CHAIR_GLOBAL_PUSHBACK
 ]);
-const DOMINO_HUMAN_CHARACTER_OPTIONS = Object.freeze([
-  {
-    id: 'rpm-current',
-    label: 'Current Avatar',
-    modelUrls: ['https://threejs.org/examples/models/gltf/readyplayer.me.glb']
-  },
-  {
-    id: 'rpm-67d411',
-    label: 'RPM 67d411',
-    modelUrls: [
-      'https://models.readyplayer.me/67d411b30787acbf58ce58ac.glb',
-      'https://api.readyplayer.me/v1/avatars/67d411b30787acbf58ce58ac.glb',
-      'https://avatars.readyplayer.me/67d411b30787acbf58ce58ac.glb'
-    ]
-  },
-  {
-    id: 'rpm-67f433',
-    label: 'RPM 67f433',
-    modelUrls: [
-      'https://models.readyplayer.me/67f433b69dc08cf26d2cf585.glb',
-      'https://api.readyplayer.me/v1/avatars/67f433b69dc08cf26d2cf585.glb',
-      'https://avatars.readyplayer.me/67f433b69dc08cf26d2cf585.glb'
-    ]
-  },
-  {
-    id: 'rpm-67e1b5',
-    label: 'RPM 67e1b5',
-    modelUrls: [
-      'https://models.readyplayer.me/67e1b51ae11c93725e4395c9.glb',
-      'https://api.readyplayer.me/v1/avatars/67e1b51ae11c93725e4395c9.glb',
-      'https://avatars.readyplayer.me/67e1b51ae11c93725e4395c9.glb'
-    ]
-  },
-  {
-    id: 'webgl-vietnam-human',
-    label: 'Vietnam Human',
-    modelUrls: ['https://raw.githubusercontent.com/hmthanh/3d-human-model/main/TranThiNgocTham.glb']
-  },
-  {
-    id: 'webgl-human-body-a',
-    label: 'Human Body A',
-    modelUrls: ['https://raw.githubusercontent.com/msorkhpar/3d-human-model-vite/main/body.glb']
-  },
-  {
-    id: 'webgl-human-body-b',
-    label: 'Human Body B',
-    modelUrls: ['https://raw.githubusercontent.com/bddicken/humanbody/main/body.glb']
-  },
-  {
-    id: 'webgl-ai-teacher',
-    label: 'AI Teacher',
-    modelUrls: ['https://raw.githubusercontent.com/Surbh77/AI-teacher/main/avatar.glb']
-  },
-  {
-    id: 'webgl-ai-teacher-1',
-    label: 'AI Teacher 1',
-    modelUrls: ['https://raw.githubusercontent.com/Surbh77/AI-teacher/main/avatar1.glb']
-  }
-]);
+const DOMINO_HUMAN_CHARACTER_OPTIONS = Object.freeze([]);
 const ARENA_WALL_HEIGHT = 3.6 * 1.3;
 const ARENA_WALL_CENTER_Y = ARENA_WALL_HEIGHT / 2;
 const ARENA_WALL_INNER_RADIUS = TABLE_RADIUS * ARENA_GROWTH * 2.4;

--- a/webapp/src/config/dominoRoyalInventoryConfig.js
+++ b/webapp/src/config/dominoRoyalInventoryConfig.js
@@ -9,17 +9,7 @@ import {
   BATTLE_ROYALE_SHARED_TABLE_THEME_OPTIONS
 } from './battleRoyaleSharedInventory.js';
 
-const DOMINO_HUMAN_CHARACTER_OPTIONS = Object.freeze([
-  { id: 'rpm-current', label: 'Current Avatar', description: 'Default Chess Battle Royal human avatar.' },
-  { id: 'rpm-67d411', label: 'RPM 67d411', description: 'Ready Player Me seated avatar variant.' },
-  { id: 'rpm-67f433', label: 'RPM 67f433', description: 'Ready Player Me seated avatar variant.' },
-  { id: 'rpm-67e1b5', label: 'RPM 67e1b5', description: 'Ready Player Me seated avatar variant.' },
-  { id: 'webgl-vietnam-human', label: 'Vietnam Human', description: 'Imported seated human model from Chess roster.' },
-  { id: 'webgl-human-body-a', label: 'Human Body A', description: 'Imported seated human model from Chess roster.' },
-  { id: 'webgl-human-body-b', label: 'Human Body B', description: 'Imported seated human model from Chess roster.' },
-  { id: 'webgl-ai-teacher', label: 'AI Teacher', description: 'Imported seated human model from Chess roster.' },
-  { id: 'webgl-ai-teacher-1', label: 'AI Teacher 1', description: 'Imported seated human model from Chess roster.' }
-]);
+const DOMINO_HUMAN_CHARACTER_OPTIONS = Object.freeze([]);
 
 export const DOMINO_ROYAL_OPTION_SETS = Object.freeze({
   tableWood: BATTLE_ROYALE_SHARED_TABLE_FINISH_OPTIONS.map(({ id, label, price = 0, description, thumbnail, woodOption }) => ({
@@ -139,7 +129,7 @@ const DOMINO_DEFAULT_IDS = Object.freeze({
   tableWood: 'peelingPaintWeathered',
   tableCloth: 'emerald',
   chairTheme: 'dining_chair_02',
-  humanCharacter: 'rpm-current'
+  humanCharacter: null
 });
 
 const getDefaultOptionId = (options) => options?.[0]?.id;

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-04-28-domino-human-seating-v38';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-04-30-domino-no-human-avatars-v39';
 
 export default function DominoRoyalArena() {
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- Remote seated human GLTF assets were causing Domino Royal to fail or stall during renderer initialization, so human avatars must be disabled to restore reliable game load.
- Preventing runtime model downloads improves startup resilience and avoids blocking match startup when remote assets are unavailable.

### Description
- Emptied the runtime human character catalog by setting `DOMINO_HUMAN_CHARACTER_OPTIONS` to an empty array in `webapp/public/domino-royal-game.js` to stop remote GLTF loads at runtime. 
- Disabled inventory exposure of human characters by setting `DOMINO_HUMAN_CHARACTER_OPTIONS` to an empty array and changing the default `humanCharacter` ID to `null` in `webapp/src/config/dominoRoyalInventoryConfig.js` so the category is no longer selectable or unlocked by default. 
- Bumped the client script version string `DOMINO_ROYAL_SCRIPT_VERSION` in `webapp/src/pages/Games/DominoRoyalArena.jsx` to force clients to fetch the updated script instead of using a cached, broken one.

### Testing
- Ran `npm test -- test/inventoryCrossGameConfig.test.js --runInBand`, which failed to start the test due to a Jest ESM parsing issue caused by `three/addons` in the test environment, so no assertions from this targeted test executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f37dbee7c08329ac2edeaeefcb90fe)