### PR TITLE
Increase opponent card lift and outward offset in Murlan Royale

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1773,9 +1773,9 @@ function computeHeldCardsPose({ player, resolvedSeatIndex = 0 }) {
 
   // Lift opponent cards higher and push them outward (away from table center)
   // so they sit closer to the avatar/chest area in portrait framing.
-  const sideSeatLift = isSideSeat ? 48.64 * MODEL_SCALE : 0;
-  const topSeatLift = isTopSeat ? 53.12 * MODEL_SCALE : 0;
-  const nonBottomOutwardPush = !isBottomHumanSeat ? -56.96 * MODEL_SCALE : 0;
+  const sideSeatLift = isSideSeat ? 97.28 * MODEL_SCALE : 0;
+  const topSeatLift = isTopSeat ? 106.24 * MODEL_SCALE : 0;
+  const nonBottomOutwardPush = !isBottomHumanSeat ? -113.92 * MODEL_SCALE : 0;
   const bottomForwardPull = isBottomHumanSeat ? -18.56 * MODEL_SCALE : 0;
   const sideSeatLateralPull =
     isSideSeat
@@ -2454,8 +2454,8 @@ const TOP_AI_HAND_CARD_SPACING_MULTIPLIER = 0.94;
 const TOP_AI_HAND_CARD_MAX_SPREAD_MULTIPLIER = 0.9;
 const SIDE_AI_HAND_CARD_SPACING_MULTIPLIER = 0.92;
 const SIDE_AI_HAND_CARD_MAX_SPREAD_MULTIPLIER = 0.88;
-const AI_TOP_SIDE_HAND_UP_SHIFT_Y = 0.32 * MODEL_SCALE;
-const AI_TOP_SIDE_HAND_OUTWARD_PUSH = 0.34 * MODEL_SCALE;
+const AI_TOP_SIDE_HAND_UP_SHIFT_Y = 0.64 * MODEL_SCALE;
+const AI_TOP_SIDE_HAND_OUTWARD_PUSH = 0.68 * MODEL_SCALE;
 const AI_HAND_FAN_MAX_YAW = HUMAN_HAND_FAN_MAX_YAW;
 const AI_HAND_FAN_ARC_LIFT = 0.062 * MODEL_SCALE;
 const HUMAN_HAND_TABLE_EDGE_MARGIN = CARD_H * 0.04;


### PR DESCRIPTION
### Motivation
- Improve portrait mobile readability by moving opponent cards visually higher and farther away from the table so they appear closer to avatars/hands, applying ~2x the previous upward/outward adjustment.

### Description
- Doubled opponent hand/card layout offsets in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` by updating the held-card pose constants (`sideSeatLift`, `topSeatLift`, `nonBottomOutwardPush`) and runtime top/side AI hand constants (`AI_TOP_SIDE_HAND_UP_SHIFT_Y`, `AI_TOP_SIDE_HAND_OUTWARD_PUSH`) while preserving human-bottom seat behavior.

### Testing
- Verified the edits with targeted code searches (`rg`) to confirm the updated constant values in `webapp/src/pages/Games/MurlanRoyaleArena.jsx` and ensured no other files were affected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6181b5b188329bd13926e5ab22255)