### PR TITLE
Fix bowling HUD/menu position and restore shot cycle (pin sweep, return, scoring)

### DIFF
--- a/Assets/Scripts/Gameplay/Bowling/BowlingBallReturnSystem.cs
+++ b/Assets/Scripts/Gameplay/Bowling/BowlingBallReturnSystem.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEngine.Events;
 
 namespace Aiming.Gameplay.Bowling
 {
@@ -7,6 +8,8 @@ namespace Aiming.Gameplay.Bowling
     /// </summary>
     public class BowlingBallReturnSystem : MonoBehaviour
     {
+        public UnityEvent onReturnStarted;
+        public UnityEvent onReturnCompleted;
         [SerializeField] private Rigidbody bowlingBall;
         [SerializeField] private Transform[] returnWaypoints;
         [SerializeField] private float moveSpeed = 4.5f;
@@ -24,7 +27,10 @@ namespace Aiming.Gameplay.Bowling
 
             returning = true;
             waypointIndex = 0;
+            bowlingBall.velocity = Vector3.zero;
+            bowlingBall.angularVelocity = Vector3.zero;
             bowlingBall.isKinematic = true;
+            onReturnStarted?.Invoke();
         }
 
         private void Update()
@@ -45,6 +51,9 @@ namespace Aiming.Gameplay.Bowling
                 {
                     returning = false;
                     bowlingBall.isKinematic = false;
+                    bowlingBall.velocity = Vector3.zero;
+                    bowlingBall.angularVelocity = Vector3.zero;
+                    onReturnCompleted?.Invoke();
                 }
             }
         }

--- a/Assets/Scripts/Gameplay/Bowling/BowlingGameFlowController.cs
+++ b/Assets/Scripts/Gameplay/Bowling/BowlingGameFlowController.cs
@@ -1,0 +1,63 @@
+using UnityEngine;
+
+namespace Aiming.Gameplay.Bowling
+{
+    /// <summary>
+    /// Orchestrates post-shot flow: score fallen pins, return ball, and reset pin deck.
+    /// Wire this from your shot-end trigger/callback.
+    /// </summary>
+    public class BowlingGameFlowController : MonoBehaviour
+    {
+        [SerializeField] private BowlingPinDeckSystem pinDeckSystem;
+        [SerializeField] private BowlingScoreboardSystem scoreboardSystem;
+        [SerializeField] private BowlingBallReturnSystem ballReturnSystem;
+        [SerializeField] private bool autoResetRackAfterReturn = true;
+
+        private void OnEnable()
+        {
+            if (ballReturnSystem != null)
+            {
+                ballReturnSystem.onReturnCompleted.AddListener(OnBallReturnCompleted);
+            }
+
+            if (pinDeckSystem != null && scoreboardSystem != null)
+            {
+                pinDeckSystem.onPinsScored.AddListener(scoreboardSystem.AddRoll);
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (ballReturnSystem != null)
+            {
+                ballReturnSystem.onReturnCompleted.RemoveListener(OnBallReturnCompleted);
+            }
+
+            if (pinDeckSystem != null && scoreboardSystem != null)
+            {
+                pinDeckSystem.onPinsScored.RemoveListener(scoreboardSystem.AddRoll);
+            }
+        }
+
+        public void CompleteShotCycle()
+        {
+            if (pinDeckSystem != null)
+            {
+                pinDeckSystem.SweepAndScoreFallenPins();
+            }
+
+            if (ballReturnSystem != null)
+            {
+                ballReturnSystem.StartReturn();
+            }
+        }
+
+        private void OnBallReturnCompleted()
+        {
+            if (autoResetRackAfterReturn && pinDeckSystem != null && pinDeckSystem.CountStandingPins() == 0)
+            {
+                pinDeckSystem.ResetRack();
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Bowling/BowlingHudLayoutTuner.cs
+++ b/Assets/Scripts/Gameplay/Bowling/BowlingHudLayoutTuner.cs
@@ -1,0 +1,54 @@
+using UnityEngine;
+
+namespace Aiming.Gameplay.Bowling
+{
+    /// <summary>
+    /// Applies portrait-friendly UI offsets for the bowling HUD.
+    /// </summary>
+    public class BowlingHudLayoutTuner : MonoBehaviour
+    {
+        [SerializeField] private RectTransform menuIcon;
+        [SerializeField] private float menuIconLowerPixels = 28f;
+        [SerializeField] private bool applyOnEnable = true;
+
+        private Vector2 _initialMenuAnchorPos;
+        private bool _captured;
+
+        private void OnEnable()
+        {
+            if (applyOnEnable)
+            {
+                Apply();
+            }
+        }
+
+        [ContextMenu("Apply HUD Tune")]
+        public void Apply()
+        {
+            if (menuIcon == null)
+            {
+                return;
+            }
+
+            if (!_captured)
+            {
+                _initialMenuAnchorPos = menuIcon.anchoredPosition;
+                _captured = true;
+            }
+
+            // Lower on screen in portrait = reduced Y anchored position.
+            menuIcon.anchoredPosition = _initialMenuAnchorPos + (Vector2.down * Mathf.Abs(menuIconLowerPixels));
+        }
+
+        [ContextMenu("Reset HUD Tune")]
+        public void ResetLayout()
+        {
+            if (menuIcon == null || !_captured)
+            {
+                return;
+            }
+
+            menuIcon.anchoredPosition = _initialMenuAnchorPos;
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Bowling/BowlingPinDeckSystem.cs
+++ b/Assets/Scripts/Gameplay/Bowling/BowlingPinDeckSystem.cs
@@ -1,0 +1,103 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Events;
+
+namespace Aiming.Gameplay.Bowling
+{
+    /// <summary>
+    /// Handles pin state detection, fallen-pin cleanup, and rack reset.
+    /// </summary>
+    public class BowlingPinDeckSystem : MonoBehaviour
+    {
+        [System.Serializable]
+        public class IntEvent : UnityEvent<int> { }
+
+        [SerializeField] private Rigidbody[] pins;
+        [SerializeField] private Transform[] pinSpawnPoints;
+        [SerializeField] private float fallenTiltDegrees = 25f;
+        [SerializeField] private float fallenHeightThreshold = 0.06f;
+
+        public IntEvent onPinsScored;
+
+        private readonly HashSet<int> _clearedPinIndices = new HashSet<int>();
+
+        public int CountStandingPins()
+        {
+            int standing = 0;
+            for (int i = 0; i < pins.Length; i++)
+            {
+                Rigidbody pin = pins[i];
+                if (pin == null || !pin.gameObject.activeSelf)
+                {
+                    continue;
+                }
+
+                if (!IsFallen(pin.transform))
+                {
+                    standing++;
+                }
+            }
+
+            return standing;
+        }
+
+        public int SweepAndScoreFallenPins()
+        {
+            int fallenThisSweep = 0;
+            for (int i = 0; i < pins.Length; i++)
+            {
+                Rigidbody pin = pins[i];
+                if (pin == null || !pin.gameObject.activeSelf || _clearedPinIndices.Contains(i))
+                {
+                    continue;
+                }
+
+                if (!IsFallen(pin.transform))
+                {
+                    continue;
+                }
+
+                fallenThisSweep++;
+                _clearedPinIndices.Add(i);
+                pin.gameObject.SetActive(false);
+            }
+
+            if (fallenThisSweep > 0)
+            {
+                onPinsScored?.Invoke(fallenThisSweep);
+            }
+
+            return fallenThisSweep;
+        }
+
+        public void ResetRack()
+        {
+            _clearedPinIndices.Clear();
+
+            int max = Mathf.Min(pins.Length, pinSpawnPoints.Length);
+            for (int i = 0; i < max; i++)
+            {
+                Rigidbody pin = pins[i];
+                Transform spawn = pinSpawnPoints[i];
+                if (pin == null || spawn == null)
+                {
+                    continue;
+                }
+
+                pin.gameObject.SetActive(true);
+                pin.velocity = Vector3.zero;
+                pin.angularVelocity = Vector3.zero;
+                pin.position = spawn.position;
+                pin.rotation = spawn.rotation;
+            }
+        }
+
+        private bool IsFallen(Transform pin)
+        {
+            float tilt = Vector3.Angle(pin.up, Vector3.up);
+            bool tooTilted = tilt >= fallenTiltDegrees;
+            bool tooLow = pin.position.y <= fallenHeightThreshold;
+            return tooTilted || tooLow;
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Bowling/BowlingScoreboardSystem.cs
+++ b/Assets/Scripts/Gameplay/Bowling/BowlingScoreboardSystem.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Events;
+
+namespace Aiming.Gameplay.Bowling
+{
+    /// <summary>
+    /// Collects pinfall rolls and computes cumulative score with BowlingRulesEngine.
+    /// </summary>
+    public class BowlingScoreboardSystem : MonoBehaviour
+    {
+        [System.Serializable]
+        public class ScoreChangedEvent : UnityEvent<int> { }
+
+        [SerializeField] private int maxFrames = 10;
+
+        public ScoreChangedEvent onScoreChanged;
+
+        private readonly List<int> _rolls = new List<int>(24);
+
+        public IReadOnlyList<int> Rolls => _rolls;
+
+        public void AddRoll(int knockedPins)
+        {
+            if (_rolls.Count >= 21)
+            {
+                return;
+            }
+
+            _rolls.Add(Mathf.Clamp(knockedPins, 0, 10));
+            onScoreChanged?.Invoke(GetTotalScore());
+        }
+
+        public void ResetMatch()
+        {
+            _rolls.Clear();
+            onScoreChanged?.Invoke(0);
+        }
+
+        public int GetTotalScore()
+        {
+            BowlingFrameScore[] frames = BowlingRulesEngine.BuildFrames(_rolls.ToArray());
+            int running = 0;
+            int frameCount = Mathf.Min(maxFrames, frames.Length);
+            for (int i = 0; i < frameCount; i++)
+            {
+                running += frames[i].total;
+            }
+
+            return running;
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- The bowling HUD/menu icon needed to be lowered for portrait UX clarity. 
- Fallen pins were not being cleaned up and the ball return flow did not reliably reset the ball state. 
- Knocked-pin counts were not being propagated to the scoreboard, breaking the scoring loop.

### Description
- Added `BowlingHudLayoutTuner` to apply a portrait-friendly downward offset to the menu icon and allow resetting the layout. 
- Hardened `BowlingBallReturnSystem` to zero linear/angular velocity before/after return and emit `onReturnStarted` and `onReturnCompleted` events for reliable sequencing. 
- Added `BowlingPinDeckSystem` to detect fallen pins (tilt/height), sweep/deactivate them, emit pin-count events, and reset the rack from spawn points. 
- Added `BowlingScoreboardSystem` to collect rolls, compute totals via `BowlingRulesEngine`, and emit `onScoreChanged` for UI binding, and added `BowlingGameFlowController` to wire pin sweep → scoring → ball return → optional rack reset.

### Testing
- `git status --short` completed and changes were committed successfully. 
- Scene/Inspector hookups and Unity PlayMode validation were not executed in this pass, so no Unity playmode or unit tests were run. 
- Manual hookup is required: attach the new components in the scene and wire events (`onPinsScored`, `onReturnCompleted`, `onScoreChanged`) to validate end-to-end behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f83f648d308329bb8bcf400ca61704)