### PR TITLE
Fix Snake & Ladder dice roll randomness bias

### DIFF
--- a/webapp/src/components/DiceRoller.jsx
+++ b/webapp/src/components/DiceRoller.jsx
@@ -64,10 +64,15 @@ export default function DiceRoller({
     onRollStart && onRollStart();
 
     const rand = () => {
-      if (window.crypto && window.crypto.getRandomValues) {
+      if (window.crypto?.getRandomValues) {
         const arr = new Uint32Array(1);
-        window.crypto.getRandomValues(arr);
-        return (arr[0] % 6) + 1;
+        const maxUnbiased = Math.floor(0x100000000 / 6) * 6;
+        let value = 0;
+        do {
+          window.crypto.getRandomValues(arr);
+          value = arr[0];
+        } while (value >= maxUnbiased);
+        return (value % 6) + 1;
       }
       return Math.floor(Math.random() * 6) + 1;
     };


### PR DESCRIPTION
### Motivation
- The dice generator used a direct modulo on a 32-bit `crypto.getRandomValues` integer causing a small but measurable bias in face distribution over long runs. 
- Make dice outcomes for Snake & Ladder uniformly distributed so rolls feel more natural and fair.

### Description
- Updated `webapp/src/components/DiceRoller.jsx` to replace the modulo-based selection with unbiased rejection sampling when `window.crypto.getRandomValues` is available.
- The new logic computes `maxUnbiased = Math.floor(0x100000000 / 6) * 6` and rejects values >= `maxUnbiased` before mapping to `1..6` to avoid modulo bias.
- Kept the existing fallback to `Math.random()` for environments without Web Crypto and did not change the roll animation timing (`tick`/`iterations`).

### Testing
- Ran `npm run eslint -- webapp/src/components/DiceRoller.jsx` which failed because this repo does not expose a top-level `eslint` npm script (diagnostic, not a code failure).
- Ran the repo lint via `npm run lint -- webapp/src/components/DiceRoller.jsx`, which executed `eslint` and completed with only a React version detection warning and no new errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5b1b636b483299bbedf44f912ea53)