### PR TITLE
Scale table, paddles and players; tune physics, AI positions, camera and audio for Table Tennis

### DIFF
--- a/webapp/src/pages/Games/TableTennis.tsx
+++ b/webapp/src/pages/Games/TableTennis.tsx
@@ -126,23 +126,24 @@ const UP = new THREE.Vector3(0, 1, 0);
 const Y_AXIS = UP;
 
 const CFG = {
-  tableL: 2.74,
-  tableW: 1.525,
-  tableY: 0.76,
+  // Match Pool Royale stage proportions so table footprint/height align in the same HDRI placement.
+  tableL: 5.8,
+  tableW: 3.2,
+  tableY: 1.45,
   tableTopThickness: 0.075,
   netH: 0.1525,
   netPostOutside: 0.1525,
-  ballR: 0.02,
+  ballR: 0.038,
   gravity: 9.81,
   airDrag: 0.22,
   magnus: 0.00125,
   tableRestitution: 0.875,
   tableFriction: 0.965,
   spinDecay: 0.72,
-  playerHeight: 1.72,
-  playerSpeed: 2.95,
-  aiSpeed: 3.05,
-  reach: 0.48,
+  playerHeight: 2.9,
+  playerSpeed: 3.35,
+  aiSpeed: 3.45,
+  reach: 0.82,
   swingDuration: 0.34,
   backhandDuration: 0.29,
   serveDuration: 0.86,
@@ -152,6 +153,10 @@ const CFG = {
   playerVisualYawFix: Math.PI,
   paddlePalmOffset: 0.038,
 };
+
+const TABLE_REFERENCE_LENGTH = 2.74;
+const TABLE_SCALE_FACTOR = CFG.tableL / TABLE_REFERENCE_LENGTH;
+const PADDLE_SCALE_FACTOR = Math.max(1, TABLE_SCALE_FACTOR * 0.78);
 
 const TABLE_HALF_W = CFG.tableW / 2;
 const TABLE_HALF_L = CFG.tableL / 2;
@@ -358,46 +363,47 @@ function createFallbackHuman(color: number) {
 }
 
 function createTableTennisPaddle(colorA: number, colorB = 0x090909) {
+  const s = PADDLE_SCALE_FACTOR;
   const g = new THREE.Group();
   const wood = material(0x9a6a35, 0.62, 0.02);
   const redRubber = material(colorA, 0.86, 0.01);
   const blackRubber = material(colorB, 0.88, 0.01);
   const edge = material(0xead5a7, 0.6, 0.0);
 
-  const handle = new THREE.Mesh(new THREE.BoxGeometry(0.048, 0.14, 0.034), wood);
-  handle.position.y = 0.045;
+  const handle = new THREE.Mesh(new THREE.BoxGeometry(0.048 * s, 0.14 * s, 0.034 * s), wood);
+  handle.position.y = 0.045 * s;
   handle.rotation.z = 0.02;
   enableShadow(handle);
   g.add(handle);
 
-  const throat = new THREE.Mesh(new THREE.BoxGeometry(0.07, 0.05, 0.014), wood);
-  throat.position.y = 0.125;
+  const throat = new THREE.Mesh(new THREE.BoxGeometry(0.07 * s, 0.05 * s, 0.014 * s), wood);
+  throat.position.y = 0.125 * s;
   enableShadow(throat);
   g.add(throat);
 
-  const bladeEdge = new THREE.Mesh(new THREE.CylinderGeometry(0.092, 0.092, 0.012, 56), edge);
+  const bladeEdge = new THREE.Mesh(new THREE.CylinderGeometry(0.092 * s, 0.092 * s, 0.012 * s, 56), edge);
   bladeEdge.rotation.x = Math.PI / 2;
   bladeEdge.scale.x = 0.92;
   bladeEdge.scale.y = 1.08;
-  bladeEdge.position.y = 0.19;
+  bladeEdge.position.y = 0.19 * s;
   enableShadow(bladeEdge);
   g.add(bladeEdge);
 
-  const front = new THREE.Mesh(new THREE.CircleGeometry(0.089, 56), redRubber);
+  const front = new THREE.Mesh(new THREE.CircleGeometry(0.089 * s, 56), redRubber);
   front.scale.y = 1.08;
-  front.position.set(0, 0.19, 0.0078);
+  front.position.set(0, 0.19 * s, 0.0078 * s);
   g.add(front);
 
-  const back = new THREE.Mesh(new THREE.CircleGeometry(0.089, 56), blackRubber);
+  const back = new THREE.Mesh(new THREE.CircleGeometry(0.089 * s, 56), blackRubber);
   back.scale.y = 1.08;
   back.rotation.y = Math.PI;
-  back.position.set(0, 0.19, -0.0078);
+  back.position.set(0, 0.19 * s, -0.0078 * s);
   g.add(back);
 
   for (let i = 0; i < 18; i++) {
-    const dot = new THREE.Mesh(new THREE.BoxGeometry(0.005, 0.005, 0.018), edge);
+    const dot = new THREE.Mesh(new THREE.BoxGeometry(0.005 * s, 0.005 * s, 0.018 * s), edge);
     const a = (i / 18) * Math.PI * 2;
-    dot.position.set(Math.cos(a) * 0.084 * 0.92, 0.19 + Math.sin(a) * 0.09 * 1.08, 0);
+    dot.position.set(Math.cos(a) * 0.084 * 0.92 * s, (0.19 + Math.sin(a) * 0.09 * 1.08) * s, 0);
     dot.rotation.z = a;
     g.add(dot);
   }
@@ -939,7 +945,8 @@ function performHit(player: HumanRig, ball: BallState, hit: DesiredHit, serve = 
   } else {
     ball.pos.y = clamp(ball.pos.y, CFG.tableY + 0.08, CFG.tableY + 0.48);
     const dist = Math.hypot(target.x - ball.pos.x, target.z - ball.pos.z);
-    const flight = clamp(dist / (3.45 + hit.power * 3.35), 0.21, 0.54);
+    const speedScale = Math.max(1, TABLE_SCALE_FACTOR * 0.85);
+    const flight = clamp(dist / ((3.45 + hit.power * 3.35) * speedScale), 0.18, 0.48);
     ball.vel.copy(ballisticVelocity(ball.pos, target, flight));
     ball.spin.set(-dirZ * (62 + hit.topSpin * 92), hit.sideSpin * 104, hit.sideSpin * 12);
     ball.phase = { kind: "rally" };
@@ -966,7 +973,7 @@ function canReachBall(player: HumanRig, ball: BallState) {
   if (ball.bounceSide !== player.side || ball.bounceCount < 1) return false;
   if (ball.pos.y < CFG.tableY + 0.06 || ball.pos.y > CFG.tableY + 0.62) return false;
   const pose = tableTennisPose(player, ball);
-  const paddleReach = pose.paddleCenter.distanceTo(ball.pos) < 0.24;
+  const paddleReach = pose.paddleCenter.distanceTo(ball.pos) < 0.24 * PADDLE_SCALE_FACTOR;
   return paddleReach;
 }
 
@@ -976,7 +983,7 @@ function updatePlayerMotion(player: HumanRig, ball: BallState, dt: number) {
   const maxStep = player.speed * dt;
   if (dist > 0.0001) player.pos.addScaledVector(to.normalize(), Math.min(maxStep, dist));
 
-  player.pos.x = clamp(player.pos.x, -0.95, 0.95);
+  player.pos.x = clamp(player.pos.x, -TABLE_HALF_W * 0.82, TABLE_HALF_W * 0.82);
   if (player.side === "near") player.pos.z = clamp(player.pos.z, TABLE_HALF_L + 0.18, TABLE_HALF_L + 0.9);
   else player.pos.z = clamp(player.pos.z, -TABLE_HALF_L - 0.9, -TABLE_HALF_L - 0.18);
 
@@ -1130,8 +1137,8 @@ export default function MobileRealisticTableTennisGame() {
     };
     loadHdri();
 
-    const camera = new THREE.PerspectiveCamera(46, 1, 0.03, 30);
-    const cameraTarget = new THREE.Vector3(0, CFG.tableY + 0.08, -0.05);
+    const camera = new THREE.PerspectiveCamera(46, 1, 0.03, 36);
+    const cameraTarget = new THREE.Vector3(0, CFG.tableY + 0.1, -0.05);
 
     scene.add(new THREE.AmbientLight(0xffffff, 0.64));
     scene.add(new THREE.HemisphereLight(0xffffff, 0x263f4b, 0.8));
@@ -1155,8 +1162,8 @@ export default function MobileRealisticTableTennisGame() {
     addTable(scene, renderer);
 
     const humanModelUrl = selectedHumanOption?.modelUrls?.[0];
-    const nearPlayer = addHuman(scene, renderer, "near", new THREE.Vector3(0, 0, TABLE_HALF_L + 0.48), 0xff6b2e, humanModelUrl);
-    const farPlayer = addHuman(scene, renderer, "far", new THREE.Vector3(0, 0, -TABLE_HALF_L - 0.48), 0x4ab7ff, humanModelUrl);
+    const nearPlayer = addHuman(scene, renderer, "near", new THREE.Vector3(0, 0, TABLE_HALF_L + 1.05), 0xff6b2e, humanModelUrl);
+    const farPlayer = addHuman(scene, renderer, "far", new THREE.Vector3(0, 0, -TABLE_HALF_L - 1.05), 0x4ab7ff, humanModelUrl);
     const players: Record<PlayerSide, HumanRig> = { near: nearPlayer, far: farPlayer };
     const ball = createBall();
     scene.add(ball.mesh);
@@ -1185,10 +1192,17 @@ export default function MobileRealisticTableTennisGame() {
     let last = performance.now();
     let pointLock = false;
     let pointLockT = 0;
-    const shotFx = new Audio("/assets/sounds/hit-wood-4-94067.mp3");
-    shotFx.volume = 0.55;
-    const bounceFx = new Audio("/assets/sounds/ping-pong-ball-hit-258590.mp3");
-    bounceFx.volume = 0.35;
+    const shotFx = new Audio("/assets/sounds/freesound_community-ping-pong-ball-100140.mp3");
+    shotFx.volume = 0.48;
+    const bounceFx = new Audio("/assets/sounds/freesound_community-ping-pong-ball-100140.mp3");
+    bounceFx.volume = 0.28;
+    bounceFx.playbackRate = 1.08;
+    const netFx = new Audio("/assets/sounds/snooker-cue-put-on-table-81295.mp3");
+    netFx.volume = 0.22;
+    netFx.playbackRate = 1.4;
+    const scoreFx = new Audio("/assets/sounds/successful.mp3");
+    scoreFx.volume = 0.26;
+    const playFx = (fx: HTMLAudioElement) => { fx.currentTime = 0; fx.play().catch(() => {}); };
     const replayFrames: THREE.Vector3[] = [];
     let replayT = 0;
 
@@ -1213,6 +1227,7 @@ export default function MobileRealisticTableTennisGame() {
         reason === "wrongSide" ? "Wrong side" :
         "Miss";
       setHud({ ...prev, ...next, status: `${reasonText}: ${winner === "near" ? "You" : "AI"} scores`, power: 0, spin: 0 });
+      playFx(scoreFx);
     };
 
     const resize = () => {
@@ -1222,7 +1237,7 @@ export default function MobileRealisticTableTennisGame() {
       renderer.setPixelRatio(Math.min(2, window.devicePixelRatio || 1));
       camera.aspect = w / h;
       camera.fov = camera.aspect < 0.72 ? 48 : 42;
-      camera.position.set(0, camera.aspect < 0.72 ? 2.85 : 2.45, camera.aspect < 0.72 ? 3.25 : 2.8);
+      camera.position.set(0, camera.aspect < 0.72 ? 5.9 : 5.0, camera.aspect < 0.72 ? 7.0 : 6.1);
       camera.lookAt(cameraTarget);
       camera.updateProjectionMatrix();
     };
@@ -1260,7 +1275,7 @@ export default function MobileRealisticTableTennisGame() {
       control.lastY = e.clientY;
       const dx = e.clientX - control.startX;
       const dy = e.clientY - control.startY;
-      nearPlayer.target.x = clamp(control.startPlayer.x + dx * 0.0047, -0.95, 0.95);
+      nearPlayer.target.x = clamp(control.startPlayer.x + dx * 0.0047, -TABLE_HALF_W * 0.82, TABLE_HALF_W * 0.82);
       nearPlayer.target.z = clamp(control.startPlayer.z + dy * 0.0032, TABLE_HALF_L + 0.18, TABLE_HALF_L + 0.9);
       setHudSafe({ power: clamp01(Math.hypot(dx, dy) / 210), spin: clamp(dx / 170, -1, 1) });
 
@@ -1367,6 +1382,7 @@ export default function MobileRealisticTableTennisGame() {
         ball.pos.z = ball.lastHitBy === "near" ? 0.025 : -0.025;
         ball.vel.z *= -0.24;
         ball.vel.y = Math.max(0.1, Math.abs(ball.vel.y) * 0.24);
+        playFx(netFx);
         awardPoint(opposite(ball.lastHitBy), "net");
       }
 
@@ -1381,8 +1397,7 @@ export default function MobileRealisticTableTennisGame() {
         ball.vel.x += ball.spin.y * 0.0012;
         ball.spin.x *= 0.82;
         ball.spin.y *= 0.86;
-        bounceFx.currentTime = 0;
-        bounceFx.play().catch(() => {});
+        playFx(bounceFx);
         handleTableBounce(side);
       }
 
@@ -1392,7 +1407,7 @@ export default function MobileRealisticTableTennisGame() {
         awardPoint(hadLegalBounce ? hitter : opposite(hitter), "out");
       }
 
-      if ((Math.abs(ball.pos.x) > 2.7 || Math.abs(ball.pos.z) > 3.7 || ball.pos.y < -0.7) && ball.lastHitBy) {
+      if ((Math.abs(ball.pos.x) > TABLE_HALF_W + 1.3 || Math.abs(ball.pos.z) > TABLE_HALF_L + 1.8 || ball.pos.y < -0.7) && ball.lastHitBy) {
         const hitter = ball.lastHitBy;
         const hadLegalBounce = ball.bounceSide === opposite(hitter) && ball.bounceCount >= 1;
         awardPoint(hadLegalBounce ? hitter : opposite(hitter), "out");
@@ -1404,10 +1419,10 @@ export default function MobileRealisticTableTennisGame() {
     }
 
     function updateAi(dt: number) {
-      const home = new THREE.Vector3(0, 0, -TABLE_HALF_L - 0.48);
+      const home = new THREE.Vector3(0, 0, -TABLE_HALF_L - 1.05);
 
       if (ball.lastHitBy === null && ball.phase.kind === "serve" && ball.phase.server === "far") {
-        farPlayer.target.lerp(new THREE.Vector3(0.08, 0, -TABLE_HALF_L - 0.48), 0.045);
+        farPlayer.target.lerp(new THREE.Vector3(0.08, 0, -TABLE_HALF_L - 1.05), 0.045);
         aiServeWindup += dt;
         if (aiServeWindup > 0.62 && farPlayer.swingT === 0) {
           startSwing(farPlayer, makeAiServeTarget(), "serve");
@@ -1421,8 +1436,8 @@ export default function MobileRealisticTableTennisGame() {
       if (incoming) {
         const landing = predictNextTableBounce(ball);
         const strikeZ = landing.z - (ball.pos.y > CFG.tableY + 0.35 ? 0.42 : 0.32);
-        farPlayer.target.x = clamp(landing.x, -0.95, 0.95);
-        farPlayer.target.z = clamp(strikeZ, -TABLE_HALF_L - 0.86, -TABLE_HALF_L - 0.2);
+        farPlayer.target.x = clamp(landing.x, -TABLE_HALF_W * 0.82, TABLE_HALF_W * 0.82);
+        farPlayer.target.z = clamp(strikeZ, -TABLE_HALF_L - 1.45, -TABLE_HALF_L - 0.42);
       } else {
         farPlayer.target.lerp(home, 0.04);
       }
@@ -1441,8 +1456,7 @@ export default function MobileRealisticTableTennisGame() {
         if (player.swingT <= 0 || player.hitThisSwing || !player.desiredHit) continue;
         if (player.action === "serve") {
           if (player.swingT >= CFG.serveContactT) {
-            shotFx.currentTime = 0;
-            shotFx.play().catch(() => {});
+            playFx(shotFx);
             performHit(player, ball, player.desiredHit, true);
             setHudSafe({ status: player.side === "near" ? "Serve: own side then AI side" : "AI served legally" });
           }
@@ -1450,8 +1464,7 @@ export default function MobileRealisticTableTennisGame() {
         }
         if (player.swingT < CFG.hitWindowStart || player.swingT > CFG.hitWindowEnd) continue;
         if (canReachBall(player, ball)) {
-          shotFx.currentTime = 0;
-          shotFx.play().catch(() => {});
+          playFx(shotFx);
           performHit(player, ball, player.desiredHit, false);
           setHudSafe({ status: player.side === "near" ? "Return sent" : "AI returned" });
         } else if (player.side === "near" && player.swingT > CFG.hitWindowEnd - 0.02) {
@@ -1479,8 +1492,8 @@ export default function MobileRealisticTableTennisGame() {
           farPlayer.action = "ready";
           nearPlayer.swingT = 0;
           farPlayer.swingT = 0;
-          nearPlayer.target.set(0, 0, TABLE_HALF_L + 0.48);
-          farPlayer.target.set(0, 0, -TABLE_HALF_L - 0.48);
+          nearPlayer.target.set(0, 0, TABLE_HALF_L + 1.05);
+          farPlayer.target.set(0, 0, -TABLE_HALF_L - 1.05);
           resetBallForServe(ball, players[currentServer]);
           aiServeWindup = 0;
           setHudSafe({ status: currentServer === "near" ? "Your serve: swipe up" : "AI is serving", power: 0, spin: 0 });


### PR DESCRIPTION
### Motivation

- Align the table footprint/height with the Pool Royale stage HDRI so the table and scene lighting match expected placement.
- Improve visual realism and gameplay by resizing the ball, paddles, and player rigs and retuning physics and AI movement to suit the new scale.
- Improve audio feedback by updating sound assets and centralizing playback handling.

### Description

- Updated `CFG` to new table dimensions, `tableY`, `ballR`, player size and speed, `reach`, and related gameplay timings, and introduced `TABLE_REFERENCE_LENGTH`, `TABLE_SCALE_FACTOR`, and `PADDLE_SCALE_FACTOR` to drive scaled geometry and physics.
- Scaled paddle geometry in `createTableTennisPaddle` using `PADDLE_SCALE_FACTOR`, adjusted paddle reach checks and hit flight calculation by applying `TABLE_SCALE_FACTOR`/`PADDLE_SCALE_FACTOR` in `canReachBall` and `performHit` respectively.
- Expanded player movement/clamp bounds and repositioned player start/idle targets and AI home/serve positions to account for the larger table, and adjusted camera position/target and frustum to frame the scaled scene.
- Replaced and tuned audio assets, added `playFx` wrapper for safe playback, introduced separate `netFx` and `scoreFx`, and updated bounce/shot/net/score usage to call `playFx` with adjusted volumes and playback rates.

### Testing

- Ran TypeScript type-check with `tsc --noEmit` and the project build with `yarn build`, both completed successfully.
- Existing automated test suite (if present) was executed via `yarn test` with no test failures reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f81f706e14832991be61771e0f5337)