### PR TITLE
Tune seated character framing, hand/throw behavior, and table/hand layout in MurlanRoyaleArena

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -109,7 +109,7 @@ const ENABLE_3D_HUMAN_CHARACTERS = true;
 const ARENA_GROWTH = 1.45; // expanded arena footprint for wider walkways
 const CHAIR_SIZE_SCALE = 1.24;
 const ARENA_PROP_SCALE = 1;
-const HUMAN_CHARACTER_EXTRA_OUTWARD_OFFSET = 0.74; // bring humans a touch closer to the table for portrait framing.
+const HUMAN_CHARACTER_EXTRA_OUTWARD_OFFSET = 1.08; // move humans visibly closer to the table for portrait framing.
 const TOP_SEAT_AVATAR_UP_LIFT = 4.9;
 const NON_HUMAN_SEAT_AVATAR_UP_LIFT = 1.0;
 const HUMAN_AVATAR_BOTTOM_OFFSET = 'calc(2.85rem + env(safe-area-inset-bottom, 0px))';
@@ -1846,12 +1846,12 @@ function createCharacterRig(instance, seatRoot, seatConfig, characterTheme, play
   applyRotationOffset(hips, THREE.MathUtils.degToRad(-9), 0, 0);
   applyRotationOffset(spine, THREE.MathUtils.degToRad(-3), 0, 0);
   applyRotationOffset(head, THREE.MathUtils.degToRad(2), 0, 0);
-  applyRotationOffset(leftUpperArm, THREE.MathUtils.degToRad(-22), THREE.MathUtils.degToRad(3), THREE.MathUtils.degToRad(2));
-  applyRotationOffset(leftForeArm, THREE.MathUtils.degToRad(-28), 0, THREE.MathUtils.degToRad(4));
-  applyRotationOffset(leftHand, THREE.MathUtils.degToRad(10), THREE.MathUtils.degToRad(6), 0);
-  applyRotationOffset(rightUpperArm, THREE.MathUtils.degToRad(-22), THREE.MathUtils.degToRad(-3), THREE.MathUtils.degToRad(-2));
-  applyRotationOffset(rightForeArm, THREE.MathUtils.degToRad(-28), 0, THREE.MathUtils.degToRad(-4));
-  applyRotationOffset(rightHand, THREE.MathUtils.degToRad(10), THREE.MathUtils.degToRad(-6), 0);
+  applyRotationOffset(leftUpperArm, THREE.MathUtils.degToRad(-40), THREE.MathUtils.degToRad(1), THREE.MathUtils.degToRad(0));
+  applyRotationOffset(leftForeArm, THREE.MathUtils.degToRad(18), 0, THREE.MathUtils.degToRad(0));
+  applyRotationOffset(leftHand, THREE.MathUtils.degToRad(2), THREE.MathUtils.degToRad(2), 0);
+  applyRotationOffset(rightUpperArm, THREE.MathUtils.degToRad(-44), THREE.MathUtils.degToRad(-2), THREE.MathUtils.degToRad(0));
+  applyRotationOffset(rightForeArm, THREE.MathUtils.degToRad(22), 0, THREE.MathUtils.degToRad(0));
+  applyRotationOffset(rightHand, THREE.MathUtils.degToRad(4), THREE.MathUtils.degToRad(-2), 0);
   // Legs rotated opposite/downward (not upward) to mirror Ludo Battle Royal seated humans.
   applyRotationOffset(leftThigh, THREE.MathUtils.degToRad(-90.5), THREE.MathUtils.degToRad(9.2), THREE.MathUtils.degToRad(2.9));
   applyRotationOffset(rightThigh, THREE.MathUtils.degToRad(-90.5), THREE.MathUtils.degToRad(1.7), THREE.MathUtils.degToRad(-1.1));
@@ -1986,7 +1986,7 @@ function attachSeatedCharacter({ template, seatConfig, characterTheme, store, pl
   const seatScale = (characterTheme.scale ?? 0.82) * CHARACTER_PROPORTION_SCALE;
   const scaleDelta = Math.max(0, CHARACTER_PROPORTION_SCALE - 1);
   seatRoot.scale.multiplyScalar(seatScale);
-  const baseSeatOffsetY = (characterTheme.normalizedSeatOffsetY ?? characterTheme.seatOffsetY ?? -0.92) - 0.08;
+  const baseSeatOffsetY = (characterTheme.normalizedSeatOffsetY ?? characterTheme.seatOffsetY ?? -0.92) - 0.2;
   const baseSeatOffsetZ = characterTheme.normalizedSeatOffsetZ ?? characterTheme.seatOffsetZ ?? -0.24;
   seatRoot.position.set(
     0,
@@ -2002,6 +2002,9 @@ function attachSeatedCharacter({ template, seatConfig, characterTheme, store, pl
   };
 
   const rig = createCharacterRig(instance, seatRoot, seatConfig, characterTheme, player, playerIndex, cardTheme, cardTextureSize);
+  if (rig?.heldCards?.parent) {
+    rig.heldCards.parent.remove(rig.heldCards);
+  }
   seatConfig.characterRig = rig;
   seatConfig.characterRoot = seatRoot;
   if (!store.characterRigs) store.characterRigs = new Map();
@@ -2044,9 +2047,9 @@ function runCharacterAction(store, rig, action) {
   if (action.type === 'PLAY') {
     const throwPrep = buildPoseVariant(basePose, {
       spine: { x: THREE.MathUtils.degToRad(-10) },
-      rightUpperArm: { x: THREE.MathUtils.degToRad(-40), y: THREE.MathUtils.degToRad(-14), z: THREE.MathUtils.degToRad(-18) },
-      rightForeArm: { x: THREE.MathUtils.degToRad(-24) },
-      rightHand: { x: THREE.MathUtils.degToRad(22), y: THREE.MathUtils.degToRad(-16) },
+      rightUpperArm: { x: THREE.MathUtils.degToRad(-52), y: THREE.MathUtils.degToRad(-10), z: THREE.MathUtils.degToRad(-12) },
+      rightForeArm: { x: THREE.MathUtils.degToRad(-6) },
+      rightHand: { x: THREE.MathUtils.degToRad(6), y: THREE.MathUtils.degToRad(-8) },
       head: { x: THREE.MathUtils.degToRad(-6) }
     });
     const throwRelease = buildPoseVariant(basePose, {
@@ -2064,15 +2067,22 @@ function runCharacterAction(store, rig, action) {
       rig.bones.rightHand.getWorldPosition(handPos);
     } else {
       rig.seatRoot.getWorldPosition(handPos);
-      handPos.add(rig.seatConfig?.forward?.clone().multiplyScalar(0.34 * MODEL_SCALE) ?? new THREE.Vector3());
-      handPos.y += 0.65 * MODEL_SCALE;
+      handPos.add(rig.seatConfig?.forward?.clone().multiplyScalar(0.16 * MODEL_SCALE) ?? new THREE.Vector3());
+      handPos.y += 0.18 * MODEL_SCALE;
+    }
+
+    const selectedCardMesh = action.cardId ? store.cardMap?.get(action.cardId)?.mesh : null;
+    const pickupPos = handPos.clone();
+    if (selectedCardMesh) {
+      selectedCardMesh.getWorldPosition(pickupPos);
+      pickupPos.y += 0.01 * MODEL_SCALE;
     }
 
     const target = (store.tableAnchor || new THREE.Vector3()).clone();
     target.y += 0.08 * MODEL_SCALE;
-    target.add((rig.seatConfig?.right || new THREE.Vector3(1, 0, 0)).clone().multiplyScalar(0.08 * MODEL_SCALE));
+    target.add((rig.seatConfig?.right || new THREE.Vector3(1, 0, 0)).clone().multiplyScalar(0.04 * MODEL_SCALE));
 
-    thrown.position.copy(handPos);
+    thrown.position.copy(pickupPos);
     thrown.lookAt(target.clone().setY(handPos.y));
 
     list.push({
@@ -2091,7 +2101,7 @@ function runCharacterAction(store, rig, action) {
           duration: 340,
           update: (t) => {
             const eased = easeInOutCubic(t);
-            thrown.position.lerpVectors(handPos, target, eased);
+            thrown.position.lerpVectors(pickupPos, target, eased);
             thrown.rotation.x = THREE.MathUtils.lerp(0, -Math.PI * 0.5, eased);
           },
           complete: () => {
@@ -2391,7 +2401,7 @@ const HUMAN_HAND_CARD_SCALE = 1.06;
 const HUMAN_HAND_CARD_SPACING = CARD_W * HUMAN_HAND_CARD_SCALE * 0.25;
 const HUMAN_HAND_CARD_MAX_SPREAD = HUMAN_HAND_CARD_SPACING * 10;
 const HUMAN_HAND_EXTRA_LIFT = 0.068 * MODEL_SCALE;
-const HUMAN_HAND_FAN_MAX_YAW = THREE.MathUtils.degToRad(15);
+const HUMAN_HAND_FAN_MAX_YAW = THREE.MathUtils.degToRad(19);
 const HUMAN_HAND_FAN_ARC_LIFT = 0.036 * MODEL_SCALE;
 const HUMAN_HAND_FAN_DIRECTION = 1;
 const HUMAN_HAND_UNIFORM_YAW_FROM_LEFT = false;
@@ -2403,13 +2413,13 @@ const HUMAN_HAND_LEFT_SHIFT = 0;
 const AI_HAND_LEFT_SHIFT = 0;
 const HUMAN_HAND_UP_SHIFT_Y = 0.108 * MODEL_SCALE;
 const HUMAN_HAND_DIRECTIONAL_LIFT = 0;
-const HUMAN_HAND_BOTTOM_INWARD_TILT_X = 0;
+const HUMAN_HAND_BOTTOM_INWARD_TILT_X = THREE.MathUtils.degToRad(4);
 const AI_HAND_CARD_SPACING = HUMAN_HAND_CARD_SPACING;
 const AI_HAND_CARD_MAX_SPREAD = HUMAN_HAND_CARD_MAX_SPREAD;
-const TOP_AI_HAND_CARD_SPACING_MULTIPLIER = 1;
-const TOP_AI_HAND_CARD_MAX_SPREAD_MULTIPLIER = 1;
-const GIFT_SIDE_AI_HAND_CARD_SPACING_MULTIPLIER = 1.06;
-const GIFT_SIDE_AI_HAND_CARD_MAX_SPREAD_MULTIPLIER = 1.08;
+const TOP_AI_HAND_CARD_SPACING_MULTIPLIER = 1.12;
+const TOP_AI_HAND_CARD_MAX_SPREAD_MULTIPLIER = 1.1;
+const GIFT_SIDE_AI_HAND_CARD_SPACING_MULTIPLIER = 1.12;
+const GIFT_SIDE_AI_HAND_CARD_MAX_SPREAD_MULTIPLIER = 1.12;
 const AI_HAND_FAN_MAX_YAW = HUMAN_HAND_FAN_MAX_YAW;
 const AI_HAND_FAN_ARC_LIFT = HUMAN_HAND_FAN_ARC_LIFT;
 const HUMAN_HAND_TABLE_EDGE_MARGIN = CARD_H * 0.04;
@@ -2437,7 +2447,7 @@ const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
 const CHAIR_GROUND_DROP = 0;
 const CHAIR_SCREEN_LOWER_OFFSET = 0.14 * MODEL_SCALE;
 const HUMAN_CHAIR_EXTRA_OUTWARD_OFFSET = 0.74 * MODEL_SCALE; // keep human chair closer to table center (portrait visual direction).
-const TABLE_HEIGHT_LIFT = 0.025 * MODEL_SCALE;
+const TABLE_HEIGHT_LIFT = 0.05 * MODEL_SCALE;
 const TABLE_HEIGHT = STOOL_HEIGHT + TABLE_HEIGHT_LIFT;
 const TABLE_SIDE_TRIM_SCALE = 1;
 const TABLE_MODEL_TARGET_DIAMETER = TABLE_RADIUS * 2.04;
@@ -3850,13 +3860,6 @@ export default function MurlanRoyaleArena({ search }) {
     state.players.forEach((player, idx) => {
       const seat = seatConfigs[idx];
       if (!seat) return;
-      refreshRigHeldCards(
-        seat.characterRig,
-        player.hand ?? [],
-        PLAYER_COLORS[idx % PLAYER_COLORS.length] ?? '#1d4ed8',
-        CARD_THEMES[appearanceRef.current.cards] ?? CARD_THEMES[0],
-        cardTextureQualityRef.current
-      );
       const cards = player.hand;
 
       const baseHeight = TABLE_HEIGHT + CARD_H / 2 + AI_CARD_LIFT + (player.isHuman ? HUMAN_HAND_EXTRA_LIFT : 0);


### PR DESCRIPTION
### Motivation

- Improve portrait framing by moving human characters closer to the table and adjusting seat offsets to avoid clipping. 
- Make seated character arms/legs and play animations look more natural and readable when throwing cards. 
- Ensure thrown cards originate from the actual card mesh when available and reduce visual offset artifacts. 
- Tweak hand fan angles, AI spacing multipliers, and table height for better visual balance.

### Description

- Increased `HUMAN_CHARACTER_EXTRA_OUTWARD_OFFSET` and lowered `baseSeatOffsetY` to shift humans closer and slightly lower for portrait framing. 
- Updated pose rotation offsets in `createCharacterRig` for upper/lower arms and hands and adjusted the `PLAY` action pose in `runCharacterAction` to new angle values. 
- Changed fallback hand world-position math and introduced `pickupPos` which uses the selected card mesh world position when available, and updated thrown mesh positioning and flight interpolation to use `pickupPos`. 
- Removed potential duplicate held-cards attachment by detaching `rig.heldCards` from its parent if present and removed the inline `refreshRigHeldCards` call in `applyStateToScene`. 
- Tuned constants: increased `HUMAN_HAND_FAN_MAX_YAW`, enabled a small `HUMAN_HAND_BOTTOM_INWARD_TILT_X`, raised `TABLE_HEIGHT_LIFT`, and adjusted several AI hand spacing multipliers (`TOP_AI_HAND_CARD_SPACING_MULTIPLIER`, `TOP_AI_HAND_CARD_MAX_SPREAD_MULTIPLIER`, `GIFT_SIDE_AI_HAND_CARD_SPACING_MULTIPLIER`, `GIFT_SIDE_AI_HAND_CARD_MAX_SPREAD_MULTIPLIER`) as well as minor target offsets used during throws.

### Testing

- Ran the frontend unit test suite with `yarn test` and all tests passed. 
- Ran the linter with `yarn lint` and no lint errors were reported. 
- Launched the development build (`yarn start`) and exercised character seating, hand display, and play/throw animations with no runtime errors observed in the console.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f49b873d94832991e97ceba5abd308)