### PR TITLE
Adjust tennis HUD and camera framing for mobile portrait

### DIFF
--- a/webapp/src/pages/Games/Tennis.tsx
+++ b/webapp/src/pages/Games/Tennis.tsx
@@ -836,7 +836,8 @@ export default function MobileThreeTennisPrototype() {
     scene.fog = new THREE.Fog(0x07100c, 12, 21);
 
     const camera = new THREE.PerspectiveCamera(46, 1, 0.05, 60);
-    const cameraTarget = new THREE.Vector3(0, 0.78, -0.7);
+    const cameraTarget = new THREE.Vector3(0, 0.96, -0.95);
+    const cameraDesiredPos = new THREE.Vector3();
 
     scene.add(new THREE.AmbientLight(0xffffff, 0.62));
     scene.add(new THREE.HemisphereLight(0xffffff, 0x254c3d, 0.7));
@@ -896,7 +897,7 @@ export default function MobileThreeTennisPrototype() {
       renderer.setPixelRatio(Math.min(2, window.devicePixelRatio || 1));
       camera.aspect = w / h;
       camera.fov = camera.aspect < 0.72 ? 48 : 42;
-      camera.position.set(0, camera.aspect < 0.72 ? 6.2 : 5.45, camera.aspect < 0.72 ? 8.15 : 7.35);
+      camera.position.set(0, camera.aspect < 0.72 ? 5.25 : 4.7, camera.aspect < 0.72 ? 9.9 : 8.9);
       camera.lookAt(cameraTarget);
       camera.updateProjectionMatrix();
     };
@@ -1066,6 +1067,18 @@ export default function MobileThreeTennisPrototype() {
       ghost.position.z += (nearPlayer.target.z - ghost.position.z) * (1 - Math.exp(-12 * dt));
       (ghost.material as THREE.MeshBasicMaterial).opacity = controlRef.current.active ? 0.62 : 0.28;
 
+      const portrait = camera.aspect < 0.72;
+      const followY = portrait ? 4.95 : 4.45;
+      const followBack = portrait ? 6.7 : 6.15;
+      const lookAheadZ = portrait ? 8.75 : 8.2;
+
+      cameraDesiredPos.set(
+        nearPlayer.pos.x * 0.22,
+        followY,
+        nearPlayer.pos.z + followBack
+      );
+      camera.position.lerp(cameraDesiredPos, 1 - Math.exp(-4.5 * dt));
+      cameraTarget.set(nearPlayer.pos.x * 0.16, 0.96, nearPlayer.pos.z - lookAheadZ);
       camera.lookAt(cameraTarget);
       renderer.render(scene, camera);
     }
@@ -1098,7 +1111,7 @@ export default function MobileThreeTennisPrototype() {
         <canvas ref={canvasRef} style={{ width: "100%", height: "100%", display: "block", touchAction: "none" }} />
       </div>
       <div style={{ position: "fixed", inset: 0, pointerEvents: "none", fontFamily: "system-ui, -apple-system, BlinkMacSystemFont, sans-serif" }}>
-        <div style={{ position: "absolute", left: 10, right: 10, top: 34, color: "white", background: "rgba(5,12,18,0.78)", border: "1px solid rgba(255,255,255,0.2)", padding: "8px 10px", borderRadius: 14, fontSize: 12, boxShadow: "0 12px 26px rgba(0,0,0,0.22)" }}>
+        <div style={{ position: "absolute", left: 10, right: 10, top: 68, color: "white", background: "rgba(5,12,18,0.78)", border: "1px solid rgba(255,255,255,0.2)", padding: "8px 10px", borderRadius: 14, fontSize: 12, boxShadow: "0 12px 26px rgba(0,0,0,0.22)" }}>
           <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8 }}>
             <div style={{ display: "flex", alignItems: "center", gap: 7 }}>
               <div style={{ width: 30, height: 30, borderRadius: "999px", overflow: "hidden", border: "1px solid rgba(255,255,255,.25)", background: "#1f2937" }}>{playerAvatar ? <img src={playerAvatar} alt={playerName} style={{ width: "100%", height: "100%", objectFit: "cover" }} /> : null}</div>


### PR DESCRIPTION
### Motivation
- Improve mobile portrait UX so the score/avatar/menu frame sits lower on screen and does not overlap gameplay visuals. 
- Ensure the in-game camera starts behind the human player and frames the full court so the bottom character is visible at match start. 

### Description
- Modified `webapp/src/pages/Games/Tennis.tsx` to move the HUD/menu frame down by changing the top offset from `top: 34` to `top: 68` so avatars, usernames and scores appear lower on portrait screens. 
- Reworked camera setup by updating the `cameraTarget` initial vector and adding a `cameraDesiredPos` vector for follow behaviour. 
- Adjusted camera base positions in `resize()` to use lower and farther-back values for portrait/startup framing. 
- Implemented a smooth behind-the-player follow in the `animate()` loop that computes `cameraDesiredPos` and lerps the camera while updating `cameraTarget` relative to the near player's position. 

### Testing
- Ran `npx eslint webapp/src/pages/Games/Tennis.tsx`, which completed successfully but the file is ignored by the project ESLint config so no lint errors were applied.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f63491922c8329b7f8e22aa9f810fc)