### PR TITLE
Chess: restore per-pad weapon swap and disable auto-3D for air/truck captures

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -7687,18 +7687,63 @@ function Chess3D({
       .filter(Boolean);
   }, [ownedCaptureAnimations, QUICK_SWAP_WEAPON_IDS]);
   const [weaponSwapOpen, setWeaponSwapOpen] = useState(false);
+  const [weaponSwapTargetKind, setWeaponSwapTargetKind] = useState(null);
+  const PIECE_GROUP_BY_PARKED_KIND = useMemo(() => ({
+    jet: 'kingQueen',
+    helicopter: 'bishopRook',
+    drone: 'knight',
+    truck: 'pawn'
+  }), []);
+  const [captureAnimationByPieceGroup, setCaptureAnimationByPieceGroup] = useState(() => ({
+    kingQueen: selectedCaptureAnimationId,
+    bishopRook: selectedCaptureAnimationId,
+    knight: selectedCaptureAnimationId,
+    pawn: selectedCaptureAnimationId
+  }));
+  useEffect(() => {
+    setCaptureAnimationByPieceGroup((prev) => ({
+      kingQueen: prev.kingQueen || selectedCaptureAnimationId,
+      bishopRook: prev.bishopRook || selectedCaptureAnimationId,
+      knight: prev.knight || selectedCaptureAnimationId,
+      pawn: prev.pawn || selectedCaptureAnimationId
+    }));
+  }, [selectedCaptureAnimationId]);
   const handleCaptureAnimationSwap = useCallback(
     (optionId) => {
-      if (!optionId || optionId === selectedCaptureAnimationId) return;
-      setChessBattleEquippedOption('captureAnimation', optionId, resolvedAccountId);
+      if (!optionId) return;
+      const targetKind = weaponSwapTargetKind;
+      const targetGroup = targetKind ? PIECE_GROUP_BY_PARKED_KIND[targetKind] : null;
+      if (targetGroup) {
+        setCaptureAnimationByPieceGroup((prev) => ({ ...prev, [targetGroup]: optionId }));
+      }
+      if (optionId !== selectedCaptureAnimationId) {
+        setChessBattleEquippedOption('captureAnimation', optionId, resolvedAccountId);
+      }
       setWeaponSwapOpen(false);
+      setWeaponSwapTargetKind(null);
     },
-    [resolvedAccountId, selectedCaptureAnimationId]
+    [PIECE_GROUP_BY_PARKED_KIND, resolvedAccountId, selectedCaptureAnimationId, weaponSwapTargetKind]
   );
   const quickSwapWeaponList = useMemo(() => {
     const pool = quickSwapWeapons.length ? quickSwapWeapons : ownedCaptureAnimations;
+    if (!weaponSwapTargetKind) return pool;
+
+    // Parked pads (jet / drone / helicopter / truck) can now be swapped with any owned firearm.
+    // Keep full firearm inventory visible when player taps one of those parked vehicles.
+    if (['jet', 'drone', 'helicopter', 'truck'].includes(weaponSwapTargetKind)) {
+      const firearmOnly = pool.filter((option) =>
+        FIREARM_CAPTURE_ANIMATION_IDS.has(option.id)
+      );
+      if (firearmOnly.length) return firearmOnly;
+    }
+
+    const filtered = pool.filter((option) => {
+      if (FIREARM_CAPTURE_ANIMATION_IDS.has(option.id)) return true;
+      return GLOBAL_CAPTURE_KIND_BY_ANIMATION_ID[option.id] === weaponSwapTargetKind;
+    });
+    if (filtered.length) return filtered;
     return pool;
-  }, [ownedCaptureAnimations, quickSwapWeapons]);
+  }, [ownedCaptureAnimations, quickSwapWeapons, weaponSwapTargetKind]);
   useEffect(() => {
     const handler = (event) => {
       if (!event?.detail?.accountId || event.detail.accountId === resolvedAccountId) {
@@ -11133,9 +11178,19 @@ function Chess3D({
       };
     };
 
-    const resolveCaptureKindForPiece = () => {
-      if (FIREARM_CAPTURE_ANIMATION_IDS.has(selectedCaptureAnimationId)) return 'firearm';
-      return GLOBAL_CAPTURE_KIND_BY_ANIMATION_ID[selectedCaptureAnimationId] || 'truck';
+    const resolvePieceGroupFromType = (pieceType) => {
+      const t = `${pieceType || ''}`.toLowerCase();
+      if (t === 'k' || t === 'q') return 'kingQueen';
+      if (t === 'b' || t === 'r') return 'bishopRook';
+      if (t === 'n') return 'knight';
+      return 'pawn';
+    };
+
+    const resolveCaptureKindForPiece = (pieceType) => {
+      const group = resolvePieceGroupFromType(pieceType);
+      const selectedId = captureAnimationByPieceGroup[group] || selectedCaptureAnimationId;
+      if (FIREARM_CAPTURE_ANIMATION_IDS.has(selectedId)) return 'firearm';
+      return GLOBAL_CAPTURE_KIND_BY_ANIMATION_ID[selectedId] || 'truck';
     };
 
     const playCaptureAnimation = ({
@@ -11148,9 +11203,10 @@ function Chess3D({
       deltaR = 0,
       deltaC = 0
     }) => {
-      const withAuto3d = (timing = {}) => {
+      const withAuto3d = (timing = {}, options = {}) => {
+        const { enableAuto3d = true } = options;
         const durationMs = Math.max(0, timing.captureResolveDelayMs ?? timing.moveDelayMs ?? 0);
-        if (durationMs > 0) {
+        if (enableAuto3d && durationMs > 0) {
           runCaptureInTemporary3dView(durationMs);
         }
         return timing;
@@ -11189,7 +11245,7 @@ function Chess3D({
         return withAuto3d({
           moveDelayMs: CAPTURE_GROUND_TOTAL * 1000,
           captureResolveDelayMs: CAPTURE_GROUND_TOTAL * 1000
-        });
+        }, { enableAuto3d: false });
       }
       if (captureKind === 'drone') {
         suppressTimerBeepUntilRef.current = performance.now() + CAPTURE_DRONE_ATTACK_TOTAL * 1000;
@@ -11223,7 +11279,7 @@ function Chess3D({
         return withAuto3d({
           moveDelayMs: CAPTURE_DRONE_ATTACK_TOTAL * 1000,
           captureResolveDelayMs: CAPTURE_DRONE_ATTACK_TOTAL * 1000
-        });
+        }, { enableAuto3d: false });
       }
       if (captureKind === 'helicopter') {
         suppressTimerBeepUntilRef.current = performance.now() + CAPTURE_HELICOPTER_TOTAL * 1000;
@@ -11276,7 +11332,7 @@ function Chess3D({
         return withAuto3d({
           moveDelayMs: helicopterImpactDelayMs,
           captureResolveDelayMs: helicopterImpactDelayMs
-        });
+        }, { enableAuto3d: false });
       }
       if (captureKind === 'jet') {
         suppressTimerBeepUntilRef.current = performance.now() + CAPTURE_JET_TOTAL * 1000;
@@ -11324,7 +11380,7 @@ function Chess3D({
         return withAuto3d({
           moveDelayMs: jetImpactDelayMs,
           captureResolveDelayMs: jetImpactDelayMs
-        });
+        }, { enableAuto3d: false });
       }
       if (captureKind === 'firearm') {
         const firearmProfile = resolveFirearmCaptureProfile();
@@ -13051,6 +13107,7 @@ function Chess3D({
         let node = hit.object;
         while (node) {
           if (node?.userData?.type === 'parkedWeapon' && node?.userData?.parkedWeaponKind) {
+            setWeaponSwapTargetKind(node.userData.parkedWeaponKind);
             setWeaponSwapOpen(true);
             return;
           }
@@ -13995,12 +14052,13 @@ function Chess3D({
               <div className="max-h-[52vh] w-[14rem] overflow-y-auto rounded-2xl border border-white/20 bg-[#060a14]/95 p-2 text-xs shadow-2xl backdrop-blur">
                 <div className="flex items-center justify-between px-2 pb-2">
                   <p className="text-[10px] uppercase tracking-[0.3em] text-sky-200/80">
-                    Quick Weapon Swap
+                    Quick Weapon Swap {weaponSwapTargetKind ? `• ${weaponSwapTargetKind}` : ''}
                   </p>
                   <button
                     type="button"
                     onClick={() => {
                       setWeaponSwapOpen(false);
+                      setWeaponSwapTargetKind(null);
                     }}
                     className="rounded-md border border-white/20 px-1.5 py-0.5 text-[10px] text-white/75 hover:border-white/40 hover:text-white"
                   >
@@ -14009,7 +14067,11 @@ function Chess3D({
                 </div>
                 <div className="space-y-2">
                   {quickSwapWeaponList.map((option) => {
-                    const isSelected = option.id === selectedCaptureAnimationId;
+                    const targetGroup = weaponSwapTargetKind ? PIECE_GROUP_BY_PARKED_KIND[weaponSwapTargetKind] : null;
+                    const activeOptionId = targetGroup
+                      ? captureAnimationByPieceGroup[targetGroup]
+                      : selectedCaptureAnimationId;
+                    const isSelected = option.id === activeOptionId;
                     return (
                       <button
                         key={option.id}


### PR DESCRIPTION
### Motivation
- Restore the expected quick-weapon UX so parked pads (jet/helicopter/drone/truck) map to piece-groups and allow selecting owned weapons from the quick-swap panel. 
- Prevent disruptive camera mode switching during long vehicle captures so the game view/layout remains stable while only the selected capture animation runs. 

### Description
- Reintroduced per-pad swap state including `weaponSwapTargetKind`, `PIECE_GROUP_BY_PARKED_KIND`, and `captureAnimationByPieceGroup` so parked pads target piece-groups and per-group selections are preserved. 
- Restored pad-click handling to set `weaponSwapTargetKind` and show a filtered `quickSwapWeaponList` that exposes firearms for vehicle pads while still allowing per-group defaults. 
- Updated `handleCaptureAnimationSwap` to apply swaps per target group and keep the quick-swap panel UX consistent. 
- Added an `options` parameter to `withAuto3d` and disabled forced temporary 3D camera switching for `truck`, `drone`, `helicopter`, and `jet` captures by calling `withAuto3d(..., { enableAuto3d: false })` while leaving auto-3D enabled for other capture types. 

### Testing
- Ran `npm -C webapp run` to verify available project scripts and that the workspace can list/run package commands (succeeded). 
- Attempted `npm -C webapp run -s lint` which failed due to the repository not having a `lint` script configured (no linting step executed). 
- No unit/integration test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3b37bbc948329add044894964a008)