### PR TITLE
Prevent OrbitControls from affecting camera during custom look and refine pointer handling

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -9405,6 +9405,9 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         cameraLookStateRef.current.lastX = clientX;
         cameraLookStateRef.current.lastY = clientY;
         cameraLookStateRef.current.lockedPosition = camera.position.clone();
+        // Freeze OrbitControls while using custom look so drag only rotates view
+        // and never shifts/lifts camera position.
+        controls.enabled = false;
       }
     };
     onPointerMove = (event) => {
@@ -9437,7 +9440,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       if (stateRef.current?.turn === 0) {
         preserveUserTurnCameraRef.current = true;
       }
-      controls?.update();
+      // Keep OrbitControls from applying any orbit/pan deltas while custom look is active.
     };
     onPointerUp = (event) => {
       const lookState = cameraLookStateRef.current;
@@ -9449,6 +9452,10 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       if (pointerLocked) {
         pointerLocked = false;
         if (controls) controls.enabled = true;
+        return;
+      }
+      if (lookState.active === false && controls) {
+        controls.enabled = true;
       }
     };
     renderer.domElement.addEventListener('pointerdown', onPointerDown, { passive: false });
@@ -9715,7 +9722,8 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         !isCamera2d &&
         cameraTurnStateRef.current.followObject?.isObject3D &&
         controls &&
-        !LUDO_CAMERA_SEAT_LOCK_ENABLED
+        !LUDO_CAMERA_SEAT_LOCK_ENABLED &&
+        !cameraLookStateRef.current.active
       ) {
         const followedTarget = cameraTurnStateRef.current.followObject.getWorldPosition(new THREE.Vector3());
         const liftedTarget = resolveFocusCameraState(followedTarget, CAMERA_TARGET_LIFT + 0.02);
@@ -9734,7 +9742,7 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
           applyCameraLookOffset({ recenter: !cameraLookStateRef.current.active });
         }
       }
-      controls?.update();
+      // Keep OrbitControls from applying any orbit/pan deltas while custom look is active.
       renderer.render(scene, camera);
       animationId = requestAnimationFrame(step);
     };


### PR DESCRIPTION
### Motivation
- Prevent `OrbitControls` from applying orbit/pan/lift deltas while the custom camera look feature is active so drag only rotates the view and does not shift camera position. 
- Ensure consistent enable/disable handling for `controls` when pointer interactions such as quick-swap, selection, dice roll, or custom look begin and end. 

### Description
- Disable `controls` when starting custom look by setting `controls.enabled = false` in the pointerdown handler. 
- Remove unconditional `controls?.update()` calls so `OrbitControls` does not apply orbit/pan deltas while custom look is active. 
- Update `pointerup` handling to early-return after restoring `controls` when `pointerLocked` was set, and to re-enable `controls` only when the custom look is inactive. 
- Skip camera follow position adjustments while `cameraLookStateRef.current.active` is true to avoid competing camera transforms. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f56f477d84832987fa1b8ac15f38bb)