### PR TITLE
Raise and move seated camera closer to table in Ludo Battle Royal

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -6004,16 +6004,16 @@ function resolveSeatedFaceCameraPose(actorEntry, fallbackTarget = null) {
       if (toGameplay.lengthSq() > 1e-8) {
         toGameplay.normalize();
         // Hard clamp camera to sit in front of the face toward table gameplay, never inside the skull mesh.
-        position.copy(headWorld).addScaledVector(toGameplay, 0.12 * MODEL_SCALE);
-        position.y += 0.03 * MODEL_SCALE;
+        position.copy(headWorld).addScaledVector(toGameplay, 0.155 * MODEL_SCALE);
+        position.y += 0.055 * MODEL_SCALE;
       }
     }
   } else if (actorEntry?.rig?.head?.isBone) {
     target.copy(headWorld);
     target.z += 0.285 * MODEL_SCALE;
     position.copy(headWorld);
-    position.z += 0.11 * MODEL_SCALE;
-    position.y += 0.03 * MODEL_SCALE;
+    position.z += 0.135 * MODEL_SCALE;
+    position.y += 0.055 * MODEL_SCALE;
   } else {
     target.copy(position).add(new THREE.Vector3(0, -0.004, 0.2 * MODEL_SCALE));
   }


### PR DESCRIPTION
### Motivation
- Improve portrait-mode framing so the seated first-person view sits higher and appears closer to the table, reducing avatar head occlusion and bringing gameplay into focus.

### Description
- Update `resolveSeatedFaceCameraPose` in `webapp/src/pages/Games/LudoBattleRoyal.jsx` to increase the face-camera forward offset from `0.12 * MODEL_SCALE` to `0.155 * MODEL_SCALE` and the upward lift from `0.03 * MODEL_SCALE` to `0.055 * MODEL_SCALE`, and to adjust the head-bone fallback offsets from `position.z += 0.11 * MODEL_SCALE` / `position.y += 0.03 * MODEL_SCALE` to `position.z += 0.135 * MODEL_SCALE` / `position.y += 0.055 * MODEL_SCALE` for consistent portrait framing.

### Testing
- Ran `npx eslint webapp/src/pages/Games/LudoBattleRoyal.jsx --max-warnings=0`, which reported the file is ignored by the repo lint configuration and produced a lint warning but no lint errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9bb6a06bc8329bf8a3e3b7917426c)