### PR TITLE
Add selectable external GLB table models to Pool Royale

### DIFF
--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -1,0 +1,54 @@
+export const POOL_ROYALE_TABLE_MODEL_STORAGE_KEY = 'poolRoyaleTableModel';
+
+const POOLTOOL_RAW_BASE =
+  'https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table';
+
+export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
+  {
+    id: 'classic',
+    label: 'Classic Royal',
+    description: 'Current Pool Royale table with built-in finish and base options.',
+    tableSizeId: '9ft',
+    isBuiltIn: true,
+    accent: 'from-emerald-400/30 via-sky-500/10 to-transparent',
+    fallbackIcon: '🎱'
+  },
+  {
+    id: 'seven-foot-showood',
+    label: '7 Foot ShoWood',
+    description: 'Pooltool seven-foot GLB table with original mapped textures.',
+    tableSizeId: '7ft',
+    gltfUrl: `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood.glb`,
+    accent: 'from-amber-400/30 via-orange-500/10 to-transparent',
+    fallbackIcon: '🪵'
+  },
+  {
+    id: 'seven-foot-showood-pbr',
+    label: '7 Foot PBR',
+    description: 'Pooltool seven-foot PBR GLB table using its original texture channels.',
+    tableSizeId: '7ft',
+    gltfUrl: `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood_pbr.glb`,
+    accent: 'from-yellow-300/30 via-stone-500/10 to-transparent',
+    fallbackIcon: '✨'
+  },
+  {
+    id: 'snooker-generic',
+    label: 'Snooker Generic',
+    description: 'Pooltool snooker table GLB fitted to Pool Royale gameplay physics.',
+    tableSizeId: '9ft',
+    gltfUrl: `${POOLTOOL_RAW_BASE}/snooker_generic/snooker_generic.glb`,
+    accent: 'from-lime-400/25 via-emerald-600/10 to-transparent',
+    fallbackIcon: '🟩'
+  }
+]);
+
+export const DEFAULT_POOL_ROYALE_TABLE_MODEL_ID =
+  POOL_ROYALE_TABLE_MODEL_OPTIONS[0].id;
+
+export function resolvePoolRoyaleTableModel(modelId) {
+  const key = typeof modelId === 'string' ? modelId.trim() : '';
+  return (
+    POOL_ROYALE_TABLE_MODEL_OPTIONS.find((option) => option.id === key) ||
+    POOL_ROYALE_TABLE_MODEL_OPTIONS[0]
+  );
+}

--- a/webapp/src/config/poolRoyaleTables.js
+++ b/webapp/src/config/poolRoyaleTables.js
@@ -4,6 +4,24 @@ const BASE_TABLE_COMPACT_SCALE = 1.44;
 const BASE_PLAYFIELD_WIDTH_MM = 2540; // WPA 9 ft playing surface width (100")
 
 const TABLE_PHYSICAL_SPECS = Object.freeze({
+  '7ft': {
+    id: '7ft',
+    label: '7 ft',
+    playfield: Object.freeze({ widthMm: 1981, heightMm: 991 }), // 78" × 39"
+    ballDiameterMm: 57.15,
+    pocketMouthMm: Object.freeze({
+      corner: 139.7,
+      side: 146.05
+    }),
+    cushionCutAngleDeg: 32,
+    sideCushionCutAngleDeg: 32,
+    cushionPocketAnglesDeg: Object.freeze({ corner: 142, side: 104 }),
+    scaleOverrides: Object.freeze({
+      scale: 1.28,
+      mobileScale: 1.38,
+      compactScale: 1.22
+    })
+  },
   '9ft': {
     id: '9ft',
     label: '9 ft (Tournament)',

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -33,6 +33,11 @@ import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
 import { PoolRoyaleRules } from '../../../../src/rules/PoolRoyaleRules.ts';
 import { useAimCalibration } from '../../hooks/useAimCalibration.js';
 import { resolveTableSize } from '../../config/poolRoyaleTables.js';
+import {
+  DEFAULT_POOL_ROYALE_TABLE_MODEL_ID,
+  POOL_ROYALE_TABLE_MODEL_STORAGE_KEY,
+  resolvePoolRoyaleTableModel
+} from '../../config/poolRoyaleTableModels.js';
 import { resolveTableSize as resolveSnookerTableSize } from '../../config/snookerClubTables.js';
 import { isGameMuted, getGameVolume } from '../../utils/sound.js';
 import { chatBeep } from '../../assets/soundData.js';
@@ -13119,6 +13124,142 @@ export function Table3D(
     }
   }
 
+  const attachExternalTableModel = () => {
+    const tableModel = resolvedTableOptions?.tableModel;
+    if (!tableModel?.gltfUrl) return;
+
+    const proceduralVisuals = [];
+    table.traverse((child) => {
+      if (child?.isMesh || child?.isLine || child?.isSprite) {
+        proceduralVisuals.push(child);
+      }
+    });
+
+    const modelRoot = new THREE.Group();
+    modelRoot.name = `pooltool-table-${tableModel.id}`;
+    modelRoot.visible = false;
+    modelRoot.userData = {
+      ...(modelRoot.userData || {}),
+      externalPoolTableModel: tableModel.id
+    };
+    table.add(modelRoot);
+
+    const fixTexture = (texture, isColor = false) => {
+      if (!texture) return;
+      if (isColor) texture.colorSpace = THREE.SRGBColorSpace;
+      texture.flipY = false;
+      texture.generateMipmaps = true;
+      texture.minFilter = THREE.LinearMipmapLinearFilter;
+      texture.magFilter = THREE.LinearFilter;
+      texture.anisotropy = resolveTextureAnisotropy(16);
+      texture.needsUpdate = true;
+    };
+
+    const prepareOriginalMaterial = (material) => {
+      if (!material) return material;
+      const prepared = material.clone ? material.clone() : material;
+      fixTexture(prepared.map, true);
+      fixTexture(prepared.emissiveMap, true);
+      fixTexture(prepared.aoMap);
+      fixTexture(prepared.normalMap);
+      fixTexture(prepared.roughnessMap);
+      fixTexture(prepared.metalnessMap);
+      prepared.depthTest = true;
+      prepared.depthWrite = prepared.transparent ? prepared.depthWrite : true;
+      prepared.needsUpdate = true;
+      return prepared;
+    };
+
+    const prepareOriginalTextureModel = (model) => {
+      model.traverse((child) => {
+        if (!child?.isMesh) return;
+        child.castShadow = true;
+        child.receiveShadow = true;
+        child.frustumCulled = false;
+        if (Array.isArray(child.material)) {
+          child.material = child.material.map(prepareOriginalMaterial);
+        } else {
+          child.material = prepareOriginalMaterial(child.material);
+        }
+      });
+    };
+
+    const fitModelToTablePhysics = (model) => {
+      model.position.set(0, 0, 0);
+      model.rotation.set(0, 0, 0);
+      model.scale.setScalar(1);
+      model.updateMatrixWorld(true);
+
+      let bounds = new THREE.Box3().setFromObject(model);
+      let size = bounds.getSize(new THREE.Vector3());
+      if (size.x > size.z) {
+        model.rotation.y = Math.PI / 2;
+        model.updateMatrixWorld(true);
+        bounds = new THREE.Box3().setFromObject(model);
+        size = bounds.getSize(new THREE.Vector3());
+      }
+
+      const targetWidth = Math.max(MICRO_EPS, frameOuterX * 2);
+      const targetDepth = Math.max(MICRO_EPS, frameOuterZ * 2);
+      const scaleX = size.x > MICRO_EPS ? targetWidth / size.x : 1;
+      const scaleZ = size.z > MICRO_EPS ? targetDepth / size.z : 1;
+      const scaleY = Math.max(MICRO_EPS, Math.min(scaleX, scaleZ));
+      model.scale.set(scaleX, scaleY, scaleZ);
+      model.updateMatrixWorld(true);
+
+      const fittedBounds = new THREE.Box3().setFromObject(model);
+      const fittedCenter = fittedBounds.getCenter(new THREE.Vector3());
+      const targetTopY = railsTopY + TABLE.THICK * 0.02;
+      model.position.add(
+        new THREE.Vector3(
+          -fittedCenter.x,
+          targetTopY - fittedBounds.max.y,
+          -fittedCenter.z
+        )
+      );
+      model.updateMatrixWorld(true);
+    };
+
+    const loader = createConfiguredGLTFLoader(renderer);
+    loader.load(
+      tableModel.gltfUrl,
+      (gltf) => {
+        const model = gltf?.scene || gltf?.scenes?.[0];
+        if (!model) {
+          table.remove(modelRoot);
+          console.warn('Pool Royale external table model missing scene', {
+            tableModel: tableModel.id,
+            url: tableModel.gltfUrl
+          });
+          return;
+        }
+        prepareOriginalTextureModel(model);
+        fitModelToTablePhysics(model);
+        proceduralVisuals.forEach((object) => {
+          object.visible = false;
+        });
+        modelRoot.add(model);
+        modelRoot.visible = true;
+        table.userData.externalTableModel = {
+          id: tableModel.id,
+          source: tableModel.gltfUrl,
+          physicsTableSize: tableSizeMeta?.id || null
+        };
+      },
+      undefined,
+      (error) => {
+        table.remove(modelRoot);
+        console.warn('Pool Royale external table model failed to load', {
+          tableModel: tableModel.id,
+          url: tableModel.gltfUrl,
+          error
+        });
+      }
+    );
+  };
+
+  attachExternalTableModel();
+
   pocketMeshes.forEach((mesh) => {
     const lift = mesh?.userData?.verticalLift || 0;
     mesh.position.y = pocketTopY - TABLE.THICK / 2 + lift;
@@ -13580,6 +13721,7 @@ function PoolRoyaleGame({
   variantKey,
   ballSetKey,
   tableSizeKey,
+  tableModelKey = DEFAULT_POOL_ROYALE_TABLE_MODEL_ID,
   playType = 'regular',
   mode = 'ai',
   accountId,
@@ -13707,6 +13849,10 @@ function PoolRoyaleGame({
   const activeTableSize = useMemo(
     () => resolveTableSize(tableSizeKey),
     [tableSizeKey]
+  );
+  const activeTableModel = useMemo(
+    () => resolvePoolRoyaleTableModel(tableModelKey),
+    [tableModelKey]
   );
   const responsiveTableSize = useResponsiveTableSize(activeTableSize);
   const resolvedAccountId = useMemo(
@@ -15511,6 +15657,10 @@ function PoolRoyaleGame({
   useEffect(() => {
     tableSizeRef.current = responsiveTableSize;
   }, [responsiveTableSize]);
+  const tableModelRef = useRef(activeTableModel);
+  useEffect(() => {
+    tableModelRef.current = activeTableModel;
+  }, [activeTableModel]);
   const applyWorldScaleRef = useRef(() => {});
   useEffect(() => {
     applyWorldScaleRef.current?.();
@@ -24415,7 +24565,8 @@ const shotPowerRef = useRef(0);
         tableSizeMeta,
         railMarkerStyleRef.current,
         activeTableBase,
-        rendererRef.current
+        rendererRef.current,
+        { tableModel: tableModelRef.current }
       );
       const SPOTS = spotPositions(baulkZ);
 
@@ -24469,7 +24620,8 @@ const shotPowerRef = useRef(0);
         tableSizeMeta,
         railMarkerStyleRef.current,
         activeTableBase,
-        rendererRef.current
+        rendererRef.current,
+        { tableModel: tableModelRef.current }
       );
       secondaryTableRef.current = secondaryTableEntry?.group ?? null;
       secondaryBaseSetterRef.current = secondaryTableEntry?.setBaseVariant ?? null;
@@ -36612,11 +36764,25 @@ export default function PoolRoyale() {
     const normalized = normalizeBallSetKey(requested);
     return normalized || null;
   }, [location.search]);
+  const tableModelKey = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    const requested = params.get('tableModel');
+    if (requested) {
+      return resolvePoolRoyaleTableModel(requested).id;
+    }
+    try {
+      return resolvePoolRoyaleTableModel(
+        window.localStorage?.getItem(POOL_ROYALE_TABLE_MODEL_STORAGE_KEY)
+      ).id;
+    } catch {}
+    return DEFAULT_POOL_ROYALE_TABLE_MODEL_ID;
+  }, [location.search]);
   const tableSizeKey = useMemo(() => {
     const params = new URLSearchParams(location.search);
     const requested = params.get('tableSize');
-    return resolveTableSize(requested).id;
-  }, [location.search]);
+    const selectedTableModel = resolvePoolRoyaleTableModel(tableModelKey);
+    return resolveTableSize(requested || selectedTableModel.tableSizeId).id;
+  }, [location.search, tableModelKey]);
   const mode = useMemo(() => {
     const params = new URLSearchParams(location.search);
     const requested = params.get('mode');
@@ -36731,6 +36897,7 @@ export default function PoolRoyale() {
         variantKey={variantKey}
         ballSetKey={ballSetKey}
         tableSizeKey={tableSizeKey}
+        tableModelKey={tableModelKey}
         playType={playType}
         mode={mode}
         accountId={accountId}

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -12,6 +12,12 @@ import {
 import { getAccountBalance, addTransaction } from '../../utils/api.js';
 import { loadAvatar } from '../../utils/avatarUtils.js';
 import { resolveTableSize } from '../../config/poolRoyaleTables.js';
+import {
+  DEFAULT_POOL_ROYALE_TABLE_MODEL_ID,
+  POOL_ROYALE_TABLE_MODEL_OPTIONS,
+  POOL_ROYALE_TABLE_MODEL_STORAGE_KEY,
+  resolvePoolRoyaleTableModel
+} from '../../config/poolRoyaleTableModels.js';
 import { socket } from '../../utils/socket.js';
 import { getOnlineUsers } from '../../utils/api.js';
 import { FLAG_EMOJIS } from '../../utils/flagEmojis.js';
@@ -70,10 +76,22 @@ export default function PoolRoyaleLobby() {
   const [variant, setVariant] = useState('uk');
   const [ukBallSet, setUkBallSet] = useState('uk');
   const [playType, setPlayType] = useState(initialPlayType);
+  const [tableModelId, setTableModelId] = useState(() => {
+    try {
+      const stored = window.localStorage?.getItem(
+        POOL_ROYALE_TABLE_MODEL_STORAGE_KEY
+      );
+      return resolvePoolRoyaleTableModel(stored).id;
+    } catch {}
+    return DEFAULT_POOL_ROYALE_TABLE_MODEL_ID;
+  });
   const [players, setPlayers] = useState(8);
-  const tableSize = resolveTableSize(searchParams.get('tableSize')).id;
+  const selectedTableModel = resolvePoolRoyaleTableModel(tableModelId);
+  const tableSize = resolveTableSize(
+    selectedTableModel?.tableSizeId || searchParams.get('tableSize')
+  ).id;
   const defaultTableSize = resolveTableSize().id;
-  const onlineTableSize = defaultTableSize;
+  const onlineTableSize = tableSize || defaultTableSize;
   const [onlinePlayers, setOnlinePlayers] = useState([]);
   const [matching, setMatching] = useState(false);
   const [spinningPlayer, setSpinningPlayer] = useState('');
@@ -198,6 +216,7 @@ export default function PoolRoyaleLobby() {
     if (resolvedAccountId) params.set('accountId', resolvedAccountId);
     const resolvedMatchTableSize = resolveTableSize(matchMeta?.tableSize).id;
     params.set('tableSize', resolvedMatchTableSize || onlineTableSize);
+    params.set('tableModel', selectedTableModel.id);
     params.set('seat', seat);
     params.set('starter', starterSeat);
     const name = (friendlyName || '').trim();
@@ -220,6 +239,13 @@ export default function PoolRoyaleLobby() {
     setMatchStatus('');
     setMatchingError('');
 
+    try {
+      window.localStorage?.setItem(
+        POOL_ROYALE_TABLE_MODEL_STORAGE_KEY,
+        selectedTableModel.id
+      );
+    } catch {}
+
     if (isOnlineMatch) {
       await runPoolRoyaleOnlineFlow({
         stake,
@@ -229,6 +255,7 @@ export default function PoolRoyaleLobby() {
         playType,
         mode,
         tableSize: onlineTableSize,
+        tableModel: selectedTableModel.id,
         avatar,
         deps: {
           ensureAccountId,
@@ -288,6 +315,7 @@ export default function PoolRoyaleLobby() {
       params.set('ballSet', 'american');
     }
     params.set('tableSize', tableSize);
+    params.set('tableModel', selectedTableModel.id);
     params.set(
       'type',
       effectivePlayType === 'friendly' ? 'regular' : effectivePlayType
@@ -584,6 +612,53 @@ export default function PoolRoyaleLobby() {
           </div>
           <p className="mt-3 text-xs text-white/60">
             Your lobby choices persist into the match intro.
+          </p>
+        </div>
+
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold text-white">Choose Table</h3>
+            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">
+              Physics + GLB
+            </span>
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            {POOL_ROYALE_TABLE_MODEL_OPTIONS.map((option) => {
+              const active = tableModelId === option.id;
+              return (
+                <button
+                  key={option.id}
+                  type="button"
+                  onClick={() => setTableModelId(option.id)}
+                  className={`lobby-option-card ${
+                    active
+                      ? 'lobby-option-card-active'
+                      : 'lobby-option-card-inactive'
+                  }`}
+                >
+                  <div
+                    className={`lobby-option-thumb bg-gradient-to-br ${
+                      option.accent ||
+                      'from-fuchsia-400/20 via-amber-500/10 to-transparent'
+                    }`}
+                  >
+                    <div className="lobby-option-thumb-inner text-2xl">
+                      {option.fallbackIcon || '🟩'}
+                    </div>
+                  </div>
+                  <div className="text-center">
+                    <p className="lobby-option-label">{option.label}</p>
+                    <p className="lobby-option-subtitle">
+                      {option.tableSizeId || '9ft'} table
+                    </p>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+          <p className="text-xs text-white/60">
+            GLB tables replace the in-game table visually while Pool Royale maps
+            pockets, rails, and ball physics to the selected table size.
           </p>
         </div>
 

--- a/webapp/src/pages/Games/poolRoyaleOnlineFlow.js
+++ b/webapp/src/pages/Games/poolRoyaleOnlineFlow.js
@@ -176,6 +176,7 @@ export async function runPoolRoyaleOnlineFlow({
   playType,
   mode,
   tableSize,
+  tableModel,
   avatar,
   deps = {},
   state,
@@ -221,6 +222,8 @@ export async function runPoolRoyaleOnlineFlow({
       : undefined;
   const normalizedTableSize =
     typeof tableSize === 'string' && tableSize.trim() ? tableSize.trim() : undefined;
+  const normalizedTableModel =
+    typeof tableModel === 'string' && tableModel.trim() ? tableModel.trim() : undefined;
 
   const telegramId = getTelegramIdFn?.();
 
@@ -445,6 +448,7 @@ export async function runPoolRoyaleOnlineFlow({
         variant,
         ballSet,
         tableSize: normalizedTableSize,
+        tableModel: normalizedTableModel,
         playType,
         playerName: getTelegramFirstNameFn?.() || `TPC ${accountId}` || 'Player',
         avatar


### PR DESCRIPTION
### Motivation
- Provide a way to visually replace the in-game Pool Royale table with external GLB models while keeping Pool Royale physics mapped to the selected table size.
- Support different table sizes (including a 7 ft physical spec) and ship a few Pooltool-sourced table model options for players to choose.

### Description
- Add `webapp/src/config/poolRoyaleTableModels.js` exporting `POOL_ROYALE_TABLE_MODEL_OPTIONS`, `DEFAULT_POOL_ROYALE_TABLE_MODEL_ID`, `POOL_ROYALE_TABLE_MODEL_STORAGE_KEY`, and `resolvePoolRoyaleTableModel` for model selection and persistence.
- Extend `webapp/src/config/poolRoyaleTables.js` to include a `'7ft'` entry in `TABLE_PHYSICAL_SPECS` so models mapped to 7 ft tables have proper physics specs.
- Implement external model loading and integration in `PoolRoyale.jsx` by adding `attachExternalTableModel`, preparing textures/materials, fitting the GLB to the table physics, and wiring `tableModel` through `Table3D` and scene setup; also add state handling for `activeTableModel` and localStorage handling for selection.
- Add a table chooser UI to `PoolRoyaleLobby.jsx`, persist the selection to `localStorage`, include `tableModel` in navigation params, and use the selected model when starting online matches.
- Thread the selected `tableModel` through the online flow by accepting `tableModel` in `runPoolRoyaleOnlineFlow` and forwarding it in the `seatTable` payload to the matchmaking socket.

### Testing
- No automated tests were added or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa3313a6b48329b1601d5a7248869c)