### PR TITLE
Chess: restore per-pad weapon swap and disable dynamic attack camera for truck/air units

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -7687,18 +7687,63 @@ function Chess3D({
       .filter(Boolean);
   }, [ownedCaptureAnimations, QUICK_SWAP_WEAPON_IDS]);
   const [weaponSwapOpen, setWeaponSwapOpen] = useState(false);
+  const [weaponSwapTargetKind, setWeaponSwapTargetKind] = useState(null);
+  const PIECE_GROUP_BY_PARKED_KIND = useMemo(() => ({
+    jet: 'kingQueen',
+    helicopter: 'bishopRook',
+    drone: 'knight',
+    truck: 'pawn'
+  }), []);
+  const [captureAnimationByPieceGroup, setCaptureAnimationByPieceGroup] = useState(() => ({
+    kingQueen: selectedCaptureAnimationId,
+    bishopRook: selectedCaptureAnimationId,
+    knight: selectedCaptureAnimationId,
+    pawn: selectedCaptureAnimationId
+  }));
+  useEffect(() => {
+    setCaptureAnimationByPieceGroup((prev) => ({
+      kingQueen: prev.kingQueen || selectedCaptureAnimationId,
+      bishopRook: prev.bishopRook || selectedCaptureAnimationId,
+      knight: prev.knight || selectedCaptureAnimationId,
+      pawn: prev.pawn || selectedCaptureAnimationId
+    }));
+  }, [selectedCaptureAnimationId]);
   const handleCaptureAnimationSwap = useCallback(
     (optionId) => {
-      if (!optionId || optionId === selectedCaptureAnimationId) return;
-      setChessBattleEquippedOption('captureAnimation', optionId, resolvedAccountId);
+      if (!optionId) return;
+      const targetKind = weaponSwapTargetKind;
+      const targetGroup = targetKind ? PIECE_GROUP_BY_PARKED_KIND[targetKind] : null;
+      if (targetGroup) {
+        setCaptureAnimationByPieceGroup((prev) => ({ ...prev, [targetGroup]: optionId }));
+      }
+      if (optionId !== selectedCaptureAnimationId) {
+        setChessBattleEquippedOption('captureAnimation', optionId, resolvedAccountId);
+      }
       setWeaponSwapOpen(false);
+      setWeaponSwapTargetKind(null);
     },
-    [resolvedAccountId, selectedCaptureAnimationId]
+    [PIECE_GROUP_BY_PARKED_KIND, resolvedAccountId, selectedCaptureAnimationId, weaponSwapTargetKind]
   );
   const quickSwapWeaponList = useMemo(() => {
     const pool = quickSwapWeapons.length ? quickSwapWeapons : ownedCaptureAnimations;
+    if (!weaponSwapTargetKind) return pool;
+
+    // Parked pads (jet / drone / helicopter / truck) can now be swapped with any owned firearm.
+    // Keep full firearm inventory visible when player taps one of those parked vehicles.
+    if (['jet', 'drone', 'helicopter', 'truck'].includes(weaponSwapTargetKind)) {
+      const firearmOnly = pool.filter((option) =>
+        FIREARM_CAPTURE_ANIMATION_IDS.has(option.id)
+      );
+      if (firearmOnly.length) return firearmOnly;
+    }
+
+    const filtered = pool.filter((option) => {
+      if (FIREARM_CAPTURE_ANIMATION_IDS.has(option.id)) return true;
+      return GLOBAL_CAPTURE_KIND_BY_ANIMATION_ID[option.id] === weaponSwapTargetKind;
+    });
+    if (filtered.length) return filtered;
     return pool;
-  }, [ownedCaptureAnimations, quickSwapWeapons]);
+  }, [ownedCaptureAnimations, quickSwapWeapons, weaponSwapTargetKind]);
   useEffect(() => {
     const handler = (event) => {
       if (!event?.detail?.accountId || event.detail.accountId === resolvedAccountId) {
@@ -11133,9 +11178,19 @@ function Chess3D({
       };
     };
 
-    const resolveCaptureKindForPiece = () => {
-      if (FIREARM_CAPTURE_ANIMATION_IDS.has(selectedCaptureAnimationId)) return 'firearm';
-      return GLOBAL_CAPTURE_KIND_BY_ANIMATION_ID[selectedCaptureAnimationId] || 'truck';
+    const resolvePieceGroupFromType = (pieceType) => {
+      const t = `${pieceType || ''}`.toLowerCase();
+      if (t === 'k' || t === 'q') return 'kingQueen';
+      if (t === 'b' || t === 'r') return 'bishopRook';
+      if (t === 'n') return 'knight';
+      return 'pawn';
+    };
+
+    const resolveCaptureKindForPiece = (pieceType) => {
+      const group = resolvePieceGroupFromType(pieceType);
+      const selectedId = captureAnimationByPieceGroup[group] || selectedCaptureAnimationId;
+      if (FIREARM_CAPTURE_ANIMATION_IDS.has(selectedId)) return 'firearm';
+      return GLOBAL_CAPTURE_KIND_BY_ANIMATION_ID[selectedId] || 'truck';
     };
 
     const playCaptureAnimation = ({
@@ -11148,9 +11203,10 @@ function Chess3D({
       deltaR = 0,
       deltaC = 0
     }) => {
-      const withAuto3d = (timing = {}) => {
+      const withAuto3d = (timing = {}, options = {}) => {
+        const useDynamicCamera = options.dynamicCamera !== false;
         const durationMs = Math.max(0, timing.captureResolveDelayMs ?? timing.moveDelayMs ?? 0);
-        if (durationMs > 0) {
+        if (useDynamicCamera && durationMs > 0) {
           runCaptureInTemporary3dView(durationMs);
         }
         return timing;
@@ -11186,10 +11242,13 @@ function Chess3D({
           strikeAltitude: CAPTURE_DRONE_STRIKE_ALTITUDE,
           targetLift: CAPTURE_TRUCK_STRIKE_TARGET_LIFT
         });
-        return withAuto3d({
-          moveDelayMs: CAPTURE_GROUND_TOTAL * 1000,
-          captureResolveDelayMs: CAPTURE_GROUND_TOTAL * 1000
-        });
+        return withAuto3d(
+          {
+            moveDelayMs: CAPTURE_GROUND_TOTAL * 1000,
+            captureResolveDelayMs: CAPTURE_GROUND_TOTAL * 1000
+          },
+          { dynamicCamera: false }
+        );
       }
       if (captureKind === 'drone') {
         suppressTimerBeepUntilRef.current = performance.now() + CAPTURE_DRONE_ATTACK_TOTAL * 1000;
@@ -11220,10 +11279,13 @@ function Chess3D({
           droneFx,
           strikeAltitude: CAPTURE_DRONE_STRIKE_ALTITUDE
         });
-        return withAuto3d({
-          moveDelayMs: CAPTURE_DRONE_ATTACK_TOTAL * 1000,
-          captureResolveDelayMs: CAPTURE_DRONE_ATTACK_TOTAL * 1000
-        });
+        return withAuto3d(
+          {
+            moveDelayMs: CAPTURE_DRONE_ATTACK_TOTAL * 1000,
+            captureResolveDelayMs: CAPTURE_DRONE_ATTACK_TOTAL * 1000
+          },
+          { dynamicCamera: false }
+        );
       }
       if (captureKind === 'helicopter') {
         suppressTimerBeepUntilRef.current = performance.now() + CAPTURE_HELICOPTER_TOTAL * 1000;
@@ -11273,10 +11335,13 @@ function Chess3D({
           missileFx
         });
         const helicopterImpactDelayMs = getAirMissileImpactTime(CAPTURE_HELICOPTER_TOTAL) * 1000;
-        return withAuto3d({
-          moveDelayMs: helicopterImpactDelayMs,
-          captureResolveDelayMs: helicopterImpactDelayMs
-        });
+        return withAuto3d(
+          {
+            moveDelayMs: helicopterImpactDelayMs,
+            captureResolveDelayMs: helicopterImpactDelayMs
+          },
+          { dynamicCamera: false }
+        );
       }
       if (captureKind === 'jet') {
         suppressTimerBeepUntilRef.current = performance.now() + CAPTURE_JET_TOTAL * 1000;
@@ -11321,10 +11386,13 @@ function Chess3D({
           missileFx
         });
         const jetImpactDelayMs = getAirMissileImpactTime(CAPTURE_JET_TOTAL) * 1000;
-        return withAuto3d({
-          moveDelayMs: jetImpactDelayMs,
-          captureResolveDelayMs: jetImpactDelayMs
-        });
+        return withAuto3d(
+          {
+            moveDelayMs: jetImpactDelayMs,
+            captureResolveDelayMs: jetImpactDelayMs
+          },
+          { dynamicCamera: false }
+        );
       }
       if (captureKind === 'firearm') {
         const firearmProfile = resolveFirearmCaptureProfile();
@@ -13051,6 +13119,7 @@ function Chess3D({
         let node = hit.object;
         while (node) {
           if (node?.userData?.type === 'parkedWeapon' && node?.userData?.parkedWeaponKind) {
+            setWeaponSwapTargetKind(node.userData.parkedWeaponKind);
             setWeaponSwapOpen(true);
             return;
           }
@@ -13995,12 +14064,13 @@ function Chess3D({
               <div className="max-h-[52vh] w-[14rem] overflow-y-auto rounded-2xl border border-white/20 bg-[#060a14]/95 p-2 text-xs shadow-2xl backdrop-blur">
                 <div className="flex items-center justify-between px-2 pb-2">
                   <p className="text-[10px] uppercase tracking-[0.3em] text-sky-200/80">
-                    Quick Weapon Swap
+                    Quick Weapon Swap {weaponSwapTargetKind ? `• ${weaponSwapTargetKind}` : ''}
                   </p>
                   <button
                     type="button"
                     onClick={() => {
                       setWeaponSwapOpen(false);
+                      setWeaponSwapTargetKind(null);
                     }}
                     className="rounded-md border border-white/20 px-1.5 py-0.5 text-[10px] text-white/75 hover:border-white/40 hover:text-white"
                   >
@@ -14009,7 +14079,11 @@ function Chess3D({
                 </div>
                 <div className="space-y-2">
                   {quickSwapWeaponList.map((option) => {
-                    const isSelected = option.id === selectedCaptureAnimationId;
+                    const targetGroup = weaponSwapTargetKind ? PIECE_GROUP_BY_PARKED_KIND[weaponSwapTargetKind] : null;
+                    const activeOptionId = targetGroup
+                      ? captureAnimationByPieceGroup[targetGroup]
+                      : selectedCaptureAnimationId;
+                    const isSelected = option.id === activeOptionId;
                     return (
                       <button
                         key={option.id}


### PR DESCRIPTION
### Motivation
- Restore prior Chess Battle Royal weapon/animation behavior so jets, helicopters and drones use the earlier animation logic and parked-pad swaps behave as they did on the April 25 snapshot. 
- Stop cinematic dynamic camera takeovers for truck and air-strike animations while keeping dynamic camera behavior for other weapon types. 
- Fix quick-weapon-swap visibility and selection so owned weapons in inventory are selectable from parked pads and per-piece group mappings are preserved.

### Description
- Restored and reworked the per-pad / piece-group capture swap logic and UI state in `webapp/src/pages/Games/ChessBattleRoyal.jsx` by reintroducing `weaponSwapTargetKind`, `PIECE_GROUP_BY_PARKED_KIND` and `captureAnimationByPieceGroup` and wiring swap selection to piece groups. 
- Updated `quickSwapWeaponList` filtering so air pads (`jet`, `drone`, `helicopter`) and `truck` show the correct (firearm-focused) options from the owned inventory and fall back to appropriate filters when needed. 
- Made parked weapon pads clickable to set the swap target kind and show the pad type in the Quick Weapon Swap UI. 
- Added an option to the capture camera helper `withAuto3d(timing, options)` and disabled dynamic temporary 3D camera transitions for `truck`, `drone`, `helicopter`, and `jet` captures by passing `{ dynamicCamera: false }` for those cases. 
- Changes are contained to `webapp/src/pages/Games/ChessBattleRoyal.jsx` and include small UI adjustments to indicate the selected pad kind and preserve per-group active selection state.

### Testing
- Ran repository verification and inspection commands (`git diff`, `git status --short`, `git log`, `nl -ba` and `rg` searches) to validate the patch and confirm the modified lines; all commands completed successfully. 
- Created the branch/commit including the changes (`git commit`) successfully. 
- No automated unit or integration test suite was executed as part of this change (no Jest/CI runs were invoked).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3b37bbc948329add044894964a008)