### PR TITLE
Align Murlan Royale held cards with avatar hand positions

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1793,6 +1793,46 @@ function computeHeldCardsPose({ player, resolvedSeatIndex = 0 }) {
   };
 }
 
+
+function alignHeldCardsToHands(rig, cardsGroup = null) {
+  if (!rig?.instance) return;
+  const heldCards = cardsGroup || rig.heldCards;
+  if (!heldCards) return;
+
+  const leftHandWorld = new THREE.Vector3();
+  const rightHandWorld = new THREE.Vector3();
+  const hasLeftHand = Boolean(rig.bones?.leftHand);
+  const hasRightHand = Boolean(rig.bones?.rightHand);
+
+  if (hasLeftHand) rig.bones.leftHand.getWorldPosition(leftHandWorld);
+  if (hasRightHand) rig.bones.rightHand.getWorldPosition(rightHandWorld);
+
+  const avgHandWorld = new THREE.Vector3();
+  if (hasLeftHand && hasRightHand) {
+    avgHandWorld.addVectors(leftHandWorld, rightHandWorld).multiplyScalar(0.5);
+  } else if (hasRightHand) {
+    avgHandWorld.copy(rightHandWorld);
+  } else if (hasLeftHand) {
+    avgHandWorld.copy(leftHandWorld);
+  } else {
+    const fallback = rig.heldCardsPose || computeHeldCardsPose({
+      player: { isHuman: Boolean(rig.isBottomHumanSeat) },
+      resolvedSeatIndex: rig.seatIndex ?? 0
+    });
+    heldCards.position.set(fallback.x, fallback.y, fallback.z);
+    return;
+  }
+
+  const localHandCenter = rig.instance.worldToLocal(avgHandWorld.clone());
+  const outwardDirection = (rig.seatConfig?.forward || new THREE.Vector3(0, 0, -1)).clone().normalize();
+  const outwardDistance = (rig.isBottomHumanSeat ? 0.06 : 0.12) * MODEL_SCALE;
+  const liftDistance = (rig.isBottomHumanSeat ? 0.055 : 0.075) * MODEL_SCALE;
+
+  localHandCenter.add(outwardDirection.multiplyScalar(outwardDistance));
+  localHandCenter.y += liftDistance;
+  heldCards.position.copy(localHandCenter);
+}
+
 function createCharacterRig(instance, seatRoot, seatConfig, characterTheme, player, playerIndex, cardTheme, cardTextureSize = null) {
   const hips = findBoneByHints(instance, ['hips', 'pelvis', 'pelvisjoint', 'hip_joint']);
   const spine = findBoneByHints(instance, ['spine', 'chest', 'torso']);
@@ -1910,6 +1950,8 @@ function createCharacterRig(instance, seatRoot, seatConfig, characterTheme, play
     rightCalf: captureBoneRotation(rightCalf)
   };
 
+  alignHeldCardsToHands(rig, heldCards);
+
   if (HUMAN_CARD_HAND_DEBUG_HELPERS) {
     const handHelper = new THREE.Mesh(
       new THREE.SphereGeometry(0.018 * MODEL_SCALE, 10, 10),
@@ -1963,6 +2005,7 @@ function refreshRigHeldCards(rig, handCardsInput, playerColor, cardTheme, cardTe
   nextCards.scale.setScalar(1.3);
 
   rig.heldCards = nextCards;
+  alignHeldCardsToHands(rig, nextCards);
 }
 
 function lerpBoneToPose(bone, from, to, t) {


### PR DESCRIPTION
### Motivation
- Held cards needed to sit visually where the character hands are and appear pushed outward and higher on portrait screens so the card stacks match the avatar hand coordinates precisely.

### Description
- Added `alignHeldCardsToHands(rig, cardsGroup = null)` which reads left/right hand bone world positions, averages them, converts that point into the character local space, and applies an outward push and upward lift before positioning the card group.
- The helper uses `rig.bones.leftHand` / `rig.bones.rightHand` when available and falls back to the previous `computeHeldCardsPose` for rigs without hand bones.
- Wired the alignment into `createCharacterRig(...)` (after `rig.seatedPose`) and into `refreshRigHeldCards(...)` (after creating `nextCards`) so cards follow the hands on initial setup and on refreshes.
- Implemented seat-aware tuning for outward and lift distances (different values for the bottom human seat vs opponents) and added the change in `webapp/src/pages/Games/MurlanRoyaleArena.jsx`.

### Testing
- Ran the production build with `npm -C webapp run build`, which completed successfully; Vite reported chunk-size/dynamic-import warnings but no build errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9a911b2bc8329ad53d42ac8ad1827)