### PR TITLE
Fix Domino Royal script loading fallback when base path is misaligned

### DIFF
--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -33,27 +33,52 @@ export default function DominoRoyalArena() {
 
     const basePath = import.meta.env.BASE_URL || '/';
     const normalizedBasePath = basePath.endsWith('/') ? basePath : `${basePath}/`;
-    const script = document.createElement('script');
-    script.type = 'module';
-    script.src = `${normalizedBasePath}domino-royal-game.js?v=${DOMINO_ROYAL_SCRIPT_VERSION}`;
-    script.dataset.dominoRoyalScript = 'true';
-    script.onload = () => {
-      if (statusNode) {
-        statusNode.textContent = 'Ready';
+    const scriptCandidates = [
+      `${normalizedBasePath}domino-royal-game.js?v=${DOMINO_ROYAL_SCRIPT_VERSION}`,
+      `/domino-royal-game.js?v=${DOMINO_ROYAL_SCRIPT_VERSION}`
+    ].filter((value, idx, arr) => arr.indexOf(value) === idx);
+
+    let activeScript = null;
+    let disposed = false;
+
+    const loadScriptFrom = (index = 0) => {
+      if (disposed || index >= scriptCandidates.length) {
+        if (statusNode) {
+          statusNode.textContent = 'Game failed to load. Please refresh and try again.';
+        }
+        return;
       }
+
+      const nextScript = document.createElement('script');
+      nextScript.type = 'module';
+      nextScript.src = scriptCandidates[index];
+      nextScript.dataset.dominoRoyalScript = 'true';
+      nextScript.dataset.dominoRoyalScriptAttempt = String(index + 1);
+
+      nextScript.onload = () => {
+        if (disposed) return;
+        if (statusNode) {
+          statusNode.textContent = 'Ready';
+        }
+      };
+
+      nextScript.onerror = () => {
+        nextScript.remove();
+        loadScriptFrom(index + 1);
+      };
+
+      activeScript = nextScript;
+      document.body.appendChild(nextScript);
     };
-    script.onerror = () => {
-      if (statusNode) {
-        statusNode.textContent = 'Game failed to load. Please refresh and try again.';
-      }
-    };
-    document.body.appendChild(script);
+
+    loadScriptFrom();
 
     return () => {
+      disposed = true;
       if (typeof window.__dominoRoyalCleanup === 'function') {
         window.__dominoRoyalCleanup('react-unmount');
       }
-      script.remove();
+      activeScript?.remove();
       if (appRoot) {
         appRoot.replaceChildren();
       }


### PR DESCRIPTION
### Motivation
- The Domino Royal arena bootstrap relied on a single `BASE_URL`-derived script URL which can fail when the app is deployed with a different base path, causing the game script not to load and the game to never start.
- The change adds resilience to asset loading so the game can recover from common base-path mismatches in different hosting environments.

### Description
- Replaced single-script injection in `DominoRoyalArena.jsx` with a sequenced loader that tries multiple `domino-royal-game.js` candidate URLs (the `BASE_URL` path then `/domino-royal-game.js`).
- Deduplicated candidate list generation and added an attempt counter on the injected script via `dataset.dominoRoyalScriptAttempt` for easier debugging.
- On script load failure the loader now removes the failed node and retries the next candidate, only reporting failure after all candidates are exhausted.
- Preserved and improved cleanup by tracking the active script node, marking the loader as disposed on unmount, and removing only the active script while still calling the existing `window.__dominoRoyalCleanup` if present.

### Testing
- Ran the production build via `npm run -s build` which completed successfully.
- Verified the new loader logic by exercising the component during build/serve cycles and confirming the script injection, retry behavior, and cleanup executed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4983fea108329a769f17bdb7f721e)