### PR TITLE
Murlan Royale: increase chair size, push human seats outward, and preserve GLTF texture mapping

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -107,7 +107,7 @@ const MODEL_SCALE = 0.75;
 const CHARACTER_PROPORTION_SCALE = 1.72;
 const ENABLE_3D_HUMAN_CHARACTERS = true;
 const ARENA_GROWTH = 1.45; // expanded arena footprint for wider walkways
-const CHAIR_SIZE_SCALE = 1;
+const CHAIR_SIZE_SCALE = 1.08;
 const ARENA_PROP_SCALE = 1;
 const TOP_SEAT_AVATAR_UP_LIFT = 4.9;
 const NON_HUMAN_SEAT_AVATAR_UP_LIFT = 1.0;
@@ -1658,7 +1658,7 @@ async function loadCharacterModel(theme, renderer = null) {
     if (!gltf) throw lastError || new Error(`Character load failed for ${theme.id || 'unknown'}`);
     const root = gltf.scene || gltf.scenes?.[0];
     if (!root) throw new Error(`Character scene missing for ${theme.id || 'unknown'}`);
-    prepareLoadedModel(root, { preserveGltfTextureMapping: true });
+    prepareLoadedModel(root, { preserveGltfTextureMapping: true, maxAnisotropy: 8 });
     return root;
   })();
   CHARACTER_MODEL_CACHE.set(cacheKey, promise);
@@ -2186,7 +2186,7 @@ async function loadPolyhavenModel(assetId, renderer = null) {
     if (!root) {
       throw new Error(`Missing scene for ${assetId}`);
     }
-    prepareLoadedModel(root, { preserveGltfTextureMapping: true });
+    prepareLoadedModel(root, { preserveGltfTextureMapping: true, maxAnisotropy: 8 });
     return root;
   })();
 
@@ -2420,7 +2420,7 @@ const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 1.1;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
 const CHAIR_GROUND_DROP = 0;
 const CHAIR_SCREEN_LOWER_OFFSET = 0.14 * MODEL_SCALE;
-const HUMAN_CHAIR_EXTRA_OUTWARD_OFFSET = 0.34 * MODEL_SCALE; // Push human seat farther from table center (portrait visual direction).
+const HUMAN_CHAIR_EXTRA_OUTWARD_OFFSET = 0.46 * MODEL_SCALE; // Push human seat farther from table center (portrait visual direction).
 const TABLE_HEIGHT_LIFT = 0.025 * MODEL_SCALE;
 const TABLE_HEIGHT = STOOL_HEIGHT + TABLE_HEIGHT_LIFT;
 const TABLE_SIDE_TRIM_SCALE = 1;


### PR DESCRIPTION
### Motivation

- Improve portrait view spacing by moving human characters visually farther from the table so the scene reads clearer on small screens. 
- Make chairs slightly larger so they read better around the table and match the requested visual scale. 
- Ensure imported GLTF character models keep their original UV/texture mapping behavior when prepared so textures appear as authored.

### Description

- Updated `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to set `CHAIR_SIZE_SCALE` to `1.08` so chairs render slightly bigger. 
- Increased `HUMAN_CHAIR_EXTRA_OUTWARD_OFFSET` from `0.34 * MODEL_SCALE` to `0.46 * MODEL_SCALE` to push human seats farther away from the table center in portrait orientation. 
- Modified character and PolyHaven model preparation calls to pass `prepareLoadedModel(..., { preserveGltfTextureMapping: true, maxAnisotropy: 8 })` so GLTF texture mapping is preserved and anisotropy is applied during texture normalization. 
- Changes are visual/tuning-only and scoped to the Murlan Royale arena rendering logic and model loading paths.

### Testing

- Ran `git diff --check` to validate whitespace/patch issues and it completed successfully. 
- Ran `git status --short` to confirm working-tree state and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f45e3c5fd883299645bfd8a6d69701)