### PR TITLE
Enable 3D zoom/look-around and tighten table/chair/camera framing in Chess Battle Royal

### DIFF
--- a/webapp/src/pages/Games/ChessBattleRoyal.jsx
+++ b/webapp/src/pages/Games/ChessBattleRoyal.jsx
@@ -364,7 +364,7 @@ const PIECE_Y = 1.2; // baseline height for meshes
 const PIECE_PLACEMENT_Y_OFFSET = 0.24; // Lower tokens slightly so they stay grounded on the board after shrinking.
 const LAYOUT_SCALE_FACTOR = 0.7225;
 const TABLE_LAYOUT_SCALE_FACTOR = 0.52; // Scale down board/table/chairs further for a tighter portrait composition.
-const PIECE_SCALE_FACTOR = 0.73 * LAYOUT_SCALE_FACTOR * 1.5 * 0.82; // Enlarge pieces so they stay readable after shrinking the board footprint.
+const PIECE_SCALE_FACTOR = 0.73 * LAYOUT_SCALE_FACTOR * 1.5 * 0.82 * 1.14; // Keep piece visual size stable while shrinking board footprint.
 const PIECE_FOOTPRINT_RATIO = 0.86;
 const BOARD_GROUP_Y_OFFSET = 0.05;
 const BOARD_MODEL_Y_OFFSET = -0.12;
@@ -372,7 +372,7 @@ const BOARD_VISUAL_Y_OFFSET = -0.03;
 const BOARD_SURFACE_DROP = 0.05;
 
 const RAW_BOARD_SIZE = BOARD.N * BOARD.tile + BOARD.rim * 2;
-const BOARD_SCALE = 0.0359 * LAYOUT_SCALE_FACTOR * TABLE_LAYOUT_SCALE_FACTOR * 0.78;
+const BOARD_SCALE = 0.0359 * LAYOUT_SCALE_FACTOR * TABLE_LAYOUT_SCALE_FACTOR * 0.69;
 const BOARD_DISPLAY_SIZE = RAW_BOARD_SIZE * BOARD_SCALE;
 const BOARD_MODEL_SPAN_BIAS = 1.18;
 const HIGHLIGHT_VERTICAL_OFFSET = 0.18;
@@ -406,8 +406,8 @@ const CHAIR_SCALE = 0.96 * LAYOUT_SCALE_FACTOR * TABLE_LAYOUT_SCALE_FACTOR;
 const CHAIR_WIDTH_SCALE = 1.1; // Slightly widen/deepen chairs so they read larger in portrait.
 const CHAIR_VERTICAL_OFFSET = -0.065 * MODEL_SCALE;
 const CHAIR_CLEARANCE = AI_CHAIR_GAP;
-const PLAYER_CHAIR_EXTRA_CLEARANCE = -0.2 * MODEL_SCALE; // Pull local chair/human closer to the table.
-const OPPONENT_CHAIR_EXTRA_CLEARANCE = -0.18 * MODEL_SCALE; // Pull opponent chair/human closer to the table too.
+const PLAYER_CHAIR_EXTRA_CLEARANCE = -0.28 * MODEL_SCALE; // Pull local chair/human closer to the table.
+const OPPONENT_CHAIR_EXTRA_CLEARANCE = -0.24 * MODEL_SCALE; // Pull opponent chair/human closer to the table too.
 const CHAIR_TABLE_PUSHBACK = 0.04 * MODEL_SCALE;
 const CHAIR_TABLE_GAP_MIN = 0.08 * MODEL_SCALE;
 const CHAIR_TABLE_GAP_MAX = 0.42 * MODEL_SCALE;
@@ -450,11 +450,11 @@ const SEATED_HUMAN_FACING_Y = 0;
 const SEATED_HUMAN_PICK_LIFT_HEIGHT = 0.16;
 const SEATED_HUMAN_HAND_PIECE_FORWARD = 0.012;
 const PLAYER_VIEW_SEAT_THETA = Math.PI / 2;
-const PLAYER_VIEW_CAMERA_BACK_OFFSET_PORTRAIT = 1.64;
+const PLAYER_VIEW_CAMERA_BACK_OFFSET_PORTRAIT = 1.38;
 const PLAYER_VIEW_CAMERA_BACK_OFFSET_LANDSCAPE = 1.34;
-const PLAYER_VIEW_CAMERA_FORWARD_OFFSET_PORTRAIT = 0.98;
+const PLAYER_VIEW_CAMERA_FORWARD_OFFSET_PORTRAIT = 1.08;
 const PLAYER_VIEW_CAMERA_FORWARD_OFFSET_LANDSCAPE = 0.68;
-const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_PORTRAIT = 1.94;
+const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_PORTRAIT = 1.72;
 const PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_LANDSCAPE = 0.78;
 const PLAYER_VIEW_LOOK_TARGET_FORWARD_BIAS = -BOARD.tile * BOARD_SCALE * 0.42;
 const TABLE_BOTTOM_PLAYER_BIAS_Z = BOARD.tile * BOARD_SCALE * 1.84; // Push board/chairs/avatars further downward on portrait screens to match the reference framing.
@@ -9675,7 +9675,7 @@ function Chess3D({
     controls.dampingFactor = 0.08;
     controls.enablePan = false;
     controls.screenSpacePanning = true;
-    controls.enableZoom = false;
+    controls.enableZoom = true;
     controls.minDistance = CAMERA_3D_MIN_RADIUS;
     controls.maxDistance = CAMERA_3D_MAX_RADIUS;
     controls.minPolarAngle = CAMERA_PULL_FORWARD_MIN;
@@ -9686,9 +9686,9 @@ function Chess3D({
     controls.target.copy(boardLookTarget);
     const cameraOffset = camera.position.clone().sub(boardLookTarget);
     const cameraSpherical = new THREE.Spherical().setFromVector3(cameraOffset);
-    const horizontalSwing = THREE.MathUtils.degToRad(isPortrait ? 32 : 27);
-    const verticalAllowanceUp = THREE.MathUtils.degToRad(isPortrait ? 18 : 14);
-    const verticalAllowanceDown = THREE.MathUtils.degToRad(isPortrait ? 20 : 16);
+    const horizontalSwing = THREE.MathUtils.degToRad(isPortrait ? 95 : 80);
+    const verticalAllowanceUp = THREE.MathUtils.degToRad(isPortrait ? 38 : 28);
+    const verticalAllowanceDown = THREE.MathUtils.degToRad(isPortrait ? 42 : 30);
     controls.minPolarAngle = clamp(
       cameraSpherical.phi - verticalAllowanceUp,
       CAMERA_PULL_FORWARD_MIN,
@@ -9809,6 +9809,8 @@ function Chess3D({
         controls.enableZoom = true;
         controls.minPolarAngle = CAMERA_PULL_FORWARD_MIN;
         controls.maxPolarAngle = CAM.phiMax;
+        controls.minAzimuthAngle = -Infinity;
+        controls.maxAzimuthAngle = Infinity;
         controls.minDistance = CAMERA_3D_MIN_RADIUS;
         controls.maxDistance = CAMERA_3D_MAX_RADIUS;
         const restore = cameraMemory.last3d || default3d;


### PR DESCRIPTION
### Motivation
- Give players freedom to look around and zoom the 3D scene while keeping a tight, readable portrait framing around the bottom player.
- Pull chairs, human characters and the player camera closer to the table so the table and seated character feel nearer on mobile portrait screens.
- Reduce the board footprint while keeping piece visuals the same readable size for clarity on small/mobile displays.

### Description
- Enabled OrbitControls zoom (`controls.enableZoom = true`), widened initial orbit allowances (larger horizontal/vertical swing) and removed azimuth locking when entering 3D mode (`minAzimuthAngle = -Infinity`, `maxAzimuthAngle = Infinity`) to allow freer rotation and zooming in 3D view. 
- Reduced the board visual scale by adjusting `BOARD_SCALE`, and increased `PIECE_SCALE_FACTOR` so pieces remain visually the same size despite the smaller board footprint. 
- Moved seating and camera closer by decreasing `PLAYER_CHAIR_EXTRA_CLEARANCE`/`OPPONENT_CHAIR_EXTRA_CLEARANCE` and tuning portrait camera offsets (`PLAYER_VIEW_CAMERA_BACK_OFFSET_PORTRAIT`, `PLAYER_VIEW_CAMERA_FORWARD_OFFSET_PORTRAIT`, `PLAYER_VIEW_CAMERA_HEIGHT_OFFSET_PORTRAIT`).
- Modified the single source file `webapp/src/pages/Games/ChessBattleRoyal.jsx` to apply the above changes.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9cbac9ac883299630e659fe49a4d4)