### PR TITLE
Refine Murlan Royale card contact positioning and hand pose

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1773,10 +1773,10 @@ function computeHeldCardsPose({ player, resolvedSeatIndex = 0 }) {
 
   // Lift opponent cards higher and push them outward (away from table center)
   // so they sit closer to the avatar/chest area in portrait framing.
-  const sideSeatLift = isSideSeat ? 97.28 * MODEL_SCALE : 0;
-  const topSeatLift = isTopSeat ? 106.24 * MODEL_SCALE : 0;
-  const nonBottomOutwardPush = !isBottomHumanSeat ? -113.92 * MODEL_SCALE : 0;
-  const bottomForwardPull = isBottomHumanSeat ? -18.56 * MODEL_SCALE : 0;
+  const sideSeatLift = isSideSeat ? 101.44 * MODEL_SCALE : 0;
+  const topSeatLift = isTopSeat ? 111.36 * MODEL_SCALE : 0;
+  const nonBottomOutwardPush = !isBottomHumanSeat ? -121.12 * MODEL_SCALE : 0;
+  const bottomForwardPull = isBottomHumanSeat ? -24.32 * MODEL_SCALE : 0;
   const sideSeatLateralPull =
     isSideSeat
       ? (normalizedSeatIndex === 1 ? -0.08 * MODEL_SCALE : 0.08 * MODEL_SCALE)
@@ -1784,7 +1784,7 @@ function computeHeldCardsPose({ player, resolvedSeatIndex = 0 }) {
 
   return {
     x: sideSeatLateralPull,
-    y: 1.2 * MODEL_SCALE + sideSeatLift + topSeatLift + (isBottomHumanSeat ? 0.64 * MODEL_SCALE : 1.28 * MODEL_SCALE),
+    y: 1.2 * MODEL_SCALE + sideSeatLift + topSeatLift + (isBottomHumanSeat ? 0.88 * MODEL_SCALE : 1.52 * MODEL_SCALE),
     z: 0.82 * MODEL_SCALE + nonBottomOutwardPush + bottomForwardPull
   };
 }
@@ -1796,6 +1796,9 @@ function createCharacterRig(instance, seatRoot, seatConfig, characterTheme, play
   const rightUpperArm = findBoneByHints(instance, ['rightarm', 'arm.r', 'r_upperarm', 'rightshoulder', 'armjointr', 'arm_joint_r_1', 'arm_joint_r', 'shoulderr']);
   const rightForeArm = findBoneByHints(instance, ['rightforearm', 'r_forearm', 'rightlowerarm', 'forearmr', 'elbowr', 'arm_joint_r_2', 'arm_joint_r_3']);
   const rightHand = findBoneByHints(instance, ['righthand', 'hand.r', 'r_hand', 'handjointr', 'hand_joint_r']);
+  const rightIndexProximal = findBoneByHints(instance, ['rightindex1', 'indexfinger1.r', 'index_01_r', 'index1_r', 'indexproximalr']);
+  const rightIndexMid = findBoneByHints(instance, ['rightindex2', 'indexfinger2.r', 'index_02_r', 'index2_r', 'indexintermediater']);
+  const rightIndexDistal = findBoneByHints(instance, ['rightindex3', 'indexfinger3.r', 'index_03_r', 'index3_r', 'indexdistalr']);
   const leftUpperArm = findBoneByHints(instance, ['leftarm', 'arm.l', 'l_upperarm', 'leftshoulder', 'armjointl', 'arm_joint_l_1', 'arm_joint_l', 'shoulderl']);
   const leftForeArm = findBoneByHints(instance, ['leftforearm', 'l_forearm', 'leftlowerarm', 'forearml', 'elbowl', 'arm_joint_l_2', 'arm_joint_l_3']);
   const leftHand = findBoneByHints(instance, ['lefthand', 'hand.l', 'l_hand', 'handjointl', 'hand_joint_l']);
@@ -1840,6 +1843,9 @@ function createCharacterRig(instance, seatRoot, seatConfig, characterTheme, play
       rightUpperArm,
       rightForeArm,
       rightHand,
+      rightIndexProximal,
+      rightIndexMid,
+      rightIndexDistal,
       leftUpperArm,
       leftForeArm,
       leftHand,
@@ -1866,7 +1872,8 @@ function createCharacterRig(instance, seatRoot, seatConfig, characterTheme, play
     heldCards,
     heldCardsPose,
     isBottomHumanSeat: Boolean(player?.isHuman),
-    currentActionId: 0
+    currentActionId: 0,
+    contactHelpers: []
   };
 
   // Match Ludo Battle Royal seated framing: keep characters visually lower on portrait screens.
@@ -1895,6 +1902,9 @@ function createCharacterRig(instance, seatRoot, seatConfig, characterTheme, play
     rightUpperArm: captureBoneRotation(rightUpperArm),
     rightForeArm: captureBoneRotation(rightForeArm),
     rightHand: captureBoneRotation(rightHand),
+    rightIndexProximal: captureBoneRotation(rightIndexProximal),
+    rightIndexMid: captureBoneRotation(rightIndexMid),
+    rightIndexDistal: captureBoneRotation(rightIndexDistal),
     leftUpperArm: captureBoneRotation(leftUpperArm),
     leftForeArm: captureBoneRotation(leftForeArm),
     leftHand: captureBoneRotation(leftHand),
@@ -1903,6 +1913,15 @@ function createCharacterRig(instance, seatRoot, seatConfig, characterTheme, play
     rightThigh: captureBoneRotation(rightThigh),
     rightCalf: captureBoneRotation(rightCalf)
   };
+  if (CHARACTER_CONTACT_HELPERS_ENABLED) {
+    const handHelper = new THREE.AxesHelper(0.07 * MODEL_SCALE);
+    const tipHelper = new THREE.AxesHelper(0.045 * MODEL_SCALE);
+    const cardsHelper = new THREE.BoxHelper(heldCards, 0x00e5ff);
+    if (rightHand) rightHand.add(handHelper);
+    if (rightIndexDistal) rightIndexDistal.add(tipHelper);
+    instance.add(cardsHelper);
+    rig.contactHelpers.push(handHelper, tipHelper, cardsHelper);
+  }
 
   return rig;
 }
@@ -2082,9 +2101,22 @@ function runCharacterAction(store, rig, action) {
     const throwPrep = buildPoseVariant(basePose, {
       spine: { x: THREE.MathUtils.degToRad(-10) },
       rightUpperArm: { x: THREE.MathUtils.degToRad(-52), y: THREE.MathUtils.degToRad(-10), z: THREE.MathUtils.degToRad(-12) },
-      rightForeArm: { x: THREE.MathUtils.degToRad(-6) },
-      rightHand: { x: THREE.MathUtils.degToRad(6), y: THREE.MathUtils.degToRad(-8) },
+      rightForeArm: { x: THREE.MathUtils.degToRad(-12) },
+      rightHand: { x: THREE.MathUtils.degToRad(10), y: THREE.MathUtils.degToRad(-10) },
+      rightIndexProximal: { x: THREE.MathUtils.degToRad(14) },
+      rightIndexMid: { x: THREE.MathUtils.degToRad(18) },
+      rightIndexDistal: { x: THREE.MathUtils.degToRad(14) },
       head: { x: THREE.MathUtils.degToRad(-6) }
+    });
+    const cardPinchPose = buildPoseVariant(basePose, {
+      spine: { x: THREE.MathUtils.degToRad(-14) },
+      rightUpperArm: { x: THREE.MathUtils.degToRad(-58), y: THREE.MathUtils.degToRad(-14), z: THREE.MathUtils.degToRad(-10) },
+      rightForeArm: { x: THREE.MathUtils.degToRad(-20) },
+      rightHand: { x: THREE.MathUtils.degToRad(22), y: THREE.MathUtils.degToRad(-14), z: THREE.MathUtils.degToRad(-8) },
+      rightIndexProximal: { x: THREE.MathUtils.degToRad(30) },
+      rightIndexMid: { x: THREE.MathUtils.degToRad(28) },
+      rightIndexDistal: { x: THREE.MathUtils.degToRad(16) },
+      head: { x: THREE.MathUtils.degToRad(-8) }
     });
     const throwRelease = buildPoseVariant(basePose, {
       spine: { x: THREE.MathUtils.degToRad(8) },
@@ -2109,7 +2141,7 @@ function runCharacterAction(store, rig, action) {
     const pickupPos = handPos.clone();
     if (selectedCardMesh) {
       selectedCardMesh.getWorldPosition(pickupPos);
-      pickupPos.y += 0.01 * MODEL_SCALE;
+      pickupPos.y += CARD_PICK_CONTACT_LIFT;
     }
 
     const target = (store.tableAnchor || new THREE.Vector3()).clone();
@@ -2121,12 +2153,17 @@ function runCharacterAction(store, rig, action) {
 
     list.push({
       start: now,
-      duration: 180,
+      duration: 120,
       update: (t) => applyRigPoseLerp(rig, throwPrep, t)
     });
     list.push({
-      start: now + 180,
-      duration: 210,
+      start: now + 120,
+      duration: 130,
+      update: (t) => applyRigPoseLerp(rig, cardPinchPose, t)
+    });
+    list.push({
+      start: now + 250,
+      duration: 220,
       update: (t) => applyRigPoseLerp(rig, throwRelease, t),
       complete: () => {
         const flightStart = performance.now();
@@ -2146,7 +2183,7 @@ function runCharacterAction(store, rig, action) {
       }
     });
     list.push({
-      start: now + 420,
+      start: now + 500,
       duration: 280,
       update: (t) => applyRigPoseLerp(rig, basePose, t)
     });
@@ -2483,6 +2520,10 @@ const STOOL_HEIGHT = CHAIR_BASE_HEIGHT + SEAT_THICKNESS;
 const CHAIR_GROUND_DROP = 0;
 const CHAIR_SCREEN_LOWER_OFFSET = 0.14 * MODEL_SCALE;
 const HUMAN_CHAIR_EXTRA_OUTWARD_OFFSET = 0.52 * MODEL_SCALE; // pull the human seat a bit closer to the table on portrait framing.
+const CHARACTER_CONTACT_HELPERS_ENABLED =
+  typeof window !== 'undefined' &&
+  new URLSearchParams(window.location.search).get('murlanContactHelpers') === '1';
+const CARD_PICK_CONTACT_LIFT = 0.014 * MODEL_SCALE;
 const TABLE_HEIGHT_LIFT = 0.05 * MODEL_SCALE;
 const TABLE_HEIGHT = STOOL_HEIGHT + TABLE_HEIGHT_LIFT;
 const TABLE_SIDE_TRIM_SCALE = 1;


### PR DESCRIPTION
### Motivation
- Improve perceived physical contact between player hands and cards so cards sit higher and more outward (closer to avatars) in portrait framing.
- Provide per-character finger bones and a dedicated pinch phase so the right-hand index can articulate during card pickup for precise contact.
- Add runtime debug helpers to make fine-tuning hand/card alignment and finger tips easier during iteration.

### Description
- Adjusted held-card anchoring math in `computeHeldCardsPose` to lift cards and push them outward for side/top/non-bottom seats by updating lift/outward/pull constants and `y` offset.
- Added right-index bone discovery (`rightIndexProximal`, `rightIndexMid`, `rightIndexDistal`) to the rig via `findBoneByHints` and included them in `rig.bones`, `rig.defaults`, and `rig.seatedPose` for pose blending.
- Introduced a new pinch phase for the `PLAY` action by adding a `cardPinchPose` between `throwPrep` and `throwRelease`, and lengthened the timeline to create a distinct pick/pinch/release sequence.
- Increased pickup vertical offset for selected cards via the `CARD_PICK_CONTACT_LIFT` constant to improve contact continuity when grabbing card meshes.
- Added optional on-screen contact debug helpers (right-hand `AxesHelper`, index-tip `AxesHelper`, and held-cards `BoxHelper`) toggleable with `?murlanContactHelpers=1` to visualize and tune hand/card contact.
- Minor timing tweak to return-to-base pose start to match the new pinch/release timing.

### Testing
- Ran the production build: `npm -C webapp run -s build`, which completed successfully (Vite reported non-blocking chunk-size warnings only). 
- Verified the modified scene file `webapp/src/pages/Games/MurlanRoyaleArena.jsx` compiles and the new helpers can be enabled with `?murlanContactHelpers=1` at runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f822966c648329b4944c283323903d)