### PR TITLE
Add stadium spectators, audio, keeper/ball physics refinements, and camera controls to FreeKickArena

### DIFF
--- a/webapp/src/pages/Games/FreeKickArena.tsx
+++ b/webapp/src/pages/Games/FreeKickArena.tsx
@@ -3,6 +3,8 @@
 import React, { useEffect, useRef, useState } from "react";
 import * as THREE from "three";
 import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js";
+import { clone as cloneSkeleton } from "three/examples/jsm/utils/SkeletonUtils.js";
+import { MURLAN_CHARACTER_THEMES } from "../../config/murlanCharacterThemes.js";
 
 type AnimName = "Idle" | "Walk" | "Run";
 type ShotState = "aim" | "runup" | "flight" | "var" | "replay" | "result";
@@ -42,8 +44,34 @@ type Actor = {
   diveDelay: number;
   diveDir: number;
   diveHeight: number;
+  saveTargetX: number;
+  saveTargetY: number;
+  celebrateTime: number;
   wallIndex: number;
   loaded: boolean;
+};
+
+type SpectatorBones = {
+  hips?: THREE.Bone;
+  spine?: THREE.Bone;
+  head?: THREE.Bone;
+  leftUpperArm?: THREE.Bone;
+  leftForeArm?: THREE.Bone;
+  rightUpperArm?: THREE.Bone;
+  rightForeArm?: THREE.Bone;
+  leftThigh?: THREE.Bone;
+  leftCalf?: THREE.Bone;
+  rightThigh?: THREE.Bone;
+  rightCalf?: THREE.Bone;
+};
+
+type StadiumSpectator = {
+  root: THREE.Group;
+  model: THREE.Object3D;
+  bones: SpectatorBones;
+  seatedPose: Partial<Record<keyof SpectatorBones, THREE.Euler>>;
+  celebrateTime: number;
+  waveSeed: number;
 };
 
 type BallState = {
@@ -62,6 +90,8 @@ type BallState = {
   netCaught: boolean;
   netAge: number;
   netVel: THREE.Vector3;
+  crossedGoalLine: boolean;
+  hitFrame: boolean;
 };
 
 type SwipeState = {
@@ -90,6 +120,16 @@ type ReplayFrame = {
 };
 
 const HUMAN_URL = "https://threejs.org/examples/models/gltf/Soldier.glb";
+const MURLAN_CHARACTER_COLORS = [0x1d69ff, 0xdc2626, 0x16a34a, 0xfacc15, 0x7c3aed, 0xf97316, 0x0891b2];
+const MAX_STADIUM_SPECTATORS = MURLAN_CHARACTER_THEMES.length;
+const GOAL_RUSH_SOUNDS = {
+  crowd: "/assets/sounds/football-crowd-3-69245.mp3",
+  whistle: "/assets/sounds/metal-whistle-6121.mp3",
+  kick: "/assets/sounds/football-game-sound-effects-359284.mp3",
+  net: "/assets/sounds/a-football-hits-the-net-goal-313216.mp3",
+  post: "/assets/sounds/frying-pan-over-the-head-89303.mp3",
+  victory: "/assets/sounds/11l-victory_sound_with_t-1749487412779-357604.mp3",
+};
 
 const FIELD_W = 22.0;
 const HALF_H = 36.0;
@@ -112,6 +152,64 @@ const GOAL_LINE_Z = -HALF_H / 2;
 const RUNUP_BACK_STEPS = 2.2;
 const TMP = new THREE.Vector3();
 const QTMP = new THREE.Quaternion();
+
+
+function shuffledCharacterColors() {
+  const count = Math.max(7, MURLAN_CHARACTER_THEMES.length || 0);
+  const colors = Array.from({ length: count }, (_, index) => MURLAN_CHARACTER_COLORS[index % MURLAN_CHARACTER_COLORS.length]);
+  for (let i = colors.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [colors[i], colors[j]] = [colors[j], colors[i]];
+  }
+  return colors;
+}
+
+function makeGoalRushAudio() {
+  let enabled = true;
+  let started = false;
+  let pendingWhistle = true;
+  const crowd = new Audio(GOAL_RUSH_SOUNDS.crowd);
+  crowd.loop = true;
+  crowd.volume = 0.5;
+
+  const playOneShot = (src: string, volume = 1) => {
+    if (!enabled || !started) return;
+    const sound = new Audio(src);
+    sound.volume = volume;
+    sound.play().catch(() => {});
+  };
+
+  const start = () => {
+    if (!enabled || started) return;
+    started = true;
+    crowd.play().catch(() => {});
+    if (pendingWhistle) {
+      pendingWhistle = false;
+      playOneShot(GOAL_RUSH_SOUNDS.whistle, 0.9);
+    }
+  };
+
+  return {
+    start,
+    whistle() {
+      if (!enabled) return;
+      if (!started) {
+        pendingWhistle = true;
+        return;
+      }
+      playOneShot(GOAL_RUSH_SOUNDS.whistle, 0.9);
+    },
+    kick() { playOneShot(GOAL_RUSH_SOUNDS.kick, 0.92); },
+    net() { playOneShot(GOAL_RUSH_SOUNDS.net, 0.95); },
+    save() { playOneShot(GOAL_RUSH_SOUNDS.post, 0.7); },
+    goal() { playOneShot(GOAL_RUSH_SOUNDS.victory, 0.72); },
+    dispose() {
+      enabled = false;
+      crowd.pause();
+      crowd.src = "";
+    },
+  };
+}
 
 function material(color: number, roughness = 0.72, metalness = 0.03) {
   return new THREE.MeshStandardMaterial({ color, roughness, metalness });
@@ -153,6 +251,73 @@ function findBones(model: THREE.Object3D): Bones {
   return bones;
 }
 
+function findBoneByHints(root: THREE.Object3D, hints: string[]) {
+  let matched: THREE.Bone | undefined;
+  root.traverse((obj) => {
+    const bone = obj as THREE.Bone;
+    if (matched || !bone.isBone) return;
+    const name = cleanName(bone.name);
+    if (hints.some((hint) => name.includes(cleanName(hint)))) matched = bone;
+  });
+  return matched;
+}
+
+function captureRotation(bone?: THREE.Bone) {
+  return bone ? bone.rotation.clone() : new THREE.Euler();
+}
+
+function addRotation(bone: THREE.Bone | undefined, x = 0, y = 0, z = 0) {
+  if (!bone) return;
+  bone.rotation.x += x;
+  bone.rotation.y += y;
+  bone.rotation.z += z;
+}
+
+function findSpectatorBones(model: THREE.Object3D): SpectatorBones {
+  return {
+    hips: findBoneByHints(model, ["hips", "pelvis", "pelvisjoint", "hip_joint"]),
+    spine: findBoneByHints(model, ["spine", "chest", "torso"]),
+    head: findBoneByHints(model, ["head", "neck", "headjoint", "head_joint"]),
+    leftUpperArm: findBoneByHints(model, ["leftarm", "arm.l", "l_upperarm", "leftshoulder", "armjointl", "arm_joint_l_1", "shoulderl"]),
+    leftForeArm: findBoneByHints(model, ["leftforearm", "l_forearm", "leftlowerarm", "forearml", "elbowl", "arm_joint_l_2"]),
+    rightUpperArm: findBoneByHints(model, ["rightarm", "arm.r", "r_upperarm", "rightshoulder", "armjointr", "arm_joint_r_1", "shoulderr"]),
+    rightForeArm: findBoneByHints(model, ["rightforearm", "r_forearm", "rightlowerarm", "forearmr", "elbowr", "arm_joint_r_2"]),
+    leftThigh: findBoneByHints(model, ["leftupleg", "leftthigh", "l_thigh", "legjointl1", "leg_joint_l_1"]),
+    leftCalf: findBoneByHints(model, ["leftleg", "leftcalf", "l_calf", "legjointl2", "leg_joint_l_2"]),
+    rightThigh: findBoneByHints(model, ["rightupleg", "rightthigh", "r_thigh", "legjointr1", "leg_joint_r_1"]),
+    rightCalf: findBoneByHints(model, ["rightleg", "rightcalf", "r_calf", "legjointr2", "leg_joint_r_2"]),
+  };
+}
+
+function applyMurlanSeatedPose(model: THREE.Object3D) {
+  const bones = findSpectatorBones(model);
+  model.position.y -= 0.09;
+  addRotation(bones.hips, THREE.MathUtils.degToRad(-9), 0, 0);
+  addRotation(bones.spine, THREE.MathUtils.degToRad(-3), 0, 0);
+  addRotation(bones.head, THREE.MathUtils.degToRad(2), 0, 0);
+  addRotation(bones.leftUpperArm, THREE.MathUtils.degToRad(-53), THREE.MathUtils.degToRad(-6), THREE.MathUtils.degToRad(-2));
+  addRotation(bones.leftForeArm, THREE.MathUtils.degToRad(40), THREE.MathUtils.degToRad(-3), THREE.MathUtils.degToRad(-2));
+  addRotation(bones.rightUpperArm, THREE.MathUtils.degToRad(-57), THREE.MathUtils.degToRad(6), THREE.MathUtils.degToRad(2));
+  addRotation(bones.rightForeArm, THREE.MathUtils.degToRad(44), THREE.MathUtils.degToRad(3), THREE.MathUtils.degToRad(2));
+  addRotation(bones.leftThigh, THREE.MathUtils.degToRad(-90.5), THREE.MathUtils.degToRad(9.2), THREE.MathUtils.degToRad(2.9));
+  addRotation(bones.rightThigh, THREE.MathUtils.degToRad(-90.5), THREE.MathUtils.degToRad(1.7), THREE.MathUtils.degToRad(-1.1));
+  addRotation(bones.leftCalf, THREE.MathUtils.degToRad(-95.1), THREE.MathUtils.degToRad(1.1), THREE.MathUtils.degToRad(0.6));
+  addRotation(bones.rightCalf, THREE.MathUtils.degToRad(-95.1), THREE.MathUtils.degToRad(-1.1), THREE.MathUtils.degToRad(-0.6));
+  const seatedPose: StadiumSpectator["seatedPose"] = {};
+  Object.entries(bones).forEach(([key, bone]) => {
+    seatedPose[key as keyof SpectatorBones] = captureRotation(bone);
+  });
+  return { bones, seatedPose };
+}
+
+function restoreSpectatorSeatedPose(spectator: StadiumSpectator) {
+  Object.entries(spectator.bones).forEach(([key, bone]) => {
+    const target = spectator.seatedPose[key as keyof SpectatorBones];
+    if (!bone || !target) return;
+    bone.rotation.copy(target);
+  });
+}
+
 function normalizeHuman(model: THREE.Object3D, height = PLAYER_H) {
   model.rotation.y = Math.PI;
   model.scale.setScalar(1);
@@ -168,8 +333,8 @@ function normalizeHuman(model: THREE.Object3D, height = PLAYER_H) {
   model.position.y -= box2.min.y;
 }
 
-function tintModel(model: THREE.Object3D, kind: ActorKind, index = 0) {
-  const color = kind === "kicker" ? new THREE.Color(0x1d69ff) : kind === "keeper" ? new THREE.Color(0x111111) : new THREE.Color(0xfacc15);
+function tintModel(model: THREE.Object3D, kind: ActorKind, index = 0, kitColor?: number) {
+  const color = kind === "keeper" ? new THREE.Color(0x111111) : new THREE.Color(kitColor ?? (kind === "kicker" ? 0x1d69ff : 0xfacc15));
   model.traverse((obj) => {
     const mesh = obj as THREE.Mesh;
     if (!mesh.isMesh) return;
@@ -185,9 +350,9 @@ function tintModel(model: THREE.Object3D, kind: ActorKind, index = 0) {
   });
 }
 
-function makeFallback(kind: ActorKind, index = 0) {
+function makeFallback(kind: ActorKind, index = 0, kitColor?: number) {
   const group = new THREE.Group();
-  const kit = kind === "kicker" ? 0x1d69ff : kind === "keeper" ? 0x111111 : 0xfacc15;
+  const kit = kind === "keeper" ? 0x111111 : kitColor ?? (kind === "kicker" ? 0x1d69ff : 0xfacc15);
   const torso = new THREE.Mesh(new THREE.CapsuleGeometry(0.19, 0.72, 8, 14), material(kit));
   torso.position.y = 1.05;
   const stripe = new THREE.Mesh(new THREE.BoxGeometry(0.28, 0.06, 0.02), material(kind === "wall" ? 0x174ea6 : 0xffffff));
@@ -202,12 +367,12 @@ function makeFallback(kind: ActorKind, index = 0) {
   return group;
 }
 
-function createActor(scene: THREE.Scene, loader: GLTFLoader, kind: ActorKind, pos: THREE.Vector3, index = 0): Actor {
+function createActor(scene: THREE.Scene, loader: GLTFLoader, kind: ActorKind, pos: THREE.Vector3, index = 0, kitColor?: number): Actor {
   const root = new THREE.Group();
   root.position.copy(pos).setY(GROUND_Y);
   scene.add(root);
 
-  const fallback = makeFallback(kind, index);
+  const fallback = makeFallback(kind, index, kitColor);
   root.add(fallback);
 
   const actor: Actor = {
@@ -229,6 +394,9 @@ function createActor(scene: THREE.Scene, loader: GLTFLoader, kind: ActorKind, po
     diveDelay: 0,
     diveDir: 0,
     diveHeight: 1.15,
+    saveTargetX: 0,
+    saveTargetY: 1.15,
+    celebrateTime: 0,
     wallIndex: index,
     loaded: false,
   };
@@ -236,7 +404,7 @@ function createActor(scene: THREE.Scene, loader: GLTFLoader, kind: ActorKind, po
   loader.setCrossOrigin("anonymous").load(HUMAN_URL, (gltf) => {
     const model = gltf.scene;
     normalizeHuman(model, kind === "keeper" ? 1.9 : PLAYER_H);
-    tintModel(model, kind, index);
+    tintModel(model, kind, index, kitColor);
     shadow(model);
     root.add(model);
     fallback.visible = false;
@@ -288,6 +456,27 @@ function updateActorBase(actor: Actor, dt: number) {
 }
 
 function applyKickerPose(kicker: Actor) {
+  if (kicker.celebrateTime > 0) {
+    const t = performance.now() * 0.008;
+    kicker.root.position.y += Math.abs(Math.sin(t * 1.7)) * 0.18;
+    kicker.root.rotation.y += Math.sin(t * 0.75) * 0.22;
+    if (kicker.bones.hips) kicker.bones.hips.rotation.y += Math.sin(t) * 0.28;
+    if (kicker.bones.spine) {
+      kicker.bones.spine.rotation.x += Math.sin(t * 1.3) * 0.12;
+      kicker.bones.spine.rotation.z += Math.sin(t * 0.9) * 0.22;
+    }
+    if (kicker.bones.leftArm) {
+      kicker.bones.leftArm.rotation.x += -1.35 + Math.sin(t) * 0.28;
+      kicker.bones.leftArm.rotation.z += -0.75 + Math.cos(t * 1.2) * 0.32;
+    }
+    if (kicker.bones.rightArm) {
+      kicker.bones.rightArm.rotation.x += -1.35 + Math.cos(t) * 0.28;
+      kicker.bones.rightArm.rotation.z += 0.75 + Math.sin(t * 1.1) * 0.32;
+    }
+    if (kicker.bones.leftUpLeg) kicker.bones.leftUpLeg.rotation.x += Math.sin(t * 1.6) * 0.35;
+    if (kicker.bones.rightUpLeg) kicker.bones.rightUpLeg.rotation.x += Math.cos(t * 1.6) * 0.35;
+    return;
+  }
   if (kicker.kickTime <= 0) return;
 
   const t = 1 - kicker.kickTime / 0.72;
@@ -404,6 +593,8 @@ function makeBall(scene: THREE.Scene): BallState {
     netCaught: false,
     netAge: 0,
     netVel: new THREE.Vector3(),
+    crossedGoalLine: false,
+    hitFrame: false,
   };
 }
 
@@ -450,34 +641,509 @@ function makeCylinderBetween(a: THREE.Vector3, b: THREE.Vector3, radius: number,
 function makeGoal(scene: THREE.Scene, netRig: NetRig) { const root = new THREE.Group(); root.position.z = GOAL_LINE_Z; const white = material(0xffffff, 0.4, 0.18); const rear = material(0xcbd5e1, 0.46, 0.28); const backScale = 0.82; const backW = GOAL_W * backScale; const backH = GOAL_H * backScale; const FL = new THREE.Vector3(-GOAL_W / 2, 0, 0); const FR = new THREE.Vector3(GOAL_W / 2, 0, 0); const FLT = new THREE.Vector3(-GOAL_W / 2, GOAL_H, 0); const FRT = new THREE.Vector3(GOAL_W / 2, GOAL_H, 0); const BL = new THREE.Vector3(-backW / 2, 0.03, -GOAL_D); const BR = new THREE.Vector3(backW / 2, 0.03, -GOAL_D); const BLT = new THREE.Vector3(-backW / 2, backH, -GOAL_D); const BRT = new THREE.Vector3(backW / 2, backH, -GOAL_D); root.add(makeCylinderBetween(FL, FLT, POST_R, white), makeCylinderBetween(FR, FRT, POST_R, white), makeCylinderBetween(FLT, FRT, POST_R, white), makeCylinderBetween(BL, BLT, POST_R * 0.48, rear), makeCylinderBetween(BR, BRT, POST_R * 0.48, rear), makeCylinderBetween(BLT, BRT, POST_R * 0.48, rear), makeCylinderBetween(FLT, BLT, POST_R * 0.42, rear), makeCylinderBetween(FRT, BRT, POST_R * 0.42, rear), makeCylinderBetween(FL, BL, POST_R * 0.36, rear), makeCylinderBetween(FR, BR, POST_R * 0.36, rear)); root.add(makeNetSurface(netRig, BL, BR, BRT, BLT, 18, 10)); root.add(makeNetSurface(netRig, FLT, FRT, BRT, BLT, 18, 8)); root.add(makeNetSurface(netRig, FL, BL, BLT, FLT, 8, 10)); root.add(makeNetSurface(netRig, FR, BR, BRT, FRT, 8, 10)); scene.add(root); }
 function triggerNetShake(netRig: NetRig, impact: THREE.Vector3) { netRig.shake = 1.35; netRig.impact.copy(impact).sub(new THREE.Vector3(0, 0, GOAL_LINE_Z)); }
 function updateNetShake(netRig: NetRig, dt: number) { if (netRig.shake <= 0) return; const time = performance.now() * 0.02; const strength = netRig.shake; netRig.lines.forEach((line, idx) => { const base = line.userData.base as THREE.Vector3[]; const attr = line.geometry.getAttribute("position") as THREE.BufferAttribute; for (let i = 0; i < 2; i++) { const p = base[i]; const distance = Math.max(0.28, p.distanceTo(netRig.impact)); const falloff = THREE.MathUtils.clamp(1.65 / distance, 0, 1.4); const wave = Math.sin(time + idx * 0.37 + i * 1.7) * 0.24 * strength * falloff; attr.setXYZ(i, p.x + wave * 0.36, p.y + Math.abs(wave) * 0.28, p.z - Math.abs(wave) * 1.45); } attr.needsUpdate = true; }); netRig.shake = Math.max(0, netRig.shake - dt * 1.65); }
-function makeBillboardsAndStands(scene: THREE.Scene) { const boardGroup = new THREE.Group(); const zBoard = GOAL_LINE_Z - GOAL_D - 0.75; const boardColors = [0x2563eb, 0xef4444, 0x16a34a, 0xfacc15, 0x7c3aed, 0x0ea5e9]; for (let i = 0; i < 6; i++) { const x = (i - 2.5) * 3.15; const board = new THREE.Mesh(new THREE.BoxGeometry(2.95, 0.82, 0.08), material(boardColors[i], 0.5, 0.02)); board.position.set(x, 0.55, zBoard); const top = new THREE.Mesh(new THREE.BoxGeometry(2.95, 0.08, 0.1), material(0xffffff, 0.55, 0.02)); top.position.set(x, 1.0, zBoard + 0.01); const textBar = new THREE.Mesh(new THREE.BoxGeometry(1.7, 0.12, 0.105), material(0xffffff, 0.55, 0.02)); textBar.position.set(x, 0.55, zBoard + 0.015); boardGroup.add(shadow(board), shadow(top), shadow(textBar)); } scene.add(boardGroup); }
+function makeChair(color: number) {
+  const chair = new THREE.Group();
+  const plastic = material(color, 0.62, 0.02);
+  const seat = new THREE.Mesh(new THREE.BoxGeometry(0.44, 0.09, 0.43), plastic);
+  seat.position.y = 0.30;
+  const frontLip = new THREE.Mesh(new THREE.BoxGeometry(0.46, 0.05, 0.08), plastic);
+  frontLip.position.set(0, 0.31, 0.25);
+  const back = new THREE.Mesh(new THREE.BoxGeometry(0.46, 0.52, 0.08), plastic);
+  back.position.set(0, 0.58, -0.18);
+  back.rotation.x = THREE.MathUtils.degToRad(-7);
+  const legMat = material(0x334155, 0.45, 0.18);
+  const legs = [
+    [-0.17, 0.14, -0.13], [0.17, 0.14, -0.13], [-0.17, 0.14, 0.15], [0.17, 0.14, 0.15],
+  ].map(([x, y, z]) => {
+    const leg = new THREE.Mesh(new THREE.BoxGeometry(0.04, 0.28, 0.04), legMat);
+    leg.position.set(x, y, z);
+    return leg;
+  });
+  chair.add(shadow(seat), shadow(frontLip), shadow(back), ...legs.map((leg) => shadow(leg)));
+  return chair;
+}
+
+function makeBillboardsAndStands(scene: THREE.Scene) {
+  const boardGroup = new THREE.Group();
+  const zBoard = GOAL_LINE_Z - GOAL_D - 0.75;
+  const boardColors = [0x2563eb, 0xef4444, 0x16a34a, 0xfacc15, 0x7c3aed, 0x0ea5e9];
+  for (let i = 0; i < 6; i++) {
+    const x = (i - 2.5) * 3.15;
+    const board = new THREE.Mesh(new THREE.BoxGeometry(2.95, 0.82, 0.08), material(boardColors[i], 0.5, 0.02));
+    board.position.set(x, 0.55, zBoard);
+    const top = new THREE.Mesh(new THREE.BoxGeometry(2.95, 0.08, 0.1), material(0xffffff, 0.55, 0.02));
+    top.position.set(x, 1.0, zBoard + 0.01);
+    const textBar = new THREE.Mesh(new THREE.BoxGeometry(1.7, 0.12, 0.105), material(0xffffff, 0.55, 0.02));
+    textBar.position.set(x, 0.55, zBoard + 0.015);
+    boardGroup.add(shadow(board), shadow(top), shadow(textBar));
+  }
+  scene.add(boardGroup);
+
+  const stands = new THREE.Group();
+  stands.position.z = GOAL_LINE_Z - GOAL_D - 2.15;
+  const concrete = material(0x7c8798, 0.9, 0.02);
+  const riserMat = material(0x64748b, 0.86, 0.03);
+  const aisleMat = material(0xdbe4ee, 0.76, 0.02);
+  const railMat = material(0xf8fafc, 0.38, 0.2);
+  const rows = 7;
+  const rowDepth = 0.82;
+  const rowRise = 0.34;
+  const width = FIELD_W + 5.2;
+  const seatAnchors: Array<{ position: THREE.Vector3; rotationY: number; themeIndex: number }> = [];
+
+  for (let row = 0; row < rows; row++) {
+    const tread = new THREE.Mesh(new THREE.BoxGeometry(width, 0.15, rowDepth), concrete);
+    tread.position.set(0, 0.20 + row * rowRise, -row * rowDepth);
+    stands.add(shadow(tread));
+
+    const riser = new THREE.Mesh(new THREE.BoxGeometry(width, rowRise, 0.12), riserMat);
+    riser.position.set(0, 0.04 + row * rowRise, -row * rowDepth + rowDepth * 0.45);
+    stands.add(shadow(riser));
+
+    const stepNose = new THREE.Mesh(new THREE.BoxGeometry(width, 0.055, 0.09), railMat);
+    stepNose.position.set(0, 0.32 + row * rowRise, -row * rowDepth + rowDepth * 0.42);
+    stands.add(shadow(stepNose));
+  }
+
+  const stairXs = [-7.1, -2.35, 2.35, 7.1];
+  stairXs.forEach((x) => {
+    for (let row = 0; row < rows; row++) {
+      const stair = new THREE.Mesh(new THREE.BoxGeometry(0.74, 0.08, rowDepth * 0.72), aisleMat);
+      stair.position.set(x, 0.36 + row * rowRise, -row * rowDepth + 0.03);
+      stands.add(shadow(stair));
+      const edgeL = new THREE.Mesh(new THREE.BoxGeometry(0.035, 0.08, rowDepth * 0.72), railMat);
+      const edgeR = edgeL.clone();
+      edgeL.position.set(x - 0.39, 0.43 + row * rowRise, -row * rowDepth + 0.03);
+      edgeR.position.set(x + 0.39, 0.43 + row * rowRise, -row * rowDepth + 0.03);
+      stands.add(shadow(edgeL), shadow(edgeR));
+    }
+  });
+
+  const chairColors = [0x1d4ed8, 0xef4444, 0xfacc15, 0x16a34a, 0xffffff, 0x0ea5e9];
+  let themeCursor = 0;
+  for (let row = 0; row < rows; row++) {
+    for (let col = 0; col < 28; col++) {
+      const x = (col - 13.5) * 0.73;
+      if (stairXs.some((aisleX) => Math.abs(x - aisleX) < 0.52)) continue;
+      const chair = makeChair(chairColors[(row + col) % chairColors.length]);
+      chair.position.set(x, 0.37 + row * rowRise, -row * rowDepth + 0.06);
+      chair.rotation.y = Math.PI;
+      stands.add(chair);
+      if (seatAnchors.length < MAX_STADIUM_SPECTATORS && (row + col) % 2 === 0) {
+        seatAnchors.push({
+          position: new THREE.Vector3(x, 0.42 + row * rowRise, stands.position.z - row * rowDepth + 0.03),
+          rotationY: Math.PI,
+          themeIndex: themeCursor++ % Math.max(1, MURLAN_CHARACTER_THEMES.length),
+        });
+      }
+    }
+  }
+
+  const backWall = new THREE.Mesh(new THREE.BoxGeometry(width + 1.1, rows * rowRise + 1.2, 0.32), material(0x334155, 0.72, 0.06));
+  backWall.position.set(0, 1.15 + rows * rowRise, -(rows - 1) * rowDepth - 0.72);
+  stands.add(shadow(backWall));
+
+  const rail = new THREE.Mesh(new THREE.BoxGeometry(width + 0.8, 0.08, 0.08), railMat);
+  rail.position.set(0, 1.06, 0.62);
+  stands.add(shadow(rail));
+  const upperRail = new THREE.Mesh(new THREE.BoxGeometry(width + 0.8, 0.08, 0.08), railMat);
+  upperRail.position.set(0, 1.25 + rows * rowRise, -(rows - 1) * rowDepth - 0.08);
+  stands.add(shadow(upperRail));
+
+  scene.userData.freeKickSpectatorSeats = seatAnchors;
+  scene.add(stands);
+}
+
+
 function addLine(scene: THREE.Scene, points: THREE.Vector3[], color = 0xffffff, opacity = 0.9) { const line = new THREE.Line(new THREE.BufferGeometry().setFromPoints(points.map((p) => new THREE.Vector3(p.x, 0.018, p.z))), new THREE.LineBasicMaterial({ color, transparent: true, opacity })); scene.add(line); return line; }
 function addRect(scene: THREE.Scene, left: number, right: number, frontZ: number, backZ: number) { addLine(scene, [new THREE.Vector3(left, 0, frontZ), new THREE.Vector3(left, 0, backZ), new THREE.Vector3(right, 0, backZ), new THREE.Vector3(right, 0, frontZ)]); }
 function makeHalfField(scene: THREE.Scene, netRig: NetRig) { const grassA = material(0x1d7d39, 0.95, 0); const grassB = material(0x16692e, 0.95, 0); for (let i = 0; i < 10; i++) { const stripe = new THREE.Mesh(new THREE.PlaneGeometry(FIELD_W, HALF_H / 10), i % 2 ? grassA : grassB); stripe.rotation.x = -Math.PI / 2; stripe.position.z = -HALF_H / 2 + HALF_H / 20 + (i * HALF_H) / 10; stripe.receiveShadow = true; scene.add(stripe); } const w = FIELD_W / 2; const h = HALF_H / 2; addLine(scene, [new THREE.Vector3(-w, 0, -h), new THREE.Vector3(w, 0, -h), new THREE.Vector3(w, 0, h), new THREE.Vector3(-w, 0, h), new THREE.Vector3(-w, 0, -h)]); addLine(scene, [new THREE.Vector3(-w, 0, h), new THREE.Vector3(w, 0, h)]); addRect(scene, -PENALTY_W / 2, PENALTY_W / 2, -h, -h + PENALTY_D); addRect(scene, -GOAL_AREA_W / 2, GOAL_AREA_W / 2, -h, -h + GOAL_AREA_D); const penaltySpot = new THREE.Mesh(new THREE.CircleGeometry(0.08, 28), new THREE.MeshBasicMaterial({ color: 0xffffff })); penaltySpot.rotation.x = -Math.PI / 2; penaltySpot.position.set(0, 0.022, -h + PENALTY_SPOT_D); scene.add(penaltySpot); const boxTopZ = -h + PENALTY_D; const spotZ = -h + PENALTY_SPOT_D; const theta = Math.acos((boxTopZ - spotZ) / ARC_R); const arcPts = new THREE.EllipseCurve(0, spotZ, ARC_R, ARC_R, theta, Math.PI - theta).getPoints(96).map((p) => new THREE.Vector3(p.x, 0, p.y)); addLine(scene, arcPts); makeGoal(scene, netRig); makeBillboardsAndStands(scene); }
+function normalizeSpectatorModel(model: THREE.Object3D, height = 1.18) {
+  model.scale.setScalar(1);
+  model.updateMatrixWorld(true);
+  const box = new THREE.Box3().setFromObject(model);
+  const h = Math.max(0.001, box.max.y - box.min.y);
+  model.scale.setScalar(height / h);
+  model.updateMatrixWorld(true);
+  const box2 = new THREE.Box3().setFromObject(model);
+  const center = box2.getCenter(new THREE.Vector3());
+  model.position.x -= center.x;
+  model.position.z -= center.z;
+  model.position.y -= box2.min.y;
+}
+
+function makeSeatedFallbackSpectator(color: number) {
+  const group = new THREE.Group();
+  const torso = new THREE.Mesh(new THREE.CapsuleGeometry(0.11, 0.38, 6, 10), material(color));
+  torso.position.y = 0.78;
+  const head = new THREE.Mesh(new THREE.SphereGeometry(0.095, 12, 10), material(0xf1d6bd));
+  head.position.y = 1.14;
+  const leftArm = new THREE.Mesh(new THREE.CapsuleGeometry(0.025, 0.34, 5, 8), material(0xf1d6bd));
+  const rightArm = leftArm.clone();
+  leftArm.position.set(-0.14, 0.78, 0.02);
+  rightArm.position.set(0.14, 0.78, 0.02);
+  leftArm.rotation.z = 0.2;
+  rightArm.rotation.z = -0.2;
+  const legMat = material(0x1f2937);
+  const leftLeg = new THREE.Mesh(new THREE.CapsuleGeometry(0.035, 0.38, 5, 8), legMat);
+  const rightLeg = leftLeg.clone();
+  leftLeg.position.set(-0.07, 0.48, 0.15);
+  rightLeg.position.set(0.07, 0.48, 0.15);
+  leftLeg.rotation.x = Math.PI / 2;
+  rightLeg.rotation.x = Math.PI / 2;
+  group.add(shadow(torso), shadow(head), shadow(leftArm), shadow(rightArm), shadow(leftLeg), shadow(rightLeg));
+  return group;
+}
+
+async function loadThemeModel(loader: GLTFLoader, theme: any) {
+  const urls = Array.isArray(theme?.modelUrls) && theme.modelUrls.length ? theme.modelUrls : theme?.url ? [theme.url] : [];
+  let lastError: unknown = null;
+  for (const url of urls) {
+    try {
+      const gltf = await loader.loadAsync(url);
+      const root = gltf.scene || gltf.scenes?.[0];
+      if (root) return root;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError || new Error("Missing Murlan character model URL");
+}
+
+async function addMurlanStadiumSpectators(scene: THREE.Scene, loader: GLTFLoader) {
+  const seats = (scene.userData.freeKickSpectatorSeats || []) as Array<{ position: THREE.Vector3; rotationY: number; themeIndex: number }>;
+  const spectators: StadiumSpectator[] = [];
+  await Promise.all(seats.map(async (seat, index) => {
+    const theme = MURLAN_CHARACTER_THEMES[seat.themeIndex % Math.max(1, MURLAN_CHARACTER_THEMES.length)];
+    let model: THREE.Object3D;
+    try {
+      const template = await loadThemeModel(loader, theme);
+      model = cloneSkeleton(template) as THREE.Object3D;
+      normalizeSpectatorModel(model, 1.16);
+    } catch (_) {
+      model = makeSeatedFallbackSpectator(MURLAN_CHARACTER_COLORS[index % MURLAN_CHARACTER_COLORS.length]);
+    }
+    shadow(model);
+    const { bones, seatedPose } = applyMurlanSeatedPose(model);
+    const root = new THREE.Group();
+    root.position.copy(seat.position);
+    root.rotation.y = seat.rotationY;
+    root.scale.setScalar(0.78);
+    root.add(model);
+    scene.add(root);
+    spectators.push({ root, model, bones, seatedPose, celebrateTime: 0, waveSeed: Math.random() * Math.PI * 2 });
+  }));
+  return spectators;
+}
+
+function triggerSpectatorGoalCelebration(spectators: StadiumSpectator[]) {
+  spectators.forEach((spectator, index) => {
+    spectator.celebrateTime = 2.8 + (index % 4) * 0.16;
+  });
+}
+
+function updateSpectators(spectators: StadiumSpectator[], dt: number) {
+  spectators.forEach((spectator) => {
+    if (spectator.celebrateTime <= 0) {
+      restoreSpectatorSeatedPose(spectator);
+      spectator.root.position.y = THREE.MathUtils.lerp(spectator.root.position.y, spectator.root.userData.baseY ?? spectator.root.position.y, 0.12);
+      return;
+    }
+    if (spectator.root.userData.baseY == null) spectator.root.userData.baseY = spectator.root.position.y;
+    spectator.celebrateTime = Math.max(0, spectator.celebrateTime - dt);
+    const t = performance.now() * 0.006 + spectator.waveSeed;
+    const stand = THREE.MathUtils.smoothstep(Math.min(1, spectator.celebrateTime), 0, 0.65);
+    spectator.root.position.y = (spectator.root.userData.baseY as number) + 0.36 * stand + Math.abs(Math.sin(t * 2.2)) * 0.04;
+    const b = spectator.bones;
+    restoreSpectatorSeatedPose(spectator);
+    addRotation(b.hips, THREE.MathUtils.degToRad(18) * stand, 0, 0);
+    addRotation(b.spine, THREE.MathUtils.degToRad(10) * stand, 0, Math.sin(t) * 0.06);
+    addRotation(b.leftUpperArm, THREE.MathUtils.degToRad(-118) * stand, 0, Math.sin(t) * 0.42);
+    addRotation(b.rightUpperArm, THREE.MathUtils.degToRad(-118) * stand, 0, -Math.sin(t + 0.7) * 0.42);
+    addRotation(b.leftForeArm, THREE.MathUtils.degToRad(-32) * stand, 0, Math.sin(t * 1.7) * 0.28);
+    addRotation(b.rightForeArm, THREE.MathUtils.degToRad(-32) * stand, 0, -Math.sin(t * 1.5) * 0.28);
+    addRotation(b.leftThigh, THREE.MathUtils.degToRad(58) * stand, 0, 0);
+    addRotation(b.rightThigh, THREE.MathUtils.degToRad(58) * stand, 0, 0);
+    addRotation(b.leftCalf, THREE.MathUtils.degToRad(58) * stand, 0, 0);
+    addRotation(b.rightCalf, THREE.MathUtils.degToRad(58) * stand, 0, 0);
+  });
+}
+
 function makeAimLine(scene: THREE.Scene) { const geometry = new THREE.BufferGeometry(); geometry.setAttribute("position", new THREE.BufferAttribute(new Float32Array(34 * 3), 3)); const line = new THREE.Line(geometry, new THREE.LineBasicMaterial({ color: 0xfff200, transparent: true, opacity: 0.95 })); scene.add(line); return line; }
 function shotPoint(start: THREE.Vector3, target: THREE.Vector3, curve: number, lift: number, t: number) { const p = start.clone().lerp(target, t); p.x += curve * Math.sin(t * Math.PI); p.y = BALL_R + lift * Math.sin(t * Math.PI) + (target.y - BALL_R) * t; return p; }
-function swipeToShot(ballPos: THREE.Vector3, swipe: SwipeState) { const dx = swipe.endX - swipe.startX; const dy = swipe.startY - swipe.endY; const targetX = THREE.MathUtils.clamp(dx / 34, -GOAL_W / 2 + 0.2, GOAL_W / 2 - 0.2); const targetY = THREE.MathUtils.clamp(0.45 + dy / 82, 0.22, GOAL_H + 1.3); const target = new THREE.Vector3(targetX, targetY, GOAL_LINE_Z - 0.2); const curve = THREE.MathUtils.clamp(dx / 58, -6.0, 6.0); const lift = THREE.MathUtils.clamp(dy / 65, 0.35, GOAL_H + 2.4); const power = THREE.MathUtils.clamp(Math.hypot(dx, dy) / 123, 0.48, 1.72); const distance = ballPos.distanceTo(target); const duration = THREE.MathUtils.clamp(distance / (18.7 + power * 10.4), 0.72, 1.34); return { target, curve, lift, power, duration }; }
+function swipeToShot(ballPos: THREE.Vector3, swipe: SwipeState) { const dx = swipe.endX - swipe.startX; const dy = swipe.startY - swipe.endY; const targetX = THREE.MathUtils.clamp(dx / 34, -GOAL_W / 2 + 0.2, GOAL_W / 2 - 0.2); const targetY = THREE.MathUtils.clamp(0.45 + dy / 82, 0.22, GOAL_H + 1.3); const target = new THREE.Vector3(targetX, targetY, GOAL_LINE_Z - GOAL_D - 0.25); const curve = THREE.MathUtils.clamp(dx / 58, -6.0, 6.0); const lift = THREE.MathUtils.clamp(dy / 65, 0.35, GOAL_H + 2.4); const power = THREE.MathUtils.clamp(Math.hypot(dx, dy) / 123, 0.48, 1.72); const distance = ballPos.distanceTo(target); const duration = THREE.MathUtils.clamp(distance / (18.7 + power * 10.4), 0.72, 1.34); return { target, curve, lift, power, duration }; }
 function setAimCurve(line: THREE.Line, ballPos: THREE.Vector3, swipe: SwipeState) { const attr = (line.geometry as THREE.BufferGeometry).getAttribute("position") as THREE.BufferAttribute; const shot = swipeToShot(ballPos, swipe); for (let i = 0; i < attr.count; i++) { const t = i / (attr.count - 1); const p = shotPoint(ballPos, shot.target, shot.curve, shot.lift, t); attr.setXYZ(i, p.x, p.y + 0.08, p.z); } attr.needsUpdate = true; line.geometry.computeBoundingSphere(); }
 function hideAimLine(line: THREE.Line) { const attr = (line.geometry as THREE.BufferGeometry).getAttribute("position") as THREE.BufferAttribute; for (let i = 0; i < attr.count; i++) attr.setXYZ(i, 99, 99, 99); attr.needsUpdate = true; }
 function freeKickPosition(spot: KickSpot) { if (spot === "left") return new THREE.Vector3(-4.6, BALL_R, GOAL_LINE_Z + 24.5); if (spot === "right") return new THREE.Vector3(4.6, BALL_R, GOAL_LINE_Z + 24.5); if (spot === "near16") return new THREE.Vector3(0.7, BALL_R, GOAL_LINE_Z + 18.8); return new THREE.Vector3(0, BALL_R, GOAL_LINE_Z + 23.0); }
 function wallCountForSpot(spot: KickSpot) { if (spot === "left" || spot === "right") return 3; if (spot === "near16") return 5; return 4; }
 function wallCenterForBall(ballPos: THREE.Vector3) { const goalCenter = new THREE.Vector3(0, 0, GOAL_LINE_Z); const toGoal = goalCenter.sub(ballPos).setY(0).normalize(); return ballPos.clone().addScaledVector(toGoal, WALL_DISTANCE).setY(0); }
 function placeWall(wall: Actor[], spot: KickSpot, ballPos: THREE.Vector3) { const count = wallCountForSpot(spot); const center = wallCenterForBall(ballPos); const toBall = ballPos.clone().sub(center).setY(0).normalize(); const side = new THREE.Vector3(toBall.z, 0, -toBall.x).normalize(); wall.forEach((actor, i) => { actor.root.visible = i < count; const offset = i - (count - 1) / 2; actor.pos.copy(center).addScaledVector(side, offset * 0.62).setY(0); actor.dir.copy(ballPos.clone().sub(actor.pos).setY(0).normalize()); actor.vel.set(0, 0, 0); actor.speed = 0; actor.jumpTime = 0; }); }
-function resetShot(ball: BallState, kicker: Actor, keeper: Actor, wall: Actor[], spot: KickSpot) { const ballPos = freeKickPosition(spot); ball.object.position.copy(ballPos); ball.vel.set(0, 0, 0); ball.spin.set(0, 0, 0); ball.curve = 0; ball.shotAge = 0; ball.shotDuration = 1.05; ball.lift = 1; ball.flying = false; ball.netCaught = false; ball.netAge = 0; ball.netVel.set(0, 0, 0); ball.shotStart.copy(ballPos); ball.shotTarget.set(0, BALL_R, GOAL_LINE_Z); ball.lastPos.copy(ballPos); ball.knuckleSeed = Math.random() * 100; const toGoal = new THREE.Vector3(0, 0, GOAL_LINE_Z).sub(ballPos).setY(0).normalize(); const runupStart = ballPos.clone().addScaledVector(toGoal, -RUNUP_BACK_STEPS).add(new THREE.Vector3(-0.42, -BALL_R, 0)).setY(0); kicker.pos.copy(runupStart); kicker.dir.copy(ballPos.clone().sub(kicker.pos).setY(0).normalize()); kicker.vel.set(0, 0, 0); kicker.speed = 0; kicker.kickTime = 0; keeper.pos.set(0, 0, GOAL_LINE_Z + 0.36); keeper.dir.set(0, 0, 1); keeper.vel.set(0, 0, 0); keeper.speed = 0; keeper.diveTime = 0; keeper.diveDelay = 0; keeper.diveDir = 0; keeper.diveHeight = 1.15; placeWall(wall, spot, ballPos); }
-function predictShotResult(ballPos: THREE.Vector3, swipe: SwipeState) { const shot = swipeToShot(ballPos, swipe); const final = shotPoint(ballPos, shot.target, shot.curve, shot.lift, 1); return { shot, final }; }
-function beginRunup(kicker: Actor, wall: Actor[], keeper: Actor, ball: BallState, swipe: SwipeState) { kicker.kickTime = 0.72; wall.forEach((w) => (w.jumpTime = 0.42)); const { final } = predictShotResult(ball.object.position, swipe); const targetSide = final.x < -0.22 ? -1 : final.x > 0.22 ? 1 : 0; const targetHeight = THREE.MathUtils.clamp(final.y, 0.35, GOAL_H + 0.35); const quality = Math.random(); keeper.diveDir = quality < 0.06 ? -targetSide || (Math.random() > 0.5 ? 1 : -1) : targetSide; keeper.diveHeight = targetHeight < 0.8 ? 0.58 : targetHeight > 1.68 ? 1.82 : 1.16; keeper.diveDelay = quality > 0.72 ? 0.08 : quality > 0.32 ? 0.15 : 0.22; keeper.diveTime = 0; }
-function shootBall(ball: BallState, swipe: SwipeState) { const shot = swipeToShot(ball.object.position, swipe); ball.curve = shot.curve; ball.lift = shot.lift; ball.shotAge = 0; ball.shotDuration = shot.duration; ball.shotStart.copy(ball.object.position); ball.shotTarget.copy(shot.target); ball.lastPos.copy(ball.object.position); ball.netCaught = false; ball.netAge = 0; ball.netVel.set(0, 0, 0); ball.spin.set(shot.curve * 0.2, shot.curve * 22.0, -shot.curve * 12.0); ball.flying = true; }
-function updateBall(ball: BallState, dt: number) { if (ball.netCaught) { ball.netAge += dt; ball.netVel.y -= 1.2 * dt; ball.netVel.multiplyScalar(Math.pow(0.82, dt * 60)); ball.object.position.addScaledVector(ball.netVel, dt); ball.object.position.z = THREE.MathUtils.clamp(ball.object.position.z, GOAL_LINE_Z - GOAL_D + 0.18, GOAL_LINE_Z - 0.18); ball.object.position.y = Math.max(BALL_R, ball.object.position.y); const spinLen = ball.netVel.length() / BALL_R; if (spinLen > 0.001) { QTMP.setFromAxisAngle(new THREE.Vector3(1, 0.2, 0).normalize(), spinLen * dt); ball.object.quaternion.premultiply(QTMP); } if (ball.netAge > 1.15 || ball.netVel.length() < 0.04) ball.flying = false; return; } if (!ball.flying) return; ball.shotAge += dt; const t = THREE.MathUtils.clamp(ball.shotAge / ball.shotDuration, 0, 1); const eased = 1 - Math.pow(1 - t, 1.25); const next = shotPoint(ball.shotStart, ball.shotTarget, ball.curve, ball.lift, eased); ball.vel.copy(next).sub(ball.lastPos).divideScalar(Math.max(0.0001, dt)); ball.object.position.copy(next); const move = next.clone().sub(ball.lastPos); const dist = move.length(); if (dist > 0.0001) { const rollAxis = new THREE.Vector3(move.z, 0, -move.x).normalize(); const rollAngle = dist / BALL_R; QTMP.setFromAxisAngle(rollAxis, rollAngle); ball.object.quaternion.premultiply(QTMP); } const curveSpin = Math.abs(ball.curve) * 0.08 + 0.04; QTMP.setFromAxisAngle(new THREE.Vector3(0, Math.sign(ball.curve || 1), 0), curveSpin); ball.object.quaternion.premultiply(QTMP); ball.lastPos.copy(next); if (t >= 1) ball.flying = false; }
-function keeperSaveCheck(keeper: Actor, ball: BallState, dt: number) { if (!ball.flying || ball.netCaught) return false; if (keeper.diveDelay > 0) { keeper.diveDelay = Math.max(0, keeper.diveDelay - dt); if (keeper.diveDelay <= 0) keeper.diveTime = 0.9; } const lateralStep = keeper.diveDir * 0.9 * Math.max(0, 1 - keeper.diveDelay * 4.5); keeper.pos.x = THREE.MathUtils.lerp(keeper.pos.x, lateralStep, 0.09); const handReach = keeper.diveDir === 0 ? 0.92 : 1.28; const keeperCenter = keeper.pos.clone().add(new THREE.Vector3(keeper.diveDir * 1.55, keeper.diveHeight, 0)); const nearGoal = ball.object.position.z < GOAL_LINE_Z + 1.65; if (nearGoal && keeperCenter.distanceTo(ball.object.position) < handReach) { ball.flying = false; return true; } return false; }
+function resetShot(ball: BallState, kicker: Actor, keeper: Actor, wall: Actor[], spot: KickSpot) {
+  const ballPos = freeKickPosition(spot);
+  ball.object.position.copy(ballPos);
+  ball.vel.set(0, 0, 0);
+  ball.spin.set(0, 0, 0);
+  ball.curve = 0;
+  ball.shotAge = 0;
+  ball.shotDuration = 1.05;
+  ball.lift = 1;
+  ball.flying = false;
+  ball.netCaught = false;
+  ball.netAge = 0;
+  ball.netVel.set(0, 0, 0);
+  ball.crossedGoalLine = false;
+  ball.hitFrame = false;
+  ball.shotStart.copy(ballPos);
+  ball.shotTarget.set(0, BALL_R, GOAL_LINE_Z);
+  ball.lastPos.copy(ballPos);
+  ball.knuckleSeed = Math.random() * 100;
+
+  const toGoal = new THREE.Vector3(0, 0, GOAL_LINE_Z).sub(ballPos).setY(0).normalize();
+  const runupStart = ballPos.clone().addScaledVector(toGoal, -RUNUP_BACK_STEPS).add(new THREE.Vector3(-0.42, -BALL_R, 0)).setY(0);
+  kicker.pos.copy(runupStart);
+  kicker.dir.copy(ballPos.clone().sub(kicker.pos).setY(0).normalize());
+  kicker.vel.set(0, 0, 0);
+  kicker.speed = 0;
+  kicker.kickTime = 0;
+  kicker.celebrateTime = 0;
+
+  keeper.pos.set(0, 0, GOAL_LINE_Z + 0.36);
+  keeper.dir.set(0, 0, 1);
+  keeper.vel.set(0, 0, 0);
+  keeper.speed = 0;
+  keeper.diveTime = 0;
+  keeper.diveDelay = 0;
+  keeper.diveDir = 0;
+  keeper.diveHeight = 1.15;
+  keeper.saveTargetX = 0;
+  keeper.saveTargetY = 1.15;
+
+  placeWall(wall, spot, ballPos);
+}
+
+function predictShotResult(ballPos: THREE.Vector3, swipe: SwipeState) {
+  const shot = swipeToShot(ballPos, swipe);
+  const final = shotPoint(ballPos, shot.target, shot.curve, shot.lift, 1);
+  let goalLine = final.clone();
+  for (let i = 0; i <= 48; i++) {
+    const t = i / 48;
+    const p = shotPoint(ballPos, shot.target, shot.curve, shot.lift, t);
+    if (p.z <= GOAL_LINE_Z) {
+      goalLine = p;
+      break;
+    }
+  }
+  return { shot, final, goalLine };
+}
+
+function beginRunup(kicker: Actor, wall: Actor[], keeper: Actor, ball: BallState, swipe: SwipeState) {
+  kicker.kickTime = 0.72;
+  wall.forEach((w) => (w.jumpTime = 0.42));
+
+  const { goalLine } = predictShotResult(ball.object.position, swipe);
+  keeper.saveTargetX = THREE.MathUtils.clamp(goalLine.x, -GOAL_W / 2 + 0.28, GOAL_W / 2 - 0.28);
+  keeper.saveTargetY = THREE.MathUtils.clamp(goalLine.y, 0.35, GOAL_H + 0.15);
+
+  const targetSide = keeper.saveTargetX < -0.28 ? -1 : keeper.saveTargetX > 0.28 ? 1 : 0;
+  const quality = Math.random();
+  keeper.diveDir = quality < 0.08 ? -targetSide || (Math.random() > 0.5 ? 1 : -1) : targetSide;
+  keeper.diveHeight = keeper.saveTargetY < 0.8 ? 0.62 : keeper.saveTargetY > 1.7 ? 1.78 : 1.18;
+  keeper.diveDelay = quality > 0.7 ? 0.06 : quality > 0.25 ? 0.12 : 0.18;
+  keeper.diveTime = 0;
+}
+
+function shootBall(ball: BallState, swipe: SwipeState) {
+  const shot = swipeToShot(ball.object.position, swipe);
+  ball.curve = shot.curve;
+  ball.lift = shot.lift;
+  ball.shotAge = 0;
+  ball.shotDuration = shot.duration;
+  ball.shotStart.copy(ball.object.position);
+  ball.shotTarget.copy(shot.target);
+  ball.lastPos.copy(ball.object.position);
+  ball.netCaught = false;
+  ball.netAge = 0;
+  ball.netVel.set(0, 0, 0);
+  ball.crossedGoalLine = false;
+  ball.hitFrame = false;
+  ball.spin.set(shot.curve * 0.2, shot.curve * 22.0, -shot.curve * 12.0);
+  ball.flying = true;
+}
+
+function rollBall(ball: BallState, move: THREE.Vector3, dt: number) {
+  const dist = move.length();
+  if (dist > 0.0001) {
+    const rollAxis = new THREE.Vector3(move.z, 0, -move.x).normalize();
+    const rollAngle = dist / BALL_R;
+    QTMP.setFromAxisAngle(rollAxis, rollAngle);
+    ball.object.quaternion.premultiply(QTMP);
+  }
+  const curveSpin = Math.abs(ball.curve) * 0.08 + 0.04;
+  QTMP.setFromAxisAngle(new THREE.Vector3(0, Math.sign(ball.curve || 1), 0), curveSpin * Math.max(1, dt * 60));
+  ball.object.quaternion.premultiply(QTMP);
+}
+
+function updateBall(ball: BallState, dt: number) {
+  if (ball.netCaught) {
+    ball.netAge += dt;
+    ball.netVel.y -= 1.2 * dt;
+    ball.netVel.multiplyScalar(Math.pow(0.82, dt * 60));
+    const prev = ball.object.position.clone();
+    ball.object.position.addScaledVector(ball.netVel, dt);
+    ball.object.position.z = THREE.MathUtils.clamp(ball.object.position.z, GOAL_LINE_Z - GOAL_D + 0.18, GOAL_LINE_Z - 0.18);
+    ball.object.position.y = Math.max(BALL_R, ball.object.position.y);
+    rollBall(ball, ball.object.position.clone().sub(prev), dt);
+    if (ball.netAge > 1.15 || ball.netVel.length() < 0.04) ball.flying = false;
+    ball.lastPos.copy(ball.object.position);
+    return;
+  }
+  if (!ball.flying) return;
+
+  const prev = ball.object.position.clone();
+  ball.shotAge += dt;
+
+  if (ball.shotAge <= ball.shotDuration) {
+    const t = THREE.MathUtils.clamp(ball.shotAge / ball.shotDuration, 0, 1);
+    const eased = 1 - Math.pow(1 - t, 1.25);
+    const next = shotPoint(ball.shotStart, ball.shotTarget, ball.curve, ball.lift, eased);
+    ball.vel.copy(next).sub(prev).divideScalar(Math.max(0.0001, dt));
+    ball.object.position.copy(next);
+  } else {
+    const knuckle = Math.sin(ball.shotAge * 12 + ball.knuckleSeed) * Math.abs(ball.curve) * 0.22;
+    ball.vel.x += (knuckle - ball.vel.x * 0.025) * dt;
+    ball.vel.y -= 8.6 * dt;
+    ball.vel.multiplyScalar(Math.pow(0.992, dt * 60));
+    ball.object.position.addScaledVector(ball.vel, dt);
+
+    if (ball.object.position.y <= BALL_R) {
+      ball.object.position.y = BALL_R;
+      if (Math.abs(ball.vel.y) > 0.9) ball.vel.y = -ball.vel.y * 0.34;
+      else ball.vel.y = 0;
+      ball.vel.x *= Math.pow(0.90, dt * 60);
+      ball.vel.z *= Math.pow(0.90, dt * 60);
+    }
+  }
+
+  rollBall(ball, ball.object.position.clone().sub(prev), dt);
+  ball.lastPos.copy(prev);
+
+  if (ball.object.position.y <= BALL_R + 0.01 && ball.vel.length() < 0.18) ball.flying = false;
+  if (ball.object.position.z < GOAL_LINE_Z - GOAL_D - 5.5 || Math.abs(ball.object.position.x) > FIELD_W * 0.85 || ball.object.position.y > GOAL_H + 8) ball.flying = false;
+}
+
+function segmentDistanceToBall(a: THREE.Vector3, b: THREE.Vector3, p: THREE.Vector3) {
+  const ab = b.clone().sub(a);
+  const t = THREE.MathUtils.clamp(p.clone().sub(a).dot(ab) / Math.max(0.0001, ab.lengthSq()), 0, 1);
+  return a.clone().addScaledVector(ab, t).distanceTo(p);
+}
+
+function keeperSaveCheck(keeper: Actor, ball: BallState, dt: number) {
+  if (!ball.flying || ball.netCaught) return false;
+  if (keeper.diveDelay > 0) {
+    keeper.diveDelay = Math.max(0, keeper.diveDelay - dt);
+    if (keeper.diveDelay <= 0) keeper.diveTime = 0.9;
+  }
+
+  const reaction = Math.max(0, 1 - keeper.diveDelay * 5.2);
+  const targetStep = THREE.MathUtils.clamp(keeper.saveTargetX * 0.42 + keeper.diveDir * 0.65, -1.55, 1.55);
+  keeper.pos.x = THREE.MathUtils.lerp(keeper.pos.x, targetStep, 0.12 * reaction + 0.035);
+
+  const nearGoal = ball.object.position.z < GOAL_LINE_Z + 1.85 && ball.object.position.z > GOAL_LINE_Z - 0.75;
+  if (!nearGoal) return false;
+
+  const bodyCenter = keeper.pos.clone().add(new THREE.Vector3(0, 1.05, 0));
+  const gloveCenter = keeper.pos.clone().add(new THREE.Vector3(keeper.diveDir * 1.48, keeper.diveHeight, 0));
+  const highGlove = keeper.pos.clone().add(new THREE.Vector3(keeper.diveDir * 1.92, keeper.diveHeight + 0.22, 0));
+  const bodyReach = 0.64;
+  const gloveReach = keeper.diveDir === 0 ? 1.08 : 1.5;
+
+  if (bodyCenter.distanceTo(ball.object.position) < bodyReach || gloveCenter.distanceTo(ball.object.position) < gloveReach || segmentDistanceToBall(gloveCenter, highGlove, ball.object.position) < BALL_R + 0.32) {
+    const push = ball.object.position.clone().sub(gloveCenter).setY(0).normalize();
+    if (push.lengthSq() < 0.001) push.set(keeper.diveDir || (ball.object.position.x < 0 ? -1 : 1), 0, 0.25).normalize();
+    ball.vel.set(push.x * 5.2, Math.max(1.4, ball.vel.y * 0.2 + 1.8), Math.max(1.2, Math.abs(ball.vel.z) * 0.28));
+    ball.object.position.addScaledVector(push, BALL_R * 1.2);
+    ball.shotAge = ball.shotDuration + 0.01;
+    return true;
+  }
+  return false;
+}
+
 function wallBlockCheck(wall: Actor[], ball: BallState) { if (!ball.flying || ball.netCaught) return false; for (const actor of wall) { if (!actor.root.visible) continue; const chest = actor.pos.clone().setY(actor.jumpTime > 0 ? 1.55 : 1.15); if (chest.distanceTo(ball.object.position) < 0.55) { ball.flying = false; return true; } } return false; }
-function isGoalPosition(p: THREE.Vector3) { const crossedLine = p.z <= GOAL_LINE_Z - 0.05; const insidePosts = Math.abs(p.x) <= GOAL_W / 2 - BALL_R; const underBar = p.y >= BALL_R && p.y <= GOAL_H - BALL_R * 0.25; return crossedLine && insidePosts && underBar; }
-function decideShot(ball: BallState, blocked: boolean, saved: boolean): Decision { if (blocked) return "BLOCKED"; if (saved) return "SAVE"; return isGoalPosition(ball.object.position) || ball.netCaught ? "GOAL" : "NO GOAL"; }
-function catchBallInNet(ball: BallState, netRig: NetRig) { ball.netCaught = true; ball.netAge = 0; ball.flying = true; ball.netVel.copy(ball.vel).multiplyScalar(0.12); ball.netVel.z = Math.min(ball.netVel.z, -0.45); ball.netVel.y *= 0.18; triggerNetShake(netRig, ball.object.position.clone()); }
+
+function markGoalCrossing(ball: BallState) {
+  if (ball.crossedGoalLine || ball.hitFrame) return false;
+  const prev = ball.lastPos;
+  const curr = ball.object.position;
+  const crossed = prev.z > GOAL_LINE_Z && curr.z <= GOAL_LINE_Z;
+  if (!crossed) return false;
+  const ratio = (prev.z - GOAL_LINE_Z) / Math.max(0.0001, prev.z - curr.z);
+  const x = THREE.MathUtils.lerp(prev.x, curr.x, ratio);
+  const y = THREE.MathUtils.lerp(prev.y, curr.y, ratio);
+  ball.crossedGoalLine = Math.abs(x) <= GOAL_W / 2 - BALL_R && y >= BALL_R && y <= GOAL_H - BALL_R * 0.25;
+  return ball.crossedGoalLine;
+}
+
+function reflectFromGoalFrame(ball: BallState) {
+  if (!ball.flying || ball.netCaught || ball.hitFrame) return false;
+  const p = ball.object.position;
+  if (p.z > GOAL_LINE_Z + 0.22 || p.z < GOAL_LINE_Z - 0.35) return false;
+  const radius = BALL_R + POST_R * 1.25;
+  const candidates = [
+    [new THREE.Vector3(-GOAL_W / 2, 0, GOAL_LINE_Z), new THREE.Vector3(-GOAL_W / 2, GOAL_H, GOAL_LINE_Z)],
+    [new THREE.Vector3(GOAL_W / 2, 0, GOAL_LINE_Z), new THREE.Vector3(GOAL_W / 2, GOAL_H, GOAL_LINE_Z)],
+    [new THREE.Vector3(-GOAL_W / 2, GOAL_H, GOAL_LINE_Z), new THREE.Vector3(GOAL_W / 2, GOAL_H, GOAL_LINE_Z)],
+  ];
+  for (const [a, b] of candidates) {
+    const ab = b.clone().sub(a);
+    const t = THREE.MathUtils.clamp(p.clone().sub(a).dot(ab) / Math.max(0.0001, ab.lengthSq()), 0, 1);
+    const closest = a.clone().addScaledVector(ab, t);
+    if (closest.distanceTo(p) <= radius) {
+      const normal = p.clone().sub(closest).normalize();
+      if (normal.lengthSq() < 0.001) normal.set(0, 0, 1);
+      ball.object.position.copy(closest).addScaledVector(normal, radius + 0.015);
+      ball.vel.reflect(normal).multiplyScalar(0.72);
+      ball.vel.z = Math.max(ball.vel.z, 1.1);
+      ball.hitFrame = true;
+      ball.shotAge = ball.shotDuration + 0.01;
+      return true;
+    }
+  }
+  return false;
+}
+
+function netCatchCheck(ball: BallState, netRig: NetRig) {
+  if (!ball.flying || ball.netCaught || !ball.crossedGoalLine) return false;
+  const p = ball.object.position;
+  const inGoalDepth = p.z <= GOAL_LINE_Z - GOAL_D + 0.2;
+  const stillInsideGoal = Math.abs(p.x) <= GOAL_W / 2 + 0.35 && p.y <= GOAL_H + 0.32;
+  if (inGoalDepth && stillInsideGoal) {
+    catchBallInNet(ball, netRig);
+    return true;
+  }
+  return false;
+}
+
+function decideShot(ball: BallState, blocked: boolean, saved: boolean): Decision {
+  if (blocked) return "BLOCKED";
+  if (saved) return "SAVE";
+  return ball.crossedGoalLine || ball.netCaught ? "GOAL" : "NO GOAL";
+}
+
+function catchBallInNet(ball: BallState, netRig: NetRig) {
+  ball.netCaught = true;
+  ball.netAge = 0;
+  ball.flying = true;
+  ball.netVel.copy(ball.vel).multiplyScalar(0.12);
+  ball.netVel.z = Math.min(ball.netVel.z, -0.45);
+  ball.netVel.y *= 0.18;
+  triggerNetShake(netRig, ball.object.position.clone());
+}
 
 export default function FreeKickGame() {
   const hostRef = useRef<HTMLDivElement | null>(null);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const swipeRef = useRef<SwipeState>({ active: false, startX: 0, startY: 0, endX: 0, endY: 0 });
+  const cameraOrbitRef = useRef(0);
   const [hud, setHud] = useState({ goals: 0, saves: 0, spot: "center" as KickSpot, state: "Swipe to aim and shoot" });
   useEffect(() => {
     const host = hostRef.current;
@@ -499,14 +1165,26 @@ export default function FreeKickGame() {
     const aimLine = makeAimLine(scene);
     hideAimLine(aimLine);
     const ball = makeBall(scene);
+    const audio = makeGoalRushAudio();
     const loader = new GLTFLoader();
-    const kicker = createActor(scene, loader, "kicker", new THREE.Vector3(0, 0, 6));
-    const keeper = createActor(scene, loader, "keeper", new THREE.Vector3(0, 0, GOAL_LINE_Z + 0.36));
-    const wall = Array.from({ length: 5 }, (_, i) => createActor(scene, loader, "wall", new THREE.Vector3(0, 0, 0), i));
+    const characterColors = shuffledCharacterColors();
+    const actorKitColor = (index: number) => characterColors[index % characterColors.length];
+    const kicker = createActor(scene, loader, "kicker", new THREE.Vector3(0, 0, 6), 0, actorKitColor(0));
+    const keeper = createActor(scene, loader, "keeper", new THREE.Vector3(0, 0, GOAL_LINE_Z + 0.36), 0, actorKitColor(1));
+    const wall = Array.from({ length: 5 }, (_, i) => createActor(scene, loader, "wall", new THREE.Vector3(0, 0, 0), i, actorKitColor(i + 2)));
+    let spectators: StadiumSpectator[] = [];
+    let disposed = false;
+    void addMurlanStadiumSpectators(scene, loader).then((loadedSpectators) => {
+      if (disposed) {
+        loadedSpectators.forEach((spectator) => scene.remove(spectator.root));
+        return;
+      }
+      spectators = loadedSpectators;
+    });
     let spot: KickSpot = "center"; let state: ShotState = "aim"; let resultTimer = 0; let varTimer = 0; let replayIndex = 0; let replayClock = 0; let pendingDecision: Decision = "NO GOAL"; let shotBlocked = false; let shotSaved = false; let shotFinalized = false; let netTriggered = false; const replayFrames: ReplayFrame[] = []; let score = { goals: 0, saves: 0 }; resetShot(ball, kicker, keeper, wall, spot);
     const resize = () => { const w = Math.max(1, host.clientWidth); const h = Math.max(1, host.clientHeight); renderer.setSize(w, h, false); renderer.setPixelRatio(Math.min(2, window.devicePixelRatio || 1)); camera.aspect = w / h; camera.updateProjectionMatrix(); };
     resize(); window.addEventListener("resize", resize);
-    const onDown = (e: PointerEvent) => { if (state !== "aim") return; swipeRef.current = { active: true, startX: e.clientX, startY: e.clientY, endX: e.clientX, endY: e.clientY }; setAimCurve(aimLine, ball.object.position, swipeRef.current); };
+    const onDown = (e: PointerEvent) => { if (state !== "aim") return; audio.start(); swipeRef.current = { active: true, startX: e.clientX, startY: e.clientY, endX: e.clientX, endY: e.clientY }; setAimCurve(aimLine, ball.object.position, swipeRef.current); };
     const onMove = (e: PointerEvent) => { if (!swipeRef.current.active || state !== "aim") return; swipeRef.current.endX = e.clientX; swipeRef.current.endY = e.clientY; setAimCurve(aimLine, ball.object.position, swipeRef.current); };
     const onUp = (e: PointerEvent) => { if (!swipeRef.current.active || state !== "aim") return; swipeRef.current.endX = e.clientX; swipeRef.current.endY = e.clientY; swipeRef.current.active = false; hideAimLine(aimLine); beginRunup(kicker, wall, keeper, ball, swipeRef.current); shotBlocked = false; shotSaved = false; shotFinalized = false; netTriggered = false; replayFrames.length = 0; state = "runup"; setHud((h) => ({ ...h, state: "2-step run-up..." })); };
     canvas.addEventListener("pointerdown", onDown); canvas.addEventListener("pointermove", onMove); canvas.addEventListener("pointerup", onUp); canvas.addEventListener("pointercancel", onUp);
@@ -520,13 +1198,15 @@ export default function FreeKickGame() {
         const strikeSpot = ball.object.position.clone().add(new THREE.Vector3(-0.24, -BALL_R, 0.42)).setY(0);
         TMP.copy(strikeSpot).sub(kicker.pos).setY(0);
         if (TMP.length() > 0.055) { kicker.dir.copy(TMP.clone().normalize()); kicker.vel.copy(kicker.dir).multiplyScalar(4.05); kicker.pos.addScaledVector(kicker.vel, dt); kicker.speed = kicker.vel.length(); } else { kicker.speed = 0; }
-        if (kicker.kickTime < 0.34 && !ball.flying) { replayFrames.length = 0; recordReplayFrame(new THREE.Vector3(0, 1.22, GOAL_LINE_Z + 0.25)); shootBall(ball, swipeRef.current); state = "flight"; setHud((h) => ({ ...h, state: "Right-foot strike · recording replay" })); }
+        if (kicker.kickTime < 0.34 && !ball.flying) { replayFrames.length = 0; recordReplayFrame(new THREE.Vector3(0, 1.22, GOAL_LINE_Z + 0.25)); shootBall(ball, swipeRef.current); audio.kick(); state = "flight"; setHud((h) => ({ ...h, state: "Right-foot strike · recording replay" })); }
       } else { kicker.speed = 0; }
-      updateBall(ball, dt); updateNetShake(netRig, dt);
+      updateBall(ball, dt); updateNetShake(netRig, dt); updateSpectators(spectators, dt);
       if (state === "flight") {
-        if (!shotBlocked && wallBlockCheck(wall, ball)) shotBlocked = true;
-        if (!shotSaved && keeperSaveCheck(keeper, ball, dt)) shotSaved = true;
-        if (!netTriggered && !shotBlocked && !shotSaved && isGoalPosition(ball.object.position)) { netTriggered = true; catchBallInNet(ball, netRig); setHud((h) => ({ ...h, state: "Ball hits net · checking VAR" })); }
+        if (!shotBlocked && wallBlockCheck(wall, ball)) { shotBlocked = true; audio.save(); }
+        if (!shotSaved && keeperSaveCheck(keeper, ball, dt)) { shotSaved = true; audio.save(); }
+        if (markGoalCrossing(ball)) setHud((h) => ({ ...h, state: "Ball crossed line · still travelling" }));
+        if (!shotBlocked && !shotSaved && reflectFromGoalFrame(ball)) { audio.save(); setHud((h) => ({ ...h, state: "Off the frame · ball still live" })); }
+        if (!netTriggered && !shotBlocked && !shotSaved && netCatchCheck(ball, netRig)) { netTriggered = true; audio.net(); setHud((h) => ({ ...h, state: "Ball hits net · checking VAR" })); }
         if (!ball.flying && !shotFinalized) { shotFinalized = true; pendingDecision = decideShot(ball, shotBlocked, shotSaved); varTimer = pendingDecision === "GOAL" || pendingDecision === "NO GOAL" ? 1.15 : 0.65; state = "var"; setHud((h) => ({ ...h, state: pendingDecision === "GOAL" ? "VAR CHECK: ball crossed line" : `VAR CHECK: ${pendingDecision}` })); }
       }
       if (state === "var") { varTimer -= dt; if (varTimer <= 0) { state = "replay"; replayIndex = 0; replayClock = 0; setHud((h) => ({ ...h, state: `SLOW REPLAY: ${pendingDecision}` })); } }
@@ -541,29 +1221,39 @@ export default function FreeKickGame() {
           const replayLook = frameData.look.clone().lerp(frameData.ball.clone().add(new THREE.Vector3(0, 0.28, 0)), 0.52);
           camera.position.copy(replayCam); camera.lookAt(replayLook);
         }
-        if (replayIndex >= replayFrames.length - 1 || replayFrames.length === 0) { state = "result"; resultTimer = pendingDecision === "GOAL" ? 1.25 : 1.05; if (pendingDecision === "GOAL") { score.goals += 1; setHud((h) => ({ ...h, goals: score.goals, state: "VAR: GOAL confirmed" })); } else { score.saves += 1; setHud((h) => ({ ...h, saves: score.saves, state: `VAR: ${pendingDecision}` })); } }
+        if (replayIndex >= replayFrames.length - 1 || replayFrames.length === 0) { state = "result"; resultTimer = pendingDecision === "GOAL" ? 2.85 : 1.05; if (pendingDecision === "GOAL") { audio.goal(); kicker.celebrateTime = 2.65; triggerSpectatorGoalCelebration(spectators); score.goals += 1; setHud((h) => ({ ...h, goals: score.goals, state: "VAR: GOAL confirmed" })); } else { score.saves += 1; setHud((h) => ({ ...h, saves: score.saves, state: `VAR: ${pendingDecision}` })); } }
       }
       if (state === "result") { resultTimer -= dt; if (resultTimer <= 0) { state = "aim"; shotBlocked = false; shotSaved = false; shotFinalized = false; netTriggered = false; replayFrames.length = 0; resetShot(ball, kicker, keeper, wall, spot); setHud((h) => ({ ...h, state: "Swipe to aim and shoot" })); } }
       if (state !== "replay") {
         updateActorBase(kicker, dt); applyKickerPose(kicker); updateActorBase(keeper, dt); applyKeeperPose(keeper);
         wall.forEach((w) => { updateActorBase(w, dt); applyWallPose(w); if (w.jumpTime > 0) w.jumpTime = Math.max(0, w.jumpTime - dt); });
         if (kicker.kickTime > 0) kicker.kickTime = Math.max(0, kicker.kickTime - dt);
+        if (kicker.celebrateTime > 0) kicker.celebrateTime = Math.max(0, kicker.celebrateTime - dt);
         if (keeper.diveTime > 0) keeper.diveTime = Math.max(0, keeper.diveTime - dt);
       }
       let lookPoint = new THREE.Vector3(0, 1.22, GOAL_LINE_Z + 0.25);
       if (state !== "replay") {
-        if (ball.flying || state === "var") { const toGoal = new THREE.Vector3(0, 0, GOAL_LINE_Z).sub(ball.object.position).setY(0).normalize(); const followPos = ball.object.position.clone().addScaledVector(toGoal, -4.3).add(new THREE.Vector3(0, 1.55, 0)); camera.position.lerp(followPos, 0.11); lookPoint = ball.object.position.clone().addScaledVector(toGoal, 6.0).add(new THREE.Vector3(0, 0.55, 0)); camera.lookAt(lookPoint); } else { const behind = new THREE.Vector3(kicker.pos.x * 0.45, 1.22, kicker.pos.z + 2.85); camera.position.lerp(behind, 0.18); lookPoint.set(0, 1.22, GOAL_LINE_Z + 0.25); camera.lookAt(lookPoint); }
+        const cameraSide = cameraOrbitRef.current;
+        if (ball.flying || state === "var") { const toGoal = new THREE.Vector3(0, 0, GOAL_LINE_Z).sub(ball.object.position).setY(0).normalize(); const side = new THREE.Vector3(toGoal.z, 0, -toGoal.x).normalize(); const followPos = ball.object.position.clone().addScaledVector(toGoal, -4.3).addScaledVector(side, cameraSide * 1.7).add(new THREE.Vector3(0, 1.55, 0)); camera.position.lerp(followPos, 0.11); lookPoint = ball.object.position.clone().addScaledVector(toGoal, 6.0).add(new THREE.Vector3(cameraSide * 0.35, 0.55, 0)); camera.lookAt(lookPoint); } else { const toGoal = new THREE.Vector3(0, 0, GOAL_LINE_Z).sub(kicker.pos).setY(0).normalize(); const side = new THREE.Vector3(toGoal.z, 0, -toGoal.x).normalize(); const behind = kicker.pos.clone().addScaledVector(toGoal, -2.95).addScaledVector(side, cameraSide * 2.2).add(new THREE.Vector3(0, 1.35, 0)); camera.position.lerp(behind, 0.18); lookPoint.copy(kicker.pos).addScaledVector(toGoal, 8.5).add(new THREE.Vector3(cameraSide * 0.65, 1.16, 0)); camera.lookAt(lookPoint); }
         if (state === "flight" || state === "var") recordReplayFrame(lookPoint);
       }
       renderer.render(scene, camera);
     };
     loop();
-    (window as any).__setFreeKickSpot = (next: KickSpot) => { spot = next; state = "aim"; hideAimLine(aimLine); replayFrames.length = 0; resetShot(ball, kicker, keeper, wall, spot); setHud((h) => ({ ...h, spot, state: `Free kick ${next}: wall ${wallCountForSpot(next)} at 9.15m` })); };
-    return () => { cancelAnimationFrame(frame); window.removeEventListener("resize", resize); canvas.removeEventListener("pointerdown", onDown); canvas.removeEventListener("pointermove", onMove); canvas.removeEventListener("pointerup", onUp); canvas.removeEventListener("pointercancel", onUp); renderer.dispose(); };
+    (window as any).__setFreeKickSpot = (next: KickSpot) => { audio.whistle(); spot = next; state = "aim"; hideAimLine(aimLine); replayFrames.length = 0; resetShot(ball, kicker, keeper, wall, spot); setHud((h) => ({ ...h, spot, state: `Free kick ${next}: wall ${wallCountForSpot(next)} at 9.15m` })); };
+    return () => { disposed = true; cancelAnimationFrame(frame); window.removeEventListener("resize", resize); canvas.removeEventListener("pointerdown", onDown); canvas.removeEventListener("pointermove", onMove); canvas.removeEventListener("pointerup", onUp); canvas.removeEventListener("pointercancel", onUp); audio.dispose(); renderer.dispose(); };
   }, []);
 
   const setSpot = (spot: KickSpot) => {
     (window as any).__setFreeKickSpot?.(spot);
+  };
+
+  const shiftCamera = (amount: number) => {
+    cameraOrbitRef.current = THREE.MathUtils.clamp(cameraOrbitRef.current + amount, -1.25, 1.25);
+  };
+
+  const centerCamera = () => {
+    cameraOrbitRef.current = 0;
   };
 
   return (
@@ -574,6 +1264,11 @@ export default function FreeKickGame() {
       <div style={{ position: "fixed", left: 0, right: 0, top: 0, padding: "12px 14px", display: "flex", justifyContent: "space-between", alignItems: "center", pointerEvents: "none", color: "white", fontFamily: "system-ui,sans-serif", textShadow: "0 2px 8px #000" }}>
         <div style={{ fontWeight: 900, fontSize: 18 }}>GOALS {hud.goals} · SAVES {hud.saves}</div>
         <div style={{ fontSize: 11, maxWidth: 220, textAlign: "right", lineHeight: 1.25 }}>{hud.state}</div>
+      </div>
+      <div style={{ position: "fixed", left: 12, bottom: 76, right: 12, display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 8, pointerEvents: "auto" }}>
+        <button onClick={() => shiftCamera(-0.35)} style={buttonStyle}>Camera<br />Left</button>
+        <button onClick={centerCamera} style={buttonStyle}>Camera<br />Center</button>
+        <button onClick={() => shiftCamera(0.35)} style={buttonStyle}>Camera<br />Right</button>
       </div>
       <div style={{ position: "fixed", left: 12, bottom: 14, right: 12, display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: 8, pointerEvents: "auto" }}>
         <button onClick={() => setSpot("left")} style={buttonStyle}>Left<br />3 wall</button>


### PR DESCRIPTION
### Motivation
- Enhance the visual realism and feedback of the free-kick scene by adding seated stadium spectators, dynamic crowd/goal audio, and kit color variation. 
- Improve referee/VAR fidelity by more accurately detecting goal-line crossings, goal-frame impacts, net catches, and keeper save behavior. 
- Give players more cinematic control with a small camera-orbit control and visible UI for camera and spot selection. 

### Description
- Add Murlan spectator support and fallbacks: new spectator types, seat anchors in `makeBillboardsAndStands`, `addMurlanStadiumSpectators` to load/clone theme models, seated pose application, celebration animation, and stand/chair geometry; include `MURLAN_CHARACTER_THEMES` usage and kit color shuffling. 
- Introduce audio helper `makeGoalRushAudio` and wire sound events (`kick`, `net`, `save`, `goal`, `whistle`, crowd) into game flow; start crowd audio on first pointer-down and play contextual one-shots. 
- Extend ball and keeper logic with new flags (`crossedGoalLine`, `hitFrame`), refined shot prediction (`predictShotResult`), goal crossing detection (`markGoalCrossing`), frame reflections (`reflectFromGoalFrame`), net catch check (`netCatchCheck`), and improved keeper save logic using `saveTargetX/Y`. 
- Visual/UX updates: tinted actor kits and fallback kit support, spectator fallbacks, kicker celebration pose, dynamic spectator celebrations, slower/adjusted replay timings, dynamic replay camera, a `cameraOrbitRef` with on-screen camera left/center/right buttons, and cleanup/dispose integration for audio and spectator lifecycle. 

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faaad846008329bf38350f1247d95e)