### PR TITLE
Persist per-piece-group capture animation prefs, prioritize quick-swap list, and adjust group mappings

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -54,8 +54,7 @@ import {
 import {
   chessBattleAccountId,
   getChessBattleInventory,
-  isChessOptionUnlocked,
-  setChessBattleEquippedOption
+  isChessOptionUnlocked
 } from '../../utils/chessBattleInventory.js';
 import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
 import { avatarToName } from '../../utils/avatarUtils.js';
@@ -1099,6 +1098,7 @@ function detectRefreshRateHint() {
 
 const GRAPHICS_STORAGE_KEY = 'chessBattleRoyalGraphics';
 const COMMENTARY_PRESET_STORAGE_KEY = 'chessBattleRoyalCommentaryPreset';
+const CAPTURE_SWAP_GROUPS_STORAGE_KEY = 'chessBattleRoyalCaptureAnimationByPieceGroup';
 const COMMENTARY_MUTE_STORAGE_KEY = 'chessBattleRoyalCommentaryMute';
 const COMMENTARY_QUEUE_LIMIT = 4;
 const COMMENTARY_MIN_INTERVAL_MS = 1200;
@@ -7680,34 +7680,86 @@ function Chess3D({
     []
   );
   const quickSwapWeapons = useMemo(() => {
-    const ownedIds = new Set((ownedCaptureAnimations || []).map((option) => option.id));
-    return QUICK_SWAP_WEAPON_IDS
-      .filter((id) => ownedIds.has(id))
+    const prioritized = [];
+    const seen = new Set();
+    const pushOption = (option) => {
+      if (!option?.id || seen.has(option.id)) return;
+      seen.add(option.id);
+      prioritized.push(option);
+    };
+    ownedCaptureAnimations.forEach(pushOption);
+    QUICK_SWAP_WEAPON_IDS
       .map((id) => CAPTURE_ANIMATION_OPTIONS.find((option) => option.id === id))
-      .filter(Boolean);
+      .forEach(pushOption);
+    return prioritized;
   }, [ownedCaptureAnimations, QUICK_SWAP_WEAPON_IDS]);
   const [weaponSwapOpen, setWeaponSwapOpen] = useState(false);
   const [weaponSwapTargetKind, setWeaponSwapTargetKind] = useState(null);
   const PIECE_GROUP_BY_PARKED_KIND = useMemo(() => ({
     jet: 'kingQueen',
-    helicopter: 'bishopRook',
-    drone: 'knight',
-    truck: 'pawn'
+    helicopter: 'bishop',
+    truck: 'knightRook',
+    drone: 'pawn'
   }), []);
-  const [captureAnimationByPieceGroup, setCaptureAnimationByPieceGroup] = useState(() => ({
-    kingQueen: selectedCaptureAnimationId,
-    bishopRook: selectedCaptureAnimationId,
-    knight: selectedCaptureAnimationId,
-    pawn: selectedCaptureAnimationId
-  }));
+  const resolveDefaultCaptureAnimationIdByKind = useCallback(
+    (kind) => {
+      const ownedIds = new Set((chessInventory?.captureAnimation || []).filter(Boolean));
+      const fallbackByKind = {
+        jet: 'fighterJetAttack',
+        helicopter: 'helicopterAttack',
+        truck: 'missileJavelin',
+        drone: 'droneAttack'
+      };
+      const preferredOwned = CAPTURE_ANIMATION_OPTIONS.find(
+        (option) => option?.id && ownedIds.has(option.id) && GLOBAL_CAPTURE_KIND_BY_ANIMATION_ID[option.id] === kind
+      );
+      if (preferredOwned?.id) return preferredOwned.id;
+      if (fallbackByKind[kind]) return fallbackByKind[kind];
+      return selectedCaptureAnimationId;
+    },
+    [chessInventory, selectedCaptureAnimationId]
+  );
+  const [captureAnimationByPieceGroup, setCaptureAnimationByPieceGroup] = useState(() => {
+    if (typeof window !== 'undefined') {
+      try {
+        const raw = window.localStorage?.getItem(CAPTURE_SWAP_GROUPS_STORAGE_KEY);
+        if (raw) {
+          const parsed = JSON.parse(raw);
+          if (parsed && typeof parsed === 'object') {
+            return {
+              kingQueen: parsed.kingQueen || selectedCaptureAnimationId,
+              bishop: parsed.bishop || selectedCaptureAnimationId,
+              knightRook: parsed.knightRook || selectedCaptureAnimationId,
+              pawn: parsed.pawn || selectedCaptureAnimationId
+            };
+          }
+        }
+      } catch {}
+    }
+    return {
+      kingQueen: selectedCaptureAnimationId,
+      bishop: selectedCaptureAnimationId,
+      knightRook: selectedCaptureAnimationId,
+      pawn: selectedCaptureAnimationId
+    };
+  });
   useEffect(() => {
     setCaptureAnimationByPieceGroup((prev) => ({
-      kingQueen: prev.kingQueen || selectedCaptureAnimationId,
-      bishopRook: prev.bishopRook || selectedCaptureAnimationId,
-      knight: prev.knight || selectedCaptureAnimationId,
-      pawn: prev.pawn || selectedCaptureAnimationId
+      kingQueen: prev.kingQueen || resolveDefaultCaptureAnimationIdByKind('jet'),
+      bishop: prev.bishop || resolveDefaultCaptureAnimationIdByKind('helicopter'),
+      knightRook: prev.knightRook || resolveDefaultCaptureAnimationIdByKind('truck'),
+      pawn: prev.pawn || resolveDefaultCaptureAnimationIdByKind('drone')
     }));
-  }, [selectedCaptureAnimationId]);
+  }, [resolveDefaultCaptureAnimationIdByKind]);
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      window.localStorage?.setItem(
+        CAPTURE_SWAP_GROUPS_STORAGE_KEY,
+        JSON.stringify(captureAnimationByPieceGroup)
+      );
+    } catch {}
+  }, [captureAnimationByPieceGroup]);
   const handleCaptureAnimationSwap = useCallback(
     (optionId) => {
       if (!optionId) return;
@@ -7716,13 +7768,10 @@ function Chess3D({
       if (targetGroup) {
         setCaptureAnimationByPieceGroup((prev) => ({ ...prev, [targetGroup]: optionId }));
       }
-      if (optionId !== selectedCaptureAnimationId) {
-        setChessBattleEquippedOption('captureAnimation', optionId, resolvedAccountId);
-      }
       setWeaponSwapOpen(false);
       setWeaponSwapTargetKind(null);
     },
-    [PIECE_GROUP_BY_PARKED_KIND, resolvedAccountId, selectedCaptureAnimationId, weaponSwapTargetKind]
+    [PIECE_GROUP_BY_PARKED_KIND, weaponSwapTargetKind]
   );
   const quickSwapWeaponList = useMemo(() => {
     const pool = quickSwapWeapons.length ? quickSwapWeapons : ownedCaptureAnimations;
@@ -11181,8 +11230,8 @@ function Chess3D({
     const resolvePieceGroupFromType = (pieceType) => {
       const t = `${pieceType || ''}`.toLowerCase();
       if (t === 'k' || t === 'q') return 'kingQueen';
-      if (t === 'b' || t === 'r') return 'bishopRook';
-      if (t === 'n') return 'knight';
+      if (t === 'b') return 'bishop';
+      if (t === 'n' || t === 'r') return 'knightRook';
       return 'pawn';
     };
 


### PR DESCRIPTION
### Motivation
- Allow players to choose and persist different capture animations per piece group and prefer owned animations when selecting defaults.
- Improve the quick-swap ordering so owned capture animations are prioritized and avoid duplicate entries.
- Simplify/group mapping logic and stop automatically writing the equipped capture animation to the account in this flow.

### Description
- Added `CAPTURE_SWAP_GROUPS_STORAGE_KEY` and persist `captureAnimationByPieceGroup` to `localStorage` so per-group preferences survive reloads.
- Reworked capture animation grouping and defaults by introducing `resolveDefaultCaptureAnimationIdByKind` which prefers owned animations, falls back to sensible defaults, and initializes state from localStorage when available.
- Renamed/restructured piece-group keys (`bishopRook` -> `bishop`, `knight` -> `knightRook`) and updated all resolvers to use the new mapping, including `resolvePieceGroupFromType` and `resolveCaptureKindForPiece`.
- Changed quick-swap weapon list construction to build a prioritized, de-duplicated list that places owned options first and then appends preferred weapon IDs from `QUICK_SWAP_WEAPON_IDS`.
- Removed the call that previously synced capture animation swaps to the account via `setChessBattleEquippedOption` and removed that import, making swaps local to the client state.

### Testing
- Ran the frontend unit test suite with `yarn test` and it completed successfully.
- Ran linting with `yarn lint` and there were no new lint errors.
- Built the app with `yarn build` to verify the bundle compiles and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f422a291d083298ebcaef288d01be3)