### PR TITLE
Prevent camera lifting when looking around in Ludo Battle Royal

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -9037,6 +9037,11 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     controls.minPolarAngle = CAM.phiMin;
     controls.maxPolarAngle = CAM.phiMax;
     controls.target.copy(boardLookTarget);
+    const initialPolar = controls.getPolarAngle();
+    // Keep camera at a fixed seated height while still allowing left/right look.
+    // This prevents upward drift when users look around on portrait/mobile.
+    controls.minPolarAngle = initialPolar;
+    controls.maxPolarAngle = initialPolar;
     const initialAzimuth = controls.getAzimuthalAngle();
     controls.minAzimuthAngle = Number.isFinite(CAMERA_FREE_LOOK_AZIMUTH_RANGE)
       ? initialAzimuth - CAMERA_FREE_LOOK_AZIMUTH_RANGE


### PR DESCRIPTION
### Motivation
- The in-game camera was drifting/lifting vertically when players looked around (notably on portrait/mobile), so the change keeps the camera at a stable seated height while preserving left/right look.

### Description
- In `webapp/src/pages/Games/LudoBattleRoyal.jsx` lock the OrbitControls polar angle after setup by adding `const initialPolar = controls.getPolarAngle(); controls.minPolarAngle = initialPolar; controls.maxPolarAngle = initialPolar;` immediately after `controls.target.copy(boardLookTarget);` to prevent upward drift.

### Testing
- No automated tests were executed for this small camera-control tweak.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f56f477d84832987fa1b8ac15f38bb)