### PR TITLE
Add selectable seated human avatars, model load timeout, and seating offsets

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -1026,7 +1026,91 @@ const CHAIR_SEAT_RADII = Object.freeze([
   CHAIR_RADIUS + CHAIR_GLOBAL_PUSHBACK,
   CHAIR_RADIUS + CHAIR_GLOBAL_PUSHBACK
 ]);
-const DOMINO_HUMAN_CHARACTER_OPTIONS = Object.freeze([]);
+const DOMINO_HUMAN_CHARACTER_OPTIONS = Object.freeze([
+  {
+    id: 'rpm-current',
+    label: 'Current Avatar',
+    modelUrls: ['https://threejs.org/examples/models/gltf/readyplayer.me.glb'],
+    scale: 1.0,
+    normalizedSeatOffsetY: -0.4,
+    normalizedSeatOffsetZ: 0.52,
+    seatPitch: 0,
+    seatYaw: 0
+  },
+  {
+    id: 'rpm-67d411',
+    label: 'RPM 67d411',
+    modelUrls: [
+      'https://models.readyplayer.me/67d411b30787acbf58ce58ac.glb',
+      'https://api.readyplayer.me/v1/avatars/67d411b30787acbf58ce58ac.glb',
+      'https://avatars.readyplayer.me/67d411b30787acbf58ce58ac.glb'
+    ],
+    scale: 1.0,
+    normalizedSeatOffsetY: -0.4,
+    normalizedSeatOffsetZ: 0.52,
+    seatPitch: 0,
+    seatYaw: 0
+  },
+  {
+    id: 'rpm-67f433',
+    label: 'RPM 67f433',
+    modelUrls: [
+      'https://models.readyplayer.me/67f433b69dc08cf26d2cf585.glb',
+      'https://api.readyplayer.me/v1/avatars/67f433b69dc08cf26d2cf585.glb',
+      'https://avatars.readyplayer.me/67f433b69dc08cf26d2cf585.glb'
+    ],
+    scale: 1.0,
+    normalizedSeatOffsetY: -0.4,
+    normalizedSeatOffsetZ: 0.52,
+    seatPitch: 0,
+    seatYaw: 0
+  },
+  {
+    id: 'rpm-67e1b5',
+    label: 'RPM 67e1b5',
+    modelUrls: [
+      'https://models.readyplayer.me/67e1b51ae11c93725e4395c9.glb',
+      'https://api.readyplayer.me/v1/avatars/67e1b51ae11c93725e4395c9.glb',
+      'https://avatars.readyplayer.me/67e1b51ae11c93725e4395c9.glb'
+    ],
+    scale: 1.0,
+    normalizedSeatOffsetY: -0.4,
+    normalizedSeatOffsetZ: 0.52,
+    seatPitch: 0,
+    seatYaw: 0
+  },
+  {
+    id: 'webgl-vietnam-human',
+    label: 'Vietnam Human',
+    modelUrls: ['https://raw.githubusercontent.com/hmthanh/3d-human-model/main/TranThiNgocTham.glb'],
+    scale: 1.0,
+    normalizedSeatOffsetY: -0.4,
+    normalizedSeatOffsetZ: 0.52,
+    seatPitch: 0,
+    seatYaw: 0
+  },
+  {
+    id: 'webgl-ai-teacher',
+    label: 'AI Teacher',
+    modelUrls: ['https://raw.githubusercontent.com/Surbh77/AI-teacher/main/avatar.glb'],
+    scale: 1.0,
+    normalizedSeatOffsetY: -0.4,
+    normalizedSeatOffsetZ: 0.52,
+    seatPitch: 0,
+    seatYaw: 0
+  },
+  {
+    id: 'webgl-ai-teacher-1',
+    label: 'AI Teacher 1',
+    modelUrls: ['https://raw.githubusercontent.com/Surbh77/AI-teacher/main/avatar1.glb'],
+    scale: 1.0,
+    normalizedSeatOffsetY: -0.4,
+    normalizedSeatOffsetZ: 0.52,
+    seatPitch: 0,
+    seatYaw: 0
+  }
+]);
+const HUMAN_MODEL_LOAD_TIMEOUT_MS = 4500;
 
 const ARENA_WALL_HEIGHT = 3.6 * 1.3;
 const ARENA_WALL_CENTER_Y = ARENA_WALL_HEIGHT / 2;
@@ -7954,18 +8038,24 @@ async function loadSeatedHumanTemplate(option) {
         const candidates = normalizeHumanModelUrlCandidates(
           targetOption.modelUrls || fallbackOption.modelUrls || []
         );
+        if (!candidates.length) return null;
         let gltf = null;
         let lastError = null;
         for (const url of candidates) {
           try {
             // eslint-disable-next-line no-await-in-loop
-            gltf = await loader.loadAsync(url);
+            gltf = await Promise.race([
+              loader.loadAsync(url),
+              new Promise((_, reject) =>
+                setTimeout(() => reject(new Error(`Seated human load timeout: ${url}`)), HUMAN_MODEL_LOAD_TIMEOUT_MS)
+              )
+            ]);
             if (gltf) break;
           } catch (error) {
             lastError = error;
           }
         }
-        if (!gltf) throw lastError || new Error('Missing seated human scene');
+        if (!gltf) return null;
         const root = gltf.scene || gltf.scenes?.[0] || gltf;
         normalizeSeatedHumanRootToChair(root);
         root.traverse((obj) => {
@@ -8082,18 +8172,22 @@ async function attachSeatedHumanActors(token) {
       } catch (error) {
         console.warn('Domino Royal human seat model failed, using default', option?.id, error);
         // eslint-disable-next-line no-await-in-loop
-        template = await loadSeatedHumanTemplate(DOMINO_HUMAN_CHARACTER_OPTIONS[0]);
+        template = await loadSeatedHumanTemplate(DOMINO_HUMAN_CHARACTER_OPTIONS[0] || null);
       }
-      if (!template || token !== chairBuildToken) return;
+      if (!template || token !== chairBuildToken) continue;
       const actor = cloneSkeleton(template);
       const actorScale =
-        template.userData?.seatedHumanScale ?? computeSeatedHumanScale(template);
+        (template.userData?.seatedHumanScale ?? computeSeatedHumanScale(template)) *
+        (option?.scale ?? 1);
       actor.scale.setScalar(actorScale);
+      const seatOffsetY = option?.normalizedSeatOffsetY ?? -0.4;
+      const seatOffsetZ = option?.normalizedSeatOffsetZ ?? 0.52;
+      const seatYOffset = SEATED_HUMAN_SEAT_Y_OFFSET + seatOffsetY * MODEL_SCALE * 0.12;
       const seatZOffset =
-        SEATED_HUMAN_SEAT_Z_OFFSET +
+        SEATED_HUMAN_SEAT_Z_OFFSET + seatOffsetZ * MODEL_SCALE * 0.02 +
         (index === HUMAN_SEAT_INDEX ? SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET : 0);
-      actor.position.set(0, SEATED_HUMAN_SEAT_Y_OFFSET, seatZOffset);
-      actor.rotation.set(0, SEATED_HUMAN_FACING_Y, 0);
+      actor.position.set(0, seatYOffset, seatZOffset);
+      actor.rotation.set(option?.seatPitch ?? 0, SEATED_HUMAN_FACING_Y + (option?.seatYaw ?? 0), 0);
       const rig = saveBoneRig(actor);
       applySeatedHumanPose(rig);
       alignSeatedHumanFeetToGroundPlane(actor, rig);

--- a/webapp/src/config/dominoRoyalInventoryConfig.js
+++ b/webapp/src/config/dominoRoyalInventoryConfig.js
@@ -10,15 +10,13 @@ import {
 } from './battleRoyaleSharedInventory.js';
 
 const DOMINO_HUMAN_CHARACTER_OPTIONS = Object.freeze([
-  { id: 'rpm-current', label: 'Current Avatar', description: 'Default Chess Battle Royal human avatar.' },
-  { id: 'rpm-67d411', label: 'RPM 67d411', description: 'Ready Player Me seated avatar variant.' },
-  { id: 'rpm-67f433', label: 'RPM 67f433', description: 'Ready Player Me seated avatar variant.' },
-  { id: 'rpm-67e1b5', label: 'RPM 67e1b5', description: 'Ready Player Me seated avatar variant.' },
-  { id: 'webgl-vietnam-human', label: 'Vietnam Human', description: 'Imported seated human model from Chess roster.' },
-  { id: 'webgl-human-body-a', label: 'Human Body A', description: 'Imported seated human model from Chess roster.' },
-  { id: 'webgl-human-body-b', label: 'Human Body B', description: 'Imported seated human model from Chess roster.' },
-  { id: 'webgl-ai-teacher', label: 'AI Teacher', description: 'Imported seated human model from Chess roster.' },
-  { id: 'webgl-ai-teacher-1', label: 'AI Teacher 1', description: 'Imported seated human model from Chess roster.' }
+  { id: 'rpm-current', label: 'Current Avatar', description: 'Ready Player Me seated avatar with full PBR texture maps.' },
+  { id: 'rpm-67d411', label: 'RPM 67d411', description: 'Ready Player Me public avatar seated with the same rig logic and motion set.' },
+  { id: 'rpm-67f433', label: 'RPM 67f433', description: 'Ready Player Me public avatar aligned to default seated scale/orientation.' },
+  { id: 'rpm-67e1b5', label: 'RPM 67e1b5', description: 'Ready Player Me public avatar using the same seated helper offsets.' },
+  { id: 'webgl-vietnam-human', label: 'Vietnam Human', description: 'Open WebGL GLB humanoid seated with the same scale/orientation rig.' },
+  { id: 'webgl-ai-teacher', label: 'AI Teacher', description: 'Open-source AI Teacher avatar adapted to the default seated pose pipeline.' },
+  { id: 'webgl-ai-teacher-1', label: 'AI Teacher 1', description: 'Second AI Teacher avatar using the same seated helpers and interaction logic.' }
 ]);
 
 export const DOMINO_ROYAL_OPTION_SETS = Object.freeze({

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-04-28-domino-human-seating-v38';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-01-domino-murlan-characters-v39';
 
 export default function DominoRoyalArena() {
   useEffect(() => {


### PR DESCRIPTION
### Motivation

- Introduce selectable seated human avatars and safer loading for remote GLB models to improve avatar variety and stability.  
- Prevent a single failed or slow remote avatar from stalling chair construction and keep default seating behavior robust.  

### Description

- Added `DOMINO_HUMAN_CHARACTER_OPTIONS` with multiple avatar entries and metadata (IDs, `modelUrls`, `scale`, normalized seat offsets, and seat orientation) in `webapp/public/domino-royal-game.js`.  
- Introduced `HUMAN_MODEL_LOAD_TIMEOUT_MS` and updated `loadSeatedHumanTemplate` to normalize URL candidates, return `null` for empty candidates, and race `loader.loadAsync` with a timeout to avoid long hangs.  
- Changed `loadSeatedHumanTemplate` to return `null` on load failure instead of throwing, and updated `attachSeatedHumanActors` to continue past a missing template instead of aborting the entire loop, apply per-option `scale`, `normalizedSeatOffsetY`/`Z`, and `seatPitch`/`seatYaw` when positioning actors, and use the saved seated scale when available.  
- Updated inventory config `DOMINO_HUMAN_CHARACTER_OPTIONS` descriptions in `webapp/src/config/dominoRoyalInventoryConfig.js` to reflect the new avatar choices, and bumped the inline game script version in `webapp/src/pages/Games/DominoRoyalArena.jsx` (`DOMINO_ROYAL_SCRIPT_VERSION`).  

### Testing

- Ran the project build with `npm run build` and the webapp bundle compiled successfully.  
- Executed the automated unit test suite with `npm test` and linting `npm run lint`, and these checks passed locally.  
- Verified that slow/missing remote avatar URLs now time out after `HUMAN_MODEL_LOAD_TIMEOUT_MS` and that chair placement proceeds when an avatar template is unavailable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4701c2824832998a410e03230610d)