### PR TITLE
Grass court visuals, AI & physics tweaks, net shake and audio/HDRI updates for Tennis scene

### DIFF
--- a/webapp/src/pages/Games/Tennis.tsx
+++ b/webapp/src/pages/Games/Tennis.tsx
@@ -118,8 +118,8 @@ const CFG = {
   minBallSpeed: 0.12,
   playerHeight: 1.82,
   playerSpeed: 5.2,
-  aiSpeed: 5.5,
-  reach: 0.92,
+  aiSpeed: 6.8,
+  reach: 1.12,
   swingDuration: 0.38,
   serveDuration: 0.86,
   hitWindowStart: 0.42,
@@ -188,14 +188,37 @@ function getWorldPos(obj: THREE.Object3D) {
   return obj.getWorldPosition(new THREE.Vector3());
 }
 
+
+function createGrassTexture() {
+  const c = document.createElement("canvas");
+  c.width = 512;
+  c.height = 512;
+  const ctx = c.getContext("2d")!;
+  ctx.fillStyle = "#2f7d3d";
+  ctx.fillRect(0, 0, 512, 512);
+  for (let i = 0; i < 28000; i++) {
+    const x = Math.random() * 512;
+    const y = Math.random() * 512;
+    const g = 90 + Math.floor(Math.random() * 90);
+    ctx.fillStyle = `rgba(${20 + Math.floor(Math.random() * 30)},${g},${20 + Math.floor(Math.random() * 25)},0.45)`;
+    ctx.fillRect(x, y, 1, 3);
+  }
+  const tex = new THREE.CanvasTexture(c);
+  tex.wrapS = tex.wrapT = THREE.RepeatWrapping;
+  tex.repeat.set(3.2, 6.4);
+  tex.colorSpace = THREE.SRGBColorSpace;
+  return tex;
+}
+
 function addCourt(scene: THREE.Scene, options: { hideFloor?: boolean } = {}) {
   const group = new THREE.Group();
   scene.add(group);
 
   const hideFloor = !!options.hideFloor;
-  const outerMat = material(0x1d7a4b, 0.88, 0.0);
-  const courtMat = material(0x286fb1, 0.82, 0.0);
-  const serviceMat = material(0x2f84c9, 0.82, 0.0);
+  const grassTex = createGrassTexture();
+  const outerMat = new THREE.MeshStandardMaterial({ map: grassTex, roughness: 0.96, metalness: 0 });
+  const courtMat = new THREE.MeshStandardMaterial({ map: grassTex, roughness: 0.93, metalness: 0, color: new THREE.Color(0x3f9f4f) });
+  const serviceMat = new THREE.MeshStandardMaterial({ map: grassTex, roughness: 0.9, metalness: 0, color: new THREE.Color(0x57b365) });
   const lineMat = material(0xf7f7f7, 0.42, 0.0);
   const netMat = transparentMaterial(0x111111, 0.36, 0.55);
   const netWhite = material(0xf7f7f7, 0.5, 0.0);
@@ -224,14 +247,14 @@ function addCourt(scene: THREE.Scene, options: { hideFloor?: boolean } = {}) {
   addBox(group, [thick, thick, CFG.courtL + thick], [-CFG.doublesW / 2, y, 0], transparentMaterial(0xffffff, 0.34));
   addBox(group, [thick, thick, CFG.courtL + thick], [CFG.doublesW / 2, y, 0], transparentMaterial(0xffffff, 0.34));
 
-  addBox(group, [CFG.doublesW + 0.35, CFG.netH, 0.025], [0, CFG.netH / 2, 0], netMat);
+  const netBody = addBox(group, [CFG.doublesW + 0.35, CFG.netH, 0.025], [0, CFG.netH / 2, 0], netMat);
   addBox(group, [CFG.doublesW + 0.55, 0.052, 0.075], [0, CFG.netH + 0.025, 0], netWhite);
   addCylinder(group, 0.045, 0.052, CFG.netH + 0.36, [-(CFG.doublesW / 2 + 0.22), (CFG.netH + 0.36) / 2, 0], postMat, 22);
   addCylinder(group, 0.045, 0.052, CFG.netH + 0.36, [CFG.doublesW / 2 + 0.22, (CFG.netH + 0.36) / 2, 0], postMat, 22);
   for (let i = -5; i <= 5; i++) addBox(group, [0.012, CFG.netH * 0.92, 0.03], [(i * CFG.doublesW) / 10, CFG.netH * 0.46, 0.018], transparentMaterial(0xffffff, 0.28));
   for (let j = 1; j <= 3; j++) addBox(group, [CFG.doublesW + 0.12, 0.011, 0.032], [0, (j * CFG.netH) / 4, 0.019], transparentMaterial(0xffffff, 0.24));
 
-  return group;
+  return { group, netBody };
 }
 
 
@@ -517,6 +540,7 @@ function addHuman(scene: THREE.Scene, side: PlayerSide, start: THREE.Vector3, ac
   };
 
   modelRoot.rotation.y = rig.yaw;
+  modelRoot.scale.setScalar(0.9);
   racket.visible = false;
 
   new GLTFLoader().setCrossOrigin("anonymous").load(
@@ -736,7 +760,7 @@ function updatePoseAndRacket(player: HumanRig, ball: BallState) {
 
 function ballisticVelocity(from: THREE.Vector3, target: THREE.Vector3, power: number, serve = false) {
   const flatDist = Math.hypot(target.x - from.x, target.z - from.z);
-  const baseSpeed = serve ? 7.2 + power * 4.2 : 5.2 + power * 2.8;
+  const baseSpeed = serve ? 8.8 + power * 4.8 : 6.3 + power * 3.3;
   const flight = clamp(flatDist / baseSpeed, serve ? 0.42 : 0.58, serve ? 0.92 : 1.22);
   return new THREE.Vector3(
     (target.x - from.x) / flight,
@@ -748,7 +772,7 @@ function ballisticVelocity(from: THREE.Vector3, target: THREE.Vector3, power: nu
 function makeUserTargetFromSwipe(startX: number, startY: number, endX: number, endY: number, isServe: boolean) {
   const dx = endX - startX;
   const dy = endY - startY;
-  const power = clamp(Math.hypot(dx, dy) / 185, isServe ? 0.5 : 0.18, 1);
+  const power = clamp(Math.hypot(dx, dy) / 165, isServe ? 0.6 : 0.24, 1);
   const aimX = clamp((dx / 140) * (CFG.courtW / 2), -CFG.courtW / 2 + 0.42, CFG.courtW / 2 - 0.42);
   const upward = clamp((-dy + 40) / 230, 0, 1);
   const targetZ = isServe ? lerp(-1.0, -CFG.serviceLineZ + 0.22, upward) : lerp(-1.15, -CFG.courtL / 2 + 0.88, upward);
@@ -756,10 +780,11 @@ function makeUserTargetFromSwipe(startX: number, startY: number, endX: number, e
 }
 
 function makeAiTarget(near: HumanRig, ball: BallState): DesiredHit {
-  const pressure = clamp01((Math.abs(ball.pos.z) - 1.0) / (CFG.courtL / 2 - 1.0));
-  const x = clamp(near.pos.x * 0.62 + (Math.random() - 0.5) * 1.15, -CFG.courtW / 2 + 0.45, CFG.courtW / 2 - 0.45);
-  const z = lerp(1.35, CFG.courtL / 2 - 1.0, 0.35 + pressure * 0.55);
-  const power = clamp(0.56 + pressure * 0.34 + Math.random() * 0.2, 0.5, 1);
+  const pressure = clamp01((Math.abs(ball.pos.z) - 0.6) / (CFG.courtL / 2 - 0.8));
+  const sideRead = clamp((ball.vel.x || 0) * 0.26, -0.5, 0.5);
+  const x = clamp(near.pos.x * 0.72 + sideRead + (Math.random() - 0.5) * 0.75, -CFG.courtW / 2 + 0.35, CFG.courtW / 2 - 0.35);
+  const z = lerp(1.2, CFG.courtL / 2 - 0.7, 0.42 + pressure * 0.5);
+  const power = clamp(0.64 + pressure * 0.36 + Math.random() * 0.22, 0.58, 1);
   const technique: ShotTechnique = pressure > 0.66 ? "topspin" : (Math.random() > 0.5 ? "slice" : "flat");
   return { target: new THREE.Vector3(x, CFG.ballR, z), power, technique };
 }
@@ -947,7 +972,7 @@ export default function MobileThreeTennisPrototype() {
       loadAt(0);
     };
     applyHdri(selectedHdriId);
-    addCourt(scene, { hideFloor: true });
+    const courtVisual = addCourt(scene, { hideFloor: false });
     const updateBillboards = () => {};
 
     const nearPlayer = addHuman(scene, "near", new THREE.Vector3(0, 0, CFG.courtL / 2 - 1.04), 0xff7a2f);
@@ -955,6 +980,7 @@ export default function MobileThreeTennisPrototype() {
     const ball = createBall();
     scene.add(ball.mesh);
     resetBallForServe(ball, nearPlayer);
+    let netShakeT = 0;
 
     const ghost = new THREE.Mesh(
       new THREE.RingGeometry(0.25, 0.32, 36),
@@ -965,13 +991,19 @@ export default function MobileThreeTennisPrototype() {
     scene.add(ghost);
 
     let frameId = 0;
-    const shotFx = new Audio("/assets/sounds/hit-wood-4-94067.mp3");
-    shotFx.volume = 0.5;
-    const bounceFx = new Audio("/assets/sounds/ping-pong-ball-hit-258590.mp3");
-    bounceFx.volume = 0.32;
+    const shotFx = new Audio("/assets/sounds/billiard-sound-05-288416.mp3");
+    shotFx.volume = 0.6;
+    const bounceFx = new Audio("/assets/sounds/freesound_community-ping-pong-ball-100140.mp3");
+    bounceFx.volume = 0.34;
+    const crowdFx = new Audio("/assets/sounds/crowd-cheering-383111.mp3");
+    crowdFx.volume = 0.32;
+    const faultFx = new Audio("/assets/sounds/metal-whistle-6121.mp3");
+    faultFx.volume = 0.25;
     let last = performance.now();
     let pointLock = false;
     let pointLockT = 0;
+    let replayText = "";
+    let replayT = 0;
 
     const setHudSafe = (patch: Partial<HudState>) => setHud((prev) => ({ ...prev, ...patch }));
 
@@ -985,6 +1017,9 @@ export default function MobileThreeTennisPrototype() {
         farScore: prev.farScore + (winner === "far" ? 1 : 0),
       };
       const reasonText = reason === "out" ? "Out ball" : reason === "doubleBounce" ? "Double bounce" : reason === "net" ? "Net fault" : "Point";
+      replayText = `Replay: ${reasonText} by ${winner === "near" ? "You" : "AI"}`;
+      replayT = 1.7;
+      void (reason === "out" || reason === "doubleBounce" || reason === "net" ? faultFx.play() : crowdFx.play()).catch(() => {});
       setHud({ ...prev, ...next, status: `${reasonText}: ${winner === "near" ? "You" : "AI"} scores`, power: 0 });
     };
 
@@ -1077,6 +1112,7 @@ export default function MobileThreeTennisPrototype() {
         ball.pos.z = ball.lastHitBy === "near" ? 0.09 : -0.09;
         ball.vel.z *= -0.22;
         ball.vel.y = Math.max(0.25, Math.abs(ball.vel.y) * 0.22);
+        netShakeT = 0.45;
         awardPoint(opposite(ball.lastHitBy), "net");
       }
 
@@ -1087,6 +1123,7 @@ export default function MobileThreeTennisPrototype() {
           ball.vel.x *= CFG.groundFriction;
           ball.vel.z *= CFG.groundFriction;
           const bounceSide = sideOfZ(ball.pos.z);
+          void bounceFx.play().catch(() => {});
           if (ball.bounceSide === bounceSide) ball.bounceCount += 1;
           else {
             ball.bounceSide = bounceSide;
@@ -1106,11 +1143,11 @@ export default function MobileThreeTennisPrototype() {
 
     function updateAi() {
       const landing = predictLanding(ball);
-      const home = new THREE.Vector3(0, 0, -CFG.courtL / 2 + 1.2);
+      const home = new THREE.Vector3(0, 0, -CFG.courtL / 2 + 0.9);
       const ballComingToAi = ball.lastHitBy === "near" && (ball.pos.z < 0.65 || landing.z < 0);
       if (ballComingToAi) {
         farPlayer.target.x = clamp(landing.x, -CFG.courtW / 2 + 0.35, CFG.courtW / 2 - 0.35);
-        farPlayer.target.z = clamp(Math.min(-0.95, landing.z + 0.22), -CFG.courtL / 2 + 0.7, -0.82);
+        farPlayer.target.z = clamp(Math.min(-0.72, landing.z + 0.42), -CFG.courtL / 2 + 0.42, -0.64);
       } else {
         farPlayer.target.lerp(home, 0.035);
       }
@@ -1143,6 +1180,11 @@ export default function MobileThreeTennisPrototype() {
       const dt = Math.min(0.033, (now - last) / 1000);
       last = now;
 
+      if (replayT > 0) {
+        replayT -= dt;
+        if (replayT > 0.05) setHudSafe({ status: replayText });
+      }
+
       if (pointLock) {
         pointLockT -= dt;
         if (pointLockT <= 0) {
@@ -1165,6 +1207,17 @@ export default function MobileThreeTennisPrototype() {
       updatePlayerMotion(farPlayer, ball, dt);
       updatePoseAndRacket(nearPlayer, ball);
       updatePoseAndRacket(farPlayer, ball);
+
+      if (netShakeT > 0) {
+        netShakeT = Math.max(0, netShakeT - dt);
+        const k = netShakeT / 0.45;
+        const wobble = Math.sin((0.45 - netShakeT) * 55) * 0.05 * k;
+        courtVisual.netBody.scale.z = 1 + Math.abs(wobble) * 1.6;
+        courtVisual.netBody.position.z = wobble;
+      } else {
+        courtVisual.netBody.scale.z += (1 - courtVisual.netBody.scale.z) * (1 - Math.exp(-10 * dt));
+        courtVisual.netBody.position.z += (0 - courtVisual.netBody.position.z) * (1 - Math.exp(-10 * dt));
+      }
 
       ghost.position.x += (nearPlayer.target.x - ghost.position.x) * (1 - Math.exp(-12 * dt));
       ghost.position.z += (nearPlayer.target.z - ghost.position.z) * (1 - Math.exp(-12 * dt));
@@ -1208,10 +1261,9 @@ export default function MobileThreeTennisPrototype() {
     getPoolRoyalInventory().then((inventory) => {
       if (cancelled) return;
       const owned = new Set(inventory?.environmentHdri || []);
-      const allowed = new Set(["suburbanGarden","countryTrackMidday","autumnPark","rooitouPark","rotesRathaus","veniceDawn2","piazzaSanMarco", POOL_ROYALE_DEFAULT_HDRI_ID]);
-      const options = POOL_ROYALE_HDRI_VARIANTS.filter((v) => allowed.has(v.id) && (owned.has(v.id) || v.id === POOL_ROYALE_DEFAULT_HDRI_ID));
+      const options = POOL_ROYALE_HDRI_VARIANTS.filter((v) => (owned.has(v.id) || v.id === POOL_ROYALE_DEFAULT_HDRI_ID) && v.id !== "colorfulStudio");
       setHdriChoices(options);
-      if (!options.some((v) => v.id === selectedHdriId)) setSelectedHdriId(POOL_ROYALE_DEFAULT_HDRI_ID);
+      if (!options.some((v) => v.id === selectedHdriId) || selectedHdriId === "colorfulStudio") setSelectedHdriId(options[0]?.id || POOL_ROYALE_DEFAULT_HDRI_ID);
     }).catch(() => {});
     return () => { cancelled = true; };
   }, [selectedHdriId]);
@@ -1249,13 +1301,7 @@ export default function MobileThreeTennisPrototype() {
             ))}
           </div>
         )}
-        <div style={{ position: "absolute", left: 10, bottom: 18, color: "white", background: "rgba(0,0,0,0.42)", border: "1px solid rgba(255,255,255,0.12)", padding: "9px 10px", borderRadius: 14, fontSize: 12, lineHeight: 1.35, maxWidth: 236 }}>
-          Procedural hands removed.<br />The character right hand holds the racket.<br />Swipe up to serve or hit deep.
-        </div>
-        <div style={{ position: "absolute", right: 12, bottom: 24, width: 48, height: 156, borderRadius: 999, background: "rgba(255,255,255,0.15)", border: "1px solid rgba(255,255,255,0.22)", overflow: "hidden", boxShadow: "0 12px 30px rgba(0,0,0,0.24)" }}>
-          <div style={{ position: "absolute", left: 0, right: 0, bottom: 0, height: `${Math.round(hud.power * 100)}%`, background: "rgba(255,255,255,0.74)", transition: hud.power === 0 ? "height 150ms ease-out" : "none" }} />
-          <div style={{ position: "absolute", inset: 0, display: "flex", alignItems: "center", justifyContent: "center", color: "rgba(0,0,0,0.75)", fontSize: 11, fontWeight: 900, writingMode: "vertical-rl", transform: "rotate(180deg)" }}>POWER</div>
-        </div>
+  
       </div>
     </div>
   );


### PR DESCRIPTION
### Motivation
- Update the tennis prototype to use a grass-like court material and improve visual polish of the net and stadium.
- Rebalance AI and ball physics to make gameplay feel snappier and more competitive.
- Add audiovisual feedback for points and net interactions and tighten HDRI selection logic.

### Description
- Added `createGrassTexture()` and replaced hardcoded materials in `addCourt` with grass-textured `MeshStandardMaterial`, and changed `addCourt` to return `{ group, netBody }` so the net can be animated. 
- Implemented net wobble animation driven by a new `netShakeT` variable that updates `netBody.position.z` and `netBody.scale.z` during `animate()`.
- Tuned gameplay parameters in `CFG` (`aiSpeed`, `reach`) and adjusted ball dynamics and targeting: changed `ballisticVelocity` base speeds, `makeUserTargetFromSwipe` power scaling, `makeAiTarget` targeting + power heuristics, and AI home/positioning logic in `updateAi`.
- Adjusted player model visuals by scaling the loaded human model and added/changed sound assets and volumes (`shotFx`, `bounceFx`, `crowdFx`, `faultFx`) and added a short replay HUD (`replayText`, `replayT`) shown after points.
- Hardened HDRI selection in the inventory fetch to exclude `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f737e774d08329a755d500c39ae624)