### PR TITLE
Adjust Murlan Royale card and character arm positioning

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1794,17 +1794,21 @@ function createCharacterRig(instance, seatRoot, seatConfig, characterTheme, play
   instance.add(heldCards);
   const resolvedSeatIndex = seatConfig?.seatIndex ?? playerIndex;
   const isBottomHumanSeat = Boolean(player?.isHuman);
-  const isSideSeat = !isBottomHumanSeat && ((resolvedSeatIndex % CHAIR_COUNT) === 1 || (resolvedSeatIndex % CHAIR_COUNT) === 3);
-  const sideSeatLift = isSideSeat ? 0.24 * MODEL_SCALE : 0;
-  const sideSeatForward = isSideSeat ? 0.1 * MODEL_SCALE : 0;
+  const normalizedSeatIndex = resolvedSeatIndex % CHAIR_COUNT;
+  const isSideSeat = !isBottomHumanSeat && (normalizedSeatIndex === 1 || normalizedSeatIndex === 3);
+  const isTopSeat = !isBottomHumanSeat && normalizedSeatIndex === 2;
+  const sideSeatLift = isSideSeat ? 0.31 * MODEL_SCALE : 0;
+  const topSeatLift = isTopSeat ? 0.36 * MODEL_SCALE : 0;
+  const nonBottomForwardPull = !isBottomHumanSeat ? 0.24 * MODEL_SCALE : 0;
+  const bottomForwardPull = isBottomHumanSeat ? 0.06 * MODEL_SCALE : 0;
   const sideSeatLateralPull =
     isSideSeat
-      ? ((resolvedSeatIndex % CHAIR_COUNT) === 1 ? -0.045 * MODEL_SCALE : 0.045 * MODEL_SCALE)
+      ? (normalizedSeatIndex === 1 ? -0.03 * MODEL_SCALE : 0.03 * MODEL_SCALE)
       : 0;
   heldCards.position.set(
     sideSeatLateralPull,
-    0.76 * MODEL_SCALE + sideSeatLift,
-    0.86 * MODEL_SCALE + sideSeatForward
+    0.76 * MODEL_SCALE + sideSeatLift + topSeatLift,
+    0.86 * MODEL_SCALE + nonBottomForwardPull + bottomForwardPull
   );
   heldCards.rotation.set(THREE.MathUtils.degToRad(-18), THREE.MathUtils.degToRad(0), THREE.MathUtils.degToRad(0));
   heldCards.scale.setScalar(1.3);
@@ -1861,12 +1865,12 @@ function createCharacterRig(instance, seatRoot, seatConfig, characterTheme, play
   applyRotationOffset(hips, THREE.MathUtils.degToRad(-9), 0, 0);
   applyRotationOffset(spine, THREE.MathUtils.degToRad(-3), 0, 0);
   applyRotationOffset(head, THREE.MathUtils.degToRad(2), 0, 0);
-  applyRotationOffset(leftUpperArm, THREE.MathUtils.degToRad(-48), THREE.MathUtils.degToRad(1), THREE.MathUtils.degToRad(0));
-  applyRotationOffset(leftForeArm, THREE.MathUtils.degToRad(22), 0, THREE.MathUtils.degToRad(0));
-  applyRotationOffset(leftHand, THREE.MathUtils.degToRad(2), THREE.MathUtils.degToRad(2), 0);
-  applyRotationOffset(rightUpperArm, THREE.MathUtils.degToRad(-52), THREE.MathUtils.degToRad(-2), THREE.MathUtils.degToRad(0));
-  applyRotationOffset(rightForeArm, THREE.MathUtils.degToRad(26), 0, THREE.MathUtils.degToRad(0));
-  applyRotationOffset(rightHand, THREE.MathUtils.degToRad(4), THREE.MathUtils.degToRad(-2), 0);
+  applyRotationOffset(leftUpperArm, THREE.MathUtils.degToRad(-50), THREE.MathUtils.degToRad(4), THREE.MathUtils.degToRad(1));
+  applyRotationOffset(leftForeArm, THREE.MathUtils.degToRad(34), THREE.MathUtils.degToRad(1), THREE.MathUtils.degToRad(2));
+  applyRotationOffset(leftHand, THREE.MathUtils.degToRad(8), THREE.MathUtils.degToRad(3), THREE.MathUtils.degToRad(1));
+  applyRotationOffset(rightUpperArm, THREE.MathUtils.degToRad(-54), THREE.MathUtils.degToRad(-4), THREE.MathUtils.degToRad(-1));
+  applyRotationOffset(rightForeArm, THREE.MathUtils.degToRad(38), THREE.MathUtils.degToRad(-1), THREE.MathUtils.degToRad(-2));
+  applyRotationOffset(rightHand, THREE.MathUtils.degToRad(10), THREE.MathUtils.degToRad(-3), THREE.MathUtils.degToRad(-1));
   // Legs rotated opposite/downward (not upward) to mirror Ludo Battle Royal seated humans.
   applyRotationOffset(leftThigh, THREE.MathUtils.degToRad(-90.5), THREE.MathUtils.degToRad(9.2), THREE.MathUtils.degToRad(2.9));
   applyRotationOffset(rightThigh, THREE.MathUtils.degToRad(-90.5), THREE.MathUtils.degToRad(1.7), THREE.MathUtils.degToRad(-1.1));


### PR DESCRIPTION
### Motivation
- Make opponent cards (top/left/right) appear higher and visually closer to their characters and pull the bottom player's cards slightly closer to their character so hands look like they are holding the cards on portrait mobile framing.
- Bring both character arms/hands inward so the seated pose matches the held-card positions and reads as a natural "holding" pose.

### Description
- Updated `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to compute a `normalizedSeatIndex` and added `isTopSeat` to handle per-seat adjustments for card anchors.
- Introduced `sideSeatLift`, `topSeatLift`, `nonBottomForwardPull`, and `bottomForwardPull`, reduced side lateral spread, and changed `heldCards.position.set(...)` so non-bottom seats are lifted and pulled forward while bottom cards receive a subtle forward pull.
- Tuned lateral offsets (smaller `sideSeatLateralPull`) so side-seat cards sit closer to their characters.
- Adjusted rotation offsets passed to `applyRotationOffset(...)` for `leftUpperArm`, `leftForeArm`, `leftHand`, `rightUpperArm`, `rightForeArm`, and `rightHand` to bring arms/hands inward toward the cards.

### Testing
- No automated tests were run for this visual/pose tuning change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5840be4a48329a7c4232069ab83d7)