### PR TITLE
Raise and push outward player cards in Murlan Royale (portrait)

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1773,10 +1773,10 @@ function computeHeldCardsPose({ player, resolvedSeatIndex = 0 }) {
 
   // Lift opponent cards higher and push them outward (away from table center)
   // so they sit closer to the avatar/chest area in portrait framing.
-  const sideSeatLift = isSideSeat ? 0.56 * MODEL_SCALE : 0;
-  const topSeatLift = isTopSeat ? 0.68 * MODEL_SCALE : 0;
-  const nonBottomOutwardPush = !isBottomHumanSeat ? -0.52 * MODEL_SCALE : 0;
-  const bottomForwardPull = isBottomHumanSeat ? -0.07 * MODEL_SCALE : 0;
+  const sideSeatLift = isSideSeat ? 0.7 * MODEL_SCALE : 0;
+  const topSeatLift = isTopSeat ? 0.82 * MODEL_SCALE : 0;
+  const nonBottomOutwardPush = !isBottomHumanSeat ? -0.68 * MODEL_SCALE : 0;
+  const bottomForwardPull = isBottomHumanSeat ? -0.12 * MODEL_SCALE : 0;
   const sideSeatLateralPull =
     isSideSeat
       ? (normalizedSeatIndex === 1 ? -0.04 * MODEL_SCALE : 0.04 * MODEL_SCALE)
@@ -1784,8 +1784,8 @@ function computeHeldCardsPose({ player, resolvedSeatIndex = 0 }) {
 
   return {
     x: sideSeatLateralPull,
-    y: 0.76 * MODEL_SCALE + sideSeatLift + topSeatLift + (isBottomHumanSeat ? -0.08 * MODEL_SCALE : 0),
-    z: 0.86 * MODEL_SCALE + nonBottomOutwardPush + bottomForwardPull
+    y: 0.84 * MODEL_SCALE + sideSeatLift + topSeatLift + (isBottomHumanSeat ? -0.12 * MODEL_SCALE : 0),
+    z: 0.82 * MODEL_SCALE + nonBottomOutwardPush + bottomForwardPull
   };
 }
 


### PR DESCRIPTION
### Motivation
- Move players' held cards higher on screen and farther outward from the table so they appear closer to avatars in portrait mobile framing.

### Description
- Updated `computeHeldCardsPose` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to increase `sideSeatLift` and `topSeatLift`, increase the outward push (`nonBottomOutwardPush`), adjust `bottomForwardPull`, and tune the base `y`/`z` offsets for all seats.

### Testing
- No automated tests were run because this is a visual layout tuning; the change was committed and the diff inspected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5c75a52088329a42c2faaa383f380)