### PR TITLE
Adjust tennis HUD placement and camera framing for full-court view

### DIFF
--- a/webapp/src/pages/Games/Tennis.tsx
+++ b/webapp/src/pages/Games/Tennis.tsx
@@ -836,7 +836,9 @@ export default function MobileThreeTennisPrototype() {
     scene.fog = new THREE.Fog(0x07100c, 12, 21);
 
     const camera = new THREE.PerspectiveCamera(46, 1, 0.05, 60);
-    const cameraTarget = new THREE.Vector3(0, 0.78, -0.7);
+    const cameraTarget = new THREE.Vector3(0, 0.84, -0.95);
+    const cameraOffset = new THREE.Vector3(0, 3.65, 4.95);
+    const cameraPosTarget = new THREE.Vector3();
 
     scene.add(new THREE.AmbientLight(0xffffff, 0.62));
     scene.add(new THREE.HemisphereLight(0xffffff, 0x254c3d, 0.7));
@@ -896,7 +898,10 @@ export default function MobileThreeTennisPrototype() {
       renderer.setPixelRatio(Math.min(2, window.devicePixelRatio || 1));
       camera.aspect = w / h;
       camera.fov = camera.aspect < 0.72 ? 48 : 42;
-      camera.position.set(0, camera.aspect < 0.72 ? 6.2 : 5.45, camera.aspect < 0.72 ? 8.15 : 7.35);
+      if (camera.aspect < 0.72) cameraOffset.set(0, 3.95, 5.35);
+      else cameraOffset.set(0, 3.65, 4.95);
+      cameraPosTarget.copy(nearPlayer.target).add(cameraOffset);
+      camera.position.copy(cameraPosTarget);
       camera.lookAt(cameraTarget);
       camera.updateProjectionMatrix();
     };
@@ -1066,6 +1071,10 @@ export default function MobileThreeTennisPrototype() {
       ghost.position.z += (nearPlayer.target.z - ghost.position.z) * (1 - Math.exp(-12 * dt));
       (ghost.material as THREE.MeshBasicMaterial).opacity = controlRef.current.active ? 0.62 : 0.28;
 
+      cameraPosTarget.copy(nearPlayer.target).add(cameraOffset);
+      camera.position.lerp(cameraPosTarget, 1 - Math.exp(-5.5 * dt));
+      cameraTarget.x += (nearPlayer.target.x - cameraTarget.x) * (1 - Math.exp(-5.2 * dt));
+      cameraTarget.z += ((nearPlayer.target.z - 5.6) - cameraTarget.z) * (1 - Math.exp(-4.3 * dt));
       camera.lookAt(cameraTarget);
       renderer.render(scene, camera);
     }
@@ -1098,7 +1107,7 @@ export default function MobileThreeTennisPrototype() {
         <canvas ref={canvasRef} style={{ width: "100%", height: "100%", display: "block", touchAction: "none" }} />
       </div>
       <div style={{ position: "fixed", inset: 0, pointerEvents: "none", fontFamily: "system-ui, -apple-system, BlinkMacSystemFont, sans-serif" }}>
-        <div style={{ position: "absolute", left: 10, right: 10, top: 34, color: "white", background: "rgba(5,12,18,0.78)", border: "1px solid rgba(255,255,255,0.2)", padding: "8px 10px", borderRadius: 14, fontSize: 12, boxShadow: "0 12px 26px rgba(0,0,0,0.22)" }}>
+        <div style={{ position: "absolute", left: 10, right: 10, top: 64, color: "white", background: "rgba(5,12,18,0.78)", border: "1px solid rgba(255,255,255,0.2)", padding: "8px 10px", borderRadius: 14, fontSize: 12, boxShadow: "0 12px 26px rgba(0,0,0,0.22)" }}>
           <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8 }}>
             <div style={{ display: "flex", alignItems: "center", gap: 7 }}>
               <div style={{ width: 30, height: 30, borderRadius: "999px", overflow: "hidden", border: "1px solid rgba(255,255,255,.25)", background: "#1f2937" }}>{playerAvatar ? <img src={playerAvatar} alt={playerName} style={{ width: "100%", height: "100%", objectFit: "cover" }} /> : null}</div>


### PR DESCRIPTION
### Motivation
- Improve portrait UX by moving the HUD/menu frame visually lower so avatars, usernames and scores no longer overlap the top area. 
- Ensure the camera starts behind the player and is slightly lower and farther out so the full court and the near human character are visible at round start. 
- Provide a smooth follow/look behavior so framing stays stable during rallies and when the player moves.

### Description
- In `webapp/src/pages/Games/Tennis.tsx` changed the HUD container `top` from `34` to `64` to lower the score/avatar frame. 
- Replaced the fixed camera placement with a player-relative setup by adding `cameraOffset` and `cameraPosTarget` and updating the initial/resize logic to position the camera using `nearPlayer.target + cameraOffset`. 
- Added per-frame smoothing: camera position now lerps toward the player-relative target and `cameraTarget` is adjusted each frame so the camera looks from behind the near player with a lower/outward bias. 
- Kept existing game logic unchanged; changes are limited to camera setup/updates and HUD positioning in the same file.

### Testing
- Built the web app with `npm --prefix webapp run build` and the production build completed successfully. 
- Build emitted pre-existing non-blocking Vite warnings about chunking and a duplicate key, which did not block the build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f63491922c8329b7f8e22aa9f810fc)