### PR TITLE
Push and lift Murlan player hand cards; disable procedural held-card meshes

### DIFF
--- a/webapp/src/pages/Games/MurlanRoyaleArena.jsx
+++ b/webapp/src/pages/Games/MurlanRoyaleArena.jsx
@@ -1673,6 +1673,8 @@ async function loadCharacterModel(theme, renderer = null) {
   return promise;
 }
 
+const SHOW_PROCEDURAL_CHARACTER_HELD_CARDS = false;
+
 function createCharacterCards({ handLift = 0.96, handCardsInput = [], cardTheme = CARD_THEMES[0], playerColor = '#1d4ed8', cardTextureSize = null } = {}) {
   const cardsGroup = new THREE.Group();
   const handCards = Array.isArray(handCardsInput) && handCardsInput.length
@@ -1809,23 +1811,26 @@ function createCharacterRig(instance, seatRoot, seatConfig, characterTheme, play
   const rightThigh = findBoneByHints(instance, ['rightupleg', 'rightthigh', 'r_thigh', 'legjointr1', 'leg_joint_r_1', 'leg_joint_r']);
   const rightCalf = findBoneByHints(instance, ['rightleg', 'rightcalf', 'r_calf', 'legjointr2', 'leg_joint_r_2', 'leg_joint_r_3']);
 
-  const heldCards = createCharacterCards({
-    handLift: characterTheme.handLift ?? 0.94,
-    handCardsInput: player?.hand ?? [],
-    cardTheme,
-    playerColor: PLAYER_COLORS[playerIndex % PLAYER_COLORS.length] ?? '#1d4ed8',
-    cardTextureSize
-  });
-
-  heldCards.userData.playerColor = PLAYER_COLORS[playerIndex % PLAYER_COLORS.length] ?? '#1d4ed8';
-  heldCards.userData.cardsSignature = (player?.hand ?? []).slice(0, 5).map((card) => `${card.rank || ''}${card.suit || ''}`).join('-');
-
-  instance.add(heldCards);
+  let heldCards = null;
   const resolvedSeatIndex = seatConfig?.seatIndex ?? playerIndex;
   const heldCardsPose = computeHeldCardsPose({ player, resolvedSeatIndex });
-  heldCards.position.set(heldCardsPose.x, heldCardsPose.y, heldCardsPose.z);
-  heldCards.rotation.set(THREE.MathUtils.degToRad(-18), THREE.MathUtils.degToRad(0), THREE.MathUtils.degToRad(0));
-  heldCards.scale.setScalar(1.2);
+  if (SHOW_PROCEDURAL_CHARACTER_HELD_CARDS) {
+    heldCards = createCharacterCards({
+      handLift: characterTheme.handLift ?? 0.94,
+      handCardsInput: player?.hand ?? [],
+      cardTheme,
+      playerColor: PLAYER_COLORS[playerIndex % PLAYER_COLORS.length] ?? '#1d4ed8',
+      cardTextureSize
+    });
+
+    heldCards.userData.playerColor = PLAYER_COLORS[playerIndex % PLAYER_COLORS.length] ?? '#1d4ed8';
+    heldCards.userData.cardsSignature = (player?.hand ?? []).slice(0, 5).map((card) => `${card.rank || ''}${card.suit || ''}`).join('-');
+
+    instance.add(heldCards);
+    heldCards.position.set(heldCardsPose.x, heldCardsPose.y, heldCardsPose.z);
+    heldCards.rotation.set(THREE.MathUtils.degToRad(-18), THREE.MathUtils.degToRad(0), THREE.MathUtils.degToRad(0));
+    heldCards.scale.setScalar(1.2);
+  }
 
   if (!leftThigh || !rightThigh) {
     instance.position.y -= 0.02 * MODEL_SCALE;
@@ -1932,6 +1937,13 @@ function createCharacterRig(instance, seatRoot, seatConfig, characterTheme, play
 
 function refreshRigHeldCards(rig, handCardsInput, playerColor, cardTheme, cardTextureSize = null) {
   if (!rig) return;
+  if (!SHOW_PROCEDURAL_CHARACTER_HELD_CARDS) {
+    const parent = rig.heldCards?.parent || null;
+    rig.heldCards?.userData?.dispose?.();
+    if (parent) parent.remove(rig.heldCards);
+    rig.heldCards = null;
+    return;
+  }
   const safeCards = Array.isArray(handCardsInput) && handCardsInput.length ? handCardsInput.slice(0, 5) : [];
   const currentCount = rig.heldCards?.children?.length ?? 0;
   const colorChanged = rig.heldCards?.userData?.playerColor !== playerColor;
@@ -2592,6 +2604,8 @@ const AI_CARD_LIFT = 0.076 * MODEL_SCALE;
 const AI_CARD_PRE_LIFT = 0.058 * MODEL_SCALE;
 const AI_CARD_PRE_LIFT_PORTION = 0.32;
 const AI_CARD_OUTWARD = 0.26 * MODEL_SCALE;
+const PLAYER_HAND_OUTWARD_PUSH_ONE_CARD = CARD_H;
+const PLAYER_HAND_UP_LIFT_ONE_CARD = CARD_H;
 
 function resolveSeatHandRadius(tableRadius, isHumanSeat) {
   const safeTableRadius = Number.isFinite(tableRadius) ? tableRadius : TABLE_RADIUS;
@@ -4028,7 +4042,8 @@ export default function MurlanRoyaleArena({ search }) {
           ? -spread / 2 + (cardIdx / Math.max(cards.length - 1, 1)) * spread
           : 0;
         const lateral = humanLineOffset;
-        const radial = player.isHuman ? radius : radius + AI_CARD_OUTWARD;
+        const radialBase = player.isHuman ? radius : radius + AI_CARD_OUTWARD;
+        const radial = radialBase + PLAYER_HAND_OUTWARD_PUSH_ONE_CARD;
         const fanArcLift = isHumanCard ? HUMAN_HAND_FAN_ARC_LIFT : AI_HAND_FAN_ARC_LIFT;
         const fanDirection = isHumanCard
           ? HUMAN_HAND_FAN_DIRECTION
@@ -4061,7 +4076,8 @@ export default function MurlanRoyaleArena({ search }) {
           (isHumanCard ? HUMAN_HAND_BOTTOM_SHIFT_Y : AI_HAND_BOTTOM_SHIFT_Y) +
           HUMAN_HAND_UP_SHIFT_Y +
           leftWeight * HUMAN_HAND_DIRECTIONAL_LIFT +
-          (!isHumanCard && (seat?.handVariant === 'top' || seat?.handVariant === 'side') ? AI_TOP_SIDE_HAND_UP_SHIFT_Y : 0);
+          (!isHumanCard && (seat?.handVariant === 'top' || seat?.handVariant === 'side') ? AI_TOP_SIDE_HAND_UP_SHIFT_Y : 0) +
+          PLAYER_HAND_UP_LIFT_ONE_CARD;
         if (isHumanCard && selectionSet.has(card.id)) target.y += HUMAN_SELECTION_OFFSET;
         mesh.scale.setScalar(HUMAN_HAND_CARD_SCALE);
         const handLookTarget = target.clone().addScaledVector(forward, 2.4 * MODEL_SCALE);


### PR DESCRIPTION
### Motivation
- Player hand cards should be visually pushed outward from the table and lifted higher (by the visual height of one card) for portrait/mobile framing. 
- The small procedural held-card groups attached to character rigs were recently added and must be removed so only the main glTF/in-game card presentation remains.

### Description
- Added `SHOW_PROCEDURAL_CHARACTER_HELD_CARDS = false` to disable the procedural held-card meshes in `MurlanRoyaleArena.jsx` and conditionally skip creating them in `createCharacterRig`.
- Added a cleanup guard in `refreshRigHeldCards` to dispose and remove any existing procedural held cards when the feature flag is off.
- Introduced `PLAYER_HAND_OUTWARD_PUSH_ONE_CARD` and `PLAYER_HAND_UP_LIFT_ONE_CARD` (set to `CARD_H`) and applied them to hand placement logic so each player hand is pushed outward and lifted by one card unit when laying out the cards.
- Changes are confined to `webapp/src/pages/Games/MurlanRoyaleArena.jsx` and keep the primary glTF card rendering untouched.

### Testing
- No automated unit/CI tests were executed for this change; please run the project CI and perform mobile-portrait manual QA to validate visual placement and that the procedural held cards are not rendered.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9ce372a748329b1db2e6c362fdbb2)