### PR TITLE
Align bottom chair distance, tweak portrait forward camera, and use base turn view for local player

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -3153,8 +3153,8 @@ const AI_CHAIR_RADIUS =
   CHAIR_INWARD_PULL;
 // Pull all chairs (with seated humans) farther away from the table edge for clearer portrait spacing.
 const CHAIR_GLOBAL_PUSHBACK = 0.68 * MODEL_SCALE;
-// Keep the bottom/local-player seat distinctly farther out than the rest.
-const SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK = 0.82 * MODEL_SCALE;
+// Keep bottom/local-player seat aligned with the same table distance used by the other chairs.
+const SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK = 0;
 
 const DEFAULT_PLAYER_COUNT = 4;
 const clampPlayerCount = (value) =>
@@ -3324,7 +3324,7 @@ const LUDO_CAMERA_PHI_MAX = 1.22;
 const PLAYER_VIEW_SEAT_THETA = Math.PI / 2;
 const PLAYER_VIEW_CAMERA_BACK_OFFSET_PORTRAIT = 1.58;
 const PLAYER_VIEW_CAMERA_BACK_OFFSET_LANDSCAPE = 1.26;
-const PLAYER_VIEW_CAMERA_FORWARD_OFFSET_PORTRAIT = 1.42;
+const PLAYER_VIEW_CAMERA_FORWARD_OFFSET_PORTRAIT = 1.5;
 const PLAYER_VIEW_CAMERA_FORWARD_OFFSET_LANDSCAPE = 0.86;
 const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_PORTRAIT = 0.8;
 const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_LANDSCAPE = 0.84;
@@ -11247,6 +11247,15 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     const boardLookTarget = arena.boardLookTarget;
     const seatWorld = new THREE.Vector3();
     anchor.getWorldPosition(seatWorld);
+    if (seatIndex === 0) {
+      const baseView = cameraTurnStateRef.current.baseTurnView;
+      if (!baseView?.position?.isVector3 || !baseView?.target?.isVector3) return null;
+      return {
+        position: baseView.position.clone(),
+        target: baseView.target.clone()
+      };
+    }
+
     const sideBlend =
       seatIndex === 1 || seatIndex === 3 ? CAMERA_SIDE_AVATAR_BLEND : CAMERA_BROADCAST_TARGET_BLEND;
     const target = boardLookTarget
@@ -11279,19 +11288,8 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       : desiredOrbitDirection;
     if (!orbitDirection.lengthSq()) return null;
 
-    const position = camera.position.clone();
-    if (seatIndex === 0) {
-      const toCamera = position.clone().sub(boardLookTarget);
-      const horizontal = toCamera.clone().setY(0);
-      if (horizontal.lengthSq() > 1e-6) {
-        horizontal.normalize();
-        position.addScaledVector(horizontal, USER_TURN_CAMERA_PULLBACK);
-      }
-      position.y += USER_TURN_CAMERA_LIFT;
-    }
-
     return {
-      position,
+      position: camera.position.clone(),
       target
     };
   }, []);


### PR DESCRIPTION
### Motivation

- Normalize chair spacing so the bottom/local player seat uses the same table distance as other seats to improve consistent portrait spacing.
- Slightly increase the portrait forward camera offset to improve framing for portrait orientations.
- Use the precomputed base turn view for the local player's turn camera to ensure stable and predictable camera framing during the user's turn.

### Description

- Set `SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK` to `0` to remove the extra outward offset for the bottom/local-player chair.
- Increase `PLAYER_VIEW_CAMERA_FORWARD_OFFSET_PORTRAIT` from `1.42` to `1.5` to adjust portrait camera framing.
- Update `resolveTurnCameraState` so that when `seatIndex === 0` it returns a cloned `baseTurnView` (`position` and `target`) from `cameraTurnStateRef.current` instead of applying ad-hoc position adjustments.

### Testing

- Ran the unit test suite with `yarn test` and it completed successfully.
- Ran the linter with `yarn lint` and there were no new linting errors.
- Built the webapp with `yarn build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f45eea32fc8329a5f1865b91eff4ad)