### PR TITLE
Add Go Crazy combat pickups, defenses, and character facing support

### DIFF
--- a/Assets/Scripts/Gameplay/Environment/MurlanRoyalTableSeatingLayout.cs
+++ b/Assets/Scripts/Gameplay/Environment/MurlanRoyalTableSeatingLayout.cs
@@ -16,6 +16,9 @@ namespace Aiming.Gameplay.Environment
         [Header("Layout Tuning")]
         [SerializeField, Min(0f)] private float humanOutwardOffset = 0.35f;
         [SerializeField, Min(0.1f)] private float chairScaleMultiplier = 1.08f;
+        [SerializeField] private bool fixHumanFacingDirection = true;
+        [SerializeField] private bool humansShouldFaceTableCenter = true;
+        [SerializeField] private Vector3 humanFacingEulerOffset = new Vector3(0f, 180f, 0f);
         [SerializeField] private bool runOnAwake = true;
 
         void Awake()
@@ -31,6 +34,7 @@ namespace Aiming.Gameplay.Environment
         {
             Vector3 center = tableCenter != null ? tableCenter.position : transform.position;
             PushHumansOutward(center);
+            FixHumanFacing(center);
             ScaleChairs();
         }
 
@@ -58,6 +62,32 @@ namespace Aiming.Gameplay.Environment
                 }
 
                 human.position += horizontalDirection.normalized * humanOutwardOffset;
+            }
+        }
+
+        private void FixHumanFacing(Vector3 center)
+        {
+            if (!fixHumanFacingDirection || humanCharacters == null)
+            {
+                return;
+            }
+
+            for (int i = 0; i < humanCharacters.Length; i++)
+            {
+                Transform human = humanCharacters[i];
+                if (human == null)
+                {
+                    continue;
+                }
+
+                Vector3 lookDirection = humansShouldFaceTableCenter ? (center - human.position) : (human.position - center);
+                lookDirection.y = 0f;
+                if (lookDirection.sqrMagnitude <= 0.0001f)
+                {
+                    continue;
+                }
+
+                human.rotation = Quaternion.LookRotation(lookDirection.normalized, Vector3.up) * Quaternion.Euler(humanFacingEulerOffset);
             }
         }
 

--- a/Assets/Scripts/Gameplay/Weapons/BattleRoyaleWeaponDirector.cs
+++ b/Assets/Scripts/Gameplay/Weapons/BattleRoyaleWeaponDirector.cs
@@ -18,7 +18,11 @@ namespace TonPlaygram.Gameplay.Weapons
         Pistol,
         Shotgun,
         Sniper,
-        GrenadeLauncher
+        GrenadeLauncher,
+        SideMissile,
+        StrikeDrone,
+        AttackHelicopter,
+        StrikeJet
     }
 
     [Serializable]
@@ -41,6 +45,7 @@ namespace TonPlaygram.Gameplay.Weapons
         public GameObject bulletPrefab;
         public GameObject shellPrefab;
         public AudioClip shotSfx;
+        public bool requiresAerialStrike;
     }
 
     public interface ILudoWeaponEvents
@@ -166,6 +171,22 @@ namespace TonPlaygram.Gameplay.Weapons
             }
 
             _fireRoutine = StartCoroutine(FireRoutine(_activeWeapon));
+        }
+
+        public bool TryEquipByPickup(string pickupWeaponId)
+        {
+            if (string.IsNullOrWhiteSpace(pickupWeaponId))
+            {
+                return false;
+            }
+
+            if (!System.Enum.TryParse(pickupWeaponId, true, out LudoWeaponType weaponType))
+            {
+                return false;
+            }
+
+            Equip(weaponType);
+            return true;
         }
 
         private IEnumerator FireRoutine(WeaponBallisticsProfile weapon)

--- a/Assets/Scripts/Gameplay/Weapons/GoCrazyTrackCombatSystem.cs
+++ b/Assets/Scripts/Gameplay/Weapons/GoCrazyTrackCombatSystem.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace TonPlaygram.Gameplay.Weapons
+{
+    public enum DefenseType
+    {
+        MissileRadar,
+        DroneRadar,
+        AntiMissileBattery
+    }
+
+    [Serializable]
+    public sealed class StoreWeaponEntry
+    {
+        public LudoWeaponType weaponType;
+        public string gltfStoreId;
+        public int softCurrencyPrice = 100;
+        public bool grantedByDefault;
+    }
+
+    public sealed class GoCrazyTrackCombatSystem : MonoBehaviour
+    {
+        [Header("Scene refs")]
+        [SerializeField] private BattleRoyaleWeaponDirector weaponDirector;
+
+        [Header("Track + progression")]
+        [SerializeField] private float trackLengthMultiplier = 2f;
+        [SerializeField] private float trackWidthMultiplier = 1.45f;
+
+        [Header("Store Catalog")]
+        [SerializeField] private List<StoreWeaponEntry> storeWeapons = new List<StoreWeaponEntry>();
+
+        private readonly HashSet<LudoWeaponType> _ownedWeapons = new HashSet<LudoWeaponType>();
+        private readonly HashSet<DefenseType> _ownedDefenses = new HashSet<DefenseType>();
+
+        public float TrackLengthMultiplier => trackLengthMultiplier;
+        public float TrackWidthMultiplier => trackWidthMultiplier;
+
+        private void Awake()
+        {
+            BootstrapInventory();
+        }
+
+        public bool CollectWeaponPickup(string pickupWeaponId)
+        {
+            if (weaponDirector == null)
+            {
+                return false;
+            }
+
+            if (!weaponDirector.TryEquipByPickup(pickupWeaponId))
+            {
+                return false;
+            }
+
+            if (Enum.TryParse(pickupWeaponId, true, out LudoWeaponType weaponType))
+            {
+                _ownedWeapons.Add(weaponType);
+            }
+
+            return true;
+        }
+
+        public bool PurchaseWeapon(LudoWeaponType weaponType)
+        {
+            bool existsInStore = storeWeapons.Exists(x => x.weaponType == weaponType);
+            if (!existsInStore)
+            {
+                return false;
+            }
+
+            _ownedWeapons.Add(weaponType);
+            return true;
+        }
+
+        public bool OwnsWeapon(LudoWeaponType weaponType) => _ownedWeapons.Contains(weaponType);
+
+        public void ActivateDefense(DefenseType defenseType)
+        {
+            _ownedDefenses.Add(defenseType);
+        }
+
+        public bool CanBlockAttack(LudoWeaponType incomingWeaponType)
+        {
+            switch (incomingWeaponType)
+            {
+                case LudoWeaponType.SideMissile:
+                    return _ownedDefenses.Contains(DefenseType.MissileRadar) || _ownedDefenses.Contains(DefenseType.AntiMissileBattery);
+                case LudoWeaponType.StrikeDrone:
+                    return _ownedDefenses.Contains(DefenseType.DroneRadar) || _ownedDefenses.Contains(DefenseType.AntiMissileBattery);
+                case LudoWeaponType.AttackHelicopter:
+                case LudoWeaponType.StrikeJet:
+                    return _ownedDefenses.Contains(DefenseType.AntiMissileBattery);
+                default:
+                    return false;
+            }
+        }
+
+        private void BootstrapInventory()
+        {
+            for (int i = 0; i < storeWeapons.Count; i++)
+            {
+                StoreWeaponEntry entry = storeWeapons[i];
+                if (entry != null && entry.grantedByDefault)
+                {
+                    _ownedWeapons.Add(entry.weaponType);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Fix characters that face the wrong direction for portrait/table scenes and provide a quick, configurable correction so visuals match on-screen orientation.
- Add Go Crazy-style combat pickups (missiles, drones, helicopters, jets) and a minimal store/inventory model so players can collect or purchase weapons and start with a chosen firearm.
- Introduce basic defensive systems (radars, anti-missile battery) and track-scaling hooks so the track and combat progression can be tuned for longer/wider gameplay.

### Description
- Updated `MurlanRoyalTableSeatingLayout` to add serialized controls `fixHumanFacingDirection`, `humansShouldFaceTableCenter`, and `humanFacingEulerOffset`, and added `FixHumanFacing(center)` which is invoked from `ApplyLayout()` to orient characters toward/away from the table center.
- Extended `LudoWeaponType` in `BattleRoyaleWeaponDirector` with `SideMissile`, `StrikeDrone`, `AttackHelicopter`, and `StrikeJet`, added `requiresAerialStrike` to `WeaponBallisticsProfile`, and added `TryEquipByPickup(string)` to map pickup IDs to weapon types and equip them through the existing director flow.
- Added new `GoCrazyTrackCombatSystem` (new file) which provides a `StoreWeaponEntry` catalog, pickup collection API (`CollectWeaponPickup`), purchase/ownership tracking (`PurchaseWeapon`, `OwnsWeapon`), defense activation (`ActivateDefense`), blocking logic (`CanBlockAttack`) and track size tuning properties `trackLengthMultiplier` and `trackWidthMultiplier`.
- Changes are additive and keep existing firing/ballistics internals unchanged so other systems can subscribe/extend without breaking current scene wiring.

### Testing
- No automated tests were executed during this rollout; changes were committed after local static inspection and file-level checks (compile-time usage assumes Unity project compile step will be run in CI or locally).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f76313e16083298a17de7ac1fe418c)