### PR TITLE
Add Go Crazy combat pickups, weapon store and inventory integration; improve track & controls

### DIFF
--- a/webapp/src/components/GoCrazyGame.jsx
+++ b/webapp/src/components/GoCrazyGame.jsx
@@ -30,7 +30,15 @@ const TRACK_PRESETS = {
   "forest-sweep": { outerX: 43, outerZ: 29, innerX: 27, innerZ: 12.6, centerX: 35, centerZ: 21, wobble: 0.11, hue: 0x2a3130 },
   "storm-bend": { outerX: 45, outerZ: 27, innerX: 27.5, innerZ: 11.5, centerX: 36, centerZ: 19, wobble: 0.14, hue: 0x2b2d33 }
 };
-const WEAPON_PICKUPS = ["RIFLE", "FIREARM", "MISSILE", "DRONE", "HELICOPTER", "JET"];
+const WEAPON_PICKUPS = ["RIFLE", "FIREARM", "MISSILE", "DRONE", "HELICOPTER", "JET"]
+const WEAPON_STORE = [
+  { id: "FIREARM", model: "/gltf/weapons/firearm.glb", price: 0 },
+  { id: "RIFLE", model: "/gltf/weapons/rifle.glb", price: 400 },
+  { id: "MISSILE", model: "/gltf/weapons/missile.glb", price: 1200 },
+  { id: "DRONE", model: "/gltf/weapons/drone.glb", price: 1700 },
+  { id: "HELICOPTER", model: "/gltf/weapons/helicopter.glb", price: 2200 },
+  { id: "JET", model: "/gltf/weapons/jet.glb", price: 2800 }
+];
 const DEFENSE_PICKUPS = ["MISSILE_RADAR", "DRONE_RADAR", "ANTI_MISSILE_BATTERY"];
 
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
@@ -50,14 +58,16 @@ function angleOnTrack(pos, track) {
 }
 
 function pointOnTrack(angle, track, lane = 0) {
-  const mod = 1 + Math.sin(angle * 3) * track.wobble;
-  return new THREE.Vector3(Math.cos(angle) * (track.centerX + lane) * mod, 0.18, Math.sin(angle) * (track.centerZ + lane * 0.45) * mod);
+  const mod = 1 + Math.sin(angle * 3) * track.wobble + Math.cos(angle * 5) * track.wobble * 0.45;
+  const hill = Math.sin(angle * 2.5 + Math.cos(angle * 0.7)) * 0.55 + Math.sin(angle * 7) * 0.15;
+  return new THREE.Vector3(Math.cos(angle) * (track.centerX + lane) * mod, 0.18 + hill, Math.sin(angle) * (track.centerZ + lane * 0.45) * mod);
 }
 
 function tangentYaw(angle, track) {
-  const dx = -Math.sin(angle) * track.centerX;
-  const dz = Math.cos(angle) * track.centerZ;
-  return Math.atan2(dx, dz);
+  const e = 0.01;
+  const p1 = pointOnTrack(angle, track, 0);
+  const p2 = pointOnTrack(angle + e, track, 0);
+  return Math.atan2(p2.x - p1.x, p2.z - p1.z);
 }
 
 function trackQuality(pos, track) {
@@ -248,13 +258,16 @@ function createProceduralTrack(scene, track) {
   }
 }
 
-function scatterGltfTrees(scene, tree) {
+function scatterGltfTrees(scene, tree, track) {
   if (!tree) return;
   for (let i = 0; i < 24; i++) {
     const a = (i / 24) * TAU + 0.08;
     const clone = cloneModel(tree);
     clone.scale.setScalar(0.45 + (i % 4) * 0.09);
-    clone.position.set(Math.cos(a) * (39 + (i % 3) * 2.2), 0, Math.sin(a) * (27 + (i % 2) * 2.3));
+    const side = i % 2 === 0 ? 1 : -1;
+    const sideOffset = side > 0 ? 6.5 : -6.5;
+    const edge = pointOnTrack(a, track, sideOffset);
+    clone.position.set(edge.x, 0, edge.z);
     clone.rotation.y = a + Math.PI * 0.25;
     enableShadows(clone);
     scene.add(clone);
@@ -401,7 +414,7 @@ function updatePlayerKart(kart, input, track, dt) {
   kart.speed = Math.max(-7, Math.min(maxSpeed, kart.speed));
   kart.speed *= Math.exp(-(quality.onRoad ? 0.65 : 2.2) * dt);
   kart.steer = lerp(kart.steer, clamp(steerRaw, -1, 1), 1 - Math.exp(-5.2 * dt));
-  const steerStrength = 1.35 * grip * clamp(Math.abs(kart.speed) / 9, 0.2, 1.05);
+  const steerStrength = 1.7 * grip * clamp(Math.abs(kart.speed) / 9, 0.24, 1.12);
   kart.yaw -= kart.steer * steerStrength * dt * Math.sign(kart.speed || 1);
   applyCrashDamping(kart, dt);
   kart.pos.addScaledVector(forwardFromYaw(kart.yaw), kart.speed * dt);
@@ -559,8 +572,8 @@ export default function SuperTuxKartPlayablePreview() {
     };
     const onPointerMove = (e) => {
       if (input.pointerId === e.pointerId) {
-        input.steer = clamp((e.clientX - input.startX) / 70, -1, 1);
-        input.accel = clamp(-(e.clientY - input.startY) / 75, -0.65, 1);
+        input.steer = clamp((e.clientX - input.startX) / 48, -1, 1);
+        input.accel = clamp(-(e.clientY - input.startY) / 60, -0.55, 1);
       }
       if (input.lookId === e.pointerId) {
         const dx = e.clientX - input.lastX;
@@ -605,7 +618,7 @@ export default function SuperTuxKartPlayablePreview() {
       if (cancelled) return;
       if (originalMode && assets?.track) scene.add(cloneModel(assets.track));
       else createProceduralTrack(scene, selectedTrack);
-      scatterGltfTrees(scene, assets?.tree);
+      scatterGltfTrees(scene, assets?.tree, selectedTrack);
 
       const variants = ["sport", "truck", "heavy", "rally", "longnose"];
       const colors = [0xff3b30, 0x35c3ff, 0xffcc00, 0x7cff6b, 0xb469ff];
@@ -630,9 +643,17 @@ export default function SuperTuxKartPlayablePreview() {
       const karts = [player, ai1, ai2, ai3, ai4];
       karts.forEach((k) => scene.add(k.group));
       const playerCombat = { activeWeapon: "FIREARM", inventory: new Set(["FIREARM"]), defenses: new Set(), ammo: { FIREARM: 999, RIFLE: 45, MISSILE: 2, DRONE: 1, HELICOPTER: 1, JET: 1 } };
+      const makeWeaponPickupMesh = (weapon) => {
+        if (weapon === "MISSILE") return new THREE.Mesh(new THREE.CylinderGeometry(0.1, 0.16, 1.0, 14), makeMat(0xff7b00, 0.35));
+        if (weapon === "DRONE") return new THREE.Mesh(new THREE.OctahedronGeometry(0.33, 0), makeMat(0x74f0ff, 0.35));
+        if (weapon === "HELICOPTER") return new THREE.Mesh(new THREE.CapsuleGeometry(0.18, 0.5, 6, 10), makeMat(0x89ff9b, 0.35));
+        if (weapon === "JET") return new THREE.Mesh(new THREE.ConeGeometry(0.25, 0.9, 12), makeMat(0x8ec9ff, 0.35));
+        if (weapon === "RIFLE") return new THREE.Mesh(new THREE.BoxGeometry(0.9, 0.14, 0.18), makeMat(0xf2d17a, 0.35));
+        return new THREE.Mesh(new THREE.BoxGeometry(0.55, 0.2, 0.18), makeMat(0xffe066, 0.35));
+      };
       const pickups = WEAPON_PICKUPS.map((weapon, i) => {
         const p = pointOnTrack((i / WEAPON_PICKUPS.length) * TAU + 0.36, selectedTrack, i % 2 === 0 ? 0.35 : -0.35);
-        const gem = new THREE.Mesh(new THREE.OctahedronGeometry(0.35, 0), makeMat(weapon === "MISSILE" ? 0xff7b00 : weapon === "DRONE" ? 0x74f0ff : 0xffe066, 0.35));
+        const gem = makeWeaponPickupMesh(weapon);
         gem.position.copy(p).add(new THREE.Vector3(0, 0.62, 0));
         gem.userData = { weapon, taken: false };
         scene.add(gem);
@@ -646,6 +667,25 @@ export default function SuperTuxKartPlayablePreview() {
         scene.add(node);
         return node;
       });
+
+      const activeProjectiles = [];
+      const activeAirStrikes = [];
+
+      function spawnProjectile(from, to, color = 0xffaa00, speed = 42, damage = 20) {
+        const mesh = new THREE.Mesh(new THREE.SphereGeometry(0.09, 10, 10), makeMat(color, 0.25, 0.2));
+        mesh.position.copy(from);
+        scene.add(mesh);
+        activeProjectiles.push({ mesh, vel: to.clone().sub(from).normalize().multiplyScalar(speed), ttl: 2, target: null, damage });
+      }
+
+      function callAirSupport(kind, target) {
+        const color = kind === "JET" ? 0x92c7ff : kind === "HELICOPTER" ? 0x6fffa6 : 0xffa14d;
+        const craft = new THREE.Mesh(new THREE.ConeGeometry(0.35, 1.2, 8), makeMat(color, 0.3, 0.2));
+        craft.rotation.x = Math.PI / 2;
+        craft.position.copy(target.pos).add(new THREE.Vector3(-6, 9, -6));
+        scene.add(craft);
+        activeAirStrikes.push({ kind, craft, target, ttl: 2.2, fired: false });
+      }
 
       const raycaster = new THREE.Raycaster();
       const pointer = new THREE.Vector2();
@@ -710,6 +750,13 @@ export default function SuperTuxKartPlayablePreview() {
         input.brake = Boolean(input.keys.Space);
         updatePlayerKart(player, input, selectedTrack, dt);
         for (const ai of [ai1, ai2, ai3, ai4]) updateAiKart(ai, karts, selectedTrack, dt);
+        for (const ai of [ai1, ai2, ai3, ai4]) {
+          const d = ai.pos.distanceTo(player.pos);
+          if (d < 18 && Math.random() < dt * 0.7) {
+            spawnProjectile(ai.pos.clone().add(new THREE.Vector3(0, 0.95, 0)), player.pos.clone().add(new THREE.Vector3(0, 0.9, 0)), 0xff665c, 38, 8);
+            hudRef.current.crash = `${ai.name} fired`;
+          }
+        }
         const impact = resolveVehicleCrashes(karts);
         if (impact > 0.8) {
           crashTextT = 1.2;
@@ -752,14 +799,43 @@ export default function SuperTuxKartPlayablePreview() {
             const canShoot = (playerCombat.ammo[w] ?? 0) > 0 || w === "FIREARM";
             if (canShoot) {
               if (w !== "FIREARM") playerCombat.ammo[w] = Math.max(0, (playerCombat.ammo[w] ?? 0) - 1);
-              target.damage += w === "FIREARM" || w === "RIFLE" ? 10 : 30;
-              target.speed *= w === "MISSILE" ? 0.35 : 0.6;
-              hudRef.current.crash = `${w} hit ${target.name}`;
+              if (w === "FIREARM" || w === "RIFLE") {
+                spawnProjectile(player.pos.clone().add(new THREE.Vector3(0, 1.1, 0)), target.pos.clone().add(new THREE.Vector3(0, 1.1, 0)), 0xffee88, 56, w === "RIFLE" ? 16 : 10);
+              } else if (w === "MISSILE") {
+                spawnProjectile(player.pos.clone().add(new THREE.Vector3(1.1, 0.65, 0)), target.pos.clone().add(new THREE.Vector3(0, 0.7, 0)), 0xff6a00, 34, 34);
+              } else {
+                callAirSupport(w, target);
+              }
+              hudRef.current.crash = `${w} locked ${target.name}`;
               if (target.damage > 92) hudRef.current.crash = `${target.name} disabled`;
             }
           }
           input.firePressed = false;
           input.fireTarget = null;
+        }
+
+        for (let i = activeProjectiles.length - 1; i >= 0; i--) {
+          const p = activeProjectiles[i];
+          p.ttl -= dt;
+          p.mesh.position.addScaledVector(p.vel, dt);
+          const hit = [ai1, ai2, ai3, ai4].find((k) => k.pos.distanceTo(p.mesh.position) < 1.2);
+          if (hit) {
+            hit.damage += p.damage;
+            hit.speed *= 0.6;
+            p.ttl = 0;
+          }
+          if (p.ttl <= 0) { scene.remove(p.mesh); p.mesh.geometry.dispose(); p.mesh.material.dispose(); activeProjectiles.splice(i, 1); }
+        }
+        for (let i = activeAirStrikes.length - 1; i >= 0; i--) {
+          const s = activeAirStrikes[i];
+          s.ttl -= dt;
+          const hover = s.target.pos.clone().add(new THREE.Vector3(0, 8.5, 0));
+          s.craft.position.lerp(hover, 1 - Math.exp(-3 * dt));
+          if (!s.fired && s.ttl < 1.5) {
+            s.fired = true;
+            spawnProjectile(s.craft.position.clone(), s.target.pos.clone().add(new THREE.Vector3(0, 1, 0)), 0xff4433, 45, 36);
+          }
+          if (s.ttl <= 0) { scene.remove(s.craft); s.craft.geometry.dispose(); s.craft.material.dispose(); activeAirStrikes.splice(i, 1); }
         }
 
         const sorted = [...karts].sort((a, b) => b.progress - a.progress);
@@ -818,6 +894,11 @@ export default function SuperTuxKartPlayablePreview() {
             {hud.crash && <div style={{ marginTop: 2, fontSize: 12, fontWeight: 900, color: "#ffd166" }}>{hud.crash}</div>}
           </div>
           <button onClick={() => setHud((h) => ({ ...h, help: !h.help }))} style={{ pointerEvents: "auto", width: 42, height: 42, borderRadius: 999, border: "1px solid rgba(255,255,255,0.25)", background: "rgba(0,0,0,0.55)", color: "white", fontSize: 18, fontWeight: 900 }}>?</button>
+        </div>
+
+        <div style={{ position: "absolute", right: 10, top: 64, maxWidth: 260, background: "rgba(0,0,0,0.5)", border: "1px solid rgba(255,255,255,0.16)", borderRadius: 12, padding: "8px 10px", fontSize: 10 }}>
+          <b>Weapon Store (GLTF slots)</b>
+          {WEAPON_STORE.map((w) => <div key={w.id}>{w.id} · ${w.price} · {w.model}</div>)}
         </div>
 
         {hud.help && (

--- a/webapp/src/config/goCrazyInventoryConfig.js
+++ b/webapp/src/config/goCrazyInventoryConfig.js
@@ -1,0 +1,40 @@
+export const GO_CRAZY_DEFAULT_LOADOUT = Object.freeze([
+  { type: 'weapon', optionId: 'firearm-basic' },
+  { type: 'defense', optionId: 'missile-radar-mk1' }
+]);
+
+export const GO_CRAZY_DEFAULT_UNLOCKS = Object.freeze({
+  weapon: ['firearm-basic'],
+  defense: ['missile-radar-mk1'],
+  support: []
+});
+
+export const GO_CRAZY_OPTION_LABELS = Object.freeze({
+  weapon: {
+    'firearm-basic': 'Basic Firearm',
+    'rifle-mk2': 'Rifle MK2',
+    'missile-sidewinder': 'Side Missile',
+    'drone-hunter': 'Hunter Drone'
+  },
+  support: {
+    'helicopter-strike': 'Helicopter Strike',
+    'jet-strike': 'Jet Strike'
+  },
+  defense: {
+    'missile-radar-mk1': 'Missile Radar',
+    'drone-radar-mk1': 'Drone Radar',
+    'anti-missile-battery': 'Anti Missile Battery'
+  }
+});
+
+export const GO_CRAZY_STORE_ITEMS = Object.freeze([
+  { id: 'gocrazy-firearm-basic', type: 'weapon', optionId: 'firearm-basic', label: 'Basic Firearm', description: 'Starter sidearm.', priceStars: 0, thumbnail: '/store-thumbs/gocrazy/firearm-basic.png' },
+  { id: 'gocrazy-rifle-mk2', type: 'weapon', optionId: 'rifle-mk2', label: 'Rifle MK2', description: 'Higher precision rifle.', priceStars: 450, thumbnail: '/store-thumbs/gocrazy/rifle-mk2.png' },
+  { id: 'gocrazy-missile', type: 'weapon', optionId: 'missile-sidewinder', label: 'Side Missile', description: 'Vehicle side launcher.', priceStars: 1200, thumbnail: '/store-thumbs/gocrazy/missile-sidewinder.png' },
+  { id: 'gocrazy-drone', type: 'weapon', optionId: 'drone-hunter', label: 'Hunter Drone', description: 'Auto-lock drone support.', priceStars: 1600, thumbnail: '/store-thumbs/gocrazy/drone-hunter.png' },
+  { id: 'gocrazy-heli', type: 'support', optionId: 'helicopter-strike', label: 'Helicopter Strike', description: 'Aerial support strike.', priceStars: 2200, thumbnail: '/store-thumbs/gocrazy/helicopter.png' },
+  { id: 'gocrazy-jet', type: 'support', optionId: 'jet-strike', label: 'Jet Strike', description: 'Fast high-damage strike.', priceStars: 2800, thumbnail: '/store-thumbs/gocrazy/jet.png' },
+  { id: 'gocrazy-missile-radar', type: 'defense', optionId: 'missile-radar-mk1', label: 'Missile Radar', description: 'Warns and mitigates missiles.', priceStars: 350, thumbnail: '/store-thumbs/gocrazy/missile-radar.png' },
+  { id: 'gocrazy-drone-radar', type: 'defense', optionId: 'drone-radar-mk1', label: 'Drone Radar', description: 'Counters drone lock-ons.', priceStars: 520, thumbnail: '/store-thumbs/gocrazy/drone-radar.png' },
+  { id: 'gocrazy-anti-missile', type: 'defense', optionId: 'anti-missile-battery', label: 'Anti-Missile Battery', description: 'Intercepts incoming rockets.', priceStars: 980, thumbnail: '/store-thumbs/gocrazy/anti-missile.png' }
+]);

--- a/webapp/src/pages/Store.jsx
+++ b/webapp/src/pages/Store.jsx
@@ -174,12 +174,24 @@ import {
   BOWLING_STORE_ITEMS
 } from '../config/bowlingInventoryConfig.js';
 import {
+  GO_CRAZY_DEFAULT_LOADOUT,
+  GO_CRAZY_OPTION_LABELS,
+  GO_CRAZY_STORE_ITEMS
+} from '../config/goCrazyInventoryConfig.js';
+import {
   addBowlingUnlock,
   bowlingAccountId,
   getBowlingInventory,
   isBowlingOptionUnlocked,
   listOwnedBowlingOptions
 } from '../utils/bowlingInventory.js';
+import {
+  addGoCrazyUnlock,
+  getGoCrazyInventory,
+  goCrazyAccountId,
+  isGoCrazyOptionUnlocked,
+  listOwnedGoCrazyOptions
+} from '../utils/goCrazyInventory.js';
 
 const TYPE_LABELS = {
   tableFinish: 'Table Finishes',
@@ -1215,6 +1227,18 @@ const storeMeta = {
     labels: BOWLING_OPTION_LABELS,
     typeLabels: TYPE_LABELS,
     accountId: POOL_STORE_ACCOUNT_ID
+  },
+  gocrazy: {
+    name: 'Go Crazy',
+    items: GO_CRAZY_STORE_ITEMS,
+    defaults: GO_CRAZY_DEFAULT_LOADOUT,
+    labels: GO_CRAZY_OPTION_LABELS,
+    typeLabels: {
+      weapon: 'Weapons',
+      support: 'Air Support',
+      defense: 'Defense'
+    },
+    accountId: POOL_STORE_ACCOUNT_ID
   }
 };
 
@@ -1261,6 +1285,9 @@ export default function Store() {
   );
   const [bowlingOwned, setBowlingOwned] = useState(() =>
     getBowlingInventory(bowlingAccountId(accountId))
+  );
+  const [goCrazyOwned, setGoCrazyOwned] = useState(() =>
+    getGoCrazyInventory(goCrazyAccountId(accountId))
   );
   const [accountBalance, setAccountBalance] = useState(null);
   const [processing, setProcessing] = useState('');
@@ -1390,6 +1417,7 @@ export default function Store() {
     setSnakeOwned(getSnakeInventory(snakeAccountId(accountId)));
     setTexasOwned(getTexasHoldemInventory(texasHoldemAccountId(accountId)));
     setBowlingOwned(getBowlingInventory(bowlingAccountId(accountId)));
+    setGoCrazyOwned(getGoCrazyInventory(goCrazyAccountId(accountId)));
     let cancelled = false;
     getPoolRoyalInventory(accountId)
       .then((inventory) => {
@@ -1844,6 +1872,11 @@ export default function Store() {
         ...item,
         key: createItemKey(item.type, item.optionId),
         slug: 'tabletennis'
+      })),
+      gocrazy: GO_CRAZY_STORE_ITEMS.map((item) => ({
+        ...item,
+        key: createItemKey(item.type, item.optionId),
+        slug: 'gocrazy'
       }))
     }),
     []
@@ -1880,7 +1913,9 @@ export default function Store() {
       tennis: (type, optionId) =>
         isPoolOptionUnlocked(type, optionId, poolOwned),
       texasholdem: (type, optionId) =>
-        isTexasOptionUnlocked(type, optionId, texasOwned)
+        isTexasOptionUnlocked(type, optionId, texasOwned),
+      gocrazy: (type, optionId) =>
+        isGoCrazyOptionUnlocked(type, optionId, goCrazyOwned)
     }),
     [
       airOwned,
@@ -1894,7 +1929,8 @@ export default function Store() {
       murlanOwned,
       dominoOwned,
       snakeOwned,
-      texasOwned
+      texasOwned,
+      goCrazyOwned
     ]
   );
 
@@ -1929,6 +1965,8 @@ export default function Store() {
         SNAKE_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
       texasholdem: (item) =>
         TEXAS_HOLDEM_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
+      gocrazy: (item) =>
+        GO_CRAZY_OPTION_LABELS[item.type]?.[item.optionId] || item.name,
       tennis: (item) =>
         POOL_ROYALE_OPTION_LABELS[item.type]?.[item.optionId] || item.name
     }),
@@ -2625,6 +2663,10 @@ export default function Store() {
                 entry.optionId,
                 resolvedAccountId
               )
+            );
+          } else if (slug === 'gocrazy') {
+            setGoCrazyOwned(
+              addGoCrazyUnlock(entry.type, entry.optionId, resolvedAccountId)
             );
           }
         }

--- a/webapp/src/utils/goCrazyInventory.js
+++ b/webapp/src/utils/goCrazyInventory.js
@@ -1,0 +1,37 @@
+import { GO_CRAZY_DEFAULT_UNLOCKS, GO_CRAZY_OPTION_LABELS } from '../config/goCrazyInventoryConfig.js';
+
+const STORAGE_KEY = 'goCrazyInventoryByAccount';
+
+const copyDefaults = () => Object.entries(GO_CRAZY_DEFAULT_UNLOCKS).reduce((acc,[k,v])=>{acc[k]=[...v];return acc;},{});
+const resolveAccountId = (accountId) => {
+  if (accountId) return accountId;
+  if (typeof window !== 'undefined') return window.localStorage.getItem('accountId') || 'guest';
+  return 'guest';
+};
+const readAll = () => {
+  if (typeof window === 'undefined') return {};
+  try { return JSON.parse(window.localStorage.getItem(STORAGE_KEY) || '{}'); } catch { return {}; }
+};
+const writeAll = (v) => { if (typeof window !== 'undefined') window.localStorage.setItem(STORAGE_KEY, JSON.stringify(v)); };
+const normalize = (raw) => {
+  const base = copyDefaults();
+  if (!raw || typeof raw !== 'object') return base;
+  const merged = { ...base };
+  Object.entries(raw).forEach(([k,v]) => { if (Array.isArray(v)) merged[k] = Array.from(new Set([...(merged[k]||[]), ...v])); });
+  return merged;
+};
+export const getGoCrazyInventory = (accountId) => {
+  const id = resolveAccountId(accountId); const all = readAll(); const inv = normalize(all[id]); writeAll({ ...all, [id]: inv }); return inv;
+};
+export const isGoCrazyOptionUnlocked = (type, optionId, inventoryOrAccountId) => {
+  const inv = (typeof inventoryOrAccountId === 'string' || !inventoryOrAccountId) ? getGoCrazyInventory(inventoryOrAccountId) : inventoryOrAccountId;
+  return Array.isArray(inv?.[type]) && inv[type].includes(optionId);
+};
+export const addGoCrazyUnlock = (type, optionId, accountId) => {
+  const id = resolveAccountId(accountId); const all = readAll(); const curr = normalize(all[id]); curr[type] = Array.from(new Set([...(curr[type]||[]), optionId])); writeAll({ ...all, [id]: curr }); return curr;
+};
+export const listOwnedGoCrazyOptions = (accountId) => {
+  const inv = getGoCrazyInventory(accountId);
+  return Object.entries(inv).flatMap(([type, values]) => (values || []).map((optionId) => ({ type, optionId, label: GO_CRAZY_OPTION_LABELS[type]?.[optionId] || optionId })));
+};
+export const goCrazyAccountId = resolveAccountId;


### PR DESCRIPTION
### Motivation
- Introduce combat gameplay for the "Go Crazy" playable preview with weapon pickups, projectiles and air support, and expose purchasable weapons via the in-app store and inventory system.
- Improve procedural track visuals and driving feel through more varied surface geometry and better tangent calculation.

### Description
- Added in-game combat systems in `webapp/src/components/GoCrazyGame.jsx`: `WEAPON_STORE`, pickup meshes, projectile spawn/resolve logic, air support mechanics, HUD weapon panel, pickup handling, and lifecycle cleanup for spawned objects.
- Improved track generation and driving behavior by updating `pointOnTrack` (added wobble/hill), `tangentYaw` (numerical derivative), steering sensitivity adjustments and `scatterGltfTrees` to place GLTF trees relative to the track.
- Added configuration for Go Crazy inventory and store in `webapp/src/config/goCrazyInventoryConfig.js` and a localStorage-backed inventory utility in `webapp/src/utils/goCrazyInventory.js` with `getGoCrazyInventory`, `isGoCrazyOptionUnlocked`, `addGoCrazyUnlock`, `listOwnedGoCrazyOptions`, and `goCrazyAccountId`.
- Integrated Go Crazy into the central store page in `webapp/src/pages/Store.jsx`: imports, `storeMeta` entry for `gocrazy`, state/hooks for owned items, label resolvers and purchase handling to add Go Crazy unlocks.

### Testing
- Performed a full project build with `npm run build` which completed successfully.
- Ran the existing test suite with `npm test` and linters which passed without errors.
- Verified the Go Crazy preview starts and the UI shows pickups, weapon HUD and store entries in a development environment (automated tests cover build/test only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7705ef2f08329b9789fa8a507940b)