### PR TITLE
Tune Pool Royale showroom table options

### DIFF
--- a/webapp/src/config/poolRoyaleTableModels.js
+++ b/webapp/src/config/poolRoyaleTableModels.js
@@ -16,38 +16,16 @@ export const POOL_ROYALE_TABLE_MODEL_OPTIONS = Object.freeze([
   },
   {
     id: 'showood-seven-foot',
-    label: 'Showood 7 ft GLB',
-    description: 'Open-source Pooltool seven-foot table with original GLB textures.',
-    tableSizeId: '8ft',
+    label: 'Showood GLB',
+    description: 'Open-source Showood table fitted exactly to the Royal Original 9 ft footprint and skinned with Pool Royale table finishes.',
+    tableSizeId: '9ft',
     assetUrl: `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood_pbr.glb`,
     fallbackAssetUrl: `${POOLTOOL_RAW_BASE}/seven_foot_showood/seven_foot_showood.glb`,
     icon: '🟫',
     kind: 'gltf',
     fitScale: 1,
-    fitStrategy: 'cover'
-  },
-  {
-    id: 'pooltool-null-pbr',
-    label: 'Pooltool PBR GLB',
-    description: 'Pooltool PBR pool table normalized to Pool Royale proportions.',
-    tableSizeId: '9ft',
-    assetUrl: `${POOLTOOL_RAW_BASE}/null/null_pbr.glb`,
-    fallbackAssetUrl: `${POOLTOOL_RAW_BASE}/null/null.glb`,
-    icon: '🟩',
-    kind: 'gltf',
-    fitScale: 1,
-    fitStrategy: 'cover'
-  },
-  {
-    id: 'snooker-generic',
-    label: 'Snooker GLB',
-    description: 'Open-source snooker-style table fitted to the 9 ft Pool Royale arena.',
-    tableSizeId: '9ft',
-    assetUrl: `${POOLTOOL_RAW_BASE}/snooker_generic/snooker_generic.glb`,
-    icon: '🟦',
-    kind: 'gltf',
-    fitScale: 1,
-    fitStrategy: 'cover'
+    fitStrategy: 'exact',
+    usePoolRoyaleFinishMaterials: true
   }
 ]);
 

--- a/webapp/src/pages/Games/PoolRoyale.jsx
+++ b/webapp/src/pages/Games/PoolRoyale.jsx
@@ -12608,16 +12608,27 @@ function fitPoolRoyaleExternalTableModel(model, tableModel, dims) {
     size = box.getSize(new THREE.Vector3());
   }
 
-  const modelWidth = Math.max(MICRO_EPS, Math.min(size.x, size.z));
-  const modelLength = Math.max(MICRO_EPS, Math.max(size.x, size.z));
-  const widthScale = dims.targetWidth / modelWidth;
-  const lengthScale = dims.targetLength / modelLength;
-  const baseFitScale =
-    tableModel?.fitStrategy === 'contain'
-      ? Math.min(widthScale, lengthScale)
-      : Math.max(widthScale, lengthScale);
-  const fitScale = baseFitScale * (tableModel?.fitScale ?? 1);
-  model.scale.multiplyScalar(fitScale);
+  const exactScale = tableModel?.fitScale ?? 1;
+  const widthScale = dims.targetWidth / Math.max(MICRO_EPS, size.x);
+  const lengthScale = dims.targetLength / Math.max(MICRO_EPS, size.z);
+  if (tableModel?.fitStrategy === 'exact') {
+    model.scale.set(
+      widthScale * exactScale,
+      Math.min(widthScale, lengthScale) * exactScale,
+      lengthScale * exactScale
+    );
+  } else {
+    const modelWidth = Math.max(MICRO_EPS, Math.min(size.x, size.z));
+    const modelLength = Math.max(MICRO_EPS, Math.max(size.x, size.z));
+    const uniformWidthScale = dims.targetWidth / modelWidth;
+    const uniformLengthScale = dims.targetLength / modelLength;
+    const baseFitScale =
+      tableModel?.fitStrategy === 'contain'
+        ? Math.min(uniformWidthScale, uniformLengthScale)
+        : Math.max(uniformWidthScale, uniformLengthScale);
+    const fitScale = baseFitScale * exactScale;
+    model.scale.multiplyScalar(fitScale);
+  }
   model.updateMatrixWorld(true);
 
   box = new THREE.Box3().setFromObject(model);
@@ -12636,6 +12647,89 @@ function fitPoolRoyaleExternalTableModel(model, tableModel, dims) {
       physics: 'Pool Royale playfield, pockets, cushions, and ball simulation'
     }
   };
+}
+
+
+function cloneExternalTableTexture(texture) {
+  if (!texture) return null;
+  const next = texture.clone();
+  next.image = texture.image;
+  next.wrapS = THREE.RepeatWrapping;
+  next.wrapT = THREE.RepeatWrapping;
+  next.repeat.set(1, 1);
+  next.offset.set(0, 0);
+  next.center.set(0.5, 0.5);
+  next.rotation = 0;
+  next.anisotropy = resolveTextureAnisotropy(12);
+  next.needsUpdate = true;
+  return next;
+}
+
+function clonePoolRoyaleMaterialForExternalTable(sourceMaterial, role, fallbackMaterial = null) {
+  const source = sourceMaterial || fallbackMaterial;
+  if (!source) return null;
+  const material = source.clone ? source.clone() : source;
+  material.name = `pool-royale-showood-${role}-${source.name || 'material'}`;
+  ['map', 'emissiveMap', 'aoMap', 'normalMap', 'roughnessMap', 'metalnessMap', 'bumpMap'].forEach((key) => {
+    if (source[key]) {
+      material[key] = cloneExternalTableTexture(source[key]);
+    }
+  });
+  if (source.normalScale?.clone) material.normalScale = source.normalScale.clone();
+  material.side = THREE.FrontSide;
+  material.shadowSide = THREE.FrontSide;
+  material.needsUpdate = true;
+  return material;
+}
+
+function classifyPoolRoyaleExternalTableMesh(mesh) {
+  const materialName = Array.isArray(mesh?.material)
+    ? mesh.material.map((mat) => mat?.name || '').join(' ')
+    : mesh?.material?.name || '';
+  const text = `${mesh?.name || ''} ${materialName}`.toLowerCase();
+  if (/pocket|drop|net|hole|leather|liner/.test(text)) return 'pocket';
+  if (/cushion|bumper|rubber|nose|bank/.test(text)) return 'cushion';
+  if (/cloth|felt|baize|slate|bed|playfield|surface/.test(text)) return 'cloth';
+  if (/rail|frame|wood|showood|leg|apron|body|cabinet|side|trim/.test(text)) return 'wood';
+  return 'wood';
+}
+
+function applyPoolRoyaleFinishToExternalTable(table, finishInfo = null) {
+  const externalRoot = table?.userData?.externalTable?.group;
+  const tableModel = table?.userData?.externalTableModel;
+  const info = finishInfo || table?.userData?.finish;
+  if (!externalRoot || !tableModel?.usePoolRoyaleFinishMaterials || !info) return;
+  let hasMeshes = false;
+  externalRoot.traverse((child) => {
+    if (child?.isMesh) hasMeshes = true;
+  });
+  if (!hasMeshes) return;
+
+  const woodSource = info.parts?.woodSurfaces?.rail ? info.parts.railMeshes?.[0]?.material : null;
+  const materials = {
+    cloth: clonePoolRoyaleMaterialForExternalTable(info.clothMat, 'cloth'),
+    cushion: clonePoolRoyaleMaterialForExternalTable(info.cushionMat || info.clothMat, 'cushion'),
+    wood: clonePoolRoyaleMaterialForExternalTable(woodSource || info.parts?.railMeshes?.[0]?.material, 'wood'),
+    pocket: null
+  };
+  const assignedMaterials = new Set(Object.values(materials).filter(Boolean));
+
+  externalRoot.traverse((child) => {
+    if (!child?.isMesh) return;
+    const role = classifyPoolRoyaleExternalTableMesh(child);
+    if (role === 'pocket') return;
+    const material = materials[role] || materials.wood || materials.cloth;
+    if (!material) return;
+    const previous = child.material;
+    child.material = material;
+    child.castShadow = true;
+    child.receiveShadow = true;
+    child.frustumCulled = false;
+    if (previous && !assignedMaterials.has(previous)) {
+      if (Array.isArray(previous)) previous.forEach((mat) => mat?.dispose?.());
+      else previous.dispose?.();
+    }
+  });
 }
 
 function mountPoolRoyaleExternalTableModel({
@@ -12663,6 +12757,7 @@ function mountPoolRoyaleExternalTableModel({
       fitPoolRoyaleExternalTableModel(model, tableModel, dims);
       externalRoot.clear();
       externalRoot.add(model);
+      applyPoolRoyaleFinishToExternalTable(table);
       setGeneratedVisualsVisible?.(false);
     })
     .catch((error) => {
@@ -13340,6 +13435,7 @@ function mountPoolRoyaleExternalTableModel({
       object.visible = visible;
     });
   };
+  table.userData.externalTableModel = resolvedTableOptions?.tableModel || null;
   const externalTable =
     resolvedTableOptions?.tableModel?.kind === 'gltf'
       ? mountPoolRoyaleExternalTableModel({
@@ -13355,6 +13451,7 @@ function mountPoolRoyaleExternalTableModel({
         })
       : null;
   table.userData.externalTable = externalTable;
+  applyPoolRoyaleFinishToExternalTable(table, finishInfo);
   parent.add(table);
 
   const baulkZ = baulkLineZ;
@@ -13778,6 +13875,7 @@ function applyTableFinishToTable(table, finish) {
   if (typeof finishInfo.applyClothDetail === 'function') {
     finishInfo.applyClothDetail(resolvedFinish?.clothDetail ?? null);
   }
+  applyPoolRoyaleFinishToExternalTable(table, finishInfo);
 
   finishInfo.id = resolvedFinish.id;
   finishInfo.palette = resolvedFinish.colors;

--- a/webapp/src/pages/Games/PoolRoyaleLobby.jsx
+++ b/webapp/src/pages/Games/PoolRoyaleLobby.jsx
@@ -657,7 +657,7 @@ export default function PoolRoyaleLobby() {
                     <p className="lobby-option-label">{option.label}</p>
                     <p className="lobby-option-subtitle">
                       {option.kind === 'gltf'
-                        ? `${option.tableSizeId} · original textures`
+                        ? `${option.tableSizeId} · Pool Royale finishes`
                         : 'Current table'}
                     </p>
                   </div>
@@ -666,7 +666,7 @@ export default function PoolRoyaleLobby() {
             })}
           </div>
           <p className="text-xs text-white/60">
-            New GLB tables replace the in-game table visually while Pool Royale keeps the matched playfield, pockets, cushions, and ball physics.
+            The Showood GLB replaces the in-game table visually while Pool Royale keeps the exact Royal Original playfield, pockets, cushions, ball physics, and selected table-finish textures.
           </p>
         </div>
 


### PR DESCRIPTION
### Motivation
- Remove redundant external GLB table options and ensure the showroom uses a single, well-integrated GLB that matches Pool Royale physics and finish workflow. 
- Make the Showood GLB render at exactly the same playfield footprint as the Royal Original so visual alignment and mapping are precise. 
- Allow Pool Royale table finishes/textures to be applied to that external GLB while preserving the GLB’s UVs so existing finish textures map correctly.

### Description
- Updated `webapp/src/config/poolRoyaleTableModels.js` to keep only `royal-original` and `showood-seven-foot`, removed `pooltool-null-pbr` and `snooker-generic`, and set the Showood entry to `tableSizeId: '9ft'`, `fitStrategy: 'exact'` and `usePoolRoyaleFinishMaterials: true`.
- Enhanced `fitPoolRoyaleExternalTableModel` in `webapp/src/pages/Games/PoolRoyale.jsx` to support a new `exact` fit strategy with precise X/Z scaling while preserving existing uniform-fit behavior for other strategies.
- Added material/texture cloning and remapping helpers (`cloneExternalTableTexture`, `clonePoolRoyaleMaterialForExternalTable`, `classifyPoolRoyaleExternalTableMesh`, `applyPoolRoyaleFinishToExternalTable`) and wired them so the Showood GLB receives Pool Royale `cloth`, `cushion`, and `wood` materials after load and whenever finishes change.
- Wired `table.userData.externalTableModel` and ensured `applyPoolRoyaleFinishToExternalTable` is called after the GLB is mounted and after `applyTableFinishToTable` updates, plus updated lobby copy in `PoolRoyaleLobby.jsx` to describe the new behavior.

### Testing
- Built the webapp with `npm --prefix webapp run build` and the build completed successfully. 
- Verified the table model catalog programmatically with a Node check that confirmed removed entries and the Showood configuration and it passed. 
- Ran `npm test -- --runInBand test/snookerTableModel.test.js` and it passed; the broader two-test run including `test/poolRoyalInventoryRoutes.test.js` failed due to an environment missing `bot/node_modules/mongoose` and a test timeout, unrelated to these changes. 
- Launched the dev server and captured a Playwright screenshot of `/games/poolroyale/lobby` to validate the lobby UI and external-GLB path (screenshot saved during the smoke run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fad96b54908329b28fb8e2a9d6240c)