### PR TITLE
Add weapon/defense combat, track scaling, new weapon types, and seating facing fixes

### DIFF
--- a/Assets/Scripts/Gameplay/Environment/MurlanRoyalTableSeatingLayout.cs
+++ b/Assets/Scripts/Gameplay/Environment/MurlanRoyalTableSeatingLayout.cs
@@ -16,6 +16,9 @@ namespace Aiming.Gameplay.Environment
         [Header("Layout Tuning")]
         [SerializeField, Min(0f)] private float humanOutwardOffset = 0.35f;
         [SerializeField, Min(0.1f)] private float chairScaleMultiplier = 1.08f;
+        [SerializeField] private bool fixHumanFacingDirection = true;
+        [SerializeField] private bool humansShouldFaceTableCenter = true;
+        [SerializeField] private Vector3 humanFacingEulerOffset = new Vector3(0f, 180f, 0f);
         [SerializeField] private bool runOnAwake = true;
 
         void Awake()
@@ -31,6 +34,7 @@ namespace Aiming.Gameplay.Environment
         {
             Vector3 center = tableCenter != null ? tableCenter.position : transform.position;
             PushHumansOutward(center);
+            FixHumanFacing(center);
             ScaleChairs();
         }
 
@@ -58,6 +62,32 @@ namespace Aiming.Gameplay.Environment
                 }
 
                 human.position += horizontalDirection.normalized * humanOutwardOffset;
+            }
+        }
+
+        private void FixHumanFacing(Vector3 center)
+        {
+            if (!fixHumanFacingDirection || humanCharacters == null)
+            {
+                return;
+            }
+
+            for (int i = 0; i < humanCharacters.Length; i++)
+            {
+                Transform human = humanCharacters[i];
+                if (human == null)
+                {
+                    continue;
+                }
+
+                Vector3 lookDirection = humansShouldFaceTableCenter ? (center - human.position) : (human.position - center);
+                lookDirection.y = 0f;
+                if (lookDirection.sqrMagnitude <= 0.0001f)
+                {
+                    continue;
+                }
+
+                human.rotation = Quaternion.LookRotation(lookDirection.normalized, Vector3.up) * Quaternion.Euler(humanFacingEulerOffset);
             }
         }
 

--- a/Assets/Scripts/Gameplay/Weapons/BattleRoyaleWeaponDirector.cs
+++ b/Assets/Scripts/Gameplay/Weapons/BattleRoyaleWeaponDirector.cs
@@ -18,7 +18,11 @@ namespace TonPlaygram.Gameplay.Weapons
         Pistol,
         Shotgun,
         Sniper,
-        GrenadeLauncher
+        GrenadeLauncher,
+        SideMissile,
+        StrikeDrone,
+        AttackHelicopter,
+        StrikeJet
     }
 
     [Serializable]
@@ -41,6 +45,7 @@ namespace TonPlaygram.Gameplay.Weapons
         public GameObject bulletPrefab;
         public GameObject shellPrefab;
         public AudioClip shotSfx;
+        public bool requiresAerialStrike;
     }
 
     public interface ILudoWeaponEvents
@@ -166,6 +171,22 @@ namespace TonPlaygram.Gameplay.Weapons
             }
 
             _fireRoutine = StartCoroutine(FireRoutine(_activeWeapon));
+        }
+
+        public bool TryEquipByPickup(string pickupWeaponId)
+        {
+            if (string.IsNullOrWhiteSpace(pickupWeaponId))
+            {
+                return false;
+            }
+
+            if (!System.Enum.TryParse(pickupWeaponId, true, out LudoWeaponType weaponType))
+            {
+                return false;
+            }
+
+            Equip(weaponType);
+            return true;
         }
 
         private IEnumerator FireRoutine(WeaponBallisticsProfile weapon)

--- a/Assets/Scripts/Gameplay/Weapons/GoCrazyTrackCombatSystem.cs
+++ b/Assets/Scripts/Gameplay/Weapons/GoCrazyTrackCombatSystem.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace TonPlaygram.Gameplay.Weapons
+{
+    public enum DefenseType
+    {
+        MissileRadar,
+        DroneRadar,
+        AntiMissileBattery
+    }
+
+    [Serializable]
+    public sealed class StoreWeaponEntry
+    {
+        public LudoWeaponType weaponType;
+        public string gltfStoreId;
+        public int softCurrencyPrice = 100;
+        public bool grantedByDefault;
+    }
+
+    public sealed class GoCrazyTrackCombatSystem : MonoBehaviour
+    {
+        [Header("Scene refs")]
+        [SerializeField] private BattleRoyaleWeaponDirector weaponDirector;
+
+        [Header("Track + progression")]
+        [SerializeField] private float trackLengthMultiplier = 2f;
+        [SerializeField] private float trackWidthMultiplier = 1.45f;
+
+        [Header("Store Catalog")]
+        [SerializeField] private List<StoreWeaponEntry> storeWeapons = new List<StoreWeaponEntry>();
+
+        private readonly HashSet<LudoWeaponType> _ownedWeapons = new HashSet<LudoWeaponType>();
+        private readonly HashSet<DefenseType> _ownedDefenses = new HashSet<DefenseType>();
+
+        public float TrackLengthMultiplier => trackLengthMultiplier;
+        public float TrackWidthMultiplier => trackWidthMultiplier;
+
+        private void Awake()
+        {
+            BootstrapInventory();
+        }
+
+        public bool CollectWeaponPickup(string pickupWeaponId)
+        {
+            if (weaponDirector == null)
+            {
+                return false;
+            }
+
+            if (!weaponDirector.TryEquipByPickup(pickupWeaponId))
+            {
+                return false;
+            }
+
+            if (Enum.TryParse(pickupWeaponId, true, out LudoWeaponType weaponType))
+            {
+                _ownedWeapons.Add(weaponType);
+            }
+
+            return true;
+        }
+
+        public bool PurchaseWeapon(LudoWeaponType weaponType)
+        {
+            bool existsInStore = storeWeapons.Exists(x => x.weaponType == weaponType);
+            if (!existsInStore)
+            {
+                return false;
+            }
+
+            _ownedWeapons.Add(weaponType);
+            return true;
+        }
+
+        public bool OwnsWeapon(LudoWeaponType weaponType) => _ownedWeapons.Contains(weaponType);
+
+        public void ActivateDefense(DefenseType defenseType)
+        {
+            _ownedDefenses.Add(defenseType);
+        }
+
+        public bool CanBlockAttack(LudoWeaponType incomingWeaponType)
+        {
+            switch (incomingWeaponType)
+            {
+                case LudoWeaponType.SideMissile:
+                    return _ownedDefenses.Contains(DefenseType.MissileRadar) || _ownedDefenses.Contains(DefenseType.AntiMissileBattery);
+                case LudoWeaponType.StrikeDrone:
+                    return _ownedDefenses.Contains(DefenseType.DroneRadar) || _ownedDefenses.Contains(DefenseType.AntiMissileBattery);
+                case LudoWeaponType.AttackHelicopter:
+                case LudoWeaponType.StrikeJet:
+                    return _ownedDefenses.Contains(DefenseType.AntiMissileBattery);
+                default:
+                    return false;
+            }
+        }
+
+        private void BootstrapInventory()
+        {
+            for (int i = 0; i < storeWeapons.Count; i++)
+            {
+                StoreWeaponEntry entry = storeWeapons[i];
+                if (entry != null && entry.grantedByDefault)
+                {
+                    _ownedWeapons.Add(entry.weaponType);
+                }
+            }
+        }
+    }
+}

--- a/webapp/src/components/GoCrazyGame.jsx
+++ b/webapp/src/components/GoCrazyGame.jsx
@@ -22,6 +22,7 @@ const MURLAN_HUMAN_MODEL_URL = "https://threejs.org/examples/models/gltf/readypl
 
 const TAU = Math.PI * 2;
 const CHECKPOINTS = [0, Math.PI / 2, Math.PI, Math.PI * 1.5];
+const TRACK_SIZE_MULTIPLIER = { length: 1.55, width: 1.35 };
 const TRACK_PRESETS = {
   "alpine-ring": { outerX: 44, outerZ: 28, innerX: 28, innerZ: 12, centerX: 36, centerZ: 20, wobble: 0.08, hue: 0x2b2f36 },
   "sunset-circuit": { outerX: 42, outerZ: 26, innerX: 26, innerZ: 11, centerX: 34, centerZ: 18.5, wobble: 0.1, hue: 0x37312d },
@@ -29,6 +30,9 @@ const TRACK_PRESETS = {
   "forest-sweep": { outerX: 43, outerZ: 29, innerX: 27, innerZ: 12.6, centerX: 35, centerZ: 21, wobble: 0.11, hue: 0x2a3130 },
   "storm-bend": { outerX: 45, outerZ: 27, innerX: 27.5, innerZ: 11.5, centerX: 36, centerZ: 19, wobble: 0.14, hue: 0x2b2d33 }
 };
+const WEAPON_PICKUPS = ["RIFLE", "FIREARM", "MISSILE", "DRONE", "HELICOPTER", "JET"];
+const DEFENSE_PICKUPS = ["MISSILE_RADAR", "DRONE_RADAR", "ANTI_MISSILE_BATTERY"];
+
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
 const lerp = (a, b, t) => a + (b - a) * t;
 
@@ -60,6 +64,19 @@ function trackQuality(pos, track) {
   const outer = (pos.x * pos.x) / (track.outerX * track.outerX) + (pos.z * pos.z) / (track.outerZ * track.outerZ);
   const inner = (pos.x * pos.x) / (track.innerX * track.innerX) + (pos.z * pos.z) / (track.innerZ * track.innerZ);
   return { onRoad: outer <= 1 && inner >= 1 };
+}
+
+
+function scaledTrack(track) {
+  return {
+    ...track,
+    outerX: track.outerX * TRACK_SIZE_MULTIPLIER.width,
+    innerX: track.innerX * TRACK_SIZE_MULTIPLIER.width,
+    centerX: track.centerX * TRACK_SIZE_MULTIPLIER.width,
+    outerZ: track.outerZ * TRACK_SIZE_MULTIPLIER.length,
+    innerZ: track.innerZ * TRACK_SIZE_MULTIPLIER.length,
+    centerZ: track.centerZ * TRACK_SIZE_MULTIPLIER.length
+  };
 }
 
 function makeMat(color, roughness = 0.78, metalness = 0.03) {
@@ -476,7 +493,7 @@ function resolveVehicleCrashes(karts) {
 export default function SuperTuxKartPlayablePreview() {
   const hostRef = useRef(null);
   const canvasRef = useRef(null);
-  const [hud, setHud] = useState({ lap: 1, speed: 0, position: 1, checkpoint: 0, help: true, status: "Loading...", mode: "playable-preview", crash: "" });
+  const [hud, setHud] = useState({ lap: 1, speed: 0, position: 1, checkpoint: 0, help: true, status: "Loading...", mode: "playable-preview", crash: "", weapon: "FIREARM", ammo: 999 });
   const hudRef = useRef(hud);
 
   useEffect(() => {
@@ -488,13 +505,13 @@ export default function SuperTuxKartPlayablePreview() {
     const canvas = canvasRef.current;
     const params = new URLSearchParams(window.location.search);
     const selectedTrackId = params.get("track") || "alpine-ring";
-    const selectedTrack = TRACK_PRESETS[selectedTrackId] || TRACK_PRESETS["alpine-ring"];
+    const selectedTrack = scaledTrack(TRACK_PRESETS[selectedTrackId] || TRACK_PRESETS["alpine-ring"]);
     if (!host || !canvas) return;
 
     let cancelled = false;
     let frameId = 0;
     const { loader, draco } = makeLoader();
-    const input = { keys: {}, steer: 0, accel: 0, brake: false, pointerId: null, startX: 0, startY: 0, lookId: null, lastX: 0, camYaw: 0 };
+    const input = { keys: {}, steer: 0, accel: 0, brake: false, pointerId: null, startX: 0, startY: 0, lookId: null, lastX: 0, camYaw: 0, firePressed: false, fireTarget: null };
     const renderer = new THREE.WebGLRenderer({ canvas, antialias: true, powerPreference: "high-performance" });
     renderer.setClearColor(0x85c7f2, 1);
     renderer.outputColorSpace = THREE.SRGBColorSpace;
@@ -537,6 +554,7 @@ export default function SuperTuxKartPlayablePreview() {
       } else {
         input.lookId = e.pointerId;
         input.lastX = e.clientX;
+        input.firePressed = true;
       }
     };
     const onPointerMove = (e) => {
@@ -558,6 +576,7 @@ export default function SuperTuxKartPlayablePreview() {
         input.accel = 0;
       }
       if (input.lookId === e.pointerId) input.lookId = null;
+      input.firePressed = false;
     };
 
     window.addEventListener("resize", resize);
@@ -567,6 +586,8 @@ export default function SuperTuxKartPlayablePreview() {
     canvas.addEventListener("pointermove", onPointerMove);
     canvas.addEventListener("pointerup", onPointerUp);
     canvas.addEventListener("pointercancel", onPointerUp);
+
+    let onTargetClick = null;
 
     async function start() {
       let assets = null;
@@ -608,12 +629,49 @@ export default function SuperTuxKartPlayablePreview() {
       const ai4 = makeKart(4);
       const karts = [player, ai1, ai2, ai3, ai4];
       karts.forEach((k) => scene.add(k.group));
+      const playerCombat = { activeWeapon: "FIREARM", inventory: new Set(["FIREARM"]), defenses: new Set(), ammo: { FIREARM: 999, RIFLE: 45, MISSILE: 2, DRONE: 1, HELICOPTER: 1, JET: 1 } };
+      const pickups = WEAPON_PICKUPS.map((weapon, i) => {
+        const p = pointOnTrack((i / WEAPON_PICKUPS.length) * TAU + 0.36, selectedTrack, i % 2 === 0 ? 0.35 : -0.35);
+        const gem = new THREE.Mesh(new THREE.OctahedronGeometry(0.35, 0), makeMat(weapon === "MISSILE" ? 0xff7b00 : weapon === "DRONE" ? 0x74f0ff : 0xffe066, 0.35));
+        gem.position.copy(p).add(new THREE.Vector3(0, 0.62, 0));
+        gem.userData = { weapon, taken: false };
+        scene.add(gem);
+        return gem;
+      });
+      const defensePickups = DEFENSE_PICKUPS.map((defense, i) => {
+        const p = pointOnTrack((i / DEFENSE_PICKUPS.length) * TAU + 1.2, selectedTrack, i % 2 === 0 ? -0.62 : 0.62);
+        const node = new THREE.Mesh(new THREE.IcosahedronGeometry(0.26, 0), makeMat(0x69ff8f, 0.45));
+        node.position.copy(p).add(new THREE.Vector3(0, 0.52, 0));
+        node.userData = { defense, taken: false };
+        scene.add(node);
+        return node;
+      });
+
+      const raycaster = new THREE.Raycaster();
+      const pointer = new THREE.Vector2();
+      const aiGroups = [ai1.group, ai2.group, ai3.group, ai4.group];
+      aiGroups.forEach((g, idx) => { g.userData.aiRef = [ai1, ai2, ai3, ai4][idx]; });
+      onTargetClick = (e) => {
+        const rect = canvas.getBoundingClientRect();
+        pointer.x = ((e.clientX - rect.left) / rect.width) * 2 - 1;
+        pointer.y = -((e.clientY - rect.top) / rect.height) * 2 + 1;
+        raycaster.setFromCamera(pointer, camera);
+        const hits = raycaster.intersectObjects(aiGroups, true);
+        if (hits[0]) {
+          const hitGroup = hits[0].object.parent;
+          const aiRef = hits[0].object?.parent?.userData?.aiRef || hitGroup?.userData?.aiRef;
+          input.fireTarget = aiRef || null;
+          input.firePressed = true;
+        }
+      };
+      canvas.addEventListener("click", onTargetClick);
+
       if (murlanHumanTemplate) {
         karts.forEach((kart, i) => {
           const human = cloneModel(murlanHumanTemplate);
           human.scale.setScalar(0.72);
           human.position.set(0, 0.45, -0.05);
-          human.rotation.y = Math.PI;
+          human.rotation.y = 0;
           human.rotation.x = -0.16;
           human.traverse((child) => {
             if (child.isBone) {
@@ -664,10 +722,52 @@ export default function SuperTuxKartPlayablePreview() {
           if (!h) return;
           h.position.y = 0.44 + Math.sin(now * 0.002 + (kart.group.userData.humanOffset || 0)) * 0.01;
         });
+        pickups.forEach((pickup) => {
+          if (pickup.userData.taken) return;
+          pickup.rotation.y += dt * 1.6;
+          pickup.position.y = 0.62 + Math.sin(now * 0.004 + pickup.position.x) * 0.05;
+          if (pickup.position.distanceTo(player.pos) < 1.6) {
+            pickup.userData.taken = true;
+            pickup.visible = false;
+            playerCombat.inventory.add(pickup.userData.weapon);
+            playerCombat.activeWeapon = pickup.userData.weapon;
+            hudRef.current.status = `Picked up ${pickup.userData.weapon}`;
+          }
+        });
+        defensePickups.forEach((pickup) => {
+          if (pickup.userData.taken) return;
+          pickup.rotation.y -= dt * 1.8;
+          if (pickup.position.distanceTo(player.pos) < 1.5) {
+            pickup.userData.taken = true;
+            pickup.visible = false;
+            playerCombat.defenses.add(pickup.userData.defense);
+            hudRef.current.status = `Defense online: ${pickup.userData.defense}`;
+          }
+        });
+
+        if (input.firePressed) {
+          const target = input.fireTarget || [ai1, ai2, ai3, ai4].filter((k) => k.damage < 100).sort((a,b)=>a.pos.distanceTo(player.pos)-b.pos.distanceTo(player.pos))[0];
+          if (target) {
+            const w = playerCombat.activeWeapon;
+            const canShoot = (playerCombat.ammo[w] ?? 0) > 0 || w === "FIREARM";
+            if (canShoot) {
+              if (w !== "FIREARM") playerCombat.ammo[w] = Math.max(0, (playerCombat.ammo[w] ?? 0) - 1);
+              target.damage += w === "FIREARM" || w === "RIFLE" ? 10 : 30;
+              target.speed *= w === "MISSILE" ? 0.35 : 0.6;
+              hudRef.current.crash = `${w} hit ${target.name}`;
+              if (target.damage > 92) hudRef.current.crash = `${target.name} disabled`;
+            }
+          }
+          input.firePressed = false;
+          input.fireTarget = null;
+        }
+
         const sorted = [...karts].sort((a, b) => b.progress - a.progress);
         const position = sorted.findIndex((k) => k === player) + 1;
         const baseStatus = originalMode ? "Original STK GLB mode" : trackQuality(player.pos, selectedTrack).onRoad ? `Track: ${selectedTrackId}` : "Off-road slowdown";
-        setHud({ ...hudRef.current, lap: player.lap, speed: Math.abs(player.speed), position, checkpoint: player.checkpoint, status: baseStatus, crash: crashTextT > 0 ? hudRef.current.crash : "" });
+        const weapon = playerCombat.activeWeapon;
+        const ammo = playerCombat.ammo[weapon] ?? 0;
+        setHud({ ...hudRef.current, lap: player.lap, speed: Math.abs(player.speed), position, checkpoint: player.checkpoint, status: baseStatus, crash: crashTextT > 0 ? hudRef.current.crash : "", weapon, ammo });
         renderer.render(scene, camera);
       };
       animate();
@@ -685,6 +785,9 @@ export default function SuperTuxKartPlayablePreview() {
       canvas.removeEventListener("pointermove", onPointerMove);
       canvas.removeEventListener("pointerup", onPointerUp);
       canvas.removeEventListener("pointercancel", onPointerUp);
+      if (onTargetClick) {
+        canvas.removeEventListener("click", onTargetClick);
+      }
       renderer.dispose();
       scene.traverse((o) => {
         const mesh = o;
@@ -711,6 +814,7 @@ export default function SuperTuxKartPlayablePreview() {
             <div style={{ fontSize: 12, fontWeight: 900, letterSpacing: 1.2, textTransform: "uppercase" }}>SuperTuxKart Truck Test</div>
             <div style={{ fontSize: 13, fontWeight: 800 }}>Pos {hud.position}/5 · Lap {hud.lap}</div>
             <div style={{ fontSize: 11, opacity: 0.82 }}>{hud.status} · {Math.round(hud.speed * 8)} km/h</div>
+            <div style={{ fontSize: 11, opacity: 0.9 }}>Weapon: {hud.weapon} · Ammo: {hud.ammo}</div>
             {hud.crash && <div style={{ marginTop: 2, fontSize: 12, fontWeight: 900, color: "#ffd166" }}>{hud.crash}</div>}
           </div>
           <button onClick={() => setHud((h) => ({ ...h, help: !h.help }))} style={{ pointerEvents: "auto", width: 42, height: 42, borderRadius: 999, border: "1px solid rgba(255,255,255,0.25)", background: "rgba(0,0,0,0.55)", color: "white", fontSize: 18, fontWeight: 900 }}>?</button>
@@ -721,7 +825,7 @@ export default function SuperTuxKartPlayablePreview() {
             <b>Controls</b><br />
             Desktop: W/↑ accelerate, S/↓ reverse, A/D steer, Space brake.<br />
             Mobile: drag left side to accelerate/steer, right side to rotate camera.<br />
-            Now includes 5 different trucks and impulse-based crash response.<br />
+            Now includes track weapon pickups and tap-to-fire combat on the right side.<br />
             Trees are GLTF-only. If no GLTF tree loads, no procedural trees are spawned.<br />
             Current mode: {hud.mode === "original-assets" ? "Original STK GLB assets loaded." : "Playable fallback because original STK GLBs are not available in this preview."}
           </div>


### PR DESCRIPTION
### Motivation
- Enable simple on-track combat and pickups in the playable SuperTuxKart fallback and introduce larger weapon/defense systems for gameplay variety. 
- Support additional aerial and missile weapon types and basic blocking logic for defensive systems. 
- Improve scene layout readability by fixing human-facing rotation around table seating in Murlan Royal scenes. 
- Expose track size tuning to make preset tracks adapt to alternate gameplay scales.

### Description
- Added `GoCrazyTrackCombatSystem` as a new Unity component implementing store entries, ownership, defenses, `CanBlockAttack` logic, and track size multipliers via `TrackLengthMultiplier`/`TrackWidthMultiplier`.
- Extended `LudoWeaponType` with `SideMissile`, `StrikeDrone`, `AttackHelicopter`, and `StrikeJet`, and added `requiresAerialStrike` to `WeaponBallisticsProfile`, plus `TryEquipByPickup(string)` to `BattleRoyaleWeaponDirector`.
- Updated `MurlanRoyalTableSeatingLayout` to add serialized options `fixHumanFacingDirection`, `humansShouldFaceTableCenter`, and `humanFacingEulerOffset`, and implemented `FixHumanFacing` which aligns human rotations when `ApplyLayout` runs.
- Enhanced the web preview `GoCrazyGame.jsx` playable fallback with track scaling (`TRACK_SIZE_MULTIPLIER` and `scaledTrack`), weapon and defense pickup spawning/collection, simple ammo/inventory and tap-to-fire combat, HUD weapon/ammo display, input additions (`firePressed`/`fireTarget`), raycast target selection, and cleanup of the added event listeners.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f76313e16083298a17de7ac1fe418c)