### PR TITLE
Enable zoom while in locked 3D look and widen capture-camera view

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -433,7 +433,7 @@ const FALLBACK_SEAT_POSITIONS = [
 const CAMERA_WHEEL_FACTOR = ARENA_CAMERA_DEFAULTS.wheelDeltaFactor;
 const CAMERA_PULL_FORWARD_MIN = THREE.MathUtils.degToRad(15);
 const CAMERA_CAPTURE_VIEW_UPWARD_BIAS = THREE.MathUtils.degToRad(21); // raise forced 3D animation camera for a stronger portrait top-down feel.
-const CAMERA_CAPTURE_VIEW_RADIUS_SCALE = 0.82; // move forced 3D animation camera slightly closer during capture
+const CAMERA_CAPTURE_VIEW_RADIUS_SCALE = 1.18; // keep forced 3D animation wider during capture so the board stays fully readable
 const CAMERA_CAPTURE_BOTTOM_AVATAR_SCREEN_OFFSET = 6; // keep local player's avatar lower so chair/animation view stays clear
 const CAMERA_LOCKED_3D_PHI = THREE.MathUtils.degToRad(24); // high diagonal angle close to 2D while still showing depth toward the opponent.
 const CAMERA_LOCKED_3D_RADIUS_SCALE = 0.9; // keep 3D camera almost at 2D distance so the whole board remains visible in portrait.
@@ -9701,8 +9701,8 @@ function Chess3D({
     );
     controls.minAzimuthAngle = cameraSpherical.theta - horizontalSwing;
     controls.maxAzimuthAngle = cameraSpherical.theta + horizontalSwing;
-    controls.minDistance = cameraSpherical.radius;
-    controls.maxDistance = cameraSpherical.radius;
+    controls.minDistance = CAMERA_3D_MIN_RADIUS;
+    controls.maxDistance = CAMERA_3D_MAX_RADIUS;
     controls.update();
     controlsRef.current = controls;
     syncSkyboxToCamera = () => {
@@ -9806,7 +9806,7 @@ function Chess3D({
         controls.enabled = true;
         controls.enableRotate = true;
         controls.enablePan = false;
-        controls.enableZoom = false;
+        controls.enableZoom = true;
         controls.minPolarAngle = CAMERA_PULL_FORWARD_MIN;
         controls.maxPolarAngle = CAM.phiMax;
         controls.minDistance = CAMERA_3D_MIN_RADIUS;
@@ -13156,6 +13156,21 @@ function Chess3D({
       sel = null;
     };
 
+    const onWheel = (event) => {
+      if (!camera || !boardLookTarget) return;
+      if (viewModeRef.current !== '3d' || !locked3dViewRef.current.activeLook) return;
+      event.preventDefault();
+      const direction = camera.position.clone().sub(boardLookTarget).normalize();
+      const currentRadius = camera.position.distanceTo(boardLookTarget);
+      const delta = event.deltaY * CAMERA_WHEEL_FACTOR;
+      const nextRadius = clamp(currentRadius + delta, CAMERA_3D_MIN_RADIUS, CAMERA_3D_MAX_RADIUS);
+      camera.position.copy(boardLookTarget).addScaledVector(direction, nextRadius);
+      locked3dViewRef.current.fixedPosition = camera.position.clone();
+      controls?.update();
+      syncSkyboxToCamera();
+    };
+
+
     function aiMove() {
       if (isReplayingRef.current) return;
       if (isMoveInteractionLocked()) {
@@ -13233,6 +13248,7 @@ function Chess3D({
     renderer.domElement.addEventListener('touchend', onClick);
     renderer.domElement.addEventListener('pointerdown', onPointerDown);
     renderer.domElement.addEventListener('pointermove', onPointerMove);
+    renderer.domElement.addEventListener('wheel', onWheel, { passive: false });
     window.addEventListener('pointerup', onPointerUp);
 
     // Loop
@@ -14076,6 +14092,7 @@ function Chess3D({
         renderer.domElement.removeEventListener('click', onClick);
         renderer.domElement.removeEventListener('touchend', onClick);
         renderer.domElement.removeEventListener('pointerdown', onPointerDown);
+        renderer.domElement.removeEventListener('wheel', onWheel);
         renderer.domElement.removeEventListener('pointermove', onPointerMove);
         window.removeEventListener('pointerup', onPointerUp);
       }


### PR DESCRIPTION
### Motivation
- Players need to be able to zoom in/out while keeping the camera physically fixed and be able to look left/right/up/down without the camera drifting. 
- During capture/animation sequences the view should back out (wider) instead of moving closer so the board stays readable. 

### Description
- Increased `CAMERA_CAPTURE_VIEW_RADIUS_SCALE` from `0.82` to `1.18` so forced capture/3D animation views use a wider (zoomed-out) radius. (modified `webapp/src/pages/Games/ChessBattleRoyal.jsx`)
- Restored a normal 3D zoom range by setting the OrbitControls distances to `CAMERA_3D_MIN_RADIUS` / `CAMERA_3D_MAX_RADIUS` instead of pinning to a single spherical radius, and enabled `controls.enableZoom` for 3D mode. (modified `webapp/src/pages/Games/ChessBattleRoyal.jsx`)
- Added a dedicated `onWheel` handler that only acts in locked 3D look mode (`viewMode === '3d' && locked3dViewRef.current.activeLook`) to change the camera radius without moving the camera orientation, update `locked3dViewRef.current.fixedPosition`, and call `syncSkyboxToCamera()`; the handler prevents default wheel scrolling. (added in `webapp/src/pages/Games/ChessBattleRoyal.jsx`)
- Registered the wheel listener on `renderer.domElement` and cleaned it up during scene teardown to avoid leaks. (added/removed in `webapp/src/pages/Games/ChessBattleRoyal.jsx`)

### Testing
- Ran `npm run -s lint -- webapp/src/pages/Games/ChessBattleRoyal.jsx`, which completed successfully and emitted only a React version detection warning in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9bafdbca883298e0d5d836223e5ff)