### PR TITLE
Table Tennis: stronger ball, trimmed SFX, realistic net, and player-eye camera

### DIFF
--- a/webapp/src/pages/Games/TableTennis.tsx
+++ b/webapp/src/pages/Games/TableTennis.tsx
@@ -105,6 +105,7 @@ type HumanRig = {
 };
 
 type HudState = { nearScore: number; farScore: number; status: string; power: number; spin: number };
+type CameraMode = "player" | "broadcast";
 
 type ControlState = {
   active: boolean;
@@ -152,6 +153,7 @@ const CFG = {
   serveContactT: 0.68,
   playerVisualYawFix: Math.PI,
   paddlePalmOffset: 0.038,
+  hitPowerBoost: 1.22,
 };
 
 const TABLE_REFERENCE_LENGTH = 2.74;
@@ -234,7 +236,7 @@ function buildRealisticTableTennisTable() {
   const whiteLine = material(0xf6f7f0, 0.45, 0.0);
   const metal = material(0x171c22, 0.38, 0.32);
   const wheelMat = material(0x0b0e12, 0.46, 0.28);
-  const netMat = transparentMaterial(0x050505, 0.46, 0.7);
+  const netMat = transparentMaterial(0x0f1115, 0.82, 0.7);
   const netTape = material(0xf2f2f2, 0.46, 0.02);
 
   addBox(group, [CFG.tableW, CFG.tableTopThickness, CFG.tableL], [0, CFG.tableY - CFG.tableTopThickness / 2, 0], tableBlue);
@@ -268,10 +270,41 @@ function buildRealisticTableTennisTable() {
   addBox(group, [0.05, 0.035, 1.74], [0.62, 0.39, 0], metal).rotation.y = -0.16;
 
   const netY = CFG.tableY + CFG.netH / 2;
-  addBox(group, [CFG.tableW + CFG.netPostOutside * 2, CFG.netH, 0.012], [0, netY, 0], netMat);
-  addBox(group, [CFG.tableW + CFG.netPostOutside * 2 + 0.035, 0.018, 0.026], [0, CFG.tableY + CFG.netH + 0.009, 0], netTape);
-  for (let i = -6; i <= 6; i++) addBox(group, [0.0035, CFG.netH * 0.86, 0.014], [(i * CFG.tableW) / 12, CFG.tableY + CFG.netH * 0.43, 0.008], transparentMaterial(0xffffff, 0.25));
-  for (let j = 1; j <= 3; j++) addBox(group, [CFG.tableW + 0.12, 0.0035, 0.014], [0, CFG.tableY + (j * CFG.netH) / 4, 0.009], transparentMaterial(0xffffff, 0.24));
+  const netW = CFG.tableW + CFG.netPostOutside * 2;
+  const netCanvas = document.createElement("canvas");
+  netCanvas.width = 512;
+  netCanvas.height = 128;
+  const netCtx = netCanvas.getContext("2d");
+  if (netCtx) {
+    netCtx.fillStyle = "rgba(16,18,22,0.90)";
+    netCtx.fillRect(0, 0, netCanvas.width, netCanvas.height);
+    netCtx.globalCompositeOperation = "destination-out";
+    for (let yRow = 8; yRow < netCanvas.height - 8; yRow += 18) {
+      for (let xCol = ((Math.floor(yRow / 18) % 2) * 11) + 8; xCol < netCanvas.width - 8; xCol += 22) {
+        netCtx.beginPath();
+        for (let i = 0; i < 6; i++) {
+          const a = (Math.PI / 3) * i + Math.PI / 6;
+          const px = xCol + Math.cos(a) * 6.6;
+          const py = yRow + Math.sin(a) * 6.6;
+          if (i === 0) netCtx.moveTo(px, py); else netCtx.lineTo(px, py);
+        }
+        netCtx.closePath();
+        netCtx.fill();
+      }
+    }
+  }
+  const netTexture = new THREE.CanvasTexture(netCanvas);
+  netTexture.colorSpace = THREE.SRGBColorSpace;
+  netTexture.anisotropy = 8;
+  const netMesh = new THREE.Mesh(new THREE.BoxGeometry(netW, CFG.netH, 0.022), new THREE.MeshStandardMaterial({
+    color: 0x1b1f26, roughness: 0.78, metalness: 0.08, transparent: true, opacity: 0.94, alphaMap: netTexture, side: THREE.DoubleSide
+  }));
+  netMesh.name = "TableNetMesh";
+  netMesh.position.set(0, netY, 0);
+  enableShadow(netMesh);
+  group.add(netMesh);
+  addBox(group, [netW + 0.035, 0.018, 0.028], [0, CFG.tableY + CFG.netH + 0.009, 0], netTape);
+  addBox(group, [netW + 0.02, 0.012, 0.028], [0, CFG.tableY + 0.009, 0], netTape);
   const leftPost = addCylinder(group, 0.017, 0.02, CFG.netH + 0.08, [-(TABLE_HALF_W + CFG.netPostOutside), CFG.tableY + (CFG.netH + 0.08) / 2, 0], metal, 18);
   const rightPost = addCylinder(group, 0.017, 0.02, CFG.netH + 0.08, [TABLE_HALF_W + CFG.netPostOutside, CFG.tableY + (CFG.netH + 0.08) / 2, 0], metal, 18);
   leftPost.rotation.z = -0.03;
@@ -939,7 +972,7 @@ function performHit(player: HumanRig, ball: BallState, hit: DesiredHit, serve = 
     ball.pos.copy(serveContactPosition(player));
     const ownBounce = new THREE.Vector3(clamp(target.x * 0.45, -TABLE_HALF_W + 0.12, TABLE_HALF_W - 0.12), BALL_SURFACE_Y, dirZ * -0.56);
     const flight = clamp(0.22 + (1 - hit.power) * 0.09, 0.22, 0.32);
-    ball.vel.copy(ballisticVelocity(ball.pos, ownBounce, flight));
+    ball.vel.copy(ballisticVelocity(ball.pos, ownBounce, flight).multiplyScalar(CFG.hitPowerBoost));
     ball.spin.set(-dirZ * (46 + hit.topSpin * 42), hit.sideSpin * 78, hit.sideSpin * 8);
     ball.phase = { kind: "serve", server: player.side, stage: "own" };
   } else {
@@ -947,7 +980,7 @@ function performHit(player: HumanRig, ball: BallState, hit: DesiredHit, serve = 
     const dist = Math.hypot(target.x - ball.pos.x, target.z - ball.pos.z);
     const speedScale = Math.max(1, TABLE_SCALE_FACTOR * 0.85);
     const flight = clamp(dist / ((3.45 + hit.power * 3.35) * speedScale), 0.18, 0.48);
-    ball.vel.copy(ballisticVelocity(ball.pos, target, flight));
+    ball.vel.copy(ballisticVelocity(ball.pos, target, flight).multiplyScalar(CFG.hitPowerBoost));
     ball.spin.set(-dirZ * (62 + hit.topSpin * 92), hit.sideSpin * 104, hit.sideSpin * 12);
     ball.phase = { kind: "rally" };
   }
@@ -1051,6 +1084,7 @@ export default function MobileRealisticTableTennisGame() {
   const controlRef = useRef<ControlState>({ active: false, pointerId: null, startX: 0, startY: 0, lastX: 0, lastY: 0, startPlayer: new THREE.Vector3() });
   const [menuOpen, setMenuOpen] = useState(false);
   const [graphicsId, setGraphicsId] = useState<'performance' | 'balanced' | 'ultra'>(() => 'balanced');
+  const [cameraMode, setCameraMode] = useState<CameraMode>(() => (typeof window !== "undefined" && window.localStorage.getItem("tableTennisCameraMode") === "broadcast") ? "broadcast" : "player");
   const accountId = typeof window !== "undefined" ? window.localStorage.getItem("accountId") || "guest" : "guest";
   const [inventory] = useState(() => getChessBattleInventory(accountId));
   const unlockedHumanCharacters = useMemo(
@@ -1087,6 +1121,9 @@ export default function MobileRealisticTableTennisGame() {
     if (selectedHumanCharacterId) window.localStorage.setItem("tableTennisSelectedHumanCharacter", selectedHumanCharacterId);
     if (selectedHdriId) window.localStorage.setItem("tableTennisSelectedHdri", selectedHdriId);
   }, [selectedHdriId, selectedHumanCharacterId]);
+  useEffect(() => {
+    if (typeof window !== "undefined") window.localStorage.setItem("tableTennisCameraMode", cameraMode);
+  }, [cameraMode]);
 
 
   const selectedHumanOption = useMemo(
@@ -1202,9 +1239,20 @@ export default function MobileRealisticTableTennisGame() {
     netFx.playbackRate = 1.4;
     const scoreFx = new Audio("/assets/sounds/successful.mp3");
     scoreFx.volume = 0.26;
-    const playFx = (fx: HTMLAudioElement) => { fx.currentTime = 0; fx.play().catch(() => {}); };
+    const playFx = (fx: HTMLAudioElement, maxSeconds = 1.5) => {
+      fx.currentTime = 0;
+      fx.play().catch(() => {});
+      window.setTimeout(() => {
+        if (!fx.paused && fx.currentTime > maxSeconds) {
+          fx.pause();
+          fx.currentTime = 0;
+        }
+      }, maxSeconds * 1000 + 20);
+    };
     const replayFrames: THREE.Vector3[] = [];
     let replayT = 0;
+    let netWobble = 0;
+    const netObject = scene.getObjectByName("TableNetMesh");
 
     const setHudSafe = (patch: Partial<HudState>) => setHud((prev) => ({ ...prev, ...patch }));
 
@@ -1383,6 +1431,7 @@ export default function MobileRealisticTableTennisGame() {
         ball.vel.z *= -0.24;
         ball.vel.y = Math.max(0.1, Math.abs(ball.vel.y) * 0.24);
         playFx(netFx);
+        netWobble = 1;
         awardPoint(opposite(ball.lastHitBy), "net");
       }
 
@@ -1515,7 +1564,20 @@ export default function MobileRealisticTableTennisGame() {
       (playerGhost.material as THREE.MeshBasicMaterial).opacity = controlRef.current.active ? 0.48 : 0.2;
       if (!controlRef.current.active) (aimGhost.material as THREE.MeshBasicMaterial).opacity *= 0.94;
 
-      camera.lookAt(cameraTarget);
+      if (netObject) {
+        netWobble = Math.max(0, netWobble - dt * 2.6);
+        netObject.rotation.x = Math.sin(now * 0.05) * 0.035 * netWobble;
+      }
+      if (cameraMode === "player") {
+        const eyeTarget = nearPlayer.pos.clone().add(new THREE.Vector3(0, 1.61, 0));
+        const fwd = forwardFromYaw(nearPlayer.yaw);
+        const side = rightFromForward(fwd);
+        const camPos = eyeTarget.clone().addScaledVector(side, 0.032).addScaledVector(fwd, 0.04);
+        camera.position.lerp(camPos, 1 - Math.exp(-16 * dt));
+        camera.lookAt(eyeTarget.clone().addScaledVector(fwd, 3.4).add(new THREE.Vector3(0, -0.18, 0)));
+      } else {
+        camera.lookAt(cameraTarget);
+      }
       renderer.render(scene, camera);
     }
 
@@ -1541,7 +1603,7 @@ export default function MobileRealisticTableTennisGame() {
         }
       });
     };
-  }, [graphicsId, selectedHdriOption?.assetId, selectedHumanOption?.id]);
+  }, [graphicsId, selectedHdriOption?.assetId, selectedHumanOption?.id, cameraMode]);
 
   return (
     <div style={{ position: "fixed", inset: 0, overflow: "hidden", background: "#091014", touchAction: "none", userSelect: "none" }}>
@@ -1588,6 +1650,10 @@ export default function MobileRealisticTableTennisGame() {
         <div style={{ position: "absolute", left: "50%", top: 10, transform: "translateX(-50%)", color: "white", background: "rgba(0,0,0,0.58)", border: "1px solid rgba(255,255,255,0.16)", padding: "9px 13px", borderRadius: 16, fontSize: 13, fontWeight: 850, letterSpacing: 0.2, boxShadow: "0 12px 26px rgba(0,0,0,0.25)", textAlign: "center", minWidth: 178 }}>
           You {hud.nearScore} — {hud.farScore} AI
           <div style={{ fontSize: 11, fontWeight: 650, opacity: 0.84, marginTop: 2 }}>{hud.status}</div>
+        </div>
+        <div style={{ position: "absolute", right: 2, top: "50%", transform: "translateY(-50%)", pointerEvents: "auto", display: "grid", gap: 6 }}>
+          <button type="button" onClick={() => setCameraMode("player")} style={{ borderRadius: "10px 0 0 10px", border: "1px solid rgba(255,255,255,.24)", background: cameraMode === "player" ? "rgba(255,255,255,.28)" : "rgba(5,10,15,.72)", color: "#fff", padding: "8px 10px", fontWeight: 800 }}>👁 Player</button>
+          <button type="button" onClick={() => setCameraMode("broadcast")} style={{ borderRadius: "10px 0 0 10px", border: "1px solid rgba(255,255,255,.24)", background: cameraMode === "broadcast" ? "rgba(255,255,255,.28)" : "rgba(5,10,15,.72)", color: "#fff", padding: "8px 10px", fontWeight: 800 }}>🎥 Arena</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
### Motivation
- Make rallies more playable after table adjustments by increasing ball strike power so shots clear the net reliably. 
- Improve immersion by trimming ball SFX to only the initial portion and adding a more realistic net visual and motion response. 
- Provide a player-perspective camera (default) while keeping the existing broadcast camera as an option so users can switch views.

### Description
- Added a configurable hit multiplier `CFG.hitPowerBoost` and applied it to serve and rally velocities inside `performHit` to increase shot power. 
- Replaced the original net geometry with a thicker `BoxGeometry` using a procedural canvas `alphaMap` to create hexagon holes and added white tape boxes at top and bottom; the mesh is named `TableNetMesh`. 
- Added a lightweight net impact reaction (`netWobble`) driven in the main `animate` loop so the net visually wobbles when the ball hits it. 
- Limited audio playback for ball-related SFX by replacing `playFx` with a bounded helper that stops playback after ~1.5s to ensure only the initial sound is heard. 
- Implemented `CameraMode` state with `player` (default) and `broadcast` modes, persisted to `localStorage`, UI toggle buttons on the right edge, and a smooth player-eye camera position/look-at computation applied during `animate`.

### Testing
- Ran the production web build with `npm -C webapp run -s build`, which completed successfully; Vite printed non-blocking chunking warnings that are unrelated to these changes. 
- No automated unit tests were modified or executed as part of this change beyond the production build step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f841f476f48329a730ba7f2d6ec13c)