### PR TITLE
refactor(pool-royale): remove legacy fallback human logic in cue rig

### DIFF
--- a/webapp/src/pages/Games/shared/bilardoHumanRig.js
+++ b/webapp/src/pages/Games/shared/bilardoHumanRig.js
@@ -59,30 +59,6 @@ function makeBasisQuaternion(side, up, forward) {
   return new THREE.Quaternion().setFromRotationMatrix(BASIS_MAT);
 }
 
-function createFallbackHuman() {
-  const group = new THREE.Group();
-  const gray = new THREE.MeshStandardMaterial({ color: 0x6b7280, roughness: 0.7, metalness: 0.05 });
-  const skin = new THREE.MeshStandardMaterial({ color: 0xf0c9a5, roughness: 0.8, metalness: 0 });
-  const addBox = (size, pos, mat) => {
-    const mesh = new THREE.Mesh(new THREE.BoxGeometry(size[0], size[1], size[2]), mat);
-    mesh.position.set(pos[0], pos[1], pos[2]);
-    mesh.castShadow = true;
-    mesh.receiveShadow = true;
-    group.add(mesh);
-  };
-  addBox([0.42, 0.72, 0.22], [0, 1.18, 0], gray);
-  addBox([0.14, 0.9, 0.14], [-0.09, 0.45, 0], gray);
-  addBox([0.14, 0.9, 0.14], [0.09, 0.45, 0], gray);
-  addBox([0.12, 0.72, 0.12], [-0.31, 1.18, 0], gray);
-  addBox([0.12, 0.72, 0.12], [0.31, 1.18, 0], gray);
-  const head = new THREE.Mesh(new THREE.SphereGeometry(0.14, 20, 20), skin);
-  head.position.set(0, 1.7, 0);
-  head.castShadow = true;
-  head.receiveShadow = true;
-  group.add(head);
-  return group;
-}
-
 function findBone(all, aliases) {
   const list = all.map((bone) => ({ bone, name: cleanName(bone.name) }));
   const names = aliases.map(cleanName);
@@ -130,16 +106,15 @@ function normalizeHuman(model, opts = {}) {
 }
 
 export function createBilardoHumanRig(scene, opts = {}) {
-  const human = { root: new THREE.Group(), modelRoot: new THREE.Group(), model: null, fallback: createFallbackHuman(), bones: {}, leftFingers: [], rightFingers: [], restQuats: new Map(), loaded: false, activeGlb: false, poseT: 0, walkT: 0, yaw: 0, breathT: 0, settleT: 0, strikeRoot: new THREE.Vector3(), strikeYaw: 0, strikeClock: 0, cfg: { ...CFG, ...opts } };
+  const human = { root: new THREE.Group(), modelRoot: new THREE.Group(), model: null, bones: {}, leftFingers: [], rightFingers: [], restQuats: new Map(), loaded: false, activeGlb: false, poseT: 0, walkT: 0, yaw: 0, breathT: 0, settleT: 0, strikeRoot: new THREE.Vector3(), strikeYaw: 0, strikeClock: 0, cfg: { ...CFG, ...opts } };
   human.root.visible = false;
   human.modelRoot.visible = false;
-  scene.add(human.root, human.modelRoot, human.fallback);
+  scene.add(human.root, human.modelRoot);
 
   const loader = opts.loader;
   const modelUrl = opts.modelUrl;
   if (!loader || !modelUrl) {
     human.loaded = true;
-    human.fallback.visible = true;
     return human;
   }
 
@@ -150,7 +125,6 @@ export function createBilardoHumanRig(scene, opts = {}) {
       human.loaded = true;
       human.activeGlb = false;
       human.modelRoot.visible = false;
-      human.fallback.visible = true;
       return;
     }
     normalizeHuman(model, opts);
@@ -173,13 +147,11 @@ export function createBilardoHumanRig(scene, opts = {}) {
     human.model = model;
     human.modelRoot.add(model);
     human.modelRoot.visible = human.activeGlb;
-    human.fallback.visible = !human.activeGlb;
     human.loaded = true;
   }, undefined, () => {
     human.loaded = true;
     human.activeGlb = false;
     human.modelRoot.visible = false;
-    human.fallback.visible = true;
   });
 
   return human;
@@ -226,15 +198,7 @@ function poseFingers(fingers, mode, weight) {
 }
 
 function driveHuman(human, frame) {
-  if (!human.activeGlb || !human.model) {
-    human.fallback.visible = true;
-    human.fallback.position.copy(frame.rootWorld);
-    human.fallback.rotation.y = human.yaw;
-    human.fallback.rotation.x = -0.16 * frame.t;
-    human.fallback.position.y -= 0.035 * frame.t;
-    return;
-  }
-  human.fallback.visible = false;
+  if (!human.activeGlb || !human.model) return;
   human.modelRoot.visible = true;
   human.modelRoot.position.copy(frame.rootWorld);
   human.modelRoot.rotation.y = human.yaw;


### PR DESCRIPTION
### Motivation
- The legacy box-based fallback human implementation was unwanted and must be removed while preserving the GLB-driven cue-holding/pose logic and the configured human size.
- Simplify the rig so the avatar path is GLB-only and no visual fallback logic interferes with the cue-back grip behavior.

### Description
- Removed the fallback/box-based human creation and all fallback visibility/positioning code from `webapp/src/pages/Games/shared/bilardoHumanRig.js` and removed the fallback object from the scene setup. 
- Updated the `human` rig structure in `createBilardoHumanRig` to no longer include the fallback mesh and early-return behavior now simply requires a loaded GLB to proceed. 
- Preserved configuration values used for sizing/pose (notably `humanScale` and related cue/grip offsets) so the GLB-driven pose and cue socket math remain unchanged. 
- Kept the existing GLB bone-finding, finger posing, two-bone IK, and cue socket logic intact so the avatar holds the cue from the back as before.

### Testing
- Ran a syntax check with `node --check webapp/src/pages/Games/shared/bilardoHumanRig.js`, which succeeded. 
- Attempted the `webapp` test command (`cd webapp && npm test ...`), but the package has no `test` script in this environment so the automated test run could not be performed. 
- Verified the modified file loads (basic static checks) and that the GLB-driven code path remains present via code inspection.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f382802e088329b6848a512af794ae)