### PR TITLE
Adjust Murlan seated human lower-body pose and chair alignment

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1848,10 +1848,10 @@ function createCharacterRig(instance, seatRoot, seatConfig, characterTheme, play
   applyRotationOffset(rightUpperArm, THREE.MathUtils.degToRad(-22), THREE.MathUtils.degToRad(-3), THREE.MathUtils.degToRad(-2));
   applyRotationOffset(rightForeArm, THREE.MathUtils.degToRad(-28), 0, THREE.MathUtils.degToRad(-4));
   applyRotationOffset(rightHand, THREE.MathUtils.degToRad(10), THREE.MathUtils.degToRad(-6), 0);
-  applyRotationOffset(leftThigh, THREE.MathUtils.degToRad(74), 0, 0);
-  applyRotationOffset(rightThigh, THREE.MathUtils.degToRad(74), 0, 0);
-  applyRotationOffset(leftCalf, THREE.MathUtils.degToRad(-82), 0, 0);
-  applyRotationOffset(rightCalf, THREE.MathUtils.degToRad(-82), 0, 0);
+  applyRotationOffset(leftThigh, THREE.MathUtils.degToRad(80), 0, 0);
+  applyRotationOffset(rightThigh, THREE.MathUtils.degToRad(80), 0, 0);
+  applyRotationOffset(leftCalf, THREE.MathUtils.degToRad(-92), 0, 0);
+  applyRotationOffset(rightCalf, THREE.MathUtils.degToRad(-92), 0, 0);
 
   rig.seatedPose = {
     hips: captureBoneRotation(hips),
@@ -1966,10 +1966,12 @@ function attachSeatedCharacter({ template, seatConfig, characterTheme, store, pl
   seatRoot.scale.multiplyScalar(seatScale);
   const baseSeatOffsetY = characterTheme.normalizedSeatOffsetY ?? characterTheme.seatOffsetY ?? -0.92;
   const baseSeatOffsetZ = characterTheme.normalizedSeatOffsetZ ?? characterTheme.seatOffsetZ ?? -0.24;
+  const seatDownwardAdjustment = 0.12;
+  const seatBackrestAdjustment = 0.06;
   seatRoot.position.set(
     0,
-    baseSeatOffsetY - 0.22 - scaleDelta * 0.08,
-    baseSeatOffsetZ - 0.03
+    baseSeatOffsetY - 0.22 - scaleDelta * 0.08 - seatDownwardAdjustment,
+    baseSeatOffsetZ - 0.03 - seatBackrestAdjustment
   );
   seatRoot.rotation.set(characterTheme.seatPitch ?? 0, characterTheme.seatYaw ?? 0, 0);
 


### PR DESCRIPTION
### Motivation
- Improve seated human visuals so the lower body appears more downward and sits closer to chairs for portrait/mobile framing. 
- Remove the floating look by adjusting pose and seat placement so avatars align with chair geometry and look natural on-screen.

### Description
- Increased seated leg bend by changing thigh rotations via `applyRotationOffset` for `leftThigh` and `rightThigh` from `74°` to `80°` and calf rotations for `leftCalf` and `rightCalf` from `-82°` to `-92°` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx`.
- Lowered and nudged the character root by adding `seatDownwardAdjustment = 0.12` and `seatBackrestAdjustment = 0.06` and applying them to `seatRoot.position.set(...)` so characters sit visually lower and slightly into the chair back.
- Changes are localized to the seated pose and seat-placement logic in `createCharacterRig` / `attachSeatedCharacter` within `MurlanRoyaleArena.jsx`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3aafdccc48329a015c2c5a5f824d8)