### PR TITLE
Lock Ludo bottom-seat camera to eye-level character FPV

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -9737,14 +9737,27 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
         }
       }
 
-      if (!isCamera2d && camera && LUDO_CAMERA_SEAT_LOCK_ENABLED) {
-        const hardLockedPosition = cameraLookStateRef.current.lockedPosition?.isVector3
-          ? cameraLookStateRef.current.lockedPosition
-          : cameraSeatLockPositionRef.current?.isVector3
-            ? cameraSeatLockPositionRef.current
-            : null;
-        if (hardLockedPosition) {
-          camera.position.copy(hardLockedPosition);
+      if (!isCamera2d && camera && controls && LUDO_CAMERA_SEAT_LOCK_ENABLED) {
+        const state = stateRef.current;
+        const shouldUseBottomSeatFpv = Boolean(state && state.turn === 0 && lockUserTurnSeatViewRef.current);
+        if (shouldUseBottomSeatFpv) {
+          const bottomActorEntry = seatedHumanActorsRef.current?.find((entry) => entry?.playerIndex === 0);
+          const facePose = resolveSeatedFaceCameraPose(bottomActorEntry, resolveBottomPlayerGameplayTarget());
+          if (facePose?.position?.isVector3 && facePose?.target?.isVector3) {
+            camera.position.copy(facePose.position);
+            controls.target.lerp(facePose.target, 0.28);
+            cameraSeatLockPositionRef.current = facePose.position.clone();
+            cameraTurnStateRef.current.currentTarget = controls.target.clone();
+          }
+        } else {
+          const hardLockedPosition = cameraLookStateRef.current.lockedPosition?.isVector3
+            ? cameraLookStateRef.current.lockedPosition
+            : cameraSeatLockPositionRef.current?.isVector3
+              ? cameraSeatLockPositionRef.current
+              : null;
+          if (hardLockedPosition) {
+            camera.position.copy(hardLockedPosition);
+          }
         }
       }
 


### PR DESCRIPTION
### Motivation
- Provide a true first-person, eye-level view for the bottom (player 0) seated human in Ludo so the camera is attached to the character's eyes and only moves when the character moves, matching the behavior used in the Murlan Royal codepath.

### Description
- In the Ludo render loop, when `LUDO_CAMERA_SEAT_LOCK_ENABLED` is active and the bottom player's locked view is in effect, sample the seated human face/eye helper via `resolveSeatedFaceCameraPose` and copy the returned `position` into the scene `camera` each frame to keep the camera attached to the character.
- Softly steer the controls target toward gameplay by calling `controls.target.lerp(facePose.target, 0.28)` so the view looks at dice/board while preserving eye-level attachment.
- Store the sampled FPV position in `cameraSeatLockPositionRef.current` and update `cameraTurnStateRef.current.currentTarget` to keep existing turn-state logic coherent.
- Preserve the original hard-lock fallback: when not using the bottom-seat FPV, continue to use the previous `cameraLookStateRef.current.lockedPosition` / `cameraSeatLockPositionRef.current` behavior.

### Testing
- Ran unit tests with `npm test -- --runInBand test/onlineGamePolicy.test.js`, and the suite passed.
- Ran `npx eslint webapp/src/pages/Games/LudoBattleRoyal.jsx` (the file is excluded by the repository lint ignore pattern, so lint reported the ignore state but no new lint errors for the change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5893f55a88329aa3eae423dae51de)