### PR TITLE
Ludo: keep camera attached to local player eye-level pose

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -9738,13 +9738,29 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       }
 
       if (!isCamera2d && camera && LUDO_CAMERA_SEAT_LOCK_ENABLED) {
-        const hardLockedPosition = cameraLookStateRef.current.lockedPosition?.isVector3
-          ? cameraLookStateRef.current.lockedPosition
-          : cameraSeatLockPositionRef.current?.isVector3
-            ? cameraSeatLockPositionRef.current
-            : null;
+        const bottomActorEntry = seatedHumanActorsRef.current?.find((entry) => entry?.playerIndex === 0);
+        const gameplayTarget = (() => {
+          const dice = diceRef.current;
+          if (dice?.isObject3D) {
+            const target = new THREE.Vector3();
+            dice.getWorldPosition(target);
+            return target;
+          }
+          return boardLookTargetRef.current?.isVector3 ? boardLookTargetRef.current.clone() : null;
+        })();
+        const liveFacePose = resolveSeatedFaceCameraPose(bottomActorEntry, gameplayTarget);
+        const hardLockedPosition = liveFacePose?.position?.isVector3
+          ? liveFacePose.position
+          : cameraLookStateRef.current.lockedPosition?.isVector3
+            ? cameraLookStateRef.current.lockedPosition
+            : cameraSeatLockPositionRef.current?.isVector3
+              ? cameraSeatLockPositionRef.current
+              : null;
         if (hardLockedPosition) {
           camera.position.copy(hardLockedPosition);
+          if (liveFacePose?.target?.isVector3 && controls) {
+            controls.target.copy(liveFacePose.target);
+          }
         }
       }
 


### PR DESCRIPTION
### Motivation
- Ensure the local player's camera remains anchored to the bottom-seat human actor's eye pose so the experience is a stable first-person player perspective while still looking toward gameplay (dice/board). 
- Replace the previous stale/cached seat-lock position with a live per-frame pose so the camera stays correct as the seated actor animates or adjusts.

### Description
- Resolve the bottom-player live face/eye pose each frame via `resolveSeatedFaceCameraPose` and prefer that `position` for `camera.position` during the seat-lock branch in the main render loop in `webapp/src/pages/Games/LudoBattleRoyal.jsx`.
- Compute a gameplay-facing target (dice world position with board fallback) and, when a live face pose exists, copy its `target` into the `OrbitControls` target so the camera looks toward gameplay while remaining attached to the player's eyes.
- Preserve fallbacks to `cameraLookStateRef.current.lockedPosition` and `cameraSeatLockPositionRef.current` when live pose data is unavailable to avoid regressions.

### Testing
- Ran `cd webapp && npm run -s build` and the production build completed successfully (Vite warnings are pre-existing and non-blocking).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5893f55a88329aa3eae423dae51de)