### PR TITLE
Widen player camera framing and stabilize bottom-player dice hand contact

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -3294,11 +3294,11 @@ function resolvePlayerColors(appearance = {}) {
   return PLAYER_COLOR_ORDER.map((_, idx) => normalizeColorValue(swatches[idx], DEFAULT_PLAYER_COLORS[idx]));
 }
 
-const CAMERA_FOV = 72;
+const CAMERA_FOV = 84;
 const CAMERA_NEAR = ARENA_CAMERA_DEFAULTS.near;
 const CAMERA_FAR = ARENA_CAMERA_DEFAULTS.far;
 const CAMERA_DOLLY_FACTOR = ARENA_CAMERA_DEFAULTS.wheelDeltaFactor;
-const CAMERA_TARGET_LIFT = 0.028 * MODEL_SCALE;
+const CAMERA_TARGET_LIFT = 0.038 * MODEL_SCALE;
 const CAMERA_SIDE_LOOK_EXTRA = 0.21;
 const CAMERA_TURN_PLAYER_LERP = 0.58;
 const CAMERA_BROADCAST_TARGET_BLEND = 0.6;
@@ -3325,10 +3325,10 @@ const LUDO_CAMERA_PHI_MAX = 1.22;
 const PLAYER_VIEW_SEAT_THETA = Math.PI / 2;
 const PLAYER_VIEW_CAMERA_BACK_OFFSET_PORTRAIT = 1.26;
 const PLAYER_VIEW_CAMERA_BACK_OFFSET_LANDSCAPE = 1.26;
-const PLAYER_VIEW_CAMERA_FORWARD_OFFSET_PORTRAIT = 2.04;
+const PLAYER_VIEW_CAMERA_FORWARD_OFFSET_PORTRAIT = 2.34;
 const PLAYER_VIEW_CAMERA_FORWARD_OFFSET_LANDSCAPE = 0.98;
-const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_PORTRAIT = 0.9;
-const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_LANDSCAPE = 0.84;
+const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_PORTRAIT = 1.12;
+const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_LANDSCAPE = 0.96;
 const PLAYER_VIEW_FIRST_PERSON_EYE_FORWARD_PORTRAIT = 0.42 * MODEL_SCALE;
 const PLAYER_VIEW_FIRST_PERSON_EYE_FORWARD_LANDSCAPE = 0.2 * MODEL_SCALE;
 const PLAYER_VIEW_LOOK_TARGET_FORWARD_BIAS = -0.02 * 3.22 * ARENA_SCALE;
@@ -8234,10 +8234,6 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
   const resolveDiceHoldContactTarget = (player, fallbackTarget = null) => {
     const dice = diceRef.current;
     if (!dice?.isObject3D) return fallbackTarget ?? null;
-    if (player === 0) {
-      // Keep local/human turn start anchored on the board rail so users see exactly where to tap to roll.
-      return fallbackTarget ?? null;
-    }
     const actorEntry = seatedHumanActorsRef.current?.find((entry) => entry?.playerIndex === player);
     if (!actorEntry) return fallbackTarget ?? null;
     const helperWorld = new THREE.Vector3();
@@ -8260,16 +8256,22 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     if (!dice) return;
     const rails = dice.userData?.railPositions;
     if (!rails || !rails[player]) return;
+    const railTarget = rails[player].clone ? rails[player].clone() : new THREE.Vector3().copy(rails[player]);
 
     if (player === 0 && !immediate) {
-      // On human turns keep the dice where it landed so the seated actor can bend from the torso,
-      // reach to that exact table spot, and grab it before the next throw.
+      // Human turn flow: grab the dice from its landing point, then bring it toward the hand
+      // so the user can tap/press while the actor visibly holds it.
+      const holdTarget = resolveDiceHoldContactTarget(player, railTarget) ?? railTarget;
       stopDiceTransition();
-      beginDiceHoldPose(player, { startMs: performance.now() - 220 });
+      beginDiceHoldPose(player, { startMs: performance.now() - 260 });
+      animateDicePosition(dice, holdTarget, {
+        duration: 320,
+        lift: 0.045,
+        onComplete: () => beginDiceHoldPose(player)
+      });
       return;
     }
 
-    const railTarget = rails[player].clone ? rails[player].clone() : new THREE.Vector3().copy(rails[player]);
     const target = resolveDiceHoldContactTarget(player, railTarget) ?? railTarget;
     if (immediate) {
       stopDiceTransition();
@@ -9675,6 +9677,13 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
       }
 
       if (diceRef.current) {
+        const holdPlayer = actorState?.holdPlayer;
+        if (Number.isInteger(holdPlayer) && !diceRef.current.userData?.isRolling && !diceTransitionRef.current) {
+          const holdContact = resolveDiceHoldContactTarget(holdPlayer, null);
+          if (holdContact?.isVector3) {
+            diceRef.current.position.lerp(holdContact, 0.45);
+          }
+        }
         const lights = diceRef.current.userData?.lights;
         if (lights?.accent) {
           const pos = diceRef.current.getWorldPosition(new THREE.Vector3());
@@ -11461,16 +11470,6 @@ function Ludo3D({ avatar, username, aiFlagOverrides, playerCount, aiCount }) {
     if (player === 0) {
       lockUserTurnSeatViewRef.current = true;
       cameraLookStateRef.current.pitch = 0;
-      const bottomActorEntry = seatedHumanActorsRef.current?.find((entry) => entry?.playerIndex === 0);
-      const facePose = resolveSeatedFaceCameraPose(bottomActorEntry, resolveBottomPlayerGameplayTarget());
-      if (facePose?.position?.isVector3 && facePose?.target?.isVector3) {
-        cameraTurnStateRef.current.baseTurnView = {
-          position: facePose.position.clone(),
-          target: facePose.target.clone()
-        };
-        animateCameraPose(facePose.target, facePose.position, duration);
-        return;
-      }
       const initialBottomView = initialBottomCameraViewRef.current;
       if (initialBottomView?.position?.isVector3 && initialBottomView?.target?.isVector3) {
         const boardLookTarget = boardLookTargetRef.current;


### PR DESCRIPTION
### Motivation
- Improve portrait gameplay framing so the player-perspective camera reads higher and wider without moving the camera backward. 
- Make bottom-player (local human) dice interactions visibly believable by ensuring the hand and dice show sustained physical contact during the tap-to-roll hold phase. 
- Keep turn-camera framing stable so the bottom player's turn matches the initial game-start framing.

### Description
- Increased camera tuning constants: set `CAMERA_FOV` to `84`, `CAMERA_TARGET_LIFT` to `0.038 * MODEL_SCALE`, `PLAYER_VIEW_CAMERA_FORWARD_OFFSET_PORTRAIT` to `2.34`, and portrait/landscape `PLAYER_VIEW_CAMERA_HEIGHT_OFFSET` to `1.12`/`0.96` to achieve a higher/wider player view without backing the camera up. 
- Re-enabled sampled hand-contact for the bottom player by removing the special-case early return in `resolveDiceHoldContactTarget` so player `0` uses the same `diceHold`/`dicePickup` helper sampling as other seats. 
- On human turns `moveDiceToRail` now animates the dice from its rail/landing spot toward the resolved hand contact target (shorter duration, slightly higher arc) and nudges into the `beginDiceHoldPose` so the user sees a reachable grab and can tap to roll. 
- Added a per-frame hold correction in the main update loop that lerps the dice toward the resolved hand contact target while `holdPlayer` is active and the dice is not rolling (and when no scripted dice transition is running), preventing visual drift during the hold phase. 
- Simplified bottom-player turn camera logic so when the bottom player has the turn the view prefers the initial match-start baseline framing when available, keeping consistent framing for the local player.

### Testing
- Ran `cd webapp && npm run -s lint -- src/pages/Games/LudoBattleRoyal.jsx`, which exited non-zero in this environment and produced no usable diagnostics. 
- Ran `cd webapp && npx eslint src/pages/Games/LudoBattleRoyal.jsx`, which completed but reported the file is ignored by current ESLint ignore patterns and emitted no rule errors for the file content itself.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9762bf44c832991b5a4a4ea369ffc)