### PR TITLE
Enhance FreeKickArena with stadium crowd, audio, camera swipe, and improved ball/keeper logic

### DIFF
--- a/webapp/src/pages/Games/FreeKickArena.tsx
+++ b/webapp/src/pages/Games/FreeKickArena.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import * as THREE from "three";
 import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js";
+import { MURLAN_CHARACTER_THEMES } from "../../config/murlanCharacterThemes.js";
 
 type AnimName = "Idle" | "Walk" | "Run";
 type ShotState = "aim" | "runup" | "flight" | "var" | "replay" | "result";
@@ -42,8 +43,11 @@ type Actor = {
   diveDelay: number;
   diveDir: number;
   diveHeight: number;
+  saveTargetX: number;
+  saveTargetY: number;
   wallIndex: number;
   loaded: boolean;
+  celebrateTime: number;
 };
 
 type BallState = {
@@ -62,6 +66,8 @@ type BallState = {
   netCaught: boolean;
   netAge: number;
   netVel: THREE.Vector3;
+  crossedGoalLine: boolean;
+  hitFrame: boolean;
 };
 
 type SwipeState = {
@@ -70,12 +76,18 @@ type SwipeState = {
   startY: number;
   endX: number;
   endY: number;
+  mode?: "shot" | "camera";
 };
 
 type NetRig = {
   lines: THREE.Line[];
   shake: number;
   impact: THREE.Vector3;
+};
+
+type StadiumRig = {
+  spectators: Actor[];
+  cheerTime: number;
 };
 
 type ReplayFrame = {
@@ -90,6 +102,18 @@ type ReplayFrame = {
 };
 
 const HUMAN_URL = "https://threejs.org/examples/models/gltf/Soldier.glb";
+const MURLAN_CHARACTER_URLS = MURLAN_CHARACTER_THEMES.map((theme) => theme.modelUrls?.[0] ?? theme.url).filter(Boolean);
+const MURLAN_CHARACTER_COLORS = [0x1d69ff, 0xdc2626, 0x16a34a, 0xfacc15, 0x7c3aed, 0xf97316, 0x0891b2];
+const CAMERA_YAW_STEP = 0.22;
+const CAMERA_YAW_LIMIT = 0.7;
+const GOAL_RUSH_SOUNDS = {
+  crowd: "/assets/sounds/football-crowd-3-69245.mp3",
+  whistle: "/assets/sounds/metal-whistle-6121.mp3",
+  kick: "/assets/sounds/football-game-sound-effects-359284.mp3",
+  net: "/assets/sounds/a-football-hits-the-net-goal-313216.mp3",
+  post: "/assets/sounds/frying-pan-over-the-head-89303.mp3",
+  victory: "/assets/sounds/11l-victory_sound_with_t-1749487412779-357604.mp3",
+};
 
 const FIELD_W = 22.0;
 const HALF_H = 36.0;
@@ -112,6 +136,73 @@ const GOAL_LINE_Z = -HALF_H / 2;
 const RUNUP_BACK_STEPS = 2.2;
 const TMP = new THREE.Vector3();
 const QTMP = new THREE.Quaternion();
+
+
+function shuffledCharacterColors() {
+  const count = Math.max(7, MURLAN_CHARACTER_THEMES.length || 0);
+  const colors = Array.from({ length: count }, (_, index) => MURLAN_CHARACTER_COLORS[index % MURLAN_CHARACTER_COLORS.length]);
+  for (let i = colors.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [colors[i], colors[j]] = [colors[j], colors[i]];
+  }
+  return colors;
+}
+
+function shuffledCharacterUrls() {
+  const urls = [...new Set(MURLAN_CHARACTER_URLS.length ? MURLAN_CHARACTER_URLS : [HUMAN_URL])];
+  for (let i = urls.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [urls[i], urls[j]] = [urls[j], urls[i]];
+  }
+  return urls;
+}
+
+function makeGoalRushAudio() {
+  let enabled = true;
+  let started = false;
+  let pendingWhistle = true;
+  const crowd = new Audio(GOAL_RUSH_SOUNDS.crowd);
+  crowd.loop = true;
+  crowd.volume = 0.5;
+
+  const playOneShot = (src: string, volume = 1) => {
+    if (!enabled || !started) return;
+    const sound = new Audio(src);
+    sound.volume = volume;
+    sound.play().catch(() => {});
+  };
+
+  const start = () => {
+    if (!enabled || started) return;
+    started = true;
+    crowd.play().catch(() => {});
+    if (pendingWhistle) {
+      pendingWhistle = false;
+      playOneShot(GOAL_RUSH_SOUNDS.whistle, 0.9);
+    }
+  };
+
+  return {
+    start,
+    whistle() {
+      if (!enabled) return;
+      if (!started) {
+        pendingWhistle = true;
+        return;
+      }
+      playOneShot(GOAL_RUSH_SOUNDS.whistle, 0.9);
+    },
+    kick() { playOneShot(GOAL_RUSH_SOUNDS.kick, 0.92); },
+    net() { playOneShot(GOAL_RUSH_SOUNDS.net, 0.95); },
+    save() { playOneShot(GOAL_RUSH_SOUNDS.post, 0.7); },
+    goal() { playOneShot(GOAL_RUSH_SOUNDS.victory, 0.72); },
+    dispose() {
+      enabled = false;
+      crowd.pause();
+      crowd.src = "";
+    },
+  };
+}
 
 function material(color: number, roughness = 0.72, metalness = 0.03) {
   return new THREE.MeshStandardMaterial({ color, roughness, metalness });
@@ -168,8 +259,8 @@ function normalizeHuman(model: THREE.Object3D, height = PLAYER_H) {
   model.position.y -= box2.min.y;
 }
 
-function tintModel(model: THREE.Object3D, kind: ActorKind, index = 0) {
-  const color = kind === "kicker" ? new THREE.Color(0x1d69ff) : kind === "keeper" ? new THREE.Color(0x111111) : new THREE.Color(0xfacc15);
+function tintModel(model: THREE.Object3D, kind: ActorKind, index = 0, kitColor?: number) {
+  const color = kind === "keeper" ? new THREE.Color(0x111111) : new THREE.Color(kitColor ?? (kind === "kicker" ? 0x1d69ff : 0xfacc15));
   model.traverse((obj) => {
     const mesh = obj as THREE.Mesh;
     if (!mesh.isMesh) return;
@@ -185,9 +276,9 @@ function tintModel(model: THREE.Object3D, kind: ActorKind, index = 0) {
   });
 }
 
-function makeFallback(kind: ActorKind, index = 0) {
+function makeFallback(kind: ActorKind, index = 0, kitColor?: number) {
   const group = new THREE.Group();
-  const kit = kind === "kicker" ? 0x1d69ff : kind === "keeper" ? 0x111111 : 0xfacc15;
+  const kit = kind === "keeper" ? 0x111111 : kitColor ?? (kind === "kicker" ? 0x1d69ff : 0xfacc15);
   const torso = new THREE.Mesh(new THREE.CapsuleGeometry(0.19, 0.72, 8, 14), material(kit));
   torso.position.y = 1.05;
   const stripe = new THREE.Mesh(new THREE.BoxGeometry(0.28, 0.06, 0.02), material(kind === "wall" ? 0x174ea6 : 0xffffff));
@@ -202,12 +293,12 @@ function makeFallback(kind: ActorKind, index = 0) {
   return group;
 }
 
-function createActor(scene: THREE.Scene, loader: GLTFLoader, kind: ActorKind, pos: THREE.Vector3, index = 0): Actor {
+function createActor(scene: THREE.Scene, loader: GLTFLoader, kind: ActorKind, pos: THREE.Vector3, index = 0, kitColor?: number, modelUrl = HUMAN_URL): Actor {
   const root = new THREE.Group();
   root.position.copy(pos).setY(GROUND_Y);
   scene.add(root);
 
-  const fallback = makeFallback(kind, index);
+  const fallback = makeFallback(kind, index, kitColor);
   root.add(fallback);
 
   const actor: Actor = {
@@ -229,14 +320,17 @@ function createActor(scene: THREE.Scene, loader: GLTFLoader, kind: ActorKind, po
     diveDelay: 0,
     diveDir: 0,
     diveHeight: 1.15,
+    saveTargetX: 0,
+    saveTargetY: 1.15,
     wallIndex: index,
     loaded: false,
+    celebrateTime: 0,
   };
 
-  loader.setCrossOrigin("anonymous").load(HUMAN_URL, (gltf) => {
+  loader.setCrossOrigin("anonymous").load(modelUrl, (gltf) => {
     const model = gltf.scene;
     normalizeHuman(model, kind === "keeper" ? 1.9 : PLAYER_H);
-    tintModel(model, kind, index);
+    tintModel(model, kind, index, kitColor);
     shadow(model);
     root.add(model);
     fallback.visible = false;
@@ -257,6 +351,32 @@ function createActor(scene: THREE.Scene, loader: GLTFLoader, kind: ActorKind, po
       actor.actions[name] = action;
     });
     actor.loaded = true;
+  }, undefined, () => {
+    if (modelUrl === HUMAN_URL) return;
+    loader.setCrossOrigin("anonymous").load(HUMAN_URL, (gltf) => {
+      const model = gltf.scene;
+      normalizeHuman(model, kind === "keeper" ? 1.9 : PLAYER_H);
+      tintModel(model, kind, index, kitColor);
+      shadow(model);
+      root.add(model);
+      fallback.visible = false;
+      actor.model = model;
+      actor.bones = findBones(model);
+      actor.mixer = new THREE.AnimationMixer(model);
+      const clips = new Map(gltf.animations.map((clip) => [clip.name.toLowerCase(), clip]));
+      const aliases: Record<AnimName, string[]> = { Idle: ["idle"], Walk: ["walk"], Run: ["run"] };
+      (Object.keys(aliases) as AnimName[]).forEach((name) => {
+        const clip = aliases[name].map((key) => clips.get(key)).find(Boolean);
+        if (!clip || !actor.mixer) return;
+        const action = actor.mixer.clipAction(clip);
+        action.enabled = true;
+        action.setLoop(THREE.LoopRepeat, Infinity);
+        action.setEffectiveWeight(name === "Idle" ? 1 : 0);
+        action.play();
+        actor.actions[name] = action;
+      });
+      actor.loaded = true;
+    });
   });
 
   return actor;
@@ -342,6 +462,77 @@ function applyKeeperPose(keeper: Actor) {
   if (keeper.bones.rightArm) keeper.bones.rightArm.rotation.z += -keeper.diveDir * 1.65 * a;
 }
 
+function applySeatedSpectatorPose(actor: Actor, cheerTime = 0) {
+  const cheer = cheerTime > 0;
+  const phase = performance.now() * 0.006 + actor.wallIndex * 0.73;
+  const wave = Math.sin(phase) * (cheer ? 0.55 : 0.08);
+  const standPhase = cheer ? Math.sin(THREE.MathUtils.clamp(cheerTime / 3.0, 0, 1) * Math.PI) : 0;
+  const standLift = standPhase * 0.46;
+  actor.root.position.copy(actor.pos).add(new THREE.Vector3(0, standLift, 0));
+  actor.root.rotation.x = 0;
+  actor.root.rotation.z = 0;
+  if (actor.dir.lengthSq() > 0.001) actor.root.rotation.y = Math.atan2(actor.dir.x, actor.dir.z);
+  setAction(actor, "Idle");
+  actor.mixer?.update(1 / 60);
+  if (actor.bones.hips) actor.bones.hips.rotation.x += cheer ? -0.03 * wave : -0.18;
+  if (actor.bones.spine) {
+    actor.bones.spine.rotation.x += cheer ? 0.08 + wave * 0.05 : 0.28;
+    actor.bones.spine.rotation.z += cheer ? wave * 0.08 : 0;
+  }
+  const thigh = cheer ? -0.16 : -1.18;
+  const shin = cheer ? 0.22 : 1.34;
+  if (actor.bones.leftUpLeg) actor.bones.leftUpLeg.rotation.x += thigh;
+  if (actor.bones.rightUpLeg) actor.bones.rightUpLeg.rotation.x += thigh;
+  if (actor.bones.leftLeg) actor.bones.leftLeg.rotation.x += shin;
+  if (actor.bones.rightLeg) actor.bones.rightLeg.rotation.x += shin;
+  if (actor.bones.leftArm) {
+    actor.bones.leftArm.rotation.x += cheer ? -2.05 + wave * 0.18 : -0.52;
+    actor.bones.leftArm.rotation.z += cheer ? -0.78 + wave * 0.32 : -0.18;
+  }
+  if (actor.bones.rightArm) {
+    actor.bones.rightArm.rotation.x += cheer ? -2.05 - wave * 0.18 : -0.52;
+    actor.bones.rightArm.rotation.z += cheer ? 0.78 + wave * 0.32 : 0.18;
+  }
+}
+
+function applyGoalDancePose(kicker: Actor) {
+  if (kicker.celebrateTime <= 0) return;
+  const t = 1 - kicker.celebrateTime / 2.45;
+  const beat = Math.sin(t * Math.PI * 8);
+  const sway = Math.sin(t * Math.PI * 4);
+  kicker.root.position.y += Math.max(0, Math.abs(beat)) * 0.14;
+  kicker.root.rotation.y += sway * 0.18;
+  if (kicker.bones.hips) {
+    kicker.bones.hips.rotation.y += sway * 0.26;
+    kicker.bones.hips.rotation.z += beat * 0.08;
+  }
+  if (kicker.bones.spine) {
+    kicker.bones.spine.rotation.x += 0.12 + Math.abs(beat) * 0.1;
+    kicker.bones.spine.rotation.z += -sway * 0.14;
+  }
+  if (kicker.bones.leftArm) {
+    kicker.bones.leftArm.rotation.x += -1.85 + beat * 0.2;
+    kicker.bones.leftArm.rotation.z += -0.74 + sway * 0.28;
+  }
+  if (kicker.bones.rightArm) {
+    kicker.bones.rightArm.rotation.x += -1.85 - beat * 0.2;
+    kicker.bones.rightArm.rotation.z += 0.74 + sway * 0.28;
+  }
+  if (kicker.bones.leftUpLeg) kicker.bones.leftUpLeg.rotation.x += -0.16 + Math.max(0, beat) * 0.32;
+  if (kicker.bones.rightUpLeg) kicker.bones.rightUpLeg.rotation.x += -0.16 + Math.max(0, -beat) * 0.32;
+  if (kicker.bones.leftLeg) kicker.bones.leftLeg.rotation.x += 0.18;
+  if (kicker.bones.rightLeg) kicker.bones.rightLeg.rotation.x += 0.18;
+}
+
+function triggerCrowdCheer(stadium: StadiumRig) {
+  stadium.cheerTime = 3.0;
+}
+
+function updateStadiumCrowd(stadium: StadiumRig, dt: number) {
+  if (stadium.cheerTime > 0) stadium.cheerTime = Math.max(0, stadium.cheerTime - dt);
+  stadium.spectators.forEach((spectator) => applySeatedSpectatorPose(spectator, stadium.cheerTime));
+}
+
 function createSoccerBallTexture() {
   const canvas = document.createElement("canvas");
   canvas.width = 512;
@@ -404,6 +595,8 @@ function makeBall(scene: THREE.Scene): BallState {
     netCaught: false,
     netAge: 0,
     netVel: new THREE.Vector3(),
+    crossedGoalLine: false,
+    hitFrame: false,
   };
 }
 
@@ -450,10 +643,170 @@ function makeCylinderBetween(a: THREE.Vector3, b: THREE.Vector3, radius: number,
 function makeGoal(scene: THREE.Scene, netRig: NetRig) { const root = new THREE.Group(); root.position.z = GOAL_LINE_Z; const white = material(0xffffff, 0.4, 0.18); const rear = material(0xcbd5e1, 0.46, 0.28); const backScale = 0.82; const backW = GOAL_W * backScale; const backH = GOAL_H * backScale; const FL = new THREE.Vector3(-GOAL_W / 2, 0, 0); const FR = new THREE.Vector3(GOAL_W / 2, 0, 0); const FLT = new THREE.Vector3(-GOAL_W / 2, GOAL_H, 0); const FRT = new THREE.Vector3(GOAL_W / 2, GOAL_H, 0); const BL = new THREE.Vector3(-backW / 2, 0.03, -GOAL_D); const BR = new THREE.Vector3(backW / 2, 0.03, -GOAL_D); const BLT = new THREE.Vector3(-backW / 2, backH, -GOAL_D); const BRT = new THREE.Vector3(backW / 2, backH, -GOAL_D); root.add(makeCylinderBetween(FL, FLT, POST_R, white), makeCylinderBetween(FR, FRT, POST_R, white), makeCylinderBetween(FLT, FRT, POST_R, white), makeCylinderBetween(BL, BLT, POST_R * 0.48, rear), makeCylinderBetween(BR, BRT, POST_R * 0.48, rear), makeCylinderBetween(BLT, BRT, POST_R * 0.48, rear), makeCylinderBetween(FLT, BLT, POST_R * 0.42, rear), makeCylinderBetween(FRT, BRT, POST_R * 0.42, rear), makeCylinderBetween(FL, BL, POST_R * 0.36, rear), makeCylinderBetween(FR, BR, POST_R * 0.36, rear)); root.add(makeNetSurface(netRig, BL, BR, BRT, BLT, 18, 10)); root.add(makeNetSurface(netRig, FLT, FRT, BRT, BLT, 18, 8)); root.add(makeNetSurface(netRig, FL, BL, BLT, FLT, 8, 10)); root.add(makeNetSurface(netRig, FR, BR, BRT, FRT, 8, 10)); scene.add(root); }
 function triggerNetShake(netRig: NetRig, impact: THREE.Vector3) { netRig.shake = 1.35; netRig.impact.copy(impact).sub(new THREE.Vector3(0, 0, GOAL_LINE_Z)); }
 function updateNetShake(netRig: NetRig, dt: number) { if (netRig.shake <= 0) return; const time = performance.now() * 0.02; const strength = netRig.shake; netRig.lines.forEach((line, idx) => { const base = line.userData.base as THREE.Vector3[]; const attr = line.geometry.getAttribute("position") as THREE.BufferAttribute; for (let i = 0; i < 2; i++) { const p = base[i]; const distance = Math.max(0.28, p.distanceTo(netRig.impact)); const falloff = THREE.MathUtils.clamp(1.65 / distance, 0, 1.4); const wave = Math.sin(time + idx * 0.37 + i * 1.7) * 0.24 * strength * falloff; attr.setXYZ(i, p.x + wave * 0.36, p.y + Math.abs(wave) * 0.28, p.z - Math.abs(wave) * 1.45); } attr.needsUpdate = true; }); netRig.shake = Math.max(0, netRig.shake - dt * 1.65); }
-function makeBillboardsAndStands(scene: THREE.Scene) { const boardGroup = new THREE.Group(); const zBoard = GOAL_LINE_Z - GOAL_D - 0.75; const boardColors = [0x2563eb, 0xef4444, 0x16a34a, 0xfacc15, 0x7c3aed, 0x0ea5e9]; for (let i = 0; i < 6; i++) { const x = (i - 2.5) * 3.15; const board = new THREE.Mesh(new THREE.BoxGeometry(2.95, 0.82, 0.08), material(boardColors[i], 0.5, 0.02)); board.position.set(x, 0.55, zBoard); const top = new THREE.Mesh(new THREE.BoxGeometry(2.95, 0.08, 0.1), material(0xffffff, 0.55, 0.02)); top.position.set(x, 1.0, zBoard + 0.01); const textBar = new THREE.Mesh(new THREE.BoxGeometry(1.7, 0.12, 0.105), material(0xffffff, 0.55, 0.02)); textBar.position.set(x, 0.55, zBoard + 0.015); boardGroup.add(shadow(board), shadow(top), shadow(textBar)); } scene.add(boardGroup); }
+function makeChair(color: number) {
+  const chair = new THREE.Group();
+  const plastic = material(color, 0.62, 0.02);
+  const seat = new THREE.Mesh(new THREE.BoxGeometry(0.42, 0.08, 0.4), plastic);
+  seat.position.y = 0.28;
+  const back = new THREE.Mesh(new THREE.BoxGeometry(0.42, 0.46, 0.08), plastic);
+  back.position.set(0, 0.55, -0.16);
+  const legMat = material(0x334155, 0.45, 0.18);
+  const legs = [
+    [-0.16, 0.13, -0.12], [0.16, 0.13, -0.12], [-0.16, 0.13, 0.14], [0.16, 0.13, 0.14],
+  ].map(([x, y, z]) => {
+    const leg = new THREE.Mesh(new THREE.BoxGeometry(0.04, 0.28, 0.04), legMat);
+    leg.position.set(x, y, z);
+    return leg;
+  });
+  chair.add(shadow(seat), shadow(back), ...legs.map((leg) => shadow(leg)));
+  return chair;
+}
+
+function makeBillboardsAndStands(scene: THREE.Scene, loader: GLTFLoader): StadiumRig {
+  const boardGroup = new THREE.Group();
+  const zBoard = GOAL_LINE_Z - GOAL_D - 0.75;
+  const boardColors = [0x2563eb, 0xef4444, 0x16a34a, 0xfacc15, 0x7c3aed, 0x0ea5e9];
+  for (let i = 0; i < 6; i++) {
+    const x = (i - 2.5) * 3.15;
+    const board = new THREE.Mesh(new THREE.BoxGeometry(2.95, 0.82, 0.08), material(boardColors[i], 0.5, 0.02));
+    board.position.set(x, 0.55, zBoard);
+    const top = new THREE.Mesh(new THREE.BoxGeometry(2.95, 0.08, 0.1), material(0xffffff, 0.55, 0.02));
+    top.position.set(x, 1.0, zBoard + 0.01);
+    const textBar = new THREE.Mesh(new THREE.BoxGeometry(1.7, 0.12, 0.105), material(0xffffff, 0.55, 0.02));
+    textBar.position.set(x, 0.55, zBoard + 0.015);
+    boardGroup.add(shadow(board), shadow(top), shadow(textBar));
+  }
+  scene.add(boardGroup);
+
+  const stands = new THREE.Group();
+  stands.position.z = GOAL_LINE_Z - GOAL_D - 2.2;
+  const concrete = material(0x8c99a8, 0.9, 0.02);
+  const riserMat = material(0x64748b, 0.85, 0.03);
+  const aisleMat = material(0xe2e8f0, 0.78, 0.02);
+  const railMat = material(0xf8fafc, 0.38, 0.2);
+  const rows = 7;
+  const rowDepth = 0.86;
+  const rowRise = 0.34;
+  const width = FIELD_W + 5.2;
+  const stairXs = [-6.35, 0, 6.35];
+
+  for (let row = 0; row < rows; row++) {
+    const z = -row * rowDepth;
+    const y = 0.18 + row * rowRise;
+    const tread = new THREE.Mesh(new THREE.BoxGeometry(width, 0.16, rowDepth), concrete);
+    tread.position.set(0, y, z);
+    const riser = new THREE.Mesh(new THREE.BoxGeometry(width, rowRise, 0.08), riserMat);
+    riser.position.set(0, y - 0.03, z + rowDepth * 0.46);
+    const lip = new THREE.Mesh(new THREE.BoxGeometry(width, 0.045, 0.07), railMat);
+    lip.position.set(0, y + 0.12, z + rowDepth * 0.46);
+    stands.add(shadow(tread), shadow(riser), shadow(lip));
+  }
+
+  stairXs.forEach((x) => {
+    for (let row = 0; row < rows; row++) {
+      const stair = new THREE.Mesh(new THREE.BoxGeometry(0.78, 0.11, rowDepth * 0.78), aisleMat);
+      stair.position.set(x, 0.32 + row * rowRise, -row * rowDepth + 0.02);
+      stands.add(shadow(stair));
+      const nose = new THREE.Mesh(new THREE.BoxGeometry(0.78, 0.035, 0.05), material(0xffffff, 0.72, 0.01));
+      nose.position.set(x, 0.4 + row * rowRise, -row * rowDepth + rowDepth * 0.38);
+      stands.add(shadow(nose));
+    }
+    const railPostCount = rows + 1;
+    for (let i = 0; i < railPostCount; i++) {
+      const postZ = -i * rowDepth + rowDepth * 0.28;
+      const postY = 0.65 + i * rowRise;
+      [-0.46, 0.46].forEach((side) => {
+        const post = new THREE.Mesh(new THREE.CylinderGeometry(0.025, 0.025, 0.62, 10), railMat);
+        post.position.set(x + side, postY, postZ);
+        stands.add(shadow(post));
+      });
+    }
+    [-0.46, 0.46].forEach((side) => {
+      const rail = makeCylinderBetween(
+        new THREE.Vector3(x + side, 0.86, rowDepth * 0.3),
+        new THREE.Vector3(x + side, 0.86 + rows * rowRise, -(rows - 1) * rowDepth + rowDepth * 0.25),
+        0.022,
+        railMat
+      );
+      stands.add(rail);
+    });
+  });
+
+  const chairColors = [0x1d4ed8, 0xffffff];
+  const spectators: Actor[] = [];
+  let characterIndex = 0;
+  for (let row = 0; row < rows; row++) {
+    for (let col = 0; col < 26; col++) {
+      const x = (col - 12.5) * 0.78;
+      if (stairXs.some((aisleX) => Math.abs(x - aisleX) < 0.58)) continue;
+      const z = stands.position.z - row * rowDepth + 0.04;
+      const y = 0.38 + row * rowRise;
+      const chair = makeChair(chairColors[(row + col) % chairColors.length]);
+      chair.position.set(x, y, -row * rowDepth + 0.04);
+      chair.rotation.y = 0;
+      stands.add(chair);
+
+      if (characterIndex < MURLAN_CHARACTER_THEMES.length) {
+        const kit = MURLAN_CHARACTER_COLORS[characterIndex % MURLAN_CHARACTER_COLORS.length];
+        const spectator = createActor(scene, loader, "wall", new THREE.Vector3(x, y + stands.position.y + 0.04, z + 0.08), characterIndex, kit, MURLAN_CHARACTER_URLS[characterIndex % Math.max(1, MURLAN_CHARACTER_URLS.length)] ?? HUMAN_URL);
+        spectator.dir.set(-x * 0.08, 0, 1).normalize();
+        spectator.wallIndex = characterIndex;
+        spectator.root.scale.setScalar(0.68);
+        spectators.push(spectator);
+        characterIndex += 1;
+      }
+    }
+  }
+
+  const backWall = new THREE.Mesh(new THREE.BoxGeometry(width + 0.9, rows * rowRise + 1.2, 0.28), material(0x475569, 0.72, 0.06));
+  backWall.position.set(0, 1.08 + rows * rowRise, -(rows - 1) * rowDepth - 0.62);
+  stands.add(shadow(backWall));
+
+  const frontRail = new THREE.Mesh(new THREE.BoxGeometry(width + 0.4, 0.08, 0.08), railMat);
+  frontRail.position.set(0, 1.05, 0.62);
+  stands.add(shadow(frontRail));
+  [-width / 2 - 0.22, width / 2 + 0.22].forEach((x) => {
+    const sideWall = new THREE.Mesh(new THREE.BoxGeometry(0.18, rows * rowRise + 0.7, rows * rowDepth + 0.8), material(0x5b6472, 0.82, 0.04));
+    sideWall.position.set(x, 0.72 + rows * rowRise * 0.5, -((rows - 1) * rowDepth) / 2);
+    stands.add(shadow(sideWall));
+  });
+
+  scene.add(stands);
+  return { spectators, cheerTime: 0 };
+}
+
+
 function addLine(scene: THREE.Scene, points: THREE.Vector3[], color = 0xffffff, opacity = 0.9) { const line = new THREE.Line(new THREE.BufferGeometry().setFromPoints(points.map((p) => new THREE.Vector3(p.x, 0.018, p.z))), new THREE.LineBasicMaterial({ color, transparent: true, opacity })); scene.add(line); return line; }
 function addRect(scene: THREE.Scene, left: number, right: number, frontZ: number, backZ: number) { addLine(scene, [new THREE.Vector3(left, 0, frontZ), new THREE.Vector3(left, 0, backZ), new THREE.Vector3(right, 0, backZ), new THREE.Vector3(right, 0, frontZ)]); }
-function makeHalfField(scene: THREE.Scene, netRig: NetRig) { const grassA = material(0x1d7d39, 0.95, 0); const grassB = material(0x16692e, 0.95, 0); for (let i = 0; i < 10; i++) { const stripe = new THREE.Mesh(new THREE.PlaneGeometry(FIELD_W, HALF_H / 10), i % 2 ? grassA : grassB); stripe.rotation.x = -Math.PI / 2; stripe.position.z = -HALF_H / 2 + HALF_H / 20 + (i * HALF_H) / 10; stripe.receiveShadow = true; scene.add(stripe); } const w = FIELD_W / 2; const h = HALF_H / 2; addLine(scene, [new THREE.Vector3(-w, 0, -h), new THREE.Vector3(w, 0, -h), new THREE.Vector3(w, 0, h), new THREE.Vector3(-w, 0, h), new THREE.Vector3(-w, 0, -h)]); addLine(scene, [new THREE.Vector3(-w, 0, h), new THREE.Vector3(w, 0, h)]); addRect(scene, -PENALTY_W / 2, PENALTY_W / 2, -h, -h + PENALTY_D); addRect(scene, -GOAL_AREA_W / 2, GOAL_AREA_W / 2, -h, -h + GOAL_AREA_D); const penaltySpot = new THREE.Mesh(new THREE.CircleGeometry(0.08, 28), new THREE.MeshBasicMaterial({ color: 0xffffff })); penaltySpot.rotation.x = -Math.PI / 2; penaltySpot.position.set(0, 0.022, -h + PENALTY_SPOT_D); scene.add(penaltySpot); const boxTopZ = -h + PENALTY_D; const spotZ = -h + PENALTY_SPOT_D; const theta = Math.acos((boxTopZ - spotZ) / ARC_R); const arcPts = new THREE.EllipseCurve(0, spotZ, ARC_R, ARC_R, theta, Math.PI - theta).getPoints(96).map((p) => new THREE.Vector3(p.x, 0, p.y)); addLine(scene, arcPts); makeGoal(scene, netRig); makeBillboardsAndStands(scene); }
+function makeHalfField(scene: THREE.Scene, netRig: NetRig, loader: GLTFLoader): StadiumRig {
+  const grassA = material(0x1d7d39, 0.95, 0);
+  const grassB = material(0x16692e, 0.95, 0);
+  for (let i = 0; i < 10; i++) {
+    const stripe = new THREE.Mesh(new THREE.PlaneGeometry(FIELD_W, HALF_H / 10), i % 2 ? grassA : grassB);
+    stripe.rotation.x = -Math.PI / 2;
+    stripe.position.z = -HALF_H / 2 + HALF_H / 20 + (i * HALF_H) / 10;
+    stripe.receiveShadow = true;
+    scene.add(stripe);
+  }
+  const w = FIELD_W / 2;
+  const h = HALF_H / 2;
+  addLine(scene, [new THREE.Vector3(-w, 0, -h), new THREE.Vector3(w, 0, -h), new THREE.Vector3(w, 0, h), new THREE.Vector3(-w, 0, h), new THREE.Vector3(-w, 0, -h)]);
+  addLine(scene, [new THREE.Vector3(-w, 0, h), new THREE.Vector3(w, 0, h)]);
+  addRect(scene, -PENALTY_W / 2, PENALTY_W / 2, -h, -h + PENALTY_D);
+  addRect(scene, -GOAL_AREA_W / 2, GOAL_AREA_W / 2, -h, -h + GOAL_AREA_D);
+  const penaltySpot = new THREE.Mesh(new THREE.CircleGeometry(0.08, 28), new THREE.MeshBasicMaterial({ color: 0xffffff }));
+  penaltySpot.rotation.x = -Math.PI / 2;
+  penaltySpot.position.set(0, 0.022, -h + PENALTY_SPOT_D);
+  scene.add(penaltySpot);
+  const boxTopZ = -h + PENALTY_D;
+  const spotZ = -h + PENALTY_SPOT_D;
+  const theta = Math.acos((boxTopZ - spotZ) / ARC_R);
+  const arcPts = new THREE.EllipseCurve(0, spotZ, ARC_R, ARC_R, theta, Math.PI - theta).getPoints(96).map((p) => new THREE.Vector3(p.x, 0, p.y));
+  addLine(scene, arcPts);
+  makeGoal(scene, netRig);
+  return makeBillboardsAndStands(scene, loader);
+}
+
 function makeAimLine(scene: THREE.Scene) { const geometry = new THREE.BufferGeometry(); geometry.setAttribute("position", new THREE.BufferAttribute(new Float32Array(34 * 3), 3)); const line = new THREE.Line(geometry, new THREE.LineBasicMaterial({ color: 0xfff200, transparent: true, opacity: 0.95 })); scene.add(line); return line; }
 function shotPoint(start: THREE.Vector3, target: THREE.Vector3, curve: number, lift: number, t: number) { const p = start.clone().lerp(target, t); p.x += curve * Math.sin(t * Math.PI); p.y = BALL_R + lift * Math.sin(t * Math.PI) + (target.y - BALL_R) * t; return p; }
 function swipeToShot(ballPos: THREE.Vector3, swipe: SwipeState) { const dx = swipe.endX - swipe.startX; const dy = swipe.startY - swipe.endY; const targetX = THREE.MathUtils.clamp(dx / 34, -GOAL_W / 2 + 0.2, GOAL_W / 2 - 0.2); const targetY = THREE.MathUtils.clamp(0.45 + dy / 82, 0.22, GOAL_H + 1.3); const target = new THREE.Vector3(targetX, targetY, GOAL_LINE_Z - 0.2); const curve = THREE.MathUtils.clamp(dx / 58, -6.0, 6.0); const lift = THREE.MathUtils.clamp(dy / 65, 0.35, GOAL_H + 2.4); const power = THREE.MathUtils.clamp(Math.hypot(dx, dy) / 123, 0.48, 1.72); const distance = ballPos.distanceTo(target); const duration = THREE.MathUtils.clamp(distance / (18.7 + power * 10.4), 0.72, 1.34); return { target, curve, lift, power, duration }; }
@@ -463,16 +816,265 @@ function freeKickPosition(spot: KickSpot) { if (spot === "left") return new THRE
 function wallCountForSpot(spot: KickSpot) { if (spot === "left" || spot === "right") return 3; if (spot === "near16") return 5; return 4; }
 function wallCenterForBall(ballPos: THREE.Vector3) { const goalCenter = new THREE.Vector3(0, 0, GOAL_LINE_Z); const toGoal = goalCenter.sub(ballPos).setY(0).normalize(); return ballPos.clone().addScaledVector(toGoal, WALL_DISTANCE).setY(0); }
 function placeWall(wall: Actor[], spot: KickSpot, ballPos: THREE.Vector3) { const count = wallCountForSpot(spot); const center = wallCenterForBall(ballPos); const toBall = ballPos.clone().sub(center).setY(0).normalize(); const side = new THREE.Vector3(toBall.z, 0, -toBall.x).normalize(); wall.forEach((actor, i) => { actor.root.visible = i < count; const offset = i - (count - 1) / 2; actor.pos.copy(center).addScaledVector(side, offset * 0.62).setY(0); actor.dir.copy(ballPos.clone().sub(actor.pos).setY(0).normalize()); actor.vel.set(0, 0, 0); actor.speed = 0; actor.jumpTime = 0; }); }
-function resetShot(ball: BallState, kicker: Actor, keeper: Actor, wall: Actor[], spot: KickSpot) { const ballPos = freeKickPosition(spot); ball.object.position.copy(ballPos); ball.vel.set(0, 0, 0); ball.spin.set(0, 0, 0); ball.curve = 0; ball.shotAge = 0; ball.shotDuration = 1.05; ball.lift = 1; ball.flying = false; ball.netCaught = false; ball.netAge = 0; ball.netVel.set(0, 0, 0); ball.shotStart.copy(ballPos); ball.shotTarget.set(0, BALL_R, GOAL_LINE_Z); ball.lastPos.copy(ballPos); ball.knuckleSeed = Math.random() * 100; const toGoal = new THREE.Vector3(0, 0, GOAL_LINE_Z).sub(ballPos).setY(0).normalize(); const runupStart = ballPos.clone().addScaledVector(toGoal, -RUNUP_BACK_STEPS).add(new THREE.Vector3(-0.42, -BALL_R, 0)).setY(0); kicker.pos.copy(runupStart); kicker.dir.copy(ballPos.clone().sub(kicker.pos).setY(0).normalize()); kicker.vel.set(0, 0, 0); kicker.speed = 0; kicker.kickTime = 0; keeper.pos.set(0, 0, GOAL_LINE_Z + 0.36); keeper.dir.set(0, 0, 1); keeper.vel.set(0, 0, 0); keeper.speed = 0; keeper.diveTime = 0; keeper.diveDelay = 0; keeper.diveDir = 0; keeper.diveHeight = 1.15; placeWall(wall, spot, ballPos); }
-function predictShotResult(ballPos: THREE.Vector3, swipe: SwipeState) { const shot = swipeToShot(ballPos, swipe); const final = shotPoint(ballPos, shot.target, shot.curve, shot.lift, 1); return { shot, final }; }
-function beginRunup(kicker: Actor, wall: Actor[], keeper: Actor, ball: BallState, swipe: SwipeState) { kicker.kickTime = 0.72; wall.forEach((w) => (w.jumpTime = 0.42)); const { final } = predictShotResult(ball.object.position, swipe); const targetSide = final.x < -0.22 ? -1 : final.x > 0.22 ? 1 : 0; const targetHeight = THREE.MathUtils.clamp(final.y, 0.35, GOAL_H + 0.35); const quality = Math.random(); keeper.diveDir = quality < 0.06 ? -targetSide || (Math.random() > 0.5 ? 1 : -1) : targetSide; keeper.diveHeight = targetHeight < 0.8 ? 0.58 : targetHeight > 1.68 ? 1.82 : 1.16; keeper.diveDelay = quality > 0.72 ? 0.08 : quality > 0.32 ? 0.15 : 0.22; keeper.diveTime = 0; }
-function shootBall(ball: BallState, swipe: SwipeState) { const shot = swipeToShot(ball.object.position, swipe); ball.curve = shot.curve; ball.lift = shot.lift; ball.shotAge = 0; ball.shotDuration = shot.duration; ball.shotStart.copy(ball.object.position); ball.shotTarget.copy(shot.target); ball.lastPos.copy(ball.object.position); ball.netCaught = false; ball.netAge = 0; ball.netVel.set(0, 0, 0); ball.spin.set(shot.curve * 0.2, shot.curve * 22.0, -shot.curve * 12.0); ball.flying = true; }
-function updateBall(ball: BallState, dt: number) { if (ball.netCaught) { ball.netAge += dt; ball.netVel.y -= 1.2 * dt; ball.netVel.multiplyScalar(Math.pow(0.82, dt * 60)); ball.object.position.addScaledVector(ball.netVel, dt); ball.object.position.z = THREE.MathUtils.clamp(ball.object.position.z, GOAL_LINE_Z - GOAL_D + 0.18, GOAL_LINE_Z - 0.18); ball.object.position.y = Math.max(BALL_R, ball.object.position.y); const spinLen = ball.netVel.length() / BALL_R; if (spinLen > 0.001) { QTMP.setFromAxisAngle(new THREE.Vector3(1, 0.2, 0).normalize(), spinLen * dt); ball.object.quaternion.premultiply(QTMP); } if (ball.netAge > 1.15 || ball.netVel.length() < 0.04) ball.flying = false; return; } if (!ball.flying) return; ball.shotAge += dt; const t = THREE.MathUtils.clamp(ball.shotAge / ball.shotDuration, 0, 1); const eased = 1 - Math.pow(1 - t, 1.25); const next = shotPoint(ball.shotStart, ball.shotTarget, ball.curve, ball.lift, eased); ball.vel.copy(next).sub(ball.lastPos).divideScalar(Math.max(0.0001, dt)); ball.object.position.copy(next); const move = next.clone().sub(ball.lastPos); const dist = move.length(); if (dist > 0.0001) { const rollAxis = new THREE.Vector3(move.z, 0, -move.x).normalize(); const rollAngle = dist / BALL_R; QTMP.setFromAxisAngle(rollAxis, rollAngle); ball.object.quaternion.premultiply(QTMP); } const curveSpin = Math.abs(ball.curve) * 0.08 + 0.04; QTMP.setFromAxisAngle(new THREE.Vector3(0, Math.sign(ball.curve || 1), 0), curveSpin); ball.object.quaternion.premultiply(QTMP); ball.lastPos.copy(next); if (t >= 1) ball.flying = false; }
-function keeperSaveCheck(keeper: Actor, ball: BallState, dt: number) { if (!ball.flying || ball.netCaught) return false; if (keeper.diveDelay > 0) { keeper.diveDelay = Math.max(0, keeper.diveDelay - dt); if (keeper.diveDelay <= 0) keeper.diveTime = 0.9; } const lateralStep = keeper.diveDir * 0.9 * Math.max(0, 1 - keeper.diveDelay * 4.5); keeper.pos.x = THREE.MathUtils.lerp(keeper.pos.x, lateralStep, 0.09); const handReach = keeper.diveDir === 0 ? 0.92 : 1.28; const keeperCenter = keeper.pos.clone().add(new THREE.Vector3(keeper.diveDir * 1.55, keeper.diveHeight, 0)); const nearGoal = ball.object.position.z < GOAL_LINE_Z + 1.65; if (nearGoal && keeperCenter.distanceTo(ball.object.position) < handReach) { ball.flying = false; return true; } return false; }
+function resetShot(ball: BallState, kicker: Actor, keeper: Actor, wall: Actor[], spot: KickSpot) {
+  const ballPos = freeKickPosition(spot);
+  ball.object.position.copy(ballPos);
+  ball.vel.set(0, 0, 0);
+  ball.spin.set(0, 0, 0);
+  ball.curve = 0;
+  ball.shotAge = 0;
+  ball.shotDuration = 1.05;
+  ball.lift = 1;
+  ball.flying = false;
+  ball.netCaught = false;
+  ball.netAge = 0;
+  ball.netVel.set(0, 0, 0);
+  ball.crossedGoalLine = false;
+  ball.hitFrame = false;
+  ball.shotStart.copy(ballPos);
+  ball.shotTarget.set(0, BALL_R, GOAL_LINE_Z);
+  ball.lastPos.copy(ballPos);
+  ball.knuckleSeed = Math.random() * 100;
+
+  const toGoal = new THREE.Vector3(0, 0, GOAL_LINE_Z).sub(ballPos).setY(0).normalize();
+  const runupStart = ballPos.clone().addScaledVector(toGoal, -RUNUP_BACK_STEPS).add(new THREE.Vector3(-0.42, -BALL_R, 0)).setY(0);
+  kicker.pos.copy(runupStart);
+  kicker.dir.copy(ballPos.clone().sub(kicker.pos).setY(0).normalize());
+  kicker.vel.set(0, 0, 0);
+  kicker.speed = 0;
+  kicker.kickTime = 0;
+
+  keeper.pos.set(0, 0, GOAL_LINE_Z + 0.36);
+  keeper.dir.set(0, 0, 1);
+  keeper.vel.set(0, 0, 0);
+  keeper.speed = 0;
+  keeper.diveTime = 0;
+  keeper.diveDelay = 0;
+  keeper.diveDir = 0;
+  keeper.diveHeight = 1.15;
+  keeper.saveTargetX = 0;
+  keeper.saveTargetY = 1.15;
+
+  placeWall(wall, spot, ballPos);
+}
+
+function predictShotResult(ballPos: THREE.Vector3, swipe: SwipeState) {
+  const shot = swipeToShot(ballPos, swipe);
+  const final = shotPoint(ballPos, shot.target, shot.curve, shot.lift, 1);
+  let goalLine = final.clone();
+  for (let i = 0; i <= 48; i++) {
+    const t = i / 48;
+    const p = shotPoint(ballPos, shot.target, shot.curve, shot.lift, t);
+    if (p.z <= GOAL_LINE_Z) {
+      goalLine = p;
+      break;
+    }
+  }
+  return { shot, final, goalLine };
+}
+
+function beginRunup(kicker: Actor, wall: Actor[], keeper: Actor, ball: BallState, swipe: SwipeState) {
+  kicker.kickTime = 0.72;
+  wall.forEach((w) => (w.jumpTime = 0.42));
+
+  const { goalLine } = predictShotResult(ball.object.position, swipe);
+  keeper.saveTargetX = THREE.MathUtils.clamp(goalLine.x, -GOAL_W / 2 + 0.28, GOAL_W / 2 - 0.28);
+  keeper.saveTargetY = THREE.MathUtils.clamp(goalLine.y, 0.35, GOAL_H + 0.15);
+
+  const targetSide = keeper.saveTargetX < -0.28 ? -1 : keeper.saveTargetX > 0.28 ? 1 : 0;
+  const quality = Math.random();
+  keeper.diveDir = quality < 0.08 ? -targetSide || (Math.random() > 0.5 ? 1 : -1) : targetSide;
+  keeper.diveHeight = keeper.saveTargetY < 0.8 ? 0.62 : keeper.saveTargetY > 1.7 ? 1.78 : 1.18;
+  keeper.diveDelay = quality > 0.7 ? 0.06 : quality > 0.25 ? 0.12 : 0.18;
+  keeper.diveTime = 0;
+}
+
+function shootBall(ball: BallState, swipe: SwipeState) {
+  const shot = swipeToShot(ball.object.position, swipe);
+  ball.curve = shot.curve;
+  ball.lift = shot.lift;
+  ball.shotAge = 0;
+  ball.shotDuration = shot.duration;
+  ball.shotStart.copy(ball.object.position);
+  ball.shotTarget.copy(shot.target);
+  ball.lastPos.copy(ball.object.position);
+  ball.netCaught = false;
+  ball.netAge = 0;
+  ball.netVel.set(0, 0, 0);
+  ball.crossedGoalLine = false;
+  ball.hitFrame = false;
+  ball.spin.set(shot.curve * 0.2, shot.curve * 22.0, -shot.curve * 12.0);
+  ball.flying = true;
+}
+
+function rollBall(ball: BallState, move: THREE.Vector3, dt: number) {
+  const dist = move.length();
+  if (dist > 0.0001) {
+    const rollAxis = new THREE.Vector3(move.z, 0, -move.x).normalize();
+    const rollAngle = dist / BALL_R;
+    QTMP.setFromAxisAngle(rollAxis, rollAngle);
+    ball.object.quaternion.premultiply(QTMP);
+  }
+  const curveSpin = Math.abs(ball.curve) * 0.08 + 0.04;
+  QTMP.setFromAxisAngle(new THREE.Vector3(0, Math.sign(ball.curve || 1), 0), curveSpin * Math.max(1, dt * 60));
+  ball.object.quaternion.premultiply(QTMP);
+}
+
+function updateBall(ball: BallState, dt: number) {
+  if (ball.netCaught) {
+    ball.netAge += dt;
+    ball.netVel.y -= 1.2 * dt;
+    ball.netVel.multiplyScalar(Math.pow(0.82, dt * 60));
+    const prev = ball.object.position.clone();
+    ball.object.position.addScaledVector(ball.netVel, dt);
+    ball.object.position.z = THREE.MathUtils.clamp(ball.object.position.z, GOAL_LINE_Z - GOAL_D + 0.18, GOAL_LINE_Z - 0.18);
+    ball.object.position.y = Math.max(BALL_R, ball.object.position.y);
+    rollBall(ball, ball.object.position.clone().sub(prev), dt);
+    if (ball.netAge > 1.15 || ball.netVel.length() < 0.04) ball.flying = false;
+    ball.lastPos.copy(ball.object.position);
+    return;
+  }
+  if (!ball.flying) return;
+
+  const prev = ball.object.position.clone();
+  ball.shotAge += dt;
+
+  if (ball.shotAge <= ball.shotDuration) {
+    const t = THREE.MathUtils.clamp(ball.shotAge / ball.shotDuration, 0, 1);
+    const eased = 1 - Math.pow(1 - t, 1.25);
+    const next = shotPoint(ball.shotStart, ball.shotTarget, ball.curve, ball.lift, eased);
+    ball.vel.copy(next).sub(prev).divideScalar(Math.max(0.0001, dt));
+    ball.object.position.copy(next);
+  } else {
+    const knuckle = Math.sin(ball.shotAge * 12 + ball.knuckleSeed) * Math.abs(ball.curve) * 0.22;
+    ball.vel.x += (knuckle - ball.vel.x * 0.025) * dt;
+    ball.vel.y -= 8.6 * dt;
+    ball.vel.multiplyScalar(Math.pow(0.992, dt * 60));
+    ball.object.position.addScaledVector(ball.vel, dt);
+
+    if (ball.object.position.y <= BALL_R) {
+      ball.object.position.y = BALL_R;
+      if (Math.abs(ball.vel.y) > 0.9) ball.vel.y = -ball.vel.y * 0.34;
+      else ball.vel.y = 0;
+      ball.vel.x *= Math.pow(0.90, dt * 60);
+      ball.vel.z *= Math.pow(0.90, dt * 60);
+    }
+  }
+
+  rollBall(ball, ball.object.position.clone().sub(prev), dt);
+  ball.lastPos.copy(prev);
+
+  if (ball.object.position.y <= BALL_R + 0.01 && ball.vel.length() < 0.18) ball.flying = false;
+  if (ball.object.position.z < GOAL_LINE_Z - GOAL_D - 5.5 || Math.abs(ball.object.position.x) > FIELD_W * 0.85 || ball.object.position.y > GOAL_H + 8) ball.flying = false;
+}
+
+function segmentDistanceToBall(a: THREE.Vector3, b: THREE.Vector3, p: THREE.Vector3) {
+  const ab = b.clone().sub(a);
+  const t = THREE.MathUtils.clamp(p.clone().sub(a).dot(ab) / Math.max(0.0001, ab.lengthSq()), 0, 1);
+  return a.clone().addScaledVector(ab, t).distanceTo(p);
+}
+
+function keeperSaveCheck(keeper: Actor, ball: BallState, dt: number) {
+  if (!ball.flying || ball.netCaught) return false;
+  if (keeper.diveDelay > 0) {
+    keeper.diveDelay = Math.max(0, keeper.diveDelay - dt);
+    if (keeper.diveDelay <= 0) keeper.diveTime = 0.9;
+  }
+
+  const reaction = Math.max(0, 1 - keeper.diveDelay * 5.2);
+  const targetStep = THREE.MathUtils.clamp(keeper.saveTargetX * 0.42 + keeper.diveDir * 0.65, -1.55, 1.55);
+  keeper.pos.x = THREE.MathUtils.lerp(keeper.pos.x, targetStep, 0.12 * reaction + 0.035);
+
+  const nearGoal = ball.object.position.z < GOAL_LINE_Z + 1.85 && ball.object.position.z > GOAL_LINE_Z - 0.75;
+  if (!nearGoal) return false;
+
+  const bodyCenter = keeper.pos.clone().add(new THREE.Vector3(0, 1.05, 0));
+  const gloveCenter = keeper.pos.clone().add(new THREE.Vector3(keeper.diveDir * 1.48, keeper.diveHeight, 0));
+  const highGlove = keeper.pos.clone().add(new THREE.Vector3(keeper.diveDir * 1.92, keeper.diveHeight + 0.22, 0));
+  const bodyReach = 0.64;
+  const gloveReach = keeper.diveDir === 0 ? 1.08 : 1.5;
+
+  if (bodyCenter.distanceTo(ball.object.position) < bodyReach || gloveCenter.distanceTo(ball.object.position) < gloveReach || segmentDistanceToBall(gloveCenter, highGlove, ball.object.position) < BALL_R + 0.32) {
+    const push = ball.object.position.clone().sub(gloveCenter).setY(0).normalize();
+    if (push.lengthSq() < 0.001) push.set(keeper.diveDir || (ball.object.position.x < 0 ? -1 : 1), 0, 0.25).normalize();
+    ball.vel.set(push.x * 5.2, Math.max(1.4, ball.vel.y * 0.2 + 1.8), Math.max(1.2, Math.abs(ball.vel.z) * 0.28));
+    ball.object.position.addScaledVector(push, BALL_R * 1.2);
+    ball.shotAge = ball.shotDuration + 0.01;
+    return true;
+  }
+  return false;
+}
+
 function wallBlockCheck(wall: Actor[], ball: BallState) { if (!ball.flying || ball.netCaught) return false; for (const actor of wall) { if (!actor.root.visible) continue; const chest = actor.pos.clone().setY(actor.jumpTime > 0 ? 1.55 : 1.15); if (chest.distanceTo(ball.object.position) < 0.55) { ball.flying = false; return true; } } return false; }
-function isGoalPosition(p: THREE.Vector3) { const crossedLine = p.z <= GOAL_LINE_Z - 0.05; const insidePosts = Math.abs(p.x) <= GOAL_W / 2 - BALL_R; const underBar = p.y >= BALL_R && p.y <= GOAL_H - BALL_R * 0.25; return crossedLine && insidePosts && underBar; }
-function decideShot(ball: BallState, blocked: boolean, saved: boolean): Decision { if (blocked) return "BLOCKED"; if (saved) return "SAVE"; return isGoalPosition(ball.object.position) || ball.netCaught ? "GOAL" : "NO GOAL"; }
-function catchBallInNet(ball: BallState, netRig: NetRig) { ball.netCaught = true; ball.netAge = 0; ball.flying = true; ball.netVel.copy(ball.vel).multiplyScalar(0.12); ball.netVel.z = Math.min(ball.netVel.z, -0.45); ball.netVel.y *= 0.18; triggerNetShake(netRig, ball.object.position.clone()); }
+
+function markGoalCrossing(ball: BallState) {
+  if (ball.crossedGoalLine || ball.hitFrame) return false;
+  const prev = ball.lastPos;
+  const curr = ball.object.position;
+  const crossed = prev.z > GOAL_LINE_Z && curr.z <= GOAL_LINE_Z;
+  if (!crossed) return false;
+  const ratio = (prev.z - GOAL_LINE_Z) / Math.max(0.0001, prev.z - curr.z);
+  const x = THREE.MathUtils.lerp(prev.x, curr.x, ratio);
+  const y = THREE.MathUtils.lerp(prev.y, curr.y, ratio);
+  ball.crossedGoalLine = Math.abs(x) <= GOAL_W / 2 - BALL_R && y >= BALL_R && y <= GOAL_H - BALL_R * 0.25;
+  return ball.crossedGoalLine;
+}
+
+function reflectFromGoalFrame(ball: BallState) {
+  if (!ball.flying || ball.netCaught || ball.hitFrame) return false;
+  const p = ball.object.position;
+  if (p.z > GOAL_LINE_Z + 0.22 || p.z < GOAL_LINE_Z - 0.35) return false;
+  const radius = BALL_R + POST_R * 1.25;
+  const candidates = [
+    [new THREE.Vector3(-GOAL_W / 2, 0, GOAL_LINE_Z), new THREE.Vector3(-GOAL_W / 2, GOAL_H, GOAL_LINE_Z)],
+    [new THREE.Vector3(GOAL_W / 2, 0, GOAL_LINE_Z), new THREE.Vector3(GOAL_W / 2, GOAL_H, GOAL_LINE_Z)],
+    [new THREE.Vector3(-GOAL_W / 2, GOAL_H, GOAL_LINE_Z), new THREE.Vector3(GOAL_W / 2, GOAL_H, GOAL_LINE_Z)],
+  ];
+  for (const [a, b] of candidates) {
+    const ab = b.clone().sub(a);
+    const t = THREE.MathUtils.clamp(p.clone().sub(a).dot(ab) / Math.max(0.0001, ab.lengthSq()), 0, 1);
+    const closest = a.clone().addScaledVector(ab, t);
+    if (closest.distanceTo(p) <= radius) {
+      const normal = p.clone().sub(closest).normalize();
+      if (normal.lengthSq() < 0.001) normal.set(0, 0, 1);
+      ball.object.position.copy(closest).addScaledVector(normal, radius + 0.015);
+      ball.vel.reflect(normal).multiplyScalar(0.72);
+      ball.vel.z = Math.max(ball.vel.z, 1.1);
+      ball.hitFrame = true;
+      ball.shotAge = ball.shotDuration + 0.01;
+      return true;
+    }
+  }
+  return false;
+}
+
+function netCatchCheck(ball: BallState, netRig: NetRig) {
+  if (!ball.flying || ball.netCaught || !ball.crossedGoalLine) return false;
+  const p = ball.object.position;
+  const inGoalDepth = p.z <= GOAL_LINE_Z - GOAL_D + 0.2;
+  const stillInsideGoal = Math.abs(p.x) <= GOAL_W / 2 + 0.35 && p.y <= GOAL_H + 0.32;
+  if (inGoalDepth && stillInsideGoal) {
+    catchBallInNet(ball, netRig);
+    return true;
+  }
+  return false;
+}
+
+function decideShot(ball: BallState, blocked: boolean, saved: boolean): Decision {
+  if (blocked) return "BLOCKED";
+  if (saved) return "SAVE";
+  return ball.crossedGoalLine || ball.netCaught ? "GOAL" : "NO GOAL";
+}
+
+function catchBallInNet(ball: BallState, netRig: NetRig) {
+  ball.netCaught = true;
+  ball.netAge = 0;
+  ball.flying = true;
+  ball.netVel.copy(ball.vel).multiplyScalar(0.12);
+  ball.netVel.z = Math.min(ball.netVel.z, -0.45);
+  ball.netVel.y *= 0.18;
+  triggerNetShake(netRig, ball.object.position.clone());
+}
 
 export default function FreeKickGame() {
   const hostRef = useRef<HTMLDivElement | null>(null);
@@ -495,39 +1097,115 @@ export default function FreeKickGame() {
     const sun = new THREE.DirectionalLight(0xffffff, 1.35);
     sun.position.set(8, 16, 10); sun.castShadow = true; sun.shadow.mapSize.set(2048, 2048); scene.add(sun);
     const netRig: NetRig = { lines: [], shake: 0, impact: new THREE.Vector3() };
-    makeHalfField(scene, netRig);
+    const loader = new GLTFLoader();
+    const stadium = makeHalfField(scene, netRig, loader);
     const aimLine = makeAimLine(scene);
     hideAimLine(aimLine);
     const ball = makeBall(scene);
-    const loader = new GLTFLoader();
-    const kicker = createActor(scene, loader, "kicker", new THREE.Vector3(0, 0, 6));
-    const keeper = createActor(scene, loader, "keeper", new THREE.Vector3(0, 0, GOAL_LINE_Z + 0.36));
-    const wall = Array.from({ length: 5 }, (_, i) => createActor(scene, loader, "wall", new THREE.Vector3(0, 0, 0), i));
-    let spot: KickSpot = "center"; let state: ShotState = "aim"; let resultTimer = 0; let varTimer = 0; let replayIndex = 0; let replayClock = 0; let pendingDecision: Decision = "NO GOAL"; let shotBlocked = false; let shotSaved = false; let shotFinalized = false; let netTriggered = false; const replayFrames: ReplayFrame[] = []; let score = { goals: 0, saves: 0 }; resetShot(ball, kicker, keeper, wall, spot);
+    const audio = makeGoalRushAudio();
+    const characterColors = shuffledCharacterColors();
+    const characterUrls = shuffledCharacterUrls();
+    const actorKitColor = (index: number) => characterColors[index % characterColors.length];
+    const actorModelUrl = (index: number) => characterUrls[index % characterUrls.length] ?? HUMAN_URL;
+    const kicker = createActor(scene, loader, "kicker", new THREE.Vector3(0, 0, 6), 0, actorKitColor(0), actorModelUrl(0));
+    const keeper = createActor(scene, loader, "keeper", new THREE.Vector3(0, 0, GOAL_LINE_Z + 0.36), 0, actorKitColor(1), actorModelUrl(1));
+    const wall = Array.from({ length: 5 }, (_, i) => createActor(scene, loader, "wall", new THREE.Vector3(0, 0, 0), i, actorKitColor(i + 2), actorModelUrl(i + 2)));
+    let spot: KickSpot = "center"; let state: ShotState = "aim"; let resultTimer = 0; let varTimer = 0; let replayIndex = 0; let replayClock = 0; let pendingDecision: Decision = "NO GOAL"; let shotBlocked = false; let shotSaved = false; let shotFinalized = false; let netTriggered = false; let cameraYaw = 0; const replayFrames: ReplayFrame[] = []; let score = { goals: 0, saves: 0 }; resetShot(ball, kicker, keeper, wall, spot);
     const resize = () => { const w = Math.max(1, host.clientWidth); const h = Math.max(1, host.clientHeight); renderer.setSize(w, h, false); renderer.setPixelRatio(Math.min(2, window.devicePixelRatio || 1)); camera.aspect = w / h; camera.updateProjectionMatrix(); };
     resize(); window.addEventListener("resize", resize);
-    const onDown = (e: PointerEvent) => { if (state !== "aim") return; swipeRef.current = { active: true, startX: e.clientX, startY: e.clientY, endX: e.clientX, endY: e.clientY }; setAimCurve(aimLine, ball.object.position, swipeRef.current); };
-    const onMove = (e: PointerEvent) => { if (!swipeRef.current.active || state !== "aim") return; swipeRef.current.endX = e.clientX; swipeRef.current.endY = e.clientY; setAimCurve(aimLine, ball.object.position, swipeRef.current); };
-    const onUp = (e: PointerEvent) => { if (!swipeRef.current.active || state !== "aim") return; swipeRef.current.endX = e.clientX; swipeRef.current.endY = e.clientY; swipeRef.current.active = false; hideAimLine(aimLine); beginRunup(kicker, wall, keeper, ball, swipeRef.current); shotBlocked = false; shotSaved = false; shotFinalized = false; netTriggered = false; replayFrames.length = 0; state = "runup"; setHud((h) => ({ ...h, state: "2-step run-up..." })); };
+    const onDown = (e: PointerEvent) => {
+      audio.start();
+      const rect = host.getBoundingClientRect();
+      const cameraZone = state !== "aim" || e.clientY - rect.top < rect.height * 0.42;
+      swipeRef.current = { active: true, startX: e.clientX, startY: e.clientY, endX: e.clientX, endY: e.clientY, mode: cameraZone ? "camera" : "shot" };
+      if (!cameraZone && state === "aim") setAimCurve(aimLine, ball.object.position, swipeRef.current);
+    };
+    const onMove = (e: PointerEvent) => {
+      if (!swipeRef.current.active) return;
+      if (swipeRef.current.mode === "camera") {
+        const dx = e.clientX - swipeRef.current.endX;
+        cameraYaw = THREE.MathUtils.clamp(cameraYaw + dx / 260, -CAMERA_YAW_LIMIT, CAMERA_YAW_LIMIT);
+        swipeRef.current.endX = e.clientX;
+        swipeRef.current.endY = e.clientY;
+        return;
+      }
+      if (state !== "aim") return;
+      swipeRef.current.endX = e.clientX;
+      swipeRef.current.endY = e.clientY;
+      setAimCurve(aimLine, ball.object.position, swipeRef.current);
+    };
+    const onUp = (e: PointerEvent) => {
+      if (!swipeRef.current.active) return;
+      if (swipeRef.current.mode === "camera" || state !== "aim") {
+        swipeRef.current.active = false;
+        return;
+      }
+      swipeRef.current.endX = e.clientX;
+      swipeRef.current.endY = e.clientY;
+      swipeRef.current.active = false;
+      hideAimLine(aimLine);
+      beginRunup(kicker, wall, keeper, ball, swipeRef.current);
+      shotBlocked = false;
+      shotSaved = false;
+      shotFinalized = false;
+      netTriggered = false;
+      replayFrames.length = 0;
+      state = "runup";
+      setHud((h) => ({ ...h, state: "2-step run-up..." }));
+    };
     canvas.addEventListener("pointerdown", onDown); canvas.addEventListener("pointermove", onMove); canvas.addEventListener("pointerup", onUp); canvas.addEventListener("pointercancel", onUp);
     const recordReplayFrame = (look: THREE.Vector3) => { if (replayFrames.length > 220) replayFrames.shift(); replayFrames.push({ ball: ball.object.position.clone(), quat: ball.object.quaternion.clone(), cam: camera.position.clone(), look: look.clone(), keeper: keeper.root.position.clone(), keeperRot: keeper.root.rotation.clone(), kicker: kicker.root.position.clone(), kickerRot: kicker.root.rotation.clone() }); };
     let last = performance.now(); let frame = 0;
     const loop = () => {
       frame = requestAnimationFrame(loop);
       const now = performance.now(); const dt = Math.min(DT_MAX, (now - last) / 1000); last = now;
-      if (state === "aim" && swipeRef.current.active) setAimCurve(aimLine, ball.object.position, swipeRef.current);
+      if (state === "aim" && swipeRef.current.active && swipeRef.current.mode === "shot") setAimCurve(aimLine, ball.object.position, swipeRef.current);
       if (state === "runup") {
         const strikeSpot = ball.object.position.clone().add(new THREE.Vector3(-0.24, -BALL_R, 0.42)).setY(0);
         TMP.copy(strikeSpot).sub(kicker.pos).setY(0);
         if (TMP.length() > 0.055) { kicker.dir.copy(TMP.clone().normalize()); kicker.vel.copy(kicker.dir).multiplyScalar(4.05); kicker.pos.addScaledVector(kicker.vel, dt); kicker.speed = kicker.vel.length(); } else { kicker.speed = 0; }
-        if (kicker.kickTime < 0.34 && !ball.flying) { replayFrames.length = 0; recordReplayFrame(new THREE.Vector3(0, 1.22, GOAL_LINE_Z + 0.25)); shootBall(ball, swipeRef.current); state = "flight"; setHud((h) => ({ ...h, state: "Right-foot strike · recording replay" })); }
+        if (kicker.kickTime < 0.34 && !ball.flying) { replayFrames.length = 0; recordReplayFrame(new THREE.Vector3(0, 1.22, GOAL_LINE_Z + 0.25)); shootBall(ball, swipeRef.current); audio.kick(); state = "flight"; setHud((h) => ({ ...h, state: "Right-foot strike · recording replay" })); }
       } else { kicker.speed = 0; }
       updateBall(ball, dt); updateNetShake(netRig, dt);
       if (state === "flight") {
-        if (!shotBlocked && wallBlockCheck(wall, ball)) shotBlocked = true;
-        if (!shotSaved && keeperSaveCheck(keeper, ball, dt)) shotSaved = true;
-        if (!netTriggered && !shotBlocked && !shotSaved && isGoalPosition(ball.object.position)) { netTriggered = true; catchBallInNet(ball, netRig); setHud((h) => ({ ...h, state: "Ball hits net · checking VAR" })); }
-        if (!ball.flying && !shotFinalized) { shotFinalized = true; pendingDecision = decideShot(ball, shotBlocked, shotSaved); varTimer = pendingDecision === "GOAL" || pendingDecision === "NO GOAL" ? 1.15 : 0.65; state = "var"; setHud((h) => ({ ...h, state: pendingDecision === "GOAL" ? "VAR CHECK: ball crossed line" : `VAR CHECK: ${pendingDecision}` })); }
+        if (!shotBlocked && wallBlockCheck(wall, ball)) {
+          shotBlocked = true;
+          shotFinalized = true;
+          pendingDecision = "BLOCKED";
+          audio.save();
+          state = "result";
+          resultTimer = 0.6;
+          score.saves += 1;
+          setHud((h) => ({ ...h, saves: score.saves, state: "BLOCKED · next free kick" }));
+        }
+        if (!shotFinalized && !shotSaved && keeperSaveCheck(keeper, ball, dt)) {
+          shotSaved = true;
+          shotFinalized = true;
+          pendingDecision = "SAVE";
+          ball.flying = false;
+          audio.save();
+          state = "result";
+          resultTimer = 0.75;
+          score.saves += 1;
+          setHud((h) => ({ ...h, saves: score.saves, state: "SAVE · next free kick" }));
+        }
+        if (!shotFinalized && markGoalCrossing(ball)) setHud((h) => ({ ...h, state: "Ball crossed line · still travelling" }));
+        if (!shotFinalized && !shotBlocked && !shotSaved && reflectFromGoalFrame(ball)) { audio.save(); setHud((h) => ({ ...h, state: "Off the frame · ball still live" })); }
+        if (!shotFinalized && !netTriggered && !shotBlocked && !shotSaved && netCatchCheck(ball, netRig)) { netTriggered = true; audio.net(); setHud((h) => ({ ...h, state: "Net contact · checking VAR" })); }
+        if (!ball.flying && !shotFinalized) {
+          shotFinalized = true;
+          pendingDecision = decideShot(ball, shotBlocked, shotSaved);
+          if (pendingDecision === "GOAL") {
+            varTimer = 1.05;
+            state = "var";
+            setHud((h) => ({ ...h, state: "VAR CHECK: ball crossed line" }));
+          } else {
+            state = "result";
+            resultTimer = 0.7;
+            score.saves += 1;
+            setHud((h) => ({ ...h, saves: score.saves, state: `${pendingDecision} · next free kick` }));
+          }
+        }
       }
       if (state === "var") { varTimer -= dt; if (varTimer <= 0) { state = "replay"; replayIndex = 0; replayClock = 0; setHud((h) => ({ ...h, state: `SLOW REPLAY: ${pendingDecision}` })); } }
       if (state === "replay") {
@@ -541,30 +1219,33 @@ export default function FreeKickGame() {
           const replayLook = frameData.look.clone().lerp(frameData.ball.clone().add(new THREE.Vector3(0, 0.28, 0)), 0.52);
           camera.position.copy(replayCam); camera.lookAt(replayLook);
         }
-        if (replayIndex >= replayFrames.length - 1 || replayFrames.length === 0) { state = "result"; resultTimer = pendingDecision === "GOAL" ? 1.25 : 1.05; if (pendingDecision === "GOAL") { score.goals += 1; setHud((h) => ({ ...h, goals: score.goals, state: "VAR: GOAL confirmed" })); } else { score.saves += 1; setHud((h) => ({ ...h, saves: score.saves, state: `VAR: ${pendingDecision}` })); } }
+        if (replayIndex >= replayFrames.length - 1 || replayFrames.length === 0) { state = "result"; resultTimer = pendingDecision === "GOAL" ? 2.65 : 1.05; if (pendingDecision === "GOAL") { audio.goal(); triggerCrowdCheer(stadium); kicker.celebrateTime = 2.45; score.goals += 1; setHud((h) => ({ ...h, goals: score.goals, state: "VAR: GOAL confirmed" })); } else { score.saves += 1; setHud((h) => ({ ...h, saves: score.saves, state: `VAR: ${pendingDecision}` })); } }
       }
       if (state === "result") { resultTimer -= dt; if (resultTimer <= 0) { state = "aim"; shotBlocked = false; shotSaved = false; shotFinalized = false; netTriggered = false; replayFrames.length = 0; resetShot(ball, kicker, keeper, wall, spot); setHud((h) => ({ ...h, state: "Swipe to aim and shoot" })); } }
       if (state !== "replay") {
-        updateActorBase(kicker, dt); applyKickerPose(kicker); updateActorBase(keeper, dt); applyKeeperPose(keeper);
+        updateActorBase(kicker, dt); applyKickerPose(kicker); applyGoalDancePose(kicker); updateActorBase(keeper, dt); applyKeeperPose(keeper);
         wall.forEach((w) => { updateActorBase(w, dt); applyWallPose(w); if (w.jumpTime > 0) w.jumpTime = Math.max(0, w.jumpTime - dt); });
         if (kicker.kickTime > 0) kicker.kickTime = Math.max(0, kicker.kickTime - dt);
         if (keeper.diveTime > 0) keeper.diveTime = Math.max(0, keeper.diveTime - dt);
+        if (kicker.celebrateTime > 0) kicker.celebrateTime = Math.max(0, kicker.celebrateTime - dt);
+        updateStadiumCrowd(stadium, dt);
       }
       let lookPoint = new THREE.Vector3(0, 1.22, GOAL_LINE_Z + 0.25);
       if (state !== "replay") {
-        if (ball.flying || state === "var") { const toGoal = new THREE.Vector3(0, 0, GOAL_LINE_Z).sub(ball.object.position).setY(0).normalize(); const followPos = ball.object.position.clone().addScaledVector(toGoal, -4.3).add(new THREE.Vector3(0, 1.55, 0)); camera.position.lerp(followPos, 0.11); lookPoint = ball.object.position.clone().addScaledVector(toGoal, 6.0).add(new THREE.Vector3(0, 0.55, 0)); camera.lookAt(lookPoint); } else { const behind = new THREE.Vector3(kicker.pos.x * 0.45, 1.22, kicker.pos.z + 2.85); camera.position.lerp(behind, 0.18); lookPoint.set(0, 1.22, GOAL_LINE_Z + 0.25); camera.lookAt(lookPoint); }
+        if (ball.flying || state === "var") { const toGoal = new THREE.Vector3(0, 0, GOAL_LINE_Z).sub(ball.object.position).setY(0).normalize(); const followOffset = toGoal.clone().multiplyScalar(-4.3).applyAxisAngle(new THREE.Vector3(0, 1, 0), cameraYaw * 0.55); const followPos = ball.object.position.clone().add(followOffset).add(new THREE.Vector3(0, 1.55, 0)); camera.position.lerp(followPos, 0.11); lookPoint = ball.object.position.clone().addScaledVector(toGoal, 6.0).add(new THREE.Vector3(0, 0.55, 0)); camera.lookAt(lookPoint); } else { lookPoint.set(0, 1.22, GOAL_LINE_Z + 0.25); const behindOffset = new THREE.Vector3(kicker.pos.x * 0.45, 0, kicker.pos.z + 2.85).sub(new THREE.Vector3(lookPoint.x, 0, lookPoint.z)).applyAxisAngle(new THREE.Vector3(0, 1, 0), cameraYaw); const behind = new THREE.Vector3(lookPoint.x + behindOffset.x, 1.22, lookPoint.z + behindOffset.z); camera.position.lerp(behind, 0.18); camera.lookAt(lookPoint); }
         if (state === "flight" || state === "var") recordReplayFrame(lookPoint);
       }
       renderer.render(scene, camera);
     };
     loop();
-    (window as any).__setFreeKickSpot = (next: KickSpot) => { spot = next; state = "aim"; hideAimLine(aimLine); replayFrames.length = 0; resetShot(ball, kicker, keeper, wall, spot); setHud((h) => ({ ...h, spot, state: `Free kick ${next}: wall ${wallCountForSpot(next)} at 9.15m` })); };
-    return () => { cancelAnimationFrame(frame); window.removeEventListener("resize", resize); canvas.removeEventListener("pointerdown", onDown); canvas.removeEventListener("pointermove", onMove); canvas.removeEventListener("pointerup", onUp); canvas.removeEventListener("pointercancel", onUp); renderer.dispose(); };
+    (window as any).__setFreeKickSpot = (next: KickSpot) => { audio.whistle(); spot = next; state = "aim"; hideAimLine(aimLine); replayFrames.length = 0; resetShot(ball, kicker, keeper, wall, spot); setHud((h) => ({ ...h, spot, state: `Free kick ${next}: wall ${wallCountForSpot(next)} at 9.15m` })); };
+    return () => { cancelAnimationFrame(frame); window.removeEventListener("resize", resize); canvas.removeEventListener("pointerdown", onDown); canvas.removeEventListener("pointermove", onMove); canvas.removeEventListener("pointerup", onUp); canvas.removeEventListener("pointercancel", onUp); audio.dispose(); renderer.dispose(); };
   }, []);
 
   const setSpot = (spot: KickSpot) => {
     (window as any).__setFreeKickSpot?.(spot);
   };
+
 
   return (
     <div style={{ position: "fixed", inset: 0, background: "#07110b", overflow: "hidden", touchAction: "none", userSelect: "none" }}>
@@ -575,6 +1256,7 @@ export default function FreeKickGame() {
         <div style={{ fontWeight: 900, fontSize: 18 }}>GOALS {hud.goals} · SAVES {hud.saves}</div>
         <div style={{ fontSize: 11, maxWidth: 220, textAlign: "right", lineHeight: 1.25 }}>{hud.state}</div>
       </div>
+
       <div style={{ position: "fixed", left: 12, bottom: 14, right: 12, display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: 8, pointerEvents: "auto" }}>
         <button onClick={() => setSpot("left")} style={buttonStyle}>Left<br />3 wall</button>
         <button onClick={() => setSpot("center")} style={buttonStyle}>Center<br />4 wall</button>


### PR DESCRIPTION
### Motivation
- Make the free-kick scene more immersive by adding stadium stands and seated spectators, character kit colors and model selection, crowd audio and goal celebration behavior.
- Improve realism of ball and keeper interactions including goal-line crossing detection, frame collisions, net catching, and more responsive keeper movement.

### Description
- Add stadium rig and stands: `makeBillboardsAndStands`/`makeHalfField` now build seating, chairs, and spawn spectator `Actor`s (with kit colors and optional model URLs) and return a `StadiumRig` used for crowd cheering updates.
- Introduce spectator and celebration poses: `applySeatedSpectatorPose`, `applyGoalDancePose`, `triggerCrowdCheer`, and `updateStadiumCrowd` to animate cheering and kicker celebrations.
- Add audio goal-rush manager via `makeGoalRushAudio` and hook sound events (`kick`, `whistle`, `net`, `save`, `goal`) into game flow; audio is started on input and disposed on cleanup.
- Improve actor/model handling: `createActor` accepts `kitColor` and `modelUrl`, tints models accordingly, and falls back to `HUMAN_URL` model on load failure; `tintModel` and `makeFallback` accept kit color.
- Enhance ball & keeper physics and shot adjudication: path sampling to predict goal crossing (`markGoalCrossing`), frame collisions/reflections (`reflectFromGoalFrame`), net catch checks (`netCatchCheck`), better ball rolling (`rollBall`), improved keeper targeting (`saveTargetX/Y`) and save collision checks (`keeperSaveCheck`), and updated decide/catch logic to account for crossing/net.
- Add camera swipe mode and yaw control: initial pointer region selects camera vs shot mode, camera yaw adjustable by dragging, and aim swipe keeps working for shots only; replay and camera follow positions updated to respect yaw.
- Misc: shuffled character colors/URLs helpers, replay/result timing tweaks, scoreboard/hud updates, audio whistling when changing spot, and audio disposal on unmount.

### Testing
- Performed TypeScript type-check and local dev build of the webapp which completed successfully.
- Ran the scene locally in the browser to validate asset loading, spectator spawning, audio playback, camera swipe behavior, and shot/replay flows; visual/manual checks confirmed expected behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faaad846008329bf38350f1247d95e)