### PR TITLE
Domino Royal: attach seated human actors after chair rebuild

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -8207,6 +8207,9 @@ async function buildChairs(
   try {
     const chairData = await ensureChairTemplateForTheme(option);
     placeChairsWithOption(option, chairData, token);
+    if (token === chairBuildToken) {
+      await attachSeatedHumanActors(token);
+    }
   } catch (error) {
     console.warn('Failed to load GLTF chair theme for Domino', error);
   }


### PR DESCRIPTION
### Motivation
- The Domino Royal scene could end up blank because chairs were rebuilt without attaching seated human characters, leaving the seating pipeline incomplete and vulnerable to async race conditions.

### Description
- Call `attachSeatedHumanActors(token)` from `buildChairs()` after `placeChairsWithOption(...)` and guard with `token === chairBuildToken` so seated actors are attached only for the active build; change is in `webapp/public/domino-royal-game.js`.

### Testing
- Ran `node --check webapp/public/domino-royal-game.js` and `npm test -- --runInBand test/dominoRoyalHdriCatalog.test.js`, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5852c4b3083299241caf4a6d65703)