### PR TITLE
Fix Murlan seated human orientation and preserve GLTF textures

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1641,7 +1641,7 @@ async function loadCharacterModel(theme, renderer = null) {
     const gltf = await loader.loadAsync(theme.url);
     const root = gltf?.scene || gltf?.scenes?.[0];
     if (!root) throw new Error(`Character scene missing for ${theme.id || 'unknown'}`);
-    prepareLoadedModel(root);
+    prepareLoadedModel(root, { preserveGltfTextureMapping: true });
     return root;
   })();
   CHARACTER_MODEL_CACHE.set(cacheKey, promise);
@@ -1831,10 +1831,10 @@ function createCharacterRig(instance, seatRoot, seatConfig, characterTheme, play
   applyRotationOffset(rightUpperArm, THREE.MathUtils.degToRad(-22), THREE.MathUtils.degToRad(-3), THREE.MathUtils.degToRad(-2));
   applyRotationOffset(rightForeArm, THREE.MathUtils.degToRad(-28), 0, THREE.MathUtils.degToRad(-4));
   applyRotationOffset(rightHand, THREE.MathUtils.degToRad(10), THREE.MathUtils.degToRad(-6), 0);
-  applyRotationOffset(leftThigh, THREE.MathUtils.degToRad(74), 0, 0);
-  applyRotationOffset(rightThigh, THREE.MathUtils.degToRad(74), 0, 0);
-  applyRotationOffset(leftCalf, THREE.MathUtils.degToRad(-82), 0, 0);
-  applyRotationOffset(rightCalf, THREE.MathUtils.degToRad(-82), 0, 0);
+  applyRotationOffset(leftThigh, THREE.MathUtils.degToRad(-74), 0, 0);
+  applyRotationOffset(rightThigh, THREE.MathUtils.degToRad(-74), 0, 0);
+  applyRotationOffset(leftCalf, THREE.MathUtils.degToRad(82), 0, 0);
+  applyRotationOffset(rightCalf, THREE.MathUtils.degToRad(82), 0, 0);
 
   rig.seatedPose = {
     hips: captureBoneRotation(hips),
@@ -1954,7 +1954,7 @@ function attachSeatedCharacter({ template, seatConfig, characterTheme, store, pl
     baseSeatOffsetY - 0.06 - scaleDelta * 0.06,
     baseSeatOffsetZ + 0.42 - scaleDelta * 0.1
   );
-  seatRoot.rotation.set(characterTheme.seatPitch ?? -0.06, characterTheme.seatYaw ?? Math.PI, 0);
+  seatRoot.rotation.set(characterTheme.seatPitch ?? -0.06, characterTheme.seatYaw ?? 0, 0);
 
   seatRoot.add(instance);
   seatRoot.userData.dispose = () => {


### PR DESCRIPTION
### Motivation
- Seated human models in the Murlan arena were facing the wrong direction and their legs were posed upwards instead of downwards, harming the portrait framing and visual correctness.
- Imported glTF character textures/UVs were being normalized in a way that could hide original material/texture mapping from authored models.

### Description
- Enabled preservation of original glTF texture mapping during character loading by calling `prepareLoadedModel(root, { preserveGltfTextureMapping: true })` in `loadCharacterModel` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx`.
- Flipped the seated leg rotation offsets in `createCharacterRig` by changing thigh and calf `applyRotationOffset` signs so legs bend downward in the seated pose.
- Fixed default seated yaw so characters face the chair/table by changing the fallback yaw from `Math.PI` to `0` when setting `seatRoot.rotation` in `attachSeatedCharacter`.

### Testing
- Ran the unit test `npm test -- --runInBand test/murlan.test.js`, which passed (all matching tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f38369752c8329b966946fbe572bfb)