### PR TITLE
Add bowling-ball palette field textures to Air Hockey

### DIFF
--- a/webapp/src/components/AirHockey3D.jsx
+++ b/webapp/src/components/AirHockey3D.jsx
@@ -467,7 +467,52 @@ const loadGltfMaterialSet = (fieldOption) => {
   return promise;
 };
 
+
+const createBowlingBallPaletteTexture = (colors = []) => {
+  if (!Array.isArray(colors) || colors.length < 3 || typeof document === 'undefined') return null;
+  const canvas = document.createElement('canvas');
+  canvas.width = 1024;
+  canvas.height = 1024;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return null;
+  const gradient = ctx.createRadialGradient(320, 260, 30, 512, 512, 560);
+  gradient.addColorStop(0, colors[0]);
+  gradient.addColorStop(0.44, colors[1]);
+  gradient.addColorStop(1, colors[2]);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  ctx.globalAlpha = 0.13;
+  for (let i = 0; i < 110; i += 1) {
+    ctx.fillStyle = i % 2 === 0 ? '#ffffff' : colors[1];
+    ctx.beginPath();
+    ctx.arc(Math.random() * canvas.width, Math.random() * canvas.height, 14 + Math.random() * 70, 0, Math.PI * 2);
+    ctx.fill();
+  }
+  ctx.globalAlpha = 0.18;
+  for (let i = 0; i < 38; i += 1) {
+    ctx.strokeStyle = i % 2 ? colors[0] : 'rgba(0,0,0,0.8)';
+    ctx.lineWidth = 8 + Math.random() * 18;
+    ctx.beginPath();
+    ctx.moveTo(Math.random() * canvas.width, Math.random() * canvas.height);
+    for (let j = 0; j < 5; j += 1) {
+      ctx.lineTo(Math.random() * canvas.width, Math.random() * canvas.height);
+    }
+    ctx.stroke();
+  }
+  ctx.globalAlpha = 1;
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.colorSpace = THREE.SRGBColorSpace;
+  texture.wrapS = THREE.RepeatWrapping;
+  texture.wrapT = THREE.RepeatWrapping;
+  texture.needsUpdate = true;
+  return texture;
+};
+
 const loadFieldSurface = async (fieldOption) => {
+  if (fieldOption?.generatedTexture === 'bowlingBall') {
+    const map = createBowlingBallPaletteTexture(fieldOption?.swatches || []);
+    return map ? { textures: { map, normal: null, roughness: null, metalness: null, emissive: null } } : null;
+  }
   if (Array.isArray(fieldOption?.gltfUrls) && fieldOption.gltfUrls.length) {
     return loadGltfMaterialSet(fieldOption);
   }

--- a/webapp/src/config/airHockeyInventoryConfig.js
+++ b/webapp/src/config/airHockeyInventoryConfig.js
@@ -310,7 +310,10 @@ const FIELD_THUMBNAILS = Object.freeze({
   'bust-marble': polyHavenThumb('marble_bust_01'),
   'bust-onyx': polyHavenThumb('marble_bust_01'),
   'clearcoat-ruby': khronosThumb('ClearCoatCarPaint'),
-  'clearcoat-azure': khronosThumb('ClearCoatCarPaint')
+  'clearcoat-azure': khronosThumb('ClearCoatCarPaint'),
+  'bowling-pink-fusion': swatchThumbnail(['#ffa3bf', '#cf245d', '#4f0822']),
+  'bowling-cyan-storm': swatchThumbnail(['#9ee7ff', '#2d88ff', '#0d1d50']),
+  'bowling-amber-flare': swatchThumbnail(['#ffe59b', '#f57e09', '#5a2c00'])
 });
 
 const AIR_HOCKEY_TABLE_FINISHES = Object.freeze([
@@ -424,6 +427,46 @@ const createKhronosGltfUrls = (assetId) =>
     `https://cdn.jsdelivr.net/gh/KhronosGroup/glTF-Sample-Assets@main/Models/${assetId}/glTF-Binary/${assetId}.glb`
   ]);
 
+
+const BOWLING_BALL_FIELD_VARIANTS = Object.freeze([
+  Object.freeze({
+    id: 'bowling-pink-fusion',
+    name: 'Bowling Pink Fusion',
+    swatches: ['#ffa3bf', '#cf245d', '#4f0822'],
+    generatedTexture: 'bowlingBall',
+    repeat: 1,
+    lineColor: '#ffe4ee',
+    roughness: 0.14,
+    clearcoat: 1,
+    clearcoatRoughness: 0.04,
+    description: 'Uses the same pink bowling ball texture palette as Bowling Realistic.'
+  }),
+  Object.freeze({
+    id: 'bowling-cyan-storm',
+    name: 'Bowling Cyan Storm',
+    swatches: ['#9ee7ff', '#2d88ff', '#0d1d50'],
+    generatedTexture: 'bowlingBall',
+    repeat: 1,
+    lineColor: '#d9f6ff',
+    roughness: 0.14,
+    clearcoat: 1,
+    clearcoatRoughness: 0.04,
+    description: 'Uses the same cyan bowling ball texture palette as Bowling Realistic.'
+  }),
+  Object.freeze({
+    id: 'bowling-amber-flare',
+    name: 'Bowling Amber Flare',
+    swatches: ['#ffe59b', '#f57e09', '#5a2c00'],
+    generatedTexture: 'bowlingBall',
+    repeat: 1,
+    lineColor: '#fff0c7',
+    roughness: 0.14,
+    clearcoat: 1,
+    clearcoatRoughness: 0.04,
+    description: 'Uses the same amber bowling ball texture palette as Bowling Realistic.'
+  })
+]);
+
 const AIR_HOCKEY_MARBLE_FIELDS = Object.freeze([
   Object.freeze({
     id: 'bust-marble',
@@ -497,7 +540,7 @@ const AIR_HOCKEY_CUSHION_CLOTH_OPTIONS = Object.freeze(
 );
 
 export const AIR_HOCKEY_CUSTOMIZATION = Object.freeze({
-  field: AIR_HOCKEY_MARBLE_FIELDS,
+  field: Object.freeze([...AIR_HOCKEY_MARBLE_FIELDS, ...BOWLING_BALL_FIELD_VARIANTS]),
   cushionCloth: AIR_HOCKEY_CUSHION_CLOTH_OPTIONS,
   table: AIR_HOCKEY_TABLE_FINISHES,
   tableBase: AIR_HOCKEY_TABLE_BASES,


### PR DESCRIPTION
### Motivation
- Players requested that Air Hockey field surfaces reuse the same color palettes and look as the bowling balls used in the Bowling Realistic game so all bowling colors are available for the Air Hockey field. 
- Make it easy to offer glossy, marble-like surface variants without adding external assets by generating the texture procedurally at runtime.

### Description
- Added three new field variants (`bowling-pink-fusion`, `bowling-cyan-storm`, `bowling-amber-flare`) and thumbnails, and wired them into the Air Hockey customization list so they appear in `AIR_HOCKEY_CUSTOMIZATION.field`.
- Added `generatedTexture: 'bowlingBall'` on the new variants to mark them for procedural generation instead of loading external marble assets.
- Implemented `createBowlingBallPaletteTexture` in `AirHockey3D.jsx` which generates a glossy, bowling-ball-style `THREE.CanvasTexture` using the variant `swatches` and sets `colorSpace`, wrapping, and `needsUpdate` for proper SRGB rendering.
- Integrated the generator into `loadFieldSurface` so `fieldOption.generatedTexture === 'bowlingBall'` returns a texture bundle (`map` with null normal/roughness) that the existing material application code uses.

### Testing
- Ran the production build with `npm --prefix webapp run -s build`, and the build completed successfully.
- Verified the change compiles with the rest of the app (no runtime tests were run in CI as part of this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9c46197d48329afa7448178e31967)