### PR TITLE
Improve GLTF loading and add external vehicle/weapon models to playable preview

### DIFF
--- a/webapp/src/components/GoCrazyGame.jsx
+++ b/webapp/src/components/GoCrazyGame.jsx
@@ -19,6 +19,11 @@ const ORIGINAL_ASSETS = {
   treeRemote: "https://raw.githubusercontent.com/jagenjo/GTR_Framework/master/data/prefabs/tree.glb"
 };
 const MURLAN_HUMAN_MODEL_URL = "https://threejs.org/examples/models/gltf/readyplayer.me.glb";
+const FERRARI_KART_URL = "https://threejs.org/examples/models/gltf/ferrari.glb";
+const BUGGY_KART_URLS = [
+  "https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Models@master/2.0/Buggy/glTF-Binary/Buggy.glb",
+  "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Buggy/glTF-Binary/Buggy.glb"
+];
 
 const TAU = Math.PI * 2;
 const CHECKPOINTS = [0, Math.PI / 2, Math.PI, Math.PI * 1.5];
@@ -31,13 +36,13 @@ const TRACK_PRESETS = {
   "storm-bend": { outerX: 45, outerZ: 27, innerX: 27.5, innerZ: 11.5, centerX: 36, centerZ: 19, wobble: 0.14, hue: 0x2b2d33 }
 };
 const WEAPON_PICKUPS = ["RIFLE", "FIREARM", "MISSILE", "DRONE", "HELICOPTER", "JET"]
-const WEAPON_STORE = [
-  { id: "FIREARM", model: "/gltf/weapons/firearm.glb", price: 0 },
-  { id: "RIFLE", model: "/gltf/weapons/rifle.glb", price: 400 },
-  { id: "MISSILE", model: "/gltf/weapons/missile.glb", price: 1200 },
-  { id: "DRONE", model: "/gltf/weapons/drone.glb", price: 1700 },
-  { id: "HELICOPTER", model: "/gltf/weapons/helicopter.glb", price: 2200 },
-  { id: "JET", model: "/gltf/weapons/jet.glb", price: 2800 }
+const WEAPON_MODELS = [
+  { id: "FIREARM", model: "/gltf/weapons/firearm.glb" },
+  { id: "RIFLE", model: "/gltf/weapons/rifle.glb" },
+  { id: "MISSILE", model: "/gltf/weapons/missile.glb" },
+  { id: "DRONE", model: "/gltf/weapons/drone.glb" },
+  { id: "HELICOPTER", model: "/gltf/weapons/helicopter.glb" },
+  { id: "JET", model: "/gltf/weapons/jet.glb" }
 ];
 const DEFENSE_PICKUPS = ["MISSILE_RADAR", "DRONE_RADAR", "ANTI_MISSILE_BATTERY"];
 
@@ -122,27 +127,40 @@ function normalizeLoadedModel(obj) {
 }
 
 function makeLoader() {
-  const loader = new GLTFLoader();
-  loader.setCrossOrigin("anonymous");
+  const manager = new THREE.LoadingManager();
+  const loader = new GLTFLoader(manager);
   const draco = new DRACOLoader();
   draco.setDecoderPath("https://www.gstatic.com/draco/versioned/decoders/1.5.7/");
   loader.setDRACOLoader(draco);
-  return { loader, draco };
+  loader.setCrossOrigin("anonymous");
+  return { loader, draco, manager };
 }
 
-function loadGltf(loader, url) {
+function loadGltf(loader, manager, url) {
+  const base = url.slice(0, url.lastIndexOf("/") + 1);
+  manager.setURLModifier((assetUrl) => {
+    if (/^(https?:)?\/\//i.test(assetUrl) || assetUrl.startsWith("data:") || assetUrl.startsWith("blob:")) return assetUrl;
+    return new URL(assetUrl, base).toString();
+  });
   return new Promise((resolve, reject) => {
-    loader.load(url, (gltf) => resolve({ scene: normalizeLoadedModel(gltf.scene), animations: gltf.animations || [] }), undefined, reject);
+    const timeout = window.setTimeout(() => reject(new Error(`Timeout loading ${url}`)), 18000);
+    loader.load(url, (gltf) => {
+      window.clearTimeout(timeout);
+      resolve({ scene: normalizeLoadedModel(gltf.scene), animations: gltf.animations || [] });
+    }, undefined, (err) => {
+      window.clearTimeout(timeout);
+      reject(err);
+    });
   });
 }
 
-async function tryLoadTree(loader) {
+async function tryLoadTree(loader, manager) {
   try {
-    const local = await loadGltf(loader, ORIGINAL_ASSETS.treeLocal);
+    const local = await loadGltf(loader, manager, ORIGINAL_ASSETS.treeLocal);
     return local.scene;
   } catch {
     try {
-      const remote = await loadGltf(loader, ORIGINAL_ASSETS.treeRemote);
+      const remote = await loadGltf(loader, manager, ORIGINAL_ASSETS.treeRemote);
       return remote.scene;
     } catch (err) {
       console.warn("No GLTF tree available. Trees will be skipped; no procedural trees are spawned.", err);
@@ -151,9 +169,9 @@ async function tryLoadTree(loader) {
   }
 }
 
-async function tryLoadMurlanHuman(loader) {
+async function tryLoadMurlanHuman(loader, manager) {
   try {
-    const gltf = await loadGltf(loader, MURLAN_HUMAN_MODEL_URL);
+    const gltf = await loadGltf(loader, manager, MURLAN_HUMAN_MODEL_URL);
     return gltf.scene;
   } catch (err) {
     console.warn("Murlan seated human GLTF could not load.", err);
@@ -161,15 +179,27 @@ async function tryLoadMurlanHuman(loader) {
   }
 }
 
-async function tryLoadOriginalAssets(loader) {
-  const firstTruck = await loadGltf(loader, ORIGINAL_ASSETS.truckVariants[0]);
-  const track = await loadGltf(loader, ORIGINAL_ASSETS.track);
+async function tryLoadVehicleModel(loader, manager, urls) {
+  for (const url of urls) {
+    try {
+      const gltf = await loadGltf(loader, manager, url);
+      return gltf.scene;
+    } catch (err) {
+      console.warn("Vehicle model URL failed:", url, err);
+    }
+  }
+  return null;
+}
+
+async function tryLoadOriginalAssets(loader, manager) {
+  const firstTruck = await loadGltf(loader, manager, ORIGINAL_ASSETS.truckVariants[0]);
+  const track = await loadGltf(loader, manager, ORIGINAL_ASSETS.track);
   const trucks = [firstTruck.scene];
   const truckAnimations = [firstTruck.animations];
 
   for (const url of ORIGINAL_ASSETS.truckVariants.slice(1)) {
     try {
-      const extra = await loadGltf(loader, url);
+      const extra = await loadGltf(loader, manager, url);
       trucks.push(extra.scene);
       truckAnimations.push(extra.animations);
     } catch {
@@ -178,7 +208,7 @@ async function tryLoadOriginalAssets(loader) {
     }
   }
 
-  const tree = await tryLoadTree(loader);
+  const tree = await tryLoadTree(loader, manager);
   return { trucks, truckAnimations, track: track.scene, tree };
 }
 
@@ -382,6 +412,23 @@ function createOriginalKart(assets, name, ai, angle, lane, index, variant, track
   return { group, pos: pos.clone(), yaw: group.rotation.y, speed: 0, steer: 0, lap: 1, checkpoint: 0, progress: angle, ai, lane, name, mass: 1.25 + index * 0.08, radius: 1.45, crashT: 0, damage: 0, yawKick: 0, variant, mixer };
 }
 
+function fitVehicleModel(model, { targetLength = 2.5, lift = 0.12, yaw = Math.PI } = {}) {
+  const box = new THREE.Box3().setFromObject(model);
+  const size = box.getSize(new THREE.Vector3());
+  const maxDim = Math.max(size.x, size.y, size.z, 0.0001);
+  const scale = targetLength / maxDim;
+  model.scale.setScalar(scale);
+  model.updateMatrixWorld(true);
+  const fitted = new THREE.Box3().setFromObject(model);
+  const center = fitted.getCenter(new THREE.Vector3());
+  model.position.x -= center.x;
+  model.position.z -= center.z;
+  model.position.y += -fitted.min.y + lift;
+  model.rotation.y += yaw;
+  enableShadows(model);
+  return model;
+}
+
 function updateCheckpoint(kart, track) {
   const a = angleOnTrack(kart.pos, track);
   const target = CHECKPOINTS[kart.checkpoint % CHECKPOINTS.length];
@@ -506,7 +553,7 @@ function resolveVehicleCrashes(karts) {
 export default function SuperTuxKartPlayablePreview() {
   const hostRef = useRef(null);
   const canvasRef = useRef(null);
-  const [hud, setHud] = useState({ lap: 1, speed: 0, position: 1, checkpoint: 0, help: true, status: "Loading...", mode: "playable-preview", crash: "", weapon: "FIREARM", ammo: 999 });
+  const [hud, setHud] = useState({ lap: 1, speed: 0, position: 1, checkpoint: 0, status: "Loading...", mode: "playable-preview", crash: "", weapon: "FIREARM", ammo: 999 });
   const hudRef = useRef(hud);
 
   useEffect(() => {
@@ -523,7 +570,7 @@ export default function SuperTuxKartPlayablePreview() {
 
     let cancelled = false;
     let frameId = 0;
-    const { loader, draco } = makeLoader();
+    const { loader, draco, manager } = makeLoader();
     const input = { keys: {}, steer: 0, accel: 0, brake: false, pointerId: null, startX: 0, startY: 0, lookId: null, lastX: 0, camYaw: 0, firePressed: false, fireTarget: null };
     const renderer = new THREE.WebGLRenderer({ canvas, antialias: true, powerPreference: "high-performance" });
     renderer.setClearColor(0x85c7f2, 1);
@@ -606,15 +653,15 @@ export default function SuperTuxKartPlayablePreview() {
       let assets = null;
       let originalMode = false;
       try {
-        assets = await tryLoadOriginalAssets(loader);
+        assets = await tryLoadOriginalAssets(loader, manager);
         originalMode = Boolean(assets.trucks.length && assets.track);
       } catch (err) {
         console.warn("Original SuperTuxKart GLB files are not available. Running playable fallback.", err);
-        const tree = await tryLoadTree(loader);
+        const tree = await tryLoadTree(loader, manager);
         assets = { trucks: [], truckAnimations: [], tree };
       }
 
-      const murlanHumanTemplate = await tryLoadMurlanHuman(loader);
+      const murlanHumanTemplate = await tryLoadMurlanHuman(loader, manager);
       if (cancelled) return;
       if (originalMode && assets?.track) scene.add(cloneModel(assets.track));
       else createProceduralTrack(scene, selectedTrack);
@@ -622,7 +669,7 @@ export default function SuperTuxKartPlayablePreview() {
 
       const variants = ["sport", "truck", "heavy", "rally", "longnose"];
       const colors = [0xff3b30, 0x35c3ff, 0xffcc00, 0x7cff6b, 0xb469ff];
-      const names = ["Red Sport Truck", "Blue Box Truck", "Yellow Heavy Truck", "Green Rally Truck", "Purple Longnose"];
+      const names = ["Ferrari Sport", "Go-Kart Buggy", "Go-Kart Buggy", "Ferrari Sport", "Go-Kart Buggy"];
       const starts = [
         { angle: Math.PI / 2, lane: 0 },
         { angle: Math.PI / 2 - 0.18, lane: -1.5 },
@@ -642,8 +689,37 @@ export default function SuperTuxKartPlayablePreview() {
       const ai4 = makeKart(4);
       const karts = [player, ai1, ai2, ai3, ai4];
       karts.forEach((k) => scene.add(k.group));
+      const ferrariTemplate = await tryLoadVehicleModel(loader, manager, [FERRARI_KART_URL]);
+      const buggyTemplate = await tryLoadVehicleModel(loader, manager, BUGGY_KART_URLS);
+      karts.forEach((kart, i) => {
+        const useFerrari = i === 0 || i === 3;
+        const template = useFerrari ? ferrariTemplate : buggyTemplate;
+        if (!template) return;
+        kart.group.clear();
+        const vehicle = cloneModel(template);
+        fitVehicleModel(vehicle, { targetLength: useFerrari ? 2.55 : 2.35, lift: 0.1, yaw: Math.PI });
+        kart.group.add(vehicle);
+      });
       const playerCombat = { activeWeapon: "FIREARM", inventory: new Set(["FIREARM"]), defenses: new Set(), ammo: { FIREARM: 999, RIFLE: 45, MISSILE: 2, DRONE: 1, HELICOPTER: 1, JET: 1 } };
+      const WEAPON_MODEL_BY_ID = Object.fromEntries(WEAPON_MODELS.map((item) => [item.id, item.model]));
+      const weaponTemplates = {};
+      await Promise.all(WEAPON_PICKUPS.map(async (weapon) => {
+        const modelUrl = WEAPON_MODEL_BY_ID[weapon];
+        if (!modelUrl) return;
+        try {
+          const gltf = await loadGltf(loader, manager, modelUrl);
+          weaponTemplates[weapon] = gltf.scene;
+        } catch (err) {
+          console.warn("Weapon pickup model failed:", weapon, modelUrl, err);
+        }
+      }));
       const makeWeaponPickupMesh = (weapon) => {
+        const model = weaponTemplates[weapon];
+        if (model) {
+          const pickup = cloneModel(model);
+          fitVehicleModel(pickup, { targetLength: 1.08, lift: 0.02, yaw: 0 });
+          return pickup;
+        }
         if (weapon === "MISSILE") return new THREE.Mesh(new THREE.CylinderGeometry(0.1, 0.16, 1.0, 14), makeMat(0xff7b00, 0.35));
         if (weapon === "DRONE") return new THREE.Mesh(new THREE.OctahedronGeometry(0.33, 0), makeMat(0x74f0ff, 0.35));
         if (weapon === "HELICOPTER") return new THREE.Mesh(new THREE.CapsuleGeometry(0.18, 0.5, 6, 10), makeMat(0x89ff9b, 0.35));
@@ -653,11 +729,11 @@ export default function SuperTuxKartPlayablePreview() {
       };
       const pickups = WEAPON_PICKUPS.map((weapon, i) => {
         const p = pointOnTrack((i / WEAPON_PICKUPS.length) * TAU + 0.36, selectedTrack, i % 2 === 0 ? 0.35 : -0.35);
-        const gem = makeWeaponPickupMesh(weapon);
-        gem.position.copy(p).add(new THREE.Vector3(0, 0.62, 0));
-        gem.userData = { weapon, taken: false };
-        scene.add(gem);
-        return gem;
+        const weaponPickup = makeWeaponPickupMesh(weapon);
+        weaponPickup.position.copy(p).add(new THREE.Vector3(0, 0.62, 0));
+        weaponPickup.userData = { weapon, taken: false };
+        scene.add(weaponPickup);
+        return weaponPickup;
       });
       const defensePickups = DEFENSE_PICKUPS.map((defense, i) => {
         const p = pointOnTrack((i / DEFENSE_PICKUPS.length) * TAU + 1.2, selectedTrack, i % 2 === 0 ? -0.62 : 0.62);
@@ -893,24 +969,7 @@ export default function SuperTuxKartPlayablePreview() {
             <div style={{ fontSize: 11, opacity: 0.9 }}>Weapon: {hud.weapon} · Ammo: {hud.ammo}</div>
             {hud.crash && <div style={{ marginTop: 2, fontSize: 12, fontWeight: 900, color: "#ffd166" }}>{hud.crash}</div>}
           </div>
-          <button onClick={() => setHud((h) => ({ ...h, help: !h.help }))} style={{ pointerEvents: "auto", width: 42, height: 42, borderRadius: 999, border: "1px solid rgba(255,255,255,0.25)", background: "rgba(0,0,0,0.55)", color: "white", fontSize: 18, fontWeight: 900 }}>?</button>
         </div>
-
-        <div style={{ position: "absolute", right: 10, top: 64, maxWidth: 260, background: "rgba(0,0,0,0.5)", border: "1px solid rgba(255,255,255,0.16)", borderRadius: 12, padding: "8px 10px", fontSize: 10 }}>
-          <b>Weapon Store (GLTF slots)</b>
-          {WEAPON_STORE.map((w) => <div key={w.id}>{w.id} · ${w.price} · {w.model}</div>)}
-        </div>
-
-        {hud.help && (
-          <div style={{ position: "absolute", left: 10, bottom: 18, maxWidth: 352, background: "rgba(0,0,0,0.58)", border: "1px solid rgba(255,255,255,0.16)", borderRadius: 16, padding: "10px 12px", fontSize: 12, lineHeight: 1.35 }}>
-            <b>Controls</b><br />
-            Desktop: W/↑ accelerate, S/↓ reverse, A/D steer, Space brake.<br />
-            Mobile: drag left side to accelerate/steer, right side to rotate camera.<br />
-            Now includes track weapon pickups and tap-to-fire combat on the right side.<br />
-            Trees are GLTF-only. If no GLTF tree loads, no procedural trees are spawned.<br />
-            Current mode: {hud.mode === "original-assets" ? "Original STK GLB assets loaded." : "Playable fallback because original STK GLBs are not available in this preview."}
-          </div>
-        )}
 
         <button onPointerDown={brakeDown} onPointerUp={brakeUp} onPointerCancel={brakeUp} style={{ pointerEvents: "auto", position: "absolute", right: 18, bottom: 22, width: 78, height: 78, borderRadius: 999, border: "1px solid rgba(255,255,255,0.25)", background: "rgba(0,0,0,0.48)", color: "white", fontSize: 13, fontWeight: 900, boxShadow: "0 12px 30px rgba(0,0,0,0.28)" }}>BRAKE</button>
       </div>


### PR DESCRIPTION
### Motivation

- Make GLTF asset loading more robust for remote and relative assets and allow using external vehicle and weapon models in the playable preview.
- Replace the simplistic single-truck visuals with fitted external vehicle models (Ferrari / Buggy) to improve variety and appearance.

### Description

- Introduce a `THREE.LoadingManager` in `makeLoader` and add a URL modifier so relative asset references inside GLTFs resolve against each model's base URL, and add load timeouts in `loadGltf` via `manager` and `window.setTimeout`.
- Add `tryLoadVehicleModel` to attempt multiple vehicle URLs, add constants `FERRARI_KART_URL` and `BUGGY_KART_URLS`, and replace the fallback trucks with fitted external vehicle templates using the new `fitVehicleModel` helper to normalize scale/position/rotation and enable shadows.
- Load weapon pickup GLTFs from `WEAPON_MODELS` into `weaponTemplates` and prefer these models for `makeWeaponPickupMesh`, with a fallback geometric primitive for missing models; rename `WEAPON_STORE` to `WEAPON_MODELS` and wire a `WEAPON_MODEL_BY_ID` map for lookups.
- Refactor original asset loaders to accept the `manager` (`tryLoadOriginalAssets`, `tryLoadTree`, `tryLoadMurlanHuman`) and update call sites; remove the HUD `help` toggle and the weapon-store debug panel from the UI.

### Testing

- No automated tests were added or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7a39874e08329bc25f7f331cd7014)