### PR TITLE
Add modular tennis gameplay: stronger shots, scaling, audio, AI, and 8‑dir walk

### DIFF
--- a/Assets/Scripts/Gameplay/Tennis/CharacterWalk8Dir.cs
+++ b/Assets/Scripts/Gameplay/Tennis/CharacterWalk8Dir.cs
@@ -1,0 +1,41 @@
+using UnityEngine;
+
+namespace TonPlaygram.Gameplay.Tennis
+{
+    [RequireComponent(typeof(CharacterController))]
+    public class CharacterWalk8Dir : MonoBehaviour
+    {
+        [SerializeField] private float walkSpeed = 4.5f;
+        [SerializeField] private Transform cameraForwardSource;
+        [SerializeField] private Animator animator;
+
+        private CharacterController _controller;
+
+        private void Awake() => _controller = GetComponent<CharacterController>();
+
+        private void Update()
+        {
+            float x = Input.GetAxis("Horizontal");
+            float y = Input.GetAxis("Vertical");
+
+            Vector3 forward = cameraForwardSource != null ? cameraForwardSource.forward : Vector3.forward;
+            Vector3 right = cameraForwardSource != null ? cameraForwardSource.right : Vector3.right;
+            forward.y = 0f;
+            right.y = 0f;
+            forward.Normalize();
+            right.Normalize();
+
+            Vector3 move = (right * x + forward * y);
+            if (move.sqrMagnitude > 1f) move.Normalize();
+
+            _controller.Move(move * (walkSpeed * Time.deltaTime));
+
+            if (animator != null)
+            {
+                animator.SetFloat("MoveX", x);
+                animator.SetFloat("MoveY", y);
+                animator.SetFloat("Speed", move.magnitude);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Tennis/README.md
+++ b/Assets/Scripts/Gameplay/Tennis/README.md
@@ -1,0 +1,16 @@
+# Tennis gameplay upgrade notes
+
+This folder adds modular tennis systems:
+
+- `TennisShotTuning`: boosts shot power and supports flat/power/topspin/curve variants.
+- `TennisCourtScaler`: scales court + characters and moves camera back to keep similar framing.
+- `TennisAudioController`: trigger shot and bounce SFX.
+- `TennisAIOpponent`: faster AI reaction and mixed shot variants.
+- `CharacterWalk8Dir`: 8-direction walk movement (forward/backward/sideways).
+
+## Free/open-source sound effect sources
+
+1. Kenney assets (CC0): https://kenney.nl/assets
+2. Sonniss GDC free packs: https://sonniss.com/gameaudiogdc
+
+Import chosen WAV/OGG files into Unity and assign them to `shotClip` and `ballBounceClip`.

--- a/Assets/Scripts/Gameplay/Tennis/TennisAIOpponent.cs
+++ b/Assets/Scripts/Gameplay/Tennis/TennisAIOpponent.cs
@@ -1,0 +1,36 @@
+using UnityEngine;
+
+namespace TonPlaygram.Gameplay.Tennis
+{
+    public class TennisAIOpponent : MonoBehaviour
+    {
+        [SerializeField] private TennisShotTuning shotTuning;
+        [SerializeField] private Rigidbody ballBody;
+        [SerializeField] private Transform hitTarget;
+        [SerializeField, Min(0.1f)] private float reactionTime = 0.18f;
+        [SerializeField, Min(0.1f)] private float minShotPower01 = 0.55f;
+        [SerializeField, Min(0.1f)] private float maxShotPower01 = 1f;
+
+        private float _nextHitTime;
+
+        private void Update()
+        {
+            if (shotTuning == null || ballBody == null || hitTarget == null) return;
+            if (Time.time < _nextHitTime) return;
+
+            if (ballBody.position.z > transform.position.z)
+            {
+                _nextHitTime = Time.time + reactionTime;
+                ShootAdaptive();
+            }
+        }
+
+        private void ShootAdaptive()
+        {
+            Vector3 aim = (hitTarget.position - ballBody.position).normalized;
+            float power = Random.Range(minShotPower01, maxShotPower01);
+            ShotVariant variant = (ShotVariant)Random.Range(0, 5);
+            shotTuning.ApplyShot(ballBody, aim, power, variant);
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Tennis/TennisAudioController.cs
+++ b/Assets/Scripts/Gameplay/Tennis/TennisAudioController.cs
@@ -1,0 +1,31 @@
+using UnityEngine;
+
+namespace TonPlaygram.Gameplay.Tennis
+{
+    [RequireComponent(typeof(AudioSource))]
+    public class TennisAudioController : MonoBehaviour
+    {
+        [Header("Assign imported clips from open-source packs")]
+        [Tooltip("Recommended source: Kenney UI Audio + Impact Sounds (CC0): https://kenney.nl/assets")]
+        public AudioClip shotClip;
+        [Tooltip("Recommended source: Sonniss GDC free packs (license in pack): https://sonniss.com/gameaudiogdc")]
+        public AudioClip ballBounceClip;
+
+        [SerializeField, Range(0f, 1f)] private float shotVolume = 0.9f;
+        [SerializeField, Range(0f, 1f)] private float bounceVolume = 0.75f;
+
+        private AudioSource _audio;
+
+        private void Awake() => _audio = GetComponent<AudioSource>();
+
+        public void PlayShot()
+        {
+            if (shotClip != null) _audio.PlayOneShot(shotClip, shotVolume);
+        }
+
+        public void PlayBounce()
+        {
+            if (ballBounceClip != null) _audio.PlayOneShot(ballBounceClip, bounceVolume);
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Tennis/TennisCourtScaler.cs
+++ b/Assets/Scripts/Gameplay/Tennis/TennisCourtScaler.cs
@@ -1,0 +1,36 @@
+using UnityEngine;
+
+namespace TonPlaygram.Gameplay.Tennis
+{
+    public class TennisCourtScaler : MonoBehaviour
+    {
+        [SerializeField] private Transform courtRoot;
+        [SerializeField] private Transform[] characterRoots;
+        [SerializeField] private Camera targetCamera;
+        [SerializeField, Min(0.1f)] private float worldScaleMultiplier = 1.2f;
+        [SerializeField, Min(1f)] private float framingDistanceScale = 1.2f;
+
+        private void Start()
+        {
+            ApplyScaleAndFraming();
+        }
+
+        [ContextMenu("Apply Scale + Camera Framing")]
+        public void ApplyScaleAndFraming()
+        {
+            if (courtRoot != null) courtRoot.localScale *= worldScaleMultiplier;
+            if (characterRoots != null)
+            {
+                for (int i = 0; i < characterRoots.Length; i++)
+                {
+                    if (characterRoots[i] != null) characterRoots[i].localScale *= worldScaleMultiplier;
+                }
+            }
+
+            if (targetCamera != null)
+            {
+                targetCamera.transform.position *= framingDistanceScale;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Tennis/TennisShotTuning.cs
+++ b/Assets/Scripts/Gameplay/Tennis/TennisShotTuning.cs
@@ -1,0 +1,46 @@
+using UnityEngine;
+
+namespace TonPlaygram.Gameplay.Tennis
+{
+    [DisallowMultipleComponent]
+    public class TennisShotTuning : MonoBehaviour
+    {
+        [Header("Power")]
+        [Min(1f)] public float baseShotPower = 16f;
+        [Range(0f, 2f)] public float topspin = 0.35f;
+        [Range(0f, 2f)] public float sidespin = 0.2f;
+        [Range(0f, 2f)] public float curvePower = 0.5f;
+
+        public void ApplyShot(Rigidbody ballBody, Vector3 aimDirection, float normalizedPower, ShotVariant variant)
+        {
+            if (ballBody == null) return;
+
+            var dir = aimDirection.sqrMagnitude > 0.0001f ? aimDirection.normalized : transform.forward;
+            float power = baseShotPower * Mathf.Clamp01(normalizedPower);
+
+            float variantPowerMultiplier = variant == ShotVariant.Power ? 1.25f : 1f;
+            float finalPower = power * variantPowerMultiplier;
+
+            ballBody.AddForce(dir * finalPower, ForceMode.Impulse);
+
+            Vector3 right = Vector3.Cross(Vector3.up, dir).normalized;
+            float side = variant == ShotVariant.CurveLeft ? -1f : variant == ShotVariant.CurveRight ? 1f : 0f;
+            float spinY = (variant == ShotVariant.Topspin ? topspin : 0.15f) * finalPower;
+
+            ballBody.AddTorque((Vector3.right * spinY) + (right * side * sidespin * finalPower), ForceMode.Impulse);
+            if (Mathf.Abs(side) > 0f)
+            {
+                ballBody.AddForce(right * side * curvePower * normalizedPower, ForceMode.Impulse);
+            }
+        }
+    }
+
+    public enum ShotVariant
+    {
+        Flat,
+        Power,
+        Topspin,
+        CurveLeft,
+        CurveRight
+    }
+}


### PR DESCRIPTION
### Motivation
- Increase shot power and add richer shot types (power, topspin, curve) so shots feel more impactful.
- Make the court and player characters larger while preserving the current camera framing on screen.
- Provide open-source audio hooks for shot and ball bounce SFX instead of reusing existing project assets.
- Improve AI reaction and variety and add simple walking in all directions while keeping existing body motion unchanged.

### Description
- Added `Assets/Scripts/Gameplay/Tennis/TennisShotTuning.cs` which raises base shot power and applies force/torque for `Flat`, `Power`, `Topspin`, `CurveLeft`, and `CurveRight` variants using `Rigidbody.AddForce` and `AddTorque`.
- Added `Assets/Scripts/Gameplay/Tennis/TennisCourtScaler.cs` that scales the `courtRoot` and `characterRoots` by a configurable `worldScaleMultiplier` and compensates camera distance with `framingDistanceScale` to preserve framing.
- Added `Assets/Scripts/Gameplay/Tennis/TennisAudioController.cs` that exposes `shotClip` and `ballBounceClip` fields and `PlayShot`/`PlayBounce` methods with recommended open-source sources (Kenney, Sonniss) called out in the README.
- Added `Assets/Scripts/Gameplay/Tennis/TennisAIOpponent.cs` and `Assets/Scripts/Gameplay/Tennis/CharacterWalk8Dir.cs` to provide faster, randomized AI shot selection and an 8-direction walk component that drives movement via `CharacterController` and animator parameters.
- Added `Assets/Scripts/Gameplay/Tennis/README.md` with integration notes and links to recommended free/open-source SFX packs.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7abfd6cb08329b46c252536ba1e57)