### PR TITLE
Adjust Snooker Royal camera for tighter player-eye cue perspective

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -5053,7 +5053,7 @@ function applySnookerScaling({
 }
 
 // Camera: keep a comfortable angle that doesn’t dip below the cloth, but allow a bit more height when it rises
-const STANDING_VIEW_PHI = 0.96; // lower the standing camera a touch so the table sits slightly lower on screen
+const STANDING_VIEW_PHI = 1.04; // lower the standing camera a touch so the table sits slightly lower on screen
 const CUE_SHOT_PHI = Math.PI / 2 - 0.26;
 const STANDING_VIEW_MARGIN = 0.001; // pull the standing frame closer so the table and balls fill more of the view
 const STANDING_VIEW_FOV = 66;
@@ -5062,14 +5062,14 @@ const CAMERA_LOWEST_PHI = CUE_SHOT_PHI - 0.1; // match Pool Royale standing-view
 const CAMERA_MIN_PHI = Math.max(CAMERA_ABS_MIN_PHI, STANDING_VIEW_PHI - 0.54);
 const CAMERA_MAX_PHI = CAMERA_LOWEST_PHI; // halt the downward sweep right above the cue while still enabling the lower AI cue height for players
 // Bring the cue camera in closer so the player view sits right against the rail on portrait screens.
-const PLAYER_CAMERA_DISTANCE_FACTOR = 0.0154; // match Pool Royale standing/cue camera distance
+const PLAYER_CAMERA_DISTANCE_FACTOR = 0.0132; // match Pool Royale standing/cue camera distance
 const BROADCAST_RADIUS_LIMIT_MULTIPLIER = 1.14;
 // Bring the standing/broadcast framing closer to the cloth so the table feels less distant while matching the rail proximity of the pocket cams
 const BROADCAST_DISTANCE_MULTIPLIER = 0.06;
 // Allow portrait/landscape standing camera framing to pull in closer without clipping the table
 const STANDING_VIEW_MARGIN_LANDSCAPE = 0.96;
 const STANDING_VIEW_MARGIN_PORTRAIT = 0.94;
-const STANDING_VIEW_DISTANCE_SCALE = 0.33; // pull the standing camera slightly closer to the table for tighter portrait framing
+const STANDING_VIEW_DISTANCE_SCALE = 0.28; // pull the standing camera slightly closer to the table for tighter portrait framing
 const BROADCAST_RADIUS_PADDING = TABLE.THICK * 0.02;
 const BROADCAST_PAIR_MARGIN = BALL_R * 5; // keep the cue/target pair safely framed within the broadcast crop
 const BROADCAST_ORBIT_FOCUS_BIAS = 0.6; // prefer the orbit camera's subject framing when updating broadcast heads
@@ -5184,7 +5184,7 @@ const CUE_VIEW_MIN_PHI = Math.min(
   CAMERA.maxPhi - CAMERA_RAIL_SAFETY,
   STANDING_VIEW_PHI + 0.26
 );
-const CUE_VIEW_PHI_LIFT = 0.06; // match Pool Royale cue-camera elevation
+const CUE_VIEW_PHI_LIFT = 0.025; // match Pool Royale cue-camera elevation
 const CUE_VIEW_TARGET_PHI = CUE_VIEW_MIN_PHI + CUE_VIEW_PHI_LIFT * 0.5;
 const CAMERA_RAIL_APPROACH_PHI = Math.min(
   STANDING_VIEW_PHI + 0.32,
@@ -5201,7 +5201,7 @@ const CAMERA_TILT_ZOOM = BALL_R * 1.5;
 const CAMERA_SURFACE_STOP_MARGIN = BALL_R * 1.3;
 const IN_HAND_CAMERA_RADIUS_MULTIPLIER = 1.32; // restore the 9pm in-hand orbit framing for cue-ball placement
 // When pushing the camera below the cue height, translate forward instead of dipping beneath the cue.
-const CUE_VIEW_FORWARD_SLIDE_MAX = CAMERA.minR * 0.32; // nudge forward slightly at the floor of the cue view, then stop
+const CUE_VIEW_FORWARD_SLIDE_MAX = CAMERA.minR * 0.42; // nudge forward slightly at the floor of the cue view, then stop
 const CUE_VIEW_FORWARD_SLIDE_BLEND_FADE = 0.32;
 const CUE_VIEW_FORWARD_SLIDE_RESET_BLEND = 0.45;
 const CUE_VIEW_SPIN_ZOOM = 0;


### PR DESCRIPTION
### Motivation
- Move the playable camera closer to the cue line and reduce foreshortening on portrait screens so the player view better matches an eye-level shooting perspective.

### Description
- Updated camera tuning constants in `webapp/src/pages/Games/SnookerRoyal.jsx` to tighten standing/cue framing: `STANDING_VIEW_PHI` -> `1.04`, `PLAYER_CAMERA_DISTANCE_FACTOR` -> `0.0132`, `STANDING_VIEW_DISTANCE_SCALE` -> `0.28`, `CUE_VIEW_PHI_LIFT` -> `0.025`, and `CUE_VIEW_FORWARD_SLIDE_MAX` -> `CAMERA.minR * 0.42`.
- These changes reduce vertical lift of the cue view and increase forward slide when the camera is lowered, improving the player-eye alignment without changing other camera logic.

### Testing
- Verified the source diff to confirm the five constant replacements were applied to `webapp/src/pages/Games/SnookerRoyal.jsx`.
- Performed repository-wide quick searches to ensure the updated constants are referenced consistently and no obvious symbol mismatches were introduced.
- No unit tests were modified; recommend running an in-app visual smoke test to validate the new camera framing on portrait devices.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f583179bf88329808c6c46941f6cef)