### PR TITLE
Lower seated Murlan characters and angle legs downward for portrait framing

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1848,10 +1848,11 @@ function createCharacterRig(instance, seatRoot, seatConfig, characterTheme, play
   applyRotationOffset(rightUpperArm, THREE.MathUtils.degToRad(-22), THREE.MathUtils.degToRad(-3), THREE.MathUtils.degToRad(-2));
   applyRotationOffset(rightForeArm, THREE.MathUtils.degToRad(-28), 0, THREE.MathUtils.degToRad(-4));
   applyRotationOffset(rightHand, THREE.MathUtils.degToRad(10), THREE.MathUtils.degToRad(-6), 0);
-  applyRotationOffset(leftThigh, THREE.MathUtils.degToRad(74), 0, 0);
-  applyRotationOffset(rightThigh, THREE.MathUtils.degToRad(74), 0, 0);
-  applyRotationOffset(leftCalf, THREE.MathUtils.degToRad(-82), 0, 0);
-  applyRotationOffset(rightCalf, THREE.MathUtils.degToRad(-82), 0, 0);
+  // Push lower body downward so seated legs rest closer to the chair cushion in portrait view.
+  applyRotationOffset(leftThigh, THREE.MathUtils.degToRad(82), 0, 0);
+  applyRotationOffset(rightThigh, THREE.MathUtils.degToRad(82), 0, 0);
+  applyRotationOffset(leftCalf, THREE.MathUtils.degToRad(-92), 0, 0);
+  applyRotationOffset(rightCalf, THREE.MathUtils.degToRad(-92), 0, 0);
 
   rig.seatedPose = {
     hips: captureBoneRotation(hips),
@@ -1968,7 +1969,7 @@ function attachSeatedCharacter({ template, seatConfig, characterTheme, store, pl
   const baseSeatOffsetZ = characterTheme.normalizedSeatOffsetZ ?? characterTheme.seatOffsetZ ?? -0.24;
   seatRoot.position.set(
     0,
-    baseSeatOffsetY - 0.22 - scaleDelta * 0.08,
+    baseSeatOffsetY - 0.29 - scaleDelta * 0.08,
     baseSeatOffsetZ - 0.03
   );
   seatRoot.rotation.set(characterTheme.seatPitch ?? 0, characterTheme.seatYaw ?? 0, 0);


### PR DESCRIPTION
### Motivation
- Fix visual issue where human characters appeared too high above chairs by moving them lower on-screen to match portrait-oriented layout expectations.
- Make the seated lower-body pose point legs more downward so seated characters look naturally seated against the chair cushion.

### Description
- Updated `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to lower the seated character root by changing `baseSeatOffsetY - 0.22 - scaleDelta * 0.08` to `baseSeatOffsetY - 0.29 - scaleDelta * 0.08` in `attachSeatedCharacter`.
- Tuned the seated rig lower-body rotations in `createCharacterRig` by changing thigh rotations from `degToRad(74)` to `degToRad(82)` and calf rotations from `degToRad(-82)` to `degToRad(-92)`.
- Added a small inline comment clarifying that the tweak targets portrait-view seating quality.

### Testing
- Verified the changes exist in the file via `rg` searches for the new offsets/rotation values which returned the updated lines, and the search command completed successfully.
- Ran `git status --short` to confirm the file was modified and staged for commit which succeeded.
- No runtime or automated unit/integration test suite was executed because this is a pose/layout tuning change only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3aafdccc48329a015c2c5a5f824d8)