### PR TITLE
Adjust Ludo seated face camera to avoid head clipping

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -3243,9 +3243,9 @@ const SEATED_HELPER_CONTACT_RIGHT = -0.016 * MODEL_SCALE;
 const SEATED_HELPER_CONTACT_UP = -0.014 * MODEL_SCALE;
 const SEATED_HELPER_CONTACT_FORWARD = 0.102 * MODEL_SCALE;
 const SEATED_HELPER_FACE_CAMERA_RIGHT = 0;
-const SEATED_HELPER_FACE_CAMERA_UP = 0.034 * MODEL_SCALE;
+const SEATED_HELPER_FACE_CAMERA_UP = 0.062 * MODEL_SCALE;
 // Move camera anchor to the face-front side so the local player's head stays out of portrait framing.
-const SEATED_HELPER_FACE_CAMERA_FORWARD = -0.06 * MODEL_SCALE;
+const SEATED_HELPER_FACE_CAMERA_FORWARD = -0.098 * MODEL_SCALE;
 const SEATED_CONTACT_IK_ITERATIONS = 7;
 const SEATED_CONTACT_IK_MAX_STEP_RAD = 0.3;
 const SEATED_CONTACT_DICE_Y_OFFSET = 0.016;
@@ -5994,7 +5994,7 @@ function resolveSeatedFaceCameraPose(actorEntry, fallbackTarget = null) {
   } else if (actorEntry?.rig?.head?.isBone) {
     actorEntry.rig.head.updateMatrixWorld?.(true);
     actorEntry.rig.head.getWorldPosition(target);
-    target.z += 0.24 * MODEL_SCALE;
+    target.z += 0.285 * MODEL_SCALE;
   } else {
     target.copy(position).add(new THREE.Vector3(0, -0.004, 0.2 * MODEL_SCALE));
   }


### PR DESCRIPTION
### Motivation
- Prevent the first-person seat camera from intersecting the local avatar head in portrait/mobile Ludo Battle Royal by shifting the eye-anchor up and slightly closer to the table so the view targets gameplay instead of face geometry.

### Description
- Updated camera/face-anchor constants in `webapp/src/pages/Games/LudoBattleRoyal.jsx` to raise the eye point and move it forward by changing `SEATED_HELPER_FACE_CAMERA_UP` and `SEATED_HELPER_FACE_CAMERA_FORWARD` respectively.
- Increased the head-bone fallback look-target forward bias by changing the head-target offset from `0.24 * MODEL_SCALE` to `0.285 * MODEL_SCALE` so the first-person view looks more toward the board.
- Change is limited to three numeric constant edits in `LudoBattleRoyal.jsx` (camera framing only).

### Testing
- No automated tests were executed for this change because it is a constants-only visual tweak; verify with an in-app visual smoke check on portrait/mobile to confirm camera framing and head clipping are resolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5bc46f4b483298ea815e01a6da2ca)