### PR TITLE
Freeze OrbitControls during custom camera look and enforce seat-lock position

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -9405,6 +9405,9 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         cameraLookStateRef.current.lastX = clientX;
         cameraLookStateRef.current.lastY = clientY;
         cameraLookStateRef.current.lockedPosition = camera.position.clone();
+        // Freeze OrbitControls while using custom look so drag only rotates view
+        // and never shifts/lifts camera position.
+        controls.enabled = false;
       }
     };
     onPointerMove = (event) => {
@@ -9449,6 +9452,10 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       if (pointerLocked) {
         pointerLocked = false;
         if (controls) controls.enabled = true;
+        return;
+      }
+      if (lookState.active === false && controls) {
+        controls.enabled = true;
       }
     };
     renderer.domElement.addEventListener('pointerdown', onPointerDown, { passive: false });
@@ -9726,6 +9733,17 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
             camera.position.lerp(followCameraTarget, 0.12);
           }
           cameraTurnStateRef.current.currentTarget = controls.target.clone();
+        }
+      }
+
+      if (!isCamera2d && camera && LUDO_CAMERA_SEAT_LOCK_ENABLED) {
+        const hardLockedPosition = cameraLookStateRef.current.lockedPosition?.isVector3
+          ? cameraLookStateRef.current.lockedPosition
+          : cameraSeatLockPositionRef.current?.isVector3
+            ? cameraSeatLockPositionRef.current
+            : null;
+        if (hardLockedPosition) {
+          camera.position.copy(hardLockedPosition);
         }
       }
 


### PR DESCRIPTION
### Motivation
- Prevent `OrbitControls` from shifting or lifting the camera while using the custom look drag so dragging only rotates the view.
- Avoid accidentally toggling `controls.enabled` twice on pointer release which could leave controls in the wrong state.
- Ensure the camera respects a hard seat-lock when `LUDO_CAMERA_SEAT_LOCK_ENABLED` to prevent camera drift during locked states.

### Description
- Disable `controls` when entering custom look in `onPointerDown` by setting `controls.enabled = false` so the view drag cannot change camera position.
- Add an early `return` in `onPointerUp` after handling the `pointerLocked` path to stop redundant re-enabling of `controls`.
- In the animation `step` loop, when `LUDO_CAMERA_SEAT_LOCK_ENABLED` copy the `lockedPosition` (from `cameraLookStateRef.current.lockedPosition` or `cameraSeatLockPositionRef.current`) into `camera.position` to hard-lock the camera.

### Testing
- Ran the unit test suite with `yarn test` and all tests passed.
- Ran the linter with `yarn lint` and there were no lint errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f56f477d84832987fa1b8ac15f38bb)