### PR TITLE
PoolRoyaleLobby: add table style selection and persist table finish/base

### DIFF
--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -32,6 +32,31 @@ import {
 
 const PLAYER_FLAG_STORAGE_KEY = 'poolRoyalePlayerFlag';
 const AI_FLAG_STORAGE_KEY = 'poolRoyaleAiFlag';
+const TABLE_FINISH_STORAGE_KEY = 'poolRoyaleTableFinish';
+const TABLE_BASE_STORAGE_KEY = 'poolRoyaleTableBase';
+
+const TABLE_STYLE_OPTIONS = [
+  {
+    id: 'classic',
+    label: 'Classic Royal',
+    finishId: 'peelingPaintWeathered',
+    baseId: 'classicCylinders'
+  },
+  {
+    id: 'modern',
+    label: 'Modern Arena',
+    finishId: 'darkWood',
+    baseId: 'openPortal',
+    tableSizeId: '8ft'
+  },
+  {
+    id: 'pro',
+    label: 'Pro Tournament',
+    finishId: 'rosewoodVeneer01',
+    baseId: 'coffeeTableRound01',
+    tableSizeId: '9ft'
+  }
+];
 
 function resolveTpcAccountNumber(player) {
   if (!player || typeof player !== 'object') return '';
@@ -70,10 +95,24 @@ export default function PoolRoyaleLobby() {
   const [variant, setVariant] = useState('uk');
   const [ukBallSet, setUkBallSet] = useState('uk');
   const [playType, setPlayType] = useState(initialPlayType);
+  const [tableStyleId, setTableStyleId] = useState(() => {
+    try {
+      const stored = window.localStorage?.getItem('poolRoyaleLobbyTableStyle');
+      if (TABLE_STYLE_OPTIONS.some((option) => option.id === stored)) {
+        return stored;
+      }
+    } catch {}
+    return 'classic';
+  });
   const [players, setPlayers] = useState(8);
-  const tableSize = resolveTableSize(searchParams.get('tableSize')).id;
+  const selectedTableStyle =
+    TABLE_STYLE_OPTIONS.find((option) => option.id === tableStyleId) ||
+    TABLE_STYLE_OPTIONS[0];
+  const tableSize = resolveTableSize(
+    selectedTableStyle?.tableSizeId || searchParams.get('tableSize')
+  ).id;
   const defaultTableSize = resolveTableSize().id;
-  const onlineTableSize = defaultTableSize;
+  const onlineTableSize = tableSize || defaultTableSize;
   const [onlinePlayers, setOnlinePlayers] = useState([]);
   const [matching, setMatching] = useState(false);
   const [spinningPlayer, setSpinningPlayer] = useState('');
@@ -219,6 +258,25 @@ export default function PoolRoyaleLobby() {
     await cleanupRef.current?.();
     setMatchStatus('');
     setMatchingError('');
+
+    try {
+      window.localStorage?.setItem(
+        'poolRoyaleLobbyTableStyle',
+        selectedTableStyle.id
+      );
+      if (selectedTableStyle.finishId) {
+        window.localStorage?.setItem(
+          TABLE_FINISH_STORAGE_KEY,
+          selectedTableStyle.finishId
+        );
+      }
+      if (selectedTableStyle.baseId) {
+        window.localStorage?.setItem(
+          TABLE_BASE_STORAGE_KEY,
+          selectedTableStyle.baseId
+        );
+      }
+    } catch {}
 
     if (isOnlineMatch) {
       await runPoolRoyaleOnlineFlow({
@@ -584,6 +642,42 @@ export default function PoolRoyaleLobby() {
           </div>
           <p className="mt-3 text-xs text-white/60">
             Your lobby choices persist into the match intro.
+          </p>
+        </div>
+
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold text-white">Table Style</h3>
+            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">
+              Arena
+            </span>
+          </div>
+          <div className="grid grid-cols-3 gap-3">
+            {TABLE_STYLE_OPTIONS.map((option) => {
+              const active = tableStyleId === option.id;
+              return (
+                <button
+                  key={option.id}
+                  type="button"
+                  onClick={() => setTableStyleId(option.id)}
+                  className={`lobby-option-card ${
+                    active
+                      ? 'lobby-option-card-active'
+                      : 'lobby-option-card-inactive'
+                  }`}
+                >
+                  <div className="lobby-option-thumb bg-gradient-to-br from-fuchsia-400/20 via-amber-500/10 to-transparent">
+                    <div className="lobby-option-thumb-inner text-2xl">🟩</div>
+                  </div>
+                  <div className="text-center">
+                    <p className="lobby-option-label">{option.label}</p>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+          <p className="text-xs text-white/60">
+            Selected table style is applied when the match starts.
           </p>
         </div>
 


### PR DESCRIPTION
### Motivation

- Provide players a way to choose a visual table style (arena) in the PoolRoyale lobby so matches can use a selected finish and base. 
- Persist the chosen table style across sessions so the selection carries into the match intro. 
- Ensure online match table sizing respects the selected style's configured table size when present.

### Description

- Add `TABLE_STYLE_OPTIONS`, `TABLE_FINISH_STORAGE_KEY`, and `TABLE_BASE_STORAGE_KEY` constants and wire them into the lobby code. 
- Introduce `tableStyleId` state initialized from `localStorage` (`poolRoyaleLobbyTableStyle`) and compute `selectedTableStyle` to drive `tableSize`. 
- Save the selected style id and, when present, its `finishId` and `baseId` into `localStorage` during `startGame`. 
- Render a 3-option table style picker in the lobby UI and apply the selected style when the match starts.

### Testing

- Ran unit tests with `yarn test` and they completed successfully. 
- Ran linter with `yarn lint` and it passed without errors. 
- Built the frontend with `yarn build` and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa3313a6b48329b1601d5a7248869c)