### PR TITLE
Adjust seated character rig offsets, card placement, and arm rotations in MurlanRoyaleArena

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1794,20 +1794,24 @@ function createCharacterRig(instance, seatRoot, seatConfig, characterTheme, play
   instance.add(heldCards);
   const resolvedSeatIndex = seatConfig?.seatIndex ?? playerIndex;
   const isBottomHumanSeat = Boolean(player?.isHuman);
-  const isSideSeat = !isBottomHumanSeat && ((resolvedSeatIndex % CHAIR_COUNT) === 1 || (resolvedSeatIndex % CHAIR_COUNT) === 3);
-  const sideSeatLift = isSideSeat ? 0.24 * MODEL_SCALE : 0;
-  const sideSeatForward = isSideSeat ? 0.1 * MODEL_SCALE : 0;
+  const normalizedSeatIndex = resolvedSeatIndex % CHAIR_COUNT;
+  const isSideSeat = !isBottomHumanSeat && (normalizedSeatIndex === 1 || normalizedSeatIndex === 3);
+  const isTopSeat = !isBottomHumanSeat && normalizedSeatIndex === 2;
+  const sideSeatLift = isSideSeat ? 0.4 * MODEL_SCALE : 0;
+  const topSeatLift = isTopSeat ? 0.48 * MODEL_SCALE : 0;
+  const nonBottomForwardPull = !isBottomHumanSeat ? -0.34 * MODEL_SCALE : 0;
+  const bottomForwardPull = isBottomHumanSeat ? -0.07 * MODEL_SCALE : 0;
   const sideSeatLateralPull =
     isSideSeat
-      ? ((resolvedSeatIndex % CHAIR_COUNT) === 1 ? -0.045 * MODEL_SCALE : 0.045 * MODEL_SCALE)
+      ? (normalizedSeatIndex === 1 ? -0.03 * MODEL_SCALE : 0.03 * MODEL_SCALE)
       : 0;
   heldCards.position.set(
     sideSeatLateralPull,
-    0.76 * MODEL_SCALE + sideSeatLift,
-    0.86 * MODEL_SCALE + sideSeatForward
+    0.76 * MODEL_SCALE + sideSeatLift + topSeatLift + (isBottomHumanSeat ? -0.08 * MODEL_SCALE : 0),
+    0.86 * MODEL_SCALE + nonBottomForwardPull + bottomForwardPull
   );
   heldCards.rotation.set(THREE.MathUtils.degToRad(-18), THREE.MathUtils.degToRad(0), THREE.MathUtils.degToRad(0));
-  heldCards.scale.setScalar(1.3);
+  heldCards.scale.setScalar(1.2);
 
   if (!leftThigh || !rightThigh) {
     instance.position.y -= 0.02 * MODEL_SCALE;
@@ -1861,12 +1865,12 @@ function createCharacterRig(instance, seatRoot, seatConfig, characterTheme, play
   applyRotationOffset(hips, THREE.MathUtils.degToRad(-9), 0, 0);
   applyRotationOffset(spine, THREE.MathUtils.degToRad(-3), 0, 0);
   applyRotationOffset(head, THREE.MathUtils.degToRad(2), 0, 0);
-  applyRotationOffset(leftUpperArm, THREE.MathUtils.degToRad(-48), THREE.MathUtils.degToRad(1), THREE.MathUtils.degToRad(0));
-  applyRotationOffset(leftForeArm, THREE.MathUtils.degToRad(22), 0, THREE.MathUtils.degToRad(0));
-  applyRotationOffset(leftHand, THREE.MathUtils.degToRad(2), THREE.MathUtils.degToRad(2), 0);
-  applyRotationOffset(rightUpperArm, THREE.MathUtils.degToRad(-52), THREE.MathUtils.degToRad(-2), THREE.MathUtils.degToRad(0));
-  applyRotationOffset(rightForeArm, THREE.MathUtils.degToRad(26), 0, THREE.MathUtils.degToRad(0));
-  applyRotationOffset(rightHand, THREE.MathUtils.degToRad(4), THREE.MathUtils.degToRad(-2), 0);
+  applyRotationOffset(leftUpperArm, THREE.MathUtils.degToRad(-53), THREE.MathUtils.degToRad(-6), THREE.MathUtils.degToRad(-2));
+  applyRotationOffset(leftForeArm, THREE.MathUtils.degToRad(40), THREE.MathUtils.degToRad(-3), THREE.MathUtils.degToRad(-2));
+  applyRotationOffset(leftHand, THREE.MathUtils.degToRad(11), THREE.MathUtils.degToRad(-4), THREE.MathUtils.degToRad(-2));
+  applyRotationOffset(rightUpperArm, THREE.MathUtils.degToRad(-57), THREE.MathUtils.degToRad(6), THREE.MathUtils.degToRad(2));
+  applyRotationOffset(rightForeArm, THREE.MathUtils.degToRad(44), THREE.MathUtils.degToRad(3), THREE.MathUtils.degToRad(2));
+  applyRotationOffset(rightHand, THREE.MathUtils.degToRad(13), THREE.MathUtils.degToRad(4), THREE.MathUtils.degToRad(2));
   // Legs rotated opposite/downward (not upward) to mirror Ludo Battle Royal seated humans.
   applyRotationOffset(leftThigh, THREE.MathUtils.degToRad(-90.5), THREE.MathUtils.degToRad(9.2), THREE.MathUtils.degToRad(2.9));
   applyRotationOffset(rightThigh, THREE.MathUtils.degToRad(-90.5), THREE.MathUtils.degToRad(1.7), THREE.MathUtils.degToRad(-1.1));


### PR DESCRIPTION
### Motivation
- Improve seated character framing and card placement for non-bottom seats by normalizing seat indexing and introducing distinct top/side handling to reduce visual clipping and better match the Ludo Battle Royal pose.
- Tweak arm rotation offsets to produce a more natural seated hold and better alignment with theme card positioning.

### Description
- Normalize seat index with `normalizedSeatIndex` and derive `isSideSeat` and new `isTopSeat` flags to drive per-seat transforms.
- Introduce `topSeatLift`, `nonBottomForwardPull`, and `bottomForwardPull` and adjust `sideSeatLift`/`sideSeatLateralPull` values to reposition held cards for different seat locations; update `heldCards.position` accordingly.
- Reduce `heldCards.scale` from `1.3` to `1.2` to better match the character pose.
- Update multiple `applyRotationOffset` calls for `leftUpperArm`, `leftForeArm`, `leftHand`, `rightUpperArm`, `rightForeArm`, and `rightHand` with new angle values to refine the seated arm pose.

### Testing
- Ran unit tests with `yarn test` and all tests passed.
- Ran linter with `yarn lint` with no errors reported.
- Built the webapp with `yarn build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5840be4a48329a7c4232069ab83d7)