### PR TITLE
Adjust Murlan Royale human/card table framing

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -110,7 +110,7 @@ const ARENA_GROWTH = 1.45; // expanded arena footprint for wider walkways
 const CHAIR_SIZE_SCALE = 1.24;
 const CHAIR_HEIGHT_TRIM_SCALE = 0.96;
 const ARENA_PROP_SCALE = 1;
-const HUMAN_CHARACTER_EXTRA_OUTWARD_OFFSET = 0.68; // bring seated humans closer to the table on portrait mobile framing.
+const HUMAN_CHARACTER_EXTRA_OUTWARD_OFFSET = 0.74; // bring seated humans slightly closer to the table on portrait mobile framing.
 const HUMAN_CHARACTER_EXTRA_LOWER_OFFSET = 0.18; // seat humans lower so hips/legs rest properly on the chair cushion.
 const TOP_SEAT_AVATAR_UP_LIFT = 4.9;
 const NON_HUMAN_SEAT_AVATAR_UP_LIFT = 1.0;
@@ -1803,11 +1803,11 @@ function createCharacterRig(instance, seatRoot, seatConfig, characterTheme, play
       : 0;
   heldCards.position.set(
     sideSeatLateralPull,
-    0.7 * MODEL_SCALE + sideSeatLift,
-    0.95 * MODEL_SCALE + sideSeatForward
+    0.78 * MODEL_SCALE + sideSeatLift,
+    1.04 * MODEL_SCALE + sideSeatForward
   );
   heldCards.rotation.set(THREE.MathUtils.degToRad(-18), THREE.MathUtils.degToRad(0), THREE.MathUtils.degToRad(0));
-  heldCards.scale.setScalar(1.45);
+  heldCards.scale.setScalar(1.32);
 
   if (!leftThigh || !rightThigh) {
     instance.position.y -= 0.02 * MODEL_SCALE;
@@ -1916,9 +1916,9 @@ function refreshRigHeldCards(rig, handCardsInput, playerColor, cardTheme, cardTe
   nextCards.userData.cardsSignature = cardsSignature;
 
   rig.instance.add(nextCards);
-  nextCards.position.set(0.0 * MODEL_SCALE, 0.7 * MODEL_SCALE, 0.95 * MODEL_SCALE);
+  nextCards.position.set(0.0 * MODEL_SCALE, 0.78 * MODEL_SCALE, 1.04 * MODEL_SCALE);
   nextCards.rotation.set(THREE.MathUtils.degToRad(-18), THREE.MathUtils.degToRad(0), THREE.MathUtils.degToRad(0));
-  nextCards.scale.setScalar(1.45);
+  nextCards.scale.setScalar(1.32);
 
   rig.heldCards = nextCards;
 }


### PR DESCRIPTION
### Motivation

- Improve portrait mobile framing by bringing seated human characters visually closer to the table.
- Make player cards appear slightly smaller for better composition and less occlusion.
- Raise and push player-held cards outward so hands read clearer and sit higher in the view.

### Description

- Increased `HUMAN_CHARACTER_EXTRA_OUTWARD_OFFSET` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` from `0.68` to `0.74` to move seated characters closer to the table.
- Raised held-card placement by changing the Y position from `0.7 * MODEL_SCALE` to `0.78 * MODEL_SCALE` and pushed them outward by changing the Z position from `0.95 * MODEL_SCALE` to `1.04 * MODEL_SCALE` in the character rig setup.
- Reduced held-card visual scale from `1.45` to `1.32` on both initial rig creation and in `refreshRigHeldCards` so cards render smaller consistently.

### Testing

- Ran `npm test -- test/murlan.test.js --runInBand` and the suite passed (`Test Suites: 1 passed`, `Tests: 12 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4e7ae573483298a5e6df12f613ad2)