### PR TITLE
Fix Domino Royal black screen by isolating game mount root

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -845,7 +845,7 @@ const SFX = {
 };
 
 /* ---------- Renderer / Scene ---------- */
-const app = document.getElementById('app');
+const app = document.getElementById('domino-royal-app') || document.getElementById('app');
 function createRendererWithFallback() {
   const attempts = [
     { antialias: true, alpha: true, powerPreference: 'high-performance' },
@@ -8405,7 +8405,7 @@ function makeDomino(
 }
 
 /* ---------- Game State ---------- */
-const statusEl = document.getElementById('status');
+const statusEl = document.getElementById('domino-royal-status') || document.getElementById('status');
 const btnDraw = document.getElementById('draw');
 const btnPass = document.getElementById('pass');
 const setControlEnabled = (enabled) => {

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,12 +4,14 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-01-domino-murlan-characters-v39';
+const DOMINO_ROYAL_APP_ID = 'domino-royal-app';
+const DOMINO_ROYAL_STATUS_ID = 'domino-royal-status';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-02-domino-root-fix-v40';
 
 export default function DominoRoyalArena() {
   useEffect(() => {
-    const statusNode = document.getElementById('status');
-    const appRoot = document.getElementById('app');
+    const statusNode = document.getElementById(DOMINO_ROYAL_STATUS_ID);
+    const appRoot = document.getElementById(DOMINO_ROYAL_APP_ID);
     if (statusNode) {
       statusNode.textContent = 'Loading Domino Royal…';
     }
@@ -62,8 +64,8 @@ export default function DominoRoyalArena() {
 
   return (
     <div className="relative h-full w-full bg-black">
-      <div id="app" />
-      <div id="status" role="status">Ready</div>
+      <div id={DOMINO_ROYAL_APP_ID} />
+      <div id={DOMINO_ROYAL_STATUS_ID} role="status">Ready</div>
       <button id="configButton" type="button" aria-label="Open game settings menu">
         <span aria-hidden="true">☰</span>
         <span>Menu</span>
@@ -80,7 +82,7 @@ export default function DominoRoyalArena() {
         <div id="configSections" />
       </div>
       <style>{`
-        #app {
+        #domino-royal-app {
           transform: scale(0.97);
           transform-origin: center center;
         }
@@ -142,7 +144,7 @@ export default function DominoRoyalArena() {
         #quickActions .quick-action[data-action="chat"] {
           left: calc(0.75rem + env(safe-area-inset-left, 0px)) !important;
         }
-        #status {
+        #domino-royal-status {
           display: block !important;
           opacity: 0;
           pointer-events: none;
@@ -185,7 +187,7 @@ export default function DominoRoyalArena() {
                 clamp(2.8rem, 8vh, 3.4rem) + 3.1rem
             ) !important;
           }
-          #status {
+          #domino-royal-status {
             top: auto !important;
             bottom: calc(
               env(safe-area-inset-bottom, 0px) + clamp(6.9rem, 15vh, 8.8rem)


### PR DESCRIPTION
### Motivation
- Prevent the Domino Royal loader from accidentally wiping the surrounding React app by avoiding queries that target the global `#app`/`#status` nodes.  
- Ensure the game boot uses a dedicated mount and status root so the in-page script can safely `replaceChildren()` without removing React UI.  
- Keep runtime backward compatibility so existing installs still load if the legacy IDs are present.  
- Preserve the seated human character setup (seat offsets/pitch/yaw) already used by the Domino runtime so seating behavior matches the Murlan Royal technique.

### Description
- Introduced `DOMINO_ROYAL_APP_ID` (`domino-royal-app`) and `DOMINO_ROYAL_STATUS_ID` (`domino-royal-status`) and updated `DominoRoyalArena.jsx` to mount the game into these dedicated elements and inject styles scoped to them.  
- Bumped the injected script cache version via `DOMINO_ROYAL_SCRIPT_VERSION` so clients fetch the updated loader.  
- Updated `webapp/public/domino-royal-game.js` to prefer the new IDs (`document.getElementById('domino-royal-app')` / `domino-royal-status`) while falling back to legacy `#app`/`#status` for compatibility.  
- Kept existing seating/character configuration and constants intact so the seated human avatar flow remains unchanged.

### Testing
- Ran the production build with `cd webapp && npm run build --silent`, which completed successfully (build warnings are non-blocking).  
- Verified the patched `domino-royal-game.js` contains fallback lookups for legacy IDs and the new scaffolded DOM nodes are present in the React component.  
- Committed the changes after a successful local build; no automated unit tests were added or failed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5852c4b3083299241caf4a6d65703)