### PR TITLE
Murlan Royale: increase chair size, push human characters outward, and preserve GLTF textures

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -107,9 +107,9 @@ const MODEL_SCALE = 0.75;
 const CHARACTER_PROPORTION_SCALE = 1.72;
 const ENABLE_3D_HUMAN_CHARACTERS = true;
 const ARENA_GROWTH = 1.45; // expanded arena footprint for wider walkways
-const CHAIR_SIZE_SCALE = 1.12;
+const CHAIR_SIZE_SCALE = 1.18;
 const ARENA_PROP_SCALE = 1;
-const HUMAN_CHARACTER_EXTRA_OUTWARD_OFFSET = 0.1; // push seated humans slightly farther from the table
+const HUMAN_CHARACTER_EXTRA_OUTWARD_OFFSET = 0.2; // push seated humans farther from the table for clearer portrait framing
 const TOP_SEAT_AVATAR_UP_LIFT = 4.9;
 const NON_HUMAN_SEAT_AVATAR_UP_LIFT = 1.0;
 const HUMAN_AVATAR_BOTTOM_OFFSET = 'calc(2.85rem + env(safe-area-inset-bottom, 0px))';
@@ -1965,7 +1965,12 @@ function attachSeatedCharacter({ template, seatConfig, characterTheme, store, pl
     obj.castShadow = true;
     obj.receiveShadow = true;
     const mats = Array.isArray(obj.material) ? obj.material : [obj.material];
-    mats.forEach((mat) => normalizeMaterialTextures(mat, 8)); // keep original glTF UV mapping while refreshing sampling
+    // Preserve the character's original glTF texture mapping exactly (no UV/wrap/flip remap).
+    mats.forEach((mat) => {
+      if (mat?.map) applySRGBColorSpace(mat.map);
+      if (mat?.emissiveMap) applySRGBColorSpace(mat.emissiveMap);
+      mat.needsUpdate = true;
+    });
   });
   normalizeCharacterPivot(instance);
 


### PR DESCRIPTION
### Motivation
- Improve portrait framing by moving seated human characters visually farther from the table and making chairs slightly larger to better match the requested look. 
- Avoid accidental re-mapping of character textures when loading glTF humans so their original UV/texture mapping remains intact.
- Keep changes localized to the Murlan Royale arena rendering so shared systems remain unaffected.

### Description
- Updated `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to increase `CHAIR_SIZE_SCALE` from `1.12` to `1.18` so chairs render bigger. 
- Increased `HUMAN_CHARACTER_EXTRA_OUTWARD_OFFSET` from `0.1` to `0.2` so seated human characters are pushed farther from the table for clearer portrait framing. 
- Replaced the per-mesh call that previously invoked `normalizeMaterialTextures` for character meshes with logic that preserves original glTF texture mapping and only applies sRGB color-space conversion to `mat.map` and `mat.emissiveMap`, followed by `mat.needsUpdate = true` to refresh materials.

### Testing
- Ran `rg -n "CHAIR_SIZE_SCALE|HUMAN_CHARACTER_EXTRA_OUTWARD_OFFSET|Preserve the character's original" webapp/src/pages/Games/MurlanRoyaleArena.jsx` to verify the updated constants and code locations, which succeeded. 
- Inspected the change with `git diff -- webapp/src/pages/Games/MurlanRoyaleArena.jsx` to confirm the intended edits, which succeeded. 
- Verified repository status with `git status --short` and committed the change; no automated unit/integration tests were executed as part of this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f470b933c88329b2a94735bf622f22)