### PR TITLE
Fix Murlan seated character orientation and GLTF texture mapping

### DIFF
--- a/webapp/src/config/murlanCharacterThemes.js
+++ b/webapp/src/config/murlanCharacterThemes.js
@@ -15,8 +15,8 @@ export const MURLAN_CHARACTER_THEMES = Object.freeze([
     seatOffsetZ: -0.22,
     normalizedSeatOffsetY: -0.4,
     normalizedSeatOffsetZ: 0.52,
-    seatPitch: -0.92,
-    seatYaw: Math.PI,
+    seatPitch: 0,
+    seatYaw: 0,
     handLift: 1.04
   },
   {
@@ -33,8 +33,8 @@ export const MURLAN_CHARACTER_THEMES = Object.freeze([
     seatOffsetZ: -0.22,
     normalizedSeatOffsetY: -0.4,
     normalizedSeatOffsetZ: 0.52,
-    seatPitch: -0.92,
-    seatYaw: Math.PI,
+    seatPitch: 0,
+    seatYaw: 0,
     handLift: 1.04
   },
   {
@@ -51,8 +51,8 @@ export const MURLAN_CHARACTER_THEMES = Object.freeze([
     seatOffsetZ: -0.22,
     normalizedSeatOffsetY: -0.4,
     normalizedSeatOffsetZ: 0.52,
-    seatPitch: -0.92,
-    seatYaw: Math.PI,
+    seatPitch: 0,
+    seatYaw: 0,
     handLift: 1.04
   },
   {
@@ -69,8 +69,8 @@ export const MURLAN_CHARACTER_THEMES = Object.freeze([
     seatOffsetZ: -0.22,
     normalizedSeatOffsetY: -0.4,
     normalizedSeatOffsetZ: 0.52,
-    seatPitch: -0.92,
-    seatYaw: Math.PI,
+    seatPitch: 0,
+    seatYaw: 0,
     handLift: 1.04
   },
   {
@@ -87,8 +87,8 @@ export const MURLAN_CHARACTER_THEMES = Object.freeze([
     seatOffsetZ: -0.22,
     normalizedSeatOffsetY: -0.4,
     normalizedSeatOffsetZ: 0.52,
-    seatPitch: -0.92,
-    seatYaw: Math.PI,
+    seatPitch: 0,
+    seatYaw: 0,
     handLift: 1.04
   },
   {
@@ -105,8 +105,8 @@ export const MURLAN_CHARACTER_THEMES = Object.freeze([
     seatOffsetZ: -0.22,
     normalizedSeatOffsetY: -0.4,
     normalizedSeatOffsetZ: 0.52,
-    seatPitch: -0.92,
-    seatYaw: Math.PI,
+    seatPitch: 0,
+    seatYaw: 0,
     handLift: 1.04
   },
   {
@@ -123,8 +123,8 @@ export const MURLAN_CHARACTER_THEMES = Object.freeze([
     seatOffsetZ: -0.22,
     normalizedSeatOffsetY: -0.4,
     normalizedSeatOffsetZ: 0.52,
-    seatPitch: -0.92,
-    seatYaw: Math.PI,
+    seatPitch: 0,
+    seatYaw: 0,
     handLift: 1.04
   }
 ]);

--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1641,7 +1641,7 @@ async function loadCharacterModel(theme, renderer = null) {
     const gltf = await loader.loadAsync(theme.url);
     const root = gltf?.scene || gltf?.scenes?.[0];
     if (!root) throw new Error(`Character scene missing for ${theme.id || 'unknown'}`);
-    prepareLoadedModel(root);
+    prepareLoadedModel(root, { preserveGltfTextureMapping: true });
     return root;
   })();
   CHARACTER_MODEL_CACHE.set(cacheKey, promise);


### PR DESCRIPTION
### Motivation
- Avatars in Murlan Royale were spawning flipped and with legs raised because default seating rotation offsets forced an inverted pose, and character GLTF imports were overwriting original UV/material mapping; this change aims to restore correct seated orientation and preserve original textures so models render as authored.

### Description
- Updated character theme defaults in `webapp/src/config/murlanCharacterThemes.js` to set `seatPitch` and `seatYaw` to neutral values (`0`) for all entries instead of `-0.92`/`Math.PI` so avatars sit facing the correct direction with legs down.
- Changed character GLTF load behavior in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to call `prepareLoadedModel(root, { preserveGltfTextureMapping: true })` when loading character models so the original GLTF texture/material mapping is preserved.

### Testing
- Ran repository searches (`rg`) to verify the `seatPitch`/`seatYaw` values were updated and that `prepareLoadedModel(..., { preserveGltfTextureMapping: true })` is present and the checks succeeded.
- Performed a commit which completed successfully (`git commit` returned success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f38369752c8329b966946fbe572bfb)