### PR TITLE
Add selectable seated human avatars, resilient loading, and seat pose/scale overrides

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -1026,7 +1026,90 @@ const CHAIR_SEAT_RADII = Object.freeze([
   CHAIR_RADIUS + CHAIR_GLOBAL_PUSHBACK,
   CHAIR_RADIUS + CHAIR_GLOBAL_PUSHBACK
 ]);
-const DOMINO_HUMAN_CHARACTER_OPTIONS = Object.freeze([]);
+const DOMINO_HUMAN_CHARACTER_OPTIONS = Object.freeze([
+  {
+    id: 'rpm-current',
+    label: 'Current Avatar',
+    modelUrls: ['https://threejs.org/examples/models/gltf/readyplayer.me.glb'],
+    scale: 1.0,
+    normalizedSeatOffsetY: -0.4,
+    normalizedSeatOffsetZ: 0.52,
+    seatPitch: 0,
+    seatYaw: 0
+  },
+  {
+    id: 'rpm-67d411',
+    label: 'RPM 67d411',
+    modelUrls: [
+      'https://models.readyplayer.me/67d411b30787acbf58ce58ac.glb',
+      'https://api.readyplayer.me/v1/avatars/67d411b30787acbf58ce58ac.glb',
+      'https://avatars.readyplayer.me/67d411b30787acbf58ce58ac.glb'
+    ],
+    scale: 1.0,
+    normalizedSeatOffsetY: -0.4,
+    normalizedSeatOffsetZ: 0.52,
+    seatPitch: 0,
+    seatYaw: 0
+  },
+  {
+    id: 'rpm-67f433',
+    label: 'RPM 67f433',
+    modelUrls: [
+      'https://models.readyplayer.me/67f433b69dc08cf26d2cf585.glb',
+      'https://api.readyplayer.me/v1/avatars/67f433b69dc08cf26d2cf585.glb',
+      'https://avatars.readyplayer.me/67f433b69dc08cf26d2cf585.glb'
+    ],
+    scale: 1.0,
+    normalizedSeatOffsetY: -0.4,
+    normalizedSeatOffsetZ: 0.52,
+    seatPitch: 0,
+    seatYaw: 0
+  },
+  {
+    id: 'rpm-67e1b5',
+    label: 'RPM 67e1b5',
+    modelUrls: [
+      'https://models.readyplayer.me/67e1b51ae11c93725e4395c9.glb',
+      'https://api.readyplayer.me/v1/avatars/67e1b51ae11c93725e4395c9.glb',
+      'https://avatars.readyplayer.me/67e1b51ae11c93725e4395c9.glb'
+    ],
+    scale: 1.0,
+    normalizedSeatOffsetY: -0.4,
+    normalizedSeatOffsetZ: 0.52,
+    seatPitch: 0,
+    seatYaw: 0
+  },
+  {
+    id: 'webgl-vietnam-human',
+    label: 'Vietnam Human',
+    modelUrls: ['https://raw.githubusercontent.com/hmthanh/3d-human-model/main/TranThiNgocTham.glb'],
+    scale: 1.0,
+    normalizedSeatOffsetY: -0.4,
+    normalizedSeatOffsetZ: 0.52,
+    seatPitch: 0,
+    seatYaw: 0
+  },
+  {
+    id: 'webgl-ai-teacher',
+    label: 'AI Teacher',
+    modelUrls: ['https://raw.githubusercontent.com/Surbh77/AI-teacher/main/avatar.glb'],
+    scale: 1.0,
+    normalizedSeatOffsetY: -0.4,
+    normalizedSeatOffsetZ: 0.52,
+    seatPitch: 0,
+    seatYaw: 0
+  },
+  {
+    id: 'webgl-ai-teacher-1',
+    label: 'AI Teacher 1',
+    modelUrls: ['https://raw.githubusercontent.com/Surbh77/AI-teacher/main/avatar1.glb'],
+    scale: 1.0,
+    normalizedSeatOffsetY: -0.4,
+    normalizedSeatOffsetZ: 0.52,
+    seatPitch: 0,
+    seatYaw: 0
+  }
+]);
 
 const ARENA_WALL_HEIGHT = 3.6 * 1.3;
 const ARENA_WALL_CENTER_Y = ARENA_WALL_HEIGHT / 2;
@@ -7965,7 +8048,10 @@ async function loadSeatedHumanTemplate(option) {
             lastError = error;
           }
         }
-        if (!gltf) throw lastError || new Error('Missing seated human scene');
+        if (!gltf) {
+          console.warn('Domino Royal: unable to load seated human template', cacheKey, lastError);
+          return null;
+        }
         const root = gltf.scene || gltf.scenes?.[0] || gltf;
         normalizeSeatedHumanRootToChair(root);
         root.traverse((obj) => {
@@ -8084,16 +8170,18 @@ async function attachSeatedHumanActors(token) {
         // eslint-disable-next-line no-await-in-loop
         template = await loadSeatedHumanTemplate(DOMINO_HUMAN_CHARACTER_OPTIONS[0]);
       }
-      if (!template || token !== chairBuildToken) return;
+      if (token !== chairBuildToken) return;
+      if (!template) continue;
       const actor = cloneSkeleton(template);
       const actorScale =
-        template.userData?.seatedHumanScale ?? computeSeatedHumanScale(template);
+        (template.userData?.seatedHumanScale ?? computeSeatedHumanScale(template)) *
+        (option?.scale ?? 1);
       actor.scale.setScalar(actorScale);
       const seatZOffset =
         SEATED_HUMAN_SEAT_Z_OFFSET +
         (index === HUMAN_SEAT_INDEX ? SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET : 0);
       actor.position.set(0, SEATED_HUMAN_SEAT_Y_OFFSET, seatZOffset);
-      actor.rotation.set(0, SEATED_HUMAN_FACING_Y, 0);
+      actor.rotation.set(option?.seatPitch ?? 0, SEATED_HUMAN_FACING_Y + (option?.seatYaw ?? 0), 0);
       const rig = saveBoneRig(actor);
       applySeatedHumanPose(rig);
       alignSeatedHumanFeetToGroundPlane(actor, rig);

--- a/webapp/src/config/dominoRoyalInventoryConfig.js
+++ b/webapp/src/config/dominoRoyalInventoryConfig.js
@@ -15,8 +15,6 @@ const DOMINO_HUMAN_CHARACTER_OPTIONS = Object.freeze([
   { id: 'rpm-67f433', label: 'RPM 67f433', description: 'Ready Player Me seated avatar variant.' },
   { id: 'rpm-67e1b5', label: 'RPM 67e1b5', description: 'Ready Player Me seated avatar variant.' },
   { id: 'webgl-vietnam-human', label: 'Vietnam Human', description: 'Imported seated human model from Chess roster.' },
-  { id: 'webgl-human-body-a', label: 'Human Body A', description: 'Imported seated human model from Chess roster.' },
-  { id: 'webgl-human-body-b', label: 'Human Body B', description: 'Imported seated human model from Chess roster.' },
   { id: 'webgl-ai-teacher', label: 'AI Teacher', description: 'Imported seated human model from Chess roster.' },
   { id: 'webgl-ai-teacher-1', label: 'AI Teacher 1', description: 'Imported seated human model from Chess roster.' }
 ]);

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-04-28-domino-human-seating-v38';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-01-domino-murlan-characters-v40-hotfix';
 
 export default function DominoRoyalArena() {
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- Provide a set of selectable seated human avatars for the Domino arena so different GLTF avatar models can be used as seated characters.  
- Make model loading more tolerant of remote failures so a missing or failing avatar model does not break chair construction.  
- Allow per-avatar scale and seat orientation overrides so different models align correctly with existing chairs.

### Description
- Added a frozen `DOMINO_HUMAN_CHARACTER_OPTIONS` array in `webapp/public/domino-royal-game.js` with multiple avatar entries, each containing `id`, `label`, `modelUrls`, `scale`, `normalizedSeatOffsetY`, `normalizedSeatOffsetZ`, `seatPitch`, and `seatYaw`.  
- Updated `loadSeatedHumanTemplate` to warn and return `null` instead of throwing when no GLTF could be loaded, and to try multiple URL candidates.  
- Updated `attachSeatedHumanActors` to skip seats when a template is unavailable, apply `option.scale` to computed seated human scale, and apply `option.seatPitch`/`seatYaw` into the actor rotation.  
- Updated inventory configuration in `webapp/src/config/dominoRoyalInventoryConfig.js` to match the exposed avatar options and removed two deprecated human entries.  
- Bumped the inline script version string in `webapp/src/pages/Games/DominoRoyalArena.jsx`.

### Testing
- Ran the project build with `npm run build` and the command completed successfully.  
- Ran the test suite with `npm test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4701c2824832998a410e03230610d)