### PR TITLE
Murlan Royale: Double held-card lift and outward offset

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1773,18 +1773,18 @@ function computeHeldCardsPose({ player, resolvedSeatIndex = 0 }) {
 
   // Lift opponent cards higher and push them outward (away from table center)
   // so they sit closer to the avatar/chest area in portrait framing.
-  const sideSeatLift = isSideSeat ? 24.32 * MODEL_SCALE : 0;
-  const topSeatLift = isTopSeat ? 26.56 * MODEL_SCALE : 0;
-  const nonBottomOutwardPush = !isBottomHumanSeat ? -28.48 * MODEL_SCALE : 0;
-  const bottomForwardPull = isBottomHumanSeat ? -9.28 * MODEL_SCALE : 0;
+  const sideSeatLift = isSideSeat ? 48.64 * MODEL_SCALE : 0;
+  const topSeatLift = isTopSeat ? 53.12 * MODEL_SCALE : 0;
+  const nonBottomOutwardPush = !isBottomHumanSeat ? -56.96 * MODEL_SCALE : 0;
+  const bottomForwardPull = isBottomHumanSeat ? -18.56 * MODEL_SCALE : 0;
   const sideSeatLateralPull =
     isSideSeat
-      ? (normalizedSeatIndex === 1 ? -0.04 * MODEL_SCALE : 0.04 * MODEL_SCALE)
+      ? (normalizedSeatIndex === 1 ? -0.08 * MODEL_SCALE : 0.08 * MODEL_SCALE)
       : 0;
 
   return {
     x: sideSeatLateralPull,
-    y: 1.2 * MODEL_SCALE + sideSeatLift + topSeatLift + (isBottomHumanSeat ? 0.32 * MODEL_SCALE : 0.64 * MODEL_SCALE),
+    y: 1.2 * MODEL_SCALE + sideSeatLift + topSeatLift + (isBottomHumanSeat ? 0.64 * MODEL_SCALE : 1.28 * MODEL_SCALE),
     z: 0.82 * MODEL_SCALE + nonBottomOutwardPush + bottomForwardPull
   };
 }


### PR DESCRIPTION
### Motivation
- Improve portrait-mobile framing by moving opponents' held cards visually closer to their avatars/chest area. 
- User requested to apply the same tuning from the previous PR but at twice the magnitude to make cards sit noticeably higher and further from the table. 
- This is a visual/layout tuning change focused on seated player presentation in the arena.

### Description
- Increased the card pose offsets in `computeHeldCardsPose` inside `webapp/src/pages/Games/MurlanRoyaleArena.jsx` so the side/top/bottom lifts and outward pushes are doubled. 
- Specifically adjusted `sideSeatLift`, `topSeatLift`, `nonBottomOutwardPush`, `bottomForwardPull`, the side-seat lateral pull, and the bottom-seat Y bias to scale up the previous tuning. 
- The change only updates pose math used to position held card groups and does not touch rendering/material or gameplay logic.

### Testing
- No automated tests were run for this visual layout tweak.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6116f28d88329ba503468fcee705a)