### PR TITLE
Fix Domino Royal script loading by using relative vendor imports

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -1,13 +1,13 @@
-import * as THREE from '/vendor/three/build/three.module.js';
-import { OrbitControls } from '/vendor/three/examples/jsm/controls/OrbitControls.js';
-import { RoomEnvironment } from '/vendor/three/examples/jsm/environments/RoomEnvironment.js';
-import { RoundedBoxGeometry } from '/vendor/three/examples/jsm/geometries/RoundedBoxGeometry.js';
-import { GLTFLoader } from '/vendor/three/examples/jsm/loaders/GLTFLoader.js';
-import { RGBELoader } from '/vendor/three/examples/jsm/loaders/RGBELoader.js';
-import { DRACOLoader } from '/vendor/three/examples/jsm/loaders/DRACOLoader.js';
-import { KTX2Loader } from '/vendor/three/examples/jsm/loaders/KTX2Loader.js';
-import { MeshoptDecoder } from '/vendor/three/examples/jsm/libs/meshopt_decoder.module.js';
-import { clone as cloneSkeleton } from '/vendor/three/examples/jsm/utils/SkeletonUtils.js';
+import * as THREE from './vendor/three/build/three.module.js';
+import { OrbitControls } from './vendor/three/examples/jsm/controls/OrbitControls.js';
+import { RoomEnvironment } from './vendor/three/examples/jsm/environments/RoomEnvironment.js';
+import { RoundedBoxGeometry } from './vendor/three/examples/jsm/geometries/RoundedBoxGeometry.js';
+import { GLTFLoader } from './vendor/three/examples/jsm/loaders/GLTFLoader.js';
+import { RGBELoader } from './vendor/three/examples/jsm/loaders/RGBELoader.js';
+import { DRACOLoader } from './vendor/three/examples/jsm/loaders/DRACOLoader.js';
+import { KTX2Loader } from './vendor/three/examples/jsm/loaders/KTX2Loader.js';
+import { MeshoptDecoder } from './vendor/three/examples/jsm/libs/meshopt_decoder.module.js';
+import { clone as cloneSkeleton } from './vendor/three/examples/jsm/utils/SkeletonUtils.js';
 import './flag-emojis.js';
 
 const urlParams = new URLSearchParams(window.location.search);


### PR DESCRIPTION
### Motivation
- Domino Royal failed to load when the app is served from a non-root base path because its runtime script used absolute `/vendor/...` module imports that don't resolve under nested base URLs.

### Description
- Updated `webapp/public/domino-royal-game.js` to replace absolute imports like `/vendor/...` with relative `./vendor/...` so the module graph resolves correctly when `domino-royal-game.js` is served from a subpath.

### Testing
- Ran `cd webapp && npm run build` and the production build completed successfully.
- Ran `node --check webapp/public/domino-royal-game.js` and the Domino script passed syntax validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4983fea108329a769f17bdb7f721e)