### PR TITLE
Adjust character proportions and human seat offset; hide held/AI cards by default

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -104,7 +104,7 @@ const resolveTableCloth = (index) => {
 const DEFAULT_FRAME_RATE_ID = 'fhd60';
 
 const MODEL_SCALE = 0.75;
-const CHARACTER_PROPORTION_SCALE = 2.0;
+const CHARACTER_PROPORTION_SCALE = 1.72;
 const ENABLE_3D_HUMAN_CHARACTERS = true;
 const ARENA_GROWTH = 1.45; // expanded arena footprint for wider walkways
 const CHAIR_SIZE_SCALE = 1;
@@ -1878,6 +1878,8 @@ function createCharacterRig(instance, seatRoot, seatConfig, characterTheme, play
 
 function refreshRigHeldCards(rig, handCardsInput, playerColor, cardTheme, cardTextureSize = null) {
   if (!rig) return;
+  if (rig.heldCards) rig.heldCards.visible = false;
+  return;
   const safeCards = Array.isArray(handCardsInput) && handCardsInput.length ? handCardsInput.slice(0, 5) : [];
   const currentCount = rig.heldCards?.children?.length ?? 0;
   const colorChanged = rig.heldCards?.userData?.playerColor !== playerColor;
@@ -2418,7 +2420,7 @@ const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 1.1;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
 const CHAIR_GROUND_DROP = 0;
 const CHAIR_SCREEN_LOWER_OFFSET = 0.14 * MODEL_SCALE;
-const HUMAN_CHAIR_EXTRA_INWARD_OFFSET = 0.06 * MODEL_SCALE; // Pull human seat slightly inward so body rests closer to the chair.
+const HUMAN_CHAIR_EXTRA_OUTWARD_OFFSET = 0.34 * MODEL_SCALE; // Push human seat farther from table center (portrait visual direction).
 const TABLE_HEIGHT_LIFT = 0.025 * MODEL_SCALE;
 const TABLE_HEIGHT = STOOL_HEIGHT + TABLE_HEIGHT_LIFT;
 const TABLE_SIDE_TRIM_SCALE = 1;
@@ -3840,6 +3842,14 @@ export default function MurlanRoyaleArena({ search }) {
         cardTextureQualityRef.current
       );
       const cards = player.hand;
+      if (!player.isHuman) {
+        cards.forEach((card) => {
+          const entry = cardMap.get(card.id);
+          if (!entry?.mesh) return;
+          entry.mesh.visible = false;
+        });
+        return;
+      }
       const baseHeight = TABLE_HEIGHT + CARD_H / 2 + AI_CARD_LIFT + (player.isHuman ? HUMAN_HAND_EXTRA_LIFT : 0);
       const forward = seat.forward;
       const right = seat.right;
@@ -5139,7 +5149,7 @@ export default function MurlanRoyaleArena({ search }) {
         const isHumanSeat = Boolean(player?.isHuman);
         const seatRadius =
           (isHumanSeat
-            ? AI_CHAIR_RADIUS - HUMAN_CHAIR_EXTRA_INWARD_OFFSET
+            ? AI_CHAIR_RADIUS + HUMAN_CHAIR_EXTRA_OUTWARD_OFFSET
             : AI_CHAIR_RADIUS) * CHAIR_SEAT_INWARD_FACTOR;
         const x = Math.cos(angle) * seatRadius * TABLE_HORIZONTAL_SHRINK;
         const z = Math.sin(angle) * seatRadius;


### PR DESCRIPTION
### Motivation

- Tweak character scaling and seating offsets to improve portrait-oriented visuals and overall table composition.
- Temporarily hide character-held cards and AI player card meshes to simplify rendering and avoid duplicate/incorrect card meshes.

### Description

- Change `CHARACTER_PROPORTION_SCALE` from `2.0` to `1.72` to reduce character proportions.
- Replace `HUMAN_CHAIR_EXTRA_INWARD_OFFSET` with `HUMAN_CHAIR_EXTRA_OUTWARD_OFFSET` and increase its value to `0.34 * MODEL_SCALE`, and update seat radius computation to add this outward offset for human seats.
- Add an early-return in `refreshRigHeldCards` that sets `rig.heldCards.visible = false` when present and returns, preventing recreation of held-card meshes.
- In the main render/update loop, hide non-human player card meshes by setting `entry.mesh.visible = false` and skipping their per-card positioning.

### Testing

- Ran the existing test suite with `yarn test` and static checks with `yarn lint`, and both completed successfully.
- No new unit tests were added for these visual/rendering adjustments.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f423ac364483299e5238169f4c1c95)