### PR TITLE
Firearm capture: per-piece animation, pellet projectiles, and visual tweaks

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -11168,8 +11168,8 @@ function Chess3D({
       'compactCarbineAttack'
     ]);
 
-    const resolveFirearmCaptureProfile = () => {
-      const singleShot = SINGLE_SHOT_FIREARM_IDS.has(selectedCaptureAnimationId);
+    const resolveFirearmCaptureProfile = (captureAnimationId) => {
+      const singleShot = SINGLE_SHOT_FIREARM_IDS.has(captureAnimationId);
       return {
         bulletCount: singleShot ? 1 : 7,
         duration: singleShot ? 0.62 : 1.15,
@@ -11192,6 +11192,10 @@ function Chess3D({
       if (FIREARM_CAPTURE_ANIMATION_IDS.has(selectedId)) return 'firearm';
       return GLOBAL_CAPTURE_KIND_BY_ANIMATION_ID[selectedId] || 'truck';
     };
+    const resolveCaptureAnimationForPiece = (pieceType) => {
+      const group = resolvePieceGroupFromType(pieceType);
+      return captureAnimationByPieceGroup[group] || selectedCaptureAnimationId;
+    };
 
     const playCaptureAnimation = ({
       fromPos,
@@ -11212,6 +11216,7 @@ function Chess3D({
         return timing;
       };
       const captureKind = resolveCaptureKindForPiece(movingType);
+      const captureAnimationId = resolveCaptureAnimationForPiece(movingType);
       if (captureKind === 'truck') {
         suppressTimerBeepUntilRef.current = performance.now() + CAPTURE_GROUND_TOTAL * 1000;
         const missileFx = createFxGroundMissile();
@@ -11383,7 +11388,7 @@ function Chess3D({
         }, { enableAuto3d: false });
       }
       if (captureKind === 'firearm') {
-        const firearmProfile = resolveFirearmCaptureProfile();
+        const firearmProfile = resolveFirearmCaptureProfile(captureAnimationId);
         playAudio(missileLaunchSoundRef);
         const missileFx = createFxMissile();
         missileFx.root.scale.setScalar(CAPTURE_MISSILE_SCALE * 0.52);
@@ -11402,7 +11407,9 @@ function Chess3D({
           singleShot: firearmProfile.singleShot,
           firedBullets: 0,
           hitTriggered: false,
-          muzzleOffset: new THREE.Vector3(0.24, 0.14, 0)
+          muzzleOffset: new THREE.Vector3(0.24, 0.14, 0),
+          activeProjectiles: [],
+          firearmId: captureAnimationId
         });
         return withAuto3d({
           moveDelayMs: firearmProfile.duration * 1000,
@@ -13624,7 +13631,7 @@ function Chess3D({
           } else if (fx.type === 'firearm') {
             const targetPos = getLiveTargetPosition(fx.to, fx.targetMesh, 0);
             fx.to.copy(targetPos);
-            const shooterPos = fx.from.clone().lerp(targetPos, 0.24);
+            const shooterPos = fx.from.clone().lerp(targetPos, 0.15);
             shooterPos.y += 0.24;
             const aimDir = targetPos.clone().sub(shooterPos).normalize();
             fx.missileFx.root.visible = true;
@@ -13642,8 +13649,46 @@ function Chess3D({
               const shotProgress = clamp01(fx.firedBullets / bulletsToFire);
               const shotPos = shooterPos.clone().lerp(targetPos, shotProgress);
               launchExplosion(shotPos);
+              const pelletCount = /shotgun/i.test(`${fx.firearmId || ''}`) ? 4 : 1;
+              for (let pelletIdx = 0; pelletIdx < pelletCount; pelletIdx += 1) {
+                const drift = pelletCount > 1 ? (pelletIdx - (pelletCount - 1) / 2) * 0.02 : 0;
+                const pelletDir = aimDir
+                  .clone()
+                  .add(new THREE.Vector3(0, pelletCount > 1 ? 0.006 * pelletIdx : 0, drift))
+                  .normalize();
+                fx.activeProjectiles.push({
+                  from: shooterPos.clone(),
+                  to: targetPos.clone().add(new THREE.Vector3(0, pelletCount > 1 ? 0.02 * pelletIdx : 0, drift * 2)),
+                  dir: pelletDir,
+                  age: 0,
+                  life: 0.2 + Math.random() * 0.12,
+                  trailScale: pelletCount > 1 ? 0.2 : 0.28
+                });
+              }
               if (!fx.singleShot && fx.firedBullets < bulletsToFire) {
                 playAudio(missileImpactSoundRef, { volume: 0.25 });
+              }
+            }
+            if (Array.isArray(fx.activeProjectiles) && fx.activeProjectiles.length) {
+              for (let projectileIdx = fx.activeProjectiles.length - 1; projectileIdx >= 0; projectileIdx -= 1) {
+                const projectile = fx.activeProjectiles[projectileIdx];
+                projectile.age += dt;
+                const pu = clamp01(projectile.age / Math.max(0.01, projectile.life));
+                const projectilePos = projectile.from.clone().lerp(projectile.to, pu);
+                const { pos: projectileArcPos } = getCaptureDirectStrikePose({
+                  launchPos: projectile.from,
+                  targetPos: projectile.to,
+                  progress: pu,
+                  altitude: CAPTURE_DRONE_REFERENCE_BOARD_ALTITUDE * 0.22
+                });
+                fx.missileFx.trail?.forEach((puff, idx) => {
+                  puff.position.copy(projectileArcPos).addScaledVector(projectile.dir, -0.07 - idx * 0.08);
+                  puff.scale.setScalar(Math.max(0.08, projectile.trailScale - idx * 0.05) * (1 - pu * 0.7));
+                });
+                if (pu >= 1) {
+                  launchExplosion(projectilePos);
+                  fx.activeProjectiles.splice(projectileIdx, 1);
+                }
               }
             }
 


### PR DESCRIPTION
### Motivation
- Make firearm-based capture effects configurable per piece and support more realistic multi-pellet/projectile behavior for shotguns and similar weapons.
- Improve visual fidelity of firearm firing by adjusting shooter origin and adding projectile trails and per-pellet impacts.

### Description
- Refactor `resolveFirearmCaptureProfile` to accept a `captureAnimationId` parameter and add `resolveCaptureAnimationForPiece` to select the animation id by piece group.
- Use the resolved `captureAnimationId` when spawning firearm capture FX and store it on the active firearm FX as `firearmId` and add an `activeProjectiles` array to track individual pellets.
- Adjust shooter origin calculation by changing the lerp factor from `0.24` to `0.15` to better position the muzzle point.
- Implement multi-pellet logic for shotgun-style firearms (detects `/shotgun/i`) that spawns multiple projectiles with small drift, lifetime, per-projectile trail scaling, and explosion on impact, and animate/remove them each frame.

### Testing
- Ran the project test suite with `yarn test` and linting with `yarn lint` and the automated checks completed without errors.
- Per-frame capture animations exercising firearm flows were exercised in automated FX update tests and reported no regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4970cb2588329b75ba474dffa7c1f)