### PR TITLE
Add Murlan-style seated human roster to Domino Battle Royal

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -1026,7 +1026,111 @@ const CHAIR_SEAT_RADII = Object.freeze([
   CHAIR_RADIUS + CHAIR_GLOBAL_PUSHBACK,
   CHAIR_RADIUS + CHAIR_GLOBAL_PUSHBACK
 ]);
-const DOMINO_HUMAN_CHARACTER_OPTIONS = Object.freeze([]);
+const DOMINO_HUMAN_CHARACTER_OPTIONS = Object.freeze([
+  {
+    id: 'rpm-current',
+    label: 'Current Avatar',
+    modelUrls: ['https://threejs.org/examples/models/gltf/readyplayer.me.glb'],
+    scale: 1.0,
+    seatOffsetY: -0.84,
+    seatOffsetZ: -0.22,
+    normalizedSeatOffsetY: -0.4,
+    normalizedSeatOffsetZ: 0.52,
+    seatPitch: 0,
+    seatYaw: 0,
+    handLift: 1.04
+  },
+  {
+    id: 'rpm-67d411',
+    label: 'RPM 67d411',
+    modelUrls: [
+      'https://models.readyplayer.me/67d411b30787acbf58ce58ac.glb',
+      'https://api.readyplayer.me/v1/avatars/67d411b30787acbf58ce58ac.glb',
+      'https://avatars.readyplayer.me/67d411b30787acbf58ce58ac.glb'
+    ],
+    scale: 1.0,
+    seatOffsetY: -0.84,
+    seatOffsetZ: -0.22,
+    normalizedSeatOffsetY: -0.4,
+    normalizedSeatOffsetZ: 0.52,
+    seatPitch: 0,
+    seatYaw: 0,
+    handLift: 1.04
+  },
+  {
+    id: 'rpm-67f433',
+    label: 'RPM 67f433',
+    modelUrls: [
+      'https://models.readyplayer.me/67f433b69dc08cf26d2cf585.glb',
+      'https://api.readyplayer.me/v1/avatars/67f433b69dc08cf26d2cf585.glb',
+      'https://avatars.readyplayer.me/67f433b69dc08cf26d2cf585.glb'
+    ],
+    scale: 1.0,
+    seatOffsetY: -0.84,
+    seatOffsetZ: -0.22,
+    normalizedSeatOffsetY: -0.4,
+    normalizedSeatOffsetZ: 0.52,
+    seatPitch: 0,
+    seatYaw: 0,
+    handLift: 1.04
+  },
+  {
+    id: 'rpm-67e1b5',
+    label: 'RPM 67e1b5',
+    modelUrls: [
+      'https://models.readyplayer.me/67e1b51ae11c93725e4395c9.glb',
+      'https://api.readyplayer.me/v1/avatars/67e1b51ae11c93725e4395c9.glb',
+      'https://avatars.readyplayer.me/67e1b51ae11c93725e4395c9.glb'
+    ],
+    scale: 1.0,
+    seatOffsetY: -0.84,
+    seatOffsetZ: -0.22,
+    normalizedSeatOffsetY: -0.4,
+    normalizedSeatOffsetZ: 0.52,
+    seatPitch: 0,
+    seatYaw: 0,
+    handLift: 1.04
+  },
+  {
+    id: 'webgl-vietnam-human',
+    label: 'Vietnam Human',
+    modelUrls: ['https://raw.githubusercontent.com/hmthanh/3d-human-model/main/TranThiNgocTham.glb'],
+    scale: 1.0,
+    seatOffsetY: -0.84,
+    seatOffsetZ: -0.22,
+    normalizedSeatOffsetY: -0.4,
+    normalizedSeatOffsetZ: 0.52,
+    seatPitch: 0,
+    seatYaw: 0,
+    handLift: 1.04
+  },
+  {
+    id: 'webgl-ai-teacher',
+    label: 'AI Teacher',
+    modelUrls: ['https://raw.githubusercontent.com/Surbh77/AI-teacher/main/avatar.glb'],
+    scale: 1.0,
+    seatOffsetY: -0.84,
+    seatOffsetZ: -0.22,
+    normalizedSeatOffsetY: -0.4,
+    normalizedSeatOffsetZ: 0.52,
+    seatPitch: 0,
+    seatYaw: 0,
+    handLift: 1.04
+  },
+  {
+    id: 'webgl-ai-teacher-1',
+    label: 'AI Teacher 1',
+    modelUrls: ['https://raw.githubusercontent.com/Surbh77/AI-teacher/main/avatar1.glb'],
+    scale: 1.0,
+    seatOffsetY: -0.84,
+    seatOffsetZ: -0.22,
+    normalizedSeatOffsetY: -0.4,
+    normalizedSeatOffsetZ: 0.52,
+    seatPitch: 0,
+    seatYaw: 0,
+    handLift: 1.04
+  }
+]);
 
 const ARENA_WALL_HEIGHT = 3.6 * 1.3;
 const ARENA_WALL_CENTER_Y = ARENA_WALL_HEIGHT / 2;

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-04-28-domino-human-seating-v38';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-01-domino-human-seating-v39';
 
 export default function DominoRoyalArena() {
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- Ensure Domino Battle Royal chairs can show the same seated human avatars and orientation as Murlan Royale so players can purchase/use the same characters and get identical seating behavior.
- Make the runtime aware of the purchasable character options already defined in the Domino store inventory so UI/store selections map to actual in-game models.

### Description
- Populated `DOMINO_HUMAN_CHARACTER_OPTIONS` in `webapp/public/domino-royal-game.js` with the Murlan roster entries, including `modelUrls`, seating offsets, scale, `seatPitch`, `seatYaw`, and `handLift` metadata so seated placement and orientation match Murlan Royale.
- Kept model URL fallback lists where available to improve robustness when loading GLB assets from multiple hosts.
- Updated the Domino runtime cache/version string in `webapp/src/pages/Games/DominoRoyalArena.jsx` (`DOMINO_ROYAL_SCRIPT_VERSION`) to force clients to fetch the updated script.
- Left store/inventory mappings intact since `webapp/src/config/dominoRoyalInventoryConfig.js` already defines matching `humanCharacter` options so the runtime now aligns with purchasable items.

### Testing
- No automated tests were executed for this change because it is a runtime/content configuration update; validation is intended via runtime smoke checks after deployment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4701c2824832998a410e03230610d)