### PR TITLE
Raise and push Murlan Royale held cards toward avatars (double offsets)

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1773,10 +1773,10 @@ function computeHeldCardsPose({ player, resolvedSeatIndex = 0 }) {
 
   // Lift opponent cards higher and push them outward (away from table center)
   // so they sit closer to the avatar/chest area in portrait framing.
-  const sideSeatLift = isSideSeat ? 3.04 * MODEL_SCALE : 0;
-  const topSeatLift = isTopSeat ? 3.32 * MODEL_SCALE : 0;
-  const nonBottomOutwardPush = !isBottomHumanSeat ? -3.56 * MODEL_SCALE : 0;
-  const bottomForwardPull = isBottomHumanSeat ? -1.16 * MODEL_SCALE : 0;
+  const sideSeatLift = isSideSeat ? 6.08 * MODEL_SCALE : 0;
+  const topSeatLift = isTopSeat ? 6.64 * MODEL_SCALE : 0;
+  const nonBottomOutwardPush = !isBottomHumanSeat ? -7.12 * MODEL_SCALE : 0;
+  const bottomForwardPull = isBottomHumanSeat ? -2.32 * MODEL_SCALE : 0;
   const sideSeatLateralPull =
     isSideSeat
       ? (normalizedSeatIndex === 1 ? -0.04 * MODEL_SCALE : 0.04 * MODEL_SCALE)


### PR DESCRIPTION
### Motivation
- Improve portrait mobile framing by moving player-held card fans visibly higher and farther from the table so they appear closer to each avatar/chest area.

### Description
- Doubled the held-card offsets inside `computeHeldCardsPose` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` by changing `sideSeatLift` from `3.04 * MODEL_SCALE` to `6.08 * MODEL_SCALE`, `topSeatLift` from `3.32 * MODEL_SCALE` to `6.64 * MODEL_SCALE`, `nonBottomOutwardPush` from `-3.56 * MODEL_SCALE` to `-7.12 * MODEL_SCALE`, and `bottomForwardPull` from `-1.16 * MODEL_SCALE` to `-2.32 * MODEL_SCALE` so fans render higher and further outward toward avatars.

### Testing
- No automated unit or integration tests were executed for this visual offset tweak; the change was reviewed via the diff and committed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5ea9751388329b309345ea4350734)