### PR TITLE
Improve tennis AI targeting and implement official-style serving rules

### DIFF
--- a/webapp/src/pages/Games/Tennis.tsx
+++ b/webapp/src/pages/Games/Tennis.tsx
@@ -10,7 +10,7 @@ import { HUMAN_CHARACTER_OPTIONS } from "../../config/ludoBattleOptions.js";
 import { getPoolRoyalInventory } from "../../utils/poolRoyalInventory.js";
 
 type PlayerSide = "near" | "far";
-type PointReason = "winner" | "out" | "doubleBounce" | "net";
+type PointReason = "winner" | "out" | "doubleBounce" | "net" | "serviceFault";
 type StrokeAction = "ready" | "forehand" | "serve";
 
 type BallState = {
@@ -135,6 +135,7 @@ const CFG = {
   serveContactT: 0.72,
   playerVisualYawFix: Math.PI,
   serveNearBaselineZ: 8.2 * WORLD_SCALE,
+  serviceBuffer: 0.28 * WORLD_SCALE,
 };
 
 const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v));
@@ -145,6 +146,27 @@ const easeInOut = (t: number) => t * t * (3 - 2 * t);
 const sideOfZ = (z: number): PlayerSide => (z >= 0 ? "near" : "far");
 const opposite = (side: PlayerSide): PlayerSide => (side === "near" ? "far" : "near");
 
+
+function serviceSideFromPoints(nearScore: number, farScore: number): "deuce" | "ad" {
+  return (nearScore + farScore) % 2 === 0 ? "deuce" : "ad";
+}
+
+function serveXForSide(player: PlayerSide, side: "deuce" | "ad") {
+  const outsideSingles = CFG.courtW / 2 + 0.42;
+  const laneMax = CFG.doublesW / 2 - 0.2;
+  const xAbs = clamp(outsideSingles, CFG.courtW / 2 + 0.12, laneMax);
+  const sign = side === "deuce" ? 1 : -1;
+  return (player === "near" ? sign : -sign) * xAbs;
+}
+
+function isInsideServiceBox(pos: THREE.Vector3, hitter: PlayerSide, side: "deuce" | "ad") {
+  const targetSide = opposite(hitter);
+  const targetRight = side === "deuce";
+  const xOk = targetRight ? pos.x >= 0 + CFG.serviceBuffer : pos.x <= 0 - CFG.serviceBuffer;
+  const xInCourt = Math.abs(pos.x) <= CFG.courtW / 2;
+  const zOk = targetSide === "far" ? pos.z <= -CFG.serviceBuffer && pos.z >= -CFG.serviceLineZ : pos.z >= CFG.serviceBuffer && pos.z <= CFG.serviceLineZ;
+  return xOk && xInCourt && zOk;
+}
 function material(color: number, roughness = 0.74, metalness = 0.02) {
   return new THREE.MeshStandardMaterial({ color, roughness, metalness });
 }
@@ -724,8 +746,12 @@ function serveReadyBallPosition(player: HumanRig) {
   return player.pos.clone().addScaledVector(right, -0.14).addScaledVector(forward, 0.26).setY(1.12 * CFG.worldScale);
 }
 
-function resetBallForServe(ball: BallState, near: HumanRig) {
+function resetBallForServe(ball: BallState, near: HumanRig, serveSide: "deuce" | "ad") {
   ball.pos.copy(serveReadyBallPosition(near));
+  near.pos.x = serveXForSide("near", serveSide);
+  near.target.x = near.pos.x;
+  near.root.position.x = near.pos.x;
+  near.modelRoot.position.x = near.pos.x;
   ball.vel.set(0, 0, 0);
   ball.spin = 0;
   ball.lastHitBy = null;
@@ -814,13 +840,15 @@ function makeUserTargetFromSwipe(startX: number, startY: number, endX: number, e
 }
 
 function makeAiTarget(near: HumanRig, ball: BallState): DesiredHit {
+  const farDefendingWide = Math.abs(ball.pos.x) > CFG.courtW * 0.32;
   const pressure = clamp01((Math.abs(ball.pos.z) - 0.6) / (CFG.courtL / 2 - 0.8));
   const sideRead = clamp((ball.vel.x || 0) * 0.26, -0.5, 0.5);
-  const x = clamp(near.pos.x * 0.72 + sideRead + (Math.random() - 0.5) * 0.75, -CFG.courtW / 2 + 0.35, CFG.courtW / 2 - 0.35);
+  const attackToOpen = farDefendingWide ? -Math.sign(ball.pos.x || 1) * (CFG.courtW * 0.36) : near.pos.x * 0.72;
+  const x = clamp(attackToOpen + sideRead + (Math.random() - 0.5) * 0.58, -CFG.courtW / 2 + 0.35, CFG.courtW / 2 - 0.35);
   const z = lerp(1.2, CFG.courtL / 2 - 0.7, 0.42 + pressure * 0.5);
-  const power = clamp(0.72 + pressure * 0.42 + Math.random() * 0.2, 0.62, 1);
+  const power = clamp(0.66 + pressure * 0.52 + Math.random() * 0.2, 0.56, 1);
   const roll = Math.random();
-  const technique: ShotTechnique = pressure > 0.72 ? "topspin" : roll > 0.66 ? "slice" : roll < 0.22 ? "lob" : "flat";
+  const technique: ShotTechnique = pressure > 0.72 ? "topspin" : roll > 0.62 ? "slice" : "flat";
   return { target: new THREE.Vector3(x, CFG.ballR, z), power, technique };
 }
 
@@ -1030,7 +1058,9 @@ export default function MobileThreeTennisPrototype() {
     const farPlayer = addHuman(scene, "far", new THREE.Vector3(0, 0, -CFG.courtL / 2 + 1.04), 0x62d2ff, aiHuman?.modelUrls?.[0] || HUMAN_URL);
     const ball = createBall();
     scene.add(ball.mesh);
-    resetBallForServe(ball, nearPlayer);
+    let currentServeSide: "deuce" | "ad" = "deuce";
+    let firstServeAttempt = true;
+    resetBallForServe(ball, nearPlayer, currentServeSide);
     let netShakeT = 0;
 
     const ghost = new THREE.Mesh(
@@ -1067,7 +1097,9 @@ export default function MobileThreeTennisPrototype() {
         nearScore: prev.nearScore + (winner === "near" ? 1 : 0),
         farScore: prev.farScore + (winner === "far" ? 1 : 0),
       };
-      const reasonText = reason === "out" ? "Out ball" : reason === "doubleBounce" ? "Double bounce" : reason === "net" ? "Net fault" : "Point";
+      const reasonText = reason === "serviceFault" ? "Service fault" : reason === "out" ? "Out ball" : reason === "doubleBounce" ? "Double bounce" : reason === "net" ? "Net fault" : "Point";
+      firstServeAttempt = true;
+      currentServeSide = serviceSideFromPoints(next.nearScore, next.farScore);
       replayText = `Replay: ${reasonText} by ${winner === "near" ? "You" : "AI"}`;
       replayT = 1.7;
       void crowdFx.play().catch(() => {});
@@ -1116,6 +1148,9 @@ export default function MobileThreeTennisPrototype() {
       const dy = e.clientY - control.startY;
       nearPlayer.target.x = clamp(control.startPlayer.x + dx * 0.012, -CFG.courtW / 2 + 0.35, CFG.courtW / 2 - 0.35);
       const minZ = ball.lastHitBy === null ? CFG.serveNearBaselineZ : 0.76;
+      if (ball.lastHitBy === null) {
+        nearPlayer.target.x = serveXForSide("near", currentServeSide);
+      }
       nearPlayer.target.z = clamp(control.startPlayer.z + dy * 0.012, minZ, CFG.courtL / 2 - 0.42);
       setHudSafe({ power: clamp01(Math.hypot(dx, dy) / 185) });
     };
@@ -1200,6 +1235,22 @@ export default function MobileThreeTennisPrototype() {
             ball.bounceSide = bounceSide;
             ball.bounceCount = 1;
           }
+          const isServeBall = ball.lastHitBy !== null && ball.bounceCount === 1;
+          if (isServeBall && !isInsideServiceBox(ball.pos, ball.lastHitBy, currentServeSide)) {
+            if (firstServeAttempt) {
+              firstServeAttempt = false;
+              pointLock = true;
+              pointLockT = 0.55;
+              setHudSafe({ status: "Fault. Second serve" });
+              nearPlayer.action = "ready";
+              farPlayer.action = "ready";
+              resetBallForServe(ball, nearPlayer, currentServeSide);
+              return;
+            } else {
+              awardPoint(opposite(ball.lastHitBy), "serviceFault");
+              return;
+            }
+          }
           const outsideX = Math.abs(ball.pos.x) > CFG.courtW / 2;
           const outsideZ = Math.abs(ball.pos.z) > CFG.courtL / 2;
           if ((outsideX || outsideZ) && ball.lastHitBy) awardPoint(opposite(ball.lastHitBy), "out");
@@ -1264,7 +1315,7 @@ export default function MobileThreeTennisPrototype() {
           farPlayer.action = "ready";
           nearPlayer.target.set(0, 0, CFG.courtL / 2 - 1.04);
           farPlayer.target.set(0, 0, -CFG.courtL / 2 + 1.04);
-          resetBallForServe(ball, nearPlayer);
+          resetBallForServe(ball, nearPlayer, currentServeSide);
           setHudSafe({ status: "Swipe up to serve", power: 0 });
         }
       } else {


### PR DESCRIPTION
### Motivation
- Make the AI play more like a pro by balancing defensive reads and attacking open court space and by varying power/technique. 
- Make serving follow real-match constraints (deuce/ad service sides, server positioned toward the singles lane) and enforce first/second-serve behavior. 
- Keep serve side rotation deterministic and tied to the score so serve alternation mirrors official tennis flow.

### Description
- Added service helpers and state: `serviceSideFromPoints`, `serveXForSide`, `isInsideServiceBox`, and the serve state flags `currentServeSide` and `firstServeAttempt` in `webapp/src/pages/Games/Tennis.tsx` to compute deuce/ad side and place the server outside the singles lane. 
- Updated `resetBallForServe` to accept `serveSide` and snap the near player X position to the correct serving lane so serves start from the proper outside-lane location. 
- Implemented first-serve fault handling and second-serve behavior by validating the first-bounce with `isInsideServiceBox` and applying a second-serve retry or awarding a `serviceFault` point on a double fault, and reset/snap flow for subsequent serves. 
- Tuned AI shot selection in `makeAiTarget` to detect when the opponent is defending wide, attack open court zones, and adjust power/technique probabilities to produce more pro-like returns.

### Testing
- Built the web app with `npm -C webapp run -s build`, which completed successfully. 
- No additional automated unit tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f95ea03b8c8329bb288969f2d9ac33)