### PR TITLE
Double held-card lift and outward offsets for Murlan Royale arena

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1773,10 +1773,10 @@ function computeHeldCardsPose({ player, resolvedSeatIndex = 0 }) {
 
   // Lift opponent cards higher and push them outward (away from table center)
   // so they sit closer to the avatar/chest area in portrait framing.
-  const sideSeatLift = isSideSeat ? 1.52 * MODEL_SCALE : 0;
-  const topSeatLift = isTopSeat ? 1.66 * MODEL_SCALE : 0;
-  const nonBottomOutwardPush = !isBottomHumanSeat ? -1.78 * MODEL_SCALE : 0;
-  const bottomForwardPull = isBottomHumanSeat ? -0.58 * MODEL_SCALE : 0;
+  const sideSeatLift = isSideSeat ? 3.04 * MODEL_SCALE : 0;
+  const topSeatLift = isTopSeat ? 3.32 * MODEL_SCALE : 0;
+  const nonBottomOutwardPush = !isBottomHumanSeat ? -3.56 * MODEL_SCALE : 0;
+  const bottomForwardPull = isBottomHumanSeat ? -1.16 * MODEL_SCALE : 0;
   const sideSeatLateralPull =
     isSideSeat
       ? (normalizedSeatIndex === 1 ? -0.04 * MODEL_SCALE : 0.04 * MODEL_SCALE)
@@ -1784,7 +1784,7 @@ function computeHeldCardsPose({ player, resolvedSeatIndex = 0 }) {
 
   return {
     x: sideSeatLateralPull,
-    y: 1.2 * MODEL_SCALE + sideSeatLift + topSeatLift + (isBottomHumanSeat ? 0.04 * MODEL_SCALE : 0.08 * MODEL_SCALE),
+    y: 1.2 * MODEL_SCALE + sideSeatLift + topSeatLift + (isBottomHumanSeat ? 0.08 * MODEL_SCALE : 0.16 * MODEL_SCALE),
     z: 0.82 * MODEL_SCALE + nonBottomOutwardPush + bottomForwardPull
   };
 }


### PR DESCRIPTION
### Motivation
- Improve portrait mobile framing by moving players' held cards visually higher and further away from the table so they sit closer to avatars/chests. 
- Apply the same tuning approach as the previous adjustment but make the lift/outward push twice as strong to meet the requested visual spacing.

### Description
- Updated `computeHeldCardsPose` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` to increase card pose offsets. 
- Doubled `sideSeatLift`, `topSeatLift`, `nonBottomOutwardPush`, and `bottomForwardPull` multipliers (values now use 2x the previous constants multiplied by `MODEL_SCALE`).
- Increased the small per-seat Y micro-offsets from `0.04/0.08` to `0.08/0.16` so vertical elevation remains consistent after the stronger outward push.
- This change is a pure visual/positioning tweak and does not modify game rules or rendering pipeline logic.

### Testing
- No automated tests were run for this visual positioning change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5e89992088329b0e23c615aef4d49)