### PR TITLE
Add selectable Murlan/ReadyPlayerMe seated avatars and seating adjustments for Domino Royal

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -1026,7 +1026,90 @@ const CHAIR_SEAT_RADII = Object.freeze([
   CHAIR_RADIUS + CHAIR_GLOBAL_PUSHBACK,
   CHAIR_RADIUS + CHAIR_GLOBAL_PUSHBACK
 ]);
-const DOMINO_HUMAN_CHARACTER_OPTIONS = Object.freeze([]);
+const DOMINO_HUMAN_CHARACTER_OPTIONS = Object.freeze([
+  {
+    id: 'rpm-current',
+    label: 'Current Avatar',
+    modelUrls: ['https://threejs.org/examples/models/gltf/readyplayer.me.glb'],
+    scale: 1.0,
+    normalizedSeatOffsetY: -0.4,
+    normalizedSeatOffsetZ: 0.52,
+    seatPitch: 0,
+    seatYaw: 0
+  },
+  {
+    id: 'rpm-67d411',
+    label: 'RPM 67d411',
+    modelUrls: [
+      'https://models.readyplayer.me/67d411b30787acbf58ce58ac.glb',
+      'https://api.readyplayer.me/v1/avatars/67d411b30787acbf58ce58ac.glb',
+      'https://avatars.readyplayer.me/67d411b30787acbf58ce58ac.glb'
+    ],
+    scale: 1.0,
+    normalizedSeatOffsetY: -0.4,
+    normalizedSeatOffsetZ: 0.52,
+    seatPitch: 0,
+    seatYaw: 0
+  },
+  {
+    id: 'rpm-67f433',
+    label: 'RPM 67f433',
+    modelUrls: [
+      'https://models.readyplayer.me/67f433b69dc08cf26d2cf585.glb',
+      'https://api.readyplayer.me/v1/avatars/67f433b69dc08cf26d2cf585.glb',
+      'https://avatars.readyplayer.me/67f433b69dc08cf26d2cf585.glb'
+    ],
+    scale: 1.0,
+    normalizedSeatOffsetY: -0.4,
+    normalizedSeatOffsetZ: 0.52,
+    seatPitch: 0,
+    seatYaw: 0
+  },
+  {
+    id: 'rpm-67e1b5',
+    label: 'RPM 67e1b5',
+    modelUrls: [
+      'https://models.readyplayer.me/67e1b51ae11c93725e4395c9.glb',
+      'https://api.readyplayer.me/v1/avatars/67e1b51ae11c93725e4395c9.glb',
+      'https://avatars.readyplayer.me/67e1b51ae11c93725e4395c9.glb'
+    ],
+    scale: 1.0,
+    normalizedSeatOffsetY: -0.4,
+    normalizedSeatOffsetZ: 0.52,
+    seatPitch: 0,
+    seatYaw: 0
+  },
+  {
+    id: 'webgl-vietnam-human',
+    label: 'Vietnam Human',
+    modelUrls: ['https://raw.githubusercontent.com/hmthanh/3d-human-model/main/TranThiNgocTham.glb'],
+    scale: 1.0,
+    normalizedSeatOffsetY: -0.4,
+    normalizedSeatOffsetZ: 0.52,
+    seatPitch: 0,
+    seatYaw: 0
+  },
+  {
+    id: 'webgl-ai-teacher',
+    label: 'AI Teacher',
+    modelUrls: ['https://raw.githubusercontent.com/Surbh77/AI-teacher/main/avatar.glb'],
+    scale: 1.0,
+    normalizedSeatOffsetY: -0.4,
+    normalizedSeatOffsetZ: 0.52,
+    seatPitch: 0,
+    seatYaw: 0
+  },
+  {
+    id: 'webgl-ai-teacher-1',
+    label: 'AI Teacher 1',
+    modelUrls: ['https://raw.githubusercontent.com/Surbh77/AI-teacher/main/avatar1.glb'],
+    scale: 1.0,
+    normalizedSeatOffsetY: -0.4,
+    normalizedSeatOffsetZ: 0.52,
+    seatPitch: 0,
+    seatYaw: 0
+  }
+]);
 
 const ARENA_WALL_HEIGHT = 3.6 * 1.3;
 const ARENA_WALL_CENTER_Y = ARENA_WALL_HEIGHT / 2;
@@ -8087,13 +8170,17 @@ async function attachSeatedHumanActors(token) {
       if (!template || token !== chairBuildToken) return;
       const actor = cloneSkeleton(template);
       const actorScale =
-        template.userData?.seatedHumanScale ?? computeSeatedHumanScale(template);
+        (template.userData?.seatedHumanScale ?? computeSeatedHumanScale(template)) *
+        (option?.scale ?? 1);
       actor.scale.setScalar(actorScale);
+      const seatOffsetY = option?.normalizedSeatOffsetY ?? -0.4;
+      const seatOffsetZ = option?.normalizedSeatOffsetZ ?? 0.52;
+      const seatYOffset = SEATED_HUMAN_SEAT_Y_OFFSET + seatOffsetY * MODEL_SCALE * 0.12;
       const seatZOffset =
-        SEATED_HUMAN_SEAT_Z_OFFSET +
+        SEATED_HUMAN_SEAT_Z_OFFSET + seatOffsetZ * MODEL_SCALE * 0.02 +
         (index === HUMAN_SEAT_INDEX ? SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET : 0);
-      actor.position.set(0, SEATED_HUMAN_SEAT_Y_OFFSET, seatZOffset);
-      actor.rotation.set(0, SEATED_HUMAN_FACING_Y, 0);
+      actor.position.set(0, seatYOffset, seatZOffset);
+      actor.rotation.set(option?.seatPitch ?? 0, SEATED_HUMAN_FACING_Y + (option?.seatYaw ?? 0), 0);
       const rig = saveBoneRig(actor);
       applySeatedHumanPose(rig);
       alignSeatedHumanFeetToGroundPlane(actor, rig);

--- a/webapp/src/config/dominoRoyalInventoryConfig.js
+++ b/webapp/src/config/dominoRoyalInventoryConfig.js
@@ -1,4 +1,5 @@
 import { MURLAN_STOOL_THEMES, MURLAN_TABLE_THEMES } from './murlanThemes.js';
+import { MURLAN_CHARACTER_THEMES } from './murlanCharacterThemes.js';
 import { POOL_ROYALE_DEFAULT_HDRI_ID } from './poolRoyaleInventoryConfig.js';
 import { swatchThumbnail } from './storeThumbnails.js';
 import {
@@ -9,17 +10,9 @@ import {
   BATTLE_ROYALE_SHARED_TABLE_THEME_OPTIONS
 } from './battleRoyaleSharedInventory.js';
 
-const DOMINO_HUMAN_CHARACTER_OPTIONS = Object.freeze([
-  { id: 'rpm-current', label: 'Current Avatar', description: 'Default Chess Battle Royal human avatar.' },
-  { id: 'rpm-67d411', label: 'RPM 67d411', description: 'Ready Player Me seated avatar variant.' },
-  { id: 'rpm-67f433', label: 'RPM 67f433', description: 'Ready Player Me seated avatar variant.' },
-  { id: 'rpm-67e1b5', label: 'RPM 67e1b5', description: 'Ready Player Me seated avatar variant.' },
-  { id: 'webgl-vietnam-human', label: 'Vietnam Human', description: 'Imported seated human model from Chess roster.' },
-  { id: 'webgl-human-body-a', label: 'Human Body A', description: 'Imported seated human model from Chess roster.' },
-  { id: 'webgl-human-body-b', label: 'Human Body B', description: 'Imported seated human model from Chess roster.' },
-  { id: 'webgl-ai-teacher', label: 'AI Teacher', description: 'Imported seated human model from Chess roster.' },
-  { id: 'webgl-ai-teacher-1', label: 'AI Teacher 1', description: 'Imported seated human model from Chess roster.' }
-]);
+const DOMINO_HUMAN_CHARACTER_OPTIONS = Object.freeze(
+  MURLAN_CHARACTER_THEMES.map(({ id, label, description }) => ({ id, label, description }))
+);
 
 export const DOMINO_ROYAL_OPTION_SETS = Object.freeze({
   tableWood: BATTLE_ROYALE_SHARED_TABLE_FINISH_OPTIONS.map(({ id, label, price = 0, description, thumbnail, woodOption }) => ({

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-04-28-domino-human-seating-v38';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-01-domino-murlan-characters-v39';
 
 export default function DominoRoyalArena() {
   useEffect(() => {


### PR DESCRIPTION
### Motivation

- Enable selectable seated human avatars for the Domino Royal arena using ReadyPlayerMe and Murlan character themes and improve avatar placement so different models sit and face correctly. 
- Surface available avatar options in the inventory configuration so the UI can list Murlan-provided character themes.
- Bump the in-page game script version to reflect the character/theme update.

### Description

- Added a populated `DOMINO_HUMAN_CHARACTER_OPTIONS` array in `webapp/public/domino-royal-game.js` with several ReadyPlayerMe and web-hosted models and metadata (id, label, `modelUrls`, `scale`, normalized seat offsets, and seat pitch/yaw). 
- Updated `attachSeatedHumanActors` to factor the selected option into actor scaling, to apply `normalizedSeatOffsetY`/`normalizedSeatOffsetZ` for seat positioning, and to apply per-option `seatPitch`/`seatYaw` to avatar rotation. 
- Replaced the hardcoded Domino character list in `webapp/src/config/dominoRoyalInventoryConfig.js` with a mapped import from `MURLAN_CHARACTER_THEMES` so `DOMINO_HUMAN_CHARACTER_OPTIONS` is derived from `MURLAN_CHARACTER_THEMES`. 
- Bumped the script/version identifier string in `webapp/src/pages/Games/DominoRoyalArena.jsx` to `2026-05-01-domino-murlan-characters-v39` to reflect the update.

### Testing

- Ran the project build with `npm run build` and it completed successfully.
- Ran the linter with `npm run lint` and it completed successfully.
- Executed the test suite with `npm test` and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4701c2824832998a410e03230610d)