### PR TITLE
Pool Royale: use local human rig behavior as main runtime source

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -532,10 +532,10 @@ function updateBilardoHumanPose(human, dt, frameData) {
   };
 })();
 
-// Use stable shared GLTF rig pipeline (known-good loading), while keeping local rig code available for reference.
-const createBilardoHumanRig = sharedCreateBilardoHumanRig;
-const chooseBilardoHumanEdgePosition = sharedChooseBilardoHumanEdgePosition;
-const updateBilardoHumanPose = sharedUpdateBilardoHumanPose;
+// Use the local Pool Royale human rig implementation as the single source of truth for walk/aim/shot behavior.
+const createBilardoHumanRig = bilardoRigLocal.createBilardoHumanRig;
+const chooseBilardoHumanEdgePosition = bilardoRigLocal.chooseBilardoHumanEdgePosition;
+const updateBilardoHumanPose = bilardoRigLocal.updateBilardoHumanPose;
 
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/v1/decoders/';
 const BASIS_TRANSCODER_PATH =


### PR DESCRIPTION
### Motivation
- The human character behavior must use the in-file/local rig implementation as the authoritative source for walking/aiming/shot behavior instead of the shared helper, keeping the runtime size/structure unchanged.

### Description
- Rebound the runtime bindings in `webapp/src/pages/Games/PoolRoyale.jsx` to use the local `bilardoRigLocal` implementation instead of the shared helpers by replacing the three exported bindings: `createBilardoHumanRig`, `chooseBilardoHumanEdgePosition`, and `updateBilardoHumanPose`.
- The change is limited to the runtime selection lines so the existing local rig code remains available in-file and becomes the active behavior source without further structural modifications.
- File touched: `webapp/src/pages/Games/PoolRoyale.jsx` (three-line replacement near the rig exports).

### Testing
- Ran `npm -s run test -- test/poolRoyaleCueStrokeTimeline.test.js` and the suite passed (1 test suite, 4 tests, all passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f49eba681c8329b2f1ff1e03f1bd37)