### PR TITLE
Disable FPV camera and shrink board/chairs/pieces in Chess Battle Royal

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -363,8 +363,8 @@ const BOARD = { N: 8, tile: 4.2, rim: 3, baseH: 0.8 };
 const PIECE_Y = 1.2; // baseline height for meshes
 const PIECE_PLACEMENT_Y_OFFSET = 0.24; // Lower tokens slightly so they stay grounded on the board after shrinking.
 const LAYOUT_SCALE_FACTOR = 0.7225;
-const TABLE_LAYOUT_SCALE_FACTOR = 0.58; // Keep the same table/board/chair proportions, but ~22% smaller than current.
-const PIECE_SCALE_FACTOR = 0.73 * LAYOUT_SCALE_FACTOR * 1.5 * 0.85; // Shrink tokens by 15% while preserving the existing style proportions.
+const TABLE_LAYOUT_SCALE_FACTOR = 0.52; // Further shrink board/table/chairs to better fit portrait framing.
+const PIECE_SCALE_FACTOR = 0.73 * LAYOUT_SCALE_FACTOR * 1.5 * 0.76; // Make chess pieces visibly smaller on screen while keeping style proportions.
 const PIECE_FOOTPRINT_RATIO = 0.86;
 const BOARD_GROUP_Y_OFFSET = 0.05;
 const BOARD_MODEL_Y_OFFSET = -0.12;
@@ -406,8 +406,8 @@ const CHAIR_SCALE = 0.96 * LAYOUT_SCALE_FACTOR * TABLE_LAYOUT_SCALE_FACTOR;
 const CHAIR_WIDTH_SCALE = 1.1; // Slightly widen/deepen chairs so they read larger in portrait.
 const CHAIR_VERTICAL_OFFSET = -0.065 * MODEL_SCALE;
 const CHAIR_CLEARANCE = AI_CHAIR_GAP;
-const PLAYER_CHAIR_EXTRA_CLEARANCE = -0.082 * MODEL_SCALE; // Keep local chair close so legs visually approach the table edge.
-const OPPONENT_CHAIR_EXTRA_CLEARANCE = -0.058 * MODEL_SCALE; // Keep opponent chair close too, with only a small gap.
+const PLAYER_CHAIR_EXTRA_CLEARANCE = -0.13 * MODEL_SCALE; // Pull local chair + seated human closer to table.
+const OPPONENT_CHAIR_EXTRA_CLEARANCE = -0.1 * MODEL_SCALE; // Pull opponent chair + seated human closer to table.
 const CHAIR_TABLE_PUSHBACK = 0.04 * MODEL_SCALE;
 const CHAIR_TABLE_GAP_MIN = 0.08 * MODEL_SCALE;
 const CHAIR_TABLE_GAP_MAX = 0.42 * MODEL_SCALE;
@@ -9744,6 +9744,10 @@ function Chess3D({
       const default3d = new THREE.Spherical(initialRadius, CAMERA_DEFAULT_PHI, theta);
 
       if (requestedMode === 'fpv') {
+        // Player-perspective camera disabled: fall back to standard 3D orbit view.
+        setViewModeInternal('3d');
+        return;
+
         cameraMemory.last3d = current;
         controls.enabled = false;
         controls.enableRotate = false;
@@ -9822,7 +9826,7 @@ function Chess3D({
       if (viewModeRef.current === '2d') {
         controls.target.copy(boardLookTarget);
       }
-      if (viewModeRef.current !== 'fpv') {
+      {
         const currentRadius = camera.position.distanceTo(boardLookTarget);
         const radius = clamp(currentRadius || CAMERA_SAFE_MAX_RADIUS, minDistance, maxDistance);
         const dir = camera.position.clone().sub(boardLookTarget).normalize();
@@ -14185,13 +14189,6 @@ function Chess3D({
                 />
               </svg>
               <span className="sr-only">Replay last move</span>
-            </button>
-            <button
-              type="button"
-              onClick={() => setViewMode((mode) => (mode === 'fpv' ? '2d' : 'fpv'))}
-              className="icon-only-button flex h-10 w-10 items-center justify-center text-[0.75rem] font-semibold uppercase tracking-[0.08em] text-white/90 transition-opacity duration-200 hover:text-white focus:outline-none"
-            >
-              {viewMode === 'fpv' ? '2D' : 'FPV'}
             </button>
           </div>
           {configOpen && (


### PR DESCRIPTION
### Motivation
- Restore the non-FPV camera behavior and avoid the player-perspective (`fpv`) view which was causing an at-table first-person framing. 
- Improve portrait-screen composition by making the board, table, and chess pieces appear smaller so more scene fits on mobile screens. 
- Tighten the staging by bringing chairs and the seated human characters closer to the table for a more compact visual.

### Description
- Reduced the scene layout scale and piece scale by updating `TABLE_LAYOUT_SCALE_FACTOR` and `PIECE_SCALE_FACTOR` in `webapp/src/pages/Games/ChessBattleRoyal.jsx`. 
- Pulled player and opponent seats closer by increasing negative offsets on `PLAYER_CHAIR_EXTRA_CLEARANCE` and `OPPONENT_CHAIR_EXTRA_CLEARANCE`. 
- Disabled the player-perspective camera path by making the `requestedMode === 'fpv'` branch fall back to the standard `3d` orbit view inside `setViewModeInternal`. 
- Removed the in-UI FPV toggle button so users can no longer switch to `fpv`, and simplified the camera `fit` logic to no longer treat `fpv` specially.

### Testing
- Verified the code changes by inspecting the diff with `git diff -- webapp/src/pages/Games/ChessBattleRoyal.jsx`, which showed the updated constants and removed UI button. (succeeded)
- Committed the change with `git commit -m "Adjust Chess Battle Royal camera and scale layout"`, which completed successfully. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9744df0148329a585bdf5485f43aa)