### PR TITLE
Adjust seated character positioning and chair spacing in Murlan Royale arena

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -109,7 +109,8 @@ const ENABLE_3D_HUMAN_CHARACTERS = true;
 const ARENA_GROWTH = 1.45; // expanded arena footprint for wider walkways
 const CHAIR_SIZE_SCALE = 1.24;
 const ARENA_PROP_SCALE = 1;
-const HUMAN_CHARACTER_EXTRA_OUTWARD_OFFSET = 1.08; // move humans visibly closer to the table for portrait framing.
+const HUMAN_CHARACTER_EXTRA_OUTWARD_OFFSET = 0.88; // reduce backward pull so seated humans appear closer to the table.
+const HUMAN_CHARACTER_EXTRA_LOWER_OFFSET = 0.18; // seat humans lower so hips/legs rest properly on the chair cushion.
 const TOP_SEAT_AVATAR_UP_LIFT = 4.9;
 const NON_HUMAN_SEAT_AVATAR_UP_LIFT = 1.0;
 const HUMAN_AVATAR_BOTTOM_OFFSET = 'calc(2.85rem + env(safe-area-inset-bottom, 0px))';
@@ -1990,7 +1991,7 @@ function attachSeatedCharacter({ template, seatConfig, characterTheme, store, pl
   const baseSeatOffsetZ = characterTheme.normalizedSeatOffsetZ ?? characterTheme.seatOffsetZ ?? -0.24;
   seatRoot.position.set(
     0,
-    baseSeatOffsetY - 0.22 - scaleDelta * 0.08,
+    baseSeatOffsetY - 0.22 - scaleDelta * 0.08 - HUMAN_CHARACTER_EXTRA_LOWER_OFFSET,
     baseSeatOffsetZ - 0.03 - HUMAN_CHARACTER_EXTRA_OUTWARD_OFFSET
   );
   seatRoot.rotation.set(characterTheme.seatPitch ?? 0, characterTheme.seatYaw ?? 0, 0);
@@ -2371,7 +2372,7 @@ const ARM_HEIGHT = 0.3 * MODEL_SCALE * STOOL_SCALE;
 const ARM_DEPTH = SEAT_DEPTH * 0.75;
 const BASE_COLUMN_HEIGHT = 0.56 * MODEL_SCALE * STOOL_SCALE;
 const BASE_TABLE_HEIGHT = 0.94 * MODEL_SCALE;
-const CHAIR_GAP = 0.152 * MODEL_SCALE;
+const CHAIR_GAP = 0.19 * MODEL_SCALE; // push chairs slightly farther from the table ring.
 const CHAIR_RADIUS = TABLE_RADIUS + SEAT_DEPTH * 0.5 + CHAIR_GAP;
 const AI_CHAIR_GAP = CHAIR_GAP;
 const AI_CHAIR_RADIUS = CHAIR_RADIUS;


### PR DESCRIPTION
### Motivation
- Improve visual seating of 3D human characters so hips/legs sit more naturally and seated humans appear closer to the table without over-pulling them backward.
- Reduce crowding by pushing chairs slightly farther from the table ring to improve spacing and composition.

### Description
- Reduced the outward/backward offset for human characters by changing `HUMAN_CHARACTER_EXTRA_OUTWARD_OFFSET` from `1.08` to `0.88` and updated the explanatory comment.
- Added `HUMAN_CHARACTER_EXTRA_LOWER_OFFSET = 0.18` and applied it to the character `seatRoot.position.y` to lower seated humans so hips/legs rest properly on the chair cushion.
- Increased `CHAIR_GAP` from `0.152 * MODEL_SCALE` to `0.19 * MODEL_SCALE` and updated the inline comment to reflect the increased distance.
- Kept other related layout and scale constants intact so the changes only affect seated character vertical/outward positioning and chair spacing.

### Testing
- Ran the unit test suite with `yarn test` and all tests passed. 
- Ran linter with `yarn lint` and no lint errors were reported. 
- Built the webapp with `yarn build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4a8a366188329883f1bee72cca971)