### PR TITLE
Fix Murlan Royal seated human orientation and preserve GLTF texture mappings

### DIFF
--- a/Assets/Scripts/Gameplay/Characters/HumanSeatedPoseCorrector.cs
+++ b/Assets/Scripts/Gameplay/Characters/HumanSeatedPoseCorrector.cs
@@ -1,0 +1,66 @@
+using UnityEngine;
+
+namespace TonPlaygram.Gameplay.Characters
+{
+    /// <summary>
+    /// Corrects imported human avatar orientation so seated characters face the expected direction
+    /// and keep legs pointing downward on screen.
+    /// </summary>
+    public sealed class HumanSeatedPoseCorrector : MonoBehaviour
+    {
+        [SerializeField] private Transform[] characterRoots;
+        [SerializeField] private bool runOnAwake = true;
+        [SerializeField] private bool includeChildrenWhenEmpty = true;
+        [SerializeField] private bool forceWorldUpForLegs = true;
+        [SerializeField] private Vector3 localEulerOffset = new Vector3(0f, 180f, 0f);
+
+        private Quaternion _offsetRotation;
+
+        private void Awake()
+        {
+            _offsetRotation = Quaternion.Euler(localEulerOffset);
+            if (runOnAwake)
+            {
+                ApplySeatedFix();
+            }
+        }
+
+        [ContextMenu("Apply Seated Orientation Fix")]
+        public void ApplySeatedFix()
+        {
+            Transform[] targets = ResolveTargets();
+            for (int i = 0; i < targets.Length; i++)
+            {
+                Transform root = targets[i];
+                if (root == null)
+                {
+                    continue;
+                }
+
+                root.localRotation = _offsetRotation * root.localRotation;
+
+                if (forceWorldUpForLegs)
+                {
+                    Vector3 euler = root.eulerAngles;
+                    euler.z = 0f;
+                    root.eulerAngles = euler;
+                }
+            }
+        }
+
+        private Transform[] ResolveTargets()
+        {
+            if (characterRoots != null && characterRoots.Length > 0)
+            {
+                return characterRoots;
+            }
+
+            if (!includeChildrenWhenEmpty)
+            {
+                return new[] { transform };
+            }
+
+            return GetComponentsInChildren<Transform>(true);
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Rendering/GltfMaterialCompatibilityAdapter.cs
+++ b/Assets/Scripts/Gameplay/Rendering/GltfMaterialCompatibilityAdapter.cs
@@ -24,6 +24,9 @@ namespace Aiming.Gameplay.Rendering
         private static readonly int EmissionMapId = Shader.PropertyToID("_EmissionMap");
         private static readonly int BaseMapStId = Shader.PropertyToID("_BaseMap_ST");
         private static readonly int MainTexStId = Shader.PropertyToID("_MainTex_ST");
+        private static readonly int BaseColorMapId = Shader.PropertyToID("_BaseColorMap");
+        private static readonly int BaseColorTextureId = Shader.PropertyToID("_BaseColorTexture");
+        private static readonly int ColorMapId = Shader.PropertyToID("_ColorMap");
 
         void Awake()
         {
@@ -109,11 +112,14 @@ namespace Aiming.Gameplay.Rendering
 
         private static void CopyPbrMaps(Material material)
         {
-            Texture baseTexture = FirstTexture(material, BaseMapId, MainTexId);
+            Texture baseTexture = FirstTexture(material, BaseMapId, MainTexId, BaseColorMapId, BaseColorTextureId, ColorMapId);
             if (baseTexture != null)
             {
                 TrySetTexture(material, BaseMapId, baseTexture);
                 TrySetTexture(material, MainTexId, baseTexture);
+                TrySetTexture(material, BaseColorMapId, baseTexture);
+                TrySetTexture(material, BaseColorTextureId, baseTexture);
+                TrySetTexture(material, ColorMapId, baseTexture);
                 SyncTextureTransform(material);
             }
 
@@ -183,6 +189,42 @@ namespace Aiming.Gameplay.Rendering
             }
         }
 
+
+        private static Vector2 FirstTextureScale(Material material, params int[] texturePropertyIds)
+        {
+            for (int i = 0; i < texturePropertyIds.Length; i++)
+            {
+                int propertyId = texturePropertyIds[i];
+                if (!material.HasProperty(propertyId))
+                {
+                    continue;
+                }
+
+                Vector2 scale = material.GetTextureScale(propertyId);
+                if (scale != Vector2.zero)
+                {
+                    return scale;
+                }
+            }
+
+            return Vector2.one;
+        }
+
+        private static Vector2 FirstTextureOffset(Material material, params int[] texturePropertyIds)
+        {
+            for (int i = 0; i < texturePropertyIds.Length; i++)
+            {
+                int propertyId = texturePropertyIds[i];
+                if (!material.HasProperty(propertyId))
+                {
+                    continue;
+                }
+
+                return material.GetTextureOffset(propertyId);
+            }
+
+            return Vector2.zero;
+        }
         private static void SyncTextureTransform(Material material)
         {
             bool hasBase = material.HasProperty(BaseMapId);
@@ -192,17 +234,18 @@ namespace Aiming.Gameplay.Rendering
                 return;
             }
 
-            Vector2 scale = material.GetTextureScale(BaseMapId);
-            Vector2 offset = material.GetTextureOffset(BaseMapId);
-            if (scale == Vector2.zero)
-            {
-                scale = material.GetTextureScale(MainTexId);
-            }
+            Vector2 scale = FirstTextureScale(material, BaseMapId, MainTexId, BaseColorMapId, BaseColorTextureId, ColorMapId);
+            Vector2 offset = FirstTextureOffset(material, BaseMapId, MainTexId, BaseColorMapId, BaseColorTextureId, ColorMapId);
 
             material.SetTextureScale(MainTexId, scale);
             material.SetTextureOffset(MainTexId, offset);
             material.SetTextureScale(BaseMapId, scale);
             material.SetTextureOffset(BaseMapId, offset);
+            if (material.HasProperty(BaseColorMapId))
+            {
+                material.SetTextureScale(BaseColorMapId, scale);
+                material.SetTextureOffset(BaseColorMapId, offset);
+            }
 
             if (material.HasProperty(BaseMapStId) && material.HasProperty(MainTexStId))
             {


### PR DESCRIPTION
### Motivation
- Imported human avatars in the Murlan Royal scenes were facing the wrong direction and their legs appeared rotated upward on screen, breaking seated poses. 
- Some GLTF/GLB character materials lost their original base-color texture mapping when the project fell back to other shaders, causing visual regressions. 
- Provide a small, inspector-driven runtime fix and improve material compatibility so artists can restore correct appearance without reauthoring assets.

### Description
- Added a new Unity component `HumanSeatedPoseCorrector` (`Assets/Scripts/Gameplay/Characters/HumanSeatedPoseCorrector.cs`) which applies a configurable `localEulerOffset` (default 180° yaw), optionally forces world-up for leg rotation, and can auto-resolve targets or accept explicit `characterRoots`, with a context-menu `Apply Seated Orientation Fix` for scene workflows. 
- Enhanced `GltfMaterialCompatibilityAdapter` (`Assets/Scripts/Gameplay/Rendering/GltfMaterialCompatibilityAdapter.cs`) to recognize additional GLTF base-color aliases (`_BaseColorMap`, `_BaseColorTexture`, `_ColorMap`) and copy textures into those properties when present. 
- Added helpers `FirstTextureScale` and `FirstTextureOffset` to choose the appropriate UV transform from common property aliases, and updated `SyncTextureTransform` to propagate scale/offset to the newly handled properties so original UV mapping is preserved. 
- Changes are inspector-tunable and non-destructive (operate on `sharedMaterials` and include context-menu/run-on-awake options for quick validation). 

### Testing
- No automated tests were executed for these edits; changes are limited to Unity C# gameplay/rendering scripts and should be validated with the project by running the Unity editor/playmode or CI build that includes playmode/editor tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f38369752c8329b966946fbe572bfb)