### PR TITLE
Adjust tennis tuning and add TV-style replay with skip controls

### DIFF
--- a/Assets/Scripts/Gameplay/Tennis/README.md
+++ b/Assets/Scripts/Gameplay/Tennis/README.md
@@ -7,6 +7,14 @@ This folder adds modular tennis systems:
 - `TennisAudioController`: trigger shot and bounce SFX.
 - `TennisAIOpponent`: faster AI reaction and mixed shot variants.
 - `CharacterWalk8Dir`: 8-direction walk movement (forward/backward/sideways).
+- `TennisReplayController`: rolling gameplay capture + TV-style replay for fouls/decisive points, with skip button support in menu and replay overlay icon.
+
+## Replay setup
+
+1. Add `TennisReplayController` on the tennis scene root.
+2. Assign `playerRoot`, `opponentRoot`, `ballRoot`, `netRoot`.
+3. Assign `replayMenuSkipButton` and `replayOverlaySkipButton`.
+4. Call `RequestReplayOnFoul()` or `RequestReplayOnDecisivePoint()` from scoring/foul system.
 
 ## Free/open-source sound effect sources
 

--- a/Assets/Scripts/Gameplay/Tennis/TennisCourtScaler.cs
+++ b/Assets/Scripts/Gameplay/Tennis/TennisCourtScaler.cs
@@ -11,8 +11,8 @@ namespace TonPlaygram.Gameplay.Tennis
         [SerializeField] private Transform netRoot;
         [SerializeField] private Camera targetCamera;
         [SerializeField] private Transform framingPivot;
-        [SerializeField, Min(0.1f)] private float worldScaleMultiplier = 1.35f;
-        [SerializeField, Min(1f)] private float framingDistanceScale = 1.35f;
+        [SerializeField, Min(0.1f)] private float worldScaleMultiplier = 1.5f;
+        [SerializeField, Min(1f)] private float framingDistanceScale = 1.5f;
 
         private bool _initialized;
         private Vector3 _initialCourtScale;

--- a/Assets/Scripts/Gameplay/Tennis/TennisReplayController.cs
+++ b/Assets/Scripts/Gameplay/Tennis/TennisReplayController.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace TonPlaygram.Gameplay.Tennis
+{
+    /// <summary>
+    /// Lightweight TV-style replay recorder for tennis rallies.
+    /// Records runtime transforms and can replay for fouls/decisive points.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public class TennisReplayController : MonoBehaviour
+    {
+        [Header("Replay Targets")]
+        [SerializeField] private Transform playerRoot;
+        [SerializeField] private Transform opponentRoot;
+        [SerializeField] private Transform ballRoot;
+        [SerializeField] private Transform netRoot;
+
+        [Header("Capture")]
+        [SerializeField, Min(2)] private int maxFrames = 420;
+        [SerializeField, Min(0.01f)] private float sampleIntervalSeconds = 1f / 30f;
+
+        [Header("Playback")]
+        [SerializeField, Min(0.25f)] private float playbackSpeed = 0.65f;
+        [SerializeField] private GameObject replayMenuSkipButton;
+        [SerializeField] private Button replayOverlaySkipButton;
+        [SerializeField] private KeyCode keyboardSkipKey = KeyCode.Space;
+
+        private readonly List<ReplayFrame> _frames = new();
+        private float _captureTimer;
+        private int _playbackIndex;
+        private bool _isReplaying;
+        private bool _skipRequested;
+
+        private void Awake()
+        {
+            if (replayOverlaySkipButton != null)
+            {
+                replayOverlaySkipButton.onClick.AddListener(SkipReplay);
+            }
+
+            SetSkipUiVisible(false);
+        }
+
+        private void Update()
+        {
+            if (_isReplaying)
+            {
+                TickPlayback();
+                return;
+            }
+
+            _captureTimer += Time.unscaledDeltaTime;
+            if (_captureTimer < sampleIntervalSeconds) return;
+
+            _captureTimer = 0f;
+            CaptureCurrentFrame();
+        }
+
+        public void RequestReplayOnFoul() => TryStartReplay("FOUL");
+
+        public void RequestReplayOnDecisivePoint() => TryStartReplay("DECISIVE POINT");
+
+        public void SkipReplay()
+        {
+            if (!_isReplaying) return;
+            _skipRequested = true;
+        }
+
+        private void TryStartReplay(string reason)
+        {
+            if (_frames.Count < 2 || _isReplaying) return;
+
+            _isReplaying = true;
+            _skipRequested = false;
+            _playbackIndex = 0;
+            SetSkipUiVisible(true);
+            Debug.Log($"[TennisReplayController] Replay started: {reason}");
+        }
+
+        private void TickPlayback()
+        {
+            if (_skipRequested)
+            {
+                StopReplay();
+                return;
+            }
+
+            if (Input.GetKeyDown(keyboardSkipKey))
+            {
+                StopReplay();
+                return;
+            }
+
+            _playbackIndex += Mathf.Max(1, Mathf.RoundToInt(playbackSpeed));
+            if (_playbackIndex >= _frames.Count)
+            {
+                StopReplay();
+                return;
+            }
+
+            ApplyFrame(_frames[_playbackIndex]);
+        }
+
+        private void StopReplay()
+        {
+            _isReplaying = false;
+            _skipRequested = false;
+            SetSkipUiVisible(false);
+        }
+
+        private void SetSkipUiVisible(bool visible)
+        {
+            if (replayMenuSkipButton != null) replayMenuSkipButton.SetActive(visible);
+            if (replayOverlaySkipButton != null) replayOverlaySkipButton.gameObject.SetActive(visible);
+        }
+
+        private void CaptureCurrentFrame()
+        {
+            _frames.Add(new ReplayFrame
+            {
+                player = Snapshot.Of(playerRoot),
+                opponent = Snapshot.Of(opponentRoot),
+                ball = Snapshot.Of(ballRoot),
+                net = Snapshot.Of(netRoot)
+            });
+
+            if (_frames.Count > maxFrames)
+            {
+                _frames.RemoveAt(0);
+            }
+        }
+
+        private void ApplyFrame(ReplayFrame frame)
+        {
+            frame.player.Apply(playerRoot);
+            frame.opponent.Apply(opponentRoot);
+            frame.ball.Apply(ballRoot);
+            frame.net.Apply(netRoot);
+        }
+
+        [Serializable]
+        private struct ReplayFrame
+        {
+            public Snapshot player;
+            public Snapshot opponent;
+            public Snapshot ball;
+            public Snapshot net;
+        }
+
+        [Serializable]
+        private struct Snapshot
+        {
+            public Vector3 position;
+            public Quaternion rotation;
+
+            public static Snapshot Of(Transform t)
+            {
+                if (t == null) return default;
+                return new Snapshot { position = t.position, rotation = t.rotation };
+            }
+
+            public void Apply(Transform t)
+            {
+                if (t == null) return;
+                t.position = position;
+                t.rotation = rotation;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Tennis/TennisShotTuning.cs
+++ b/Assets/Scripts/Gameplay/Tennis/TennisShotTuning.cs
@@ -6,7 +6,7 @@ namespace TonPlaygram.Gameplay.Tennis
     public class TennisShotTuning : MonoBehaviour
     {
         [Header("Power")]
-        [Min(1f)] public float baseShotPower = 16f;
+        [Min(1f)] public float baseShotPower = 14.5f;
         [Range(0f, 2f)] public float topspin = 0.35f;
         [Range(0f, 2f)] public float sidespin = 0.2f;
         [Range(0f, 2f)] public float curvePower = 0.5f;


### PR DESCRIPTION
### Motivation
- Soften tennis shot feel and improve balance by slightly lowering default shot power. 
- Make the court and core objects visually larger while keeping the camera framing similar to the existing view. 
- Provide TV-style replay for fouls and decisive points with an easy skip flow so replays don't interrupt play.

### Description
- Reduced base shot power in `TennisShotTuning` by changing `baseShotPower` from `16f` to `14.5f` to reduce overall hit strength while keeping shot variant logic unchanged. 
- Increased `worldScaleMultiplier` and `framingDistanceScale` defaults to `1.5f` in `TennisCourtScaler` so court, characters, racket, net and ball appear larger while the camera is moved back to preserve framing. 
- Added new `TennisReplayController` that samples transforms (player, opponent, ball, net) into a bounded buffer (`maxFrames`, sampled at `sampleIntervalSeconds`) and can start playback via `RequestReplayOnFoul()` and `RequestReplayOnDecisivePoint()`; playback supports menu skip button, overlay skip button, and keyboard skip, and uses `playbackSpeed` to control replay rate. 
- Updated `Assets/Scripts/Gameplay/Tennis/README.md` with setup and integration steps for the replay controller (assign roots, hook skip UI, call replay triggers).

### Testing
- Ran repository checks: `git status --short` completed successfully. 
- Committed changes with `git commit -m "Tune tennis scale/power and add replay controller"` which succeeded. 
- Created PR metadata via `make_pr` which produced the PR title and body successfully. 
- No automated unit or runtime tests were run as part of this change; integration/QA and playtesting in-editor are recommended to validate replay timing, camera framing, and physics balance.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9cf0d41f08329a3fa3dc6b3a0d68a)