### PR TITLE
Adjust Ludo Battle Royale camera and bottom-seat framing for portrait

### DIFF
--- a/webapp/src/pages/Games/LudoBattleRoyal.jsx
+++ b/webapp/src/pages/Games/LudoBattleRoyal.jsx
@@ -3154,7 +3154,7 @@ const AI_CHAIR_RADIUS =
 // Pull all chairs (with seated humans) farther away from the table edge for clearer portrait spacing.
 const CHAIR_GLOBAL_PUSHBACK = 0.68 * MODEL_SCALE;
 // Keep bottom/local-player seat aligned with the same table distance used by the other chairs.
-const SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK = 0;
+const SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK = 0.22 * MODEL_SCALE;
 
 const DEFAULT_PLAYER_COUNT = 4;
 const clampPlayerCount = (value) =>
@@ -3193,7 +3193,7 @@ const SEATED_HUMAN_VISUAL_SCALE_MULTIPLIER = 4.2;
 const SEATED_HUMAN_SEAT_Y_OFFSET = -6.75 * MODEL_SCALE * STOOL_SCALE;
 // Shift humans farther back on the chair so they appear more outward from the table in portrait gameplay.
 const SEATED_HUMAN_SEAT_Z_OFFSET = -SEAT_DEPTH * 0.42;
-const SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET = -SEAT_DEPTH * 0.2;
+const SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET = -SEAT_DEPTH * 0.34;
 const SEATED_HUMAN_FACING_Y = 0;
 // Keep feet lower to preserve the deeper seat grounding after the stronger vertical drop.
 const SEATED_HUMAN_FOOT_GROUND_CLEARANCE = -1.55 * MODEL_SCALE * STOOL_SCALE;
@@ -4654,8 +4654,8 @@ const BOARD_ROTATION_Y = -Math.PI / 2;
 const CAMERA_BASE_RADIUS = Math.max(TABLE_RADIUS, BOARD_RADIUS);
 const CAMERA_EXTRA_ZOOM_IN = 0.82;
 const CAMERA_EXTRA_ZOOM_OUT = 1.32;
-const INITIAL_CAMERA_DISTANCE_FACTOR = 0.8;
-const PORTRAIT_INITIAL_CAMERA_DISTANCE_FACTOR = 0.74;
+const INITIAL_CAMERA_DISTANCE_FACTOR = 0.68;
+const PORTRAIT_INITIAL_CAMERA_DISTANCE_FACTOR = 0.62;
 const CAM = {
   fov: CAMERA_FOV,
   near: CAMERA_NEAR,
@@ -4668,7 +4668,7 @@ const CAM = {
 const CAMERA_2D_DISTANCE_FACTOR = 1.08;
 const CAMERA_2D_MAX_DISTANCE_FACTOR = 1.32;
 const CAMERA_3D_VERTICAL_DROP = 0;
-const CAMERA_3D_HEIGHT_BOOST = 0.12 * MODEL_SCALE;
+const CAMERA_3D_HEIGHT_BOOST = 0.26 * MODEL_SCALE;
 const CAMERA_LOOKDOWN_TARGET_OFFSET = 0.062 * MODEL_SCALE;
 const TRACK_COORDS = Object.freeze([
   [6, 1],


### PR DESCRIPTION
### Motivation
- Improve portrait framing by lifting the 3D camera so the view reads higher, move the camera closer to the table, and keep the local (bottom) chair and seated human visually anchored at the bottom of the screen.

### Description
- Tuned constants in `webapp/src/pages/Games/LudoBattleRoyal.jsx` to affect camera and seating: updated `SELF_BOTTOM_CHAIR_EXTRA_PUSHBACK` from `0` to `0.22 * MODEL_SCALE` to push the bottom chair outward. 
- Moved the local seated avatar back by changing `SELF_BOTTOM_HUMAN_EXTRA_Z_OFFSET` from `-SEAT_DEPTH * 0.2` to `-SEAT_DEPTH * 0.34` so the human sits visually farther from the table. 
- Brought the camera closer by reducing `INITIAL_CAMERA_DISTANCE_FACTOR` from `0.8` to `0.68` and `PORTRAIT_INITIAL_CAMERA_DISTANCE_FACTOR` from `0.74` to `0.62` so initial framing is tighter to the table. 
- Raised the in-game viewpoint by increasing `CAMERA_3D_HEIGHT_BOOST` from `0.12 * MODEL_SCALE` to `0.26 * MODEL_SCALE` to make the camera sit higher on portrait screens.

### Testing
- Verified the code delta with `git diff -- webapp/src/pages/Games/LudoBattleRoyal.jsx` and committed the change with `git commit`, which completed successfully. 
- No automated unit/integration tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9f179fc108329b56c79754d24b9cd)