### PR TITLE
Adjust Murlan Royale held-card placement for portrait framing

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1773,10 +1773,10 @@ function computeHeldCardsPose({ player, resolvedSeatIndex = 0 }) {
 
   // Lift opponent cards higher and push them outward (away from table center)
   // so they sit closer to the avatar/chest area in portrait framing.
-  const sideSeatLift = isSideSeat ? 1.02 * MODEL_SCALE : 0;
-  const topSeatLift = isTopSeat ? 1.16 * MODEL_SCALE : 0;
-  const nonBottomOutwardPush = !isBottomHumanSeat ? -1.1 * MODEL_SCALE : 0;
-  const bottomForwardPull = isBottomHumanSeat ? -0.28 * MODEL_SCALE : 0;
+  const sideSeatLift = isSideSeat ? 1.18 * MODEL_SCALE : 0;
+  const topSeatLift = isTopSeat ? 1.3 * MODEL_SCALE : 0;
+  const nonBottomOutwardPush = !isBottomHumanSeat ? -1.34 * MODEL_SCALE : 0;
+  const bottomForwardPull = isBottomHumanSeat ? -0.36 * MODEL_SCALE : 0;
   const sideSeatLateralPull =
     isSideSeat
       ? (normalizedSeatIndex === 1 ? -0.04 * MODEL_SCALE : 0.04 * MODEL_SCALE)
@@ -1784,7 +1784,7 @@ function computeHeldCardsPose({ player, resolvedSeatIndex = 0 }) {
 
   return {
     x: sideSeatLateralPull,
-    y: 0.96 * MODEL_SCALE + sideSeatLift + topSeatLift + (isBottomHumanSeat ? -0.02 * MODEL_SCALE : 0),
+    y: 1.04 * MODEL_SCALE + sideSeatLift + topSeatLift + (isBottomHumanSeat ? 0 : 0.02 * MODEL_SCALE),
     z: 0.82 * MODEL_SCALE + nonBottomOutwardPush + bottomForwardPull
   };
 }


### PR DESCRIPTION
### Motivation
- Improve portrait mobile framing by making player-held cards appear higher on screen and farther from the table so they sit closer to the avatar/chest area, matching the previous PR's visual adjustment.

### Description
- Updated `computeHeldCardsPose` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to increase vertical lift and outward offset for non-bottom seats and slightly raise the shared base hand height; specifically `sideSeatLift` 1.02→1.18, `topSeatLift` 1.16→1.30, `nonBottomOutwardPush` -1.10→-1.34, `bottomForwardPull` -0.28→-0.36, and base `y` 0.96→1.04 (keeps lateral pull unchanged).

### Testing
- No automated tests were executed for this visual/tuning change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5d781260c8329ae8a9396e6a240f1)