### PR TITLE
Double held-card lift and outward offsets for Murlan Royale

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1773,10 +1773,10 @@ function computeHeldCardsPose({ player, resolvedSeatIndex = 0 }) {
 
   // Lift opponent cards higher and push them outward (away from table center)
   // so they sit closer to the avatar/chest area in portrait framing.
-  const sideSeatLift = isSideSeat ? 6.08 * MODEL_SCALE : 0;
-  const topSeatLift = isTopSeat ? 6.64 * MODEL_SCALE : 0;
-  const nonBottomOutwardPush = !isBottomHumanSeat ? -7.12 * MODEL_SCALE : 0;
-  const bottomForwardPull = isBottomHumanSeat ? -2.32 * MODEL_SCALE : 0;
+  const sideSeatLift = isSideSeat ? 12.16 * MODEL_SCALE : 0;
+  const topSeatLift = isTopSeat ? 13.28 * MODEL_SCALE : 0;
+  const nonBottomOutwardPush = !isBottomHumanSeat ? -14.24 * MODEL_SCALE : 0;
+  const bottomForwardPull = isBottomHumanSeat ? -4.64 * MODEL_SCALE : 0;
   const sideSeatLateralPull =
     isSideSeat
       ? (normalizedSeatIndex === 1 ? -0.04 * MODEL_SCALE : 0.04 * MODEL_SCALE)
@@ -1784,7 +1784,7 @@ function computeHeldCardsPose({ player, resolvedSeatIndex = 0 }) {
 
   return {
     x: sideSeatLateralPull,
-    y: 1.2 * MODEL_SCALE + sideSeatLift + topSeatLift + (isBottomHumanSeat ? 0.08 * MODEL_SCALE : 0.16 * MODEL_SCALE),
+    y: 1.2 * MODEL_SCALE + sideSeatLift + topSeatLift + (isBottomHumanSeat ? 0.16 * MODEL_SCALE : 0.32 * MODEL_SCALE),
     z: 0.82 * MODEL_SCALE + nonBottomOutwardPush + bottomForwardPull
   };
 }


### PR DESCRIPTION
### Motivation
- Tune portrait framing so player-held cards sit higher and farther toward avatars/chest area, applying roughly 2× the previous lift/outward push for clearer on-screen visibility.

### Description
- Increased the held-card pose offsets in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` by doubling `sideSeatLift`, `topSeatLift`, `nonBottomOutwardPush`, and `bottomForwardPull`, and increased the small Y bias for bottom/non-bottom seats to preserve visual balance.

### Testing
- No automated tests were run for this visual/layout-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6000bf66883298052058297ad41e7)