### PR TITLE
Freeze camera position during custom-look and ensure OrbitControls state is correct

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -9376,6 +9376,17 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       camera.lookAt(target);
     };
 
+    const enforceCustomLookCameraLock = () => {
+      if (!controls || !camera || isCamera2d || !LUDO_CAMERA_CUSTOM_LOOK_ENABLED) return;
+      const lockedPosition = cameraLookStateRef.current.lockedPosition;
+      if (!lockedPosition?.isVector3) return;
+      const target = getCameraLookTarget();
+      if (!target) return;
+      camera.position.copy(lockedPosition);
+      controls.target.copy(target);
+      camera.lookAt(target);
+    };
+
     let pointerLocked = false;
     let onPointerMove = null;
     onPointerDown = (event) => {
@@ -9405,6 +9416,9 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         cameraLookStateRef.current.lastX = clientX;
         cameraLookStateRef.current.lastY = clientY;
         cameraLookStateRef.current.lockedPosition = camera.position.clone();
+        // Freeze OrbitControls while using custom look so drag only rotates view
+        // and never shifts/lifts camera position.
+        controls.enabled = false;
       }
     };
     onPointerMove = (event) => {
@@ -9449,6 +9463,10 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       if (pointerLocked) {
         pointerLocked = false;
         if (controls) controls.enabled = true;
+        return;
+      }
+      if (lookState.active === false && controls) {
+        controls.enabled = true;
       }
     };
     renderer.domElement.addEventListener('pointerdown', onPointerDown, { passive: false });
@@ -9734,7 +9752,11 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           applyCameraLookOffset({ recenter: !cameraLookStateRef.current.active });
         }
       }
+      // Hard-lock position every frame during custom look so gameplay camera
+      // systems can still retarget view without ever moving the camera anchor.
+      enforceCustomLookCameraLock();
       controls?.update();
+      enforceCustomLookCameraLock();
       renderer.render(scene, camera);
       animationId = requestAnimationFrame(step);
     };


### PR DESCRIPTION
### Motivation
- Prevent the camera anchor from shifting while the player is using the custom-look drag so the view rotates in-place and gameplay camera systems can still retarget view without moving the camera anchor. 
- Ensure `OrbitControls` does not inadvertently move or re-enable during custom-look interactions, and avoid conflicting re-enable logic after pointer events.

### Description
- Added `enforceCustomLookCameraLock` to hard-lock the camera position to `cameraLookStateRef.current.lockedPosition` and target the computed look target when custom-look is enabled. 
- Freeze `OrbitControls` on pointer down for custom-look by setting `controls.enabled = false`, and updated pointer-up handling to correctly re-enable controls only when appropriate. 
- Call `enforceCustomLookCameraLock()` every animation frame (before and after `controls.update()`) so the camera position is maintained throughout rendering and control updates. 

### Testing
- Ran the repository linting (`yarn lint`) and static checks, which completed successfully. 
- Ran the unit test suite (`yarn test`), and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f56f477d84832987fa1b8ac15f38bb)