### PR TITLE
Enhance Free Kick Arena audio, characters, and stadium stands

### DIFF
--- a/webapp/src/pages/Games/FreeKickArena.tsx
+++ b/webapp/src/pages/Games/FreeKickArena.tsx
@@ -3,6 +3,8 @@
 import React, { useEffect, useRef, useState } from "react";
 import * as THREE from "three";
 import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js";
+// @ts-expect-error Murlan Royale character inventory is authored in JS.
+import { MURLAN_CHARACTER_THEMES } from "../../config/murlanCharacterThemes.js";
 
 type AnimName = "Idle" | "Walk" | "Run";
 type ShotState = "aim" | "runup" | "flight" | "var" | "replay" | "result";
@@ -89,7 +91,23 @@ type ReplayFrame = {
   kickerRot: THREE.Euler;
 };
 
+type HumanCharacterTheme = {
+  id?: string;
+  label?: string;
+  url?: string;
+  modelUrls?: string[];
+};
+
 const HUMAN_URL = "https://threejs.org/examples/models/gltf/Soldier.glb";
+const FREE_KICK_CHARACTER_POOL: HumanCharacterTheme[] = (MURLAN_CHARACTER_THEMES as HumanCharacterTheme[]).filter((theme) =>
+  Boolean(theme?.url || theme?.modelUrls?.length)
+);
+const FALLBACK_HUMAN_THEME: HumanCharacterTheme = { id: "mixamo-soldier", label: "Soldier", modelUrls: [HUMAN_URL] };
+const CROWD_SOUND_URL = "/assets/sounds/football-crowd-3-69245.mp3";
+const WHISTLE_SOUND_URL = "/assets/sounds/metal-whistle-6121.mp3";
+const KICK_SOUND_URL = "/assets/sounds/football-game-sound-effects-359284.mp3";
+const GOAL_NET_SOUND_URL = "/assets/sounds/a-football-hits-the-net-goal-313216.mp3";
+const POST_HIT_SOUND_URL = "/assets/sounds/frying-pan-over-the-head-89303.mp3";
 
 const FIELD_W = 22.0;
 const HALF_H = 36.0;
@@ -168,6 +186,24 @@ function normalizeHuman(model: THREE.Object3D, height = PLAYER_H) {
   model.position.y -= box2.min.y;
 }
 
+function modelUrlsForTheme(theme?: HumanCharacterTheme) {
+  const urls = [
+    ...(Array.isArray(theme?.modelUrls) ? theme?.modelUrls ?? [] : []),
+    theme?.url,
+    HUMAN_URL,
+  ].filter(Boolean) as string[];
+  return Array.from(new Set(urls));
+}
+
+function chooseRandomHumanThemes(count: number) {
+  const pool = FREE_KICK_CHARACTER_POOL.length ? [...FREE_KICK_CHARACTER_POOL] : [FALLBACK_HUMAN_THEME];
+  for (let i = pool.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [pool[i], pool[j]] = [pool[j], pool[i]];
+  }
+  return Array.from({ length: count }, (_, i) => pool[i % pool.length] ?? FALLBACK_HUMAN_THEME);
+}
+
 function tintModel(model: THREE.Object3D, kind: ActorKind, index = 0) {
   const color = kind === "kicker" ? new THREE.Color(0x1d69ff) : kind === "keeper" ? new THREE.Color(0x111111) : new THREE.Color(0xfacc15);
   model.traverse((obj) => {
@@ -202,7 +238,7 @@ function makeFallback(kind: ActorKind, index = 0) {
   return group;
 }
 
-function createActor(scene: THREE.Scene, loader: GLTFLoader, kind: ActorKind, pos: THREE.Vector3, index = 0): Actor {
+function createActor(scene: THREE.Scene, loader: GLTFLoader, kind: ActorKind, pos: THREE.Vector3, index = 0, characterTheme: HumanCharacterTheme = FALLBACK_HUMAN_THEME): Actor {
   const root = new THREE.Group();
   root.position.copy(pos).setY(GROUND_Y);
   scene.add(root);
@@ -233,31 +269,45 @@ function createActor(scene: THREE.Scene, loader: GLTFLoader, kind: ActorKind, po
     loaded: false,
   };
 
-  loader.setCrossOrigin("anonymous").load(HUMAN_URL, (gltf) => {
-    const model = gltf.scene;
-    normalizeHuman(model, kind === "keeper" ? 1.9 : PLAYER_H);
-    tintModel(model, kind, index);
-    shadow(model);
-    root.add(model);
-    fallback.visible = false;
-    actor.model = model;
-    actor.bones = findBones(model);
-    actor.mixer = new THREE.AnimationMixer(model);
+  const urls = modelUrlsForTheme(characterTheme);
+  const loadNext = (urlIndex = 0) => {
+    const url = urls[urlIndex] ?? HUMAN_URL;
+    loader.setCrossOrigin("anonymous").load(
+      url,
+      (gltf) => {
+        const model = gltf.scene;
+        normalizeHuman(model, kind === "keeper" ? 1.9 : PLAYER_H);
+        tintModel(model, kind, index);
+        shadow(model);
+        root.add(model);
+        fallback.visible = false;
+        actor.model = model;
+        actor.bones = findBones(model);
+        actor.mixer = new THREE.AnimationMixer(model);
 
-    const clips = new Map(gltf.animations.map((clip) => [clip.name.toLowerCase(), clip]));
-    const aliases: Record<AnimName, string[]> = { Idle: ["idle"], Walk: ["walk"], Run: ["run"] };
-    (Object.keys(aliases) as AnimName[]).forEach((name) => {
-      const clip = aliases[name].map((key) => clips.get(key)).find(Boolean);
-      if (!clip || !actor.mixer) return;
-      const action = actor.mixer.clipAction(clip);
-      action.enabled = true;
-      action.setLoop(THREE.LoopRepeat, Infinity);
-      action.setEffectiveWeight(name === "Idle" ? 1 : 0);
-      action.play();
-      actor.actions[name] = action;
-    });
-    actor.loaded = true;
-  });
+        const clips = new Map<string, any>(gltf.animations.map((clip: any) => [clip.name.toLowerCase(), clip]));
+        const aliases: Record<AnimName, string[]> = { Idle: ["idle"], Walk: ["walk"], Run: ["run"] };
+        (Object.keys(aliases) as AnimName[]).forEach((name) => {
+          const clip = aliases[name]
+            .map((key) => clips.get(key) ?? [...clips.entries()].find(([clipName]) => clipName.includes(key))?.[1])
+            .find(Boolean);
+          if (!clip || !actor.mixer) return;
+          const action = actor.mixer.clipAction(clip);
+          action.enabled = true;
+          action.setLoop(THREE.LoopRepeat, Infinity);
+          action.setEffectiveWeight(name === "Idle" ? 1 : 0);
+          action.play();
+          actor.actions[name] = action;
+        });
+        actor.loaded = true;
+      },
+      undefined,
+      () => {
+        if (urlIndex + 1 < urls.length) loadNext(urlIndex + 1);
+      }
+    );
+  };
+  loadNext();
 
   return actor;
 }
@@ -382,6 +432,82 @@ function createSoccerBallTexture() {
   return tex;
 }
 
+function createFreeKickAudio() {
+  let audioEnabled = true;
+  let audioStarted = false;
+  let pendingWhistle = false;
+  const crowdSound = new Audio(CROWD_SOUND_URL);
+  const whistleSound = new Audio(WHISTLE_SOUND_URL);
+  const goalNetSound = new Audio(GOAL_NET_SOUND_URL);
+  const postHitSound = new Audio(POST_HIT_SOUND_URL);
+  crowdSound.loop = true;
+  crowdSound.volume = 0.5;
+  postHitSound.volume = 0.7;
+
+  const playWhistle = () => {
+    if (!audioEnabled || !audioStarted) {
+      pendingWhistle = true;
+      return;
+    }
+    pendingWhistle = false;
+    whistleSound.currentTime = 0;
+    void whistleSound.play().catch(() => {});
+    window.setTimeout(() => {
+      whistleSound.pause();
+      whistleSound.currentTime = 0;
+    }, 2000);
+  };
+
+  const init = () => {
+    if (audioStarted || !audioEnabled) return;
+    audioStarted = true;
+    void crowdSound.play().catch(() => {});
+    if (pendingWhistle) playWhistle();
+  };
+
+  const playTransient = (url: string, maxDuration = 700, volume = 1, startAt = 0) => {
+    if (!audioEnabled) return;
+    const snd = new Audio(url);
+    snd.volume = volume;
+    snd.currentTime = startAt;
+    void snd.play().catch(() => {});
+    window.setTimeout(() => snd.pause(), maxDuration);
+  };
+
+  return {
+    init,
+    hit: () => playTransient(KICK_SOUND_URL, 700),
+    wall: () => playTransient(POST_HIT_SOUND_URL, 520, 0.44, 0.15),
+    save: playWhistle,
+    post: () => {
+      if (!audioEnabled) return;
+      postHitSound.currentTime = 0.15;
+      void postHitSound.play().catch(() => {});
+      window.setTimeout(() => {
+        postHitSound.pause();
+        postHitSound.currentTime = 0.15;
+      }, 1000);
+    },
+    goal: () => {
+      if (!audioEnabled) return;
+      goalNetSound.currentTime = 0;
+      void goalNetSound.play().catch(() => {});
+      window.setTimeout(() => {
+        goalNetSound.pause();
+        goalNetSound.currentTime = 0;
+      }, 2000);
+      playWhistle();
+    },
+    dispose: () => {
+      audioEnabled = false;
+      crowdSound.pause();
+      whistleSound.pause();
+      goalNetSound.pause();
+      postHitSound.pause();
+    },
+  };
+}
+
 function makeBall(scene: THREE.Scene): BallState {
   const object = new THREE.Group();
   const ballMat = new THREE.MeshStandardMaterial({ map: createSoccerBallTexture(), roughness: 0.42, metalness: 0.02 });
@@ -450,7 +576,61 @@ function makeCylinderBetween(a: THREE.Vector3, b: THREE.Vector3, radius: number,
 function makeGoal(scene: THREE.Scene, netRig: NetRig) { const root = new THREE.Group(); root.position.z = GOAL_LINE_Z; const white = material(0xffffff, 0.4, 0.18); const rear = material(0xcbd5e1, 0.46, 0.28); const backScale = 0.82; const backW = GOAL_W * backScale; const backH = GOAL_H * backScale; const FL = new THREE.Vector3(-GOAL_W / 2, 0, 0); const FR = new THREE.Vector3(GOAL_W / 2, 0, 0); const FLT = new THREE.Vector3(-GOAL_W / 2, GOAL_H, 0); const FRT = new THREE.Vector3(GOAL_W / 2, GOAL_H, 0); const BL = new THREE.Vector3(-backW / 2, 0.03, -GOAL_D); const BR = new THREE.Vector3(backW / 2, 0.03, -GOAL_D); const BLT = new THREE.Vector3(-backW / 2, backH, -GOAL_D); const BRT = new THREE.Vector3(backW / 2, backH, -GOAL_D); root.add(makeCylinderBetween(FL, FLT, POST_R, white), makeCylinderBetween(FR, FRT, POST_R, white), makeCylinderBetween(FLT, FRT, POST_R, white), makeCylinderBetween(BL, BLT, POST_R * 0.48, rear), makeCylinderBetween(BR, BRT, POST_R * 0.48, rear), makeCylinderBetween(BLT, BRT, POST_R * 0.48, rear), makeCylinderBetween(FLT, BLT, POST_R * 0.42, rear), makeCylinderBetween(FRT, BRT, POST_R * 0.42, rear), makeCylinderBetween(FL, BL, POST_R * 0.36, rear), makeCylinderBetween(FR, BR, POST_R * 0.36, rear)); root.add(makeNetSurface(netRig, BL, BR, BRT, BLT, 18, 10)); root.add(makeNetSurface(netRig, FLT, FRT, BRT, BLT, 18, 8)); root.add(makeNetSurface(netRig, FL, BL, BLT, FLT, 8, 10)); root.add(makeNetSurface(netRig, FR, BR, BRT, FRT, 8, 10)); scene.add(root); }
 function triggerNetShake(netRig: NetRig, impact: THREE.Vector3) { netRig.shake = 1.35; netRig.impact.copy(impact).sub(new THREE.Vector3(0, 0, GOAL_LINE_Z)); }
 function updateNetShake(netRig: NetRig, dt: number) { if (netRig.shake <= 0) return; const time = performance.now() * 0.02; const strength = netRig.shake; netRig.lines.forEach((line, idx) => { const base = line.userData.base as THREE.Vector3[]; const attr = line.geometry.getAttribute("position") as THREE.BufferAttribute; for (let i = 0; i < 2; i++) { const p = base[i]; const distance = Math.max(0.28, p.distanceTo(netRig.impact)); const falloff = THREE.MathUtils.clamp(1.65 / distance, 0, 1.4); const wave = Math.sin(time + idx * 0.37 + i * 1.7) * 0.24 * strength * falloff; attr.setXYZ(i, p.x + wave * 0.36, p.y + Math.abs(wave) * 0.28, p.z - Math.abs(wave) * 1.45); } attr.needsUpdate = true; }); netRig.shake = Math.max(0, netRig.shake - dt * 1.65); }
-function makeBillboardsAndStands(scene: THREE.Scene) { const boardGroup = new THREE.Group(); const zBoard = GOAL_LINE_Z - GOAL_D - 0.75; const boardColors = [0x2563eb, 0xef4444, 0x16a34a, 0xfacc15, 0x7c3aed, 0x0ea5e9]; for (let i = 0; i < 6; i++) { const x = (i - 2.5) * 3.15; const board = new THREE.Mesh(new THREE.BoxGeometry(2.95, 0.82, 0.08), material(boardColors[i], 0.5, 0.02)); board.position.set(x, 0.55, zBoard); const top = new THREE.Mesh(new THREE.BoxGeometry(2.95, 0.08, 0.1), material(0xffffff, 0.55, 0.02)); top.position.set(x, 1.0, zBoard + 0.01); const textBar = new THREE.Mesh(new THREE.BoxGeometry(1.7, 0.12, 0.105), material(0xffffff, 0.55, 0.02)); textBar.position.set(x, 0.55, zBoard + 0.015); boardGroup.add(shadow(board), shadow(top), shadow(textBar)); } scene.add(boardGroup); }
+function makeBillboardsAndStands(scene: THREE.Scene) {
+  const boardGroup = new THREE.Group();
+  const zBoard = GOAL_LINE_Z - GOAL_D - 0.75;
+  const boardColors = [0x2563eb, 0xef4444, 0x16a34a, 0xfacc15, 0x7c3aed, 0x0ea5e9];
+  for (let i = 0; i < 6; i++) {
+    const x = (i - 2.5) * 3.15;
+    const board = new THREE.Mesh(new THREE.BoxGeometry(2.95, 0.82, 0.08), material(boardColors[i], 0.5, 0.02));
+    board.position.set(x, 0.55, zBoard);
+    const top = new THREE.Mesh(new THREE.BoxGeometry(2.95, 0.08, 0.1), material(0xffffff, 0.55, 0.02));
+    top.position.set(x, 1.0, zBoard + 0.01);
+    const textBar = new THREE.Mesh(new THREE.BoxGeometry(1.7, 0.12, 0.105), material(0xffffff, 0.55, 0.02));
+    textBar.position.set(x, 0.55, zBoard + 0.015);
+    boardGroup.add(shadow(board), shadow(top), shadow(textBar));
+  }
+  scene.add(boardGroup);
+
+  const stand = new THREE.Group();
+  stand.position.z = GOAL_LINE_Z - GOAL_D - 2.45;
+  const concrete = material(0x64748b, 0.86, 0.02);
+  const aisleMat = material(0xd1d5db, 0.78, 0.02);
+  const chairSeatMat = material(0x1d4ed8, 0.58, 0.02);
+  const chairBackMat = material(0x2563eb, 0.52, 0.02);
+  const railMat = material(0xf8fafc, 0.42, 0.12);
+  const rowCount = 7;
+  const seatsPerRow = 22;
+  const standWidth = 18.2;
+  const seatSpacing = standWidth / seatsPerRow;
+  for (let row = 0; row < rowCount; row++) {
+    const y = 0.42 + row * 0.34;
+    const z = -row * 0.64;
+    const step = new THREE.Mesh(new THREE.BoxGeometry(standWidth + 2.4, 0.18, 0.68), concrete);
+    step.position.set(0, y - 0.12, z + 0.1);
+    stand.add(shadow(step));
+    for (let seat = 0; seat < seatsPerRow; seat++) {
+      const x = -standWidth / 2 + seatSpacing * (seat + 0.5);
+      const inAisle = Math.abs(x) < 0.55 || Math.abs(x - 4.55) < 0.34 || Math.abs(x + 4.55) < 0.34;
+      if (inAisle) continue;
+      const seatMesh = new THREE.Mesh(new THREE.BoxGeometry(0.48, 0.08, 0.42), chairSeatMat);
+      seatMesh.position.set(x, y + 0.06, z - 0.05);
+      const back = new THREE.Mesh(new THREE.BoxGeometry(0.5, 0.42, 0.08), chairBackMat);
+      back.position.set(x, y + 0.32, z - 0.29);
+      stand.add(shadow(seatMesh), shadow(back));
+    }
+  }
+  [-4.55, 0, 4.55].forEach((x) => {
+    const stairs = new THREE.Mesh(new THREE.BoxGeometry(0.7, 0.1, rowCount * 0.68 + 0.38), aisleMat);
+    stairs.position.set(x, 1.25, -2.02);
+    stairs.rotation.x = THREE.MathUtils.degToRad(-14);
+    stand.add(shadow(stairs));
+  });
+  const rail = new THREE.Mesh(new THREE.BoxGeometry(standWidth + 2.9, 0.08, 0.08), railMat);
+  rail.position.set(0, 0.78, 0.55);
+  stand.add(shadow(rail));
+  scene.add(stand);
+}
 function addLine(scene: THREE.Scene, points: THREE.Vector3[], color = 0xffffff, opacity = 0.9) { const line = new THREE.Line(new THREE.BufferGeometry().setFromPoints(points.map((p) => new THREE.Vector3(p.x, 0.018, p.z))), new THREE.LineBasicMaterial({ color, transparent: true, opacity })); scene.add(line); return line; }
 function addRect(scene: THREE.Scene, left: number, right: number, frontZ: number, backZ: number) { addLine(scene, [new THREE.Vector3(left, 0, frontZ), new THREE.Vector3(left, 0, backZ), new THREE.Vector3(right, 0, backZ), new THREE.Vector3(right, 0, frontZ)]); }
 function makeHalfField(scene: THREE.Scene, netRig: NetRig) { const grassA = material(0x1d7d39, 0.95, 0); const grassB = material(0x16692e, 0.95, 0); for (let i = 0; i < 10; i++) { const stripe = new THREE.Mesh(new THREE.PlaneGeometry(FIELD_W, HALF_H / 10), i % 2 ? grassA : grassB); stripe.rotation.x = -Math.PI / 2; stripe.position.z = -HALF_H / 2 + HALF_H / 20 + (i * HALF_H) / 10; stripe.receiveShadow = true; scene.add(stripe); } const w = FIELD_W / 2; const h = HALF_H / 2; addLine(scene, [new THREE.Vector3(-w, 0, -h), new THREE.Vector3(w, 0, -h), new THREE.Vector3(w, 0, h), new THREE.Vector3(-w, 0, h), new THREE.Vector3(-w, 0, -h)]); addLine(scene, [new THREE.Vector3(-w, 0, h), new THREE.Vector3(w, 0, h)]); addRect(scene, -PENALTY_W / 2, PENALTY_W / 2, -h, -h + PENALTY_D); addRect(scene, -GOAL_AREA_W / 2, GOAL_AREA_W / 2, -h, -h + GOAL_AREA_D); const penaltySpot = new THREE.Mesh(new THREE.CircleGeometry(0.08, 28), new THREE.MeshBasicMaterial({ color: 0xffffff })); penaltySpot.rotation.x = -Math.PI / 2; penaltySpot.position.set(0, 0.022, -h + PENALTY_SPOT_D); scene.add(penaltySpot); const boxTopZ = -h + PENALTY_D; const spotZ = -h + PENALTY_SPOT_D; const theta = Math.acos((boxTopZ - spotZ) / ARC_R); const arcPts = new THREE.EllipseCurve(0, spotZ, ARC_R, ARC_R, theta, Math.PI - theta).getPoints(96).map((p) => new THREE.Vector3(p.x, 0, p.y)); addLine(scene, arcPts); makeGoal(scene, netRig); makeBillboardsAndStands(scene); }
@@ -472,6 +652,7 @@ function keeperSaveCheck(keeper: Actor, ball: BallState, dt: number) { if (!ball
 function wallBlockCheck(wall: Actor[], ball: BallState) { if (!ball.flying || ball.netCaught) return false; for (const actor of wall) { if (!actor.root.visible) continue; const chest = actor.pos.clone().setY(actor.jumpTime > 0 ? 1.55 : 1.15); if (chest.distanceTo(ball.object.position) < 0.55) { ball.flying = false; return true; } } return false; }
 function isGoalPosition(p: THREE.Vector3) { const crossedLine = p.z <= GOAL_LINE_Z - 0.05; const insidePosts = Math.abs(p.x) <= GOAL_W / 2 - BALL_R; const underBar = p.y >= BALL_R && p.y <= GOAL_H - BALL_R * 0.25; return crossedLine && insidePosts && underBar; }
 function decideShot(ball: BallState, blocked: boolean, saved: boolean): Decision { if (blocked) return "BLOCKED"; if (saved) return "SAVE"; return isGoalPosition(ball.object.position) || ball.netCaught ? "GOAL" : "NO GOAL"; }
+function isPostHitPosition(p: THREE.Vector3) { const crossedLine = p.z <= GOAL_LINE_Z + 0.12; const nearUpright = Math.abs(Math.abs(p.x) - GOAL_W / 2) < 0.28 && p.y <= GOAL_H + 0.25; const nearCrossbar = Math.abs(p.y - GOAL_H) < 0.22 && Math.abs(p.x) <= GOAL_W / 2 + 0.22; return crossedLine && (nearUpright || nearCrossbar); }
 function catchBallInNet(ball: BallState, netRig: NetRig) { ball.netCaught = true; ball.netAge = 0; ball.flying = true; ball.netVel.copy(ball.vel).multiplyScalar(0.12); ball.netVel.z = Math.min(ball.netVel.z, -0.45); ball.netVel.y *= 0.18; triggerNetShake(netRig, ball.object.position.clone()); }
 
 export default function FreeKickGame() {
@@ -494,19 +675,21 @@ export default function FreeKickGame() {
     scene.add(new THREE.AmbientLight(0xffffff, 0.68));
     const sun = new THREE.DirectionalLight(0xffffff, 1.35);
     sun.position.set(8, 16, 10); sun.castShadow = true; sun.shadow.mapSize.set(2048, 2048); scene.add(sun);
+    const audio = createFreeKickAudio();
     const netRig: NetRig = { lines: [], shake: 0, impact: new THREE.Vector3() };
     makeHalfField(scene, netRig);
     const aimLine = makeAimLine(scene);
     hideAimLine(aimLine);
     const ball = makeBall(scene);
     const loader = new GLTFLoader();
-    const kicker = createActor(scene, loader, "kicker", new THREE.Vector3(0, 0, 6));
-    const keeper = createActor(scene, loader, "keeper", new THREE.Vector3(0, 0, GOAL_LINE_Z + 0.36));
-    const wall = Array.from({ length: 5 }, (_, i) => createActor(scene, loader, "wall", new THREE.Vector3(0, 0, 0), i));
+    const matchCharacters = chooseRandomHumanThemes(7);
+    const kicker = createActor(scene, loader, "kicker", new THREE.Vector3(0, 0, 6), 0, matchCharacters[0]);
+    const keeper = createActor(scene, loader, "keeper", new THREE.Vector3(0, 0, GOAL_LINE_Z + 0.36), 0, matchCharacters[1]);
+    const wall = Array.from({ length: 5 }, (_, i) => createActor(scene, loader, "wall", new THREE.Vector3(0, 0, 0), i, matchCharacters[i + 2]));
     let spot: KickSpot = "center"; let state: ShotState = "aim"; let resultTimer = 0; let varTimer = 0; let replayIndex = 0; let replayClock = 0; let pendingDecision: Decision = "NO GOAL"; let shotBlocked = false; let shotSaved = false; let shotFinalized = false; let netTriggered = false; const replayFrames: ReplayFrame[] = []; let score = { goals: 0, saves: 0 }; resetShot(ball, kicker, keeper, wall, spot);
     const resize = () => { const w = Math.max(1, host.clientWidth); const h = Math.max(1, host.clientHeight); renderer.setSize(w, h, false); renderer.setPixelRatio(Math.min(2, window.devicePixelRatio || 1)); camera.aspect = w / h; camera.updateProjectionMatrix(); };
     resize(); window.addEventListener("resize", resize);
-    const onDown = (e: PointerEvent) => { if (state !== "aim") return; swipeRef.current = { active: true, startX: e.clientX, startY: e.clientY, endX: e.clientX, endY: e.clientY }; setAimCurve(aimLine, ball.object.position, swipeRef.current); };
+    const onDown = (e: PointerEvent) => { audio.init(); if (state !== "aim") return; swipeRef.current = { active: true, startX: e.clientX, startY: e.clientY, endX: e.clientX, endY: e.clientY }; setAimCurve(aimLine, ball.object.position, swipeRef.current); };
     const onMove = (e: PointerEvent) => { if (!swipeRef.current.active || state !== "aim") return; swipeRef.current.endX = e.clientX; swipeRef.current.endY = e.clientY; setAimCurve(aimLine, ball.object.position, swipeRef.current); };
     const onUp = (e: PointerEvent) => { if (!swipeRef.current.active || state !== "aim") return; swipeRef.current.endX = e.clientX; swipeRef.current.endY = e.clientY; swipeRef.current.active = false; hideAimLine(aimLine); beginRunup(kicker, wall, keeper, ball, swipeRef.current); shotBlocked = false; shotSaved = false; shotFinalized = false; netTriggered = false; replayFrames.length = 0; state = "runup"; setHud((h) => ({ ...h, state: "2-step run-up..." })); };
     canvas.addEventListener("pointerdown", onDown); canvas.addEventListener("pointermove", onMove); canvas.addEventListener("pointerup", onUp); canvas.addEventListener("pointercancel", onUp);
@@ -520,14 +703,14 @@ export default function FreeKickGame() {
         const strikeSpot = ball.object.position.clone().add(new THREE.Vector3(-0.24, -BALL_R, 0.42)).setY(0);
         TMP.copy(strikeSpot).sub(kicker.pos).setY(0);
         if (TMP.length() > 0.055) { kicker.dir.copy(TMP.clone().normalize()); kicker.vel.copy(kicker.dir).multiplyScalar(4.05); kicker.pos.addScaledVector(kicker.vel, dt); kicker.speed = kicker.vel.length(); } else { kicker.speed = 0; }
-        if (kicker.kickTime < 0.34 && !ball.flying) { replayFrames.length = 0; recordReplayFrame(new THREE.Vector3(0, 1.22, GOAL_LINE_Z + 0.25)); shootBall(ball, swipeRef.current); state = "flight"; setHud((h) => ({ ...h, state: "Right-foot strike · recording replay" })); }
+        if (kicker.kickTime < 0.34 && !ball.flying) { replayFrames.length = 0; recordReplayFrame(new THREE.Vector3(0, 1.22, GOAL_LINE_Z + 0.25)); shootBall(ball, swipeRef.current); audio.hit(); state = "flight"; setHud((h) => ({ ...h, state: "Right-foot strike · recording replay" })); }
       } else { kicker.speed = 0; }
       updateBall(ball, dt); updateNetShake(netRig, dt);
       if (state === "flight") {
-        if (!shotBlocked && wallBlockCheck(wall, ball)) shotBlocked = true;
-        if (!shotSaved && keeperSaveCheck(keeper, ball, dt)) shotSaved = true;
-        if (!netTriggered && !shotBlocked && !shotSaved && isGoalPosition(ball.object.position)) { netTriggered = true; catchBallInNet(ball, netRig); setHud((h) => ({ ...h, state: "Ball hits net · checking VAR" })); }
-        if (!ball.flying && !shotFinalized) { shotFinalized = true; pendingDecision = decideShot(ball, shotBlocked, shotSaved); varTimer = pendingDecision === "GOAL" || pendingDecision === "NO GOAL" ? 1.15 : 0.65; state = "var"; setHud((h) => ({ ...h, state: pendingDecision === "GOAL" ? "VAR CHECK: ball crossed line" : `VAR CHECK: ${pendingDecision}` })); }
+        if (!shotBlocked && wallBlockCheck(wall, ball)) { shotBlocked = true; audio.wall(); }
+        if (!shotSaved && keeperSaveCheck(keeper, ball, dt)) { shotSaved = true; audio.save(); }
+        if (!netTriggered && !shotBlocked && !shotSaved && isGoalPosition(ball.object.position)) { netTriggered = true; catchBallInNet(ball, netRig); audio.goal(); setHud((h) => ({ ...h, state: "Ball hits net · checking VAR" })); }
+        if (!ball.flying && !shotFinalized) { shotFinalized = true; pendingDecision = decideShot(ball, shotBlocked, shotSaved); if (pendingDecision === "NO GOAL" && isPostHitPosition(ball.object.position)) audio.post(); varTimer = pendingDecision === "GOAL" || pendingDecision === "NO GOAL" ? 1.15 : 0.65; state = "var"; setHud((h) => ({ ...h, state: pendingDecision === "GOAL" ? "VAR CHECK: ball crossed line" : `VAR CHECK: ${pendingDecision}` })); }
       }
       if (state === "var") { varTimer -= dt; if (varTimer <= 0) { state = "replay"; replayIndex = 0; replayClock = 0; setHud((h) => ({ ...h, state: `SLOW REPLAY: ${pendingDecision}` })); } }
       if (state === "replay") {
@@ -559,7 +742,7 @@ export default function FreeKickGame() {
     };
     loop();
     (window as any).__setFreeKickSpot = (next: KickSpot) => { spot = next; state = "aim"; hideAimLine(aimLine); replayFrames.length = 0; resetShot(ball, kicker, keeper, wall, spot); setHud((h) => ({ ...h, spot, state: `Free kick ${next}: wall ${wallCountForSpot(next)} at 9.15m` })); };
-    return () => { cancelAnimationFrame(frame); window.removeEventListener("resize", resize); canvas.removeEventListener("pointerdown", onDown); canvas.removeEventListener("pointermove", onMove); canvas.removeEventListener("pointerup", onUp); canvas.removeEventListener("pointercancel", onUp); renderer.dispose(); };
+    return () => { cancelAnimationFrame(frame); window.removeEventListener("resize", resize); canvas.removeEventListener("pointerdown", onDown); canvas.removeEventListener("pointermove", onMove); canvas.removeEventListener("pointerup", onUp); canvas.removeEventListener("pointercancel", onUp); audio.dispose(); renderer.dispose(); };
   }, []);
 
   const setSpot = (spot: KickSpot) => {


### PR DESCRIPTION
### Motivation
- Reuse existing Goal Rush football SFX and Murlan Royale human character assets to make Free Kick Arena feel consistent with other arenas. 
- Add visual crowd/stands and varied human players so matches look and sound more like a stadium event.

### Description
- Reused Goal Rush audio assets and added a `createFreeKickAudio()` manager that drives crowd loop, whistle, kick, net, post, wall and save feedback and is wired into gameplay events (`audio.init`, `audio.hit`, `audio.wall`, `audio.save`, `audio.goal`, `audio.post`, `audio.dispose`).
- Integrated Murlan Royale human character inventory by importing `MURLAN_CHARACTER_THEMES`, added `modelUrlsForTheme()` and `chooseRandomHumanThemes()` and changed `createActor()` to accept a `characterTheme` and attempt multiple model URLs with graceful fallback.
- Randomizes and assigns character themes per-match for kicker, keeper and wall actors so humans are not identical each game.
- Extended the arena visuals by enhancing `makeBillboardsAndStands()` to generate stepped grandstands with chairs, stair aisles and rails behind the goal line and invoked it during field construction.

### Testing
- Ran `npm run build` and the production build completed successfully.
- Ran `npx tsc --noEmit` which reported existing repo-wide type/declaration issues (missing `three` typings and other pre-existing strictness errors) and therefore failed across the project.
- Performed a Playwright-based smoke check against `/games/freekickarena` (headless screenshot flow); the page rendered and a screenshot attempt completed though the browser console showed network/asset warnings and some resource load errors during the smoke run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faaad846008329bf38350f1247d95e)