### PR TITLE
Snooker Royal: use Pooltool snooker GLB as default table base (preserve gameplay footprint/height)

### DIFF
--- a/webapp/src/config/snookerRoyalInventoryConfig.js
+++ b/webapp/src/config/snookerRoyalInventoryConfig.js
@@ -318,6 +318,7 @@ const CUE_STYLE_THUMBNAILS = Object.freeze({
 });
 
 const BASE_VARIANT_THUMBNAILS = Object.freeze({
+  pooltoolSnooker: polyHavenThumb('wooden_table_02'),
   classicCylinders: swatchThumbnail(['#8f6243', '#6f3a2f', '#fef3c7']),
   openPortal: swatchThumbnail(['#f8fafc', '#e5e7eb', '#93c5fd']),
   coffeeTableRound01: polyHavenThumb('coffee_table_round_01'),
@@ -333,6 +334,12 @@ export const SNOOKER_ROYALE_HDRI_VARIANT_MAP = Object.freeze(
 );
 
 export const SNOOKER_ROYALE_BASE_VARIANTS = Object.freeze([
+  {
+    id: 'pooltoolSnooker',
+    name: 'Pooltool Snooker Table',
+    description: 'Snooker table GLB from the Pooltool open-source set, scaled to match the existing gameplay footprint and height.',
+    swatches: ['#356a3a', '#6b3f2a']
+  },
   {
     id: 'classicCylinders',
     name: 'Classic Cylinders',

--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -10381,6 +10381,94 @@ function Table3D(
     return clone;
   };
 
+  
+  const POOLTOOL_SNOOKER_TABLE_URL = 'https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table/snooker.glb';
+  const externalBaseTemplates = new Map();
+  const externalBasePromises = new Map();
+
+  const ensureExternalBaseTemplate = (templateKey, urls, renderer = null) => {
+    if (externalBaseTemplates.has(templateKey)) return Promise.resolve(externalBaseTemplates.get(templateKey));
+    if (externalBasePromises.has(templateKey)) return externalBasePromises.get(templateKey);
+    const promise = (async () => {
+      const loader = createConfiguredGLTFLoader(renderer);
+      let lastError = null;
+      for (const url of urls) {
+        try {
+          // eslint-disable-next-line no-await-in-loop
+          const gltf = await loader.loadAsync(url);
+          const scene = gltf?.scene || gltf?.scenes?.[0];
+          if (!scene) throw new Error('Missing scene for external base');
+          externalBaseTemplates.set(templateKey, scene);
+          return scene;
+        } catch (error) {
+          lastError = error;
+        }
+      }
+      console.warn('Failed to load external snooker table base; using fallback.', lastError);
+      externalBaseTemplates.set(templateKey, null);
+      return null;
+    })();
+    externalBasePromises.set(templateKey, promise);
+    promise.finally(() => externalBasePromises.delete(templateKey));
+    return promise;
+  };
+
+  const cloneExternalBaseTemplate = (templateKey) => {
+    const template = externalBaseTemplates.get(templateKey);
+    if (!template) return null;
+    const clone = template.clone(true);
+    clone.traverse((child) => {
+      if (!child?.isMesh) return;
+      const materials = Array.isArray(child.material) ? child.material : [child.material];
+      const refreshed = materials.map((mat) => sharpenGltfMaterial(mat));
+      child.material = Array.isArray(child.material) ? refreshed : refreshed[0] ?? child.material;
+      child.castShadow = true;
+      child.receiveShadow = true;
+      tagBasePart(child);
+    });
+    tagBasePart(clone);
+    return clone;
+  };
+
+  const createExternalSnookerTableBuilder = () => {
+    const templateKey = 'pooltool-snooker-table';
+    const builder = (ctx) => {
+      const meshes = [];
+      const legMeshes = [];
+      const normalizeOptions = { topInset: ctx.skirtH * 0.03, fill: 1 };
+      const template = cloneExternalBaseTemplate(templateKey);
+      const asyncReady = template
+        ? null
+        : ensureExternalBaseTemplate(templateKey, [POOLTOOL_SNOOKER_TABLE_URL], ctx.renderer);
+      const buildInstance = () => {
+        const base = cloneExternalBaseTemplate(templateKey);
+        if (!base) return;
+        const bounds = new THREE.Box3().setFromObject(base);
+        const size = bounds.getSize(new THREE.Vector3());
+        const targetWidth = ctx.frameOuterX * 2;
+        const targetDepth = ctx.frameOuterZ * 2;
+        const scaleX = size.x > MICRO_EPS ? targetWidth / size.x : 1;
+        const scaleZ = size.z > MICRO_EPS ? targetDepth / size.z : 1;
+        const uniformScale = Math.min(scaleX, scaleZ);
+        if (Number.isFinite(uniformScale) && uniformScale > 0) {
+          base.scale.setScalar(uniformScale);
+        }
+        base.updateMatrixWorld(true);
+        const scaledBounds = new THREE.Box3().setFromObject(base);
+        base.position.set(-scaledBounds.getCenter(new THREE.Vector3()).x, ctx.floorY - scaledBounds.min.y, -scaledBounds.getCenter(new THREE.Vector3()).z);
+        base.updateMatrixWorld(true);
+        meshes.push(base);
+        base.traverse((child) => {
+          if (child?.isMesh) legMeshes.push(child);
+        });
+      };
+      if (template) buildInstance();
+      return { meshes, legMeshes, normalizeOptions, asyncReady };
+    };
+    builder.isPolyhaven = true;
+    return builder;
+  };
+
   const createPolyhavenTableBaseBuilder = (
     assetId,
     {
@@ -10457,6 +10545,7 @@ function Table3D(
   };
 
   const baseBuilders = {
+    pooltoolSnooker: createExternalSnookerTableBuilder(),
     classicCylinders: (ctx) => {
       const pocketSafeInsetX = Math.min(ctx.frameOuterX, ctx.legInset + LEG_POCKET_CLEARANCE);
       const pocketSafeInsetZ = Math.min(


### PR DESCRIPTION
### Motivation
- Replace the visual table model used by Snooker Royal with the Pooltool snooker GLB while keeping the existing gameplay footprint and table height unchanged.
- Load an external .glb as a first-class base variant so designers can pick the richer Pooltool asset without breaking play alignment.

### Description
- Added a new `pooltoolSnooker` base variant and thumbnail to `webapp/src/config/snookerRoyalInventoryConfig.js` and placed it first so it becomes the default selected base.
- Implemented an external GLTF loader and template cache (`ensureExternalBaseTemplate`, `externalBaseTemplates`, `externalBasePromises`) in `webapp/src/pages/Games/SnookerRoyal.jsx` that fetches `https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table/snooker.glb` using the existing GLTF loader configuration.
- Added `cloneExternalBaseTemplate` and `createExternalSnookerTableBuilder()` which scale, uniformly fit, center, and floor-anchor the loaded model to the current table footprint so visual size/height remain aligned with gameplay.
- Registered the new builder in `baseBuilders` as `pooltoolSnooker` and preserved existing fallback behavior when external loading fails.

### Testing
- Verified the code changes with repository searches and diffs using `rg` and `git diff` and created a commit (`git commit`) which succeeded.
- Performed file-level inspection of the inserted loader/builder code in `SnookerRoyal.jsx` and the added variant in `snookerRoyalInventoryConfig.js` using `sed`/`nl` to ensure correct placement.
- No automated unit or integration tests were executed as part of this change; runtime verification should be performed in a local/dev build to confirm the GLB loads and the visual table aligns with gameplay dimensions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa0ed5a4f88329a8327d1b4aa7702a)