### PR TITLE
Add selectable open-source snooker table model, loader, and tests

### DIFF
--- a/test/snookerTableModel.test.js
+++ b/test/snookerTableModel.test.js
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import {
+  applySnookerTableModelParam,
+  resolveSnookerTableModel,
+  TABLE_MODEL_CLASSIC,
+  TABLE_MODEL_OPENSOURCE,
+  TABLE_MODEL_OPENSOURCE_GLB_URL
+} from '../webapp/src/pages/Games/snookerTableModel.js';
+
+describe('snooker table model selection', () => {
+  test('resolveSnookerTableModel defaults to classic', () => {
+    assert.equal(resolveSnookerTableModel(null), TABLE_MODEL_CLASSIC);
+    assert.equal(resolveSnookerTableModel(''), TABLE_MODEL_CLASSIC);
+    assert.equal(resolveSnookerTableModel('invalid'), TABLE_MODEL_CLASSIC);
+  });
+
+  test('resolveSnookerTableModel accepts opensource value case-insensitively', () => {
+    assert.equal(resolveSnookerTableModel('opensource'), TABLE_MODEL_OPENSOURCE);
+    assert.equal(resolveSnookerTableModel('OpenSource'), TABLE_MODEL_OPENSOURCE);
+  });
+
+  test('applySnookerTableModelParam always writes a safe tableModel param', () => {
+    const params = new URLSearchParams();
+    applySnookerTableModelParam(params, 'opensource');
+    assert.equal(params.get('tableModel'), TABLE_MODEL_OPENSOURCE);
+
+    applySnookerTableModelParam(params, 'unknown');
+    assert.equal(params.get('tableModel'), TABLE_MODEL_CLASSIC);
+  });
+
+  test('uses the Pooltool snooker_generic GLB source', () => {
+    assert.match(
+      TABLE_MODEL_OPENSOURCE_GLB_URL,
+      /pooltool\/models\/table\/snooker_generic\/snooker_generic\.glb$/
+    );
+  });
+});

--- a/webapp/src/pages/Games/SnookerRoyal.jsx
+++ b/webapp/src/pages/Games/SnookerRoyal.jsx
@@ -16,6 +16,12 @@ import { EXRLoader } from 'three/examples/jsm/loaders/EXRLoader.js';
 import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader.js';
 import { GroundedSkybox } from 'three/examples/jsm/objects/GroundedSkybox.js';
 import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.js';
+import {
+  resolveSnookerTableModel,
+  TABLE_MODEL_CLASSIC,
+  TABLE_MODEL_OPENSOURCE,
+  TABLE_MODEL_OPENSOURCE_GLB_URL
+} from './snookerTableModel.js';
 import { PoolRoyalePowerSlider } from '../../../../pool-royale-power-slider.js';
 import '../../../../pool-royale-power-slider.css';
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -11298,6 +11304,7 @@ function SnookerRoyalGame({
   variantKey,
   ballSetKey,
   tableSizeKey,
+  tableModel = TABLE_MODEL_CLASSIC,
   playType = 'regular',
   mode = 'ai',
   trainingMode = 'solo',
@@ -11310,7 +11317,6 @@ function SnookerRoyalGame({
   opponentAvatar
 }) {
   const navigate = useNavigate();
-  const location = useLocation();
   const mountRef = useRef(null);
   const rafRef = useRef(null);
   const worldRef = useRef(null);
@@ -19833,6 +19839,107 @@ const powerRef = useRef(hud.power);
         return Math.max(1.15, snookerWidth / poolWidth);
       };
       const snookerDecorScale = resolveSnookerScale();
+      const attachOpenSourceTableModel = (tableGroup) => {
+        if (tableModel !== TABLE_MODEL_OPENSOURCE || !tableGroup) return;
+        tableGroup.updateMatrixWorld(true);
+        const targetBox = new THREE.Box3().setFromObject(tableGroup);
+        const targetSize = targetBox.getSize(new THREE.Vector3());
+        const proceduralMeshes = new Set();
+        tableGroup.traverse((node) => {
+          if (node?.isMesh) proceduralMeshes.add(node.uuid);
+        });
+        const loader = new GLTFLoader();
+        loader.setCrossOrigin('anonymous');
+        const draco = new DRACOLoader();
+        draco.setDecoderPath(DRACO_DECODER_PATH);
+        loader.setDRACOLoader(draco);
+        const ktx2 = new KTX2Loader();
+        ktx2.setTranscoderPath(BASIS_TRANSCODER_PATH);
+        if (rendererRef.current) {
+          try {
+            ktx2.detectSupport(rendererRef.current);
+          } catch (error) {
+            console.warn('Snooker Royal table KTX2 support detection failed', error);
+          }
+        }
+        loader.setKTX2Loader(ktx2);
+        loader.setMeshoptDecoder(MeshoptDecoder);
+        const tuneOriginalPooltoolTextures = (root) => {
+          root.traverse((node) => {
+            if (!node?.isMesh) return;
+            node.castShadow = true;
+            node.receiveShadow = true;
+            const materials = Array.isArray(node.material) ? node.material : [node.material];
+            materials.forEach((material) => {
+              if (!material) return;
+              ['map', 'emissiveMap'].forEach((key) => {
+                if (material[key]) {
+                  material[key].colorSpace = THREE.SRGBColorSpace;
+                }
+              });
+              [
+                'map',
+                'emissiveMap',
+                'aoMap',
+                'normalMap',
+                'roughnessMap',
+                'metalnessMap'
+              ].forEach((key) => {
+                const texture = material[key];
+                if (!texture) return;
+                texture.flipY = false;
+                texture.generateMipmaps = true;
+                texture.minFilter = THREE.LinearMipmapLinearFilter;
+                texture.magFilter = THREE.LinearFilter;
+                texture.anisotropy = 8;
+                texture.needsUpdate = true;
+              });
+              material.needsUpdate = true;
+            });
+          });
+        };
+        loader.load(
+          TABLE_MODEL_OPENSOURCE_GLB_URL,
+          (gltf) => {
+            const visual = gltf?.scene;
+            if (!visual) return;
+            visual.updateMatrixWorld(true);
+            const sourceBox = new THREE.Box3().setFromObject(visual);
+            const sourceSize = sourceBox.getSize(new THREE.Vector3());
+            const scaleXZ = Math.min(
+              targetSize.x / Math.max(sourceSize.x, 0.0001),
+              targetSize.z / Math.max(sourceSize.z, 0.0001)
+            );
+            const scaleY = targetSize.y / Math.max(sourceSize.y, 0.0001);
+            visual.scale.set(scaleXZ, scaleY, scaleXZ);
+            visual.updateMatrixWorld(true);
+            const scaledBox = new THREE.Box3().setFromObject(visual);
+            const scaledCenter = scaledBox.getCenter(new THREE.Vector3());
+            const targetCenter = targetBox.getCenter(new THREE.Vector3());
+            visual.position.set(
+              targetCenter.x - scaledCenter.x,
+              targetBox.min.y - scaledBox.min.y,
+              targetCenter.z - scaledCenter.z
+            );
+            tuneOriginalPooltoolTextures(visual);
+            visual.name = 'pooltool-snooker-generic-table';
+            tableGroup.traverse((node) => {
+              if (node?.isMesh && proceduralMeshes.has(node.uuid)) {
+                node.visible = false;
+              }
+            });
+            tableGroup.add(visual);
+            tableGroup.userData.openSourceVisual = visual;
+            tableGroup.userData.openSourceVisualUrl = TABLE_MODEL_OPENSOURCE_GLB_URL;
+          },
+          undefined,
+          (error) => {
+            console.warn('Failed to load Pooltool snooker_generic table model', error);
+          }
+        );
+      };
+      attachOpenSourceTableModel(table);
+      attachOpenSourceTableModel(secondaryTableEntry?.group);
       const disposeSecondaryDecor = () => {
         const currentDecor = secondaryTableDecorRef.current;
         if (currentDecor?.group?.parent) {
@@ -28415,8 +28522,13 @@ const powerRef = useRef(hud.power);
 }
 
 export default function SnookerRoyal() {
-  const navigate = useNavigate();
   const location = useLocation();
+  const tableModel = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    return resolveSnookerTableModel(params.get('tableModel'));
+  }, [location.search]);
+
+  const navigate = useNavigate();
   const variantKey = useMemo(() => {
     return 'snooker';
   }, [location.search]);
@@ -28551,6 +28663,7 @@ export default function SnookerRoyal() {
       variantKey={variantKey}
       ballSetKey={ballSetKey}
       tableSizeKey={tableSizeKey}
+      tableModel={tableModel}
       playType={playType}
       mode={mode}
       trainingMode={trainingMode}

--- a/webapp/src/pages/Games/SnookerRoyalLobby.jsx
+++ b/webapp/src/pages/Games/SnookerRoyalLobby.jsx
@@ -14,6 +14,12 @@ import { runSnookerRoyalOnlineFlow } from './snookerRoyalOnlineFlow.js';
 import OptionIcon from '../../components/OptionIcon.jsx';
 import { getLobbyIcon } from '../../config/gameAssets.js';
 import GameLobbyHeader from '../../components/GameLobbyHeader.jsx';
+import {
+  applySnookerTableModelParam,
+  resolveSnookerTableModel,
+  TABLE_MODEL_CLASSIC,
+  TABLE_MODEL_OPENSOURCE
+} from './snookerTableModel.js';
 
 const PLAYER_FLAG_STORAGE_KEY = 'snookerRoyalPlayerFlag';
 const AI_FLAG_STORAGE_KEY = 'snookerRoyalAiFlag';
@@ -39,6 +45,10 @@ export default function SnookerRoyalLobby() {
   const [playType, setPlayType] = useState(initialPlayType);
   const [players, setPlayers] = useState(8);
   const tableSize = resolveTableSize(searchParams.get('tableSize')).id;
+  const initialTableModel = (() => {
+    return resolveSnookerTableModel(searchParams.get('tableModel'));
+  })();
+  const [tableModel, setTableModel] = useState(initialTableModel);
   const [onlinePlayers, setOnlinePlayers] = useState([]);
   const [matching, setMatching] = useState(false);
   const [spinningPlayer, setSpinningPlayer] = useState('');
@@ -126,6 +136,7 @@ export default function SnookerRoyalLobby() {
     const resolvedAccountId = accountIdRef.current;
     if (resolvedAccountId) params.set('accountId', resolvedAccountId);
     if (tableSize) params.set('tableSize', tableSize);
+    applySnookerTableModelParam(params, tableModel);
     params.set('seat', seat);
     params.set('starter', starterSeat);
     const name = (friendlyName || '').trim();
@@ -196,6 +207,7 @@ export default function SnookerRoyalLobby() {
     const params = new URLSearchParams();
     params.set('variant', forcedVariant);
     params.set('tableSize', tableSize);
+    applySnookerTableModelParam(params, tableModel);
     params.set('type', playType);
     params.set('mode', mode);
     if (isOnlineMatch) {
@@ -426,6 +438,39 @@ export default function SnookerRoyalLobby() {
           </div>
           <p className="text-xs text-white/60 text-center">
             Tournament mode locks online matchmaking and uses the bracket flow.
+          </p>
+        </div>
+
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold text-white">Choose Table</h3>
+            <span className="text-[11px] uppercase tracking-[0.3em] text-white/40">Layout</span>
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            {[
+              { id: TABLE_MODEL_CLASSIC, label: 'Classic Table', desc: 'Current playable table' },
+              { id: TABLE_MODEL_OPENSOURCE, label: 'New Snooker Table', desc: 'Open-source GLTF table model' }
+            ].map(({ id, label, desc }) => {
+              const active = tableModel === id;
+              return (
+                <button
+                  key={id}
+                  type="button"
+                  onClick={() => setTableModel(id)}
+                  className={`lobby-option-card ${
+                    active ? 'lobby-option-card-active' : 'lobby-option-card-inactive'
+                  }`}
+                >
+                  <div className="text-center">
+                    <p className="lobby-option-label">{label}</p>
+                    <p className="lobby-option-subtitle">{desc}</p>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+          <p className="text-xs text-white/60 text-center">
+            You can switch between the existing table and the new snooker model before match start.
           </p>
         </div>
 

--- a/webapp/src/pages/Games/snookerTableModel.js
+++ b/webapp/src/pages/Games/snookerTableModel.js
@@ -1,0 +1,15 @@
+export const TABLE_MODEL_CLASSIC = 'classic';
+export const TABLE_MODEL_OPENSOURCE = 'opensource';
+export const TABLE_MODEL_OPENSOURCE_GLB_URL =
+  'https://raw.githubusercontent.com/ekiefl/pooltool/main/pooltool/models/table/snooker_generic/snooker_generic.glb';
+
+export function resolveSnookerTableModel(value) {
+  const requested = String(value || '').toLowerCase();
+  return requested === TABLE_MODEL_OPENSOURCE ? TABLE_MODEL_OPENSOURCE : TABLE_MODEL_CLASSIC;
+}
+
+export function applySnookerTableModelParam(params, tableModel) {
+  const resolved = resolveSnookerTableModel(tableModel);
+  params.set('tableModel', resolved);
+  return resolved;
+}


### PR DESCRIPTION
### Motivation

- Provide an option to switch the snooker table visual to a new open-source GLB model and persist that choice through lobby navigation and match start.

### Description

- Add new module `webapp/src/pages/Games/snookerTableModel.js` exporting `TABLE_MODEL_CLASSIC`, `TABLE_MODEL_OPENSOURCE`, `TABLE_MODEL_OPENSOURCE_GLB_URL`, `resolveSnookerTableModel`, and `applySnookerTableModelParam` for safe resolution and URL param handling of the table model.
- Wire table model selection into the lobby by adding UI options and state in `SnookerRoyalLobby.jsx`, applying the selected model with `applySnookerTableModelParam` when building match URLs and start parameters.
- Update `SnookerRoyal.jsx` to accept a `tableModel` prop (defaulting to `TABLE_MODEL_CLASSIC`), resolve the value from the URL, and attach an `attachOpenSourceTableModel` loader that loads the GLB from `TABLE_MODEL_OPENSOURCE_GLB_URL`, scales/positions it and hides procedural meshes when `tableModel === TABLE_MODEL_OPENSOURCE`.
- Add unit tests in `test/snookerTableModel.test.js` to verify `resolveSnookerTableModel` behavior, `applySnookerTableModelParam` safety, and that the GLB URL points to the expected Pooltool path.

### Testing

- Added `test/snookerTableModel.test.js` containing four unit tests that validate `resolveSnookerTableModel`, `applySnookerTableModelParam`, and the GLB URL pattern.  
- Ran the test suite via `npm test` and the new tests passed.  
- No regressions observed in the existing snooker flows during automated test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa2d3eb8008329b5c0710ab48ca4bf)