### PR TITLE
Refine human cue pose and IK for idle vs shooting states

### DIFF
--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -25298,23 +25298,23 @@ const shotPowerRef = useRef(0);
               .setY(TABLE_Y + TABLE.THICK + 0.009);
             const bridgeCuePoint = bridgeTarget
               .clone()
-              .addScaledVector(aimForward, 0.01)
+              .addScaledVector(aimForward, 0.014)
               .add(new THREE.Vector3(0, HUMAN_BRIDGE_CUE_LIFT, 0));
-            const cueTip = cueWorld
+            const cueTipShoot = cueWorld
               .clone()
               .addScaledVector(aimForward, -cueBallGap)
               .setY(bridgeTarget.y + HUMAN_BRIDGE_CUE_LIFT - 0.004);
-            const cueBack = bridgeCuePoint
+            const cueBackShoot = bridgeCuePoint
               .clone()
               .addScaledVector(aimForward, -(HUMAN_CUE_LENGTH - HUMAN_BRIDGE_DIST - BALL_R - cueBallGap))
               .add(new THREE.Vector3(0, 0.024, 0));
-            const cueShootDir = cueTip.clone().sub(cueBack).normalize();
-            const gripTarget = cueBack
+            const cueShootDir = cueTipShoot.clone().sub(cueBackShoot).normalize();
+            const shootGripTarget = cueBackShoot
               .clone()
               .addScaledVector(cueShootDir, 0.58);
             if (isHumanShooter && state === 'dragging') {
               activeHumanCueViewRef.current = {
-                cueBack: cueBack.clone(),
+                cueBack: cueBackShoot.clone(),
                 bridgeTarget: bridgeTarget.clone(),
                 aimForward: aimForward.clone(),
                 side: side.clone()
@@ -25323,10 +25323,18 @@ const shotPowerRef = useRef(0);
             const standingYaw = Math.atan2(-aimForward.x, -aimForward.z);
             const idleRight = walkRoot
               .clone()
-              .add(new THREE.Vector3(0.24, 1.1, 0.02).applyAxisAngle(new THREE.Vector3(0, 1, 0), standingYaw));
+              .add(new THREE.Vector3(0.31, 0.8, -0.015).applyAxisAngle(new THREE.Vector3(0, 1, 0), standingYaw));
             const idleLeft = walkRoot
               .clone()
               .add(new THREE.Vector3(-0.18, 1.08, 0.03).applyAxisAngle(new THREE.Vector3(0, 1, 0), standingYaw));
+            const idleCueDir = new THREE.Vector3(0.055, 0.965, -0.13)
+              .applyAxisAngle(new THREE.Vector3(0, 1, 0), standingYaw)
+              .normalize();
+            const idleCueBack = idleRight.clone().addScaledVector(idleCueDir, -0.24);
+            const idleCueTip = idleRight.clone().addScaledVector(idleCueDir, HUMAN_CUE_LENGTH - 0.24);
+            const cueBack = state === 'idle' ? idleCueBack : cueBackShoot;
+            const cueTip = state === 'idle' ? idleCueTip : cueTipShoot;
+            const gripTarget = state === 'idle' ? idleRight : shootGripTarget;
             const isFiniteVec3 = (v) =>
               Number.isFinite(v?.x) && Number.isFinite(v?.y) && Number.isFinite(v?.z);
             if (

--- a/webapp/src/pages/Games/shared/bilardoHumanRig.js
+++ b/webapp/src/pages/Games/shared/bilardoHumanRig.js
@@ -32,6 +32,7 @@ const CFG = {
   rightHandRollShoot: -2.05,
   rightHandDownPose: 0.42,
   rightHandCueSocketLocal: new THREE.Vector3(-0.004, -0.014, 0.092),
+  idleCueDir: new THREE.Vector3(0.055, 0.965, -0.13),
   footGroundY: 0.035,
   kneeBendShot: 0.16,
   footLockStrength: 1.0,
@@ -253,7 +254,7 @@ function driveHuman(human, frame) {
   const ik = easeInOut(clamp01(frame.t));
   const idle = 1 - ik;
   const cueDir = frame.cueTipWorld.clone().sub(frame.cueBackWorld).normalize();
-  const standingCueDir = new THREE.Vector3(0.055, 0.965, -0.13).applyAxisAngle(Y_AXIS, human.yaw).normalize();
+  const standingCueDir = (human.cfg?.idleCueDir || CFG.idleCueDir).clone().applyAxisAngle(Y_AXIS, human.yaw).normalize();
   const shotQ = makeBasisQuaternion(frame.side, UP, frame.forward);
 
   if (frame.walkAmount * idle > 0.001) {
@@ -285,11 +286,13 @@ function driveHuman(human, frame) {
   }
 
   const rightGrip = frame.rightHandWorld.clone();
-  const rightIdleElbow = rightGrip.clone().addScaledVector(UP, 0.1 + 0.28 * ik).addScaledVector(frame.side, -0.22 - 0.04 * ik).addScaledVector(frame.forward, -0.03 * idle);
-  const rightElbow = frame.rightElbow.clone().lerp(rightIdleElbow, idle * 0.52);
-  const rightHold = 0.88 + 0.12 * ik;
-  const rightArmPole = UP.clone().multiplyScalar(1.32).addScaledVector(frame.side, -0.62).addScaledVector(frame.forward, -1.05).normalize();
-  aimTwoBone(b.rightUpperArm, b.rightLowerArm, rightElbow, rightGrip, rightArmPole, rightHold, rightHold);
+  const rightIdleElbow = rightGrip.clone()
+    .addScaledVector(UP, 0.04 + 0.14 * ik)
+    .addScaledVector(frame.side, -0.2)
+    .addScaledVector(frame.forward, -0.03 * idle);
+  const rightElbow = frame.rightElbow.clone().lerp(rightIdleElbow, idle * 0.5);
+  const pole = frame.side.clone().multiplyScalar(-1).addScaledVector(UP, 0.32).addScaledVector(frame.forward, -0.55).normalize();
+  aimTwoBone(b.rightUpperArm, b.rightLowerArm, rightElbow, rightGrip, pole, 0.9 + 0.1 * ik, 1.0);
 
   const standingHandSide = frame.side.clone().multiplyScalar(-1).addScaledVector(UP, -0.55).addScaledVector(frame.forward, 0.16).normalize();
   const standingHandUp = UP.clone().multiplyScalar(-1.0).addScaledVector(frame.side, -0.64).addScaledVector(frame.forward, 0.2).normalize();
@@ -348,10 +351,10 @@ export function updateBilardoHumanPose(human, dt, frameData) {
   const power = frameData.power ?? 0; const stroke = state === 'dragging' ? Math.sin(performance.now() * 0.011) * (0.25 + power * 0.75) : 0; const follow = state === 'striking' ? Math.sin(clamp01(human.strikeClock / (cfg.strikeTime + cfg.holdTime)) * Math.PI) : 0;
   const forward = new THREE.Vector3(0, 0, -1).applyAxisAngle(Y_AXIS, human.yaw).normalize(); const side = new THREE.Vector3(forward.z, 0, -forward.x).normalize(); const local = (v) => v.clone().applyAxisAngle(Y_AXIS, human.yaw).add(human.root.position); const powerLean = power * t;
   const rootWorld = human.root.position.clone().addScaledVector(forward, 0.018 * powerLean + 0.026 * follow);
-  const torso = local(new THREE.Vector3(0, lerp(1.3, 1.12, t) + breath, lerp(0.02, -0.16, t) - 0.014 * powerLean));
-  const chest = local(new THREE.Vector3(0, lerp(1.52, 1.22, t) + breath, lerp(0.02, -0.42, t) - 0.024 * powerLean));
-  const neck = local(new THREE.Vector3(0, lerp(1.68, 1.25, t) + breath, lerp(0.02, -0.61, t) - 0.028 * powerLean));
-  const head = local(new THREE.Vector3(0, lerp(1.84, 1.34, t) + breath - cfg.chinToCueHeight * 0.16 * t, lerp(0.04, -0.72, t) - 0.028 * powerLean));
+  const torso = local(new THREE.Vector3(0, lerp(1.3, 1.14, t) + breath, lerp(0.02, -0.16, t) - 0.014 * powerLean));
+  const chest = local(new THREE.Vector3(0, lerp(1.52, 1.24, t) + breath, lerp(0.02, -0.42, t) - 0.024 * powerLean));
+  const neck = local(new THREE.Vector3(0, lerp(1.68, 1.28, t) + breath, lerp(0.02, -0.61, t) - 0.028 * powerLean));
+  const head = local(new THREE.Vector3(0, lerp(1.84, 1.37, t) + breath - cfg.chinToCueHeight * 0.16 * t, lerp(0.04, -0.72, t) - 0.028 * powerLean));
   const leftShoulder = local(new THREE.Vector3(-0.23, lerp(1.58, 1.36, t) + breath, lerp(0, -0.46, t) - 0.018 * human.settleT));
   const rightShoulder = local(new THREE.Vector3(0.23, lerp(1.58, 1.36, t) + breath, lerp(0, -0.34, t) - 0.018 * human.settleT));
   const leftHip = local(new THREE.Vector3(-0.13, 0.92, 0.02)); const rightHip = local(new THREE.Vector3(0.13, 0.92, 0.02));


### PR DESCRIPTION
### Motivation
- Improve visual consistency of the player model by separating idle and shooting cue poses and adjusting hand/arm IK so the cue sits naturally in both states.
- Reduce snapping/artifacts caused by reusing the same cue back/tip vectors for different states and allow per-config idle cue direction.
- Fine-tune torso/head offsets and elbow/pole parameters to get more natural posture during aiming and walking.

### Description
- PoolRoyale.jsx: split cue tip/back computation into `cueTipShoot`/`cueBackShoot` for the shooting path and added idle cue geometry (`idleCueDir`, `idleCueBack`, `idleCueTip`) so `cueBack`/`cueTip`/`gripTarget` are chosen per `state` (`idle` vs shoot). 
- PoolRoyale.jsx: adjusted bridge cue offset from `0.01` to `0.014` and tweaked idle hand/root offsets used for the idle pose.
- bilardoHumanRig.js: added `CFG.idleCueDir` to the configuration and use `human.cfg?.idleCueDir` for the standing cue direction fallback in `driveHuman`.
- bilardoHumanRig.js: revised right-arm IK setup by changing idle elbow offsets, recomputing the IK pole vector, and adjusting `aimTwoBone` parameters to improve elbow placement and hand orientation.
- bilardoHumanRig.js: small adjustments to torso/chest/neck/head target heights to better match the new cue/pose geometry.

### Testing
- Ran the project's unit test suite with `yarn test`, which completed successfully. 
- Built the webapp with `yarn build` to verify there are no compile-time errors, and the build succeeded. 
- Ran `eslint`/static checks on the modified files and they passed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9563632bc8329bf35914ba97e58c9)