### PR TITLE
Support selectable external GLB table models for Pool Royale

### DIFF
--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -1,0 +1,60 @@
+export const POOL_ROYALE_TABLE_MODEL_STORAGE_KEY = 'poolRoyaleTableModel';
+
+const POOLTOOL_RAW_BASE =
+  'https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table';
+
+export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
+  {
+    id: 'royal-original',
+    label: 'Royal Original',
+    description: 'Current TonPlaygram table with existing gameplay geometry.',
+    tableSizeId: '9ft',
+    finishId: 'peelingPaintWeathered',
+    baseId: 'classicCylinders',
+    icon: '🎱',
+    kind: 'native'
+  },
+  {
+    id: 'showood-seven-foot',
+    label: 'Showood 7 ft GLB',
+    description: 'Open-source Pooltool seven-foot table with original GLB textures.',
+    tableSizeId: '8ft',
+    assetUrl: `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood_pbr.glb`,
+    fallbackAssetUrl: `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood.glb`,
+    icon: '🟫',
+    kind: 'gltf',
+    fitScale: 1.02
+  },
+  {
+    id: 'pooltool-null-pbr',
+    label: 'Pooltool PBR GLB',
+    description: 'Pooltool PBR pool table normalized to Pool Royale proportions.',
+    tableSizeId: '9ft',
+    assetUrl: `${POOLTOOL_RAW_BASE}/null/null_pbr.glb`,
+    fallbackAssetUrl: `${POOLTOOL_RAW_BASE}/null/null.glb`,
+    icon: '🟩',
+    kind: 'gltf',
+    fitScale: 1
+  },
+  {
+    id: 'snooker-generic',
+    label: 'Snooker GLB',
+    description: 'Open-source snooker-style table fitted to the 9 ft Pool Royale arena.',
+    tableSizeId: '9ft',
+    assetUrl: `${POOLTOOL_RAW_BASE}/snooker_generic/snooker_generic.glb`,
+    icon: '🟦',
+    kind: 'gltf',
+    fitScale: 1.04
+  }
+]);
+
+export const DEFAULT_POOL_ROYALE_TABLE_MODEL_ID =
+  POOL_ROYALE_TABLE_MODEL_OPTIONS[0].id;
+
+export function resolvePoolRoyaleTableModel(modelId) {
+  const key = typeof modelId === 'string' ? modelId.trim() : '';
+  return (
+    POOL_ROYALE_TABLE_MODEL_OPTIONS.find((option) => option.id === key) ||
+    POOL_ROYALE_TABLE_MODEL_OPTIONS[0]
+  );
+}

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -33,6 +33,10 @@ import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
 import { PoolRoyaleRules } from '../../../../src/rules/PoolRoyaleRules.ts';
 import { useAimCalibration } from '../../hooks/useAimCalibration.js';
 import { resolveTableSize } from '../../config/poolRoyaleTables.js';
+import {
+  POOL_ROYALE_TABLE_MODEL_STORAGE_KEY,
+  resolvePoolRoyaleTableModel
+} from '../../config/poolRoyaleTableModels.js';
 import { resolveTableSize as resolveSnookerTableSize } from '../../config/snookerClubTables.js';
 import { isGameMuted, getGameVolume } from '../../utils/sound.js';
 import { chatBeep } from '../../assets/soundData.js';
@@ -12510,6 +12514,185 @@ export function Table3D(
     return loader;
   };
 
+
+
+const poolRoyaleExternalTableTemplates = new Map();
+const poolRoyaleExternalTablePromises = new Map();
+
+function preparePoolRoyaleExternalTableMaterials(root) {
+  root?.traverse?.((child) => {
+    if (!child?.isMesh) return;
+    child.castShadow = true;
+    child.receiveShadow = true;
+    child.frustumCulled = false;
+
+    const prepareTexture = (texture, isColor = false) => {
+      if (!texture) return;
+      if (isColor) texture.colorSpace = THREE.SRGBColorSpace;
+      texture.flipY = false;
+      texture.generateMipmaps = true;
+      texture.minFilter = THREE.LinearMipmapLinearFilter;
+      texture.magFilter = THREE.LinearFilter;
+      texture.anisotropy = resolveTextureAnisotropy(12);
+      texture.needsUpdate = true;
+    };
+
+    const prepareMaterial = (material) => {
+      if (!material) return material;
+      const mat = material.clone ? material.clone() : material;
+      mat.transparent = false;
+      mat.depthWrite = true;
+      mat.depthTest = true;
+      mat.polygonOffset = false;
+      if ('side' in mat) mat.side = THREE.FrontSide;
+      if ('alphaTest' in mat) mat.alphaTest = 0;
+      prepareTexture(mat.map, true);
+      prepareTexture(mat.emissiveMap, true);
+      prepareTexture(mat.aoMap, false);
+      prepareTexture(mat.normalMap, false);
+      prepareTexture(mat.roughnessMap, false);
+      prepareTexture(mat.metalnessMap, false);
+      mat.needsUpdate = true;
+      return mat;
+    };
+
+    if (Array.isArray(child.material)) {
+      child.material = child.material.map(prepareMaterial);
+    } else if (child.material) {
+      child.material = prepareMaterial(child.material);
+    }
+  });
+}
+
+function clonePoolRoyaleExternalTableTemplate(template) {
+  const clone = template.clone(true);
+  preparePoolRoyaleExternalTableMaterials(clone);
+  return clone;
+}
+
+async function loadPoolRoyaleExternalTableTemplate(tableModel, renderer = null) {
+  if (!tableModel?.assetUrl) return null;
+  if (poolRoyaleExternalTableTemplates.has(tableModel.id)) {
+    return poolRoyaleExternalTableTemplates.get(tableModel.id);
+  }
+  if (poolRoyaleExternalTablePromises.has(tableModel.id)) {
+    return poolRoyaleExternalTablePromises.get(tableModel.id);
+  }
+  const promise = (async () => {
+    const loader = createConfiguredGLTFLoader(renderer);
+    let lastError = null;
+    const urls = [tableModel.assetUrl, tableModel.fallbackAssetUrl].filter(Boolean);
+    for (const url of urls) {
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        const gltf = await loader.loadAsync(url);
+        const scene = gltf?.scene || gltf?.scenes?.[0];
+        if (!scene) throw new Error(`Missing GLTF scene for ${tableModel.id}`);
+        poolRoyaleExternalTableTemplates.set(tableModel.id, scene);
+        return scene;
+      } catch (error) {
+        lastError = error;
+      }
+    }
+    throw lastError || new Error(`Failed to load Pool Royale table model: ${tableModel.id}`);
+  })();
+  poolRoyaleExternalTablePromises.set(tableModel.id, promise);
+  promise.catch(() => poolRoyaleExternalTablePromises.delete(tableModel.id));
+  return promise;
+}
+
+function fitPoolRoyaleExternalTableModel(model, tableModel, dims) {
+  if (!model || !dims) return;
+  model.position.set(0, 0, 0);
+  model.rotation.set(0, 0, 0);
+  model.scale.setScalar(1);
+  model.updateMatrixWorld(true);
+
+  let box = new THREE.Box3().setFromObject(model);
+  let size = box.getSize(new THREE.Vector3());
+  if (size.x > size.z && dims.targetLength > dims.targetWidth) {
+    model.rotation.y = Math.PI / 2;
+    model.updateMatrixWorld(true);
+    box = new THREE.Box3().setFromObject(model);
+    size = box.getSize(new THREE.Vector3());
+  }
+
+  const modelWidth = Math.max(MICRO_EPS, Math.min(size.x, size.z));
+  const modelLength = Math.max(MICRO_EPS, Math.max(size.x, size.z));
+  const widthScale = dims.targetWidth / modelWidth;
+  const lengthScale = dims.targetLength / modelLength;
+  const fitScale = Math.min(widthScale, lengthScale) * (tableModel?.fitScale ?? 1);
+  model.scale.multiplyScalar(fitScale);
+  model.updateMatrixWorld(true);
+
+  box = new THREE.Box3().setFromObject(model);
+  const center = box.getCenter(new THREE.Vector3());
+  model.position.x -= center.x;
+  model.position.z -= center.z;
+  model.position.y += dims.cushionTopLocal - box.max.y + (tableModel?.verticalOffset ?? 0);
+  model.updateMatrixWorld(true);
+  model.userData = {
+    ...(model.userData || {}),
+    poolRoyaleExternalTable: true,
+    tableModelId: tableModel?.id,
+    fittedToPlayfield: {
+      width: dims.targetWidth,
+      length: dims.targetLength,
+      physics: 'Pool Royale playfield, pockets, cushions, and ball simulation'
+    }
+  };
+}
+
+function mountPoolRoyaleExternalTableModel({
+  table,
+  tableModel,
+  renderer,
+  dims,
+  setGeneratedVisualsVisible
+}) {
+  if (!table || !tableModel?.assetUrl) return null;
+  const externalRoot = new THREE.Group();
+  externalRoot.name = `pool-royale-external-table-${tableModel.id}`;
+  externalRoot.userData = {
+    ...(externalRoot.userData || {}),
+    poolRoyaleExternalTableRoot: true,
+    tableModelId: tableModel.id
+  };
+  table.add(externalRoot);
+  let disposed = false;
+
+  loadPoolRoyaleExternalTableTemplate(tableModel, renderer)
+    .then((template) => {
+      if (disposed || !template) return;
+      const model = clonePoolRoyaleExternalTableTemplate(template);
+      fitPoolRoyaleExternalTableModel(model, tableModel, dims);
+      externalRoot.clear();
+      externalRoot.add(model);
+      setGeneratedVisualsVisible?.(false);
+    })
+    .catch((error) => {
+      console.warn('Pool Royale external table failed to load; keeping native table', {
+        tableModelId: tableModel.id,
+        error
+      });
+      if (!disposed) setGeneratedVisualsVisible?.(true);
+    });
+
+  return {
+    group: externalRoot,
+    dispose: () => {
+      disposed = true;
+      if (externalRoot.parent) externalRoot.parent.remove(externalRoot);
+      externalRoot.traverse((child) => {
+        if (!child?.isMesh) return;
+        child.geometry?.dispose?.();
+        const material = child.material;
+        if (Array.isArray(material)) material.forEach((mat) => mat?.dispose?.());
+        else material?.dispose?.();
+      });
+    }
+  };
+}
   const buildPolyhavenModelUrls = (assetId) => {
     if (!assetId) return [];
     const normalizedId = `${assetId}`.trim();
@@ -13135,6 +13318,34 @@ export function Table3D(
   table.userData.cushionLipClearance = clothPlaneWorld;
   table.userData.clothPlaneLocal = clothPlaneLocal;
   table.userData.finish = finishInfo;
+  table.userData.tableModelId = resolvedTableOptions?.tableModel?.id || 'royal-original';
+
+  const generatedVisualObjects = [];
+  table.traverse((child) => {
+    if (child !== table && (child.isMesh || child.isLine || child.isSprite)) {
+      generatedVisualObjects.push(child);
+    }
+  });
+  const setGeneratedVisualsVisible = (visible) => {
+    generatedVisualObjects.forEach((object) => {
+      object.visible = visible;
+    });
+  };
+  const externalTable =
+    resolvedTableOptions?.tableModel?.kind === 'gltf'
+      ? mountPoolRoyaleExternalTableModel({
+          table,
+          tableModel: resolvedTableOptions.tableModel,
+          renderer,
+          dims: {
+            targetWidth: TABLE.W,
+            targetLength: TABLE.H,
+            cushionTopLocal
+          },
+          setGeneratedVisualsVisible
+        })
+      : null;
+  table.userData.externalTable = externalTable;
   parent.add(table);
 
   const baulkZ = baulkLineZ;
@@ -13580,6 +13791,7 @@ function PoolRoyaleGame({
   variantKey,
   ballSetKey,
   tableSizeKey,
+  tableModelKey,
   playType = 'regular',
   mode = 'ai',
   accountId,
@@ -13707,6 +13919,10 @@ function PoolRoyaleGame({
   const activeTableSize = useMemo(
     () => resolveTableSize(tableSizeKey),
     [tableSizeKey]
+  );
+  const activeTableModel = useMemo(
+    () => resolvePoolRoyaleTableModel(tableModelKey),
+    [tableModelKey]
   );
   const responsiveTableSize = useResponsiveTableSize(activeTableSize);
   const resolvedAccountId = useMemo(
@@ -24415,7 +24631,8 @@ const shotPowerRef = useRef(0);
         tableSizeMeta,
         railMarkerStyleRef.current,
         activeTableBase,
-        rendererRef.current
+        rendererRef.current,
+        { tableModel: activeTableModel }
       );
       const SPOTS = spotPositions(baulkZ);
 
@@ -24469,7 +24686,8 @@ const shotPowerRef = useRef(0);
         tableSizeMeta,
         railMarkerStyleRef.current,
         activeTableBase,
-        rendererRef.current
+        rendererRef.current,
+        { tableModel: activeTableModel }
       );
       secondaryTableRef.current = secondaryTableEntry?.group ?? null;
       secondaryBaseSetterRef.current = secondaryTableEntry?.setBaseVariant ?? null;
@@ -36617,6 +36835,17 @@ export default function PoolRoyale() {
     const requested = params.get('tableSize');
     return resolveTableSize(requested).id;
   }, [location.search]);
+  const tableModelKey = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    const requested = params.get('tableModel');
+    if (requested) return resolvePoolRoyaleTableModel(requested).id;
+    try {
+      return resolvePoolRoyaleTableModel(
+        window.localStorage?.getItem(POOL_ROYALE_TABLE_MODEL_STORAGE_KEY)
+      ).id;
+    } catch {}
+    return resolvePoolRoyaleTableModel().id;
+  }, [location.search]);
   const mode = useMemo(() => {
     const params = new URLSearchParams(location.search);
     const requested = params.get('mode');
@@ -36731,6 +36960,7 @@ export default function PoolRoyale() {
         variantKey={variantKey}
         ballSetKey={ballSetKey}
         tableSizeKey={tableSizeKey}
+        tableModelKey={tableModelKey}
         playType={playType}
         mode={mode}
         accountId={accountId}

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -12,6 +12,11 @@ import {
 import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
 import { resolveTableSize } from '../../config/poolRoyaleTables.js';
+import {
+  POOL_ROYALE_TABLE_MODEL_OPTIONS,
+  POOL_ROYALE_TABLE_MODEL_STORAGE_KEY,
+  resolvePoolRoyaleTableModel
+} from '../../config/poolRoyaleTableModels.js';
 import { socket } from '../../utils/socket.js';
 import { getOnlineUsers } from '../../utils/api.js';
 import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
@@ -32,6 +37,8 @@ import {
 
 const PLAYER_FLAG_STORAGE_KEY = 'poolRoyalePlayerFlag';
 const AI_FLAG_STORAGE_KEY = 'poolRoyaleAiFlag';
+const TABLE_FINISH_STORAGE_KEY = 'poolRoyaleTableFinish';
+const TABLE_BASE_STORAGE_KEY = 'poolRoyaleTableBase';
 
 function resolveTpcAccountNumber(player) {
   if (!player || typeof player !== 'object') return '';
@@ -70,10 +77,22 @@ export default function PoolRoyaleLobby() {
   const [variant, setVariant] = useState('uk');
   const [ukBallSet, setUkBallSet] = useState('uk');
   const [playType, setPlayType] = useState(initialPlayType);
+  const [tableModelId, setTableModelId] = useState(() => {
+    try {
+      const stored = window.localStorage?.getItem(
+        POOL_ROYALE_TABLE_MODEL_STORAGE_KEY
+      );
+      return resolvePoolRoyaleTableModel(stored).id;
+    } catch {}
+    return resolvePoolRoyaleTableModel().id;
+  });
   const [players, setPlayers] = useState(8);
-  const tableSize = resolveTableSize(searchParams.get('tableSize')).id;
+  const selectedTableModel = resolvePoolRoyaleTableModel(tableModelId);
+  const tableSize = resolveTableSize(
+    selectedTableModel?.tableSizeId || searchParams.get('tableSize')
+  ).id;
   const defaultTableSize = resolveTableSize().id;
-  const onlineTableSize = defaultTableSize;
+  const onlineTableSize = tableSize || defaultTableSize;
   const [onlinePlayers, setOnlinePlayers] = useState([]);
   const [matching, setMatching] = useState(false);
   const [spinningPlayer, setSpinningPlayer] = useState('');
@@ -186,6 +205,7 @@ export default function PoolRoyaleLobby() {
     if (variant === 'uk' && ukBallSet === 'american') {
       params.set('ballSet', 'american');
     }
+    params.set('tableModel', selectedTableModel.id);
     params.set('type', playType);
     params.set('mode', 'online');
     params.set('tableId', startedId);
@@ -219,6 +239,25 @@ export default function PoolRoyaleLobby() {
     await cleanupRef.current?.();
     setMatchStatus('');
     setMatchingError('');
+
+    try {
+      window.localStorage?.setItem(
+        POOL_ROYALE_TABLE_MODEL_STORAGE_KEY,
+        selectedTableModel.id
+      );
+      if (selectedTableModel.finishId) {
+        window.localStorage?.setItem(
+          TABLE_FINISH_STORAGE_KEY,
+          selectedTableModel.finishId
+        );
+      }
+      if (selectedTableModel.baseId) {
+        window.localStorage?.setItem(
+          TABLE_BASE_STORAGE_KEY,
+          selectedTableModel.baseId
+        );
+      }
+    } catch {}
 
     if (isOnlineMatch) {
       await runPoolRoyaleOnlineFlow({
@@ -288,6 +327,7 @@ export default function PoolRoyaleLobby() {
       params.set('ballSet', 'american');
     }
     params.set('tableSize', tableSize);
+    params.set('tableModel', selectedTableModel.id);
     params.set(
       'type',
       effectivePlayType === 'friendly' ? 'regular' : effectivePlayType
@@ -584,6 +624,49 @@ export default function PoolRoyaleLobby() {
           </div>
           <p className="mt-3 text-xs text-white/60">
             Your lobby choices persist into the match intro.
+          </p>
+        </div>
+
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold text-white">Pool Table</h3>
+            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">
+              GLB Arena
+            </span>
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            {POOL_ROYALE_TABLE_MODEL_OPTIONS.map((option) => {
+              const active = tableModelId === option.id;
+              return (
+                <button
+                  key={option.id}
+                  type="button"
+                  onClick={() => setTableModelId(option.id)}
+                  className={`lobby-option-card ${
+                    active
+                      ? 'lobby-option-card-active'
+                      : 'lobby-option-card-inactive'
+                  }`}
+                >
+                  <div className="lobby-option-thumb bg-gradient-to-br from-fuchsia-400/20 via-amber-500/10 to-transparent">
+                    <div className="lobby-option-thumb-inner text-2xl">
+                      {option.icon || '🎱'}
+                    </div>
+                  </div>
+                  <div className="text-center">
+                    <p className="lobby-option-label">{option.label}</p>
+                    <p className="lobby-option-subtitle">
+                      {option.kind === 'gltf'
+                        ? `${option.tableSizeId} · original textures`
+                        : 'Current table'}
+                    </p>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+          <p className="text-xs text-white/60">
+            New GLB tables replace the in-game table visually while Pool Royale keeps the matched playfield, pockets, cushions, and ball physics.
           </p>
         </div>
 


### PR DESCRIPTION
### Motivation
- Allow players to replace the native Pool Royale table visuals with external GLB table models while preserving the existing playfield, pockets, cushions, and physics.
- Provide a small curated set of table model options and persist the player's choice across sessions.
- Ensure external models are loaded, cached, fitted to the Pool Royale playfield, and safely disposed to avoid memory leaks.

### Description
- Added `webapp/src/config/poolRoyaleTableModels.js` which declares `POOL_ROYALE_TABLE_MODEL_OPTIONS`, a resolver `resolvePoolRoyaleTableModel`, and a storage key constant for persisting the selected model.
- Extended `PoolRoyale.jsx` to support loading and mounting external GLTF/GLB table models with caching, material/texture preparation, fitting logic (`fitPoolRoyaleExternalTableModel`), and safe disposal; integrated the external model into `Table3D` and added `tableModelId` metadata.
- Plumbed the selected table model through the UI and routing by adding a `tableModelKey` prop to `PoolRoyaleGame`, reading/storing the selection from `localStorage`, and passing the choice into the game URL and `Table3D` call.
- Updated `PoolRoyaleLobby.jsx` to render a table picker UI, persist selected model and related default finish/base IDs to `localStorage` on start, and include the `tableModel` parameter when navigating to a match.

### Testing
- Ran a local webapp build (`yarn build`) to confirm the app compiles with the new modules and references and the build succeeded.
- Ran the webapp test suite (`yarn test`) and existing automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa3313a6b48329b1601d5a7248869c)