### PR TITLE
Adjust Ludo first-person camera higher and closer to table

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -3244,9 +3244,9 @@ const SEATED_HELPER_CONTACT_UP = -0.014 * MODEL_SCALE;
 const SEATED_HELPER_CONTACT_FORWARD = 0.102 * MODEL_SCALE;
 const SEATED_HELPER_FACE_CAMERA_RIGHT = 0;
 // Lift first-person camera anchor so viewpoint aligns at eye level on portrait screens.
-const SEATED_HELPER_FACE_CAMERA_UP = 0.082 * MODEL_SCALE;
+const SEATED_HELPER_FACE_CAMERA_UP = 0.116 * MODEL_SCALE;
 // Move camera anchor to the face-front side so the local player's head stays out of portrait framing.
-const SEATED_HELPER_FACE_CAMERA_FORWARD = -0.098 * MODEL_SCALE;
+const SEATED_HELPER_FACE_CAMERA_FORWARD = -0.072 * MODEL_SCALE;
 const SEATED_CONTACT_IK_ITERATIONS = 7;
 const SEATED_CONTACT_IK_MAX_STEP_RAD = 0.3;
 const SEATED_CONTACT_DICE_Y_OFFSET = 0.016;
@@ -6004,16 +6004,16 @@ function resolveSeatedFaceCameraPose(actorEntry, fallbackTarget = null) {
       if (toGameplay.lengthSq() > 1e-8) {
         toGameplay.normalize();
         // Hard clamp camera to sit in front of the face toward table gameplay, never inside the skull mesh.
-        position.copy(headWorld).addScaledVector(toGameplay, 0.12 * MODEL_SCALE);
-        position.y += 0.03 * MODEL_SCALE;
+        position.copy(headWorld).addScaledVector(toGameplay, 0.165 * MODEL_SCALE);
+        position.y += 0.058 * MODEL_SCALE;
       }
     }
   } else if (actorEntry?.rig?.head?.isBone) {
     target.copy(headWorld);
     target.z += 0.285 * MODEL_SCALE;
     position.copy(headWorld);
-    position.z += 0.11 * MODEL_SCALE;
-    position.y += 0.03 * MODEL_SCALE;
+    position.z += 0.145 * MODEL_SCALE;
+    position.y += 0.058 * MODEL_SCALE;
   } else {
     target.copy(position).add(new THREE.Vector3(0, -0.004, 0.2 * MODEL_SCALE));
   }


### PR DESCRIPTION
### Motivation
- The first-person camera for seated Ludo players was visually too low and too far outward on portrait/mobile screens, causing the view to sit on the avatar eyes and miss the table gameplay.
- Tune the face-camera anchor and runtime clamp so the POV is higher and nudged inward toward the table while still avoiding intersections with the skull mesh.

### Description
- Increased the face-camera helper vertical offset by updating `SEATED_HELPER_FACE_CAMERA_UP` to raise the camera anchor. 
- Reduced the outward framing by changing `SEATED_HELPER_FACE_CAMERA_FORWARD` to move the helper slightly closer to the table. 
- Increased runtime head-based clamp distances in `resolveSeatedFaceCameraPose` so the computed `position` is pushed higher and more inward toward gameplay.
- Modified file `webapp/src/pages/Games/LudoBattleRoyal.jsx` to apply these changes.

### Testing
- No automated tests were executed for this UI/tuning change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9bb6a06bc8329bf8a3e3b7917426c)