### PR TITLE
Tennis: lower camera & HUD, larger court, dedicated lobby with flag avatars, menu and thumbnail updates

### DIFF
--- a/webapp/public/assets/icons/tennis-icon.svg
+++ b/webapp/public/assets/icons/tennis-icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256"><rect width="256" height="256" rx="48" fill="#0c1b2a"/><text x="128" y="152" text-anchor="middle" font-size="96">🎾</text></svg>

--- a/webapp/src/config/gameAssets.js
+++ b/webapp/src/config/gameAssets.js
@@ -24,6 +24,8 @@ export const gameThumbnails = {
   fourinrowroyale: '/assets/icons/four-in-row-royale.svg',
   tavullbattleroyal: '/assets/icons/Backgammonroyallogo.png',
   ludobattleroyal: '/assets/icons/Ludo%20battle%20Royal%20game%20logo.png',
+  tennis: '/assets/icons/tennis-icon.svg',
+  tabletennis: '/assets/icons/Goal%20rush%20logo.png',
 };
 
 const buildLobbyIconSet = (keys, icon) =>

--- a/webapp/src/config/gamesCatalog.js
+++ b/webapp/src/config/gamesCatalog.js
@@ -10,9 +10,9 @@ const gamesCatalog = [
   },
   {
     name: 'Tennis',
-    route: '/games/tennis',
+    route: '/games/tennis/lobby',
     slug: 'tennis',
-    image: '/assets/icons/Goal%20rush%20logo.png',
+    image: '/assets/icons/tennis-icon.svg',
     description: '3D tennis rally with swipe controls and physics.'
   },
   {

--- a/webapp/src/pages/Games/Tennis.tsx
+++ b/webapp/src/pages/Games/Tennis.tsx
@@ -100,9 +100,9 @@ const UP = new THREE.Vector3(0, 1, 0);
 const Y_AXIS = UP;
 
 const CFG = {
-  courtW: 4.18,
-  doublesW: 5.25,
-  courtL: 12.1,
+  courtW: 5.25,
+  doublesW: 6.4,
+  courtL: 14.0,
   serviceLineZ: 2.85,
   netH: 0.64,
   ballR: 0.085,
@@ -196,7 +196,7 @@ function addCourt(scene: THREE.Scene) {
   const netWhite = material(0xf7f7f7, 0.5, 0.0);
   const postMat = material(0x333333, 0.35, 0.25);
 
-  addBox(group, [9.8, 0.045, 15.9], [0, -0.045, 0], floorMat);
+  addBox(group, [11.6, 0.045, 18.8], [0, -0.045, 0], floorMat);
   addBox(group, [CFG.doublesW + 1.15, 0.035, CFG.courtL + 1.15], [0, -0.015, 0], outerMat);
   addBox(group, [CFG.courtW, 0.04, CFG.courtL], [0, 0.004, 0], courtMat);
   addBox(group, [CFG.courtW - 0.2, 0.043, CFG.serviceLineZ * 2], [0, 0.012, 0], serviceMat);
@@ -896,7 +896,7 @@ export default function MobileThreeTennisPrototype() {
       renderer.setPixelRatio(Math.min(2, window.devicePixelRatio || 1));
       camera.aspect = w / h;
       camera.fov = camera.aspect < 0.72 ? 48 : 42;
-      camera.position.set(0, camera.aspect < 0.72 ? 6.95 : 6.15, camera.aspect < 0.72 ? 8.15 : 7.35);
+      camera.position.set(0, camera.aspect < 0.72 ? 6.2 : 5.45, camera.aspect < 0.72 ? 8.15 : 7.35);
       camera.lookAt(cameraTarget);
       camera.updateProjectionMatrix();
     };
@@ -1098,7 +1098,7 @@ export default function MobileThreeTennisPrototype() {
         <canvas ref={canvasRef} style={{ width: "100%", height: "100%", display: "block", touchAction: "none" }} />
       </div>
       <div style={{ position: "fixed", inset: 0, pointerEvents: "none", fontFamily: "system-ui, -apple-system, BlinkMacSystemFont, sans-serif" }}>
-        <div style={{ position: "absolute", left: 10, right: 10, top: 8, color: "white", background: "rgba(5,12,18,0.78)", border: "1px solid rgba(255,255,255,0.2)", padding: "8px 10px", borderRadius: 14, fontSize: 12, boxShadow: "0 12px 26px rgba(0,0,0,0.22)" }}>
+        <div style={{ position: "absolute", left: 10, right: 10, top: 34, color: "white", background: "rgba(5,12,18,0.78)", border: "1px solid rgba(255,255,255,0.2)", padding: "8px 10px", borderRadius: 14, fontSize: 12, boxShadow: "0 12px 26px rgba(0,0,0,0.22)" }}>
           <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8 }}>
             <div style={{ display: "flex", alignItems: "center", gap: 7 }}>
               <div style={{ width: 30, height: 30, borderRadius: "999px", overflow: "hidden", border: "1px solid rgba(255,255,255,.25)", background: "#1f2937" }}>{playerAvatar ? <img src={playerAvatar} alt={playerName} style={{ width: "100%", height: "100%", objectFit: "cover" }} /> : null}</div>
@@ -1109,7 +1109,7 @@ export default function MobileThreeTennisPrototype() {
               <div><div style={{ fontWeight: 700, textAlign: "right" }}>{rivalName}</div><div style={{ opacity: 0.7, textAlign: "right" }}>Points {hud.farScore}</div></div>
               <div style={{ width: 30, height: 30, borderRadius: "999px", border: "1px solid rgba(255,255,255,.25)", background: "#334155", display: "flex", alignItems: "center", justifyContent: "center" }}>🎾</div>
             </div>
-            <button type="button" style={{ pointerEvents: "auto", width: 32, height: 32, borderRadius: 8, border: "1px solid rgba(255,255,255,0.25)", background: "rgba(255,255,255,0.08)", color: "#fff" }} onClick={() => alert("Menu: graphics options are available from the game settings panel.")}>☰</button>
+            <button type="button" style={{ pointerEvents: "auto", width: 92, height: 34, borderRadius: 999, border: "1px solid rgba(255,255,255,0.25)", background: "rgba(0,0,0,0.55)", color: "#fff", fontWeight: 700, letterSpacing: 0.4 }} onClick={() => alert("Menu: graphics options are available from the game settings panel.")}>☰ Menu</button>
           </div>
           <div style={{ fontSize: 11, fontWeight: 600, opacity: 0.82, marginTop: 6, textAlign: "center" }}>{hud.status}</div>
         </div>

--- a/webapp/src/pages/Games/TennisLobby.jsx
+++ b/webapp/src/pages/Games/TennisLobby.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import useTelegramBackButton from '../../hooks/useTelegramBackButton.js';
 import { ensureAccountId, getTelegramFirstName, getTelegramId, getTelegramPhotoUrl } from '../../utils/telegram.js';
@@ -7,6 +7,7 @@ import { loadAvatar } from '../../utils/avatarUtils.js';
 import GameLobbyHeader from '../../components/GameLobbyHeader.jsx';
 import { runSimpleOnlineFlow } from '../../utils/simpleOnlineFlow.js';
 import { socket } from '../../utils/socket.js';
+import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
 
 export default function TennisLobby() {
   const navigate = useNavigate();
@@ -15,6 +16,8 @@ export default function TennisLobby() {
   const [stake, setStake] = useState({ token: 'TPC', amount: 100 });
   const [avatar, setAvatar] = useState('');
   const [matching, setMatching] = useState(false);
+  const [playerFlag, setPlayerFlag] = useState('🇺🇸');
+  const [aiFlag, setAiFlag] = useState('🇬🇧');
   const [matchStatus, setMatchStatus] = useState('');
   const [matchError, setMatchError] = useState('');
 
@@ -24,6 +27,16 @@ export default function TennisLobby() {
       setAvatar(saved || getTelegramPhotoUrl());
     } catch {}
   }, []);
+
+
+  const playerAvatar = useMemo(() => `${playerFlag} You`, [playerFlag]);
+  const aiAvatar = useMemo(() => `${aiFlag} AI`, [aiFlag]);
+
+  const randomAiFlag = () => {
+    const available = FLAG_EMOJIS.filter((flag) => flag !== playerFlag);
+    if (!available.length) return '🤖';
+    return available[Math.floor(Math.random() * available.length)] || '🤖';
+  };
 
   const startGame = async () => {
     if (mode === 'online') {
@@ -44,6 +57,7 @@ export default function TennisLobby() {
           if (stake.amount) params.set('amount', String(stake.amount));
           if (avatar) params.set('avatar', avatar);
           params.set('name', getTelegramFirstName() || 'Player');
+          params.set('playerFlag', playerFlag);
           navigate(`/games/tennis?${params.toString()}`);
         }
       });
@@ -52,8 +66,12 @@ export default function TennisLobby() {
 
     const params = new URLSearchParams();
     params.set('mode', 'ai');
+    const pickedAiFlag = randomAiFlag();
+    setAiFlag(pickedAiFlag);
     if (avatar) params.set('avatar', avatar);
     params.set('name', getTelegramFirstName() || 'Player');
+    params.set('playerFlag', playerFlag);
+    params.set('opponent', `${pickedAiFlag} AI`);
     navigate(`/games/tennis?${params.toString()}`);
   };
 
@@ -61,9 +79,17 @@ export default function TennisLobby() {
     <div className="relative min-h-screen bg-[#070b16] text-text">
       <div className="absolute inset-0 tetris-grid-bg opacity-60" />
       <div className="relative z-10 space-y-4 p-4 pb-8">
-        <GameLobbyHeader slug="tennis" title="Table Tennis Lobby" badge="1v1 only" />
+        <GameLobbyHeader slug="tennis" title="Tennis Lobby" badge="1v1 only" />
         <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-[#101828]/80 to-[#0b1324]/90 p-4 text-white/80">
-          <p className="text-xs">Mode rules: AI is free, Online uses TPC streak stake.</p>
+          <p className="text-xs">Mode rules: 1v1 only. Vs AI is free, Online uses TPC streak stake.</p>
+          <div className="mt-3 grid grid-cols-2 gap-3">
+            <button type="button" onClick={() => setPlayerFlag(FLAG_EMOJIS[(FLAG_EMOJIS.indexOf(playerFlag) + 1) % FLAG_EMOJIS.length] || '🇺🇸')} className="lobby-option-card lobby-option-card-inactive">
+              <p className="lobby-option-label">{playerAvatar}</p><p className="lobby-option-subtitle">Tap to change your flag avatar</p>
+            </button>
+            <div className="lobby-option-card lobby-option-card-inactive">
+              <p className="lobby-option-label">{aiAvatar}</p><p className="lobby-option-subtitle">AI avatar randomizes every new AI game</p>
+            </div>
+          </div>
           <div className="mt-3 grid grid-cols-2 gap-3">
             <button type="button" onClick={() => setMode('ai')} className={`lobby-option-card ${mode === 'ai' ? 'lobby-option-card-active' : 'lobby-option-card-inactive'}`}>
               <p className="lobby-option-label">Vs AI</p><p className="lobby-option-subtitle">Free practice</p>


### PR DESCRIPTION
### Motivation
- Improve portrait UX by moving the in-game camera and HUD visuals lower so player names/points appear closer to the bottom of the screen. 
- Make the tennis arena feel bigger by increasing court and floor dimensions. 
- Provide a dedicated Tennis lobby (1v1 only) that uses world-flag avatars (like other games) and randomly picks an AI flag per new AI match, while avoiding confusion with the Table Tennis lobby. 
- Align the in-game menu control placement/style to match the requested placement and add clear tennis thumbnail branding.

### Description
- Adjusted in-game playfield and camera in `webapp/src/pages/Games/Tennis.tsx` by increasing `CFG.courtW`, `CFG.doublesW`, and `CFG.courtL`, expanding the base floor box, lowering the camera `position.set(...)`, and moving the top HUD container down via its `top` style; also replaced the compact menu icon with a fuller `☰ Menu` control for better placement. 
- Updated the Tennis lobby in `webapp/src/pages/Games/TennisLobby.jsx` to be tennis-specific (title/text), added `playerFlag`/`aiFlag` state and a simple flag picker using `FLAG_EMOJIS`, randomized the AI avatar flag when starting an AI game, and included the selected flag in the navigation params (`playerFlag` / `opponent`). 
- Wired catalog and assets so Tennis opens its lobby and shows a proper tennis thumbnail by updating `webapp/src/config/gamesCatalog.js` (route → `/games/tennis/lobby`, image → tennis icon) and `webapp/src/config/gameAssets.js` (added `tennis` thumbnail entry). 
- Added a small tennis SVG thumbnail asset at `webapp/public/assets/icons/tennis-icon.svg` (emoji-based placeholder) and minor UI copy/text tweaks in the lobby to clearly state the 1v1 mode and AI/online rules.

### Testing
- Built the web app with `cd webapp && npm run -s build`, and the build completed successfully. 
- The build emitted pre-existing project warnings (duplicate package key and large chunk advisories) which are unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f613940254832996e3fe81a95307f0)