### PR TITLE
Support multiple seated human avatars with per-model scale/offset and attach timing fix

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -1026,7 +1026,90 @@ const CHAIR_SEAT_RADII = Object.freeze([
   CHAIR_RADIUS + CHAIR_GLOBAL_PUSHBACK,
   CHAIR_RADIUS + CHAIR_GLOBAL_PUSHBACK
 ]);
-const DOMINO_HUMAN_CHARACTER_OPTIONS = Object.freeze([]);
+const DOMINO_HUMAN_CHARACTER_OPTIONS = Object.freeze([
+  {
+    id: 'rpm-current',
+    label: 'Current Avatar',
+    modelUrls: ['https://threejs.org/examples/models/gltf/readyplayer.me.glb'],
+    scale: 1.0,
+    normalizedSeatOffsetY: -0.4,
+    normalizedSeatOffsetZ: 0.52,
+    seatPitch: 0,
+    seatYaw: 0
+  },
+  {
+    id: 'rpm-67d411',
+    label: 'RPM 67d411',
+    modelUrls: [
+      'https://models.readyplayer.me/67d411b30787acbf58ce58ac.glb',
+      'https://api.readyplayer.me/v1/avatars/67d411b30787acbf58ce58ac.glb',
+      'https://avatars.readyplayer.me/67d411b30787acbf58ce58ac.glb'
+    ],
+    scale: 1.0,
+    normalizedSeatOffsetY: -0.4,
+    normalizedSeatOffsetZ: 0.52,
+    seatPitch: 0,
+    seatYaw: 0
+  },
+  {
+    id: 'rpm-67f433',
+    label: 'RPM 67f433',
+    modelUrls: [
+      'https://models.readyplayer.me/67f433b69dc08cf26d2cf585.glb',
+      'https://api.readyplayer.me/v1/avatars/67f433b69dc08cf26d2cf585.glb',
+      'https://avatars.readyplayer.me/67f433b69dc08cf26d2cf585.glb'
+    ],
+    scale: 1.0,
+    normalizedSeatOffsetY: -0.4,
+    normalizedSeatOffsetZ: 0.52,
+    seatPitch: 0,
+    seatYaw: 0
+  },
+  {
+    id: 'rpm-67e1b5',
+    label: 'RPM 67e1b5',
+    modelUrls: [
+      'https://models.readyplayer.me/67e1b51ae11c93725e4395c9.glb',
+      'https://api.readyplayer.me/v1/avatars/67e1b51ae11c93725e4395c9.glb',
+      'https://avatars.readyplayer.me/67e1b51ae11c93725e4395c9.glb'
+    ],
+    scale: 1.0,
+    normalizedSeatOffsetY: -0.4,
+    normalizedSeatOffsetZ: 0.52,
+    seatPitch: 0,
+    seatYaw: 0
+  },
+  {
+    id: 'webgl-vietnam-human',
+    label: 'Vietnam Human',
+    modelUrls: ['https://raw.githubusercontent.com/hmthanh/3d-human-model/main/TranThiNgocTham.glb'],
+    scale: 1.0,
+    normalizedSeatOffsetY: -0.4,
+    normalizedSeatOffsetZ: 0.52,
+    seatPitch: 0,
+    seatYaw: 0
+  },
+  {
+    id: 'webgl-ai-teacher',
+    label: 'AI Teacher',
+    modelUrls: ['https://raw.githubusercontent.com/Surbh77/AI-teacher/main/avatar.glb'],
+    scale: 1.0,
+    normalizedSeatOffsetY: -0.4,
+    normalizedSeatOffsetZ: 0.52,
+    seatPitch: 0,
+    seatYaw: 0
+  },
+  {
+    id: 'webgl-ai-teacher-1',
+    label: 'AI Teacher 1',
+    modelUrls: ['https://raw.githubusercontent.com/Surbh77/AI-teacher/main/avatar1.glb'],
+    scale: 1.0,
+    normalizedSeatOffsetY: -0.4,
+    normalizedSeatOffsetZ: 0.52,
+    seatPitch: 0,
+    seatYaw: 0
+  }
+]);
 
 const ARENA_WALL_HEIGHT = 3.6 * 1.3;
 const ARENA_WALL_CENTER_Y = ARENA_WALL_HEIGHT / 2;
@@ -8087,13 +8170,17 @@ async function attachSeatedHumanActors(token) {
       if (!template || token !== chairBuildToken) return;
       const actor = cloneSkeleton(template);
       const actorScale =
-        template.userData?.seatedHumanScale ?? computeSeatedHumanScale(template);
+        (template.userData?.seatedHumanScale ?? computeSeatedHumanScale(template)) *
+        (option?.scale ?? 1);
       actor.scale.setScalar(actorScale);
+      const seatOffsetY = option?.normalizedSeatOffsetY ?? -0.4;
+      const seatOffsetZ = option?.normalizedSeatOffsetZ ?? 0.52;
+      const seatYOffset = SEATED_HUMAN_SEAT_Y_OFFSET + seatOffsetY * MODEL_SCALE * 0.12;
       const seatZOffset =
-        SEATED_HUMAN_SEAT_Z_OFFSET +
+        SEATED_HUMAN_SEAT_Z_OFFSET + seatOffsetZ * MODEL_SCALE * 0.02 +
         (index === HUMAN_SEAT_INDEX ? SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET : 0);
-      actor.position.set(0, SEATED_HUMAN_SEAT_Y_OFFSET, seatZOffset);
-      actor.rotation.set(0, SEATED_HUMAN_FACING_Y, 0);
+      actor.position.set(0, seatYOffset, seatZOffset);
+      actor.rotation.set(option?.seatPitch ?? 0, SEATED_HUMAN_FACING_Y + (option?.seatYaw ?? 0), 0);
       const rig = saveBoneRig(actor);
       applySeatedHumanPose(rig);
       alignSeatedHumanFeetToGroundPlane(actor, rig);
@@ -8113,6 +8200,9 @@ async function buildChairs(
   try {
     const chairData = await ensureChairTemplateForTheme(option);
     placeChairsWithOption(option, chairData, token);
+    Promise.resolve().then(() => attachSeatedHumanActors(token)).catch((error) => {
+      console.warn('Domino Royal seated-human attach skipped after chair build', error);
+    });
   } catch (error) {
     console.warn('Failed to load GLTF chair theme for Domino', error);
   }

--- a/webapp/src/config/dominoRoyalInventoryConfig.js
+++ b/webapp/src/config/dominoRoyalInventoryConfig.js
@@ -10,15 +10,13 @@ import {
 } from './battleRoyaleSharedInventory.js';
 
 const DOMINO_HUMAN_CHARACTER_OPTIONS = Object.freeze([
-  { id: 'rpm-current', label: 'Current Avatar', description: 'Default Chess Battle Royal human avatar.' },
+  { id: 'rpm-current', label: 'Current Avatar', description: 'Ready Player Me seated avatar with full PBR texture maps.' },
   { id: 'rpm-67d411', label: 'RPM 67d411', description: 'Ready Player Me seated avatar variant.' },
   { id: 'rpm-67f433', label: 'RPM 67f433', description: 'Ready Player Me seated avatar variant.' },
   { id: 'rpm-67e1b5', label: 'RPM 67e1b5', description: 'Ready Player Me seated avatar variant.' },
-  { id: 'webgl-vietnam-human', label: 'Vietnam Human', description: 'Imported seated human model from Chess roster.' },
-  { id: 'webgl-human-body-a', label: 'Human Body A', description: 'Imported seated human model from Chess roster.' },
-  { id: 'webgl-human-body-b', label: 'Human Body B', description: 'Imported seated human model from Chess roster.' },
-  { id: 'webgl-ai-teacher', label: 'AI Teacher', description: 'Imported seated human model from Chess roster.' },
-  { id: 'webgl-ai-teacher-1', label: 'AI Teacher 1', description: 'Imported seated human model from Chess roster.' }
+  { id: 'webgl-vietnam-human', label: 'Vietnam Human', description: 'Open WebGL GLB humanoid seated variant.' },
+  { id: 'webgl-ai-teacher', label: 'AI Teacher', description: 'Open-source AI Teacher avatar adapted to seated pose.' },
+  { id: 'webgl-ai-teacher-1', label: 'AI Teacher 1', description: 'Second AI Teacher seated variant.' }
 ]);
 
 export const DOMINO_ROYAL_OPTION_SETS = Object.freeze({

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-04-28-domino-human-seating-v38';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-01-domino-human-fix-v40';
 
 export default function DominoRoyalArena() {
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- Enable selecting different seated human avatars for Domino Royal and allow per-model placement tweaks to avoid misalignment. 
- Ensure seated avatar geometry is scaled and positioned correctly relative to chairs for a variety of GLB models. 
- Reduce race conditions by deferring avatar attachment until after chairs are placed.

### Description
- Added a concrete `DOMINO_HUMAN_CHARACTER_OPTIONS` array in `webapp/public/domino-royal-game.js` with multiple avatar entries, each providing `id`, `label`, `modelUrls`, `scale`, `normalizedSeatOffsetY`, `normalizedSeatOffsetZ`, `seatPitch`, and `seatYaw` fields. 
- Updated `attachSeatedHumanActors` to apply per-option `scale`, `normalizedSeatOffsetY`, and `normalizedSeatOffsetZ` when computing actor scale and position, and to use `seatPitch`/`seatYaw` to adjust rotation; falling back to existing defaults when values are absent. 
- Deferred invocation of `attachSeatedHumanActors` after `placeChairsWithOption` by scheduling it on a microtask (`Promise.resolve().then(...)`) to avoid blocking chair build and to handle errors gracefully. 
- Refined `DOMINO_HUMAN_CHARACTER_OPTIONS` metadata in `webapp/src/config/dominoRoyalInventoryConfig.js` (updated descriptions and removed redundant entries) and bumped the inline game script version in `webapp/src/pages/Games/DominoRoyalArena.jsx` to `2026-05-01-domino-human-fix-v40`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4701c2824832998a410e03230610d)