### PR TITLE
Adjust Murlan Royale seated character lower-body alignment

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1848,10 +1848,11 @@ function createCharacterRig(instance, seatRoot, seatConfig, characterTheme, play
   applyRotationOffset(rightUpperArm, THREE.MathUtils.degToRad(-22), THREE.MathUtils.degToRad(-3), THREE.MathUtils.degToRad(-2));
   applyRotationOffset(rightForeArm, THREE.MathUtils.degToRad(-28), 0, THREE.MathUtils.degToRad(-4));
   applyRotationOffset(rightHand, THREE.MathUtils.degToRad(10), THREE.MathUtils.degToRad(-6), 0);
-  applyRotationOffset(leftThigh, THREE.MathUtils.degToRad(74), 0, 0);
-  applyRotationOffset(rightThigh, THREE.MathUtils.degToRad(74), 0, 0);
-  applyRotationOffset(leftCalf, THREE.MathUtils.degToRad(-82), 0, 0);
-  applyRotationOffset(rightCalf, THREE.MathUtils.degToRad(-82), 0, 0);
+  // Lower-body seat contact tuning (mobile portrait): legs sit lower and tuck toward the chair.
+  applyRotationOffset(leftThigh, THREE.MathUtils.degToRad(82), 0, 0);
+  applyRotationOffset(rightThigh, THREE.MathUtils.degToRad(82), 0, 0);
+  applyRotationOffset(leftCalf, THREE.MathUtils.degToRad(-96), 0, 0);
+  applyRotationOffset(rightCalf, THREE.MathUtils.degToRad(-96), 0, 0);
 
   rig.seatedPose = {
     hips: captureBoneRotation(hips),
@@ -1968,8 +1969,8 @@ function attachSeatedCharacter({ template, seatConfig, characterTheme, store, pl
   const baseSeatOffsetZ = characterTheme.normalizedSeatOffsetZ ?? characterTheme.seatOffsetZ ?? -0.24;
   seatRoot.position.set(
     0,
-    baseSeatOffsetY - 0.22 - scaleDelta * 0.08,
-    baseSeatOffsetZ - 0.03
+    baseSeatOffsetY - 0.3 - scaleDelta * 0.1,
+    baseSeatOffsetZ - 0.08
   );
   seatRoot.rotation.set(characterTheme.seatPitch ?? 0, characterTheme.seatYaw ?? 0, 0);
 


### PR DESCRIPTION
### Motivation
- Improve portrait/mobile framing by moving human avatars visually lower and closer to chairs so legs contact the seat more naturally.
- Make a minimal, conservative visual-only adjustment to seated rigs without changing gameplay logic.

### Description
- Increased thigh bend and calf tuck in the seated base pose by updating rotation offsets in `createCharacterRig` to make legs sit lower and tuck toward the chair (`leftThigh`/`rightThigh` 74°→82°, `leftCalf`/`rightCalf` -82°→-96°) in `webapp/src/pages/Games/MurlanRoyaleArena.jsx`.
- Lowered and slightly moved the character root toward the chair by adjusting `seatRoot.position` Y and Z offsets (`baseSeatOffsetY - 0.22 - ...` → `baseSeatOffsetY - 0.3 - ...`, and `baseSeatOffsetZ - 0.03` → `baseSeatOffsetZ - 0.08`) in `attachSeatedCharacter`.
- Scoped change to Murlan Royale 3D character rig and seat placement only, affecting seated pose and seat offsets for portrait framing.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3aafdccc48329a015c2c5a5f824d8)