### PR TITLE
Restore default per-piece capture air unit mappings

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -7695,19 +7695,19 @@ function Chess3D({
     truck: 'pawn'
   }), []);
   const [captureAnimationByPieceGroup, setCaptureAnimationByPieceGroup] = useState(() => ({
-    kingQueen: selectedCaptureAnimationId,
-    bishopRook: selectedCaptureAnimationId,
-    knight: selectedCaptureAnimationId,
-    pawn: selectedCaptureAnimationId
+    kingQueen: 'fighterJetAttack',
+    bishopRook: 'helicopterAttack',
+    knight: 'droneAttack',
+    pawn: 'missileJavelin'
   }));
   useEffect(() => {
     setCaptureAnimationByPieceGroup((prev) => ({
-      kingQueen: prev.kingQueen || selectedCaptureAnimationId,
-      bishopRook: prev.bishopRook || selectedCaptureAnimationId,
-      knight: prev.knight || selectedCaptureAnimationId,
-      pawn: prev.pawn || selectedCaptureAnimationId
+      kingQueen: prev.kingQueen || 'fighterJetAttack',
+      bishopRook: prev.bishopRook || 'helicopterAttack',
+      knight: prev.knight || 'droneAttack',
+      pawn: prev.pawn || 'missileJavelin'
     }));
-  }, [selectedCaptureAnimationId]);
+  }, []);
   const handleCaptureAnimationSwap = useCallback(
     (optionId) => {
       if (!optionId) return;


### PR DESCRIPTION
### Motivation
- Restore the expected jet/helicopter/drone/truck capture behaviors so each chess piece triggers the same air/ground unit animations and flight paths as earlier.
- Prevent a single global selected capture animation from initializing all piece groups to the same weapon, which broke per-piece routing and visuals.
- Keep live weapon-swap UI/behavior intact while ensuring sensible per-piece defaults for first-run or absent user prefs.

### Description
- Set explicit defaults for `captureAnimationByPieceGroup` so `kingQueen` maps to `fighterJetAttack`, `bishopRook` maps to `helicopterAttack`, `knight` maps to `droneAttack`, and `pawn` maps to `missileJavelin` in `webapp/src/pages/Games/ChessBattleRoyal.jsx`.
- Changed the initialization effect to preserve those defaults (removed dependency on `selectedCaptureAnimationId`) so per-group defaults are not clobbered by a global selected id at startup.
- Kept the existing `weaponSwap` handlers and `PIECE_GROUP_BY_PARKED_KIND` mapping so users can still change per-pad animations at runtime.

### Testing
- Ran the linter targeting the edited file with `npm -s run lint -- webapp/src/pages/Games/ChessBattleRoyal.jsx`, which completed but emitted a React-version detection warning; no lint errors were reported for the change.
- No automated unit tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f58c14d9ac83299f92ecbef9678bc9)