### PR TITLE
Tune Murlan Royale camera, top-seat card framing, and avatar arm pose

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1795,8 +1795,8 @@ function createCharacterRig(instance, seatRoot, seatConfig, characterTheme, play
   const resolvedSeatIndex = seatConfig?.seatIndex ?? playerIndex;
   const isBottomHumanSeat = Boolean(player?.isHuman);
   const isSideSeat = !isBottomHumanSeat && ((resolvedSeatIndex % CHAIR_COUNT) === 1 || (resolvedSeatIndex % CHAIR_COUNT) === 3);
-  const sideSeatLift = isSideSeat ? 0.2 * MODEL_SCALE : 0;
-  const sideSeatForward = isSideSeat ? 0.06 * MODEL_SCALE : 0;
+  const sideSeatLift = isSideSeat ? 0.24 * MODEL_SCALE : 0;
+  const sideSeatForward = isSideSeat ? 0.1 * MODEL_SCALE : 0;
   const sideSeatLateralPull =
     isSideSeat
       ? ((resolvedSeatIndex % CHAIR_COUNT) === 1 ? -0.045 * MODEL_SCALE : 0.045 * MODEL_SCALE)
@@ -1861,11 +1861,11 @@ function createCharacterRig(instance, seatRoot, seatConfig, characterTheme, play
   applyRotationOffset(hips, THREE.MathUtils.degToRad(-9), 0, 0);
   applyRotationOffset(spine, THREE.MathUtils.degToRad(-3), 0, 0);
   applyRotationOffset(head, THREE.MathUtils.degToRad(2), 0, 0);
-  applyRotationOffset(leftUpperArm, THREE.MathUtils.degToRad(-40), THREE.MathUtils.degToRad(1), THREE.MathUtils.degToRad(0));
-  applyRotationOffset(leftForeArm, THREE.MathUtils.degToRad(18), 0, THREE.MathUtils.degToRad(0));
+  applyRotationOffset(leftUpperArm, THREE.MathUtils.degToRad(-48), THREE.MathUtils.degToRad(1), THREE.MathUtils.degToRad(0));
+  applyRotationOffset(leftForeArm, THREE.MathUtils.degToRad(22), 0, THREE.MathUtils.degToRad(0));
   applyRotationOffset(leftHand, THREE.MathUtils.degToRad(2), THREE.MathUtils.degToRad(2), 0);
-  applyRotationOffset(rightUpperArm, THREE.MathUtils.degToRad(-44), THREE.MathUtils.degToRad(-2), THREE.MathUtils.degToRad(0));
-  applyRotationOffset(rightForeArm, THREE.MathUtils.degToRad(22), 0, THREE.MathUtils.degToRad(0));
+  applyRotationOffset(rightUpperArm, THREE.MathUtils.degToRad(-52), THREE.MathUtils.degToRad(-2), THREE.MathUtils.degToRad(0));
+  applyRotationOffset(rightForeArm, THREE.MathUtils.degToRad(26), 0, THREE.MathUtils.degToRad(0));
   applyRotationOffset(rightHand, THREE.MathUtils.degToRad(4), THREE.MathUtils.degToRad(-2), 0);
   // Legs rotated opposite/downward (not upward) to mirror Ludo Battle Royal seated humans.
   applyRotationOffset(leftThigh, THREE.MathUtils.degToRad(-90.5), THREE.MathUtils.degToRad(9.2), THREE.MathUtils.degToRad(2.9));
@@ -2435,8 +2435,8 @@ const TOP_AI_HAND_CARD_SPACING_MULTIPLIER = 0.94;
 const TOP_AI_HAND_CARD_MAX_SPREAD_MULTIPLIER = 0.9;
 const SIDE_AI_HAND_CARD_SPACING_MULTIPLIER = 0.92;
 const SIDE_AI_HAND_CARD_MAX_SPREAD_MULTIPLIER = 0.88;
-const AI_TOP_SIDE_HAND_UP_SHIFT_Y = 0.06 * MODEL_SCALE;
-const AI_TOP_SIDE_HAND_OUTWARD_PUSH = 0.06 * MODEL_SCALE;
+const AI_TOP_SIDE_HAND_UP_SHIFT_Y = 0.09 * MODEL_SCALE;
+const AI_TOP_SIDE_HAND_OUTWARD_PUSH = 0.1 * MODEL_SCALE;
 const AI_HAND_FAN_MAX_YAW = HUMAN_HAND_FAN_MAX_YAW;
 const AI_HAND_FAN_ARC_LIFT = HUMAN_HAND_FAN_ARC_LIFT;
 const HUMAN_HAND_TABLE_EDGE_MARGIN = CARD_H * 0.04;
@@ -5316,7 +5316,7 @@ export default function MurlanRoyaleArena({ search }) {
       const safeHorizontalReach = Math.max(2.6 * MODEL_SCALE, cameraBoundRadius);
       const maxOrbitRadius = Math.max(3.6 * MODEL_SCALE, safeHorizontalReach / Math.sin(ARENA_CAMERA_DEFAULTS.phiMax));
       const minOrbitRadius = Math.max(2.4 * MODEL_SCALE, maxOrbitRadius * 0.58);
-      const desiredRadius = Math.min(maxOrbitRadius, minOrbitRadius * 1.1) * CAMERA_INWARD_RADIUS_FACTOR * 0.9;
+      const desiredRadius = Math.min(maxOrbitRadius, minOrbitRadius * 1.1) * CAMERA_INWARD_RADIUS_FACTOR * 0.86;
       spherical.radius = desiredRadius;
       spherical.phi = THREE.MathUtils.clamp(
         spherical.phi,


### PR DESCRIPTION
### Motivation
- Subtly move the gameplay camera closer to the table on portrait mobile so the table reads better while keeping the change small and non-disruptive.
- Raise and push outward only the top/side opponent held-card groups so the top-left and top-right player cards appear higher and more outward on screen without touching the bottom human player or community/discard piles.
- Bring seated human avatar forearms/hands slightly closer to their held cards and a touch lower for a more natural resting reach.

### Description
- Tuned the initial orbit radius used for the seated camera by reducing the inward multiplier from `0.9` to `0.86` to move the camera just a bit closer to the table (`webapp/src/pages/Games/MurlanRoyaleArena.jsx`).
- Increased top/side seat held-card positioning by raising `sideSeatLift` from `0.2 * MODEL_SCALE` to `0.24 * MODEL_SCALE` and `sideSeatForward` from `0.06 * MODEL_SCALE` to `0.1 * MODEL_SCALE` so top-left/top-right card groups sit higher and more outward on screen.
- Increased AI top/side hand offsets `AI_TOP_SIDE_HAND_UP_SHIFT_Y` and `AI_TOP_SIDE_HAND_OUTWARD_PUSH` from `0.06 * MODEL_SCALE` to `0.09 * MODEL_SCALE` and from `0.06 * MODEL_SCALE` to `0.1 * MODEL_SCALE` respectively to reinforce the visual lift/outward push for those seats.
- Adjusted seated avatar base arm rotations to move forearms/hands closer/lower by changing `applyRotationOffset` angles for `leftUpperArm`, `leftForeArm`, `rightUpperArm`, and `rightForeArm` (small integer-degree tweaks) to improve resting reach and card proximity.
- All edits are confined to `webapp/src/pages/Games/MurlanRoyaleArena.jsx` and intentionally keep other card transforms (bottom human, community, discard/used pile) untouched.

### Testing
- No automated tests were executed as part of this change; visual verification and in-game playthroughs are recommended to confirm the intended portrait-screen framing and avatar pose adjustments.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5789409388329b325fd50d56cfec5)