### PR TITLE
Adjust Murlan Royale held-card pose to sit higher and farther outward

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1773,10 +1773,10 @@ function computeHeldCardsPose({ player, resolvedSeatIndex = 0 }) {
 
   // Lift opponent cards higher and push them outward (away from table center)
   // so they sit closer to the avatar/chest area in portrait framing.
-  const sideSeatLift = isSideSeat ? 1.36 * MODEL_SCALE : 0;
-  const topSeatLift = isTopSeat ? 1.5 * MODEL_SCALE : 0;
-  const nonBottomOutwardPush = !isBottomHumanSeat ? -1.58 * MODEL_SCALE : 0;
-  const bottomForwardPull = isBottomHumanSeat ? -0.46 * MODEL_SCALE : 0;
+  const sideSeatLift = isSideSeat ? 1.52 * MODEL_SCALE : 0;
+  const topSeatLift = isTopSeat ? 1.66 * MODEL_SCALE : 0;
+  const nonBottomOutwardPush = !isBottomHumanSeat ? -1.78 * MODEL_SCALE : 0;
+  const bottomForwardPull = isBottomHumanSeat ? -0.58 * MODEL_SCALE : 0;
   const sideSeatLateralPull =
     isSideSeat
       ? (normalizedSeatIndex === 1 ? -0.04 * MODEL_SCALE : 0.04 * MODEL_SCALE)
@@ -1784,7 +1784,7 @@ function computeHeldCardsPose({ player, resolvedSeatIndex = 0 }) {
 
   return {
     x: sideSeatLateralPull,
-    y: 1.12 * MODEL_SCALE + sideSeatLift + topSeatLift + (isBottomHumanSeat ? 0 : 0.03 * MODEL_SCALE),
+    y: 1.2 * MODEL_SCALE + sideSeatLift + topSeatLift + (isBottomHumanSeat ? 0.04 * MODEL_SCALE : 0.08 * MODEL_SCALE),
     z: 0.82 * MODEL_SCALE + nonBottomOutwardPush + bottomForwardPull
   };
 }


### PR DESCRIPTION
### Motivation
- Improve portrait/mobile readability by moving players' held cards visually higher and further outward toward avatars so cards are easier to see.

### Description
- Update `computeHeldCardsPose` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to increase `sideSeatLift` (1.36 → 1.52), `topSeatLift` (1.50 → 1.66), `nonBottomOutwardPush` (-1.58 → -1.78), `bottomForwardPull` (-0.46 → -0.58), and raise the base `y` baseline from `1.12` to `1.2` with adjusted seat-aware offsets.

### Testing
- No automated tests were added or executed for this UI/tuning change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5e19bd7b8832992c22ae3d9ee2753)