### PR TITLE
Adjust character proportions and seating offsets; disable held card rendering

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -104,7 +104,7 @@ const resolveTableCloth = (index) => {
 const DEFAULT_FRAME_RATE_ID = 'fhd60';
 
 const MODEL_SCALE = 0.75;
-const CHARACTER_PROPORTION_SCALE = 2.0;
+const CHARACTER_PROPORTION_SCALE = 1.72;
 const ENABLE_3D_HUMAN_CHARACTERS = true;
 const ARENA_GROWTH = 1.45; // expanded arena footprint for wider walkways
 const CHAIR_SIZE_SCALE = 1;
@@ -803,7 +803,6 @@ function applyTextureSetToModel(model, textureSet, fallbackTexture, maxAnisotrop
     if (!material) return;
     material.roughness = Math.max(material.roughness ?? 0.4, 0.4);
     material.metalness = Math.min(material.metalness ?? 0.4, 0.4);
-
     if (material.map) {
       normalizeTexture(material.map, true);
     } else if (textureSet?.diffuse) {
@@ -1878,6 +1877,8 @@ function createCharacterRig(instance, seatRoot, seatConfig, characterTheme, play
 
 function refreshRigHeldCards(rig, handCardsInput, playerColor, cardTheme, cardTextureSize = null) {
   if (!rig) return;
+  if (rig.heldCards) rig.heldCards.visible = false;
+  return;
   const safeCards = Array.isArray(handCardsInput) && handCardsInput.length ? handCardsInput.slice(0, 5) : [];
   const currentCount = rig.heldCards?.children?.length ?? 0;
   const colorChanged = rig.heldCards?.userData?.playerColor !== playerColor;
@@ -2418,7 +2419,7 @@ const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 1.1;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
 const CHAIR_GROUND_DROP = 0;
 const CHAIR_SCREEN_LOWER_OFFSET = 0.14 * MODEL_SCALE;
-const HUMAN_CHAIR_EXTRA_INWARD_OFFSET = 0.06 * MODEL_SCALE; // Pull human seat slightly inward so body rests closer to the chair.
+const HUMAN_CHAIR_EXTRA_INWARD_OFFSET = -0.26 * MODEL_SCALE; // Negative pushes human seat outward, away from table center (portrait visual direction).
 const TABLE_HEIGHT_LIFT = 0.025 * MODEL_SCALE;
 const TABLE_HEIGHT = STOOL_HEIGHT + TABLE_HEIGHT_LIFT;
 const TABLE_SIDE_TRIM_SCALE = 1;


### PR DESCRIPTION
### Motivation
- Tweak avatar appearance and seating to better match the intended portrait/visual composition around the table.
- Temporarily disable character-held card rendering to avoid visual artifacts while card handling is being reworked.

### Description
- Update `CHARACTER_PROPORTION_SCALE` from `2.0` to `1.72` to change overall character proportions.
- Change `HUMAN_CHAIR_EXTRA_INWARD_OFFSET` from `0.06 * MODEL_SCALE` to `-0.26 * MODEL_SCALE` to push human seats outward for the portrait visual direction.
- Short-circuit `refreshRigHeldCards` to hide any existing `rig.heldCards` by setting `rig.heldCards.visible = false` and returning early, preventing recreation of held-card meshes.
- Minor whitespace/formatting cleanup in `applyTextureSetToModel` with no behavior change.

### Testing
- Ran the project's automated unit test suite with `yarn test`, and tests completed successfully.
- Ran the linter with `yarn lint`, and no new lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f423ac364483299e5238169f4c1c95)