### PR TITLE
Tennis: reduce shot power, enlarge court framing, and add TV-style replay with skip

### DIFF
--- a/Assets/Scripts/Gameplay/Tennis/README.md
+++ b/Assets/Scripts/Gameplay/Tennis/README.md
@@ -14,3 +14,11 @@ This folder adds modular tennis systems:
 2. Sonniss GDC free packs: https://sonniss.com/gameaudiogdc
 
 Import chosen WAV/OGG files into Unity and assign them to `shotClip` and `ballBounceClip`.
+
+
+## Replay flow (TV-style VAR)
+
+- Add `TennisReplayDirector` in the tennis scene and connect `ReplayBroadcastGate`.
+- Call `OnDecisivePoint(...)` for match-point / winner moments and `OnFoul(...)` for fouls.
+- Wire `menuSkipReplayButton` (menu-level skip) and `replaySkipIconButton` (overlay skip icon).
+- Optional: assign `replayOverlay` CanvasGroup to show replay UI while active.

--- a/Assets/Scripts/Gameplay/Tennis/TennisCourtScaler.cs
+++ b/Assets/Scripts/Gameplay/Tennis/TennisCourtScaler.cs
@@ -11,8 +11,8 @@ namespace TonPlaygram.Gameplay.Tennis
         [SerializeField] private Transform netRoot;
         [SerializeField] private Camera targetCamera;
         [SerializeField] private Transform framingPivot;
-        [SerializeField, Min(0.1f)] private float worldScaleMultiplier = 1.35f;
-        [SerializeField, Min(1f)] private float framingDistanceScale = 1.35f;
+        [SerializeField, Min(0.1f)] private float worldScaleMultiplier = 1.5f;
+        [SerializeField, Min(1f)] private float framingDistanceScale = 1.5f;
 
         private bool _initialized;
         private Vector3 _initialCourtScale;

--- a/Assets/Scripts/Gameplay/Tennis/TennisReplayDirector.cs
+++ b/Assets/Scripts/Gameplay/Tennis/TennisReplayDirector.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections;
+using UnityEngine;
+using UnityEngine.UI;
+using Aiming.Gameplay.Broadcast;
+
+namespace TonPlaygram.Gameplay.Tennis
+{
+    /// <summary>
+    /// Lightweight TV-style replay trigger for decisive points/fouls with global skip controls.
+    /// Hook this from gameplay events: OnDecisivePoint / OnFoul.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public class TennisReplayDirector : MonoBehaviour
+    {
+        [Header("Replay Dependencies")]
+        [SerializeField] private ReplayBroadcastGate replayGate;
+
+        [Header("Replay Timing")]
+        [SerializeField, Min(0.2f)] private float replayDurationSeconds = 3f;
+        [SerializeField] private bool pauseGameplayDuringReplay = true;
+
+        [Header("Skip Controls")]
+        [SerializeField] private Button menuSkipReplayButton;
+        [SerializeField] private Button replaySkipIconButton;
+        [SerializeField] private CanvasGroup replayOverlay;
+
+        private Coroutine replayRoutine;
+        private bool isReplayActive;
+        private float previousTimeScale = 1f;
+
+        public bool IsReplayActive => isReplayActive;
+
+        private void Awake()
+        {
+            if (menuSkipReplayButton != null)
+                menuSkipReplayButton.onClick.AddListener(SkipReplay);
+            if (replaySkipIconButton != null)
+                replaySkipIconButton.onClick.AddListener(SkipReplay);
+
+            SetReplayOverlayVisible(false);
+        }
+
+        private void OnDestroy()
+        {
+            if (menuSkipReplayButton != null)
+                menuSkipReplayButton.onClick.RemoveListener(SkipReplay);
+            if (replaySkipIconButton != null)
+                replaySkipIconButton.onClick.RemoveListener(SkipReplay);
+        }
+
+        public void OnDecisivePoint(string pointId, Vector3 ballPosition, Vector3 shotDirection, float powerNormalized)
+        {
+            RequestReplay(pointId, ballPosition, shotDirection, powerNormalized, replayOnPoint: true, replayOnFoul: false);
+        }
+
+        public void OnFoul(string foulId, Vector3 ballPosition, Vector3 shotDirection, float powerNormalized)
+        {
+            RequestReplay(foulId, ballPosition, shotDirection, powerNormalized, replayOnPoint: false, replayOnFoul: true);
+        }
+
+        public void SkipReplay()
+        {
+            if (!isReplayActive) return;
+            EndReplay();
+        }
+
+        private void RequestReplay(string shotId, Vector3 ballPosition, Vector3 shotDirection, float powerNormalized, bool replayOnPoint, bool replayOnFoul)
+        {
+            if (replayGate == null) return;
+
+            var payload = new ReplayBroadcastPayload
+            {
+                shotId = shotId,
+                cueBallPosition = ballPosition,
+                cueDirection = shotDirection,
+                powerNormalized = Mathf.Clamp01(powerNormalized),
+                replayOnPottedBall = replayOnPoint,
+                replayOnFoul = replayOnFoul
+            };
+
+            if (!replayGate.TryBroadcastReplay(payload)) return;
+
+            if (replayRoutine != null)
+                StopCoroutine(replayRoutine);
+
+            replayRoutine = StartCoroutine(ReplayRoutine());
+        }
+
+        private IEnumerator ReplayRoutine()
+        {
+            isReplayActive = true;
+            SetReplayOverlayVisible(true);
+
+            if (pauseGameplayDuringReplay)
+            {
+                previousTimeScale = Time.timeScale;
+                Time.timeScale = 0f;
+            }
+
+            yield return new WaitForSecondsRealtime(replayDurationSeconds);
+
+            EndReplay();
+        }
+
+        private void EndReplay()
+        {
+            if (replayRoutine != null)
+            {
+                StopCoroutine(replayRoutine);
+                replayRoutine = null;
+            }
+
+            if (pauseGameplayDuringReplay)
+                Time.timeScale = previousTimeScale;
+
+            isReplayActive = false;
+            SetReplayOverlayVisible(false);
+        }
+
+        private void SetReplayOverlayVisible(bool visible)
+        {
+            if (replayOverlay == null) return;
+            replayOverlay.alpha = visible ? 1f : 0f;
+            replayOverlay.interactable = visible;
+            replayOverlay.blocksRaycasts = visible;
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Tennis/TennisShotTuning.cs
+++ b/Assets/Scripts/Gameplay/Tennis/TennisShotTuning.cs
@@ -6,7 +6,7 @@ namespace TonPlaygram.Gameplay.Tennis
     public class TennisShotTuning : MonoBehaviour
     {
         [Header("Power")]
-        [Min(1f)] public float baseShotPower = 16f;
+        [Min(1f)] public float baseShotPower = 14.8f;
         [Range(0f, 2f)] public float topspin = 0.35f;
         [Range(0f, 2f)] public float sidespin = 0.2f;
         [Range(0f, 2f)] public float curvePower = 0.5f;
@@ -18,7 +18,7 @@ namespace TonPlaygram.Gameplay.Tennis
             var dir = aimDirection.sqrMagnitude > 0.0001f ? aimDirection.normalized : transform.forward;
             float power = baseShotPower * Mathf.Clamp01(normalizedPower);
 
-            float variantPowerMultiplier = variant == ShotVariant.Power ? 1.25f : 1f;
+            float variantPowerMultiplier = variant == ShotVariant.Power ? 1.15f : 1f;
             float finalPower = power * variantPowerMultiplier;
 
             ballBody.AddForce(dir * finalPower, ForceMode.Impulse);


### PR DESCRIPTION
### Motivation
- Make tennis rallies feel less overpowering by slightly reducing shot force and the Power-variant multiplier. 
- Make the playable scene look larger by scaling court, characters and rackets while keeping camera framing consistent. 
- Provide a TV/VAR-style replay flow for decisive points and fouls with user-accessible skip controls so replays behave like broadcast highlights.

### Description
- Tuning: lowered `TennisShotTuning.baseShotPower` from `16f` to `14.8f` and reduced the Power variant multiplier from `1.25f` to `1.15f` to soften shot strength. 
- Scaling & framing: increased `TennisCourtScaler.worldScaleMultiplier` and `framingDistanceScale` from `1.35f` to `1.5f` so the court/characters appear bigger while the camera moves back to preserve framing. 
- Replay system: added `TennisReplayDirector` which integrates with `ReplayBroadcastGate`, exposes `OnDecisivePoint(...)` and `OnFoul(...)` triggers, shows a replay overlay via `CanvasGroup`, optionally pauses gameplay during replay using `Time.timeScale`, and wires skip handlers for both a menu skip `Button` and a replay overlay skip icon `Button`. 
- Documentation: updated `Assets/Scripts/Gameplay/Tennis/README.md` with wiring notes for the new replay flow and skip-button setup.

### Testing
- No automated unit/integration tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9cf0d41f08329a3fa3dc6b3a0d68a)