### PR TITLE
Tennis: enable HDRI switching, tune AI/shots, add SFX & replay, and clean HUD/UI

### DIFF
--- a/webapp/src/pages/Games/Tennis.tsx
+++ b/webapp/src/pages/Games/Tennis.tsx
@@ -118,8 +118,8 @@ const CFG = {
   minBallSpeed: 0.12,
   playerHeight: 1.82,
   playerSpeed: 5.2,
-  aiSpeed: 5.5,
-  reach: 0.92,
+  aiSpeed: 6.8,
+  reach: 1.12,
   swingDuration: 0.38,
   serveDuration: 0.86,
   hitWindowStart: 0.42,
@@ -517,6 +517,7 @@ function addHuman(scene: THREE.Scene, side: PlayerSide, start: THREE.Vector3, ac
   };
 
   modelRoot.rotation.y = rig.yaw;
+  modelRoot.scale.setScalar(0.9);
   racket.visible = false;
 
   new GLTFLoader().setCrossOrigin("anonymous").load(
@@ -736,7 +737,7 @@ function updatePoseAndRacket(player: HumanRig, ball: BallState) {
 
 function ballisticVelocity(from: THREE.Vector3, target: THREE.Vector3, power: number, serve = false) {
   const flatDist = Math.hypot(target.x - from.x, target.z - from.z);
-  const baseSpeed = serve ? 7.2 + power * 4.2 : 5.2 + power * 2.8;
+  const baseSpeed = serve ? 8.8 + power * 4.8 : 6.3 + power * 3.3;
   const flight = clamp(flatDist / baseSpeed, serve ? 0.42 : 0.58, serve ? 0.92 : 1.22);
   return new THREE.Vector3(
     (target.x - from.x) / flight,
@@ -748,7 +749,7 @@ function ballisticVelocity(from: THREE.Vector3, target: THREE.Vector3, power: nu
 function makeUserTargetFromSwipe(startX: number, startY: number, endX: number, endY: number, isServe: boolean) {
   const dx = endX - startX;
   const dy = endY - startY;
-  const power = clamp(Math.hypot(dx, dy) / 185, isServe ? 0.5 : 0.18, 1);
+  const power = clamp(Math.hypot(dx, dy) / 165, isServe ? 0.6 : 0.24, 1);
   const aimX = clamp((dx / 140) * (CFG.courtW / 2), -CFG.courtW / 2 + 0.42, CFG.courtW / 2 - 0.42);
   const upward = clamp((-dy + 40) / 230, 0, 1);
   const targetZ = isServe ? lerp(-1.0, -CFG.serviceLineZ + 0.22, upward) : lerp(-1.15, -CFG.courtL / 2 + 0.88, upward);
@@ -756,10 +757,11 @@ function makeUserTargetFromSwipe(startX: number, startY: number, endX: number, e
 }
 
 function makeAiTarget(near: HumanRig, ball: BallState): DesiredHit {
-  const pressure = clamp01((Math.abs(ball.pos.z) - 1.0) / (CFG.courtL / 2 - 1.0));
-  const x = clamp(near.pos.x * 0.62 + (Math.random() - 0.5) * 1.15, -CFG.courtW / 2 + 0.45, CFG.courtW / 2 - 0.45);
-  const z = lerp(1.35, CFG.courtL / 2 - 1.0, 0.35 + pressure * 0.55);
-  const power = clamp(0.56 + pressure * 0.34 + Math.random() * 0.2, 0.5, 1);
+  const pressure = clamp01((Math.abs(ball.pos.z) - 0.6) / (CFG.courtL / 2 - 0.8));
+  const sideRead = clamp((ball.vel.x || 0) * 0.26, -0.5, 0.5);
+  const x = clamp(near.pos.x * 0.72 + sideRead + (Math.random() - 0.5) * 0.75, -CFG.courtW / 2 + 0.35, CFG.courtW / 2 - 0.35);
+  const z = lerp(1.2, CFG.courtL / 2 - 0.7, 0.42 + pressure * 0.5);
+  const power = clamp(0.64 + pressure * 0.36 + Math.random() * 0.22, 0.58, 1);
   const technique: ShotTechnique = pressure > 0.66 ? "topspin" : (Math.random() > 0.5 ? "slice" : "flat");
   return { target: new THREE.Vector3(x, CFG.ballR, z), power, technique };
 }
@@ -965,10 +967,14 @@ export default function MobileThreeTennisPrototype() {
     scene.add(ghost);
 
     let frameId = 0;
-    const shotFx = new Audio("/assets/sounds/hit-wood-4-94067.mp3");
-    shotFx.volume = 0.5;
-    const bounceFx = new Audio("/assets/sounds/ping-pong-ball-hit-258590.mp3");
-    bounceFx.volume = 0.32;
+    const shotFx = new Audio("/assets/sounds/billiard-sound-05-288416.mp3");
+    shotFx.volume = 0.6;
+    const bounceFx = new Audio("/assets/sounds/freesound_community-ping-pong-ball-100140.mp3");
+    bounceFx.volume = 0.34;
+    const crowdFx = new Audio("/assets/sounds/crowd-cheering-383111.mp3");
+    crowdFx.volume = 0.32;
+    const faultFx = new Audio("/assets/sounds/metal-whistle-6121.mp3");
+    faultFx.volume = 0.25;
     let last = performance.now();
     let pointLock = false;
     let pointLockT = 0;
@@ -985,6 +991,9 @@ export default function MobileThreeTennisPrototype() {
         farScore: prev.farScore + (winner === "far" ? 1 : 0),
       };
       const reasonText = reason === "out" ? "Out ball" : reason === "doubleBounce" ? "Double bounce" : reason === "net" ? "Net fault" : "Point";
+      replayText = `Replay: ${reasonText} by ${winner === "near" ? "You" : "AI"}`;
+      replayT = 1.7;
+      void (reason === "winner" ? crowdFx.play() : faultFx.play()).catch(() => {});
       setHud({ ...prev, ...next, status: `${reasonText}: ${winner === "near" ? "You" : "AI"} scores`, power: 0 });
     };
 
@@ -1087,6 +1096,7 @@ export default function MobileThreeTennisPrototype() {
           ball.vel.x *= CFG.groundFriction;
           ball.vel.z *= CFG.groundFriction;
           const bounceSide = sideOfZ(ball.pos.z);
+          void bounceFx.play().catch(() => {});
           if (ball.bounceSide === bounceSide) ball.bounceCount += 1;
           else {
             ball.bounceSide = bounceSide;
@@ -1106,11 +1116,11 @@ export default function MobileThreeTennisPrototype() {
 
     function updateAi() {
       const landing = predictLanding(ball);
-      const home = new THREE.Vector3(0, 0, -CFG.courtL / 2 + 1.2);
+      const home = new THREE.Vector3(0, 0, -CFG.courtL / 2 + 0.9);
       const ballComingToAi = ball.lastHitBy === "near" && (ball.pos.z < 0.65 || landing.z < 0);
       if (ballComingToAi) {
         farPlayer.target.x = clamp(landing.x, -CFG.courtW / 2 + 0.35, CFG.courtW / 2 - 0.35);
-        farPlayer.target.z = clamp(Math.min(-0.95, landing.z + 0.22), -CFG.courtL / 2 + 0.7, -0.82);
+        farPlayer.target.z = clamp(Math.min(-0.72, landing.z + 0.42), -CFG.courtL / 2 + 0.42, -0.64);
       } else {
         farPlayer.target.lerp(home, 0.035);
       }
@@ -1142,6 +1152,11 @@ export default function MobileThreeTennisPrototype() {
       const now = performance.now();
       const dt = Math.min(0.033, (now - last) / 1000);
       last = now;
+
+      if (replayT > 0) {
+        replayT -= dt;
+        if (replayT > 0.05) setHudSafe({ status: replayText });
+      }
 
       if (pointLock) {
         pointLockT -= dt;
@@ -1208,8 +1223,7 @@ export default function MobileThreeTennisPrototype() {
     getPoolRoyalInventory().then((inventory) => {
       if (cancelled) return;
       const owned = new Set(inventory?.environmentHdri || []);
-      const allowed = new Set(["suburbanGarden","countryTrackMidday","autumnPark","rooitouPark","rotesRathaus","veniceDawn2","piazzaSanMarco", POOL_ROYALE_DEFAULT_HDRI_ID]);
-      const options = POOL_ROYALE_HDRI_VARIANTS.filter((v) => allowed.has(v.id) && (owned.has(v.id) || v.id === POOL_ROYALE_DEFAULT_HDRI_ID));
+      const options = POOL_ROYALE_HDRI_VARIANTS.filter((v) => owned.has(v.id) || v.id === POOL_ROYALE_DEFAULT_HDRI_ID);
       setHdriChoices(options);
       if (!options.some((v) => v.id === selectedHdriId)) setSelectedHdriId(POOL_ROYALE_DEFAULT_HDRI_ID);
     }).catch(() => {});
@@ -1249,13 +1263,7 @@ export default function MobileThreeTennisPrototype() {
             ))}
           </div>
         )}
-        <div style={{ position: "absolute", left: 10, bottom: 18, color: "white", background: "rgba(0,0,0,0.42)", border: "1px solid rgba(255,255,255,0.12)", padding: "9px 10px", borderRadius: 14, fontSize: 12, lineHeight: 1.35, maxWidth: 236 }}>
-          Procedural hands removed.<br />The character right hand holds the racket.<br />Swipe up to serve or hit deep.
-        </div>
-        <div style={{ position: "absolute", right: 12, bottom: 24, width: 48, height: 156, borderRadius: 999, background: "rgba(255,255,255,0.15)", border: "1px solid rgba(255,255,255,0.22)", overflow: "hidden", boxShadow: "0 12px 30px rgba(0,0,0,0.24)" }}>
-          <div style={{ position: "absolute", left: 0, right: 0, bottom: 0, height: `${Math.round(hud.power * 100)}%`, background: "rgba(255,255,255,0.74)", transition: hud.power === 0 ? "height 150ms ease-out" : "none" }} />
-          <div style={{ position: "absolute", inset: 0, display: "flex", alignItems: "center", justifyContent: "center", color: "rgba(0,0,0,0.75)", fontSize: 11, fontWeight: 900, writingMode: "vertical-rl", transform: "rotate(180deg)" }}>POWER</div>
-        </div>
+  
       </div>
     </div>
   );


### PR DESCRIPTION
### Motivation
- Allow players to actually switch owned HDRIs in the Tennis scene instead of being blocked by a hardcoded allowlist so inventory-owned environments are usable. 
- Improve visual scale and perception so human characters read correctly against the court and HDRI backgrounds.  
- Make gameplay feel more responsive and realistic by increasing shot/serve power, improving AI positioning/decisioning, surfacing audio feedback, and adding a simple replay HUD signal for point/fault events. 

### Description
- HDRI selection: remove the hardcoded allowlist and filter `POOL_ROYALE_HDRI_VARIANTS` by owned IDs (keeps default) so owned HDRIs appear in the in-game menu (`webapp/src/pages/Games/Tennis.tsx`).
- Visual scale: set `modelRoot.scale.setScalar(0.9)` so the loaded human rig scales better relative to the court/HDRI scene (`addHuman`).
- Gameplay tuning: increase AI speed and reach (`CFG.aiSpeed`, `CFG.reach`), raise ballistic/base shot and serve speeds (changes in `ballisticVelocity`), and adjust swipe-to-power scaling (`makeUserTargetFromSwipe`) to enable stronger shots and deeper serves.
- AI improvements: refine `makeAiTarget` to use ball velocity/pressure and add better placement/power choices, and tweak AI home/target z offsets for faster, more realistic positioning.
- Audio & replay: wire existing project sound assets into the scene (`shotFx`, `bounceFx`, `crowdFx`, `faultFx`), play bounce/shot/fault cues at appropriate times, and add a lightweight replay HUD flow using `replayText`/`replayT` to show short replay messaging when a point/fault is awarded.
- UI cleanup: remove the bottom instructional frame and the vertical power card from the bottom-right HUD so the screen is cleaner and less obstructed.

### Testing
- Built the web app for production with Vite using `npm --prefix webapp run build` and the build completed successfully (non-blocking chunk-size/dynamic-import warnings were reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f737e774d08329a755d500c39ae624)