### PR TITLE
Persist per-piece-group capture animations, refine quick-swap prioritization, and fix group mappings

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -54,8 +54,7 @@ import {
 import {
   chessBattleAccountId,
   getChessBattleInventory,
-  isChessOptionUnlocked,
-  setChessBattleEquippedOption
+  isChessOptionUnlocked
 } from '../../utils/chessBattleInventory.js';
 import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
 import { avatarToName } from '../../utils/avatarUtils.js';
@@ -2601,6 +2600,7 @@ const DEFAULT_APPEARANCE = {
   environmentHdri: DEFAULT_HDRI_INDEX
 };
 const APPEARANCE_STORAGE_KEY = 'chessBattleRoyalAppearance';
+const CAPTURE_GROUP_SWAP_STORAGE_KEY = 'chessBattleRoyalCaptureGroupSwap';
 const CHAIR_COLOR_OPTIONS = Object.freeze([...CHESS_CHAIR_OPTIONS]);
 const TABLE_THEME_OPTIONS = Object.freeze([...CHESS_BATTLE_TABLE_OPTIONS]);
 const HUMAN_CHARACTER_OPTIONS = Object.freeze([...CHESS_HUMAN_CHARACTER_OPTIONS]);
@@ -7680,34 +7680,85 @@ function Chess3D({
     []
   );
   const quickSwapWeapons = useMemo(() => {
-    const ownedIds = new Set((ownedCaptureAnimations || []).map((option) => option.id));
-    return QUICK_SWAP_WEAPON_IDS
-      .filter((id) => ownedIds.has(id))
+    const prioritized = [];
+    const seen = new Set();
+    const pushOption = (option) => {
+      if (!option?.id || seen.has(option.id)) return;
+      seen.add(option.id);
+      prioritized.push(option);
+    };
+    ownedCaptureAnimations.forEach(pushOption);
+    QUICK_SWAP_WEAPON_IDS
       .map((id) => CAPTURE_ANIMATION_OPTIONS.find((option) => option.id === id))
-      .filter(Boolean);
+      .forEach(pushOption);
+    return prioritized;
   }, [ownedCaptureAnimations, QUICK_SWAP_WEAPON_IDS]);
   const [weaponSwapOpen, setWeaponSwapOpen] = useState(false);
   const [weaponSwapTargetKind, setWeaponSwapTargetKind] = useState(null);
   const PIECE_GROUP_BY_PARKED_KIND = useMemo(() => ({
     jet: 'kingQueen',
-    helicopter: 'bishopRook',
-    drone: 'knight',
-    truck: 'pawn'
+    helicopter: 'bishop',
+    truck: 'knightRook',
+    drone: 'pawn'
   }), []);
-  const [captureAnimationByPieceGroup, setCaptureAnimationByPieceGroup] = useState(() => ({
-    kingQueen: selectedCaptureAnimationId,
-    bishopRook: selectedCaptureAnimationId,
-    knight: selectedCaptureAnimationId,
-    pawn: selectedCaptureAnimationId
-  }));
+  const resolveDefaultCaptureAnimationIdByKind = useCallback(
+    (kind) => {
+      const ownedIds = new Set((chessInventory?.captureAnimation || []).filter(Boolean));
+      const fallbackByKind = {
+        jet: 'fighterJetAttack',
+        helicopter: 'helicopterAttack',
+        truck: 'missileJavelin',
+        drone: 'droneAttack'
+      };
+      const preferredOwned = CAPTURE_ANIMATION_OPTIONS.find(
+        (option) => option?.id && ownedIds.has(option.id) && GLOBAL_CAPTURE_KIND_BY_ANIMATION_ID[option.id] === kind
+      );
+      if (preferredOwned?.id) return preferredOwned.id;
+      if (fallbackByKind[kind]) return fallbackByKind[kind];
+      return selectedCaptureAnimationId;
+    },
+    [chessInventory, selectedCaptureAnimationId]
+  );
+  const [captureAnimationByPieceGroup, setCaptureAnimationByPieceGroup] = useState(() => {
+    if (typeof window !== 'undefined') {
+      try {
+        const stored = JSON.parse(window.localStorage?.getItem(CAPTURE_GROUP_SWAP_STORAGE_KEY) || '{}');
+        if (stored && typeof stored === 'object') {
+          return {
+            kingQueen: typeof stored.kingQueen === 'string' ? stored.kingQueen : selectedCaptureAnimationId,
+            bishop: typeof stored.bishop === 'string' ? stored.bishop : selectedCaptureAnimationId,
+            knightRook: typeof stored.knightRook === 'string' ? stored.knightRook : selectedCaptureAnimationId,
+            pawn: typeof stored.pawn === 'string' ? stored.pawn : selectedCaptureAnimationId
+          };
+        }
+      } catch {}
+    }
+    return {
+      kingQueen: selectedCaptureAnimationId,
+      bishop: selectedCaptureAnimationId,
+      knightRook: selectedCaptureAnimationId,
+      pawn: selectedCaptureAnimationId
+    };
+  });
   useEffect(() => {
     setCaptureAnimationByPieceGroup((prev) => ({
-      kingQueen: prev.kingQueen || selectedCaptureAnimationId,
-      bishopRook: prev.bishopRook || selectedCaptureAnimationId,
-      knight: prev.knight || selectedCaptureAnimationId,
-      pawn: prev.pawn || selectedCaptureAnimationId
+      kingQueen: prev.kingQueen || resolveDefaultCaptureAnimationIdByKind('jet'),
+      bishop: prev.bishop || resolveDefaultCaptureAnimationIdByKind('helicopter'),
+      knightRook: prev.knightRook || resolveDefaultCaptureAnimationIdByKind('truck'),
+      pawn: prev.pawn || resolveDefaultCaptureAnimationIdByKind('drone')
     }));
-  }, [selectedCaptureAnimationId]);
+  }, [resolveDefaultCaptureAnimationIdByKind]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      window.localStorage?.setItem(
+        CAPTURE_GROUP_SWAP_STORAGE_KEY,
+        JSON.stringify(captureAnimationByPieceGroup)
+      );
+    } catch {}
+  }, [captureAnimationByPieceGroup]);
+
   const handleCaptureAnimationSwap = useCallback(
     (optionId) => {
       if (!optionId) return;
@@ -7716,13 +7767,10 @@ function Chess3D({
       if (targetGroup) {
         setCaptureAnimationByPieceGroup((prev) => ({ ...prev, [targetGroup]: optionId }));
       }
-      if (optionId !== selectedCaptureAnimationId) {
-        setChessBattleEquippedOption('captureAnimation', optionId, resolvedAccountId);
-      }
       setWeaponSwapOpen(false);
       setWeaponSwapTargetKind(null);
     },
-    [PIECE_GROUP_BY_PARKED_KIND, resolvedAccountId, selectedCaptureAnimationId, weaponSwapTargetKind]
+    [PIECE_GROUP_BY_PARKED_KIND, weaponSwapTargetKind]
   );
   const quickSwapWeaponList = useMemo(() => {
     const pool = quickSwapWeapons.length ? quickSwapWeapons : ownedCaptureAnimations;
@@ -11181,8 +11229,8 @@ function Chess3D({
     const resolvePieceGroupFromType = (pieceType) => {
       const t = `${pieceType || ''}`.toLowerCase();
       if (t === 'k' || t === 'q') return 'kingQueen';
-      if (t === 'b' || t === 'r') return 'bishopRook';
-      if (t === 'n') return 'knight';
+      if (t === 'b') return 'bishop';
+      if (t === 'n' || t === 'r') return 'knightRook';
       return 'pawn';
     };
 


### PR DESCRIPTION
### Motivation
- Enable players to assign and persist different capture animations per piece group and make quick-swap behavior more predictable and prioritized.
- Fix incorrect piece-group mappings and remove an unintended side-effect that wrote a global equipped option during local swaps.

### Description
- Remove `setChessBattleEquippedOption` usage and stop modifying the global equipped option when swapping capture animations. 
- Add `CAPTURE_GROUP_SWAP_STORAGE_KEY` and persist `captureAnimationByPieceGroup` to `localStorage`, restoring it on initialization. 
- Introduce `resolveDefaultCaptureAnimationIdByKind` to pick sensible defaults per capture kind and initialize `captureAnimationByPieceGroup` from stored values or defaults. 
- Improve quick-swap ordering by de-duplicating and prioritizing owned capture animations, and adjust parked-piece group mappings and `resolvePieceGroupFromType` to use `bishop`, `knightRook`, `kingQueen`, and `pawn` groups.

### Testing
- Ran unit tests with `yarn test` and all tests passed. 
- Ran linting with `yarn lint` and no issues were reported. 
- Built the app with `yarn build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f422a291d083298ebcaef288d01be3)