### PR TITLE
Introduce shared snooker human rig and integrate into SnookerRoyal player model

### DIFF
--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -94,6 +94,11 @@ import {
   SPIN_STUN_RADIUS
 } from './snookerRoyalSpinUtils.js';
 import { sampleCueStrokeTimeline } from './poolRoyaleCueStrokeTimeline.js';
+import {
+  createSnookerHumanRig,
+  updateBilardoHumanPose,
+  chooseHumanEdgePosition
+} from './shared/snookerHumanRig.js';
 
 const DRACO_DECODER_PATH = 'https://www.gstatic.com/draco/versioned/decoders/1.5.7/';
 const BASIS_TRANSCODER_PATH =
@@ -5377,6 +5382,14 @@ const TMP_VEC2_AXIS = new THREE.Vector2();
 const TMP_VEC2_VIEW = new THREE.Vector2();
 const TMP_EULER_A = new THREE.Euler();
 const TMP_VEC3_A = new THREE.Vector3();
+const TMP_VEC3_B = new THREE.Vector3();
+const TMP_VEC3_C = new THREE.Vector3();
+const TMP_VEC3_D = new THREE.Vector3();
+const TMP_VEC3_E = new THREE.Vector3();
+const TMP_VEC3_F = new THREE.Vector3();
+const TMP_VEC3_G = new THREE.Vector3();
+const TMP_VEC3_H = new THREE.Vector3();
+const TMP_VEC3_Y_UP = new THREE.Vector3(0, 1, 0);
 const TMP_VEC3_BUTT = new THREE.Vector3();
 const TMP_VEC3_CUE_TIP_OFFSET = new THREE.Vector3();
 const TMP_VEC3_CUE_BUTT_OFFSET = new THREE.Vector3();
@@ -20431,40 +20444,39 @@ const powerRef = useRef(hud.power);
       };
       const cueTipLocal = new THREE.Vector3(0, 0, -cueLen / 2);
       const cueButtLocal = new THREE.Vector3(0, 0, cueLen / 2);
-      const humanActor = new THREE.Group();
-      const humanModelRoot = new THREE.Group();
-      humanActor.add(humanModelRoot);
-      humanActor.visible = false;
-      table.add(humanActor);
-      const humanLoader = new GLTFLoader();
-      humanLoader.setCrossOrigin('anonymous');
-      humanLoader.load(
-        'https://threejs.org/examples/models/gltf/readyplayer.me.glb',
-        (gltf) => {
-          const model = gltf?.scene;
-          if (!model) return;
-          model.traverse((obj) => {
-            if (!obj?.isMesh) return;
-            obj.castShadow = true;
-            obj.receiveShadow = true;
-            obj.frustumCulled = false;
-          });
-          const scaleFactor = SCALE * 1.18;
-          model.scale.setScalar(scaleFactor);
-          model.rotation.set(0, Math.PI, 0);
-          model.position.set(0, 0, 0);
-          model.updateMatrixWorld(true);
-          const box = new THREE.Box3().setFromObject(model);
-          const center = box.getCenter(new THREE.Vector3());
-          model.position.set(-center.x, -box.min.y, -center.z);
-          humanModelRoot.add(model);
-          humanActor.visible = true;
-        },
-        undefined,
-        () => {
-          humanActor.visible = false;
-        }
-      );
+      const humanRig = createSnookerHumanRig(table, {
+        scale: SCALE,
+        loader: new GLTFLoader(),
+        modelUrl: 'https://threejs.org/examples/models/gltf/readyplayer.me.glb',
+        humanScale: SCALE * 1.18,
+        rightHandCueSocketLocal: new THREE.Vector3(-0.004, -0.014, 0.092).multiplyScalar(SCALE),
+        rightForearmOutward: 0.36 * SCALE,
+        rightForearmBack: 0.44 * SCALE,
+        rightForearmDown: 0.48 * SCALE,
+        rightForearmLength: 0.34 * SCALE,
+        rightStrokePull: 0.30 * SCALE,
+        rightStrokePush: 0.24 * SCALE,
+        rightHandShotLift: -0.30 * SCALE,
+        rightElbowShotRise: 0.18 * SCALE,
+        rightElbowShotSide: -0.46 * SCALE,
+        rightElbowShotBack: -0.78 * SCALE,
+        bridgePalmTableLift: 0.006 * SCALE,
+        bridgeHandBackFromBall: 0.235 * SCALE,
+        bridgeHandSide: -0.012 * SCALE,
+        cueLength: cueLen,
+        bridgeDist: 0.24 * SCALE,
+        shootCueGripFromBack: 0.58 * SCALE,
+        idleRightHandY: 0.8 * SCALE,
+        idleRightHandX: 0.31 * SCALE,
+        idleRightHandZ: -0.015 * SCALE,
+        footGroundY: 0.035 * SCALE,
+        kneeBendShot: 0.16 * SCALE,
+        stanceWidth: 0.52 * SCALE,
+        chinToCueHeight: 0.11 * SCALE,
+        tableTopY: CUE_Y - 0.08 * SCALE,
+        edgeMargin: 0.58 * SCALE,
+        desiredShootDistance: 1.06 * SCALE
+      });
       const resolveCueButtTiltSign = (group, tilt) => {
         if (!group || !Number.isFinite(tilt) || tilt === 0) return 1;
         const rotY = group.rotation.y;
@@ -26001,18 +26013,64 @@ const powerRef = useRef(hud.power);
             fit(1 + edge * 0.08);
           }
           const frameCamera = updateCamera();
-          if (humanActor.visible && cueStick) {
-            const yaw = cueStick.rotation.y;
-            const forwardX = Math.sin(yaw - Math.PI);
-            const forwardZ = Math.cos(yaw - Math.PI);
-            const sideX = forwardZ;
-            const sideZ = -forwardX;
-            humanActor.position.set(
-              cueStick.position.x - forwardX * (SCALE * 3.6) - sideX * (SCALE * 0.7),
-              0,
-              cueStick.position.z - forwardZ * (SCALE * 3.6) - sideZ * (SCALE * 0.7)
+          if (humanRig && cueStick) {
+            const state = shooting ? 'striking' : (sliderInstanceRef.current?.dragging ? 'dragging' : 'idle');
+            TMP_VEC3_CUE_TIP_OFFSET.copy(cueTipLocal).applyEuler(cueStick.rotation);
+            TMP_VEC3_CUE_BUTT_OFFSET.copy(cueButtLocal).applyEuler(cueStick.rotation);
+            const cueTipWorld = TMP_VEC3_A.set(
+              cueStick.position.x + TMP_VEC3_CUE_TIP_OFFSET.x,
+              cueStick.position.y + TMP_VEC3_CUE_TIP_OFFSET.y,
+              cueStick.position.z + TMP_VEC3_CUE_TIP_OFFSET.z
             );
-            humanActor.rotation.y = yaw;
+            const cueBackWorld = TMP_VEC3_B.set(
+              cueStick.position.x + TMP_VEC3_CUE_BUTT_OFFSET.x,
+              cueStick.position.y + TMP_VEC3_CUE_BUTT_OFFSET.y,
+              cueStick.position.z + TMP_VEC3_CUE_BUTT_OFFSET.z
+            );
+            const aimForward = TMP_VEC3_C.copy(cueTipWorld).sub(cueBackWorld);
+            if (aimForward.lengthSq() < 1e-8) {
+              aimForward.set(Math.sin(cueStick.rotation.y - Math.PI), 0, Math.cos(cueStick.rotation.y - Math.PI));
+            } else {
+              aimForward.normalize();
+            }
+            const cueBallWorld = TMP_VEC3_D.set(cue.pos.x, CUE_Y, cue.pos.y);
+            const rootTarget = chooseHumanEdgePosition(cueBallWorld, aimForward, {
+              tableW: PLAY_W,
+              tableL: PLAY_H,
+              ...humanRig.cfg
+            });
+            const aimSide = TMP_VEC3_E.set(aimForward.z, 0, -aimForward.x).normalize();
+            const bridgeTarget = TMP_VEC3_F.copy(cueBallWorld)
+              .addScaledVector(aimForward, -(humanRig.cfg.bridgeHandBackFromBall ?? 0.235 * SCALE))
+              .addScaledVector(aimSide, humanRig.cfg.bridgeHandSide ?? (-0.012 * SCALE))
+              .setY((humanRig.cfg.tableTopY ?? CUE_Y - 0.08 * SCALE) + (humanRig.cfg.bridgePalmTableLift ?? 0.006 * SCALE));
+            const standingYaw = Math.atan2(-aimForward.x, -aimForward.z);
+            const idleRight = TMP_VEC3_G.copy(rootTarget).add(
+              new THREE.Vector3(
+                humanRig.cfg.idleRightHandX ?? 0.31 * SCALE,
+                humanRig.cfg.idleRightHandY ?? 0.8 * SCALE,
+                humanRig.cfg.idleRightHandZ ?? -0.015 * SCALE
+              ).applyAxisAngle(TMP_VEC3_Y_UP, standingYaw)
+            );
+            const idleLeft = TMP_VEC3_H.copy(rootTarget).add(
+              new THREE.Vector3(-0.18 * SCALE, 1.08 * SCALE, 0.03 * SCALE).applyAxisAngle(TMP_VEC3_Y_UP, standingYaw)
+            );
+            try {
+              updateBilardoHumanPose(humanRig, dt, {
+                state,
+                rootTarget,
+                aimForward,
+                bridgeTarget,
+                gripTarget: cueBackWorld.clone().addScaledVector(aimForward, humanRig.cfg.shootCueGripFromBack ?? 0.58 * SCALE),
+                idleRight,
+                idleLeft,
+                cueBack: cueBackWorld,
+                cueTip: cueTipWorld,
+                power: powerRef.current ?? 0
+              });
+            } catch (rigError) {
+              console.error('Snooker Royal human rig update failed', rigError);
+            }
           }
           renderer.render(scene, frameCamera ?? camera);
           const shouldStreamAim =

--- a/webapp/src/pages/Games/shared/snookerHumanRig.js
+++ b/webapp/src/pages/Games/shared/snookerHumanRig.js
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 
 const CFG = {
+  scale: 1,
   poseLambda: 9,
   moveLambda: 5.6,
   rotLambda: 8.5,
@@ -21,6 +22,8 @@ const CFG = {
   cueLength: 1.46,
   bridgeDist: 0.24,
   shootCueGripFromBack: 0.58,
+  idleCueGripFromBack: 0.24,
+  idleCueDir: new THREE.Vector3(0.055, 0.965, -0.13),
   rightForearmOutward: 0.36,
   rightForearmBack: 0.44,
   rightForearmDown: 0.48,
@@ -281,11 +284,13 @@ function driveHuman(human, frame) {
   }
 
   const rightGrip = frame.rightHandWorld.clone();
-  const rightIdleElbow = rightGrip.clone().addScaledVector(UP, 0.1 + 0.28 * ik).addScaledVector(frame.side, -0.22 - 0.04 * ik).addScaledVector(frame.forward, -0.03 * idle);
-  const rightElbow = frame.rightElbow.clone().lerp(rightIdleElbow, idle * 0.52);
-  const rightHold = 0.88 + 0.12 * ik;
-  const rightArmPole = UP.clone().multiplyScalar(1.32).addScaledVector(frame.side, -0.62).addScaledVector(frame.forward, -1.05).normalize();
-  aimTwoBone(b.rightUpperArm, b.rightLowerArm, rightElbow, rightGrip, rightArmPole, rightHold, rightHold);
+  const rightIdleElbow = rightGrip.clone()
+    .addScaledVector(UP, 0.04 * (human.cfg?.scale ?? CFG.scale) + 0.14 * (human.cfg?.scale ?? CFG.scale) * ik)
+    .addScaledVector(frame.side, -0.2 * (human.cfg?.scale ?? CFG.scale))
+    .addScaledVector(frame.forward, -0.03 * (human.cfg?.scale ?? CFG.scale) * idle);
+  const rightElbow = frame.rightElbow.clone().lerp(rightIdleElbow, idle * 0.5);
+  const pole = frame.side.clone().multiplyScalar(-1).addScaledVector(UP, 0.32).addScaledVector(frame.forward, -0.55).normalize();
+  aimTwoBone(b.rightUpperArm, b.rightLowerArm, rightElbow, rightGrip, pole, 0.9 + 0.1 * ik, 1.0);
 
   const standingHandSide = frame.side.clone().multiplyScalar(-1)
     .addScaledVector(UP, -0.55)
@@ -295,7 +300,7 @@ function driveHuman(human, frame) {
     .addScaledVector(frame.side, -0.64)
     .addScaledVector(frame.forward, 0.2)
     .normalize();
-  const standingCueDir = new THREE.Vector3(0.055, 0.965, -0.13).applyAxisAngle(Y_AXIS, human.yaw).normalize();
+  const standingCueDir = (human.cfg?.idleCueDir ?? CFG.idleCueDir).clone().applyAxisAngle(Y_AXIS, human.yaw).normalize();
   const handForwardForOrientation = ik >= 0.025 ? standingCueDir : cueDir;
   const rollForOrientation = ik >= 0.025
     ? (human.cfg?.rightHandRollIdle ?? CFG.rightHandRollIdle)


### PR DESCRIPTION
### Motivation
- Replace the ad-hoc `humanActor` loader and per-page pose logic with a reusable, configurable human rig to centralize pose/IK behavior and improve maintainability and realism. 
- Provide a common API for positioning and updating the human model so other cue games can share the same pose-driving logic and configuration.

### Description
- Add `webapp/src/pages/Games/shared/snookerHumanRig.js` which defines a configurable rig (`CFG`) and exposes rig-driving utilities used to create and update the human model for cue poses. 
- Replace the inline GLTF loader and `humanActor` in `SnookerRoyal.jsx` with `createSnookerHumanRig(...)` and use `updateBilardoHumanPose(...)` and `chooseHumanEdgePosition(...)` during the frame update to compute root, bridge and grip targets. 
- Introduce several temporary `THREE.Vector3` temps and compute `cueTipWorld`/`cueBackWorld` to drive aiming and idle/striking poses, and wrap the rig update in a `try/catch` to avoid breaking the main render loop on rig errors. 
- Adjust rig configuration and pose math: add `scale`, `idleCueDir`, and other config values to the rig defaults and apply `human.cfg.scale` in elbow/arm calculations to keep pose proportions consistent with the table/cue scale. 

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8384adf60832981b0d6c50e8b3b9b)