### PR TITLE
Tennis: add inventory + store entries, in-game ad boards, AI/physics tweaks, loader & audio

### DIFF
--- a/test/tennisInventoryConfig.test.js
+++ b/test/tennisInventoryConfig.test.js
@@ -1,0 +1,14 @@
+import { TENNIS_HDRI_OPTIONS, TENNIS_STORE_ITEMS } from '../webapp/src/config/tennisInventoryConfig.js';
+
+const REQUIRED = ['suburbanGarden','countryTrackMidday','autumnPark','rooitouPark','rotesRathaus','veniceDawn2','piazzaSanMarco'];
+
+describe('tennis hdri catalog', () => {
+  test('contains requested ids in options and store', () => {
+    const optionIds = new Set(TENNIS_HDRI_OPTIONS.map((i) => i.id));
+    const storeIds = new Set(TENNIS_STORE_ITEMS.map((i) => i.optionId));
+    REQUIRED.forEach((id) => {
+      expect(optionIds.has(id)).toBe(true);
+      expect(storeIds.has(id)).toBe(true);
+    });
+  });
+});

--- a/webapp/src/config/tennisInventoryConfig.js
+++ b/webapp/src/config/tennisInventoryConfig.js
@@ -1,0 +1,30 @@
+import { polyHavenThumb } from './storeThumbnails.js';
+
+const reduceLabels = (items) => items.reduce((acc, option) => { acc[option.id] = option.label; return acc; }, {});
+
+export const TENNIS_HDRI_OPTIONS = Object.freeze([
+  { id:'suburbanGarden', name:'Suburban Garden', label:'Suburban Garden HDRI', assetId:'suburban_garden', price: 1900 },
+  { id:'countryTrackMidday', name:'Country Track Midday', label:'Country Track Midday HDRI', assetId:'country_track_midday', price: 1920 },
+  { id:'autumnPark', name:'Autumn Park', label:'Autumn Park HDRI', assetId:'autumn_park', price: 1940 },
+  { id:'rooitouPark', name:'Rooitou Park', label:'Rooitou Park HDRI', assetId:'rooitou_park', price: 1980 },
+  { id:'rotesRathaus', name:'Rotes Rathaus', label:'Rotes Rathaus HDRI', assetId:'rotes_rathaus', price: 2020 },
+  { id:'veniceDawn2', name:'Venice Dawn 2', label:'Venice Dawn 2 HDRI', assetId:'venice_dawn_2', price: 2060 },
+  { id:'piazzaSanMarco', name:'Piazza San Marco', label:'Piazza San Marco HDRI', assetId:'piazza_san_marco', price: 2120 }
+].map((variant) => ({ ...variant, thumbnail: polyHavenThumb(variant.assetId), type: 'environmentHdri' })));
+
+export const TENNIS_DEFAULT_LOADOUT = Object.freeze({ environmentHdri: [TENNIS_HDRI_OPTIONS[0].id] });
+
+export const TENNIS_OPTION_LABELS = Object.freeze({ environmentHdri: Object.freeze(reduceLabels(TENNIS_HDRI_OPTIONS)) });
+
+export const TENNIS_STORE_ITEMS = Object.freeze(
+  TENNIS_HDRI_OPTIONS.map((option) => ({
+    id: `tennis-hdri-${option.id}`,
+    type: 'environmentHdri',
+    optionId: option.id,
+    name: option.name,
+    price: option.price,
+    description: `Official Poly Haven ${option.name} environment for Tennis arenas.`,
+    thumbnail: option.thumbnail,
+    swatches: ['#0f172a', '#38bdf8']
+  }))
+);

--- a/webapp/src/pages/Games/Tennis.tsx
+++ b/webapp/src/pages/Games/Tennis.tsx
@@ -3,11 +3,13 @@
 import React, { useEffect, useRef, useState } from "react";
 import * as THREE from "three";
 import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js";
+import { DRACOLoader } from "three/examples/jsm/loaders/DRACOLoader.js";
+import { MeshoptDecoder } from "three/examples/jsm/libs/meshopt_decoder.module.js";
 import { useLocation } from "react-router-dom";
 
 type PlayerSide = "near" | "far";
 type PointReason = "winner" | "out" | "doubleBounce" | "net";
-type StrokeAction = "ready" | "forehand" | "serve";
+type StrokeAction = "ready" | "forehand" | "backhand" | "slice" | "lob" | "serve";
 
 type BallState = {
   mesh: THREE.Mesh;
@@ -113,9 +115,9 @@ const CFG = {
   minBallSpeed: 0.12,
   playerHeight: 1.82,
   playerSpeed: 5.2,
-  aiSpeed: 4.65,
+  aiSpeed: 5.45,
   reach: 0.92,
-  swingDuration: 0.42,
+  swingDuration: 0.38,
   serveDuration: 0.86,
   hitWindowStart: 0.42,
   hitWindowEnd: 0.72,
@@ -183,7 +185,40 @@ function getWorldPos(obj: THREE.Object3D) {
   return obj.getWorldPosition(new THREE.Vector3());
 }
 
+
+function createScrollingAdTexture(title: string, subtitle: string, bg: string, fg: string) {
+  const canvas = document.createElement("canvas");
+  canvas.width = 1024;
+  canvas.height = 256;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return { texture: new THREE.CanvasTexture(canvas), update: () => {} };
+  let offset = 0;
+  const update = (dt: number) => {
+    offset = (offset + dt * 180) % canvas.width;
+    ctx.fillStyle = bg;
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    for (let x = -canvas.width; x < canvas.width * 2; x += 280) {
+      const px = x - offset;
+      ctx.fillStyle = "rgba(255,255,255,0.08)";
+      ctx.fillRect(px, 0, 120, canvas.height);
+      ctx.fillStyle = fg;
+      ctx.font = "900 54px system-ui";
+      ctx.fillText(title, px + 16, 98);
+      ctx.font = "700 28px system-ui";
+      ctx.fillText(subtitle, px + 16, 156);
+    }
+  };
+  update(0);
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.colorSpace = THREE.SRGBColorSpace;
+  texture.wrapS = THREE.RepeatWrapping;
+  texture.wrapT = THREE.ClampToEdgeWrapping;
+  texture.needsUpdate = true;
+  return { texture, update: (dt: number) => { update(dt); texture.needsUpdate = true; } };
+}
+
 function addCourt(scene: THREE.Scene) {
+  const adBoards: Array<{ mesh: THREE.Mesh; update: (dt:number)=>void }> = [];
   const group = new THREE.Group();
   scene.add(group);
 
@@ -225,6 +260,13 @@ function addCourt(scene: THREE.Scene) {
   for (let i = -5; i <= 5; i++) addBox(group, [0.012, CFG.netH * 0.92, 0.03], [(i * CFG.doublesW) / 10, CFG.netH * 0.46, 0.018], transparentMaterial(0xffffff, 0.28));
   for (let j = 1; j <= 3; j++) addBox(group, [CFG.doublesW + 0.12, 0.011, 0.032], [0, (j * CFG.netH) / 4, 0.019], transparentMaterial(0xffffff, 0.24));
 
+  const adSpecs: Array<[number, number, number, number, string, string]> = [[-3.7, 1.25, -4.2, 0, "POOL ROYALE", "Play now"],[3.7,1.25,-4.2,0,"SNOOKER ROYAL","New arenas"],[-3.7,1.25,4.2,0,"GOAL RUSH","1v1 challenge"],[3.7,1.25,4.2,0,"TEXAS HOLDEM","Live tables"],[-3.2,1.25,0,Math.PI/2,"CHESS BATTLE","Tactics"],[3.2,1.25,0,-Math.PI/2,"SNAKE LADDER","Quick match"]];
+  adSpecs.forEach(([x,y,z,ry,title,subtitle],idx)=>{
+    const ad = createScrollingAdTexture(title, subtitle, idx % 2 === 0 ? "#0f172a" : "#1f2937", idx % 2 === 0 ? "#38bdf8" : "#f97316");
+    const mat = new THREE.MeshStandardMaterial({ map: ad.texture, emissive: new THREE.Color(0x111111), emissiveIntensity: 0.35, roughness: 0.4, metalness: 0.06 });
+    const board = addBox(group,[1.9,0.64,0.05],[x,y,z], mat); board.rotation.y=ry; adBoards.push({ mesh: board, update: ad.update });
+  });
+  (group as THREE.Group & { userData: Record<string, unknown> }).userData.adBoards = adBoards;
   return group;
 }
 
@@ -466,7 +508,12 @@ function addHuman(scene: THREE.Scene, side: PlayerSide, start: THREE.Vector3, ac
   modelRoot.rotation.y = rig.yaw;
   racket.visible = false;
 
-  new GLTFLoader().setCrossOrigin("anonymous").load(
+  const gltfLoader = new GLTFLoader().setCrossOrigin("anonymous");
+  const dracoLoader = new DRACOLoader();
+  dracoLoader.setDecoderPath("https://www.gstatic.com/draco/versioned/decoders/1.5.7/");
+  gltfLoader.setDRACOLoader(dracoLoader);
+  gltfLoader.setMeshoptDecoder?.(MeshoptDecoder);
+  gltfLoader.load(
     HUMAN_URL,
     (gltf) => {
       const model = gltf.scene;
@@ -702,15 +749,17 @@ function makeUserTargetFromSwipe(startX: number, startY: number, endX: number, e
   return { target: new THREE.Vector3(aimX, CFG.ballR, targetZ), power };
 }
 
-function makeAiTarget(near: HumanRig, ball: BallState) {
+function makeAiTarget(near: HumanRig, ball: BallState, style: "drive" | "slice" | "lob" = "drive") {
   const pressure = clamp01((Math.abs(ball.pos.z) - 1.0) / (CFG.courtL / 2 - 1.0));
   const x = clamp(near.pos.x * 0.62 + (Math.random() - 0.5) * 1.15, -CFG.courtW / 2 + 0.45, CFG.courtW / 2 - 0.45);
-  const z = lerp(1.35, CFG.courtL / 2 - 1.0, 0.35 + pressure * 0.55);
-  const power = clamp(0.48 + pressure * 0.38 + Math.random() * 0.12, 0.42, 0.92);
+  const zBias = style === "lob" ? 0.72 : style === "slice" ? 0.44 : 0.56;
+  const z = lerp(1.35, CFG.courtL / 2 - 0.84, 0.3 + pressure * zBias);
+  const powerBoost = style === "drive" ? 0.12 : style === "slice" ? -0.04 : 0.02;
+  const power = clamp(0.52 + pressure * 0.36 + Math.random() * 0.16 + powerBoost, 0.45, 0.98);
   return { target: new THREE.Vector3(x, CFG.ballR, z), power };
 }
 
-function performHit(player: HumanRig, ball: BallState, hit: DesiredHit, serve = false) {
+function performHit(player: HumanRig, ball: BallState, hit: DesiredHit, serve = false, action: StrokeAction = "forehand", hitFx?: HTMLAudioElement) {
   const target = hit.target.clone();
   target.x = clamp(target.x, -CFG.courtW / 2 + 0.28, CFG.courtW / 2 - 0.28);
   target.z = player.side === "near" ? clamp(target.z, -CFG.courtL / 2 + 0.6, -0.65) : clamp(target.z, 0.65, CFG.courtL / 2 - 0.6);
@@ -719,12 +768,15 @@ function performHit(player: HumanRig, ball: BallState, hit: DesiredHit, serve = 
   else ball.pos.y = clamp(ball.pos.y, 0.58, 1.25);
 
   ball.vel.copy(ballisticVelocity(ball.pos, target, hit.power, serve));
-  ball.spin = serve ? 0.75 + hit.power * 0.65 : 0.3 + hit.power * 0.9;
+  if (action === "slice") { ball.vel.y *= 0.9; ball.vel.x += (Math.random()-0.5)*0.55; }
+  if (action === "lob") { ball.vel.y += 1.1; }
+  ball.spin = serve ? 0.75 + hit.power * 0.65 : (action === "slice" ? 1.2 : 0.35) + hit.power * (action === "forehand" || action === "backhand" ? 1.05 : 0.85);
   ball.lastHitBy = player.side;
   ball.bounceSide = null;
   ball.bounceCount = 0;
   player.cooldown = serve ? 0.42 : 0.28;
   player.hitThisSwing = true;
+  if (hitFx) { hitFx.currentTime = 0; hitFx.play().catch(() => {}); }
 }
 
 function canReachBall(player: HumanRig, ball: BallState) {
@@ -752,7 +804,7 @@ function updatePlayerMotion(player: HumanRig, ball: BallState, dt: number) {
   const to = player.target.clone().sub(player.pos);
   const dist = to.length();
   const maxStep = player.speed * dt;
-  if (dist > 0.0001) player.pos.addScaledVector(to.normalize(), Math.min(maxStep, dist));
+  if (player.swingT <= 0 && dist > 0.0001) player.pos.addScaledVector(to.normalize(), Math.min(maxStep, dist));
 
   player.pos.x = clamp(player.pos.x, -CFG.courtW / 2 + 0.35, CFG.courtW / 2 - 0.35);
   if (player.side === "near") player.pos.z = clamp(player.pos.z, 0.76, CFG.courtL / 2 - 0.42);
@@ -854,7 +906,8 @@ export default function MobileThreeTennisPrototype() {
     sun.shadow.camera.bottom = -9;
     scene.add(sun);
 
-    addCourt(scene);
+    const court = addCourt(scene);
+    const adBoards = ((court as THREE.Group).userData.adBoards || []) as Array<{ mesh: THREE.Mesh; update: (dt:number)=>void }>;
 
     const nearPlayer = addHuman(scene, "near", new THREE.Vector3(0, 0, CFG.courtL / 2 - 1.04), 0xff7a2f);
     const farPlayer = addHuman(scene, "far", new THREE.Vector3(0, 0, -CFG.courtL / 2 + 1.04), 0x62d2ff);
@@ -872,6 +925,12 @@ export default function MobileThreeTennisPrototype() {
 
     let frameId = 0;
     let last = performance.now();
+    const crowdLoop = new Audio("/assets/sounds/football-crowd-3-69245.mp3");
+    crowdLoop.loop = true; crowdLoop.volume = 0.22;
+    const cheerFx = new Audio("/assets/sounds/crowd-cheering-383111.mp3");
+    cheerFx.volume = 0.45;
+    const hitFx = new Audio("/assets/sounds/freesound_community-ping-pong-ball-100140.mp3");
+    hitFx.volume = 0.32;
     let pointLock = false;
     let pointLockT = 0;
 
@@ -888,6 +947,7 @@ export default function MobileThreeTennisPrototype() {
       };
       const reasonText = reason === "out" ? "Out ball" : reason === "doubleBounce" ? "Double bounce" : reason === "net" ? "Net fault" : "Point";
       setHud({ ...prev, ...next, status: `${reasonText}: ${winner === "near" ? "You" : "AI"} scores`, power: 0 });
+      cheerFx.currentTime = 0; cheerFx.play().catch(() => {});
     };
 
     const resize = () => {
@@ -1013,7 +1073,12 @@ export default function MobileThreeTennisPrototype() {
       } else {
         farPlayer.target.lerp(home, 0.035);
       }
-      if (ballComingToAi && canReachBall(farPlayer, ball) && farPlayer.swingT === 0) startSwing(farPlayer, makeAiTarget(nearPlayer, ball), "forehand");
+      if (ballComingToAi && canReachBall(farPlayer, ball) && farPlayer.swingT === 0) {
+        const r = Math.random();
+        const action: StrokeAction = r > 0.76 ? "lob" : r > 0.5 ? "slice" : r > 0.24 ? "backhand" : "forehand";
+        const aiStyle = action === "lob" ? "lob" : action === "slice" ? "slice" : "drive";
+        startSwing(farPlayer, makeAiTarget(nearPlayer, ball, aiStyle), action);
+      }
     }
 
     function checkSwingHits() {
@@ -1021,14 +1086,14 @@ export default function MobileThreeTennisPrototype() {
         if (player.swingT <= 0 || player.hitThisSwing || !player.desiredHit) continue;
         if (player.action === "serve") {
           if (player.swingT >= CFG.serveContactT) {
-            performHit(player, ball, player.desiredHit, true);
+            performHit(player, ball, player.desiredHit, true, player.action, hitFx);
             setHudSafe({ status: "Serve sent" });
           }
           continue;
         }
         if (player.swingT < CFG.hitWindowStart || player.swingT > CFG.hitWindowEnd) continue;
         if (canReachBall(player, ball)) {
-          performHit(player, ball, player.desiredHit, false);
+          performHit(player, ball, player.desiredHit, false, player.action, hitFx);
           setHudSafe({ status: player.side === "near" ? "Forehand return" : "AI returned" });
         }
       }
@@ -1068,21 +1133,24 @@ export default function MobileThreeTennisPrototype() {
       (ghost.material as THREE.MeshBasicMaterial).opacity = controlRef.current.active ? 0.62 : 0.28;
 
       const portrait = camera.aspect < 0.72;
-      const followY = portrait ? 4.95 : 4.45;
-      const followBack = portrait ? 6.7 : 6.15;
-      const lookAheadZ = portrait ? 8.75 : 8.2;
+      const followY = portrait ? 5.35 : 4.9;
+      const followBack = portrait ? 8.85 : 8.1;
+      const lookAheadZ = portrait ? 10.45 : 9.6;
 
-      cameraDesiredPos.set(
-        nearPlayer.pos.x * 0.22,
-        followY,
-        nearPlayer.pos.z + followBack
-      );
+      cameraDesiredPos.set(nearPlayer.pos.x * 0.18, followY, nearPlayer.pos.z + followBack);
       camera.position.lerp(cameraDesiredPos, 1 - Math.exp(-4.5 * dt));
-      cameraTarget.set(nearPlayer.pos.x * 0.16, 0.96, nearPlayer.pos.z - lookAheadZ);
+      cameraTarget.set(nearPlayer.pos.x * 0.1, 0.92, nearPlayer.pos.z - lookAheadZ);
+      adBoards.forEach((board, idx) => {
+        board.update(dt);
+        const pulse = 0.35 + 0.35 * (0.5 + 0.5 * Math.sin(now * 0.002 + idx));
+        const mat = board.mesh.material as THREE.MeshStandardMaterial;
+        mat.emissiveIntensity = pulse;
+      });
       camera.lookAt(cameraTarget);
       renderer.render(scene, camera);
     }
 
+    crowdLoop.play().catch(() => {});
     animate();
 
     return () => {
@@ -1092,6 +1160,8 @@ export default function MobileThreeTennisPrototype() {
       canvas.removeEventListener("pointermove", onPointerMove);
       canvas.removeEventListener("pointerup", onPointerUp);
       canvas.removeEventListener("pointercancel", onPointerUp);
+      crowdLoop.pause();
+      crowdLoop.currentTime = 0;
       renderer.dispose();
       scene.traverse((obj) => {
         const mesh = obj as THREE.Mesh;

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -133,6 +133,7 @@ import {
 } from '../config/texasHoldemInventoryConfig.js';
 import { TABLE_CLOTH_OPTIONS } from '../utils/tableCustomizationOptions.js';
 import { TABLE_SHAPE_OPTIONS } from '../utils/murlanTable.js';
+import { TENNIS_DEFAULT_LOADOUT, TENNIS_OPTION_LABELS, TENNIS_STORE_ITEMS } from '../config/tennisInventoryConfig.js';
 import {
   SNAKE_DEFAULT_LOADOUT,
   SNAKE_OPTION_LABELS,
@@ -1162,6 +1163,14 @@ const storeMeta = {
     labels: SNAKE_OPTION_LABELS,
     typeLabels: SNAKE_TYPE_LABELS,
     accountId: SNAKE_STORE_ACCOUNT_ID
+  },
+  tennis: {
+    name: 'Tennis',
+    items: TENNIS_STORE_ITEMS,
+    defaults: TENNIS_DEFAULT_LOADOUT,
+    labels: TENNIS_OPTION_LABELS,
+    typeLabels: TYPE_LABELS,
+    accountId: POOL_STORE_ACCOUNT_ID
   },
   texasholdem: {
     name: "Texas Hold'em",


### PR DESCRIPTION
### Motivation
- Provide a Tennis game product bundle (HDRI options and store items) and integrate it into the Store UI. 
- Improve the Tennis scene with richer visuals (scrolling ad boards), better model loading support, audio feedback, and more varied AI and player stroke behavior.

### Description
- Added a new inventory config `webapp/src/config/tennisInventoryConfig.js` that exports `TENNIS_HDRI_OPTIONS`, `TENNIS_DEFAULT_LOADOUT`, `TENNIS_OPTION_LABELS`, and `TENNIS_STORE_ITEMS` and uses `polyHavenThumb` for thumbnails. 
- Integrated Tennis store entries into `webapp/src/pages/Store.jsx` by importing and registering `TENNIS_DEFAULT_LOADOUT`, `TENNIS_OPTION_LABELS`, and `TENNIS_STORE_ITEMS`. 
- Added a unit test `test/tennisInventoryConfig.test.js` that asserts key HDRI ids are present in both options and store items. 
- Enhanced the Tennis scene in `webapp/src/pages/Games/Tennis.tsx` with the following changes: switched to use `DRACOLoader` and `MeshoptDecoder` for GLTF loading, expanded `StrokeAction` types, adjusted gameplay config values (`aiSpeed`, `swingDuration`), added scrolling ad board textures via `createScrollingAdTexture` and attached `adBoards` to the court, improved AI target selection and randomized stroke selection/styles, extended `performHit` to accept `action` and optional `hitFx` audio and modified ball behavior for `slice`/`lob`, prevented player translation while swinging, adjusted camera follow parameters, and added crowd/cheer/hit audio loops and cleanup. 

### Testing
- Ran unit tests with `npm test` and the new `tennisInventoryConfig.test.js` passed. 
- Existing test suite completed successfully with no regressions reported on the modified modules.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f63ca3fda48329923f094149e35f7e)