### PR TITLE
Improve human aim trigger and refactor human right-arm/forearm pose

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -25241,7 +25241,7 @@ const shotPowerRef = useRef(0);
           if (isReplay) mode = 'idle';
           else if (isShotActive && (singleHumanMode || seat === shotSeat) && shotAge < 420) mode = 'strike';
           else if (isShotActive) mode = 'react';
-          else if (isHumanShooter && (loweredCueCamera || draggingSlider || sliderPowerActive)) mode = 'aim';
+          else if (isHumanShooter && (hasAim || loweredCueCamera || draggingSlider || sliderPowerActive)) mode = 'aim';
           if (anim) anim.mode = mode;
 
           if (human) {
@@ -25311,10 +25311,7 @@ const shotPowerRef = useRef(0);
             const cueShootDir = cueTip.clone().sub(cueBack).normalize();
             const gripTarget = cueBack
               .clone()
-              .addScaledVector(cueShootDir, 0.58)
-              .addScaledVector(aimForward, -0.08 - 0.18)
-              .addScaledVector(WORLD_UP, 0.055)
-              .addScaledVector(side, 0.14);
+              .addScaledVector(cueShootDir, 0.58);
             if (isHumanShooter && state === 'dragging') {
               activeHumanCueViewRef.current = {
                 cueBack: cueBack.clone(),

--- a/webapp/src/pages/Games/shared/snookerHumanRig.js
+++ b/webapp/src/pages/Games/shared/snookerHumanRig.js
@@ -21,10 +21,13 @@ const CFG = {
   cueLength: 1.46,
   bridgeDist: 0.24,
   shootCueGripFromBack: 0.58,
-  rightHandShotExtraBack: 0.18,
-  rightHandShotLift: 0.055,
-  rightHandForwardClamp: -0.08,
-  rightHandOutward: 0.14,
+  rightForearmOutward: 0.36,
+  rightForearmBack: 0.44,
+  rightForearmDown: 0.48,
+  rightForearmLength: 0.34,
+  rightStrokePull: 0.30,
+  rightStrokePush: 0.24,
+  rightHandShotLift: -0.30,
   idleRightHandY: 0.8,
   idleRightHandX: 0.31,
   idleRightHandZ: -0.015,
@@ -35,9 +38,9 @@ const CFG = {
   footGroundY: 0.035,
   kneeBendShot: 0.16,
   footLockStrength: 1.0,
-  rightElbowShotRise: 0.84,
-  rightElbowShotSide: -0.34,
-  rightElbowShotBack: -0.82
+  rightElbowShotRise: 0.18,
+  rightElbowShotSide: -0.46,
+  rightElbowShotBack: -0.78
 };
 
 const Y_AXIS = new THREE.Vector3(0, 1, 0);
@@ -365,17 +368,28 @@ export function updateBilardoHumanPose(human, dt, frameData) {
   const handIk = easeInOut(clamp01(t));
   const idleGripSide = side.clone().multiplyScalar(-1).addScaledVector(UP, -0.55).addScaledVector(forward, 0.16).normalize();
   const idleGripUp = UP.clone().multiplyScalar(-1.0).addScaledVector(side, -0.64).addScaledVector(forward, 0.2).normalize();
-  const liveGripSide = side.clone().multiplyScalar(-1).addScaledVector(UP, lerp(-0.55, -0.2, handIk)).addScaledVector(side, 0.18 * handIk).addScaledVector(forward, lerp(0.16, -0.02, handIk)).normalize();
-  const liveGripUp = UP.clone().multiplyScalar(lerp(-1.0, 0.74, handIk)).addScaledVector(side, lerp(-0.64, -0.22, handIk)).addScaledVector(forward, lerp(0.2, -0.22, handIk)).normalize();
-  const backGripPoint = frameData.cueBack.clone().addScaledVector(cueDirForHand, cfg.shootCueGripFromBack);
-  const liveCueGripPoint = backGripPoint
-    .clone()
-    .addScaledVector(forward, 0.002 * stroke * t + 0.002 * follow * power);
+  const liveGripSide = side.clone().multiplyScalar(-1).addScaledVector(UP, lerp(-0.55, -0.62, handIk)).addScaledVector(side, 0.5 * handIk).addScaledVector(forward, lerp(0.16, -0.08, handIk)).normalize();
+  const liveGripUp = UP.clone().multiplyScalar(lerp(-1.0, 0.12, handIk)).addScaledVector(side, lerp(-0.64, -0.04, handIk)).addScaledVector(forward, lerp(0.2, -0.48, handIk)).normalize();
+  const lockedRightElbow = rightShoulder.clone()
+    .addScaledVector(UP, lerp(0.04, cfg.rightElbowShotRise, t))
+    .addScaledVector(side, lerp(-0.18, cfg.rightElbowShotSide, t))
+    .addScaledVector(forward, lerp(-0.04, cfg.rightElbowShotBack, t));
+  const pullBack = state === 'dragging' ? -cfg.rightStrokePull * (1 - Math.pow(1 - power, 3)) : 0;
+  const pushForward = state === 'striking' ? cfg.rightStrokePush * follow : 0;
+  const smallPractice = state === 'dragging' ? stroke * 0.035 : 0;
+  const forearmStroke = pullBack + pushForward + smallPractice;
+  const forearmBase = lockedRightElbow.clone()
+    .addScaledVector(side, cfg.rightForearmOutward * t)
+    .addScaledVector(UP, -cfg.rightForearmDown * t)
+    .addScaledVector(UP, cfg.rightHandShotLift * t)
+    .addScaledVector(forward, -cfg.rightForearmBack * t)
+    .addScaledVector(cueDirForHand, cfg.rightForearmLength);
+  const liveCueGripPoint = forearmBase.clone().addScaledVector(cueDirForHand, forearmStroke);
   const idleWristTarget = frameData.idleRight.clone().sub(cueSocketOffsetWorld(idleGripSide, idleGripUp, cueDirForHand, cfg.rightHandRollIdle, cfg.rightHandCueSocketLocal));
   const liveWristTarget = liveCueGripPoint.clone().sub(cueSocketOffsetWorld(liveGripSide, liveGripUp, cueDirForHand, lerp(cfg.rightHandRollIdle, cfg.rightHandRollShoot - (cfg.rightHandDownPose ?? 0), handIk), cfg.rightHandCueSocketLocal));
   const rightHand = idleWristTarget.clone().lerp(liveWristTarget, t);
   const leftElbow = leftShoulder.clone().lerp(leftHand, 0.62).addScaledVector(UP, 0.006 * t).addScaledVector(side, -0.044 * t).addScaledVector(forward, 0.065 * t);
-  const rightElbow = rightHand.clone().addScaledVector(UP, lerp(0.12, cfg.rightElbowShotRise, t)).addScaledVector(side, lerp(-0.18, cfg.rightElbowShotSide, t)).addScaledVector(forward, lerp(-0.04, cfg.rightElbowShotBack, t));
+  const rightElbow = lockedRightElbow;
   const leftKnee = leftHip.clone().lerp(leftFoot, 0.53).addScaledVector(UP, lerp(0.2, cfg.kneeBendShot, t)).addScaledVector(forward, 0.04 * t).addScaledVector(side, -0.012 * t);
   const rightKnee = rightHip.clone().lerp(rightFoot, 0.52).addScaledVector(UP, lerp(0.2, cfg.kneeBendShot * 0.88, t)).addScaledVector(forward, -0.03 * t).addScaledVector(side, 0.014 * t);
   human.root.visible = true;


### PR DESCRIPTION
### Motivation

- Ensure human shooter enters `aim` mode when an explicit aim state exists and make the hand/cue grip calculation more robust for realistic poses.
- Replace brittle ad-hoc grip offsets with a dedicated forearm model to improve stroke animation and elbow locking.

### Description

- Added `hasAim` to the aiming condition in `PoolRoyale.jsx` so a human shooter will enter `aim` mode when explicit aim input is present by checking `hasAim` alongside existing camera/slider conditions.  
- Simplified the computed `gripTarget` in `PoolRoyale.jsx` to use only the cue shooting direction offset (`cueShootDir`), removing several hard-coded world offsets that conflicted with the refined rig model.  
- Reworked `snookerHumanRig.js` configuration and arm IK by replacing several small hand-offset params with a forearm-based parameter set (`rightForearmOutward`, `rightForearmBack`, `rightForearmDown`, `rightForearmLength`, `rightStrokePull`, `rightStrokePush`, `rightHandShotLift`) and adjusted elbow pose constants.  
- Implemented `lockedRightElbow`, `forearmBase`, and `forearmStroke` calculations and recomputed `liveCueGripPoint` from the forearm model, and updated `liveGripSide`/`liveGripUp` to match the new pose system, finally driving the rig with the new `rightElbow` and grip targets.

### Testing

- Ran the project test suite with `yarn test` and all unit tests completed successfully.  
- Ran the linter with `yarn lint` and reported no new linting errors.  
- Built the front-end with `yarn build` to validate bundling and the production compile, and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f82f4a97d08329a8ee93d4389f7db3)