### PR TITLE
Adjust Ludo first-person camera to eye-level

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -3243,7 +3243,8 @@ const SEATED_HELPER_CONTACT_RIGHT = -0.016 * MODEL_SCALE;
 const SEATED_HELPER_CONTACT_UP = -0.014 * MODEL_SCALE;
 const SEATED_HELPER_CONTACT_FORWARD = 0.102 * MODEL_SCALE;
 const SEATED_HELPER_FACE_CAMERA_RIGHT = 0;
-const SEATED_HELPER_FACE_CAMERA_UP = 0.062 * MODEL_SCALE;
+// Lift first-person camera anchor so viewpoint aligns at eye level on portrait screens.
+const SEATED_HELPER_FACE_CAMERA_UP = 0.082 * MODEL_SCALE;
 // Move camera anchor to the face-front side so the local player's head stays out of portrait framing.
 const SEATED_HELPER_FACE_CAMERA_FORWARD = -0.098 * MODEL_SCALE;
 const SEATED_CONTACT_IK_ITERATIONS = 7;


### PR DESCRIPTION
### Motivation
- Ensure the first-person camera sits at the character's eye level on portrait/mobile screens so the viewpoint reads more naturally during seated gameplay.

### Description
- Raised the seated face-camera anchor in `webapp/src/pages/Games/LudoBattleRoyal.jsx` by changing `SEATED_HELPER_FACE_CAMERA_UP` from `0.062 * MODEL_SCALE` to `0.082 * MODEL_SCALE` and added an inline comment explaining the intent.

### Testing
- No automated tests were run for this change because it is a small camera-tuning constant update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f88861e34c83299e8d47d4870ff340)