### PR TITLE
Improve serve mechanics, service fault detection, and AI behavior in Tennis prototype

### DIFF
--- a/webapp/src/pages/Games/Tennis.tsx
+++ b/webapp/src/pages/Games/Tennis.tsx
@@ -10,7 +10,7 @@ import { HUMAN_CHARACTER_OPTIONS } from "../../config/ludoBattleOptions.js";
 import { getPoolRoyalInventory } from "../../utils/poolRoyalInventory.js";
 
 type PlayerSide = "near" | "far";
-type PointReason = "winner" | "out" | "doubleBounce" | "net";
+type PointReason = "winner" | "out" | "doubleBounce" | "net" | "serviceFault";
 type StrokeAction = "ready" | "forehand" | "serve";
 
 type BallState = {
@@ -126,7 +126,7 @@ const CFG = {
   minBallSpeed: 0.12 * WORLD_SCALE,
   playerHeight: 2.2 * WORLD_SCALE,
   playerSpeed: 7.1 * WORLD_SCALE,
-  aiSpeed: 9.8 * WORLD_SCALE,
+  aiSpeed: 11.6 * WORLD_SCALE,
   reach: 1.45 * WORLD_SCALE,
   swingDuration: 0.38,
   serveDuration: 0.86,
@@ -135,6 +135,7 @@ const CFG = {
   serveContactT: 0.72,
   playerVisualYawFix: Math.PI,
   serveNearBaselineZ: 8.2 * WORLD_SCALE,
+  serviceBuffer: 0.28 * WORLD_SCALE,
 };
 
 const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v));
@@ -145,6 +146,35 @@ const easeInOut = (t: number) => t * t * (3 - 2 * t);
 const sideOfZ = (z: number): PlayerSide => (z >= 0 ? "near" : "far");
 const opposite = (side: PlayerSide): PlayerSide => (side === "near" ? "far" : "near");
 
+
+function serviceSideFromPoints(nearScore: number, farScore: number): "deuce" | "ad" {
+  return (nearScore + farScore) % 2 === 0 ? "deuce" : "ad";
+}
+
+function serveXForSide(player: PlayerSide, side: "deuce" | "ad") {
+  const outsideSingles = CFG.courtW / 2 + 0.42;
+  const laneMax = CFG.doublesW / 2 - 0.2;
+  const xAbs = clamp(outsideSingles, CFG.courtW / 2 + 0.12, laneMax);
+  const sign = side === "deuce" ? 1 : -1;
+  return (player === "near" ? sign : -sign) * xAbs;
+}
+
+
+function serveLaneBoundsX(side: "deuce" | "ad") {
+  const laneMinAbs = CFG.courtW / 2 + 0.12;
+  const laneMaxAbs = CFG.doublesW / 2 - 0.12;
+  if (side === "deuce") return { min: laneMinAbs, max: laneMaxAbs };
+  return { min: -laneMaxAbs, max: -laneMinAbs };
+}
+
+function isInsideServiceBox(pos: THREE.Vector3, hitter: PlayerSide, side: "deuce" | "ad") {
+  const targetSide = opposite(hitter);
+  const targetRight = side === "deuce";
+  const xOk = targetRight ? pos.x >= 0 + CFG.serviceBuffer : pos.x <= 0 - CFG.serviceBuffer;
+  const xInCourt = Math.abs(pos.x) <= CFG.courtW / 2;
+  const zOk = targetSide === "far" ? pos.z <= -CFG.serviceBuffer && pos.z >= -CFG.serviceLineZ : pos.z >= CFG.serviceBuffer && pos.z <= CFG.serviceLineZ;
+  return xOk && xInCourt && zOk;
+}
 function material(color: number, roughness = 0.74, metalness = 0.02) {
   return new THREE.MeshStandardMaterial({ color, roughness, metalness });
 }
@@ -724,8 +754,14 @@ function serveReadyBallPosition(player: HumanRig) {
   return player.pos.clone().addScaledVector(right, -0.14).addScaledVector(forward, 0.26).setY(1.12 * CFG.worldScale);
 }
 
-function resetBallForServe(ball: BallState, near: HumanRig) {
+function resetBallForServe(ball: BallState, near: HumanRig, serveSide: "deuce" | "ad") {
   ball.pos.copy(serveReadyBallPosition(near));
+  near.pos.x = serveXForSide("near", serveSide);
+  near.target.x = near.pos.x;
+  near.pos.z = Math.max(near.pos.z, CFG.serveNearBaselineZ);
+  near.target.z = near.pos.z;
+  near.root.position.x = near.pos.x;
+  near.modelRoot.position.x = near.pos.x;
   ball.vel.set(0, 0, 0);
   ball.spin = 0;
   ball.lastHitBy = null;
@@ -814,13 +850,15 @@ function makeUserTargetFromSwipe(startX: number, startY: number, endX: number, e
 }
 
 function makeAiTarget(near: HumanRig, ball: BallState): DesiredHit {
+  const farDefendingWide = Math.abs(ball.pos.x) > CFG.courtW * 0.32;
   const pressure = clamp01((Math.abs(ball.pos.z) - 0.6) / (CFG.courtL / 2 - 0.8));
   const sideRead = clamp((ball.vel.x || 0) * 0.26, -0.5, 0.5);
-  const x = clamp(near.pos.x * 0.72 + sideRead + (Math.random() - 0.5) * 0.75, -CFG.courtW / 2 + 0.35, CFG.courtW / 2 - 0.35);
+  const attackToOpen = farDefendingWide ? -Math.sign(ball.pos.x || 1) * (CFG.courtW * 0.36) : near.pos.x * 0.72;
+  const x = clamp(attackToOpen + sideRead + (Math.random() - 0.5) * 0.58, -CFG.courtW / 2 + 0.35, CFG.courtW / 2 - 0.35);
   const z = lerp(1.2, CFG.courtL / 2 - 0.7, 0.42 + pressure * 0.5);
-  const power = clamp(0.72 + pressure * 0.42 + Math.random() * 0.2, 0.62, 1);
+  const power = clamp(0.66 + pressure * 0.52 + Math.random() * 0.2, 0.56, 1);
   const roll = Math.random();
-  const technique: ShotTechnique = pressure > 0.72 ? "topspin" : roll > 0.66 ? "slice" : roll < 0.22 ? "lob" : "flat";
+  const technique: ShotTechnique = pressure > 0.72 ? "topspin" : roll > 0.62 ? "slice" : "flat";
   return { target: new THREE.Vector3(x, CFG.ballR, z), power, technique };
 }
 
@@ -1030,7 +1068,9 @@ export default function MobileThreeTennisPrototype() {
     const farPlayer = addHuman(scene, "far", new THREE.Vector3(0, 0, -CFG.courtL / 2 + 1.04), 0x62d2ff, aiHuman?.modelUrls?.[0] || HUMAN_URL);
     const ball = createBall();
     scene.add(ball.mesh);
-    resetBallForServe(ball, nearPlayer);
+    let currentServeSide: "deuce" | "ad" = "deuce";
+    let firstServeAttempt = true;
+    resetBallForServe(ball, nearPlayer, currentServeSide);
     let netShakeT = 0;
 
     const ghost = new THREE.Mesh(
@@ -1067,7 +1107,9 @@ export default function MobileThreeTennisPrototype() {
         nearScore: prev.nearScore + (winner === "near" ? 1 : 0),
         farScore: prev.farScore + (winner === "far" ? 1 : 0),
       };
-      const reasonText = reason === "out" ? "Out ball" : reason === "doubleBounce" ? "Double bounce" : reason === "net" ? "Net fault" : "Point";
+      const reasonText = reason === "serviceFault" ? "Service fault" : reason === "out" ? "Out ball" : reason === "doubleBounce" ? "Double bounce" : reason === "net" ? "Net fault" : "Point";
+      firstServeAttempt = true;
+      currentServeSide = serviceSideFromPoints(next.nearScore, next.farScore);
       replayText = `Replay: ${reasonText} by ${winner === "near" ? "You" : "AI"}`;
       replayT = 1.7;
       void crowdFx.play().catch(() => {});
@@ -1116,6 +1158,10 @@ export default function MobileThreeTennisPrototype() {
       const dy = e.clientY - control.startY;
       nearPlayer.target.x = clamp(control.startPlayer.x + dx * 0.012, -CFG.courtW / 2 + 0.35, CFG.courtW / 2 - 0.35);
       const minZ = ball.lastHitBy === null ? CFG.serveNearBaselineZ : 0.76;
+      if (ball.lastHitBy === null) {
+        const lane = serveLaneBoundsX(currentServeSide);
+        nearPlayer.target.x = clamp(control.startPlayer.x + dx * 0.012, Math.min(lane.min, lane.max), Math.max(lane.min, lane.max));
+      }
       nearPlayer.target.z = clamp(control.startPlayer.z + dy * 0.012, minZ, CFG.courtL / 2 - 0.42);
       setHudSafe({ power: clamp01(Math.hypot(dx, dy) / 185) });
     };
@@ -1200,6 +1246,22 @@ export default function MobileThreeTennisPrototype() {
             ball.bounceSide = bounceSide;
             ball.bounceCount = 1;
           }
+          const isServeBall = ball.lastHitBy !== null && ball.bounceCount === 1;
+          if (isServeBall && !isInsideServiceBox(ball.pos, ball.lastHitBy, currentServeSide)) {
+            if (firstServeAttempt) {
+              firstServeAttempt = false;
+              pointLock = false;
+              pointLockT = 0;
+              setHudSafe({ status: "Fault. Move left/right and serve again" });
+              nearPlayer.action = "ready";
+              farPlayer.action = "ready";
+              resetBallForServe(ball, nearPlayer, currentServeSide);
+              return;
+            } else {
+              awardPoint(opposite(ball.lastHitBy), "serviceFault");
+              return;
+            }
+          }
           const outsideX = Math.abs(ball.pos.x) > CFG.courtW / 2;
           const outsideZ = Math.abs(ball.pos.z) > CFG.courtL / 2;
           if ((outsideX || outsideZ) && ball.lastHitBy) awardPoint(opposite(ball.lastHitBy), "out");
@@ -1215,14 +1277,18 @@ export default function MobileThreeTennisPrototype() {
     function updateAi() {
       const landing = predictLanding(ball);
       const home = new THREE.Vector3(0, 0, -CFG.courtL / 2 + 0.9);
-      const ballComingToAi = ball.lastHitBy === "near" && (ball.pos.z < 0.65 || landing.z < 0);
+      const ballComingToAi = ball.lastHitBy === "near" && landing.z < 0.2;
       if (ballComingToAi) {
         farPlayer.target.x = clamp(landing.x, -CFG.courtW / 2 + 0.35, CFG.courtW / 2 - 0.35);
         farPlayer.target.z = clamp(Math.min(-0.72, landing.z + 0.42), -CFG.courtL / 2 + 0.42, -0.64);
       } else {
         farPlayer.target.lerp(home, 0.035);
       }
-      if (ballComingToAi && canReachBall(farPlayer, ball) && farPlayer.swingT === 0) startSwing(farPlayer, makeAiTarget(nearPlayer, ball), "forehand");
+      const aiCanSwingNow = farPlayer.swingT === 0 && farPlayer.cooldown <= 0;
+      const ballEnteringAiHalf = ball.pos.z < -0.15 || landing.z < -0.45;
+      if (ballComingToAi && aiCanSwingNow && ballEnteringAiHalf) {
+        startSwing(farPlayer, makeAiTarget(nearPlayer, ball), "forehand");
+      }
     }
 
     function checkSwingHits() {
@@ -1236,8 +1302,17 @@ export default function MobileThreeTennisPrototype() {
           }
           continue;
         }
-        if (player.swingT < CFG.hitWindowStart || player.swingT > CFG.hitWindowEnd) continue;
-        if (canReachBall(player, ball)) {
+        const isAi = player.side === "far";
+        const hitStart = isAi ? Math.max(0.3, CFG.hitWindowStart - 0.12) : CFG.hitWindowStart;
+        const hitEnd = isAi ? Math.min(0.88, CFG.hitWindowEnd + 0.14) : CFG.hitWindowEnd;
+        if (player.swingT < hitStart || player.swingT > hitEnd) continue;
+        const aiCloseEnough =
+          isAi &&
+          Math.abs(ball.pos.z - player.pos.z) < CFG.reach * 1.45 &&
+          Math.abs(ball.pos.x - player.pos.x) < CFG.reach * 1.15 &&
+          ball.pos.y >= 0.25 &&
+          ball.pos.y <= 1.85;
+        if (canReachBall(player, ball) || aiCloseEnough) {
           performHit(player, ball, player.desiredHit, false);
           void racketHitFx.play().catch(() => {});
           setHudSafe({ status: player.side === "near" ? "Forehand return" : "AI returned" });
@@ -1264,7 +1339,7 @@ export default function MobileThreeTennisPrototype() {
           farPlayer.action = "ready";
           nearPlayer.target.set(0, 0, CFG.courtL / 2 - 1.04);
           farPlayer.target.set(0, 0, -CFG.courtL / 2 + 1.04);
-          resetBallForServe(ball, nearPlayer);
+          resetBallForServe(ball, nearPlayer, currentServeSide);
           setHudSafe({ status: "Swipe up to serve", power: 0 });
         }
       } else {
@@ -1294,10 +1369,18 @@ export default function MobileThreeTennisPrototype() {
       ghost.position.z += (nearPlayer.target.z - ghost.position.z) * (1 - Math.exp(-12 * dt));
       (ghost.material as THREE.MeshBasicMaterial).opacity = controlRef.current.active ? 0.62 : 0.28;
 
-      cameraPosTarget.copy(nearPlayer.target).add(cameraOffset);
+      const preServe = ball.lastHitBy === null;
+      if (preServe) {
+        const serveCamOffset = new THREE.Vector3(nearPlayer.target.x * 0.08, 6.25 * CFG.worldScale, 10.4 * CFG.worldScale);
+        cameraPosTarget.copy(nearPlayer.target).add(serveCamOffset);
+        cameraTarget.x += (nearPlayer.target.x * 0.2 - cameraTarget.x) * (1 - Math.exp(-5.2 * dt));
+        cameraTarget.z += ((-CFG.courtL * 0.24) - cameraTarget.z) * (1 - Math.exp(-5.1 * dt));
+      } else {
+        cameraPosTarget.copy(nearPlayer.target).add(cameraOffset);
+        cameraTarget.x += (nearPlayer.target.x - cameraTarget.x) * (1 - Math.exp(-5.2 * dt));
+        cameraTarget.z += ((nearPlayer.target.z - 6.9 * CFG.worldScale) - cameraTarget.z) * (1 - Math.exp(-4.3 * dt));
+      }
       camera.position.lerp(cameraPosTarget, 1 - Math.exp(-5.5 * dt));
-      cameraTarget.x += (nearPlayer.target.x - cameraTarget.x) * (1 - Math.exp(-5.2 * dt));
-      cameraTarget.z += ((nearPlayer.target.z - 6.9 * CFG.worldScale) - cameraTarget.z) * (1 - Math.exp(-4.3 * dt));
       updateBillboards(now * 0.001);
       camera.lookAt(cameraTarget);
       renderer.render(scene, camera);


### PR DESCRIPTION
### Motivation
- Make serving more realistic by enforcing service-lane placement, tracking first/second serve attempts, and detecting service faults. 
- Reduce unfair AI behavior and improve return targeting to create better rallies. 
- Improve pre-serve camera and player placement so the serve feels responsive and visually clear.

### Description
- Added service helper functions `serviceSideFromPoints`, `serveXForSide`, `serveLaneBoundsX`, and `isInsideServiceBox`, and a `serviceBuffer` config to manage service placement and validation. 
- Updated `resetBallForServe` to accept the serve side and position the server model and targets appropriately, and introduced `currentServeSide` and `firstServeAttempt` state to track serve attempts. 
- Implemented service-fault logic in the bounce handler to allow a retry on first fault and award a point on second fault by using the new `serviceFault` `PointReason` and updating `awardPoint` to reset serve state and compute next `currentServeSide`. 
- Constrained pointer movement while preparing a serve to lane bounds, tweaked AI targeting (`makeAiTarget`) to attack open court and adjusted AI swing timing and reach checks in `updateAi` and `checkSwingHits`. 
- Tuned gameplay constants (`aiSpeed`, minor power/technique adjustments), and added pre-serve camera positioning to better frame the serve visually.

### Testing
- Ran the project build with `npm run build` which completed successfully. 
- Executed the test suite with `npm test` and the automated tests passed. 
- Lint and type checks were run as part of the build and did not report errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f95ea03b8c8329bb288969f2d9ac33)