### PR TITLE
Freeze OrbitControls during custom camera look and ensure lifted follow target is used

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -9405,6 +9405,9 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         cameraLookStateRef.current.lastX = clientX;
         cameraLookStateRef.current.lastY = clientY;
         cameraLookStateRef.current.lockedPosition = camera.position.clone();
+        // Freeze OrbitControls while using custom look so drag only rotates view
+        // and never shifts/lifts camera position.
+        controls.enabled = false;
       }
     };
     onPointerMove = (event) => {
@@ -9449,6 +9452,10 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       if (pointerLocked) {
         pointerLocked = false;
         if (controls) controls.enabled = true;
+        return;
+      }
+      if (lookState.active === false && controls) {
+        controls.enabled = true;
       }
     };
     renderer.domElement.addEventListener('pointerdown', onPointerDown, { passive: false });
@@ -9725,7 +9732,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             const followCameraTarget = liftedTarget.target.clone().add(cameraTurnStateRef.current.followOffset);
             camera.position.lerp(followCameraTarget, 0.12);
           }
-          cameraTurnStateRef.current.currentTarget = controls.target.clone();
+          cameraTurnStateRef.current.currentTarget = liftedTarget.target.clone();
         }
       }
 


### PR DESCRIPTION
### Motivation

- Prevent OrbitControls from shifting the camera position while the user is performing a custom drag-look gesture.  
- Ensure the camera follow logic uses the lifted focus target instead of the raw `controls.target` when computing the current follow target.  

### Description

- Freeze `OrbitControls` by setting `controls.enabled = false` when entering the custom look mode so drag-only input rotates the view without moving the camera.  
- Adjust pointer-up logic to avoid re-enabling `controls` prematurely by returning early when `pointerLocked` was handled and only re-enabling when `lookState.active === false`.  
- Replace `cameraTurnStateRef.current.currentTarget = controls.target.clone()` with `liftedTarget.target.clone()` so the follow target reflects the lifted focus calculation.  

### Testing

- Ran the app build process with `yarn build` and the build completed successfully.  
- Executed the unit test suite with `yarn test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f56f477d84832987fa1b8ac15f38bb)