### PR TITLE
Increase opponent held-card outward offset in Murlan Royale

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1779,7 +1779,7 @@ function computeHeldCardsPose({ player, resolvedSeatIndex = 0 }) {
   // so they sit closer to the avatar/chest area in portrait framing.
   const sideSeatLift = isSideSeat ? 132.5 * MODEL_SCALE : 0;
   const topSeatLift = isTopSeat ? 144.5 * MODEL_SCALE : 0;
-  const nonBottomOutwardPush = !isBottomHumanSeat ? -153.5 * MODEL_SCALE : 0;
+  const nonBottomOutwardPush = !isBottomHumanSeat ? -186.5 * MODEL_SCALE : 0;
   const bottomForwardPull = isBottomHumanSeat ? -32.5 * MODEL_SCALE : 0;
   const sideSeatLateralPull =
     isSideSeat


### PR DESCRIPTION
### Motivation
- Make non-human players' held cards sit further outward from the table center in portrait framing so opponent hands read more clearly and don't overlap the table/avatars.

### Description
- Adjusted the `nonBottomOutwardPush` value in `computeHeldCardsPose` inside `webapp/src/pages/Games/MurlanRoyaleArena.jsx` from `-153.5 * MODEL_SCALE` to `-186.5 * MODEL_SCALE` to push opponent cards farther outward while leaving the bottom human seat behavior unchanged.

### Testing
- Ran `npx eslint webapp/src/pages/Games/MurlanRoyaleArena.jsx` and `npx eslint --no-ignore webapp/src/pages/Games/MurlanRoyaleArena.jsx`, both completed with no lint errors (the repo ignore setting produced a warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f957515dc88329b082e84363515566)