### PR TITLE
Murlan Royale: raise and push player held cards outward (2x tuning)

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1773,9 +1773,10 @@ function computeHeldCardsPose({ player, resolvedSeatIndex = 0 }) {
 
   // Lift opponent cards higher and push them outward (away from table center)
   // so they sit closer to the avatar/chest area in portrait framing.
-  const sideSeatLift = isSideSeat ? 12.16 * MODEL_SCALE : 0;
-  const topSeatLift = isTopSeat ? 13.28 * MODEL_SCALE : 0;
-  const nonBottomOutwardPush = !isBottomHumanSeat ? -14.24 * MODEL_SCALE : 0;
+  // Request: make this roughly 2x stronger than the previous PR tuning.
+  const sideSeatLift = isSideSeat ? 24.32 * MODEL_SCALE : 0;
+  const topSeatLift = isTopSeat ? 26.56 * MODEL_SCALE : 0;
+  const nonBottomOutwardPush = !isBottomHumanSeat ? -28.48 * MODEL_SCALE : 0;
   const bottomForwardPull = isBottomHumanSeat ? -4.64 * MODEL_SCALE : 0;
   const sideSeatLateralPull =
     isSideSeat


### PR DESCRIPTION
### Motivation
- Increase visual separation of opponent held cards so they appear higher and farther from the table toward avatars in portrait mobile framing with a stronger offset than the previous tuning.

### Description
- Doubled the pose tuning constants in `computeHeldCardsPose` in `webapp/src/pages/Games/MurlanRoyaleArena.jsx`: `sideSeatLift` changed from `12.16 * MODEL_SCALE` to `24.32 * MODEL_SCALE`, `topSeatLift` from `13.28 * MODEL_SCALE` to `26.56 * MODEL_SCALE`, and `nonBottomOutwardPush` from `-14.24 * MODEL_SCALE` to `-28.48 * MODEL_SCALE`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f60edc92c08329a585975ab83bf25a)