### PR TITLE
Murlan Royale: shrink/reposition seated humans, hide floating cards, and normalize GLTF materials

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -104,7 +104,7 @@ const resolveTableCloth = (index) => {
 const DEFAULT_FRAME_RATE_ID = 'fhd60';
 
 const MODEL_SCALE = 0.75;
-const CHARACTER_PROPORTION_SCALE = 2.0;
+const CHARACTER_PROPORTION_SCALE = 1.72;
 const ENABLE_3D_HUMAN_CHARACTERS = true;
 const ARENA_GROWTH = 1.45; // expanded arena footprint for wider walkways
 const CHAIR_SIZE_SCALE = 1;
@@ -803,6 +803,9 @@ function applyTextureSetToModel(model, textureSet, fallbackTexture, maxAnisotrop
     if (!material) return;
     material.roughness = Math.max(material.roughness ?? 0.4, 0.4);
     material.metalness = Math.min(material.metalness ?? 0.4, 0.4);
+    if (material.color?.setRGB) material.color.setRGB(1, 1, 1);
+    if (material.emissive?.setRGB) material.emissive.setRGB(0, 0, 0);
+    material.emissiveIntensity = 0;
 
     if (material.map) {
       normalizeTexture(material.map, true);
@@ -1878,6 +1881,8 @@ function createCharacterRig(instance, seatRoot, seatConfig, characterTheme, play
 
 function refreshRigHeldCards(rig, handCardsInput, playerColor, cardTheme, cardTextureSize = null) {
   if (!rig) return;
+  if (rig.heldCards) rig.heldCards.visible = false;
+  return;
   const safeCards = Array.isArray(handCardsInput) && handCardsInput.length ? handCardsInput.slice(0, 5) : [];
   const currentCount = rig.heldCards?.children?.length ?? 0;
   const colorChanged = rig.heldCards?.userData?.playerColor !== playerColor;
@@ -1972,7 +1977,7 @@ function attachSeatedCharacter({ template, seatConfig, characterTheme, store, pl
   const baseSeatOffsetZ = characterTheme.normalizedSeatOffsetZ ?? characterTheme.seatOffsetZ ?? -0.24;
   seatRoot.position.set(
     0,
-    baseSeatOffsetY - 0.22 - scaleDelta * 0.08,
+    baseSeatOffsetY - 0.29 - scaleDelta * 0.1,
     baseSeatOffsetZ - 0.03
   );
   seatRoot.rotation.set(characterTheme.seatPitch ?? 0, characterTheme.seatYaw ?? 0, 0);
@@ -2417,8 +2422,8 @@ const DEAL_SHUFFLE_LEAD_IN_MS = 220;
 const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 1.1;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
 const CHAIR_GROUND_DROP = 0;
-const CHAIR_SCREEN_LOWER_OFFSET = 0.14 * MODEL_SCALE;
-const HUMAN_CHAIR_EXTRA_INWARD_OFFSET = 0.06 * MODEL_SCALE; // Pull human seat slightly inward so body rests closer to the chair.
+const CHAIR_SCREEN_LOWER_OFFSET = 0.19 * MODEL_SCALE;
+const HUMAN_CHAIR_EXTRA_INWARD_OFFSET = -0.16 * MODEL_SCALE; // Negative pushes human seat outward, away from table center (portrait visual direction).
 const TABLE_HEIGHT_LIFT = 0.025 * MODEL_SCALE;
 const TABLE_HEIGHT = STOOL_HEIGHT + TABLE_HEIGHT_LIFT;
 const TABLE_SIDE_TRIM_SCALE = 1;


### PR DESCRIPTION
### Motivation
- Make seated human characters visually smaller, pushed outward from the table center, and lower on portrait screens to match requested framing and the provided photo.
- Remove the distracting floating card meshes that appear above the scene for seated characters.
- Improve GLTF material/texture handling so imported human models render with neutral base/emissive values and avoid tint/glow issues.

### Description
- Reduced the global seated character scale by changing `CHARACTER_PROPORTION_SCALE` from `2.0` to `1.72` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to make humans appear smaller on-screen.
- Pushed human chairs/characters outward and lower by setting `HUMAN_CHAIR_EXTRA_INWARD_OFFSET` to `-0.16 * MODEL_SCALE`, increasing `CHAIR_SCREEN_LOWER_OFFSET` to `0.19 * MODEL_SCALE`, and deepening the seat root Y placement (`baseSeatOffsetY - 0.29 - scaleDelta * 0.1`).
- Disabled character-held floating cards by early-returning from `refreshRigHeldCards` and setting `rig.heldCards.visible = false` so held-card meshes are hidden instead of rendered above the screen.
- Improved GLTF texture/material normalization by forcing neutral colors and clearing emissive on materials in `applyTextureSetToModel` (set `material.color` to white, `material.emissive` to black and `material.emissiveIntensity = 0`) to avoid pink/glow artifacts.

### Testing
- Ran lint for the updated file using `npm run -s lint -- webapp/src/pages/Games/MurlanRoyaleArena.jsx`, which completed with an ESLint environment warning about React auto-detection (no fatal errors reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f423ac364483299e5238169f4c1c95)