### PR TITLE
Murlan Royale: push humans outward, enlarge chairs, and preserve GLTF texture mapping

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -838,20 +838,23 @@ function applyTextureSetToModel(model, textureSet, fallbackTexture, maxAnisotrop
   });
 }
 
-function normalizeMaterialTextures(material, maxAnisotropy = 1) {
+function preserveOriginalGltfMaterialTextures(material, maxAnisotropy = 1) {
   if (!material) return;
   if (material.map) {
     applySRGBColorSpace(material.map);
-    normalizePbrTexture(material.map, maxAnisotropy, { preserveWrapping: true });
+    material.map.anisotropy = Math.max(material.map.anisotropy ?? 1, maxAnisotropy);
+    material.map.needsUpdate = true;
   }
   if (material.emissiveMap) {
     applySRGBColorSpace(material.emissiveMap);
-    normalizePbrTexture(material.emissiveMap, maxAnisotropy, { preserveWrapping: true });
+    material.emissiveMap.anisotropy = Math.max(material.emissiveMap.anisotropy ?? 1, maxAnisotropy);
+    material.emissiveMap.needsUpdate = true;
   }
-  normalizePbrTexture(material.normalMap, maxAnisotropy, { preserveWrapping: true });
-  normalizePbrTexture(material.roughnessMap, maxAnisotropy, { preserveWrapping: true });
-  normalizePbrTexture(material.metalnessMap, maxAnisotropy, { preserveWrapping: true });
-  normalizePbrTexture(material.aoMap, maxAnisotropy, { preserveWrapping: true });
+  [material.normalMap, material.roughnessMap, material.metalnessMap, material.aoMap].forEach((texture) => {
+    if (!texture) return;
+    texture.anisotropy = Math.max(texture.anisotropy ?? 1, maxAnisotropy);
+    texture.needsUpdate = true;
+  });
 }
 
 function prepareLoadedModel(model, options = {}) {
@@ -864,7 +867,7 @@ function prepareLoadedModel(model, options = {}) {
       mats.forEach((mat) => {
         if (!mat) return;
         if (preserveGltfTextureMapping) {
-          normalizeMaterialTextures(mat, maxAnisotropy);
+          preserveOriginalGltfMaterialTextures(mat, maxAnisotropy);
         } else {
           if (mat.map) applySRGBColorSpace(mat.map);
           if (mat.emissiveMap) applySRGBColorSpace(mat.emissiveMap);
@@ -2350,7 +2353,7 @@ const CHAIR_RADIUS = TABLE_RADIUS + SEAT_DEPTH * 0.5 + CHAIR_GAP;
 const AI_CHAIR_GAP = CHAIR_GAP;
 const AI_CHAIR_RADIUS = CHAIR_RADIUS;
 const CHAIR_SEAT_INWARD_FACTOR = 1;
-const CHAIR_VISUAL_SCALE = 1.3;
+const CHAIR_VISUAL_SCALE = 1.35;
 const CAMERA_SEATED_LATERAL_OFFSETS = Object.freeze({ portrait: 0, landscape: 0 });
 const CAMERA_SEATED_RETREAT_OFFSETS = Object.freeze({
   portrait: 0.92,
@@ -2420,7 +2423,7 @@ const CHAIR_BASE_HEIGHT = BASE_TABLE_HEIGHT - SEAT_THICKNESS * 1.1;
 const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
 const CHAIR_GROUND_DROP = 0;
 const CHAIR_SCREEN_LOWER_OFFSET = 0.14 * MODEL_SCALE;
-const HUMAN_CHAIR_EXTRA_OUTWARD_OFFSET = 0.46 * MODEL_SCALE; // Push human seat farther from table center (portrait visual direction).
+const HUMAN_CHAIR_EXTRA_OUTWARD_OFFSET = 0.62 * MODEL_SCALE; // Push human seat farther from table center (portrait visual direction).
 const TABLE_HEIGHT_LIFT = 0.025 * MODEL_SCALE;
 const TABLE_HEIGHT = STOOL_HEIGHT + TABLE_HEIGHT_LIFT;
 const TABLE_SIDE_TRIM_SCALE = 1;


### PR DESCRIPTION
### Motivation
- Improve portrait-screen readability by moving human characters visually farther from the table and slightly enlarging chairs for better balance.
- Preserve original GLTF texture/UV mapping for character models to avoid unintended remapping while still ensuring correct color space and anisotropy.

### Description
- Added `preserveOriginalGltfMaterialTextures(material, maxAnisotropy)` to apply SRGB and anisotropy while keeping the GLTF's original texture mapping, and wired it into `prepareLoadedModel` when `preserveGltfTextureMapping` is true.
- Updated model preparation to call the new preservation function instead of remapping PBR textures when `preserveGltfTextureMapping` is enabled.
- Increased `CHAIR_VISUAL_SCALE` from `1.3` to `1.35` to make chairs slightly larger.
- Increased `HUMAN_CHAIR_EXTRA_OUTWARD_OFFSET` from `0.46 * MODEL_SCALE` to `0.62 * MODEL_SCALE` to move human seats farther from the table.

### Testing
- Ran `npm -s test -- test/murlan.test.js` and the suite passed (`12` tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4620c4d78832988d06b875d0216b5)