### PR TITLE
Improve seated face-camera positioning to sit in front of avatar head and face gameplay

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -3243,9 +3243,9 @@ const SEATED_HELPER_CONTACT_RIGHT = -0.016 * MODEL_SCALE;
 const SEATED_HELPER_CONTACT_UP = -0.014 * MODEL_SCALE;
 const SEATED_HELPER_CONTACT_FORWARD = 0.102 * MODEL_SCALE;
 const SEATED_HELPER_FACE_CAMERA_RIGHT = 0;
-const SEATED_HELPER_FACE_CAMERA_UP = 0.034 * MODEL_SCALE;
+const SEATED_HELPER_FACE_CAMERA_UP = 0.062 * MODEL_SCALE;
 // Move camera anchor to the face-front side so the local player's head stays out of portrait framing.
-const SEATED_HELPER_FACE_CAMERA_FORWARD = -0.06 * MODEL_SCALE;
+const SEATED_HELPER_FACE_CAMERA_FORWARD = -0.098 * MODEL_SCALE;
 const SEATED_CONTACT_IK_ITERATIONS = 7;
 const SEATED_CONTACT_IK_MAX_STEP_RAD = 0.3;
 const SEATED_CONTACT_DICE_Y_OFFSET = 0.016;
@@ -5985,16 +5985,34 @@ function resolveSeatedFaceCameraPose(actorEntry, fallbackTarget = null) {
   if (!faceHelper?.isObject3D) return null;
   const position = new THREE.Vector3();
   const target = new THREE.Vector3();
+  const headWorld = new THREE.Vector3();
+  const toGameplay = new THREE.Vector3();
   faceHelper.updateMatrixWorld?.(true);
   faceHelper.getWorldPosition(position);
 
   // First-person camera must sit on eyes, but should look toward gameplay (dice/board), not at avatar face.
+  if (actorEntry?.rig?.head?.isBone) {
+    actorEntry.rig.head.updateMatrixWorld?.(true);
+    actorEntry.rig.head.getWorldPosition(headWorld);
+  }
+
   if (fallbackTarget?.isVector3) {
     target.copy(fallbackTarget);
+    if (headWorld.lengthSq() > 1e-8) {
+      toGameplay.copy(target).sub(headWorld);
+      if (toGameplay.lengthSq() > 1e-8) {
+        toGameplay.normalize();
+        // Hard clamp camera to sit in front of the face toward table gameplay, never inside the skull mesh.
+        position.copy(headWorld).addScaledVector(toGameplay, 0.12 * MODEL_SCALE);
+        position.y += 0.03 * MODEL_SCALE;
+      }
+    }
   } else if (actorEntry?.rig?.head?.isBone) {
-    actorEntry.rig.head.updateMatrixWorld?.(true);
-    actorEntry.rig.head.getWorldPosition(target);
-    target.z += 0.24 * MODEL_SCALE;
+    target.copy(headWorld);
+    target.z += 0.285 * MODEL_SCALE;
+    position.copy(headWorld);
+    position.z += 0.11 * MODEL_SCALE;
+    position.y += 0.03 * MODEL_SCALE;
   } else {
     target.copy(position).add(new THREE.Vector3(0, -0.004, 0.2 * MODEL_SCALE));
   }


### PR DESCRIPTION
### Motivation

- Prevent the first-person/portrait camera from intersecting the avatar skull and ensure it looks toward gameplay (board/dice) rather than directly at the face. 

### Description

- Tightened camera anchor offsets by increasing `SEATED_HELPER_FACE_CAMERA_UP` and moving `SEATED_HELPER_FACE_CAMERA_FORWARD` further forward. 
- Enhanced `resolveSeatedFaceCameraPose` to sample the head world position and compute a clamped camera position that sits in front of the face toward the gameplay target when a `fallbackTarget` is provided. 
- Adjusted default head-target and camera offsets when a head bone is present to move the camera slightly forward and up from the head position. 
- Added local helper vectors (`headWorld`, `toGameplay`) and updated head world-position sampling to avoid placing the camera inside the skull. 

### Testing

- Ran the webapp build with `yarn build` and it completed successfully. 
- Executed unit tests with `yarn test` and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5bc46f4b483298ea815e01a6da2ca)