### PR TITLE
Adjust seated character offsets and held-card geometry/positioning for better portrait layout

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -110,7 +110,7 @@ const ARENA_GROWTH = 1.45; // expanded arena footprint for wider walkways
 const CHAIR_SIZE_SCALE = 1.24;
 const CHAIR_HEIGHT_TRIM_SCALE = 0.96;
 const ARENA_PROP_SCALE = 1;
-const HUMAN_CHARACTER_EXTRA_OUTWARD_OFFSET = 0.68; // bring seated humans closer to the table on portrait mobile framing.
+const HUMAN_CHARACTER_EXTRA_OUTWARD_OFFSET = 0.62; // nudge seated humans just a bit closer to the table on portrait mobile framing.
 const HUMAN_CHARACTER_EXTRA_LOWER_OFFSET = 0.18; // seat humans lower so hips/legs rest properly on the chair cushion.
 const TOP_SEAT_AVATAR_UP_LIFT = 4.9;
 const NON_HUMAN_SEAT_AVATAR_UP_LIFT = 1.0;
@@ -1675,7 +1675,7 @@ function createCharacterCards({ handLift = 0.96, handCardsInput = [], cardTheme 
     ? handCardsInput.slice(0, 5)
     : [{ rank: 'A', suit: '♠' }, { rank: 'K', suit: '♥' }, { rank: 'Q', suit: '♣' }];
   const safeCount = Math.max(handCards.length, 2);
-  const cardGeometry = createCardGeometry(0.2 * MODEL_SCALE, 0.29 * MODEL_SCALE, 0.01 * MODEL_SCALE, {
+  const cardGeometry = createCardGeometry(0.186 * MODEL_SCALE, 0.27 * MODEL_SCALE, 0.01 * MODEL_SCALE, {
     rounded: true,
     cornerRadiusRatio: 0.18,
     segments: 14
@@ -1803,11 +1803,11 @@ function createCharacterRig(instance, seatRoot, seatConfig, characterTheme, play
       : 0;
   heldCards.position.set(
     sideSeatLateralPull,
-    0.7 * MODEL_SCALE + sideSeatLift,
-    0.95 * MODEL_SCALE + sideSeatForward
+    0.76 * MODEL_SCALE + sideSeatLift,
+    0.86 * MODEL_SCALE + sideSeatForward
   );
   heldCards.rotation.set(THREE.MathUtils.degToRad(-18), THREE.MathUtils.degToRad(0), THREE.MathUtils.degToRad(0));
-  heldCards.scale.setScalar(1.45);
+  heldCards.scale.setScalar(1.3);
 
   if (!leftThigh || !rightThigh) {
     instance.position.y -= 0.02 * MODEL_SCALE;
@@ -1916,9 +1916,9 @@ function refreshRigHeldCards(rig, handCardsInput, playerColor, cardTheme, cardTe
   nextCards.userData.cardsSignature = cardsSignature;
 
   rig.instance.add(nextCards);
-  nextCards.position.set(0.0 * MODEL_SCALE, 0.7 * MODEL_SCALE, 0.95 * MODEL_SCALE);
+  nextCards.position.set(0.0 * MODEL_SCALE, 0.76 * MODEL_SCALE, 0.86 * MODEL_SCALE);
   nextCards.rotation.set(THREE.MathUtils.degToRad(-18), THREE.MathUtils.degToRad(0), THREE.MathUtils.degToRad(0));
-  nextCards.scale.setScalar(1.45);
+  nextCards.scale.setScalar(1.3);
 
   rig.heldCards = nextCards;
 }


### PR DESCRIPTION
### Motivation
- Improve seated human placement and card visuals to better fit portrait mobile framing and overall visual balance.

### Description
- Reduce `HUMAN_CHARACTER_EXTRA_OUTWARD_OFFSET` from `0.68` to `0.62` and update the inline comment to reflect the smaller nudge toward the table.
- Shrink character-held card geometry in `createCardGeometry` from `(0.2, 0.29)` to `(0.186, 0.27)` while preserving rounded corners and segment settings.
- Adjust held-card placement and scale by moving positions from `(0.7, 0.95)` to `(0.76, 0.86)` and changing the card scale from `1.45` to `1.3` in both `createCharacterRig` and `refreshRigHeldCards`.
- No changes were made to non-rendering logic or public APIs; this is purely a rendering/UX tweak.

### Testing
- Ran `yarn test` (unit tests) which passed.
- Ran `yarn build` which completed successfully.
- Ran `yarn lint` which reported no new issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4e7ae573483298a5e6df12f613ad2)