### PR TITLE
Align local player chair distance and normalize turn camera for bottom seat; tweak portrait camera forward offset

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -3153,8 +3153,8 @@ const AI_CHAIR_RADIUS =
   CHAIR_INWARD_PULL;
 // Pull all chairs (with seated humans) farther away from the table edge for clearer portrait spacing.
 const CHAIR_GLOBAL_PUSHBACK = 0.68 * MODEL_SCALE;
-// Keep the bottom/local-player seat distinctly farther out than the rest.
-const SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK = 0.82 * MODEL_SCALE;
+// Keep bottom/local-player seat aligned with the same table distance used by the other chairs.
+const SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK = 0;
 
 const DEFAULT_PLAYER_COUNT = 4;
 const clampPlayerCount = (value) =>
@@ -3324,7 +3324,7 @@ const LUDO_CAMERA_PHI_MAX = 1.22;
 const PLAYER_VIEW_SEAT_THETA = Math.PI / 2;
 const PLAYER_VIEW_CAMERA_BACK_OFFSET_PORTRAIT = 1.58;
 const PLAYER_VIEW_CAMERA_BACK_OFFSET_LANDSCAPE = 1.26;
-const PLAYER_VIEW_CAMERA_FORWARD_OFFSET_PORTRAIT = 1.42;
+const PLAYER_VIEW_CAMERA_FORWARD_OFFSET_PORTRAIT = 1.46;
 const PLAYER_VIEW_CAMERA_FORWARD_OFFSET_LANDSCAPE = 0.86;
 const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_PORTRAIT = 0.8;
 const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_LANDSCAPE = 0.84;
@@ -11257,6 +11257,15 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     if (direction.lengthSq() < 1e-6) return null;
     direction.normalize();
 
+    if (seatIndex === 0) {
+      const baseView = cameraTurnStateRef.current.baseTurnView;
+      if (!baseView?.position?.isVector3 || !baseView?.target?.isVector3) return null;
+      return {
+        position: baseView.position.clone(),
+        target: baseView.target.clone()
+      };
+    }
+
     const isTopOrBottomSeat = Math.abs(direction.z) >= Math.abs(direction.x);
     if (isTopOrBottomSeat) {
       const baseView = cameraTurnStateRef.current.baseTurnView;
@@ -11280,15 +11289,6 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     if (!orbitDirection.lengthSq()) return null;
 
     const position = camera.position.clone();
-    if (seatIndex === 0) {
-      const toCamera = position.clone().sub(boardLookTarget);
-      const horizontal = toCamera.clone().setY(0);
-      if (horizontal.lengthSq() > 1e-6) {
-        horizontal.normalize();
-        position.addScaledVector(horizontal, USER_TURN_CAMERA_PULLBACK);
-      }
-      position.y += USER_TURN_CAMERA_LIFT;
-    }
 
     return {
       position,


### PR DESCRIPTION
### Motivation
- Align the bottom/local-player chair distance with the other chairs to produce consistent portrait spacing around the table.
- Make the turn-camera behavior for the bottom (local) seat consistent with the configured base turn view to avoid special-case offsets and unexpected camera motion.
- Slightly adjust the portrait camera forward offset to improve framing for player view.

### Description
- Set `SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK` to `0` instead of `0.82 * MODEL_SCALE` so the bottom seat matches other chairs.
- Bump `PLAYER_VIEW_CAMERA_FORWARD_OFFSET_PORTRAIT` from `1.42` to `1.46` to tweak portrait framing.
- Update `resolveTurnCameraState` to return the cloned `baseTurnView` `position` and `target` for `seatIndex === 0`, removing the previous manual pullback/lift adjustment for the local player.

### Testing
- Ran the project's automated test suite via `yarn test` and code linting via `yarn lint`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f45eea32fc8329a5f1865b91eff4ad)