### PR TITLE
Add service/second-serve logic, serve positioning, AI & camera tweaks for tennis prototype

### DIFF
--- a/webapp/src/pages/Games/Tennis.tsx
+++ b/webapp/src/pages/Games/Tennis.tsx
@@ -10,7 +10,7 @@ import { HUMAN_CHARACTER_OPTIONS } from "../../config/ludoBattleOptions.js";
 import { getPoolRoyalInventory } from "../../utils/poolRoyalInventory.js";
 
 type PlayerSide = "near" | "far";
-type PointReason = "winner" | "out" | "doubleBounce" | "net";
+type PointReason = "winner" | "out" | "doubleBounce" | "net" | "serviceFault";
 type StrokeAction = "ready" | "forehand" | "serve";
 
 type BallState = {
@@ -126,7 +126,7 @@ const CFG = {
   minBallSpeed: 0.12 * WORLD_SCALE,
   playerHeight: 2.2 * WORLD_SCALE,
   playerSpeed: 7.1 * WORLD_SCALE,
-  aiSpeed: 9.8 * WORLD_SCALE,
+  aiSpeed: 11.9 * WORLD_SCALE,
   reach: 1.45 * WORLD_SCALE,
   swingDuration: 0.38,
   serveDuration: 0.86,
@@ -135,6 +135,7 @@ const CFG = {
   serveContactT: 0.72,
   playerVisualYawFix: Math.PI,
   serveNearBaselineZ: 8.2 * WORLD_SCALE,
+  serviceBuffer: 0.28 * WORLD_SCALE,
 };
 
 const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v));
@@ -144,6 +145,35 @@ const easeOutCubic = (t: number) => 1 - Math.pow(1 - t, 3);
 const easeInOut = (t: number) => t * t * (3 - 2 * t);
 const sideOfZ = (z: number): PlayerSide => (z >= 0 ? "near" : "far");
 const opposite = (side: PlayerSide): PlayerSide => (side === "near" ? "far" : "near");
+
+
+function serviceSideFromPoints(nearScore: number, farScore: number): "deuce" | "ad" {
+  return (nearScore + farScore) % 2 === 0 ? "deuce" : "ad";
+}
+
+function serveXForSide(player: PlayerSide, side: "deuce" | "ad") {
+  const outsideSingles = CFG.courtW / 2 + 0.42;
+  const laneMax = CFG.doublesW / 2 - 0.2;
+  const xAbs = clamp(outsideSingles, CFG.courtW / 2 + 0.12, laneMax);
+  const sign = side === "deuce" ? 1 : -1;
+  return (player === "near" ? sign : -sign) * xAbs;
+}
+
+function isInsideServiceBox(pos: THREE.Vector3, hitter: PlayerSide, side: "deuce" | "ad") {
+  const targetSide = opposite(hitter);
+  const targetRight = side === "deuce";
+  const xOk = targetRight ? pos.x >= 0 + CFG.serviceBuffer : pos.x <= 0 - CFG.serviceBuffer;
+  const xInCourt = Math.abs(pos.x) <= CFG.courtW / 2;
+  const zOk = targetSide === "far" ? pos.z <= -CFG.serviceBuffer && pos.z >= -CFG.serviceLineZ : pos.z >= CFG.serviceBuffer && pos.z <= CFG.serviceLineZ;
+  return xOk && xInCourt && zOk;
+}
+
+function clampServeLaneX(x: number) {
+  const outer = CFG.doublesW / 2 - 0.16;
+  const inner = CFG.courtW / 2 + 0.2;
+  const abs = clamp(Math.abs(x), inner, outer);
+  return Math.sign(x || 1) * abs;
+}
 
 function material(color: number, roughness = 0.74, metalness = 0.02) {
   return new THREE.MeshStandardMaterial({ color, roughness, metalness });
@@ -724,8 +754,12 @@ function serveReadyBallPosition(player: HumanRig) {
   return player.pos.clone().addScaledVector(right, -0.14).addScaledVector(forward, 0.26).setY(1.12 * CFG.worldScale);
 }
 
-function resetBallForServe(ball: BallState, near: HumanRig) {
+function resetBallForServe(ball: BallState, near: HumanRig, serveSide: "deuce" | "ad") {
   ball.pos.copy(serveReadyBallPosition(near));
+  near.pos.x = clampServeLaneX(serveXForSide("near", serveSide));
+  near.target.x = near.pos.x;
+  near.root.position.x = near.pos.x;
+  near.modelRoot.position.x = near.pos.x;
   ball.vel.set(0, 0, 0);
   ball.spin = 0;
   ball.lastHitBy = null;
@@ -814,13 +848,15 @@ function makeUserTargetFromSwipe(startX: number, startY: number, endX: number, e
 }
 
 function makeAiTarget(near: HumanRig, ball: BallState): DesiredHit {
+  const farDefendingWide = Math.abs(ball.pos.x) > CFG.courtW * 0.32;
   const pressure = clamp01((Math.abs(ball.pos.z) - 0.6) / (CFG.courtL / 2 - 0.8));
   const sideRead = clamp((ball.vel.x || 0) * 0.26, -0.5, 0.5);
-  const x = clamp(near.pos.x * 0.72 + sideRead + (Math.random() - 0.5) * 0.75, -CFG.courtW / 2 + 0.35, CFG.courtW / 2 - 0.35);
+  const attackToOpen = farDefendingWide ? -Math.sign(ball.pos.x || 1) * (CFG.courtW * 0.36) : near.pos.x * 0.72;
+  const x = clamp(attackToOpen + sideRead + (Math.random() - 0.5) * 0.58, -CFG.courtW / 2 + 0.35, CFG.courtW / 2 - 0.35);
   const z = lerp(1.2, CFG.courtL / 2 - 0.7, 0.42 + pressure * 0.5);
-  const power = clamp(0.72 + pressure * 0.42 + Math.random() * 0.2, 0.62, 1);
+  const power = clamp(0.66 + pressure * 0.52 + Math.random() * 0.2, 0.56, 1);
   const roll = Math.random();
-  const technique: ShotTechnique = pressure > 0.72 ? "topspin" : roll > 0.66 ? "slice" : roll < 0.22 ? "lob" : "flat";
+  const technique: ShotTechnique = pressure > 0.72 ? "topspin" : roll > 0.62 ? "slice" : "flat";
   return { target: new THREE.Vector3(x, CFG.ballR, z), power, technique };
 }
 
@@ -882,8 +918,10 @@ function updatePlayerMotion(player: HumanRig, ball: BallState, dt: number) {
   const maxStep = player.speed * dt;
   if (dist > 0.0001) player.pos.addScaledVector(to.normalize(), Math.min(maxStep, dist));
 
-  player.pos.x = clamp(player.pos.x, -CFG.courtW / 2 + 0.35, CFG.courtW / 2 - 0.35);
-  if (player.side === "near") player.pos.z = clamp(player.pos.z, 0.76, CFG.courtL / 2 - 0.42);
+  const serveLock = player.side === "near" && player.action === "serve" && player.hitThisSwing === false;
+  if (serveLock) player.pos.x = clampServeLaneX(player.pos.x);
+  else player.pos.x = clamp(player.pos.x, -CFG.courtW / 2 + 0.35, CFG.courtW / 2 - 0.35);
+  if (player.side === "near") player.pos.z = clamp(player.pos.z, serveLock ? CFG.serveNearBaselineZ : 0.76, CFG.courtL / 2 - 0.42);
   else player.pos.z = clamp(player.pos.z, -CFG.courtL / 2 + 0.42, -0.76);
 
   let face: THREE.Vector3;
@@ -1030,7 +1068,9 @@ export default function MobileThreeTennisPrototype() {
     const farPlayer = addHuman(scene, "far", new THREE.Vector3(0, 0, -CFG.courtL / 2 + 1.04), 0x62d2ff, aiHuman?.modelUrls?.[0] || HUMAN_URL);
     const ball = createBall();
     scene.add(ball.mesh);
-    resetBallForServe(ball, nearPlayer);
+    let currentServeSide: "deuce" | "ad" = "deuce";
+    let firstServeAttempt = true;
+    resetBallForServe(ball, nearPlayer, currentServeSide);
     let netShakeT = 0;
 
     const ghost = new THREE.Mesh(
@@ -1067,7 +1107,9 @@ export default function MobileThreeTennisPrototype() {
         nearScore: prev.nearScore + (winner === "near" ? 1 : 0),
         farScore: prev.farScore + (winner === "far" ? 1 : 0),
       };
-      const reasonText = reason === "out" ? "Out ball" : reason === "doubleBounce" ? "Double bounce" : reason === "net" ? "Net fault" : "Point";
+      const reasonText = reason === "serviceFault" ? "Service fault" : reason === "out" ? "Out ball" : reason === "doubleBounce" ? "Double bounce" : reason === "net" ? "Net fault" : "Point";
+      firstServeAttempt = true;
+      currentServeSide = serviceSideFromPoints(next.nearScore, next.farScore);
       replayText = `Replay: ${reasonText} by ${winner === "near" ? "You" : "AI"}`;
       replayT = 1.7;
       void crowdFx.play().catch(() => {});
@@ -1114,8 +1156,10 @@ export default function MobileThreeTennisPrototype() {
       control.lastTs = performance.now();
       const dx = e.clientX - control.startX;
       const dy = e.clientY - control.startY;
-      nearPlayer.target.x = clamp(control.startPlayer.x + dx * 0.012, -CFG.courtW / 2 + 0.35, CFG.courtW / 2 - 0.35);
-      const minZ = ball.lastHitBy === null ? CFG.serveNearBaselineZ : 0.76;
+      const isServeSetup = ball.lastHitBy === null;
+      if (isServeSetup) nearPlayer.target.x = clampServeLaneX(control.startPlayer.x + dx * 0.012);
+      else nearPlayer.target.x = clamp(control.startPlayer.x + dx * 0.012, -CFG.courtW / 2 + 0.35, CFG.courtW / 2 - 0.35);
+      const minZ = isServeSetup ? CFG.serveNearBaselineZ : 0.76;
       nearPlayer.target.z = clamp(control.startPlayer.z + dy * 0.012, minZ, CFG.courtL / 2 - 0.42);
       setHudSafe({ power: clamp01(Math.hypot(dx, dy) / 185) });
     };
@@ -1200,6 +1244,22 @@ export default function MobileThreeTennisPrototype() {
             ball.bounceSide = bounceSide;
             ball.bounceCount = 1;
           }
+          const isServeBall = ball.lastHitBy !== null && ball.bounceCount === 1;
+          if (isServeBall && !isInsideServiceBox(ball.pos, ball.lastHitBy, currentServeSide)) {
+            if (firstServeAttempt) {
+              firstServeAttempt = false;
+              pointLock = true;
+              pointLockT = 0.55;
+              setHudSafe({ status: "Fault. Second serve" });
+              nearPlayer.action = "ready";
+              farPlayer.action = "ready";
+              resetBallForServe(ball, nearPlayer, currentServeSide);
+              return;
+            } else {
+              awardPoint(opposite(ball.lastHitBy), "serviceFault");
+              return;
+            }
+          }
           const outsideX = Math.abs(ball.pos.x) > CFG.courtW / 2;
           const outsideZ = Math.abs(ball.pos.z) > CFG.courtL / 2;
           if ((outsideX || outsideZ) && ball.lastHitBy) awardPoint(opposite(ball.lastHitBy), "out");
@@ -1215,7 +1275,7 @@ export default function MobileThreeTennisPrototype() {
     function updateAi() {
       const landing = predictLanding(ball);
       const home = new THREE.Vector3(0, 0, -CFG.courtL / 2 + 0.9);
-      const ballComingToAi = ball.lastHitBy === "near" && (ball.pos.z < 0.65 || landing.z < 0);
+      const ballComingToAi = ball.lastHitBy === "near" && (ball.pos.z < 1.8 || landing.z < 0.85 || ball.vel.z < -0.35);
       if (ballComingToAi) {
         farPlayer.target.x = clamp(landing.x, -CFG.courtW / 2 + 0.35, CFG.courtW / 2 - 0.35);
         farPlayer.target.z = clamp(Math.min(-0.72, landing.z + 0.42), -CFG.courtL / 2 + 0.42, -0.64);
@@ -1264,7 +1324,7 @@ export default function MobileThreeTennisPrototype() {
           farPlayer.action = "ready";
           nearPlayer.target.set(0, 0, CFG.courtL / 2 - 1.04);
           farPlayer.target.set(0, 0, -CFG.courtL / 2 + 1.04);
-          resetBallForServe(ball, nearPlayer);
+          resetBallForServe(ball, nearPlayer, currentServeSide);
           setHudSafe({ status: "Swipe up to serve", power: 0 });
         }
       } else {
@@ -1294,10 +1354,15 @@ export default function MobileThreeTennisPrototype() {
       ghost.position.z += (nearPlayer.target.z - ghost.position.z) * (1 - Math.exp(-12 * dt));
       (ghost.material as THREE.MeshBasicMaterial).opacity = controlRef.current.active ? 0.62 : 0.28;
 
-      cameraPosTarget.copy(nearPlayer.target).add(cameraOffset);
+      const isServeView = ball.lastHitBy === null;
+      const activeOffset = isServeView
+        ? new THREE.Vector3(0, 5.85 * CFG.worldScale, 10.5 * CFG.worldScale)
+        : cameraOffset;
+      cameraPosTarget.copy(nearPlayer.target).add(activeOffset);
       camera.position.lerp(cameraPosTarget, 1 - Math.exp(-5.5 * dt));
       cameraTarget.x += (nearPlayer.target.x - cameraTarget.x) * (1 - Math.exp(-5.2 * dt));
-      cameraTarget.z += ((nearPlayer.target.z - 6.9 * CFG.worldScale) - cameraTarget.z) * (1 - Math.exp(-4.3 * dt));
+      const serveFocusZ = nearPlayer.target.z - 10.7 * CFG.worldScale;
+      cameraTarget.z += ((isServeView ? serveFocusZ : (nearPlayer.target.z - 6.9 * CFG.worldScale)) - cameraTarget.z) * (1 - Math.exp(-4.3 * dt));
       updateBillboards(now * 0.001);
       camera.lookAt(cameraTarget);
       renderer.render(scene, camera);


### PR DESCRIPTION
### Motivation
- Implement proper tennis serving rules including first/second serve and service fault detection. 
- Constrain serve placement and player positioning to realistic service lanes and adapt camera to better frame serve actions. 
- Improve AI positioning and shot selection to respond to wide/defensive balls and balance aggression.

### Description
- Added a `serviceFault` variant to `PointReason` and new helper functions `serviceSideFromPoints`, `serveXForSide`, `isInsideServiceBox`, and `clampServeLaneX` to compute service lanes and validate service boxes. 
- Introduced `serviceBuffer` in `CFG`, increased `aiSpeed`, and adjusted AI target/power/technique logic in `makeAiTarget` to prefer attacking open court and tune randomness. 
- Updated `resetBallForServe` signature to accept `serveSide` and snap the server (`nearPlayer`) X position into the serve lane, and added `currentServeSide` and `firstServeAttempt` state to track serving side and second-serve attempts. 
- Implemented serve-specific input and motion constraints so the server is locked into the serve lane until contact, updated pointer handling for serve targeting, and added bounce-time checks to detect faults and trigger second serve behavior or award a `serviceFault` point. 
- Adjusted camera offsets and focus when in serve view so the shot is framed differently from regular play.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f95ea03b8c8329bb288969f2d9ac33)