### PR TITLE
Add open-source snooker table model, lobby selector, and loader

### DIFF
--- a/test/snookerTableModel.test.js
+++ b/test/snookerTableModel.test.js
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import {
+  applySnookerTableModelParam,
+  resolveSnookerTableModel,
+  TABLE_MODEL_CLASSIC,
+  TABLE_MODEL_OPENSOURCE
+} from '../webapp/src/pages/Games/snookerTableModel.js';
+
+describe('snooker table model selection', () => {
+  test('resolveSnookerTableModel defaults to classic', () => {
+    assert.equal(resolveSnookerTableModel(null), TABLE_MODEL_CLASSIC);
+    assert.equal(resolveSnookerTableModel(''), TABLE_MODEL_CLASSIC);
+    assert.equal(resolveSnookerTableModel('invalid'), TABLE_MODEL_CLASSIC);
+  });
+
+  test('resolveSnookerTableModel accepts opensource value case-insensitively', () => {
+    assert.equal(resolveSnookerTableModel('opensource'), TABLE_MODEL_OPENSOURCE);
+    assert.equal(resolveSnookerTableModel('OpenSource'), TABLE_MODEL_OPENSOURCE);
+  });
+
+  test('applySnookerTableModelParam always writes a safe tableModel param', () => {
+    const params = new URLSearchParams();
+    applySnookerTableModelParam(params, 'opensource');
+    assert.equal(params.get('tableModel'), TABLE_MODEL_OPENSOURCE);
+
+    applySnookerTableModelParam(params, 'unknown');
+    assert.equal(params.get('tableModel'), TABLE_MODEL_CLASSIC);
+  });
+});

--- a/webapp/src/pages/Games/OpenSourceSnookerTable.jsx
+++ b/webapp/src/pages/Games/OpenSourceSnookerTable.jsx
@@ -1,0 +1,161 @@
+"use client";
+
+import React, { useEffect, useRef, useState } from 'react';
+import * as THREE from 'three';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader.js';
+import { KTX2Loader } from 'three/examples/jsm/loaders/KTX2Loader.js';
+import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.js';
+
+const GITHUB_API_BASE = 'https://api.github.com/repos/ekiefl/pooltool/contents';
+const TABLE_DIRS = ['pooltool/models/table', 'pooltool/models/tables', 'pooltool/models'];
+
+function isTableGLB(path) {
+  const p = String(path || '').toLowerCase();
+  if (!p.endsWith('.glb') && !p.endsWith('.gltf')) return false;
+  if (!p.includes('table')) return false;
+  if (p.includes('ball') || p.includes('cue') || p.includes('menu') || p.includes('hud')) return false;
+  return true;
+}
+
+async function fetchJson(url) {
+  const response = await fetch(url, { mode: 'cors', headers: { Accept: 'application/vnd.github+json' } });
+  if (!response.ok) throw new Error(`${response.status} ${url}`);
+  return response.json();
+}
+
+async function walkGithubDirectory(path, depth = 0, seen = new Set()) {
+  if (depth > 7 || seen.has(path)) return [];
+  seen.add(path);
+  let entries = [];
+  try {
+    const json = await fetchJson(`${GITHUB_API_BASE}/${path}?ref=main`);
+    entries = Array.isArray(json) ? json : [json];
+  } catch {
+    return [];
+  }
+  const results = [];
+  for (const entry of entries) {
+    if (entry.type === 'dir') {
+      const lower = entry.path.toLowerCase();
+      const useful = lower.includes('table') || lower.includes('models') || lower.includes('billiard') || lower.includes('snooker') || lower.includes('pool');
+      if (useful) results.push(...(await walkGithubDirectory(entry.path, depth + 1, seen)));
+    } else if (entry.type === 'file' && entry.download_url && isTableGLB(entry.path)) {
+      results.push({ path: entry.path, url: entry.download_url });
+    }
+  }
+  return results;
+}
+
+async function discoverSnookerTable() {
+  const assets = [];
+  for (const dir of TABLE_DIRS) assets.push(...(await walkGithubDirectory(dir)));
+  const ranked = [...assets].sort((a, b) => {
+    const score = (path) => {
+      const p = path.toLowerCase();
+      let s = 0;
+      if (p.includes('snooker')) s += 10;
+      if (p.includes('table')) s += 5;
+      if (p.endsWith('.glb')) s += 2;
+      return s;
+    };
+    return score(b.path) - score(a.path);
+  });
+  const snooker = ranked[0];
+  return snooker || assets[0] || null;
+}
+
+export default function OpenSourceSnookerTable() {
+  const canvasRef = useRef(null);
+  const [status, setStatus] = useState('Loading snooker table model…');
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
+    renderer.outputColorSpace = THREE.SRGBColorSpace;
+    renderer.setClearColor(0x0f172a, 1);
+
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(58, 1, 0.05, 260);
+    camera.position.set(0, 8.8, 24);
+    scene.add(new THREE.AmbientLight(0xffffff, 1.6));
+    const key = new THREE.DirectionalLight(0xffffff, 1.1);
+    key.position.set(-7, 11, 8);
+    scene.add(key);
+
+    const loader = new GLTFLoader();
+    const draco = new DRACOLoader();
+    draco.setDecoderPath('https://www.gstatic.com/draco/versioned/decoders/1.5.7/');
+    loader.setDRACOLoader(draco);
+    const ktx2 = new KTX2Loader();
+    ktx2.setTranscoderPath('https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/libs/basis/');
+    ktx2.detectSupport(renderer);
+    loader.setKTX2Loader(ktx2);
+    loader.setMeshoptDecoder(MeshoptDecoder);
+
+    const resize = () => {
+      const w = window.innerWidth;
+      const h = window.innerHeight;
+      renderer.setSize(w, h, false);
+      camera.aspect = w / h;
+      camera.updateProjectionMatrix();
+    };
+    window.addEventListener('resize', resize);
+    resize();
+
+    let frame = 0;
+    let model = null;
+    let cancelled = false;
+    let yaw = 0;
+
+    const animate = () => {
+      frame = requestAnimationFrame(animate);
+      yaw += 0.002;
+      camera.position.set(Math.sin(yaw) * 24, 9, Math.cos(yaw) * 24);
+      camera.lookAt(0, 1.8, 0);
+      renderer.render(scene, camera);
+    };
+
+    (async () => {
+      const asset = await discoverSnookerTable();
+      if (!asset || cancelled) {
+        setStatus('No snooker table asset found.');
+        return;
+      }
+      loader.load(asset.url, (gltf) => {
+        if (cancelled) return;
+        model = gltf.scene;
+        const box = new THREE.Box3().setFromObject(model);
+        const size = box.getSize(new THREE.Vector3());
+        const scale = 6.5 / Math.max(size.x, size.y, size.z, 0.0001);
+        model.scale.setScalar(scale);
+        const box2 = new THREE.Box3().setFromObject(model);
+        const center = box2.getCenter(new THREE.Vector3());
+        model.position.set(-center.x, -box2.min.y + 0.75, -center.z);
+        scene.add(model);
+        setStatus(`Loaded: ${asset.path}`);
+      }, undefined, () => setStatus('Failed to load table model.'));
+    })();
+
+    animate();
+
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(frame);
+      window.removeEventListener('resize', resize);
+      if (model) scene.remove(model);
+      renderer.dispose();
+      draco.dispose();
+      ktx2.dispose();
+    };
+  }, []);
+
+  return (
+    <div style={{ position: 'fixed', inset: 0, background: '#0f172a' }}>
+      <canvas ref={canvasRef} style={{ width: '100%', height: '100%', display: 'block' }} />
+      <div style={{ position: 'absolute', top: 8, left: 8, right: 8, color: '#fff', fontWeight: 700, fontSize: 12 }}>{status}</div>
+    </div>
+  );
+}

--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -16,6 +16,8 @@ import { EXRLoader } from 'three/examples/jsm/loaders/EXRLoader.js';
 import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader.js';
 import { GroundedSkybox } from 'three/examples/jsm/objects/GroundedSkybox.js';
 import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.js';
+import OpenSourceSnookerTable from './OpenSourceSnookerTable.jsx';
+import { resolveSnookerTableModel, TABLE_MODEL_OPENSOURCE } from './snookerTableModel.js';
 import { PoolRoyalePowerSlider } from '../../../../pool-royale-power-slider.js';
 import '../../../../pool-royale-power-slider.css';
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -11310,7 +11312,6 @@ function SnookerRoyalGame({
   opponentAvatar
 }) {
   const navigate = useNavigate();
-  const location = useLocation();
   const mountRef = useRef(null);
   const rafRef = useRef(null);
   const worldRef = useRef(null);
@@ -28415,8 +28416,17 @@ const powerRef = useRef(hud.power);
 }
 
 export default function SnookerRoyal() {
-  const navigate = useNavigate();
   const location = useLocation();
+  const tableModel = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    return resolveSnookerTableModel(params.get('tableModel'));
+  }, [location.search]);
+
+  if (tableModel === TABLE_MODEL_OPENSOURCE) {
+    return <OpenSourceSnookerTable />;
+  }
+
+  const navigate = useNavigate();
   const variantKey = useMemo(() => {
     return 'snooker';
   }, [location.search]);

--- a/webapp/src/pages/Games/SnookerRoyalLobby.jsx
+++ b/webapp/src/pages/Games/SnookerRoyalLobby.jsx
@@ -14,6 +14,12 @@ import { runSnookerRoyalOnlineFlow } from './snookerRoyalOnlineFlow.js';
 import OptionIcon from '../../components/OptionIcon.jsx';
 import { getLobbyIcon } from '../../config/gameAssets.js';
 import GameLobbyHeader from '../../components/GameLobbyHeader.jsx';
+import {
+  applySnookerTableModelParam,
+  resolveSnookerTableModel,
+  TABLE_MODEL_CLASSIC,
+  TABLE_MODEL_OPENSOURCE
+} from './snookerTableModel.js';
 
 const PLAYER_FLAG_STORAGE_KEY = 'snookerRoyalPlayerFlag';
 const AI_FLAG_STORAGE_KEY = 'snookerRoyalAiFlag';
@@ -39,6 +45,10 @@ export default function SnookerRoyalLobby() {
   const [playType, setPlayType] = useState(initialPlayType);
   const [players, setPlayers] = useState(8);
   const tableSize = resolveTableSize(searchParams.get('tableSize')).id;
+  const initialTableModel = (() => {
+    return resolveSnookerTableModel(searchParams.get('tableModel'));
+  })();
+  const [tableModel, setTableModel] = useState(initialTableModel);
   const [onlinePlayers, setOnlinePlayers] = useState([]);
   const [matching, setMatching] = useState(false);
   const [spinningPlayer, setSpinningPlayer] = useState('');
@@ -126,6 +136,7 @@ export default function SnookerRoyalLobby() {
     const resolvedAccountId = accountIdRef.current;
     if (resolvedAccountId) params.set('accountId', resolvedAccountId);
     if (tableSize) params.set('tableSize', tableSize);
+    applySnookerTableModelParam(params, tableModel);
     params.set('seat', seat);
     params.set('starter', starterSeat);
     const name = (friendlyName || '').trim();
@@ -196,6 +207,7 @@ export default function SnookerRoyalLobby() {
     const params = new URLSearchParams();
     params.set('variant', forcedVariant);
     params.set('tableSize', tableSize);
+    applySnookerTableModelParam(params, tableModel);
     params.set('type', playType);
     params.set('mode', mode);
     if (isOnlineMatch) {
@@ -426,6 +438,39 @@ export default function SnookerRoyalLobby() {
           </div>
           <p className="text-xs text-white/60 text-center">
             Tournament mode locks online matchmaking and uses the bracket flow.
+          </p>
+        </div>
+
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold text-white">Choose Table</h3>
+            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Layout</span>
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            {[
+              { id: TABLE_MODEL_CLASSIC, label: 'Classic Table', desc: 'Current playable table' },
+              { id: TABLE_MODEL_OPENSOURCE, label: 'New Snooker Table', desc: 'Open-source GLTF table model' }
+            ].map(({ id, label, desc }) => {
+              const active = tableModel === id;
+              return (
+                <button
+                  key={id}
+                  type="button"
+                  onClick={() => setTableModel(id)}
+                  className={`lobby-option-card ${
+                    active ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
+                  }`}
+                >
+                  <div className="text-center">
+                    <p className="lobby-option-label">{label}</p>
+                    <p className="lobby-option-subtitle">{desc}</p>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+          <p className="text-xs text-white/60 text-center">
+            You can switch between the existing table and the new snooker model before match start.
           </p>
         </div>
 

--- a/webapp/src/pages/Games/snookerTableModel.js
+++ b/webapp/src/pages/Games/snookerTableModel.js
@@ -1,0 +1,13 @@
+export const TABLE_MODEL_CLASSIC = 'classic';
+export const TABLE_MODEL_OPENSOURCE = 'opensource';
+
+export function resolveSnookerTableModel(value) {
+  const requested = String(value || '').toLowerCase();
+  return requested === TABLE_MODEL_OPENSOURCE ? TABLE_MODEL_OPENSOURCE : TABLE_MODEL_CLASSIC;
+}
+
+export function applySnookerTableModelParam(params, tableModel) {
+  const resolved = resolveSnookerTableModel(tableModel);
+  params.set('tableModel', resolved);
+  return resolved;
+}


### PR DESCRIPTION
### Motivation
- Provide an opt-in open-source GLTF/GLB snooker table model to experiment with new visuals while keeping the classic table as default.
- Allow players to choose the table model from the Snooker Royal lobby and propagate the choice into game navigation parameters.
- Encapsulate table model selection logic in a small utility to safely read/apply URL params.

### Description
- Added `webapp/src/pages/Games/snookerTableModel.js` with `TABLE_MODEL_CLASSIC`, `TABLE_MODEL_OPENSOURCE`, `resolveSnookerTableModel`, and `applySnookerTableModelParam` to centralize resolution and param application.
- Implemented `OpenSourceSnookerTable.jsx` which discovers GLTF/GLB table assets from a GitHub repo, loads them via `three` (`GLTFLoader`, `DRACOLoader`, `KTX2Loader`, `MeshoptDecoder`), and renders a simple rotating preview with status messages.
- Integrated table model selection into `SnookerRoyal.jsx` to conditionally render the new `OpenSourceSnookerTable` when the resolved table model is `TABLE_MODEL_OPENSOURCE`.
- Updated `SnookerRoyalLobby.jsx` to add a UI control for choosing between `Classic` and `New Snooker Table`, to store the selection in state, and to include the `tableModel` param (via `applySnookerTableModelParam`) when navigating or starting matches.
- Added unit tests `test/snookerTableModel.test.js` that cover `resolveSnookerTableModel` behavior and `applySnookerTableModelParam` behavior.

### Testing
- Ran unit tests for the new module with the added `test/snookerTableModel.test.js` and they passed successfully.
- Basic smoke load of `OpenSourceSnookerTable` tested in development to confirm discovery and GLTF loading logic (manual/dev preview, no automated rendering tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa2d3eb8008329b5c0710ab48ca4bf)