### PR TITLE
Fix Murlan Royale character seating orientation and preserve GLTF textures

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1641,7 +1641,7 @@ async function loadCharacterModel(theme, renderer = null) {
     const gltf = await loader.loadAsync(theme.url);
     const root = gltf?.scene || gltf?.scenes?.[0];
     if (!root) throw new Error(`Character scene missing for ${theme.id || 'unknown'}`);
-    prepareLoadedModel(root);
+    prepareLoadedModel(root, { preserveGltfTextureMapping: true });
     return root;
   })();
   CHARACTER_MODEL_CACHE.set(cacheKey, promise);
@@ -1831,10 +1831,10 @@ function createCharacterRig(instance, seatRoot, seatConfig, characterTheme, play
   applyRotationOffset(rightUpperArm, THREE.MathUtils.degToRad(-22), THREE.MathUtils.degToRad(-3), THREE.MathUtils.degToRad(-2));
   applyRotationOffset(rightForeArm, THREE.MathUtils.degToRad(-28), 0, THREE.MathUtils.degToRad(-4));
   applyRotationOffset(rightHand, THREE.MathUtils.degToRad(10), THREE.MathUtils.degToRad(-6), 0);
-  applyRotationOffset(leftThigh, THREE.MathUtils.degToRad(74), 0, 0);
-  applyRotationOffset(rightThigh, THREE.MathUtils.degToRad(74), 0, 0);
-  applyRotationOffset(leftCalf, THREE.MathUtils.degToRad(-82), 0, 0);
-  applyRotationOffset(rightCalf, THREE.MathUtils.degToRad(-82), 0, 0);
+  applyRotationOffset(leftThigh, THREE.MathUtils.degToRad(-74), 0, 0);
+  applyRotationOffset(rightThigh, THREE.MathUtils.degToRad(-74), 0, 0);
+  applyRotationOffset(leftCalf, THREE.MathUtils.degToRad(82), 0, 0);
+  applyRotationOffset(rightCalf, THREE.MathUtils.degToRad(82), 0, 0);
 
   rig.seatedPose = {
     hips: captureBoneRotation(hips),
@@ -1954,7 +1954,8 @@ function attachSeatedCharacter({ template, seatConfig, characterTheme, store, pl
     baseSeatOffsetY - 0.06 - scaleDelta * 0.06,
     baseSeatOffsetZ + 0.42 - scaleDelta * 0.1
   );
-  seatRoot.rotation.set(characterTheme.seatPitch ?? -0.06, characterTheme.seatYaw ?? Math.PI, 0);
+  const resolvedSeatYaw = (characterTheme.seatYaw ?? Math.PI) - Math.PI;
+  seatRoot.rotation.set(characterTheme.seatPitch ?? -0.06, resolvedSeatYaw, 0);
 
   seatRoot.add(instance);
   seatRoot.userData.dispose = () => {


### PR DESCRIPTION
### Motivation
- Ensure 3D human characters in the Murlan Royale arena sit with legs downwards and face the table for correct portrait framing and interaction.
- Preserve original GLTF texture/material mapping so imported character models retain their native appearance and UVs.

### Description
- Load character GLTFs with `prepareLoadedModel(root, { preserveGltfTextureMapping: true })` in `loadCharacterModel` so native GLTF materials/UVs are preserved.
- Invert the base seated thigh/calf rotations in `createCharacterRig` so `leftThigh/rightThigh` use `-74°` and `leftCalf/rightCalf` use `+82°`, producing a downward-bent seated leg pose.
- Flip the seat-facing baseline by applying `const resolvedSeatYaw = (characterTheme.seatYaw ?? Math.PI) - Math.PI` and using `resolvedSeatYaw` for `seatRoot.rotation` so characters face the table.
- Modified file: `webapp/src/pages/Games/MurlanRoyaleArena.jsx`.

### Testing
- No automated unit or integration tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f38369752c8329b966946fbe572bfb)