### PR TITLE
Snooker: tighten human cue stance and add eye‑level cue camera

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -17846,6 +17846,42 @@ const powerRef = useRef(hud.power);
               syncBlendToSpherical();
             }
           }
+
+          const cueViewReady =
+            humanActor?.visible &&
+            cueStick?.visible &&
+            cue?.active &&
+            !shooting &&
+            !replayPlaybackRef.current;
+          const cueViewBlend = THREE.MathUtils.clamp(
+            (TMP_SPH.phi - (CAMERA.maxPhi - 0.26)) / 0.18,
+            0,
+            1
+          );
+          if (cueViewReady && cueViewBlend > 0) {
+            const cueYaw = cueStick.rotation.y;
+            const cueForward = TMP_VEC3_A.set(
+              Math.sin(cueYaw - Math.PI),
+              0,
+              Math.cos(cueYaw - Math.PI)
+            ).normalize();
+            const cueSide = TMP_VEC3_B.set(cueForward.z, 0, -cueForward.x).normalize();
+            const eyeHeight = 1.58 * worldScaleFactor;
+            const eyeOffsetBack = 0.4 * worldScaleFactor;
+            const eyeOffsetSide = -0.08 * worldScaleFactor;
+            const eyePos = TMP_VEC3_C
+              .copy(humanActor.position)
+              .addScaledVector(cueForward, eyeOffsetBack)
+              .addScaledVector(cueSide, eyeOffsetSide);
+            eyePos.y = eyeHeight;
+            const cueFocus = TMP_VEC3_D
+              .copy(cue.pos3D || lookTarget)
+              .addScaledVector(cueForward, -3.4 * worldScaleFactor);
+            cueFocus.y = Math.max(baseSurfaceWorldY + 0.05 * worldScaleFactor, cueFocus.y + 0.02 * worldScaleFactor);
+            camera.position.lerp(eyePos, cueViewBlend);
+            lookTarget = lookTarget.clone().lerp(cueFocus, cueViewBlend);
+          }
+
           camera.lookAt(lookTarget);
           renderCamera = camera;
           broadcastArgs.focusWorld =
@@ -26008,9 +26044,9 @@ const powerRef = useRef(hud.power);
             const sideX = forwardZ;
             const sideZ = -forwardX;
             humanActor.position.set(
-              cueStick.position.x - forwardX * (SCALE * 3.6) - sideX * (SCALE * 0.7),
+              cueStick.position.x - forwardX * (SCALE * 2.28) - sideX * (SCALE * 0.26),
               0,
-              cueStick.position.z - forwardZ * (SCALE * 3.6) - sideZ * (SCALE * 0.7)
+              cueStick.position.z - forwardZ * (SCALE * 2.28) - sideZ * (SCALE * 0.26)
             );
             humanActor.rotation.y = yaw;
           }


### PR DESCRIPTION
### Motivation
- The avatar stood visibly too far from the cue and didn't appear to hold the cue, so the human placement needed tightening to match reference photos and the in-code grip behavior.
- When the camera is lowered the player should get an eye‑level/player perspective for aiming, but that view must look down the cue/gameplay lane rather than at the avatar's face.

### Description
- Moved the human actor closer to the cue by tightening placement offsets in `humanActor.position.set(...)` (replaced `SCALE * 3.6` / `0.7` with `SCALE * 2.28` / `0.26`).
- Added a conditional cue camera blend inside `updateCamera()` that computes an eye anchor from `humanActor.position` and the cue orientation and lerps the camera position toward that eye position when the orbit phi indicates a lowered camera.
- The blended camera target is computed forward along the cue/gameplay direction (`cue.pos3D || lookTarget` plus a forward offset) so the camera maintains focus on the shot line and table action rather than the avatar.
- Activation guards include `humanActor?.visible`, `cueStick?.visible`, `cue?.active`, `!shooting`, and `!replayPlaybackRef.current` to avoid interfering with replays or shot execution.

### Testing
- Verified the source diff with `git diff -- webapp/src/pages/Games/SnookerRoyal.jsx` and inspected the patched regions (`nl -ba ... | sed -n '17838,17905p;26034,26060p'`), and the diff shows only `webapp/src/pages/Games/SnookerRoyal.jsx` changed.
- Committed the change with `git commit -m "Adjust Snooker human cue stance and eye-level cue camera"`, which completed successfully.
- Performed local code checks (`git status --short` and file inspection via `sed`/`nl`) to confirm the inserted cue‑view logic and human placement update are present and correctly placed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f583179bf88329808c6c46941f6cef)