### PR TITLE
Support Air Hockey purchases and add bowling-ball field variants to store

### DIFF
--- a/bot/models/User.js
+++ b/bot/models/User.js
@@ -146,6 +146,8 @@ const userSchema = new mongoose.Schema({
   // Persist Snooker Royal unlocks server-side for cross-device sync
   snookerRoyalInventory: { type: Object, default: undefined },
 
+  // Persist Air Hockey unlocks server-side for cross-device sync
+  airHockeyInventory: { type: Object, default: undefined },
 
 });
 

--- a/bot/routes/store.js
+++ b/bot/routes/store.js
@@ -9,6 +9,7 @@ import {
 } from '../utils/memoryUserStore.js';
 import { POOL_ROYALE_DEFAULT_UNLOCKS } from '../../webapp/src/config/poolRoyaleInventoryConfig.js';
 import { SNOOKER_ROYALE_DEFAULT_UNLOCKS } from '../../webapp/src/config/snookerRoyalInventoryConfig.js';
+import { AIR_HOCKEY_DEFAULT_UNLOCKS } from '../../webapp/src/config/airHockeyInventoryConfig.js';
 
 const router = Router();
 
@@ -17,7 +18,8 @@ export const BUNDLES = {};
 
 const STORE_INVENTORY_TARGETS = {
   poolroyale: 'pool',
-  snookerroyale: 'snooker'
+  snookerroyale: 'snooker',
+  airhockey: 'airHockey'
 };
 
 function copyDefaults(defaults = {}) {
@@ -40,9 +42,11 @@ function normalizeInventory(rawInventory, defaults) {
 export function applyStoreItemDelivery(user, items = []) {
   const poolInventory = normalizeInventory(user.poolRoyalInventory, POOL_ROYALE_DEFAULT_UNLOCKS);
   const snookerInventory = normalizeInventory(user.snookerRoyalInventory, SNOOKER_ROYALE_DEFAULT_UNLOCKS);
+  const airHockeyInventory = normalizeInventory(user.airHockeyInventory, AIR_HOCKEY_DEFAULT_UNLOCKS);
   const delivery = {
     pool: [],
     snooker: [],
+    airHockey: [],
     unsupported: []
   };
 
@@ -62,20 +66,31 @@ export function applyStoreItemDelivery(user, items = []) {
       return;
     }
 
-    const current = new Set(snookerInventory[item.type] || []);
+    if (target === 'snooker') {
+      const current = new Set(snookerInventory[item.type] || []);
+      const sizeBefore = current.size;
+      current.add(item.optionId);
+      snookerInventory[item.type] = [...current];
+      if (current.size !== sizeBefore) delivery.snooker.push(item);
+      return;
+    }
+
+    const current = new Set(airHockeyInventory[item.type] || []);
     const sizeBefore = current.size;
     current.add(item.optionId);
-    snookerInventory[item.type] = [...current];
-    if (current.size !== sizeBefore) delivery.snooker.push(item);
+    airHockeyInventory[item.type] = [...current];
+    if (current.size !== sizeBefore) delivery.airHockey.push(item);
   });
 
   user.poolRoyalInventory = poolInventory;
   user.snookerRoyalInventory = snookerInventory;
+  user.airHockeyInventory = airHockeyInventory;
 
   return {
     ...delivery,
     poolInventory,
-    snookerInventory
+    snookerInventory,
+    airHockeyInventory
   };
 }
 
@@ -180,6 +195,7 @@ async function handleTpcPurchase(req, res) {
     delivery: {
       pool: delivery.pool.length,
       snooker: delivery.snooker.length,
+      airHockey: delivery.airHockey.length,
       unsupported: delivery.unsupported.length
     }
   });

--- a/test/storeDelivery.test.js
+++ b/test/storeDelivery.test.js
@@ -1,10 +1,11 @@
 import { applyStoreItemDelivery } from '../bot/routes/store.js';
 
 describe('applyStoreItemDelivery', () => {
-  test('delivers Pool and Snooker unlocks and tracks unsupported items', () => {
+  test('delivers Pool, Snooker, and Air Hockey unlocks and tracks unsupported items', () => {
     const user = {
       poolRoyalInventory: { tableFinish: ['classic_green'] },
-      snookerRoyalInventory: { cueStyle: ['stock'] }
+      snookerRoyalInventory: { cueStyle: ['stock'] },
+      airHockeyInventory: { field: ['bust-marble'] }
     };
 
     const result = applyStoreItemDelivery(user, [
@@ -15,13 +16,15 @@ describe('applyStoreItemDelivery', () => {
 
     expect(result.pool).toHaveLength(1);
     expect(result.snooker).toHaveLength(1);
-    expect(result.unsupported).toHaveLength(1);
+    expect(result.airHockey).toHaveLength(1);
+    expect(result.unsupported).toHaveLength(0);
     expect(user.poolRoyalInventory.tableFinish).toEqual(
       expect.arrayContaining(['classic_green', 'neo_carbon'])
     );
     expect(user.snookerRoyalInventory.cueStyle).toEqual(
       expect.arrayContaining(['stock', 'pro_black'])
     );
+    expect(user.airHockeyInventory.table).toContain('ice_blue');
   });
 
   test('does not duplicate already owned items', () => {

--- a/webapp/src/config/airHockeyInventoryConfig.js
+++ b/webapp/src/config/airHockeyInventoryConfig.js
@@ -592,12 +592,12 @@ export const AIR_HOCKEY_OPTION_LABELS = Object.freeze(
 );
 
 export const AIR_HOCKEY_STORE_ITEMS = [
-  ...AIR_HOCKEY_MARBLE_FIELDS.map((field, idx) => ({
+  ...AIR_HOCKEY_CUSTOMIZATION.field.map((field, idx) => ({
     id: `field-${field.id}`,
     type: 'field',
     optionId: field.id,
     name: `${field.name} Surface`,
-    price: 520 + idx * 20,
+    price: field.price ?? 520 + idx * 20,
     description: field.description,
     swatches: field.swatches,
     thumbnail: FIELD_THUMBNAILS[field.id] || swatchThumbnail(field.swatches)


### PR DESCRIPTION
### Motivation
- Ensure items purchased for Air Hockey appear in the in-game menu and can be selected by players instead of being treated as unsupported. 
- Reuse existing bowling-ball textures/colors as selectable Air Hockey field finishes so store visuals and gameplay options match the realistic bowling assets. 

### Description
- Wire up backend delivery for Air Hockey by mapping the `airhockey` store slug to a new `airHockey` target and updating `applyStoreItemDelivery` to write unlocks into `airHockeyInventory`. 
- Persist Air Hockey unlocks server-side by adding `airHockeyInventory` to the user schema in `bot/models/User.js`. 
- Expand the Air Hockey store catalog by changing `AIR_HOCKEY_STORE_ITEMS` to enumerate `AIR_HOCKEY_CUSTOMIZATION.field` (which includes `BOWLING_BALL_FIELD_VARIANTS`) and use `field.price ?? ...` when available in `webapp/src/config/airHockeyInventoryConfig.js`. 
- Update the store delivery API response to include `airHockey` delivery counts and update tests to cover Pool, Snooker, and Air Hockey deliveries in `test/storeDelivery.test.js`. 

### Testing
- Ran the unit test file `test/storeDelivery.test.js` with `npm test -- test/storeDelivery.test.js` and it passed. 
- The modified `applyStoreItemDelivery` behavior is validated by the updated tests which now assert Air Hockey items are delivered and persisted (test suite: PASS).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa1bd3495083298a656243f4f4e2d5)