### PR TITLE
Improve bowling scene flow, visuals, and shared inventory

### DIFF
--- a/webapp/src/config/bowlingInventoryConfig.js
+++ b/webapp/src/config/bowlingInventoryConfig.js
@@ -1,42 +1,40 @@
-const POLYHAVEN_BASE = 'https://dl.polyhaven.org/file/ph-assets/HDRIs/hdr/1k';
-const THUMB_BASE = 'https://cdn.polyhaven.com/asset_img/thumbs';
+import {
+  POOL_ROYALE_HDRI_VARIANTS,
+  POOL_ROYALE_STORE_ITEMS,
+} from './poolRoyaleInventoryConfig.js';
 
-const HDRIS = [
-  ['studio_small_09','Studio Small 09'],
-  ['studio_small_03','Studio Small 03'],
-  ['photo_studio_01','Photo Studio 01'],
-  ['brown_photostudio_02','Brown Photostudio 02'],
-  ['skidpan','Skidpan'],
-  ['empty_warehouse_01','Empty Warehouse 01'],
-  ['industrial_workshop_foundry','Industrial Workshop Foundry'],
-  ['abandoned_parking','Abandoned Parking'],
-  ['lebombo','Lebombo'],
-  ['aerodynamics_workshop','Aerodynamics Workshop']
-];
+export const BOWLING_HDRI_VARIANTS = Object.freeze(
+  POOL_ROYALE_HDRI_VARIANTS.map((variant, index) => ({
+    id: variant.id,
+    name: variant.name,
+    description: variant.description || 'Shared Pool Royale HDRI for bowling.',
+    sourceUrl: variant.sourceUrl,
+    hdriUrl: variant.hdriUrl,
+    thumbnailUrl: variant.thumbnailUrl,
+    priceCoins: index === 0 ? 0 : variant.priceCoins ?? 450,
+    rarity: index === 0 ? 'common' : 'rare',
+  }))
+);
 
-export const BOWLING_HDRI_VARIANTS = Object.freeze(HDRIS.map(([id, label], index) => ({
-  id,
-  name: label,
-  description: 'Poly Haven HDRI adapted for long-lane bowling lighting.',
-  sourceUrl: `https://polyhaven.com/a/${id}`,
-  hdriUrl: `${POLYHAVEN_BASE}/${id}_1k.hdr`,
-  thumbnailUrl: `${THUMB_BASE}/${id}.png?height=240`,
-  priceCoins: index === 0 ? 0 : 450,
-  rarity: index === 0 ? 'common' : 'rare'
-})));
+export const BOWLING_OPTION_LABELS = Object.freeze({
+  environmentHdri: 'Bowling HDRI Environment',
+  tableFinish: 'Bowling Table Finish',
+  chromeColor: 'Bowling Chrome Plates',
+});
 
-export const BOWLING_OPTION_LABELS = Object.freeze({ environmentHdri: 'Bowling HDRI Environment' });
+export const BOWLING_DEFAULT_LOADOUT = Object.freeze({
+  environmentHdri: BOWLING_HDRI_VARIANTS[0]?.id,
+});
 
-export const BOWLING_DEFAULT_LOADOUT = Object.freeze({ environmentHdri: BOWLING_HDRI_VARIANTS[0].id });
+const poolVisualStoreItems = POOL_ROYALE_STORE_ITEMS.filter((item) =>
+  ['environmentHdri', 'tableFinish', 'chromeColor'].includes(item.type)
+);
 
-export const BOWLING_STORE_ITEMS = Object.freeze(BOWLING_HDRI_VARIANTS.map((variant) => ({
-  id: `bowling-hdri-${variant.id}`,
-  game: 'bowling',
-  type: 'environmentHdri',
-  optionId: variant.id,
-  name: variant.name,
-  description: variant.description,
-  image: variant.thumbnailUrl,
-  priceCoins: variant.priceCoins,
-  featured: variant.id === BOWLING_DEFAULT_LOADOUT.environmentHdri
-})));
+export const BOWLING_STORE_ITEMS = Object.freeze(
+  poolVisualStoreItems.map((item) => ({
+    ...item,
+    id: `bowling-${item.id}`,
+    game: 'bowling',
+    featured: item.type === 'environmentHdri' ? item.optionId === BOWLING_DEFAULT_LOADOUT.environmentHdri : !!item.featured,
+  }))
+);

--- a/webapp/src/pages/Games/BowlingRealistic.tsx
+++ b/webapp/src/pages/Games/BowlingRealistic.tsx
@@ -5,7 +5,7 @@ import * as THREE from "three";
 import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js";
 import { RGBELoader } from "three/examples/jsm/loaders/RGBELoader.js";
 
-type PlayerAction = "idle" | "approach" | "throw" | "recover";
+type PlayerAction = "idle" | "approach" | "throw" | "recover" | "toRack" | "pickBall" | "toApproach";
 type BallReturnState = "idle" | "toPit" | "hidden" | "returning";
 
 type HudState = {
@@ -51,6 +51,8 @@ type HumanRig = {
   approachT: number;
   throwT: number;
   recoverT: number;
+  returnWalkT: number;
+  pickT: number;
   walkCycle: number;
   approachFrom: THREE.Vector3;
   approachTo: THREE.Vector3;
@@ -81,7 +83,7 @@ type PinState = {
 };
 
 const HUMAN_URL = "https://threejs.org/examples/models/gltf/readyplayer.me.glb";
-const HUMAN_INITIAL_SCALE = 0.92;
+const HUMAN_INITIAL_SCALE = 1.18;
 const HDRI_OPTIONS = [
   { id: "studio_small_09", name: "Studio Small 09", slug: "studio_small_09", thumb: "https://cdn.polyhaven.com/asset_img/thumbs/studio_small_09.png?height=160" },
   { id: "studio_small_03", name: "Studio Small 03", slug: "studio_small_03", thumb: "https://cdn.polyhaven.com/asset_img/thumbs/studio_small_03.png?height=160" },
@@ -111,7 +113,7 @@ const OAK = {
 const UP = new THREE.Vector3(0, 1, 0);
 
 const CFG = {
-  laneY: 0.08,
+  laneY: 0,
   laneHalfW: 1.56,
   gutterHalfW: 2.08,
   playerStartZ: 7.15,
@@ -126,6 +128,8 @@ const CFG = {
   approachDuration: 0.56,
   throwDuration: 0.9,
   recoverDuration: 0.28,
+  returnWalkDuration: 1.08,
+  pickDuration: 0.42,
   releaseT: 0.56,
 };
 
@@ -366,6 +370,8 @@ function addHuman(scene: THREE.Scene, start: THREE.Vector3, accent: number): Hum
     approachT: 0,
     throwT: 0,
     recoverT: 0,
+    returnWalkT: 0,
+    pickT: 0,
     walkCycle: 0,
     approachFrom: start.clone(),
     approachTo: start.clone(),
@@ -563,7 +569,7 @@ function createEnvironment(scene: THREE.Scene, loader: THREE.TextureLoader) {
   }
 
   const gutterMat = new THREE.MeshStandardMaterial({ color: 0x262f3a, roughness: 0.38, metalness: 0.2 });
-  const metalMat = new THREE.MeshStandardMaterial({ color: 0x4a5462, roughness: 0.34, metalness: 0.74 });
+  const metalMat = new THREE.MeshPhysicalMaterial({ color: 0xd9e2ef, roughness: 0.16, metalness: 1, clearcoat: 1, clearcoatRoughness: 0.05 });
   const blackMat = new THREE.MeshStandardMaterial({ color: 0x101216, roughness: 0.84 });
 
   // Arena removed: no walls, no ceiling, and no extra room floor.
@@ -694,7 +700,7 @@ function startApproach(rig: HumanRig, intent: ThrowIntent) {
   rig.approachTo.set(clamp(intent.releaseX * 0.34, -0.4, 0.4), CFG.laneY, CFG.approachStopZ);
 }
 
-function updateHuman(rig: HumanRig, ball: BallState, dt: number) {
+function updateHuman(rig: HumanRig, ball: BallState, dt: number, canStartReturnCycle: boolean) {
   if (rig.action === "approach") {
     rig.approachT = clamp01(rig.approachT + dt / CFG.approachDuration);
     rig.walkCycle += dt * 16.8;
@@ -729,8 +735,22 @@ function updateHuman(rig: HumanRig, ball: BallState, dt: number) {
     }
     if (rig.recoverT >= 1) {
       rig.recoverT = 0;
-      rig.action = "idle";
+      rig.action = "toRack";
+      rig.returnWalkT = 0.001;
     }
+  } else if (rig.action === "toRack") {
+    rig.returnWalkT = clamp01(rig.returnWalkT + dt / CFG.returnWalkDuration);
+    rig.walkCycle += dt * 12.8;
+    rig.pos.lerpVectors(rig.approachTo, new THREE.Vector3(1.55, CFG.laneY, 6.1), easeInOut(rig.returnWalkT));
+    if (rig.returnWalkT >= 1) { rig.action = "pickBall"; rig.pickT = 0.001; }
+  } else if (rig.action === "pickBall") {
+    rig.pickT = clamp01(rig.pickT + dt / CFG.pickDuration);
+    if (rig.pickT >= 1 && canStartReturnCycle) { rig.action = "toApproach"; rig.returnWalkT = 0.001; }
+  } else if (rig.action === "toApproach") {
+    rig.returnWalkT = clamp01(rig.returnWalkT + dt / CFG.returnWalkDuration);
+    rig.walkCycle += dt * 12.8;
+    rig.pos.lerpVectors(new THREE.Vector3(1.55, CFG.laneY, 6.1), new THREE.Vector3(0, CFG.laneY, CFG.playerStartZ), easeInOut(rig.returnWalkT));
+    if (rig.returnWalkT >= 1) rig.action = "idle";
   } else if (rig.model) {
     rig.model.position.y *= 0.82;
     rig.model.rotation.x *= 0.82;
@@ -1211,7 +1231,7 @@ export default function MobileBowlingRealistic() {
       const now = performance.now();
       const dt = Math.min(0.033, (now - last) / 1000);
       last = now;
-      updateHuman(player, ball, dt);
+      updateHuman(player, ball, dt, true);
       if (player.action === "throw" && pendingIntent && player.throwT >= CFG.releaseT && ball.held) {
         lastShotStandingBefore = standingPinsCount(pins);
         releaseBall(ball, pendingIntent);
@@ -1220,6 +1240,10 @@ export default function MobileBowlingRealistic() {
       }
       updateBall(ball, pins, dt);
       const pinsMoving = updatePins(pins, dt);
+      const mechanismBusy = ball.returnState !== "idle" || ball.rolling || pinsMoving;
+      if ((player.action === "pickBall" || player.action === "toApproach") && mechanismBusy) {
+        player.action = "pickBall";
+      }
       if (pinsMoving) pinsWereMoving = true;
       if (!shotResolved && !ball.rolling && pinsWereMoving && !pinsMoving) {
         settleTimer += dt;
@@ -1295,14 +1319,6 @@ export default function MobileBowlingRealistic() {
           </div>
         </div> : null}
 
-        <div style={{ position: "absolute", left: 10, bottom: 18, color: "white", background: "rgba(5,8,14,0.54)", border: "1px solid rgba(255,255,255,0.14)", padding: "10px 11px", borderRadius: 16, fontSize: 12, lineHeight: 1.38, maxWidth: 265, boxShadow: "0 14px 30px rgba(0,0,0,0.22)", backdropFilter: "blur(10px)" }}>
-          Swipe visually upward to bowl.<br />Slide left or right to aim on the lane.<br />HDRI skybox is visible and swipe direction maps directly to aim.
-        </div>
-
-        <div style={{ position: "absolute", right: 12, bottom: 24, width: 52, height: 166, borderRadius: 999, background: "rgba(255,255,255,0.16)", border: "1px solid rgba(255,255,255,0.26)", overflow: "hidden", boxShadow: "0 12px 30px rgba(0,0,0,0.24)", backdropFilter: "blur(8px)" }}>
-          <div style={{ position: "absolute", left: 0, right: 0, bottom: 0, height: `${Math.round(hud.power * 100)}%`, background: "rgba(139,215,255,0.9)", transition: hud.power === 0 ? "height 150ms ease-out" : "none" }} />
-          <div style={{ position: "absolute", inset: 0, display: "flex", alignItems: "center", justifyContent: "center", color: "rgba(0,0,0,0.8)", fontSize: 11, fontWeight: 950, writingMode: "vertical-rl", transform: "rotate(180deg)" }}>POWER</div>
-        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
### Motivation
- Clear lower-screen clutter by removing the instructional/power overlay so the player view is unobstructed during play. 
- Make the human player more prominent and implement a realistic post-throw loop (walk to rack → pick ball → return) to match real bowling flow. 
- Align the lane/human/mechanism to HDRI ground level and give the return/cleaning mechanism a more chrome/table-finish look. 
- Reuse the existing Pool Royale HDRI/material inventory so bowling can surface the same HDRIs and visual store items for personalization.

### Description
- Removed the bottom instruction/power UI overlay from `webapp/src/pages/Games/BowlingRealistic.tsx` to clear the lower screen area. 
- Increased human scale by changing `HUMAN_INITIAL_SCALE` from `0.92` to `1.18` and ensured the model is locked to lane ground using `lockHumanToLaneGround`. 
- Extended the human state machine by adding `toRack`, `pickBall`, and `toApproach` actions and new `returnWalkT`/`pickT` fields on `HumanRig`, plus `returnWalkDuration` and `pickDuration` in `CFG`, and updated `updateHuman(...)` to drive the walk/pick/return cycle. 
- Grounded the scene by setting `CFG.laneY` to `0` so field, human and mechanism sit at HDRI floor level. 
- Improved mechanism visuals by replacing the metal material with a chrome-style `THREE.MeshPhysicalMaterial` (tuned `metalness`, `clearcoat`, `roughness`). 
- Added coordination between mechanism and human by passing a `canStartReturnCycle` flag to `updateHuman` and gating the pick/return transitions while the ball return/pin-cleaning is busy. 
- Reworked bowling inventory in `webapp/src/config/bowlingInventoryConfig.js` to import `POOL_ROYALE_HDRI_VARIANTS` and `POOL_ROYALE_STORE_ITEMS`, map HDRI variants for bowling, and expose pooled visual store items filtered to `['environmentHdri','tableFinish','chromeColor']` so bowling can reuse Pool Royale HDRIs and finishes. 

### Testing
- Ran `npm test -- --runInBand test/inventoryCrossGameConfig.test.js test/checkersBattleHdriCatalog.test.js` and both test suites passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f979f0d0e48329a5ac788f7eb11e38)