### PR TITLE
Add world scaling and adjust physics, camera, and serve behavior for scaled world

### DIFF
--- a/webapp/src/pages/Games/Tennis.tsx
+++ b/webapp/src/pages/Games/Tennis.tsx
@@ -107,29 +107,32 @@ const Y_AXIS = UP;
 
 const TENNIS_HDRI_OPTION_IDS = Object.freeze(["suburbanGarden","countryTrackMidday","autumnPark","rooitouPark","rotesRathaus","veniceDawn2","piazzaSanMarco"]);
 
+const WORLD_SCALE = 1.2;
+
 const CFG = {
-  courtW: 7.45,
-  doublesW: 8.9,
-  courtL: 19.8,
-  serviceLineZ: 3.65,
-  netH: 0.78,
-  ballR: 0.1,
+  worldScale: WORLD_SCALE,
+  courtW: 7.45 * WORLD_SCALE,
+  doublesW: 8.9 * WORLD_SCALE,
+  courtL: 19.8 * WORLD_SCALE,
+  serviceLineZ: 3.65 * WORLD_SCALE,
+  netH: 0.78 * WORLD_SCALE,
+  ballR: 0.1 * WORLD_SCALE,
   gravity: 9.8,
   airDrag: 0.078,
   bounceRestitution: 0.74,
   groundFriction: 0.86,
-  minBallSpeed: 0.12,
-  playerHeight: 2.2,
-  playerSpeed: 7.1,
-  aiSpeed: 9.8,
-  reach: 1.45,
+  minBallSpeed: 0.12 * WORLD_SCALE,
+  playerHeight: 2.2 * WORLD_SCALE,
+  playerSpeed: 7.1 * WORLD_SCALE,
+  aiSpeed: 9.8 * WORLD_SCALE,
+  reach: 1.45 * WORLD_SCALE,
   swingDuration: 0.38,
   serveDuration: 0.86,
   hitWindowStart: 0.42,
   hitWindowEnd: 0.72,
   serveContactT: 0.72,
   playerVisualYawFix: Math.PI,
-  serveNearBaselineZ: 8.2,
+  serveNearBaselineZ: 8.2 * WORLD_SCALE,
 };
 
 const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v));
@@ -711,11 +714,16 @@ function serveTossPosition(player: HumanRig, tRaw: number) {
 
 function serveContactPosition(player: HumanRig) {
   const { forward, right } = baseVectors(player);
-  return player.pos.clone().addScaledVector(right, 0.16).addScaledVector(forward, 0.52).setY(2.22);
+  return player.pos.clone().addScaledVector(right, 0.16).addScaledVector(forward, 0.52).setY(2.22 * CFG.worldScale);
+}
+
+function serveReadyBallPosition(player: HumanRig) {
+  const { forward, right } = baseVectors(player);
+  return player.pos.clone().addScaledVector(right, -0.14).addScaledVector(forward, 0.26).setY(1.12 * CFG.worldScale);
 }
 
 function resetBallForServe(ball: BallState, near: HumanRig) {
-  ball.pos.copy(serveTossPosition(near, 0));
+  ball.pos.copy(serveReadyBallPosition(near));
   ball.vel.set(0, 0, 0);
   ball.spin = 0;
   ball.lastHitBy = null;
@@ -777,7 +785,8 @@ function updatePoseAndRacket(player: HumanRig, ball: BallState) {
 
 function ballisticVelocity(from: THREE.Vector3, target: THREE.Vector3, power: number, serve = false) {
   const flatDist = Math.hypot(target.x - from.x, target.z - from.z);
-  const baseSpeed = serve ? 10.4 + power * 5.8 : 7.6 + power * 4.6;
+  const speedScale = CFG.worldScale * 1.22;
+  const baseSpeed = (serve ? 10.4 + power * 5.8 : 7.6 + power * 4.6) * speedScale;
   const flight = clamp(flatDist / baseSpeed, serve ? 0.42 : 0.58, serve ? 0.92 : 1.22);
   return new THREE.Vector3(
     (target.x - from.x) / flight,
@@ -789,7 +798,7 @@ function ballisticVelocity(from: THREE.Vector3, target: THREE.Vector3, power: nu
 function makeUserTargetFromSwipe(startX: number, startY: number, endX: number, endY: number, isServe: boolean) {
   const dx = endX - startX;
   const dy = endY - startY;
-  const power = clamp(Math.hypot(dx, dy) / 165, isServe ? 0.6 : 0.24, 1);
+  const power = clamp(Math.hypot(dx, dy) / 155, isServe ? 0.78 : 0.38, 1);
   const aimX = clamp((dx / 140) * (CFG.courtW / 2), -CFG.courtW / 2 + 0.42, CFG.courtW / 2 - 0.42);
   const upward = clamp((-dy + 40) / 230, 0, 1);
   const targetZ = isServe ? lerp(-1.0, -CFG.serviceLineZ + 0.22, upward) : lerp(-1.15, -CFG.courtL / 2 + 0.88, upward);
@@ -958,8 +967,8 @@ export default function MobileThreeTennisPrototype() {
     scene.fog = null;
 
     const camera = new THREE.PerspectiveCamera(44, 1, 0.05, 70);
-    const cameraTarget = new THREE.Vector3(0, 0.95, -1.45);
-    const cameraOffset = new THREE.Vector3(0, 4.95, 7.7);
+    const cameraTarget = new THREE.Vector3(0, 0.95 * CFG.worldScale, -1.45 * CFG.worldScale);
+    const cameraOffset = new THREE.Vector3(0, 4.95 * CFG.worldScale, 7.7 * CFG.worldScale);
     const cameraPosTarget = new THREE.Vector3();
 
     scene.add(new THREE.AmbientLight(0xffffff, 0.62));
@@ -1060,8 +1069,8 @@ export default function MobileThreeTennisPrototype() {
       renderer.setPixelRatio(Math.min(2, window.devicePixelRatio || 1));
       camera.aspect = w / h;
       camera.fov = camera.aspect < 0.72 ? 52 : 46;
-      if (camera.aspect < 0.72) cameraOffset.set(0, 5.45, 8.55);
-      else cameraOffset.set(0, 4.95, 7.7);
+      if (camera.aspect < 0.72) cameraOffset.set(0, 5.45 * CFG.worldScale, 8.55 * CFG.worldScale);
+      else cameraOffset.set(0, 4.95 * CFG.worldScale, 7.7 * CFG.worldScale);
       cameraPosTarget.copy(nearPlayer.target).add(cameraOffset);
       camera.position.copy(cameraPosTarget);
       camera.lookAt(cameraTarget);
@@ -1116,10 +1125,21 @@ export default function MobileThreeTennisPrototype() {
     resize();
 
     function updateServeTossLock() {
-      const serving = nearPlayer.action === "serve" && nearPlayer.swingT > 0 && !nearPlayer.hitThisSwing && ball.lastHitBy === null;
+      if (ball.lastHitBy !== null) return false;
+      const preparingServe = nearPlayer.action === "ready" || nearPlayer.swingT <= 0;
+      if (preparingServe) {
+        ball.pos.copy(serveReadyBallPosition(nearPlayer));
+        ball.vel.set(0, 0, 0);
+        ball.spin = 0;
+        ball.mesh.position.copy(ball.pos);
+        return true;
+      }
+      const serving = nearPlayer.action === "serve" && nearPlayer.swingT > 0 && !nearPlayer.hitThisSwing;
       if (!serving) return false;
       if (nearPlayer.swingT < CFG.serveContactT) {
         ball.pos.copy(serveTossPosition(nearPlayer, nearPlayer.swingT));
+        ball.vel.set(0, 0, 0);
+        ball.spin = 0;
         ball.mesh.position.copy(ball.pos);
         return true;
       }
@@ -1261,7 +1281,7 @@ export default function MobileThreeTennisPrototype() {
       cameraPosTarget.copy(nearPlayer.target).add(cameraOffset);
       camera.position.lerp(cameraPosTarget, 1 - Math.exp(-5.5 * dt));
       cameraTarget.x += (nearPlayer.target.x - cameraTarget.x) * (1 - Math.exp(-5.2 * dt));
-      cameraTarget.z += ((nearPlayer.target.z - 6.9) - cameraTarget.z) * (1 - Math.exp(-4.3 * dt));
+      cameraTarget.z += ((nearPlayer.target.z - 6.9 * CFG.worldScale) - cameraTarget.z) * (1 - Math.exp(-4.3 * dt));
       updateBillboards(now * 0.001);
       camera.lookAt(cameraTarget);
       renderer.render(scene, camera);


### PR DESCRIPTION
### Motivation

- Introduce a single world scale so the tennis scene, physics, and camera can be uniformly resized.
- Ensure serve toss/ready ball positioning and physics stay correct after scaling.
- Tweak input power mapping and ballistic speed to better match the scaled scene.

### Description

- Add `WORLD_SCALE` and expose it as `CFG.worldScale`, and multiply court dimensions, ball radius, player sizes, speeds, reach and other spatial constants by the world scale.
- Adjust physics/speed calculations by applying a `speedScale` in `ballisticVelocity`, and scale the `serveContactPosition` Y coordinate and camera `cameraTarget`/`cameraOffset`/resize offsets by `CFG.worldScale`.
- Add `serveReadyBallPosition` and use it in `resetBallForServe` and in the updated `updateServeTossLock` logic to place and lock the ready ball (zeroing velocity/spin) while preparing a serve; also ensure toss behavior zeros velocity/spin during toss stage.
- Slightly adjust the swipe-to-target power computation in `makeUserTargetFromSwipe` (divisor/clamp tweaks) to match scaled interactions.

### Testing

- Ran project build (`yarn build`) which completed successfully with TypeScript compilation passing.
- Ran automated test suite (`yarn test`) where available, and tests completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f89c25e8508329bcead5ffda90daae)