### PR TITLE
Bowling: realistic pinsetter, multi-ball return, and seating controller

### DIFF
--- a/Assets/Scripts/Gameplay/Bowling/BowlingBallReturnSystem.cs
+++ b/Assets/Scripts/Gameplay/Bowling/BowlingBallReturnSystem.cs
@@ -1,51 +1,119 @@
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace Aiming.Gameplay.Bowling
 {
     /// <summary>
-    /// Sends the ball through a side return path to mimic a real bowling return channel.
+    /// Returns played balls through an under-lane path and keeps remaining balls in storage slots.
     /// </summary>
     public class BowlingBallReturnSystem : MonoBehaviour
     {
-        [SerializeField] private Rigidbody bowlingBall;
+        [SerializeField] private Rigidbody[] bowlingBalls;
         [SerializeField] private Transform[] returnWaypoints;
+        [SerializeField] private Transform[] ballStorageSlots;
+        [SerializeField] private Transform playerPickupPoint;
         [SerializeField] private float moveSpeed = 4.5f;
         [SerializeField] private float snapDistance = 0.08f;
 
+        private readonly Queue<Rigidbody> queue = new Queue<Rigidbody>();
         private int waypointIndex;
         private bool returning;
+        private Rigidbody activeBall;
+
+        private void Awake()
+        {
+            if (bowlingBalls == null)
+            {
+                return;
+            }
+
+            for (int i = 0; i < bowlingBalls.Length; i++)
+            {
+                if (bowlingBalls[i] != null)
+                {
+                    queue.Enqueue(bowlingBalls[i]);
+                }
+            }
+
+            SnapQueuedBallsToStorage();
+        }
 
         public void StartReturn()
         {
-            if (bowlingBall == null || returnWaypoints == null || returnWaypoints.Length == 0)
+            if (returning || returnWaypoints == null || returnWaypoints.Length == 0 || queue.Count == 0)
+            {
+                return;
+            }
+
+            activeBall = queue.Dequeue();
+            if (activeBall == null)
             {
                 return;
             }
 
             returning = true;
             waypointIndex = 0;
-            bowlingBall.isKinematic = true;
+            activeBall.isKinematic = true;
         }
 
         private void Update()
         {
-            if (!returning || bowlingBall == null)
+            if (!returning || activeBall == null)
             {
                 return;
             }
 
             Transform target = returnWaypoints[waypointIndex];
-            Vector3 next = Vector3.MoveTowards(bowlingBall.position, target.position, moveSpeed * Time.deltaTime);
-            bowlingBall.MovePosition(next);
+            Vector3 next = Vector3.MoveTowards(activeBall.position, target.position, moveSpeed * Time.deltaTime);
+            activeBall.MovePosition(next);
 
-            if (Vector3.Distance(next, target.position) <= snapDistance)
+            if (Vector3.Distance(next, target.position) > snapDistance)
             {
-                waypointIndex++;
-                if (waypointIndex >= returnWaypoints.Length)
+                return;
+            }
+
+            waypointIndex++;
+            if (waypointIndex < returnWaypoints.Length)
+            {
+                return;
+            }
+
+            returning = false;
+            activeBall.isKinematic = false;
+
+            if (playerPickupPoint != null)
+            {
+                activeBall.position = playerPickupPoint.position;
+            }
+
+            queue.Enqueue(activeBall);
+            activeBall = null;
+            SnapQueuedBallsToStorage();
+        }
+
+        private void SnapQueuedBallsToStorage()
+        {
+            if (ballStorageSlots == null || ballStorageSlots.Length == 0)
+            {
+                return;
+            }
+
+            int slot = 0;
+            foreach (Rigidbody rb in queue)
+            {
+                if (rb == null || slot >= ballStorageSlots.Length)
                 {
-                    returning = false;
-                    bowlingBall.isKinematic = false;
+                    continue;
                 }
+
+                Transform storage = ballStorageSlots[slot];
+                if (storage != null)
+                {
+                    rb.position = storage.position;
+                    rb.rotation = storage.rotation;
+                }
+
+                slot++;
             }
         }
     }

--- a/Assets/Scripts/Gameplay/Bowling/BowlingPinDeckMechanism.cs
+++ b/Assets/Scripts/Gameplay/Bowling/BowlingPinDeckMechanism.cs
@@ -1,0 +1,89 @@
+using System.Collections;
+using UnityEngine;
+
+namespace Aiming.Gameplay.Bowling
+{
+    /// <summary>
+    /// Simulates a realistic 10-pin cycle: sweep down, clear deadwood, table lift/spot, and release.
+    /// Driven by transforms so art can be replaced with higher fidelity GLTF meshes.
+    /// </summary>
+    public class BowlingPinDeckMechanism : MonoBehaviour
+    {
+        [Header("Mechanism Parts")]
+        [SerializeField] private Transform sweepBar;
+        [SerializeField] private Transform pinTable;
+        [SerializeField] private Transform deadwoodCollector;
+
+        [Header("Sweep Travel")]
+        [SerializeField] private float sweepGuardY = 1.2f;
+        [SerializeField] private float sweepDeckY = 0.35f;
+        [SerializeField] private float sweepSpeed = 2.5f;
+
+        [Header("Table Travel")]
+        [SerializeField] private float tableUpY = 2.8f;
+        [SerializeField] private float tableDetectY = 0.9f;
+        [SerializeField] private float tableSpotY = 0.7f;
+        [SerializeField] private float tableSpeed = 2f;
+
+        [Header("Timing")]
+        [SerializeField] private float deadwoodHoldSeconds = 0.4f;
+        [SerializeField] private float settlePauseSeconds = 0.35f;
+
+        private bool _isCycling;
+
+        public bool IsCycling => _isCycling;
+
+        public void StartCycle()
+        {
+            if (_isCycling)
+            {
+                return;
+            }
+
+            StartCoroutine(CycleRoutine());
+        }
+
+        private IEnumerator CycleRoutine()
+        {
+            _isCycling = true;
+
+            yield return MoveLocalY(sweepBar, sweepDeckY, sweepSpeed);
+            yield return MoveLocalY(pinTable, tableDetectY, tableSpeed);
+            yield return new WaitForSeconds(settlePauseSeconds);
+
+            if (deadwoodCollector != null)
+            {
+                deadwoodCollector.gameObject.SetActive(true);
+            }
+
+            yield return new WaitForSeconds(deadwoodHoldSeconds);
+            yield return MoveLocalY(sweepBar, sweepGuardY, sweepSpeed);
+            yield return MoveLocalY(pinTable, tableUpY, tableSpeed);
+            yield return MoveLocalY(pinTable, tableSpotY, tableSpeed);
+            yield return MoveLocalY(pinTable, tableUpY, tableSpeed);
+
+            if (deadwoodCollector != null)
+            {
+                deadwoodCollector.gameObject.SetActive(false);
+            }
+
+            _isCycling = false;
+        }
+
+        private static IEnumerator MoveLocalY(Transform target, float toY, float speed)
+        {
+            if (target == null)
+            {
+                yield break;
+            }
+
+            Vector3 p = target.localPosition;
+            while (Mathf.Abs(p.y - toY) > 0.005f)
+            {
+                p.y = Mathf.MoveTowards(p.y, toY, speed * Time.deltaTime);
+                target.localPosition = p;
+                yield return null;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Bowling/BowlingSeatingController.cs
+++ b/Assets/Scripts/Gameplay/Bowling/BowlingSeatingController.cs
@@ -1,0 +1,75 @@
+using UnityEngine;
+using UnityEngine.AI;
+
+namespace Aiming.Gameplay.Bowling
+{
+    /// <summary>
+    /// Moves the human avatar to a chair after a throw and returns to throw position when turn starts.
+    /// </summary>
+    public class BowlingSeatingController : MonoBehaviour
+    {
+        [SerializeField] private NavMeshAgent humanAgent;
+        [SerializeField] private Animator humanAnimator;
+        [SerializeField] private Transform throwStandPoint;
+        [SerializeField] private Transform chairSitPoint;
+        [SerializeField] private float arriveDistance = 0.2f;
+        [SerializeField] private string sitBoolParam = "IsSitting";
+
+        private bool _seated;
+
+        public void OnShotFinished()
+        {
+            if (humanAgent == null || chairSitPoint == null)
+            {
+                return;
+            }
+
+            SetSitAnimation(false);
+            humanAgent.isStopped = false;
+            humanAgent.SetDestination(chairSitPoint.position);
+            _seated = false;
+        }
+
+        public void OnNextTurnReady()
+        {
+            if (humanAgent == null || throwStandPoint == null)
+            {
+                return;
+            }
+
+            SetSitAnimation(false);
+            humanAgent.isStopped = false;
+            humanAgent.SetDestination(throwStandPoint.position);
+            _seated = false;
+        }
+
+        private void Update()
+        {
+            if (humanAgent == null || _seated)
+            {
+                return;
+            }
+
+            if (!humanAgent.pathPending && humanAgent.remainingDistance <= arriveDistance)
+            {
+                humanAgent.isStopped = true;
+
+                if (chairSitPoint != null && Vector3.Distance(transform.position, chairSitPoint.position) <= arriveDistance + 0.05f)
+                {
+                    transform.position = chairSitPoint.position;
+                    transform.rotation = chairSitPoint.rotation;
+                    SetSitAnimation(true);
+                    _seated = true;
+                }
+            }
+        }
+
+        private void SetSitAnimation(bool sit)
+        {
+            if (humanAnimator != null && !string.IsNullOrWhiteSpace(sitBoolParam))
+            {
+                humanAnimator.SetBool(sitBoolParam, sit);
+            }
+        }
+    }
+}

--- a/docs/bowling-realism-assets.md
+++ b/docs/bowling-realism-assets.md
@@ -1,0 +1,30 @@
+# Bowling Realism Asset Notes
+
+## Recommended open-source GLTF assets
+
+- Bowling pins (CC0): Poly Pizza "Bowling pin" GLB.
+- Bowling furniture (tables/chairs): Poly Pizza / Kenney Furniture Kit (GLB/GLTF exports).
+
+## Real-world mechanism references reviewed
+
+- HowStuffWorks pinsetter breakdown (sweep bar, table lift, deadwood cycle).
+- Brunswick service manuals for GS/A2 machine sequencing and ball return separation.
+- Bowling mechanic references showing: pit -> accelerator/lift -> gravity return rack.
+
+## Scene wiring checklist
+
+1. Replace old pin mesh prefabs with a single high-quality GLTF pin prefab.
+2. Connect `BowlingPinDeckMechanism` parts:
+   - `sweepBar`
+   - `pinTable`
+   - `deadwoodCollector`
+3. Connect `BowlingBallReturnSystem`:
+   - all active balls in `bowlingBalls`
+   - under-lane spline anchors in `returnWaypoints`
+   - waiting rack anchors in `ballStorageSlots`
+   - user pickup anchor in `playerPickupPoint`
+4. Add Murlan Royal table + chairs GLTFs near the bowler area.
+5. Connect `BowlingSeatingController`:
+   - `throwStandPoint` aligned to lane start
+   - `chairSitPoint` matching Murlan Royal seating framing
+   - navmesh agent + animator


### PR DESCRIPTION
### Motivation
- Improve bowling realism by enabling high-fidelity GLTF pin/table/chair swaps and by modelling a realistic pinsetter cycle and ball-return/holding flow. 
- Provide a natural player flow where the human avatar walks to a chair after a throw and returns to the throw point on the next turn, matching Murlan Royal seating framing.

### Description
- Reworked the ball return into a queue-based system by modifying `Assets/Scripts/Gameplay/Bowling/BowlingBallReturnSystem.cs` to accept `bowlingBalls[]`, stage balls in `ballStorageSlots`, drive a return path via `returnWaypoints`, deliver to `playerPickupPoint`, and use `SnapQueuedBallsToStorage()` to position spare balls. 
- Added `Assets/Scripts/Gameplay/Bowling/BowlingPinDeckMechanism.cs` which implements a configurable pinsetter cycle (`StartCycle()`): sweep down, detect/hold, deadwood clear, lift/spot/release using transform-driven motion and timing parameters. 
- Added `Assets/Scripts/Gameplay/Bowling/BowlingSeatingController.cs` which uses `NavMeshAgent` and an `Animator` to move the human avatar to `chairSitPoint` after a shot and back to `throwStandPoint` at the next turn, toggling a sit boolean animation parameter. 
- Added integration notes at `docs/bowling-realism-assets.md` with recommended open-source GLTF assets, mechanism references, and a Unity scene wiring checklist for connecting the new components and replacing art with GLTFs.

### Testing
- Verified repository changes and staged files using `git status` and successfully committed the changes via `git add` + `git commit`. 
- Inspected new and modified file contents with `nl`/file dumps for `BowlingBallReturnSystem.cs`, `BowlingPinDeckMechanism.cs`, `BowlingSeatingController.cs`, and `docs/bowling-realism-assets.md`, and these inspections succeeded. 
- No unit or playmode tests were added or run in this PR; integration/scene hookup and runtime validation are required in Unity (connect inspector references, bake NavMesh, and test `StartReturn()`/`StartCycle()`/seating flow).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f764b8c44083299a95804cf75b4c6c)