### PR TITLE
Adjust Murlan Royal seating layout and preserve GLTF UV mapping

### DIFF
--- a/Assets/Scripts/Gameplay/Environment/MurlanRoyalTableSeatingLayout.cs
+++ b/Assets/Scripts/Gameplay/Environment/MurlanRoyalTableSeatingLayout.cs
@@ -1,0 +1,83 @@
+using UnityEngine;
+
+namespace Aiming.Gameplay.Environment
+{
+    /// <summary>
+    /// Pushes human characters farther from the table and slightly enlarges chairs.
+    /// Useful for portrait-camera readability tuning in Murlan Royal scenes.
+    /// </summary>
+    public class MurlanRoyalTableSeatingLayout : MonoBehaviour
+    {
+        [Header("References")]
+        [SerializeField] private Transform tableCenter;
+        [SerializeField] private Transform[] humanCharacters;
+        [SerializeField] private Transform[] chairs;
+
+        [Header("Layout Tuning")]
+        [SerializeField, Min(0f)] private float humanOutwardOffset = 0.35f;
+        [SerializeField, Min(0.1f)] private float chairScaleMultiplier = 1.08f;
+        [SerializeField] private bool runOnAwake = true;
+
+        void Awake()
+        {
+            if (runOnAwake)
+            {
+                ApplyLayout();
+            }
+        }
+
+        [ContextMenu("Apply Murlan Royal Seating Layout")]
+        public void ApplyLayout()
+        {
+            Vector3 center = tableCenter != null ? tableCenter.position : transform.position;
+            PushHumansOutward(center);
+            ScaleChairs();
+        }
+
+        private void PushHumansOutward(Vector3 center)
+        {
+            if (humanCharacters == null)
+            {
+                return;
+            }
+
+            for (int i = 0; i < humanCharacters.Length; i++)
+            {
+                Transform human = humanCharacters[i];
+                if (human == null)
+                {
+                    continue;
+                }
+
+                Vector3 horizontalDirection = human.position - center;
+                horizontalDirection.y = 0f;
+
+                if (horizontalDirection.sqrMagnitude <= 0.0001f)
+                {
+                    continue;
+                }
+
+                human.position += horizontalDirection.normalized * humanOutwardOffset;
+            }
+        }
+
+        private void ScaleChairs()
+        {
+            if (chairs == null)
+            {
+                return;
+            }
+
+            for (int i = 0; i < chairs.Length; i++)
+            {
+                Transform chair = chairs[i];
+                if (chair == null)
+                {
+                    continue;
+                }
+
+                chair.localScale *= chairScaleMultiplier;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Rendering/GltfMaterialCompatibilityAdapter.cs
+++ b/Assets/Scripts/Gameplay/Rendering/GltfMaterialCompatibilityAdapter.cs
@@ -109,12 +109,13 @@ namespace Aiming.Gameplay.Rendering
 
         private static void CopyPbrMaps(Material material)
         {
-            Texture baseTexture = FirstTexture(material, BaseMapId, MainTexId);
+            int sourceUvPropertyId;
+            Texture baseTexture = FirstTexture(material, out sourceUvPropertyId, BaseMapId, MainTexId);
             if (baseTexture != null)
             {
                 TrySetTexture(material, BaseMapId, baseTexture);
                 TrySetTexture(material, MainTexId, baseTexture);
-                SyncTextureTransform(material);
+                SyncTextureTransform(material, sourceUvPropertyId);
             }
 
             if (material.HasProperty(BaseColorId) && material.HasProperty(ColorId))
@@ -157,6 +158,13 @@ namespace Aiming.Gameplay.Rendering
 
         private static Texture FirstTexture(Material material, params int[] texturePropertyIds)
         {
+            int ignored;
+            return FirstTexture(material, out ignored, texturePropertyIds);
+        }
+
+        private static Texture FirstTexture(Material material, out int sourcePropertyId, params int[] texturePropertyIds)
+        {
+            sourcePropertyId = -1;
             for (int i = 0; i < texturePropertyIds.Length; i++)
             {
                 int propertyId = texturePropertyIds[i];
@@ -168,6 +176,7 @@ namespace Aiming.Gameplay.Rendering
                 Texture tex = material.GetTexture(propertyId);
                 if (tex != null)
                 {
+                    sourcePropertyId = propertyId;
                     return tex;
                 }
             }
@@ -183,7 +192,7 @@ namespace Aiming.Gameplay.Rendering
             }
         }
 
-        private static void SyncTextureTransform(Material material)
+        private static void SyncTextureTransform(Material material, int sourceUvPropertyId)
         {
             bool hasBase = material.HasProperty(BaseMapId);
             bool hasMain = material.HasProperty(MainTexId);
@@ -192,12 +201,14 @@ namespace Aiming.Gameplay.Rendering
                 return;
             }
 
-            Vector2 scale = material.GetTextureScale(BaseMapId);
-            Vector2 offset = material.GetTextureOffset(BaseMapId);
-            if (scale == Vector2.zero)
+            int sourceProperty = sourceUvPropertyId == MainTexId ? MainTexId : BaseMapId;
+            if (!material.HasProperty(sourceProperty))
             {
-                scale = material.GetTextureScale(MainTexId);
+                sourceProperty = BaseMapId;
             }
+
+            Vector2 scale = material.GetTextureScale(sourceProperty);
+            Vector2 offset = material.GetTextureOffset(sourceProperty);
 
             material.SetTextureScale(MainTexId, scale);
             material.SetTextureOffset(MainTexId, offset);


### PR DESCRIPTION
### Motivation
- Improve portrait-screen readability for the Murlan Royal scene by moving human characters visually farther from the table and slightly increasing chair size. 
- Ensure imported GLTF/GLB character materials retain their original UV transforms when adapted to the active render pipeline to avoid texture mapping shifts.

### Description
- Added a new Unity component `MurlanRoyalTableSeatingLayout` at `Assets/Scripts/Gameplay/Environment/MurlanRoyalTableSeatingLayout.cs` with inspector-configurable fields `humanOutwardOffset`, `chairScaleMultiplier`, and `runOnAwake`, and a context menu `Apply Murlan Royal Seating Layout` to push characters outward and scale chairs. 
- Modified `Assets/Scripts/Gameplay/Rendering/GltfMaterialCompatibilityAdapter.cs` so `FirstTexture` returns the source texture property id and `SyncTextureTransform` accepts that id, preserving the original source (`_BaseMap` vs `_MainTex`) when copying UV scale/offset. 
- Kept changes parameterized for per-scene tuning without code edits and ensured the adapter still falls back to supported shaders when needed.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f45e3c5fd883299645bfd8a6d69701)