### PR TITLE
Add Tennis 1v1 lobby and update in-game HUD to tennis-style scoreboard

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -67,6 +67,7 @@ import PoolRoyaleCareer from './pages/Games/PoolRoyaleCareer.jsx';
 import SnookerRoyal from './pages/Games/SnookerRoyal.jsx';
 import SnookerRoyalLobby from './pages/Games/SnookerRoyalLobby.jsx';
 import Tennis from './pages/Games/Tennis.tsx';
+import TennisLobby from './pages/Games/TennisLobby.jsx';
 
 import StoreThumbnailStudioPoolRoyale from './pages/Tools/StoreThumbnailStudioPoolRoyale.jsx';
 
@@ -369,6 +370,11 @@ export default function App() {
                   <PoolRoyale />
                 </GameLiveAvatarOverlay>
               }
+            />
+
+            <Route
+              path="/games/tennis/lobby"
+              element={<TennisLobby />}
             />
 
             <Route

--- a/webapp/src/config/gamesCatalog.js
+++ b/webapp/src/config/gamesCatalog.js
@@ -2,7 +2,7 @@ const gamesCatalog = [
 
   {
     name: 'Tennis',
-    route: '/games/tennis',
+    route: '/games/tennis/lobby',
     slug: 'tennis',
     image: '/assets/icons/Goal%20rush%20logo.png',
     description: '3D tennis rally with swipe controls and physics.'

--- a/webapp/src/pages/Games/Tennis.tsx
+++ b/webapp/src/pages/Games/Tennis.tsx
@@ -1065,7 +1065,15 @@ export default function MobileThreeTennisPrototype() {
 
     animate();
 
-    return () => {
+  
+  const searchParams = new URLSearchParams(typeof window !== "undefined" ? window.location.search : "");
+  const playerName = searchParams.get("player") || "You";
+  const opponentName = searchParams.get("opponent") || "AI";
+  const tennisPointLabels = ["0", "15", "30", "40"];
+  const nearPoint = tennisPointLabels[Math.min(hud.nearScore, 3)] || "40";
+  const farPoint = tennisPointLabels[Math.min(hud.farScore, 3)] || "40";
+
+  return () => {
       cancelAnimationFrame(frameId);
       window.removeEventListener("resize", resize);
       canvas.removeEventListener("pointerdown", onPointerDown);
@@ -1091,9 +1099,19 @@ export default function MobileThreeTennisPrototype() {
         <canvas ref={canvasRef} style={{ width: "100%", height: "100%", display: "block", touchAction: "none" }} />
       </div>
       <div style={{ position: "fixed", inset: 0, pointerEvents: "none", fontFamily: "system-ui, -apple-system, BlinkMacSystemFont, sans-serif" }}>
-        <div style={{ position: "absolute", left: "50%", top: 10, transform: "translateX(-50%)", color: "white", background: "rgba(0,0,0,0.54)", border: "1px solid rgba(255,255,255,0.16)", padding: "9px 13px", borderRadius: 16, fontSize: 13, fontWeight: 800, letterSpacing: 0.2, boxShadow: "0 12px 26px rgba(0,0,0,0.22)", textAlign: "center", minWidth: 174 }}>
-          You {hud.nearScore} — {hud.farScore} AI
-          <div style={{ fontSize: 11, fontWeight: 600, opacity: 0.82, marginTop: 2 }}>{hud.status}</div>
+        <div style={{ position: "absolute", top: 10, left: 10, right: 10, color: "white", pointerEvents: "auto" }}>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 8 }}>
+            <div style={{ display: "flex", alignItems: "center", gap: 8 }}><div style={{ width: 32, height: 32, borderRadius: 999, background: "#50c8ff" }} /><strong>{playerName}</strong></div>
+            <button style={{ borderRadius: 10, border: "1px solid rgba(255,255,255,0.24)", background: "rgba(0,0,0,0.45)", color: "white", padding: "6px 10px" }}>☰</button>
+            <div style={{ display: "flex", alignItems: "center", gap: 8 }}><strong>{opponentName}</strong><div style={{ width: 32, height: 32, borderRadius: 999, background: "#ff8ab2" }} /></div>
+          </div>
+          <div style={{ background: "rgba(0,0,0,0.54)", border: "1px solid rgba(255,255,255,0.16)", padding: "8px 12px", borderRadius: 14, fontSize: 12, boxShadow: "0 12px 26px rgba(0,0,0,0.22)" }}>
+            <div style={{ display: "grid", gridTemplateColumns: "1fr auto auto", gap: 8, fontWeight: 800 }}>
+              <span>{playerName}</span><span>{hud.nearScore}</span><span>{nearPoint}</span>
+              <span>{opponentName}</span><span>{hud.farScore}</span><span>{farPoint}</span>
+            </div>
+            <div style={{ fontSize: 11, fontWeight: 600, opacity: 0.82, marginTop: 4, textAlign: "center" }}>{hud.status}</div>
+          </div>
         </div>
         <div style={{ position: "absolute", left: 10, bottom: 18, color: "white", background: "rgba(0,0,0,0.42)", border: "1px solid rgba(255,255,255,0.12)", padding: "9px 10px", borderRadius: 14, fontSize: 12, lineHeight: 1.35, maxWidth: 236 }}>
           Procedural hands removed.<br />The character right hand holds the racket.<br />Swipe up to serve or hit deep.

--- a/webapp/src/pages/Games/TennisLobby.jsx
+++ b/webapp/src/pages/Games/TennisLobby.jsx
@@ -1,0 +1,116 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import GameLobbyHeader from '../../components/GameLobbyHeader.jsx';
+import FlagPickerModal from '../../components/FlagPickerModal.jsx';
+import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
+import { ensureAccountId, getTelegramFirstName, getTelegramPhotoUrl } from '../../utils/telegram.js';
+import { loadAvatar } from '../../utils/avatarUtils.js';
+import { runSimpleOnlineFlow } from '../../utils/simpleOnlineFlow.js';
+import { socket } from '../../utils/socket.js';
+import { getAccountBalance, addTransaction } from '../../utils/api.js';
+
+function pickRandomFlags(count) {
+  if (!count) return [];
+  const available = FLAG_EMOJIS.map((_, idx) => idx);
+  for (let i = available.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [available[i], available[j]] = [available[j], available[i]];
+  }
+  return available.slice(0, count);
+}
+
+export default function TennisLobby() {
+  const navigate = useNavigate();
+  const [mode, setMode] = useState('ai');
+  const [avatar, setAvatar] = useState('');
+  const [flags, setFlags] = useState(() => pickRandomFlags(1));
+  const [showFlagPicker, setShowFlagPicker] = useState(false);
+  const [stake, setStake] = useState(100);
+  const [matching, setMatching] = useState(false);
+  const [matchStatus, setMatchStatus] = useState('');
+  const [matchError, setMatchError] = useState('');
+
+  useEffect(() => {
+    try {
+      const saved = loadAvatar();
+      setAvatar(saved || getTelegramPhotoUrl());
+    } catch {}
+  }, []);
+
+  const startGame = async () => {
+    if (mode === 'online') {
+      await runSimpleOnlineFlow({
+        gameType: 'tennis',
+        stake: { token: 'TPC', amount: stake },
+        maxPlayers: 2,
+        avatar,
+        playerName: getTelegramFirstName() || 'Player',
+        state: { setMatching, setMatchStatus, setMatchError },
+        deps: { ensureAccountId, getAccountBalance, addTransaction, socket },
+        onMatched: ({ accountId, tableId }) => {
+          const params = new URLSearchParams();
+          params.set('mode', 'online');
+          params.set('tableId', tableId);
+          params.set('accountId', accountId);
+          params.set('player', getTelegramFirstName() || 'You');
+          params.set('opponent', 'Online rival');
+          navigate(`/games/tennis?${params.toString()}`);
+        }
+      });
+      return;
+    }
+
+    const params = new URLSearchParams();
+    params.set('mode', 'ai');
+    params.set('player', getTelegramFirstName() || 'You');
+    params.set('opponent', 'AI Pro');
+    if (avatar) params.set('avatar', avatar);
+    if (flags.length) params.set('flags', flags.join(','));
+    navigate(`/games/tennis?${params.toString()}`);
+  };
+
+  return (
+    <div className="relative min-h-screen bg-[#070b16] text-text p-4 space-y-4">
+      <GameLobbyHeader slug="tennis" title="Tennis Lobby" badge="1v1 only" />
+      <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
+        <p className="text-xs text-white/60 uppercase tracking-[0.22em]">Glam Avatar</p>
+        <div className="mt-3 flex items-center gap-3">
+          <div className="h-12 w-12 rounded-full overflow-hidden border border-white/20 bg-white/10">
+            {avatar ? <img src={avatar} alt="avatar" className="h-full w-full object-cover" /> : <div className="h-full grid place-items-center">🙂</div>}
+          </div>
+          <div>
+            <div className="font-semibold text-white">{getTelegramFirstName() || 'Player'}</div>
+            <button type="button" className="text-xs text-cyan-300" onClick={() => setShowFlagPicker(true)}>
+              World glam set: {flags.length ? flags.map((f) => FLAG_EMOJIS[f]).join(' ') : '🌍'}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <button type="button" onClick={() => setMode('ai')} className={`lobby-option-card ${mode === 'ai' ? 'lobby-option-card-active' : 'lobby-option-card-inactive'}`}>
+          <p className="lobby-option-label">Vs AI (Free)</p>
+          <p className="lobby-option-subtitle">No TPC stake</p>
+        </button>
+        <button type="button" onClick={() => setMode('online')} className={`lobby-option-card ${mode === 'online' ? 'lobby-option-card-active' : 'lobby-option-card-inactive'}`}>
+          <p className="lobby-option-label">Online 1v1</p>
+          <p className="lobby-option-subtitle">TPC streak queue</p>
+        </button>
+      </div>
+
+      {mode === 'online' && (
+        <label className="block rounded-xl border border-white/10 bg-white/5 p-3 text-sm text-white/80">
+          TPC stake
+          <input type="number" min={1} step={10} value={stake} onChange={(e) => setStake(Math.max(1, Number(e.target.value) || 1))} className="mt-2 w-full rounded-lg bg-black/30 px-2 py-2" />
+        </label>
+      )}
+
+      <button type="button" disabled={matching} onClick={startGame} className="w-full rounded-xl bg-cyan-500 text-black font-bold py-3 disabled:opacity-60">
+        {matching ? (matchStatus || 'Matching...') : 'Start 1v1 Match'}
+      </button>
+      {matchError && <p className="text-sm text-red-300">{matchError}</p>}
+
+      <FlagPickerModal isOpen={showFlagPicker} count={1} initialSelection={flags} onClose={() => setShowFlagPicker(false)} onConfirm={(s) => { setFlags(s); setShowFlagPicker(false); }} />
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Provide a dedicated lobby flow for Tennis that enforces 1v1 matches and supports both free vs-AI play and online 1v1 matchmaking with TPC staking and streaks. 
- Reuse the existing global glam/avatar selection UX (the world/flag picker used by Murlan Royale) so Tennis has consistent avatar presentation. 
- Improve the in-match UI to match real tennis scoreboards with avatars, player names, a menu control, and tennis point labels for clearer mobile portrait presentation.

### Description
- Added a new lobby page `webapp/src/pages/Games/TennisLobby.jsx` implementing a strict 1v1 flow with `Vs AI (Free)` and `Online 1v1` modes, flag/glam avatar selection via `FlagPickerModal`, and online matchmaking using `runSimpleOnlineFlow`. 
- Registered the lobby route and import in `webapp/src/App.jsx` at `/games/tennis/lobby` and preserved the gameplay route `/games/tennis`. 
- Updated `webapp/src/config/gamesCatalog.js` to point Tennis to the new lobby route. 
- Updated the in-game HUD in `webapp/src/pages/Games/Tennis.tsx` to show top-aligned player/opponent avatar chips and names, a menu icon, tennis-style point labels (`0/15/30/40`) alongside score counters, and preserved the status/power UI.

### Testing
- Built the web app with `cd webapp && npm run -s build`, which completed successfully (Vite build passed) with non-blocking warnings about chunk sizes and some dynamic/static import overlaps that pre-existed and are unchanged by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5f59e3b948329b0d0498cad7a4cd3)