### PR TITLE
Adjust Murlan Royale player/chair spacing and preserve glTF texture mapping

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -107,8 +107,9 @@ const MODEL_SCALE = 0.75;
 const CHARACTER_PROPORTION_SCALE = 1.72;
 const ENABLE_3D_HUMAN_CHARACTERS = true;
 const ARENA_GROWTH = 1.45; // expanded arena footprint for wider walkways
-const CHAIR_SIZE_SCALE = 1.08;
+const CHAIR_SIZE_SCALE = 1.12;
 const ARENA_PROP_SCALE = 1;
+const HUMAN_CHARACTER_EXTRA_OUTWARD_OFFSET = 0.1; // push seated humans slightly farther from the table
 const TOP_SEAT_AVATAR_UP_LIFT = 4.9;
 const NON_HUMAN_SEAT_AVATAR_UP_LIFT = 1.0;
 const HUMAN_AVATAR_BOTTOM_OFFSET = 'calc(2.85rem + env(safe-area-inset-bottom, 0px))';
@@ -1963,6 +1964,8 @@ function attachSeatedCharacter({ template, seatConfig, characterTheme, store, pl
     if (!obj?.isMesh) return;
     obj.castShadow = true;
     obj.receiveShadow = true;
+    const mats = Array.isArray(obj.material) ? obj.material : [obj.material];
+    mats.forEach((mat) => normalizeMaterialTextures(mat, 8)); // keep original glTF UV mapping while refreshing sampling
   });
   normalizeCharacterPivot(instance);
 
@@ -1975,7 +1978,7 @@ function attachSeatedCharacter({ template, seatConfig, characterTheme, store, pl
   seatRoot.position.set(
     0,
     baseSeatOffsetY - 0.22 - scaleDelta * 0.08,
-    baseSeatOffsetZ - 0.03
+    baseSeatOffsetZ - 0.03 - HUMAN_CHARACTER_EXTRA_OUTWARD_OFFSET
   );
   seatRoot.rotation.set(characterTheme.seatPitch ?? 0, characterTheme.seatYaw ?? 0, 0);
 


### PR DESCRIPTION
### Motivation
- Make seated human characters appear slightly farther from the table and make chairs a bit larger to improve visual spacing and readability in the Murlan Royale arena. 
- Ensure character glTF textures keep their original UV mapping/behavior when cloned and re-sampled at runtime.

### Description
- Increased chair visual scale by updating `CHAIR_SIZE_SCALE` from `1.08` to `1.12` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` so chairs render larger around the table.
- Added `HUMAN_CHARACTER_EXTRA_OUTWARD_OFFSET` and applied it to seated character placement by subtracting it from the character `seatRoot` Z position so human characters are pushed slightly farther away from the table.
- When attaching a cloned character instance, explicitly run `normalizeMaterialTextures(mat, 8)` for each material on the cloned meshes to preserve the original glTF texture/UV mapping while refreshing sampling settings.
- Changes are limited to `webapp/src/pages/Games/MurlanRoyaleArena.jsx` and the related runtime behavior when loading/attaching chair and character models.

### Testing
- Ran a production build with `npm --prefix webapp run -s build`, which completed successfully (Vite build finished and bundles were produced); build warnings from bundling were informational and non-blocking.
- No automated unit tests were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f46ba7d9148329bfd3829394890748)