### PR TITLE
Add procedural human rig and cue-holding animation to SnookerRoyal

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -20433,6 +20433,68 @@ const powerRef = useRef(hud.power);
       const cueButtLocal = new THREE.Vector3(0, 0, cueLen / 2);
       const humanActor = new THREE.Group();
       const humanModelRoot = new THREE.Group();
+      const humanRigState = {
+        poseT: 0,
+        yaw: 0,
+        walkT: 0,
+        breathT: 0,
+        root: new THREE.Vector3(),
+        target: new THREE.Vector3(),
+        rightHandTarget: new THREE.Vector3(),
+        leftHandTarget: new THREE.Vector3(),
+        rightElbowTarget: new THREE.Vector3(),
+        leftElbowTarget: new THREE.Vector3()
+      };
+      const dampScalarHuman = (current, target, lambda, dt) => THREE.MathUtils.lerp(current, target, 1 - Math.exp(-lambda * dt));
+      const dampVectorHuman = (current, target, lambda, dt) => current.lerp(target, 1 - Math.exp(-lambda * dt));
+      const cleanBoneName = (name) => String(name || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+      const setBoneWorldQuaternion = (bone, q) => {
+        if (!bone || !q) return;
+        const parentQ = new THREE.Quaternion();
+        bone.parent?.getWorldQuaternion(parentQ);
+        bone.quaternion.copy(parentQ.invert().multiply(q));
+        bone.updateMatrixWorld(true);
+      };
+      const firstBoneChild = (bone) => bone?.children?.find((child) => child?.isBone);
+      const rotateBoneToward = (bone, target, strength = 1, fallbackDir = new THREE.Vector3(0, 1, 0)) => {
+        if (!bone || strength <= 0) return;
+        const bonePos = bone.getWorldPosition(new THREE.Vector3());
+        const childPos = firstBoneChild(bone)?.getWorldPosition(new THREE.Vector3()) || bonePos.clone().addScaledVector(fallbackDir.clone().normalize(), 0.25 * SCALE);
+        const current = childPos.sub(bonePos).normalize();
+        const desired = target.clone().sub(bonePos);
+        if (desired.lengthSq() < 1e-6 || current.lengthSq() < 1e-6) return;
+        const delta = new THREE.Quaternion().slerpQuaternions(new THREE.Quaternion(), new THREE.Quaternion().setFromUnitVectors(current, desired.normalize()), THREE.MathUtils.clamp(strength, 0, 1));
+        setBoneWorldQuaternion(bone, delta.multiply(bone.getWorldQuaternion(new THREE.Quaternion())));
+      };
+      const HUMAN_TABLE_FORWARD_OFFSET = SCALE * 2.7;
+      const HUMAN_TABLE_SIDE_OFFSET = SCALE * 0.42;
+      const HUMAN_HAND_SOCKET_TO_CUE = new THREE.Vector3(-0.02 * SCALE, -0.025 * SCALE, 0.095 * SCALE);
+      let humanRightHandBone = null;
+      let humanLeftHandBone = null;
+      let humanRightUpperArmBone = null;
+      let humanRightLowerArmBone = null;
+      let humanLeftUpperArmBone = null;
+      let humanLeftLowerArmBone = null;
+      const findHumanBone = (root, aliases = []) => {
+        const wanted = aliases.map((name) => String(name || '').toLowerCase().replace(/[^a-z0-9]/g, ''));
+        const allBones = [];
+        root?.traverse?.((obj) => {
+          if (obj?.isBone) allBones.push(obj);
+        });
+        const cleaned = (name) => cleanBoneName(name);
+        for (const alias of wanted) {
+          const exact = allBones.find((bone) => {
+            const n = cleaned(bone.name);
+            return n === alias || n.endsWith(alias);
+          });
+          if (exact) return exact;
+        }
+        for (const alias of wanted) {
+          const loose = allBones.find((bone) => cleaned(bone.name).includes(alias));
+          if (loose) return loose;
+        }
+        return null;
+      };
       humanActor.add(humanModelRoot);
       humanActor.visible = false;
       table.add(humanActor);
@@ -20457,6 +20519,12 @@ const powerRef = useRef(hud.power);
           const box = new THREE.Box3().setFromObject(model);
           const center = box.getCenter(new THREE.Vector3());
           model.position.set(-center.x, -box.min.y, -center.z);
+          humanRightHandBone = findHumanBone(model, ['righthand', 'handr', 'mixamorigRightHand']);
+          humanLeftHandBone = findHumanBone(model, ['lefthand', 'handl', 'mixamorigLeftHand']);
+          humanRightUpperArmBone = findHumanBone(model, ['rightupperarm', 'rightarm', 'mixamorigRightArm']);
+          humanRightLowerArmBone = findHumanBone(model, ['rightforearm', 'rightlowerarm', 'mixamorigRightForeArm']);
+          humanLeftUpperArmBone = findHumanBone(model, ['leftupperarm', 'leftarm', 'mixamorigLeftArm']);
+          humanLeftLowerArmBone = findHumanBone(model, ['leftforearm', 'leftlowerarm', 'mixamorigLeftForeArm']);
           humanModelRoot.add(model);
           humanActor.visible = true;
         },
@@ -26008,11 +26076,37 @@ const powerRef = useRef(hud.power);
             const sideX = forwardZ;
             const sideZ = -forwardX;
             humanActor.position.set(
-              cueStick.position.x - forwardX * (SCALE * 3.6) - sideX * (SCALE * 0.7),
+              cueStick.position.x - forwardX * HUMAN_TABLE_FORWARD_OFFSET - sideX * HUMAN_TABLE_SIDE_OFFSET,
               0,
-              cueStick.position.z - forwardZ * (SCALE * 3.6) - sideZ * (SCALE * 0.7)
+              cueStick.position.z - forwardZ * HUMAN_TABLE_FORWARD_OFFSET - sideZ * HUMAN_TABLE_SIDE_OFFSET
             );
-            humanActor.rotation.y = yaw;
+            humanRigState.yaw = dampScalarHuman(humanRigState.yaw, yaw, 8.5, deltaSeconds);
+            humanActor.rotation.y = humanRigState.yaw;
+            humanRigState.target.copy(humanActor.position);
+            dampVectorHuman(humanRigState.root, humanRigState.target, 6.4, deltaSeconds);
+            humanActor.position.copy(humanRigState.root);
+            humanRigState.breathT += deltaSeconds * 0.6;
+
+            if (humanRightHandBone) {
+              const cueDir = TMP_VEC3_E.copy(cueTipLocal).applyEuler(cueStick.rotation).add(cueStick.position).sub(TMP_VEC3_C.copy(cueButtLocal).applyEuler(cueStick.rotation).add(cueStick.position)).normalize();
+              const cueGripWorldSeed = TMP_VEC3_C.copy(cueButtLocal).applyEuler(cueStick.rotation).add(cueStick.position);
+              humanRigState.rightHandTarget.copy(cueGripWorldSeed).addScaledVector(cueDir, -0.02 * SCALE);
+              humanRigState.leftHandTarget.copy(cueGripWorldSeed).addScaledVector(cueDir, -0.58 * SCALE).addScaledVector(new THREE.Vector3(cueDir.z, 0, -cueDir.x).normalize(), -0.03 * SCALE);
+              humanRigState.rightElbowTarget.copy(humanRigState.rightHandTarget).addScaledVector(new THREE.Vector3(cueDir.z, 0.25, -cueDir.x).normalize(), -0.45 * SCALE).addScaledVector(new THREE.Vector3(0,1,0), 0.22 * SCALE);
+              humanRigState.leftElbowTarget.copy(humanRigState.leftHandTarget).addScaledVector(new THREE.Vector3(-cueDir.z, 0.15, cueDir.x).normalize(), -0.34 * SCALE).addScaledVector(new THREE.Vector3(0,1,0), 0.16 * SCALE);
+
+              rotateBoneToward(humanRightUpperArmBone, humanRigState.rightElbowTarget, 0.95);
+              rotateBoneToward(humanRightLowerArmBone, humanRigState.rightHandTarget, 0.98);
+              rotateBoneToward(humanLeftUpperArmBone, humanRigState.leftElbowTarget, 0.9);
+              rotateBoneToward(humanLeftLowerArmBone, humanRigState.leftHandTarget, 0.92);
+
+              humanActor.updateMatrixWorld(true);
+              const handWorld = humanRightHandBone.getWorldPosition(TMP_VEC3_A);
+              const handSocketWorld = TMP_VEC3_B.copy(HUMAN_HAND_SOCKET_TO_CUE).applyQuaternion(humanActor.quaternion).add(handWorld);
+              const cueGripWorld = TMP_VEC3_C.copy(cueButtLocal).applyEuler(cueStick.rotation).add(cueStick.position);
+              const attachDelta = TMP_VEC3_D.copy(cueGripWorld).sub(handSocketWorld);
+              humanActor.position.add(attachDelta);
+            }
           }
           renderer.render(scene, frameCamera ?? camera);
           const shouldStreamAim =


### PR DESCRIPTION
### Motivation

- Provide an in-scene human model that visually holds the cue and follows the cue stick to improve realism and player feedback. 
- Support a variety of GLTF rigs by heuristically finding bones and applying damped procedural posing so the avatar aligns smoothly with the cue.

### Description

- Introduce `humanRigState` and damping helpers `dampScalarHuman` and `dampVectorHuman` to smoothly interpolate pose, yaw, and root position over time.
- Add bone utilities `cleanBoneName`, `setBoneWorldQuaternion`, `firstBoneChild`, `rotateBoneToward`, and `findHumanBone` to locate and manipulate upper/lower arm and hand bones across different glTF naming conventions.
- Load a Ready Player Me GLB with `GLTFLoader`, scale/center it, populate bone references (`humanRightHandBone`, `humanLeftHandBone`, `humanRightUpperArmBone`, `humanRightLowerArmBone`, `humanLeftUpperArmBone`, `humanLeftLowerArmBone`), and toggle `humanActor.visible` based on load success.
- Compute actor placement relative to the cue using `HUMAN_TABLE_FORWARD_OFFSET`, `HUMAN_TABLE_SIDE_OFFSET`, and `HUMAN_HAND_SOCKET_TO_CUE`, then smooth yaw/position and compute hand and elbow targets to rotate arm bones toward the cue and attach the hand to the cue grip.

### Testing

- Ran the webapp build using `yarn build` and the build completed successfully. 
- Executed lint checks with `yarn lint` and no new issues were reported. 
- Ran the unit test suite with `yarn test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6501e10908329ad6b577fb50c13e2)