### PR TITLE
Adjust Murlan Royale held card pose closer to avatars

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1773,10 +1773,10 @@ function computeHeldCardsPose({ player, resolvedSeatIndex = 0 }) {
 
   // Lift opponent cards higher and push them outward (away from table center)
   // so they sit closer to the avatar/chest area in portrait framing.
-  const sideSeatLift = isSideSeat ? 0.84 * MODEL_SCALE : 0;
-  const topSeatLift = isTopSeat ? 0.98 * MODEL_SCALE : 0;
-  const nonBottomOutwardPush = !isBottomHumanSeat ? -0.9 * MODEL_SCALE : 0;
-  const bottomForwardPull = isBottomHumanSeat ? -0.18 * MODEL_SCALE : 0;
+  const sideSeatLift = isSideSeat ? 1.02 * MODEL_SCALE : 0;
+  const topSeatLift = isTopSeat ? 1.16 * MODEL_SCALE : 0;
+  const nonBottomOutwardPush = !isBottomHumanSeat ? -1.1 * MODEL_SCALE : 0;
+  const bottomForwardPull = isBottomHumanSeat ? -0.28 * MODEL_SCALE : 0;
   const sideSeatLateralPull =
     isSideSeat
       ? (normalizedSeatIndex === 1 ? -0.04 * MODEL_SCALE : 0.04 * MODEL_SCALE)
@@ -1784,7 +1784,7 @@ function computeHeldCardsPose({ player, resolvedSeatIndex = 0 }) {
 
   return {
     x: sideSeatLateralPull,
-    y: 0.9 * MODEL_SCALE + sideSeatLift + topSeatLift + (isBottomHumanSeat ? -0.08 * MODEL_SCALE : 0),
+    y: 0.96 * MODEL_SCALE + sideSeatLift + topSeatLift + (isBottomHumanSeat ? -0.02 * MODEL_SCALE : 0),
     z: 0.82 * MODEL_SCALE + nonBottomOutwardPush + bottomForwardPull
   };
 }


### PR DESCRIPTION
### Motivation
- Improve portrait mobile framing by raising players' held cards and shifting them outward so cards sit visually closer to the avatar/chest area.

### Description
- Update `computeHeldCardsPose` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` by increasing `sideSeatLift` and `topSeatLift`, increasing `nonBottomOutwardPush`, adjusting `bottomForwardPull`, and raising the returned `y` offset so opponent and human held cards appear higher and more outward.

### Testing
- Performed repository checks with `git diff -- webapp/src/pages/Games/MurlanRoyaleArena.jsx` and committed the change with `git commit`, both of which completed successfully; no automated unit or integration tests were run for this tuning-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5d1005f608329aca6e20e1fe91b00)