### PR TITLE
Lift and push Murlan player cards higher and outward

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1773,10 +1773,10 @@ function computeHeldCardsPose({ player, resolvedSeatIndex = 0 }) {
 
   // Lift opponent cards higher and push them outward (away from table center)
   // so they sit closer to the avatar/chest area in portrait framing.
-  const sideSeatLift = isSideSeat ? 0.7 * MODEL_SCALE : 0;
-  const topSeatLift = isTopSeat ? 0.82 * MODEL_SCALE : 0;
-  const nonBottomOutwardPush = !isBottomHumanSeat ? -0.68 * MODEL_SCALE : 0;
-  const bottomForwardPull = isBottomHumanSeat ? -0.12 * MODEL_SCALE : 0;
+  const sideSeatLift = isSideSeat ? 0.84 * MODEL_SCALE : 0;
+  const topSeatLift = isTopSeat ? 0.98 * MODEL_SCALE : 0;
+  const nonBottomOutwardPush = !isBottomHumanSeat ? -0.9 * MODEL_SCALE : 0;
+  const bottomForwardPull = isBottomHumanSeat ? -0.18 * MODEL_SCALE : 0;
   const sideSeatLateralPull =
     isSideSeat
       ? (normalizedSeatIndex === 1 ? -0.04 * MODEL_SCALE : 0.04 * MODEL_SCALE)
@@ -1784,7 +1784,7 @@ function computeHeldCardsPose({ player, resolvedSeatIndex = 0 }) {
 
   return {
     x: sideSeatLateralPull,
-    y: 0.84 * MODEL_SCALE + sideSeatLift + topSeatLift + (isBottomHumanSeat ? -0.12 * MODEL_SCALE : 0),
+    y: 0.9 * MODEL_SCALE + sideSeatLift + topSeatLift + (isBottomHumanSeat ? -0.08 * MODEL_SCALE : 0),
     z: 0.82 * MODEL_SCALE + nonBottomOutwardPush + bottomForwardPull
   };
 }


### PR DESCRIPTION
### Motivation
- Improve portrait/mobile framing by moving player-held cards visually higher and farther away from the table so they appear closer to avatars/chest area.

### Description
- Adjusted numeric pose constants inside `computeHeldCardsPose` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` by increasing `sideSeatLift`, `topSeatLift`, `nonBottomOutwardPush`, `bottomForwardPull`, and the base `y` offset to raise and push cards outward for side/top/non-bottom seats.

### Testing
- No automated tests were run for this visual/layout tweak.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5cce4b13083298586c6cfc83c45e3)