### PR TITLE
Improve tennis AI reaction timing and world scaling/framing

### DIFF
--- a/Assets/Scripts/Gameplay/Tennis/TennisAIOpponent.cs
+++ b/Assets/Scripts/Gameplay/Tennis/TennisAIOpponent.cs
@@ -7,7 +7,9 @@ namespace TonPlaygram.Gameplay.Tennis
         [SerializeField] private TennisShotTuning shotTuning;
         [SerializeField] private Rigidbody ballBody;
         [SerializeField] private Transform hitTarget;
-        [SerializeField, Min(0.1f)] private float reactionTime = 0.18f;
+        [SerializeField, Min(0.01f)] private float reactionTime = 0.1f;
+        [SerializeField, Min(0f)] private float anticipationTime = 0.14f;
+        [SerializeField, Min(0.01f)] private float minReactionTime = 0.05f;
         [SerializeField, Min(0.1f)] private float minShotPower01 = 0.55f;
         [SerializeField, Min(0.1f)] private float maxShotPower01 = 1f;
 
@@ -18,9 +20,13 @@ namespace TonPlaygram.Gameplay.Tennis
             if (shotTuning == null || ballBody == null || hitTarget == null) return;
             if (Time.time < _nextHitTime) return;
 
-            if (ballBody.position.z > transform.position.z)
+            bool ballComingToAi = ballBody.velocity.z > 0f;
+            float predictedBallZ = ballBody.position.z + (ballBody.velocity.z * anticipationTime);
+            if (ballComingToAi && predictedBallZ > transform.position.z)
             {
-                _nextHitTime = Time.time + reactionTime;
+                float speed = ballBody.velocity.magnitude;
+                float adaptiveReaction = Mathf.Max(minReactionTime, reactionTime - (speed * 0.003f));
+                _nextHitTime = Time.time + adaptiveReaction;
                 ShootAdaptive();
             }
         }

--- a/Assets/Scripts/Gameplay/Tennis/TennisCourtScaler.cs
+++ b/Assets/Scripts/Gameplay/Tennis/TennisCourtScaler.cs
@@ -6,9 +6,21 @@ namespace TonPlaygram.Gameplay.Tennis
     {
         [SerializeField] private Transform courtRoot;
         [SerializeField] private Transform[] characterRoots;
+        [SerializeField] private Transform[] racketRoots;
+        [SerializeField] private Transform ballRoot;
+        [SerializeField] private Transform netRoot;
         [SerializeField] private Camera targetCamera;
-        [SerializeField, Min(0.1f)] private float worldScaleMultiplier = 1.2f;
-        [SerializeField, Min(1f)] private float framingDistanceScale = 1.2f;
+        [SerializeField] private Transform framingPivot;
+        [SerializeField, Min(0.1f)] private float worldScaleMultiplier = 1.35f;
+        [SerializeField, Min(1f)] private float framingDistanceScale = 1.35f;
+
+        private bool _initialized;
+        private Vector3 _initialCourtScale;
+        private Vector3[] _initialCharacterScales;
+        private Vector3[] _initialRacketScales;
+        private Vector3 _initialBallScale;
+        private Vector3 _initialNetScale;
+        private Vector3 _initialCameraPosition;
 
         private void Start()
         {
@@ -18,19 +30,75 @@ namespace TonPlaygram.Gameplay.Tennis
         [ContextMenu("Apply Scale + Camera Framing")]
         public void ApplyScaleAndFraming()
         {
-            if (courtRoot != null) courtRoot.localScale *= worldScaleMultiplier;
-            if (characterRoots != null)
-            {
-                for (int i = 0; i < characterRoots.Length; i++)
-                {
-                    if (characterRoots[i] != null) characterRoots[i].localScale *= worldScaleMultiplier;
-                }
-            }
+            EnsureInitialized();
+
+            SetScaled(courtRoot, _initialCourtScale);
+            SetScaled(ballRoot, _initialBallScale);
+            SetScaled(netRoot, _initialNetScale);
+            SetScaledArray(characterRoots, _initialCharacterScales);
+            SetScaledArray(racketRoots, _initialRacketScales);
+
+            ApplyCameraFraming();
+        }
+
+        private void EnsureInitialized()
+        {
+            if (_initialized) return;
+            _initialized = true;
+
+            _initialCourtScale = courtRoot != null ? courtRoot.localScale : Vector3.one;
+            _initialBallScale = ballRoot != null ? ballRoot.localScale : Vector3.one;
+            _initialNetScale = netRoot != null ? netRoot.localScale : Vector3.one;
+
+            _initialCharacterScales = CaptureScales(characterRoots);
+            _initialRacketScales = CaptureScales(racketRoots);
 
             if (targetCamera != null)
             {
-                targetCamera.transform.position *= framingDistanceScale;
+                _initialCameraPosition = targetCamera.transform.position;
             }
+        }
+
+        private void ApplyCameraFraming()
+        {
+            if (targetCamera == null) return;
+
+            if (framingPivot == null)
+            {
+                targetCamera.transform.position = _initialCameraPosition * framingDistanceScale;
+                return;
+            }
+
+            Vector3 offset = _initialCameraPosition - framingPivot.position;
+            targetCamera.transform.position = framingPivot.position + (offset * framingDistanceScale);
+        }
+
+        private Vector3[] CaptureScales(Transform[] roots)
+        {
+            if (roots == null) return null;
+
+            var scales = new Vector3[roots.Length];
+            for (int i = 0; i < roots.Length; i++)
+            {
+                scales[i] = roots[i] != null ? roots[i].localScale : Vector3.one;
+            }
+
+            return scales;
+        }
+
+        private void SetScaledArray(Transform[] roots, Vector3[] baseScales)
+        {
+            if (roots == null || baseScales == null) return;
+            for (int i = 0; i < roots.Length && i < baseScales.Length; i++)
+            {
+                SetScaled(roots[i], baseScales[i]);
+            }
+        }
+
+        private void SetScaled(Transform target, Vector3 baseScale)
+        {
+            if (target == null) return;
+            target.localScale = baseScale * worldScaleMultiplier;
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Make the AI react earlier and feel snappier when the ball is coming to its side. 
- Enlarge on-screen gameplay elements (characters, rackets, ball, court, net) while keeping the camera framing visually consistent.

### Description
- In `TennisAIOpponent.cs` reduced default `reactionTime`, added `anticipationTime` and `minReactionTime`, and predict the ball position using `Rigidbody.velocity` to trigger earlier responses and compute an adaptive reaction delay based on incoming ball speed. 
- Kept `ShootAdaptive()` behavior intact while the AI timing is driven by the prediction and adaptive timing. 
- In `TennisCourtScaler.cs` added `racketRoots`, `ballRoot`, `netRoot`, and optional `framingPivot`, increased default `worldScaleMultiplier` and `framingDistanceScale`, and switched to caching initial scales and camera position so scaling re-applies from baseline rather than compounding. 
- Added helper methods `EnsureInitialized`, `ApplyCameraFraming`, `CaptureScales`, `SetScaledArray`, and `SetScaled` to safely apply size changes and maintain composition when the camera backs out.

### Testing
- No automated Unity PlayMode or Editor tests were executed in this CLI environment. 
- Static/sanity checks of the modified files completed; runtime validation should be performed in the Unity Editor (run `Unity Test Runner` PlayMode tests and verify scene framing and AI responsiveness in play mode).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9be3e839c8329a9d1a8f6643c5db3)