### PR TITLE
Restore Domino Royal to non-human-character configuration

### DIFF
--- a/webapp/public/domino-royal-game.js
+++ b/webapp/public/domino-royal-game.js
@@ -1,13 +1,13 @@
-import * as THREE from './vendor/three/build/three.module.js';
-import { OrbitControls } from './vendor/three/examples/jsm/controls/OrbitControls.js';
-import { RoomEnvironment } from './vendor/three/examples/jsm/environments/RoomEnvironment.js';
-import { RoundedBoxGeometry } from './vendor/three/examples/jsm/geometries/RoundedBoxGeometry.js';
-import { GLTFLoader } from './vendor/three/examples/jsm/loaders/GLTFLoader.js';
-import { RGBELoader } from './vendor/three/examples/jsm/loaders/RGBELoader.js';
-import { DRACOLoader } from './vendor/three/examples/jsm/loaders/DRACOLoader.js';
-import { KTX2Loader } from './vendor/three/examples/jsm/loaders/KTX2Loader.js';
-import { MeshoptDecoder } from './vendor/three/examples/jsm/libs/meshopt_decoder.module.js';
-import { clone as cloneSkeleton } from './vendor/three/examples/jsm/utils/SkeletonUtils.js';
+import * as THREE from '/vendor/three/build/three.module.js';
+import { OrbitControls } from '/vendor/three/examples/jsm/controls/OrbitControls.js';
+import { RoomEnvironment } from '/vendor/three/examples/jsm/environments/RoomEnvironment.js';
+import { RoundedBoxGeometry } from '/vendor/three/examples/jsm/geometries/RoundedBoxGeometry.js';
+import { GLTFLoader } from '/vendor/three/examples/jsm/loaders/GLTFLoader.js';
+import { RGBELoader } from '/vendor/three/examples/jsm/loaders/RGBELoader.js';
+import { DRACOLoader } from '/vendor/three/examples/jsm/loaders/DRACOLoader.js';
+import { KTX2Loader } from '/vendor/three/examples/jsm/loaders/KTX2Loader.js';
+import { MeshoptDecoder } from '/vendor/three/examples/jsm/libs/meshopt_decoder.module.js';
+import { clone as cloneSkeleton } from '/vendor/three/examples/jsm/utils/SkeletonUtils.js';
 import './flag-emojis.js';
 
 const urlParams = new URLSearchParams(window.location.search);
@@ -1026,91 +1026,7 @@ const CHAIR_SEAT_RADII = Object.freeze([
   CHAIR_RADIUS + CHAIR_GLOBAL_PUSHBACK,
   CHAIR_RADIUS + CHAIR_GLOBAL_PUSHBACK
 ]);
-const DOMINO_HUMAN_CHARACTER_OPTIONS = Object.freeze([
-  {
-    id: 'rpm-current',
-    label: 'Current Avatar',
-    modelUrls: ['https://threejs.org/examples/models/gltf/readyplayer.me.glb'],
-    scale: 1.0,
-    normalizedSeatOffsetY: -0.4,
-    normalizedSeatOffsetZ: 0.52,
-    seatPitch: 0,
-    seatYaw: 0
-  },
-  {
-    id: 'rpm-67d411',
-    label: 'RPM 67d411',
-    modelUrls: [
-      'https://models.readyplayer.me/67d411b30787acbf58ce58ac.glb',
-      'https://api.readyplayer.me/v1/avatars/67d411b30787acbf58ce58ac.glb',
-      'https://avatars.readyplayer.me/67d411b30787acbf58ce58ac.glb'
-    ],
-    scale: 1.0,
-    normalizedSeatOffsetY: -0.4,
-    normalizedSeatOffsetZ: 0.52,
-    seatPitch: 0,
-    seatYaw: 0
-  },
-  {
-    id: 'rpm-67f433',
-    label: 'RPM 67f433',
-    modelUrls: [
-      'https://models.readyplayer.me/67f433b69dc08cf26d2cf585.glb',
-      'https://api.readyplayer.me/v1/avatars/67f433b69dc08cf26d2cf585.glb',
-      'https://avatars.readyplayer.me/67f433b69dc08cf26d2cf585.glb'
-    ],
-    scale: 1.0,
-    normalizedSeatOffsetY: -0.4,
-    normalizedSeatOffsetZ: 0.52,
-    seatPitch: 0,
-    seatYaw: 0
-  },
-  {
-    id: 'rpm-67e1b5',
-    label: 'RPM 67e1b5',
-    modelUrls: [
-      'https://models.readyplayer.me/67e1b51ae11c93725e4395c9.glb',
-      'https://api.readyplayer.me/v1/avatars/67e1b51ae11c93725e4395c9.glb',
-      'https://avatars.readyplayer.me/67e1b51ae11c93725e4395c9.glb'
-    ],
-    scale: 1.0,
-    normalizedSeatOffsetY: -0.4,
-    normalizedSeatOffsetZ: 0.52,
-    seatPitch: 0,
-    seatYaw: 0
-  },
-  {
-    id: 'webgl-vietnam-human',
-    label: 'Vietnam Human',
-    modelUrls: ['https://raw.githubusercontent.com/hmthanh/3d-human-model/main/TranThiNgocTham.glb'],
-    scale: 1.0,
-    normalizedSeatOffsetY: -0.4,
-    normalizedSeatOffsetZ: 0.52,
-    seatPitch: 0,
-    seatYaw: 0
-  },
-  {
-    id: 'webgl-ai-teacher',
-    label: 'AI Teacher',
-    modelUrls: ['https://raw.githubusercontent.com/Surbh77/AI-teacher/main/avatar.glb'],
-    scale: 1.0,
-    normalizedSeatOffsetY: -0.4,
-    normalizedSeatOffsetZ: 0.52,
-    seatPitch: 0,
-    seatYaw: 0
-  },
-  {
-    id: 'webgl-ai-teacher-1',
-    label: 'AI Teacher 1',
-    modelUrls: ['https://raw.githubusercontent.com/Surbh77/AI-teacher/main/avatar1.glb'],
-    scale: 1.0,
-    normalizedSeatOffsetY: -0.4,
-    normalizedSeatOffsetZ: 0.52,
-    seatPitch: 0,
-    seatYaw: 0
-  }
-]);
-const HUMAN_MODEL_LOAD_TIMEOUT_MS = 4500;
+const DOMINO_HUMAN_CHARACTER_OPTIONS = Object.freeze([]);
 
 const ARENA_WALL_HEIGHT = 3.6 * 1.3;
 const ARENA_WALL_CENTER_Y = ARENA_WALL_HEIGHT / 2;
@@ -8038,24 +7954,18 @@ async function loadSeatedHumanTemplate(option) {
         const candidates = normalizeHumanModelUrlCandidates(
           targetOption.modelUrls || fallbackOption.modelUrls || []
         );
-        if (!candidates.length) return null;
         let gltf = null;
         let lastError = null;
         for (const url of candidates) {
           try {
             // eslint-disable-next-line no-await-in-loop
-            gltf = await Promise.race([
-              loader.loadAsync(url),
-              new Promise((_, reject) =>
-                setTimeout(() => reject(new Error(`Seated human load timeout: ${url}`)), HUMAN_MODEL_LOAD_TIMEOUT_MS)
-              )
-            ]);
+            gltf = await loader.loadAsync(url);
             if (gltf) break;
           } catch (error) {
             lastError = error;
           }
         }
-        if (!gltf) return null;
+        if (!gltf) throw lastError || new Error('Missing seated human scene');
         const root = gltf.scene || gltf.scenes?.[0] || gltf;
         normalizeSeatedHumanRootToChair(root);
         root.traverse((obj) => {
@@ -8172,22 +8082,18 @@ async function attachSeatedHumanActors(token) {
       } catch (error) {
         console.warn('Domino Royal human seat model failed, using default', option?.id, error);
         // eslint-disable-next-line no-await-in-loop
-        template = await loadSeatedHumanTemplate(DOMINO_HUMAN_CHARACTER_OPTIONS[0] || null);
+        template = await loadSeatedHumanTemplate(DOMINO_HUMAN_CHARACTER_OPTIONS[0]);
       }
-      if (!template || token !== chairBuildToken) continue;
+      if (!template || token !== chairBuildToken) return;
       const actor = cloneSkeleton(template);
       const actorScale =
-        (template.userData?.seatedHumanScale ?? computeSeatedHumanScale(template)) *
-        (option?.scale ?? 1);
+        template.userData?.seatedHumanScale ?? computeSeatedHumanScale(template);
       actor.scale.setScalar(actorScale);
-      const seatOffsetY = option?.normalizedSeatOffsetY ?? -0.4;
-      const seatOffsetZ = option?.normalizedSeatOffsetZ ?? 0.52;
-      const seatYOffset = SEATED_HUMAN_SEAT_Y_OFFSET + seatOffsetY * MODEL_SCALE * 0.12;
       const seatZOffset =
-        SEATED_HUMAN_SEAT_Z_OFFSET + seatOffsetZ * MODEL_SCALE * 0.02 +
+        SEATED_HUMAN_SEAT_Z_OFFSET +
         (index === HUMAN_SEAT_INDEX ? SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET : 0);
-      actor.position.set(0, seatYOffset, seatZOffset);
-      actor.rotation.set(option?.seatPitch ?? 0, SEATED_HUMAN_FACING_Y + (option?.seatYaw ?? 0), 0);
+      actor.position.set(0, SEATED_HUMAN_SEAT_Y_OFFSET, seatZOffset);
+      actor.rotation.set(0, SEATED_HUMAN_FACING_Y, 0);
       const rig = saveBoneRig(actor);
       applySeatedHumanPose(rig);
       alignSeatedHumanFeetToGroundPlane(actor, rig);
@@ -8207,9 +8113,6 @@ async function buildChairs(
   try {
     const chairData = await ensureChairTemplateForTheme(option);
     placeChairsWithOption(option, chairData, token);
-    if (token === chairBuildToken) {
-      await attachSeatedHumanActors(token);
-    }
   } catch (error) {
     console.warn('Failed to load GLTF chair theme for Domino', error);
   }

--- a/webapp/src/config/dominoRoyalInventoryConfig.js
+++ b/webapp/src/config/dominoRoyalInventoryConfig.js
@@ -9,15 +9,7 @@ import {
   BATTLE_ROYALE_SHARED_TABLE_THEME_OPTIONS
 } from './battleRoyaleSharedInventory.js';
 
-const DOMINO_HUMAN_CHARACTER_OPTIONS = Object.freeze([
-  { id: 'rpm-current', label: 'Current Avatar', description: 'Ready Player Me seated avatar with full PBR texture maps.' },
-  { id: 'rpm-67d411', label: 'RPM 67d411', description: 'Ready Player Me public avatar seated with the same rig logic and motion set.' },
-  { id: 'rpm-67f433', label: 'RPM 67f433', description: 'Ready Player Me public avatar aligned to default seated scale/orientation.' },
-  { id: 'rpm-67e1b5', label: 'RPM 67e1b5', description: 'Ready Player Me public avatar using the same seated helper offsets.' },
-  { id: 'webgl-vietnam-human', label: 'Vietnam Human', description: 'Open WebGL GLB humanoid seated with the same scale/orientation rig.' },
-  { id: 'webgl-ai-teacher', label: 'AI Teacher', description: 'Open-source AI Teacher avatar adapted to the default seated pose pipeline.' },
-  { id: 'webgl-ai-teacher-1', label: 'AI Teacher 1', description: 'Second AI Teacher avatar using the same seated helpers and interaction logic.' }
-]);
+const DOMINO_HUMAN_CHARACTER_OPTIONS = Object.freeze([]);
 
 export const DOMINO_ROYAL_OPTION_SETS = Object.freeze({
   tableWood: BATTLE_ROYALE_SHARED_TABLE_FINISH_OPTIONS.map(({ id, label, price = 0, description, thumbnail, woodOption }) => ({
@@ -137,7 +129,7 @@ const DOMINO_DEFAULT_IDS = Object.freeze({
   tableWood: 'peelingPaintWeathered',
   tableCloth: 'emerald',
   chairTheme: 'dining_chair_02',
-  humanCharacter: 'rpm-current'
+  humanCharacter: null
 });
 
 const getDefaultOptionId = (options) => options?.[0]?.id;

--- a/webapp/src/pages/Games/DominoRoyalArena.jsx
+++ b/webapp/src/pages/Games/DominoRoyalArena.jsx
@@ -4,7 +4,7 @@ import { DOMINO_ROYAL_INLINE_STYLE } from './dominoRoyalTemplate.js';
 
 const INLINE_STYLE_ID = 'domino-royal-inline-style';
 const GAME_SCRIPT_SELECTOR = 'script[data-domino-royal-script="true"]';
-const DOMINO_ROYAL_SCRIPT_VERSION = '2026-05-01-domino-murlan-characters-v39';
+const DOMINO_ROYAL_SCRIPT_VERSION = '2026-04-28-domino-human-seating-v38';
 
 export default function DominoRoyalArena() {
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- Restore Domino Royal to a known-working state that does not surface or attach seated human avatars so the game renders and behaves like the prior non-human-character setup.

### Description
- Remove and disable the Domino seated-human catalog and loader paths by setting `DOMINO_HUMAN_CHARACTER_OPTIONS` to an empty array and making the Domino `humanCharacter` default `null` in `webapp/src/config/dominoRoyalInventoryConfig.js`.
- Revert runtime/loader changes in `webapp/public/domino-royal-game.js` to the earlier behavior that avoids loading/attaching external human GLTFs and simplify the seated-human loading code (no model URL candidates, no timeout path, and no automatic attach step in `buildChairs`).
- Update the React loader script version in `webapp/src/pages/Games/DominoRoyalArena.jsx` to the matching runtime version so the page loads the restored `domino-royal-game.js` build.
- Preserve existing chair/theme/table/domino customization flows while disabling the human-seat attachment and model-loading branches.

### Testing
- Ran a recent-history check with `git log --since='5 days ago' -- webapp/public/domino-royal-game.js webapp/src/pages/Games/DominoRoyalArena.jsx` and confirmed the earlier snapshot references were present (succeeded).
- Performed static verification with `rg -n "humanCharacter" webapp/src/config/dominoRoyalInventoryConfig.js webapp/src/pages/Games/DominoRoyalArena.jsx` to confirm the human options array is empty and default is `null` (succeeded).
- Inspected diffs with `git diff` and checked the working tree with `git status --short` to ensure the intended files were updated and human-model entries removed from `webapp/public/domino-royal-game.js` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5b0599d0c832996eedc6fea634388)