### PR TITLE
Improve GoCrazy pickups, layout, animations and resource cleanup

### DIFF
--- a/webapp/src/components/GoCrazyGame.jsx
+++ b/webapp/src/components/GoCrazyGame.jsx
@@ -61,6 +61,16 @@ const WEAPON_MODEL_CANDIDATES = {
 const DEFENSE_PICKUPS = ["MISSILE_RADAR", "DRONE_RADAR", "ANTI_MISSILE_BATTERY"];
 const WEAPON_ICON = { FIREARM: "🔫", RIFLE: "🪖", MISSILE: "🚀", DRONE: "🛸", HELICOPTER: "🚁", JET: "✈️", TRUCK: "🚒", TOWER: "📡" };
 const SUPPORT_PICKUP_TYPES = ["TRUCK", "DRONE", "HELICOPTER", "JET", "TOWER"];
+const PICKUP_BUBBLE_COLORS = {
+  FIREARM: 0xffd166,
+  RIFLE: 0x8ec9ff,
+  MISSILE: 0xff7b54,
+  DRONE: 0x91ffba,
+  HELICOPTER: 0xe8a6ff,
+  JET: 0x7df3ff,
+  TRUCK: 0xffb58f,
+  TOWER: 0xb7ff7f
+};
 
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
 const lerp = (a, b, t) => a + (b - a) * t;
@@ -163,7 +173,7 @@ function loadGltf(dracoDecoderPath, url) {
     const timeout = window.setTimeout(() => reject(new Error(`Timeout loading ${url}`)), 18000);
     loader.load(url, (gltf) => {
       window.clearTimeout(timeout);
-      resolve({ scene: normalizeLoadedModel(gltf.scene), animations: gltf.animations || [] });
+      resolve({ scene: applyOriginalTextureQuality(normalizeLoadedModel(gltf.scene)), animations: gltf.animations || [] });
     }, undefined, (err) => {
       window.clearTimeout(timeout);
       draco.dispose();
@@ -416,6 +426,31 @@ function createTruckVariant(color, name, variant, track, ai = false, angle = Mat
   };
 }
 
+
+function disposeObject3D(root) {
+  if (!root) return;
+  root.traverse?.((obj) => {
+    if (!obj.isMesh) return;
+    obj.geometry?.dispose?.();
+    const mat = obj.material;
+    if (Array.isArray(mat)) mat.forEach((m) => m?.dispose?.());
+    else mat?.dispose?.();
+  });
+}
+
+function addPrecisionHelpers(node, { color = 0xff44ff, size = 0.7 } = {}) {
+  if (!node) return;
+  const box = new THREE.Box3().setFromObject(node);
+  if (!Number.isFinite(box.min.x)) return;
+  const center = box.getCenter(new THREE.Vector3());
+  const helperAnchor = new THREE.Group();
+  helperAnchor.position.copy(center);
+  helperAnchor.add(new THREE.AxesHelper(size));
+  const wire = new THREE.Box3Helper(box, color);
+  node.parent?.add(wire);
+  node.parent?.add(helperAnchor);
+}
+
 function createOriginalKart(assets, name, ai, angle, lane, index, variant, track) {
   if (!assets.trucks.length) throw new Error("Original truck asset not loaded.");
   const group = new THREE.Group();
@@ -575,6 +610,601 @@ function resolveVehicleCrashes(karts) {
   return strongest;
 }
 
+
+
+const GO_CRAZY_PARKED_CONFIG = Object.freeze({
+  HELICOPTER: { targetLength: 5.8, lift: 0.35, laneOffset: 10.4, bank: 0.05, spin: 0.3, hoverAmp: 0.09, hoverSpeed: 2.2, pulse: 0.9, bubbleColor: 0x9ef4ff },
+  JET: { targetLength: 6.2, lift: 0.28, laneOffset: -10.6, bank: 0.08, spin: 0.12, hoverAmp: 0.03, hoverSpeed: 1.6, pulse: 0.8, bubbleColor: 0xc0d4ff },
+  TRUCK: { targetLength: 5.9, lift: 0.24, laneOffset: 10.8, bank: 0.03, spin: 0.08, hoverAmp: 0.02, hoverSpeed: 1.2, pulse: 0.5, bubbleColor: 0xffc297 },
+  DRONE: { targetLength: 4.2, lift: 0.42, laneOffset: -10.9, bank: 0.06, spin: 0.65, hoverAmp: 0.12, hoverSpeed: 2.8, pulse: 1.15, bubbleColor: 0x94ffd8 },
+  TOWER: { targetLength: 5.4, lift: 0.21, laneOffset: 11.1, bank: 0.02, spin: 0.04, hoverAmp: 0.01, hoverSpeed: 0.9, pulse: 0.45, bubbleColor: 0xc5ff9e },
+  MISSILE: { targetLength: 5.5, lift: 0.3, laneOffset: -10.2, bank: 0.03, spin: 0.15, hoverAmp: 0.05, hoverSpeed: 1.9, pulse: 0.85, bubbleColor: 0xffa786 }
+});
+
+const GO_CRAZY_PICKUP_CONFIG = Object.freeze({
+  FIREARM: { targetLength: 1.35, lift: 0.08, yaw: 0, baseY: 1.03, bubbleScale: 1.02, bob: 0.09, glow: 0.2, lane: 0.8 },
+  RIFLE: { targetLength: 1.55, lift: 0.08, yaw: Math.PI * 0.5, baseY: 1.08, bubbleScale: 1.08, bob: 0.1, glow: 0.23, lane: -0.82 },
+  MISSILE: { targetLength: 1.72, lift: 0.1, yaw: 0, baseY: 1.12, bubbleScale: 1.11, bob: 0.12, glow: 0.26, lane: 0.9 },
+  DRONE: { targetLength: 1.48, lift: 0.09, yaw: 0, baseY: 1.16, bubbleScale: 1.16, bob: 0.13, glow: 0.24, lane: -0.94 },
+  HELICOPTER: { targetLength: 1.62, lift: 0.1, yaw: 0, baseY: 1.2, bubbleScale: 1.18, bob: 0.14, glow: 0.24, lane: 0.95 },
+  JET: { targetLength: 1.66, lift: 0.1, yaw: 0, baseY: 1.24, bubbleScale: 1.2, bob: 0.15, glow: 0.26, lane: -0.98 },
+  TRUCK: { targetLength: 1.8, lift: 0.09, yaw: 0, baseY: 1.1, bubbleScale: 1.12, bob: 0.1, glow: 0.21, lane: 0.86 },
+  TOWER: { targetLength: 1.95, lift: 0.1, yaw: 0, baseY: 1.1, bubbleScale: 1.09, bob: 0.09, glow: 0.19, lane: -0.86 }
+});
+
+const GO_CRAZY_LAYOUT_TUNING = Object.freeze([
+  { id: 'slot_001', angleMul: 1/240, lane: -0.68, lift: 0.03, scale: 0.82, tint: 0x33748e },
+  { id: 'slot_002', angleMul: 2/240, lane: 0.76, lift: 0.04, scale: 0.89, tint: 0x33a4c7 },
+  { id: 'slot_003', angleMul: 3/240, lane: -0.84, lift: 0.05, scale: 0.96, tint: 0x33d500 },
+  { id: 'slot_004', angleMul: 4/240, lane: 0.92, lift: 0.06, scale: 1.03, tint: 0x340539 },
+  { id: 'slot_005', angleMul: 5/240, lane: -0.60, lift: 0.07, scale: 1.10, tint: 0x343572 },
+  { id: 'slot_006', angleMul: 6/240, lane: 0.68, lift: 0.08, scale: 0.75, tint: 0x3465ab },
+  { id: 'slot_007', angleMul: 7/240, lane: -0.76, lift: 0.02, scale: 0.82, tint: 0x3495e4 },
+  { id: 'slot_008', angleMul: 8/240, lane: 0.84, lift: 0.03, scale: 0.89, tint: 0x34c61d },
+  { id: 'slot_009', angleMul: 9/240, lane: -0.92, lift: 0.04, scale: 0.96, tint: 0x34f656 },
+  { id: 'slot_010', angleMul: 10/240, lane: 0.60, lift: 0.05, scale: 1.03, tint: 0x35268f },
+  { id: 'slot_011', angleMul: 11/240, lane: -0.68, lift: 0.06, scale: 1.10, tint: 0x3556c8 },
+  { id: 'slot_012', angleMul: 12/240, lane: 0.76, lift: 0.07, scale: 0.75, tint: 0x358701 },
+  { id: 'slot_013', angleMul: 13/240, lane: -0.84, lift: 0.08, scale: 0.82, tint: 0x35b73a },
+  { id: 'slot_014', angleMul: 14/240, lane: 0.92, lift: 0.02, scale: 0.89, tint: 0x35e773 },
+  { id: 'slot_015', angleMul: 15/240, lane: -0.60, lift: 0.03, scale: 0.96, tint: 0x3617ac },
+  { id: 'slot_016', angleMul: 16/240, lane: 0.68, lift: 0.04, scale: 1.03, tint: 0x3647e5 },
+  { id: 'slot_017', angleMul: 17/240, lane: -0.76, lift: 0.05, scale: 1.10, tint: 0x36781e },
+  { id: 'slot_018', angleMul: 18/240, lane: 0.84, lift: 0.06, scale: 0.75, tint: 0x36a857 },
+  { id: 'slot_019', angleMul: 19/240, lane: -0.92, lift: 0.07, scale: 0.82, tint: 0x36d890 },
+  { id: 'slot_020', angleMul: 20/240, lane: 0.60, lift: 0.08, scale: 0.89, tint: 0x3708c9 },
+  { id: 'slot_021', angleMul: 21/240, lane: -0.68, lift: 0.02, scale: 0.96, tint: 0x373902 },
+  { id: 'slot_022', angleMul: 22/240, lane: 0.76, lift: 0.03, scale: 1.03, tint: 0x37693b },
+  { id: 'slot_023', angleMul: 23/240, lane: -0.84, lift: 0.04, scale: 1.10, tint: 0x379974 },
+  { id: 'slot_024', angleMul: 24/240, lane: 0.92, lift: 0.05, scale: 0.75, tint: 0x37c9ad },
+  { id: 'slot_025', angleMul: 25/240, lane: -0.60, lift: 0.06, scale: 0.82, tint: 0x37f9e6 },
+  { id: 'slot_026', angleMul: 26/240, lane: 0.68, lift: 0.07, scale: 0.89, tint: 0x382a1f },
+  { id: 'slot_027', angleMul: 27/240, lane: -0.76, lift: 0.08, scale: 0.96, tint: 0x385a58 },
+  { id: 'slot_028', angleMul: 28/240, lane: 0.84, lift: 0.02, scale: 1.03, tint: 0x388a91 },
+  { id: 'slot_029', angleMul: 29/240, lane: -0.92, lift: 0.03, scale: 1.10, tint: 0x38baca },
+  { id: 'slot_030', angleMul: 30/240, lane: 0.60, lift: 0.04, scale: 0.75, tint: 0x38eb03 },
+  { id: 'slot_031', angleMul: 31/240, lane: -0.68, lift: 0.05, scale: 0.82, tint: 0x391b3c },
+  { id: 'slot_032', angleMul: 32/240, lane: 0.76, lift: 0.06, scale: 0.89, tint: 0x394b75 },
+  { id: 'slot_033', angleMul: 33/240, lane: -0.84, lift: 0.07, scale: 0.96, tint: 0x397bae },
+  { id: 'slot_034', angleMul: 34/240, lane: 0.92, lift: 0.08, scale: 1.03, tint: 0x39abe7 },
+  { id: 'slot_035', angleMul: 35/240, lane: -0.60, lift: 0.02, scale: 1.10, tint: 0x39dc20 },
+  { id: 'slot_036', angleMul: 36/240, lane: 0.68, lift: 0.03, scale: 0.75, tint: 0x3a0c59 },
+  { id: 'slot_037', angleMul: 37/240, lane: -0.76, lift: 0.04, scale: 0.82, tint: 0x3a3c92 },
+  { id: 'slot_038', angleMul: 38/240, lane: 0.84, lift: 0.05, scale: 0.89, tint: 0x3a6ccb },
+  { id: 'slot_039', angleMul: 39/240, lane: -0.92, lift: 0.06, scale: 0.96, tint: 0x3a9d04 },
+  { id: 'slot_040', angleMul: 40/240, lane: 0.60, lift: 0.07, scale: 1.03, tint: 0x3acd3d },
+  { id: 'slot_041', angleMul: 41/240, lane: -0.68, lift: 0.08, scale: 1.10, tint: 0x3afd76 },
+  { id: 'slot_042', angleMul: 42/240, lane: 0.76, lift: 0.02, scale: 0.75, tint: 0x3b2daf },
+  { id: 'slot_043', angleMul: 43/240, lane: -0.84, lift: 0.03, scale: 0.82, tint: 0x3b5de8 },
+  { id: 'slot_044', angleMul: 44/240, lane: 0.92, lift: 0.04, scale: 0.89, tint: 0x3b8e21 },
+  { id: 'slot_045', angleMul: 45/240, lane: -0.60, lift: 0.05, scale: 0.96, tint: 0x3bbe5a },
+  { id: 'slot_046', angleMul: 46/240, lane: 0.68, lift: 0.06, scale: 1.03, tint: 0x3bee93 },
+  { id: 'slot_047', angleMul: 47/240, lane: -0.76, lift: 0.07, scale: 1.10, tint: 0x3c1ecc },
+  { id: 'slot_048', angleMul: 48/240, lane: 0.84, lift: 0.08, scale: 0.75, tint: 0x3c4f05 },
+  { id: 'slot_049', angleMul: 49/240, lane: -0.92, lift: 0.02, scale: 0.82, tint: 0x3c7f3e },
+  { id: 'slot_050', angleMul: 50/240, lane: 0.60, lift: 0.03, scale: 0.89, tint: 0x3caf77 },
+  { id: 'slot_051', angleMul: 51/240, lane: -0.68, lift: 0.04, scale: 0.96, tint: 0x3cdfb0 },
+  { id: 'slot_052', angleMul: 52/240, lane: 0.76, lift: 0.05, scale: 1.03, tint: 0x3d0fe9 },
+  { id: 'slot_053', angleMul: 53/240, lane: -0.84, lift: 0.06, scale: 1.10, tint: 0x3d4022 },
+  { id: 'slot_054', angleMul: 54/240, lane: 0.92, lift: 0.07, scale: 0.75, tint: 0x3d705b },
+  { id: 'slot_055', angleMul: 55/240, lane: -0.60, lift: 0.08, scale: 0.82, tint: 0x3da094 },
+  { id: 'slot_056', angleMul: 56/240, lane: 0.68, lift: 0.02, scale: 0.89, tint: 0x3dd0cd },
+  { id: 'slot_057', angleMul: 57/240, lane: -0.76, lift: 0.03, scale: 0.96, tint: 0x3e0106 },
+  { id: 'slot_058', angleMul: 58/240, lane: 0.84, lift: 0.04, scale: 1.03, tint: 0x3e313f },
+  { id: 'slot_059', angleMul: 59/240, lane: -0.92, lift: 0.05, scale: 1.10, tint: 0x3e6178 },
+  { id: 'slot_060', angleMul: 60/240, lane: 0.60, lift: 0.06, scale: 0.75, tint: 0x3e91b1 },
+  { id: 'slot_061', angleMul: 61/240, lane: -0.68, lift: 0.07, scale: 0.82, tint: 0x3ec1ea },
+  { id: 'slot_062', angleMul: 62/240, lane: 0.76, lift: 0.08, scale: 0.89, tint: 0x3ef223 },
+  { id: 'slot_063', angleMul: 63/240, lane: -0.84, lift: 0.02, scale: 0.96, tint: 0x3f225c },
+  { id: 'slot_064', angleMul: 64/240, lane: 0.92, lift: 0.03, scale: 1.03, tint: 0x3f5295 },
+  { id: 'slot_065', angleMul: 65/240, lane: -0.60, lift: 0.04, scale: 1.10, tint: 0x3f82ce },
+  { id: 'slot_066', angleMul: 66/240, lane: 0.68, lift: 0.05, scale: 0.75, tint: 0x3fb307 },
+  { id: 'slot_067', angleMul: 67/240, lane: -0.76, lift: 0.06, scale: 0.82, tint: 0x3fe340 },
+  { id: 'slot_068', angleMul: 68/240, lane: 0.84, lift: 0.07, scale: 0.89, tint: 0x401379 },
+  { id: 'slot_069', angleMul: 69/240, lane: -0.92, lift: 0.08, scale: 0.96, tint: 0x4043b2 },
+  { id: 'slot_070', angleMul: 70/240, lane: 0.60, lift: 0.02, scale: 1.03, tint: 0x4073eb },
+  { id: 'slot_071', angleMul: 71/240, lane: -0.68, lift: 0.03, scale: 1.10, tint: 0x40a424 },
+  { id: 'slot_072', angleMul: 72/240, lane: 0.76, lift: 0.04, scale: 0.75, tint: 0x40d45d },
+  { id: 'slot_073', angleMul: 73/240, lane: -0.84, lift: 0.05, scale: 0.82, tint: 0x410496 },
+  { id: 'slot_074', angleMul: 74/240, lane: 0.92, lift: 0.06, scale: 0.89, tint: 0x4134cf },
+  { id: 'slot_075', angleMul: 75/240, lane: -0.60, lift: 0.07, scale: 0.96, tint: 0x416508 },
+  { id: 'slot_076', angleMul: 76/240, lane: 0.68, lift: 0.08, scale: 1.03, tint: 0x419541 },
+  { id: 'slot_077', angleMul: 77/240, lane: -0.76, lift: 0.02, scale: 1.10, tint: 0x41c57a },
+  { id: 'slot_078', angleMul: 78/240, lane: 0.84, lift: 0.03, scale: 0.75, tint: 0x41f5b3 },
+  { id: 'slot_079', angleMul: 79/240, lane: -0.92, lift: 0.04, scale: 0.82, tint: 0x4225ec },
+  { id: 'slot_080', angleMul: 80/240, lane: 0.60, lift: 0.05, scale: 0.89, tint: 0x425625 },
+  { id: 'slot_081', angleMul: 81/240, lane: -0.68, lift: 0.06, scale: 0.96, tint: 0x42865e },
+  { id: 'slot_082', angleMul: 82/240, lane: 0.76, lift: 0.07, scale: 1.03, tint: 0x42b697 },
+  { id: 'slot_083', angleMul: 83/240, lane: -0.84, lift: 0.08, scale: 1.10, tint: 0x42e6d0 },
+  { id: 'slot_084', angleMul: 84/240, lane: 0.92, lift: 0.02, scale: 0.75, tint: 0x431709 },
+  { id: 'slot_085', angleMul: 85/240, lane: -0.60, lift: 0.03, scale: 0.82, tint: 0x434742 },
+  { id: 'slot_086', angleMul: 86/240, lane: 0.68, lift: 0.04, scale: 0.89, tint: 0x43777b },
+  { id: 'slot_087', angleMul: 87/240, lane: -0.76, lift: 0.05, scale: 0.96, tint: 0x43a7b4 },
+  { id: 'slot_088', angleMul: 88/240, lane: 0.84, lift: 0.06, scale: 1.03, tint: 0x43d7ed },
+  { id: 'slot_089', angleMul: 89/240, lane: -0.92, lift: 0.07, scale: 1.10, tint: 0x440826 },
+  { id: 'slot_090', angleMul: 90/240, lane: 0.60, lift: 0.08, scale: 0.75, tint: 0x44385f },
+  { id: 'slot_091', angleMul: 91/240, lane: -0.68, lift: 0.02, scale: 0.82, tint: 0x446898 },
+  { id: 'slot_092', angleMul: 92/240, lane: 0.76, lift: 0.03, scale: 0.89, tint: 0x4498d1 },
+  { id: 'slot_093', angleMul: 93/240, lane: -0.84, lift: 0.04, scale: 0.96, tint: 0x44c90a },
+  { id: 'slot_094', angleMul: 94/240, lane: 0.92, lift: 0.05, scale: 1.03, tint: 0x44f943 },
+  { id: 'slot_095', angleMul: 95/240, lane: -0.60, lift: 0.06, scale: 1.10, tint: 0x45297c },
+  { id: 'slot_096', angleMul: 96/240, lane: 0.68, lift: 0.07, scale: 0.75, tint: 0x4559b5 },
+  { id: 'slot_097', angleMul: 97/240, lane: -0.76, lift: 0.08, scale: 0.82, tint: 0x4589ee },
+  { id: 'slot_098', angleMul: 98/240, lane: 0.84, lift: 0.02, scale: 0.89, tint: 0x45ba27 },
+  { id: 'slot_099', angleMul: 99/240, lane: -0.92, lift: 0.03, scale: 0.96, tint: 0x45ea60 },
+  { id: 'slot_100', angleMul: 100/240, lane: 0.60, lift: 0.04, scale: 1.03, tint: 0x461a99 },
+  { id: 'slot_101', angleMul: 101/240, lane: -0.68, lift: 0.05, scale: 1.10, tint: 0x464ad2 },
+  { id: 'slot_102', angleMul: 102/240, lane: 0.76, lift: 0.06, scale: 0.75, tint: 0x467b0b },
+  { id: 'slot_103', angleMul: 103/240, lane: -0.84, lift: 0.07, scale: 0.82, tint: 0x46ab44 },
+  { id: 'slot_104', angleMul: 104/240, lane: 0.92, lift: 0.08, scale: 0.89, tint: 0x46db7d },
+  { id: 'slot_105', angleMul: 105/240, lane: -0.60, lift: 0.02, scale: 0.96, tint: 0x470bb6 },
+  { id: 'slot_106', angleMul: 106/240, lane: 0.68, lift: 0.03, scale: 1.03, tint: 0x473bef },
+  { id: 'slot_107', angleMul: 107/240, lane: -0.76, lift: 0.04, scale: 1.10, tint: 0x476c28 },
+  { id: 'slot_108', angleMul: 108/240, lane: 0.84, lift: 0.05, scale: 0.75, tint: 0x479c61 },
+  { id: 'slot_109', angleMul: 109/240, lane: -0.92, lift: 0.06, scale: 0.82, tint: 0x47cc9a },
+  { id: 'slot_110', angleMul: 110/240, lane: 0.60, lift: 0.07, scale: 0.89, tint: 0x47fcd3 },
+  { id: 'slot_111', angleMul: 111/240, lane: -0.68, lift: 0.08, scale: 0.96, tint: 0x482d0c },
+  { id: 'slot_112', angleMul: 112/240, lane: 0.76, lift: 0.02, scale: 1.03, tint: 0x485d45 },
+  { id: 'slot_113', angleMul: 113/240, lane: -0.84, lift: 0.03, scale: 1.10, tint: 0x488d7e },
+  { id: 'slot_114', angleMul: 114/240, lane: 0.92, lift: 0.04, scale: 0.75, tint: 0x48bdb7 },
+  { id: 'slot_115', angleMul: 115/240, lane: -0.60, lift: 0.05, scale: 0.82, tint: 0x48edf0 },
+  { id: 'slot_116', angleMul: 116/240, lane: 0.68, lift: 0.06, scale: 0.89, tint: 0x491e29 },
+  { id: 'slot_117', angleMul: 117/240, lane: -0.76, lift: 0.07, scale: 0.96, tint: 0x494e62 },
+  { id: 'slot_118', angleMul: 118/240, lane: 0.84, lift: 0.08, scale: 1.03, tint: 0x497e9b },
+  { id: 'slot_119', angleMul: 119/240, lane: -0.92, lift: 0.02, scale: 1.10, tint: 0x49aed4 },
+  { id: 'slot_120', angleMul: 120/240, lane: 0.60, lift: 0.03, scale: 0.75, tint: 0x49df0d },
+  { id: 'slot_121', angleMul: 121/240, lane: -0.68, lift: 0.04, scale: 0.82, tint: 0x4a0f46 },
+  { id: 'slot_122', angleMul: 122/240, lane: 0.76, lift: 0.05, scale: 0.89, tint: 0x4a3f7f },
+  { id: 'slot_123', angleMul: 123/240, lane: -0.84, lift: 0.06, scale: 0.96, tint: 0x4a6fb8 },
+  { id: 'slot_124', angleMul: 124/240, lane: 0.92, lift: 0.07, scale: 1.03, tint: 0x4a9ff1 },
+  { id: 'slot_125', angleMul: 125/240, lane: -0.60, lift: 0.08, scale: 1.10, tint: 0x4ad02a },
+  { id: 'slot_126', angleMul: 126/240, lane: 0.68, lift: 0.02, scale: 0.75, tint: 0x4b0063 },
+  { id: 'slot_127', angleMul: 127/240, lane: -0.76, lift: 0.03, scale: 0.82, tint: 0x4b309c },
+  { id: 'slot_128', angleMul: 128/240, lane: 0.84, lift: 0.04, scale: 0.89, tint: 0x4b60d5 },
+  { id: 'slot_129', angleMul: 129/240, lane: -0.92, lift: 0.05, scale: 0.96, tint: 0x4b910e },
+  { id: 'slot_130', angleMul: 130/240, lane: 0.60, lift: 0.06, scale: 1.03, tint: 0x4bc147 },
+  { id: 'slot_131', angleMul: 131/240, lane: -0.68, lift: 0.07, scale: 1.10, tint: 0x4bf180 },
+  { id: 'slot_132', angleMul: 132/240, lane: 0.76, lift: 0.08, scale: 0.75, tint: 0x4c21b9 },
+  { id: 'slot_133', angleMul: 133/240, lane: -0.84, lift: 0.02, scale: 0.82, tint: 0x4c51f2 },
+  { id: 'slot_134', angleMul: 134/240, lane: 0.92, lift: 0.03, scale: 0.89, tint: 0x4c822b },
+  { id: 'slot_135', angleMul: 135/240, lane: -0.60, lift: 0.04, scale: 0.96, tint: 0x4cb264 },
+  { id: 'slot_136', angleMul: 136/240, lane: 0.68, lift: 0.05, scale: 1.03, tint: 0x4ce29d },
+  { id: 'slot_137', angleMul: 137/240, lane: -0.76, lift: 0.06, scale: 1.10, tint: 0x4d12d6 },
+  { id: 'slot_138', angleMul: 138/240, lane: 0.84, lift: 0.07, scale: 0.75, tint: 0x4d430f },
+  { id: 'slot_139', angleMul: 139/240, lane: -0.92, lift: 0.08, scale: 0.82, tint: 0x4d7348 },
+  { id: 'slot_140', angleMul: 140/240, lane: 0.60, lift: 0.02, scale: 0.89, tint: 0x4da381 },
+  { id: 'slot_141', angleMul: 141/240, lane: -0.68, lift: 0.03, scale: 0.96, tint: 0x4dd3ba },
+  { id: 'slot_142', angleMul: 142/240, lane: 0.76, lift: 0.04, scale: 1.03, tint: 0x4e03f3 },
+  { id: 'slot_143', angleMul: 143/240, lane: -0.84, lift: 0.05, scale: 1.10, tint: 0x4e342c },
+  { id: 'slot_144', angleMul: 144/240, lane: 0.92, lift: 0.06, scale: 0.75, tint: 0x4e6465 },
+  { id: 'slot_145', angleMul: 145/240, lane: -0.60, lift: 0.07, scale: 0.82, tint: 0x4e949e },
+  { id: 'slot_146', angleMul: 146/240, lane: 0.68, lift: 0.08, scale: 0.89, tint: 0x4ec4d7 },
+  { id: 'slot_147', angleMul: 147/240, lane: -0.76, lift: 0.02, scale: 0.96, tint: 0x4ef510 },
+  { id: 'slot_148', angleMul: 148/240, lane: 0.84, lift: 0.03, scale: 1.03, tint: 0x4f2549 },
+  { id: 'slot_149', angleMul: 149/240, lane: -0.92, lift: 0.04, scale: 1.10, tint: 0x4f5582 },
+  { id: 'slot_150', angleMul: 150/240, lane: 0.60, lift: 0.05, scale: 0.75, tint: 0x4f85bb },
+  { id: 'slot_151', angleMul: 151/240, lane: -0.68, lift: 0.06, scale: 0.82, tint: 0x4fb5f4 },
+  { id: 'slot_152', angleMul: 152/240, lane: 0.76, lift: 0.07, scale: 0.89, tint: 0x4fe62d },
+  { id: 'slot_153', angleMul: 153/240, lane: -0.84, lift: 0.08, scale: 0.96, tint: 0x501666 },
+  { id: 'slot_154', angleMul: 154/240, lane: 0.92, lift: 0.02, scale: 1.03, tint: 0x50469f },
+  { id: 'slot_155', angleMul: 155/240, lane: -0.60, lift: 0.03, scale: 1.10, tint: 0x5076d8 },
+  { id: 'slot_156', angleMul: 156/240, lane: 0.68, lift: 0.04, scale: 0.75, tint: 0x50a711 },
+  { id: 'slot_157', angleMul: 157/240, lane: -0.76, lift: 0.05, scale: 0.82, tint: 0x50d74a },
+  { id: 'slot_158', angleMul: 158/240, lane: 0.84, lift: 0.06, scale: 0.89, tint: 0x510783 },
+  { id: 'slot_159', angleMul: 159/240, lane: -0.92, lift: 0.07, scale: 0.96, tint: 0x5137bc },
+  { id: 'slot_160', angleMul: 160/240, lane: 0.60, lift: 0.08, scale: 1.03, tint: 0x5167f5 },
+  { id: 'slot_161', angleMul: 161/240, lane: -0.68, lift: 0.02, scale: 1.10, tint: 0x51982e },
+  { id: 'slot_162', angleMul: 162/240, lane: 0.76, lift: 0.03, scale: 0.75, tint: 0x51c867 },
+  { id: 'slot_163', angleMul: 163/240, lane: -0.84, lift: 0.04, scale: 0.82, tint: 0x51f8a0 },
+  { id: 'slot_164', angleMul: 164/240, lane: 0.92, lift: 0.05, scale: 0.89, tint: 0x5228d9 },
+  { id: 'slot_165', angleMul: 165/240, lane: -0.60, lift: 0.06, scale: 0.96, tint: 0x525912 },
+  { id: 'slot_166', angleMul: 166/240, lane: 0.68, lift: 0.07, scale: 1.03, tint: 0x52894b },
+  { id: 'slot_167', angleMul: 167/240, lane: -0.76, lift: 0.08, scale: 1.10, tint: 0x52b984 },
+  { id: 'slot_168', angleMul: 168/240, lane: 0.84, lift: 0.02, scale: 0.75, tint: 0x52e9bd },
+  { id: 'slot_169', angleMul: 169/240, lane: -0.92, lift: 0.03, scale: 0.82, tint: 0x5319f6 },
+  { id: 'slot_170', angleMul: 170/240, lane: 0.60, lift: 0.04, scale: 0.89, tint: 0x534a2f },
+  { id: 'slot_171', angleMul: 171/240, lane: -0.68, lift: 0.05, scale: 0.96, tint: 0x537a68 },
+  { id: 'slot_172', angleMul: 172/240, lane: 0.76, lift: 0.06, scale: 1.03, tint: 0x53aaa1 },
+  { id: 'slot_173', angleMul: 173/240, lane: -0.84, lift: 0.07, scale: 1.10, tint: 0x53dada },
+  { id: 'slot_174', angleMul: 174/240, lane: 0.92, lift: 0.08, scale: 0.75, tint: 0x540b13 },
+  { id: 'slot_175', angleMul: 175/240, lane: -0.60, lift: 0.02, scale: 0.82, tint: 0x543b4c },
+  { id: 'slot_176', angleMul: 176/240, lane: 0.68, lift: 0.03, scale: 0.89, tint: 0x546b85 },
+  { id: 'slot_177', angleMul: 177/240, lane: -0.76, lift: 0.04, scale: 0.96, tint: 0x549bbe },
+  { id: 'slot_178', angleMul: 178/240, lane: 0.84, lift: 0.05, scale: 1.03, tint: 0x54cbf7 },
+  { id: 'slot_179', angleMul: 179/240, lane: -0.92, lift: 0.06, scale: 1.10, tint: 0x54fc30 },
+  { id: 'slot_180', angleMul: 180/240, lane: 0.60, lift: 0.07, scale: 0.75, tint: 0x552c69 },
+  { id: 'slot_181', angleMul: 181/240, lane: -0.68, lift: 0.08, scale: 0.82, tint: 0x555ca2 },
+  { id: 'slot_182', angleMul: 182/240, lane: 0.76, lift: 0.02, scale: 0.89, tint: 0x558cdb },
+  { id: 'slot_183', angleMul: 183/240, lane: -0.84, lift: 0.03, scale: 0.96, tint: 0x55bd14 },
+  { id: 'slot_184', angleMul: 184/240, lane: 0.92, lift: 0.04, scale: 1.03, tint: 0x55ed4d },
+  { id: 'slot_185', angleMul: 185/240, lane: -0.60, lift: 0.05, scale: 1.10, tint: 0x561d86 },
+  { id: 'slot_186', angleMul: 186/240, lane: 0.68, lift: 0.06, scale: 0.75, tint: 0x564dbf },
+  { id: 'slot_187', angleMul: 187/240, lane: -0.76, lift: 0.07, scale: 0.82, tint: 0x567df8 },
+  { id: 'slot_188', angleMul: 188/240, lane: 0.84, lift: 0.08, scale: 0.89, tint: 0x56ae31 },
+  { id: 'slot_189', angleMul: 189/240, lane: -0.92, lift: 0.02, scale: 0.96, tint: 0x56de6a },
+  { id: 'slot_190', angleMul: 190/240, lane: 0.60, lift: 0.03, scale: 1.03, tint: 0x570ea3 },
+  { id: 'slot_191', angleMul: 191/240, lane: -0.68, lift: 0.04, scale: 1.10, tint: 0x573edc },
+  { id: 'slot_192', angleMul: 192/240, lane: 0.76, lift: 0.05, scale: 0.75, tint: 0x576f15 },
+  { id: 'slot_193', angleMul: 193/240, lane: -0.84, lift: 0.06, scale: 0.82, tint: 0x579f4e },
+  { id: 'slot_194', angleMul: 194/240, lane: 0.92, lift: 0.07, scale: 0.89, tint: 0x57cf87 },
+  { id: 'slot_195', angleMul: 195/240, lane: -0.60, lift: 0.08, scale: 0.96, tint: 0x57ffc0 },
+  { id: 'slot_196', angleMul: 196/240, lane: 0.68, lift: 0.02, scale: 1.03, tint: 0x582ff9 },
+  { id: 'slot_197', angleMul: 197/240, lane: -0.76, lift: 0.03, scale: 1.10, tint: 0x586032 },
+  { id: 'slot_198', angleMul: 198/240, lane: 0.84, lift: 0.04, scale: 0.75, tint: 0x58906b },
+  { id: 'slot_199', angleMul: 199/240, lane: -0.92, lift: 0.05, scale: 0.82, tint: 0x58c0a4 },
+  { id: 'slot_200', angleMul: 200/240, lane: 0.60, lift: 0.06, scale: 0.89, tint: 0x58f0dd },
+  { id: 'slot_201', angleMul: 201/240, lane: -0.68, lift: 0.07, scale: 0.96, tint: 0x592116 },
+  { id: 'slot_202', angleMul: 202/240, lane: 0.76, lift: 0.08, scale: 1.03, tint: 0x59514f },
+  { id: 'slot_203', angleMul: 203/240, lane: -0.84, lift: 0.02, scale: 1.10, tint: 0x598188 },
+  { id: 'slot_204', angleMul: 204/240, lane: 0.92, lift: 0.03, scale: 0.75, tint: 0x59b1c1 },
+  { id: 'slot_205', angleMul: 205/240, lane: -0.60, lift: 0.04, scale: 0.82, tint: 0x59e1fa },
+  { id: 'slot_206', angleMul: 206/240, lane: 0.68, lift: 0.05, scale: 0.89, tint: 0x5a1233 },
+  { id: 'slot_207', angleMul: 207/240, lane: -0.76, lift: 0.06, scale: 0.96, tint: 0x5a426c },
+  { id: 'slot_208', angleMul: 208/240, lane: 0.84, lift: 0.07, scale: 1.03, tint: 0x5a72a5 },
+  { id: 'slot_209', angleMul: 209/240, lane: -0.92, lift: 0.08, scale: 1.10, tint: 0x5aa2de },
+  { id: 'slot_210', angleMul: 210/240, lane: 0.60, lift: 0.02, scale: 0.75, tint: 0x5ad317 },
+  { id: 'slot_211', angleMul: 211/240, lane: -0.68, lift: 0.03, scale: 0.82, tint: 0x5b0350 },
+  { id: 'slot_212', angleMul: 212/240, lane: 0.76, lift: 0.04, scale: 0.89, tint: 0x5b3389 },
+  { id: 'slot_213', angleMul: 213/240, lane: -0.84, lift: 0.05, scale: 0.96, tint: 0x5b63c2 },
+  { id: 'slot_214', angleMul: 214/240, lane: 0.92, lift: 0.06, scale: 1.03, tint: 0x5b93fb },
+  { id: 'slot_215', angleMul: 215/240, lane: -0.60, lift: 0.07, scale: 1.10, tint: 0x5bc434 },
+  { id: 'slot_216', angleMul: 216/240, lane: 0.68, lift: 0.08, scale: 0.75, tint: 0x5bf46d },
+  { id: 'slot_217', angleMul: 217/240, lane: -0.76, lift: 0.02, scale: 0.82, tint: 0x5c24a6 },
+  { id: 'slot_218', angleMul: 218/240, lane: 0.84, lift: 0.03, scale: 0.89, tint: 0x5c54df },
+  { id: 'slot_219', angleMul: 219/240, lane: -0.92, lift: 0.04, scale: 0.96, tint: 0x5c8518 },
+  { id: 'slot_220', angleMul: 220/240, lane: 0.60, lift: 0.05, scale: 1.03, tint: 0x5cb551 },
+  { id: 'slot_221', angleMul: 221/240, lane: -0.68, lift: 0.06, scale: 1.10, tint: 0x5ce58a },
+  { id: 'slot_222', angleMul: 222/240, lane: 0.76, lift: 0.07, scale: 0.75, tint: 0x5d15c3 },
+  { id: 'slot_223', angleMul: 223/240, lane: -0.84, lift: 0.08, scale: 0.82, tint: 0x5d45fc },
+  { id: 'slot_224', angleMul: 224/240, lane: 0.92, lift: 0.02, scale: 0.89, tint: 0x5d7635 },
+  { id: 'slot_225', angleMul: 225/240, lane: -0.60, lift: 0.03, scale: 0.96, tint: 0x5da66e },
+  { id: 'slot_226', angleMul: 226/240, lane: 0.68, lift: 0.04, scale: 1.03, tint: 0x5dd6a7 },
+  { id: 'slot_227', angleMul: 227/240, lane: -0.76, lift: 0.05, scale: 1.10, tint: 0x5e06e0 },
+  { id: 'slot_228', angleMul: 228/240, lane: 0.84, lift: 0.06, scale: 0.75, tint: 0x5e3719 },
+  { id: 'slot_229', angleMul: 229/240, lane: -0.92, lift: 0.07, scale: 0.82, tint: 0x5e6752 },
+  { id: 'slot_230', angleMul: 230/240, lane: 0.60, lift: 0.08, scale: 0.89, tint: 0x5e978b },
+  { id: 'slot_231', angleMul: 231/240, lane: -0.68, lift: 0.02, scale: 0.96, tint: 0x5ec7c4 },
+  { id: 'slot_232', angleMul: 232/240, lane: 0.76, lift: 0.03, scale: 1.03, tint: 0x5ef7fd },
+  { id: 'slot_233', angleMul: 233/240, lane: -0.84, lift: 0.04, scale: 1.10, tint: 0x5f2836 },
+  { id: 'slot_234', angleMul: 234/240, lane: 0.92, lift: 0.05, scale: 0.75, tint: 0x5f586f },
+  { id: 'slot_235', angleMul: 235/240, lane: -0.60, lift: 0.06, scale: 0.82, tint: 0x5f88a8 },
+  { id: 'slot_236', angleMul: 236/240, lane: 0.68, lift: 0.07, scale: 0.89, tint: 0x5fb8e1 },
+  { id: 'slot_237', angleMul: 237/240, lane: -0.76, lift: 0.08, scale: 0.96, tint: 0x5fe91a },
+  { id: 'slot_238', angleMul: 238/240, lane: 0.84, lift: 0.02, scale: 1.03, tint: 0x601953 },
+  { id: 'slot_239', angleMul: 239/240, lane: -0.92, lift: 0.03, scale: 1.10, tint: 0x60498c },
+  { id: 'slot_240', angleMul: 240/240, lane: 0.60, lift: 0.04, scale: 0.75, tint: 0x6079c5 },
+]);
+
+function spawnLayoutHelpers(scene, track) {
+  const group = new THREE.Group();
+  group.name = "goCrazyLayoutHelpers";
+  GO_CRAZY_LAYOUT_TUNING.forEach((entry, idx) => {
+    const a = entry.angleMul * TAU;
+    const p = pointOnTrack(a, track, entry.lane);
+    const marker = new THREE.Mesh(
+      new THREE.BoxGeometry(0.15 * entry.scale, 0.08 * entry.scale, 0.9 * entry.scale),
+      new THREE.MeshStandardMaterial({ color: entry.tint, transparent: true, opacity: 0.45, roughness: 0.6, metalness: 0.05 })
+    );
+    marker.position.copy(p).add(new THREE.Vector3(0, entry.lift + 0.04, 0));
+    marker.rotation.y = tangentYaw(a, track);
+    marker.userData.phase = idx * 0.17;
+    marker.userData.baseY = marker.position.y;
+    const axis = new THREE.AxesHelper(0.22 * entry.scale);
+    axis.position.copy(marker.position).add(new THREE.Vector3(0, 0.08, 0));
+    group.add(marker, axis);
+  });
+  scene.add(group);
+  return group;
+}
+
+function animateLayoutHelpers(group, now) {
+  if (!group) return;
+  group.children.forEach((child) => {
+    if (!child.isMesh) return;
+    const phase = child.userData.phase || 0;
+    child.position.y = (child.userData.baseY || child.position.y) + Math.sin(now * 0.002 + phase) * 0.015;
+  });
+}
+
+function applyOriginalTextureQuality(root) {
+  root?.traverse?.((child) => {
+    if (!child?.isMesh) return;
+    const mats = Array.isArray(child.material) ? child.material : [child.material];
+    mats.filter(Boolean).forEach((mat) => {
+      if (mat.map) {
+        mat.map.flipY = false;
+        mat.map.colorSpace = THREE.SRGBColorSpace;
+        mat.map.anisotropy = 8;
+        mat.map.needsUpdate = true;
+      }
+      if (mat.normalMap) mat.normalMap.needsUpdate = true;
+      if (mat.roughnessMap) mat.roughnessMap.needsUpdate = true;
+      if (mat.metalnessMap) mat.metalnessMap.needsUpdate = true;
+      mat.needsUpdate = true;
+    });
+  });
+  return root;
+}
+
+function makeGroundHelperBundle(node, color = 0x66ffee, axisScale = 1.1) {
+  const root = new THREE.Group();
+  const box = new THREE.Box3().setFromObject(node);
+  const center = box.getCenter(new THREE.Vector3());
+  const footY = box.min.y;
+  const axis = new THREE.AxesHelper(axisScale);
+  axis.position.set(center.x, footY, center.z);
+  const ring = new THREE.Mesh(
+    new THREE.TorusGeometry(Math.max(0.45, box.getSize(new THREE.Vector3()).x * 0.2), 0.03, 8, 28),
+    new THREE.MeshBasicMaterial({ color, transparent: true, opacity: 0.92 })
+  );
+  ring.rotation.x = Math.PI * 0.5;
+  ring.position.set(center.x, footY + 0.02, center.z);
+  const marker = new THREE.Mesh(new THREE.CylinderGeometry(0.04, 0.04, 0.5, 8), new THREE.MeshBasicMaterial({ color }));
+  marker.position.set(center.x, footY + 0.25, center.z);
+  root.add(axis, ring, marker, new THREE.Box3Helper(box, color));
+  return root;
+}
+
+function createRoadEdgeDecorations(scene, track) {
+  const group = new THREE.Group();
+  group.name = 'goCrazyRoadDecorations';
+  const tireMat = makeMat(0x141414, 0.82, 0.16);
+  const treadMat = makeMat(0x2f2f33, 0.75, 0.08);
+  for (let i = 0; i < 72; i++) {
+    const a = (i / 72) * TAU;
+    const outer = pointOnTrack(a, track, 12.4);
+    const inner = pointOnTrack(a, track, -12.4);
+    [outer, inner].forEach((pt, idx) => {
+      const tire = new THREE.Mesh(new THREE.TorusGeometry(0.52, 0.14, 12, 18), tireMat);
+      tire.position.copy(pt).add(new THREE.Vector3(0, 0.28, 0));
+      tire.rotation.x = Math.PI * 0.5;
+      tire.rotation.z = (idx ? -1 : 1) * a * 0.66;
+      const tread = new THREE.Mesh(new THREE.CylinderGeometry(0.08, 0.08, 1.55, 12), treadMat);
+      tread.position.copy(pt).add(new THREE.Vector3(0, 0.09, 0));
+      tread.rotation.z = Math.PI * 0.5;
+      tread.rotation.y = tangentYaw(a, track) + (idx ? Math.PI * 0.5 : -Math.PI * 0.5);
+      group.add(tire, tread);
+    });
+  }
+  scene.add(group);
+  return group;
+}
+
+const GO_CRAZY_PULSE_PROFILE = Object.freeze([
+  { t: 0, y: 0.92, alpha: 0.20, scale: 0.85 },
+  { t: 1, y: 0.93, alpha: 0.28, scale: 0.88 },
+  { t: 2, y: 0.94, alpha: 0.36, scale: 0.91 },
+  { t: 3, y: 0.95, alpha: 0.44, scale: 0.94 },
+  { t: 4, y: 0.96, alpha: 0.52, scale: 0.97 },
+  { t: 5, y: 0.97, alpha: 0.60, scale: 1.00 },
+  { t: 6, y: 0.98, alpha: 0.68, scale: 1.03 },
+  { t: 7, y: 0.99, alpha: 0.20, scale: 1.06 },
+  { t: 8, y: 1.00, alpha: 0.28, scale: 1.09 },
+  { t: 9, y: 0.92, alpha: 0.36, scale: 1.12 },
+  { t: 10, y: 0.93, alpha: 0.44, scale: 1.15 },
+  { t: 11, y: 0.94, alpha: 0.52, scale: 0.85 },
+  { t: 12, y: 0.95, alpha: 0.60, scale: 0.88 },
+  { t: 13, y: 0.96, alpha: 0.68, scale: 0.91 },
+  { t: 14, y: 0.97, alpha: 0.20, scale: 0.94 },
+  { t: 15, y: 0.98, alpha: 0.28, scale: 0.97 },
+  { t: 16, y: 0.99, alpha: 0.36, scale: 1.00 },
+  { t: 17, y: 1.00, alpha: 0.44, scale: 1.03 },
+  { t: 18, y: 0.92, alpha: 0.52, scale: 1.06 },
+  { t: 19, y: 0.93, alpha: 0.60, scale: 1.09 },
+  { t: 20, y: 0.94, alpha: 0.68, scale: 1.12 },
+  { t: 21, y: 0.95, alpha: 0.20, scale: 1.15 },
+  { t: 22, y: 0.96, alpha: 0.28, scale: 0.85 },
+  { t: 23, y: 0.97, alpha: 0.36, scale: 0.88 },
+  { t: 24, y: 0.98, alpha: 0.44, scale: 0.91 },
+  { t: 25, y: 0.99, alpha: 0.52, scale: 0.94 },
+  { t: 26, y: 1.00, alpha: 0.60, scale: 0.97 },
+  { t: 27, y: 0.92, alpha: 0.68, scale: 1.00 },
+  { t: 28, y: 0.93, alpha: 0.20, scale: 1.03 },
+  { t: 29, y: 0.94, alpha: 0.28, scale: 1.06 },
+  { t: 30, y: 0.95, alpha: 0.36, scale: 1.09 },
+  { t: 31, y: 0.96, alpha: 0.44, scale: 1.12 },
+  { t: 32, y: 0.97, alpha: 0.52, scale: 1.15 },
+  { t: 33, y: 0.98, alpha: 0.60, scale: 0.85 },
+  { t: 34, y: 0.99, alpha: 0.68, scale: 0.88 },
+  { t: 35, y: 1.00, alpha: 0.20, scale: 0.91 },
+  { t: 36, y: 0.92, alpha: 0.28, scale: 0.94 },
+  { t: 37, y: 0.93, alpha: 0.36, scale: 0.97 },
+  { t: 38, y: 0.94, alpha: 0.44, scale: 1.00 },
+  { t: 39, y: 0.95, alpha: 0.52, scale: 1.03 },
+  { t: 40, y: 0.96, alpha: 0.60, scale: 1.06 },
+  { t: 41, y: 0.97, alpha: 0.68, scale: 1.09 },
+  { t: 42, y: 0.98, alpha: 0.20, scale: 1.12 },
+  { t: 43, y: 0.99, alpha: 0.28, scale: 1.15 },
+  { t: 44, y: 1.00, alpha: 0.36, scale: 0.85 },
+  { t: 45, y: 0.92, alpha: 0.44, scale: 0.88 },
+  { t: 46, y: 0.93, alpha: 0.52, scale: 0.91 },
+  { t: 47, y: 0.94, alpha: 0.60, scale: 0.94 },
+  { t: 48, y: 0.95, alpha: 0.68, scale: 0.97 },
+  { t: 49, y: 0.96, alpha: 0.20, scale: 1.00 },
+  { t: 50, y: 0.97, alpha: 0.28, scale: 1.03 },
+  { t: 51, y: 0.98, alpha: 0.36, scale: 1.06 },
+  { t: 52, y: 0.99, alpha: 0.44, scale: 1.09 },
+  { t: 53, y: 1.00, alpha: 0.52, scale: 1.12 },
+  { t: 54, y: 0.92, alpha: 0.60, scale: 1.15 },
+  { t: 55, y: 0.93, alpha: 0.68, scale: 0.85 },
+  { t: 56, y: 0.94, alpha: 0.20, scale: 0.88 },
+  { t: 57, y: 0.95, alpha: 0.28, scale: 0.91 },
+  { t: 58, y: 0.96, alpha: 0.36, scale: 0.94 },
+  { t: 59, y: 0.97, alpha: 0.44, scale: 0.97 },
+  { t: 60, y: 0.98, alpha: 0.52, scale: 1.00 },
+  { t: 61, y: 0.99, alpha: 0.60, scale: 1.03 },
+  { t: 62, y: 1.00, alpha: 0.68, scale: 1.06 },
+  { t: 63, y: 0.92, alpha: 0.20, scale: 1.09 },
+  { t: 64, y: 0.93, alpha: 0.28, scale: 1.12 },
+  { t: 65, y: 0.94, alpha: 0.36, scale: 1.15 },
+  { t: 66, y: 0.95, alpha: 0.44, scale: 0.85 },
+  { t: 67, y: 0.96, alpha: 0.52, scale: 0.88 },
+  { t: 68, y: 0.97, alpha: 0.60, scale: 0.91 },
+  { t: 69, y: 0.98, alpha: 0.68, scale: 0.94 },
+  { t: 70, y: 0.99, alpha: 0.20, scale: 0.97 },
+  { t: 71, y: 1.00, alpha: 0.28, scale: 1.00 },
+  { t: 72, y: 0.92, alpha: 0.36, scale: 1.03 },
+  { t: 73, y: 0.93, alpha: 0.44, scale: 1.06 },
+  { t: 74, y: 0.94, alpha: 0.52, scale: 1.09 },
+  { t: 75, y: 0.95, alpha: 0.60, scale: 1.12 },
+  { t: 76, y: 0.96, alpha: 0.68, scale: 1.15 },
+  { t: 77, y: 0.97, alpha: 0.20, scale: 0.85 },
+  { t: 78, y: 0.98, alpha: 0.28, scale: 0.88 },
+  { t: 79, y: 0.99, alpha: 0.36, scale: 0.91 },
+  { t: 80, y: 1.00, alpha: 0.44, scale: 0.94 },
+  { t: 81, y: 0.92, alpha: 0.52, scale: 0.97 },
+  { t: 82, y: 0.93, alpha: 0.60, scale: 1.00 },
+  { t: 83, y: 0.94, alpha: 0.68, scale: 1.03 },
+  { t: 84, y: 0.95, alpha: 0.20, scale: 1.06 },
+  { t: 85, y: 0.96, alpha: 0.28, scale: 1.09 },
+  { t: 86, y: 0.97, alpha: 0.36, scale: 1.12 },
+  { t: 87, y: 0.98, alpha: 0.44, scale: 1.15 },
+  { t: 88, y: 0.99, alpha: 0.52, scale: 0.85 },
+  { t: 89, y: 1.00, alpha: 0.60, scale: 0.88 },
+  { t: 90, y: 0.92, alpha: 0.68, scale: 0.91 },
+  { t: 91, y: 0.93, alpha: 0.20, scale: 0.94 },
+  { t: 92, y: 0.94, alpha: 0.28, scale: 0.97 },
+  { t: 93, y: 0.95, alpha: 0.36, scale: 1.00 },
+  { t: 94, y: 0.96, alpha: 0.44, scale: 1.03 },
+  { t: 95, y: 0.97, alpha: 0.52, scale: 1.06 },
+  { t: 96, y: 0.98, alpha: 0.60, scale: 1.09 },
+  { t: 97, y: 0.99, alpha: 0.68, scale: 1.12 },
+  { t: 98, y: 1.00, alpha: 0.20, scale: 1.15 },
+  { t: 99, y: 0.92, alpha: 0.28, scale: 0.85 },
+  { t: 100, y: 0.93, alpha: 0.36, scale: 0.88 },
+  { t: 101, y: 0.94, alpha: 0.44, scale: 0.91 },
+  { t: 102, y: 0.95, alpha: 0.52, scale: 0.94 },
+  { t: 103, y: 0.96, alpha: 0.60, scale: 0.97 },
+  { t: 104, y: 0.97, alpha: 0.68, scale: 1.00 },
+  { t: 105, y: 0.98, alpha: 0.20, scale: 1.03 },
+  { t: 106, y: 0.99, alpha: 0.28, scale: 1.06 },
+  { t: 107, y: 1.00, alpha: 0.36, scale: 1.09 },
+  { t: 108, y: 0.92, alpha: 0.44, scale: 1.12 },
+  { t: 109, y: 0.93, alpha: 0.52, scale: 1.15 },
+  { t: 110, y: 0.94, alpha: 0.60, scale: 0.85 },
+  { t: 111, y: 0.95, alpha: 0.68, scale: 0.88 },
+  { t: 112, y: 0.96, alpha: 0.20, scale: 0.91 },
+  { t: 113, y: 0.97, alpha: 0.28, scale: 0.94 },
+  { t: 114, y: 0.98, alpha: 0.36, scale: 0.97 },
+  { t: 115, y: 0.99, alpha: 0.44, scale: 1.00 },
+  { t: 116, y: 1.00, alpha: 0.52, scale: 1.03 },
+  { t: 117, y: 0.92, alpha: 0.60, scale: 1.06 },
+  { t: 118, y: 0.93, alpha: 0.68, scale: 1.09 },
+  { t: 119, y: 0.94, alpha: 0.20, scale: 1.12 },
+  { t: 120, y: 0.95, alpha: 0.28, scale: 1.15 },
+  { t: 121, y: 0.96, alpha: 0.36, scale: 0.85 },
+  { t: 122, y: 0.97, alpha: 0.44, scale: 0.88 },
+  { t: 123, y: 0.98, alpha: 0.52, scale: 0.91 },
+  { t: 124, y: 0.99, alpha: 0.60, scale: 0.94 },
+  { t: 125, y: 1.00, alpha: 0.68, scale: 0.97 },
+  { t: 126, y: 0.92, alpha: 0.20, scale: 1.00 },
+  { t: 127, y: 0.93, alpha: 0.28, scale: 1.03 },
+  { t: 128, y: 0.94, alpha: 0.36, scale: 1.06 },
+  { t: 129, y: 0.95, alpha: 0.44, scale: 1.09 },
+  { t: 130, y: 0.96, alpha: 0.52, scale: 1.12 },
+  { t: 131, y: 0.97, alpha: 0.60, scale: 1.15 },
+  { t: 132, y: 0.98, alpha: 0.68, scale: 0.85 },
+  { t: 133, y: 0.99, alpha: 0.20, scale: 0.88 },
+  { t: 134, y: 1.00, alpha: 0.28, scale: 0.91 },
+  { t: 135, y: 0.92, alpha: 0.36, scale: 0.94 },
+  { t: 136, y: 0.93, alpha: 0.44, scale: 0.97 },
+  { t: 137, y: 0.94, alpha: 0.52, scale: 1.00 },
+  { t: 138, y: 0.95, alpha: 0.60, scale: 1.03 },
+  { t: 139, y: 0.96, alpha: 0.68, scale: 1.06 },
+  { t: 140, y: 0.97, alpha: 0.20, scale: 1.09 },
+  { t: 141, y: 0.98, alpha: 0.28, scale: 1.12 },
+  { t: 142, y: 0.99, alpha: 0.36, scale: 1.15 },
+  { t: 143, y: 1.00, alpha: 0.44, scale: 0.85 },
+  { t: 144, y: 0.92, alpha: 0.52, scale: 0.88 },
+  { t: 145, y: 0.93, alpha: 0.60, scale: 0.91 },
+  { t: 146, y: 0.94, alpha: 0.68, scale: 0.94 },
+  { t: 147, y: 0.95, alpha: 0.20, scale: 0.97 },
+  { t: 148, y: 0.96, alpha: 0.28, scale: 1.00 },
+  { t: 149, y: 0.97, alpha: 0.36, scale: 1.03 },
+  { t: 150, y: 0.98, alpha: 0.44, scale: 1.06 },
+  { t: 151, y: 0.99, alpha: 0.52, scale: 1.09 },
+  { t: 152, y: 1.00, alpha: 0.60, scale: 1.12 },
+  { t: 153, y: 0.92, alpha: 0.68, scale: 1.15 },
+  { t: 154, y: 0.93, alpha: 0.20, scale: 0.85 },
+  { t: 155, y: 0.94, alpha: 0.28, scale: 0.88 },
+  { t: 156, y: 0.95, alpha: 0.36, scale: 0.91 },
+  { t: 157, y: 0.96, alpha: 0.44, scale: 0.94 },
+  { t: 158, y: 0.97, alpha: 0.52, scale: 0.97 },
+  { t: 159, y: 0.98, alpha: 0.60, scale: 1.00 },
+  { t: 160, y: 0.99, alpha: 0.68, scale: 1.03 },
+  { t: 161, y: 1.00, alpha: 0.20, scale: 1.06 },
+  { t: 162, y: 0.92, alpha: 0.28, scale: 1.09 },
+  { t: 163, y: 0.93, alpha: 0.36, scale: 1.12 },
+  { t: 164, y: 0.94, alpha: 0.44, scale: 1.15 },
+  { t: 165, y: 0.95, alpha: 0.52, scale: 0.85 },
+  { t: 166, y: 0.96, alpha: 0.60, scale: 0.88 },
+  { t: 167, y: 0.97, alpha: 0.68, scale: 0.91 },
+  { t: 168, y: 0.98, alpha: 0.20, scale: 0.94 },
+  { t: 169, y: 0.99, alpha: 0.28, scale: 0.97 },
+  { t: 170, y: 1.00, alpha: 0.36, scale: 1.00 },
+  { t: 171, y: 0.92, alpha: 0.44, scale: 1.03 },
+  { t: 172, y: 0.93, alpha: 0.52, scale: 1.06 },
+  { t: 173, y: 0.94, alpha: 0.60, scale: 1.09 },
+  { t: 174, y: 0.95, alpha: 0.68, scale: 1.12 },
+  { t: 175, y: 0.96, alpha: 0.20, scale: 1.15 },
+  { t: 176, y: 0.97, alpha: 0.28, scale: 0.85 },
+  { t: 177, y: 0.98, alpha: 0.36, scale: 0.88 },
+  { t: 178, y: 0.99, alpha: 0.44, scale: 0.91 },
+  { t: 179, y: 1.00, alpha: 0.52, scale: 0.94 },
+]);
+
+function applyPulseProfileToBubble(bubble, nowMs, phase = 0) {
+  if (!bubble) return;
+  const idx = Math.floor((nowMs * 0.03 + phase) % GO_CRAZY_PULSE_PROFILE.length);
+  const p = GO_CRAZY_PULSE_PROFILE[idx];
+  if (!p) return;
+  bubble.scale.setScalar(p.scale);
+  bubble.material.opacity = Math.min(0.65, Math.max(0.2, p.alpha));
+}
+function createPickupBubble(weapon) {
+  const cfg = GO_CRAZY_PICKUP_CONFIG[weapon] || GO_CRAZY_PICKUP_CONFIG.FIREARM;
+  const c = PICKUP_BUBBLE_COLORS[weapon] || 0x8fd3ff;
+  const bubble = new THREE.Mesh(
+    new THREE.SphereGeometry(cfg.bubbleScale, 20, 18),
+    new THREE.MeshStandardMaterial({
+      color: c,
+      emissive: new THREE.Color(c).multiplyScalar(cfg.glow),
+      transparent: true,
+      opacity: 0.35,
+      roughness: 0.18,
+      metalness: 0.09
+    })
+  );
+  bubble.position.y = 0.18;
+  return bubble;
+}
+
+function animateSupportUnitActor(actor, kind, now, dt) {
+  if (!actor) return;
+  const cfg = GO_CRAZY_PARKED_CONFIG[kind] || GO_CRAZY_PARKED_CONFIG.TRUCK;
+  const phase = actor.userData.animPhase || 0;
+  const time = now * 0.001 + phase;
+  const baseY = actor.userData.baseY ?? actor.position.y;
+  actor.position.y = baseY + Math.sin(time * cfg.hoverSpeed) * cfg.hoverAmp;
+  actor.rotation.y += dt * cfg.spin;
+  actor.rotation.z = Math.sin(time * (cfg.hoverSpeed * 0.7)) * cfg.bank;
+  actor.rotation.x = Math.cos(time * (cfg.hoverSpeed * 0.45)) * cfg.bank * 0.55;
+  const helperPulse = actor.userData.helperPulse;
+  if (helperPulse) {
+    const s = 1 + Math.sin(time * 2.2) * 0.08 * cfg.pulse;
+    helperPulse.scale.setScalar(s);
+  }
+}
+
+function animateAirStrikeCraft(craftState, now, dt) {
+  if (!craftState?.craft) return;
+  const s = craftState;
+  const swing = Math.sin(now * 0.004 + s.phase) * 0.06;
+  if (s.kind === 'HELICOPTER' || s.kind === 'DRONE') s.craft.rotation.y += dt * 3.8;
+  if (s.kind === 'JET') s.craft.rotation.z = swing;
+  if (s.kind === 'MISSILE') s.craft.rotation.x = -0.2 + swing * 0.4;
+}
+
 export default function SuperTuxKartPlayablePreview() {
   const hostRef = useRef(null);
   const canvasRef = useRef(null);
@@ -690,6 +1320,8 @@ export default function SuperTuxKartPlayablePreview() {
       if (cancelled) return;
       if (originalMode && assets?.track) scene.add(cloneModel(assets.track));
       else createProceduralTrack(scene, selectedTrack);
+      const layoutHelpers = spawnLayoutHelpers(scene, selectedTrack);
+      createRoadEdgeDecorations(scene, selectedTrack);
       scatterGltfTrees(scene, assets?.tree, selectedTrack);
 
       const variants = ["sport", "truck", "heavy", "rally", "longnose"];
@@ -743,7 +1375,8 @@ export default function SuperTuxKartPlayablePreview() {
           if (res.status === "fulfilled" && res.value) {
             parkedTemplates[kind] = res.value;
             const park = cloneModel(res.value);
-            fitVehicleModel(park, { targetLength: 5.4, lift: 0.05, yaw: 0 });
+            fitVehicleModel(park, { targetLength: 5.4, lift: 0.24, yaw: 0 });
+            addPrecisionHelpers(park, { color: 0x76ffea, size: 0.9 });
             const a = (i / parkedKinds.length) * TAU + 0.18;
             const edge = pointOnTrack(a, selectedTrack, i % 2 === 0 ? 9.5 : -9.5);
             park.position.copy(edge).add(new THREE.Vector3(0, 0.2, 0));
@@ -759,8 +1392,8 @@ export default function SuperTuxKartPlayablePreview() {
         const model = weaponTemplates[weapon];
         if (model) {
           const pickup = cloneModel(model);
-          const sizeByWeapon = { FIREARM: 1.25, RIFLE: 1.45, MISSILE: 1.6, DRONE: 1.35, HELICOPTER: 1.5, JET: 1.55 };
-          fitVehicleModel(pickup, { targetLength: sizeByWeapon[weapon] || 1.2, lift: 0.03, yaw: weapon === "RIFLE" ? Math.PI * 0.5 : 0 });
+          const cfg = GO_CRAZY_PICKUP_CONFIG[weapon] || GO_CRAZY_PICKUP_CONFIG.FIREARM;
+          fitVehicleModel(pickup, { targetLength: cfg.targetLength, lift: cfg.lift, yaw: cfg.yaw });
           return pickup;
         }
         if (weapon === "MISSILE") return new THREE.Mesh(new THREE.CylinderGeometry(0.16, 0.22, 1.3, 14), makeMat(0xff7b00, 0.35));
@@ -773,7 +1406,8 @@ export default function SuperTuxKartPlayablePreview() {
       const pickupSlots = Array.from({ length: 12 }, (_, i) => (i / 12) * TAU + 0.25);
       const pickupTypes = [...WEAPON_PICKUPS, ...SUPPORT_PICKUP_TYPES];
       const pickups = pickupTypes.map((weapon, i) => {
-        const p = pointOnTrack((i / WEAPON_PICKUPS.length) * TAU + 0.36, selectedTrack, i % 2 === 0 ? 0.35 : -0.35);
+        const cfg = GO_CRAZY_PICKUP_CONFIG[weapon] || GO_CRAZY_PICKUP_CONFIG.FIREARM;
+        const p = pointOnTrack((i / WEAPON_PICKUPS.length) * TAU + 0.36, selectedTrack, cfg.lane);
         const weaponPickup = SUPPORT_PICKUP_TYPES.includes(weapon)
           ? new THREE.Group()
           : makeWeaponPickupMesh(weapon);
@@ -781,14 +1415,17 @@ export default function SuperTuxKartPlayablePreview() {
           const src = parkedTemplates[weapon];
           if (src) {
             const mini = cloneModel(src);
-            fitVehicleModel(mini, { targetLength: 1.8, lift: 0.03, yaw: 0 });
+            const miniCfg = GO_CRAZY_PICKUP_CONFIG[weapon] || GO_CRAZY_PICKUP_CONFIG.FIREARM;
+            fitVehicleModel(mini, { targetLength: miniCfg.targetLength, lift: miniCfg.lift, yaw: miniCfg.yaw });
             weaponPickup.add(mini);
           }
         }
-        const bubble = new THREE.Mesh(new THREE.SphereGeometry(0.9, 14, 12), new THREE.MeshStandardMaterial({ color: 0x8fd3ff, transparent: true, opacity: 0.28, roughness: 0.2, metalness: 0.05 }));
+        const bubbleColor = PICKUP_BUBBLE_COLORS[weapon] || 0x8fd3ff;
+        const bubble = new THREE.Mesh(new THREE.SphereGeometry(0.95, 16, 14), new THREE.MeshStandardMaterial({ color: bubbleColor, emissive: new THREE.Color(bubbleColor).multiplyScalar(0.18), transparent: true, opacity: 0.35, roughness: 0.15, metalness: 0.08 }));
+        bubble.position.y = 0.15;
         weaponPickup.add(bubble);
-        weaponPickup.position.copy(p).add(new THREE.Vector3(0, 0.62, 0));
-        weaponPickup.userData = { weapon, taken: false, slotIndex: i };
+        weaponPickup.position.copy(p).add(new THREE.Vector3(0, 0.88, 0));
+        weaponPickup.userData = { weapon, taken: false, slotIndex: i, baseY: weaponPickup.position.y };
         scene.add(weaponPickup);
         return weaponPickup;
       });
@@ -803,8 +1440,12 @@ export default function SuperTuxKartPlayablePreview() {
             if (pickup && !pickup.userData.taken) {
               scene.remove(pickup);
               const upgraded = makeWeaponPickupMesh(weapon);
+              const ubColor = PICKUP_BUBBLE_COLORS[weapon] || 0x8fd3ff;
+              const ub = new THREE.Mesh(new THREE.SphereGeometry(0.95, 16, 14), new THREE.MeshStandardMaterial({ color: ubColor, emissive: new THREE.Color(ubColor).multiplyScalar(0.18), transparent: true, opacity: 0.35, roughness: 0.15, metalness: 0.08 }));
+              ub.position.y = 0.15;
+              upgraded.add(ub);
               upgraded.position.copy(pickup.position);
-              upgraded.userData = { ...pickup.userData };
+              upgraded.userData = { ...pickup.userData, baseY: pickup.userData.baseY ?? pickup.position.y };
               scene.add(upgraded);
               pickups[pickups.indexOf(pickup)] = upgraded;
             }
@@ -841,7 +1482,7 @@ export default function SuperTuxKartPlayablePreview() {
         fitVehicleModel(craft, { targetLength: 5.4, lift: 0.05, yaw: 0 });
         craft.position.copy(launchPos);
         scene.add(craft);
-        activeAirStrikes.push({ kind, craft, target, ttl: 3.2, fired: 0, stage: "takeoff", home: launchPos.clone() });
+        activeAirStrikes.push({ kind, craft, target, ttl: 3.2, fired: 0, stage: "takeoff", home: launchPos.clone(), phase: Math.random() * TAU });
       }
 
       const raycaster = new THREE.Raycaster();
@@ -922,6 +1563,13 @@ export default function SuperTuxKartPlayablePreview() {
         }
         crashTextT = Math.max(0, crashTextT - dt);
         updateCamera(dt);
+        Object.entries(parkedActors).forEach(([kind, actor], idx) => {
+          if (!actor) return;
+          const t = now * 0.0015 + idx * 0.7;
+          if (kind === "HELICOPTER" || kind === "DRONE") actor.position.y = 0.24 + Math.sin(t * 2.2) * 0.06;
+          if (kind === "JET") actor.rotation.z = Math.sin(t * 1.4) * 0.04;
+          actor.rotation.y += dt * (kind === "DRONE" ? 0.35 : 0.08);
+        });
         karts.forEach((kart) => {
           const h = kart.group.userData.humanModel;
           if (!h) return;
@@ -936,7 +1584,7 @@ export default function SuperTuxKartPlayablePreview() {
           }
           pickup.visible = true;
           pickup.rotation.y += dt * 1.6;
-          pickup.position.y = 0.62 + Math.sin(now * 0.004 + pickup.position.x) * 0.05;
+          pickup.position.y = (pickup.userData.baseY ?? 0.88) + Math.sin(now * 0.004 + pickup.position.x) * 0.08;
           if (pickup.position.distanceTo(player.pos) < 1.6) {
             pickup.userData.taken = true;
             pickup.visible = false;
@@ -947,7 +1595,8 @@ export default function SuperTuxKartPlayablePreview() {
               pickup.userData.taken = false;
               pickup.userData.slotIndex = (pickup.userData.slotIndex + 1 + Math.floor(Math.random() * 5)) % pickupSlots.length;
               const np = pointOnTrack(pickupSlots[pickup.userData.slotIndex], selectedTrack, Math.random() > 0.5 ? 0.8 : -0.8);
-              pickup.position.copy(np).add(new THREE.Vector3(0, 0.62, 0));
+              pickup.position.copy(np).add(new THREE.Vector3(0, 0.88, 0));
+              pickup.userData.baseY = pickup.position.y;
             }, 2200);
           }
         });
@@ -1001,6 +1650,7 @@ export default function SuperTuxKartPlayablePreview() {
           s.ttl -= dt;
           const hover = s.target.pos.clone().add(new THREE.Vector3(0, 8.5, 0));
           const land = s.home.clone();
+          animateAirStrikeCraft(s, now, dt);
           if (s.stage === "takeoff") {
             s.craft.position.lerp(hover, 1 - Math.exp(-2.8 * dt));
             if (s.craft.position.distanceTo(hover) < 1.5) s.stage = "strike";
@@ -1014,7 +1664,7 @@ export default function SuperTuxKartPlayablePreview() {
             s.fired += 1;
             if (s.fired >= 2) s.stage = "land";
           }
-          if (s.ttl <= 0) { scene.remove(s.craft); s.craft.geometry.dispose(); s.craft.material.dispose(); activeAirStrikes.splice(i, 1); }
+          if (s.ttl <= 0) { scene.remove(s.craft); disposeObject3D(s.craft); activeAirStrikes.splice(i, 1); }
         }
 
         const sorted = [...karts].sort((a, b) => b.progress - a.progress);
@@ -1043,14 +1693,7 @@ export default function SuperTuxKartPlayablePreview() {
         canvas.removeEventListener("click", onTargetClick);
       }
       renderer.dispose();
-      scene.traverse((o) => {
-        const mesh = o;
-        if (!mesh.isMesh) return;
-        mesh.geometry?.dispose?.();
-        const mat = mesh.material;
-        if (Array.isArray(mat)) mat.forEach((m) => m.dispose());
-        else mat?.dispose?.();
-      });
+      disposeObject3D(scene);
     };
   }, []);
 


### PR DESCRIPTION
### Motivation
- Improve visual fidelity and layout for the GoCrazy playable preview by adding tuned pickup bubble colors, placement, and pulsing profiles. 
- Add helpers and decorations to assist level authoring and to make parked/support units feel animated. 
- Fix texture handling for loaded GLTFs and ensure robust disposal of geometries/materials to avoid memory leaks.

### Description
- Introduces configuration constants for pickup visuals and layout (`GO_CRAZY_PICKUP_CONFIG`, `GO_CRAZY_PARKED_CONFIG`, `GO_CRAZY_LAYOUT_TUNING`, `PICKUP_BUBBLE_COLORS`, `GO_CRAZY_PULSE_PROFILE`).
- Adds helper functions: `disposeObject3D`, `addPrecisionHelpers`, `spawnLayoutHelpers`, `animateLayoutHelpers`, `applyOriginalTextureQuality`, `makeGroundHelperBundle`, `createRoadEdgeDecorations`, `applyPulseProfileToBubble`, `createPickupBubble`, `animateSupportUnitActor`, and `animateAirStrikeCraft` to handle decoration, animation and cleanup.
- Updates `loadGltf` to call `applyOriginalTextureQuality` so textures are configured after load and updates parked unit setup to use new tuning and helper visuals.
- Reworks pickup creation and runtime behavior to use the pickup config (sizes, lifts, lanes), per-weapon bubble colors and baseY handling, and upgrade loaded GLTF pickups while preserving `baseY`.
- Adds phase/randomization to air-strike entries and uses `disposeObject3D` when removing crafted objects; replaces ad-hoc traversal disposal at unmount with the centralized `disposeObject3D(scene)` call.

### Testing
- Ran project build using `npm run build` which completed successfully. 
- Ran linter via `npm run lint` with no new lint errors. 
- No automated unit tests were present/changed for these rendering features so no `npm test` coverage was modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f839e18f6c8329a9d91b3caf4027f1)