### PR TITLE
Adjust FPV camera, pointer handling, and layout scaling for Chess Battle Royale

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -363,8 +363,8 @@ const BOARD = { N: 8, tile: 4.2, rim: 3, baseH: 0.8 };
 const PIECE_Y = 1.2; // baseline height for meshes
 const PIECE_PLACEMENT_Y_OFFSET = 0.24; // Lower tokens slightly so they stay grounded on the board after shrinking.
 const LAYOUT_SCALE_FACTOR = 0.7225;
-const TABLE_LAYOUT_SCALE_FACTOR = 0.58; // Keep the same table/board/chair proportions, but ~22% smaller than current.
-const PIECE_SCALE_FACTOR = 0.73 * LAYOUT_SCALE_FACTOR * 1.5 * 0.85; // Shrink tokens by 15% while preserving the existing style proportions.
+const TABLE_LAYOUT_SCALE_FACTOR = 0.5; // Keep the same table/board/chair proportions, but ~22% smaller than current.
+const PIECE_SCALE_FACTOR = 0.73 * LAYOUT_SCALE_FACTOR * 1.5 * 0.78; // Shrink tokens by 15% while preserving the existing style proportions.
 const PIECE_FOOTPRINT_RATIO = 0.86;
 const BOARD_GROUP_Y_OFFSET = 0.05;
 const BOARD_MODEL_Y_OFFSET = -0.12;
@@ -406,9 +406,9 @@ const CHAIR_SCALE = 0.96 * LAYOUT_SCALE_FACTOR * TABLE_LAYOUT_SCALE_FACTOR;
 const CHAIR_WIDTH_SCALE = 1.1; // Slightly widen/deepen chairs so they read larger in portrait.
 const CHAIR_VERTICAL_OFFSET = -0.065 * MODEL_SCALE;
 const CHAIR_CLEARANCE = AI_CHAIR_GAP;
-const PLAYER_CHAIR_EXTRA_CLEARANCE = -0.082 * MODEL_SCALE; // Keep local chair close so legs visually approach the table edge.
-const OPPONENT_CHAIR_EXTRA_CLEARANCE = -0.058 * MODEL_SCALE; // Keep opponent chair close too, with only a small gap.
-const CHAIR_TABLE_PUSHBACK = 0.04 * MODEL_SCALE;
+const PLAYER_CHAIR_EXTRA_CLEARANCE = -0.12 * MODEL_SCALE; // Keep local chair close so legs visually approach the table edge.
+const OPPONENT_CHAIR_EXTRA_CLEARANCE = -0.1 * MODEL_SCALE; // Keep opponent chair close too, with only a small gap.
+const CHAIR_TABLE_PUSHBACK = -0.01 * MODEL_SCALE;
 const CHAIR_TABLE_GAP_MIN = 0.08 * MODEL_SCALE;
 const CHAIR_TABLE_GAP_MAX = 0.42 * MODEL_SCALE;
 const CHAIR_TABLE_SHAPE_BIAS = 0.18 * MODEL_SCALE;
@@ -456,10 +456,11 @@ const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_PORTRAIT = 1.94;
 const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_LANDSCAPE = 0.78;
 const PLAYER_VIEW_LOOK_TARGET_FORWARD_BIAS = -BOARD.tile * BOARD_SCALE * 0.42;
 const TABLE_BOTTOM_PLAYER_BIAS_Z = BOARD.tile * BOARD_SCALE * 1.84; // Push board/chairs/avatars further downward on portrait screens to match the reference framing.
-const FPV_FACE_FORWARD_OFFSET = 0.012; // keep camera very close and centered in front of the face.
-const FPV_FACE_UP_OFFSET = -0.003; // tiny vertical lift to avoid clipping while staying face-level.
-const FPV_HEAD_FOLLOW_SMOOTHING = 0.78;
-const FPV_BOB_AMPLITUDE = 0.004;
+const FPV_FACE_FORWARD_OFFSET = 0.0015; // keep camera very close and centered in front of the face.
+const FPV_FACE_UP_OFFSET = 0; // tiny vertical lift to avoid clipping while staying face-level.
+const FPV_HEAD_FOLLOW_SMOOTHING = 1;
+const FPV_BOB_AMPLITUDE = 0;
+const FPV_BASE_PITCH_BIAS = -0.16; // tilt camera slightly upward by default so the board/opponent stay centered like portrait reference.
 const SEATED_HUMAN_MOVE_DURATION_MS = 520; // Slightly longer to keep finger contact readable during pickup/carry/place.
 const SEATED_HUMAN_PICKUP_PHASE_END = 0.24;
 const SEATED_HUMAN_CARRY_PHASE_END = 0.8;
@@ -2634,12 +2635,12 @@ const BOARD_SURFACE_OFFSETS_BY_SHAPE = Object.freeze({
   diamondEdge: 0.024
 });
 const LOWER_PROFILE_TABLE_SHAPE_IDS = new Set(['classicOctagon', 'hexagonTable', 'grandOval', 'diamondEdge']);
-const LOWER_PROFILE_TABLE_HEIGHT_DELTA = 0;
-const SIDE_PARKED_AIRCRAFT_SCALE_MULTIPLIER = 17.5; // keep side parking weapons realistic beside seated humans
+const LOWER_PROFILE_TABLE_HEIGHT_DELTA = 0.06 * MODEL_SCALE;
+const SIDE_PARKED_AIRCRAFT_SCALE_MULTIPLIER = 13.8; // keep side parking weapons realistic beside seated humans
 const SIDE_PARKED_AIR_UNITS_INWARD_OFFSET = -2.2; // push parked vehicles much farther to the sides
 const SIDE_PARKED_AIR_UNITS_BOARD_LEVEL_LIFT = 0.26; // lift pad markers/parked units from floor to board/table level
 const SIDE_PARKED_AIR_UNITS_LANE_SPREAD = 1.92; // increase spacing between parking slots
-const SIDE_PARKED_TRUCK_SCALE_MULTIPLIER = 1.06; // keep truck close to true-size relative to helicopter shell
+const SIDE_PARKED_TRUCK_SCALE_MULTIPLIER = 0.9; // keep truck close to true-size relative to helicopter shell
 
 function getTableHeightForShape(shapeId) {
   if (LOWER_PROFILE_TABLE_SHAPE_IDS.has(shapeId)) {
@@ -7809,7 +7810,9 @@ function Chess3D({
     pitch: 0,
     targetYaw: 0,
     targetPitch: 0,
-    bobTime: 0
+    bobTime: 0,
+    lastPointerX: null,
+    lastPointerY: null
   });
   const [graphicsId, setGraphicsId] = useState(() => {
     const fallback = resolveDefaultGraphicsId();
@@ -13032,7 +13035,10 @@ function Chess3D({
 
     const onPointerDown = (event) => {
       if (viewModeRef.current === 'fpv') {
-        firstPersonViewRef.current.activeLook = true;
+        const fp = firstPersonViewRef.current;
+        fp.activeLook = true;
+        fp.lastPointerX = Number.isFinite(event.clientX) ? event.clientX : null;
+        fp.lastPointerY = Number.isFinite(event.clientY) ? event.clientY : null;
         return;
       }
       if (isReplayingRef.current) return;
@@ -13060,8 +13066,20 @@ function Chess3D({
       if (viewModeRef.current === 'fpv') {
         const fp = firstPersonViewRef.current;
         if (fp.activeLook) {
-          fp.targetYaw -= (event.movementX || 0) * 0.0024;
-          fp.targetPitch = clamp(fp.targetPitch - (event.movementY || 0) * 0.002, -0.6, 0.5);
+          const deltaX = Number.isFinite(event.movementX) && event.movementX !== 0
+            ? event.movementX
+            : (Number.isFinite(event.clientX) && Number.isFinite(fp.lastPointerX)
+              ? event.clientX - fp.lastPointerX
+              : 0);
+          const deltaY = Number.isFinite(event.movementY) && event.movementY !== 0
+            ? event.movementY
+            : (Number.isFinite(event.clientY) && Number.isFinite(fp.lastPointerY)
+              ? event.clientY - fp.lastPointerY
+              : 0);
+          fp.targetYaw -= deltaX * 0.0024;
+          fp.targetPitch = clamp(fp.targetPitch - deltaY * 0.002, -0.46, 0.78);
+          fp.lastPointerX = Number.isFinite(event.clientX) ? event.clientX : fp.lastPointerX;
+          fp.lastPointerY = Number.isFinite(event.clientY) ? event.clientY : fp.lastPointerY;
         }
         return;
       }
@@ -13076,6 +13094,8 @@ function Chess3D({
 
     const onPointerUp = (event) => {
       firstPersonViewRef.current.activeLook = false;
+      firstPersonViewRef.current.lastPointerX = null;
+      firstPersonViewRef.current.lastPointerY = null;
       if (viewModeRef.current === 'fpv') return;
       if (isReplayingRef.current) return;
       if (isMoveInteractionLocked()) return;
@@ -13916,7 +13936,8 @@ function Chess3D({
         fpState.yaw = THREE.MathUtils.lerp(fpState.yaw, fpState.targetYaw, 0.18);
         fpState.pitch = THREE.MathUtils.lerp(fpState.pitch, fpState.targetPitch, 0.2);
         localActorEntry.actor.rotation.y = SEATED_HUMAN_FACING_Y + fpState.yaw;
-        addBoneRot(localActorEntry.rig, localActorEntry.rig.head, fpState.pitch * 0.85, 0, 0);
+        const effectivePitch = fpState.pitch + FPV_BASE_PITCH_BIAS;
+        addBoneRot(localActorEntry.rig, localActorEntry.rig.head, effectivePitch * 0.85, 0, 0);
         fpState.bobTime += dt * (2.2 + Math.abs(fpState.targetYaw - fpState.yaw) * 6);
         const bobOffset = Math.sin(fpState.bobTime * 7.2) * FPV_BOB_AMPLITUDE;
         const rig = localActorEntry.rig;


### PR DESCRIPTION
### Motivation
- Improve first-person-view (FPV) camera behavior and stability so the head/face framing and look controls feel better on portrait layouts. 
- Tweak table/chair/piece scales and clearances to better match the intended portrait reference framing and correct relative proportions. 
- Make pointer delta calculations robust for environments where `movementX`/`movementY` are not provided (e.g. touch or some browsers).

### Description
- Adjusted global layout/scale constants including `TABLE_LAYOUT_SCALE_FACTOR`, `PIECE_SCALE_FACTOR`, chair clearances (`PLAYER_CHAIR_EXTRA_CLEARANCE`, `OPPONENT_CHAIR_EXTRA_CLEARANCE`) and `CHAIR_TABLE_PUSHBACK` to change table/chair spacing and proportions. 
- Tuned table shape/side-parked asset scales: set `LOWER_PROFILE_TABLE_HEIGHT_DELTA` to `0.06 * MODEL_SCALE`, reduced `SIDE_PARKED_AIRCRAFT_SCALE_MULTIPLIER` and `SIDE_PARKED_TRUCK_SCALE_MULTIPLIER` to rebalance parked vehicle sizes. 
- Updated FPV constants: changed `FPV_FACE_FORWARD_OFFSET`, `FPV_FACE_UP_OFFSET`, `FPV_HEAD_FOLLOW_SMOOTHING`, `FPV_BOB_AMPLITUDE` and added `FPV_BASE_PITCH_BIAS` to bias the head pitch so board/opponent remain centered in portrait captures. 
- Enhanced FPV pointer handling by adding `lastPointerX`/`lastPointerY` to `firstPersonViewRef`, recording them on pointer down, clearing on pointer up, and computing fallback `deltaX`/`deltaY` from `clientX/clientY` when `movementX/movementY` are not available; also widened/clamped pitch/yaw ranges. 
- Applied the base pitch bias when computing bone rotation for the local actor head via `addBoneRot` so FPV view reflects the new bias.

### Testing
- Ran a production build with `yarn build`, which completed successfully. 
- Executed the unit test suite with `yarn test`, and all tests passed. 
- Ran linting with `yarn lint`, and no lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f957f91c0c83299a35284e936ad09e)