### PR TITLE
Adjust Murlan Royale avatar framing, hide top floating cards, and tune GLTF materials

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1659,6 +1659,19 @@ async function loadCharacterModel(theme, renderer = null) {
     const root = gltf.scene || gltf.scenes?.[0];
     if (!root) throw new Error(`Character scene missing for ${theme.id || 'unknown'}`);
     prepareLoadedModel(root, { preserveGltfTextureMapping: true });
+    root.traverse((obj) => {
+      if (!obj?.isMesh) return;
+      const mats = Array.isArray(obj.material) ? obj.material : [obj.material];
+      mats.forEach((mat) => {
+        if (!mat) return;
+        if (mat.map) mat.color?.set?.('#ffffff');
+        if (mat.emissive) mat.emissive.set('#000000');
+        if (typeof mat.emissiveIntensity === 'number') mat.emissiveIntensity = 0;
+        if (typeof mat.roughness === 'number') mat.roughness = Math.max(mat.roughness, 0.78);
+        if (typeof mat.metalness === 'number') mat.metalness = Math.min(mat.metalness, 0.12);
+        mat.needsUpdate = true;
+      });
+    });
     return root;
   })();
   CHARACTER_MODEL_CACHE.set(cacheKey, promise);
@@ -1965,15 +1978,15 @@ function attachSeatedCharacter({ template, seatConfig, characterTheme, store, pl
   normalizeCharacterPivot(instance);
 
   const seatRoot = new THREE.Group();
-  const seatScale = (characterTheme.scale ?? 0.82) * CHARACTER_PROPORTION_SCALE;
+  const seatScale = (characterTheme.scale ?? 0.72) * CHARACTER_PROPORTION_SCALE;
   const scaleDelta = Math.max(0, CHARACTER_PROPORTION_SCALE - 1);
   seatRoot.scale.multiplyScalar(seatScale);
-  const baseSeatOffsetY = (characterTheme.normalizedSeatOffsetY ?? characterTheme.seatOffsetY ?? -0.92) - 0.05;
+  const baseSeatOffsetY = (characterTheme.normalizedSeatOffsetY ?? characterTheme.seatOffsetY ?? -0.92) - 0.1;
   const baseSeatOffsetZ = characterTheme.normalizedSeatOffsetZ ?? characterTheme.seatOffsetZ ?? -0.24;
   seatRoot.position.set(
     0,
     baseSeatOffsetY - 0.22 - scaleDelta * 0.08,
-    baseSeatOffsetZ - 0.03
+    baseSeatOffsetZ + 0.04
   );
   seatRoot.rotation.set(characterTheme.seatPitch ?? 0, characterTheme.seatYaw ?? 0, 0);
 
@@ -2185,6 +2198,19 @@ async function loadPolyhavenModel(assetId, renderer = null) {
       throw new Error(`Missing scene for ${assetId}`);
     }
     prepareLoadedModel(root, { preserveGltfTextureMapping: true });
+    root.traverse((obj) => {
+      if (!obj?.isMesh) return;
+      const mats = Array.isArray(obj.material) ? obj.material : [obj.material];
+      mats.forEach((mat) => {
+        if (!mat) return;
+        if (mat.map) mat.color?.set?.('#ffffff');
+        if (mat.emissive) mat.emissive.set('#000000');
+        if (typeof mat.emissiveIntensity === 'number') mat.emissiveIntensity = 0;
+        if (typeof mat.roughness === 'number') mat.roughness = Math.max(mat.roughness, 0.78);
+        if (typeof mat.metalness === 'number') mat.metalness = Math.min(mat.metalness, 0.12);
+        mat.needsUpdate = true;
+      });
+    });
     return root;
   })();
 
@@ -2418,7 +2444,7 @@ const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 1.1;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
 const CHAIR_GROUND_DROP = 0;
 const CHAIR_SCREEN_LOWER_OFFSET = 0.14 * MODEL_SCALE;
-const HUMAN_CHAIR_EXTRA_INWARD_OFFSET = 0.06 * MODEL_SCALE; // Pull human seat slightly inward so body rests closer to the chair.
+const HUMAN_CHAIR_EXTRA_INWARD_OFFSET = -0.08 * MODEL_SCALE; // Push human seat outward so body sits farther from center on portrait screens.
 const TABLE_HEIGHT_LIFT = 0.025 * MODEL_SCALE;
 const TABLE_HEIGHT = STOOL_HEIGHT + TABLE_HEIGHT_LIFT;
 const TABLE_SIDE_TRIM_SCALE = 1;
@@ -3856,6 +3882,7 @@ export default function MurlanRoyaleArena({ search }) {
         const layerIndex = isHumanCard ? cards.length - 1 - cardIdx : cardIdx;
         applyHandCardLayering(mesh, isHumanCard, layerIndex);
         const isGiftSideSeat = seat?.handVariant === 'giftSide';
+        const isTopAiSeat = !isHumanCard && seat?.handVariant === 'top';
         const backLogoVariant = isHumanCard
           ? 'default'
           : seat?.handVariant === 'top'
@@ -3864,6 +3891,10 @@ export default function MurlanRoyaleArena({ search }) {
               ? 'sideGift'
               : 'side';
         setBackLogoOrientation(mesh, backLogoVariant);
+        if (isTopAiSeat) {
+          mesh.visible = false;
+          return;
+        }
         mesh.visible = true;
         updateCardFace(mesh, isHumanCard ? 'front' : 'back');
         handsVisible.add(card.id);


### PR DESCRIPTION
### Motivation
- Make human avatars appear smaller, lower on-screen and farther outward from the table center for better portrait framing. 
- Remove the distracting floating cards at the top of the screen for the top AI seat. 
- Improve GLTF character material/texture handling so loaded character models render with more neutral/consistent shading.

### Description
- Reduced default seated character scale by lowering the fallback `characterTheme.scale` multiplier in `attachSeatedCharacter` from `0.82` to `0.72` and adjusted the seat position offsets (`baseSeatOffsetY` and Z) to move characters lower and more outward. 
- Reversed and increased the human chair offset by changing `HUMAN_CHAIR_EXTRA_INWARD_OFFSET` from `0.06 * MODEL_SCALE` to `-0.08 * MODEL_SCALE` so human chairs sit farther from the table center. 
- Hid floating top-seat cards by skipping rendering for seats where `!isHumanCard && seat?.handVariant === 'top'` (early `mesh.visible = false; return;`). 
- Tuned GLTF material post-processing in `loadCharacterModel` and `loadPolyhavenModel` by neutralizing `emissive`, forcing mapped textures to neutral color application, clamping `roughness` (min `0.78`) and limiting `metalness` (max `0.12`), and calling `mat.needsUpdate = true` to improve texture appearance. 
- Changed only `webapp/src/pages/Games/MurlanRoyaleArena.jsx` in this PR.

### Testing
- Ran `git -C /workspace/TonPlaygramWebApp diff -- webapp/src/pages/Games/MurlanRoyaleArena.jsx` to review the local diff and it completed successfully. 
- Ran `git -C /workspace/TonPlaygramWebApp status --short` to confirm working tree changes and it completed successfully. 
- Committed the change with `git -C /workspace/TonPlaygramWebApp commit -m "Adjust Murlan Royale character framing and top-seat cards"` and the commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f423ac364483299e5238169f4c1c95)