### PR TITLE
Enhance human rig: per-finger posing, global scale, leg IK and pose refinements

### DIFF
--- a/webapp/src/pages/Games/shared/humanRigCore.js
+++ b/webapp/src/pages/Games/shared/humanRigCore.js
@@ -5,6 +5,7 @@ const UP = Y_AXIS;
 const BASIS_MAT = new THREE.Matrix4();
 
 const BASE_CFG = {
+  scale: 1,
   poseLambda: 9,
   moveLambda: 5.6,
   rotLambda: 8.5,
@@ -70,7 +71,59 @@ const twistBone = (bone, axis, amount) => bone && Math.abs(amount) > 1e-5 && set
 const aimTwoBone = (u,l,e,h,p,us=0.96,ls=0.98) => { for(let i=0;i<4;i+=1){ rotateBoneToward(u,e,us,p); rotateBoneToward(l,h,ls,p);} };
 function setHandBasis(bone, side, up, forward, roll = 0, strength = 1) { if (!bone) return; const q = makeBasisQuaternion(side, up, forward); if (Math.abs(roll) > 1e-4) q.multiply(new THREE.Quaternion().setFromAxisAngle(forward.clone().normalize(), roll)); setBoneWorldQuaternion(bone, bone.getWorldQuaternion(new THREE.Quaternion()).slerp(q, clamp01(strength))); }
 function cueSocketOffsetWorld(side, up, forward, roll, socketLocal) { const q = makeBasisQuaternion(side, up, forward); if (Math.abs(roll) > 1e-5) q.multiply(new THREE.Quaternion().setFromAxisAngle(forward.clone().normalize(), roll)); return socketLocal.clone().applyQuaternion(q); }
-function poseFingers(fingers, mode, weight) { const w = clamp01(weight); fingers.forEach((f) => { if (mode === 'idle') { f.rotation.x += 0.018 * w; return; } f.rotation.x += (mode === 'grip' ? 0.5 : 0.2) * w; }); }
+function poseFingers(fingers, mode, weight) {
+  const w = clamp01(weight);
+  fingers.forEach((finger, i) => {
+    const n = cleanName(finger.name);
+    const thumb = n.includes('thumb');
+    const index = n.includes('index');
+    const middle = n.includes('middle');
+    const ring = n.includes('ring');
+    const pinky = n.includes('pinky') || n.includes('little');
+    const base = !(n.includes('2') || n.includes('3') || n.includes('intermediate') || n.includes('distal'));
+    const mid = n.includes('2') || n.includes('intermediate');
+    const tip = n.includes('3') || n.includes('distal');
+    if (mode === 'idle') {
+      finger.rotation.x += 0.018 * w;
+      finger.rotation.z += 0.01 * w * (i % 2 ? -1 : 1);
+      return;
+    }
+    if (mode === 'grip') {
+      if (thumb) {
+        finger.rotation.x += 0.48 * w;
+        finger.rotation.y += -0.82 * w;
+        finger.rotation.z += 0.54 * w;
+        return;
+      }
+      const curl = index ? (base ? 0.58 : mid ? 0.9 : 0.68)
+        : middle ? (base ? 0.76 : mid ? 1.02 : 0.76)
+        : ring ? (base ? 0.72 : mid ? 0.92 : 0.7)
+        : pinky ? (base ? 0.62 : mid ? 0.82 : 0.62)
+        : 0;
+      finger.rotation.x += curl * w;
+      finger.rotation.y += (index ? -0.12 : middle ? -0.03 : ring ? 0.04 : pinky ? 0.08 : 0) * w;
+      finger.rotation.z += (index ? -0.08 : middle ? -0.02 : ring ? 0.06 : pinky ? 0.12 : 0) * w;
+      return;
+    }
+    if (thumb) {
+      finger.rotation.x += -0.18 * w;
+      finger.rotation.y += 0.95 * w;
+      finger.rotation.z += -0.95 * w;
+    } else if (index) {
+      finger.rotation.x += (base ? 0.26 : mid ? 0.42 : 0.28) * w;
+      finger.rotation.y += -0.46 * w;
+      finger.rotation.z += -0.42 * w;
+    } else if (middle) {
+      finger.rotation.x += (base ? 0.18 : mid ? 0.32 : 0.22) * w;
+      finger.rotation.y += -0.12 * w;
+      finger.rotation.z += -0.14 * w;
+    } else if (ring || pinky) {
+      finger.rotation.x += (base ? (ring ? 0.08 : 0.05) : mid ? (ring ? 0.18 : 0.16) : tip ? (ring ? 0.12 : 0.1) : 0.1) * w;
+      finger.rotation.y += (ring ? 0.18 : 0.34) * w;
+      finger.rotation.z += (ring ? 0.28 : 0.46) * w;
+    }
+  });
+}
 
 export function createHumanRig(scene, opts = {}) {
   const cfg = { ...BASE_CFG, ...opts };
@@ -83,24 +136,64 @@ export function createHumanRig(scene, opts = {}) {
   return human;
 }
 
-function driveHuman(human, frame) { if (!human.activeGlb || !human.model) return; const cfg = human.cfg; human.modelRoot.visible=true; human.modelRoot.position.copy(frame.rootWorld); human.modelRoot.rotation.y=human.yaw; human.modelRoot.updateMatrixWorld(true); human.restQuats.forEach((q,b)=>b.quaternion.copy(q));
+function driveHuman(human, frame) { if (!human.activeGlb || !human.model) return; const cfg = human.cfg; human.modelRoot.visible=true; human.modelRoot.position.copy(frame.rootWorld); human.modelRoot.rotation.y=human.yaw; human.modelRoot.updateMatrixWorld(true); human.restQuats.forEach((q,b)=>b.quaternion.copy(q)); human.modelRoot.updateMatrixWorld(true);
   const b = human.bones; const ik = easeInOut(clamp01(frame.t)); const idle=1-ik; const cueDir = frame.cueTipWorld.clone().sub(frame.cueBackWorld).normalize(); const standingCueDir = cfg.idleCueDir.clone().applyAxisAngle(Y_AXIS, human.yaw).normalize();
-  const rightGrip = frame.rightHandWorld.clone(); const rightIdleElbow = rightGrip.clone().addScaledVector(UP,0.04+0.14*ik).addScaledVector(frame.side,-0.2).addScaledVector(frame.forward,-0.03*idle); const rightElbow=frame.rightElbow.clone().lerp(rightIdleElbow,idle*0.5); const pole = frame.side.clone().multiplyScalar(-1).addScaledVector(UP,0.32).addScaledVector(frame.forward,-0.55).normalize(); aimTwoBone(b.rightUpperArm,b.rightLowerArm,rightElbow,rightGrip,pole,0.9+0.1*ik,1.0);
+  if (frame.walkAmount * idle > 0.001) {
+    const s = Math.sin(human.walkT * 6.2);
+    const c = Math.cos(human.walkT * 6.2);
+    const w = frame.walkAmount * idle;
+    if (b.leftUpperLeg) b.leftUpperLeg.rotation.x += s * 0.22 * w;
+    if (b.rightUpperLeg) b.rightUpperLeg.rotation.x -= s * 0.22 * w;
+    if (b.leftLowerLeg) b.leftLowerLeg.rotation.x += Math.max(0, -s) * 0.18 * w;
+    if (b.rightLowerLeg) b.rightLowerLeg.rotation.x += Math.max(0, s) * 0.18 * w;
+    if (b.leftUpperArm) b.leftUpperArm.rotation.x -= s * 0.2 * w;
+    if (b.rightUpperArm) b.rightUpperArm.rotation.x += s * 0.2 * w;
+    if (b.spine) b.spine.rotation.z += c * 0.02 * w;
+    if (b.hips) b.hips.rotation.z -= c * 0.014 * w;
+  }
+
+  if (ik >= 0.025) {
+    const shotQ = makeBasisQuaternion(frame.side, UP, frame.forward);
+    rotateBoneToward(b.hips, frame.torsoCenterWorld, (0.12 + 0.35 * ik) * ik, frame.forward);
+    twistBone(b.hips, frame.side, -0.045 * ik);
+    twistBone(b.hips, frame.forward, -0.025 * ik);
+    rotateBoneToward(b.spine, frame.chestCenterWorld, (0.34 + 0.34 * ik) * ik, frame.forward);
+    twistBone(b.spine, frame.side, -0.2 * ik);
+    twistBone(b.spine, frame.forward, -0.04 * ik);
+    rotateBoneToward(b.chest, frame.neckWorld, (0.5 + 0.28 * ik) * ik, frame.forward);
+    twistBone(b.chest, frame.side, -0.32 * ik);
+    twistBone(b.chest, frame.forward, -0.025 * ik);
+    rotateBoneToward(b.neck, frame.headCenterWorld, 0.64 * ik, frame.forward);
+    twistBone(b.neck, frame.side, -0.12 * ik);
+    setBoneWorldQuaternion(b.head, b.head ? b.head.getWorldQuaternion(new THREE.Quaternion()).slerp(shotQ.clone().multiply(new THREE.Quaternion().setFromAxisAngle(frame.side, -0.12 * ik)).multiply(new THREE.Quaternion().setFromAxisAngle(frame.forward, -0.025 * ik)), 0.74 * ik) : shotQ);
+    human.modelRoot.updateMatrixWorld(true);
+  }
+  const rightGrip = frame.rightHandWorld.clone(); const rightIdleElbow = rightGrip.clone().addScaledVector(UP,(0.04+0.14*ik)*cfg.scale).addScaledVector(frame.side,-0.2*cfg.scale).addScaledVector(frame.forward,-0.03*cfg.scale*idle); const rightElbow=frame.rightElbow.clone().lerp(rightIdleElbow,idle*0.5); const pole = frame.side.clone().multiplyScalar(-1).addScaledVector(UP,0.32).addScaledVector(frame.forward,-0.55).normalize(); aimTwoBone(b.rightUpperArm,b.rightLowerArm,rightElbow,rightGrip,pole,0.9+0.1*ik,1.0);
   const standingHandSide = frame.side.clone().multiplyScalar(-1).addScaledVector(UP,-0.55).addScaledVector(frame.forward,0.16).normalize(); const standingHandUp = UP.clone().multiplyScalar(-1).addScaledVector(frame.side,-0.64).addScaledVector(frame.forward,0.2).normalize(); const handForward = ik>=0.025 ? standingCueDir : cueDir; const roll = ik>=0.025 ? cfg.rightHandRollIdle : cfg.rightHandRollIdle + 0.02*frame.stroke; setHandBasis(b.rightHand, standingHandSide, standingHandUp, handForward, roll, 1.0); poseFingers(human.rightFingers,'grip',0.95);
   if (ik < 0.025) { poseFingers(human.leftFingers,'idle',1); return; }
-  const leftHand = frame.leftHandWorld.clone(); const leftElbow = frame.leftElbow.clone(); aimTwoBone(b.leftUpperArm,b.leftLowerArm,leftElbow,leftHand,frame.side.clone().multiplyScalar(-1).addScaledVector(UP,0.1).normalize(),0.98*ik,1.0*ik);
+  const leftHand = frame.leftHandWorld.clone().addScaledVector(frame.forward, 0.032 * cfg.scale * ik).addScaledVector(frame.side, -0.018 * cfg.scale * ik).addScaledVector(UP, -0.018 * cfg.scale * ik); const leftElbow = frame.leftElbow.clone().addScaledVector(frame.forward, 0.045 * cfg.scale * ik).addScaledVector(frame.side, -0.05 * cfg.scale * ik).addScaledVector(UP, -0.01 * cfg.scale * ik); aimTwoBone(b.leftUpperArm,b.leftLowerArm,leftElbow,leftHand,frame.side.clone().multiplyScalar(-1).addScaledVector(UP,0.1).normalize(),0.98*ik,1.0*ik);
+  twistBone(b.leftUpperArm, frame.forward, -0.2 * ik);
+  twistBone(b.leftLowerArm, frame.forward, 0.025 * ik);
   const bridgeSide = frame.side.clone().multiplyScalar(-1).addScaledVector(frame.forward,-0.52).normalize(); const bridgeUp = UP.clone().multiplyScalar(0.78).addScaledVector(frame.forward,-0.28).addScaledVector(frame.side,-0.16).normalize(); setHandBasis(b.leftHand, bridgeSide, bridgeUp, cueDir, -0.68*ik, 1.0*ik); poseFingers(human.leftFingers,'bridge',ik);
+  aimTwoBone(b.leftUpperLeg, b.leftLowerLeg, frame.leftKnee, frame.leftFootWorld, frame.forward.clone().addScaledVector(UP, 0.18).normalize(), 0.9 * ik, 1.0 * ik);
+  twistBone(b.leftUpperLeg, frame.forward, -0.035 * ik);
+  setHandBasis(b.leftFoot, frame.side, frame.up, frame.forward, -0.02 * ik, cfg.footLockStrength * ik);
+  aimTwoBone(b.rightUpperLeg, b.rightLowerLeg, frame.rightKnee, frame.rightFootWorld, frame.forward.clone().multiplyScalar(-1).addScaledVector(UP, 0.18).normalize(), 0.9 * ik, 1.0 * ik);
+  twistBone(b.rightUpperLeg, frame.forward, 0.03 * ik);
+  setHandBasis(b.rightFoot, frame.side, frame.up, frame.forward, 0.02 * ik, cfg.footLockStrength * ik);
 }
 
-export function updateHumanPose(human, dt, frameData){ if(!human||!frameData) return; const cfg=human.cfg; const state=frameData.state||'idle'; human.poseT=dampScalar(human.poseT,state==='idle'?0:1,cfg.poseLambda,dt); human.breathT+=dt*(state==='idle'?1.05:0.5); if(state==='striking'){ if(human.strikeClock===0){ human.strikeRoot.copy(human.root.position.lengthSq()>0.001?human.root.position:frameData.rootTarget); human.strikeYaw=human.yaw;} human.strikeClock+=dt;} else human.strikeClock=0;
- const rootGoal=state==='striking'?human.strikeRoot:frameData.rootTarget; dampVector(human.root.position,rootGoal,state==='striking'?12:cfg.moveLambda,dt); const moveAmountRaw=human.root.position.distanceTo(rootGoal); human.walkT+=dt*(2+Math.min(7,moveAmountRaw*10)); human.yaw=dampScalar(human.yaw,state==='striking'?human.strikeYaw:yawFromForward(frameData.aimForward),cfg.rotLambda,dt);
- const t=easeInOut(human.poseT), idle=1-t; const walk=Math.sin(human.walkT*6.2)*Math.min(1,moveAmountRaw*12); const forward = new THREE.Vector3(0,0,-1).applyAxisAngle(Y_AXIS,human.yaw).normalize(); const side = new THREE.Vector3(forward.z,0,-forward.x).normalize(); const local = (v)=>v.clone().applyAxisAngle(Y_AXIS,human.yaw).add(human.root.position);
- const torso = local(new THREE.Vector3(0, lerp(1.3,1.14,t), lerp(0.02,-0.16,t))); const chest=local(new THREE.Vector3(0,lerp(1.52,1.24,t),lerp(0.02,-0.42,t))); const neck=local(new THREE.Vector3(0,lerp(1.68,1.28,t),lerp(0.02,-0.61,t))); const head=local(new THREE.Vector3(0,lerp(1.84,1.37,t),lerp(0.04,-0.72,t))); const leftShoulder=local(new THREE.Vector3(-0.23,lerp(1.58,1.36,t),lerp(0,-0.46,t))); const rightShoulder=local(new THREE.Vector3(0.23,lerp(1.58,1.36,t),lerp(0,-0.34,t)));
- const leftHip=local(new THREE.Vector3(-0.13,0.92,0.02)); const rightHip=local(new THREE.Vector3(0.13,0.92,0.02)); const leftFoot=local(new THREE.Vector3(-0.13,cfg.footGroundY,0.03+walk*0.018).lerp(new THREE.Vector3(-cfg.stanceWidth*0.42,cfg.footGroundY,-0.34),t)); const rightFoot=local(new THREE.Vector3(0.13,cfg.footGroundY,-0.03-walk*0.018).lerp(new THREE.Vector3(cfg.stanceWidth*0.5,cfg.footGroundY,0.34),t));
- const bridgePalm = frameData.bridgeTarget.clone().addScaledVector(forward,-0.006*t).addScaledVector(side,-0.012*t).setY(cfg.tableTopY+cfg.bridgePalmTableLift); const leftHand = frameData.idleLeft.clone().lerp(bridgePalm,t); const cueDir = frameData.cueTip.clone().sub(frameData.cueBack).normalize(); const handIk=easeInOut(clamp01(t)); const idleGripSide=side.clone().multiplyScalar(-1).addScaledVector(UP,-0.55).addScaledVector(forward,0.16).normalize(); const idleGripUp=UP.clone().multiplyScalar(-1).addScaledVector(side,-0.64).addScaledVector(forward,0.2).normalize(); const liveGripSide=side.clone().multiplyScalar(-1).addScaledVector(UP,lerp(-0.55,-0.62,handIk)).addScaledVector(side,0.5*handIk).addScaledVector(forward,lerp(0.16,-0.08,handIk)).normalize(); const liveGripUp=UP.clone().multiplyScalar(lerp(-1.0,0.12,handIk)).addScaledVector(side,lerp(-0.64,-0.04,handIk)).addScaledVector(forward,lerp(0.2,-0.48,handIk)).normalize();
- const lockedRightElbow = rightShoulder.clone().addScaledVector(UP, lerp(0.04,cfg.rightElbowShotRise,t)).addScaledVector(side,lerp(-0.18,cfg.rightElbowShotSide,t)).addScaledVector(forward,lerp(-0.04,cfg.rightElbowShotBack,t)); const pullBack = state==='dragging' ? -cfg.rightStrokePull*easeOutCubic(frameData.power||0) : 0; const push = state==='striking' ? cfg.rightStrokePush*Math.sin(clamp01(human.strikeClock/(cfg.strikeTime+cfg.holdTime))*Math.PI):0; const forearmBase = lockedRightElbow.clone().addScaledVector(side,cfg.rightForearmOutward*t).addScaledVector(UP,-cfg.rightForearmDown*t).addScaledVector(UP,cfg.rightHandShotLift*t).addScaledVector(forward,-cfg.rightForearmBack*t).addScaledVector(cueDir,cfg.rightForearmLength); const liveGripPoint = forearmBase.clone().addScaledVector(cueDir,pullBack+push); const idleWrist=frameData.idleRight.clone().sub(cueSocketOffsetWorld(idleGripSide,idleGripUp,cueDir,cfg.rightHandRollIdle,cfg.rightHandCueSocketLocal)); const liveWrist=liveGripPoint.clone().sub(cueSocketOffsetWorld(liveGripSide,liveGripUp,cueDir,lerp(cfg.rightHandRollIdle,cfg.rightHandRollShoot-cfg.rightHandDownPose,handIk),cfg.rightHandCueSocketLocal));
- const rightHand = idleWrist.clone().lerp(liveWrist,t); const leftElbow = leftShoulder.clone().lerp(leftHand,0.62); const leftKnee = leftHip.clone().lerp(leftFoot,0.53).addScaledVector(UP,lerp(0.2,cfg.kneeBendShot,t)); const rightKnee = rightHip.clone().lerp(rightFoot,0.52).addScaledVector(UP,lerp(0.2,cfg.kneeBendShot*0.88,t));
- human.root.visible=true; driveHuman(human,{t,stroke:pullBack+push,forward,side,up:UP,rootWorld:human.root.position.clone(),torsoCenterWorld:torso,chestCenterWorld:chest,neckWorld:neck,headCenterWorld:head,leftElbow,rightElbow:lockedRightElbow,leftHandWorld:leftHand,rightHandWorld:rightHand,leftKnee,rightKnee,leftFootWorld:leftFoot,rightFootWorld:rightFoot,cueBackWorld:frameData.cueBack,cueTipWorld:frameData.cueTip});
+export function updateHumanPose(human, dt, frameData){ if(!human||!frameData) return; const cfg=human.cfg; const state=frameData.state||'idle'; human.poseT=dampScalar(human.poseT,state==='idle'?0:1,cfg.poseLambda,dt); human.breathT+=dt*(state==='idle'?1.05:0.5); human.settleT=dampScalar(human.settleT,state==='dragging'?1:0,5.5,dt); if(state==='striking'){ if(human.strikeClock===0){ human.strikeRoot.copy(human.root.position.lengthSq()>0.001?human.root.position:frameData.rootTarget); human.strikeYaw=human.yaw;} human.strikeClock+=dt;} else human.strikeClock=0;
+ const rootGoal=state==='striking'?human.strikeRoot:frameData.rootTarget; dampVector(human.root.position,rootGoal,state==='striking'?12:cfg.moveLambda,dt); const moveAmountRaw=human.root.position.distanceTo(rootGoal); human.walkT+=dt*(2+Math.min(7,moveAmountRaw*10/cfg.scale)); human.yaw=dampScalar(human.yaw,state==='striking'?human.strikeYaw:yawFromForward(frameData.aimForward),cfg.rotLambda,dt);
+ const t=easeInOut(human.poseT), idle=1-t; const breath=Math.sin(human.breathT*Math.PI*2)*((0.006+idle*0.004)*cfg.scale); const walk=Math.sin(human.walkT*6.2)*Math.min(1,moveAmountRaw*12/cfg.scale); const walkAmount=clamp01(moveAmountRaw*18/cfg.scale)*idle; const strikeFollow=state==='striking'?Math.sin(clamp01(human.strikeClock/(cfg.strikeTime+cfg.holdTime))*Math.PI):0; const powerLean=(frameData.power||0)*t; const forward = new THREE.Vector3(0,0,-1).applyAxisAngle(Y_AXIS,human.yaw).normalize(); const side = new THREE.Vector3(forward.z,0,-forward.x).normalize(); const local = (v)=>v.clone().applyAxisAngle(Y_AXIS,human.yaw).add(human.root.position);
+ const rootWorld = human.root.position.clone().addScaledVector(forward, (0.018 * powerLean + 0.026 * strikeFollow)*cfg.scale); rootWorld.y = 0;
+ const torso = local(new THREE.Vector3(0, lerp(1.3,1.14,t)*cfg.scale+breath, (lerp(0.02,-0.16,t)-0.014*powerLean)*cfg.scale)); const chest=local(new THREE.Vector3(0,lerp(1.52,1.24,t)*cfg.scale+breath,(lerp(0.02,-0.42,t)-0.024*powerLean)*cfg.scale)); const neck=local(new THREE.Vector3(0,lerp(1.68,1.28,t)*cfg.scale+breath,(lerp(0.02,-0.61,t)-0.028*powerLean)*cfg.scale)); const head=local(new THREE.Vector3(0,lerp(1.84,1.37,t)*cfg.scale+breath-cfg.chinToCueHeight*0.16*t,(lerp(0.04,-0.72,t)-0.028*powerLean)*cfg.scale)); const leftShoulder=local(new THREE.Vector3(-0.23*cfg.scale,lerp(1.58,1.36,t)*cfg.scale+breath,(lerp(0,-0.46,t)-0.018*human.settleT)*cfg.scale)); const rightShoulder=local(new THREE.Vector3(0.23*cfg.scale,lerp(1.58,1.36,t)*cfg.scale+breath,(lerp(0,-0.34,t)-0.018*human.settleT)*cfg.scale));
+ const leftHip=local(new THREE.Vector3(-0.13*cfg.scale,0.92*cfg.scale,0.02*cfg.scale)); const rightHip=local(new THREE.Vector3(0.13*cfg.scale,0.92*cfg.scale,0.02*cfg.scale)); const leftFoot=local(new THREE.Vector3(-0.13*cfg.scale,cfg.footGroundY,0.03*cfg.scale+walk*0.018*cfg.scale).lerp(new THREE.Vector3(-cfg.stanceWidth*0.42,cfg.footGroundY,-0.34*cfg.scale),t)); const rightFoot=local(new THREE.Vector3(0.13*cfg.scale,cfg.footGroundY,-0.03*cfg.scale-walk*0.018*cfg.scale).lerp(new THREE.Vector3(cfg.stanceWidth*0.5,cfg.footGroundY,0.34*cfg.scale),t));
+ const bridgePalm = frameData.bridgeTarget.clone().addScaledVector(forward,-0.006*cfg.scale*t).addScaledVector(side,-0.012*cfg.scale*t).setY(cfg.tableTopY+cfg.bridgePalmTableLift).addScaledVector(UP, -0.01 * cfg.scale * human.settleT); const leftHand = frameData.idleLeft.clone().lerp(bridgePalm,t); const cueDir = frameData.cueTip.clone().sub(frameData.cueBack).normalize(); const handIk=easeInOut(clamp01(t)); const idleGripSide=side.clone().multiplyScalar(-1).addScaledVector(UP,-0.55).addScaledVector(forward,0.16).normalize(); const idleGripUp=UP.clone().multiplyScalar(-1).addScaledVector(side,-0.64).addScaledVector(forward,0.2).normalize(); const liveGripSide=side.clone().multiplyScalar(-1).addScaledVector(UP,lerp(-0.55,-0.62,handIk)).addScaledVector(side,0.5*handIk).addScaledVector(forward,lerp(0.16,-0.08,handIk)).normalize(); const liveGripUp=UP.clone().multiplyScalar(lerp(-1.0,0.12,handIk)).addScaledVector(side,lerp(-0.64,-0.04,handIk)).addScaledVector(forward,lerp(0.2,-0.48,handIk)).normalize();
+ const socketLocal = cfg.rightHandCueSocketLocal.clone().multiplyScalar(cfg.scale);
+ const lockedRightElbow = rightShoulder.clone().addScaledVector(UP, lerp(0.04*cfg.scale,cfg.rightElbowShotRise,t)).addScaledVector(side,lerp(-0.18*cfg.scale,cfg.rightElbowShotSide,t)).addScaledVector(forward,lerp(-0.04*cfg.scale,cfg.rightElbowShotBack,t)); const pullBack = state==='dragging' ? -cfg.rightStrokePull*easeOutCubic(frameData.power||0) : 0; const push = state==='striking' ? cfg.rightStrokePush*Math.sin(clamp01(human.strikeClock/(cfg.strikeTime+cfg.holdTime))*Math.PI):0; const forearmBase = lockedRightElbow.clone().addScaledVector(side,cfg.rightForearmOutward*t).addScaledVector(UP,-cfg.rightForearmDown*t).addScaledVector(UP,cfg.rightHandShotLift*t).addScaledVector(forward,-cfg.rightForearmBack*t).addScaledVector(cueDir,cfg.rightForearmLength); const liveGripPoint = forearmBase.clone().addScaledVector(cueDir,pullBack+push); const idleWrist=frameData.idleRight.clone().sub(cueSocketOffsetWorld(idleGripSide,idleGripUp,cueDir,cfg.rightHandRollIdle,socketLocal)); const liveWrist=liveGripPoint.clone().sub(cueSocketOffsetWorld(liveGripSide,liveGripUp,cueDir,lerp(cfg.rightHandRollIdle,cfg.rightHandRollShoot-cfg.rightHandDownPose,handIk),socketLocal));
+ const rightHand = idleWrist.clone().lerp(liveWrist,t); const leftElbow = leftShoulder.clone().lerp(leftHand,0.62).addScaledVector(UP,0.006*cfg.scale*t).addScaledVector(side,-0.044*cfg.scale*t).addScaledVector(forward,0.065*cfg.scale*t); const leftKnee = leftHip.clone().lerp(leftFoot,0.53).addScaledVector(UP,lerp(0.2*cfg.scale,cfg.kneeBendShot,t)).addScaledVector(forward,0.04*cfg.scale*t).addScaledVector(side,-0.012*cfg.scale*t); const rightKnee = rightHip.clone().lerp(rightFoot,0.52).addScaledVector(UP,lerp(0.2*cfg.scale,cfg.kneeBendShot*0.88,t)).addScaledVector(forward,-0.03*cfg.scale*t).addScaledVector(side,0.014*cfg.scale*t);
+ human.root.visible=true; driveHuman(human,{t,stroke:pullBack+push,walkAmount,forward,side,up:UP,rootWorld,torsoCenterWorld:torso,chestCenterWorld:chest,neckWorld:neck,headCenterWorld:head,leftElbow,rightElbow:lockedRightElbow,leftHandWorld:leftHand,rightHandWorld:rightHand,leftKnee,rightKnee,leftFootWorld:leftFoot,rightFootWorld:rightFoot,cueBackWorld:frameData.cueBack,cueTipWorld:frameData.cueTip});
 }
 
 export function chooseHumanEdgePosition(cueBallWorld, aimForward, opts = {}) { const cfg = { ...BASE_CFG, ...opts }; const desired = cueBallWorld.clone().addScaledVector(aimForward, -cfg.desiredShootDistance); const xEdge = (opts.tableW ?? 2.0)/2 + cfg.edgeMargin; const zEdge = (opts.tableL ?? 3.6)/2 + cfg.edgeMargin; const c=[new THREE.Vector3(-xEdge,0,clamp(desired.z,-zEdge,zEdge)),new THREE.Vector3(xEdge,0,clamp(desired.z,-zEdge,zEdge)),new THREE.Vector3(clamp(desired.x,-xEdge,xEdge),0,-zEdge),new THREE.Vector3(clamp(desired.x,-xEdge,xEdge),0,zEdge)]; return c.sort((a,b)=>a.distanceToSquared(desired)-b.distanceToSquared(desired))[0].clone(); }


### PR DESCRIPTION
### Motivation
- Add more realistic hand poses, per-finger articulation, and more consistent scaling support across the human rig. 
- Improve leg/foot behavior and add walk sway and settle behavior so avatars move and pose more naturally during idle, dragging, and striking states.
- Make torso/head/hip/chest rotations follow aiming/shot states with better damping and small tweaks for strike/power lean.

### Description
- Introduce a global `scale` config in `BASE_CFG` and apply `cfg.scale` to positions, offsets, walk/walkAmount, breath, and socket math throughout `updateHumanPose` and `driveHuman`.
- Replace the simple `poseFingers` with a richer implementation that inspects finger names and applies nuanced rotations per-finger and per-phalanx for `idle`, `grip`, and other modes in `poseFingers`.
- Add leg/foot procedural motion in `driveHuman`, including walk sway (upper/lower leg and arm swings), per-leg IK via `aimTwoBone`, leg twists, and foot locking using `setHandBasis` on foot bones.
- Enhance torso/hip/spine/chest/head aiming by adding conditional shot-driven rotations, twists, and a `settleT` influence, and update left-arm/bridge offsets and wrist/elbow calculations (including scaling of `rightHandCueSocketLocal` via `socketLocal`).
- Add breathing (`breathT`) and settling behavior, scale-aware root/world offsets for strike/power lean, and refinements to left/right knee/elbow positioning and walk timing.

### Testing
- Ran the project build with `yarn build` and the build completed successfully. 
- Ran the unit test suite with `yarn test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f968b294b48329a36e15e4b1f14ab7)