### PR TITLE
Lock camera position during Ludo custom-look drag

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -9405,6 +9405,9 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         cameraLookStateRef.current.lastX = clientX;
         cameraLookStateRef.current.lastY = clientY;
         cameraLookStateRef.current.lockedPosition = camera.position.clone();
+        // Freeze OrbitControls while using custom look so drag only rotates view
+        // and never shifts/lifts camera position.
+        controls.enabled = false;
       }
     };
     onPointerMove = (event) => {
@@ -9449,6 +9452,10 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       if (pointerLocked) {
         pointerLocked = false;
         if (controls) controls.enabled = true;
+        return;
+      }
+      if (lookState.active === false && controls) {
+        controls.enabled = true;
       }
     };
     renderer.domElement.addEventListener('pointerdown', onPointerDown, { passive: false });


### PR DESCRIPTION
### Motivation
- Prevent the camera from drifting or being lifted when the player uses the custom look drag so the view can rotate while the camera position stays fixed.

### Description
- Disabled `OrbitControls` while the custom-look gesture is active, re-enabled controls on pointer release, and added an early return to avoid conflicting state transitions in `webapp/src/pages/Games/LudoBattleRoyal.jsx`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f56f477d84832987fa1b8ac15f38bb)